### PR TITLE
add debug build target for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,13 @@ config: cmd/generate-config/main.go cmd/generate-config/config_template.go cmd/g
 build: cmd/db-server/main.go
 	go build -o mo-server cmd/db-server/main.go
 
+# Building mo-server binary for debugging, it uses the latest MatrixCube from master.
+.PHONY: debug
+debug: cmd/db-server/main.go
+	go get github.com/matrixorigin/matrixcube
+	go mod tidy
+	go build -tags debug -o mo-server cmd/db-server/main.go
+
 # Running unit test cases
 # Set test timeout to 15 minutes
 # Excluding frontend test cases temporarily


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #

**What this PR does / why we need it:**

Add the debug build target for the Makefile. It uses the latest MatrixCube code from master to build the mo-server binary. Go build tags `debug' is specified for such debug builds.  

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
