### PR TITLE
fix "close nil channel" on ARM core of M1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/btree v1.0.1
 	github.com/matrixorigin/matrixcube v0.0.0-20210918015916-eb3dad263a86
-	github.com/matrixorigin/simdcsv v0.0.0-20210918120857-7fe39d18cd58
+	github.com/matrixorigin/simdcsv v0.0.0-20210926114300-591bf748a770
 	github.com/panjf2000/ants/v2 v2.4.5
 	github.com/pierrec/lz4 v2.6.0+incompatible
 	github.com/pingcap/parser v0.0.0-20210310110710-c7333a4927e6

--- a/pkg/frontend/load.go
+++ b/pkg/frontend/load.go
@@ -1277,6 +1277,11 @@ func saveLinesToStorage(handler *ParseLineHandler, force bool) error {
 LoadLoop reads data from stream, extracts the fields, and saves into the table
  */
 func (mce *MysqlCmdExecutor) LoadLoop(load *tree.Load, dbHandler engine.Database, tableHandler engine.Relation) (*LoadResult, error) {
+	defer func() {
+		if er := recover(); er != nil{
+			logutil.Errorf("loadLoop panic")
+		}
+	}()
 	var err error
 	ses := mce.routine.GetSession()
 


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #865 

**What this PR does / why we need it:**

the simdcsv uses csv package of go as the csv parser.
Then it does not need close any channels of simdcsv.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
