### PR TITLE
support constant default expr when create table (#855)

### DIFF
--- a/pkg/vm/engine/aoe/common/helper/helper.go
+++ b/pkg/vm/engine/aoe/common/helper/helper.go
@@ -134,8 +134,7 @@ func ColumnDefs(sid, tid uint64, defs []engine.TableDef) []aoe.ColumnInfo {
 				Name:     	 v.Attr.Name,
 				Alg:      	 v.Attr.Alg,
 				Type:     	 v.Attr.Type,
-				DefaultExpr: v.Attr.DefaultExpr,
-				DefaultIsNull: v.Attr.DefaultIsNull,
+				Default: 	 v.Attr.Default,
 			})
 			id++
 		}
@@ -166,11 +165,10 @@ func Attribute(tbl aoe.TableInfo) []metadata.Attribute {
 	attrs := make([]metadata.Attribute, len(tbl.Columns))
 	for i, col := range tbl.Columns {
 		attrs[i] = metadata.Attribute{
-			Alg:  col.Alg,
-			Name: col.Name,
-			Type: col.Type,
-			DefaultExpr: col.DefaultExpr,
-			DefaultIsNull: col.DefaultIsNull,
+			Alg:  	 col.Alg,
+			Name: 	 col.Name,
+			Type: 	 col.Type,
+			Default: col.Default,
 		}
 	}
 	return attrs

--- a/pkg/vm/engine/aoe/model.go
+++ b/pkg/vm/engine/aoe/model.go
@@ -16,6 +16,7 @@ package aoe
 
 import (
 	"matrixone/pkg/container/types"
+	"matrixone/pkg/vm/metadata"
 )
 
 type SchemaState byte
@@ -71,15 +72,14 @@ type TabletInfo struct {
 
 // ColumnInfo stores the information of a column.
 type ColumnInfo struct {
-	SchemaId uint64     `json:"schema_id"`
-	TableID  uint64     `json:"table_id"`
-	Id       uint64     `json:"column_id"`
-	Name     string     `json:"name"`
-	Type     types.Type `json:"type"`
-	DefaultExpr string  `json:"default_expr"`
-	DefaultIsNull bool  `json:"default_is_null"`
-	Alg      int        `json:"alg"`
-	Epoch    uint64     `json:"epoch"`
+	SchemaId uint64     		  `json:"schema_id"`
+	TableID  uint64     		  `json:"table_id"`
+	Id       uint64     		  `json:"column_id"`
+	Name     string     		  `json:"name"`
+	Type     types.Type 		  `json:"type"`
+	Default  metadata.DefaultExpr `json:"default"`
+	Alg      int        		  `json:"alg"`
+	Epoch    uint64     		  `json:"epoch"`
 }
 
 type IndexInfo struct {

--- a/pkg/vm/metadata/types.go
+++ b/pkg/vm/metadata/types.go
@@ -30,9 +30,34 @@ type Attribute struct {
 	Alg int
 	// Name name of attribute
 	Name string
-	// Default expression attributes of attribute
-	DefaultExpr string
-	DefaultIsNull bool
+	// Default contains default expression definition of attribute
+	Default DefaultExpr
 	// type of attribute
 	Type types.Type
+}
+
+type DefaultExpr struct {
+	Exist  bool
+	Expr   string
+	IsNull bool
+}
+
+// MakeDefaultExpr returns a new DefaultExpr
+func MakeDefaultExpr(exist bool, expr string, isNull bool) DefaultExpr {
+	return DefaultExpr{
+		Exist:  exist,
+		Expr:   expr,
+		IsNull: isNull,
+	}
+}
+
+// EmptyDefaultExpr means there is no definition for default expr
+var EmptyDefaultExpr = DefaultExpr{Exist: false}
+
+func (attr Attribute) HasDefaultExpr() bool {
+	return attr.Default.Exist
+}
+
+func (attr Attribute) GetDefaultExpr() (string, bool) {
+	return attr.Default.Expr, attr.Default.IsNull
 }


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

  only support constant default expr likes 5, 'abc', 7.5
  
  1+7, a*b is not supported.

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
