### PR TITLE
Support operators in Insert.

### DIFF
--- a/pkg/sql/build/create.go
+++ b/pkg/sql/build/create.go
@@ -140,7 +140,7 @@ func (b *build) tableInfo(stmt tree.TableExpr) (string, string, error) {
 // has default expr or not / column default expr string / is null expression / error msg
 // from column definition when create table
 // it will check default expression's type and value, if default values does not adapt to column type
-// there will make a simple type conversion for values TODO: not implement
+// there will make a simple type conversion for values
 // likes:
 // 		create table testTb1 (first int default 15.6) ==> create table testTb1 (first int default 16)
 //		create table testTb2 (first int default 'abc') ==> error(Invalid default value for 'first')
@@ -170,7 +170,6 @@ func getDefaultExprFromColumnDef(column *tree.ColumnTableDef, typ *types.Type) (
 			if val, err := buildConstant(*typ, defaultExpr.Expr); err != nil { // build constant failed
 				return metadata.EmptyDefaultExpr, sqlerror.New(errno.InvalidColumnDefinition, fmt.Sprintf("Invalid default value for '%s'", column.Name.Parts[0]))
 			} else {
-				ret = defaultExpr.Expr.String()
 				switch v := val.(type) {
 				case int64:
 					ret = strconv.FormatInt(v, 10)

--- a/pkg/sql/build/expr.go
+++ b/pkg/sql/build/expr.go
@@ -712,6 +712,8 @@ func buildConstant(typ types.Type, n tree.Expr) (interface{}, error) {
 				}
 			case int64:
 				return val * -1, nil
+			case float32:
+				return val * -1, nil
 			case float64:
 				return val * -1, nil
 			}

--- a/pkg/sql/build/expr.go
+++ b/pkg/sql/build/expr.go
@@ -887,10 +887,7 @@ func buildConstantValue(typ types.Type, n *tree.NumVal) (interface{}, error) {
 			}
 			return v, nil
 		case types.T_float32:
-			v, ok := constant.Float32Val(val)
-			if !ok {
-				return nil, ErrValueOutRange
-			}
+			v, _ := constant.Float32Val(val)
 			return float32(v), nil
 		case types.T_float64:
 			v, ok := constant.Float64Val(val)

--- a/pkg/sql/build/prune.go
+++ b/pkg/sql/build/prune.go
@@ -31,7 +31,11 @@ var (
 	// ErrZeroModulus is reported when computing the rest of a division by zero.
 	ErrZeroModulus = errors.New("zero modulus")
 	// ErrEvalResultOutRange is reported evaluate result is out of range.
-	ErrEvalResultOutRange = errors.New("binary result out of range")
+	ErrEvalResultOutRange = errors.New("binary operator result out of range")
+	// ErrValueOutRange is reported if a value is out of range.
+	ErrValueOutRange = errors.New("value is out of range")
+	// ErrBinaryNotSupportString is reported if binary operator's arguments are string.
+	ErrBinaryNotSupportString = errors.New("binary operators does not support for constant string")
 )
 
 func (b *build) pruneExtend(e extend.Extend, isProjection bool) (extend.Extend, error) {

--- a/pkg/sql/build/prune.go
+++ b/pkg/sql/build/prune.go
@@ -30,6 +30,8 @@ var (
 	ErrDivByZero = errors.New("division by zero")
 	// ErrZeroModulus is reported when computing the rest of a division by zero.
 	ErrZeroModulus = errors.New("zero modulus")
+	// ErrEvalResultOutRange is reported evaluate result is out of range.
+	ErrEvalResultOutRange = errors.New("binary result out of range")
 )
 
 func (b *build) pruneExtend(e extend.Extend, isProjection bool) (extend.Extend, error) {

--- a/pkg/sql/tree/constant.go
+++ b/pkg/sql/tree/constant.go
@@ -41,6 +41,10 @@ func (n *NumVal) String() string {
 	return n.origString
 }
 
+func (n *NumVal) IsNegative() bool {
+	return n.negative
+}
+
 func NewNumVal(value constant.Value, origString string, negative bool) *NumVal {
 	return &NumVal{Value: value, origString: origString, negative: negative}
 }

--- a/pkg/sql/tree/transformer_test.go
+++ b/pkg/sql/tree/transformer_test.go
@@ -38,7 +38,7 @@ func TestParser(t *testing.T) {
 
 	//insert into tbl2 select col_1c,max(col_1b), "K" from tbl1;
 	//insert into tbl2 values (1,2),(3,4);
-	sql := "insert into iis values (-1);"
+	sql := "create table table20 (`\" + \"` int);"
 
 	stmtNodes, _, err := p.Parse(sql, "", "")
 	if err != nil {

--- a/pkg/sql/tree/transformer_test.go
+++ b/pkg/sql/tree/transformer_test.go
@@ -38,7 +38,7 @@ func TestParser(t *testing.T) {
 
 	//insert into tbl2 select col_1c,max(col_1b), "K" from tbl1;
 	//insert into tbl2 values (1,2),(3,4);
-	sql := "create table table20 (`" + "` int);"
+	sql := "insert into iis values (-1);"
 
 	stmtNodes, _, err := p.Parse(sql, "", "")
 	if err != nil {

--- a/pkg/sql/unittest/sql_test.go
+++ b/pkg/sql/unittest/sql_test.go
@@ -609,16 +609,16 @@ func TestOperators(t *testing.T) {
 		for _, e := range es {
 			err := e.Compile(nil, Print)
 			if expected == nil {
-				require.NoError(t, err)
+				require.NoError(t, err, sql)
 			} else {
-				require.EqualError(t, err, expected.Error())
+				require.EqualError(t, err, expected.Error(), sql)
 				break
 			}
 			err = e.Run(1)
 			if expected == nil {
-				require.NoError(t, err)
+				require.NoError(t, err, sql)
 			} else {
-				require.EqualError(t, err, expected.Error())
+				require.EqualError(t, err, expected.Error(), sql)
 				break
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #825

**What this PR does / why we need it:**

Support Operators in Insert. Such as `insert into tbl values (100 + 5 / 3 div 2 mod 7);`
And support insert float into int or uint. (Rule: .5 will return nearest large integer, .4 will return small)

But range check does not work normally because attribute `negative` in NumVal doesn't work.

For example: 
we received AST 
`UnaryExpr{Op: minus, NumVal: {val: 1,  negative: false } } `    for -1,
and It does not suit for our expects.
Our Expects, -1 's AST is `NumVal{val: 1, negative: true}`.

this problem will be resolved after new parser works.

**Special notes for your reviewer:**

so ugly the codes are.

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
