### PR TITLE
Support Like Operator

### DIFF
--- a/pkg/sql/build/expr.go
+++ b/pkg/sql/build/expr.go
@@ -383,7 +383,7 @@ func (b *build) buildUnaryWithoutCheck(o op.OP, e *tree.UnaryExpr) (extend.Exten
 	case tree.UNARY_PLUS:
 		return b.buildExprWithoutCheck(o, e.Expr)
 	}
-	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e))
+	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e.Op))
 }
 
 func (b *build) buildBinaryWithoutCheck(o op.OP, e *tree.BinaryExpr) (extend.Extend, error) {
@@ -449,7 +449,7 @@ func (b *build) buildBinaryWithoutCheck(o op.OP, e *tree.BinaryExpr) (extend.Ext
 		}
 		return &extend.BinaryExtend{Op: overload.IntegerDiv, Left: left, Right: right}, nil
 	}
-	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e))
+	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e.Op))
 }
 
 func (b *build) buildComparisonWithoutCheck(o op.OP, e *tree.ComparisonExpr) (extend.Extend, error) {
@@ -515,7 +515,7 @@ func (b *build) buildComparisonWithoutCheck(o op.OP, e *tree.ComparisonExpr) (ex
 		}
 		return &extend.BinaryExtend{Op: overload.NE, Left: left, Right: right}, nil
 	}
-	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e))
+	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e.Op))
 }
 
 func (b *build) buildUnary(o op.OP, e *tree.UnaryExpr) (extend.Extend, error) {
@@ -660,8 +660,18 @@ func (b *build) buildComparison(o op.OP, e *tree.ComparisonExpr) (extend.Extend,
 			return nil, err
 		}
 		return &extend.BinaryExtend{Op: overload.NE, Left: left, Right: right}, nil
+	case tree.LIKE:
+		left, err := b.buildExpr(o, e.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := b.buildExpr(o, e.Right)
+		if err != nil {
+			return nil, err
+		}
+		return &extend.BinaryExtend{Op: overload.Like, Left: left, Right: right}, nil
 	}
-	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e))
+	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e.Op.ToString()))
 }
 
 func (b *build) buildAttribute(o op.OP, e *tree.UnresolvedName) (extend.Extend, error) {

--- a/pkg/sql/build/prune.go
+++ b/pkg/sql/build/prune.go
@@ -1470,6 +1470,9 @@ func (b *build) pruneGe(e *extend.BinaryExtend) (extend.Extend, error) {
 func (b *build) pruneLike(e *extend.BinaryExtend) (extend.Extend, error) {
 	le, lok := e.Left.(*extend.ValueExtend)
 	re, rok := e.Right.(*extend.ValueExtend)
+	if !lok || !rok {
+		return e, nil
+	}
 
 	vec := vector.New(types.Type{Oid: types.T_int64, Size: 8})
 	vec.Ref = 1

--- a/pkg/sql/build/prune.go
+++ b/pkg/sql/build/prune.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/extend"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/extend/overload"
 	"github.com/matrixorigin/matrixone/pkg/sqlerror"
+	"github.com/matrixorigin/matrixone/pkg/vectorize/like"
 )
 
 var (
@@ -82,6 +83,8 @@ func (b *build) pruneExtend(e extend.Extend, isProjection bool) (extend.Extend, 
 			return b.prunePlus(n)
 		case overload.Minus:
 			return b.pruneMinus(n)
+		case overload.Like:
+			return b.pruneLike(n)
 		}
 	}
 	return e, nil
@@ -1460,6 +1463,32 @@ func (b *build) pruneGe(e *extend.BinaryExtend) (extend.Extend, error) {
 			return nil, sqlerror.New(errno.DatatypeMismatch, fmt.Sprintf("illegal expression '%s'", e))
 		}
 		return e, nil
+	}
+	return e, nil
+}
+
+func (b *build) pruneLike(e *extend.BinaryExtend) (extend.Extend, error) {
+	le, lok := e.Left.(*extend.ValueExtend)
+	re, rok := e.Right.(*extend.ValueExtend)
+
+	vec := vector.New(types.Type{Oid: types.T_int64, Size: 8})
+	vec.Ref = 1
+
+	if !le.V.Typ.Eq(re.V.Typ) || (le.V.Typ.Oid != types.T_char && le.V.Typ.Oid != types.T_varchar) {
+		return nil, errors.New("operator LIKE only support for varchar and char")
+	}
+	switch {
+	case lok && rok:
+		k, err := like.PureLikePure(le.V.Col.(*types.Bytes).Data, re.V.Col.(*types.Bytes).Data, make([]int64, 1))
+		if err != nil {
+			return nil, err
+		}
+		if k != nil {
+			vec.SetCol([]int64{1})
+		} else {
+			vec.SetCol([]int64{0})
+		}
+		return &extend.ValueExtend{V: vec}, nil
 	}
 	return e, nil
 }

--- a/pkg/sql/build/show.go
+++ b/pkg/sql/build/show.go
@@ -31,9 +31,9 @@ func (b *build) buildShowTables(stmt *tree.ShowTables) (op.OP, error) {
 	if err != nil {
 		return nil, sqlerror.New(errno.InvalidSchemaName, err.Error())
 	}
-	return showTables.New(db), nil
+	return showTables.New(db, stmt.Like), nil
 }
 
 func (b *build) buildShowDatabases(stmt *tree.ShowDatabases) (op.OP, error) {
-	return showDatabases.New(b.e), nil
+	return showDatabases.New(b.e, stmt.Like), nil
 }

--- a/pkg/sql/colexec/extend/overload/binary.go
+++ b/pkg/sql/colexec/extend/overload/binary.go
@@ -510,6 +510,27 @@ func initCastRulesForBinaryOps() {
 		}
 		binOpsReturnType[index][types.T_float64][types.T_float32] = types.T(nret)
 	}
+	// LIKE cast rule
+	{
+		index := Like - firstBinaryOp
+		// cast to varchar like varchar
+		nl, nr, nret := types.Type{Oid: types.T_varchar, Size: 24}, types.Type{Oid: types.T_varchar, Size: 24}, types.T_sel
+		// like between char and varchar
+		binOpsTypeCastRules[index][types.T_char][types.T_varchar] = castResult{
+			has:           true,
+			leftCast:      nl,
+			rightCast:     nr,
+			newReturnType: types.T(nret),
+		}
+		binOpsReturnType[index][types.T_char][types.T_varchar] = types.T(nret)
+		binOpsTypeCastRules[index][types.T_varchar][types.T_char] = castResult{
+			has:           true,
+			leftCast:      nr,
+			rightCast:     nl,
+			newReturnType: types.T(nret),
+		}
+		binOpsReturnType[index][types.T_varchar][types.T_char] = types.T(nret)
+	}
 
 	// EQ / NE / GE / GT / LE / LT
 	{

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -34,6 +34,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/op/showTables"
 	"github.com/matrixorigin/matrixone/pkg/sql/protocol"
 	"github.com/matrixorigin/matrixone/pkg/sqlerror"
+	"github.com/matrixorigin/matrixone/pkg/vectorize/like"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/pipeline"
 	"net"
@@ -259,9 +260,26 @@ func (s *Scope) ShowTables(u interface{}, fill func(interface{}, *batch.Batch) e
 	{
 		rs := o.Db.Relations()
 		vs := make([][]byte, len(rs))
-		for i, r := range rs {
-			vs[i] = []byte(r)
+
+		// like
+		count := 0
+		if o.Like == nil {
+			for _, r := range rs {
+				vs[count] = []byte(r)
+				count++
+			}
+		} else {
+			tempSlice := make([]int64, 1)
+			for _, r := range rs {
+				str := []byte(r)
+				if k, _ := like.PureLikePure(str, o.Like, tempSlice); k != nil {
+					vs[count] = str
+					count++
+				}
+			}
 		}
+		vs = vs[:count]
+
 		vec := vector.New(types.Type{Oid: types.T_varchar, Size: 24})
 		if err := vec.Append(vs); err != nil {
 			return err
@@ -277,9 +295,26 @@ func (s *Scope) ShowDatabases(u interface{}, fill func(interface{}, *batch.Batch
 	{
 		rs := o.E.Databases()
 		vs := make([][]byte, len(rs))
-		for i, r := range rs {
-			vs[i] = []byte(r)
+
+		// like
+		count := 0
+		if o.Like == nil {
+			for _, r := range rs {
+				vs[count] = []byte(r)
+				count++
+			}
+		} else {
+			tempSlice := make([]int64, 1)
+			for _, r := range rs {
+				str := []byte(r)
+				if k, _ := like.PureLikePure(str, o.Like, tempSlice); k != nil {
+					vs[count] = str
+					count++
+				}
+			}
 		}
+		vs = vs[:count]
+
 		vec := vector.New(types.Type{Oid: types.T_varchar, Size: 24})
 		if err := vec.Append(vs); err != nil {
 			return err

--- a/pkg/sql/op/showDatabases/show.go
+++ b/pkg/sql/op/showDatabases/show.go
@@ -16,11 +16,16 @@ package showDatabases
 
 import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
 
-func New(e engine.Engine) *ShowDatabases {
-	return &ShowDatabases{e}
+func New(e engine.Engine, like *tree.ComparisonExpr) *ShowDatabases {
+	var l []byte = nil
+	if like != nil {
+		l = []byte(like.Right.String())
+	}
+	return &ShowDatabases{e, l}
 }
 
 func (n *ShowDatabases) String() string {

--- a/pkg/sql/op/showDatabases/types.go
+++ b/pkg/sql/op/showDatabases/types.go
@@ -18,4 +18,5 @@ import "github.com/matrixorigin/matrixone/pkg/vm/engine"
 
 type ShowDatabases struct {
 	E engine.Engine
+	Like []byte
 }

--- a/pkg/sql/op/showTables/show.go
+++ b/pkg/sql/op/showTables/show.go
@@ -16,11 +16,16 @@ package showTables
 
 import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
 
-func New(db engine.Database) *ShowTables {
-	return &ShowTables{db}
+func New(db engine.Database, like *tree.ComparisonExpr) *ShowTables {
+	var l []byte = nil
+	if like != nil {
+		l = []byte(like.Right.String())
+	}
+	return &ShowTables{db, l}
 }
 
 func (n *ShowTables) String() string {

--- a/pkg/sql/op/showTables/types.go
+++ b/pkg/sql/op/showTables/types.go
@@ -14,8 +14,11 @@
 
 package showTables
 
-import "github.com/matrixorigin/matrixone/pkg/vm/engine"
+import (
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+)
 
 type ShowTables struct {
 	Db engine.Database
+	Like []byte
 }

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -26,7 +26,7 @@ var (
 		input  string
 		output string
 	}{
-		input: "insert into uus values (255, 65535, 4294967295, 18446744073709551615)",
+		input: "select '123' like '\\%'",
 	}
 )
 

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -26,7 +26,7 @@ var (
 		input  string
 		output string
 	}{
-		input: "select '123' like '\\%'",
+		input: "insert into uus values (255, 65535, 4294967295, 18446744073709551615)",
 	}
 )
 

--- a/pkg/vectorize/like/like.go
+++ b/pkg/vectorize/like/like.go
@@ -186,7 +186,7 @@ func sliceLikeSlice(s *types.Bytes, exprs *types.Bytes, rs []int64) ([]int64, er
 			return nil, err
 		}
 		if k != nil {
-			rs[count] = i
+			rs[count] = int64(i)
 			count++
 		}
 	}
@@ -201,7 +201,7 @@ func pureLikeSlice(p []byte, exprs *types.Bytes, rs []int64) ([]int64, error) {
 			return nil, err
 		}
 		if k != nil {
-			rs[count] = i
+			rs[count] = int64(i)
 			count++
 		}
 	}
@@ -211,104 +211,93 @@ func pureLikeSlice(p []byte, exprs *types.Bytes, rs []int64) ([]int64, error) {
 func pureLikePure(p []byte, expr []byte, rs []int64) ([]int64, error) {
 	n := len(expr)
 	if n == 0 {
-		count := 0
 		if len(p) == 0 {
 			rs[0] = int64(0)
-			count++
+			return rs[:1], nil
 		}
-		return rs[:count], nil
+		return nil, nil
 	}
 	if n == 1 && expr[0] == '%' {
 		rs[0] = int64(0)
 		return rs[:1], nil
 	}
 	if n == 1 && expr[0] == '_' {
-		count := 0
 		if len(p) == 1 {
 			rs[0] = int64(0)
-			count++
+			return rs[:1], nil
 		}
-		return rs[:1], nil
+		return nil, nil
 	}
 	if n > 1 && !bytes.ContainsAny(expr[1:n-1], "_%") {
 		c0 := expr[0]   // first character
 		c1 := expr[n-1] // last character
 		switch {
 		case !(c0 == '%' || c0 == '_') && !(c1 == '%' || c1 == '_'):
-			count := 0
 			if len(p) == n && bytes.Compare(expr, p) == 0 {
-				rs[count] = int64(0)
-				count++
+				rs[0] = int64(0)
+				return rs[:1], nil
 			}
-			return rs[:count], nil
+			return nil, nil
 		case c0 == '_' && !(c1 == '%' || c1 == '_'):
 			suffix := expr[1:]
-			count := 0
 			if len(p) == n && bytes.Compare(suffix, p[1:]) == 0 {
-				rs[count] = int64(0)
-				count++
+				rs[0] = int64(0)
+				return rs[:1], nil
 			}
-			return rs[:count], nil
+			return nil, nil
 		case c0 == '%' && !(c1 == '%' || c1 == '_'):
 			suffix := expr[1:]
-			count := 0
 			if bytes.HasSuffix(p, suffix) {
-				rs[count] = int64(0)
-				count++
+				rs[0] = int64(0)
+				return rs[:1], nil
 			}
-			return rs[:count], nil
+			return nil, nil
 		case c1 == '_' && !(c0 == '%' || c0 == '_'):
 			prefix := expr[:n-1]
-			count := 0
 			if len(p) == n && bytes.Compare(prefix, p[:n-1]) == 0 {
-				rs[count] = int64(0)
-				count++
+				rs[0] = int64(0)
+				return rs[:1], nil
 			}
-			return rs[:count], nil
+			return nil, nil
 		case c1 == '%' && !(c0 == '%' || c0 == '_'):
 			prefix := expr[:n-1]
-			count := 0
 			if len(p) >= n && bytes.Compare(p[:n-1], prefix) == 0 {
-				rs[count] = int64(0)
-				count++
+				rs[0] = int64(0)
+				return rs[:1], nil
 			}
-			return rs[:count], nil
+			return nil, nil
 		case c0 == '%' && c1 == '%':
 			substr := expr[1 : n-1]
-			count := 0
 			if bytes.Contains(p, substr) {
-				rs[count] = int64(0)
-				count++
+				rs[0] = int64(0)
+				return rs[:1], nil
 			}
-			return rs[:count], nil
+			return nil, nil
 		case c0 == '%' && c1 == '_':
 			suffix := expr[1 : n-1]
-			count := 0
 			if len(p) > 0 && bytes.HasSuffix(p[:len(p)-1], suffix) {
-				rs[count] = int64(0)
-				count++
+				rs[0] = int64(0)
+				return rs[:1], nil
 			}
-			return rs[:count], nil
+			return nil, nil
 		case c0 == '_' && c1 == '%':
 			prefix := expr[1 : n-1]
-			count := 0
 			if len(p) > 0 && bytes.HasPrefix(p[1:], prefix) {
-				rs[count] = int64(0)
-				count++
+				rs[0] = int64(0)
+				return rs[:1], nil
 			}
-			return rs[:count], nil
+			return nil, nil
 		}
 	}
 	reg, err := regexp.Compile(convert(expr))
 	if err != nil {
 		return nil, err
 	}
-	count := 0
 	if reg.Match(p) {
-		rs[count] = int64(0)
-		count++
+		rs[0] = int64(0)
+		return rs[:1], nil
 	}
-	return rs[:count], nil
+	return nil, nil
 }
 
 func convert(expr []byte) string {

--- a/pkg/vectorize/like/like.go
+++ b/pkg/vectorize/like/like.go
@@ -74,7 +74,7 @@ func sliceLikePure(s *types.Bytes, expr []byte, rs []int64) ([]int64, error) {
 		}
 		return rs[:count], nil
 	}
-	if n > 1 && !bytes.ContainsAny(expr[1:len(expr)-1], "_%") {
+	if n >= 1 && !bytes.ContainsAny(expr[1:len(expr)-1], "_%") {
 		c0 := expr[0]   // first character
 		c1 := expr[n-1] // last character
 		switch {
@@ -175,8 +175,8 @@ func sliceLikePure(s *types.Bytes, expr []byte, rs []int64) ([]int64, error) {
 
 func sliceLikeSlice(s *types.Bytes, exprs *types.Bytes, rs []int64) ([]int64, error) {
 	count := 0
-	n := len(s.Data)
-	if n != len(exprs.Data) {
+	n := len(s.Lengths)
+	if n != len(exprs.Lengths) {
 		return nil, errors.New("unexpected error when LIKE operator")
 	}
 	for i, o1 := range s.Offsets {
@@ -228,7 +228,7 @@ func pureLikePure(p []byte, expr []byte, rs []int64) ([]int64, error) {
 		}
 		return nil, nil
 	}
-	if n > 1 && !bytes.ContainsAny(expr[1:n-1], "_%") {
+	if n >= 1 && !bytes.ContainsAny(expr[1:n-1], "_%") {
 		c0 := expr[0]   // first character
 		c1 := expr[n-1] // last character
 		switch {

--- a/pkg/vectorize/like/like.go
+++ b/pkg/vectorize/like/like.go
@@ -81,7 +81,7 @@ func sliceLikePure(s *types.Bytes, expr []byte, rs []int64) ([]int64, error) {
 		}
 		return rs[:count], nil
 	}
-	if n >= 1 && !bytes.ContainsAny(expr[1:len(expr)-1], "_%") {
+	if n > 1 && !bytes.ContainsAny(expr[1:len(expr)-1], "_%") {
 		c0 := expr[0]   // first character
 		c1 := expr[n-1] // last character
 		switch {
@@ -236,7 +236,7 @@ func pureLikePure(p []byte, expr []byte, rs []int64) ([]int64, error) {
 		}
 		return nil, nil
 	}
-	if n >= 1 && !bytes.ContainsAny(expr[1:n-1], "_%") {
+	if n > 1 && !bytes.ContainsAny(expr[1:n-1], "_%") {
 		c0 := expr[0]   // first character
 		c1 := expr[n-1] // last character
 		switch {
@@ -330,7 +330,7 @@ func sliceNullLikePure(s *types.Bytes, expr []byte, nulls *roaring.Bitmap, rs []
 		cFlag = 2
 	case n == 1 && expr[0] == '_':
 		cFlag = 3
-	case n >= 1 && !bytes.ContainsAny(expr[1:len(expr)-1], "_%"):
+	case n > 1 && !bytes.ContainsAny(expr[1:len(expr)-1], "_%"):
 		cFlag = 4
 	default:
 		cFlag = 5
@@ -518,7 +518,7 @@ func replace(s string) string {
 		}
 		switch c {
 		case '_':
-			w += copy(r[w:], []byte{'*'})
+			w += copy(r[w:], []byte{'.'})
 		case '%':
 			w += copy(r[w:], []byte{'.', '*'})
 		case '\\':


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #979

**What this PR does / why we need it:**

1.Support Like Operator.
For Example: 
`select * from tbl where '123' like '_%'`
`select * from tbl where column1 like column2`
`select * from tbl where column1 like 'example'`
`select * from tbl where 'example' like column1`

2.Support Like in show tables and show databases.
For Example:
`show databases like 'db_'`
`show tables like '%qwq%'`

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
