### PR TITLE
support LIKE operator

### DIFF
--- a/pkg/sql/build/expr.go
+++ b/pkg/sql/build/expr.go
@@ -383,7 +383,7 @@ func (b *build) buildUnaryWithoutCheck(o op.OP, e *tree.UnaryExpr) (extend.Exten
 	case tree.UNARY_PLUS:
 		return b.buildExprWithoutCheck(o, e.Expr)
 	}
-	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e))
+	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e.Op))
 }
 
 func (b *build) buildBinaryWithoutCheck(o op.OP, e *tree.BinaryExpr) (extend.Extend, error) {
@@ -449,7 +449,7 @@ func (b *build) buildBinaryWithoutCheck(o op.OP, e *tree.BinaryExpr) (extend.Ext
 		}
 		return &extend.BinaryExtend{Op: overload.IntegerDiv, Left: left, Right: right}, nil
 	}
-	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e))
+	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e.Op))
 }
 
 func (b *build) buildComparisonWithoutCheck(o op.OP, e *tree.ComparisonExpr) (extend.Extend, error) {
@@ -515,7 +515,7 @@ func (b *build) buildComparisonWithoutCheck(o op.OP, e *tree.ComparisonExpr) (ex
 		}
 		return &extend.BinaryExtend{Op: overload.NE, Left: left, Right: right}, nil
 	}
-	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e))
+	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e.Op))
 }
 
 func (b *build) buildUnary(o op.OP, e *tree.UnaryExpr) (extend.Extend, error) {
@@ -660,8 +660,18 @@ func (b *build) buildComparison(o op.OP, e *tree.ComparisonExpr) (extend.Extend,
 			return nil, err
 		}
 		return &extend.BinaryExtend{Op: overload.NE, Left: left, Right: right}, nil
+	case tree.LIKE:
+		left, err := b.buildExpr(o, e.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := b.buildExpr(o, e.Right)
+		if err != nil {
+			return nil, err
+		}
+		return &extend.BinaryExtend{Op: overload.Like, Left: left, Right: right}, nil
 	}
-	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e))
+	return nil, sqlerror.New(errno.SyntaxErrororAccessRuleViolation, fmt.Sprintf("'%v' is not support now", e.Op.ToString()))
 }
 
 func (b *build) buildAttribute(o op.OP, e *tree.UnresolvedName) (extend.Extend, error) {

--- a/pkg/sql/build/show.go
+++ b/pkg/sql/build/show.go
@@ -24,6 +24,7 @@ import (
 )
 
 func (b *build) buildShowTables(stmt *tree.ShowTables) (op.OP, error) {
+	var likeStr []byte
 	if len(stmt.DBName) == 0 {
 		stmt.DBName = b.db
 	}
@@ -31,9 +32,24 @@ func (b *build) buildShowTables(stmt *tree.ShowTables) (op.OP, error) {
 	if err != nil {
 		return nil, sqlerror.New(errno.InvalidSchemaName, err.Error())
 	}
-	return showTables.New(db), nil
+	if stmt.Where != nil {
+
+	}
+	if stmt.Like != nil {
+		likeStr = []byte(stmt.Like.Right.String())
+	}
+	return showTables.New(db, likeStr), nil
 }
 
 func (b *build) buildShowDatabases(stmt *tree.ShowDatabases) (op.OP, error) {
-	return showDatabases.New(b.e), nil
+	var likeStr []byte
+	// semantic analysis
+	if stmt.Where != nil {
+
+	}
+	if stmt.Like != nil {
+		likeStr = []byte(stmt.Like.Right.String())
+	}
+
+	return showDatabases.New(b.e, likeStr), nil
 }

--- a/pkg/sql/colexec/extend/overload/binary.go
+++ b/pkg/sql/colexec/extend/overload/binary.go
@@ -510,6 +510,27 @@ func initCastRulesForBinaryOps() {
 		}
 		binOpsReturnType[index][types.T_float64][types.T_float32] = types.T(nret)
 	}
+	// LIKE cast rule
+	{
+		index := Like - firstBinaryOp
+		// cast to varchar like varchar
+		nl, nr, nret := types.Type{Oid: types.T_varchar, Size: 24}, types.Type{Oid: types.T_varchar, Size: 24}, types.T_sel
+		// like between char and varchar
+		binOpsTypeCastRules[index][types.T_char][types.T_varchar] = castResult{
+			has:           true,
+			leftCast:      nl,
+			rightCast:     nr,
+			newReturnType: types.T(nret),
+		}
+		binOpsReturnType[index][types.T_char][types.T_varchar] = types.T(nret)
+		binOpsTypeCastRules[index][types.T_varchar][types.T_char] = castResult{
+			has:           true,
+			leftCast:      nr,
+			rightCast:     nl,
+			newReturnType: types.T(nret),
+		}
+		binOpsReturnType[index][types.T_varchar][types.T_char] = types.T(nret)
+	}
 
 	// EQ / NE / GE / GT / LE / LT
 	{

--- a/pkg/sql/colexec/extend/overload/like.go
+++ b/pkg/sql/colexec/extend/overload/like.go
@@ -1,0 +1,280 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package overload
+
+import (
+	"errors"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/encoding"
+	"github.com/matrixorigin/matrixone/pkg/vectorize/like"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"github.com/matrixorigin/matrixone/pkg/vm/register"
+)
+
+var (
+	errTemp = errors.New("operator LIKE can not support for NULL now")
+	errUnexpected = errors.New("unexpected case for LIKE operator")
+)
+
+func init() {
+	BinOps[Like] = []*BinOp{
+		{
+			LeftType: types.T_char,
+			RightType: types.T_char,
+			ReturnType: types.T_sel,
+			Fn: func(lv *vector.Vector, rv *vector.Vector, proc *process.Process, lc bool, rc bool) (*vector.Vector, error) {
+				lvs, rvs := lv.Col.(*types.Bytes), rv.Col.(*types.Bytes)
+				rtl := int64(SelsType.Size)  //Type(T_sel).Length
+				switch {
+				// 1. []string Reg expr
+				case !lc && rc:
+					vec, err := register.Get(proc, int64(len(lvs.Lengths)) * rtl, SelsType)
+					if err != nil {
+						return nil, err
+					}
+					rs := encoding.DecodeInt64Slice(vec.Data)
+					rs = rs[:len(lvs.Lengths)]
+					if lv.Nsp.Any() {
+						rs, err = like.SliceNullLikePure(lvs, rvs.Get(0), lv.Nsp.Np, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+						vec.Nsp = lv.Nsp
+					} else {
+						rs, err = like.SliceLikePure(lvs, rvs.Get(0), rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+					}
+					if lv.Ref == 0 {
+						register.Put(proc, lv)
+					}
+					return vec, nil
+				// 2. string Reg expr
+				case lc && rc: // in our design, this case should deal while pruning extends.
+					vec, err := register.Get(proc, rtl, SelsType)
+					if err != nil {
+						return nil, err
+					}
+					rs := encoding.DecodeInt64Slice(vec.Data)
+					rs = rs[:1]
+					rs, err = like.PureLikePure(lvs.Get(0), rvs.Get(0), rs)
+					if err != nil {
+						return nil, err
+					}
+					vec.SetCol(rs)
+					return vec, nil
+				// 3. string Reg []expr
+				case lc && !rc:
+					vec, err := register.Get(proc, int64(len(rvs.Lengths)) * rtl, SelsType)
+					if err != nil {
+						return nil, err
+					}
+					rs := encoding.DecodeInt64Slice(vec.Data)
+					rs = rs[:len(rvs.Lengths)]
+					if rv.Nsp.Any() {
+						rs, err = like.PureLikeSliceNull(lvs.Get(0), rvs, rv.Nsp.Np, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+						vec.Nsp = rv.Nsp
+					} else {
+						rs, err = like.PureLikeSlice(lvs.Get(0), rvs, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+					}
+					if rv.Ref == 0 {
+						register.Put(proc, rv)
+					}
+					return vec, nil
+				// 4. []string Reg []expr
+				case !lc && !rc:
+					vec, err := register.Get(proc, int64(len(lvs.Lengths)) * rtl, SelsType)
+					if err != nil {
+						return nil, err
+					}
+					rs := encoding.DecodeInt64Slice(vec.Data)
+					rs = rs[:len(rvs.Lengths)]
+					if rv.Nsp.Any() && lv.Nsp.Any() {
+						nsp := lv.Nsp.Or(rv.Nsp)
+						rs, err = like.SliceNullLikeSliceNull(lvs, rvs, nsp.Np, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+						vec.Nsp = nsp
+					} else if rv.Nsp.Any() && !lv.Nsp.Any() {
+						rs, err = like.SliceNullLikeSliceNull(lvs, rvs, rv.Nsp.Np, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+						vec.Nsp = rv.Nsp
+					} else if !rv.Nsp.Any() && lv.Nsp.Any() {
+						rs, err = like.SliceNullLikeSliceNull(lvs, rvs, lv.Nsp.Np, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+						vec.Nsp = lv.Nsp
+					} else {
+						rs, err = like.SliceLikeSlice(lvs, rvs, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+					}
+					if lv.Ref == 0 {
+						register.Put(proc, lv)
+					}
+					if rv.Ref == 0 {
+						register.Put(proc, rv)
+					}
+					return vec, nil
+				}
+				return nil, errUnexpected
+			},
+		},
+
+		{
+			LeftType: types.T_varchar,
+			RightType: types.T_varchar,
+			ReturnType: types.T_sel,
+			Fn: func(lv *vector.Vector, rv *vector.Vector, proc *process.Process, lc bool, rc bool) (*vector.Vector, error) {
+				lvs, rvs := lv.Col.(*types.Bytes), rv.Col.(*types.Bytes)
+				rtl := int64(SelsType.Size)  //Type(T_sel).Length
+				switch {
+				// 1. []string Reg expr
+				case !lc && rc:
+					vec, err := register.Get(proc, int64(len(lvs.Lengths)) * rtl, SelsType)
+					if err != nil {
+						return nil, err
+					}
+					rs := encoding.DecodeInt64Slice(vec.Data)
+					rs = rs[:len(lvs.Lengths)]
+					if lv.Nsp.Any() {
+						rs, err = like.SliceNullLikePure(lvs, rvs.Get(0), lv.Nsp.Np, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+						vec.Nsp = lv.Nsp
+					} else {
+						rs, err = like.SliceLikePure(lvs, rvs.Get(0), rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+					}
+					if lv.Ref == 0 {
+						register.Put(proc, lv)
+					}
+					return vec, nil
+				// 2. string Reg expr
+				case lc && rc: // in our design, this case should deal while pruning extends.
+					vec, err := register.Get(proc, rtl, SelsType)
+					if err != nil {
+						return nil, err
+					}
+					rs := encoding.DecodeInt64Slice(vec.Data)
+					rs = rs[:1]
+					rs, err = like.PureLikePure(lvs.Get(0), rvs.Get(0), rs)
+					if err != nil {
+						return nil, err
+					}
+					vec.SetCol(rs)
+					return vec, nil
+				// 3. string Reg []expr
+				case lc && !rc:
+					vec, err := register.Get(proc, int64(len(rvs.Lengths)) * rtl, SelsType)
+					if err != nil {
+						return nil, err
+					}
+					rs := encoding.DecodeInt64Slice(vec.Data)
+					rs = rs[:len(rvs.Lengths)]
+					if rv.Nsp.Any() {
+						rs, err = like.PureLikeSliceNull(lvs.Get(0), rvs, rv.Nsp.Np, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+						vec.Nsp = rv.Nsp
+					} else {
+						rs, err = like.PureLikeSlice(lvs.Get(0), rvs, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+					}
+					if rv.Ref == 0 {
+						register.Put(proc, rv)
+					}
+					return vec, nil
+				// 4. []string Reg []expr
+				case !lc && !rc:
+					vec, err := register.Get(proc, int64(len(lvs.Lengths)) * rtl, SelsType)
+					if err != nil {
+						return nil, err
+					}
+					rs := encoding.DecodeInt64Slice(vec.Data)
+					rs = rs[:len(rvs.Lengths)]
+					if rv.Nsp.Any() && lv.Nsp.Any() {
+						nsp := lv.Nsp.Or(rv.Nsp)
+						rs, err = like.SliceNullLikeSliceNull(lvs, rvs, nsp.Np, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+						vec.Nsp = nsp
+					} else if rv.Nsp.Any() && !lv.Nsp.Any() {
+						rs, err = like.SliceNullLikeSliceNull(lvs, rvs, rv.Nsp.Np, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+						vec.Nsp = rv.Nsp
+					} else if !rv.Nsp.Any() && lv.Nsp.Any() {
+						rs, err = like.SliceNullLikeSliceNull(lvs, rvs, lv.Nsp.Np, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+						vec.Nsp = lv.Nsp
+					} else {
+						rs, err = like.SliceLikeSlice(lvs, rvs, rs)
+						if err != nil {
+							return nil, err
+						}
+						vec.SetCol(rs)
+					}
+					if lv.Ref == 0 {
+						register.Put(proc, lv)
+					}
+					if rv.Ref == 0 {
+						register.Put(proc, rv)
+					}
+					return vec, nil
+				}
+				return nil, errUnexpected
+			},
+		},
+	}
+}

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -34,6 +34,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/op/showTables"
 	"github.com/matrixorigin/matrixone/pkg/sql/protocol"
 	"github.com/matrixorigin/matrixone/pkg/sqlerror"
+	"github.com/matrixorigin/matrixone/pkg/vectorize/like"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/pipeline"
 	"net"
@@ -259,9 +260,26 @@ func (s *Scope) ShowTables(u interface{}, fill func(interface{}, *batch.Batch) e
 	{
 		rs := o.Db.Relations()
 		vs := make([][]byte, len(rs))
-		for i, r := range rs {
-			vs[i] = []byte(r)
+
+		// like
+		count := 0
+		if o.Like == nil {
+			for _, r := range rs {
+				vs[count] = []byte(r)
+				count++
+			}
+		} else {
+			tempSlice := make([]int64, 1)
+			for _, r := range rs {
+				str := []byte(r)
+				if k, _ := like.PureLikePure(str, o.Like, tempSlice); k != nil {
+					vs[count] = str
+					count++
+				}
+			}
 		}
+		vs = vs[:count]
+
 		vec := vector.New(types.Type{Oid: types.T_varchar, Size: 24})
 		if err := vec.Append(vs); err != nil {
 			return err
@@ -277,9 +295,26 @@ func (s *Scope) ShowDatabases(u interface{}, fill func(interface{}, *batch.Batch
 	{
 		rs := o.E.Databases()
 		vs := make([][]byte, len(rs))
-		for i, r := range rs {
-			vs[i] = []byte(r)
+
+		// like
+		count := 0
+		if o.Like == nil {
+			for _, r := range rs {
+				vs[count] = []byte(r)
+				count++
+			}
+		} else {
+			tempSlice := make([]int64, 1)
+			for _, r := range rs {
+				str := []byte(r)
+				if k, _ := like.PureLikePure(str, o.Like, tempSlice); k != nil {
+					vs[count] = str
+					count++
+				}
+			}
 		}
+		vs = vs[:count]
+
 		vec := vector.New(types.Type{Oid: types.T_varchar, Size: 24})
 		if err := vec.Append(vs); err != nil {
 			return err

--- a/pkg/sql/op/showDatabases/show.go
+++ b/pkg/sql/op/showDatabases/show.go
@@ -19,8 +19,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
 
-func New(e engine.Engine) *ShowDatabases {
-	return &ShowDatabases{e}
+func New(e engine.Engine, like []byte) *ShowDatabases {
+	return &ShowDatabases{e, like}
 }
 
 func (n *ShowDatabases) String() string {

--- a/pkg/sql/op/showDatabases/types.go
+++ b/pkg/sql/op/showDatabases/types.go
@@ -18,4 +18,5 @@ import "github.com/matrixorigin/matrixone/pkg/vm/engine"
 
 type ShowDatabases struct {
 	E engine.Engine
+	Like []byte
 }

--- a/pkg/sql/op/showTables/show.go
+++ b/pkg/sql/op/showTables/show.go
@@ -19,8 +19,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
 
-func New(db engine.Database) *ShowTables {
-	return &ShowTables{db}
+func New(db engine.Database, like []byte) *ShowTables {
+	return &ShowTables{db, like}
 }
 
 func (n *ShowTables) String() string {

--- a/pkg/sql/op/showTables/types.go
+++ b/pkg/sql/op/showTables/types.go
@@ -14,8 +14,11 @@
 
 package showTables
 
-import "github.com/matrixorigin/matrixone/pkg/vm/engine"
+import (
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+)
 
 type ShowTables struct {
 	Db engine.Database
+	Like []byte
 }

--- a/pkg/sql/unittest/sql_test.go
+++ b/pkg/sql/unittest/sql_test.go
@@ -363,6 +363,14 @@ func TestBinaryOperators(t *testing.T) {
 		{"select u2 % u1, u2 % u2, u2 % u3, u2 % u4 from uus;"},
 		{"select u3 % u1, u3 % u2, u3 % u3, u3 % u4 from uus;"},
 		{"select u4 % u1, u4 % u2, u4 % u3, u4 % u4 from uus;"},
+		// like operator
+		{"select * from ccs where c1 like c2;"},
+		{"select * from ccs where c1 like '123';"},
+		{"select * from ccs where c2 like '234';"},
+		{"select * from ccs where c2 like c1;"},
+		{"select * from ccs where '123' like c1;"},
+		{"select * from ccs where '123' like c2;"},
+		{"select c1, c2 from ccs where 'abc' like 'bca';"},
 		// not operator
 		{"select not i1, not i2, not i3, not i4 from iis where not i1 and not i2 and not i3 and not i4;"},
 		{"select not f1, not f2 from ffs where not f1 or not f2;"},


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #979

**What this PR does / why we need it:**

1.Support Like Operator.
For Example:
select * from tbl where '123' like '_%'
select * from tbl where column1 like column2
select * from tbl where column1 like 'example'
select * from tbl where 'example' like column1

2.Support Like in show tables and show databases.
For Example:
show databases like 'db_'
show tables like '%qwq%'

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
