### PR TITLE
Mislead writebatch timeout

### DIFF
--- a/pkg/frontend/load.go
+++ b/pkg/frontend/load.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"encoding/csv"
 	"fmt"
-	"github.com/matrixorigin/simdcsv"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -26,16 +25,18 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/metadata"
+	"github.com/matrixorigin/simdcsv"
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
 )
 
 type LoadResult struct {
-	Records, Deleted, Skipped, Warnings uint64
+	Records, Deleted, Skipped, Warnings, WriteTimeout uint64
 }
 
 type DebugTime struct {
@@ -480,18 +481,22 @@ func initWriteBatchHandler(handler *ParseLineHandler,wHandler *WriteBatchHandler
 	return nil
 }
 
-func collectWriteBatchResult(handler *ParseLineHandler,wh *WriteBatchHandler) {
+func collectWriteBatchResult(handler *ParseLineHandler, wh *WriteBatchHandler, err error) {
 	//fmt.Printf("++++> %d %d %d %d \n",
 	//	wh.result.Skipped,
 	//	wh.result.Deleted,
 	//	wh.result.Warnings,
 	//	wh.result.Records,
 	//)
+	if wh == nil {
+		return
+	}
 
 	handler.result.Skipped += wh.result.Skipped
 	handler.result.Deleted += wh.result.Deleted
 	handler.result.Warnings += wh.result.Warnings
 	handler.result.Records += wh.result.Records
+	handler.result.WriteTimeout += wh.result.WriteTimeout
 	//
 	handler.row2col += wh.row2col
 	handler.fillBlank += wh.fillBlank
@@ -530,6 +535,20 @@ func errorCanBeIgnored(err error) bool {
 	default:
 		return true
 	}
+}
+
+/*
+isWriteBatchTimeoutError returns true when the err is a write batch timeout.
+ */
+func isWriteBatchTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	es := err.Error()
+	if strings.Index(es,"exec timeout") != -1 {
+		return true
+	}
+	return false
 }
 
 func rowToColumnAndSaveToStorage(handler *WriteBatchHandler, forceConvert bool) error {
@@ -1141,10 +1160,7 @@ func rowToColumnAndSaveToStorage(handler *WriteBatchHandler, forceConvert bool) 
 	*/
 	//the second parameter must be FALSE here
 	err = writeBatchToStorage(handler,forceConvert)
-	if err != nil {
-		logutil.Errorf("saveBatchToStorage failed. err:%v",err)
-		return err
-	}
+
 	toStorage += time.Since(wait_c)
 
 	allFetchCnt += fetchCnt
@@ -1156,6 +1172,11 @@ func rowToColumnAndSaveToStorage(handler *WriteBatchHandler, forceConvert bool) 
 
 	//fmt.Printf("----- row2col %s fillBlank %s toStorage %s\n",
 	//	row2col,fillBlank,toStorage)
+
+	if err != nil {
+		logutil.Errorf("saveBatchToStorage failed. err:%v",err)
+		return err
+	}
 
 	if allFetchCnt != countOfLineArray {
 		return fmt.Errorf("allFetchCnt %d != countOfLineArray %d ",allFetchCnt,countOfLineArray)
@@ -1169,6 +1190,7 @@ save batch to storage.
 when force is true, batchsize will be changed.
 */
 func writeBatchToStorage(handler *WriteBatchHandler,force bool) error {
+	var err error = nil
 	if handler.batchFilled == handler.batchSize{
 		//batchBytes := 0
 		//for _, vec := range handler.batchData.Vecs {
@@ -1185,15 +1207,20 @@ func writeBatchToStorage(handler *WriteBatchHandler,force bool) error {
 		//fmt.Printf("----batchBytes %v B %v MB\n",batchBytes,batchBytes / 1024.0 / 1024.0)
 		//
 		wait_a := time.Now()
-		err := handler.tableHandler.Write(handler.timestamp,handler.batchData)
-		if err != nil {
+		err = handler.tableHandler.Write(handler.timestamp,handler.batchData)
+		if err == nil {
+			handler.result.Records += uint64(handler.batchSize)
+		}else if isWriteBatchTimeoutError(err) {
 			logutil.Errorf("write failed. err: %v",err)
-			return err
+			handler.result.WriteTimeout += uint64(handler.batchSize)
+			//clean timeout error
+			err = nil
+		}else{
+			logutil.Errorf("write failed. err: %v",err)
+			handler.result.Skipped += uint64(handler.batchSize)
 		}
 
 		handler.writeBatch += time.Since(wait_a)
-
-		handler.result.Records += uint64(handler.batchSize)
 
 		wait_b := time.Now()
 		//clear batch
@@ -1268,17 +1295,22 @@ func writeBatchToStorage(handler *WriteBatchHandler,force bool) error {
 				//	fmt.Printf("len %d type %d %s \n",vec.Length(),vec.Typ.Oid,vec.Typ.String())
 				//}
 
-				err := handler.tableHandler.Write(handler.timestamp, handler.batchData)
-				if err != nil {
+				err = handler.tableHandler.Write(handler.timestamp, handler.batchData)
+				if err == nil {
+					handler.result.Records += uint64(handler.batchSize)
+				}else if isWriteBatchTimeoutError(err) {
+					logutil.Errorf("write failed. err: %v",err)
+					handler.result.WriteTimeout += uint64(handler.batchSize)
+					//clean timeout error
+					err = nil
+				}else{
 					logutil.Errorf("write failed. err:%v \n", err)
-					return err
+					handler.result.Skipped += uint64(handler.batchSize)
 				}
 			}
-
-			handler.result.Records += uint64(needLen)
 		}
 	}
-	return nil
+	return err
 }
 
 func saveLinesToStorage(handler *ParseLineHandler, force bool) error {
@@ -1468,7 +1500,7 @@ func (mce *MysqlCmdExecutor) LoadLoop(load *tree.Load, dbHandler engine.Database
 		case ne = <- handler.simdCsvNotiyEventChan:
 			switch ne.neType {
 			case NOTIFY_EVENT_WRITE_BATCH_RESULT:
-				collectWriteBatchResult(handler,ne.wbh)
+				collectWriteBatchResult(handler, ne.wbh, nil)
 			case NOTIFY_EVENT_END:
 				err = nil
 				quit = true
@@ -1479,6 +1511,7 @@ func (mce *MysqlCmdExecutor) LoadLoop(load *tree.Load, dbHandler engine.Database
 					err = ne.err
 					quit = true
 				}
+				collectWriteBatchResult(handler, ne.wbh, ne.err)
 			default:
 				logutil.Errorf("get unsupported notify event %d",ne.neType)
 				quit = true
@@ -1515,9 +1548,13 @@ func (mce *MysqlCmdExecutor) LoadLoop(load *tree.Load, dbHandler engine.Database
 
 		switch ne.neType {
 		case NOTIFY_EVENT_WRITE_BATCH_RESULT:
-			collectWriteBatchResult(handler,ne.wbh)
+			collectWriteBatchResult(handler, ne.wbh, nil)
+		case NOTIFY_EVENT_END:
+		case NOTIFY_EVENT_READ_SIMDCSV_ERROR,
+			NOTIFY_EVENT_OUTPUT_SIMDCSV_ERROR,
+			NOTIFY_EVENT_WRITE_BATCH_ERROR:
+			collectWriteBatchResult(handler, ne.wbh, ne.err)
 		default:
-
 		}
 	}
 

--- a/pkg/frontend/load.go
+++ b/pkg/frontend/load.go
@@ -1297,15 +1297,15 @@ func writeBatchToStorage(handler *WriteBatchHandler,force bool) error {
 
 				err = handler.tableHandler.Write(handler.timestamp, handler.batchData)
 				if err == nil {
-					handler.result.Records += uint64(handler.batchSize)
+					handler.result.Records += uint64(needLen)
 				}else if isWriteBatchTimeoutError(err) {
 					logutil.Errorf("write failed. err: %v",err)
-					handler.result.WriteTimeout += uint64(handler.batchSize)
+					handler.result.WriteTimeout += uint64(needLen)
 					//clean timeout error
 					err = nil
 				}else{
 					logutil.Errorf("write failed. err:%v \n", err)
-					handler.result.Skipped += uint64(handler.batchSize)
+					handler.result.Skipped += uint64(needLen)
 				}
 			}
 		}

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -610,8 +610,8 @@ func (mce *MysqlCmdExecutor) handleLoadData(load *tree.Load) error {
 	/*
 		response
 	*/
-	info := NewMysqlError(ER_LOAD_INFO, result.Records, result.Deleted, result.Skipped, result.Warnings).Error()
-	resp := NewOkResponse(result.Records, 0, uint16(result.Warnings), 0, int(COM_QUERY), " "+info)
+	info := NewMysqlError(ER_LOAD_INFO, result.Records, result.Deleted, result.Skipped, result.Warnings, result.WriteTimeout).Error()
+	resp := NewOkResponse(result.Records, 0, uint16(result.Warnings), 0, int(COM_QUERY), info)
 	if err = proto.SendResponse(resp); err != nil {
 		return fmt.Errorf("routine send response failed. error:%v ", err)
 	}

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -19,10 +19,10 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"github.com/huandu/go-clone"
-	"math/rand"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"math/rand"
 	"strconv"
 	"sync"
 	"time"
@@ -864,7 +864,7 @@ func (mp *MysqlProtocolImpl) makeOKPayload(affectedRows, lastInsertId uint64, st
 
 	//ensured by capturing packets
 	//it only works on MAC
-	//pos = mp.io.WriteUint8(data,pos,0x2f)
+	pos = mp.io.WriteUint8(data,pos,0x2f)
 
 	if mp.capability&CLIENT_SESSION_TRACK != 0 {
 		//TODO:implement it

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -850,7 +850,7 @@ func (mp *MysqlProtocolImpl) negotiateAuthenticationMethod() ([]byte, error) {
 
 //make a OK packet
 func (mp *MysqlProtocolImpl) makeOKPayload(affectedRows, lastInsertId uint64, statusFlags, warnings uint16, message string) []byte {
-	var data = make([]byte, 128)
+	var data = make([]byte, 128+len(message)+10)
 	var pos = 0
 	pos = mp.io.WriteUint8(data, pos, defines.OKHeader)
 	pos = mp.writeIntLenEnc(data, pos, affectedRows)
@@ -862,21 +862,11 @@ func (mp *MysqlProtocolImpl) makeOKPayload(affectedRows, lastInsertId uint64, st
 		pos = mp.io.WriteUint16(data, pos, statusFlags)
 	}
 
-	//ensured by capturing packets
-	//it only works on MAC
-	pos = mp.io.WriteUint8(data,pos,0x2f)
-
 	if mp.capability&CLIENT_SESSION_TRACK != 0 {
 		//TODO:implement it
 	} else {
-		alen := Min(len(data)-pos, len(message))
-		blen := len(message) - alen
-		if alen > 0 {
-			pos = mp.writeStringFix(data, pos, message, alen)
-		}
-		if blen > 0 {
-			return mp.appendStringFix(data, message, blen)
-		}
+		//string<lenenc> instead of string<EOF> in the manual of mysql
+		pos = mp.writeStringLenEnc(data,pos,message)
 		return data[:pos]
 	}
 	return data

--- a/pkg/frontend/mysql_protocol_predefines.go
+++ b/pkg/frontend/mysql_protocol_predefines.go
@@ -6234,7 +6234,7 @@ var errorMsgRefer = map[uint16]errorMsgItem{
 	ER_BLOBS_AND_NO_TERMINATED:       {1084, []string{"42000", "S1009"}, "You can't use fixed rowlength with BLOBs; please use 'fields terminated by'"},
 	ER_TEXTFILE_NOT_READABLE:         {1085, []string{"HY000"}, "The file '%-.128s' must be in the database directory or be readable by all"},
 	ER_FILE_EXISTS_ERROR:             {1086, []string{"HY000"}, "File '%-.200s' already exists"},
-	ER_LOAD_INFO:                     {1087, []string{"HY000"}, "Records: %d  Deleted: %d  Skipped: %d  Warnings: %d"},
+	ER_LOAD_INFO:                     {1087, []string{"HY000"}, "Records: %d  Deleted: %d  Skipped: %d  Warnings: %d WriteTimeout: %d"},
 	ER_ALTER_INFO:                    {1088, []string{"HY000"}, "Records: %ld  Duplicates: %ld"},
 	ER_WRONG_SUB_KEY:                 {1089, []string{"HY000"}, "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys"},
 	ER_CANT_REMOVE_ALL_FIELDS:        {1090, []string{"42000"}, "You can't delete all columns with ALTER TABLE; use DROP TABLE instead"},


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

fix #1230 

**What this PR does / why we need it:**
Some colleagues complain that the load drops the data during working when the writebatch timeout happens.
Actually it is not.  The recorder counter does not include the counts from the timeout. So, it is suitable to separate out counts of timeout from the total counter.


**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
