### PR TITLE
Support Type Date (create / insert and show in frontEnd)

### DIFF
--- a/pkg/encoding/debug_encoding.go
+++ b/pkg/encoding/debug_encoding.go
@@ -20,8 +20,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/gob"
-	"math"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"math"
 	"reflect"
 	"unsafe"
 )

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -1186,6 +1186,8 @@ func convertEngineTypeToMysqlType(engineType uint8, col *MysqlColumn) error {
 		col.SetColumnType(defines.MYSQL_TYPE_STRING)
 	case types.T_varchar:
 		col.SetColumnType(defines.MYSQL_TYPE_VARCHAR)
+	case types.T_date:
+		col.SetColumnType(defines.MYSQL_TYPE_DATE)
 	default:
 		return fmt.Errorf("RunWhileSend : unsupported type %d \n", engineType)
 	}

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -19,10 +19,11 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"github.com/huandu/go-clone"
-	"math/rand"
 	"github.com/matrixorigin/matrixone/pkg/config"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"math/rand"
 	"strconv"
 	"sync"
 	"time"
@@ -1128,7 +1129,13 @@ func (mp *MysqlProtocolImpl) makeResultSetTextRow(mrs *MysqlResultSet, r uint64)
 			} else {
 				data = mp.appendStringLenEnc(data, value)
 			}
-		case defines.MYSQL_TYPE_DATE, defines.MYSQL_TYPE_DATETIME, defines.MYSQL_TYPE_TIMESTAMP, defines.MYSQL_TYPE_TIME:
+		case defines.MYSQL_TYPE_DATE:
+			if value, err2 := mrs.GetInt64(r, i); err2 != nil {
+				return nil, err2
+			} else {
+				data = mp.appendStringLenEnc(data, types.Date(value).String())
+			}
+		case defines.MYSQL_TYPE_DATETIME, defines.MYSQL_TYPE_TIMESTAMP, defines.MYSQL_TYPE_TIME:
 			return nil, fmt.Errorf("unsupported DATE/DATETIME/TIMESTAMP/MYSQL_TYPE_TIME")
 		default:
 			return nil, fmt.Errorf("unsupported column type %d ", mysqlColumn.ColumnType())

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -39,6 +39,10 @@ import (
 	"strings"
 )
 
+const (
+	nullString = "NULL"
+)
+
 // CreateDatabase do create database work according to create database plan.
 func (s *Scope) CreateDatabase(ts uint64) error {
 	p, _ := s.Plan.(*plan.CreateDatabase)
@@ -240,7 +244,16 @@ func (s *Scope) ShowColumns(u interface{}, fill func(interface{}, *batch.Batch) 
 				typ:  attrDef.Attr.Type,
 			}
 			if attrDef.Attr.HasDefaultExpr() {
-				attrs[count].dft = fmt.Sprintf("%v", attrDef.Attr.Default.Value)
+				if attrDef.Attr.Default.IsNull {
+					attrs[count].dft = nullString
+				} else {
+					switch attrDef.Attr.Type.Oid {
+					case types.T_date:
+						attrs[count].dft = fmt.Sprintf("%s", attrDef.Attr.Default.Value)
+					default:
+						attrs[count].dft = fmt.Sprintf("%v", attrDef.Attr.Default.Value)
+					}
+				}
 			}
 			count++
 		}

--- a/pkg/sql/ftree/build_test.go
+++ b/pkg/sql/ftree/build_test.go
@@ -16,12 +16,12 @@ package ftree
 
 import (
 	"fmt"
-	"log"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/memEngine"
+	"log"
 	"testing"
 )
 
@@ -43,7 +43,7 @@ var querys = []string{
 	"select distinct spID,userID from t1 where score>2 order by spID asc;",
 	"select distinct spID,userID from t1 where spID>2 order by userID desc;",
 	"select distinct sum(spID) from t1 group by userID;",
-	"select distinct sum(spID) as sum from t1 group by userID order by sum asc;",
+"select distinct sum(spID) as sum from t1 group by u						serID order by sum asc;",
 	"select distinct sum(spID) as sum from t1 where score>1 group by userID order by sum asc;",
 	"select userID,MAX(score) from t1 where userID between 2 and 3 group by userID;",
 	"select userID,MAX(score) from t1 where userID not between 2 and 3 group by userID order by userID desc;",

--- a/pkg/sql/plan/create_table.go
+++ b/pkg/sql/plan/create_table.go
@@ -163,6 +163,8 @@ func (b *build) getTableDefType(typ tree.ResolvableTypeReference) (*types.Type, 
 			return &types.Type{Oid: types.T_char, Size: 24, Width: n.InternalType.DisplayWith}, nil
 		case defines.MYSQL_TYPE_VAR_STRING, defines.MYSQL_TYPE_VARCHAR:
 			return &types.Type{Oid: types.T_varchar, Size: 24, Width: n.InternalType.DisplayWith}, nil
+		case defines.MYSQL_TYPE_DATE:
+			return &types.Type{Oid: types.T_date, Size: 4}, nil
 		}
 	}
 	return nil, errors.New(errno.IndeterminateDatatype, fmt.Sprintf("unsupport type: '%v'", typ))
@@ -293,6 +295,8 @@ func rangeCheck(value interface{}, typ types.Type, columnName string, rowNumber 
 			return nil, errors.New(errno.DatatypeMismatch, "unexpected type and value")
 		}
 		return nil, errors.New(errno.DataException, fmt.Sprintf("Data too long for column '%s' at row %d", columnName, rowNumber))
+	case types.Date:
+		return v, nil
 	default:
 		return nil, errors.New(errno.DatatypeMismatch, "unexpected type and value")
 	}

--- a/pkg/sql/plan/expr.go
+++ b/pkg/sql/plan/expr.go
@@ -16,8 +16,6 @@ package plan
 
 import (
 	"fmt"
-	"go/constant"
-	"math"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
@@ -28,6 +26,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	"github.com/matrixorigin/matrixone/pkg/sql/viewexec/transformer"
+	"go/constant"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -782,6 +782,11 @@ func buildConstantValue(typ types.Type, num *tree.NumVal) (interface{}, error) {
 				return float64(-v), nil
 			}
 			return float64(v), nil
+		case types.T_date:
+			v, _ := constant.Uint64Val(val)
+			if !num.Negative() {
+				return types.ParseDate(strconv.FormatUint(v, 10))
+			}
 		}
 	case constant.Float:
 		switch typ.Oid {
@@ -842,6 +847,8 @@ func buildConstantValue(typ types.Type, num *tree.NumVal) (interface{}, error) {
 			switch typ.Oid {
 			case types.T_char, types.T_varchar:
 				return constant.StringVal(val), nil
+			case types.T_date:
+				return types.ParseDate(constant.StringVal(val))
 			}
 		}
 	}

--- a/pkg/sql/plan/insert.go
+++ b/pkg/sql/plan/insert.go
@@ -353,6 +353,28 @@ func (b *build) BuildInsert(stmt *tree.Insert, plan *Insert) error {
 			if err := vector.Append(vec, vs); err != nil {
 				return err
 			}
+		case types.T_date:
+			vs := make([]types.Date, len(rows.Rows))
+			{
+				for j, row := range rows.Rows {
+					v, err := buildConstant(vec.Typ, row[i])
+					if err != nil {
+						return err
+					}
+					if v == nil {
+						nulls.Add(vec.Nsp, uint64(j))
+					} else {
+						if vv, err := rangeCheck(v.(types.Date), vec.Typ, bat.Attrs[i], j+1); err != nil {
+							return err
+						} else {
+							vs[j] = vv.(types.Date)
+						}
+					}
+				}
+			}
+			if err := vector.Append(vec, vs); err != nil {
+				return err
+			}
 		default:
 			return errors.New(errno.DatatypeMismatch, fmt.Sprintf("insert for type '%v' not implement now", vec.Typ))
 		}
@@ -391,6 +413,8 @@ func (b *build) BuildInsert(stmt *tree.Insert, plan *Insert) error {
 				return err
 			}
 			vec.Col = col
+		case types.T_date:
+			vec.Col = make([]types.Date, len(rows.Rows))
 		default:
 			return errors.New(errno.DatatypeMismatch, fmt.Sprintf("insert for type '%v' not implement now", vec.Typ))
 		}

--- a/pkg/sql/plan/insert.go
+++ b/pkg/sql/plan/insert.go
@@ -448,6 +448,9 @@ func makeExprFromVal(typ types.Type, value interface{}, isNull bool) tree.Expr {
 	case types.T_char, types.T_varchar:
 		res := value.(string)
 		return tree.NewNumVal(constant.MakeString(res), res, false)
+	case types.T_date:
+		res := value.(types.Date).String()
+		return tree.NewNumVal(constant.MakeString(res), res, false)
 	}
 	return tree.NewNumVal(constant.MakeUnknown(), "NULL", false)
 }

--- a/pkg/sql/protocol/protocol.go
+++ b/pkg/sql/protocol/protocol.go
@@ -1726,6 +1726,23 @@ func EncodeVector(v *vector.Vector, buf *bytes.Buffer) error {
 		buf.Write(encoding.EncodeUint64(v.Link))
 		buf.Write(encoding.EncodeUint32(uint32(len(v.Data))))
 		buf.Write(v.Data)
+	case types.T_date:
+		buf.Write(encoding.EncodeType(v.Typ))
+		buf.Write(encoding.EncodeUint64(v.Ref))
+		nb, err := v.Nsp.Show()
+		if err != nil {
+			return err
+		}
+		buf.Write(encoding.EncodeUint32(uint32(len(nb))))
+		if len(nb) > 0 {
+			buf.Write(nb)
+		}
+		vs := v.Col.([]types.Date)
+		buf.Write(encoding.EncodeUint32(uint32(len(vs))))
+		buf.Write(encoding.EncodeDateSlice(vs))
+		buf.Write(encoding.EncodeUint64(v.Link))
+		buf.Write(encoding.EncodeUint32(uint32(len(v.Data))))
+		buf.Write(v.Data)
 	default:
 		return fmt.Errorf("unsupport vector type '%s'", v.Typ)
 	}
@@ -2080,6 +2097,34 @@ func DecodeVector(data []byte) (*vector.Vector, []byte, error) {
 			}
 			data = data[n:]
 			v.Col = col
+		} else {
+			data = data[4:]
+		}
+		v.Link = encoding.DecodeUint64(data[:8])
+		data = data[8:]
+		n := encoding.DecodeUint32(data[:4])
+		data = data[4:]
+		v.Data = data[:n]
+		data = data[n:]
+		return v, data, nil
+	case types.T_date:
+		v := vector.New(typ)
+		v.Or = true
+		v.Ref = encoding.DecodeUint64(data[:8])
+		data = data[8:]
+		if n := encoding.DecodeUint32(data[:4]); n > 0 {
+			data = data[4:]
+			if err := v.Nsp.Read(data[:n]); err != nil {
+				return nil, nil, err
+			}
+			data = data[n:]
+		} else {
+			data = data[4:]
+		}
+		if n := encoding.DecodeUint32(data[:4]); n > 0 {
+			data = data[4:]
+			v.Col = encoding.DecodeDateSlice(data[:n*4])
+			data = data[n*4:]
 		} else {
 			data = data[4:]
 		}

--- a/pkg/sql/protocol/protocol.go
+++ b/pkg/sql/protocol/protocol.go
@@ -61,6 +61,8 @@ func init() {
 	gob.Register(Source{})
 	gob.Register(Node{})
 	gob.Register(Scope{})
+
+	gob.Register(types.Date(0))
 }
 
 func EncodeScope(s Scope, buf *bytes.Buffer) error {

--- a/pkg/sql/unittest/sql_test.go
+++ b/pkg/sql/unittest/sql_test.go
@@ -85,10 +85,13 @@ func TestDataType(t *testing.T) {
 
 	sqls := []string {
 		"create table tdate (a date);",
+		"create table tdefdate (a date default '20211202')",
 		"insert into tdate values ('20070210'), ('1997-02-10'), ('01-04-28'), (20041112);",
+		"insert into tdefdate values ();",
 	}
 	res := [][]string {
 		{"tdate", "a\n\t[2007-02-10 1997-02-10 2001-04-28 2004-11-12]-&{<nil>}\n\n"},
+		{"tdefdate", "a\n\t2021-12-02\n\n"},
 	}
 
 	for _, sql := range sqls {

--- a/pkg/sql/unittest/sql_test.go
+++ b/pkg/sql/unittest/sql_test.go
@@ -17,7 +17,6 @@ package unittest
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/sql/compile"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -26,6 +25,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/mmu/guest"
 	"github.com/matrixorigin/matrixone/pkg/vm/mmu/host"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -74,6 +74,27 @@ func TestInsertFunction(t *testing.T) {
 		require.NoError(t, sqlRun(p, e, proc), p)
 	}
 	for _, s := range works {
+		require.Equal(t, s[1], TempSelect(e, "test", s[0]))
+	}
+}
+
+// TestDataType will do test for new Types
+// For Example: date, datetime
+func TestDataType(t *testing.T) {
+	e, proc := newTestEngine()
+
+	sqls := []string {
+		"create table tdate (a date);",
+		"insert into tdate values ('20070210'), ('1997-02-10'), ('01-04-28'), (20041112);",
+	}
+	res := [][]string {
+		{"tdate", "a\n\t[2007-02-10 1997-02-10 2001-04-28 2004-11-12]-&{<nil>}\n\n"},
+	}
+
+	for _, sql := range sqls {
+		require.NoError(t, sqlRun(sql, e, proc), sql)
+	}
+	for _, s := range res {
 		require.Equal(t, s[1], TempSelect(e, "test", s[0]))
 	}
 }

--- a/pkg/vm/engine/aoe/protocol/protocol.go
+++ b/pkg/vm/engine/aoe/protocol/protocol.go
@@ -552,6 +552,20 @@ func EncodeVector(v *vector.Vector, buf *bytes.Buffer) error {
 		if len(data) > 0 {
 			buf.Write(data)
 		}
+	case types.T_date:
+		buf.Write(encoding.EncodeType(v.Typ))
+		buf.Write(encoding.EncodeUint64(v.Ref))
+		nb, err := v.Nsp.Show()
+		if err != nil {
+			return err
+		}
+		buf.Write(encoding.EncodeUint32(uint32(len(nb))))
+		if len(nb) > 0 {
+			buf.Write(nb)
+		}
+		vs := v.Col.([]types.Date)
+		buf.Write(encoding.EncodeUint32(uint32(len(vs))))
+		buf.Write(encoding.EncodeDateSlice(vs))
 	default:
 		return fmt.Errorf("unsupport vector type '%s'", v.Typ)
 	}
@@ -840,6 +854,28 @@ func DecodeVector(data []byte) (*vector.Vector, []byte, error) {
 			}
 			data = data[n:]
 			v.Col = col
+		} else {
+			data = data[4:]
+		}
+		return v, data, nil
+	case types.T_date:
+		v := vector.New(typ)
+		v.Or = true
+		v.Ref = encoding.DecodeUint64(data[:8])
+		data = data[8:]
+		if n := encoding.DecodeUint32(data[:4]); n > 0 {
+			data = data[4:]
+			if err := v.Nsp.Read(data[:n]); err != nil {
+				return nil, nil, err
+			}
+			data = data[n:]
+		} else {
+			data = data[4:]
+		}
+		if n := encoding.DecodeUint32(data[:4]); n > 0 {
+			data = data[4:]
+			v.Col = encoding.DecodeDateSlice(data[:n*4])
+			data = data[n*4:]
 		} else {
 			data = data[4:]
 		}

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -39,7 +39,7 @@ type Attribute struct {
 
 type DefaultExpr struct {
 	Exist  bool
-	Value  interface{} // int64, float32, float64, string
+	Value  interface{} // int64, float32, float64, string, types.Date
 	IsNull bool
 }
 


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #827 

**What this PR does / why we need it:**

1. Support create table using column type 'date'
For Example:
`create table tbl (c1 date default '2021-12-02');`

2. Support insert constant value into date column, and range is from 19000101 to 99991231
constant value format can be
(1) 'yyyy-mm-dd'
(2) 'yyyymmdd'
(3) 'yy-mm-dd'
(4) 'yymmdd'
(5) INT yymmdd, yyyymmdd likes 19201003, 211202
For Example:
`insert into tbl values (201202), ('1997-02-11'), (19700315);`

3. Fix a bug while show columns from table.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
