### PR TITLE
Support `datetime` column type. create / insert / select

### DIFF
--- a/pkg/container/types/date.go
+++ b/pkg/container/types/date.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/matrixorigin/matrixone/pkg/errno"
 	"github.com/matrixorigin/matrixone/pkg/sql/errors"
+	"regexp"
 	"strconv"
 	"time"
 )
@@ -54,57 +55,96 @@ var (
 
 	leapYearMonthDays = []uint8{31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
 	flatYearMonthDays = []uint8{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+
+	regDate = regexp.MustCompile(`^(?P<year>[0-9]+)[-](?P<month>[0-9]+)[-](?P<day>[0-9]+)$`)
 )
 
 const (
-	FullYearMonthDay = len("yyyy-mm-dd")
-	DisputedYearMonthDay = len("yy-mm-dd") // also "yyyymmdd"
-	SimpleYearMonthDay = len("yymmdd")
+	shortestDateFormat = len("mdd")
+	todayDate          = "today()"
+	todayLength        = len(todayDate)
+
+	formatTwo1 = len("yyyymmdd")
+	formatTwo2 = len("yyymmdd")
+	formatTwo3 = len("yymmdd")
+	formatTwo4 = len("ymmdd")
+	formatTwo5 = len("mmdd")
+	formatTwo6 = len("mdd")
 
 	MaxDateYear = 9999
-	MinDateYear = 1000
+	MinDateYear = 0
 	MaxMonthInYear = 12
 	MinMonthInYear = 1
 
-	CenturyStr = "20"
+	thisCenturyStr0 = "2"
+	thisCenturyStr1 = "20"
+	thisCenturyStr2 = "200"
+	thisCenturyStr3 = "2000"
 )
 
 // ParseDate will parse string to be a Date.
 // can only solve string Format like :
-// "yyyy-mm-dd"
-// "yy-mm-dd" is same to "20yy-mm-dd"
-// "yyyymmdd"
-// "yymmdd" is same to "20yymmdd"
-// And the supported range is '1000-01-01' to '9999-12-31'
+// 1. 'year-month-day'
+//	{
+//		at this format, each part (year, month, day) doesn't always need to be filled completely
+//		year can be YYYY or YYY or YY or Y
+//  	month can be X or 0X
+//		day can be X or 0X
+//	}
+// 2. 'YearMonthDay'
+//	{
+//		at this format, each part should follow the rule: len(Day) is 2, len(Month) > 0, len(Month) <= len(Year) and can not be 1 at the same time
+//		in short, format can be:
+//		yyyymmdd, yyymmdd, yymmdd, ymmdd, mmdd, mdd (year will start from 2000 if incomplete)
+//	}
+// And the supported range is '0000-01-01' to '9999-12-31'
 func ParseDate(s string) (Date, error) {
 	var parts [3]string
-	var year, month, day int64
+	var year int64
+	var month, day uint64
 	var err error
 
-	switch len(s) {
-	case FullYearMonthDay: // yyyy-mm-dd
-		parts[0], parts[1], parts[2] = s[0:4], s[5:7], s[8:]
-	case DisputedYearMonthDay: // yy-mm-dd, yyyymmdd
-		if s[2] == '-' {
-			parts[0], parts[1], parts[2] = CenturyStr + s[0:2], s[3:5], s[6:]
-		} else {
-			parts[0], parts[1], parts[2] = s[0:4], s[4:6], s[6:]
-		}
-	case SimpleYearMonthDay: // yymmdd
-		parts[0], parts[1], parts[2] = CenturyStr + s[0:2], s[2:4], s[4:]
-	default:
+	l := len(s)
+	if l < shortestDateFormat {
 		return -1, errIncorrectDateValue
+	}
+	// todo: may it should use function but not a string constant
+	//if l == todayLength && s == todayDate { // special case
+	//	return Today(), nil
+	//}
+
+	match := regDate.FindStringSubmatch(s)
+
+	if len(match) == 4 { // Format `year-month-day`
+		parts[0], parts[1], parts[2] = match[1], match[2], match[3]
+	} else { // Format `yearMonthDay`
+		switch l {
+		case formatTwo1: // yyyymmdd
+			parts[0], parts[1], parts[2] = s[0:4], s[4:6], s[6:]
+		case formatTwo2: // yyymmdd
+			parts[0], parts[1], parts[2] = thisCenturyStr0 + s[0:3], s[3:5], s[5:]
+		case formatTwo3: // yymmdd
+			parts[0], parts[1], parts[2] = thisCenturyStr1 + s[0:2], s[2:4], s[4:]
+		case formatTwo4: // ymmdd
+			parts[0], parts[1], parts[2] = thisCenturyStr2 + s[0:1], s[1:3], s[3:]
+		case formatTwo5: // mmdd
+			parts[0], parts[1], parts[2] = thisCenturyStr3, s[0:2], s[2:]
+		case formatTwo6: // mdd
+			parts[0], parts[1], parts[2] = thisCenturyStr3, s[0:1], s[1:]
+		default:
+			return -1, errIncorrectDateValue
+		}
 	}
 
 	year, err = strconv.ParseInt(parts[0], 10, 32)
 	if err != nil {
 		return -1, errIncorrectDateValue
 	}
-	month, err = strconv.ParseInt(parts[1], 10, 16)
+	month, err = strconv.ParseUint(parts[1], 10, 8)
 	if err != nil {
 		return -1, errIncorrectDateValue
 	}
-	day, err = strconv.ParseInt(parts[2], 10, 16)
+	day, err = strconv.ParseUint(parts[2], 10, 8)
 	if err != nil {
 		return -1, errIncorrectDateValue
 	}
@@ -133,7 +173,7 @@ func validDate(year int32, month, day uint8) bool {
 
 func (a Date) String() string {
 	y, m, d, _ := a.Calendar(true)
-	return fmt.Sprintf("%d-%02d-%02d", y, m, d)
+	return fmt.Sprintf("%04d-%02d-%02d", y, m, d)
 }
 
 // Holds number of days since January 1, year 1 in Gregorian calendar

--- a/pkg/container/types/datetime.go
+++ b/pkg/container/types/datetime.go
@@ -15,6 +15,12 @@
 package types
 
 import (
+	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/errno"
+	"github.com/matrixorigin/matrixone/pkg/sql/errors"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 	"unsafe"
 )
@@ -30,7 +36,9 @@ const (
 // calendar, and lower 20 bits holds number of microseconds
 
 func (a Datetime) String() string {
-	return ""
+	y, m, d, _ := a.ToDate().Calendar(true)
+	hour, minute, sec := a.Clock()
+	return fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", y, m, d, hour, minute, sec)
 }
 
 const (
@@ -38,7 +46,183 @@ const (
 	hasMonotonic   = 1 << 63
 	unixToInternal = (1969*365 + 1969/4 - 1969/100 + 1969/400) * secsPerDay
 	wallToInternal = (1884*365 + 1884/4 - 1884/100 + 1884/400) * secsPerDay
+
+	minHourInDay, maxHourInDay = 0, 23
+	minMinuteInHour, maxMinuteInHour = 0, 59
+	minSecondInMinute, maxSecondInMinute = 0, 59
 )
+
+var (
+	errIncorrectDatetimeValue = errors.New(errno.DataException, "Incorrect datetime value")
+
+	// reg1 reg2 are regexps to match `year-month-day hh:mm:ss.msec`
+	reg1 = regexp.MustCompile(`^(?P<year>[0-9]+)[-](?P<month>[0-9]+)[-](?P<day>[0-9]+)$`)
+	reg2 = regexp.MustCompile(`^(?P<hour>[0-9]+)[:](?P<minute>[0-9]+)[:](?P<second>[0-9]+)(?P<msec>[.][0-9]+)?$`)
+
+	nowDatetime = "now()"
+	nowDatetimeLength = len(nowDatetime)
+
+	// regSimple is the regexp to match `yearMonthDayHourMinuteSecond.Sec` and some datetime like that
+	regSimple = regexp.MustCompile(`^(?P<part1>[0-9]+)(?P<part2>[.][0-9]+)?$`)
+
+	// format1 format2 format3 format4 are valid length cases for datetime-format used in ParseDatetime
+	format1 = 4 + 2 + 2 + 2 + 2 + 2 // full year + month + day + hour + minute + second
+	format2 = 3 + 2 + 2 + 2 + 2 + 2
+	format3 = 2 + 2 + 2 + 2 + 2 + 2
+	format4 = 1 + 2 + 2 + 2 + 2 + 2 // shortest year + month + day + hour + minute + second
+)
+
+// ParseDatetime parse a format string to be a Datetime
+// support Format:
+//	All Datetime
+//	Datetime + day time(hh:mm:ss or hh:mm:ss.[0, 9]*)
+func ParseDatetime(s string) (Datetime, error) {
+	var year int32
+	var month, day, hour, minute, second uint8
+	var msec uint32 = 0
+	var ymdhms [6]string // strings of year, month, day, hour, minute, second
+
+	if len(s) < shortestDateFormat {
+		return -1, errIncorrectDatetimeValue
+	}
+
+	//if len(s) == nowDatetimeLength && s == nowDatetime { // special case
+	//	return Now(), nil
+	//}
+
+	{ // match which string without hour-minute-second part.
+		if d, err := ParseDate(s); err == nil {
+			return d.ToTime(), nil
+		}
+	}
+
+	datetimeParts := strings.Split(s, " ")
+	switch len(datetimeParts) {
+	case 1: // possible to be `yearMonthDayHourMinuteSecond.Msec`
+		{
+			match := regSimple.FindStringSubmatch(datetimeParts[0])
+			switch len(match) {
+			case 3:
+				if len(match[1]) <= format1 && len(match[1]) >= format4 {
+					if len(match[2]) > 1 {
+						if ms, err := strconv.ParseUint(match[2][1:], 10, 32); err != nil {
+							return -1, errIncorrectDatetimeValue
+						} else {
+							msec = uint32(ms)
+						}
+					}
+					switch len(match[1]) {
+					case format1:
+						ymdhms[0], ymdhms[1], ymdhms[2] = match[1][0:4], match[1][4:6], match[1][6:8]
+						ymdhms[3], ymdhms[4], ymdhms[5] = match[1][8:10], match[1][10:12], match[1][12:]
+					case format2:
+						ymdhms[0], ymdhms[1], ymdhms[2] = thisCenturyStr0 + match[1][0:3], match[1][3:5], match[1][5:7]
+						ymdhms[3], ymdhms[4], ymdhms[5] = match[1][7:9], match[1][9:11], match[1][11:]
+					case format3:
+						ymdhms[0], ymdhms[1], ymdhms[2] = thisCenturyStr1 + match[1][0:2], match[1][2:4], match[1][4:6]
+						ymdhms[3], ymdhms[4], ymdhms[5] = match[1][6:8], match[1][8:10], match[1][10:]
+					case format4:
+						ymdhms[0], ymdhms[1], ymdhms[2] = thisCenturyStr2 + match[1][0:1], match[1][1:3], match[1][3:5]
+						ymdhms[3], ymdhms[4], ymdhms[5] = match[1][5:7], match[1][7:9], match[1][9:]
+					}
+				} else {
+					return -1, errIncorrectDatetimeValue
+				}
+			default:
+				return -1, errIncorrectDatetimeValue
+			}
+		}
+	case 2:	// only possible to be `year-month-day hh:mm:ss.[0,9]*`
+		{ // to match year-month-day
+			match := reg1.FindStringSubmatch(datetimeParts[0])
+			switch len(match) {
+			case 4:
+				ymdhms[0], ymdhms[1], ymdhms[2] = match[1], match[2], match[3]
+			default:
+				return -1, errIncorrectDatetimeValue
+			}
+		}
+		{ // to match hh:mm:ss.[0-9]*
+			match := reg2.FindStringSubmatch(datetimeParts[1])
+			switch len(match) {
+			case 5:
+				ymdhms[3], ymdhms[4], ymdhms[5] = match[1], match[2], match[3]
+				if len(match[4]) > 1 { // with fractional part, and match[4] is '.xx'
+					if ms, err := strconv.ParseUint(match[4][1:], 10, 32); err != nil {
+						return -1, errIncorrectDatetimeValue
+					} else {
+						msec = uint32(ms)
+					}
+				}
+			default:
+				return -1, errIncorrectDatetimeValue
+			}
+		}
+	default:
+		return -1, errIncorrectDatetimeValue
+	}
+
+	{ // year
+		y, err := strconv.ParseInt(ymdhms[0], 10, 32)
+		if err != nil {
+			return -1, errIncorrectDatetimeValue
+		}
+		year = int32(y)
+	}
+	{ // month
+		m, err := strconv.ParseUint(ymdhms[1], 10, 8)
+		if err != nil {
+			return -1, errIncorrectDatetimeValue
+		}
+		month = uint8(m)
+	}
+	{ // day
+		d, err := strconv.ParseUint(ymdhms[2], 10, 8)
+		if err != nil {
+			return -1, errIncorrectDatetimeValue
+		}
+		day = uint8(d)
+	}
+	{ // hour
+		h, err := strconv.ParseUint(ymdhms[3], 10, 8)
+		if err != nil {
+			return -1, errIncorrectDatetimeValue
+		}
+		hour = uint8(h)
+	}
+	{ // minute
+		m, err := strconv.ParseUint(ymdhms[4], 10, 8)
+		if err != nil {
+			return -1, errIncorrectDatetimeValue
+		}
+		minute = uint8(m)
+	}
+	{ // second
+		s, err := strconv.ParseUint(ymdhms[5], 10, 8)
+		if err != nil {
+			return -1, errIncorrectDatetimeValue
+		}
+		second = uint8(s)
+	}
+	if !validDate(year, month, day) || !validTimeInDay(hour, minute, second) {
+		return -1, errIncorrectDatetimeValue
+	}
+	return FromClock(year, month, day, hour, minute, second, msec), nil
+}
+
+// validTimeInDay return true if hour, minute and second can be a time during a day
+func validTimeInDay(h, m, s uint8) bool {
+	if h < minHourInDay || h > maxHourInDay {
+		return false
+	}
+	if m < minMinuteInHour || m > maxMinuteInHour {
+		return false
+	}
+	if s < minSecondInMinute || s > maxSecondInMinute {
+		return false
+	}
+	return true
+}
 
 func Now() Datetime {
 	t := time.Now()
@@ -53,10 +237,6 @@ func Now() Datetime {
 		nsec = int64(wall)
 	}
 	return Datetime((sec << 20) + nsec/1000)
-}
-
-func ParseDatetime(s []byte) Datetime {
-	return 0
 }
 
 func (dt Datetime) ToDate() Date {

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -1188,6 +1188,8 @@ func convertEngineTypeToMysqlType(engineType uint8, col *MysqlColumn) error {
 		col.SetColumnType(defines.MYSQL_TYPE_VARCHAR)
 	case types.T_date:
 		col.SetColumnType(defines.MYSQL_TYPE_DATE)
+	case types.T_datetime:
+		col.SetColumnType(defines.MYSQL_TYPE_DATETIME)
 	default:
 		return fmt.Errorf("RunWhileSend : unsupported type %d \n", engineType)
 	}

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -1135,7 +1135,13 @@ func (mp *MysqlProtocolImpl) makeResultSetTextRow(mrs *MysqlResultSet, r uint64)
 			} else {
 				data = mp.appendStringLenEnc(data, types.Date(value).String())
 			}
-		case defines.MYSQL_TYPE_DATETIME, defines.MYSQL_TYPE_TIMESTAMP, defines.MYSQL_TYPE_TIME:
+		case defines.MYSQL_TYPE_DATETIME:
+			if value, err2 := mrs.GetInt64(r, i); err2 != nil {
+				return nil, err2
+			} else {
+				data = mp.appendStringLenEnc(data, types.Datetime(value).String())
+			}
+		case defines.MYSQL_TYPE_TIMESTAMP, defines.MYSQL_TYPE_TIME:
 			return nil, fmt.Errorf("unsupported DATE/DATETIME/TIMESTAMP/MYSQL_TYPE_TIME")
 		default:
 			return nil, fmt.Errorf("unsupported column type %d ", mysqlColumn.ColumnType())

--- a/pkg/sql/plan/create_table.go
+++ b/pkg/sql/plan/create_table.go
@@ -184,6 +184,8 @@ func (b *build) getTableDefType(typ tree.ResolvableTypeReference) (*types.Type, 
 			return &types.Type{Oid: types.T_varchar, Size: 24, Width: n.InternalType.DisplayWith}, nil
 		case defines.MYSQL_TYPE_DATE:
 			return &types.Type{Oid: types.T_date, Size: 4}, nil
+		case defines.MYSQL_TYPE_DATETIME:
+			return &types.Type{Oid: types.T_datetime, Size: 8}, nil
 		}
 	}
 	return nil, errors.New(errno.IndeterminateDatatype, fmt.Sprintf("unsupport type: '%v'", typ))
@@ -314,7 +316,7 @@ func rangeCheck(value interface{}, typ types.Type, columnName string, rowNumber 
 			return nil, errors.New(errno.DatatypeMismatch, "unexpected type and value")
 		}
 		return nil, errors.New(errno.DataException, fmt.Sprintf("Data too long for column '%s' at row %d", columnName, rowNumber))
-	case types.Date:
+	case types.Date, types.Datetime:
 		return v, nil
 	default:
 		return nil, errors.New(errno.DatatypeMismatch, "unexpected type and value")

--- a/pkg/sql/plan/expr.go
+++ b/pkg/sql/plan/expr.go
@@ -783,9 +783,12 @@ func buildConstantValue(typ types.Type, num *tree.NumVal) (interface{}, error) {
 			}
 			return float64(v), nil
 		case types.T_date:
-			v, _ := constant.Uint64Val(val)
 			if !num.Negative() {
-				return types.ParseDate(strconv.FormatUint(v, 10))
+				return types.ParseDate(str)
+			}
+		case types.T_datetime:
+			if !num.Negative() {
+				return types.ParseDatetime(str)
 			}
 		}
 	case constant.Float:
@@ -841,6 +844,8 @@ func buildConstantValue(typ types.Type, num *tree.NumVal) (interface{}, error) {
 				return float64(-v), nil
 			}
 			return float64(v), nil
+		case types.T_datetime:
+			return types.ParseDatetime(str)
 		}
 	case constant.String:
 		if !num.Negative() {
@@ -849,6 +854,8 @@ func buildConstantValue(typ types.Type, num *tree.NumVal) (interface{}, error) {
 				return constant.StringVal(val), nil
 			case types.T_date:
 				return types.ParseDate(constant.StringVal(val))
+			case types.T_datetime:
+				return types.ParseDatetime(constant.StringVal(val))
 			}
 		}
 	}

--- a/pkg/sql/protocol/protocol.go
+++ b/pkg/sql/protocol/protocol.go
@@ -63,6 +63,7 @@ func init() {
 	gob.Register(Scope{})
 
 	gob.Register(types.Date(0))
+	gob.Register(types.Datetime(0))
 }
 
 func EncodeScope(s Scope, buf *bytes.Buffer) error {
@@ -1745,6 +1746,23 @@ func EncodeVector(v *vector.Vector, buf *bytes.Buffer) error {
 		buf.Write(encoding.EncodeUint64(v.Link))
 		buf.Write(encoding.EncodeUint32(uint32(len(v.Data))))
 		buf.Write(v.Data)
+	case types.T_datetime:
+		buf.Write(encoding.EncodeType(v.Typ))
+		buf.Write(encoding.EncodeUint64(v.Ref))
+		nb, err := v.Nsp.Show()
+		if err != nil {
+			return err
+		}
+		buf.Write(encoding.EncodeUint32(uint32(len(nb))))
+		if len(nb) > 0 {
+			buf.Write(nb)
+		}
+		vs := v.Col.([]types.Datetime)
+		buf.Write(encoding.EncodeUint32(uint32(len(vs))))
+		buf.Write(encoding.EncodeDatetimeSlice(vs))
+		buf.Write(encoding.EncodeUint64(v.Link))
+		buf.Write(encoding.EncodeUint32(uint32(len(v.Data))))
+		buf.Write(v.Data)
 	default:
 		return fmt.Errorf("unsupport vector type '%s'", v.Typ)
 	}
@@ -2127,6 +2145,34 @@ func DecodeVector(data []byte) (*vector.Vector, []byte, error) {
 			data = data[4:]
 			v.Col = encoding.DecodeDateSlice(data[:n*4])
 			data = data[n*4:]
+		} else {
+			data = data[4:]
+		}
+		v.Link = encoding.DecodeUint64(data[:8])
+		data = data[8:]
+		n := encoding.DecodeUint32(data[:4])
+		data = data[4:]
+		v.Data = data[:n]
+		data = data[n:]
+		return v, data, nil
+	case types.T_datetime:
+		v := vector.New(typ)
+		v.Or = true
+		v.Ref = encoding.DecodeUint64(data[:8])
+		data = data[8:]
+		if n := encoding.DecodeUint32(data[:4]); n > 0 {
+			data = data[4:]
+			if err := v.Nsp.Read(data[:n]); err != nil {
+				return nil, nil, err
+			}
+			data = data[n:]
+		} else {
+			data = data[4:]
+		}
+		if n := encoding.DecodeUint32(data[:4]); n > 0 {
+			data = data[4:]
+			v.Col = encoding.DecodeDatetimeSlice(data[:n*8])
+			data = data[n*8:]
 		} else {
 			data = data[4:]
 		}

--- a/pkg/vm/engine/aoe/protocol/protocol.go
+++ b/pkg/vm/engine/aoe/protocol/protocol.go
@@ -566,6 +566,20 @@ func EncodeVector(v *vector.Vector, buf *bytes.Buffer) error {
 		vs := v.Col.([]types.Date)
 		buf.Write(encoding.EncodeUint32(uint32(len(vs))))
 		buf.Write(encoding.EncodeDateSlice(vs))
+	case types.T_datetime:
+		buf.Write(encoding.EncodeType(v.Typ))
+		buf.Write(encoding.EncodeUint64(v.Ref))
+		nb, err := v.Nsp.Show()
+		if err != nil {
+			return err
+		}
+		buf.Write(encoding.EncodeUint32(uint32(len(nb))))
+		if len(nb) > 0 {
+			buf.Write(nb)
+		}
+		vs := v.Col.([]types.Datetime)
+		buf.Write(encoding.EncodeUint32(uint32(len(vs))))
+		buf.Write(encoding.EncodeDatetimeSlice(vs))
 	default:
 		return fmt.Errorf("unsupport vector type '%s'", v.Typ)
 	}
@@ -876,6 +890,28 @@ func DecodeVector(data []byte) (*vector.Vector, []byte, error) {
 			data = data[4:]
 			v.Col = encoding.DecodeDateSlice(data[:n*4])
 			data = data[n*4:]
+		} else {
+			data = data[4:]
+		}
+		return v, data, nil
+	case types.T_datetime:
+		v := vector.New(typ)
+		v.Or = true
+		v.Ref = encoding.DecodeUint64(data[:8])
+		data = data[8:]
+		if n := encoding.DecodeUint32(data[:4]); n > 0 {
+			data = data[4:]
+			if err := v.Nsp.Read(data[:n]); err != nil {
+				return nil, nil, err
+			}
+			data = data[n:]
+		} else {
+			data = data[4:]
+		}
+		if n := encoding.DecodeUint32(data[:4]); n > 0 {
+			data = data[4:]
+			v.Col = encoding.DecodeDatetimeSlice(data[:n*8])
+			data = data[n*8:]
 		} else {
 			data = data[4:]
 		}

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -39,7 +39,7 @@ type Attribute struct {
 
 type DefaultExpr struct {
 	Exist  bool
-	Value  interface{} // int64, float32, float64, string, types.Date
+	Value  interface{} // int64, float32, float64, string, types.Date, types.Datetime
 	IsNull bool
 }
 


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #827 

**What this PR does / why we need it:**

1.Support insert / create / select for `datetime` type.
but can not support `insert into tbl values (now());`.

supported format for datetime type:
1.'2015-10-3 12:11:10'
2.'2015-10-3'
3.12030205153444

2. use regexp to refactor ParseDate

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
