### PR TITLE
add cpu, allocs, heap profiling flags

### DIFF
--- a/cmd/db-server/profile.go
+++ b/cmd/db-server/profile.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"runtime/metrics"
+	"runtime/pprof"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+)
+
+var (
+	cpuProfilePathFlag       = flag.String("cpu-profile", "", "write cpu profile to the specified file")
+	allocsProfilePathFlag    = flag.String("allocs-profile", "", "write allocs profile to the specified file")
+	heapProfilePathFlag      = flag.String("heap-profile", "", "write heap profile to the specified file")
+	heapProfileThresholdFlag = flag.Uint64("heap-profile-threshold", 8*1024*1024*1024,
+		"take a heap profile if mapped memory changes exceed the specified threshold bytes")
+)
+
+func startCPUProfile() func() {
+	cpuProfilePath := *cpuProfilePathFlag
+	if cpuProfilePath == "" {
+		cpuProfilePath = "cpu-profile"
+	}
+	f, err := os.Create(cpuProfilePath)
+	if err != nil {
+		panic(err)
+	}
+	pprof.StartCPUProfile(f)
+	logutil.Infof("CPU profiling enabled, writing to %s", cpuProfilePath)
+	return func() {
+		pprof.StopCPUProfile()
+		f.Close()
+	}
+}
+
+func writeAllocsProfile() {
+	profile := pprof.Lookup("allocs")
+	if profile == nil {
+		return
+	}
+	profilePath := *allocsProfilePathFlag
+	if profilePath == "" {
+		profilePath = "allocs-profile"
+	}
+	f, err := os.Create(profilePath)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	if err := profile.WriteTo(f, 0); err != nil {
+		panic(err)
+	}
+	logutil.Infof("Allocs profile written to %s", profilePath)
+}
+
+func init() {
+	if *heapProfilePathFlag != "" {
+		return
+	}
+	go func() {
+
+		samples := []metrics.Sample{
+			{
+				Name: "/memory/classes/total:bytes",
+			},
+		}
+		var lastUsing uint64
+		for range time.NewTicker(time.Second).C {
+			metrics.Read(samples)
+			using := samples[0].Value.Uint64()
+			if using-lastUsing > *heapProfileThresholdFlag {
+				profile := pprof.Lookup("heap")
+				if profile == nil {
+					continue
+				}
+				profilePath := *heapProfilePathFlag
+				if profilePath == "" {
+					profilePath = "allocs-profile"
+				}
+				profilePath += "." + time.Now().Format("15:04:05.000000")
+				f, err := os.Create(profilePath)
+				if err != nil {
+					panic(err)
+				}
+				defer f.Close()
+				if err := profile.WriteTo(f, 0); err != nil {
+					panic(err)
+				}
+				logutil.Infof("Heap profile written to %s", profilePath)
+			}
+			lastUsing = using
+		}
+
+	}()
+}


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #1322

**What this PR does / why we need it:**

Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):

Usages:

cpu profiling:
./db-server -cpu-profile cpuprofile system_vars_config.toml
After server shutdown, the CPU profile will be written to `cpuprofile`

allocation profiling:
./db-server -allocs-profile allocsprofile system_vars_config.toml
After server shutdown, the allocation profile will be written to `allocsprofile`

auto heap profile snapshot:
./db-server -heap-profile heap -heap-profile-threshold 1000000000 system_vars_config.toml
If heap allocates more than 1G in one second, take a heap profile and write to heap.[time].


