### PR TITLE
Feature: support command line argument --version in mo-server executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 BIN_NAME := mo-server
 BUILD_CFG := gen_config
 UNAME_S := $(shell uname -s)
+GO_VERSION=$(shell go version)
+BRANCH_NAME=$(shell git rev-parse --abbrev-ref HEAD)
+LAST_COMMIT_ID=$(shell git rev-parse HEAD)
+BUILD_TIME=$(shell date)
 
 # Creating build config
 .PHONY: config
@@ -21,7 +25,8 @@ build: cmd/db-server/main.go
 	@go generate ./pkg/sql/colexec/extend/overload
 	$(info [Build binary])
 	@go mod tidy
-	@go build -o $(BIN_NAME) cmd/db-server/main.go
+	@go build -ldflags="-X 'main.GoVersion=$(GO_VERSION)' -X 'main.BranchName=$(BRANCH_NAME)' -X 'main.LastCommitId=$(LAST_COMMIT_ID)' -X 'main.BuildTime=$(BUILD_TIME)'" -o $(BIN_NAME) cmd/db-server/main.go 
+
 
 # Building mo-server binary for debugging, it uses the latest MatrixCube from master.
 .PHONY: debug
@@ -30,7 +35,7 @@ debug: cmd/db-server/main.go
 	$(info [Build binary for debug])
 	go get github.com/matrixorigin/matrixcube
 	go mod tidy
-	go build -tags debug -o $(BIN_NAME) cmd/db-server/main.go
+	go build -tags debug -ldflags="-X 'main.GoVersion=$(GO_VERSION)' -X 'main.BranchName=$(BRANCH_NAME)' -X 'main.LastCommitId=$(LAST_COMMIT_ID)' -X 'main.BuildTime=$(BUILD_TIME)'" -o $(BIN_NAME) cmd/db-server/main.go 
 
 # Run Static Code Analysis
 .PHONY: sca

--- a/cmd/db-server/main.go
+++ b/cmd/db-server/main.go
@@ -78,6 +78,16 @@ var (
 	pci *frontend.PDCallbackImpl
 )
 
+// Variables used to hold the build info.
+var (
+	GoVersion    string = ""
+	BranchName   string = ""
+	LastCommitId string = ""
+	BuildTime    string = ""
+	MoVersion    string = "v0.1.0"
+)
+
+
 func createMOServer(callback *frontend.PDCallbackImpl) {
 	address := fmt.Sprintf("%s:%d", config.GlobalSystemVariables.GetHost(), config.GlobalSystemVariables.GetPort())
 	pu := config.NewParameterUnit(&config.GlobalSystemVariables, config.HostMmu, config.Mempool, config.StorageEngine, config.ClusterNodes, config.ClusterCatalog)
@@ -135,6 +145,17 @@ func main() {
 	if len(os.Args) < 2 {
 		fmt.Printf("Usage: %s configFile\n", os.Args[0])
 		os.Exit(-1)
+	}
+
+	// if the argument passed in is "--version", return version info and exit
+	if os.Args[1] == "--version" {
+		fmt.Println("MatrixOne build info:")
+		fmt.Printf("\tThe golang version used to build this binary: %s\n", GoVersion)
+		fmt.Printf("\tGit branch name: %s\n", BranchName)
+		fmt.Printf("\tLast git commit ID: %s\n", LastCommitId)
+		fmt.Printf("\tBuildtime: %s\n", BuildTime)
+		fmt.Printf("\tCurrent Matrixone version: %s\n", MoVersion)
+		os.Exit(0)
 	}
 	flag.Parse()
 


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #1326

**What this PR does / why we need it:**
pass the argument "--version" to mo-server executable to get the build info.
Not Available

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
