### PR TITLE
[CONFIG] Support advertise rpc addresses parameters for pd

### DIFF
--- a/cmd/generate-config/system_vars_def.toml
+++ b/cmd/generate-config/system_vars_def.toml
@@ -364,14 +364,19 @@ max-backups = 0 # maximum numbers of old log files to retain.
 
 # Cube Configs
 # In a distributed setting, the ip of addr-raft and addr-client should set to the ip address of the machine that mo-server runs on.
-# In a distributed setting, the shard-groups should set to 2.
+# Docker or NAT network environment configuration,  
+# If a client cannot access Cube through the default client URLs listened to by Cube, you must manually set the advertise client URLs
+# For exmaple, addr-raft = "0.0.0.0:10000", addr-advertise-raft = "${HOST}:10000". The same to addr-client.
 addr-raft = "localhost:10000"
+addr-advertise-raft = ""
 addr-client = "localhost:20000"
+addr-advertise-client = ""
 dir-deploy = ""
 version = ""
 githash = ""
 capacity = 0
 use-memory-as-storage = false
+# In a distributed setting, the shard-groups should set to 2.
 shard-groups = 1
 
 # Replication Configs
@@ -419,7 +424,10 @@ raft-event-worker = 32
 # In a distributed setting, there are three nodes act as prophet, each of which should have different names.
 name = "node0"
 data-dir = ""
+# RPC port for other client to access prophet.
+# Docker or NAT network  exmaple, rpc-addr = "0.0.0.0:30000", rpc-advertise-addr = "${HOST}:30000"
 rpc-addr = "localhost:30000"
+rpc-advertise-addr = ""
 # In a distributed setting, adjust this setting according to you network status. For poor network connections, set this value larger.
 rpc-timeout = "10s"
 # In a distributed setting, if a node is not a prophet node(i.e., a pure storage node), set the value storage-node = false.
@@ -438,6 +446,9 @@ join = ""
 client-urls = "http://localhost:40000"
 # In a distributed setting, change the localhost to the machine ip to expose the client-urls to other nodes in the cluster.
 peer-urls = "http://localhost:50000"
+# In some situations such as in the Docker or NAT network environment, 
+# if a client cannot access prophet through the default client URLs listened to by prophet, you must manually set the advertise client URLs
+# For example,client-url = "http://0.0.0.0:40000", advertise-client-urls = "http://${HOST}:40000", The same to peer-urls.
 advertise-client-urls = ""
 advertise-peer-urls = ""
 initial-cluster = ""

--- a/cmd/generate-config/system_vars_def.toml
+++ b/cmd/generate-config/system_vars_def.toml
@@ -364,7 +364,7 @@ max-backups = 0 # maximum numbers of old log files to retain.
 
 # Cube Configs
 # In a distributed setting, the ip of addr-raft and addr-client should set to the ip address of the machine that mo-server runs on.
-# Docker or NAT network environment configuration,  
+# Docker or NAT network environment configuration
 # If a client cannot access Cube through the default client URLs listened to by Cube, you must manually set the advertise client URLs
 # For exmaple, addr-raft = "0.0.0.0:10000", addr-advertise-raft = "${HOST}:10000". The same to addr-client.
 addr-raft = "localhost:10000"
@@ -425,7 +425,8 @@ raft-event-worker = 32
 name = "node0"
 data-dir = ""
 # RPC port for other client to access prophet.
-# Docker or NAT network  exmaple, rpc-addr = "0.0.0.0:30000", rpc-advertise-addr = "${HOST}:30000"
+# Docker or NAT network environment configuration
+# For exmaple, rpc-addr = "0.0.0.0:30000", rpc-advertise-addr = "${HOST}:30000"
 rpc-addr = "localhost:30000"
 rpc-advertise-addr = ""
 # In a distributed setting, adjust this setting according to you network status. For poor network connections, set this value larger.
@@ -435,20 +436,25 @@ storage-node = true
 # In a distributed setting, if a node is a prophet node, the value external-etcd should be empty.
 # If a node is not a prophet node(i.e., the above setting storage-node = false), the value of external-etcd should be the three prophet node's prophet.embed-etcd's peer-urls.
 external-etcd = ["", "", ""]
+# If prophet cluster have 3 nodes (also prophet cluster should have 3 nodes at least), lease should be 3. external-etcd should config nodes advertise-client-urls.
 lease = 0
 
 # In a distributed setting, only the three prophet nodes need to adjust this setting
 [prophet.embed-etcd]
 # For the genesis node in the three prophet, the join value should remain a empty string.
 # For the other two nodes in the prophet group, the join value should set to the genesis node's peer-urls.
+# see more: https://etcd.io/docs/v3.5/op-guide/clustering/
 join = ""
 # In a distributed setting, change the localhost to the machine ip to expose the client-urls to other nodes in the cluster.
+# When you deploy a cluster, you must specify the IP address of the current host as client-urls (for example, "http://192.168.100.214:40000"). 
+# If the cluster runs on Docker, specify the IP address of Docker as "http://0.0.0.0:40000"
 client-urls = "http://localhost:40000"
 # In a distributed setting, change the localhost to the machine ip to expose the client-urls to other nodes in the cluster.
+# The list of peer URLs to be listened to by a prophet node
 peer-urls = "http://localhost:50000"
 # In some situations such as in the Docker or NAT network environment, 
 # if a client cannot access prophet through the default client URLs listened to by prophet, you must manually set the advertise client URLs
-# For example,client-url = "http://0.0.0.0:40000", advertise-client-urls = "http://${HOST}:40000", The same to peer-urls.
+# For example, client-url = "http://0.0.0.0:40000", advertise-client-urls = "http://${HOST}:40000", The same to peer-urls.
 advertise-client-urls = ""
 advertise-peer-urls = ""
 initial-cluster = ""

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,8 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/btree v1.0.1
 	github.com/huandu/go-clone v1.3.0
-	github.com/matrixorigin/matrixcube v0.0.0-20211216114139-2b4dd613790b
+	// github.com/matrixorigin/matrixcube v0.0.0-20211216114139-2b4dd613790b
+	github.com/matrixorigin/matrixcube v0.0.0-20211220041330-cc59ca84ab28
 	github.com/matrixorigin/simdcsv v0.0.0-20210926114300-591bf748a770
 	github.com/panjf2000/ants/v2 v2.4.6
 	github.com/pierrec/lz4 v2.6.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/matrixorigin/etcd/raft/v3 v3.5.1-0.20210824022435-0203115049c2 h1:s7CQEsRxL8+/sAPW23uIqpwR+M8Aje81AH6w3/ZkxQw=
 github.com/matrixorigin/etcd/raft/v3 v3.5.1-0.20210824022435-0203115049c2/go.mod h1:UFOHSIvO/nKwd4lhkwabrTD3cqW5yVyYYf/KlD00Szc=
-github.com/matrixorigin/matrixcube v0.0.0-20211216114139-2b4dd613790b h1:GVYbiH+iSG001UxBr1xDeOgJNQ3MQxaMCA93JMTlCG0=
-github.com/matrixorigin/matrixcube v0.0.0-20211216114139-2b4dd613790b/go.mod h1:5xrn3BfKKYJw9rDwO5E/RwWg0wPE3H8wnQyjpwIhyYk=
+github.com/matrixorigin/matrixcube v0.0.0-20211220041330-cc59ca84ab28 h1:LUKAgKcX5yw7sP/dafpd4JsjSwgOwNhZiX69hgJgIII=
+github.com/matrixorigin/matrixcube v0.0.0-20211220041330-cc59ca84ab28/go.mod h1:5xrn3BfKKYJw9rDwO5E/RwWg0wPE3H8wnQyjpwIhyYk=
 github.com/matrixorigin/simdcsv v0.0.0-20210926114300-591bf748a770 h1:apc228jeCtUvvfkaydzJygk1jdH8y+THma2o73Yv4Vg=
 github.com/matrixorigin/simdcsv v0.0.0-20210926114300-591bf748a770/go.mod h1:A7O+LRuZcr/BbOLsMzM/q69ZmoLENUMpptYG0pPzTFQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #1445

**What this PR does / why we need it:**

In some situations such as in the Docker or NAT network environment, if a client cannot access service through the default client URLs listened to by service, you must manually set the advertise client URLs.  Link： [matrixcube PR](https://github.com/matrixorigin/matrixcube/pull/574)

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
