### PR TITLE
built-in functions do not use type-implicit-conversion

### DIFF
--- a/pkg/sql/colexec/extend/overload/binary.go
+++ b/pkg/sql/colexec/extend/overload/binary.go
@@ -701,5 +701,8 @@ func initCastRulesForBinaryOps() {
 
 // binaryOpsNeedCast returns true if a binary operator needs type-cast for its arguments.
 func binaryOpsNeedCast(op int, ltyp types.T, rtyp types.T) (castResult, bool) {
+	if op > NE || op < Or {
+		return castResult{}, false
+	}
 	return binOpsTypeCastRules[op-firstBinaryOp][ltyp][rtyp], binOpsTypeCastRules[op-firstBinaryOp][ltyp][rtyp].has
 }

--- a/pkg/sql/colexec/extend/overload/unary.go
+++ b/pkg/sql/colexec/extend/overload/unary.go
@@ -115,5 +115,8 @@ func initCastRulesForUnaryOps() {
 
 // unaryOpsNeedCast returns true if a unary operator needs type-cast for its argument.
 func unaryOpsNeedCast(op int, argTyp types.T) (castResult, bool) {
+	if op < 0 || op > Not {
+		return castResult{}, false
+	}
 	return unaryOpsTypeCastRules[op-firstUnaryOp][argTyp], unaryOpsTypeCastRules[op-firstUnaryOp][argTyp].has
 }

--- a/pkg/sql/plan/drop_index.go
+++ b/pkg/sql/plan/drop_index.go
@@ -15,8 +15,14 @@
 package plan
 
 import (
+	"github.com/matrixorigin/matrixone/pkg/errno"
+	"github.com/matrixorigin/matrixone/pkg/sql/errors"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+)
+
+var (
+	errIndexNotExist = errors.New(errno.InvalidName, "index doesn't exist")
 )
 
 func (b *build) BuildDropIndex(stmt *tree.DropIndex, plan *DropIndex) error {
@@ -34,6 +40,10 @@ func (b *build) BuildDropIndex(stmt *tree.DropIndex, plan *DropIndex) error {
 				break
 			}
 		}
+	}
+
+	if notExisted && !stmt.IfExists {
+		return errIndexNotExist
 	}
 
 	plan.Relation = r


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

1.adjust code: built-in functions do not use type-implicit-conversion
2.add a error case for drop index

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
