### PR TITLE
fix SafeIds Unmarshal

### DIFF
--- a/pkg/vm/engine/aoe/storage/wal/shard/shard_test.go
+++ b/pkg/vm/engine/aoe/storage/wal/shard/shard_test.go
@@ -232,6 +232,14 @@ func TestProxy2(t *testing.T) {
 	mgr.Checkpoint(indice[4])
 	time.Sleep(waitTime)
 	assert.Equal(t, uint64(17), s0.GetSafeId())
+
+	safe_ids := mgr.GetSafeIds()
+	assert.Equal(t, 1, len(safe_ids.Ids))
+	assert.Equal(t, uint64(17), safe_ids.Ids[0].Id)
+	entry := SafeIdsToEntry(safe_ids)
+	parsed_safe_ids, err := EntryToSafeIds(entry)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(17), parsed_safe_ids.Ids[0].Id)
 }
 
 func TestProxy3(t *testing.T) {

--- a/pkg/vm/engine/aoe/storage/wal/shard/types.go
+++ b/pkg/vm/engine/aoe/storage/wal/shard/types.go
@@ -78,8 +78,8 @@ func (ids *SafeIds) Marshal() ([]byte, error) {
 
 func (ids *SafeIds) Unmarshal(buf []byte) error {
 	ids.Ids = make([]SafeId, len(buf)/SafeIdSize)
-	for i, id := range ids.Ids {
-		id.Unmarshal(buf[i*SafeIdSize : (i+1)*SafeIdSize])
+	for i := range ids.Ids {
+		ids.Ids[i].Unmarshal(buf[i*SafeIdSize : (i+1)*SafeIdSize])
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

When SafeIds.Unmarshal is called, bytes are unmarshalled into local variable，not into the Ids filed in SafeIds struct

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
