### PR TITLE
rewrite ParseDate and ParseDatetime functions

### DIFF
--- a/pkg/container/types/date.go
+++ b/pkg/container/types/date.go
@@ -19,7 +19,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/errno"
 	"github.com/matrixorigin/matrixone/pkg/sql/errors"
 	"regexp"
-	"strconv"
 	"time"
 )
 
@@ -60,95 +59,39 @@ var (
 )
 
 const (
-	shortestDateFormat = len("mdd")
-	todayDate          = "today()"
-	todayLength        = len(todayDate)
-
-	formatTwo1 = len("yyyymmdd")
-	formatTwo2 = len("yyymmdd")
-	formatTwo3 = len("yymmdd")
-	formatTwo4 = len("ymmdd")
-	formatTwo5 = len("mmdd")
-	formatTwo6 = len("mdd")
-
 	MaxDateYear    = 9999
 	MinDateYear    = 0
 	MaxMonthInYear = 12
 	MinMonthInYear = 1
-
-	thisCenturyStr0 = "2"
-	thisCenturyStr1 = "20"
-	thisCenturyStr2 = "200"
-	thisCenturyStr3 = "2000"
 )
 
-// ParseDate will parse string to be a Date.
-// can only solve string Format like :
-// 1. 'year-month-day'
-//	{
-//		at this format, each part (year, month, day) doesn't always need to be filled completely
-//		year can be YYYY or YYY or YY or Y
-//  	month can be X or 0X
-//		day can be X or 0X
-//	}
-// 2. 'YearMonthDay'
-//	{
-//		at this format, each part should follow the rule: len(Day) is 2, len(Month) > 0, len(Month) <= len(Year) and can not be 1 at the same time
-//		in short, format can be:
-//		yyyymmdd, yyymmdd, yymmdd, ymmdd, mmdd, mdd (year will start from 2000 if incomplete)
-//	}
-// And the supported range is '0000-01-01' to '9999-12-31'
+// ParseDate will parse a string to be a Date
+// Support Format:
+// `yyyy-mm-dd`
+// `yyyymmdd`
 func ParseDate(s string) (Date, error) {
-	var parts [3]string
-	var year int64
-	var month, day uint64
-	var err error
+	var y int32
+	var m, d uint8
 
-	l := len(s)
-	if l < shortestDateFormat {
+	if len(s) < 8 {
 		return -1, errIncorrectDateValue
 	}
-	// todo: may it should use function but not a string constant
-	//if l == todayLength && s == todayDate { // special case
-	//	return Today(), nil
-	//}
 
-	match := regDate.FindStringSubmatch(s)
-
-	if len(match) == 4 { // Format `year-month-day`
-		parts[0], parts[1], parts[2] = match[1], match[2], match[3]
-	} else { // Format `yearMonthDay`
-		switch l {
-		case formatTwo1: // yyyymmdd
-			parts[0], parts[1], parts[2] = s[0:4], s[4:6], s[6:]
-		case formatTwo2: // yyymmdd
-			parts[0], parts[1], parts[2] = thisCenturyStr0+s[0:3], s[3:5], s[5:]
-		case formatTwo3: // yymmdd
-			parts[0], parts[1], parts[2] = thisCenturyStr1+s[0:2], s[2:4], s[4:]
-		case formatTwo4: // ymmdd
-			parts[0], parts[1], parts[2] = thisCenturyStr2+s[0:1], s[1:3], s[3:]
-		case formatTwo5: // mmdd
-			parts[0], parts[1], parts[2] = thisCenturyStr3, s[0:2], s[2:]
-		case formatTwo6: // mdd
-			parts[0], parts[1], parts[2] = thisCenturyStr3, s[0:1], s[1:]
-		default:
+	y = int32(s[0]-'0') * 1000 + int32(s[1]-'0') * 100 + int32(s[2]-'0') * 10 + int32(s[3]-'0')
+	if s[4] == '-' {
+		if len(s) != 10 || s[7] != '-'{
 			return -1, errIncorrectDateValue
 		}
+		m = (s[5]-'0') * 10 + (s[6]-'0')
+		d = (s[8]-'0') * 10 + (s[9]-'0')
+	} else {
+		if len(s) != 8 {
+			return -1, errIncorrectDateValue
+		}
+		m = (s[4]-'0') * 10 + (s[5]-'0')
+		d = (s[6]-'0') * 10 + (s[7]-'0')
 	}
 
-	year, err = strconv.ParseInt(parts[0], 10, 32)
-	if err != nil {
-		return -1, errIncorrectDateValue
-	}
-	month, err = strconv.ParseUint(parts[1], 10, 8)
-	if err != nil {
-		return -1, errIncorrectDateValue
-	}
-	day, err = strconv.ParseUint(parts[2], 10, 8)
-	if err != nil {
-		return -1, errIncorrectDateValue
-	}
-	y, m, d := int32(year), uint8(month), uint8(day)
 	if validDate(y, m, d) {
 		return FromCalendar(y, m, d), nil
 	}

--- a/pkg/sql/unittest/sql_test.go
+++ b/pkg/sql/unittest/sql_test.go
@@ -105,7 +105,7 @@ func TestDateType(t *testing.T) {
 	sqls := []string{
 		"create table tdate (a date);",
 		"create table tdefdate (a date default '20211202')",
-		"insert into tdate values ('20070210'), ('1997-02-10'), ('01-04-28'), (20041112), ('0000000123-4-3');",
+		"insert into tdate values ('20070210'), ('1997-02-10'), ('0001-04-28'), (20041112), ('0123-04-03');",
 		"insert into tdefdate values ();",
 	}
 	res := [][]string{
@@ -143,7 +143,7 @@ func TestDateComparison(t *testing.T) {
 	e, proc := newTestEngine()
 	sqls := []string{
 		"create table tdate (a date);",
-		"insert into tdate values ('20070210'), ('1997-02-10'), ('01-04-28'), (20041112), ('0000000123-4-3');",
+		"insert into tdate values ('20070210'), ('1997-02-10'), ('2001-04-28'), (20041112), ('0123-04-03');",
 		"select * from tdate where a < '2004-01-01'",
 		"select * from tdate where '2004-01-01' < a",
 		"select * from tdate where a > '2004-01-01'",
@@ -165,7 +165,7 @@ func TestDatetimeComparison(t *testing.T) {
 	e, proc := newTestEngine()
 	sqls := []string{
 		"create table tdatetime (a datetime);",
-		"insert into tdatetime values ('2018-04-28 10:21:15'), ('17-04-28 03:05:01'), (250716163958), (20211203145633);",
+		"insert into tdatetime values ('2018-04-28 10:21:15'), ('2017-04-28 03:05:01'), (20250716163958), (20211203145633);",
 		"select * from tdatetime where a < '2020-01-01 10:21:15'",
 		"select * from tdatetime where '2020-01-01 10:21:15' < a",
 		"select * from tdatetime where a = '2020-01-01 10:21:15'",
@@ -189,11 +189,11 @@ func TestDatetimeType(t *testing.T) {
 	// TestCase expected run success
 	sqls := []string{
 		"create table tbl1 (a datetime);", // test datetime format without msec part
-		"insert into tbl1 values ('2018-04-28 10:21:15'), ('17-04-28 03:05:01'), (250716163958), (20211203145633);",
+		"insert into tbl1 values ('2018-04-28 10:21:15'), ('2017-04-28 03:05:01'), (20250716163958), (20211203145633);",
 		"create table tbl2 (a datetime);", // test datetime with msec part
-		"insert into tbl2 values ('2018-04-28 10:21:15.123'), ('17-04-28 03:05:01.456'), (250716163958.567), (20211203145633.890);",
+		"insert into tbl2 values ('2018-04-28 10:21:15.123'), ('2017-04-28 03:05:01.456'), (20250716163958.567), (20211203145633.890);",
 		"create table tbl3 (a datetime);", // test datetime without hour / minute / second
-		"insert into tbl3 values ('20180428'), ('170428'), (250716), (20211203);",
+		"insert into tbl3 values ('20180428'), ('20170428'), (20250716), (20211203);",
 
 		"create table tdatetimedef (a datetime default '2015-03-03 12:12:12');",
 		"insert into tdatetimedef values ();",
@@ -211,8 +211,8 @@ func TestDatetimeType(t *testing.T) {
 	}
 
 	res := [][]string{
-		{"tbl1", "a\n\t[2018-04-28 10:21:15 0017-04-28 03:05:01 2025-07-16 16:39:58 2021-12-03 14:56:33]-&{<nil>}\n\n"},
-		{"tbl2", "a\n\t[2018-04-28 10:21:15 0017-04-28 03:05:01 2025-07-16 16:39:58 2021-12-03 14:56:33]-&{<nil>}\n\n"}, // that is disputed. what does msec do?
+		{"tbl1", "a\n\t[2018-04-28 10:21:15 2017-04-28 03:05:01 2025-07-16 16:39:58 2021-12-03 14:56:33]-&{<nil>}\n\n"},
+		{"tbl2", "a\n\t[2018-04-28 10:21:15 2017-04-28 03:05:01 2025-07-16 16:39:58 2021-12-03 14:56:33]-&{<nil>}\n\n"}, // that is disputed. what does msec do?
 		{"tbl3", "a\n\t[2018-04-28 00:00:00 2017-04-28 00:00:00 2025-07-16 00:00:00 2021-12-03 00:00:00]-&{<nil>}\n\n"},
 		{"tdatetimedef", "a\n\t2015-03-03 12:12:12\n\n"},
 	}
@@ -334,7 +334,7 @@ func sqlRun(sql string, e engine.Engine, proc *process.Process) error {
 	return nil
 }
 
-// a simple select function Todo: need delete when support select * from relation.
+// a simple select function
 func TempSelect(e engine.Engine, schema, name string) string {
 	var buff bytes.Buffer
 


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

**Which issue(s) this PR fixes:**

issue #1511 

**What this PR does / why we need it:**

rewrite functions ParseDate and ParseDatetime

but we have more restrict requirement for value format at the same time. now can only support

Date: 1.yyyy-mm-dd 2.yyyymmdd
Datetime: 1.all Date 2. yyyy-mm-dd hh:mm:ss(.msec) 3. yyyymmddhhmmss(.msec)

in simple test to run old and new functions 100-million times. 
old parseDate functions cost 32s, parseDatetime cost 1min 30s
and new function cost 812ms, parseDatetime cost 1.4s
it is faster than olds.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
