### PR TITLE
fix issue#1688, #1687, #1690

### DIFF
--- a/pkg/sql/colexec/extend/overload/init.go
+++ b/pkg/sql/colexec/extend/overload/init.go
@@ -238,10 +238,10 @@ func initCastRulesForBinaryOps() {
 		ops := []int{Plus, Minus, Mult}
 		for _, op := range ops {
 			{
-				// cast to int64 op int64 : +, -, * between int and uint
+				// for Plus, Minus, and Multiply operators between int and uint types, cast both sides to uint64 before operation
 				targetType := []types.Type{
-					{Oid: types.T_int64, Size: 8},
-					{Oid: types.T_int64, Size: 8},
+					{Oid: types.T_uint64, Size: 8},
+					{Oid: types.T_uint64, Size: 8},
 				}
 				for _, l := range ints {
 					for _, r := range uints {
@@ -255,7 +255,7 @@ func initCastRulesForBinaryOps() {
 			{
 				/*
 					cast to float64 op float64:
-					1. +, -, * between int and uint
+					1. +, -, * between int and float
 					2. +, -, * between uint and float
 				*/
 				targetType := []types.Type{
@@ -285,13 +285,16 @@ func initCastRulesForBinaryOps() {
 	{
 		{
 			/*
-				cast to float64 / float64 (integerDiv will return int64):
+				cast to float64 / float64 (integerDiv will return int64 as result):
 				1. div between int and int
 				2. div between uint and uint
 				3. div between int and uint
 				4. div between int and float
 				5. div between uint and float
 				6. div between float32 and float64
+				7. integerDiv between int and int
+				8. integerDiv between uint and uint
+				9. integerDiv between int and uint
 			*/
 			targetType := []types.Type{
 				{Oid: types.T_float64, Size: 8},

--- a/pkg/sql/colexec/extend/overload/minus.template
+++ b/pkg/sql/colexec/extend/overload/minus.template
@@ -139,7 +139,7 @@ func initMinus(){
                         rs[i] = RETURN_GO_TYPE(lvs[i])
                     }
                     nulls.Set(vec.Nsp, lv.Nsp)
-                    vector.SetCol(vec, sub.{.RTYP}SubByScalar(RETURN_GO_TYPE(lvs[0]), rs, rs))
+                    vector.SetCol(vec, sub.{.RTYP}SubByScalar(RETURN_GO_TYPE(rvs[0]), rs, rs))
                     if lv.Ref == 0 {
                         process.Put(proc, lv)
                     }

--- a/pkg/sql/colexec/extend/overload/mult.template
+++ b/pkg/sql/colexec/extend/overload/mult.template
@@ -192,7 +192,7 @@ func initMult() {
                     for i := range rs {
                         rs[i] = RETURN_GO_TYPE(rvs[i])
                     }
-                    vector.SetCol(vec, mul.{.RETTYP}MulScalar(RETURN_GO_TYPE(rvs[0]), rs, rs))
+                    vector.SetCol(vec, mul.{.RETTYP}MulScalar(RETURN_GO_TYPE(lvs[0]), rs, rs))
                     if rv.Ref == 0 {
                         process.Put(proc, rv)
                     }

--- a/pkg/sql/plan/prune.go
+++ b/pkg/sql/plan/prune.go
@@ -354,7 +354,7 @@ func (b *build) pruneDiv(e *extend.BinaryExtend) (extend.Extend, error) {
 		if isZero(re) {
 			return nil, ErrDivByZero
 		}
-		switch e.Left.ReturnType() {
+		switch e.Right.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(re); err != nil {
 				return nil, err
@@ -405,7 +405,7 @@ func (b *build) pruneDiv(e *extend.BinaryExtend) (extend.Extend, error) {
 		}
 		return div(le, re)
 	case lok && !rok:
-		switch e.Right.ReturnType() {
+		switch e.Left.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(le); err != nil {
 				return nil, err
@@ -567,7 +567,7 @@ func (b *build) pruneMul(e *extend.BinaryExtend) (extend.Extend, error) {
 	re, rok := e.Right.(*extend.ValueExtend)
 	switch {
 	case !lok && rok:
-		switch e.Left.ReturnType() {
+		switch e.Right.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(re); err != nil {
 				return nil, err
@@ -615,7 +615,7 @@ func (b *build) pruneMul(e *extend.BinaryExtend) (extend.Extend, error) {
 	case lok && rok:
 		return mul(le, re)
 	case lok && !rok:
-		switch e.Right.ReturnType() {
+		switch e.Left.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(le); err != nil {
 				return nil, err
@@ -669,7 +669,7 @@ func (b *build) prunePlus(e *extend.BinaryExtend) (extend.Extend, error) {
 	re, rok := e.Right.(*extend.ValueExtend)
 	switch {
 	case !lok && rok:
-		switch e.Left.ReturnType() {
+		switch e.Right.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(re); err != nil {
 				return nil, err
@@ -717,7 +717,7 @@ func (b *build) prunePlus(e *extend.BinaryExtend) (extend.Extend, error) {
 	case lok && rok:
 		return plus(le, re)
 	case lok && !rok:
-		switch e.Right.ReturnType() {
+		switch e.Left.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(le); err != nil {
 				return nil, err
@@ -771,7 +771,7 @@ func (b *build) pruneMinus(e *extend.BinaryExtend) (extend.Extend, error) {
 	re, rok := e.Right.(*extend.ValueExtend)
 	switch {
 	case !lok && rok:
-		switch e.Left.ReturnType() {
+		switch e.Right.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(re); err != nil {
 				return nil, err
@@ -819,7 +819,7 @@ func (b *build) pruneMinus(e *extend.BinaryExtend) (extend.Extend, error) {
 	case lok && rok:
 		return minus(le, re)
 	case lok && !rok:
-		switch e.Right.ReturnType() {
+		switch e.Left.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(le); err != nil {
 				return nil, err
@@ -873,7 +873,7 @@ func (b *build) pruneEq(e *extend.BinaryExtend) (extend.Extend, error) {
 	re, rok := e.Right.(*extend.ValueExtend)
 	switch {
 	case !lok && rok:
-		switch e.Left.ReturnType() {
+		switch e.Right.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(re); err != nil {
 				return nil, err
@@ -928,7 +928,7 @@ func (b *build) pruneEq(e *extend.BinaryExtend) (extend.Extend, error) {
 	case lok && rok:
 		return Eq(le, re)
 	case lok && !rok:
-		switch e.Right.ReturnType() {
+		switch e.Left.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(le); err != nil {
 				return nil, err
@@ -989,7 +989,7 @@ func (b *build) pruneNe(e *extend.BinaryExtend) (extend.Extend, error) {
 	re, rok := e.Right.(*extend.ValueExtend)
 	switch {
 	case !lok && rok:
-		switch e.Left.ReturnType() {
+		switch e.Right.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(re); err != nil {
 				return nil, err
@@ -1044,7 +1044,7 @@ func (b *build) pruneNe(e *extend.BinaryExtend) (extend.Extend, error) {
 	case lok && rok:
 		return Ne(le, re)
 	case lok && !rok:
-		switch e.Right.ReturnType() {
+		switch e.Left.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(le); err != nil {
 				return nil, err
@@ -1105,7 +1105,7 @@ func (b *build) pruneLt(e *extend.BinaryExtend) (extend.Extend, error) {
 	re, rok := e.Right.(*extend.ValueExtend)
 	switch {
 	case !lok && rok:
-		switch e.Left.ReturnType() {
+		switch e.Right.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(re); err != nil {
 				return nil, err
@@ -1160,7 +1160,7 @@ func (b *build) pruneLt(e *extend.BinaryExtend) (extend.Extend, error) {
 	case lok && rok:
 		return Lt(le, re)
 	case lok && !rok:
-		switch e.Right.ReturnType() {
+		switch e.Left.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(le); err != nil {
 				return nil, err
@@ -1221,7 +1221,7 @@ func (b *build) pruneLe(e *extend.BinaryExtend) (extend.Extend, error) {
 	re, rok := e.Right.(*extend.ValueExtend)
 	switch {
 	case !lok && rok:
-		switch e.Left.ReturnType() {
+		switch e.Right.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(re); err != nil {
 				return nil, err
@@ -1276,7 +1276,7 @@ func (b *build) pruneLe(e *extend.BinaryExtend) (extend.Extend, error) {
 	case lok && rok:
 		return Le(le, re)
 	case lok && !rok:
-		switch e.Right.ReturnType() {
+		switch e.Left.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(le); err != nil {
 				return nil, err
@@ -1337,7 +1337,7 @@ func (b *build) pruneGt(e *extend.BinaryExtend) (extend.Extend, error) {
 	re, rok := e.Right.(*extend.ValueExtend)
 	switch {
 	case !lok && rok:
-		switch e.Left.ReturnType() {
+		switch e.Right.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(re); err != nil {
 				return nil, err
@@ -1392,7 +1392,7 @@ func (b *build) pruneGt(e *extend.BinaryExtend) (extend.Extend, error) {
 	case lok && rok:
 		return Gt(le, re)
 	case lok && !rok:
-		switch e.Right.ReturnType() {
+		switch e.Left.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(le); err != nil {
 				return nil, err
@@ -1453,7 +1453,7 @@ func (b *build) pruneGe(e *extend.BinaryExtend) (extend.Extend, error) {
 	re, rok := e.Right.(*extend.ValueExtend)
 	switch {
 	case !lok && rok:
-		switch e.Left.ReturnType() {
+		switch e.Right.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(re); err != nil {
 				return nil, err
@@ -1508,7 +1508,7 @@ func (b *build) pruneGe(e *extend.BinaryExtend) (extend.Extend, error) {
 	case lok && rok:
 		return Ge(le, re)
 	case lok && !rok:
-		switch e.Right.ReturnType() {
+		switch e.Left.ReturnType() {
 		case types.T_int8:
 			if err := toInt8(le); err != nil {
 				return nil, err

--- a/pkg/sql/plan/prune_test.go
+++ b/pkg/sql/plan/prune_test.go
@@ -322,7 +322,7 @@ func Test_build_pruneExtend(t *testing.T) {
 			want: &extend.BinaryExtend{
 				Op:    overload.EQ,
 				Left:  &extend.Attribute{Name: "a", Type: types.T_int8},
-				Right: &extend.ValueExtend{V: testutil.MakeInt8Vector([]int8{1}, 1)},
+				Right: &extend.ValueExtend{V: testutil.MakeInt64Vector([]int64{1}, 1)},
 			},
 		},
 		{
@@ -338,23 +338,11 @@ func Test_build_pruneExtend(t *testing.T) {
 			want: &extend.BinaryExtend{
 				Op:    overload.EQ,
 				Left:  &extend.Attribute{Name: "a", Type: types.T_int16},
-				Right: &extend.ValueExtend{V: testutil.MakeInt16Vector([]int16{1}, 1)},
+				Right: &extend.ValueExtend{V: testutil.MakeInt64Vector([]int64{1}, 1)},
 			},
 		},
 		{
 			name:   "binary_eq_3",
-			fields: fields{},
-			args: args{
-				e: &extend.BinaryExtend{
-					Op:    overload.EQ,
-					Left:  &extend.Attribute{Name: "a", Type: types.T_int16},
-					Right: &extend.ValueExtend{V: testutil.MakeStringVector([]string{"abc"}, 0)},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name:   "binary_eq_4",
 			fields: fields{},
 			args: args{
 				e: &extend.BinaryExtend{
@@ -366,11 +354,11 @@ func Test_build_pruneExtend(t *testing.T) {
 			want: &extend.BinaryExtend{
 				Op:    overload.EQ,
 				Left:  &extend.Attribute{Name: "a", Type: types.T_int32},
-				Right: &extend.ValueExtend{V: testutil.MakeInt32Vector([]int32{1}, 1)},
+				Right: &extend.ValueExtend{V: testutil.MakeInt64Vector([]int64{1}, 1)},
 			},
 		},
 		{
-			name:   "binary_eq_5",
+			name:   "binary_eq_4",
 			fields: fields{},
 			args: args{
 				e: &extend.BinaryExtend{
@@ -386,7 +374,7 @@ func Test_build_pruneExtend(t *testing.T) {
 			},
 		},
 		{
-			name:   "binary_eq_6",
+			name:   "binary_eq_5",
 			fields: fields{},
 			args: args{
 				e: &extend.BinaryExtend{
@@ -398,55 +386,7 @@ func Test_build_pruneExtend(t *testing.T) {
 			want: &extend.BinaryExtend{
 				Op:    overload.EQ,
 				Left:  &extend.Attribute{Name: "a", Type: types.T_uint8},
-				Right: &extend.ValueExtend{V: testutil.MakeUint8Vector([]uint8{1}, 1)},
-			},
-		},
-		{
-			name:   "binary_eq_7",
-			fields: fields{},
-			args: args{
-				e: &extend.BinaryExtend{
-					Op:    overload.EQ,
-					Left:  &extend.Attribute{Name: "a", Type: types.T_uint16},
-					Right: &extend.ValueExtend{V: testutil.MakeInt64Vector([]int64{1}, 0)},
-				},
-			},
-			want: &extend.BinaryExtend{
-				Op:    overload.EQ,
-				Left:  &extend.Attribute{Name: "a", Type: types.T_uint16},
-				Right: &extend.ValueExtend{V: testutil.MakeUint16Vector([]uint16{1}, 1)},
-			},
-		},
-		{
-			name:   "binary_eq_8",
-			fields: fields{},
-			args: args{
-				e: &extend.BinaryExtend{
-					Op:    overload.EQ,
-					Left:  &extend.Attribute{Name: "a", Type: types.T_uint32},
-					Right: &extend.ValueExtend{V: testutil.MakeInt64Vector([]int64{1}, 0)},
-				},
-			},
-			want: &extend.BinaryExtend{
-				Op:    overload.EQ,
-				Left:  &extend.Attribute{Name: "a", Type: types.T_uint32},
-				Right: &extend.ValueExtend{V: testutil.MakeUint32Vector([]uint32{1}, 1)},
-			},
-		},
-		{
-			name:   "binary_eq_9",
-			fields: fields{},
-			args: args{
-				e: &extend.BinaryExtend{
-					Op:    overload.EQ,
-					Left:  &extend.Attribute{Name: "a", Type: types.T_uint64},
-					Right: &extend.ValueExtend{V: testutil.MakeInt64Vector([]int64{1}, 0)},
-				},
-			},
-			want: &extend.BinaryExtend{
-				Op:    overload.EQ,
-				Left:  &extend.Attribute{Name: "a", Type: types.T_uint64},
-				Right: &extend.ValueExtend{V: testutil.MakeUint64Vector([]uint64{1}, 1)},
+				Right: &extend.ValueExtend{V: testutil.MakeInt64Vector([]int64{1}, 1)},
 			},
 		},
 

--- a/pkg/sql/unittest/operator_test.go
+++ b/pkg/sql/unittest/operator_test.go
@@ -95,7 +95,7 @@ func TestPlusOperator(t *testing.T) {
 		{sql: "select f1 + 1.0, 1.0 + f1, f1 - 2.0, 2.0 - f1, f1 * 3.0, 3.0 * f1, f1 / 0.5, 0.5 / f1 from ffs;", res: executeResult{
 			null: false,
 			attr: []string{"f1 + 1", "1 + f1", "f1 - 2", "2 - f1", "f1 * 3", "3 * f1", "f1 / 0.5", "0.5 / f1"},
-			data: [][]string{{"23.200001", "23.200001", "20.200001", "-20.200001", "66.600006", "66.600006", "44.400002", "0.022523"}, {"null", "null", "null", "null", "null", "null", "null", "null"}},
+			data: [][]string{{"23.200001", "23.200001", "20.200001", "-20.200001", "66.600002", "66.600002", "44.400002", "0.022523"}, {"null", "null", "null", "null", "null", "null", "null", "null"}},
 		}},
 		{sql: "select f2 + f2, f2 - f2, f2 * f2, f2 / f2 from ffs;", res: executeResult{
 			null: false,
@@ -192,17 +192,17 @@ func TestMinusOperator(t *testing.T) {
 		{sql: "select u2 - u1, u2 - u2, u2 - u3, u2 - u4, u2 - 2, 3 - u2 from uus;", res: executeResult{
 			null: false,
 			attr: []string{"u2 - u1", "u2 - u2", "u2 - u3", "u2 - u4", "u2 - 2", "3 - u2"},
-			data: [][]string{[]string{"30", "0", "4294966996", "18446744073709548316", "31", "65506"}, []string{"null", "null", "null", "null", "null", "null"}},
+			data: [][]string{[]string{"30", "0", "4294966996", "18446744073709548316", "31", "-30"}, []string{"null", "null", "null", "null", "null", "null"}},
 		}},
 		{sql: "select u3 - u1, u3 - u2, u3 - u3, u3 - u4, u3 - 2, 3 - u3 from uus;", res: executeResult{
 			null: false,
 			attr: []string{"u3 - u1", "u3 - u2", "u3 - u3", "u3 - u4", "u3 - 2", "3 - u3"},
-			data: [][]string{{"330", "300", "0", "18446744073709548616", "331", "4294966966"}, []string{"null", "null", "null", "null", "null", "null"}},
+			data: [][]string{{"330", "300", "0", "18446744073709548616", "331", "-330"}, []string{"null", "null", "null", "null", "null", "null"}},
 		}},
 		{sql: "select u4 - u1, u4 - u2, u4 - u3, u4 - u4, u4 - 2, 3 - u4 from uus;", res: executeResult{
 			null: false,
 			attr: []string{"u4 - u1", "u4 - u2", "u4 - u3", "u4 - u4", "u4 - 2", "3 - u4"},
-			data: [][]string{{"3330", "3300", "3000", "0", "3331", "18446744073709548286"}, []string{"null", "null", "null", "null", "null", "null"}},
+			data: [][]string{{"3330", "3300", "3000", "0", "3331", "-3330"}, []string{"null", "null", "null", "null", "null", "null"}},
 		}},
 
 		{sql: "select f11 - f12, f21 - f22 from ffs2;", res: executeResult{
@@ -1493,7 +1493,7 @@ func TestComparisonOperator(t *testing.T) {
 			null: false,
 			data: [][]string{{"1", "11", "111", "1111"}},
 		}},
-		{sql: "select * from ffs where f1 in (22.2);", res: executeResult{
+		{sql: "select * from ffs where f2 in (222.222);", res: executeResult{
 			null: false,
 			data: [][]string{{"22.200001", "222.222000"}},
 		}},

--- a/pkg/sql/unittest/operator_test.go
+++ b/pkg/sql/unittest/operator_test.go
@@ -192,17 +192,17 @@ func TestMinusOperator(t *testing.T) {
 		{sql: "select u2 - u1, u2 - u2, u2 - u3, u2 - u4, u2 - 2, 3 - u2 from uus;", res: executeResult{
 			null: false,
 			attr: []string{"u2 - u1", "u2 - u2", "u2 - u3", "u2 - u4", "u2 - 2", "3 - u2"},
-			data: [][]string{[]string{"30", "0", "4294966996", "18446744073709548316", "31", "-30"}, []string{"null", "null", "null", "null", "null", "null"}},
+			data: [][]string{[]string{"30", "0", "4294966996", "18446744073709548316", "31", "18446744073709551586"}, []string{"null", "null", "null", "null", "null", "null"}},
 		}},
 		{sql: "select u3 - u1, u3 - u2, u3 - u3, u3 - u4, u3 - 2, 3 - u3 from uus;", res: executeResult{
 			null: false,
 			attr: []string{"u3 - u1", "u3 - u2", "u3 - u3", "u3 - u4", "u3 - 2", "3 - u3"},
-			data: [][]string{{"330", "300", "0", "18446744073709548616", "331", "-330"}, []string{"null", "null", "null", "null", "null", "null"}},
+			data: [][]string{{"330", "300", "0", "18446744073709548616", "331", "18446744073709551286"}, []string{"null", "null", "null", "null", "null", "null"}},
 		}},
 		{sql: "select u4 - u1, u4 - u2, u4 - u3, u4 - u4, u4 - 2, 3 - u4 from uus;", res: executeResult{
 			null: false,
 			attr: []string{"u4 - u1", "u4 - u2", "u4 - u3", "u4 - u4", "u4 - 2", "3 - u4"},
-			data: [][]string{{"3330", "3300", "3000", "0", "3331", "-3330"}, []string{"null", "null", "null", "null", "null", "null"}},
+			data: [][]string{{"3330", "3300", "3000", "0", "3331", "18446744073709548286"}, []string{"null", "null", "null", "null", "null", "null"}},
 		}},
 
 		{sql: "select f11 - f12, f21 - f22 from ffs2;", res: executeResult{

--- a/pkg/vectorize/eq/eq.go
+++ b/pkg/vectorize/eq/eq.go
@@ -17,6 +17,7 @@ package eq
 import (
 	"bytes"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"math"
 
 	roaring "github.com/RoaringBitmap/roaring/roaring64"
 )
@@ -1265,10 +1266,21 @@ func float32EqNullableScalarSels(x float32, ys []float32, nulls *roaring.Bitmap,
 	return rs[:rsi]
 }
 
+const tolerance = .00001
+
+func float64Equal(x, y float64) bool {
+	diff := math.Abs(x - y)
+	mean := math.Abs(x + y)
+	if math.IsNaN(diff / mean) {
+		return true
+	}
+	return (diff / mean) < tolerance
+}
+
 func float64Eq(xs, ys []float64, rs []int64) []int64 {
 	rsi := 0
 	for i, x := range xs {
-		if x == ys[i] {
+		if float64Equal(x, ys[i]) {
 			rs[rsi] = int64(i)
 			rsi++
 		}
@@ -1294,7 +1306,7 @@ func float64EqNullable(xs, ys []float64, nulls *roaring.Bitmap, rs []int64) []in
 			} else {
 				nextNull = -1
 			}
-		} else if x == ys[i] {
+		} else if float64Equal(x, ys[i]) {
 			rs[rsi] = int64(i)
 			rsi++
 		}
@@ -1305,7 +1317,7 @@ func float64EqNullable(xs, ys []float64, nulls *roaring.Bitmap, rs []int64) []in
 func float64EqSels(xs, ys []float64, rs, sels []int64) []int64 {
 	rsi := 0
 	for _, sel := range sels {
-		if xs[sel] == ys[sel] {
+		if float64Equal(xs[sel], ys[sel]) {
 			rs[rsi] = sel
 			rsi++
 		}
@@ -1316,7 +1328,7 @@ func float64EqSels(xs, ys []float64, rs, sels []int64) []int64 {
 func float64EqNullableSels(xs, ys []float64, nulls *roaring.Bitmap, rs, sels []int64) []int64 {
 	rsi := 0
 	for _, sel := range sels {
-		if !nulls.Contains(uint64(sel)) && xs[sel] == ys[sel] {
+		if !nulls.Contains(uint64(sel)) && float64Equal(xs[sel], ys[sel]) {
 			rs[rsi] = sel
 			rsi++
 		}
@@ -1327,7 +1339,7 @@ func float64EqNullableSels(xs, ys []float64, nulls *roaring.Bitmap, rs, sels []i
 func float64EqScalar(x float64, ys []float64, rs []int64) []int64 {
 	rsi := 0
 	for i, y := range ys {
-		if x == y {
+		if float64Equal(x, y) {
 			rs[rsi] = int64(i)
 			rsi++
 		}
@@ -1353,7 +1365,7 @@ func float64EqNullableScalar(x float64, ys []float64, nulls *roaring.Bitmap, rs 
 			} else {
 				nextNull = -1
 			}
-		} else if x == y {
+		} else if float64Equal(x, y) {
 			rs[rsi] = int64(i)
 			rsi++
 		}
@@ -1364,7 +1376,7 @@ func float64EqNullableScalar(x float64, ys []float64, nulls *roaring.Bitmap, rs 
 func float64EqScalarSels(x float64, ys []float64, rs, sels []int64) []int64 {
 	rsi := 0
 	for _, sel := range sels {
-		if x == ys[sel] {
+		if float64Equal(x, ys[sel]) {
 			rs[rsi] = sel
 			rsi++
 		}
@@ -1375,7 +1387,7 @@ func float64EqScalarSels(x float64, ys []float64, rs, sels []int64) []int64 {
 func float64EqNullableScalarSels(x float64, ys []float64, nulls *roaring.Bitmap, rs, sels []int64) []int64 {
 	rsi := 0
 	for _, sel := range sels {
-		if !nulls.Contains(uint64(sel)) && x == ys[sel] {
+		if !nulls.Contains(uint64(sel)) && float64Equal(x, ys[sel]) {
 			rs[rsi] = sel
 			rsi++
 		}


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #1688 
issue #1687 

**What this PR does / why we need it:**

equal operator has its own typecast rules in the map OperatorCastRules,
original pruneEq operation will produce incorrect answer, e.g., 2 = 2.1 will be evaluated true.

