### PR TITLE
[RFC] implement ln builtin function

### DIFF
--- a/pkg/builtin/types.go
+++ b/pkg/builtin/types.go
@@ -24,4 +24,5 @@ const (
 	Round
 	Floor
 	Abs
+	Ln
 )

--- a/pkg/builtin/unary/ln.go
+++ b/pkg/builtin/unary/ln.go
@@ -1,0 +1,307 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unary
+
+import (
+	"fmt"
+
+	"github.com/matrixorigin/matrixone/pkg/builtin"
+	"github.com/matrixorigin/matrixone/pkg/container/nulls"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/encoding"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/extend"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/extend/overload"
+	"github.com/matrixorigin/matrixone/pkg/vectorize/ln"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+func init() {
+	negative_number_error := "Invalid argument for logarithm"
+
+	extend.FunctionRegistry["ln"] = builtin.Ln
+	extend.UnaryReturnTypes[builtin.Ln] = func(extend extend.Extend) types.T {
+		return types.T_float64
+	}
+
+	extend.UnaryStrings[builtin.Ln] = func(e extend.Extend) string {
+		return fmt.Sprintf("ln(%s)", e)
+	}
+
+	overload.OpTypes[builtin.Ln] = overload.Unary
+	overload.UnaryOps[builtin.Ln] = []*overload.UnaryOp{
+		{ // T_uint8
+			Typ:        types.T_uint8,
+			ReturnType: types.T_float64,
+			Fn: func(origVec *vector.Vector, proc *process.Process, _ bool) (*vector.Vector, error) {
+				origVecCol := origVec.Col.([]uint8)
+				resultVector, err := process.Get(proc, 8*int64(len(origVecCol)), types.Type{Oid: types.T_float64, Size: 8})
+				if err != nil {
+					return nil, err
+				}
+				results := encoding.DecodeFloat64Slice(resultVector.Data)
+				results = results[:len(origVecCol)]
+				resultVector.Col = results
+				nulls.Set(resultVector.Nsp, origVec.Nsp)
+				lnResult := ln.LnUint8(origVecCol, results)
+				if nulls.Any(lnResult.Nsp) {
+					logutil.Warn(negative_number_error)
+					if !nulls.Any(resultVector.Nsp) {
+						resultVector.Nsp = lnResult.Nsp
+					} else {
+						resultVector.Nsp.Or(lnResult.Nsp)
+					}
+				}
+				vector.SetCol(resultVector, results)
+				return resultVector, nil
+			},
+		},
+		{ // T_uint16
+			Typ:        types.T_uint16,
+			ReturnType: types.T_float64,
+			Fn: func(origVec *vector.Vector, proc *process.Process, _ bool) (*vector.Vector, error) {
+				origVecCol := origVec.Col.([]uint16)
+				resultVector, err := process.Get(proc, 8*int64(len(origVecCol)), types.Type{Oid: types.T_float64, Size: 8})
+				if err != nil {
+					return nil, err
+				}
+				results := encoding.DecodeFloat64Slice(resultVector.Data)
+				results = results[:len(origVecCol)]
+				resultVector.Col = results
+				nulls.Set(resultVector.Nsp, origVec.Nsp)
+				lnResult := ln.LnUint16(origVecCol, results)
+				if nulls.Any(lnResult.Nsp) {
+					logutil.Warn(negative_number_error)
+					if !nulls.Any(resultVector.Nsp) {
+						resultVector.Nsp = lnResult.Nsp
+					} else {
+						resultVector.Nsp.Or(lnResult.Nsp)
+					}
+				}
+				vector.SetCol(resultVector, results)
+				return resultVector, nil
+			},
+		},
+		{ // T_uint32
+			Typ:        types.T_uint32,
+			ReturnType: types.T_float64,
+			Fn: func(origVec *vector.Vector, proc *process.Process, _ bool) (*vector.Vector, error) {
+				origVecCol := origVec.Col.([]uint32)
+				resultVector, err := process.Get(proc, 8*int64(len(origVecCol)), types.Type{Oid: types.T_float64, Size: 8})
+				if err != nil {
+					return nil, err
+				}
+				results := encoding.DecodeFloat64Slice(resultVector.Data)
+				results = results[:len(origVecCol)]
+				resultVector.Col = results
+				nulls.Set(resultVector.Nsp, origVec.Nsp)
+				lnResult := ln.LnUint32(origVecCol, results)
+				if nulls.Any(lnResult.Nsp) {
+					logutil.Warn(negative_number_error)
+					if !nulls.Any(resultVector.Nsp) {
+						resultVector.Nsp = lnResult.Nsp
+					} else {
+						resultVector.Nsp.Or(lnResult.Nsp)
+					}
+				}
+				vector.SetCol(resultVector, results)
+				return resultVector, nil
+			},
+		},
+		{ // T_uint64
+			Typ:        types.T_uint64,
+			ReturnType: types.T_float64,
+			Fn: func(origVec *vector.Vector, proc *process.Process, _ bool) (*vector.Vector, error) {
+				origVecCol := origVec.Col.([]uint64)
+				resultVector, err := process.Get(proc, 8*int64(len(origVecCol)), types.Type{Oid: types.T_float64, Size: 8})
+				if err != nil {
+					return nil, err
+				}
+				results := encoding.DecodeFloat64Slice(resultVector.Data)
+				results = results[:len(origVecCol)]
+				resultVector.Col = results
+				nulls.Set(resultVector.Nsp, origVec.Nsp)
+				lnResult := ln.LnUint64(origVecCol, results)
+				if nulls.Any(lnResult.Nsp) {
+					logutil.Warn(negative_number_error)
+					if !nulls.Any(resultVector.Nsp) {
+						resultVector.Nsp = lnResult.Nsp
+					} else {
+						resultVector.Nsp.Or(lnResult.Nsp)
+					}
+				}
+				vector.SetCol(resultVector, results)
+				return resultVector, nil
+			},
+		},
+		{ // T_int8
+			Typ:        types.T_int8,
+			ReturnType: types.T_float64,
+			Fn: func(origVec *vector.Vector, proc *process.Process, _ bool) (*vector.Vector, error) {
+				origVecCol := origVec.Col.([]int8)
+				resultVector, err := process.Get(proc, 8*int64(len(origVecCol)), types.Type{Oid: types.T_float64, Size: 8})
+				if err != nil {
+					return nil, err
+				}
+				results := encoding.DecodeFloat64Slice(resultVector.Data)
+				results = results[:len(origVecCol)]
+				resultVector.Col = results
+				nulls.Set(resultVector.Nsp, origVec.Nsp)
+				lnResult := ln.LnInt8(origVecCol, results)
+				if nulls.Any(lnResult.Nsp) {
+					logutil.Warn(negative_number_error)
+					if !nulls.Any(resultVector.Nsp) {
+						resultVector.Nsp = lnResult.Nsp
+					} else {
+						resultVector.Nsp.Or(lnResult.Nsp)
+					}
+				}
+				vector.SetCol(resultVector, results)
+				return resultVector, nil
+			},
+		},
+		{ // T_int16
+			Typ:        types.T_int16,
+			ReturnType: types.T_float64,
+			Fn: func(origVec *vector.Vector, proc *process.Process, _ bool) (*vector.Vector, error) {
+				origVecCol := origVec.Col.([]int16)
+				resultVector, err := process.Get(proc, 8*int64(len(origVecCol)), types.Type{Oid: types.T_float64, Size: 8})
+				if err != nil {
+					return nil, err
+				}
+				results := encoding.DecodeFloat64Slice(resultVector.Data)
+				results = results[:len(origVecCol)]
+				resultVector.Col = results
+				nulls.Set(resultVector.Nsp, origVec.Nsp)
+				lnResult := ln.LnInt16(origVecCol, results)
+				if nulls.Any(lnResult.Nsp) {
+					logutil.Warn(negative_number_error)
+					if !nulls.Any(resultVector.Nsp) {
+						resultVector.Nsp = lnResult.Nsp
+					} else {
+						resultVector.Nsp.Or(lnResult.Nsp)
+					}
+				}
+				vector.SetCol(resultVector, results)
+				return resultVector, nil
+			},
+		},
+		{ // T_int32
+			Typ:        types.T_int32,
+			ReturnType: types.T_float64,
+			Fn: func(origVec *vector.Vector, proc *process.Process, _ bool) (*vector.Vector, error) {
+				origVecCol := origVec.Col.([]int32)
+				resultVector, err := process.Get(proc, 8*int64(len(origVecCol)), types.Type{Oid: types.T_float64, Size: 8})
+				if err != nil {
+					return nil, err
+				}
+				results := encoding.DecodeFloat64Slice(resultVector.Data)
+				results = results[:len(origVecCol)]
+				resultVector.Col = results
+				nulls.Set(resultVector.Nsp, origVec.Nsp)
+				lnResult := ln.LnInt32(origVecCol, results)
+				if nulls.Any(lnResult.Nsp) {
+					logutil.Warn(negative_number_error)
+					if !nulls.Any(resultVector.Nsp) {
+						resultVector.Nsp = lnResult.Nsp
+					} else {
+						resultVector.Nsp.Or(lnResult.Nsp)
+					}
+				}
+				vector.SetCol(resultVector, results)
+				return resultVector, nil
+			},
+		},
+		{ // T_int64
+			Typ:        types.T_int64,
+			ReturnType: types.T_float64,
+			Fn: func(origVec *vector.Vector, proc *process.Process, _ bool) (*vector.Vector, error) {
+				origVecCol := origVec.Col.([]int64)
+				resultVector, err := process.Get(proc, 8*int64(len(origVecCol)), types.Type{Oid: types.T_float64, Size: 8})
+				if err != nil {
+					return nil, err
+				}
+				results := encoding.DecodeFloat64Slice(resultVector.Data)
+				results = results[:len(origVecCol)]
+				resultVector.Col = results
+				nulls.Set(resultVector.Nsp, origVec.Nsp)
+				lnResult := ln.LnInt64(origVecCol, results)
+				if nulls.Any(lnResult.Nsp) {
+					logutil.Warn(negative_number_error)
+					if !nulls.Any(resultVector.Nsp) {
+						resultVector.Nsp = lnResult.Nsp
+					} else {
+						resultVector.Nsp.Or(lnResult.Nsp)
+					}
+				}
+				vector.SetCol(resultVector, results)
+				return resultVector, nil
+			},
+		},
+		{ // T_float32
+			Typ:        types.T_float32,
+			ReturnType: types.T_float64,
+			Fn: func(origVec *vector.Vector, proc *process.Process, _ bool) (*vector.Vector, error) {
+				origVecCol := origVec.Col.([]float32)
+				resultVector, err := process.Get(proc, 8*int64(len(origVecCol)), types.Type{Oid: types.T_float64, Size: 8})
+				if err != nil {
+					return nil, err
+				}
+				results := encoding.DecodeFloat64Slice(resultVector.Data)
+				results = results[:len(origVecCol)]
+				resultVector.Col = results
+				nulls.Set(resultVector.Nsp, origVec.Nsp)
+				lnResult := ln.LnFloat32(origVecCol, results)
+				if nulls.Any(lnResult.Nsp) {
+					logutil.Warn(negative_number_error)
+					if !nulls.Any(resultVector.Nsp) {
+						resultVector.Nsp = lnResult.Nsp
+					} else {
+						resultVector.Nsp.Or(lnResult.Nsp)
+					}
+				}
+				vector.SetCol(resultVector, results)
+				return resultVector, nil
+			},
+		},
+		{ // T_float64
+			Typ:        types.T_float64,
+			ReturnType: types.T_float64,
+			Fn: func(origVec *vector.Vector, proc *process.Process, _ bool) (*vector.Vector, error) {
+				origVecCol := origVec.Col.([]float64)
+				resultVector, err := process.Get(proc, 8*int64(len(origVecCol)), types.Type{Oid: types.T_float64, Size: 8})
+				if err != nil {
+					return nil, err
+				}
+				results := encoding.DecodeFloat64Slice(resultVector.Data)
+				results = results[:len(origVecCol)]
+				resultVector.Col = results
+				nulls.Set(resultVector.Nsp, origVec.Nsp)
+				lnResult := ln.LnFloat64(origVecCol, results)
+				if nulls.Any(lnResult.Nsp) {
+					logutil.Warn(negative_number_error)
+					if !nulls.Any(resultVector.Nsp) {
+						resultVector.Nsp = lnResult.Nsp
+					} else {
+						resultVector.Nsp.Or(lnResult.Nsp)
+					}
+				}
+				vector.SetCol(resultVector, results)
+				return resultVector, nil
+			},
+		},
+	}
+}

--- a/pkg/vectorize/ln/ln.go
+++ b/pkg/vectorize/ln/ln.go
@@ -1,0 +1,195 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ln
+
+import (
+	"github.com/matrixorigin/matrixone/pkg/container/nulls"
+	"math"
+)
+
+type LnResult struct {
+	Result []float64
+	Nsp    *nulls.Nulls
+}
+
+var (
+	lnUint8   func([]uint8, []float64) LnResult
+	lnUint16  func([]uint16, []float64) LnResult
+	lnUint32  func([]uint32, []float64) LnResult
+	lnUint64  func([]uint64, []float64) LnResult
+	lnInt8    func([]int8, []float64) LnResult
+	lnInt16   func([]int16, []float64) LnResult
+	lnInt32   func([]int32, []float64) LnResult
+	lnInt64   func([]int64, []float64) LnResult
+	lnFloat32 func([]float32, []float64) LnResult
+	lnFloat64 func([]float64, []float64) LnResult
+)
+
+func init() {
+	lnUint8 = lnUint8Pure
+	lnUint16 = lnUint16Pure
+	lnUint32 = lnUint32Pure
+	lnUint64 = lnUint64Pure
+	lnInt8 = lnInt8Pure
+	lnInt16 = lnInt16Pure
+	lnInt32 = lnInt32Pure
+	lnInt64 = lnInt64Pure
+	lnFloat32 = lnFloat32Pure
+	lnFloat64 = lnFloat64Pure
+}
+
+func LnUint8(xs []uint8, rs []float64) LnResult {
+	return lnUint8(xs, rs)
+}
+
+func lnUint8Pure(xs []uint8, rs []float64) LnResult {
+	result := LnResult{Result: rs, Nsp: new(nulls.Nulls)}
+	for i, n := range xs {
+		rs[i] = math.Log(float64(n)) / math.Log(math.E)
+	}
+	return result
+}
+
+func LnUint16(xs []uint16, rs []float64) LnResult {
+	return lnUint16(xs, rs)
+}
+
+func lnUint16Pure(xs []uint16, rs []float64) LnResult {
+	result := LnResult{Result: rs, Nsp: new(nulls.Nulls)}
+	for i, n := range xs {
+		rs[i] = math.Log(float64(n)) / math.Log(math.E)
+	}
+	return result
+}
+
+func LnUint32(xs []uint32, rs []float64) LnResult {
+	return lnUint32(xs, rs)
+}
+
+func lnUint32Pure(xs []uint32, rs []float64) LnResult {
+	result := LnResult{Result: rs, Nsp: new(nulls.Nulls)}
+	for i, n := range xs {
+		rs[i] = math.Log(float64(n)) / math.Log(math.E)
+	}
+	return result
+}
+
+func LnUint64(xs []uint64, rs []float64) LnResult {
+	return lnUint64(xs, rs)
+}
+
+func lnUint64Pure(xs []uint64, rs []float64) LnResult {
+	result := LnResult{Result: rs, Nsp: new(nulls.Nulls)}
+	for i, n := range xs {
+		rs[i] = math.Log(float64(n)) / math.Log(math.E)
+	}
+	return result
+}
+
+func LnInt8(xs []int8, rs []float64) LnResult {
+	return lnInt8(xs, rs)
+}
+
+func lnInt8Pure(xs []int8, rs []float64) LnResult {
+	result := LnResult{Result: rs, Nsp: new(nulls.Nulls)}
+	for i, n := range xs {
+		if n <= 0 {
+			nulls.Add(result.Nsp, uint64(i))
+		} else {
+			rs[i] = math.Log(float64(n)) / math.Log(math.E)
+		}
+	}
+	return result
+}
+
+func LnInt16(xs []int16, rs []float64) LnResult {
+	return lnInt16(xs, rs)
+}
+
+func lnInt16Pure(xs []int16, rs []float64) LnResult {
+	result := LnResult{Result: rs, Nsp: new(nulls.Nulls)}
+	for i, n := range xs {
+		if n <= 0 {
+			nulls.Add(result.Nsp, uint64(i))
+		} else {
+			rs[i] = math.Log(float64(n)) / math.Log(math.E)
+		}
+	}
+	return result
+}
+
+func LnInt32(xs []int32, rs []float64) LnResult {
+	return lnInt32(xs, rs)
+}
+
+func lnInt32Pure(xs []int32, rs []float64) LnResult {
+	result := LnResult{Result: rs, Nsp: new(nulls.Nulls)}
+	for i, n := range xs {
+		if n <= 0 {
+			nulls.Add(result.Nsp, uint64(i))
+		} else {
+			rs[i] = math.Log(float64(n)) / math.Log(math.E)
+		}
+	}
+	return result
+}
+
+func LnInt64(xs []int64, rs []float64) LnResult {
+	return lnInt64(xs, rs)
+}
+
+func lnInt64Pure(xs []int64, rs []float64) LnResult {
+	result := LnResult{Result: rs, Nsp: new(nulls.Nulls)}
+	for i, n := range xs {
+		if n <= 0 {
+			nulls.Add(result.Nsp, uint64(i))
+		} else {
+			rs[i] = math.Log(float64(n)) / math.Log(math.E)
+		}
+	}
+	return result
+}
+
+func LnFloat32(xs []float32, rs []float64) LnResult {
+	return lnFloat32(xs, rs)
+}
+
+func lnFloat32Pure(xs []float32, rs []float64) LnResult {
+	result := LnResult{Result: rs, Nsp: new(nulls.Nulls)}
+	for i, n := range xs {
+		if n <= 0 {
+			nulls.Add(result.Nsp, uint64(i))
+		} else {
+			rs[i] = math.Log(float64(n)) / math.Log(math.E)
+		}
+	}
+	return result
+}
+
+func LnFloat64(xs []float64, rs []float64) LnResult {
+	return lnFloat64(xs, rs)
+}
+
+func lnFloat64Pure(xs []float64, rs []float64) LnResult {
+	result := LnResult{Result: rs, Nsp: new(nulls.Nulls)}
+	for i, n := range xs {
+		if n <= 0 {
+			nulls.Add(result.Nsp, uint64(i))
+		} else {
+			rs[i] = math.Log(n) / math.Log(math.E)
+		}
+	}
+	return result
+}

--- a/pkg/vectorize/ln/ln_test.go
+++ b/pkg/vectorize/ln/ln_test.go
@@ -1,0 +1,379 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ln
+
+import (
+	"github.com/matrixorigin/matrixone/pkg/container/nulls"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestLnUint8(t *testing.T) {
+	//Test values
+	nums := []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	//Predefined Correct Values
+	expect := []float64{0, 0.6931471805599453, 1.0986122886681096,
+		1.3862943611198906, 1.6094379124341003, 1.791759469228055,
+		1.9459101490553132, 2.0794415416798357, 2.1972245773362196,
+		2.302585092994046,
+	}
+
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnUint8(nums, actual)
+	require.Equal(t, nulls.Any(lnResult.Nsp), false)
+
+	for i := range actual {
+		require.Equal(t, expect[i], actual[i])
+	}
+}
+
+func TestLnUint16(t *testing.T) {
+	//Test values
+	nums := []uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	//Predefined Correct Values
+	expect := []float64{0, 0.6931471805599453, 1.0986122886681096,
+		1.3862943611198906, 1.6094379124341003, 1.791759469228055,
+		1.9459101490553132, 2.0794415416798357, 2.1972245773362196,
+		2.302585092994046,
+	}
+
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnUint16(nums, actual)
+	require.Equal(t, nulls.Any(lnResult.Nsp), false)
+
+	for i := range actual {
+		require.Equal(t, expect[i], actual[i])
+	}
+}
+
+func TestLnUint32(t *testing.T) {
+	//Test values
+	nums := []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	//Predefined Correct Values
+	expect := []float64{0, 0.6931471805599453, 1.0986122886681096,
+		1.3862943611198906, 1.6094379124341003, 1.791759469228055,
+		1.9459101490553132, 2.0794415416798357, 2.1972245773362196,
+		2.302585092994046,
+	}
+
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnUint32(nums, actual)
+	require.Equal(t, nulls.Any(lnResult.Nsp), false)
+
+	for i := range actual {
+		require.Equal(t, expect[i], actual[i])
+	}
+}
+
+func TestLnUint64(t *testing.T) {
+	//Test values
+	nums := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	//Predefined Correct Values
+	expect := []float64{0, 0.6931471805599453, 1.0986122886681096,
+		1.3862943611198906, 1.6094379124341003, 1.791759469228055,
+		1.9459101490553132, 2.0794415416798357, 2.1972245773362196,
+		2.302585092994046,
+	}
+
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnUint64(nums, actual)
+	require.Equal(t, nulls.Any(lnResult.Nsp), false)
+
+	for i := range actual {
+		require.Equal(t, expect[i], actual[i])
+	}
+}
+
+func TestLnInt8(t *testing.T) {
+	//Test values
+	nums := []int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	//Predefined Correct Values
+	expect := []float64{0, 0.6931471805599453, 1.0986122886681096,
+		1.3862943611198906, 1.6094379124341003, 1.791759469228055,
+		1.9459101490553132, 2.0794415416798357, 2.1972245773362196,
+		2.302585092994046,
+	}
+
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnInt8(nums, actual)
+	require.Equal(t, nulls.Any(lnResult.Nsp), false)
+
+	for i := range actual {
+		require.Equal(t, expect[i], actual[i])
+	}
+}
+
+func TestLnInt16(t *testing.T) {
+	//Test values
+	nums := []int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	//Predefined Correct Values
+	expect := []float64{0, 0.6931471805599453, 1.0986122886681096,
+		1.3862943611198906, 1.6094379124341003, 1.791759469228055,
+		1.9459101490553132, 2.0794415416798357, 2.1972245773362196,
+		2.302585092994046,
+	}
+
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnInt16(nums, actual)
+	require.Equal(t, nulls.Any(lnResult.Nsp), false)
+
+	for i := range actual {
+		require.Equal(t, expect[i], actual[i])
+	}
+}
+
+func TestLnInt32(t *testing.T) {
+	//Test values
+	nums := []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	//Predefined Correct Values
+	expect := []float64{0, 0.6931471805599453, 1.0986122886681096,
+		1.3862943611198906, 1.6094379124341003, 1.791759469228055,
+		1.9459101490553132, 2.0794415416798357, 2.1972245773362196,
+		2.302585092994046,
+	}
+
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnInt32(nums, actual)
+	require.Equal(t, nulls.Any(lnResult.Nsp), false)
+
+	for i := range actual {
+		require.Equal(t, expect[i], actual[i])
+	}
+}
+
+func TestLnInt64(t *testing.T) {
+	//Test values
+	nums := []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	//Predefined Correct Values
+	expect := []float64{0, 0.6931471805599453, 1.0986122886681096,
+		1.3862943611198906, 1.6094379124341003, 1.791759469228055,
+		1.9459101490553132, 2.0794415416798357, 2.1972245773362196,
+		2.302585092994046,
+	}
+
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnInt64(nums, actual)
+	require.Equal(t, nulls.Any(lnResult.Nsp), false)
+
+	for i := range actual {
+		require.Equal(t, expect[i], actual[i])
+	}
+}
+
+func TestLnFloat32(t *testing.T) {
+	//Test values
+	nums := []float32{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9}
+	//Predefined Correct Values
+	expect := []float64{
+		0.0953102014787409,
+		0.7884573820386862,
+		1.1939224540228235,
+		1.4816045625986316,
+		1.7047480922384253,
+		1.8870696345827689,
+		2.0412203040888763,
+		2.1747517431585770,
+		2.2925347186082479,
+	}
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnFloat32(nums, actual)
+	require.Equal(t, nulls.Any(lnResult.Nsp), false)
+
+	for i := range actual {
+		require.Equal(t, expect[i], actual[i])
+	}
+}
+
+func TestLnFloat64(t *testing.T) {
+	//Test values
+	nums := []float64{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9}
+	//Predefined Correct Values
+	expect := []float64{
+		0.09531017980432493,
+		0.7884573603642703,
+		1.1939224684724346,
+		1.4816045409242156,
+		1.7047480922384253,
+		1.8870696490323797,
+		2.0412203288596382,
+		2.174751721484161,
+		2.2925347571405443,
+	}
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnFloat64(nums, actual)
+	require.Equal(t, nulls.Any(lnResult.Nsp), false)
+
+	for i := range actual {
+		require.Equal(t, expect[i], actual[i])
+	}
+}
+
+func TestNegativeLnInt8(t *testing.T) {
+	//Test values
+	nums := []int8{1, -1, 2, -2, 3, -3}
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnInt8(nums, actual)
+	for i := 0; i < len(actual)/2; i++ {
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2)), false)
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2+1)), true)
+	}
+}
+
+func TestNegativeLnInt16(t *testing.T) {
+	//Test values
+	nums := []int16{1, -1, 2, -2, 3, -3}
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnInt16(nums, actual)
+	for i := 0; i < len(actual)/2; i++ {
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2)), false)
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2+1)), true)
+	}
+}
+
+func TestNegativeLnInt32(t *testing.T) {
+	//Test values
+	nums := []int32{1, -1, 2, -2, 3, -3}
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnInt32(nums, actual)
+	for i := 0; i < len(actual)/2; i++ {
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2)), false)
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2+1)), true)
+	}
+}
+
+func TestNegativeLnInt64(t *testing.T) {
+	//Test values
+	nums := []int64{1, -1, 2, -2, 3, -3}
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnInt64(nums, actual)
+	for i := 0; i < len(actual)/2; i++ {
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2)), false)
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2+1)), true)
+	}
+}
+
+func TestNegativeLnFloat32(t *testing.T) {
+	//Test values
+	nums := []float32{1, -1.1, 2, -2.2, 3, -3.3}
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnFloat32(nums, actual)
+	for i := 0; i < len(actual)/2; i++ {
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2)), false)
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2+1)), true)
+	}
+}
+
+func TestNegativeLnFloat64(t *testing.T) {
+	//Test values
+	nums := []float64{1, -1.1, 2, -2.2, 3, -3.3}
+	//Init a new variable
+	actual := make([]float64, len(nums))
+	//Run ln function
+	lnResult := LnFloat64(nums, actual)
+	for i := 0; i < len(actual)/2; i++ {
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2)), false)
+		require.Equal(t, nulls.Contains(lnResult.Nsp, uint64(i*2+1)), true)
+	}
+}
+
+func TestZeroLnInt8(t *testing.T) {
+	//Test values
+	nums := []int8{0}
+	//Init a new variable
+	actual := make([]float64, 1)
+	//Run ln function
+	lnResult := LnInt8(nums, actual)
+	require.Equal(t, nulls.Contains(lnResult.Nsp, 0), true)
+}
+
+func TestZeroLnInt16(t *testing.T) {
+	//Test values
+	nums := []int16{0}
+	//Init a new variable
+	actual := make([]float64, 1)
+	//Run ln function
+	lnResult := LnInt16(nums, actual)
+	require.Equal(t, nulls.Contains(lnResult.Nsp, 0), true)
+}
+
+func TestZeroLnInt32(t *testing.T) {
+	//Test values
+	nums := []int32{0}
+	//Init a new variable
+	actual := make([]float64, 1)
+	//Run ln function
+	lnResult := LnInt32(nums, actual)
+	require.Equal(t, nulls.Contains(lnResult.Nsp, 0), true)
+}
+
+func TestZeroLnInt64(t *testing.T) {
+	//Test values
+	nums := []int64{0}
+	//Init a new variable
+	actual := make([]float64, 1)
+	//Run ln function
+	lnResult := LnInt64(nums, actual)
+	require.Equal(t, nulls.Contains(lnResult.Nsp, 0), true)
+}
+
+func TestZeroLnFloat32(t *testing.T) {
+	//Test values
+	nums := []float32{0}
+	//Init a new variable
+	actual := make([]float64, 1)
+	//Run ln function
+	lnResult := LnFloat32(nums, actual)
+	require.Equal(t, nulls.Contains(lnResult.Nsp, 0), true)
+}
+
+func TestZeroLnFloat64(t *testing.T) {
+	//Test values
+	nums := []float64{0}
+	//Init a new variable
+	actual := make([]float64, 1)
+	//Run ln function
+	lnResult := LnFloat64(nums, actual)
+	require.Equal(t, nulls.Contains(lnResult.Nsp, 0), true)
+}


### PR DESCRIPTION
**What type of PR is this?**

- [x] Feature

**Which issue(s) this PR fixes:**

issue #1825

**What this PR does / why we need it:**

implement ln(x).

**Special notes for your reviewer:**

1. how can I output "NULL" for users if the x <= 0?

2. what if we have a table `p1` like this:
```
+------+--------+
| id   | score  |
+------+--------+
|    1 | 1.1000 |
|    2 | 2.2000 |
|   -1 | 3.3000 |
|    4 | 4.4000 |
+------+--------+

```

and use `select ln(id) from p1;`
show it output all enties like:
```
+--------+
| ln(id) | 
+--------+
| 0.0000 |
| 0.6931 |
| NULL   |
| 1.3862 |
+--------+
ERROR 1105 (HY000): unknown error:Invalid argument for logarithm
```
But for now, it will only output:
"ERROR 1105 (HY000): unknown error: Invalid argument for logarithm"
Is there any way to fix it?