### PR TITLE
Implement built-in function power.

### DIFF
--- a/pkg/builtin/binary/power.go
+++ b/pkg/builtin/binary/power.go
@@ -1,0 +1,129 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package binary
+
+import (
+	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/builtin"
+	"github.com/matrixorigin/matrixone/pkg/container/nulls"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/encoding"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/extend"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/extend/overload"
+	"github.com/matrixorigin/matrixone/pkg/vectorize/power"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+// append cast rules for built-in function power
+func init() {
+	targetType := []types.Type{{Oid: types.T_float64, Size: 8}, {Oid: types.T_float64, Size: 8}}
+	sourceTypes := []types.T{types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64,
+		types.T_int8, types.T_int16, types.T_int32, types.T_int64, types.T_float32, types.T_float64}
+
+	for _, left := range sourceTypes {
+		for _, right := range sourceTypes {
+			overload.AppendCastRules(builtin.Power, 2, []types.T{left, right}, targetType)
+			overload.AppendCastRules(builtin.Power, 2, []types.T{right, left}, targetType)
+		}
+	}
+}
+
+func init() {
+	extend.FunctionRegistry["power"] = builtin.Power
+	extend.BinaryReturnTypes[builtin.Power] = func(e extend.Extend, e2 extend.Extend) types.T {
+		return types.T_float64
+	}
+
+	extend.BinaryStrings[builtin.Power] = func(e extend.Extend, e2 extend.Extend) string {
+		return fmt.Sprintf("power(%s, %s)", e, e2)
+	}
+
+	overload.OpTypes[builtin.Power] = overload.Binary
+
+	overload.BinOps[builtin.Power] = []*overload.BinOp{
+		{
+			LeftType:   types.T_float64,
+			RightType:  types.T_float64,
+			ReturnType: types.T_float64,
+			Fn: func(lv, rv *vector.Vector, proc *process.Process, lc, rc bool) (*vector.Vector, error) {
+				lvs, rvs := lv.Col.([]float64), rv.Col.([]float64)
+				switch {
+				case lc && !rc:
+					if rv.Ref == 1 || rv.Ref == 0 {
+						rv.Ref = 0
+						power.PowerScalarLeftConst(lvs[0], rvs, rvs)
+						return rv, nil
+					}
+					vec, err := process.Get(proc, 8*int64(len(rvs)), lv.Typ)
+					if err != nil {
+						return nil, err
+					}
+					rs := encoding.DecodeFloat64Slice(vec.Data)
+					rs = rs[:len(rvs)]
+					nulls.Set(vec.Nsp, rv.Nsp)
+					vector.SetCol(vec, power.PowerScalarLeftConst(lvs[0], rvs, rs))
+					return vec, nil
+				case !lc && rc:
+					if lv.Ref == 1 || lv.Ref == 0 {
+						lv.Ref = 0
+						power.PowerScalarRightConst(rvs[0], lvs, lvs)
+						return lv, nil
+					}
+					vec, err := process.Get(proc, 8*int64(len(lvs)), lv.Typ)
+					if err != nil {
+						return nil, err
+					}
+					rs := encoding.DecodeFloat64Slice(vec.Data)
+					rs = rs[:len(rvs)]
+					nulls.Set(vec.Nsp, rv.Nsp)
+					vector.SetCol(vec, power.PowerScalarRightConst(rvs[0], lvs, rs))
+					return vec, nil
+				case lv.Ref == 1 || lv.Ref == 0:
+					lv.Ref = 0
+					power.Power(lvs, rvs, lvs)
+					lv.Nsp = lv.Nsp.Or(rv.Nsp)
+					if rv.Ref == 0 {
+						process.Put(proc, rv)
+					}
+					return lv, nil
+				case rv.Ref == 1 || rv.Ref == 0:
+					rv.Ref = 0
+					power.Power(lvs, rvs, rvs)
+					rv.Nsp = rv.Nsp.Or(lv.Nsp)
+					if lv.Ref == 0 {
+						process.Put(proc, lv)
+					}
+					return rv, nil
+				}
+				vec, err := process.Get(proc, 8*int64(len(lvs)), lv.Typ)
+				if err != nil {
+					return nil, err
+				}
+				rs := encoding.DecodeFloat64Slice(vec.Data)
+				rs = rs[:len(rvs)]
+				nulls.Or(lv.Nsp, rv.Nsp, vec.Nsp)
+				vector.SetCol(vec, power.Power(lvs, rvs, rs))
+				if lv.Ref == 0 {
+					process.Put(proc, lv)
+				}
+				if rv.Ref == 0 {
+					process.Put(proc, rv)
+				}
+				return vec, nil
+			},
+		},
+	}
+}

--- a/pkg/builtin/types.go
+++ b/pkg/builtin/types.go
@@ -26,4 +26,5 @@ const (
 	Abs
 	Log
 	Ln
+	Power
 )

--- a/pkg/sql/colexec/extend/overload/init.go
+++ b/pkg/sql/colexec/extend/overload/init.go
@@ -55,6 +55,11 @@ type retType struct {
 	ret      types.T
 }
 
+func AppendCastRules(op int, numArgs uint8, sourceTypes []types.T, targetTypes []types.Type) {
+	cr := castRule{numArgs, sourceTypes, targetTypes}
+	OperatorCastRules[op] = append(OperatorCastRules[op], cr)
+}
+
 // GetUnaryOpReturnType returns the returnType of unary ops or binary functions
 func GetUnaryOpReturnType(op int, arg types.T) types.T {
 	if m, ok := OperatorReturnType[op]; ok {

--- a/pkg/vectorize/power/power.go
+++ b/pkg/vectorize/power/power.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package power
+
+import (
+	"math"
+)
+
+var (
+	powerScalarLeftConst  func(scalar float64, rv []float64, rs []float64) []float64
+	powerScalarRightConst func(scalar float64, rv []float64, rs []float64) []float64
+	power                 func(lv, rv, rs []float64) []float64
+)
+
+func init() {
+	powerScalarLeftConst = powerScalarLeftConstPure
+	powerScalarRightConst = powerScalarRightConstPure
+	power = powerPure
+}
+
+func PowerScalarLeftConst(scalar float64, rv []float64, rs []float64) []float64 {
+	return powerScalarLeftConst(scalar, rv, rs)
+}
+
+func powerScalarLeftConstPure(scalar float64, rv []float64, rs []float64) []float64 {
+	for i, x := range rv {
+		rs[i] = math.Pow(scalar, x)
+	}
+	return rs
+}
+
+func PowerScalarRightConst(scalar float64, rv []float64, rs []float64) []float64 {
+	return powerScalarRightConst(scalar, rv, rs)
+}
+
+func powerScalarRightConstPure(scalar float64, rv []float64, rs []float64) []float64 {
+	for i, x := range rv {
+		rs[i] = math.Pow(x, scalar)
+	}
+	return rs
+}
+
+func Power(lv, rv, rs []float64) []float64 {
+	return power(lv, rv, rs)
+}
+
+func powerPure(lv, rv, rs []float64) []float64 {
+	for i, x := range lv {
+		rs[i] = math.Pow(x, rv[i])
+	}
+	return rs
+}

--- a/pkg/vectorize/power/power_test.go
+++ b/pkg/vectorize/power/power_test.go
@@ -1,0 +1,65 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package power
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPower(t *testing.T) {
+	//Test values
+	lvs := []float64{2, 3, 4, 5, 6, 7, 8, 9}
+	rvs := []float64{2, 2, 3, 3, 4, 4, 2, 2}
+
+	//Predefined Correct Values
+	expected := []float64{4, 9, 64, 125, 1296, 2401, 64, 81}
+
+	newNums := powerPure(lvs, rvs, rvs)
+
+	for i, _ := range newNums {
+		require.Equal(t, expected[i], newNums[i])
+	}
+}
+
+func TestPowerScalarLeftConst(t *testing.T) {
+	//Test values
+	var lc float64 = 2
+	rvs := []float64{2, 3, 4, 5, 6, 7, 8, 9}
+
+	//Predefined Correct Values
+	expected := []float64{4, 8, 16, 32, 64, 128, 256, 512}
+
+	newNums := powerScalarLeftConstPure(lc, rvs, rvs)
+
+	for i, _ := range newNums {
+		require.Equal(t, expected[i], newNums[i])
+	}
+}
+
+func TestPowerScalarRightConst(t *testing.T) {
+	//Test values
+	lvs := []float64{2, 3, 4, 5, 6, 7, 8, 9}
+	var rc float64 = 2
+
+	//Predefined Correct Values
+	expected := []float64{4, 9, 16, 25, 36, 49, 64, 81}
+
+	newNums := powerScalarRightConstPure(rc, lvs, lvs)
+
+	for i, _ := range newNums {
+		require.Equal(t, expected[i], newNums[i])
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #1824

**What this PR does / why we need it:**
This PR implements built-in function power.
Suppose we have **table tb(int,int,double)**:
```SQL
mysql> select * from tb_power;
+------+------+--------+
| a    | b    | c      |
+------+------+--------+
|    2 |    2 | 3.1400 |
|    2 |   -2 | 2.7800 |
+------+------+--------+
```
When we execute _select power(a,b),power(a,c),power(c,a) from tb_power_. It will print like this:
```SQL
mysql> select power(a,b),power(a,c),power(c,a) from tb_power;
+-------------+-------------+-------------+
| power(a, b) | power(a, c) | power(c, a) |
+-------------+-------------+-------------+
|      4.0000 |      8.8152 |      9.8596 |
|      0.2500 |      6.8685 |      7.7284 |
+-------------+-------------+-------------+
```
**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
