### PR TITLE
docker build job time limit

### DIFF
--- a/.github/workflows/docker_ci.yml
+++ b/.github/workflows/docker_ci.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
 
     steps:
       - name: Checkout


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

Cancel job time limit of docker build and push workflow

**Special notes for your reviewer:**

[Default github action usage limit](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits)

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
