### PR TITLE
Fix the problem of negative sign logical inversion

### DIFF
--- a/pkg/sql/plan/prune.go
+++ b/pkg/sql/plan/prune.go
@@ -201,11 +201,20 @@ func splitNotBinary(e *extend.BinaryExtend) extend.Extend {
 }
 
 func (b *build) pruneUnaryMinus(e *extend.UnaryExtend) (extend.Extend, error) {
-	v, ok := e.E.(*extend.ValueExtend)
-	if !ok {
+	switch n := e.E.(type) {
+	case *extend.UnaryExtend:
+		tempExtend, err := b.pruneUnaryMinus(n)
+		if err == nil {
+			if temp, ok := tempExtend.(*extend.ValueExtend); ok {
+				return Neg(temp)
+			}
+		}
+		return tempExtend, err
+	case *extend.ValueExtend:
+		return Neg(n)
+	default:
 		return e, nil
 	}
-	return Neg(v)
 }
 
 func (b *build) pruneOr(e *extend.BinaryExtend) (extend.Extend, error) {

--- a/pkg/sql/rewrite/astrewrite.go
+++ b/pkg/sql/rewrite/astrewrite.go
@@ -107,7 +107,7 @@ func rewriteFilterCondition(expr tree.Expr) tree.Expr {
 		}
 		return tree.NewComparisonExpr(tree.EQUAL, t.Expr, tree.NewNumVal(constant.MakeInt64(0), "0", false))
 	// rewrite to != 0
-	case *tree.UnresolvedName, *tree.NumVal, *tree.CastExpr:
+	case *tree.UnresolvedName, *tree.NumVal, *tree.CastExpr, *tree.UnaryExpr:
 		return tree.NewComparisonExpr(tree.NOT_EQUAL, t, tree.NewNumVal(constant.MakeInt64(0), "0", false))
 	case *tree.BinaryExpr:
 		if !isLogicalBinaryOp(t.Op) {

--- a/pkg/sql/unittest/dml_test.go
+++ b/pkg/sql/unittest/dml_test.go
@@ -214,6 +214,27 @@ func TestInsertAndSelectFunction(t *testing.T) {
 				{"1"},
 			},
 		}},
+
+		{sql: "create table issue1660 (a int, b int);"},
+		{sql: "insert into issue1660 values (0, 0), (1, 2);"},
+		{sql: "select * from issue1660 where -a;", res: executeResult{
+			attr: []string{"a", "b"},
+			data: [][]string{
+				{"1", "2"},
+			},
+		}, com: "issue 1660"},
+
+		{sql: "create table t_issue1659 (a int, b int);"},
+		{sql: "insert into t_issue1659 values (1, 2), (3, 4), (5, 6);"},
+		{sql: "select * from t_issue1659 where (--1);", res: executeResult{
+			attr: []string{"a", "b"},
+			data: [][]string{
+				{"1", "2"},
+				{"3", "4"},
+				{"5", "6"},
+			},
+		}, com: "issue 1659"},
+
 		{sql: "insert into cha1 values ('1');", err: "[22000]Data too long for column 'a' at row 1"},
 		{sql: "insert into cha2 values ('21');", err: "[22000]Data too long for column 'a' at row 1"},
 		{sql: "insert into iis (i1) values (128);", err: "[22000]Out of range value for column 'i1' at row 1"},
@@ -239,11 +260,11 @@ func TestCAQ(t *testing.T) {
 		{sql: "create table output (store_id int, item_id int unsigned, guest_id int, item_num int, output_incomes double);"},
 		{sql: "create table house (item_id int unsigned, item_num int);"},
 		{sql: "insert into store (store_id, store_area, store_type, incomes, duration) values " +
-		"(1, 'shanghai', 0, 2500, 16), (2, 'shanghai', 0, 70000, 40), (3, 'beijing', 1, 10000, 10), (4, 'shenzhen', 1, 0, 5);"},
+			"(1, 'shanghai', 0, 2500, 16), (2, 'shanghai', 0, 70000, 40), (3, 'beijing', 1, 10000, 10), (4, 'shenzhen', 1, 0, 5);"},
 		{sql: "insert into input (store_id, item_id, item_num, input_cost) values " +
-		"(1, 100, 1000, 500), (1, 101, 30, 900), (1, 102, 40, 80), (2, 101, 500, 400), (3, 103, 20, 800), (3, 102, 5, 80), (4, 105, 1005, 2010);"},
+			"(1, 100, 1000, 500), (1, 101, 30, 900), (1, 102, 40, 80), (2, 101, 500, 400), (3, 103, 20, 800), (3, 102, 5, 80), (4, 105, 1005, 2010);"},
 		{sql: "insert into output (store_id, item_id, guest_id, item_num, output_incomes) values " +
-		"(1, 100, 30001, 700, 700), (1, 102, 30001, 1, 20), (2, 101, 30003, 200, 500), (3, 102, 30002, 1, 10);"},
+			"(1, 100, 30001, 700, 700), (1, 102, 30001, 1, 20), (2, 101, 30003, 200, 500), (3, 102, 30002, 1, 10);"},
 		{sql: "insert into house values (101, 5000), (102, 1000), (103, 5000), (104, 100), (105, 1);"},
 
 		{sql: "select count(*) from store join input on store.store_id = input.store_id;", res: executeResult{
@@ -264,25 +285,25 @@ func TestCAQ(t *testing.T) {
 			"store join input on store.store_id = input.store_id " +
 			"group by store_area;",
 			res: executeResult{
-			attr: []string{"store_area", "sum(incomes)"},
-			data: [][]string{
-				{"shanghai", "77500.000000"},
-				{"beijing", "20000.000000"},
-				{"shenzhen", "0.000000"},
-			},
-		}},
+				attr: []string{"store_area", "sum(incomes)"},
+				data: [][]string{
+					{"shanghai", "77500.000000"},
+					{"beijing", "20000.000000"},
+					{"shenzhen", "0.000000"},
+				},
+			}},
 
 		{sql: "select store_area, store_type, sum(incomes) from " +
 			"store join input on store.store_id = input.store_id " +
 			"group by store_area, store_type;",
 			res: executeResult{
-			attr: []string{"store_area", "store_type", "sum(incomes)"},
-			data: [][]string{
-				{"shanghai", "0", "77500.000000"},
-				{"beijing", "1", "20000.000000"},
-				{"shenzhen", "1", "0.000000"},
-			},
-		}},
+				attr: []string{"store_area", "store_type", "sum(incomes)"},
+				data: [][]string{
+					{"shanghai", "0", "77500.000000"},
+					{"beijing", "1", "20000.000000"},
+					{"shenzhen", "1", "0.000000"},
+				},
+			}},
 
 		//{sql: "select store_area, store_type, item_id, sum(incomes) from " +
 		//	"store join input on store.store_id = input.store_id " +
@@ -304,12 +325,12 @@ func TestCAQ(t *testing.T) {
 			" join house on house.item_id = output.item_id" +
 			" group by store_type;",
 			res: executeResult{
-			attr: []string{"store_type", "max(output_incomes)"},
-			data: [][]string{
-				{"0", "500.000000"},
-				{"1", "10.000000"},
-			},
-		}},
+				attr: []string{"store_type", "max(output_incomes)"},
+				data: [][]string{
+					{"0", "500.000000"},
+					{"1", "10.000000"},
+				},
+			}},
 
 		{sql: "select store_type, max(output_incomes) from " +
 			"store join output on store.store_id = output.store_id" +
@@ -317,11 +338,11 @@ func TestCAQ(t *testing.T) {
 			"where store.store_id < 2 " +
 			"group by store_type;",
 			res: executeResult{
-			attr: []string{"store_type", "max(output_incomes)"},
-			data: [][]string{
-				{"0", "20.000000"},
-			},
-		}},
+				attr: []string{"store_type", "max(output_incomes)"},
+				data: [][]string{
+					{"0", "20.000000"},
+				},
+			}},
 
 		{sql: "select store_type, max(output_incomes) from " +
 			"store join output on store.store_id = output.store_id " +
@@ -329,11 +350,11 @@ func TestCAQ(t *testing.T) {
 			"group by store_type " +
 			"having store_type < 1",
 			res: executeResult{
-			attr: []string{"store_type", "max(output_incomes)"},
-			data: [][]string{
-				{"0", "500.000000"},
-			},
-		}},
+				attr: []string{"store_type", "max(output_incomes)"},
+				data: [][]string{
+					{"0", "500.000000"},
+				},
+			}},
 
 		{sql: "select store_id from store join input on store.store_id = input.store_id;", err: "[42701]Column 'store_id' is ambiguous"},
 	}


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #1660 #1659

**What this PR does / why we need it:**

Cause of problem #1660:
When the where conditional expression of the select statement is a negative sign unary expression, it cannot be used as the result of logical calculation, resulting in program crash,
Solution:
Rewrite the unary expression in the where clause in the rewriting part of AST syntax tree, and modify the unary expression to unaryexpr= 0

Cause of problem #1659:
When the where conditional expression of the select statement contains multiple negative unary expressions, such as -- 1, when pruning the negative unary expression, this situation is handled, resulting in incorrect where calculation results
Solution:
When pruning the unary expression with negative sign (corresponding function pruneunaryminus), judge whether the sub expression of the negative expression is still a negative expression and handle it separately

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
