### PR TITLE
Fix pruning error of multiple not expressions

### DIFF
--- a/pkg/sql/plan/prune.go
+++ b/pkg/sql/plan/prune.go
@@ -110,7 +110,7 @@ func (b *build) pruneConditionNot(e *extend.UnaryExtend) (extend.Extend, error) 
 	}
 	// split not extends
 	ext = logicInverse(ext)
-	return ext, nil
+	return b.pruneExtend(ext, false)
 }
 
 func (b *build) pruneProjectionNot(e *extend.UnaryExtend) (extend.Extend, error) {

--- a/pkg/sql/unittest/dml_test.go
+++ b/pkg/sql/unittest/dml_test.go
@@ -235,6 +235,52 @@ func TestInsertAndSelectFunction(t *testing.T) {
 			},
 		}, com: "issue 1659"},
 
+		{sql: "create table t_issue1653 (a int, b int);"},
+		{sql: "insert into t_issue1653 values (1, 2), (3, 4), (5, 6);"},
+		{sql: "select * from t_issue1653 where not (-0);", res: executeResult{
+			attr: []string{"a", "b"},
+			data: [][]string{
+				{"1", "2"},
+				{"3", "4"},
+				{"5", "6"},
+			},
+		}, com: "issue 1653"},
+
+		{sql: "create table t_issue1651 (a int);"},
+		{sql: "insert into t_issue1651 values(1), (2), (3);"},
+		{sql: "select * from t_issue1651 where -a;", res: executeResult{
+			attr: []string{"a"},
+			data: [][]string{
+				{"1"},
+				{"2"},
+				{"3"},
+			},
+		}, com: "issue 1651"},
+
+		{sql: "create table t_issue_1641 (id_2 int, col_varchar_2 char(511));"},
+		{sql: "insert into t_issue_1641 (id_2, col_varchar_2) values (-0, 'false'), (1, '-0'), (-0, ''), (65535, 'false'), (1, ''), (-1, '-1'), (-1, '1'), (1, 'false'), (-1, '1'), (65535, ' '), (-1, '-1'), (-1, '2020-02-02 02:02:00'), (-1, '-0'), (65535, '-1'), (1, ' '), (1, '0000-00-00 00:00:00') ;"},
+		{sql: "select t_issue_1641.id_2 as col_1, t_issue_1641.col_varchar_2 as col_2 from t_issue_1641 where not (not 73751114271);", res: executeResult{
+			attr: []string{"col_1", "col_2"},
+			data: [][]string{
+				{"0", "false"},
+				{"1", "-0"},
+				{"0", ""},
+				{"65535", "false"},
+				{"1", ""},
+				{"-1", "-1"},
+				{"-1", "1"},
+				{"1", "false"},
+				{"-1", "1"},
+				{"65535", " "},
+				{"-1", "-1"},
+				{"-1", "2020-02-02 02:02:00"},
+				{"-1", "-0"},
+				{"65535", "-1"},
+				{"1", " "},
+				{"1", "0000-00-00 00:00:00"},
+			},
+		}, com: "issue 1641"},
+
 		{sql: "insert into cha1 values ('1');", err: "[22000]Data too long for column 'a' at row 1"},
 		{sql: "insert into cha2 values ('21');", err: "[22000]Data too long for column 'a' at row 1"},
 		{sql: "insert into iis (i1) values (128);", err: "[22000]Out of range value for column 'i1' at row 1"},


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #1641 #1651 #1653

**What this PR does / why we need it:**
Cause of problem #1653/#1641/#1651:
When there are multiple not expressions in the where conditional expression, the unary subexpression of the not expression is logically inverted only once, without considering the nesting of not expressions.

Solution:
After pruning and logical inversion of the not expression in the where conditional expression, clip the unary subexpression of the not expression again until there is no not expression


**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
