### PR TITLE
Enable molint as a part of SCA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ endif
 .PHONY: install-static-check-tools
 install-static-check-tools:
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(GOPATH)/bin v1.45.2
+	@go install github.com/matrixorigin/linter/cmd/molint@latest
 
 # TODO: tracking https://github.com/golangci/golangci-lint/issues/2649
 DIRS=pkg/... \
@@ -122,14 +123,7 @@ EXTRA_LINTERS=-E misspell -E exportloopref -E rowserrcheck -E depguard -E unconv
 .PHONY: static-check
 static-check:
 	@go generate ./pkg/sql/colexec/extend/overload
+	@go vet -vettool=$(shell which molint) ./...
 	@for p in $(DIRS); do \
     golangci-lint run $(EXTRA_LINTERS) $$p; \
   done;
-
-.PHONY: install-molint
-install-molint:
-	@go install github.com/matrixorigin/linter/cmd/molint@latest
-
-.PHONY: molint
-molint:
-	@go vet -vettool=$(shell which molint) ./...


### PR DESCRIPTION
Calling recover() in non-test code will require approval first

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

mo-lint will be installed and invoked as a part of SCA. At this stage, it only checks whether there is any unexpected call to recover(), we can add more checks later when necessary.  

Already talked to code owns of all existing calls to recover(), resolved some of them and @nnsgmsone confirmed a few calls to recover() that is indeed required. 

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
