### PR TITLE
Added go-licenses check to the static-check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ endif
 install-static-check-tools:
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b $(GOPATH)/bin v1.45.2
 	@go install github.com/matrixorigin/linter/cmd/molint@latest
+	@go install github.com/google/go-licenses@latest
 
 # TODO: tracking https://github.com/golangci/golangci-lint/issues/2649
 DIRS=pkg/... \
@@ -124,6 +125,7 @@ EXTRA_LINTERS=-E misspell -E exportloopref -E rowserrcheck -E depguard -E unconv
 static-check:
 	@go generate ./pkg/sql/colexec/extend/overload
 	@go vet -vettool=$(shell which molint) ./...
+	@go-licenses check ./...
 	@for p in $(DIRS); do \
     golangci-lint run $(EXTRA_LINTERS) $$p; \
   done;


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

Added go-licenses check to the static-check target. go-licenses is a tool that can check for code with forbidden licenses (such as AGPL3.0) imported by MO.  

See a list of forbidden licenses as defined by google's licenseclassifier
https://github.com/google/licenseclassifier/blob/842c0d70d7027215932deb13801890992c9ba364/license_type.go#L323

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
