### PR TITLE
Static check: fix apparent cases for `errcheck`;

### DIFF
--- a/cmd/db-server/debug.go
+++ b/cmd/db-server/debug.go
@@ -35,7 +35,10 @@ func startCPUProfile() func() {
 	if err != nil {
 		panic(err)
 	}
-	pprof.StartCPUProfile(f)
+	err = pprof.StartCPUProfile(f)
+	if err != nil {
+		panic(err)
+	}
 	logutil.Infof("CPU profiling enabled, writing to %s", cpuProfilePath)
 	return func() {
 		pprof.StopCPUProfile()

--- a/pkg/sql/colexec2/mergeoffset/offset_test.go
+++ b/pkg/sql/colexec2/mergeoffset/offset_test.go
@@ -67,13 +67,15 @@ func TestString(t *testing.T) {
 
 func TestPrepare(t *testing.T) {
 	for _, tc := range tcs {
-		Prepare(tc.proc, tc.arg)
+		err := Prepare(tc.proc, tc.arg)
+		require.NoError(t, err)
 	}
 }
 
 func TestOffset(t *testing.T) {
 	for _, tc := range tcs {
-		Prepare(tc.proc, tc.arg)
+		err := Prepare(tc.proc, tc.arg)
+		require.NoError(t, err)
 		tc.proc.Reg.MergeReceivers[0].Ch <- newBatch(t, tc.types, tc.proc, Rows)
 		tc.proc.Reg.MergeReceivers[0].Ch <- &batch.Batch{}
 		tc.proc.Reg.MergeReceivers[0].Ch <- nil
@@ -100,7 +102,8 @@ func BenchmarkOffset(b *testing.B) {
 
 		t := new(testing.T)
 		for _, tc := range tcs {
-			Prepare(tc.proc, tc.arg)
+			err := Prepare(tc.proc, tc.arg)
+			require.NoError(t, err)
 			tc.proc.Reg.MergeReceivers[0].Ch <- newBatch(t, tc.types, tc.proc, BenchmarkRows)
 			tc.proc.Reg.MergeReceivers[0].Ch <- &batch.Batch{}
 			tc.proc.Reg.MergeReceivers[0].Ch <- nil

--- a/pkg/vm/engine/tae/samples/sample2/main.go
+++ b/pkg/vm/engine/tae/samples/sample2/main.go
@@ -42,7 +42,9 @@ func init() {
 
 func startProfile() {
 	f, _ := os.Create(cpuprofile)
-	pprof.StartCPUProfile(f)
+	if err := pprof.StartCPUProfile(f); err != nil {
+		panic(err)
+	}
 }
 
 func stopProfile() {

--- a/pkg/vm/engine/tae/samples/sample3/main.go
+++ b/pkg/vm/engine/tae/samples/sample3/main.go
@@ -44,7 +44,9 @@ func init() {
 
 func startProfile() {
 	f, _ := os.Create(cpuprofile)
-	pprof.StartCPUProfile(f)
+	if err := pprof.StartCPUProfile(f); err != nil {
+		panic(err)
+	}
 }
 
 func stopProfile() {

--- a/pkg/vm/engine/tae/tables/txnentries/mergeblockscmd.go
+++ b/pkg/vm/engine/tae/tables/txnentries/mergeblockscmd.go
@@ -103,7 +103,7 @@ func WriteUint32Array(w io.Writer, array []uint32) (n int64, err error) {
 	}
 	n = 4
 	for _, i := range array {
-		if binary.Write(w, binary.BigEndian, i); err != nil {
+		if err = binary.Write(w, binary.BigEndian, i); err != nil {
 			return
 		}
 		n += 4
@@ -119,7 +119,7 @@ func ReadUint32Array(r io.Reader) (array []uint32, n int64, err error) {
 	n = 4
 	array = make([]uint32, length)
 	for i := 0; i < int(length); i++ {
-		if binary.Read(r, binary.BigEndian, &array[i]); err != nil {
+		if err = binary.Read(r, binary.BigEndian, &array[i]); err != nil {
 			return
 		}
 		n += 4

--- a/pkg/vm/engine/tae/txn/txnbase/helper.go
+++ b/pkg/vm/engine/tae/txn/txnbase/helper.go
@@ -99,7 +99,7 @@ func UnmarshalBatchFrom(r io.Reader) (vecTypes []types.Type, bat batch.IBatch, n
 	var size uint32
 	var vecs uint16
 	pos := 0
-	if binary.Read(r, binary.BigEndian, &size); err != nil {
+	if err = binary.Read(r, binary.BigEndian, &size); err != nil {
 		return
 	}
 	buf := make([]byte, size-4)
@@ -107,11 +107,11 @@ func UnmarshalBatchFrom(r io.Reader) (vecTypes []types.Type, bat batch.IBatch, n
 		return
 	}
 	bbuf := bytes.NewBuffer(buf)
-	if binary.Read(bbuf, binary.BigEndian, &vecs); err != nil {
+	if err = binary.Read(bbuf, binary.BigEndian, &vecs); err != nil {
 		return
 	}
 	var rows uint32
-	if binary.Read(bbuf, binary.BigEndian, &rows); err != nil {
+	if err = binary.Read(bbuf, binary.BigEndian, &rows); err != nil {
 		return
 	}
 	pos += 2 + 4
@@ -131,7 +131,7 @@ func UnmarshalBatchFrom(r io.Reader) (vecTypes []types.Type, bat batch.IBatch, n
 		col := vector.NewVector(vecTypes[i], uint64(rows))
 		cols[i] = col
 		attrs[i] = i
-		if col.(vector.IVectorNode).Unmarshal(buf[pos : pos+int(lens[i])]); err != nil {
+		if err = col.(vector.IVectorNode).Unmarshal(buf[pos : pos+int(lens[i])]); err != nil {
 			return
 		}
 		pos += int(lens[i])


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

**Which issue(s) this PR fixes:**

issue #2133

**What this PR does / why we need it:**

Fix some apparent cases marked via linter [errcheck](https://github.com/kisielk/errcheck).
```bash
# how to check via errcheck
golangci-lint run --disable-all --max-same-issues 10000 --max-issues-per-linter 10000 -E errcheck
```

**Special notes for your reviewer:**

In the current repository, there are 647 cases marked by `errcheck`:
- 388 cases within test code
- 259 cases within normal code (non-test code)

This PR fix just apparent ones.

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
