### PR TITLE
explain support txn CompileContext

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -955,8 +955,10 @@ func (mce *MysqlCmdExecutor) handleExplainStmt(stmt *tree.ExplainStmt) error {
 	}
 
 	//get query optimizer and execute Optimize
-	mockOptimizer := plan2.NewMockOptimizer()
-	qry, err := mockOptimizer.Optimize(stmt.Statement)
+	buildPlan, err := plan2.BuildPlan(mce.ses.txnCompileCtx, stmt.Statement)
+	if err != nil {
+		return err
+	}
 
 	if err != nil {
 		logutil.Errorf("build query plan and optimize failed, error: %v", err)
@@ -966,7 +968,7 @@ func (mce *MysqlCmdExecutor) handleExplainStmt(stmt *tree.ExplainStmt) error {
 	// build explain data buffer
 	buffer := explain.NewExplainDataBuffer()
 	// generator query explain
-	explainQuery := explain.NewExplainQueryImpl(qry)
+	explainQuery := explain.NewExplainQueryImpl(buildPlan.GetQuery())
 	err = explainQuery.ExplainPlan(buffer, es)
 	if err != nil {
 		logutil.Errorf("explain Query statement error: %v", err)

--- a/pkg/sql/plan2/explain/explain_expr.go
+++ b/pkg/sql/plan2/explain/explain_expr.go
@@ -78,16 +78,12 @@ func describeExpr(expr *plan.Expr, options *ExplainOptions) (string, error) {
 	return result, nil
 }
 
+// generator function expression(Expr_F) explain infomation
 func funcExprExplain(funcExpr *plan.Expr_F, Typ *plan.Type, options *ExplainOptions) (string, error) {
 	// SysFunsAndOperatorsMap
 	var result string
 	funcName := funcExpr.F.GetFunc().GetObjName()
 	funcDef := funcExpr.F.GetFunc()
-	// Get function explain type
-	// funcProtoType, ok := plan2.BuiltinFunctionsMap[funcName]
-	// if !ok {
-	// 	return result, errors.New(errno.InvalidName, "invalid function or opreator name '"+funcName+"'")
-	// }
 
 	funcProtoType, err := function.GetFunctionByID(funcDef.Obj)
 	if err != nil {

--- a/pkg/sql/plan2/explain/explain_node.go
+++ b/pkg/sql/plan2/explain/explain_node.go
@@ -333,7 +333,7 @@ func (ndesc *NodeDescribeImpl) GetGroupByInfo(options *ExplainOptions) (string, 
 }
 
 func (ndesc *NodeDescribeImpl) GetAggregationInfo(options *ExplainOptions) (string, error) {
-	var result string = "Aggregate Functions:"
+	var result string = "Aggregate Functions: "
 	if options.Format == EXPLAIN_FORMAT_TEXT {
 		var first bool = true
 		for _, v := range ndesc.Node.GetAggList() {
@@ -403,6 +403,7 @@ func (c *CostDescribeImpl) GetDescription(options *ExplainOptions) (string, erro
 			" ndv=" + strconv.FormatFloat(c.Cost.Ndv, 'f', 2, 64) +
 			" rowsize=" + strconv.FormatFloat(c.Cost.Rowsize, 'f', 0, 64)
 	}
+
 	return result, nil
 }
 

--- a/pkg/sql/plan2/explain/explain_node.go
+++ b/pkg/sql/plan2/explain/explain_node.go
@@ -119,7 +119,7 @@ func (ndesc *NodeDescribeImpl) GetNodeBasicInfo(options *ExplainOptions) (string
 		case plan.Node_DELETE:
 			result += " on "
 			if ndesc.Node.ObjRef != nil {
-				result += ndesc.Node.ObjRef.GetDbName() + "." + ndesc.Node.ObjRef.GetObjName()
+				result += ndesc.Node.ObjRef.GetSchemaName() + "." + ndesc.Node.ObjRef.GetObjName()
 			} else if ndesc.Node.TableDef != nil {
 				result += ndesc.Node.TableDef.GetName()
 			}
@@ -168,7 +168,16 @@ func (ndesc *NodeDescribeImpl) GetNodeBasicInfo(options *ExplainOptions) (string
 
 	// Get Costs info of Node
 	if options.Format == EXPLAIN_FORMAT_TEXT {
-		result += " (cost=%.2f..%.2f rows=%.0f width=%f)"
+		costDescImpl := &CostDescribeImpl{
+			Cost: ndesc.Node.GetCost(),
+		}
+		costInfo, err := costDescImpl.GetDescription(options)
+		if err != nil {
+			return result, err
+		}
+		result += costInfo
+
+		//result += " (cost=%.2f..%.2f rows=%.0f width=%f)"
 	} else if options.Format == EXPLAIN_FORMAT_JSON {
 		return result, errors.New(errno.FeatureNotSupported, "unimplement explain format json")
 	} else if options.Format == EXPLAIN_FORMAT_DOT {
@@ -383,12 +392,17 @@ type CostDescribeImpl struct {
 
 func (c *CostDescribeImpl) GetDescription(options *ExplainOptions) (string, error) {
 	//(cost=11.75..13.15 rows=140 width=4)
-	var result string = "(cost=" +
-		strconv.FormatFloat(c.Cost.Start, 'f', 2, 64) +
-		".." + strconv.FormatFloat(c.Cost.Total, 'f', 2, 64) +
-		" rows=" + strconv.FormatFloat(c.Cost.Card, 'f', 2, 64) +
-		" ndv=" + strconv.FormatFloat(c.Cost.Ndv, 'f', 2, 64) +
-		" width=" + strconv.FormatFloat(c.Cost.Rowsize, 'f', 0, 64)
+	var result string
+	if c.Cost == nil {
+		result = " (cost=%.2f..%.2f rows=%.2f ndv=%.2f rowsize=%.f)"
+	} else {
+		result = "(cost=" +
+			strconv.FormatFloat(c.Cost.Start, 'f', 2, 64) +
+			".." + strconv.FormatFloat(c.Cost.Total, 'f', 2, 64) +
+			" card=" + strconv.FormatFloat(c.Cost.Card, 'f', 2, 64) +
+			" ndv=" + strconv.FormatFloat(c.Cost.Ndv, 'f', 2, 64) +
+			" rowsize=" + strconv.FormatFloat(c.Cost.Rowsize, 'f', 0, 64)
+	}
 	return result, nil
 }
 

--- a/pkg/sql/plan2/explain/explain_query.go
+++ b/pkg/sql/plan2/explain/explain_query.go
@@ -116,8 +116,12 @@ func traversalPlan(node *plan.Node, Nodes []*plan.Node, settings *FormatSettings
 	settings.level++
 	// Recursive traversal Query Plan
 	if len(node.Children) > 0 {
-		for _, childIndex := range node.Children {
-			err = traversalPlan(Nodes[childIndex], Nodes, settings, options)
+		for _, childNodeId := range node.Children {
+			index, err := serachNodeIndex(childNodeId, Nodes)
+			if err != nil {
+				return err
+			}
+			err = traversalPlan(Nodes[index], Nodes, settings, options)
 			if err != nil {
 				return err
 			}
@@ -125,4 +129,14 @@ func traversalPlan(node *plan.Node, Nodes []*plan.Node, settings *FormatSettings
 	}
 	settings.level--
 	return nil
+}
+
+// serach target node's index in Nodes slice
+func serachNodeIndex(nodeId int32, Nodes []*plan.Node) (int32, error) {
+	for i, node := range Nodes {
+		if node.NodeId == nodeId {
+			return int32(i), nil
+		}
+	}
+	return -1, errors.New(errno.InternalError, "Invalid Plan nodeId")
 }

--- a/pkg/sql/plan2/explain/explain_test.go
+++ b/pkg/sql/plan2/explain/explain_test.go
@@ -33,7 +33,18 @@ func TestSingleSql(t *testing.T) {
 	// input := "explain verbose select c_custkey from (select c_custkey from CUSTOMER group by c_custkey ) a"
 	// input := "explain SELECT N_NAME, N_REGIONKEY FROM NATION WHERE N_REGIONKEY > 0 AND N_NAME LIKE '%AA'"
 	// input := "explain verbose SELECT N_NAME, N_REGIONKEY a FROM NATION WHERE N_NATIONKEY > 0 AND N_NATIONKEY < 10"
-	input := "explain verbose SELECT N_NAME, N_REGIONKEY a FROM NATION WHERE N_NATIONKEY > 0 OR N_NATIONKEY < 10"
+	//input := "explain verbose SELECT N_NAME, N_REGIONKEY a FROM NATION WHERE N_NATIONKEY > 0 OR N_NATIONKEY < 10"
+	//input := "explain verbose select * from part where p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')"
+	input := `explain verbose 
+         select 
+              case 
+                   when p_type like 'PROMO%' 
+                       then l_extendedprice * (1 - l_discount)
+                   when p_type like 'PRX%' 
+                       then l_extendedprice * (2 - l_discount)
+              else 0 end
+		from lineitem,part 
+		where l_shipdate < date '1996-04-01' + interval '1 month'`
 
 	mock := plan2.NewMockOptimizer()
 	err := runOneStmt(mock, t, input)

--- a/pkg/sql/plan2/function/operators.go
+++ b/pkg/sql/plan2/function/operators.go
@@ -1377,7 +1377,7 @@ var operators = map[int][]Function{
 		{
 			Index:     0,
 			Flag:      plan.Function_STRICT,
-			Layout:    EXISTS_ANY_PREDICATE,
+			Layout:    IN_PREDICATE,
 			ReturnTyp: types.T_bool,
 			TypeCheckFn: func(inputTypes []types.T, _ []types.T) (match bool) {
 				if len(inputTypes) == 2 && inputTypes[1] == types.T_tuple {


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #2363

**What this PR does / why we need it:**
1. After the implementation of CompilerContext, explain needs to replace the original mock Compiler Context to support the explain operation of normal SQL
2. Note that the explain function is based on plan2, so you need to Set the 'usePlan' option to true which 
in the configuration file 'system_vars_config.toml'

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
