### PR TITLE
fix(docs): Dead link in CN README

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -138,8 +138,7 @@ MatrixOne的架构图如下图所示：
   <img alt="MatrixOne" height="500" width="700" src="https://github.com/matrixorigin/artwork/blob/main/docs/overview/overall-architecture.png?raw=true">
 </p>
 
-关于更详细的MatrixOne技术架构，可以参考[MatrixOne架构](https://docs.matrixorigin.io/cn/0.3.0/MatrixOne/Overview/matrixone-architecture/)与[MatrixOne技术设计](https://docs.matrixorigin.cn/0.3.0/MatrixOne/Overview/MatrixOne-Tech-Design/matrixone-techdesign/)
-
+关于更详细的MatrixOne技术架构，可以参考[MatrixOne架构](https://docs.matrixorigin.io/cn/0.3.0/MatrixOne/Overview/matrixone-architecture/)与[MatrixOne技术设计](https://docs.matrixorigin.io/cn/0.3.0/MatrixOne/Overview/MatrixOne-Tech-Design/matrixone-techdesign/)
 
 ## ⚡️ <a id="quick-start">快速上手</a>
 


### PR DESCRIPTION
Signed-off-by: ericsyh <ericshenyuhao@outlook.com>

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [x] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

Fix the dead link in README_CN. Change the link address from https://docs.matrixorigin.cn/0.3.0/MatrixOne/Overview/MatrixOne-Tech-Design/matrixone-techdesign/ to https://docs.matrixorigin.io/cn/0.3.0/MatrixOne/Overview/MatrixOne-Tech-Design/matrixone-techdesign/

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
