### PR TITLE
fix bug 2969(return column name is wrong)

### DIFF
--- a/pkg/sql/plan2/build_test.go
+++ b/pkg/sql/plan2/build_test.go
@@ -30,7 +30,7 @@ func TestSingleSql(t *testing.T) {
 	// sql := `SELECT * FROM (SELECT relname as Tables_in_mo FROM mo_tables WHERE reldatabase = 'mo') a`
 	// sql := "SELECT nation2.* FROM nation2 natural join region"
 	// sql := `select n_name, avg(N_REGIONKEY) t from NATION where n_name != 'a' group by n_name having avg(N_REGIONKEY) > 10 order by t limit 20`
-	sql := `select date_add('1997-12-31 23:59:59',INTERVAL 100000 SECOND)`
+	sql := `select distinct(n_name), ((abs(n_regionkey))) from nation`
 	// stmts, err := mysql.Parse(sql)
 	// if err != nil {
 	// 	t.Fatalf("%+v", err)
@@ -410,6 +410,7 @@ func TestSingleTableSqlBuilder(t *testing.T) {
 		"SELECT -1",
 		"select date_add('1997-12-31 23:59:59',INTERVAL 100000 SECOND)",
 		"select date_sub('1997-12-31 23:59:59',INTERVAL 2 HOUR)",
+		"select distinct(n_name), ((abs(n_regionkey))) from nation",
 	}
 	runTestShouldPass(mock, t, sqls, false, false)
 

--- a/pkg/sql/plan2/query_builder.go
+++ b/pkg/sql/plan2/query_builder.go
@@ -326,7 +326,14 @@ func (builder *QueryBuilder) buildSelect(stmt *tree.Select, ctx *BindContext, is
 			if len(selectExpr.As) > 0 {
 				ctx.headings = append(ctx.headings, string(selectExpr.As))
 			} else {
-				ctx.headings = append(ctx.headings, tree.String(selectExpr.Expr, dialect.MYSQL))
+				for {
+					if parenExpr, ok := expr.(*tree.ParenExpr); ok {
+						expr = parenExpr.Expr
+					} else {
+						break
+					}
+				}
+				ctx.headings = append(ctx.headings, tree.String(expr, dialect.MYSQL))
 			}
 
 			err = ctx.qualifyColumnNames(expr)


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #2969 

**What this PR does / why we need it:**

these sqls:
select distinct(col1) from tbl
select (col1) from tbl
select ((col1)) from tbl

will return column:  col1

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
