### PR TITLE
logservice: use sync.Pool to avoid morpc allocations

### DIFF
--- a/pkg/logservice/client.go
+++ b/pkg/logservice/client.go
@@ -16,6 +16,7 @@ package logservice
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -64,18 +65,26 @@ type client struct {
 	cfg    LogServiceClientConfig
 	client morpc.RPCClient
 	addr   string
+	req    *RPCRequest
+	pool   *sync.Pool
 }
 
 var _ Client = (*client)(nil)
 
 func CreateClient(ctx context.Context,
 	name string, cfg LogServiceClientConfig) (Client, error) {
+	pool := &sync.Pool{}
+	pool.New = func() interface{} {
+		return &RPCResponse{pool: pool}
+	}
 	c := &client{
-		cfg: cfg,
+		cfg:  cfg,
+		req:  &RPCRequest{},
+		pool: pool,
 	}
 	var e error
 	for _, addr := range cfg.ServiceAddresses {
-		cc, err := getRPCClient(ctx, addr)
+		cc, err := getRPCClient(ctx, addr, c.pool)
 		if err != nil {
 			e = err
 			continue
@@ -161,17 +170,14 @@ func (c *client) request(ctx context.Context,
 		Index:   index,
 		MaxSize: maxSize,
 	}
-	rr := &RPCRequest{
-		Request: req,
-		payload: payload,
-	}
-	// FIXME: fix SendOption
-	// FIXME: how to avoid allocation here?
+	c.req.Request = req
+	c.req.payload = payload
 	future, err := c.client.Send(ctx,
-		c.addr, rr, morpc.SendOptions{Timeout: time.Duration(timeout)})
+		c.addr, c.req, morpc.SendOptions{Timeout: time.Duration(timeout)})
 	if err != nil {
 		return pb.Response{}, nil, err
 	}
+	defer future.Close()
 	msg, err := future.Get()
 	if err != nil {
 		return pb.Response{}, nil, err
@@ -180,6 +186,8 @@ func (c *client) request(ctx context.Context,
 	if !ok {
 		panic("unexpected response type")
 	}
+	resp := response.Response
+	defer response.Release()
 	var recs pb.LogRecordResponse
 	if len(response.payload) > 0 {
 		MustUnmarshal(&recs, response.payload)
@@ -188,7 +196,7 @@ func (c *client) request(ctx context.Context,
 	if err != nil {
 		return pb.Response{}, nil, err
 	}
-	return response.Response, recs.Records, nil
+	return resp, recs.Records, nil
 }
 
 func (c *client) connect(ctx context.Context, mt pb.MethodType) error {
@@ -226,12 +234,11 @@ func (c *client) getTruncatedIndex(ctx context.Context) (Lsn, error) {
 	return resp.Index, nil
 }
 
-func getRPCClient(ctx context.Context, target string) (morpc.RPCClient, error) {
+func getRPCClient(ctx context.Context, target string, pool *sync.Pool) (morpc.RPCClient, error) {
 	mf := func() morpc.Message {
-		return &RPCResponse{}
+		return pool.Get().(*RPCResponse)
 	}
 	codec := morpc.NewMessageCodec(mf, defaultWriteSocketSize)
-	// FIXME: set options
 	bf := morpc.NewGoettyBasedBackendFactory(codec,
 		morpc.WithBackendConnectWhenCreate(),
 		morpc.WithBackendConnectTimeout(connectionTimeout))

--- a/pkg/logservice/client_test.go
+++ b/pkg/logservice/client_test.go
@@ -129,7 +129,7 @@ func TestClientRead(t *testing.T) {
 		recs, lsn, err := c.Read(ctx, 4, math.MaxUint64)
 		require.NoError(t, err)
 		assert.Equal(t, uint64(4), lsn)
-		assert.Equal(t, 2, len(recs))
+		require.Equal(t, 2, len(recs))
 		assert.Equal(t, cmd, recs[0].Data)
 		assert.Equal(t, cmd2, recs[1].Data)
 


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

Use sync.Pool to avoid allocations in morpc.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
