### PR TITLE
add information functions 

### DIFF
--- a/cmd/generate-config/system_vars_def.toml
+++ b/cmd/generate-config/system_vars_def.toml
@@ -448,6 +448,15 @@ values = ["true", "false"]
 comment = "default is true. if true, metrics can be scraped through host:status/metrics endpoint"
 update-mode = "dynamic"
 
+[[parameter]]
+name = "enableMetric"
+scope = ["global"]
+access = ["file"]
+type = "bool"
+domain-type = "set"
+values = ["true", "false"]
+comment = "default is true. if true, enable metric at booting"
+update-mode = "dynamic"
 
 # Cluster Configs
 pre-allocated-group-num = 20

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -68,7 +68,7 @@ func InitServerVersion(v string) {
 			serverVersion = string(vv)
 		}
 	} else {
-		serverVersion = "0.3.0"
+		serverVersion = "0.5.0"
 	}
 }
 

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -223,7 +223,7 @@ func (ses *Session) SetGlobalVar(name string, value interface{}) error {
 // GetGlobalVar gets this value of the system variable in global
 func (ses *Session) GetGlobalVar(name string) (interface{}, error) {
 	if def, val, ok := ses.gSysVars.GetGlobalSysVar(name); ok {
-		if def.Scope == ScopeSession {
+		if def.GetScope() == ScopeSession {
 			//empty
 			return nil, errorSystemVariableSessionEmpty
 		}
@@ -239,19 +239,19 @@ func (ses *Session) GetTxnCompileCtx() *TxnCompilerContext {
 // SetSessionVar sets the value of system variable in session
 func (ses *Session) SetSessionVar(name string, value interface{}) error {
 	if def, _, ok := ses.gSysVars.GetGlobalSysVar(name); ok {
-		if def.Scope == ScopeGlobal {
+		if def.GetScope() == ScopeGlobal {
 			return errorSystemVariableIsGlobal
 		}
 		//scope session & both
-		if !def.Dynamic {
+		if !def.GetDynamic() {
 			return errorSystemVariableIsReadOnly
 		}
 
-		cv, err := def.Type.Convert(value)
+		cv, err := def.GetType().Convert(value)
 		if err != nil {
 			return err
 		}
-		ses.sysVars[def.Name] = cv
+		ses.sysVars[def.GetName()] = cv
 	} else {
 		return errorSystemVariableDoesNotExist
 	}
@@ -262,7 +262,7 @@ func (ses *Session) SetSessionVar(name string, value interface{}) error {
 func (ses *Session) GetSessionVar(name string) (interface{}, error) {
 	if def, gVal, ok := ses.gSysVars.GetGlobalSysVar(name); ok {
 		ciname := strings.ToLower(name)
-		if def.Scope == ScopeGlobal {
+		if def.GetScope() == ScopeGlobal {
 			return gVal, nil
 		}
 		return ses.sysVars[ciname], nil
@@ -332,8 +332,16 @@ func (ses *Session) SetDatabaseName(db string) {
 	ses.txnCompileCtx.SetDatabase(db)
 }
 
+func (ses *Session) DatabaseNameIsEmpty() bool {
+	return len(ses.GetDatabaseName()) == 0
+}
+
 func (ses *Session) GetUserName() string {
 	return ses.protocol.GetUserName()
+}
+
+func (ses *Session) SetUserName(uname string) {
+	ses.protocol.SetUserName(uname)
 }
 
 func (th *TxnHandler) GetStorage() engine.Engine {
@@ -602,9 +610,6 @@ type TxnCompilerContext struct {
 }
 
 func InitTxnCompilerContext(txn *TxnHandler, db string) *TxnCompilerContext {
-	if len(db) == 0 {
-		db = "mo_catalog"
-	}
 	return &TxnCompilerContext{txnHandler: txn, dbName: db, QryTyp: TXN_DEFAULT}
 }
 
@@ -636,16 +641,17 @@ func (tcc *TxnCompilerContext) DatabaseExists(name string) bool {
 	return true
 }
 
-func (tcc *TxnCompilerContext) Resolve(dbName string, tableName string) (*plan2.ObjectRef, *plan2.TableDef) {
-	if len(dbName) == 0 {
-		dbName = tcc.DefaultDatabase()
+func (tcc *TxnCompilerContext) getRelation(dbName string, tableName string) (engine.Relation, error) {
+	dbName, err := tcc.ensureDatabaseIsNotEmpty(dbName)
+	if err != nil {
+		return nil, err
 	}
 
 	//open database
 	db, err := tcc.txnHandler.GetStorage().Database(dbName, tcc.txnHandler.GetTxn().GetCtx())
 	if err != nil {
 		logutil.Errorf("get database %v error %v", dbName, err)
-		return nil, nil
+		return nil, err
 	}
 
 	tableNames := db.Relations(tcc.txnHandler.GetTxn().GetCtx())
@@ -655,9 +661,30 @@ func (tcc *TxnCompilerContext) Resolve(dbName string, tableName string) (*plan2.
 	table, err := db.Relation(tableName, tcc.txnHandler.GetTxn().GetCtx())
 	if err != nil {
 		logutil.Errorf("get table %v error %v", tableName, err)
+		return nil, err
+	}
+	return table, nil
+}
+
+func (tcc *TxnCompilerContext) ensureDatabaseIsNotEmpty(dbName string) (string, error) {
+	if len(dbName) == 0 {
+		dbName = tcc.DefaultDatabase()
+	}
+	if len(dbName) == 0 {
+		return "", NewMysqlError(ER_NO_DB_ERROR)
+	}
+	return dbName, nil
+}
+
+func (tcc *TxnCompilerContext) Resolve(dbName string, tableName string) (*plan2.ObjectRef, *plan2.TableDef) {
+	dbName, err := tcc.ensureDatabaseIsNotEmpty(dbName)
+	if err != nil {
 		return nil, nil
 	}
-
+	table, err := tcc.getRelation(dbName, tableName)
+	if err != nil {
+		return nil, nil
+	}
 	engineDefs := table.TableDefs(tcc.txnHandler.GetTxn().GetCtx())
 
 	var defs []*plan2.ColDef
@@ -717,24 +744,12 @@ func (tcc *TxnCompilerContext) ResolveVariable(varName string, isSystemVar, isGl
 }
 
 func (tcc *TxnCompilerContext) GetPrimaryKeyDef(dbName string, tableName string) []*plan2.ColDef {
-	if len(dbName) == 0 {
-		dbName = tcc.DefaultDatabase()
-	}
-
-	//open database
-	db, err := tcc.txnHandler.GetStorage().Database(dbName, tcc.txnHandler.GetTxn().GetCtx())
+	dbName, err := tcc.ensureDatabaseIsNotEmpty(dbName)
 	if err != nil {
-		logutil.Errorf("get database %v error %v", dbName, err)
 		return nil
 	}
-
-	tableNames := db.Relations(tcc.txnHandler.GetTxn().GetCtx())
-	logutil.Infof("dbName %v tableNames %v", dbName, tableNames)
-
-	//open table
-	relation, err := db.Relation(tableName, tcc.txnHandler.GetTxn().GetCtx())
+	relation, err := tcc.getRelation(dbName, tableName)
 	if err != nil {
-		logutil.Errorf("get table %v error %v", tableName, err)
 		return nil
 	}
 
@@ -761,24 +776,12 @@ func (tcc *TxnCompilerContext) GetPrimaryKeyDef(dbName string, tableName string)
 }
 
 func (tcc *TxnCompilerContext) GetHideKeyDef(dbName string, tableName string) *plan2.ColDef {
-	if len(dbName) == 0 {
-		dbName = tcc.DefaultDatabase()
-	}
-
-	//open database
-	db, err := tcc.txnHandler.GetStorage().Database(dbName, tcc.txnHandler.GetTxn().GetCtx())
+	dbName, err := tcc.ensureDatabaseIsNotEmpty(dbName)
 	if err != nil {
-		logutil.Errorf("get database %v error %v", dbName, err)
 		return nil
 	}
-
-	tableNames := db.Relations(tcc.txnHandler.GetTxn().GetCtx())
-	logutil.Infof("dbName %v tableNames %v", dbName, tableNames)
-
-	//open table
-	relation, err := db.Relation(tableName, tcc.txnHandler.GetTxn().GetCtx())
+	relation, err := tcc.getRelation(dbName, tableName)
 	if err != nil {
-		logutil.Errorf("get table %v error %v", tableName, err)
 		return nil
 	}
 
@@ -802,5 +805,16 @@ func (tcc *TxnCompilerContext) GetHideKeyDef(dbName string, tableName string) *p
 }
 
 func (tcc *TxnCompilerContext) Cost(obj *plan2.ObjectRef, e *plan2.Expr) *plan2.Cost {
-	return &plan2.Cost{}
+	dbName := obj.GetSchemaName()
+	tableName := obj.GetObjName()
+	dbName, err := tcc.ensureDatabaseIsNotEmpty(dbName)
+	if err != nil {
+		return nil
+	}
+	table, err := tcc.getRelation(dbName, tableName)
+	if err != nil {
+		return nil
+	}
+	rows := table.Rows()
+	return &plan2.Cost{Card: float64(rows)}
 }

--- a/pkg/frontend/types.go
+++ b/pkg/frontend/types.go
@@ -2,7 +2,9 @@ package frontend
 
 import (
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/aoe"
 )
 
 type ComputationRunner interface {
@@ -21,4 +23,42 @@ type ComputationWrapper interface {
 	GetAffectedRows() uint64
 
 	Compile(u interface{}, fill func(interface{}, *batch.Batch) error) (interface{}, error)
+}
+
+type ColumnInfo interface {
+	GetName() string
+
+	GetType() types.T
+}
+
+var _ ColumnInfo = &aoeColumnInfo{}
+var _ ColumnInfo = &engineColumnInfo{}
+
+type aoeColumnInfo struct {
+	info aoe.ColumnInfo
+}
+
+func (ac *aoeColumnInfo) GetName() string {
+	return ac.info.Name
+}
+
+func (ac *aoeColumnInfo) GetType() types.T {
+	return ac.info.Type.Oid
+}
+
+type TableInfo interface {
+	GetColumns()
+}
+
+type engineColumnInfo struct {
+	name string
+	typ  types.Type
+}
+
+func (ec *engineColumnInfo) GetName() string {
+	return ec.name
+}
+
+func (ec *engineColumnInfo) GetType() types.T {
+	return ec.typ.Oid
 }

--- a/pkg/sql/compile2/scope.go
+++ b/pkg/sql/compile2/scope.go
@@ -462,6 +462,7 @@ func (s *Scope) ParallelRun(e engine.Engine) error {
 		ss[i].Proc.Lim = s.Proc.Lim
 		ss[i].Proc.UnixTime = s.Proc.UnixTime
 		ss[i].Proc.Snapshot = s.Proc.Snapshot
+		ss[i].Proc.SessionInfo = s.Proc.SessionInfo
 	}
 	{
 		var flg bool

--- a/pkg/sql/plan2/function/builtin/unary/infomation_function.go
+++ b/pkg/sql/plan2/function/builtin/unary/infomation_function.go
@@ -1,0 +1,315 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unary
+
+import (
+	"errors"
+	"github.com/matrixorigin/matrixone/pkg/container/nulls"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+var (
+	errorParameterIsInvalid = errors.New("the parameter is invalid")
+)
+
+/*
+These functions get information from the session and system status.
+*/
+
+//
+func adapter(vectors []*vector.Vector,
+	proc *process.Process,
+	resultType types.Type,
+	parameterCount int,
+	evaluateMemoryCapacityForJobFunc func(proc *process.Process, params ...interface{}) (int, error),
+	jobFunc func(proc *process.Process, params ...interface{}) (interface{}, error),
+) (*vector.Vector, error) {
+	if parameterCount == 0 {
+		//step 1: evaluate the capacity for result vector
+		capacity, err := evaluateMemoryCapacityForJobFunc(proc)
+		if err != nil {
+			return nil, err
+		}
+		//step 2: allocate the memory for the result
+		var resultSpace interface{}
+		switch resultType.Oid {
+		case types.T_varchar, types.T_char:
+			resultSpace = &types.Bytes{
+				Data:    make([]byte, capacity),
+				Offsets: make([]uint32, 1),
+				Lengths: make([]uint32, 1),
+			}
+		case types.T_uint64:
+			resultSpace = make([]uint64, 1)
+		}
+		//step 3: evaluate the function and get the result
+		result, err := jobFunc(proc, resultSpace)
+		if err != nil {
+			return nil, err
+		}
+		//step 4: fill the result vector
+		resultVector := vector.NewConst(resultType)
+		if result == nil {
+			nulls.Add(resultVector.Nsp, 0)
+		} else {
+			vector.SetCol(resultVector, result)
+		}
+		return resultVector, nil
+	}
+	return nil, errorParameterIsInvalid
+}
+
+func fillString(str string, dst *types.Bytes) error {
+	if dst == nil ||
+		dst.Data == nil ||
+		dst.Offsets == nil ||
+		dst.Lengths == nil ||
+		len(dst.Offsets) != len(dst.Lengths) {
+		return errorParameterIsInvalid
+	}
+	l := len(dst.Data)
+	copy(dst.Data, []byte(str)[:l])
+	dst.Offsets[0] = 0
+	dst.Lengths[0] = uint32(l)
+	return nil
+}
+
+func evaluateMemoryCapacityForDatabase(proc *process.Process, params ...interface{}) (int, error) {
+	return len(proc.SessionInfo.GetDatabase()), nil
+}
+
+func doDatabase(proc *process.Process, params ...interface{}) (interface{}, error) {
+	result := params[0].(*types.Bytes)
+	dbName := proc.SessionInfo.GetDatabase()
+	if len(dbName) == 0 {
+		return nil, nil
+	}
+	err := fillString(dbName, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// Database returns the default (current) database name
+func Database(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_varchar.ToType(),
+		0,
+		evaluateMemoryCapacityForDatabase,
+		doDatabase)
+}
+
+func evaluateMemoryCapacityForUser(proc *process.Process, params ...interface{}) (int, error) {
+	return len(proc.SessionInfo.GetUserHost()), nil
+}
+
+func doUser(proc *process.Process, params ...interface{}) (interface{}, error) {
+	result := params[0].(*types.Bytes)
+	err := fillString(proc.SessionInfo.GetUserHost(), result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// User returns the user name and host name provided by the client
+func User(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_varchar.ToType(),
+		0,
+		evaluateMemoryCapacityForUser,
+		doUser)
+}
+
+func evaluateMemoryCapacityForConnectionID(proc *process.Process, params ...interface{}) (int, error) {
+	return 8, nil
+}
+
+func doConnectionID(proc *process.Process, params ...interface{}) (interface{}, error) {
+	result := params[0].([]uint64)
+	result[0] = proc.SessionInfo.ConnectionID
+	return result, nil
+}
+
+// ConnectionID returns the connection ID (thread ID) for the connection
+func ConnectionID(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_uint64.ToType(),
+		0,
+		evaluateMemoryCapacityForConnectionID,
+		doConnectionID)
+}
+
+func evaluateMemoryCapacityForCharset(proc *process.Process, params ...interface{}) (int, error) {
+	return len(proc.SessionInfo.GetCharset()), nil
+}
+
+func doCharset(proc *process.Process, params ...interface{}) (interface{}, error) {
+	result := params[0].(*types.Bytes)
+	err := fillString(proc.SessionInfo.GetCharset(), result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// Charset returns the character set of the argument
+func Charset(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	//TODO: even the charset has one parameter but
+	//the result is utf8 always. So, we do not process the parameter
+	return adapter(vectors, proc, types.T_varchar.ToType(),
+		0,
+		evaluateMemoryCapacityForCharset,
+		doCharset)
+}
+
+func evaluateMemoryCapacityForCurrentRole(proc *process.Process, params ...interface{}) (int, error) {
+	return len(proc.SessionInfo.GetRole()), nil
+}
+
+func doCurrentRole(proc *process.Process, params ...interface{}) (interface{}, error) {
+	result := params[0].(*types.Bytes)
+	role := proc.SessionInfo.GetRole()
+	if len(role) == 0 {
+		return nil, nil
+	}
+	err := fillString(role, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// Current_Role returns the current active roles
+func CurrentRole(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_varchar.ToType(),
+		0,
+		evaluateMemoryCapacityForCurrentRole,
+		doCurrentRole)
+}
+
+func evaluateMemoryCapacityForFoundRows(proc *process.Process, params ...interface{}) (int, error) {
+	return 8, nil
+}
+
+func doFoundRows(proc *process.Process, params ...interface{}) (interface{}, error) {
+	result := params[0].([]uint64)
+	result[0] = 0
+	return result, nil
+}
+
+// For a SELECT with a LIMIT clause, the number of rows that would be returned were there no LIMIT clause
+func FoundRows(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_uint64.ToType(),
+		0,
+		evaluateMemoryCapacityForFoundRows,
+		doFoundRows)
+}
+
+// ICU library version
+func ICULIBVersion(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_varchar.ToType(), 0,
+		func(proc *process.Process, params ...interface{}) (int, error) {
+			return 0, nil
+		},
+		func(proc *process.Process, params ...interface{}) (interface{}, error) {
+			result := params[0].(*types.Bytes)
+			err := fillString("", result)
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+	)
+}
+
+// Value of the AUTOINCREMENT column for the last INSERT
+func LastInsertID(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_uint64.ToType(), 0,
+		func(proc *process.Process, params ...interface{}) (int, error) {
+			return 0, nil
+		},
+		func(proc *process.Process, params ...interface{}) (interface{}, error) {
+			result := params[0].([]uint64)
+			result[0] = 0
+			return result, nil
+		},
+	)
+}
+
+//RolesGraphml returns a GraphML document representing memory role subgraphs
+func RolesGraphml(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_varchar.ToType(), 0,
+		func(proc *process.Process, params ...interface{}) (int, error) {
+			return 0, nil
+		},
+		func(proc *process.Process, params ...interface{}) (interface{}, error) {
+			result := params[0].(*types.Bytes)
+			err := fillString("", result)
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+	)
+}
+
+//RowCount returns The number of rows updated
+func RowCount(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_uint64.ToType(), 0,
+		func(proc *process.Process, params ...interface{}) (int, error) {
+			return 0, nil
+		},
+		func(proc *process.Process, params ...interface{}) (interface{}, error) {
+			result := params[0].([]uint64)
+			result[0] = 0
+			return result, nil
+		},
+	)
+}
+
+//	Return a string that indicates the MySQL server version
+func Version(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_varchar.ToType(), 0,
+		func(proc *process.Process, params ...interface{}) (int, error) {
+			return len(proc.SessionInfo.GetVersion()), nil
+		},
+		func(proc *process.Process, params ...interface{}) (interface{}, error) {
+			result := params[0].(*types.Bytes)
+			err := fillString(proc.SessionInfo.GetVersion(), result)
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+	)
+}
+
+//Collation	returns the collation of the string argument
+func Collation(vectors []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
+	return adapter(vectors, proc, types.T_varchar.ToType(), 0,
+		func(proc *process.Process, params ...interface{}) (int, error) {
+			return len(proc.SessionInfo.GetCollation()), nil
+		},
+		func(proc *process.Process, params ...interface{}) (interface{}, error) {
+			result := params[0].(*types.Bytes)
+			err := fillString(proc.SessionInfo.GetCollation(), result)
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		},
+	)
+}

--- a/pkg/sql/plan2/function/buitins.go
+++ b/pkg/sql/plan2/function/buitins.go
@@ -2229,4 +2229,172 @@ var builtins = map[int]Functions{
 			},
 		},
 	},
+	DATABASE: {
+		Id: DATABASE,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{},
+				ReturnTyp: types.T_varchar,
+				Fn:        unary.Database,
+			},
+		},
+	},
+	USER: {
+		Id: USER,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{},
+				ReturnTyp: types.T_varchar,
+				Fn:        unary.User,
+			},
+		},
+	},
+	CONNECTION_ID: {
+		Id: CONNECTION_ID,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{},
+				ReturnTyp: types.T_uint64,
+				Fn:        unary.ConnectionID,
+			},
+		},
+	},
+	CHARSET: {
+		Id: CHARSET,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{types.T_varchar},
+				ReturnTyp: types.T_varchar,
+				Fn:        unary.Charset,
+			},
+		},
+	},
+	CURRENT_ROLE: {
+		Id: CURRENT_ROLE,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{},
+				ReturnTyp: types.T_varchar,
+				Fn:        unary.CurrentRole,
+			},
+		},
+	},
+	FOUND_ROWS: {
+		Id: FOUND_ROWS,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{},
+				ReturnTyp: types.T_uint64,
+				Fn:        unary.FoundRows,
+			},
+		},
+	},
+	ICULIBVERSION: {
+		Id: ICULIBVERSION,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{},
+				ReturnTyp: types.T_varchar,
+				Fn:        unary.ICULIBVersion,
+			},
+		},
+	},
+	LAST_INSERT_ID: {
+		Id: LAST_INSERT_ID,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{},
+				ReturnTyp: types.T_uint64,
+				Fn:        unary.LastInsertID,
+			},
+		},
+	},
+	ROLES_GRAPHML: {
+		Id: ROLES_GRAPHML,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{},
+				ReturnTyp: types.T_varchar,
+				Fn:        unary.RolesGraphml,
+			},
+		},
+	},
+	ROW_COUNT: {
+		Id: ROW_COUNT,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{},
+				ReturnTyp: types.T_uint64,
+				Fn:        unary.RowCount,
+			},
+		},
+	},
+	VERSION: {
+		Id: VERSION,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{},
+				ReturnTyp: types.T_varchar,
+				Fn:        unary.Version,
+			},
+		},
+	},
+	COLLATION: {
+		Id: COLLATION,
+		Overloads: []Function{
+			{
+				Index:     0,
+				Volatile:  true,
+				Flag:      plan.Function_STRICT,
+				Layout:    STANDARD_FUNCTION,
+				Args:      []types.T{types.T_varchar},
+				ReturnTyp: types.T_varchar,
+				Fn:        unary.Collation,
+			},
+		},
+	},
 }

--- a/pkg/sql/plan2/function/function_id.go
+++ b/pkg/sql/plan2/function/function_id.go
@@ -204,7 +204,23 @@ const (
 	DATE_SUB              // DATE_SUB
 	APPROX_COUNT_DISTINCT // APPROX_COUNT_DISTINCT, special aggregate
 
+	//information functions
+	//Reference to : https://dev.mysql.com/doc/refman/8.0/en/information-functions.html
+	DATABASE
+	USER
+	CONNECTION_ID
+	CHARSET
+	CURRENT_ROLE
+	FOUND_ROWS
+	ICULIBVERSION
+	LAST_INSERT_ID
+	ROLES_GRAPHML
+	ROW_COUNT
+	VERSION
+	COLLATION
+
 	TIMESTAMP // TIMESTAMP
+
 	// FUNCTION_END_NUMBER is not a function, just a flag to record the max number of function.
 	// TODO: every one should put the new function id in front of this one if you want to make a new function.
 	FUNCTION_END_NUMBER
@@ -290,40 +306,56 @@ var functionIdRegister = map[string]int32{
 	"from_unixtime":     FROM_UNIXTIME,
 	// unary functions
 	// whoever edit this, please follow the lexical order, or come up with a better ordering method
-	"abs":         ABS,
-	"acos":        ACOS,
-	"bit_length":  BIT_LENGTH,
-	"date":        DATE,
-	"day":         DAY,
-	"dayofyear":   DAYOFYEAR,
-	"exp":         EXP,
-	"empty":       EMPTY,
-	"length":      LENGTH,
-	"lengthutf8":  LENGTH_UTF8,
-	"char_length": LENGTH_UTF8,
-	"ln":          LN,
-	"log":         LOG,
-	"ltrim":       LTRIM,
-	"month":       MONTH,
-	"oct":         OCT,
-	"reverse":     REVERSE,
-	"rtrim":       RTRIM,
-	"sin":         SIN,
-	"sinh":        SINH,
-	"space":       SPACE,
-	"tan":         TAN,
-	"week":        WEEK,
-	"weekday":     WEEKDAY,
-	"year":        YEAR,
-	"extract":     EXTRACT,
-	"if":          IFF,
-	"iff":         IFF,
-	"date_add":    DATE_ADD,
-	"date_sub":    DATE_SUB,
-	"atan":        ATAN,
-	"cos":         COS,
-	"cot":         COT,
-	"timestamp":   TIMESTAMP,
+	"abs":            ABS,
+	"acos":           ACOS,
+	"bit_length":     BIT_LENGTH,
+	"date":           DATE,
+	"day":            DAY,
+	"dayofyear":      DAYOFYEAR,
+	"exp":            EXP,
+	"empty":          EMPTY,
+	"length":         LENGTH,
+	"lengthutf8":     LENGTH_UTF8,
+	"char_length":    LENGTH_UTF8,
+	"ln":             LN,
+	"log":            LOG,
+	"ltrim":          LTRIM,
+	"month":          MONTH,
+	"oct":            OCT,
+	"reverse":        REVERSE,
+	"rtrim":          RTRIM,
+	"sin":            SIN,
+	"sinh":           SINH,
+	"space":          SPACE,
+	"tan":            TAN,
+	"week":           WEEK,
+	"weekday":        WEEKDAY,
+	"year":           YEAR,
+	"extract":        EXTRACT,
+	"if":             IFF,
+	"iff":            IFF,
+	"date_add":       DATE_ADD,
+	"date_sub":       DATE_SUB,
+	"atan":           ATAN,
+	"cos":            COS,
+	"cot":            COT,
+	"timestamp":      TIMESTAMP,
+	"database":       DATABASE,
+	"schema":         DATABASE,
+	"user":           USER,
+	"system_user":    USER,
+	"session_user":   USER,
+	"current_user":   USER,
+	"connection_id":  CONNECTION_ID,
+	"charset":        CHARSET,
+	"current_role":   CURRENT_ROLE,
+	"found_rows":     FOUND_ROWS,
+	"icu_version":    ICULIBVERSION,
+	"last_insert_id": LAST_INSERT_ID,
+	"roles_graphml":  ROLES_GRAPHML,
+	"row_count":      ROW_COUNT,
+	"version":        VERSION,
+	"collation":      COLLATION,
 }
 
 func GetFunctionIsWinfunByName(name string) bool {

--- a/pkg/vm/process/process.go
+++ b/pkg/vm/process/process.go
@@ -40,6 +40,7 @@ func NewFromProc(m *mheap.Mheap, p *Process, regNumber int) *Process {
 	proc.Lim = p.Lim
 	proc.UnixTime = p.UnixTime
 	proc.Snapshot = p.Snapshot
+	proc.SessionInfo = p.SessionInfo
 	// reg and cancel
 	proc.Cancel = cancel
 	proc.Reg.MergeReceivers = make([]*WaitRegister, regNumber)

--- a/pkg/vm/process/types.go
+++ b/pkg/vm/process/types.go
@@ -55,6 +55,52 @@ type Limitation struct {
 	PartitionRows int64
 }
 
+// session information
+type SessionInfo struct {
+	User         string
+	Host         string
+	Role         string
+	ConnectionID uint64
+	Database     string
+	Version      string
+}
+
+func (si *SessionInfo) GetUser() string {
+	return si.User
+}
+
+func (si *SessionInfo) GetHost() string {
+	return si.Host
+}
+
+func (si *SessionInfo) GetUserHost() string {
+	return si.User + "@" + si.Host
+}
+
+func (si *SessionInfo) GetRole() string {
+	return si.Role
+}
+
+func (si *SessionInfo) GetCharset() string {
+	return "utf8mb4"
+}
+
+func (si *SessionInfo) GetCollation() string {
+	return "utf8mb4_general_ci"
+}
+
+func (si *SessionInfo) GetConnectionID() uint64 {
+	return si.ConnectionID
+}
+
+func (si *SessionInfo) GetDatabase() string {
+	return si.Database
+}
+
+func (si *SessionInfo) GetVersion() string {
+	return si.Version
+}
+
 // Process contains context used in query execution
 // one or more pipeline will be generated for one query,
 // and one pipeline has one process instance.
@@ -70,6 +116,8 @@ type Process struct {
 
 	// snapshot is transaction context
 	Snapshot []byte
+
+	SessionInfo SessionInfo
 
 	// snapshot is transaction context
 	Cancel context.CancelFunc


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #2386 

**What this PR does / why we need it:**

**Updates** 

First:
1, update setting variable in session context.
2, fix commend field listing for tae.
3, remove the restrictions that when the default database is empty in plan2 that are maintained in the plan1.

The jdbc and mysql administrator gui tools like DBeaver, mysql workbench read and update some system variables after the connection with mysql was established or during the iteration with mysql. The jdbc compatibilty has relationship with these system variables that should be correct, updatable. The mo designs the mechanism to maintain these variables like changing,reading and persisting the values of system variables in suitable context.

Second : Add some information functions for jdbc.
Reference to [information functions](https://dev.mysql.com/doc/refman/8.0/en/information-functions.html)

Name 
CHARSET()
COLLATION()
CONNECTION_ID()
CURRENT_ROLE()
CURRENT_USER()
DATABASE()
FOUND_ROWS()
ICU_VERSION()
LAST_INSERT_ID()
ROLES_GRAPHML()
ROW_COUNT()
SCHEMA()
SESSION_USER()
SYSTEM_USER()
USER()
VERSION)()

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
