### PR TITLE
fix vector expand bug during extend

### DIFF
--- a/pkg/vm/engine/tae/stl/containers/stdvec.go
+++ b/pkg/vm/engine/tae/stl/containers/stdvec.go
@@ -175,7 +175,16 @@ func (vec *StdVector[T]) AppendMany(vals ...T) {
 	}
 	predictSize := len(vals) + len(vec.slice)
 	if predictSize > vec.capacity {
-		vec.tryExpand(predictSize)
+		var newCap int
+		if vec.capacity < 2 {
+			newCap = 4
+		} else {
+			newCap = vec.capacity * 2
+		}
+		if newCap < predictSize {
+			newCap = predictSize
+		}
+		vec.tryExpand(newCap)
 	}
 	vec.slice = append(vec.slice, vals...)
 	vec.buf = unsafe.Slice((*byte)(unsafe.Pointer(&vec.slice[0])), stl.SizeOfMany[T](predictSize))


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

The default policy is to expand vector capacity to at least 2x. and I forgot to apply this policy for `extend` operation.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
