### PR TITLE
Resolve where condition expression type missing

### DIFF
--- a/pkg/sql/plan/make.go
+++ b/pkg/sql/plan/make.go
@@ -136,12 +136,15 @@ func makePlan2CastExpr(expr *Expr, targetType *Type) (*Expr, error) {
 	t := &plan.Expr{Expr: &plan.Expr_T{T: &plan.TargetType{
 		Typ: copyType(targetType),
 	}}}
-	return &plan.Expr{Expr: &plan.Expr_F{
-		F: &plan.Function{
-			Func: &ObjectRef{Obj: id},
-			Args: []*Expr{expr, t},
+	return &plan.Expr{
+		Expr: &plan.Expr_F{
+			F: &plan.Function{
+				Func: &ObjectRef{Obj: id},
+				Args: []*Expr{expr, t},
+			},
 		},
-	}}, nil
+		Typ: targetType,
+	}, nil
 }
 
 func copyType(t *Type) *Type {


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #3829

**What this PR does / why we need it:**

When the where conditional expression type of the query statement is not a boolean type, you need to call the cast function to convert it into a Boolean expression. However, in this case, the cast expression type is lost, resulting in panic when explaining. Now repair this

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
