### PR TITLE
(tae): add bitset adaptor

### DIFF
--- a/pkg/vm/engine/tae/stl/adaptors/adaptors_test.go
+++ b/pkg/vm/engine/tae/stl/adaptors/adaptors_test.go
@@ -1,0 +1,37 @@
+package adaptors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBitSet1(t *testing.T) {
+	bs := NewBitSet(10)
+	assert.Equal(t, 10, bs.Size())
+	assert.True(t, bs.IsEmpty())
+
+	bs.Add(2)
+	assert.False(t, bs.IsEmpty())
+	assert.Equal(t, 1, bs.GetCardinality())
+
+	bs.Remove(2)
+	assert.True(t, bs.IsEmpty())
+	assert.Equal(t, 0, bs.GetCardinality())
+
+	bs.AddRange(3, 8)
+	assert.False(t, bs.IsEmpty())
+	assert.Equal(t, 5, bs.GetCardinality())
+
+	bs.AddRange(4, 7)
+	assert.False(t, bs.IsEmpty())
+	assert.Equal(t, 5, bs.GetCardinality())
+
+	bs.RemoveRange(4, 7)
+	assert.False(t, bs.IsEmpty())
+	assert.Equal(t, 2, bs.GetCardinality())
+
+	bs.Clear()
+	assert.True(t, bs.IsEmpty())
+	assert.Equal(t, 0, bs.GetCardinality())
+}

--- a/pkg/vm/engine/tae/stl/adaptors/bitset.go
+++ b/pkg/vm/engine/tae/stl/adaptors/bitset.go
@@ -1,0 +1,137 @@
+package adaptors
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/stl/containers"
+)
+
+func NewBitSet(size int) *BitSet {
+	capacity := (size-1)>>3 + 1
+	if size <= int(common.K*8) {
+		set := make([]byte, capacity)
+		return &BitSet{
+			size: size,
+			set:  set,
+		}
+	}
+	storage := containers.NewStdVector[byte](&containers.Options{
+		Capacity: capacity,
+	})
+	return &BitSet{
+		size:    size,
+		set:     storage.Data()[:capacity],
+		storage: storage,
+	}
+}
+
+func (bs *BitSet) Close() {
+	if bs.storage != nil {
+		bs.storage.Close()
+	}
+}
+
+func (bs *BitSet) GetCardinality() int {
+	return bs.bitcnt
+}
+
+func (bs *BitSet) IsEmpty() bool {
+	return bs.bitcnt == 0
+}
+
+func (bs *BitSet) Contains(x int) bool {
+	return (bs.set[x>>3] & (1 << (x & 0x7))) != 0
+}
+
+func (bs *BitSet) Add(x int) {
+	if x >= bs.size {
+		panic(fmt.Errorf("set %d bit but size is %d", x, bs.size))
+	}
+	old := bs.set[x>>3] & (1 << (x & 0x7))
+	bs.set[x>>3] |= 1 << (x & 0x7)
+	if old == 0 {
+		bs.bitcnt += 1
+	}
+}
+
+// [start, end)
+func (bs *BitSet) AddRange(start, end int) {
+	if start >= end {
+		return
+	}
+	if start >= bs.size || end > bs.size {
+		panic(fmt.Errorf("add range [%d, %d) but size is %d", start, end, bs.size))
+	}
+	for x := start; x < end; x++ {
+		old := bs.set[x>>3] & (1 << (x & 0x7))
+		bs.set[x>>3] |= 1 << (x & 0x7)
+		if old == 0 {
+			bs.bitcnt += 1
+		}
+	}
+}
+
+func (bs *BitSet) Remove(x int) {
+	if x >= bs.size {
+		panic(fmt.Errorf("remove %d bit but size is %d", x, bs.size))
+	}
+	old := bs.set[x>>3] & (1 << (x & 0x7))
+	bs.set[x>>3] &= ^(1 << (x & 0x7))
+	if old != 0 {
+		bs.bitcnt -= 1
+	}
+}
+
+func (bs *BitSet) RemoveRange(start, end int) {
+	if start >= end {
+		return
+	}
+	if start >= bs.size || end > bs.size {
+		panic(fmt.Errorf("remove range [%d, %d) but size is %d", start, end, bs.size))
+	}
+	for x := start; x < end; x++ {
+		old := bs.set[x>>3] & (1 << (x & 0x7))
+		bs.set[x>>3] &= ^(1 << (x & 0x7))
+		if old != 0 {
+			bs.bitcnt -= 1
+		}
+	}
+}
+
+func (bs *BitSet) Clear() {
+	for i := range bs.set {
+		bs.set[i] = 0
+	}
+	bs.bitcnt = 0
+}
+
+func (bs *BitSet) Data() []byte {
+	return bs.set
+}
+
+func (bs *BitSet) String() string {
+	w := new(bytes.Buffer)
+	_, _ = w.WriteString(fmt.Sprintf("BitSet<%d>:[Cardinality=%d]", bs.size, bs.bitcnt))
+	if bs.storage != nil {
+		_, _ = w.WriteString("[Allocated]")
+	}
+	_ = w.WriteByte('[')
+	cnt := 0
+	for x := 0; x < bs.size; x++ {
+		if cnt >= 20 || cnt >= bs.bitcnt {
+			break
+		}
+		if bs.Contains(x) {
+			cnt++
+			_, _ = w.WriteString(fmt.Sprintf("%d", x))
+			_ = w.WriteByte(',')
+		}
+	}
+	if cnt < bs.bitcnt {
+		_, _ = w.WriteString("...")
+	}
+	_ = w.WriteByte(']')
+	return w.String()
+}

--- a/pkg/vm/engine/tae/stl/adaptors/bitset.go
+++ b/pkg/vm/engine/tae/stl/adaptors/bitset.go
@@ -27,6 +27,8 @@ func NewBitSet(size int) *BitSet {
 	}
 }
 
+func (bs *BitSet) Size() int { return bs.size }
+
 func (bs *BitSet) Close() {
 	if bs.storage != nil {
 		bs.storage.Close()

--- a/pkg/vm/engine/tae/stl/adaptors/types.go
+++ b/pkg/vm/engine/tae/stl/adaptors/types.go
@@ -5,6 +5,12 @@ import (
 )
 
 type Buffer struct {
-	// storage *containers.StdVector[byte]
 	storage stl.Vector[byte]
+}
+
+type BitSet struct {
+	storage stl.Vector[byte]
+	set     []byte
+	size    int
+	bitcnt  int
 }


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

Performance is higher than roaring. It will be used to indicate reverted rows of a block in the state machine.

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
