### PR TITLE
Makefile: build production mo-server by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,17 @@
 #
 # Examples
 #
-# To build MO -
+# By default, make builds the mo-server
+#
+# make
+#
+# To re-build MO -
 #	
 #	make clean
 #	make config
 #	make build
 #
-# To build MO in debug mode also with race detector enabled -
+# To re-build MO in debug mode also with race detector enabled -
 #
 # make clean
 # make config
@@ -50,6 +54,11 @@ MO_VERSION=$(shell git describe --tags $(shell git rev-list --tags --max-count=1
 ifneq ($(GOARCH)$(TARGET_ARCH)$(GOOS)$(TARGET_OS),)
 $(error cross compilation has been disabled)
 endif
+
+###############################################################################
+# default target
+###############################################################################
+all: build
 
 ###############################################################################
 # code generation

--- a/cgo/Makefile
+++ b/cgo/Makefile
@@ -10,6 +10,7 @@ all: $(LIBS) $(OBJS)
 	ar -rcs libmo.a *.o
 	ranlib libmo.a
 	rm -f *.o
+	rm -f $(LIBS)
 
 libdecnumber.a:
 	(cd external; bash ./build.sh)


### PR DESCRIPTION
intermediate libxxx.a files are no longer kept

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

`make` should build the non-debug version of mo-server by default. 

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
