### PR TITLE
common: added the RaceEnabled invariant

### DIFF
--- a/pkg/common/invariants/race_disabled.go
+++ b/pkg/common/invariants/race_disabled.go
@@ -1,0 +1,24 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !race
+// +build !race
+
+package invariants
+
+// RaceEnabled is true when running with the race detector enabled. It implies
+// running in the testing mode, extra checks can be executed with no concern on
+// performance impact - as the race detector is already making the program
+// 2-10x slower anyway.
+const RaceEnabled = false

--- a/pkg/common/invariants/race_enabled.go
+++ b/pkg/common/invariants/race_enabled.go
@@ -1,0 +1,24 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build race
+// +build race
+
+package invariants
+
+// RaceEnabled is true when running with the race detector enabled. It implies
+// running in the testing mode, extra checks can be executed with no concern on
+// performance impact - as the race detector is already making the program
+// 2-10x slower anyway.
+const RaceEnabled = true


### PR DESCRIPTION
when writing code, you can use this RaceEnabled flag to test whether
your code is running in race testing mode and run more checks without
worrying on possible overheads introduced by such extra checks - as
the race detector makes your program 2-10x slower already.

**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

Added the RaceEnabled invariant. 

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
