### PR TITLE
logservice: always validate client config first

### DIFF
--- a/pkg/logservice/client.go
+++ b/pkg/logservice/client.go
@@ -49,21 +49,6 @@ func IsTempError(err error) bool {
 	return isTempError(err)
 }
 
-// ClientConfig is the configuration for log service clients.
-type ClientConfig struct {
-	// ReadOnly indicates whether this is a read-only client.
-	ReadOnly bool
-	// LogShardID is the shard ID of the log service shard to be used.
-	LogShardID uint64
-	// DNReplicaID is the replica ID of the DN that owns the created client.
-	DNReplicaID uint64
-	// DiscoveryAddress is the Log Service discovery address provided by k8s.
-	DiscoveryAddress string
-	// LogService nodes service addresses. This field is provided for testing
-	// purposes only.
-	ServiceAddresses []string
-}
-
 // Client is the Log Service Client interface exposed to the DN.
 type Client interface {
 	// Close closes the client.
@@ -115,6 +100,9 @@ var _ Client = (*managedClient)(nil)
 // to the Log Service in parallel, multiple clients should be created and used
 // to do so.
 func NewClient(ctx context.Context, cfg ClientConfig) (Client, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 	client, err := newClient(ctx, cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/logservice/client_test.go
+++ b/pkg/logservice/client_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/lni/dragonboat/v4"
 	"github.com/lni/goutils/leaktest"
 	"github.com/lni/vfs"
@@ -61,6 +62,13 @@ func runClientTest(t *testing.T,
 	}()
 
 	fn(t, service, scfg, c)
+}
+
+func TestClientConfigIsValidated(t *testing.T) {
+	cfg := ClientConfig{}
+	cc, err := NewClient(context.TODO(), cfg)
+	assert.Nil(t, cc)
+	assert.True(t, errors.Is(err, ErrInvalidConfig))
 }
 
 func TestClientCanBeReset(t *testing.T) {

--- a/pkg/logservice/hakeeper_client.go
+++ b/pkg/logservice/hakeeper_client.go
@@ -71,18 +71,27 @@ var _ LogHAKeeperClient = (*managedHAKeeperClient)(nil)
 // NewCNHAKeeperClient creates a HAKeeper client to be used by a CN node.
 func NewCNHAKeeperClient(ctx context.Context,
 	cfg HAKeeperClientConfig) (CNHAKeeperClient, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 	return newManagedHAKeeperClient(ctx, cfg)
 }
 
 // NewDNHAKeeperClient creates a HAKeeper client to be used by a DN node.
 func NewDNHAKeeperClient(ctx context.Context,
 	cfg HAKeeperClientConfig) (DNHAKeeperClient, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 	return newManagedHAKeeperClient(ctx, cfg)
 }
 
 // NewLogHAKeeperClient creates a HAKeeper client to be used by a Log Service node.
 func NewLogHAKeeperClient(ctx context.Context,
 	cfg HAKeeperClientConfig) (LogHAKeeperClient, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 	return newManagedHAKeeperClient(ctx, cfg)
 }
 

--- a/pkg/logservice/hakeeper_client_test.go
+++ b/pkg/logservice/hakeeper_client_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/google/uuid"
 	"github.com/lni/dragonboat/v4"
 	"github.com/lni/goutils/leaktest"
@@ -29,6 +31,19 @@ import (
 
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 )
+
+func TestHAKeeperClientConfigIsValidated(t *testing.T) {
+	cfg := HAKeeperClientConfig{}
+	cc1, err := NewCNHAKeeperClient(context.TODO(), cfg)
+	assert.Nil(t, cc1)
+	assert.True(t, errors.Is(err, ErrInvalidConfig))
+	cc2, err := NewDNHAKeeperClient(context.TODO(), cfg)
+	assert.Nil(t, cc2)
+	assert.True(t, errors.Is(err, ErrInvalidConfig))
+	cc3, err := NewLogHAKeeperClient(context.TODO(), cfg)
+	assert.Nil(t, cc3)
+	assert.True(t, errors.Is(err, ErrInvalidConfig))
+}
 
 func TestHAKeeperClientsCanBeCreated(t *testing.T) {
 	fn := func(t *testing.T, s *Service) {


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

always validate client config first

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
