### PR TITLE
logservice: stop hakeeper ticker on KillZombie command

### DIFF
--- a/pkg/logservice/store_test.go
+++ b/pkg/logservice/store_test.go
@@ -498,6 +498,18 @@ func TestRemoveReplica(t *testing.T) {
 	}
 }
 
+func TestStopReplicaCanStopHAKeeperTicker(t *testing.T) {
+	fn := func(t *testing.T, store *store) {
+		peers := make(map[uint64]dragonboat.Target)
+		peers[1] = store.id()
+		assert.NoError(t, store.startHAKeeperReplica(1, peers, false))
+		assert.Equal(t, int64(1), store.tickerStopper.GetTaskCount())
+		assert.NoError(t, store.stopReplica(hakeeper.DefaultHAKeeperShardID, 1))
+		assert.Equal(t, int64(0), store.tickerStopper.GetTaskCount())
+	}
+	runStoreTest(t, fn)
+}
+
 func hasShard(s *store, shardID uint64) bool {
 	hb := s.getHeartbeatMessage()
 	for _, info := range hb.Replicas {


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

issue #

**What this PR does / why we need it:**

When HAKeeper replica is stopped by a KillZombie command, HAKeeper ticker managed by the Log Store should be stopped as well. This avoids flooding the log with a ton of ticker failed error messages.  

**Special notes for your reviewer:**

Not Available

**Additional documentation (e.g. design docs, usage docs, etc.):**

Not Available
