### PR TITLE
add an empty getExecTypeFromPlan for test

### DIFF
--- a/pkg/sql/plan/build.go
+++ b/pkg/sql/plan/build.go
@@ -108,6 +108,22 @@ func BuildPlan(ctx CompilerContext, stmt tree.Statement) (*Plan, error) {
 	}
 }
 
+// GetExecType get executor will execute base AP or TP
+func GetExecTypeFromPlan(_ *Plan) ExecInfo {
+	defInfo := ExecInfo{
+		Typ:        ExecTypeAP,
+		WithGPU:    false,
+		WithBigMem: false,
+		CnNumbers:  2,
+	}
+
+	// TODO : fill the function
+
+	// empty function with default return
+	// just for test
+	return defInfo
+}
+
 //GetResultColumnsFromPlan
 func GetResultColumnsFromPlan(p *Plan) []*ColDef {
 	getResultColumnsByProjectionlist := func(query *Query) []*ColDef {

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -77,6 +77,20 @@ type BaseOptimizer struct {
 	ctx   CompilerContext
 }
 
+type ExecType int
+
+const (
+	ExecTypeAP ExecType = iota
+	ExecTypeTP
+)
+
+type ExecInfo struct {
+	Typ        ExecType
+	WithGPU    bool
+	WithBigMem bool
+	CnNumbers  int
+}
+
 ///////////////////////////////
 // Data structures for refactor
 ///////////////////////////////


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
define an interface(empty function) to get execute type from plan for test

we will finish the function later
