### PR TITLE
fix onReplayAppendCmd

### DIFF
--- a/pkg/vm/engine/tae/db/replay.go
+++ b/pkg/vm/engine/tae/db/replay.go
@@ -257,7 +257,35 @@ func (replayer *Replayer) OnReplayCmd(txncmd txnif.TxnCmd, idxCtx *wal.Index) {
 }
 
 func (db *DB) onReplayAppendCmd(cmd *txnimpl.AppendCmd, observer wal.ReplayObserver) {
+	hasActive := false
+	for _, info := range cmd.Infos {
+		database, err := db.Catalog.GetDatabaseByID(info.GetDBID())
+		if err != nil {
+			panic(err)
+		}
+		id := info.GetDest()
+		blk, err := database.GetBlockEntryByID(id)
+		if err != nil {
+			panic(err)
+		}
+		if !blk.IsActive() {
+			continue
+		}
+		if observer != nil {
+			observer.OnTimeStamp(blk.GetBlockData().GetMaxCheckpointTS())
+		}
+		if cmd.Ts <= blk.GetBlockData().GetMaxCheckpointTS() {
+			continue
+		}
+		hasActive = true
+	}
+
+	if !hasActive {
+		return
+	}
+
 	var data *containers.Batch
+
 	for _, subTxnCmd := range cmd.Cmds {
 		switch subCmd := subTxnCmd.(type) {
 		case *txnbase.BatchCmd:


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #4428

## What this PR does / why we need it:

Fix onReplayAppendCmd. Check whether there exists active block before load data. 