### PR TITLE
logservice: fixed various HAKeeper client connectivity issues

### DIFF
--- a/pkg/logservice/client.go
+++ b/pkg/logservice/client.go
@@ -470,14 +470,14 @@ func getRPCClient(ctx context.Context, target string, pool *sync.Pool) (morpc.RP
 	mf := func() morpc.Message {
 		return pool.Get().(*RPCResponse)
 	}
-	timeout, err := getTimeoutFromContext(ctx)
+	/*timeout, err := getTimeoutFromContext(ctx)
 	if err != nil {
 		return nil, err
-	}
+	}*/
 	codec := morpc.NewMessageCodec(mf, defaultWriteSocketSize)
 	bf := morpc.NewGoettyBasedBackendFactory(codec,
 		morpc.WithBackendConnectWhenCreate(),
-		morpc.WithBackendConnectTimeout(timeout))
+		morpc.WithBackendConnectTimeout(time.Second))
 	return morpc.NewClient(bf,
 		morpc.WithClientInitBackends([]string{target}, []int{1}),
 		morpc.WithClientMaxBackendPerHost(1))

--- a/pkg/logservice/service_bootstrap.go
+++ b/pkg/logservice/service_bootstrap.go
@@ -51,6 +51,9 @@ func (s *Service) BootstrapHAKeeper(ctx context.Context, cfg Config) error {
 		if err := s.store.setInitialClusterInfo(numOfLogShards,
 			numOfDNShards, numOfLogReplicas); err != nil {
 			plog.Errorf("failed to set initial cluster info, %v", err)
+			if err == dragonboat.ErrShardNotFound {
+				return nil
+			}
 			time.Sleep(time.Second)
 			continue
 		}

--- a/pkg/logservice/service_commands.go
+++ b/pkg/logservice/service_commands.go
@@ -134,7 +134,7 @@ func (s *Service) heartbeatWorker(ctx context.Context) {
 }
 
 func (s *Service) heartbeat(ctx context.Context) {
-	ctx2, cancel := context.WithTimeout(ctx, time.Second)
+	ctx2, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	if s.haClient == nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

* use constant connection timeout value which is much smaller than the LOG node heartbeat timeout. this ensures we get chance to try most specified HAKeeper nodes. 
* during bootstrap, it is possible for the HAKeeper replica to be removed by a KILL command, terminate the local bootstrap procedure when that happens. 
* always keep the ticker worker even after the HAKeeper replica is stopped.    