### PR TITLE
proto: fixed proto/gen.sh

### DIFF
--- a/proto/gen.sh
+++ b/proto/gen.sh
@@ -21,6 +21,10 @@ PROTO_SYNTAX_VERSION='3'
 PROTOC_VERSION='21.1'
 GOGOPROTOBUF_VERSION='1.'
 
+if [ "${GOPATH}" == "" ];then
+  GOPATH=`go env GOPATH`
+fi
+echo "GOPATH: ${GOPATH}"
 
 res=$(program_exists goimports)
 echo "res: ${res}"


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

When the environmental variable GOPATH is not set, get its value from the output of the `go env GOPATH` command otherwise gen.sh will be using incorrect paths. 