### PR TITLE
dnservice: fix start failed if any replica exists

### DIFF
--- a/pkg/dnservice/store.go
+++ b/pkg/dnservice/store.go
@@ -295,7 +295,7 @@ func (s *store) createReplica(shard metadata.DNShard) error {
 		return err
 	}
 
-	s.addDNShard(shard)
+	s.addDNShardLocked(shard)
 	return nil
 }
 

--- a/pkg/dnservice/store_metadata.go
+++ b/pkg/dnservice/store_metadata.go
@@ -62,10 +62,7 @@ func (s *store) initMetadata() error {
 	return nil
 }
 
-func (s *store) addDNShard(shard metadata.DNShard) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
+func (s *store) addDNShardLocked(shard metadata.DNShard) {
 	for _, dn := range s.mu.metadata.Shards {
 		if dn.ShardID == shard.ShardID {
 			return


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

If any Replica exists, a deadlock will occur when DNService starts.