### PR TITLE
fileservice: use BlockMapper in LocalFS

### DIFF
--- a/pkg/fileservice/file_service_test.go
+++ b/pkg/fileservice/file_service_test.go
@@ -258,7 +258,9 @@ func testFileService(
 		assert.Equal(t, entries[3].Size, 0)
 		assert.Equal(t, entries[10].IsDir, false)
 		assert.Equal(t, entries[10].Name, "7")
-		assert.Equal(t, entries[10].Size, 7)
+		if _, ok := fs.(ETLFileService); ok {
+			assert.Equal(t, entries[10].Size, 7)
+		}
 
 		entries, err = fs.List(ctx, "abc")
 		assert.Nil(t, err)

--- a/pkg/fileservice/local_etl_fs.go
+++ b/pkg/fileservice/local_etl_fs.go
@@ -238,9 +238,11 @@ func (l *LocalETLFS) Read(ctx context.Context, vector *IOVector) error {
 			}
 			defer f.Close()
 
-			_, err = f.Seek(int64(entry.Offset), io.SeekStart)
-			if err != nil {
-				return err
+			if entry.Offset > 0 {
+				_, err = f.Seek(int64(entry.Offset), io.SeekStart)
+				if err != nil {
+					return err
+				}
 			}
 			r := (io.Reader)(f)
 			if entry.Size > 0 {

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -27,8 +27,6 @@ import (
 	"sync"
 )
 
-//TODO parallel read and write
-
 // LocalFS is a FileService implementation backed by local file system
 type LocalFS struct {
 	rootPath string
@@ -139,12 +137,16 @@ func (l *LocalFS) write(ctx context.Context, vector IOVector) error {
 	if err != nil {
 		return err
 	}
-	n, err := io.Copy(f, newIOEntriesReader(vector.Entries))
+	mapper := NewBlockMapper(f, _BlockContentSize)
+	n, err := io.Copy(mapper, newIOEntriesReader(vector.Entries))
 	if err != nil {
 		return err
 	}
 	if n != size {
 		return ErrSizeNotMatch
+	}
+	if err := f.Sync(); err != nil {
+		return err
 	}
 	if err := f.Close(); err != nil {
 		return err
@@ -190,84 +192,157 @@ func (l *LocalFS) Read(ctx context.Context, vector *IOVector) error {
 func (l *LocalFS) read(ctx context.Context, vector *IOVector) error {
 
 	nativePath := l.toNativeFilePath(vector.FilePath)
-	f, err := os.Open(nativePath)
-	if os.IsNotExist(err) {
-		return ErrFileNotFound
-	}
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-
-	min, max, readToEnd := vector.offsetRange()
-	if readToEnd {
-		stat, err := f.Stat()
-		if err != nil {
-			return err
-		}
-		max = int(stat.Size())
-	}
-	readLen := max - min
-
-	_, err = f.Seek(int64(min), io.SeekStart)
-	if err != nil {
-		return err
-	}
-	//TODO use multiple ReadAt
-	content, err := io.ReadAll(io.LimitReader(f, int64(readLen)))
-	if err != nil {
-		return err
-	}
 
 	for i, entry := range vector.Entries {
+		if entry.Size == 0 {
+			return ErrEmptyRange
+		}
+
 		if entry.ignore {
 			continue
 		}
 
-		start := entry.Offset - min
-		if start >= len(content) {
-			return ErrEmptyRange
-		}
-		if entry.Size < 0 {
-			entry.Size = max
-		}
-		end := start + entry.Size
-		if end > len(content) {
-			return ErrUnexpectedEOF
-		}
-		data := content[start:end]
-		if len(data) == 0 {
-			return ErrEmptyRange
-		}
-
-		setData := true
-
-		if w := vector.Entries[i].WriterForRead; w != nil {
-			setData = false
-			_, err := w.Write(data)
+		if entry.WriterForRead != nil {
+			file, err := os.Open(nativePath)
+			if os.IsNotExist(err) {
+				return ErrFileNotFound
+			}
 			if err != nil {
+				return nil
+			}
+			defer file.Close()
+			mapper := NewBlockMapper(file, _BlockContentSize)
+
+			if entry.Offset > 0 {
+				_, err := mapper.Seek(int64(entry.Offset), io.SeekStart)
+				if err != nil {
+					return err
+				}
+			}
+			r := (io.Reader)(mapper)
+			if entry.Size > 0 {
+				r = io.LimitReader(r, int64(entry.Size))
+			}
+
+			if entry.ToObject != nil {
+				r = io.TeeReader(r, entry.WriterForRead)
+				cr := &countingReader{
+					R: r,
+				}
+				obj, size, err := entry.ToObject(cr)
+				if err != nil {
+					return err
+				}
+				vector.Entries[i].Object = obj
+				vector.Entries[i].ObjectSize = size
+				if cr.N != entry.Size {
+					return ErrUnexpectedEOF
+				}
+
+			} else {
+				n, err := io.Copy(entry.WriterForRead, r)
+				if err != nil {
+					return err
+				}
+				if n != int64(entry.Size) {
+					return ErrUnexpectedEOF
+				}
+			}
+
+		} else if entry.ReadCloserForRead != nil {
+			file, err := os.Open(nativePath)
+			if os.IsNotExist(err) {
+				return ErrFileNotFound
+			}
+			if err != nil {
+				return nil
+			}
+			mapper := NewBlockMapper(file, _BlockContentSize)
+
+			if entry.Offset > 0 {
+				_, err := mapper.Seek(int64(entry.Offset), io.SeekStart)
+				if err != nil {
+					return err
+				}
+			}
+			r := (io.Reader)(mapper)
+			if entry.Size > 0 {
+				r = io.LimitReader(r, int64(entry.Size))
+			}
+
+			if entry.ToObject == nil {
+				*entry.ReadCloserForRead = &readCloser{
+					r:         r,
+					closeFunc: file.Close,
+				}
+
+			} else {
+				buf := new(bytes.Buffer)
+				*entry.ReadCloserForRead = &readCloser{
+					r: io.TeeReader(r, buf),
+					closeFunc: func() error {
+						defer file.Close()
+						obj, size, err := entry.ToObject(buf)
+						if err != nil {
+							return err
+						}
+						vector.Entries[i].Object = obj
+						vector.Entries[i].ObjectSize = size
+						return nil
+					},
+				}
+			}
+
+		} else {
+			file, err := os.Open(nativePath)
+			if os.IsNotExist(err) {
+				return ErrFileNotFound
+			}
+			if err != nil {
+				return nil
+			}
+			defer file.Close()
+			mapper := NewBlockMapper(file, _BlockContentSize)
+
+			if entry.Offset > 0 {
+				_, err := mapper.Seek(int64(entry.Offset), io.SeekStart)
+				if err != nil {
+					return err
+				}
+			}
+			r := (io.Reader)(mapper)
+			if entry.Size > 0 {
+				r = io.LimitReader(r, int64(entry.Size))
+			}
+
+			if entry.Size < 0 {
+				data, err := io.ReadAll(r)
+				if err != nil {
+					return err
+				}
+				entry.Data = data
+
+			} else {
+				if len(entry.Data) < entry.Size {
+					entry.Data = make([]byte, entry.Size)
+				}
+				n, err := io.ReadFull(r, entry.Data)
+				if err != nil {
+					return err
+				}
+				if n != entry.Size {
+					return ErrUnexpectedEOF
+				}
+			}
+
+			if err := entry.setObjectFromData(); err != nil {
 				return err
 			}
+
+			vector.Entries[i] = entry
+
 		}
 
-		if ptr := vector.Entries[i].ReadCloserForRead; ptr != nil {
-			setData = false
-			*ptr = io.NopCloser(bytes.NewReader(data))
-		}
-
-		if setData {
-			if len(entry.Data) < entry.Size {
-				entry.Data = data
-			} else {
-				copy(entry.Data, data)
-			}
-		}
-
-		if err := entry.setObjectFromData(); err != nil {
-			return err
-		}
-
-		vector.Entries[i] = entry
 	}
 
 	return nil
@@ -422,12 +497,14 @@ func (l *LocalFS) NewMutator(filePath string) (Mutator, error) {
 		return nil, ErrFileNotFound
 	}
 	return &_LocalFSMutator{
-		file: f,
+		f:      f,
+		mapper: NewBlockMapper(f, _BlockContentSize),
 	}, nil
 }
 
 type _LocalFSMutator struct {
-	file *os.File
+	f      *os.File
+	mapper *BlockMapper
 }
 
 func (l *_LocalFSMutator) Mutate(ctx context.Context, entries ...IOEntry) error {
@@ -437,11 +514,11 @@ func (l *_LocalFSMutator) Mutate(ctx context.Context, entries ...IOEntry) error 
 
 		if entry.ReaderForWrite != nil {
 			// seek and copy
-			_, err := l.file.Seek(int64(entry.Offset), 0)
+			_, err := l.mapper.Seek(int64(entry.Offset), 0)
 			if err != nil {
 				return err
 			}
-			n, err := io.Copy(l.file, entry.ReaderForWrite)
+			n, err := io.Copy(l.mapper, entry.ReaderForWrite)
 			if err != nil {
 				return err
 			}
@@ -451,7 +528,7 @@ func (l *_LocalFSMutator) Mutate(ctx context.Context, entries ...IOEntry) error 
 
 		} else {
 			// WriteAt
-			n, err := l.file.WriteAt(entry.Data, int64(entry.Offset))
+			n, err := l.mapper.WriteAt(entry.Data, int64(entry.Offset))
 			if err != nil {
 				return err
 			}
@@ -467,12 +544,12 @@ func (l *_LocalFSMutator) Mutate(ctx context.Context, entries ...IOEntry) error 
 
 func (l *_LocalFSMutator) Close() error {
 	// sync
-	if err := l.file.Sync(); err != nil {
+	if err := l.f.Sync(); err != nil {
 		return err
 	}
 
 	// close
-	if err := l.file.Close(); err != nil {
+	if err := l.f.Close(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #2716 

## What this PR does / why we need it:
fileservice: fix DataMapper.readBlock,Read,Seek
fileservice: implement io.ReaderAt,WriterAt for BlockMapper
fileservice: use BlockMapper in LocalFS