### PR TITLE
Enable flexible `morpc` option for package `logservice`

### DIFF
--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -125,7 +125,7 @@ func TestSendWithAlreadyContextDone(t *testing.T) {
 			assert.Nil(t, resp)
 		},
 		WithBackendConnectWhenCreate(),
-		WithBackendFilter(func(Message) bool {
+		WithBackendFilter(func(Message, string) bool {
 			cancel()
 			return true
 		}))
@@ -150,7 +150,7 @@ func TestSendWithResetConnAndRetry(t *testing.T) {
 			assert.Equal(t, req, resp)
 			assert.True(t, retry > 0)
 		},
-		WithBackendFilter(func(Message) bool {
+		WithBackendFilter(func(Message, string) bool {
 			retry++
 			return true
 		}))
@@ -201,7 +201,7 @@ func TestSendWithReconnect(t *testing.T) {
 			}
 		},
 		WithBackendConnectWhenCreate(),
-		WithBackendFilter(func(m Message) bool {
+		WithBackendFilter(func(Message, string) bool {
 			idx++
 			if idx%2 == 0 {
 				rb.closeConn(false)
@@ -231,7 +231,7 @@ func TestSendWithCannotConnectWillTimeout(t *testing.T) {
 			assert.Nil(t, resp)
 			assert.Equal(t, err, ctx.Err())
 		},
-		WithBackendFilter(func(m Message) bool {
+		WithBackendFilter(func(Message, string) bool {
 			assert.NoError(t, rb.conn.Disconnect())
 			rb.remote = ""
 			return true
@@ -319,7 +319,7 @@ func TestBusy(t *testing.T) {
 			c <- struct{}{}
 		},
 		WithBackendConnectWhenCreate(),
-		WithBackendFilter(func(Message) bool {
+		WithBackendFilter(func(Message, string) bool {
 			if n == 0 {
 				<-c
 				n++

--- a/pkg/dnservice/store.go
+++ b/pkg/dnservice/store.go
@@ -51,10 +51,10 @@ func WithConfigAdjust(adjustConfigFunc func(c *Config)) Option {
 	}
 }
 
-// WithRequestFilter set filtering txn.TxnRequest sent to other DNShard
-func WithRequestFilter(filter func(*txn.TxnRequest) bool) Option {
+// WithBackendFilter set filtering txn.TxnRequest sent to other DNShard
+func WithBackendFilter(filter func(*txn.TxnRequest, string) bool) Option {
 	return func(s *store) {
-		s.options.requestFilter = filter
+		s.options.backendFilter = filter
 	}
 }
 
@@ -88,7 +88,7 @@ type store struct {
 	options struct {
 		logServiceClientFactory func(metadata.DNShard) (logservice.Client, error)
 		hakeekerClientFactory   func() (logservice.DNHAKeeperClient, error)
-		requestFilter           func(*txn.TxnRequest) bool
+		backendFilter           func(req *txn.TxnRequest, backendAddr string) bool
 		adjustConfigFunc        func(c *Config)
 	}
 
@@ -390,8 +390,8 @@ func (s *store) initFileService() error {
 func (s *store) getBackendOptions() []morpc.BackendOption {
 	return []morpc.BackendOption{
 		morpc.WithBackendLogger(s.logger),
-		morpc.WithBackendFilter(func(m morpc.Message) bool {
-			return s.options.requestFilter == nil || s.options.requestFilter(m.(*txn.TxnRequest))
+		morpc.WithBackendFilter(func(m morpc.Message, backendAddr string) bool {
+			return s.options.backendFilter == nil || s.options.backendFilter(m.(*txn.TxnRequest), backendAddr)
 		}),
 		morpc.WithBackendBusyBufferSize(s.cfg.RPC.BusyQueueSize),
 		morpc.WithBackendBufferSize(s.cfg.RPC.SendQueueSize),

--- a/pkg/logservice/client_test.go
+++ b/pkg/logservice/client_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 )
 
@@ -36,7 +37,11 @@ func runClientTest(t *testing.T,
 	defer leaktest.AfterTest(t)()
 	cfg := getServiceTestConfig()
 	defer vfs.ReportLeakedFD(cfg.FS, t)
-	service, err := NewService(cfg)
+	service, err := NewService(cfg,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service.Close())
@@ -119,7 +124,11 @@ func TestClientCanBeConnectedByReverseProxy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cfg := getServiceTestConfig()
 	defer vfs.ReportLeakedFD(cfg.FS, t)
-	service, err := NewService(cfg)
+	service, err := NewService(cfg,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service.Close())

--- a/pkg/logservice/hakeeper_client_test.go
+++ b/pkg/logservice/hakeeper_client_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/hakeeper"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 )
@@ -303,13 +304,21 @@ func testNotHAKeeperErrorIsHandled(t *testing.T, fn func(*testing.T, *managedHAK
 		DisableWorkers:      true,
 	}
 	cfg1.Fill()
-	service1, err := NewService(cfg1)
+	service1, err := NewService(cfg1,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service1.Close())
 	}()
 	cfg2.Fill()
-	service2, err := NewService(cfg2)
+	service2, err := NewService(cfg2,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service2.Close())

--- a/pkg/logservice/option.go
+++ b/pkg/logservice/option.go
@@ -1,0 +1,60 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logservice
+
+import (
+	"context"
+
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
+)
+
+// Option is utility that sets callback for Service.
+type Option func(*Service)
+
+// WithBackendFilter sets filter via which could select remote backend.
+func WithBackendFilter(filter func(morpc.Message, string) bool) Option {
+	return func(s *Service) {
+		s.options.backendFilter = filter
+	}
+}
+
+type ContextKey string
+
+const (
+	BackendOption ContextKey = "morpc.BackendOption"
+	ClientOption  ContextKey = "morpc.ClientOption"
+)
+
+func GetBackendOptions(ctx context.Context) []morpc.BackendOption {
+	if v := ctx.Value(BackendOption); v != nil {
+		return v.([]morpc.BackendOption)
+	}
+	return nil
+}
+
+func GetClientOptions(ctx context.Context) []morpc.ClientOption {
+	if v := ctx.Value(ClientOption); v != nil {
+		return v.([]morpc.ClientOption)
+	}
+	return nil
+}
+
+func SetBackendOptions(ctx context.Context, opts ...morpc.BackendOption) context.Context {
+	return context.WithValue(ctx, BackendOption, opts)
+}
+
+func SetClientOptions(ctx context.Context, opts ...morpc.ClientOption) context.Context {
+	return context.WithValue(ctx, ClientOption, opts)
+}

--- a/pkg/logservice/option_test.go
+++ b/pkg/logservice/option_test.go
@@ -1,0 +1,61 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logservice
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
+)
+
+func TestWithOption(t *testing.T) {
+	ctx := context.Background()
+	require.Nil(t, GetBackendOptions(ctx))
+	require.Nil(t, GetClientOptions(ctx))
+
+	// set morpc.BackendOption
+	backendOpts := []morpc.BackendOption{
+		morpc.WithBackendConnectWhenCreate(),
+		morpc.WithBackendConnectTimeout(time.Second),
+	}
+	ctx1 := SetBackendOptions(ctx, backendOpts...)
+	backendOptsRet := GetBackendOptions(ctx1)
+	require.NotNil(t, backendOptsRet)
+	require.Equal(t, len(backendOpts), len(backendOptsRet))
+	require.Equal(t, backendOpts, backendOptsRet)
+
+	// set morpc.BackendOption again
+	newBackendOpts := []morpc.BackendOption{
+		morpc.WithBackendConnectWhenCreate(),
+	}
+	ctx2 := SetBackendOptions(ctx1, newBackendOpts...)
+	newBackendOptsRet := GetBackendOptions(ctx2)
+	require.NotNil(t, backendOptsRet)
+	require.Equal(t, len(newBackendOpts), len(newBackendOptsRet))
+	require.Equal(t, newBackendOpts, newBackendOptsRet)
+
+	clientOpts := []morpc.ClientOption{
+		morpc.WithClientMaxBackendPerHost(1),
+	}
+	ctx3 := SetClientOptions(ctx, clientOpts...)
+	clientOptsRet := GetClientOptions(ctx3)
+	require.NotNil(t, clientOptsRet)
+	require.Equal(t, len(clientOpts), len(clientOptsRet))
+	require.Equal(t, clientOpts, clientOptsRet)
+}

--- a/pkg/logservice/service_commands_test.go
+++ b/pkg/logservice/service_commands_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 )
 
@@ -46,7 +47,11 @@ func TestBackgroundTickAndHeartbeat(t *testing.T) {
 	cfg.HAKeeperTickInterval.Duration = 5 * time.Millisecond
 	cfg.HAKeeperClientConfig.ServiceAddresses = []string{"127.0.0.1:9002"}
 	cfg.Fill()
-	service, err := NewService(cfg)
+	service, err := NewService(cfg,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service.Close())

--- a/pkg/logservice/service_test.go
+++ b/pkg/logservice/service_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 )
 
@@ -56,7 +57,11 @@ func runServiceTest(t *testing.T,
 	defer leaktest.AfterTest(t)()
 	cfg := getServiceTestConfig()
 	defer vfs.ReportLeakedFD(cfg.FS, t)
-	service, err := NewService(cfg)
+	service, err := NewService(cfg,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	peers := make(map[uint64]dragonboat.Target)
 	peers[1] = service.ID()
@@ -79,7 +84,11 @@ func TestNewService(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cfg := getServiceTestConfig()
 	defer vfs.ReportLeakedFD(cfg.FS, t)
-	service, err := NewService(cfg)
+	service, err := NewService(cfg,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	assert.NoError(t, service.Close())
 }
@@ -508,7 +517,11 @@ func TestShardInfoCanBeQueried(t *testing.T) {
 		DisableWorkers:      true,
 	}
 	cfg1.Fill()
-	service1, err := NewService(cfg1)
+	service1, err := NewService(cfg1,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service1.Close())
@@ -517,7 +530,11 @@ func TestShardInfoCanBeQueried(t *testing.T) {
 	peers1[1] = service1.ID()
 	assert.NoError(t, service1.store.startReplica(1, 1, peers1, false))
 	cfg2.Fill()
-	service2, err := NewService(cfg2)
+	service2, err := NewService(cfg2,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service2.Close())
@@ -629,7 +646,11 @@ func TestGossipInSimulatedCluster(t *testing.T) {
 		}
 		cfg.GossipProbeInterval.Duration = 350 * time.Millisecond
 		configs = append(configs, cfg)
-		service, err := NewService(cfg)
+		service, err := NewService(cfg,
+			WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+				return true
+			}),
+		)
 		require.NoError(t, err)
 		services = append(services, service)
 	}
@@ -732,7 +753,11 @@ func TestGossipInSimulatedCluster(t *testing.T) {
 	require.NoError(t, services[12].Close())
 	services[12] = nil
 	time.Sleep(2 * time.Second)
-	service, err := NewService(configs[12])
+	service, err := NewService(configs[12],
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, service.Close())

--- a/pkg/logservice/service_wrap.go
+++ b/pkg/logservice/service_wrap.go
@@ -23,8 +23,8 @@ type WrappedService struct {
 	svc *Service
 }
 
-func NewWrappedService(c Config) (*WrappedService, error) {
-	svc, err := NewService(c)
+func NewWrappedService(c Config, opts ...Option) (*WrappedService, error) {
+	svc, err := NewService(c, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/logservice/store_hakeeper_check_test.go
+++ b/pkg/logservice/store_hakeeper_check_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/hakeeper"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 )
@@ -194,25 +195,41 @@ func runHAKeeperClusterTest(t *testing.T, fn func(*testing.T, []*Service)) {
 	cfg4.HAKeeperConfig.LogStoreTimeout.Duration = 5 * time.Second
 	cfg4.HAKeeperConfig.DNStoreTimeout.Duration = 10 * time.Second
 	cfg1.Fill()
-	service1, err := NewService(cfg1)
+	service1, err := NewService(cfg1,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service1.Close())
 	}()
 	cfg2.Fill()
-	service2, err := NewService(cfg2)
+	service2, err := NewService(cfg2,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service2.Close())
 	}()
 	cfg3.Fill()
-	service3, err := NewService(cfg3)
+	service3, err := NewService(cfg3,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service3.Close())
 	}()
 	cfg4.Fill()
-	service4, err := NewService(cfg4)
+	service4, err := NewService(cfg4,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, service4.Close())

--- a/pkg/logservice/testclient.go
+++ b/pkg/logservice/testclient.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 )
 
@@ -35,7 +36,11 @@ func NewTestService(fs vfs.FS) (*Service, ClientConfig, error) {
 		DisableWorkers:       true,
 	}
 	cfg.Fill()
-	service, err := NewService(cfg)
+	service, err := NewService(cfg,
+		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
+			return true
+		}),
+	)
 	if err != nil {
 		return nil, ClientConfig{}, err
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #4003

## What this PR does / why we need it:
- Enable flexible `morpc` option for package `logservice`
- Extend `morpc.WithBackendFilter` in order to support network partition feature