### PR TITLE
fix: dockerignore config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
 # macOS
 .DS_Store
 
@@ -11,9 +13,9 @@
 # generate files
 mo-service
 mo-server
-system_vars_config.toml
 gen_config
+store/
 
-# cgo
-*.o
-*.a
+# cgo compiler files linked system lib, so ignore it
+**/*.o
+**/*.a


### PR DESCRIPTION
Signed-off-by: wanglei4687 <wanglei4687@gmail.com>

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

1. cago compiler with link system lib, so  ignore cgo generate files
`/usr/bin/ld` is my local Apple's linker

For example: 
```
#16 52.59 # github.com/matrixorigin/matrixone/cmd/db-server
#16 52.59 /usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
#16 52.59 /usr/bin/ld: /tmp/go-link-2126209758/000006.o: in function `_cgo_df8c56550131_Cfunc_Decimal128_Add':
#16 52.59 decimal.cgo2.c:(.text+0x71): undefined reference to `Decimal128_Add'
#16 52.59 /usr/bin/ld: /tmp/go-link-2126209758/000006.o: in function `_cgo_df8c56550131_Cfunc_Decimal128_AddDecimal64':
#16 52.59 decimal.cgo2.c:(.text+0xcd): undefined reference to `Decimal128_AddDecimal64'
#16 52.59 /usr/bin/ld: /tmp/go-link-2126209758/000006.o: in function `_cgo_df8c56550131_Cfunc_Decimal128_AddInt64':
```

2. According to #4535, the `system_vars_config.toml` will be the default config and  `make config` do not generate configuration files. So `system_vars_config.toml` should not be ignored. It's related to [optools/images/Dockerfile](https://github.com/matrixorigin/matrixone/blob/main/optools/images/Dockerfile)

3. Add some other generate files, like `gen_config` and ignore generate data at `store/`. 

4. Fix config error
