### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -50,9 +50,9 @@ func TestS3FS(t *testing.T) {
 	err = json.Unmarshal(content, &config)
 	assert.Nil(t, err)
 
-	os.Setenv("AWS_REGION", config.Region)
-	os.Setenv("AWS_ACCESS_KEY_ID", config.APIKey)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", config.APISecret)
+	t.Setenv("AWS_REGION", config.Region)
+	t.Setenv("AWS_ACCESS_KEY_ID", config.APIKey)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", config.APISecret)
 
 	t.Run("file service", func(t *testing.T) {
 		testFileService(t, func() FileService {
@@ -129,9 +129,9 @@ func TestS3FSMinioServer(t *testing.T) {
 	assert.Nil(t, err)
 
 	// set s3 credentials
-	os.Setenv("AWS_REGION", "test")
-	os.Setenv("AWS_ACCESS_KEY_ID", "minioadmin")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "minioadmin")
+	t.Setenv("AWS_REGION", "test")
+	t.Setenv("AWS_ACCESS_KEY_ID", "minioadmin")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "minioadmin")
 
 	endpoint := "http://localhost:9000"
 
@@ -195,9 +195,9 @@ func BenchmarkS3FS(b *testing.B) {
 	err = json.Unmarshal(content, &config)
 	assert.Nil(b, err)
 
-	os.Setenv("AWS_REGION", config.Region)
-	os.Setenv("AWS_ACCESS_KEY_ID", config.APIKey)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", config.APISecret)
+	b.Setenv("AWS_REGION", config.Region)
+	b.Setenv("AWS_ACCESS_KEY_ID", config.APIKey)
+	b.Setenv("AWS_SECRET_ACCESS_KEY", config.APISecret)
 
 	b.ResetTimer()
 

--- a/pkg/util/metric/config_test.go
+++ b/pkg/util/metric/config_test.go
@@ -15,7 +15,6 @@
 package metric
 
 import (
-	"os"
 	"strconv"
 	"testing"
 
@@ -26,16 +25,16 @@ func TestEnvOrDefaultBool(t *testing.T) {
 	key := "MO_TEST"
 	assert.Equal(t, envOrDefaultBool(key, 42), int32(42))
 	for _, s := range []string{"1", "True", "T", "true"} {
-		os.Setenv(key, s)
+		t.Setenv(key, s)
 		assert.Equal(t, envOrDefaultBool(key, 42), int32(1))
 	}
 	for _, s := range []string{"0", "f", "false"} {
-		os.Setenv(key, s)
+		t.Setenv(key, s)
 		assert.Equal(t, envOrDefaultBool(key, 42), int32(0))
 	}
 
 	for _, s := range []string{"", "nope", "stop"} {
-		os.Setenv(key, s)
+		t.Setenv(key, s)
 		assert.Equal(t, envOrDefaultBool(key, 42), int32(42))
 	}
 }
@@ -45,11 +44,11 @@ func TestEnvOrDefaultInt(t *testing.T) {
 	assert.Equal(t, envOrDefaultInt[int32](key, 42), int32(42))
 
 	for _, i := range []int{1, 2, 3, 5} {
-		os.Setenv(key, strconv.Itoa(i))
+		t.Setenv(key, strconv.Itoa(i))
 		assert.Equal(t, envOrDefaultInt[int32](key, 42), int32(i))
 	}
 	for _, s := range []string{"x", "02f1", "ffs", "0x12"} {
-		os.Setenv(key, s)
+		t.Setenv(key, s)
 		assert.Equal(t, envOrDefaultInt[int64](key, 42), int64(42))
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

Reference: https://pkg.go.dev/testing#T.Setenv