### PR TITLE
txn: support create txn sender by config

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -219,7 +219,7 @@ func (s *service) getHAKeeperClient() (client logservice.CNHAKeeperClient, err e
 
 func (s *service) getTxnSender() (sender rpc.TxnSender, err error) {
 	s.initTxnSenderOnce.Do(func() {
-		sender, err = rpc.NewSender(s.logger) //TODO options
+		sender, err = rpc.NewSenderWithConfig(s.cfg.RPC, s.logger)
 		if err != nil {
 			return
 		}

--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -88,6 +88,9 @@ type Config struct {
 		// ClientConfig hakeeper client configuration
 		ClientConfig logservice.HAKeeperClientConfig
 	}
+
+	// RPC rpc config used to build txn sender
+	RPC rpc.Config `toml:"rpc"`
 }
 
 type service struct {

--- a/pkg/dnservice/cfg.go
+++ b/pkg/dnservice/cfg.go
@@ -20,22 +20,19 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/logservice"
+	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 	"github.com/matrixorigin/matrixone/pkg/util/toml"
 )
 
 var (
 	defaultListenAddress    = "0.0.0.0:22000"
 	defaultServiceAddress   = "127.0.0.1:22000"
-	defaultMaxConnections   = 400
-	defaultMaxIdleDuration  = time.Minute
-	defaultSendQueueSize    = 10240
 	defaultMaxClockOffset   = time.Millisecond * 500
 	defaultZombieTimeout    = time.Hour
 	defaultDiscoveryTimeout = time.Second * 30
 	defaultHeatbeatDuration = time.Second
 	defaultConnectTimeout   = time.Second * 30
 	defaultHeatbeatTimeout  = time.Millisecond * 500
-	defaultBufferSize       = 1024
 )
 
 // Config dn store configuration
@@ -67,26 +64,7 @@ type Config struct {
 	}
 
 	// RPC configuration
-	RPC struct {
-		// MaxConnections maximum number of connections to communicate with each DNStore.
-		// Default is 400.
-		MaxConnections int `toml:"max-connections"`
-		// MaxIdleDuration maximum connection idle time, connection will be closed automatically
-		// if this value is exceeded. Default is 1 min.
-		MaxIdleDuration toml.Duration `toml:"max-idle-duration"`
-		// SendQueueSize maximum capacity of the send request queue per connection, when the
-		// queue is full, the send request will be blocked. Default is 10240.
-		SendQueueSize int `toml:"send-queue-size"`
-		// BusyQueueSize when the length of the send queue reaches the currently set value, the
-		// current connection is busy with high load. When any connection with Busy status exists,
-		// a new connection will be created until the value set by MaxConnections is reached.
-		// Default is 3/4 of SendQueueSize.
-		BusyQueueSize int `toml:"busy-queue-size"`
-		// WriteBufferSize buffer size for write messages per connection. Default is 1kb
-		WriteBufferSize toml.ByteSize `toml:"write-buffer-size"`
-		// ReadBufferSize buffer size for read messages per connection. Default is 1kb
-		ReadBufferSize toml.ByteSize `toml:"read-buffer-size"`
-	}
+	RPC rpc.Config `toml:"rpc"`
 
 	// Txn transactions configuration
 	Txn struct {
@@ -129,24 +107,6 @@ func (c *Config) Validate() error {
 	}
 	if c.ServiceAddress == "" {
 		c.ServiceAddress = c.ListenAddress
-	}
-	if c.RPC.MaxConnections == 0 {
-		c.RPC.MaxConnections = defaultMaxConnections
-	}
-	if c.RPC.SendQueueSize == 0 {
-		c.RPC.SendQueueSize = defaultSendQueueSize
-	}
-	if c.RPC.BusyQueueSize == 0 {
-		c.RPC.BusyQueueSize = c.RPC.SendQueueSize * 3 / 4
-	}
-	if c.RPC.WriteBufferSize == 0 {
-		c.RPC.WriteBufferSize = toml.ByteSize(defaultBufferSize)
-	}
-	if c.RPC.ReadBufferSize == 0 {
-		c.RPC.ReadBufferSize = toml.ByteSize(defaultBufferSize)
-	}
-	if c.RPC.MaxIdleDuration.Duration == 0 {
-		c.RPC.MaxIdleDuration.Duration = defaultMaxIdleDuration
 	}
 	if c.Txn.Clock.MaxClockOffset.Duration == 0 {
 		c.Txn.Clock.MaxClockOffset.Duration = defaultMaxClockOffset

--- a/pkg/dnservice/cfg_test.go
+++ b/pkg/dnservice/cfg_test.go
@@ -17,7 +17,6 @@ package dnservice
 import (
 	"testing"
 
-	"github.com/matrixorigin/matrixone/pkg/util/toml"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,15 +25,9 @@ func TestValidate(t *testing.T) {
 	assert.Error(t, c.Validate())
 	c.UUID = "dn1"
 	assert.NoError(t, c.Validate())
-
 	assert.Equal(t, defaultListenAddress, c.ListenAddress)
 	assert.Equal(t, c.ListenAddress, defaultListenAddress)
 	assert.Equal(t, c.ServiceAddress, defaultServiceAddress)
-	assert.Equal(t, defaultMaxConnections, c.RPC.MaxConnections)
-	assert.Equal(t, defaultSendQueueSize, c.RPC.SendQueueSize)
-	assert.Equal(t, defaultMaxIdleDuration, c.RPC.MaxIdleDuration.Duration)
-	assert.Equal(t, toml.ByteSize(defaultBufferSize), c.RPC.WriteBufferSize)
-	assert.Equal(t, toml.ByteSize(defaultBufferSize), c.RPC.ReadBufferSize)
 	assert.Equal(t, defaultMaxClockOffset, c.Txn.Clock.MaxClockOffset.Duration)
 	assert.Equal(t, localClockBackend, c.Txn.Clock.Backend)
 	assert.Equal(t, taeStorageBackend, c.Txn.Storage.Backend)

--- a/pkg/txn/rpc/cfg.go
+++ b/pkg/txn/rpc/cfg.go
@@ -1,0 +1,92 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"time"
+
+	"github.com/fagongzi/goetty/v2"
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
+	"go.uber.org/zap"
+)
+
+var (
+	defaultMaxConnections  = 400
+	defaultMaxIdleDuration = time.Minute
+	defaultSendQueueSize   = 10240
+	defaultBufferSize      = 1024
+)
+
+// Config txn sender config
+type Config struct {
+	// MaxConnections maximum number of connections to communicate with each DNStore.
+	// Default is 400.
+	MaxConnections int `toml:"max-connections"`
+	// MaxIdleDuration maximum connection idle time, connection will be closed automatically
+	// if this value is exceeded. Default is 1 min.
+	MaxIdleDuration toml.Duration `toml:"max-idle-duration"`
+	// SendQueueSize maximum capacity of the send request queue per connection, when the
+	// queue is full, the send request will be blocked. Default is 10240.
+	SendQueueSize int `toml:"send-queue-size"`
+	// BusyQueueSize when the length of the send queue reaches the currently set value, the
+	// current connection is busy with high load. When any connection with Busy status exists,
+	// a new connection will be created until the value set by MaxConnections is reached.
+	// Default is 3/4 of SendQueueSize.
+	BusyQueueSize int `toml:"busy-queue-size"`
+	// WriteBufferSize buffer size for write messages per connection. Default is 1kb
+	WriteBufferSize toml.ByteSize `toml:"write-buffer-size"`
+	// ReadBufferSize buffer size for read messages per connection. Default is 1kb
+	ReadBufferSize toml.ByteSize `toml:"read-buffer-size"`
+}
+
+func (c *Config) adjust() {
+	if c.MaxConnections == 0 {
+		c.MaxConnections = defaultMaxConnections
+	}
+	if c.SendQueueSize == 0 {
+		c.SendQueueSize = defaultSendQueueSize
+	}
+	if c.BusyQueueSize == 0 {
+		c.BusyQueueSize = c.SendQueueSize * 3 / 4
+	}
+	if c.WriteBufferSize == 0 {
+		c.WriteBufferSize = toml.ByteSize(defaultBufferSize)
+	}
+	if c.ReadBufferSize == 0 {
+		c.ReadBufferSize = toml.ByteSize(defaultBufferSize)
+	}
+	if c.MaxIdleDuration.Duration == 0 {
+		c.MaxIdleDuration.Duration = defaultMaxIdleDuration
+	}
+}
+
+func (c Config) getBackendOptions(logger *zap.Logger) []morpc.BackendOption {
+	return []morpc.BackendOption{
+		morpc.WithBackendLogger(logger),
+		morpc.WithBackendBusyBufferSize(c.BusyQueueSize),
+		morpc.WithBackendBufferSize(c.SendQueueSize),
+		morpc.WithBackendGoettyOptions(goetty.WithSessionRWBUfferSize(int(c.ReadBufferSize),
+			int(c.WriteBufferSize))),
+	}
+}
+
+func (c Config) getClientOptions(logger *zap.Logger) []morpc.ClientOption {
+	return []morpc.ClientOption{
+		morpc.WithClientLogger(logger),
+		morpc.WithClientMaxBackendPerHost(c.MaxConnections),
+		morpc.WithClientMaxBackendMaxIdleDuration(c.MaxIdleDuration.Duration),
+	}
+}

--- a/pkg/txn/rpc/cfg_test.go
+++ b/pkg/txn/rpc/cfg_test.go
@@ -1,0 +1,32 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdjustConfig(t *testing.T) {
+	c := Config{}
+	c.adjust()
+	assert.Equal(t, defaultMaxConnections, c.MaxConnections)
+	assert.Equal(t, defaultSendQueueSize, c.SendQueueSize)
+	assert.Equal(t, defaultMaxIdleDuration, c.MaxIdleDuration.Duration)
+	assert.Equal(t, toml.ByteSize(defaultBufferSize), c.WriteBufferSize)
+	assert.Equal(t, toml.ByteSize(defaultBufferSize), c.ReadBufferSize)
+}

--- a/pkg/txn/rpc/sender.go
+++ b/pkg/txn/rpc/sender.go
@@ -37,7 +37,7 @@ func WithSenderPayloadBufferSize(value int) SenderOption {
 // WithSenderBackendOptions set options for create backend connections
 func WithSenderBackendOptions(options ...morpc.BackendOption) SenderOption {
 	return func(s *sender) {
-		s.options.backendCreateOptions = options
+		s.options.backendCreateOptions = append(s.options.backendCreateOptions, options...)
 	}
 }
 
@@ -71,6 +71,14 @@ type sender struct {
 		responsePool    *sync.Pool
 		localStreamPool *sync.Pool
 	}
+}
+
+// NewSenderWithConfig create a txn sender by config and options
+func NewSenderWithConfig(cfg Config, logger *zap.Logger, options ...SenderOption) (TxnSender, error) {
+	cfg.adjust()
+	options = append(options, WithSenderBackendOptions(cfg.getBackendOptions(logger)...))
+	options = append(options, WithSenderClientOptions(cfg.getClientOptions(logger)...))
+	return NewSender(logger, options...)
 }
 
 // NewSender create a txn sender


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Support create txn sender by config. And DN and CN service can share this implementation.