### PR TITLE
cnservice: allow running standalone memory engine

### DIFF
--- a/pkg/dnservice/factory.go
+++ b/pkg/dnservice/factory.go
@@ -125,9 +125,7 @@ func (s *store) newLocalClock() clock.Clock {
 func (s *store) newMemTxnStorage(shard metadata.DNShard, logClient logservice.Client) (storage.TxnStorage, error) {
 	hm := host.New(1 << 30)
 	gm := guest.New(1<<30, hm)
-	return txnstorage.New(
-		txnstorage.NewMemHandler(mheap.New(gm), txnstorage.SnapshotIsolation),
-	)
+	return txnstorage.NewMemoryStorage(mheap.New(gm), txnstorage.SnapshotIsolation)
 }
 
 func (s *store) newMemKVStorage(shard metadata.DNShard, logClient logservice.Client) (storage.TxnStorage, error) {

--- a/pkg/vm/engine/txn/test/node.go
+++ b/pkg/vm/engine/txn/test/node.go
@@ -45,10 +45,11 @@ func (t *testEnv) NewNode(id uint64) *Node {
 		Address:   fmt.Sprintf("shard-%d", id),
 	}
 
-	storage, err := txnstorage.New(
-		txnstorage.NewMemHandler(testutil.NewMheap(), txnstorage.IsolationPolicy{
+	storage, err := txnstorage.NewMemoryStorage(
+		testutil.NewMheap(),
+		txnstorage.IsolationPolicy{
 			Read: txnstorage.ReadCommitted,
-		}),
+		},
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #4250 

## What this PR does / why we need it:
cnservice: add Config.Validate
cnservice: add service.initMemoryEngine; wait available DN before starting memory engine
dnservice: use txnstorage in newMemTxnStorage
mo-service: implement standalone service type; add config file for standalone memory engine deployment
mo-service: wait hakeeper ready before starting DN
mo-service: wait shard ready before starting CN
txnengine: set node address in Shard
txnengine: update cluster details in GetClusterDetailsFromHAKeeper