### PR TITLE
logservice: fixed gossip seed addresses used in tests

### DIFF
--- a/pkg/logservice/service_test.go
+++ b/pkg/logservice/service_test.go
@@ -34,14 +34,18 @@ import (
 )
 
 const (
-	testServiceAddress = "127.0.0.1:9000"
+	testServiceAddress     = "127.0.0.1:9000"
+	testGossipAddress      = "127.0.0.1:9010"
+	dummyGossipSeedAddress = "127.0.0.1:9100"
 )
 
 func getServiceTestConfig() Config {
 	c := Config{
 		UUID:                 uuid.New().String(),
 		RTTMillisecond:       10,
-		GossipSeedAddresses:  []string{"127.0.0.1:9000"},
+		GossipAddress:        testGossipAddress,
+		GossipListenAddress:  testGossipAddress,
+		GossipSeedAddresses:  []string{testGossipAddress, dummyGossipSeedAddress},
 		DeploymentID:         1,
 		FS:                   vfs.NewStrictMem(),
 		ServiceListenAddress: testServiceAddress,

--- a/pkg/logservice/store_test.go
+++ b/pkg/logservice/store_test.go
@@ -59,7 +59,8 @@ func getStoreTestConfig() Config {
 	cfg := Config{
 		UUID:                uuid.New().String(),
 		RTTMillisecond:      10,
-		GossipSeedAddresses: []string{"127.0.0.1:9000"},
+		GossipAddress:       testGossipAddress,
+		GossipSeedAddresses: []string{testGossipAddress, dummyGossipSeedAddress},
 		DeploymentID:        1,
 		FS:                  vfs.NewStrictMem(),
 		UseTeeLogDB:         true,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

Stop directing gossip traffics to service address as that could confuse some tests.  