### PR TITLE
bugfix: trace collection with HANG problem

### DIFF
--- a/pkg/util/export/batch_processor.go
+++ b/pkg/util/export/batch_processor.go
@@ -91,8 +91,8 @@ func (b *bufferHolder) Add(item batchpipe.HasName) {
 		time.Sleep(time.Millisecond)
 		b.mux.RLock()
 	}
-	defer b.mux.RUnlock()
 	b.buffer.Add(item)
+	b.mux.RUnlock()
 	if b.buffer.ShouldFlush() {
 		b.signal(b)
 	}
@@ -254,7 +254,7 @@ loop:
 	logutil.Debugf("doCollect %dth: Done.", idx)
 }
 
-func awakeBuffer(c *MOCollector) func(holder *bufferHolder) {
+var awakeBuffer = func(c *MOCollector) func(holder *bufferHolder) {
 	return func(holder *bufferHolder) {
 		c.awakeGenerate <- holder
 	}


### PR DESCRIPTION
…ck wait buffer.RLook

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #4523

## What this PR does / why we need it:

trace collection may Hang(actually deadlock), while buffer.Lock wait buffer.RLook, leads to mo-service no-response