### PR TITLE
txn: return DNShardNotFound instead of panic

### DIFF
--- a/pkg/dnservice/store_rpc_handler.go
+++ b/pkg/dnservice/store_rpc_handler.go
@@ -143,7 +143,8 @@ func (s *store) handleGetStatus(ctx context.Context, request *txn.TxnRequest, re
 func (s *store) validDNShard(request *txn.TxnRequest, response *txn.TxnResponse) *replica {
 	shard := request.GetTargetDN()
 	r := s.getReplica(shard.ShardID)
-	if r == nil {
+	if r == nil ||
+		r.shard.GetReplicaID() != shard.GetReplicaID() {
 		s.mu.RLock()
 		defer s.mu.RUnlock()
 		response.TxnError = &txn.TxnError{

--- a/pkg/txn/service/errors.go
+++ b/pkg/txn/service/errors.go
@@ -80,3 +80,10 @@ func newWaitTxnError(err error) *txn.TxnError {
 		Message: err.Error(),
 	}
 }
+
+func newDNShardFoundError() *txn.TxnError {
+	return &txn.TxnError{
+		Code:    txn.ErrorCode_DNShardNotFound,
+		Message: "DNShard not match, need to fetch latest DNShards from hakeeper, and retry again",
+	}
+}

--- a/pkg/txn/service/service.go
+++ b/pkg/txn/service/service.go
@@ -187,12 +187,15 @@ func (s *service) getTxnContext(txnID []byte) *txnContext {
 	return v.(*txnContext)
 }
 
-func (s *service) validDNShard(dn metadata.DNShard) {
+func (s *service) validDNShard(dn metadata.DNShard) bool {
 	if !s.shard.Equal(dn) {
-		s.logger.Fatal("DN metadata not match",
+		// DNShard not match, so cn need to fetch latest DNShards from hakeeper.
+		s.logger.Error("DN metadata not match",
 			zap.String("request-dn", dn.DebugString()),
 			zap.String("local-dn", s.shard.DebugString()))
+		return false
 	}
+	return true
 }
 
 func (s *service) acquireTxnContext() *txnContext {

--- a/pkg/txn/service/service_cn_handler.go
+++ b/pkg/txn/service/service_cn_handler.go
@@ -44,7 +44,10 @@ func (s *service) Read(ctx context.Context, request *txn.TxnRequest, response *t
 
 	response.CNOpResponse = &txn.CNOpResponse{}
 	s.checkCNRequest(request)
-	s.validDNShard(request.GetTargetDN())
+	if !s.validDNShard(request.GetTargetDN()) {
+		response.TxnError = newDNShardFoundError()
+		return nil
+	}
 
 	s.waitClockTo(request.Txn.SnapshotTS)
 
@@ -119,7 +122,10 @@ func (s *service) Write(ctx context.Context, request *txn.TxnRequest, response *
 
 	response.CNOpResponse = &txn.CNOpResponse{}
 	s.checkCNRequest(request)
-	s.validDNShard(request.GetTargetDN())
+	if !s.validDNShard(request.GetTargetDN()) {
+		response.TxnError = newDNShardFoundError()
+		return nil
+	}
 
 	txnID := request.Txn.ID
 	txnCtx, _ := s.maybeAddTxn(request.Txn)
@@ -164,7 +170,11 @@ func (s *service) Commit(ctx context.Context, request *txn.TxnRequest, response 
 	defer util.LogTxnHandleResult(s.logger, response)
 
 	response.CommitResponse = &txn.TxnCommitResponse{}
-	s.validDNShard(request.GetTargetDN())
+	if !s.validDNShard(request.GetTargetDN()) {
+		response.TxnError = newDNShardFoundError()
+		return nil
+	}
+
 	if len(request.Txn.DNShards) == 0 {
 		s.logger.Fatal("commit with empty dn shards")
 	}
@@ -306,7 +316,11 @@ func (s *service) Rollback(ctx context.Context, request *txn.TxnRequest, respons
 	defer util.LogTxnHandleResult(s.logger, response)
 
 	response.RollbackResponse = &txn.TxnRollbackResponse{}
-	s.validDNShard(request.GetTargetDN())
+	if !s.validDNShard(request.GetTargetDN()) {
+		response.TxnError = newDNShardFoundError()
+		return nil
+	}
+
 	if len(request.Txn.DNShards) == 0 {
 		s.logger.Fatal("rollback with empty dn shards")
 	}

--- a/pkg/txn/service/service_cn_handler_test.go
+++ b/pkg/txn/service/service_cn_handler_test.go
@@ -48,6 +48,29 @@ func TestReadBasic(t *testing.T) {
 	checkReadResponses(t, resp, "")
 }
 
+func TestReadWithDNShardNotMatch(t *testing.T) {
+	sender := NewTestSender()
+	defer func() {
+		assert.NoError(t, sender.Close())
+	}()
+	sender.setFilter(func(req *txn.TxnRequest) bool {
+		req.CNRequest.Target.ReplicaID = 0
+		return true
+	})
+
+	s := NewTestTxnService(t, 1, sender, NewTestClock(0))
+	assert.NoError(t, s.Start())
+	defer func() {
+		assert.NoError(t, s.Close(false))
+	}()
+
+	sender.AddTxnService(s)
+
+	rTxn := NewTestTxn(1, 1)
+	resp := readTestData(t, sender, 1, rTxn, 1)
+	checkResponses(t, resp, newDNShardFoundError())
+}
+
 func TestReadWithSelfWrite(t *testing.T) {
 	sender := NewTestSender()
 	defer func() {
@@ -394,6 +417,28 @@ func TestWriteBasic(t *testing.T) {
 	assert.Equal(t, GetTestValue(1, wTxn), v)
 }
 
+func TestWriteWithDNShardNotMatch(t *testing.T) {
+	sender := NewTestSender()
+	defer func() {
+		assert.NoError(t, sender.Close())
+	}()
+	sender.setFilter(func(req *txn.TxnRequest) bool {
+		req.CNRequest.Target.ReplicaID = 0
+		return true
+	})
+
+	s := NewTestTxnService(t, 1, sender, NewTestClock(0)).(*service)
+	assert.NoError(t, s.Start())
+	defer func() {
+		assert.NoError(t, s.Close(false))
+	}()
+
+	sender.AddTxnService(s)
+
+	wTxn := NewTestTxn(1, 1)
+	checkResponses(t, writeTestData(t, sender, 1, wTxn, 1), newDNShardFoundError())
+}
+
 func TestWriteWithWWConflict(t *testing.T) {
 	sender := NewTestSender()
 	defer func() {
@@ -449,6 +494,34 @@ func TestCommitWithSingleDNShard(t *testing.T) {
 		assert.Equal(t, [][]byte{GetTestValue(i, wTxn)}, values)
 		assert.Equal(t, []timestamp.Timestamp{NewTestTimestamp(2)}, timestamps)
 	}
+}
+
+func TestCommitWithDNShardNotMatch(t *testing.T) {
+	sender := NewTestSender()
+	defer func() {
+		assert.NoError(t, sender.Close())
+	}()
+	sender.setFilter(func(req *txn.TxnRequest) bool {
+		if req.CommitRequest != nil {
+			req.Txn.DNShards[0].ReplicaID = 0
+		}
+		return true
+	})
+
+	s := NewTestTxnService(t, 1, sender, NewTestClock(1)).(*service)
+	assert.NoError(t, s.Start())
+	defer func() {
+		assert.NoError(t, s.Close(false))
+	}()
+
+	sender.AddTxnService(s)
+
+	n := byte(10)
+	wTxn := NewTestTxn(1, 1, 1)
+	for i := byte(0); i < n; i++ {
+		checkResponses(t, writeTestData(t, sender, 1, wTxn, i))
+	}
+	checkResponses(t, commitWriteData(t, sender, wTxn), newDNShardFoundError())
 }
 
 func TestCommitWithMultiDNShards(t *testing.T) {
@@ -572,6 +645,41 @@ func TestRollback(t *testing.T) {
 
 	checkData(t, wTxn, s1, 2, 0, false)
 	checkData(t, wTxn, s2, 2, 0, false)
+}
+
+func TestRollbackWithDNShardNotFound(t *testing.T) {
+	sender := NewTestSender()
+	defer func() {
+		assert.NoError(t, sender.Close())
+	}()
+
+	sender.setFilter(func(req *txn.TxnRequest) bool {
+		if req.RollbackRequest != nil {
+			req.Txn.DNShards[0].ReplicaID = 0
+		}
+		return true
+	})
+
+	s1 := NewTestTxnService(t, 1, sender, NewTestClock(1)).(*service)
+	assert.NoError(t, s1.Start())
+	defer func() {
+		assert.NoError(t, s1.Close(false))
+	}()
+	s2 := NewTestTxnService(t, 2, sender, NewTestClock(1)).(*service)
+	assert.NoError(t, s2.Start())
+	defer func() {
+		assert.NoError(t, s2.Close(false))
+	}()
+
+	sender.AddTxnService(s1)
+	sender.AddTxnService(s2)
+
+	wTxn := NewTestTxn(1, 1, 1)
+	checkResponses(t, writeTestData(t, sender, 1, wTxn, 1))
+	wTxn.DNShards = append(wTxn.DNShards, NewTestDNShard(2))
+	checkResponses(t, writeTestData(t, sender, 2, wTxn, 2))
+
+	checkResponses(t, rollbackWriteData(t, sender, wTxn), newDNShardFoundError())
 }
 
 func writeTestData(t *testing.T, sender rpc.TxnSender, toShard uint64, wTxn txn.TxnMeta, keys ...byte) []txn.TxnResponse {

--- a/pkg/txn/service/service_dn_handler.go
+++ b/pkg/txn/service/service_dn_handler.go
@@ -30,7 +30,6 @@ func (s *service) Prepare(ctx context.Context, request *txn.TxnRequest, response
 	defer util.LogTxnHandleResult(s.logger, response)
 
 	response.PrepareResponse = &txn.TxnPrepareResponse{}
-	s.validDNShard(request.GetTargetDN())
 
 	txnID := request.Txn.ID
 	txnCtx := s.getTxnContext(txnID)
@@ -85,7 +84,6 @@ func (s *service) GetStatus(ctx context.Context, request *txn.TxnRequest, respon
 	defer util.LogTxnHandleResult(s.logger, response)
 
 	response.GetStatusResponse = &txn.TxnGetStatusResponse{}
-	s.validDNShard(request.GetTargetDN())
 
 	txnID := request.Txn.ID
 	txnCtx := s.getTxnContext(txnID)
@@ -111,7 +109,6 @@ func (s *service) CommitDNShard(ctx context.Context, request *txn.TxnRequest, re
 	defer util.LogTxnHandleResult(s.logger, response)
 
 	response.CommitDNShardResponse = &txn.TxnCommitDNShardResponse{}
-	s.validDNShard(request.GetTargetDN())
 
 	txnID := request.Txn.ID
 	txnCtx := s.getTxnContext(txnID)
@@ -167,7 +164,6 @@ func (s *service) RollbackDNShard(ctx context.Context, request *txn.TxnRequest, 
 	defer util.LogTxnHandleResult(s.logger, response)
 
 	response.RollbackDNShardResponse = &txn.TxnRollbackDNShardResponse{}
-	s.validDNShard(request.GetTargetDN())
 
 	txnID := request.Txn.ID
 	txnCtx := s.getTxnContext(txnID)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
return DNShardNotFound instead of panic for all rerequests send from CN