### PR TITLE
morpc: panic if deadline not set in Context

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -739,6 +739,9 @@ func (s *stream) Send(ctx context.Context, request Message) error {
 	if s.id != request.GetID() {
 		panic("request.id != stream.id")
 	}
+	if _, ok := ctx.Deadline(); !ok {
+		panic("deadline not set in context")
+	}
 	s.activeFunc()
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
panic if deadline not set in Context. Help to quickly locate the wrong way to use Context in morpc