### PR TITLE
Reduce unnecessary non-sequential memory copies

### DIFF
--- a/pkg/sql/colexec/anti/join.go
+++ b/pkg/sql/colexec/anti/join.go
@@ -165,10 +165,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 		copy(ctr.inBuckets, hashmap.OneUInt8s)
 		vals, zvals := itr.Find(i, n, ctr.vecs, ctr.inBuckets)
 		for k := 0; k < n; k++ {
-			if ctr.inBuckets[k] == 0 {
-				continue
-			}
-			if zvals[k] == 0 {
+			if ctr.inBuckets[k] == 0 || zvals[k] == 0 {
 				continue
 			}
 			if vals[k] == 0 {
@@ -182,7 +179,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 				continue
 			}
 			if ap.Cond != nil {
-				flg := true // mark no tuple satisfies the condition
+				matched := false // mark if any tuple satisfies the condition
 				sels := mSels[vals[k]-1]
 				for _, sel := range sels {
 					vec, err := colexec.JoinFilterEvalExprInBucket(bat, ctr.bat, i+k, int(sel), proc, ap.Cond)
@@ -191,13 +188,13 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 					}
 					bs := vec.Col.([]bool)
 					if bs[0] {
-						flg = false
+						matched = true
 						vec.Free(proc.Mp)
 						break
 					}
 					vec.Free(proc.Mp)
 				}
-				if !flg {
+				if matched {
 					continue
 				}
 				for j, pos := range ap.Result {

--- a/pkg/sql/colexec/loopleft/join.go
+++ b/pkg/sql/colexec/loopleft/join.go
@@ -17,7 +17,6 @@ package loopleft
 import (
 	"bytes"
 
-	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
@@ -99,38 +98,17 @@ func (ctr *container) emptyProbe(bat *batch.Batch, ap *Argument, proc *process.P
 	defer bat.Clean(proc.GetMheap())
 	anal.Input(bat)
 	rbat := batch.NewWithSize(len(ap.Result))
-	rbat.Zs = proc.GetMheap().GetSels()
+	count := bat.Length()
 	for i, rp := range ap.Result {
 		if rp.Rel == 0 {
-			rbat.Vecs[i] = vector.New(bat.Vecs[rp.Pos].Typ)
+			rbat.Vecs[i] = bat.Vecs[rp.Pos]
+			bat.Vecs[rp.Pos] = nil
 		} else {
-			rbat.Vecs[i] = vector.New(ctr.bat.Vecs[rp.Pos].Typ)
+			rbat.Vecs[i] = vector.NewConstNull(ctr.bat.Vecs[rp.Pos].Typ, count)
 		}
 	}
-	count := bat.Length()
-	for i := 0; i < count; i += hashmap.UnitLimit {
-		n := count - i
-		if n > hashmap.UnitLimit {
-			n = hashmap.UnitLimit
-		}
-		for k := 0; k < n; k++ {
-			for j, rp := range ap.Result {
-				if rp.Rel == 0 {
-					if err := vector.UnionOne(rbat.Vecs[j], bat.Vecs[rp.Pos], int64(i+k), proc.GetMheap()); err != nil {
-						rbat.Clean(proc.GetMheap())
-						return err
-					}
-				} else {
-					if err := vector.UnionNull(rbat.Vecs[j], nil, proc.GetMheap()); err != nil {
-						rbat.Clean(proc.GetMheap())
-						return err
-					}
-				}
-			}
-			rbat.Zs = append(rbat.Zs, bat.Zs[i+k])
-		}
-	}
-	rbat.ExpandNulls()
+	rbat.Zs = bat.Zs
+	bat.Zs = nil
 	anal.Output(rbat)
 	proc.SetInputBatch(rbat)
 	return nil
@@ -150,7 +128,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 	}
 	count := bat.Length()
 	for i := 0; i < count; i++ {
-		flg := true
+		matched := false
 		vec, err := colexec.JoinFilterEvalExpr(bat, ctr.bat, i, proc, ap.Cond)
 		if err != nil {
 			return err
@@ -159,7 +137,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 		if len(bs) == 1 {
 			if bs[0] {
 				for j := 0; j < len(ctr.bat.Zs); j++ {
-					flg = false
+					matched = true
 					for k, rp := range ap.Result {
 						if rp.Rel == 0 {
 							if err := vector.UnionOne(rbat.Vecs[k], bat.Vecs[rp.Pos], int64(i), proc.GetMheap()); err != nil {
@@ -180,7 +158,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 		} else {
 			for j, b := range bs {
 				if b {
-					flg = false
+					matched = true
 					for k, rp := range ap.Result {
 						if rp.Rel == 0 {
 							if err := vector.UnionOne(rbat.Vecs[k], bat.Vecs[rp.Pos], int64(i), proc.GetMheap()); err != nil {
@@ -199,7 +177,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 			}
 		}
 		vector.Clean(vec, proc.Mp)
-		if flg {
+		if !matched {
 			for k, rp := range ap.Result {
 				if rp.Rel == 0 {
 					if err := vector.UnionOne(rbat.Vecs[k], bat.Vecs[rp.Pos], int64(i), proc.GetMheap()); err != nil {

--- a/pkg/sql/colexec/projection/projection.go
+++ b/pkg/sql/colexec/projection/projection.go
@@ -61,10 +61,10 @@ func Call(idx int, proc *process.Process, arg any) (bool, error) {
 		}
 		rbat.Vecs[i] = vec
 	}
-	for _, vec := range rbat.Vecs {
-		for k := 0; k < len(bat.Vecs); k++ {
-			if vec == bat.Vecs[k] {
-				bat.Vecs = append(bat.Vecs[:k], bat.Vecs[k+1:]...)
+	for i, vec := range bat.Vecs {
+		for _, rVec := range rbat.Vecs {
+			if vec == rVec {
+				bat.Vecs[i] = nil
 				break
 			}
 		}

--- a/pkg/sql/colexec/semi/join.go
+++ b/pkg/sql/colexec/semi/join.go
@@ -118,7 +118,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 				continue
 			}
 			if ap.Cond != nil {
-				flg := true // mark no tuple satisfies the condition
+				matched := false // mark if any tuple satisfies the condition
 				sels := mSels[vals[k]-1]
 				for _, sel := range sels {
 					vec, err := colexec.JoinFilterEvalExprInBucket(bat, ctr.bat, i+k, int(sel), proc, ap.Cond)
@@ -127,13 +127,13 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 					}
 					bs := vec.Col.([]bool)
 					if bs[0] {
-						flg = false
+						matched = true
 						vec.Free(proc.Mp)
 						break
 					}
 					vec.Free(proc.Mp)
 				}
-				if flg {
+				if !matched {
 					continue
 				}
 			}


### PR DESCRIPTION
When the right table of LEFT/SINGLE/ANTI join is empty, we should simply
move vectors from left table to output.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: