### PR TITLE
{Opt] Fix bugs in scalar handling to enable constant fold

### DIFF
--- a/pkg/sql/plan/function/builtin/binary/typecast.go
+++ b/pkg/sql/plan/function/builtin/binary/typecast.go
@@ -138,13 +138,13 @@ var (
 	BytesToInt64   = BytesToInt[int64]
 	Int64ToBytes   = IntToBytes[int64]
 	BytesToUint8   = BytesToUint[uint8]
-	Uint8ToBytes   = IntToBytes[uint8]
+	Uint8ToBytes   = UintToBytes[uint8]
 	BytesToUint16  = BytesToUint[uint16]
-	Uint16ToBytes  = IntToBytes[uint16]
+	Uint16ToBytes  = UintToBytes[uint16]
 	BytesToUint32  = BytesToUint[uint32]
-	Uint32ToBytes  = IntToBytes[uint32]
+	Uint32ToBytes  = UintToBytes[uint32]
 	BytesToUint64  = BytesToUint[uint64]
-	Uint64ToBytes  = IntToBytes[uint64]
+	Uint64ToBytes  = UintToBytes[uint64]
 	BytesToFloat32 = BytesToFloat[float32]
 	Float32ToBytes = FloatToBytes[float32]
 	BytesToFloat64 = BytesToFloat[float64]
@@ -166,8 +166,8 @@ var (
 	BoolToBytes         = boolToBytes
 	DateToBytes         = dateToBytes
 	DateToDatetime      = dateToDateTime
-	DateTimeToBytes     = datetimeToBytes
-	DateTimeToDate      = datetimeToDate
+	DatetimeToBytes     = datetimeToBytes
+	DatetimeToDate      = datetimeToDate
 )
 
 func NumericToNumeric[T1, T2 constraints.Integer | constraints.Float](xs []T1, rs []T2) ([]T2, error) {
@@ -257,7 +257,7 @@ func BytesToUint[T constraints.Unsigned](xs *types.Bytes, rs []T) ([]T, error) {
 	return rs, nil
 }
 
-func IntToBytes[T constraints.Integer](xs []T, rs *types.Bytes) (*types.Bytes, error) {
+func IntToBytes[T constraints.Signed](xs []T, rs *types.Bytes) (*types.Bytes, error) {
 	oldLen := uint32(0)
 	for _, x := range xs {
 		rs.Data = strconv.AppendInt(rs.Data, int64(x), 10)
@@ -269,7 +269,7 @@ func IntToBytes[T constraints.Integer](xs []T, rs *types.Bytes) (*types.Bytes, e
 	return rs, nil
 }
 
-func UintToBytes[T constraints.Integer](xs []T, rs *types.Bytes) (*types.Bytes, error) {
+func UintToBytes[T constraints.Unsigned](xs []T, rs *types.Bytes) (*types.Bytes, error) {
 	oldLen := uint32(0)
 	for _, x := range xs {
 		rs.Data = strconv.AppendUint(rs.Data, uint64(x), 10)
@@ -375,11 +375,11 @@ func timestampToDatetime(loc *time.Location, xs []types.Timestamp, rs []types.Da
 
 func timestampToVarchar(loc *time.Location, xs []types.Timestamp, rs *types.Bytes, precision int32) (*types.Bytes, error) {
 	oldLen := uint32(0)
-	for i, x := range xs {
+	for _, x := range xs {
 		rs.Data = append(rs.Data, []byte(x.String2(loc, precision))...)
 		newLen := uint32(len(rs.Data))
-		rs.Offsets[i] = oldLen
-		rs.Lengths[i] = newLen - oldLen
+		rs.Offsets = append(rs.Offsets, oldLen)
+		rs.Lengths = append(rs.Lengths, newLen-oldLen)
 		oldLen = newLen
 	}
 	return rs, nil

--- a/pkg/sql/plan/function/builtin/unary/math.go
+++ b/pkg/sql/plan/function/builtin/unary/math.go
@@ -90,6 +90,9 @@ func Log(vs []*vector.Vector, proc *process.Process) (*vector.Vector, error) {
 	if len(vs) == 1 {
 		return math1(vs, proc, momath.Ln)
 	}
+	if vs[0].IsScalarNull() {
+		return vector.NewConstNull(vs[0].Typ, vs[1].Count()), nil
+	}
 	vals := vs[0].Col.([]float64)
 	for i := range vals {
 		if vals[i] == float64(1) {

--- a/pkg/sql/plan/function/operator/cast.go
+++ b/pkg/sql/plan/function/operator/cast.go
@@ -717,49 +717,71 @@ func CastDecimal64ToString(lv, rv *vector.Vector, proc *process.Process) (*vecto
 	var err error
 
 	lvs := vector.MustTCols[types.Decimal64](lv)
-	col := &types.Bytes{
-		Data:    make([]byte, 0, len(lvs)),
+	if lv.IsScalar() {
+		vec := proc.AllocScalarVector(rv.Typ)
+		rs := &types.Bytes{
+			Data:    []byte{},
+			Offsets: make([]uint32, 0, 1),
+			Lengths: make([]uint32, 0, 1),
+		}
+		if _, err = binary.Decimal64ToBytes(lvs, rs, lv.Typ.Scale); err != nil {
+			return nil, err
+		}
+		nulls.Set(vec.Nsp, lv.Nsp)
+		vector.SetCol(vec, rs)
+		return vec, nil
+	}
+
+	vec, err := proc.AllocVector(rv.Typ, int64(rv.Typ.Size)*int64(len(lvs)))
+	if err != nil {
+		return nil, err
+	}
+	rs := &types.Bytes{
+		Data:    []byte{},
 		Offsets: make([]uint32, 0, len(lvs)),
 		Lengths: make([]uint32, 0, len(lvs)),
 	}
-	if col, err = binary.Decimal64ToBytes(lvs, col, lv.Typ.Scale); err != nil {
+	if _, err := binary.Decimal64ToBytes(lvs, rs, lv.Typ.Scale); err != nil {
 		return nil, err
 	}
-	if err = proc.Mp.Gm.Alloc(int64(cap(col.Data))); err != nil {
-		return nil, err
-	}
-	vec := vector.New(rv.Typ)
-	if lv.IsScalar() {
-		vec.IsConst = true
-	}
-	vec.Data = col.Data
 	nulls.Set(vec.Nsp, lv.Nsp)
-	vector.SetCol(vec, col)
+	vector.SetCol(vec, rs)
 	return vec, nil
 }
 
 func CastDecimal128ToString(lv, rv *vector.Vector, proc *process.Process) (*vector.Vector, error) {
 	var err error
+
 	lvs := vector.MustTCols[types.Decimal128](lv)
-	col := &types.Bytes{
-		Data:    make([]byte, 0, len(lvs)),
+	if lv.IsScalar() {
+		vec := proc.AllocScalarVector(rv.Typ)
+		rs := &types.Bytes{
+			Data:    []byte{},
+			Offsets: make([]uint32, 0, 1),
+			Lengths: make([]uint32, 0, 1),
+		}
+		if _, err = binary.Decimal128ToBytes(lvs, rs, lv.Typ.Scale); err != nil {
+			return nil, err
+		}
+		nulls.Set(vec.Nsp, lv.Nsp)
+		vector.SetCol(vec, rs)
+		return vec, nil
+	}
+
+	vec, err := proc.AllocVector(rv.Typ, int64(rv.Typ.Size)*int64(len(lvs)))
+	if err != nil {
+		return nil, err
+	}
+	rs := &types.Bytes{
+		Data:    []byte{},
 		Offsets: make([]uint32, 0, len(lvs)),
 		Lengths: make([]uint32, 0, len(lvs)),
 	}
-
-	if col, err = binary.Decimal128ToBytes(lvs, col, lv.Typ.Scale); err != nil {
+	if _, err := binary.Decimal128ToBytes(lvs, rs, lv.Typ.Scale); err != nil {
 		return nil, err
 	}
-	if err = proc.Mp.Gm.Alloc(int64(cap(col.Data))); err != nil {
-		return nil, err
-	}
-	vec := vector.New(rv.Typ)
-	if lv.IsScalar() {
-		vec.IsConst = true
-	}
-	vec.Data = col.Data
 	nulls.Set(vec.Nsp, lv.Nsp)
-	vector.SetCol(vec, col)
+	vector.SetCol(vec, rs)
 	return vec, nil
 }
 
@@ -1063,49 +1085,73 @@ func CastSpecials1Float[T constraints.Float](lv, rv *vector.Vector, proc *proces
 // (int8 /int16/int32/int64) -> (char / varhcar / text)
 func CastSpecials2Int[T constraints.Signed](lv, rv *vector.Vector, proc *process.Process) (*vector.Vector, error) {
 	var err error
+
 	lvs := vector.MustTCols[T](lv)
-	col := &types.Bytes{
-		Data:    make([]byte, 0, len(lvs)),
+	if lv.IsScalar() {
+		vec := proc.AllocScalarVector(rv.Typ)
+		rs := &types.Bytes{
+			Data:    []byte{},
+			Offsets: make([]uint32, 0, 1),
+			Lengths: make([]uint32, 0, 1),
+		}
+		if _, err = binary.IntToBytes(lvs, rs); err != nil {
+			return nil, err
+		}
+		nulls.Set(vec.Nsp, lv.Nsp)
+		vector.SetCol(vec, rs)
+		return vec, nil
+	}
+
+	vec, err := proc.AllocVector(rv.Typ, int64(rv.Typ.Size)*int64(len(lvs)))
+	if err != nil {
+		return nil, err
+	}
+	rs := &types.Bytes{
+		Data:    []byte{},
 		Offsets: make([]uint32, 0, len(lvs)),
 		Lengths: make([]uint32, 0, len(lvs)),
 	}
-	if col, err = binary.IntToBytes(lvs, col); err != nil {
+	if _, err := binary.IntToBytes(lvs, rs); err != nil {
 		return nil, err
 	}
-	if err = proc.Mp.Gm.Alloc(int64(cap(col.Data))); err != nil {
-		return nil, err
-	}
-	vec := vector.New(rv.Typ)
-	if lv.IsScalar() {
-		vec.IsConst = true
-	}
-	vec.Data = col.Data
 	nulls.Set(vec.Nsp, lv.Nsp)
-	vector.SetCol(vec, col)
+	vector.SetCol(vec, rs)
 	return vec, nil
 }
 
 func CastSpecials2Uint[T constraints.Unsigned](lv, rv *vector.Vector, proc *process.Process) (*vector.Vector, error) {
 	var err error
+
 	lvs := vector.MustTCols[T](lv)
-	col := &types.Bytes{
-		Data:    make([]byte, 0, len(lvs)),
+	if lv.IsScalar() {
+		vec := proc.AllocScalarVector(rv.Typ)
+		rs := &types.Bytes{
+			Data:    []byte{},
+			Offsets: make([]uint32, 0, 1),
+			Lengths: make([]uint32, 0, 1),
+		}
+		if _, err = binary.UintToBytes(lvs, rs); err != nil {
+			return nil, err
+		}
+		nulls.Set(vec.Nsp, lv.Nsp)
+		vector.SetCol(vec, rs)
+		return vec, nil
+	}
+
+	vec, err := proc.AllocVector(rv.Typ, int64(rv.Typ.Size)*int64(len(lvs)))
+	if err != nil {
+		return nil, err
+	}
+	rs := &types.Bytes{
+		Data:    []byte{},
 		Offsets: make([]uint32, 0, len(lvs)),
 		Lengths: make([]uint32, 0, len(lvs)),
 	}
-	if col, err = binary.UintToBytes(lvs, col); err != nil {
+	if _, err := binary.UintToBytes(lvs, rs); err != nil {
 		return nil, err
 	}
-	if err = proc.Mp.Gm.Alloc(int64(cap(col.Data))); err != nil {
-		return nil, err
-	}
-	vec := vector.New(rv.Typ)
-	if lv.IsScalar() {
-		vec.IsConst = true
-	}
-	vec.Data = col.Data
 	nulls.Set(vec.Nsp, lv.Nsp)
-	vector.SetCol(vec, col)
+	vector.SetCol(vec, rs)
 	return vec, nil
 }
 
@@ -1113,25 +1159,37 @@ func CastSpecials2Uint[T constraints.Unsigned](lv, rv *vector.Vector, proc *proc
 // (float32/float64) -> (char / varhcar)
 func CastSpecials2Float[T constraints.Float](lv, rv *vector.Vector, proc *process.Process) (*vector.Vector, error) {
 	var err error
+
 	lvs := vector.MustTCols[T](lv)
-	col := &types.Bytes{
-		Data:    make([]byte, 0, len(lvs)),
+	if lv.IsScalar() {
+		vec := proc.AllocScalarVector(rv.Typ)
+		rs := &types.Bytes{
+			Data:    []byte{},
+			Offsets: make([]uint32, 0, 1),
+			Lengths: make([]uint32, 0, 1),
+		}
+		if _, err = binary.FloatToBytes(lvs, rs); err != nil {
+			return nil, err
+		}
+		nulls.Set(vec.Nsp, lv.Nsp)
+		vector.SetCol(vec, rs)
+		return vec, nil
+	}
+
+	vec, err := proc.AllocVector(rv.Typ, int64(rv.Typ.Size)*int64(len(lvs)))
+	if err != nil {
+		return nil, err
+	}
+	rs := &types.Bytes{
+		Data:    []byte{},
 		Offsets: make([]uint32, 0, len(lvs)),
 		Lengths: make([]uint32, 0, len(lvs)),
 	}
-	if col, err = binary.FloatToBytes(lvs, col); err != nil {
+	if _, err := binary.FloatToBytes(lvs, rs); err != nil {
 		return nil, err
 	}
-	if err = proc.Mp.Gm.Alloc(int64(cap(col.Data))); err != nil {
-		return nil, err
-	}
-	vec := vector.New(rv.Typ)
-	if lv.IsScalar() {
-		vec.IsConst = true
-	}
-	vec.Data = col.Data
 	nulls.Set(vec.Nsp, lv.Nsp)
-	vector.SetCol(vec, col)
+	vector.SetCol(vec, rs)
 	return vec, nil
 }
 
@@ -1172,9 +1230,6 @@ func CastSpecials2Float[T constraints.Float](lv, rv *vector.Vector, proc *proces
 func CastSpecials3(lv, rv *vector.Vector, proc *process.Process) (*vector.Vector, error) {
 	source := vector.MustBytesCols(lv)
 	if lv.IsScalar() {
-		if lv.IsScalarNull() {
-			return proc.AllocScalarNullVector(rv.Typ), nil
-		}
 		vec := proc.AllocScalarVector(rv.Typ)
 		vec.Col = &types.Bytes{
 			Data:    make([]byte, len(source.Data)),
@@ -1611,14 +1666,11 @@ func castTimestampAsVarchar(lv, rv *vector.Vector, proc *process.Process) (*vect
 	resultElementSize := int(resultType.Size)
 	precision := lv.Typ.Precision
 	if lv.IsScalar() {
-		if lv.IsScalarNull() {
-			return proc.AllocScalarNullVector(resultType), nil
-		}
 		vec := proc.AllocScalarVector(resultType)
 		rs := &types.Bytes{
 			Data:    []byte{},
-			Offsets: make([]uint32, 1),
-			Lengths: make([]uint32, 1),
+			Offsets: make([]uint32, 0, 1),
+			Lengths: make([]uint32, 0, 1),
 		}
 		if _, err := binary.TimestampToVarchar(proc.SessionInfo.TimeZone, lvs, rs, precision); err != nil {
 			return nil, err
@@ -1634,8 +1686,8 @@ func castTimestampAsVarchar(lv, rv *vector.Vector, proc *process.Process) (*vect
 	}
 	rs := &types.Bytes{
 		Data:    []byte{},
-		Offsets: make([]uint32, len(lvs)),
-		Lengths: make([]uint32, len(lvs)),
+		Offsets: make([]uint32, 0, len(lvs)),
+		Lengths: make([]uint32, 0, len(lvs)),
 	}
 	if _, err := binary.TimestampToVarchar(proc.SessionInfo.TimeZone, lvs, rs, precision); err != nil {
 		return nil, err
@@ -1688,49 +1740,73 @@ func CastStringAsDecimal64(lv, rv *vector.Vector, proc *process.Process) (*vecto
 
 func CastBoolToString(lv, rv *vector.Vector, proc *process.Process) (*vector.Vector, error) {
 	var err error
+
 	lvs := vector.MustTCols[bool](lv)
-	col := &types.Bytes{
-		Data:    make([]byte, 0, len(lvs)),
+	if lv.IsScalar() {
+		vec := proc.AllocScalarVector(rv.Typ)
+		rs := &types.Bytes{
+			Data:    []byte{},
+			Offsets: make([]uint32, 0, 1),
+			Lengths: make([]uint32, 0, 1),
+		}
+		if _, err = binary.BoolToBytes(lvs, rs); err != nil {
+			return nil, err
+		}
+		nulls.Set(vec.Nsp, lv.Nsp)
+		vector.SetCol(vec, rs)
+		return vec, nil
+	}
+
+	vec, err := proc.AllocVector(rv.Typ, int64(rv.Typ.Size)*int64(len(lvs)))
+	if err != nil {
+		return nil, err
+	}
+	rs := &types.Bytes{
+		Data:    []byte{},
 		Offsets: make([]uint32, 0, len(lvs)),
 		Lengths: make([]uint32, 0, len(lvs)),
 	}
-	if col, err = binary.BoolToBytes(lvs, col); err != nil {
+	if _, err := binary.BoolToBytes(lvs, rs); err != nil {
 		return nil, err
 	}
-	if err = proc.Mp.Gm.Alloc(int64(cap(col.Data))); err != nil {
-		return nil, err
-	}
-	vec := vector.New(rv.Typ)
-	if lv.IsScalar() {
-		vec.IsConst = true
-	}
-	vec.Data = col.Data
 	nulls.Set(vec.Nsp, lv.Nsp)
-	vector.SetCol(vec, col)
+	vector.SetCol(vec, rs)
 	return vec, nil
 }
 
 func CastDateAsString(lv, rv *vector.Vector, proc *process.Process) (*vector.Vector, error) {
 	var err error
+
 	lvs := vector.MustTCols[types.Date](lv)
-	col := &types.Bytes{
-		Data:    make([]byte, 0, len(lvs)),
+	if lv.IsScalar() {
+		vec := proc.AllocScalarVector(rv.Typ)
+		rs := &types.Bytes{
+			Data:    []byte{},
+			Offsets: make([]uint32, 0, 1),
+			Lengths: make([]uint32, 0, 1),
+		}
+		if _, err = binary.DateToBytes(lvs, rs); err != nil {
+			return nil, err
+		}
+		nulls.Set(vec.Nsp, lv.Nsp)
+		vector.SetCol(vec, rs)
+		return vec, nil
+	}
+
+	vec, err := proc.AllocVector(rv.Typ, int64(rv.Typ.Size)*int64(len(lvs)))
+	if err != nil {
+		return nil, err
+	}
+	rs := &types.Bytes{
+		Data:    []byte{},
 		Offsets: make([]uint32, 0, len(lvs)),
 		Lengths: make([]uint32, 0, len(lvs)),
 	}
-	if col, err = binary.DateToBytes(lvs, col); err != nil {
+	if _, err := binary.DateToBytes(lvs, rs); err != nil {
 		return nil, err
 	}
-	if err = proc.Mp.Gm.Alloc(int64(cap(col.Data))); err != nil {
-		return nil, err
-	}
-	vec := vector.New(rv.Typ)
-	if lv.IsScalar() {
-		vec.IsConst = true
-	}
-	vec.Data = col.Data
 	nulls.Set(vec.Nsp, lv.Nsp)
-	vector.SetCol(vec, col)
+	vector.SetCol(vec, rs)
 	return vec, nil
 }
 
@@ -1853,25 +1929,37 @@ func CastDateAsTimeStamp(lv, rv *vector.Vector, proc *process.Process) (*vector.
 
 func CastDatetimeAsString(lv, rv *vector.Vector, proc *process.Process) (*vector.Vector, error) {
 	var err error
+
 	lvs := vector.MustTCols[types.Datetime](lv)
-	col := &types.Bytes{
-		Data:    make([]byte, 0, len(lvs)),
+	if lv.IsScalar() {
+		vec := proc.AllocScalarVector(rv.Typ)
+		rs := &types.Bytes{
+			Data:    []byte{},
+			Offsets: make([]uint32, 0, 1),
+			Lengths: make([]uint32, 0, 1),
+		}
+		if _, err = binary.DatetimeToBytes(lvs, rs, lv.Typ.Precision); err != nil {
+			return nil, err
+		}
+		nulls.Set(vec.Nsp, lv.Nsp)
+		vector.SetCol(vec, rs)
+		return vec, nil
+	}
+
+	vec, err := proc.AllocVector(rv.Typ, int64(rv.Typ.Size)*int64(len(lvs)))
+	if err != nil {
+		return nil, err
+	}
+	rs := &types.Bytes{
+		Data:    []byte{},
 		Offsets: make([]uint32, 0, len(lvs)),
 		Lengths: make([]uint32, 0, len(lvs)),
 	}
-	if col, err = binary.DateTimeToBytes(lvs, col, lv.Typ.Precision); err != nil {
+	if _, err := binary.DatetimeToBytes(lvs, rs, lv.Typ.Precision); err != nil {
 		return nil, err
 	}
-	if err = proc.Mp.Gm.Alloc(int64(cap(col.Data))); err != nil {
-		return nil, err
-	}
-	vec := vector.New(rv.Typ)
-	if lv.IsScalar() {
-		vec.IsConst = true
-	}
-	vec.Data = col.Data
 	nulls.Set(vec.Nsp, lv.Nsp)
-	vector.SetCol(vec, col)
+	vector.SetCol(vec, rs)
 	return vec, nil
 }
 
@@ -1883,7 +1971,7 @@ func CastDatetimeAsDate(lv, rv *vector.Vector, proc *process.Process) (*vector.V
 	if lv.IsScalar() {
 		vec := proc.AllocScalarVector(rv.Typ)
 		rs := make([]types.Date, 1)
-		if _, err := binary.DateTimeToDate(lvs, rs); err != nil {
+		if _, err := binary.DatetimeToDate(lvs, rs); err != nil {
 			return nil, err
 		}
 		nulls.Set(vec.Nsp, lv.Nsp)
@@ -1896,7 +1984,7 @@ func CastDatetimeAsDate(lv, rv *vector.Vector, proc *process.Process) (*vector.V
 	}
 	rs := types.DecodeDateSlice(vec.Data)
 	rs = rs[:len(lvs)]
-	if _, err := binary.DateTimeToDate(lvs, rs); err != nil {
+	if _, err := binary.DatetimeToDate(lvs, rs); err != nil {
 		return nil, err
 	}
 	nulls.Set(vec.Nsp, lv.Nsp)

--- a/pkg/sql/plan/rule/constant_fold.go
+++ b/pkg/sql/plan/rule/constant_fold.go
@@ -139,7 +139,7 @@ func getConstantValue(vec *vector.Vector) *plan.Const {
 
 func isConstant(e *plan.Expr) bool {
 	switch ef := e.Expr.(type) {
-	case *plan.Expr_C:
+	case *plan.Expr_C, *plan.Expr_T:
 		return true
 	case *plan.Expr_F:
 		overloadID := ef.F.Func.GetObj()

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -634,7 +634,7 @@ func getConstantValue(vec *vector.Vector) *plan.Const {
 
 func isConstant(e *plan.Expr) bool {
 	switch ef := e.Expr.(type) {
-	case *plan.Expr_C:
+	case *plan.Expr_C, *plan.Expr_T:
 		return true
 	case *plan.Expr_F:
 		overloadID := ef.F.Func.GetObj()

--- a/test/result/explain/explain.result
+++ b/test/result/explain/explain.result
@@ -298,13 +298,13 @@ QUERY PLAN
 Project(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)
   ->  Project(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)
         ->  Table Scan on explain.t1(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)
-              Filter Cond: (CAST(t1.dl AS DOUBLE) <> CAST(4 AS DOUBLE))
+              Filter Cond: (CAST(t1.dl AS DOUBLE) <> 4)
 explain select * from (select ti as t,fl as f from t1 where dl <> 4) sub;
 QUERY PLAN
 Project(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)
   ->  Project(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)
         ->  Table Scan on explain.t1(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)
-              Filter Cond: (CAST(t1.dl AS DOUBLE) <> CAST(4 AS DOUBLE))
+              Filter Cond: (CAST(t1.dl AS DOUBLE) <> 4)
 explain select id,min(ti) from (select * from t1) sub group by id;
 QUERY PLAN
 Project(cost=0.00..0.00 card=4.33 ndv=0.00 rowsize=0)
@@ -395,7 +395,7 @@ Project(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)
               ->  Project(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)
                     ->  Project(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)
                           ->  Table Scan on explain.t1(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)
-                                Filter Cond: (CAST(t1.id AS BIGINT) > 4), (CAST(t1.id AS BIGINT) > 2), (CAST(t1.ti AS BIGINT) > 1), (CAST(t1.fl AS DOUBLE) <> CAST(CAST('4.5' AS DECIMAL128) AS DOUBLE))
+                                Filter Cond: (CAST(t1.id AS BIGINT) > 4), (CAST(t1.id AS BIGINT) > 2), (CAST(t1.ti AS BIGINT) > 1), (CAST(t1.fl AS DOUBLE) <> 4.5)
 explain select * from (select * from t1 where id > 100) sub ;
 QUERY PLAN
 Project(cost=0.00..0.00 card=9.00 ndv=0.00 rowsize=0)


### PR DESCRIPTION
The previous implementation of cast(* as char) handles scalars in a
wrong way, thus constant folding can't be enabled on cast.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: