### PR TITLE
[Enhancement]: gcc build mod only allowed in C99

### DIFF
--- a/cgo/Makefile
+++ b/cgo/Makefile
@@ -1,6 +1,6 @@
 DEBUG_OPT :=
 OPT_LV := -O3
-CFLAGS=-I./external/decNumber -g ${OPT_LV} -Wall -Werror
+CFLAGS=-std=c99 -I./external/decNumber -g ${OPT_LV} -Wall -Werror
 OBJS=mo.o arith.o compare.o logic.o decimal.o
 
 all: libmo.a


### PR DESCRIPTION
gcc build mod only allowed in C99

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

issue: 4867