### PR TITLE
 vector: return nil in encodeColToByteSlice if vector.Col is nil 

### DIFF
--- a/pkg/container/vector/tools.go
+++ b/pkg/container/vector/tools.go
@@ -160,6 +160,9 @@ func (v *Vector) setupColFromData(start, end int) {
 }
 
 func (v *Vector) encodeColToByteSlice() []byte {
+	if v.Col == nil {
+		return nil
+	}
 	switch v.GetType().Oid {
 	case types.T_bool:
 		return types.EncodeBoolSlice(v.Col.([]bool))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
 vector: return nil in encodeColToByteSlice if vector.Col is nil 