### PR TITLE
logservice: skip TestGossipInSimulatedCluster

### DIFF
--- a/pkg/logservice/service_test.go
+++ b/pkg/logservice/service_test.go
@@ -652,6 +652,8 @@ func TestShardInfoCanBeQueried(t *testing.T) {
 }
 
 func TestGossipInSimulatedCluster(t *testing.T) {
+	t.Skip("need fix goroutine leak in memberlist lib, skip it now")
+
 	defer leaktest.AfterTest(t)()
 	debug.SetMemoryLimit(1 << 30)
 	// start all services


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Has goroutine leak in memberlist. Skip the TestGossipInSimulatedCluster first, and fix it later.