### PR TITLE
taskservice: support re-allocate CN for task

### DIFF
--- a/pkg/taskservice/mem_task_storage.go
+++ b/pkg/taskservice/mem_task_storage.go
@@ -31,6 +31,7 @@ type memTaskStorage struct {
 	taskIndexes     map[string]uint64
 	cronTasks       map[uint64]task.CronTask
 	cronTaskIndexes map[string]uint64
+	preUpdate       func()
 }
 
 func newMemTaskStorage() TaskStorage {
@@ -65,6 +66,10 @@ func (s *memTaskStorage) Add(ctx context.Context, tasks ...task.Task) (int, erro
 }
 
 func (s *memTaskStorage) Update(ctx context.Context, tasks []task.Task, conds ...Condition) (int, error) {
+	if s.preUpdate != nil {
+		s.preUpdate()
+	}
+
 	c := conditions{}
 	for _, cond := range conds {
 		cond(&c)

--- a/pkg/taskservice/task_service.go
+++ b/pkg/taskservice/task_service.go
@@ -104,6 +104,8 @@ func (s *taskService) Allocate(ctx context.Context, value task.Task, taskRunner 
 		old.Epoch = 1
 		old.TaskRunner = taskRunner
 		old.LastHeartbeat = time.Now().UnixMilli()
+	default:
+		return ErrInvalidTask
 	}
 
 	n, err := s.store.Update(ctx,

--- a/pkg/taskservice/task_service_test.go
+++ b/pkg/taskservice/task_service_test.go
@@ -104,6 +104,36 @@ func TestAllocate(t *testing.T) {
 	assert.Equal(t, uint32(1), v.Epoch)
 }
 
+func TestReAllocate(t *testing.T) {
+	store := newMemTaskStorage()
+	s := NewTaskService(store)
+	defer func() {
+		assert.NoError(t, s.Close())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
+	defer cancel()
+
+	assert.NoError(t, s.Create(ctx, newTestTaskMetadata("t1")))
+	v := mustGetTestTask(t, store, 1)[0]
+	assert.NoError(t, s.Allocate(ctx, v, "r1"))
+
+	v = mustGetTestTask(t, store, 1)[0]
+	assert.Equal(t, task.TaskStatus_Running, v.Status)
+	assert.True(t, v.LastHeartbeat > 0)
+	assert.Equal(t, "r1", v.TaskRunner)
+	assert.Equal(t, uint32(1), v.Epoch)
+
+	last := v.LastHeartbeat
+	time.Sleep(time.Millisecond)
+	assert.NoError(t, s.Allocate(ctx, v, "r2"))
+	v = mustGetTestTask(t, store, 1)[0]
+	assert.Equal(t, task.TaskStatus_Running, v.Status)
+	assert.True(t, v.LastHeartbeat > last)
+	assert.Equal(t, "r2", v.TaskRunner)
+	assert.Equal(t, uint32(2), v.Epoch)
+}
+
 func TestAllocateWithNotExistTask(t *testing.T) {
 	store := newMemTaskStorage()
 	s := NewTaskService(store)
@@ -117,38 +147,28 @@ func TestAllocateWithNotExistTask(t *testing.T) {
 	assert.Equal(t, ErrInvalidTask, s.Allocate(ctx, task.Task{ID: 1}, "r1"))
 }
 
-func TestAllocateMultiTimes(t *testing.T) {
-	store := newMemTaskStorage()
+func TestAllocateWithInvalidEpoch(t *testing.T) {
+	store := newMemTaskStorage().(*memTaskStorage)
 	s := NewTaskService(store)
 	defer func() {
 		assert.NoError(t, s.Close())
 	}()
+
+	store.preUpdate = func() {
+		store.Lock()
+		defer store.Unlock()
+
+		for k, v := range store.tasks {
+			v.Epoch++
+			store.tasks[k] = v
+		}
+	}
 
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
 	defer cancel()
 
 	assert.NoError(t, s.Create(ctx, newTestTaskMetadata("t1")))
 	v := mustGetTestTask(t, store, 1)[0]
-
-	assert.NoError(t, s.Allocate(ctx, v, "r1"))
-	assert.Equal(t, ErrInvalidTask, s.Allocate(ctx, v, "r2"))
-}
-
-func TestAllocateWithInvalidStatus(t *testing.T) {
-	store := newMemTaskStorage()
-	s := NewTaskService(store)
-	defer func() {
-		assert.NoError(t, s.Close())
-	}()
-
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
-	defer cancel()
-
-	assert.NoError(t, s.Create(ctx, newTestTaskMetadata("t1")))
-	v := mustGetTestTask(t, store, 1)[0]
-	v.Status = task.TaskStatus_Running
-	mustUpdateTestTask(t, store, 1, []task.Task{v})
-
 	assert.Equal(t, ErrInvalidTask, s.Allocate(ctx, v, "r2"))
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Support re-allocate CN for timed out tasks. The task scheduler will re-allocate the CN for timed out task to make sure the task will be executed.