### PR TITLE
fix bug: output is incorrect in union clause

### DIFF
--- a/pkg/sql/plan/function/type_check.go
+++ b/pkg/sql/plan/function/type_check.go
@@ -368,12 +368,12 @@ func initTypeCheckRelated() {
 
 	// init preferredTypeConvert
 	preferredConversion := map[types.T][]types.T{
-		types.T_int8:       {types.T_int64, types.T_int32, types.T_int16, types.T_float64},
-		types.T_int16:      {types.T_int64, types.T_int32, types.T_float64},
+		types.T_int8:       {types.T_int64, types.T_int32, types.T_int16, types.T_float32, types.T_float64},
+		types.T_int16:      {types.T_int64, types.T_int32, types.T_float32, types.T_float64},
 		types.T_int32:      {types.T_int64, types.T_float64},
 		types.T_int64:      {types.T_float64},
-		types.T_uint8:      {types.T_uint64, types.T_uint32, types.T_uint16, types.T_float64},
-		types.T_uint16:     {types.T_uint64, types.T_uint32, types.T_float64},
+		types.T_uint8:      {types.T_uint64, types.T_uint32, types.T_uint16, types.T_float32, types.T_float64},
+		types.T_uint16:     {types.T_uint64, types.T_uint32, types.T_float32, types.T_float64},
 		types.T_uint32:     {types.T_uint64, types.T_float64},
 		types.T_uint64:     {types.T_int64, types.T_float64},
 		types.T_float32:    {types.T_float64},

--- a/test/cases/union/union.result
+++ b/test/cases/union/union.result
@@ -46,3 +46,30 @@ select a from t1 union select a from t1;
 a
 1
 2
+drop table if exists t3;
+create table t3(
+a tinyint
+);
+insert into t3 values (20),(10),(30),(-10);
+drop table if exists t4;
+create table t4(
+col1 smallint,
+col2 smallint unsigned,
+col3 float,
+col4 bool
+);
+insert into t4 values(100, 65535, 127.0, 1);
+insert into t4 values(300, 0, 1.0, 0);
+insert into t4 values(500, 100, 0.0, 0);
+insert into t4 values(200, 35, 127.0, 1);
+insert into t4 values(200, 35, 127.44, 1);
+select a from t3 union select col3 from t4 order by a;
+a
+-10
+0
+1
+10
+20
+30
+127
+127.44

--- a/test/cases/union/union.sql
+++ b/test/cases/union/union.sql
@@ -20,3 +20,21 @@ insert into t2 values (11, "aa"),(22, "bb");
 (((select a from t1) limit 1)) limit 1;
 (select a from t1 union select aa from t2) order by aa;
 select a from t1 union select a from t1;
+drop table if exists t3;
+create table t3(
+a tinyint
+);
+insert into t3 values (20),(10),(30),(-10);
+drop table if exists t4;
+create table t4(
+col1 smallint,
+col2 smallint unsigned,
+col3 float,
+col4 bool
+);
+insert into t4 values(100, 65535, 127.0, 1);
+insert into t4 values(300, 0, 1.0, 0);
+insert into t4 values(500, 100, 0.0, 0);
+insert into t4 values(200, 35, 127.0, 1);
+insert into t4 values(200, 35, 127.44, 1);
+select a from t3 union select col3 from t4 order by a;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #4943 

## What this PR does / why we need it:
fix bug: output is incorrect in union clause
because plan will cast int8 & float32 to float64.  but that's unnecessary