### PR TITLE
txn: fix panic when sending txn response

### DIFF
--- a/pkg/pb/txn/txn.go
+++ b/pkg/pb/txn/txn.go
@@ -46,6 +46,9 @@ func (m TxnResponse) HasFlag(flag uint32) bool {
 func (m TxnRequest) DebugString() string {
 	var buffer bytes.Buffer
 
+	buffer.WriteString(fmt.Sprintf("%d: ",
+		m.RequestID))
+
 	buffer.WriteString("<")
 	buffer.WriteString(m.Txn.DebugString())
 	buffer.WriteString(">/")
@@ -73,6 +76,9 @@ func (m TxnError) DebugString() string {
 // DebugString returns debug string
 func (m TxnResponse) DebugString() string {
 	var buffer bytes.Buffer
+
+	buffer.WriteString(fmt.Sprintf("%d: ",
+		m.RequestID))
 
 	if m.Txn != nil {
 		buffer.WriteString("<")

--- a/pkg/txn/service/service_cn_handler.go
+++ b/pkg/txn/service/service_cn_handler.go
@@ -110,7 +110,8 @@ func (s *service) Read(ctx context.Context, request *txn.TxnRequest, response *t
 	}
 
 	response.CNOpResponse.Payload = data
-	response.Txn = &request.Txn
+	txnMeta := request.Txn
+	response.Txn = &txnMeta
 	return nil
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
When TxnService handles Read, TxnResponse directly references the Txn of TxnRequest, causing the protobuf object to be reset when the response is sent asynchronously, and then panic