### PR TITLE
expand rowid to include node id

### DIFF
--- a/pkg/container/types/types.go
+++ b/pkg/container/types/types.go
@@ -80,7 +80,7 @@ const (
 
 const (
 	TxnTsSize = 12
-	RowidSize = 16
+	RowidSize = 24
 )
 
 type Type struct {

--- a/pkg/sql/colexec/update/update.go
+++ b/pkg/sql/colexec/update/update.go
@@ -131,7 +131,7 @@ func Call(_ int, proc *process.Process, arg any) (bool, error) {
 func FilterBatch(bat *batch.Batch, batLen int, proc *process.Process) (*batch.Batch, uint64) {
 	var cnt uint64 = 0
 	newBat := &batch.Batch{}
-	m := make(map[[16]byte]int, batLen)
+	m := make(map[[types.RowidSize]byte]int, batLen)
 
 	for _, vec := range bat.Vecs {
 		v := vector.New(vec.Typ)

--- a/pkg/vm/engine/tae/catalog/block.go
+++ b/pkg/vm/engine/tae/catalog/block.go
@@ -194,7 +194,8 @@ func (entry *BlockEntry) DestroyData() (err error) {
 }
 
 func (entry *BlockEntry) MakeKey() []byte {
-	return model.EncodeBlockKeyPrefix(entry.segment.ID, entry.ID)
+	nodeID := entry.GetCatalog().NodeID
+	return model.EncodeBlockKeyPrefix(nodeID, entry.segment.ID, entry.ID)
 }
 
 // IsActive is coarse API: no consistency check

--- a/pkg/vm/engine/tae/catalog/catalog.go
+++ b/pkg/vm/engine/tae/catalog/catalog.go
@@ -63,6 +63,7 @@ type Catalog struct {
 
 	tableCnt  int32
 	columnCnt int32
+	NodeID    uint64
 }
 
 func genDBFullName(tenantID uint32, name string) string {

--- a/pkg/vm/engine/tae/catalog/catalog.go
+++ b/pkg/vm/engine/tae/catalog/catalog.go
@@ -63,7 +63,7 @@ type Catalog struct {
 
 	tableCnt  int32
 	columnCnt int32
-	NodeID    uint64
+	NodeID    uint32
 }
 
 func genDBFullName(tenantID uint32, name string) string {

--- a/pkg/vm/engine/tae/db/hidden_test.go
+++ b/pkg/vm/engine/tae/db/hidden_test.go
@@ -58,7 +58,7 @@ func TestHiddenWithPK1(t *testing.T) {
 			defer view.Close()
 			fp := blk.Fingerprint()
 			_ = view.GetData().Foreach(func(v any, _ int) (err error) {
-				sid, bid, offset := model.DecodePhyAddrKeyFromValue(v)
+				_, sid, bid, offset := model.DecodePhyAddrKeyFromValue(v)
 				t.Logf("sid=%d,bid=%d,offset=%d", sid, bid, offset)
 				assert.Equal(t, fp.SegmentID, sid)
 				assert.Equal(t, fp.BlockID, bid)
@@ -83,7 +83,7 @@ func TestHiddenWithPK1(t *testing.T) {
 		fp := blk.Fingerprint()
 		t.Log(fp.String())
 		_ = view.GetData().Foreach(func(v any, _ int) (err error) {
-			sid, bid, offset := model.DecodePhyAddrKeyFromValue(v)
+			_, sid, bid, offset := model.DecodePhyAddrKeyFromValue(v)
 			t.Logf("sid=%d,bid=%d,offset=%d", sid, bid, offset)
 			assert.Equal(t, fp.SegmentID, sid)
 			assert.Equal(t, fp.BlockID, bid)
@@ -125,7 +125,7 @@ func TestHiddenWithPK1(t *testing.T) {
 			meta := blk.GetMeta().(*catalog.BlockEntry)
 			t.Log(meta.String())
 			_ = view.GetData().Foreach(func(v any, _ int) (err error) {
-				sid, bid, offset := model.DecodePhyAddrKeyFromValue(v)
+				_, sid, bid, offset := model.DecodePhyAddrKeyFromValue(v)
 				// t.Logf("sid=%d,bid=%d,offset=%d", sid, bid, offset)
 				assert.Equal(t, meta.GetSegment().ID, sid)
 				assert.Equal(t, meta.ID, bid)
@@ -167,7 +167,7 @@ func TestHiddenWithPK1(t *testing.T) {
 			t.Log(meta.String())
 			t.Log(meta.GetSegment().String())
 			_ = view.GetData().Foreach(func(v any, _ int) (err error) {
-				sid, bid, offset := model.DecodePhyAddrKeyFromValue(v)
+				_, sid, bid, offset := model.DecodePhyAddrKeyFromValue(v)
 				// t.Logf("sid=%d,bid=%d,offset=%d", sid, bid, offset)
 				assert.Equal(t, meta.GetSegment().ID, sid)
 				assert.Equal(t, meta.ID, bid)
@@ -207,7 +207,7 @@ func TestGetDeleteUpdateByHiddenKey(t *testing.T) {
 	assert.NoError(t, err)
 	defer view.Close()
 	_ = view.GetData().Foreach(func(v any, _ int) (err error) {
-		sid, bid, offset := model.DecodePhyAddrKeyFromValue(v)
+		_, sid, bid, offset := model.DecodePhyAddrKeyFromValue(v)
 		t.Logf("sid=%d,bid=%d,offset=%d", sid, bid, offset)
 		expectV := bats[0].Vecs[3].Get(int(offset))
 		cv, err := rel.GetValueByPhyAddrKey(v, 3)
@@ -270,7 +270,7 @@ func TestHidden2(t *testing.T) {
 			}
 		}
 		_ = hidden.GetData().Foreach(func(key any, _ int) (err error) {
-			sid, bid, offset := model.DecodePhyAddrKeyFromValue(key)
+			_, sid, bid, offset := model.DecodePhyAddrKeyFromValue(key)
 			t.Logf("sid=%d,bid=%d,offset=%d", sid, bid, offset)
 			v, err := rel.GetValueByPhyAddrKey(key, schema.PhyAddrKey.Idx)
 			assert.NoError(t, err)
@@ -306,7 +306,7 @@ func TestHidden2(t *testing.T) {
 			}
 		}
 		_ = hidden.GetData().Foreach(func(key any, _ int) (err error) {
-			sid, bid, offset := model.DecodePhyAddrKeyFromValue(key)
+			_, sid, bid, offset := model.DecodePhyAddrKeyFromValue(key)
 			t.Logf("sid=%d,bid=%d,offset=%d", sid, bid, offset)
 			v, err := rel.GetValueByPhyAddrKey(key, schema.PhyAddrKey.Idx)
 			assert.NoError(t, err)
@@ -321,7 +321,7 @@ func TestHidden2(t *testing.T) {
 			return
 		}, nil)
 		fp := blk.Fingerprint()
-		key := model.EncodePhyAddrKey(fp.SegmentID, fp.BlockID, 2)
+		key := model.EncodePhyAddrKey(0, fp.SegmentID, fp.BlockID, 2)
 		v, err := rel.GetValueByPhyAddrKey(key, 2)
 		assert.NoError(t, err)
 		assert.Equal(t, int32(8888), v.(int32))

--- a/pkg/vm/engine/tae/db/open.go
+++ b/pkg/vm/engine/tae/db/open.go
@@ -70,6 +70,8 @@ func Open(dirname string, opts *options.Options) (db *DB, err error) {
 		return
 	}
 	db.Catalog = db.Opts.Catalog
+	// TODO: init NodeID
+	// db.Catalog.NodeID = nodeID
 
 	// Init and start txn manager
 	txnStoreFactory := txnimpl.TxnStoreFactory(db.Opts.Catalog, db.Wal, txnBufMgr, dataFactory)

--- a/pkg/vm/engine/tae/db/txn_test.go
+++ b/pkg/vm/engine/tae/db/txn_test.go
@@ -262,7 +262,7 @@ func (c *APP1Client) GetGoodRepetory(goodId uint64) (id *common.ID, offset uint3
 				return
 			}
 			id = blk.Fingerprint()
-			key := model.EncodePhyAddrKey(id.SegmentID, id.BlockID, uint32(row))
+			key := model.EncodePhyAddrKey(0, id.SegmentID, id.BlockID, uint32(row))
 			cntv, err := rel.GetValueByPhyAddrKey(key, 2)
 			if err != nil {
 				return

--- a/pkg/vm/engine/tae/model/model_test.go
+++ b/pkg/vm/engine/tae/model/model_test.go
@@ -29,13 +29,13 @@ func TestPrepareHiddenData(t *testing.T) {
 		SegmentID: 2,
 		BlockID:   3,
 	}
-	prefix := EncodeBlockKeyPrefix(id.SegmentID, id.BlockID)
+	prefix := EncodeBlockKeyPrefix(0, id.SegmentID, id.BlockID)
 	data, err := PreparePhyAddrData(typ, prefix, 0, 20)
 	assert.NoError(t, err)
 	assert.Equal(t, 20, data.Length())
 	for i := 0; i < data.Length(); i++ {
 		v := data.Get(i)
-		sid, bid, off := DecodePhyAddrKey(v.(types.Rowid))
+		_, sid, bid, off := DecodePhyAddrKey(v.(types.Rowid))
 		assert.Equal(t, sid, id.SegmentID)
 		assert.Equal(t, bid, id.BlockID)
 		assert.Equal(t, off, uint32(i))

--- a/pkg/vm/engine/tae/tables/block.go
+++ b/pkg/vm/engine/tae/tables/block.go
@@ -730,7 +730,7 @@ func (blk *dataBlock) GetByFilter(txn txnif.AsyncTxn, filter *handle.Filter) (of
 		panic("logic error")
 	}
 	if blk.meta.GetSchema().SortKey == nil {
-		_, _, offset = model.DecodePhyAddrKeyFromValue(filter.Val)
+		_, _, _, offset = model.DecodePhyAddrKeyFromValue(filter.Val)
 		return
 	}
 	ts := txn.GetStartTS()

--- a/pkg/vm/engine/tae/txn/txnimpl/localseg.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/localseg.go
@@ -402,7 +402,7 @@ func (seg *localSegment) Rows() uint32 {
 func (seg *localSegment) GetByFilter(filter *handle.Filter) (id *common.ID, offset uint32, err error) {
 	id = seg.entry.AsCommonID()
 	if !seg.table.schema.HasPK() {
-		_, _, offset = model.DecodePhyAddrKeyFromValue(filter.Val)
+		_, _, _, offset = model.DecodePhyAddrKeyFromValue(filter.Val)
 		return
 	}
 	if seg.table.schema.IsSinglePK() {

--- a/pkg/vm/engine/tae/txn/txnimpl/node.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/node.go
@@ -187,7 +187,8 @@ func NewInsertNode(tbl *txnTable, mgr base.INodeManager, id *common.ID, driver w
 	impl.LoadFunc = impl.OnLoad
 	impl.table = tbl
 	impl.appends = make([]*appendInfo, 0)
-	impl.prefix = model.EncodeBlockKeyPrefix(id.SegmentID, id.BlockID)
+	nodeID := tbl.entry.GetDB().GetCatalog().NodeID
+	impl.prefix = model.EncodeBlockKeyPrefix(nodeID, id.SegmentID, id.BlockID)
 	mgr.RegisterNode(impl)
 	return impl
 }

--- a/pkg/vm/engine/tae/txn/txnimpl/relation.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/relation.go
@@ -241,7 +241,7 @@ func (h *txnRelation) UpdateByFilter(filter *handle.Filter, col uint16, v any) (
 }
 
 func (h *txnRelation) UpdateByPhyAddrKey(key any, col int, v any) error {
-	sid, bid, row := model.DecodePhyAddrKeyFromValue(key)
+	_, sid, bid, row := model.DecodePhyAddrKeyFromValue(key)
 	id := &common.ID{
 		TableID:   h.table.entry.ID,
 		SegmentID: sid,
@@ -269,7 +269,7 @@ func (h *txnRelation) DeleteByPhyAddrKeys(keys containers.Vector) (err error) {
 	var row uint32
 	dbId := h.table.entry.GetDB().ID
 	err = keys.Foreach(func(key any, _ int) (err error) {
-		id.SegmentID, id.BlockID, row = model.DecodePhyAddrKeyFromValue(key)
+		_, id.SegmentID, id.BlockID, row = model.DecodePhyAddrKeyFromValue(key)
 		err = h.Txn.GetStore().RangeDelete(dbId, id, row, row, handle.DT_Normal)
 		return
 	}, nil)
@@ -277,7 +277,7 @@ func (h *txnRelation) DeleteByPhyAddrKeys(keys containers.Vector) (err error) {
 }
 
 func (h *txnRelation) DeleteByPhyAddrKey(key any) error {
-	sid, bid, row := model.DecodePhyAddrKeyFromValue(key)
+	_, sid, bid, row := model.DecodePhyAddrKeyFromValue(key)
 	id := &common.ID{
 		TableID:   h.table.entry.ID,
 		SegmentID: sid,
@@ -291,7 +291,7 @@ func (h *txnRelation) RangeDelete(id *common.ID, start, end uint32, dt handle.De
 }
 
 func (h *txnRelation) GetValueByPhyAddrKey(key any, col int) (any, error) {
-	sid, bid, row := model.DecodePhyAddrKeyFromValue(key)
+	_, sid, bid, row := model.DecodePhyAddrKeyFromValue(key)
 	id := &common.ID{
 		TableID:   h.table.entry.ID,
 		SegmentID: sid,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #4715 

## What this PR does / why we need it:

- encode node id (uint64) to the first 8 bytes of physical row id
- the node id is kept in the NodeID field of Catalog, for now, it is always 0, a placeholder.