### PR TITLE
improve: show console log in logfile, while run bvt

### DIFF
--- a/etc/cn-standalone-test.toml
+++ b/etc/cn-standalone-test.toml
@@ -3,7 +3,7 @@ service-type = "CN"
 
 [log]
 level = "debug"
-format = "json"
+format = "console"
 max-size = 512
 
 [hakeeper-client]


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

set console format log, as running bvt.
it can show real newline or tab character in the message field, instead of '\n' or '\t'.
if developers want to log some formated-json, or panic stacktrace, they can benift from it.

log example 
- new (console format)
```
2022/09/23 15:09:02.943420 +0800 INFO db/db.go:115 [PrintStats][Caller=github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db.(*catalogStatsMonitor).PostExecute]:{
  "CatalogStats": {
    "MaxDBID": 1002,
    "MaxTID": 1027,
    "MaxSID": 1004,
    "MaxBID": 1004
  },
  "TxnStats": {
    "MaxTS": [
   ...
2022/09/23 15:10:59.183640 +0800 ERROR frontend/routine.go:123 routine execute request failed. error:internal error: panic runtime error: invalid memory address or nil pointer dereference: goroutine 145 [running]:
runtime/debug.Stack()
    /Users/reus/gotip/src/runtime/debug/stack.go:24 +0x64
github.com/matrixorigin/matrixone/pkg/common/moerr.ConvertPanicError({0x102b96a40?, 0x103dd9760})
    /Users/reus/mo/mem/pkg/common/moerr/error.go:410 +0x5c
github.com/matrixorigin/matrixone/pkg/frontend.(*MysqlCmdExecutor).ExecRequest.func1()
    /Users/reus/mo/mem/pkg/frontend/mysql_cmd_executor.go:2434 +0xe0
panic({0x102b96a40, 0x103dd9760})
    /Users/reus/gotip/src/runtime/panic.go:884 +0x204
github.com/matrixorigin/matrixone/pkg/frontend.(*TenantInfo).GetTenant(...)
    /Users/reus/mo/mem/pkg/frontend/authenticate.go:51
...
```
- original (json format)
```
{"level":"INFO","time":"2022/09/23 15:04:39.036862 +0800","caller":"db/replay.go:196","msg":"CATALOG[CNT=1][CommitId=0,MaxTS=0-0,LSN=0]\n\t\tDB[1][name=0-mo_catalog][C@1-0,D@0-0]\n\t\t\tTBL[1][name=mo_database][C@1-0,D@0-0]\n\t\t\t\t[A]SEG[101][C@1-0,D@0-0]\n\t\t\t\t\t[A]BLK[201][C@1-0,D@0-0]\n\t\t\tTBL[2][name=mo_tables][C@1-0,D@0-0]\n\t\t\t\t[A]SEG[102][C@1-0,D@0-0]\n\t\t\t\t\t[A]BLK[202][C@1-0,D@0-0]\n\t\t\tTBL[3][name=mo_columns][C@1-0,D@0-0]\n\t\t\t\t[A]SEG[103][C@1-0,D@0-0]\n\t\t\t\t\t[A]BLK[203][C@1-0,D@0-0]"}
...
```