### PR TITLE
hlc: disable hlc offset checker by default

### DIFF
--- a/cmd/mo-service/config.go
+++ b/cmd/mo-service/config.go
@@ -82,8 +82,11 @@ type Config struct {
 	Clock struct {
 		// Backend clock backend implementation. [LOCAL|HLC], default LOCAL.
 		Backend string `toml:"source"`
-		// MaxClockOffset max clock offset between two nodes. Default is 500ms
+		// MaxClockOffset max clock offset between two nodes. Default is 500ms.
+		// Only valid when enable-check-clock-offset is true
 		MaxClockOffset tomlutil.Duration `toml:"max-clock-offset"`
+		// EnableCheckMaxClockOffset enable local clock offset checker
+		EnableCheckMaxClockOffset bool `toml:"enable-check-clock-offset"`
 	}
 }
 
@@ -117,6 +120,9 @@ func (c *Config) validate() error {
 	}
 	if _, ok := supportTxnClockBackends[strings.ToUpper(c.Clock.Backend)]; !ok {
 		return moerr.NewInternalError("%s clock backend not support", c.Clock.Backend)
+	}
+	if !c.Clock.EnableCheckMaxClockOffset {
+		c.Clock.MaxClockOffset.Duration = 0
 	}
 	return nil
 }

--- a/etc/cn-standalone-test.toml
+++ b/etc/cn-standalone-test.toml
@@ -12,11 +12,6 @@ service-addresses = [
     "2"
 ]
 
-[clock]
-# Due to the poor performance of ci machines, which can cause timers that detect clock 
-# drift to be delayed in scheduling execution, the configuration is larger.
-max-clock-offset = "1s"
-
 [[fileservice]]
 name = "LOCAL"
 backend = "MEM"

--- a/pkg/txn/clock/hlc.go
+++ b/pkg/txn/clock/hlc.go
@@ -111,8 +111,10 @@ func NewUnixNanoHLCClockWithStopper(stopper *stopper.Stopper, maxOffset time.Dur
 		physicalClock: physicalClock,
 		maxOffset:     maxOffset,
 	}
-	if err := stopper.RunTask(clock.offsetMonitor); err != nil {
-		panic(err)
+	if maxOffset > 0 {
+		if err := stopper.RunTask(clock.offsetMonitor); err != nil {
+			panic(err)
+		}
 	}
 	return clock
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Disable hlc offset checker by default. In clock-si's algorithm, there is no correctness problem