### PR TITLE
refactor: use pkg/catalog in other packages

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -25,6 +25,63 @@ const (
 	MO_DATABASE = "mo_database"
 	MO_TABLES   = "mo_tables"
 	MO_COLUMNS  = "mo_columns"
+
+	SystemDBAttr_ID          = "dat_id"
+	SystemDBAttr_Name        = "datname"
+	SystemDBAttr_CatalogName = "dat_catalog_name"
+	SystemDBAttr_CreateSQL   = "dat_createsql"
+	SystemDBAttr_Owner       = "owner"
+	SystemDBAttr_Creator     = "creator"
+	SystemDBAttr_CreateAt    = "created_time"
+	SystemDBAttr_AccID       = "account_id"
+
+	SystemRelAttr_ID          = "rel_id"
+	SystemRelAttr_Name        = "relname"
+	SystemRelAttr_DBName      = "reldatabase"
+	SystemRelAttr_DBID        = "reldatabase_id"
+	SystemRelAttr_Persistence = "relpersistence"
+	SystemRelAttr_Kind        = "relkind"
+	SystemRelAttr_Comment     = "rel_comment"
+	SystemRelAttr_CreateSQL   = "rel_createsql"
+	SystemRelAttr_CreateAt    = "created_time"
+	SystemRelAttr_Creator     = "creator"
+	SystemRelAttr_Owner       = "owner"
+	SystemRelAttr_AccID       = "account_id"
+	SystemRelAttr_Partition   = "partitioned"
+
+	SystemColAttr_UniqName        = "att_uniq_name"
+	SystemColAttr_AccID           = "account_id"
+	SystemColAttr_Name            = "attname"
+	SystemColAttr_DBID            = "att_database_id"
+	SystemColAttr_DBName          = "att_database"
+	SystemColAttr_RelID           = "att_relname_id"
+	SystemColAttr_RelName         = "att_relname"
+	SystemColAttr_Type            = "atttyp"
+	SystemColAttr_Num             = "attnum"
+	SystemColAttr_Length          = "att_length"
+	SystemColAttr_NullAbility     = "attnotnull"
+	SystemColAttr_HasExpr         = "atthasdef"
+	SystemColAttr_DefaultExpr     = "att_default"
+	SystemColAttr_IsDropped       = "attisdropped"
+	SystemColAttr_ConstraintType  = "att_constraint_type"
+	SystemColAttr_IsUnsigned      = "att_is_unsigned"
+	SystemColAttr_IsAutoIncrement = "att_is_auto_increment"
+	SystemColAttr_Comment         = "att_comment"
+	SystemColAttr_IsHidden        = "att_is_hidden"
+
+	SystemCatalogName  = "def"
+	SystemPersistRel   = "p"
+	SystemTransientRel = "t"
+
+	SystemOrdinaryRel     = "r"
+	SystemIndexRel        = "i"
+	SystemSequenceRel     = "S"
+	SystemViewRel         = "v"
+	SystemMaterializedRel = "m"
+	SystemExternalRel     = "e"
+
+	SystemColPKConstraint = "p"
+	SystemColNoConstraint = "n"
 )
 
 const (
@@ -45,49 +102,50 @@ const (
 
 var (
 	MoDatabaseSchema = []string{
-		"dat_id",
-		"datname",
-		"dat_catalog_name",
-		"dat_createsql",
-		"owner",
-		"creator",
-		"created_time",
-		"account_id",
+		SystemDBAttr_ID,
+		SystemDBAttr_Name,
+		SystemDBAttr_CatalogName,
+		SystemDBAttr_CreateSQL,
+		SystemDBAttr_Owner,
+		SystemDBAttr_Creator,
+		SystemDBAttr_CreateAt,
+		SystemDBAttr_AccID,
 	}
 	MoTablesSchema = []string{
-		"rel_id",
-		"relname",
-		"reldatabase",
-		"reldatabase_id",
-		"relpersistence",
-		"relkind",
-		"rel_comment",
-		"rel_createsql",
-		"created_time",
-		"creator",
-		"owner",
-		"account_id",
+		SystemRelAttr_ID,
+		SystemRelAttr_Name,
+		SystemRelAttr_DBName,
+		SystemRelAttr_DBID,
+		SystemRelAttr_Persistence,
+		SystemRelAttr_Kind,
+		SystemRelAttr_Comment,
+		SystemRelAttr_CreateSQL,
+		SystemRelAttr_CreateAt,
+		SystemRelAttr_Creator,
+		SystemRelAttr_Owner,
+		SystemRelAttr_AccID,
+		SystemRelAttr_Partition,
 	}
 	MoColumnsSchema = []string{
-		"att_uniq_name",
-		"account_id",
-		"att_database_id",
-		"att_database",
-		"att_relname_id",
-		"att_relname",
-		"attname",
-		"atttyp",
-		"attnum",
-		"att_length",
-		"attnotnull",
-		"atthasdef",
-		"att_default",
-		"attisdropped",
-		"att_constraint_type",
-		"att_is_unsigned",
-		"att_is_auto_increment",
-		"att_comment",
-		"att_is_hidden",
+		SystemColAttr_UniqName,
+		SystemColAttr_AccID,
+		SystemColAttr_DBID,
+		SystemColAttr_DBName,
+		SystemColAttr_RelID,
+		SystemColAttr_RelName,
+		SystemColAttr_Name,
+		SystemColAttr_Type,
+		SystemColAttr_Num,
+		SystemColAttr_Length,
+		SystemColAttr_NullAbility,
+		SystemColAttr_HasExpr,
+		SystemColAttr_DefaultExpr,
+		SystemColAttr_IsDropped,
+		SystemColAttr_ConstraintType,
+		SystemColAttr_IsUnsigned,
+		SystemColAttr_IsAutoIncrement,
+		SystemColAttr_Comment,
+		SystemColAttr_IsHidden,
 	}
 	MoDatabaseTypes = []types.Type{
 		types.New(types.T_uint64, 0, 0, 0),    // dat_id
@@ -103,7 +161,7 @@ var (
 		types.New(types.T_uint64, 0, 0, 0),    // rel_id
 		types.New(types.T_varchar, 100, 0, 0), // relname
 		types.New(types.T_varchar, 100, 0, 0), // reldatabase
-		types.New(types.T_uint32, 0, 0, 0),    // reldatabase_id
+		types.New(types.T_uint64, 0, 0, 0),    // reldatabase_id
 		types.New(types.T_varchar, 100, 0, 0), // relpersistence
 		types.New(types.T_varchar, 100, 0, 0), // relkind
 		types.New(types.T_varchar, 100, 0, 0), // rel_comment
@@ -112,6 +170,7 @@ var (
 		types.New(types.T_uint32, 0, 0, 0),    // creator
 		types.New(types.T_uint32, 0, 0, 0),    // owner
 		types.New(types.T_uint32, 0, 0, 0),    // account_id
+		types.New(types.T_blob, 0, 0, 0),      // partition
 	}
 	MoColumnsTypes = []types.Type{
 		types.New(types.T_varchar, 256, 0, 0),  // att_uniq_name

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
@@ -30,7 +31,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/moengine"
 	"github.com/matrixorigin/matrixone/pkg/vm/mempool"
 	"github.com/matrixorigin/matrixone/pkg/vm/mmu/guest"

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -16,6 +16,8 @@ package plan
 
 import (
 	"encoding/json"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -23,7 +25,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/operator"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 )
 
 func buildCreateView(stmt *tree.CreateView, ctx CompilerContext) (*Plan, error) {

--- a/pkg/sql/plan/build_delete.go
+++ b/pkg/sql/plan/build_delete.go
@@ -17,11 +17,11 @@ package plan
 import (
 	"strings"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 )
 
 func buildDelete(stmt *tree.Delete, ctx CompilerContext) (*Plan, error) {

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -15,12 +15,12 @@
 package plan
 
 import (
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 )
 
 func buildInsert(stmt *tree.Insert, ctx CompilerContext) (p *Plan, err error) {

--- a/pkg/sql/plan/build_load.go
+++ b/pkg/sql/plan/build_load.go
@@ -18,11 +18,11 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 )
 
 func buildLoad(stmt *tree.Load, ctx CompilerContext) (*Plan, error) {

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -20,13 +20,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 )
 
 const MO_CATALOG_DB_NAME = "mo_catalog"

--- a/pkg/sql/plan/build_update.go
+++ b/pkg/sql/plan/build_update.go
@@ -17,11 +17,11 @@ package plan
 import (
 	"fmt"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 )
 
 type tableInfo struct {

--- a/pkg/sql/plan/mock.go
+++ b/pkg/sql/plan/mock.go
@@ -18,11 +18,11 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 )
 
 type MockCompilerContext struct {

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -17,6 +17,7 @@ package plan
 import (
 	"encoding/json"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -24,7 +25,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 )
 
 func NewQueryBuilder(queryType plan.Query_StatementType, ctx CompilerContext) *QueryBuilder {

--- a/pkg/txn/storage/txn/account.go
+++ b/pkg/txn/storage/txn/account.go
@@ -15,7 +15,7 @@
 package txnstorage
 
 import (
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	txnengine "github.com/matrixorigin/matrixone/pkg/vm/engine/txn"
 )
 
@@ -30,7 +30,7 @@ func (m *MemHandler) ensureAccount(
 	keys, err := m.databases.Index(tx, Tuple{
 		index_AccountID_Name,
 		Uint(accessInfo.AccountID),
-		Text(catalog.SystemDBName),
+		Text(catalog.MO_CATALOG),
 	})
 	if err != nil {
 		return err
@@ -40,7 +40,7 @@ func (m *MemHandler) ensureAccount(
 		db := &DatabaseRow{
 			ID:        txnengine.NewID(),
 			AccountID: accessInfo.AccountID,
-			Name:      catalog.SystemDBName,
+			Name:      catalog.MO_CATALOG,
 		}
 		err := m.databases.Insert(tx, db)
 		//TODO add a unique constraint on (AccountID, Name)

--- a/pkg/txn/storage/txn/catalog_handler_test.go
+++ b/pkg/txn/storage/txn/catalog_handler_test.go
@@ -21,11 +21,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/matrixorigin/matrixone/pkg/txn/storage/txn/memtable"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	txnengine "github.com/matrixorigin/matrixone/pkg/vm/engine/txn"
 	"github.com/stretchr/testify/assert"
 )
@@ -65,7 +65,7 @@ func TestCatalogHandler(t *testing.T) {
 	{
 		var resp txnengine.OpenDatabaseResp
 		err = handler.HandleOpenDatabase(meta, txnengine.OpenDatabaseReq{
-			Name: catalog.SystemDBName,
+			Name: catalog.MO_CATALOG,
 		}, &resp)
 		assert.Nil(t, err)
 		dbID = resp.ID
@@ -88,7 +88,7 @@ func TestCatalogHandler(t *testing.T) {
 		var resp txnengine.OpenRelationResp
 		err = handler.HandleOpenRelation(meta, txnengine.OpenRelationReq{
 			DatabaseID: dbID,
-			Name:       catalog.SystemTable_DB_Name,
+			Name:       catalog.MO_DATABASE,
 		}, &resp)
 		assert.Nil(t, err)
 		tableID = resp.ID
@@ -130,7 +130,7 @@ func TestCatalogHandler(t *testing.T) {
 		var resp txnengine.OpenRelationResp
 		err = handler.HandleOpenRelation(meta, txnengine.OpenRelationReq{
 			DatabaseID: dbID,
-			Name:       catalog.SystemTable_Table_Name,
+			Name:       catalog.MO_TABLES,
 		}, &resp)
 		assert.Nil(t, err)
 		tableID = resp.ID
@@ -171,7 +171,7 @@ func TestCatalogHandler(t *testing.T) {
 		var resp txnengine.OpenRelationResp
 		err = handler.HandleOpenRelation(meta, txnengine.OpenRelationReq{
 			DatabaseID: dbID,
-			Name:       catalog.SystemTable_Columns_Name,
+			Name:       catalog.MO_COLUMNS,
 		}, &resp)
 		assert.Nil(t, err)
 		tableID = resp.ID
@@ -196,9 +196,9 @@ func TestCatalogHandler(t *testing.T) {
 			},
 		}, &resp)
 		assert.Nil(t, err)
-		totalColumns := len(catalog.SystemDBSchema.ColDefs) +
-			len(catalog.SystemTableSchema.ColDefs) +
-			len(catalog.SystemColumnSchema.ColDefs)
+		totalColumns := len(catalog.MoDatabaseSchema) +
+			len(catalog.MoTablesSchema) +
+			len(catalog.MoColumnsSchema)
 		assert.Equal(t, totalColumns, resp.Batch.Length())
 		assert.Equal(t, 2, len(resp.Batch.Attrs))
 	}

--- a/pkg/txn/storage/txn/log_tail.go
+++ b/pkg/txn/storage/txn/log_tail.go
@@ -18,13 +18,13 @@ import (
 	"database/sql"
 	"errors"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	apipb "github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/txn/storage/txn/memtable"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 )
 
 type LogTailEntry = apipb.Entry
@@ -103,7 +103,7 @@ func (m *MemHandler) HandleGetLogTail(meta txn.TxnMeta, req apipb.SyncLogTailReq
 		return nil
 	}
 
-	if tableID == ID(catalog.SystemTable_DB_ID) {
+	if tableID == ID(catalog.MO_DATABASE_ID) {
 		// databases
 		if err := logTailHandleSystemTable(
 			m.databases,
@@ -115,7 +115,7 @@ func (m *MemHandler) HandleGetLogTail(meta txn.TxnMeta, req apipb.SyncLogTailReq
 			return err
 		}
 
-	} else if tableID == ID(catalog.SystemTable_Table_ID) {
+	} else if tableID == ID(catalog.MO_TABLES_ID) {
 		// relations
 		if err := logTailHandleSystemTable(
 			m.relations,
@@ -127,7 +127,7 @@ func (m *MemHandler) HandleGetLogTail(meta txn.TxnMeta, req apipb.SyncLogTailReq
 			return err
 		}
 
-	} else if tableID == ID(catalog.SystemTable_Columns_ID) {
+	} else if tableID == ID(catalog.MO_COLUMNS_ID) {
 		// attributes
 		if err := logTailHandleSystemTable(
 			m.attributes,

--- a/pkg/vm/engine/tae/catalog/database.go
+++ b/pkg/vm/engine/tae/catalog/database.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"sync"
 
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -122,11 +123,10 @@ func NewDBEntryByTS(catalog *Catalog, name string, ts types.TS) *DBEntry {
 }
 
 func NewSystemDBEntry(catalog *Catalog) *DBEntry {
-	id := SystemDBID
 	entry := &DBEntry{
-		DBBaseEntry: NewDBBaseEntry(id),
+		DBBaseEntry: NewDBBaseEntry(pkgcatalog.MO_CATALOG_ID),
 		catalog:     catalog,
-		name:        SystemDBName,
+		name:        pkgcatalog.MO_CATALOG,
 		entries:     make(map[uint64]*common.GenericDLNode[*TableEntry]),
 		nameNodes:   make(map[string]*nodeList[*TableEntry]),
 		link:        common.NewGenericSortedDList(compareTableFn),

--- a/pkg/vm/engine/tae/catalog/model.go
+++ b/pkg/vm/engine/tae/catalog/model.go
@@ -15,6 +15,7 @@
 package catalog
 
 import (
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 )
 
@@ -40,82 +41,13 @@ const (
 	AttrCommitTs = "commit_ts"
 	AttrAborted  = "aborted"
 
-	TenantSysID = uint32(0)
-
-	SystemDBID               = uint64(1)
-	SystemDBName             = "mo_catalog"
-	CatalogName              = "taec"
-	SystemTable_DB_Name      = "mo_database"
-	SystemTable_Table_Name   = "mo_tables"
-	SystemTable_Columns_Name = "mo_columns"
-	SystemTable_DB_ID        = uint64(1)
-	SystemTable_Table_ID     = uint64(2)
-	SystemTable_Columns_ID   = uint64(3)
+	TenantSysID              = uint32(0)
 	SystemSegment_DB_ID      = uint64(101)
 	SystemSegment_Table_ID   = uint64(102)
 	SystemSegment_Columns_ID = uint64(103)
 	SystemBlock_DB_ID        = uint64(201)
 	SystemBlock_Table_ID     = uint64(202)
 	SystemBlock_Columns_ID   = uint64(203)
-
-	SystemCatalogName  = "def"
-	SystemPersistRel   = "p"
-	SystemTransientRel = "t"
-
-	SystemOrdinaryRel     = "r"
-	SystemIndexRel        = "i"
-	SystemSequenceRel     = "S"
-	SystemViewRel         = "v"
-	SystemMaterializedRel = "m"
-	SystemExternalRel     = "e"
-
-	SystemColPKConstraint = "p"
-	SystemColNoConstraint = "n"
-)
-
-const (
-	SystemDBAttr_ID          = "dat_id"
-	SystemDBAttr_Name        = "datname"
-	SystemDBAttr_CatalogName = "dat_catalog_name"
-	SystemDBAttr_CreateSQL   = "dat_createsql"
-	SystemDBAttr_Owner       = "owner"
-	SystemDBAttr_Creator     = "creator"
-	SystemDBAttr_CreateAt    = "created_time"
-	SystemDBAttr_AccID       = "account_id"
-
-	SystemRelAttr_ID          = "rel_id"
-	SystemRelAttr_Name        = "relname"
-	SystemRelAttr_DBName      = "reldatabase"
-	SystemRelAttr_DBID        = "reldatabase_id"
-	SystemRelAttr_Persistence = "relpersistence"
-	SystemRelAttr_Kind        = "relkind"
-	SystemRelAttr_Comment     = "rel_comment"
-	SystemRelAttr_CreateSQL   = "rel_createsql"
-	SystemRelAttr_CreateAt    = "created_time"
-	SystemRelAttr_Creator     = "creator"
-	SystemRelAttr_Owner       = "owner"
-	SystemRelAttr_AccID       = "account_id"
-	SystemRelAttr_Partition   = "partitioned"
-
-	SystemColAttr_UniqName        = "att_uniq_name"
-	SystemColAttr_AccID           = "account_id"
-	SystemColAttr_Name            = "attname"
-	SystemColAttr_DBID            = "att_database_id"
-	SystemColAttr_DBName          = "att_database"
-	SystemColAttr_RelID           = "att_relname_id"
-	SystemColAttr_RelName         = "att_relname"
-	SystemColAttr_Type            = "atttyp"
-	SystemColAttr_Num             = "attnum"
-	SystemColAttr_Length          = "att_length"
-	SystemColAttr_NullAbility     = "attnotnull"
-	SystemColAttr_HasExpr         = "atthasdef"
-	SystemColAttr_DefaultExpr     = "att_default"
-	SystemColAttr_IsDropped       = "attisdropped"
-	SystemColAttr_ConstraintType  = "att_constraint_type"
-	SystemColAttr_IsUnsigned      = "att_is_unsigned"
-	SystemColAttr_IsAutoIncrement = "att_is_auto_increment"
-	SystemColAttr_IsHidden        = "att_is_hidden"
-	SystemColAttr_Comment         = "att_comment"
 )
 
 var SystemDBSchema *Schema
@@ -138,171 +70,49 @@ func init() {
 	var err error
 	PhyAddrColumnType = types.T_Rowid.ToType()
 
-	ti8 := types.T_int8.ToType()
-	ti32 := types.T_int32.ToType()
-	tu32 := types.T_uint32.ToType()
-	tu64 := types.T_uint64.ToType()
-	ttimestamp := types.T_timestamp.ToType()
-	tvarchar := types.T_varchar.ToType()
-	tsinglechar := types.T_char.ToType()
-	ttext := types.T_blob.ToType()
-
-	/*
-
-		SystemDBSchema
-
-	*/
-
-	SystemDBSchema = NewEmptySchema(SystemTable_DB_Name)
-	if err = SystemDBSchema.AppendPKCol(SystemDBAttr_ID, tu64, 0); err != nil {
-		panic(err)
+	SystemDBSchema = NewEmptySchema(catalog.MO_DATABASE)
+	for i, colname := range catalog.MoDatabaseSchema {
+		if i == 0 {
+			if err = SystemDBSchema.AppendPKCol(colname, catalog.MoDatabaseTypes[i], 0); err != nil {
+				panic(err)
+			}
+		} else {
+			if err = SystemDBSchema.AppendCol(colname, catalog.MoDatabaseTypes[i]); err != nil {
+				panic(err)
+			}
+		}
 	}
-	if err = SystemDBSchema.AppendCol(SystemDBAttr_Name, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemDBSchema.AppendCol(SystemDBAttr_CatalogName, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemDBSchema.AppendCol(SystemDBAttr_CreateSQL, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemDBSchema.AppendCol(SystemDBAttr_Owner, tu32); err != nil {
-		panic(err)
-	}
-	if err = SystemDBSchema.AppendCol(SystemDBAttr_Creator, tu32); err != nil {
-		panic(err)
-	}
-	if err = SystemDBSchema.AppendCol(SystemDBAttr_CreateAt, ttimestamp); err != nil {
-		panic(err)
-	}
-	if err = SystemDBSchema.AppendCol(SystemDBAttr_AccID, tu32); err != nil {
-		panic(err)
-	}
-
 	if err = SystemDBSchema.Finalize(true); err != nil {
 		panic(err)
 	}
 
-	/*
-
-		SystemTableSchema
-
-	*/
-
-	SystemTableSchema = NewEmptySchema(SystemTable_Table_Name)
-	if err = SystemTableSchema.AppendPKCol(SystemRelAttr_ID, tu64, 0); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_Name, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_DBName, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_DBID, tu64); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_Persistence, tsinglechar); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_Kind, tsinglechar); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_Comment, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_CreateSQL, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_CreateAt, ttimestamp); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_Creator, tu32); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_Owner, tu32); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_AccID, tu32); err != nil {
-		panic(err)
-	}
-	if err = SystemTableSchema.AppendCol(SystemRelAttr_Partition, ttext); err != nil {
-		panic(err)
+	SystemTableSchema = NewEmptySchema(catalog.MO_TABLES)
+	for i, colname := range catalog.MoTablesSchema {
+		if i == 0 {
+			if err = SystemTableSchema.AppendPKCol(colname, catalog.MoTablesTypes[i], 0); err != nil {
+				panic(err)
+			}
+		} else {
+			if err = SystemTableSchema.AppendCol(colname, catalog.MoTablesTypes[i]); err != nil {
+				panic(err)
+			}
+		}
 	}
 	if err = SystemTableSchema.Finalize(true); err != nil {
 		panic(err)
 	}
 
-	/*
-
-		SystemColumnSchema
-
-	*/
-
-	SystemColumnSchema = NewEmptySchema(SystemTable_Columns_Name)
-	if err = SystemColumnSchema.AppendColDef(&ColDef{
-		Name:    SystemColAttr_UniqName,
-		Type:    tvarchar,
-		Hidden:  true,
-		SortIdx: 0,
-		SortKey: true,
-		Primary: true,
-	}); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_AccID, tu32); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_DBID, tu64); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_DBName, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_RelID, tu64); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_RelName, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_Name, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_Type, ti32); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_Num, ti32); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_Length, ti32); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_NullAbility, ti8); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_HasExpr, ti8); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_DefaultExpr, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_IsDropped, ti8); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_ConstraintType, tsinglechar); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_IsUnsigned, ti8); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_IsAutoIncrement, ti8); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_Comment, tvarchar); err != nil {
-		panic(err)
-	}
-	if err = SystemColumnSchema.AppendCol(SystemColAttr_IsHidden, ti8); err != nil {
-		panic(err)
+	SystemColumnSchema = NewEmptySchema(catalog.MO_COLUMNS)
+	for i, colname := range catalog.MoColumnsSchema {
+		if i == 0 {
+			if err = SystemColumnSchema.AppendPKCol(colname, catalog.MoColumnsTypes[i], 0); err != nil {
+				panic(err)
+			}
+		} else {
+			if err = SystemColumnSchema.AppendCol(colname, catalog.MoColumnsTypes[i]); err != nil {
+				panic(err)
+			}
+		}
 	}
 	if err = SystemColumnSchema.Finalize(true); err != nil {
 		panic(err)

--- a/pkg/vm/engine/tae/catalog/table.go
+++ b/pkg/vm/engine/tae/catalog/table.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"sync/atomic"
 
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -49,7 +50,7 @@ type TableEntry struct {
 }
 
 func genTblFullName(tenantID uint32, name string) string {
-	if name == SystemTable_DB_Name || name == SystemTable_Table_Name || name == SystemTable_Columns_Name {
+	if name == pkgcatalog.MO_DATABASE || name == pkgcatalog.MO_TABLES || name == pkgcatalog.MO_COLUMNS {
 		tenantID = 0
 	}
 	return fmt.Sprintf("%d-%s", tenantID, name)
@@ -123,9 +124,9 @@ func (entry *TableEntry) IsVirtual() bool {
 	if !entry.db.IsSystemDB() {
 		return false
 	}
-	return entry.schema.Name == SystemTable_DB_Name ||
-		entry.schema.Name == SystemTable_Table_Name ||
-		entry.schema.Name == SystemTable_Columns_Name
+	return entry.schema.Name == pkgcatalog.MO_DATABASE ||
+		entry.schema.Name == pkgcatalog.MO_TABLES ||
+		entry.schema.Name == pkgcatalog.MO_COLUMNS
 }
 
 func (entry *TableEntry) GetRows() uint64 {

--- a/pkg/vm/engine/tae/db/db_test.go
+++ b/pkg/vm/engine/tae/db/db_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/model"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/testutils/config"
 
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
@@ -1357,9 +1358,9 @@ func TestSystemDB1(t *testing.T) {
 	defer tae.Close()
 	schema := catalog.MockSchema(2, 0)
 	txn, _ := tae.StartTxn(nil)
-	_, err := txn.CreateDatabase(catalog.SystemDBName)
+	_, err := txn.CreateDatabase(pkgcatalog.MO_CATALOG)
 	assert.NotNil(t, err)
-	_, err = txn.DropDatabase(catalog.SystemDBName)
+	_, err = txn.DropDatabase(pkgcatalog.MO_CATALOG)
 	assert.NotNil(t, err)
 
 	db1, err := txn.CreateDatabase("db1")
@@ -1370,23 +1371,23 @@ func TestSystemDB1(t *testing.T) {
 	_, err = txn.CreateDatabase("db2")
 	assert.Nil(t, err)
 
-	db, _ := txn.GetDatabase(catalog.SystemDBName)
-	table, err := db.GetRelationByName(catalog.SystemTable_DB_Name)
+	db, _ := txn.GetDatabase(pkgcatalog.MO_CATALOG)
+	table, err := db.GetRelationByName(pkgcatalog.MO_DATABASE)
 	assert.Nil(t, err)
 	it := table.MakeBlockIt()
 	rows := 0
 	for it.Valid() {
 		blk := it.GetBlock()
 		rows += blk.Rows()
-		view, err := blk.GetColumnDataByName(catalog.SystemDBAttr_Name, nil)
+		view, err := blk.GetColumnDataByName(pkgcatalog.SystemDBAttr_Name, nil)
 		assert.Nil(t, err)
 		defer view.Close()
 		assert.Equal(t, 3, view.Length())
-		view, err = blk.GetColumnDataByName(catalog.SystemDBAttr_CatalogName, nil)
+		view, err = blk.GetColumnDataByName(pkgcatalog.SystemDBAttr_CatalogName, nil)
 		assert.Nil(t, err)
 		defer view.Close()
 		assert.Equal(t, 3, view.Length())
-		view, err = blk.GetColumnDataByName(catalog.SystemDBAttr_CreateSQL, nil)
+		view, err = blk.GetColumnDataByName(pkgcatalog.SystemDBAttr_CreateSQL, nil)
 		assert.Nil(t, err)
 		defer view.Close()
 		assert.Equal(t, 3, view.Length())
@@ -1394,28 +1395,28 @@ func TestSystemDB1(t *testing.T) {
 	}
 	assert.Equal(t, 3, rows)
 
-	table, err = db.GetRelationByName(catalog.SystemTable_Table_Name)
+	table, err = db.GetRelationByName(pkgcatalog.MO_TABLES)
 	assert.Nil(t, err)
 	it = table.MakeBlockIt()
 	rows = 0
 	for it.Valid() {
 		blk := it.GetBlock()
 		rows += blk.Rows()
-		view, err := blk.GetColumnDataByName(catalog.SystemRelAttr_Name, nil)
+		view, err := blk.GetColumnDataByName(pkgcatalog.SystemRelAttr_Name, nil)
 		assert.Nil(t, err)
 		defer view.Close()
 		assert.Equal(t, 4, view.Length())
-		view, err = blk.GetColumnDataByName(catalog.SystemRelAttr_Persistence, nil)
+		view, err = blk.GetColumnDataByName(pkgcatalog.SystemRelAttr_Persistence, nil)
 		assert.NoError(t, err)
 		defer view.Close()
-		view, err = blk.GetColumnDataByName(catalog.SystemRelAttr_Kind, nil)
+		view, err = blk.GetColumnDataByName(pkgcatalog.SystemRelAttr_Kind, nil)
 		assert.NoError(t, err)
 		defer view.Close()
 		it.Next()
 	}
 	assert.Equal(t, 4, rows)
 
-	table, err = db.GetRelationByName(catalog.SystemTable_Columns_Name)
+	table, err = db.GetRelationByName(pkgcatalog.MO_COLUMNS)
 	assert.Nil(t, err)
 
 	bat := containers.NewBatch()
@@ -1427,32 +1428,32 @@ func TestSystemDB1(t *testing.T) {
 	for it.Valid() {
 		blk := it.GetBlock()
 		rows += blk.Rows()
-		view, err := blk.GetColumnDataByName(catalog.SystemColAttr_DBName, nil)
+		view, err := blk.GetColumnDataByName(pkgcatalog.SystemColAttr_DBName, nil)
 		assert.NoError(t, err)
 		defer view.Close()
-		bat.AddVector(catalog.SystemColAttr_DBName, view.Orphan())
+		bat.AddVector(pkgcatalog.SystemColAttr_DBName, view.Orphan())
 
-		view, err = blk.GetColumnDataByName(catalog.SystemColAttr_RelName, nil)
+		view, err = blk.GetColumnDataByName(pkgcatalog.SystemColAttr_RelName, nil)
 		assert.Nil(t, err)
 		defer view.Close()
-		bat.AddVector(catalog.SystemColAttr_RelName, view.Orphan())
+		bat.AddVector(pkgcatalog.SystemColAttr_RelName, view.Orphan())
 
-		view, err = blk.GetColumnDataByName(catalog.SystemColAttr_Name, nil)
+		view, err = blk.GetColumnDataByName(pkgcatalog.SystemColAttr_Name, nil)
 		assert.Nil(t, err)
 		defer view.Close()
-		bat.AddVector(catalog.SystemColAttr_Name, view.Orphan())
+		bat.AddVector(pkgcatalog.SystemColAttr_Name, view.Orphan())
 
-		view, err = blk.GetColumnDataByName(catalog.SystemColAttr_ConstraintType, nil)
-		assert.Nil(t, err)
-		defer view.Close()
-		t.Log(view.GetData().String())
-		bat.AddVector(catalog.SystemColAttr_ConstraintType, view.Orphan())
-
-		view, err = blk.GetColumnDataByName(catalog.SystemColAttr_Type, nil)
+		view, err = blk.GetColumnDataByName(pkgcatalog.SystemColAttr_ConstraintType, nil)
 		assert.Nil(t, err)
 		defer view.Close()
 		t.Log(view.GetData().String())
-		view, err = blk.GetColumnDataByName(catalog.SystemColAttr_Num, nil)
+		bat.AddVector(pkgcatalog.SystemColAttr_ConstraintType, view.Orphan())
+
+		view, err = blk.GetColumnDataByName(pkgcatalog.SystemColAttr_Type, nil)
+		assert.Nil(t, err)
+		defer view.Close()
+		t.Log(view.GetData().String())
+		view, err = blk.GetColumnDataByName(pkgcatalog.SystemColAttr_Num, nil)
 		assert.Nil(t, err)
 		defer view.Close()
 		t.Log(view.GetData().String())
@@ -1461,29 +1462,28 @@ func TestSystemDB1(t *testing.T) {
 	t.Log(rows)
 
 	for i := 0; i < bat.Vecs[0].Length(); i++ {
-		dbName := bat.Vecs[0].Get(i)
-		relName := bat.Vecs[1].Get(i)
-		attrName := bat.Vecs[2].Get(i)
-		ct := bat.Vecs[3].Get(i)
-		t.Logf("%s,%s,%s,%s", dbName, relName, attrName, ct)
-		if dbName == catalog.SystemDBName {
-			if relName == catalog.SystemTable_DB_Name {
-				if attrName == catalog.SystemDBAttr_Name {
-					assert.Equal(t, catalog.SystemColPKConstraint, ct)
+		dbName := string(bat.Vecs[0].Get(i).([]byte))
+		relName := string(bat.Vecs[1].Get(i).([]byte))
+		attrName := string(bat.Vecs[2].Get(i).([]byte))
+		ct := string(bat.Vecs[3].Get(i).([]byte))
+		if dbName == pkgcatalog.MO_CATALOG {
+			if relName == pkgcatalog.MO_DATABASE {
+				if attrName == pkgcatalog.SystemDBAttr_ID {
+					assert.Equal(t, pkgcatalog.SystemColPKConstraint, ct)
 				} else {
-					assert.Equal(t, catalog.SystemColNoConstraint, ct)
+					assert.Equal(t, pkgcatalog.SystemColNoConstraint, ct)
 				}
-			} else if relName == catalog.SystemTable_Table_Name {
-				if attrName == catalog.SystemRelAttr_DBName || attrName == catalog.SystemRelAttr_Name {
-					assert.Equal(t, catalog.SystemColPKConstraint, ct)
+			} else if relName == pkgcatalog.MO_TABLES {
+				if attrName == pkgcatalog.SystemRelAttr_ID {
+					assert.Equal(t, pkgcatalog.SystemColPKConstraint, ct)
 				} else {
-					assert.Equal(t, catalog.SystemColNoConstraint, ct)
+					assert.Equal(t, pkgcatalog.SystemColNoConstraint, ct)
 				}
-			} else if relName == catalog.SystemTable_Columns_Name {
-				if attrName == catalog.SystemColAttr_DBName || attrName == catalog.SystemColAttr_RelName || attrName == catalog.SystemColAttr_Name {
-					assert.Equal(t, catalog.SystemColPKConstraint, ct)
+			} else if relName == pkgcatalog.MO_COLUMNS {
+				if attrName == pkgcatalog.SystemColAttr_UniqName {
+					assert.Equal(t, pkgcatalog.SystemColPKConstraint, ct)
 				} else {
-					assert.Equal(t, catalog.SystemColNoConstraint, ct)
+					assert.Equal(t, pkgcatalog.SystemColNoConstraint, ct)
 				}
 			}
 		}
@@ -1500,13 +1500,13 @@ func TestSystemDB2(t *testing.T) {
 	defer tae.Close()
 
 	txn, _ := tae.StartTxn(nil)
-	sysDB, err := txn.GetDatabase(catalog.SystemDBName)
+	sysDB, err := txn.GetDatabase(pkgcatalog.MO_CATALOG)
 	assert.NoError(t, err)
-	_, err = sysDB.DropRelationByName(catalog.SystemTable_DB_Name)
+	_, err = sysDB.DropRelationByName(pkgcatalog.MO_DATABASE)
 	assert.Error(t, err)
-	_, err = sysDB.DropRelationByName(catalog.SystemTable_Table_Name)
+	_, err = sysDB.DropRelationByName(pkgcatalog.MO_TABLES)
 	assert.Error(t, err)
-	_, err = sysDB.DropRelationByName(catalog.SystemTable_Columns_Name)
+	_, err = sysDB.DropRelationByName(pkgcatalog.MO_COLUMNS)
 	assert.Error(t, err)
 
 	schema := catalog.MockSchema(2, 0)
@@ -1523,7 +1523,7 @@ func TestSystemDB2(t *testing.T) {
 	assert.NoError(t, txn.Commit())
 
 	txn, _ = tae.StartTxn(nil)
-	sysDB, err = txn.GetDatabase(catalog.SystemDBName)
+	sysDB, err = txn.GetDatabase(pkgcatalog.MO_CATALOG)
 	assert.NoError(t, err)
 	rel, err = sysDB.GetRelationByName(schema.Name)
 	assert.NoError(t, err)
@@ -1541,7 +1541,7 @@ func TestSystemDB3(t *testing.T) {
 	schema.SegmentMaxBlocks = 2
 	bat := catalog.MockBatch(schema, 20)
 	defer bat.Close()
-	db, err := txn.GetDatabase(catalog.SystemDBName)
+	db, err := txn.GetDatabase(pkgcatalog.MO_CATALOG)
 	assert.NoError(t, err)
 	rel, err := db.CreateRelation(schema)
 	assert.NoError(t, err)
@@ -2781,7 +2781,7 @@ func TestMultiTenantMoCatalogOps(t *testing.T) {
 
 	s := catalog.MockSchemaAll(1, 0)
 	s.Name = "mo_accounts"
-	txn0, sysDB := tae.getDB(catalog.SystemDBName)
+	txn0, sysDB := tae.getDB(pkgcatalog.MO_CATALOG)
 	_, err = sysDB.CreateRelation(s)
 	assert.NoError(t, err)
 	assert.NoError(t, txn0.Commit())
@@ -2797,7 +2797,7 @@ func TestMultiTenantMoCatalogOps(t *testing.T) {
 	// pretend 'mo_users'
 	s = catalog.MockSchemaAll(1, 0)
 	s.Name = "mo_users"
-	txn11, sysDB := tae.getDB(catalog.SystemDBName)
+	txn11, sysDB := tae.getDB(pkgcatalog.MO_CATALOG)
 	_, err = sysDB.CreateRelation(s)
 	assert.NoError(t, err)
 	assert.NoError(t, txn11.Commit())
@@ -2813,7 +2813,7 @@ func TestMultiTenantMoCatalogOps(t *testing.T) {
 
 	bat2 := catalog.MockBatch(schema21, int(schema21.BlockMaxRows*3+5))
 	tae.createRelAndAppend(bat2, true)
-	txn21, sysDB := tae.getDB(catalog.SystemDBName)
+	txn21, sysDB := tae.getDB(pkgcatalog.MO_CATALOG)
 	s = catalog.MockSchemaAll(1, 0)
 	s.Name = "mo_users"
 	_, err = sysDB.CreateRelation(s)
@@ -2835,15 +2835,15 @@ func TestMultiTenantMoCatalogOps(t *testing.T) {
 		checkAllColRowsByScan(t, tbl, 35, false)
 		// [mo_catalog, db]
 		assert.Equal(t, 2, len(mustStartTxn(t, tae, 2).DatabaseNames()))
-		_, sysDB = tae.getDB(catalog.SystemDBName)
+		_, sysDB = tae.getDB(pkgcatalog.MO_CATALOG)
 		sysDB.Relations()
-		sysDBTbl, _ := sysDB.GetRelationByName(catalog.SystemTable_DB_Name)
+		sysDBTbl, _ := sysDB.GetRelationByName(pkgcatalog.MO_DATABASE)
 		// [mo_catalog, db]
 		checkAllColRowsByScan(t, sysDBTbl, 2, true)
-		sysTblTbl, _ := sysDB.GetRelationByName(catalog.SystemTable_Table_Name)
+		sysTblTbl, _ := sysDB.GetRelationByName(pkgcatalog.MO_TABLES)
 		// [mo_database, mo_tables, mo_columns, 'mo_users_t2' 'test-table-a-timestamp']
 		checkAllColRowsByScan(t, sysTblTbl, 5, true)
-		sysColTbl, _ := sysDB.GetRelationByName(catalog.SystemTable_Columns_Name)
+		sysColTbl, _ := sysDB.GetRelationByName(pkgcatalog.MO_COLUMNS)
 		// [mo_database(8), mo_tables(13), mo_columns(19), 'mo_users_t2'(1+1), 'test-table-a-timestamp'(2+1)]
 		checkAllColRowsByScan(t, sysColTbl, reservedColumnsCnt+5, true)
 	}
@@ -2856,15 +2856,15 @@ func TestMultiTenantMoCatalogOps(t *testing.T) {
 		checkAllColRowsByScan(t, tbl, 29, false)
 		// [mo_catalog, db]
 		assert.Equal(t, 2, len(mustStartTxn(t, tae, 1).DatabaseNames()))
-		_, sysDB = tae.getDB(catalog.SystemDBName)
+		_, sysDB = tae.getDB(pkgcatalog.MO_CATALOG)
 		sysDB.Relations()
-		sysDBTbl, _ := sysDB.GetRelationByName(catalog.SystemTable_DB_Name)
+		sysDBTbl, _ := sysDB.GetRelationByName(pkgcatalog.MO_DATABASE)
 		// [mo_catalog, db]
 		checkAllColRowsByScan(t, sysDBTbl, 2, true)
-		sysTblTbl, _ := sysDB.GetRelationByName(catalog.SystemTable_Table_Name)
+		sysTblTbl, _ := sysDB.GetRelationByName(pkgcatalog.MO_TABLES)
 		// [mo_database, mo_tables, mo_columns, 'mo_users_t1' 'test-table-a-timestamp']
 		checkAllColRowsByScan(t, sysTblTbl, 5, true)
-		sysColTbl, _ := sysDB.GetRelationByName(catalog.SystemTable_Columns_Name)
+		sysColTbl, _ := sysDB.GetRelationByName(pkgcatalog.MO_COLUMNS)
 		// [mo_database(8), mo_tables(13), mo_columns(19), 'mo_users_t1'(1+1), 'test-table-a-timestamp'(3+1)]
 		checkAllColRowsByScan(t, sysColTbl, reservedColumnsCnt+6, true)
 	}
@@ -2874,15 +2874,15 @@ func TestMultiTenantMoCatalogOps(t *testing.T) {
 		tae.bindTenantID(0)
 		// [mo_catalog]
 		assert.Equal(t, 1, len(mustStartTxn(t, tae, 0).DatabaseNames()))
-		_, sysDB = tae.getDB(catalog.SystemDBName)
+		_, sysDB = tae.getDB(pkgcatalog.MO_CATALOG)
 		sysDB.Relations()
-		sysDBTbl, _ := sysDB.GetRelationByName(catalog.SystemTable_DB_Name)
+		sysDBTbl, _ := sysDB.GetRelationByName(pkgcatalog.MO_DATABASE)
 		// [mo_catalog]
 		checkAllColRowsByScan(t, sysDBTbl, 1, true)
-		sysTblTbl, _ := sysDB.GetRelationByName(catalog.SystemTable_Table_Name)
+		sysTblTbl, _ := sysDB.GetRelationByName(pkgcatalog.MO_TABLES)
 		// [mo_database, mo_tables, mo_columns, 'mo_accounts']
 		checkAllColRowsByScan(t, sysTblTbl, 4, true)
-		sysColTbl, _ := sysDB.GetRelationByName(catalog.SystemTable_Columns_Name)
+		sysColTbl, _ := sysDB.GetRelationByName(pkgcatalog.MO_COLUMNS)
 		// [mo_database(8), mo_tables(13), mo_columns(19), 'mo_accounts'(1+1)]
 		checkAllColRowsByScan(t, sysColTbl, reservedColumnsCnt+2, true)
 	}
@@ -3049,7 +3049,7 @@ func TestLogtailBasic(t *testing.T) {
 	resp, err := LogtailHandler(tae.DB, api.SyncLogTailReq{
 		CnHave: tots(minTs),
 		CnWant: tots(catalogDropTs),
-		Table:  &api.TableID{DbId: catalog.SystemDBID, TbId: catalog.SystemTable_DB_ID},
+		Table:  &api.TableID{DbId: pkgcatalog.MO_CATALOG_ID, TbId: pkgcatalog.MO_DATABASE_ID},
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(resp.Commands)) // insert and delete
@@ -3070,7 +3070,7 @@ func TestLogtailBasic(t *testing.T) {
 	resp, err = LogtailHandler(tae.DB, api.SyncLogTailReq{
 		CnHave: tots(minTs),
 		CnWant: tots(catalogDropTs),
-		Table:  &api.TableID{DbId: catalog.SystemDBID, TbId: catalog.SystemTable_Table_ID},
+		Table:  &api.TableID{DbId: pkgcatalog.MO_CATALOG_ID, TbId: pkgcatalog.MO_TABLES_ID},
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(resp.Commands)) // insert
@@ -3086,7 +3086,7 @@ func TestLogtailBasic(t *testing.T) {
 	resp, err = LogtailHandler(tae.DB, api.SyncLogTailReq{
 		CnHave: tots(minTs),
 		CnWant: tots(catalogDropTs),
-		Table:  &api.TableID{DbId: catalog.SystemDBID, TbId: catalog.SystemTable_Columns_ID},
+		Table:  &api.TableID{DbId: pkgcatalog.MO_CATALOG_ID, TbId: pkgcatalog.MO_COLUMNS_ID},
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(resp.Commands)) // insert

--- a/pkg/vm/engine/tae/db/txn_test.go
+++ b/pkg/vm/engine/tae/db/txn_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -625,14 +626,14 @@ func TestTxn8(t *testing.T) {
 	bats := bat.Split(2)
 
 	txn, _ := tae.StartTxn(nil)
-	db, _ := txn.GetDatabase(catalog.SystemDBName)
+	db, _ := txn.GetDatabase(pkgcatalog.MO_CATALOG)
 	rel, _ := db.CreateRelation(schema)
 	err := rel.Append(bats[0])
 	assert.NoError(t, err)
 	assert.NoError(t, txn.Commit())
 
 	txn, _ = tae.StartTxn(nil)
-	db, _ = txn.GetDatabase(catalog.SystemDBName)
+	db, _ = txn.GetDatabase(pkgcatalog.MO_CATALOG)
 	rel, _ = db.GetRelationByName(schema.Name)
 	err = rel.Append(bats[1])
 	assert.NoError(t, err)

--- a/pkg/vm/engine/tae/moengine/engine_test.go
+++ b/pkg/vm/engine/tae/moengine/engine_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/mmu/guest"
 	"github.com/matrixorigin/matrixone/pkg/vm/mmu/host"
 
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
@@ -605,17 +606,17 @@ func TestSysRelation(t *testing.T) {
 	txn, err := e.StartTxn(nil)
 	assert.Nil(t, err)
 	txnOperator := TxnToTxnOperator(txn)
-	err = e.Create(ctx, catalog.SystemTable_DB_Name, txnOperator)
+	err = e.Create(ctx, pkgcatalog.MO_DATABASE, txnOperator)
 	assert.Nil(t, err)
 	names, _ := e.Databases(ctx, txnOperator)
 	assert.Equal(t, 2, len(names))
-	dbase, err := e.Database(ctx, catalog.SystemTable_DB_Name, txnOperator)
+	dbase, err := e.Database(ctx, pkgcatalog.MO_DATABASE, txnOperator)
 	assert.Nil(t, err)
 	schema := catalog.MockSchema(13, 12)
-	checkSysTable(t, catalog.SystemTable_DB_Name, dbase, txn, 1, schema)
+	checkSysTable(t, pkgcatalog.MO_DATABASE, dbase, txn, 1, schema)
 	schema = catalog.MockSchema(14, 13)
-	checkSysTable(t, catalog.SystemTable_Table_Name, dbase, txn, 2, schema)
+	checkSysTable(t, pkgcatalog.MO_TABLES, dbase, txn, 2, schema)
 	schema = catalog.MockSchema(15, 14)
-	checkSysTable(t, catalog.SystemTable_Columns_Name, dbase, txn, 3, schema)
+	checkSysTable(t, pkgcatalog.MO_COLUMNS, dbase, txn, 3, schema)
 	assert.Nil(t, txn.Commit())
 }

--- a/pkg/vm/engine/tae/moengine/helper.go
+++ b/pkg/vm/engine/tae/moengine/helper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
@@ -108,12 +109,12 @@ func SchemaToDefs(schema *catalog.Schema) (defs []engine.TableDef, err error) {
 	}
 	pro := new(engine.PropertiesDef)
 	pro.Properties = append(pro.Properties, engine.Property{
-		Key:   catalog.SystemRelAttr_Kind,
+		Key:   pkgcatalog.SystemRelAttr_Kind,
 		Value: string(schema.Relkind),
 	})
 	if schema.Createsql != "" {
 		pro.Properties = append(pro.Properties, engine.Property{
-			Key:   catalog.SystemRelAttr_CreateSQL,
+			Key:   pkgcatalog.SystemRelAttr_CreateSQL,
 			Value: schema.Createsql,
 		})
 	}
@@ -149,11 +150,11 @@ func DefsToSchema(name string, defs []engine.TableDef) (schema *catalog.Schema, 
 		case *engine.PropertiesDef:
 			for _, property := range defVal.Properties {
 				switch strings.ToLower(property.Key) {
-				case catalog.SystemRelAttr_Comment:
+				case pkgcatalog.SystemRelAttr_Comment:
 					schema.Comment = property.Value
-				case catalog.SystemRelAttr_Kind:
+				case pkgcatalog.SystemRelAttr_Kind:
 					schema.Relkind = property.Value
-				case catalog.SystemRelAttr_CreateSQL:
+				case pkgcatalog.SystemRelAttr_CreateSQL:
 					schema.Createsql = property.Value
 				default:
 				}

--- a/pkg/vm/engine/tae/moengine/sys_relation.go
+++ b/pkg/vm/engine/tae/moengine/sys_relation.go
@@ -17,10 +17,10 @@ package moengine
 import (
 	"context"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
 )
 
@@ -38,9 +38,9 @@ func newSysRelation(h handle.Relation) *sysRelation {
 }
 
 func isSysRelation(name string) bool {
-	if name == catalog.SystemTable_DB_Name ||
-		name == catalog.SystemTable_Table_Name ||
-		name == catalog.SystemTable_Columns_Name {
+	if name == catalog.MO_DATABASE ||
+		name == catalog.MO_TABLES ||
+		name == catalog.MO_COLUMNS {
 		return true
 	}
 	return false

--- a/pkg/vm/engine/tae/txn/txnimpl/relation.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/relation.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sync"
 
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
@@ -140,11 +141,11 @@ func (h *txnRelation) GetSchema() any { return h.table.entry.GetSchema() }
 
 func (h *txnRelation) Rows() int64 {
 	if h.table.entry.GetDB().IsSystemDB() && h.table.entry.IsVirtual() {
-		if h.table.entry.GetSchema().Name == catalog.SystemTable_DB_Name {
+		if h.table.entry.GetSchema().Name == pkgcatalog.MO_DATABASE {
 			return int64(h.table.entry.GetCatalog().CoarseDBCnt())
-		} else if h.table.entry.GetSchema().Name == catalog.SystemTable_Table_Name {
+		} else if h.table.entry.GetSchema().Name == pkgcatalog.MO_TABLES {
 			return int64(h.table.entry.GetCatalog().CoarseTableCnt())
-		} else if h.table.entry.GetSchema().Name == catalog.SystemTable_Columns_Name {
+		} else if h.table.entry.GetSchema().Name == pkgcatalog.MO_COLUMNS {
 			return int64(h.table.entry.GetCatalog().CoarseColumnCnt())
 		}
 		panic("logic error")

--- a/pkg/vm/engine/tae/txn/txnimpl/sysdb.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/sysdb.go
@@ -15,10 +15,10 @@
 package txnimpl
 
 import (
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/util/metric"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
 )
 
@@ -30,12 +30,12 @@ var sysSharedDBNames map[string]bool
 
 func init() {
 	sysTableNames = make(map[string]bool)
-	sysTableNames[catalog.SystemTable_Columns_Name] = true
-	sysTableNames[catalog.SystemTable_Table_Name] = true
-	sysTableNames[catalog.SystemTable_DB_Name] = true
+	sysTableNames[pkgcatalog.MO_COLUMNS] = true
+	sysTableNames[pkgcatalog.MO_TABLES] = true
+	sysTableNames[pkgcatalog.MO_DATABASE] = true
 
 	sysSharedDBNames = make(map[string]bool)
-	sysSharedDBNames[catalog.SystemDBName] = true
+	sysSharedDBNames[pkgcatalog.MO_CATALOG] = true
 	sysSharedDBNames[metric.MetricDBConst] = true
 	sysSharedDBNames[trace.SystemDBConst] = true
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #5247

## What this PR does / why we need it:

maintain only one catalog definition

- move column name constants from tae/catalog to pkg/catalog
- packages (except tae) will import pkg/catalog to get catalog-related constants
- modification on some ut