### PR TITLE
update buffer manager

### DIFF
--- a/pkg/vm/engine/tae/buffer/base/types.go
+++ b/pkg/vm/engine/tae/buffer/base/types.go
@@ -44,7 +44,7 @@ type IMemoryNode interface {
 
 type INodeHandle interface {
 	io.Closer
-	GetID() common.ID
+	Key() any
 	GetNode() INode
 }
 
@@ -54,7 +54,7 @@ type INode interface {
 	common.IRef
 	RLock()
 	RUnlock()
-	GetID() common.ID
+	Key() any
 
 	// unload the data return the size quota back
 	Unload()
@@ -107,9 +107,9 @@ type INodeManager interface {
 	RegisterNode(INode)
 	UnregisterNode(INode)
 	Pin(INode) INodeHandle
-	PinByID(common.ID) (INodeHandle, error)
+	PinByKey(any) (INodeHandle, error)
 	TryPin(INode, time.Duration) (INodeHandle, error)
-	TryPinByID(common.ID, time.Duration) (INodeHandle, error)
+	TryPinByKey(any, time.Duration) (INodeHandle, error)
 	Unpin(INode)
 	MakeRoom(uint64) bool
 }

--- a/pkg/vm/engine/tae/buffer/base/types.go
+++ b/pkg/vm/engine/tae/buffer/base/types.go
@@ -55,19 +55,45 @@ type INode interface {
 	RLock()
 	RUnlock()
 	GetID() common.ID
+
+	// unload the data return the size quota back
 	Unload()
+	// whether the node unloadable
 	Unloadable() bool
+	// whether the node is loaded
 	IsLoaded() bool
+	// load data into the node
 	Load()
+
+	// increase the node reference count and get a handle of the node
 	MakeHandle() INodeHandle
+
+	// true if the node can be destoryed and hard evicted from the node manager
+	// false if the node can only be unloaded on evicted
 	HardEvictable() bool
+
+	// destory the node resources
+	// node manager destoryes a node when Close a node
 	Destroy()
+
+	// the size of the node
 	Size() uint64
+
+	// the iteration of the node.
+	// it is increased by 1 when the reference count is 0 during UnPin
 	Iteration() uint64
 	IncIteration() uint64
+
+	// whether a node is closed
 	IsClosed() bool
+	// try to close a node. It cannot be closed when the reference count is not 0
+	// true if closed and false otherwise
 	TryClose() bool
+
+	// the node state
 	GetState() NodeState
+
+	// expand a node size and execute the callback
 	Expand(uint64, func() error) error
 }
 
@@ -81,6 +107,7 @@ type INodeManager interface {
 	RegisterNode(INode)
 	UnregisterNode(INode)
 	Pin(INode) INodeHandle
+	PinByID(common.ID) (INodeHandle, error)
 	TryPin(INode, time.Duration) (INodeHandle, error)
 	TryPinByID(common.ID, time.Duration) (INodeHandle, error)
 	Unpin(INode)

--- a/pkg/vm/engine/tae/buffer/buffer_test.go
+++ b/pkg/vm/engine/tae/buffer/buffer_test.go
@@ -27,13 +27,16 @@ type testNodeHandle struct {
 }
 
 func (h *testNodeHandle) load() {
-	h.t.Logf("Load %s", h.id.BlockString())
+	id := h.key.(common.ID)
+	h.t.Logf("Load %s", id.BlockString())
 }
 func (h *testNodeHandle) unload() {
-	h.t.Logf("Unload %s", h.id.BlockString())
+	id := h.key.(common.ID)
+	h.t.Logf("Unload %s", id.BlockString())
 }
 func (h *testNodeHandle) destroy() {
-	h.t.Logf("Destroy %s", h.id.BlockString())
+	id := h.key.(common.ID)
+	h.t.Logf("Destroy %s", id.BlockString())
 }
 
 func newTestNodeHandle(mgr *nodeManager, id common.ID, size uint64, t *testing.T) *testNodeHandle {

--- a/pkg/vm/engine/tae/buffer/node.go
+++ b/pkg/vm/engine/tae/buffer/node.go
@@ -36,8 +36,8 @@ func newNodeHandle(n base.INode, mgr base.INodeManager) *nodeHandle {
 	}
 }
 
-func (h *nodeHandle) GetID() common.ID {
-	return h.n.GetID()
+func (h *nodeHandle) Key() any {
+	return h.n.Key()
 }
 
 func (h *nodeHandle) GetNode() base.INode {
@@ -53,7 +53,7 @@ type Node struct {
 	common.RefHelper
 	sync.RWMutex
 	mgr               base.INodeManager
-	id                common.ID
+	key               any
 	state             base.NodeState
 	size              uint64
 	iter              uint64
@@ -66,10 +66,10 @@ type Node struct {
 	UnloadFunc        func()
 }
 
-func NewNode(impl base.INode, mgr base.INodeManager, id common.ID, size uint64) *Node {
+func NewNode(impl base.INode, mgr base.INodeManager, key any, size uint64) *Node {
 	return &Node{
 		mgr:  mgr,
-		id:   id,
+		key:  key,
 		size: size,
 		impl: impl,
 	}
@@ -79,8 +79,8 @@ func (n *Node) Size() uint64 {
 	return n.size
 }
 
-func (n *Node) GetID() common.ID {
-	return n.id
+func (n *Node) Key() any {
+	return n.key
 }
 
 func (n *Node) MakeHandle() base.INodeHandle {

--- a/pkg/vm/engine/tae/buffer/nodemgr.go
+++ b/pkg/vm/engine/tae/buffer/nodemgr.go
@@ -85,6 +85,20 @@ func (mgr *nodeManager) Count() int {
 	return len(mgr.nodes)
 }
 
+func (mgr *nodeManager) Add(node base.INode) (err error) {
+	if !node.IsLoaded() {
+		mgr.RegisterNode(node)
+		return
+	}
+	ok := mgr.MakeRoom(node.Size())
+	if !ok {
+		err = base.ErrNoSpace
+		return
+	}
+	mgr.RegisterNode(node)
+	return
+}
+
 func (mgr *nodeManager) RegisterNode(node base.INode) {
 	id := node.GetID()
 	mgr.Lock()

--- a/pkg/vm/engine/tae/txn/txnimpl/node.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/node.go
@@ -322,8 +322,8 @@ func (n *insertNode) execUnload() (en wal.LogEntry) {
 		panic(err)
 	} else {
 		atomic.StoreUint64(&n.lsn, seq)
-		id := n.GetID()
-		logutil.Debugf("Unloading lsn=%d id=%s", seq, id.SegmentString())
+		id := n.Key()
+		logutil.Debugf("Unloading lsn=%d id=%v", seq, id)
 	}
 	// e.WaitDone()
 	// e.Free()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
1. Change the node key from common.ID to any
2. Enhancement evict related logic
    Previously, a buffer node needed to be registered first. When Pinning a node, it applies a size quota and loads data. When a node is evicted, it only unloads the data and returns back its size quota. 
    Now, when a hard evictable node is evicted, it will be destroyed and then removed from the buffer manager
3. Add PinByKey, TryPinByKey and Add APIs