### PR TITLE
txn: fix clock checker

### DIFF
--- a/pkg/txn/clock/hlc.go
+++ b/pkg/txn/clock/hlc.go
@@ -170,7 +170,9 @@ func (c *HLCClock) offsetMonitor(ctx context.Context) {
 func (c *HLCClock) getPhysicalClock() int64 {
 	newPts := c.physicalClock()
 	oldPts := c.keepPhysicalClock(newPts)
-	c.handleClockJump(oldPts, newPts)
+	if c.maxOffset > 0 {
+		c.handleClockJump(oldPts, newPts)
+	}
 
 	return newPts
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Disable clock max offset check not work when using now() to get current timestamp.