### PR TITLE
default disable MetricToProm (prometheus/promhttp service)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matrixorigin/matrixone
 
-go 1.18
+go 1.19
 
 require (
 	github.com/BurntSushi/toml v1.0.0

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -325,10 +325,11 @@ type ObservabilityParameters struct {
 	Host string `toml:"host"`
 
 	// StatusPort defines which port the mo status server (for metric etc.) listens on and clients connect to
+	// Start listen with EnableMetricToProm is true.
 	StatusPort int64 `toml:"statusPort"`
 
-	// DisableMetricToProm default is false. if false, metrics can be scraped through host:status/metrics endpoint
-	DisableMetricToProm bool `toml:"disableMetricToProm"`
+	// EnableMetricToProm default is false. if true, metrics can be scraped through host:status/metrics endpoint
+	EnableMetricToProm bool `toml:"enableMetricToProm"`
 
 	// DisableMetric default is false. if false, enable metric at booting
 	DisableMetric bool `toml:"disableMetric"`

--- a/pkg/util/metric/config.go
+++ b/pkg/util/metric/config.go
@@ -34,7 +34,7 @@ var (
 )
 
 func initConfigByParamaterUnit(SV *config.ObservabilityParameters) {
-	setExportToProm(!SV.DisableMetricToProm)
+	setExportToProm(SV.EnableMetricToProm)
 }
 
 func envOrDefaultBool(key string, defaultValue int32) int32 {

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -41,7 +41,7 @@ func TestMetric(t *testing.T) {
 		SV.SetDefaultValues("test")
 		SV.Host = "0.0.0.0"
 		SV.StatusPort = 7001
-		SV.DisableMetricToProm = false
+		SV.EnableMetricToProm = true
 		SV.BatchProcessor = InternalExecutor
 		defer setGatherInterval(setGatherInterval(30 * time.Millisecond))
 		defer setRawHistBufLimit(setRawHistBufLimit(5))
@@ -94,7 +94,7 @@ func TestMetricNoProm(t *testing.T) {
 		SV := &config.ObservabilityParameters{}
 		SV.Host = "0.0.0.0"
 		SV.StatusPort = 7001
-		SV.DisableMetricToProm = true
+		SV.EnableMetricToProm = false
 		SV.BatchProcessor = InternalExecutor
 
 		defer setGatherInterval(setGatherInterval(30 * time.Millisecond))
@@ -110,7 +110,7 @@ func TestMetricNoProm(t *testing.T) {
 		require.Contains(t, err.Error(), "connection refused")
 
 		// make static-check(errcheck) happay
-		SV.DisableMetricToProm = false
+		SV.EnableMetricToProm = true
 	})
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

- rename param `disableMetricToProm` to `enableMetricToProm`, default disable `statusPort` listening.
- modify go.mod dependence go 1.18 -> go 1.19