### PR TITLE
fix bug:  when get @float_var then cast value as decimal

### DIFF
--- a/pkg/sql/plan/make.go
+++ b/pkg/sql/plan/make.go
@@ -20,6 +20,21 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 )
 
+func makePlan2DecimalExprWithType(v string) (*plan.Expr, error) {
+	_, scale, err := types.ParseStringToDecimal128WithoutTable(v)
+	if err != nil {
+		return nil, err
+	}
+	typ := &plan.Type{
+		Id:        int32(types.T_decimal128),
+		Width:     34,
+		Scale:     scale,
+		Precision: 34,
+		Nullable:  false,
+	}
+	return appendCastBeforeExpr(makePlan2StringConstExprWithType(v), typ)
+}
+
 func makePlan2NullConstExprWithType() *plan.Expr {
 	return &plan.Expr{
 		Expr: &plan.Expr_C{

--- a/pkg/sql/plan/make.go
+++ b/pkg/sql/plan/make.go
@@ -109,25 +109,25 @@ func makePlan2Uint64ConstExprWithType(v uint64) *plan.Expr {
 	}
 }
 
-func makePlan2Float64ConstExpr(v float64) *plan.Expr_C {
-	return &plan.Expr_C{C: &plan.Const{
-		Isnull: false,
-		Value: &plan.Const_Dval{
-			Dval: v,
-		},
-	}}
-}
+// func makePlan2Float64ConstExpr(v float64) *plan.Expr_C {
+// 	return &plan.Expr_C{C: &plan.Const{
+// 		Isnull: false,
+// 		Value: &plan.Const_Dval{
+// 			Dval: v,
+// 		},
+// 	}}
+// }
 
-func makePlan2Float64ConstExprWithType(v float64) *plan.Expr {
-	return &plan.Expr{
-		Expr: makePlan2Float64ConstExpr(v),
-		Typ: &plan.Type{
-			Id:       int32(types.T_float64),
-			Nullable: false,
-			Size:     8,
-		},
-	}
-}
+// func makePlan2Float64ConstExprWithType(v float64) *plan.Expr {
+// 	return &plan.Expr{
+// 		Expr: makePlan2Float64ConstExpr(v),
+// 		Typ: &plan.Type{
+// 			Id:       int32(types.T_float64),
+// 			Nullable: false,
+// 			Size:     8,
+// 		},
+// 	}
+// }
 
 func makePlan2StringConstExpr(v string) *plan.Expr_C {
 	return &plan.Expr_C{C: &plan.Const{

--- a/pkg/sql/plan/visit_plan_rule.go
+++ b/pkg/sql/plan/visit_plan_rule.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"sort"
+	"strconv"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -270,9 +271,15 @@ func (rule *ResetVarRefRule) ApplyExpr(e *plan.Expr) (*plan.Expr, error) {
 		case uint64:
 			expr = makePlan2Uint64ConstExprWithType(val)
 		case float32:
-			expr = makePlan2Float64ConstExprWithType(float64(val))
+			// when we build plan with constant in float, we cast them to decimal.
+			// so we cast @float_var to decimal too.
+			strVal := strconv.FormatFloat(float64(val), 'f', -1, 64)
+			expr, err = makePlan2DecimalExprWithType(strVal)
 		case float64:
-			expr = makePlan2Float64ConstExprWithType(val)
+			// when we build plan with constant in float, we cast them to decimal.
+			// so we cast @float_var to decimal too.
+			strVal := strconv.FormatFloat(val, 'f', -1, 64)
+			expr, err = makePlan2DecimalExprWithType(strVal)
 		case bool:
 			expr = makePlan2BoolConstExprWithType(val)
 		case nil:

--- a/test/cases/prepare/prepare.test
+++ b/test/cases/prepare/prepare.test
@@ -56,3 +56,11 @@ prepare stmt1 from 'update t1 set a=a+? where b = 1';
 set @a=0.1111;
 execute stmt1 using @a;
 select a, b from t1;
+
+drop table if exists t1;
+create table t1 (a decimal(12,2));
+insert into t1 values (30000);
+prepare stmt1 from 'update t1 set a = a + ?';
+set @a=4418.59;
+execute stmt1 using @a;
+select a from t1;

--- a/test/result/prepare/prepare.result
+++ b/test/result/prepare/prepare.result
@@ -78,3 +78,12 @@ execute stmt1 using @a;
 select a, b from t1;
 a	b
 12.3333	1
+drop table if exists t1;
+create table t1 (a decimal(12,2));
+insert into t1 values (30000);
+prepare stmt1 from 'update t1 set a = a + ?';
+set @a=4418.59;
+execute stmt1 using @a;
+select a from t1;
+a
+34418.59


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #5285 

## What this PR does / why we need it:
we will cast float constant  as decimal when build plan.
so when we execute plan by using @float_var,  we cast the @float_var's value as decimal now.
that will help us to keep the precision
