### PR TITLE
stop flushing phyaddr column and generate when reading

### DIFF
--- a/pkg/vm/engine/tae/common/compress.go
+++ b/pkg/vm/engine/tae/common/compress.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+type CompressType uint8
+
+const (
+	Plain CompressType = iota
+	Lz4
+)
+
+func Compress(raw []byte, ctyp CompressType) []byte {
+	return raw
+}
+
+func Decompress(src []byte, dst []byte, ctyp CompressType) error {
+	copy(dst, src)
+	return nil
+}

--- a/pkg/vm/engine/tae/common/dlnode.go
+++ b/pkg/vm/engine/tae/common/dlnode.go
@@ -144,9 +144,9 @@ func (l *GenericSortedDList[T]) Delete(n *GenericDLNode[T]) {
 // Loop the list and apply fn on each node
 func (l *GenericSortedDList[T]) Loop(fn func(n *GenericDLNode[T]) bool, reverse bool) {
 	if reverse {
-		LoopGenericSortedDList[T](l.tail, fn, reverse)
+		LoopGenericSortedDList(l.tail, fn, reverse)
 	} else {
-		LoopGenericSortedDList[T](l.head, fn, reverse)
+		LoopGenericSortedDList(l.head, fn, reverse)
 	}
 }
 

--- a/pkg/vm/engine/tae/db/db_test.go
+++ b/pkg/vm/engine/tae/db/db_test.go
@@ -16,7 +16,6 @@ package db
 
 import (
 	"bytes"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/dataio/blockio"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -35,6 +34,7 @@ import (
 	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/dataio/blockio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
@@ -730,7 +730,7 @@ func TestAutoCompactABlk2(t *testing.T) {
 	testutils.EnsureNoLeak(t)
 	opts := new(options.Options)
 	opts.CacheCfg = new(options.CacheCfg)
-	opts.CacheCfg.InsertCapacity = common.K * 5
+	opts.CacheCfg.InsertCapacity = common.M * 5
 	opts.CacheCfg.TxnCapacity = common.M
 	opts = config.WithQuickScanAndCKPOpts(opts)
 	db := initDB(t, opts)

--- a/pkg/vm/engine/tae/tables/block.go
+++ b/pkg/vm/engine/tae/tables/block.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/wal"
 
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables/evictable"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables/indexwrapper"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables/jobs"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables/updates"
@@ -651,7 +652,9 @@ func (blk *dataBlock) LoadColumnData(
 	def := blk.meta.GetSchema().ColDefs[colIdx]
 	// FIXME "GetMetaLoc()"
 	metaLoc := blk.meta.GetMetaLoc()
-	return blk.colObjects[colIdx].GetData(metaLoc, def.NullAbility, def.Type, buffer)
+	id := blk.meta.AsCommonID()
+	id.Idx = uint16(colIdx)
+	return evictable.FetchColumnData(buffer, blk.bufMgr, id, blk.colObjects[colIdx], metaLoc, def)
 }
 
 func (blk *dataBlock) ablkGetByFilter(ts types.TS, filter *handle.Filter) (offset uint32, err error) {

--- a/pkg/vm/engine/tae/tables/evictable/bf.go
+++ b/pkg/vm/engine/tae/tables/evictable/bf.go
@@ -1,0 +1,90 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evictable
+
+import (
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer/base"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/file"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+)
+
+type BfNode struct {
+	*buffer.Node
+
+	Bf index.StaticFilter
+
+	metaKey, bfKey string
+	mgr            base.INodeManager
+	colMetaFactory EvictableNodeFactory
+}
+
+func NewBfNode(mgr base.INodeManager, bfKey, metaKey string, col file.ColumnBlock, metaloc string, typ types.Type) (node *BfNode, err error) {
+	node = &BfNode{
+		bfKey:          bfKey,
+		metaKey:        metaKey,
+		mgr:            mgr,
+		colMetaFactory: func() (base.INode, error) { return NewColumnMetaNode(mgr, metaKey, col, metaloc, typ), nil },
+	}
+
+	h, err := PinEvictableNode(mgr, metaKey, node.colMetaFactory)
+	if err != nil {
+		return
+	}
+	defer h.Close()
+	meta := h.GetNode().(*ColumnMetaNode)
+	size := meta.GetMeta().GetBloomFilter().OriginSize()
+	node.Node = buffer.NewNode(node, mgr, bfKey, uint64(size))
+	node.LoadFunc = node.onLoad
+	node.UnloadFunc = node.onUnload
+	node.HardEvictableFunc = func() bool { return true }
+	return
+}
+
+func (n *BfNode) onLoad() {
+	var h base.INodeHandle
+	var err error
+	h, err = PinEvictableNode(n.mgr, n.metaKey, n.colMetaFactory)
+	if err != nil {
+		panic(err)
+	}
+	metaNode := h.GetNode().(*ColumnMetaNode)
+	h.Close()
+
+	stat := metaNode.GetMeta()
+	compressTyp := stat.GetAlg()
+	// Do IO, fetch bloomfilter buf
+	fsData, err := metaNode.GetIndex(objectio.BloomFilterType)
+	if err != nil {
+		panic(err)
+	}
+	rawSize := stat.GetBloomFilter().OriginSize()
+	buf := make([]byte, rawSize)
+	data := fsData.(*objectio.BloomFilter).GetData()
+	if err = common.Decompress(data, buf, common.CompressType(compressTyp)); err != nil {
+		panic(err)
+	}
+	n.Bf, err = index.NewBinaryFuseFilterFromSource(buf)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (n *BfNode) onUnload() {
+	n.Bf = nil
+}

--- a/pkg/vm/engine/tae/tables/evictable/coldata.go
+++ b/pkg/vm/engine/tae/tables/evictable/coldata.go
@@ -1,0 +1,171 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evictable
+
+import (
+	"bytes"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer/base"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/dataio/blockio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/file"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/model"
+)
+
+type ColDataNode struct {
+	*buffer.Node
+
+	Data containers.Vector
+
+	colDataKey string
+	colDef     *catalog.ColDef
+
+	// used for rowid
+	rows     uint32
+	sid, bid uint64
+
+	// used for other columns
+	metaKey        string
+	mgr            base.INodeManager
+	colMetaFactory EvictableNodeFactory
+}
+
+type BackendKind = uint8
+
+const (
+	Disk = iota
+	S3
+)
+
+var StorageBackend BackendKind = Disk
+
+func NewColDataNode(mgr base.INodeManager, colDataKey, metaKey string, col file.ColumnBlock, metaloc string, colDef *catalog.ColDef, sid, bid uint64) (node *ColDataNode, err error) {
+	node = &ColDataNode{
+		colDataKey:     colDataKey,
+		metaKey:        metaKey,
+		sid:            sid,
+		bid:            bid,
+		mgr:            mgr,
+		colDef:         colDef,
+		colMetaFactory: func() (base.INode, error) { return NewColumnMetaNode(mgr, metaKey, col, metaloc, colDef.Type), nil },
+	}
+	// For disk, size is zero, do not cache, read directly when GetData
+	var size uint32 = 0
+	if node.colDef.IsPhyAddr() {
+		_, _, node.rows = blockio.DecodeMetaLoc(metaloc)
+		size = types.RowidSize * node.rows
+	} else if StorageBackend == S3 {
+		// on s3, fetch coldata to get data size
+		h, pinerr := PinEvictableNode(mgr, metaKey, node.colMetaFactory)
+		if pinerr != nil {
+			return nil, pinerr
+		}
+		defer h.Close()
+		meta := h.GetNode().(*ColumnMetaNode)
+		size = meta.GetMeta().GetLocation().OriginSize()
+	}
+
+	node.Node = buffer.NewNode(node, mgr, colDataKey, uint64(size))
+	node.LoadFunc = node.onLoad
+	node.UnloadFunc = node.onUnload
+	node.HardEvictableFunc = func() bool { return true }
+	return
+}
+
+func (n *ColDataNode) onLoad() {
+	if n.colDef.IsPhyAddr() {
+		n.constructRowId()
+		return
+	}
+	switch StorageBackend {
+	case S3:
+		// fetch data via s3 and cache it
+		// TODOa: error handling
+		data, _ := n.fetchData()
+		n.Data = data
+	case Disk:
+		// for disk, do nothing when load
+	}
+}
+
+func (n *ColDataNode) constructRowId() {
+	prefix := model.EncodeBlockKeyPrefix(n.sid, n.bid)
+	n.Data, _ = model.PreparePhyAddrData(
+		types.T_Rowid.ToType(),
+		prefix,
+		0,
+		n.rows,
+	)
+}
+
+func (n *ColDataNode) fetchData() (containers.Vector, error) {
+	var h base.INodeHandle
+	var err error
+	h, err = PinEvictableNode(n.mgr, n.metaKey, n.colMetaFactory)
+	if err != nil {
+		return nil, err
+	}
+	metaNode := h.GetNode().(*ColumnMetaNode)
+	defer h.Close()
+
+	// Do IO, fetch data buf
+	fsVector, err := metaNode.GetData()
+	if err != nil {
+		return nil, err
+	}
+
+	srcBuf := fsVector.Entries[0].Data
+	v := vector.New(n.colDef.Type)
+	v.Read(srcBuf)
+	return containers.MOToVectorTmp(v, n.colDef.NullAbility), nil
+}
+
+func (n *ColDataNode) GetData(buf *bytes.Buffer) (containers.Vector, error) {
+	// after load, for s3 and phy addr, its data is n.Data
+	if n.colDef.IsPhyAddr() {
+		return copyVector(n.Data, buf), nil
+	}
+	switch StorageBackend {
+	case Disk:
+		// for disk, read directly
+		return n.fetchData()
+	case S3:
+		return copyVector(n.Data, buf), nil
+	}
+	return nil, nil
+}
+
+func (n *ColDataNode) onUnload() {
+	n.Data = nil
+}
+
+func FetchColumnData(buf *bytes.Buffer, mgr base.INodeManager, id *common.ID, col file.ColumnBlock, metaloc string, colDef *catalog.ColDef) (res containers.Vector, err error) {
+	colDataKey := EncodeColDataKey(id)
+	factory := func() (base.INode, error) {
+		return NewColDataNode(mgr, colDataKey, EncodeColMetaKey(id), col, metaloc, colDef, id.SegmentID, id.BlockID)
+	}
+	h, err := PinEvictableNode(mgr, colDataKey, factory)
+	if err != nil {
+		return nil, err
+	}
+	defer h.Close()
+	node := h.GetNode().(*ColDataNode)
+	return node.GetData(buf)
+}

--- a/pkg/vm/engine/tae/tables/evictable/colmeta.go
+++ b/pkg/vm/engine/tae/tables/evictable/colmeta.go
@@ -1,0 +1,79 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evictable
+
+import (
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer/base"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/dataio/blockio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/file"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+)
+
+type ColumnMetaNode struct {
+	*buffer.Node
+	// data
+	objectio.ColumnObject
+	Zonemap *index.ZoneMap
+	typ     types.Type
+	// used to load data
+	col     file.ColumnBlock
+	metaloc string
+}
+
+func NewColumnMetaNode(mgr base.INodeManager, metaKey string, col file.ColumnBlock, metaloc string, typ types.Type) *ColumnMetaNode {
+	node := &ColumnMetaNode{
+		col:     col,
+		metaloc: metaloc,
+		typ:     typ,
+	}
+	_, ext, _ := blockio.DecodeMetaLoc(metaloc)
+	baseNode := buffer.NewNode(node, mgr, metaKey, uint64(ext.OriginSize()))
+	node.Node = baseNode
+	node.LoadFunc = node.onLoad
+	node.UnloadFunc = node.onUnLoad
+	node.HardEvictableFunc = func() bool { return true }
+	return node
+}
+
+func (n *ColumnMetaNode) onLoad() {
+	if n.ColumnObject != nil {
+		return
+	}
+	// Do IO, fetch columnData
+	meta := n.col.GetDataObject(n.metaloc)
+	n.ColumnObject = meta
+
+	// deserialize zonemap
+	zmData, err := meta.GetIndex(objectio.ZoneMapType)
+
+	// TODOa: Error Handling?
+	if err != nil {
+		panic(err)
+	}
+	data := zmData.(*objectio.ZoneMap)
+	n.Zonemap = index.NewZoneMap(n.typ)
+	err = n.Zonemap.Unmarshal(data.GetData())
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (n *ColumnMetaNode) onUnLoad() {
+	n.Zonemap = nil
+	n.ColumnObject = nil
+}

--- a/pkg/vm/engine/tae/tables/evictable/utils.go
+++ b/pkg/vm/engine/tae/tables/evictable/utils.go
@@ -1,0 +1,57 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evictable
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer/base"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+)
+
+const (
+	ConstPinDuration = 16 * time.Second
+)
+
+func EncodeColMetaKey(id *common.ID) string {
+	return fmt.Sprintf("colMeta-%d-%d", id.BlockID, id.Idx)
+}
+
+func EncodeColBfKey(id *common.ID) string {
+	return fmt.Sprintf("colBf-%d-%d", id.BlockID, id.Idx)
+}
+
+func EncodeColDataKey(id *common.ID) string {
+	return fmt.Sprintf("colData-%d-%d", id.BlockID, id.Idx)
+}
+
+type EvictableNodeFactory = func() (base.INode, error)
+
+func PinEvictableNode(mgr base.INodeManager, key string, factory EvictableNodeFactory) (base.INodeHandle, error) {
+	var h base.INodeHandle
+	var err error
+	h, err = mgr.TryPinByKey(key, ConstPinDuration)
+	if err == base.ErrNotFound {
+		node, newerr := factory()
+		if newerr != nil {
+			return nil, newerr
+		}
+		// Ignore duplicate node and TODO: maybe handle no space
+		mgr.Add(node)
+		h, err = mgr.TryPinByKey(key, ConstPinDuration)
+	}
+	return h, err
+}

--- a/pkg/vm/engine/tae/tables/evictable/utils.go
+++ b/pkg/vm/engine/tae/tables/evictable/utils.go
@@ -15,15 +15,17 @@
 package evictable
 
 import (
+	"bytes"
 	"fmt"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer/base"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 )
 
 const (
-	ConstPinDuration = 16 * time.Second
+	ConstPinDuration = 5 * time.Second
 )
 
 func EncodeColMetaKey(id *common.ID) string {
@@ -54,4 +56,12 @@ func PinEvictableNode(mgr base.INodeManager, key string, factory EvictableNodeFa
 		h, err = mgr.TryPinByKey(key, ConstPinDuration)
 	}
 	return h, err
+}
+
+func copyVector(data containers.Vector, buf *bytes.Buffer) containers.Vector {
+	if buf != nil {
+		return containers.CloneWithBuffer(data, buf, containers.DefaultAllocator)
+	} else {
+		return data.CloneWindow(0, data.Length(), containers.DefaultAllocator)
+	}
 }

--- a/pkg/vm/engine/tae/tables/indexwrapper/bfnode.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/bfnode.go
@@ -94,7 +94,7 @@ func (n *bfNode) onLoad() {
 	rawSize := stat.GetBloomFilter().OriginSize()
 	buf := make([]byte, rawSize)
 	data := fsData.(*objectio.BloomFilter).GetData()
-	if err = Decompress(data, buf, CompressType(compressTyp)); err != nil {
+	if err = common.Decompress(data, buf, common.CompressType(compressTyp)); err != nil {
 		panic(err)
 	}
 	n.bf, err = index.NewBinaryFuseFilterFromSource(buf)
@@ -163,7 +163,7 @@ func (r *BfReader) MayContainsAnyKeys(keys containers.Vector, visibility *roarin
 func (r *BfReader) Destroy() error { return nil }
 
 type BFWriter struct {
-	cType       CompressType
+	cType       common.CompressType
 	writer      objectio.Writer
 	block       objectio.BlockObject
 	impl        index.StaticFilter
@@ -176,7 +176,7 @@ func NewBFWriter() *BFWriter {
 	return &BFWriter{}
 }
 
-func (writer *BFWriter) Init(wr objectio.Writer, block objectio.BlockObject, cType CompressType, colIdx uint16, internalIdx uint16) error {
+func (writer *BFWriter) Init(wr objectio.Writer, block objectio.BlockObject, cType common.CompressType, colIdx uint16, internalIdx uint16) error {
 	writer.writer = wr
 	writer.block = block
 	writer.cType = cType
@@ -210,7 +210,7 @@ func (writer *BFWriter) Finalize() (*IndexMeta, error) {
 	}
 	bf := objectio.NewBloomFilter(writer.colIdx, uint8(writer.cType), iBuf)
 	rawSize := uint32(len(iBuf))
-	compressed := Compress(iBuf, writer.cType)
+	compressed := common.Compress(iBuf, writer.cType)
 	exactSize := uint32(len(compressed))
 	meta.SetSize(rawSize, exactSize)
 

--- a/pkg/vm/engine/tae/tables/indexwrapper/bfnode.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/bfnode.go
@@ -19,145 +19,51 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer/base"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/file"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables/evictable"
 )
 
-type bfNode struct {
-	*buffer.Node
-
-	bf index.StaticFilter
-
-	metaKey, bfKey string
-	typ            types.Type
-	mgr            base.INodeManager
-	col            file.ColumnBlock
-	metaloc        string
-}
-
-func newBfNode(mgr base.INodeManager, bfKey, metaKey string, col file.ColumnBlock, metaloc string, typ types.Type) (node *bfNode, err error) {
-	node = &bfNode{
-		bfKey:   bfKey,
-		metaKey: metaKey,
-		typ:     typ,
-		mgr:     mgr,
-		col:     col,
-		metaloc: metaloc,
-	}
-
-	h, err := node.pinMeta()
-	if err != nil {
-		return
-	}
-	defer h.Close()
-	meta := h.GetNode().(*columnMetaNode)
-	size := meta.GetMeta().GetBloomFilter().OriginSize()
-	node.Node = buffer.NewNode(node, mgr, bfKey, uint64(size))
-	node.LoadFunc = node.onLoad
-	node.UnloadFunc = node.onUnload
-	node.HardEvictableFunc = func() bool { return true }
-	return
-}
-
-func (n *bfNode) pinMeta() (base.INodeHandle, error) {
-	var h base.INodeHandle
-	var err error
-	h, err = n.mgr.TryPinByKey(n.metaKey, ConstPinDuration)
-	if err == base.ErrNotFound {
-		n.mgr.Add(newColumnMetaNode(n.mgr, n.metaKey, n.col, n.metaloc, n.typ))
-		h, err = n.mgr.TryPinByKey(n.metaKey, ConstPinDuration)
-	}
-	return h, err
-}
-
-func (n *bfNode) onLoad() {
-	var h base.INodeHandle
-	var err error
-	h, err = n.pinMeta()
-	if err != nil {
-		panic(err)
-	}
-	metaNode := h.GetNode().(*columnMetaNode)
-	h.Close()
-
-	stat := metaNode.GetMeta()
-	compressTyp := stat.GetAlg()
-	// Do IO, fetch bloomfilter buf
-	fsData, err := metaNode.GetIndex(objectio.BloomFilterType)
-	if err != nil {
-		panic(err)
-	}
-	rawSize := stat.GetBloomFilter().OriginSize()
-	buf := make([]byte, rawSize)
-	data := fsData.(*objectio.BloomFilter).GetData()
-	if err = common.Decompress(data, buf, common.CompressType(compressTyp)); err != nil {
-		panic(err)
-	}
-	n.bf, err = index.NewBinaryFuseFilterFromSource(buf)
-	if err != nil {
-		panic(err)
-	}
-}
-
-func (n *bfNode) onUnload() {
-	n.bf = nil
-}
-
 type BfReader struct {
-	metaKey, bfKey string
-	typ            types.Type
-	mgr            base.INodeManager
-	col            file.ColumnBlock
-	metaloc        string
+	bfKey     string
+	mgr       base.INodeManager
+	bfFacotry evictable.EvictableNodeFactory
 }
 
 func newBfReader(mgr base.INodeManager, typ types.Type, id common.ID, col file.ColumnBlock, metaloc string) *BfReader {
-	return &BfReader{
-		metaKey: encodeColMetaKey(&id),
-		bfKey:   encodeColBfKey(&id),
-		mgr:     mgr,
-		col:     col,
-		metaloc: metaloc,
-	}
-}
+	metaKey := evictable.EncodeColMetaKey(&id)
+	bfKey := evictable.EncodeColBfKey(&id)
 
-func (r *BfReader) pin() (h base.INodeHandle, err error) {
-	h, err = r.mgr.TryPinByKey(r.bfKey, ConstPinDuration)
-	if err == base.ErrNotFound {
-		bfNode, newerr := newBfNode(r.mgr, r.bfKey, r.metaKey, r.col, r.metaloc, r.typ)
-		if newerr != nil {
-			return nil, newerr
-		}
-		r.mgr.Add(bfNode)
-		h, err = r.mgr.TryPinByKey(r.bfKey, ConstPinDuration)
+	return &BfReader{
+		mgr:       mgr,
+		bfKey:     bfKey,
+		bfFacotry: func() (base.INode, error) { return evictable.NewBfNode(mgr, bfKey, metaKey, col, metaloc, typ) },
 	}
-	return h, err
 }
 
 func (r *BfReader) MayContainsKey(key any) (b bool, err error) {
-	h, err := r.pin()
+	h, err := evictable.PinEvictableNode(r.mgr, r.bfKey, r.bfFacotry)
 	if err != nil {
 		// TODOa: Error Handling?
 		return
 	}
 	defer h.Close()
-	bfNode := h.GetNode().(*bfNode)
-	return bfNode.bf.MayContainsKey(key)
+	bfNode := h.GetNode().(*evictable.BfNode)
+	return bfNode.Bf.MayContainsKey(key)
 }
 
 func (r *BfReader) MayContainsAnyKeys(keys containers.Vector, visibility *roaring.Bitmap) (b bool, m *roaring.Bitmap, err error) {
-	h, err := r.pin()
+	h, err := evictable.PinEvictableNode(r.mgr, r.bfKey, r.bfFacotry)
 	if err != nil {
 		// TODOa: Error Handling?
 		return
 	}
 	defer h.Close()
-	bfNode := h.GetNode().(*bfNode)
-	return bfNode.bf.MayContainsAnyKeys(keys, visibility)
+	bfNode := h.GetNode().(*evictable.BfNode)
+	return bfNode.Bf.MayContainsAnyKeys(keys, visibility)
 }
 
 func (r *BfReader) Destroy() error { return nil }

--- a/pkg/vm/engine/tae/tables/indexwrapper/bfnode_test.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/bfnode_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/testutils"
 	"github.com/stretchr/testify/assert"
@@ -57,7 +58,7 @@ func TestStaticFilterIndex(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(blocks))
 
-	cType := Plain
+	cType := common.Plain
 	typ := types.Type{Oid: types.T_int32}
 	colIdx := uint16(0)
 	interIdx := uint16(0)

--- a/pkg/vm/engine/tae/tables/indexwrapper/meta.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/meta.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 )
 
 type IndexType uint8
@@ -30,25 +31,9 @@ const (
 	ARTIndex
 )
 
-type CompressType uint8
-
-const (
-	Plain CompressType = iota
-	Lz4
-)
-
-func Compress(raw []byte, ctyp CompressType) []byte {
-	return raw
-}
-
-func Decompress(src []byte, dst []byte, ctyp CompressType) error {
-	copy(dst, src)
-	return nil
-}
-
 type IndexMeta struct {
 	IdxType     IndexType
-	CompType    CompressType
+	CompType    common.CompressType
 	ColIdx      uint16
 	InternalIdx uint16
 	Size        uint32
@@ -58,7 +43,7 @@ type IndexMeta struct {
 func NewEmptyIndexMeta() *IndexMeta {
 	return &IndexMeta{
 		IdxType:  InvalidIndexType,
-		CompType: Plain,
+		CompType: common.Plain,
 	}
 }
 
@@ -66,7 +51,7 @@ func (meta *IndexMeta) SetIndexType(typ IndexType) {
 	meta.IdxType = typ
 }
 
-func (meta *IndexMeta) SetCompressType(typ CompressType) {
+func (meta *IndexMeta) SetCompressType(typ common.CompressType) {
 	meta.CompType = typ
 }
 
@@ -105,7 +90,7 @@ func (meta *IndexMeta) Marshal() ([]byte, error) {
 func (meta *IndexMeta) Unmarshal(buf []byte) error {
 	meta.IdxType = IndexType(types.DecodeFixed[uint8](buf[:1]))
 	buf = buf[1:]
-	meta.CompType = CompressType(types.DecodeFixed[uint8](buf[1:]))
+	meta.CompType = common.CompressType(types.DecodeFixed[uint8](buf[1:]))
 	buf = buf[1:]
 	meta.ColIdx = types.DecodeFixed[uint16](buf[:2])
 	buf = buf[2:]

--- a/pkg/vm/engine/tae/tables/indexwrapper/zmnode_test.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/zmnode_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/testutils"
 	"github.com/matrixorigin/matrixone/pkg/vm/mheap"
@@ -60,7 +61,7 @@ func TestBlockZoneMapIndex(t *testing.T) {
 	blocks, err := objectWriter.WriteEnd()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(blocks))
-	cType := Plain
+	cType := common.Plain
 	typ := types.Type{Oid: types.T_int32}
 	pkColIdx := uint16(0)
 	interIdx := uint16(0)

--- a/pkg/vm/engine/tae/tables/indexwrapper/zonemapnode.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/zonemapnode.go
@@ -15,138 +15,54 @@
 package indexwrapper
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/RoaringBitmap/roaring"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer/base"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/dataio/blockio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/file"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables/evictable"
 )
-
-const (
-	ConstPinDuration = 5 * time.Second
-)
-
-func encodeColMetaKey(id *common.ID) string {
-	return fmt.Sprintf("colMeta-%d-%d", id.BlockID, id.Idx)
-}
-
-func encodeColBfKey(id *common.ID) string {
-	return fmt.Sprintf("colBf-%d-%d", id.BlockID, id.Idx)
-}
-
-// func encodeColDataKey(id *common.ID) string {
-// 	return fmt.Sprintf("colData-%d-%d", id.BlockID, id.Idx)
-// }
-
-type columnMetaNode struct {
-	*buffer.Node
-	// data
-	objectio.ColumnObject
-	zonemap *index.ZoneMap
-	typ     types.Type
-	// used to load data
-	col     file.ColumnBlock
-	metaloc string
-}
-
-func newColumnMetaNode(mgr base.INodeManager, metaKey string, col file.ColumnBlock, metaloc string, typ types.Type) *columnMetaNode {
-	node := &columnMetaNode{
-		col:     col,
-		metaloc: metaloc,
-		typ:     typ,
-	}
-	_, ext, _ := blockio.DecodeMetaLoc(metaloc)
-	baseNode := buffer.NewNode(node, mgr, metaKey, uint64(ext.OriginSize()))
-	node.Node = baseNode
-	node.LoadFunc = node.onLoad
-	node.UnloadFunc = node.onUnLoad
-	node.HardEvictableFunc = func() bool { return true }
-	return node
-}
-
-func (n *columnMetaNode) onLoad() {
-	if n.ColumnObject != nil {
-		return
-	}
-	// Do IO, fetch columnData
-	meta := n.col.GetDataObject(n.metaloc)
-	n.ColumnObject = meta
-
-	// deserialize zonemap
-	zmData, err := meta.GetIndex(objectio.ZoneMapType)
-	// TODOa: Error Handling?
-	if err != nil {
-		panic(err)
-	}
-	data := zmData.(*objectio.ZoneMap)
-	n.zonemap = index.NewZoneMap(n.typ)
-	err = n.zonemap.Unmarshal(data.GetData())
-	if err != nil {
-		panic(err)
-	}
-}
-
-func (n *columnMetaNode) onUnLoad() {
-	n.zonemap = nil
-	n.ColumnObject = nil
-}
 
 type ZmReader struct {
-	metaKey string
-	typ     types.Type
-	mgr     base.INodeManager
-	col     file.ColumnBlock
-	metaloc string
+	metaKey        string
+	mgr            base.INodeManager
+	colMetaFactory evictable.EvictableNodeFactory
 }
 
 func newZmReader(mgr base.INodeManager, typ types.Type, id common.ID, col file.ColumnBlock, metaloc string) *ZmReader {
+	metaKey := evictable.EncodeColMetaKey(&id)
 	return &ZmReader{
-		metaKey: encodeColMetaKey(&id),
-		typ:     typ,
+		metaKey: metaKey,
 		mgr:     mgr,
-		col:     col,
-		metaloc: metaloc,
+		colMetaFactory: func() (base.INode, error) {
+			return evictable.NewColumnMetaNode(mgr, metaKey, col, metaloc, typ), nil
+		},
 	}
-}
-
-func (r *ZmReader) pin() (h base.INodeHandle, err error) {
-	h, err = r.mgr.TryPinByKey(r.metaKey, ConstPinDuration)
-	if err == base.ErrNotFound {
-		// Ingnore duplicate node error. TODO NoSpaceError
-		r.mgr.Add(newColumnMetaNode(r.mgr, r.metaKey, r.col, r.metaloc, r.typ))
-		h, err = r.mgr.TryPinByKey(r.metaKey, ConstPinDuration)
-	}
-	return h, err
 }
 
 func (r *ZmReader) Contains(key any) bool {
-	h, err := r.pin()
+	h, err := evictable.PinEvictableNode(r.mgr, r.metaKey, r.colMetaFactory)
 	if err != nil {
 		// TODOa: Error Handling?
 		return false
 	}
 	defer h.Close()
-	zm := h.GetNode().(*columnMetaNode)
-	return zm.zonemap.Contains(key)
+	node := h.GetNode().(*evictable.ColumnMetaNode)
+	return node.Zonemap.Contains(key)
 }
 
 func (r *ZmReader) ContainsAny(keys containers.Vector) (visibility *roaring.Bitmap, ok bool) {
-	h, err := r.pin()
+	h, err := evictable.PinEvictableNode(r.mgr, r.metaKey, r.colMetaFactory)
 	if err != nil {
 		return
 	}
 	defer h.Close()
-	zm := h.GetNode().(*columnMetaNode)
-	return zm.zonemap.ContainsAny(keys)
+	node := h.GetNode().(*evictable.ColumnMetaNode)
+	return node.Zonemap.ContainsAny(keys)
 }
 
 func (r *ZmReader) Destroy() error { return nil }

--- a/pkg/vm/engine/tae/tables/indexwrapper/zonemapnode.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/zonemapnode.go
@@ -152,7 +152,7 @@ func (r *ZmReader) ContainsAny(keys containers.Vector) (visibility *roaring.Bitm
 func (r *ZmReader) Destroy() error { return nil }
 
 type ZMWriter struct {
-	cType       CompressType
+	cType       common.CompressType
 	writer      objectio.Writer
 	block       objectio.BlockObject
 	zonemap     *index.ZoneMap
@@ -164,7 +164,7 @@ func NewZMWriter() *ZMWriter {
 	return &ZMWriter{}
 }
 
-func (writer *ZMWriter) Init(wr objectio.Writer, block objectio.BlockObject, cType CompressType, colIdx uint16, internalIdx uint16) error {
+func (writer *ZMWriter) Init(wr objectio.Writer, block objectio.BlockObject, cType common.CompressType, colIdx uint16, internalIdx uint16) error {
 	writer.writer = wr
 	writer.block = block
 	writer.cType = cType
@@ -194,7 +194,7 @@ func (writer *ZMWriter) Finalize() (*IndexMeta, error) {
 		return nil, err
 	}
 	rawSize := uint32(len(iBuf))
-	compressed := Compress(iBuf, writer.cType)
+	compressed := common.Compress(iBuf, writer.cType)
 	exactSize := uint32(len(compressed))
 	meta.SetSize(rawSize, exactSize)
 	err = appender.WriteIndex(writer.block, zonemap)

--- a/pkg/vm/engine/tae/tables/jobs/compactblk.go
+++ b/pkg/vm/engine/tae/tables/jobs/compactblk.go
@@ -16,7 +16,6 @@ package jobs
 
 import (
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/dataio/blockio"
 	"time"
 
 	"github.com/RoaringBitmap/roaring"
@@ -24,6 +23,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/dataio/blockio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/mergesort"
@@ -108,16 +108,6 @@ func (task *compactBlockTask) PrepareData(blkKey []byte) (preparer *model.Prepar
 			return preparer, err
 		}
 	}
-	// Prepare PhyAddr column data
-	phyAddrVec, err := model.PreparePhyAddrData(
-		catalog.PhyAddrColumnType,
-		blkKey,
-		0,
-		uint32(preparer.Columns.Length()))
-	if err != nil {
-		return
-	}
-	preparer.Columns.AddVector(catalog.PhyAddrColumnName, phyAddrVec)
 	return
 }
 

--- a/pkg/vm/engine/tae/tables/jobs/helper.go
+++ b/pkg/vm/engine/tae/tables/jobs/helper.go
@@ -17,6 +17,7 @@ package jobs
 import (
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables/indexwrapper"
 )
@@ -25,7 +26,7 @@ func BuildColumnIndex(writer objectio.Writer, block objectio.BlockObject, colDef
 	zmPos := 0
 
 	zoneMapWriter := indexwrapper.NewZMWriter()
-	if err = zoneMapWriter.Init(writer, block, indexwrapper.Plain, uint16(colDef.Idx), uint16(zmPos)); err != nil {
+	if err = zoneMapWriter.Init(writer, block, common.Plain, uint16(colDef.Idx), uint16(zmPos)); err != nil {
 		return
 	}
 	if isSorted && columnData.Length() > 2 {
@@ -51,7 +52,7 @@ func BuildColumnIndex(writer objectio.Writer, block objectio.BlockObject, colDef
 
 	bfPos := 1
 	bfWriter := indexwrapper.NewBFWriter()
-	if err = bfWriter.Init(writer, block, indexwrapper.Plain, uint16(colDef.Idx), uint16(bfPos)); err != nil {
+	if err = bfWriter.Init(writer, block, common.Plain, uint16(colDef.Idx), uint16(bfPos)); err != nil {
 		return
 	}
 	if err = bfWriter.AddValues(columnData); err != nil {

--- a/pkg/vm/engine/tae/tables/jobs/mergeblocks.go
+++ b/pkg/vm/engine/tae/tables/jobs/mergeblocks.go
@@ -239,24 +239,13 @@ func (task *mergeBlocksTask) Execute() (err error) {
 		batch := containers.NewBatch()
 		batchs = append(batchs, batch)
 	}
-	phyAddrVecs := make([]containers.Vector, 0)
 	phyAddr := schema.PhyAddrKey
-	for i, blk := range task.createdBlks {
-		vec, err := model.PreparePhyAddrData(phyAddr.Type, blk.MakeKey(), 0, uint32(vecs[i].Length()))
-		if err != nil {
-			return err
-		}
-		phyAddrVecs = append(phyAddrVecs, vec)
-		//batchs[i].AddVector(phyAddr.Name, vec)
-	}
+
 	// Build and flush block index if sort key is defined
 	// Flush sort key it correlates to only one column
 
 	for _, def := range schema.ColDefs {
 		if def.IsPhyAddr() {
-			for i := range task.createdBlks {
-				batchs[i].AddVector(phyAddr.Name, phyAddrVecs[i])
-			}
 			continue
 		}
 		// Skip


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #5178 

## What this PR does / why we need it:

- move Compress / Decompress to common
- don't add phyaddr data to batches when compacting and merging blocks
- generating phyaddr column when loading a ColDataNode