### PR TITLE
Release the buffer after WriteEnd is executed

### DIFF
--- a/pkg/objectio/block.go
+++ b/pkg/objectio/block.go
@@ -17,8 +17,6 @@ package objectio
 import (
 	"bytes"
 	"encoding/binary"
-
-	"github.com/matrixorigin/matrixone/pkg/container/batch"
 )
 
 // Block is the organizational structure of a batch in objectio
@@ -33,9 +31,6 @@ type Block struct {
 	// columns is the vector in the batch
 	columns []ColumnObject
 
-	// data is the batch to be written
-	data *batch.Batch
-
 	// object is a container that can store multiple blocks,
 	// using a fileservice file storage
 	object *Object
@@ -44,15 +39,14 @@ type Block struct {
 	extent Extent
 }
 
-func NewBlock(batch *batch.Batch, object *Object) BlockObject {
+func NewBlock(colCnt uint16, object *Object) BlockObject {
 	header := BlockHeader{
-		columnCount: uint16(len(batch.Vecs)),
+		columnCount: colCnt,
 	}
 	block := &Block{
 		header:  header,
-		data:    batch,
 		object:  object,
-		columns: make([]ColumnObject, len(batch.Vecs)),
+		columns: make([]ColumnObject, colCnt),
 	}
 	for i := range block.columns {
 		block.columns[i] = NewColumnBlock(uint16(i), block.object)

--- a/pkg/objectio/writer.go
+++ b/pkg/objectio/writer.go
@@ -67,7 +67,7 @@ func (w *ObjectWriter) WriteHeader() error {
 }
 
 func (w *ObjectWriter) Write(batch *batch.Batch) (BlockObject, error) {
-	block := NewBlock(batch, w.object)
+	block := NewBlock(uint16(len(batch.Vecs)), w.object)
 	w.AddBlock(block.(*Block))
 	for i, vec := range batch.Vecs {
 		buf, err := vec.Show()

--- a/pkg/objectio/writer.go
+++ b/pkg/objectio/writer.go
@@ -146,6 +146,11 @@ func (w *ObjectWriter) WriteEnd() ([]BlockObject, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// The buffer needs to be released at the end of WriteEnd
+	// Because the outside may hold this writer
+	// After WriteEnd is called, no more data can be written
+	w.buffer = nil
 	return w.blocks, err
 }
 

--- a/pkg/objectio/writer_test.go
+++ b/pkg/objectio/writer_test.go
@@ -94,6 +94,7 @@ func TestNewObjectWriter(t *testing.T) {
 	blocks, err := objectWriter.WriteEnd()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(blocks))
+	assert.Nil(t, objectWriter.(*ObjectWriter).buffer)
 
 	objectReader, _ := NewObjectReader(name, service)
 	extents := make([]Extent, 2)

--- a/pkg/vm/engine/tae/tables/indexwrapper/bfnode_test.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/bfnode_test.go
@@ -52,11 +52,8 @@ func TestStaticFilterIndex(t *testing.T) {
 
 	objectWriter, err := objectio.NewObjectWriter(name, service)
 	assert.Nil(t, err)
-	/*fd*/ _, err = objectWriter.Write(bat)
+	/*fd*/ block, err := objectWriter.Write(bat)
 	assert.Nil(t, err)
-	blocks, err := objectWriter.WriteEnd()
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(blocks))
 
 	cType := common.Plain
 	typ := types.Type{Oid: types.T_int32}
@@ -64,7 +61,7 @@ func TestStaticFilterIndex(t *testing.T) {
 	interIdx := uint16(0)
 
 	writer := NewBFWriter()
-	err = writer.Init(objectWriter, blocks[0], cType, colIdx, interIdx)
+	err = writer.Init(objectWriter, block, cType, colIdx, interIdx)
 	require.NoError(t, err)
 
 	keys := containers.MockVector2(typ, 1000, 0)
@@ -73,6 +70,9 @@ func TestStaticFilterIndex(t *testing.T) {
 
 	_, err = writer.Finalize()
 	require.NoError(t, err)
+	blocks, err := objectWriter.WriteEnd()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(blocks))
 
 	/*reader := NewBFReader(bufManager, file, new(common.ID))
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/59

## What this PR does / why we need it:
The buffer needs to be released at the end of WriteEnd
Because the outside may hold this writer
After WriteEnd is called, no more data can be written