### PR TITLE
memorystorage, memoryengine: add ID param to CreateDatabaseReq, CreateRelationReq

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -142,6 +142,7 @@ const (
 // tae and memengine do not make the catalog into a table
 // for its convenience, a conversion interface is provided to ensure easy use.
 type CreateDatabase struct {
+	DatabaseId  uint64
 	Name        string
 	CreateSql   string
 	Owner       uint32
@@ -156,6 +157,7 @@ type DropDatabase struct {
 }
 
 type CreateTable struct {
+	TableId      uint64
 	Name         string
 	CreateSql    string
 	Owner        uint32

--- a/pkg/txn/storage/memorystorage/mem_handler.go
+++ b/pkg/txn/storage/memorystorage/mem_handler.go
@@ -277,9 +277,11 @@ func (m *MemHandler) HandleCreateDatabase(meta txn.TxnMeta, req memoryengine.Cre
 		return moerr.NewDBAlreadyExists(req.Name)
 	}
 
-	id := memoryengine.NewID()
+	if req.ID.IsEmpty() {
+		req.ID = memoryengine.NewID()
+	}
 	err = m.databases.Insert(tx, &DatabaseRow{
-		ID:        id,
+		ID:        req.ID,
 		AccountID: req.AccessInfo.AccountID,
 		Name:      req.Name,
 	})
@@ -287,7 +289,7 @@ func (m *MemHandler) HandleCreateDatabase(meta txn.TxnMeta, req memoryengine.Cre
 		return err
 	}
 
-	resp.ID = id
+	resp.ID = req.ID
 	return nil
 }
 
@@ -319,8 +321,11 @@ func (m *MemHandler) HandleCreateRelation(meta txn.TxnMeta, req memoryengine.Cre
 	}
 
 	// row
+	if req.ID.IsEmpty() {
+		req.ID = memoryengine.NewID()
+	}
 	row := &RelationRow{
-		ID:         memoryengine.NewID(),
+		ID:         req.ID,
 		DatabaseID: req.DatabaseID,
 		Name:       req.Name,
 		Type:       req.Type,

--- a/pkg/txn/storage/memorystorage/precommit.go
+++ b/pkg/txn/storage/memorystorage/precommit.go
@@ -36,6 +36,7 @@ func (m *MemHandler) HandlePreCommit(meta txn.TxnMeta, req apipb.PrecommitWriteC
 		case []catalog.CreateDatabase:
 			for _, cmd := range cmds {
 				req := txnengine.CreateDatabaseReq{
+					ID:   ID(cmd.DatabaseId),
 					Name: cmd.Name,
 					AccessInfo: txnengine.AccessInfo{
 						UserID:    cmd.Owner,
@@ -51,6 +52,7 @@ func (m *MemHandler) HandlePreCommit(meta txn.TxnMeta, req apipb.PrecommitWriteC
 		case []catalog.CreateTable:
 			for _, cmd := range cmds {
 				req := txnengine.CreateRelationReq{
+					ID:           ID(cmd.TableId),
 					Name:         cmd.Name,
 					DatabaseName: cmd.DatabaseName,
 					DatabaseID:   txnengine.ID(cmd.DatabaseId),

--- a/pkg/vm/engine/memoryengine/database.go
+++ b/pkg/vm/engine/memoryengine/database.go
@@ -124,7 +124,7 @@ func (d *Database) Relations(ctx context.Context) ([]string, error) {
 		ctx,
 		d.txnOperator,
 		true,
-		d.engine.allShards,
+		d.engine.anyShard,
 		OpGetRelations,
 		GetRelationsReq{
 			DatabaseID: d.id,

--- a/pkg/vm/engine/memoryengine/operations.go
+++ b/pkg/vm/engine/memoryengine/operations.go
@@ -107,6 +107,7 @@ type Response interface {
 }
 
 type CreateDatabaseReq struct {
+	ID         ID
 	AccessInfo AccessInfo
 	Name       string
 }
@@ -143,6 +144,7 @@ type DeleteDatabaseResp struct {
 }
 
 type CreateRelationReq struct {
+	ID           ID
 	DatabaseID   ID
 	DatabaseName string
 	Name         string


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #5417 

## What this PR does / why we need it:
memorystorage, memoryengine: add ID param to CreateDatabaseReq, CreateRelationReq
 memoryengine: do not send Database.Relations to all shards 