### PR TITLE
fix: no system db and tables in logtail response

### DIFF
--- a/pkg/vm/engine/tae/db/db_test.go
+++ b/pkg/vm/engine/tae/db/db_test.go
@@ -3096,7 +3096,7 @@ func TestLogtailBasic(t *testing.T) {
 	// at first, we can see nothing
 	minTs, maxTs := types.BuildTS(0, 0), types.BuildTS(1000, 1000)
 	reader := logMgr.GetReader(minTs, maxTs)
-	assert.False(t, reader.HasCatalogChanges())
+	assert.True(t, reader.HasCatalogChanges())
 	assert.Equal(t, 0, len(reader.GetDirtyByTable(1000, 1000).Segs))
 
 	schema := catalog.MockSchemaAll(2, -1)
@@ -3219,11 +3219,12 @@ func TestLogtailBasic(t *testing.T) {
 
 	assert.Equal(t, api.Entry_Insert, resp.Commands[0].EntryType)
 	assert.Equal(t, len(catalog.SystemDBSchema.ColDefs)+fixedColCnt, len(resp.Commands[0].Bat.Vecs))
-	check_same_rows(resp.Commands[0].Bat, 2)                                 // 2 db
+	check_same_rows(resp.Commands[0].Bat, 3)                                 // 2 db + mo_catalog
 	datname, err := vector.ProtoVectorToVector(resp.Commands[0].Bat.Vecs[3]) // datname column
 	assert.NoError(t, err)
-	assert.Equal(t, "todrop", datname.GetString(0))
-	assert.Equal(t, "db", datname.GetString(1))
+	assert.Equal(t, pkgcatalog.MO_CATALOG, datname.GetString(0))
+	assert.Equal(t, "todrop", datname.GetString(1))
+	assert.Equal(t, "db", datname.GetString(2))
 
 	assert.Equal(t, api.Entry_Delete, resp.Commands[1].EntryType)
 	assert.Equal(t, fixedColCnt, len(resp.Commands[1].Bat.Vecs))
@@ -3239,11 +3240,11 @@ func TestLogtailBasic(t *testing.T) {
 	assert.Equal(t, 1, len(resp.Commands)) // insert
 	assert.Equal(t, api.Entry_Insert, resp.Commands[0].EntryType)
 	assert.Equal(t, len(catalog.SystemTableSchema.ColDefs)+fixedColCnt, len(resp.Commands[0].Bat.Vecs))
-	check_same_rows(resp.Commands[0].Bat, 2)                                 // 2 tables
+	check_same_rows(resp.Commands[0].Bat, 5)                                 // 2 tables + 3 sys tables
 	relname, err := vector.ProtoVectorToVector(resp.Commands[0].Bat.Vecs[3]) // relname column
 	assert.NoError(t, err)
-	assert.Equal(t, schema.Name, relname.GetString(0))
-	assert.Equal(t, schema.Name, relname.GetString(1))
+	assert.Equal(t, schema.Name, relname.GetString(3))
+	assert.Equal(t, schema.Name, relname.GetString(4))
 
 	// get columns catalog change
 	resp, err = logtail.HandleSyncLogTailReq(tae.LogtailMgr, tae.Catalog, api.SyncLogTailReq{
@@ -3255,7 +3256,8 @@ func TestLogtailBasic(t *testing.T) {
 	assert.Equal(t, 1, len(resp.Commands)) // insert
 	assert.Equal(t, api.Entry_Insert, resp.Commands[0].EntryType)
 	assert.Equal(t, len(catalog.SystemColumnSchema.ColDefs)+fixedColCnt, len(resp.Commands[0].Bat.Vecs))
-	check_same_rows(resp.Commands[0].Bat, len(schema.ColDefs)*2) // column count of 2 tables
+	sysColumnsCount := len(catalog.SystemDBSchema.ColDefs) + len(catalog.SystemTableSchema.ColDefs) + len(catalog.SystemColumnSchema.ColDefs)
+	check_same_rows(resp.Commands[0].Bat, len(schema.ColDefs)*2+sysColumnsCount) // column count of 2 tables
 
 	// get user table change
 	resp, err = logtail.HandleSyncLogTailReq(tae.LogtailMgr, tae.Catalog, api.SyncLogTailReq{
@@ -3612,8 +3614,8 @@ func TestWatchDirty(t *testing.T) {
 	wg.Wait()
 	seenDirty := false
 	prevVal, prevCount := 0, 0
-	// wait two seconds for ch to produce consecutive zeros
-	assert.NoError(t, testutils.WaitChTimeout(1*time.Second, dirtyCountCh, func(count int, closed bool) (moveOn bool, err error) {
+	// wait for ch to produce consecutive zeros
+	assert.NoError(t, testutils.WaitChTimeout(20*time.Second, dirtyCountCh, func(count int, closed bool) (moveOn bool, err error) {
 		if closed {
 			return false, moerr.NewInternalError("unexpected close on chan")
 		}

--- a/pkg/vm/engine/tae/logtail/operator.go
+++ b/pkg/vm/engine/tae/logtail/operator.go
@@ -150,9 +150,6 @@ func (c *BoundTableOperator) processDatabases() error {
 	dbIt := c.catalog.MakeDBIt(true)
 	for ; dbIt.Valid(); dbIt.Next() {
 		dbentry := dbIt.Get().GetPayload()
-		if dbentry.IsSystemDB() {
-			continue
-		}
 		if err := c.visitor.OnDatabase(dbentry); err != nil {
 			return err
 		}
@@ -167,9 +164,6 @@ func (c *BoundTableOperator) processTables() error {
 	dbIt := c.catalog.MakeDBIt(true)
 	for ; dbIt.Valid(); dbIt.Next() {
 		db := dbIt.Get().GetPayload()
-		if db.IsSystemDB() {
-			continue
-		}
 		tblIt := db.MakeTableIt(true)
 		for ; tblIt.Valid(); tblIt.Next() {
 			if err := c.visitor.OnTable(tblIt.Get().GetPayload()); err != nil {

--- a/pkg/vm/engine/tae/logtail/reader.go
+++ b/pkg/vm/engine/tae/logtail/reader.go
@@ -54,6 +54,9 @@ func (v *LogtailReader) GetDirtyByTable(dbID, id uint64) (tree *common.TableTree
 }
 
 func (v *LogtailReader) HasCatalogChanges() bool {
+	if v.start.IsEmpty() {
+		return true
+	}
 	changed := false
 	readOp := func(txn txnif.AsyncTxn) (moveOn bool) {
 		if txn.GetStore().HasCatalogChanges() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
- return system db and tables if cn query logtail using zero timestamp as the start, keep consistent with memoryengine