### PR TITLE
Change panic to error log in truncation worker.

### DIFF
--- a/pkg/logservice/store.go
+++ b/pkg/logservice/store.go
@@ -17,7 +17,6 @@ package logservice
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,6 +29,7 @@ import (
 	"github.com/lni/dragonboat/v4/plugin/tee"
 	"github.com/lni/dragonboat/v4/raftpb"
 	sm "github.com/lni/dragonboat/v4/statemachine"
+	"go.uber.org/zap"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
@@ -683,7 +683,7 @@ func (l *store) truncationWorker(ctx context.Context) {
 			return
 		case <-l.mu.truncateCh:
 			if err := l.processTruncateLog(ctx); err != nil {
-				panic(err)
+				l.logger.Error("truncate failed", zap.Error(err))
 			}
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
If there are two continuous truncate request from tae without applied index advance, and the first one is in pending state, dragonboat will return requestRejected error.

This is not a error that affects the correctness of the cluster, so just change panic to error log.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Avoid panic caused by truncation worker.