### PR TITLE
support secondary index

### DIFF
--- a/test/cases/dml/delete/delete.test
+++ b/test/cases/dml/delete/delete.test
@@ -154,4 +154,13 @@ insert into t1 values(1, 2);
 insert into t1 values(1, null);
 delete from t1 where a = 1;
 
+drop table if exists t1;
+create table t1(a int, b varchar(20), index(a, b));
+insert into t1 values(1, '1');
+insert into t1 values(1, '1');
+insert into t1 values(2, '2');
+insert into t1 values(3, '3');
+delete from t1 where a = 1;
+select * from t1;
+
 drop database if exists db1;

--- a/test/cases/dml/insert/insert.test
+++ b/test/cases/dml/insert/insert.test
@@ -141,3 +141,11 @@ insert into t1 values(2, '3');
 insert into t1 values(null, '1');
 insert into t1 values(null, '2');
 insert into t1 values(null, '2');
+
+drop table if exists t1;
+create table t1(a int, b varchar(20), index(a, b));
+insert into t1 values(1, '1');
+insert into t1 values(1, '1');
+insert into t1 values(2, '2');
+insert into t1 values(3, '3');
+select * from t1;

--- a/test/cases/dml/update/update.test
+++ b/test/cases/dml/update/update.test
@@ -185,4 +185,13 @@ insert into t1(a) values(1);
 update t1 set a = 2 where a = 1;
 select c is not null from t1;
 
+drop table if exists t1;
+create table t1(a int, b varchar(20), index(a, b));
+insert into t1 values(1, '1');
+insert into t1 values(1, '1');
+insert into t1 values(2, '2');
+insert into t1 values(3, '3');
+update t1 set a = 2 where a = 1;
+select * from t1;
+
 drop database if exists db1;

--- a/test/result/dml/delete/delete.result
+++ b/test/result/dml/delete/delete.result
@@ -219,5 +219,15 @@ a    b
 insert into t1 values(1, 2);
 insert into t1 values(1, null);
 delete from t1 where a = 1;
-
+drop table if exists t1;
+create table t1(a int, b varchar(20), index(a, b));
+insert into t1 values(1, '1');
+insert into t1 values(1, '1');
+insert into t1 values(2, '2');
+insert into t1 values(3, '3');
+delete from t1 where a = 1;
+select * from t1;
+a    b
+2    2
+3    3
 drop database if exists db1;

--- a/test/result/dml/insert/insert.result
+++ b/test/result/dml/insert/insert.result
@@ -208,4 +208,15 @@ tae data: duplicate
 insert into t1 values(null, '1');
 insert into t1 values(null, '2');
 insert into t1 values(null, '2');
-
+drop table if exists t1;
+create table t1(a int, b varchar(20), index(a, b));
+insert into t1 values(1, '1');
+insert into t1 values(1, '1');
+insert into t1 values(2, '2');
+insert into t1 values(3, '3');
+select * from t1;
+a    b
+1    1
+1    1
+2    2
+3    3

--- a/test/result/dml/update/update.result
+++ b/test/result/dml/update/update.result
@@ -300,4 +300,17 @@ update t1 set a = 2 where a = 1;
 select c is not null from t1;
 c is not null
 true
+drop table if exists t1;
+create table t1(a int, b varchar(20), index(a, b));
+insert into t1 values(1, '1');
+insert into t1 values(1, '1');
+insert into t1 values(2, '2');
+insert into t1 values(3, '3');
+update t1 set a = 2 where a = 1;
+select * from t1;
+a    b
+2    1
+2    1
+2    2
+3    3
 drop database if exists db1;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #3609

## What this PR does / why we need it:
when create index, system will create index table. this is not a full implementaion, just a half. later I also need to add row id col to index table to accelerate query and add optimizer rule to accelerate sql. after finish accelerate, the unique index and secondary index is a full implementation.