### PR TITLE
Change the default value of GossipProbeInterval from 50ms to 5s.

### DIFF
--- a/pkg/logservice/config.go
+++ b/pkg/logservice/config.go
@@ -35,7 +35,7 @@ const (
 	defaultGossipAddress     = "0.0.0.0:32002"
 	defaultGossipSeedAddress = "127.0.0.1:32002"
 
-	defaultGossipProbeInterval = 50 * time.Millisecond
+	defaultGossipProbeInterval = 5 * time.Second
 	defaultHeartbeatInterval   = time.Second
 	defaultLogDBBufferSize     = 768 * 1024
 )
@@ -79,7 +79,7 @@ type Config struct {
 	// GossipSeedAddresses is list of seed addresses that are used for
 	// introducing the local node into the gossip network.
 	GossipSeedAddresses []string `toml:"gossip-seed-addresses"`
-	// GossipProbeInternval how often gossip nodes probe each other.
+	// GossipProbeInterval how often gossip nodes probe each other.
 	GossipProbeInterval toml.Duration `toml:"gossip-probe-interval"`
 	// HeartbeatInterval is the interval of how often log service node should be
 	// sending heartbeat message to the HAKeeper.
@@ -87,7 +87,7 @@ type Config struct {
 	// HAKeeperTickInterval is the interval of how often log service node should
 	// tick the HAKeeper.
 	HAKeeperTickInterval toml.Duration `toml:"hakeeper-tick-interval"`
-	// HAKeeperCheckInterval is the internval of how often HAKeeper should run
+	// HAKeeperCheckInterval is the interval of how often HAKeeper should run
 	// cluster health checks.
 	HAKeeperCheckInterval toml.Duration `toml:"hakeeper-check-interval"`
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

The default value of GossipProbeInterval is 50ms, which is too short and not necessary. Change it to 5s.