### PR TITLE
fix bug: insert table with default value have no vector.data

### DIFF
--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -17,9 +17,10 @@ package vector
 import (
 	"bytes"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/common/bitmap"
 	"reflect"
 	"unsafe"
+
+	"github.com/matrixorigin/matrixone/pkg/common/bitmap"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -515,6 +516,15 @@ func NewWithNspSize(typ types.Type, n int64) *Vector {
 		Typ:      typ,
 		original: false,
 	}
+}
+
+func NewConstDefault(typ types.Type, length int, mp *mpool.MPool) *Vector {
+	v := New(typ)
+	v.isConst = true
+	val := GetDefaultConstVal(typ)
+	v.Append(val, false, mp)
+	v.length = length
+	return v
 }
 
 func NewConst(typ types.Type, length int) *Vector {
@@ -1495,5 +1505,53 @@ func (v *Vector) String() string {
 
 	default:
 		panic("vec to string unknown types.")
+	}
+}
+
+func GetDefaultConstVal(typ types.Type) any {
+	switch typ.Oid {
+	case types.T_bool:
+		return false
+	case types.T_int8:
+		return int8(0)
+	case types.T_int16:
+		return int16(0)
+	case types.T_int32:
+		return int32(0)
+	case types.T_int64:
+		return int64(0)
+	case types.T_uint8:
+		return uint8(0)
+	case types.T_uint16:
+		return uint16(0)
+	case types.T_uint32:
+		return uint32(0)
+	case types.T_uint64:
+		return uint64(0)
+	case types.T_float32:
+		return float32(0)
+	case types.T_float64:
+		return float64(0)
+	case types.T_date:
+		return types.Date(0)
+	case types.T_datetime:
+		return types.Datetime(0)
+	case types.T_timestamp:
+		return types.Timestamp(0)
+	case types.T_decimal64:
+		return types.Decimal64{}
+	case types.T_decimal128:
+		return types.Decimal128{}
+	case types.T_uuid:
+		return types.Uuid{}
+	case types.T_TS:
+		return types.TS{}
+	case types.T_Rowid:
+		return types.Rowid{}
+	case types.T_char, types.T_varchar, types.T_blob, types.T_json:
+		return types.Varlena{}
+	default:
+		//T_any T_star T_tuple T_interval
+		return int64(0)
 	}
 }

--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -518,11 +518,11 @@ func NewWithNspSize(typ types.Type, n int64) *Vector {
 	}
 }
 
-func NewConstDefault(typ types.Type, length int, mp *mpool.MPool) *Vector {
+func NewConstNullWithData(typ types.Type, length int, mp *mpool.MPool) *Vector {
 	v := New(typ)
 	v.isConst = true
-	val := GetDefaultConstVal(typ)
-	v.Append(val, false, mp)
+	val := GetInitConstVal(typ)
+	v.Append(val, true, mp)
 	v.length = length
 	return v
 }
@@ -1508,7 +1508,7 @@ func (v *Vector) String() string {
 	}
 }
 
-func GetDefaultConstVal(typ types.Type) any {
+func GetInitConstVal(typ types.Type) any {
 	switch typ.Oid {
 	case types.T_bool:
 		return false
@@ -1543,13 +1543,17 @@ func GetDefaultConstVal(typ types.Type) any {
 	case types.T_decimal128:
 		return types.Decimal128{}
 	case types.T_uuid:
-		return types.Uuid{}
+		var emptyUuid [16]byte
+		return emptyUuid[:]
 	case types.T_TS:
-		return types.TS{}
+		var emptyTs [types.TxnTsSize]byte
+		return emptyTs[:]
 	case types.T_Rowid:
-		return types.Rowid{}
-	case types.T_char, types.T_varchar, types.T_blob, types.T_json:
-		return types.Varlena{}
+		var emptyRowid [types.RowidSize]byte
+		return emptyRowid[:]
+	case types.T_char, types.T_varchar, types.T_blob, types.T_json, types.T_text:
+		var emptyVarlena [types.VarlenaSize]byte
+		return emptyVarlena[:]
 	default:
 		//T_any T_star T_tuple T_interval
 		return int64(0)

--- a/pkg/sql/colexec/expr_eval.go
+++ b/pkg/sql/colexec/expr_eval.go
@@ -55,7 +55,7 @@ func EvalExpr(bat *batch.Batch, proc *process.Process, expr *plan.Expr) (*vector
 			if types.T(expr.Typ.GetId()) == types.T_any {
 				vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
 			} else {
-				vec = vector.NewConstDefault(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
+				vec = vector.NewConstNullWithData(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
 			}
 		} else {
 			switch t.C.GetValue().(type) {
@@ -167,7 +167,7 @@ func JoinFilterEvalExpr(r, s *batch.Batch, rRow int, proc *process.Process, expr
 			if types.T(expr.Typ.GetId()) == types.T_any {
 				vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
 			} else {
-				vec = vector.NewConstDefault(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
+				vec = vector.NewConstNullWithData(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
 			}
 		} else {
 			switch t.C.GetValue().(type) {
@@ -278,7 +278,7 @@ func EvalExprByZonemapBat(bat *batch.Batch, proc *process.Process, expr *plan.Ex
 			if types.T(expr.Typ.GetId()) == types.T_any {
 				vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
 			} else {
-				vec = vector.NewConstDefault(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
+				vec = vector.NewConstNullWithData(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
 			}
 		} else {
 			switch t.C.GetValue().(type) {
@@ -449,7 +449,7 @@ func JoinFilterEvalExprInBucket(r, s *batch.Batch, rRow, sRow int, proc *process
 			if types.T(expr.Typ.GetId()) == types.T_any {
 				vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
 			} else {
-				vec = vector.NewConstDefault(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
+				vec = vector.NewConstNullWithData(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
 			}
 		} else {
 			switch t.C.GetValue().(type) {

--- a/pkg/sql/colexec/expr_eval.go
+++ b/pkg/sql/colexec/expr_eval.go
@@ -52,7 +52,11 @@ func EvalExpr(bat *batch.Batch, proc *process.Process, expr *plan.Expr) (*vector
 	switch t := e.(type) {
 	case *plan.Expr_C:
 		if t.C.GetIsnull() {
-			vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
+			if types.T(expr.Typ.GetId()) == types.T_any {
+				vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
+			} else {
+				vec = vector.NewConstDefault(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
+			}
 		} else {
 			switch t.C.GetValue().(type) {
 			case *plan.Const_Bval:
@@ -160,7 +164,11 @@ func JoinFilterEvalExpr(r, s *batch.Batch, rRow int, proc *process.Process, expr
 	case *plan.Expr_C:
 		length := 1
 		if t.C.GetIsnull() {
-			vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
+			if types.T(expr.Typ.GetId()) == types.T_any {
+				vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
+			} else {
+				vec = vector.NewConstDefault(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
+			}
 		} else {
 			switch t.C.GetValue().(type) {
 			case *plan.Const_Bval:
@@ -267,7 +275,11 @@ func EvalExprByZonemapBat(bat *batch.Batch, proc *process.Process, expr *plan.Ex
 	switch t := e.(type) {
 	case *plan.Expr_C:
 		if t.C.GetIsnull() {
-			vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
+			if types.T(expr.Typ.GetId()) == types.T_any {
+				vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
+			} else {
+				vec = vector.NewConstDefault(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
+			}
 		} else {
 			switch t.C.GetValue().(type) {
 			case *plan.Const_Bval:
@@ -434,7 +446,11 @@ func JoinFilterEvalExprInBucket(r, s *batch.Batch, rRow, sRow int, proc *process
 	case *plan.Expr_C:
 		length := 1
 		if t.C.GetIsnull() {
-			vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
+			if types.T(expr.Typ.GetId()) == types.T_any {
+				vec = vector.NewConstNull(types.Type{Oid: types.T(expr.Typ.GetId())}, length)
+			} else {
+				vec = vector.NewConstDefault(types.Type{Oid: types.T(expr.Typ.GetId())}, length, proc.Mp())
+			}
 		} else {
 			switch t.C.GetValue().(type) {
 			case *plan.Const_Bval:


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #5772  #5754

## What this PR does / why we need it:
when insert into table with column's default value.  we use NewConstNull,  that method will not set vector.data, then will panic in disttae