### PR TITLE
Update xorfilter&Fix immutable not release bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/BurntSushi/toml v1.0.0
-	github.com/FastFilter/xorfilter v0.1.1
+	github.com/FastFilter/xorfilter v0.1.2
 	github.com/RoaringBitmap/roaring v0.9.4
 	github.com/aws/aws-sdk-go-v2 v1.16.5
 	github.com/aws/aws-sdk-go-v2/config v1.15.11


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/117

## What this PR does / why we need it:
The root cause is that a block in the worker of the flushblock is blocked due to the infinite loop of xorfilter.PopulateBinaryFuse8, resulting in the subsequent blocks not being flushed.
Looks like xorfilter fixed this bug in https://github.com/FastFilter/xorfilter/commit/e6a74e8548ba6e1eb0672a6c741a00d7c9734243