### PR TITLE
Update e2e.yml

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   bvt-linux-x86:
-    runs-on: ubuntu-latest
+    runs-on: x86-runner
     name: e2e BVT Test on Linux/x64
     timeout-minutes: 30
 
@@ -61,7 +61,7 @@ jobs:
           locale
           sleep 120s
           cd $GITHUB_WORKSPACE/mo-tester
-          ./run.sh -n -g -p $GITHUB_WORKSPACE/head/test/cases 2>&1
+          ./run.sh -n -g -p $GITHUB_WORKSPACE/head/test/distributed/cases 2>&1
 
       - name: Check mo-service Status
         if: ${{ always() && !cancelled() }}


### PR DESCRIPTION
1. use a self-hosted runner instead of GitHub-hosted runner(2c7G) to avoid oom problem.
2. use distribute bvt cases

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
1. use a self-hosted runner instead of GitHub-hosted runner(2c7G) to avoid oom
2. use distribute bvt cases