### PR TITLE
taskservice: panic if query by primary key != 1

### DIFF
--- a/pkg/taskservice/task_service.go
+++ b/pkg/taskservice/task_service.go
@@ -16,6 +16,7 @@ package taskservice
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -130,7 +131,7 @@ func (s *taskService) Allocate(ctx context.Context, value task.Task, taskRunner 
 		return nil
 	}
 	if len(exists) != 1 {
-		return moerr.NewInvalidTask(taskRunner, value.ID)
+		panic(fmt.Sprintf("query task by primary key, return %d records", len(exists)))
 	}
 
 	old := exists[0]


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
panic if query by primary key returns more than 1 records