### PR TITLE
bugfix: EXTERNAL table adapt result from s3 ListObjects

### DIFF
--- a/pkg/sql/colexec/external/external.go
+++ b/pkg/sql/colexec/external/external.go
@@ -155,11 +155,12 @@ func ReadDir(param *tree.ExternParam) (fileList []string, err error) {
 				if entry.IsDir && i+1 == len(pathDir) {
 					continue
 				}
-				matched, _ := filepath.Match(pathDir[i], entry.Name)
+				name := path.Base(entry.Name)
+				matched, _ := filepath.Match(pathDir[i], name)
 				if !matched {
 					continue
 				}
-				l.PushBack(path.Join(l.Front().Value.(string), entry.Name))
+				l.PushBack(path.Join(l.Front().Value.(string), name))
 			}
 			l.Remove(l.Front())
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

EXTERNAL table just need basename of filepath.
- EXTERNAL table support wildcard path, need check each level's elem of filepath. But s3 ListObjects return elems with its whole path info.

