### PR TITLE
morpc: add max body size option

### DIFF
--- a/pkg/common/morpc/codec.go
+++ b/pkg/common/morpc/codec.go
@@ -53,6 +53,13 @@ func WithCodecIntegrationHLC(clock clock.Clock) CodecOption {
 	}
 }
 
+// WithCodecMaxBodySize set rpc max body size
+func WithCodecMaxBodySize(size int) CodecOption {
+	return func(c *messageCodec) {
+		c.codec = length.NewWithSize(c.bc, 0, 0, 0, size)
+	}
+}
+
 type messageCodec struct {
 	codec codec.Codec
 	bc    *baseCodec


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6096 

## What this PR does / why we need it:
MORPC default max body size limit is 10M. So need make this value configurable