### PR TITLE
dnservice: get main fs and temp fs and pass to TAE explicitly

### DIFF
--- a/cmd/mo-service/config.go
+++ b/cmd/mo-service/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/cnservice"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/config"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/dnservice"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
@@ -38,10 +39,6 @@ const (
 	cnServiceType  = "CN"
 	dnServiceType  = "DN"
 	logServiceType = "LOG"
-
-	s3FileServiceName    = "S3"
-	localFileServiceName = "LOCAL"
-	etlFileServiceName   = "ETL"
 )
 
 var (
@@ -135,7 +132,7 @@ func (c *Config) validate() error {
 	}
 	for idx := range c.FileServices {
 		switch c.FileServices[idx].Name {
-		case localFileServiceName, etlFileServiceName:
+		case defines.LocalFileServiceName, defines.ETLFileServiceName:
 			if c.FileServices[idx].DataDir == "" {
 				c.FileServices[idx].DataDir = filepath.Join(c.DataDir, strings.ToLower(c.FileServices[idx].Name))
 			}
@@ -171,20 +168,20 @@ func (c *Config) createFileService(defaultName string) (*fileservice.FileService
 	}
 
 	// ensure local exists
-	_, err = fileservice.Get[fileservice.FileService](fs, localFileServiceName)
+	_, err = fileservice.Get[fileservice.FileService](fs, defines.LocalFileServiceName)
 	if err != nil {
 		return nil, err
 	}
 
 	// ensure s3 exists
-	_, err = fileservice.Get[fileservice.FileService](fs, s3FileServiceName)
+	_, err = fileservice.Get[fileservice.FileService](fs, defines.S3FileServiceName)
 	if err != nil {
 		return nil, err
 	}
 
 	// ensure etl exists, for trace & metric
 	if !c.Observability.DisableMetric || !c.Observability.DisableTrace {
-		_, err = fileservice.Get[fileservice.FileService](fs, etlFileServiceName)
+		_, err = fileservice.Get[fileservice.FileService](fs, defines.ETLFileServiceName)
 		if err != nil {
 			return nil, moerr.ConvertPanicError(err)
 		}

--- a/cmd/mo-service/config_test.go
+++ b/cmd/mo-service/config_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/dnservice"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
@@ -79,15 +80,15 @@ func TestFileServiceFactory(t *testing.T) {
 		Backend: "MEM",
 	})
 	c.FileServices = append(c.FileServices, fileservice.Config{
-		Name:    localFileServiceName,
+		Name:    defines.LocalFileServiceName,
 		Backend: "MEM",
 	})
 	c.FileServices = append(c.FileServices, fileservice.Config{
-		Name:    s3FileServiceName,
+		Name:    defines.S3FileServiceName,
 		Backend: "MEM",
 	})
 	c.FileServices = append(c.FileServices, fileservice.Config{
-		Name:    etlFileServiceName,
+		Name:    defines.ETLFileServiceName,
 		Backend: "DISK-ETL",
 	})
 

--- a/cmd/mo-service/main.go
+++ b/cmd/mo-service/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/cnservice/cnclient"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/dnservice"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
@@ -111,7 +112,7 @@ func startService(cfg *Config, stopper *stopper.Stopper) error {
 
 	setupGlobalComponents(cfg, stopper)
 
-	fs, err := cfg.createFileService(localFileServiceName)
+	fs, err := cfg.createFileService(defines.LocalFileServiceName)
 	if err != nil {
 		return err
 	}

--- a/pkg/cnservice/distributed_tae.go
+++ b/pkg/cnservice/distributed_tae.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/config"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 )
@@ -48,13 +49,13 @@ func (s *service) initDistributedTAE(
 	}
 
 	// use s3 as main file service
-	mainFS, err := fileservice.Get[fileservice.FileService](s.fileService, "S3")
+	mainFS, err := fileservice.Get[fileservice.FileService](s.fileService, defines.S3FileServiceName)
 	if err != nil {
 		return err
 	}
 
 	// use local as temp file service
-	tempFS, err := fileservice.Get[fileservice.FileService](s.fileService, "LOCAL")
+	tempFS, err := fileservice.Get[fileservice.FileService](s.fileService, defines.LocalFileServiceName)
 	if err != nil {
 		return err
 	}

--- a/pkg/cnservice/distributed_tae.go
+++ b/pkg/cnservice/distributed_tae.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/config"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 )
 
@@ -46,11 +47,25 @@ func (s *service) initDistributedTAE(
 		return err
 	}
 
+	// use s3 as main file service
+	mainFS, err := fileservice.Get[fileservice.FileService](s.fileService, "S3")
+	if err != nil {
+		return err
+	}
+
+	// use local as temp file service
+	tempFS, err := fileservice.Get[fileservice.FileService](s.fileService, "LOCAL")
+	if err != nil {
+		return err
+	}
+
 	// engine
 	pu.StorageEngine = disttae.New(
 		ctx,
 		mp,
 		s.fileService,
+		mainFS,
+		tempFS,
 		client,
 		hakeeper,
 		pu.GetClusterDetails,

--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/config"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/frontend"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
@@ -49,7 +50,7 @@ func NewService(
 	}
 
 	// get metadata fs
-	fs, err := fileservice.Get[fileservice.ReplaceableFileService](fileService, "LOCAL")
+	fs, err := fileservice.Get[fileservice.ReplaceableFileService](fileService, defines.LocalFileServiceName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cnservice/server_metadata_test.go
+++ b/pkg/cnservice/server_metadata_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/fagongzi/util/protoc"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
@@ -26,7 +27,7 @@ import (
 )
 
 func TestInitMetadata(t *testing.T) {
-	fs, err := fileservice.NewMemoryFS("LOCAL")
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
 	assert.NoError(t, err)
 
 	s := &service{logger: logutil.GetPanicLogger(), metadataFS: fs}
@@ -40,7 +41,7 @@ func TestInitMetadata(t *testing.T) {
 }
 
 func TestInitMetadataWithExistData(t *testing.T) {
-	fs, err := fileservice.NewMemoryFS("LOCAL")
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
 	assert.NoError(t, err)
 	value := metadata.CNStore{
 		UUID: "cn1",
@@ -62,7 +63,7 @@ func TestInitMetadataWithInvalidUUIDWillPanic(t *testing.T) {
 		assert.Fail(t, "must panic")
 	}()
 
-	fs, err := fileservice.NewMemoryFS("LOCAL")
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
 	assert.NoError(t, err)
 	value := metadata.CNStore{
 		UUID: "cn1",

--- a/pkg/defines/const.go
+++ b/pkg/defines/const.go
@@ -21,3 +21,9 @@ const (
 	EOFHeader         byte = 0xfe
 	LocalInFileHeader byte = 0xfb
 )
+
+const (
+	S3FileServiceName    = "S3"
+	LocalFileServiceName = "LOCAL"
+	ETLFileServiceName   = "ETL"
+)

--- a/pkg/dnservice/cfg.go
+++ b/pkg/dnservice/cfg.go
@@ -98,8 +98,6 @@ type Config struct {
 			dataDir string `toml:"-"`
 			// Backend txn storage backend implementation. [TAE|Mem], default TAE.
 			Backend StorageType `toml:"backend"`
-			// FileService tae used fileservice, default is LOCAL
-			FileService string `toml:"fileservice"`
 			// LogBackend the backend used to store logs
 			LogBackend string `toml:"log-backend"`
 		}
@@ -123,9 +121,6 @@ func (c *Config) Validate() error {
 	}
 	if c.Txn.Storage.Backend == "" {
 		c.Txn.Storage.Backend = StorageTAE
-	}
-	if c.Txn.Storage.FileService == "" {
-		c.Txn.Storage.FileService = localFileServiceName
 	}
 	if c.Txn.Storage.LogBackend == "" {
 		c.Txn.Storage.LogBackend = defaultLogBackend

--- a/pkg/dnservice/factory.go
+++ b/pkg/dnservice/factory.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
@@ -29,12 +30,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/memoryengine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"go.uber.org/zap"
-)
-
-const (
-	s3FileServiceName    = "S3"
-	localFileServiceName = "LOCAL"
-	etlFileServiceName   = "ETL"
 )
 
 var (
@@ -140,12 +135,12 @@ func (s *store) newTAEStorage(shard metadata.DNShard, factory logservice.ClientF
 		GlobalInterval:      s.cfg.Ckp.GlobalInterval.Duration,
 	}
 	// use s3 as main file service
-	mainFS, err := fileservice.Get[fileservice.FileService](s.fileService, s3FileServiceName)
+	mainFS, err := fileservice.Get[fileservice.FileService](s.fileService, defines.S3FileServiceName)
 	if err != nil {
 		return nil, err
 	}
 	// use local as temp file service
-	tempFS, err := fileservice.Get[fileservice.FileService](s.fileService, localFileServiceName)
+	tempFS, err := fileservice.Get[fileservice.FileService](s.fileService, defines.LocalFileServiceName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dnservice/store.go
+++ b/pkg/dnservice/store.go
@@ -22,6 +22,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -135,7 +136,7 @@ func NewService(cfg *Config,
 	common.InitTAEMPool()
 
 	// get metadata fs
-	metadataFS, err := fileservice.Get[fileservice.ReplaceableFileService](fileService, localFileServiceName)
+	metadataFS, err := fileservice.Get[fileservice.ReplaceableFileService](fileService, defines.LocalFileServiceName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dnservice/store_metadata_test.go
+++ b/pkg/dnservice/store_metadata_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/fagongzi/util/protoc"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
@@ -26,7 +27,7 @@ import (
 )
 
 func TestInitMetadata(t *testing.T) {
-	fs, err := fileservice.NewMemoryFS(localFileServiceName)
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
 	assert.NoError(t, err)
 
 	s := &store{logger: logutil.GetPanicLogger(), metadataFileService: fs}
@@ -42,7 +43,7 @@ func TestInitMetadata(t *testing.T) {
 }
 
 func TestInitMetadataWithExistData(t *testing.T) {
-	fs, err := fileservice.NewMemoryFS(localFileServiceName)
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
 	assert.NoError(t, err)
 	value := metadata.DNStore{
 		UUID: "dn1",
@@ -81,7 +82,7 @@ func TestInitMetadataWithInvalidUUIDWillPanic(t *testing.T) {
 		assert.Fail(t, "must panic")
 	}()
 
-	fs, err := fileservice.NewMemoryFS(localFileServiceName)
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
 	assert.NoError(t, err)
 	value := metadata.DNStore{
 		UUID: "dn1",

--- a/pkg/dnservice/store_test.go
+++ b/pkg/dnservice/store_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	logservicepb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
@@ -55,16 +56,16 @@ func TestAddReplica(t *testing.T) {
 }
 
 func TestStartWithReplicas(t *testing.T) {
-	localFS, err := fileservice.NewMemoryFS(localFileServiceName)
+	localFS, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
 	assert.NoError(t, err)
 
 	factory := func(name string) (*fileservice.FileServices, error) {
-		s3fs, err := fileservice.NewMemoryFS(s3FileServiceName)
+		s3fs, err := fileservice.NewMemoryFS(defines.S3FileServiceName)
 		if err != nil {
 			return nil, err
 		}
 		return fileservice.NewFileServices(
-			localFileServiceName,
+			defines.LocalFileServiceName,
 			s3fs,
 			localFS,
 		)
@@ -140,19 +141,19 @@ func runDNStoreTest(
 	opts ...Option) {
 	runDNStoreTestWithFileServiceFactory(t, testFn, func(name string) (*fileservice.FileServices, error) {
 		local, err := fileservice.NewMemoryFS(
-			localFileServiceName,
+			defines.LocalFileServiceName,
 		)
 		if err != nil {
 			return nil, err
 		}
 		s3, err := fileservice.NewMemoryFS(
-			s3FileServiceName,
+			defines.S3FileServiceName,
 		)
 		if err != nil {
 			return nil, err
 		}
 		etl, err := fileservice.NewMemoryFS(
-			etlFileServiceName,
+			defines.ETLFileServiceName,
 		)
 		if err != nil {
 			return nil, err
@@ -237,7 +238,7 @@ func newTestStore(
 	}
 	options = append(options, WithClock(clock.NewHLCClock(func() int64 { return time.Now().UTC().UnixNano() },
 		time.Duration(math.MaxInt64))))
-	fs, err := fsFactory(localFileServiceName)
+	fs, err := fsFactory(defines.LocalFileServiceName)
 	assert.Nil(t, err)
 	s, err := NewService(c, fs, options...)
 	assert.NoError(t, err)

--- a/pkg/logutil/adapt_s3.go
+++ b/pkg/logutil/adapt_s3.go
@@ -16,12 +16,14 @@ package logutil
 
 import (
 	"fmt"
+
 	"github.com/aws/smithy-go/logging"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"go.uber.org/zap"
 )
 
 func GetS3Logger() logging.Logger {
-	logger := GetSkip1Logger().Named("S3")
+	logger := GetSkip1Logger().Named(defines.S3FileServiceName)
 	return &S3Logger{
 		Logger: logger,
 	}

--- a/pkg/objectio/fs.go
+++ b/pkg/objectio/fs.go
@@ -22,8 +22,9 @@ import (
 )
 
 type ObjectFS struct {
-	Service fileservice.FileService
-	Dir     string
+	MainFS fileservice.FileService
+	TempFS fileservice.FileService
+	Dir    string
 }
 
 func TmpNewFileservice(dir string) fileservice.FileService {
@@ -40,14 +41,15 @@ func TmpNewFileservice(dir string) fileservice.FileService {
 	return service
 }
 
-func NewObjectFS(service fileservice.FileService, dir string) *ObjectFS {
+func NewObjectFS(mainFS fileservice.FileService, tempFS fileservice.FileService, dir string) *ObjectFS {
 	fs := &ObjectFS{
-		Service: service,
-		Dir:     dir,
+		MainFS: mainFS,
+		TempFS: tempFS,
+		Dir:    dir,
 	}
 	return fs
 }
 
 func (o *ObjectFS) ListDir(dir string) ([]fileservice.DirEntry, error) {
-	return o.Service.List(context.Background(), dir)
+	return o.MainFS.List(context.Background(), dir)
 }

--- a/pkg/objectio/fs.go
+++ b/pkg/objectio/fs.go
@@ -17,7 +17,9 @@ package objectio
 import (
 	"context"
 	"fmt"
+
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 )
 
@@ -29,7 +31,7 @@ type ObjectFS struct {
 
 func TmpNewFileservice(dir string) fileservice.FileService {
 	c := fileservice.Config{
-		Name:    "LOCAL",
+		Name:    defines.LocalFileServiceName,
 		Backend: "DISK",
 		DataDir: dir,
 	}

--- a/pkg/objectio/writer_test.go
+++ b/pkg/objectio/writer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/stretchr/testify/assert"
@@ -66,7 +67,7 @@ func TestNewObjectWriter(t *testing.T) {
 	bat := newBatch(mp)
 	defer bat.Clean(mp)
 	c := fileservice.Config{
-		Name:    "LOCAL",
+		Name:    defines.LocalFileServiceName,
 		Backend: "DISK",
 		DataDir: dir,
 	}

--- a/pkg/objectio/writer_test.go
+++ b/pkg/objectio/writer_test.go
@@ -140,7 +140,7 @@ func TestNewObjectWriter(t *testing.T) {
 	}
 	assert.True(t, nb0 == pool.CurrNB())
 
-	fs := NewObjectFS(service, dir)
+	fs := NewObjectFS(service, testutil.NewFS(), dir)
 	dirs, err := fs.ListDir("")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(dirs))

--- a/pkg/tests/service/fileservice.go
+++ b/pkg/tests/service/fileservice.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 )
 
@@ -58,12 +59,12 @@ func (c *testCluster) buildFileServices() *fileServices {
 
 	dnLocals := make([]fileservice.FileService, 0, dnServiceNum)
 	for i := 0; i < dnServiceNum; i++ {
-		dnLocals = append(dnLocals, factory(c.dn.cfgs[i].DataDir, "LOCAL"))
+		dnLocals = append(dnLocals, factory(c.dn.cfgs[i].DataDir, defines.LocalFileServiceName))
 	}
 
 	cnLocals := make([]fileservice.FileService, 0, cnServiceNum)
 	for i := 0; i < cnServiceNum; i++ {
-		cnLocals = append(cnLocals, factory(filepath.Join(c.opt.rootDataDir, c.cn.cfgs[i].UUID), "LOCAL"))
+		cnLocals = append(cnLocals, factory(filepath.Join(c.opt.rootDataDir, c.cn.cfgs[i].UUID), defines.LocalFileServiceName))
 	}
 
 	return &fileServices{
@@ -72,7 +73,7 @@ func (c *testCluster) buildFileServices() *fileServices {
 		cnServiceNum: cnServiceNum,
 		dnLocalFSs:   dnLocals,
 		cnLocalFSs:   cnLocals,
-		s3FS:         factory(c.opt.rootDataDir, "S3"),
+		s3FS:         factory(c.opt.rootDataDir, defines.S3FileServiceName),
 	}
 }
 

--- a/pkg/tests/service/service.go
+++ b/pkg/tests/service/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/dnservice"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/hakeeper"
@@ -1322,7 +1323,7 @@ func (c *testCluster) initDNServices(fileservices *fileServices) []DNService {
 		cfg := c.dn.cfgs[i]
 		opt := c.dn.opts[i]
 		fs, err := fileservice.NewFileServices(
-			"LOCAL",
+			defines.LocalFileServiceName,
 			fileservices.getDNLocalFileService(i),
 			fileservices.getS3FileService(),
 		)
@@ -1383,7 +1384,7 @@ func (c *testCluster) initCNServices(fileservices *fileServices) []CNService {
 		cfg := c.cn.cfgs[i]
 		opt := c.cn.opts[i]
 		fs, err := fileservice.NewFileServices(
-			"LOCAL",
+			defines.LocalFileServiceName,
 			fileservices.getCNLocalFileService(i),
 			fileservices.getS3FileService(),
 		)

--- a/pkg/txn/storage/tae/storage.go
+++ b/pkg/txn/storage/tae/storage.go
@@ -38,14 +38,16 @@ func NewTAEStorage(
 	dataDir string,
 	shard metadata.DNShard,
 	factory logservice.ClientFactory,
-	fs fileservice.FileService,
+	mainFS fileservice.FileService,
+	tempFS fileservice.FileService,
 	clock clock.Clock,
 	ckpCfg *options.CheckpointCfg,
 	logStore options.LogstoreType,
 ) (*taeStorage, error) {
 	opt := &options.Options{
 		Clock:         clock,
-		Fs:            fs,
+		MainFS:        mainFS,
+		TempFS:        tempFS,
 		Lc:            logservicedriver.LogServiceClientFactory(factory),
 		Shard:         shard,
 		CheckpointCfg: ckpCfg,

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -34,7 +34,9 @@ import (
 func New(
 	ctx context.Context,
 	mp *mpool.MPool,
-	fs fileservice.FileService,
+	allFS fileservice.FileService,
+	mainFS fileservice.FileService,
+	tempFS fileservice.FileService,
 	cli client.TxnClient,
 	idGen IDGenerator,
 	getClusterDetails engine.GetClusterDetailsFunc,
@@ -50,7 +52,9 @@ func New(
 	return &Engine{
 		db:                db,
 		mp:                mp,
-		fs:                fs,
+		allFS:             allFS,
+		mainFS:            mainFS,
+		tempFS:            tempFS,
 		cli:               cli,
 		idGen:             idGen,
 		txnHeap:           &transactionHeap{},
@@ -101,7 +105,7 @@ func (e *Engine) Database(ctx context.Context, name string,
 		db := &database{
 			txn:          txn,
 			db:           e.db,
-			fs:           e.fs,
+			fs:           e.mainFS,
 			databaseId:   catalog.MO_CATALOG_ID,
 			databaseName: name,
 		}
@@ -115,7 +119,7 @@ func (e *Engine) Database(ctx context.Context, name string,
 	db := &database{
 		txn:          txn,
 		db:           e.db,
-		fs:           e.fs,
+		fs:           e.mainFS,
 		databaseId:   id,
 		databaseName: name,
 	}
@@ -150,7 +154,7 @@ func (e *Engine) Delete(ctx context.Context, name string, op client.TxnOperator)
 		db = &database{
 			txn:          txn,
 			db:           e.db,
-			fs:           e.fs,
+			fs:           e.mainFS,
 			databaseId:   id,
 			databaseName: name,
 		}
@@ -219,7 +223,7 @@ func (e *Engine) New(ctx context.Context, op client.TxnOperator) error {
 		e.mp,
 		e.cli,
 		op,
-		e.fs,
+		e.allFS,
 		e.getClusterDetails,
 	)
 	txn := &Transaction{

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -92,7 +92,9 @@ type MVCC interface {
 type Engine struct {
 	sync.RWMutex
 	mp                *mpool.MPool
-	fs                fileservice.FileService
+	allFS             fileservice.FileService
+	mainFS            fileservice.FileService
+	tempFS            fileservice.FileService
 	db                *DB
 	cli               client.TxnClient
 	idGen             IDGenerator

--- a/pkg/vm/engine/tae/dataio/blockio/reader.go
+++ b/pkg/vm/engine/tae/dataio/blockio/reader.go
@@ -42,7 +42,7 @@ func NewReader(cxt context.Context, fs *objectio.ObjectFS, key string) (*Reader,
 	if err != nil {
 		return nil, err
 	}
-	reader, err := objectio.NewObjectReader(meta.GetKey(), fs.Service)
+	reader, err := objectio.NewObjectReader(meta.GetKey(), fs.MainFS)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func NewCheckpointReader(fs *objectio.ObjectFS, key string) (*Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	reader, err := objectio.NewObjectReader(name, fs.Service)
+	reader, err := objectio.NewObjectReader(name, fs.MainFS)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vm/engine/tae/dataio/blockio/writer.go
+++ b/pkg/vm/engine/tae/dataio/blockio/writer.go
@@ -28,7 +28,7 @@ type Writer struct {
 }
 
 func NewWriter(ctx context.Context, fs *objectio.ObjectFS, name string) *Writer {
-	writer, err := objectio.NewObjectWriter(name, fs.Service)
+	writer, err := objectio.NewObjectWriter(name, fs.MainFS)
 	if err != nil {
 		panic(any(err))
 	}

--- a/pkg/vm/engine/tae/db/checkpoint/replay.go
+++ b/pkg/vm/engine/tae/db/checkpoint/replay.go
@@ -55,7 +55,7 @@ func (r *runner) Replay(dataFactory catalog.DataFactory) (maxTs types.TS, err er
 	})
 	targetIdx := metaFiles[len(metaFiles)-1].index
 	dir := dirs[targetIdx]
-	reader, err := objectio.NewObjectReader(CheckpointDir+dir.Name, r.fs.Service)
+	reader, err := objectio.NewObjectReader(CheckpointDir+dir.Name, r.fs.MainFS)
 	if err != nil {
 		return
 	}

--- a/pkg/vm/engine/tae/db/db_test.go
+++ b/pkg/vm/engine/tae/db/db_test.go
@@ -3781,7 +3781,7 @@ func TestBlockRead(t *testing.T) {
 		colNulls = append(colNulls, col.NullAbility)
 	}
 	t.Log("read columns: ", columns)
-	fs := tae.DB.Fs.Service
+	fs := tae.DB.Fs.MainFS
 	pool, err := mpool.NewMPool("test", 0, mpool.NoFixed)
 	assert.NoError(t, err)
 	b1, err := blockio.BlockReadInner(

--- a/pkg/vm/engine/tae/db/open.go
+++ b/pkg/vm/engine/tae/db/open.go
@@ -57,11 +57,15 @@ func Open(dirname string, opts *options.Options) (db *DB, err error) {
 	txnBufMgr := buffer.NewNodeManager(opts.CacheCfg.TxnCapacity, nil)
 
 	serviceDir := path.Join(dirname, "data")
-	if opts.Fs == nil {
+	if opts.MainFS == nil {
 		// TODO:fileservice needs to be passed in as a parameter
-		opts.Fs = objectio.TmpNewFileservice(path.Join(dirname, "data"))
+		opts.MainFS = objectio.TmpNewFileservice(path.Join(dirname, "data"))
 	}
-	fs := objectio.NewObjectFS(opts.Fs, serviceDir)
+	if opts.TempFS == nil {
+		// TODO:fileservice needs to be passed in as a parameter
+		opts.TempFS = objectio.TmpNewFileservice(path.Join(dirname, "temp-data"))
+	}
+	fs := objectio.NewObjectFS(opts.MainFS, opts.TempFS, serviceDir)
 
 	db = &DB{
 		Dir:       dirname,

--- a/pkg/vm/engine/tae/options/types.go
+++ b/pkg/vm/engine/tae/options/types.go
@@ -66,7 +66,8 @@ type Options struct {
 	Catalog       *catalog.Catalog
 
 	Clock     clock.Clock
-	Fs        fileservice.FileService
+	MainFS    fileservice.FileService
+	TempFS    fileservice.FileService
 	Lc        logservicedriver.LogServiceClientFactory
 	Shard     metadata.DNShard
 	LogStoreT LogstoreType

--- a/pkg/vm/engine/tae/tables/indexwrapper/bfnode_test.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/bfnode_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
@@ -44,7 +45,7 @@ func TestStaticFilterIndex(t *testing.T) {
 	name := fmt.Sprintf("%d.blk", id)
 	bat := newBatch()
 	c := fileservice.Config{
-		Name:    "LOCAL",
+		Name:    defines.LocalFileServiceName,
 		Backend: "DISK",
 		DataDir: dir,
 	}

--- a/pkg/vm/engine/tae/tables/indexwrapper/zmnode_test.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/zmnode_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
@@ -46,7 +47,7 @@ func TestBlockZoneMapIndex(t *testing.T) {
 	name := fmt.Sprintf("%d.blk", id)
 	bat := newBatch()
 	c := fileservice.Config{
-		Name:    "LOCAL",
+		Name:    defines.LocalFileServiceName,
 		Backend: "DISK",
 		DataDir: dir,
 	}

--- a/pkg/vm/engine/tae/txn/txnimpl/txn_test.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/txn_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -414,7 +415,7 @@ func initTestContext(t *testing.T, dir string) (*catalog.Catalog, *txnbase.TxnMa
 	mutBufMgr := buffer.NewNodeManager(common.G, nil)
 	serviceDir := path.Join(dir, "data")
 	service := objectio.TmpNewFileservice(path.Join(dir, "data"))
-	fs := objectio.NewObjectFS(service, serviceDir)
+	fs := objectio.NewObjectFS(service, testutil.NewFS(), serviceDir)
 	factory := tables.NewDataFactory(fs, mutBufMgr, nil, dir)
 	mgr := txnbase.NewTxnManager(TxnStoreFactory(c, driver, txnBufMgr, factory),
 		TxnFactory(c), types.NewMockHLCClock(1))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
TAE should use the main file service or temp file service explicitly. 
Main file service name is S3, temp file service name is LOCAL.
For testing purposes, instead of setting main file service name to LOCAL, just set S3's backend to disk or mem.