### PR TITLE
fix point read bug

### DIFF
--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -79,7 +79,7 @@ func (r *blockReader) Read(cols []string, _ *plan.Expr, m *mpool.MPool) (*batch.
 
 	// if expr like : pkCol = xx，  we will try to find(binary search) the row in batch
 	vec := bat.GetVector(int32(r.pkidxInColIdxs))
-	canCompute, v := getPkValueByExpr(r.expr, int32(r.primaryIdx), vec.Typ.Oid)
+	canCompute, v := getPkValueByExpr(r.expr, int32(r.pkidxInColIdxs), vec.Typ.Oid)
 	if canCompute {
 		row := findRowByPkValue(vec, v)
 		if row >= vec.Length() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6280

## What this PR does / why we need it:
still have bug in main branch.   replay like:
create table t1(a int, b int, c int primary key);
select a,c from t1 where c =xx;

in this case pkidxInColIdxs = 1   but primaryIdx = 2.   
so we can not getPkValueByExpr.(expr's ColIndx = 1)
