### PR TITLE
fix bug: can't get row_id's idx

### DIFF
--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -17,6 +17,7 @@ package disttae
 import (
 	"sort"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
@@ -52,14 +53,24 @@ func (r *blockReader) Read(cols []string, _ *plan.Expr, m *mpool.MPool) (*batch.
 			r.colNulls = make([]bool, len(cols))
 			r.pkidxInColIdxs = -1
 			for i, column := range cols {
-				r.colIdxs[i] = uint16(r.tableDef.Name2ColIndex[column])
-				if r.colIdxs[i] == uint16(r.primaryIdx) {
-					r.pkidxInColIdxs = i
-				}
-				colDef := r.tableDef.Cols[r.colIdxs[i]]
-				r.colTypes[i] = types.T(colDef.Typ.Id).ToType()
-				if colDef.Default != nil {
-					r.colNulls[i] = colDef.Default.NullAbility
+				// sometimes Name2ColIndex have no row_id， sometimes have one
+				if column == catalog.Row_ID {
+					if colIdx, ok := r.tableDef.Name2ColIndex[column]; ok {
+						r.colIdxs[i] = uint16(colIdx)
+					} else {
+						r.colIdxs[i] = uint16(len(r.tableDef.Name2ColIndex))
+					}
+					r.colTypes[i] = types.T_Rowid.ToType()
+				} else {
+					r.colIdxs[i] = uint16(r.tableDef.Name2ColIndex[column])
+					if r.colIdxs[i] == uint16(r.primaryIdx) {
+						r.pkidxInColIdxs = i
+					}
+					colDef := r.tableDef.Cols[r.colIdxs[i]]
+					r.colTypes[i] = types.T(colDef.Typ.Id).ToType()
+					if colDef.Default != nil {
+						r.colNulls[i] = colDef.Default.NullAbility
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
fix bug: can't get row_id's idx
sql: update t1 set a=a+1         after flush. when get row_id's idx in Read,  can not find the index.  because Name2ColIndex have no row_id column.  so we set the idx to length of Name2ColIndex.
sql: insert into t2 values (1).   if t2 have auto_increment column.  that case,  Name2ColIndex will have row_id column.

thanks @nnsgmsone @aptend 