### PR TITLE
fileservice: deref symlink in LocalETLFS.List, LocalFS.List

### DIFF
--- a/pkg/fileservice/local_etl_fs.go
+++ b/pkg/fileservice/local_etl_fs.go
@@ -330,9 +330,13 @@ func (l *LocalETLFS) List(ctx context.Context, dirPath string) (ret []DirEntry, 
 		if err != nil {
 			return nil, err
 		}
+		isDir, err := entryIsDir(nativePath, name, info)
+		if err != nil {
+			return nil, err
+		}
 		ret = append(ret, DirEntry{
 			Name:  name,
-			IsDir: entry.IsDir(),
+			IsDir: isDir,
 			Size:  info.Size(),
 		})
 	}

--- a/pkg/fileservice/local_etl_fs_test.go
+++ b/pkg/fileservice/local_etl_fs_test.go
@@ -86,4 +86,35 @@ func TestLocalETLFS(t *testing.T) {
 
 	})
 
+	t.Run("deref symlink", func(t *testing.T) {
+		dir := t.TempDir()
+
+		aPath := filepath.Join(dir, "a")
+		err := os.Mkdir(aPath, 0755)
+		assert.Nil(t, err)
+
+		bPath := filepath.Join(dir, "b")
+		err = os.Symlink(aPath, bPath)
+		assert.Nil(t, err)
+
+		filePathInA := filepath.Join(aPath, "foo")
+		err = os.WriteFile(
+			filePathInA,
+			[]byte("foo"),
+			0644,
+		)
+		assert.Nil(t, err)
+
+		fs, err := NewLocalETLFS("foo", dir)
+		assert.Nil(t, err)
+
+		ctx := context.Background()
+		entries, err := fs.List(ctx, "")
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(entries))
+		assert.True(t, entries[0].IsDir)
+		assert.True(t, entries[1].IsDir)
+
+	})
+
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
set IsDir to true if it's a symlink to another dir