### PR TITLE
bugfix: sql_transaction metric count needs in VALID txn

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2282,7 +2282,7 @@ func incTransactionCounter(tenant string) {
 }
 
 func incTransactionErrorsCounter(tenant string, t metric.SQLType) {
-	if t == metric.SQLTypeRollback || t == metric.SQLTypeAutoRollback {
+	if t == metric.SQLTypeRollback {
 		return
 	}
 	metric.TransactionErrorsCounter(tenant, t).Inc()

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2282,6 +2282,9 @@ func incTransactionCounter(tenant string) {
 }
 
 func incTransactionErrorsCounter(tenant string, t metric.SQLType) {
+	if t == metric.SQLTypeRollback || t == metric.SQLTypeAutoRollback {
+		return
+	}
 	metric.TransactionErrorsCounter(tenant, t).Inc()
 }
 

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -517,7 +517,7 @@ func (ses *Session) GetTenantInfo() *TenantInfo {
 
 // GetTenantName return tenant name according to GetTenantInfo and stmt.
 //
-// With stmt = nil, should be only called in TxnBegin, TxnCommit, TxnRollback
+// With stmt = nil, should be only called in TxnHandler.NewTxn, TxnHandler.CommitTxn, TxnHandler.RollbackTxn
 func (ses *Session) GetTenantName(stmt tree.Statement) string {
 	tenant := sysAccountName
 	if ses.GetTenantInfo() != nil && (stmt == nil || !IsPrepareStatement(stmt)) {
@@ -859,12 +859,6 @@ func (ses *Session) TxnCommitSingleStatement(stmt tree.Statement) error {
 		err = ses.GetTxnHandler().CommitTxn()
 		ses.ClearServerStatus(SERVER_STATUS_IN_TRANS)
 		ses.ClearOptionBits(OPTION_BEGIN)
-		// metric count
-		tenant := ses.GetTenantName(stmt)
-		incTransactionCounter(tenant)
-		if err != nil {
-			incTransactionErrorsCounter(tenant, metric.SQLTypeAutoCommit)
-		}
 	}
 	return err
 }
@@ -887,13 +881,6 @@ func (ses *Session) TxnRollbackSingleStatement(stmt tree.Statement) error {
 		err = ses.GetTxnHandler().RollbackTxn()
 		ses.ClearServerStatus(SERVER_STATUS_IN_TRANS)
 		ses.ClearOptionBits(OPTION_BEGIN)
-		// metric count
-		tenant := ses.GetTenantName(stmt)
-		incTransactionCounter(tenant)
-		incTransactionErrorsCounter(tenant, metric.SQLTypeOther) // exec rollback cnt
-		if err != nil {
-			incTransactionErrorsCounter(tenant, metric.SQLTypeAutoRollback)
-		}
 	}
 	return err
 }
@@ -904,25 +891,17 @@ It commits the current transaction implicitly.
 */
 func (ses *Session) TxnBegin() error {
 	var err error
-	tenant := ses.GetTenantName(nil)
 	if ses.InMultiStmtTransactionMode() {
 		ses.ClearServerStatus(SERVER_STATUS_IN_TRANS)
 		err = ses.GetTxnHandler().CommitTxn()
-		// metric count: last txn
-		incTransactionCounter(tenant)
 	}
 	ses.ClearOptionBits(OPTION_BEGIN)
 	if err != nil {
-		// metric count: last txn commit failed.
-		incTransactionErrorsCounter(tenant, metric.SQLTypeCommit)
 		return err
 	}
 	ses.SetOptionBits(OPTION_BEGIN)
 	ses.SetServerStatus(SERVER_STATUS_IN_TRANS)
 	err = ses.GetTxnHandler().NewTxn()
-	if err != nil {
-		incTransactionErrorsCounter(tenant, metric.SQLTypeBegin)
-	}
 	return err
 }
 
@@ -933,12 +912,6 @@ func (ses *Session) TxnCommit() error {
 	err = ses.GetTxnHandler().CommitTxn()
 	ses.ClearServerStatus(SERVER_STATUS_IN_TRANS)
 	ses.ClearOptionBits(OPTION_BEGIN)
-	// metric count
-	tenant := ses.GetTenantName(nil)
-	incTransactionCounter(tenant)
-	if err != nil {
-		incTransactionErrorsCounter(tenant, metric.SQLTypeCommit)
-	}
 	return err
 }
 
@@ -948,13 +921,6 @@ func (ses *Session) TxnRollback() error {
 	ses.ClearServerStatus(SERVER_STATUS_IN_TRANS | SERVER_STATUS_IN_TRANS_READONLY)
 	err = ses.GetTxnHandler().RollbackTxn()
 	ses.ClearOptionBits(OPTION_BEGIN)
-	// metric count
-	tenant := ses.GetTenantName(nil)
-	incTransactionCounter(tenant)
-	incTransactionErrorsCounter(tenant, metric.SQLTypeOther)
-	if err != nil {
-		incTransactionErrorsCounter(tenant, metric.SQLTypeRollback)
-	}
 	return err
 }
 
@@ -1225,6 +1191,12 @@ func (th *TxnHandler) NewTxn() error {
 		}
 	}
 	th.SetInvalid()
+	defer func() {
+		if err != nil {
+			tenant := th.ses.GetTenantName(nil)
+			incTransactionErrorsCounter(tenant, metric.SQLTypeBegin)
+		}
+	}()
 	err = th.TxnClientNew()
 	if err != nil {
 		return err
@@ -1239,7 +1211,8 @@ func (th *TxnHandler) NewTxn() error {
 		storage.Hints().CommitOrRollbackTimeout,
 	)
 	defer cancel()
-	return storage.New(ctx, th.GetTxnOperator())
+	err = storage.New(ctx, th.GetTxnOperator())
+	return err
 }
 
 // IsValidTxn checks the transaction is true or not.
@@ -1286,6 +1259,14 @@ func (th *TxnHandler) CommitTxn() error {
 	)
 	defer cancel()
 	var err, err2 error
+	defer func() {
+		// metric count
+		tenant := ses.GetTenantName(nil)
+		incTransactionCounter(tenant)
+		if err != nil {
+			incTransactionErrorsCounter(tenant, metric.SQLTypeCommit)
+		}
+	}()
 	txnOp := th.GetTxnOperator()
 	if txnOp == nil {
 		logErrorf(sessionProfile, "CommitTxn: txn operator is null")
@@ -1330,6 +1311,15 @@ func (th *TxnHandler) RollbackTxn() error {
 	)
 	defer cancel()
 	var err, err2 error
+	defer func() {
+		// metric count
+		tenant := ses.GetTenantName(nil)
+		incTransactionCounter(tenant)
+		incTransactionErrorsCounter(tenant, metric.SQLTypeOther) // exec rollback cnt
+		if err != nil {
+			incTransactionErrorsCounter(tenant, metric.SQLTypeRollback)
+		}
+	}()
 	txnOp := th.GetTxnOperator()
 	if txnOp == nil {
 		logErrorf(sessionProfile, "RollbackTxn: txn operator is null")


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/6435

## What this PR does / why we need it:

move `sql_transaction_total` and `sql_transaction_errors` count action from `Session` to `TxnHandler`