### PR TITLE
Revert "close all futures when close the client (#6439)"

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -308,21 +308,8 @@ func (rb *remoteBackend) Close() {
 	rb.stopWriteLoop()
 	rb.stateMu.Unlock()
 
-	for _, future := range rb.getFutures() {
-		future.Close()
-	}
 	rb.stopper.Stop()
 	rb.doClose()
-}
-
-func (rb *remoteBackend) getFutures() []*Future {
-	rb.mu.Lock()
-	defer rb.mu.Unlock()
-	futures := make([]*Future, 0, len(rb.mu.futures))
-	for _, future := range rb.mu.futures {
-		futures = append(futures, future)
-	}
-	return futures
 }
 
 func (rb *remoteBackend) Busy() bool {

--- a/pkg/common/morpc/future_test.go
+++ b/pkg/common/morpc/future_test.go
@@ -54,8 +54,6 @@ func TestCloseChanAfterGC(t *testing.T) {
 func TestNewFuture(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	ctx2, cancel2 := context.WithCancel(ctx)
-	defer cancel2()
 
 	f := newFuture(nil)
 	f.init(1, ctx)
@@ -66,7 +64,7 @@ func TestNewFuture(t *testing.T) {
 	assert.NotNil(t, f.c)
 	assert.Equal(t, 0, len(f.c))
 	assert.Equal(t, uint64(1), f.id)
-	assert.Equal(t, ctx2, f.ctx)
+	assert.Equal(t, ctx, f.ctx)
 }
 
 func TestReleaseFuture(t *testing.T) {
@@ -81,7 +79,7 @@ func TestReleaseFuture(t *testing.T) {
 	assert.True(t, f.mu.closed)
 	assert.Equal(t, 0, len(f.c))
 	assert.Equal(t, uint64(0), f.id)
-	assert.Error(t, f.ctx.Err())
+	assert.Nil(t, f.ctx)
 }
 
 func TestGet(t *testing.T) {

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -87,6 +87,7 @@ func TestHandleServerWithPayloadMessage(t *testing.T) {
 
 func TestHandleServerWriteWithClosedSession(t *testing.T) {
 	wc := make(chan struct{}, 1)
+	defer close(wc)
 
 	testRPCServer(t, func(rs *server) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -96,7 +97,6 @@ func TestHandleServerWriteWithClosedSession(t *testing.T) {
 		rs.RegisterRequestHandler(func(_ context.Context, request Message, _ uint64, cs ClientSession) error {
 			assert.NoError(t, c.Close())
 			wc <- struct{}{}
-			close(wc)
 			return cs.Write(ctx, request)
 		})
 
@@ -106,7 +106,7 @@ func TestHandleServerWriteWithClosedSession(t *testing.T) {
 
 		defer f.Close()
 		resp, err := f.Get()
-		assert.Error(t, f.ctx.Err(), err)
+		assert.Error(t, ctx.Err(), err)
 		assert.Nil(t, resp)
 	}, WithServerWriteFilter(func(_ Message) bool {
 		<-wc


### PR DESCRIPTION
This reverts commit fcda32551ba7076fa24b8156b5d374da253220c1.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: