### PR TITLE
fileservice: add s3-no-key to GetForETL

### DIFF
--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -168,6 +168,38 @@ func TestDynamicS3(t *testing.T) {
 	})
 }
 
+func TestDynamicS3NoKey(t *testing.T) {
+	config, err := loadS3TestConfig()
+	assert.Nil(t, err)
+	if config.Endpoint == "" {
+		// no config
+		t.Skip()
+	}
+	t.Setenv("AWS_REGION", config.Region)
+	t.Setenv("AWS_ACCESS_KEY_ID", config.APIKey)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", config.APISecret)
+	testFileService(t, func(name string) FileService {
+		buf := new(strings.Builder)
+		w := csv.NewWriter(buf)
+		err := w.Write([]string{
+			"s3-no-key",
+			config.Endpoint,
+			config.Region,
+			config.Bucket,
+			time.Now().Format("2006-01-02.15:04:05.000000"),
+			name,
+		})
+		assert.Nil(t, err)
+		w.Flush()
+		fs, _, err := GetForETL(nil, JoinPath(
+			buf.String(),
+			"foo/bar/baz",
+		))
+		assert.Nil(t, err)
+		return fs
+	})
+}
+
 func TestS3FSMinioServer(t *testing.T) {
 
 	// find minio executable


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Users may want to add an external table specifying the endpoint and bucket but no key or secret. 