### PR TITLE
transfer deletes if the target block was compacted - phase 2

### DIFF
--- a/pkg/vm/engine/tae/tables/block.go
+++ b/pkg/vm/engine/tae/tables/block.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/dataio/blockio"
 
@@ -905,6 +906,11 @@ func (blk *dataBlock) DumpData(attr string) (view *model.ColumnView, err error) 
 }
 
 func (blk *dataBlock) BatchDedup(txn txnif.AsyncTxn, pks containers.Vector, rowmask *roaring.Bitmap) (err error) {
+	defer func() {
+		if moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry) {
+			logutil.Infof("BatchDedup BLK-%d: %v", blk.meta.ID, err)
+		}
+	}()
 	var dupRow uint32
 	if blk.meta.IsAppendable() {
 		ts := txn.GetStartTS()
@@ -933,6 +939,9 @@ func (blk *dataBlock) BatchDedup(txn txnif.AsyncTxn, pks containers.Vector, rowm
 			defer sortKey.Close()
 			deduplicate := func(v1 any, _ int) error {
 				return sortKey.GetData().Foreach(func(v2 any, row int) error {
+					if sortKey.DeleteMask != nil && sortKey.DeleteMask.ContainsInt(row) {
+						return nil
+					}
 					if compute.CompareGeneric(v1, v2, pks.GetType()) == 0 {
 						entry := common.TypeStringValue(pks.GetType(), v1)
 						return moerr.NewDuplicateEntry(entry, pkDef.Name)

--- a/pkg/vm/engine/tae/tables/updates/chain_test.go
+++ b/pkg/vm/engine/tae/tables/updates/chain_test.go
@@ -159,7 +159,7 @@ func TestDeleteChain1(t *testing.T) {
 func TestDeleteChain2(t *testing.T) {
 	defer testutils.AfterTest(t)()
 	testutils.EnsureNoLeak(t)
-	controller := NewMVCCHandle(nil)
+	controller := NewMVCCHandle(catalog.NewStandaloneBlock(nil, 0, types.TS{}))
 	chain := NewDeleteChain(nil, controller)
 
 	txn1 := mockTxn()

--- a/pkg/vm/engine/tae/tables/updates/delete.go
+++ b/pkg/vm/engine/tae/tables/updates/delete.go
@@ -152,6 +152,10 @@ func (node *DeleteNode) IsDeletedLocked(row uint32) bool {
 }
 
 func (node *DeleteNode) RangeDeleteLocked(start, end uint32) {
+	// logutil.Debugf("RangeDelete BLK-%d Start=%d End=%d",
+	// 	node.chain.mvcc.meta.ID,
+	// 	start,
+	// 	end)
 	node.mask.AddRange(uint64(start), uint64(end+1))
 	for i := start; i < end+1; i++ {
 		node.chain.InsertInDeleteView(i, node)

--- a/pkg/vm/engine/tae/txn/txnimpl/store.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/store.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/buffer/base"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
@@ -261,6 +262,11 @@ func (store *txnStore) UnsafeGetDatabase(id uint64) (h handle.Database, err erro
 }
 
 func (store *txnStore) GetDatabase(name string) (h handle.Database, err error) {
+	defer func() {
+		if err == moerr.GetOkExpectedEOB() {
+			err = moerr.NewBadDB(name)
+		}
+	}()
 	meta, err := store.catalog.TxnGetDBEntryByName(name, store.txn)
 	if err != nil {
 		return

--- a/pkg/vm/engine/tae/txn/txnimpl/txn_test.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/txn_test.go
@@ -518,7 +518,7 @@ func TestTransaction2(t *testing.T) {
 	t.Log(dropped.String())
 
 	_, err = txn2.GetDatabase(name)
-	assert.True(t, moerr.IsMoErrCode(err, moerr.OkExpectedEOB))
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadDB))
 	t.Log(err)
 
 	txn3, _ := mgr.StartTxn(nil)

--- a/pkg/vm/engine/tae/txn/txnimpl/txn_test.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/txn_test.go
@@ -801,9 +801,9 @@ func TestDedup1(t *testing.T) {
 		assert.Nil(t, txn3.Commit())
 
 		err = rel.Append(bats[3])
-		// TODO: should be w-w error
-		assert.Error(t, err)
-		_ = txn.Rollback()
+		assert.NoError(t, err)
+		err = txn.Commit()
+		assert.True(t, moerr.IsMoErrCode(err, moerr.ErrTxnWWConflict))
 	}
 	t.Log(c.SimplePPString(common.PPL1))
 }

--- a/pkg/vm/engine/tae/txn/txnimpl/txndb.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/txndb.go
@@ -140,15 +140,16 @@ func (db *txnDB) RangeDelete(id *common.ID, start, end uint32, dt handle.DeleteT
 	if table.IsDeleted() {
 		return moerr.NewNotFound()
 	}
-	if start == end {
-		return db.DeleteOne(table, id, start, dt)
-	}
-	for i := start; i <= end; i++ {
-		if err = db.DeleteOne(table, id, i, dt); err != nil {
-			return
-		}
-	}
-	return
+	return table.RangeDelete(id, start, end, dt)
+	// if start == end {
+	// 	return db.DeleteOne(table, id, start, dt)
+	// }
+	// for i := start; i <= end; i++ {
+	// 	if err = db.DeleteOne(table, id, i, dt); err != nil {
+	// 		return
+	// 	}
+	// }
+	// return
 }
 
 func (db *txnDB) GetByFilter(tid uint64, filter *handle.Filter) (id *common.ID, offset uint32, err error) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6049 #6333 #6514 

## What this PR does / why we need it:

1. Fix persisted appendable block dedup overkill
2. Change the txn dedup behavior before committing
3. Do not transfer deletes before committing due to snapshot isolation constraints