### PR TITLE
morpc: fix encoding error after goetty buffer expansion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/axiomhq/hyperloglog v0.0.0-20220105174342-98591331716a
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/docker/go-units v0.4.0
-	github.com/fagongzi/goetty/v2 v2.0.3-0.20221103025002-a4c7a0d38815
+	github.com/fagongzi/goetty/v2 v2.0.3-0.20221112031939-24c732da4b95
 	github.com/fagongzi/util v0.0.0-20210923134909-bccc37b5040d
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,10 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/fagongzi/goetty/v2 v2.0.3-0.20221103025002-a4c7a0d38815 h1:3/GJ0uNS6LEVXuD7hfvyyA0Shq42XrIrI/4Ls6z4CC8=
 github.com/fagongzi/goetty/v2 v2.0.3-0.20221103025002-a4c7a0d38815/go.mod h1:OwIBpVwRW1HjF/Jhc2Av3UvG2NygMg+bdqGxZaqwhU0=
+github.com/fagongzi/goetty/v2 v2.0.3-0.20221112031032-017f2f62f6b3 h1:liic+jQp0XS2fZOxBK1yXVcRKHunOed7Bp6x6kScYiw=
+github.com/fagongzi/goetty/v2 v2.0.3-0.20221112031032-017f2f62f6b3/go.mod h1:OwIBpVwRW1HjF/Jhc2Av3UvG2NygMg+bdqGxZaqwhU0=
+github.com/fagongzi/goetty/v2 v2.0.3-0.20221112031939-24c732da4b95 h1:GaoE/ZFYcB3UqADB9v4k1Ntidaid/cJSqlDSjSwlIrg=
+github.com/fagongzi/goetty/v2 v2.0.3-0.20221112031939-24c732da4b95/go.mod h1:OwIBpVwRW1HjF/Jhc2Av3UvG2NygMg+bdqGxZaqwhU0=
 github.com/fagongzi/util v0.0.0-20210923134909-bccc37b5040d h1:1pILVCatHj3eVo9i52dZyY4BwjTmSIeN+/hoJh8rD0Y=
 github.com/fagongzi/util v0.0.0-20210923134909-bccc37b5040d/go.mod h1:5cqSns2zMRcJeVGvAqeTrbXFqh5AqBFr5uVKP9T2kiE=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=

--- a/pkg/common/morpc/codec_header.go
+++ b/pkg/common/morpc/codec_header.go
@@ -66,9 +66,7 @@ func (hc *traceCodec) Encode(msg *RPCMessage, out *buf.ByteBuf) (int, error) {
 	c := span.SpanContext()
 	n := c.Size()
 	out.MustWriteByte(byte(n))
-	idx := out.GetWriteIndex()
-	out.Grow(n)
-	out.SetWriteIndex(idx + n)
+	idx, _ := setWriterIndexAfterGow(out, n)
 	c.MarshalTo(out.RawSlice(idx, idx+n))
 	return 1 + n, nil
 }

--- a/pkg/common/morpc/codec_test.go
+++ b/pkg/common/morpc/codec_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/fagongzi/goetty/v2/buf"
+	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -186,13 +187,16 @@ func TestNewWithMaxBodySize(t *testing.T) {
 }
 
 func TestBufferScale(t *testing.T) {
+	stopper := stopper.NewStopper("")
+	defer stopper.Stop()
+
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Hour*10)
 	defer cancel()
 	c1 := newTestCodec(WithCodecEnableChecksum(),
-		WithCodecIntegrationHLC(clock.NewUnixNanoHLCClock(ctx, 0)),
+		WithCodecIntegrationHLC(clock.NewUnixNanoHLCClockWithStopper(stopper, 0)),
 		WithCodecPayloadCopyBufferSize(16*1024))
 	c2 := newTestCodec(WithCodecEnableChecksum(),
-		WithCodecIntegrationHLC(clock.NewUnixNanoHLCClock(ctx, 0)),
+		WithCodecIntegrationHLC(clock.NewUnixNanoHLCClockWithStopper(stopper, 0)),
 		WithCodecPayloadCopyBufferSize(16*1024))
 	out := buf.NewByteBuf(32)
 	conn := buf.NewByteBuf(32)

--- a/pkg/common/morpc/codec_test.go
+++ b/pkg/common/morpc/codec_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fagongzi/goetty/v2/buf"
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncodeAndDecode(t *testing.T) {
@@ -182,4 +183,40 @@ func TestNewWithMaxBodySize(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, v.(RPCMessage).Ctx)
 	assert.NotNil(t, v.(RPCMessage).cancel)
+}
+
+func TestBufferScale(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Hour*10)
+	defer cancel()
+	c1 := newTestCodec(WithCodecEnableChecksum(),
+		WithCodecIntegrationHLC(clock.NewUnixNanoHLCClock(ctx, 0)),
+		WithCodecPayloadCopyBufferSize(16*1024))
+	c2 := newTestCodec(WithCodecEnableChecksum(),
+		WithCodecIntegrationHLC(clock.NewUnixNanoHLCClock(ctx, 0)),
+		WithCodecPayloadCopyBufferSize(16*1024))
+	out := buf.NewByteBuf(32)
+	conn := buf.NewByteBuf(32)
+
+	n := 100
+	var messages []RPCMessage
+	for i := 0; i < n; i++ {
+		msg := RPCMessage{Ctx: ctx, Message: newTestMessage(uint64(i))}
+		payload := make([]byte, 1024*1024)
+		payload[len(payload)-1] = byte(i)
+		msg.Message.(*testMessage).payload = payload
+		messages = append(messages, msg)
+
+		require.NoError(t, c1.Encode(msg, out, conn))
+	}
+	_, err := out.WriteTo(conn)
+	if err != nil {
+		require.Equal(t, io.EOF, err)
+	}
+
+	for i := 0; i < n; i++ {
+		msg, ok, err := c2.Decode(conn)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, messages[i].Message, msg.(RPCMessage).Message)
+	}
 }

--- a/pkg/frontend/server.go
+++ b/pkg/frontend/server.go
@@ -16,11 +16,12 @@ package frontend
 
 import (
 	"context"
+	"sync/atomic"
+	"syscall"
+
 	"github.com/fagongzi/goetty/v2"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
-	"sync/atomic"
-	"syscall"
 )
 
 // RelationName counter for the new connection
@@ -83,6 +84,7 @@ func NewMOServer(ctx context.Context, addr string, pu *config.ParameterUnit) *MO
 		goetty.WithAppSessionOptions(
 			goetty.WithSessionCodec(codec),
 			goetty.WithSessionLogger(logutil.GetGlobalLogger()),
+			goetty.WithSessionDisableCompactAfterGrow(),
 			goetty.WithSessionRWBUfferSize(1024*1024, 1024*1024)),
 		goetty.WithAppSessionAware(rm))
 	if err != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Our goetty's encoder will hold some buffer internal indexes externally, and these indexes will change after buf expansion, causing the encoded data to be misaligned