### PR TITLE
Fix the bug of BlockRead causing mpool oom

### DIFF
--- a/pkg/vm/engine/tae/dataio/blockio/read.go
+++ b/pkg/vm/engine/tae/dataio/blockio/read.go
@@ -72,8 +72,14 @@ func BlockRead(
 	bat := batch.NewWithSize(len(columns))
 	bat.Attrs = columns
 	for i, vec := range columnBatch.Vecs {
-		movec := containers.UnmarshalToMoVec(vec)
-		bat.Vecs[i] = movec
+		// If the vector uses mpool to allocate memory internally,
+		// it needs to be free here
+		if vec.Allocated() > 0 {
+			bat.Vecs[i] = containers.CopyToMoVec(vec)
+		} else {
+			bat.Vecs[i] = containers.UnmarshalToMoVec(vec)
+		}
+		vec.Close()
 	}
 	bat.SetZs(bat.Vecs[0].Length(), pool)
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6352 

## What this PR does / why we need it:
The rootcause is that the internal read block of tae uses mpool,since the vector of the computing layer does not support serialization and deserialization based on mpool #5937, the computing layer cannot free these data. So you need tae to free yourself