### PR TITLE
cnservice: use disttae and logservice ad default

### DIFF
--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -178,6 +178,12 @@ func (c *Config) Validate() error {
 	if c.TaskRunner.RetryInterval.Duration == 0 {
 		c.TaskRunner.RetryInterval.Duration = time.Second
 	}
+	if c.Engine.Type == "" {
+		c.Engine.Type = EngineDistributedTAE
+	}
+	if c.Engine.Logstore == "" {
+		c.Engine.Logstore = options.LogstoreLogservice
+	}
 	return nil
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Make cnservice's engine uses the appropriate default configuration 