### PR TITLE
refactor: solve data race bug in NewReader in another way

### DIFF
--- a/pkg/vm/engine/disttae/partition.go
+++ b/pkg/vm/engine/disttae/partition.go
@@ -453,20 +453,6 @@ func (p *Partition) IterDeletedRowIDs(ctx context.Context, blockIDs []uint64, ts
 	}
 }
 
-func copyBlk(blk ModifyBlockMeta) ModifyBlockMeta {
-	newBlk := ModifyBlockMeta{
-		meta: BlockMeta{
-			Rows:    blk.meta.Rows,
-			Info:    blk.meta.Info,
-			Zonemap: make([][64]byte, len(blk.meta.Zonemap)),
-		},
-		deletes: make([]int, len(blk.deletes)),
-	}
-	copy(newBlk.deletes, blk.deletes)
-	copy(newBlk.meta.Zonemap, blk.meta.Zonemap)
-	return newBlk
-}
-
 func (p *Partition) NewReader(
 	ctx context.Context,
 	readerNumber int,
@@ -535,7 +521,7 @@ func (p *Partition) NewReader(
 				ctx:      ctx,
 				tableDef: tableDef,
 				sels:     make([]int64, 0, 1024),
-				blks:     []ModifyBlockMeta{copyBlk(blks[i])},
+				blks:     []ModifyBlockMeta{blks[i]},
 			})
 		}
 		return []engine.Reader{&mergeReader{readers}}, nil
@@ -548,7 +534,7 @@ func (p *Partition) NewReader(
 				ctx:      ctx,
 				tableDef: tableDef,
 				sels:     make([]int64, 0, 1024),
-				blks:     []ModifyBlockMeta{copyBlk(blks[i])},
+				blks:     []ModifyBlockMeta{blks[i]},
 			}
 		}
 		for j := len(blks) + 1; j < readerNumber; j++ {
@@ -561,17 +547,13 @@ func (p *Partition) NewReader(
 		step = 1
 	}
 	for i := 1; i < readerNumber; i++ {
-		newBlks := make([]ModifyBlockMeta, len(blks))
-		for i, item := range blks {
-			newBlks[i] = copyBlk(item)
-		}
 		if i == readerNumber-1 {
 			readers[i] = &blockMergeReader{
 				fs:       fs,
 				ts:       ts,
 				ctx:      ctx,
 				tableDef: tableDef,
-				blks:     newBlks[(i-1)*step:],
+				blks:     blks[(i-1)*step:],
 				sels:     make([]int64, 0, 1024),
 			}
 		} else {
@@ -580,7 +562,7 @@ func (p *Partition) NewReader(
 				ts:       ts,
 				ctx:      ctx,
 				tableDef: tableDef,
-				blks:     newBlks[(i-1)*step : i*step],
+				blks:     blks[(i-1)*step : i*step],
 				sels:     make([]int64, 0, 1024),
 			}
 		}

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -148,10 +148,12 @@ func (r *blockMergeReader) Read(cols []string, expr *plan.Expr, m *mpool.MPool) 
 		return nil, err
 	}
 	r.sels = r.sels[:0]
-	sort.Ints(r.blks[0].deletes)
+	deletes := make([]int, len(r.blks[0].deletes))
+	copy(deletes, r.blks[0].deletes)
+	sort.Ints(deletes)
 	for i := 0; i < bat.Length(); i++ {
-		if len(r.blks[0].deletes) > 0 && i == r.blks[0].deletes[0] {
-			r.blks[0].deletes = r.blks[0].deletes[1:]
+		if len(deletes) > 0 && i == deletes[0] {
+			deletes = deletes[1:]
 			continue
 		}
 		r.sels = append(r.sels, int64(i))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #6469 

## What this PR does / why we need it:
refactor for PR 6462 which to solve data race bug in NewReader.

the bug root cause:
1、we will make multi preScopes in compile.compileMinusAndIntersect/compileUnion/compileGroup for performance
2、multi compile.preScopes will make multi scope.ParallelRun call.  then we will get multi Reader which share one relation(another name is table) in one transaction.
3  in blockMergeReader.Read we will get the share relation's attribute (table.meta.modifedBlocks[i].deletes) to filter rows.
but while filter rows, we do a wrong action, we modify the attribute.  because multi readers exists and do Read in the same time,  data race happed!

after discuss with @nnsgmsone .  we think multi reader in one txn is necessary for performance. but reader modify share data is not allowed.  so i change the code for step 3.


