### PR TITLE
enhance rw fix to recur transfer deletes

### DIFF
--- a/pkg/vm/engine/tae/tables/jobs/compactblk.go
+++ b/pkg/vm/engine/tae/tables/jobs/compactblk.go
@@ -234,10 +234,12 @@ func (task *compactBlockTask) Execute() (err error) {
 	}
 	createdStr := "nil"
 	if task.created != nil {
-		task.created.Fingerprint().BlockString()
+		createdStr = task.created.Fingerprint().BlockString()
 	}
 	logutil.Info("[Done]",
+		common.AnyField("txn-start-ts", task.txn.GetStartTS().ToString()),
 		common.OperationField(task.Name()),
+		common.AnyField("compacted", task.meta.Repr()),
 		common.AnyField("created", createdStr),
 		common.DurationField(time.Since(now)))
 	return


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6049 

## What this PR does / why we need it:

Recur transfer deletes to handle block compacted more than once