### PR TITLE
[Enhancement]: An expression optimizer rule for tpch q7 #6560

### DIFF
--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -2033,6 +2033,13 @@ func (builder *QueryBuilder) pushdownFilters(nodeID int32, filters []*plan.Expr)
 		canPushdown = filters
 		for _, filter := range node.FilterList {
 			canPushdown = append(canPushdown, splitPlanConjunction(applyDistributivity(filter))...)
+			keys := checkDNF(filter)
+			for _, key := range keys {
+				extraFilter := walkThroughDNF(filter, key)
+				if extraFilter != nil {
+					canPushdown = append(canPushdown, DeepCopyExpr(extraFilter))
+				}
+			}
 		}
 
 		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], canPushdown)

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -365,7 +365,7 @@ func checkDNF(expr *plan.Expr) []string {
 }
 
 func walkThroughDNF(expr *plan.Expr, keywords string) *plan.Expr {
-	var retExpr *plan.Expr = nil
+	var retExpr *plan.Expr
 	switch exprImpl := expr.Expr.(type) {
 	case *plan.Expr_F:
 		if exprImpl.F.Func.ObjName == "or" {

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -330,6 +330,18 @@ func intersectSlice(left, right []string) []string {
 	return ret
 }
 
+/*
+DNF means disjunctive normal form, for example (a and b) or (c and d) or (e and f)
+if we have a DNF filter, for example (c1=1 and c2=1) or (c1=2 and c2=2)
+we can have extra filter: (c1=1 or c1=2) and (c2=1 or c2=2), which can be pushed down to optimize join
+
+checkDNF scan the expr and return all groups of cond
+for example (c1=1 and c2=1) or (c1=2 and c3=2), c1 is a group because it appears in all disjunctives
+and c2,c3 is not a group
+
+walkThroughDNF accept a keyword string, walk through the expr,
+and extract all the conds which contains the keyword
+*/
 func checkDNF(expr *plan.Expr) []string {
 	var ret []string
 	switch exprImpl := expr.Expr.(type) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6560

## What this PR does / why we need it:
deduce new filters from disjunctive normal form filters, which can be pushed down to optimize join.
in local tpch test with 1g data, reduce q7 time costs from 1s to 0.25s