### PR TITLE
fix delete in merge and enable delete3

### DIFF
--- a/pkg/vm/engine/tae/db/db_test.go
+++ b/pkg/vm/engine/tae/db/db_test.go
@@ -2797,7 +2797,7 @@ func TestImmutableIndexInAblk(t *testing.T) {
 }
 
 func TestDelete3(t *testing.T) {
-	t.Skip(any("This case crashes occasionally, is being fixed, skip it for now"))
+	// t.Skip(any("This case crashes occasionally, is being fixed, skip it for now"))
 	defer testutils.AfterTest(t)()
 	opts := config.WithQuickScanAndCKPOpts(nil)
 	tae := newTestEngine(t, opts)

--- a/pkg/vm/engine/tae/db/db_test.go
+++ b/pkg/vm/engine/tae/db/db_test.go
@@ -2792,7 +2792,7 @@ func TestImmutableIndexInAblk(t *testing.T) {
 	_, err = meta.GetBlockData().GetByFilter(txn, filter)
 	assert.NoError(t, err)
 
-	err = meta.GetBlockData().BatchDedup(txn, bat.Vecs[1], nil)
+	err = meta.GetBlockData().BatchDedup(txn, bat.Vecs[1], nil, false)
 	assert.Error(t, err)
 }
 

--- a/pkg/vm/engine/tae/iface/data/block.go
+++ b/pkg/vm/engine/tae/iface/data/block.go
@@ -91,7 +91,7 @@ type Block interface {
 	// check wether any delete intents with prepared ts within [from, to]
 	HasDeleteIntentsPreparedIn(from, to types.TS) bool
 
-	BatchDedup(txn txnif.AsyncTxn, pks containers.Vector, rowmask *roaring.Bitmap) error
+	BatchDedup(txn txnif.AsyncTxn, pks containers.Vector, rowmask *roaring.Bitmap, precommit bool) error
 	GetByFilter(txn txnif.AsyncTxn, filter *handle.Filter) (uint32, error)
 	GetValue(txn txnif.AsyncTxn, row, col int) (any, error)
 	PPString(level common.PPLevel, depth int, prefix string) string

--- a/pkg/vm/engine/tae/tables/block.go
+++ b/pkg/vm/engine/tae/tables/block.go
@@ -868,10 +868,10 @@ func (blk *dataBlock) onCheckConflictAndDedup(
 			txn.GetTxnState(true)
 			blk.mvcc.RLock()
 		}
+		if err = appendnode.CheckConflict(conflictTS); err != nil {
+			return
+		}
 		if appendnode.IsAborted() || !appendnode.IsVisible(dedupTS) {
-			if err = appendnode.CheckConflict(conflictTS); err != nil {
-				return
-			}
 			return nil
 		}
 		deleteNode := blk.GetDeleteNodeByRow(row).(*updates.DeleteNode)
@@ -885,14 +885,11 @@ func (blk *dataBlock) onCheckConflictAndDedup(
 			txn.GetTxnState(true)
 			blk.mvcc.RLock()
 		}
-		if deleteNode.IsAborted() || !deleteNode.IsVisible(dedupTS) {
-			return moerr.GetOkExpectedDup()
-		}
-		if err = appendnode.CheckConflict(conflictTS); err != nil {
-			return
-		}
 		if err = deleteNode.CheckConflict(conflictTS); err != nil {
 			return
+		}
+		if deleteNode.IsAborted() || !deleteNode.IsVisible(dedupTS) {
+			return moerr.GetOkExpectedDup()
 		}
 		return nil
 	}

--- a/pkg/vm/engine/tae/tables/block.go
+++ b/pkg/vm/engine/tae/tables/block.go
@@ -856,20 +856,20 @@ func (blk *dataBlock) GetActiveRow(key any, ts types.TS) (row uint32, err error)
 func (blk *dataBlock) onCheckConflictAndDedup(
 	dupRow *uint32,
 	rowmask *roaring.Bitmap,
-	ts types.TS) func(row uint32) (err error) {
+	dedupTS, conflictTS types.TS) func(row uint32) (err error) {
 	return func(row uint32) (err error) {
 		if rowmask != nil && rowmask.Contains(row) {
 			return nil
 		}
 		appendnode := blk.GetAppendNodeByRow(row)
-		needWait, txn := appendnode.NeedWaitCommitting(ts)
+		needWait, txn := appendnode.NeedWaitCommitting(dedupTS)
 		if needWait {
 			blk.mvcc.RUnlock()
 			txn.GetTxnState(true)
 			blk.mvcc.RLock()
 		}
-		if appendnode.IsAborted() || !appendnode.IsVisible(ts) {
-			if err = appendnode.CheckConflict(ts); err != nil {
+		if appendnode.IsAborted() || !appendnode.IsVisible(dedupTS) {
+			if err = appendnode.CheckConflict(conflictTS); err != nil {
 				return
 			}
 			return nil
@@ -879,19 +879,19 @@ func (blk *dataBlock) onCheckConflictAndDedup(
 			*dupRow = row
 			return moerr.GetOkExpectedDup()
 		}
-		needWait, txn = deleteNode.NeedWaitCommitting(ts)
+		needWait, txn = deleteNode.NeedWaitCommitting(dedupTS)
 		if needWait {
 			blk.mvcc.RUnlock()
 			txn.GetTxnState(true)
 			blk.mvcc.RLock()
 		}
-		if deleteNode.IsAborted() || !deleteNode.IsVisible(ts) {
+		if deleteNode.IsAborted() || !deleteNode.IsVisible(dedupTS) {
 			return moerr.GetOkExpectedDup()
 		}
-		if err = appendnode.CheckConflict(ts); err != nil {
+		if err = appendnode.CheckConflict(conflictTS); err != nil {
 			return
 		}
-		if err = deleteNode.CheckConflict(ts); err != nil {
+		if err = deleteNode.CheckConflict(conflictTS); err != nil {
 			return
 		}
 		return nil
@@ -900,7 +900,7 @@ func (blk *dataBlock) onCheckConflictAndDedup(
 
 func (blk *dataBlock) dedupWithPK(
 	keys containers.Vector,
-	ts types.TS,
+	dedupTS, conflictTS types.TS,
 	rowmask *roaring.Bitmap) (selects *roaring.Bitmap, dupRow uint32, err error) {
 	blk.mvcc.RLock()
 	defer blk.mvcc.RUnlock()
@@ -909,7 +909,8 @@ func (blk *dataBlock) dedupWithPK(
 		blk.onCheckConflictAndDedup(
 			&dupRow,
 			rowmask,
-			ts),
+			dedupTS,
+			conflictTS),
 	)
 	return
 }
@@ -924,19 +925,22 @@ func (blk *dataBlock) DumpData(attr string) (view *model.ColumnView, err error) 
 	return
 }
 
-func (blk *dataBlock) BatchDedup(txn txnif.AsyncTxn, pks containers.Vector, rowmask *roaring.Bitmap) (err error) {
+func (blk *dataBlock) BatchDedup(txn txnif.AsyncTxn, pks containers.Vector, rowmask *roaring.Bitmap, precommit bool) (err error) {
 	defer func() {
 		if moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry) {
 			logutil.Infof("BatchDedup BLK-%d: %v", blk.meta.ID, err)
 		}
 	}()
+	ts := txn.GetStartTS()
+	if precommit {
+		ts = txn.GetPrepareTS()
+	}
 	var dupRow uint32
 	if blk.meta.IsAppendable() {
-		ts := txn.GetStartTS()
 		blk.mvcc.RLock()
 		defer blk.mvcc.RUnlock()
 		var keyselects *roaring.Bitmap
-		keyselects, err = blk.pkIndex.BatchDedup(pks, blk.onCheckConflictAndDedup(&dupRow, rowmask, ts))
+		keyselects, err = blk.pkIndex.BatchDedup(pks, blk.onCheckConflictAndDedup(&dupRow, rowmask, ts, txn.GetStartTS()))
 		if err == nil {
 			return
 		}
@@ -949,7 +953,7 @@ func (blk *dataBlock) BatchDedup(txn txnif.AsyncTxn, pks containers.Vector, rowm
 			var sortKey *model.ColumnView
 			sortKey, err = blk.ResolveColumnFromMeta(
 				metaLoc,
-				txn.GetStartTS(),
+				ts,
 				pkDef.Idx,
 				nil)
 			if err != nil {
@@ -977,7 +981,7 @@ func (blk *dataBlock) BatchDedup(txn txnif.AsyncTxn, pks containers.Vector, rowm
 		return err
 	}
 
-	keyselects, _, err := blk.dedupWithPK(pks, txn.GetStartTS(), rowmask)
+	keyselects, _, err := blk.dedupWithPK(pks, ts, txn.GetStartTS(), rowmask)
 	if err == nil {
 		return
 	}
@@ -988,11 +992,18 @@ func (blk *dataBlock) BatchDedup(txn txnif.AsyncTxn, pks containers.Vector, rowm
 	metaLoc := blk.meta.GetMetaLoc()
 	sortKey, err := blk.ResolveColumnFromMeta(
 		metaLoc,
-		txn.GetStartTS(),
+		ts,
 		pkDef.Idx,
 		nil)
 	if err != nil {
 		return
+	}
+	if rowmask != nil {
+		if sortKey.DeleteMask == nil {
+			sortKey.DeleteMask = rowmask
+		} else {
+			sortKey.DeleteMask.Or(rowmask)
+		}
 	}
 	defer sortKey.Close()
 	deduplicate := func(v any, _ int) error {

--- a/pkg/vm/engine/tae/tables/block.go
+++ b/pkg/vm/engine/tae/tables/block.go
@@ -960,6 +960,13 @@ func (blk *dataBlock) BatchDedup(txn txnif.AsyncTxn, pks containers.Vector, rowm
 				return
 			}
 			defer sortKey.Close()
+			if rowmask != nil {
+				if sortKey.DeleteMask == nil {
+					sortKey.DeleteMask = rowmask
+				} else {
+					sortKey.DeleteMask.Or(rowmask)
+				}
+			}
 			deduplicate := func(v1 any, _ int) error {
 				return sortKey.GetData().Foreach(func(v2 any, row int) error {
 					if sortKey.DeleteMask != nil && sortKey.DeleteMask.ContainsInt(row) {

--- a/pkg/vm/engine/tae/txn/txnimpl/block.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/block.go
@@ -161,7 +161,7 @@ func (blk *txnBlock) Fingerprint() *common.ID { return blk.entry.AsCommonID() }
 func (blk *txnBlock) BatchDedup(pks containers.Vector, invisibility *roaring.Bitmap) (err error) {
 	blkData := blk.entry.GetBlockData()
 	blk.Txn.GetStore().LogBlockID(blk.getDBID(), blk.entry.GetSegment().GetTable().GetID(), blk.entry.GetID())
-	return blkData.BatchDedup(blk.Txn, pks, invisibility)
+	return blkData.BatchDedup(blk.Txn, pks, invisibility, false)
 }
 
 func (blk *txnBlock) getDBID() uint64 {

--- a/pkg/vm/engine/tae/txn/txnimpl/table.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table.go
@@ -779,7 +779,7 @@ func (tbl *txnTable) Dedup(keys containers.Vector) (err error) {
 				rowmask = deleteNode.GetRowMaskRefLocked()
 			}
 		}
-		if err = blkData.BatchDedup(tbl.store.txn, keys, rowmask); err != nil {
+		if err = blkData.BatchDedup(tbl.store.txn, keys, rowmask, false); err != nil {
 			// logutil.Infof("%s, %s, %v", blk.String(), rowmask, err)
 			return
 		}
@@ -852,7 +852,7 @@ func (tbl *txnTable) PreCommitDedup(pks containers.Vector, preCommit bool) (err 
 					rowmask = deleteNode.GetRowMaskRefLocked()
 				}
 			}
-			if err = blkData.BatchDedup(tbl.store.txn, pks, rowmask); err != nil {
+			if err = blkData.BatchDedup(tbl.store.txn, pks, rowmask, true); err != nil {
 				return
 			}
 			blkIt.Next()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6562 

## What this PR does / why we need it:
1. dedup by maxts when preprepare.
2. prepare delete node in mergeblocks when create.
3. consume rowmask when dedup.