### PR TITLE
Add a mysql compatibility mode

### DIFF
--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -701,6 +701,21 @@ func TestSubQuery(t *testing.T) {
 	runTestShouldError(mock, t, sqls)
 }
 
+func TestMysqlCompatibilityMode(t *testing.T) {
+	mock := NewMockOptimizer()
+
+	sqls := []string{
+		"SELECT n_nationkey FROM NATION group by n_name",
+		"SELECT n_nationkey, min(n_name) FROM NATION",
+		"SELECT n_nationkey + 100 FROM NATION group by n_name",
+	}
+	// withou mysql compatibility
+	runTestShouldError(mock, t, sqls)
+	// with mysql compatibility
+	mock.ctxt.mysqlCompatible = true
+	runTestShouldPass(mock, t, sqls, false, false)
+}
+
 func TestTcl(t *testing.T) {
 	mock := NewMockOptimizer()
 	// should pass

--- a/pkg/sql/plan/mock.go
+++ b/pkg/sql/plan/mock.go
@@ -30,6 +30,8 @@ type MockCompilerContext struct {
 	tables  map[string]*TableDef
 	costs   map[string]*Cost
 	pks     map[string][]int
+
+	mysqlCompatible bool
 }
 
 func (m *MockCompilerContext) ResolveVariable(varName string, isSystemVar, isGlobalVar bool) (interface{}, error) {
@@ -41,6 +43,12 @@ func (m *MockCompilerContext) ResolveVariable(varName string, isSystemVar, isGlo
 	dec, _ := types.ParseStringToDecimal128("200.001", 2, 2, false)
 	vars["decimal_var"] = dec
 	vars["null_var"] = nil
+
+	if m.mysqlCompatible {
+		vars["sql_mode"] = ""
+	} else {
+		vars["sql_mode"] = "ONLY_FULL_GROUP_BY"
+	}
 
 	if result, ok := vars[varName]; ok {
 		return result, nil

--- a/pkg/sql/plan/mysql_compatibility.go
+++ b/pkg/sql/plan/mysql_compatibility.go
@@ -1,0 +1,47 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import "github.com/matrixorigin/matrixone/pkg/pb/plan"
+
+func (builder *QueryBuilder) wrapBareColRefsInAnyValue(expr *plan.Expr, ctx *BindContext) *plan.Expr {
+	switch exprImpl := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		if exprImpl.Col.RelPos == ctx.groupTag || exprImpl.Col.RelPos == ctx.aggregateTag {
+			return expr
+		}
+		newExpr, _ := bindFuncExprImplByPlanExpr("any_value", []*plan.Expr{expr})
+		colPos := len(ctx.aggregates)
+		ctx.aggregates = append(ctx.aggregates, newExpr)
+		return &plan.Expr{
+			Typ: ctx.aggregates[colPos].Typ,
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{
+					RelPos: ctx.aggregateTag,
+					ColPos: int32(colPos),
+				},
+			},
+		}
+
+	case *plan.Expr_F:
+		for i, arg := range exprImpl.F.Args {
+			exprImpl.F.Args[i] = builder.wrapBareColRefsInAnyValue(arg, ctx)
+		}
+		return expr
+
+	default:
+		return expr
+	}
+}

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -17,6 +17,7 @@ package plan
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -1318,7 +1319,18 @@ func (builder *QueryBuilder) buildSelect(stmt *tree.Select, ctx *BindContext, is
 	}
 
 	if (len(ctx.groups) > 0 || len(ctx.aggregates) > 0) && len(projectionBinder.boundCols) > 0 {
-		return 0, moerr.NewSyntaxError("column %q must appear in the GROUP BY clause or be used in an aggregate function", projectionBinder.boundCols[0])
+		mode, err := builder.compCtx.ResolveVariable("sql_mode", true, false)
+		if err != nil {
+			return 0, err
+		}
+		if strings.Contains(mode.(string), "ONLY_FULL_GROUP_BY") {
+			return 0, moerr.NewSyntaxError("column %q must appear in the GROUP BY clause or be used in an aggregate function", projectionBinder.boundCols[0])
+		}
+
+		// For MySQL compatibility, wrap bare ColRefs in any_value()
+		for i, proj := range ctx.projects {
+			ctx.projects[i] = builder.wrapBareColRefsInAnyValue(proj, ctx)
+		}
 	}
 
 	// FIXME: delete this when SINGLE join is ready


### PR DESCRIPTION
This affects behavior of queries with aggregation. When sql_mode doesn't contain ONLY_FULL_GROUP_BY, which is the default before mysql 8.0, columns that doesn't appear in GROUP BY clause or aggregate function will be automatically wrapped in an any_value aggregate.

Temporarily we use sql_mode, but after #6606 is implemented, we will shift to use mysql_compatibility_mode for all mysql compatibility issues.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6604

## What this PR does / why we need it: