### PR TITLE
[bug] fix bug #6526 that mo cannot restart.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 // see https://github.com/hashicorp/memberlist/pull/273 for progress
 replace github.com/hashicorp/memberlist => github.com/matrixorigin/memberlist v0.4.1-0.20221101065119-bb7bce164406
 
-replace github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef => github.com/matrixorigin/dragonboat/v4 v4.0.0-20221031100441-62f1755ca7ab
+replace github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef => github.com/matrixorigin/dragonboat/v4 v4.0.0-20221116064434-34611fc96385
 
 replace github.com/lni/vfs v0.2.1-0.20220616104132-8852fd867376 => github.com/matrixorigin/vfs v0.2.1-0.20220616104132-8852fd867376
 

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/matrixorigin/dragonboat/v4 v4.0.0-20221031100441-62f1755ca7ab h1:UK0Awi/SCT8OjSlVk34Dc4nVI2jUU8Ty+BWCcX3rB+0=
-github.com/matrixorigin/dragonboat/v4 v4.0.0-20221031100441-62f1755ca7ab/go.mod h1:bR6ZGoUwApH4/P4+AezNGT0xehljg+j+Z/Q2Fz+Y4a0=
+github.com/matrixorigin/dragonboat/v4 v4.0.0-20221116064434-34611fc96385 h1:x4k92fYYDFXqkYI5AL+A8ykry7Gq0R9EQPa+06si2uk=
+github.com/matrixorigin/dragonboat/v4 v4.0.0-20221116064434-34611fc96385/go.mod h1:bR6ZGoUwApH4/P4+AezNGT0xehljg+j+Z/Q2Fz+Y4a0=
 github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4 h1:+SmZP2bG+YcO/ntzjCleCu6hFTJiue7Oj2tftpJKTlU=
 github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4/go.mod h1:LIHvF0fflR+zyXUQFQOiHPpKANf3UIr7DFIv5CBPOoU=
 github.com/matrixorigin/memberlist v0.4.1-0.20221101065119-bb7bce164406 h1:/OUpnb/8qjNhxQeSJuYuFzzNQMaYrWbC5vVp2iiJqEI=


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6526, #6542, https://github.com/matrixorigin/MO-Cloud/issues/235

## What this PR does / why we need it:
If there are many logs need to replay when restart, it will take long time to replay logs because for every index entry, file is opened. And it causes timeout panic in tae to get logservice client as there is no leader elected before the logs are all replayed.

Replace db.getEntries() with a higher performance one in dragonboat/tan. The new one does not support multiplexed collection which is not used.

The original version almost open log file for each index entry which cause low performance.

The new version open file and keep reading log entries until we get a unavailble log entry identified by
(ies[passed].pos-offset)%blockSize != 0. And then reopen the log file from the position of latest index entry. The read operation ends until the size exceeds maxSize or index entires completes traversal.
