### PR TITLE
log: add a log printing framework

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -42,6 +42,7 @@
 /pkg/common/moerror @fengttt
 /pkg/common/morpc @zhangxu19830126
 /pkg/common/stopper @zhangxu19830126
+/pkg/common/log @zhangxu19830126
 
 # other directories under pkg
 /pkg/cnservice @nnsgmsone @reusee @daviszhen

--- a/pkg/common/log/doc.go
+++ b/pkg/common/log/doc.go
@@ -1,0 +1,25 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package log is used to control the log printing in MatrixOne.
+//
+// Printing logs using the Log package enables the following functions:
+//  1. Uniform logger name
+//  2. Support search all logs by service's uuid.
+//  3. Support search the operation logs of all related processes by process ID, e.g.
+//     search all logs of that transaction by transaction.
+//  4. Sampling and printing of frequently output logs.
+//  5. One line of code to add a time consuming log to a function.
+//  6. Support for using the mo_ctl function to control log printing.
+package log

--- a/pkg/common/log/example_log_test.go
+++ b/pkg/common/log/example_log_test.go
@@ -1,0 +1,131 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_test
+
+import (
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/log"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"go.uber.org/zap"
+)
+
+func ExampleGetServiceLogger() {
+	cnServiceLogger := log.GetServiceLogger(logutil.GetGlobalLogger(), log.CN, "cn0")
+	log.Info(cnServiceLogger).Log("this is a info log")
+	// Output logs:
+	// 2022/11/17 15:25:49.375367 +0800 INFO cn-service log/logger.go:51 this is a info log {"uuid": "cn0"}
+}
+
+func ExampleGetModuleLogger() {
+	cnServiceLogger := log.GetServiceLogger(logutil.GetGlobalLogger(), log.CN, "cn0")
+	txnClientLogger := log.GetModuleLogger(cnServiceLogger, log.TxnClient)
+	log.Info(txnClientLogger).Log("this is a info log")
+	// Output logs:
+	// 2022/11/17 15:27:24.562799 +0800 INFO cn-service.txn-client log/logger.go:51 this is a info log {"uuid": "cn0"}
+}
+
+func ExampleInfo() {
+	log.Info(logutil.GetGlobalLogger()).Log("this is a info log")
+	// Output logs:
+	// 2022/11/17 15:27:52.036861 +0800 INFO log/logger.go:51 this is a info log
+}
+
+func ExampleDebug() {
+	log.Debug(logutil.GetGlobalLogger()).Log("this is a debug log")
+	// Output logs:
+	// 2022/11/17 15:27:52.036861 +0800 DEBUG log/logger.go:51 this is a debug log
+}
+
+func ExampleError() {
+	log.Error(logutil.GetGlobalLogger()).Log("this is a error log")
+	// Output logs:
+	// 2022/11/17 15:27:52.036861 +0800 ERROR log/logger.go:51 this is a error log
+}
+
+func ExampleWarn() {
+	log.Warn(logutil.GetGlobalLogger()).Log("this is a warn log")
+	// Output logs:
+	// 2022/11/17 15:27:52.036861 +0800 WARN log/logger.go:51 this is a warn log
+}
+
+func ExamplePanic() {
+	log.Panic(logutil.GetGlobalLogger()).Log("this is a panic log")
+	// Output logs:
+	// 2022/11/17 15:27:52.036861 +0800 PANIC log/logger.go:51 this is a panic log
+	// panic stacks...
+}
+
+func ExampleFatal() {
+	log.Fatal(logutil.GetGlobalLogger()).Log("this is a fatal log")
+	// Output logs:
+	// 2022/11/17 15:27:52.036861 +0800 FATAL log/logger.go:51 this is a fatal log
+	// fatal stacks...
+}
+
+func ExampleLogContext_Log() {
+	log.Info(logutil.GetGlobalLogger()).Log("this is a example log",
+		zap.String("field-1", "field-1"),
+		zap.String("field-2", "field-2"))
+	// Output logs:
+	// 2022/11/17 15:27:52.036861 +0800 INFO log/logger.go:51 this is a example log {"field-1": "field-1", "field-2": "field-2"}
+}
+
+func ExampleLogContext_LogAction() {
+	someAction()
+	// Output logs:
+	// 2022/11/17 15:28:15.599321 +0800 INFO log/logger.go:51 do action
+	// 2022/11/17 15:28:16.600754 +0800 INFO log/logger.go:51 do action {"cost": "1.001430792s"}
+}
+
+func ExampleLogContext_WithProcess() {
+	processStep1InCN("txn uuid")
+	processStep2InDN("txn uuid")
+	processStep3InLOG("txn uuid")
+
+	// Output logs:
+	// 2022/11/17 15:36:04.724470 +0800 INFO cn-service log/logger.go:51 step 1 {"uuid": "cn0", "process": "txn", "process-id": "txn uuid"}
+	// 2022/11/17 15:36:04.724797 +0800 INFO dn-service log/logger.go:51 step 2 {"uuid": "dn0", "process": "txn", "process-id": "txn uuid"}
+	// 2022/11/17 15:36:04.724812 +0800 INFO log-service log/logger.go:51 step 3 {"uuid": "log0", "process": "txn", "process-id": "txn uuid"}
+}
+
+func ExampleLogContext_WithSampleLog() {
+	n := 10000
+	for i := 0; i < n; i++ {
+		log.Info(logutil.GetGlobalLogger()).WithSampleLog(log.ExampleSample, uint64(n)).Log("example sample log")
+	}
+	// Output logs:
+	// 2022/11/17 15:43:14.645242 +0800 INFO log/logger.go:51 example sample log
+}
+
+func someAction() {
+	defer log.Info(logutil.GetGlobalLogger()).LogAction("do action")()
+	time.Sleep(time.Second)
+}
+
+func processStep1InCN(id string) {
+	logger := log.GetServiceLogger(logutil.GetGlobalLogger(), log.CN, "cn0")
+	log.Info(logger).WithProcess(log.Txn, id).Log("step 1")
+}
+
+func processStep2InDN(id string) {
+	logger := log.GetServiceLogger(logutil.GetGlobalLogger(), log.DN, "dn0")
+	log.Info(logger).WithProcess(log.Txn, id).Log("step 2")
+}
+
+func processStep3InLOG(id string) {
+	logger := log.GetServiceLogger(logutil.GetGlobalLogger(), log.LOG, "log0")
+	log.Info(logger).WithProcess(log.Txn, id).Log("step 3")
+}

--- a/pkg/common/log/filter.go
+++ b/pkg/common/log/filter.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"sync/atomic"
+)
+
+var (
+	// all log filters register here.
+	filters = []logFilter{sampleFilter}
+
+	// all SampleType register here.
+	samples = map[SampleType]*sampleValue{}
+)
+
+func sampleFilter(ctx LogContext) bool {
+	if ctx.sampleType == noneSample {
+		return true
+	}
+	if v, ok := samples[ctx.sampleType]; ok {
+		return v.incr()%ctx.samplefrequency == 0
+	}
+	return false
+}
+
+type sampleValue struct {
+	v uint64
+}
+
+func (s *sampleValue) incr() uint64 {
+	return atomic.AddUint64(&s.v, 1)
+}

--- a/pkg/common/log/filter.go
+++ b/pkg/common/log/filter.go
@@ -23,7 +23,9 @@ var (
 	filters = []logFilter{sampleFilter}
 
 	// all SampleType register here.
-	samples = map[SampleType]*sampleValue{}
+	samples = map[SampleType]*sampleValue{
+		ExampleSample: {},
+	}
 )
 
 func sampleFilter(ctx LogContext) bool {

--- a/pkg/common/log/filter_test.go
+++ b/pkg/common/log/filter_test.go
@@ -1,0 +1,29 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSampleFilter(t *testing.T) {
+	st := SampleType(1)
+	samples[st] = &sampleValue{}
+	ctx := Info(nil).WithSampleLog(st, 2)
+	assert.False(t, sampleFilter(ctx))
+	assert.True(t, sampleFilter(ctx))
+}

--- a/pkg/common/log/logger.go
+++ b/pkg/common/log/logger.go
@@ -1,0 +1,156 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// GetServiceLogger returns service logger, it will using the service as the logger name, and
+// append FieldNameServiceUUID field to the logger
+func GetServiceLogger(logger *zap.Logger, service ServiceType, uuid string) *zap.Logger {
+	return logger.Named(string(service)).With(zap.String(FieldNameServiceUUID, uuid))
+}
+
+// GetModuleLogger returns the module logger, it will add ".module" to logger name.
+// e.g. if the logger's name is cn-service, module is txn, the new logger's name is
+// "cn-service.txn".
+func GetModuleLogger(logger *zap.Logger, module Module) *zap.Logger {
+	return logger.Named(string(module))
+}
+
+// Log is the entry point for mo log printing. Return true to indicate that the log
+// is being recorded by the current LogContext.
+func (c LogContext) Log(msg string, fields ...zap.Field) bool {
+	if c.logger == nil {
+		panic("missing logger")
+	}
+
+	for _, fiter := range filters {
+		if !fiter(c) {
+			return false
+		}
+	}
+
+	if ce := c.logger.Check(c.level, msg); ce != nil {
+		if len(c.fields) == 0 {
+			c.fields = fields
+		} else {
+			c.fields = append(c.fields, fields...)
+		}
+
+		ce.Write(c.fields...)
+		return true
+	}
+	return false
+}
+
+// LogAction used to log an action, or generate 2 logs, the first log occurring
+// at the place where the call is made and the second log occurring at the end
+// of the function where the LogAction is called, with the additional time consuming.
+// e.g.:
+//
+//	func LogActionExample() {
+//	    defer log.Info(zapLogger).LogAction("example action")()
+//	}
+//
+// This method should often be used to log the elapsed time of a function and, as the
+// logs appear in pairs, can also be used to check whether a function has been executed.
+func (c LogContext) LogAction(action string, fields ...zap.Field) func() {
+	startAt := time.Now()
+	if !c.Log(action, fields...) {
+		return nothing
+	}
+	return func() {
+		fields = append(fields, zap.Duration(FieldNameCost, time.Since(startAt)))
+		c.Log(action, fields...)
+	}
+}
+
+// LogContext used to describe how log are recorded
+type LogContext struct {
+	logger          *zap.Logger
+	ctx             context.Context
+	level           zapcore.Level
+	fields          []zap.Field
+	sampleType      SampleType
+	samplefrequency uint64
+}
+
+// WithContext aappend ctx to the log context. Used to log trace information, e.g. trace id.
+func (c LogContext) WithContext(ctx context.Context) LogContext {
+	c.ctx = ctx
+	return c
+}
+
+// WithProcess if the current log belongs to a certain process, the process name and process ID
+// can be recorded. When analyzing the log, all related logs can be retrieved according to the
+// process ID.
+func (c LogContext) WithProcess(process Process, processID string) LogContext {
+	c.fields = append(c.fields,
+		zap.String(FieldNameProcess, string(process)),
+		zap.String(FieldNameProcessID, processID))
+	return c
+}
+
+// WithSampleLog sample print the log, using log counts as sampling frequency
+func (c LogContext) WithSampleLog(sampleType SampleType, frequency uint64) LogContext {
+	c.sampleType = sampleType
+	c.samplefrequency = frequency
+	return c
+}
+
+// Info info log context
+func Info(logger *zap.Logger) LogContext {
+	return defaultLogContext(logger, zap.InfoLevel)
+}
+
+// Error errror log context
+func Error(logger *zap.Logger) LogContext {
+	return defaultLogContext(logger, zap.ErrorLevel)
+}
+
+// Debug debug log context
+func Debug(logger *zap.Logger) LogContext {
+	return defaultLogContext(logger, zap.DebugLevel)
+}
+
+// Warn warn log context
+func Warn(logger *zap.Logger) LogContext {
+	return defaultLogContext(logger, zap.WarnLevel)
+}
+
+// Panic panic log context
+func Panic(logger *zap.Logger) LogContext {
+	return defaultLogContext(logger, zap.PanicLevel)
+}
+
+// Fatal fatal log context
+func Fatal(logger *zap.Logger) LogContext {
+	return defaultLogContext(logger, zap.FatalLevel)
+}
+
+func defaultLogContext(logger *zap.Logger, level zapcore.Level) LogContext {
+	return LogContext{
+		logger: logger,
+		level:  level,
+	}
+}
+
+func nothing() {}

--- a/pkg/common/log/logger.go
+++ b/pkg/common/log/logger.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -53,6 +54,9 @@ func (c LogContext) Log(msg string, fields ...zap.Field) bool {
 			c.fields = fields
 		} else {
 			c.fields = append(c.fields, fields...)
+		}
+		if c.ctx != nil {
+			c.fields = append(c.fields, trace.ContextField(c.ctx))
 		}
 
 		ce.Write(c.fields...)

--- a/pkg/common/log/types.go
+++ b/pkg/common/log/types.go
@@ -1,0 +1,77 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+// ServiceType used to describe which type of service the log belongs to
+type ServiceType string
+
+var (
+	// CN cn service type
+	CN = ServiceType("cn-service")
+	// DN dn service type
+	DN = ServiceType("dn-service")
+	// LOG log service type
+	LOG = ServiceType("log-service")
+)
+
+// Module used to describe which component module the log belongs to
+type Module string
+
+var (
+	// TxnClient txn client module
+	TxnClient = Module("txn-client")
+)
+
+var (
+	// FieldNameServiceUUID service uuid field name
+	FieldNameServiceUUID = "uuid"
+	// FieldNameProcess process of the mo, e.g. transaction
+	FieldNameProcess = "process"
+	// FieldNameProcessID the log of a processing process may be distributed in
+	// many places, we can search all the logs associated with the current process
+	// by process-id. For example, we can use the transaction ID as process-id to
+	// find all logs of this transaction in the cluster.
+	FieldNameProcessID = "process-id"
+	// FieldNameCost cost field name, this field is used to log how long a function,
+	// operation or other action takes
+	FieldNameCost = "cost"
+)
+
+// Process used to describe which process the log belongs to. We can filter out all
+// process-related logs by specifying the process field as the value to analyse the
+// logs.
+type Process string
+
+var (
+	// SystemInit system init process
+	SystemInit = Process("system-init")
+	// Txn transaction process
+	Txn = Process("txn")
+	// Close close serivce or components process. e.g. close cn/dn/log service
+	Close = Process("close")
+)
+
+// SampleType there are some behaviours in the system that print debug logs frequently,
+// such as the scheduling of HAKeeper, which may print hundreds of logs a second. What
+// these logs do is that these behaviours are still happening at debug level. So we just
+// need to sample the output.
+type SampleType int
+
+var (
+	noneSample = SampleType(0)
+)
+
+// logFilter used to filter the print log, returns false to abort this print
+type logFilter func(ctx LogContext) bool

--- a/pkg/common/log/types.go
+++ b/pkg/common/log/types.go
@@ -14,6 +14,8 @@
 
 package log
 
+import "math"
+
 // ServiceType used to describe which type of service the log belongs to
 type ServiceType string
 
@@ -71,6 +73,8 @@ type SampleType int
 
 var (
 	noneSample = SampleType(0)
+	// ExampleSample used in examples
+	ExampleSample = SampleType(math.MaxInt)
 )
 
 // logFilter used to filter the print log, returns false to abort this print


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #5048 

## What this PR does / why we need it:
Add log framework. Printing logs using the Log package enables the following functions:
 1. Uniform logger name
 2. Support search all logs by service's uuid.
 3. Support search the operation logs of all related processes by process ID, e.g.
     search all logs of that transaction by transaction.
 4. Sampling and printing of frequently output logs.
 5. One line of code to add a time consuming log to a function.
 6. Support for using the mo_ctl function to control log printing.