### PR TITLE
Fix compute range by int pk oom  for 0.6

### DIFF
--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -335,3 +335,9 @@ func (w *workspaceRow) Indexes() []memtable.Tuple {
 func (w *workspaceRow) UniqueIndexes() []memtable.Tuple {
 	return nil
 }
+
+type pkRange struct {
+	isRange bool
+	items   []int64
+	ranges  []int64
+}

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -394,7 +394,7 @@ func computeRangeByNonIntPk(expr *plan.Expr, pkIdx int32) (bool, uint64) {
 // only under the following conditions：
 // 1、function named ["and", "or", ">", "<", ">=", "<=", "="]
 // 2、if function name is not "and", "or".  then one arg is column, the other is constant
-func computeRangeByIntPk(expr *plan.Expr, pkIdx int32, parentFun string) (bool, [][2]int64) {
+func computeRangeByIntPk(expr *plan.Expr, pkIdx int32, parentFun string) (bool, *pkRange) {
 	type argType int
 	var typeConstant argType = 0
 	var typeColumn argType = 1
@@ -443,9 +443,9 @@ func computeRangeByIntPk(expr *plan.Expr, pkIdx int32, parentFun string) (bool, 
 			}
 
 			if funName == "and" {
-				return true, _computeAnd(leftRange, rightRange)
+				return _computeAnd(leftRange, rightRange)
 			} else {
-				return true, _computeOr(leftRange, rightRange)
+				return _computeOr(leftRange, rightRange)
 			}
 
 		case ">", "<", ">=", "<=", "=":
@@ -461,7 +461,9 @@ func computeRangeByIntPk(expr *plan.Expr, pkIdx int32, parentFun string) (bool, 
 				if subExpr.Col.ColPos != pkIdx {
 					// if  pk > 10 and noPk < 10.  we just use pk > 10
 					if parentFun == "and" {
-						return true, [][2]int64{}
+						return true, &pkRange{
+							isRange: false,
+						}
 					}
 					// if pk > 10 or noPk < 10,   we use all list
 					return false, nil
@@ -481,15 +483,30 @@ func computeRangeByIntPk(expr *plan.Expr, pkIdx int32, parentFun string) (bool, 
 					}
 					switch funName {
 					case ">":
-						return true, [][2]int64{{rightConstat + 1, math.MaxInt64}}
+						return true, &pkRange{
+							isRange: true,
+							ranges:  []int64{rightConstat + 1, math.MaxInt64},
+						}
 					case ">=":
-						return true, [][2]int64{{rightConstat, math.MaxInt64}}
+						return true, &pkRange{
+							isRange: true,
+							ranges:  []int64{rightConstat, math.MaxInt64},
+						}
 					case "<":
-						return true, [][2]int64{{math.MinInt64, rightConstat - 1}}
+						return true, &pkRange{
+							isRange: true,
+							ranges:  []int64{math.MinInt64, rightConstat - 1},
+						}
 					case "<=":
-						return true, [][2]int64{{math.MinInt64, rightConstat}}
+						return true, &pkRange{
+							isRange: true,
+							ranges:  []int64{math.MinInt64, rightConstat},
+						}
 					case "=":
-						return true, [][2]int64{{rightConstat, rightConstat}}
+						return true, &pkRange{
+							isRange: false,
+							items:   []int64{rightConstat},
+						}
 					}
 					return false, nil
 				}
@@ -497,7 +514,9 @@ func computeRangeByIntPk(expr *plan.Expr, pkIdx int32, parentFun string) (bool, 
 				if subExpr.Col.ColPos != pkIdx {
 					// if  pk > 10 and noPk < 10.  we just use pk > 10
 					if parentFun == "and" {
-						return true, [][2]int64{}
+						return true, &pkRange{
+							isRange: false,
+						}
 					}
 					// if pk > 10 or noPk < 10,   we use all list
 					return false, nil
@@ -506,15 +525,30 @@ func computeRangeByIntPk(expr *plan.Expr, pkIdx int32, parentFun string) (bool, 
 				if leftArg == typeConstant {
 					switch funName {
 					case ">":
-						return true, [][2]int64{{math.MinInt64, leftConstant - 1}}
+						return true, &pkRange{
+							isRange: true,
+							ranges:  []int64{math.MinInt64, leftConstant - 1},
+						}
 					case ">=":
-						return true, [][2]int64{{math.MinInt64, leftConstant}}
+						return true, &pkRange{
+							isRange: true,
+							ranges:  []int64{math.MinInt64, leftConstant},
+						}
 					case "<":
-						return true, [][2]int64{{leftConstant + 1, math.MaxInt64}}
+						return true, &pkRange{
+							isRange: true,
+							ranges:  []int64{leftConstant + 1, math.MaxInt64},
+						}
 					case "<=":
-						return true, [][2]int64{{leftConstant, math.MaxInt64}}
+						return true, &pkRange{
+							isRange: true,
+							ranges:  []int64{leftConstant, math.MaxInt64},
+						}
 					case "=":
-						return true, [][2]int64{{leftConstant, leftConstant}}
+						return true, &pkRange{
+							isRange: false,
+							items:   []int64{leftConstant},
+						}
 					}
 					return false, nil
 				}
@@ -525,14 +559,83 @@ func computeRangeByIntPk(expr *plan.Expr, pkIdx int32, parentFun string) (bool, 
 	return false, nil
 }
 
-func _computeAnd(leftRange [][2]int64, rightRange [][2]int64) [][2]int64 {
-	if len(leftRange) == 0 {
-		return rightRange
-	} else if len(rightRange) == 0 {
-		return leftRange
+func _computeOr(left *pkRange, right *pkRange) (bool, *pkRange) {
+	result := &pkRange{
+		isRange: false,
+		items:   []int64{},
 	}
 
-	compute := func(left [2]int64, right [2]int64) (bool, [2]int64) {
+	compute := func(left []int64, right []int64) [][]int64 {
+		min := left[0]
+		max := left[1]
+		if min > right[1] {
+			// eg: a > 10 or a < 2
+			return [][]int64{left, right}
+		} else if max < right[0] {
+			// eg: a < 2 or a > 10
+			return [][]int64{left, right}
+		} else {
+			// eg: a > 2 or a < 10
+			// a > 2 or a > 10
+			// a > 2 or a = -2
+			if right[0] < min {
+				min = right[0]
+			}
+			if right[1] > max {
+				max = right[1]
+			}
+			return [][]int64{{min, max}}
+		}
+	}
+
+	if !left.isRange {
+		if !right.isRange {
+			result.items = append(left.items, right.items...)
+			return len(result.items) < int(MAX_RANGE_SIZE), result
+		} else {
+			r := right.ranges
+			if r[0] == math.MinInt64 || r[1] == math.MaxInt64 || r[1]-r[0] > MAX_RANGE_SIZE {
+				return false, nil
+			}
+			result.items = append(result.items, left.items...)
+			for i := right.ranges[0]; i <= right.ranges[1]; i++ {
+				result.items = append(result.items, i)
+			}
+			return len(result.items) < int(MAX_RANGE_SIZE), result
+		}
+	} else {
+		if !right.isRange {
+			r := left.ranges
+			if r[0] == math.MinInt64 || r[1] == math.MaxInt64 || r[1]-r[0] > MAX_RANGE_SIZE {
+				return false, nil
+			}
+			result.items = append(result.items, right.items...)
+			for i := left.ranges[0]; i <= left.ranges[1]; i++ {
+				result.items = append(result.items, i)
+			}
+			return len(result.items) < int(MAX_RANGE_SIZE), result
+		} else {
+			newRange := compute(left.ranges, right.ranges)
+			for _, r := range newRange {
+				if r[0] == math.MinInt64 || r[1] == math.MaxInt64 || r[1]-r[0] > MAX_RANGE_SIZE {
+					return false, nil
+				}
+				for i := r[0]; i <= r[1]; i++ {
+					result.items = append(result.items, i)
+				}
+			}
+			return len(result.items) < int(MAX_RANGE_SIZE), result
+		}
+	}
+}
+
+func _computeAnd(left *pkRange, right *pkRange) (bool, *pkRange) {
+	result := &pkRange{
+		isRange: false,
+		items:   []int64{},
+	}
+
+	compute := func(left []int64, right []int64) (bool, []int64) {
 		min := left[0]
 		max := left[1]
 
@@ -552,65 +655,50 @@ func _computeAnd(leftRange [][2]int64, rightRange [][2]int64) [][2]int64 {
 			if right[1] < max {
 				max = right[1]
 			}
-			return true, [2]int64{min, max}
-		}
-
-	}
-
-	// eg: (a >3 or a=1) and (a < 10 or a =11)
-	var newRange [][2]int64
-	for _, left := range leftRange {
-		for _, right := range rightRange {
-			ok, tmp := compute(left, right)
-			if ok {
-				newRange = append(newRange, tmp)
-			}
+			return true, []int64{min, max}
 		}
 	}
 
-	return newRange
-}
-
-func _computeOr(leftRange [][2]int64, rightRange [][2]int64) [][2]int64 {
-	if len(leftRange) == 0 {
-		return rightRange
-	} else if len(rightRange) == 0 {
-		return leftRange
-	}
-
-	compute := func(left [2]int64, right [2]int64) [][2]int64 {
-		min := left[0]
-		max := left[1]
-		if min > right[1] {
-			// eg: a > 10 or a < 2
-			return [][2]int64{left, right}
-		} else if max < right[0] {
-			// eg: a < 2 or a > 10
-			return [][2]int64{left, right}
+	if !left.isRange {
+		if !right.isRange {
+			result.items = append(left.items, right.items...)
+			return len(result.items) < int(MAX_RANGE_SIZE), result
 		} else {
-			// eg: a > 2 or a < 10
-			// a > 2 or a > 10
-			// a > 2 or a = -2
-			if right[0] < min {
-				min = right[0]
+			r := right.ranges
+			if r[0] == math.MinInt64 || r[1] == math.MaxInt64 || r[1]-r[0] > MAX_RANGE_SIZE {
+				return false, nil
 			}
-			if right[1] > max {
-				max = right[1]
+			result.items = append(result.items, left.items...)
+			for i := right.ranges[0]; i <= right.ranges[1]; i++ {
+				result.items = append(result.items, i)
 			}
-			return [][2]int64{{min, max}}
+			return len(result.items) < int(MAX_RANGE_SIZE), result
+		}
+	} else {
+		if !right.isRange {
+			r := left.ranges
+			if r[0] == math.MinInt64 || r[1] == math.MaxInt64 || r[1]-r[0] > MAX_RANGE_SIZE {
+				return false, nil
+			}
+			result.items = append(result.items, right.items...)
+			for i := left.ranges[0]; i <= left.ranges[1]; i++ {
+				result.items = append(result.items, i)
+			}
+			return len(result.items) < int(MAX_RANGE_SIZE), result
+		} else {
+			ok, r := compute(left.ranges, right.ranges)
+			if !ok {
+				return false, nil
+			}
+			if r[0] == math.MinInt64 || r[1] == math.MaxInt64 || r[1]-r[0] > MAX_RANGE_SIZE {
+				return false, nil
+			}
+			for i := r[0]; i <= r[1]; i++ {
+				result.items = append(result.items, i)
+			}
+			return len(result.items) < int(MAX_RANGE_SIZE), result
 		}
 	}
-
-	// eg: (a>10 or a=1) or (a<5 or a=6)
-	var newRange [][2]int64
-	for _, left := range leftRange {
-		for _, right := range rightRange {
-			tmp := compute(left, right)
-			newRange = append(newRange, tmp...)
-		}
-	}
-
-	return newRange
 }
 
 func getHashValue(buf []byte) uint64 {
@@ -622,8 +710,7 @@ func getHashValue(buf []byte) uint64 {
 	hashtable.BytesBatchGenHashStates(&buf, &states, 1)
 	return states[0]
 }
-
-func getListByRange[T DNStore](list []T, pkRange [][2]int64) []int {
+func getListByItems[T DNStore](list []T, items []int64) []int {
 	fullList := func() []int {
 		dnList := make([]int, len(list))
 		for i := range list {
@@ -631,25 +718,25 @@ func getListByRange[T DNStore](list []T, pkRange [][2]int64) []int {
 		}
 		return dnList
 	}
+
 	listLen := uint64(len(list))
-	if listLen == 1 || len(pkRange) == 0 {
+	if listLen == 1 {
 		return []int{0}
 	}
 
+	if len(items) == 0 || int64(len(items)) > MAX_RANGE_SIZE {
+		return fullList()
+	}
+
 	listMap := make(map[uint64]struct{})
-	for _, r := range pkRange {
-		if r[1]-r[0] > MAX_RANGE_SIZE {
+	for _, item := range items {
+		keys := make([]byte, 8)
+		binary.LittleEndian.PutUint64(keys, uint64(item))
+		val := getHashValue(keys)
+		modVal := val % listLen
+		listMap[modVal] = struct{}{}
+		if len(listMap) == int(listLen) {
 			return fullList()
-		}
-		for i := r[0]; i <= r[1]; i++ {
-			keys := make([]byte, 8)
-			binary.LittleEndian.PutUint64(keys, uint64(i))
-			val := getHashValue(keys)
-			modVal := val % listLen
-			listMap[modVal] = struct{}{}
-			if len(listMap) == int(listLen) {
-				return fullList()
-			}
 		}
 	}
 	dnList := make([]int, len(listMap))
@@ -660,6 +747,44 @@ func getListByRange[T DNStore](list []T, pkRange [][2]int64) []int {
 	}
 	return dnList
 }
+
+// func getListByRange[T DNStore](list []T, pkRange [][2]int64) []int {
+// 	fullList := func() []int {
+// 		dnList := make([]int, len(list))
+// 		for i := range list {
+// 			dnList[i] = i
+// 		}
+// 		return dnList
+// 	}
+// 	listLen := uint64(len(list))
+// 	if listLen == 1 || len(pkRange) == 0 {
+// 		return []int{0}
+// 	}
+
+// 	listMap := make(map[uint64]struct{})
+// 	for _, r := range pkRange {
+// 		if r[1]-r[0] > MAX_RANGE_SIZE {
+// 			return fullList()
+// 		}
+// 		for i := r[0]; i <= r[1]; i++ {
+// 			keys := make([]byte, 8)
+// 			binary.LittleEndian.PutUint64(keys, uint64(i))
+// 			val := getHashValue(keys)
+// 			modVal := val % listLen
+// 			listMap[modVal] = struct{}{}
+// 			if len(listMap) == int(listLen) {
+// 				return fullList()
+// 			}
+// 		}
+// 	}
+// 	dnList := make([]int, len(listMap))
+// 	i := 0
+// 	for idx := range listMap {
+// 		dnList[i] = int(idx)
+// 		i++
+// 	}
+// 	return dnList
+// }
 
 func checkIfDataInBlock(data any, meta BlockMeta, colIdx int, typ types.Type) (bool, error) {
 	zm := index.NewZoneMap(typ)

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -17,7 +17,6 @@ package disttae
 import (
 	"bytes"
 	"context"
-	"math"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -417,25 +416,25 @@ func TestComputeRangeByNonIntPk(t *testing.T) {
 func TestComputeRangeByIntPk(t *testing.T) {
 	type asserts = struct {
 		result bool
-		data   [][2]int64
+		items  []int64
 		expr   *plan.Expr
 	}
 
 	testCases := []asserts{
 		// a > abs(20)   not support now
-		{false, [][2]int64{{21, math.MaxInt64}}, makeFunctionExprForTest("like", []*plan.Expr{
+		{false, []int64{21}, makeFunctionExprForTest("like", []*plan.Expr{
 			makeColExprForTest(0, types.T_int64),
 			makeFunctionExprForTest("abs", []*plan.Expr{
 				plan2.MakePlan2Int64ConstExprWithType(20),
 			}),
 		})},
 		// a > 20
-		{true, [][2]int64{{21, math.MaxInt64}}, makeFunctionExprForTest(">", []*plan.Expr{
+		{true, []int64{}, makeFunctionExprForTest(">", []*plan.Expr{
 			makeColExprForTest(0, types.T_int64),
 			plan2.MakePlan2Int64ConstExprWithType(20),
 		})},
 		// a > 20 and b < 1  is equal a > 20
-		{true, [][2]int64{{21, math.MaxInt64}}, makeFunctionExprForTest("and", []*plan.Expr{
+		{false, []int64{}, makeFunctionExprForTest("and", []*plan.Expr{
 			makeFunctionExprForTest(">", []*plan.Expr{
 				makeColExprForTest(0, types.T_int64),
 				plan2.MakePlan2Int64ConstExprWithType(20),
@@ -446,7 +445,7 @@ func TestComputeRangeByIntPk(t *testing.T) {
 			}),
 		})},
 		// 1 < b and a > 20   is equal a > 20
-		{true, [][2]int64{{21, math.MaxInt64}}, makeFunctionExprForTest("and", []*plan.Expr{
+		{false, []int64{}, makeFunctionExprForTest("and", []*plan.Expr{
 			makeFunctionExprForTest("<", []*plan.Expr{
 				plan2.MakePlan2Int64ConstExprWithType(1),
 				makeColExprForTest(1, types.T_int64),
@@ -457,7 +456,7 @@ func TestComputeRangeByIntPk(t *testing.T) {
 			}),
 		})},
 		// a > 20 or b < 1  false.
-		{false, [][2]int64{{21, math.MaxInt64}}, makeFunctionExprForTest("or", []*plan.Expr{
+		{false, []int64{}, makeFunctionExprForTest("or", []*plan.Expr{
 			makeFunctionExprForTest(">", []*plan.Expr{
 				makeColExprForTest(0, types.T_int64),
 				plan2.MakePlan2Int64ConstExprWithType(20),
@@ -468,23 +467,40 @@ func TestComputeRangeByIntPk(t *testing.T) {
 			}),
 		})},
 		// a = 20
-		{true, [][2]int64{{20, 20}}, makeFunctionExprForTest("=", []*plan.Expr{
+		{true, []int64{20}, makeFunctionExprForTest("=", []*plan.Expr{
 			makeColExprForTest(0, types.T_int64),
 			plan2.MakePlan2Int64ConstExprWithType(20),
 		})},
-		// a > 20 and a < 100
-		{true, [][2]int64{{21, 99}}, makeFunctionExprForTest("and", []*plan.Expr{
+		// a > 20 and a < =25
+		{true, []int64{21, 22, 23, 24, 25}, makeFunctionExprForTest("and", []*plan.Expr{
 			makeFunctionExprForTest(">", []*plan.Expr{
 				makeColExprForTest(0, types.T_int64),
 				plan2.MakePlan2Int64ConstExprWithType(20),
 			}),
-			makeFunctionExprForTest("<", []*plan.Expr{
+			makeFunctionExprForTest("<=", []*plan.Expr{
 				makeColExprForTest(0, types.T_int64),
-				plan2.MakePlan2Int64ConstExprWithType(100),
+				plan2.MakePlan2Int64ConstExprWithType(25),
+			}),
+		})},
+		// a > 20 and a <=25 and b > 100   todo： unsupport now。  when compute a <=25 and b > 10, we get items too much.
+		{false, []int64{21, 22, 23, 24, 25}, makeFunctionExprForTest("and", []*plan.Expr{
+			makeFunctionExprForTest(">", []*plan.Expr{
+				makeColExprForTest(0, types.T_int64),
+				plan2.MakePlan2Int64ConstExprWithType(20),
+			}),
+			makeFunctionExprForTest("and", []*plan.Expr{
+				makeFunctionExprForTest("<=", []*plan.Expr{
+					makeColExprForTest(0, types.T_int64),
+					plan2.MakePlan2Int64ConstExprWithType(25),
+				}),
+				makeFunctionExprForTest(">", []*plan.Expr{
+					makeColExprForTest(1, types.T_int64),
+					plan2.MakePlan2Int64ConstExprWithType(100),
+				}),
 			}),
 		})},
 		// a > 20 and a < 10  => empty
-		{true, [][2]int64{}, makeFunctionExprForTest("and", []*plan.Expr{
+		{false, []int64{}, makeFunctionExprForTest("and", []*plan.Expr{
 			makeFunctionExprForTest(">", []*plan.Expr{
 				makeColExprForTest(0, types.T_int64),
 				plan2.MakePlan2Int64ConstExprWithType(20),
@@ -494,30 +510,36 @@ func TestComputeRangeByIntPk(t *testing.T) {
 				plan2.MakePlan2Int64ConstExprWithType(10),
 			}),
 		})},
-		// a < 20 or a > 100
-		{true, [][2]int64{{math.MinInt64, 19}, {101, math.MaxInt64}}, makeFunctionExprForTest("or", []*plan.Expr{
+		// a < 20 or 100 < a
+		{false, []int64{}, makeFunctionExprForTest("or", []*plan.Expr{
 			makeFunctionExprForTest("<", []*plan.Expr{
 				makeColExprForTest(0, types.T_int64),
 				plan2.MakePlan2Int64ConstExprWithType(20),
 			}),
-			makeFunctionExprForTest(">", []*plan.Expr{
-				makeColExprForTest(0, types.T_int64),
-				plan2.MakePlan2Int64ConstExprWithType(100),
-			}),
-		})},
-		// a < 20 or a > 100
-		{true, [][2]int64{{math.MinInt64, 19}, {101, math.MaxInt64}}, makeFunctionExprForTest("or", []*plan.Expr{
 			makeFunctionExprForTest("<", []*plan.Expr{
-				makeColExprForTest(0, types.T_int64),
-				plan2.MakePlan2Int64ConstExprWithType(20),
-			}),
-			makeFunctionExprForTest(">", []*plan.Expr{
-				makeColExprForTest(0, types.T_int64),
 				plan2.MakePlan2Int64ConstExprWithType(100),
+				makeColExprForTest(0, types.T_int64),
 			}),
 		})},
-		// (a >5 or a=1) and (a < 8 or a =11) => 1,6,7,11
-		{true, [][2]int64{{6, 7}, {11, 11}, {1, 1}}, makeFunctionExprForTest("and", []*plan.Expr{
+		// a =1 or a = 2 or a=30
+		{true, []int64{2, 1, 30}, makeFunctionExprForTest("or", []*plan.Expr{
+			makeFunctionExprForTest("=", []*plan.Expr{
+				makeColExprForTest(0, types.T_int64),
+				plan2.MakePlan2Int64ConstExprWithType(2),
+			}),
+			makeFunctionExprForTest("or", []*plan.Expr{
+				makeFunctionExprForTest("=", []*plan.Expr{
+					makeColExprForTest(0, types.T_int64),
+					plan2.MakePlan2Int64ConstExprWithType(1),
+				}),
+				makeFunctionExprForTest("=", []*plan.Expr{
+					makeColExprForTest(0, types.T_int64),
+					plan2.MakePlan2Int64ConstExprWithType(30),
+				}),
+			}),
+		})},
+		// (a >5 or a=1) and (a < 8 or a =11) => 1,6,7,11  todo,  now can't compute now
+		{false, []int64{6, 7, 11, 1}, makeFunctionExprForTest("and", []*plan.Expr{
 			makeFunctionExprForTest("or", []*plan.Expr{
 				makeFunctionExprForTest(">", []*plan.Expr{
 					makeColExprForTest(0, types.T_int64),
@@ -548,11 +570,11 @@ func TestComputeRangeByIntPk(t *testing.T) {
 				t.Fatalf("test computeRangeByIntPk at cases[%d], get result is different with expected", i)
 			}
 			if result {
-				if len(data) != len(testCase.data) {
+				if len(data.items) != len(testCase.items) {
 					t.Fatalf("test computeRangeByIntPk at cases[%d], data length is not match", i)
 				}
-				for j, r := range testCase.data {
-					if r[0] != data[j][0] || r[1] != data[j][1] {
+				for j, val := range testCase.items {
+					if data.items[j] != val {
 						t.Fatalf("test computeRangeByIntPk at cases[%d], data[%d] is not match", i, j)
 					}
 				}
@@ -561,34 +583,34 @@ func TestComputeRangeByIntPk(t *testing.T) {
 	})
 }
 
-func TestGetListByRange(t *testing.T) {
-	type asserts = struct {
-		result []DNStore
-		list   []DNStore
-		r      [][2]int64
-	}
+// func TestGetListByRange(t *testing.T) {
+// 	type asserts = struct {
+// 		result []DNStore
+// 		list   []DNStore
+// 		r      [][2]int64
+// 	}
 
-	testCases := []asserts{
-		{[]DNStore{{UUID: "1"}, {UUID: "2"}}, []DNStore{{UUID: "1"}, {UUID: "2"}}, [][2]int64{{14, 32324234234234}}},
-		{[]DNStore{{UUID: "1"}}, []DNStore{{UUID: "1"}, {UUID: "2"}}, [][2]int64{{14, 14}}},
-	}
+// 	testCases := []asserts{
+// 		{[]DNStore{{UUID: "1"}, {UUID: "2"}}, []DNStore{{UUID: "1"}, {UUID: "2"}}, [][2]int64{{14, 32324234234234}}},
+// 		{[]DNStore{{UUID: "1"}}, []DNStore{{UUID: "1"}, {UUID: "2"}}, [][2]int64{{14, 14}}},
+// 	}
 
-	t.Run("test getListByRange", func(t *testing.T) {
-		for i, testCase := range testCases {
-			result := getListByRange(testCase.list, testCase.r)
-			if len(result) != len(testCase.result) {
-				t.Fatalf("test getListByRange at cases[%d], data length is not match", i)
-			}
-			/*
-				for j, r := range testCase.result {
-					if r.UUID != result[j].UUID {
-						t.Fatalf("test getListByRange at cases[%d], result[%d] is not match", i, j)
-					}
-				}
-			*/
-		}
-	})
-}
+// 	t.Run("test getListByRange", func(t *testing.T) {
+// 		for i, testCase := range testCases {
+// 			result := getListByRange(testCase.list, testCase.r)
+// 			if len(result) != len(testCase.result) {
+// 				t.Fatalf("test getListByRange at cases[%d], data length is not match", i)
+// 			}
+// 			/*
+// 				for j, r := range testCase.result {
+// 					if r.UUID != result[j].UUID {
+// 						t.Fatalf("test getListByRange at cases[%d], result[%d] is not match", i, j)
+// 					}
+// 				}
+// 			*/
+// 		}
+// 	})
+// }
 
 func TestCheckIfDataInBlock(t *testing.T) {
 	meta := BlockMeta{

--- a/test/cases/dml/select/select.test
+++ b/test/cases/dml/select/select.test
@@ -202,3 +202,7 @@ drop table if exists t1;
 create table if not exists t1(a int auto_increment primary key);
 drop table if exists t1;
 SELECT WORD FROM INFORMATION_SCHEMA.KEYWORDS WHERE RESERVED=1 ORDER BY WORD limit 1;
+drop table if exists t1;
+create table t1 (a int primary key, b int);
+select * from t1 WHERE (a IN ('1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','26','27','28','29') AND b = 0) ORDER BY `a` ASC;
+drop table if exists t1;

--- a/test/distributed/cases/dml/select/select.test
+++ b/test/distributed/cases/dml/select/select.test
@@ -202,3 +202,7 @@ drop table if exists t1;
 create table if not exists t1(a int auto_increment primary key);
 drop table if exists t1;
 SELECT WORD FROM INFORMATION_SCHEMA.KEYWORDS WHERE RESERVED=1 ORDER BY WORD limit 1;
+drop table if exists t1;
+create table t1 (a int primary key, b int);
+select * from t1 WHERE (a IN ('1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','26','27','28','29') AND b = 0) ORDER BY `a` ASC;
+drop table if exists t1;

--- a/test/distributed/result/dml/select/select.result
+++ b/test/distributed/result/dml/select/select.result
@@ -389,3 +389,8 @@ drop table if exists t1;
 SELECT WORD FROM INFORMATION_SCHEMA.KEYWORDS WHERE RESERVED=1 ORDER BY WORD limit 1;
 word
 ACCESSIBLE
+drop table if exists t1;
+create table t1 (a int primary key, b int);
+select * from t1 WHERE (a IN ('1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','26','27','28','29') AND b = 0) ORDER BY `a` ASC;
+a    b
+drop table if exists t1;

--- a/test/result/dml/select/select.result
+++ b/test/result/dml/select/select.result
@@ -389,3 +389,8 @@ drop table if exists t1;
 SELECT WORD FROM INFORMATION_SCHEMA.KEYWORDS WHERE RESERVED=1 ORDER BY WORD limit 1;
 word
 ACCESSIBLE
+drop table if exists t1;
+create table t1 (a int primary key, b int);
+select * from t1 WHERE (a IN ('1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16','17','18','19','20','21','26','27','28','29') AND b = 0) ORDER BY `a` ASC;
+a    b
+drop table if exists t1;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
fix bug: computeRangeByIntPk will oom.
change the compute logic, these change will use less mem. but not support less expr.
may be we can improve this function in the future.