### PR TITLE
[cherry pick]: revisit and optimize vector deletion operation (#6704)

### DIFF
--- a/pkg/vm/engine/tae/common/generator.go
+++ b/pkg/vm/engine/tae/common/generator.go
@@ -14,7 +14,32 @@
 
 package common
 
+type OffsetT interface {
+	int | uint32
+}
+
 type RowGen interface {
 	HasNext() bool
 	Next() uint32
+}
+
+type RowGenWrapper[T OffsetT] struct {
+	Sels []T
+	Idx  int
+}
+
+func NewRowGenWrapper[T OffsetT](sels ...T) *RowGenWrapper[T] {
+	return &RowGenWrapper[T]{
+		Sels: sels,
+	}
+}
+
+func (wrapper *RowGenWrapper[T]) HasNext() bool {
+	return wrapper.Idx < len(wrapper.Sels)
+}
+
+func (wrapper *RowGenWrapper[T]) Next() uint32 {
+	row := wrapper.Sels[wrapper.Idx]
+	wrapper.Idx++
+	return uint32(row)
 }

--- a/pkg/vm/engine/tae/common/hack.go
+++ b/pkg/vm/engine/tae/common/hack.go
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package common
 
 import (
+	"fmt"
+
 	"github.com/matrixorigin/matrixone/pkg/container/types"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 )
 
-func InplaceDeleteRowsFromSlice[T types.FixedSizeT](v any, rowGen common.RowGen) any {
+func InplaceDeleteRowsFromSlice[T types.FixedSizeT](v any, rowGen RowGen) any {
 	if !rowGen.HasNext() {
 		return v
 	}
@@ -38,7 +39,7 @@ func InplaceDeleteRowsFromSlice[T types.FixedSizeT](v any, rowGen common.RowGen)
 	return slice[:currPos]
 }
 
-func InplaceDeleteRows(orig any, rowGen common.RowGen) any {
+func InplaceDeleteRows(orig any, rowGen RowGen) any {
 	if !rowGen.HasNext() {
 		return orig
 	}
@@ -78,10 +79,14 @@ func InplaceDeleteRows(orig any, rowGen common.RowGen) any {
 		return InplaceDeleteRowsFromSlice[types.Date](arr, rowGen)
 	case []types.Datetime:
 		return InplaceDeleteRowsFromSlice[types.Datetime](arr, rowGen)
+	case []types.Time:
+		return InplaceDeleteRowsFromSlice[types.Time](arr, rowGen)
 	case []types.TS:
 		return InplaceDeleteRowsFromSlice[types.TS](arr, rowGen)
 	case []types.Rowid:
 		return InplaceDeleteRowsFromSlice[types.Rowid](arr, rowGen)
+	case []types.Varlena:
+		return InplaceDeleteRowsFromSlice[types.Varlena](arr, rowGen)
 	}
-	panic("not support")
+	panic(fmt.Sprintf("not support: %T", orig))
 }

--- a/pkg/vm/engine/tae/common/hack_test.go
+++ b/pkg/vm/engine/tae/common/hack_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package compute
+package common
 
 import (
 	"testing"

--- a/pkg/vm/engine/tae/containers/vecbase.go
+++ b/pkg/vm/engine/tae/containers/vecbase.go
@@ -64,10 +64,12 @@ func (base *vecBase[T]) tryCOW() {
 func (base *vecBase[T]) Update(i int, v any) { base.derived.stlvec.Update(i, v.(T)) }
 func (base *vecBase[T]) Delete(i int)        { base.derived.stlvec.Delete(i) }
 func (base *vecBase[T]) DeleteBatch(deletes *roaring.Bitmap) {
-	arr := deletes.ToArray()
-	for i := len(arr) - 1; i >= 0; i-- {
-		base.derived.stlvec.Delete(int(arr[i]))
+	if deletes == nil || deletes.IsEmpty() {
+		return
 	}
+	base.derived.stlvec.BatchDelete(
+		deletes.Iterator(),
+		int(deletes.GetCardinality()))
 }
 func (base *vecBase[T]) Append(v any) {
 	base.tryCOW()

--- a/pkg/vm/engine/tae/containers/vecimpl.go
+++ b/pkg/vm/engine/tae/containers/vecimpl.go
@@ -106,26 +106,17 @@ func (impl *nullableVecImpl[T]) Delete(i int) {
 func (impl *nullableVecImpl[T]) DeleteBatch(deletes *roaring.Bitmap) {
 	impl.tryCOW()
 	if !impl.HasNull() {
-		arr := deletes.ToArray()
-		for i := len(arr) - 1; i >= 0; i-- {
-			impl.vecBase.Delete(int(arr[i]))
-		}
+		impl.vecBase.DeleteBatch(deletes)
 		return
 	}
 	nulls := impl.derived.nulls
 	max := nulls.Maximum()
 	min := deletes.Minimum()
 	if max < uint64(min) {
-		arr := deletes.ToArray()
-		for i := len(arr) - 1; i >= 0; i-- {
-			impl.vecBase.Delete(int(arr[i]))
-		}
+		impl.vecBase.DeleteBatch(deletes)
 		return
 	} else if max == uint64(min) {
-		arr := deletes.ToArray()
-		for i := len(arr) - 1; i >= 0; i-- {
-			impl.vecBase.Delete(int(arr[i]))
-		}
+		impl.vecBase.DeleteBatch(deletes)
 		nulls.Remove(uint64(min))
 		return
 	}

--- a/pkg/vm/engine/tae/containers/vector_test.go
+++ b/pkg/vm/engine/tae/containers/vector_test.go
@@ -459,6 +459,7 @@ func TestCompact(t *testing.T) {
 	vec := MakeVector(types.T_varchar.ToType(), true, opts)
 
 	vec.Append(types.Null{})
+	t.Log(vec.String())
 	deletes := roaring.BitmapOf(0)
 	//{null}
 	vec.Compact(deletes)

--- a/pkg/vm/engine/tae/stl/containers/stdvec.go
+++ b/pkg/vm/engine/tae/stl/containers/stdvec.go
@@ -177,10 +177,21 @@ func (vec *StdVector[T]) Delete(i int) (deleted T) {
 	return
 }
 
-func (vec *StdVector[T]) RangeDelete(offset, length int) {
-	vec.slice = append(vec.slice[:offset], vec.slice[offset+length:]...)
-	size := len(vec.buf) - stl.SizeOfMany[T](length)
+func (vec *StdVector[T]) BatchDelete(rowGen common.RowGen, cnt int) {
+	common.InplaceDeleteRows(vec.slice, rowGen)
+	size := len(vec.buf) - stl.SizeOfMany[T](cnt)
+	vec.slice = unsafe.Slice((*T)(unsafe.Pointer(&vec.buf[0])), len(vec.slice)-cnt)
 	vec.buf = vec.buf[:size]
+}
+
+func (vec *StdVector[T]) BatchDeleteUint32s(sels ...uint32) {
+	gen := common.NewRowGenWrapper(sels...)
+	vec.BatchDelete(gen, len(sels))
+}
+
+func (vec *StdVector[T]) BatchDeleteInts(sels ...int) {
+	gen := common.NewRowGenWrapper(sels...)
+	vec.BatchDelete(gen, len(sels))
 }
 
 func (vec *StdVector[T]) AppendMany(vals ...T) {

--- a/pkg/vm/engine/tae/stl/types.go
+++ b/pkg/vm/engine/tae/stl/types.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 )
 
 func Sizeof[T any]() int {
@@ -107,8 +108,11 @@ type Vector[T any] interface {
 	Update(i int, v T)
 	// Delete deletes a element at i
 	Delete(i int) (deleted T)
-	// Delete deletes elements in [offset, offset+length)
-	RangeDelete(offset, length int)
+	// BatchDelete delete rows from rowGen
+	// cnt specifies the total delete count
+	BatchDelete(rowGen common.RowGen, cnt int)
+	BatchDeleteInts(sels ...int)
+	BatchDeleteUint32s(sels ...uint32)
 
 	// Returns the underlying memory allocator
 	GetAllocator() *mpool.MPool


### PR DESCRIPTION
For better performance.
+1000x faster than the current implementation if apply many deletes to a vector

Approved by: @LeftHandCold

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: