### PR TITLE
Adjust the parallelism of the pipeline according to the cost

### DIFF
--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -35,6 +35,11 @@ type (
 	TxnOperator = client.TxnOperator
 )
 
+// number of rows per core scheduled to be processed
+const (
+	Single_Core_Rows = 1000000
+)
+
 // type of scope
 const (
 	Merge = iota


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [X] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
A very simple improvement to modify the parallelism of the pipeline by cost. The current design is simple and assumes that a core needs to process at least 100w rows of data. A more systematic approach will be adopted later.