### PR TITLE
[Enhancement] Optimize the checker of logservice in hakeeper.

### DIFF
--- a/pkg/hakeeper/checkers/logservice/parse_test.go
+++ b/pkg/hakeeper/checkers/logservice/parse_test.go
@@ -69,19 +69,20 @@ func TestFixedLogShardInfo(t *testing.T) {
 			},
 		},
 		{
-			desc: "shard 1 has 2 replicas, which expected to be 3",
+			desc: "shard 1 has 3 replicas, which expected to be 1, and leader is the last to be removed",
 			record: metadata.LogShardRecord{
 				ShardID:          1,
-				NumberOfReplicas: 3,
+				NumberOfReplicas: 1,
 			},
 			info: pb.LogShardInfo{
 				ShardID:  1,
-				Replicas: map[uint64]string{1: "a", 2: "b"},
+				Replicas: map[uint64]string{1: "a", 2: "b", 3: "c"},
+				LeaderID: 2,
 			},
 			expected: &fixingShard{
 				shardID:  1,
-				replicas: map[uint64]string{1: "a", 2: "b"},
-				toAdd:    1,
+				replicas: map[uint64]string{2: "b"},
+				toAdd:    0,
 			},
 		},
 	}


### PR DESCRIPTION
When hakeeper decides to remove replicas, make sure the leader replica is the last one, which means we should remove follower replicas first.

In addition, add a slow log in appender.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: