### PR TITLE
Fix fileservice lru memory leak bug

### DIFF
--- a/pkg/fileservice/lru.go
+++ b/pkg/fileservice/lru.go
@@ -106,15 +106,15 @@ func (l *LRU) evict() {
 	}
 }
 
-func (l *LRU) Get(key any) (value any, ok bool) {
+func (l *LRU) Get(key any) (value any, size int64, ok bool) {
 	l.Lock()
 	defer l.Unlock()
 	if elem, ok := l.kv[key]; ok {
 		l.evicts.MoveToFront(elem)
 		item := elem.Value.(*lruItem)
-		return item.Value, true
+		return item.Value, item.Size, true
 	}
-	return nil, false
+	return nil, 0, false
 }
 
 func (l *LRU) Flush() {

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -60,9 +60,10 @@ func (m *MemCache) Read(
 			Offset: entry.Offset,
 			Size:   entry.Size,
 		}
-		obj, ok := m.lru.Get(key)
+		obj, size, ok := m.lru.Get(key)
 		if ok {
 			vector.Entries[i].Object = obj
+			vector.Entries[i].ObjectSize = size
 			vector.Entries[i].ignore = true
 			numHit++
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
lru.Get(key) in memcache.Read does not initialize ObjectSize, so that the 'replace' of lru.Set only reduces size and does not add size, and finally lru memory leaks