### PR TITLE
morpc: add check max body size in Encode

### DIFF
--- a/pkg/common/morpc/codec.go
+++ b/pkg/common/morpc/codec.go
@@ -69,6 +69,7 @@ func WithCodecMaxBodySize(size int) CodecOption {
 			size = defaultMaxMessageSize
 		}
 		c.codec = length.NewWithSize(c.bc, 0, 0, 0, size)
+		c.bc.maxBodySize = size
 	}
 }
 
@@ -91,6 +92,7 @@ type messageCodec struct {
 func NewMessageCodec(messageFactory func() Message, options ...CodecOption) Codec {
 	bc := &baseCodec{
 		messageFactory: messageFactory,
+		maxBodySize:    defaultMaxMessageSize,
 	}
 	c := &messageCodec{codec: length.NewWithSize(bc, 0, 0, 0, defaultMaxMessageSize), bc: bc}
 	c.AddHeaderCodec(&deadlineContextCodec{})
@@ -117,6 +119,7 @@ func (c *messageCodec) AddHeaderCodec(hc HeaderCodec) {
 type baseCodec struct {
 	enableChecksum bool
 	payloadBufSize int
+	maxBodySize    int
 	messageFactory func() Message
 	headerCodecs   []HeaderCodec
 }
@@ -201,7 +204,7 @@ func (c *baseCodec) Encode(data interface{}, out *buf.ByteBuf, conn io.Writer) e
 	totalSize += n
 
 	// 3.1 message body
-	bodySize, body, err := writeBody(out, msg.Message)
+	bodySize, body, err := c.writeBody(out, msg.Message, totalSize)
 	if err != nil {
 		return err
 	}
@@ -308,8 +311,16 @@ func writeUint64At(offset int, out *buf.ByteBuf, value uint64) {
 	buf.Uint64ToBytesTo(value, out.RawSlice(idx, idx+8))
 }
 
-func writeBody(out *buf.ByteBuf, msg Message) (int, []byte, error) {
+func (c *baseCodec) writeBody(out *buf.ByteBuf, msg Message, writtenSize int) (int, []byte, error) {
+	maxCanWrite := c.maxBodySize - writtenSize
 	size := msg.Size()
+	if size > maxCanWrite {
+		return 0, nil,
+			moerr.NewInternalError("message body %d is too large, max is %d",
+				size+writtenSize,
+				c.maxBodySize)
+	}
+
 	index, _ := setWriterIndexAfterGow(out, size)
 	data := out.RawSlice(index, index+size)
 	if _, err := msg.MarshalTo(data); err != nil {

--- a/pkg/common/morpc/codec_test.go
+++ b/pkg/common/morpc/codec_test.go
@@ -224,3 +224,18 @@ func TestBufferScale(t *testing.T) {
 		require.Equal(t, messages[i].Message, msg.(RPCMessage).Message)
 	}
 }
+
+func TestEncodeWithLargeMessageMustReturnError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
+	defer cancel()
+
+	maxBodySize := 1024
+	codec := newTestCodec(WithCodecMaxBodySize(maxBodySize))
+	buf1 := buf.NewByteBuf(32)
+	buf2 := buf.NewByteBuf(32)
+
+	msg := RPCMessage{Ctx: ctx, Message: newTestMessage(1)}
+	msg.Message.(*testMessage).payload = make([]byte, 1024)
+	err := codec.Encode(msg, buf1, buf2)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #
Add rpc message max body size check in Encode. And writes to the rpc will immediately return a hesitation message oversize error
## What this PR does / why we need it: