### PR TITLE
Remove test skip to reproduce goroutin leak in CI.

### DIFF
--- a/pkg/logservice/service_test.go
+++ b/pkg/logservice/service_test.go
@@ -636,8 +636,6 @@ func TestShardInfoCanBeQueried(t *testing.T) {
 }
 
 func TestGossipInSimulatedCluster(t *testing.T) {
-	t.Skip("need fix goroutine leak in memberlist lib, skip it now")
-
 	defer leaktest.AfterTest(t)()
 	debug.SetMemoryLimit(1 << 30)
 	// start all services


### PR DESCRIPTION
Cannot repro leak in local env, so remove the skip and try to repro leak in CI and get the leak stack.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #4992

## What this PR does / why we need it: