### PR TITLE
optimize for high concurrent small insert

### DIFF
--- a/pkg/vm/engine/tae/txn/txnimpl/node.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/node.go
@@ -344,7 +344,10 @@ func (n *insertNode) Append(data *containers.Batch, offset uint32) (an uint32, e
 	schema := n.table.entry.GetSchema()
 	if n.data == nil {
 		opts := new(containers.Options)
-		opts.Capacity = int(txnbase.MaxNodeRows)
+		opts.Capacity = data.Length() - int(offset)
+		if opts.Capacity > int(txnbase.MaxNodeRows) {
+			opts.Capacity = int(txnbase.MaxNodeRows)
+		}
 		n.data = containers.BuildBatch(
 			schema.AllNames(),
 			schema.AllTypes(),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

Previously it always allocated a MaxNodeRows for any txn insertion, which was not friendly to high concurrent small transactions.