### PR TITLE
logservice: add more debug log for logsservice

### DIFF
--- a/pkg/logservice/message.go
+++ b/pkg/logservice/message.go
@@ -15,6 +15,7 @@
 package logservice
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
@@ -47,7 +48,7 @@ func (r *RPCRequest) GetID() uint64 {
 }
 
 func (r *RPCRequest) DebugString() string {
-	return r.Request.Method.String()
+	return fmt.Sprintf("%s:%p", r.Request.Method.String(), r.payload)
 }
 
 func (r *RPCRequest) GetPayloadField() []byte {
@@ -84,7 +85,7 @@ func (r *RPCResponse) GetID() uint64 {
 }
 
 func (r *RPCResponse) DebugString() string {
-	return ""
+	return r.Response.Method.String()
 }
 
 func (r *RPCResponse) GetPayloadField() []byte {

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/appender.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/appender.go
@@ -49,13 +49,13 @@ func (a *driverAppender) append(retryTimout, appendTimeout time.Duration) {
 	// 	panic(moerr.NewInternalError("record size %d, larger than max size 20K", size))
 	// }
 	a.client.TryResize(size)
-	logutil.Debugf("Log Service Driver: append start prepare %p", &a.client.record)
+	logutil.Debugf("Log Service Driver: append start prepare %p", a.client.record.Data)
 	record := a.client.record
 	copy(record.Payload(), a.entry.payload)
 	record.ResizePayload(size)
 	defer logSlowAppend()()
 	ctx, cancel := context.WithTimeout(context.Background(), appendTimeout)
-	logutil.Debugf("Log Service Driver: append start %p", &a.client.record)
+	logutil.Debugf("Log Service Driver: append start %p", a.client.record.Data)
 	lsn, err := a.client.c.Append(ctx, record)
 	if err != nil {
 		logutil.Errorf("append failed: %v", err)
@@ -72,7 +72,7 @@ func (a *driverAppender) append(retryTimout, appendTimeout time.Duration) {
 			return err == nil
 		})
 	}
-	logutil.Debugf("Log Service Driver: append end %p", &a.client.record)
+	logutil.Debugf("Log Service Driver: append end %p", a.client.record.Data)
 	if err != nil {
 		logutil.Infof("size is %d", size)
 		panic(err)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6745

## What this PR does / why we need it:
Print a pointer to the data where the race occurred, in the event of a race, the check can analyse the relevant logs