### PR TITLE
fix filepath

### DIFF
--- a/pkg/sql/colexec/external/external.go
+++ b/pkg/sql/colexec/external/external.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 
@@ -170,8 +169,8 @@ func GetForETLWithType(param *tree.ExternParam, prefix string) (res fileservice.
 
 func ReadDir(param *tree.ExternParam) (fileList []string, err error) {
 	filePath := strings.TrimSpace(param.Filepath)
-	filePath = filepath.Clean(filePath)
-	sep := string(filepath.Separator)
+	filePath = path.Clean(filePath)
+	sep := string("/")
 	pathDir := strings.Split(filePath, sep)
 	l := list.New()
 	if pathDir[0] == "" {
@@ -199,7 +198,7 @@ func ReadDir(param *tree.ExternParam) (fileList []string, err error) {
 				if entry.IsDir && i+1 == len(pathDir) {
 					continue
 				}
-				matched, err := filepath.Match(pathDir[i], entry.Name)
+				matched, err := path.Match(pathDir[i], entry.Name)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/colexec/external/external.go
+++ b/pkg/sql/colexec/external/external.go
@@ -170,10 +170,12 @@ func GetForETLWithType(param *tree.ExternParam, prefix string) (res fileservice.
 
 func ReadDir(param *tree.ExternParam) (fileList []string, err error) {
 	filePath := strings.TrimSpace(param.Filepath)
-	pathDir := strings.Split(filePath, "/")
+	filePath = filepath.Clean(filePath)
+	sep := string(filepath.Separator)
+	pathDir := strings.Split(filePath, sep)
 	l := list.New()
 	if pathDir[0] == "" {
-		l.PushBack("/")
+		l.PushBack(sep)
 	} else {
 		l.PushBack(pathDir[0])
 	}
@@ -197,7 +199,10 @@ func ReadDir(param *tree.ExternParam) (fileList []string, err error) {
 				if entry.IsDir && i+1 == len(pathDir) {
 					continue
 				}
-				matched, _ := filepath.Match(pathDir[i], entry.Name)
+				matched, err := filepath.Match(pathDir[i], entry.Name)
+				if err != nil {
+					return nil, err
+				}
 				if !matched {
 					continue
 				}

--- a/pkg/sql/colexec/external/external_test.go
+++ b/pkg/sql/colexec/external/external_test.go
@@ -564,4 +564,12 @@ func TestReadDirSymlink(t *testing.T) {
 	assert.Equal(t, 1, len(files))
 	assert.Equal(t, fooPathInB, files[0])
 
+	path1 := root + "/a//b/./../b/c/foo"
+	files1, err := ReadDir(&tree.ExternParam{
+		Filepath: path1,
+	})
+	assert.Nil(t, err)
+	pathWant1 := root + "/a/b/c/foo"
+	assert.Equal(t, 1, len(files1))
+	assert.Equal(t, pathWant1, files1[0])
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6865 

## What this PR does / why we need it:
1, use the go package **filepath** handling the complicate file path.