### PR TITLE
morpc: make future get after write loop handled

### DIFF
--- a/pkg/common/morpc/future_test.go
+++ b/pkg/common/morpc/future_test.go
@@ -89,9 +89,11 @@ func TestGet(t *testing.T) {
 
 	req := newTestMessage(1)
 	f := newFuture(func(f *Future) { f.reset() })
+	f.ref()
 	f.init(1, ctx)
 	defer f.Close()
 
+	f.writeCompleted()
 	f.done(req, nil)
 	resp, err := f.Get()
 	assert.Nil(t, err)
@@ -103,9 +105,11 @@ func TestGetWithTimeout(t *testing.T) {
 	defer cancel()
 
 	f := newFuture(func(f *Future) { f.reset() })
+	f.ref()
 	f.init(1, ctx)
 	defer f.Close()
 
+	f.writeCompleted()
 	resp, err := f.Get()
 	assert.NotNil(t, err)
 	assert.Nil(t, resp)
@@ -117,12 +121,14 @@ func TestGetWithError(t *testing.T) {
 	defer cancel()
 
 	f := newFuture(func(f *Future) { f.reset() })
+	f.ref()
 	f.init(1, ctx)
 	defer f.Close()
 
 	errResp := moerr.NewBackendClosed()
 	f.error(1, errResp, nil)
 
+	f.writeCompleted()
 	resp, err := f.Get()
 	assert.Error(t, err)
 	assert.Nil(t, resp)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6745

## What this PR does / why we need it:
If context' deadline is before  write request, it maybe cause data  race