### PR TITLE
bugfix: shutdown trace meet error panic

### DIFF
--- a/cmd/mo-service/main.go
+++ b/cmd/mo-service/main.go
@@ -299,8 +299,7 @@ func initTraceMetric(ctx context.Context, st metadata.ServiceType, cfg *Config, 
 			<-ctx.Done()
 			// flush trace/log/error framework
 			if err = trace.Shutdown(trace.DefaultContext()); err != nil {
-				logutil.Error("Shutdown trace", logutil.ErrorField(err), logutil.NoReportFiled())
-				panic(err)
+				logutil.Warn("Shutdown trace", logutil.ErrorField(err), logutil.NoReportFiled())
 			}
 		})
 		initWG.Wait()

--- a/pkg/util/trace/trace.go
+++ b/pkg/util/trace/trace.go
@@ -153,8 +153,10 @@ func Shutdown(ctx context.Context) error {
 	_ = atomic.SwapPointer((*unsafe.Pointer)(unsafe.Pointer(gTracer.(*MOTracer))), unsafe.Pointer(&tracer))
 
 	// fixme: need stop timeout
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 	for _, p := range GetTracerProvider().spanProcessors {
-		if err := p.Shutdown(ctx); err != nil {
+		if err := p.Shutdown(shutdownCtx); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/7017

## What this PR does / why we need it:
fix mo panic while do normally shutdown or got kill signal
- use context.Background() with timeout as shutdown context
- add ut cover trace.Shutdown() with cancled context