### PR TITLE
Change rows per block and blocks per seg.

### DIFF
--- a/pkg/vm/engine/tae/options/types.go
+++ b/pkg/vm/engine/tae/options/types.go
@@ -33,8 +33,8 @@ const (
 	DefaultIndexCacheSize = 128 * common.M
 	DefaultMTCacheSize    = 4 * common.G
 
-	DefaultBlockMaxRows     = uint32(40000)
-	DefaultBlocksPerSegment = uint16(40)
+	DefaultBlockMaxRows     = uint32(8192)
+	DefaultBlocksPerSegment = uint16(256)
 
 	DefaultScannerInterval              = time.Second * 5
 	DefaultCheckpointFlushInterval      = time.Minute


### PR DESCRIPTION
Default to 8K rows per block.  Might have something to do with both ap/tp perf and metadata cache size.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: