### PR TITLE
[Bug]: mo's scan with predicate is slower than clickhouse #6870

### DIFF
--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -970,7 +970,7 @@ func bindFuncExprImplByPlanExpr(name string, args []*Expr) (*plan.Expr, error) {
 		case *plan.Expr_C:
 			if _, ok := args[1].Expr.(*plan.Expr_Col); ok {
 				if checkNoNeedCast(types.T(args[0].Typ.Id), types.T(args[1].Typ.Id), leftExpr) {
-					tmpType := types.T(args[1].Typ.Id).ToType() // cast const_expr as column_expr's type
+					tmpType := argsType[1] // cast const_expr as column_expr's type
 					argsCastType = []types.Type{tmpType, tmpType}
 					// need to update function id
 					funcID, _, _, err = function.GetFunctionByName(name, argsCastType)
@@ -982,7 +982,7 @@ func bindFuncExprImplByPlanExpr(name string, args []*Expr) (*plan.Expr, error) {
 		case *plan.Expr_Col:
 			if rightExpr, ok := args[1].Expr.(*plan.Expr_C); ok {
 				if checkNoNeedCast(types.T(args[1].Typ.Id), types.T(args[0].Typ.Id), rightExpr) {
-					tmpType := types.T(args[0].Typ.Id).ToType() // cast const_expr as column_expr's type
+					tmpType := argsType[0] // cast const_expr as column_expr's type
 					argsCastType = []types.Type{tmpType, tmpType}
 					funcID, _, _, err = function.GetFunctionByName(name, argsCastType)
 					if err != nil {

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -969,7 +969,7 @@ func bindFuncExprImplByPlanExpr(name string, args []*Expr) (*plan.Expr, error) {
 		switch leftExpr := args[0].Expr.(type) {
 		case *plan.Expr_C:
 			if _, ok := args[1].Expr.(*plan.Expr_Col); ok {
-				if checkNoNeedCast(types.T(args[0].Typ.Id), types.T(args[1].Typ.Id), leftExpr) {
+				if checkNoNeedCast(argsType[0], argsType[1], leftExpr) {
 					tmpType := argsType[1] // cast const_expr as column_expr's type
 					argsCastType = []types.Type{tmpType, tmpType}
 					// need to update function id
@@ -981,7 +981,7 @@ func bindFuncExprImplByPlanExpr(name string, args []*Expr) (*plan.Expr, error) {
 			}
 		case *plan.Expr_Col:
 			if rightExpr, ok := args[1].Expr.(*plan.Expr_C); ok {
-				if checkNoNeedCast(types.T(args[1].Typ.Id), types.T(args[0].Typ.Id), rightExpr) {
+				if checkNoNeedCast(argsType[1], argsType[0], rightExpr) {
 					tmpType := argsType[0] // cast const_expr as column_expr's type
 					argsCastType = []types.Type{tmpType, tmpType}
 					funcID, _, _, err = function.GetFunctionByName(name, argsCastType)

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1086,12 +1086,16 @@ func unwindTupleComparison(nonEqOp, op string, leftExprs, rightExprs []*plan.Exp
 // checkNoNeedCast
 // if constant's type higher than column's type
 // and constant's value in range of column's type, then no cast was needed
-func checkNoNeedCast(constT, columnT types.T, constExpr *plan.Expr_C) bool {
-	switch constT {
+func checkNoNeedCast(constT, columnT types.Type, constExpr *plan.Expr_C) bool {
+	switch constT.Oid {
 	case types.T_char, types.T_varchar:
-		switch columnT {
+		switch columnT.Oid {
 		case types.T_char, types.T_varchar:
-			return true
+			if constT.Width <= columnT.Width {
+				return true
+			} else {
+				return false
+			}
 		default:
 			return false
 		}
@@ -1102,7 +1106,7 @@ func checkNoNeedCast(constT, columnT types.T, constExpr *plan.Expr_C) bool {
 			return false
 		}
 		constVal := val.I64Val
-		switch columnT {
+		switch columnT.Oid {
 		case types.T_int8:
 			return constVal <= int64(math.MaxInt8) && constVal >= int64(math.MinInt8)
 		case types.T_int16:
@@ -1128,7 +1132,7 @@ func checkNoNeedCast(constT, columnT types.T, constExpr *plan.Expr_C) bool {
 			return false
 		}
 		constVal := val_u.U64Val
-		switch columnT {
+		switch columnT.Oid {
 		case types.T_int8:
 			return constVal <= math.MaxInt8
 		case types.T_int16:

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1088,9 +1088,9 @@ func unwindTupleComparison(nonEqOp, op string, leftExprs, rightExprs []*plan.Exp
 // and constant's value in range of column's type, then no cast was needed
 func checkNoNeedCast(constT, columnT types.Type, constExpr *plan.Expr_C) bool {
 	switch constT.Oid {
-	case types.T_char, types.T_varchar:
+	case types.T_char, types.T_varchar, types.T_text:
 		switch columnT.Oid {
-		case types.T_char, types.T_varchar:
+		case types.T_char, types.T_varchar, types.T_text:
 			if constT.Width <= columnT.Width {
 				return true
 			} else {

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1088,6 +1088,14 @@ func unwindTupleComparison(nonEqOp, op string, leftExprs, rightExprs []*plan.Exp
 // and constant's value in range of column's type, then no cast was needed
 func checkNoNeedCast(constT, columnT types.T, constExpr *plan.Expr_C) bool {
 	switch constT {
+	case types.T_char, types.T_varchar:
+		switch columnT {
+		case types.T_char, types.T_varchar:
+			return true
+		default:
+			return false
+		}
+
 	case types.T_int8, types.T_int16, types.T_int32, types.T_int64:
 		val, valOk := constExpr.C.Value.(*plan.Const_I64Val)
 		if !valOk {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6870

## What this PR does / why we need it:
when column compare constant, we should cast constant instead of column.
for char/varchar type, if the length of constant is shorter than column, we can cast constant only