### PR TITLE
fileservice: add disk cache

### DIFF
--- a/pkg/fileservice/config.go
+++ b/pkg/fileservice/config.go
@@ -102,6 +102,8 @@ func newMinioFileService(cfg Config) (FileService, error) {
 		cfg.S3.Bucket,
 		cfg.S3.KeyPrefix,
 		int64(cfg.Cache.MemoryCapacity),
+		int64(cfg.Cache.DiskCapacity),
+		cfg.Cache.DiskPath,
 	)
 	if err != nil {
 		return nil, err
@@ -117,6 +119,8 @@ func newS3FileService(cfg Config) (FileService, error) {
 		cfg.S3.Bucket,
 		cfg.S3.KeyPrefix,
 		int64(cfg.Cache.MemoryCapacity),
+		int64(cfg.Cache.DiskCapacity),
+		cfg.Cache.DiskPath,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -1,0 +1,208 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	"github.com/matrixorigin/matrixone/pkg/util/trace"
+)
+
+//TODO LRU
+
+type DiskCache struct {
+	capacity   int64
+	path       string
+	stats      *CacheStats
+	fileExists sync.Map
+}
+
+func NewDiskCache(path string, capacity int64) (*DiskCache, error) {
+	err := os.MkdirAll(path, 0755)
+	if err != nil {
+		return nil, err
+	}
+	return &DiskCache{
+		capacity: capacity,
+		path:     path,
+		stats:    new(CacheStats),
+	}, nil
+}
+
+var _ Cache = new(DiskCache)
+
+func (d *DiskCache) Read(
+	ctx context.Context,
+	vector *IOVector,
+) (
+	err error,
+) {
+	_, span := trace.Start(ctx, "DiskCache.Read")
+	defer span.End()
+
+	numHit := 0
+	defer func() {
+		if d.stats != nil {
+			atomic.AddInt64(&d.stats.NumRead, int64(len(vector.Entries)))
+			atomic.AddInt64(&d.stats.NumHit, int64(numHit))
+		}
+	}()
+
+	for i, entry := range vector.Entries {
+		if entry.done {
+			continue
+		}
+		if entry.Size < 0 {
+			// ignore size unknown entry
+			continue
+		}
+
+		linkPath := d.entryLinkPath(vector, entry)
+		file, err := os.Open(linkPath)
+		if err != nil {
+			// ignore error
+			continue
+		}
+		defer file.Close()
+
+		if _, err := file.Seek(entry.Offset, 0); err != nil {
+			// ignore error
+			continue
+		}
+		data := make([]byte, entry.Size)
+		if _, err := io.ReadFull(file, data); err != nil {
+			// ignore error
+			continue
+		}
+
+		entry.Data = data
+		if entry.WriterForRead != nil {
+			if _, err := entry.WriterForRead.Write(data); err != nil {
+				return err
+			}
+		}
+		if entry.ReadCloserForRead != nil {
+			*entry.ReadCloserForRead = io.NopCloser(bytes.NewReader(data))
+		}
+		if err := entry.setObjectFromData(); err != nil {
+			return err
+		}
+
+		entry.done = true
+
+		vector.Entries[i] = entry
+		numHit++
+	}
+
+	return nil
+}
+
+func (d *DiskCache) Update(
+	ctx context.Context,
+	vector *IOVector,
+) (
+	err error,
+) {
+
+	for _, entry := range vector.Entries {
+		if len(entry.Data) == 0 {
+			// no data
+			continue
+		}
+		if entry.Size < 0 {
+			// ignore size unknown entry
+			continue
+		}
+
+		linkPath := d.entryLinkPath(vector, entry)
+		if _, ok := d.fileExists.Load(linkPath); ok {
+			// already exists
+			continue
+		}
+		_, err := os.Stat(linkPath)
+		if err == nil {
+			// file exists
+			d.fileExists.Store(linkPath, true)
+			continue
+		}
+
+		// write data
+		dataPath := d.entryDataPath(vector, entry)
+		err = os.MkdirAll(filepath.Dir(dataPath), 0755)
+		if err != nil {
+			return err
+		}
+		file, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0644)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		n, err := file.WriteAt(entry.Data, entry.Offset)
+		if err != nil {
+			return err
+		}
+		if int64(n) != entry.Size {
+			return io.ErrShortWrite
+		}
+
+		// link
+		if err := os.Symlink(dataPath, linkPath); err != nil {
+			if os.IsExist(err) {
+				// ok
+			} else {
+				return err
+			}
+		}
+
+		d.fileExists.Store(linkPath, true)
+	}
+
+	return nil
+}
+
+func (d *DiskCache) Flush() {
+	//TODO
+}
+
+func (d *DiskCache) CacheStats() *CacheStats {
+	return d.stats
+}
+
+func (d *DiskCache) entryLinkPath(vector *IOVector, entry IOEntry) string {
+	if entry.Size < 0 {
+		panic("should not cache size -1 entry")
+	}
+	return filepath.Join(
+		d.path,
+		toOSPath(vector.FilePath),
+		fmt.Sprintf("%d-%d", entry.Offset, entry.Size),
+	)
+}
+
+func (d *DiskCache) entryDataPath(vector *IOVector, entry IOEntry) string {
+	return filepath.Join(
+		d.path,
+		toOSPath(vector.FilePath),
+		"data",
+	)
+}

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -1,0 +1,118 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiskCache(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// new
+	cache, err := NewDiskCache(dir, 1024)
+	assert.Nil(t, err)
+
+	// update
+	testUpdate := func(cache *DiskCache) {
+		vec := &IOVector{
+			FilePath: "foo",
+			Entries: []IOEntry{
+				{
+					Offset: 0,
+					Size:   1,
+					Data:   []byte("a"),
+				},
+				// no data
+				{
+					Offset: 98,
+					Size:   0,
+				},
+				// size unknown
+				{
+					Offset: 9999,
+					Size:   -1,
+					Data:   []byte("abc"),
+				},
+			},
+		}
+		err = cache.Update(ctx, vec)
+		assert.Nil(t, err)
+	}
+	testUpdate(cache)
+
+	// update again
+	testUpdate(cache)
+
+	// read
+	testRead := func(cache *DiskCache) {
+		buf := new(bytes.Buffer)
+		var r io.ReadCloser
+		vec := &IOVector{
+			FilePath: "foo",
+			Entries: []IOEntry{
+				// written data
+				{
+					Offset:            0,
+					Size:              1,
+					WriterForRead:     buf,
+					ReadCloserForRead: &r,
+				},
+				// not exists
+				{
+					Offset: 1,
+					Size:   1,
+				},
+				// bad offset
+				{
+					Offset: 999,
+					Size:   1,
+				},
+			},
+		}
+		err = cache.Read(ctx, vec)
+		assert.Nil(t, err)
+		defer r.Close()
+		assert.True(t, vec.Entries[0].done)
+		assert.Equal(t, []byte("a"), vec.Entries[0].Data)
+		assert.Equal(t, []byte("a"), buf.Bytes())
+		bs, err := io.ReadAll(r)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("a"), bs)
+		assert.False(t, vec.Entries[1].done)
+		assert.False(t, vec.Entries[2].done)
+	}
+	testRead(cache)
+
+	// read again
+	testRead(cache)
+
+	// new cache instance and read
+	cache, err = NewDiskCache(dir, 1024)
+	assert.Nil(t, err)
+	testRead(cache)
+
+	// new cache instance and update
+	cache, err = NewDiskCache(dir, 1024)
+	assert.Nil(t, err)
+	testUpdate(cache)
+
+}

--- a/pkg/fileservice/file_service.go
+++ b/pkg/fileservice/file_service.go
@@ -111,10 +111,9 @@ type IOEntry struct {
 	// used in capacity limited caches
 	ObjectSize int64
 
-	// ignore indicates the entry should be ignored
-	// if true, implementations must not change any field
-	// for caches to skip individual IOEntry without using another IOVector
-	ignore bool
+	// done indicates whether the entry is filled with data
+	// for implementing cascade cache
+	done bool
 }
 
 // DirEntry is a file or dir

--- a/pkg/fileservice/file_service_test.go
+++ b/pkg/fileservice/file_service_test.go
@@ -480,7 +480,7 @@ func testFileService(
 				},
 			},
 		})
-		assert.True(t, moerr.IsMoErrCode(moerr.ConvertGoError(context.TODO(), err), moerr.ErrUnexpectedEOF))
+		assert.True(t, moerr.IsMoErrCode(moerr.ConvertGoError(ctx, err), moerr.ErrUnexpectedEOF))
 
 		err = fs.Read(ctx, &IOVector{
 			FilePath: "foo",
@@ -604,8 +604,8 @@ func testFileService(
 			FilePath: "foo",
 			Entries: []IOEntry{
 				{
-					Size:   int64(len(data)),
-					ignore: true,
+					Size: int64(len(data)),
+					done: true,
 				},
 				{
 					Size: int64(len(data)),
@@ -710,7 +710,7 @@ func testFileService(
 		fs := newFS(fsName)
 
 		reader, writer := io.Pipe()
-		n := 8
+		n := 65536
 
 		go func() {
 			csvWriter := csv.NewWriter(writer)

--- a/pkg/fileservice/io_entry_test.go
+++ b/pkg/fileservice/io_entry_test.go
@@ -51,4 +51,12 @@ func TestIOEntriesReader(t *testing.T) {
 	}
 	assert.Nil(t, iotest.TestReader(newIOEntriesReader(entries), bytes.Repeat([]byte("a"), 1024)))
 
+	entries = []IOEntry{
+		{
+			Size:           -1,
+			ReaderForWrite: bytes.NewReader([]byte("abc")),
+		},
+	}
+	assert.Nil(t, iotest.TestReader(newIOEntriesReader(entries), []byte("abc")))
+
 }

--- a/pkg/fileservice/local_etl_fs.go
+++ b/pkg/fileservice/local_etl_fs.go
@@ -170,7 +170,7 @@ func (l *LocalETLFS) Read(ctx context.Context, vector *IOVector) error {
 			return moerr.NewEmptyRangeNoCtx(path.File)
 		}
 
-		if entry.ignore {
+		if entry.done {
 			continue
 		}
 
@@ -284,6 +284,7 @@ func (l *LocalETLFS) Read(ctx context.Context, vector *IOVector) error {
 					return err
 				}
 				entry.Data = data
+				entry.Size = int64(len(data))
 
 			} else {
 				if int64(len(entry.Data)) < entry.Size {

--- a/pkg/fileservice/mem_cache_test.go
+++ b/pkg/fileservice/mem_cache_test.go
@@ -51,7 +51,11 @@ func TestMemCacheLeak(t *testing.T) {
 			},
 		},
 	}
-	err = m.Read(ctx, vec, fs.Read)
+	err = m.Read(ctx, vec)
+	assert.Nil(t, err)
+	err = fs.Read(ctx, vec)
+	assert.Nil(t, err)
+	err = m.Update(ctx, vec)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), m.lru.size)
 	assert.Equal(t, int64(1), vec.Entries[0].ObjectSize)
@@ -68,7 +72,11 @@ func TestMemCacheLeak(t *testing.T) {
 			},
 		},
 	}
-	err = m.Read(ctx, vec, fs.Read)
+	err = m.Read(ctx, vec)
+	assert.Nil(t, err)
+	err = fs.Read(ctx, vec)
+	assert.Nil(t, err)
+	err = m.Update(ctx, vec)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), m.lru.size)
 	assert.Equal(t, int64(1), vec.Entries[0].ObjectSize)

--- a/pkg/fileservice/memory_fs.go
+++ b/pkg/fileservice/memory_fs.go
@@ -166,7 +166,7 @@ func (m *MemoryFS) Read(ctx context.Context, vector *IOVector) error {
 	}
 
 	for i, entry := range vector.Entries {
-		if entry.ignore {
+		if entry.done {
 			continue
 		}
 
@@ -197,8 +197,11 @@ func (m *MemoryFS) Read(ctx context.Context, vector *IOVector) error {
 		}
 
 		if setData {
-			if int64(len(entry.Data)) < entry.Size {
+			if int64(len(entry.Data)) < entry.Size || entry.Size < 0 {
 				entry.Data = data
+				if entry.Size < 0 {
+					entry.Size = int64(len(data))
+				}
 			} else {
 				copy(entry.Data, data)
 			}

--- a/pkg/fileservice/path.go
+++ b/pkg/fileservice/path.go
@@ -16,6 +16,7 @@ package fileservice
 
 import (
 	"encoding/csv"
+	"os"
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -102,4 +103,13 @@ func JoinPath(serviceName string, path string) string {
 	buf.WriteString(ServiceNameSeparator)
 	buf.WriteString(path)
 	return buf.String()
+}
+
+var osPathSeparatorStr = string([]rune{os.PathSeparator})
+
+func toOSPath(filePath string) string {
+	if os.PathSeparator == '/' {
+		return filePath
+	}
+	return strings.ReplaceAll(filePath, "/", osPathSeparatorStr)
 }

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -49,7 +49,8 @@ type S3FS struct {
 	bucket    string
 	keyPrefix string
 
-	memCache *MemCache
+	memCache  *MemCache
+	diskCache *DiskCache
 }
 
 // key mapping scheme:
@@ -64,6 +65,8 @@ func NewS3FS(
 	bucket string,
 	keyPrefix string,
 	memCacheCapacity int64,
+	diskCacheCapacity int64,
+	diskCachePath string,
 ) (*S3FS, error) {
 
 	fs, err := newS3FS([]string{
@@ -77,9 +80,12 @@ func NewS3FS(
 		return nil, err
 	}
 
-	if memCacheCapacity > 0 {
-		fs.memCache = NewMemCache(memCacheCapacity)
-		logutil.Info("fileservice: cache initialized", zap.Any("fs-name", name), zap.Any("capacity", memCacheCapacity))
+	if err := fs.initCaches(
+		memCacheCapacity,
+		diskCacheCapacity,
+		diskCachePath,
+	); err != nil {
+		return nil, err
 	}
 
 	return fs, nil
@@ -94,6 +100,8 @@ func NewS3FSOnMinio(
 	bucket string,
 	keyPrefix string,
 	memCacheCapacity int64,
+	diskCacheCapacity int64,
+	diskCachePath string,
 ) (*S3FS, error) {
 
 	fs, err := newS3FS([]string{
@@ -108,12 +116,46 @@ func NewS3FSOnMinio(
 		return nil, err
 	}
 
-	if memCacheCapacity > 0 {
-		fs.memCache = NewMemCache(memCacheCapacity)
-		logutil.Info("fileservice: cache initialized", zap.Any("fs-name", name), zap.Any("capacity", memCacheCapacity))
+	if err := fs.initCaches(
+		memCacheCapacity,
+		diskCacheCapacity,
+		diskCachePath,
+	); err != nil {
+		return nil, err
 	}
 
 	return fs, nil
+}
+
+func (s *S3FS) initCaches(
+	memCacheCapacity int64,
+	diskCacheCapacity int64,
+	diskCachePath string,
+) error {
+
+	// memory cache
+	if memCacheCapacity == 0 {
+		memCacheCapacity = 512 << 20
+	}
+	if memCacheCapacity > 0 {
+		s.memCache = NewMemCache(memCacheCapacity)
+		logutil.Info("fileservice: mem cache initialized", zap.Any("fs-name", s.name), zap.Any("capacity", memCacheCapacity))
+	}
+
+	// disk cache
+	if diskCacheCapacity == 0 {
+		diskCacheCapacity = 8 << 30
+	}
+	if diskCacheCapacity > 0 && diskCachePath != "" {
+		var err error
+		s.diskCache, err = NewDiskCache(diskCachePath, diskCacheCapacity)
+		if err != nil {
+			return err
+		}
+		logutil.Info("fileservice: disk cache initialized", zap.Any("fs-name", s.name), zap.Any("capacity", memCacheCapacity))
+	}
+
+	return nil
 }
 
 func (s *S3FS) Name() string {
@@ -266,7 +308,7 @@ func (s *S3FS) write(ctx context.Context, vector IOVector) error {
 	return nil
 }
 
-func (s *S3FS) Read(ctx context.Context, vector *IOVector) error {
+func (s *S3FS) Read(ctx context.Context, vector *IOVector) (err error) {
 	ctx, span := trace.Start(ctx, "S3FS.Read")
 	defer span.End()
 
@@ -274,12 +316,31 @@ func (s *S3FS) Read(ctx context.Context, vector *IOVector) error {
 		return moerr.NewEmptyVectorNoCtx()
 	}
 
-	if s.memCache == nil {
-		// no cache
-		return s.read(ctx, vector)
+	if s.memCache != nil {
+		if err := s.memCache.Read(ctx, vector); err != nil {
+			return err
+		}
+		defer func() {
+			if err != nil {
+				return
+			}
+			err = s.memCache.Update(ctx, vector)
+		}()
 	}
 
-	if err := s.memCache.Read(ctx, vector, s.read); err != nil {
+	if s.diskCache != nil {
+		if err := s.diskCache.Read(ctx, vector); err != nil {
+			return err
+		}
+		defer func() {
+			if err != nil {
+				return
+			}
+			err = s.diskCache.Update(ctx, vector)
+		}()
+	}
+
+	if err := s.read(ctx, vector); err != nil {
 		return err
 	}
 
@@ -287,6 +348,10 @@ func (s *S3FS) Read(ctx context.Context, vector *IOVector) error {
 }
 
 func (s *S3FS) read(ctx context.Context, vector *IOVector) error {
+	if vector.allDone() {
+		return nil
+	}
+
 	ctx, span := trace.Start(ctx, "S3FS.read")
 	defer span.End()
 	path, err := ParsePathAtService(vector.FilePath, s.name)
@@ -300,7 +365,7 @@ func (s *S3FS) read(ctx context.Context, vector *IOVector) error {
 	max := int64(0)
 	readToEnd := false
 	for _, entry := range vector.Entries {
-		if entry.ignore {
+		if entry.done {
 			continue
 		}
 		if entry.Offset < min {
@@ -386,7 +451,7 @@ func (s *S3FS) read(ctx context.Context, vector *IOVector) error {
 	}
 
 	for i, entry := range vector.Entries {
-		if entry.ignore {
+		if entry.done {
 			continue
 		}
 
@@ -494,6 +559,9 @@ func (s *S3FS) read(ctx context.Context, vector *IOVector) error {
 			}
 			if int64(len(entry.Data)) < entry.Size || entry.Size < 0 {
 				entry.Data = data
+				if entry.Size < 0 {
+					entry.Size = int64(len(data))
+				}
 			} else {
 				copy(entry.Data, data)
 			}
@@ -758,7 +826,7 @@ func newS3FS(arguments []string) (*S3FS, error) {
 					s3.EndpointResolverFunc(
 						func(
 							region string,
-							options s3.EndpointResolverOptions,
+							_ s3.EndpointResolverOptions,
 						) (
 							ep aws.Endpoint,
 							err error,

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -88,6 +88,7 @@ func TestS3FS(t *testing.T) {
 	t.Setenv("AWS_SECRET_ACCESS_KEY", config.APISecret)
 
 	t.Run("file service", func(t *testing.T) {
+		cacheDir := t.TempDir()
 		testFileService(t, func(name string) FileService {
 
 			fs, err := NewS3FS(
@@ -97,6 +98,8 @@ func TestS3FS(t *testing.T) {
 				config.Bucket,
 				time.Now().Format("2006-01-02.15:04:05.000000"),
 				128*1024,
+				128*1024,
+				cacheDir,
 			)
 			assert.Nil(t, err)
 
@@ -105,6 +108,7 @@ func TestS3FS(t *testing.T) {
 	})
 
 	t.Run("list root", func(t *testing.T) {
+		cacheDir := t.TempDir()
 		fs, err := NewS3FS(
 			"",
 			"s3",
@@ -112,6 +116,8 @@ func TestS3FS(t *testing.T) {
 			config.Bucket,
 			"",
 			128*1024,
+			128*1024,
+			cacheDir,
 		)
 		assert.Nil(t, err)
 		ctx := context.Background()
@@ -121,6 +127,7 @@ func TestS3FS(t *testing.T) {
 	})
 
 	t.Run("caching file service", func(t *testing.T) {
+		cacheDir := t.TempDir()
 		testCachingFileService(t, func() CachingFileService {
 			fs, err := NewS3FS(
 				"",
@@ -129,6 +136,8 @@ func TestS3FS(t *testing.T) {
 				config.Bucket,
 				time.Now().Format("2006-01-02.15:04:05.000000"),
 				128*1024,
+				128*1024,
+				cacheDir,
 			)
 			assert.Nil(t, err)
 			return fs
@@ -298,6 +307,7 @@ func TestS3FSMinioServer(t *testing.T) {
 
 	// run test
 	t.Run("file service", func(t *testing.T) {
+		cacheDir := t.TempDir()
 		testFileService(t, func(name string) FileService {
 
 			fs, err := NewS3FSOnMinio(
@@ -307,6 +317,8 @@ func TestS3FSMinioServer(t *testing.T) {
 				"test",
 				time.Now().Format("2006-01-02.15:04:05.000000"),
 				128*1024,
+				128*1024,
+				cacheDir,
 			)
 			assert.Nil(t, err)
 
@@ -328,6 +340,8 @@ func BenchmarkS3FS(b *testing.B) {
 	b.Setenv("AWS_ACCESS_KEY_ID", config.APIKey)
 	b.Setenv("AWS_SECRET_ACCESS_KEY", config.APISecret)
 
+	cacheDir := b.TempDir()
+
 	b.ResetTimer()
 
 	benchmarkFileService(b, func() FileService {
@@ -338,6 +352,8 @@ func BenchmarkS3FS(b *testing.B) {
 			config.Bucket,
 			time.Now().Format("2006-01-02.15:04:05.000000"),
 			128*1024,
+			128*1024,
+			cacheDir,
 		)
 		assert.Nil(b, err)
 		return fs

--- a/pkg/fileservice/vector.go
+++ b/pkg/fileservice/vector.go
@@ -14,33 +14,11 @@
 
 package fileservice
 
-import (
-	"context"
-
-	"github.com/matrixorigin/matrixone/pkg/util/toml"
-)
-
-type CacheKey struct {
-	Path   string
-	Offset int64
-	Size   int64
-}
-
-type CacheConfig struct {
-	MemoryCapacity toml.ByteSize `toml:"memory-capacity"`
-	DiskPath       string        `toml:"disk-path"`
-	DiskCapacity   toml.ByteSize `toml:"disk-capacity"`
-}
-
-type Cache interface {
-	Read(
-		ctx context.Context,
-		vector *IOVector,
-	) error
-	Update(
-		ctx context.Context,
-		vector *IOVector,
-	) error
-	Flush()
-	CacheStats() *CacheStats
+func (v *IOVector) allDone() bool {
+	for _, entry := range v.Entries {
+		if !entry.done {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6943 

## What this PR does / why we need it:
fileservice: set S3 mem cache defaultly
fileservice: rename IOEntry.ignore to done
fileservice: refactor cache process
fileservice: add disk cache configs
fileservice: use disk cache in S3
fileservice: implement DiskCache.Read