### PR TITLE
fileservice: check context done in methods

### DIFF
--- a/pkg/fileservice/io_entry_test.go
+++ b/pkg/fileservice/io_entry_test.go
@@ -16,6 +16,7 @@ package fileservice
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"testing/iotest"
 
@@ -23,6 +24,7 @@ import (
 )
 
 func TestIOEntriesReader(t *testing.T) {
+	ctx := context.Background()
 
 	entries := []IOEntry{
 		{
@@ -31,7 +33,7 @@ func TestIOEntriesReader(t *testing.T) {
 			Data:   []byte("a"),
 		},
 	}
-	assert.Nil(t, iotest.TestReader(newIOEntriesReader(entries), []byte("a")))
+	assert.Nil(t, iotest.TestReader(newIOEntriesReader(ctx, entries), []byte("a")))
 
 	entries = []IOEntry{
 		{
@@ -40,7 +42,7 @@ func TestIOEntriesReader(t *testing.T) {
 			Data:   []byte("a"),
 		},
 	}
-	assert.Nil(t, iotest.TestReader(newIOEntriesReader(entries), []byte("\x00a")))
+	assert.Nil(t, iotest.TestReader(newIOEntriesReader(ctx, entries), []byte("\x00a")))
 
 	entries = []IOEntry{
 		{
@@ -49,7 +51,7 @@ func TestIOEntriesReader(t *testing.T) {
 			Data:   bytes.Repeat([]byte("a"), 1024),
 		},
 	}
-	assert.Nil(t, iotest.TestReader(newIOEntriesReader(entries), bytes.Repeat([]byte("a"), 1024)))
+	assert.Nil(t, iotest.TestReader(newIOEntriesReader(ctx, entries), bytes.Repeat([]byte("a"), 1024)))
 
 	entries = []IOEntry{
 		{
@@ -57,6 +59,6 @@ func TestIOEntriesReader(t *testing.T) {
 			ReaderForWrite: bytes.NewReader([]byte("abc")),
 		},
 	}
-	assert.Nil(t, iotest.TestReader(newIOEntriesReader(entries), []byte("abc")))
+	assert.Nil(t, iotest.TestReader(newIOEntriesReader(ctx, entries), []byte("abc")))
 
 }

--- a/pkg/fileservice/local_etl_fs.go
+++ b/pkg/fileservice/local_etl_fs.go
@@ -60,6 +60,12 @@ func (l *LocalETLFS) ensureTempDir() (err error) {
 }
 
 func (l *LocalETLFS) Write(ctx context.Context, vector IOVector) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	path, err := ParsePathAtService(vector.FilePath, l.name)
 	if err != nil {
 		return err
@@ -106,7 +112,7 @@ func (l *LocalETLFS) write(ctx context.Context, vector IOVector) error {
 	if err != nil {
 		return err
 	}
-	n, err := io.Copy(f, newIOEntriesReader(vector.Entries))
+	n, err := io.Copy(f, newIOEntriesReader(ctx, vector.Entries))
 	if err != nil {
 		return err
 	}
@@ -146,6 +152,11 @@ func (l *LocalETLFS) write(ctx context.Context, vector IOVector) error {
 }
 
 func (l *LocalETLFS) Read(ctx context.Context, vector *IOVector) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 
 	if len(vector.Entries) == 0 {
 		return moerr.NewEmptyVectorNoCtx()
@@ -313,6 +324,11 @@ func (l *LocalETLFS) Read(ctx context.Context, vector *IOVector) error {
 }
 
 func (l *LocalETLFS) List(ctx context.Context, dirPath string) (ret []DirEntry, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 
 	path, err := ParsePathAtService(dirPath, l.name)
 	if err != nil {
@@ -363,6 +379,12 @@ func (l *LocalETLFS) List(ctx context.Context, dirPath string) (ret []DirEntry, 
 }
 
 func (l *LocalETLFS) Delete(ctx context.Context, filePaths ...string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	for _, filePath := range filePaths {
 		if err := l.deleteSingle(ctx, filePath); err != nil {
 			return err
@@ -512,6 +534,11 @@ func (l *LocalETLFSMutator) Append(ctx context.Context, entries ...IOEntry) erro
 }
 
 func (l *LocalETLFSMutator) mutate(ctx context.Context, baseOffset int64, entries ...IOEntry) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 
 	// write
 	for _, entry := range entries {

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -116,6 +116,12 @@ func (l *LocalFS) Name() string {
 }
 
 func (l *LocalFS) Write(ctx context.Context, vector IOVector) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	path, err := ParsePathAtService(vector.FilePath, l.name)
 	if err != nil {
 		return err
@@ -133,6 +139,12 @@ func (l *LocalFS) Write(ctx context.Context, vector IOVector) error {
 }
 
 func (l *LocalFS) write(ctx context.Context, vector IOVector) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	path, err := ParsePathAtService(vector.FilePath, l.name)
 	if err != nil {
 		return err
@@ -160,7 +172,7 @@ func (l *LocalFS) write(ctx context.Context, vector IOVector) error {
 		return err
 	}
 	fileWithChecksum := NewFileWithChecksum(f, _BlockContentSize)
-	n, err := io.Copy(fileWithChecksum, newIOEntriesReader(vector.Entries))
+	n, err := io.Copy(fileWithChecksum, newIOEntriesReader(ctx, vector.Entries))
 	if err != nil {
 		return err
 	}
@@ -203,6 +215,11 @@ func (l *LocalFS) write(ctx context.Context, vector IOVector) error {
 }
 
 func (l *LocalFS) Read(ctx context.Context, vector *IOVector) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 
 	if len(vector.Entries) == 0 {
 		return moerr.NewEmptyVectorNoCtx()
@@ -389,6 +406,11 @@ func (l *LocalFS) read(ctx context.Context, vector *IOVector) error {
 }
 
 func (l *LocalFS) List(ctx context.Context, dirPath string) (ret []DirEntry, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 
 	path, err := ParsePathAtService(dirPath, l.name)
 	if err != nil {
@@ -443,6 +465,12 @@ func (l *LocalFS) List(ctx context.Context, dirPath string) (ret []DirEntry, err
 }
 
 func (l *LocalFS) Delete(ctx context.Context, filePaths ...string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	for _, filePath := range filePaths {
 		if err := l.deleteSingle(ctx, filePath); err != nil {
 			return err
@@ -583,6 +611,11 @@ func (l *LocalFSMutator) Append(ctx context.Context, entries ...IOEntry) error {
 }
 
 func (l *LocalFSMutator) mutate(ctx context.Context, baseOffset int64, entries ...IOEntry) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 
 	// write
 	for _, entry := range entries {

--- a/pkg/fileservice/memory_fs.go
+++ b/pkg/fileservice/memory_fs.go
@@ -49,6 +49,12 @@ func (m *MemoryFS) Name() string {
 }
 
 func (m *MemoryFS) List(ctx context.Context, dirPath string) (entries []DirEntry, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	m.RLock()
 	defer m.RUnlock()
 
@@ -88,6 +94,12 @@ func (m *MemoryFS) List(ctx context.Context, dirPath string) (entries []DirEntry
 }
 
 func (m *MemoryFS) Write(ctx context.Context, vector IOVector) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	m.Lock()
 	defer m.Unlock()
 
@@ -108,6 +120,11 @@ func (m *MemoryFS) Write(ctx context.Context, vector IOVector) error {
 }
 
 func (m *MemoryFS) write(ctx context.Context, vector IOVector) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 
 	path, err := ParsePathAtService(vector.FilePath, m.name)
 	if err != nil {
@@ -128,7 +145,7 @@ func (m *MemoryFS) write(ctx context.Context, vector IOVector) error {
 		return vector.Entries[i].Offset < vector.Entries[j].Offset
 	})
 
-	r := newIOEntriesReader(vector.Entries)
+	r := newIOEntriesReader(ctx, vector.Entries)
 	data, err := io.ReadAll(r)
 	if err != nil {
 		return err
@@ -143,6 +160,11 @@ func (m *MemoryFS) write(ctx context.Context, vector IOVector) error {
 }
 
 func (m *MemoryFS) Read(ctx context.Context, vector *IOVector) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 
 	path, err := ParsePathAtService(vector.FilePath, m.name)
 	if err != nil {
@@ -218,6 +240,12 @@ func (m *MemoryFS) Read(ctx context.Context, vector *IOVector) error {
 }
 
 func (m *MemoryFS) Delete(ctx context.Context, filePaths ...string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	m.Lock()
 	defer m.Unlock()
 	for _, filePath := range filePaths {

--- a/pkg/fileservice/mutable_file_service_test.go
+++ b/pkg/fileservice/mutable_file_service_test.go
@@ -107,4 +107,12 @@ func testMutableFileService(
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("123dq123"), vec.Entries[0].Data)
 
+	// context canceled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = mutator.Mutate(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+	err = mutator.Append(ctx)
+	assert.ErrorIs(t, err, context.Canceled)
+
 }

--- a/pkg/fileservice/replaceable_file_service_test.go
+++ b/pkg/fileservice/replaceable_file_service_test.go
@@ -63,4 +63,9 @@ func testReplaceableFileService(
 
 	assert.Equal(t, 2, len(vec.Entries[0].Data))
 
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = fs.Replace(ctx, IOVector{})
+	assert.ErrorIs(t, err, context.Canceled)
+
 }

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -163,6 +163,12 @@ func (s *S3FS) Name() string {
 }
 
 func (s *S3FS) List(ctx context.Context, dirPath string) (entries []DirEntry, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	ctx, span := trace.Start(ctx, "S3FS.List")
 	defer span.End()
 	if ctx == nil {
@@ -225,6 +231,12 @@ func (s *S3FS) List(ctx context.Context, dirPath string) (entries []DirEntry, er
 }
 
 func (s *S3FS) Write(ctx context.Context, vector IOVector) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	ctx, span := trace.Start(ctx, "S3FS.Write")
 	defer span.End()
 
@@ -283,7 +295,7 @@ func (s *S3FS) write(ctx context.Context, vector IOVector) error {
 	}
 
 	// put
-	content, err := io.ReadAll(newIOEntriesReader(vector.Entries))
+	content, err := io.ReadAll(newIOEntriesReader(ctx, vector.Entries))
 	if err != nil {
 		return err
 	}
@@ -309,6 +321,12 @@ func (s *S3FS) write(ctx context.Context, vector IOVector) error {
 }
 
 func (s *S3FS) Read(ctx context.Context, vector *IOVector) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	ctx, span := trace.Start(ctx, "S3FS.Read")
 	defer span.End()
 
@@ -579,6 +597,12 @@ func (s *S3FS) read(ctx context.Context, vector *IOVector) error {
 }
 
 func (s *S3FS) Delete(ctx context.Context, filePaths ...string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	ctx, span := trace.Start(ctx, "S3FS.Delete")
 	defer span.End()
 

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -168,11 +168,12 @@ func TestDynamicS3(t *testing.T) {
 		})
 		assert.Nil(t, err)
 		w.Flush()
-		fs, _, err := GetForETL(nil, JoinPath(
+		fs, path, err := GetForETL(nil, JoinPath(
 			buf.String(),
 			"foo/bar/baz",
 		))
 		assert.Nil(t, err)
+		assert.Equal(t, path, "foo/bar/baz")
 		return fs
 	})
 }
@@ -200,11 +201,12 @@ func TestDynamicS3NoKey(t *testing.T) {
 		})
 		assert.Nil(t, err)
 		w.Flush()
-		fs, _, err := GetForETL(nil, JoinPath(
+		fs, path, err := GetForETL(nil, JoinPath(
 			buf.String(),
 			"foo/bar/baz",
 		))
 		assert.Nil(t, err)
+		assert.Equal(t, path, "foo/bar/baz")
 		return fs
 	})
 }
@@ -232,11 +234,12 @@ func TestDynamicS3Opts(t *testing.T) {
 		})
 		assert.Nil(t, err)
 		w.Flush()
-		fs, _, err := GetForETL(nil, JoinPath(
+		fs, path, err := GetForETL(nil, JoinPath(
 			buf.String(),
 			"foo/bar/baz",
 		))
 		assert.Nil(t, err)
+		assert.Equal(t, path, "foo/bar/baz")
 		return fs
 	})
 }

--- a/pkg/frontend/query_result_test.go
+++ b/pkg/frontend/query_result_test.go
@@ -147,6 +147,8 @@ func Test_saveQueryResultMeta(t *testing.T) {
 	yes := openSaveQueryResult(ses)
 	assert.True(t, yes)
 
+	ses.requestCtx = context.Background()
+
 	//result string
 	wantResult := "0,0,0\n1,1,1\n2,2,2\n0,0,0\n1,1,1\n2,2,2\n0,0,0\n1,1,1\n2,2,2\n"
 	//save blocks

--- a/pkg/sql/colexec/external/external_test.go
+++ b/pkg/sql/colexec/external/external_test.go
@@ -549,6 +549,7 @@ func Test_GetBatchData(t *testing.T) {
 
 func TestReadDirSymlink(t *testing.T) {
 	root := t.TempDir()
+	ctx := context.Background()
 
 	// create a/b/c
 	err := os.MkdirAll(filepath.Join(root, "a", "b", "c"), 0755)
@@ -569,7 +570,7 @@ func TestReadDirSymlink(t *testing.T) {
 	fooPathInB := filepath.Join(root, "a", "b", "d", "foo")
 	files, err := ReadDir(&tree.ExternParam{
 		Filepath: fooPathInB,
-		Ctx:      context.Background(),
+		Ctx:      ctx,
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(files))
@@ -578,6 +579,7 @@ func TestReadDirSymlink(t *testing.T) {
 	path1 := root + "/a//b/./../b/c/foo"
 	files1, err := ReadDir(&tree.ExternParam{
 		Filepath: path1,
+		Ctx:      ctx,
 	})
 	assert.Nil(t, err)
 	pathWant1 := root + "/a/b/c/foo"

--- a/pkg/util/export/merge_test.go
+++ b/pkg/util/export/merge_test.go
@@ -297,11 +297,11 @@ func TestNewMergeWithContextDone(t *testing.T) {
 
 	ctx := trace.Generate(context.Background())
 	ctx, cancel := context.WithCancel(ctx)
-	cancel()
 
 	type args struct {
-		ctx  context.Context
-		opts []MergeOption
+		ctx    context.Context
+		cancel context.CancelFunc
+		opts   []MergeOption
 	}
 	tests := []struct {
 		name string
@@ -311,7 +311,8 @@ func TestNewMergeWithContextDone(t *testing.T) {
 		{
 			name: "normal",
 			args: args{
-				ctx: ctx,
+				ctx:    ctx,
+				cancel: cancel,
 				opts: []MergeOption{WithFileServiceName(defines.ETLFileServiceName),
 					WithFileService(fs), WithTable(dummyTable),
 					WithMaxFileSize(1), WithMinFilesMerge(1), WithMaxFileSize(16 * mpool.MB), WithMaxMergeJobs(16)},
@@ -337,6 +338,7 @@ func TestNewMergeWithContextDone(t *testing.T) {
 			}
 			require.Nil(t, err)
 
+			tt.args.cancel()
 			_, err = reader.ReadLine()
 			//err = got.doMergeFiles(ctx, dummyTable.Table, files, 0)
 			t.Logf("doMergeFiles meet err: %s", err)
@@ -357,11 +359,11 @@ func TestNewMergeNOFiles(t *testing.T) {
 
 	ctx := trace.Generate(context.Background())
 	ctx, cancel := context.WithCancel(ctx)
-	cancel()
 
 	type args struct {
-		ctx  context.Context
-		opts []MergeOption
+		ctx    context.Context
+		cancel context.CancelFunc
+		opts   []MergeOption
 	}
 	tests := []struct {
 		name string
@@ -371,7 +373,8 @@ func TestNewMergeNOFiles(t *testing.T) {
 		{
 			name: "normal",
 			args: args{
-				ctx: ctx,
+				ctx:    ctx,
+				cancel: cancel,
 				opts: []MergeOption{WithFileServiceName(defines.ETLFileServiceName),
 					WithFileService(fs), WithTable(dummyTable),
 					WithMaxFileSize(1), WithMinFilesMerge(1), WithMaxFileSize(16 * mpool.MB), WithMaxMergeJobs(16)},
@@ -381,6 +384,7 @@ func TestNewMergeNOFiles(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			defer tt.args.cancel()
 
 			filePath := newFilePath(dummyTable, ts)
 			files := []string{filePath}
@@ -390,6 +394,7 @@ func TestNewMergeNOFiles(t *testing.T) {
 
 			err := got.doMergeFiles(ctx, dummyTable.Table, files, 0)
 			require.Equal(t, true, strings.Contains(err.Error(), "is not found"))
+
 		})
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Check context done in methods to ensure that error is returned when the context is canceled