### PR TITLE
statemetn_info record stats json

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -4352,6 +4352,9 @@ func serializePlanToJson(ctx context.Context, queryPlan *plan2.Plan, uuid uuid.U
 		}
 		// data transform Global to json
 		if len(marshalPlan.Steps) > 0 {
+			if len(marshalPlan.Steps) > 1 {
+				logutil.Fatalf("need handle multi execPlan trees, cnt: %d", len(marshalPlan.Steps))
+			}
 			buffer := &bytes.Buffer{}
 			encoder := json.NewEncoder(buffer)
 			encoder.SetEscapeHTML(false)

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -4351,8 +4351,10 @@ func serializePlanToJson(ctx context.Context, queryPlan *plan2.Plan, uuid uuid.U
 			jsonBytes = buffer.Bytes()
 		}
 		// data transform Global to json
-		buffer.Reset()
 		if len(marshalPlan.Steps) > 0 {
+			buffer := &bytes.Buffer{}
+			encoder := json.NewEncoder(buffer)
+			encoder.SetEscapeHTML(false)
 			global := marshalPlan.Steps[0].GraphData.Global
 			err = encoder.Encode(&global)
 			if err != nil {

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -4329,7 +4329,7 @@ func buildErrorJsonPlan(uuid uuid.UUID, errcode uint16, msg string) []byte {
 	return buffer.Bytes()
 }
 
-func serializePlanToJson(ctx context.Context, queryPlan *plan2.Plan, uuid uuid.UUID) (jsonBytes []byte, rows int64, size int64) {
+func serializePlanToJson(ctx context.Context, queryPlan *plan2.Plan, uuid uuid.UUID) (jsonBytes []byte, statsJonsBytes []byte, stats trace.Statistic) {
 	if queryPlan != nil && queryPlan.GetQuery() != nil {
 		explainQuery := explain.NewExplainQueryImpl(queryPlan.GetQuery())
 		options := &explain.ExplainOptions{
@@ -4338,7 +4338,7 @@ func serializePlanToJson(ctx context.Context, queryPlan *plan2.Plan, uuid uuid.U
 			Format:  explain.EXPLAIN_FORMAT_TEXT,
 		}
 		marshalPlan := explainQuery.BuildJsonPlan(ctx, uuid, options)
-		rows, size = marshalPlan.StatisticsRead()
+		stats.RowsRead, stats.BytesScan = marshalPlan.StatisticsRead()
 		// data transform to json datastruct
 		buffer := &bytes.Buffer{}
 		encoder := json.NewEncoder(buffer)
@@ -4350,19 +4350,30 @@ func serializePlanToJson(ctx context.Context, queryPlan *plan2.Plan, uuid uuid.U
 		} else {
 			jsonBytes = buffer.Bytes()
 		}
+		// data transform Global to json
+		buffer.Reset()
+		if len(marshalPlan.Steps) > 0 {
+			global := marshalPlan.Steps[0].GraphData.Global
+			err = encoder.Encode(&global)
+			if err != nil {
+				statsJonsBytes = []byte(fmt.Sprintf(`{"code":200,"message":"%q"}`, err.Error()))
+			} else {
+				statsJonsBytes = buffer.Bytes()
+			}
+		}
 	} else {
 		jsonBytes = buildErrorJsonPlan(uuid, moerr.ErrWarn, "sql query no record execution plan")
 	}
-	return jsonBytes, rows, size
+	return jsonBytes, statsJonsBytes, stats
 }
 
 // SerializeExecPlan Serialize the execution plan by json
-var SerializeExecPlan = func(ctx context.Context, plan any, uuid uuid.UUID) ([]byte, int64, int64) {
+var SerializeExecPlan = func(ctx context.Context, plan any, uuid uuid.UUID) ([]byte, []byte, trace.Statistic) {
 	if plan == nil {
 		return serializePlanToJson(ctx, nil, uuid)
 	} else if queryPlan, ok := plan.(*plan2.Plan); !ok {
 		moError := moerr.NewInternalError(ctx, "execPlan not type of plan2.Plan: %s", reflect.ValueOf(plan).Type().Name())
-		return buildErrorJsonPlan(uuid, moError.ErrorCode(), moError.Error()), 0, 0
+		return buildErrorJsonPlan(uuid, moError.ErrorCode(), moError.Error()), []byte{}, trace.Statistic{}
 	} else {
 		// data transform to json dataStruct
 		return serializePlanToJson(ctx, queryPlan, uuid)

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -1179,9 +1179,9 @@ func TestSerializePlanToJson(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
-		json, rows, bytes := serializePlanToJson(mock.CurrentContext().GetContext(), plan, uuid.New())
-		require.Equal(t, int64(0), rows)
-		require.Equal(t, int64(0), bytes)
+		json, _, stats := serializePlanToJson(mock.CurrentContext().GetContext(), plan, uuid.New())
+		require.Equal(t, int64(0), stats.RowsRead)
+		require.Equal(t, int64(0), stats.BytesScan)
 		t.Logf("SQL plan to json : %s\n", string(json))
 	}
 }

--- a/pkg/sql/plan/explain/explain_query.go
+++ b/pkg/sql/plan/explain/explain_query.go
@@ -255,6 +255,25 @@ func (d *ExplainData) StatisticsRead() (rows int64, size int64) {
 	return
 }
 
+func (d *ExplainData) GlobalStatics() (rows int64, size int64) {
+	for _, step := range d.Steps {
+		for _, node := range step.GraphData.Nodes {
+			if node.Name != TableScan && node.Name != ExternalScan {
+				continue
+			}
+			for _, s := range node.Statistics.Throughput {
+				switch s.Name {
+				case InputRows:
+					rows += s.Value
+				case InputSize:
+					size += s.Value
+				}
+			}
+		}
+	}
+	return
+}
+
 // Statistics of global resource usage, adding resources of all nodes
 func (graphData *GraphData) StatisticsGlobalResource(ctx context.Context) error {
 	if graphData == nil {

--- a/pkg/sql/plan/explain/explain_query.go
+++ b/pkg/sql/plan/explain/explain_query.go
@@ -255,25 +255,6 @@ func (d *ExplainData) StatisticsRead() (rows int64, size int64) {
 	return
 }
 
-func (d *ExplainData) GlobalStatics() (rows int64, size int64) {
-	for _, step := range d.Steps {
-		for _, node := range step.GraphData.Nodes {
-			if node.Name != TableScan && node.Name != ExternalScan {
-				continue
-			}
-			for _, s := range node.Statistics.Throughput {
-				switch s.Name {
-				case InputRows:
-					rows += s.Value
-				case InputSize:
-					size += s.Value
-				}
-			}
-		}
-	}
-	return
-}
-
 // Statistics of global resource usage, adding resources of all nodes
 func (graphData *GraphData) StatisticsGlobalResource(ctx context.Context) error {
 	if graphData == nil {

--- a/pkg/util/export/table/table.go
+++ b/pkg/util/export/table/table.go
@@ -53,7 +53,7 @@ type Column struct {
 func (col *Column) ToCreateSql(ctx context.Context) string {
 	sb := strings.Builder{}
 	sb.WriteString(fmt.Sprintf("`%s` %s ", col.Name, col.Type))
-	if col.Type == "JSON" {
+	if strings.ToUpper(col.Type) == "JSON" {
 		sb.WriteString("NOT NULL ")
 		if len(col.Default) == 0 {
 			panic(moerr.NewNotSupported(ctx, "json column need default in csv, but not in schema"))

--- a/pkg/util/trace/buffer_pipe_test.go
+++ b/pkg/util/trace/buffer_pipe_test.go
@@ -385,7 +385,7 @@ log_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000
 				},
 				buf: buf,
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,0,0,0,,,0,
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"{""code"":200,""message"":""NO ExecPlan""}",,,0,
 `,
 		},
 		{
@@ -424,8 +424,8 @@ log_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000
 				},
 				buf: buf,
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,0,0,0,,,0,
-00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,0001-01-01 00:00:00.000001,0001-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,0,0,0,,,0,
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"{""code"":200,""message"":""NO ExecPlan""}",,,0,
+00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,0001-01-01 00:00:00.000001,0001-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,"{""code"":200,""message"":""NO ExecPlan""}",,,0,
 `,
 		},
 		{
@@ -496,7 +496,7 @@ func Test_genCsvData_diffAccount(t *testing.T) {
 				},
 				buf: buf,
 			},
-			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,0,0,0,,,0,
+			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"{""code"":200,""message"":""NO ExecPlan""}",,,0,
 `},
 		},
 		{
@@ -535,8 +535,8 @@ func Test_genCsvData_diffAccount(t *testing.T) {
 				},
 				buf: buf,
 			},
-			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,0,0,0,,,0,
-`, `00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,sys,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,0001-01-01 00:00:00.000001,0001-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,0,0,0,,,0,
+			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"{""code"":200,""message"":""NO ExecPlan""}",,,0,
+`, `00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,sys,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,0001-01-01 00:00:00.000001,0001-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,"{""code"":200,""message"":""NO ExecPlan""}",,,0,
 `},
 		},
 	}
@@ -623,18 +623,15 @@ func Test_genCsvData_LongQueryTime(t *testing.T) {
 						Error:                moerr.NewInternalError(DefaultContext(), "test error"),
 						ExecPlan:             map[string]string{"key": "val"},
 						SerializeExecPlan:    dummySerializeExecPlan,
-						Memory:               1024,
-						Cpu:                  1_000,
-						IO:                   1_000,
 						SqlSourceType:        "internal",
 					},
 				},
 				buf:    buf,
 				queryT: int64(time.Second),
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,0,0,0,,,0,
-00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""no exec plan""}",0,0,0,0,0,,,0,
-00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,0001-01-01 00:00:00.000001,0001-01-01 00:00:01.000001,1000000000,Failed,20101,internal error: test error,"{""key"":""val""}",1,1,1000,1024,1000,,,0,internal
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"{""code"":200,""message"":""NO ExecPlan""}",,,0,
+00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""no exec plan""}",0,0,{},,,0,
+00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,0001-01-01 00:00:00.000001,0001-01-01 00:00:01.000001,1000000000,Failed,20101,internal error: test error,"{""key"":""val""}",1,1,{},,,0,internal
 `,
 		},
 	}

--- a/pkg/util/trace/report_statement_test.go
+++ b/pkg/util/trace/report_statement_test.go
@@ -155,27 +155,27 @@ var realNoExecPlanJsonResult = `{"code":200,"message":"NO ExecPlan Serialize fun
 var dummyNoExecPlanJsonResult = `{"code":200,"message":"no exec plan"}`
 var dummyNoExecPlanJsonResult2 = `{"func":"dummy2","code":200,"message":"no exec plan"}`
 
-var dummySerializeExecPlan = func(_ context.Context, plan any, _ uuid.UUID) ([]byte, int64, int64) {
+var dummySerializeExecPlan = func(_ context.Context, plan any, _ uuid.UUID) ([]byte, []byte, Statistic) {
 	if plan == nil {
-		return []byte(dummyNoExecPlanJsonResult), 0, 0
+		return []byte(dummyNoExecPlanJsonResult), []byte{}, Statistic{}
 	}
 	json, err := json.Marshal(plan)
 	if err != nil {
-		return []byte(fmt.Sprintf(`{"err": %q}`, err.Error())), 0, 0
+		return []byte(fmt.Sprintf(`{"err": %q}`, err.Error())), []byte{}, Statistic{}
 	}
-	return json, 1, 1
+	return json, []byte{}, Statistic{RowsRead: 1, BytesScan: 1}
 }
 
-var dummySerializeExecPlan2 = func(_ context.Context, plan any, _ uuid.UUID) ([]byte, int64, int64) {
+var dummySerializeExecPlan2 = func(_ context.Context, plan any, _ uuid.UUID) ([]byte, []byte, Statistic) {
 	if plan == nil {
-		return []byte(dummyNoExecPlanJsonResult2), 0, 0
+		return []byte(dummyNoExecPlanJsonResult2), []byte{}, Statistic{}
 	}
 	json, err := json.Marshal(plan)
 	if err != nil {
-		return []byte(fmt.Sprintf(`{"func":"dymmy2","err": %q}`, err.Error())), 0, 0
+		return []byte(fmt.Sprintf(`{"func":"dymmy2","err": %q}`, err.Error())), []byte{}, Statistic{}
 	}
 	val := fmt.Sprintf(`{"func":"dummy2","result":%s}`, json)
-	return []byte(val), 0, 0
+	return []byte(val), []byte{}, Statistic{}
 }
 
 func TestStatementInfo_ExecPlan2Json(t *testing.T) {
@@ -281,7 +281,7 @@ func TestStatementInfo_ExecPlan2Json(t *testing.T) {
 			tt.args.setDefault()
 			s := &StatementInfo{}
 			s.SetExecPlan(tt.args.ExecPlan, tt.args.SerializeExecPlan)
-			got := s.ExecPlan2Json(ctx)
+			got, _ := s.ExecPlan2Json(ctx)
 			assert.Equalf(t, tt.want, got, "ExecPlan2Json()")
 
 			mapper := new(map[string]any)

--- a/pkg/util/trace/schema.go
+++ b/pkg/util/trace/schema.go
@@ -69,9 +69,7 @@ var (
 	execPlanCol  = table.Column{Name: "exec_plan", Type: "JSON", Default: jsonColumnDEFAULT, Comment: "statement execution plan"}
 	rowsReadCol  = table.Column{Name: "rows_read", Type: bigintUnsignedType, Default: "0", Comment: "rows read total"}
 	bytesScanCol = table.Column{Name: "bytes_scan", Type: bigintUnsignedType, Default: "0", Comment: "bytes scan total"}
-	cpuCol       = table.Column{Name: "cpu", Type: bigintUnsignedType, Default: "0", Comment: "cpu time, unit: ?"}
-	memoryCol    = table.Column{Name: "memory", Type: bigintUnsignedType, Default: "0", Comment: "memory cost byte"}
-	ioCol        = table.Column{Name: "io", Type: bigintUnsignedType, Default: "0", Comment: "io count"}
+	statsCol     = table.Column{Name: "stats", Type: "JSON", Default: jsonColumnDEFAULT, Comment: "global stats info in exec_plan"}
 	stmtTypeCol  = table.Column{Name: "statement_type", Type: "varchar(128)", Default: "", Comment: "statement type, val in [Insert, Delete, Update, Drop Table, Drop User, ...]"}
 	queryTypeCol = table.Column{Name: "query_type", Type: "varchar(128)", Default: "", Comment: "query type, val in [DQL, DDL, DML, DCL, TCL]"}
 	sqlTypeCol   = table.Column{Name: "sql_source_type", Type: "TEXT", Default: "", Comment: "sql statement source type"}
@@ -102,9 +100,7 @@ var (
 			execPlanCol,
 			rowsReadCol,
 			bytesScanCol,
-			cpuCol,
-			memoryCol,
-			ioCol,
+			statsCol,
 			stmtTypeCol,
 			queryTypeCol,
 			roleIdCol,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/6596

## What this PR does / why we need it:

record query explain's global stats in table statment_info's individual column, like `statement_info.stats`

- example
```
mysql> select statement_id, statement, stats from system.statement_info where json_unquote(json_extract(exec_plan, '$.code')) = 0 limit 10\G
*************************** 1. row ***************************
statement_id: 5860eaec-8d7f-11ed-ad54-3ebf9f3960c8
   statement: show tables
       stats: {"statistics": {"IO": [{"name": "Disk IO", "unit": "byte", "value": 0}, {"name": "S3 IO", "unit": "byte", "value": 3619}], "Memory": [{"name": "Memory Size", "unit": "byte", "value": 66}], "Network": [{"name": "Network", "unit": "byte", "value": 0}], "Throughput": [{"name": "Input Rows", "unit": "count", "value": 68}, {"name": "Output Rows", "unit": "count", "value": 4}, {"name": "Input Size", "unit": "byte", "value": 3854}, {"name": "Output Size", "unit": "byte", "value": 470}], "Time": [{"name": "Time Consumed", "unit": "us", "value": 100}, {"name": "Wait Time", "unit": "us", "value": 770}]}, "totalStats": {"name": "Time spent", "unit": "us", "value": 100}}
*************************** 2. row ***************************
statement_id: 58616e4a-8d7f-11ed-ad54-3ebf9f3960c8
   statement: select task_id, task_metadata_id, task_metadata_executor, task_metadata_context, task_metadata_option, task_parent_id, task_status, task_runner, task_epoch, last_heartbeat, result_code, error_msg, create_at, end_at from mo_task.sys_async_task where task_id > 15 and task_runner = "dd1dccb4-4d3c-41f8-b482-5251dc7a41bf" order by task_id limit 1
       stats: {"statistics": {"IO": [{"name": "Disk IO", "unit": "byte", "value": 0}, {"name": "S3 IO", "unit": "byte", "value": 1326}], "Memory": [{"name": "Memory Size", "unit": "byte", "value": 5}], "Network": [{"name": "Network", "unit": "byte", "value": 0}], "Throughput": [{"name": "Input Rows", "unit": "count", "value": 5}, {"name": "Output Rows", "unit": "count", "value": 0}, {"name": "Input Size", "unit": "byte", "value": 1326}, {"name": "Output Size", "unit": "byte", "value": 0}], "Time": [{"name": "Time Consumed", "unit": "us", "value": 12}, {"name": "Wait Time", "unit": "us", "value": 421}]}, "totalStats": {"name": "Time spent", "unit": "us", "value": 12}}
...
```