### PR TITLE
fileservice: do not check IOEntry.Size when reading to the end of file in LocalFS/LocalETLFS.Read

### DIFF
--- a/pkg/fileservice/file_service_test.go
+++ b/pkg/fileservice/file_service_test.go
@@ -163,6 +163,7 @@ func testFileService(
 	t.Run("WriterForRead", func(t *testing.T) {
 		fs := newFS(fsName)
 		ctx := context.Background()
+
 		err := fs.Write(ctx, IOVector{
 			FilePath: "foo",
 			Entries: []IOEntry{
@@ -174,6 +175,7 @@ func testFileService(
 			},
 		})
 		assert.Nil(t, err)
+
 		buf := new(bytes.Buffer)
 		vec := &IOVector{
 			FilePath: "foo",
@@ -188,6 +190,22 @@ func testFileService(
 		err = fs.Read(ctx, vec)
 		assert.Nil(t, err)
 		assert.Equal(t, []byte("1234"), buf.Bytes())
+
+		buf = new(bytes.Buffer)
+		vec = &IOVector{
+			FilePath: "foo",
+			Entries: []IOEntry{
+				{
+					Offset:        0,
+					Size:          -1,
+					WriterForRead: buf,
+				},
+			},
+		}
+		err = fs.Read(ctx, vec)
+		assert.Nil(t, err)
+		assert.Equal(t, []byte("1234"), buf.Bytes())
+
 	})
 
 	t.Run("ReadCloserForRead", func(t *testing.T) {

--- a/pkg/fileservice/local_etl_fs.go
+++ b/pkg/fileservice/local_etl_fs.go
@@ -204,7 +204,7 @@ func (l *LocalETLFS) Read(ctx context.Context, vector *IOVector) error {
 				}
 				vector.Entries[i].Object = obj
 				vector.Entries[i].ObjectSize = size
-				if cr.N != entry.Size {
+				if entry.Size > 0 && cr.N != entry.Size {
 					return moerr.NewUnexpectedEOFNoCtx(path.File)
 				}
 
@@ -213,7 +213,7 @@ func (l *LocalETLFS) Read(ctx context.Context, vector *IOVector) error {
 				if err != nil {
 					return err
 				}
-				if n != int64(entry.Size) {
+				if entry.Size > 0 && n != int64(entry.Size) {
 					return moerr.NewUnexpectedEOFNoCtx(path.File)
 				}
 			}

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -271,7 +271,7 @@ func (l *LocalFS) read(ctx context.Context, vector *IOVector) error {
 				}
 				vector.Entries[i].Object = obj
 				vector.Entries[i].ObjectSize = size
-				if cr.N != entry.Size {
+				if entry.Size > 0 && cr.N != entry.Size {
 					return moerr.NewUnexpectedEOFNoCtx(path.File)
 				}
 
@@ -280,7 +280,7 @@ func (l *LocalFS) read(ctx context.Context, vector *IOVector) error {
 				if err != nil {
 					return err
 				}
-				if n != int64(entry.Size) {
+				if entry.Size > 0 && n != int64(entry.Size) {
 					return moerr.NewUnexpectedEOFNoCtx(path.File)
 				}
 			}


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: