### PR TITLE
Take global logger as the default logger for logtail server

### DIFF
--- a/pkg/vm/engine/tae/logtail/service/server.go
+++ b/pkg/vm/engine/tae/logtail/service/server.go
@@ -150,7 +150,7 @@ func NewLogtailServer(
 	address string, cfg *options.LogtailServerCfg, logtail taelogtail.Logtailer, clock clock.Clock, opts ...ServerOption,
 ) (*LogtailServer, error) {
 	s := &LogtailServer{
-		logger:     logutil.GetLogger(),
+		logger:     logutil.GetGlobalLogger(),
 		cfg:        cfg,
 		ssmgr:      NewSessionManager(),
 		waterline:  NewWaterliner(clock),

--- a/pkg/vm/engine/tae/logtail/service/service_test.go
+++ b/pkg/vm/engine/tae/logtail/service/service_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/pb/logtail"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -45,6 +46,7 @@ func TestService(t *testing.T) {
 	/* ---- construct logtail server ---- */
 	logtailServer, err := NewLogtailServer(
 		address, options.NewDefaultLogtailServerCfg(), logtailer, clock,
+		WithServerLogger(logutil.GetLogger()),
 		WithServerCollectInterval(500*time.Millisecond),
 		WithServerSendTimeout(5*time.Second),
 		WithServerEnableChecksum(true),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6894

## What this PR does / why we need it:
The debug log should be under control, and we must change the default logger for `logtail server`.