### PR TITLE
Take dnservice's logger for tae engine's logtail server

### DIFF
--- a/pkg/dnservice/factory.go
+++ b/pkg/dnservice/factory.go
@@ -157,6 +157,7 @@ func (s *store) newTAEStorage(shard metadata.DNShard, factory logservice.ClientF
 		fs,
 		s.rt.Clock(),
 		ckpcfg,
+		s.rt.Logger().RawLogger(),
 		logtailServerAddr,
 		logtailServerCfg,
 		options.LogstoreType(s.cfg.Txn.Storage.LogBackend))

--- a/pkg/dnservice/factory.go
+++ b/pkg/dnservice/factory.go
@@ -155,9 +155,8 @@ func (s *store) newTAEStorage(shard metadata.DNShard, factory logservice.ClientF
 		shard,
 		factory,
 		fs,
-		s.rt.Clock(),
+		s.rt,
 		ckpcfg,
-		s.rt.Logger().RawLogger(),
 		logtailServerAddr,
 		logtailServerCfg,
 		options.LogstoreType(s.cfg.Txn.Storage.LogBackend))

--- a/pkg/txn/storage/tae/storage.go
+++ b/pkg/txn/storage/tae/storage.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/rpc"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 )
 
 type taeStorage struct {
@@ -48,6 +49,7 @@ func NewTAEStorage(
 	fs fileservice.FileService,
 	clock clock.Clock,
 	ckpCfg *options.CheckpointCfg,
+	logger *zap.Logger,
 	logtailServerAddr string,
 	logtailServerCfg *options.LogtailServerCfg,
 	logStore options.LogstoreType,
@@ -64,7 +66,10 @@ func NewTAEStorage(
 	taeHandler := rpc.NewTAEHandle(dataDir, opt)
 	tae := taeHandler.GetTxnEngine().GetTAE(context.Background())
 	logtailer := logtail.NewLogtailer(tae.BGCheckpointRunner, tae.LogtailMgr, tae.Catalog)
-	server, err := service.NewLogtailServer(logtailServerAddr, logtailServerCfg, logtailer, clock)
+	server, err := service.NewLogtailServer(
+		logtailServerAddr, logtailServerCfg, logtailer, clock,
+		service.WithServerLogger(logger),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/txn/storage/tae/storage.go
+++ b/pkg/txn/storage/tae/storage.go
@@ -17,12 +17,14 @@ package taestorage
 import (
 	"context"
 
+	"go.uber.org/multierr"
+
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
-	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/matrixorigin/matrixone/pkg/txn/storage"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/rpchandle"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logstore/driver/logservicedriver"
@@ -30,8 +32,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail/service"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/rpc"
-	"go.uber.org/multierr"
-	"go.uber.org/zap"
 )
 
 type taeStorage struct {
@@ -47,15 +47,14 @@ func NewTAEStorage(
 	shard metadata.DNShard,
 	factory logservice.ClientFactory,
 	fs fileservice.FileService,
-	clock clock.Clock,
+	rt runtime.Runtime,
 	ckpCfg *options.CheckpointCfg,
-	logger *zap.Logger,
 	logtailServerAddr string,
 	logtailServerCfg *options.LogtailServerCfg,
 	logStore options.LogstoreType,
 ) (*taeStorage, error) {
 	opt := &options.Options{
-		Clock:         clock,
+		Clock:         rt.Clock(),
 		Fs:            fs,
 		Lc:            logservicedriver.LogServiceClientFactory(factory),
 		Shard:         shard,
@@ -66,10 +65,7 @@ func NewTAEStorage(
 	taeHandler := rpc.NewTAEHandle(dataDir, opt)
 	tae := taeHandler.GetTxnEngine().GetTAE(context.Background())
 	logtailer := logtail.NewLogtailer(tae.BGCheckpointRunner, tae.LogtailMgr, tae.Catalog)
-	server, err := service.NewLogtailServer(
-		logtailServerAddr, logtailServerCfg, logtailer, clock,
-		service.WithServerLogger(logger),
-	)
+	server, err := service.NewLogtailServer(logtailServerAddr, logtailServerCfg, logtailer, rt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vm/engine/tae/logtail/service/session.go
+++ b/pkg/vm/engine/tae/logtail/service/session.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/log"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
@@ -51,7 +52,7 @@ func NewSessionManager() *SessionManager {
 // GetSession constructs a session for new morpc.ClientSession.
 func (sm *SessionManager) GetSession(
 	rootCtx context.Context,
-	logger *zap.Logger,
+	logger *log.MOLogger,
 	sendTimeout time.Duration,
 	pooler ResponsePooler,
 	notifier SessionErrorNotifier,
@@ -119,7 +120,7 @@ type Session struct {
 	cancelFunc context.CancelFunc
 	wg         sync.WaitGroup
 
-	logger      *zap.Logger
+	logger      *log.MOLogger
 	sendTimeout time.Duration
 	pooler      ResponsePooler
 	notifier    SessionErrorNotifier
@@ -144,7 +145,7 @@ type ResponsePooler interface {
 // NewSession constructs a session for logtail client.
 func NewSession(
 	rootCtx context.Context,
-	logger *zap.Logger,
+	logger *log.MOLogger,
 	sendTimeout time.Duration,
 	pooler ResponsePooler,
 	notifier SessionErrorNotifier,

--- a/pkg/vm/engine/tae/logtail/service/session_test.go
+++ b/pkg/vm/engine/tae/logtail/service/session_test.go
@@ -23,11 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/matrixorigin/matrixone/pkg/common/log"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/pb/logtail"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 )
 
 func TestSessionManger(t *testing.T) {
@@ -36,21 +38,21 @@ func TestSessionManger(t *testing.T) {
 	ctx := context.Background()
 
 	// constructs mocker
-	logger := logutil.GetGlobalLogger().Named(LogtailServiceRPCName)
+	logger := mockMOLogger()
 	pooler := mockResponsePooler()
-	notifier := mockSessionErrorNotifier(logger)
+	notifier := mockSessionErrorNotifier(logger.RawLogger())
 	sendTimeout := 5 * time.Second
 	poisionTime := 10 * time.Millisecond
 
 	/* ---- 1. register sessioin A ---- */
-	csA := mockNormalClientSession(logger)
+	csA := mockNormalClientSession(logger.RawLogger())
 	streamA := mockMorpcStream(csA, 10)
 	sessionA := sm.GetSession(ctx, logger, sendTimeout, pooler, notifier, streamA, poisionTime)
 	require.NotNil(t, sessionA)
 	require.Equal(t, 1, len(sm.ListSession()))
 
 	/* ---- 2. register sessioin B ---- */
-	csB := mockNormalClientSession(logger)
+	csB := mockNormalClientSession(logger.RawLogger())
 	streamB := mockMorpcStream(csB, 11)
 	sessionB := sm.GetSession(ctx, logger, sendTimeout, pooler, notifier, streamB, poisionTime)
 	require.NotNil(t, sessionB)
@@ -68,9 +70,9 @@ func TestSessionError(t *testing.T) {
 	defer cancel()
 
 	// constructs mocker
-	logger := logutil.GetGlobalLogger().Named(LogtailServiceRPCName)
+	logger := mockMOLogger()
 	pooler := mockResponsePooler()
-	notifier := mockSessionErrorNotifier(logger)
+	notifier := mockSessionErrorNotifier(logger.RawLogger())
 	cs := mockBrokenClientSession()
 	stream := mockMorpcStream(cs, 10)
 	sendTimeout := 5 * time.Second
@@ -106,9 +108,9 @@ func TestPoisionSession(t *testing.T) {
 	defer cancel()
 
 	// constructs mocker
-	logger := logutil.GetGlobalLogger().Named(LogtailServiceRPCName)
+	logger := mockMOLogger()
 	pooler := mockResponsePooler()
-	notifier := mockSessionErrorNotifier(logger)
+	notifier := mockSessionErrorNotifier(logger.RawLogger())
 	cs := mockBlockStream()
 	stream := mockMorpcStream(cs, 10)
 	sendTimeout := 5 * time.Second
@@ -139,10 +141,10 @@ func TestSession(t *testing.T) {
 	defer cancel()
 
 	// constructs mocker
-	logger := logutil.GetGlobalLogger().Named(LogtailServiceRPCName)
+	logger := mockMOLogger()
 	pooler := mockResponsePooler()
-	notifier := mockSessionErrorNotifier(logger)
-	cs := mockNormalClientSession(logger)
+	notifier := mockSessionErrorNotifier(logger.RawLogger())
+	cs := mockNormalClientSession(logger.RawLogger())
 	stream := mockMorpcStream(cs, 10)
 	sendTimeout := 5 * time.Second
 	poisionTime := 10 * time.Millisecond
@@ -380,4 +382,12 @@ func mockMorpcStream(cs morpc.ClientSession, id uint64) morpcStream {
 		id: id,
 		cs: cs,
 	}
+}
+
+func mockMOLogger() *log.MOLogger {
+	return log.GetServiceLogger(
+		logutil.GetGlobalLogger().Named(LogtailServiceRPCName),
+		metadata.ServiceType_DN,
+		"uuid",
+	)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6894

## What this PR does / why we need it:
The log should be under control, and we take dnservice's logger for tae engine's logtail server.