### PR TITLE
fileservice: disable caches in S3 tests

### DIFF
--- a/pkg/fileservice/file_service_bench_test.go
+++ b/pkg/fileservice/file_service_bench_test.go
@@ -46,20 +46,20 @@ func benchmarkFileService(b *testing.B, newFS func() FileService) {
 		assert.Nil(b, err)
 
 		parts2 := fixedSplit(content, 4*1024)
-		readVector := &IOVector{
-			FilePath: "foo",
-		}
-		offset = int64(0)
-		for _, part := range parts2 {
-			readVector.Entries = append(readVector.Entries, IOEntry{
-				Offset: offset,
-				Size:   int64(len(part)),
-			})
-			offset += int64(len(part))
-		}
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
+			readVector := &IOVector{
+				FilePath: "foo",
+			}
+			offset = int64(0)
+			for _, part := range parts2 {
+				readVector.Entries = append(readVector.Entries, IOEntry{
+					Offset: offset,
+					Size:   int64(len(part)),
+				})
+				offset += int64(len(part))
+			}
 			err = fs.Read(ctx, readVector)
 			b.SetBytes(int64(len(content)))
 			assert.Nil(b, err)

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -97,8 +97,8 @@ func TestS3FS(t *testing.T) {
 				config.Endpoint,
 				config.Bucket,
 				time.Now().Format("2006-01-02.15:04:05.000000"),
-				128*1024,
-				128*1024,
+				-1,
+				-1,
 				cacheDir,
 			)
 			assert.Nil(t, err)
@@ -115,8 +115,8 @@ func TestS3FS(t *testing.T) {
 			config.Endpoint,
 			config.Bucket,
 			"",
-			128*1024,
-			128*1024,
+			-1,
+			-1,
 			cacheDir,
 		)
 		assert.Nil(t, err)
@@ -319,8 +319,8 @@ func TestS3FSMinioServer(t *testing.T) {
 				endpoint,
 				"test",
 				time.Now().Format("2006-01-02.15:04:05.000000"),
-				128*1024,
-				128*1024,
+				-1,
+				-1,
 				cacheDir,
 			)
 			assert.Nil(t, err)
@@ -354,8 +354,8 @@ func BenchmarkS3FS(b *testing.B) {
 			config.Endpoint,
 			config.Bucket,
 			time.Now().Format("2006-01-02.15:04:05.000000"),
-			128*1024,
-			128*1024,
+			-1,
+			-1,
 			cacheDir,
 		)
 		assert.Nil(b, err)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
We don't want to test the cache in S3 tests.