### PR TITLE
bugfix: data trace on bufferHolder.buffer

### DIFF
--- a/pkg/util/export/batch_processor.go
+++ b/pkg/util/export/batch_processor.go
@@ -87,9 +87,10 @@ func (b *bufferHolder) Start() {
 // Add call buffer.Add(), while bufferHolder is NOT readonly
 func (b *bufferHolder) Add(item batchpipe.HasName) {
 	b.mux.Lock()
-	b.buffer.Add(item)
+	buf := b.buffer
+	buf.Add(item)
 	b.mux.Unlock()
-	if b.buffer.ShouldFlush() {
+	if buf.ShouldFlush() {
 		b.signal(b)
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/7629

## What this PR does / why we need it:
fix bvt found data race issue.
- found at https://github.com/matrixorigin/matrixone/actions/runs/3890422599/jobs/6639527529

- data race
```
2023-01-11T07:02:29.6342071Z WARNING: DATA RACE
2023-01-11T07:02:29.6342271Z Write at 0x00c00007e078 by goroutine 14:
2023-01-11T07:02:29.6342414Z   ??()
2023-01-11T07:02:29.6342695Z       -:0 +0xd7b434
2023-01-11T07:02:29.6342926Z   sync/atomic.CompareAndSwapInt32()
2023-01-11T07:02:29.6343172Z       <autogenerated>:1 +0x18
2023-01-11T07:02:29.6343555Z   github.com/matrixorigin/matrixone/pkg/util/export.(*dummyBuffer).ShouldFlush()
2023-01-11T07:02:29.6344108Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor_test.go:107 +0x3c
2023-01-11T07:02:29.6344466Z   github.com/matrixorigin/matrixone/pkg/util/export.(*bufferHolder).Add()
2023-01-11T07:02:29.6344993Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor.go:92 +0x90
2023-01-11T07:02:29.6345377Z   github.com/matrixorigin/matrixone/pkg/util/export.(*MOCollector).doCollect()
2023-01-11T07:02:29.6345912Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor.go:299 +0x254
2023-01-11T07:02:29.6346290Z   github.com/matrixorigin/matrixone/pkg/util/export.(*MOCollector).Start.func3()
2023-01-11T07:02:29.6346821Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor.go:257 +0x40
2023-01-11T07:02:29.6346835Z
2023-01-11T07:02:29.6347066Z Previous write at 0x00c00007e078 by goroutine 15:
2023-01-11T07:02:29.6347466Z   github.com/matrixorigin/matrixone/pkg/util/export.(*dummyPipeImpl).NewItemBuffer()
2023-01-11T07:02:29.6348018Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor_test.go:144 +0x140
2023-01-11T07:02:29.6348412Z   github.com/matrixorigin/matrixone/pkg/util/export.(*bufferHolder).getGenerateReq()
2023-01-11T07:02:29.6348940Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor.go:141 +0x16c
2023-01-11T07:02:29.6349297Z   github.com/matrixorigin/matrixone/pkg/util/export.glob..func1.1()
2023-01-11T07:02:29.6349825Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor.go:322 +0x30
2023-01-11T07:02:29.6350176Z   github.com/matrixorigin/matrixone/pkg/util/export.(*bufferHolder).Add()
2023-01-11T07:02:29.6350698Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor.go:93 +0xb0
2023-01-11T07:02:29.6351071Z   github.com/matrixorigin/matrixone/pkg/util/export.(*MOCollector).doCollect()
2023-01-11T07:02:29.6351746Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor.go:299 +0x254
2023-01-11T07:02:29.6352217Z   github.com/matrixorigin/matrixone/pkg/util/export.(*MOCollector).Start.func3()
2023-01-11T07:02:29.6352753Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor.go:257 +0x40
2023-01-11T07:02:29.6352764Z
2023-01-11T07:02:29.6352965Z Goroutine 14 (running) created at:
2023-01-11T07:02:29.6353456Z   github.com/matrixorigin/matrixone/pkg/util/export.(*MOCollector).Start()
2023-01-11T07:02:29.6353997Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor.go:257 +0x194
2023-01-11T07:02:29.6354371Z   github.com/matrixorigin/matrixone/pkg/util/export.TestNewMOCollector()
2023-01-11T07:02:29.6354921Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor_test.go:169 +0x27c
2023-01-11T07:02:29.6355098Z   testing.tRunner()
2023-01-11T07:02:29.6355582Z       /opt/hostedtoolcache/go/1.19.5/arm64/src/testing/testing.go:1446 +0x188
2023-01-11T07:02:29.6355769Z   testing.(*T).Run.func1()
2023-01-11T07:02:29.6356249Z       /opt/hostedtoolcache/go/1.19.5/arm64/src/testing/testing.go:1493 +0x40
2023-01-11T07:02:29.6356260Z
2023-01-11T07:02:29.6356452Z Goroutine 15 (running) created at:
2023-01-11T07:02:29.6357357Z   github.com/matrixorigin/matrixone/pkg/util/export.(*MOCollector).Start()
2023-01-11T07:02:29.6357903Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor.go:257 +0x194
2023-01-11T07:02:29.6358437Z   github.com/matrixorigin/matrixone/pkg/util/export.TestNewMOCollector()
2023-01-11T07:02:29.6358999Z       /runner/_work/matrixone/matrixone/pkg/util/export/batch_processor_test.go:169 +0x27c
2023-01-11T07:02:29.6359173Z   testing.tRunner()
2023-01-11T07:02:29.6359660Z       /opt/hostedtoolcache/go/1.19.5/arm64/src/testing/testing.go:1446 +0x188
2023-01-11T07:02:29.6359848Z   testing.(*T).Run.func1()
2023-01-11T07:02:29.6360328Z       /opt/hostedtoolcache/go/1.19.5/arm64/src/testing/testing.go:1493 +0x40
```