### PR TITLE
use api of blockio to write S3

### DIFF
--- a/pkg/vm/engine/tae/rpc/base_test.go
+++ b/pkg/vm/engine/tae/rpc/base_test.go
@@ -17,9 +17,8 @@ package rpc
 import (
 	"context"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/objectio"
+	catalog2 "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"testing"
 	"time"
 
@@ -747,49 +746,15 @@ func toPBBatch(bat *batch.Batch) (*api.Batch, error) {
 	return rbat, nil
 }
 
-func getIndexDataFromVec(
-	idx uint16,
-	vec *vector.Vector,
-) (objectio.IndexData, objectio.IndexData, error) {
-	var bloomFilter, zoneMap objectio.IndexData
-
-	// get min/max from  vector
-	if vec.Length() > 0 {
-		cvec := containers.NewVectorWithSharedMemory(vec, true)
-
-		// create zone map
-		zm := index.NewZoneMap(vec.Typ)
-		ctx := new(index.KeysCtx)
-		ctx.Keys = cvec
-		ctx.Count = vec.Length()
-		defer ctx.Keys.Close()
-		err := zm.BatchUpdate(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
-		buf, err := zm.Marshal()
-		if err != nil {
-			return nil, nil, err
-		}
-		zoneMap, err = objectio.NewZoneMap(idx, buf)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// create bloomfilter
-		sf, err := index.NewBinaryFuseFilter(cvec)
-		if err != nil {
-			return nil, nil, err
-		}
-		bf, err := sf.Marshal()
-		if err != nil {
-			return nil, nil, err
-		}
-		alg := uint8(0)
-		bloomFilter = objectio.NewBloomFilter(idx, alg, bf)
+func toTAEBatchWithSharedMemory(schema *catalog2.Schema,
+	bat *batch.Batch) *containers.Batch {
+	allNullables := schema.AllNullables()
+	taeBatch := containers.NewEmptyBatch()
+	for i, vec := range bat.Vecs {
+		v := containers.NewVectorWithSharedMemory(vec, allNullables[i])
+		taeBatch.AddVector(bat.Attrs[i], v)
 	}
-
-	return bloomFilter, zoneMap, nil
+	return taeBatch
 }
 
 //gen LogTail

--- a/pkg/vm/engine/tae/rpc/rpc_test.go
+++ b/pkg/vm/engine/tae/rpc/rpc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/dataio/blockio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/mergesort"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables/jobs"
 	"os"
 	"path"
 	"sync"
@@ -59,9 +60,9 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 		DataDir: dir,
 	}
 	//create dir;
-	service, err := fileservice.NewFileService(c)
+	fs, err := fileservice.NewFileService(c)
 	assert.Nil(t, err)
-	opts.Fs = service
+	opts.Fs = fs
 	handle := mockTAEHandle(t, opts)
 	defer handle.HandleClose(context.TODO())
 	IDAlloc := catalog.NewIDAllocator()
@@ -93,70 +94,53 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 	moBats[2] = containers.CopyToMoBatch(taeBats[2])
 	moBats[3] = containers.CopyToMoBatch(taeBats[3])
 
-	//write moBats[0], moBats[1] two blocks into file service
+	//write taeBats[0], taeBats[1] two blocks into file service
 	id := 1
 	objName1 := fmt.Sprintf("%d.seg", id)
-	objectWriter, err := objectio.NewObjectWriter(objName1, service)
-	assert.Nil(t, err)
-	for i, bat := range moBats {
+	writer := blockio.NewWriter(context.Background(),
+		objectio.NewObjectFS(fs, "data"), objName1)
+	for i, bat := range taeBats {
 		if i == 2 {
 			break
 		}
-		fd, err := objectWriter.Write(bat)
+		block, err := writer.WriteBlock(bat)
 		assert.Nil(t, err)
-		for i, mvec := range bat.Vecs {
-			bloomFilter, zoneMap, err := getIndexDataFromVec(uint16(i), mvec)
-			assert.Nil(t, err)
-			if bloomFilter != nil {
-				err = objectWriter.WriteIndex(fd, bloomFilter)
-				assert.Nil(t, err)
-			}
-			if zoneMap != nil {
-				err = objectWriter.WriteIndex(fd, zoneMap)
-				assert.Nil(t, err)
-			}
-		}
+		err = jobs.BuildBlockIndex(writer.GetWriter(), block,
+			schema, bat, true)
+		assert.Nil(t, err)
 	}
-	blocks, err := objectWriter.WriteEnd(context.Background())
+	blocks, err := writer.Sync()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(blocks))
 	metaLoc1, err := blockio.EncodeMetaLocWithObject(
 		blocks[0].GetExtent(),
-		uint32(moBats[0].Vecs[0].Length()),
+		uint32(taeBats[0].Vecs[0].Length()),
 		blocks,
 	)
 	assert.Nil(t, err)
 	metaLoc2, err := blockio.EncodeMetaLocWithObject(
 		blocks[1].GetExtent(),
-		uint32(moBats[1].Vecs[0].Length()),
+		uint32(taeBats[1].Vecs[0].Length()),
 		blocks,
 	)
 	assert.Nil(t, err)
-	//write moBats[3] into file service
+
+	//write taeBats[3] into file service
 	id += 1
 	objName2 := fmt.Sprintf("%d.seg", id)
-	objectWriter, err = objectio.NewObjectWriter(objName2, service)
+	writer = blockio.NewWriter(context.Background(),
+		objectio.NewObjectFS(fs, "data"), objName2)
+	block, err := writer.WriteBlock(taeBats[3])
 	assert.Nil(t, err)
-	fd, err := objectWriter.Write(moBats[3])
+	err = jobs.BuildBlockIndex(writer.GetWriter(),
+		block, schema, taeBats[3], true)
 	assert.Nil(t, err)
-	for i, mvec := range moBats[3].Vecs {
-		bloomFilter, zoneMap, err := getIndexDataFromVec(uint16(i), mvec)
-		assert.Nil(t, err)
-		if bloomFilter != nil {
-			err = objectWriter.WriteIndex(fd, bloomFilter)
-			assert.Nil(t, err)
-		}
-		if zoneMap != nil {
-			err = objectWriter.WriteIndex(fd, zoneMap)
-			assert.Nil(t, err)
-		}
-	}
-	blocks, err = objectWriter.WriteEnd(context.Background())
-	assert.Nil(t, err)
+	blocks, err = writer.Sync()
 	assert.Equal(t, 1, len(blocks))
+	assert.Nil(t, err)
 	metaLoc3, err := blockio.EncodeMetaLocWithObject(
 		blocks[0].GetExtent(),
-		uint32(moBats[3].Vecs[0].Length()),
+		uint32(taeBats[3].Vecs[0].Length()),
 		blocks,
 	)
 	assert.Nil(t, err)
@@ -249,7 +233,7 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 	assert.Equal(t, metaLoc2, loc2)
 	entries = append(entries, addS3BlkEntry1)
 
-	//add one block from S3 into "tbtest" table
+	//add one non-appendable block from S3 into "tbtest" table
 	metaLocBat2 := containers.BuildBatch(attrs, vecTypes, nullable, vecOpts)
 	metaLocBat2.Vecs[0].Append([]byte(metaLoc3))
 	metaLocMoBat2 := containers.CopyToMoBatch(metaLocBat2)
@@ -321,13 +305,15 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 	//write deleted row ids into FS
 	id += 1
 	objName3 := fmt.Sprintf("%d.del", id)
-	objectWriter, err = objectio.NewObjectWriter(objName3, service)
-	assert.Nil(t, err)
+	writer = blockio.NewWriter(context.Background(),
+		objectio.NewObjectFS(fs, "data"), objName3)
 	for _, bat := range hideBats {
-		_, err := objectWriter.Write(bat)
+		taeBat := toTAEBatchWithSharedMemory(schema, bat)
+		//defer taeBat.Close()
+		_, err := writer.WriteBlock(taeBat)
 		assert.Nil(t, err)
 	}
-	blocks, err = objectWriter.WriteEnd(context.Background())
+	blocks, err = writer.Sync()
 	assert.Nil(t, err)
 	assert.Equal(t, len(hideBats), len(blocks))
 	delLoc1, err := blockio.EncodeMetaLocWithObject(

--- a/pkg/vm/engine/tae/tables/jobs/flushblk.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushblk.go
@@ -63,7 +63,7 @@ func (task *flushBlkTask) Execute() error {
 	if err != nil {
 		return err
 	}
-	if err = BuildBlockIndex(writer.GetWriter(), block, task.meta, task.data, true); err != nil {
+	if err = BuildBlockIndex(writer.GetWriter(), block, task.meta.GetSchema(), task.data, true); err != nil {
 		return err
 	}
 	if task.delta != nil {

--- a/pkg/vm/engine/tae/tables/jobs/helper.go
+++ b/pkg/vm/engine/tae/tables/jobs/helper.go
@@ -67,8 +67,7 @@ func BuildColumnIndex(writer objectio.Writer, block objectio.BlockObject, colDef
 	return
 }
 
-func BuildBlockIndex(writer objectio.Writer, block objectio.BlockObject, meta *catalog.BlockEntry, columnsData *containers.Batch, isSorted bool) (err error) {
-	schema := meta.GetSchema()
+func BuildBlockIndex(writer objectio.Writer, block objectio.BlockObject, schema *catalog.Schema, columnsData *containers.Batch, isSorted bool) (err error) {
 	blkMetas := indexwrapper.NewEmptyIndicesMeta()
 	pkIdx := -10086
 	if schema.HasPK() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #7158 

## What this PR does / why we need it:
1.  Use  api of blockio to write S3 , instead of objectio.
2.  UT code of TAE  would  call  it.
3. CN  maybe use it in the future.