### PR TITLE
morpc: reset last received seqence in stream

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -17,6 +17,7 @@ package morpc
 import (
 	"context"
 	"fmt"
+
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -835,7 +836,6 @@ func (s *stream) Send(ctx context.Context, request Message) error {
 	}
 
 	s.sequence++
-	fmt.Printf("steam send %+v with seqence %d\n", request, s.sequence)
 	return s.sendFunc(backendSendMessage{
 		message: RPCMessage{
 			Ctx:            ctx,
@@ -879,7 +879,6 @@ func (s *stream) done(message RPCMessage) {
 	defer s.mu.Unlock()
 
 	if s.mu.closed {
-		fmt.Printf("steam recv %+v with closed\n", message.Message)
 		return
 	}
 
@@ -889,12 +888,10 @@ func (s *stream) done(message RPCMessage) {
 	}
 	if response != nil &&
 		message.streamSequence != s.lastReceivedSequence+1 {
-		fmt.Printf("steam recv %+v with seqence not match, except %d, but got %d\n", message.Message, s.lastReceivedSequence+1, message.streamSequence)
 		response = nil
 	}
 
 	s.lastReceivedSequence = message.streamSequence
-	fmt.Printf("steam recv %+v ok\n", message)
 	s.c <- response
 }
 

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -675,6 +675,12 @@ func TestLockedStream(t *testing.T) {
 	)
 }
 
+func TestIssue7678(t *testing.T) {
+	s := &stream{lastReceivedSequence: 10}
+	s.init(0, false)
+	assert.Equal(t, uint32(0), s.lastReceivedSequence)
+}
+
 func testBackendSend(t *testing.T,
 	handleFunc func(goetty.IOSession, interface{}, uint64) error,
 	testFunc func(b *remoteBackend),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #7678 

## What this PR does / why we need it:
The stream object in morpc is reusable, but lastReceivedSeqence is not reset at reset, so the match detection of seqence does not pass, resulting in some messages being lost.