### PR TITLE
use unsafe.String to convert bytes to string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matrixorigin/matrixone
 
-go 1.19
+go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.0.0

--- a/pkg/lockservice/deadlock.go
+++ b/pkg/lockservice/deadlock.go
@@ -68,7 +68,7 @@ func (d *detector) close() {
 }
 
 func (d *detector) txnClosed(txnID []byte) {
-	v := unsafeByteSliceToString(txnID)
+	v := unsafeBytesToString(txnID)
 	d.ignoreTxns.Delete(v)
 }
 
@@ -133,7 +133,7 @@ func (w *waiters) add(txnID []byte) bool {
 	if bytes.Equal(w.waitTxns[0], txnID) {
 		return false
 	}
-	v := unsafeByteSliceToString(txnID)
+	v := unsafeBytesToString(txnID)
 	if _, ok := w.ignoreTxns.Load(v); ok {
 		return true
 	}

--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -43,7 +43,7 @@ func newMapBasedTxnHandler(fsp *fixedSlicePool) activeTxnHolder {
 func (h *mapBasedTxnHolder) getActiveTxn(
 	txnID []byte,
 	create bool) *activeTxn {
-	txnKey := unsafeByteSliceToString(txnID)
+	txnKey := unsafeBytesToString(txnID)
 	h.mu.RLock()
 	if v, ok := h.mu.activeTxns[txnKey]; ok {
 		h.mu.RUnlock()
@@ -62,7 +62,7 @@ func (h *mapBasedTxnHolder) getActiveTxn(
 }
 
 func (h *mapBasedTxnHolder) deleteActiveTxn(txnID []byte) *activeTxn {
-	txnKey := unsafeByteSliceToString(txnID)
+	txnKey := unsafeBytesToString(txnID)
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	v, ok := h.mu.activeTxns[txnKey]
@@ -155,6 +155,10 @@ func (s *service) getLockTable(tableID uint64) *lockTable {
 	return l
 }
 
-func unsafeByteSliceToString(key []byte) string {
-	return *(*string)(unsafe.Pointer(&key))
+func unsafeBytesToString(b []byte) string {
+	// see https://go.dev/src/internal/coverage/slicereader/slicereader.go#L93
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(&b[0], len(b))
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Go 1.20 introduced unsafe.String, which can convert byte slice to string in a decent way.