### PR TITLE
fileservice: allow printable non-ASCII characters in file path

### DIFF
--- a/pkg/fileservice/file_service.go
+++ b/pkg/fileservice/file_service.go
@@ -53,6 +53,7 @@ type IOVector struct {
 	// service name is optional, if omitted, the receiver FileService will use the default name of the service
 	// file name parts are separated by '/'
 	// valid characters in file name: 0-9 a-z A-Z / ! - _ . * ' ( )
+	// and all printable non-ASCII characters
 	// example:
 	// s3:a/b/c S3:a/b/c represents the same file 'a/b/c' located in 'S3' service
 	FilePath string

--- a/pkg/fileservice/path.go
+++ b/pkg/fileservice/path.go
@@ -18,6 +18,7 @@ import (
 	"encoding/csv"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 )
@@ -50,13 +51,15 @@ func ParsePath(s string) (path Path, err error) {
 		// most common patterns first
 		if r >= '0' && r <= '9' ||
 			r >= 'a' && r <= 'z' ||
-			r >= 'A' && r <= 'Z' ||
-			r == '@' ||
-			r == '/' {
+			r >= 'A' && r <= 'Z' {
 			continue
 		}
 		switch r {
-		case '!', '-', '_', '.', '*', '\'', '(', ')':
+		case '!', '-', '_', '.', '*', '\'', '(', ')', '@', '/':
+			continue
+		}
+		// printable non-ASCII characters
+		if r > unicode.MaxASCII && unicode.IsPrint(r) {
 			continue
 		}
 		err = moerr.NewInvalidPathNoCtx(path.File)

--- a/pkg/fileservice/path_test.go
+++ b/pkg/fileservice/path_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePath(t *testing.T) {
+	path, err := ParsePath("foo")
+	assert.Nil(t, err)
+	assert.Equal(t, "foo", path.File)
+
+	path, err = ParsePath(JoinPath("foo", "bar"))
+	assert.Nil(t, err)
+	assert.Equal(t, "bar", path.File)
+	assert.Equal(t, "foo", path.Service)
+
+	path, err = ParsePath(JoinPath("foo,baz,quux", "bar"))
+	assert.Nil(t, err)
+	assert.Equal(t, "bar", path.File)
+	assert.Equal(t, "foo", path.Service)
+	assert.Equal(t, []string{"baz", "quux"}, path.ServiceArguments)
+
+	path, err = ParsePath("矩阵")
+	assert.Nil(t, err)
+	assert.Equal(t, "矩阵", path.File)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: