### PR TITLE
fileservice: add profiler

### DIFF
--- a/cmd/mo-service/main.go
+++ b/cmd/mo-service/main.go
@@ -70,6 +70,10 @@ func main() {
 	if *allocsProfilePathFlag != "" {
 		defer writeAllocsProfile()
 	}
+	if *fileServiceProfilePathFlag != "" {
+		stop := startFileServiceProfile()
+		defer stop()
+	}
 	if *httpListenAddr != "" {
 		go func() {
 			http.ListenAndServe(*httpListenAddr, nil)

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/google/btree v1.1.2
 	github.com/google/gofuzz v1.2.0
 	github.com/google/gops v0.3.25
+	github.com/google/pprof v0.0.0-20230207041349-798e818bf904
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef

--- a/go.sum
+++ b/go.sum
@@ -286,6 +286,8 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE2YxKWtnnQls6rQjjW5oV7qg2U=
+github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -111,9 +111,15 @@ func (d *DiskCache) Read(
 
 		vector.Entries[i] = entry
 		numHit++
+		d.cacheHit()
 	}
 
 	return nil
+}
+
+//go:noinline
+func (d *DiskCache) cacheHit() {
+	profileAddSample()
 }
 
 func (d *DiskCache) Update(
@@ -166,7 +172,7 @@ func (d *DiskCache) Update(
 		}
 
 		// link
-		if err := os.Symlink(dataPath, linkPath); err != nil {
+		if err := os.Link(dataPath, linkPath); err != nil {
 			if os.IsExist(err) {
 				// ok
 			} else {

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -146,6 +146,8 @@ func (l *LocalFS) write(ctx context.Context, vector IOVector) error {
 	default:
 	}
 
+	profileAddSample()
+
 	path, err := ParsePathAtService(vector.FilePath, l.name)
 	if err != nil {
 		return err
@@ -249,6 +251,8 @@ func (l *LocalFS) read(ctx context.Context, vector *IOVector) error {
 	if vector.allDone() {
 		return nil
 	}
+
+	profileAddSample()
 
 	path, err := ParsePathAtService(vector.FilePath, l.name)
 	if err != nil {
@@ -413,6 +417,8 @@ func (l *LocalFS) List(ctx context.Context, dirPath string) (ret []DirEntry, err
 	default:
 	}
 
+	profileAddSample()
+
 	path, err := ParsePathAtService(dirPath, l.name)
 	if err != nil {
 		return nil, err
@@ -472,6 +478,8 @@ func (l *LocalFS) StatFile(ctx context.Context, filePath string) (*DirEntry, err
 	default:
 	}
 
+	profileAddSample()
+
 	path, err := ParsePathAtService(filePath, l.name)
 	if err != nil {
 		return nil, err
@@ -504,6 +512,8 @@ func (l *LocalFS) Delete(ctx context.Context, filePaths ...string) error {
 		return ctx.Err()
 	default:
 	}
+
+	profileAddSample()
 
 	for _, filePath := range filePaths {
 		if err := l.deleteSingle(ctx, filePath); err != nil {
@@ -650,6 +660,8 @@ func (l *LocalFSMutator) mutate(ctx context.Context, baseOffset int64, entries .
 		return ctx.Err()
 	default:
 	}
+
+	profileAddSample()
 
 	// write
 	for _, entry := range entries {

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -70,10 +70,16 @@ func (m *MemCache) Read(
 			vector.Entries[i].ObjectSize = size
 			vector.Entries[i].done = true
 			numHit++
+			m.cacheHit()
 		}
 	}
 
 	return
+}
+
+//go:noinline
+func (m *MemCache) cacheHit() {
+	profileAddSample()
 }
 
 func (m *MemCache) Update(

--- a/pkg/fileservice/profile.go
+++ b/pkg/fileservice/profile.go
@@ -1,0 +1,140 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"io"
+	"runtime"
+	"sync/atomic"
+
+	"github.com/google/pprof/profile"
+)
+
+func StartProfile(w io.Writer) (stop func()) {
+	state := <-profileChan
+	id := atomic.AddInt64(&nextProfilerID, 1)
+	profiler := newProfiler()
+	state.profilers[id] = profiler
+	profileChan <- state
+	return func() {
+		state := <-profileChan
+		profiler := state.profilers[id]
+		delete(state.profilers, id)
+		profileChan <- state
+		profiler.profile.Write(w)
+	}
+}
+
+var nextProfilerID int64
+
+type profileState struct {
+	profilers map[int64]*profiler
+}
+
+var profileChan = func() chan *profileState {
+	ch := make(chan *profileState, 1)
+	state := &profileState{
+		profilers: make(map[int64]*profiler),
+	}
+	ch <- state
+	return ch
+}()
+
+func profileAddSample() {
+	state := <-profileChan
+	for _, profiler := range state.profilers {
+		profiler.addSample()
+	}
+	profileChan <- state
+}
+
+type profiler struct {
+	profile        *profile.Profile
+	functionIDs    map[uint64]bool
+	nextLocationID uint64
+}
+
+func newProfiler() *profiler {
+	return &profiler{
+		profile: &profile.Profile{
+			SampleType: []*profile.ValueType{
+				{
+					Type: "count",
+					Unit: "count",
+				},
+			},
+		},
+		functionIDs: make(map[uint64]bool),
+	}
+}
+
+func (p *profiler) getFunction(function *runtime.Func, pc uintptr) *profile.Function {
+	file, line := function.FileLine(pc)
+	id := uint64(function.Entry())
+	fn := &profile.Function{
+		ID:        id,
+		Name:      function.Name(),
+		Filename:  file,
+		StartLine: int64(line),
+	}
+	if _, ok := p.functionIDs[id]; !ok {
+		p.profile.Function = append(p.profile.Function, fn)
+		p.functionIDs[id] = true
+	}
+	return fn
+}
+
+func (p *profiler) getLocation(frame runtime.Frame) *profile.Location {
+	p.nextLocationID++
+	loc := &profile.Location{
+		ID: p.nextLocationID,
+		Line: []profile.Line{
+			{
+				Function: p.getFunction(frame.Func, frame.PC),
+				Line:     int64(frame.Line),
+			},
+		},
+	}
+	p.profile.Location = append(p.profile.Location, loc)
+	return loc
+}
+
+func (p *profiler) addSample() {
+	p.nextLocationID++
+	sample := &profile.Sample{
+		Value: []int64{
+			1,
+		},
+	}
+
+	pcs := make([]uintptr, 1024)
+	pcs = pcs[:runtime.Callers(2, pcs)]
+	frames := runtime.CallersFrames(pcs)
+	for {
+		frame, more := frames.Next()
+		if frame.Func == nil {
+			// inline
+			continue
+		}
+		location := p.getLocation(frame)
+		sample.Location = append(sample.Location, location)
+
+		if !more {
+			break
+		}
+	}
+
+	p.profile.Sample = append(p.profile.Sample, sample)
+}

--- a/pkg/fileservice/profile_test.go
+++ b/pkg/fileservice/profile_test.go
@@ -1,0 +1,38 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProfile(t *testing.T) {
+	t.Skip()
+	out, err := os.Create("prof")
+	assert.Nil(t, err)
+	defer out.Close()
+	stop := StartProfile(out)
+	defer stop()
+
+	testFileService(t, func(name string) FileService {
+		dir := t.TempDir()
+		fs, err := NewLocalFS(name, dir, -1)
+		assert.Nil(t, err)
+		return fs
+	})
+}

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -127,7 +127,7 @@ func TestS3FS(t *testing.T) {
 		assert.True(t, len(entries) > 0)
 	})
 
-	t.Run("caching file service", func(t *testing.T) {
+	t.Run("mem caching file service", func(t *testing.T) {
 		cacheDir := t.TempDir()
 		testCachingFileService(t, func() CachingFileService {
 			fs, err := NewS3FS(
@@ -137,6 +137,24 @@ func TestS3FS(t *testing.T) {
 				config.Bucket,
 				time.Now().Format("2006-01-02.15:04:05.000000"),
 				128*1024,
+				-1,
+				cacheDir,
+			)
+			assert.Nil(t, err)
+			return fs
+		})
+	})
+
+	t.Run("disk caching file service", func(t *testing.T) {
+		cacheDir := t.TempDir()
+		testCachingFileService(t, func() CachingFileService {
+			fs, err := NewS3FS(
+				"",
+				"s3",
+				config.Endpoint,
+				config.Bucket,
+				time.Now().Format("2006-01-02.15:04:05.000000"),
+				-1,
 				128*1024,
 				cacheDir,
 			)


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

mo-service: add /debug/fs/ http handler
fileservice: add s3 profile point
mo-service: add file-service-profile

Usage:

method 1: start `mo-service` with `-file-service-profile <file path>`, after the program exit, the profile will be written to `<file path>`

method 2: start `mo-service` with `-debug-http :9876`, and open profile with `go tool pprof -http :9999 'http://localhost:9876/debug/fs?seconds=120'`