### PR TITLE
lockservice: make locktable as interface

### DIFF
--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -73,8 +73,7 @@ func (h *mapBasedTxnHolder) deleteActiveTxn(txnID []byte) *activeTxn {
 }
 
 type service struct {
-	tables sync.Map // tableid -> *locktable
-	// activeTxn        sync.Map // txnid -> *activeTxns
+	tables           sync.Map // tableid -> locktable
 	activeTxns       activeTxnHolder
 	fsp              *fixedSlicePool
 	deadlockDetector *detector
@@ -143,14 +142,14 @@ func (s *service) abortDeadlockTxn(txnID []byte) {
 	txn.abort(txnID)
 }
 
-func (s *service) getLockTable(tableID uint64) *lockTable {
+func (s *service) getLockTable(tableID uint64) lockTable {
 	if v, ok := s.tables.Load(tableID); ok {
-		return v.(*lockTable)
+		return v.(lockTable)
 	}
 
-	l := newLockTable(tableID, s.deadlockDetector)
+	l := newLocalLockTable(tableID, s.deadlockDetector)
 	if v, loaded := s.tables.LoadOrStore(tableID, l); loaded {
-		return v.(*lockTable)
+		return v.(lockTable)
 	}
 	return l
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #7066 

## What this PR does / why we need it:
According to our [design](https://github.com/matrixorigin/docs/blob/main/design/pessimistic_txn.md), this make locktable as a interface, and rename origin implemention to localLockTable