### PR TITLE
logservice: fix bug #8154, logservice not working if failover happens.

### DIFF
--- a/pkg/logservice/shardinfo.go
+++ b/pkg/logservice/shardinfo.go
@@ -121,7 +121,7 @@ func (s *Service) getShardInfo(shardID uint64) (pb.ShardInfoQueryResult, bool) {
 	for nodeID, uuid := range shard.Nodes {
 		data, ok := r.GetMeta(uuid)
 		if !ok {
-			return pb.ShardInfoQueryResult{}, false
+			continue
 		}
 		var md storeMeta
 		md.unmarshal(data)


### PR DESCRIPTION
If failover happens, logservice heartbeat cannot work anymore it cannot get HAKeeper client.

See #8154 for more details.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8154

## What this PR does / why we need it:

1. 这个bug只在k8s环境中才会有，因为发生在 GetShardInfo() 中
2. 以3节点为例，当logservice 的一个节点failover，旧的pod被删掉，新的pod加入集群，同时gossip也会对logservice集群做同样的操作
3. 此时，整个集群中的节点为3个，包括2个旧的和1个新的；但是logservice的副本虽然也是3个，但是都是旧的，因为logservice的副本的删除/增加是通过HAKeeper中判断各副本的心跳tick来完成
4. 但是logservice副本无法完成心跳操作，因为在获取 HAKeeper client的时候，GetShardInfo() 中会尝试比较节点和副本的状态，如果状态不一致，就返回错误了，就导致了集群心跳完全停止了
5. 解决办法是，在比较节点和副本的状态时，信息对不上的忽略，只返回匹配上的副本，通过这些副本建立HAKeeper client连接，完成心跳发送，从而完成logservice 副本的删除/增加操作。