### PR TITLE
Improve publishment performance and stability

### DIFF
--- a/pkg/vm/engine/tae/logtail/logtailer.go
+++ b/pkg/vm/engine/tae/logtail/logtailer.go
@@ -16,6 +16,7 @@ package logtail
 
 import (
 	"context"
+	"math"
 
 	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -96,12 +97,10 @@ func (l *LogtailerImpl) RangeLogtail(
 	}
 
 	if checkpointed.GreaterEq(end) {
-		u64Max := uint64(0)
-		u64Max -= 1
 		return []logtail.TableLogtail{{
 			CkpLocation: ckpLoc,
 			Ts:          &to,
-			Table:       &api.TableID{DbId: u64Max, TbId: u64Max},
+			Table:       &api.TableID{DbId: math.MaxUint64, TbId: math.MaxUint64},
 		}}, nil
 	} else if ckpLoc != "" {
 		start = checkpointed.Next()
@@ -174,10 +173,6 @@ type tableRespBuilder struct {
 func (b *tableRespBuilder) build() (logtail.TableLogtail, error) {
 	resp, err := b.collect()
 	if err != nil {
-		return logtail.TableLogtail{}, err
-	}
-	if len(resp.Commands) == 0 {
-		logutil.Info("[Logtail] empty table logtail", zap.Any("t_id", b.tid))
 		return logtail.TableLogtail{}, err
 	}
 	ret := logtail.TableLogtail{}

--- a/pkg/vm/engine/tae/logtail/logtailer.go
+++ b/pkg/vm/engine/tae/logtail/logtailer.go
@@ -147,7 +147,7 @@ func (l *LogtailerImpl) getTableRespBuilder(did, tid uint64, reader *Reader, ckp
 func (l *LogtailerImpl) getCatalogRespBuilder(scope Scope, reader *Reader, ckpLoc string) *tableRespBuilder {
 	b := &tableRespBuilder{
 		did:    pkgcatalog.MO_CATALOG_ID,
-		scope:  ScopeUserTables,
+		scope:  scope,
 		reader: reader,
 		c:      l.c,
 	}

--- a/pkg/vm/engine/tae/logtail/logtailer.go
+++ b/pkg/vm/engine/tae/logtail/logtailer.go
@@ -30,6 +30,7 @@ import (
 // Logtailer provides logtail for the specified table.
 type Logtailer interface {
 	// RangeLogtail returns logtail for all tables within the range (from, to].
+	// NOTE: caller should keep time range monotonous, or there would be a checkpoint.
 	RangeLogtail(
 		ctx context.Context, from, to timestamp.Timestamp,
 	) ([]logtail.TableLogtail, error)

--- a/pkg/vm/engine/tae/logtail/service/server.go
+++ b/pkg/vm/engine/tae/logtail/service/server.go
@@ -16,6 +16,7 @@ package service
 
 import (
 	"context"
+	"math"
 	gotrace "runtime/trace"
 	"time"
 
@@ -444,6 +445,9 @@ func (s *LogtailServer) logtailSender(ctx context.Context) {
 					logger.Error("fail to fetch additional logtail", zap.Error(err))
 					risk += 1
 					return
+				}
+				if len(tails) == 1 && tails[0].Table.TbId == math.MaxUint64 {
+					panic("unexpected checkpoint within time range")
 				}
 
 				// format table ID beforehand


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #6894

## What this PR does / why we need it:
There were some interval spikes when receiving response from DN service.
We've noticed that it isn't stable when fetching incremental log tail.
This PR change the way of log tail fetching with an optimization of complexity: from `O(N*M)` to `O(D*M)`
> `N` is the number of subscribed tables
> `D` is the number of dirty tables
> `M` is the cost for log tail fetching