### PR TITLE
fileservice: replace CacheStats with perfcounter 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -108,6 +108,9 @@
 /pkg/pb/timestamp @zhangxu19830126
 /pkg/pb/txn @zhangxu19830126 
 
+# pkg/perfcounter
+/pkg/perfcounter @reusee
+
 # pkg/sort 
 /pkg/sort @nnsgmsone
 

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -45,5 +45,4 @@ type Cache interface {
 		async bool,
 	) error
 	Flush()
-	CacheStats() *CacheStats
 }

--- a/pkg/fileservice/caching_file_service.go
+++ b/pkg/fileservice/caching_file_service.go
@@ -24,11 +24,6 @@ type CachingFileService interface {
 	// SetAsyncUpdate sets cache update operation to async mode
 	SetAsyncUpdate(bool)
 
-	// CacheStats returns cache statistics
-	CacheStats() *CacheStats
-}
-
-type CacheStats struct {
-	NumRead int64
-	NumHit  int64
+	// CacheCounter returns the internal counter
+	CacheCounter() *Counter
 }

--- a/pkg/fileservice/caching_file_service_test.go
+++ b/pkg/fileservice/caching_file_service_test.go
@@ -32,6 +32,8 @@ func testCachingFileService(
 	fs := newFS()
 	fs.SetAsyncUpdate(false)
 	ctx := context.Background()
+	var counter Counter
+	ctx = WithCounter(ctx, &counter)
 
 	buf := new(bytes.Buffer)
 	err := gob.NewEncoder(buf).Encode(map[int]int{
@@ -89,9 +91,14 @@ func testCachingFileService(
 	assert.Equal(t, 42, m[42])
 	assert.Equal(t, int64(1), vec.Entries[0].ObjectSize)
 
-	stats := fs.CacheStats()
-	assert.Equal(t, stats.NumRead, int64(2))
-	assert.Equal(t, stats.NumHit, int64(1))
+	// counter
+	assert.Equal(t, counter.CacheRead, int64(2))
+	assert.Equal(t, counter.CacheHit, int64(1))
+	{
+		counter := fs.CacheCounter()
+		assert.Equal(t, counter.CacheRead, int64(2))
+		assert.Equal(t, counter.CacheHit, int64(1))
+	}
 
 	// flush
 	fs.FlushCache()

--- a/pkg/fileservice/caching_file_service_test.go
+++ b/pkg/fileservice/caching_file_service_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,8 +33,8 @@ func testCachingFileService(
 	fs := newFS()
 	fs.SetAsyncUpdate(false)
 	ctx := context.Background()
-	var counter Counter
-	ctx = WithCounter(ctx, &counter)
+	var counter perfcounter.Counter
+	ctx = perfcounter.WithCounter(ctx, &counter)
 
 	buf := new(bytes.Buffer)
 	err := gob.NewEncoder(buf).Encode(map[int]int{
@@ -94,11 +95,6 @@ func testCachingFileService(
 	// counter
 	assert.Equal(t, counter.CacheRead, int64(2))
 	assert.Equal(t, counter.CacheHit, int64(1))
-	{
-		counter := fs.CacheCounter()
-		assert.Equal(t, counter.CacheRead, int64(2))
-		assert.Equal(t, counter.CacheHit, int64(1))
-	}
 
 	// flush
 	fs.FlushCache()

--- a/pkg/fileservice/caching_file_service_test.go
+++ b/pkg/fileservice/caching_file_service_test.go
@@ -93,8 +93,8 @@ func testCachingFileService(
 	assert.Equal(t, int64(1), vec.Entries[0].ObjectSize)
 
 	// counter
-	assert.Equal(t, counter.CacheRead, int64(2))
-	assert.Equal(t, counter.CacheHit, int64(1))
+	assert.Equal(t, counter.Cache.Read.Load(), int64(2))
+	assert.Equal(t, counter.Cache.Hit.Load(), int64(1))
 
 	// flush
 	fs.FlushCache()

--- a/pkg/fileservice/config.go
+++ b/pkg/fileservice/config.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 )
 
 const (
@@ -46,24 +47,24 @@ type Config struct {
 type NewFileServicesFunc = func(defaultName string) (*FileServices, error)
 
 // NewFileService create file service from config
-func NewFileService(cfg Config) (FileService, error) {
+func NewFileService(cfg Config, perfCounter *perfcounter.Counter) (FileService, error) {
 	switch strings.ToUpper(cfg.Backend) {
 	case memFileServiceBackend:
-		return newMemFileService(cfg)
+		return newMemFileService(cfg, perfCounter)
 	case diskFileServiceBackend:
-		return newDiskFileService(cfg)
+		return newDiskFileService(cfg, perfCounter)
 	case diskETLFileServiceBackend:
-		return newDiskETLFileService(cfg)
+		return newDiskETLFileService(cfg, perfCounter)
 	case minioFileServiceBackend:
-		return newMinioFileService(cfg)
+		return newMinioFileService(cfg, perfCounter)
 	case s3FileServiceBackend:
-		return newS3FileService(cfg)
+		return newS3FileService(cfg, perfCounter)
 	default:
 		return nil, moerr.NewInternalErrorNoCtx("file service backend %s not implemented", cfg.Backend)
 	}
 }
 
-func newMemFileService(cfg Config) (FileService, error) {
+func newMemFileService(cfg Config, _ *perfcounter.Counter) (FileService, error) {
 	fs, err := NewMemoryFS(cfg.Name)
 	if err != nil {
 		return nil, err
@@ -71,11 +72,12 @@ func newMemFileService(cfg Config) (FileService, error) {
 	return fs, nil
 }
 
-func newDiskFileService(cfg Config) (FileService, error) {
+func newDiskFileService(cfg Config, perfCounter *perfcounter.Counter) (FileService, error) {
 	fs, err := NewLocalFS(
 		cfg.Name,
 		cfg.DataDir,
 		int64(cfg.Cache.MemoryCapacity),
+		perfCounter,
 	)
 	if err != nil {
 		return nil, err
@@ -83,7 +85,7 @@ func newDiskFileService(cfg Config) (FileService, error) {
 	return fs, nil
 }
 
-func newDiskETLFileService(cfg Config) (FileService, error) {
+func newDiskETLFileService(cfg Config, _ *perfcounter.Counter) (FileService, error) {
 	fs, err := NewLocalETLFS(
 		cfg.Name,
 		cfg.DataDir,
@@ -94,7 +96,7 @@ func newDiskETLFileService(cfg Config) (FileService, error) {
 	return fs, nil
 }
 
-func newMinioFileService(cfg Config) (FileService, error) {
+func newMinioFileService(cfg Config, perfCounter *perfcounter.Counter) (FileService, error) {
 	fs, err := NewS3FSOnMinio(
 		cfg.S3.SharedConfigProfile,
 		cfg.Name,
@@ -104,6 +106,7 @@ func newMinioFileService(cfg Config) (FileService, error) {
 		int64(cfg.Cache.MemoryCapacity),
 		int64(cfg.Cache.DiskCapacity),
 		cfg.Cache.DiskPath,
+		perfCounter,
 	)
 	if err != nil {
 		return nil, err
@@ -111,7 +114,7 @@ func newMinioFileService(cfg Config) (FileService, error) {
 	return fs, nil
 }
 
-func newS3FileService(cfg Config) (FileService, error) {
+func newS3FileService(cfg Config, perfCounter *perfcounter.Counter) (FileService, error) {
 	fs, err := NewS3FS(
 		cfg.S3.SharedConfigProfile,
 		cfg.Name,
@@ -121,6 +124,7 @@ func newS3FileService(cfg Config) (FileService, error) {
 		int64(cfg.Cache.MemoryCapacity),
 		int64(cfg.Cache.DiskCapacity),
 		cfg.Cache.DiskPath,
+		perfCounter,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/fileservice/config.go
+++ b/pkg/fileservice/config.go
@@ -47,24 +47,24 @@ type Config struct {
 type NewFileServicesFunc = func(defaultName string) (*FileServices, error)
 
 // NewFileService create file service from config
-func NewFileService(cfg Config, perfCounter *perfcounter.Counter) (FileService, error) {
+func NewFileService(cfg Config, perfCounters []*perfcounter.Counter) (FileService, error) {
 	switch strings.ToUpper(cfg.Backend) {
 	case memFileServiceBackend:
-		return newMemFileService(cfg, perfCounter)
+		return newMemFileService(cfg, perfCounters)
 	case diskFileServiceBackend:
-		return newDiskFileService(cfg, perfCounter)
+		return newDiskFileService(cfg, perfCounters)
 	case diskETLFileServiceBackend:
-		return newDiskETLFileService(cfg, perfCounter)
+		return newDiskETLFileService(cfg, perfCounters)
 	case minioFileServiceBackend:
-		return newMinioFileService(cfg, perfCounter)
+		return newMinioFileService(cfg, perfCounters)
 	case s3FileServiceBackend:
-		return newS3FileService(cfg, perfCounter)
+		return newS3FileService(cfg, perfCounters)
 	default:
 		return nil, moerr.NewInternalErrorNoCtx("file service backend %s not implemented", cfg.Backend)
 	}
 }
 
-func newMemFileService(cfg Config, _ *perfcounter.Counter) (FileService, error) {
+func newMemFileService(cfg Config, _ []*perfcounter.Counter) (FileService, error) {
 	fs, err := NewMemoryFS(cfg.Name)
 	if err != nil {
 		return nil, err
@@ -72,12 +72,12 @@ func newMemFileService(cfg Config, _ *perfcounter.Counter) (FileService, error) 
 	return fs, nil
 }
 
-func newDiskFileService(cfg Config, perfCounter *perfcounter.Counter) (FileService, error) {
+func newDiskFileService(cfg Config, perfCounters []*perfcounter.Counter) (FileService, error) {
 	fs, err := NewLocalFS(
 		cfg.Name,
 		cfg.DataDir,
 		int64(cfg.Cache.MemoryCapacity),
-		perfCounter,
+		perfCounters,
 	)
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func newDiskFileService(cfg Config, perfCounter *perfcounter.Counter) (FileServi
 	return fs, nil
 }
 
-func newDiskETLFileService(cfg Config, _ *perfcounter.Counter) (FileService, error) {
+func newDiskETLFileService(cfg Config, _ []*perfcounter.Counter) (FileService, error) {
 	fs, err := NewLocalETLFS(
 		cfg.Name,
 		cfg.DataDir,
@@ -96,7 +96,7 @@ func newDiskETLFileService(cfg Config, _ *perfcounter.Counter) (FileService, err
 	return fs, nil
 }
 
-func newMinioFileService(cfg Config, perfCounter *perfcounter.Counter) (FileService, error) {
+func newMinioFileService(cfg Config, perfCounters []*perfcounter.Counter) (FileService, error) {
 	fs, err := NewS3FSOnMinio(
 		cfg.S3.SharedConfigProfile,
 		cfg.Name,
@@ -106,7 +106,7 @@ func newMinioFileService(cfg Config, perfCounter *perfcounter.Counter) (FileServ
 		int64(cfg.Cache.MemoryCapacity),
 		int64(cfg.Cache.DiskCapacity),
 		cfg.Cache.DiskPath,
-		perfCounter,
+		perfCounters,
 	)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func newMinioFileService(cfg Config, perfCounter *perfcounter.Counter) (FileServ
 	return fs, nil
 }
 
-func newS3FileService(cfg Config, perfCounter *perfcounter.Counter) (FileService, error) {
+func newS3FileService(cfg Config, perfCounters []*perfcounter.Counter) (FileService, error) {
 	fs, err := NewS3FS(
 		cfg.S3.SharedConfigProfile,
 		cfg.Name,
@@ -124,7 +124,7 @@ func newS3FileService(cfg Config, perfCounter *perfcounter.Counter) (FileService
 		int64(cfg.Cache.MemoryCapacity),
 		int64(cfg.Cache.DiskCapacity),
 		cfg.Cache.DiskPath,
-		perfCounter,
+		perfCounters,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -31,25 +31,25 @@ import (
 //TODO full data. If we know the size and it's small, we can get the whole object in one request and save it to a file named full_data
 
 type DiskCache struct {
-	capacity    int64
-	path        string
-	fileExists  sync.Map
-	perfCounter *perfcounter.Counter
+	capacity     int64
+	path         string
+	fileExists   sync.Map
+	perfCounters []*perfcounter.Counter
 }
 
 func NewDiskCache(
 	path string,
 	capacity int64,
-	perfCounter *perfcounter.Counter,
+	perfCounters []*perfcounter.Counter,
 ) (*DiskCache, error) {
 	err := os.MkdirAll(path, 0755)
 	if err != nil {
 		return nil, err
 	}
 	return &DiskCache{
-		capacity:    capacity,
-		path:        path,
-		perfCounter: perfCounter,
+		capacity:     capacity,
+		path:         path,
+		perfCounters: perfCounters,
 	}, nil
 }
 
@@ -69,7 +69,7 @@ func (d *DiskCache) Read(
 			c.Cache.Hit.Add(numHit)
 			c.Cache.DiskRead.Add(numRead)
 			c.Cache.DiskHit.Add(numHit)
-		}, d.perfCounter)
+		}, d.perfCounters...)
 	}()
 
 	for i, entry := range vector.Entries {

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -25,7 +25,6 @@ import (
 	"sync/atomic"
 
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
-	"github.com/matrixorigin/matrixone/pkg/util/trace"
 )
 
 //TODO LRU
@@ -63,8 +62,6 @@ func (d *DiskCache) Read(
 ) (
 	err error,
 ) {
-	_, span := trace.Start(ctx, "DiskCache.Read")
-	defer span.End()
 
 	var numHit, numRead int64
 	defer func() {

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 )
@@ -66,10 +65,10 @@ func (d *DiskCache) Read(
 	var numHit, numRead int64
 	defer func() {
 		perfcounter.Update(ctx, func(c *perfcounter.Counter) {
-			atomic.AddInt64(&c.CacheRead, numRead)
-			atomic.AddInt64(&c.CacheHit, numHit)
-			atomic.AddInt64(&c.DiskCacheRead, numRead)
-			atomic.AddInt64(&c.DiskCacheHit, numHit)
+			c.Cache.Read.Add(numRead)
+			c.Cache.Hit.Add(numHit)
+			c.Cache.DiskRead.Add(numRead)
+			c.Cache.DiskHit.Add(numHit)
 		}, d.perfCounter)
 	}()
 

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -28,7 +28,7 @@ func TestDiskCache(t *testing.T) {
 	ctx := context.Background()
 
 	// new
-	cache, err := NewDiskCache(dir, 1024)
+	cache, err := NewDiskCache(dir, 1024, nil)
 	assert.Nil(t, err)
 
 	// update
@@ -106,12 +106,12 @@ func TestDiskCache(t *testing.T) {
 	testRead(cache)
 
 	// new cache instance and read
-	cache, err = NewDiskCache(dir, 1024)
+	cache, err = NewDiskCache(dir, 1024, nil)
 	assert.Nil(t, err)
 	testRead(cache)
 
 	// new cache instance and update
-	cache, err = NewDiskCache(dir, 1024)
+	cache, err = NewDiskCache(dir, 1024, nil)
 	assert.Nil(t, err)
 	testUpdate(cache)
 

--- a/pkg/fileservice/example_test.go
+++ b/pkg/fileservice/example_test.go
@@ -30,6 +30,7 @@ func TestCacheWithRCExample(t *testing.T) {
 		"rc",
 		dir,
 		32<<20,
+		nil,
 	)
 	assert.Nil(t, err)
 
@@ -79,6 +80,7 @@ func TestCacheWithReleasableExample(t *testing.T) {
 		"rc",
 		dir,
 		32<<20,
+		nil,
 	)
 	assert.Nil(t, err)
 

--- a/pkg/fileservice/file_services_test.go
+++ b/pkg/fileservice/file_services_test.go
@@ -25,7 +25,7 @@ func TestFileServices(t *testing.T) {
 	t.Run("file service", func(t *testing.T) {
 		testFileService(t, func(name string) FileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS(name, dir, 0)
+			fs, err := NewLocalFS(name, dir, 0, nil)
 			assert.Nil(t, err)
 			fs2, err := NewFileServices(name, fs)
 			assert.Nil(t, err)

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -44,7 +44,7 @@ type LocalFS struct {
 	memCache    *MemCache
 	asyncUpdate bool
 
-	perfCounter *perfcounter.Counter
+	perfCounters []*perfcounter.Counter
 }
 
 var _ FileService = new(LocalFS)
@@ -57,7 +57,7 @@ func NewLocalFS(
 	name string,
 	rootPath string,
 	memCacheCapacity int64,
-	perfCounter *perfcounter.Counter,
+	perfCounters []*perfcounter.Counter,
 ) (*LocalFS, error) {
 
 	// ensure dir
@@ -105,16 +105,16 @@ func NewLocalFS(
 	}
 
 	fs := &LocalFS{
-		name:        name,
-		rootPath:    rootPath,
-		dirFiles:    make(map[string]*os.File),
-		asyncUpdate: true,
-		perfCounter: perfCounter,
+		name:         name,
+		rootPath:     rootPath,
+		dirFiles:     make(map[string]*os.File),
+		asyncUpdate:  true,
+		perfCounters: perfCounters,
 	}
 	if memCacheCapacity > 0 {
 		fs.memCache = NewMemCache(
 			WithLRU(memCacheCapacity),
-			WithPerfCounter(perfCounter),
+			WithPerfCounters(perfCounters),
 		)
 		logutil.Info("fileservice: cache initialized", zap.Any("fs-name", name), zap.Any("capacity", memCacheCapacity))
 	}

--- a/pkg/fileservice/local_fs_test.go
+++ b/pkg/fileservice/local_fs_test.go
@@ -25,7 +25,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("file service", func(t *testing.T) {
 		testFileService(t, func(name string) FileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS(name, dir, -1)
+			fs, err := NewLocalFS(name, dir, -1, nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -34,7 +34,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("mutable file service", func(t *testing.T) {
 		testMutableFileService(t, func() MutableFileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS("local", dir, -1)
+			fs, err := NewLocalFS("local", dir, -1, nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -43,7 +43,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("replaceable file service", func(t *testing.T) {
 		testReplaceableFileService(t, func() ReplaceableFileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS("local", dir, -1)
+			fs, err := NewLocalFS("local", dir, -1, nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -52,7 +52,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("caching file service", func(t *testing.T) {
 		testCachingFileService(t, func() CachingFileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS("local", dir, 128*1024)
+			fs, err := NewLocalFS("local", dir, 128*1024, nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -63,7 +63,7 @@ func TestLocalFS(t *testing.T) {
 func BenchmarkLocalFS(b *testing.B) {
 	benchmarkFileService(b, func() FileService {
 		dir := b.TempDir()
-		fs, err := NewLocalFS("local", dir, -1)
+		fs, err := NewLocalFS("local", dir, -1, nil)
 		assert.Nil(b, err)
 		return fs
 	})

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -16,7 +16,6 @@ package fileservice
 
 import (
 	"context"
-	"sync/atomic"
 
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memcachepolicy"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memcachepolicy/clockpolicy"
@@ -91,10 +90,10 @@ func (m *MemCache) Read(
 	var numHit, numRead int64
 	defer func() {
 		perfcounter.Update(ctx, func(c *perfcounter.Counter) {
-			atomic.AddInt64(&c.CacheRead, numRead)
-			atomic.AddInt64(&c.CacheHit, numHit)
-			atomic.AddInt64(&c.MemCacheRead, numRead)
-			atomic.AddInt64(&c.MemCacheHit, numHit)
+			c.Cache.Read.Add(numRead)
+			c.Cache.Hit.Add(numHit)
+			c.Cache.MemRead.Add(numRead)
+			c.Cache.MemHit.Add(numHit)
 		}, m.counters...)
 	}()
 

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -21,13 +21,14 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memcachepolicy"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memcachepolicy/clockpolicy"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memcachepolicy/lrupolicy"
+	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 )
 
 type MemCache struct {
 	policy   memcachepolicy.Policy
 	ch       chan func()
-	counters []*Counter
+	counters []*perfcounter.Counter
 }
 
 func NewMemCache(opts ...Options) *MemCache {
@@ -62,7 +63,7 @@ func WithClock(capacity int64) Options {
 	}
 }
 
-func WithCacheCounter(counter *Counter) Options {
+func WithPerfCounter(counter *perfcounter.Counter) Options {
 	return func(o *options) {
 		o.counters = append(o.counters, counter)
 	}
@@ -72,7 +73,7 @@ type Options func(*options)
 
 type options struct {
 	policy   memcachepolicy.Policy
-	counters []*Counter
+	counters []*perfcounter.Counter
 }
 
 func defaultOptions() options {
@@ -92,7 +93,7 @@ func (m *MemCache) Read(
 
 	var numHit, numRead int64
 	defer func() {
-		updateCounters(ctx, func(c *Counter) {
+		perfcounter.Update(ctx, func(c *perfcounter.Counter) {
 			atomic.AddInt64(&c.CacheRead, numRead)
 			atomic.AddInt64(&c.CacheHit, numHit)
 			atomic.AddInt64(&c.MemCacheRead, numRead)

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -61,9 +61,9 @@ func WithClock(capacity int64) Options {
 	}
 }
 
-func WithPerfCounter(counter *perfcounter.Counter) Options {
+func WithPerfCounters(counters []*perfcounter.Counter) Options {
 	return func(o *options) {
-		o.counters = append(o.counters, counter)
+		o.counters = append(o.counters, counters...)
 	}
 }
 

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -22,7 +22,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memcachepolicy/clockpolicy"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memcachepolicy/lrupolicy"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
-	"github.com/matrixorigin/matrixone/pkg/util/trace"
 )
 
 type MemCache struct {
@@ -88,8 +87,6 @@ func (m *MemCache) Read(
 ) (
 	err error,
 ) {
-	_, span := trace.Start(ctx, "MemCache.Read")
-	defer span.End()
 
 	var numHit, numRead int64
 	defer func() {

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -26,7 +26,6 @@ import (
 	pathpkg "path"
 	"sort"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -985,7 +984,7 @@ func newS3FS(arguments []string) (*S3FS, error) {
 func (s *S3FS) s3ListObjects(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
 	FSProfileHandler.AddSample()
 	perfcounter.Update(ctx, func(counter *perfcounter.Counter) {
-		atomic.AddInt64(&counter.S3ListObjects, 1)
+		counter.S3.List.Add(1)
 	}, s.perfCounter)
 	return s.s3Client.ListObjectsV2(ctx, params, optFns...)
 }
@@ -993,7 +992,7 @@ func (s *S3FS) s3ListObjects(ctx context.Context, params *s3.ListObjectsV2Input,
 func (s *S3FS) s3HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
 	FSProfileHandler.AddSample()
 	perfcounter.Update(ctx, func(counter *perfcounter.Counter) {
-		atomic.AddInt64(&counter.S3HeadObject, 1)
+		counter.S3.Head.Add(1)
 	}, s.perfCounter)
 	return s.s3Client.HeadObject(ctx, params, optFns...)
 }
@@ -1001,7 +1000,7 @@ func (s *S3FS) s3HeadObject(ctx context.Context, params *s3.HeadObjectInput, opt
 func (s *S3FS) s3PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 	FSProfileHandler.AddSample()
 	perfcounter.Update(ctx, func(counter *perfcounter.Counter) {
-		atomic.AddInt64(&counter.S3PutObject, 1)
+		counter.S3.Put.Add(1)
 	}, s.perfCounter)
 	return s.s3Client.PutObject(ctx, params, optFns...)
 }
@@ -1009,7 +1008,7 @@ func (s *S3FS) s3PutObject(ctx context.Context, params *s3.PutObjectInput, optFn
 func (s *S3FS) s3GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
 	FSProfileHandler.AddSample()
 	perfcounter.Update(ctx, func(counter *perfcounter.Counter) {
-		atomic.AddInt64(&counter.S3GetObject, 1)
+		counter.S3.Get.Add(1)
 	}, s.perfCounter)
 	return s.s3Client.GetObject(ctx, params, optFns...)
 }
@@ -1017,7 +1016,7 @@ func (s *S3FS) s3GetObject(ctx context.Context, params *s3.GetObjectInput, optFn
 func (s *S3FS) s3DeleteObjects(ctx context.Context, params *s3.DeleteObjectsInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
 	FSProfileHandler.AddSample()
 	perfcounter.Update(ctx, func(counter *perfcounter.Counter) {
-		atomic.AddInt64(&counter.S3DeleteObjects, 1)
+		counter.S3.DeleteMulti.Add(1)
 	}, s.perfCounter)
 	return s.s3Client.DeleteObjects(ctx, params, optFns...)
 }
@@ -1025,7 +1024,7 @@ func (s *S3FS) s3DeleteObjects(ctx context.Context, params *s3.DeleteObjectsInpu
 func (s *S3FS) s3DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
 	FSProfileHandler.AddSample()
 	perfcounter.Update(ctx, func(counter *perfcounter.Counter) {
-		atomic.AddInt64(&counter.S3DeleteObject, 1)
+		counter.S3.Delete.Add(1)
 	}, s.perfCounter)
 	return s.s3Client.DeleteObject(ctx, params, optFns...)
 }

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -389,9 +389,6 @@ func (s *S3FS) Read(ctx context.Context, vector *IOVector) (err error) {
 	default:
 	}
 
-	ctx, span := trace.Start(ctx, "S3FS.Read")
-	defer span.End()
-
 	if len(vector.Entries) == 0 {
 		return moerr.NewEmptyVectorNoCtx()
 	}

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,6 +102,7 @@ func TestS3FS(t *testing.T) {
 				-1,
 				-1,
 				cacheDir,
+				nil,
 			)
 			assert.Nil(t, err)
 
@@ -119,12 +121,13 @@ func TestS3FS(t *testing.T) {
 			-1,
 			-1,
 			cacheDir,
+			nil,
 		)
 		assert.Nil(t, err)
 		ctx := context.Background()
-		var counter, counter2 Counter
-		ctx = WithCounter(ctx, &counter)
-		ctx = WithCounter(ctx, &counter2)
+		var counter, counter2 perfcounter.Counter
+		ctx = perfcounter.WithCounter(ctx, &counter)
+		ctx = perfcounter.WithCounter(ctx, &counter2)
 		entries, err := fs.List(ctx, "")
 		assert.Nil(t, err)
 		assert.True(t, len(entries) > 0)
@@ -144,6 +147,7 @@ func TestS3FS(t *testing.T) {
 				128*1024,
 				-1,
 				cacheDir,
+				nil,
 			)
 			assert.Nil(t, err)
 			return fs
@@ -162,6 +166,7 @@ func TestS3FS(t *testing.T) {
 				-1,
 				128*1024,
 				cacheDir,
+				nil,
 			)
 			assert.Nil(t, err)
 			return fs
@@ -415,6 +420,7 @@ func TestS3FSMinioServer(t *testing.T) {
 				-1,
 				-1,
 				cacheDir,
+				nil,
 			)
 			assert.Nil(t, err)
 
@@ -450,6 +456,7 @@ func BenchmarkS3FS(b *testing.B) {
 			-1,
 			-1,
 			cacheDir,
+			nil,
 		)
 		assert.Nil(b, err)
 		return fs

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -131,8 +131,8 @@ func TestS3FS(t *testing.T) {
 		entries, err := fs.List(ctx, "")
 		assert.Nil(t, err)
 		assert.True(t, len(entries) > 0)
-		assert.Equal(t, int64(1), counter.S3ListObjects)
-		assert.Equal(t, int64(1), counter2.S3ListObjects)
+		assert.Equal(t, int64(1), counter.S3.List.Load())
+		assert.Equal(t, int64(1), counter2.S3.List.Load())
 	})
 
 	t.Run("mem caching file service", func(t *testing.T) {

--- a/pkg/objectio/fs.go
+++ b/pkg/objectio/fs.go
@@ -34,7 +34,7 @@ func TmpNewFileservice(dir string) fileservice.FileService {
 		Backend: "DISK",
 		DataDir: dir,
 	}
-	service, err := fileservice.NewFileService(c)
+	service, err := fileservice.NewFileService(c, nil)
 	if err != nil {
 		err = moerr.NewInternalErrorNoCtx(fmt.Sprintf("NewFileService failed: %s", err.Error()))
 		panic(any(err))

--- a/pkg/objectio/writer_test.go
+++ b/pkg/objectio/writer_test.go
@@ -71,7 +71,7 @@ func TestNewObjectWriter(t *testing.T) {
 		Backend: "DISK",
 		DataDir: dir,
 	}
-	service, err := fileservice.NewFileService(c)
+	service, err := fileservice.NewFileService(c, nil)
 	assert.Nil(t, err)
 
 	objectWriter, err := NewObjectWriter(name, service)

--- a/pkg/perfcounter/context.go
+++ b/pkg/perfcounter/context.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Matrix Origin
+// Copyright 2023 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,55 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fileservice
+package perfcounter
 
-import (
-	"context"
-)
+import "context"
 
-type Counter struct {
-	S3ListObjects   int64
-	S3HeadObject    int64
-	S3PutObject     int64
-	S3GetObject     int64
-	S3DeleteObjects int64
-	S3DeleteObject  int64
-
-	CacheRead     int64
-	CacheHit      int64
-	MemCacheRead  int64
-	MemCacheHit   int64
-	DiskCacheRead int64
-	DiskCacheHit  int64
-}
+type Counters = map[*Counter]struct{}
 
 type ctxKeyCounters struct{}
 
 var CtxKeyCounters = ctxKeyCounters{}
-
-type Counters = map[*Counter]struct{}
-
-func updateCounters(ctx context.Context, fn func(*Counter), extraCounters ...*Counter) {
-	v := ctx.Value(CtxKeyCounters)
-	var counters Counters
-	if v != nil {
-		counters = v.(Counters)
-		for counter := range counters {
-			fn(counter)
-		}
-	}
-	for _, counter := range extraCounters {
-		if counter == nil {
-			continue
-		}
-		if counters != nil {
-			if _, ok := counters[counter]; ok {
-				continue
-			}
-		}
-		fn(counter)
-	}
-}
 
 func WithCounter(ctx context.Context, counter *Counter) context.Context {
 	// check existed

--- a/pkg/perfcounter/counter.go
+++ b/pkg/perfcounter/counter.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Matrix Origin
+// Copyright 2023 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fileservice
+package perfcounter
 
-// CachingFileService is an extension to the FileService
-type CachingFileService interface {
-	FileService
+type Counter struct {
+	S3ListObjects   int64
+	S3HeadObject    int64
+	S3PutObject     int64
+	S3GetObject     int64
+	S3DeleteObjects int64
+	S3DeleteObject  int64
 
-	// FlushCache flushes cache
-	FlushCache()
-
-	// SetAsyncUpdate sets cache update operation to async mode
-	SetAsyncUpdate(bool)
+	CacheRead     int64
+	CacheHit      int64
+	MemCacheRead  int64
+	MemCacheHit   int64
+	DiskCacheRead int64
+	DiskCacheHit  int64
 }

--- a/pkg/perfcounter/counter.go
+++ b/pkg/perfcounter/counter.go
@@ -14,18 +14,24 @@
 
 package perfcounter
 
-type Counter struct {
-	S3ListObjects   int64
-	S3HeadObject    int64
-	S3PutObject     int64
-	S3GetObject     int64
-	S3DeleteObjects int64
-	S3DeleteObject  int64
+import "sync/atomic"
 
-	CacheRead     int64
-	CacheHit      int64
-	MemCacheRead  int64
-	MemCacheHit   int64
-	DiskCacheRead int64
-	DiskCacheHit  int64
+type Counter struct {
+	S3 struct {
+		List        atomic.Int64
+		Head        atomic.Int64
+		Put         atomic.Int64
+		Get         atomic.Int64
+		Delete      atomic.Int64
+		DeleteMulti atomic.Int64
+	}
+
+	Cache struct {
+		Read     atomic.Int64
+		Hit      atomic.Int64
+		MemRead  atomic.Int64
+		MemHit   atomic.Int64
+		DiskRead atomic.Int64
+		DiskHit  atomic.Int64
+	}
 }

--- a/pkg/perfcounter/update_test.go
+++ b/pkg/perfcounter/update_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Matrix Origin
+// Copyright 2023 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,37 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fileservice
+package perfcounter
 
 import (
-	"io"
+	"context"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
-func TestProfile(t *testing.T) {
-	stop := FSProfileHandler.StartProfile(io.Discard)
-	defer stop()
-	testFileService(t, func(name string) FileService {
-		dir := t.TempDir()
-		fs, err := NewLocalFS(name, dir, -1, nil)
-		assert.Nil(t, err)
-		return fs
-	})
-}
-
-func BenchmarkNoProfileAddSample(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		FSProfileHandler.AddSample()
-	}
-}
-
-func BenchmarkProfileAddSample(b *testing.B) {
-	stop := FSProfileHandler.StartProfile(io.Discard)
-	defer stop()
+func BenchmarkUpdate(b *testing.B) {
+	counter := new(Counter)
+	ctx := WithCounter(context.Background(), counter)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		FSProfileHandler.AddSample()
+		Update(ctx, func(c *Counter) {
+		})
 	}
 }

--- a/pkg/tests/service/fileservice.go
+++ b/pkg/tests/service/fileservice.go
@@ -51,7 +51,7 @@ func (c *testCluster) buildFileServices() *fileServices {
 	}
 	if c.opt.keepData {
 		factory = func(dir string, name string) fileservice.FileService {
-			fs, err := fileservice.NewLocalFS(name, filepath.Join(dir, name), 0)
+			fs, err := fileservice.NewLocalFS(name, filepath.Join(dir, name), 0, nil)
 			require.NoError(c.t, err)
 			return fs
 		}

--- a/pkg/util/export/etl/csv_test.go
+++ b/pkg/util/export/etl/csv_test.go
@@ -38,7 +38,7 @@ func TestLocalFSWriter(t *testing.T) {
 	t.Logf("whereami: %s, %s", selfDir, basedir)
 
 	require.Equal(t, nil, err)
-	fs, err := fileservice.NewLocalFS("test", path.Join(basedir, "system"), mpool.MB)
+	fs, err := fileservice.NewLocalFS("test", path.Join(basedir, "system"), mpool.MB, nil)
 	require.Equal(t, nil, err)
 	ctx := context.Background()
 	// csv_test.go:23: whereami: /private/var/folders/lw/05zz3bq12djbnhv1wyzk2jgh0000gn/T/GoLand
@@ -155,7 +155,7 @@ func TestFSWriter_Write(t *testing.T) {
 	require.Equal(t, nil, err)
 	t.Logf("path: %s", path)
 
-	localFs, err := fileservice.NewLocalFS(defines.ETLFileServiceName, basedir, mpool.MB) // db root database.
+	localFs, err := fileservice.NewLocalFS(defines.ETLFileServiceName, basedir, mpool.MB, nil) // db root database.
 	require.Equal(t, nil, err)
 	tests := []struct {
 		name    string

--- a/pkg/util/export/etl/tae_test.go
+++ b/pkg/util/export/etl/tae_test.go
@@ -63,7 +63,7 @@ func TestTAEWriter_WriteElems(t *testing.T) {
 	}
 	var services = make([]fileservice.FileService, 0, 1)
 	for _, config := range configs {
-		service, err := fileservice.NewFileService(config)
+		service, err := fileservice.NewFileService(config, nil)
 		require.Nil(t, err)
 		services = append(services, service)
 	}
@@ -171,7 +171,7 @@ func TestTAEWriter_WriteRow(t *testing.T) {
 	}
 	var services = make([]fileservice.FileService, 0, 1)
 	for _, config := range configs {
-		service, err := fileservice.NewFileService(config)
+		service, err := fileservice.NewFileService(config, nil)
 		require.Nil(t, err)
 		services = append(services, service)
 	}
@@ -313,7 +313,7 @@ func TestTaeReadFile(t *testing.T) {
 	}
 	var services = make([]fileservice.FileService, 0, 1)
 	for _, config := range configs {
-		service, err := fileservice.NewFileService(config)
+		service, err := fileservice.NewFileService(config, nil)
 		require.Nil(t, err)
 		services = append(services, service)
 	}
@@ -385,7 +385,7 @@ func TestTaeReadFile_ReadAll(t *testing.T) {
 	}
 	var services = make([]fileservice.FileService, 0, 1)
 	for _, config := range configs {
-		service, err := fileservice.NewFileService(config)
+		service, err := fileservice.NewFileService(config, nil)
 		require.Nil(t, err)
 		services = append(services, service)
 	}

--- a/pkg/vm/engine/tae/dataio/blockio/writer_test.go
+++ b/pkg/vm/engine/tae/dataio/blockio/writer_test.go
@@ -63,7 +63,7 @@ func TestWriter_WriteBlockAndZoneMap(t *testing.T) {
 		Backend: "DISK",
 		DataDir: dir,
 	}
-	service, err := fileservice.NewFileService(c)
+	service, err := fileservice.NewFileService(c, nil)
 	assert.Nil(t, err)
 	writer, _ := NewBlockWriter(service, name)
 	idxs := make([]uint16, 3)

--- a/pkg/vm/engine/tae/rpc/rpc_test.go
+++ b/pkg/vm/engine/tae/rpc/rpc_test.go
@@ -59,7 +59,7 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 		DataDir: dir,
 	}
 	//create dir;
-	fs, err := fileservice.NewFileService(c)
+	fs, err := fileservice.NewFileService(c, nil)
 	assert.Nil(t, err)
 	opts.Fs = fs
 	handle := mockTAEHandle(t, opts)

--- a/pkg/vm/engine/tae/tables/indexwrapper/bfnode_test.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/bfnode_test.go
@@ -45,7 +45,7 @@ func TestStaticFilterIndex(t *testing.T) {
 		Backend: "DISK",
 		DataDir: dir,
 	}
-	service, err := fileservice.NewFileService(c)
+	service, err := fileservice.NewFileService(c, nil)
 	assert.Nil(t, err)
 
 	objectWriter, err := objectio.NewObjectWriter(name, service)

--- a/pkg/vm/engine/tae/tables/indexwrapper/zmnode_test.go
+++ b/pkg/vm/engine/tae/tables/indexwrapper/zmnode_test.go
@@ -53,7 +53,7 @@ func TestBlockZoneMapIndex(t *testing.T) {
 		Backend: "DISK",
 		DataDir: dir,
 	}
-	service, err := fileservice.NewFileService(c)
+	service, err := fileservice.NewFileService(c, nil)
 	assert.Nil(t, err)
 
 	objectWriter, err := objectio.NewObjectWriter(name, service)

--- a/pkg/vm/pipeline/pipeline.go
+++ b/pkg/vm/pipeline/pipeline.go
@@ -48,8 +48,8 @@ func (p *Pipeline) String() string {
 
 func (p *Pipeline) Run(r engine.Reader, proc *process.Process) (end bool, err error) {
 	// performance counter
-	var perfCounter perfcounter.Counter
-	proc.Ctx = perfcounter.WithCounter(proc.Ctx, &perfCounter)
+	perfCounter := new(perfcounter.Counter)
+	proc.Ctx = perfcounter.WithCounter(proc.Ctx, perfCounter)
 	defer func() {
 		_ = perfCounter //TODO
 	}()

--- a/pkg/vm/pipeline/pipeline.go
+++ b/pkg/vm/pipeline/pipeline.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
@@ -46,6 +47,13 @@ func (p *Pipeline) String() string {
 }
 
 func (p *Pipeline) Run(r engine.Reader, proc *process.Process) (end bool, err error) {
+	// performance counter
+	var perfCounter perfcounter.Counter
+	proc.Ctx = perfcounter.WithCounter(proc.Ctx, &perfCounter)
+	defer func() {
+		_ = perfCounter //TODO
+	}()
+
 	var bat *batch.Batch
 	// used to handle some push-down request
 	if p.reg != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

fileservice: optimize counter updating

fileservice: remove CacheStats

fileservice: make counters in context maps

fileservice: add CachingFileService.CacheCounter