### PR TITLE
morpc: fix TestServerTimeoutCacheWillRemoved

### DIFF
--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -218,7 +218,7 @@ func TestStreamServerWithCache(t *testing.T) {
 
 func TestServerTimeoutCacheWillRemoved(t *testing.T) {
 	testRPCServer(t, func(rs *server) {
-		ctx, cancel := context.WithTimeout(context.TODO(), time.Millisecond*10)
+		ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
 		defer cancel()
 
 		c := newTestClient(t)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8278 

## What this PR does / why we need it:
TestServerTimeoutCacheWillRemoved has too small timeout, and ci is too slow, may make test failed