### PR TITLE
fileservice: remove ETLFileServiceName

### DIFF
--- a/cmd/mo-service/config.go
+++ b/cmd/mo-service/config.go
@@ -139,7 +139,7 @@ func (c *Config) validate() error {
 	}
 	for idx := range c.FileServices {
 		switch c.FileServices[idx].Name {
-		case defines.LocalFileServiceName, defines.ETLFileServiceName:
+		case defines.LocalFileServiceName:
 			if c.FileServices[idx].DataDir == "" {
 				c.FileServices[idx].DataDir = filepath.Join(c.DataDir, strings.ToLower(c.FileServices[idx].Name))
 			}
@@ -211,14 +211,6 @@ func (c *Config) createFileService(defaultName string, perfCounterSet *perfcount
 	_, err = fileservice.Get[fileservice.FileService](fs, defines.SharedFileServiceName)
 	if err != nil {
 		return nil, err
-	}
-
-	// ensure etl exists, for trace & metric
-	if !c.Observability.DisableMetric || !c.Observability.DisableTrace {
-		_, err = fileservice.Get[fileservice.FileService](fs, defines.ETLFileServiceName)
-		if err != nil {
-			return nil, moerr.ConvertPanicError(context.Background(), err)
-		}
 	}
 
 	return fs, nil

--- a/cmd/mo-service/config_test.go
+++ b/cmd/mo-service/config_test.go
@@ -87,10 +87,6 @@ func TestFileServiceFactory(t *testing.T) {
 		Name:    defines.SharedFileServiceName,
 		Backend: "MEM",
 	})
-	c.FileServices = append(c.FileServices, fileservice.Config{
-		Name:    defines.ETLFileServiceName,
-		Backend: "DISK-ETL",
-	})
 
 	fs, err := c.createFileService("A", globalCounterSet, 0, "")
 	assert.NoError(t, err)

--- a/cmd/mo-service/main.go
+++ b/cmd/mo-service/main.go
@@ -123,7 +123,7 @@ func waitSignalToStop(stopper *stopper.Stopper) {
 	}
 }
 
-func startService(ctx context.Context, cfg *Config, stopper *stopper.Stopper, globalCounterSet *perfcounter.CounterSet) error {
+func startService(ctx context.Context, cfg *Config, stopper *stopper.Stopper, globalCounterSet *perfcounter.CounterSet) (err error) {
 	if err := cfg.validate(); err != nil {
 		return err
 	}
@@ -147,7 +147,12 @@ func startService(ctx context.Context, cfg *Config, stopper *stopper.Stopper, gl
 		return err
 	}
 
-	if err = initTraceMetric(ctx, st, cfg, stopper, fs, uuid); err != nil {
+	sharedFS, err := fileservice.Get[fileservice.FileService](fs, defines.SharedFileServiceName)
+	if err != nil {
+		return err
+	}
+	fsForMetrics := fileservice.SubPath(sharedFS, "etl")
+	if err = initTraceMetric(ctx, st, cfg, stopper, fsForMetrics, uuid); err != nil {
 		return err
 	}
 

--- a/pkg/defines/const.go
+++ b/pkg/defines/const.go
@@ -25,7 +25,6 @@ const (
 const (
 	SharedFileServiceName = "SHARED"
 	LocalFileServiceName  = "LOCAL"
-	ETLFileServiceName    = "ETL"
 )
 
 const (

--- a/pkg/dnservice/store_test.go
+++ b/pkg/dnservice/store_test.go
@@ -149,19 +149,13 @@ func runDNStoreTest(
 		if err != nil {
 			return nil, err
 		}
-		s3, err := fileservice.NewMemoryFS(
+		shared, err := fileservice.NewMemoryFS(
 			defines.SharedFileServiceName,
 		)
 		if err != nil {
 			return nil, err
 		}
-		etl, err := fileservice.NewMemoryFS(
-			defines.ETLFileServiceName,
-		)
-		if err != nil {
-			return nil, err
-		}
-		return fileservice.NewFileServices(name, local, s3, etl)
+		return fileservice.NewFileServices(name, local, shared)
 	}, opts...)
 }
 

--- a/pkg/fileservice/config.go
+++ b/pkg/fileservice/config.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 )
 
@@ -107,6 +108,7 @@ func newMinioFileService(cfg Config, perfCounters []*perfcounter.CounterSet) (Fi
 		int64(cfg.Cache.DiskCapacity),
 		cfg.Cache.DiskPath,
 		perfCounters,
+		cfg.Name == defines.ETLFileServiceName,
 	)
 	if err != nil {
 		return nil, err
@@ -125,6 +127,7 @@ func newS3FileService(cfg Config, perfCounters []*perfcounter.CounterSet) (FileS
 		int64(cfg.Cache.DiskCapacity),
 		cfg.Cache.DiskPath,
 		perfCounters,
+		cfg.Name == defines.ETLFileServiceName,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/fileservice/config.go
+++ b/pkg/fileservice/config.go
@@ -15,10 +15,10 @@
 package fileservice
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 )
 
@@ -49,6 +49,9 @@ type NewFileServicesFunc = func(defaultName string) (*FileServices, error)
 
 // NewFileService create file service from config
 func NewFileService(cfg Config, perfCounterSets []*perfcounter.CounterSet) (FileService, error) {
+	if cfg.Name == "" {
+		panic("empty name")
+	}
 	switch strings.ToUpper(cfg.Backend) {
 	case memFileServiceBackend:
 		return newMemFileService(cfg, perfCounterSets)
@@ -74,6 +77,9 @@ func newMemFileService(cfg Config, _ []*perfcounter.CounterSet) (FileService, er
 }
 
 func newDiskFileService(cfg Config, perfCounters []*perfcounter.CounterSet) (FileService, error) {
+	if cfg.DataDir == "" {
+		panic(fmt.Sprintf("empty data dir: %+v", cfg))
+	}
 	fs, err := NewLocalFS(
 		cfg.Name,
 		cfg.DataDir,
@@ -108,7 +114,7 @@ func newMinioFileService(cfg Config, perfCounters []*perfcounter.CounterSet) (Fi
 		int64(cfg.Cache.DiskCapacity),
 		cfg.Cache.DiskPath,
 		perfCounters,
-		cfg.Name == defines.ETLFileServiceName,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -127,7 +133,7 @@ func newS3FileService(cfg Config, perfCounters []*perfcounter.CounterSet) (FileS
 		int64(cfg.Cache.DiskCapacity),
 		cfg.Cache.DiskPath,
 		perfCounters,
-		cfg.Name == defines.ETLFileServiceName,
+		false,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/fileservice/file_service.go
+++ b/pkg/fileservice/file_service.go
@@ -69,6 +69,8 @@ type IOVector struct {
 	// implementations may or may not delete the file after this time
 	// zero value means no expire
 	ExpireAt time.Time
+	// Preload indicates whether the I/O is for preloading
+	Preload bool
 }
 
 type IOEntry struct {

--- a/pkg/fileservice/file_service_test.go
+++ b/pkg/fileservice/file_service_test.go
@@ -49,7 +49,7 @@ func testFileService(
 		ctx := context.Background()
 		fs := newFS(fsName)
 
-		assert.Equal(t, fsName, fs.Name())
+		assert.True(t, strings.Contains(fs.Name(), fsName))
 
 		entries, err := fs.List(ctx, "")
 		assert.Nil(t, err)
@@ -490,7 +490,7 @@ func testFileService(
 		assert.Equal(t, entries[7].Name, "7")
 
 		// with fs name
-		entries, err = fs.List(ctx, JoinPath(fsName, "qux/quux/"))
+		entries, err = fs.List(ctx, JoinPath(fs.Name(), "qux/quux/"))
 		assert.Nil(t, err)
 		assert.Equal(t, len(entries), 8)
 		assert.Equal(t, entries[0].IsDir, false)
@@ -499,7 +499,7 @@ func testFileService(
 		assert.Equal(t, entries[7].Name, "7")
 
 		// with fs name and / prefix and suffix
-		entries, err = fs.List(ctx, JoinPath(fsName, "/qux/quux/"))
+		entries, err = fs.List(ctx, JoinPath(fs.Name(), "/qux/quux/"))
 		assert.Nil(t, err)
 		assert.Equal(t, len(entries), 8)
 		assert.Equal(t, entries[0].IsDir, false)
@@ -779,7 +779,7 @@ func testFileService(
 			},
 		})
 		assert.Nil(t, err)
-		entries, err := fs.List(ctx, JoinPath(fsName, "/path"))
+		entries, err := fs.List(ctx, JoinPath(fs.Name(), "/path"))
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(entries))
 		assert.Equal(t, "to", entries[0].Name)

--- a/pkg/fileservice/path.go
+++ b/pkg/fileservice/path.go
@@ -31,6 +31,17 @@ type Path struct {
 	File             string
 }
 
+func (p Path) String() string {
+	return JoinPath(
+		p.ServiceString(),
+		p.File,
+	)
+}
+
+func (p Path) ServiceString() string {
+	return strings.Join(append([]string{p.Service}, p.ServiceArguments...), ",")
+}
+
 func ParsePath(s string) (path Path, err error) {
 	// split
 	i := strings.LastIndex(s, ServiceNameSeparator)
@@ -86,21 +97,24 @@ func parseService(str string) (service string, arguments []string, err error) {
 	return
 }
 
-func ParsePathAtService(s string, serviceName string) (path Path, err error) {
+func ParsePathAtService(s string, serviceStr string) (path Path, err error) {
 	path, err = ParsePath(s)
 	if err != nil {
 		return
 	}
-	if serviceName != "" &&
+	if serviceStr != "" &&
 		path.Service != "" &&
-		!strings.EqualFold(path.Service, serviceName) {
-		err = moerr.NewWrongServiceNoCtx(serviceName, path.Service)
+		!strings.EqualFold(path.ServiceString(), serviceStr) {
+		err = moerr.NewWrongServiceNoCtx(serviceStr, path.Service)
 		return
 	}
 	return
 }
 
 func JoinPath(serviceName string, path string) string {
+	if len(serviceName) == 0 {
+		return path
+	}
 	buf := new(strings.Builder)
 	buf.WriteString(serviceName)
 	buf.WriteString(ServiceNameSeparator)

--- a/pkg/fileservice/path_test.go
+++ b/pkg/fileservice/path_test.go
@@ -21,22 +21,29 @@ import (
 )
 
 func TestParsePath(t *testing.T) {
-	path, err := ParsePath("foo")
+	p := "foo"
+	path, err := ParsePath(p)
 	assert.Nil(t, err)
 	assert.Equal(t, "foo", path.File)
+	assert.Equal(t, p, path.String())
 
-	path, err = ParsePath(JoinPath("foo", "bar"))
+	p = JoinPath("foo", "bar")
+	path, err = ParsePath(p)
 	assert.Nil(t, err)
 	assert.Equal(t, "bar", path.File)
 	assert.Equal(t, "foo", path.Service)
+	assert.Equal(t, p, path.String())
 
-	path, err = ParsePath(JoinPath("foo,baz,quux", "bar"))
+	p = JoinPath("foo,baz,quux", "bar")
+	path, err = ParsePath(p)
 	assert.Nil(t, err)
 	assert.Equal(t, "bar", path.File)
 	assert.Equal(t, "foo", path.Service)
 	assert.Equal(t, []string{"baz", "quux"}, path.ServiceArguments)
+	assert.Equal(t, p, path.String())
 
 	path, err = ParsePath("矩阵")
 	assert.Nil(t, err)
 	assert.Equal(t, "矩阵", path.File)
+	assert.Equal(t, "矩阵", path.String())
 }

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -73,6 +73,7 @@ func NewS3FS(
 	diskCacheCapacity int64,
 	diskCachePath string,
 	perfCounterSets []*perfcounter.CounterSet,
+	noCache bool,
 ) (*S3FS, error) {
 
 	fs, err := newS3FS([]string{
@@ -88,12 +89,14 @@ func NewS3FS(
 
 	fs.perfCounterSets = perfCounterSets
 
-	if err := fs.initCaches(
-		memCacheCapacity,
-		diskCacheCapacity,
-		diskCachePath,
-	); err != nil {
-		return nil, err
+	if !noCache {
+		if err := fs.initCaches(
+			memCacheCapacity,
+			diskCacheCapacity,
+			diskCachePath,
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	return fs, nil
@@ -111,6 +114,7 @@ func NewS3FSOnMinio(
 	diskCacheCapacity int64,
 	diskCachePath string,
 	perfCounterSets []*perfcounter.CounterSet,
+	noCache bool,
 ) (*S3FS, error) {
 
 	fs, err := newS3FS([]string{
@@ -127,12 +131,14 @@ func NewS3FSOnMinio(
 
 	fs.perfCounterSets = perfCounterSets
 
-	if err := fs.initCaches(
-		memCacheCapacity,
-		diskCacheCapacity,
-		diskCachePath,
-	); err != nil {
-		return nil, err
+	if !noCache {
+		if err := fs.initCaches(
+			memCacheCapacity,
+			diskCacheCapacity,
+			diskCachePath,
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	return fs, nil

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -103,6 +103,7 @@ func TestS3FS(t *testing.T) {
 				-1,
 				cacheDir,
 				nil,
+				true,
 			)
 			assert.Nil(t, err)
 
@@ -122,6 +123,7 @@ func TestS3FS(t *testing.T) {
 			-1,
 			cacheDir,
 			nil,
+			true,
 		)
 		assert.Nil(t, err)
 		ctx := context.Background()
@@ -148,6 +150,7 @@ func TestS3FS(t *testing.T) {
 				-1,
 				cacheDir,
 				nil,
+				false,
 			)
 			assert.Nil(t, err)
 			return fs
@@ -167,6 +170,7 @@ func TestS3FS(t *testing.T) {
 				128*1024,
 				cacheDir,
 				nil,
+				false,
 			)
 			assert.Nil(t, err)
 			return fs
@@ -421,6 +425,7 @@ func TestS3FSMinioServer(t *testing.T) {
 				-1,
 				cacheDir,
 				nil,
+				true,
 			)
 			assert.Nil(t, err)
 
@@ -457,6 +462,7 @@ func BenchmarkS3FS(b *testing.B) {
 			-1,
 			cacheDir,
 			nil,
+			true,
 		)
 		assert.Nil(b, err)
 		return fs

--- a/pkg/fileservice/sub_path.go
+++ b/pkg/fileservice/sub_path.go
@@ -1,0 +1,118 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"context"
+	"path"
+	"strings"
+)
+
+type subPathFS struct {
+	upstream FileService
+	path     string
+	name     string
+}
+
+// SubPath returns a FileService instance that operates at specified sub path of the upstream instance
+func SubPath(upstream FileService, path string) FileService {
+	return &subPathFS{
+		upstream: upstream,
+		path:     path,
+		name: strings.Join([]string{
+			"sub",
+			upstream.Name(),
+			path,
+		}, ","),
+	}
+}
+
+var _ FileService = new(subPathFS)
+
+func (s *subPathFS) Name() string {
+	return s.name
+}
+
+func (s *subPathFS) toUpstreamPath(p string) (string, error) {
+	parsed, err := ParsePathAtService(p, s.name)
+	if err != nil {
+		return "", err
+	}
+	parsed.File = path.Join(s.path, parsed.File)
+	parsed.Service = s.upstream.Name()
+	parsed.ServiceArguments = nil
+	return parsed.String(), nil
+}
+
+func (s *subPathFS) Write(ctx context.Context, vector IOVector) error {
+	p, err := s.toUpstreamPath(vector.FilePath)
+	if err != nil {
+		return err
+	}
+	vector.FilePath = p
+	return s.upstream.Write(ctx, vector)
+}
+
+func (s *subPathFS) Read(ctx context.Context, vector *IOVector) error {
+	subVector := *vector
+	p, err := s.toUpstreamPath(subVector.FilePath)
+	if err != nil {
+		return err
+	}
+	subVector.FilePath = p
+	return s.upstream.Read(ctx, &subVector)
+}
+
+func (s *subPathFS) List(ctx context.Context, dirPath string) ([]DirEntry, error) {
+	p, err := s.toUpstreamPath(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := s.upstream.List(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func (s *subPathFS) Delete(ctx context.Context, filePaths ...string) error {
+	if len(filePaths) == 0 {
+		return nil
+	}
+	if len(filePaths) == 1 {
+		p, err := s.toUpstreamPath(filePaths[0])
+		if err != nil {
+			return err
+		}
+		return s.upstream.Delete(ctx, p)
+	}
+	subPaths := make([]string, 0, len(filePaths))
+	for _, p := range filePaths {
+		pp, err := s.toUpstreamPath(p)
+		if err != nil {
+			return err
+		}
+		subPaths = append(subPaths, pp)
+	}
+	return s.upstream.Delete(ctx, subPaths...)
+}
+
+func (s *subPathFS) StatFile(ctx context.Context, filePath string) (*DirEntry, error) {
+	p, err := s.toUpstreamPath(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return s.upstream.StatFile(ctx, p)
+}

--- a/pkg/fileservice/sub_path_test.go
+++ b/pkg/fileservice/sub_path_test.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubPathFS(t *testing.T) {
+	t.Run("file service", func(t *testing.T) {
+		testFileService(t, func(name string) FileService {
+			upstream, err := NewMemoryFS(name)
+			assert.Nil(t, err)
+			return SubPath(upstream, "foo")
+		})
+	})
+}

--- a/pkg/testutil/util_new.go
+++ b/pkg/testutil/util_new.go
@@ -61,19 +61,14 @@ func NewFS() *fileservice.FileServices {
 	if err != nil {
 		panic(err)
 	}
-	s3, err := fileservice.NewMemoryFS(defines.SharedFileServiceName)
-	if err != nil {
-		panic(err)
-	}
-	etl, err := fileservice.NewMemoryFS(defines.ETLFileServiceName)
+	shared, err := fileservice.NewMemoryFS(defines.SharedFileServiceName)
 	if err != nil {
 		panic(err)
 	}
 	fs, err := fileservice.NewFileServices(
 		"local",
 		local,
-		s3,
-		etl,
+		shared,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/util/export/etl/csv.go
+++ b/pkg/util/export/etl/csv.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/util/export/table"
 )
@@ -112,8 +111,6 @@ type FSWriter struct {
 
 	mux sync.Mutex
 
-	fileServiceName string // const
-
 	offset int // see Write, should not have size bigger than 2GB
 }
 
@@ -125,9 +122,8 @@ func (f FSWriterOption) Apply(w *FSWriter) {
 
 func NewFSWriter(ctx context.Context, fs fileservice.FileService, opts ...FSWriterOption) *FSWriter {
 	w := &FSWriter{
-		ctx:             ctx,
-		fs:              fs,
-		fileServiceName: defines.ETLFileServiceName,
+		ctx: ctx,
+		fs:  fs,
 	}
 	for _, o := range opts {
 		o.Apply(w)
@@ -153,7 +149,7 @@ func (w *FSWriter) Write(p []byte) (n int, err error) {
 mkdirRetry:
 	if err = w.fs.Write(w.ctx, fileservice.IOVector{
 		// like: etl:store/system/filename.csv
-		FilePath: w.fileServiceName + fileservice.ServiceNameSeparator + w.filepath,
+		FilePath: w.filepath,
 		Entries: []fileservice.IOEntry{
 			{
 				Offset: int64(w.offset),

--- a/pkg/util/export/etl/csv_test.go
+++ b/pkg/util/export/etl/csv_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
-	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -150,13 +150,7 @@ func TestFSWriter_Write(t *testing.T) {
 		p []byte
 	}
 
-	basedir := t.TempDir()
-	path, err := filepath.Abs(".")
-	require.Equal(t, nil, err)
-	t.Logf("path: %s", path)
-
-	localFs, err := fileservice.NewLocalFS(defines.ETLFileServiceName, basedir, mpool.MB, nil) // db root database.
-	require.Equal(t, nil, err)
+	fs := testutil.NewFS()
 	tests := []struct {
 		name    string
 		fields  fields
@@ -168,7 +162,7 @@ func TestFSWriter_Write(t *testing.T) {
 			name: "local_fs",
 			fields: fields{
 				ctx:      context.Background(),
-				fs:       localFs,
+				fs:       fs,
 				table:    "dummy",
 				database: "system",
 				nodeUUID: "node_uuid",

--- a/pkg/util/export/etl/tae.go
+++ b/pkg/util/export/etl/tae.go
@@ -25,7 +25,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
-	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/util/export/table"
@@ -50,12 +49,11 @@ type TAEWriter struct {
 }
 
 func NewTAEWriter(ctx context.Context, tbl *table.Table, mp *mpool.MPool, filePath string, fs fileservice.FileService) *TAEWriter {
-	filename := defines.ETLFileServiceName + fileservice.ServiceNameSeparator + filePath
 	w := &TAEWriter{
 		ctx:       ctx,
 		batchSize: BatchSize,
 		mp:        mp,
-		filename:  filename,
+		filename:  filePath,
 		fs:        fs,
 		rows:      make([]*table.Row, 0, BatchSize),
 	}
@@ -65,7 +63,7 @@ func NewTAEWriter(ctx context.Context, tbl *table.Table, mp *mpool.MPool, filePa
 		w.columnsTypes = append(w.columnsTypes, c.ColType.ToType())
 		w.idxs[idx] = uint16(idx)
 	}
-	w.writer, _ = blockio.NewBlockWriter(fs, filename)
+	w.writer, _ = blockio.NewBlockWriter(fs, filePath)
 	return w
 }
 
@@ -303,10 +301,9 @@ type TAEReader struct {
 
 func NewTaeReader(ctx context.Context, tbl *table.Table, filePath string, filesize int64, fs fileservice.FileService, mp *mpool.MPool) (*TAEReader, error) {
 	var err error
-	path := defines.ETLFileServiceName + fileservice.ServiceNameSeparator + filePath
 	r := &TAEReader{
 		ctx:      ctx,
-		filepath: path,
+		filepath: filePath,
 		filesize: filesize,
 		fs:       fs,
 		mp:       mp,

--- a/pkg/util/export/etl/tae_test.go
+++ b/pkg/util/export/etl/tae_test.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
-	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/util/export/table"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace"
@@ -55,24 +55,8 @@ func TestTAEWriter_WriteElems(t *testing.T) {
 	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
 	require.Nil(t, err)
 	ctx := context.TODO()
-	configs := []fileservice.Config{{
-		Name:    defines.ETLFileServiceName,
-		Backend: "DISK",
-		DataDir: t.TempDir(),
-	},
-	}
-	var services = make([]fileservice.FileService, 0, 1)
-	for _, config := range configs {
-		service, err := fileservice.NewFileService(config, nil)
-		require.Nil(t, err)
-		services = append(services, service)
-	}
-	// create FileServices
-	fs, err := fileservice.NewFileServices(
-		defines.LocalFileServiceName,
-		services...,
-	)
-	require.Nil(t, err)
+
+	fs := testutil.NewFS()
 
 	filepath := path.Join(t.TempDir(), "file.tae")
 	writer := NewTAEWriter(ctx, dummyAllTypeTable, mp, filepath, fs)
@@ -91,7 +75,7 @@ func TestTAEWriter_WriteElems(t *testing.T) {
 	// Done. write
 
 	folder := path.Dir(filepath)
-	files, err := fs.List(ctx, defines.ETLFileServiceName+fileservice.ServiceNameSeparator+folder)
+	files, err := fs.List(ctx, folder)
 	require.Nil(t, err)
 	require.Equal(t, 1, len(files))
 
@@ -163,24 +147,7 @@ func TestTAEWriter_WriteRow(t *testing.T) {
 	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
 	require.Nil(t, err)
 	ctx := context.TODO()
-	configs := []fileservice.Config{{
-		Name:    defines.ETLFileServiceName,
-		Backend: "DISK-ETL",
-		DataDir: t.TempDir(),
-	},
-	}
-	var services = make([]fileservice.FileService, 0, 1)
-	for _, config := range configs {
-		service, err := fileservice.NewFileService(config, nil)
-		require.Nil(t, err)
-		services = append(services, service)
-	}
-	// create FileServices
-	fs, err := fileservice.NewFileServices(
-		defines.LocalFileServiceName,
-		services...,
-	)
-	require.Nil(t, err)
+	fs := testutil.NewFS()
 
 	type fields struct {
 		ctx context.Context
@@ -288,7 +255,7 @@ func TestTAEWriter_WriteRow(t *testing.T) {
 			writer.FlushAndClose()
 
 			folder := path.Dir(filePath)
-			entrys, err := fs.List(ctx, defines.ETLFileServiceName+fileservice.ServiceNameSeparator+folder)
+			entrys, err := fs.List(ctx, folder)
 			require.Nil(t, err)
 			require.NotEqual(t, 0, len(entrys))
 			for _, e := range entrys {
@@ -305,26 +272,9 @@ func TestTaeReadFile(t *testing.T) {
 	mp, err := mpool.NewMPool("TestTaeReadFile", 0, mpool.NoFixed)
 	require.Nil(t, err)
 	ctx := context.TODO()
-	configs := []fileservice.Config{{
-		Name:    defines.ETLFileServiceName,
-		Backend: "DISK-ETL",
-		DataDir: "mo-data/etl",
-	},
-	}
-	var services = make([]fileservice.FileService, 0, 1)
-	for _, config := range configs {
-		service, err := fileservice.NewFileService(config, nil)
-		require.Nil(t, err)
-		services = append(services, service)
-	}
-	// create FileServices
-	fs, err := fileservice.NewFileServices(
-		defines.LocalFileServiceName,
-		services...,
-	)
-	require.Nil(t, err)
+	fs := testutil.NewFS()
 
-	entrys, err := fs.List(context.TODO(), "etl:/")
+	entrys, err := fs.List(context.TODO(), "")
 	require.Nil(t, err)
 	if len(entrys) == 0 {
 		t.Skip()
@@ -377,27 +327,10 @@ func TestTaeReadFile_ReadAll(t *testing.T) {
 	mp, err := mpool.NewMPool("TestTaeReadFile", 0, mpool.NoFixed)
 	require.Nil(t, err)
 	ctx := context.TODO()
-	configs := []fileservice.Config{{
-		Name:    defines.ETLFileServiceName,
-		Backend: "DISK-ETL",
-		DataDir: "mo-data/etl",
-	},
-	}
-	var services = make([]fileservice.FileService, 0, 1)
-	for _, config := range configs {
-		service, err := fileservice.NewFileService(config, nil)
-		require.Nil(t, err)
-		services = append(services, service)
-	}
-	// create FileServices
-	fs, err := fileservice.NewFileServices(
-		defines.LocalFileServiceName,
-		services...,
-	)
-	require.Nil(t, err)
+	fs := testutil.NewFS()
 
 	folder := "/sys/logs/2023/01/11/rawlog"
-	entrys, err := fs.List(context.TODO(), "etl:"+folder)
+	entrys, err := fs.List(context.TODO(), folder)
 	require.Nil(t, err)
 	if len(entrys) == 0 {
 		t.Skip()

--- a/pkg/util/export/example/main.go
+++ b/pkg/util/export/example/main.go
@@ -22,22 +22,23 @@ package main
 
 import (
 	"context"
-	"github.com/matrixorigin/matrixone/pkg/config"
-	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
-	"github.com/matrixorigin/matrixone/pkg/txn/clock"
-	"github.com/matrixorigin/matrixone/pkg/util/metric/mometric"
-	"go.uber.org/zap/zapcore"
 	"net/http"
 	"os"
 	"runtime"
 	"sync"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/config"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/txn/clock"
+	"github.com/matrixorigin/matrixone/pkg/util/metric/mometric"
+	"go.uber.org/zap/zapcore"
+
 	_ "net/http/pprof"
 	"runtime/pprof"
 
 	morun "github.com/matrixorigin/matrixone/pkg/common/runtime"
-	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/util/export"
@@ -60,11 +61,7 @@ func main() {
 		DisableStore: true,
 	})
 
-	fs, err := fileservice.NewLocalETLFS(defines.ETLFileServiceName, "mo-data/etl")
-	if err != nil {
-		logutil.Infof("failed open fileservice: %v", err)
-		return
-	}
+	fs := testutil.NewFS()
 	files, err := fs.List(ctx, "/")
 	if err != nil {
 		logutil.Infof("failed list /: %v", err)
@@ -117,7 +114,7 @@ func main() {
 	cancel()
 }
 
-func mergeTable(ctx context.Context, fs *fileservice.LocalETLFS, table *table.Table) {
+func mergeTable(ctx context.Context, fs fileservice.FileService, table *table.Table) {
 	var err error
 	ctx, span := trace.Start(ctx, "mergeTable")
 	defer span.End()

--- a/pkg/util/export/merge_test.go
+++ b/pkg/util/export/merge_test.go
@@ -26,12 +26,12 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
-	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/task"
 	"github.com/matrixorigin/matrixone/pkg/taskservice"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/util/export/table"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/robfig/cron/v3"
@@ -222,15 +222,19 @@ var mergeLock sync.Mutex
 func TestNewMerge(t *testing.T) {
 	mergeLock.Lock()
 	defer mergeLock.Unlock()
-	fs, err := fileservice.NewLocalETLFS(defines.ETLFileServiceName, t.TempDir())
-	require.Nil(t, err)
+	fs := testutil.NewFS()
 	ts, _ := time.Parse("2006-01-02 15:04:05", "2021-01-01 00:00:00")
 
 	ctx := trace.Generate(context.Background())
 
-	defaultOpts := []MergeOption{WithFileServiceName(defines.ETLFileServiceName),
-		WithFileService(fs), WithTable(dummyTable),
-		WithMaxFileSize(1), WithMinFilesMerge(1), WithMaxFileSize(16 * mpool.MB), WithMaxMergeJobs(16)}
+	defaultOpts := []MergeOption{
+		WithFileService(fs),
+		WithTable(dummyTable),
+		WithMaxFileSize(1),
+		WithMinFilesMerge(1),
+		WithMaxFileSize(16 * mpool.MB),
+		WithMaxMergeJobs(16),
+	}
 
 	type args struct {
 		ctx  context.Context
@@ -305,8 +309,7 @@ func TestNewMergeWithContextDone(t *testing.T) {
 	}
 	mergeLock.Lock()
 	defer mergeLock.Unlock()
-	fs, err := fileservice.NewLocalETLFS(defines.ETLFileServiceName, t.TempDir())
-	require.Nil(t, err)
+	fs := testutil.NewFS()
 	ts, _ := time.Parse("2006-01-02 15:04:05", "2021-01-01 00:00:00")
 
 	ctx := trace.Generate(context.Background())
@@ -324,9 +327,14 @@ func TestNewMergeWithContextDone(t *testing.T) {
 			name: "normal",
 			args: args{
 				ctx: ctx,
-				opts: []MergeOption{WithFileServiceName(defines.ETLFileServiceName),
-					WithFileService(fs), WithTable(dummyTable),
-					WithMaxFileSize(1), WithMinFilesMerge(1), WithMaxFileSize(16 * mpool.MB), WithMaxMergeJobs(16)},
+				opts: []MergeOption{
+					WithFileService(fs),
+					WithTable(dummyTable),
+					WithMaxFileSize(1),
+					WithMinFilesMerge(1),
+					WithMaxFileSize(16 * mpool.MB),
+					WithMaxMergeJobs(16),
+				},
 			},
 			want: nil,
 		},
@@ -360,8 +368,7 @@ func TestNewMergeNOFiles(t *testing.T) {
 	}
 	mergeLock.Lock()
 	defer mergeLock.Unlock()
-	fs, err := fileservice.NewLocalETLFS(defines.ETLFileServiceName, t.TempDir())
-	require.Nil(t, err)
+	fs := testutil.NewFS()
 	ts, _ := time.Parse("2006-01-02 15:04:05", "2021-01-01 00:00:00")
 
 	ctx := trace.Generate(context.Background())
@@ -381,9 +388,14 @@ func TestNewMergeNOFiles(t *testing.T) {
 			name: "normal",
 			args: args{
 				ctx: ctx,
-				opts: []MergeOption{WithFileServiceName(defines.ETLFileServiceName),
-					WithFileService(fs), WithTable(dummyTable),
-					WithMaxFileSize(1), WithMinFilesMerge(1), WithMaxFileSize(16 * mpool.MB), WithMaxMergeJobs(16)},
+				opts: []MergeOption{
+					WithFileService(fs),
+					WithTable(dummyTable),
+					WithMaxFileSize(1),
+					WithMinFilesMerge(1),
+					WithMaxFileSize(16 * mpool.MB),
+					WithMaxMergeJobs(16),
+				},
 			},
 			want: nil,
 		},
@@ -408,8 +420,7 @@ func TestNewMergeNOFiles(t *testing.T) {
 func TestMergeTaskExecutorFactory(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	t.Logf("tmpDir: %s/%s", t.TempDir(), t.Name())
-	fs, err := fileservice.NewLocalETLFS(defines.ETLFileServiceName, path.Join(t.TempDir(), t.Name()))
-	require.Nil(t, err)
+	fs := testutil.NewFS()
 	targetDate := "2021-01-01"
 	ts, err := time.Parse("2006-01-02 15:04:05", targetDate+" 00:00:00")
 	require.Nil(t, err)
@@ -516,8 +527,7 @@ func TestCreateCronTask(t *testing.T) {
 func TestNewMergeService(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Minute*5)
 	defer cancel()
-	fs, err := fileservice.NewLocalETLFS(defines.ETLFileServiceName, path.Join(t.TempDir(), t.Name()))
-	require.Nil(t, err)
+	fs := testutil.NewFS()
 
 	type args struct {
 		ctx  context.Context

--- a/pkg/vm/engine/disttae/partition_state.go
+++ b/pkg/vm/engine/disttae/partition_state.go
@@ -386,6 +386,8 @@ func (p *PartitionState) HandleMetadataInsert(ctx context.Context, input *api.Ba
 			}
 
 		})
+
+		//TODO preload
 	}
 
 	partitionStateProfileHandler.AddSample()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Should not enable cache for ETL S3 fs.

fileservice: disable caches for ETL+S3

defines: remove ETLFileServiceName