### PR TITLE
fileservice: use ListObjects instead of ListObjectsV2 in s3

### DIFF
--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -56,6 +56,7 @@ type S3FS struct {
 	asyncUpdate bool
 
 	perfCounterSets []*perfcounter.CounterSet
+	listMaxKeys     int32
 }
 
 // key mapping scheme:
@@ -207,16 +208,17 @@ func (s *S3FS) List(ctx context.Context, dirPath string) (entries []DirEntry, er
 	if prefix != "" {
 		prefix += "/"
 	}
-	var cont *string
+	var marker *string
 
 	for {
 		output, err := s.s3ListObjects(
 			ctx,
-			&s3.ListObjectsV2Input{
-				Bucket:            ptrTo(s.bucket),
-				Delimiter:         ptrTo("/"),
-				Prefix:            ptrTo(prefix),
-				ContinuationToken: cont,
+			&s3.ListObjectsInput{
+				Bucket:    ptrTo(s.bucket),
+				Delimiter: ptrTo("/"),
+				Prefix:    ptrTo(prefix),
+				Marker:    marker,
+				MaxKeys:   s.listMaxKeys,
 			},
 		)
 		if err != nil {
@@ -244,11 +246,10 @@ func (s *S3FS) List(ctx context.Context, dirPath string) (entries []DirEntry, er
 			})
 		}
 
-		if output.ContinuationToken == nil ||
-			*output.ContinuationToken == "" {
+		if !output.IsTruncated {
 			break
 		}
-		cont = output.ContinuationToken
+		marker = output.NextMarker
 	}
 
 	return
@@ -987,12 +988,12 @@ func newS3FS(arguments []string) (*S3FS, error) {
 
 }
 
-func (s *S3FS) s3ListObjects(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+func (s *S3FS) s3ListObjects(ctx context.Context, params *s3.ListObjectsInput, optFns ...func(*s3.Options)) (*s3.ListObjectsOutput, error) {
 	FSProfileHandler.AddSample()
 	perfcounter.Update(ctx, func(counter *perfcounter.CounterSet) {
 		counter.S3.List.Add(1)
 	}, s.perfCounterSets...)
-	return s.s3Client.ListObjectsV2(ctx, params, optFns...)
+	return s.s3Client.ListObjects(ctx, params, optFns...)
 }
 
 func (s *S3FS) s3HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -106,6 +106,7 @@ func TestS3FS(t *testing.T) {
 				true,
 			)
 			assert.Nil(t, err)
+			fs.listMaxKeys = 5 // to test continuation
 
 			return fs
 		})
@@ -133,8 +134,8 @@ func TestS3FS(t *testing.T) {
 		entries, err := fs.List(ctx, "")
 		assert.Nil(t, err)
 		assert.True(t, len(entries) > 0)
-		assert.Equal(t, int64(1), counterSet.S3.List.Load())
-		assert.Equal(t, int64(1), counterSet2.S3.List.Load())
+		assert.True(t, counterSet.S3.List.Load() > 0)
+		assert.True(t, counterSet2.S3.List.Load() > 0)
 	})
 
 	t.Run("mem caching file service", func(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8473 

## What this PR does / why we need it: