### PR TITLE
ETLMerge No cache & fix other ut issue

### DIFF
--- a/pkg/util/export/batch_processor.go
+++ b/pkg/util/export/batch_processor.go
@@ -508,7 +508,6 @@ func (c *MOCollector) Stop(graceful bool) error {
 		c.mux.Unlock()
 		close(c.stopCh)
 		c.stopWait.Wait()
-		close(c.awakeCollect)
 		close(c.awakeGenerate)
 		close(c.awakeBatch)
 		if !graceful {

--- a/pkg/util/export/etl/tae.go
+++ b/pkg/util/export/etl/tae.go
@@ -313,7 +313,7 @@ func NewTaeReader(ctx context.Context, tbl *table.Table, filePath string, filesi
 		r.typs = append(r.typs, c.ColType.ToType())
 		r.idxs[idx] = uint16(idx)
 	}
-	r.blockReader, err = blockio.NewFileReader(r.fs, r.filepath)
+	r.blockReader, err = blockio.NewFileReaderNoCache(r.fs, r.filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/export/etl/tae.go
+++ b/pkg/util/export/etl/tae.go
@@ -358,9 +358,11 @@ func (r *TAEReader) ReadRow(row *table.Row) error {
 }
 
 func (r *TAEReader) Close() {
-	for _, b := range r.batchs {
-		b.Clean(r.mp)
+	for idx := range r.batchs {
+		// do NOT release it in mpool (like r.batchs[idx].Clean(r.mp)). right now, the buffer is new one.
+		r.batchs[idx] = nil
 	}
+	r.batchs = nil
 }
 
 func GetVectorArrayLen(ctx context.Context, vec *vector.Vector) (int, error) {

--- a/pkg/vm/engine/tae/dataio/blockio/reader.go
+++ b/pkg/vm/engine/tae/dataio/blockio/reader.go
@@ -54,8 +54,19 @@ func NewObjectReader(service fileservice.FileService, key string) (dataio.Reader
 	}, nil
 }
 
-func NewFileReader(service fileservice.FileService, name string) (*BlockReader, error) {
+func NewFileReader(service fileservice.FileService, name string, opts ...objectio.ReaderOptionFunc) (*BlockReader, error) {
 	reader, err := objectio.NewObjectReader(name, service)
+	if err != nil {
+		return nil, err
+	}
+	return &BlockReader{
+		reader: reader,
+		name:   name,
+	}, nil
+}
+
+func NewFileReaderNoCache(service fileservice.FileService, name string) (*BlockReader, error) {
+	reader, err := objectio.NewObjectReader(name, service, objectio.WithNoCacheReader(true))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/8354,
ut issue  https://github.com/matrixorigin/matrixone/issues/8524

## What this PR does / why we need it:

1. ETLMerge read data with NoCache
2. NOT free ETLMerge Reader's vector in mpool
3. fix ut leak routinue issue.