### PR TITLE
fileservice: add FileService.Preload

### DIFF
--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -16,17 +16,10 @@ package fileservice
 
 import (
 	"context"
+	"io"
 
 	"github.com/matrixorigin/matrixone/pkg/util/toml"
 )
-
-//TODO in-memory bytes cache
-
-type CacheKey struct {
-	Path   string
-	Offset int64
-	Size   int64
-}
 
 type CacheConfig struct {
 	MemoryCapacity toml.ByteSize `toml:"memory-capacity"`
@@ -34,7 +27,8 @@ type CacheConfig struct {
 	DiskCapacity   toml.ByteSize `toml:"disk-capacity"`
 }
 
-type Cache interface {
+// VectorCache caches IOVector
+type IOVectorCache interface {
 	Read(
 		ctx context.Context,
 		vector *IOVector,
@@ -47,9 +41,36 @@ type Cache interface {
 	Flush()
 }
 
+type IOVectorCacheKey struct {
+	Path   string
+	Offset int64
+	Size   int64
+}
+
+// ObjectCache caches IOEntry.Object
 type ObjectCache interface {
 	Set(key any, value any, size int64, preloading bool)
 	Get(key any, preloading bool) (value any, size int64, ok bool)
 	Flush()
 	Size() int64
+}
+
+// FileContentCache caches contents of files
+type FileContentCache interface {
+	GetFileContent(
+		ctx context.Context,
+		path string,
+		offset int64,
+	) (
+		r io.ReadCloser,
+		err error,
+	)
+
+	SetFileContent(
+		ctx context.Context,
+		path string,
+		readFunc func(ctx context.Context, vec *IOVector) error,
+	) (
+		err error,
+	)
 }

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"sync"
@@ -26,15 +27,18 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 )
 
-//TODO LRU
-
-//TODO full data. If we know the size and it's small, we can get the whole object in one request and save it to a file named full_data
+//TODO cache evict
 
 type DiskCache struct {
 	capacity        int64
 	path            string
 	fileExists      sync.Map
 	perfCounterSets []*perfcounter.CounterSet
+
+	settingContent struct {
+		sync.Mutex
+		m map[string]chan struct{}
+	}
 }
 
 func NewDiskCache(
@@ -46,14 +50,16 @@ func NewDiskCache(
 	if err != nil {
 		return nil, err
 	}
-	return &DiskCache{
+	ret := &DiskCache{
 		capacity:        capacity,
 		path:            path,
 		perfCounterSets: perfCounterSets,
-	}, nil
+	}
+	ret.settingContent.m = make(map[string]chan struct{})
+	return ret, nil
 }
 
-var _ Cache = new(DiskCache)
+var _ IOVectorCache = new(DiskCache)
 
 func (d *DiskCache) Read(
 	ctx context.Context,
@@ -65,15 +71,26 @@ func (d *DiskCache) Read(
 		return nil
 	}
 
-	var numHit, numRead int64
+	var numHit, numRead, numOpen int64
 	defer func() {
 		perfcounter.Update(ctx, func(c *perfcounter.CounterSet) {
 			c.Cache.Read.Add(numRead)
 			c.Cache.Hit.Add(numHit)
-			c.Cache.DiskRead.Add(numRead)
-			c.Cache.DiskHit.Add(numHit)
+			c.Cache.Disk.Read.Add(numRead)
+			c.Cache.Disk.Hit.Add(numHit)
+			c.Cache.Disk.OpenFile.Add(numOpen)
 		}, d.perfCounterSets...)
 	}()
+
+	contentOK := false
+	contentPath := d.contentPath(vector.FilePath)
+	contentFile, err := os.Open(contentPath)
+	if err == nil {
+		numOpen++
+		contentOK = true
+	} else {
+		err = nil // ignore
+	}
 
 	for i, entry := range vector.Entries {
 		if entry.done {
@@ -86,13 +103,24 @@ func (d *DiskCache) Read(
 
 		numRead++
 
-		linkPath := d.entryLinkPath(vector, entry)
-		file, err := os.Open(linkPath)
-		if err != nil {
-			// ignore error
+		var file *os.File
+		if contentOK {
+			// use content file
+			file = contentFile
+		} else {
+			// open link file
+			linkPath := d.entryLinkPath(vector, entry)
+			linkFile, err := os.Open(linkPath)
+			if err == nil {
+				file = linkFile
+				defer linkFile.Close()
+				numOpen++
+			}
+		}
+		if file == nil {
+			// no file available
 			continue
 		}
-		defer file.Close()
 
 		if _, err := file.Seek(entry.Offset, 0); err != nil {
 			// ignore error
@@ -142,6 +170,27 @@ func (d *DiskCache) Update(
 		return nil
 	}
 
+	var numOpen, numStat int64
+	defer func() {
+		perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
+			set.Cache.Disk.OpenFile.Add(numOpen)
+			set.Cache.Disk.StatFile.Add(numStat)
+		})
+	}()
+
+	contentOK := false
+	contentPath := d.contentPath(vector.FilePath)
+	if _, ok := d.fileExists.Load(contentPath); ok {
+		contentOK = true
+	} else {
+		_, err := os.Stat(contentPath)
+		if err == nil {
+			numStat++
+			contentOK = true
+			d.fileExists.Store(contentPath, true)
+		}
+	}
+
 	for _, entry := range vector.Entries {
 		if len(entry.Data) == 0 {
 			// no data
@@ -161,31 +210,42 @@ func (d *DiskCache) Update(
 		if err == nil {
 			// file exists
 			d.fileExists.Store(linkPath, true)
+			numStat++
 			continue
 		}
 
-		// write data
-		dataPath := d.entryDataPath(vector, entry)
-		err = os.MkdirAll(filepath.Dir(dataPath), 0755)
-		if err != nil {
-			return err
-		}
-		file, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0644)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
+		var linkTarget string
 
-		n, err := file.WriteAt(entry.Data, entry.Offset)
-		if err != nil {
-			return err
-		}
-		if int64(n) != entry.Size {
-			return io.ErrShortWrite
+		if contentOK {
+			linkTarget = contentPath
+
+		} else {
+			// write data
+			dataPath := d.entryDataPath(vector, entry)
+			err = os.MkdirAll(filepath.Dir(dataPath), 0755)
+			if err != nil {
+				return err
+			}
+			file, err := os.OpenFile(dataPath, os.O_RDWR|os.O_CREATE, 0644)
+			if err != nil {
+				return err
+			}
+			numOpen++
+			n, err := file.WriteAt(entry.Data, entry.Offset)
+			if err != nil {
+				return err
+			}
+			if err := file.Close(); err != nil {
+				return err
+			}
+			if int64(n) != entry.Size {
+				return io.ErrShortWrite
+			}
+			linkTarget = dataPath
 		}
 
 		// link
-		if err := os.Link(dataPath, linkPath); err != nil {
+		if err := os.Link(linkTarget, linkPath); err != nil {
 			if os.IsExist(err) {
 				// ok
 			} else {
@@ -201,6 +261,114 @@ func (d *DiskCache) Update(
 
 func (d *DiskCache) Flush() {
 	//TODO
+}
+
+var _ FileContentCache = new(DiskCache)
+
+func (d *DiskCache) GetFileContent(ctx context.Context, filePath string, offset int64) (r io.ReadCloser, err error) {
+	contentPath := d.contentPath(filePath)
+	f, err := os.Open(contentPath)
+	if err != nil {
+		return nil, err
+	}
+	perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
+		set.Cache.Disk.OpenFile.Add(1)
+	})
+	if offset > 0 {
+		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			return nil, err
+		}
+	}
+	perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
+		set.Cache.Disk.GetFileContent.Add(1)
+	})
+	return f, nil
+}
+
+func (d *DiskCache) SetFileContent(
+	ctx context.Context,
+	filePath string,
+	readFunc func(context.Context, *IOVector) error,
+) (err error) {
+
+	contentPath := d.contentPath(filePath)
+
+	_, err = os.Stat(contentPath)
+	if err == nil {
+		// file exists
+		perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
+			set.Cache.Disk.StatFile.Add(1)
+		})
+		return nil
+	}
+
+	// concurrency control
+	d.settingContent.Lock()
+	waitChan, wait := d.settingContent.m[contentPath]
+	if wait {
+		d.settingContent.Unlock()
+		<-waitChan
+		return nil
+	}
+	waitChan = make(chan struct{})
+	d.settingContent.m[contentPath] = waitChan
+	d.settingContent.Unlock()
+	defer func() {
+		close(waitChan)
+	}()
+
+	w, done, closeW, err := d.newFileContentWriter(filePath)
+	if err != nil {
+		return err
+	}
+	defer closeW()
+	vec := IOVector{
+		FilePath: filePath,
+		Entries: []IOEntry{
+			{
+				Offset:        0,
+				Size:          -1,
+				WriterForRead: w,
+			},
+		},
+	}
+	if err := readFunc(ctx, &vec); err != nil {
+		return err
+	}
+	if err := done(); err != nil {
+		return err
+	}
+
+	perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
+		set.Cache.Disk.SetFileContent.Add(1)
+	})
+
+	return nil
+}
+
+func (d *DiskCache) newFileContentWriter(filePath string) (w io.Writer, done func() error, closeFunc func() error, err error) {
+	contentPath := d.contentPath(filePath)
+	tmpPath := contentPath + fmt.Sprintf(".%d.tmp", rand.Int63())
+	err = os.MkdirAll(filepath.Dir(tmpPath), 0755)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	var doneOnce sync.Once
+	return f, func() (err error) {
+		doneOnce.Do(func() {
+			if err = f.Close(); err != nil {
+				return
+			}
+			if err = os.Rename(tmpPath, contentPath); err != nil {
+				return
+			}
+		})
+		return
+	}, f.Close, nil
 }
 
 func (d *DiskCache) entryLinkPath(vector *IOVector, entry IOEntry) string {
@@ -219,5 +387,13 @@ func (d *DiskCache) entryDataPath(vector *IOVector, entry IOEntry) string {
 		d.path,
 		toOSPath(vector.FilePath),
 		"data",
+	)
+}
+
+func (d *DiskCache) contentPath(filePath string) string {
+	return filepath.Join(
+		d.path,
+		toOSPath(filePath),
+		"full-data",
 	)
 }

--- a/pkg/fileservice/file_service.go
+++ b/pkg/fileservice/file_service.go
@@ -49,6 +49,9 @@ type FileService interface {
 	// Stat returns infomations about a file
 	// returns ErrFileNotFound if requested file not found
 	StatFile(ctx context.Context, filePath string) (*DirEntry, error)
+
+	// Preload indicates the service to preload a file
+	Preload(ctx context.Context, filePath string) error
 }
 
 type IOVector struct {

--- a/pkg/fileservice/file_service_test.go
+++ b/pkg/fileservice/file_service_test.go
@@ -513,7 +513,7 @@ func testFileService(
 		}
 		entries, err = fs.List(ctx, "qux/quux")
 		assert.Nil(t, err)
-		assert.Equal(t, len(entries), 0)
+		assert.Equal(t, 0, len(entries))
 
 	})
 

--- a/pkg/fileservice/file_services.go
+++ b/pkg/fileservice/file_services.go
@@ -82,6 +82,21 @@ func (f *FileServices) List(ctx context.Context, dirPath string) ([]DirEntry, er
 	return fs.List(ctx, dirPath)
 }
 
+func (f *FileServices) Preload(ctx context.Context, dirPath string) error {
+	path, err := ParsePathAtService(dirPath, "")
+	if err != nil {
+		return err
+	}
+	if path.Service == "" {
+		path.Service = f.defaultName
+	}
+	fs, err := Get[FileService](f, path.Service)
+	if err != nil {
+		return err
+	}
+	return fs.Preload(ctx, dirPath)
+}
+
 func (f *FileServices) Name() string {
 	return f.defaultName
 }

--- a/pkg/fileservice/io.go
+++ b/pkg/fileservice/io.go
@@ -43,3 +43,18 @@ func (c *countingReader) Read(data []byte) (int, error) {
 	c.N += int64(n)
 	return n, err
 }
+
+type writeCloser struct {
+	w         io.Writer
+	closeFunc func() error
+}
+
+var _ io.WriteCloser = new(writeCloser)
+
+func (r *writeCloser) Write(data []byte) (int, error) {
+	return r.w.Write(data)
+}
+
+func (r *writeCloser) Close() error {
+	return r.closeFunc()
+}

--- a/pkg/fileservice/local_etl_fs.go
+++ b/pkg/fileservice/local_etl_fs.go
@@ -324,6 +324,10 @@ func (l *LocalETLFS) Read(ctx context.Context, vector *IOVector) error {
 
 }
 
+func (l *LocalETLFS) Preload(ctx context.Context, filePath string) error {
+	return nil
+}
+
 func (l *LocalETLFS) StatFile(ctx context.Context, filePath string) (*DirEntry, error) {
 	select {
 	case <-ctx.Done():

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -257,6 +257,11 @@ func (l *LocalFS) Read(ctx context.Context, vector *IOVector) (err error) {
 	return nil
 }
 
+func (l *LocalFS) Preload(ctx context.Context, filePath string) error {
+	//TODO load to memory
+	return nil
+}
+
 func (l *LocalFS) read(ctx context.Context, vector *IOVector) error {
 	if vector.allDone() {
 		return nil

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -77,7 +77,7 @@ func defaultMemCacheOptions() memCacheOptions {
 	return memCacheOptions{}
 }
 
-var _ Cache = new(MemCache)
+var _ IOVectorCache = new(MemCache)
 
 func (m *MemCache) Read(
 	ctx context.Context,
@@ -94,8 +94,8 @@ func (m *MemCache) Read(
 		perfcounter.Update(ctx, func(c *perfcounter.CounterSet) {
 			c.Cache.Read.Add(numRead)
 			c.Cache.Hit.Add(numHit)
-			c.Cache.MemRead.Add(numRead)
-			c.Cache.MemHit.Add(numHit)
+			c.Cache.Memory.Read.Add(numRead)
+			c.Cache.Memory.Hit.Add(numHit)
 		}, m.counterSets...)
 	}()
 
@@ -106,7 +106,7 @@ func (m *MemCache) Read(
 		if entry.ToObject == nil {
 			continue
 		}
-		key := CacheKey{
+		key := IOVectorCacheKey{
 			Path:   vector.FilePath,
 			Offset: entry.Offset,
 			Size:   entry.Size,
@@ -141,7 +141,7 @@ func (m *MemCache) Update(
 		if entry.Object == nil {
 			continue
 		}
-		key := CacheKey{
+		key := IOVectorCacheKey{
 			Path:   vector.FilePath,
 			Offset: entry.Offset,
 			Size:   entry.Size,

--- a/pkg/fileservice/memory_fs.go
+++ b/pkg/fileservice/memory_fs.go
@@ -240,6 +240,10 @@ func (m *MemoryFS) Read(ctx context.Context, vector *IOVector) error {
 	return nil
 }
 
+func (m *MemoryFS) Preload(ctx context.Context, filePath string) error {
+	return nil
+}
+
 func (m *MemoryFS) StatFile(ctx context.Context, filePath string) (*DirEntry, error) {
 	select {
 	case <-ctx.Done():

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -90,7 +90,6 @@ func TestS3FS(t *testing.T) {
 	t.Setenv("AWS_SECRET_ACCESS_KEY", config.APISecret)
 
 	t.Run("file service", func(t *testing.T) {
-		cacheDir := t.TempDir()
 		testFileService(t, func(name string) FileService {
 
 			fs, err := NewS3FS(
@@ -101,7 +100,7 @@ func TestS3FS(t *testing.T) {
 				time.Now().Format("2006-01-02.15:04:05.000000"),
 				-1,
 				-1,
-				cacheDir,
+				"",
 				nil,
 				true,
 			)
@@ -113,7 +112,6 @@ func TestS3FS(t *testing.T) {
 	})
 
 	t.Run("list root", func(t *testing.T) {
-		cacheDir := t.TempDir()
 		fs, err := NewS3FS(
 			"",
 			"s3",
@@ -122,7 +120,7 @@ func TestS3FS(t *testing.T) {
 			"",
 			-1,
 			-1,
-			cacheDir,
+			"",
 			nil,
 			true,
 		)
@@ -139,7 +137,6 @@ func TestS3FS(t *testing.T) {
 	})
 
 	t.Run("mem caching file service", func(t *testing.T) {
-		cacheDir := t.TempDir()
 		testCachingFileService(t, func() CachingFileService {
 			fs, err := NewS3FS(
 				"",
@@ -149,7 +146,7 @@ func TestS3FS(t *testing.T) {
 				time.Now().Format("2006-01-02.15:04:05.000000"),
 				128*1024,
 				-1,
-				cacheDir,
+				"",
 				nil,
 				false,
 			)
@@ -159,7 +156,6 @@ func TestS3FS(t *testing.T) {
 	})
 
 	t.Run("disk caching file service", func(t *testing.T) {
-		cacheDir := t.TempDir()
 		testCachingFileService(t, func() CachingFileService {
 			fs, err := NewS3FS(
 				"",
@@ -169,7 +165,7 @@ func TestS3FS(t *testing.T) {
 				time.Now().Format("2006-01-02.15:04:05.000000"),
 				-1,
 				128*1024,
-				cacheDir,
+				t.TempDir(),
 				nil,
 				false,
 			)

--- a/pkg/fileservice/sub_path.go
+++ b/pkg/fileservice/sub_path.go
@@ -87,6 +87,18 @@ func (s *subPathFS) List(ctx context.Context, dirPath string) ([]DirEntry, error
 	return entries, nil
 }
 
+func (s *subPathFS) Preload(ctx context.Context, filePath string) error {
+	p, err := s.toUpstreamPath(filePath)
+	if err != nil {
+		return err
+	}
+	err = s.upstream.Preload(ctx, p)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *subPathFS) Delete(ctx context.Context, filePaths ...string) error {
 	if len(filePaths) == 0 {
 		return nil

--- a/pkg/perfcounter/counter_logexporter.go
+++ b/pkg/perfcounter/counter_logexporter.go
@@ -35,10 +35,10 @@ func (c *CounterLogExporter) Export() []zap.Field {
 
 	reads := c.counter.Cache.Read.SwapW(0)
 	hits := c.counter.Cache.Hit.SwapW(0)
-	memReads := c.counter.Cache.MemRead.SwapW(0)
-	memHits := c.counter.Cache.MemHit.SwapW(0)
-	diskReads := c.counter.Cache.DiskRead.SwapW(0)
-	diskHits := c.counter.Cache.DiskHit.SwapW(0)
+	memReads := c.counter.Cache.Memory.Read.SwapW(0)
+	memHits := c.counter.Cache.Memory.Hit.SwapW(0)
+	diskReads := c.counter.Cache.Disk.Read.SwapW(0)
+	diskHits := c.counter.Cache.Disk.Hit.SwapW(0)
 
 	fields = append(fields, zap.Any("reads", reads))
 	fields = append(fields, zap.Any("hits", hits))

--- a/pkg/perfcounter/counter_set.go
+++ b/pkg/perfcounter/counter_set.go
@@ -29,12 +29,20 @@ type CounterSet struct {
 	}
 
 	Cache struct {
-		Read     stats.Counter
-		Hit      stats.Counter
-		MemRead  stats.Counter
-		MemHit   stats.Counter
-		DiskRead stats.Counter
-		DiskHit  stats.Counter
+		Read   stats.Counter
+		Hit    stats.Counter
+		Memory struct {
+			Read stats.Counter
+			Hit  stats.Counter
+		}
+		Disk struct {
+			Read           stats.Counter
+			Hit            stats.Counter
+			GetFileContent stats.Counter
+			SetFileContent stats.Counter
+			OpenFile       stats.Counter
+			StatFile       stats.Counter
+		}
 	}
 
 	FileServices map[string]*CounterSet


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
fileservice: cache types renaming and sketch FileContentCache

fileservice: implement FileContentCache for DiskCache; implement Preload for S3FS

perfcounter: add disk cache get/set file content fields

fileservice: use full-data file in DiskCache.Read/Update

fileservice: more disk cache tests and bug fixes

fileservice: add disk cache file stat counter field

fileservice: refactor FileContentCache interface

fileservice: add concurrency control to DiskCache.SetFileContent
