### PR TITLE
logservice: support domain name config for gossip-address.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,9 +134,9 @@ require (
 
 // required until memberlist issue 272 is resolved
 // see https://github.com/hashicorp/memberlist/pull/273 for progress
-replace github.com/hashicorp/memberlist => github.com/matrixorigin/memberlist v0.4.1-0.20221125074841-7595e1626d36
+replace github.com/hashicorp/memberlist => github.com/matrixorigin/memberlist v0.5.1-0.20230322082342-95015c95ee76
 
-replace github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef => github.com/matrixorigin/dragonboat/v4 v4.0.0-20230302063425-d44b237aabe8
+replace github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef => github.com/matrixorigin/dragonboat/v4 v4.0.0-20230322100352-2390d003ee0f
 
 replace github.com/lni/vfs v0.2.1-0.20220616104132-8852fd867376 => github.com/matrixorigin/vfs v0.2.1-0.20220616104132-8852fd867376
 

--- a/go.sum
+++ b/go.sum
@@ -390,12 +390,12 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/matrixorigin/dragonboat/v4 v4.0.0-20230302063425-d44b237aabe8 h1:MWJc19WlKwHKcNUV+oOQVveXDLhp87abNZNPw/OD1Ik=
-github.com/matrixorigin/dragonboat/v4 v4.0.0-20230302063425-d44b237aabe8/go.mod h1:bR6ZGoUwApH4/P4+AezNGT0xehljg+j+Z/Q2Fz+Y4a0=
+github.com/matrixorigin/dragonboat/v4 v4.0.0-20230322100352-2390d003ee0f h1:a2b9x3rXl92UZ4eq+p+fa6b//V6rPuSQav6qskwO57k=
+github.com/matrixorigin/dragonboat/v4 v4.0.0-20230322100352-2390d003ee0f/go.mod h1:bR6ZGoUwApH4/P4+AezNGT0xehljg+j+Z/Q2Fz+Y4a0=
 github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4 h1:+SmZP2bG+YcO/ntzjCleCu6hFTJiue7Oj2tftpJKTlU=
 github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4/go.mod h1:LIHvF0fflR+zyXUQFQOiHPpKANf3UIr7DFIv5CBPOoU=
-github.com/matrixorigin/memberlist v0.4.1-0.20221125074841-7595e1626d36 h1:JxDUpqN51LbPF7+bAqIBqGq9atInx8JKihm8J3J9/ME=
-github.com/matrixorigin/memberlist v0.4.1-0.20221125074841-7595e1626d36/go.mod h1:yvyXLpo0QaGE59Y7hDTsTzDD25JYBZ4mHgHUZ8lrOI0=
+github.com/matrixorigin/memberlist v0.5.1-0.20230322082342-95015c95ee76 h1:MpmqMPooJ0Ea7W4ldIGbQV4D3z+sEiCu6C6aTibiwiQ=
+github.com/matrixorigin/memberlist v0.5.1-0.20230322082342-95015c95ee76/go.mod h1:yvyXLpo0QaGE59Y7hDTsTzDD25JYBZ4mHgHUZ8lrOI0=
 github.com/matrixorigin/simdcsv v0.0.0-20230210060146-09b8e45209dd h1:DvqhuH3kOpsE6vXZA5WEaRNAUUUcf44S1p5VInbjdfU=
 github.com/matrixorigin/simdcsv v0.0.0-20230210060146-09b8e45209dd/go.mod h1:79jCHry8mER+PwqF5EMG3ZE4b0lflH1IE/zF3Zs6lR8=
 github.com/matrixorigin/vfs v0.2.1-0.20220616104132-8852fd867376 h1:1XpEh8nPx1yFTeTFMj/aMipEiilDhQToQS8gjEU2HxM=

--- a/pkg/logservice/config.go
+++ b/pkg/logservice/config.go
@@ -85,6 +85,9 @@ type Config struct {
 	LogDBBufferSize uint64 `toml:"logdb-buffer-size"`
 	// GossipAddress is the address used for accepting gossip communication.
 	GossipAddress string `toml:"gossip-address"`
+	// GossipAddressV2 is the address used for accepting gossip communication.
+	// This is for domain name support.
+	GossipAddressV2 string `toml:"gossip-address-v2"`
 	// GossipListenAddress is the local listen address of the GossipAddress
 	GossipListenAddress string `toml:"gossip-listen-address"`
 	// GossipSeedAddresses is list of seed addresses that are used for
@@ -341,6 +344,11 @@ func (c *Config) Fill() {
 	}
 	if c.LogDBBufferSize == 0 {
 		c.LogDBBufferSize = defaultLogDBBufferSize
+	}
+	// If GossipAddressV2 is set, we use it as gossip address, and GossipAddress
+	// will be overridden by it.
+	if len(c.GossipAddressV2) != 0 {
+		c.GossipAddress = c.GossipAddressV2
 	}
 	if len(c.GossipAddress) == 0 {
 		c.GossipAddress = defaultGossipAddress

--- a/pkg/logservice/config_test.go
+++ b/pkg/logservice/config_test.go
@@ -274,3 +274,13 @@ func TestHAKeeperClientConfigValidate(t *testing.T) {
 		}
 	}
 }
+
+func TestGossipAddressV2IsUsed(t *testing.T) {
+	cfg := Config{
+		GossipAddress:   "127.0.0.1:9001",
+		GossipAddressV2: "localhost:9002",
+	}
+	cfg.Fill()
+	assert.Equal(t, cfg.GossipAddress, cfg.GossipAddressV2)
+	assert.Equal(t, cfg.GossipAddress, cfg.GossipListenAddress)
+}


### PR DESCRIPTION
Currenty, the config gossip-address for logservice can only be set to an IP address, as memeberlist and dragonboat force it. But when a logservice pod is recreated, the IP address of it is changed but the pod's data, UUID and domain name are unchanged, and the memberlist mark the IP address conflict and the whole cluster is unstable.

So we need to set gossip-address to a domain name as it is not changed. Add a new config gossip-address-v2 to keep compatibility. If gossip-address-v2 is set, use it as the gossip address, otherwise, use the old one gossip-address.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8483 

## What this PR does / why we need it: