### PR TITLE
[FIX] Added T_BlockId to all the type switch statements.

### DIFF
--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -120,6 +120,11 @@ func New(typ types.Type, desc, nullsLast bool) Compare {
 			return newCompare(rowidDescCompare, rowidCopy, nullsLast)
 		}
 		return newCompare(rowidAscCompare, rowidCopy, nullsLast)
+	case types.T_Blockid:
+		if desc {
+			return newCompare(blockidDescCompare, blockidCopy, nullsLast)
+		}
+		return newCompare(blockidAscCompare, blockidCopy, nullsLast)
 	case types.T_uuid:
 		if desc {
 			return newCompare(uuidDescCompare, uuidCopy, nullsLast)
@@ -162,7 +167,11 @@ func txntsAscCompare(x, y types.TS) int {
 	return bytes.Compare(x[:], y[:])
 }
 func rowidAscCompare(x, y types.Rowid) int {
-	return bytes.Compare(x[:], x[:])
+	return bytes.Compare(x[:], y[:])
+}
+
+func blockidAscCompare(x, y types.Blockid) int {
+	return bytes.Compare(x[:], y[:])
 }
 
 func genericAscCompare[T types.OrderedT](x, y T) int {
@@ -203,6 +212,10 @@ func rowidDescCompare(x, y types.Rowid) int {
 	return bytes.Compare(y[:], x[:])
 }
 
+func blockidDescCompare(x, y types.Blockid) int {
+	return bytes.Compare(y[:], x[:])
+}
+
 func genericDescCompare[T types.OrderedT](x, y T) int {
 	if x == y {
 		return 0
@@ -233,6 +246,10 @@ func txntsCopy(vecDst, vecSrc []types.TS, dst, src int64) {
 	vecDst[dst] = vecSrc[src]
 }
 func rowidCopy(vecDst, vecSrc []types.Rowid, dst, src int64) {
+	vecDst[dst] = vecSrc[src]
+}
+
+func blockidCopy(vecDst, vecSrc []types.Blockid, dst, src int64) {
 	vecDst[dst] = vecSrc[src]
 }
 

--- a/pkg/container/types/txnts.go
+++ b/pkg/container/types/txnts.go
@@ -326,10 +326,21 @@ func BuildRowid(a, b int64) (ret Rowid) {
 	return
 }
 
+// TODO: aptend, Kindly verify this
+func BuildBlockid(a, b int64) (ret Blockid) {
+	copy(ret[0:8], EncodeInt64(&a))
+	copy(ret[0:8], EncodeInt64(&b))
+	return
+}
+
 func CompareTSTSAligned(a, b TS) int64 {
 	return int64(bytes.Compare(a[:], b[:]))
 }
 
 func CompareRowidRowidAligned(a, b Rowid) int64 {
+	return int64(bytes.Compare(a[:], b[:]))
+}
+
+func CompareBlockidBlockidAligned(a, b Blockid) int64 {
 	return int64(bytes.Compare(a[:], b[:]))
 }

--- a/pkg/container/vector/functionTools.go
+++ b/pkg/container/vector/functionTools.go
@@ -366,6 +366,8 @@ func NewFunctionResultWrapper(typ types.Type, mp *mpool.MPool, isConst bool, len
 		return newResultFunc[types.TS](v, mp)
 	case types.T_Rowid:
 		return newResultFunc[types.Rowid](v, mp)
+	case types.T_Blockid:
+		return newResultFunc[types.Blockid](v, mp)
 	case types.T_uuid:
 		return newResultFunc[types.Uuid](v, mp)
 	}

--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -493,6 +493,8 @@ func (v *Vector) ToConst(row, length int, mp *mpool.MPool) *Vector {
 		return NewConstFixed(v.typ, v.col.([]types.TS)[row], length, mp)
 	case types.T_Rowid:
 		return NewConstFixed(v.typ, v.col.([]types.Rowid)[row], length, mp)
+	case types.T_Blockid:
+		return NewConstFixed(v.typ, v.col.([]types.Blockid)[row], length, mp)
 	case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary, types.T_json, types.T_blob, types.T_text:
 		return NewConstBytes(v.typ, v.GetBytesAt(row), length, mp)
 	}
@@ -602,6 +604,8 @@ func (v *Vector) Shrink(sels []int64, negate bool) {
 		shrinkFixed[types.TS](v, sels, negate)
 	case types.T_Rowid:
 		shrinkFixed[types.Rowid](v, sels, negate)
+	case types.T_Blockid:
+		shrinkFixed[types.Blockid](v, sels, negate)
 	default:
 		panic(fmt.Sprintf("unexpect type %s for function vector.Shrink", v.typ))
 	}
@@ -656,6 +660,8 @@ func (v *Vector) Shuffle(sels []int64, mp *mpool.MPool) error {
 		shuffleFixed[types.TS](v, sels, mp)
 	case types.T_Rowid:
 		shuffleFixed[types.Rowid](v, sels, mp)
+	case types.T_Blockid:
+		shuffleFixed[types.Blockid](v, sels, mp)
 	default:
 		panic(fmt.Sprintf("unexpect type %s for function vector.Shuffle", v.typ))
 	}
@@ -808,6 +814,11 @@ func GetUnionOneFunction(typ types.Type, mp *mpool.MPool) func(v, w *Vector, sel
 	case types.T_Rowid:
 		return func(v, w *Vector, sel int64) error {
 			ws := MustFixedCol[types.Rowid](w)
+			return appendOneFixed(v, ws[sel], nulls.Contains(w.nsp, uint64(sel)), mp)
+		}
+	case types.T_Blockid:
+		return func(v, w *Vector, sel int64) error {
+			ws := MustFixedCol[types.Blockid](w)
 			return appendOneFixed(v, ws[sel], nulls.Contains(w.nsp, uint64(sel)), mp)
 		}
 	case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary, types.T_json, types.T_blob, types.T_text:
@@ -1089,6 +1100,8 @@ func (v *Vector) String() string {
 		return vecToString[types.TS](v)
 	case types.T_Rowid:
 		return vecToString[types.Rowid](v)
+	case types.T_Blockid:
+		return vecToString[types.Blockid](v)
 	case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary, types.T_json, types.T_blob, types.T_text:
 		col := MustStrCol(v)
 		if len(col) == 1 {
@@ -1195,6 +1208,8 @@ func AppendAny(vec *Vector, val any, isNull bool, mp *mpool.MPool) error {
 		return appendOneFixed(vec, val.(types.TS), false, mp)
 	case types.T_Rowid:
 		return appendOneFixed(vec, val.(types.Rowid), false, mp)
+	case types.T_Blockid:
+		return appendOneFixed(vec, val.(types.Blockid), false, mp)
 	case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary, types.T_json, types.T_blob, types.T_text:
 		return appendOneBytes(vec, val.([]byte), false, mp)
 	}

--- a/pkg/container/vector/vector_test.go
+++ b/pkg/container/vector/vector_test.go
@@ -366,6 +366,16 @@ func TestShrink(t *testing.T) {
 		v.Free(mp)
 		require.Equal(t, int64(0), mp.CurrNB())
 	}
+	{ // blockid
+		vs := make([]types.Blockid, 4)
+		v := NewVec(types.T_Blockid.ToType())
+		err := AppendFixedList(v, vs, nil, mp)
+		require.NoError(t, err)
+		v.Shrink([]int64{1, 2}, false)
+		require.Equal(t, vs[1:3], MustFixedCol[types.Blockid](v))
+		v.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	}
 }
 
 func TestShuffle(t *testing.T) {
@@ -599,6 +609,18 @@ func TestShuffle(t *testing.T) {
 		v.Shuffle([]int64{1, 2}, mp)
 		require.Equal(t, vs[1:3], MustFixedCol[types.Rowid](v))
 		require.Equal(t, "[[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]]-&{<nil>}", v.String())
+		v.Free(mp)
+		require.Equal(t, int64(0), mp.CurrNB())
+	}
+	{ // blockid
+		vs := make([]types.Blockid, 4)
+		v := NewVec(types.T_Blockid.ToType())
+		err := AppendFixedList(v, vs, nil, mp)
+		require.NoError(t, err)
+		v.Shuffle([]int64{1, 2}, mp)
+		require.Equal(t, vs[1:3], MustFixedCol[types.Blockid](v))
+		//TODO: aptend, Kindly verify this output.
+		require.Equal(t, "[[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]]-&{<nil>}", v.String())
 		v.Free(mp)
 		require.Equal(t, int64(0), mp.CurrNB())
 	}

--- a/pkg/frontend/output.go
+++ b/pkg/frontend/output.go
@@ -228,6 +228,8 @@ func extractRowFromVector(ses *Session, vec *vector.Vector, i int, row []interfa
 		row[i] = vector.GetFixedAt[types.Uuid](vec, rowIndex).ToString()
 	case types.T_Rowid:
 		row[i] = vector.GetFixedAt[types.Rowid](vec, rowIndex)
+	case types.T_Blockid:
+		row[i] = vector.GetFixedAt[types.Blockid](vec, rowIndex)
 	default:
 		logErrorf(ses.GetDebugString(), "extractRowFromVector : unsupported type %d", vec.GetType().Oid)
 		return moerr.NewInternalError(ses.requestCtx, "extractRowFromVector : unsupported type %d", vec.GetType().Oid)

--- a/pkg/sql/plan/function/operator/cast2.go
+++ b/pkg/sql/plan/function/operator/cast2.go
@@ -400,6 +400,9 @@ func NewCast(parameters []*vector.Vector, result vector.FunctionResultWrapper, p
 	case types.T_Rowid:
 		s := vector.GenerateFunctionFixedTypeParameter[types.Rowid](from)
 		err = rowidToOthers(proc.Ctx, s, *toType, result, length)
+	case types.T_Blockid:
+		s := vector.GenerateFunctionFixedTypeParameter[types.Blockid](from)
+		err = blockidToOthers(proc.Ctx, s, *toType, result, length)
 	case types.T_json:
 		s := vector.GenerateFunctionStrParameter(from)
 		err = jsonToOthers(proc.Ctx, s, *toType, result, length)
@@ -1436,6 +1439,17 @@ func rowidToOthers(ctx context.Context,
 		return nil
 	}
 	return moerr.NewInternalError(ctx, fmt.Sprintf("unsupported cast from rowid to %s", toType))
+}
+
+func blockidToOthers(ctx context.Context,
+	source vector.FunctionParameterWrapper[types.Blockid],
+	toType types.Type, result vector.FunctionResultWrapper, length int) error {
+	if toType.Oid == types.T_Blockid {
+		rs := vector.MustFunctionResult[types.Blockid](result)
+		rs.SetFromParameter(source)
+		return nil
+	}
+	return moerr.NewInternalError(ctx, fmt.Sprintf("unsupported cast from blockid to %s", toType))
 }
 
 func jsonToOthers(ctx context.Context,

--- a/pkg/testutil/util_function.go
+++ b/pkg/testutil/util_function.go
@@ -531,6 +531,24 @@ func (fc *FunctionTestCase) Run() (succeed bool, errInfo string) {
 					i+1, want, get)
 			}
 		}
+	case types.T_Blockid:
+		r := vector.GenerateFunctionFixedTypeParameter[types.Blockid](v)
+		s := vector.GenerateFunctionFixedTypeParameter[types.Blockid](vExpected)
+		for i = 0; i < uint64(fc.fnLength); i++ {
+			want, null1 := s.GetValue(i)
+			get, null2 := r.GetValue(i)
+			if null1 {
+				if null2 {
+					continue
+				} else {
+					return false, fmt.Sprintf("the %dth row expected NULL, but get not null", i+1)
+				}
+			}
+			if want != get {
+				return false, fmt.Sprintf("the %dth row expected %v, but get %v",
+					i+1, want, get)
+			}
+		}
 	case types.T_json:
 		r := vector.GenerateFunctionStrParameter(v)
 		s := vector.GenerateFunctionStrParameter(vExpected)
@@ -641,6 +659,9 @@ func newVectorByType(mp *mpool.MPool, typ types.Type, val any, nsp *nulls.Nulls)
 		vector.AppendFixedList(vec, values, nil, mp)
 	case types.T_Rowid:
 		values := val.([]types.Rowid)
+		vector.AppendFixedList(vec, values, nil, mp)
+	case types.T_Blockid:
+		values := val.([]types.Blockid)
 		vector.AppendFixedList(vec, values, nil, mp)
 	case types.T_json:
 		values := val.([]string)

--- a/pkg/testutil/util_new.go
+++ b/pkg/testutil/util_new.go
@@ -229,6 +229,11 @@ func NewVector(n int, typ types.Type, m *mpool.MPool, random bool, Values interf
 			return NewRowidVector(n, typ, m, random, vs)
 		}
 		return NewRowidVector(n, typ, m, random, nil)
+	case types.T_Blockid:
+		if vs, ok := Values.([]types.Blockid); ok {
+			return NewBlockidVector(n, typ, m, random, vs)
+		}
+		return NewBlockidVector(n, typ, m, random, nil)
 	default:
 		panic(moerr.NewInternalErrorNoCtx("unsupport vector's type '%v", typ))
 	}
@@ -273,6 +278,29 @@ func NewRowidVector(n int, typ types.Type, m *mpool.MPool, _ bool, vs []types.Ro
 
 		rowId[1] = int64(i)
 		if err := vector.AppendFixed(vec, *(*types.Rowid)(unsafe.Pointer(&rowId[0])), false, m); err != nil {
+			vec.Free(m)
+			return nil
+		}
+	}
+	return vec
+}
+
+func NewBlockidVector(n int, typ types.Type, m *mpool.MPool, _ bool, vs []types.Blockid) *vector.Vector {
+	vec := vector.NewVec(typ)
+	if vs != nil {
+		for i := range vs {
+			if err := vector.AppendFixed(vec, vs[i], false, m); err != nil {
+				vec.Free(m)
+				return nil
+			}
+		}
+		return vec
+	}
+	for i := 0; i < n; i++ {
+		var rowId [2]int64
+
+		rowId[1] = int64(i)
+		if err := vector.AppendFixed(vec, *(*types.Blockid)(unsafe.Pointer(&rowId[0])), false, m); err != nil {
 			vec.Free(m)
 			return nil
 		}

--- a/pkg/txn/storage/memorystorage/memorytable/types.go
+++ b/pkg/txn/storage/memorystorage/memorytable/types.go
@@ -227,6 +227,8 @@ func TypeMatch(v any, typ types.T) bool {
 		_, ok = v.(types.TS)
 	case types.T_Rowid:
 		_, ok = v.(types.Rowid)
+	case types.T_Blockid:
+		_, ok = v.(types.Blockid)
 	default:
 		panic(fmt.Sprintf("fixme: %v", typ))
 	}

--- a/pkg/txn/storage/memorystorage/memorytable/vector_utils.go
+++ b/pkg/txn/storage/memorystorage/memorytable/vector_utils.go
@@ -88,7 +88,8 @@ func VectorAt(vec *vector.Vector, i int) (value Nullable) {
 
 	case types.T_Rowid:
 		return vectorAtFixed[types.Rowid](vec, i)
-
+	case types.T_Blockid:
+		return vectorAtFixed[types.Blockid](vec, i)
 	case types.T_uuid:
 		return vectorAtFixed[types.Uuid](vec, i)
 

--- a/pkg/vm/engine/memoryengine/shard_hash.go
+++ b/pkg/vm/engine/memoryengine/shard_hash.go
@@ -581,7 +581,20 @@ func getNullableValueFromVector(vec *vector.Vector, i int) (value Nullable) {
 			Value:  vector.MustFixedCol[types.Rowid](vec)[i],
 		}
 		return
-
+	case types.T_Blockid:
+		if vec.IsConstNull() {
+			var zero types.Blockid
+			value = Nullable{
+				IsNull: true,
+				Value:  zero,
+			}
+			return
+		}
+		value = Nullable{
+			IsNull: vec.GetNulls().Contains(uint64(i)),
+			Value:  vector.MustFixedCol[types.Blockid](vec)[i],
+		}
+		return
 	case types.T_uuid:
 		if vec.IsConstNull() {
 			var zero types.Uuid

--- a/pkg/vm/engine/tae/compute/compare.go
+++ b/pkg/vm/engine/tae/compute/compare.go
@@ -95,6 +95,8 @@ func CompareGeneric(a, b any, t types.Type) int64 {
 		return int64(a.(types.TS).Compare(b.(types.TS)))
 	case types.T_Rowid:
 		return CompareBytes(a, b)
+	case types.T_Blockid:
+		return CompareBytes(a, b)
 	case types.T_uuid:
 		return types.CompareUuid(a.(types.Uuid), b.(types.Uuid))
 	case types.T_char, types.T_varchar, types.T_blob,

--- a/pkg/vm/engine/tae/compute/compute.go
+++ b/pkg/vm/engine/tae/compute/compute.go
@@ -229,6 +229,12 @@ func GetOffsetByVal(data containers.Vector, v any, skipmask *roaring.Bitmap) (of
 			v.(types.Rowid),
 			types.CompareRowidRowidAligned,
 			skipmask)
+	case types.T_Blockid:
+		return GetOffsetWithFunc(
+			data.Slice().([]types.Blockid),
+			v.(types.Blockid),
+			types.CompareBlockidBlockidAligned,
+			skipmask)
 	case types.T_uuid:
 		return GetOffsetWithFunc(
 			data.Slice().([]types.Uuid),

--- a/pkg/vm/engine/tae/containers/mock.go
+++ b/pkg/vm/engine/tae/containers/mock.go
@@ -219,7 +219,10 @@ func MockVector(t types.Type, rows int, unique, nullable bool, provider Vector) 
 		for i := int32(1); i <= int32(rows); i++ {
 			vec.Append(types.BuildRowid(int64(i+1), int64(i)))
 		}
-
+	case types.T_Blockid:
+		for i := int32(1); i <= int32(rows); i++ {
+			vec.Append(types.BuildBlockid(int64(i+1), int64(i)))
+		}
 	default:
 		panic("not supported")
 	}

--- a/pkg/vm/engine/tae/containers/utils.go
+++ b/pkg/vm/engine/tae/containers/utils.go
@@ -373,7 +373,12 @@ func MockVec(typ types.Type, rows int, offset int) *movec.Vector {
 			data = append(data, types.BuildRowid(int64(i+1), int64(i%16)))
 		}
 		_ = movec.AppendFixedList(vec, data, nil, mockMp)
-
+	case types.T_Blockid:
+		data := make([]types.Blockid, 0)
+		for i := 0; i < rows; i++ {
+			data = append(data, types.BuildBlockid(int64(i+1), int64(i%16)))
+		}
+		_ = movec.AppendFixedList(vec, data, nil, mockMp)
 	default:
 		panic("not support")
 	}
@@ -464,6 +469,8 @@ func AppendValue(vec *movec.Vector, v any) {
 		AppendFixedValue[types.TS](vec, v)
 	case types.T_Rowid:
 		AppendFixedValue[types.Rowid](vec, v)
+	case types.T_Blockid:
+		AppendFixedValue[types.Blockid](vec, v)
 	case types.T_char, types.T_varchar, types.T_json,
 		types.T_binary, types.T_varbinary, types.T_blob, types.T_text:
 		AppendBytes(vec, v)
@@ -517,6 +524,8 @@ func GetValue(col *movec.Vector, row uint32) any {
 		return movec.GetFixedAt[types.TS](col, int(row))
 	case types.T_Rowid:
 		return movec.GetFixedAt[types.Rowid](col, int(row))
+	case types.T_Blockid:
+		return movec.GetFixedAt[types.Blockid](col, int(row))
 	case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary, types.T_json, types.T_blob, types.T_text:
 		return col.GetBytesAt(int(row))
 	default:
@@ -567,7 +576,8 @@ func UpdateValue(col *movec.Vector, row uint32, val any) {
 		GenericUpdateFixedValue[types.TS](col, row, val)
 	case types.T_Rowid:
 		GenericUpdateFixedValue[types.Rowid](col, row, val)
-
+	case types.T_Blockid:
+		GenericUpdateFixedValue[types.Blockid](col, row, val)
 	case types.T_varchar, types.T_char, types.T_json,
 		types.T_binary, types.T_varbinary, types.T_blob, types.T_text:
 		GenericUpdateBytes(col, row, val)

--- a/pkg/vm/engine/tae/index/zonemap.go
+++ b/pkg/vm/engine/tae/index/zonemap.go
@@ -401,6 +401,11 @@ func (zm *ZoneMap) Unmarshal(buf []byte) error {
 		buf = buf[32:]
 		zm.max = buf[:types.RowidSize]
 		return nil
+	case types.T_Blockid:
+		zm.min = buf[:types.BlockidSize]
+		buf = buf[32:]
+		zm.max = buf[:types.BlockidSize]
+		return nil
 	case types.T_char, types.T_varchar, types.T_json,
 		types.T_binary, types.T_varbinary, types.T_blob, types.T_text:
 		minBuf := make([]byte, buf[31]&0x7f)

--- a/pkg/vm/engine/tae/mergesort/mergesort.go
+++ b/pkg/vm/engine/tae/mergesort/mergesort.go
@@ -112,6 +112,8 @@ func SortBlockColumns(cols []containers.Vector, pk int) ([]uint32, error) {
 		Sort(cols[pk], tsLess, sortedIdx)
 	case types.T_Rowid:
 		Sort(cols[pk], rowidLess, sortedIdx)
+	case types.T_Blockid:
+		Sort(cols[pk], blockidLess, sortedIdx)
 	case types.T_char, types.T_json, types.T_varchar,
 		types.T_binary, types.T_varbinary, types.T_blob, types.T_text:
 		Sort(cols[pk], bytesLess, sortedIdx)
@@ -217,6 +219,8 @@ func MergeSortedColumn(column []containers.Vector, sortedIdx *[]uint32, fromLayo
 		ret, mapping = Merge(column, sortedIdx, tsLess, fromLayout, toLayout)
 	case types.T_Rowid:
 		ret, mapping = Merge(column, sortedIdx, rowidLess, fromLayout, toLayout)
+	case types.T_Blockid:
+		ret, mapping = Merge(column, sortedIdx, blockidLess, fromLayout, toLayout)
 	case types.T_char, types.T_json, types.T_varchar,
 		types.T_binary, types.T_varbinary, types.T_blob, types.T_text:
 		ret, mapping = Merge(column, sortedIdx, bytesLess, fromLayout, toLayout)

--- a/pkg/vm/engine/tae/mergesort/types.go
+++ b/pkg/vm/engine/tae/mergesort/types.go
@@ -32,9 +32,10 @@ func boolLess(a, b bool) bool                   { return !a && b }
 func ltTypeLess[T Lter[T]](a, b T) bool         { return a.Lt(b) }
 
 // it seems that go has no const generic type, handle these types respectively
-func tsLess(a, b types.TS) bool       { return bytes.Compare(a[:], b[:]) < 0 }
-func rowidLess(a, b types.Rowid) bool { return bytes.Compare(a[:], b[:]) < 0 }
-func bytesLess(a, b []byte) bool      { return bytes.Compare(a, b) < 0 }
+func tsLess(a, b types.TS) bool           { return bytes.Compare(a[:], b[:]) < 0 }
+func rowidLess(a, b types.Rowid) bool     { return bytes.Compare(a[:], b[:]) < 0 }
+func blockidLess(a, b types.Blockid) bool { return bytes.Compare(a[:], b[:]) < 0 }
+func bytesLess(a, b []byte) bool          { return bytes.Compare(a, b) < 0 }
 
 const nullFirst = true
 

--- a/pkg/vm/engine/tae/txn/txnimpl/index.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/index.go
@@ -240,6 +240,8 @@ func (idx *simpleTableIndex) BatchInsert(
 		return InsertOp[types.TS](colType, attr, col.Slice(), start, count, row, dedupInput, idx.tree)
 	case types.T_Rowid:
 		return InsertOp[types.Rowid](colType, attr, col.Slice(), start, count, row, dedupInput, idx.tree)
+	case types.T_Blockid:
+		return InsertOp[types.Blockid](colType, attr, col.Slice(), start, count, row, dedupInput, idx.tree)
 	case types.T_char, types.T_varchar, types.T_json,
 		types.T_binary, types.T_varbinary, types.T_blob, types.T_text:
 		vs := col.Bytes()
@@ -333,6 +335,9 @@ func (idx *simpleTableIndex) BatchDedup(attr string, col containers.Vector) erro
 	case types.T_Rowid:
 		vals := col.Slice()
 		return DedupOp[types.Rowid](colType, attr, vals, idx.tree)
+	case types.T_Blockid:
+		vals := col.Slice()
+		return DedupOp[types.Blockid](colType, attr, vals, idx.tree)
 	case types.T_char, types.T_varchar, types.T_json,
 		types.T_binary, types.T_varbinary, types.T_blob, types.T_text:
 		bs := col.Bytes()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
The new DN vector is embedding the CN vector inside it. Hence we find the missing `T_BlockId` in some `type switch` to be a problem.