### PR TITLE
[Improvement] Replace dnVec.CloneMOVec() with cnVec.CloneWindow()

### DIFF
--- a/pkg/container/vector/vector_test.go
+++ b/pkg/container/vector/vector_test.go
@@ -643,7 +643,7 @@ func TestCopy(t *testing.T) {
 	}
 }
 
-func TestCloneWindow(t *testing.T) {
+func TestCloneWindowWithMpNil(t *testing.T) {
 	mp := mpool.MustNewZero()
 	vec1 := NewVec(types.T_int32.ToType())
 	AppendFixed(vec1, int32(1), false, mp)

--- a/pkg/container/vector/vector_test.go
+++ b/pkg/container/vector/vector_test.go
@@ -15,7 +15,6 @@
 package vector
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -649,7 +648,7 @@ func TestCloneWindowWithMpNil(t *testing.T) {
 	AppendFixed(vec1, int32(1), false, mp)
 	AppendFixed(vec1, int32(2), true, mp)
 	AppendFixed(vec1, int32(3), false, mp)
-	assert.False(t, vec1.NeedDup())
+	require.False(t, vec1.NeedDup())
 
 	vec1Len := vec1.Length()
 	vec2, err := vec1.CloneWindow(0, vec1Len, nil)
@@ -657,26 +656,26 @@ func TestCloneWindowWithMpNil(t *testing.T) {
 	vec1.Free(mp)
 
 	t.Log(vec2.String())
-	assert.True(t, vec2.NeedDup())
-	assert.Equal(t, int32(1), GetFixedAt[int32](vec2, 0))
-	assert.True(t, vec2.GetNulls().Contains(uint64(1)))
-	assert.Equal(t, int32(3), GetFixedAt[int32](vec2, 2))
+	require.True(t, vec2.NeedDup())
+	require.Equal(t, int32(1), GetFixedAt[int32](vec2, 0))
+	require.True(t, vec2.GetNulls().Contains(uint64(1)))
+	require.Equal(t, int32(3), GetFixedAt[int32](vec2, 2))
 
 	vec3 := NewVec(types.T_char.ToType())
 	AppendBytes(vec3, []byte("h"), false, mp)
 	AppendBytes(vec3, []byte("xx"), true, mp)
 	AppendBytes(vec3, []byte("uuu"), false, mp)
-	assert.False(t, vec3.NeedDup())
+	require.False(t, vec3.NeedDup())
 
 	vec3Len := vec3.Length()
 	vec4, err := vec3.CloneWindow(0, vec3Len, nil)
 	require.NoError(t, err)
 	vec3.Free(mp)
 
-	assert.True(t, vec4.NeedDup())
-	assert.Equal(t, 1, len(vec4.GetBytesAt(0)))
-	assert.Equal(t, 3, len(vec4.GetBytesAt(2)))
-	assert.True(t, vec4.GetNulls().Contains(uint64(1)))
+	require.True(t, vec4.NeedDup())
+	require.Equal(t, 1, len(vec4.GetBytesAt(0)))
+	require.Equal(t, 3, len(vec4.GetBytesAt(2)))
+	require.True(t, vec4.GetNulls().Contains(uint64(1)))
 }
 
 /*

--- a/pkg/container/vector/vector_test.go
+++ b/pkg/container/vector/vector_test.go
@@ -650,8 +650,7 @@ func TestCloneWindowWithMpNil(t *testing.T) {
 	AppendFixed(vec1, int32(3), false, mp)
 	require.False(t, vec1.NeedDup())
 
-	vec1Len := vec1.Length()
-	vec2, err := vec1.CloneWindow(0, vec1Len, nil)
+	vec2, err := vec1.CloneWindow(0, vec1.Length(), nil)
 	require.NoError(t, err)
 	vec1.Free(mp)
 
@@ -667,8 +666,7 @@ func TestCloneWindowWithMpNil(t *testing.T) {
 	AppendBytes(vec3, []byte("uuu"), false, mp)
 	require.False(t, vec3.NeedDup())
 
-	vec3Len := vec3.Length()
-	vec4, err := vec3.CloneWindow(0, vec3Len, nil)
+	vec4, err := vec3.CloneWindow(0, vec3.Length(), nil)
 	require.NoError(t, err)
 	vec3.Free(mp)
 

--- a/pkg/vm/engine/tae/containers/utils.go
+++ b/pkg/vm/engine/tae/containers/utils.go
@@ -128,15 +128,6 @@ func NewNonNullBatchWithSharedMemory(b *batch.Batch) *Batch {
 	return bat
 }
 
-func CloneMOVec(v *movec.Vector) *movec.Vector {
-	end := v.Length()
-	dest, err := v.CloneWindow(0, end, nil)
-	if err != nil {
-		panic(err)
-	}
-	return dest
-}
-
 func NewVectorWithSharedMemory(v *movec.Vector, nullable bool) Vector {
 	vec := MakeVector(*v.GetType(), nullable)
 	var bs *Bytes

--- a/pkg/vm/engine/tae/containers/utils.go
+++ b/pkg/vm/engine/tae/containers/utils.go
@@ -130,11 +130,11 @@ func NewNonNullBatchWithSharedMemory(b *batch.Batch) *Batch {
 
 func CloneMOVec(v *movec.Vector) *movec.Vector {
 	end := v.Length()
-	res, err := v.CloneWindow(0, end, nil)
+	dest, err := v.CloneWindow(0, end, nil)
 	if err != nil {
 		panic(err)
 	}
-	return res
+	return dest
 }
 
 func NewVectorWithSharedMemory(v *movec.Vector, nullable bool) Vector {

--- a/pkg/vm/engine/tae/containers/utils.go
+++ b/pkg/vm/engine/tae/containers/utils.go
@@ -129,80 +129,12 @@ func NewNonNullBatchWithSharedMemory(b *batch.Batch) *Batch {
 }
 
 func CloneMOVec(v *movec.Vector) *movec.Vector {
-	typ := *v.GetType()
-	if typ.IsVarlen() {
-		var header []types.Varlena
-		data, area := movec.MustVarlenaRawData(v)
-		header = make([]types.Varlena, len(data))
-		copy(header, data)
-		storage := make([]byte, len(area))
-		if len(storage) > 0 {
-			copy(storage, area)
-		}
-		dest, _ := movec.FromDNVector(typ, header, storage)
-		if v.GetNulls().Any() {
-			dest.SetNulls(v.GetNulls().Clone())
-		}
-		return dest
+	end := v.Length()
+	res, err := v.CloneWindow(0, end, nil)
+	if err != nil {
+		panic(err)
 	}
-	var bs *Bytes
-
-	switch v.GetType().Oid {
-	case types.T_bool:
-		bs = movecToBytes[bool](v)
-	case types.T_int8:
-		bs = movecToBytes[int8](v)
-	case types.T_int16:
-		bs = movecToBytes[int16](v)
-	case types.T_int32:
-		bs = movecToBytes[int32](v)
-	case types.T_int64:
-		bs = movecToBytes[int64](v)
-	case types.T_uint8:
-		bs = movecToBytes[uint8](v)
-	case types.T_uint16:
-		bs = movecToBytes[uint16](v)
-	case types.T_uint32:
-		bs = movecToBytes[uint32](v)
-	case types.T_uint64:
-		bs = movecToBytes[uint64](v)
-	case types.T_float32:
-		bs = movecToBytes[float32](v)
-	case types.T_float64:
-		bs = movecToBytes[float64](v)
-	case types.T_date:
-		bs = movecToBytes[types.Date](v)
-	case types.T_time:
-		bs = movecToBytes[types.Time](v)
-	case types.T_datetime:
-		bs = movecToBytes[types.Datetime](v)
-	case types.T_timestamp:
-		bs = movecToBytes[types.Timestamp](v)
-	case types.T_decimal64:
-		bs = movecToBytes[types.Decimal64](v)
-	case types.T_decimal128:
-		bs = movecToBytes[types.Decimal128](v)
-	case types.T_uuid:
-		bs = movecToBytes[types.Uuid](v)
-	case types.T_TS:
-		bs = movecToBytes[types.TS](v)
-	case types.T_Rowid:
-		bs = movecToBytes[types.Rowid](v)
-	case types.T_Blockid:
-		bs = movecToBytes[types.Blockid](v)
-	default:
-		panic(any(moerr.NewInternalErrorNoCtx("%s not supported", typ.String())))
-	}
-	data := make([]byte, len(bs.Storage))
-	if len(data) > 0 {
-		copy(data, bs.Storage)
-	}
-	dest, _ := movec.FromDNVector(typ, nil, data)
-
-	if v.GetNulls().Any() {
-		dest.SetNulls(v.GetNulls().Clone())
-	}
-	return dest
+	return res
 }
 
 func NewVectorWithSharedMemory(v *movec.Vector, nullable bool) Vector {

--- a/pkg/vm/engine/tae/containers/vector_test.go
+++ b/pkg/vm/engine/tae/containers/vector_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/compress"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
-	movec "github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/testutils"
 	"github.com/pierrec/lz4/v4"
 	"github.com/stretchr/testify/assert"
@@ -519,36 +518,4 @@ func BenchmarkVectorExtend(t *testing.B) {
 	for i := 0; i < t.N; i++ {
 		vec1.Extend(vec2)
 	}
-}
-
-func TestCloneCNVector(t *testing.T) {
-	mp := mpool.MustNewZero()
-	vec1 := movec.NewVec(types.T_int32.ToType())
-	movec.AppendFixed(vec1, int32(1), false, mp)
-	movec.AppendFixed(vec1, int32(2), true, mp)
-	movec.AppendFixed(vec1, int32(3), false, mp)
-	assert.False(t, vec1.NeedDup())
-
-	vec2 := CloneMOVec(vec1)
-	vec1.Free(mp)
-
-	t.Log(vec2.String())
-	assert.True(t, vec2.NeedDup())
-	assert.Equal(t, int32(1), movec.GetFixedAt[int32](vec2, 0))
-	assert.True(t, vec2.GetNulls().Contains(uint64(1)))
-	assert.Equal(t, int32(3), movec.GetFixedAt[int32](vec2, 2))
-
-	vec3 := movec.NewVec(types.T_char.ToType())
-	movec.AppendBytes(vec3, []byte("h"), false, mp)
-	movec.AppendBytes(vec3, []byte("xx"), true, mp)
-	movec.AppendBytes(vec3, []byte("uuu"), false, mp)
-	assert.False(t, vec3.NeedDup())
-
-	vec4 := CloneMOVec(vec3)
-	vec3.Free(mp)
-
-	assert.True(t, vec4.NeedDup())
-	assert.Equal(t, 1, len(vec4.GetBytesAt(0)))
-	assert.Equal(t, 3, len(vec4.GetBytesAt(2)))
-	assert.True(t, vec4.GetNulls().Contains(uint64(1)))
 }

--- a/pkg/vm/engine/tae/dataio/blockio/read.go
+++ b/pkg/vm/engine/tae/dataio/blockio/read.go
@@ -84,8 +84,7 @@ func BlockReadInner(
 	for i, col := range columnBatch.Vecs {
 		// Fixme: Due to # 8684, we are not able to use mpool yet
 		// Fixme: replace with cnVec.Dup(nil) when it implemented.
-		colLen := col.Length()
-		columnBatch.Vecs[i], err = col.CloneWindow(0, colLen, nil)
+		columnBatch.Vecs[i], err = col.CloneWindow(0, col.Length(), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/vm/engine/tae/dataio/blockio/read.go
+++ b/pkg/vm/engine/tae/dataio/blockio/read.go
@@ -17,7 +17,6 @@ package blockio
 import (
 	"context"
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -84,7 +83,9 @@ func BlockReadInner(
 	// remove rows from columns
 	for i, col := range columnBatch.Vecs {
 		// Fixme: Due to # 8684, we are not able to use mpool yet
-		columnBatch.Vecs[i] = containers.CloneMOVec(col)
+		// Fixme: replace with cnVec.Dup(nil) when it implemented.
+		colLen := col.Length()
+		columnBatch.Vecs[i], err = col.CloneWindow(0, colLen, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [X] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Reusing CN vector CloneWindow, to mimic CloneMOVec() functionality.
https://github.com/matrixorigin/matrixone/commit/4322ac6b9603f76b0dac339feb3d61b0e209e8bd#r106062041