### PR TITLE
fileservice: add DiskCache eviction

### DIFF
--- a/pkg/perfcounter/counter_set.go
+++ b/pkg/perfcounter/counter_set.go
@@ -48,6 +48,7 @@ type FileServiceCounterSet struct {
 			SetFileContent stats.Counter
 			OpenFile       stats.Counter
 			StatFile       stats.Counter
+			Error          stats.Counter
 		}
 	}
 


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8723 

## What this PR does / why we need it:
fileservice: ignore disk write error in disk cache; add .mofscache extension to disk cache files

fileservice: add DiskCache.collect and evict

fileservice: add DiskCache eviction