### PR TITLE
vector: pre-alloc buffer to reduce allocations in Vector.MarshalBinary

### DIFF
--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -293,8 +293,12 @@ func (v *Vector) Free(mp *mpool.MPool) {
 	v.cantFreeArea = false
 }
 
+var sizeOfVectorStruct = int(unsafe.Sizeof(Vector{}))
+
 func (v *Vector) MarshalBinary() ([]byte, error) {
-	var buf bytes.Buffer
+	buf := bytes.NewBuffer(
+		make([]byte, 0, sizeOfVectorStruct+len(v.data)+len(v.area)),
+	)
 
 	// write class
 	buf.WriteByte(uint8(v.class))

--- a/pkg/container/vector/vector_test.go
+++ b/pkg/container/vector/vector_test.go
@@ -1042,3 +1042,17 @@ func TestStrMarshalAndUnMarshal(t *testing.T) {
 	w.Free(mp)
 	require.Equal(t, int64(0), mp.CurrNB())
 }
+
+func BenchmarkMarshalBinary(b *testing.B) {
+	mp := mpool.MustNewZero()
+	v := NewVec(types.T_text.ToType())
+	err := AppendBytesList(v, [][]byte{[]byte("x"), []byte("y")}, nil, mp)
+	require.NoError(b, err)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.MarshalBinary()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
vector: add MarshalBinary benchmark

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
reduce allocations per call from 2 to 1 in benchmark