### PR TITLE
fileservice: disk cache evict fixes

### DIFF
--- a/pkg/fileservice/config.go
+++ b/pkg/fileservice/config.go
@@ -84,6 +84,8 @@ func newDiskFileService(cfg Config, perfCounters []*perfcounter.CounterSet) (Fil
 		cfg.Name,
 		cfg.DataDir,
 		int64(cfg.Cache.MemoryCapacity),
+		int64(cfg.Cache.DiskCapacity),
+		cfg.Cache.DiskPath,
 		perfCounters,
 	)
 	if err != nil {

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -243,7 +243,7 @@ func TestDiskCacheEviction(t *testing.T) {
 	ctx = perfcounter.WithCounterSet(ctx, &counterSet)
 
 	// new
-	cache, err := NewDiskCache(dir, 1, nil)
+	cache, err := NewDiskCache(dir, 3, nil)
 	assert.Nil(t, err)
 
 	n := 128
@@ -267,7 +267,6 @@ func TestDiskCacheEviction(t *testing.T) {
 
 	assert.Equal(t, int64(128), counterSet.FileService.Cache.Disk.SetFileContent.Load())
 
-	cache.stats.Lock()
-	cache.evict()
-	cache.stats.Unlock()
+	cache.evict(ctx)
+	assert.True(t, counterSet.FileService.Cache.Disk.Evict.Load() > 0)
 }

--- a/pkg/fileservice/example_test.go
+++ b/pkg/fileservice/example_test.go
@@ -30,6 +30,8 @@ func TestCacheWithRCExample(t *testing.T) {
 		"rc",
 		dir,
 		32<<20,
+		0,
+		"",
 		nil,
 	)
 	assert.Nil(t, err)
@@ -80,6 +82,8 @@ func TestCacheWithReleasableExample(t *testing.T) {
 		"rc",
 		dir,
 		32<<20,
+		0,
+		"",
 		nil,
 	)
 	assert.Nil(t, err)

--- a/pkg/fileservice/file_services_test.go
+++ b/pkg/fileservice/file_services_test.go
@@ -25,7 +25,7 @@ func TestFileServices(t *testing.T) {
 	t.Run("file service", func(t *testing.T) {
 		testFileService(t, func(name string) FileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS(name, dir, 0, nil)
+			fs, err := NewLocalFS(name, dir, 0, -1, "", nil)
 			assert.Nil(t, err)
 			fs2, err := NewFileServices(name, fs)
 			assert.Nil(t, err)

--- a/pkg/fileservice/local_fs_test.go
+++ b/pkg/fileservice/local_fs_test.go
@@ -25,7 +25,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("file service", func(t *testing.T) {
 		testFileService(t, func(name string) FileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS(name, dir, -1, nil)
+			fs, err := NewLocalFS(name, dir, -1, -1, "", nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -34,7 +34,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("mutable file service", func(t *testing.T) {
 		testMutableFileService(t, func() MutableFileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS("local", dir, -1, nil)
+			fs, err := NewLocalFS("local", dir, -1, -1, "", nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -43,7 +43,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("replaceable file service", func(t *testing.T) {
 		testReplaceableFileService(t, func() ReplaceableFileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS("local", dir, -1, nil)
+			fs, err := NewLocalFS("local", dir, -1, -1, "", nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -52,7 +52,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("caching file service", func(t *testing.T) {
 		testCachingFileService(t, func() CachingFileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS("local", dir, 128*1024, nil)
+			fs, err := NewLocalFS("local", dir, 128*1024, -1, "", nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -63,7 +63,7 @@ func TestLocalFS(t *testing.T) {
 func BenchmarkLocalFS(b *testing.B) {
 	benchmarkFileService(b, func() FileService {
 		dir := b.TempDir()
-		fs, err := NewLocalFS("local", dir, -1, nil)
+		fs, err := NewLocalFS("local", dir, -1, -1, "", nil)
 		assert.Nil(b, err)
 		return fs
 	})

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -99,6 +99,11 @@ func (m *MemCache) Read(
 		}, m.counterSets...)
 	}()
 
+	path, err := ParsePath(vector.FilePath)
+	if err != nil {
+		return err
+	}
+
 	for i, entry := range vector.Entries {
 		if entry.done {
 			continue
@@ -107,7 +112,7 @@ func (m *MemCache) Read(
 			continue
 		}
 		key := IOVectorCacheKey{
-			Path:   vector.FilePath,
+			Path:   path.File,
 			Offset: entry.Offset,
 			Size:   entry.Size,
 		}
@@ -137,12 +142,18 @@ func (m *MemCache) Update(
 	if vector.NoCache {
 		return nil
 	}
+
+	path, err := ParsePath(vector.FilePath)
+	if err != nil {
+		return err
+	}
+
 	for _, entry := range vector.Entries {
 		if entry.Object == nil {
 			continue
 		}
 		key := IOVectorCacheKey{
-			Path:   vector.FilePath,
+			Path:   path.File,
 			Offset: entry.Offset,
 			Size:   entry.Size,
 		}

--- a/pkg/fileservice/profile_test.go
+++ b/pkg/fileservice/profile_test.go
@@ -26,7 +26,7 @@ func TestProfile(t *testing.T) {
 	defer stop()
 	testFileService(t, func(name string) FileService {
 		dir := t.TempDir()
-		fs, err := NewLocalFS(name, dir, -1, nil)
+		fs, err := NewLocalFS(name, dir, -1, -1, "", nil)
 		assert.Nil(t, err)
 		return fs
 	})

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -162,7 +162,10 @@ func (s *S3FS) initCaches(
 			WithLRU(memCacheCapacity),
 			WithPerfCounterSets(s.perfCounterSets),
 		)
-		logutil.Info("fileservice: mem cache initialized", zap.Any("fs-name", s.name), zap.Any("capacity", memCacheCapacity))
+		logutil.Info("fileservice: memory cache initialized",
+			zap.Any("fs-name", s.name),
+			zap.Any("capacity", memCacheCapacity),
+		)
 	}
 
 	// disk cache
@@ -179,7 +182,11 @@ func (s *S3FS) initCaches(
 		if err != nil {
 			return err
 		}
-		logutil.Info("fileservice: disk cache initialized", zap.Any("fs-name", s.name), zap.Any("capacity", diskCacheCapacity))
+		logutil.Info("fileservice: disk cache initialized",
+			zap.Any("fs-name", s.name),
+			zap.Any("capacity", diskCacheCapacity),
+			zap.Any("path", diskCachePath),
+		)
 	}
 
 	return nil
@@ -377,7 +384,7 @@ func (s *S3FS) write(ctx context.Context, vector IOVector) (err error) {
 			if err != nil {
 				return
 			}
-			err = done()
+			err = done(ctx)
 		}()
 		r = io.TeeReader(
 			newIOEntriesReader(ctx, vector.Entries),

--- a/pkg/perfcounter/counter_set.go
+++ b/pkg/perfcounter/counter_set.go
@@ -52,6 +52,7 @@ type FileServiceCounterSet struct {
 			OpenFile       stats.Counter
 			StatFile       stats.Counter
 			Error          stats.Counter
+			Evict          stats.Counter
 		}
 	}
 

--- a/pkg/tests/service/fileservice.go
+++ b/pkg/tests/service/fileservice.go
@@ -45,14 +45,14 @@ func (c *testCluster) buildFileServices() *fileServices {
 	dnServiceNum := c.opt.initial.dnServiceNum
 	cnServiceNum := c.opt.initial.cnServiceNum
 
-	factory := func(dir string, name string) fileservice.FileService {
+	factory := func(_ string, name string) fileservice.FileService {
 		fs, err := fileservice.NewMemoryFS(name)
 		require.NoError(c.t, err)
 		return fs
 	}
 	if c.opt.keepData {
 		factory = func(dir string, name string) fileservice.FileService {
-			fs, err := fileservice.NewLocalFS(name, filepath.Join(dir, name), 0, nil)
+			fs, err := fileservice.NewLocalFS(name, filepath.Join(dir, name), 0, 0, "", nil)
 			require.NoError(c.t, err)
 			return fs
 		}

--- a/pkg/util/export/etl/csv_test.go
+++ b/pkg/util/export/etl/csv_test.go
@@ -38,7 +38,7 @@ func TestLocalFSWriter(t *testing.T) {
 	t.Logf("whereami: %s, %s", selfDir, basedir)
 
 	require.Equal(t, nil, err)
-	fs, err := fileservice.NewLocalFS("test", path.Join(basedir, "system"), mpool.MB, nil)
+	fs, err := fileservice.NewLocalFS("test", path.Join(basedir, "system"), mpool.MB, -1, "", nil)
 	require.Equal(t, nil, err)
 	ctx := context.Background()
 	// csv_test.go:23: whereami: /private/var/folders/lw/05zz3bq12djbnhv1wyzk2jgh0000gn/T/GoLand


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8723 

## What this PR does / why we need it:
fileservice: add disk cache to LocalFS

fileservice: fix disk and memory cache path

fileservice: naming fixes

fileservice: use symlink in disk cache

fileservice: add disk cache eviction logs

fileservice: disable disk caches for LocalFS