### PR TITLE
fileservice: disk cache fixes

### DIFF
--- a/etc/dn-minimal-s3-test.toml
+++ b/etc/dn-minimal-s3-test.toml
@@ -34,6 +34,8 @@ key-prefix = "s3 key preifx"
 memory-capacity = "128MB"
 disk-capacity = "1GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 name = "ETL"

--- a/etc/launch-tae-CN-tae-DN/cn.toml
+++ b/etc/launch-tae-CN-tae-DN/cn.toml
@@ -24,6 +24,8 @@ data-dir = "mo-data/s3"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 name = "ETL"

--- a/etc/launch-tae-CN-tae-DN/dn.toml
+++ b/etc/launch-tae-CN-tae-DN/dn.toml
@@ -24,6 +24,8 @@ data-dir = "mo-data/s3"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 name = "ETL"

--- a/etc/launch-tae-CN-tae-DN/log.toml
+++ b/etc/launch-tae-CN-tae-DN/log.toml
@@ -20,6 +20,8 @@ data-dir = "mo-data/s3"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 name = "ETL"

--- a/etc/launch-tae-compose/config/cn-0.toml
+++ b/etc/launch-tae-compose/config/cn-0.toml
@@ -28,6 +28,8 @@ key-prefix = "server/data"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 backend = "MINIO"

--- a/etc/launch-tae-compose/config/cn-1.toml
+++ b/etc/launch-tae-compose/config/cn-1.toml
@@ -28,6 +28,8 @@ key-prefix = "server/data"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 backend = "MINIO"

--- a/etc/launch-tae-compose/config/dn.toml
+++ b/etc/launch-tae-compose/config/dn.toml
@@ -23,6 +23,8 @@ key-prefix = "server/data"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 backend = "MINIO"

--- a/etc/launch-tae-compose/config/log.toml
+++ b/etc/launch-tae-compose/config/log.toml
@@ -24,6 +24,8 @@ key-prefix = "server/data"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 backend = "MINIO"

--- a/etc/launch-tae-multi-CN-tae-DN/cn1.toml
+++ b/etc/launch-tae-multi-CN-tae-DN/cn1.toml
@@ -24,6 +24,8 @@ data-dir = "mo-data/s3"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 name = "ETL"

--- a/etc/launch-tae-multi-CN-tae-DN/cn2.toml
+++ b/etc/launch-tae-multi-CN-tae-DN/cn2.toml
@@ -24,6 +24,8 @@ data-dir = "mo-data/s3"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 name = "ETL"

--- a/etc/launch-tae-multi-CN-tae-DN/dn.toml
+++ b/etc/launch-tae-multi-CN-tae-DN/dn.toml
@@ -24,6 +24,8 @@ data-dir = "mo-data/s3"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 name = "ETL"

--- a/etc/launch-tae-multi-CN-tae-DN/log.toml
+++ b/etc/launch-tae-multi-CN-tae-DN/log.toml
@@ -20,6 +20,8 @@ data-dir = "mo-data/s3"
 memory-capacity = "512MB"
 disk-capacity = "8GB"
 disk-path = "mo-data/file-service-cache"
+disk-min-evict-interval = "7m"
+disk-evict-target = 0.8
 
 [[fileservice]]
 name = "ETL"

--- a/pkg/cnservice/server_metadata_test.go
+++ b/pkg/cnservice/server_metadata_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestInitMetadata(t *testing.T) {
-	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName, fileservice.DisabledCacheConfig, nil)
 	assert.NoError(t, err)
 
 	s := &service{logger: logutil.GetPanicLogger(), metadataFS: fs}
@@ -41,7 +41,7 @@ func TestInitMetadata(t *testing.T) {
 }
 
 func TestInitMetadataWithExistData(t *testing.T) {
-	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName, fileservice.DisabledCacheConfig, nil)
 	assert.NoError(t, err)
 	value := metadata.CNStore{
 		UUID: "cn1",
@@ -63,7 +63,7 @@ func TestInitMetadataWithInvalidUUIDWillPanic(t *testing.T) {
 		assert.Fail(t, "must panic")
 	}()
 
-	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName, fileservice.DisabledCacheConfig, nil)
 	assert.NoError(t, err)
 	value := metadata.CNStore{
 		UUID: "cn1",

--- a/pkg/dnservice/store_metadata_test.go
+++ b/pkg/dnservice/store_metadata_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestInitMetadata(t *testing.T) {
-	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName, fileservice.DisabledCacheConfig, nil)
 	assert.NoError(t, err)
 
 	s := &store{rt: runtime.DefaultRuntime(), metadataFileService: fs}
@@ -43,7 +43,7 @@ func TestInitMetadata(t *testing.T) {
 }
 
 func TestInitMetadataWithExistData(t *testing.T) {
-	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName, fileservice.DisabledCacheConfig, nil)
 	assert.NoError(t, err)
 	value := metadata.DNStore{
 		UUID: "dn1",
@@ -82,7 +82,7 @@ func TestInitMetadataWithInvalidUUIDWillPanic(t *testing.T) {
 		assert.Fail(t, "must panic")
 	}()
 
-	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
+	fs, err := fileservice.NewMemoryFS(defines.LocalFileServiceName, fileservice.DisabledCacheConfig, nil)
 	assert.NoError(t, err)
 	value := metadata.DNStore{
 		UUID: "dn1",

--- a/pkg/dnservice/store_test.go
+++ b/pkg/dnservice/store_test.go
@@ -59,11 +59,11 @@ func TestAddReplica(t *testing.T) {
 }
 
 func TestStartWithReplicas(t *testing.T) {
-	localFS, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
+	localFS, err := fileservice.NewMemoryFS(defines.LocalFileServiceName, fileservice.DisabledCacheConfig, nil)
 	assert.NoError(t, err)
 
 	factory := func(name string) (*fileservice.FileServices, error) {
-		s3fs, err := fileservice.NewMemoryFS(defines.SharedFileServiceName)
+		s3fs, err := fileservice.NewMemoryFS(defines.SharedFileServiceName, fileservice.DisabledCacheConfig, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -145,18 +145,21 @@ func runDNStoreTest(
 	runDNStoreTestWithFileServiceFactory(t, testFn, func(name string) (*fileservice.FileServices, error) {
 		local, err := fileservice.NewMemoryFS(
 			defines.LocalFileServiceName,
+			fileservice.DisabledCacheConfig, nil,
 		)
 		if err != nil {
 			return nil, err
 		}
 		s3, err := fileservice.NewMemoryFS(
 			defines.SharedFileServiceName,
+			fileservice.DisabledCacheConfig, nil,
 		)
 		if err != nil {
 			return nil, err
 		}
 		etl, err := fileservice.NewMemoryFS(
 			defines.ETLFileServiceName,
+			fileservice.DisabledCacheConfig, nil,
 		)
 		if err != nil {
 			return nil, err
@@ -186,7 +189,7 @@ func runDNStoreTestWithFileServiceFactory(
 
 	if fsFactory == nil {
 		fsFactory = func(name string) (*fileservice.FileServices, error) {
-			fs, err := fileservice.NewMemoryFS(name)
+			fs, err := fileservice.NewMemoryFS(name, fileservice.DisabledCacheConfig, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -17,14 +17,33 @@ package fileservice
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/util/toml"
 )
 
 type CacheConfig struct {
-	MemoryCapacity toml.ByteSize `toml:"memory-capacity"`
-	DiskPath       string        `toml:"disk-path"`
-	DiskCapacity   toml.ByteSize `toml:"disk-capacity"`
+	MemoryCapacity       toml.ByteSize `toml:"memory-capacity"`
+	DiskPath             string        `toml:"disk-path"`
+	DiskCapacity         toml.ByteSize `toml:"disk-capacity"`
+	DiskMinEvictInterval toml.Duration `toml:"disk-min-evict-interval"`
+	DiskEvictTarget      float64       `toml:"disk-evict-target"`
+}
+
+func (c *CacheConfig) SetDefaults() {
+	if c.DiskMinEvictInterval.Duration == 0 {
+		c.DiskMinEvictInterval.Duration = time.Minute * 7
+	}
+	if c.DiskEvictTarget == 0 {
+		c.DiskEvictTarget = 0.8
+	}
+}
+
+const DisableCacheCapacity = 1
+
+var DisabledCacheConfig = CacheConfig{
+	MemoryCapacity: DisableCacheCapacity,
+	DiskCapacity:   DisableCacheCapacity,
 }
 
 // VectorCache caches IOVector

--- a/pkg/fileservice/config.go
+++ b/pkg/fileservice/config.go
@@ -68,8 +68,12 @@ func NewFileService(cfg Config, perfCounterSets []*perfcounter.CounterSet) (File
 	}
 }
 
-func newMemFileService(cfg Config, _ []*perfcounter.CounterSet) (FileService, error) {
-	fs, err := NewMemoryFS(cfg.Name)
+func newMemFileService(cfg Config, perfCounters []*perfcounter.CounterSet) (FileService, error) {
+	fs, err := NewMemoryFS(
+		cfg.Name,
+		cfg.Cache,
+		perfCounters,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -83,9 +87,7 @@ func newDiskFileService(cfg Config, perfCounters []*perfcounter.CounterSet) (Fil
 	fs, err := NewLocalFS(
 		cfg.Name,
 		cfg.DataDir,
-		int64(cfg.Cache.MemoryCapacity),
-		int64(cfg.Cache.DiskCapacity),
-		cfg.Cache.DiskPath,
+		cfg.Cache,
 		perfCounters,
 	)
 	if err != nil {
@@ -112,9 +114,7 @@ func newMinioFileService(cfg Config, perfCounters []*perfcounter.CounterSet) (Fi
 		cfg.S3.Endpoint,
 		cfg.S3.Bucket,
 		cfg.S3.KeyPrefix,
-		int64(cfg.Cache.MemoryCapacity),
-		int64(cfg.Cache.DiskCapacity),
-		cfg.Cache.DiskPath,
+		cfg.Cache,
 		perfCounters,
 		false,
 	)
@@ -131,9 +131,7 @@ func newS3FileService(cfg Config, perfCounters []*perfcounter.CounterSet) (FileS
 		cfg.S3.Endpoint,
 		cfg.S3.Bucket,
 		cfg.S3.KeyPrefix,
-		int64(cfg.Cache.MemoryCapacity),
-		int64(cfg.Cache.DiskCapacity),
-		cfg.Cache.DiskPath,
+		cfg.Cache,
 		perfCounters,
 		false,
 	)

--- a/pkg/fileservice/example_test.go
+++ b/pkg/fileservice/example_test.go
@@ -29,9 +29,9 @@ func TestCacheWithRCExample(t *testing.T) {
 	fs, err := NewLocalFS(
 		"rc",
 		dir,
-		32<<20,
-		0,
-		"",
+		CacheConfig{
+			MemoryCapacity: 32 << 20,
+		},
 		nil,
 	)
 	assert.Nil(t, err)
@@ -81,9 +81,9 @@ func TestCacheWithReleasableExample(t *testing.T) {
 	fs, err := NewLocalFS(
 		"rc",
 		dir,
-		32<<20,
-		0,
-		"",
+		CacheConfig{
+			MemoryCapacity: 32 << 20,
+		},
 		nil,
 	)
 	assert.Nil(t, err)

--- a/pkg/fileservice/file_services_test.go
+++ b/pkg/fileservice/file_services_test.go
@@ -25,7 +25,7 @@ func TestFileServices(t *testing.T) {
 	t.Run("file service", func(t *testing.T) {
 		testFileService(t, func(name string) FileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS(name, dir, 0, -1, "", nil)
+			fs, err := NewLocalFS(name, dir, DisabledCacheConfig, nil)
 			assert.Nil(t, err)
 			fs2, err := NewFileServices(name, fs)
 			assert.Nil(t, err)
@@ -35,9 +35,9 @@ func TestFileServices(t *testing.T) {
 }
 
 func TestFileServicesNameCaseInsensitive(t *testing.T) {
-	fs1, err := NewMemoryFS("foo")
+	fs1, err := NewMemoryFS("foo", DisabledCacheConfig, nil)
 	assert.Nil(t, err)
-	fs2, err := NewMemoryFS("FOO")
+	fs2, err := NewMemoryFS("FOO", DisabledCacheConfig, nil)
 	assert.Nil(t, err)
 	_, err = NewFileServices(fs1.Name(), fs1, fs2)
 	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrDupServiceName))

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -57,9 +57,7 @@ const (
 func NewLocalFS(
 	name string,
 	rootPath string,
-	memCacheCapacity int64,
-	diskCacheCapacity int64,
-	diskCachePath string,
+	cacheConfig CacheConfig,
 	perfCounterSets []*perfcounter.CounterSet,
 ) (*LocalFS, error) {
 
@@ -115,35 +113,28 @@ func NewLocalFS(
 		perfCounterSets: perfCounterSets,
 	}
 
-	if err := fs.initCaches(
-		memCacheCapacity,
-		diskCacheCapacity,
-		diskCachePath,
-	); err != nil {
+	if err := fs.initCaches(cacheConfig); err != nil {
 		return nil, err
 	}
 
 	return fs, nil
 }
 
-func (l *LocalFS) initCaches(
-	memCacheCapacity int64,
-	diskCacheCapacity int64,
-	diskCachePath string,
-) error {
+func (l *LocalFS) initCaches(config CacheConfig) error {
+	config.SetDefaults()
 
-	if memCacheCapacity > 0 {
+	if config.MemoryCapacity > DisableCacheCapacity { // 1 means disable
 		l.memCache = NewMemCache(
-			WithLRU(memCacheCapacity),
+			WithLRU(int64(config.MemoryCapacity)),
 			WithPerfCounterSets(l.perfCounterSets),
 		)
 		logutil.Info("fileservice: memory cache initialized",
 			zap.Any("fs-name", l.name),
-			zap.Any("capacity", memCacheCapacity),
+			zap.Any("config", config),
 		)
 	}
 
-	//if diskCacheCapacity > 0 && diskCachePath != "" {
+	//if diskCacheCapacity > DisableCacheCapacity && diskCachePath != "" {
 	//	var err error
 	//	l.diskCache, err = NewDiskCache(
 	//		diskCachePath,

--- a/pkg/fileservice/local_fs_test.go
+++ b/pkg/fileservice/local_fs_test.go
@@ -25,7 +25,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("file service", func(t *testing.T) {
 		testFileService(t, func(name string) FileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS(name, dir, -1, -1, "", nil)
+			fs, err := NewLocalFS(name, dir, DisabledCacheConfig, nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -34,7 +34,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("mutable file service", func(t *testing.T) {
 		testMutableFileService(t, func() MutableFileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS("local", dir, -1, -1, "", nil)
+			fs, err := NewLocalFS("local", dir, DisabledCacheConfig, nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -43,7 +43,7 @@ func TestLocalFS(t *testing.T) {
 	t.Run("replaceable file service", func(t *testing.T) {
 		testReplaceableFileService(t, func() ReplaceableFileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS("local", dir, -1, -1, "", nil)
+			fs, err := NewLocalFS("local", dir, DisabledCacheConfig, nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -52,7 +52,9 @@ func TestLocalFS(t *testing.T) {
 	t.Run("caching file service", func(t *testing.T) {
 		testCachingFileService(t, func() CachingFileService {
 			dir := t.TempDir()
-			fs, err := NewLocalFS("local", dir, 128*1024, -1, "", nil)
+			fs, err := NewLocalFS("local", dir, CacheConfig{
+				MemoryCapacity: 128 * 1024,
+			}, nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -63,7 +65,7 @@ func TestLocalFS(t *testing.T) {
 func BenchmarkLocalFS(b *testing.B) {
 	benchmarkFileService(b, func() FileService {
 		dir := b.TempDir()
-		fs, err := NewLocalFS("local", dir, -1, -1, "", nil)
+		fs, err := NewLocalFS("local", dir, DisabledCacheConfig, nil)
 		assert.Nil(b, err)
 		return fs
 	})

--- a/pkg/fileservice/mem_cache_test.go
+++ b/pkg/fileservice/mem_cache_test.go
@@ -25,7 +25,7 @@ import (
 func TestMemCacheLeak(t *testing.T) {
 	ctx := context.Background()
 
-	fs, err := NewMemoryFS("test")
+	fs, err := NewMemoryFS("test", DisabledCacheConfig, nil)
 	assert.Nil(t, err)
 	err = fs.Write(ctx, IOVector{
 		FilePath: "foo",

--- a/pkg/fileservice/memory_fs_test.go
+++ b/pkg/fileservice/memory_fs_test.go
@@ -24,7 +24,7 @@ func TestMemoryFS(t *testing.T) {
 
 	t.Run("file service", func(t *testing.T) {
 		testFileService(t, func(name string) FileService {
-			fs, err := NewMemoryFS(name)
+			fs, err := NewMemoryFS(name, DisabledCacheConfig, nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -32,7 +32,7 @@ func TestMemoryFS(t *testing.T) {
 
 	t.Run("replaceable file service", func(t *testing.T) {
 		testReplaceableFileService(t, func() ReplaceableFileService {
-			fs, err := NewMemoryFS("memory")
+			fs, err := NewMemoryFS("memory", DisabledCacheConfig, nil)
 			assert.Nil(t, err)
 			return fs
 		})
@@ -42,7 +42,7 @@ func TestMemoryFS(t *testing.T) {
 
 func BenchmarkMemoryFS(b *testing.B) {
 	benchmarkFileService(b, func() FileService {
-		fs, err := NewMemoryFS("memory")
+		fs, err := NewMemoryFS("memory", DisabledCacheConfig, nil)
 		assert.Nil(b, err)
 		return fs
 	})

--- a/pkg/fileservice/profile_test.go
+++ b/pkg/fileservice/profile_test.go
@@ -26,7 +26,7 @@ func TestProfile(t *testing.T) {
 	defer stop()
 	testFileService(t, func(name string) FileService {
 		dir := t.TempDir()
-		fs, err := NewLocalFS(name, dir, -1, -1, "", nil)
+		fs, err := NewLocalFS(name, dir, DisabledCacheConfig, nil)
 		assert.Nil(t, err)
 		return fs
 	})

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -98,9 +98,7 @@ func TestS3FS(t *testing.T) {
 				config.Endpoint,
 				config.Bucket,
 				time.Now().Format("2006-01-02.15:04:05.000000"),
-				-1,
-				-1,
-				"",
+				DisabledCacheConfig,
 				nil,
 				true,
 			)
@@ -118,9 +116,7 @@ func TestS3FS(t *testing.T) {
 			config.Endpoint,
 			config.Bucket,
 			"",
-			-1,
-			-1,
-			"",
+			DisabledCacheConfig,
 			nil,
 			true,
 		)
@@ -144,9 +140,9 @@ func TestS3FS(t *testing.T) {
 				config.Endpoint,
 				config.Bucket,
 				time.Now().Format("2006-01-02.15:04:05.000000"),
-				128*1024,
-				-1,
-				"",
+				CacheConfig{
+					MemoryCapacity: 128 * 1024,
+				},
 				nil,
 				false,
 			)
@@ -163,9 +159,11 @@ func TestS3FS(t *testing.T) {
 				config.Endpoint,
 				config.Bucket,
 				time.Now().Format("2006-01-02.15:04:05.000000"),
-				-1,
-				128*1024,
-				t.TempDir(),
+				CacheConfig{
+					MemoryCapacity: 1,
+					DiskCapacity:   128 * 1024,
+					DiskPath:       t.TempDir(),
+				},
 				nil,
 				false,
 			)
@@ -418,9 +416,9 @@ func TestS3FSMinioServer(t *testing.T) {
 				endpoint,
 				"test",
 				time.Now().Format("2006-01-02.15:04:05.000000"),
-				-1,
-				-1,
-				cacheDir,
+				CacheConfig{
+					DiskPath: cacheDir,
+				},
 				nil,
 				true,
 			)
@@ -455,9 +453,9 @@ func BenchmarkS3FS(b *testing.B) {
 			config.Endpoint,
 			config.Bucket,
 			time.Now().Format("2006-01-02.15:04:05.000000"),
-			-1,
-			-1,
-			cacheDir,
+			CacheConfig{
+				DiskPath: cacheDir,
+			},
 			nil,
 			true,
 		)

--- a/pkg/fileservice/sub_path_test.go
+++ b/pkg/fileservice/sub_path_test.go
@@ -23,7 +23,7 @@ import (
 func TestSubPathFS(t *testing.T) {
 	t.Run("file service", func(t *testing.T) {
 		testFileService(t, func(name string) FileService {
-			upstream, err := NewMemoryFS(name)
+			upstream, err := NewMemoryFS(name, DisabledCacheConfig, nil)
 			assert.Nil(t, err)
 			return SubPath(upstream, "foo")
 		})

--- a/pkg/logservice/testclient.go
+++ b/pkg/logservice/testclient.go
@@ -67,15 +67,15 @@ func NewTestService(fs vfs.FS) (*Service, ClientConfig, error) {
 }
 
 func newFS() *fileservice.FileServices {
-	local, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
+	local, err := fileservice.NewMemoryFS(defines.LocalFileServiceName, fileservice.DisabledCacheConfig, nil)
 	if err != nil {
 		panic(err)
 	}
-	s3, err := fileservice.NewMemoryFS(defines.SharedFileServiceName)
+	s3, err := fileservice.NewMemoryFS(defines.SharedFileServiceName, fileservice.DisabledCacheConfig, nil)
 	if err != nil {
 		panic(err)
 	}
-	etl, err := fileservice.NewMemoryFS(defines.ETLFileServiceName)
+	etl, err := fileservice.NewMemoryFS(defines.ETLFileServiceName, fileservice.DisabledCacheConfig, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/perfcounter/counter_set.go
+++ b/pkg/perfcounter/counter_set.go
@@ -45,14 +45,16 @@ type FileServiceCounterSet struct {
 			Hit  stats.Counter
 		}
 		Disk struct {
-			Read           stats.Counter
-			Hit            stats.Counter
-			GetFileContent stats.Counter
-			SetFileContent stats.Counter
-			OpenFile       stats.Counter
-			StatFile       stats.Counter
-			Error          stats.Counter
-			Evict          stats.Counter
+			Read             stats.Counter
+			Hit              stats.Counter
+			GetFileContent   stats.Counter
+			SetFileContent   stats.Counter
+			OpenFile         stats.Counter
+			StatFile         stats.Counter
+			Error            stats.Counter
+			Evict            stats.Counter
+			EvictPending     stats.Counter
+			EvictImmediately stats.Counter
 		}
 	}
 

--- a/pkg/tests/service/fileservice.go
+++ b/pkg/tests/service/fileservice.go
@@ -46,13 +46,13 @@ func (c *testCluster) buildFileServices() *fileServices {
 	cnServiceNum := c.opt.initial.cnServiceNum
 
 	factory := func(_ string, name string) fileservice.FileService {
-		fs, err := fileservice.NewMemoryFS(name)
+		fs, err := fileservice.NewMemoryFS(name, fileservice.DisabledCacheConfig, nil)
 		require.NoError(c.t, err)
 		return fs
 	}
 	if c.opt.keepData {
 		factory = func(dir string, name string) fileservice.FileService {
-			fs, err := fileservice.NewLocalFS(name, filepath.Join(dir, name), 0, 0, "", nil)
+			fs, err := fileservice.NewLocalFS(name, filepath.Join(dir, name), fileservice.CacheConfig{}, nil)
 			require.NoError(c.t, err)
 			return fs
 		}

--- a/pkg/testutil/util_new.go
+++ b/pkg/testutil/util_new.go
@@ -59,15 +59,15 @@ func NewProcessWithMPool(mp *mpool.MPool) *process.Process {
 var NewProc = NewProcess
 
 func NewFS() *fileservice.FileServices {
-	local, err := fileservice.NewMemoryFS(defines.LocalFileServiceName)
+	local, err := fileservice.NewMemoryFS(defines.LocalFileServiceName, fileservice.DisabledCacheConfig, nil)
 	if err != nil {
 		panic(err)
 	}
-	s3, err := fileservice.NewMemoryFS(defines.SharedFileServiceName)
+	s3, err := fileservice.NewMemoryFS(defines.SharedFileServiceName, fileservice.DisabledCacheConfig, nil)
 	if err != nil {
 		panic(err)
 	}
-	etl, err := fileservice.NewMemoryFS(defines.ETLFileServiceName)
+	etl, err := fileservice.NewMemoryFS(defines.ETLFileServiceName, fileservice.DisabledCacheConfig, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/util/export/etl/csv_test.go
+++ b/pkg/util/export/etl/csv_test.go
@@ -38,7 +38,9 @@ func TestLocalFSWriter(t *testing.T) {
 	t.Logf("whereami: %s, %s", selfDir, basedir)
 
 	require.Equal(t, nil, err)
-	fs, err := fileservice.NewLocalFS("test", path.Join(basedir, "system"), mpool.MB, -1, "", nil)
+	fs, err := fileservice.NewLocalFS("test", path.Join(basedir, "system"), fileservice.CacheConfig{
+		MemoryCapacity: mpool.MB,
+	}, nil)
 	require.Equal(t, nil, err)
 	ctx := context.Background()
 	// csv_test.go:23: whereami: /private/var/folders/lw/05zz3bq12djbnhv1wyzk2jgh0000gn/T/GoLand

--- a/pkg/util/file/file_test.go
+++ b/pkg/util/file/file_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func TestReadAndWriteFile(t *testing.T) {
-	fs, err := fileservice.NewMemoryFS(testPath)
+	fs, err := fileservice.NewMemoryFS(testPath, fileservice.DisabledCacheConfig, nil)
 	assert.NoError(t, err)
 
 	v, err := ReadFile(fs, testFile)


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8842 

## What this PR does / why we need it:
fileservice: add disk cache to MemoryFS

fileservice: ignore symlink error in DiskCache.Update

fileservice: add more disk cache eviction params