### PR TITLE
[Opt] Remove unnecessary PROJECT nodes from plan

### DIFF
--- a/pkg/sql/plan/opt_misc.go
+++ b/pkg/sql/plan/opt_misc.go
@@ -1,0 +1,477 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import "github.com/matrixorigin/matrixone/pkg/pb/plan"
+
+// removeSimpleProjections On top of each subquery or view it has a PROJECT node, which interrupts optimizer rules such as join order.
+func (builder *QueryBuilder) removeSimpleProjections(nodeID int32, parentType plan.Node_NodeType) (int32, map[[2]int32]*plan.Expr) {
+	projMap := make(map[[2]int32]*plan.Expr)
+	node := builder.qry.Nodes[nodeID]
+
+	for i, childID := range node.Children {
+		newChildID, childProjMap := builder.removeSimpleProjections(childID, node.NodeType)
+		node.Children[i] = newChildID
+		for ref, expr := range childProjMap {
+			projMap[ref] = expr
+		}
+	}
+
+	removeProjectionsForExprList(node.ProjectList, projMap)
+	removeProjectionsForExprList(node.OnList, projMap)
+	removeProjectionsForExprList(node.FilterList, projMap)
+	removeProjectionsForExprList(node.GroupBy, projMap)
+	removeProjectionsForExprList(node.GroupingSet, projMap)
+	removeProjectionsForExprList(node.AggList, projMap)
+
+	for i := range node.OrderBy {
+		node.OrderBy[i].Expr = removeProjectionsForExpr(node.OrderBy[i].Expr, projMap)
+	}
+
+	if builder.canRemoveProject(parentType, node) {
+		allColRef := true
+		for _, proj := range node.ProjectList {
+			if _, ok := proj.Expr.(*plan.Expr_Col); !ok {
+				if _, ok := proj.Expr.(*plan.Expr_C); !ok {
+					allColRef = false
+					break
+				}
+			}
+		}
+
+		if allColRef {
+			tag := node.BindingTags[0]
+			for i, proj := range node.ProjectList {
+				projMap[[2]int32{tag, int32(i)}] = proj
+			}
+
+			nodeID = node.Children[0]
+		}
+	}
+
+	return nodeID, projMap
+}
+
+// FIXME: We should remove PROJECT node for more cases, but keep them now to avoid intricate issues.
+func (builder *QueryBuilder) canRemoveProject(parentType plan.Node_NodeType, node *plan.Node) bool {
+	if node.NodeType != plan.Node_PROJECT || node.Limit != nil || node.Offset != nil {
+		return false
+	}
+
+	if parentType == plan.Node_DISTINCT || parentType == plan.Node_UNKNOWN {
+		return false
+	}
+	if parentType == plan.Node_UNION || parentType == plan.Node_UNION_ALL {
+		return false
+	}
+	if parentType == plan.Node_MINUS || parentType == plan.Node_MINUS_ALL {
+		return false
+	}
+	if parentType == plan.Node_INTERSECT || parentType == plan.Node_INTERSECT_ALL {
+		return false
+	}
+	if parentType == plan.Node_FUNCTION_SCAN || parentType == plan.Node_EXTERNAL_FUNCTION {
+		return false
+	}
+
+	childType := builder.qry.Nodes[node.Children[0]].NodeType
+	if childType == plan.Node_VALUE_SCAN || childType == plan.Node_EXTERNAL_SCAN {
+		return false
+	}
+	if childType == plan.Node_FUNCTION_SCAN || childType == plan.Node_EXTERNAL_FUNCTION {
+		return false
+	}
+
+	return true
+}
+
+func removeProjectionsForExprList(exprList []*plan.Expr, projMap map[[2]int32]*plan.Expr) {
+	for i, expr := range exprList {
+		exprList[i] = removeProjectionsForExpr(expr, projMap)
+	}
+}
+
+func removeProjectionsForExpr(expr *plan.Expr, projMap map[[2]int32]*plan.Expr) *plan.Expr {
+	if expr == nil {
+		return nil
+	}
+
+	switch ne := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		mapID := [2]int32{ne.Col.RelPos, ne.Col.ColPos}
+		if projExpr, ok := projMap[mapID]; ok {
+			return DeepCopyExpr(projExpr)
+		}
+
+	case *plan.Expr_F:
+		for i, arg := range ne.F.Args {
+			ne.F.Args[i] = removeProjectionsForExpr(arg, projMap)
+		}
+	}
+
+	return expr
+}
+
+func (builder *QueryBuilder) pushdownFilters(nodeID int32, filters []*plan.Expr, separateNonEquiConds bool) (int32, []*plan.Expr) {
+	node := builder.qry.Nodes[nodeID]
+
+	var canPushdown, cantPushdown []*plan.Expr
+
+	switch node.NodeType {
+	case plan.Node_AGG:
+		groupTag := node.BindingTags[0]
+		aggregateTag := node.BindingTags[1]
+
+		for _, filter := range filters {
+			if !containsTag(filter, aggregateTag) {
+				canPushdown = append(canPushdown, replaceColRefs(filter, groupTag, node.GroupBy))
+			} else {
+				cantPushdown = append(cantPushdown, filter)
+			}
+		}
+
+		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], canPushdown, separateNonEquiConds)
+
+		if len(cantPushdownChild) > 0 {
+			childID = builder.appendNode(&plan.Node{
+				NodeType:   plan.Node_FILTER,
+				Children:   []int32{node.Children[0]},
+				FilterList: cantPushdownChild,
+			}, nil)
+		}
+
+		node.Children[0] = childID
+
+	case plan.Node_FILTER:
+		canPushdown = filters
+		for _, filter := range node.FilterList {
+			canPushdown = append(canPushdown, splitPlanConjunction(applyDistributivity(builder.GetContext(), filter))...)
+		}
+
+		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], canPushdown, separateNonEquiConds)
+
+		if len(cantPushdownChild) > 0 {
+			node.Children[0] = childID
+			node.FilterList = cantPushdownChild
+		} else {
+			nodeID = childID
+		}
+
+	case plan.Node_JOIN:
+		leftTags := make(map[int32]*Binding)
+		for _, tag := range builder.enumerateTags(node.Children[0]) {
+			leftTags[tag] = nil
+		}
+
+		rightTags := make(map[int32]*Binding)
+		for _, tag := range builder.enumerateTags(node.Children[1]) {
+			rightTags[tag] = nil
+		}
+
+		var markTag int32
+		if node.JoinType == plan.Node_MARK {
+			markTag = node.BindingTags[0]
+		}
+
+		if node.JoinType == plan.Node_INNER {
+			for _, cond := range node.OnList {
+				filters = append(filters, splitPlanConjunction(applyDistributivity(builder.GetContext(), cond))...)
+			}
+
+			node.OnList = nil
+		}
+
+		var leftPushdown, rightPushdown []*plan.Expr
+		var turnInner bool
+
+		joinSides := make([]int8, len(filters))
+
+		for i, filter := range filters {
+			canTurnInner := true
+
+			joinSides[i] = getJoinSide(filter, leftTags, rightTags, markTag)
+			if f, ok := filter.Expr.(*plan.Expr_F); ok {
+				for _, arg := range f.F.Args {
+					if getJoinSide(arg, leftTags, rightTags, markTag) == JoinSideBoth {
+						canTurnInner = false
+						break
+					}
+				}
+			}
+
+			canTurnInner = canTurnInner && rejectsNull(filter, builder.compCtx.GetProcess())
+			leftOrRightJoin := (node.JoinType == plan.Node_LEFT && joinSides[i]&JoinSideRight != 0) || (node.JoinType == plan.Node_RIGHT && joinSides[i]&JoinSideLeft != 0)
+			if canTurnInner && leftOrRightJoin {
+				for _, cond := range node.OnList {
+					filters = append(filters, splitPlanConjunction(applyDistributivity(builder.GetContext(), cond))...)
+				}
+
+				node.JoinType = plan.Node_INNER
+				node.OnList = nil
+				turnInner = true
+
+				break
+			}
+
+			// TODO: FULL OUTER join should be handled here. However we don't have FULL OUTER join now.
+		}
+
+		if turnInner {
+			joinSides = make([]int8, len(filters))
+
+			for i, filter := range filters {
+				joinSides[i] = getJoinSide(filter, leftTags, rightTags, markTag)
+			}
+		} else if node.JoinType == plan.Node_LEFT {
+			var newOnList []*plan.Expr
+			for _, cond := range node.OnList {
+				conj := splitPlanConjunction(applyDistributivity(builder.GetContext(), cond))
+				for _, conjElem := range conj {
+					side := getJoinSide(conjElem, leftTags, rightTags, markTag)
+					if side&JoinSideLeft == 0 {
+						rightPushdown = append(rightPushdown, conjElem)
+					} else {
+						newOnList = append(newOnList, conjElem)
+					}
+				}
+			}
+
+			node.OnList = newOnList
+		}
+
+		if !separateNonEquiConds {
+			var extraFilters []*plan.Expr
+			for i, filter := range filters {
+				if joinSides[i] != JoinSideBoth {
+					continue
+				}
+				switch exprImpl := filter.Expr.(type) {
+				case *plan.Expr_F:
+					if exprImpl.F.Func.ObjName == "or" {
+						keys := checkDNF(filter)
+						for _, key := range keys {
+							extraFilter := walkThroughDNF(builder.GetContext(), filter, key)
+							if extraFilter != nil {
+								extraFilters = append(extraFilters, DeepCopyExpr(extraFilter))
+								joinSides = append(joinSides, getJoinSide(extraFilter, leftTags, rightTags, markTag))
+							}
+						}
+					}
+				}
+			}
+			filters = append(filters, extraFilters...)
+		}
+
+		for i, filter := range filters {
+			switch joinSides[i] {
+			case JoinSideNone:
+				if c, ok := filter.Expr.(*plan.Expr_C); ok {
+					if c, ok := c.C.Value.(*plan.Const_Bval); ok {
+						if c.Bval {
+							break
+						}
+					}
+				}
+
+				switch node.JoinType {
+				case plan.Node_INNER:
+					leftPushdown = append(leftPushdown, DeepCopyExpr(filter))
+					rightPushdown = append(rightPushdown, filter)
+
+				case plan.Node_LEFT, plan.Node_SEMI, plan.Node_ANTI, plan.Node_SINGLE, plan.Node_MARK:
+					leftPushdown = append(leftPushdown, filter)
+
+				default:
+					cantPushdown = append(cantPushdown, filter)
+				}
+
+			case JoinSideLeft:
+				if node.JoinType != plan.Node_OUTER && node.JoinType != plan.Node_RIGHT {
+					leftPushdown = append(leftPushdown, filter)
+				} else {
+					cantPushdown = append(cantPushdown, filter)
+				}
+
+			case JoinSideRight:
+				if node.JoinType == plan.Node_INNER || node.JoinType == plan.Node_RIGHT {
+					rightPushdown = append(rightPushdown, filter)
+				} else {
+					cantPushdown = append(cantPushdown, filter)
+				}
+
+			case JoinSideBoth:
+				if node.JoinType == plan.Node_INNER {
+					if separateNonEquiConds {
+						if f, ok := filter.Expr.(*plan.Expr_F); ok {
+							if f.F.Func.ObjName == "=" {
+								if getJoinSide(f.F.Args[0], leftTags, rightTags, markTag) != JoinSideBoth {
+									if getJoinSide(f.F.Args[1], leftTags, rightTags, markTag) != JoinSideBoth {
+										node.OnList = append(node.OnList, filter)
+										break
+									}
+								}
+							}
+						}
+					} else {
+						node.OnList = append(node.OnList, filter)
+						break
+					}
+				}
+
+				cantPushdown = append(cantPushdown, filter)
+
+			case JoinSideMark:
+				if tryMark, ok := filter.Expr.(*plan.Expr_Col); ok {
+					if tryMark.Col.RelPos == node.BindingTags[0] {
+						node.JoinType = plan.Node_SEMI
+						node.BindingTags = nil
+						break
+					}
+				} else if fExpr, ok := filter.Expr.(*plan.Expr_F); ok {
+					if filter.Typ.NotNullable && fExpr.F.Func.ObjName == "not" {
+						arg := fExpr.F.Args[0]
+						if tryMark, ok := arg.Expr.(*plan.Expr_Col); ok {
+							if tryMark.Col.RelPos == node.BindingTags[0] {
+								node.JoinType = plan.Node_ANTI
+								node.BindingTags = nil
+								break
+							}
+						}
+					}
+				}
+
+				cantPushdown = append(cantPushdown, filter)
+
+			default:
+				cantPushdown = append(cantPushdown, filter)
+			}
+		}
+
+		if node.JoinType == plan.Node_INNER {
+			//only inner join can deduce new predicate
+			builder.pushdownFilters(node.Children[0], predsDeduction(rightPushdown, node.OnList), separateNonEquiConds)
+			builder.pushdownFilters(node.Children[1], predsDeduction(leftPushdown, node.OnList), separateNonEquiConds)
+		}
+
+		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], leftPushdown, separateNonEquiConds)
+
+		if len(cantPushdownChild) > 0 {
+			childID = builder.appendNode(&plan.Node{
+				NodeType:   plan.Node_FILTER,
+				Children:   []int32{node.Children[0]},
+				FilterList: cantPushdownChild,
+			}, nil)
+		}
+
+		node.Children[0] = childID
+
+		childID, cantPushdownChild = builder.pushdownFilters(node.Children[1], rightPushdown, separateNonEquiConds)
+
+		if len(cantPushdownChild) > 0 {
+			childID = builder.appendNode(&plan.Node{
+				NodeType:   plan.Node_FILTER,
+				Children:   []int32{node.Children[1]},
+				FilterList: cantPushdownChild,
+			}, nil)
+		}
+
+		node.Children[1] = childID
+
+	case plan.Node_UNION, plan.Node_UNION_ALL, plan.Node_MINUS, plan.Node_MINUS_ALL, plan.Node_INTERSECT, plan.Node_INTERSECT_ALL:
+		leftChild := builder.qry.Nodes[node.Children[0]]
+		rightChild := builder.qry.Nodes[node.Children[1]]
+		var canPushDownRight []*plan.Expr
+
+		for _, filter := range filters {
+			canPushdown = append(canPushdown, replaceColRefsForSet(DeepCopyExpr(filter), leftChild.ProjectList))
+			canPushDownRight = append(canPushDownRight, replaceColRefsForSet(filter, rightChild.ProjectList))
+		}
+
+		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], canPushdown, separateNonEquiConds)
+		if len(cantPushdownChild) > 0 {
+			childID = builder.appendNode(&plan.Node{
+				NodeType:   plan.Node_FILTER,
+				Children:   []int32{node.Children[0]},
+				FilterList: cantPushdownChild,
+			}, nil)
+		}
+		node.Children[0] = childID
+
+		childID, cantPushdownChild = builder.pushdownFilters(node.Children[1], canPushDownRight, separateNonEquiConds)
+		if len(cantPushdownChild) > 0 {
+			childID = builder.appendNode(&plan.Node{
+				NodeType:   plan.Node_FILTER,
+				Children:   []int32{node.Children[1]},
+				FilterList: cantPushdownChild,
+			}, nil)
+		}
+		node.Children[1] = childID
+
+	case plan.Node_PROJECT:
+		child := builder.qry.Nodes[node.Children[0]]
+		if (child.NodeType == plan.Node_VALUE_SCAN || child.NodeType == plan.Node_EXTERNAL_SCAN) && child.RowsetData == nil {
+			cantPushdown = filters
+			break
+		}
+
+		projectTag := node.BindingTags[0]
+
+		for _, filter := range filters {
+			canPushdown = append(canPushdown, replaceColRefs(filter, projectTag, node.ProjectList))
+		}
+
+		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], canPushdown, separateNonEquiConds)
+
+		if len(cantPushdownChild) > 0 {
+			childID = builder.appendNode(&plan.Node{
+				NodeType:   plan.Node_FILTER,
+				Children:   []int32{node.Children[0]},
+				FilterList: cantPushdownChild,
+			}, nil)
+		}
+
+		node.Children[0] = childID
+
+	case plan.Node_TABLE_SCAN, plan.Node_EXTERNAL_SCAN:
+		node.FilterList = append(node.FilterList, filters...)
+	case plan.Node_FUNCTION_SCAN:
+		node.FilterList = append(node.FilterList, filters...)
+		childId := node.Children[0]
+		childId, err := builder.pushdownFilters(childId, nil, separateNonEquiConds)
+		if err != nil {
+			return 0, err
+		}
+		node.Children[0] = childId
+
+	default:
+		if len(node.Children) > 0 {
+			childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], filters, separateNonEquiConds)
+
+			if len(cantPushdownChild) > 0 {
+				childID = builder.appendNode(&plan.Node{
+					NodeType:   plan.Node_FILTER,
+					Children:   []int32{node.Children[0]},
+					FilterList: cantPushdownChild,
+				}, nil)
+			}
+
+			node.Children[0] = childID
+		} else {
+			cantPushdown = filters
+		}
+	}
+
+	return nodeID, cantPushdown
+}

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -58,21 +58,21 @@ func NewQueryBuilder(queryType plan.Query_StatementType, ctx CompilerContext) *Q
 	}
 }
 
-func (builder *QueryBuilder) remapExpr(expr *Expr, colMap map[[2]int32][2]int32) error {
+func (builder *QueryBuilder) remapColRefForExpr(expr *Expr, colMap map[[2]int32][2]int32) error {
 	switch ne := expr.Expr.(type) {
 	case *plan.Expr_Col:
-		mapId := [2]int32{ne.Col.RelPos, ne.Col.ColPos}
-		if ids, ok := colMap[mapId]; ok {
+		mapID := [2]int32{ne.Col.RelPos, ne.Col.ColPos}
+		if ids, ok := colMap[mapID]; ok {
 			ne.Col.RelPos = ids[0]
 			ne.Col.ColPos = ids[1]
-			ne.Col.Name = builder.nameByColRef[mapId]
+			ne.Col.Name = builder.nameByColRef[mapID]
 		} else {
-			return moerr.NewParseError(builder.GetContext(), "can't find column %v in context's map %v", mapId, colMap)
+			return moerr.NewParseError(builder.GetContext(), "can't find column %v in context's map %v", mapID, colMap)
 		}
 
 	case *plan.Expr_F:
 		for _, arg := range ne.F.GetArgs() {
-			err := builder.remapExpr(arg, colMap)
+			err := builder.remapColRefForExpr(arg, colMap)
 			if err != nil {
 				return err
 			}
@@ -139,7 +139,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, colRefCnt map[[2]int3
 
 		for _, expr := range node.FilterList {
 			decreaseRefCnt(expr, colRefCnt)
-			err := builder.remapExpr(expr, internalRemapping.globalToLocal)
+			err := builder.remapColRefForExpr(expr, internalRemapping.globalToLocal)
 			if err != nil {
 				return nil, err
 			}
@@ -195,12 +195,12 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, colRefCnt map[[2]int3
 		}
 
 		if node.NodeType == plan.Node_FUNCTION_SCAN {
-			childId := node.Children[0]
-			childNode := builder.qry.Nodes[childId]
+			childID := node.Children[0]
+			childNode := builder.qry.Nodes[childID]
 			if childNode.NodeType != plan.Node_PROJECT {
 				break
 			}
-			_, err := builder.remapAllColRefs(childId, colRefCnt)
+			_, err := builder.remapAllColRefs(childID, colRefCnt)
 			if err != nil {
 				return nil, err
 			}
@@ -250,7 +250,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, colRefCnt map[[2]int3
 
 		for _, expr := range node.ProjectList {
 			decreaseRefCnt(expr, colRefCnt)
-			err := builder.remapExpr(expr, internalMap)
+			err := builder.remapColRefForExpr(expr, internalMap)
 			if err != nil {
 				return nil, err
 			}
@@ -285,7 +285,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, colRefCnt map[[2]int3
 
 		for _, expr := range node.OnList {
 			decreaseRefCnt(expr, colRefCnt)
-			err := builder.remapExpr(expr, internalMap)
+			err := builder.remapColRefForExpr(expr, internalMap)
 			if err != nil {
 				return nil, err
 			}
@@ -385,7 +385,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, colRefCnt map[[2]int3
 
 		for idx, expr := range node.GroupBy {
 			decreaseRefCnt(expr, colRefCnt)
-			err := builder.remapExpr(expr, childRemapping.globalToLocal)
+			err := builder.remapColRefForExpr(expr, childRemapping.globalToLocal)
 			if err != nil {
 				return nil, err
 			}
@@ -412,7 +412,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, colRefCnt map[[2]int3
 		groupSize := int32(len(node.GroupBy))
 		for idx, expr := range node.AggList {
 			decreaseRefCnt(expr, colRefCnt)
-			err := builder.remapExpr(expr, childRemapping.globalToLocal)
+			err := builder.remapColRefForExpr(expr, childRemapping.globalToLocal)
 			if err != nil {
 				return nil, err
 			}
@@ -480,7 +480,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, colRefCnt map[[2]int3
 
 		for _, orderBy := range node.OrderBy {
 			decreaseRefCnt(orderBy.Expr, colRefCnt)
-			err := builder.remapExpr(orderBy.Expr, childRemapping.globalToLocal)
+			err := builder.remapColRefForExpr(orderBy.Expr, childRemapping.globalToLocal)
 			if err != nil {
 				return nil, err
 			}
@@ -534,7 +534,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, colRefCnt map[[2]int3
 
 		for _, expr := range node.FilterList {
 			decreaseRefCnt(expr, colRefCnt)
-			err := builder.remapExpr(expr, childRemapping.globalToLocal)
+			err := builder.remapColRefForExpr(expr, childRemapping.globalToLocal)
 			if err != nil {
 				return nil, err
 			}
@@ -605,7 +605,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, colRefCnt map[[2]int3
 		for _, needed := range neededProj {
 			expr := node.ProjectList[needed]
 			decreaseRefCnt(expr, colRefCnt)
-			err := builder.remapExpr(expr, childRemapping.globalToLocal)
+			err := builder.remapColRefForExpr(expr, childRemapping.globalToLocal)
 			if err != nil {
 				return nil, err
 			}
@@ -705,27 +705,28 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, colRefCnt map[[2]int3
 }
 
 func (builder *QueryBuilder) createQuery() (*Query, error) {
-	for i, rootId := range builder.qry.Steps {
-		rootId, _ = builder.pushdownFilters(rootId, nil, false)
-		ReCalcNodeStats(rootId, builder, true, true)
-		rootId = builder.aggPushDown(rootId)
-		ReCalcNodeStats(rootId, builder, true, false)
-		rootId = builder.determineJoinOrder(rootId)
-		ReCalcNodeStats(rootId, builder, true, false)
-		rootId = builder.pushdownSemiAntiJoins(rootId)
-		ReCalcNodeStats(rootId, builder, true, false)
-		rootId = builder.applySwapRuleByStats(rootId, true)
-		SortFilterListByStats(builder.GetContext(), rootId, builder)
-		builder.qry.Steps[i] = rootId
+	for i, rootID := range builder.qry.Steps {
+		builder.removeSimpleProjections(rootID, plan.Node_UNKNOWN)
+		rootID, _ = builder.pushdownFilters(rootID, nil, false)
+		ReCalcNodeStats(rootID, builder, true, true)
+		rootID = builder.aggPushDown(rootID)
+		ReCalcNodeStats(rootID, builder, true, false)
+		rootID = builder.determineJoinOrder(rootID)
+		ReCalcNodeStats(rootID, builder, true, false)
+		rootID = builder.pushdownSemiAntiJoins(rootID)
+		ReCalcNodeStats(rootID, builder, true, false)
+		rootID = builder.applySwapRuleByStats(rootID, true)
+		SortFilterListByStats(builder.GetContext(), rootID, builder)
+		builder.qry.Steps[i] = rootID
 
 		colRefCnt := make(map[[2]int32]int)
-		rootNode := builder.qry.Nodes[rootId]
+		rootNode := builder.qry.Nodes[rootID]
 		resultTag := rootNode.BindingTags[0]
 		for i := range rootNode.ProjectList {
 			colRefCnt[[2]int32{resultTag, int32(i)}] = 1
 		}
 
-		_, err := builder.remapAllColRefs(rootId, colRefCnt)
+		_, err := builder.remapAllColRefs(rootID, colRefCnt)
 		if err != nil {
 			return nil, err
 		}
@@ -924,15 +925,15 @@ func (builder *QueryBuilder) buildUnion(stmt *tree.UnionClause, astOrderBy tree.
 	}
 
 	// build UNION/MINUS node one by one
-	lastNodeId := newNodes[0]
+	lastNodeID := newNodes[0]
 	for i := 1; i < len(newNodes); i++ {
 		utIdx := i - 1
 		lastTag = builder.genNewTag()
-		leftNodeTag := builder.qry.Nodes[lastNodeId].BindingTags[0]
+		leftNodeTag := builder.qry.Nodes[lastNodeID].BindingTags[0]
 
-		lastNodeId = builder.appendNode(&plan.Node{
+		lastNodeID = builder.appendNode(&plan.Node{
 			NodeType:    newUnionType[utIdx],
-			Children:    []int32{lastNodeId, newNodes[i]},
+			Children:    []int32{lastNodeID, newNodes[i]},
 			BindingTags: []int32{lastTag},
 			ProjectList: getProjectList(leftNodeTag, lastTag),
 		}, ctx)
@@ -961,10 +962,10 @@ func (builder *QueryBuilder) buildUnion(stmt *tree.UnionClause, astOrderBy tree.
 	projectionBinder := NewProjectionBinder(builder, ctx, havingBinder)
 
 	// append a project node
-	lastNodeId = builder.appendNode(&plan.Node{
+	lastNodeID = builder.appendNode(&plan.Node{
 		NodeType:    plan.Node_PROJECT,
 		ProjectList: ctx.projects,
-		Children:    []int32{lastNodeId},
+		Children:    []int32{lastNodeID},
 		BindingTags: []int32{ctx.projectTag},
 	}, ctx)
 
@@ -1001,16 +1002,16 @@ func (builder *QueryBuilder) buildUnion(stmt *tree.UnionClause, astOrderBy tree.
 			orderBys = append(orderBys, orderBy)
 		}
 
-		lastNodeId = builder.appendNode(&plan.Node{
+		lastNodeID = builder.appendNode(&plan.Node{
 			NodeType: plan.Node_SORT,
-			Children: []int32{lastNodeId},
+			Children: []int32{lastNodeID},
 			OrderBy:  orderBys,
 		}, ctx)
 	}
 
 	// append limit
 	if astLimit != nil {
-		node := builder.qry.Nodes[lastNodeId]
+		node := builder.qry.Nodes[lastNodeID]
 
 		limitBinder := NewLimitBinder(builder, ctx)
 		if astLimit.Offset != nil {
@@ -1034,7 +1035,7 @@ func (builder *QueryBuilder) buildUnion(stmt *tree.UnionClause, astOrderBy tree.
 	}
 
 	// append result PROJECT node
-	if builder.qry.Nodes[lastNodeId].NodeType != plan.Node_PROJECT {
+	if builder.qry.Nodes[lastNodeID].NodeType != plan.Node_PROJECT {
 		for i := 0; i < len(ctx.projects); i++ {
 			ctx.results = append(ctx.results, &plan.Expr{
 				Typ: ctx.projects[i].Typ,
@@ -1048,10 +1049,10 @@ func (builder *QueryBuilder) buildUnion(stmt *tree.UnionClause, astOrderBy tree.
 		}
 		ctx.resultTag = builder.genNewTag()
 
-		lastNodeId = builder.appendNode(&plan.Node{
+		lastNodeID = builder.appendNode(&plan.Node{
 			NodeType:    plan.Node_PROJECT,
 			ProjectList: ctx.results,
-			Children:    []int32{lastNodeId},
+			Children:    []int32{lastNodeID},
 			BindingTags: []int32{ctx.resultTag},
 		}, ctx)
 	} else {
@@ -1063,7 +1064,7 @@ func (builder *QueryBuilder) buildUnion(stmt *tree.UnionClause, astOrderBy tree.
 		builder.qry.Headings = append(builder.qry.Headings, ctx.headings...)
 	}
 
-	return lastNodeId, nil
+	return lastNodeID, nil
 }
 
 func (builder *QueryBuilder) buildSelect(stmt *tree.Select, ctx *BindContext, isRoot bool) (int32, error) {
@@ -1898,15 +1899,15 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext) (
 		if midNode.NodeType == plan.Node_TABLE_SCAN {
 			dbName := midNode.ObjRef.SchemaName
 			tableName := midNode.TableDef.Name
-			currentAccountId := builder.compCtx.GetAccountId()
+			currentAccountID := builder.compCtx.GetAccountId()
 			if sub := builder.compCtx.GetQueryingSubscription(); sub != nil {
-				currentAccountId = uint32(sub.AccountId)
+				currentAccountID = uint32(sub.AccountId)
 				builder.qry.Nodes[nodeID].NotCacheable = true
 			}
-			if currentAccountId != catalog.System_Account {
+			if currentAccountID != catalog.System_Account {
 				// add account filter for system table scan
 				if dbName == catalog.MO_CATALOG && tableName == catalog.MO_DATABASE {
-					modatabaseFilter := util.BuildMoDataBaseFilter(uint64(currentAccountId))
+					modatabaseFilter := util.BuildMoDataBaseFilter(uint64(currentAccountID))
 					ctx.binder = NewWhereBinder(builder, ctx)
 					accountFilterExprs, err := splitAndBindCondition(modatabaseFilter, ctx)
 					if err != nil {
@@ -1914,7 +1915,7 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext) (
 					}
 					builder.qry.Nodes[nodeID].FilterList = accountFilterExprs
 				} else if dbName == catalog.MO_CATALOG && tableName == catalog.MO_TABLES {
-					motablesFilter := util.BuildMoTablesFilter(uint64(currentAccountId))
+					motablesFilter := util.BuildMoTablesFilter(uint64(currentAccountID))
 					ctx.binder = NewWhereBinder(builder, ctx)
 					accountFilterExprs, err := splitAndBindCondition(motablesFilter, ctx)
 					if err != nil {
@@ -1922,7 +1923,7 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext) (
 					}
 					builder.qry.Nodes[nodeID].FilterList = accountFilterExprs
 				} else if dbName == catalog.MO_CATALOG && tableName == catalog.MO_COLUMNS {
-					moColumnsFilter := util.BuildMoColumnsFilter(uint64(currentAccountId))
+					moColumnsFilter := util.BuildMoColumnsFilter(uint64(currentAccountID))
 					ctx.binder = NewWhereBinder(builder, ctx)
 					accountFilterExprs, err := splitAndBindCondition(moColumnsFilter, ctx)
 					if err != nil {
@@ -1935,8 +1936,8 @@ func (builder *QueryBuilder) buildTable(stmt tree.TableExpr, ctx *BindContext) (
 						NumParts: 1,
 						Parts:    tree.NameParts{util.GetClusterTableAttributeName()},
 					}
-					currentAccountId := builder.compCtx.GetAccountId()
-					right := tree.NewNumVal(constant.MakeUint64(uint64(currentAccountId)), strconv.Itoa(int(currentAccountId)), false)
+					currentAccountID := builder.compCtx.GetAccountId()
+					right := tree.NewNumVal(constant.MakeUint64(uint64(currentAccountID)), strconv.Itoa(int(currentAccountID)), false)
 					right.ValType = tree.P_uint64
 					//account_id = the accountId of the non-sys account
 					accountFilter := &tree.ComparisonExpr{
@@ -2176,358 +2177,6 @@ func (builder *QueryBuilder) buildJoinTable(tbl *tree.JoinTableExpr, ctx *BindCo
 	}
 
 	return nodeID, nil
-}
-
-func (builder *QueryBuilder) pushdownFilters(nodeID int32, filters []*plan.Expr, separateNonEquiConds bool) (int32, []*plan.Expr) {
-	node := builder.qry.Nodes[nodeID]
-
-	var canPushdown, cantPushdown []*plan.Expr
-
-	switch node.NodeType {
-	case plan.Node_AGG:
-		groupTag := node.BindingTags[0]
-		aggregateTag := node.BindingTags[1]
-
-		for _, filter := range filters {
-			if !containsTag(filter, aggregateTag) {
-				canPushdown = append(canPushdown, replaceColRefs(filter, groupTag, node.GroupBy))
-			} else {
-				cantPushdown = append(cantPushdown, filter)
-			}
-		}
-
-		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], canPushdown, separateNonEquiConds)
-
-		if len(cantPushdownChild) > 0 {
-			childID = builder.appendNode(&plan.Node{
-				NodeType:   plan.Node_FILTER,
-				Children:   []int32{node.Children[0]},
-				FilterList: cantPushdownChild,
-			}, nil)
-		}
-
-		node.Children[0] = childID
-
-	case plan.Node_FILTER:
-		canPushdown = filters
-		for _, filter := range node.FilterList {
-			canPushdown = append(canPushdown, splitPlanConjunction(applyDistributivity(builder.GetContext(), filter))...)
-		}
-
-		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], canPushdown, separateNonEquiConds)
-
-		if len(cantPushdownChild) > 0 {
-			node.Children[0] = childID
-			node.FilterList = cantPushdownChild
-		} else {
-			nodeID = childID
-		}
-
-	case plan.Node_JOIN:
-		leftTags := make(map[int32]*Binding)
-		for _, tag := range builder.enumerateTags(node.Children[0]) {
-			leftTags[tag] = nil
-		}
-
-		rightTags := make(map[int32]*Binding)
-		for _, tag := range builder.enumerateTags(node.Children[1]) {
-			rightTags[tag] = nil
-		}
-
-		var markTag int32
-		if node.JoinType == plan.Node_MARK {
-			markTag = node.BindingTags[0]
-		}
-
-		if node.JoinType == plan.Node_INNER {
-			for _, cond := range node.OnList {
-				filters = append(filters, splitPlanConjunction(applyDistributivity(builder.GetContext(), cond))...)
-			}
-
-			node.OnList = nil
-		}
-
-		var leftPushdown, rightPushdown []*plan.Expr
-		var turnInner bool
-
-		joinSides := make([]int8, len(filters))
-
-		for i, filter := range filters {
-			canTurnInner := true
-
-			joinSides[i] = getJoinSide(filter, leftTags, rightTags, markTag)
-			if f, ok := filter.Expr.(*plan.Expr_F); ok {
-				for _, arg := range f.F.Args {
-					if getJoinSide(arg, leftTags, rightTags, markTag) == JoinSideBoth {
-						canTurnInner = false
-						break
-					}
-				}
-			}
-
-			canTurnInner = canTurnInner && rejectsNull(filter, builder.compCtx.GetProcess())
-			leftOrRightJoin := (node.JoinType == plan.Node_LEFT && joinSides[i]&JoinSideRight != 0) || (node.JoinType == plan.Node_RIGHT && joinSides[i]&JoinSideLeft != 0)
-			if canTurnInner && leftOrRightJoin {
-				for _, cond := range node.OnList {
-					filters = append(filters, splitPlanConjunction(applyDistributivity(builder.GetContext(), cond))...)
-				}
-
-				node.JoinType = plan.Node_INNER
-				node.OnList = nil
-				turnInner = true
-
-				break
-			}
-
-			// TODO: FULL OUTER join should be handled here. However we don't have FULL OUTER join now.
-		}
-
-		if turnInner {
-			joinSides = make([]int8, len(filters))
-
-			for i, filter := range filters {
-				joinSides[i] = getJoinSide(filter, leftTags, rightTags, markTag)
-			}
-		} else if node.JoinType == plan.Node_LEFT {
-			var newOnList []*plan.Expr
-			for _, cond := range node.OnList {
-				conj := splitPlanConjunction(applyDistributivity(builder.GetContext(), cond))
-				for _, conjElem := range conj {
-					side := getJoinSide(conjElem, leftTags, rightTags, markTag)
-					if side&JoinSideLeft == 0 {
-						rightPushdown = append(rightPushdown, conjElem)
-					} else {
-						newOnList = append(newOnList, conjElem)
-					}
-				}
-			}
-
-			node.OnList = newOnList
-		}
-
-		if !separateNonEquiConds {
-			var extraFilters []*plan.Expr
-			for i, filter := range filters {
-				if joinSides[i] != JoinSideBoth {
-					continue
-				}
-				switch exprImpl := filter.Expr.(type) {
-				case *plan.Expr_F:
-					if exprImpl.F.Func.ObjName == "or" {
-						keys := checkDNF(filter)
-						for _, key := range keys {
-							extraFilter := walkThroughDNF(builder.GetContext(), filter, key)
-							if extraFilter != nil {
-								extraFilters = append(extraFilters, DeepCopyExpr(extraFilter))
-								joinSides = append(joinSides, getJoinSide(extraFilter, leftTags, rightTags, markTag))
-							}
-						}
-					}
-				}
-			}
-			filters = append(filters, extraFilters...)
-		}
-
-		for i, filter := range filters {
-			switch joinSides[i] {
-			case JoinSideNone:
-				if c, ok := filter.Expr.(*plan.Expr_C); ok {
-					if c, ok := c.C.Value.(*plan.Const_Bval); ok {
-						if c.Bval {
-							break
-						}
-					}
-				}
-
-				switch node.JoinType {
-				case plan.Node_INNER:
-					leftPushdown = append(leftPushdown, DeepCopyExpr(filter))
-					rightPushdown = append(rightPushdown, filter)
-
-				case plan.Node_LEFT, plan.Node_SEMI, plan.Node_ANTI, plan.Node_SINGLE, plan.Node_MARK:
-					leftPushdown = append(leftPushdown, filter)
-
-				default:
-					cantPushdown = append(cantPushdown, filter)
-				}
-
-			case JoinSideLeft:
-				if node.JoinType != plan.Node_OUTER && node.JoinType != plan.Node_RIGHT {
-					leftPushdown = append(leftPushdown, filter)
-				} else {
-					cantPushdown = append(cantPushdown, filter)
-				}
-
-			case JoinSideRight:
-				if node.JoinType == plan.Node_INNER || node.JoinType == plan.Node_RIGHT {
-					rightPushdown = append(rightPushdown, filter)
-				} else {
-					cantPushdown = append(cantPushdown, filter)
-				}
-
-			case JoinSideBoth:
-				if node.JoinType == plan.Node_INNER {
-					if separateNonEquiConds {
-						if f, ok := filter.Expr.(*plan.Expr_F); ok {
-							if f.F.Func.ObjName == "=" {
-								if getJoinSide(f.F.Args[0], leftTags, rightTags, markTag) != JoinSideBoth {
-									if getJoinSide(f.F.Args[1], leftTags, rightTags, markTag) != JoinSideBoth {
-										node.OnList = append(node.OnList, filter)
-										break
-									}
-								}
-							}
-						}
-					} else {
-						node.OnList = append(node.OnList, filter)
-						break
-					}
-				}
-
-				cantPushdown = append(cantPushdown, filter)
-
-			case JoinSideMark:
-				if tryMark, ok := filter.Expr.(*plan.Expr_Col); ok {
-					if tryMark.Col.RelPos == node.BindingTags[0] {
-						node.JoinType = plan.Node_SEMI
-						node.BindingTags = nil
-						break
-					}
-				} else if fExpr, ok := filter.Expr.(*plan.Expr_F); ok {
-					if filter.Typ.NotNullable && fExpr.F.Func.ObjName == "not" {
-						arg := fExpr.F.Args[0]
-						if tryMark, ok := arg.Expr.(*plan.Expr_Col); ok {
-							if tryMark.Col.RelPos == node.BindingTags[0] {
-								node.JoinType = plan.Node_ANTI
-								node.BindingTags = nil
-								break
-							}
-						}
-					}
-				}
-
-				cantPushdown = append(cantPushdown, filter)
-
-			default:
-				cantPushdown = append(cantPushdown, filter)
-			}
-		}
-
-		if node.JoinType == plan.Node_INNER {
-			//only inner join can deduce new predicate
-			builder.pushdownFilters(node.Children[0], predsDeduction(rightPushdown, node.OnList), separateNonEquiConds)
-			builder.pushdownFilters(node.Children[1], predsDeduction(leftPushdown, node.OnList), separateNonEquiConds)
-		}
-
-		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], leftPushdown, separateNonEquiConds)
-
-		if len(cantPushdownChild) > 0 {
-			childID = builder.appendNode(&plan.Node{
-				NodeType:   plan.Node_FILTER,
-				Children:   []int32{node.Children[0]},
-				FilterList: cantPushdownChild,
-			}, nil)
-		}
-
-		node.Children[0] = childID
-
-		childID, cantPushdownChild = builder.pushdownFilters(node.Children[1], rightPushdown, separateNonEquiConds)
-
-		if len(cantPushdownChild) > 0 {
-			childID = builder.appendNode(&plan.Node{
-				NodeType:   plan.Node_FILTER,
-				Children:   []int32{node.Children[1]},
-				FilterList: cantPushdownChild,
-			}, nil)
-		}
-
-		node.Children[1] = childID
-
-	case plan.Node_UNION, plan.Node_UNION_ALL, plan.Node_MINUS, plan.Node_MINUS_ALL, plan.Node_INTERSECT, plan.Node_INTERSECT_ALL:
-		leftChild := builder.qry.Nodes[node.Children[0]]
-		rightChild := builder.qry.Nodes[node.Children[1]]
-		var canPushDownRight []*plan.Expr
-
-		for _, filter := range filters {
-			canPushdown = append(canPushdown, replaceColRefsForSet(DeepCopyExpr(filter), leftChild.ProjectList))
-			canPushDownRight = append(canPushDownRight, replaceColRefsForSet(filter, rightChild.ProjectList))
-		}
-
-		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], canPushdown, separateNonEquiConds)
-		if len(cantPushdownChild) > 0 {
-			childID = builder.appendNode(&plan.Node{
-				NodeType:   plan.Node_FILTER,
-				Children:   []int32{node.Children[0]},
-				FilterList: cantPushdownChild,
-			}, nil)
-		}
-		node.Children[0] = childID
-
-		childID, cantPushdownChild = builder.pushdownFilters(node.Children[1], canPushDownRight, separateNonEquiConds)
-		if len(cantPushdownChild) > 0 {
-			childID = builder.appendNode(&plan.Node{
-				NodeType:   plan.Node_FILTER,
-				Children:   []int32{node.Children[1]},
-				FilterList: cantPushdownChild,
-			}, nil)
-		}
-		node.Children[1] = childID
-
-	case plan.Node_PROJECT:
-		child := builder.qry.Nodes[node.Children[0]]
-		if (child.NodeType == plan.Node_VALUE_SCAN || child.NodeType == plan.Node_EXTERNAL_SCAN) && child.RowsetData == nil {
-			cantPushdown = filters
-			break
-		}
-
-		projectTag := node.BindingTags[0]
-
-		for _, filter := range filters {
-			canPushdown = append(canPushdown, replaceColRefs(filter, projectTag, node.ProjectList))
-		}
-
-		childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], canPushdown, separateNonEquiConds)
-
-		if len(cantPushdownChild) > 0 {
-			childID = builder.appendNode(&plan.Node{
-				NodeType:   plan.Node_FILTER,
-				Children:   []int32{node.Children[0]},
-				FilterList: cantPushdownChild,
-			}, nil)
-		}
-
-		node.Children[0] = childID
-
-	case plan.Node_TABLE_SCAN, plan.Node_EXTERNAL_SCAN:
-		node.FilterList = append(node.FilterList, filters...)
-	case plan.Node_FUNCTION_SCAN:
-		node.FilterList = append(node.FilterList, filters...)
-		childId := node.Children[0]
-		childId, err := builder.pushdownFilters(childId, nil, separateNonEquiConds)
-		if err != nil {
-			return 0, err
-		}
-		node.Children[0] = childId
-
-	default:
-		if len(node.Children) > 0 {
-			childID, cantPushdownChild := builder.pushdownFilters(node.Children[0], filters, separateNonEquiConds)
-
-			if len(cantPushdownChild) > 0 {
-				childID = builder.appendNode(&plan.Node{
-					NodeType:   plan.Node_FILTER,
-					Children:   []int32{node.Children[0]},
-					FilterList: cantPushdownChild,
-				}, nil)
-			}
-
-			node.Children[0] = childID
-		} else {
-			cantPushdown = filters
-		}
-	}
-
-	return nodeID, cantPushdown
 }
 
 func (builder *QueryBuilder) buildTableFunction(tbl *tree.TableFunction, ctx *BindContext) (int32, error) {


### PR DESCRIPTION
On top of each subquery or view, there is a PROJECT node. It's unnecessary and will interfere various optimizer rules, such as join order and aggregate push-down/pull-up. This commit removes most of that kind of PROJECT node, but some are retained to avoid intricate issues.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: