### PR TITLE
do not go cross join for non equal conds

### DIFF
--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -152,8 +152,8 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 			Typs:   t.Typs,
 		}
 	case vm.LoopJoin:
-		t := sourceIns.Arg.(*loopanti.Argument)
-		res.Arg = &loopanti.Argument{
+		t := sourceIns.Arg.(*loopjoin.Argument)
+		res.Arg = &loopjoin.Argument{
 			Result: t.Result,
 			Cond:   t.Cond,
 			Typs:   t.Typs,


### PR DESCRIPTION
…ry poor

in this situation, we put the non equal conds in the onlist and go loop join

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # mocloud512

## What this PR does / why we need it:
when onlist is empty, it will be a cross join, performance will be very poor in this situation
we put the non equal conds in the onlist and go loop join