### PR TITLE
fileservice: use one file per IOEntry in disk cache

### DIFF
--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -28,6 +28,8 @@ type CacheConfig struct {
 	DiskCapacity         toml.ByteSize `toml:"disk-capacity"`
 	DiskMinEvictInterval toml.Duration `toml:"disk-min-evict-interval"`
 	DiskEvictTarget      float64       `toml:"disk-evict-target"`
+
+	enableDiskCacheForLocalFS bool // for testing only
 }
 
 func (c *CacheConfig) SetDefaults() {

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -134,22 +134,25 @@ func (l *LocalFS) initCaches(config CacheConfig) error {
 		)
 	}
 
-	//if diskCacheCapacity > DisableCacheCapacity && diskCachePath != "" {
-	//	var err error
-	//	l.diskCache, err = NewDiskCache(
-	//		diskCachePath,
-	//		diskCacheCapacity,
-	//		l.perfCounterSets,
-	//	)
-	//	if err != nil {
-	//		return err
-	//	}
-	//	logutil.Info("fileservice: disk cache initialized",
-	//		zap.Any("fs-name", l.name),
-	//		zap.Any("capacity", diskCacheCapacity),
-	//		zap.Any("path", diskCachePath),
-	//	)
-	//}
+	if config.enableDiskCacheForLocalFS {
+		if config.DiskCapacity > DisableCacheCapacity && config.DiskPath != "" {
+			var err error
+			l.diskCache, err = NewDiskCache(
+				config.DiskPath,
+				int64(config.DiskCapacity),
+				config.DiskMinEvictInterval.Duration,
+				config.DiskEvictTarget,
+				l.perfCounterSets,
+			)
+			if err != nil {
+				return err
+			}
+			logutil.Info("fileservice: disk cache initialized",
+				zap.Any("fs-name", l.name),
+				zap.Any("config", config),
+			)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8866 

## What this PR does / why we need it:
fileservice: add LocalFS with disk cache tests

fileservice: fix DiskCache.Read

fileservice: add IOEntry.ReadFromOSFile
