### PR TITLE
fix issue 8741 that connector operator early free the vector before dup and cause crash finally

### DIFF
--- a/pkg/container/batch/batch.go
+++ b/pkg/container/batch/batch.go
@@ -327,3 +327,11 @@ func (bat *Batch) AddCnt(cnt int) {
 func (bat *Batch) SubCnt(cnt int) {
 	atomic.StoreInt64(&bat.Cnt, bat.Cnt-int64(cnt))
 }
+
+func (bat *Batch) ReplaceVector(oldVec *vector.Vector, newVec *vector.Vector) {
+	for i, vec := range bat.Vecs {
+		if vec == oldVec {
+			bat.SetVector(int32(i), newVec)
+		}
+	}
+}

--- a/pkg/container/batch/batch_test.go
+++ b/pkg/container/batch/batch_test.go
@@ -56,6 +56,24 @@ func TestBatch(t *testing.T) {
 	}
 }
 
+func TestBatch_ReplaceVector(t *testing.T) {
+	v1, v2, v3 := &vector.Vector{}, &vector.Vector{}, &vector.Vector{}
+	bat := &Batch{
+		Vecs: []*vector.Vector{
+			v1,
+			v1,
+			v1,
+			v2,
+			v2,
+		},
+	}
+	bat.ReplaceVector(bat.Vecs[0], v3)
+	require.Equal(t, v3, bat.Vecs[0])
+	require.Equal(t, v3, bat.Vecs[1])
+	require.Equal(t, v3, bat.Vecs[2])
+	require.Equal(t, v2, bat.Vecs[3])
+}
+
 func newTestCase(ts []types.Type) batchTestCase {
 	return batchTestCase{
 		types: ts,

--- a/pkg/frontend/export.go
+++ b/pkg/frontend/export.go
@@ -371,6 +371,7 @@ func preCopyBat(obj interface{}, bat *batch.Batch) *batch.Batch {
 	ses := obj.(*Session)
 	bat2 := &batch.Batch{}
 	for _, vec := range bat.Vecs {
+		// XXX should we free the old vec here ?
 		tmp, _ := vec.Dup(ses.GetMemPool())
 		bat2.Vecs = append(bat2.Vecs, tmp)
 	}

--- a/pkg/sql/colexec/connector/connector.go
+++ b/pkg/sql/colexec/connector/connector.go
@@ -16,7 +16,6 @@ package connector
 
 import (
 	"bytes"
-
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -42,12 +41,13 @@ func Call(_ int, proc *process.Process, arg any, _ bool, _ bool) (bool, error) {
 	// do not send the source batch to remote node.
 	for i := range bat.Vecs {
 		if bat.Vecs[i].NeedDup() {
-			vec, err := bat.Vecs[i].Dup(proc.Mp())
+			oldVec := bat.Vecs[i]
+			vec, err := oldVec.Dup(proc.Mp())
 			if err != nil {
 				return false, err
 			}
-			bat.Vecs[i].Free(proc.Mp())
-			bat.Vecs[i] = vec
+			bat.ReplaceVector(oldVec, vec)
+			oldVec.Free(proc.Mp())
 		}
 	}
 

--- a/pkg/sql/colexec/constraint_util.go
+++ b/pkg/sql/colexec/constraint_util.go
@@ -368,6 +368,7 @@ func GetUpdateBatch(proc *process.Process, bat *batch.Batch, idxList []int32, ba
 			}
 		} else {
 			if rowSkip == nil {
+				// XXX should we free the fromVec here ?
 				toVec, err = fromVec.Dup(proc.Mp())
 				if err != nil {
 					return nil, err
@@ -376,7 +377,10 @@ func GetUpdateBatch(proc *process.Process, bat *batch.Batch, idxList []int32, ba
 				toVec = vector.NewVec(*fromVec.GetType())
 				for j := 0; j < fromVec.Length(); j++ {
 					if !rowSkip[j] {
-						toVec.UnionOne(fromVec, int64(j), proc.Mp())
+						err = toVec.UnionOne(fromVec, int64(j), proc.Mp())
+						if err != nil {
+							return nil, err
+						}
 					}
 				}
 			}

--- a/pkg/sql/colexec/dispatch/dispatch.go
+++ b/pkg/sql/colexec/dispatch/dispatch.go
@@ -102,14 +102,16 @@ func Call(idx int, proc *process.Process, arg any, isFirst bool, isLast bool) (b
 		return false, nil
 	}
 
-	for i, vec := range bat.Vecs {
-		if vec.NeedDup() {
-			cloneVec, err := vec.Dup(proc.Mp())
+	for i := range bat.Vecs {
+		if bat.Vecs[i].NeedDup() {
+			oldVec := bat.Vecs[i]
+			cloneVec, err := bat.Vecs[i].Dup(proc.Mp())
 			if err != nil {
 				bat.Clean(proc.Mp())
 				return false, err
 			}
-			bat.Vecs[i] = cloneVec
+			bat.ReplaceVector(oldVec, cloneVec)
+			oldVec.Free(proc.Mp())
 		}
 	}
 

--- a/pkg/sql/colexec/order/order.go
+++ b/pkg/sql/colexec/order/order.go
@@ -86,12 +86,13 @@ func (ctr *container) process(ap *Argument, bat *batch.Batch, proc *process.Proc
 	for i := 0; i < bat.VectorCount(); i++ {
 		vec := bat.GetVector(int32(i))
 		if vec.NeedDup() {
-			nvec, err := bat.Vecs[i].Dup(proc.Mp())
+			oldVec := bat.Vecs[i]
+			nvec, err := oldVec.Dup(proc.Mp())
 			if err != nil {
 				return false, err
 			}
-			bat.SetVector(int32(i), nvec)
-
+			bat.ReplaceVector(oldVec, nvec)
+			oldVec.Free(proc.Mp())
 		}
 	}
 

--- a/pkg/sql/colexec/projection/projection.go
+++ b/pkg/sql/colexec/projection/projection.go
@@ -16,7 +16,6 @@ package projection
 
 import (
 	"bytes"
-
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"

--- a/pkg/sql/colexec/table_function/meta_scan.go
+++ b/pkg/sql/colexec/table_function/meta_scan.go
@@ -83,6 +83,8 @@ func metaScanCall(_ int, proc *process.Process, arg *Argument) (bool, error) {
 			if err != nil {
 				return false, err
 			}
+			bats[0].ReplaceVector(vec, metaVecs[i])
+			vec.Free(proc.Mp())
 		} else {
 			metaVecs[i] = vec
 		}

--- a/pkg/sql/compile/scopeRemoteRun.go
+++ b/pkg/sql/compile/scopeRemoteRun.go
@@ -1357,13 +1357,15 @@ func decodeBatch(mp *mpool.MPool, data []byte) (*batch.Batch, error) {
 	err := types.Decode(data, bat)
 	// allocated memory of vec from mPool.
 	for i := range bat.Vecs {
-		bat.Vecs[i], err = bat.Vecs[i].Dup(mp)
-		if err != nil {
+		oldVec := bat.Vecs[i]
+		vec, err1 := oldVec.Dup(mp)
+		if err1 != nil {
 			for j := 0; j < i; j++ {
 				bat.Vecs[j].Free(mp)
 			}
-			return nil, err
+			return nil, err1
 		}
+		bat.ReplaceVector(oldVec, vec)
 	}
 	// allocated memory of aggVec from mPool.
 	for i, ag := range bat.Aggs {

--- a/pkg/testutil/util_debug.go
+++ b/pkg/testutil/util_debug.go
@@ -1,0 +1,38 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+)
+
+var _ = OperatorCatchBatch
+
+// OperatorCatchBatch return a string with format
+//
+//	`insert operator catch a batch, batch length is 100, [vec 0 : len is 100]`
+func OperatorCatchBatch(operatorName string, bat *batch.Batch) string {
+	if bat == nil {
+		return ""
+	}
+	str := fmt.Sprintf("`%s` operator catch a batch, batch length is %d\n", operatorName, bat.Length())
+	for i, vec := range bat.Vecs {
+		str += fmt.Sprintf("[vec %d[type is %d, %p] : len is %d]\n", i,
+			vec.GetType().Oid, vec,
+			vec.Length())
+	}
+	return str
+}

--- a/pkg/vm/engine/disttae/partition_reader.go
+++ b/pkg/vm/engine/disttae/partition_reader.go
@@ -16,6 +16,8 @@ package disttae
 
 import (
 	"context"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/dataio"
@@ -144,6 +146,7 @@ func (p *PartitionReader) Read(ctx context.Context, colNames []string, expr *pla
 			rbat.SetAttributes(colNames)
 			rbat.Cnt = 1
 			rbat.SetZs(rbat.Vecs[0].Length(), p.procMPool)
+			logutil.Debug(testutil.OperatorCatchBatch("partition reader[s3]", rbat))
 			return rbat, nil
 		} else {
 			bat = p.inserts[0].GetSubBatch(colNames)
@@ -172,6 +175,7 @@ func (p *PartitionReader) Read(ctx context.Context, colNames []string, expr *pla
 				}
 				b.Zs = append(b.Zs, int64(bat.Zs[j]))
 			}
+			logutil.Debug(testutil.OperatorCatchBatch("partition reader[workspace]", b))
 			return b, nil
 		}
 	}
@@ -230,5 +234,7 @@ func (p *PartitionReader) Read(ctx context.Context, colNames []string, expr *pla
 	if rows == 0 {
 		return nil, nil
 	}
+	// XXX I'm not sure `normal` is a good description
+	logutil.Debug(testutil.OperatorCatchBatch("partition reader[normal]", b))
 	return b, nil
 }

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -16,6 +16,8 @@ package disttae
 
 import (
 	"context"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"sort"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -103,6 +105,8 @@ func (r *blockReader) Read(ctx context.Context, cols []string, _ *plan.Expr, m *
 			bat.Shrink([]int64{int64(row)})
 		}
 	}
+
+	logutil.Debug(testutil.OperatorCatchBatch("block reader", bat))
 	return bat, nil
 }
 
@@ -162,6 +166,8 @@ func (r *blockMergeReader) Read(ctx context.Context, cols []string, expr *plan.E
 		r.sels = append(r.sels, int64(i))
 	}
 	bat.Shrink(r.sels)
+
+	logutil.Debug(testutil.OperatorCatchBatch("block merge reader", bat))
 	return bat, nil
 }
 
@@ -185,6 +191,7 @@ func (r *mergeReader) Read(ctx context.Context, cols []string, expr *plan.Expr, 
 			r.rds = r.rds[1:]
 		}
 		if bat != nil {
+			logutil.Debug(testutil.OperatorCatchBatch("merge reader", bat))
 			return bat, nil
 		}
 	}

--- a/pkg/vm/engine/memoryengine/table_reader.go
+++ b/pkg/vm/engine/memoryengine/table_reader.go
@@ -17,6 +17,8 @@ package memoryengine
 import (
 	"context"
 	"encoding/binary"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -176,6 +178,7 @@ func (t *TableReader) Read(ctx context.Context, colNames []string, plan *plan.Ex
 			continue
 		}
 
+		logutil.Debug(testutil.OperatorCatchBatch("table reader", resp.Batch))
 		return resp.Batch, nil
 	}
 

--- a/pkg/vm/engine/tae/moengine/reader.go
+++ b/pkg/vm/engine/tae/moengine/reader.go
@@ -17,6 +17,8 @@ package moengine
 import (
 	"bytes"
 	"context"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
@@ -66,6 +68,7 @@ func (r *txnReader) Read(ctx context.Context, attrs []string, _ *plan.Expr, m *m
 	for i := 0; i < n; i++ {
 		bat.Zs[i] = 1
 	}
+	logutil.Debug(testutil.OperatorCatchBatch("txn reader", bat))
 	return bat, nil
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8741 

## What this PR does / why we need it:
1. add some log with debug level.
2. fix a pipeline bug that will early free vector while doing the dup.