### PR TITLE
morpc: fatal if read and write loop panic

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -389,6 +389,14 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 		close(rb.writeC)
 	}()
 
+	// fatal if panic
+	defer func() {
+		if err := recover(); err != nil {
+			rb.logger.Fatal("write loop failed",
+				zap.Any("err", err))
+		}
+	}()
+
 	messages := make([]*Future, 0, rb.options.batchSendSize)
 	stopped := false
 	for {
@@ -480,6 +488,14 @@ func (rb *remoteBackend) readLoop(ctx context.Context) {
 	if rb.options.hasPayloadResponse {
 		cb = wg.Done
 	}
+
+	// fatal if panic
+	defer func() {
+		if err := recover(); err != nil {
+			rb.logger.Fatal("read loop failed",
+				zap.Any("err", err))
+		}
+	}()
 
 	for {
 		select {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8561 

## What this PR does / why we need it:
push mode will cause morpc writeloop exception exit, in read and write loop plus recover, found panic, directly record fatal log, exit the process