### PR TITLE
[Opt] Transform count distinct into 2 agg nodes

### DIFF
--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -325,10 +325,10 @@ func getValueFromVector(vec *vector.Vector, ses *Session, expr *plan2.Expr) (int
 		return vec.GetStringAt(0), nil
 	case types.T_decimal64:
 		val := vector.GetFixedAt[types.Decimal64](vec, 0)
-		return plan2.MakePlan2Decimal64ExprWithType(val, plan2.DeepCopyTyp(expr.Typ)), nil
+		return plan2.MakePlan2Decimal64ExprWithType(val, plan2.DeepCopyType(expr.Typ)), nil
 	case types.T_decimal128:
 		val := vector.GetFixedAt[types.Decimal128](vec, 0)
-		return plan2.MakePlan2Decimal128ExprWithType(val, plan2.DeepCopyTyp(expr.Typ)), nil
+		return plan2.MakePlan2Decimal128ExprWithType(val, plan2.DeepCopyType(expr.Typ)), nil
 	case types.T_json:
 		val := vec.GetBytesAt(0)
 		byteJson := types.DecodeJson(val)

--- a/pkg/sql/plan/deepcopy.go
+++ b/pkg/sql/plan/deepcopy.go
@@ -404,7 +404,7 @@ func DeepCopyDefault(def *plan.Default) *plan.Default {
 	}
 }
 
-func DeepCopyTyp(typ *plan.Type) *plan.Type {
+func DeepCopyType(typ *plan.Type) *plan.Type {
 	if typ == nil {
 		return nil
 	}
@@ -425,7 +425,7 @@ func DeepCopyColDef(col *plan.ColDef) *plan.ColDef {
 		ColId:     col.ColId,
 		Name:      col.Name,
 		Alg:       col.Alg,
-		Typ:       DeepCopyTyp(col.Typ),
+		Typ:       DeepCopyType(col.Typ),
 		Default:   DeepCopyDefault(col.Default),
 		Primary:   col.Primary,
 		Pkidx:     col.Pkidx,
@@ -861,7 +861,7 @@ func DeepCopyExpr(expr *Expr) *Expr {
 		return nil
 	}
 	newExpr := &Expr{
-		Typ: DeepCopyTyp(expr.Typ),
+		Typ: DeepCopyType(expr.Typ),
 	}
 
 	switch item := expr.Expr.(type) {
@@ -974,7 +974,7 @@ func DeepCopyExpr(expr *Expr) *Expr {
 	case *plan.Expr_T:
 		newExpr.Expr = &plan.Expr_T{
 			T: &plan.TargetType{
-				Typ: DeepCopyTyp(item.T.Typ),
+				Typ: DeepCopyType(item.T.Typ),
 			},
 		}
 

--- a/pkg/sql/plan/distinct_agg.go
+++ b/pkg/sql/plan/distinct_agg.go
@@ -1,0 +1,77 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+)
+
+func (builder *QueryBuilder) optimizeDistinctAgg(nodeID int32) {
+	node := builder.qry.Nodes[nodeID]
+
+	for _, childID := range node.Children {
+		builder.optimizeDistinctAgg(childID)
+	}
+
+	if node.NodeType == plan.Node_AGG {
+		if len(node.AggList) != 1 {
+			return
+		}
+
+		aggFunc := node.AggList[0].GetF()
+		if uint64(aggFunc.Func.Obj)&function.Distinct == 0 || (aggFunc.Func.ObjName != "count" && aggFunc.Func.ObjName != "sum") {
+			return
+		}
+
+		oldGroupLen := len(node.GroupBy)
+		oldGroupBy := node.GroupBy
+		toCount := aggFunc.Args[0]
+
+		newGroupTag := builder.genNewTag()
+		newAggregateTag := builder.genNewTag()
+		aggNodeID := builder.appendNode(&plan.Node{
+			NodeType:    plan.Node_AGG,
+			Children:    []int32{node.Children[0]},
+			GroupBy:     append(oldGroupBy, toCount),
+			BindingTags: []int32{newGroupTag, newAggregateTag},
+		}, nil)
+
+		node.Children[0] = aggNodeID
+		node.GroupBy = make([]*plan.Expr, oldGroupLen)
+		for i := range node.GroupBy {
+			node.GroupBy[i] = &plan.Expr{
+				Typ: DeepCopyType(oldGroupBy[i].Typ),
+				Expr: &plan.Expr_Col{
+					Col: &plan.ColRef{
+						RelPos: newGroupTag,
+						ColPos: int32(i),
+					},
+				},
+			}
+		}
+
+		aggFunc.Func.Obj &= function.DistinctMask
+		aggFunc.Args[0] = &plan.Expr{
+			Typ: DeepCopyType(toCount.Typ),
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{
+					RelPos: newGroupTag,
+					ColPos: int32(oldGroupLen),
+				},
+			},
+		}
+	}
+}

--- a/pkg/sql/plan/having_binder.go
+++ b/pkg/sql/plan/having_binder.go
@@ -120,7 +120,9 @@ func (b *HavingBinder) BindAggFunc(funcName string, astExpr *tree.FuncExpr, dept
 		return nil, err
 	}
 	if astExpr.Type == tree.FUNC_TYPE_DISTINCT {
-		expr.GetF().Func.Obj = int64(int64(uint64(expr.GetF().Func.Obj) | function.Distinct))
+		if funcName != "max" && funcName != "min" && funcName != "any_value" {
+			expr.GetF().Func.Obj = int64(int64(uint64(expr.GetF().Func.Obj) | function.Distinct))
+		}
 	}
 	b.insideAgg = false
 

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -832,6 +832,7 @@ func (builder *QueryBuilder) createQuery() (*Query, error) {
 		rootID = builder.aggPullup(rootID, rootID)
 		ReCalcNodeStats(rootID, builder, true, false)
 		rootID = builder.pushdownSemiAntiJoins(rootID)
+		builder.optimizeDistinctAgg(rootID)
 		ReCalcNodeStats(rootID, builder, true, false)
 		builder.applySwapRuleByStats(rootID, true)
 		SortFilterListByStats(builder.GetContext(), rootID, builder)

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -190,7 +190,12 @@ func getColNdv(col *plan.ColRef, nodeID int32, builder *QueryBuilder) float64 {
 		return -1
 	}
 
-	if binding, ok := builder.ctxByNode[nodeID].bindingByTag[col.RelPos]; ok {
+	ctx := builder.ctxByNode[nodeID]
+	if ctx == nil {
+		return -1
+	}
+
+	if binding, ok := ctx.bindingByTag[col.RelPos]; ok {
 		s := sc.GetStatsInfoMap(binding.tableID)
 		return s.NdvMap[binding.cols[col.ColPos]]
 	} else {

--- a/pkg/sql/plan/visit_plan.go
+++ b/pkg/sql/plan/visit_plan.go
@@ -97,7 +97,7 @@ func (vq *VisitPlan) exploreNode(ctx context.Context, rule VisitPlanRule, node *
 	}
 
 	applyAndResetType := func(e *Expr) (*Expr, error) {
-		oldType := DeepCopyTyp(e.Typ)
+		oldType := DeepCopyType(e.Typ)
 		e, err = rule.ApplyExpr(e)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
For TPCH q16 SF=10, it reduces time cost from 2.3s to 0.9s, and eliminates 4.3GB memory allocation on hashtable.

TPCH q16 SF=100 is now runnable on 32GB memory machine.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9049

## What this PR does / why we need it: