### PR TITLE
lockop:  return retry error if refresh expr not enabled

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -464,6 +464,10 @@ func (s *service) getTxnClient() (c client.TxnClient, err error) {
 			opts = append(opts,
 				client.WithEnableCNBasedConsistency())
 		}
+		if s.cfg.Txn.EnableRefreshExpression {
+			opts = append(opts,
+				client.WithEnableRefreshExpression())
+		}
 		opts = append(opts, client.WithLockService(s.lockService))
 		c = client.NewTxnClient(
 			sender,

--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -171,6 +171,12 @@ type Config struct {
 		// EnableCNBasedConsistency ensure that all the transactions on a CN can read
 		// the writes of the previous committed transaction
 		EnableCNBasedConsistency bool `toml:"enable-cn-based-consistency"`
+		// EnableRefreshExpressionIn RC mode, in the event of a conflict, the later transaction
+		// needs to see the latest data after the previous transaction commits. At this time we
+		// need to re-read the data, re-read the latest data, and re-compute the expression. This
+		// feature was turned off in 0.8 and is not supported for now. The replacement solution is
+		// to return a retry error and let the whole computation re-execute.
+		EnableRefreshExpression bool `toml:"enable-refresh-expression"`
 	} `toml:"txn"`
 }
 

--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -176,7 +176,8 @@ const (
 	ErrAppendableSegmentNotFound uint16 = 20624
 	ErrAppendableBlockNotFound   uint16 = 20625
 	ErrTAEDebug                  uint16 = 20626
-	ErrDuplicateKey              uint16 = 20626
+	ErrDuplicateKey              uint16 = 20627
+	ErrTxnNeedRetry              uint16 = 20628
 
 	// Group 7: lock service
 	// ErrDeadLockDetected lockservice has detected a deadlock and should abort the transaction if it receives this error
@@ -319,6 +320,7 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	ErrAppendableSegmentNotFound: {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "appendable segment not found"},
 	ErrAppendableBlockNotFound:   {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "appendable block not found"},
 	ErrDuplicateKey:              {ER_DUP_KEYNAME, []string{MySQLDefaultSqlState}, "duplicate key name '%s'"},
+	ErrTxnNeedRetry:              {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "txn need retry in rc mode"},
 
 	// Group 7: lock service
 	ErrDeadLockDetected:     {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "deadlock detected"},
@@ -924,6 +926,10 @@ func NewAppendableSegmentNotFound(ctx context.Context) *Error {
 
 func NewAppendableBlockNotFound(ctx context.Context) *Error {
 	return newError(ctx, ErrAppendableBlockNotFound)
+}
+
+func NewTxnNeedRetry(ctx context.Context) *Error {
+	return newError(ctx, ErrTxnNeedRetry)
 }
 
 func NewDeadLockDetected(ctx context.Context) *Error {

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -299,3 +299,7 @@ func NewNoUDFNoCtx(f string) *Error {
 func NewProcedureAlreadyExistsNoCtx(f string) *Error {
 	return newError(Context(), ErrProcedureAlreadyExists, f)
 }
+
+func NewTxnNeedRetryNoCtx() *Error {
+	return newError(Context(), ErrTxnNeedRetry)
+}

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -77,6 +77,15 @@ func WithEnableCNBasedConsistency() TxnClientCreateOption {
 	}
 }
 
+// WithEnableRefreshExpression in RC mode, in the event of a conflict, the later transaction needs
+// to see the latest data after the previous transaction commits. At this time we need to re-read
+// the data, re-read the latest data, and re-compute the expression.
+func WithEnableRefreshExpression() TxnClientCreateOption {
+	return func(tc *txnClient) {
+		tc.enableRefreshExpression = true
+	}
+}
+
 var _ TxnClient = (*txnClient)(nil)
 
 type txnClient struct {
@@ -87,6 +96,7 @@ type txnClient struct {
 	timestampWaiter            TimestampWaiter
 	enableCNBasedConsistency   bool
 	enableSacrificingFreshness bool
+	enableRefreshExpression    bool
 
 	mu struct {
 		sync.RWMutex

--- a/pkg/txn/client/client_feature.go
+++ b/pkg/txn/client/client_feature.go
@@ -1,0 +1,23 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+func (client *txnClient) RefreshExpressionEnabled() bool {
+	return client.enableRefreshExpression
+}
+
+func (client *txnClient) CNBasedConsistencyEnabled() bool {
+	return client.enableCNBasedConsistency
+}

--- a/pkg/txn/client/client_feature_test.go
+++ b/pkg/txn/client/client_feature_test.go
@@ -1,0 +1,35 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFeatureEnabled(t *testing.T) {
+	runtime.SetupProcessLevelRuntime(runtime.DefaultRuntime())
+	c := NewTxnClient(newTestTxnSender())
+	assert.False(t, c.(TxnClientWithFeature).CNBasedConsistencyEnabled())
+	assert.False(t, c.(TxnClientWithFeature).RefreshExpressionEnabled())
+
+	c = NewTxnClient(newTestTxnSender(),
+		WithEnableCNBasedConsistency(),
+		WithEnableRefreshExpression())
+	assert.True(t, c.(TxnClientWithFeature).CNBasedConsistencyEnabled())
+	assert.True(t, c.(TxnClientWithFeature).RefreshExpressionEnabled())
+}

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -43,6 +43,16 @@ type TxnClient interface {
 	Close() error
 }
 
+// TxnClientWithFeature is similar to TxnClient, except that some methods have been added to determine
+// whether certain features are supported.
+type TxnClientWithFeature interface {
+	TxnClient
+	// RefreshExpressionEnabled return true if refresh expression feature enabled
+	RefreshExpressionEnabled() bool
+	// CNBasedConsistencyEnabled return true if cn based consistency feature enabled
+	CNBasedConsistencyEnabled() bool
+}
+
 // TxnOperator operator for transaction clients, handling read and write
 // requests for transactions, and handling distributed transactions across DN
 // nodes.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #7066 

## What this PR does / why we need it:
In RC mode, when a conflict occurs, if the refresh expression feature is not turned on, then a transaction retry error is returned and then the entire sql needs to be re-executed here in the execution.