### PR TITLE
[feat] proxy: add session variable for pipeline.

### DIFF
--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -2028,7 +2028,7 @@ func (mp *MysqlProtocolImpl) makeResultSetTextRow(data []byte, mrs *MysqlResultS
 		}
 		mysqlColumn, ok := column.(*MysqlColumn)
 		if !ok {
-			return nil, moerr.NewInternalError(mp.ses.requestCtx, "sendColumn need MysqlColumn")
+			return nil, moerr.NewInternalError(ctx, "sendColumn need MysqlColumn")
 		}
 
 		if isNil, err1 := mrs.ColumnIsNull(ctx, r, i); err1 != nil {
@@ -2153,7 +2153,7 @@ func (mp *MysqlProtocolImpl) makeResultSetTextRow(data []byte, mrs *MysqlResultS
 				data = mp.appendStringLenEnc(data, value)
 			}
 		default:
-			return nil, moerr.NewInternalError(mp.ses.requestCtx, "unsupported column type %d ", mysqlColumn.ColumnType())
+			return nil, moerr.NewInternalError(ctx, "unsupported column type %d ", mysqlColumn.ColumnType())
 		}
 	}
 	return data, nil
@@ -2584,6 +2584,11 @@ func (mp *MysqlProtocolImpl) MakeOKPayload(affectedRows, lastInsertId uint64, st
 // MakeErrPayload exposes (*MysqlProtocolImpl).makeErrPayload() function.
 func (mp *MysqlProtocolImpl) MakeErrPayload(errCode uint16, sqlState, errorMessage string) []byte {
 	return mp.makeErrPayload(errCode, sqlState, errorMessage)
+}
+
+// MakeEOFPayload exposes (*MysqlProtocolImpl).makeEOFPayload() function.
+func (mp *MysqlProtocolImpl) MakeEOFPayload(warnings, status uint16) []byte {
+	return mp.makeEOFPayload(warnings, status)
 }
 
 // tryUpdateSalt tries to update salt with the value read from proxy module.

--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -1259,6 +1259,14 @@ var gSysVarsDefs = map[string]SystemVariable{
 		Type:              InitSystemVariableBoolType("mo_pk_check_by_dn"),
 		Default:           int8(0),
 	},
+	"cn_label": {
+		Name:              "cn_label",
+		Scope:             ScopeSession,
+		Dynamic:           true,
+		SetVarHintApplies: false,
+		Type:              InitSystemVariableStringType("cn_label"),
+		Default:           "",
+	},
 }
 
 func updateTimeZone(sess *Session, vars map[string]interface{}, name string, val interface{}) error {

--- a/pkg/proxy/conn_manager_test.go
+++ b/pkg/proxy/conn_manager_test.go
@@ -98,27 +98,21 @@ func TestConnManagerConnection(t *testing.T) {
 	cm := newConnManager()
 	require.NotNil(t, cm)
 
-	cn11 := &CNServer{
-		hash: "hash1",
-		reqLabel: newLabelInfo("t1", map[string]string{
+	cn11 := testMakeCNServer("cn11", "", 0, "hash1",
+		newLabelInfo("t1", map[string]string{
 			"k1": "v1",
 		}),
-		uuid: "cn11",
-	}
-	cn12 := &CNServer{
-		hash: "hash1",
-		reqLabel: newLabelInfo("t1", map[string]string{
+	)
+	cn12 := testMakeCNServer("cn12", "", 0, "hash1",
+		newLabelInfo("t1", map[string]string{
 			"k1": "v1",
 		}),
-		uuid: "cn12",
-	}
-	cn21 := &CNServer{
-		hash: "hash2",
-		reqLabel: newLabelInfo("t1", map[string]string{
+	)
+	cn21 := testMakeCNServer("cn21", "", 0, "hash2",
+		newLabelInfo("t1", map[string]string{
 			"k2": "v2",
 		}),
-		uuid: "cn21",
-	}
+	)
 
 	tu0 := newTunnel(context.TODO(), nil, nil)
 
@@ -196,25 +190,21 @@ func TestConnManagerConnectionConcurrency(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		wg.Add(2)
 		go func(j int) {
-			cn11 := &CNServer{
-				hash: "hash1",
-				reqLabel: newLabelInfo("t1", map[string]string{
+			cn11 := testMakeCNServer(fmt.Sprintf("cn1-%d", j), "", 0, "hash1",
+				newLabelInfo("t1", map[string]string{
 					"k1": "v1",
 				}),
-				uuid: fmt.Sprintf("cn1-%d", j),
-			}
+			)
 			tu11 := newTunnel(context.TODO(), nil, nil)
 			cm.connect(cn11, tu11)
 			wg.Done()
 		}(i)
 		go func(j int) {
-			cn11 := &CNServer{
-				hash: "hash2",
-				reqLabel: newLabelInfo("t1", map[string]string{
+			cn11 := testMakeCNServer(fmt.Sprintf("cn2-%d", j), "", 0, "hash2",
+				newLabelInfo("t1", map[string]string{
 					"k2": "v2",
 				}),
-				uuid: fmt.Sprintf("cn2-%d", j),
-			}
+			)
 			tu11 := newTunnel(context.TODO(), nil, nil)
 			cm.connect(cn11, tu11)
 			wg.Done()
@@ -232,13 +222,11 @@ func TestConnManagerLabelInfo(t *testing.T) {
 	cm := newConnManager()
 	require.NotNil(t, cm)
 
-	cn11 := &CNServer{
-		hash: "hash1",
-		reqLabel: newLabelInfo("t1", map[string]string{
+	cn11 := testMakeCNServer("cn11", "", 0, "hash1",
+		newLabelInfo("t1", map[string]string{
 			"k1": "v1",
 		}),
-		uuid: "cn11",
-	}
+	)
 
 	tu11 := newTunnel(context.TODO(), nil, nil)
 	cm.connect(cn11, tu11)

--- a/pkg/proxy/counter_set.go
+++ b/pkg/proxy/counter_set.go
@@ -38,6 +38,8 @@ func (e *counterLogExporter) Export() []zap.Field {
 	var fields []zap.Field
 	fields = append(fields, zap.Int64("accepted connections",
 		e.counter.connAccepted.Load()))
+	fields = append(fields, zap.Int64("total connections",
+		e.counter.connAccepted.Load()))
 	fields = append(fields, zap.Int64("client disconnect",
 		e.counter.clientDisconnect.Load()))
 	fields = append(fields, zap.Int64("server disconnect",
@@ -58,6 +60,7 @@ func (e *counterLogExporter) Export() []zap.Field {
 // counterSet contains all items that need to be tracked in proxy.
 type counterSet struct {
 	connAccepted             stats.Counter
+	connTotal                stats.Counter
 	clientDisconnect         stats.Counter
 	serverDisconnect         stats.Counter
 	connRefused              stats.Counter

--- a/pkg/proxy/event_test.go
+++ b/pkg/proxy/event_test.go
@@ -16,6 +16,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 
@@ -25,17 +26,82 @@ import (
 )
 
 func TestMakeEvent(t *testing.T) {
-	e := makeEvent(nil)
+	e, r := makeEvent(nil)
 	require.Nil(t, e)
+	require.True(t, r)
 
-	e = makeEvent(makeSimplePacket("kill quer8y 12"))
-	require.Nil(t, e)
+	t.Run("kill query", func(t *testing.T) {
+		e, r = makeEvent(&eventReq{msg: makeSimplePacket("kill quer8y 12")})
+		require.Nil(t, e)
+		require.True(t, r)
 
-	e = makeEvent(makeSimplePacket("kill query 123"))
-	require.NotNil(t, e)
+		e, r = makeEvent(&eventReq{msg: makeSimplePacket("kill query 123")})
+		require.NotNil(t, e)
+		require.True(t, r)
 
-	e = makeEvent(makeSimplePacket("kiLL Query 12"))
-	require.NotNil(t, e)
+		e, r = makeEvent(&eventReq{msg: makeSimplePacket("kiLL Query 12")})
+		require.NotNil(t, e)
+		require.True(t, r)
+
+		e, r = makeEvent(&eventReq{msg: makeSimplePacket("set ")})
+		require.Nil(t, e)
+		require.True(t, r)
+	})
+
+	t.Run("set var", func(t *testing.T) {
+		stmtsValid := []string{
+			"set session a=1",
+			"set session a='1'",
+			"set local a=1",
+			"set local a='1'",
+			"set @@session.a=1",
+			"set @@session.a='1'",
+			"set @@local.a=1",
+			"set @@local.a='1'",
+			"set @@a=1",
+			"set @@a='1'",
+			"set a=1",
+			"set a='1'",
+			// user variables.
+			"set @a=1",
+			"set @a='1'",
+			// session variables.
+			"set session a:=1",
+			"set session a:='1'",
+			"set local a:=1",
+			"set local a:='1'",
+			"set @@session.a:=1",
+			"set @@session.a:='1'",
+			"set @@local.a:=1",
+			"set @@local.a:='1'",
+			"set @@a:=1",
+			"set @@a:='1'",
+			"set a:=1",
+			"set a:='1'",
+			// user variables.
+			"set @a:=1",
+			"set @a:='1'",
+		}
+		stmtsInvalid := []string{
+			"set '1'",
+			"set _'1'",
+			"set _a'1'",
+			"set _a='1'",
+			"set @@@a:='1'",
+			"set @a@:='1'",
+			"set @a:='1",
+		}
+		for _, stmt := range stmtsValid {
+			e, r = makeEvent(&eventReq{msg: makeSimplePacket(stmt)})
+			require.NotNil(t, e)
+			require.False(t, r)
+		}
+		for _, stmt := range stmtsInvalid {
+			e, r = makeEvent(&eventReq{msg: makeSimplePacket(stmt)})
+			require.Nil(t, e)
+			require.True(t, r)
+		}
+	})
 }
 
 func TestKillQueryEvent(t *testing.T) {
@@ -44,23 +110,15 @@ func TestKillQueryEvent(t *testing.T) {
 	tp := newTestProxyHandler(t)
 	defer tp.closeFn()
 
-	addr1 := "127.0.0.1:38001"
-	cn1 := &CNServer{
-		connID: 10,
-		addr:   addr1,
-		uuid:   "uuid1",
-	}
+	addr1 := "127.0.0.1:38301"
+	cn1 := testMakeCNServer("uuid1", addr1, 10, "", labelInfo{})
 	stopFn1 := startTestCNServer(t, tp.ctx, addr1)
 	defer func() {
 		require.NoError(t, stopFn1())
 	}()
 
-	addr2 := "127.0.0.1:38002"
-	cn2 := &CNServer{
-		connID: 20,
-		addr:   addr2,
-		uuid:   "uuid2",
-	}
+	addr2 := "127.0.0.1:38302"
+	cn2 := testMakeCNServer("uuid2", addr2, 20, "", labelInfo{})
 	stopFn2 := startTestCNServer(t, tp.ctx, addr2)
 	defer func() {
 		require.NoError(t, stopFn2())
@@ -110,11 +168,13 @@ func TestKillQueryEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	// tunnel1 is on cn1, connection ID is 10.
-	_, _, err = tp.ru.Connect(cn1, nil, tu1)
+	_, ret, err := tp.ru.Connect(cn1, testPacket, tu1)
 	require.NoError(t, err)
+	// get connection id from result.
+	connID := ret[6]
 
 	// tunnel2 is on cn2, connection ID is 20.
-	_, _, err = tp.ru.Connect(cn2, nil, tu2)
+	_, _, err = tp.ru.Connect(cn2, testPacket, tu2)
 	require.NoError(t, err)
 
 	err = tu1.run(cc1, sc1)
@@ -180,7 +240,7 @@ func TestKillQueryEvent(t *testing.T) {
 	go func() {
 		<-sendEventCh
 		// client2 send kill query 10, which is on server1.
-		if _, err := client2.Write(makeSimplePacket("kill query 10")); err != nil {
+		if _, err := client2.Write(makeSimplePacket(fmt.Sprintf("kill query %d", connID))); err != nil {
 			errChan <- err
 			return
 		}
@@ -203,10 +263,166 @@ func TestKillQueryEvent(t *testing.T) {
 	}
 }
 
+func TestSetVarEvent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tp := newTestProxyHandler(t)
+	defer tp.closeFn()
+
+	addr1 := "127.0.0.1:38003"
+	cn1 := testMakeCNServer("uuid1", addr1, 10, "", labelInfo{})
+	stopFn1 := startTestCNServer(t, tp.ctx, addr1)
+	defer func() {
+		require.NoError(t, stopFn1())
+	}()
+
+	addr2 := "127.0.0.1:38004"
+	cn2 := testMakeCNServer("uuid2", addr2, 20, "", labelInfo{})
+	stopFn2 := startTestCNServer(t, tp.ctx, addr2)
+	defer func() {
+		require.NoError(t, stopFn2())
+	}()
+
+	tu1 := newTunnel(tp.ctx, tp.logger, nil)
+	defer func() { _ = tu1.Close() }()
+	tu2 := newTunnel(tp.ctx, tp.logger, nil)
+	defer func() { _ = tu2.Close() }()
+
+	// Client2 will send "kill query 10", which will route to the server which
+	// has connection ID 10. In this case, the connection is server1.
+	clientProxy1, _ := net.Pipe()
+	serverProxy1, _ := net.Pipe()
+
+	cc1 := newMockClientConn(clientProxy1, "t1", labelInfo{}, tp.ru, tu1)
+	require.NotNil(t, cc1)
+	sc1 := newMockServerConn(serverProxy1)
+	require.NotNil(t, sc1)
+
+	clientProxy2, client2 := net.Pipe()
+	serverProxy2, _ := net.Pipe()
+
+	cc2 := newMockClientConn(clientProxy2, "t1", labelInfo{}, tp.ru, tu2)
+	require.NotNil(t, cc2)
+	sc2 := newMockServerConn(serverProxy2)
+	require.NotNil(t, sc2)
+
+	res := make(chan []byte)
+	st := stopper.NewStopper("test-event", stopper.WithLogger(tp.logger.RawLogger()))
+	defer st.Stop()
+	err := st.RunNamedTask("test-event-handler", func(ctx context.Context) {
+		for {
+			select {
+			case e := <-tu2.reqC:
+				_ = cc2.HandleEvent(ctx, e, tu2.respC)
+			case r := <-tu2.respC:
+				if len(r) > 0 {
+					res <- r
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+	require.NoError(t, err)
+
+	// tunnel1 is on cn1, connection ID is 10.
+	_, _, err = tp.ru.Connect(cn1, testPacket, tu1)
+	require.NoError(t, err)
+
+	// tunnel2 is on cn2, connection ID is 20.
+	_, _, err = tp.ru.Connect(cn2, testPacket, tu2)
+	require.NoError(t, err)
+
+	err = tu1.run(cc1, sc1)
+	require.NoError(t, err)
+	require.Nil(t, tu1.ctx.Err())
+
+	func() {
+		tu1.mu.Lock()
+		defer tu1.mu.Unlock()
+		require.True(t, tu1.mu.started)
+	}()
+
+	err = tu2.run(cc2, sc2)
+	require.NoError(t, err)
+	require.Nil(t, tu2.ctx.Err())
+
+	func() {
+		tu2.mu.Lock()
+		defer tu2.mu.Unlock()
+		require.True(t, tu2.mu.started)
+	}()
+
+	tu1.mu.Lock()
+	csp1 := tu1.mu.csp
+	scp1 := tu1.mu.scp
+	tu1.mu.Unlock()
+
+	tu2.mu.Lock()
+	csp2 := tu2.mu.csp
+	scp2 := tu2.mu.scp
+	tu2.mu.Unlock()
+
+	barrierStart1, barrierEnd1 := make(chan struct{}), make(chan struct{})
+	barrierStart2, barrierEnd2 := make(chan struct{}), make(chan struct{})
+	csp1.testHelper.beforeSend = func() {
+		<-barrierStart1
+		<-barrierEnd1
+	}
+	csp2.testHelper.beforeSend = func() {
+		<-barrierStart2
+		<-barrierEnd2
+	}
+
+	csp1.mu.Lock()
+	require.True(t, csp1.mu.started)
+	csp1.mu.Unlock()
+
+	scp1.mu.Lock()
+	require.True(t, scp1.mu.started)
+	scp1.mu.Unlock()
+
+	csp2.mu.Lock()
+	require.True(t, csp2.mu.started)
+	csp2.mu.Unlock()
+
+	scp2.mu.Lock()
+	require.True(t, scp2.mu.started)
+	scp2.mu.Unlock()
+
+	// Client2 writes some MySQL packets.
+	sendEventCh := make(chan struct{}, 1)
+	errChan := make(chan error, 1)
+	go func() {
+		<-sendEventCh
+		if _, err := client2.Write(makeSimplePacket("set session cn_label='account=acc1'")); err != nil {
+			errChan <- err
+			return
+		}
+	}()
+
+	sendEventCh <- struct{}{}
+	barrierStart2 <- struct{}{}
+	barrierEnd2 <- struct{}{}
+
+	// wait for result
+	<-res
+	require.Equal(t, 1, len(cc2.(*mockClientConn).setVarStmts))
+
+	select {
+	case err = <-errChan:
+		t.Fatalf("require no error, but got %v", err)
+	default:
+	}
+}
+
 func TestEventType_String(t *testing.T) {
 	e1 := baseEvent{}
 	require.Equal(t, "Unknown", e1.eventType().String())
 
 	e2 := killQueryEvent{}
 	require.Equal(t, "KillQuery", e2.eventType().String())
+
+	e3 := setVarEvent{}
+	require.Equal(t, "SetVar", e3.eventType().String())
 }

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -98,6 +98,7 @@ func newProxyHandler(
 // handle handles the incoming connection.
 func (h *handler) handle(c goetty.IOSession) error {
 	h.counterSet.connAccepted.Add(1)
+	h.counterSet.connTotal.Add(1)
 
 	// Create a new tunnel to manage client connection and server connection.
 	t := newTunnel(h.ctx, h.logger, h.counterSet)
@@ -163,9 +164,11 @@ func (h *handler) handle(c goetty.IOSession) error {
 
 	select {
 	case <-h.ctx.Done():
+		h.counterSet.connTotal.Add(-1)
 		return h.ctx.Err()
 	case err := <-t.errC:
 		h.counterSet.updateWithErr(err)
+		h.counterSet.connTotal.Add(-1)
 		h.logger.Error("proxy handle error", zap.Error(err))
 		return err
 	}

--- a/pkg/proxy/handler_test.go
+++ b/pkg/proxy/handler_test.go
@@ -68,7 +68,7 @@ func newTestProxyHandler(t *testing.T) *testProxyHandler {
 		hc:     hc,
 		mc:     mc,
 		re:     re,
-		ru:     newRouter(mc, re, true),
+		ru:     newRouter(mc, re, false),
 		closeFn: func() {
 			mc.Close()
 			st.Stop()
@@ -91,11 +91,7 @@ func TestHandler_Handle(t *testing.T) {
 	cfg.HAKeeper.ClientConfig.ServiceAddresses = []string{"127.0.0.1:8000"}
 	hc := &mockHAKeeperClient{}
 	addr := "127.0.0.1:48090"
-	cn1 := &CNServer{
-		uuid: "cn11",
-		addr: addr,
-		salt: testSlat,
-	}
+	cn1 := testMakeCNServer("cn11", addr, 0, "", labelInfo{})
 	hc.updateCN(cn1.uuid, cn1.addr, map[string]metadata.LabelList{})
 	// start backend server.
 	stopFn := startTestCNServer(t, ctx, addr)
@@ -121,11 +117,30 @@ func TestHandler_Handle(t *testing.T) {
 	require.NotNil(t, db)
 	defer func() {
 		_ = db.Close()
+		timeout := time.NewTimer(time.Second * 3)
+		tick := time.NewTicker(time.Millisecond * 100)
+		var connTotal int64
+		tt := false
+		for {
+			select {
+			case <-tick.C:
+				connTotal = s.counterSet.connTotal.Load()
+			case <-timeout.C:
+				tt = true
+			}
+			if connTotal == 0 || tt {
+				break
+			}
+		}
+		tick.Stop()
+		timeout.Stop()
+		require.Equal(t, int64(0), connTotal)
 	}()
 	_, err = db.Exec("anystmt")
 	require.NoError(t, err)
 
 	require.Equal(t, int64(1), s.counterSet.connAccepted.Load())
+	require.Equal(t, int64(1), s.counterSet.connTotal.Load())
 }
 
 func TestHandler_HandleWithSSL(t *testing.T) {
@@ -142,11 +157,7 @@ func TestHandler_HandleWithSSL(t *testing.T) {
 	cfg.HAKeeper.ClientConfig.ServiceAddresses = []string{"127.0.0.1:8020"}
 	hc := &mockHAKeeperClient{}
 	addr := "127.0.0.1:48091"
-	cn1 := &CNServer{
-		uuid: "cn11",
-		addr: addr,
-		salt: testSlat,
-	}
+	cn1 := testMakeCNServer("cn11", addr, 0, "", labelInfo{})
 	hc.updateCN(cn1.uuid, cn1.addr, map[string]metadata.LabelList{})
 	// start backend server.
 	stopFn := startTestCNServer(t, ctx, addr)
@@ -219,9 +230,10 @@ func TestHandler_HandleWithSSL(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, int64(1), s.counterSet.connAccepted.Load())
+	require.Equal(t, int64(1), s.counterSet.connTotal.Load())
 }
 
-func TestHandler_HandleEvent(t *testing.T) {
+func TestHandler_HandleEventKillQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -234,11 +246,7 @@ func TestHandler_HandleEvent(t *testing.T) {
 	cfg.HAKeeper.ClientConfig.ServiceAddresses = []string{"127.0.0.1:8000"}
 	hc := &mockHAKeeperClient{}
 	addr := "127.0.0.1:48190"
-	cn1 := &CNServer{
-		uuid: "cn11",
-		addr: addr,
-		salt: testSlat,
-	}
+	cn1 := testMakeCNServer("cn11", addr, 0, "", labelInfo{})
 	hc.updateCN(cn1.uuid, cn1.addr, map[string]metadata.LabelList{})
 	// start backend server.
 	stopFn := startTestCNServer(t, ctx, addr)
@@ -277,14 +285,68 @@ func TestHandler_HandleEvent(t *testing.T) {
 		_ = db2.Close()
 	}()
 
-	var err1 error
-	for i := 0; i < 5; i++ {
-		_, err1 = db2.Exec(fmt.Sprintf("kill query %d", connID))
-		if err1 == nil {
-			break
-		}
-	}
-	require.NoError(t, err1)
+	_, err = db2.Exec("kill query 9999")
+	require.Error(t, err)
+
+	_, err = db2.Exec(fmt.Sprintf("kill query %d", connID))
+	require.NoError(t, err)
 
 	require.Equal(t, int64(2), s.counterSet.connAccepted.Load())
+}
+
+func TestHandler_HandleEventSetVar(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runtime.SetupProcessLevelRuntime(runtime.DefaultRuntime())
+	cfg := Config{
+		ListenAddress:     "127.0.0.1:40020",
+		RebalanceDisabled: true,
+	}
+	cfg.HAKeeper.ClientConfig.ServiceAddresses = []string{"127.0.0.1:8000"}
+	hc := &mockHAKeeperClient{}
+	addr := "127.0.0.1:48190"
+	cn1 := testMakeCNServer("cn11", addr, 0, "", labelInfo{})
+	hc.updateCN(cn1.uuid, cn1.addr, map[string]metadata.LabelList{})
+	// start backend server.
+	stopFn := startTestCNServer(t, ctx, addr)
+	defer func() {
+		require.NoError(t, stopFn())
+	}()
+
+	// start proxy.
+	s, err := NewServer(ctx, cfg, WithRuntime(runtime.DefaultRuntime()),
+		WithHAKeeperClient(hc))
+	defer func() {
+		err := s.Close()
+		require.NoError(t, err)
+	}()
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	err = s.Start()
+	require.NoError(t, err)
+
+	db1, err := sql.Open("mysql", fmt.Sprintf("dump:111@tcp(%s)/db1", cfg.ListenAddress))
+	// connect to server.
+	require.NoError(t, err)
+	require.NotNil(t, db1)
+	defer func() {
+		_ = db1.Close()
+	}()
+	_, err = db1.Exec("set session cn_label='acc1'")
+	require.NoError(t, err)
+
+	res, err := db1.Query("show session variables")
+	require.NoError(t, err)
+	defer res.Close()
+	var varName, varValue string
+	for res.Next() {
+		err := res.Scan(&varName, &varValue)
+		require.NoError(t, err)
+		require.Equal(t, "cn_label", varName)
+		require.Equal(t, "acc1", varValue)
+	}
+
+	require.Equal(t, int64(1), s.counterSet.connAccepted.Load())
 }

--- a/pkg/proxy/rebalancer_test.go
+++ b/pkg/proxy/rebalancer_test.go
@@ -52,45 +52,39 @@ func TestCollectTunnels(t *testing.T) {
 	defer st.Stop()
 	ha := LabelHash("hash1")
 
-	cn11 := &CNServer{
-		hash: ha,
-		reqLabel: newLabelInfo("t1", map[string]string{
+	addr1 := "127.0.0.1:38041"
+	cn11 := testMakeCNServer("cn11", addr1, 0, ha,
+		newLabelInfo("t1", map[string]string{
 			"k1": "v1",
 			"k2": "v2",
 		}),
-		uuid: "cn11",
-		addr: "127.0.0.1:38001",
-	}
+	)
 	hc.updateCN("cn11", cn11.addr, map[string]metadata.LabelList{
 		tenantLabelKey: {Labels: []string{"t1"}},
 		"k1":           {Labels: []string{"v1"}},
 		"k2":           {Labels: []string{"v2"}},
 	})
 
-	cn12 := &CNServer{
-		hash: ha,
-		reqLabel: newLabelInfo("t1", map[string]string{
+	addr2 := "127.0.0.1:38002"
+	cn12 := testMakeCNServer("cn12", addr2, 0, ha,
+		newLabelInfo("t1", map[string]string{
 			"k1": "v1",
 			"k2": "v2",
 		}),
-		uuid: "cn12",
-		addr: "127.0.0.1:38002",
-	}
+	)
 	hc.updateCN("cn12", cn12.addr, map[string]metadata.LabelList{
 		tenantLabelKey: {Labels: []string{"t1"}},
 		"k1":           {Labels: []string{"v1"}},
 		"k2":           {Labels: []string{"v2"}},
 	})
 
-	cn13 := &CNServer{
-		hash: ha,
-		reqLabel: newLabelInfo("t1", map[string]string{
+	addr3 := "127.0.0.1:38003"
+	cn13 := testMakeCNServer("cn13", addr3, 0, ha,
+		newLabelInfo("t1", map[string]string{
 			"k1": "v1",
 			"k2": "v2",
 		}),
-		uuid: "cn13",
-		addr: "127.0.0.1:38003",
-	}
+	)
 	hc.updateCN("cn13", cn13.addr, map[string]metadata.LabelList{
 		tenantLabelKey: {Labels: []string{"t1"}},
 		"k1":           {Labels: []string{"v1"}},
@@ -161,14 +155,13 @@ func TestDoRebalance(t *testing.T) {
 	defer tp.closeFn()
 
 	// Construct backend CN servers.
-	cn11 := &CNServer{
-		reqLabel: newLabelInfo("t1", map[string]string{
+	addr1 := "127.0.0.1:38001"
+	cn11 := testMakeCNServer("cn11", addr1, 0, "",
+		newLabelInfo("t1", map[string]string{
 			"k1": "v1",
 			"k2": "v2",
 		}),
-		uuid: "cn11",
-		addr: "127.0.0.1:38001",
-	}
+	)
 	li := labelInfo{
 		Tenant: "t1",
 	}
@@ -184,14 +177,13 @@ func TestDoRebalance(t *testing.T) {
 		require.NoError(t, stopFn11())
 	}()
 
-	cn12 := &CNServer{
-		reqLabel: newLabelInfo("t1", map[string]string{
+	addr2 := "127.0.0.1:38002"
+	cn12 := testMakeCNServer("cn12", addr2, 0, "",
+		newLabelInfo("t1", map[string]string{
 			"k1": "v1",
 			"k2": "v2",
 		}),
-		uuid: "cn12",
-		addr: "127.0.0.1:38002",
-	}
+	)
 	cn12.hash, err = li.getHash()
 	require.NoError(t, err)
 	tp.hc.updateCN("cn12", cn12.addr, map[string]metadata.LabelList{

--- a/pkg/proxy/router.go
+++ b/pkg/proxy/router.go
@@ -15,6 +15,7 @@
 package proxy
 
 import (
+	"net"
 	"time"
 
 	"github.com/fagongzi/goetty/v2"
@@ -61,10 +62,18 @@ type CNServer struct {
 	uuid string
 	// addr is the net address of CN server.
 	addr string
+	// conn for test.
+	conn net.Conn
 }
 
 // Connect connects to backend server and returns IOSession.
 func (s *CNServer) Connect() (goetty.IOSession, error) {
+	if s.conn != nil { // for test.
+		return goetty.NewIOSession(
+			goetty.WithSessionCodec(frontend.NewSqlCodec()),
+			goetty.WithSessionConn(0, s.conn),
+		), nil
+	}
 	c := goetty.NewIOSession(goetty.WithSessionCodec(frontend.NewSqlCodec()))
 	err := c.Connect(s.addr, defaultConnectTimeout)
 	if err != nil {

--- a/pkg/proxy/server_conn.go
+++ b/pkg/proxy/server_conn.go
@@ -153,7 +153,9 @@ func (s *serverConn) ExecStmt(stmt string, resp chan<- []byte) error {
 			return err
 		}
 		bs := packetToBytes(res)
-		sendResp(bs, resp)
+		if resp != nil {
+			sendResp(bs, resp)
+		}
 		if isEOFPacket(bs) || isOKPacket(bs) || isErrPacket(bs) {
 			break
 		}

--- a/pkg/proxy/server_conn_test.go
+++ b/pkg/proxy/server_conn_test.go
@@ -17,6 +17,7 @@ package proxy
 import (
 	"context"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -25,11 +26,31 @@ import (
 	"github.com/fagongzi/goetty/v2"
 	"github.com/lni/goutils/leaktest"
 	"github.com/matrixorigin/matrixone/pkg/config"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/frontend"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/stretchr/testify/require"
 )
 
 var testSlat = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0}
+var testPacket = &frontend.Packet{
+	Length:     1,
+	SequenceID: 0,
+	Payload:    []byte{1},
+}
+
+func testMakeCNServer(
+	uuid string, addr string, connID uint32, hash LabelHash, reqLabel labelInfo,
+) *CNServer {
+	return &CNServer{
+		connID:   connID,
+		addr:     addr,
+		uuid:     uuid,
+		salt:     testSlat,
+		hash:     hash,
+		reqLabel: reqLabel,
+	}
+}
 
 type mockServerConn struct {
 	conn net.Conn
@@ -72,9 +93,10 @@ type testCNServer struct {
 }
 
 type testHandler struct {
-	mysqlProto *frontend.MysqlProtocolImpl
-	connID     uint32
-	conn       goetty.IOSession
+	mysqlProto  *frontend.MysqlProtocolImpl
+	connID      uint32
+	conn        goetty.IOSession
+	sessionVars map[string]string
 }
 
 func startTestCNServer(t *testing.T, ctx context.Context, addr string) func() error {
@@ -154,6 +176,7 @@ func (s *testCNServer) Start() error {
 					conn:   c,
 					mysqlProto: frontend.NewMysqlClientProtocol(
 						cid, c, 0, &fp),
+					sessionVars: make(map[string]string),
 				}
 				go func(h *testHandler) {
 					testHandle(h)
@@ -172,14 +195,90 @@ func testHandle(h *testHandler) {
 	// server reads auth information from client.
 	_, _ = h.conn.Read(goetty.ReadOptions{})
 	// server writes ok packet.
-	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeOKPayload(0, 0, 0, 0, ""))
-	var err error
-	for err == nil {
-		_, err = h.conn.Read(goetty.ReadOptions{})
-		h.mysqlProto.SetSequenceID(1)
-		// set last insert id as connection id to do test more easily.
-		_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeOKPayload(0, uint64(h.connID), 0, 0, ""))
+	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeOKPayload(0, uint64(h.connID), 0, 0, ""))
+	for {
+		msg, err := h.conn.Read(goetty.ReadOptions{})
+		if err != nil {
+			break
+		}
+		packet, ok := msg.(*frontend.Packet)
+		if !ok {
+			return
+		}
+		if packet.Length > 1 && packet.Payload[0] == 3 {
+			if strings.HasPrefix(string(packet.Payload[1:]), "set session") {
+				h.handleSetVar(packet)
+			} else if string(packet.Payload[1:]) == "show session variables" {
+				h.handleShowVar()
+			} else {
+				h.handleCommon()
+			}
+		} else {
+			h.handleCommon()
+		}
 	}
+}
+
+func (h *testHandler) handleCommon() {
+	h.mysqlProto.SetSequenceID(1)
+	// set last insert id as connection id to do test more easily.
+	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeOKPayload(0, uint64(h.connID), 0, 0, ""))
+}
+
+func (h *testHandler) handleSetVar(packet *frontend.Packet) {
+	words := strings.Split(string(packet.Payload[1:]), " ")
+	v := strings.Split(words[2], "=")
+	h.sessionVars[v[0]] = strings.Trim(v[1], "'")
+	h.mysqlProto.SetSequenceID(1)
+	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeOKPayload(0, uint64(h.connID), 0, 0, ""))
+}
+
+func (h *testHandler) handleShowVar() {
+	h.mysqlProto.SetSequenceID(1)
+	err := h.mysqlProto.SendColumnCountPacket(2)
+	if err != nil {
+		_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeErrPayload(0, "", err.Error()))
+		return
+	}
+	cols := []*plan.ColDef{
+		{Typ: &plan.Type{Id: int32(types.T_char)}, Name: "Variable_name"},
+		{Typ: &plan.Type{Id: int32(types.T_char)}, Name: "Value"},
+	}
+	columns := make([]interface{}, len(cols))
+	res := &frontend.MysqlResultSet{}
+	for i, col := range cols {
+		c := new(frontend.MysqlColumn)
+		c.SetName(col.Name)
+		c.SetOrgName(col.Name)
+		c.SetTable(col.Typ.Table)
+		c.SetOrgTable(col.Typ.Table)
+		c.SetAutoIncr(col.Typ.AutoIncr)
+		c.SetSchema("")
+		c.SetDecimal(col.Typ.Scale)
+		columns[i] = c
+		res.AddColumn(c)
+	}
+	for _, c := range columns {
+		if err := h.mysqlProto.SendColumnDefinitionPacket(context.TODO(), c.(frontend.Column), 3); err != nil {
+			_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeErrPayload(0, "", err.Error()))
+			return
+		}
+	}
+	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeEOFPayload(0, 0))
+	for k, v := range h.sessionVars {
+		row := make([]interface{}, 2)
+		row[0] = k
+		row[1] = v
+		res.AddRow(row)
+	}
+	ses := &frontend.Session{}
+	ses.SetRequestContext(context.Background())
+	h.mysqlProto.SetSession(ses)
+	if err := h.mysqlProto.SendResultSetTextBatchRow(res, res.GetRowCount()); err != nil {
+		_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeErrPayload(0, "", err.Error()))
+		return
+	}
+	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeEOFPayload(0, 0))
 }
 
 func (s *testCNServer) Stop() error {
@@ -192,15 +291,11 @@ func TestServerConn_Create(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
 	addr := "127.0.0.1:38009"
-	cn1 := &CNServer{
-		reqLabel: newLabelInfo("t1", map[string]string{
-			"k1": "v1",
-			"k2": "v2",
-		}),
-		uuid: "cn11",
-		addr: addr,
-		salt: testSlat,
-	}
+	cn1 := testMakeCNServer("cn11", addr, 0, "", labelInfo{})
+	cn1.reqLabel = newLabelInfo("t1", map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	})
 	// server not started.
 	sc, err := newServerConn(cn1, nil, nil)
 	require.Error(t, err)
@@ -222,15 +317,11 @@ func TestServerConn_Create(t *testing.T) {
 func TestServerConn_Connect(t *testing.T) {
 	defer leaktest.AfterTest(t)
 	addr := "127.0.0.1:38090"
-	cn1 := &CNServer{
-		reqLabel: newLabelInfo("t1", map[string]string{
-			"k1": "v1",
-			"k2": "v2",
-		}),
-		uuid: "cn11",
-		addr: addr,
-		salt: testSlat,
-	}
+	cn1 := testMakeCNServer("cn11", addr, 0, "", labelInfo{})
+	cn1.reqLabel = newLabelInfo("t1", map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	})
 	tp := newTestProxyHandler(t)
 	defer tp.closeFn()
 	stopFn := startTestCNServer(t, tp.ctx, addr)
@@ -261,14 +352,11 @@ func TestFakeCNServer(t *testing.T) {
 	}()
 
 	li := labelInfo{}
-	cn1 := &CNServer{
-		reqLabel: newLabelInfo("t1", map[string]string{
-			"k1": "v1",
-			"k2": "v2",
-		}),
-		uuid: "cn11",
-		addr: "127.0.0.1:38009",
-	}
+	cn1 := testMakeCNServer("cn11", addr, 0, "", labelInfo{})
+	cn1.reqLabel = newLabelInfo("t1", map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	})
 
 	cleanup := testStartClient(t, tp, li, cn1)
 	defer cleanup()
@@ -278,15 +366,11 @@ func TestServerConn_ExecStmt(t *testing.T) {
 	defer leaktest.AfterTest(t)
 
 	addr := "127.0.0.1:38190"
-	cn1 := &CNServer{
-		reqLabel: newLabelInfo("t1", map[string]string{
-			"k1": "v1",
-			"k2": "v2",
-		}),
-		uuid: "cn11",
-		addr: addr,
-		salt: testSlat,
-	}
+	cn1 := testMakeCNServer("cn11", addr, 0, "", labelInfo{})
+	cn1.reqLabel = newLabelInfo("t1", map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	})
 	tp := newTestProxyHandler(t)
 	defer tp.closeFn()
 	stopFn := startTestCNServer(t, tp.ctx, addr)

--- a/pkg/proxy/tunnel.go
+++ b/pkg/proxy/tunnel.go
@@ -47,7 +47,7 @@ type tunnel struct {
 	cc ClientConn
 	// reqC is the event request channel. Events may be happened in tunnel data flow,
 	// and need to be handled in client connection.
-	reqC chan IEventReq
+	reqC chan IEvent
 	// respC is the event response channel.
 	respC chan []byte
 	// closeOnce controls the close function to close tunnel only once.
@@ -83,7 +83,7 @@ func newTunnel(ctx context.Context, logger *log.MOLogger, cs *counterSet) *tunne
 		logger:    logger,
 		errC:      make(chan error, 1),
 		// We need to handle events synchronously, so this channel has no buffer.
-		reqC: make(chan IEventReq),
+		reqC: make(chan IEvent),
 		// response channel should have buffer, because it is handled in the same
 		// for-select with reqC.
 		respC: make(chan []byte, 10),


### PR DESCRIPTION
Add session variable cn_label fro pipelien and keep session variables and user variables when transfer connection between CN servers.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9079 

## What this PR does / why we need it: