### PR TITLE
Add Location for Object's ColumnMeta

### DIFF
--- a/pkg/objectio/writer.go
+++ b/pkg/objectio/writer.go
@@ -155,7 +155,12 @@ func (w *objectWriterV1) prepareObjectMeta(objectMeta ObjectMeta, offset uint32)
 
 func (w *objectWriterV1) prepareBlockMeta(offset uint32) uint32 {
 	maxIndex := w.getMaxIndex()
+	var off, size, oSize uint32
 	for idx := uint16(0); idx < maxIndex; idx++ {
+		off = offset
+		size = 0
+		oSize = 0
+		alg := uint8(0)
 		for i, block := range w.blocks {
 			if block.meta.BlockHeader().ColumnCount() <= idx {
 				continue
@@ -164,7 +169,17 @@ func (w *objectWriterV1) prepareBlockMeta(offset uint32) uint32 {
 			location.SetOffset(offset)
 			w.blocks[i].meta.ColumnMeta(uint16(idx)).setLocation(location)
 			offset += location.Length()
+			size += location.Length()
+			oSize += location.OriginSize()
+			alg = location.Alg()
 		}
+		if uint16(len(w.colmeta)) <= idx {
+			continue
+		}
+		w.colmeta[idx].Location().SetAlg(alg)
+		w.colmeta[idx].Location().SetOffset(off)
+		w.colmeta[idx].Location().SetLength(size)
+		w.colmeta[idx].Location().SetOriginSize(oSize)
 	}
 	return offset
 }

--- a/pkg/vm/engine/tae/blockio/writer_test.go
+++ b/pkg/vm/engine/tae/blockio/writer_test.go
@@ -81,6 +81,16 @@ func TestWriter_WriteBlockAndZoneMap(t *testing.T) {
 	require.NoError(t, err)
 	meta, err := reader.LoadObjectMeta(context.TODO(), mp)
 	require.NoError(t, err)
+	blkMeta1 := meta.GetBlockMeta(0)
+	blkMeta2 := meta.GetBlockMeta(1)
+	for i := uint16(0); i < meta.BlockHeader().ColumnCount(); i++ {
+		offset := blkMeta1.ColumnMeta(i).Location().Offset()
+		length := blkMeta1.ColumnMeta(i).Location().Length() + blkMeta2.ColumnMeta(i).Location().Length()
+		oSize := blkMeta1.ColumnMeta(i).Location().OriginSize() + blkMeta2.ColumnMeta(i).Location().OriginSize()
+		assert.Equal(t, offset, meta.ObjectColumnMeta(i).Location().Offset())
+		assert.Equal(t, length, meta.ObjectColumnMeta(i).Location().Length())
+		assert.Equal(t, oSize, meta.ObjectColumnMeta(i).Location().OriginSize())
+	}
 	header := meta.BlockHeader()
 	require.Equal(t, uint32(80000), header.Rows())
 	t.Log(meta.ObjectColumnMeta(0).Ndv(), meta.ObjectColumnMeta(1).Ndv(), meta.ObjectColumnMeta(2).Ndv())


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Add offset and compressed size and original size info for Object's ColumnMeta