### PR TITLE
[refactor] hakeeper: Change the behavior of updating cn label.

### DIFF
--- a/pkg/clusterservice/cluster.go
+++ b/pkg/clusterservice/cluster.go
@@ -165,9 +165,8 @@ func (c *cluster) DebugUpdateCNLabel(uuid string, kvs map[string][]string) error
 		convert[k] = metadata.LabelList{Labels: v}
 	}
 	label := logpb.CNStoreLabel{
-		UUID:      uuid,
-		Operation: logpb.SetLabel,
-		Labels:    convert,
+		UUID:   uuid,
+		Labels: convert,
 	}
 	proxyClient := c.client.(logservice.ProxyHAKeeperClient)
 	if err := proxyClient.UpdateCNLabel(ctx, label); err != nil {

--- a/pkg/hakeeper/rsm_test.go
+++ b/pkg/hakeeper/rsm_test.go
@@ -656,8 +656,7 @@ func TestHandleUpdateCNLabel(t *testing.T) {
 	uuid := "uuid1"
 	tsm1 := NewStateMachine(0, 1).(*stateMachine)
 	label := pb.CNStoreLabel{
-		UUID:      uuid,
-		Operation: pb.SetLabel,
+		UUID: uuid,
 		Labels: map[string]metadata.LabelList{
 			"account": {Labels: []string{"a", "b"}},
 			"role":    {Labels: []string{"1", "2"}},
@@ -686,8 +685,7 @@ func TestHandleUpdateCNLabel(t *testing.T) {
 	assert.Equal(t, 1, len(s.Stores))
 
 	label = pb.CNStoreLabel{
-		UUID:      uuid,
-		Operation: pb.SetLabel,
+		UUID: uuid,
 		Labels: map[string]metadata.LabelList{
 			"account": {Labels: []string{"a", "b"}},
 			"role":    {Labels: []string{"1", "2"}},
@@ -709,10 +707,9 @@ func TestHandleUpdateCNLabel(t *testing.T) {
 	assert.Equal(t, labels.Labels, []string{"1", "2"})
 
 	label = pb.CNStoreLabel{
-		UUID:      uuid,
-		Operation: pb.DeleteLabel,
+		UUID: uuid,
 		Labels: map[string]metadata.LabelList{
-			"account": {Labels: []string{"a", "b"}},
+			"role": {Labels: []string{"1", "2"}},
 		},
 	}
 	cmd = GetUpdateCNLabelCmd(label)

--- a/pkg/logservice/hakeeper_client_test.go
+++ b/pkg/logservice/hakeeper_client_test.go
@@ -428,8 +428,7 @@ func TestHAKeeperClientUpdateCNLabel(t *testing.T) {
 		}()
 
 		label := pb.CNStoreLabel{
-			UUID:      s.ID(),
-			Operation: pb.SetLabel,
+			UUID: s.ID(),
 			Labels: map[string]metadata.LabelList{
 				"account": {Labels: []string{"a", "b"}},
 				"role":    {Labels: []string{"1", "2"}},
@@ -446,8 +445,7 @@ func TestHAKeeperClientUpdateCNLabel(t *testing.T) {
 		require.NoError(t, err)
 
 		label = pb.CNStoreLabel{
-			UUID:      s.ID(),
-			Operation: pb.SetLabel,
+			UUID: s.ID(),
 			Labels: map[string]metadata.LabelList{
 				"account": {Labels: []string{"a", "b"}},
 				"role":    {Labels: []string{"1", "2"}},
@@ -468,10 +466,9 @@ func TestHAKeeperClientUpdateCNLabel(t *testing.T) {
 		require.NoError(t, err)
 
 		label = pb.CNStoreLabel{
-			UUID:      s.ID(),
-			Operation: pb.DeleteLabel,
+			UUID: s.ID(),
 			Labels: map[string]metadata.LabelList{
-				"role": {Labels: []string{"1", "2"}},
+				"account": {Labels: []string{"a", "b"}},
 			},
 		}
 		err = c1.UpdateCNLabel(ctx, label)

--- a/pkg/logservice/service_test.go
+++ b/pkg/logservice/service_test.go
@@ -819,8 +819,7 @@ func TestServiceHandleCNUpdateLabel(t *testing.T) {
 		req := pb.Request{
 			Method: pb.UPDATE_CN_LABEL,
 			CNStoreLabel: &pb.CNStoreLabel{
-				UUID:      uuid,
-				Operation: pb.SetLabel,
+				UUID: uuid,
 				Labels: map[string]metadata.LabelList{
 					"account": {Labels: []string{"a", "b"}},
 					"role":    {Labels: []string{"1", "2"}},
@@ -848,8 +847,7 @@ func TestServiceHandleCNUpdateLabel(t *testing.T) {
 		req = pb.Request{
 			Method: pb.UPDATE_CN_LABEL,
 			CNStoreLabel: &pb.CNStoreLabel{
-				UUID:      uuid,
-				Operation: pb.SetLabel,
+				UUID: uuid,
 				Labels: map[string]metadata.LabelList{
 					"account": {Labels: []string{"a", "b"}},
 					"role":    {Labels: []string{"1", "2"}},
@@ -881,10 +879,9 @@ func TestServiceHandleCNUpdateLabel(t *testing.T) {
 		req = pb.Request{
 			Method: pb.UPDATE_CN_LABEL,
 			CNStoreLabel: &pb.CNStoreLabel{
-				UUID:      uuid,
-				Operation: pb.DeleteLabel,
+				UUID: uuid,
 				Labels: map[string]metadata.LabelList{
-					"account": {Labels: []string{}},
+					"role": {Labels: []string{"1", "2"}},
 				},
 			},
 		}

--- a/pkg/logservice/store_test.go
+++ b/pkg/logservice/store_test.go
@@ -575,8 +575,7 @@ func TestUpdateCNLabel(t *testing.T) {
 
 		uuid := "uuid1"
 		label := pb.CNStoreLabel{
-			UUID:      uuid,
-			Operation: pb.SetLabel,
+			UUID: uuid,
 			Labels: map[string]metadata.LabelList{
 				"account": {Labels: []string{"a", "b"}},
 				"role":    {Labels: []string{"1", "2"}},
@@ -593,8 +592,7 @@ func TestUpdateCNLabel(t *testing.T) {
 		assert.NoError(t, err)
 
 		label = pb.CNStoreLabel{
-			UUID:      uuid,
-			Operation: pb.SetLabel,
+			UUID: uuid,
 			Labels: map[string]metadata.LabelList{
 				"account": {Labels: []string{"a", "b"}},
 				"role":    {Labels: []string{"1", "2"}},
@@ -616,10 +614,9 @@ func TestUpdateCNLabel(t *testing.T) {
 		assert.Equal(t, labels2.Labels, []string{"1", "2"})
 
 		label = pb.CNStoreLabel{
-			UUID:      uuid,
-			Operation: pb.DeleteLabel,
+			UUID: uuid,
 			Labels: map[string]metadata.LabelList{
-				"role": {Labels: []string{"1", "2"}},
+				"account": {Labels: []string{"a", "b"}},
 			},
 		}
 		err = store.updateCNLabel(ctx, label)

--- a/pkg/pb/logservice/logservice.go
+++ b/pkg/pb/logservice/logservice.go
@@ -93,12 +93,7 @@ func (s *CNState) UpdateLabel(label CNStoreLabel) {
 	if !ok {
 		return
 	}
-	for k, v := range label.Labels {
-		storeInfo.Labels[k] = v
-		if label.Operation == DeleteLabel {
-			delete(storeInfo.Labels, k)
-		}
-	}
+	storeInfo.Labels = label.Labels
 	s.Stores[label.UUID] = storeInfo
 }
 

--- a/pkg/pb/logservice/logservice.pb.go
+++ b/pkg/pb/logservice/logservice.pb.go
@@ -1533,6 +1533,7 @@ type CNStoreLabel struct {
 	// UUID is the uuid of the CN store.
 	UUID string `protobuf:"bytes,1,opt,name=UUID,proto3" json:"UUID,omitempty"`
 	// Operation is the CN label operation.
+	// TODO(volgariver6): Unused field.
 	Operation CNLabelOp `protobuf:"varint,2,opt,name=Operation,proto3,enum=logservice.CNLabelOp" json:"Operation,omitempty"`
 	// Labels is the labels of the CN store.
 	Labels               map[string]metadata.LabelList `protobuf:"bytes,3,rep,name=Labels,proto3" json:"Labels" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`

--- a/pkg/pb/logservice/logservice_test.go
+++ b/pkg/pb/logservice/logservice_test.go
@@ -344,8 +344,7 @@ func TestCNLabelUpdate(t *testing.T) {
 	state := CNState{Stores: map[string]CNStoreInfo{}}
 
 	label := CNStoreLabel{
-		UUID:      "cn-1",
-		Operation: SetLabel,
+		UUID: "cn-1",
 		Labels: map[string]metadata.LabelList{
 			"account": {
 				Labels: []string{"a1", "a2"},
@@ -373,8 +372,7 @@ func TestCNLabelUpdate(t *testing.T) {
 	})
 
 	label = CNStoreLabel{
-		UUID:      "cn-1",
-		Operation: SetLabel,
+		UUID: "cn-1",
 		Labels: map[string]metadata.LabelList{
 			"account": {
 				Labels: []string{"a1", "a2"},
@@ -401,11 +399,10 @@ func TestCNLabelUpdate(t *testing.T) {
 	})
 
 	label = CNStoreLabel{
-		UUID:      "cn-1",
-		Operation: DeleteLabel,
+		UUID: "cn-1",
 		Labels: map[string]metadata.LabelList{
-			"account": {
-				Labels: []string{"a1", "a2"},
+			"role": {
+				Labels: []string{"r1"},
 			},
 		},
 	}

--- a/proto/logservice.proto
+++ b/proto/logservice.proto
@@ -226,6 +226,7 @@ message CNStoreLabel {
   // UUID is the uuid of the CN store.
   string UUID = 1;
   // Operation is the CN label operation.
+  // TODO(volgariver6): Unused field.
   CNLabelOp Operation = 2;
   // Labels is the labels of the CN store.
   map<string, metadata.LabelList> Labels = 3 [(gogoproto.nullable) = false];


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #9275 

## What this PR does / why we need it:
修改更新 cn label 的接口行为，移除 Delete 操作，只保留 Set 操作，每次 update 时更新全量的 cn label 信息。