### PR TITLE
[feat] determine the range of CNs for pipeline.

### DIFF
--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -312,7 +312,25 @@ func (cwft *TxnComputationWrapper) Compile(requestCtx context.Context, u interfa
 	}
 	cwft.proc.Ctx = txnCtx
 	cwft.proc.FileService = cwft.ses.GetParameterUnit().FileService
-	cwft.compile = compile.New(addr, cwft.ses.GetDatabaseName(), cwft.ses.GetSql(), cwft.ses.GetUserName(), txnCtx, cwft.ses.GetStorage(), cwft.proc, cwft.stmt)
+
+	var tenant string
+	tInfo := cwft.ses.GetTenantInfo()
+	if tInfo != nil {
+		tenant = tInfo.GetTenant()
+	}
+	cwft.compile = compile.New(
+		addr,
+		cwft.ses.GetDatabaseName(),
+		cwft.ses.GetSql(),
+		tenant,
+		cwft.ses.GetUserName(),
+		txnCtx,
+		cwft.ses.GetStorage(),
+		cwft.proc,
+		cwft.stmt,
+		cwft.ses.isInternal,
+		cwft.ses.getCNLabels(),
+	)
 
 	if _, ok := cwft.stmt.(*tree.ExplainAnalyze); ok {
 		fill = func(obj interface{}, bat *batch.Batch) error { return nil }

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -1689,3 +1689,25 @@ func (ses *Session) getLastCommitTS() timestamp.Timestamp {
 	}
 	return minTS
 }
+
+// getCNLabels parse the session variable and returns map[string]string.
+func (ses *Session) getCNLabels() map[string]string {
+	label, ok := ses.sysVars["cn_label"]
+	if !ok {
+		return nil
+	}
+	labelStr, ok := label.(string)
+	if !ok {
+		return nil
+	}
+	labels := strings.Split(labelStr, ",")
+	res := make(map[string]string, len(labels))
+	for _, kvStr := range labels {
+		kvs := strings.Split(kvStr, "=")
+		if len(kvs) != 2 {
+			continue
+		}
+		res[kvs[0]] = kvs[1]
+	}
+	return res
+}

--- a/pkg/frontend/test/engine_mock.go
+++ b/pkg/frontend/test/engine_mock.go
@@ -110,6 +110,20 @@ func (m *MockTableDef) EXPECT() *MockTableDefMockRecorder {
 	return m.recorder
 }
 
+// ToPBVersion mocks base method.
+func (m *MockTableDef) ToPBVersion() engine.TableDefPB {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ToPBVersion")
+	ret0, _ := ret[0].(engine.TableDefPB)
+	return ret0
+}
+
+// ToPBVersion indicates an expected call of ToPBVersion.
+func (mr *MockTableDefMockRecorder) ToPBVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToPBVersion", reflect.TypeOf((*MockTableDef)(nil).ToPBVersion))
+}
+
 // tableDef mocks base method.
 func (m *MockTableDef) tableDef() {
 	m.ctrl.T.Helper()
@@ -143,6 +157,20 @@ func NewMockConstraint(ctrl *gomock.Controller) *MockConstraint {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockConstraint) EXPECT() *MockConstraintMockRecorder {
 	return m.recorder
+}
+
+// ToPBVersion mocks base method.
+func (m *MockConstraint) ToPBVersion() engine.ConstraintPB {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ToPBVersion")
+	ret0, _ := ret[0].(engine.ConstraintPB)
+	return ret0
+}
+
+// ToPBVersion indicates an expected call of ToPBVersion.
+func (mr *MockConstraintMockRecorder) ToPBVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToPBVersion", reflect.TypeOf((*MockConstraint)(nil).ToPBVersion))
 }
 
 // constraint mocks base method.
@@ -820,18 +848,18 @@ func (mr *MockEngineMockRecorder) NewBlockReader(ctx, num, ts, expr, ranges, tbl
 }
 
 // Nodes mocks base method.
-func (m *MockEngine) Nodes() (engine.Nodes, error) {
+func (m *MockEngine) Nodes(isInternal bool, tenant string, cnLabel map[string]string) (engine.Nodes, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Nodes")
+	ret := m.ctrl.Call(m, "Nodes", isInternal, tenant, cnLabel)
 	ret0, _ := ret[0].(engine.Nodes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Nodes indicates an expected call of Nodes.
-func (mr *MockEngineMockRecorder) Nodes() *gomock.Call {
+func (mr *MockEngineMockRecorder) Nodes(isInternal, tenant, cnLabel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nodes", reflect.TypeOf((*MockEngine)(nil).Nodes))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nodes", reflect.TypeOf((*MockEngine)(nil).Nodes), isInternal, tenant, cnLabel)
 }
 
 // Rollback mocks base method.

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -70,19 +70,21 @@ const (
 )
 
 // New is used to new an object of compile
-func New(addr, db string, sql string, uid string, ctx context.Context,
-	e engine.Engine, proc *process.Process, stmt tree.Statement) *Compile {
+func New(addr, db string, sql string, tenant, uid string, ctx context.Context,
+	e engine.Engine, proc *process.Process, stmt tree.Statement, isInternal bool, cnLabel map[string]string) *Compile {
 	return &Compile{
-		e:    e,
-		db:   db,
-		ctx:  ctx,
-		uid:  uid,
-		sql:  sql,
-		proc: proc,
-		stmt: stmt,
-		addr: addr,
-
-		stepRegs: make(map[int32][]*process.WaitRegister),
+		e:          e,
+		db:         db,
+		ctx:        ctx,
+		tenant:     tenant,
+		uid:        uid,
+		sql:        sql,
+		proc:       proc,
+		stmt:       stmt,
+		addr:       addr,
+		stepRegs:   make(map[int32][]*process.WaitRegister),
+		isInternal: isInternal,
+		cnLabel:    cnLabel,
 	}
 }
 
@@ -418,7 +420,7 @@ func (c *Compile) compileAttachedScope(ctx context.Context, attachedPlan *plan.P
 
 func (c *Compile) compileQuery(ctx context.Context, qry *plan.Query) ([]*Scope, error) {
 	var err error
-	c.cnList, err = c.e.Nodes()
+	c.cnList, err = c.e.Nodes(c.isInternal, c.tenant, c.cnLabel)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -85,7 +85,7 @@ func TestCompile(t *testing.T) {
 	txnClient.EXPECT().New(gomock.Any(), gomock.Any()).Return(txnOperator, nil).AnyTimes()
 	for _, tc := range tcs {
 		tc.proc.TxnClient = txnClient
-		c := New("test", "test", tc.sql, "", context.TODO(), tc.e, tc.proc, tc.stmt)
+		c := New("test", "test", tc.sql, "", "", context.TODO(), tc.e, tc.proc, tc.stmt, false, nil)
 		err := c.Compile(ctx, tc.pn, nil, testPrint)
 		require.NoError(t, err)
 		c.GetAffectedRows()
@@ -103,7 +103,7 @@ func TestCompileWithFaults(t *testing.T) {
 	var ctx = context.Background()
 	fault.AddFaultPoint(ctx, "panic_in_batch_append", ":::", "panic", 0, "")
 	tc := newTestCase("select * from R join S on R.uid = S.uid", t)
-	c := New("test", "test", tc.sql, "", context.TODO(), tc.e, tc.proc, nil)
+	c := New("test", "test", tc.sql, "", "", context.TODO(), tc.e, tc.proc, nil, false, nil)
 	err := c.Compile(ctx, tc.pn, nil, testPrint)
 	require.NoError(t, err)
 	c.GetAffectedRows()

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -77,7 +77,7 @@ func generateScopeCases(t *testing.T, testCases []string) []*Scope {
 		require.NoError(t1, err)
 		qry, err := opt.Optimize(stmts[0])
 		require.NoError(t1, err)
-		c := New("test", "test", sql, "", context.Background(), e, proc, nil)
+		c := New("test", "test", sql, "", "", context.Background(), e, proc, nil, false, nil)
 		err = c.Compile(ctx, &plan.Plan{Plan: &plan.Plan_Query{Query: qry}}, nil, func(a any, batch *batch.Batch) error {
 			return nil
 		})

--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -167,6 +167,8 @@ type Compile struct {
 	addr string
 	// db current database name.
 	db string
+	// tenant is the account name.
+	tenant string
 	// uid the user who initiated the sql.
 	uid string
 	// sql sql text.
@@ -186,6 +188,10 @@ type Compile struct {
 	s3CounterSet perfcounter.CounterSet
 
 	stepRegs map[int32][]*process.WaitRegister
+
+	isInternal bool
+	// cnLabel is the CN labels which is parsed from session variable "cn_label".
+	cnLabel map[string]string
 }
 
 type RemoteReceivRegInfo struct {

--- a/pkg/vm/engine/entire_engine.go
+++ b/pkg/vm/engine/entire_engine.go
@@ -76,8 +76,10 @@ func (e *EntireEngine) Database(ctx context.Context, databaseName string, op cli
 	return e.Engine.Database(ctx, databaseName, op)
 }
 
-func (e *EntireEngine) Nodes() (cnNodes Nodes, err error) {
-	return e.Engine.Nodes()
+func (e *EntireEngine) Nodes(
+	isInternal bool, tenant string, cnLabel map[string]string) (cnNodes Nodes, err error,
+) {
+	return e.Engine.Nodes(isInternal, tenant, cnLabel)
 }
 
 func (e *EntireEngine) Hints() Hints {

--- a/pkg/vm/engine/entire_engine_test.go
+++ b/pkg/vm/engine/entire_engine_test.go
@@ -139,10 +139,10 @@ func TestEntireEngineDatabase(t *testing.T) {
 
 func TestEntireEngineNodes(t *testing.T) {
 	ee := buildEntireEngineWithoutTempEngine()
-	ee.Nodes()
+	ee.Nodes(false, "", nil)
 	assert.Equal(t, only_engine, ee.state)
 	ee = buildEntireEngineWithTempEngine()
-	ee.Nodes()
+	ee.Nodes(false, "", nil)
 	assert.Equal(t, only_engine, ee.state)
 }
 
@@ -270,7 +270,7 @@ func (e *testEngine) Database(ctx context.Context, name string, txnOp client.Txn
 	return nil, nil
 }
 
-func (e *testEngine) Nodes() (Nodes, error) {
+func (e *testEngine) Nodes(_ bool, _ string, _ map[string]string) (Nodes, error) {
 	e.parent.step = e.parent.step + 1
 	if e.name == origin {
 		e.parent.state = e.parent.state + e.parent.step*e.parent.state

--- a/pkg/vm/engine/memoryengine/binded.go
+++ b/pkg/vm/engine/memoryengine/binded.go
@@ -70,8 +70,8 @@ func (b *BindedEngine) New(ctx context.Context, _ client.TxnOperator) error {
 	return b.engine.New(ctx, b.txnOp)
 }
 
-func (b *BindedEngine) Nodes() (cnNodes engine.Nodes, err error) {
-	return b.engine.Nodes()
+func (b *BindedEngine) Nodes(isInternal bool, tenant string, cnLabel map[string]string) (cnNodes engine.Nodes, err error) {
+	return b.engine.Nodes(isInternal, tenant, cnLabel)
 }
 
 func (b *BindedEngine) Rollback(ctx context.Context, _ client.TxnOperator) error {

--- a/pkg/vm/engine/memoryengine/engine.go
+++ b/pkg/vm/engine/memoryengine/engine.go
@@ -16,6 +16,7 @@ package memoryengine
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
@@ -166,10 +167,16 @@ func (e *Engine) Delete(ctx context.Context, dbName string, txnOperator client.T
 	return nil
 }
 
-func (e *Engine) Nodes() (engine.Nodes, error) {
+func (e *Engine) Nodes(isInternal bool, tenant string, cnLabel map[string]string) (engine.Nodes, error) {
 	var nodes engine.Nodes
 	cluster := clusterservice.GetMOCluster()
-	cluster.GetCNService(clusterservice.NewSelector(),
+	var selector clusterservice.Selector
+	if isInternal || strings.ToLower(tenant) == "sys" {
+		selector = clusterservice.NewSelector()
+	} else {
+		selector = selector.SelectByLabel(cnLabel, clusterservice.EQ)
+	}
+	cluster.GetCNService(selector,
 		func(c metadata.CNService) bool {
 			nodes = append(nodes, engine.Node{
 				Mcpu: 1,

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -584,8 +584,9 @@ type Engine interface {
 	// Database creates a handle for a database
 	Database(ctx context.Context, databaseName string, op client.TxnOperator) (Database, error)
 
-	// Nodes returns all nodes for worker jobs
-	Nodes() (cnNodes Nodes, err error)
+	// Nodes returns all nodes for worker jobs. isInternal, tenant, cnLabel are
+	// used to filter CN servers.
+	Nodes(isInternal bool, tenant string, cnLabel map[string]string) (cnNodes Nodes, err error)
 
 	// Hints returns hints of engine features
 	// return value should not be cached


### PR DESCRIPTION
When get cn node list in compile phase, filter the nodes by cn label, which is stored in session variable "cn_label".

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9080 

## What this PR does / why we need it: