### PR TITLE
Resize multi-block hash table in place

### DIFF
--- a/pkg/common/hashmap/iterator.go
+++ b/pkg/common/hashmap/iterator.go
@@ -97,15 +97,15 @@ func (itr *intHashMapIterator) Insert(start, count int, vecs []*vector.Vector) (
 	copy(itr.mp.hashes[:count], zeroUint64[:count])
 	if itr.nbucket != 0 {
 		if itr.mp.hasNull {
-			err = itr.mp.hashMap.InsertBatchInBucket(count, itr.mp.hashes, unsafe.Pointer(&itr.mp.keys[0]), itr.mp.values, itr.ibucket, itr.nbucket, itr.m)
+			err = itr.mp.hashMap.InsertBatchInBucket(count, itr.mp.hashes[:count], unsafe.Pointer(&itr.mp.keys[0]), itr.mp.values, itr.ibucket, itr.nbucket, itr.m)
 		} else {
-			err = itr.mp.hashMap.InsertBatchWithRingInBucket(count, itr.mp.zValues, itr.mp.hashes, unsafe.Pointer(&itr.mp.keys[0]), itr.mp.values, itr.ibucket, itr.nbucket, itr.m)
+			err = itr.mp.hashMap.InsertBatchWithRingInBucket(count, itr.mp.zValues, itr.mp.hashes[:count], unsafe.Pointer(&itr.mp.keys[0]), itr.mp.values, itr.ibucket, itr.nbucket, itr.m)
 		}
 	} else {
 		if itr.mp.hasNull {
-			err = itr.mp.hashMap.InsertBatch(count, itr.mp.hashes, unsafe.Pointer(&itr.mp.keys[0]), itr.mp.values, itr.m)
+			err = itr.mp.hashMap.InsertBatch(count, itr.mp.hashes[:count], unsafe.Pointer(&itr.mp.keys[0]), itr.mp.values, itr.m)
 		} else {
-			err = itr.mp.hashMap.InsertBatchWithRing(count, itr.mp.zValues, itr.mp.hashes, unsafe.Pointer(&itr.mp.keys[0]), itr.mp.values, itr.m)
+			err = itr.mp.hashMap.InsertBatchWithRing(count, itr.mp.zValues, itr.mp.hashes[:count], unsafe.Pointer(&itr.mp.keys[0]), itr.mp.values, itr.m)
 		}
 	}
 	vs, zvs := itr.mp.values[:count], itr.mp.zValues[:count]

--- a/pkg/container/hashtable/bucket.go
+++ b/pkg/container/hashtable/bucket.go
@@ -28,7 +28,7 @@ func (ht *StringHashMap) InsertStringBatchInBucket(states [][3]uint64, keys [][]
 	BytesBatchGenHashStates(&keys[0], &states[0], len(keys))
 
 	for i := range keys {
-		if states[i][0]%nbucket != ibucket {
+		if states[i][1]%nbucket != ibucket {
 			values[i] = 0
 			continue
 		}
@@ -113,7 +113,7 @@ func (ht *StringHashMap) InsertStringBatchWithRingInBucket(zValues []int64, stat
 		if zValues[i] == 0 {
 			continue
 		}
-		if states[i][0]%nbucket != ibucket {
+		if states[i][1]%nbucket != ibucket {
 			values[i] = 0
 			continue
 		}
@@ -204,7 +204,7 @@ func (ht *StringHashMap) FindStringBatchInBucket(states [][3]uint64, keys [][]by
 	BytesBatchGenHashStates(&keys[0], &states[0], len(keys))
 
 	for i := range keys {
-		if states[i][0]%nbucket != ibucket {
+		if states[i][1]%nbucket != ibucket {
 			inBuckets[i] = 0 // mark of 0 means it is not in the processed bucket
 			continue
 		}
@@ -217,7 +217,7 @@ func (ht *StringHashMap) FindStringBatchWithRingInBucket(states [][3]uint64, zVa
 	BytesBatchGenHashStates(&keys[0], &states[0], len(keys))
 
 	for i := range keys {
-		if states[i][0]%nbucket != ibucket {
+		if states[i][1]%nbucket != ibucket {
 			inBuckets[i] = 0 // mark of 0 means it is not in the processed bucket
 			continue
 		}
@@ -239,17 +239,15 @@ func (ht *Int64HashMap) InsertBatchInBucket(n int, hashes []uint64, keysPtr unsa
 		Int64BatchHash(keysPtr, &hashes[0], n)
 	}
 
-	keys := unsafe.Slice((*uint64)(keysPtr), n)
-
-	for i, key := range keys {
-		if hashes[i]%nbucket != ibucket {
+	for i, hash := range hashes {
+		if (hashes[i]>>16)%nbucket != ibucket {
 			values[i] = 0
 			continue
 		}
-		cell := ht.findCell(hashes[i], key)
+		cell := ht.findCell(hash)
 		if cell.Mapped == 0 {
 			ht.elemCnt++
-			cell.Key = key
+			cell.Key = hash
 			cell.Mapped = ht.elemCnt
 		}
 		values[i] = cell.Mapped
@@ -266,19 +264,18 @@ func (ht *Int64HashMap) InsertBatchWithRingInBucket(n int, zValues []int64, hash
 		Int64BatchHash(keysPtr, &hashes[0], n)
 	}
 
-	keys := unsafe.Slice((*uint64)(keysPtr), n)
-	for i, key := range keys {
+	for i, hash := range hashes {
 		if zValues[i] == 0 {
 			continue
 		}
-		if hashes[i]%nbucket != ibucket {
+		if (hashes[i]>>16)%nbucket != ibucket {
 			values[i] = 0
 			continue
 		}
-		cell := ht.findCell(hashes[i], key)
+		cell := ht.findCell(hash)
 		if cell.Mapped == 0 {
 			ht.elemCnt++
-			cell.Key = key
+			cell.Key = hash
 			cell.Mapped = ht.elemCnt
 		}
 		values[i] = cell.Mapped
@@ -291,13 +288,12 @@ func (ht *Int64HashMap) FindBatchInBucket(n int, hashes []uint64, keysPtr unsafe
 		Int64BatchHash(keysPtr, &hashes[0], n)
 	}
 
-	keys := unsafe.Slice((*uint64)(keysPtr), n)
-	for i, key := range keys {
-		if hashes[i]%nbucket != ibucket {
+	for i, hash := range hashes {
+		if (hashes[i]>>16)%nbucket != ibucket {
 			inBuckets[i] = 0 // mark of 0 means it is not in the processed bucket
 			continue
 		}
-		cell := ht.findCell(hashes[i], key)
+		cell := ht.findCell(hash)
 		values[i] = cell.Mapped
 	}
 }
@@ -307,9 +303,8 @@ func (ht *Int64HashMap) FindBatchWithRingInBucket(n int, zValues []int64, hashes
 		Int64BatchHash(keysPtr, &hashes[0], n)
 	}
 
-	keys := unsafe.Slice((*uint64)(keysPtr), n)
-	for i, key := range keys {
-		if hashes[i]%nbucket != ibucket {
+	for i, hash := range hashes {
+		if (hashes[i]>>16)%nbucket != ibucket {
 			inBuckets[i] = 0 // mark of 0 means it is not in the processed bucket
 			continue
 		}
@@ -317,7 +312,7 @@ func (ht *Int64HashMap) FindBatchWithRingInBucket(n int, zValues []int64, hashes
 			values[i] = 0
 			continue
 		}
-		cell := ht.findCell(hashes[i], key)
+		cell := ht.findCell(hash)
 		values[i] = cell.Mapped
 	}
 }

--- a/pkg/container/hashtable/hash.go
+++ b/pkg/container/hashtable/hash.go
@@ -23,8 +23,7 @@ import (
 )
 
 var (
-	Int64BatchHash     = wyhashInt64Batch
-	Int64CellBatchHash = wyhashInt64CellBatch
+	Int64BatchHash = wyhashInt64Batch
 
 	BytesBatchGenHashStates  = wyhashBytesBatch
 	Int192BatchGenHashStates = wyhashInt192Batch
@@ -123,14 +122,6 @@ func wyhashInt64Batch(data unsafe.Pointer, hashes *uint64, length int) {
 
 	for i := 0; i < length; i++ {
 		hashSlice[i] = wyhash64(dataSlice[i], randseed)
-	}
-}
-
-func wyhashInt64CellBatch(data unsafe.Pointer, hashes *uint64, length int) {
-	dataSlice := unsafe.Slice((*Int64HashMapCell)(data), length)
-	hashSlice := unsafe.Slice(hashes, length)
-	for i := 0; i < length; i++ {
-		hashSlice[i] = wyhash64(dataSlice[i].Key, randseed)
 	}
 }
 

--- a/pkg/container/hashtable/hash_amd64.go
+++ b/pkg/container/hashtable/hash_amd64.go
@@ -21,7 +21,6 @@ import (
 )
 
 func crc32Int64BatchHash(data unsafe.Pointer, hashes *uint64, length int)
-func crc32Int64CellBatchHash(data unsafe.Pointer, hashes *uint64, length int)
 
 func aesBytesBatchGenHashStates(data *[]byte, states *[3]uint64, length int)
 func aesInt192BatchGenHashStates(data *[3]uint64, states *[3]uint64, length int)
@@ -31,7 +30,6 @@ func aesInt320BatchGenHashStates(data *[5]uint64, states *[3]uint64, length int)
 func init() {
 	if cpu.X86.HasSSE42 {
 		Int64BatchHash = crc32Int64BatchHash
-		Int64CellBatchHash = crc32Int64CellBatchHash
 	}
 
 	if cpu.X86.HasAES {

--- a/pkg/container/hashtable/hash_amd64.s
+++ b/pkg/container/hashtable/hash_amd64.s
@@ -25,6 +25,11 @@ loop:
 	SUBQ $8, CX
 	JL   tail
 
+	VMOVDQU (SI), Y0
+	VMOVDQU Y0, (DI)
+	VMOVDQU 0x20(SI), Y1
+	VMOVDQU Y1, 0x20(DI)
+
 	MOVQ $-1, R8
 	MOVQ $-1, R9
 	MOVQ $-1, R10
@@ -43,14 +48,14 @@ loop:
 	CRC32Q 0x30(SI), R14
 	CRC32Q 0x38(SI), R15
 
-	MOVQ R8, 0x00(DI)
-	MOVQ R9, 0x08(DI)
-	MOVQ R10, 0x10(DI)
-	MOVQ R11, 0x18(DI)
-	MOVQ R12, 0x20(DI)
-	MOVQ R13, 0x28(DI)
-	MOVQ R14, 0x30(DI)
-	MOVQ R15, 0x38(DI)
+	MOVL R8, 0x00(DI)
+	MOVL R9, 0x08(DI)
+	MOVL R10, 0x10(DI)
+	MOVL R11, 0x18(DI)
+	MOVL R12, 0x20(DI)
+	MOVL R13, 0x28(DI)
+	MOVL R14, 0x30(DI)
+	MOVL R15, 0x38(DI)
 
 	ADDQ $0x40, SI
 	ADDQ $0x40, DI
@@ -62,68 +67,12 @@ tail:
 
 tailLoop:
 	MOVQ   $-1, R8
+	MOVQ   (SI), R9
+	MOVQ   R9, (DI)
 	CRC32Q (SI), R8
-	MOVQ   R8, (DI)
+	MOVL   R8, (DI)
 
 	ADDQ $0x08, SI
-	ADDQ $0x08, DI
-	LOOP tailLoop
-
-done:
-	RET
-
-// func crc32Int64CellBatchHash(data *uint64, hashes *uint64, length int)
-// Requires: SSE4.2
-TEXT ·crc32Int64CellBatchHash(SB), NOSPLIT, $0-24
-	MOVQ data+0(FP), SI
-	MOVQ hashes+8(FP), DI
-	MOVQ length+16(FP), CX
-
-loop:
-	SUBQ $8, CX
-	JL   tail
-
-	MOVQ $-1, R8
-	MOVQ $-1, R9
-	MOVQ $-1, R10
-	MOVQ $-1, R11
-	MOVQ $-1, R12
-	MOVQ $-1, R13
-	MOVQ $-1, R14
-	MOVQ $-1, R15
-
-	CRC32Q 0x00(SI), R8
-	CRC32Q 0x10(SI), R9
-	CRC32Q 0x20(SI), R10
-	CRC32Q 0x30(SI), R11
-	CRC32Q 0x40(SI), R12
-	CRC32Q 0x50(SI), R13
-	CRC32Q 0x60(SI), R14
-	CRC32Q 0x70(SI), R15
-
-	MOVQ R8, 0x00(DI)
-	MOVQ R9, 0x08(DI)
-	MOVQ R10, 0x10(DI)
-	MOVQ R11, 0x18(DI)
-	MOVQ R12, 0x20(DI)
-	MOVQ R13, 0x28(DI)
-	MOVQ R14, 0x30(DI)
-	MOVQ R15, 0x38(DI)
-
-	ADDQ $0x80, SI
-	ADDQ $0x40, DI
-	JMP  loop
-
-tail:
-	ADDQ $8, CX
-	JE   done
-
-tailLoop:
-	MOVQ   $-1, R8
-	CRC32Q (SI), R8
-	MOVQ   R8, (DI)
-
-	ADDQ $0x10, SI
 	ADDQ $0x08, DI
 	LOOP tailLoop
 

--- a/pkg/container/hashtable/hash_arm64.go
+++ b/pkg/container/hashtable/hash_arm64.go
@@ -22,7 +22,6 @@ import (
 )
 
 func crc32Int64BatchHash(data unsafe.Pointer, hashes *uint64, length int)
-func crc32Int64CellBatchHash(data unsafe.Pointer, hashes *uint64, length int)
 
 func aesBytesBatchGenHashStates(data *[]byte, states *[3]uint64, length int)
 func aesInt192BatchGenHashStates(data *[3]uint64, states *[3]uint64, length int)
@@ -32,7 +31,6 @@ func aesInt320BatchGenHashStates(data *[5]uint64, states *[3]uint64, length int)
 func init() {
 	if cpu.ARM64.HasCRC32 || (runtime.GOARCH == "arm64" && runtime.GOOS == "darwin") {
 		Int64BatchHash = crc32Int64BatchHash
-		Int64CellBatchHash = crc32Int64CellBatchHash
 	}
 
 	if cpu.ARM64.HasAES || (runtime.GOARCH == "arm64" && runtime.GOOS == "darwin") {

--- a/pkg/container/hashtable/hash_arm64.s
+++ b/pkg/container/hashtable/hash_arm64.s
@@ -25,6 +25,9 @@ loop:
 	SUBS $8, R2
 	BLT  tail
 
+	VLD1 (R0), [V0.B16, V1.B16, V2.B16, V3.B16]
+	VST1 [V0.B16, V1.B16, V2.B16, V3.B16], (R1)
+
 	MOVD $-1, R3
 	MOVD $-1, R4
 	MOVD $-1, R5
@@ -48,10 +51,14 @@ loop:
 	CRC32CX R17, R9
 	CRC32CX R19, R10
 
-	STP.P (R3, R4), 16(R1)
-	STP.P (R5, R6), 16(R1)
-	STP.P (R7, R8), 16(R1)
-	STP.P (R9, R10), 16(R1)
+	MOVW.P R3, 8(R1)
+	MOVW.P R4, 8(R1)
+	MOVW.P R5, 8(R1)
+	MOVW.P R6, 8(R1)
+	MOVW.P R7, 8(R1)
+	MOVW.P R8, 8(R1)
+	MOVW.P R9, 8(R1)
+	MOVW.P R10, 8(R1)
 
 	JMP loop
 
@@ -61,70 +68,11 @@ tail:
 
 tailLoop:
 	MOVD    $-1, R3
+	MOVD    (R0), R5
 	MOVD.P  8(R0), R4
 	CRC32CX R4, R3
-	MOVD.P  R3, 8(R1)
-
-	SUBS $1, R2
-	BNE  tailLoop
-
-done:
-	RET
-
-// func crc32Int64CellBatchHash(data *uint64, hashes *uint64, length int)
-// Requires: CRC32
-TEXT ·crc32Int64CellBatchHash(SB), NOSPLIT, $0-24
-	MOVD data+0(FP), R0
-	MOVD hashes+8(FP), R1
-	MOVD length+16(FP), R2
-
-loop:
-	SUBS $8, R2
-	BLT  tail
-
-	MOVD $-1, R3
-	MOVD $-1, R4
-	MOVD $-1, R5
-	MOVD $-1, R6
-	MOVD $-1, R7
-	MOVD $-1, R8
-	MOVD $-1, R9
-	MOVD $-1, R10
-
-	MOVD.P 16(R0), R11
-	MOVD.P 16(R0), R12
-	MOVD.P 16(R0), R13
-	MOVD.P 16(R0), R14
-	MOVD.P 16(R0), R15
-	MOVD.P 16(R0), R16
-	MOVD.P 16(R0), R17
-	MOVD.P 16(R0), R19
-
-	CRC32CX R11, R3
-	CRC32CX R12, R4
-	CRC32CX R13, R5
-	CRC32CX R14, R6
-	CRC32CX R15, R7
-	CRC32CX R16, R8
-	CRC32CX R17, R9
-	CRC32CX R19, R10
-
-	STP.P (R3, R4), 16(R1)
-	STP.P (R5, R6), 16(R1)
-	STP.P (R7, R8), 16(R1)
-	STP.P (R9, R10), 16(R1)
-
-	JMP loop
-
-tail:
-	ADDS $8, R2
-	BEQ  done
-
-tailLoop:
-	MOVD    $-1, R4
-	MOVD.P  16(R0), R3
-	CRC32CX R3, R4
-	MOVD.P  R4, 8(R1)
+	MOVD    R5, (R1)
+	MOVW.P  R3, 8(R1)
 
 	SUBS $1, R2
 	BNE  tailLoop


### PR DESCRIPTION
Total memory allocation in hash table reduced from 39.6GB to 25.3GB for TPCH Q18 SF=100.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9380

## What this PR does / why we need it: