### PR TITLE
implement collect new account storage_usage metric in shorter time

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -124,6 +124,9 @@ var (
 	// defaultMetricUpdateStorageUsageInterval default: 15 min.
 	defaultMetricUpdateStorageUsageInterval = 15 * time.Minute
 
+	// defaultMetricStorageUsageCheckNewInterval default: 1 min
+	defaultMetricStorageUsageCheckNewInterval = time.Minute
+
 	// defaultMergeCycle default: 4 hours
 	defaultMergeCycle = 4 * time.Hour
 
@@ -555,8 +558,11 @@ type ObservabilityParameters struct {
 	// MetricGatherInterval default is 15 sec.
 	MetricGatherInterval int `toml:"metricGatherInterval"`
 
-	// MetricUpdateStorageUsageInterval, default: 30 min
-	MetricUpdateStorageUsageInterval toml.Duration `toml:"metricUpdateStorageUsageInterval"`
+	// MetricStorageUsageUpdateInterval, default: 30 min
+	MetricStorageUsageUpdateInterval toml.Duration `toml:"metricStorageUsageUpdateInterval"`
+
+	// MetricStorageUsageCheckNewInterval, default: 1 min
+	MetricStorageUsageCheckNewInterval toml.Duration `toml:"metricStorageUsageCheckNewInterval"`
 
 	// MergeCycle default: 14400 sec (4 hours).
 	// PS: only used while MO init.
@@ -606,8 +612,12 @@ func (op *ObservabilityParameters) SetDefaultValues(version string) {
 		op.MetricGatherInterval = defaultMetricGatherInterval
 	}
 
-	if op.MetricUpdateStorageUsageInterval.Duration <= 0 {
-		op.MetricUpdateStorageUsageInterval.Duration = defaultMetricUpdateStorageUsageInterval
+	if op.MetricStorageUsageUpdateInterval.Duration <= 0 {
+		op.MetricStorageUsageUpdateInterval.Duration = defaultMetricUpdateStorageUsageInterval
+	}
+
+	if op.MetricStorageUsageCheckNewInterval.Duration <= 0 {
+		op.MetricStorageUsageCheckNewInterval.Duration = defaultMetricStorageUsageCheckNewInterval
 	}
 
 	if op.MergeCycle.Duration <= 0 {

--- a/pkg/util/export/batch_processor.go
+++ b/pkg/util/export/batch_processor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/util/batchpipe"
+	"github.com/matrixorigin/matrixone/pkg/util/errutil"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace"
 
@@ -315,7 +316,8 @@ func (c *MOCollector) Register(name batchpipe.HasName, impl motrace.PipeImpl) {
 func (c *MOCollector) Collect(ctx context.Context, item batchpipe.HasName) error {
 	select {
 	case <-c.stopCh:
-		return moerr.NewInternalError(ctx, "stopped")
+		ctx = errutil.ContextWithNoReport(ctx, true)
+		return moerr.NewInternalError(ctx, "MOCollector stopped")
 	case c.awakeCollect <- item:
 		return nil
 	}

--- a/pkg/util/metric/mometric/metric.go
+++ b/pkg/util/metric/mometric/metric.go
@@ -68,7 +68,8 @@ func InitMetric(ctx context.Context, ieFactory func() ie.InternalExecutor, SV *c
 	var initOpts InitOptions
 	opts = append(opts,
 		withExportInterval(SV.MetricExportInterval),
-		withUpdateInterval(SV.MetricUpdateStorageUsageInterval.Duration),
+		withUpdateInterval(SV.MetricStorageUsageUpdateInterval.Duration),
+		withCheckNewInterval(SV.MetricStorageUsageCheckNewInterval.Duration),
 		withMultiTable(SV.MetricMultiTable),
 	)
 	for _, opt := range opts {
@@ -116,6 +117,7 @@ func InitMetric(ctx context.Context, ieFactory func() ie.InternalExecutor, SV *c
 	}
 
 	metric.SetUpdateStorageUsageInterval(initOpts.updateInterval)
+	metric.SetStorageUsageCheckNewInterval(initOpts.checkNewInterval)
 	logutil.Infof("metric with ExportInterval: %v", initOpts.exportInterval)
 	logutil.Infof("metric with UpdateStorageUsageInterval: %v", initOpts.updateInterval)
 }
@@ -292,6 +294,9 @@ type InitOptions struct {
 	// updateInterval, update StorageUsage interval
 	// set by withUpdateInterval
 	updateInterval time.Duration
+	// checkNewAccountInterval, check new account Internal to collect new account for metric StorageUsage
+	// set by withCheckNewInterval
+	checkNewInterval time.Duration
 }
 
 type InitOption func(*InitOptions)
@@ -327,6 +332,12 @@ func withExportInterval(sec int) InitOption {
 func withUpdateInterval(interval time.Duration) InitOption {
 	return InitOption(func(opts *InitOptions) {
 		opts.updateInterval = interval
+	})
+}
+
+func withCheckNewInterval(interval time.Duration) InitOption {
+	return InitOption(func(opts *InitOptions) {
+		opts.checkNewInterval = interval
 	})
 }
 

--- a/pkg/util/metric/test/cron_task_test.go
+++ b/pkg/util/metric/test/cron_task_test.go
@@ -64,6 +64,10 @@ func TestCalculateStorageUsage(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
 	defer cancel()
 
+	c.WaitCNStoreTaskServiceCreatedIndexed(ctx, 0)
+	c.WaitDNStoreTaskServiceCreatedIndexed(ctx, 0)
+	c.WaitLogStoreTaskServiceCreatedIndexed(ctx, 0)
+
 	ctrl := gomock.NewController(t)
 	txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
 	txnOperator.EXPECT().Txn().Return(txn.TxnMeta{}).AnyTimes()
@@ -76,7 +80,7 @@ func TestCalculateStorageUsage(t *testing.T) {
 	table.EXPECT().TableDefs(gomock.Any()).Return(nil, nil).AnyTimes()
 	table.EXPECT().GetPrimaryKeys(gomock.Any()).Return(nil, nil).AnyTimes()
 	table.EXPECT().GetHideKeys(gomock.Any()).Return(nil, nil).AnyTimes()
-	table.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(100), int64(1000000), int64(1000000), nil).AnyTimes()
+	//table.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(int32(100), int64(1000000), int64(1000000), nil).AnyTimes()
 	table.EXPECT().TableColumns(gomock.Any()).Return(nil, nil).AnyTimes()
 	table.EXPECT().GetTableID(gomock.Any()).Return(uint64(10)).AnyTimes()
 	db := mock_frontend.NewMockDatabase(ctrl)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/528

## What this PR does / why we need it:

implement check-new-account loop
1. accept new config item `metricStorageUsageCheckNewInterval`
2. check new account regularly, and collect new account's storage usage metric.