### PR TITLE
fix logtail hung in close stream

### DIFF
--- a/pkg/vm/engine/tae/logtail/service/client.go
+++ b/pkg/vm/engine/tae/logtail/service/client.go
@@ -68,7 +68,7 @@ func NewLogtailClient(stream morpc.Stream, opts ...ClientOption) (*LogtailClient
 
 // Close closes stream.
 func (c *LogtailClient) Close() error {
-	return c.stream.Close(false)
+	return c.stream.Close(true)
 }
 
 // Subscribe subscribes table.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
The logtail client will close the stream when it encounters an error. if the stream's server is still sending messages to the stream, it will fill up the stream's channal and cause a deadlock when it closes.