### PR TITLE
fix the output of explain

### DIFF
--- a/pkg/sql/plan/explain/explain_expr.go
+++ b/pkg/sql/plan/explain/explain_expr.go
@@ -62,9 +62,9 @@ func describeExpr(ctx context.Context, expr *plan.Expr, options *ExplainOptions,
 		case *plan.Const_U64Val:
 			fmt.Fprintf(buf, "%d", val.U64Val)
 		case *plan.Const_Fval:
-			fmt.Fprintf(buf, "%.32f", val.Fval)
+			fmt.Fprintf(buf, "%v", strconv.FormatFloat(float64(val.Fval), 'f', -1, 32))
 		case *plan.Const_Dval:
-			fmt.Fprintf(buf, "%.64f", val.Dval)
+			fmt.Fprintf(buf, "%v", strconv.FormatFloat(val.Dval, 'f', -1, 64))
 		case *plan.Const_Sval:
 			buf.WriteString("'" + val.Sval + "'")
 		case *plan.Const_Bval:


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
change the output of explain to this: Filter Cond: (lineorder.lo_discount >= 1)
instead of this:  Filter Cond: (lineorder.lo_discount >= 1.0000000000000000000000000000000000000000000000000000000000000000)