### PR TITLE
[refactor] proxy: change the action of drop account.

### DIFF
--- a/pkg/proxy/event_test.go
+++ b/pkg/proxy/event_test.go
@@ -114,14 +114,14 @@ func TestMakeEvent(t *testing.T) {
 			dst: n1,
 		})
 		require.NotNil(t, e)
-		require.True(t, r)
+		require.False(t, r)
 
 		e, r = makeEvent(&eventReq{
 			msg: makeSimplePacket("alter account if exists  a1 suspend"),
 			dst: n1,
 		})
 		require.NotNil(t, e)
-		require.True(t, r)
+		require.False(t, r)
 
 		e, r = makeEvent(&eventReq{
 			msg: makeSimplePacket("alter1 account a1 suspend"),
@@ -140,14 +140,14 @@ func TestMakeEvent(t *testing.T) {
 			dst: n1,
 		})
 		require.NotNil(t, e)
-		require.True(t, r)
+		require.False(t, r)
 
 		e, r = makeEvent(&eventReq{
 			msg: makeSimplePacket("drop account if exists a1"),
 			dst: n1,
 		})
 		require.NotNil(t, e)
-		require.True(t, r)
+		require.False(t, r)
 
 		e, r = makeEvent(&eventReq{
 			msg: makeSimplePacket("dr1op account a1"),

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -73,7 +73,7 @@ func NewServer(ctx context.Context, config Config, opts ...Option) (*Server, err
 		goetty.WithAppLogger(s.runtime.Logger().RawLogger()),
 		goetty.WithAppHandleSessionFunc(s.handler.handle),
 		goetty.WithAppSessionOptions(
-			goetty.WithSessionCodec(frontend.NewSqlCodec()),
+			goetty.WithSessionCodec(WithProxyProtocolCodec(frontend.NewSqlCodec())),
 			goetty.WithSessionLogger(s.runtime.Logger().RawLogger()),
 		),
 	)

--- a/pkg/proxy/tunnel.go
+++ b/pkg/proxy/tunnel.go
@@ -480,10 +480,3 @@ func (p *pipe) pause(ctx context.Context) error {
 	}
 	return nil
 }
-
-// inTxn returns if the session is in a txn.
-func (p *pipe) inTxn() bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.mu.inTxn
-}


### PR DESCRIPTION
Send the drop account statement to backend directly instead of execute it in a new connection. And whatever its result is, trigger the kill connection operation.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: