### PR TITLE
Remove some wrong mpool use in agg

### DIFF
--- a/pkg/sql/colexec/agg/distagg.go
+++ b/pkg/sql/colexec/agg/distagg.go
@@ -429,11 +429,10 @@ func (a *UnaryDistAgg[T1, T2]) UnmarshalBinary(data []byte) error {
 	setDistAggValues[T1, T2](a, a.otyp)
 	a.srcs = decode.Srcs
 	a.maps = make([]*hashmap.StrHashMap, len(a.srcs))
-	m := mpool.MustNewZeroNoFixed()
+	m := mpool.MustNewZeroNoFixed() // this is a hack, will remove later
 	for i, src := range a.srcs {
 		mp, err := hashmap.NewStrMap(true, 0, 0, m)
 		if err != nil {
-			m.Free(data)
 			for j := 0; j < i; j++ {
 				a.maps[j].Free()
 			}

--- a/pkg/sql/colexec/multi_col/group_concat/group_concat.go
+++ b/pkg/sql/colexec/multi_col/group_concat/group_concat.go
@@ -84,19 +84,15 @@ func (gc *GroupConcat) MarshalBinary() (data []byte, err error) {
 
 // encoding.BinaryUnmarshaler
 func (gc *GroupConcat) UnmarshalBinary(data []byte) error {
+	var err error
+
 	eg := &EncodeGroupConcat{}
 	types.Decode(data, eg)
 	m := mpool.MustNewZeroNoFixed()
-	da1, err := m.Alloc(len(eg.InsertsStrData))
-	if err != nil {
-		return err
-	}
+	da1 := make([]byte, len(eg.InsertsStrData))
 	copy(da1, eg.InsertsStrData)
 	gc.inserts = types.DecodeStringSlice(da1)
-	da2, err := m.Alloc(len(eg.ResStrData))
-	if err != nil {
-		return err
-	}
+	da2 := make([]byte, len(eg.ResStrData))
 	copy(da2, eg.ResStrData)
 	gc.res = types.DecodeStringSlice(da2)
 	gc.arg = eg.Arg


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

1. remove an illegal free in the distinct aggregate
2.  remove two illegal alloc in the group_concat