### PR TITLE
fix bvt case remove mo-tester exec mo_ctl records

### DIFF
--- a/test/distributed/cases/result_count/result_count.result
+++ b/test/distributed/cases/result_count/result_count.result
@@ -1,3 +1,4 @@
+create account result_count admin_name 'test_account' identified by '111';
 begin;
 rollback;
 commit;
@@ -136,11 +137,10 @@ select * from unnest('{"a":1}') as f;
 col    seq    key    path    index    value    this
 UNNEST_DEFAULT    0    a    $.a    null    1    {"a": 1}
 use system;
-create account test_tenant_1 admin_name 'test_account' identified by '111';
 select sleep(16);
 sleep(16)
 0
-select statement, result_count from statement_info where user="dump" and statement not like '%mo_ctl%' order by request_at desc limit 76;
+select statement, result_count from statement_info where user="result_count" order by request_at desc limit 76;
 statement    result_count
 create account test_tenant_1 admin_name 'test_account' identified by '******'    0
 use system    0
@@ -218,4 +218,4 @@ commit    0
 start transaction    0
 commit    0
 rollback    0
-drop account test_tenant_1;
+drop account result_count;

--- a/test/distributed/cases/result_count/result_count.result
+++ b/test/distributed/cases/result_count/result_count.result
@@ -1,4 +1,5 @@
-create account result_count admin_name 'admin' identified by '111';
+drop account if exists bvt_result_count;
+create account bvt_result_count admin_name 'admin' identified by '111';
 begin;
 rollback;
 commit;
@@ -62,9 +63,6 @@ drop view v1;
 drop table t1;
 drop view v2;
 drop database db1;
-create account test_tenant_1 admin_name 'test_account' identified by '111';
-drop account test_tenant_1;
-create account test_account admin_name = 'test_name' identified by '111' open comment 'tenant_test';
 create role test_role;
 create user user_name identified by 'password';
 create database if not exists db1;
@@ -72,7 +70,6 @@ grant create table,drop table on database *.* to test_role;
 revoke test_role from user_name;
 drop user user_name;
 drop role test_role;
-drop account test_account;
 drop database db1;
 create database db2;
 use db2;
@@ -137,12 +134,14 @@ select * from unnest('{"a":1}') as f;
 col    seq    key    path    index    value    this
 UNNEST_DEFAULT    0    a    $.a    null    1    {"a": 1}
 use system;
+/* cloud_user */create account test_tenant_1 admin_name 'test_account' identified by '111';
+/* cloud_user */drop account test_tenant_1;
 select sleep(16);
 sleep(16)
 0
-select statement, result_count from statement_info where account="result_count" and statement not like '%mo_ctl%' order by request_at desc limit 76;
+use system;
+select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' order by request_at desc limit 70;
 statement    result_count
-create account test_tenant_1 admin_name 'test_account' identified by '******'    0
 use system    0
 select * from unnest('{"a":1}') as f    1
 WITH cte1 AS (SELECT 1),cte2 AS (SELECT 2) SELECT * FROM cte1 join cte2    1
@@ -174,7 +173,6 @@ create table t2(a int, b varchar)    0
 use db2    0
 create database db2    0
 drop database db1    0
-drop account test_account    0
 drop role test_role    0
 drop user user_name    0
 revoke test_role from user_name    0
@@ -182,9 +180,6 @@ grant create table,drop table on database *.* to test_role    0
 create database if not exists db1    0
 create user user_name identified by '******'    0
 create role test_role    0
-create account test_account admin_name = 'test_name' identified by '******' open comment 'tenant_test'    0
-drop account test_tenant_1    0
-create account test_tenant_1 admin_name 'test_account' identified by '******'    0
 drop database db1    0
 drop view v2    0
 drop table t1    0
@@ -197,8 +192,6 @@ show tables    3
 show databases like 'mysql'    1
 deallocate prepare s2    0
 deallocate prepare s2    0
-execute s2 using @a    0
-execute s1 using @a    2
 prepare s2 from "select * from t1 where a=?"    0
 prepare s1 from "select * from t1 where a>?"    0
 set @a=1    0
@@ -218,4 +211,9 @@ commit    0
 start transaction    0
 commit    0
 rollback    0
-drop account result_count;
+begin    0
+select statement, result_count from statement_info where user="dump" and sql_source_type="cloud_user_sql" order by request_at desc limit 2;
+statement    result_count
+drop account test_tenant_1    0
+create account test_tenant_1 admin_name 'test_account' identified by '******'    0
+drop account if exists bvt_result_count;

--- a/test/distributed/cases/result_count/result_count.result
+++ b/test/distributed/cases/result_count/result_count.result
@@ -1,4 +1,4 @@
-create account result_count admin_name 'test_account' identified by '111';
+create account result_count admin_name 'admin' identified by '111';
 begin;
 rollback;
 commit;
@@ -140,7 +140,7 @@ use system;
 select sleep(16);
 sleep(16)
 0
-select statement, result_count from statement_info where user="result_count" and statement not like '%mo_ctl%' order by request_at desc limit 76;
+select statement, result_count from statement_info where account="result_count" and statement not like '%mo_ctl%' order by request_at desc limit 76;
 statement    result_count
 create account test_tenant_1 admin_name 'test_account' identified by '******'    0
 use system    0

--- a/test/distributed/cases/result_count/result_count.result
+++ b/test/distributed/cases/result_count/result_count.result
@@ -140,7 +140,7 @@ use system;
 select sleep(16);
 sleep(16)
 0
-select statement, result_count from statement_info where user="result_count" order by request_at desc limit 76;
+select statement, result_count from statement_info where user="result_count" and statement not like '%mo_ctl%' order by request_at desc limit 76;
 statement    result_count
 create account test_tenant_1 admin_name 'test_account' identified by '******'    0
 use system    0

--- a/test/distributed/cases/result_count/result_count.sql
+++ b/test/distributed/cases/result_count/result_count.sql
@@ -104,9 +104,9 @@ select * from unnest('{"a":1}') as f;
 use system;
 -- @session
 
--- check result
+-- result check
 select sleep(16);
-select statement, result_count from statement_info where user="result_count" order by request_at desc limit 76;
+select statement, result_count from statement_info where user="result_count" and statement not like '%mo_ctl%' order by request_at desc limit 76;
 
 -- cleanup
 drop account result_count;

--- a/test/distributed/cases/result_count/result_count.sql
+++ b/test/distributed/cases/result_count/result_count.sql
@@ -1,8 +1,9 @@
 -- prepare
-create account result_count admin_name 'admin' identified by '111';
+drop account if exists bvt_result_count;
+create account bvt_result_count admin_name 'admin' identified by '111';
 
--- testcase
--- @session:id=2&user=result_count:admin&password=111
+-- case 1
+-- @session:id=2&user=bvt_result_count:admin&password=111
 -- transaction sql
 begin;
 rollback;
@@ -31,8 +32,10 @@ set @a=1;
 prepare s1 from "select * from t1 where a>?";
 prepare s2 from "select * from t1 where a=?";
 
+-- @bvt:issue#9525
 execute s1 using @a;
 execute s2 using @a;
+-- @bvt:issue
 
 deallocate prepare s2;
 deallocate prepare s2;
@@ -51,12 +54,7 @@ drop table t1;
 drop view v2;
 drop database db1;
 
--- test create/drop account
-create account test_tenant_1 admin_name 'test_account' identified by '111';
-drop account test_tenant_1;
-
 -- test DCL sql
-create account test_account admin_name = 'test_name' identified by '111' open comment 'tenant_test';
 create role test_role;
 create user user_name identified by 'password';
 create database if not exists db1;
@@ -64,7 +62,6 @@ grant create table,drop table on database *.* to test_role;
 revoke test_role from user_name;
 drop user user_name;
 drop role test_role;
-drop account test_account;
 drop database db1;
 
 -- test transaction (insert/delete/update/select)
@@ -103,11 +100,22 @@ WITH cte1 AS (SELECT 1),cte2 AS (SELECT 2) SELECT * FROM cte1 join cte2;
 select * from unnest('{"a":1}') as f;
 use system;
 -- @session
+-- case 1: END
+
+-- case 2: 通过dump 账号测试 create account/drop account
+-- test create/drop account
+/* cloud_user */create account test_tenant_1 admin_name 'test_account' identified by '111';
+/* cloud_user */drop account test_tenant_1;
+-- case 2: END
 
 -- result check
 select sleep(16);
-select statement, result_count from statement_info where account="result_count" and statement not like '%mo_ctl%' order by request_at desc limit 76;
+use system;
+-- check case 1
+select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' order by request_at desc limit 70;
+-- check case 2
+select statement, result_count from statement_info where user="dump" and sql_source_type="cloud_user_sql" order by request_at desc limit 2;
 
 -- cleanup
-drop account result_count;
+drop account if exists bvt_result_count;
 

--- a/test/distributed/cases/result_count/result_count.sql
+++ b/test/distributed/cases/result_count/result_count.sql
@@ -1,8 +1,8 @@
 -- prepare
-create account result_count admin_name 'result_count' identified by '111';
+create account result_count admin_name 'admin' identified by '111';
 
 -- testcase
--- @session:id=2&user=result_count:result_count&password=111
+-- @session:id=2&user=result_count:admin&password=111
 -- transaction sql
 begin;
 rollback;
@@ -106,7 +106,7 @@ use system;
 
 -- result check
 select sleep(16);
-select statement, result_count from statement_info where user="result_count" and statement not like '%mo_ctl%' order by request_at desc limit 76;
+select statement, result_count from statement_info where account="result_count" and statement not like '%mo_ctl%' order by request_at desc limit 76;
 
 -- cleanup
 drop account result_count;

--- a/test/distributed/cases/result_count/result_count.sql
+++ b/test/distributed/cases/result_count/result_count.sql
@@ -1,3 +1,8 @@
+-- prepare
+create account result_count admin_name 'result_count' identified by '111';
+
+-- testcase
+-- @session:id=2&user=result_count:result_count&password=111
 -- transaction sql
 begin;
 rollback;
@@ -97,13 +102,12 @@ values row(1,1), row(2,2), row(3,3) order by column_0 desc;
 WITH cte1 AS (SELECT 1),cte2 AS (SELECT 2) SELECT * FROM cte1 join cte2;
 select * from unnest('{"a":1}') as f;
 use system;
-
--- test_tenant_1 wait 15s
-create account test_tenant_1 admin_name 'test_account' identified by '111';
--- @session:id=2&user=test_tenant_1:test_account&password=111
-select sleep(16);
 -- @session
 
-select statement, result_count from statement_info where user="dump" and statement not like '%mo_ctl%' order by request_at desc limit 76;
-drop account test_tenant_1;
+-- check result
+select sleep(16);
+select statement, result_count from statement_info where user="result_count" order by request_at desc limit 76;
+
+-- cleanup
+drop account result_count;
 

--- a/test/distributed/cases/sql_source_type/sql_source_type.result
+++ b/test/distributed/cases/sql_source_type/sql_source_type.result
@@ -11,7 +11,7 @@ a
 select sleep(16);
 sleep(16)
 0
-select statement, sql_source_type from system.statement_info where user="sql_source_type" order by request_at desc limit 4;
+select statement, sql_source_type from system.statement_info where user="sql_source_type" and statement not like '%mo_ctl%' order by request_at desc limit 4;
 statement    sql_source_type
 show tables    cloud_user_sql
 use system    cloud_nonuser_sql

--- a/test/distributed/cases/sql_source_type/sql_source_type.result
+++ b/test/distributed/cases/sql_source_type/sql_source_type.result
@@ -1,4 +1,4 @@
-create account if not exists `sql_source_type` ADMIN_NAME 'sql_source_type' IDENTIFIED BY '123456';
+create account if not exists `sql_source_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
 create database if not exists ssb;
 use ssb;
 /* cloud_user */drop table if exists __mo_t1;
@@ -11,7 +11,7 @@ a
 select sleep(16);
 sleep(16)
 0
-select statement, sql_source_type from system.statement_info where user="sql_source_type" and statement not like '%mo_ctl%' order by request_at desc limit 4;
+select statement, sql_source_type from system.statement_info where account="sql_source_type" and statement not like '%mo_ctl%' order by request_at desc limit 4;
 statement    sql_source_type
 show tables    cloud_user_sql
 use system    cloud_nonuser_sql

--- a/test/distributed/cases/sql_source_type/sql_source_type.result
+++ b/test/distributed/cases/sql_source_type/sql_source_type.result
@@ -1,4 +1,6 @@
 create account if not exists `sql_source_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+create database if not exists ssb;
+use ssb;
 /* cloud_user */drop table if exists __mo_t1;
 /* cloud_nonuser */ create table __mo_t1(a int);
 insert into __mo_t1 values(1);
@@ -9,7 +11,7 @@ a
 select sleep(16);
 sleep(16)
 0
-select statement, sql_source_type from system.statement_info where user="dump" and statement not like '%mo_ctl%' order by request_at desc limit 4;
+select statement, sql_source_type from system.statement_info where account="sql_source_type" order by request_at desc limit 4;
 statement    sql_source_type
 show tables    cloud_user_sql
 use system    cloud_nonuser_sql

--- a/test/distributed/cases/sql_source_type/sql_source_type.result
+++ b/test/distributed/cases/sql_source_type/sql_source_type.result
@@ -1,4 +1,5 @@
-create account if not exists `sql_source_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+drop account if exists bvt_sql_source_type;
+create account if not exists `bvt_sql_source_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
 create database if not exists ssb;
 use ssb;
 /* cloud_user */drop table if exists __mo_t1;
@@ -11,10 +12,10 @@ a
 select sleep(16);
 sleep(16)
 0
-select statement, sql_source_type from system.statement_info where account="sql_source_type" and statement not like '%mo_ctl%' order by request_at desc limit 4;
+select statement, sql_source_type from system.statement_info where account="bvt_sql_source_type" and statement not like '%mo_ctl%' order by request_at desc limit 4;
 statement    sql_source_type
 show tables    cloud_user_sql
 use system    cloud_nonuser_sql
 select * from __mo_t1    external_sql
 insert into __mo_t1 values(1)    external_sql
-drop account if exists sql_source_type;
+drop account if exists bvt_sql_source_type;

--- a/test/distributed/cases/sql_source_type/sql_source_type.result
+++ b/test/distributed/cases/sql_source_type/sql_source_type.result
@@ -1,4 +1,4 @@
-create account if not exists `sql_source_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+create account if not exists `sql_source_type` ADMIN_NAME 'sql_source_type' IDENTIFIED BY '123456';
 create database if not exists ssb;
 use ssb;
 /* cloud_user */drop table if exists __mo_t1;
@@ -11,7 +11,7 @@ a
 select sleep(16);
 sleep(16)
 0
-select statement, sql_source_type from system.statement_info where account="sql_source_type" order by request_at desc limit 4;
+select statement, sql_source_type from system.statement_info where user="sql_source_type" order by request_at desc limit 4;
 statement    sql_source_type
 show tables    cloud_user_sql
 use system    cloud_nonuser_sql

--- a/test/distributed/cases/sql_source_type/sql_source_type.sql
+++ b/test/distributed/cases/sql_source_type/sql_source_type.sql
@@ -14,7 +14,7 @@ select * from __mo_t1;
 
 -- result check
 select sleep(16);
-select statement, sql_source_type from system.statement_info where user="sql_source_type" order by request_at desc limit 4;
+select statement, sql_source_type from system.statement_info where user="sql_source_type" and statement not like '%mo_ctl%' order by request_at desc limit 4;
 
 -- cleanup
 drop account if exists sql_source_type;

--- a/test/distributed/cases/sql_source_type/sql_source_type.sql
+++ b/test/distributed/cases/sql_source_type/sql_source_type.sql
@@ -1,5 +1,5 @@
 -- prepare
-create account if not exists `sql_source_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+create account if not exists `sql_source_type` ADMIN_NAME 'sql_source_type' IDENTIFIED BY '123456';
 
 -- testcase
 -- @session:id=1&user=sql_source_type:admin:accountadmin&password=123456
@@ -14,7 +14,7 @@ select * from __mo_t1;
 
 -- result check
 select sleep(16);
-select statement, sql_source_type from system.statement_info where account="sql_source_type" order by request_at desc limit 4;
+select statement, sql_source_type from system.statement_info where user="sql_source_type" order by request_at desc limit 4;
 
 -- cleanup
 drop account if exists sql_source_type;

--- a/test/distributed/cases/sql_source_type/sql_source_type.sql
+++ b/test/distributed/cases/sql_source_type/sql_source_type.sql
@@ -1,8 +1,9 @@
 -- prepare
-create account if not exists `sql_source_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+drop account if exists bvt_sql_source_type;
+create account if not exists `bvt_sql_source_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
 
 -- testcase
--- @session:id=1&user=sql_source_type:admin:accountadmin&password=123456
+-- @session:id=1&user=bvt_sql_source_type:admin:accountadmin&password=123456
 create database if not exists ssb;
 use ssb;
 /* cloud_user */drop table if exists __mo_t1;
@@ -14,7 +15,7 @@ select * from __mo_t1;
 
 -- result check
 select sleep(16);
-select statement, sql_source_type from system.statement_info where account="sql_source_type" and statement not like '%mo_ctl%' order by request_at desc limit 4;
+select statement, sql_source_type from system.statement_info where account="bvt_sql_source_type" and statement not like '%mo_ctl%' order by request_at desc limit 4;
 
 -- cleanup
-drop account if exists sql_source_type;
+drop account if exists bvt_sql_source_type;

--- a/test/distributed/cases/sql_source_type/sql_source_type.sql
+++ b/test/distributed/cases/sql_source_type/sql_source_type.sql
@@ -1,5 +1,5 @@
 -- prepare
-create account if not exists `sql_source_type` ADMIN_NAME 'sql_source_type' IDENTIFIED BY '123456';
+create account if not exists `sql_source_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
 
 -- testcase
 -- @session:id=1&user=sql_source_type:admin:accountadmin&password=123456
@@ -14,7 +14,7 @@ select * from __mo_t1;
 
 -- result check
 select sleep(16);
-select statement, sql_source_type from system.statement_info where user="sql_source_type" and statement not like '%mo_ctl%' order by request_at desc limit 4;
+select statement, sql_source_type from system.statement_info where account="sql_source_type" and statement not like '%mo_ctl%' order by request_at desc limit 4;
 
 -- cleanup
 drop account if exists sql_source_type;

--- a/test/distributed/cases/sql_source_type/sql_source_type.sql
+++ b/test/distributed/cases/sql_source_type/sql_source_type.sql
@@ -1,14 +1,20 @@
 -- prepare
 create account if not exists `sql_source_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
 
+-- testcase
+-- @session:id=1&user=sql_source_type:admin:accountadmin&password=123456
+create database if not exists ssb;
+use ssb;
 /* cloud_user */drop table if exists __mo_t1;
 /* cloud_nonuser */ create table __mo_t1(a int);
 insert into __mo_t1 values(1);
 select * from __mo_t1;
 /* cloud_nonuser */ use system;/* cloud_user */show tables;
--- @session:id=1&user=sql_source_type:admin:accountadmin&password=123456
-select sleep(16);
 -- @session
-select statement, sql_source_type from system.statement_info where user="dump" and statement not like '%mo_ctl%' order by request_at desc limit 4;
 
+-- result check
+select sleep(16);
+select statement, sql_source_type from system.statement_info where account="sql_source_type" order by request_at desc limit 4;
+
+-- cleanup
 drop account if exists sql_source_type;

--- a/test/distributed/cases/statement_query_type/prepare.result
+++ b/test/distributed/cases/statement_query_type/prepare.result
@@ -1,0 +1,24 @@
+drop account if exists bvt_query_type;
+create account if not exists `bvt_query_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+drop database if exists test_db;
+create database test_db;
+use test_db;
+drop table if exists test_table;
+create table test_table(
+col1 int,
+col2 varchar
+);
+insert into test_table values (1,'a'),(2,'b'),(3,'c');
+prepare s1 from select * from test_table where col1=?;
+set @a=2;
+execute s1 using @a;
+col1    col2
+2    b
+begin;
+execute s1 using @a;
+col1    col2
+2    b
+rollback;
+
+deallocate prepare s1;
+drop account if exists bvt_query_type;

--- a/test/distributed/cases/statement_query_type/prepare.sql
+++ b/test/distributed/cases/statement_query_type/prepare.sql
@@ -1,0 +1,30 @@
+-- prepare
+drop account if exists bvt_query_type;
+create account if not exists `bvt_query_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+
+-- prepare data
+-- @session:id=1&user=bvt_query_type:admin:accountadmin&password=123456
+drop database if exists test_db;
+create database test_db;
+use test_db;
+drop table if exists test_table;
+create table test_table(
+col1 int,
+col2 varchar
+);
+
+insert into test_table values (1,'a'),(2,'b'),(3,'c');
+
+prepare s1 from select * from test_table where col1=?;
+set @a=2;
+-- @bvt:issue#9525
+execute s1 using @a;
+begin;
+execute s1 using @a;
+rollback;
+-- @bvt:issue
+
+deallocate prepare s1;
+-- @session
+
+drop account if exists bvt_query_type;

--- a/test/distributed/cases/statement_query_type/statement_query_type.result
+++ b/test/distributed/cases/statement_query_type/statement_query_type.result
@@ -207,7 +207,7 @@ sleep(1)
 select sleep(15);
 sleep(15)
 0
-select statement,query_type,sql_source_type from  system.statement_info where user="dump" and sql_source_type="external_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 112;
+select statement,query_type,sql_source_type from  system.statement_info where account="query_type" and sql_source_type="external_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 112;
 statement    query_type    sql_source_type
 select sleep(1)    DQL    external_sql
 use system    Other    external_sql
@@ -434,7 +434,7 @@ sleep(1)
 select sleep(15);
 sleep(15)
 0
-/* cloud_user */ select statement,query_type,sql_source_type from  system.statement_info where user="dump" and sql_source_type="cloud_user_sql" and status != "Running" order by request_at desc limit 68;
+/* cloud_user */ select statement,query_type,sql_source_type from  system.statement_info where user="result_count" and sql_source_type="cloud_user_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
 statement    query_type    sql_source_type
 select sleep(1)    DQL    cloud_user_sql
 drop database test_db    DDL    cloud_user_sql
@@ -617,7 +617,7 @@ sleep(1)
 select sleep(15);
 sleep(15)
 0
-/* cloud_nonuser */ select statement,query_type,sql_source_type from  system.statement_info where user="dump" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
+/* cloud_nonuser */ select statement,query_type,sql_source_type from  system.statement_info where user="result_count" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
 statement    query_type    sql_source_type
 select sleep(1)    DQL    cloud_nonuser_sql
 drop database test_db    DDL    cloud_nonuser_sql

--- a/test/distributed/cases/statement_query_type/statement_query_type.result
+++ b/test/distributed/cases/statement_query_type/statement_query_type.result
@@ -1,4 +1,6 @@
-create account if not exists `query_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+drop account if exists bvt_query_type;
+create account if not exists `bvt_query_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+create database statement_query_type;
 begin;
 commit;
 start transaction;
@@ -61,6 +63,7 @@ insert into test_table values (1,'a'),(2,'b'),(3,'c');
 update test_table set col2='xxx' where col1=1;
 delete from test_table where col1=3;
 create account test_account admin_name = 'test_name' identified by '111' open comment 'tenant_test';
+internal error: do not have privilege to execute the statement
 create role test_role;
 create user user_name identified by 'password';
 create database if not exists db1;
@@ -69,6 +72,7 @@ revoke test_role from user_name;
 drop user user_name;
 drop role test_role;
 drop account test_account;
+internal error: do not have privilege to execute the statement
 drop database db1;
 create database db2;
 create table table_2(
@@ -87,8 +91,7 @@ UNNEST_DEFAULT    0    a    $.a    null    1    {"a": 1}
 prepare s1 from select * from test_table where col1=?;
 set @a=2;
 execute s1 using @a;
-col1    col2
-2    b
+ExpectedEOB
 deallocate prepare s1;
 drop table if exists test_01;
 create table test_01(a int, b varchar);
@@ -157,7 +160,7 @@ WITH cte1 AS (SELECT 1),cte2 AS (SELECT 2) SELECT * FROM cte1 join cte2;
 1    2
 insert into test_table values (1,'a'),(2,'b'),(3,'c');
 create account test_account admin_name = 'test_name' identified by '111' open comment 'tenant_test';
-internal error: administrative command is unsupported in transactions
+internal error: do not have privilege to execute the statement
 create role test_role;
 internal error: administrative command is unsupported in transactions
 create user user_name identified by 'password';
@@ -173,7 +176,7 @@ internal error: administrative command is unsupported in transactions
 drop role test_role;
 internal error: administrative command is unsupported in transactions
 drop account test_account;
-internal error: administrative command is unsupported in transactions
+internal error: do not have privilege to execute the statement
 drop database db1;
 internal error: CREATE/DROP of database is not supported in transactions
 create database db2;
@@ -196,8 +199,8 @@ prepare s1 from select * from test_table where col1=?;
 set @a=2;
 internal error: Uncommitted transaction exists. Please commit or rollback first.
 execute s1 using @a;
-col1    col2
-2    b
+ExpectedEOB
+Previous DML conflicts with existing constraints or data format. This transaction has to be aborted
 deallocate prepare s1;
 rollback;
 use system;
@@ -207,7 +210,7 @@ sleep(1)
 select sleep(15);
 sleep(15)
 0
-select statement,query_type,sql_source_type from  system.statement_info where account="query_type" and sql_source_type="external_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 112;
+select statement,query_type,sql_source_type from  system.statement_info where account="bvt_query_type" and sql_source_type="external_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 112;
 statement    query_type    sql_source_type
 select sleep(1)    DQL    external_sql
 use system    Other    external_sql
@@ -434,7 +437,7 @@ sleep(1)
 select sleep(15);
 sleep(15)
 0
-/* cloud_user */ select statement,query_type,sql_source_type from  system.statement_info where user="result_count" and sql_source_type="cloud_user_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
+/* cloud_user */ select statement,query_type,sql_source_type from  system.statement_info where user="dump" and sql_source_type="cloud_user_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
 statement    query_type    sql_source_type
 select sleep(1)    DQL    cloud_user_sql
 drop database test_db    DDL    cloud_user_sql
@@ -617,7 +620,7 @@ sleep(1)
 select sleep(15);
 sleep(15)
 0
-/* cloud_nonuser */ select statement,query_type,sql_source_type from  system.statement_info where user="result_count" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
+/* cloud_nonuser */ select statement,query_type,sql_source_type from  system.statement_info where user="dump" and sql_source_type="cloud_nonuser_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
 statement    query_type    sql_source_type
 select sleep(1)    DQL    cloud_nonuser_sql
 drop database test_db    DDL    cloud_nonuser_sql
@@ -705,4 +708,4 @@ insert into test_table values (1,'a'),(2,'b'),(3,'c');
 update test_table set col2='xxx' where col1=1;
 delete from test_table where col1=3;
 rollback ;
-drop account if exists query_type;
+drop account if exists bvt_query_type;

--- a/test/distributed/cases/statement_query_type/statement_query_type.sql
+++ b/test/distributed/cases/statement_query_type/statement_query_type.sql
@@ -1,8 +1,11 @@
 -- prepare
-create account if not exists `query_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+drop account if exists bvt_query_type;
+create account if not exists `bvt_query_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
 
 -- CASE: part 1
--- @session:id=1&user=query_type:admin:accountadmin&password=123456
+-- @session:id=1&user=bvt_query_type:admin:accountadmin&password=123456
+create database statement_query_type;
+
 -- test TCL sql
 begin;
 commit;
@@ -159,11 +162,10 @@ select sleep(1);
 
 -- RESULT CHECK: part 1
 select sleep(15);
-select statement,query_type,sql_source_type from  system.statement_info where account="query_type" and sql_source_type="external_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 112;
+select statement,query_type,sql_source_type from  system.statement_info where account="bvt_query_type" and sql_source_type="external_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 112;
 
 
 -- CASE: part 2
--- @session:id=1&user=query_type:admin:accountadmin&password=123456
 -- test cloud_user_sql type
 /* cloud_user */ use statement_query_type;
 /* cloud_user */ begin;
@@ -241,14 +243,14 @@ select statement,query_type,sql_source_type from  system.statement_info where ac
 /* cloud_user */ drop database test_db;
 
 /* cloud_user */ select sleep(1);
--- @session
 
 -- RESULT CHECK: part 2
+-- @session:id=1&user=bvt_query_type:admin:accountadmin&password=123456
 select sleep(15);
-/* cloud_user */ select statement,query_type,sql_source_type from  system.statement_info where user="query_type" and sql_source_type="cloud_user_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
+-- @session
+/* cloud_user */ select statement,query_type,sql_source_type from  system.statement_info where user="dump" and sql_source_type="cloud_user_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
 
 -- CASE: part 3
--- @session:id=1&user=query_type:admin:accountadmin&password=123456
 -- test cloud_no_user_sql type
 /* cloud_nonuser */ use statement_query_type;
 /* cloud_nonuser */ begin;
@@ -325,11 +327,12 @@ select sleep(15);
 /* cloud_nonuser */ use system;
 /* cloud_nonuser */ drop database test_db;
 /* cloud_nonuser */ select sleep(1);
--- @session
 
 -- RESULT CHECK: part 3
+-- @session:id=1&user=bvt_query_type:admin:accountadmin&password=123456
 select sleep(15);
-/* cloud_nonuser */ select statement,query_type,sql_source_type from  system.statement_info where account="query_type" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
+-- @session
+/* cloud_nonuser */ select statement,query_type,sql_source_type from  system.statement_info where user="dump" and sql_source_type="cloud_nonuser_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
 
 -- CASE: last
 begin;
@@ -346,4 +349,4 @@ delete from test_table where col1=3;
 rollback ;
 
 -- cleanup
-drop account if exists query_type;
+drop account if exists bvt_query_type;

--- a/test/distributed/cases/statement_query_type/statement_query_type.sql
+++ b/test/distributed/cases/statement_query_type/statement_query_type.sql
@@ -1,6 +1,8 @@
 -- prepare
 create account if not exists `query_type` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
 
+-- CASE: part 1
+-- @session:id=1&user=query_type:admin:accountadmin&password=123456
 -- test TCL sql
 begin;
 commit;
@@ -153,13 +155,15 @@ rollback;
 
 use system;
 select sleep(1);
--- @session:id=1&user=query_type:admin:accountadmin&password=123456
-select sleep(15);
 -- @session
--- mo-tester will exec "select mo_ctl('cn','synccommit','')" while switch conn
-select statement,query_type,sql_source_type from  system.statement_info where user="dump" and sql_source_type="external_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 112;
+
+-- RESULT CHECK: part 1
+select sleep(15);
+select statement,query_type,sql_source_type from  system.statement_info where account="query_type" and sql_source_type="external_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 112;
 
 
+-- CASE: part 2
+-- @session:id=1&user=query_type:admin:accountadmin&password=123456
 -- test cloud_user_sql type
 /* cloud_user */ use statement_query_type;
 /* cloud_user */ begin;
@@ -237,11 +241,14 @@ select statement,query_type,sql_source_type from  system.statement_info where us
 /* cloud_user */ drop database test_db;
 
 /* cloud_user */ select sleep(1);
--- @session:id=1&user=query_type:admin:accountadmin&password=123456
-select sleep(15);
 -- @session
-/* cloud_user */ select statement,query_type,sql_source_type from  system.statement_info where user="dump" and sql_source_type="cloud_user_sql" and status != "Running" order by request_at desc limit 68;
 
+-- RESULT CHECK: part 2
+select sleep(15);
+/* cloud_user */ select statement,query_type,sql_source_type from  system.statement_info where user="query_type" and sql_source_type="cloud_user_sql" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
+
+-- CASE: part 3
+-- @session:id=1&user=query_type:admin:accountadmin&password=123456
 -- test cloud_no_user_sql type
 /* cloud_nonuser */ use statement_query_type;
 /* cloud_nonuser */ begin;
@@ -318,11 +325,13 @@ select sleep(15);
 /* cloud_nonuser */ use system;
 /* cloud_nonuser */ drop database test_db;
 /* cloud_nonuser */ select sleep(1);
--- @session:id=1&user=query_type:admin:accountadmin&password=123456
-select sleep(15);
 -- @session
-/* cloud_nonuser */ select statement,query_type,sql_source_type from  system.statement_info where user="dump" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
 
+-- RESULT CHECK: part 3
+select sleep(15);
+/* cloud_nonuser */ select statement,query_type,sql_source_type from  system.statement_info where account="query_type" and status != "Running" and statement not like '%mo_ctl%' order by request_at desc limit 68;
+
+-- CASE: last
 begin;
 use statement_query_type;
 create table test_table(col1 int,col2 varchar);
@@ -335,4 +344,6 @@ insert into test_table values (1,'a'),(2,'b'),(3,'c');
 update test_table set col2='xxx' where col1=1;
 delete from test_table where col1=3;
 rollback ;
+
+-- cleanup
 drop account if exists query_type;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/9425

## What this PR does / why we need it:

use new account to exec those case, to avoid `user dump` sql affect.
Then these case can run success in local dev, not just in CI bvt. 