### PR TITLE
[Bug Fix]: Revert #9002

### DIFF
--- a/pkg/container/batch/batch.go
+++ b/pkg/container/batch/batch.go
@@ -142,6 +142,14 @@ func (bat *Batch) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
+func (bat *Batch) ExpandNulls() {
+	if len(bat.Zs) > 0 {
+		for i := range bat.Vecs {
+			bat.Vecs[i].TryExpandNulls(len(bat.Zs))
+		}
+	}
+}
+
 // I think Shrink should have a mpool!!!
 func (bat *Batch) Shrink(sels []int64) {
 	for _, vec := range bat.Vecs {
@@ -280,8 +288,12 @@ func (bat *Batch) Append(ctx context.Context, mh *mpool.MPool, b *Batch) (*Batch
 	// fault.AddFaultPoint("panic_in_batch_append", ":::", "PANIC", 0, "")
 	fault.TriggerFault("panic_in_batch_append")
 
+	flags := make([]uint8, b.Vecs[0].Length())
+	for i := range flags {
+		flags[i]++
+	}
 	for i := range bat.Vecs {
-		if err := bat.Vecs[i].UnionBatch(b.Vecs[i], 0, b.Vecs[i].Length(), nil, mh); err != nil {
+		if err := bat.Vecs[i].UnionBatch(b.Vecs[i], 0, b.Vecs[i].Length(), flags[:b.Vecs[i].Length()], mh); err != nil {
 			return bat, err
 		}
 	}

--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -1783,7 +1783,7 @@ func (v *Vector) UnionBatch(w *Vector, offset int64, cnt int, flags []uint8, mp 
 		return err
 	}
 
-	if w.IsConstNull() {
+	if w.IsConst() {
 		oldLen := v.length
 		v.length += addCnt
 		if w.IsConstNull() {

--- a/pkg/sql/colexec/anti/join.go
+++ b/pkg/sql/colexec/anti/join.go
@@ -120,6 +120,7 @@ func (ctr *container) emptyProbe(bat *batch.Batch, ap *Argument, proc *process.P
 			rbat.Zs = append(rbat.Zs, bat.Zs[i+k])
 		}
 	}
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil
@@ -199,6 +200,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 		}
 		eligible = eligible[:0]
 	}
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/group/group.go
+++ b/pkg/sql/colexec/group/group.go
@@ -131,6 +131,7 @@ func (ctr *container) process(ap *Argument, proc *process.Process, anal process.
 			}
 		}
 		if ctr.bat != nil {
+			ctr.bat.ExpandNulls()
 			anal.Alloc(int64(ctr.bat.Size()))
 			anal.Output(ctr.bat, isLast)
 			proc.SetInputBatch(ctr.bat)
@@ -212,6 +213,7 @@ func (ctr *container) processWithGroup(ap *Argument, proc *process.Process, anal
 					ctr.bat.Zs[i] = 1
 				}
 			}
+			ctr.bat.ExpandNulls()
 			anal.Output(ctr.bat, isLast)
 			proc.SetInputBatch(ctr.bat)
 			ctr.bat = nil

--- a/pkg/sql/colexec/join/join.go
+++ b/pkg/sql/colexec/join/join.go
@@ -189,6 +189,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 			}
 		}
 	}
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/left/join.go
+++ b/pkg/sql/colexec/left/join.go
@@ -244,6 +244,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 			}
 		}
 	}
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/loopanti/join.go
+++ b/pkg/sql/colexec/loopanti/join.go
@@ -138,6 +138,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 		}
 		vec.Free(proc.Mp())
 	}
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/loopjoin/join.go
+++ b/pkg/sql/colexec/loopjoin/join.go
@@ -157,6 +157,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 		}
 		vec.Free(proc.Mp())
 	}
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/loopleft/join.go
+++ b/pkg/sql/colexec/loopleft/join.go
@@ -197,6 +197,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 			rbat.Zs = append(rbat.Zs, bat.Zs[i])
 		}
 	}
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/loopmark/join.go
+++ b/pkg/sql/colexec/loopmark/join.go
@@ -173,6 +173,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 	}
 	rbat.Zs = bat.Zs
 	bat.Zs = nil
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/loopsemi/join.go
+++ b/pkg/sql/colexec/loopsemi/join.go
@@ -124,6 +124,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 		}
 		vec.Free(proc.Mp())
 	}
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/loopsingle/join.go
+++ b/pkg/sql/colexec/loopsingle/join.go
@@ -187,6 +187,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 	}
 	rbat.Zs = bat.Zs
 	bat.Zs = nil
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/mergegroup/group.go
+++ b/pkg/sql/colexec/mergegroup/group.go
@@ -72,6 +72,7 @@ func Call(idx int, proc *process.Process, arg interface{}, isFirst bool, isLast 
 					}
 				}
 				anal.Output(ctr.bat, isLast)
+				ctr.bat.ExpandNulls()
 			}
 			ctr.state = End
 		case End:

--- a/pkg/sql/colexec/mergeorder/order.go
+++ b/pkg/sql/colexec/mergeorder/order.go
@@ -66,6 +66,8 @@ func Call(idx int, proc *process.Process, arg any, isFirst bool, isLast bool) (b
 		}
 
 		anal.Input(bat, isFirst)
+		bat.ExpandNulls()
+
 		if err = mergeSort(proc, bat, ap, ctr, anal); err != nil {
 			break
 		}
@@ -82,6 +84,7 @@ func Call(idx int, proc *process.Process, arg any, isFirst bool, isLast bool) (b
 			ctr.bat.Vecs[i].Free(proc.Mp())
 		}
 		ctr.bat.Vecs = ctr.bat.Vecs[:ctr.n]
+		ctr.bat.ExpandNulls()
 	}
 	if err = ctr.bat.Shuffle(ctr.finalSelectList, proc.Mp()); err != nil {
 		ap.Free(proc, true)

--- a/pkg/sql/colexec/mergetop/top.go
+++ b/pkg/sql/colexec/mergetop/top.go
@@ -215,6 +215,7 @@ func (ctr *container) eval(limit int64, proc *process.Process, anal process.Anal
 		ctr.bat.Vecs[i].Free(proc.Mp())
 	}
 	ctr.bat.Vecs = ctr.bat.Vecs[:ctr.n]
+	ctr.bat.ExpandNulls()
 	anal.Output(ctr.bat, isLast)
 	proc.SetInputBatch(ctr.bat)
 	ctr.bat = nil

--- a/pkg/sql/colexec/product/product.go
+++ b/pkg/sql/colexec/product/product.go
@@ -121,6 +121,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 			rbat.Zs = append(rbat.Zs, ctr.bat.Zs[j])
 		}
 	}
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/right/join.go
+++ b/pkg/sql/colexec/right/join.go
@@ -190,6 +190,7 @@ func (ctr *container) sendLast(ap *Argument, proc *process.Process, analyze proc
 			rbat.Zs = append(rbat.Zs, ctr.bat.Zs[i])
 		}
 	}
+	rbat.ExpandNulls()
 	analyze.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return false, nil
@@ -281,6 +282,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 			}
 		}
 	}
+	rbat.ExpandNulls()
 	proc.SetInputBatch(rbat)
 	return nil
 }

--- a/pkg/sql/colexec/rightanti/join.go
+++ b/pkg/sql/colexec/rightanti/join.go
@@ -167,6 +167,7 @@ func (ctr *container) sendLast(ap *Argument, proc *process.Process, analyze proc
 			rbat.Zs = append(rbat.Zs, ctr.bat.Zs[i])
 		}
 	}
+	rbat.ExpandNulls()
 	analyze.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return false, nil

--- a/pkg/sql/colexec/rightsemi/join.go
+++ b/pkg/sql/colexec/rightsemi/join.go
@@ -168,6 +168,7 @@ func (ctr *container) sendLast(ap *Argument, proc *process.Process, analyze proc
 			rbat.Zs = append(rbat.Zs, ctr.bat.Zs[i])
 		}
 	}
+	rbat.ExpandNulls()
 	analyze.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return false, nil

--- a/pkg/sql/colexec/semi/join.go
+++ b/pkg/sql/colexec/semi/join.go
@@ -166,6 +166,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 		}
 		eligible = eligible[:0]
 	}
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/single/join.go
+++ b/pkg/sql/colexec/single/join.go
@@ -224,6 +224,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *Argument, proc *process.Proces
 	}
 	rbat.Zs = bat.Zs
 	bat.Zs = nil
+	rbat.ExpandNulls()
 	anal.Output(rbat, isLast)
 	proc.SetInputBatch(rbat)
 	return nil

--- a/pkg/sql/colexec/top/top.go
+++ b/pkg/sql/colexec/top/top.go
@@ -210,6 +210,7 @@ func (ctr *container) eval(limit int64, proc *process.Process) error {
 		ctr.bat.Vecs[i].Free(proc.Mp())
 	}
 	ctr.bat.Vecs = ctr.bat.Vecs[:ctr.n]
+	ctr.bat.ExpandNulls()
 	proc.Reg.InputBatch = ctr.bat
 	ctr.bat = nil
 	return nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #
https://github.com/matrixorigin/MO-Cloud/issues/723  (memory corruption issue)
https://github.com/matrixorigin/MO-Cloud/issues/669 (holds most of the memory corruption discussions)

## What this PR does / why we need it:
It is observed that there is a memory corruption issue causing `SIGSEGV` or `found pointer to free object`. After `git bisect`, we find that the issue is most likely caused by #9002 PR. The commit before that PR (#8938) was tested multiple times and did not show any signs of memory corruption.

**NOTE**: Since the issue occurs after a GC sweep, we made some modifications to do aggressive GC while running the service.

```shell
make debug

GODEBUG=invalidptr=1,cgocheck=2,madvdontneed=1 GOGC=2 GOMEMLIMIT=10MiB ./mo-service -debug-http :9876 -launch ./etc/launch-tae-CN-tae-DN/launch.toml >out.log  2>err.log
```

and [Makefile](https://github.com/matrixorigin/matrixone/blob/490d81a5bc132cca786ba649f0d959d43e6e25d4/Makefile#L110)

```Makefile
$(CGO_OPTS) go build -gcflags=-d=checkptr $(RACE_OPT) $(GOLDFLAGS) -o $(BIN_NAME) ./cmd/mo-service
```