### PR TITLE
add internal sql executor

### DIFF
--- a/pkg/cnservice/distributed_tae.go
+++ b/pkg/cnservice/distributed_tae.go
@@ -62,13 +62,14 @@ func (s *service) initDistributedTAE(
 	blockio.Start()
 
 	// engine
-	pu.StorageEngine = disttae.New(
+	s.storeEngine = disttae.New(
 		ctx,
 		mp,
 		fs,
 		client,
 		hakeeper,
 	)
+	pu.StorageEngine = s.storeEngine
 
 	// log tail client to subscribe table and receive table log.
 	usePushModel := s.cfg.TurnOnPushModel
@@ -84,5 +85,6 @@ func (s *service) initDistributedTAE(
 		}
 	}
 
+	s.initInternalSQlExecutor(mp)
 	return nil
 }

--- a/pkg/cnservice/memory_engine.go
+++ b/pkg/cnservice/memory_engine.go
@@ -104,13 +104,13 @@ func (s *service) initMemoryEngineNonDist(
 	)
 	pu.TxnClient = txnClient
 
-	engine := memoryengine.New(
+	s.storeEngine = memoryengine.New(
 		ctx,
 		memoryengine.NewDefaultShardPolicy(mp),
 		memoryengine.RandomIDGenerator,
 		cluster,
 	)
-	pu.StorageEngine = engine
-
+	pu.StorageEngine = s.storeEngine
+	s.initInternalSQlExecutor(mp)
 	return nil
 }

--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/config"
@@ -35,6 +36,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
+	"github.com/matrixorigin/matrixone/pkg/sql/compile"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 	"github.com/matrixorigin/matrixone/pkg/txn/storage/memorystorage"
@@ -89,6 +91,10 @@ func NewService(
 		},
 	}
 
+	if _, err = srv.getHAKeeperClient(); err != nil {
+		return nil, err
+	}
+
 	pu := config.NewParameterUnit(
 		&cfg.Frontend,
 		nil,
@@ -96,7 +102,7 @@ func NewService(
 		engine.Nodes{engine.Node{
 			Addr: cfg.ServiceAddress,
 		}})
-
+	pu.HAKeeperClient = srv._hakeeperClient
 	cfg.Frontend.SetDefaultValues()
 	cfg.Frontend.SetMaxMessageSize(uint64(cfg.RPC.MaxMessageSize))
 	frontend.InitServerVersion(pu.SV.MoVersion)
@@ -106,9 +112,6 @@ func NewService(
 
 	srv.pu = pu
 	if err = srv.initMOServer(ctx, pu, srv.aicm); err != nil {
-		return nil, err
-	}
-	if _, err = srv.getHAKeeperClient(); err != nil {
 		return nil, err
 	}
 
@@ -226,6 +229,7 @@ func (s *service) stopRPCs() error {
 			return err
 		}
 	}
+	s.timestampWaiter.Close()
 	return nil
 }
 
@@ -354,7 +358,6 @@ func (s *service) getHAKeeperClient() (client logservice.CNHAKeeperClient, err e
 			return
 		}
 		s._hakeeperClient = client
-		s.pu.HAKeeperClient = client
 		s.initClusterService()
 		s.initLockService()
 	})
@@ -491,6 +494,7 @@ func (s *service) getTxnClient() (c client.TxnClient, err error) {
 func (s *service) initLockService() {
 	cfg := s.cfg.getLockServiceConfig()
 	s.lockService = lockservice.NewLockService(cfg)
+	runtime.ProcessLevelRuntime().SetGlobalVariables(runtime.LockService, s.lockService)
 }
 
 // put the waiting-next type msg into client session's cache and return directly
@@ -534,4 +538,15 @@ func handleAssemblePipeline(ctx context.Context, message morpc.Message, cs morpc
 	msg := message.(*pipeline.Message)
 	msg.SetData(append(data, msg.GetData()...))
 	return nil
+}
+
+func (s *service) initInternalSQlExecutor(mp *mpool.MPool) {
+	exec := compile.NewSQLExecutor(
+		s.cfg.ServiceAddress,
+		s.storeEngine,
+		mp,
+		s._txnClient,
+		s.fileService,
+		s.aicm)
+	runtime.ProcessLevelRuntime().SetGlobalVariables(runtime.InternalSQLExecutor, exec)
 }

--- a/pkg/common/runtime/types.go
+++ b/pkg/common/runtime/types.go
@@ -28,6 +28,8 @@ const (
 	LockService = "lock-service"
 	// CtlService ctl service
 	CtlService = "ctl-service"
+	// InternalSQLExecutor attr name for internal sql executor
+	InternalSQLExecutor = "internal-sql-executor"
 	// TxnOptions options used to create txn
 	TxnOptions = "txn-options"
 	// TxnMode runtime default txn mode

--- a/pkg/container/batch/batch.go
+++ b/pkg/container/batch/batch.go
@@ -265,6 +265,22 @@ func (bat *Batch) String() string {
 	return buf.String()
 }
 
+func (bat *Batch) Dup(mp *mpool.MPool) (*Batch, error) {
+	rbat := NewWithSize(len(bat.Vecs))
+	rbat.SetAttributes(bat.Attrs)
+	for j, vec := range bat.Vecs {
+		typ := *bat.GetVector(int32(j)).GetType()
+		rvec := vector.NewVec(typ)
+		if err := vector.GetUnionAllFunction(typ, mp)(rvec, vec); err != nil {
+			rbat.Clean(mp)
+			return nil, err
+		}
+		rbat.SetVector(int32(j), rvec)
+	}
+	rbat.Zs = append(rbat.Zs, bat.Zs...)
+	return rbat, nil
+}
+
 func (bat *Batch) Append(ctx context.Context, mh *mpool.MPool, b *Batch) (*Batch, error) {
 	if bat == nil {
 		return b, nil

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -1,0 +1,320 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compile
+
+import (
+	"context"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/lockservice"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"go.uber.org/multierr"
+)
+
+// WithTxn exec sql in a exists txn
+func (opts Options) WithTxn(txnOp client.TxnOperator) Options {
+	opts.txnOp = txnOp
+	return opts
+}
+
+// WithDatabase exec sql in database
+func (opts Options) WithDatabase(database string) Options {
+	opts.database = database
+	return opts
+}
+
+// WithAccountID execute sql in account
+func (opts Options) WithAccountID(accoundID uint32) Options {
+	opts.accoundID = accoundID
+	return opts
+}
+
+// WithMinCommittedTS use minCommittedTS to exec sql. It will set txn's snapshot to
+// minCommittedTS+1, so the txn can see the data which committed at minCommittedTS.
+// It's not work if txn operator is set.
+func (opts Options) WithMinCommittedTS(ts timestamp.Timestamp) Options {
+	opts.minCommittedTS = ts
+	return opts
+}
+
+type sqlExecutor struct {
+	addr      string
+	eng       engine.Engine
+	mp        *mpool.MPool
+	txnClient client.TxnClient
+	fs        fileservice.FileService
+	ls        lockservice.LockService
+	aicm      *defines.AutoIncrCacheManager
+}
+
+// NewSQLExecutor returns a internal used sql service. It can execute sql in current CN.
+func NewSQLExecutor(
+	addr string,
+	eng engine.Engine,
+	mp *mpool.MPool,
+	txnClient client.TxnClient,
+	fs fileservice.FileService,
+	aicm *defines.AutoIncrCacheManager) SQLExecutor {
+	v, ok := runtime.ProcessLevelRuntime().GetGlobalVariables(runtime.LockService)
+	if !ok {
+		panic("missing lock service")
+	}
+	return &sqlExecutor{
+		addr:      addr,
+		eng:       eng,
+		txnClient: txnClient,
+		fs:        fs,
+		ls:        v.(lockservice.LockService),
+		aicm:      aicm,
+		mp:        mp,
+	}
+}
+
+func (s *sqlExecutor) Exec(
+	ctx context.Context,
+	sql string,
+	opts Options) (Result, error) {
+	var res Result
+	err := s.ExecTxn(
+		ctx,
+		func(exec TxnExecutor) error {
+			v, err := exec.Exec(sql)
+			res = v
+			return err
+		},
+		opts)
+	if err != nil {
+		return Result{}, err
+	}
+	return res, nil
+}
+
+func (s *sqlExecutor) ExecTxn(
+	ctx context.Context,
+	execFunc func(TxnExecutor) error,
+	opts Options) error {
+	exec, err := newTxnExecutor(ctx, s, opts)
+	if err != nil {
+		return err
+	}
+	err = execFunc(exec)
+	if err != nil {
+		return exec.rollback()
+	}
+	return exec.commit()
+}
+
+func (s *sqlExecutor) getCompileContext(
+	ctx context.Context,
+	proc *process.Process,
+	opts Options) *compilerContext {
+	return newCompilerContext(
+		ctx,
+		opts.database,
+		s.eng,
+		proc)
+}
+
+func (s *sqlExecutor) adjustOptions(
+	ctx context.Context,
+	opts Options) (context.Context, Options, error) {
+	if opts.accoundID > 0 {
+		ctx = context.WithValue(
+			ctx,
+			defines.TenantIDKey{},
+			opts.accoundID)
+	}
+
+	if opts.txnOp == nil {
+		txnOp, err := s.txnClient.New(ctx, opts.minCommittedTS)
+		if err != nil {
+			return nil, Options{}, err
+		}
+		opts.txnOp = txnOp
+		opts.innerTxn = true
+	}
+	return ctx, opts, nil
+}
+
+type txnExecutor struct {
+	s    *sqlExecutor
+	ctx  context.Context
+	opts Options
+}
+
+func newTxnExecutor(
+	ctx context.Context,
+	s *sqlExecutor,
+	opts Options) (*txnExecutor, error) {
+	ctx, opts, err := s.adjustOptions(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	if opts.innerTxn {
+		if err := s.eng.New(ctx, opts.txnOp); err != nil {
+			return nil, err
+		}
+	}
+	return &txnExecutor{s: s, ctx: ctx, opts: opts}, nil
+}
+
+func (exec *txnExecutor) Exec(sql string) (Result, error) {
+	stmts, err := parsers.Parse(exec.ctx, dialect.MYSQL, sql, 1)
+	if err != nil {
+		return Result{}, err
+	}
+
+	proc := process.New(
+		exec.ctx,
+		exec.s.mp,
+		exec.s.txnClient,
+		exec.opts.txnOp,
+		exec.s.fs,
+		exec.s.ls,
+		exec.s.aicm,
+	)
+
+	pn, err := plan.BuildPlan(
+		exec.s.getCompileContext(exec.ctx, proc, exec.opts),
+		stmts[0])
+	if err != nil {
+		return Result{}, err
+	}
+
+	c := New(
+		exec.s.addr,
+		exec.opts.database,
+		sql,
+		"",
+		"",
+		exec.ctx,
+		exec.s.eng,
+		proc,
+		stmts[0],
+		false,
+		nil)
+
+	var result Result
+	var batches []*batch.Batch
+	err = c.Compile(
+		exec.ctx,
+		pn,
+		nil,
+		func(a any, bat *batch.Batch) error {
+			if bat != nil {
+				// the bat is valid only in current method. So we need copy data.
+				// FIXME: add a custom streaming apply handler to consume readed data. Now
+				// our current internal sql will never read too much data.
+				rows, err := bat.Dup(exec.s.mp)
+				if err != nil {
+					return err
+				}
+				batches = append(batches, rows)
+			}
+			return nil
+		})
+	if err != nil {
+		return Result{}, err
+	}
+	if err := c.Run(0); err != nil {
+		return Result{}, err
+	}
+
+	result.batches = batches
+	result.affectedRows = c.GetAffectedRows()
+	return result, nil
+}
+
+func (exec *txnExecutor) commit() error {
+	if !exec.opts.innerTxn {
+		return nil
+	}
+	if err := exec.s.eng.Commit(
+		exec.ctx,
+		exec.opts.txnOp); err != nil {
+		return err
+	}
+	return exec.opts.txnOp.Commit(exec.ctx)
+}
+
+func (exec *txnExecutor) rollback() error {
+	if !exec.opts.innerTxn {
+		return nil
+	}
+	err := exec.s.eng.Rollback(
+		exec.ctx,
+		exec.opts.txnOp)
+	return multierr.Append(err,
+		exec.opts.txnOp.Rollback(exec.ctx))
+}
+
+func (res Result) GetAffectedRows() uint64 {
+	return res.affectedRows
+}
+
+func (res Result) Close() {
+	for _, rows := range res.batches {
+		rows.Clean(res.mp)
+	}
+}
+
+// ReadRows read all rows, apply is used to read cols data in a row. If apply return false, stop
+// reading. If the query has a lot of data, apply will be called multiple times, giving a batch of
+// rows for each call.
+func (res Result) ReadRows(apply func(cols []*vector.Vector) bool) {
+	for _, rows := range res.batches {
+		if !apply(rows.Vecs) {
+			return
+		}
+	}
+}
+
+// GetFixedRows get fixed rows, int, float, etc.
+func GetFixedRows[T any](vec *vector.Vector) []T {
+	return vector.MustFixedCol[T](vec)
+}
+
+// GetBytesRows get bytes rows, varchar, varbinary, text, json, etc.
+func GetBytesRows(vec *vector.Vector) [][]byte {
+	n := vec.Length()
+	data, area := vector.MustVarlenaRawData(vec)
+	rows := make([][]byte, 0, n)
+	for idx := range data {
+		rows = append(rows, data[idx].GetByteSlice(area))
+	}
+	return rows
+}
+
+// GetStringRows get bytes rows, varchar, varbinary, text, json, etc.
+func GetStringRows(vec *vector.Vector) []string {
+	n := vec.Length()
+	data, area := vector.MustVarlenaRawData(vec)
+	rows := make([]string, 0, n)
+	for idx := range data {
+		rows = append(rows, string(data[idx].GetByteSlice(area)))
+	}
+	return rows
+}

--- a/pkg/sql/compile/sql_executor_context.go
+++ b/pkg/sql/compile/sql_executor_context.go
@@ -1,0 +1,389 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compile
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/util"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+var _ plan.CompilerContext = new(compilerContext)
+
+type compilerContext struct {
+	ctx       context.Context
+	defaultDB string
+	engine    engine.Engine
+	proc      *process.Process
+}
+
+func (c *compilerContext) CheckSubscriptionValid(subName, accName string, pubName string) error {
+	panic("not supported in internal sql executor")
+}
+
+func (c *compilerContext) IsPublishing(dbName string) (bool, error) {
+	panic("not supported in internal sql executor")
+}
+
+func (c *compilerContext) SetQueryingSubscription(meta *plan.SubscriptionMeta) {
+	panic("not supported in internal sql executor")
+}
+
+func (c *compilerContext) GetQueryingSubscription() *plan.SubscriptionMeta {
+	return nil
+}
+
+func newCompilerContext(
+	ctx context.Context,
+	defaultDB string,
+	eng engine.Engine,
+	proc *process.Process) *compilerContext {
+	return &compilerContext{
+		ctx:       ctx,
+		defaultDB: defaultDB,
+		engine:    eng,
+		proc:      proc,
+	}
+}
+
+func (c *compilerContext) ResolveUdf(name string, ast []*plan.Expr) (string, error) {
+	panic("not supported in internal sql executor")
+}
+
+func (c *compilerContext) ResolveAccountIds(accountNames []string) ([]uint32, error) {
+	panic("not supported in internal sql executor")
+}
+
+func (c *compilerContext) Stats(obj *plan.ObjectRef) bool {
+	return false
+}
+
+func (c *compilerContext) GetStatsCache() *plan.StatsCache {
+	return nil
+}
+
+func (c *compilerContext) GetSubscriptionMeta(dbName string) (*plan.SubscriptionMeta, error) {
+	return nil, nil
+}
+
+func (c *compilerContext) GetProcess() *process.Process {
+	return c.proc
+}
+
+func (c *compilerContext) GetQueryResultMeta(uuid string) ([]*plan.ColDef, string, error) {
+	panic("not supported in internal sql executor")
+}
+
+func (c *compilerContext) DatabaseExists(name string) bool {
+	_, err := c.engine.Database(
+		c.ctx,
+		name,
+		c.proc.TxnOperator,
+	)
+	return err == nil
+}
+
+func (c *compilerContext) GetDatabaseId(dbName string) (uint64, error) {
+	database, err := c.engine.Database(c.ctx, dbName, c.proc.TxnOperator)
+	if err != nil {
+		return 0, err
+	}
+	databaseId, err := strconv.ParseUint(database.GetDatabaseId(c.ctx), 10, 64)
+	if err != nil {
+		return 0, moerr.NewInternalError(c.ctx, "The databaseid of '%s' is not a valid number", dbName)
+	}
+	return databaseId, nil
+}
+
+func (c *compilerContext) DefaultDatabase() string {
+	return c.defaultDB
+}
+
+func (c *compilerContext) GetPrimaryKeyDef(
+	dbName string,
+	tableName string) []*plan.ColDef {
+	dbName, err := c.ensureDatabaseIsNotEmpty(dbName)
+	if err != nil {
+		return nil
+	}
+	relation, err := c.getRelation(dbName, tableName)
+	if err != nil {
+		return nil
+	}
+
+	priKeys, err := relation.GetPrimaryKeys(c.ctx)
+	if err != nil {
+		return nil
+	}
+	if len(priKeys) == 0 {
+		return nil
+	}
+
+	priDefs := make([]*plan.ColDef, 0, len(priKeys))
+	for _, key := range priKeys {
+		priDefs = append(priDefs, &plan.ColDef{
+			Name: key.Name,
+			Typ: &plan.Type{
+				Id:    int32(key.Type.Oid),
+				Width: key.Type.Width,
+				Scale: key.Type.Scale,
+			},
+			Primary: key.Primary,
+		})
+	}
+	return priDefs
+}
+
+func (c *compilerContext) GetRootSql() string {
+	return ""
+}
+
+func (c *compilerContext) GetUserName() string {
+	return "root"
+}
+
+func (c *compilerContext) GetAccountId() uint32 {
+	if v := c.ctx.Value(defines.TenantIDKey{}); v != nil {
+		return v.(uint32)
+	}
+	return 0
+}
+
+func (c *compilerContext) GetContext() context.Context {
+	return c.ctx
+}
+
+func (c *compilerContext) ResolveById(tableId uint64) (objRef *plan.ObjectRef, tableDef *plan.TableDef) {
+	dbName, tableName, _ := c.engine.GetNameById(c.ctx, c.proc.TxnOperator, tableId)
+	if dbName == "" || tableName == "" {
+		return nil, nil
+	}
+	return c.Resolve(dbName, tableName)
+}
+
+func (c *compilerContext) Resolve(dbName string, tableName string) (*plan.ObjectRef, *plan.TableDef) {
+	dbName, err := c.ensureDatabaseIsNotEmpty(dbName)
+	if err != nil {
+		return nil, nil
+	}
+	table, err := c.getRelation(dbName, tableName)
+	if err != nil {
+		return nil, nil
+	}
+	return c.getTableDef(table, dbName, tableName)
+}
+
+func (c *compilerContext) ResolveVariable(varName string, isSystemVar bool, isGlobalVar bool) (interface{}, error) {
+	return "", nil
+}
+
+func (c *compilerContext) SetBuildingAlterView(yesOrNo bool, dbName, viewName string) {
+	panic("not supported in internal sql executor")
+}
+
+func (c *compilerContext) GetBuildingAlterView() (bool, string, string) {
+	panic("not supported in internal sql executor")
+}
+
+func (c *compilerContext) ensureDatabaseIsNotEmpty(dbName string) (string, error) {
+	if len(dbName) == 0 {
+		dbName = c.DefaultDatabase()
+	}
+	if len(dbName) == 0 {
+		return "", moerr.NewNoDB(c.GetContext())
+	}
+	return dbName, nil
+}
+
+func (c *compilerContext) getRelation(
+	dbName string,
+	tableName string) (engine.Relation, error) {
+	dbName, err := c.ensureDatabaseIsNotEmpty(dbName)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := c.engine.Database(c.ctx, dbName, c.proc.TxnOperator)
+	if err != nil {
+		return nil, err
+	}
+
+	table, err := db.Relation(c.ctx, tableName)
+	if err != nil {
+		return nil, err
+	}
+	return table, nil
+}
+
+func (c *compilerContext) getTableDef(
+	table engine.Relation,
+	dbName, tableName string) (*plan.ObjectRef, *plan.TableDef) {
+	tableId := table.GetTableID(c.ctx)
+	engineDefs, err := table.TableDefs(c.ctx)
+	if err != nil {
+		return nil, nil
+	}
+
+	var clusterByDef *plan.ClusterByDef
+	var cols []*plan.ColDef
+	var schemaVersion uint32
+	var defs []*plan.TableDefType
+	var properties []*plan.Property
+	var TableType, Createsql string
+	var partitionInfo *plan.PartitionByDef
+	var viewSql *plan.ViewDef
+	var foreignKeys []*plan.ForeignKeyDef
+	var primarykey *plan.PrimaryKeyDef
+	var indexes []*plan.IndexDef
+	var refChildTbls []uint64
+	var subscriptionName string
+	var pubAccountId int32 = -1
+
+	for _, def := range engineDefs {
+		if attr, ok := def.(*engine.AttributeDef); ok {
+			col := &plan.ColDef{
+				ColId: attr.Attr.ID,
+				Name:  attr.Attr.Name,
+				Typ: &plan.Type{
+					Id:          int32(attr.Attr.Type.Oid),
+					Width:       attr.Attr.Type.Width,
+					Scale:       attr.Attr.Type.Scale,
+					AutoIncr:    attr.Attr.AutoIncrement,
+					Table:       tableName,
+					NotNullable: attr.Attr.Default != nil && !attr.Attr.Default.NullAbility,
+				},
+				Primary:   attr.Attr.Primary,
+				Default:   attr.Attr.Default,
+				OnUpdate:  attr.Attr.OnUpdate,
+				Comment:   attr.Attr.Comment,
+				ClusterBy: attr.Attr.ClusterBy,
+				Hidden:    attr.Attr.IsHidden,
+				Seqnum:    uint32(attr.Attr.Seqnum),
+			}
+			// Is it a composite primary key
+			if attr.Attr.Name == catalog.CPrimaryKeyColName {
+				continue
+			}
+			if attr.Attr.ClusterBy {
+				clusterByDef = &plan.ClusterByDef{
+					Name: attr.Attr.Name,
+				}
+				if util.JudgeIsCompositeClusterByColumn(attr.Attr.Name) {
+					continue
+				}
+			}
+			cols = append(cols, col)
+		} else if pro, ok := def.(*engine.PropertiesDef); ok {
+			for _, p := range pro.Properties {
+				switch p.Key {
+				case catalog.SystemRelAttr_Kind:
+					TableType = p.Value
+				case catalog.SystemRelAttr_CreateSQL:
+					Createsql = p.Value
+				default:
+				}
+				properties = append(properties, &plan.Property{
+					Key:   p.Key,
+					Value: p.Value,
+				})
+			}
+		} else if viewDef, ok := def.(*engine.ViewDef); ok {
+			viewSql = &plan.ViewDef{
+				View: viewDef.View,
+			}
+		} else if c, ok := def.(*engine.ConstraintDef); ok {
+			for _, ct := range c.Cts {
+				switch k := ct.(type) {
+				case *engine.IndexDef:
+					indexes = k.Indexes
+				case *engine.ForeignKeyDef:
+					foreignKeys = k.Fkeys
+				case *engine.RefChildTableDef:
+					refChildTbls = k.Tables
+				case *engine.PrimaryKeyDef:
+					primarykey = k.Pkey
+				}
+			}
+		} else if commnetDef, ok := def.(*engine.CommentDef); ok {
+			properties = append(properties, &plan.Property{
+				Key:   catalog.SystemRelAttr_Comment,
+				Value: commnetDef.Comment,
+			})
+		} else if partitionDef, ok := def.(*engine.PartitionDef); ok {
+			if partitionDef.Partitioned > 0 {
+				p := &plan.PartitionByDef{}
+				err = p.UnMarshalPartitionInfo(([]byte)(partitionDef.Partition))
+				if err != nil {
+					return nil, nil
+				}
+				partitionInfo = p
+			}
+		} else if v, ok := def.(*engine.VersionDef); ok {
+			schemaVersion = v.Version
+		}
+	}
+	if len(properties) > 0 {
+		defs = append(defs, &plan.TableDefType{
+			Def: &plan.TableDef_DefType_Properties{
+				Properties: &plan.PropertiesDef{
+					Properties: properties,
+				},
+			},
+		})
+	}
+
+	if primarykey != nil && primarykey.PkeyColName == catalog.CPrimaryKeyColName {
+		cols = append(cols, plan.MakeHiddenColDefByName(catalog.CPrimaryKeyColName))
+	}
+	if clusterByDef != nil && util.JudgeIsCompositeClusterByColumn(clusterByDef.Name) {
+		cols = append(cols, plan.MakeHiddenColDefByName(clusterByDef.Name))
+	}
+	rowIdCol := plan.MakeRowIdColDef()
+	cols = append(cols, rowIdCol)
+
+	//convert
+	obj := &plan.ObjectRef{
+		SchemaName:       dbName,
+		ObjName:          tableName,
+		SubscriptionName: subscriptionName,
+		PubAccountId:     pubAccountId,
+	}
+
+	tableDef := &plan.TableDef{
+		TblId:     tableId,
+		Name:      tableName,
+		Cols:      cols,
+		Defs:      defs,
+		TableType: TableType,
+		Createsql: Createsql,
+		Pkey:      primarykey,
+		//CompositePkey: CompositePkey,
+		ViewSql:      viewSql,
+		Partition:    partitionInfo,
+		Fkeys:        foreignKeys,
+		RefChildTbls: refChildTbls,
+		ClusterBy:    clusterByDef,
+		Indexes:      indexes,
+		Version:      schemaVersion,
+	}
+	return obj, tableDef
+}

--- a/pkg/sql/compile/sql_executor_test.go
+++ b/pkg/sql/compile/sql_executor_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compile
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadRows(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer func() {
+		require.Equal(t, int64(0), mp.CurrNB())
+	}()
+
+	res := Result{mp: mp}
+	bat := newBatch(2)
+	appendCols(t, bat, 0, types.New(types.T_int32, 0, 0), []int32{1, 2, 3, 4}, mp)
+	appendBytesCols(t, bat, 1, types.New(types.T_varchar, 2, 0), [][]byte{[]byte("s1"), []byte("s2"), []byte("s3"), []byte("s4")}, mp)
+	res.batches = append(res.batches, bat)
+
+	bat = newBatch(2)
+	appendCols(t, bat, 0, types.New(types.T_int32, 0, 0), []int32{5, 6, 7, 8}, mp)
+	appendBytesCols(t, bat, 1, types.New(types.T_varchar, 2, 0), [][]byte{[]byte("s5"), []byte("s6"), []byte("s7"), []byte("s8")}, mp)
+	res.batches = append(res.batches, bat)
+
+	defer res.Close()
+
+	var col1 []int32
+	var col2 [][]byte
+	var cols2WithString []string
+	res.ReadRows(func(cols []*vector.Vector) bool {
+		col1 = append(col1, GetFixedRows[int32](cols[0])...)
+		col2 = append(col2, GetBytesRows(cols[1])...)
+		cols2WithString = append(cols2WithString, GetStringRows(cols[1])...)
+		return true
+	})
+	assert.Equal(t, []int32{1, 2, 3, 4, 5, 6, 7, 8}, col1)
+	assert.Equal(t, [][]byte{[]byte("s1"), []byte("s2"), []byte("s3"), []byte("s4"), []byte("s5"), []byte("s6"), []byte("s7"), []byte("s8")}, col2)
+	assert.Equal(t, []string{"s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"}, cols2WithString)
+}
+
+func newBatch(cols int) *batch.Batch {
+	bat := batch.NewWithSize(cols)
+	bat.InitZsOne(cols)
+	return bat
+}
+
+func appendCols[T any](
+	t *testing.T,
+	bat *batch.Batch,
+	colIndex int,
+	tp types.Type,
+	values []T,
+	mp *mpool.MPool) {
+
+	col := vector.NewVec(tp)
+	require.NoError(t, vector.AppendFixedList(col, values, nil, mp))
+	bat.Vecs[colIndex] = col
+}
+
+func appendBytesCols(
+	t *testing.T,
+	bat *batch.Batch,
+	colIndex int,
+	tp types.Type,
+	values [][]byte,
+	mp *mpool.MPool) {
+
+	col := vector.NewVec(tp)
+	for _, v := range values {
+		require.NoError(t, vector.AppendBytes(col, v[:], false, mp))
+	}
+	bat.Vecs[colIndex] = col
+}

--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Matrix Origin
+// Copyright 2023 Matrix Origin
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"
@@ -198,4 +199,36 @@ type RemoteReceivRegInfo struct {
 	Idx      int
 	Uuid     uuid.UUID
 	FromAddr string
+}
+
+// SQLExecutor is used to execute internal sql. All internal requirements for writing
+// data should be done using the internal sql executor, otherwise pessimistic transactions
+// may not work.
+type SQLExecutor interface {
+	// Exec exec a sql in a exists txn.
+	Exec(ctx context.Context, sql string, opts Options) (Result, error)
+	// ExecTxn executor sqls in a txn. execFunc can use TxnExecutor to exec multiple sqls
+	// in a transaction.
+	ExecTxn(ctx context.Context, execFunc func(TxnExecutor) error, opts Options) error
+}
+
+// TxnExecutor exec all sqls in a transaction.
+type TxnExecutor interface {
+	Exec(sql string) (Result, error)
+}
+
+// Options execute options.
+type Options struct {
+	txnOp          client.TxnOperator
+	database       string
+	accoundID      uint32
+	minCommittedTS timestamp.Timestamp
+	innerTxn       bool
+}
+
+// Result exec sql result
+type Result struct {
+	affectedRows uint64
+	batches      []*batch.Batch
+	mp           *mpool.MPool
 }

--- a/pkg/tests/txn/cluster_basic_test.go
+++ b/pkg/tests/txn/cluster_basic_test.go
@@ -155,7 +155,6 @@ func TestWriteSkewIsAllowed(t *testing.T) {
 }
 
 func TestBasicSingleShardWithInternalSQLExecutor(t *testing.T) {
-	defer leaktest.AfterTest(t)()
 	if testing.Short() {
 		t.Skip("skipping in short mode.")
 		return
@@ -205,6 +204,7 @@ func TestBasicSingleShardWithInternalSQLExecutor(t *testing.T) {
 					})
 					require.Equal(t, []int32{1, 2, 3}, ids)
 					require.Equal(t, []string{"a", "b", "c"}, names)
+					res.Close()
 					return nil
 				},
 				compile.Options{}.WithDatabase("zx"))

--- a/pkg/tests/txn/cluster_basic_test.go
+++ b/pkg/tests/txn/cluster_basic_test.go
@@ -15,11 +15,16 @@
 package txn
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/lni/goutils/leaktest"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/sql/compile"
 	"github.com/matrixorigin/matrixone/pkg/tests/service"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/stretchr/testify/require"
@@ -145,6 +150,64 @@ func TestWriteSkewIsAllowed(t *testing.T) {
 
 			checkRead(t, mustNewTxn(t, cli), k1, "b", nil, true)
 			checkRead(t, mustNewTxn(t, cli), k2, "a", nil, true)
+		})
+	}
+}
+
+func TestBasicSingleShardWithInternalSQLExecutor(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	if testing.Short() {
+		t.Skip("skipping in short mode.")
+		return
+	}
+
+	// this case will start a mo cluster with 1 CNService, 1 DNService and 3 LogService.
+	// A Txn read and write will success.
+	for name, options := range testOptionsSet {
+		t.Run(name, func(t *testing.T) {
+			c, err := NewCluster(t,
+				getBasicClusterOptions(options...))
+			require.NoError(t, err)
+			defer c.Stop()
+			c.Start()
+
+			v, ok := runtime.ProcessLevelRuntime().GetGlobalVariables(runtime.InternalSQLExecutor)
+			if !ok {
+				panic("missing internal sql executor")
+			}
+			exec := v.(compile.SQLExecutor)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+			exec.ExecTxn(
+				ctx,
+				func(te compile.TxnExecutor) error {
+					res, err := te.Exec("create database zx")
+					require.NoError(t, err)
+					res.Close()
+
+					res, err = te.Exec("create table t1 (id int primary key, name varchar(255))")
+					require.NoError(t, err)
+					res.Close()
+
+					res, err = te.Exec("insert into t1 values (1, 'a'),(2, 'b'),(3, 'c')")
+					require.NoError(t, err)
+					require.Equal(t, uint64(3), res.GetAffectedRows())
+					res.Close()
+
+					res, err = te.Exec("select id,name from t1 order by id")
+					require.NoError(t, err)
+					var ids []int32
+					var names []string
+					res.ReadRows(func(cols []*vector.Vector) bool {
+						ids = append(ids, compile.GetFixedRows[int32](cols[0])...)
+						names = append(names, compile.GetStringRows(cols[1])...)
+						return true
+					})
+					require.Equal(t, []int32{1, 2, 3}, ids)
+					require.Equal(t, []string{"a", "b", "c"}, names)
+					return nil
+				},
+				compile.Options{}.WithDatabase("zx"))
 		})
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Add internal sql executor, without any permission check.  And support execute internal sql in an existing txn, or you can create a new txn to execute sql.  Can ue internal sql executor like as below:
```go
v, ok := runtime.ProcessLevelRuntime().GetGlobalVariables(runtime.InternalSQLExecutor)
if !ok {
panic("missing internal sql executor")
}
exec := v.(compile.SQLExecutor)
ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
defer cancel()
exec.ExecTxn(
ctx,
func(te compile.TxnExecutor) error {
	res, err := te.Exec("create database zx")
	require.NoError(t, err)
	res.Close()

	res, err = te.Exec("create table t1 (id int primary key, name varchar(255))")
	require.NoError(t, err)
	res.Close()

	res, err = te.Exec("insert into t1 values (1, 'a'),(2, 'b'),(3, 'c')")
	require.NoError(t, err)
	require.Equal(t, uint64(3), res.GetAffectedRows())
	res.Close()

	res, err = te.Exec("select id,name from t1 order by id")
	require.NoError(t, err)
	var ids []int32
	var names []string
	res.ReadRows(func(cols []*vector.Vector) bool {
		ids = append(ids, compile.GetFixedRows[int32](cols[0])...)
		names = append(names, compile.GetStringRows(cols[1])...)
		return true
	})
	require.Equal(t, []int32{1, 2, 3}, ids)
	require.Equal(t, []string{"a", "b", "c"}, names)
	return nil
},
compile.Options{}.WithDatabase("zx"))
```