### PR TITLE
fix: fixed tls handshake race

### DIFF
--- a/pkg/proxy/handler_test.go
+++ b/pkg/proxy/handler_test.go
@@ -307,11 +307,10 @@ func TestHandler_HandleWithSSL(t *testing.T) {
 		_ = db.Close()
 	}()
 	_, _ = db.Exec("any stmt")
-	// FIXME: Although the functional code is ok, but this test case
-	// occasionally fails.
-	// require.NoError(t, err)
-	// require.Equal(t, int64(1), s.counterSet.connAccepted.Load())
-	// require.Equal(t, int64(1), s.counterSet.connTotal.Load())
+	_, err = db.Exec("any stmt")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), s.counterSet.connAccepted.Load())
+	require.Equal(t, int64(1), s.counterSet.connTotal.Load())
 }
 
 func testWithServer(t *testing.T, fn func(*testing.T, string, *Server)) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

`TestHandler_HandleWithSSL` occasionally fails, which indicates the client will occasionally fail to complete TLS handshake when TLS is enabled.

## What this PR does / why we need it:

As explained in https://github.com/fagongzi/goetty/pull/49, the TLS handshake packet might have been read into goetty's read buffer. TLS handshake must read from the buffer first, otherwise the handshake packet might lost and the handhshake would timeout.

Goetty is bumped to https://github.com/matrixorigin/goetty/commit/a657e607e505cc8e3d663998848804632cc53edb as well.