### PR TITLE
CI: add 'make compose' and 'make compose-clean', modify e2e-compose workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,6 @@ test/distributed/resources/into_outfile/outfile_*.csv
 test/distributed/resources/into_outfile_2/outfile_*.csv
 test/distributed/resources/json/export_*.csv
 
+#make compose bvt generate files
+docker-compose-log/
+

--- a/.github/workflows/e2e-compose.yml
+++ b/.github/workflows/e2e-compose.yml
@@ -26,11 +26,13 @@ jobs:
         run: echo "run attempt is ${{ github.run_attempt }}"
   
       - name: docker compose launch-tae-multi-CN-tae-DN
-        run: |    
+        run: |
           sed -i 's/enable-sacrificing-freshness = false/enable-sacrificing-freshness = true/' ./etc/launch-tae-compose/config/cn-0.toml
           sed -i 's/enable-sacrificing-freshness = false/enable-sacrificing-freshness = true/' ./etc/launch-tae-compose/config/cn-1.toml
           cat ./etc/launch-tae-compose/config/cn-0.toml
           cat ./etc/launch-tae-compose/config/cn-1.toml
+
+          mkdir -p ${{ github.workspace }}/docker-compose-log
           docker-compose -f etc/launch-tae-compose/compose.yaml --profile launch-tae-multi-CN-tae-DN up -d --build
           # wait for ready
           sleep 10
@@ -64,14 +66,9 @@ jobs:
       - name: export log
         if: ${{ failure() }}
         run: |
-          mkdir -p ${{ github.workspace }}/multi-cn-docker-compose-log
-          docker compose -f etc/launch-tae-compose/compose.yaml --profile launch-tae-multi-CN-tae-DN logs cn-0 >   ${{ github.workspace }}/multi-cn-docker-compose-log/cn-0.log
-          docker compose -f etc/launch-tae-compose/compose.yaml --profile launch-tae-multi-CN-tae-DN logs cn-1 >   ${{ github.workspace }}/multi-cn-docker-compose-log/cn-1.log
-          docker compose -f etc/launch-tae-compose/compose.yaml --profile launch-tae-multi-CN-tae-DN logs dn >  ${{ github.workspace }}/multi-cn-docker-compose-log/dn.log
-          docker compose -f etc/launch-tae-compose/compose.yaml --profile launch-tae-multi-CN-tae-DN logs logservice >  ${{ github.workspace }}/multi-cn-docker-compose-log/logservice.log
-          mv  ${{ github.workspace }}/mo-tester/report ${{ github.workspace }}/multi-cn-docker-compose-log
-          curl http://localhost:12345/debug/pprof/goroutine\?debug=2 -o ${{ github.workspace }}/multi-cn-docker-compose-log/cn-0-dump-stacks.log
-          curl http://localhost:22345/debug/pprof/goroutine\?debug=2 -o ${{ github.workspace }}/multi-cn-docker-compose-log/cn-1-dump-stacks.log
+          mv  ${{ github.workspace }}/mo-tester/report ${{ github.workspace }}/docker-compose-log
+          curl http://localhost:12345/debug/pprof/goroutine\?debug=2 -o ${{ github.workspace }}/docker-compose-log/cn-0-dump-stacks.log
+          curl http://localhost:22345/debug/pprof/goroutine\?debug=2 -o ${{ github.workspace }}/docker-compose-log/cn-1-dump-stacks.log
 
 
       - name: shutdown containers
@@ -86,5 +83,5 @@ jobs:
         with:
           name: multi-cn-e2e-push-docker-compose-log
           path: |
-             ${{ github.workspace }}/multi-cn-docker-compose-log
+             ${{ github.workspace }}/docker-compose-log
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ test/distributed/resources/into_outfile/outfile_*.csv
 test/distributed/resources/into_outfile_2/outfile_*.csv
 test/distributed/resources/json/export_*.csv
 /protobuf/
+
+# docker compose bvt generate files
+docker-compose-log/

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,23 @@ ci-clean:
 	@docker rmi matrixorigin/matrixone:local-ci
 	@docker image prune -f
 
+
+###############################################################################
+# docker compose bvt test
+###############################################################################
+
+COMPOSE_LAUNCH := "launch-tae-multi-CN-tae-DN"
+
+.PHONY: compose
+compose:
+	@cd optools/compose_bvt && ./compose_bvt.sh $(ROOT_DIR) $(COMPOSE_LAUNCH)
+
+.PHONY: compose-clean
+compose-clean:
+	@docker compose -f etc/launch-tae-compose/compose.yaml --profile launch-tae-multi-CN-tae-DN down --remove-orphans
+	@docker volume rm launch-tae-compose_minio_storage
+	@docker image prune -f
+
 ###############################################################################
 # clean
 ###############################################################################

--- a/etc/launch-tae-compose/compose.yaml
+++ b/etc/launch-tae-compose/compose.yaml
@@ -8,7 +8,7 @@ x-mo-common: &mo-common
       context: ../../
       dockerfile: ./optools/images/Dockerfile
       args:
-        GOPROXY: "https://goproxy.cn,direct"
+        GOPROXY: "https://proxy.golang.org,direct"
     image: matrixorigin/matrixone:latest
     volumes:
       - ../../etc/launch-tae-compose/config:/config

--- a/etc/launch-tae-compose/compose.yaml
+++ b/etc/launch-tae-compose/compose.yaml
@@ -8,11 +8,12 @@ x-mo-common: &mo-common
       context: ../../
       dockerfile: ./optools/images/Dockerfile
       args:
-        GOPROXY: "https://proxy.golang.org,direct"
+        GOPROXY: "https://goproxy.cn,direct"
     image: matrixorigin/matrixone:latest
     volumes:
       - ../../etc/launch-tae-compose/config:/config
       - ../../test:/test
+      - ../../docker-compose-log:/log
     restart: on-failure
     tty: true
 
@@ -21,7 +22,7 @@ services:
   cn-0:
     container_name: cn-0
     <<: *mo-common
-    entrypoint: ["/mo-service", "-debug-http", ":12345", "-cfg", "/config/cn-0.toml"]
+    entrypoint: ["/bin/bash","-c","set -euo pipefail; /mo-service -debug-http :12345 -cfg /config/cn-0.toml | tee /log/cn-0.log"]
     profiles:
       - launch-tae-CN-tae-DN
       - launch-tae-multi-CN-tae-DN
@@ -36,11 +37,13 @@ services:
       - AWS_SECRET_ACCESS_KEY=minio123
     networks:
       monet:
+        aliases:
+          - "cn0"
 
   cn-1:
     container_name: cn-1
     <<: *mo-common
-    entrypoint: ["/mo-service", "-debug-http", ":12345", "-cfg", "/config/cn-1.toml"]
+    entrypoint: ["/bin/bash","-c","set -euo pipefail; /mo-service -debug-http :12345 -cfg /config/cn-1.toml | tee /log/cn-1.log"]
     depends_on:
       - dn
     ports:
@@ -54,11 +57,13 @@ services:
       - AWS_SECRET_ACCESS_KEY=minio123
     networks:
       monet:
+        aliases:
+          - "cn1"
 
   dn:
     container_name: dn
     <<: *mo-common
-    entrypoint: ["/mo-service", "-debug-http", ":12345", "-cfg", "/config/dn.toml"]
+    entrypoint: ["/bin/bash","-c","set -euo pipefail; /mo-service -debug-http :12345 -cfg /config/dn.toml | tee /log/dn.log"]
     profiles:
       - launch-tae-CN-tae-DN
       - launch-tae-multi-CN-tae-DN
@@ -71,6 +76,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=minio123
     networks:
       monet:
+        aliases:
+          - "dn"
 
   logservice:
     container_name: logservice
@@ -78,7 +85,7 @@ services:
     profiles:
       - launch-tae-CN-tae-DN
       - launch-tae-multi-CN-tae-DN
-    entrypoint: ["/mo-service", "-debug-http", ":12345", "-cfg", "/config/log.toml"]
+    entrypoint: ["/bin/bash","-c","set -euo pipefail; /mo-service -debug-http :12345 -cfg /config/log.toml | tee /log/logservice.log"]
     depends_on:
       - createbuckets
     ports:
@@ -90,6 +97,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=minio123
     networks:
       monet:
+        aliases:
+          - "logservice"
 
   minio:
     image: minio/minio:latest
@@ -143,6 +152,3 @@ volumes:
 networks:
   monet:
     driver: bridge
-    ipam:
-      config:
-        - subnet: 179.19.0.0/16

--- a/etc/launch-tae-compose/config/log.toml
+++ b/etc/launch-tae-compose/config/log.toml
@@ -47,7 +47,7 @@ deployment-id = 1
 uuid = "7c4dccb4-4d3c-41f8-b482-5251dc7a41bf"
 raft-address = "logservice:32000"
 logservice-address = "logservice:32001"
-gossip-address = "179.19.0.4:32002"
+gossip-address-v2 = "logservice:32002"
 logservice-listen-address = "0.0.0.0:32001"
 gossip-seed-addresses = [
   "logservice:32002",

--- a/optools/compose_bvt/Dockerfile.tester
+++ b/optools/compose_bvt/Dockerfile.tester
@@ -2,11 +2,7 @@ FROM matrixorigin/tester:go1.20-jdk8
 
 WORKDIR /
 
-ENV https_proxy 'http://10.222.1.111:8080'
-
 RUN git clone https://github.com/matrixorigin/mo-tester.git && apt update && apt install -y mariadb-client
-
-ENV https_proxy ''
 
 COPY . /matrixone
 

--- a/optools/compose_bvt/Dockerfile.tester
+++ b/optools/compose_bvt/Dockerfile.tester
@@ -1,0 +1,17 @@
+FROM matrixorigin/tester:go1.20-jdk8
+
+WORKDIR /
+
+ENV https_proxy 'http://10.222.1.111:8080'
+
+RUN git clone https://github.com/matrixorigin/mo-tester.git && apt update && apt install -y mariadb-client
+
+ENV https_proxy ''
+
+COPY . /matrixone
+
+RUN cd mo-tester && sed -i 's/127.0.0.1/cn0/g' mo.yml
+
+ENV LC_ALL 'C.UTF-8'
+
+CMD ["/matrixone/optools/compose_bvt/entrypoint.sh"]

--- a/optools/compose_bvt/compose_bvt.sh
+++ b/optools/compose_bvt/compose_bvt.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+MO_WORKSPACE=$1
+COMPOSE_LAUNCH=$2
+
+function export_logs() {
+    cd ${MO_WORKSPACE}
+    #docker compose -f etc/launch-tae-compose/compose.yaml --profile ${COMPOSE_LAUNCH}  logs cn-0 >  docker-compose-log/cn-0.log
+    #docker compose -f etc/launch-tae-compose/compose.yaml --profile ${COMPOSE_LAUNCH} logs cn-1 >  docker-compose-log/cn-1.log
+    #docker compose -f etc/launch-tae-compose/compose.yaml --profile ${COMPOSE_LAUNCH} logs dn > docker-compose-log/dn.log
+    #docker compose -f etc/launch-tae-compose/compose.yaml --profile ${COMPOSE_LAUNCH} logs logservice > docker-compose-log/logservice.log
+    curl http://localhost:12345/debug/pprof/goroutine\?debug=2 -o docker-compose-log/cn-0-dump-stacks.log
+    curl http://localhost:22345/debug/pprof/goroutine\?debug=2 -o docker-compose-log/cn-1-dump-stacks.log
+    sed -i.bak 's/enable-sacrificing-freshness = true/enable-sacrificing-freshness = false/' ./etc/launch-tae-compose/config/cn-0.toml
+    sed -i.bak 's/enable-sacrificing-freshness = true/enable-sacrificing-freshness = false/' ./etc/launch-tae-compose/config/cn-1.toml
+    rm -f ./etc/launch-tae-compose/config/*.bak
+}
+
+function compose_bvt() {
+    trap "export_logs" EXIT
+
+    cd ${MO_WORKSPACE}
+    sed -i.bak 's/enable-sacrificing-freshness = false/enable-sacrificing-freshness = true/' ./etc/launch-tae-compose/config/cn-0.toml
+    sed -i.bak 's/enable-sacrificing-freshness = false/enable-sacrificing-freshness = true/' ./etc/launch-tae-compose/config/cn-1.toml
+
+    docker compose -f etc/launch-tae-compose/compose.yaml --profile "${COMPOSE_LAUNCH}" up -d --build
+    docker build -t matrixorigin/compose_tester:local -f optools/compose_bvt/Dockerfile.tester .
+    docker run -it --name compose-tester --privileged --network launch-tae-compose_monet -v ${MO_WORKSPACE}/docker-compose-log:/test --rm matrixorigin/compose_tester:local
+    exit 0
+}
+
+#create the dir for export logs
+rm -rf ${MO_WORKSPACE}/docker-compose-log && mkdir -p ${MO_WORKSPACE}/docker-compose-log
+
+compose_bvt
+
+exit $?

--- a/optools/compose_bvt/compose_bvt.sh
+++ b/optools/compose_bvt/compose_bvt.sh
@@ -7,15 +7,12 @@ COMPOSE_LAUNCH=$2
 
 function export_logs() {
     cd ${MO_WORKSPACE}
-    #docker compose -f etc/launch-tae-compose/compose.yaml --profile ${COMPOSE_LAUNCH}  logs cn-0 >  docker-compose-log/cn-0.log
-    #docker compose -f etc/launch-tae-compose/compose.yaml --profile ${COMPOSE_LAUNCH} logs cn-1 >  docker-compose-log/cn-1.log
-    #docker compose -f etc/launch-tae-compose/compose.yaml --profile ${COMPOSE_LAUNCH} logs dn > docker-compose-log/dn.log
-    #docker compose -f etc/launch-tae-compose/compose.yaml --profile ${COMPOSE_LAUNCH} logs logservice > docker-compose-log/logservice.log
-    curl http://localhost:12345/debug/pprof/goroutine\?debug=2 -o docker-compose-log/cn-0-dump-stacks.log
-    curl http://localhost:22345/debug/pprof/goroutine\?debug=2 -o docker-compose-log/cn-1-dump-stacks.log
     sed -i.bak 's/enable-sacrificing-freshness = true/enable-sacrificing-freshness = false/' ./etc/launch-tae-compose/config/cn-0.toml
     sed -i.bak 's/enable-sacrificing-freshness = true/enable-sacrificing-freshness = false/' ./etc/launch-tae-compose/config/cn-1.toml
     rm -f ./etc/launch-tae-compose/config/*.bak
+    curl http://localhost:12345/debug/pprof/goroutine\?debug=2 -o docker-compose-log/cn-0-dump-stacks.log
+    curl http://localhost:22345/debug/pprof/goroutine\?debug=2 -o docker-compose-log/cn-1-dump-stacks.log
+
 }
 
 function compose_bvt() {

--- a/optools/compose_bvt/entrypoint.sh
+++ b/optools/compose_bvt/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SECONDS=0
+
+# mv log to mount path
+function packLog() {
+    mv /mo-tester/report /test/
+
+    duration=$SECONDS
+    echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
+}
+
+function run_bvt() {
+    trap packLog EXIT
+    while [ $(mariadb -h cn0 -P 6001 -u dump -p111 --execute 'show databases;' 2>&1 | wc -l) -le 1 ]; do
+        echo 'wait mo init finished'
+        sleep 1
+    done
+    cd /mo-tester && ./run.sh -n -g -p /matrixone/test/distributed/cases/ -s /test/distributed/resources 2>&1
+}
+
+run_bvt


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
1. add 'make compose' and 'make compose-clean'  command
2. change the method of export log in e2e-cmpose.yaml by modify image entrypoint