### PR TITLE
Avoid copying rowid in blockreader

### DIFF
--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -206,7 +206,11 @@ func readBlockData(
 	hasRowId, idxes, typs := getRowsIdIndex(colIndexes, colTypes)
 	if hasRowId {
 		// generate rowid
-		rowid = vp.GetVector(objectio.RowidType)
+		if vp == nil {
+			rowid = vector.NewVec(objectio.RowidType)
+		} else {
+			rowid = vp.GetVector(objectio.RowidType)
+		}
 		if err = objectio.ConstructRowidColumnTo(
 			rowid,
 			&info.BlockID,

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -135,6 +135,10 @@ func BlockReadInner(
 	result = batch.NewWithSize(len(loaded.Vecs))
 	for i, col := range loaded.Vecs {
 		typ := *col.GetType()
+		if typ.Oid == types.T_Rowid {
+			result.Vecs[i] = col
+			continue
+		}
 		if vp == nil {
 			result.Vecs[i] = vector.NewVec(typ)
 		} else {
@@ -149,12 +153,11 @@ func BlockReadInner(
 		}
 	}
 
-	if rowid != nil {
-		rowid.Free(mp)
-	}
-
 	if err != nil {
 		for _, col := range result.Vecs {
+			if col.GetType().Oid == types.T_Rowid {
+				continue
+			}
 			if col != nil {
 				col.Free(mp)
 			}

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -103,13 +103,13 @@ func BlockReadInner(
 	vp engine.VectorPool,
 ) (result *batch.Batch, err error) {
 	var (
-		rowid       *vector.Vector
+		//rowid       *vector.Vector
 		deletedRows []int64
 		loaded      *batch.Batch
 	)
 
 	// read block data from storage
-	if loaded, rowid, deletedRows, err = readBlockData(
+	if loaded, _, deletedRows, err = readBlockData(
 		ctx, seqnums, colTypes, info, ts, fs, mp,
 	); err != nil {
 		return

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -137,6 +137,10 @@ func BlockReadInner(
 		typ := *col.GetType()
 		if typ.Oid == types.T_Rowid {
 			result.Vecs[i] = col
+			// shrink the vector by deleted rows
+			if len(deletedRows) > 0 {
+				result.Vecs[i].Shrink(deletedRows, true)
+			}
 			continue
 		}
 		if vp == nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
The rowid is generated by encoding and is not stored in the fileservice cache, so there is no need for blockreader to copy it