### PR TITLE
fix locktable events workers leak

### DIFF
--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -60,7 +60,6 @@ func newLocalLockTable(
 		events:   events,
 	}
 	l.mu.store = newBtreeBasedStorage()
-	l.events.start()
 	return l
 }
 

--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -65,6 +65,7 @@ func NewLockService(cfg Config) LockService {
 		s.abortDeadlockTxn)
 	s.clock = runtime.ProcessLevelRuntime().Clock()
 	s.initRemote()
+	s.events.start()
 	return s
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
events workers started when every local lock table created, it makes goroutines leak. it must be only start one times.