### PR TITLE
fix lock multi-rows may lost if current lock found

### DIFF
--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -247,7 +247,6 @@ func (l *localLockTable) acquireRowLockLocked(c lockContext) lockContext {
 						panic("BUG: waiters should be empty, " + str + "," + v.String() + ", " + fmt.Sprintf("table(%d)  %+v", l.bind.Table, key))
 					}
 					c.w = nil
-					return c
 				}
 				continue
 			}

--- a/pkg/lockservice/lock_table_local_test.go
+++ b/pkg/lockservice/lock_table_local_test.go
@@ -579,6 +579,64 @@ func TestMergeRangeWithConflict(t *testing.T) {
 		})
 }
 
+func TestLocalLockTableMulitiRowLocksCannotMissIfFoundSelfTxn(t *testing.T) {
+	runLockServiceTests(
+		t,
+		[]string{"s1"},
+		func(_ *lockTableAllocator, s []*service) {
+			l := s[0]
+			ctx, cancel := context.WithTimeout(context.Background(),
+				time.Second*10)
+			defer cancel()
+
+			mustAddTestLock(
+				t,
+				ctx,
+				l,
+				1,
+				[]byte{2},
+				[][]byte{{1}},
+				pb.Granularity_Row)
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				mustAddTestLock(
+					t,
+					ctx,
+					l,
+					1,
+					[]byte{1},
+					[][]byte{{1}},
+					pb.Granularity_Row)
+			}()
+			go func() {
+				defer wg.Done()
+				waitWaiters(t, l, 1, []byte{1}, 1)
+				mustAddTestLock(
+					t,
+					ctx,
+					l,
+					1,
+					[]byte{1},
+					[][]byte{{1}, {2}},
+					pb.Granularity_Row)
+			}()
+
+			waitWaiters(t, l, 1, []byte{1}, 1, 1)
+			require.NoError(t, l.Unlock(ctx, []byte{2}, timestamp.Timestamp{}))
+
+			wg.Wait()
+			v, err := l.getLockTable(1)
+			require.NoError(t, err)
+			lt := v.(*localLockTable)
+			lt.mu.Lock()
+			defer lt.mu.Unlock()
+			require.Equal(t, 2, lt.mu.store.Len())
+		})
+}
+
 func getRowOptions() pb.LockOptions {
 	return pb.LockOptions{Granularity: pb.Granularity_Row}
 }

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -804,6 +804,7 @@ func waitWaiters(
 	s *service,
 	table uint64,
 	key []byte,
-	waitersCount int) {
-	require.NoError(t, WaitWaiters(s, table, key, waitersCount))
+	waitersCount int,
+	sameTxnCounts ...int) {
+	require.NoError(t, WaitWaiters(s, table, key, waitersCount, sameTxnCounts...))
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
may lost locks in below flow:
1. txn1 hold row1
2. txn2/op1 lock row1 will wait txn1 on row1
3. txn2/op2 lock row1 and row2 will add into txn2/op1's same txn list, also wait on row1
4. txn1 unlock, and txn1/op1 added lock row1
5. txn1/op2 will missing row2