### PR TITLE
lockservice: add ready status to waiter to avoid invalid notify

### DIFF
--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -98,7 +98,7 @@ func (l *localLockTable) doLock(
 			}
 			// no waiter, all locks are added
 			if c.w == nil {
-				c.txn.setBlocked(c.txn.txnID, nil, false)
+				c.txn.clearBlocked(c.txn.txnID, false)
 				logLocalLockAdded(l.bind.ServiceID, c.txn, l.bind.Table, c.rows, c.opts)
 				if c.result.Timestamp.IsEmpty() {
 					c.result.Timestamp = c.lockedTS

--- a/pkg/lockservice/lock_table_local_test.go
+++ b/pkg/lockservice/lock_table_local_test.go
@@ -425,6 +425,7 @@ func TestMergeRangeWithNoConflict(t *testing.T) {
 					var wg sync.WaitGroup
 					for _, txnID := range c.existsWaiters[i] {
 						w := acquireWaiter("", []byte(txnID))
+						w.setStatus("", blocking)
 						lock.waiter.add("", w)
 						wg.Add(1)
 						require.NoError(t, stopper.RunTask(func(ctx context.Context) {

--- a/pkg/lockservice/txn.go
+++ b/pkg/lockservice/txn.go
@@ -16,6 +16,7 @@ package lockservice
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 
 	"github.com/matrixorigin/matrixone/pkg/common/util"
@@ -239,7 +240,7 @@ func (txn *activeTxn) fetchWhoWaitingMe(
 	return true
 }
 
-func (txn *activeTxn) setBlocked(txnID []byte, w *waiter, locked bool) {
+func (txn *activeTxn) clearBlocked(txnID []byte, locked bool) {
 	if !locked {
 		txn.Lock()
 		defer txn.Unlock()
@@ -250,10 +251,29 @@ func (txn *activeTxn) setBlocked(txnID []byte, w *waiter, locked bool) {
 		panic("invalid set Blocked")
 	}
 
-	txn.blockedWaiter = w
-	if w != nil {
-		return
+	txn.blockedWaiter = nil
+}
+
+func (txn *activeTxn) setBlocked(txnID []byte, w *waiter, locked bool) {
+	if !locked {
+		txn.Lock()
+		defer txn.Unlock()
 	}
+
+	if w == nil {
+		panic("invalid waiter")
+	}
+
+	// txn already closed
+	if !bytes.Equal(txn.txnID, txnID) {
+		panic("invalid set Blocked")
+	}
+
+	if !w.casStatus("", ready, blocking) {
+		panic(fmt.Sprintf("invalid waiter status %d, %s", w.getStatus(), w))
+	}
+
+	txn.blockedWaiter = w
 }
 
 func (txn *activeTxn) isRemoteLocked() bool {

--- a/pkg/lockservice/waiter.go
+++ b/pkg/lockservice/waiter.go
@@ -54,14 +54,15 @@ func newWaiter() *waiter {
 		waiters: newWaiterQueue(),
 	}
 	w.setFinalizer()
-	w.setStatus("", waiting)
+	w.setStatus("", ready)
 	return w
 }
 
 type waiterStatus int32
 
 const (
-	waiting waiterStatus = iota
+	ready waiterStatus = iota
+	blocking
 	notified
 	completed
 )
@@ -218,7 +219,7 @@ func (w *waiter) mustSendNotification(
 }
 
 func (w *waiter) resetWait(serviceID string) {
-	if w.casStatus(serviceID, completed, waiting) {
+	if w.casStatus(serviceID, completed, ready) {
 		w.event = event{}
 		return
 	}
@@ -229,7 +230,7 @@ func (w *waiter) wait(
 	ctx context.Context,
 	serviceID string) notifyValue {
 	status := w.getStatus()
-	if status != waiting &&
+	if status != blocking &&
 		status != notified {
 		panic(fmt.Sprintf("BUG: waiter's status cannot be %d", status))
 	}
@@ -266,14 +267,9 @@ func (w *waiter) notify(serviceID string, value notifyValue) bool {
 
 	for {
 		status := w.getStatus()
-		// already notified, no wait on w
-		if status == notified {
-			logWaiterNotifySkipped(serviceID, debug, "already notified")
-			return false
-		}
-		if status == completed {
-			// wait already completed, wait timeout or wait a result.
-			logWaiterNotifySkipped(serviceID, debug, "already completed")
+		// not on wait, no need to notify
+		if status != blocking {
+			logWaiterNotifySkipped(serviceID, debug, "waiter not in blocking")
 			return false
 		}
 
@@ -358,7 +354,7 @@ func (w *waiter) reset(serviceID string) {
 	w.txnID = nil
 	w.event = event{}
 	w.latestCommitTS = timestamp.Timestamp{}
-	w.setStatus(serviceID, waiting)
+	w.setStatus(serviceID, ready)
 	w.waitTxn = pb.WaitTxn{}
 	w.waiters.reset()
 	w.sameTxnWaiters = w.sameTxnWaiters[:0]


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Add a new status "ready" to waiter status to avoid received a invalid notify. The notify can only at blocking status. 