### PR TITLE
txn.WrapError handles all types of errors

### DIFF
--- a/pkg/pb/txn/txn.go
+++ b/pkg/pb/txn/txn.go
@@ -240,7 +240,7 @@ func WrapError(err error, internalCode uint16) *TxnError {
 		return v
 	}
 
-	panic(fmt.Sprintf("only moerr supported, got %T, %v", err, err.Error()))
+	return WrapError(moerr.NewInternalErrorNoCtx(err.Error()), internalCode)
 }
 
 // UnwrapError unwrap the moerr from the TxnError


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

txn may return context.DeadlineExceeded error. 
Wrap should handle this error instead of just panic.