### PR TITLE
improve auto-increment in load scene

### DIFF
--- a/pkg/incrservice/cfg.go
+++ b/pkg/incrservice/cfg.go
@@ -15,7 +15,7 @@
 package incrservice
 
 const (
-	defaultCountPerAllocate = 3000000
+	defaultCountPerAllocate = 10000
 )
 
 // Config auto increment config

--- a/pkg/incrservice/store_mem.go
+++ b/pkg/incrservice/store_mem.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"math"
 	"sync"
+	"time"
 )
 
 type memStore struct {
@@ -89,6 +90,7 @@ func (s *memStore) Alloc(
 	next := getNext(curr, count, int(c.Step))
 	c.Offset = next
 	from, to := getNextRange(curr, next, int(c.Step))
+	time.Sleep(time.Millisecond * 10)
 	return from, to, nil
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
For the load scenario, if the machine is good enough, there will be very many goroutines to concurrently fetch the value of the auto-increment column, which will immediately trigger the cache of the auto-increment column to be insufficient and thus go to the store to allocate a new cache, which causes the load to block all due to this allocation being slow. The idea of our optimization here is to reduce the number of allocations as much as possible, add an atomic counter, check how many concurrent requests are waiting when allocating (of course this is imprecise, but it doesn't matter), and then allocate more than one at a time.