### PR TITLE
Fix the bug of double free detection in mpool

### DIFF
--- a/pkg/vm/engine/disttae/partition_reader.go
+++ b/pkg/vm/engine/disttae/partition_reader.go
@@ -160,16 +160,22 @@ func (p *PartitionReader) Read(ctx context.Context, colNames []string, expr *pla
 			if err != nil {
 				return nil, err
 			}
-			rbat := bat
-			for i, vec := range rbat.Vecs {
-				rbat.Vecs[i], err = vec.Dup(p.procMPool)
-				if err != nil {
+			rbat := batch.NewWithSize(bat.VectorCount())
+			rbat.SetAttributes(colNames)
+			for i, vec := range bat.Vecs {
+				typ := *vec.GetType()
+				if vp == nil {
+					rbat.Vecs[i] = vector.NewVec(typ)
+				} else {
+					rbat.Vecs[i] = vp.GetVector(typ)
+				}
+				if err := vector.GetUnionAllFunction(typ, mp)(rbat.Vecs[i], vec); err != nil {
+					bat.Clean(p.procMPool)
+					rbat.Clean(p.procMPool)
 					return nil, err
 				}
 			}
-			rbat.SetAttributes(colNames)
-			rbat.Cnt = 1
-			rbat.SetZs(rbat.Vecs[0].Length(), p.procMPool)
+			bat.Clean(p.procMPool)
 
 			var hasRowId bool
 			// note: if there is rowId colName, it must be the last one
@@ -225,11 +231,9 @@ func (p *PartitionReader) Read(ctx context.Context, colNames []string, expr *pla
 				}
 			}
 			logutil.Debugf("read %v with %v", colNames, p.seqnumMp)
-			/*
-				CORNER CASE:
-				if some rowIds[j] is in p.deletes above, then some rows has been filtered.
-				the bat.Length() is not always the right value for the result batch b.
-			*/
+			//		CORNER CASE:
+			//		if some rowIds[j] is in p.deletes above, then some rows has been filtered.
+			//		the bat.Length() is not always the right value for the result batch b.
 			b.SetZs(b.Vecs[0].Length(), mp)
 			logutil.Debug(testutil.OperatorCatchBatch("partition reader[workspace]", b))
 			return b, nil

--- a/pkg/vm/engine/disttae/partition_reader.go
+++ b/pkg/vm/engine/disttae/partition_reader.go
@@ -176,6 +176,7 @@ func (p *PartitionReader) Read(ctx context.Context, colNames []string, expr *pla
 				}
 			}
 			bat.Clean(p.procMPool)
+			rbat.SetZs(rbat.Vecs[0].Length(), p.procMPool)
 
 			var hasRowId bool
 			// note: if there is rowId colName, it must be the last one

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -488,6 +488,7 @@ func (tbl *txnTable) LoadDeletesForBlockIn(
 						panic("Load Block Deletes Error")
 					}
 				}
+				rowIdBat.Clean(tbl.db.txn.proc.GetMPool())
 			}
 		}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9732

## What this PR does / why we need it:
* since the current mpool detection does not take competition into account, there may be some double free missed, and eventually mo will encounter the free > alloc error
* add some missing free