### PR TITLE
keep log internal error with stacktrace info

### DIFF
--- a/pkg/logutil/adapt_cron.go
+++ b/pkg/logutil/adapt_cron.go
@@ -20,7 +20,7 @@ import (
 )
 
 func GetCronLogger(logInfo bool) cron.Logger {
-	logger := GetErrorLogger().Sugar().Named("cron")
+	logger := GetSkip1Logger().Sugar().Named("cron")
 	return &CronLogger{
 		SugaredLogger: logger,
 		logInfo:       logInfo,

--- a/pkg/logutil/api.go
+++ b/pkg/logutil/api.go
@@ -34,7 +34,7 @@ func Warn(msg string, fields ...zap.Field) {
 }
 
 func Error(msg string, fields ...zap.Field) {
-	GetErrorLogger().Error(msg, fields...)
+	GetSkip1Logger().Error(msg, fields...)
 }
 
 func Panic(msg string, fields ...zap.Field) {
@@ -66,9 +66,9 @@ func Warnf(msg string, fields ...interface{}) {
 // Errorf only use in develop mode
 func Errorf(msg string, fields ...interface{}) {
 	if len(fields) == 0 {
-		GetErrorLogger().Error(msg)
+		GetSkip1Logger().Error(msg)
 	} else {
-		GetErrorLogger().Error(fmt.Sprintf(msg, fields...))
+		GetSkip1Logger().Error(fmt.Sprintf(msg, fields...))
 	}
 }
 

--- a/pkg/logutil/internal.go
+++ b/pkg/logutil/internal.go
@@ -65,6 +65,8 @@ func GetSkip1Logger() *zap.Logger {
 	return _skip1Logger.Load().(*zap.Logger)
 }
 
+// GetErrorLogger return logger which stacktrace is zap.ErrorLevel forever.
+// Make sure you need the stacktrace which you do error-log.
 func GetErrorLogger() *zap.Logger {
 	return _errorLogger.Load().(*zap.Logger)
 }
@@ -73,7 +75,8 @@ func GetErrorLogger() *zap.Logger {
 func replaceGlobalLogger(logger *zap.Logger) {
 	_globalLogger.Store(logger)
 	_skip1Logger.Store(logger.WithOptions(zap.AddCallerSkip(1)))
-	_errorLogger.Store(logger.WithOptions(zap.AddCallerSkip(1)))
+	// PS: _errorLogger must have error-level stacktrace.
+	_errorLogger.Store(logger.WithOptions(zap.AddCallerSkip(1), zap.AddStacktrace(zap.ErrorLevel)))
 }
 
 type LogConfig struct {


### PR DESCRIPTION
…do error-log with stack info for moerr.New

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

internal error still need stack info to locate the call chain. So keep logutil.GetErrorLogger() return logger with `stacktrace: error` to do error-log with stack info while calling `moerr.New()`
