### PR TITLE
(disttae): some code change to blockMergeReader for deletes

### DIFF
--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -16,7 +16,6 @@ package disttae
 
 import (
 	"context"
-	"sort"
 
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
@@ -183,24 +182,6 @@ func (r *blockMergeReader) Read(ctx context.Context, cols []string,
 		}
 	}
 
-	logutil.Debugf("read %v with %v", cols, r.seqnums)
-
-	//TODO::there is a bug to fix.
-	//var deletes []int64
-	//if len(r.blks[0].deletes) > 0 {
-	//	deletes := make([]int64, len(r.blks[0].deletes))
-	//	copy(deletes, r.blks[0].deletes)
-	//	//FIXME::why sort deletes?  batch.Shrink need to shrink by the ordered sels.
-	//	sort.Slice(deletes, func(i, j int) bool {
-	//		return deletes[i] < deletes[j]
-	//	})
-	//}
-	bat, err := blockio.BlockRead(r.ctx, info, nil, r.seqnums, r.colTypes, r.ts, r.fs, mp, vp)
-	if err != nil {
-		return nil, err
-	}
-	bat.SetAttributes(cols)
-
 	//start to load deletes, which maybe
 	//in txn.blockId_dn_delete_metaLoc_batch or in partitionState.
 	if _, ok := r.table.db.txn.blockId_dn_delete_metaLoc_batch[r.blks[0].meta.BlockID]; ok {
@@ -210,9 +191,7 @@ func (r *blockMergeReader) Read(ctx context.Context, cols []string,
 		}
 		//TODO:: need to optimize .
 		r.blks[0].deletes = append(r.blks[0].deletes, deletes...)
-
 	}
-
 	{
 		state, err := r.table.getPartitionState(ctx)
 		if err != nil {
@@ -227,22 +206,12 @@ func (r *blockMergeReader) Read(ctx context.Context, cols []string,
 		}
 		iter.Close()
 	}
-	//TODO::there is a bug to fix
-	r.sels = r.sels[:0]
-	deletes := make([]int64, len(r.blks[0].deletes))
-	copy(deletes, r.blks[0].deletes)
-	//sort.Ints(deletes)
-	sort.Slice(deletes, func(i, j int) bool {
-		return deletes[i] < deletes[j]
-	})
-	for i := 0; i < bat.Length(); i++ {
-		if len(deletes) > 0 && i == int(deletes[0]) {
-			deletes = deletes[1:]
-			continue
-		}
-		r.sels = append(r.sels, int64(i))
+
+	bat, err := blockio.BlockRead(r.ctx, info, r.blks[0].deletes, r.seqnums, r.colTypes, r.ts, r.fs, mp, vp)
+	if err != nil {
+		return nil, err
 	}
-	bat.Shrink(r.sels)
+	bat.SetAttributes(cols)
 
 	logutil.Debug(testutil.OperatorCatchBatch("block merge reader", bat))
 	return bat, nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #9309 

## What this PR does / why we need it:

1. Remove low-efficient deletes related logic
2. Pass external deletes into block read API