### PR TITLE
improve tpcc performance a lot by supporting composite primary key filter

### DIFF
--- a/pkg/container/nulls/nulls.go
+++ b/pkg/container/nulls/nulls.go
@@ -371,6 +371,19 @@ func (nsp *Nulls) GetCardinality() int {
 	return nsp.Count()
 }
 
+func (nsp *Nulls) Foreach(fn func(uint64) bool) {
+	if nsp.IsEmpty() {
+		return
+	}
+	itr := nsp.np.Iterator()
+	for itr.HasNext() {
+		row := itr.Next()
+		if !fn(row) {
+			break
+		}
+	}
+}
+
 func (nsp *Nulls) Merge(o *Nulls) {
 	if o.Count() == 0 {
 		return

--- a/pkg/container/vector/utils.go
+++ b/pkg/container/vector/utils.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package vector
 
 import (
@@ -6,6 +20,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 )
 
+// FindFirstIndexInSortedSlice finds the first index of v in a sorted slice s
+// If v is not found, return -1
 func OrderedFindFirstIndexInSortedSlice[T types.OrderedT](v T, s []T) int {
 	if len(s) == 0 {
 		return -1
@@ -34,6 +50,9 @@ func OrderedFindFirstIndexInSortedSlice[T types.OrderedT](v T, s []T) int {
 	return -1
 }
 
+// FindFirstIndexInSortedSlice finds the first index of v in a sorted slice s
+// If v is not found, return -1
+// compare is a function to compare two elements in s
 func FixedSizeFindFirstIndexInSortedSliceWithCompare[T types.FixedSizeTExceptStrType](
 	v T, s []T, compare func(T, T) int64,
 ) int {
@@ -64,6 +83,7 @@ func FixedSizeFindFirstIndexInSortedSliceWithCompare[T types.FixedSizeTExceptStr
 	return -1
 }
 
+// FindFirstIndexInSortedSlice finds the first index of v in a sorted varlen vector
 func FindFirstIndexInSortedVarlenVector(vec *Vector, v []byte) int {
 	length := vec.Length()
 	if length == 0 {

--- a/pkg/container/vector/utils.go
+++ b/pkg/container/vector/utils.go
@@ -1,0 +1,91 @@
+package vector
+
+import (
+	"bytes"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+)
+
+func OrderedFindFirstIndexInSortedSlice[T types.OrderedT](v T, s []T) int {
+	if len(s) == 0 {
+		return -1
+	}
+	if len(s) == 1 {
+		if s[0] == v {
+			return 0
+		}
+		return -1
+	}
+	if s[0] == v {
+		return 0
+	}
+	l, r := 0, len(s)-1
+	for l < r {
+		mid := (l + r) / 2
+		if s[mid] >= v {
+			r = mid
+		} else {
+			l = mid + 1
+		}
+	}
+	if s[l] == v {
+		return l
+	}
+	return -1
+}
+
+func FixedSizeFindFirstIndexInSortedSliceWithCompare[T types.FixedSizeTExceptStrType](
+	v T, s []T, compare func(T, T) int64,
+) int {
+	if len(s) == 0 {
+		return -1
+	}
+	if len(s) == 1 {
+		if s[0] == v {
+			return 0
+		}
+		return -1
+	}
+	if s[0] == v {
+		return 0
+	}
+	l, r := 0, len(s)-1
+	for l < r {
+		mid := (l + r) / 2
+		if compare(s[mid], v) >= 0 {
+			r = mid
+		} else {
+			l = mid + 1
+		}
+	}
+	if s[l] == v {
+		return l
+	}
+	return -1
+}
+
+func FindFirstIndexInSortedVarlenVector(vec *Vector, v []byte) int {
+	length := vec.Length()
+	if length == 0 {
+		return -1
+	}
+	if bytes.Equal(vec.GetBytesAt(0), v) {
+		return 0
+	}
+	if length == 1 {
+		return -1
+	}
+	l, r := 0, length-1
+	for l < r {
+		mid := (l + r) / 2
+		if bytes.Compare(vec.GetBytesAt(mid), v) >= 0 {
+			r = mid
+		} else {
+			l = mid + 1
+		}
+	}
+	if bytes.Equal(vec.GetBytesAt(l), v) {
+		return l
+	}
+	return -1
+}

--- a/pkg/container/vector/utils_test.go
+++ b/pkg/container/vector/utils_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package vector
 
 import (

--- a/pkg/container/vector/utils_test.go
+++ b/pkg/container/vector/utils_test.go
@@ -1,0 +1,62 @@
+package vector
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindFirstIndex(t *testing.T) {
+	testCases := []struct {
+		items  []int32
+		target int32
+		result int
+	}{
+		{[]int32{1, 2, 2, 3, 3}, 3, 3},
+		{[]int32{1, 2, 3, 3, 5}, 3, 2},
+		{[]int32{1, 2, 2, 2, 2}, 3, -1},
+	}
+
+	t.Run("test orderedFindFirstIndexInSortedSlice", func(t *testing.T) {
+		for i, testCase := range testCases {
+			result := OrderedFindFirstIndexInSortedSlice(testCase.target, testCase.items)
+			require.Equal(t, testCase.result, result, "test OrderedFindFirstIndexInSortedSlice at cases[%d], get result is different with expected", i)
+		}
+	})
+}
+
+// test FindFirstIndexInSortedVarlenVector
+func TestFindFirstIndexInSortedVarlenVector(t *testing.T) {
+	mp := mpool.MustNewZero()
+	v1 := NewVec(types.T_char.ToType())
+	err := AppendStringList(v1, []string{"a", "b", "b", "c", "c"}, nil, mp)
+	require.NoError(t, err)
+	defer v1.Free(mp)
+	v2 := NewVec(types.T_char.ToType())
+	err = AppendStringList(v2, []string{"a", "b", "c", "c", "e"}, nil, mp)
+	require.NoError(t, err)
+	defer v2.Free(mp)
+	v3 := NewVec(types.T_char.ToType())
+	err = AppendStringList(v3, []string{"a", "b", "b", "b", "b"}, nil, mp)
+	require.NoError(t, err)
+	defer v3.Free(mp)
+
+	testCases := []struct {
+		items  *Vector
+		target string
+		result int
+	}{
+		{v1, "c", 3},
+		{v2, "c", 2},
+		{v3, "c", -1},
+	}
+
+	t.Run("test FindFirstIndexInSortedVarlenVector", func(t *testing.T) {
+		for i, testCase := range testCases {
+			result := FindFirstIndexInSortedVarlenVector(testCase.items, []byte(testCase.target))
+			require.Equal(t, testCase.result, result, "test FindFirstIndexInSortedVarlenVector at cases[%d], get result is different with expected", i)
+		}
+	})
+}

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/nulls"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -68,6 +69,13 @@ func (mixin *withFilterMixin) tryUpdateColumns(cols []string) {
 	mixin.columns.pkPos = -1
 	mixin.columns.rowidPos = -1
 	mixin.columns.indexOfFirstSortedColumn = -1
+	compPKName2Pos := make(map[string]int)
+	if mixin.tableDef.Pkey != nil && mixin.tableDef.Pkey.CompPkeyCol != nil {
+		pk := mixin.tableDef.Pkey
+		for i, name := range pk.Names {
+			compPKName2Pos[name] = i
+		}
+	}
 	for i, column := range cols {
 		if column == catalog.Row_ID {
 			mixin.columns.rowidPos = i
@@ -80,6 +88,11 @@ func (mixin *withFilterMixin) tryUpdateColumns(cols []string) {
 			colIdx := mixin.tableDef.Name2ColIndex[column]
 			colDef := mixin.tableDef.Cols[colIdx]
 			mixin.columns.seqnums[i] = uint16(colDef.Seqnum)
+
+			if _, ok := compPKName2Pos[column]; ok {
+				compPKName2Pos[column] = i
+			}
+
 			if mixin.tableDef.Pkey != nil && mixin.tableDef.Pkey.PkeyColName == column {
 				// primary key is in the cols
 				mixin.columns.pkPos = i
@@ -90,6 +103,15 @@ func (mixin *withFilterMixin) tryUpdateColumns(cols []string) {
 			// }
 		}
 	}
+	if len(compPKName2Pos) != 0 {
+		for _, name := range mixin.tableDef.Pkey.Names {
+			if pos, ok := compPKName2Pos[name]; !ok {
+				break
+			} else {
+				mixin.columns.compPKPositions = append(mixin.columns.compPKPositions, pos)
+			}
+		}
+	}
 }
 
 func (mixin *withFilterMixin) getReadFilter() (filter blockio.ReadFilter) {
@@ -97,7 +119,74 @@ func (mixin *withFilterMixin) getReadFilter() (filter blockio.ReadFilter) {
 		filter = mixin.filterState.filter
 		return
 	}
+	pk := mixin.tableDef.Pkey
+	if pk == nil {
+		mixin.filterState.evaluated = true
+		mixin.filterState.filter = nil
+		return
+	}
+	if pk.CompPkeyCol == nil {
+		return mixin.getNonCompositPKFilter()
+	}
+	return mixin.getCompositPKFilter()
+}
 
+func (mixin *withFilterMixin) getCompositPKFilter() (filter blockio.ReadFilter) {
+	// if no primary key is included in the columns or no filter expr is given,
+	// no filter is needed
+	if len(mixin.columns.compPKPositions) == 0 || mixin.filterState.expr == nil {
+		mixin.filterState.evaluated = true
+		mixin.filterState.filter = nil
+		return
+	}
+
+	// evaluate
+	pkNames := mixin.tableDef.Pkey.Names
+	pkVals := make([]*plan.Expr_C, len(pkNames))
+	ok := getCompositPKVals(mixin.filterState.expr, pkNames, pkVals)
+
+	if !ok || pkVals[0] == nil {
+		mixin.filterState.evaluated = true
+		mixin.filterState.filter = nil
+		return
+	}
+	cnt := getValidCompositePKCnt(pkVals)
+	pkVals = pkVals[:cnt]
+
+	filterFuncs := make([]func(*vector.Vector, *nulls.Bitmap) *nulls.Bitmap, len(pkVals))
+	for i := range filterFuncs {
+		filterFuncs[i] = getCompositeFilterFuncByExpr(pkVals[i], i == 0)
+	}
+
+	filter = func(vecs []*vector.Vector) []int32 {
+		var sels *nulls.Bitmap
+		for i := range filterFuncs {
+			pos := mixin.columns.compPKPositions[i]
+			vec := vecs[pos]
+			sels = filterFuncs[i](vec, sels)
+			if sels.IsEmpty() {
+				break
+			}
+		}
+		if sels.IsEmpty() {
+			return nil
+		}
+		res := make([]int32, 0, sels.GetCardinality())
+		sels.Foreach(func(i uint64) bool {
+			res = append(res, int32(i))
+			return true
+		})
+		// logutil.Debugf("%s: %d/%d", mixin.tableDef.Name, len(res), vecs[0].Length())
+
+		return res
+	}
+
+	mixin.filterState.evaluated = true
+	mixin.filterState.filter = filter
+	return
+}
+
+func (mixin *withFilterMixin) getNonCompositPKFilter() (filter blockio.ReadFilter) {
 	// if no primary key is included in the columns or no filter expr is given,
 	// no filter is needed
 	if mixin.columns.pkPos == -1 || mixin.filterState.expr == nil {

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -114,7 +114,7 @@ func (mixin *withFilterMixin) getReadFilter() (filter blockio.ReadFilter) {
 	// C: {A|B} and {A|B}
 	// D: {A|B|C} [and {A|B|C}]*
 	// for other patterns, no filter is needed
-	ok, searchFunc := getBinarySearchFuncByExpr(
+	ok, searchFunc := getNonCompositePKSearchFuncByExpr(
 		mixin.filterState.expr,
 		mixin.tableDef.Pkey.PkeyColName,
 		mixin.columns.colTypes[mixin.columns.pkPos].Oid,

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1230,17 +1230,37 @@ func (tbl *txnTable) newMergeReader(ctx context.Context, num int,
 	expr *plan.Expr) ([]engine.Reader, error) {
 
 	var encodedPrimaryKey []byte
-	if tbl.primaryIdx >= 0 && expr != nil {
-		pkColumn := tbl.tableDef.Cols[tbl.primaryIdx]
-		ok, v := getPkValueByExpr(expr, pkColumn.Name, types.T(pkColumn.Typ.Id))
-		if ok {
-			var packer *types.Packer
-			put := tbl.db.txn.engine.packerPool.Get(&packer)
-			defer put.Put()
-			encodedPrimaryKey = logtailreplay.EncodePrimaryKey(v, packer)
+	pk := tbl.tableDef.Pkey
+	if pk != nil && expr != nil {
+		// TODO: workaround for composite primary key
+		// right now for composite primary key, the filter expr will not be pushed down
+		// here we try to serialize the composite primary key
+		if pk.CompPkeyCol != nil {
+			pkVals := make([]*plan.Expr_C, len(pk.Names))
+			getCompositPKVals(expr, pk.Names, pkVals)
+			cnt := getValidCompositePKCnt(pkVals)
+			if cnt == len(pkVals) {
+				var packer *types.Packer
+				put := tbl.db.txn.engine.packerPool.Get(&packer)
+				for _, pkVal := range pkVals {
+					serialTupleByConstExpr(pkVal, packer)
+				}
+				v := packer.Bytes()
+				packer.Reset()
+				encodedPrimaryKey = logtailreplay.EncodePrimaryKey(v, packer)
+				put.Put()
+			}
+		} else {
+			pkColumn := tbl.tableDef.Cols[tbl.primaryIdx]
+			ok, v := getPkValueByExpr(expr, pkColumn.Name, types.T(pkColumn.Typ.Id))
+			if ok {
+				var packer *types.Packer
+				put := tbl.db.txn.engine.packerPool.Get(&packer)
+				encodedPrimaryKey = logtailreplay.EncodePrimaryKey(v, packer)
+				put.Put()
+			}
 		}
 	}
-
 	rds := make([]engine.Reader, num)
 	mrds := make([]mergeReader, num)
 

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -413,6 +413,8 @@ type withFilterMixin struct {
 		colTypes []types.Type
 		// colNulls []bool
 
+		compPKPositions []int // composite primary key pos in the columns
+
 		pkPos    int // -1 means no primary key in columns
 		rowidPos int // -1 means no rowid in columns
 

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -751,6 +751,9 @@ func EvalSelectedOnOrderedSortedColumnFactory[T types.OrderedT](
 	return func(col *vector.Vector, sels *nulls.Bitmap) *nulls.Bitmap {
 		vals := vector.MustFixedCol[T](col)
 		idx := vector.OrderedFindFirstIndexInSortedSlice(v, vals)
+		if idx < 0 {
+			return nil
+		}
 		var newSels nulls.Bitmap
 		if sels.IsEmpty() {
 			for idx < len(vals) {
@@ -787,6 +790,9 @@ func EvalSelectedOnFixedSizeSortedColumnFactory[T types.FixedSizeTExceptStrType]
 	return func(col *vector.Vector, sels *nulls.Bitmap) *nulls.Bitmap {
 		vals := vector.MustFixedCol[T](col)
 		idx := vector.FixedSizeFindFirstIndexInSortedSliceWithCompare(v, vals, comp)
+		if idx < 0 {
+			return nil
+		}
 		var newSels nulls.Bitmap
 		if sels.IsEmpty() {
 			for idx < len(vals) {
@@ -822,6 +828,9 @@ func EvalSelectedOnVarlenSortedColumnFactory(
 ) func(*vector.Vector, *nulls.Bitmap) *nulls.Bitmap {
 	return func(col *vector.Vector, sels *nulls.Bitmap) *nulls.Bitmap {
 		idx := vector.FindFirstIndexInSortedVarlenVector(col, v)
+		if idx < 0 {
+			return nil
+		}
 		var newSels nulls.Bitmap
 		length := col.Length()
 		if sels.IsEmpty() {

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -1027,3 +1027,48 @@ func getCompositeFilterFuncByExpr(
 		panic(fmt.Sprintf("unexpected const expr %v", expr))
 	}
 }
+
+func serialTupleByConstExpr(expr *plan.Expr_C, packer *types.Packer) {
+	switch val := expr.C.Value.(type) {
+	case *plan.Const_Bval:
+		packer.EncodeBool(val.Bval)
+	case *plan.Const_I8Val:
+		packer.EncodeInt8(int8(val.I8Val))
+	case *plan.Const_I16Val:
+		packer.EncodeInt16(int16(val.I16Val))
+	case *plan.Const_I32Val:
+		packer.EncodeInt32(val.I32Val)
+	case *plan.Const_I64Val:
+		packer.EncodeInt64(val.I64Val)
+	case *plan.Const_U8Val:
+		packer.EncodeUint8(uint8(val.U8Val))
+	case *plan.Const_U16Val:
+		packer.EncodeUint16(uint16(val.U16Val))
+	case *plan.Const_U32Val:
+		packer.EncodeUint32(val.U32Val)
+	case *plan.Const_U64Val:
+		packer.EncodeUint64(val.U64Val)
+	case *plan.Const_Fval:
+		packer.EncodeFloat32(val.Fval)
+	case *plan.Const_Dval:
+		packer.EncodeFloat64(val.Dval)
+	case *plan.Const_Timeval:
+		packer.EncodeTime(types.Time(val.Timeval))
+	case *plan.Const_Timestampval:
+		packer.EncodeTimestamp(types.Timestamp(val.Timestampval))
+	case *plan.Const_Dateval:
+		packer.EncodeDate(types.Date(val.Dateval))
+	case *plan.Const_Datetimeval:
+		packer.EncodeDatetime(types.Datetime(val.Datetimeval))
+	case *plan.Const_Decimal64Val:
+		packer.EncodeDecimal64(types.Decimal64(val.Decimal64Val.A))
+	case *plan.Const_Decimal128Val:
+		packer.EncodeDecimal128(types.Decimal128{B0_63: uint64(val.Decimal128Val.A), B64_127: uint64(val.Decimal128Val.B)})
+	case *plan.Const_Sval:
+		packer.EncodeStringType(util.UnsafeStringToBytes(val.Sval))
+	case *plan.Const_Jsonval:
+		packer.EncodeStringType(util.UnsafeStringToBytes(val.Jsonval))
+	default:
+		panic(fmt.Sprintf("unexpected const expr %v", expr))
+	}
+}

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -447,7 +447,7 @@ func TestGetCompositePkValueByExpr(t *testing.T) {
 		}
 		cnt := 0
 		if ok {
-			cnt = getComputableCompositePKCnt(vals)
+			cnt = getValidCompositePKCnt(vals)
 		}
 		require.Equal(t, tc.expect[i], cnt)
 	}
@@ -775,32 +775,3 @@ func TestComputeRangeByIntPk(t *testing.T) {
 		}
 	})
 }
-
-// func TestGetListByRange(t *testing.T) {
-// 	type asserts = struct {
-// 		result []DNStore
-// 		list   []DNStore
-// 		r      [][2]int64
-// 	}
-
-// 	testCases := []asserts{
-// 		{[]DNStore{{UUID: "1"}, {UUID: "2"}}, []DNStore{{UUID: "1"}, {UUID: "2"}}, [][2]int64{{14, 32324234234234}}},
-// 		{[]DNStore{{UUID: "1"}}, []DNStore{{UUID: "1"}, {UUID: "2"}}, [][2]int64{{14, 14}}},
-// 	}
-
-// 	t.Run("test getListByRange", func(t *testing.T) {
-// 		for i, testCase := range testCases {
-// 			result := getListByRange(testCase.list, testCase.r)
-// 			if len(result) != len(testCase.result) {
-// 				t.Fatalf("test getListByRange at cases[%d], data length is not match", i)
-// 			}
-// 			/*
-// 				for j, r := range testCase.result {
-// 					if r.UUID != result[j].UUID {
-// 						t.Fatalf("test getListByRange at cases[%d], result[%d] is not match", i, j)
-// 					}
-// 				}
-// 			*/
-// 		}
-// 	})
-// }

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -301,10 +301,11 @@ func TestGetCompositePkValueByExpr(t *testing.T) {
 		desc: []string{
 			"a=10", "a=20 and b=10", "a=20 and d=10", "b=20 and c=10",
 			"b=10 and d=20", "b=10 and c=20 and d=30",
-			"c=10 and d=20", "a=20 and d=10 or d=10",
+			"c=10 and d=20", "d=10 or a=10", "d=10 or c=20 and a=30",
+			"d=10 or c=20 and d=30", "d=10 and c=20 or d=30",
 		},
 		expect: []int{
-			0, 0, 1, 0, 1, 3, 2, 0,
+			0, 0, 1, 0, 1, 3, 2, 0, 0, 1, 0,
 		},
 		exprs: []*plan.Expr{
 			makeFunctionExprForTest("=", []*plan.Expr{
@@ -375,6 +376,64 @@ func TestGetCompositePkValueByExpr(t *testing.T) {
 				makeFunctionExprForTest("=", []*plan.Expr{
 					makeColExprForTest(3, types.T_float64),
 					plan2.MakePlan2Float64ConstExprWithType(20),
+				}),
+			}),
+			makeFunctionExprForTest("or", []*plan.Expr{
+				makeFunctionExprForTest("=", []*plan.Expr{
+					makeColExprForTest(2, types.T_float64),
+					plan2.MakePlan2Float64ConstExprWithType(20),
+				}),
+				makeFunctionExprForTest("=", []*plan.Expr{
+					makeColExprForTest(0, types.T_float64),
+					plan2.MakePlan2Float64ConstExprWithType(0),
+				}),
+			}),
+			makeFunctionExprForTest("and", []*plan.Expr{
+				makeFunctionExprForTest("or", []*plan.Expr{
+					makeFunctionExprForTest("=", []*plan.Expr{
+						makeColExprForTest(3, types.T_float64),
+						plan2.MakePlan2Float64ConstExprWithType(10),
+					}),
+					makeFunctionExprForTest("=", []*plan.Expr{
+						makeColExprForTest(2, types.T_float64),
+						plan2.MakePlan2Float64ConstExprWithType(20),
+					}),
+				}),
+				makeFunctionExprForTest("=", []*plan.Expr{
+					makeColExprForTest(0, types.T_float64),
+					plan2.MakePlan2Float64ConstExprWithType(30),
+				}),
+			}),
+			makeFunctionExprForTest("and", []*plan.Expr{
+				makeFunctionExprForTest("or", []*plan.Expr{
+					makeFunctionExprForTest("=", []*plan.Expr{
+						makeColExprForTest(3, types.T_float64),
+						plan2.MakePlan2Float64ConstExprWithType(10),
+					}),
+					makeFunctionExprForTest("=", []*plan.Expr{
+						makeColExprForTest(2, types.T_float64),
+						plan2.MakePlan2Float64ConstExprWithType(20),
+					}),
+				}),
+				makeFunctionExprForTest("=", []*plan.Expr{
+					makeColExprForTest(3, types.T_float64),
+					plan2.MakePlan2Float64ConstExprWithType(30),
+				}),
+			}),
+			makeFunctionExprForTest("or", []*plan.Expr{
+				makeFunctionExprForTest("and", []*plan.Expr{
+					makeFunctionExprForTest("=", []*plan.Expr{
+						makeColExprForTest(3, types.T_float64),
+						plan2.MakePlan2Float64ConstExprWithType(10),
+					}),
+					makeFunctionExprForTest("=", []*plan.Expr{
+						makeColExprForTest(2, types.T_float64),
+						plan2.MakePlan2Float64ConstExprWithType(20),
+					}),
+				}),
+				makeFunctionExprForTest("=", []*plan.Expr{
+					makeColExprForTest(3, types.T_float64),
+					plan2.MakePlan2Float64ConstExprWithType(30),
 				}),
 			}),
 		},


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9309 

## What this PR does / why we need it:

Support composite primary key filter when read a block, which will reduce the allocation of memory. 
in my local test, the tpcc performance will be improved by more than 100%.

TODO:
There is a partionReader, which now dominates the performance of tpcc, and it will be optimized in the next PRs