### PR TITLE
[Bug]: q21 of tpch_100g report 'internal error: send notify msg to dispatch operator timeout' on eks with 2*cn

### DIFF
--- a/pkg/sql/compile/scopeRemoteRunTypes.go
+++ b/pkg/sql/compile/scopeRemoteRunTypes.go
@@ -43,7 +43,7 @@ import (
 const (
 	maxMessageSizeToMoRpc = 64 * mpool.MB
 
-	HandleNotifyTimeout = 60 * time.Second
+	HandleNotifyTimeout = 120 * time.Second
 )
 
 // cnInformation records service information to help handle messages.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9842

## What this PR does / why we need it:
change HandleNotifyTimeout  from 60s to 120s.
not a root fix, but tpch 100g can run eks with 2cn