### PR TITLE
improve tpcc performance by prefix scan

### DIFF
--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -219,7 +219,7 @@ func (e *Engine) GetNameById(ctx context.Context, op client.TxnOperator, tableId
 				return "", "", err
 			}
 			distDb := db.(*txnDatabase)
-			tableName, rel, _ := distDb.getRelationById(noRepCtx, tableId)
+			tableName, rel := distDb.getRelationById(noRepCtx, tableId)
 			if rel != nil {
 				tblName = tableName
 				break
@@ -251,7 +251,7 @@ func (e *Engine) GetRelationById(ctx context.Context, op client.TxnOperator, tab
 				return false
 			}
 			distDb := db.(*txnDatabase)
-			tableName, rel, err = distDb.getRelationById(noRepCtx, tableId)
+			tableName, rel = distDb.getRelationById(noRepCtx, tableId)
 			if rel != nil {
 				return false
 			}
@@ -267,7 +267,7 @@ func (e *Engine) GetRelationById(ctx context.Context, op client.TxnOperator, tab
 				return "", "", nil, err
 			}
 			distDb := db.(*txnDatabase)
-			tableName, rel, err = distDb.getRelationById(noRepCtx, tableId)
+			tableName, rel = distDb.getRelationById(noRepCtx, tableId)
 			if rel != nil {
 				break
 			}

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -97,13 +97,13 @@ func (db *txnDatabase) getTableNameById(ctx context.Context, id uint64) string {
 	return tblName
 }
 
-func (db *txnDatabase) getRelationById(ctx context.Context, id uint64) (string, engine.Relation, error) {
+func (db *txnDatabase) getRelationById(ctx context.Context, id uint64) (string, engine.Relation) {
 	tblName := db.getTableNameById(ctx, id)
 	if tblName == "" {
-		return "", nil, moerr.NewInternalError(ctx, "can not find table by id %d", id)
+		return "", nil
 	}
-	rel, err := db.Relation(ctx, tblName)
-	return tblName, rel, err
+	rel, _ := db.Relation(ctx, tblName)
+	return tblName, rel
 }
 
 func (db *txnDatabase) Relation(ctx context.Context, name string) (engine.Relation, error) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9309 

## What this PR does / why we need it:

1. Prefix scan the in-memory primary index for composite primary keys
2. Remove the internal error trace for each txn
   
<img width="1682" alt="image" src="https://github.com/matrixorigin/matrixone/assets/39627130/a096d426-fbd3-4738-86c9-db1c2dc1f219">

