### PR TITLE
[bug] dn: split commands in case it is too large for RPC message.

### DIFF
--- a/pkg/dnservice/factory.go
+++ b/pkg/dnservice/factory.go
@@ -162,5 +162,6 @@ func (s *store) newTAEStorage(ctx context.Context, shard metadata.DNShard, facto
 		logtailServerCfg,
 		options.LogstoreType(s.cfg.Txn.Storage.LogBackend),
 		s.cfg.Txn.IncrementalDedup,
+		uint64(s.cfg.RPC.MaxMessageSize),
 	)
 }

--- a/pkg/txn/storage/tae/storage.go
+++ b/pkg/txn/storage/tae/storage.go
@@ -54,6 +54,7 @@ func NewTAEStorage(
 	logtailServerCfg *options.LogtailServerCfg,
 	logStore options.LogstoreType,
 	incrementalDedup bool,
+	maxMessageSize uint64,
 ) (*taeStorage, error) {
 	opt := &options.Options{
 		Clock:            rt.Clock(),
@@ -64,6 +65,7 @@ func NewTAEStorage(
 		LogStoreT:        logStore,
 		IncrementalDedup: incrementalDedup,
 		Ctx:              ctx,
+		MaxMessageSize:   maxMessageSize,
 	}
 
 	taeHandler := rpc.NewTAEHandle(dataDir, opt)

--- a/pkg/vm/engine/tae/db/open.go
+++ b/pkg/vm/engine/tae/db/open.go
@@ -105,7 +105,8 @@ func Open(dirname string, opts *options.Options) (db *DB, err error) {
 		db.Wal,
 		db.TransferTable,
 		indexCache,
-		dataFactory)
+		dataFactory,
+		opts.MaxMessageSize)
 	txnFactory := txnimpl.TxnFactory(db.Opts.Catalog)
 	db.TxnMgr = txnbase.NewTxnManager(txnStoreFactory, txnFactory, db.Opts.Clock)
 	db.LogtailMgr = logtail.NewManager(

--- a/pkg/vm/engine/tae/options/types.go
+++ b/pkg/vm/engine/tae/options/types.go
@@ -82,4 +82,6 @@ type Options struct {
 	Shard     metadata.DNShard
 	LogStoreT LogstoreType
 	Ctx       context.Context
+	// MaxMessageSize is the size of max message which is sent to log-service.
+	MaxMessageSize uint64
 }

--- a/pkg/vm/engine/tae/txn/txnimpl/cmdmgr.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/cmdmgr.go
@@ -30,9 +30,9 @@ type commandManager struct {
 	driver wal.Driver
 }
 
-func newCommandManager(driver wal.Driver) *commandManager {
+func newCommandManager(driver wal.Driver, maxMessageSize uint64) *commandManager {
 	return &commandManager{
-		cmd:    txnbase.NewTxnCmd(),
+		cmd:    txnbase.NewTxnCmd(maxMessageSize),
 		driver: driver,
 	}
 }
@@ -54,7 +54,6 @@ func (mgr *commandManager) ApplyTxnRecord(tid string, txn txnif.AsyncTxn) (logEn
 	if mgr.driver == nil {
 		return
 	}
-	mgr.cmd.SetCmdSize(mgr.csn)
 	mgr.cmd.SetTxn(txn)
 	var buf []byte
 	if buf, err = mgr.cmd.MarshalBinary(); err != nil {

--- a/pkg/vm/engine/tae/txn/txnimpl/command_test.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/command_test.go
@@ -29,7 +29,7 @@ import (
 func TestComposedCmd(t *testing.T) {
 	defer testutils.AfterTest(t)()
 	testutils.EnsureNoLeak(t)
-	composed := txnbase.NewComposedCmd()
+	composed := txnbase.NewComposedCmd(0)
 	defer composed.Close()
 
 	schema := catalog.MockSchema(1, 0)
@@ -72,8 +72,59 @@ func TestComposedCmd(t *testing.T) {
 
 	buf, err := composed.MarshalBinary()
 	assert.Nil(t, err)
-	vcomposed2, err := txnbase.BuildCommandFrom(buf)
+	_, err = txnbase.BuildCommandFrom(buf)
 	assert.Nil(t, err)
-	composed2 := vcomposed2.(*txnbase.ComposedCmd)
-	assert.Equal(t, composed.CmdSize, composed2.CmdSize)
+}
+
+func TestComposedCmdMaxSize(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	testutils.EnsureNoLeak(t)
+	composed := txnbase.NewComposedCmd(2048)
+	defer composed.Close()
+
+	schema := catalog.MockSchema(1, 0)
+	c := catalog.MockCatalog(nil)
+	defer c.Close()
+
+	db, _ := c.CreateDBEntry("db", "", "", nil)
+	dbCmd, err := db.MakeCommand(1)
+	assert.Nil(t, err)
+	composed.AddCmd(dbCmd)
+
+	table, _ := db.CreateTableEntry(schema, nil, nil)
+	for i := 2; i <= 10; i++ {
+		cmd, err := table.MakeCommand(uint32(i))
+		assert.Nil(t, err)
+		composed.AddCmd(cmd)
+	}
+
+	buf, err := composed.MarshalBinary()
+	assert.Nil(t, err)
+	assert.Equal(t, true, composed.MoreCmds())
+	cmd, err := txnbase.BuildCommandFrom(buf)
+	assert.Nil(t, err)
+	c1, ok := cmd.(*txnbase.ComposedCmd)
+	assert.True(t, ok)
+	assert.NotNil(t, c1)
+	assert.Equal(t, composed.LastPos, len(c1.Cmds))
+
+	buf, err = composed.MarshalBinary()
+	assert.Nil(t, err)
+	assert.Equal(t, true, composed.MoreCmds())
+	cmd, err = txnbase.BuildCommandFrom(buf)
+	assert.Nil(t, err)
+	c2, ok := cmd.(*txnbase.ComposedCmd)
+	assert.True(t, ok)
+	assert.NotNil(t, c2)
+	assert.Equal(t, composed.LastPos, len(c1.Cmds)+len(c2.Cmds))
+
+	buf, err = composed.MarshalBinary()
+	assert.Nil(t, err)
+	assert.Equal(t, false, composed.MoreCmds())
+	cmd, err = txnbase.BuildCommandFrom(buf)
+	assert.Nil(t, err)
+	c3, ok := cmd.(*txnbase.ComposedCmd)
+	assert.True(t, ok)
+	assert.NotNil(t, c3)
+	assert.Equal(t, 10, len(c1.Cmds)+len(c2.Cmds)+len(c3.Cmds))
 }

--- a/pkg/vm/engine/tae/txn/txnimpl/store.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/store.go
@@ -62,9 +62,10 @@ var TxnStoreFactory = func(
 	driver wal.Driver,
 	transferTable *model.HashPageTable,
 	indexCache model.LRUCache,
-	dataFactory *tables.DataFactory) txnbase.TxnStoreFactory {
+	dataFactory *tables.DataFactory,
+	maxMessageSize uint64) txnbase.TxnStoreFactory {
 	return func() txnif.TxnStore {
-		return newStore(ctx, catalog, driver, transferTable, indexCache, dataFactory)
+		return newStore(ctx, catalog, driver, transferTable, indexCache, dataFactory, maxMessageSize)
 	}
 }
 
@@ -74,13 +75,14 @@ func newStore(
 	driver wal.Driver,
 	transferTable *model.HashPageTable,
 	indexCache model.LRUCache,
-	dataFactory *tables.DataFactory) *txnStore {
+	dataFactory *tables.DataFactory,
+	maxMessageSize uint64) *txnStore {
 	return &txnStore{
 		ctx:           ctx,
 		transferTable: transferTable,
 		dbs:           make(map[uint64]*txnDB),
 		catalog:       catalog,
-		cmdMgr:        newCommandManager(driver),
+		cmdMgr:        newCommandManager(driver, maxMessageSize),
 		driver:        driver,
 		logs:          make([]entry.Entry, 0),
 		dataFactory:   dataFactory,
@@ -676,13 +678,18 @@ func (store *txnStore) PrepareWAL() (err error) {
 		return
 	}
 
-	logEntry, err := store.cmdMgr.ApplyTxnRecord(store.txn.GetID(), store.txn)
-	if err != nil {
-		return
+	// Apply the record from the command list.
+	// Split the commands by max message size.
+	for store.cmdMgr.cmd.MoreCmds() {
+		logEntry, err := store.cmdMgr.ApplyTxnRecord(store.txn.GetID(), store.txn)
+		if err != nil {
+			return err
+		}
+		if logEntry != nil {
+			store.logs = append(store.logs, logEntry)
+		}
 	}
-	if logEntry != nil {
-		store.logs = append(store.logs, logEntry)
-	}
+
 	for _, db := range store.dbs {
 		if err = db.Apply1PCCommit(); err != nil {
 			return

--- a/pkg/vm/engine/tae/txn/txnimpl/txn_test.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/txn_test.go
@@ -362,7 +362,7 @@ func TestNodeCommand(t *testing.T) {
 func TestTxnManager1(t *testing.T) {
 	defer testutils.AfterTest(t)()
 	testutils.EnsureNoLeak(t)
-	mgr := txnbase.NewTxnManager(TxnStoreFactory(context.Background(), nil, nil, nil, nil, nil),
+	mgr := txnbase.NewTxnManager(TxnStoreFactory(context.Background(), nil, nil, nil, nil, nil, 0),
 		TxnFactory(nil), types.NewMockHLCClock(1))
 	mgr.Start()
 	txn, _ := mgr.StartTxn(nil)
@@ -423,7 +423,7 @@ func initTestContext(t *testing.T, dir string) (*catalog.Catalog, *txnbase.TxnMa
 	service := objectio.TmpNewFileservice(path.Join(dir, "data"))
 	fs := objectio.NewObjectFS(service, serviceDir)
 	factory := tables.NewDataFactory(fs, indexCache, nil, dir)
-	mgr := txnbase.NewTxnManager(TxnStoreFactory(context.Background(), c, driver, nil, indexCache, factory),
+	mgr := txnbase.NewTxnManager(TxnStoreFactory(context.Background(), c, driver, nil, indexCache, factory, 0),
 		TxnFactory(c), types.NewMockHLCClock(1))
 	mgr.Start()
 	return c, mgr, driver


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9647 

## What this PR does / why we need it:
If there are too many cmds, the message size will be too large to send out by RPC. So split it by max-message-size in config.