### PR TITLE
Fix dn crash

### DIFF
--- a/pkg/vm/engine/tae/logtail/service/response.go
+++ b/pkg/vm/engine/tae/logtail/service/response.go
@@ -115,29 +115,6 @@ type LogtailResponseSegmentPool interface {
 	Release(*LogtailResponseSegment)
 }
 
-type segmentPool struct {
-	pool *sync.Pool
-}
-
-func NewLogtailResponseSegmentPool() LogtailResponseSegmentPool {
-	return &segmentPool{
-		pool: &sync.Pool{
-			New: func() any {
-				return &LogtailResponseSegment{}
-			},
-		},
-	}
-}
-
-func (p *segmentPool) Acquire() *LogtailResponseSegment {
-	return p.pool.Get().(*LogtailResponseSegment)
-}
-
-func (p *segmentPool) Release(seg *LogtailResponseSegment) {
-	seg.Reset()
-	p.pool.Put(seg)
-}
-
 // LogtailServerSegmentPool describes segment pool for logtail server.
 type LogtailServerSegmentPool interface {
 	LogtailResponseSegmentPool

--- a/pkg/vm/engine/tae/logtail/service/session.go
+++ b/pkg/vm/engine/tae/logtail/service/session.go
@@ -154,7 +154,6 @@ func (s *morpcStream) write(
 		s.logger.Debug("real segment proto size", zap.Int("ProtoSize", seg.ProtoSize()))
 
 		if err := s.cs.Write(ctx, seg); err != nil {
-			s.segments.Release(seg)
 			return err
 		}
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9862

## What this PR does / why we need it:
If dn releases `logtail.MessageSegment` on morpc error, there would be panic from morpc side.