### PR TITLE
fix cn ping panic

### DIFF
--- a/pkg/common/morpc/client.go
+++ b/pkg/common/morpc/client.go
@@ -210,8 +210,11 @@ func (c *client) Ping(ctx context.Context, backend string) error {
 		}
 
 		f, err := b.SendInternal(ctx, &flagOnlyMessage{flag: flagPing})
-		if err != nil && err == backendClosed {
-			continue
+		if err != nil {
+			if err == backendClosed {
+				continue
+			}
+			return err
 		}
 		_, err = f.Get()
 		f.Close()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9896

## What this PR does / why we need it:

`Ping` returns error when err is not nil and the error is not `backendClosed` error