### PR TITLE
print the number of WAL entries when replay

### DIFF
--- a/pkg/vm/engine/tae/db/replay.go
+++ b/pkg/vm/engine/tae/db/replay.go
@@ -42,6 +42,8 @@ type Replayer struct {
 	wg            sync.WaitGroup
 	applyDuration time.Duration
 	txnCmdChan    chan *txnbase.TxnCmd
+	readCount     int
+	applyCount    int
 }
 
 func newReplayer(dataFactory *tables.DataFactory, db *DB, ckpedTS types.TS) *Replayer {
@@ -89,7 +91,9 @@ func (replayer *Replayer) Replay() {
 	replayer.wg.Wait()
 	logutil.Info("open-tae", common.OperationField("replay"),
 		common.OperandField("wal"),
-		common.AnyField("apply logentries cost", replayer.applyDuration))
+		common.AnyField("apply logentries cost", replayer.applyDuration),
+		common.AnyField("read count", replayer.readCount),
+		common.AnyField("apply count", replayer.applyCount))
 }
 
 func (replayer *Replayer) OnReplayEntry(group uint32, lsn uint64, payload []byte, typ uint16, info any) {
@@ -133,10 +137,12 @@ func (replayer *Replayer) OnTimeStamp(ts types.TS) {
 
 func (replayer *Replayer) OnReplayTxn(cmd txnif.TxnCmd, lsn uint64) {
 	var err error
+	replayer.readCount++
 	txnCmd := cmd.(*txnbase.TxnCmd)
 	if txnCmd.PrepareTS.LessEq(replayer.maxTs) {
 		return
 	}
+	replayer.applyCount++
 	txn := txnimpl.MakeReplayTxn(replayer.db.TxnMgr, txnCmd.TxnCtx, lsn,
 		txnCmd, replayer, replayer.db.Catalog, replayer.DataFactory, replayer.db.Wal)
 	if err = replayer.db.TxnMgr.OnReplayTxn(txn); err != nil {

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/driver.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/driver.go
@@ -123,7 +123,11 @@ func (d *LogServiceDriver) Replay(h driver.ApplyHandle) error {
 		common.OperandField("wal"),
 		common.AnyField("backend", "logservice"),
 		common.AnyField("apply cost", r.applyDuration),
-		common.AnyField("read cost", d.readDuration))
+		common.AnyField("read cost", d.readDuration),
+		common.AnyField("read count", r.readCount),
+		common.AnyField("internal count", r.internalCount),
+		common.AnyField("apply count", r.applyCount),
+	)
 
 	return nil
 }

--- a/pkg/vm/engine/tae/logtail/service/session.go
+++ b/pkg/vm/engine/tae/logtail/service/session.go
@@ -330,7 +330,7 @@ func (ss *Session) FilterLogtail(tails ...wrapLogtail) []logtail.TableLogtail {
 		if state, ok := ss.tables[t.id]; ok && state == TableSubscribed {
 			qualified = append(qualified, t.tail)
 		} else {
-			ss.logger.Info("table not subscribed, filter out",
+			ss.logger.Debug("table not subscribed, filter out",
 				zap.String("id", string(t.id)),
 				zap.String("checkpoint", t.tail.CkpLocation),
 			)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Update logs.
Count the number of WAL entries when replay.