### PR TITLE
make incrservice using external txn in all ops

### DIFF
--- a/pkg/incrservice/allocator.go
+++ b/pkg/incrservice/allocator.go
@@ -50,7 +50,7 @@ func (a *allocator) adjust() {
 	}
 }
 
-func (a *allocator) alloc(
+func (a *allocator) allocate(
 	ctx context.Context,
 	tableID uint64,
 	key string,
@@ -59,7 +59,7 @@ func (a *allocator) alloc(
 	c := make(chan struct{})
 	var from, to uint64
 	var err error
-	a.asyncAlloc(
+	a.asyncAllocate(
 		ctx,
 		tableID,
 		key,
@@ -77,7 +77,7 @@ func (a *allocator) alloc(
 	return from, to, err
 }
 
-func (a *allocator) asyncAlloc(
+func (a *allocator) asyncAllocate(
 	ctx context.Context,
 	tableID uint64,
 	col string,
@@ -148,7 +148,7 @@ func (a *allocator) doAllocate(act action) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 
-	from, to, err := a.store.Alloc(
+	from, to, err := a.store.Allocate(
 		ctx,
 		act.tableID,
 		act.col,

--- a/pkg/incrservice/allocator.go
+++ b/pkg/incrservice/allocator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/log"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"go.uber.org/zap"
 )
 
@@ -53,7 +54,8 @@ func (a *allocator) alloc(
 	ctx context.Context,
 	tableID uint64,
 	key string,
-	count int) (uint64, uint64, error) {
+	count int,
+	txnOp client.TxnOperator) (uint64, uint64, error) {
 	c := make(chan struct{})
 	var from, to uint64
 	var err error
@@ -62,6 +64,7 @@ func (a *allocator) alloc(
 		tableID,
 		key,
 		count,
+		txnOp,
 		func(
 			v1, v2 uint64,
 			e error) {
@@ -79,11 +82,13 @@ func (a *allocator) asyncAlloc(
 	tableID uint64,
 	col string,
 	count int,
+	txnOp client.TxnOperator,
 	apply func(uint64, uint64, error)) {
 	select {
 	case <-ctx.Done():
 		apply(0, 0, ctx.Err())
 	case a.c <- action{
+		txnOp:         txnOp,
 		accountID:     getAccountID(ctx),
 		actionType:    allocType,
 		tableID:       tableID,
@@ -97,7 +102,8 @@ func (a *allocator) updateMinValue(
 	ctx context.Context,
 	tableID uint64,
 	col string,
-	minValue uint64) error {
+	minValue uint64,
+	txnOp client.TxnOperator) error {
 	var err error
 	c := make(chan struct{})
 	fn := func(e error) {
@@ -108,6 +114,7 @@ func (a *allocator) updateMinValue(
 	case <-ctx.Done():
 		fn(ctx.Err())
 	case a.c <- action{
+		txnOp:       txnOp,
 		accountID:   getAccountID(ctx),
 		actionType:  updateType,
 		tableID:     tableID,
@@ -145,7 +152,8 @@ func (a *allocator) doAllocate(act action) {
 		ctx,
 		act.tableID,
 		act.col,
-		act.count)
+		act.count,
+		act.txnOp)
 	if a.logger.Enabled(zap.DebugLevel) {
 		a.logger.Debug(
 			"allocate new range",
@@ -167,7 +175,8 @@ func (a *allocator) doUpdate(act action) {
 		ctx,
 		act.tableID,
 		act.col,
-		act.minValue)
+		act.minValue,
+		act.txnOp)
 	if a.logger.Enabled(zap.DebugLevel) {
 		a.logger.Debug(
 			"update range min value",
@@ -190,6 +199,7 @@ var (
 )
 
 type action struct {
+	txnOp         client.TxnOperator
 	accountID     uint32
 	actionType    int
 	tableID       uint64

--- a/pkg/incrservice/allocator_test.go
+++ b/pkg/incrservice/allocator_test.go
@@ -86,8 +86,9 @@ func TestAlloc(t *testing.T) {
 								Offset:  0,
 								Step:    uint64(c.step),
 							},
-						}))
-				from, to, err := a.alloc(ctx, 0, c.key, c.count)
+						},
+						nil))
+				from, to, err := a.alloc(ctx, 0, c.key, c.count, nil)
 				require.NoError(t, err)
 				require.Equal(t, c.expectFrom, from)
 				require.Equal(t, c.expectTo, to)
@@ -157,7 +158,8 @@ func TestAsyncAlloc(t *testing.T) {
 								Offset:  0,
 								Step:    uint64(c.step),
 							},
-						}))
+						},
+						nil))
 				var wg sync.WaitGroup
 				wg.Add(1)
 				a.asyncAlloc(
@@ -165,6 +167,7 @@ func TestAsyncAlloc(t *testing.T) {
 					0,
 					c.key,
 					c.count,
+					nil,
 					func(from, to uint64, err error) {
 						defer wg.Done()
 						require.NoError(t, err)

--- a/pkg/incrservice/allocator_test.go
+++ b/pkg/incrservice/allocator_test.go
@@ -88,7 +88,7 @@ func TestAlloc(t *testing.T) {
 							},
 						},
 						nil))
-				from, to, err := a.alloc(ctx, 0, c.key, c.count, nil)
+				from, to, err := a.allocate(ctx, 0, c.key, c.count, nil)
 				require.NoError(t, err)
 				require.Equal(t, c.expectFrom, from)
 				require.Equal(t, c.expectTo, to)
@@ -162,7 +162,7 @@ func TestAsyncAlloc(t *testing.T) {
 						nil))
 				var wg sync.WaitGroup
 				wg.Add(1)
-				a.asyncAlloc(
+				a.asyncAllocate(
 					ctx,
 					0,
 					c.key,

--- a/pkg/incrservice/column_cache.go
+++ b/pkg/incrservice/column_cache.go
@@ -333,7 +333,7 @@ func (col *columnCache) preAllocate(
 	if col.cfg.CountPerAllocate > count {
 		count = col.cfg.CountPerAllocate
 	}
-	col.allocator.asyncAlloc(
+	col.allocator.asyncAllocate(
 		ctx,
 		tableID,
 		col.col.ColName,
@@ -367,7 +367,7 @@ func (col *columnCache) allocateLocked(
 		n = 1
 	}
 	for {
-		from, to, err := col.allocator.alloc(
+		from, to, err := col.allocator.allocate(
 			ctx,
 			tableID,
 			col.col.ColName,

--- a/pkg/incrservice/column_cache.go
+++ b/pkg/incrservice/column_cache.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"go.uber.org/zap"
 	"golang.org/x/exp/constraints"
 )
@@ -56,7 +57,8 @@ func newColumnCache(
 	tableID uint64,
 	col AutoColumn,
 	cfg Config,
-	allocator valueAllocator) (*columnCache, error) {
+	allocator valueAllocator,
+	txnOp client.TxnOperator) (*columnCache, error) {
 	item := &columnCache{
 		logger:    getLogger(),
 		col:       col,
@@ -65,7 +67,7 @@ func newColumnCache(
 		overflow:  col.Offset == math.MaxUint64,
 		ranges:    &ranges{step: col.Step, values: make([]uint64, 0, 1)},
 	}
-	item.preAllocate(ctx, tableID, cfg.CountPerAllocate)
+	item.preAllocate(ctx, tableID, cfg.CountPerAllocate, txnOp)
 	item.Lock()
 	defer item.Unlock()
 	if err := item.waitPrevAllocatingLocked(ctx); err != nil {
@@ -89,7 +91,8 @@ func (col *columnCache) insertAutoValues(
 	ctx context.Context,
 	tableID uint64,
 	vec *vector.Vector,
-	rows int) (uint64, error) {
+	rows int,
+	txnOp client.TxnOperator) (uint64, error) {
 	switch vec.GetType().Oid {
 	case types.T_int8:
 		return insertAutoValues[int8](
@@ -105,7 +108,8 @@ func (col *columnCache) insertAutoValues(
 					"tinyint",
 					"value %v",
 					v)
-			})
+			},
+			txnOp)
 	case types.T_int16:
 		return insertAutoValues[int16](
 			ctx,
@@ -120,7 +124,8 @@ func (col *columnCache) insertAutoValues(
 					"smallint",
 					"value %v",
 					v)
-			})
+			},
+			txnOp)
 	case types.T_int32:
 		return insertAutoValues[int32](
 			ctx,
@@ -134,7 +139,8 @@ func (col *columnCache) insertAutoValues(
 					"int",
 					"value %v",
 					v)
-			})
+			},
+			txnOp)
 	case types.T_int64:
 		return insertAutoValues[int64](
 			ctx,
@@ -149,7 +155,8 @@ func (col *columnCache) insertAutoValues(
 					"bigint",
 					"value %v",
 					v)
-			})
+			},
+			txnOp)
 	case types.T_uint8:
 		return insertAutoValues[uint8](
 			ctx,
@@ -164,7 +171,8 @@ func (col *columnCache) insertAutoValues(
 					"tinyint unsigned",
 					"value %v",
 					v)
-			})
+			},
+			txnOp)
 	case types.T_uint16:
 		return insertAutoValues[uint16](
 			ctx,
@@ -179,7 +187,8 @@ func (col *columnCache) insertAutoValues(
 					"smallint unsigned",
 					"value %v",
 					v)
-			})
+			},
+			txnOp)
 	case types.T_uint32:
 		return insertAutoValues[uint32](
 			ctx,
@@ -194,7 +203,8 @@ func (col *columnCache) insertAutoValues(
 					"int unsigned",
 					"value %v",
 					v)
-			})
+			},
+			txnOp)
 	case types.T_uint64:
 		return insertAutoValues[uint64](
 			ctx,
@@ -209,7 +219,8 @@ func (col *columnCache) insertAutoValues(
 					"bigint unsigned",
 					"auto_incrment column constant value overflows bigint unsigned",
 				)
-			})
+			},
+			txnOp)
 	default:
 		return 0, moerr.NewInvalidInput(ctx, "invalid auto_increment type '%v'", vec.GetType().Oid)
 	}
@@ -225,7 +236,8 @@ func (col *columnCache) updateTo(
 	ctx context.Context,
 	tableID uint64,
 	count int,
-	manualValue uint64) error {
+	manualValue uint64,
+	txnOp client.TxnOperator) error {
 	col.Lock()
 
 	contains := col.ranges.updateTo(manualValue)
@@ -243,7 +255,8 @@ func (col *columnCache) updateTo(
 		ctx,
 		tableID,
 		col.col.ColName,
-		manualValue)
+		manualValue,
+		txnOp)
 }
 
 func (col *columnCache) applyAutoValues(
@@ -302,7 +315,8 @@ func (col *columnCache) applyAutoValues(
 func (col *columnCache) preAllocate(
 	ctx context.Context,
 	tableID uint64,
-	count int) {
+	count int,
+	txnOp client.TxnOperator) {
 	col.Lock()
 	defer col.Unlock()
 
@@ -324,6 +338,7 @@ func (col *columnCache) preAllocate(
 		tableID,
 		col.col.ColName,
 		count,
+		txnOp,
 		func(from, to uint64, err error) {
 			if err == nil {
 				col.applyAllocate(from, to)
@@ -356,7 +371,8 @@ func (col *columnCache) allocateLocked(
 			ctx,
 			tableID,
 			col.col.ColName,
-			count*n)
+			count*n,
+			nil)
 		if err == nil {
 			col.allocateCount.Add(1)
 			col.applyAllocateLocked(from, to)
@@ -370,7 +386,7 @@ func (col *columnCache) maybeAllocate(tableID uint64) {
 	low := col.ranges.left() <= col.cfg.LowCapacity
 	col.Unlock()
 	if low {
-		col.preAllocate(context.Background(), tableID, col.cfg.CountPerAllocate)
+		col.preAllocate(context.Background(), tableID, col.cfg.CountPerAllocate, nil)
 	}
 }
 
@@ -432,7 +448,8 @@ func insertAutoValues[T constraints.Integer](
 	rows int,
 	max T,
 	col *columnCache,
-	outOfRangeError func(v uint64) error) (uint64, error) {
+	outOfRangeError func(v uint64) error,
+	txnOp client.TxnOperator) (uint64, error) {
 	// all values are filled after insert
 	defer func() {
 		vec.SetNulls(nil)
@@ -474,12 +491,13 @@ func insertAutoValues[T constraints.Integer](
 				ctx,
 				tableID,
 				rows,
-				maxValue); err != nil {
+				maxValue,
+				txnOp); err != nil {
 				return 0, err
 			}
 		}
 	}
-	col.preAllocate(ctx, tableID, rows)
+	col.preAllocate(ctx, tableID, rows, nil)
 	err := col.applyAutoValues(
 		ctx,
 		tableID,

--- a/pkg/incrservice/column_cache_test.go
+++ b/pkg/incrservice/column_cache_test.go
@@ -341,7 +341,7 @@ func TestOverflow(t *testing.T) {
 		func(
 			ctx context.Context,
 			cc *columnCache) {
-			require.NoError(t, cc.updateTo(ctx, 0, 1, math.MaxUint64))
+			require.NoError(t, cc.updateTo(ctx, 0, 1, math.MaxUint64, nil))
 			require.True(t, cc.overflow)
 
 			require.NoError(t,
@@ -457,7 +457,7 @@ func testColumnCacheInsert[T constraints.Integer](
 		func(
 			ctx context.Context,
 			c *columnCache) {
-			lastInsertValue, err := c.insertAutoValues(ctx, 0, input, rows)
+			lastInsertValue, err := c.insertAutoValues(ctx, 0, input, rows, nil)
 			require.NoError(t, err)
 			assert.Equal(t, expecLastInsertValue, lastInsertValue)
 			assert.Equal(t,
@@ -524,8 +524,9 @@ func runColumnCacheTestsWithInitOffset(
 			a.(*allocator).store.Create(
 				ctx,
 				0,
-				[]AutoColumn{col})
-			cc, err := newColumnCache(ctx, 0, col, Config{CountPerAllocate: capacity}, a)
+				[]AutoColumn{col},
+				nil)
+			cc, err := newColumnCache(ctx, 0, col, Config{CountPerAllocate: capacity}, a, nil)
 			require.NoError(t, err)
 			fn(ctx, cc)
 		},

--- a/pkg/incrservice/service.go
+++ b/pkg/incrservice/service.go
@@ -107,7 +107,7 @@ func (s *service) Reset(
 	newTableID uint64,
 	keep bool,
 	txnOp client.TxnOperator) error {
-	cols, err := s.store.GetColumns(ctx, oldTableID)
+	cols, err := s.store.GetColumns(ctx, oldTableID, txnOp)
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func (s *service) getCommittedTableCache(
 		return c, nil
 	}
 
-	cols, err := s.store.GetColumns(ctx, tableID)
+	cols, err := s.store.GetColumns(ctx, tableID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/incrservice/service.go
+++ b/pkg/incrservice/service.go
@@ -18,10 +18,8 @@ import (
 	"context"
 	"encoding/hex"
 	"sync"
-	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/log"
-	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
@@ -33,14 +31,12 @@ type service struct {
 	cfg       Config
 	store     IncrValueStore
 	allocator valueAllocator
-	deleteC   chan uint64
-	stopper   *stopper.Stopper
 
 	mu struct {
 		sync.Mutex
 		closed  bool
 		tables  map[uint64]incrTableCache
-		creates map[string][]incrTableCache
+		creates map[string][]uint64
 		deletes map[string][]uint64
 	}
 }
@@ -55,13 +51,10 @@ func NewIncrService(
 		cfg:       cfg,
 		store:     store,
 		allocator: newValueAllocator(store),
-		deleteC:   make(chan uint64, 1024),
-		stopper:   stopper.NewStopper("IncrService", stopper.WithLogger(logger.RawLogger())),
 	}
 	s.mu.tables = make(map[uint64]incrTableCache, 1024)
-	s.mu.creates = make(map[string][]incrTableCache, 1024)
+	s.mu.creates = make(map[string][]uint64, 1024)
 	s.mu.deletes = make(map[string][]uint64, 1024)
-	s.stopper.RunTask(s.deleteTableCache)
 	return s
 }
 
@@ -77,7 +70,7 @@ func (s *service) Create(
 		AppendEventCallback(
 			client.ClosedEvent,
 			s.txnClosed)
-	if err := s.store.Create(ctx, tableID, cols); err != nil {
+	if err := s.store.Create(ctx, tableID, cols, txnOp); err != nil {
 		s.logger.Error("create auto increment cache failed",
 			zap.Uint64("table-id", tableID),
 			zap.String("txn", hex.EncodeToString(txnOp.Txn().ID)),
@@ -89,7 +82,9 @@ func (s *service) Create(
 		tableID,
 		cols,
 		s.cfg,
-		s.allocator)
+		s.allocator,
+		txnOp,
+		false)
 	if err != nil {
 		return err
 	}
@@ -97,7 +92,7 @@ func (s *service) Create(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	key := string(txnOp.Txn().ID)
-	s.mu.creates[key] = append(s.mu.creates[key], c)
+	s.mu.creates[key] = append(s.mu.creates[key], tableID)
 	return s.doCreateLocked(
 		tableID,
 		c,
@@ -152,6 +147,9 @@ func (s *service) Delete(
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.store.Delete(ctx, tableID, txnOp); err != nil {
+		return err
+	}
 
 	key := string(txnOp.Txn().ID)
 	s.mu.deletes[key] = append(s.mu.deletes[key], tableID)
@@ -203,8 +201,6 @@ func (s *service) Close() {
 	}
 	s.mu.Unlock()
 
-	s.stopper.Stop()
-	close(s.deleteC)
 	s.allocator.close()
 	s.store.Close()
 }
@@ -236,12 +232,15 @@ func (s *service) getCommittedTableCache(
 	if err != nil {
 		return nil, err
 	}
+
 	c, err = newTableCache(
 		ctx,
 		tableID,
 		cols,
 		s.cfg,
-		s.allocator)
+		s.allocator,
+		nil,
+		true)
 	if err != nil {
 		return nil, err
 	}
@@ -264,17 +263,17 @@ func (s *service) handleCreatesLocked(txnMeta txn.TxnMeta) {
 		return
 	}
 
-	if txnMeta.Status != txn.TxnStatus_Committed {
-		for _, c := range tables {
-			if s.logger.Enabled(zap.DebugLevel) {
-				s.logger.Debug("destroy creates table",
-					zap.String("resean", "txn aborted"),
-					zap.String("txn", hex.EncodeToString(txnMeta.ID)),
-					zap.Any("table", c.table()))
+	for _, id := range tables {
+		if tc, ok := s.mu.tables[id]; ok {
+			if txnMeta.Status == txn.TxnStatus_Committed {
+				tc.commit()
+			} else {
+				_ = tc.close()
+				delete(s.mu.tables, id)
 			}
-			s.detroyTableCache(c.table(), true)
 		}
 	}
+
 	delete(s.mu.creates, key)
 }
 
@@ -285,51 +284,15 @@ func (s *service) handleDeletesLocked(txnMeta txn.TxnMeta) {
 		return
 	}
 
-	if s.logger.Enabled(zap.DebugLevel) {
-		s.logger.Debug("destroy deletes table auto increment cache",
-			zap.String("resean", "txn committed"),
-			zap.String("txn", hex.EncodeToString(txnMeta.ID)),
-			zap.Any("tables", tables))
-	}
 	if txnMeta.Status == txn.TxnStatus_Committed {
 		for _, id := range tables {
-			s.detroyTableCache(id, false)
+			if tc, ok := s.mu.tables[id]; ok {
+				_ = tc.close()
+				delete(s.mu.tables, id)
+			}
 		}
 	}
 	delete(s.mu.deletes, key)
-}
-
-func (s *service) detroyTableCache(
-	tableID uint64,
-	mustExists bool) {
-	if _, ok := s.mu.tables[tableID]; !ok && mustExists {
-		panic("missing created incr table cache")
-	}
-	s.deleteC <- tableID
-}
-
-func (s *service) deleteTableCache(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case tableID := <-s.deleteC:
-			s.mu.Lock()
-			if tc, ok := s.mu.tables[tableID]; ok {
-				_ = tc.close()
-				delete(s.mu.tables, tableID)
-			}
-			s.mu.Unlock()
-			ctx2, cancel := context.WithTimeout(ctx, time.Second*10)
-			for i := 0; i < 2; i++ {
-				if err := s.store.Delete(ctx2, tableID); err == nil {
-					cancel()
-					break
-				}
-			}
-			cancel()
-		}
-	}
 }
 
 func (s *service) getTableCache(tableID uint64) incrTableCache {

--- a/pkg/incrservice/service.go
+++ b/pkg/incrservice/service.go
@@ -17,9 +17,11 @@ package incrservice
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"sync"
 
 	"github.com/matrixorigin/matrixone/pkg/common/log"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
@@ -105,7 +107,7 @@ func (s *service) Reset(
 	newTableID uint64,
 	keep bool,
 	txnOp client.TxnOperator) error {
-	cols, err := s.store.GetCloumns(ctx, oldTableID)
+	cols, err := s.store.GetColumns(ctx, oldTableID)
 	if err != nil {
 		return err
 	}
@@ -228,9 +230,12 @@ func (s *service) getCommittedTableCache(
 		return c, nil
 	}
 
-	cols, err := s.store.GetCloumns(ctx, tableID)
+	cols, err := s.store.GetColumns(ctx, tableID)
 	if err != nil {
 		return nil, err
+	}
+	if len(cols) == 0 {
+		return nil, moerr.NewNoSuchTableNoCtx("", fmt.Sprintf("%d", tableID))
 	}
 
 	c, err = newTableCache(

--- a/pkg/incrservice/service_test.go
+++ b/pkg/incrservice/service_test.go
@@ -49,10 +49,7 @@ func TestCreate(t *testing.T) {
 			assert.Equal(t, 1, len(s.mu.creates[string(op.Txn().ID)]))
 			assert.Equal(t, 2, len(s.mu.tables[0].columns()))
 			s.mu.Unlock()
-
-			s.store.(*memStore).Lock()
-			assert.Equal(t, 2, len(s.store.(*memStore).caches[0]))
-			s.store.(*memStore).Unlock()
+			checkStoreCachesUncommitted(t, s.store.(*memStore), op, 2)
 
 			require.NoError(t, op.Commit(ctx))
 			s.mu.Lock()
@@ -60,10 +57,7 @@ func TestCreate(t *testing.T) {
 			assert.Equal(t, 0, len(s.mu.creates))
 			assert.Equal(t, 0, len(s.mu.deletes))
 			s.mu.Unlock()
-
-			s.store.(*memStore).Lock()
-			assert.Equal(t, 2, len(s.store.(*memStore).caches[0]))
-			s.store.(*memStore).Unlock()
+			checkStoreCachesCommitted(t, s.store.(*memStore), 2)
 		})
 }
 
@@ -112,18 +106,14 @@ func TestCreateWithTxnAborted(t *testing.T) {
 			assert.Equal(t, 1, len(s.mu.creates[string(op.Txn().ID)]))
 			assert.Equal(t, 2, len(s.mu.tables[0].columns()))
 			s.mu.Unlock()
-
-			s.store.(*memStore).Lock()
-			assert.Equal(t, 2, len(s.store.(*memStore).caches[0]))
-			s.store.(*memStore).Unlock()
+			checkStoreCachesUncommitted(t, s.store.(*memStore), op, 2)
 
 			require.NoError(t, op.Rollback(ctx))
 			s.mu.Lock()
 			assert.Equal(t, 0, len(s.mu.creates))
 			assert.Equal(t, 0, len(s.mu.deletes))
 			s.mu.Unlock()
-
-			waitStoreCachesCount(t, ctx, s.store.(*memStore), 0)
+			checkStoreCachesCommitted(t, s.store.(*memStore), 0)
 			assert.Equal(t, 0, len(s.mu.tables))
 		})
 }
@@ -142,13 +132,13 @@ func TestDelete(t *testing.T) {
 			def := newTestTableDef(2)
 			require.NoError(t, s.Create(ctx, 0, def, op))
 			require.NoError(t, op.Commit(ctx))
-			waitStoreCachesCount(t, ctx, s.store.(*memStore), 2)
+			checkStoreCachesCommitted(t, s.store.(*memStore), 2)
 
 			s2 := ss[1]
 			op2 := ops[1]
 			require.NoError(t, s.Delete(ctx, 0, op2))
 			require.NoError(t, op2.Commit(ctx))
-			waitStoreCachesCount(t, ctx, s2.store.(*memStore), 0)
+			checkStoreCachesCommitted(t, s2.store.(*memStore), 0)
 		})
 }
 
@@ -166,13 +156,12 @@ func TestDeleteWithTxnAborted(t *testing.T) {
 			def := newTestTableDef(2)
 			require.NoError(t, s.Create(ctx, 0, def, op))
 			require.NoError(t, op.Commit(ctx))
-
-			waitStoreCachesCount(t, ctx, s.store.(*memStore), 2)
+			checkStoreCachesCommitted(t, s.store.(*memStore), 2)
 
 			op2 := ops[1]
 			require.NoError(t, s.Delete(ctx, 0, op2))
 			require.NoError(t, op2.Rollback(ctx))
-			assert.Equal(t, 0, len(s.deleteC))
+			checkStoreCachesCommitted(t, s.store.(*memStore), 2)
 		})
 }
 
@@ -190,13 +179,13 @@ func TestDeleteOnOtherService(t *testing.T) {
 			def := newTestTableDef(2)
 			require.NoError(t, s.Create(ctx, 0, def, op))
 			require.NoError(t, op.Commit(ctx))
-			waitStoreCachesCount(t, ctx, s.store.(*memStore), 2)
+			checkStoreCachesCommitted(t, s.store.(*memStore), 2)
 
 			s2 := ss[1]
 			op2 := ops[1]
 			require.NoError(t, s2.Delete(ctx, 0, op2))
 			require.NoError(t, op2.Commit(ctx))
-			waitStoreCachesCount(t, ctx, s2.store.(*memStore), 0)
+			checkStoreCachesCommitted(t, s2.store.(*memStore), 0)
 		})
 }
 
@@ -244,22 +233,21 @@ func newTestTableDef(autoCols int) []AutoColumn {
 	return cols
 }
 
-func waitStoreCachesCount(
+func checkStoreCachesCommitted(
 	t *testing.T,
-	ctx context.Context,
 	store *memStore,
 	n int) {
-	for {
-		select {
-		case <-ctx.Done():
-			t.Fail()
-		default:
-			store.Lock()
-			if len(store.caches[0]) == n {
-				store.Unlock()
-				return
-			}
-			store.Unlock()
-		}
-	}
+	store.Lock()
+	defer store.Unlock()
+	require.Equal(t, n, len(store.caches[0]))
+}
+
+func checkStoreCachesUncommitted(
+	t *testing.T,
+	store *memStore,
+	txnOp client.TxnOperator,
+	n int) {
+	store.Lock()
+	defer store.Unlock()
+	require.Equal(t, n, len(store.uncommitted[string(txnOp.Txn().ID)][0]))
 }

--- a/pkg/incrservice/store_mem.go
+++ b/pkg/incrservice/store_mem.go
@@ -80,7 +80,7 @@ func (s *memStore) Create(
 	return nil
 }
 
-func (s *memStore) GetCloumns(
+func (s *memStore) GetColumns(
 	ctx context.Context,
 	tableID uint64) ([]AutoColumn, error) {
 	s.Lock()
@@ -88,7 +88,7 @@ func (s *memStore) GetCloumns(
 	return s.caches[tableID], nil
 }
 
-func (s *memStore) Alloc(
+func (s *memStore) Allocate(
 	ctx context.Context,
 	tableID uint64,
 	key string,

--- a/pkg/incrservice/store_mem.go
+++ b/pkg/incrservice/store_mem.go
@@ -82,10 +82,17 @@ func (s *memStore) Create(
 
 func (s *memStore) GetColumns(
 	ctx context.Context,
-	tableID uint64) ([]AutoColumn, error) {
+	tableID uint64,
+	txnOp client.TxnOperator) ([]AutoColumn, error) {
 	s.Lock()
 	defer s.Unlock()
-	return s.caches[tableID], nil
+	s.Lock()
+	defer s.Unlock()
+	m := s.caches
+	if txnOp != nil {
+		m = s.uncommitted[string(txnOp.Txn().ID)]
+	}
+	return m[tableID], nil
 }
 
 func (s *memStore) Allocate(

--- a/pkg/incrservice/store_sql.go
+++ b/pkg/incrservice/store_sql.go
@@ -170,11 +170,12 @@ func (s *sqlStore) Delete(
 
 func (s *sqlStore) GetColumns(
 	ctx context.Context,
-	tableID uint64) ([]AutoColumn, error) {
+	tableID uint64,
+	txnOp client.TxnOperator) ([]AutoColumn, error) {
 	fetchSQL := fmt.Sprintf(`select col_name, col_index, offset, step from %s where table_id = %d order by col_index`,
 		incrTableName,
 		tableID)
-	opts := executor.Options{}.WithDatabase(database)
+	opts := executor.Options{}.WithDatabase(database).WithTxn(txnOp)
 	res, err := s.exec.Exec(ctx, fetchSQL, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/incrservice/store_sql.go
+++ b/pkg/incrservice/store_sql.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
@@ -69,7 +68,7 @@ func (s *sqlStore) Create(
 		opts)
 }
 
-func (s *sqlStore) Alloc(
+func (s *sqlStore) Allocate(
 	ctx context.Context,
 	tableID uint64,
 	colName string,
@@ -169,7 +168,7 @@ func (s *sqlStore) Delete(
 	return nil
 }
 
-func (s *sqlStore) GetCloumns(
+func (s *sqlStore) GetColumns(
 	ctx context.Context,
 	tableID uint64) ([]AutoColumn, error) {
 	fetchSQL := fmt.Sprintf(`select col_name, col_index, offset, step from %s where table_id = %d order by col_index`,
@@ -203,9 +202,6 @@ func (s *sqlStore) GetCloumns(
 			Offset:   offsets[idx],
 			Step:     steps[idx],
 		}
-	}
-	if len(cols) == 0 {
-		return nil, moerr.NewNoSuchTableNoCtx(database, fmt.Sprintf("%d", tableID))
 	}
 	return cols, nil
 }

--- a/pkg/incrservice/types.go
+++ b/pkg/incrservice/types.go
@@ -32,7 +32,7 @@ func GetAutoIncrementService() AutoIncrementService {
 	return v.(AutoIncrementService)
 }
 
-// AutoIncrementService provides data service for the columns of auto-incremenet.
+// AutoIncrementService provides data service for the columns of auto-increment.
 // Each CN contains a service instance. Whenever a table containing an auto-increment
 // column is created, the service internally creates a data cache for the auto-increment
 // column to avoid updating the sequence values of these auto-increment columns each
@@ -100,20 +100,20 @@ type incrTableCache interface {
 }
 
 type valueAllocator interface {
-	alloc(ctx context.Context, tableID uint64, col string, count int, txnOp client.TxnOperator) (uint64, uint64, error)
-	asyncAlloc(ctx context.Context, tableID uint64, col string, count int, txnOp client.TxnOperator, cb func(uint64, uint64, error))
+	allocate(ctx context.Context, tableID uint64, col string, count int, txnOp client.TxnOperator) (uint64, uint64, error)
+	asyncAllocate(ctx context.Context, tableID uint64, col string, count int, txnOp client.TxnOperator, cb func(uint64, uint64, error))
 	updateMinValue(ctx context.Context, tableID uint64, col string, minValue uint64, txnOp client.TxnOperator) error
 	close()
 }
 
 // IncrValueStore is used to add and delete metadata records for auto-increment columns.
 type IncrValueStore interface {
-	// GetCloumns return auto columns of table.
-	GetCloumns(ctx context.Context, tableID uint64) ([]AutoColumn, error)
+	// GetColumns return auto columns of table.
+	GetColumns(ctx context.Context, tableID uint64) ([]AutoColumn, error)
 	// Create add metadata records into catalog.AutoIncrTableName.
 	Create(ctx context.Context, tableID uint64, cols []AutoColumn, txnOp client.TxnOperator) error
-	// Alloc alloc new range for auto-increment column.
-	Alloc(ctx context.Context, tableID uint64, col string, count int, txnOp client.TxnOperator) (uint64, uint64, error)
+	// Allocate allocate new range for auto-increment column.
+	Allocate(ctx context.Context, tableID uint64, col string, count int, txnOp client.TxnOperator) (uint64, uint64, error)
 	// UpdateMinValue update auto column min value to specified value.
 	UpdateMinValue(ctx context.Context, tableID uint64, col string, minValue uint64, txnOp client.TxnOperator) error
 	// Delete remove metadata records from catalog.AutoIncrTableName.

--- a/pkg/incrservice/types.go
+++ b/pkg/incrservice/types.go
@@ -109,7 +109,7 @@ type valueAllocator interface {
 // IncrValueStore is used to add and delete metadata records for auto-increment columns.
 type IncrValueStore interface {
 	// GetColumns return auto columns of table.
-	GetColumns(ctx context.Context, tableID uint64) ([]AutoColumn, error)
+	GetColumns(ctx context.Context, tableID uint64, txnOp client.TxnOperator) ([]AutoColumn, error)
 	// Create add metadata records into catalog.AutoIncrTableName.
 	Create(ctx context.Context, tableID uint64, cols []AutoColumn, txnOp client.TxnOperator) error
 	// Allocate allocate new range for auto-increment column.

--- a/pkg/sql/colexec/preinsert/preinsert.go
+++ b/pkg/sql/colexec/preinsert/preinsert.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
@@ -114,6 +115,9 @@ func genAutoIncrCol(bat *batch.Batch, proc *proc, arg *Argument) error {
 		arg.TableDef.TblId,
 		bat)
 	if err != nil {
+		if moerr.IsMoErrCode(err, moerr.ErrNoSuchTable) {
+			return moerr.NewNoSuchTableNoCtx(arg.SchemaName, arg.TableDef.Name)
+		}
 		return err
 	}
 	proc.SetLastInsertID(lastInsertValue)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #9914 

## What this PR does / why we need it:
Make incrservice using external txn in all ops.  And returns pretty error if table dropped