### PR TITLE
let the lock op of the same txn serially

### DIFF
--- a/pkg/lockservice/lock_table_remote.go
+++ b/pkg/lockservice/lock_table_remote.go
@@ -15,6 +15,7 @@
 package lockservice
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/matrixorigin/matrixone/pkg/common/log"
@@ -77,7 +78,18 @@ func (l *remoteLockTable) lock(
 	req.Lock.ServiceID = l.serviceID
 	req.Lock.Rows = rows
 
+	// rpc maybe wait too long, to avoid deadlock, we need unlock txn, and lock again
+	// after rpc completed
+	txn.Unlock()
 	resp, err := l.client.Send(ctx, req)
+	txn.Lock()
+
+	// txn closed
+	if !bytes.Equal(req.Lock.TxnID, txn.txnID) {
+		cb(pb.Result{}, ErrTxnNotFound)
+		return
+	}
+
 	if err == nil {
 		defer releaseResponse(resp)
 		if err := l.maybeHandleBindChanged(resp); err != nil {
@@ -86,11 +98,7 @@ func (l *remoteLockTable) lock(
 			return
 		}
 
-		// we use mutex lock here to avoid the deadlock detection
-		// mechanism reading an incorrect data.
-		txn.Lock()
-		defer txn.Unlock()
-		txn.lockAdded(l.serviceID, l.bind.Table, rows, nil, true)
+		txn.lockAdded(l.serviceID, l.bind.Table, rows, nil)
 		logRemoteLockAdded(l.serviceID, txn, rows, opts, l.bind)
 		cb(resp.Lock.Result, nil)
 		return

--- a/pkg/lockservice/lock_table_remote_test.go
+++ b/pkg/lockservice/lock_table_remote_test.go
@@ -48,6 +48,8 @@ func TestLockRemote(t *testing.T) {
 			txn := newActiveTxn(txnID, string(txnID), newFixedSlicePool(32), "")
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 			defer cancel()
+			txn.Lock()
+			defer txn.Unlock()
 			l.lock(ctx, txn, [][]byte{{1}}, LockOptions{}, func(r pb.Result, err error) {
 				assert.NoError(t, err)
 			})
@@ -179,10 +181,12 @@ func TestRemoteWithBindChanged(t *testing.T) {
 			txn := newActiveTxn(txnID, string(txnID), newFixedSlicePool(32), "")
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 			defer cancel()
+			txn.Lock()
 			l.lock(ctx, txn, [][]byte{{1}}, LockOptions{}, func(r pb.Result, err error) {
 				assert.Error(t, ErrLockTableBindChanged, err)
 			})
 			assert.Equal(t, newBind, <-c)
+			txn.Unlock()
 
 			l.unlock(txn, nil, timestamp.Timestamp{})
 			assert.Equal(t, newBind, <-c)

--- a/pkg/lockservice/log.go
+++ b/pkg/lockservice/log.go
@@ -172,23 +172,17 @@ func logLocalLockWaitOnResult(
 	key []byte,
 	opts LockOptions,
 	waiter *waiter,
-	err error) {
+	notify notifyValue) {
 	logger := getWithSkipLogger()
-	level := zap.DebugLevel
-	fn := logger.Debug
-	if err != nil {
-		level = zap.ErrorLevel
-		fn = logger.Error
-	}
-	if logger.Enabled(level) {
-		fn("lock wait on local result",
+	if logger.Enabled(zap.DebugLevel) {
+		logger.Debug("lock wait on local result",
 			serviceIDField(serviceID),
 			txnField(txn),
 			zap.Uint64("table", tableID),
 			bytesField("wait-on-key", key),
 			zap.String("opts", opts.DebugString()),
 			zap.Stringer("waiter", waiter),
-			zap.Any("result", err))
+			zap.Any("result", notify))
 	}
 }
 
@@ -331,7 +325,7 @@ func logAbortDeadLock(
 			serviceIDField(serviceID),
 			zap.String("wait-txn", txn.DebugString()),
 			txnField(activeTxn),
-			zap.Stringer("block", activeTxn.blockedWaiter))
+			waiterArrayField("blocked-waiters", activeTxn.blockedWaiters...))
 	}
 }
 

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -532,7 +532,7 @@ func TestMultipleRangeLocks(t *testing.T) {
 	)
 }
 
-func TestLockResultWithNoConfict(t *testing.T) {
+func TestLockResultWithNoConflict(t *testing.T) {
 	runLockServiceTests(
 		t,
 		[]string{"s1"},
@@ -565,7 +565,7 @@ func TestLockResultWithNoConfict(t *testing.T) {
 	)
 }
 
-func TestLockResultWithConfictAndTxnCommitted(t *testing.T) {
+func TestLockResultWithConflictAndTxnCommitted(t *testing.T) {
 	runLockServiceTests(
 		t,
 		[]string{"s1"},
@@ -616,7 +616,7 @@ func TestLockResultWithConfictAndTxnCommitted(t *testing.T) {
 	)
 }
 
-func TestLockResultWithConfictAndTxnAborted(t *testing.T) {
+func TestLockResultWithConflictAndTxnAborted(t *testing.T) {
 	runLockServiceTests(
 		t,
 		[]string{"s1"},

--- a/pkg/lockservice/txn_test.go
+++ b/pkg/lockservice/txn_test.go
@@ -30,9 +30,9 @@ func TestLockAdded(t *testing.T) {
 	fsp := newFixedSlicePool(2)
 	txn := newActiveTxn(id, string(id), fsp, "")
 
-	txn.lockAdded("s1", 1, [][]byte{[]byte("k1")}, nil, false)
-	txn.lockAdded("s1", 1, [][]byte{[]byte("k11")}, nil, false)
-	txn.lockAdded("s1", 2, [][]byte{[]byte("k2"), []byte("k22")}, nil, false)
+	txn.lockAdded("s1", 1, [][]byte{[]byte("k1")}, nil)
+	txn.lockAdded("s1", 1, [][]byte{[]byte("k11")}, nil)
+	txn.lockAdded("s1", 2, [][]byte{[]byte("k2"), []byte("k22")}, nil)
 
 	assert.Equal(t, 2, len(txn.holdLocks))
 
@@ -80,7 +80,7 @@ func TestClose(t *testing.T) {
 		})
 	assert.Empty(t, txn.txnID)
 	assert.Empty(t, txn.txnKey)
-	assert.Nil(t, txn.blockedWaiter)
+	assert.Empty(t, txn.blockedWaiters)
 	assert.Empty(t, txn.holdLocks)
 	assert.Equal(t, 0, tables[1].(*localLockTable).mu.store.Len())
 	assert.Equal(t, 0, tables[2].(*localLockTable).mu.store.Len())

--- a/pkg/lockservice/types.go
+++ b/pkg/lockservice/types.go
@@ -26,6 +26,8 @@ import (
 var (
 	// ErrDeadlockDetectorClosed deadlock detector is closed
 	ErrDeadlockDetectorClosed = moerr.NewInvalidStateNoCtx("deadlock detector is closed")
+	// ErrTxnClosed txn not found
+	ErrTxnNotFound = moerr.NewInvalidStateNoCtx("txn not found")
 	// ErrDeadLockDetected dead lock detected
 	ErrDeadLockDetected = moerr.NewDeadLockDetectedNoCtx()
 	// ErrLockTableBindChanged lock table and lock service bind changed
@@ -53,7 +55,7 @@ type LockStorage interface {
 	Seek(key []byte) ([]byte, Lock, bool)
 	// Prev returns the first KV Pair that is < the given key
 	Prev(key []byte) ([]byte, Lock, bool)
-	// Range range in [start, end), if end == nil, no upperbound
+	// Range range in [start, end), if end == nil, no upperBounded
 	Range(start []byte, end []byte, fn func([]byte, Lock) bool)
 	// Iter iter all values
 	Iter(func([]byte, Lock) bool)
@@ -97,7 +99,7 @@ type LockService interface {
 
 	// Observability methods
 
-	// GetWaitingList get specical txnID's waiting list
+	// GetWaitingList get special txnID's waiting list
 	GetWaitingList(ctx context.Context, txnID []byte) (bool, []pb.WaitTxn, error)
 	// ForceRefreshLockTableBinds force refresh all lock tables binds
 	ForceRefreshLockTableBinds()

--- a/pkg/lockservice/waiter_events.go
+++ b/pkg/lockservice/waiter_events.go
@@ -117,7 +117,9 @@ func (mw *waiterEvents) handle(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case c := <-mw.eventC:
+			c.txn.Lock()
 			c.doLock()
+			c.txn.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9909 

## What this PR does / why we need it:
Let the lock operation of the same transaction spend serially. Currently, for update operations, delete and insert are parallel, once a deadlock occurs, the original design cannot meet this concurrent locking scenario