### PR TITLE
txn: need wait  if have not received notification

### DIFF
--- a/pkg/txn/client/timestamp_waiter.go
+++ b/pkg/txn/client/timestamp_waiter.go
@@ -84,7 +84,8 @@ func (tw *timestampWaiter) Close() {
 func (tw *timestampWaiter) addToWait(ts timestamp.Timestamp) *waiter {
 	tw.mu.Lock()
 	defer tw.mu.Unlock()
-	if tw.mu.lastNotified.GreaterEq(ts) {
+	if !tw.mu.lastNotified.IsEmpty() &&
+		tw.mu.lastNotified.GreaterEq(ts) {
 		return nil
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
In txn client's timestamp waiter.  If no notifications have been received, all new things need to wait until at least the first logtail notify.