### PR TITLE
proxy: improve performance of isStmt functions

### DIFF
--- a/pkg/proxy/util.go
+++ b/pkg/proxy/util.go
@@ -30,12 +30,12 @@ var (
 	commit   = "[cC][oO][mM][mM][iI][tT]"
 	rollback = "[rR][oO][lL][lL][bB][aA][cC][kK]"
 
-	beginPattern = fmt.Sprintf("^%s(%s)%s%s%s$",
-		spaceAtLeastZero, begin, spaceAtLeastZero, end, spaceAtLeastZero)
-	commitPattern = fmt.Sprintf("^%s(%s)%s%s%s$",
-		spaceAtLeastZero, commit, spaceAtLeastZero, end, spaceAtLeastZero)
-	rollbackPattern = fmt.Sprintf("^%s(%s)%s%s%s$",
-		spaceAtLeastZero, rollback, spaceAtLeastZero, end, spaceAtLeastZero)
+	beginRegex = regexp.MustCompile(fmt.Sprintf("^%s(%s)%s%s%s$",
+		spaceAtLeastZero, begin, spaceAtLeastZero, end, spaceAtLeastZero))
+	commitRegex = regexp.MustCompile(fmt.Sprintf("^%s(%s)%s%s%s$",
+		spaceAtLeastZero, commit, spaceAtLeastZero, end, spaceAtLeastZero))
+	rollbackRegex = regexp.MustCompile(fmt.Sprintf("^%s(%s)%s%s%s$",
+		spaceAtLeastZero, rollback, spaceAtLeastZero, end, spaceAtLeastZero))
 )
 
 // makeOKPacket returns an OK packet
@@ -130,20 +130,17 @@ func pickTunnels(tuns tunnelSet, n int) []*tunnel {
 
 // isStmtBegin returns true iff it is begin statement.
 func isStmtBegin(c []byte) bool {
-	matched, _ := regexp.MatchString(beginPattern, string(c))
-	return matched
+	return beginRegex.Match(c)
 }
 
 // isStmtCommit returns true iff it is commit statement.
 func isStmtCommit(c []byte) bool {
-	matched, _ := regexp.MatchString(commitPattern, string(c))
-	return matched
+	return commitRegex.Match(c)
 }
 
 // isStmtRollback returns true iff it is rollback statement.
 func isStmtRollback(c []byte) bool {
-	matched, _ := regexp.MatchString(rollbackPattern, string(c))
-	return matched
+	return rollbackRegex.Match(c)
 }
 
 // sortMap sorts a complex map instance.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:


## What this PR does / why we need it:

The `regexp.MatchString(pattern, str)` function performs a `regexp.Compile(pattern)` operation internally. Since we already know the regex pattern at compile time, we can use `regexp.MustCompile` to avoid compiling the same regex pattern for each function invocation.

This pull request updates the `isStmtBegin`, `isStmtCommit`, and `isStmtRollback` functions to use pre-compiled regex patterns, resulting in better performance and less memory allocations.

Sample benchmark:
```go
var (
	beginPattern = fmt.Sprintf("^%s(%s)%s%s%s$",
		spaceAtLeastZero, begin, spaceAtLeastZero, end, spaceAtLeastZero)

	beginRegex = regexp.MustCompile(beginPattern)
)

func isStmtBegin(c []byte) bool {
	matched, _ := regexp.MatchString(beginPattern, string(c))
	return matched
}

func isStmtBeginNew(c []byte) bool {
	return beginRegex.Match(c)
}

func BenchmarkIsStmtBegin(b *testing.B) {
	for i := 0; i < b.N; i++ {
		isStmtBegin([]byte{'b', 'e', 'g', 'i', 'n'})
	}
}

func BenchmarkIsStmtBeginNew(b *testing.B) {
	for i := 0; i < b.N; i++ {
		isStmtBeginNew([]byte{'b', 'e', 'g', 'i', 'n'})
	}
}
```

Result:
```
goos: linux
goarch: amd64
pkg: github.com/matrixorigin/matrixone/pkg/proxy
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkIsStmtBegin-16       	   68071	     22374 ns/op	    8528 B/op	     116 allocs/op
BenchmarkIsStmtBeginNew-16    	 3735127	       280.3 ns/op	       5 B/op	       1 allocs/op
```