### PR TITLE
fix notify applied logtail block

### DIFF
--- a/pkg/txn/client/timestamp_waiter.go
+++ b/pkg/txn/client/timestamp_waiter.go
@@ -149,7 +149,7 @@ var (
 	waitersPool = sync.Pool{
 		New: func() any {
 			w := &waiter{
-				c: make(chan struct{}),
+				c: make(chan struct{}, 1),
 			}
 			runtime.SetFinalizer(w, func(w *waiter) {
 				close(w.c)
@@ -173,7 +173,9 @@ func newWaiter(ts timestamp.Timestamp) *waiter {
 
 func (w *waiter) init(ts timestamp.Timestamp) {
 	w.waitAfter = ts
-	w.ref()
+	if w.ref() != 1 {
+		panic("BUG: waiter init must has ref count 1")
+	}
 }
 
 func (w *waiter) wait(ctx context.Context) error {
@@ -189,12 +191,16 @@ func (w *waiter) notify() {
 	w.c <- struct{}{}
 }
 
-func (w *waiter) ref() {
-	w.refCount.Add(1)
+func (w *waiter) ref() int32 {
+	return w.refCount.Add(1)
 }
 
 func (w *waiter) unref() {
-	if w.refCount.Add(-1) == 0 {
+	n := w.refCount.Add(-1)
+	if n < 0 {
+		panic("BUG: negative ref count")
+	}
+	if n == 0 {
 		w.reset()
 		waitersPool.Put(w)
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9992 

## What this PR does / why we need it:
Use a buffered channel of size 1 to avoid waiter no longer waiting for state and notify being blocked due to ctx cancel