### PR TITLE
fix data race in lock service

### DIFF
--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -249,14 +249,17 @@ func writeResponse(
 	if err != nil {
 		resp.WrapError(err)
 	}
+	detail := ""
 	if getLogger().Enabled(zap.DebugLevel) {
+		detail = resp.DebugString()
 		getLogger().Debug("handle request completed",
-			zap.String("response", resp.DebugString()))
+			zap.String("response", detail))
 	}
+	// after write, response will be released by rpc
 	if err := cs.Write(ctx, resp); err != nil {
 		getLogger().Error("write response failed",
 			zap.Error(err),
-			zap.String("response", resp.DebugString()))
+			zap.String("response", detail))
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9884 

## What this PR does / why we need it:
get response detail before write to avoid data race