### PR TITLE
disable build hash table on left  in right join

### DIFF
--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -1050,7 +1050,6 @@ func makeInsertPlan(
 					Children:    []int32{rightId, lastNodeId},
 					JoinType:    plan.Node_RIGHT,
 					OnList:      []*Expr{condExpr},
-					BuildOnLeft: true,
 					ProjectList: []*Expr{rowIdExpr, rightRowIdExpr, pkColExpr},
 					RuntimeFilterBuildList: []*plan.RuntimeFilterSpec{
 						{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Disable build hash table on left table in right join. Because maybe lost some data, and will then cause the primary key constraint to be misclassified