### PR TITLE
reduce the number of workers to execute compaction task

### DIFF
--- a/pkg/vm/engine/tae/options/options.go
+++ b/pkg/vm/engine/tae/options/options.go
@@ -189,9 +189,13 @@ func (o *Options) FillDefaults(dirname string) *Options {
 		if ioworkers < runtime.NumCPU() {
 			ioworkers = runtime.NumCPU()
 		}
+		workers := runtime.NumCPU() / 4
+		if workers < 1 {
+			workers = 1
+		}
 		o.SchedulerCfg = &SchedulerCfg{
 			IOWorkers:    ioworkers,
-			AsyncWorkers: DefaultAsyncWorkers,
+			AsyncWorkers: workers,
 		}
 	}
 

--- a/pkg/vm/engine/tae/tables/mnode.go
+++ b/pkg/vm/engine/tae/tables/mnode.go
@@ -53,8 +53,14 @@ func newMemoryNode(block *baseBlock) *memoryNode {
 	// Get the lastest schema, it will not be modified, so just keep the pointer
 	schema := block.meta.GetSchema()
 	impl.writeSchema = schema
-	impl.data = containers.BuildBatchWithPool(
-		schema.AllNames(), schema.AllTypes(), 0, block.rt.VectorPool.Memtable,
+	// impl.data = containers.BuildBatchWithPool(
+	// 	schema.AllNames(), schema.AllTypes(), 0, block.rt.VectorPool.Memtable,
+	// )
+	opts := containers.Options{
+		Allocator: common.MutMemAllocator,
+	}
+	impl.data = containers.BuildBatch(
+		schema.AllNames(), schema.AllTypes(), opts,
 	)
 	impl.initPKIndex(schema)
 	impl.OnZeroCB = impl.close


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

Currently, It always set 16 workers to execute the background compaction jobs. The compaction task is an IO-and-CPU-bound job(load data, sort block, calc ndv, bloomfilter...). In a resource-limited environment, it will use up most of the hardware resources. Here we set the workers to be max(CpuNumers/4, 1).

I will temporarily disable the memtable vector pool for this pr, because the current memtable reuse has some problems, the actual observation shows that the reuse rate is very low, and the relevant resources are still pinned.