### PR TITLE
filter uncommitted blocks by exprs  when call rangesOnePart

### DIFF
--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -260,10 +260,10 @@ func newBlockReader(
 			ctx:      ctx,
 			fs:       fs,
 			ts:       ts,
+			proc:     proc,
 			tableDef: tableDef,
 		},
 		blks:    blks,
-		proc:    proc,
 		blkDels: make(map[types.Blockid][]int64),
 	}
 	r.filterState.expr = filterExpr
@@ -347,11 +347,11 @@ func newBlockMergeReader(
 			ctx:      ctx,
 			tableDef: txnTable.tableDef,
 			ts:       ts,
+			proc:     proc,
 			fs:       fs,
 		},
 		dirtyBlks: dirtyBlks,
 		table:     txnTable,
-		proc:      proc,
 	}
 	r.filterState.expr = filterExpr
 	return r

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -390,12 +390,11 @@ func (r *blockMergeReader) Read(
 
 	// load deletes from txn.blockId_dn_delete_metaLoc_batch
 	if _, ok := r.table.db.txn.blockId_dn_delete_metaLoc_batch[info.BlockID]; ok {
-		deletes, err := r.table.LoadDeletesForBlock(info.BlockID)
+		err := r.table.LoadDeletesForBlock(info.BlockID, &r.buffer)
 		if err != nil {
 			return nil, err
 		}
-		//TODO:: need to optimize .
-		r.buffer = append(r.buffer, deletes...)
+		//r.buffer = append(r.buffer, deletes...)
 	}
 
 	// load deletes from partition state for the specified block
@@ -432,7 +431,8 @@ func (r *blockMergeReader) Read(
 	}
 	//load deletes from txn.deletedBlocks.
 	txn := r.table.db.txn
-	r.buffer = append(r.buffer, txn.deletedBlocks.getDeletedOffsetsByBlock(&info.BlockID)...)
+	//r.buffer = append(r.buffer, txn.deletedBlocks.getDeletedOffsetsByBlock(&info.BlockID)...)
+	txn.deletedBlocks.getDeletedOffsetsByBlock(&info.BlockID, &r.buffer)
 
 	filter := r.getReadFilter(r.proc)
 

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1499,7 +1499,9 @@ func (tbl *txnTable) newBlockReader(
 	}
 
 	infos, steps := groupBlocksToObjects(blkInfos, num)
-	fs, err := fileservice.Get[fileservice.FileService](tbl.db.txn.engine.fs, defines.SharedFileServiceName)
+	fs, err := fileservice.Get[fileservice.FileService](
+		tbl.db.txn.engine.fs,
+		defines.SharedFileServiceName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -425,6 +425,7 @@ type withFilterMixin struct {
 	ctx      context.Context
 	fs       fileservice.FileService
 	ts       timestamp.Timestamp
+	proc     *process.Process
 	tableDef *plan.TableDef
 
 	// columns used for reading
@@ -462,7 +463,7 @@ type blockReader struct {
 	// block list to scan
 	blks    []*catalog.BlockInfo
 	blkDels map[types.Blockid][]int64
-	proc    *process.Process
+	//proc    *process.Process
 }
 
 // TODO::blockMergeReader should inherit from blockReader.
@@ -472,7 +473,7 @@ type blockMergeReader struct {
 	table     *txnTable
 	dirtyBlks []*catalog.BlockInfo
 	buffer    []int64
-	proc      *process.Process
+	//proc      *process.Process
 }
 
 type mergeReader struct {

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -192,13 +192,11 @@ func (b *deletedBlocks) addDeletedBlocks(blockID *types.Blockid, offsets []int64
 	b.offsets[*blockID] = append(b.offsets[*blockID], offsets...)
 }
 
-func (b *deletedBlocks) getDeletedOffsetsByBlock(blockID *types.Blockid) []int64 {
+func (b *deletedBlocks) getDeletedOffsetsByBlock(blockID *types.Blockid, offsets *[]int64) {
 	b.RLock()
 	defer b.RUnlock()
 	res := b.offsets[*blockID]
-	offsets := make([]int64, len(res))
-	copy(offsets, res)
-	return offsets
+	*offsets = append(*offsets, res...)
 }
 
 func (b *deletedBlocks) removeBlockDeletedInfos(ids []*types.Blockid) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9665 

## What this PR does / why we need it:
1. filter uncommitted blks  by exprs when call `rangesOnePart` function .
