### PR TITLE
remove bvt check with compressed size

### DIFF
--- a/test/distributed/cases/function/table_func_metadata_scan.result
+++ b/test/distributed/cases/function/table_func_metadata_scan.result
@@ -37,9 +37,6 @@ select col_name, rows_cnt, null_cnt, origin_size from metadata_scan('table_func_
 col_name    rows_cnt    null_cnt    origin_size
 a    8192    0    32805
 b    8192    4096    197697
-select sum(compress_size) from metadata_scan('table_func_metadata_scan.t', '*') g;
-sum(compress_size)
-12638
 select sum(origin_size) from metadata_scan('table_func_metadata_scan.t', '*') g;
 sum(origin_size)
 230502

--- a/test/distributed/cases/function/table_func_metadata_scan.sql
+++ b/test/distributed/cases/function/table_func_metadata_scan.sql
@@ -23,6 +23,5 @@ select count(*) from metadata_scan('table_func_metadata_scan.t', 'a') g;
 select count(*) from metadata_scan('table_func_metadata_scan.t', 'c') g;
 select col_name, rows_cnt, null_cnt, origin_size from metadata_scan('table_func_metadata_scan.t', 'a') g;
 select col_name, rows_cnt, null_cnt, origin_size from metadata_scan('table_func_metadata_scan.t', '*') g;
-select sum(compress_size) from metadata_scan('table_func_metadata_scan.t', '*') g;
 select sum(origin_size) from metadata_scan('table_func_metadata_scan.t', '*') g;
 drop table if exists t;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

The compressed block size will change. Remove related compressed block size check during metadata scan