### PR TITLE
commit cannot update snapshot ts in rc mode

### DIFF
--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -209,7 +209,7 @@ func (cwft *TxnComputationWrapper) Compile(requestCtx context.Context, u interfa
 	// See `func (exec *txnExecutor) Exec(sql string)` for details.
 	txnOp := cwft.GetProcess().TxnOperator
 	if txnOp != nil {
-		err := txnOp.GetWorkspace().IncrStatementID(requestCtx)
+		err := txnOp.GetWorkspace().IncrStatementID(requestCtx, false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/frontend/test/txn_mock.go
+++ b/pkg/frontend/test/txn_mock.go
@@ -1164,17 +1164,17 @@ func (m *MockWorkspace) EXPECT() *MockWorkspaceMockRecorder {
 }
 
 // IncrStatementID mocks base method.
-func (m *MockWorkspace) IncrStatementID(ctx context.Context) error {
+func (m *MockWorkspace) IncrStatementID(ctx context.Context, commit bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IncrStatementID", ctx)
+	ret := m.ctrl.Call(m, "IncrStatementID", ctx, commit)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // IncrStatementID indicates an expected call of IncrStatementID.
-func (mr *MockWorkspaceMockRecorder) IncrStatementID(ctx interface{}) *gomock.Call {
+func (mr *MockWorkspaceMockRecorder) IncrStatementID(ctx, commit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncrStatementID", reflect.TypeOf((*MockWorkspace)(nil).IncrStatementID), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncrStatementID", reflect.TypeOf((*MockWorkspace)(nil).IncrStatementID), ctx, commit)
 }
 
 // RollbackLastStatement mocks base method.

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -617,7 +617,7 @@ func TestGetExprValue(t *testing.T) {
 		eng.EXPECT().Nodes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 		ws := mock_frontend.NewMockWorkspace(ctrl)
-		ws.EXPECT().IncrStatementID(gomock.Any()).Return(nil).AnyTimes()
+		ws.EXPECT().IncrStatementID(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
 		txnOperator.EXPECT().Commit(gomock.Any()).Return(nil).AnyTimes()
@@ -714,7 +714,7 @@ func TestGetExprValue(t *testing.T) {
 		eng.EXPECT().Nodes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 		ws := mock_frontend.NewMockWorkspace(ctrl)
-		ws.EXPECT().IncrStatementID(gomock.Any()).Return(nil).AnyTimes()
+		ws.EXPECT().IncrStatementID(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
 		txnOperator.EXPECT().Commit(gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -328,7 +328,7 @@ func (c *Compile) Run(_ uint64) error {
 				return err
 			}
 			//  increase the statement id
-			if err = c.proc.TxnOperator.GetWorkspace().IncrStatementID(c.ctx); err != nil {
+			if err = c.proc.TxnOperator.GetWorkspace().IncrStatementID(c.ctx, false); err != nil {
 				return err
 			}
 

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -81,7 +81,7 @@ func testPrint(_ interface{}, _ *batch.Batch) error {
 type Ws struct {
 }
 
-func (w *Ws) IncrStatementID(ctx context.Context) error {
+func (w *Ws) IncrStatementID(ctx context.Context, commit bool) error {
 	return nil
 }
 

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -178,7 +178,7 @@ func (exec *txnExecutor) Exec(sql string) (executor.Result, error) {
 	// maybe we should fix it.
 	txnOp := exec.opts.Txn()
 	if txnOp != nil {
-		err := txnOp.GetWorkspace().IncrStatementID(exec.ctx)
+		err := txnOp.GetWorkspace().IncrStatementID(exec.ctx, false)
 		if err != nil {
 			return executor.Result{}, err
 		}

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -186,7 +186,7 @@ type Workspace interface {
 	// IncrStatementID incr the execute statement id. It maintains the statement id, first statement is 1,
 	// second is 2, and so on. If in rc mode, snapshot will updated to latest applied commit ts from dn. And
 	// workspace will update snapshot data for later read request.
-	IncrStatementID(ctx context.Context) error
+	IncrStatementID(ctx context.Context, commit bool) error
 	// RollbackLastStatement rollback the last statement.
 	RollbackLastStatement(ctx context.Context) error
 }

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -398,7 +398,7 @@ func (e *Engine) Commit(ctx context.Context, op client.TxnOperator) error {
 	if txn == nil {
 		return moerr.NewTxnClosedNoCtx(op.Txn().ID)
 	}
-	txn.IncrStatementID(ctx)
+	txn.IncrStatementID(ctx, true)
 	defer e.delTransaction(txn)
 	if txn.readOnly.Load() {
 		return nil

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -221,7 +221,7 @@ func (txn *Transaction) PutCnBlockDeletes(blockId *types.Blockid, offsets []int6
 	txn.deletedBlocks.addDeletedBlocks(blockId, offsets)
 }
 
-func (txn *Transaction) IncrStatementID(ctx context.Context) error {
+func (txn *Transaction) IncrStatementID(ctx context.Context, commit bool) error {
 	if err := txn.mergeTxnWorkspace(); err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func (txn *Transaction) IncrStatementID(ctx context.Context) error {
 	// For RC isolation, update the snapshot TS of transaction for each statement including
 	// the first one. Means that, the timestamp of the first statement is not the transaction's
 	// begin timestamp, but its own timestamp.
-	if txn.meta.IsRCIsolation() {
+	if !commit && txn.meta.IsRCIsolation() {
 		if err := txn.op.UpdateSnapshot(
 			ctx,
 			timestamp.Timestamp{}); err != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
In RC mode, the snapshot ts of the transaction are updated before each statement is executed. but cn treats commit as a statement as well, and obviously commit cannot update the snapshot ts. Because once dn has only incremental de-duplication turned on, it means that dn will only check for duplicate primary keys between snapshot ts and commit ts. If commit updates snapshot ts, then it means that the primary key de-duplication in the interval [last snapshot, new snapshot] neither cn nor dn will check