### PR TITLE
make vectorPool.getVector fetch vector from the end

### DIFF
--- a/pkg/vm/process/process.go
+++ b/pkg/vm/process/process.go
@@ -311,8 +311,8 @@ func (vp *vectorPool) getVector(typ types.Type) *vector.Vector {
 	defer vp.Unlock()
 	key := uint8(typ.Oid)
 	if vecs := vp.vecs[key]; len(vecs) > 0 {
-		vec := vecs[0]
-		vp.vecs[key] = vecs[1:]
+		vec := vecs[len(vecs)-1]
+		vp.vecs[key] = vecs[:len(vecs)-1]
 		return vec
 	}
 	return nil


### PR DESCRIPTION
* make vectorPool.getVector fetch vector from the end(#10201)

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10201

## What this PR does / why we need it: