### PR TITLE
fix bug for lockRows

### DIFF
--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -1813,19 +1813,12 @@ func lockRows(
 	}
 
 	id := rel.GetTableID(proc.Ctx)
-	defs, err := rel.GetPrimaryKeys(proc.Ctx)
-	if err != nil {
-		return err
-	}
-	if len(defs) != 1 {
-		panic("invalid primary keys")
-	}
 
-	err = lockop.LockRows(
+	err := lockop.LockRows(
 		proc,
 		id,
 		vec,
-		defs[0].Type)
+		*vec.GetType())
 	return err
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
fix bug for lockRows.  
for lock table in mo_catalog, we do not use primary key some times.