### PR TITLE
fix dead lock

### DIFF
--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -296,8 +296,9 @@ type mapBasedTxnHolder struct {
 		// remoteServices known remote service
 		remoteServices map[string]*list.Element[remote]
 		// head(oldest) -> tail (newest)
-		dequeue    list.Deque[remote]
-		activeTxns map[string]*activeTxn
+		dequeue           list.Deque[remote]
+		activeTxns        map[string]*activeTxn
+		activeTxnServices map[string]string
 	}
 }
 
@@ -308,6 +309,7 @@ func newMapBasedTxnHandler(
 	h.fsp = fsp
 	h.serviceID = serviceID
 	h.mu.activeTxns = make(map[string]*activeTxn, 1024)
+	h.mu.activeTxnServices = make(map[string]string)
 	h.mu.remoteServices = make(map[string]*list.Element[remote])
 	h.mu.dequeue = list.New[remote]()
 	return h
@@ -344,6 +346,7 @@ func (h *mapBasedTxnHolder) getActiveTxn(
 
 	txn := newActiveTxn(txnID, txnKey, h.fsp, remoteService)
 	h.mu.activeTxns[txnKey] = txn
+	h.mu.activeTxnServices[txnKey] = txn.remoteService
 
 	if remoteService != "" {
 		if _, ok := h.mu.remoteServices[remoteService]; !ok {
@@ -365,6 +368,7 @@ func (h *mapBasedTxnHolder) deleteActiveTxn(txnID []byte) *activeTxn {
 	v, ok := h.mu.activeTxns[txnKey]
 	if ok {
 		delete(h.mu.activeTxns, txnKey)
+		delete(h.mu.activeTxnServices, txnKey)
 	}
 	return v
 }
@@ -408,12 +412,12 @@ func (h *mapBasedTxnHolder) getTimeoutRemoveTxn(
 			return true
 		})
 
-		for _, txn := range h.mu.activeTxns {
-			txn.Lock()
-			if _, ok := timeoutServices[txn.remoteService]; ok {
-				timeoutTxns = append(timeoutTxns, txn.txnID)
+		for txnKey := range h.mu.activeTxns {
+			remoteService := h.mu.activeTxnServices[txnKey]
+			if _, ok := timeoutServices[remoteService]; ok {
+				timeoutTxns = append(timeoutTxns, util.UnsafeStringToBytes(txnKey))
 			}
-			txn.Unlock()
+
 		}
 	}
 	return timeoutTxns, wait


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
1. txn1 get activeTxn's mutex
2. txn1 add lock on pk1 and wait txn2 completed
3. check timeout txn task start
4. task get the mutext of activeTxnMap
5. task check txn1, try get mutext of activeTxn blocked
6. txn2 completed, unlock all locks
7. txn2 try to delete activeTxn from activeTxnMap, blocked
8. dead lock encountered.