### PR TITLE
fix proxy transfer msg out of bounds

### DIFF
--- a/pkg/proxy/mysql_conn_buf.go
+++ b/pkg/proxy/mysql_conn_buf.go
@@ -147,6 +147,14 @@ func (b *msgBuf) preRecv() (int, txnTag, error) {
 	if bodyLen == 0 {
 		return mysqlHeadLen, txnOther, nil
 	}
+
+	// body is not equal to 0, read out the cmd type info
+	if b.readAvail() < preRecvLen {
+		if err := b.receiveAtLeast(cmdLen); err != nil {
+			return 0, 0, err
+		}
+	}
+
 	cmd := b.buf[b.begin+mysqlHeadLen]
 
 	// Max length is 3 bytes.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10164 

## What this PR does / why we need it:
when transferring msg from src to dst, in proxy, msg buf may go out of bounds.
