### PR TITLE
improve tp performance in high concurrency and big data scenarios

### DIFF
--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -326,11 +326,11 @@ func (r *blockReader) Read(
 	}
 
 	// get the block read filter
-	filter, _ := r.getReadFilter(r.proc)
+	filter, positions := r.getReadFilter(r.proc)
 
 	// read the block
 	bat, err := blockio.BlockRead(
-		r.ctx, blockInfo, r.buffer, r.columns.seqnums, r.columns.colTypes, r.ts, filter, r.fs, mp, vp,
+		r.ctx, blockInfo, r.buffer, r.columns.seqnums, r.columns.colTypes, r.ts, positions, filter, r.fs, mp, vp,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -174,8 +174,7 @@ func (mixin *withFilterMixin) getCompositPKFilter(proc *process.Process) (
 			inputSels []int32
 		)
 		for i := range filterFuncs {
-			pos := mixin.columns.compPKPositions[i]
-			vec := vecs[pos]
+			vec := vecs[i]
 			mixin.sels = mixin.sels[:0]
 			filterFuncs[i](vec, inputSels, &mixin.sels)
 			if len(mixin.sels) == 0 {
@@ -231,7 +230,7 @@ func (mixin *withFilterMixin) getNonCompositPKFilter(proc *process.Process) (
 	// it returns the offset of the primary key in the pk vector.
 	// if the primary key is not found, it returns empty slice
 	filter = func(vecs []*vector.Vector) []int32 {
-		vec := vecs[mixin.columns.pkPos]
+		vec := vecs[0]
 		row := searchFunc(vec)
 		if row < 0 {
 			return nil

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -445,9 +445,10 @@ type withFilterMixin struct {
 	filterState struct {
 		evaluated bool
 		//point select for primary key
-		expr      *plan.Expr
-		filter    blockio.ReadFilter
-		positions []uint16 // positions of the columns in the filter
+		expr     *plan.Expr
+		filter   blockio.ReadFilter
+		seqnums  []uint16 // seqnums of the columns in the filter
+		colTypes []types.Type
 	}
 
 	sels []int32

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -434,7 +434,7 @@ type withFilterMixin struct {
 		colTypes []types.Type
 		// colNulls []bool
 
-		compPKPositions []int // composite primary key pos in the columns
+		compPKPositions []uint16 // composite primary key pos in the columns
 
 		pkPos    int // -1 means no primary key in columns
 		rowidPos int // -1 means no rowid in columns
@@ -445,8 +445,9 @@ type withFilterMixin struct {
 	filterState struct {
 		evaluated bool
 		//point select for primary key
-		expr   *plan.Expr
-		filter blockio.ReadFilter
+		expr      *plan.Expr
+		filter    blockio.ReadFilter
+		positions []uint16 // positions of the columns in the filter
 	}
 
 	sels []int32

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -92,7 +92,8 @@ func BlockRead(
 	columns []uint16,
 	colTypes []types.Type,
 	ts timestamp.Timestamp,
-	filterColumns []uint16,
+	filterSeqnums []uint16,
+	filterColTypes []types.Type,
 	filter ReadFilter,
 	fs fileservice.FileService,
 	mp *mpool.MPool,
@@ -108,12 +109,8 @@ func BlockRead(
 	)
 
 	if filter != nil && info.Sorted {
-		filterTypes := make([]types.Type, len(filterColumns))
-		for i, col := range filterColumns {
-			filterTypes[i] = colTypes[col]
-		}
 		if sels, err = ReadByFilter(
-			ctx, info, inputDeletes, filterColumns, filterTypes,
+			ctx, info, inputDeletes, filterSeqnums, filterColTypes,
 			types.TimestampToTS(ts), filter, fs, mp,
 		); err != nil {
 			return nil, err


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #9309 

## What this PR does / why we need it:

<img width="1052" alt="WeChatWorkScreenshot_e8ba01fb-0a77-48d2-97f5-ca811c3f9cfe" src="https://github.com/matrixorigin/matrixone/assets/39627130/f196fa58-5eb3-4731-a7ca-686d9b8606d1">

In TPCC scenario, about 85% of blocks will be loaded and filtered by filter expr. Here we load the primary keys first to evaluate the filter expr and then only load other columns if the block is not filtered.
Also, we only prefetch primary keys when the filter expr is not nil.

After this PR, we can avoid mass eviction in the LRU cache.