### PR TITLE
fix possible mpool leak when network fails

### DIFF
--- a/pkg/vm/engine/tae/logtail/service/server.go
+++ b/pkg/vm/engine/tae/logtail/service/server.go
@@ -483,6 +483,7 @@ func (s *LogtailServer) logtailSender(ctx context.Context) {
 						logger.Error("fail to publish incremental logtail", zap.Error(err),
 							zap.Uint64("stream-id", session.stream.streamID), zap.String("remote", session.stream.remote),
 						)
+						closeCB()
 						continue
 					}
 				}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

When pushing logtail to cn, if there is a problem with the network, resulting in a failure, it may cause a leak of mpool