### PR TITLE
[bug] the version is not correct when build binary in CI.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           repository: matrixorigin/matrixone
           ref: ${{ env.branch }}
+      - name: Get tags
+        run: git fetch --tags origin
       - name: Use Golang
         uses: actions/setup-go@v4
         with:
@@ -52,6 +54,8 @@ jobs:
         with:
           repository: matrixorigin/matrixone
           ref: ${{ env.branch }}         
+      - name: Get tags
+        run: git fetch --tags origin
       - name: Use Golang
         uses: actions/setup-go@v4
         with:
@@ -87,6 +91,8 @@ jobs:
         with:
           repository: matrixorigin/matrixone
           ref: ${{ env.branch }}          
+      - name: Get tags
+        run: git fetch --tags origin
       - name: Use Golang
         uses: actions/setup-go@v4
         with:
@@ -140,6 +146,8 @@ jobs:
         with:
           repository: matrixorigin/matrixone
           ref: ${{ env.branch }}
+      - name: Get tags
+        run: git fetch --tags origin
       - name: Check go Version
         run: |
           go version


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10389 

## What this PR does / why we need it:
The version of MO is determined by a git command, which gets the latest tag of repo, so we need to fetch all tags before build release binary.