### PR TITLE
fix buildin function purge_log just handle first table

### DIFF
--- a/pkg/sql/plan/function/func_builtin.go
+++ b/pkg/sql/plan/function/func_builtin.go
@@ -466,8 +466,9 @@ func buildInPurgeLog(parameters []*vector.Vector, result vector.FunctionResultWr
 					sql := fmt.Sprintf("delete from `%s`.`%s` where `%s` < %q",
 						tbl.Database, tbl.Table, tbl.TimestampColumn.Name, v2.String())
 					opts := executor.Options{}.WithDatabase(tbl.Database)
-					_, err := exec.Exec(proc.Ctx, sql, opts)
-					return err
+					if _, err := exec.Exec(proc.Ctx, sql, opts); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/test/distributed/cases/function/func_purge_log.result
+++ b/test/distributed/cases/function/func_purge_log.result
@@ -27,4 +27,11 @@ NULL
 select purge_log(NULL, NULL) a;
 a
 NULL
+set @ts=now();
+select purge_log('statement_info,metric', DATE_ADD( @ts, interval 1 day)) a;
+a
+0
+select count(1) val from system_metrics.metric where `collecttime` <  DATE_ADD( @ts, interval 1 minute);
+val
+0
 drop account if exists bvt_purge_log;

--- a/test/distributed/cases/function/func_purge_log.sql
+++ b/test/distributed/cases/function/func_purge_log.sql
@@ -22,5 +22,10 @@ select purge_log('rawlog_not_exist', NULL) a;
 select purge_log(NULL, '2023-06-30') a;
 select purge_log(NULL, NULL) a;
 
+-- case for issue 10421
+set @ts=now();
+select purge_log('statement_info,metric', DATE_ADD( @ts, interval 1 day)) a;
+select count(1) val from system_metrics.metric where `collecttime` <  DATE_ADD( @ts, interval 1 minute);
+
 -- clean
 drop account if exists bvt_purge_log;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10421

## What this PR does / why we need it:

fix buildin function purge_log just handle first table