### PR TITLE
fix alter stmt crash bug

### DIFF
--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1963,6 +1963,8 @@ func buildAlterTable(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, error) 
 			}
 		case *tree.TableOptionAutoIncrement:
 			return nil, moerr.NewInvalidInput(ctx.GetContext(), "Can't set AutoIncr column value.")
+		default:
+			return nil, moerr.NewInvalidInput(ctx.GetContext(), "Do not support this stmt now.")
 		}
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10355

## What this PR does / why we need it:
fix alter stmt crash bug:
There are tons of ALTER TABLE cases that users might try. The following statements still crash MO.

ALTER TABLE t2 CHARACTER SET = utf8mb4;
ALTER TABLE t2 ROW_FORMAT = COMPRESSED;
ALTER TABLE t2 ENGINE = InnoDB;

I'm referring from this page. https://dev.mysql.com/doc/refman/8.0/en/alter-table.html