### PR TITLE
fix logtail lagging gc

### DIFF
--- a/pkg/vm/engine/tae/db/open.go
+++ b/pkg/vm/engine/tae/db/open.go
@@ -228,8 +228,10 @@ func Open(ctx context.Context, dirname string, opts *options.Options) (db *DB, e
 			opts.CheckpointCfg.GCCheckpointInterval,
 			func(ctx context.Context) error {
 				ckp := db.BGCheckpointRunner.MaxCheckpoint()
-				if ckp != nil && ckp.IsCommitted() {
-					db.LogtailMgr.GCByTS(ctx, ckp.GetEnd())
+				if ckp != nil {
+					// use previous end to gc logtail
+					ts := types.BuildTS(ckp.GetStart().Physical(), 0) // GetStart is previous + 1, reset it here
+					db.LogtailMgr.GCByTS(ctx, ts)
 				}
 				return nil
 			},


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

## What this PR does / why we need it:

related to issue #10440

Before this pr, every minute, dn checks if the max checkpoint is finished, if so, gc logtail using the end timestamp. However, it is possible that every check will find the checkpoint is unfinished, and skip gc logtail, leading to a lot of unused logtail in memory.

In this pr,  the start ts of the max checkpoint is used to calculate the end ts of the previous checkpoint.


