### PR TITLE
skip dup check for update non pk col

### DIFF
--- a/pkg/sql/plan/build_update.go
+++ b/pkg/sql/plan/build_update.go
@@ -187,11 +187,19 @@ func selectUpdateTables(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.
 		// add update expr to project list
 		updateColPosMap := make(map[string]int)
 		offset := len(tableDef.Cols)
+		updatePkCol := false
+		var pkNameMap map[string]struct{} = make(map[string]struct{})
+		for _, pkName := range tableDef.Pkey.Names {
+			pkNameMap[pkName] = struct{}{}
+		}
 		for colName, updateKey := range updateKeys {
 			selectList = append(selectList, tree.SelectExpr{
 				Expr: updateKey,
 			})
 			updateColPosMap[colName] = offset
+			if _, ok := pkNameMap[colName]; ok {
+				updatePkCol = true
+			}
 			offset++
 		}
 
@@ -206,6 +214,7 @@ func selectUpdateTables(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.
 		upPlanCtx.updateColPosMap = updateColPosMap
 		upPlanCtx.allDelTableIDs = map[uint64]struct{}{}
 		upPlanCtx.checkInsertPkDup = checkInsertPkDup
+		upPlanCtx.updatePkCol = updatePkCol
 
 		for idx, col := range tableDef.Cols {
 			// row_id、compPrimaryKey、clusterByKey will not inserted from old data
@@ -257,15 +266,17 @@ func getPkFilterExpr(builder *QueryBuilder, tableDef *TableDef) *Expr {
 			continue
 		}
 
-		pkName := fmt.Sprintf("%s.%s", tableDef.Name, tableDef.Pkey.PkeyColName)
+		basePkName := tableDef.Pkey.PkeyColName
+		tblAndPkName := fmt.Sprintf("%s.%s", tableDef.Name, tableDef.Pkey.PkeyColName)
 		if e, ok := node.FilterList[0].Expr.(*plan.Expr_F); ok && e.F.Func.ObjName == "=" {
-			if pkExpr, ok := e.F.Args[0].Expr.(*plan.Expr_Col); ok && pkExpr.Col.Name == pkName {
+			if pkExpr, ok := e.F.Args[0].Expr.(*plan.Expr_Col); ok && (pkExpr.Col.Name == tblAndPkName || pkExpr.Col.Name == basePkName) {
 				return DeepCopyExpr(e.F.Args[1])
 			}
 
-			if pkExpr, ok := e.F.Args[1].Expr.(*plan.Expr_Col); ok && pkExpr.Col.Name == pkName {
+			if pkExpr, ok := e.F.Args[1].Expr.(*plan.Expr_Col); ok && (pkExpr.Col.Name == tblAndPkName || pkExpr.Col.Name == basePkName) {
 				return DeepCopyExpr(e.F.Args[0])
 			}
+
 		}
 	}
 	return nil

--- a/pkg/sql/plan/build_update.go
+++ b/pkg/sql/plan/build_update.go
@@ -189,8 +189,13 @@ func selectUpdateTables(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.
 		offset := len(tableDef.Cols)
 		updatePkCol := false
 		var pkNameMap = make(map[string]struct{})
-		for _, pkName := range tableDef.Pkey.Names {
-			pkNameMap[pkName] = struct{}{}
+		if tableDef.Pkey != nil {
+			for _, pkName := range tableDef.Pkey.Names {
+				pkNameMap[pkName] = struct{}{}
+			}
+		} else {
+			// we don't known if update pk. just set true and let check pk dup work
+			updatePkCol = true
 		}
 		for colName, updateKey := range updateKeys {
 			selectList = append(selectList, tree.SelectExpr{

--- a/pkg/sql/plan/build_update.go
+++ b/pkg/sql/plan/build_update.go
@@ -188,7 +188,7 @@ func selectUpdateTables(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.
 		updateColPosMap := make(map[string]int)
 		offset := len(tableDef.Cols)
 		updatePkCol := false
-		var pkNameMap map[string]struct{} = make(map[string]struct{})
+		var pkNameMap = make(map[string]struct{})
 		for _, pkName := range tableDef.Pkey.Names {
 			pkNameMap[pkName] = struct{}{}
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10447 

## What this PR does / why we need it:
1、如果更改的列不是pk，或者复合主键的某列。那么该更新语句跳过pk查重
2、有时候旧逻辑会跳过pk查重