### PR TITLE
fix a mpool leak after stream closed

### DIFF
--- a/pkg/vm/engine/tae/logtail/service/server.go
+++ b/pkg/vm/engine/tae/logtail/service/server.go
@@ -354,7 +354,7 @@ func (s *LogtailServer) sessionErrorHandler(ctx context.Context) {
 			}
 
 			// drop session directly
-			if e.err != nil {
+			if e.err != nil && s.ssmgr.HasSession(e.session.stream) {
 				e.session.PostClean()
 				s.ssmgr.DeleteSession(e.session.stream)
 			}

--- a/pkg/vm/engine/tae/logtail/service/session.go
+++ b/pkg/vm/engine/tae/logtail/service/session.go
@@ -290,6 +290,20 @@ func (ss *Session) PostClean() {
 
 	ss.cancelFunc()
 	ss.wg.Wait()
+
+	left := len(ss.sendChan)
+
+	// release all left responses in sendChan
+	if left > 0 {
+		i := 0
+		for resp := range ss.sendChan {
+			if i >= left {
+				break
+			}
+			i++
+			ss.responses.Release(resp.response)
+		}
+	}
 }
 
 // Register registers table for client.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

In this PR:
1. it will free all pending responses in the session after the stream is closed.
2. it will free the incoming response when there is no session. (the previous active sessions were deleted from the session manager)