### PR TITLE
Index syntax supports sorting

### DIFF
--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -309,6 +309,22 @@ func TestBuildCreateTable(t *testing.T) {
 					UNIQUE KEY (col1, col3)
 				);`,
 
+		`CREATE TABLE t1 (
+			col1 INT NOT NULL,
+			col2 DATE NOT NULL,
+			col3 INT NOT NULL,
+			col4 INT NOT NULL,
+			UNIQUE KEY (col1 DESC)
+		);`,
+
+		`CREATE TABLE t2 (
+			col1 INT NOT NULL,
+			col2 DATE NOT NULL,
+			col3 INT NOT NULL,
+			col4 INT NOT NULL,
+			UNIQUE KEY (col1 ASC)
+		);`,
+
 		"CREATE TABLE t2 (" +
 			"	`PRIMARY` INT NOT NULL, " +
 			"	col2 DATE NOT NULL, " +
@@ -369,22 +385,6 @@ func TestBuildCreateTableError(t *testing.T) {
 			col4 INT NOT NULL
 		);`,
 
-		`CREATE TABLE t1 (
-			col1 INT NOT NULL,
-			col2 DATE NOT NULL,
-			col3 INT NOT NULL,
-			col4 INT NOT NULL,
-			UNIQUE KEY (col1 DESC)
-		);`,
-
-		`CREATE TABLE t2 (
-			col1 INT NOT NULL,
-			col2 DATE NOT NULL,
-			col3 INT NOT NULL,
-			col4 INT NOT NULL,
-			UNIQUE KEY (col1 ASC)
-		);`,
-
 		`CREATE TABLE t3 (
 			col1 INT NOT NULL,
 			col2 DATE NOT NULL,
@@ -403,6 +403,8 @@ func TestBuildAlterTable(t *testing.T) {
 		"ALTER TABLE emp ADD UNIQUE idx1 (empno, ename);",
 		"ALTER TABLE emp ADD UNIQUE INDEX idx1 (empno, ename);",
 		"ALTER TABLE emp ADD INDEX idx1 (ename, sal);",
+		"ALTER TABLE emp ADD INDEX idx2 (ename, sal DESC);",
+		"ALTER TABLE emp ADD UNIQUE INDEX idx1 (empno ASC);",
 		//"alter table emp drop foreign key fk1",
 		//"alter table nation add FOREIGN KEY fk_t1(n_nationkey) REFERENCES nation2(n_nationkey)",
 	}
@@ -414,7 +416,6 @@ func TestBuildAlterTableError(t *testing.T) {
 	// should pass
 	sqls := []string{
 		"ALTER TABLE emp ADD UNIQUE idx1 ((empno+1) DESC, ename);",
-		"ALTER TABLE emp ADD UNIQUE INDEX idx1 (empno ASC, ename);",
 		"ALTER TABLE emp ADD INDEX idx2 (ename, (sal*30) DESC);",
 		"ALTER TABLE emp ADD UNIQUE INDEX idx1 ((empno+20), (sal*30));",
 	}

--- a/pkg/sql/plan/build_index_util.go
+++ b/pkg/sql/plan/build_index_util.go
@@ -114,9 +114,6 @@ func checkIndexKeypartSupportability(context context.Context, keyParts []*tree.K
 		if key.Expr != nil {
 			return moerr.NewInternalError(context, "unsupported index which using expression as keypart")
 		}
-		if key.Direction != tree.DefaultDirection {
-			return moerr.NewInternalError(context, "the index keypart does not support sorting")
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10515

## What this PR does / why we need it:
在mysql中：索引的语法是：
ADD {INDEX | KEY} [index_name]
     [index_type] (key_part,...) [index_option] ...
ADD [CONSTRAINT [symbol]] UNIQUE [INDEX | KEY]
        [index_name] [index_type] (key_part,...)
        [index_option] ...
                
        key_part: {col_name [(length)] | (expr)} [ASC | DESC]

目前咱们mo的索引不支持使用表达式expr作为索引组成键，出现表达式作为索引组成键会报错，但是mo语法支持索引键排序[ASC | DESC] @heni02 @DanielZhangQD @LiSong0214 @domingozhang 