### PR TITLE
Modify defaultLogtailCollectInterval to 2ms

### DIFF
--- a/pkg/dnservice/cfg.go
+++ b/pkg/dnservice/cfg.go
@@ -54,7 +54,7 @@ var (
 
 	defaultRpcMaxMsgSize              = 1024 * mpool.KB
 	defaultRpcPayloadCopyBufferSize   = 1024 * mpool.KB
-	defaultLogtailCollectInterval     = 50 * time.Millisecond
+	defaultLogtailCollectInterval     = 2 * time.Millisecond
 	defaultLogtailResponseSendTimeout = 10 * time.Second
 	defaultMaxLogtailFetchFailure     = 5
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Now the logtail-collect-interval is configured to 2ms in dn.toml. If it is not configured, MO will use the default value 50ms (defaultLogtailCollectInterval), which will cause poor performance of MO. So it needs to be fixed.