### PR TITLE
Improve stats calculate cost while collect statement info

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -3950,9 +3950,8 @@ func (h *marshalPlanHandler) Stats(ctx context.Context) (statsByte statistic.Sta
 	if h.query != nil {
 		options := &explain.MarshalPlanOptions
 		statsByte.Reset()
-		for _, rootNodeId := range h.query.Steps {
+		for _, node := range h.query.Nodes {
 			// part 1: for statistic.StatsArray
-			node := h.query.Nodes[rootNodeId]
 			s := explain.GetStatistic4Trace(ctx, node, options)
 			statsByte.Add(&s)
 			// part 2: for motrace.Statistic

--- a/pkg/sql/plan/explain/explain_query.go
+++ b/pkg/sql/plan/explain/explain_query.go
@@ -245,6 +245,8 @@ func PreOrderPlan(ctx context.Context, node *plan.Node, Nodes []*plan.Node, grap
 }
 
 // StatisticsRead statistics read rows, size in ExplainData
+//
+// Deprecated: please use explain.GetInputRowsAndInputSize instead.
 func (d *ExplainData) StatisticsRead() (rows int64, size int64) {
 	for _, step := range d.Steps {
 		for _, node := range step.GraphData.Nodes {

--- a/pkg/sql/plan/explain/marshal_query.go
+++ b/pkg/sql/plan/explain/marshal_query.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace/statistic"
 )
 
 // The global variable is used to serialize plan and avoid objects being repeatedly created
@@ -510,6 +511,27 @@ const S3IOByte = "S3 IO Byte"
 const S3IOInputCount = "S3 IO Input Count"
 const S3IOOutputCount = "S3 IO Output Count"
 const Network = "Network"
+
+func GetStatistic4Trace(ctx context.Context, node *plan.Node, options *ExplainOptions) (s statistic.StatsArray) {
+	s.Reset()
+	if options.Analyze && node.AnalyzeInfo != nil {
+		analyzeInfo := node.AnalyzeInfo
+		s.WithTimeConsumed(float64(analyzeInfo.TimeConsumed)).
+			WithMemorySize(float64(analyzeInfo.MemorySize)).
+			WithS3IOInputCount(float64(analyzeInfo.S3IOInputCount)).
+			WithS3IOOutputCount(float64(analyzeInfo.S3IOOutputCount))
+	}
+	return
+}
+
+// GetInputRowsAndInputSize return plan.Node AnalyzeInfo InputRows and InputSize.
+// migrate ExplainData.StatisticsRead to here
+func GetInputRowsAndInputSize(ctx context.Context, node *plan.Node, options *ExplainOptions) (rows int64, size int64) {
+	if options.Analyze && node.AnalyzeInfo != nil {
+		return node.AnalyzeInfo.InputRows, node.AnalyzeInfo.InputSize
+	}
+	return
+}
 
 func (m MarshalNodeImpl) GetStatistics(ctx context.Context, options *ExplainOptions) Statistics {
 	statistics := NewStatistics()

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -123,7 +123,7 @@ func StatementInfoFilter(i Item) bool {
 		// Check StatementType
 		switch statementInfo.StatementType {
 		case "Insert", "Update", "Delete", "Execute", "Commit", "Select":
-			if statementInfo.Duration < GetTracerProvider().selectAggrThreshold {
+			if statementInfo.Duration <= GetTracerProvider().selectAggrThreshold {
 				return true
 			}
 		}

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -123,7 +123,7 @@ func StatementInfoFilter(i Item) bool {
 		// Check StatementType
 		switch statementInfo.StatementType {
 		case "Insert", "Update", "Delete", "Execute", "Select":
-			if statementInfo.Duration < GetTracerProvider().selectAggrThreshold {
+			if statementInfo.Duration <= GetTracerProvider().selectAggrThreshold {
 				return true
 			}
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

1. directly get stats from `plan.Query`, instead of from `MarshalPlan`, which is parsed from planQuery.
2. modify config `LongQueryTime` default value. 
    - If config `DisableStmtAggregation == false`, `LongQueryTime` is NO less than `SelectAggrThreshold`