### PR TITLE
correct the behavior of handle shutdown cmd

### DIFF
--- a/cmd/mo-service/main.go
+++ b/cmd/mo-service/main.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/cnservice"
@@ -83,10 +84,11 @@ func main() {
 	}
 
 	ctx := context.Background()
+	shutdownC := make(chan struct{})
 
 	stopper := stopper.NewStopper("main", stopper.WithLogger(logutil.GetGlobalLogger()))
 	if *launchFile != "" {
-		if err := startCluster(ctx, stopper, globalCounterSet); err != nil {
+		if err := startCluster(ctx, stopper, globalCounterSet, shutdownC); err != nil {
 			panic(err)
 		}
 	} else if *configFile != "" {
@@ -94,22 +96,33 @@ func main() {
 		if err := parseConfigFromFile(*configFile, cfg); err != nil {
 			panic(fmt.Sprintf("failed to parse config from %s, error: %s", *configFile, err.Error()))
 		}
-		if err := startService(ctx, cfg, stopper, globalCounterSet); err != nil {
+		if err := startService(ctx, cfg, stopper, globalCounterSet, shutdownC); err != nil {
 			panic(err)
 		}
 	} else {
 		panic(errors.New("no configuration specified"))
 	}
 
-	waitSignalToStop(stopper)
+	waitSignalToStop(stopper, shutdownC)
 	logutil.GetGlobalLogger().Info("Shutdown complete")
 }
 
-func waitSignalToStop(stopper *stopper.Stopper) {
+func waitSignalToStop(stopper *stopper.Stopper, shutdownC chan struct{}) {
 	sigchan := make(chan os.Signal, 1)
 	signal.Notify(sigchan, syscall.SIGTERM, syscall.SIGINT)
-	sig := <-sigchan
-	logutil.GetGlobalLogger().Info("Starting shutdown...", zap.String("signal", sig.String()))
+
+	detail := "Starting shutdown..."
+	select {
+	case sig := <-sigchan:
+		detail += "signal: " + sig.String()
+	case <-shutdownC:
+		// waiting, give a chance let all log stores and dn stores to get
+		// shutdown cmd from ha keeper
+		time.Sleep(time.Second * 5)
+		detail += "ha keeper issues shutdown command"
+	}
+
+	logutil.GetGlobalLogger().Info(detail)
 	stopper.Stop()
 	if cnProxy != nil {
 		if err := cnProxy.Stop(); err != nil {
@@ -118,7 +131,13 @@ func waitSignalToStop(stopper *stopper.Stopper) {
 	}
 }
 
-func startService(ctx context.Context, cfg *Config, stopper *stopper.Stopper, globalCounterSet *perfcounter.CounterSet) error {
+func startService(
+	ctx context.Context,
+	cfg *Config,
+	stopper *stopper.Stopper,
+	globalCounterSet *perfcounter.CounterSet,
+	shutdownC chan struct{},
+) error {
 	if err := cfg.validate(); err != nil {
 		return err
 	}
@@ -154,9 +173,9 @@ func startService(ctx context.Context, cfg *Config, stopper *stopper.Stopper, gl
 	case metadata.ServiceType_CN:
 		return startCNService(cfg, stopper, fs, globalCounterSet)
 	case metadata.ServiceType_DN:
-		return startDNService(cfg, stopper, fs, globalCounterSet)
+		return startDNService(cfg, stopper, fs, globalCounterSet, shutdownC)
 	case metadata.ServiceType_LOG:
-		return startLogService(cfg, stopper, fs, globalCounterSet)
+		return startLogService(cfg, stopper, fs, globalCounterSet, shutdownC)
 	case metadata.ServiceType_PROXY:
 		return startProxyService(cfg, stopper)
 	default:
@@ -218,6 +237,7 @@ func startDNService(
 	stopper *stopper.Stopper,
 	fileService fileservice.FileService,
 	perfCounterSet *perfcounter.CounterSet,
+	shutdownC chan struct{},
 ) error {
 	if err := waitClusterCondition(cfg.HAKeeperClient, waitHAKeeperRunning); err != nil {
 		return err
@@ -237,7 +257,8 @@ func startDNService(
 			perfCounterSet,
 			&c,
 			r,
-			fileService)
+			fileService,
+			shutdownC)
 		if err != nil {
 			panic(err)
 		}
@@ -257,9 +278,11 @@ func startLogService(
 	stopper *stopper.Stopper,
 	fileService fileservice.FileService,
 	perfCounterSet *perfcounter.CounterSet,
+	shutdownC chan struct{},
 ) error {
 	lscfg := cfg.getLogServiceConfig()
 	s, err := logservice.NewService(lscfg, fileService,
+		shutdownC,
 		logservice.WithRuntime(runtime.ProcessLevelRuntime()))
 	if err != nil {
 		panic(err)

--- a/pkg/dnservice/store.go
+++ b/pkg/dnservice/store.go
@@ -96,6 +96,7 @@ type store struct {
 	ctlservice          ctlservice.CtlService
 	replicas            *sync.Map
 	stopper             *stopper.Stopper
+	shutdownC           chan struct{}
 
 	options struct {
 		logServiceClientFactory func(metadata.DNShard) (logservice.Client, error)
@@ -123,6 +124,7 @@ func NewService(
 	cfg *Config,
 	rt runtime.Runtime,
 	fileService fileservice.FileService,
+	shutdownC chan struct{},
 	opts ...Option) (Service, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, err
@@ -146,6 +148,7 @@ func NewService(
 		rt:                  rt,
 		fileService:         fileService,
 		metadataFileService: metadataFS,
+		shutdownC:           shutdownC,
 	}
 	for _, opt := range opts {
 		opt(s)

--- a/pkg/dnservice/store_heartbeat.go
+++ b/pkg/dnservice/store_heartbeat.go
@@ -118,7 +118,9 @@ func (s *store) handleRemoveReplica(cmd logservicepb.ScheduleCommand) {
 }
 
 func (s *store) handleShutdownStore(_ logservicepb.ScheduleCommand) {
-	if err := s.Close(); err != nil {
-		s.rt.Logger().Error("failed to shutdown store", zap.Error(err))
+	// notify main routine that have received shutdown cmd
+	select {
+	case s.shutdownC <- struct{}{}:
+	default:
 	}
 }

--- a/pkg/hakeeper/checkers/syshealth/check.go
+++ b/pkg/hakeeper/checkers/syshealth/check.go
@@ -15,8 +15,11 @@
 package syshealth
 
 import (
+	"fmt"
+
 	"github.com/matrixorigin/matrixone/pkg/hakeeper"
 	"github.com/matrixorigin/matrixone/pkg/hakeeper/operator"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 )
 
@@ -55,6 +58,17 @@ func Check(
 	if sysHealthy {
 		return nil, sysHealthy
 	}
+
+	detail := "Expired logStore info..."
+	for uuid, _ := range logStores.expired {
+		detail += fmt.Sprintf("store %s replicas: [", uuid)
+		for _, replicaInfo := range logState.Stores[uuid].Replicas {
+			detail += fmt.Sprintf("%d-%d, ", replicaInfo.ShardID, replicaInfo.ReplicaID)
+		}
+		detail += "]; "
+	}
+
+	logutil.GetGlobalLogger().Info(detail)
 
 	// parse all dn stores
 	dnStores := parseDnState(cfg, dnState, currTick)

--- a/pkg/hakeeper/checkers/syshealth/check.go
+++ b/pkg/hakeeper/checkers/syshealth/check.go
@@ -60,7 +60,7 @@ func Check(
 	}
 
 	detail := "Expired logStore info..."
-	for uuid, _ := range logStores.expired {
+	for uuid := range logStores.expired {
 		detail += fmt.Sprintf("store %s replicas: [", uuid)
 		for _, replicaInfo := range logState.Stores[uuid].Replicas {
 			detail += fmt.Sprintf("%d-%d, ", replicaInfo.ShardID, replicaInfo.ReplicaID)

--- a/pkg/logservice/client_test.go
+++ b/pkg/logservice/client_test.go
@@ -59,6 +59,7 @@ func runClientTest(
 	defer vfs.ReportLeakedFD(cfg.FS, t)
 	service, err := NewService(cfg,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),
@@ -144,6 +145,7 @@ func TestClientCanBeConnectedByReverseProxy(t *testing.T) {
 	defer vfs.ReportLeakedFD(cfg.FS, t)
 	service, err := NewService(cfg,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),

--- a/pkg/logservice/hakeeper_client_test.go
+++ b/pkg/logservice/hakeeper_client_test.go
@@ -313,6 +313,7 @@ func testNotHAKeeperErrorIsHandled(t *testing.T, fn func(*testing.T, *managedHAK
 	cfg2.Fill()
 	service1, err := NewService(cfg1,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),
@@ -323,6 +324,7 @@ func testNotHAKeeperErrorIsHandled(t *testing.T, fn func(*testing.T, *managedHAK
 	}()
 	service2, err := NewService(cfg2,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),

--- a/pkg/logservice/service.go
+++ b/pkg/logservice/service.go
@@ -68,6 +68,7 @@ type Service struct {
 	stopper     *stopper.Stopper
 	haClient    LogHAKeeperClient
 	fileService fileservice.FileService
+	shutdownC   chan struct{}
 
 	options struct {
 		// morpc client would filter remote backend via this
@@ -85,6 +86,7 @@ type Service struct {
 func NewService(
 	cfg Config,
 	fileService fileservice.FileService,
+	shutdownC chan struct{},
 	opts ...Option,
 ) (*Service, error) {
 	cfg.Fill()
@@ -96,6 +98,7 @@ func NewService(
 		cfg:         cfg,
 		stopper:     stopper.NewStopper("log-service"),
 		fileService: fileService,
+		shutdownC:   shutdownC,
 	}
 	for _, opt := range opts {
 		opt(service)

--- a/pkg/logservice/service_commands.go
+++ b/pkg/logservice/service_commands.go
@@ -109,8 +109,10 @@ func (s *Service) handleKillZombie(cmd pb.ScheduleCommand) {
 }
 
 func (s *Service) handleShutdownStore(_ pb.ScheduleCommand) {
-	if err := s.Close(); err != nil {
-		s.runtime.Logger().Error("failed to shutdown replica", zap.Error(err))
+	// notify main routine that have received shutdown cmd
+	select {
+	case s.shutdownC <- struct{}{}:
+	default:
 	}
 }
 

--- a/pkg/logservice/service_test.go
+++ b/pkg/logservice/service_test.go
@@ -67,6 +67,7 @@ func runServiceTest(t *testing.T,
 	defer vfs.ReportLeakedFD(cfg.FS, t)
 	service, err := NewService(cfg,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),
@@ -110,6 +111,7 @@ func TestNewService(t *testing.T) {
 	defer vfs.ReportLeakedFD(cfg.FS, t)
 	service, err := NewService(cfg,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),
@@ -539,6 +541,7 @@ func TestShardInfoCanBeQueried(t *testing.T) {
 	cfg1.Fill()
 	service1, err := NewService(cfg1,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),
@@ -552,6 +555,7 @@ func TestShardInfoCanBeQueried(t *testing.T) {
 	assert.NoError(t, service1.store.startReplica(1, 1, peers1, false))
 	service2, err := NewService(cfg2,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),
@@ -668,6 +672,7 @@ func TestGossipInSimulatedCluster(t *testing.T) {
 		configs = append(configs, cfg)
 		service, err := NewService(cfg,
 			newFS(),
+			nil,
 			WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 				return true
 			}),
@@ -781,6 +786,7 @@ func TestGossipInSimulatedCluster(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	service, err := NewService(configs[12],
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),

--- a/pkg/logservice/service_wrap.go
+++ b/pkg/logservice/service_wrap.go
@@ -28,9 +28,10 @@ type WrappedService struct {
 func NewWrappedService(
 	c Config,
 	fileService fileservice.FileService,
+	shutdownC chan struct{},
 	opts ...Option,
 ) (*WrappedService, error) {
-	svc, err := NewService(c, fileService, opts...)
+	svc, err := NewService(c, fileService, shutdownC, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/logservice/store_hakeeper_check_test.go
+++ b/pkg/logservice/store_hakeeper_check_test.go
@@ -224,6 +224,7 @@ func runHAKeeperClusterTest(t *testing.T, fn func(*testing.T, []*Service)) {
 	cfg4.Fill()
 	service1, err := NewService(cfg1,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),
@@ -234,6 +235,7 @@ func runHAKeeperClusterTest(t *testing.T, fn func(*testing.T, []*Service)) {
 	}()
 	service2, err := NewService(cfg2,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),
@@ -244,6 +246,7 @@ func runHAKeeperClusterTest(t *testing.T, fn func(*testing.T, []*Service)) {
 	}()
 	service3, err := NewService(cfg3,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),
@@ -254,6 +257,7 @@ func runHAKeeperClusterTest(t *testing.T, fn func(*testing.T, []*Service)) {
 	}()
 	service4, err := NewService(cfg4,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),

--- a/pkg/logservice/testclient.go
+++ b/pkg/logservice/testclient.go
@@ -37,6 +37,7 @@ func NewTestService(fs vfs.FS) (*Service, ClientConfig, error) {
 	cfg.Fill()
 	service, err := NewService(cfg,
 		newFS(),
+		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {
 			return true
 		}),

--- a/pkg/pb/logservice/logservice.go
+++ b/pkg/pb/logservice/logservice.go
@@ -223,9 +223,6 @@ func (s *LogState) updateShards(hb LogStoreHeartbeat) {
 // Do not add CN's StartTaskRunner info to log string, because there has user and password.
 func (m *ScheduleCommand) LogString() string {
 	c := func(s string) string {
-		if len(s) > 6 {
-			return s[:6]
-		}
 		return s
 	}
 

--- a/pkg/pb/logservice/logservice_test.go
+++ b/pkg/pb/logservice/logservice_test.go
@@ -333,7 +333,7 @@ func TestLogString(t *testing.T) {
 				},
 				ServiceType: LogService,
 			},
-			expected: "L/Start storeA storeA:1:1:0 [1:storeA 2:storeB 3:storeC]",
+			expected: "L/Start storeA storeA:1:1:0 [1:storeA123 2:storeB 3:storeC]",
 		},
 	}
 

--- a/pkg/tests/service/dnservice.go
+++ b/pkg/tests/service/dnservice.go
@@ -146,7 +146,7 @@ func newDNService(
 	opts dnOptions,
 ) (DNService, error) {
 	CounterSet := new(perfcounter.CounterSet)
-	svc, err := dnservice.NewService(CounterSet, cfg, rt, fs, opts...)
+	svc, err := dnservice.NewService(CounterSet, cfg, rt, fs, nil, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tests/service/logservice.go
+++ b/pkg/tests/service/logservice.go
@@ -147,7 +147,7 @@ func newLogService(
 	fs fileservice.FileService,
 	opts logOptions,
 ) (LogService, error) {
-	svc, err := logservice.NewWrappedService(cfg, fs, opts...)
+	svc, err := logservice.NewWrappedService(cfg, fs, nil, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10658 #10422 #10888 

## What this PR does / why we need it:

when the ha keeper found the log replicas of any shards less than half of the initial setting (num-of-log-shard-replicas), it will issue a shutdown command to log services and dn services to shut down all stores.

however, the shutdown command handler will fall into a deadlock when the log store and dn store received these commands:

heartbeat sends log store and dn store msg to ha keeper, and calls `handleCommands` to handle commands. the shutdown handler then calls service.close which will cancel all ctx and wait tasks exit. but the heartbeat task can detect the cancel signal only when handleCommands is returned.

so, when the shutdown command is generated, the log service and dn service will print these msg respectively
endlessly:
```
 tasks still running in stopper {"stopper": "log-service", "continuous": "3m0.017973416s", "tasks": "log-heartbeat-worker"}

"msg":"tasks still running in stopper","uuid":"dd4dccb4-4d3c-41f8-b482-5251dc7a41bf","stopper":"dn-store","continuous":"2m30.016708291s","tasks":"undefined"
```

the shutdown command needs to shut down all log stores and dn stores because the log shards lose more than half of the replicas, which cannot continue providing log service.
