### PR TITLE
fix 10499 and quick return if any null used in pk filter expr

### DIFF
--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -153,11 +153,12 @@ func (mixin *withFilterMixin) getCompositPKFilter(proc *process.Process) (
 	// evaluate
 	pkNames := mixin.tableDef.Pkey.Names
 	pkVals := make([]*plan.Const, len(pkNames))
-	ok := getCompositPKVals(mixin.filterState.expr, pkNames, pkVals, proc)
+	ok, hasNull := getCompositPKVals(mixin.filterState.expr, pkNames, pkVals, proc)
 
 	if !ok || pkVals[0] == nil {
 		mixin.filterState.evaluated = true
 		mixin.filterState.filter = nil
+		mixin.filterState.hasNull = hasNull
 		return
 	}
 	cnt := getValidCompositePKCnt(pkVals)

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -217,7 +217,7 @@ func (mixin *withFilterMixin) getNonCompositPKFilter(proc *process.Process) (
 	// C: {A|B} and {A|B}
 	// D: {A|B|C} [and {A|B|C}]*
 	// for other patterns, no filter is needed
-	ok, searchFunc := getNonCompositePKSearchFuncByExpr(
+	ok, hasNull, searchFunc := getNonCompositePKSearchFuncByExpr(
 		mixin.filterState.expr,
 		mixin.tableDef.Pkey.PkeyColName,
 		mixin.columns.colTypes[mixin.columns.pkPos].Oid,
@@ -226,6 +226,7 @@ func (mixin *withFilterMixin) getNonCompositPKFilter(proc *process.Process) (
 	if !ok || searchFunc == nil {
 		mixin.filterState.evaluated = true
 		mixin.filterState.filter = nil
+		mixin.filterState.hasNull = hasNull
 		return
 	}
 

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -324,6 +324,11 @@ func (r *blockReader) Read(
 	// get the block read filter
 	filter := r.getReadFilter(r.proc)
 
+	// if any null expr is found in the primary key (composite primary keys), quick return
+	if r.filterState.hasNull {
+		return nil, nil
+	}
+
 	//prefetch some objects
 	for len(r.steps) > 0 && r.steps[0] == r.currentStep {
 		if filter != nil && blockInfo.Sorted {

--- a/pkg/vm/engine/disttae/tools.go
+++ b/pkg/vm/engine/disttae/tools.go
@@ -1186,161 +1186,161 @@ func genColumnPrimaryKey(tableId uint64, name string) string {
 // 	return false
 // }
 
-func transferIval[T int32 | int64](v T, oid types.T) (bool, any) {
+func transferIval[T int32 | int64](v T, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_int8:
-		return true, int8(v)
+		return true, false, int8(v)
 	case types.T_int16:
-		return true, int16(v)
+		return true, false, int16(v)
 	case types.T_int32:
-		return true, int32(v)
+		return true, false, int32(v)
 	case types.T_int64:
-		return true, int64(v)
+		return true, false, int64(v)
 	case types.T_uint8:
-		return true, uint8(v)
+		return true, false, uint8(v)
 	case types.T_uint16:
-		return true, uint16(v)
+		return true, false, uint16(v)
 	case types.T_uint32:
-		return true, uint32(v)
+		return true, false, uint32(v)
 	case types.T_uint64:
-		return true, uint64(v)
+		return true, false, uint64(v)
 	case types.T_float32:
-		return true, float32(v)
+		return true, false, float32(v)
 	case types.T_float64:
-		return true, float64(v)
+		return true, false, float64(v)
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferUval[T uint32 | uint64](v T, oid types.T) (bool, any) {
+func transferUval[T uint32 | uint64](v T, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_int8:
-		return true, int8(v)
+		return true, false, int8(v)
 	case types.T_int16:
-		return true, int16(v)
+		return true, false, int16(v)
 	case types.T_int32:
-		return true, int32(v)
+		return true, false, int32(v)
 	case types.T_int64:
-		return true, int64(v)
+		return true, false, int64(v)
 	case types.T_uint8:
-		return true, uint8(v)
+		return true, false, uint8(v)
 	case types.T_uint16:
-		return true, uint16(v)
+		return true, false, uint16(v)
 	case types.T_uint32:
-		return true, uint32(v)
+		return true, false, uint32(v)
 	case types.T_uint64:
-		return true, uint64(v)
+		return true, false, uint64(v)
 	case types.T_float32:
-		return true, float32(v)
+		return true, false, float32(v)
 	case types.T_float64:
-		return true, float64(v)
+		return true, false, float64(v)
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferFval(v float32, oid types.T) (bool, any) {
+func transferFval(v float32, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_float32:
-		return true, float32(v)
+		return true, false, float32(v)
 	case types.T_float64:
-		return true, float64(v)
+		return true, false, float64(v)
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferDval(v float64, oid types.T) (bool, any) {
+func transferDval(v float64, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_float32:
-		return true, float32(v)
+		return true, false, float32(v)
 	case types.T_float64:
-		return true, float64(v)
+		return true, false, float64(v)
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferSval(v string, oid types.T) (bool, any) {
+func transferSval(v string, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_json:
-		return true, []byte(v)
+		return true, false, []byte(v)
 	case types.T_char, types.T_varchar:
-		return true, []byte(v)
+		return true, false, []byte(v)
 	case types.T_text, types.T_blob:
-		return true, []byte(v)
+		return true, false, []byte(v)
 	case types.T_binary, types.T_varbinary:
-		return true, []byte(v)
+		return true, false, []byte(v)
 	case types.T_uuid:
 		var uv types.Uuid
 		copy(uv[:], []byte(v)[:])
-		return true, uv
+		return true, false, uv
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferBval(v bool, oid types.T) (bool, any) {
+func transferBval(v bool, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_bool:
-		return true, v
+		return true, false, v
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferDateval(v int32, oid types.T) (bool, any) {
+func transferDateval(v int32, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_date:
-		return true, types.Date(v)
+		return true, false, types.Date(v)
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferTimeval(v int64, oid types.T) (bool, any) {
+func transferTimeval(v int64, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_time:
-		return true, types.Time(v)
+		return true, false, types.Time(v)
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferDatetimeval(v int64, oid types.T) (bool, any) {
+func transferDatetimeval(v int64, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_datetime:
-		return true, types.Datetime(v)
+		return true, false, types.Datetime(v)
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferTimestampval(v int64, oid types.T) (bool, any) {
+func transferTimestampval(v int64, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_timestamp:
-		return true, types.Timestamp(v)
+		return true, false, types.Timestamp(v)
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferDecimal64val(v int64, oid types.T) (bool, any) {
+func transferDecimal64val(v int64, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_decimal64:
-		return true, types.Decimal64(v)
+		return true, false, types.Decimal64(v)
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 
-func transferDecimal128val(a, b int64, oid types.T) (bool, any) {
+func transferDecimal128val(a, b int64, oid types.T) (bool, bool, any) {
 	switch oid {
 	case types.T_decimal128:
-		return true, types.Decimal128{B0_63: uint64(a), B64_127: uint64(b)}
+		return true, false, types.Decimal128{B0_63: uint64(a), B64_127: uint64(b)}
 	default:
-		return false, nil
+		return false, false, nil
 	}
 }
 

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1442,6 +1442,8 @@ func (tbl *txnTable) newMergeReader(
 		if pk.CompPkeyCol != nil {
 			pkVals := make([]*plan.Const, len(pk.Names))
 			_, hasNull := getCompositPKVals(expr, pk.Names, pkVals, tbl.proc)
+
+			// return empty reader if the composite primary key has null value
 			if hasNull {
 				return []engine.Reader{
 					new(emptyReader),

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1441,7 +1441,12 @@ func (tbl *txnTable) newMergeReader(
 		// here we try to serialize the composite primary key
 		if pk.CompPkeyCol != nil {
 			pkVals := make([]*plan.Const, len(pk.Names))
-			getCompositPKVals(expr, pk.Names, pkVals, tbl.proc)
+			_, hasNull := getCompositPKVals(expr, pk.Names, pkVals, tbl.proc)
+			if hasNull {
+				return []engine.Reader{
+					new(emptyReader),
+				}, nil
+			}
 			cnt := getValidCompositePKCnt(pkVals)
 			if cnt != 0 {
 				var packer *types.Packer

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1465,7 +1465,12 @@ func (tbl *txnTable) newMergeReader(
 			}
 		} else {
 			pkColumn := tbl.tableDef.Cols[tbl.primaryIdx]
-			ok, v := getPkValueByExpr(expr, pkColumn.Name, types.T(pkColumn.Typ.Id), tbl.proc)
+			ok, hasNull, v := getPkValueByExpr(expr, pkColumn.Name, types.T(pkColumn.Typ.Id), tbl.proc)
+			if hasNull {
+				return []engine.Reader{
+					new(emptyReader),
+				}, nil
+			}
 			if ok {
 				var packer *types.Packer
 				put := tbl.db.txn.engine.packerPool.Get(&packer)

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -451,6 +451,7 @@ type withFilterMixin struct {
 		filter   blockio.ReadFilter
 		seqnums  []uint16 // seqnums of the columns in the filter
 		colTypes []types.Type
+		hasNull  bool
 	}
 
 	sels []int32

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -192,59 +192,72 @@ func getPkExpr(expr *plan.Expr, pkName string, proc *process.Process) (bool, *pl
 	return false, nil
 }
 
-func getNonCompositePKSearchFuncByExpr(expr *plan.Expr, pkName string, oid types.T,
-	proc *process.Process) (bool, func(*vector.Vector) int) {
+func getNonCompositePKSearchFuncByExpr(
+	expr *plan.Expr, pkName string, oid types.T, proc *process.Process,
+) (bool, bool, func(*vector.Vector) int) {
 	canCompute, valExpr := getPkExpr(expr, pkName, proc)
 	if !canCompute {
-		return canCompute, nil
+		return false, false, nil
+	}
+
+	if valExpr.Isnull {
+		return false, true, nil
 	}
 
 	switch val := valExpr.Value.(type) {
 	case *plan.Const_I8Val:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(int8(val.I8Val))
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(int8(val.I8Val))
 	case *plan.Const_I16Val:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(int16(val.I16Val))
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(int16(val.I16Val))
 	case *plan.Const_I32Val:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(int32(val.I32Val))
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(int32(val.I32Val))
 	case *plan.Const_I64Val:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(int64(val.I64Val))
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(int64(val.I64Val))
 	case *plan.Const_Fval:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(val.Fval)
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(val.Fval)
 	case *plan.Const_Dval:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(val.Dval)
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(val.Dval)
 	case *plan.Const_U8Val:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(uint8(val.U8Val))
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(uint8(val.U8Val))
 	case *plan.Const_U16Val:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(uint16(val.U16Val))
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(uint16(val.U16Val))
 	case *plan.Const_U32Val:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(uint32(val.U32Val))
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(uint32(val.U32Val))
 	case *plan.Const_U64Val:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(val.U64Val)
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(val.U64Val)
 	case *plan.Const_Dateval:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(val.Dateval)
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(val.Dateval)
 	case *plan.Const_Timeval:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(val.Timeval)
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(val.Timeval)
 	case *plan.Const_Datetimeval:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(val.Datetimeval)
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(val.Datetimeval)
 	case *plan.Const_Timestampval:
-		return true, vector.OrderedBinarySearchOffsetByValFactory(val.Timestampval)
+		return true, false, vector.OrderedBinarySearchOffsetByValFactory(val.Timestampval)
 	case *plan.Const_Decimal64Val:
-		return true, vector.FixSizedBinarySearchOffsetByValFactory(types.Decimal64(val.Decimal64Val.A), types.CompareDecimal64)
+		return true, false, vector.FixSizedBinarySearchOffsetByValFactory(types.Decimal64(val.Decimal64Val.A), types.CompareDecimal64)
 	case *plan.Const_Decimal128Val:
 		v := types.Decimal128{B0_63: uint64(val.Decimal128Val.A), B64_127: uint64(val.Decimal128Val.B)}
-		return true, vector.FixSizedBinarySearchOffsetByValFactory(v, types.CompareDecimal128)
+		return true, false, vector.FixSizedBinarySearchOffsetByValFactory(v, types.CompareDecimal128)
 	case *plan.Const_Sval:
-		return true, vector.VarlenBinarySearchOffsetByValFactory(util.UnsafeStringToBytes(val.Sval))
+		return true, false, vector.VarlenBinarySearchOffsetByValFactory(util.UnsafeStringToBytes(val.Sval))
 	case *plan.Const_Jsonval:
-		return true, vector.VarlenBinarySearchOffsetByValFactory(util.UnsafeStringToBytes(val.Jsonval))
+		return true, false, vector.VarlenBinarySearchOffsetByValFactory(util.UnsafeStringToBytes(val.Jsonval))
 	}
-	return false, nil
+	return false, false, nil
 }
 
-func getPkValueByExpr(expr *plan.Expr, pkName string, oid types.T, proc *process.Process) (bool, any) {
+func getPkValueByExpr(
+	expr *plan.Expr,
+	pkName string,
+	oid types.T,
+	proc *process.Process,
+) (bool, bool, any) {
 	canCompute, valExpr := getPkExpr(expr, pkName, proc)
 	if !canCompute {
-		return canCompute, nil
+		return false, false, nil
+	}
+	if valExpr.Isnull {
+		return false, true, nil
 	}
 	switch val := valExpr.Value.(type) {
 	case *plan.Const_I8Val:
@@ -286,7 +299,7 @@ func getPkValueByExpr(expr *plan.Expr, pkName string, oid types.T, proc *process
 	case *plan.Const_Jsonval:
 		return transferSval(val.Jsonval, oid)
 	}
-	return false, nil
+	return false, false, nil
 }
 
 // computeRangeByNonIntPk compute NonIntPk range Expr

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -501,7 +501,7 @@ func TestGetNonIntPkValueByExpr(t *testing.T) {
 
 	t.Run("test getPkValueByExpr", func(t *testing.T) {
 		for i, testCase := range testCases {
-			result, data := getPkValueByExpr(testCase.expr, "a", testCase.typ, nil)
+			result, _, data := getPkValueByExpr(testCase.expr, "a", testCase.typ, nil)
 			if result != testCase.result {
 				t.Fatalf("test getPkValueByExpr at cases[%d], get result is different with expected", i)
 			}

--- a/test/distributed/cases/dml/select/select.result
+++ b/test/distributed/cases/dml/select/select.result
@@ -423,3 +423,23 @@ mo_ctl(dn, flush, db1.t1)
 {\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
 select a from t1 where a = '';
 invalid argument cast to int, bad value
+drop database if exists db1;
+create database db1;
+use db1;
+create table t1 (a int,b int, primary key(a,b));
+insert into t1 values (1,1),(2,2),(3,3),(4,4),(5,5);
+select count(*) from t1 where a is null;
+count(*)
+0
+select count(*) from t1 where a = null;
+count(*)
+0
+select mo_ctl('dn', 'flush', 'db1.t1');
+mo_ctl(dn, flush, db1.t1)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select count(*) from t1 where a is null;
+count(*)
+0
+select count(*) from t1 where a = null;
+count(*)
+0

--- a/test/distributed/cases/dml/select/select.result
+++ b/test/distributed/cases/dml/select/select.result
@@ -443,3 +443,23 @@ count(*)
 select count(*) from t1 where a = null;
 count(*)
 0
+drop database if exists db1;
+create database db1;
+use db1;
+create table t1 (a int,b int, primary key(a));
+insert into t1 values (1,1),(2,2),(3,3),(4,4),(5,5);
+select count(*) from t1 where a is null;
+count(*)
+0
+select count(*) from t1 where a = null;
+count(*)
+0
+select mo_ctl('dn', 'flush', 'db1.t1');
+mo_ctl(dn, flush, db1.t1)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select count(*) from t1 where a is null;
+count(*)
+0
+select count(*) from t1 where a = null;
+count(*)
+0

--- a/test/distributed/cases/dml/select/select.test
+++ b/test/distributed/cases/dml/select/select.test
@@ -224,3 +224,14 @@ insert into t1 values (1,1);
 -- @separator:table
 select mo_ctl('dn', 'flush', 'db1.t1');
 select a from t1 where a = '';
+drop database if exists db1;
+create database db1;
+use db1;
+create table t1 (a int,b int, primary key(a,b));
+insert into t1 values (1,1),(2,2),(3,3),(4,4),(5,5);
+select count(*) from t1 where a is null;
+select count(*) from t1 where a = null;
+-- @separator:table
+select mo_ctl('dn', 'flush', 'db1.t1');
+select count(*) from t1 where a is null;
+select count(*) from t1 where a = null;

--- a/test/distributed/cases/dml/select/select.test
+++ b/test/distributed/cases/dml/select/select.test
@@ -235,3 +235,14 @@ select count(*) from t1 where a = null;
 select mo_ctl('dn', 'flush', 'db1.t1');
 select count(*) from t1 where a is null;
 select count(*) from t1 where a = null;
+drop database if exists db1;
+create database db1;
+use db1;
+create table t1 (a int,b int, primary key(a));
+insert into t1 values (1,1),(2,2),(3,3),(4,4),(5,5);
+select count(*) from t1 where a is null;
+select count(*) from t1 where a = null;
+-- @separator:table
+select mo_ctl('dn', 'flush', 'db1.t1');
+select count(*) from t1 where a is null;
+select count(*) from t1 where a = null;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10499 

## What this PR does / why we need it:

1. it should not panic if eval expr of any key in composite primary keys $key = null
2. quick return if any null used in pk filter expr