### PR TITLE
improve performance if locked with no conflict

### DIFF
--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -41,8 +41,9 @@ type localLockTable struct {
 	events   *waiterEvents
 	mu       struct {
 		sync.RWMutex
-		closed bool
-		store  LockStorage
+		closed          bool
+		store           LockStorage
+		lastCommittedTS timestamp.Timestamp
 	}
 }
 
@@ -60,6 +61,7 @@ func newLocalLockTable(
 		events:   events,
 	}
 	l.mu.store = newBtreeBasedStorage()
+	l.mu.lastCommittedTS, _ = clock.Now()
 	return l
 }
 
@@ -182,6 +184,9 @@ func (l *localLockTable) unlock(
 		}
 		return true
 	})
+	if l.mu.lastCommittedTS.Less(commitTS) {
+		l.mu.lastCommittedTS = commitTS
+	}
 }
 
 func (l *localLockTable) getLock(txnID, key []byte, fn func(Lock)) {
@@ -282,9 +287,9 @@ func (l *localLockTable) acquireRowLockLocked(c lockContext) lockContext {
 		// lock added, need create new waiter next time
 		c.w = nil
 	}
-	now, _ := l.clock.Now()
+
 	c.offset = 0
-	c.lockedTS = now
+	c.lockedTS = l.mu.lastCommittedTS
 	return c
 }
 
@@ -315,9 +320,8 @@ func (l *localLockTable) acquireRangeLockLocked(c lockContext) lockContext {
 		// lock added, need create new waiter next time
 		c.w = nil
 	}
-	now, _ := l.clock.Now()
 	c.offset = 0
-	c.lockedTS = now
+	c.lockedTS = l.mu.lastCommittedTS
 	return c
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Improve performance if locked with no conflict.  The lock service internally records the maximum commit timestamp for each table, and when a transaction acquires a lock, if there is no conflict, the last commit timestamp is used as the lockedTS, to avoid unnecessary waits