### PR TITLE
fix check data changed

### DIFF
--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -691,7 +691,7 @@ func hasNewVersionInRange(
 	vec *vector.Vector,
 	from, to timestamp.Timestamp) (bool, error) {
 	if vec == nil {
-		return true, nil
+		return false, nil
 	}
 	txnClient := proc.TxnClient
 	txnOp, err := txnClient.New(proc.Ctx, to.Prev())

--- a/pkg/vm/engine/disttae/logtailreplay/primary_key_utils.go
+++ b/pkg/vm/engine/disttae/logtailreplay/primary_key_utils.go
@@ -57,6 +57,9 @@ func (p *PartitionState) PrimaryKeyMayBeModified(
 	} else {
 		empty = false
 	}
+	if empty {
+		return true
+	}
 	for iter.Next() {
 		empty = false
 		row := iter.Entry()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10502 

## What this PR does / why we need it:
When you realize that you have already flushed, and the commit timestamp of the flush is after the from, then you should force the return of the data change, and you don't need to check the memory value.