### PR TITLE
Remove the dealy of rc mode

### DIFF
--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -273,14 +273,6 @@ func (tc *txnOperator) UpdateSnapshot(
 	}
 
 	minTS := ts
-	/*
-		// In rc mode, this logic is not needed to introduce redundant waits,
-		// and should be used to ensure that rc is correct by detecting the
-		// presence of a primary key modification and then reeval.
-			if minTS.IsEmpty() && tc.mu.txn.IsRCIsolation() {
-				minTS, _ = tc.clock.Now()
-			}
-	*/
 
 	lastSnapshotTS, err := tc.timestampWaiter.GetTimestamp(
 		ctx,

--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -273,10 +273,14 @@ func (tc *txnOperator) UpdateSnapshot(
 	}
 
 	minTS := ts
-	// we need to waiter the latest snapshot ts which is greater than the current snapshot
-	if minTS.IsEmpty() && tc.mu.txn.IsRCIsolation() {
-		minTS, _ = tc.clock.Now()
-	}
+	/*
+		// In rc mode, this logic is not needed to introduce redundant waits,
+		// and should be used to ensure that rc is correct by detecting the
+		// presence of a primary key modification and then reeval.
+			if minTS.IsEmpty() && tc.mu.txn.IsRCIsolation() {
+				minTS, _ = tc.clock.Now()
+			}
+	*/
 
 	lastSnapshotTS, err := tc.timestampWaiter.GetTimestamp(
 		ctx,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10498

## What this PR does / why we need it:
* In rc mode, this logic is not needed to introduce redundant waits, and should be used to ensure that rc is correct by detecting the presence of a primary key modification and then reeval.