### PR TITLE
clean s3count after get compile from pool

### DIFF
--- a/pkg/perfcounter/counter_set.go
+++ b/pkg/perfcounter/counter_set.go
@@ -165,3 +165,12 @@ func iterFields(v reflect.Value, path []string, fn IterFieldsFunc) error {
 
 	return nil
 }
+
+func (cs *FileServiceCounterSet) ResetS3() {
+	cs.S3.List.Reset()
+	cs.S3.Head.Reset()
+	cs.S3.Put.Reset()
+	cs.S3.Get.Reset()
+	cs.S3.Delete.Reset()
+	cs.S3.DeleteMulti.Reset()
+}

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -141,6 +141,7 @@ func (c *Compile) clear() {
 	for k := range c.cnLabel {
 		delete(c.cnLabel, k)
 	}
+	c.s3CounterSet.FileService.ResetS3()
 }
 
 // helper function to judge if init temporary engine is needed

--- a/pkg/util/metric/stats/counter.go
+++ b/pkg/util/metric/stats/counter.go
@@ -47,3 +47,9 @@ func (c *Counter) SwapW(new int64) int64 {
 func (c *Counter) LoadW() int64 {
 	return c.window.Load()
 }
+
+// Reset reset the global and window counter to 0
+func (c *Counter) Reset() {
+	c.global.Store(0)
+	c.window.Store(0)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10562

## What this PR does / why we need it:
clean the s3counter after get compile from pool