### PR TITLE
[bug] proxy: drop/suspend account does not work for multi proxies.

### DIFF
--- a/pkg/cnservice/server_heartbeat.go
+++ b/pkg/cnservice/server_heartbeat.go
@@ -91,6 +91,7 @@ func (s *service) handleCommands(cmds []logservicepb.ScheduleCommand) {
 		if cmd.CreateTaskService != nil {
 			s.createTaskService(cmd.CreateTaskService)
 			s.createSQLLogger(cmd.CreateTaskService)
+			s.createProxyUser(cmd.CreateTaskService)
 		}
 	}
 }

--- a/pkg/cnservice/server_task.go
+++ b/pkg/cnservice/server_task.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	logservicepb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/task"
+	"github.com/matrixorigin/matrixone/pkg/proxy"
 	"github.com/matrixorigin/matrixone/pkg/taskservice"
 	"github.com/matrixorigin/matrixone/pkg/util/export"
 	db_holder "github.com/matrixorigin/matrixone/pkg/util/export/etl/db"
@@ -119,6 +120,10 @@ func (s *service) initSqlWriterFactory() {
 func (s *service) createSQLLogger(command *logservicepb.CreateTaskService) {
 	frontend.SetSpecialUser(db_holder.MOLoggerUser, []byte(command.User.Password))
 	db_holder.SetSQLWriterDBUser(db_holder.MOLoggerUser, command.User.Password)
+}
+
+func (s *service) createProxyUser(command *logservicepb.CreateTaskService) {
+	frontend.SetSpecialUser(proxy.SQLUserName, []byte(command.User.Password))
 }
 
 func (s *service) startTaskRunner() {

--- a/pkg/proxy/bootstrap.go
+++ b/pkg/proxy/bootstrap.go
@@ -43,6 +43,7 @@ func (h *handler) bootstrap(ctx context.Context) {
 		case <-ticker.C:
 			if state.TaskTableUser.GetUsername() != "" && state.TaskTableUser.GetPassword() != "" {
 				db_holder.SetSQLWriterDBUser(db_holder.MOLoggerUser, state.TaskTableUser.GetPassword())
+				h.sqlWorker.SetSQLUser(SQLUserName, state.TaskTableUser.GetPassword())
 
 				addressFunc := func(ctx context.Context, _ bool) (string, error) {
 					ctx, cancel := context.WithTimeout(ctx, time.Second*3)
@@ -60,6 +61,7 @@ func (h *handler) bootstrap(ctx context.Context) {
 					return "", nil
 				}
 				db_holder.SetSQLWriterDBAddressFunc(addressFunc)
+				h.sqlWorker.SetAddressFn(addressFunc)
 
 				h.logger.Info("proxy bootstrap succeeded")
 				return

--- a/pkg/proxy/bootstrap_test.go
+++ b/pkg/proxy/bootstrap_test.go
@@ -37,7 +37,7 @@ func TestBootstrap(t *testing.T) {
 		RebalanceInterval: toml.Duration{Duration: time.Second},
 	}
 	cfg.Cluster.RefreshInterval = toml.Duration{Duration: defaultRefreshInterval}
-	h, err := newProxyHandler(ctx, rt, cfg, st, nil, &c)
+	h, err := newProxyHandler(ctx, rt, cfg, st, nil, &c, true)
 	require.NoError(t, err)
 	h.bootstrap(ctx)
 

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -126,6 +126,13 @@ func WithTLSKeyFile(f string) Option {
 	}
 }
 
+// WithTest set the test field to true.
+func WithTest() Option {
+	return func(s *Server) {
+		s.test = true
+	}
+}
+
 // FillDefault fill the default config values of proxy server.
 func (c *Config) FillDefault() {
 	if c.ListenAddress == "" {

--- a/pkg/proxy/conn_manager.go
+++ b/pkg/proxy/conn_manager.go
@@ -278,17 +278,17 @@ func (m *connManager) getCNServerByConnID(connID uint32) *CNServer {
 	return nil
 }
 
-// getCNServersByTenant returns a CN server list by tenant.
-func (m *connManager) getCNServersByTenant(tenant Tenant) []*CNServer {
+// GetCNServersByTenant returns a CN server list by tenant.
+func (m *connManager) GetCNServersByTenant(tenant string) ([]*CNServer, error) {
 	m.Lock()
 	defer m.Unlock()
-	cns, ok := m.tenantConns[tenant]
+	cns, ok := m.tenantConns[Tenant(tenant)]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	cnList := make([]*CNServer, 0, len(cns))
 	for cn := range cns {
 		cnList = append(cnList, cn)
 	}
-	return cnList
+	return cnList, nil
 }

--- a/pkg/proxy/handler_test.go
+++ b/pkg/proxy/handler_test.go
@@ -68,7 +68,7 @@ func newTestProxyHandler(t *testing.T) *testProxyHandler {
 		hc:     hc,
 		mc:     mc,
 		re:     re,
-		ru:     newRouter(mc, re, false),
+		ru:     newRouter(mc, re, re.connManager, false),
 		closeFn: func() {
 			mc.Close()
 			st.Stop()
@@ -422,7 +422,7 @@ func testWithServer(t *testing.T, fn func(*testing.T, string, *Server)) {
 
 	// start proxy.
 	s, err := NewServer(ctx, cfg, WithRuntime(runtime.DefaultRuntime()),
-		WithHAKeeperClient(hc))
+		WithHAKeeperClient(hc), WithTest())
 	defer func() {
 		err := s.Close()
 		require.NoError(t, err)

--- a/pkg/proxy/router_test.go
+++ b/pkg/proxy/router_test.go
@@ -29,6 +29,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type mockSQLWorker struct{}
+
+func newMockSQLWorker() *mockSQLWorker {
+	return &mockSQLWorker{}
+}
+
+func (w *mockSQLWorker) GetCNServersByTenant(tenant string) ([]*CNServer, error) {
+	return nil, nil
+}
+
 func TestCNServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	temp := os.TempDir()
@@ -76,7 +86,7 @@ func TestRouter_SelectEmptyCN(t *testing.T) {
 	time.Sleep(time.Millisecond * 200)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 
 	li1 := labelInfo{
 		Tenant: "t1",
@@ -112,7 +122,7 @@ func TestRouter_RouteForCommon(t *testing.T) {
 	time.Sleep(time.Millisecond * 200)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 	ctx := context.TODO()
 
 	li1 := labelInfo{
@@ -188,7 +198,7 @@ func TestRouter_RouteForSys(t *testing.T) {
 	defer mc.Close()
 	rt.SetGlobalVariables(runtime.ClusterService, mc)
 	re := testRebalancer(t, st, logger, mc)
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 	li1 := labelInfo{
 		Tenant: "sys",
 	}
@@ -256,7 +266,7 @@ func TestRouter_SelectByConnID(t *testing.T) {
 	defer func() {
 		require.NoError(t, stopFn1())
 	}()
-	ru := newRouter(nil, re, true)
+	ru := newRouter(nil, re, newMockSQLWorker(), true)
 
 	cn1 := testMakeCNServer("uuid1", addr1, 10, "", labelInfo{})
 	_, _, err := ru.Connect(cn1, testPacket, nil)
@@ -329,7 +339,7 @@ func TestRouter_ConnectAndSelectBalanced(t *testing.T) {
 	time.Sleep(time.Millisecond * 200)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 
 	connResult := make(map[string]struct{})
 	li1 := labelInfo{
@@ -434,7 +444,7 @@ func TestRouter_ConnectAndSelectSpecify(t *testing.T) {
 	time.Sleep(time.Millisecond * 200)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 
 	connResult := make(map[string]struct{})
 	li1 := labelInfo{
@@ -528,7 +538,7 @@ func TestRouter_Filter(t *testing.T) {
 	time.Sleep(time.Millisecond * 200)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 
 	cn, err := ru.Route(ctx, clientInfo{username: "dump"}, func(s string) bool {
 		return s == "cn1"
@@ -575,7 +585,7 @@ func TestRouter_RetryableConnect(t *testing.T) {
 	time.Sleep(time.Millisecond * 200)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 
 	li1 := labelInfo{
 		Tenant: "t1",

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -40,6 +40,7 @@ type Server struct {
 	counterSet *counterSet
 	// for test.
 	testHAKeeperClient logservice.ClusterHAKeeperClient
+	test               bool
 }
 
 // NewServer creates the proxy server.
@@ -68,7 +69,7 @@ func NewServer(ctx context.Context, config Config, opts ...Option) (*Server, err
 	stats.Register(statsFamilyName, stats.WithLogExporter(logExporter))
 
 	s.stopper = stopper.NewStopper("mo-proxy", stopper.WithLogger(s.runtime.Logger().RawLogger()))
-	h, err := newProxyHandler(ctx, s.runtime, s.config, s.stopper, s.counterSet, s.testHAKeeperClient)
+	h, err := newProxyHandler(ctx, s.runtime, s.config, s.stopper, s.counterSet, s.testHAKeeperClient, s.test)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proxy/sql_worker.go
+++ b/pkg/proxy/sql_worker.go
@@ -1,0 +1,157 @@
+// Copyright 2021 - 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+)
+
+const SQLUserName = "proxy_user"
+
+// SQLRouter routes connections with SQL query. It executes some queries to
+// get information about tenant, connection ID or others and returns the
+// property CN servers.
+type SQLRouter interface {
+	// GetCNServersByTenant gets all connection information by tenant name.
+	// It connects to CN backend server to query data.
+	GetCNServersByTenant(string) ([]*CNServer, error)
+}
+
+// SQLWorker is the interface which contains methods to init the SQL worker.
+type SQLWorker interface {
+	// SetSQLUser sets up the auth information to connect to backend servers.
+	// The information comes from TaskTableUser which is in HAKeeper.
+	SetSQLUser(username, password string)
+	// SetAddressFn sets up the function which returns the backend server address.
+	// The information comes from TaskTableUser which is in HAKeeper.
+	SetAddressFn(f sqlAddressFn)
+}
+
+// sqlUser defines the structure which contains username and password
+// that is used to connect to backend server.
+type sqlUser struct {
+	username string
+	password string
+}
+
+// sqlAddressFn is the function that would return the backend server address.
+type sqlAddressFn func(context.Context, bool) (string, error)
+
+// sqlWorker is the type of SQL worker, which do some SQL query jobs.
+type sqlWorker struct {
+	mu struct {
+		sync.RWMutex
+		sqlUser       sqlUser
+		addressGetter sqlAddressFn
+	}
+}
+
+// newSQLWorker creates a new sqlWorker instance.
+func newSQLWorker() *sqlWorker {
+	return &sqlWorker{}
+}
+
+// readyRLocked checks if the worker is ready. It checks its username
+// and address getter function, if they are both not empty, the worker
+// is ready. It requires the read lock.
+func (w *sqlWorker) readyRLocked() bool {
+	return w.mu.sqlUser.username != "" && w.mu.addressGetter != nil
+}
+
+// SetSQLUser implements the SQLWorker interface.
+func (w *sqlWorker) SetSQLUser(username, password string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.mu.sqlUser.username = username
+	w.mu.sqlUser.password = password
+}
+
+// SetAddressFn implements the SQLWorker interface.
+func (w *sqlWorker) SetAddressFn(f sqlAddressFn) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.mu.addressGetter = f
+}
+
+// initDB uses user info and address getter function to open the connection to
+// backend server and returns the sql.DB instance.
+func (w *sqlWorker) initDB() (*sql.DB, error) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if !w.readyRLocked() {
+		return nil, moerr.NewInternalErrorNoCtx("SQL worker is not ready yet")
+	}
+	dbAddress, err := w.mu.addressGetter(context.Background(), true)
+	if err != nil {
+		return nil, err
+	}
+	sock := "tcp"
+	if strings.Contains(dbAddress, "sock") {
+		sock = "unix"
+	}
+	dsn := fmt.Sprintf("%s:%s@%s(%s)/?timeout=5s",
+		w.mu.sqlUser.username, w.mu.sqlUser.password, sock, dbAddress)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// GetCNServersByTenant implements the SQLWorker interface.
+func (w *sqlWorker) GetCNServersByTenant(tenant string) ([]*CNServer, error) {
+	db, err := w.initDB()
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	// The special user has the highest priority to fetch all tenants' information.
+	// So we filter with tenant name.
+	rows, err := db.Query(
+		fmt.Sprintf("select node_id, conn_id, host from processlist() a where account='%s'", tenant))
+	if err != nil {
+		return nil, err
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	defer rows.Close()
+	var cns []*CNServer
+	for rows.Next() {
+		var (
+			nodeID string
+			connID uint32
+			host   string
+		)
+		err := rows.Scan(&nodeID, &connID, &host)
+		if err != nil {
+			return nil, err
+		} else {
+			cns = append(cns, &CNServer{
+				backendConnID: connID,
+				uuid:          nodeID,
+				addr:          host,
+			})
+		}
+	}
+	return cns, nil
+}

--- a/pkg/proxy/sql_worker_test.go
+++ b/pkg/proxy/sql_worker_test.go
@@ -1,0 +1,60 @@
+// Copyright 2021 - 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSqlWorker_InitDBNotReady(t *testing.T) {
+	testWithServer(t, func(t *testing.T, addr string, server *Server) {
+		w := newSQLWorker()
+		db, err := w.initDB()
+		require.Error(t, err)
+		require.Nil(t, db)
+	})
+}
+
+func TestSqlWorker_InitDB(t *testing.T) {
+	testWithServer(t, func(t *testing.T, addr string, server *Server) {
+		w := newSQLWorker()
+		w.SetSQLUser("dump", "111")
+		w.SetAddressFn(func(ctx context.Context, b bool) (string, error) {
+			return addr, nil
+		})
+		db, err := w.initDB()
+		require.NoError(t, err)
+		require.NotNil(t, db)
+		defer func() {
+			_ = db.Close()
+		}()
+	})
+}
+
+func TestSqlWorker_GetCNServersByTenant(t *testing.T) {
+	testWithServer(t, func(t *testing.T, addr string, server *Server) {
+		w := newSQLWorker()
+		w.SetSQLUser("dump", "111")
+		w.SetAddressFn(func(ctx context.Context, b bool) (string, error) {
+			return addr, nil
+		})
+		cns, err := w.GetCNServersByTenant("t1")
+		require.NoError(t, err)
+		require.Greater(t, len(cns), 0)
+	})
+}


### PR DESCRIPTION
Before, proxy get the connection information within itself, and it does not know infos in other proxy. So we need to use show processlist function to get global connection info to kill the right connection.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10122 

## What this PR does / why we need it: