### PR TITLE
increase timeout to 30s for table subscription

### DIFF
--- a/pkg/vm/engine/disttae/logtailPushModel.go
+++ b/pkg/vm/engine/disttae/logtailPushModel.go
@@ -53,7 +53,7 @@ const (
 	// periodToCheckTableSubscribeSucceed : check table subscribe status period after push client send a subscribe request.
 	// maxTimeToCheckTableSubscribeSucceed : max time to wait for table subscribe succeed. if time exceed, return error.
 	periodToCheckTableSubscribeSucceed  = 1 * time.Millisecond
-	maxTimeToCheckTableSubscribeSucceed = 10 * time.Second
+	maxTimeToCheckTableSubscribeSucceed = 30 * time.Second
 	maxCheckRangeTableSubscribeSucceed  = int(maxTimeToCheckTableSubscribeSucceed / periodToCheckTableSubscribeSucceed)
 
 	// unsubscribe process related constants.
@@ -494,14 +494,14 @@ func (s *subscribedTable) setTableSubscribe(dbId, tblId uint64) {
 		isDeleting: false,
 		latestTime: time.Now(),
 	}
-	logutil.Debugf("[log-tail-push-client] subscribe tbl[db: %d, tbl: %d] succeed", dbId, tblId)
+	logutil.Infof("[log-tail-push-client] subscribe tbl[db: %d, tbl: %d] succeed", dbId, tblId)
 }
 
 func (s *subscribedTable) setTableUnsubscribe(dbId, tblId uint64) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	delete(s.m, subscribeID{dbId, tblId})
-	logutil.Debugf("[log-tail-push-client] unsubscribe tbl[db: %d, tbl: %d] succeed", dbId, tblId)
+	logutil.Infof("[log-tail-push-client] unsubscribe tbl[db: %d, tbl: %d] succeed", dbId, tblId)
 }
 
 // syncLogTailTimestamp is a global log tail timestamp for a cn node.
@@ -724,6 +724,16 @@ func distributeSubscribeResponse(
 	tbl := lt.GetTable()
 	notDistribute := ifShouldNotDistribute(tbl.DbId, tbl.TbId)
 	if notDistribute {
+		// time check for issue #10833.
+		startTime := time.Now()
+		defer func() {
+			tDuration := time.Since(startTime)
+			if tDuration > time.Millisecond*5 {
+				logutil.Warnf("[log-tail-push-client] consume subscribe response for tbl[dbId: %d, tblID: %d] cost %s",
+					tbl.DbId, tbl.TbId, tDuration.String())
+			}
+		}()
+
 		if err := e.consumeSubscribeResponse(ctx, response, false); err != nil {
 			return err
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10833

## What this PR does / why we need it:
1. adjust some log level of log tail push client.
2. increase timeout to 30s for table subscription. (If the state of a table does not change to 'subscribed' within 30 seconds after sending the subscribe request, an error is returned.)