### PR TITLE
fix morpc mem

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -613,6 +613,8 @@ func (rb *remoteBackend) doClose() {
 	rb.closeOnce.Do(func() {
 		close(rb.resetConnC)
 		rb.closeConn(false)
+		// TODO: re create when reconnect
+		rb.conn = nil
 	})
 }
 

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -742,7 +742,7 @@ func testBackendSendWithoutServer(t *testing.T, addr string,
 	b := rb.(*remoteBackend)
 	defer func() {
 		b.Close()
-		assert.False(t, b.conn.Connected())
+		assert.Nil(t, b.conn)
 	}()
 	testFunc(b)
 }

--- a/pkg/common/morpc/client.go
+++ b/pkg/common/morpc/client.go
@@ -148,6 +148,9 @@ func (c *client) adjust() {
 			}
 		}
 	}
+	if c.options.maxIdleDuration == 0 {
+		c.options.maxIdleDuration = defaultMaxIdleDuration
+	}
 }
 
 func (c *client) maybeInitBackends() error {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
release tcp mem when closed immediately. If wait gc task, has a 1 minutes latency.