### PR TITLE
improve performance in pessimistic mode

### DIFF
--- a/pkg/frontend/test/txn_mock.go
+++ b/pkg/frontend/test/txn_mock.go
@@ -1326,6 +1326,32 @@ func (mr *MockWorkspaceMockRecorder) EndStatement() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndStatement", reflect.TypeOf((*MockWorkspace)(nil).EndStatement))
 }
 
+// GetSQLCount mocks base method.
+func (m *MockWorkspace) GetSQLCount() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSQLCount")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// GetSQLCount indicates an expected call of GetSQLCount.
+func (mr *MockWorkspaceMockRecorder) GetSQLCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSQLCount", reflect.TypeOf((*MockWorkspace)(nil).GetSQLCount))
+}
+
+// IncrSQLCount mocks base method.
+func (m *MockWorkspace) IncrSQLCount() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "IncrSQLCount")
+}
+
+// IncrSQLCount indicates an expected call of IncrSQLCount.
+func (mr *MockWorkspaceMockRecorder) IncrSQLCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IncrSQLCount", reflect.TypeOf((*MockWorkspace)(nil).IncrSQLCount))
+}
+
 // IncrStatementID mocks base method.
 func (m *MockWorkspace) IncrStatementID(ctx context.Context, commit bool) error {
 	m.ctrl.T.Helper()

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -616,6 +616,8 @@ func TestGetExprValue(t *testing.T) {
 
 		ws := mock_frontend.NewMockWorkspace(ctrl)
 		ws.EXPECT().IncrStatementID(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		ws.EXPECT().IncrSQLCount().AnyTimes()
+		ws.EXPECT().GetSQLCount().AnyTimes()
 		ws.EXPECT().StartStatement().AnyTimes()
 		ws.EXPECT().EndStatement().AnyTimes()
 		ws.EXPECT().Adjust().AnyTimes()
@@ -718,6 +720,8 @@ func TestGetExprValue(t *testing.T) {
 		ws.EXPECT().StartStatement().AnyTimes()
 		ws.EXPECT().EndStatement().AnyTimes()
 		ws.EXPECT().Adjust().AnyTimes()
+		ws.EXPECT().IncrSQLCount().AnyTimes()
+		ws.EXPECT().GetSQLCount().AnyTimes()
 
 		txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
 		txnOperator.EXPECT().Commit(gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -336,6 +336,7 @@ func (c *Compile) Run(_ uint64) error {
 		pool.Put(c)
 	}()
 	if c.proc.TxnOperator != nil {
+		c.proc.TxnOperator.GetWorkspace().IncrSQLCount()
 		c.proc.TxnOperator.ResetRetry(false)
 	}
 	if err := c.runOnce(); err != nil {

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -101,8 +101,10 @@ func (w *Ws) Adjust() error {
 	return nil
 }
 
-func (w *Ws) StartStatement() {}
-func (w *Ws) EndStatement()   {}
+func (w *Ws) StartStatement()     {}
+func (w *Ws) EndStatement()       {}
+func (w *Ws) IncrSQLCount()       {}
+func (w *Ws) GetSQLCount() uint64 { return 0 }
 
 func TestCompile(t *testing.T) {
 	cnclient.NewCNClient("test", new(cnclient.ClientConfig))

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -271,9 +271,7 @@ func (client *txnClient) determineTxnSnapshot(
 	ctx context.Context,
 	minTS timestamp.Timestamp) (timestamp.Timestamp, error) {
 	// always use the current ts as txn's snapshot ts is enableSacrificingFreshness
-	if !client.enableSacrificingFreshness ||
-		(client.getTxnIsolation() == txn.TxnIsolation_RC &&
-			minTS.IsEmpty()) {
+	if !client.enableSacrificingFreshness {
 		// TODO: Consider how to handle clock offsets. If use Clock-SI, can use the current
 		// time minus the maximum clock offset as the transaction's snapshotTimestamp to avoid
 		// conflicts due to clock uncertainty.

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -205,4 +205,7 @@ type Workspace interface {
 
 	Commit(ctx context.Context) error
 	Rollback(ctx context.Context) error
+
+	IncrSQLCount()
+	GetSQLCount() uint64
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Improve performance in pessimistic(rc) mode.  Pessimistic(rc)mode no need use current timestamp as txn's snapshot ts, and when the first statement is executed, we can use the snapshot of the created transaction, no need to update the snapshot.