### PR TITLE
add default panic handler for log append task

### DIFF
--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/driver.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/driver.go
@@ -80,7 +80,14 @@ func NewLogServiceDriver(cfg *Config) *LogServiceDriver {
 		GetClientRetryTimeOut: cfg.GetClientRetryTimeOut,
 		retryDuration:         cfg.RetryTimeout,
 	}
-	pool, _ := ants.NewPool(10)
+
+	// the tasks submitted to LogServiceDriver.appendPool append entries to logservice,
+	// and we hope the task will crash all the dn service if append failed.
+	// so, set panic to pool.options.PanicHandler here, or it will only crash
+	// the goroutine the append task belongs to.
+	pool, _ := ants.NewPool(10, ants.WithPanicHandler(func(v interface{}) {
+		panic(v)
+	}))
 
 	d := &LogServiceDriver{
 		clientPool:      newClientPool(cfg.ClientPoolMaxSize, cfg.ClientPoolMaxSize, clientpoolConfig),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10926 

## What this PR does / why we need it:

when ctrl+c shut down the log service, the dn service cannot append entries to the log service, after retrying 180s, the append task will panic.

however, all append tasks are submitted to a goroutine pool to be scheduled, and the pool will catch the panic through `recover`, and do some operations specified by users.

In the previous implementation, no panic handler is specified to the pool when calling the 'ants.NewPool, so the panic` can only crash the goroutine it belongs to instead of the dn service.

after the append task crashes, some other tasks will fall into the dead wait, which expected the append task to return and do some further work.

that is why the ctrl+c cannot shut down the dn service.

the fix is to specify a panic handler.

but it still needs to wait for 180s when the ctrl + c dn service or the log service cash in some situations.
