### PR TITLE
fix checks pk changed with the wrong timestamp

### DIFF
--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -438,7 +438,7 @@ func doLock(
 		}
 
 		// if [snapshotTS, newSnapshotTS] has been modified, need retry at new snapshot ts
-		changed, err := fn(proc, tableID, eng, vec, snapshotTS.Prev(), newSnapshotTS)
+		changed, err := fn(proc, tableID, eng, vec, snapshotTS, newSnapshotTS)
 		if err != nil {
 			return false, timestamp.Timestamp{}, err
 		}

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -437,8 +437,8 @@ func doLock(
 			fn = hasNewVersionInRange
 		}
 
-		// if [snapshotTS, lockedTS] has been modified, need retry at new snapshot ts
-		changed, err := fn(proc, tableID, eng, vec, snapshotTS.Prev(), lockedTS)
+		// if [snapshotTS, newSnapshotTS] has been modified, need retry at new snapshot ts
+		changed, err := fn(proc, tableID, eng, vec, snapshotTS.Prev(), newSnapshotTS)
 		if err != nil {
 			return false, timestamp.Timestamp{}, err
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Since the original transaction is used to check for primary key changes, in order to ensure that the logtail of the locked TS can be seen by the transaction, a larger snapshotTS needs to be used to get a new snapshot to check for it, instead of using the lockedTS, which would have missed the commits corresponding to the lockedTS writes.