### PR TITLE
logtailreplay: optimize checkpoints consumption

### DIFF
--- a/pkg/vm/engine/disttae/db.go
+++ b/pkg/vm/engine/disttae/db.go
@@ -36,6 +36,7 @@ func (e *Engine) init(ctx context.Context, m *mpool.MPool) error {
 	defer e.Unlock()
 
 	e.catalog = cache.NewCatalog()
+	e.partitions = make(map[[2]uint64]*logtailreplay.Partition)
 
 	var packer *types.Packer
 	put := e.packerPool.Get(&packer)
@@ -269,44 +270,36 @@ func (e *Engine) getPartition(databaseId, tableId uint64) *logtailreplay.Partiti
 func (e *Engine) lazyLoad(ctx context.Context, tbl *txnTable) (*logtailreplay.Partition, error) {
 	part := e.getPartition(tbl.db.databaseId, tbl.tableId)
 
-	select {
-	case <-part.Lock():
-		defer part.Unlock()
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-
-	state, doneMutate := part.MutateState()
-
-	if err := state.ConsumeCheckpoints(func(checkpoint string) error {
-		entries, closeCBs, err := logtail.LoadCheckpointEntries(
-			ctx,
-			checkpoint,
-			tbl.tableId,
-			tbl.tableName,
-			tbl.db.databaseId,
-			tbl.db.databaseName,
-			tbl.db.txn.engine.mp,
-			tbl.db.txn.engine.fs)
-		defer func() {
-			for _, cb := range closeCBs {
-				cb()
-			}
-		}()
-		if err != nil {
-			return err
-		}
-		for _, entry := range entries {
-			if err = consumeEntry(ctx, tbl.primarySeqnum, e, state, entry); err != nil {
+	if err := part.ConsumeCheckpoints(
+		ctx,
+		func(checkpoint string, state *logtailreplay.PartitionState) error {
+			entries, closeCBs, err := logtail.LoadCheckpointEntries(
+				ctx,
+				checkpoint,
+				tbl.tableId,
+				tbl.tableName,
+				tbl.db.databaseId,
+				tbl.db.databaseName,
+				tbl.db.txn.engine.mp,
+				tbl.db.txn.engine.fs)
+			defer func() {
+				for _, cb := range closeCBs {
+					cb()
+				}
+			}()
+			if err != nil {
 				return err
 			}
-		}
-		return nil
-	}); err != nil {
+			for _, entry := range entries {
+				if err = consumeEntry(ctx, tbl.primarySeqnum, e, state, entry); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	); err != nil {
 		return nil, err
 	}
-
-	doneMutate()
 
 	return part, nil
 }

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -43,7 +43,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/util/errutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/cache"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/logtailreplay"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -75,13 +74,12 @@ func New(
 	}
 
 	e := &Engine{
-		mp:         mp,
-		fs:         fs,
-		ls:         ls.(lockservice.LockService),
-		cli:        cli,
-		idGen:      idGen,
-		dnID:       dnID,
-		partitions: make(map[[2]uint64]*logtailreplay.Partition),
+		mp:    mp,
+		fs:    fs,
+		ls:    ls.(lockservice.LockService),
+		cli:   cli,
+		idGen: idGen,
+		dnID:  dnID,
 		packerPool: fileservice.NewPool(
 			128,
 			func() *types.Packer {

--- a/pkg/vm/engine/disttae/logtailPushModel.go
+++ b/pkg/vm/engine/disttae/logtailPushModel.go
@@ -982,7 +982,7 @@ func updatePartitionOfPush(
 
 	if lazyLoad {
 		if len(tl.CkpLocation) > 0 {
-			state.AppendCheckpoint(tl.CkpLocation)
+			state.AppendCheckpoint(tl.CkpLocation, partition)
 		}
 
 		err = consumeLogTailOfPushWithLazyLoad(

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 )
 
-func BenchmarkPartitionState(b *testing.B) {
+func BenchmarkPartitionStateConcurrentWriteAndIter(b *testing.B) {
 	partition := NewPartition()
 	end := make(chan struct{})
 	defer func() {

--- a/pkg/vm/engine/disttae/logtailreplay/partition_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_test.go
@@ -1,0 +1,63 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logtailreplay
+
+import (
+	"context"
+	"testing"
+)
+
+func BenchmarkPartitonConsumeCheckpoint(b *testing.B) {
+	partition := NewPartition()
+
+	state, done := partition.MutateState()
+	state.checkpoints = append(state.checkpoints, "a", "b", "c")
+	done()
+
+	b.ResetTimer()
+
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		err := partition.ConsumeCheckpoints(ctx, func(checkpoint string, state *PartitionState) error {
+			return nil
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkConcurrentPartitonConsumeCheckpoint(b *testing.B) {
+	partition := NewPartition()
+
+	state, done := partition.MutateState()
+	state.checkpoints = append(state.checkpoints, "a", "b", "c")
+	done()
+
+	b.ResetTimer()
+
+	ctx := context.Background()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			err := partition.ConsumeCheckpoints(ctx, func(checkpoint string, state *PartitionState) error {
+				return nil
+			})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+}


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

logtailreplay: add Partition.ConsumeCheckpoints

logtailreplay: add benchmark for Partiton.ConsumeCheckpoints

logtailreplay: add Partition.checkpointConsumed

disttae: ensure partition checkpoints are consumed once