### PR TITLE
add ctx to interrupt dn from long retry round

### DIFF
--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/append.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/append.go
@@ -46,7 +46,7 @@ func (d *LogServiceDriver) appendAppender() {
 	d.appendtimes++
 	d.onAppendQueue(d.appendable)
 	d.appendedQueue <- d.appendable
-	d.appendable = newDriverAppender()
+	d.appendable = newDriverAppender(d.closeCtx)
 }
 
 func (d *LogServiceDriver) onPreAppend(items ...any) {

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/appender.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/appender.go
@@ -16,7 +16,7 @@ package logservicedriver
 
 import (
 	"context"
-	"errors"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"sync"
 	"time"
 
@@ -86,7 +86,7 @@ func (a *driverAppender) append(retryTimout, appendTimeout time.Duration) {
 			// so, give a chance here to let dn can detect this intentional shut down operation and panic with err timely.
 			select {
 			case <-a.closeCtx.Done():
-				err = errors.New("dn is supposed to be shut down when appender retry")
+				err = moerr.NewInternalErrorNoCtx("dn is supposed to be shut down when appender retry")
 				return true
 			default:
 			}

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/appender.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/appender.go
@@ -16,10 +16,10 @@ package logservicedriver
 
 import (
 	"context"
-	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"sync"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logstore/driver/entry"

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/driver_test.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/driver_test.go
@@ -15,6 +15,7 @@
 package logservicedriver
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -49,7 +50,7 @@ func restartDriver(t *testing.T, d *LogServiceDriver, h func(*entry.Entry)) *Log
 	t.Logf("Driver Lsn %d, Syncing %d, Synced %d", d.driverLsn, d.syncing, d.synced)
 	t.Logf("Truncated %d", d.truncating.Load())
 	t.Logf("LSTruncated %d", d.truncatedLogserviceLsn)
-	d = NewLogServiceDriver(d.config)
+	d = NewLogServiceDriver(context.TODO(), d.config)
 	tempLsn := uint64(0)
 	err := d.Replay(func(e *entry.Entry) {
 		if e.Lsn <= tempLsn {
@@ -86,7 +87,7 @@ func TestReplay1(t *testing.T) {
 	defer service.Close()
 
 	cfg := NewTestConfig(ccfg)
-	driver := NewLogServiceDriver(cfg)
+	driver := NewLogServiceDriver(context.TODO(), cfg)
 
 	entryCount := 10000
 	entries := make([]*entry.Entry, entryCount)
@@ -126,7 +127,7 @@ func TestReplay2(t *testing.T) {
 
 	cfg := NewTestConfig(ccfg)
 	cfg.NewRecordSize = 100
-	driver := NewLogServiceDriver(cfg)
+	driver := NewLogServiceDriver(context.TODO(), cfg)
 
 	entryCount := 10000
 	entries := make([]*entry.Entry, entryCount)

--- a/pkg/vm/engine/tae/logstore/store/store.go
+++ b/pkg/vm/engine/tae/logstore/store/store.go
@@ -15,6 +15,7 @@
 package store
 
 import (
+	"context"
 	"sync"
 
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logstore/driver"
@@ -45,9 +46,9 @@ type StoreImpl struct {
 	truncateQueue   sm.Queue
 }
 
-func NewStoreWithLogserviceDriver(factory logservicedriver.LogServiceClientFactory) Store {
+func NewStoreWithLogserviceDriver(ctx context.Context, factory logservicedriver.LogServiceClientFactory) Store {
 	cfg := logservicedriver.NewDefaultConfig(factory)
-	driver := logservicedriver.NewLogServiceDriver(cfg)
+	driver := logservicedriver.NewLogServiceDriver(ctx, cfg)
 	return NewStore(driver)
 }
 

--- a/pkg/vm/engine/tae/wal/driver.go
+++ b/pkg/vm/engine/tae/wal/driver.go
@@ -42,7 +42,7 @@ type walDriver struct {
 
 func NewDriverWithLogservice(ctx context.Context, factory logservicedriver.LogServiceClientFactory) Driver {
 	ckpDuration := time.Second * 5
-	impl := store.NewStoreWithLogserviceDriver(factory)
+	impl := store.NewStoreWithLogserviceDriver(ctx, factory)
 	driver := NewDriverWithStore(ctx, impl, true, ckpDuration)
 	return driver
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10926 #10658 

## What this PR does / why we need it:

在某些情况下， log service 会先于 dn service 退出，dn 有很大的概率会陷入 append log 的长时间重试中。

这些情况，可以分为两类：
1. log 意外退出，那么 dn 应该尽量重试，因为 log 随时可能会恢复
 
2. 整个系统有意退出，如用户使用 ctrl + c，或者 ha keeper 产生了 shutdown cmd，对于这种情况，应该让 dn 尽快退出，而不会重试过久，甚至陷入死锁。

PR #10988 解决的是让 dn 能够在 append retry 超时后正确的 Panic（之前的 Panic会被捕获，dn 会陷入死锁）

PR #10671 解决的是让 log 和 dn 能够正确的处理 ha keeper 产生的 shutdown 命令

当前的 PR 解决的是 当上面第 2 种情况发生时，dn 能够尽快的从 retry append 中退出。
