### PR TITLE
improve performance for checking PK dup in some cases

### DIFF
--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -338,7 +338,7 @@ func getDmlTableInfo(ctx CompilerContext, tableExprs tree.TableExprs, with *tree
 	return tblInfo, nil
 }
 
-func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Insert, info *dmlSelectInfo) (bool, map[int]int, error) {
+func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Insert, info *dmlSelectInfo) (bool, map[int]int, bool, error) {
 	var err error
 	var insertColumns []string
 	tableDef := info.tblInfo.tableDefs[0]
@@ -356,6 +356,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 	info.tblInfo.newColPosMap = append(info.tblInfo.newColPosMap, oldColPosMap)
 
 	checkInsertPkDup := true
+	isInsertWithoutAutoPkCol := false
 	pkPosInValues := make(map[int]int)
 
 	if stmt.Columns == nil {
@@ -371,7 +372,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 		for _, column := range stmt.Columns {
 			colName := string(column)
 			if _, ok := colToIdx[colName]; !ok {
-				return false, nil, moerr.NewBadFieldError(builder.GetContext(), colName, tableDef.Name)
+				return false, nil, false, moerr.NewBadFieldError(builder.GetContext(), colName, tableDef.Name)
 			}
 			insertColumns = append(insertColumns, colName)
 		}
@@ -388,14 +389,14 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 		if isAllDefault {
 			for j, row := range slt.Rows {
 				if row != nil {
-					return false, nil, moerr.NewWrongValueCountOnRow(builder.GetContext(), j+1)
+					return false, nil, false, moerr.NewWrongValueCountOnRow(builder.GetContext(), j+1)
 				}
 			}
 		} else {
 			colCount := len(insertColumns)
 			for j, row := range slt.Rows {
 				if len(row) != colCount {
-					return false, nil, moerr.NewWrongValueCountOnRow(builder.GetContext(), j+1)
+					return false, nil, false, moerr.NewWrongValueCountOnRow(builder.GetContext(), j+1)
 				}
 			}
 		}
@@ -404,7 +405,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 		//but it does not work at the case:
 		//insert into a(a) values (); insert into a values (0),();
 		if isAllDefault && syntaxHasColumnNames {
-			return false, nil, moerr.NewInvalidInput(builder.GetContext(), "insert values does not match the number of columns")
+			return false, nil, false, moerr.NewInvalidInput(builder.GetContext(), "insert values does not match the number of columns")
 		}
 		checkInsertPkDup = len(slt.Rows) > 1
 		if CNPrimaryCheck && len(slt.Rows) <= maxRowThenUnusePkFilterExpr {
@@ -435,7 +436,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 
 		err = buildValueScan(isAllDefault, info, builder, bindCtx, tableDef, slt, insertColumns, colToIdx)
 		if err != nil {
-			return false, nil, err
+			return false, nil, false, err
 		}
 
 	case *tree.SelectClause:
@@ -444,7 +445,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 		subCtx := NewBindContext(builder, bindCtx)
 		info.rootId, err = builder.buildSelect(astSlt, subCtx, false)
 		if err != nil {
-			return false, nil, err
+			return false, nil, false, err
 		}
 
 	case *tree.ParenSelect:
@@ -453,23 +454,23 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 		subCtx := NewBindContext(builder, bindCtx)
 		info.rootId, err = builder.buildSelect(astSlt, subCtx, false)
 		if err != nil {
-			return false, nil, err
+			return false, nil, false, err
 		}
 
 	default:
-		return false, nil, moerr.NewInvalidInput(builder.GetContext(), "insert has unknown select statement")
+		return false, nil, false, moerr.NewInvalidInput(builder.GetContext(), "insert has unknown select statement")
 	}
 
 	err = builder.addBinding(info.rootId, tree.AliasClause{
 		Alias: derivedTableName,
 	}, bindCtx)
 	if err != nil {
-		return false, nil, err
+		return false, nil, false, err
 	}
 
 	lastNode := builder.qry.Nodes[info.rootId]
 	if len(insertColumns) != len(lastNode.ProjectList) {
-		return false, nil, moerr.NewInvalidInput(builder.GetContext(), "insert values does not match the number of columns")
+		return false, nil, false, moerr.NewInvalidInput(builder.GetContext(), "insert values does not match the number of columns")
 	}
 
 	tag := builder.qry.Nodes[info.rootId].BindingTags[0]
@@ -490,7 +491,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 		}
 		projExpr, err = forceCastExpr(builder.GetContext(), projExpr, tableDef.Cols[colIdx].Typ)
 		if err != nil {
-			return false, nil, err
+			return false, nil, false, err
 		}
 		insertColToExpr[column] = projExpr
 	}
@@ -508,7 +509,11 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 		} else {
 			defExpr, err := getDefaultExpr(builder.GetContext(), col)
 			if err != nil {
-				return false, nil, err
+				return false, nil, false, err
+			}
+
+			if col.Typ.AutoIncr && col.Name == tableDef.Pkey.PkeyColName {
+				isInsertWithoutAutoPkCol = true
 			}
 			projectList = append(projectList, defExpr)
 		}
@@ -565,7 +570,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 		// if table have unique columns, we do the rewrite. if not, do nothing(do not throw error)
 		if len(uniqueCols) > 0 {
 			if len(uniqueCols) > 1 {
-				return false, nil, moerr.NewNYI(builder.GetContext(), "one unique constraint supported for on duplicate key clause now.")
+				return false, nil, false, moerr.NewNYI(builder.GetContext(), "one unique constraint supported for on duplicate key clause now.")
 			}
 
 			joinCtx := NewBindContext(builder, bindCtx)
@@ -597,17 +602,17 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 					if _, ok := updateExpr.(*tree.DefaultVal); ok {
 						defExpr, err = getDefaultExpr(builder.GetContext(), col)
 						if err != nil {
-							return false, nil, err
+							return false, nil, false, err
 						}
 					} else {
 						defExpr, err = binder.BindExpr(updateExpr, 0, true)
 						if err != nil {
-							return false, nil, err
+							return false, nil, false, err
 						}
 					}
 					defExpr, err = forceCastExpr(builder.GetContext(), defExpr, col.Typ)
 					if err != nil {
-						return false, nil, err
+						return false, nil, false, err
 					}
 					updateExprs[col.Name] = defExpr
 				}
@@ -650,14 +655,14 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 					}
 					eqExpr, err := bindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{leftExpr, rightExpr})
 					if err != nil {
-						return false, nil, err
+						return false, nil, false, err
 					}
 					if condIdx == 0 {
 						condExpr = eqExpr
 					} else {
 						condExpr, err = bindFuncExprImplByPlanExpr(builder.GetContext(), "and", []*Expr{condExpr, eqExpr})
 						if err != nil {
-							return false, nil, err
+							return false, nil, false, err
 						}
 					}
 					condIdx++
@@ -668,7 +673,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 				} else {
 					joinConds, err = bindFuncExprImplByPlanExpr(builder.GetContext(), "or", []*Expr{joinConds, condExpr})
 					if err != nil {
-						return false, nil, err
+						return false, nil, false, err
 					}
 				}
 				joinIdx++
@@ -678,7 +683,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 			leftCtx := builder.ctxByNode[info.rootId]
 			err = joinCtx.mergeContexts(builder.GetContext(), leftCtx, rightCtx)
 			if err != nil {
-				return false, nil, err
+				return false, nil, false, err
 			}
 			newRootId := builder.appendNode(&plan.Node{
 				NodeType: plan.Node_JOIN,
@@ -702,7 +707,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 		}
 	}
 
-	return checkInsertPkDup, pkPosInValues, nil
+	return checkInsertPkDup, pkPosInValues, isInsertWithoutAutoPkCol, nil
 }
 
 func deleteToSelect(builder *QueryBuilder, bindCtx *BindContext, node *tree.Delete, haveConstraint bool, tblInfo *dmlTableInfo) (int32, error) {

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -53,7 +53,7 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 	builder.haveOnDuplicateKey = len(stmt.OnDuplicateUpdate) > 0
 
 	bindCtx := NewBindContext(builder, nil)
-	checkInsertPkDup, pkPosInValues, err := initInsertStmt(builder, bindCtx, stmt, rewriteInfo)
+	checkInsertPkDup, pkPosInValues, isInsertWithoutAutoPkCol, err := initInsertStmt(builder, bindCtx, stmt, rewriteInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 
 		query.StmtType = plan.Query_UPDATE
 	} else {
-		err = buildInsertPlans(ctx, builder, bindCtx, objRef, tableDef, rewriteInfo.rootId, checkInsertPkDup, pkFilterExprs)
+		err = buildInsertPlans(ctx, builder, bindCtx, objRef, tableDef, rewriteInfo.rootId, checkInsertPkDup, pkFilterExprs, isInsertWithoutAutoPkCol)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/plan/build_load.go
+++ b/pkg/sql/plan/build_load.go
@@ -93,7 +93,8 @@ func buildLoad(stmt *tree.Load, ctx CompilerContext, isPrepareStmt bool) (*Plan,
 		NodeType: plan.Node_PROJECT,
 		Stats:    &plan.Stats{},
 	}
-	if err := getProjectNode(stmt, ctx, projectNode, tableDef); err != nil {
+	isInsertWithoutAutoPkCol, err := getProjectNode(stmt, ctx, projectNode, tableDef)
+	if err != nil {
 		return nil, err
 	}
 	if stmt.Param.Parallel && (getCompressType(stmt.Param, fileName) != tree.NOCOMPRESS || stmt.Local) {
@@ -119,7 +120,7 @@ func buildLoad(stmt *tree.Load, ctx CompilerContext, isPrepareStmt bool) (*Plan,
 	// append hidden column to tableDef
 	newTableDef := DeepCopyTableDef(tableDef)
 	checkInsertPkDup := false
-	err = buildInsertPlans(ctx, builder, bindCtx, objRef, newTableDef, lastNodeId, checkInsertPkDup, nil)
+	err = buildInsertPlans(ctx, builder, bindCtx, objRef, newTableDef, lastNodeId, checkInsertPkDup, nil, isInsertWithoutAutoPkCol)
 	if err != nil {
 		return nil, err
 	}
@@ -161,9 +162,10 @@ func checkFileExist(param *tree.ExternParam, ctx CompilerContext) (string, error
 	return fileList[0], nil
 }
 
-func getProjectNode(stmt *tree.Load, ctx CompilerContext, node *plan.Node, tableDef *TableDef) error {
+func getProjectNode(stmt *tree.Load, ctx CompilerContext, node *plan.Node, tableDef *TableDef) (bool, error) {
 	tblName := string(stmt.Table.ObjectName)
 	colToIndex := make(map[int32]string, 0)
+	isInsertWithoutAutoPkCol := false
 	if len(stmt.Param.Tail.ColumnList) == 0 {
 		for i := 0; i < len(tableDef.Cols); i++ {
 			colToIndex[int32(i)] = tableDef.Cols[i].Name
@@ -173,13 +175,13 @@ func getProjectNode(stmt *tree.Load, ctx CompilerContext, node *plan.Node, table
 			switch realCol := col.(type) {
 			case *tree.UnresolvedName:
 				if _, ok := tableDef.Name2ColIndex[realCol.Parts[0]]; !ok {
-					return moerr.NewInternalError(ctx.GetContext(), "column '%s' does not exist", realCol.Parts[0])
+					return isInsertWithoutAutoPkCol, moerr.NewInternalError(ctx.GetContext(), "column '%s' does not exist", realCol.Parts[0])
 				}
 				colToIndex[int32(i)] = realCol.Parts[0]
 			case *tree.VarExpr:
 				//NOTE:variable like '@abc' will be passed by.
 			default:
-				return moerr.NewInternalError(ctx.GetContext(), "unsupported column type %v", realCol)
+				return isInsertWithoutAutoPkCol, moerr.NewInternalError(ctx.GetContext(), "unsupported column type %v", realCol)
 			}
 		}
 	}
@@ -218,8 +220,12 @@ func getProjectNode(stmt *tree.Load, ctx CompilerContext, node *plan.Node, table
 			}
 		}
 		node.ProjectList[i] = tmp
+
+		if tableDef.Cols[i].Typ.AutoIncr && tableDef.Cols[i].Name == tableDef.Pkey.PkeyColName {
+			isInsertWithoutAutoPkCol = true
+		}
 	}
-	return nil
+	return isInsertWithoutAutoPkCol, nil
 }
 
 func InitNullMap(param *tree.ExternParam, ctx CompilerContext) error {

--- a/pkg/sql/plan/build_update.go
+++ b/pkg/sql/plan/build_update.go
@@ -42,11 +42,12 @@ func buildTableUpdate(stmt *tree.Update, ctx CompilerContext, isPrepareStmt bool
 	if err != nil {
 		return nil, err
 	}
-	// need change to get update values. not get values from where clause
-	// if !updatePlanCtxs[0].checkInsertPkDup {
-	// 	pkFilterExpr := getPkFilterExpr(builder, tblInfo.tableDefs[0])
-	// 	updatePlanCtxs[0].pkFilterExprs = []*Expr{pkFilterExpr}
+
+	// if len(updatePlanCtxs) == 1 && updatePlanCtxs[0].updatePkCol {
+	// 	pkFilterExpr := getPkFilterExpr(builder, lastNodeId, updatePlanCtxs[0], tblInfo.tableDefs[0])
+	// 	updatePlanCtxs[0].pkFilterExprs = pkFilterExpr
 	// }
+
 	builder.qry.Steps = append(builder.qry.Steps[:sourceStep], builder.qry.Steps[sourceStep+1:]...)
 
 	// append sink node
@@ -147,24 +148,6 @@ func selectUpdateTables(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.
 	}
 
 	updatePlanCtxs := make([]*dmlPlanCtx, len(aliasList))
-	checkInsertPkDup := true
-	if len(aliasList) == 1 && stmt.Where != nil {
-		tableDef := tableInfo.tableDefs[0]
-		if comp, ok := stmt.Where.Expr.(*tree.ComparisonExpr); ok {
-			if comp.Op == tree.EQUAL {
-				if name, ok := comp.Left.(*tree.UnresolvedName); ok {
-					if name.NumParts == 1 && name.Parts[0] == tableDef.Pkey.PkeyColName {
-						checkInsertPkDup = false
-					}
-				} else if name, ok := comp.Right.(*tree.UnresolvedName); ok {
-					if name.NumParts == 1 && name.Parts[0] == tableDef.Pkey.PkeyColName {
-						checkInsertPkDup = false
-					}
-				}
-			}
-		}
-	}
-
 	for i, alias := range aliasList {
 		tableDef := tableInfo.tableDefs[i]
 		updateKeys := tableInfo.updateKeys[i]
@@ -185,25 +168,27 @@ func selectUpdateTables(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.
 		updateColPosMap := make(map[string]int)
 		offset := len(tableDef.Cols)
 		updatePkCol := false
+		updatePkColCount := 0
 		var pkNameMap = make(map[string]struct{})
 		if tableDef.Pkey != nil {
 			for _, pkName := range tableDef.Pkey.Names {
 				pkNameMap[pkName] = struct{}{}
 			}
-		} else {
-			// we don't known if update pk. just set true and let check pk dup work
-			updatePkCol = true
 		}
+
 		for colName, updateKey := range updateKeys {
 			selectList = append(selectList, tree.SelectExpr{
 				Expr: updateKey,
 			})
 			updateColPosMap[colName] = offset
 			if _, ok := pkNameMap[colName]; ok {
-				updatePkCol = true
+				updatePkColCount++
 			}
 			offset++
 		}
+
+		// we don't known if update pk if tableDef.Pkey is nil. just set true and let check pk dup work
+		updatePkCol = tableDef.Pkey == nil || updatePkColCount == len(pkNameMap)
 
 		// append  table.* to project list
 		upPlanCtx := getDmlPlanCtx()
@@ -215,7 +200,7 @@ func selectUpdateTables(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.
 		upPlanCtx.rowIdPos = rowIdPos
 		upPlanCtx.updateColPosMap = updateColPosMap
 		upPlanCtx.allDelTableIDs = map[uint64]struct{}{}
-		upPlanCtx.checkInsertPkDup = checkInsertPkDup
+		upPlanCtx.checkInsertPkDup = true
 		upPlanCtx.updatePkCol = updatePkCol
 
 		for idx, col := range tableDef.Cols {
@@ -256,30 +241,45 @@ func selectUpdateTables(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.
 	return lastNodeId, updatePlanCtxs, nil
 }
 
-// func getPkFilterExpr(builder *QueryBuilder, tableDef *TableDef) *Expr {
+// todo:  seems this filter do not make any sense for check pk dup in update statement
+//        need more research
+// func getPkFilterExpr(builder *QueryBuilder, lastNodeId int32, upCtx *dmlPlanCtx, tableDef *TableDef) []*Expr {
+// 	node := builder.qry.Nodes[lastNodeId]
+// 	var pkNameMap = make(map[string]int)
+// 	for idx, pkName := range tableDef.Pkey.Names {
+// 		pkNameMap[pkName] = idx
+// 	}
 
-// 	for _, node := range builder.qry.Nodes {
-// 		if node.NodeType != plan.Node_FILTER || len(node.Children) != 1 {
-// 			continue
-// 		}
-
-// 		preNode := builder.qry.Nodes[node.Children[0]]
-// 		if preNode.NodeType != plan.Node_TABLE_SCAN || preNode.TableDef.TblId != tableDef.TblId {
-// 			continue
-// 		}
-
-// 		basePkName := tableDef.Pkey.PkeyColName
-// 		tblAndPkName := fmt.Sprintf("%s.%s", tableDef.Name, tableDef.Pkey.PkeyColName)
-// 		if e, ok := node.FilterList[0].Expr.(*plan.Expr_F); ok && e.F.Func.ObjName == "=" {
-// 			if pkExpr, ok := e.F.Args[0].Expr.(*plan.Expr_Col); ok && (pkExpr.Col.Name == tblAndPkName || pkExpr.Col.Name == basePkName) {
-// 				return DeepCopyExpr(e.F.Args[1])
+// 	filterExpr := make([]*Expr, len(tableDef.Pkey.Names))
+// 	for colName, colIdx := range upCtx.updateColPosMap {
+// 		if pkIdx, ok := pkNameMap[colName]; ok {
+// 			switch e := node.ProjectList[colIdx].Expr.(type) {
+// 			case *plan.Expr_C:
+// 			case *plan.Expr_F:
+// 				if e.F.Func.ObjName != "cast" {
+// 					return nil
+// 				}
+// 				if _, isConst := e.F.Args[0].Expr.(*plan.Expr_C); !isConst {
+// 					return nil
+// 				}
+// 			default:
+// 				return nil
 // 			}
 
-// 			if pkExpr, ok := e.F.Args[1].Expr.(*plan.Expr_Col); ok && (pkExpr.Col.Name == tblAndPkName || pkExpr.Col.Name == basePkName) {
-// 				return DeepCopyExpr(e.F.Args[0])
+// 			expr, err := bindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{{
+// 				Typ: node.ProjectList[colIdx].Typ,
+// 				Expr: &plan.Expr_Col{
+// 					Col: &ColRef{
+// 						ColPos: int32(pkIdx),
+// 						Name:   tableDef.Pkey.PkeyColName,
+// 					},
+// 				},
+// 			}, node.ProjectList[colIdx]})
+// 			if err != nil {
+// 				return nil
 // 			}
-
+// 			filterExpr[pkIdx] = expr
 // 		}
 // 	}
-// 	return nil
+// 	return filterExpr
 // }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10655 

## What this PR does / why we need it:
1、have t1 (a int auto_increment primary key, b int, c int);
 insert  into t1(b, c) values (1,1),(2,2)  will not check PK dup now.

2、have t1 (a uuid primary key, b int, c int);
 insert  into t1(b, c) values ("2675a10c-31d1-11ee-be6c-f93a3353072c",1)
 use PK_col = xx to improve performance in checking PK dup, not join entire table any more.

3、when insert table which have no primary key.  we do not lock the rows now.