### PR TITLE
use cannot retry error instead of w-w conflict

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -200,6 +200,7 @@ const (
 	ErrDuplicateKey              uint16 = 20627
 	ErrTxnNeedRetry              uint16 = 20628
 	ErrTAENeedRetry              uint16 = 20629
+	ErrTxnCannotRetry            uint16 = 20630
 
 	// Group 7: lock service
 	// ErrDeadLockDetected lockservice has detected a deadlock and should abort the transaction if it receives this error
@@ -388,6 +389,7 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	ErrDuplicateKey:              {ER_DUP_KEYNAME, []string{MySQLDefaultSqlState}, "duplicate key name '%s'"},
 	ErrTxnNeedRetry:              {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "txn need retry in rc mode"},
 	ErrTAENeedRetry:              {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "tae need retry"},
+	ErrTxnCannotRetry:            {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "txn s3 writes can not retry in rc mode"},
 
 	// Group 7: lock service
 	ErrDeadLockDetected:     {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "deadlock detected"},
@@ -1018,6 +1020,10 @@ func NewAppendableBlockNotFound(ctx context.Context) *Error {
 
 func NewTxnNeedRetry(ctx context.Context) *Error {
 	return newError(ctx, ErrTxnNeedRetry)
+}
+
+func NewTxnCannotRetry(ctx context.Context) *Error {
+	return newError(ctx, ErrTxnCannotRetry)
 }
 
 func NewDeadLockDetected(ctx context.Context) *Error {

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -307,3 +307,7 @@ func NewProcedureAlreadyExistsNoCtx(f string) *Error {
 func NewTxnNeedRetryNoCtx() *Error {
 	return newError(Context(), ErrTxnNeedRetry)
 }
+
+func NewTxnCannotRetryNoCtx() *Error {
+	return newError(Context(), ErrTxnCannotRetry)
+}

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -327,7 +327,7 @@ func (txn *Transaction) adjustUpdateOrderLocked() error {
 func (txn *Transaction) RollbackLastStatement(ctx context.Context) error {
 	// If has s3 operation, can not rollback.
 	if txn.hasS3Op.Load() {
-		return moerr.NewTxnWWConflict(ctx)
+		return moerr.NewTxnCannotRetry(ctx)
 	}
 
 	txn.Lock()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11024

## What this PR does / why we need it:
use cannot retry error instead of w-w conflict error,  if txn statement need retry s3 writes