### PR TITLE
adjust the position of `cluster by` option in the output of `show create table`

### DIFF
--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -255,6 +255,32 @@ func buildShowCreateTable(stmt *tree.ShowCreateTable, ctx CompilerContext) (*Pla
 	}
 	createStr += ")"
 
+	var comment string
+	var partition string
+	for _, def := range tableDef.Defs {
+		if proDef, ok := def.Def.(*plan.TableDef_DefType_Properties); ok {
+			for _, kv := range proDef.Properties.Properties {
+				if kv.Key == catalog.SystemRelAttr_Comment {
+					comment = " COMMENT='" + kv.Value + "'"
+				}
+			}
+		}
+	}
+
+	if tableDef.Partition != nil {
+		partition = ` ` + tableDef.Partition.PartitionMsg
+	}
+
+	createStr += comment
+	createStr += partition
+
+	/**
+	Fix issue: https://github.com/matrixorigin/MO-Cloud/issues/1028#issuecomment-1667642384
+	Based on the grammar of the 'create table' in the file pkg/sql/parsers/dialect/mysql/mysql_sql.y
+		https://github.com/matrixorigin/matrixone/blob/68db7260e411e5a4541eaccf78ca9bb57e810f24/pkg/sql/parsers/dialect/mysql/mysql_sql.y#L6076C7-L6076C7
+		https://github.com/matrixorigin/matrixone/blob/68db7260e411e5a4541eaccf78ca9bb57e810f24/pkg/sql/parsers/dialect/mysql/mysql_sql.y#L6097
+	The 'cluster by' is after the 'partition by' and the 'table options', so we need to add the 'cluster by' string after the 'partition by' and the 'table options'.
+	*/
 	if tableDef.ClusterBy != nil {
 		clusterby := " CLUSTER BY ("
 		if util.JudgeIsCompositeClusterByColumn(tableDef.ClusterBy.Name) {
@@ -274,25 +300,6 @@ func buildShowCreateTable(stmt *tree.ShowCreateTable, ctx CompilerContext) (*Pla
 		clusterby += ")"
 		createStr += clusterby
 	}
-
-	var comment string
-	var partition string
-	for _, def := range tableDef.Defs {
-		if proDef, ok := def.Def.(*plan.TableDef_DefType_Properties); ok {
-			for _, kv := range proDef.Properties.Properties {
-				if kv.Key == catalog.SystemRelAttr_Comment {
-					comment = " COMMENT='" + kv.Value + "'"
-				}
-			}
-		}
-	}
-
-	if tableDef.Partition != nil {
-		partition = ` ` + tableDef.Partition.PartitionMsg
-	}
-
-	createStr += comment
-	createStr += partition
 
 	if tableDef.TableType == catalog.SystemExternalRel {
 		param := tree.ExternParam{}

--- a/test/distributed/cases/dml/show/show3.result
+++ b/test/distributed/cases/dml/show/show3.result
@@ -1,0 +1,7 @@
+set global enable_privilege_cache = off;
+create table t1 (a int, b int, c int) COMMENT='before cluster by' PARTITION BY hash(a+b) PARTITIONS 2  CLUSTER BY (a,b);
+create table t2 (a int, b int, c int) CLUSTER BY (a,b) PARTITION BY hash(a+b) PARTITIONS 2   COMMENT='after cluster by';
+SQL parser error: You have an error in your SQL syntax; check the manual that corresponds to your MatrixOne server version for the right syntax to use. syntax error at line 1 column 64 near " PARTITION BY hash(a+b) PARTITIONS 2   COMMENT='after cluster by';";
+create table t3 (a int, b int, c int) PARTITION BY hash(a+b) PARTITIONS 2  COMMENT='before cluster by' CLUSTER BY (a,b);
+SQL parser error: You have an error in your SQL syntax; check the manual that corresponds to your MatrixOne server version for the right syntax to use. syntax error at line 1 column 82 near "  COMMENT='before cluster by' CLUSTER BY (a,b);";
+set global enable_privilege_cache = on;

--- a/test/distributed/cases/dml/show/show3.sql
+++ b/test/distributed/cases/dml/show/show3.sql
@@ -1,0 +1,8 @@
+set global enable_privilege_cache = off;
+--success
+create table t1 (a int, b int, c int) COMMENT='before cluster by' PARTITION BY hash(a+b) PARTITIONS 2  CLUSTER BY (a,b);
+--error
+create table t2 (a int, b int, c int) CLUSTER BY (a,b) PARTITION BY hash(a+b) PARTITIONS 2   COMMENT='after cluster by';
+--error
+create table t3 (a int, b int, c int) PARTITION BY hash(a+b) PARTITIONS 2  COMMENT='before cluster by' CLUSTER BY (a,b);
+set global enable_privilege_cache = on;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/1028#issuecomment-1667642384

## What this PR does / why we need it:

1. 调整 `show create table` 输出字符串中`cluster by`字符串的位置。
根据`create table`的语法，`cluster by` 选项是放在最后的位置。
在`show create table`也要放到最后。mo-dump会用`show create table`的结果来构造`create table` 语法。

![image](https://github.com/matrixorigin/matrixone/assets/60595215/b65181f6-36c7-4996-aae8-60d8dae43e3e)


