### PR TITLE
Modify the default rpc buffer size for mysql protocol server

### DIFF
--- a/pkg/frontend/server.go
+++ b/pkg/frontend/server.go
@@ -98,7 +98,7 @@ func NewMOServer(
 			goetty.WithSessionCodec(codec),
 			goetty.WithSessionLogger(logutil.GetGlobalLogger()),
 			goetty.WithSessionDisableCompactAfterGrow(),
-			goetty.WithSessionRWBUfferSize(1024*1024, 1024*1024)),
+			goetty.WithSessionRWBUfferSize(DefaultRpcBufferSize, DefaultRpcBufferSize)),
 		goetty.WithAppSessionAware(rm))
 	if err != nil {
 		logutil.Panicf("start server failed with %+v", err)

--- a/pkg/frontend/types.go
+++ b/pkg/frontend/types.go
@@ -28,6 +28,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 )
 
+const (
+	DefaultRpcBufferSize = 1 << 10
+)
+
 type (
 	TxnOperator = client.TxnOperator
 	TxnClient   = client.TxnClient


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10945

## What this PR does / why we need it:
* The default 1MB rpc buffer is too large, and in tp scenarios, a high concurrency can easily lead to oom.