### PR TITLE
[bug] logservice: cannot set correct CN work state.

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -1452,7 +1452,7 @@ func doShowBackendServers(ses *Session) error {
 		// For super use dump and root, we should list all servers.
 		if isSuperUser(u) {
 			clusterservice.GetMOCluster().GetCNService(
-				clusterservice.NewSelector(), func(s metadata.CNService) bool {
+				clusterservice.NewSelectAll(), func(s metadata.CNService) bool {
 					appendFn(&s)
 					return true
 				})

--- a/pkg/pb/logservice/logservice.go
+++ b/pkg/pb/logservice/logservice.go
@@ -75,11 +75,13 @@ func (s *CNState) Update(hb CNStoreHeartbeat, tick uint64) {
 		storeInfo = CNStoreInfo{}
 		storeInfo.Labels = make(map[string]metadata.LabelList)
 	}
-	v, ok := metadata.WorkState_value[metadata.ToTitle(hb.InitWorkState)]
-	if !ok {
-		storeInfo.WorkState = metadata.WorkState_Working
-	} else {
-		storeInfo.WorkState = metadata.WorkState(v)
+	if storeInfo.WorkState == metadata.WorkState_Unknown { // set init value
+		v, ok := metadata.WorkState_value[metadata.ToTitle(hb.InitWorkState)]
+		if !ok || v == int32(metadata.WorkState_Unknown) {
+			storeInfo.WorkState = metadata.WorkState_Working
+		} else {
+			storeInfo.WorkState = metadata.WorkState(v)
+		}
 	}
 	storeInfo.Tick = tick
 	storeInfo.ServiceAddress = hb.ServiceAddress


### PR DESCRIPTION
CN work state can be updated by CN heartbeat, we need to handle it correctly.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11143

## What this PR does / why we need it: