### PR TITLE
improve implementation of dn deletes 

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -175,6 +175,7 @@ const (
 	BlockMeta_DeltaLoc        = "delta_loc"
 	BlockMeta_CommitTs        = "committs"
 	BlockMeta_SegmentID       = "segment_id"
+	BlockMeta_MemTruncPoint   = "trunc_pointt"
 	BlockMeta_TableIdx_Insert = "%!%mo__meta_tbl_index" // mark which table this metaLoc belongs to
 	BlockMeta_Type            = "%!%mo__meta_type"
 	BlockMeta_Deletes_Length  = "%!%mo__meta_deletes_length"
@@ -277,13 +278,14 @@ const (
 	MO_COLUMNS_ATT_SEQNUM_IDX            = 22
 	MO_COLUMNS_ATT_ENUM_IDX              = 23
 
-	BLOCKMETA_ID_IDX         = 0
-	BLOCKMETA_ENTRYSTATE_IDX = 1
-	BLOCKMETA_SORTED_IDX     = 2
-	BLOCKMETA_METALOC_IDX    = 3
-	BLOCKMETA_DELTALOC_IDX   = 4
-	BLOCKMETA_COMMITTS_IDX   = 5
-	BLOCKMETA_SEGID_IDX      = 6
+	BLOCKMETA_ID_IDX            = 0
+	BLOCKMETA_ENTRYSTATE_IDX    = 1
+	BLOCKMETA_SORTED_IDX        = 2
+	BLOCKMETA_METALOC_IDX       = 3
+	BLOCKMETA_DELTALOC_IDX      = 4
+	BLOCKMETA_COMMITTS_IDX      = 5
+	BLOCKMETA_SEGID_IDX         = 6
+	BLOCKMETA_MemTruncPoint_IDX = 7
 
 	SKIP_ROWID_OFFSET = 1 //rowid is the 0th vector in the batch
 )
@@ -541,6 +543,16 @@ var (
 		BlockMeta_DeltaLoc,
 		BlockMeta_CommitTs,
 		BlockMeta_SegmentID,
+		BlockMeta_MemTruncPoint,
+	}
+	MoTableMetaSchemaV1 = []string{
+		BlockMeta_ID,
+		BlockMeta_EntryState,
+		BlockMeta_Sorted,
+		BlockMeta_MetaLoc,
+		BlockMeta_DeltaLoc,
+		BlockMeta_CommitTs,
+		BlockMeta_SegmentID,
 	}
 	MoDatabaseTypes = []types.Type{
 		types.New(types.T_uint64, 0, 0),     // dat_id
@@ -644,6 +656,16 @@ var (
 		types.New(types.T_uint16, 0, 0),     // att_seqnum
 	}
 	MoTableMetaTypes = []types.Type{
+		types.New(types.T_Blockid, 0, 0),                   // block_id
+		types.New(types.T_bool, 0, 0),                      // entry_state, true for appendable
+		types.New(types.T_bool, 0, 0),                      // sorted, true for sorted by primary key
+		types.New(types.T_varchar, types.MaxVarcharLen, 0), // meta_loc
+		types.New(types.T_varchar, types.MaxVarcharLen, 0), // delta_loc
+		types.New(types.T_TS, 0, 0),                        // committs
+		types.New(types.T_uuid, 0, 0),                      // segment_id
+		types.New(types.T_TS, 0, 0),                        // flush_point
+	}
+	MoTableMetaTypesV1 = []types.Type{
 		types.New(types.T_Blockid, 0, 0),                   // block_id
 		types.New(types.T_bool, 0, 0),                      // entry_state, true for appendable
 		types.New(types.T_bool, 0, 0),                      // sorted, true for sorted by primary key

--- a/pkg/container/types/rowid.go
+++ b/pkg/container/types/rowid.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"unsafe"
 
@@ -165,6 +166,13 @@ func (b *Blockid) String() string {
 func (b *Blockid) ShortString() string {
 	filen, blkn := b.Offsets()
 	return fmt.Sprintf("%d-%d", filen, blkn)
+}
+
+func (b *Blockid) ShortStringEx() string {
+	var shortuuid [8]byte
+	hex.Encode(shortuuid[:], b[:4])
+	filen, blkn := b.Offsets()
+	return fmt.Sprintf("%s-%d-%d", string(shortuuid[:]), filen, blkn)
 }
 
 func (b *Blockid) Offsets() (uint16, uint16) {

--- a/pkg/perfcounter/counter_set.go
+++ b/pkg/perfcounter/counter_set.go
@@ -84,6 +84,7 @@ type DistTAECounterSet struct {
 		MetadataDeleteEntries stats.Counter
 
 		InsertRows   stats.Counter
+		DeleteRows   stats.Counter
 		ActiveRows   stats.Counter
 		InsertBlocks stats.Counter
 	}

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -381,6 +381,7 @@ func (p *PartitionState) HandleRowsDelete(
 		)
 	}
 
+	numDeletes := int64(0)
 	for i, rowID := range rowIDVector {
 		moprobe.WithRegion(ctx, moprobe.PartitionStateHandleDel, func() {
 
@@ -394,6 +395,7 @@ func (p *PartitionState) HandleRowsDelete(
 			if !ok {
 				entry = pivot
 				entry.ID = atomic.AddInt64(&nextRowEntryID, 1)
+				numDeletes++
 			}
 
 			entry.Deleted = true
@@ -432,6 +434,7 @@ func (p *PartitionState) HandleRowsDelete(
 	perfcounter.Update(ctx, func(c *perfcounter.CounterSet) {
 		c.DistTAE.Logtail.Entries.Add(1)
 		c.DistTAE.Logtail.DeleteEntries.Add(1)
+		c.DistTAE.Logtail.DeleteRows.Add(numDeletes)
 	})
 }
 

--- a/pkg/vm/engine/tae/catalog/catalog.go
+++ b/pkg/vm/engine/tae/catalog/catalog.go
@@ -837,13 +837,7 @@ func (catalog *Catalog) onReplayDeleteBlock(
 		logutil.Info(catalog.SimplePPString(common.PPL3))
 		panic(err)
 	}
-	blkDeleteAt := blk.GetDeleteAt()
-	if !blkDeleteAt.IsEmpty() {
-		if !blkDeleteAt.Equal(txnNode.End) {
-			panic(moerr.NewInternalErrorNoCtx("logic err expect %s, get %s", txnNode.End.ToString(), blkDeleteAt.ToString()))
-		}
-		return
-	}
+
 	prevUn := blk.MVCCChain.GetLatestNodeLocked()
 	un := &MVCCNode[*MetadataMVCCNode]{
 		EntryMVCCNode: &EntryMVCCNode{
@@ -1142,6 +1136,9 @@ func (catalog *Catalog) RecurLoop(processor Processor) (err error) {
 		}
 		if err = dbEntry.RecurLoop(processor); err != nil {
 			return
+		}
+		if err = processor.OnPostDatabase(dbEntry); err != nil {
+			break
 		}
 		dbIt.Next()
 	}

--- a/pkg/vm/engine/tae/catalog/database.go
+++ b/pkg/vm/engine/tae/catalog/database.go
@@ -616,6 +616,9 @@ func (e *DBEntry) RecurLoop(processor Processor) (err error) {
 		if err = table.RecurLoop(processor); err != nil {
 			return
 		}
+		if err = processor.OnPostTable(table); err != nil {
+			break
+		}
 		tableIt.Next()
 	}
 	if moerr.IsMoErrCode(err, moerr.OkStopCurrRecur) {

--- a/pkg/vm/engine/tae/catalog/processor.go
+++ b/pkg/vm/engine/tae/catalog/processor.go
@@ -20,18 +20,22 @@ package catalog
 // Return a int code.
 type Processor interface {
 	OnDatabase(database *DBEntry) error
+	OnPostDatabase(database *DBEntry) error
 	OnTable(table *TableEntry) error
+	OnPostTable(table *TableEntry) error
 	OnPostSegment(segment *SegmentEntry) error
 	OnSegment(segment *SegmentEntry) error
 	OnBlock(block *BlockEntry) error
 }
 
 type LoopProcessor struct {
-	DatabaseFn    func(*DBEntry) error
-	TableFn       func(*TableEntry) error
-	SegmentFn     func(*SegmentEntry) error
-	BlockFn       func(*BlockEntry) error
-	PostSegmentFn func(*SegmentEntry) error
+	DatabaseFn     func(*DBEntry) error
+	TableFn        func(*TableEntry) error
+	SegmentFn      func(*SegmentEntry) error
+	BlockFn        func(*BlockEntry) error
+	PostDatabaseFn func(*DBEntry) error
+	PostTableFn    func(*TableEntry) error
+	PostSegmentFn  func(*SegmentEntry) error
 }
 
 func (p *LoopProcessor) OnDatabase(database *DBEntry) error {
@@ -41,9 +45,23 @@ func (p *LoopProcessor) OnDatabase(database *DBEntry) error {
 	return nil
 }
 
+func (p *LoopProcessor) OnPostDatabase(database *DBEntry) error {
+	if p.PostDatabaseFn != nil {
+		return p.PostDatabaseFn(database)
+	}
+	return nil
+}
+
 func (p *LoopProcessor) OnTable(table *TableEntry) error {
 	if p.TableFn != nil {
 		return p.TableFn(table)
+	}
+	return nil
+}
+
+func (p *LoopProcessor) OnPostTable(table *TableEntry) error {
+	if p.PostTableFn != nil {
+		return p.PostTableFn(table)
 	}
 	return nil
 }

--- a/pkg/vm/engine/tae/catalog/segment.go
+++ b/pkg/vm/engine/tae/catalog/segment.go
@@ -32,7 +32,8 @@ import (
 type SegmentDataFactory = func(meta *SegmentEntry) data.Segment
 
 type SegmentEntry struct {
-	ID objectio.Segmentid
+	ID   objectio.Segmentid
+	Stat SegStat
 	*BaseEntryImpl[*MetadataMVCCNode]
 	table   *TableEntry
 	entries map[types.Blockid]*common.GenericDLNode[*BlockEntry]
@@ -40,6 +41,14 @@ type SegmentEntry struct {
 	link *common.GenericSortedDList[*BlockEntry]
 	*SegmentNode
 	segData data.Segment
+}
+
+type SegStat struct {
+	// min max etc. later
+	Rows           int
+	Dels           int
+	SameDelsStreak int
+	MergeIntent    int
 }
 
 func NewSegmentEntry(table *TableEntry, id *objectio.Segmentid, txn txnif.AsyncTxn, state EntryState, dataFactory SegmentDataFactory) *SegmentEntry {
@@ -398,7 +407,7 @@ func (entry *SegmentEntry) deleteEntryLocked(block *BlockEntry) error {
 }
 
 func (entry *SegmentEntry) RemoveEntry(block *BlockEntry) (err error) {
-	logutil.Debug("[Catalog]", common.OperationField("remove"),
+	logutil.Info("[Catalog]", common.OperationField("remove"),
 		common.OperandField(block.String()))
 	entry.Lock()
 	defer entry.Unlock()

--- a/pkg/vm/engine/tae/catalog/segment.go
+++ b/pkg/vm/engine/tae/catalog/segment.go
@@ -235,6 +235,10 @@ func (entry *SegmentEntry) IsSorted() bool {
 	return entry.sorted
 }
 
+func (entry *SegmentEntry) IsSortedLocked() bool {
+	return entry.sorted
+}
+
 func (entry *SegmentEntry) GetTable() *TableEntry {
 	return entry.table
 }

--- a/pkg/vm/engine/tae/catalog/table.go
+++ b/pkg/vm/engine/tae/catalog/table.go
@@ -57,26 +57,6 @@ type TableEntry struct {
 	fullName string
 }
 
-type DirtyDelsSrc struct {
-	ver      atomic.Int64
-	versions map[int64][]*BlockEntry
-}
-
-func (src *DirtyDelsSrc) GetDirtyDels() (ver int64, ret [][]*BlockEntry) {
-	ver = src.ver.Load()
-	for v, list := range src.versions {
-		if v <= ver {
-			ret = append(ret, list)
-		}
-	}
-	return
-}
-
-func (src *DirtyDelsSrc) AddDirtyDels(list []*BlockEntry) {
-	ver := src.ver.Add(1)
-	src.versions[ver] = list
-}
-
 func genTblFullName(tenantID uint32, name string) string {
 	if name == pkgcatalog.MO_DATABASE || name == pkgcatalog.MO_TABLES || name == pkgcatalog.MO_COLUMNS {
 		tenantID = 0
@@ -110,9 +90,6 @@ func NewTableEntryWithTableId(db *DBEntry, schema *Schema, txnCtx txnif.AsyncTxn
 		e.tableData = dataFactory(e)
 	}
 	e.CreateWithTxnAndSchema(txnCtx, schema)
-	// e.Stats.FlushGapDuration = 6 * time.Minute
-	// e.Stats.FlushMemCapacity = 20 * 1024 * 1024
-	// e.Stats.FlushTableTailEnabled = true
 	return e
 }
 

--- a/pkg/vm/engine/tae/common/stats.go
+++ b/pkg/vm/engine/tae/common/stats.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+)
+
+type TableCompactStat struct {
+	sync.RWMutex
+
+	Inited bool
+
+	// Configs
+
+	// make this table apply flush table tail policy
+	FlushTableTailEnabled bool
+	// how often to flush table tail
+	// this duration will be add some random value to avoid flush many tables at the same time
+	FlushGapDuration time.Duration
+	// if the size of table tail, in bytes, exceeds FlushMemCapacity, flush it immediately
+	FlushMemCapacity int
+
+	// Status
+
+	// dirty end range flushed by last flush txn. If we are waiting for a ckp [a, b], if all dirty tables' LastFlush are greater than b,
+	// the checkpoint is ready to collect data and write all down.
+	LastFlush types.TS
+	// FlushDeadline is the deadline to flush table tail
+	FlushDeadline time.Time
+}
+
+func (s *TableCompactStat) ResetDeadline() {
+	// add random +/- 10%
+	factor := 1.0 + float64(rand.Intn(21)-10)/100.0
+	s.FlushDeadline = time.Now().Add(time.Duration(factor * float64(s.FlushGapDuration)))
+}

--- a/pkg/vm/engine/tae/common/stats.go
+++ b/pkg/vm/engine/tae/common/stats.go
@@ -46,8 +46,15 @@ type TableCompactStat struct {
 	FlushDeadline time.Time
 }
 
-func (s *TableCompactStat) ResetDeadline() {
+func (s *TableCompactStat) ResetDeadlineWithLock() {
 	// add random +/- 10%
 	factor := 1.0 + float64(rand.Intn(21)-10)/100.0
 	s.FlushDeadline = time.Now().Add(time.Duration(factor * float64(s.FlushGapDuration)))
+}
+
+func (s *TableCompactStat) InitWithLock(durationHint time.Duration) {
+	s.FlushGapDuration = durationHint * 5
+	s.FlushMemCapacity = 20 * 1024 * 1024
+	s.FlushTableTailEnabled = true
+	s.Inited = true
 }

--- a/pkg/vm/engine/tae/containers/batch.go
+++ b/pkg/vm/engine/tae/containers/batch.go
@@ -145,6 +145,14 @@ func (bat *Batch) Length() int {
 	return bat.Vecs[0].Length()
 }
 
+func (bat *Batch) ApproxSize() int {
+	size := 0
+	for _, vec := range bat.Vecs {
+		size += vec.ApproxSize()
+	}
+	return size
+}
+
 func (bat *Batch) Allocated() int {
 	allocated := 0
 	for _, vec := range bat.Vecs {

--- a/pkg/vm/engine/tae/containers/batch_test.go
+++ b/pkg/vm/engine/tae/containers/batch_test.go
@@ -16,6 +16,8 @@ package containers
 
 import (
 	"bytes"
+	"math/rand"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -191,4 +193,21 @@ func TestBatchSpliter(t *testing.T) {
 		actuals_2 = append(actuals_2, bat.Length())
 	}
 	assert.Equal(t, expects_2, actuals_2)
+}
+
+func TestApproxSize(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	vec := MockVector(types.T_uint8.ToType(), 1024, false, nil)
+	t.Log(vec.ApproxSize())
+	defer vec.Close()
+
+	svec := MakeVector(types.T_varchar.ToType())
+	defer svec.Close()
+	sizeCnt := 0
+	for i := 0; i < 1024; i++ {
+		l := rand.Intn(100)
+		sizeCnt += l
+		svec.Append([]byte(strings.Repeat("x", l)), false)
+	}
+	t.Log(svec.ApproxSize(), sizeCnt)
 }

--- a/pkg/vm/engine/tae/containers/types.go
+++ b/pkg/vm/engine/tae/containers/types.go
@@ -72,6 +72,7 @@ type Vector interface {
 	ForeachWindow(offset, length int, op ItOp, sels *nulls.Bitmap) error
 
 	Length() int
+	ApproxSize() int
 	Allocated() int
 	GetAllocator() *mpool.MPool
 

--- a/pkg/vm/engine/tae/containers/vector.go
+++ b/pkg/vm/engine/tae/containers/vector.go
@@ -123,6 +123,14 @@ func NewVector(typ types.Type, opts ...Options) *vectorWrapper {
 	return vec
 }
 
+func (vec *vectorWrapper) ApproxSize() int {
+	if vec.wrapped.NeedDup() {
+		return 0
+	} else {
+		return vec.wrapped.Size()
+	}
+}
+
 func (vec *vectorWrapper) PreExtend(length int) (err error) {
 	vec.tryCOW()
 	return vec.wrapped.PreExtend(length, vec.mpool)
@@ -497,33 +505,15 @@ func (vec *vectorWrapper) String() string {
 // Deprecated: Only use for test functions
 func (vec *vectorWrapper) PPString(num int) string {
 	var w bytes.Buffer
-	_, _ = w.WriteString(fmt.Sprintf("[T=%s][Len=%d][Data=(", vec.GetType().String(), vec.Length()))
 	limit := vec.Length()
 	if num > 0 && num < limit {
 		limit = num
 	}
-	size := vec.Length()
-	long := false
-	if size > limit {
-		long = true
-		size = limit
-	}
-	for i := 0; i < size; i++ {
-		if vec.IsNull(i) {
-			_, _ = w.WriteString("null")
-			continue
-		}
-		if vec.GetType().IsVarlen() {
-			_, _ = w.WriteString(fmt.Sprintf("%s, ", vec.Get(i).([]byte)))
-		} else {
-			_, _ = w.WriteString(fmt.Sprintf("%v, ", vec.Get(i)))
-		}
-	}
-	if long {
+	_, _ = w.WriteString(fmt.Sprintf("[T=%s]%s", vec.GetType().String(), common.MoVectorToString(vec.GetDownstreamVector(), limit)))
+	if vec.Length() > num {
 		_, _ = w.WriteString("...")
 	}
-	_, _ = w.WriteString(")]")
-	_, _ = w.WriteString(fmt.Sprintf(")][%v]", vec.element != nil))
+	_, _ = w.WriteString(fmt.Sprintf("[%v]", vec.element != nil))
 	return w.String()
 }
 

--- a/pkg/vm/engine/tae/db/dbutils/runtime.go
+++ b/pkg/vm/engine/tae/db/dbutils/runtime.go
@@ -91,8 +91,9 @@ type Runtime struct {
 
 	Fs *objectio.ObjectFS
 
-	TransferTable *model.HashPageTable
-	Scheduler     tasks.TaskScheduler
+	TransferTable   *model.HashPageTable
+	TransferDelsMap *model.TransDelsForBlks
+	Scheduler       tasks.TaskScheduler
 
 	Options *options.Options
 
@@ -103,6 +104,7 @@ type Runtime struct {
 
 func NewRuntime(opts ...RuntimeOption) *Runtime {
 	r := new(Runtime)
+	r.TransferDelsMap = model.NewTransDelsForBlks()
 	for _, opt := range opts {
 		opt(r)
 	}

--- a/pkg/vm/engine/tae/db/open.go
+++ b/pkg/vm/engine/tae/db/open.go
@@ -186,6 +186,7 @@ func Open(ctx context.Context, dirname string, opts *options.Options) (db *DB, e
 			opts.CheckpointCfg.FlushInterval,
 			func(_ context.Context) (err error) {
 				db.Runtime.PrintVectorPoolUsage()
+				db.Runtime.TransferDelsMap.Prune(opts.TransferTableTTL)
 				transferTable.RunTTL(time.Now())
 				return
 			}),

--- a/pkg/vm/engine/tae/db/scanner.go
+++ b/pkg/vm/engine/tae/db/scanner.go
@@ -99,7 +99,9 @@ func NewDBScanner(db *DB, errHandler ErrHandler) *dbScanner {
 	scanner.SegmentFn = scanner.onSegment
 	scanner.PostSegmentFn = scanner.onPostSegment
 	scanner.TableFn = scanner.onTable
+	scanner.PostTableFn = scanner.onPostTable
 	scanner.DatabaseFn = scanner.onDatabase
+	scanner.PostDatabaseFn = scanner.onPostDatabase
 	return scanner
 }
 
@@ -121,6 +123,26 @@ func (scanner *dbScanner) onPostSegment(entry *catalog.SegmentEntry) (err error)
 	for _, op := range scanner.ops {
 		err = op.OnPostSegment(entry)
 		if err = scanner.errHandler.OnSegmentErr(entry, err); err != nil {
+			break
+		}
+	}
+	return
+}
+
+func (scanner *dbScanner) onPostTable(entry *catalog.TableEntry) (err error) {
+	for _, op := range scanner.ops {
+		err = op.OnPostTable(entry)
+		if err = scanner.errHandler.OnTableErr(entry, err); err != nil {
+			break
+		}
+	}
+	return
+}
+
+func (scanner *dbScanner) onPostDatabase(entry *catalog.DBEntry) (err error) {
+	for _, op := range scanner.ops {
+		err = op.OnPostDatabase(entry)
+		if err = scanner.errHandler.OnDatabaseErr(entry, err); err != nil {
 			break
 		}
 	}

--- a/pkg/vm/engine/tae/db/scannerop.go
+++ b/pkg/vm/engine/tae/db/scannerop.go
@@ -16,8 +16,10 @@ package db
 
 import (
 	"container/heap"
-	"fmt"
+	"math"
+	"os"
 	"sort"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -29,7 +31,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables/jobs"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tasks"
 )
@@ -41,38 +42,50 @@ type ScannerOp interface {
 }
 
 const (
-	constMergeRightNow     = int(options.DefaultBlockMaxRows) * int(options.DefaultBlocksPerSegment)
-	constMergeWaitDuration = 3 * time.Minute
-	constMergeMinBlks      = 3
-	constMergeMinRows      = 3000
-	constHeapCapacity      = 300
-	const4GBytes           = 4 * (1 << 30)
+	constMergeWaitDuration  = 1 * time.Minute
+	constMergeMinBlks       = 5
+	constHeapCapacity       = 300
+	const4GBytes            = 4 * (1 << 30)
+	constKeyMergeWaitFactor = "MO_MERGE_WAIT" // smaller value means shorter wait, cost much more io
 )
 
+func EnvOrDefaultFloat(key string, defaultValue float64) float64 {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return defaultValue
+	}
+	i, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return defaultValue
+	}
+	return i
+}
+
 // min heap item
-type mItem struct {
+type mItem[T any] struct {
 	row   int
-	entry *catalog.BlockEntry
+	entry T
 }
 
-type itemSet []*mItem
+type itemSet[T any] []*mItem[T]
 
-func (is itemSet) Len() int { return len(is) }
+func (is itemSet[T]) Len() int { return len(is) }
 
-func (is itemSet) Less(i, j int) bool {
-	return is[i].row < is[j].row
+func (is itemSet[T]) Less(i, j int) bool {
+	// max heap
+	return is[i].row > is[j].row
 }
 
-func (is itemSet) Swap(i, j int) {
+func (is itemSet[T]) Swap(i, j int) {
 	is[i], is[j] = is[j], is[i]
 }
 
-func (is *itemSet) Push(x any) {
-	item := x.(*mItem)
+func (is *itemSet[T]) Push(x any) {
+	item := x.(*mItem[T])
 	*is = append(*is, item)
 }
 
-func (is *itemSet) Pop() any {
+func (is *itemSet[T]) Pop() any {
 	old := *is
 	n := len(old)
 	item := old[n-1]
@@ -81,33 +94,33 @@ func (is *itemSet) Pop() any {
 	return item
 }
 
-func (is *itemSet) Clear() {
+func (is *itemSet[T]) Clear() {
 	old := *is
 	*is = old[:0]
 }
 
-// mergedBlkBuilder founds out blocks to be merged via maintaining a min heap holding
+// heapBuilder founds out blocks to be merged via maintaining a min heap holding
 // up to default 300 items.
-type mergedBlkBuilder struct {
-	blocks itemSet
-	cap    int
+type heapBuilder[T any] struct {
+	items itemSet[T]
+	cap   int
 }
 
-func (h *mergedBlkBuilder) reset() {
-	h.blocks.Clear()
+func (h *heapBuilder[T]) reset() {
+	h.items.Clear()
 }
 
-func (h *mergedBlkBuilder) push(item *mItem) {
-	heap.Push(&h.blocks, item)
-	if h.blocks.Len() > h.cap {
-		heap.Pop(&h.blocks)
+func (h *heapBuilder[T]) push(item *mItem[T]) {
+	heap.Push(&h.items, item)
+	if h.items.Len() > h.cap {
+		heap.Pop(&h.items)
 	}
 }
 
 // copy out the items in the heap
-func (h *mergedBlkBuilder) finish() []*catalog.BlockEntry {
-	ret := make([]*catalog.BlockEntry, h.blocks.Len())
-	for i, item := range h.blocks {
+func (h *heapBuilder[T]) finish() []T {
+	ret := make([]T, h.items.Len())
+	for i, item := range h.items {
 		ret[i] = item.entry
 	}
 	return ret
@@ -117,14 +130,17 @@ func (h *mergedBlkBuilder) finish() []*catalog.BlockEntry {
 // if a segment has no any non-dropped blocks, it can be deleted. except the
 // segment has the max segment id, appender may creates block in it.
 type deletableSegBuilder struct {
-	segHasNonDropBlk bool
-	maxSegId         uint64
-	segCandids       []*catalog.SegmentEntry // appendable
-	nsegCandids      []*catalog.SegmentEntry // non-appendable
+	segHasNonDropBlk     bool
+	segRowCnt, segRowDel int
+	segIsSorted          bool
+	isCreating           bool
+	maxSegId             uint64
+	segCandids           []*catalog.SegmentEntry // appendable
+	nsegCandids          []*catalog.SegmentEntry // non-appendable
 }
 
 func (d *deletableSegBuilder) reset() {
-	d.segHasNonDropBlk = false
+	d.resetForNewSeg()
 	d.maxSegId = 0
 	d.segCandids = d.segCandids[:0]
 	d.nsegCandids = d.nsegCandids[:0]
@@ -132,6 +148,10 @@ func (d *deletableSegBuilder) reset() {
 
 func (d *deletableSegBuilder) resetForNewSeg() {
 	d.segHasNonDropBlk = false
+	d.segIsSorted = false
+	d.isCreating = false
+	d.segRowCnt = 0
+	d.segRowDel = 0
 }
 
 // call this when a non dropped block was found when iterating blocks of a segment,
@@ -174,115 +194,66 @@ func (d *deletableSegBuilder) finish() []*catalog.SegmentEntry {
 	return ret
 }
 
-type stat struct {
-	ttl          time.Time
-	lastTotalRow int
-}
-
-func (st *stat) String() string {
-	return fmt.Sprintf("row%d[%s]", st.lastTotalRow, st.ttl)
-}
-
 // mergeLimiter consider update rate and time to decide to merge or not.
 type mergeLimiter struct {
-	stats                map[uint64]*stat
-	concurrentMergeLimit int32
-	activeMergeCount     int32
+	objectMinRows       int
+	maxRowsForBlk       int
+	tableName           string
+	memAvail            int
+	activeMergeBlkCount int32
+	mergeWaitFactor     float64
 }
 
-func (ml *mergeLimiter) IncActiveCount() {
-	atomic.AddInt32(&ml.activeMergeCount, 1)
+func (ml *mergeLimiter) IncActiveCount(n int) {
+	atomic.AddInt32(&ml.activeMergeBlkCount, int32(n))
 }
 
-func (ml *mergeLimiter) OnExecDone(_ any) {
-	atomic.AddInt32(&ml.activeMergeCount, -1)
+func (ml *mergeLimiter) OnExecDone(v any) {
+	task := v.(tasks.MScopedTask)
+	n := int32(len(task.Scopes()))
+	atomic.AddInt32(&ml.activeMergeBlkCount, -n)
 }
 
-// merge immediately if it has enough rows, skip if:
-// 1. has only a few rows or blocks
-// 2. is actively updating, which means total rows changes obviously compared with last time
-// in other cases, wait some time to merge
-func (ml *mergeLimiter) canMerge(tid uint64, totalRow int, blks int) bool {
-	if atomic.LoadInt32(&ml.activeMergeCount) >= ml.concurrentMergeLimit {
+func (ml *mergeLimiter) checkMemAvail(blks int) bool {
+	if ml.maxRowsForBlk == 0 {
 		return false
 	}
-	if totalRow > constMergeRightNow {
-		logutil.Infof("Mergeblocks %d merge right now: %d rows %d blks", tid, totalRow, blks)
-		delete(ml.stats, tid)
-		return true
-	}
-	if blks < constMergeMinBlks || totalRow < constMergeMinRows {
-		return false
-	}
-
-	if st, ok := ml.stats[tid]; !ok {
-		ml.stats[tid] = &stat{
-			ttl:          ml.ttl(totalRow),
-			lastTotalRow: totalRow,
-		}
-		return false
-	} else if d := totalRow - st.lastTotalRow; d > 5 || d < -5 {
-		// a lot of things happened in the past scan interval...
-		st.ttl = ml.ttl(totalRow)
-		st.lastTotalRow = totalRow
-		logutil.Infof("Mergeblocks delta %d on table %d, resched to %v", d, tid, st.ttl)
-		return false
-	} else {
-		// this table is quiet finally, check ttl
-		return st.ttl.Before(time.Now())
-	}
+	merging := atomic.LoadInt32(&ml.activeMergeBlkCount)
+	return ml.calcQuotaBlks()-int(merging) > blks
 }
 
-func (ml *mergeLimiter) ttl(totalRow int) time.Time {
-	return time.Now().Add(time.Duration(
-		(float32(constMergeWaitDuration) / float32(constMergeRightNow)) *
-			(float32(constMergeRightNow) - float32(totalRow))))
+func (ml *mergeLimiter) calcQuotaBlks() int {
+	// by experience, it is assumed the merging 256 * 8192 rows costs 4 GB
+	return ml.memAvail / const4GBytes * 256 * 8192 / ml.maxRowsForBlk
 }
 
-// prune old stat entry
-func (ml *mergeLimiter) pruneStale() {
-	staleIds := make([]uint64, 0)
-	t := time.Now().Add(-10 * time.Minute)
-	for id, st := range ml.stats {
-		if st.ttl.Before(t) {
-			staleIds = append(staleIds, id)
-		}
-	}
-	for _, id := range staleIds {
-		delete(ml.stats, id)
-	}
-}
-
-func (ml *mergeLimiter) String() string {
-	return fmt.Sprintf("%v", ml.stats)
+func (ml *mergeLimiter) determineGapIntentFactor(rowsGap float64) float64 {
+	return rowsGap / float64(ml.objectMinRows) * 5 * ml.mergeWaitFactor
 }
 
 type MergeTaskBuilder struct {
 	db *DB
 	*catalog.LoopProcessor
-	runCnt      int
-	tableRowCnt int
-	tid         uint64
-	limiter     *mergeLimiter
-	segBuilder  *deletableSegBuilder
-	blkBuilder  *mergedBlkBuilder
+	tableRowCnt      int
+	tableDelete      int
+	tid              uint64
+	limiter          *mergeLimiter
+	delSegBuilder    *deletableSegBuilder
+	sortedSegBuilder *heapBuilder[*catalog.SegmentEntry]
 }
 
 func newMergeTaskBuiler(db *DB) *MergeTaskBuilder {
 	op := &MergeTaskBuilder{
 		db:            db,
 		LoopProcessor: new(catalog.LoopProcessor),
-		limiter: &mergeLimiter{
-			stats:                make(map[uint64]*stat),
-			concurrentMergeLimit: 1,
-		},
-		segBuilder: &deletableSegBuilder{
+		limiter:       &mergeLimiter{},
+		delSegBuilder: &deletableSegBuilder{
 			segCandids:  make([]*catalog.SegmentEntry, 0),
 			nsegCandids: make([]*catalog.SegmentEntry, 0),
 		},
-		blkBuilder: &mergedBlkBuilder{
-			blocks: make(itemSet, 0, constHeapCapacity),
-			cap:    constHeapCapacity,
+		sortedSegBuilder: &heapBuilder[*catalog.SegmentEntry]{
+			items: make(itemSet[*catalog.SegmentEntry], 0, 2),
+			cap:   2,
 		},
 	}
 
@@ -290,49 +261,113 @@ func newMergeTaskBuiler(db *DB) *MergeTaskBuilder {
 	op.BlockFn = op.onBlock
 	op.SegmentFn = op.onSegment
 	op.PostSegmentFn = op.onPostSegment
+	op.PostTableFn = op.onPostTable
 	return op
+}
+
+func (s *MergeTaskBuilder) checkSortedSegs(segs []*catalog.SegmentEntry) (
+	mblks []*catalog.BlockEntry, msegs []*catalog.SegmentEntry,
+) {
+	if len(segs) < 2 {
+		return
+	}
+	s1, s2 := segs[0], segs[1]
+	r1 := s1.Stat.Rows - s1.Stat.Dels
+	r2 := s2.Stat.Rows - s2.Stat.Dels
+	logutil.Infof(
+		"mergeblocks ======== %v %v | %v %v | %v %v",
+		s1.SortHint, s2.SortHint, r1, r2, s1.Stat.MergeIntent, s2.Stat.MergeIntent,
+	)
+	// skip big segment which is over 200 blks
+	if r1 > s.limiter.objectMinRows*40 || r2 > s.limiter.objectMinRows*40 {
+		return
+	}
+
+	// push back schedule for big gap
+	if gap := math.Abs(float64(r1 - r2)); gap > float64(s.limiter.objectMinRows) {
+		// bump intention
+		s1.Stat.MergeIntent++
+		s2.Stat.MergeIntent++
+		waitIntent := s.limiter.determineGapIntentFactor(gap)
+		if float64(s1.Stat.MergeIntent) < waitIntent ||
+			float64(s2.Stat.MergeIntent) < waitIntent {
+			return
+		}
+	}
+
+	msegs = segs[:2]
+	mblks = make([]*catalog.BlockEntry, 0, len(msegs)*constMergeMinBlks)
+	for _, seg := range msegs {
+		blkit := seg.MakeBlockIt(true)
+		for ; blkit.Valid(); blkit.Next() {
+			entry := blkit.Get().GetPayload()
+			if !entry.IsActive() {
+				continue
+			}
+			entry.RLock()
+			if entry.IsCommitted() &&
+				catalog.ActiveWithNoTxnFilter(entry.BaseEntryImpl) {
+				mblks = append(mblks, entry)
+			}
+			entry.RUnlock()
+		}
+	}
+
+	logutil.Infof("mergeblocks merge %v-%v, sorted %d and %d rows",
+		s.tid, s.limiter.tableName, r1, r2)
+	return
 }
 
 func (s *MergeTaskBuilder) trySchedMergeTask() {
 	if s.tid == 0 {
 		return
 	}
-	// compactable blks
-	mergedBlks := s.blkBuilder.finish()
 	// deletable segs
-	mergedSegs := s.segBuilder.finish()
-	hasDelSeg := len(mergedSegs) > 0
-	hasMergeBlk := s.limiter.canMerge(s.tid, s.tableRowCnt, len(mergedBlks))
-	if !hasDelSeg && !hasMergeBlk {
+	delSegs := s.delSegBuilder.finish()
+	hasDelSeg := len(delSegs) > 0
+
+	hasMergeObjects := false
+
+	mergedBlks, msegs := s.checkSortedSegs(s.sortedSegBuilder.finish())
+	if len(mergedBlks) > 0 && s.limiter.checkMemAvail(len(mergedBlks)) {
+		delSegs = append(delSegs, msegs...)
+		hasMergeObjects = true
+	}
+
+	if !hasDelSeg && !hasMergeObjects {
 		return
 	}
 
-	segScopes := make([]common.ID, len(mergedSegs))
-	for i, s := range mergedSegs {
+	segScopes := make([]common.ID, len(delSegs))
+	for i, s := range delSegs {
 		segScopes[i] = *s.AsCommonID()
 	}
 
 	// remove stale segments only
-	if hasDelSeg && !hasMergeBlk {
+	if hasDelSeg && !hasMergeObjects {
 		factory := func(ctx *tasks.Context, txn txnif.AsyncTxn) (tasks.Task, error) {
-			return jobs.NewDelSegTask(ctx, txn, mergedSegs), nil
+			return jobs.NewDelSegTask(ctx, txn, delSegs), nil
 		}
 		_, err := s.db.Runtime.Scheduler.ScheduleMultiScopedTxnTask(nil, tasks.DataCompactionTask, segScopes, factory)
 		if err != nil {
 			logutil.Infof("[Mergeblocks] Schedule del seg errinfo=%v", err)
 			return
 		}
-		logutil.Infof("[Mergeblocks] Scheduled | del %d seg", len(mergedSegs))
+		logutil.Infof("[Mergeblocks] Scheduled | %d-%s del %d seg",
+			s.tid, s.limiter.tableName, len(delSegs))
 		return
 	}
+
+	// remove stale segments and mrege objects
 
 	scopes := make([]common.ID, len(mergedBlks))
 	for i, blk := range mergedBlks {
 		scopes[i] = *blk.AsCommonID()
 	}
+	scopes = append(scopes, segScopes...)
 
 	factory := func(ctx *tasks.Context, txn txnif.AsyncTxn) (tasks.Task, error) {
-		return jobs.NewMergeBlocksTask(ctx, txn, mergedBlks, mergedSegs, nil, s.db.Runtime)
+		return jobs.NewMergeBlocksTask(ctx, txn, mergedBlks, delSegs, nil, s.db.Runtime)
 	}
 	task, err := s.db.Runtime.Scheduler.ScheduleMultiScopedTxnTask(nil, tasks.DataCompactionTask, scopes, factory)
 	if err != nil {
@@ -340,101 +375,185 @@ func (s *MergeTaskBuilder) trySchedMergeTask() {
 			logutil.Infof("[Mergeblocks] Schedule error info=%v", err)
 		}
 	} else {
-		// record big merge
-		if len(scopes) > constHeapCapacity/3 {
-			s.limiter.IncActiveCount()
-			task.AddObserver(s.limiter)
+		// reset flag of sorted
+		for _, seg := range delSegs {
+			seg.Stat.SameDelsStreak = 0
+			seg.Stat.MergeIntent = 0
 		}
-		logutil.Infof("[Mergeblocks] Scheduled | Scopes=[%d],[%d]%s",
+		n := len(scopes)
+		s.limiter.IncActiveCount(n)
+		task.AddObserver(s.limiter)
+		if n > constMergeMinBlks {
+			n = constMergeMinBlks
+		}
+		logutil.Infof("[Mergeblocks] Scheduled | %d-%s Scopes=[%d],[%d]%s",
+			s.tid, s.limiter.tableName,
 			len(segScopes), len(scopes),
-			common.BlockIDArraryString(scopes[:constMergeMinBlks]))
+			common.BlockIDArraryString(scopes[:n]))
 	}
 }
 
-func (s *MergeTaskBuilder) resetForTable(tid uint64) {
+func (s *MergeTaskBuilder) resetForTable(entry *catalog.TableEntry) {
 	s.tableRowCnt = 0
-	s.tid = tid
-	s.segBuilder.reset()
-	s.blkBuilder.reset()
+	s.tableDelete = 0
+	s.tid = 0
+	if entry != nil {
+		s.tid = entry.ID
+		schema := entry.GetLastestSchema()
+		s.limiter.maxRowsForBlk = int(schema.BlockMaxRows)
+		s.limiter.objectMinRows = determineObjectMinRows(
+			int(schema.SegmentMaxBlocks), int(schema.BlockMaxRows))
+		s.limiter.tableName = schema.Name
+	}
+	s.delSegBuilder.reset()
+	s.sortedSegBuilder.reset()
 }
 
+func determineObjectMinRows(segMaxBlks, blkMaxRows int) int {
+	// the max rows of a full object
+	objectFullRows := segMaxBlks * blkMaxRows
+	// we want every object has at least 5 blks rows
+	objectMinRows := constMergeMinBlks * blkMaxRows
+	if objectFullRows < objectMinRows { // for small config in unit test
+		return objectFullRows
+	}
+	return objectMinRows
+}
+
+// PreExecute is called before each loop, refresh and print stats
 func (s *MergeTaskBuilder) PreExecute() error {
-	// clean stale stats for every 10min (default)
-	if s.runCnt++; s.runCnt >= 120 {
-		s.runCnt = 0
-		s.limiter.pruneStale()
-	}
 
-	// print stats for every 50s (default)
-	if s.runCnt%10 == 0 {
-		logutil.Infof("Mergeblocks stats: %s", s.limiter.String())
+	// fresh mem use
+	if stats, err := mem.VirtualMemory(); err == nil {
+		s.limiter.memAvail = int(stats.Available)
 	}
-
-	if s.runCnt%5 == 0 {
-		// fresh mem use
-		if stats, err := mem.VirtualMemory(); err == nil {
-			logutil.Infof("Mergeblocks available mem: %dg", stats.Available/(1<<30))
-			if limit := int32(stats.Available / const4GBytes); limit != s.limiter.concurrentMergeLimit && limit > 1 {
-				s.limiter.concurrentMergeLimit = limit
-				logutil.Infof("Mergeblocks set concurrency limit %d", limit)
-			}
-		}
+	if f := EnvOrDefaultFloat(constKeyMergeWaitFactor, 1.0); f < 0.1 {
+		s.limiter.mergeWaitFactor = 0.1
+	} else {
+		s.limiter.mergeWaitFactor = f
 	}
 	return nil
 }
 func (s *MergeTaskBuilder) PostExecute() error {
-	s.trySchedMergeTask()
-	s.resetForTable(0)
-	if cnt := atomic.LoadInt32(&s.limiter.activeMergeCount); cnt > 0 {
-		logutil.Infof("Mergeblocks current big active task: %d", cnt)
+	if cnt := atomic.LoadInt32(&s.limiter.activeMergeBlkCount); cnt > 0 {
+		logutil.Infof(
+			"Mergeblocks avail mem: %dG, quota blk: %d, current active blk: %d",
+			s.limiter.memAvail/(1<<30), s.limiter.calcQuotaBlks(), cnt)
 	}
+	logutil.Infof("mergeblocks ------------------------------------")
 	return nil
 }
 
 func (s *MergeTaskBuilder) onTable(tableEntry *catalog.TableEntry) (err error) {
-	s.trySchedMergeTask()
-	s.resetForTable(tableEntry.ID)
 	if !tableEntry.IsActive() {
 		err = moerr.GetOkStopCurrRecur()
 	}
+	s.resetForTable(tableEntry)
+	return
+}
+
+func (s *MergeTaskBuilder) onPostTable(tableEntry *catalog.TableEntry) (err error) {
+	// base on the info of tableEntry, we can decide whether to merge or not
+	s.trySchedMergeTask()
 	return
 }
 
 func (s *MergeTaskBuilder) onSegment(segmentEntry *catalog.SegmentEntry) (err error) {
-	if !segmentEntry.IsActive() || (!segmentEntry.IsAppendable() && segmentEntry.IsSorted()) {
+	if !segmentEntry.IsActive() {
 		return moerr.GetOkStopCurrRecur()
 	}
-	// handle appendable segs
-	// TODO Iter non appendable segs to delete all. Typical occasion is TPCC
-	s.segBuilder.resetForNewSeg()
+
+	segmentEntry.RLock()
+	defer segmentEntry.RUnlock()
+
+	// Skip uncommitted entries
+	if !segmentEntry.IsCommitted() ||
+		!catalog.ActiveWithNoTxnFilter(segmentEntry.BaseEntryImpl) {
+		return moerr.GetOkStopCurrRecur()
+	}
+
+	s.delSegBuilder.resetForNewSeg()
+	s.delSegBuilder.segIsSorted = segmentEntry.IsSorted()
 	return
 }
 
-func (s *MergeTaskBuilder) onPostSegment(segmentEntry *catalog.SegmentEntry) (err error) {
-	s.segBuilder.push(segmentEntry)
+func (s *MergeTaskBuilder) onPostSegment(seg *catalog.SegmentEntry) (err error) {
+	s.delSegBuilder.push(seg)
+
+	if !seg.IsSorted() || s.delSegBuilder.isCreating {
+		return nil
+	}
+
+	// for sorted segments, we have to see if it is qualified to be merged
+	seg.Stat.Rows = s.delSegBuilder.segRowCnt
+	if seg.Stat.Dels == s.delSegBuilder.segRowDel {
+		// SameDelsStreak is used to tell how frequently the segment is modified
+		seg.Stat.SameDelsStreak++
+	} else {
+		seg.Stat.SameDelsStreak = 0
+	}
+	seg.Stat.Dels = s.delSegBuilder.segRowDel
+	rowsLeftOnSeg := s.delSegBuilder.segRowCnt - s.delSegBuilder.segRowDel
+	// it has too few rows, merge it
+	iscandidate := func() bool {
+		if rowsLeftOnSeg < s.limiter.objectMinRows {
+			return true
+		}
+		if rowsLeftOnSeg < seg.Stat.Rows/2 {
+			return true
+		}
+		// //
+		// if seg.Stat.SameDelsStreak > 24 {
+		// 	return true
+		// }
+		return false
+	}
+
+	if iscandidate() {
+		s.sortedSegBuilder.push(&mItem[*catalog.SegmentEntry]{
+			row:   rowsLeftOnSeg,
+			entry: seg,
+		})
+	}
 	return nil
 }
 
+// for sorted segments, we just collect the rows and dels on this segment
+// for non-sorted segments, flushTableTail will take care of them, here we just check if it is deletable(having no active blocks)
 func (s *MergeTaskBuilder) onBlock(entry *catalog.BlockEntry) (err error) {
 	if !entry.IsActive() {
 		return
 	}
-	s.segBuilder.hintNonDropBlock()
+	// it has active blk, this seg can't be deleted
+	s.delSegBuilder.hintNonDropBlock()
+
+	// this blk is not in a s3 object
+	if !s.delSegBuilder.segIsSorted {
+		return
+	}
 
 	entry.RLock()
 	defer entry.RUnlock()
 
 	// Skip uncommitted entries and appendable block
 	if !entry.IsCommitted() ||
-		!catalog.ActiveWithNoTxnFilter(entry.BaseEntryImpl) ||
-		!catalog.NonAppendableBlkFilter(entry) {
+		!catalog.ActiveWithNoTxnFilter(entry.BaseEntryImpl) {
+		// txn appending metalocs
+		s.delSegBuilder.isCreating = true
 		return
 	}
 
+	if !catalog.NonAppendableBlkFilter(entry) {
+		panic("append block in sorted segment")
+	}
+
+	// nblks in appenable segs or non-sorted non-appendable segs
+	// these blks are formed by continuous append
 	entry.RUnlock()
 	rows := entry.GetBlockData().Rows()
+	dels := entry.GetBlockData().GetTotalChanges()
 	entry.RLock()
-	s.tableRowCnt += rows
-	s.blkBuilder.push(&mItem{row: rows, entry: entry})
+	s.delSegBuilder.segRowCnt += rows
+	s.delSegBuilder.segRowDel += dels
 	return nil
 }

--- a/pkg/vm/engine/tae/db/scannerop.go
+++ b/pkg/vm/engine/tae/db/scannerop.go
@@ -473,7 +473,7 @@ func (s *MergeTaskBuilder) onSegment(segmentEntry *catalog.SegmentEntry) (err er
 	}
 
 	s.delSegBuilder.resetForNewSeg()
-	s.delSegBuilder.segIsSorted = segmentEntry.IsSorted()
+	s.delSegBuilder.segIsSorted = segmentEntry.IsSortedLocked()
 	return
 }
 

--- a/pkg/vm/engine/tae/db/test/compatibility/registry.go
+++ b/pkg/vm/engine/tae/db/test/compatibility/registry.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	version = 3
+	version = 4
 )
 
 type optType int

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -850,6 +850,330 @@ func TestCompactMemAlter(t *testing.T) {
 	}
 }
 
+func TestFlushTableMergeOrder(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	testutils.EnsureNoLeak(t)
+	ctx := context.Background()
+
+	opts := config.WithLongScanAndCKPOpts(nil)
+	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
+	defer tae.Close()
+
+	worker := ops.NewOpWorker(context.Background(), "xx")
+	worker.Start()
+	defer worker.Stop()
+
+	schema := catalog.NewEmptySchema("test")
+	schema.AppendCol("aa", types.T_int64.ToType())
+	schema.AppendCol("bb", types.T_int32.ToType())
+	schema.AppendFakePKCol()
+	schema.BlockMaxRows = 78
+	schema.SegmentMaxBlocks = 256
+	require.NoError(t, schema.Finalize(false))
+	tae.BindSchema(schema)
+
+	// new bacth for aa and bb vector, and fill aa and bb with some random values
+	bat := containers.NewBatch()
+	bat.AddVector("aa", containers.NewVector(types.T_int64.ToType()))
+	bat.AddVector("bb", containers.NewVector(types.T_int32.ToType()))
+
+	dedup := make(map[int32]bool)
+
+	rows := 500
+
+	for i := 0; i < rows; i++ {
+		bb := int32(rand.Intn(100000))
+		if _, ok := dedup[bb]; ok {
+			continue
+		} else {
+			dedup[bb] = true
+		}
+		aa := int64(20000000 + bb)
+		bat.Vecs[0].Append(aa, false)
+		bat.Vecs[1].Append(bb, false)
+	}
+
+	defer bat.Close()
+	testutil.CreateRelationAndAppend(t, 0, tae.DB, "db", schema, bat, true)
+
+	{
+		txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+		it := rel.MakeBlockIt()
+		for ; it.Valid(); it.Next() {
+			blk := it.GetBlock()
+			blk.RangeDelete(0, 0, handle.DT_Normal)
+			blk.RangeDelete(3, 3, handle.DT_Normal)
+		}
+		require.NoError(t, txn.Commit(context.Background()))
+	}
+
+	txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+	blkMetas := testutil.GetAllBlockMetas(rel)
+	task, err := jobs.NewFlushTableTailTask(tasks.WaitableCtx, txn, blkMetas, tae.DB.Runtime, types.MaxTs())
+	require.NoError(t, err)
+	worker.SendOp(task)
+	err = task.WaitDone()
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(context.Background()))
+}
+
+func TestFlushTableMergeOrderPK(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	testutils.EnsureNoLeak(t)
+	ctx := context.Background()
+
+	opts := config.WithLongScanAndCKPOpts(nil)
+	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
+	defer tae.Close()
+
+	worker := ops.NewOpWorker(context.Background(), "xx")
+	worker.Start()
+	defer worker.Stop()
+
+	schema := catalog.NewEmptySchema("test")
+	schema.AppendPKCol("aa", types.T_int64.ToType(), 0)
+	schema.AppendCol("bb", types.T_int32.ToType())
+	schema.BlockMaxRows = 78
+	schema.SegmentMaxBlocks = 256
+	require.NoError(t, schema.Finalize(false))
+	tae.BindSchema(schema)
+
+	// new bacth for aa and bb vector, and fill aa and bb with some random values
+	bat := containers.NewBatch()
+	bat.AddVector("aa", containers.NewVector(types.T_int64.ToType()))
+	bat.AddVector("bb", containers.NewVector(types.T_int32.ToType()))
+
+	dedup := make(map[int32]bool)
+
+	target := 500
+	rows := 0
+
+	for i := 0; i < target; i++ {
+		bb := int32(rand.Intn(100000))
+		if _, ok := dedup[bb]; ok {
+			continue
+		} else {
+			dedup[bb] = true
+		}
+		rows++
+		aa := int64(20000000 + bb)
+		bat.Vecs[0].Append(aa, false)
+		bat.Vecs[1].Append(bb, false)
+	}
+
+	defer bat.Close()
+	testutil.CreateRelationAndAppend(t, 0, tae.DB, "db", schema, bat, true)
+
+	deleted := 0
+	{
+		txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+		for x := range dedup {
+			err := rel.DeleteByFilter(context.Background(), handle.NewEQFilter(int64(x+20000000)))
+			require.NoError(t, err)
+			deleted++
+			if deleted > rows/2 {
+				break
+			}
+		}
+		require.NoError(t, txn.Commit(context.Background()))
+	}
+
+	txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+	blkMetas := testutil.GetAllBlockMetas(rel)
+	task, err := jobs.NewFlushTableTailTask(tasks.WaitableCtx, txn, blkMetas, tae.DB.Runtime, types.MaxTs())
+	require.NoError(t, err)
+	worker.SendOp(task)
+	err = task.WaitDone()
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(context.Background()))
+
+	tae.Restart(ctx)
+	tae.CheckRowsByScan(rows-deleted, true)
+}
+
+func TestFlushTableNoPk(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	testutils.EnsureNoLeak(t)
+	ctx := context.Background()
+
+	opts := config.WithLongScanAndCKPOpts(nil)
+	// db := initDB(ctx, t, opts)
+	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
+	defer tae.Close()
+
+	worker := ops.NewOpWorker(context.Background(), "xx")
+	worker.Start()
+	defer worker.Stop()
+	schema := catalog.MockSchemaAll(13, -1)
+	schema.Name = "table"
+	schema.BlockMaxRows = 20
+	schema.SegmentMaxBlocks = 10
+	tae.BindSchema(schema)
+	bat := catalog.MockBatch(schema, 2*(int(schema.BlockMaxRows)*2+int(schema.BlockMaxRows/2)))
+	defer bat.Close()
+	testutil.CreateRelationAndAppend(t, 0, tae.DB, "db", schema, bat, true)
+
+	txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+	blkMetas := testutil.GetAllBlockMetas(rel)
+	task, err := jobs.NewFlushTableTailTask(tasks.WaitableCtx, txn, blkMetas, tae.DB.Runtime, types.MaxTs())
+	require.NoError(t, err)
+	worker.SendOp(task)
+	err = task.WaitDone()
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(context.Background()))
+
+	tae.Restart(ctx)
+	tae.CheckRowsByScan(100, true)
+}
+
+func TestFlushTabletail(t *testing.T) {
+	// TODO
+	defer testutils.AfterTest(t)()
+	testutils.EnsureNoLeak(t)
+	ctx := context.Background()
+
+	opts := config.WithLongScanAndCKPOpts(nil)
+	// db := initDB(ctx, t, opts)
+	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
+	defer tae.Close()
+
+	worker := ops.NewOpWorker(context.Background(), "xx")
+	worker.Start()
+	defer worker.Stop()
+	schema := catalog.MockSchemaAll(13, 2)
+	schema.Name = "table"
+	schema.BlockMaxRows = 20
+	schema.SegmentMaxBlocks = 10
+	bats := catalog.MockBatch(schema, 2*(int(schema.BlockMaxRows)*2+int(schema.BlockMaxRows/2))).Split(2)
+	bat := bats[0]  // 50 rows
+	bat2 := bats[1] // 50 rows
+
+	defer bat.Close()
+	defer bat2.Close()
+	testutil.CreateRelationAndAppend(t, 0, tae.DB, "db", schema, bat, true)
+
+	{
+		txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat.Vecs[2].Get(1))))
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat.Vecs[2].Get(19)))) // ab0 has 2
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat.Vecs[2].Get(21)))) // ab1 has 1
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat.Vecs[2].Get(45)))) // ab2 has 1
+
+		require.NoError(t, txn.Commit(context.Background()))
+	}
+
+	var commitDeleteAfterFlush txnif.AsyncTxn
+	{
+		var rel handle.Relation
+		commitDeleteAfterFlush, rel = testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat.Vecs[2].Get(42)))) // expect to transfer to nablk1
+	}
+
+	flushTable := func() {
+		txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+		blkMetas := testutil.GetAllBlockMetas(rel)
+		task, err := jobs.NewFlushTableTailTask(tasks.WaitableCtx, txn, blkMetas, tae.Runtime, types.MaxTs())
+		require.NoError(t, err)
+		worker.SendOp(task)
+		err = task.WaitDone()
+		require.NoError(t, err)
+		require.NoError(t, txn.Commit(context.Background()))
+	}
+
+	flushTable()
+
+	{
+		require.NoError(t, commitDeleteAfterFlush.Commit(context.Background()))
+		txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+		_, _, err := rel.GetByFilter(context.Background(), handle.NewEQFilter(bat.Vecs[2].Get(42)))
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNotFound))
+
+		require.NoError(t, rel.Append(context.Background(), bat2))
+		require.NoError(t, txn.Commit(context.Background()))
+	}
+	{
+		txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat.Vecs[2].Get(15))))
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat.Vecs[2].Get(20)))) // nab0 has 2
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat.Vecs[2].Get(27)))) // nab1 has 2
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat2.Vecs[2].Get(11))))
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat2.Vecs[2].Get(15)))) // ab3 has 2, ab4 and ab5 has 0
+		require.NoError(t, txn.Commit(context.Background()))
+	}
+
+	flushTable()
+
+	{
+		txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat.Vecs[2].Get(10)))) // nab0 has 2+1, nab1 has 2
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat2.Vecs[2].Get(44))))
+		require.NoError(t, rel.DeleteByFilter(context.Background(), handle.NewEQFilter(bat2.Vecs[2].Get(45)))) // nab5 has 2
+		require.NoError(t, txn.Commit(context.Background()))
+	}
+
+	flushTable()
+
+	{
+		txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+		it := rel.MakeBlockIt()
+		// 6 nablks has 87 rows
+		dels := []int{3, 2, 0, 0, 0, 2}
+		total := 0
+		for i := 0; it.Valid(); it.Next() {
+			blk := it.GetBlock()
+			view, err := blk.GetColumnDataById(context.Background(), 2)
+			require.NoError(t, err)
+			defer view.Close()
+			viewDel := 0
+			if view.DeleteMask != nil {
+				viewDel = view.DeleteMask.GetCardinality()
+			}
+			require.Equal(t, dels[i], viewDel)
+			view.ApplyDeletes()
+			total += view.Length()
+			i++
+		}
+		require.Equal(t, 87, total)
+		require.NoError(t, txn.Commit(context.Background()))
+	}
+
+	t.Log(tae.Catalog.SimplePPString(common.PPL2))
+
+	tae.Restart(ctx)
+	{
+		txn, rel := testutil.GetDefaultRelation(t, tae.DB, schema.Name)
+		it := rel.MakeBlockIt()
+		// 6 nablks has 87 rows
+		dels := []int{3, 2, 0, 0, 0, 2}
+		total := 0
+		idxs := make([]int, 0, len(schema.ColDefs)-1)
+		for i := 0; i < len(schema.ColDefs)-1; i++ {
+			idxs = append(idxs, i)
+		}
+		for i := 0; it.Valid(); it.Next() {
+			blk := it.GetBlock()
+			views, err := blk.GetColumnDataByIds(context.Background(), idxs)
+			require.NoError(t, err)
+			defer views.Close()
+			for j, view := range views.Columns {
+				require.Equal(t, schema.ColDefs[j].Type.Oid, view.GetData().GetType().Oid)
+			}
+
+			viewDel := 0
+			if views.DeleteMask != nil {
+				viewDel = views.DeleteMask.GetCardinality()
+			}
+			require.Equal(t, dels[i], viewDel)
+			views.ApplyDeletes()
+			total += views.Columns[0].Length()
+			i++
+		}
+		require.Equal(t, 87, total)
+		require.NoError(t, txn.Commit(context.Background()))
+	}
+
+}
+
 func TestCompactBlock2(t *testing.T) {
 	defer testutils.AfterTest(t)()
 	testutils.EnsureNoLeak(t)
@@ -4411,7 +4735,7 @@ func TestWatchDirty(t *testing.T) {
 	}
 	wg.Wait()
 
-	timer := time.After(10 * time.Second)
+	timer := time.After(20 * time.Second)
 	for {
 		select {
 		case <-timer:
@@ -6403,6 +6727,7 @@ func TestAppendAndGC(t *testing.T) {
 	testutils.WaitExpect(10000, func() bool {
 		return db.Runtime.Scheduler.GetPenddingLSNCnt() == 0
 	})
+	t.Log(tae.Catalog.SimplePPString(common.PPL1))
 	assert.Equal(t, uint64(0), db.Runtime.Scheduler.GetPenddingLSNCnt())
 	err = db.DiskCleaner.CheckGC()
 	assert.Nil(t, err)
@@ -7025,7 +7350,7 @@ func TestGCCatalog2(t *testing.T) {
 
 	tae.CreateRelAndAppend(bat, true)
 	t.Log(tae.Catalog.SimplePPString(3))
-	testutils.WaitExpect(4000, checkCompactAndGCFn)
+	testutils.WaitExpect(10000, checkCompactAndGCFn)
 	assert.True(t, checkCompactAndGCFn())
 	t.Log(tae.Catalog.SimplePPString(3))
 }
@@ -8052,4 +8377,64 @@ func TestCheckpointReadWrite2(t *testing.T) {
 
 	t1 := tae.TxnMgr.StatMaxCommitTS()
 	testutil.CheckCheckpointReadWrite(t, types.TS{}, t1, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
+}
+
+func TestEstimateMemSize(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	ctx := context.Background()
+
+	opts := config.WithLongScanAndCKPOpts(nil)
+	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
+	defer tae.Close()
+	schema := catalog.MockSchemaAll(2, 1)
+	schema.BlockMaxRows = 50
+	schemaBig := catalog.MockSchemaAll(14, 1)
+
+	schema50rowSize := 0
+	{
+		tae.BindSchema(schema)
+		bat := catalog.MockBatch(schema, 50)
+		testutil.CreateRelationAndAppend(t, 0, tae.DB, "db", schema, bat, true)
+		txn, rel := tae.GetRelation()
+		blk := testutil.GetOneBlockMeta(rel)
+		size1 := blk.GetBlockData().EstimateMemSize()
+		schema50rowSize = size1
+
+		err := rel.DeleteByPhyAddrKey(*objectio.NewRowid(&blk.ID, 1))
+		require.NoError(t, err)
+		size2 := blk.GetBlockData().EstimateMemSize()
+
+		err = rel.DeleteByPhyAddrKey(*objectio.NewRowid(&blk.ID, 5))
+		require.NoError(t, err)
+		size3 := blk.GetBlockData().EstimateMemSize()
+		require.Less(t, size1, size2)
+		require.Less(t, size2, size3)
+		require.NoError(t, txn.Rollback(ctx))
+		size4 := blk.GetBlockData().EstimateMemSize()
+		t.Log(size1, size2, size3, size4)
+	}
+
+	{
+		tae.BindSchema(schemaBig)
+		bat := catalog.MockBatch(schemaBig, 50)
+		testutil.CreateRelationAndAppend(t, 0, tae.DB, "db", schemaBig, bat, false)
+		txn, rel := tae.GetRelation()
+		blk := testutil.GetOneBlockMeta(rel)
+		size1 := blk.GetBlockData().EstimateMemSize()
+
+		err := rel.DeleteByPhyAddrKey(*objectio.NewRowid(&blk.ID, 1))
+		require.NoError(t, err)
+
+		size2 := blk.GetBlockData().EstimateMemSize()
+
+		err = rel.DeleteByPhyAddrKey(*objectio.NewRowid(&blk.ID, 5))
+		require.NoError(t, err)
+		size3 := blk.GetBlockData().EstimateMemSize()
+
+		t.Log(size1, size2, size3)
+		require.Less(t, size1, size2)
+		require.Less(t, size2, size3)
+		require.Less(t, schema50rowSize, size1)
+		require.NoError(t, txn.Commit(ctx))
+	}
 }

--- a/pkg/vm/engine/tae/db/testutil/funcs.go
+++ b/pkg/vm/engine/tae/db/testutil/funcs.go
@@ -162,6 +162,15 @@ func GetOneBlockMeta(rel handle.Relation) *catalog.BlockEntry {
 	return it.GetBlock().GetMeta().(*catalog.BlockEntry)
 }
 
+func GetAllBlockMetas(rel handle.Relation) (metas []*catalog.BlockEntry) {
+	it := rel.MakeBlockIt()
+	for ; it.Valid(); it.Next() {
+		blk := it.GetBlock()
+		metas = append(metas, blk.GetMeta().(*catalog.BlockEntry))
+	}
+	return
+}
+
 func CheckAllColRowsByScan(t *testing.T, rel handle.Relation, expectRows int, applyDelete bool) {
 	schema := rel.Schema().(*catalog.Schema)
 	for _, def := range schema.ColDefs {

--- a/pkg/vm/engine/tae/iface/data/block.go
+++ b/pkg/vm/engine/tae/iface/data/block.go
@@ -27,6 +27,7 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
@@ -87,7 +88,7 @@ type Block interface {
 	CollectChangesInRange(ctx context.Context, startTs, endTs types.TS) (*containers.BlockView, error)
 
 	// check wether any delete intents with prepared ts within [from, to]
-	HasDeleteIntentsPreparedIn(from, to types.TS) bool
+	HasDeleteIntentsPreparedIn(from, to types.TS) (bool, bool)
 
 	// check if all rows are committed before ts
 	// NOTE: here we assume that the block is visible to the ts
@@ -114,6 +115,8 @@ type Block interface {
 	GetValue(ctx context.Context, txn txnif.AsyncTxn, readSchema any, row, col int) (any, bool, error)
 	Foreach(ctx context.Context, readSchema any, colIdx int, op func(v any, isNull bool, row int) error, sels *nulls.Bitmap) error
 	PPString(level common.PPLevel, depth int, prefix string) string
+	EstimateMemSize() int
+	GetRuntime() *dbutils.Runtime
 
 	Init() error
 	TryUpgrade() error

--- a/pkg/vm/engine/tae/iface/handle/block.go
+++ b/pkg/vm/engine/tae/iface/handle/block.go
@@ -68,7 +68,7 @@ type BlockReader interface {
 	GetDeltaLoc() objectio.Location
 	Fingerprint() *common.ID
 	Rows() int
-	Prefetch(idxes []uint16) error
+	Prefetch(idxes []int) error
 	// Why need rowmask?
 	// We don't update the index until committing the transaction. Before that, even if we deleted a row
 	// from a block, the index would not change. If then we insert a row with the same primary key as the

--- a/pkg/vm/engine/tae/logtail/collector.go
+++ b/pkg/vm/engine/tae/logtail/collector.go
@@ -154,7 +154,7 @@ func (d *dirtyCollector) Run() {
 func (d *dirtyCollector) ScanInRangePruned(from, to types.TS) (
 	tree *DirtyTreeEntry) {
 	tree, _ = d.ScanInRange(from, to)
-	if err := d.tryCompactTree(d.interceptor, tree.tree); err != nil {
+	if err := d.tryCompactTree(d.interceptor, tree.tree, to); err != nil {
 		panic(err)
 	}
 	return
@@ -317,7 +317,7 @@ func (d *dirtyCollector) cleanupStorage() {
 			toDeletes = append(toDeletes, entry)
 			return true
 		}
-		if err := d.tryCompactTree(d.interceptor, entry.tree); err != nil {
+		if err := d.tryCompactTree(d.interceptor, entry.tree, entry.end); err != nil {
 			logutil.Warnf("error: interceptor on dirty tree: %v", err)
 		}
 		if entry.tree.IsEmpty() {
@@ -341,7 +341,7 @@ func (d *dirtyCollector) cleanupStorage() {
 // iter the tree and call interceptor to process block. flushed block, empty seg and table will be removed from the tree
 func (d *dirtyCollector) tryCompactTree(
 	interceptor DirtyEntryInterceptor,
-	tree *model.Tree) (err error) {
+	tree *model.Tree, ts types.TS) (err error) {
 	var (
 		db  *catalog.DBEntry
 		tbl *catalog.TableEntry
@@ -371,6 +371,14 @@ func (d *dirtyCollector) tryCompactTree(
 			}
 			break
 		}
+
+		tbl.Stats.RLock()
+		if tbl.Stats.FlushTableTailEnabled && tbl.Stats.LastFlush.GreaterEq(ts) {
+			tree.Shrink(id)
+			tbl.Stats.RUnlock()
+			continue
+		}
+		tbl.Stats.RUnlock()
 
 		for id, dirtySeg := range dirtyTable.Segs {
 			// remove empty segs

--- a/pkg/vm/engine/tae/logtail/handle.go
+++ b/pkg/vm/engine/tae/logtail/handle.go
@@ -542,6 +542,7 @@ func visitBlkMeta(e *catalog.BlockEntry, node *catalog.MVCCNode[*catalog.Metadat
 	insBatch.GetVectorByName(pkgcatalog.BlockMeta_DeltaLoc).Append([]byte(node.BaseNode.DeltaLoc), false)
 	insBatch.GetVectorByName(pkgcatalog.BlockMeta_CommitTs).Append(committs, false)
 	insBatch.GetVectorByName(pkgcatalog.BlockMeta_SegmentID).Append(e.GetSegment().ID, false)
+	insBatch.GetVectorByName(pkgcatalog.BlockMeta_MemTruncPoint).Append(node.Start, false)
 	insBatch.GetVectorByName(catalog.AttrCommitTs).Append(createts, false)
 	insBatch.GetVectorByName(catalog.AttrRowID).Append(objectio.HackBlockid2Rowid(&e.ID), false)
 

--- a/pkg/vm/engine/tae/logtail/handle.go
+++ b/pkg/vm/engine/tae/logtail/handle.go
@@ -542,7 +542,16 @@ func visitBlkMeta(e *catalog.BlockEntry, node *catalog.MVCCNode[*catalog.Metadat
 	insBatch.GetVectorByName(pkgcatalog.BlockMeta_DeltaLoc).Append([]byte(node.BaseNode.DeltaLoc), false)
 	insBatch.GetVectorByName(pkgcatalog.BlockMeta_CommitTs).Append(committs, false)
 	insBatch.GetVectorByName(pkgcatalog.BlockMeta_SegmentID).Append(e.GetSegment().ID, false)
-	insBatch.GetVectorByName(pkgcatalog.BlockMeta_MemTruncPoint).Append(node.Start, false)
+	// for appendable block(deleted, because we skip empty metaloc), non-dropped non-appendabled blocks, those new nodes are
+	// produced by flush table tail, it's safe to truncate mem data in CN
+	memTruncTs := node.Start
+	if !e.IsAppendable() && committs.Equal(deletets) {
+		// for deleted non-appendable block, it must be produced by merging blocks. In this case,
+		// do not truncate any data in CN, because merging blocks didn't flush deletes to disk.
+		memTruncTs = types.TS{}
+	}
+
+	insBatch.GetVectorByName(pkgcatalog.BlockMeta_MemTruncPoint).Append(memTruncTs, false)
 	insBatch.GetVectorByName(catalog.AttrCommitTs).Append(createts, false)
 	insBatch.GetVectorByName(catalog.AttrRowID).Append(objectio.HackBlockid2Rowid(&e.ID), false)
 

--- a/pkg/vm/engine/tae/logtail/types.go
+++ b/pkg/vm/engine/tae/logtail/types.go
@@ -60,20 +60,21 @@ const (
 
 var (
 	// for blk meta response
-	BlkMetaSchema   *catalog.Schema
-	DelSchema       *catalog.Schema
-	SegSchema       *catalog.Schema
-	TxnNodeSchema   *catalog.Schema
-	DBDNSchema      *catalog.Schema
-	TblDNSchema     *catalog.Schema
-	SegDNSchema     *catalog.Schema
-	BlkDNSchema     *catalog.Schema
-	MetaSchema_V1   *catalog.Schema
-	MetaSchema      *catalog.Schema
-	DBDelSchema     *catalog.Schema
-	TblDelSchema    *catalog.Schema
-	ColumnDelSchema *catalog.Schema
-	DNMetaSchema    *catalog.Schema
+	BlkMetaSchema    *catalog.Schema // latest version
+	BlkMetaSchema_V1 *catalog.Schema // previous version
+	DelSchema        *catalog.Schema
+	SegSchema        *catalog.Schema
+	TxnNodeSchema    *catalog.Schema
+	DBDNSchema       *catalog.Schema
+	TblDNSchema      *catalog.Schema
+	SegDNSchema      *catalog.Schema
+	BlkDNSchema      *catalog.Schema
+	MetaSchema_V1    *catalog.Schema
+	MetaSchema       *catalog.Schema
+	DBDelSchema      *catalog.Schema
+	TblDelSchema     *catalog.Schema
+	ColumnDelSchema  *catalog.Schema
+	DNMetaSchema     *catalog.Schema
 )
 
 var (
@@ -297,6 +298,23 @@ func init() {
 		}
 	}
 	if err := BlkMetaSchema.Finalize(true); err != nil { // no phyaddr column
+		panic(err)
+	}
+
+	BlkMetaSchema_V1 = catalog.NewEmptySchema("blkMetaV1")
+
+	for i, colname := range pkgcatalog.MoTableMetaSchemaV1 {
+		if i == 0 {
+			if err := BlkMetaSchema_V1.AppendPKCol(colname, pkgcatalog.MoTableMetaTypesV1[i], 0); err != nil {
+				panic(err)
+			}
+		} else {
+			if err := BlkMetaSchema_V1.AppendCol(colname, pkgcatalog.MoTableMetaTypesV1[i]); err != nil {
+				panic(err)
+			}
+		}
+	}
+	if err := BlkMetaSchema_V1.Finalize(true); err != nil { // no phyaddr column
 		panic(err)
 	}
 

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -47,8 +47,9 @@ const (
 	CheckpointVersion3 uint32 = 3
 	CheckpointVersion4 uint32 = 4
 	CheckpointVersion5 uint32 = 5
+	CheckpointVersion6 uint32 = 6
 
-	CheckpointCurrentVersion = CheckpointVersion5
+	CheckpointCurrentVersion = CheckpointVersion6
 )
 
 const (
@@ -117,6 +118,7 @@ var checkpointDataSchemas_V2 [MaxIDX]*catalog.Schema
 var checkpointDataSchemas_V3 [MaxIDX]*catalog.Schema
 var checkpointDataSchemas_V4 [MaxIDX]*catalog.Schema
 var checkpointDataSchemas_V5 [MaxIDX]*catalog.Schema
+var checkpointDataSchemas_V6 [MaxIDX]*catalog.Schema
 var checkpointDataSchemas_Curr [MaxIDX]*catalog.Schema
 
 var checkpointDataReferVersions map[uint32][MaxIDX]*checkpointDataItem
@@ -146,7 +148,7 @@ func init() {
 		BlkDNSchema,
 		DelSchema,
 		BlkDNSchema,
-		BlkMetaSchema, // 23
+		BlkMetaSchema_V1, // 23
 		DNMetaSchema,
 	}
 	checkpointDataSchemas_V2 = [MaxIDX]*catalog.Schema{
@@ -173,7 +175,7 @@ func init() {
 		BlkDNSchema,
 		DelSchema,
 		BlkDNSchema,
-		BlkMetaSchema, // 23
+		BlkMetaSchema_V1, // 23
 		DNMetaSchema,
 	}
 	checkpointDataSchemas_V3 = [MaxIDX]*catalog.Schema{
@@ -192,15 +194,15 @@ func init() {
 		SegDNSchema,
 		DelSchema,
 		SegDNSchema,
-		BlkMetaSchema, // 15
+		BlkMetaSchema_V1, // 15
 		BlkDNSchema,
 		DelSchema,
 		BlkDNSchema,
-		BlkMetaSchema, // 19
+		BlkMetaSchema_V1, // 19
 		BlkDNSchema,
 		DelSchema,
 		BlkDNSchema,
-		BlkMetaSchema, // 23
+		BlkMetaSchema_V1, // 23
 		DNMetaSchema,
 	}
 	checkpointDataSchemas_V4 = [MaxIDX]*catalog.Schema{
@@ -219,18 +221,46 @@ func init() {
 		SegDNSchema,
 		DelSchema,
 		SegDNSchema,
-		BlkMetaSchema, // 15
+		BlkMetaSchema_V1, // 15
 		BlkDNSchema,
 		DelSchema,
 		BlkDNSchema,
-		BlkMetaSchema, // 19
+		BlkMetaSchema_V1, // 19
 		BlkDNSchema,
 		DelSchema,
 		BlkDNSchema,
-		BlkMetaSchema, // 23
+		BlkMetaSchema_V1, // 23
 		DNMetaSchema,
 	}
 	checkpointDataSchemas_V5 = [MaxIDX]*catalog.Schema{
+		MetaSchema,
+		catalog.SystemDBSchema,
+		TxnNodeSchema,
+		DBDelSchema, // 3
+		DBDNSchema,
+		catalog.SystemTableSchema,
+		TblDNSchema,
+		TblDelSchema, // 7
+		TblDNSchema,
+		catalog.SystemColumnSchema,
+		ColumnDelSchema,
+		SegSchema, // 11
+		SegDNSchema,
+		DelSchema,
+		SegDNSchema,
+		BlkMetaSchema_V1, // 15
+		BlkDNSchema,
+		DelSchema,
+		BlkDNSchema,
+		BlkMetaSchema_V1, // 19
+		BlkDNSchema,
+		DelSchema,
+		BlkDNSchema,
+		BlkMetaSchema_V1, // 23
+		DNMetaSchema,
+	}
+
+	checkpointDataSchemas_V6 = [MaxIDX]*catalog.Schema{
 		MetaSchema,
 		catalog.SystemDBSchema,
 		TxnNodeSchema,
@@ -265,7 +295,8 @@ func init() {
 	registerCheckpointDataReferVersion(CheckpointVersion3, checkpointDataSchemas_V3[:])
 	registerCheckpointDataReferVersion(CheckpointVersion4, checkpointDataSchemas_V4[:])
 	registerCheckpointDataReferVersion(CheckpointVersion5, checkpointDataSchemas_V5[:])
-	checkpointDataSchemas_Curr = checkpointDataSchemas_V5
+	registerCheckpointDataReferVersion(CheckpointVersion6, checkpointDataSchemas_V6[:])
+	checkpointDataSchemas_Curr = checkpointDataSchemas_V6
 }
 
 func registerCheckpointDataReferVersion(version uint32, schemas []*catalog.Schema) {
@@ -562,7 +593,7 @@ func NewCNCheckpointData() *CNCheckpointData {
 	}
 }
 
-func swithCheckpointIdx(i uint16, tableID uint64) uint16 {
+func switchCheckpointIdx(i uint16, tableID uint64) uint16 {
 	idx := uint16(i)
 
 	if i == BlockInsert {
@@ -690,7 +721,7 @@ func (data *CNCheckpointData) PrefetchFrom(
 				break
 			}
 		}
-		idx := swithCheckpointIdx(uint16(i), tableID)
+		idx := switchCheckpointIdx(uint16(i), tableID)
 		schema := checkpointDataReferVersions[version][uint32(idx)]
 		idxes := make([]uint16, len(schema.attrs))
 		for attr := range schema.attrs {
@@ -1046,7 +1077,7 @@ func (data *CNCheckpointData) ReadFromData(
 				break
 			}
 		}
-		idx := swithCheckpointIdx(uint16(i), tableID)
+		idx := switchCheckpointIdx(uint16(i), tableID)
 		it := table.locations.MakeIterator()
 		for it.HasNext() {
 			block := it.Next()
@@ -1081,6 +1112,15 @@ func (data *CNCheckpointData) ReadFromData(
 				if err != nil {
 					return
 				}
+			}
+		}
+
+		if version <= CheckpointVersion5 {
+			if dataBats[i] != nil && (idx == BLKCNMetaInsertIDX || idx == BLKMetaInsertIDX) {
+				blkMetaBat := dataBats[i]
+				committs := blkMetaBat.Vecs[2+pkgcatalog.BLOCKMETA_COMMITTS_IDX]
+				blkMetaBat.Attrs = append(blkMetaBat.Attrs, pkgcatalog.BlockMeta_MemTruncPoint)
+				blkMetaBat.Vecs = append(blkMetaBat.Vecs, committs)
 			}
 		}
 	}
@@ -1421,7 +1461,7 @@ func (data *CheckpointData) WriteTo(
 					break
 				}
 			}
-			idx := swithCheckpointIdx(uint16(i), tid)
+			idx := switchCheckpointIdx(uint16(i), tid)
 			for _, block := range blockIndexs[idx] {
 				if table.End <= block.GetStartOffset() {
 					break
@@ -1897,6 +1937,29 @@ func (data *CheckpointData) readAll(
 					}
 				}
 			}
+
+			if version <= CheckpointVersion5 {
+				if uint16(idx) == BLKDNMetaInsertIDX {
+					for _, bat := range bats {
+						committs := bat.GetVectorByName(pkgcatalog.BlockMeta_CommitTs)
+						bat.AddVector(pkgcatalog.BlockMeta_MemTruncPoint, committs)
+					}
+				}
+
+				if uint16(idx) == BLKMetaInsertIDX {
+					for _, bat := range bats {
+						committs := bat.GetVectorByName(pkgcatalog.BlockMeta_CommitTs)
+						bat.AddVector(pkgcatalog.BlockMeta_MemTruncPoint, committs)
+					}
+				}
+
+				if uint16(idx) == BLKCNMetaInsertIDX {
+					for _, bat := range bats {
+						committs := bat.GetVectorByName(pkgcatalog.BlockMeta_CommitTs)
+						bat.AddVector(pkgcatalog.BlockMeta_MemTruncPoint, committs)
+					}
+				}
+			}
 			for i := range bats {
 				data.bats[idx].Append(bats[i])
 			}
@@ -2341,6 +2404,7 @@ func (collector *BaseCollector) VisitBlk(entry *catalog.BlockEntry) (err error) 
 	blkDNMetaInsSortedVec := blkDNMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_Sorted).GetDownstreamVector()
 	blkDNMetaInsSegIDVec := blkDNMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_SegmentID).GetDownstreamVector()
 	blkDNMetaInsCommitTsVec := blkDNMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_CommitTs).GetDownstreamVector()
+	blkDNMetaInsMemTruncVec := blkDNMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_MemTruncPoint).GetDownstreamVector()
 
 	blkDNMetaInsTxnDBIDVec := blkDNMetaInsTxnBat.GetVectorByName(SnapshotAttr_DBID).GetDownstreamVector()
 	blkDNMetaInsTxnTIDVec := blkDNMetaInsTxnBat.GetVectorByName(SnapshotAttr_TID).GetDownstreamVector()
@@ -2364,6 +2428,7 @@ func (collector *BaseCollector) VisitBlk(entry *catalog.BlockEntry) (err error) 
 	blkCNMetaInsSortedVec := blkCNMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_Sorted).GetDownstreamVector()
 	blkCNMetaInsSegIDVec := blkCNMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_SegmentID).GetDownstreamVector()
 	blkCNMetaInsCommitTsVec := blkCNMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_CommitTs).GetDownstreamVector()
+	blkCNMetaInsMemTruncVec := blkCNMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_MemTruncPoint).GetDownstreamVector()
 
 	blkMetaInsRowIDVec := blkMetaInsBat.GetVectorByName(catalog.AttrRowID).GetDownstreamVector()
 	blkMetaInsCommitTimeVec := blkMetaInsBat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector()
@@ -2374,6 +2439,7 @@ func (collector *BaseCollector) VisitBlk(entry *catalog.BlockEntry) (err error) 
 	blkMetaInsSortedVec := blkMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_Sorted).GetDownstreamVector()
 	blkMetaInsSegIDVec := blkMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_SegmentID).GetDownstreamVector()
 	blkMetaInsCommitTsVec := blkMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_CommitTs).GetDownstreamVector()
+	blkMetaInsMemTruncVec := blkMetaInsBat.GetVectorByName(pkgcatalog.BlockMeta_MemTruncPoint).GetDownstreamVector()
 
 	blkMetaInsTxnDBIDVec := blkMetaInsTxnBat.GetVectorByName(SnapshotAttr_DBID).GetDownstreamVector()
 	blkMetaInsTxnTIDVec := blkMetaInsTxnBat.GetVectorByName(SnapshotAttr_TID).GetDownstreamVector()
@@ -2477,6 +2543,7 @@ func (collector *BaseCollector) VisitBlk(entry *catalog.BlockEntry) (err error) 
 					false,
 					common.DefaultAllocator,
 				)
+				vector.AppendFixed(blkDNMetaInsMemTruncVec, metaNode.Start, false, common.DefaultAllocator)
 				vector.AppendFixed(
 					blkDNMetaInsRowIDVec,
 					objectio.HackBlockid2Rowid(&entry.ID),
@@ -2607,6 +2674,12 @@ func (collector *BaseCollector) VisitBlk(entry *catalog.BlockEntry) (err error) 
 					false,
 					common.DefaultAllocator,
 				)
+				memTrucate := metaNode.Start
+				if !entry.IsAppendable() && metaNode.DeletedAt.Equal(metaNode.GetEnd()) {
+					memTrucate = types.TS{}
+				}
+				vector.AppendFixed(blkCNMetaInsMemTruncVec, memTrucate, false, common.DefaultAllocator)
+
 			} else {
 				is_sorted := false
 				if !entry.IsAppendable() && entry.GetSchema().HasSortKey() {
@@ -2666,6 +2739,8 @@ func (collector *BaseCollector) VisitBlk(entry *catalog.BlockEntry) (err error) 
 					false,
 					common.DefaultAllocator,
 				)
+
+				vector.AppendFixed(blkMetaInsMemTruncVec, metaNode.Start, false, common.DefaultAllocator)
 
 				vector.AppendFixed(
 					blkMetaInsTxnDBIDVec,

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -138,11 +138,11 @@ func init() {
 		SegDNSchema,
 		DelSchema,
 		SegDNSchema,
-		BlkMetaSchema, // 15
+		BlkMetaSchema_V1, // 15
 		BlkDNSchema,
 		DelSchema,
 		BlkDNSchema,
-		BlkMetaSchema, // 19
+		BlkMetaSchema_V1, // 19
 		BlkDNSchema,
 		DelSchema,
 		BlkDNSchema,
@@ -165,11 +165,11 @@ func init() {
 		SegDNSchema,
 		DelSchema,
 		SegDNSchema,
-		BlkMetaSchema, // 15
+		BlkMetaSchema_V1, // 15
 		BlkDNSchema,
 		DelSchema,
 		BlkDNSchema,
-		BlkMetaSchema, // 19
+		BlkMetaSchema_V1, // 19
 		BlkDNSchema,
 		DelSchema,
 		BlkDNSchema,

--- a/pkg/vm/engine/tae/mergesort/func.go
+++ b/pkg/vm/engine/tae/mergesort/func.go
@@ -144,7 +144,11 @@ func Multiplex(
 		ret[i].PreExtend(int(toLayout[i]))
 		for j := 0; j < int(toLayout[i]); j++ {
 			s := src[k]
-			ret[i].Append(col[s].Get(cursors[s]), col[s].IsNull(cursors[s]))
+			if col[s].IsNull(cursors[s]) {
+				ret[i].Append(nil, true)
+			} else {
+				ret[i].Append(col[s].Get(cursors[s]), false)
+			}
 			cursors[s]++
 			k++
 		}

--- a/pkg/vm/engine/tae/model/transferdels.go
+++ b/pkg/vm/engine/tae/model/transferdels.go
@@ -1,0 +1,84 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"bytes"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+)
+
+type TransDels struct {
+	// any txn starts after this ts won't check this table
+	noUseAfter types.TS
+	bornTime   time.Time
+	// row -> commit ts
+	Mapping map[int]types.TS
+}
+
+func NewTransDels(endts types.TS) *TransDels {
+	return &TransDels{
+		noUseAfter: endts,
+		bornTime:   time.Now(),
+		Mapping:    make(map[int]types.TS),
+	}
+}
+
+func (t *TransDels) PPString() string {
+	var w bytes.Buffer
+	for row, ts := range t.Mapping {
+		_, _ = w.WriteString(strconv.Itoa(row))
+		_, _ = w.WriteString(":")
+		_, _ = w.WriteString(ts.ToString())
+		_, _ = w.WriteString(", ")
+	}
+	return w.String()
+}
+
+type TransDelsForBlks struct {
+	sync.RWMutex
+	dels map[types.Blockid]*TransDels
+}
+
+func NewTransDelsForBlks() *TransDelsForBlks {
+	return &TransDelsForBlks{
+		dels: make(map[types.Blockid]*TransDels),
+	}
+}
+
+func (t *TransDelsForBlks) GetDelsForBlk(blkid types.Blockid) *TransDels {
+	t.RLock()
+	defer t.RUnlock()
+	return t.dels[blkid]
+}
+
+func (t *TransDelsForBlks) SetDelsForBlk(blkid types.Blockid, dels *TransDels) {
+	t.Lock()
+	defer t.Unlock()
+	t.dels[blkid] = dels
+}
+
+func (t *TransDelsForBlks) Prune(gap time.Duration) {
+	t.Lock()
+	defer t.Unlock()
+	for blkid, del := range t.dels {
+		if time.Since(del.bornTime) > gap {
+			delete(t.dels, blkid)
+		}
+	}
+}

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -79,6 +79,22 @@ func (blk *baseBlock) Close() {
 	// TODO
 }
 
+func (blk *baseBlock) GetRuntime() *dbutils.Runtime {
+	return blk.rt
+}
+
+func (blk *baseBlock) EstimateMemSize() int {
+	node := blk.PinNode()
+	defer node.Unref()
+	blk.RLock()
+	defer blk.RUnlock()
+	size := blk.mvcc.EstimateMemSizeLocked()
+	if !node.IsPersisted() {
+		size += node.MustMNode().EstimateMemSize()
+	}
+	return size
+}
+
 func (blk *baseBlock) PinNode() *Node {
 	n := blk.node.Load()
 	// if ref fails, reload.
@@ -307,7 +323,9 @@ func (blk *baseBlock) foreachPersistedDeletesCommittedInRange(
 		abortVec := deletes.Vecs[3].GetDownstreamVector()
 		commitTsVec := deletes.Vecs[1].GetDownstreamVector()
 		rowIdVec := deletes.Vecs[0].GetDownstreamVector()
-		for i := 0; i < deletes.Length(); i++ {
+
+		rstart, rend := blockio.FindIntervalForBlock(vector.MustFixedCol[types.Rowid](rowIdVec), &blk.meta.ID)
+		for i := rstart; i < rend; i++ {
 			if skipAbort {
 				abort := vector.GetFixedAt[bool](abortVec, i)
 				if abort {
@@ -563,11 +581,10 @@ func (blk *baseBlock) PPString(level common.PPLevel, depth int, prefix string) s
 	return s
 }
 
-func (blk *baseBlock) HasDeleteIntentsPreparedIn(from, to types.TS) (found bool) {
+func (blk *baseBlock) HasDeleteIntentsPreparedIn(from, to types.TS) (found, isPersist bool) {
 	blk.RLock()
 	defer blk.RUnlock()
-	found = blk.mvcc.GetDeleteChain().HasDeleteIntentsPreparedInLocked(from, to)
-	return
+	return blk.mvcc.GetDeleteChain().HasDeleteIntentsPreparedInLocked(from, to)
 }
 
 func (blk *baseBlock) CollectChangesInRange(ctx context.Context, startTs, endTs types.TS) (view *containers.BlockView, err error) {

--- a/pkg/vm/engine/tae/tables/blk.go
+++ b/pkg/vm/engine/tae/tables/blk.go
@@ -124,7 +124,7 @@ func (blk *block) BatchDedup(
 ) (err error) {
 	defer func() {
 		if moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry) {
-			logutil.Infof("BatchDedup BLK-%s: %v", blk.meta.ID.String(), err)
+			logutil.Infof("BatchDedup %s (%v)BLK-%s: %v", blk.meta.GetSegment().GetTable().GetLastestSchema().Name, blk.IsAppendable(), blk.meta.ID.String(), err)
 		}
 	}()
 	return blk.PersistedBatchDedup(

--- a/pkg/vm/engine/tae/tables/jobs/compactblk.go
+++ b/pkg/vm/engine/tae/tables/jobs/compactblk.go
@@ -289,7 +289,7 @@ func (task *compactBlockTask) Execute(ctx context.Context) (err error) {
 		}
 		if deletes != nil {
 			defer deletes.Close()
-			deleteTask := NewFlushDeletesTask(tasks.WaitableCtx, oldBlkData.GetFs(), oldBMeta, deletes)
+			deleteTask := NewFlushDeletesTask(tasks.WaitableCtx, oldBlkData.GetFs(), deletes)
 			if err = task.rt.Scheduler.Schedule(deleteTask); err != nil {
 				return
 			}

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -1,0 +1,727 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"time"
+	"unsafe"
+
+	"github.com/matrixorigin/matrixone/pkg/common/bitmap"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/util/fault"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/mergesort"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables/txnentries"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tasks"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var FlushTableTailTaskFactory = func(
+	metas []*catalog.BlockEntry, rt *dbutils.Runtime, endTs types.TS, /* end of dirty range*/
+) tasks.TxnTaskFactory {
+	return func(ctx *tasks.Context, txn txnif.AsyncTxn) (tasks.Task, error) {
+		return NewFlushTableTailTask(ctx, txn, metas, rt, endTs)
+	}
+}
+
+type flushTableTailTask struct {
+	*tasks.BaseTask
+	txn        txnif.AsyncTxn
+	rt         *dbutils.Runtime
+	dirtyEndTs types.TS
+
+	scopes []common.ID
+	schema *catalog.Schema
+
+	rel  handle.Relation
+	dbid uint64
+
+	// record the row mapping from deleted blocks to created blocks
+	transMappings *txnentries.BlkTransferBooking
+
+	ablksMetas        []*catalog.BlockEntry
+	delSrcMetas       []*catalog.BlockEntry
+	ablksHandles      []handle.Block
+	delSrcHandles     []handle.Block
+	createdBlkHandles []handle.Block
+
+	dirtyLen                 int
+	createdMergedObjectName  string
+	createdDeletesObjectName string
+
+	mergeRowsCnt, ablksDeletesCnt, nblksDeletesCnt int
+}
+
+func NewFlushTableTailTask(
+	ctx *tasks.Context,
+	txn txnif.AsyncTxn,
+	blks []*catalog.BlockEntry,
+	rt *dbutils.Runtime,
+	dirtyEndTs types.TS,
+) (task *flushTableTailTask, err error) {
+	task = &flushTableTailTask{
+		txn:        txn,
+		rt:         rt,
+		dirtyEndTs: dirtyEndTs,
+	}
+	meta := blks[0]
+	dbId := meta.GetSegment().GetTable().GetDB().ID
+	task.dbid = dbId
+	database, err := txn.UnsafeGetDatabase(dbId)
+	if err != nil {
+		return
+	}
+	tableId := meta.GetSegment().GetTable().ID
+	rel, err := database.UnsafeGetRelation(tableId)
+	task.rel = rel
+	if err != nil {
+		return
+	}
+	task.schema = rel.Schema().(*catalog.Schema)
+
+	for _, blk := range blks {
+		task.scopes = append(task.scopes, *blk.AsCommonID())
+		var seg handle.Segment
+		seg, err = rel.GetSegment(&meta.GetSegment().ID)
+		if err != nil {
+			return
+		}
+		var hdl handle.Block
+		if hdl, err = seg.GetBlock(blk.ID); err != nil {
+			return
+		}
+		if blk.IsAppendable() {
+			task.ablksMetas = append(task.ablksMetas, blk)
+			task.ablksHandles = append(task.ablksHandles, hdl)
+		} else {
+			task.delSrcMetas = append(task.delSrcMetas, blk)
+			task.delSrcHandles = append(task.delSrcHandles, hdl)
+		}
+	}
+	task.transMappings = txnentries.NewBlkTransferBooking(len(task.ablksHandles))
+
+	task.BaseTask = tasks.NewBaseTask(task, tasks.DataCompactionTask, ctx)
+
+	tblEntry := rel.GetMeta().(*catalog.TableEntry)
+	tblEntry.Stats.RLock()
+	defer tblEntry.Stats.RUnlock()
+	task.dirtyLen = len(tblEntry.DeletedDirties)
+	for _, blk := range tblEntry.DeletedDirties {
+		task.scopes = append(task.scopes, *blk.AsCommonID())
+		var seg handle.Segment
+		seg, err = rel.GetSegment(&meta.GetSegment().ID)
+		if err != nil {
+			return
+		}
+		var hdl handle.Block
+		if hdl, err = seg.GetBlock(blk.ID); err != nil {
+			return
+		}
+		task.delSrcMetas = append(task.delSrcMetas, blk)
+		task.delSrcHandles = append(task.delSrcHandles, hdl)
+	}
+	return
+}
+
+// Scopes is used in conflict checking in scheduler. For ScopedTask interface
+func (task *flushTableTailTask) Scopes() []common.ID { return task.scopes }
+
+// Name is for ScopedTask interface
+func (task *flushTableTailTask) Name() string {
+	return fmt.Sprintf("[%d]FT-%d-%s", task.ID(), task.rel.ID(), task.schema.Name)
+}
+
+func (task *flushTableTailTask) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	blks := ""
+	for _, blk := range task.ablksMetas {
+		blks = fmt.Sprintf("%s%s,", blks, blk.ID.ShortStringEx())
+	}
+	enc.AddString("a-blks", blks)
+	delsrc := ""
+	for _, del := range task.delSrcMetas {
+		delsrc = fmt.Sprintf("%s%s,", delsrc, del.ID.ShortStringEx())
+	}
+	enc.AddString("deletes-src", delsrc)
+
+	toblks := ""
+	for _, blk := range task.createdBlkHandles {
+		id := blk.ID()
+		toblks = fmt.Sprintf("%s%s,", toblks, id.ShortStringEx())
+	}
+	if toblks != "" {
+		enc.AddString("to-blks", toblks)
+	}
+	return
+}
+
+func (task *flushTableTailTask) Execute(ctx context.Context) (err error) {
+	task.rt.Throttle.AcquireCompactionQuota()
+	defer task.rt.Throttle.ReleaseCompactionQuota()
+
+	logutil.Info("[Start]", common.OperationField(task.Name()), common.OperandField(task),
+		common.OperandField(len(task.ablksHandles)+len(task.delSrcHandles)))
+
+	phaseDesc := ""
+	defer func() {
+		if err != nil {
+			logutil.Error("[DoneWithErr]", common.OperationField(task.Name()),
+				common.AnyField("error", err),
+				common.AnyField("phase", phaseDesc),
+			)
+		}
+	}()
+	now := time.Now()
+
+	/////////////////////
+	//// phase seperator
+	///////////////////
+
+	phaseDesc = "1-flushing appendable blocks for snapshot"
+	snapshotSubtasks, err := task.flushAblksForSnapshot(ctx)
+	if err != nil {
+		return
+	}
+	defer releaseFlushBlkTasks(snapshotSubtasks, nil)
+
+	/////////////////////
+	//// phase seperator
+	///////////////////
+
+	phaseDesc = "1-write all deletes from nablks"
+	// just collect deletes, do not soft delete it, leave that to merge task.
+	deleteTask, emptyMap, err := task.flushAllDeletesFromDelSrc(ctx)
+	if err != nil {
+		return
+	}
+	if deleteTask != nil && deleteTask.delta != nil {
+		defer deleteTask.delta.Close()
+	}
+	/////////////////////
+	//// phase seperator
+	///////////////////
+
+	phaseDesc = "1-merge ablocks"
+	// merge ablocks, no need to wait, it is a sync procedure, that is why put it
+	// after flushAblksForSnapshot and flushAllDeletesFromNBlks
+	if err = task.mergeAblks(ctx); err != nil {
+		return
+	}
+
+	/////////////////////
+	//// phase seperator
+	///////////////////
+	phaseDesc = "1-waiting flushing appendable blocks for snapshot"
+	// wait flush tasks
+	if err = task.waitFlushAblkForSnapshot(ctx, snapshotSubtasks); err != nil {
+		return
+	}
+
+	/////////////////////
+	//// phase seperator
+	///////////////////
+
+	phaseDesc = "1-wait flushing all deletes from nablks"
+	if err = task.waitFlushAllDeletesFromDelSrc(ctx, deleteTask, emptyMap); err != nil {
+		return
+	}
+
+	phaseDesc = "1-wait LogTxnEntry"
+	txnEntry := txnentries.NewFlushTableTailEntry(
+		task.txn,
+		task.ID(),
+		task.transMappings,
+		task.rel.GetMeta().(*catalog.TableEntry),
+		task.ablksMetas,
+		task.delSrcMetas,
+		task.ablksHandles,
+		task.delSrcHandles,
+		task.createdBlkHandles,
+		task.createdDeletesObjectName,
+		task.createdMergedObjectName,
+		task.dirtyLen,
+		task.rt,
+		task.dirtyEndTs,
+	)
+	task.rel.GetDB()
+	readset := make([]*common.ID, 0, len(task.ablksMetas)+len(task.delSrcMetas))
+	for _, blk := range task.ablksMetas {
+		readset = append(readset, blk.AsCommonID())
+	}
+	for _, blk := range task.delSrcMetas[:(len(task.delSrcMetas) - task.dirtyLen)] {
+		readset = append(readset, blk.AsCommonID())
+	}
+	if err = task.txn.LogTxnEntry(
+		task.dbid,
+		task.rel.ID(),
+		txnEntry,
+		readset,
+	); err != nil {
+		return
+	}
+	/////////////////////
+
+	logutil.Info("[End]", common.OperationField(task.Name()),
+		common.AnyField("txn-start-ts", task.txn.GetStartTS().ToString()),
+		zap.Int("ablks-deletes", task.ablksDeletesCnt),
+		zap.Int("ablks-merge-rows", task.mergeRowsCnt),
+		zap.Int("nblks-deletes", task.nblksDeletesCnt),
+		common.DurationField(time.Since(now)),
+		common.OperandField(task))
+
+	sleep, name, exist := fault.TriggerFault("slow_flush")
+	if exist && name == task.schema.Name {
+		time.Sleep(time.Duration(sleep) * time.Second)
+	}
+	return
+}
+
+// prepareAblkSortedData read the data from appendable blocks, sort them if sort key exists
+func (task *flushTableTailTask) prepareAblkSortedData(ctx context.Context, blkidx int, idxs []int, sortKeyPos int) (bat *containers.Batch, empty bool, err error) {
+	if len(idxs) <= 0 {
+		logutil.Infof("[FlushTabletail] no mergeable columns")
+		return nil, true, nil
+	}
+	blk := task.ablksHandles[blkidx]
+
+	views, err := blk.GetColumnDataByIds(ctx, idxs)
+	if err != nil {
+		return
+	}
+	bat = containers.NewBatch()
+	rowCntBeforeApplyDelete := views.Columns[0].Length()
+	deletes := views.DeleteMask
+	views.ApplyDeletes()
+	defer views.Close()
+	for i, colidx := range idxs {
+		colview := views.Columns[i]
+		if colview == nil {
+			empty = true
+			return
+		}
+		vec := colview.Orphan()
+		if vec.Length() == 0 {
+			empty = true
+			vec.Close()
+			bat.Close()
+			return
+		}
+		bat.AddVector(task.schema.ColDefs[colidx].Name, vec.TryConvertConst())
+	}
+
+	if deletes != nil {
+		task.ablksDeletesCnt += deletes.GetCardinality()
+	}
+
+	var sortMapping []int32
+	if sortKeyPos >= 0 {
+		if blkidx == 0 {
+			logutil.Infof("flushtabletail sort blk on %s", bat.Attrs[sortKeyPos])
+		}
+		sortMapping, err = mergesort.SortBlockColumns(bat.Vecs, sortKeyPos, task.rt.VectorPool.Transient)
+		if err != nil {
+			return
+		}
+	}
+	task.transMappings.AddSortPhaseMapping(blkidx, rowCntBeforeApplyDelete, deletes, sortMapping)
+	return
+}
+
+// mergeAblks merge the data from appendable blocks, and write the merged data to new block,
+// recording row mapping in blkTransferBooking struct
+func (task *flushTableTailTask) mergeAblks(ctx context.Context) (err error) {
+	if len(task.ablksMetas) == 0 {
+		return nil
+	}
+
+	// prepare columns idx and sortKey to read sorted batch
+	schema := task.schema
+	seqnums := make([]uint16, 0, len(schema.ColDefs))
+	readColIdxs := make([]int, 0, len(schema.ColDefs))
+	sortKeyIdx := -1
+	sortKeyPos := -1
+	if schema.HasSortKey() {
+		sortKeyIdx = schema.GetSingleSortKeyIdx()
+	}
+	for i, def := range schema.ColDefs {
+		if def.IsPhyAddr() {
+			continue
+		}
+		readColIdxs = append(readColIdxs, def.Idx)
+		if def.Idx == sortKeyIdx {
+			sortKeyPos = i
+		}
+		seqnums = append(seqnums, def.SeqNum)
+	}
+
+	// read from ablocks
+	readedBats := make([]*containers.Batch, 0, len(task.ablksHandles))
+	for _, block := range task.ablksHandles {
+		err = block.Prefetch(readColIdxs)
+		if err != nil {
+			return
+		}
+	}
+	for i := range task.ablksHandles {
+		bat, empty, err := task.prepareAblkSortedData(ctx, i, readColIdxs, sortKeyPos)
+		if err != nil {
+			return err
+		}
+		if empty {
+			continue
+		}
+		readedBats = append(readedBats, bat)
+	}
+
+	for _, bat := range readedBats {
+		defer bat.Close()
+	}
+
+	if len(readedBats) == 0 {
+		//just  soft delete all ablks and return
+		for _, blk := range task.ablksHandles {
+			seg := blk.GetSegment()
+			if err = seg.SoftDeleteBlock(blk.ID()); err != nil {
+				return err
+			}
+		}
+		task.transMappings.Clean()
+		return nil
+	}
+
+	// create new object to hold merged blocks
+	var toSegmentEntry *catalog.SegmentEntry
+	var toSegmentHandle handle.Segment
+	if toSegmentHandle, err = task.rel.CreateNonAppendableSegment(false); err != nil {
+		return
+	}
+	toSegmentEntry = toSegmentHandle.GetMeta().(*catalog.SegmentEntry)
+	toSegmentEntry.SetSorted()
+
+	// prepare merge
+	// pick the sort key or first column to run first merge, determing the ordering
+	sortVecs := make([]containers.Vector, 0, len(readedBats))
+	// fromLayout describes the layout of the input batch, which is a list of batch length
+	fromLayout := make([]uint32, 0, len(readedBats))
+	// toLayout describes the layout of the output batch, i.e. [8192, 8192, 8192, 4242]
+	toLayout := make([]uint32, 0, len(readedBats))
+	totalRowCnt := 0
+	if sortKeyPos < 0 {
+		// no pk, just pick the first column to reshape
+		sortKeyPos = 0
+	}
+	for _, bat := range readedBats {
+		vec := bat.Vecs[sortKeyPos]
+		fromLayout = append(fromLayout, uint32(vec.Length()))
+		totalRowCnt += vec.Length()
+		sortVecs = append(sortVecs, vec)
+	}
+	task.mergeRowsCnt = totalRowCnt
+	rowsLeft := totalRowCnt
+	for rowsLeft > 0 {
+		if rowsLeft > int(schema.BlockMaxRows) {
+			toLayout = append(toLayout, schema.BlockMaxRows)
+			rowsLeft -= int(schema.BlockMaxRows)
+		} else {
+			toLayout = append(toLayout, uint32(rowsLeft))
+			break
+		}
+	}
+
+	// do first sort
+	allocSz := totalRowCnt * 4
+	node, err := common.DefaultAllocator.Alloc(allocSz)
+	if err != nil {
+		panic(err)
+	}
+	defer common.DefaultAllocator.Free(node)
+	// sortedIdx is used to shuffle other columns according to the order of the sort key
+	sortedIdx := unsafe.Slice((*uint32)(unsafe.Pointer(&node[0])), totalRowCnt)
+	orderedVecs, mapping := mergeColumns(sortVecs, &sortedIdx, true, fromLayout, toLayout, schema.HasSortKey(), task.rt.VectorPool.Transient)
+	for _, vec := range orderedVecs {
+		defer vec.Close()
+	}
+	task.transMappings.UpdateMappingAfterMerge(mapping, fromLayout, toLayout)
+
+	// create blks to hold sorted data
+	writtenBatches := make([]*containers.Batch, 0, len(orderedVecs))
+	task.createdBlkHandles = make([]handle.Block, 0, len(orderedVecs))
+	for i := range orderedVecs {
+		blk, err := toSegmentHandle.CreateNonAppendableBlock(
+			new(objectio.CreateBlockOpt).WithFileIdx(0).WithBlkIdx(uint16(i)))
+		if err != nil {
+			return err
+		}
+		task.createdBlkHandles = append(task.createdBlkHandles, blk)
+		writtenBatches = append(writtenBatches, containers.NewBatch())
+	}
+
+	// make all columns ordered and prepared writtenBatches
+	vecs := make([]containers.Vector, 0, len(readedBats))
+	for i, idx := range readColIdxs {
+		// skip rowid and sort(reshape) column in the first run
+		if schema.ColDefs[idx].IsPhyAddr() {
+			continue
+		}
+		if i == sortKeyPos {
+			for i, vec := range orderedVecs {
+				writtenBatches[i].AddVector(schema.ColDefs[idx].Name, vec)
+			}
+			continue
+		}
+		vecs = vecs[:0]
+		for _, bat := range readedBats {
+			vecs = append(vecs, bat.Vecs[i])
+		}
+		vecs, _ := mergeColumns(vecs, &sortedIdx, false, fromLayout, toLayout, schema.HasSortKey(), task.rt.VectorPool.Transient)
+
+		for i := range vecs {
+			defer vecs[i].Close()
+		}
+		for i, vec := range vecs {
+			writtenBatches[i].AddVector(schema.ColDefs[idx].Name, vec)
+		}
+	}
+
+	// write!
+	name := objectio.BuildObjectName(&toSegmentEntry.ID, 0)
+	writer, err := blockio.NewBlockWriterNew(task.rt.Fs.Service, name, schema.Version, seqnums)
+	if err != nil {
+		return err
+	}
+	if schema.HasPK() {
+		pkIdx := schema.GetSingleSortKeyIdx()
+		writer.SetPrimaryKey(uint16(pkIdx))
+	}
+	for _, bat := range writtenBatches {
+		_, err = writer.WriteBatch(containers.ToCNBatch(bat))
+		if err != nil {
+			return err
+		}
+	}
+	writtenBlocks, _, err := writer.Sync(ctx)
+	if err != nil {
+		return err
+	}
+	task.createdMergedObjectName = name.String()
+
+	// update new status for created blocks
+	var metaLoc objectio.Location
+	for i, block := range writtenBlocks {
+		metaLoc = blockio.EncodeLocation(name, block.GetExtent(), uint32(writtenBatches[i].Length()), block.GetID())
+		if err = task.createdBlkHandles[i].UpdateMetaLoc(metaLoc); err != nil {
+			return err
+		}
+		if err = task.createdBlkHandles[i].GetMeta().(*catalog.BlockEntry).GetBlockData().Init(); err != nil {
+			return err
+		}
+	}
+
+	// soft delete all ablks
+	for _, blk := range task.ablksHandles {
+		seg := blk.GetSegment()
+		if err = seg.SoftDeleteBlock(blk.ID()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// flushAblksForSnapshot schedule io task to flush ablocks for snapshot read. this function will not release any data in io task
+func (task *flushTableTailTask) flushAblksForSnapshot(ctx context.Context) (subtasks []*flushBlkTask, err error) {
+	defer func() {
+		if err != nil {
+			releaseFlushBlkTasks(subtasks, err)
+		}
+	}()
+	subtasks = make([]*flushBlkTask, len(task.ablksMetas))
+	// fire flush task
+	for i, blk := range task.ablksMetas {
+		var data, deletes *containers.Batch
+		var dataVer *containers.BatchWithVersion
+		blkData := blk.GetBlockData()
+		if dataVer, err = blkData.CollectAppendInRange(types.TS{}, task.txn.GetStartTS(), true); err != nil {
+			return
+		}
+		data = dataVer.Batch
+		if data == nil || data.Length() == 0 {
+			// the new appendable block might has no data when we flush the table, just skip it
+			// In previous impl, runner will only pass non-empty blk to NewCompactBlackTask
+			continue
+		}
+		// do not close data, leave that to wait phase
+		if deletes, err = blkData.CollectDeleteInRange(ctx, types.TS{}, task.txn.GetStartTS(), true); err != nil {
+			return
+		}
+		if deletes != nil {
+			// make sure every batch in deltaloc object is sorted by rowid
+			mergesort.SortBlockColumns(deletes.Vecs, 0, task.rt.VectorPool.Transient)
+		}
+
+		ablockTask := NewFlushBlkTask(
+			tasks.WaitableCtx,
+			dataVer.Version,
+			dataVer.Seqnums,
+			blkData.GetFs(),
+			blk,
+			data,
+			deletes,
+		)
+		if err = task.rt.Scheduler.Schedule(ablockTask); err != nil {
+			return
+		}
+		subtasks[i] = ablockTask
+	}
+	return
+}
+
+// waitFlushAblkForSnapshot waits all io tasks about flushing ablock for snapshot read, update locations
+func (task *flushTableTailTask) waitFlushAblkForSnapshot(ctx context.Context, subtasks []*flushBlkTask) (err error) {
+	for i, subtask := range subtasks {
+		if subtask == nil {
+			continue
+		}
+		if err = subtask.WaitDone(); err != nil {
+			return
+		}
+		metaLocABlk := blockio.EncodeLocation(
+			subtask.name,
+			subtask.blocks[0].GetExtent(),
+			uint32(subtask.data.Length()),
+			subtask.blocks[0].GetID(),
+		)
+		if err = task.ablksHandles[i].UpdateMetaLoc(metaLocABlk); err != nil {
+			return
+		}
+		if subtask.delta == nil {
+			continue
+		}
+		deltaLoc := blockio.EncodeLocation(
+			subtask.name,
+			subtask.blocks[1].GetExtent(),
+			uint32(subtask.delta.Length()),
+			subtask.blocks[1].GetID())
+
+		if err = task.ablksHandles[i].UpdateDeltaLoc(deltaLoc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// flushAllDeletesFromDelSrc collects all deletes from blks and flush them into one block
+func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (subtask *flushDeletesTask, emtpyDelBlkIdx *bitmap.Bitmap, err error) {
+	var bufferBatch *containers.Batch
+	defer func() {
+		if err != nil && bufferBatch != nil {
+			bufferBatch.Close()
+		}
+	}()
+	for i, blk := range task.delSrcMetas {
+		blkData := blk.GetBlockData()
+		var deletes *containers.Batch
+		if deletes, err = blkData.CollectDeleteInRange(ctx, types.TS{}, task.txn.GetStartTS(), true); err != nil {
+			return
+		}
+		if deletes == nil || deletes.Length() == 0 {
+			if emtpyDelBlkIdx == nil {
+				emtpyDelBlkIdx = &bitmap.Bitmap{}
+				emtpyDelBlkIdx.InitWithSize(len(task.delSrcMetas))
+			}
+			emtpyDelBlkIdx.Add(uint64(i))
+			continue
+		}
+		if bufferBatch == nil {
+			bufferBatch = makeDeletesTempBatch(deletes, task.rt.VectorPool.Transient)
+		}
+		task.nblksDeletesCnt += deletes.Length()
+		// deletes is closed by Extend
+		bufferBatch.Extend(deletes)
+	}
+	if bufferBatch != nil {
+		// make sure every batch in deltaloc object is sorted by rowid
+		mergesort.SortBlockColumns(bufferBatch.Vecs, 0, task.rt.VectorPool.Transient)
+		subtask = NewFlushDeletesTask(tasks.WaitableCtx, task.rt.Fs, bufferBatch)
+		if err = task.rt.Scheduler.Schedule(subtask); err != nil {
+			return
+		}
+	}
+	return
+}
+
+// waitFlushAllDeletesFromDelSrc waits all io tasks about flushing deletes from blks, update locations but skip those in emtpyDelBlkIdx
+func (task *flushTableTailTask) waitFlushAllDeletesFromDelSrc(ctx context.Context, subtask *flushDeletesTask, emtpyDelBlkIdx *bitmap.Bitmap) (err error) {
+	if subtask == nil {
+		return
+	}
+	if err = subtask.WaitDone(); err != nil {
+		return err
+	}
+	task.createdDeletesObjectName = subtask.name.String()
+	deltaLoc := blockio.EncodeLocation(
+		subtask.name,
+		subtask.blocks[0].GetExtent(),
+		uint32(subtask.delta.Length()),
+		subtask.blocks[0].GetID())
+	logutil.Infof("[FlushTabletail] task %d update %s for approximate %d blks", task.ID(), deltaLoc, len(task.delSrcHandles))
+	for i, hdl := range task.delSrcHandles {
+		if emtpyDelBlkIdx != nil && emtpyDelBlkIdx.Contains(uint64(i)) {
+			continue
+		}
+		if err = hdl.UpdateDeltaLoc(deltaLoc); err != nil {
+			return err
+		}
+	}
+	return
+}
+
+func makeDeletesTempBatch(template *containers.Batch, pool *containers.VectorPool) *containers.Batch {
+	bat := containers.NewBatchWithCapacity(len(template.Attrs))
+	for i, name := range template.Attrs {
+		bat.AddVector(name, pool.GetVector(template.Vecs[i].GetType()))
+	}
+	return bat
+}
+
+func releaseFlushBlkTasks(subtasks []*flushBlkTask, err error) {
+	if err != nil {
+		logutil.Infof("[FlushTabletail] release flush task bat because of err %v", err)
+		for _, subtask := range subtasks {
+			if subtask != nil {
+				// wait done, otherwise the data might be released before flush, and cause data race
+				subtask.WaitDone()
+			}
+		}
+	}
+	for _, subtask := range subtasks {
+		if subtask != nil && subtask.data != nil {
+			subtask.data.Close()
+		}
+		if subtask != nil && subtask.delta != nil {
+			subtask.delta.Close()
+		}
+	}
+}

--- a/pkg/vm/engine/tae/tables/jobs/flushblk.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushblk.go
@@ -16,6 +16,7 @@ package jobs
 
 import (
 	"context"
+
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 
 	"github.com/matrixorigin/matrixone/pkg/objectio"
@@ -73,6 +74,7 @@ func (task *flushBlkTask) Execute(ctx context.Context) error {
 	if task.meta.GetSchema().HasPK() {
 		writer.SetPrimaryKey(uint16(task.meta.GetSchema().GetSingleSortKeyIdx()))
 	}
+
 	_, err = writer.WriteBatch(containers.ToCNBatch(task.data))
 	if err != nil {
 		return err

--- a/pkg/vm/engine/tae/tables/jobs/flushdeletes.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushdeletes.go
@@ -16,11 +16,11 @@ package jobs
 
 import (
 	"context"
+
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tasks"
@@ -29,7 +29,6 @@ import (
 type flushDeletesTask struct {
 	*tasks.BaseTask
 	delta  *containers.Batch
-	meta   *catalog.BlockEntry
 	fs     *objectio.ObjectFS
 	name   objectio.ObjectName
 	blocks []objectio.BlockObject
@@ -38,11 +37,9 @@ type flushDeletesTask struct {
 func NewFlushDeletesTask(
 	ctx *tasks.Context,
 	fs *objectio.ObjectFS,
-	meta *catalog.BlockEntry,
 	delta *containers.Batch,
 ) *flushDeletesTask {
 	task := &flushDeletesTask{
-		meta:  meta,
 		fs:    fs,
 		delta: delta,
 	}
@@ -50,10 +47,10 @@ func NewFlushDeletesTask(
 	return task
 }
 
-func (task *flushDeletesTask) Scope() *common.ID { return task.meta.AsCommonID() }
+func (task *flushDeletesTask) Scope() *common.ID { return nil }
 
 func (task *flushDeletesTask) Execute(ctx context.Context) error {
-	name := task.meta.BuildDeleteObjectName()
+	name := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
 	task.name = name
 	writer, err := blockio.NewBlockWriterNew(task.fs.Service, name, 0, nil)
 	if err != nil {

--- a/pkg/vm/engine/tae/tables/jobs/mergeblocks.go
+++ b/pkg/vm/engine/tae/tables/jobs/mergeblocks.go
@@ -62,17 +62,18 @@ var MergeBlocksIntoSegmentTaskFctory = func(
 
 type mergeBlocksTask struct {
 	*tasks.BaseTask
-	txn         txnif.AsyncTxn
-	rt          *dbutils.Runtime
-	toSegEntry  *catalog.SegmentEntry
-	createdSegs []*catalog.SegmentEntry
-	mergedSegs  []*catalog.SegmentEntry
-	mergedBlks  []*catalog.BlockEntry
-	createdBlks []*catalog.BlockEntry
-	compacted   []handle.Block
-	rel         handle.Relation
-	scopes      []common.ID
-	deletes     []*nulls.Bitmap
+	txn           txnif.AsyncTxn
+	rt            *dbutils.Runtime
+	toSegEntry    *catalog.SegmentEntry
+	createdSegs   []*catalog.SegmentEntry
+	mergedSegs    []*catalog.SegmentEntry
+	mergedBlks    []*catalog.BlockEntry
+	createdBlks   []*catalog.BlockEntry
+	transMappings *txnentries.BlkTransferBooking
+	compacted     []handle.Block
+	rel           handle.Relation
+	scopes        []common.ID
+	deletes       []*nulls.Bitmap
 }
 
 func NewMergeBlocksTask(
@@ -89,6 +90,7 @@ func NewMergeBlocksTask(
 		compacted:   make([]handle.Block, 0),
 		toSegEntry:  toSegEntry,
 	}
+	task.transMappings = txnentries.NewBlkTransferBooking(len(task.mergedBlks))
 	dbId := mergedBlks[0].GetSegment().GetTable().GetDB().ID
 	database, err := txn.GetDatabaseByID(dbId)
 	if err != nil {
@@ -118,30 +120,31 @@ func NewMergeBlocksTask(
 
 func (task *mergeBlocksTask) Scopes() []common.ID { return task.scopes }
 
-func (task *mergeBlocksTask) mergeColumns(
+func mergeColumns(
 	srcVecs []containers.Vector,
 	sortedIdx *[]uint32,
 	isPrimary bool,
 	fromLayout,
 	toLayout []uint32,
-	sort bool) (retVecs []containers.Vector, mapping []uint32) {
+	sort bool,
+	pool *containers.VectorPool) (retVecs []containers.Vector, mapping []uint32) {
 	if len(srcVecs) == 0 {
 		return
 	}
 	if sort {
 		if isPrimary {
-			retVecs, mapping = mergesort.MergeSortedColumn(srcVecs, sortedIdx, fromLayout, toLayout, task.rt.VectorPool.Transient)
+			retVecs, mapping = mergesort.MergeSortedColumn(srcVecs, sortedIdx, fromLayout, toLayout, pool)
 		} else {
-			retVecs = mergesort.ShuffleColumn(srcVecs, *sortedIdx, fromLayout, toLayout, task.rt.VectorPool.Transient)
+			retVecs = mergesort.ShuffleColumn(srcVecs, *sortedIdx, fromLayout, toLayout, pool)
 		}
 	} else {
-		retVecs, mapping = task.mergeColumnWithOutSort(srcVecs, fromLayout, toLayout)
+		retVecs, mapping = mergeColumnWithOutSort(srcVecs, fromLayout, toLayout, pool)
 	}
 	return
 }
 
-func (task *mergeBlocksTask) mergeColumnWithOutSort(
-	column []containers.Vector, fromLayout, toLayout []uint32,
+func mergeColumnWithOutSort(
+	column []containers.Vector, fromLayout, toLayout []uint32, pool *containers.VectorPool,
 ) (ret []containers.Vector, mapping []uint32) {
 	totalLength := uint32(0)
 	for _, i := range toLayout {
@@ -151,14 +154,14 @@ func (task *mergeBlocksTask) mergeColumnWithOutSort(
 	for i := range mapping {
 		mapping[i] = uint32(i)
 	}
-	ret = mergesort.Reshape(column, fromLayout, toLayout, task.rt.VectorPool.Transient)
+	ret = mergesort.Reshape(column, fromLayout, toLayout, pool)
 	return
 }
 
 func (task *mergeBlocksTask) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	blks := ""
 	for _, blk := range task.mergedBlks {
-		blks = fmt.Sprintf("%s%s,", blks, blk.ID.String())
+		blks = fmt.Sprintf("%s%s,", blks, blk.ID.ShortStringEx())
 	}
 	enc.AddString("from-blks", blks)
 	segs := ""
@@ -169,18 +172,10 @@ func (task *mergeBlocksTask) MarshalLogObject(enc zapcore.ObjectEncoder) (err er
 
 	toblks := ""
 	for _, blk := range task.createdBlks {
-		toblks = fmt.Sprintf("%s%s,", toblks, blk.ID.String())
+		toblks = fmt.Sprintf("%s%s,", toblks, blk.ID.ShortStringEx())
 	}
 	if toblks != "" {
 		enc.AddString("to-blks", toblks)
-	}
-
-	tosegs := ""
-	for _, seg := range task.createdSegs {
-		tosegs = fmt.Sprintf("%s%s,", tosegs, seg.ID.ToString())
-	}
-	if tosegs != "" {
-		enc.AddString("to-segs", tosegs)
 	}
 	return
 }
@@ -198,6 +193,7 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 		}
 	}()
 	now := time.Now()
+
 	// merge data according to the schema at startTs
 	schema := task.rel.Schema().(*catalog.Schema)
 	logutil.Info("[Start] Mergeblocks", common.OperationField(task.Name()),
@@ -221,7 +217,6 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 	}
 	logutil.Infof("Mergeblocks on sort column %s\n", sortColDef.Name)
 	phaseNumber = 1
-	idxes := make([]uint16, 0, len(schema.ColDefs)-1)
 	seqnums := make([]uint16, 0, len(schema.ColDefs)-1)
 	Idxs := make([]int, 0, len(schema.ColDefs))
 	views := make([]*containers.BlockView, len(task.compacted))
@@ -230,11 +225,10 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 		if def.IsPhyAddr() {
 			continue
 		}
-		idxes = append(idxes, uint16(def.Idx))
 		seqnums = append(seqnums, def.SeqNum)
 	}
 	for _, block := range task.compacted {
-		err = block.Prefetch(idxes)
+		err = block.Prefetch(Idxs)
 		if err != nil {
 			return
 		}
@@ -244,7 +238,9 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 			return
 		}
 		defer views[i].Close()
+
 		task.deletes[i] = views[i].DeleteMask
+		rowCntBeforeApplyDelete := views[i].Columns[0].Length()
 		views[i].ApplyDeletes()
 		vec := views[i].Columns[sortColDef.Idx].GetData()
 		defer vec.Close()
@@ -252,7 +248,8 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 			skipBlks = append(skipBlks, i)
 			continue
 		}
-		sortVecs = append(sortVecs, vec)
+		task.transMappings.AddSortPhaseMapping(i, rowCntBeforeApplyDelete, task.deletes[i], nil /*it is sorted, no mapping*/)
+		sortVecs = append(sortVecs, vec.TryConvertConst())
 		rows = append(rows, uint32(vec.Length()))
 		fromAddr = append(fromAddr, uint32(length))
 		length += vec.Length()
@@ -272,6 +269,7 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 				return err
 			}
 		}
+		task.transMappings.Clean()
 		return nil
 	}
 
@@ -285,9 +283,6 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 		task.createdSegs = append(task.createdSegs, task.toSegEntry)
 	} else {
 		panic("warning: merge to a existing segment")
-		// if toSegEntry, err = task.rel.GetSegment(task.toSegEntry.ID); err != nil {
-		// 	return
-		// }
 	}
 
 	to := make([]uint32, 0)
@@ -312,7 +307,8 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 	defer common.DefaultAllocator.Free(node)
 	sortedIdx := unsafe.Slice((*uint32)(unsafe.Pointer(&node[0])), length)
 
-	vecs, mapping := task.mergeColumns(sortVecs, &sortedIdx, true, rows, to, schema.HasSortKey())
+	vecs, mapping := mergeColumns(sortVecs, &sortedIdx, true, rows, to, schema.HasSortKey(), task.rt.VectorPool.Transient)
+	task.transMappings.UpdateMappingAfterMerge(mapping, rows, to)
 	// logutil.Infof("mapping is %v", mapping)
 	// logutil.Infof("sortedIdx is %v", sortedIdx)
 	length = 0
@@ -353,14 +349,14 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 		// If only one single sort key, it was processed before
 		vecs = vecs[:0]
 		for i := range task.compacted {
-			vec := views[i].Columns[def.Idx].Orphan()
+			vec := views[i].Columns[def.Idx].Orphan().TryConvertConst()
 			defer vec.Close()
 			if vec.Length() == 0 {
 				continue
 			}
 			vecs = append(vecs, vec)
 		}
-		vecs, _ := task.mergeColumns(vecs, &sortedIdx, false, rows, to, schema.HasSortKey())
+		vecs, _ := mergeColumns(vecs, &sortedIdx, false, rows, to, schema.HasSortKey(), task.rt.VectorPool.Transient)
 		for i := range vecs {
 			defer vecs[i].Close()
 		}
@@ -425,6 +421,7 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 		task.createdSegs,
 		task.mergedBlks,
 		task.createdBlks,
+		task.transMappings,
 		mapping,
 		fromAddr,
 		toAddr,
@@ -439,6 +436,7 @@ func (task *mergeBlocksTask) Execute(ctx context.Context) (err error) {
 	logutil.Info("[Done] Mergeblocks",
 		common.AnyField("txn-start-ts", task.txn.GetStartTS().ToString()),
 		common.OperationField(task.Name()),
+		common.OperandField(schema.Name),
 		common.OperandField(task),
 		common.DurationField(time.Since(now)))
 

--- a/pkg/vm/engine/tae/tables/mnode.go
+++ b/pkg/vm/engine/tae/tables/mnode.go
@@ -156,6 +156,13 @@ func (node *memoryNode) Rows() uint32 {
 	return uint32(node.data.Length())
 }
 
+func (node *memoryNode) EstimateMemSize() int {
+	if node.data == nil {
+		return 0
+	}
+	return node.data.ApproxSize()
+}
+
 func (node *memoryNode) GetColumnDataWindow(
 	readSchema *catalog.Schema,
 	from uint32,

--- a/pkg/vm/engine/tae/tables/txnentries/compactblk.go
+++ b/pkg/vm/engine/tae/tables/txnentries/compactblk.go
@@ -144,7 +144,7 @@ func (entry *compactBlockEntry) Set1PC()     {}
 func (entry *compactBlockEntry) Is1PC() bool { return false }
 func (entry *compactBlockEntry) PrepareCommit() (err error) {
 	dataBlock := entry.from.GetMeta().(*catalog.BlockEntry).GetBlockData()
-	if dataBlock.HasDeleteIntentsPreparedIn(entry.txn.GetStartTS().Next(), types.MaxTs()) {
+	if found, _ := dataBlock.HasDeleteIntentsPreparedIn(entry.txn.GetStartTS().Next(), types.MaxTs()); found {
 		err = moerr.NewTxnWWConflictNoCtx()
 	}
 	return

--- a/pkg/vm/engine/tae/tables/txnentries/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/txnentries/flushTableTail.go
@@ -1,0 +1,402 @@
+package txnentries
+
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/container/nulls"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/model"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tasks"
+)
+
+type flushTableTailEntry struct {
+	txn txnif.AsyncTxn
+
+	taskID     uint64
+	tableEntry *catalog.TableEntry
+
+	transMappings      *BlkTransferBooking
+	ablksMetas         []*catalog.BlockEntry
+	delSrcMetas        []*catalog.BlockEntry
+	ablksHandles       []handle.Block
+	delSrcHandles      []handle.Block
+	createdBlkHandles  []handle.Block
+	pageIds            []*common.ID
+	nextRoundDirties   []*catalog.BlockEntry
+	createdDeletesFile string
+	createdMergeFile   string
+	dirtyLen           int
+	rt                 *dbutils.Runtime
+	dirtyEndTs         types.TS
+}
+
+func NewFlushTableTailEntry(
+	txn txnif.AsyncTxn,
+	taskID uint64,
+	mapping *BlkTransferBooking,
+	tableEntry *catalog.TableEntry,
+	ablksMetas []*catalog.BlockEntry,
+	nblksMetas []*catalog.BlockEntry,
+	ablksHandles []handle.Block,
+	nblksHandles []handle.Block,
+	createdBlkHandles []handle.Block,
+	createdDeletesFile string,
+	createdMergeFile string,
+	dirtyLen int,
+	rt *dbutils.Runtime,
+	dirtyEndTs types.TS,
+) *flushTableTailEntry {
+
+	entry := &flushTableTailEntry{
+		txn:                txn,
+		taskID:             taskID,
+		transMappings:      mapping,
+		tableEntry:         tableEntry,
+		ablksMetas:         ablksMetas,
+		delSrcMetas:        nblksMetas,
+		ablksHandles:       ablksHandles,
+		delSrcHandles:      nblksHandles,
+		createdBlkHandles:  createdBlkHandles,
+		createdDeletesFile: createdDeletesFile,
+		createdMergeFile:   createdMergeFile,
+		dirtyLen:           dirtyLen,
+		rt:                 rt,
+		dirtyEndTs:         dirtyEndTs,
+	}
+	entry.addTransferPages()
+	return entry
+}
+
+// add transfer pages for dropped ablocks
+func (entry *flushTableTailEntry) addTransferPages() {
+	for i, m := range entry.transMappings.Mappings {
+		if len(m) == 0 {
+			continue
+		}
+		id := entry.ablksHandles[i].Fingerprint()
+		entry.pageIds = append(entry.pageIds, id)
+		page := model.NewTransferHashPage(id, time.Now())
+		for srcRow, dst := range m {
+			blkid := entry.createdBlkHandles[dst.Idx].ID()
+			page.Train(uint32(srcRow), *objectio.NewRowid(&blkid, uint32(dst.Row)))
+		}
+		entry.rt.TransferTable.AddPage(page)
+	}
+}
+
+// PrepareCommit check deletes between start ts and commit ts
+func (entry *flushTableTailEntry) PrepareCommit() error {
+	found := false
+	for _, blk := range entry.delSrcMetas {
+		exist, isPersist := blk.GetBlockData().HasDeleteIntentsPreparedIn(entry.txn.GetStartTS().Next(), types.MaxTs())
+		if exist {
+			found = true
+			logutil.Infof("[FlushTabletail] task %d has write-write conflict on nblk %s, isPersist[%v]", entry.taskID, blk.ID.String(), isPersist)
+			if blk.HasDropCommitted() {
+				panic(fmt.Sprintf("[FlushTabletail] task %d has write-write conflict on nblk %s, but it has been dropped", entry.taskID, blk.ID.String()))
+			}
+		}
+	}
+
+	// transfer deletes in (startts .. committs] for ablocks
+	delTbls := make([]*model.TransDels, len(entry.createdBlkHandles))
+	for i, blk := range entry.ablksMetas {
+		mapping := entry.transMappings.Mappings[i]
+		if len(mapping) == 0 {
+			// empty frozen ablocks, it can not has any more deletes
+			continue
+		}
+		dataBlock := blk.GetBlockData()
+		bat, err := dataBlock.CollectDeleteInRange(entry.txn.GetContext(), entry.txn.GetStartTS().Next(), entry.txn.GetPrepareTS(), false)
+		if err != nil {
+			return err
+		}
+		if bat == nil || bat.Length() == 0 {
+			continue
+		}
+		rowid := vector.MustFixedCol[types.Rowid](bat.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
+		ts := vector.MustFixedCol[types.TS](bat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
+
+		count := len(rowid)
+		for i := 0; i < count; i++ {
+			row := rowid[i].GetRowOffset()
+			destpos, ok := mapping[int(row)]
+			if !ok {
+				panic(fmt.Sprintf("%s find no transfer mapping for row %d", blk.ID.String(), row))
+			}
+			if delTbls[destpos.Idx] == nil {
+				delTbls[destpos.Idx] = model.NewTransDels(entry.txn.GetPrepareTS())
+			}
+			delTbls[destpos.Idx].Mapping[destpos.Row] = ts[i]
+			if err = entry.createdBlkHandles[destpos.Idx].RangeDelete(uint32(destpos.Row), uint32(destpos.Row), handle.DT_MergeCompact); err != nil {
+				return err
+			}
+		}
+		found = true
+		entry.nextRoundDirties = append(entry.nextRoundDirties, blk)
+		logutil.Infof("[FlushTabletail] task %d has write-write conflict on ablk %s trans cnt %d ", entry.taskID, blk.ID.String(), count)
+	}
+	for i, delTbl := range delTbls {
+		if delTbl != nil {
+			destid := entry.createdBlkHandles[i].ID()
+			entry.rt.TransferDelsMap.SetDelsForBlk(destid, delTbl)
+		}
+	}
+
+	if found {
+		logutil.Infof("[FlushTabletail] task %d ww (%s .. %s)", entry.taskID, entry.txn.GetStartTS().ToString(), entry.txn.GetPrepareTS().ToString())
+	}
+	return nil
+}
+
+// PrepareRollback remove transfer page and written files
+func (entry *flushTableTailEntry) PrepareRollback() (err error) {
+	logutil.Warnf("[FlushTabletail] FT task %d rollback", entry.taskID)
+	// remove transfer page
+	for _, id := range entry.pageIds {
+		_ = entry.rt.TransferTable.DeletePage(id)
+	}
+
+	// remove written file
+	fs := entry.rt.Fs.Service
+
+	// object for snapshot read of ablocks
+	ablkNames := make([]string, 0, len(entry.ablksMetas))
+	for _, blk := range entry.ablksMetas {
+		if !blk.HasPersistedData() {
+			logutil.Infof("[FlushTabletail] skip empty ablk %s when rollback", blk.ID.String())
+			continue
+		}
+		seg := blk.ID.Segment()
+		num, _ := blk.ID.Offsets()
+		name := objectio.BuildObjectName(seg, num).String()
+		ablkNames = append(ablkNames, name)
+	}
+
+	// for io task, dispatch by round robin, scope can be nil
+	entry.rt.Scheduler.ScheduleScopedFn(&tasks.Context{}, tasks.IOTask, nil, func() error {
+		// TODO: variable as timeout
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		for _, name := range ablkNames {
+			_ = fs.Delete(ctx, name)
+		}
+		if entry.createdDeletesFile != "" {
+			_ = fs.Delete(ctx, entry.createdDeletesFile)
+		}
+		if entry.createdMergeFile != "" {
+			_ = fs.Delete(ctx, entry.createdMergeFile)
+		}
+		return nil
+	})
+	return
+}
+
+// ApplyCommit Gc in memory deletes and update table compact status
+func (entry *flushTableTailEntry) ApplyCommit() (err error) {
+	for i, blk := range entry.ablksMetas {
+		_ = blk.GetBlockData().TryUpgrade()
+		blk.GetBlockData().GCInMemeoryDeletesByTS(entry.ablksHandles[i].GetDeltaPersistedTS())
+	}
+
+	for i, blk := range entry.delSrcMetas {
+		blk.GetBlockData().GCInMemeoryDeletesByTS(entry.delSrcHandles[i].GetDeltaPersistedTS())
+	}
+
+	tbl := entry.tableEntry
+	tbl.Stats.Lock()
+	defer tbl.Stats.Unlock()
+	tbl.Stats.LastFlush = entry.dirtyEndTs
+	// no merge tasks touch the dirties, we are good to clean all
+	if entry.dirtyLen == len(tbl.DeletedDirties) {
+		tbl.DeletedDirties = tbl.DeletedDirties[:0]
+	} else {
+		// some merge tasks touch the dirties, we need to keep those new dirties
+		tbl.DeletedDirties = tbl.DeletedDirties[entry.dirtyLen:]
+	}
+	tbl.DeletedDirties = append(tbl.DeletedDirties, entry.nextRoundDirties...)
+	return
+}
+
+func (entry *flushTableTailEntry) ApplyRollback() (err error) {
+	return
+}
+
+func (entry *flushTableTailEntry) MakeCommand(csn uint32) (cmd txnif.TxnCmd, err error) {
+	return &flushTableTailCmd{}, nil
+}
+func (entry *flushTableTailEntry) IsAborted() bool { return false }
+func (entry *flushTableTailEntry) Set1PC()         {}
+func (entry *flushTableTailEntry) Is1PC() bool     { return false }
+
+////////////////////////////////////////
+// flushTableTailCmd
+////////////////////////////////////////
+
+type flushTableTailCmd struct{}
+
+func (cmd *flushTableTailCmd) GetType() uint16 { return IOET_WALTxnCommand_Compact }
+func (cmd *flushTableTailCmd) WriteTo(w io.Writer) (n int64, err error) {
+	typ := IOET_WALTxnCommand_FlushTableTail
+	if _, err = w.Write(types.EncodeUint16(&typ)); err != nil {
+		return
+	}
+	n = 2
+	ver := IOET_WALTxnCommand_FlushTableTail_CurrVer
+	if _, err = w.Write(types.EncodeUint16(&ver)); err != nil {
+		return
+	}
+	n = 2
+	return
+}
+func (cmd *flushTableTailCmd) MarshalBinary() (buf []byte, err error) {
+	var bbuf bytes.Buffer
+	if _, err = cmd.WriteTo(&bbuf); err != nil {
+		return
+	}
+	buf = bbuf.Bytes()
+	return
+}
+func (cmd *flushTableTailCmd) ReadFrom(r io.Reader) (n int64, err error) { return }
+func (cmd *flushTableTailCmd) UnmarshalBinary(buf []byte) (err error)    { return }
+func (cmd *flushTableTailCmd) Desc() string                              { return "CmdName=CPCT" }
+func (cmd *flushTableTailCmd) String() string                            { return "CmdName=CPCT" }
+func (cmd *flushTableTailCmd) VerboseString() string                     { return "CmdName=CPCT" }
+func (cmd *flushTableTailCmd) ApplyCommit()                              {}
+func (cmd *flushTableTailCmd) ApplyRollback()                            {}
+func (cmd *flushTableTailCmd) SetReplayTxn(txnif.AsyncTxn)               {}
+func (cmd *flushTableTailCmd) Close()                                    {}
+
+////////////////////////////////////////
+// transferMapping
+////////////////////////////////////////
+
+type DestPos struct {
+	Idx int // idx of the created blk
+	Row int // destination row number
+}
+
+type BlkTransferBooking struct {
+	// row in the deleted blk -> row in the created blk
+	Mappings []map[int]DestPos
+}
+
+func NewBlkTransferBooking(size int) *BlkTransferBooking {
+	mappings := make([]map[int]DestPos, size)
+	for i := 0; i < size; i++ {
+		mappings[i] = make(map[int]DestPos)
+	}
+	return &BlkTransferBooking{
+		Mappings: mappings,
+	}
+}
+
+func (b *BlkTransferBooking) Clean() {
+	for i := 0; i < len(b.Mappings); i++ {
+		b.Mappings[i] = make(map[int]DestPos)
+	}
+}
+
+func (b *BlkTransferBooking) AddSortPhaseMapping(idx int, originRowCnt int, deletes *nulls.Nulls, mapping []int32) {
+	// TODO: remove panic check
+	if mapping != nil {
+		deletecnt := 0
+		if deletes != nil {
+			deletecnt = deletes.GetCardinality()
+		}
+		if len(mapping) != originRowCnt-deletecnt {
+			panic(fmt.Sprintf("mapping length %d != originRowCnt %d - deletes %s", len(mapping), originRowCnt, deletes))
+		}
+		// mapping sortedVec[i] = originalVec[sortMapping[i]]
+		// transpose it, originalVec[sortMapping[i]] = sortedVec[i]
+		// [9 4 8 5 2 6 0 7 3 1](orignVec)  -> [6 9 4 8 1 3 5 7 2 0](sortedVec)
+		// [0 1 2 3 4 5 6 7 8 9](sortedVec) -> [0 1 2 3 4 5 6 7 8 9](originalVec)
+		// TODO: use a more efficient way to transpose, in place
+		transposedMapping := make([]int32, len(mapping))
+		for sortedPos, originalPos := range mapping {
+			transposedMapping[originalPos] = int32(sortedPos)
+		}
+		mapping = transposedMapping
+	}
+	posInVecApplyDeletes := 0
+	targetMapping := b.Mappings[idx]
+	for origRow := 0; origRow < originRowCnt; origRow++ {
+		if deletes != nil && deletes.Contains(uint64(origRow)) {
+			// this row has been deleted, skip its mapping
+			continue
+		}
+		if mapping == nil {
+			// no sort phase, the mapping is 1:1, just use posInVecApplyDeletes
+			targetMapping[origRow] = DestPos{Idx: -1, Row: posInVecApplyDeletes}
+		} else {
+			targetMapping[origRow] = DestPos{Idx: -1, Row: int(mapping[posInVecApplyDeletes])}
+		}
+		posInVecApplyDeletes++
+	}
+}
+
+func (b *BlkTransferBooking) UpdateMappingAfterMerge(mapping, fromLayout, toLayout []uint32) {
+	bisectHaystack := make([]uint32, 0, len(toLayout)+1)
+	bisectHaystack = append(bisectHaystack, 0)
+	for _, x := range toLayout {
+		bisectHaystack = append(bisectHaystack, bisectHaystack[len(bisectHaystack)-1]+x)
+	}
+
+	// given toLayout and a needle, find its corresponding block index and row index in the block
+	// For example, toLayout [8192, 8192, 1024], needle = 0 -> (0, 0); needle = 8192 -> (1, 0); needle = 8193 -> (1, 1)
+	bisectPinpoint := func(needle uint32) (int, uint32) {
+		i, j := 0, len(bisectHaystack)
+		for i < j {
+			m := (i + j) / 2
+			if bisectHaystack[m] > needle {
+				j = m
+			} else {
+				i = m + 1
+			}
+		}
+		// bisectHaystack[i] is the first number > needle, so the needle falls into i-1 th block
+		blkIdx := i - 1
+		rows := needle - bisectHaystack[blkIdx]
+		return blkIdx, rows
+	}
+
+	var totalHandledRows int
+
+	for _, m := range b.Mappings {
+		var curTotal int
+		var destTotal uint32
+		for srcRow := range m {
+			curTotal = totalHandledRows + m[srcRow].Row
+			destTotal = mapping[curTotal]
+			destBlkIdx, destRowIdx := bisectPinpoint(destTotal)
+			m[srcRow] = DestPos{Idx: destBlkIdx, Row: int(destRowIdx)}
+		}
+		totalHandledRows += len(m)
+	}
+}

--- a/pkg/vm/engine/tae/tables/txnentries/types.go
+++ b/pkg/vm/engine/tae/tables/txnentries/types.go
@@ -19,14 +19,17 @@ import (
 )
 
 const (
-	IOET_WALTxnCommand_Compact uint16 = 3006
-	IOET_WALTxnCommand_Merge   uint16 = 3007
+	IOET_WALTxnCommand_Compact        uint16 = 3006
+	IOET_WALTxnCommand_Merge          uint16 = 3007
+	IOET_WALTxnCommand_FlushTableTail uint16 = 3014
 
-	IOET_WALTxnCommand_Compact_V1 uint16 = 1
-	IOET_WALTxnCommand_Merge_V1   uint16 = 1
+	IOET_WALTxnCommand_Compact_V1        uint16 = 1
+	IOET_WALTxnCommand_Merge_V1          uint16 = 1
+	IOET_WALTxnCommand_FlashTableTail_V1 uint16 = 1
 
-	IOET_WALTxnCommand_Compact_CurrVer = IOET_WALTxnCommand_Compact_V1
-	IOET_WALTxnCommand_Merge_CurrVer   = IOET_WALTxnCommand_Merge_V1
+	IOET_WALTxnCommand_Compact_CurrVer        = IOET_WALTxnCommand_Compact_V1
+	IOET_WALTxnCommand_Merge_CurrVer          = IOET_WALTxnCommand_Merge_V1
+	IOET_WALTxnCommand_FlushTableTail_CurrVer = IOET_WALTxnCommand_FlashTableTail_V1
 )
 
 func init() {
@@ -50,6 +53,18 @@ func init() {
 		nil,
 		func(b []byte) (any, error) {
 			cmd := new(mergeBlocksCmd)
+			err := cmd.UnmarshalBinary(b)
+			return cmd, err
+		},
+	)
+	objectio.RegisterIOEnrtyCodec(
+		objectio.IOEntryHeader{
+			Type:    IOET_WALTxnCommand_FlushTableTail,
+			Version: IOET_WALTxnCommand_FlashTableTail_V1,
+		},
+		nil,
+		func(b []byte) (any, error) {
+			cmd := new(flushTableTailCmd)
 			err := cmd.UnmarshalBinary(b)
 			return cmd, err
 		},

--- a/pkg/vm/engine/tae/tables/updates/delete.go
+++ b/pkg/vm/engine/tae/tables/updates/delete.go
@@ -208,7 +208,7 @@ func (node *DeleteNode) PrepareCommit() (err error) {
 	node.chain.Load().mvcc.Lock()
 	defer node.chain.Load().mvcc.Unlock()
 	if node.nt == NT_Persisted {
-		if node.chain.Load().HasDeleteIntentsPreparedInLocked(node.Start, node.Txn.GetPrepareTS()) {
+		if found, _ := node.chain.Load().HasDeleteIntentsPreparedInLocked(node.Start, node.Txn.GetPrepareTS()); found {
 			return txnif.ErrTxnNeedRetry
 		}
 	}
@@ -328,6 +328,10 @@ func (node *DeleteNode) StringLocked() string {
 	if node.nt == NT_Persisted {
 		ntype = "PERSISTED"
 	}
+	dtype := "N"
+	if node.dt == handle.DT_MergeCompact {
+		dtype = "MC"
+	}
 	commitState := "C"
 	if node.GetEnd() == txnif.UncommitTS {
 		commitState = "UC"
@@ -339,7 +343,7 @@ func (node *DeleteNode) StringLocked() string {
 	case NT_Persisted:
 		payload = fmt.Sprintf("[delta=%s]", node.deltaloc.String())
 	}
-	s := fmt.Sprintf("[%s:%s]%s%s", ntype, commitState, payload, node.TxnMVCCNode.String())
+	s := fmt.Sprintf("[%s:%s:%s]%s%s", ntype, commitState, dtype, payload, node.TxnMVCCNode.String())
 	return s
 }
 

--- a/pkg/vm/engine/tae/tables/updates/mvcc.go
+++ b/pkg/vm/engine/tae/tables/updates/mvcc.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -30,6 +31,23 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
 )
+
+var (
+	AppendNodeApproxSize int
+	DeleteNodeApproxSize int
+
+	DeleteChainApproxSize int
+	MVCCHandleApproxSize  int
+)
+
+func init() {
+	txnNodeSize := int(unsafe.Sizeof(txnbase.TxnMVCCNode{}))
+	AppendNodeApproxSize = int(unsafe.Sizeof(AppendNode{})) + txnNodeSize
+	DeleteNodeApproxSize = int(unsafe.Sizeof(DeleteNode{})) + txnNodeSize
+
+	DeleteChainApproxSize = int(unsafe.Sizeof(DeleteChain{}))
+	MVCCHandleApproxSize = int(unsafe.Sizeof(MVCCHandle{}))
+}
 
 type MVCCHandle struct {
 	*sync.RWMutex
@@ -70,6 +88,14 @@ func (n *MVCCHandle) StringLocked() string {
 	}
 	s = fmt.Sprintf("%s\n%s", s, n.appends.StringLocked())
 	return s
+}
+
+func (n *MVCCHandle) EstimateMemSizeLocked() int {
+	size := n.deletes.Load().EstimateMemSizeLocked()
+	if n.appends != nil {
+		size += len(n.appends.MVCC) * AppendNodeApproxSize
+	}
+	return size + MVCCHandleApproxSize
 }
 
 // ==========================================================

--- a/pkg/vm/engine/tae/txn/txnimpl/block.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/block.go
@@ -258,7 +258,7 @@ func (blk *txnBlock) GetColumnDataByIds(ctx context.Context, colIdxes []int) (*c
 	return blk.entry.GetBlockData().GetColumnDataByIds(ctx, blk.Txn, blk.table.GetLocalSchema(), colIdxes)
 }
 
-func (blk *txnBlock) Prefetch(idxes []uint16) error {
+func (blk *txnBlock) Prefetch(idxes []int) error {
 	schema := blk.table.GetLocalSchema()
 	seqnums := make([]uint16, 0, len(idxes))
 	for _, idx := range idxes {

--- a/pkg/vm/engine/tae/txn/txnimpl/sysblock.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/sysblock.go
@@ -377,7 +377,7 @@ func (blk *txnSysBlock) GetColumnDataById(ctx context.Context, colIdx int) (view
 	}
 }
 
-func (blk *txnSysBlock) Prefetch(idxes []uint16) error {
+func (blk *txnSysBlock) Prefetch(idxes []int) error {
 	return nil
 }
 

--- a/pkg/vm/engine/tae/txn/txnimpl/table.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table.go
@@ -254,9 +254,10 @@ func (tbl *txnTable) recurTransferDelete(
 	if err = tbl.RangeDelete(newID, offset, offset, pk, handle.DT_Normal); err != nil {
 		return err
 	}
-	common.DoIfDebugEnabled(func() {
-		logutil.Debugf("depth-%d transfer delete from blk-%s row-%d to blk-%s row-%d",
+	common.DoIfInfoEnabled(func() {
+		logutil.Infof("depth-%d %s transfer delete from blk-%s row-%d to blk-%s row-%d",
 			depth,
+			tbl.schema.Name,
 			id.BlockID.String(),
 			row,
 			blockID.String(),
@@ -866,6 +867,7 @@ func (tbl *txnTable) UpdateMetaLoc(id *common.ID, metaLoc objectio.Location) (er
 	if err != nil {
 		return
 	}
+	tbl.store.txn.GetMemo().AddBlock(tbl.entry.GetDB().ID, id.TableID, &id.BlockID)
 	if isNewNode {
 		tbl.txnEntries.Append(meta)
 	}
@@ -885,6 +887,7 @@ func (tbl *txnTable) UpdateDeltaLoc(id *common.ID, deltaloc objectio.Location) (
 	if err != nil {
 		return
 	}
+	tbl.store.txn.GetMemo().AddBlock(tbl.entry.GetDB().ID, id.TableID, &id.BlockID)
 	if isNewNode {
 		tbl.txnEntries.Append(meta)
 	}

--- a/test/distributed/cases/function/table_func_metadata_scan.result
+++ b/test/distributed/cases/function/table_func_metadata_scan.result
@@ -36,10 +36,10 @@ a    8192    0    32806
 select col_name, rows_cnt, null_cnt, origin_size from metadata_scan('table_func_metadata_scan.t', '*') g;
 col_name    rows_cnt    null_cnt    origin_size
 a    8192    0    32806
-b    8192    4096    197698
+b    8192    4096    197690
 select sum(origin_size) from metadata_scan('table_func_metadata_scan.t', '*') g;
 sum(origin_size)
-230504
+230496
 select approx_count(*) from t;
 approx_count(*)
 8192


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10531 #10527

## What this PR does / why we need it:

1. flush table changes in one flush task, avoiding a lot amount of flush task for every block
2. write deletes from different blocks into one block, reduce IO load
3. merging is allowed when updating actively
4. many other bug fixes