### PR TITLE
set default max active user transactions

### DIFF
--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -345,6 +345,9 @@ func (c *Config) Validate() error {
 	if c.Txn.MaxActiveAges.Duration == 0 {
 		c.Txn.MaxActiveAges.Duration = time.Minute * 2
 	}
+	if c.Txn.MaxActive == 0 {
+		c.Txn.MaxActive = runtime.NumCPU() * 4
+	}
 	c.Ctl.Adjust(foundMachineHost, defaultCtlListenAddress)
 	c.LockService.ServiceID = c.UUID
 	c.LockService.Validate()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
use cpu numbers * 4 as default max active user txns.