### PR TITLE
[Enhancement]: proxy do not connect to cn if it cannot connect to.

### DIFF
--- a/pkg/proxy/router.go
+++ b/pkg/proxy/router.go
@@ -87,6 +87,9 @@ func (s *CNServer) Connect() (goetty.IOSession, error) {
 	if err != nil {
 		return nil, newConnectErr(err)
 	}
+	if len(s.salt) != 20 {
+		return nil, moerr.NewInternalErrorNoCtx("salt is empty")
+	}
 	// When build connection with backend server, proxy send its salt
 	// to make sure the backend server uses the same salt to do authentication.
 	if err := c.Write(s.salt, goetty.WriteOptions{Flush: true}); err != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11162

## What this PR does / why we need it:
Prevoisly, the connect() mothod in porxy only return retryable error when
the cn pod is down and could not connect to, and it is not enough. We 
add a timeout check in handshake phase to return a timeout error if the
CN server is hang.