### PR TITLE
fix missing deadlock check

### DIFF
--- a/pkg/lockservice/lock_table_local_test.go
+++ b/pkg/lockservice/lock_table_local_test.go
@@ -430,6 +430,7 @@ func TestMergeRangeWithNoConflict(t *testing.T) {
 					var wg sync.WaitGroup
 					for _, txnID := range c.existsWaiters[i] {
 						w := acquireWaiter("", []byte(txnID))
+						w.belongTo = pb.WaitTxn{CreatedOn: "s1", TxnID: []byte(txnID)}
 						w.setStatus("", blocking)
 						lock.waiter.add("", true, w)
 						wg.Add(1)

--- a/pkg/lockservice/txn.go
+++ b/pkg/lockservice/txn.go
@@ -173,7 +173,13 @@ func (txn *activeTxn) abort(
 	}
 }
 
-func (txn *activeTxn) clearBlocked(txnID []byte) {
+func (txn *activeTxn) clearBlocked(txnID []byte, w *waiter) {
+	ws := txn.blockedWaiters[:0]
+	for _, v := range txn.blockedWaiters {
+		if v != w {
+			ws = append(ws, v)
+		}
+	}
 	txn.blockedWaiters = txn.blockedWaiters[:0]
 }
 

--- a/pkg/lockservice/txn.go
+++ b/pkg/lockservice/txn.go
@@ -180,7 +180,7 @@ func (txn *activeTxn) clearBlocked(txnID []byte, w *waiter) {
 			ws = append(ws, v)
 		}
 	}
-	txn.blockedWaiters = txn.blockedWaiters[:0]
+	txn.blockedWaiters = ws
 }
 
 func (txn *activeTxn) setBlocked(txnID []byte, w *waiter) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
1. Transaction A's waiting list is [B, C, D]. Means [B, C, D] wait A. If A closed, B will get the lock, so wait relation is changed, [C, D] wait A -> [C, D] wait B. So C, D need check deadlock with B.

2. When a transaction has not been locked for a long time, it is possible that the deadlock detection was missed, rejoin the deadlock detection queue