### PR TITLE
impove trace mem usage in Debug api

### DIFF
--- a/pkg/util/export/merge_test.go
+++ b/pkg/util/export/merge_test.go
@@ -316,6 +316,8 @@ func TestMergeTaskExecutorFactory(t *testing.T) {
 	ts, err := time.Parse("2006-01-02 15:04:05", targetDate+" 00:00:00")
 	require.Nil(t, err)
 
+	ctx := trace.Generate(context.TODO())
+
 	type args struct {
 		ctx  context.Context
 		opts []MergeOption
@@ -329,7 +331,7 @@ func TestMergeTaskExecutorFactory(t *testing.T) {
 		{
 			name: "normal",
 			args: args{
-				ctx:  context.Background(),
+				ctx:  ctx,
 				opts: []MergeOption{WithFileService(fs)},
 				task: task.Task{
 					Metadata: task.TaskMetadata{

--- a/pkg/util/trace/noop_trace.go
+++ b/pkg/util/trace/noop_trace.go
@@ -46,8 +46,10 @@ func (t NoopTracer) Start(ctx context.Context, name string, opts ...SpanStartOpt
 	if _, ok := span.(NoopSpan); !ok {
 		// span is likely already a NoopSpan, but let's be sure
 		span = NoopSpan{}
+		return ContextWithSpan(ctx, span), span
+	} else {
+		return ctx, span
 	}
-	return ContextWithSpan(ctx, span), span
 }
 
 func (t NoopTracer) Debug(ctx context.Context, name string, opts ...SpanStartOption) (context.Context, Span) {

--- a/pkg/util/trace/noop_trace.go
+++ b/pkg/util/trace/noop_trace.go
@@ -47,9 +47,17 @@ func (t NoopTracer) Start(ctx context.Context, name string, opts ...SpanStartOpt
 		// span is likely already a NoopSpan, but let's be sure
 		span = NoopSpan{}
 		return ContextWithSpan(ctx, span), span
-	} else {
-		return ctx, span
+	} else if len(opts) > 0 {
+		var sc = SpanConfig{}
+		for _, opt := range opts {
+			opt.ApplySpanStart(&sc)
+		}
+		if sc.NewRoot {
+			span = NoopSpan{}
+			return ContextWithSpan(ctx, span), span
+		}
 	}
+	return ctx, span
 }
 
 func (t NoopTracer) Debug(ctx context.Context, name string, opts ...SpanStartOption) (context.Context, Span) {

--- a/pkg/util/trace/noop_trace_test.go
+++ b/pkg/util/trace/noop_trace_test.go
@@ -201,6 +201,17 @@ func Test_NoopTracer_Start(t1 *testing.T) {
 			want1: NoopSpan{},
 		},
 		{
+			name: "empty",
+			args: args{
+				ctx:   context.Background(),
+				name:  "NoopTracer_Start",
+				in2:   []SpanStartOption{},
+				endIn: []SpanEndOption{},
+			},
+			want:  context.Background(),
+			want1: NoopSpan{},
+		},
+		{
 			name: "NonRecording",
 			args: args{
 				ctx:   ContextWithSpan(context.Background(), &NonRecordingSpan{}),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #  (from WeCom group)

## What this PR does / why we need it:

modification: reduce `context.Context` allocation in `trace.Debug`

improvment: 
- mem cost reduced from 200+MB to a few Bytes. Test by benchmark: `BenchmarkWithoutConflict`

test cmd: 
```
cd .../matrixone/pkg/lockservice
go test -test.bench BenchmarkWithoutConflict -test.run ^$ -test.benchtime 1s -test.memprofile ..../alloc.pprof
```

- improved pprof (alloc)
[improved_alloc.profile.pb.gz](https://github.com/matrixorigin/matrixone/files/12523543/improved_alloc.profile.pb.gz)

![image](https://github.com/matrixorigin/matrixone/assets/3927687/ec4b1d49-a730-4572-b49a-7b3b0e1b9aee)


- origin pprof (alloc)
[alloc.profile.pb.gz](https://github.com/matrixorigin/matrixone/files/12523525/alloc.profile.pb.gz)

![image](https://github.com/matrixorigin/matrixone/assets/3927687/26247882-de89-47a9-8273-3f1850c00a25)

