### PR TITLE
remove pipeline's wrong log

### DIFF
--- a/pkg/sql/colexec/connector/connector.go
+++ b/pkg/sql/colexec/connector/connector.go
@@ -17,7 +17,6 @@ package connector
 import (
 	"bytes"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
-	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -42,15 +41,17 @@ func Call(_ int, proc *process.Process, arg any, _ bool, _ bool) (process.ExecSt
 		return process.ExecNext, nil
 	}
 
+	// there is no need to log anything here.
+	// because the context is already canceled means the pipeline closed normally.
 	select {
 	case <-proc.Ctx.Done():
 		proc.PutBatch(bat)
-		logutil.Warn("proc context done during connector send")
 		return process.ExecStop, nil
+
 	case <-reg.Ctx.Done():
 		proc.PutBatch(bat)
-		logutil.Warn("reg.Ctx done during connector send")
 		return process.ExecStop, nil
+
 	case reg.Ch <- bat:
 		proc.SetInputBatch(nil)
 		return process.ExecNext, nil

--- a/pkg/sql/colexec/receiver_operator.go
+++ b/pkg/sql/colexec/receiver_operator.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
-	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -110,12 +109,10 @@ func (r *ReceiverOperator) ReceiveFromAllRegs(analyze process.Analyze) (*batch.B
 
 		// chosen == 0 means the info comes from proc context.Done
 		if chosen == 0 {
-			logutil.Debugf("process context done during merge receive")
 			return nil, true, nil
 		}
 
 		if !ok {
-			logutil.Errorf("children pipeline closed unexpectedly")
 			r.RemoveChosen(chosen)
 			return nil, true, nil
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
context done is an expected performance for pipeline, it means pipeline ends normally.
So it is no need to write logs for those situations.