### PR TITLE
Fix frontend log fromat

### DIFF
--- a/pkg/frontend/cmd_executor.go
+++ b/pkg/frontend/cmd_executor.go
@@ -16,6 +16,7 @@ package frontend
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -206,7 +207,7 @@ func Execute(ctx context.Context, ses *Session, proc *process.Process, stmtExec 
 
 	// only log if time of compile is longer than 1s
 	if time.Since(cmpBegin) > time.Second {
-		logInfo(ses, "time of Exec.Build : %s", time.Since(cmpBegin).String())
+		logInfo(ses, ses.GetDebugString(), fmt.Sprintf("time of Exec.Build : %s", time.Since(cmpBegin).String()))
 	}
 
 	err = stmtExec.ResponseBeforeExec(ctx, ses)
@@ -223,7 +224,7 @@ func Execute(ctx context.Context, ses *Session, proc *process.Process, stmtExec 
 
 	// only log if time of run is longer than 1s
 	if time.Since(runBegin) > time.Second {
-		logInfo(ses, "time of Exec.Run : %s", time.Since(runBegin).String())
+		logInfo(ses, ses.GetDebugString(), fmt.Sprintf("time of Exec.Run : %s", time.Since(runBegin).String()))
 	}
 
 	_ = stmtExec.RecordExecPlan(ctx)

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -3169,7 +3169,7 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 
 	// only log if build time is longer than 1s
 	if time.Since(cmpBegin) > time.Second {
-		logInfo(ses, "time of Exec.Build : %s", time.Since(cmpBegin).String())
+		logInfo(ses, ses.GetDebugString(), fmt.Sprintf("time of Exec.Build : %s", time.Since(cmpBegin).String()))
 	}
 
 	mrs = ses.GetMysqlResultSet()
@@ -3265,7 +3265,7 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 
 		// only log if run time is longer than 1s
 		if time.Since(runBegin) > time.Second {
-			logInfo(ses, "time of Exec.Run : %s", time.Since(runBegin).String())
+			logInfo(ses, ses.GetDebugString(), fmt.Sprintf("time of Exec.Run : %s", time.Since(runBegin).String()))
 		}
 
 		/*
@@ -3347,7 +3347,7 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 
 		// only log if run time is longer than 1s
 		if time.Since(runBegin) > time.Second {
-			logInfo(ses, "time of Exec.Run : %s", time.Since(runBegin).String())
+			logInfo(ses, ses.GetDebugString(), fmt.Sprintf("time of Exec.Run : %s", time.Since(runBegin).String()))
 		}
 
 		if runResult == nil {
@@ -3357,7 +3357,7 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 		}
 		echoTime := time.Now()
 
-		logDebug(ses, "time of SendResponse %s", time.Since(echoTime).String())
+		logDebug(ses, ses.GetDebugString(), fmt.Sprintf("time of SendResponse %s", time.Since(echoTime).String()))
 
 		/*
 			Step 4: Serialize the execution plan by json
@@ -3416,7 +3416,7 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 
 		// only log if run time is longer than 1s
 		if time.Since(runBegin) > time.Second {
-			logInfo(ses, "time of Exec.Run : %s", time.Since(runBegin).String())
+			logInfo(ses, ses.GetDebugString(), fmt.Sprintf("time of Exec.Run : %s", time.Since(runBegin).String()))
 		}
 
 		if cwft, ok := cw.(*TxnComputationWrapper); ok {

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -1184,7 +1184,7 @@ func (mp *MysqlProtocolImpl) authenticateUser(ctx context.Context, authResponse 
 
 			//TO Check password
 			if len(psw) == 0 || mp.checkPassword(psw, mp.GetSalt(), authResponse) {
-				logInfo(mp.ses, "check password succeeded", "")
+				logInfo(mp.ses, mp.ses.GetDebugString(), "check password succeeded")
 			} else {
 				return moerr.NewInternalError(ctx, "check password failed")
 			}

--- a/pkg/util/export/table/table_test.go
+++ b/pkg/util/export/table/table_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -380,6 +382,57 @@ func TestTimeField(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			f := TimeField(tt.args.val)
 			assert.Equalf(t, tt.want, f.GetTime(), "TimeField(%v)", tt.args.val)
+		})
+	}
+}
+
+// BenchmarkTimeField
+//
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/matrixorigin/matrixone/pkg/util/export/table
+// BenchmarkTimeField
+// BenchmarkTimeField/uuid.string
+// BenchmarkTimeField/uuid.string-10         	31779484	        39.32 ns/op
+// BenchmarkTimeField/EncodeUUIDHex
+// BenchmarkTimeField/EncodeUUIDHex-10       	33151078	        37.44 ns/op
+// PASS
+func BenchmarkTimeField(b *testing.B) {
+	type args struct {
+		val [16]byte
+	}
+	benchmarks := []struct {
+		name string
+		args args
+		op   func(val [16]byte)
+	}{
+		{
+			name: "uuid.string",
+			args: args{
+				val: uuid.New(),
+			},
+			op: func(val [16]byte) {
+				_ = uuid.UUID(val).String()
+			},
+		},
+		{
+			name: "EncodeUUIDHex",
+			args: args{
+				val: uuid.New(),
+			},
+			op: func(val [16]byte) {
+				var bytes [36]byte
+				util.EncodeUUIDHex(bytes[:], val[:])
+				_ = string(bytes[:])
+			},
+		},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				bm.op(bm.args.val)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

changes:
1. correct frontend log `caller` location, like: `frontend/util.go:524` -> `frontend/mysql_cmd_executor.go:3268`
2. correct frontend `logInfo()` params, like: `logInfo(ses, msg, params)` -> `logInfo(ses, info, fmt.Sprintf(msg, params))`
3. correct frontend log fields's value: `session_id` and `statement_id`.

check log:
```
mysql> select sleep(2);
```
- new log format
```
{"level":"INFO","time":"2023/09/07 14:59:33.889767 +0800","name":"log-service.frontend","caller":"frontend/mysql_cmd_executor.go:3268","msg":"time of Exec.Run : 2.000382875s","uuid":"7c4dccb4-4d3c-41f8-b482-5251dc7a41bf","session_info":"connectionId 29422|127.0.0.1:51489|{account sys:dump:moadmin -- 0:1:0}|goRoutineId 7626|1604ddce-4d4c-11ee-a647-3ebf9f3960c8","session_id":"1604ddce-4d4c-11ee-a647-3ebf9f3960c8","statement_id":"187ef814-4d4c-11ee-a647-3ebf9f3960c8"}
```

- original log format
```
{"level":"INFO","time":"2023/09/04 15:27:42.086417 +0800","caller":"frontend/util.go:524","msg":"10.000170333s","session_info":"time of Exec.Run : %s","session_id":"\ufffd\ufffd\u000e\ufffdJ\ufffd\u0011\ufffd\ufffd%>\ufffd\ufffd9`\ufffd","statement_id":"\ufffd\ufffdi\ufffdJ\ufffd\u0011\ufffd\ufffd%>\ufffd\ufffd9`\ufffd"}
```