### PR TITLE
fix release lock multi-times

### DIFF
--- a/pkg/lockservice/lock.go
+++ b/pkg/lockservice/lock.go
@@ -83,22 +83,22 @@ func (l Lock) isEmpty() bool {
 		(l.waiters == nil || l.waiters.size() == 0)
 }
 
-func (l Lock) tryHold(c *lockContext) bool {
+func (l Lock) tryHold(c *lockContext) (bool, bool) {
 	if l.isEmpty() {
 		panic("BUG: try hold on empty lock")
 	}
 
 	// txn already hold the lock
 	if l.holders.contains(c.txn.txnID) {
-		return true
+		return true, false
 	}
 
 	if l.canHold(c) {
 		l.addHolder(c)
-		return true
+		return true, true
 	}
 
-	return false
+	return false, false
 }
 
 // (no holders && is first waiter txn) || (both shared lock) can hold lock

--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -105,6 +105,7 @@ func (l *localLockTable) doLock(
 			if err != nil {
 				logLocalLockFailed(c.txn, table, c.rows, c.opts, err)
 				if c.w != nil {
+					c.w.disableNotify()
 					c.w.close()
 				}
 				c.done(err)
@@ -286,6 +287,7 @@ func (l *localLockTable) acquireRowLockLocked(c *lockContext) error {
 			hold, newHolder := lock.tryHold(c)
 			if hold {
 				if c.w != nil {
+					c.w.disableNotify()
 					c.w.close()
 					c.w = nil
 				}

--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -404,9 +404,17 @@ func (l *localLockTable) addRangeLockLocked(
 		if ok1 && ok2 &&
 			l1.isShared() && l2.isShared() &&
 			l1.isLockRangeStart() && l2.isLockRangeEnd() {
-			l1.tryHold(c)
-			l2.tryHold(c)
-			c.txn.lockAdded(l.bind.Table, [][]byte{start, end})
+			hold, newHolder := l1.tryHold(c)
+			if !hold {
+				panic("BUG: must get shared lock")
+			}
+			hold, _ = l2.tryHold(c)
+			if !hold {
+				panic("BUG: must get shared lock")
+			}
+			if newHolder {
+				c.txn.lockAdded(l.bind.Table, [][]byte{start, end})
+			}
 			return nil, Lock{}, nil
 		}
 	}

--- a/pkg/lockservice/lock_table_local_test.go
+++ b/pkg/lockservice/lock_table_local_test.go
@@ -854,3 +854,53 @@ type target struct {
 	Start string `json:"start"`
 	End   string `json:"end"`
 }
+
+func TestCannotBlockByDeadlockBusyCheck(t *testing.T) {
+	table := uint64(1)
+
+	cases := []struct {
+		option pb.LockOptions
+		rows   [][]byte
+	}{
+		{
+			option: newTestRowExclusiveOptions(),
+			rows:   newTestRows(1),
+		},
+		{
+			option: newTestRangeExclusiveOptions(),
+			rows:   newTestRows(1, 2),
+		},
+	}
+
+	for _, c := range cases {
+		getRunner(false)(
+			t,
+			table,
+			func(
+				ctx context.Context,
+				s *service,
+				lt *localLockTable) {
+				s.deadlockDetector.mu.Lock()
+				s.deadlockDetector.mu.preCheckFunc = func(holdTxnID []byte, txn pb.WaitTxn) error {
+					return ErrDeadlockCheckBusy
+				}
+				s.deadlockDetector.mu.Unlock()
+
+				txn1 := newTestTxnID(1)
+
+				_, err := s.Lock(ctx, table, c.rows, txn1, c.option)
+				require.NoError(t, err)
+
+				defer func() {
+					assert.NoError(t, s.Unlock(ctx, txn1, timestamp.Timestamp{}))
+				}()
+
+				// txn2 will failed by busy check
+				txn2 := newTestTxnID(2)
+				_, err = s.Lock(ctx, table, c.rows, txn2, c.option)
+				require.Equal(t, ErrDeadlockCheckBusy, err)
+			},
+		)
+	}
+
+}

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -338,7 +338,7 @@ func (s *service) handleFetchWhoWaitingMe(ctx context.Context) {
 				"")
 			if txn == nil {
 				writeResponse(w.ctx, w.cancel, w.resp, nil, w.cs)
-				return
+				continue
 			}
 			txn.fetchWhoWaitingMe(
 				s.cfg.ServiceID,

--- a/pkg/lockservice/waiter.go
+++ b/pkg/lockservice/waiter.go
@@ -203,6 +203,14 @@ func (w *waiter) wait(ctx context.Context) notifyValue {
 	return w.mustRecvNotification(ctx)
 }
 
+func (w *waiter) disableNotify() {
+	w.setStatus(completed)
+	select {
+	case <-w.c:
+	default:
+	}
+}
+
 // notify return false means this waiter is completed, cannot be used to notify
 func (w *waiter) notify(value notifyValue) bool {
 	debug := ""


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11670 

## What this PR does / why we need it:
Currently our pipeline will result in concurrent locking for the same transaction, e.g. update will have 2 operations insert and delete, which will concurrently add the same lock. Due to concurrency, if an operation acquires a lock and records the lock in the transaction's lock-holding slice, then when another transaction acquires the lock, it can't add the lock to the transaction again, or else let a lock be released multiple times at the end of the transaction.