### PR TITLE
[bug] incre: bootstrap fails occasionally as the txn is not set.

### DIFF
--- a/pkg/incrservice/service_test.go
+++ b/pkg/incrservice/service_test.go
@@ -76,7 +76,7 @@ func TestCreateOnOtherService(t *testing.T) {
 			require.NoError(t, op.Commit(ctx))
 
 			s2 := ss[0]
-			_, err := s2.getCommittedTableCache(ctx, 0)
+			_, err := s2.getCommittedTableCache(ctx, 0, nil)
 			require.NoError(t, err)
 			s2.mu.Lock()
 			assert.Equal(t, 1, len(s2.mu.tables))

--- a/pkg/incrservice/types.go
+++ b/pkg/incrservice/types.go
@@ -51,9 +51,9 @@ type AutoIncrementService interface {
 	// delete operation is triggered.
 	Delete(ctx context.Context, tableID uint64, txn client.TxnOperator) error
 	// InsertValues insert auto columns values into bat.
-	InsertValues(ctx context.Context, tableID uint64, bat *batch.Batch) (uint64, error)
+	InsertValues(ctx context.Context, tableID uint64, bat *batch.Batch, txn client.TxnOperator) (uint64, error)
 	// CurrentValue return current incr column value.
-	CurrentValue(ctx context.Context, tableID uint64, col string) (uint64, error)
+	CurrentValue(ctx context.Context, tableID uint64, col string, txn client.TxnOperator) (uint64, error)
 	// Close close the auto increment service
 	Close()
 }

--- a/pkg/sql/colexec/preinsert/preinsert.go
+++ b/pkg/sql/colexec/preinsert/preinsert.go
@@ -111,7 +111,8 @@ func genAutoIncrCol(bat *batch.Batch, proc *proc, arg *Argument) error {
 	lastInsertValue, err := proc.IncrService.InsertValues(
 		proc.Ctx,
 		arg.TableDef.TblId,
-		bat)
+		bat,
+		proc.TxnOperator)
 	if err != nil {
 		if moerr.IsMoErrCode(err, moerr.ErrNoSuchTable) {
 			return moerr.NewNoSuchTableNoCtx(arg.SchemaName, arg.TableDef.Name)

--- a/pkg/sql/plan/function/auto_increase.go
+++ b/pkg/sql/plan/function/auto_increase.go
@@ -22,6 +22,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/incrservice"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/functionUtil"
+	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
@@ -61,7 +62,8 @@ func builtInInternalAutoIncrement(parameters []*vector.Vector, result vector.Fun
 			autoIncrement, err := getCurrentValue(
 				proc.Ctx,
 				tableId,
-				autoIncrCol)
+				autoIncrCol,
+				proc.TxnOperator)
 			if err != nil {
 				return err
 			}
@@ -92,9 +94,11 @@ func getTableAutoIncrCol(
 func getCurrentValue(
 	ctx context.Context,
 	tableID uint64,
-	col string) (uint64, error) {
+	col string,
+	txnOp client.TxnOperator) (uint64, error) {
 	return incrservice.GetAutoIncrementService().CurrentValue(
 		ctx,
 		tableID,
-		col)
+		col,
+		txnOp)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10750 

## What this PR does / why we need it:
There is no txn operator information in InsertValues() and CurrentValue(),
which should use it to get results from SQL store. We should pass the txn
operator into them to use the txn operator to get result from mo_increment_columns
table.