### PR TITLE
record conn type in statement_info.stats

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -209,6 +209,19 @@ func (mce *MysqlCmdExecutor) GetRoutineManager() *RoutineManager {
 	return mce.routineMgr
 }
 
+func transferSessionConnType2StatisticConnType(c ConnType) statistic.ConnType {
+	switch c {
+	case ConnTypeUnset:
+		return statistic.ConnTypeUnknown
+	case ConnTypeInternal:
+		return statistic.ConnTypeInternal
+	case ConnTypeExternal:
+		return statistic.ConnTypeExternal
+	default:
+		panic("unknown connection type")
+	}
+}
+
 var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Process, cw ComputationWrapper, envBegin time.Time, envStmt, sqlType string, useEnv bool) context.Context {
 	// set StatementID
 	var stmID uuid.UUID
@@ -277,6 +290,7 @@ var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Proc
 	stm.RequestAt = requestAt
 	stm.StatementType = getStatementType(statement).GetStatementType()
 	stm.QueryType = getStatementType(statement).GetQueryType()
+	stm.ConnType = transferSessionConnType2StatisticConnType(ses.connType)
 	if sqlType == constant.InternalSql && isCmdFieldListSql(envStmt) {
 		// fix original issue #8165
 		stm.User = ""

--- a/pkg/util/trace/impl/motrace/buffer_pipe_test.go
+++ b/pkg/util/trace/impl/motrace/buffer_pipe_test.go
@@ -448,7 +448,7 @@ log_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000
 				},
 				buf: buf,
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[2,0,0,0,0,0]",,,0,,0,0
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
 `,
 		},
 		{
@@ -489,8 +489,8 @@ log_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000
 				},
 				buf: buf,
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[2,0,0,0,0,0]",,,0,,0,0
-00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,"[2,0,0,0,0,0]",,,0,,0,0
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
+00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
 `,
 		},
 		{
@@ -567,7 +567,7 @@ func Test_genCsvData_diffAccount(t *testing.T) {
 				buf: buf,
 			},
 			wantReqCnt: 1,
-			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[2,0,0,0,0,0]",,,0,,0,0
+			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
 `},
 		},
 		{
@@ -609,8 +609,8 @@ func Test_genCsvData_diffAccount(t *testing.T) {
 				buf: buf,
 			},
 			wantReqCnt: 1,
-			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[2,0,0,0,0,0]",,,0,,0,0
-`, `00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,sys,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,"[2,0,0,0,0,0]",,,0,,0,0
+			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
+`, `00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,sys,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
 `},
 		},
 	}
@@ -707,9 +707,9 @@ func Test_genCsvData_LongQueryTime(t *testing.T) {
 				buf:    buf,
 				queryT: int64(time.Second),
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[2,0,0,0,0,0]",,,0,,0,1
-00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""no exec plan""}",0,0,"[2,0,0,0,0,0]",,,0,,0,2
-00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000000000,Failed,20101,internal error: test error,"{""key"":""val""}",1,1,"[2,1,2.000,3,4,5]",,,0,internal,0,3
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""success"":false,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,1
+00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""no exec plan""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,2
+00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000000000,Failed,20101,internal error: test error,"{""key"":""val""}",1,1,"[3,1,2.000,3,4,5,0]",,,0,internal,0,3
 `,
 		},
 	}

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -177,6 +177,8 @@ type StatementInfo struct {
 
 	ResultCount int64 `json:"result_count"` // see EndStatement
 
+	ConnType statistic.ConnType `json:"-"` // see frontend.RecordStatement
+
 	// flow ctrl
 	// #		|case 1 |case 2 |case 3 |case 4|
 	// end		| false | false | true  | true |  (set true at EndStatement)
@@ -415,6 +417,7 @@ func (s *StatementInfo) ExecPlan2Stats(ctx context.Context) []byte {
 	} else {
 		statsArray, stats = s.ExecPlan.Stats(ctx)
 		s.statsArray.InitIfEmpty().Add(&statsArray)
+		s.statsArray.WithConnType(s.ConnType)
 		s.RowsRead = stats.RowsRead
 		s.BytesScan = stats.BytesScan
 		return s.statsArray.ToJsonString()

--- a/pkg/util/trace/impl/motrace/report_statement_test.go
+++ b/pkg/util/trace/impl/motrace/report_statement_test.go
@@ -311,7 +311,7 @@ func (p *dummySerializableExecPlan) Stats(ctx context.Context) (statistic.StatsA
 
 func TestMergeStats(t *testing.T) {
 	e := &StatementInfo{}
-	e.statsArray.Init().WithTimeConsumed(80335).WithMemorySize(1800).WithS3IOInputCount(1).WithS3IOOutputCount(0)
+	e.statsArray.Init().WithTimeConsumed(80335).WithMemorySize(1800).WithS3IOInputCount(1).WithS3IOOutputCount(0).WithConnType(statistic.ConnTypeInternal)
 
 	n := &StatementInfo{}
 	n.statsArray.Init().WithTimeConsumed(147960).WithMemorySize(1800).WithS3IOInputCount(0).WithS3IOOutputCount(0)
@@ -321,7 +321,7 @@ func TestMergeStats(t *testing.T) {
 		t.Fatalf("mergeStats failed: %v", err)
 	}
 
-	wantBytes := []byte("[2,228295,3600.000,1,0,0]")
+	wantBytes := []byte("[3,228295,3600.000,1,0,0,1]")
 	require.Equal(t, wantBytes, e.statsArray.ToJsonString())
 
 	n = &StatementInfo{}
@@ -332,7 +332,7 @@ func TestMergeStats(t *testing.T) {
 		t.Fatalf("mergeStats failed: %v", err)
 	}
 
-	wantBytes = []byte("[2,228296,3601.000,1,0,0]")
+	wantBytes = []byte("[3,228296,3601.000,1,0,0,1]")
 	require.Equal(t, wantBytes, e.statsArray.ToJsonString())
 
 }

--- a/pkg/util/trace/impl/motrace/statistic/stats_array.go
+++ b/pkg/util/trace/impl/motrace/statistic/stats_array.go
@@ -26,11 +26,12 @@ const (
 )
 
 const (
-	StatsArrayVersion = StatsArrayVersion2
+	StatsArrayVersion = StatsArrayVersion3
 
 	StatsArrayVersion0 = 0 // raw statistics
 	StatsArrayVersion1 = 1 // float64 array
 	StatsArrayVersion2 = 2 // float64 array + plus one elem OutTrafficBytes
+	StatsArrayVersion3 = 3 // ... + one elem: ConnType
 )
 
 const (
@@ -40,6 +41,7 @@ const (
 	StatsArrayIndexS3IOInputCount
 	StatsArrayIndexS3IOOutputCount // index: 4
 	StatsArrayIndexOutTrafficBytes // index: 5
+	StatsArrayIndexConnType        // index: 6
 
 	StatsArrayLength
 )
@@ -47,6 +49,15 @@ const (
 const (
 	StatsArrayLengthV1 = 5
 	StatsArrayLengthV2 = 6
+	StatsArrayLengthV3 = 7
+)
+
+type ConnType float64
+
+const (
+	ConnTypeUnknown  ConnType = 0
+	ConnTypeInternal ConnType = 1
+	ConnTypeExternal ConnType = 2
 )
 
 func NewStatsArray() *StatsArray {
@@ -95,6 +106,12 @@ func (s *StatsArray) GetOutTrafficBytes() float64 { // unit: byte
 	}
 	return (*s)[StatsArrayIndexOutTrafficBytes]
 }
+func (s *StatsArray) GetConnType() float64 {
+	if s.GetVersion() < StatsArrayVersion3 {
+		return 0
+	}
+	return (*s)[StatsArrayIndexConnType]
+}
 
 // WithVersion set the version array in StatsArray, please carefully to use.
 func (s *StatsArray) WithVersion(v float64) *StatsArray { (*s)[StatsArrayIndexVersion] = v; return s }
@@ -117,6 +134,13 @@ func (s *StatsArray) WithS3IOOutputCount(v float64) *StatsArray {
 func (s *StatsArray) WithOutTrafficBytes(v float64) *StatsArray {
 	if s.GetVersion() >= StatsArrayVersion2 {
 		(*s)[StatsArrayIndexOutTrafficBytes] = v
+	}
+	return s
+}
+
+func (s *StatsArray) WithConnType(v ConnType) *StatsArray {
+	if s.GetVersion() >= StatsArrayVersion3 {
+		(*s)[StatsArrayIndexConnType] = float64(v)
 	}
 	return s
 }

--- a/pkg/util/trace/impl/motrace/statistic/stats_array.go
+++ b/pkg/util/trace/impl/motrace/statistic/stats_array.go
@@ -70,6 +70,10 @@ func NewStatsArrayV1() *StatsArray {
 }
 
 func NewStatsArrayV2() *StatsArray {
+	return NewStatsArray().WithVersion(StatsArrayVersion2)
+}
+
+func NewStatsArrayV3() *StatsArray {
 	return NewStatsArray()
 }
 
@@ -146,19 +150,30 @@ func (s *StatsArray) WithConnType(v ConnType) *StatsArray {
 }
 
 func (s *StatsArray) ToJsonString() []byte {
-	if s.GetVersion() == StatsArrayVersion1 {
+	switch s.GetVersion() {
+	case StatsArrayVersion1:
 		return StatsArrayToJsonString((*s)[:StatsArrayLengthV1])
+	case StatsArrayVersion2:
+		return StatsArrayToJsonString((*s)[:StatsArrayLengthV2])
+	case StatsArrayVersion3:
+		return StatsArrayToJsonString((*s)[:StatsArrayLengthV3])
+	default:
+		return StatsArrayToJsonString((*s)[:])
 	}
-	return StatsArrayToJsonString((*s)[:])
 }
 
-func (s *StatsArray) Add(src *StatsArray) *StatsArray {
-	dstLen := len(*src)
-	if len(*s) < len(*src) {
+// Add do add two stats array together
+// except for Element ConnType, which idx = StatsArrayIndexConnType, just keep s[StatsArrayIndexConnType] value.
+func (s *StatsArray) Add(delta *StatsArray) *StatsArray {
+	dstLen := len(*delta)
+	if len(*s) < len(*delta) {
 		dstLen = len(*s)
 	}
 	for idx := 1; idx < dstLen; idx++ {
-		(*s)[idx] += (*src)[idx]
+		if idx == StatsArrayIndexConnType {
+			continue
+		}
+		(*s)[idx] += (*delta)[idx]
 	}
 	return s
 }

--- a/pkg/util/trace/impl/motrace/statistic/stats_array_test.go
+++ b/pkg/util/trace/impl/motrace/statistic/stats_array_test.go
@@ -233,6 +233,69 @@ func TestStatsArray_AddV2(t *testing.T) {
 	}
 }
 
+func TestStatsArray_AddV3(t *testing.T) {
+	type field struct {
+		version      float64
+		timeConsumed float64
+		memory       float64
+		s3in         float64
+		s3out        float64
+		traffic      float64
+		connType     ConnType
+	}
+	tests := []struct {
+		name       string
+		field      field
+		wantString []byte
+	}{
+		{
+			name: "normal",
+			field: field{
+				version:      1,
+				timeConsumed: 2,
+				memory:       3,
+				s3in:         4,
+				s3out:        5,
+				traffic:      6,
+				connType:     ConnTypeInternal,
+			},
+			wantString: []byte(`[3,3,5.000,7,9,11,1]`),
+		},
+		{
+			name: "random",
+			field: field{
+				version:      1,
+				timeConsumed: 65,
+				memory:       6,
+				s3in:         78,
+				s3out:        3494,
+				traffic:      456,
+				connType:     ConnTypeExternal,
+			},
+			wantString: []byte(`[3,66,8.000,81,3498,461,1]`),
+		},
+	}
+
+	getInitStatsArray := func() *StatsArray {
+		return NewStatsArrayV3().WithTimeConsumed(1).WithMemorySize(2).WithS3IOInputCount(3).WithS3IOOutputCount(4).WithOutTrafficBytes(5).WithConnType(ConnTypeInternal)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := getInitStatsArray()
+			s := NewStatsArrayV3().
+				WithTimeConsumed(tt.field.timeConsumed).
+				WithMemorySize(tt.field.memory).
+				WithS3IOInputCount(tt.field.s3in).
+				WithS3IOOutputCount(tt.field.s3out).
+				WithOutTrafficBytes(tt.field.traffic).
+				WithConnType(tt.field.connType)
+			got := dst.Add(s).ToJsonString()
+			require.Equal(t, tt.wantString, got)
+		})
+	}
+}
+
 func TestStatsArray_InitIfEmpty(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/11761
https://github.com/matrixorigin/MO-Cloud/issues/1004

## What this PR does / why we need it:
changes:
1. Record ConnType while do `RecordStatement()` in frontend
2. Add new elem `StatsArrayIndexConnType` in statistics.StatsArray
3. Modify `StatsArray.Add()` ignore StatsArray elem.
