### PR TITLE
add read timeout for lockservice remote lock

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -89,7 +89,7 @@
 /pkg/incrservice @zhangxu19830126
 
 # pkg/lockservice 
-/pkg/lockservice @zhangxu19830126 @w-zr
+/pkg/lockservice @zhangxu19830126
 
 # pkg/logservice
 /pkg/logservice @zhangxu19830126

--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -17,6 +17,7 @@ package morpc
 import (
 	"context"
 	"fmt"
+	"math"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -109,6 +110,13 @@ func WithBackendGoettyOptions(options ...goetty.Option) BackendOption {
 	}
 }
 
+// WithBackendReadTimeout set read timeout for read loop.
+func WithBackendReadTimeout(value time.Duration) BackendOption {
+	return func(rb *remoteBackend) {
+		rb.options.readTimeout = value
+	}
+}
+
 type remoteBackend struct {
 	remote      string
 	logger      *zap.Logger
@@ -123,6 +131,7 @@ type remoteBackend struct {
 	ctx         context.Context
 	cancel      context.CancelFunc
 	cancelOnce  sync.Once
+	pingTimer   *time.Timer
 
 	options struct {
 		hasPayloadResponse bool
@@ -133,6 +142,7 @@ type remoteBackend struct {
 		batchSendSize      int
 		streamBufferSize   int
 		filter             func(msg Message, backendAddr string) bool
+		readTimeout        time.Duration
 	}
 
 	stateMu struct {
@@ -266,18 +276,21 @@ func (rb *remoteBackend) SendInternal(ctx context.Context, request Message) (*Fu
 }
 
 func (rb *remoteBackend) send(ctx context.Context, request Message, internal bool) (*Future, error) {
-	request.SetID(rb.nextID())
-
-	f := rb.newFuture()
-	f.init(RPCMessage{Ctx: ctx, Message: request, internal: internal})
-	rb.addFuture(f)
-
+	f := rb.getFuture(ctx, request, internal)
 	if err := rb.doSend(f); err != nil {
 		f.Close()
 		return nil, err
 	}
 	rb.active()
 	return f, nil
+}
+
+func (rb *remoteBackend) getFuture(ctx context.Context, request Message, internal bool) *Future {
+	request.SetID(rb.nextID())
+	f := rb.newFuture()
+	f.init(RPCMessage{Ctx: ctx, Message: request, internal: internal})
+	rb.addFuture(f)
+	return f
 }
 
 func (rb *remoteBackend) NewStream(unlockAfterClose bool) (Stream, error) {
@@ -388,6 +401,7 @@ func (rb *remoteBackend) inactive() {
 func (rb *remoteBackend) writeLoop(ctx context.Context) {
 	rb.logger.Debug("write loop started")
 	defer func() {
+		rb.pingTimer.Stop()
 		rb.closeConn(false)
 		rb.readStopper.Stop()
 		rb.closeConn(true)
@@ -407,6 +421,7 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 		}
 	}()
 
+	rb.pingTimer = time.NewTimer(rb.getPingTimeout())
 	messages := make([]*Future, 0, rb.options.batchSendSize)
 	stopped := false
 	for {
@@ -510,7 +525,7 @@ func (rb *remoteBackend) readLoop(ctx context.Context) {
 			rb.clean()
 			return
 		default:
-			msg, err := rb.conn.Read(goetty.ReadOptions{})
+			msg, err := rb.conn.Read(goetty.ReadOptions{Timeout: rb.options.readTimeout})
 			if err != nil {
 				rb.logger.Error("read from backend failed", zap.Error(err))
 				rb.inactiveReadLoop()
@@ -540,34 +555,35 @@ func (rb *remoteBackend) fetch(messages []*Future, maxFetchCount int) ([]*Future
 	}
 	messages = messages[:0]
 	select {
+	case <-rb.pingTimer.C:
+		f := rb.getFuture(context.TODO(), &flagOnlyMessage{flag: flagPing}, true)
+		// no need wait response, close immediately
+		f.Close()
+		messages = rb.fetchN(append(messages, f), maxFetchCount-1)
+		rb.pingTimer.Reset(rb.getPingTimeout())
 	case f := <-rb.writeC:
-		messages = append(messages, f)
-		n := maxFetchCount - 1
-	OUTER:
-		for i := 0; i < n; i++ {
-			select {
-			case f := <-rb.writeC:
-				messages = append(messages, f)
-			default:
-				break OUTER
-			}
-		}
+		messages = rb.fetchN(append(messages, f), maxFetchCount-1)
 	case <-rb.resetConnC:
 		// If the connect needs to be reset, then all futures in the waiting response state will never
 		// get the response and need to be notified of an error immediately.
 		rb.makeAllWaitingFutureFailed()
 		rb.handleResetConn()
 	case <-rb.stopWriteC:
-		for {
-			select {
-			case f := <-rb.writeC:
-				messages = append(messages, f)
-			default:
-				return messages, true
-			}
-		}
+		return rb.fetchN(messages, math.MaxInt), true
 	}
 	return messages, false
+}
+
+func (rb *remoteBackend) fetchN(messages []*Future, n int) []*Future {
+	for i := 0; i < n; i++ {
+		select {
+		case f := <-rb.writeC:
+			messages = append(messages, f)
+		default:
+			return messages
+		}
+	}
+	return messages
 }
 
 func (rb *remoteBackend) makeAllWritesDoneWithClosed() {
@@ -839,6 +855,13 @@ func (rb *remoteBackend) newFuture() *Future {
 
 func (rb *remoteBackend) nextID() uint64 {
 	return atomic.AddUint64(&rb.atomic.id, 1)
+}
+
+func (rb *remoteBackend) getPingTimeout() time.Duration {
+	if rb.options.readTimeout > 0 {
+		return rb.options.readTimeout / 5
+	}
+	return time.Duration(math.MaxInt64)
 }
 
 type goettyBasedBackendFactory struct {

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -58,6 +58,27 @@ func TestSend(t *testing.T) {
 	)
 }
 
+func TestReadTimeout(t *testing.T) {
+	testBackendSend(t,
+		func(conn goetty.IOSession, msg interface{}, _ uint64) error {
+			// no response
+			return nil
+		},
+		func(b *remoteBackend) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+			req := newTestMessage(1)
+			f, err := b.Send(ctx, req)
+			assert.NoError(t, err)
+			defer f.Close()
+
+			_, err = f.Get()
+			assert.Error(t, err)
+		},
+		WithBackendReadTimeout(time.Millisecond*200),
+	)
+}
+
 func TestSendWithPayloadCannotTimeout(t *testing.T) {
 	testBackendSend(t,
 		func(conn goetty.IOSession, msg interface{}, _ uint64) error {

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -39,7 +39,7 @@ var (
 		},
 	}
 
-	defaultRPCTimeout = time.Second * 3
+	defaultRPCTimeout = time.Second * 10
 )
 
 type client struct {
@@ -54,6 +54,10 @@ func NewClient(cfg morpc.Config) (Client, error) {
 		cluster: clusterservice.GetMOCluster(),
 	}
 	c.cfg.Adjust()
+	// add read timeout for lockservice client, to avoid remote lock hung and cannot read the lock response
+	// due to tcp disconnected.
+	c.cfg.BackendOptions = append(c.cfg.BackendOptions,
+		morpc.WithBackendReadTimeout(defaultRPCTimeout))
 
 	client, err := c.cfg.NewClient("",
 		getLogger().RawLogger(),

--- a/pkg/lockservice/service_remote_test.go
+++ b/pkg/lockservice/service_remote_test.go
@@ -579,8 +579,7 @@ func runBindChangedTests(
 
 			c.RPC.BackendOptions = append(c.RPC.BackendOptions,
 				morpc.WithBackendFilter(func(m morpc.Message, s string) bool {
-					req := m.(*pb.Request)
-					if req.Method == pb.Method_KeepLockTableBind &&
+					if req, ok := m.(*pb.Request); ok && req.Method == pb.Method_KeepLockTableBind &&
 						req.KeepLockTableBind.ServiceID == "s1" {
 						return !skip.Load()
 					}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11838

## What this PR does / why we need it:
In our environment, it is possible to not sense a tcp disconnect, causing the remote lock to fail to return, resulting in a hung. we've added a heartbeat mechanism to morpc and added a read timeout to read to solve this problem.