### PR TITLE
[bug] distcache: limit the item count for the dist cache.

### DIFF
--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -74,7 +74,7 @@ func (c *CacheConfig) setDefaults() {
 }
 
 func (c *CacheConfig) SetRemoteCacheCallback() {
-	if c.KeyRouterFactory == nil {
+	if !c.RemoteCacheEnabled || c.KeyRouterFactory == nil {
 		return
 	}
 	c.InitKeyRouter = &sync.Once{}

--- a/pkg/gossip/delegate.go
+++ b/pkg/gossip/delegate.go
@@ -62,6 +62,9 @@ func (d *delegate) NodeMeta(limit int) []byte {
 
 // NotifyMsg implements the memberlist.Delegate interface.
 func (d *delegate) NotifyMsg(data []byte) {
+	if len(data) == 0 {
+		return
+	}
 	var item gossip.CacheKeyItem
 	if err := item.Unmarshal(data); err != nil {
 		d.logger.Error("failed to unmarshal cache item from buf", zap.Error(err))

--- a/pkg/gossip/dist_key_cache.go
+++ b/pkg/gossip/dist_key_cache.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	defaultCacheQueueSize = 100
+	maxItemCount          = 8192 * 2000 // about 1.5GB
 )
 
 // DistKeyCache keeps the key cache of local set/delete items
@@ -79,6 +80,9 @@ func (dc *DistKeyCache) AddItem(key cache.CacheKey, operation gossip.Operation) 
 	}
 	dc.queueMu.Lock()
 	defer dc.queueMu.Unlock()
+	if len(dc.queueMu.itemQueue) >= maxItemCount {
+		return
+	}
 	item := gossip.CacheKeyItem{
 		Operation:     operation,
 		CacheKey:      key,

--- a/pkg/gossip/node.go
+++ b/pkg/gossip/node.go
@@ -34,7 +34,7 @@ const (
 	// We do not need to exchange the entire data of node.
 	defaultPushPullInterval  = 0
 	defaultGossipInterval    = time.Second
-	defaultUDPBufferSize     = 64 * 1024
+	defaultUDPBufferSize     = 4 * 1024 * 1024 // 4MB
 	defaultHandoffQueueDepth = 4096
 )
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11918

## What this PR does / why we need it:
Do not set items if the remote cache is not enabled. Also, add
count limit for key cache queue, to avoid large memory occupation.