### PR TITLE
fix drop account

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -1037,7 +1037,6 @@ var (
 		`drop view if exists mo_catalog.mo_sessions;`,
 	}
 	dropMoPubsSql         = `drop table if exists mo_catalog.mo_pubs;`
-	deleteMoPubsSql       = `delete from mo_catalog.mo_pubs;`
 	dropAutoIcrColSql     = fmt.Sprintf("drop table if exists mo_catalog.`%s`;", catalog.MOAutoIncrTable)
 	dropMoIndexes         = fmt.Sprintf(`drop table if exists %s.%s;`, catalog.MO_CATALOG, catalog.MO_INDEXES)
 	dropMoTablePartitions = fmt.Sprintf(`drop table if exists %s.%s;`, catalog.MO_CATALOG, catalog.MO_TABLE_PARTITIONS)
@@ -4120,14 +4119,6 @@ func doDropAccount(ctx context.Context, ses *Session, da *tree.DropAccount) (err
 			if err != nil {
 				return err
 			}
-		}
-
-		// delete all publications
-
-		err = bh.Exec(deleteCtx, deleteMoPubsSql)
-
-		if err != nil {
-			return err
 		}
 
 		//drop databases created by user


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11747 

## What this PR does / why we need it:

原先的drop account 写死了delete from mo_pubs。如果mo_pubs不存在会报错。
去掉delete from mo_pubs。只用drop table if exists 就行了。