### PR TITLE
fix cannot allocate new cache

### DIFF
--- a/pkg/incrservice/column_cache_test.go
+++ b/pkg/incrservice/column_cache_test.go
@@ -59,7 +59,7 @@ func TestColumnCacheAllocate(t *testing.T) {
 			c *columnCache) {
 			c.Lock()
 			require.NoError(t, c.waitPrevAllocatingLocked(ctx))
-			require.NoError(t, c.allocateLocked(ctx, 0, 200, 0))
+			require.NoError(t, c.allocateLocked(ctx, 0, 200, 0, nil))
 			c.Unlock()
 
 			c.Lock()
@@ -80,7 +80,7 @@ func TestColumnCacheInsert(t *testing.T) {
 			c *columnCache) {
 			c.Lock()
 			require.NoError(t, c.waitPrevAllocatingLocked(ctx))
-			require.NoError(t, c.allocateLocked(ctx, 0, 200, 0))
+			require.NoError(t, c.allocateLocked(ctx, 0, 200, 0, nil))
 			c.Unlock()
 
 			c.Lock()
@@ -354,7 +354,8 @@ func TestOverflow(t *testing.T) {
 					func(i int, u uint64) error {
 						require.Equal(t, uint64(0), u)
 						return nil
-					}))
+					},
+					nil))
 		},
 	)
 }
@@ -380,7 +381,8 @@ func TestOverflowWithInit(t *testing.T) {
 					func(i int, u uint64) error {
 						require.Equal(t, uint64(0), u)
 						return nil
-					}))
+					},
+					nil))
 		},
 	)
 }
@@ -415,7 +417,8 @@ func TestMergeAllocate(t *testing.T) {
 							func(i int, u uint64) error {
 								added.Add(1)
 								return nil
-							})
+							},
+							nil)
 					}
 				}()
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11957

## What this PR does / why we need it:
fix cannot allocate new cache. If create auto-incr table and insert too many records, cannot allocate new incr cache again. 