### PR TITLE
Fix incorrect locking logic for inserting tables without primary keys

### DIFF
--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -325,6 +325,7 @@ func LockRows(
 	tableID uint64,
 	vec *vector.Vector,
 	pkType types.Type,
+	lockMode lock.LockMode,
 ) error {
 	if !proc.TxnOperator.Txn().IsPessimistic() {
 		return nil
@@ -335,6 +336,7 @@ func LockRows(
 
 	opts := DefaultLockOptions(parker).
 		WithLockTable(false, false).
+		WithLockMode(lockMode).
 		WithFetchLockRowsFunc(GetFetchRowsFunc(pkType))
 	_, defChanged, refreshTS, err := doLock(
 		proc.Ctx,

--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -16,6 +16,7 @@ package compile
 
 import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
@@ -41,7 +42,7 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 	if c.proc.TxnOperator.Txn().IsPessimistic() {
 		var retryErr error
 		// 1. lock origin table metadata in catalog
-		if err = lockMoTable(c, dbName, tblName); err != nil {
+		if err = lockMoTable(c, dbName, tblName, lock.LockMode_Exclusive); err != nil {
 			if !moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetry) &&
 				!moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetryWithDefChanged) {
 				return err

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -1407,11 +1407,13 @@ func (c *Compile) compileExternScan(ctx context.Context, n *plan.Node) ([]*Scope
 	defer span.End()
 
 	// lock table's meta
-	if err := lockMoTable(c, n.ObjRef.SchemaName, n.TableDef.Name, lock.LockMode_Shared); err != nil {
-		return nil, err
+	if n.ObjRef != nil && n.TableDef != nil {
+		if err := lockMoTable(c, n.ObjRef.SchemaName, n.TableDef.Name, lock.LockMode_Shared); err != nil {
+			return nil, err
+		}
 	}
 	// lock table, for tables with no primary key, there is no need to lock the data
-	if n.ObjRef != nil && c.proc.TxnOperator.Txn().IsPessimistic() &&
+	if n.ObjRef != nil && c.proc.TxnOperator.Txn().IsPessimistic() && n.TableDef != nil &&
 		n.TableDef.Pkey.PkeyColName != catalog.FakePrimaryKeyColName {
 		db, err := c.e.Database(ctx, n.ObjRef.SchemaName, c.proc.TxnOperator)
 		if err != nil {

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -44,6 +44,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -1405,8 +1406,13 @@ func (c *Compile) compileExternScan(ctx context.Context, n *plan.Node) ([]*Scope
 	ctx, span := trace.Start(ctx, "compileExternScan")
 	defer span.End()
 
-	// lock table
-	if n.ObjRef != nil && c.proc.TxnOperator.Txn().IsPessimistic() {
+	// lock table's meta
+	if err := lockMoTable(c, n.ObjRef.SchemaName, n.TableDef.Name, lock.LockMode_Shared); err != nil {
+		return nil, err
+	}
+	// lock table, for tables with no primary key, there is no need to lock the data
+	if n.ObjRef != nil && c.proc.TxnOperator.Txn().IsPessimistic() &&
+		n.TableDef.Pkey.PkeyColName != catalog.FakePrimaryKeyColName {
 		db, err := c.e.Database(ctx, n.ObjRef.SchemaName, c.proc.TxnOperator)
 		if err != nil {
 			panic(err)

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -2298,6 +2298,7 @@ func lockMoTable(c *Compile, dbName string, tblName string, lockMode lock.LockMo
 	if err != nil {
 		return err
 	}
+	defer vec.Free(c.proc.Mp())
 	if err := lockRows(c.e, c.proc, dbRel, vec, lockMode); err != nil {
 		return err
 	}

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -28,6 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/incrservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
+	"github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/lockop"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
@@ -115,7 +116,7 @@ func (s *Scope) AlterView(c *Compile) error {
 		return err
 	}
 
-	if err := lockMoTable(c, dbName, tblName); err != nil {
+	if err := lockMoTable(c, dbName, tblName, lock.LockMode_Exclusive); err != nil {
 		return err
 	}
 
@@ -204,7 +205,7 @@ func (s *Scope) AlterTableInplace(c *Compile) error {
 	if c.proc.TxnOperator.Txn().IsPessimistic() {
 		var retryErr error
 		// 1. lock origin table metadata in catalog
-		if err = lockMoTable(c, dbName, tblName); err != nil {
+		if err = lockMoTable(c, dbName, tblName, lock.LockMode_Exclusive); err != nil {
 			if !moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetry) &&
 				!moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetryWithDefChanged) {
 				return err
@@ -571,7 +572,7 @@ func (s *Scope) CreateTable(c *Compile) error {
 		}
 	}
 
-	if err := lockMoTable(c, dbName, tblName); err != nil {
+	if err := lockMoTable(c, dbName, tblName, lock.LockMode_Exclusive); err != nil {
 		return err
 	}
 
@@ -1098,7 +1099,7 @@ func (s *Scope) TruncateTable(c *Compile) error {
 
 	if !isTemp && c.proc.TxnOperator.Txn().IsPessimistic() {
 		var err error
-		if e := lockMoTable(c, dbName, tblName); e != nil {
+		if e := lockMoTable(c, dbName, tblName, lock.LockMode_Shared); e != nil {
 			if !moerr.IsMoErrCode(e, moerr.ErrTxnNeedRetry) &&
 				!moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetryWithDefChanged) {
 				return e
@@ -1239,7 +1240,7 @@ func (s *Scope) DropSequence(c *Compile) error {
 		return err
 	}
 
-	if err := lockMoTable(c, dbName, tblName); err != nil {
+	if err := lockMoTable(c, dbName, tblName, lock.LockMode_Exclusive); err != nil {
 		return err
 	}
 
@@ -1291,7 +1292,7 @@ func (s *Scope) DropTable(c *Compile) error {
 
 	if !isTemp && !isView && c.proc.TxnOperator.Txn().IsPessimistic() {
 		var err error
-		if e := lockMoTable(c, dbName, tblName); e != nil {
+		if e := lockMoTable(c, dbName, tblName, lock.LockMode_Exclusive); e != nil {
 			if !moerr.IsMoErrCode(e, moerr.ErrTxnNeedRetry) &&
 				!moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetryWithDefChanged) {
 				return e
@@ -1529,7 +1530,7 @@ func (s *Scope) CreateSequence(c *Compile) error {
 		return moerr.NewTableAlreadyExists(c.ctx, tblName)
 	}
 
-	if err := lockMoTable(c, dbName, tblName); err != nil {
+	if err := lockMoTable(c, dbName, tblName, lock.LockMode_Exclusive); err != nil {
 		return err
 	}
 
@@ -1609,7 +1610,7 @@ func (s *Scope) AlterSequence(c *Compile) error {
 		return moerr.NewInternalError(c.ctx, "sequence %s not exists", tblName)
 	}
 
-	if err := lockMoTable(c, dbName, tblName); err != nil {
+	if err := lockMoTable(c, dbName, tblName, lock.LockMode_Exclusive); err != nil {
 		return err
 	}
 
@@ -2178,7 +2179,8 @@ func lockRows(
 	eng engine.Engine,
 	proc *process.Process,
 	rel engine.Relation,
-	vec *vector.Vector) error {
+	vec *vector.Vector,
+	lockMode lock.LockMode) error {
 
 	if vec == nil || vec.Length() == 0 {
 		panic("lock rows is empty")
@@ -2191,7 +2193,8 @@ func lockRows(
 		proc,
 		id,
 		vec,
-		*vec.GetType())
+		*vec.GetType(),
+		lockMode)
 	return err
 }
 
@@ -2280,13 +2283,13 @@ func lockMoDatabase(c *Compile, dbName string) error {
 	if err != nil {
 		return err
 	}
-	if err := lockRows(c.e, c.proc, dbRel, vec); err != nil {
+	if err := lockRows(c.e, c.proc, dbRel, vec, lock.LockMode_Exclusive); err != nil {
 		return err
 	}
 	return nil
 }
 
-func lockMoTable(c *Compile, dbName string, tblName string) error {
+func lockMoTable(c *Compile, dbName string, tblName string, lockMode lock.LockMode) error {
 	dbRel, err := getRelFromMoCatalog(c, catalog.MO_TABLES)
 	if err != nil {
 		return err
@@ -2295,7 +2298,7 @@ func lockMoTable(c *Compile, dbName string, tblName string) error {
 	if err != nil {
 		return err
 	}
-	if err := lockRows(c.e, c.proc, dbRel, vec); err != nil {
+	if err := lockRows(c.e, c.proc, dbRel, vec, lockMode); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue [#1409](https://github.com/matrixorigin/MO-Cloud/issues/1409)

## What this PR does / why we need it:
* For the case of inserting into a table with no primary key, the original logic was to mindlessly lock the entire table, which is not correct. The logic should have been to just lock the metadata information of this table to ensure that it doesn't conflict with the alter.