### PR TITLE
 fix the sort key missing in tables having cluster by clause

### DIFF
--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"runtime/debug"
 	"runtime/trace"
 	"sync"
 	"sync/atomic"
@@ -264,18 +263,6 @@ func (p *PartitionState) HandleLogtailEntry(
 	switch entry.EntryType {
 	case api.Entry_Insert:
 		if IsBlkTable(entry.TableName) {
-			blkIds := "[ "
-			for _, b := range vector.MustFixedCol[types.Blockid](mustVectorFromProto(entry.Bat.Vecs[2])) {
-				blkIds += b.String() + ", "
-			}
-			blkIds += " ]"
-
-			str := fmt.Sprintf("tableName = %s, tableId = %v \n sorted = %v \n"+
-				"stack = %s", entry.TableName,
-				blkIds,
-				vector.MustFixedCol[bool](mustVectorFromProto(entry.Bat.Vecs[4])),
-				string(debug.Stack()[:]))
-			fmt.Println("-------------- HandleLogtailEntry: ", str)
 			p.HandleMetadataInsert(ctx, entry.Bat)
 		} else {
 			p.HandleRowsInsert(ctx, entry.Bat, primarySeqnum, packer)

--- a/pkg/vm/engine/tae/catalog/schema.go
+++ b/pkg/vm/engine/tae/catalog/schema.go
@@ -572,6 +572,9 @@ func (s *Schema) ReadFromBatch(bat *containers.Batch, offset int, targetTid uint
 		def.Hidden = i82bool(isHidden)
 		isClusterBy := bat.GetVectorByName((pkgcatalog.SystemColAttr_IsClusterBy)).Get(offset).(int8)
 		def.ClusterBy = i82bool(isClusterBy)
+		if def.ClusterBy {
+			def.SortKey = true
+		}
 		isAutoIncrement := bat.GetVectorByName((pkgcatalog.SystemColAttr_IsAutoIncrement)).Get(offset).(int8)
 		def.AutoIncrement = i82bool(isAutoIncrement)
 		def.Comment = string(bat.GetVectorByName((pkgcatalog.SystemColAttr_Comment)).Get(offset).([]byte))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11973 

## What this PR does / why we need it:
 fix the sort key missing in tables having a `cluster by` clause.

the sort key only exists in memory and is constructed when creating schema by reading checkpoint data.

the sort key will be used later in `metadata_scan` and judging if it is needed to `mergesort` columns.