### PR TITLE
Make sure no one use ses.tStmt after EndStatement

### DIFF
--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -504,12 +504,14 @@ func logStatementStringStatus(ctx context.Context, ses *Session, stmtStr string,
 	str := SubStringFromBegin(stmtStr, int(ses.GetParameterUnit().SV.LengthOfQueryPrinted))
 	outBytes := ses.GetMysqlProtocol().CalculateOutTrafficBytes()
 	if status == success {
-		motrace.EndStatement(ctx, nil, ses.sentRows.Load(), outBytes)
 		logDebug(ses, ses.GetDebugString(), "query trace status", logutil.ConnectionIdField(ses.GetConnectionID()), logutil.StatementField(str), logutil.StatusField(status.String()), trace.ContextField(ctx))
+		err = nil // make sure: it is nil for EndStatement
 	} else {
-		motrace.EndStatement(ctx, err, ses.sentRows.Load(), outBytes)
 		logError(ses, ses.GetDebugString(), "query trace status", logutil.ConnectionIdField(ses.GetConnectionID()), logutil.StatementField(str), logutil.StatusField(status.String()), logutil.ErrorField(err), trace.ContextField(ctx))
 	}
+	// pls make sure: NO ONE use the ses.tStmt after EndStatement
+	motrace.EndStatement(ctx, err, ses.sentRows.Load(), outBytes)
+	// need just below EndStatement
 	ses.SetTStmt(nil)
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11952

## What this PR does / why we need it:

refix_issue_11952, changes:
- move EndStatement after LogDebug / LogError, which still need ses.tStmt to log.