### PR TITLE
change config frontend::lengthOfQueryPrinted default as 1KiB

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -69,7 +69,7 @@ var (
 	defaultServerVersionPrefix = "8.0.30-MatrixOne-v"
 
 	//the length of query printed into console. -1, complete string. 0, empty string. >0 , length of characters at the header of the string.
-	defaultLengthOfQueryPrinted = 200000
+	defaultLengthOfQueryPrinted = 1024
 
 	//the count of rows in vector of batch in load data
 	defaultBatchSizeInLoadData = 40000


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11944

## What this PR does / why we need it:

changes:
- config frontend::lengthOfQueryPrinted default value as 1KiB

affect 2 places:
1. record in table system.statement_info, column `statement` will be truncated as 1KiB length
2. logs printed by CN, which has `statement` field
    - for example:
    -   2023/10/08 16:24:54.173199 +0800 ERROR log-service.frontend frontend/util.go:511 query trace status {....., "connection_id": 113711, **"statement": "uset test"**, "status": "fail", "error": ".....", "span": ....., "session_info": "connectionId 113711.....", "session_id": ".....", "statement_id": "......"}
