### PR TITLE
merge more blocks

### DIFF
--- a/pkg/sql/plan/function/ctl/cmd_inspectdn.go
+++ b/pkg/sql/plan/function/ctl/cmd_inspectdn.go
@@ -40,6 +40,6 @@ func handleInspectTN() handleFunc {
 		func(data []byte) (interface{}, error) {
 			resp := &db.InspectResp{}
 			types.Decode(data, resp)
-			return resp.GetResponse(), nil
+			return resp, nil
 		})
 }

--- a/pkg/sql/plan/function/ctl/ctl.go
+++ b/pkg/sql/plan/function/ctl/ctl.go
@@ -21,9 +21,11 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	pb "github.com/matrixorigin/matrixone/pkg/pb/ctl"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/functionUtil"
 	"github.com/matrixorigin/matrixone/pkg/util/json"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -91,6 +93,11 @@ func MoCtl(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *pr
 		})
 
 	if err != nil {
+		return err
+	}
+	if command == strings.ToUpper(pb.CmdMethod_Inspect.String()) {
+		obj := res.Data.([]any)[0].(*db.InspectResp)
+		err = rs.AppendBytes([]byte(obj.ConsoleString()), false)
 		return err
 	}
 	err = rs.AppendBytes(json.Pretty(res), false)

--- a/pkg/vm/engine/tae/catalog/segment.go
+++ b/pkg/vm/engine/tae/catalog/segment.go
@@ -55,6 +55,16 @@ type SegStat struct {
 	RemainingRows  int
 }
 
+func (s *SegStat) String() string {
+	zonemapStr := "nil"
+	if s.SortKeyZonemap != nil {
+		zonemapStr = s.SortKeyZonemap.String()
+	}
+	return fmt.Sprintf("loaded:%t, oSize:%s, rows:%d, remainingRows:%d, zm: %s",
+		s.Loaded, common.HumanReadableBytes(s.OriginSize), s.Rows, s.RemainingRows, zonemapStr,
+	)
+}
+
 func NewSegmentEntry(table *TableEntry, id *objectio.Segmentid, txn txnif.AsyncTxn, state EntryState, dataFactory SegmentDataFactory) *SegmentEntry {
 	e := &SegmentEntry{
 		ID: *id,
@@ -147,7 +157,7 @@ func (entry *SegmentEntry) LoadObjectInfo() error {
 	}
 	// special case for raw log table.
 	if entry.GetTable().GetLastestSchema().Name == motrace.RawLogTbl &&
-		len(entry.table.entries) > int(common.NotLoadMoreThan.Load()) {
+		len(entry.table.entries) > int(common.RuntimeNotLoadMoreThan.Load()) {
 		return nil
 	}
 	entry.RLock()

--- a/pkg/vm/engine/tae/catalog/segment.go
+++ b/pkg/vm/engine/tae/catalog/segment.go
@@ -146,7 +146,8 @@ func (entry *SegmentEntry) LoadObjectInfo() error {
 		return nil
 	}
 	// special case for raw log table.
-	if entry.GetTable().GetLastestSchema().Name == motrace.RawLogTbl && len(entry.table.entries) > 4096 {
+	if entry.GetTable().GetLastestSchema().Name == motrace.RawLogTbl &&
+		len(entry.table.entries) > int(common.NotLoadMoreThan.Load()) {
 		return nil
 	}
 	entry.RLock()

--- a/pkg/vm/engine/tae/catalog/segment.go
+++ b/pkg/vm/engine/tae/catalog/segment.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace"
 
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
@@ -142,6 +143,10 @@ func (entry *SegmentEntry) Less(b *SegmentEntry) int {
 // LoadObjectInfo is called only in merge scanner goroutine, no need to hold lock
 func (entry *SegmentEntry) LoadObjectInfo() error {
 	if entry.Stat.Loaded {
+		return nil
+	}
+	// special case for raw log table.
+	if entry.GetTable().GetLastestSchema().Name == motrace.RawLogTbl && len(entry.table.entries) > 4096 {
 		return nil
 	}
 	entry.RLock()

--- a/pkg/vm/engine/tae/catalog/segment.go
+++ b/pkg/vm/engine/tae/catalog/segment.go
@@ -52,7 +52,7 @@ type SegStat struct {
 	OriginSize     int
 	SortKeyZonemap index.ZM
 	Rows           int
-	Dels           int
+	RemainingRows  int
 }
 
 func NewSegmentEntry(table *TableEntry, id *objectio.Segmentid, txn txnif.AsyncTxn, state EntryState, dataFactory SegmentDataFactory) *SegmentEntry {

--- a/pkg/vm/engine/tae/catalog/table.go
+++ b/pkg/vm/engine/tae/catalog/table.go
@@ -290,6 +290,24 @@ func (entry *TableEntry) PPString(level common.PPLevel, depth int, prefix string
 	return w.String()
 }
 
+func (entry *TableEntry) ObjectStatsString() string {
+	var w bytes.Buffer
+
+	it := entry.MakeSegmentIt(true)
+	for ; it.Valid(); it.Next() {
+		segment := it.Get().GetPayload()
+		if !segment.IsActive() {
+			continue
+		}
+		_ = w.WriteByte('\n')
+		_, _ = w.WriteString(segment.ID.ToString())
+		_ = w.WriteByte('\n')
+		_, _ = w.WriteString("    ")
+		_, _ = w.WriteString(segment.Stat.String())
+	}
+	return w.String()
+}
+
 func (entry *TableEntry) String() string {
 	entry.RLock()
 	defer entry.RUnlock()

--- a/pkg/vm/engine/tae/common/stats.go
+++ b/pkg/vm/engine/tae/common/stats.go
@@ -65,8 +65,6 @@ type TableCompactStat struct {
 
 	// Configs
 
-	// make this table apply flush table tail policy
-	FlushTableTailEnabled bool
 	// how often to flush table tail
 	// this duration will be add some random value to avoid flush many tables at the same time
 	FlushGapDuration time.Duration
@@ -93,7 +91,6 @@ func (s *TableCompactStat) ResetDeadlineWithLock() {
 func (s *TableCompactStat) InitWithLock(durationHint time.Duration) {
 	s.FlushGapDuration = durationHint * 5
 	s.FlushMemCapacity = 20 * 1024 * 1024
-	s.FlushTableTailEnabled = true
 	s.Inited = true
 }
 

--- a/pkg/vm/engine/tae/common/stats.go
+++ b/pkg/vm/engine/tae/common/stats.go
@@ -17,10 +17,21 @@ package common
 import (
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 )
+
+const DefaultNotLoadMoreThan = 4096
+
+var (
+	NotLoadMoreThan atomic.Int32
+)
+
+func init() {
+	NotLoadMoreThan.Store(DefaultNotLoadMoreThan)
+}
 
 type TableCompactStat struct {
 	sync.RWMutex

--- a/pkg/vm/engine/tae/db/checkpoint/runner.go
+++ b/pkg/vm/engine/tae/db/checkpoint/runner.go
@@ -833,10 +833,6 @@ func (r *runner) tryCompactTree(entry *logtail.DirtyTreeEntry, force bool) {
 			table.Stats.Unlock()
 		}
 
-		if !table.Stats.FlushTableTailEnabled {
-			return nil
-		}
-
 		dirtyTree := entry.GetTree().GetTable(tableID)
 		_, endTs := entry.GetTimeRange()
 

--- a/pkg/vm/engine/tae/db/checkpoint/runner.go
+++ b/pkg/vm/engine/tae/db/checkpoint/runner.go
@@ -810,19 +810,6 @@ func (r *runner) EstimateTableMemSize(table *catalog.TableEntry, tree *model.Tab
 	return size
 }
 
-func humanReadableSize(size int) string {
-	if size < 1024 {
-		return fmt.Sprintf("%dB", size)
-	}
-	if size < 1024*1024 {
-		return fmt.Sprintf("%dKB", size/1024)
-	}
-	if size < 1024*1024*1024 {
-		return fmt.Sprintf("%dMB", size/1024/1024)
-	}
-	return fmt.Sprintf("%dGB", size/1024/1024/1024)
-}
-
 func (r *runner) tryCompactTree(entry *logtail.DirtyTreeEntry, force bool) {
 	if entry.IsEmpty() {
 		return
@@ -863,7 +850,7 @@ func (r *runner) tryCompactTree(entry *logtail.DirtyTreeEntry, force bool) {
 		if !stats.LastFlush.IsEmpty() && size > 2*1000*1024 {
 			logutil.Infof("[flushtabletail] %s(%s)  FlushCountDown %v",
 				table.GetLastestSchema().Name,
-				humanReadableSize(size),
+				common.HumanReadableBytes(size),
 				time.Until(stats.FlushDeadline))
 		}
 

--- a/pkg/vm/engine/tae/db/db.go
+++ b/pkg/vm/engine/tae/db/db.go
@@ -16,10 +16,11 @@ package db
 
 import (
 	"context"
-	"github.com/matrixorigin/matrixone/pkg/util/fault"
 	"io"
 	"sync/atomic"
 	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/util/fault"
 
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
@@ -59,6 +60,7 @@ type DB struct {
 
 	BGScanner          wb.IHeartbeater
 	BGCheckpointRunner checkpoint.Runner
+	MergeHandle        *MergeTaskBuilder
 
 	DiskCleaner *gc2.DiskCleaner
 

--- a/pkg/vm/engine/tae/db/merge/executor.go
+++ b/pkg/vm/engine/tae/db/merge/executor.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
@@ -76,8 +77,7 @@ func (e *MergeExecutor) PrintStats() {
 	)
 }
 
-func (e *MergeExecutor) AddActiveTask(taskId uint64, blkn int, msegs []*catalog.SegmentEntry) {
-	osize, esize := estimateMergeConsume(msegs)
+func (e *MergeExecutor) AddActiveTask(taskId uint64, blkn, esize int) {
 	atomic.AddInt64(&e.activeEstimateBytes, int64(esize))
 	atomic.AddInt32(&e.activeMergeBlkCount, int32(blkn))
 	e.taskConsume.Lock()
@@ -89,9 +89,6 @@ func (e *MergeExecutor) AddActiveTask(taskId uint64, blkn int, msegs []*catalog.
 		estBytes int
 	}{blkn, esize}
 	e.taskConsume.Unlock()
-	logutil.Infof(
-		"Mergeblocks active task %d-%s, blk %d, osize %s, merge size %s",
-		taskId, e.tableName, blkn, humanReadableBytes(osize), humanReadableBytes(esize))
 }
 
 func (e *MergeExecutor) OnExecDone(v any) {
@@ -106,8 +103,42 @@ func (e *MergeExecutor) OnExecDone(v any) {
 	atomic.AddInt64(&e.activeEstimateBytes, -int64(stat.estBytes))
 }
 
-func (e *MergeExecutor) ExecuteFor(tid uint64, tblName string, delSegs []*catalog.SegmentEntry, policy Policy) {
-	e.tableName = tblName
+func (e *MergeExecutor) ManuallyExecute(entry *catalog.TableEntry, segs []*catalog.SegmentEntry) error {
+	mem := e.memAvailBytes()
+	if mem > constMaxMemCap {
+		mem = constMaxMemCap
+	}
+	osize, esize := estimateMergeConsume(segs)
+	if esize > 2*mem/3 {
+		return moerr.NewInternalErrorNoCtx("no enough mem to merge. osize %d, mem %d", osize, mem)
+	}
+
+	mergedBlks, msegs := expandObjectList(segs)
+	blkCnt := len(mergedBlks)
+
+	scopes := make([]common.ID, blkCnt)
+	for i, blk := range mergedBlks {
+		scopes[i] = *blk.AsCommonID()
+	}
+
+	factory := func(ctx *tasks.Context, txn txnif.AsyncTxn) (tasks.Task, error) {
+		return jobs.NewMergeBlocksTask(ctx, txn, mergedBlks, msegs, nil, e.rt)
+	}
+	task, err := e.rt.Scheduler.ScheduleMultiScopedTxnTask(tasks.WaitableCtx, tasks.DataCompactionTask, scopes, factory)
+	if err == tasks.ErrScheduleScopeConflict {
+		return moerr.NewInternalErrorNoCtx("conflict with running merging jobs, try later")
+	} else if err != nil {
+		return moerr.NewInternalErrorNoCtx("schedule error: %v", err)
+	}
+	logMergeTask(entry.GetLastestSchema().Name, task.ID(), nil, msegs, len(mergedBlks), osize, esize)
+	if err = task.WaitDone(); err != nil {
+		return moerr.NewInternalErrorNoCtx("merge error: %v", err)
+	}
+	return nil
+}
+
+func (e *MergeExecutor) ExecuteFor(entry *catalog.TableEntry, delSegs []*catalog.SegmentEntry, policy Policy) {
+	e.tableName = entry.GetLastestSchema().Name
 	hasDelSeg := len(delSegs) > 0
 
 	hasMergeObjects := false
@@ -115,7 +146,7 @@ func (e *MergeExecutor) ExecuteFor(tid uint64, tblName string, delSegs []*catalo
 	objectList := policy.Revise(0, int64(e.memAvailBytes()))
 	mergedBlks, msegs := expandObjectList(objectList)
 	blkCnt := len(mergedBlks)
-	if blkCnt > 0 && e.checkMemAvail(msegs) {
+	if blkCnt > 0 {
 		delSegs = append(delSegs, msegs...)
 		hasMergeObjects = true
 	}
@@ -137,7 +168,7 @@ func (e *MergeExecutor) ExecuteFor(tid uint64, tblName string, delSegs []*catalo
 		if _, err := e.rt.Scheduler.ScheduleMultiScopedTxnTask(nil, tasks.DataCompactionTask, segScopes, factory); err != nil {
 			logutil.Infof("[Mergeblocks] Schedule del seg errinfo=%v", err)
 		} else {
-			logutil.Infof("[Mergeblocks] Scheduled Object Del| %d-%s del %d segs", tid, tblName, len(delSegs))
+			logutil.Infof("[Mergeblocks] Scheduled Object Del| %d-%s del %d segs", entry.ID, e.tableName, len(delSegs))
 		}
 		return
 	}
@@ -160,20 +191,11 @@ func (e *MergeExecutor) ExecuteFor(tid uint64, tblName string, delSegs []*catalo
 		return
 	}
 
-	e.AddActiveTask(task.ID(), blkCnt, msegs)
+	osize, esize := estimateMergeConsume(msegs)
+	e.AddActiveTask(task.ID(), blkCnt, esize)
 	task.AddObserver(e)
-
-	logMergeTask(e.tableName, delSegs, msegs)
-}
-
-func (e *MergeExecutor) checkMemAvail(msegs []*catalog.SegmentEntry) bool {
-	avail := e.memAvailBytes()
-	_, consume := estimateMergeConsume(msegs)
-	sufficient := avail > consume
-	if !sufficient {
-		logutil.Infof("mergeblocks skip %s, estimate cost %s", e.tableName, humanReadableBytes(consume))
-	}
-	return sufficient
+	entry.Stats.AddMerge(osize, len(msegs), blkCnt)
+	logMergeTask(e.tableName, task.ID(), delSegs, msegs, blkCnt, osize, esize)
 }
 
 func (e *MergeExecutor) memAvailBytes() int {
@@ -207,17 +229,21 @@ func expandObjectList(segs []*catalog.SegmentEntry) (
 	return
 }
 
-func logMergeTask(name string, dels, merges []*catalog.SegmentEntry) {
+func logMergeTask(name string, taskId uint64, dels, merges []*catalog.SegmentEntry, blkn, osize, esize int) {
 	infoBuf := &bytes.Buffer{}
 	infoBuf.WriteString("merged:")
 	for _, seg := range merges {
-		infoBuf.WriteString(fmt.Sprintf(" %d(%s)", seg.Stat.RemainingRows, shortSegId(seg.ID)))
+		infoBuf.WriteString(fmt.Sprintf(" %d(%s)", seg.Stat.RemainingRows, common.ShortSegId(seg.ID)))
 	}
 	if len(dels) > 0 {
 		infoBuf.WriteString(" | del:")
 		for _, seg := range dels {
-			infoBuf.WriteString(fmt.Sprintf(" %s", shortSegId(seg.ID)))
+			infoBuf.WriteString(fmt.Sprintf(" %s", common.ShortSegId(seg.ID)))
 		}
 	}
-	logutil.Infof("[Mergeblocks] Scheduled %v, %s", name, infoBuf.String())
+	logutil.Infof(
+		"[Mergeblocks] Scheduled %v [t%d|bn%d,on%d|%s,%s], %s", name,
+		taskId, len(merges), blkn, common.HumanReadableBytes(osize), common.HumanReadableBytes(esize),
+		infoBuf.String(),
+	)
 }

--- a/pkg/vm/engine/tae/db/merge/executor.go
+++ b/pkg/vm/engine/tae/db/merge/executor.go
@@ -211,7 +211,7 @@ func logMergeTask(name string, dels, merges []*catalog.SegmentEntry) {
 	infoBuf := &bytes.Buffer{}
 	infoBuf.WriteString("merged:")
 	for _, seg := range merges {
-		infoBuf.WriteString(fmt.Sprintf(" %d(%s)", seg.Stat.Rows-seg.Stat.Dels, shortSegId(seg.ID)))
+		infoBuf.WriteString(fmt.Sprintf(" %d(%s)", seg.Stat.RemainingRows, shortSegId(seg.ID)))
 	}
 	if len(dels) > 0 {
 		infoBuf.WriteString(" | del:")

--- a/pkg/vm/engine/tae/db/merge/mod.go
+++ b/pkg/vm/engine/tae/db/merge/mod.go
@@ -15,7 +15,7 @@
 package merge
 
 import (
-	"sync/atomic"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 )
@@ -25,19 +25,13 @@ const (
 	const1GBytes            = 1 << 30
 	const1MBytes            = 1 << 20
 	constMergeExpansionRate = 6
-	DefaultMaxMergeObjN     = 64
-)
-
-var (
-	MaxMergeSegN atomic.Int32 = atomic.Int32{}
+	constMaxMemCap          = 4 * constMergeExpansionRate * const1GBytes // max orginal memory for a object
+	constSmallMergeGap      = 3 * time.Minute
 )
 
 type Policy interface {
 	OnObject(obj *catalog.SegmentEntry)
 	Revise(cpu, mem int64) []*catalog.SegmentEntry
-	ResetForTable(id uint64, schema *catalog.Schema)
-}
-
-func init() {
-	MaxMergeSegN.Store(DefaultMaxMergeObjN)
+	ResetForTable(id uint64, schema *catalog.TableEntry)
+	Config(uint64, any)
 }

--- a/pkg/vm/engine/tae/db/merge/mod.go
+++ b/pkg/vm/engine/tae/db/merge/mod.go
@@ -34,4 +34,5 @@ type Policy interface {
 	Revise(cpu, mem int64) []*catalog.SegmentEntry
 	ResetForTable(id uint64, schema *catalog.TableEntry)
 	Config(uint64, any)
+	GetConfig(uint64) any
 }

--- a/pkg/vm/engine/tae/db/merge/mod.go
+++ b/pkg/vm/engine/tae/db/merge/mod.go
@@ -14,17 +14,30 @@
 
 package merge
 
-import "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+import (
+	"sync/atomic"
+
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+)
 
 const (
 	constMergeMinBlks       = 5
 	const1GBytes            = 1 << 30
 	const1MBytes            = 1 << 20
 	constMergeExpansionRate = 6
+	DefaultMaxMergeObjN     = 64
+)
+
+var (
+	MaxMergeSegN atomic.Int32 = atomic.Int32{}
 )
 
 type Policy interface {
 	OnObject(obj *catalog.SegmentEntry)
-	Revise(cpu, mem float64) []*catalog.SegmentEntry
+	Revise(cpu, mem int64) []*catalog.SegmentEntry
 	ResetForTable(id uint64, schema *catalog.Schema)
+}
+
+func init() {
+	MaxMergeSegN.Store(DefaultMaxMergeObjN)
 }

--- a/pkg/vm/engine/tae/db/merge/policyBasic.go
+++ b/pkg/vm/engine/tae/db/merge/policyBasic.go
@@ -119,6 +119,17 @@ func (o *Basic) Config(id uint64, c any) {
 	o.configProvider.SetConfig(id, cfg)
 }
 
+func (o *Basic) GetConfig(id uint64) any {
+	r := o.configProvider.GetConfig(id)
+	if r == nil {
+		r = &BasicPolicyConfig{
+			ObjectMinRows:  40960,
+			MergeMaxOneRun: int(common.RuntimeMaxMergeObjN.Load()),
+		}
+	}
+	return r
+}
+
 func (o *Basic) Revise(cpu, mem int64) []*catalog.SegmentEntry {
 	segs := o.objHeap.finish()
 	sort.Slice(segs, func(i, j int) bool {

--- a/pkg/vm/engine/tae/db/merge/policyBasic.go
+++ b/pkg/vm/engine/tae/db/merge/policyBasic.go
@@ -40,7 +40,7 @@ func NewBasicPolicy() *Basic {
 
 // impl Policy for Basic
 func (o *Basic) OnObject(obj *catalog.SegmentEntry) {
-	rowsLeftOnSeg := obj.Stat.Rows - obj.Stat.Dels
+	rowsLeftOnSeg := obj.Stat.RemainingRows
 	// it has too few rows, merge it
 	iscandidate := func() bool {
 		if rowsLeftOnSeg < o.objectMinRows {
@@ -70,7 +70,7 @@ func (o *Basic) Revise(cpu, mem int64) []*catalog.SegmentEntry {
 		return segs
 	}
 	sort.Slice(segs, func(i, j int) bool {
-		return segs[i].Stat.Rows-segs[i].Stat.Dels < segs[j].Stat.Rows-segs[j].Stat.Dels
+		return segs[i].Stat.RemainingRows < segs[j].Stat.RemainingRows
 	})
 	segs = segs[:len(segs)-1]
 	for needPopout(segs) {

--- a/pkg/vm/engine/tae/db/merge/policyOverlap.go
+++ b/pkg/vm/engine/tae/db/merge/policyOverlap.go
@@ -52,17 +52,18 @@ func (o *Overlap) OnObject(obj *catalog.SegmentEntry) {
 			logutil.Infof("Mergeblocks %d %s %s", obj.SortHint, mint.ErrString(), maxt.ErrString())
 		}
 	}
-
 }
+
+func (o *Overlap) Config(uint64, any) {}
 
 func (o *Overlap) Revise(cpu, mem int64) []*catalog.SegmentEntry {
 	o.analyzer.analyze(o.schema.GetSingleSortKeyType().Oid, o.schema.Name)
 	return nil
 }
 
-func (o *Overlap) ResetForTable(id uint64, schema *catalog.Schema) {
+func (o *Overlap) ResetForTable(id uint64, entry *catalog.TableEntry) {
 	o.id = id
-	o.schema = schema
+	o.schema = entry.GetLastestSchema()
 	o.analyzer.reset()
 }
 

--- a/pkg/vm/engine/tae/db/merge/policyOverlap.go
+++ b/pkg/vm/engine/tae/db/merge/policyOverlap.go
@@ -54,7 +54,8 @@ func (o *Overlap) OnObject(obj *catalog.SegmentEntry) {
 	}
 }
 
-func (o *Overlap) Config(uint64, any) {}
+func (o *Overlap) Config(uint64, any)   {}
+func (o *Overlap) GetConfig(uint64) any { return nil }
 
 func (o *Overlap) Revise(cpu, mem int64) []*catalog.SegmentEntry {
 	o.analyzer.analyze(o.schema.GetSingleSortKeyType().Oid, o.schema.Name)

--- a/pkg/vm/engine/tae/db/merge/policyOverlap.go
+++ b/pkg/vm/engine/tae/db/merge/policyOverlap.go
@@ -55,7 +55,7 @@ func (o *Overlap) OnObject(obj *catalog.SegmentEntry) {
 
 }
 
-func (o *Overlap) Revise(cpu, mem float64) []*catalog.SegmentEntry {
+func (o *Overlap) Revise(cpu, mem int64) []*catalog.SegmentEntry {
 	o.analyzer.analyze(o.schema.GetSingleSortKeyType().Oid, o.schema.Name)
 	return nil
 }

--- a/pkg/vm/engine/tae/db/merge/utils.go
+++ b/pkg/vm/engine/tae/db/merge/utils.go
@@ -93,7 +93,7 @@ func estimateMergeConsume(msegs []*catalog.SegmentEntry) (origSize, estSize int)
 	rows, merged := 0, 0
 	for _, m := range msegs {
 		rows += m.Stat.Rows
-		merged += m.Stat.Rows - m.Stat.Dels
+		merged += m.Stat.RemainingRows
 		origSize += m.Stat.OriginSize
 	}
 	// by test exprience, full 8192 rows batch will expand to (6~8)x memory comsupation.

--- a/pkg/vm/engine/tae/db/open.go
+++ b/pkg/vm/engine/tae/db/open.go
@@ -163,8 +163,8 @@ func Open(ctx context.Context, dirname string, opts *options.Options) (db *DB, e
 
 	// Init timed scanner
 	scanner := NewDBScanner(db, nil)
-	mergeOp := newMergeTaskBuiler(db)
-	scanner.RegisterOp(mergeOp)
+	db.MergeHandle = newMergeTaskBuiler(db)
+	scanner.RegisterOp(db.MergeHandle)
 	db.Wal.Start()
 	db.BGCheckpointRunner.Start()
 

--- a/pkg/vm/engine/tae/db/operations.go
+++ b/pkg/vm/engine/tae/db/operations.go
@@ -252,6 +252,15 @@ func (m *InspectResp) UnmarshalBinary(data []byte) error {
 	return m.Unmarshal(data)
 }
 
+func (m *InspectResp) ConsoleString() string {
+	switch m.Typ {
+	case InspectNormal:
+		return fmt.Sprintf("\nmsg: %s\n\n%v", m.Message, string(m.Payload))
+	default:
+		return fmt.Sprintf("\nmsg: %s\n\n unhandled resp type %v", m.Message, m.Typ)
+	}
+}
+
 const (
 	InspectNormal = 0
 	InspectCata   = 1

--- a/pkg/vm/engine/tae/db/scannerop.go
+++ b/pkg/vm/engine/tae/db/scannerop.go
@@ -161,6 +161,10 @@ func (s *MergeTaskBuilder) ConfigPolicy(id uint64, c any) {
 	s.objPolicy.Config(id, c)
 }
 
+func (s *MergeTaskBuilder) GetPolicy(id uint64) any {
+	return s.objPolicy.GetConfig(id)
+}
+
 func (s *MergeTaskBuilder) trySchedMergeTask() {
 	if s.tid == 0 {
 		return

--- a/pkg/vm/engine/tae/db/scannerop.go
+++ b/pkg/vm/engine/tae/db/scannerop.go
@@ -202,7 +202,7 @@ func (s *MergeTaskBuilder) onPostSegment(seg *catalog.SegmentEntry) (err error) 
 	}
 	// for sorted segments, we have to feed it to policy to see if it is qualified to be merged
 	seg.Stat.Rows = s.segmentHelper.segRowCnt
-	seg.Stat.Dels = s.segmentHelper.segRowDel
+	seg.Stat.RemainingRows = s.segmentHelper.segRowCnt - s.segmentHelper.segRowDel
 	seg.LoadObjectInfo()
 	if s.schema.Name == motrace.RawLogTbl && seg.Stat.OriginSize == 0 {
 		// after loading object info, original size is still 0, we have to estimate it by experience

--- a/pkg/vm/engine/tae/db/scannerop.go
+++ b/pkg/vm/engine/tae/db/scannerop.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace"
 
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
@@ -203,6 +204,12 @@ func (s *MergeTaskBuilder) onPostSegment(seg *catalog.SegmentEntry) (err error) 
 	seg.Stat.Rows = s.segmentHelper.segRowCnt
 	seg.Stat.Dels = s.segmentHelper.segRowDel
 	seg.LoadObjectInfo()
+	if s.schema.Name == motrace.RawLogTbl && seg.Stat.OriginSize == 0 {
+		// after loading object info, original size is still 0, we have to estimate it by experience
+		factor := 1 + seg.Stat.Rows/1600
+		seg.Stat.OriginSize = (1 << 20) * factor
+
+	}
 	s.objPolicy.OnObject(seg)
 	return nil
 }

--- a/pkg/vm/engine/tae/index/zm.go
+++ b/pkg/vm/engine/tae/index/zm.go
@@ -17,10 +17,11 @@ package index
 import (
 	"bytes"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/vectorize/moarray"
 	"math"
 	"sort"
 	"strings"
+
+	"github.com/matrixorigin/matrixone/pkg/vectorize/moarray"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -87,8 +88,18 @@ func (zm ZM) doInit(v []byte) {
 func (zm ZM) String() string {
 	var b strings.Builder
 	if zm.IsString() {
+		minBuf, maxBuf := zm.GetMinBuf(), zm.GetMaxBuf()
+		smin, smax := string(minBuf), string(maxBuf)
+
+		if r, _, e := types.DecodeTuple(minBuf); e == nil {
+
+			smin = r.ErrString()
+		}
+		if r, _, e := types.DecodeTuple(maxBuf); e == nil {
+			smax = r.ErrString()
+		}
 		_, _ = b.WriteString(fmt.Sprintf("ZM(%s)%d[%v,%v]",
-			zm.GetType().String(), zm.GetScale(), string(zm.GetMinBuf()), string(zm.GetMaxBuf())))
+			zm.GetType().String(), zm.GetScale(), smin, smax))
 	} else {
 		_, _ = b.WriteString(fmt.Sprintf("ZM(%s)%d[%v,%v]",
 			zm.GetType().String(), zm.GetScale(), zm.GetMin(), zm.GetMax()))

--- a/pkg/vm/engine/tae/index/zm_test.go
+++ b/pkg/vm/engine/tae/index/zm_test.go
@@ -16,6 +16,7 @@ package index
 
 import (
 	"bytes"
+	"encoding/hex"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -437,4 +438,9 @@ func BenchmarkUpdateZMVector(b *testing.B) {
 			BatchUpdateZM(zm, vec)
 		}
 	})
+}
+
+func TestXxx(t *testing.T) {
+	a := []byte("fefefef")
+	t.Log(hex.EncodeToString(a))
 }

--- a/pkg/vm/engine/tae/index/zm_test.go
+++ b/pkg/vm/engine/tae/index/zm_test.go
@@ -16,7 +16,6 @@ package index
 
 import (
 	"bytes"
-	"encoding/hex"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -438,9 +437,4 @@ func BenchmarkUpdateZMVector(b *testing.B) {
 			BatchUpdateZM(zm, vec)
 		}
 	})
-}
-
-func TestXxx(t *testing.T) {
-	a := []byte("fefefef")
-	t.Log(hex.EncodeToString(a))
 }

--- a/pkg/vm/engine/tae/logtail/collector.go
+++ b/pkg/vm/engine/tae/logtail/collector.go
@@ -373,7 +373,7 @@ func (d *dirtyCollector) tryCompactTree(
 		}
 
 		tbl.Stats.RLock()
-		if tbl.Stats.FlushTableTailEnabled && tbl.Stats.LastFlush.GreaterEq(to) {
+		if tbl.Stats.LastFlush.GreaterEq(to) {
 			tree.Shrink(id)
 			tbl.Stats.RUnlock()
 			continue

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -918,9 +918,6 @@ func (h *Handle) HandleWrite(
 				locations = append(locations, location)
 			}
 			err = tb.AddBlksWithMetaLoc(ctx, locations)
-			if req.TableName == "rawlog" {
-				logutil.Infof("mergeblocks add metaloc %s %d", shortSegId(locations[0].Name().SegmentId()), len(locations))
-			}
 			return
 		}
 		//check the input batch passed by cn is valid.

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -847,12 +847,6 @@ func (h *Handle) HandleDropOrTruncateRelation(
 	return err
 }
 
-func shortSegId(x objectio.Segmentid) string {
-	var shortuuid [8]byte
-	hex.Encode(shortuuid[:], x[:4])
-	return string(shortuuid[:])
-}
-
 // HandleWrite Handle DML commands
 func (h *Handle) HandleWrite(
 	ctx context.Context,

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -17,7 +17,6 @@ package rpc
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"fmt"
 
 	"os"

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -17,6 +17,7 @@ package rpc
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 
 	"os"
@@ -846,6 +847,12 @@ func (h *Handle) HandleDropOrTruncateRelation(
 	return err
 }
 
+func shortSegId(x objectio.Segmentid) string {
+	var shortuuid [8]byte
+	hex.Encode(shortuuid[:], x[:4])
+	return string(shortuuid[:])
+}
+
 // HandleWrite Handle DML commands
 func (h *Handle) HandleWrite(
 	ctx context.Context,
@@ -911,6 +918,9 @@ func (h *Handle) HandleWrite(
 				locations = append(locations, location)
 			}
 			err = tb.AddBlksWithMetaLoc(ctx, locations)
+			if req.TableName == "rawlog" {
+				logutil.Infof("mergeblocks add metaloc %s %d", shortSegId(locations[0].Name().SegmentId()), len(locations))
+			}
 			return
 		}
 		//check the input batch passed by cn is valid.

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -145,7 +145,12 @@ func (c *objStatArg) String() string {
 
 func (c *objStatArg) Run() error {
 	if c.tbl != nil {
-		c.ctx.resp.Payload = []byte(c.tbl.ObjectStatsString())
+		b := &bytes.Buffer{}
+		p := c.ctx.db.MergeHandle.GetPolicy(c.tbl.ID).(*merge.BasicPolicyConfig)
+		b.WriteString(c.tbl.ObjectStatsString())
+		b.WriteByte('\n')
+		b.WriteString(fmt.Sprintf("\n%s", p.String()))
+		c.ctx.resp.Payload = b.Bytes()
 	}
 	return nil
 }

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -15,10 +15,12 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -26,7 +28,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/merge"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
 	"github.com/spf13/cobra"
 )
 
@@ -43,14 +44,20 @@ func (i *inspectContext) String() string   { return "" }
 func (i *inspectContext) Set(string) error { return nil }
 func (i *inspectContext) Type() string     { return "ictx" }
 
-type catalogArg struct {
-	ctx       *inspectContext
-	outfile   *os.File
-	tblHandle handle.Relation
-	verbose   common.PPLevel
+type InspectCmd interface {
+	FromCommand(cmd *cobra.Command) error
+	String() string
+	Run() error
 }
 
-func (c *catalogArg) fromCommand(cmd *cobra.Command) (err error) {
+type catalogArg struct {
+	ctx     *inspectContext
+	outfile *os.File
+	tbl     *catalog.TableEntry
+	verbose common.PPLevel
+}
+
+func (c *catalogArg) FromCommand(cmd *cobra.Command) (err error) {
 	c.ctx = cmd.Flag("ictx").Value.(*inspectContext)
 	count, _ := cmd.Flags().GetCount("verbose")
 	var lv common.PPLevel
@@ -66,27 +73,16 @@ func (c *catalogArg) fromCommand(cmd *cobra.Command) (err error) {
 	}
 	c.verbose = lv
 
-	db, _ := cmd.Flags().GetString("db")
-	table, _ := cmd.Flags().GetString("table")
-	if db != "" && table != "" {
-		txn, _ := c.ctx.db.StartTxn(nil)
-		dbHdl, err := txn.GetDatabase(db)
-		if err != nil {
-			cmd.OutOrStdout().Write([]byte(fmt.Sprintf("%v err: %v", db, err)))
-			return err
-		}
-		tblHdl, err := dbHdl.GetRelationByName(table)
-		if err != nil {
-			cmd.OutOrStdout().Write([]byte(fmt.Sprintf("%v err: %v", table, err)))
-			return err
-		}
-		c.tblHandle = tblHdl
+	address, _ := cmd.Flags().GetString("target")
+	c.tbl, err = parseTableTarget(address, c.ctx.db)
+	if err != nil {
+		return err
 	}
+
 	file, _ := cmd.Flags().GetString("outfile")
 	if file != "" {
 		if f, err := os.Create(file); err != nil {
-			cmd.OutOrStdout().Write([]byte(fmt.Sprintf("open %s err: %v", file, err)))
-			return err
+			return moerr.NewInternalErrorNoCtx("open %s err: %v", file, err)
 		} else {
 			c.outfile = f
 		}
@@ -94,92 +90,214 @@ func (c *catalogArg) fromCommand(cmd *cobra.Command) (err error) {
 	return nil
 }
 
-func runCatalog(arg *catalogArg, respWriter io.Writer) {
-	if arg.outfile != nil {
-		var ret string
-		if arg.tblHandle != nil {
-			meta := arg.tblHandle.GetMeta().(*catalog.TableEntry)
-			ret = meta.PPString(arg.verbose, 0, "")
-		} else {
-			ret = arg.ctx.db.Catalog.SimplePPString(arg.verbose)
-		}
-		arg.outfile.WriteString(ret)
-		defer arg.outfile.Close()
-		respWriter.Write([]byte("write file done"))
-	} else {
-		var visitor *catalogRespVisitor
-		if arg.tblHandle != nil {
-			visitor = newTableRespVisitor(arg.verbose)
-			meta := arg.tblHandle.GetMeta().(*catalog.TableEntry)
-			meta.RecurLoop(visitor)
-		} else {
-			visitor = newCatalogRespVisitor(arg.verbose)
-			arg.ctx.db.Catalog.RecurLoop(visitor)
-		}
-		ret, _ := types.Encode(visitor.GetResponse())
-		arg.ctx.resp.Payload = ret
-		arg.ctx.resp.Typ = db.InspectCata
+func (c *catalogArg) String() string {
+	t := "*"
+	if c.tbl != nil {
+		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchema().Name)
 	}
+	f := "nil"
+	if c.outfile != nil {
+		f = c.outfile.Name()
+	}
+	return fmt.Sprintf("(%s) outfile: %v, verbose: %d, ", t, f, c.verbose)
+}
+
+func (c *catalogArg) Run() error {
+	var ret string
+	if c.tbl != nil {
+		ret = c.tbl.PPString(c.verbose, 0, "")
+	} else {
+		ret = c.ctx.db.Catalog.SimplePPString(c.verbose)
+	}
+	if c.outfile != nil {
+		c.outfile.WriteString(ret)
+		defer c.outfile.Close()
+		c.ctx.resp.Payload = []byte("write file done")
+	} else {
+		c.ctx.resp.Payload = []byte(ret)
+	}
+	return nil
+}
+
+type objStatArg struct {
+	ctx *inspectContext
+	tbl *catalog.TableEntry
+}
+
+func (c *objStatArg) FromCommand(cmd *cobra.Command) (err error) {
+	c.ctx = cmd.Flag("ictx").Value.(*inspectContext)
+
+	address, _ := cmd.Flags().GetString("target")
+	c.tbl, err = parseTableTarget(address, c.ctx.db)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *objStatArg) String() string {
+	t := "*"
+	if c.tbl != nil {
+		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchema().Name)
+	}
+	return t
+}
+
+func (c *objStatArg) Run() error {
+	if c.tbl != nil {
+		c.ctx.resp.Payload = []byte(c.tbl.ObjectStatsString())
+	}
+	return nil
+}
+
+type manuallyMergeArg struct {
+	ctx     *inspectContext
+	tbl     *catalog.TableEntry
+	objects []*catalog.SegmentEntry
+}
+
+func (c *manuallyMergeArg) FromCommand(cmd *cobra.Command) (err error) {
+	c.ctx = cmd.Flag("ictx").Value.(*inspectContext)
+
+	address, _ := cmd.Flags().GetString("target")
+	c.tbl, err = parseTableTarget(address, c.ctx.db)
+	if err != nil {
+		return err
+	}
+	if c.tbl == nil {
+		return moerr.NewInvalidInputNoCtx("need table target")
+	}
+
+	objects, _ := cmd.Flags().GetStringSlice("objects")
+
+	dedup := make(map[string]struct{}, len(objects))
+	for _, o := range objects {
+		if _, ok := dedup[o]; ok {
+			return moerr.NewInvalidInputNoCtx("duplicate object %s", o)
+		}
+		dedup[o] = struct{}{}
+	}
+	if len(dedup) < 2 {
+		return moerr.NewInvalidInputNoCtx("need at least 2 objects")
+	}
+	segs := make([]*catalog.SegmentEntry, 0, len(objects))
+	for o := range dedup {
+		parts := strings.Split(o, "_")
+		uid, err := types.ParseUuid(parts[0])
+		if err != nil {
+			return err
+		}
+		seg, err := c.tbl.GetSegmentByID(&uid)
+		if err != nil {
+			return moerr.NewInvalidInputNoCtx("not found object %s", o)
+		}
+		if !seg.IsActive() || !seg.IsSorted() || seg.GetNextObjectIndex() != 1 {
+			return moerr.NewInvalidInputNoCtx("object is deleted or not a flushed one %s", o)
+		}
+		segs = append(segs, seg)
+	}
+
+	c.objects = segs
+	return nil
+}
+
+func (c *manuallyMergeArg) String() string {
+	t := "*"
+	if c.tbl != nil {
+		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchema().Name)
+	}
+
+	b := &bytes.Buffer{}
+	for _, o := range c.objects {
+		b.WriteString(fmt.Sprintf("%s_0000,", o.ID.ToString()))
+	}
+
+	return fmt.Sprintf("(%s) objects: %s", t, b.String())
+}
+
+func (c *manuallyMergeArg) Run() error {
+	err := c.ctx.db.MergeHandle.ManuallyMerge(c.tbl, c.objects)
+	if err != nil {
+		return err
+	}
+	c.ctx.resp.Payload = []byte(fmt.Sprintf(
+		"success. see more to run select mo_ctl('dn', 'inspect', 'object -t %s.%s')\\G",
+		c.tbl.GetDB().GetName(), c.tbl.GetLastestSchema().Name,
+	))
+	return nil
 }
 
 type compactPolicyArg struct {
-	ctx             *inspectContext
-	maxMergeObjN    int32
-	notLoadMoreThan int32
+	ctx              *inspectContext
+	tbl              *catalog.TableEntry
+	maxMergeObjN     int32
+	minRowsQualified int32
+	notLoadMoreThan  int32
 }
 
-func (c *compactPolicyArg) fromCommand(cmd *cobra.Command) (err error) {
+func (c *compactPolicyArg) FromCommand(cmd *cobra.Command) (err error) {
 	c.ctx = cmd.Flag("ictx").Value.(*inspectContext)
 
+	address, _ := cmd.Flags().GetString("target")
+	c.tbl, err = parseTableTarget(address, c.ctx.db)
+	if err != nil {
+		return err
+	}
 	c.maxMergeObjN, _ = cmd.Flags().GetInt32("maxMergeObjN")
+	c.minRowsQualified, _ = cmd.Flags().GetInt32("minRowsQualified")
 	c.notLoadMoreThan, _ = cmd.Flags().GetInt32("notLoadMoreThan")
 	return nil
 }
 
-func runCompactPolicy(arg *compactPolicyArg) error {
-	merge.MaxMergeSegN.Store(arg.maxMergeObjN)
-	common.NotLoadMoreThan.Store(arg.notLoadMoreThan)
-	return nil
+func (c *compactPolicyArg) String() string {
+	t := "*"
+	if c.tbl != nil {
+		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchema().Name)
+	}
+	return fmt.Sprintf(
+		"(%s) maxMergeObjN: %v, minRowsQualified: %v, notLoadMoreThan: %v",
+		t, c.maxMergeObjN, c.minRowsQualified, c.notLoadMoreThan,
+	)
+}
 
+func (c *compactPolicyArg) Run() error {
+	if c.tbl == nil {
+		// reset all
+		c.ctx.db.MergeHandle.ConfigPolicy(0, nil)
+		common.RuntimeMaxMergeObjN.Store(c.maxMergeObjN)
+	} else {
+		c.ctx.db.MergeHandle.ConfigPolicy(c.tbl.ID, &merge.BasicPolicyConfig{
+			MergeMaxOneRun: int(c.maxMergeObjN),
+			ObjectMinRows:  int(c.minRowsQualified),
+		})
+	}
+	common.RuntimeNotLoadMoreThan.Store(c.notLoadMoreThan)
+	c.ctx.resp.Payload = []byte("<empty>")
+	return nil
+}
+
+func RunFactory[T InspectCmd](t T) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if err := t.FromCommand(cmd); err != nil {
+			cmd.OutOrStdout().Write([]byte(fmt.Sprintf("parse err: %v", err)))
+			return
+		}
+		err := t.Run()
+		if err != nil {
+			cmd.OutOrStdout().Write(
+				[]byte(fmt.Sprintf("run err: %v", err)),
+			)
+		} else {
+			cmd.OutOrStdout().Write(
+				[]byte(fmt.Sprintf("success. arg %v", t.String())),
+			)
+		}
+	}
 }
 
 func initCommand(ctx context.Context, inspectCtx *inspectContext) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use: "inspect",
-	}
-
-	catalogCmd := &cobra.Command{
-		Use:   "catalog",
-		Short: "show catalog",
-		Run: func(cmd *cobra.Command, args []string) {
-			arg := &catalogArg{}
-			if err := arg.fromCommand(cmd); err != nil {
-				return
-			}
-			runCatalog(arg, cmd.OutOrStdout())
-		},
-	}
-
-	policyCmd := &cobra.Command{
-		Use:   "policy",
-		Short: "set flush policy for table",
-		Run: func(cmd *cobra.Command, args []string) {
-			arg := &compactPolicyArg{}
-			if err := arg.fromCommand(cmd); err != nil {
-				cmd.OutOrStdout().Write([]byte(fmt.Sprintf("%v", err)))
-				return
-			}
-			err := runCompactPolicy(arg)
-
-			if err != nil {
-				cmd.OutOrStdout().Write([]byte(fmt.Sprintf("%v", err)))
-			} else {
-				cmd.OutOrStdout().Write([]byte(
-					fmt.Sprintf(
-						"success. maxMergeObjN %v", arg.maxMergeObjN,
-					)))
-			}
-		},
 	}
 
 	rootCmd.PersistentFlags().VarPF(inspectCtx, "ictx", "", "").Hidden = true
@@ -188,15 +306,47 @@ func initCommand(ctx context.Context, inspectCtx *inspectContext) *cobra.Command
 	rootCmd.SetErr(inspectCtx.out)
 	rootCmd.SetOut(inspectCtx.out)
 
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+	catalogCmd := &cobra.Command{
+		Use:   "catalog",
+		Short: "show catalog",
+		Run:   RunFactory(&catalogArg{}),
+	}
+
 	catalogCmd.Flags().CountP("verbose", "v", "verbose level")
 	catalogCmd.Flags().StringP("outfile", "o", "", "write output to a file")
-	catalogCmd.Flags().StringP("db", "d", "", "database name")
-	catalogCmd.Flags().StringP("table", "t", "", "table name")
+	catalogCmd.Flags().StringP("target", "t", "*", "format: db.table")
 	rootCmd.AddCommand(catalogCmd)
 
-	policyCmd.Flags().Int32P("maxMergeObjN", "o", merge.DefaultMaxMergeObjN, "max objects merged for one")
-	policyCmd.Flags().Int32P("notLoadMoreThan", "l", common.DefaultNotLoadMoreThan, "not load if too much objects")
+	objectCmd := &cobra.Command{
+		Use:   "object",
+		Short: "show object statistics",
+		Run:   RunFactory(&objStatArg{}),
+	}
+	objectCmd.Flags().StringP("target", "t", "*", "format: db.table")
+	rootCmd.AddCommand(objectCmd)
+
+	policyCmd := &cobra.Command{
+		Use:   "policy",
+		Short: "set merge policy for table",
+		Run:   RunFactory(&compactPolicyArg{}),
+	}
+	policyCmd.Flags().StringP("target", "t", "*", "format: db.table")
+	policyCmd.Flags().Int32P("maxMergeObjN", "o", common.DefaultMaxMergeObjN, "max number of objects merged for one")
+	policyCmd.Flags().Int32P("minRowsQualified", "m", 5*8192, "object with a few rows will be picked up to merge")
+	policyCmd.Flags().Int32P("notLoadMoreThan", "l", common.DefaultNotLoadMoreThan, "not load metadata if table has too much objects. Only works for rawlog table")
 	rootCmd.AddCommand(policyCmd)
+
+	mmCmd := &cobra.Command{
+		Use:   "merge",
+		Short: "manually merge objects",
+		Run:   RunFactory(&manuallyMergeArg{}),
+	}
+
+	mmCmd.Flags().StringP("target", "t", "*", "format: db.table")
+	mmCmd.Flags().StringSliceP("objects", "o", nil, "format: object_id_0000,object_id_0000")
+	rootCmd.AddCommand(mmCmd)
 
 	return rootCmd
 }
@@ -206,70 +356,23 @@ func RunInspect(ctx context.Context, inspectCtx *inspectContext) {
 	rootCmd.Execute()
 }
 
-type catalogRespVisitor struct {
-	catalog.LoopProcessor
-	level common.PPLevel
-	stack []*db.CatalogResp
-}
-
-func newCatalogRespVisitor(lv common.PPLevel) *catalogRespVisitor {
-	return &catalogRespVisitor{
-		level: lv,
-		stack: []*db.CatalogResp{{Item: "Catalog"}},
+func parseTableTarget(address string, db *db.DB) (*catalog.TableEntry, error) {
+	if address == "*" {
+		return nil, nil
 	}
-}
-
-func newTableRespVisitor(lv common.PPLevel) *catalogRespVisitor {
-	v := &catalogRespVisitor{
-		level: lv,
-		stack: []*db.CatalogResp{{Item: "Catalog"}},
+	parts := strings.Split(address, ".")
+	if len(parts) != 2 {
+		return nil, moerr.NewInvalidInputNoCtx(fmt.Sprintf("invalid db.table: %q", address))
 	}
-	v.onstack(0, &db.CatalogResp{Item: "DB"})
-	v.onstack(1, &db.CatalogResp{Item: "Tbl"})
-	return v
-}
-
-func (c *catalogRespVisitor) GetResponse() *db.CatalogResp {
-	return c.stack[0]
-}
-
-func entryLevelString[T interface {
-	StringWithLevel(common.PPLevel) string
-}](entry T, lv common.PPLevel) *db.CatalogResp {
-	return &db.CatalogResp{Item: entry.StringWithLevel(lv)}
-}
-
-func (c *catalogRespVisitor) onstack(idx int, resp *db.CatalogResp) {
-	c.stack = c.stack[:idx+1]
-	c.stack[idx].Sub = append(c.stack[idx].Sub, resp)
-	c.stack = append(c.stack, resp)
-}
-
-func (c *catalogRespVisitor) OnDatabase(database *catalog.DBEntry) error {
-	c.onstack(0, entryLevelString(database, c.level))
-	return nil
-}
-
-func (c *catalogRespVisitor) OnTable(table *catalog.TableEntry) error {
-	if c.level == common.PPL0 {
-		return moerr.GetOkStopCurrRecur()
+	txn, _ := db.StartTxn(nil)
+	dbHdl, err := txn.GetDatabase(parts[0])
+	if err != nil {
+		return nil, err
 	}
-	c.onstack(1, entryLevelString(table, c.level))
-	return nil
-}
-
-func (c *catalogRespVisitor) OnSegment(seg *catalog.SegmentEntry) error {
-	if c.level == common.PPL0 {
-		return moerr.GetOkStopCurrRecur()
+	tblHdl, err := dbHdl.GetRelationByName(parts[1])
+	if err != nil {
+		return nil, err
 	}
-	c.onstack(2, entryLevelString(seg, c.level))
-	return nil
-}
-
-func (c *catalogRespVisitor) OnBlock(blk *catalog.BlockEntry) error {
-	if c.level == common.PPL0 {
-		return moerr.GetOkStopCurrRecur()
-	}
-	c.onstack(3, entryLevelString(blk, c.level))
-	return nil
+	txn.Commit(context.Background())
+	return tblHdl.GetMeta().(*catalog.TableEntry), nil
 }

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -123,19 +123,22 @@ func runCatalog(arg *catalogArg, respWriter io.Writer) {
 }
 
 type compactPolicyArg struct {
-	ctx          *inspectContext
-	maxMergeObjN int32
+	ctx             *inspectContext
+	maxMergeObjN    int32
+	notLoadMoreThan int32
 }
 
 func (c *compactPolicyArg) fromCommand(cmd *cobra.Command) (err error) {
 	c.ctx = cmd.Flag("ictx").Value.(*inspectContext)
 
 	c.maxMergeObjN, _ = cmd.Flags().GetInt32("maxMergeObjN")
+	c.notLoadMoreThan, _ = cmd.Flags().GetInt32("notLoadMoreThan")
 	return nil
 }
 
 func runCompactPolicy(arg *compactPolicyArg) error {
 	merge.MaxMergeSegN.Store(arg.maxMergeObjN)
+	common.NotLoadMoreThan.Store(arg.notLoadMoreThan)
 	return nil
 
 }
@@ -191,7 +194,8 @@ func initCommand(ctx context.Context, inspectCtx *inspectContext) *cobra.Command
 	catalogCmd.Flags().StringP("table", "t", "", "table name")
 	rootCmd.AddCommand(catalogCmd)
 
-	policyCmd.Flags().Int32P("maxMergeObjN", "s", merge.DefaultMaxMergeObjN, "max objects merged for one")
+	policyCmd.Flags().Int32P("maxMergeObjN", "o", merge.DefaultMaxMergeObjN, "max objects merged for one")
+	policyCmd.Flags().Int32P("notLoadMoreThan", "l", common.DefaultNotLoadMoreThan, "not load if too much objects")
 	rootCmd.AddCommand(policyCmd)
 
 	return rootCmd

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -155,6 +155,7 @@ func (task *flushTableTailTask) Name() string {
 }
 
 func (task *flushTableTailTask) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	enc.AddString("endTs", task.dirtyEndTs.ToString())
 	blks := ""
 	for _, blk := range task.ablksMetas {
 		blks = fmt.Sprintf("%s%s,", blks, blk.ID.ShortStringEx())


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12075

## What this PR does / why we need it:

merge more blocks for once.

add `merge`, `object`, and `policy` commands to check and control merging
```bash
mysql> select mo_ctl('dn', 'inspect', 'help')\G
*************************** 1. row ***************************
mo_ctl(dn, inspect, help): 
msg: Usage:
  inspect [command]

Available Commands:
  catalog     show catalog
  help        Help about any command
  merge       manually merge objects
  object      show object statistics
  policy      set merge policy for table

Flags:
  -h, --help   help for inspect
```