### PR TITLE
Limit the size of a single checkpoint file (#12095)

### DIFF
--- a/pkg/objectio/metav2.go
+++ b/pkg/objectio/metav2.go
@@ -25,6 +25,7 @@ const (
 	SchemaTombstone DataMetaType = 1
 
 	CkpMetaStart DataMetaType = 2
+	CkpMetaEnd   DataMetaType = 25 + 2
 )
 
 const (

--- a/pkg/objectio/writer_test.go
+++ b/pkg/objectio/writer_test.go
@@ -292,9 +292,9 @@ func TestNewObjectReader(t *testing.T) {
 	assert.Nil(t, err)
 	_, err = objectWriter.WriteTombstone(bat)
 	assert.Nil(t, err)
-	_, err = objectWriter.WriteSubBlock(bat, 2)
+	_, _, err = objectWriter.WriteSubBlock(bat, 2)
 	assert.Nil(t, err)
-	_, err = objectWriter.WriteSubBlock(bat, 26)
+	_, _, err = objectWriter.WriteSubBlock(bat, 26)
 	assert.Nil(t, err)
 	ts := time.Now()
 	option := WriteOptions{

--- a/pkg/vm/engine/tae/blockio/writer.go
+++ b/pkg/vm/engine/tae/blockio/writer.go
@@ -129,7 +129,7 @@ func (w *BlockWriter) WriteTombstoneBatch(batch *batch.Batch) (objectio.BlockObj
 	return w.writer.WriteTombstone(batch)
 }
 
-func (w *BlockWriter) WriteSubBatch(batch *batch.Batch, dataType objectio.DataMetaType) (objectio.BlockObject, error) {
+func (w *BlockWriter) WriteSubBatch(batch *batch.Batch, dataType objectio.DataMetaType) (objectio.BlockObject, int, error) {
 	return w.writer.WriteSubBlock(batch, dataType)
 }
 

--- a/pkg/vm/engine/tae/db/checkpoint/option.go
+++ b/pkg/vm/engine/tae/db/checkpoint/option.go
@@ -78,6 +78,12 @@ func WithCheckpointBlockRows(rows int) Option {
 	}
 }
 
+func WithCheckpointSize(size int) Option {
+	return func(r *runner) {
+		r.options.checkpointSize = size
+	}
+}
+
 func WithReserveWALEntryCount(count uint64) Option {
 	return func(r *runner) {
 		r.options.reservedWALEntryCount = count

--- a/pkg/vm/engine/tae/db/checkpoint/runner.go
+++ b/pkg/vm/engine/tae/db/checkpoint/runner.go
@@ -181,6 +181,7 @@ type runner struct {
 		checkpointQueueSize int
 
 		checkpointBlockRows int
+		checkpointSize      int
 
 		reservedWALEntryCount uint64
 	}
@@ -278,6 +279,7 @@ func (r *runner) String() string {
 	_, _ = fmt.Fprintf(&buf, "waitQueueSize=%v, ", r.options.waitQueueSize)
 	_, _ = fmt.Fprintf(&buf, "checkpointQueueSize=%v, ", r.options.checkpointQueueSize)
 	_, _ = fmt.Fprintf(&buf, "checkpointBlockRows=%v, ", r.options.checkpointBlockRows)
+	_, _ = fmt.Fprintf(&buf, "checkpointSize=%v, ", r.options.checkpointSize)
 	_, _ = fmt.Fprintf(&buf, ">")
 	return buf.String()
 }
@@ -505,7 +507,7 @@ func (r *runner) doIncrementalCheckpoint(entry *CheckpointEntry) (err error) {
 		return
 	}
 	defer data.Close()
-	cnLocation, tnLocation, err := data.WriteTo(r.rt.Fs.Service, r.options.checkpointBlockRows)
+	cnLocation, tnLocation, err := data.WriteTo(r.rt.Fs.Service, r.options.checkpointBlockRows, r.options.checkpointSize)
 	if err != nil {
 		return
 	}
@@ -528,7 +530,7 @@ func (r *runner) doGlobalCheckpoint(end types.TS, ckpLSN, truncateLSN uint64, in
 	}
 	defer data.Close()
 
-	cnLocation, tnLocation, err := data.WriteTo(r.rt.Fs.Service, r.options.checkpointBlockRows)
+	cnLocation, tnLocation, err := data.WriteTo(r.rt.Fs.Service, r.options.checkpointBlockRows, r.options.checkpointSize)
 	if err != nil {
 		return
 	}
@@ -690,6 +692,9 @@ func (r *runner) fillDefaults() {
 	}
 	if r.options.checkpointBlockRows <= 0 {
 		r.options.checkpointBlockRows = logtail.DefaultCheckpointBlockRows
+	}
+	if r.options.checkpointSize <= 0 {
+		r.options.checkpointSize = logtail.DefaultCheckpointSize
 	}
 }
 

--- a/pkg/vm/engine/tae/db/open.go
+++ b/pkg/vm/engine/tae/db/open.go
@@ -136,6 +136,7 @@ func Open(ctx context.Context, dirname string, opts *options.Options) (db *DB, e
 		checkpoint.WithCollectInterval(opts.CheckpointCfg.ScanInterval),
 		checkpoint.WithMinCount(int(opts.CheckpointCfg.MinCount)),
 		checkpoint.WithCheckpointBlockRows(opts.CheckpointCfg.BlockRows),
+		checkpoint.WithCheckpointSize(opts.CheckpointCfg.Size),
 		checkpoint.WithMinIncrementalInterval(opts.CheckpointCfg.IncrementalInterval),
 		checkpoint.WithGlobalMinCount(int(opts.CheckpointCfg.GlobalMinCount)),
 		checkpoint.WithGlobalVersionInterval(opts.CheckpointCfg.GlobalVersionInterval),

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -71,6 +71,7 @@ import (
 const (
 	ModuleName               = "TAEDB"
 	smallCheckpointBlockRows = 10
+	smallCheckpointSize      = 1024
 )
 
 func TestAppend(t *testing.T) {
@@ -8475,7 +8476,7 @@ func TestCheckpointReadWrite(t *testing.T) {
 	assert.NoError(t, txn.Commit(context.Background()))
 
 	t1 := tae.TxnMgr.StatMaxCommitTS()
-	testutil.CheckCheckpointReadWrite(t, types.TS{}, t1, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
+	testutil.CheckCheckpointReadWrite(t, types.TS{}, t1, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 
 	txn, err = tae.StartTxn(nil)
 	assert.NoError(t, err)
@@ -8488,8 +8489,8 @@ func TestCheckpointReadWrite(t *testing.T) {
 	assert.NoError(t, txn.Commit(context.Background()))
 
 	t2 := tae.TxnMgr.StatMaxCommitTS()
-	testutil.CheckCheckpointReadWrite(t, types.TS{}, t2, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
-	testutil.CheckCheckpointReadWrite(t, t1, t2, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
+	testutil.CheckCheckpointReadWrite(t, types.TS{}, t2, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
+	testutil.CheckCheckpointReadWrite(t, t1, t2, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 
 	txn, err = tae.StartTxn(nil)
 	assert.NoError(t, err)
@@ -8497,8 +8498,8 @@ func TestCheckpointReadWrite(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, txn.Commit(context.Background()))
 	t3 := tae.TxnMgr.StatMaxCommitTS()
-	testutil.CheckCheckpointReadWrite(t, types.TS{}, t3, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
-	testutil.CheckCheckpointReadWrite(t, t2, t3, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
+	testutil.CheckCheckpointReadWrite(t, types.TS{}, t3, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
+	testutil.CheckCheckpointReadWrite(t, t2, t3, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 
 	schema := catalog.MockSchemaAll(2, 1)
 	schema.BlockMaxRows = 1
@@ -8508,13 +8509,13 @@ func TestCheckpointReadWrite(t *testing.T) {
 
 	tae.CreateRelAndAppend(bat, true)
 	t4 := tae.TxnMgr.StatMaxCommitTS()
-	testutil.CheckCheckpointReadWrite(t, types.TS{}, t4, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
-	testutil.CheckCheckpointReadWrite(t, t3, t4, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
+	testutil.CheckCheckpointReadWrite(t, types.TS{}, t4, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
+	testutil.CheckCheckpointReadWrite(t, t3, t4, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 
 	tae.CompactBlocks(false)
 	t5 := tae.TxnMgr.StatMaxCommitTS()
-	testutil.CheckCheckpointReadWrite(t, types.TS{}, t5, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
-	testutil.CheckCheckpointReadWrite(t, t4, t5, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
+	testutil.CheckCheckpointReadWrite(t, types.TS{}, t5, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
+	testutil.CheckCheckpointReadWrite(t, t4, t5, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 }
 
 func TestCheckpointReadWrite2(t *testing.T) {
@@ -8539,7 +8540,7 @@ func TestCheckpointReadWrite2(t *testing.T) {
 	}
 
 	t1 := tae.TxnMgr.StatMaxCommitTS()
-	testutil.CheckCheckpointReadWrite(t, types.TS{}, t1, tae.Catalog, smallCheckpointBlockRows, tae.Opts.Fs)
+	testutil.CheckCheckpointReadWrite(t, types.TS{}, t1, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 }
 
 func TestEstimateMemSize(t *testing.T) {

--- a/pkg/vm/engine/tae/db/testutil/engine.go
+++ b/pkg/vm/engine/tae/db/testutil/engine.go
@@ -378,13 +378,14 @@ func writeIncrementalCheckpoint(
 	start, end types.TS,
 	c *catalog.Catalog,
 	checkpointBlockRows int,
+	checkpointSize int,
 	fs fileservice.FileService,
 ) (objectio.Location, objectio.Location) {
 	factory := logtail.IncrementalCheckpointDataFactory(start, end)
 	data, err := factory(c)
 	assert.NoError(t, err)
 	defer data.Close()
-	cnLocation, tnLocation, err := data.WriteTo(fs, checkpointBlockRows)
+	cnLocation, tnLocation, err := data.WriteTo(fs, checkpointBlockRows, checkpointSize)
 	assert.NoError(t, err)
 	return cnLocation, tnLocation
 }
@@ -613,9 +614,10 @@ func CheckCheckpointReadWrite(
 	start, end types.TS,
 	c *catalog.Catalog,
 	checkpointBlockRows int,
+	checkpointSize int,
 	fs fileservice.FileService,
 ) {
-	location, _ := writeIncrementalCheckpoint(t, start, end, c, checkpointBlockRows, fs)
+	location, _ := writeIncrementalCheckpoint(t, start, end, c, checkpointBlockRows, checkpointSize, fs)
 	tnData := tnReadCheckpoint(t, location, fs)
 
 	checkTNCheckpointData(context.Background(), t, tnData, start, end, c)

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -40,6 +40,7 @@ import (
 )
 
 const DefaultCheckpointBlockRows = 10000
+const DefaultCheckpointSize = 1024 * 1024 * 1024
 
 const (
 	CheckpointVersion1 uint32 = 1
@@ -1440,26 +1441,44 @@ func formatBatch(bat *containers.Batch) {
 	}
 }
 
-func (data *CheckpointData) prepareTNMetaBatch(name objectio.ObjectName, blks []objectio.BlockObject, schemaType []uint16) {
-	for i, blk := range blks {
-		location := objectio.BuildLocation(name, blk.GetExtent(), 0, blk.GetID())
-		data.bats[TNMetaIDX].GetVectorByName(CheckpointMetaAttr_BlockLocation).Append([]byte(location), false)
-		data.bats[TNMetaIDX].GetVectorByName(CheckpointMetaAttr_SchemaType).Append(schemaType[i], false)
+func (data *CheckpointData) prepareTNMetaBatch(
+	checkpointNames []objectio.ObjectName,
+	objectBlocks [][]objectio.BlockObject,
+	schemaTypes [][]uint16,
+) {
+	for i, blks := range objectBlocks {
+		for y, blk := range blks {
+			location := objectio.BuildLocation(checkpointNames[i], blk.GetExtent(), 0, blk.GetID())
+			data.bats[TNMetaIDX].GetVectorByName(CheckpointMetaAttr_BlockLocation).Append([]byte(location), false)
+			data.bats[TNMetaIDX].GetVectorByName(CheckpointMetaAttr_SchemaType).Append(schemaTypes[i][y], false)
+		}
 	}
+}
+
+type blockIndexes struct {
+	fileNum uint16
+	indexes *BlockLocation
 }
 
 func (data *CheckpointData) WriteTo(
 	fs fileservice.FileService,
 	blockRows int,
+	checkpointSize int,
 ) (CNLocation, TNLocation objectio.Location, err error) {
+	checkpointNames := make([]objectio.ObjectName, 1)
 	segmentid := objectio.NewSegmentid()
-	name := objectio.BuildObjectName(segmentid, 0)
+	fileNum := uint16(0)
+	name := objectio.BuildObjectName(segmentid, fileNum)
 	writer, err := blockio.NewBlockWriterNew(fs, name, 0, nil)
 	if err != nil {
 		return
 	}
-	blockIndexs := make([][]*BlockLocation, MaxIDX)
+	checkpointNames[0] = name
+	objectBlocks := make([][]objectio.BlockObject, 0)
+	indexes := make([][]blockIndexes, MaxIDX)
+	schemas := make([][]uint16, 0)
 	schemaTypes := make([]uint16, 0)
+	var objectSize int
 	for i := range checkpointDataSchemas_Curr {
 		if i == int(MetaIDX) || i == int(TNMetaIDX) {
 			continue
@@ -1468,13 +1487,36 @@ func (data *CheckpointData) WriteTo(
 		formatBatch(data.bats[i])
 		var block objectio.BlockObject
 		var bat *containers.Batch
+		var size int
+		var blks []objectio.BlockObject
+		if objectSize > checkpointSize {
+			fileNum++
+			blks, _, err = writer.Sync(context.Background())
+			if err != nil {
+				return
+			}
+			name = objectio.BuildObjectName(segmentid, fileNum)
+			writer, err = blockio.NewBlockWriterNew(fs, name, 0, nil)
+			if err != nil {
+				return
+			}
+			checkpointNames = append(checkpointNames, name)
+			objectBlocks = append(objectBlocks, blks)
+			schemas = append(schemas, schemaTypes)
+			schemaTypes = make([]uint16, 0)
+			objectSize = 0
+		}
 		if data.bats[i].Length() == 0 {
-			if block, err = writer.WriteSubBatch(containers.ToCNBatch(data.bats[i]), objectio.ConvertToSchemaType(uint16(i))); err != nil {
+			if block, size, err = writer.WriteSubBatch(containers.ToCNBatch(data.bats[i]), objectio.ConvertToSchemaType(uint16(i))); err != nil {
 				return
 			}
 			blockLoc := BuildBlockLoaction(block.GetID(), uint64(offset), uint64(0))
-			blockIndexs[i] = append(blockIndexs[i], &blockLoc)
+			indexes[i] = append(indexes[i], blockIndexes{
+				fileNum: fileNum,
+				indexes: &blockLoc,
+			})
 			schemaTypes = append(schemaTypes, uint16(i))
+			objectSize += size
 		} else {
 			split := containers.NewBatchSplitter(data.bats[i], blockRows)
 			for {
@@ -1482,20 +1524,29 @@ func (data *CheckpointData) WriteTo(
 				if err != nil {
 					break
 				}
-				if block, err = writer.WriteSubBatch(containers.ToCNBatch(bat), objectio.ConvertToSchemaType(uint16(i))); err != nil {
+				if block, size, err = writer.WriteSubBatch(containers.ToCNBatch(bat), objectio.ConvertToSchemaType(uint16(i))); err != nil {
 					return
 				}
 				Endoffset := offset + bat.Length()
 				blockLoc := BuildBlockLoaction(block.GetID(), uint64(offset), uint64(Endoffset))
-				blockIndexs[i] = append(blockIndexs[i], &blockLoc)
+				indexes[i] = append(indexes[i], blockIndexes{
+					fileNum: fileNum,
+					indexes: &blockLoc,
+				})
 				schemaTypes = append(schemaTypes, uint16(i))
 				offset += bat.Length()
+				objectSize += size
 			}
 		}
 	}
 	blks, _, err := writer.Sync(context.Background())
+	if err != nil {
+		return
+	}
+	schemas = append(schemas, schemaTypes)
+	objectBlocks = append(objectBlocks, blks)
 
-	data.prepareTNMetaBatch(name, blks, schemaTypes)
+	data.prepareTNMetaBatch(checkpointNames, objectBlocks, schemas)
 
 	for tid, mata := range data.meta {
 		for i, table := range mata.tables {
@@ -1511,13 +1562,16 @@ func (data *CheckpointData) WriteTo(
 				}
 			}
 			idx := switchCheckpointIdx(uint16(i), tid)
-			for _, block := range blockIndexs[idx] {
+			for _, blockIdx := range indexes[idx] {
+				block := blockIdx.indexes
+				name = checkpointNames[blockIdx.fileNum]
 				if table.End <= block.GetStartOffset() {
 					break
 				}
 				if table.Start >= block.GetEndOffset() {
 					continue
 				}
+				blks = objectBlocks[blockIdx.fileNum]
 				//blockLoc1 := objectio.BuildLocation(name, blks[block.GetID()].GetExtent(), 0, block.GetID())
 				//logutil.Infof("write block %v to %d-%d, table is %d-%d", blockLoc1.String(), block.GetStartOffset(), block.GetEndOffset(), table.Start, table.End)
 				if table.Uint64Contains(block.GetStartOffset(), block.GetEndOffset()) {
@@ -1547,10 +1601,13 @@ func (data *CheckpointData) WriteTo(
 
 	data.meta[0] = NewCheckpointMeta()
 	data.meta[0].tables[0] = NewTableMeta()
-	blockLoc := BuildBlockLoactionWithLocation(
-		name, blks[0].GetExtent(), 0, blks[0].GetID(),
-		0, 0)
-	data.meta[0].tables[0].locations.Append(blockLoc)
+	for num, fileName := range checkpointNames {
+		loc := objectBlocks[num][0]
+		blockLoc := BuildBlockLoactionWithLocation(
+			fileName, loc.GetExtent(), 0, loc.GetID(),
+			0, 0)
+		data.meta[0].tables[0].locations.Append(blockLoc)
+	}
 	data.prepareMeta()
 	if err != nil {
 		return
@@ -1562,7 +1619,7 @@ func (data *CheckpointData) WriteTo(
 	if err != nil {
 		return
 	}
-	if _, err = writer2.WriteSubBatch(
+	if _, _, err = writer2.WriteSubBatch(
 		containers.ToCNBatch(data.bats[MetaIDX]),
 		objectio.ConvertToSchemaType(uint16(MetaIDX))); err != nil {
 		return
@@ -1570,7 +1627,7 @@ func (data *CheckpointData) WriteTo(
 	if err != nil {
 		return
 	}
-	if _, err = writer2.WriteSubBatch(
+	if _, _, err = writer2.WriteSubBatch(
 		containers.ToCNBatch(data.bats[TNMetaIDX]),
 		objectio.ConvertToSchemaType(uint16(TNMetaIDX))); err != nil {
 		return
@@ -1864,9 +1921,14 @@ func (data *CheckpointData) replayMetaBatch() {
 	for i := 0; i < data.bats[MetaIDX].GetVectorByName(SnapshotAttr_TID).Length(); i++ {
 		tid := tidVec[i]
 		if tid == 0 {
-			bl := BlockLocation(insVec[i])
-			loc := bl.GetLocation()
-			data.locations[loc.Name().String()] = loc
+			bl := BlockLocations(insVec[i])
+			it := bl.MakeIterator()
+			for it.HasNext() {
+				block := it.Next()
+				if !block.GetLocation().IsEmpty() {
+					data.locations[block.GetLocation().Name().String()] = block.GetLocation()
+				}
+			}
 			continue
 		}
 		insLocation := insVec[i]
@@ -1886,7 +1948,6 @@ func (data *CheckpointData) replayMetaBatch() {
 				block := it.Next()
 				if !block.GetLocation().IsEmpty() {
 					data.locations[block.GetLocation().Name().String()] = block.GetLocation()
-					return
 				}
 			}
 		}

--- a/pkg/vm/engine/tae/options/cfg.go
+++ b/pkg/vm/engine/tae/options/cfg.go
@@ -51,6 +51,7 @@ type CheckpointCfg struct {
 	// only for test
 	// it is used to control the block rows of the checkpoint
 	BlockRows int
+	Size      int
 }
 
 type GCCfg struct {


### PR DESCRIPTION
Limit the size of a single checkpoint file.
Because the offset of the layout is of uint32 type, a single file cannot exceed 4 G.

Approved by: @XuPeng-SH

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: