### PR TITLE
fix lockservice panic with try hold on empty lock

### DIFF
--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -193,12 +193,15 @@ func (l *localLockTable) unlock(
 			if !lock.holders.contains(txn.txnID) {
 				getLogger().Fatal("BUG: unlock a lock that is not held by the current txn")
 			}
+			if len(startKey) > 0 && !lock.isLockRangeEnd() {
+				panic("BUG: missing range end key")
+			}
 
-			lock.closeTxn(
+			lockCanRemoved := lock.closeTxn(
 				txn,
 				notifyValue{ts: commitTS})
 			logLockUnlocked(txn, key, lock)
-			if lock.isEmpty() {
+			if lockCanRemoved {
 				l.mu.store.Delete(key)
 				if len(startKey) > 0 {
 					l.mu.store.Delete(startKey)

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -480,25 +480,20 @@ func TestRangeLockWithWaitQueue(t *testing.T) {
 					wg.Add(2)
 
 					// add txn2 into wait queue
-					close2 := make(chan struct{})
 					go func() {
 						defer wg.Done()
 						_, err := s.Lock(ctx, table, rows, txn2, option)
 						require.NoError(t, err)
-						<-close2
 						require.NoError(t, s.Unlock(ctx, txn2, timestamp.Timestamp{}))
 					}()
 					require.NoError(t, waitLocalWaiters(lt, rows[0], 1))
 					checkLock(t, lt, rows[0], [][]byte{txn1}, [][]byte{txn2}, []int32{3})
 
 					// add txn3 into wait queue
-					close3 := make(chan struct{})
 					go func() {
 						defer wg.Done()
 						_, err := s.Lock(ctx, table, rows, txn3, option)
 						require.NoError(t, err)
-
-						<-close3
 						require.NoError(t, s.Unlock(ctx, txn3, timestamp.Timestamp{}))
 					}()
 
@@ -507,21 +502,8 @@ func TestRangeLockWithWaitQueue(t *testing.T) {
 					checkLock(t, lt, rows[0], [][]byte{txn1}, [][]byte{txn2, txn3}, []int32{3, 3})
 					checkLock(t, lt, rows[1], [][]byte{txn1}, [][]byte{txn2, txn3}, []int32{3, 3})
 
-					// close txn1, txn2 get lock
+					// close txn1, txn2 or txn3 get lock
 					require.NoError(t, s.Unlock(ctx, txn1, timestamp.Timestamp{}))
-					require.NoError(t, waitLocalWaiters(lt, rows[0], 1))
-					require.NoError(t, waitLocalWaiters(lt, rows[1], 1))
-					checkLock(t, lt, rows[0], [][]byte{txn2}, [][]byte{txn3}, []int32{3})
-					checkLock(t, lt, rows[1], [][]byte{txn2}, [][]byte{txn3}, []int32{3})
-
-					// close txn2, txn3 get lock
-					close(close2)
-					require.NoError(t, waitLocalWaiters(lt, rows[0], 0))
-					require.NoError(t, waitLocalWaiters(lt, rows[1], 0))
-					checkLock(t, lt, rows[0], [][]byte{txn3}, nil, nil)
-					checkLock(t, lt, rows[1], [][]byte{txn3}, nil, nil)
-
-					close(close3)
 					wg.Wait()
 				})
 		})
@@ -630,12 +612,14 @@ func TestRangeLockWithSameTxnWithConflict(t *testing.T) {
 
 					// close txn1, txn2 get lock
 					require.NoError(t, s.Unlock(ctx, txn1, timestamp.Timestamp{}))
+
 					require.NoError(t, waitLocalWaiters(lt, rows[0], 0))
 					require.NoError(t, waitLocalWaiters(lt, rows[1], 0))
-					checkLock(t, lt, rows[0], [][]byte{txn2}, nil, nil)
-					checkLock(t, lt, rows[1], [][]byte{txn2}, nil, nil)
 
 					wg.Wait()
+
+					checkLock(t, lt, rows[0], [][]byte{txn2}, nil, nil)
+					checkLock(t, lt, rows[1], [][]byte{txn2}, nil, nil)
 					require.NoError(t, s.Unlock(ctx, txn2, timestamp.Timestamp{}))
 				})
 		})
@@ -1235,6 +1219,108 @@ func TestRowLockWithConflictAndUnlock(t *testing.T) {
 			checkLock(t, lt, rows[0], [][]byte{txn1}, [][]byte{txn2}, []int32{1})
 			require.NoError(t, s.Unlock(ctx, txn1, timestamp.Timestamp{}))
 		})
+}
+
+func TestUnlockRangeLockCanNotifyAllWaiters(t *testing.T) {
+	table := uint64(0)
+	getRunner(false)(
+		t,
+		table,
+		func(
+			ctx context.Context,
+			s *service,
+			lt *localLockTable) {
+			rangeOption := newTestRangeExclusiveOptions()
+			rowOption := newTestRowExclusiveOptions()
+			rows := newTestRows(1, 10)
+			rows2 := newTestRows(2)
+			rows3 := newTestRows(3, 4)
+			txn1 := newTestTxnID(1)
+			txn2 := newTestTxnID(2)
+			txn3 := newTestTxnID(3)
+
+			// txn1 hold the lock
+			_, err := s.Lock(ctx, table, rows, txn1, rangeOption)
+			require.NoError(t, err)
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			// txn2 blocked by txn1
+			go func() {
+				defer wg.Done()
+
+				_, err := s.Lock(ctx, table, rows2, txn2, rowOption)
+				require.NoError(t, err)
+			}()
+			require.NoError(t, waitLocalWaiters(lt, rows[0], 1))
+			checkLock(t, lt, rows[0], [][]byte{txn1}, [][]byte{txn2}, []int32{3})
+
+			// txn3 blocked by txn1
+			go func() {
+				defer wg.Done()
+
+				_, err := s.Lock(ctx, table, rows3, txn3, rangeOption)
+				require.NoError(t, err)
+			}()
+			require.NoError(t, waitLocalWaiters(lt, rows[0], 2))
+			checkLock(t, lt, rows[0], [][]byte{txn1}, [][]byte{txn2, txn3}, []int32{3, 3})
+
+			// unlock txn, txn2 and txn3 can both get lock
+			require.NoError(t, s.Unlock(ctx, txn1, timestamp.Timestamp{}))
+
+			wg.Wait()
+			require.NoError(t, s.Unlock(ctx, txn2, timestamp.Timestamp{}))
+			require.NoError(t, s.Unlock(ctx, txn3, timestamp.Timestamp{}))
+		})
+}
+
+func TestHasAnyHolderCannotNotifyWaiters(t *testing.T) {
+	for name, runner := range runners {
+		t.Run(name, func(t *testing.T) {
+			table := uint64(0)
+			runner(
+				t,
+				table,
+				func(
+					ctx context.Context,
+					s *service,
+					lt *localLockTable) {
+					option := newTestRowSharedOptions()
+					rows := newTestRows(1)
+					txn1 := newTestTxnID(1)
+					txn2 := newTestTxnID(2)
+					txn3 := newTestTxnID(3)
+
+					// txn1 get lock
+					_, err := s.Lock(ctx, table, rows, txn1, option)
+					require.NoError(t, err)
+					checkLock(t, lt, rows[0], [][]byte{txn1}, nil, nil)
+
+					// txn2 get lock, shared
+					_, err = s.Lock(ctx, table, rows, txn2, option)
+					require.NoError(t, err)
+					checkLock(t, lt, rows[0], [][]byte{txn1, txn2}, nil, nil)
+
+					c := make(chan struct{})
+					// txn1 blocked by txn1 and txn2
+					go func() {
+						defer close(c)
+						_, err = s.Lock(ctx, table, rows, txn3, newTestRowExclusiveOptions())
+						require.NoError(t, err)
+					}()
+					waitLocalWaiters(lt, rows[0], 1)
+
+					// close txn1 cannot notify txn3
+					require.NoError(t, s.Unlock(ctx, txn1, timestamp.Timestamp{}))
+					require.True(t, checkLocalWaitersStatus(lt, rows[0], []waiterStatus{blocking}))
+
+					require.NoError(t, s.Unlock(ctx, txn2, timestamp.Timestamp{}))
+					<-c
+					require.NoError(t, s.Unlock(ctx, txn3, timestamp.Timestamp{}))
+				})
+		})
+	}
 }
 
 func BenchmarkWithoutConflict(b *testing.B) {

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -799,7 +799,7 @@ func TestManyRowLockInManyGoroutines(t *testing.T) {
 					rows := newTestRows(1, 2, 3, 4, 5, 6)
 
 					var succeeds atomic.Int32
-					sum := int32(200)
+					sum := int32(10)
 					var wg sync.WaitGroup
 					for i := int32(0); i < sum; i++ {
 						wg.Add(1)
@@ -834,7 +834,7 @@ func TestManyRangeLockInManyGoroutines(t *testing.T) {
 					rows := newTestRows(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 
 					var succeeds atomic.Int32
-					sum := int32(200)
+					sum := int32(10)
 					var wg sync.WaitGroup
 					for i := int32(0); i < sum; i++ {
 						wg.Add(1)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12015 

## What this PR does / why we need it:
Fix try hold on empty lock.  If a range lock has no holders, the all waiters need to be notified.  Because these waiters may be attempting to acquire a non-conflicting row locks or range locks between the current range.  Also, the range locks needs to be removed, otherwise an Empty Lock will be left in the lock table.