### PR TITLE
update mo_sessions view

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2576,7 +2576,10 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 		trace.WithKind(trace.SpanKindStatement))
 	defer span.End(trace.WithStatementExtra(ses.GetTxnId(), ses.GetStmtId(), ses.GetSqlOfStmt()))
 
+	ses.SetQueryInProgress(true)
 	ses.SetQueryStart(time.Now())
+	defer ses.SetQueryEnd(time.Now())
+	defer ses.SetQueryInProgress(false)
 
 	// per statement profiler
 	requestCtx, endStmtProfile := fileservice.NewStatementProfiler(requestCtx)

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -247,6 +247,7 @@ type Session struct {
 	stmtProfile process.StmtProfile
 	// queryEnd is the time when the query ends
 	queryEnd        time.Time
+	// queryInProgress indicates whether the query is in progress
 	queryInProgress atomic.Bool
 }
 

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -17,6 +17,7 @@ package frontend
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"sync"
 
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -32,6 +33,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/util/metric"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+)
+
+var (
+	dumpUUID = uuid.UUID{}
 )
 
 type TxnHandler struct {
@@ -229,7 +234,11 @@ func (th *TxnHandler) NewTxn() (context.Context, TxnOperator, error) {
 	//	txnOp.GetWorkspace().StartStatement()
 	//	th.enableStartStmt()
 	//}
-	th.ses.SetTxnId(txnOp.Txn().ID)
+	if err != nil {
+		th.ses.SetTxnId(dumpUUID[:])
+	} else {
+		th.ses.SetTxnId(txnOp.Txn().ID)
+	}
 	return txnCtx, txnOp, err
 }
 
@@ -337,6 +346,7 @@ func (th *TxnHandler) CommitTxn() error {
 		ses.updateLastCommitTS(txnOp.Txn().CommitTS)
 	}
 	th.SetTxnOperatorInvalid()
+	th.ses.SetTxnId(dumpUUID[:])
 	return err
 }
 
@@ -401,6 +411,7 @@ func (th *TxnHandler) RollbackTxn() error {
 		}
 	}
 	th.SetTxnOperatorInvalid()
+	th.ses.SetTxnId(dumpUUID[:])
 	return err
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11976 

## What this PR does / why we need it:

讨论见：https://github.com/matrixorigin/docs/blob/main/design/system_view.md#%E4%BC%9A%E8%AF%9D

策略调整：
1, 信息最多持续时间3秒。

    一个语句执行完成，最多3秒后，相关的信息会被清空。
    一个语句执行完成，如果下一条语句在3秒内开始执行，部分信息就是下一条的。
    ```
    //例子
    |---sql---|--空闲3s---|---下一个sql---|
             /|\        /|\     /|\
              |          |       |
              |          |       |---------看到部分信息被更新，不是所有信息同时更新。
              |          |
              |          |-------------看不到第一个sql的信息
              |
            看到第一个sql的信息。
        
    ```

2. txn_id。 
    
    - 事务的生命周期可能长于sql语句。例如：begin开启事务后，执行了一些语句。但是在commit/rollback之前事务一直存在。但此时可能没有执行语句。
    - commit/rollback之后，不论成果与否，事务都会结束。此时txn_id会被清空。
    - 事务创建失败。txn_id也为空