### PR TITLE
fileservice: write to disk cache in S3FS.Write and Read

### DIFF
--- a/pkg/fileservice/caching_file_service_test.go
+++ b/pkg/fileservice/caching_file_service_test.go
@@ -49,6 +49,7 @@ func testCachingFileService(
 				Data: data,
 			},
 		},
+		CachePolicy: SkipAll,
 	})
 	assert.Nil(t, err)
 

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -102,7 +101,7 @@ func (d *DiskCache) Read(
 		return nil
 	}
 
-	var numHit, numRead, numOpen, numError int64
+	var numHit, numRead, numOpenIOEntry, numOpenFull, numError int64
 	defer func() {
 		v2.FSReadHitDiskCounter.Add(float64(numHit))
 		perfcounter.Update(ctx, func(c *perfcounter.CounterSet) {
@@ -111,7 +110,8 @@ func (d *DiskCache) Read(
 			c.FileService.Cache.Disk.Read.Add(numRead)
 			c.FileService.Cache.Disk.Hit.Add(numHit)
 			c.FileService.Cache.Disk.Error.Add(numError)
-			c.FileService.Cache.Disk.OpenFile.Add(numOpen)
+			c.FileService.Cache.Disk.OpenIOEntryFile.Add(numOpenIOEntry)
+			c.FileService.Cache.Disk.OpenFullFile.Add(numOpenFull)
 		}, d.perfCounterSets...)
 	}()
 
@@ -133,15 +133,33 @@ func (d *DiskCache) Read(
 		numRead++
 
 		var file *os.File
-		// open entry file
-		entryPath := d.entryDataFilePath(path.File, entry)
-		d.waitUpdateComplete(entryPath)
-		entryFile, err := os.Open(entryPath)
+
+		// entry file
+		diskPath := d.pathForIOEntry(path.File, entry)
+		d.waitUpdateComplete(diskPath)
+		diskFile, err := os.Open(diskPath)
 		if err == nil {
-			file = entryFile
-			defer entryFile.Close()
-			numOpen++
+			file = diskFile
+			defer diskFile.Close()
+			numOpenIOEntry++
 		}
+
+		if file == nil {
+			// full file
+			diskPath := d.pathForFile(path.File)
+			d.waitUpdateComplete(diskPath)
+			diskFile, err := os.Open(diskPath)
+			if err == nil {
+				defer diskFile.Close()
+				numOpenFull++
+				// seek
+				_, err = diskFile.Seek(entry.Offset, io.SeekStart)
+				if err == nil {
+					file = diskFile
+				}
+			}
+		}
+
 		if file == nil {
 			// no file available
 			continue
@@ -179,16 +197,6 @@ func (d *DiskCache) Update(
 		return nil
 	}
 
-	var numOpen, numStat, numError, numWrite int64
-	defer func() {
-		perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
-			set.FileService.Cache.Disk.OpenFile.Add(numOpen)
-			set.FileService.Cache.Disk.StatFile.Add(numStat)
-			set.FileService.Cache.Disk.WriteFile.Add(numWrite)
-			set.FileService.Cache.Disk.Error.Add(numError)
-		})
-	}()
-
 	path, err := ParsePath(vector.FilePath)
 	if err != nil {
 		return err
@@ -214,66 +222,82 @@ func (d *DiskCache) Update(
 			continue
 		}
 
-		entryFilePath := d.entryDataFilePath(path.File, entry)
-
-		func() {
-			doneUpdate := d.startUpdate(entryFilePath)
-			defer doneUpdate()
-
-			if _, ok := d.fileExists.Load(entryFilePath); ok {
-				// already exists
-				return
-			}
-			_, err := os.Stat(entryFilePath)
-			if err == nil {
-				// file exists
-				d.fileExists.Store(entryFilePath, true)
-				numStat++
-				return
-			}
-
-			// write data
-			dir := filepath.Dir(entryFilePath)
-			err = os.MkdirAll(dir, 0755)
-			if err != nil {
-				numError++
-				return // ignore error
-			}
-			f, err := os.CreateTemp(dir, "*")
-			if err != nil {
-				numError++
-				return // ignore error
-			}
-			numOpen++
-			n, err := f.Write(entry.Data)
-			if err != nil {
-				f.Close()
-				os.Remove(f.Name())
-				numError++
-				return // ignore error
-			}
-			if err := f.Close(); err != nil {
-				numError++
-				return // ignore error
-			}
-			if err := os.Rename(f.Name(), entryFilePath); err != nil {
-				numError++
-				return // ignore error
-			}
-
-			numWrite++
-			d.triggerEvict(ctx, int64(n))
-			d.fileExists.Store(entryFilePath, true)
-
+		diskPath := d.pathForIOEntry(path.File, entry)
+		written, err := d.writeFile(ctx, diskPath, entry.Data)
+		if err != nil {
+			return err
+		}
+		if written {
 			for _, fn := range onWritten {
 				fn(vector.FilePath, entry)
 			}
-
-		}()
+		}
 
 	}
 
 	return nil
+}
+
+func (d *DiskCache) writeFile(ctx context.Context, diskPath string, data []byte) (bool, error) {
+	var numCreate, numStat, numError, numWrite int64
+	defer func() {
+		perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
+			set.FileService.Cache.Disk.CreateFile.Add(numCreate)
+			set.FileService.Cache.Disk.StatFile.Add(numStat)
+			set.FileService.Cache.Disk.WriteFile.Add(numWrite)
+			set.FileService.Cache.Disk.Error.Add(numError)
+		})
+	}()
+
+	doneUpdate := d.startUpdate(diskPath)
+	defer doneUpdate()
+
+	if _, ok := d.fileExists.Load(diskPath); ok {
+		// already exists
+		return false, nil
+	}
+	_, err := os.Stat(diskPath)
+	if err == nil {
+		// file exists
+		d.fileExists.Store(diskPath, true)
+		numStat++
+		return false, nil
+	}
+
+	// write data
+	dir := filepath.Dir(diskPath)
+	err = os.MkdirAll(dir, 0755)
+	if err != nil {
+		numError++
+		return false, nil // ignore error
+	}
+	f, err := os.CreateTemp(dir, "*")
+	if err != nil {
+		numError++
+		return false, nil // ignore error
+	}
+	numCreate++
+	n, err := f.Write(data)
+	if err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		numError++
+		return false, nil // ignore error
+	}
+	if err := f.Close(); err != nil {
+		numError++
+		return false, nil // ignore error
+	}
+	if err := os.Rename(f.Name(), diskPath); err != nil {
+		numError++
+		return false, nil // ignore error
+	}
+
+	numWrite++
+	d.triggerEvict(ctx, int64(n))
+	d.fileExists.Store(diskPath, true)
+
+	return true, nil
 }
 
 func (d *DiskCache) Flush() {
@@ -404,40 +428,9 @@ func (d *DiskCache) evict(ctx context.Context) {
 	}
 }
 
-func (d *DiskCache) newFileContentWriter(contentPath string) (w io.Writer, done func(context.Context) error, closeFunc func() error, err error) {
-	dir := filepath.Dir(contentPath)
-	err = os.MkdirAll(dir, 0755)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	f, err := os.CreateTemp(dir, "*")
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	var doneOnce sync.Once
-	return f, func(ctx context.Context) (err error) {
-		doneOnce.Do(func() {
-			var info fs.FileInfo
-			info, err = f.Stat()
-			if err != nil {
-				return
-			}
-			name := f.Name()
-			if err = f.Close(); err != nil {
-				return
-			}
-			if err = os.Rename(name, contentPath); err != nil {
-				return
-			}
-			d.triggerEvict(ctx, info.Size())
-		})
-		return
-	}, f.Close, nil
-}
-
 const cacheFileSuffix = ".mofscache"
 
-func (d *DiskCache) entryDataFilePath(path string, entry IOEntry) string {
+func (d *DiskCache) pathForIOEntry(path string, entry IOEntry) string {
 	if entry.Size < 0 {
 		panic("should not cache size -1 entry")
 	}
@@ -445,6 +438,14 @@ func (d *DiskCache) entryDataFilePath(path string, entry IOEntry) string {
 		d.path,
 		toOSPath(path),
 		fmt.Sprintf("%d-%d%s", entry.Offset, entry.Size, cacheFileSuffix),
+	)
+}
+
+func (d *DiskCache) pathForFile(path string) string {
+	return filepath.Join(
+		d.path,
+		toOSPath(path),
+		fmt.Sprintf("full%s", cacheFileSuffix),
 	)
 }
 
@@ -470,4 +471,15 @@ func (d *DiskCache) startUpdate(path string) (done func()) {
 		d.updatingPaths.L.Unlock()
 	}
 	return
+}
+
+var _ FileCache = new(DiskCache)
+
+func (d *DiskCache) SetFile(ctx context.Context, path string, content []byte) error {
+	diskPath := d.pathForFile(path)
+	_, err := d.writeFile(ctx, diskPath, content)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/fileservice/file_cache.go
+++ b/pkg/fileservice/file_cache.go
@@ -1,0 +1,23 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"context"
+)
+
+type FileCache interface {
+	SetFile(ctx context.Context, path string, content []byte) error
+}

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/tls"
 	"io"
-	"math"
 	"net/http/httptrace"
 	pathpkg "path"
 	"sort"
@@ -41,11 +40,10 @@ type S3FS struct {
 	storage   ObjectStorage
 	keyPrefix string
 
-	memCache              *MemCache
-	diskCache             *DiskCache
-	remoteCache           *RemoteCache
-	asyncUpdate           bool
-	writeDiskCacheOnWrite bool
+	memCache    *MemCache
+	diskCache   *DiskCache
+	remoteCache *RemoteCache
+	asyncUpdate bool
 
 	perfCounterSets []*perfcounter.CounterSet
 
@@ -301,29 +299,7 @@ func (s *S3FS) write(ctx context.Context, vector IOVector) (bytesWritten int, er
 
 	// content
 	var content []byte
-	if s.writeDiskCacheOnWrite && s.diskCache != nil {
-		// also write to disk cache
-		w, done, closeW, err := s.diskCache.newFileContentWriter(vector.FilePath)
-		if err != nil {
-			return 0, err
-		}
-		defer closeW()
-		defer func() {
-			if err != nil {
-				return
-			}
-			err = done(ctx)
-		}()
-		r := io.TeeReader(
-			newIOEntriesReader(ctx, vector.Entries),
-			w,
-		)
-		content, err = io.ReadAll(r)
-		if err != nil {
-			return 0, err
-		}
-
-	} else if len(vector.Entries) == 1 &&
+	if len(vector.Entries) == 1 &&
 		vector.Entries[0].Size > 0 &&
 		int(vector.Entries[0].Size) == len(vector.Entries[0].Data) {
 		// one piece of data
@@ -353,6 +329,13 @@ func (s *S3FS) write(ctx context.Context, vector IOVector) (bytesWritten int, er
 	key := s.pathToKey(path.File)
 	if err := s.storage.Write(ctx, key, r, size, expire); err != nil {
 		return 0, err
+	}
+
+	// write to disk cache
+	if s.diskCache != nil && !vector.CachePolicy.Any(SkipDiskWrites) {
+		if err := s.diskCache.SetFile(ctx, vector.FilePath, content); err != nil {
+			return 0, err
+		}
 	}
 
 	return len(content), nil
@@ -457,32 +440,30 @@ func (s *S3FS) read(ctx context.Context, vector *IOVector, bytesCounter *atomic.
 	}
 
 	// calculate object read range
-	min := ptrTo(int64(math.MaxInt))
-	max := ptrTo(int64(0))
-	readToEnd := false
-	n := 0
-	for _, entry := range vector.Entries {
-		entry := entry
-		if entry.done {
-			continue
-		}
-		n++
-		if entry.Offset < *min {
-			min = &entry.Offset
-		}
-		if entry.Size < 0 {
-			entry.Size = 0
-			readToEnd = true
-		}
-		if end := entry.Offset + entry.Size; end > *max {
-			max = &end
-		}
-	}
-	if readToEnd {
-		max = nil
-	}
+	//min := ptrTo(int64(math.MaxInt))
+	//max := ptrTo(int64(0))
+	//for _, entry := range vector.Entries {
+	//	entry := entry
+	//	if entry.done {
+	//		continue
+	//	}
+	//	if entry.Offset < *min {
+	//		min = &entry.Offset
+	//	}
+	//	if entry.Size < 0 {
+	//		entry.Size = 0
+	//		max = nil
+	//	}
+	//	if max != nil {
+	//		if end := entry.Offset + entry.Size; end > *max {
+	//			max = &end
+	//		}
+	//	}
+	//}
 
-	v2.FSReadS3Counter.Add(float64(n))
+	// just read the whole object
+	min := ptrTo[int64](0)
+	max := (*int64)(nil)
 
 	// a function to get an io.ReadCloser
 	getReader := func(ctx context.Context, min *int64, max *int64) (io.ReadCloser, error) {
@@ -531,11 +512,16 @@ func (s *S3FS) read(ctx context.Context, vector *IOVector, bytesCounter *atomic.
 		return
 	}
 
+	numNotDoneEntries := 0
+	defer func() {
+		v2.FSReadS3Counter.Add(float64(numNotDoneEntries))
+	}()
 	for i, entry := range vector.Entries {
 		if entry.done {
 			continue
 		}
 		entry := entry
+		numNotDoneEntries++
 
 		start := entry.Offset - *min
 
@@ -659,6 +645,16 @@ func (s *S3FS) read(ctx context.Context, vector *IOVector, bytesCounter *atomic.
 		}
 
 		vector.Entries[i] = entry
+	}
+
+	// write to disk cache
+	if contentErr == nil &&
+		len(contentBytes) > 0 &&
+		s.diskCache != nil &&
+		!vector.CachePolicy.Any(SkipDiskWrites) {
+		if err := s.diskCache.SetFile(ctx, vector.FilePath, contentBytes); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/perfcounter/counter_set.go
+++ b/pkg/perfcounter/counter_set.go
@@ -53,7 +53,9 @@ type FileServiceCounterSet struct {
 			Hit              stats.Counter
 			GetFileContent   stats.Counter
 			SetFileContent   stats.Counter
-			OpenFile         stats.Counter
+			OpenIOEntryFile  stats.Counter
+			OpenFullFile     stats.Counter
+			CreateFile       stats.Counter
 			StatFile         stats.Counter
 			WriteFile        stats.Counter
 			Error            stats.Counter


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11569 

## What this PR does / why we need it:
fileservice: add FileCache

fileservice: rename DiskCache.entryDataFilePath to pathForIOEntry

fileservice: sketch FileCache impl for DiskCache

fileservice: remove S3FS.writeDiskCacheOnWrite

fileservice: add DiskCache.writeFile

fileservice: remove FileCache.GetFile; try get full file in DiskCache.Read

fileservice: add DiskCache.SetFile tests

fileservice: write to disk file cache in S3FS.write