### PR TITLE
Fix batch splitter (#12311)

### DIFF
--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -2856,10 +2856,32 @@ func (v *Vector) Window(start, end int) (*Vector, error) {
 
 // CloneWindow Deep copies the content from start to end into another vector. Afterwise it's safe to destroy the original one.
 func (v *Vector) CloneWindow(start, end int, mp *mpool.MPool) (*Vector, error) {
-	w := NewVec(v.typ)
 	if start == end {
-		return w, nil
+		return NewVec(v.typ), nil
 	}
+	if end > v.Length() {
+		panic(fmt.Sprintf("CloneWindow end %d >= length %d", end, v.Length()))
+	}
+	if v.IsConstNull() {
+		return NewConstNull(v.typ, end-start, mp), nil
+	} else if v.IsConst() {
+		if v.typ.IsVarlen() {
+			return NewConstBytes(v.typ, v.GetBytesAt(0), end-start, mp), nil
+		} else {
+			vec := NewVec(v.typ)
+			vec.class = v.class
+			vec.col = v.col
+			vec.data = make([]byte, len(v.data))
+			copy(vec.data, v.data)
+			vec.capacity = v.capacity
+			vec.length = end - start
+			vec.cantFreeArea = true
+			vec.cantFreeData = true
+			vec.sorted = v.sorted
+			return vec, nil
+		}
+	}
+	w := NewVec(v.typ)
 	if err := v.CloneWindowTo(w, start, end, mp); err != nil {
 		return nil, err
 	}

--- a/pkg/container/vector/vector_test.go
+++ b/pkg/container/vector/vector_test.go
@@ -663,6 +663,27 @@ func TestCopy(t *testing.T) {
 	}
 }
 
+func TestCloneWindow(t *testing.T) {
+	mp := mpool.MustNewZero()
+	v1 := NewConstNull(types.T_int32.ToType(), 10, mp)
+	defer v1.Free(mp)
+	v2, err := v1.CloneWindow(3, 5, mp)
+	defer v2.Free(mp)
+	require.NoError(t, err)
+	require.True(t, v2.IsConstNull())
+	require.Equal(t, 2, v2.Length())
+
+	v3 := NewConstFixed[int32](types.T_int32.ToType(), 10, 20, mp)
+	defer v3.Free(mp)
+	v4, err := v3.CloneWindow(3, 5, mp)
+	defer v4.Free(mp)
+	require.NoError(t, err)
+	require.True(t, v4.IsConst())
+	require.Equal(t, 2, v4.Length())
+	require.Equal(t, int32(10), GetFixedAt[int32](v4, 0))
+	require.Equal(t, int32(10), GetFixedAt[int32](v4, 1))
+}
+
 func TestCloneWindowWithMpNil(t *testing.T) {
 	mp := mpool.MustNewZero()
 	vec1 := NewVec(types.T_int32.ToType())

--- a/pkg/vm/engine/tae/containers/batch.go
+++ b/pkg/vm/engine/tae/containers/batch.go
@@ -542,7 +542,7 @@ func (bs *BatchSplitter) Next() (*Batch, error) {
 		nextOffset = bs.internal.Length()
 		length = nextOffset - bs.offset
 	}
-	bat := bs.internal.Window(bs.offset, length)
+	bat := bs.internal.CloneWindow(bs.offset, length)
 	bs.offset = nextOffset
 	return bat, nil
 }

--- a/pkg/vm/engine/tae/containers/vector.go
+++ b/pkg/vm/engine/tae/containers/vector.go
@@ -385,9 +385,11 @@ func (vec *vectorWrapper) CloneWindow(offset, length int, allocator ...*mpool.MP
 	}
 
 	cloned := NewVector(*vec.GetType(), opts)
-	if err := vec.wrapped.CloneWindowTo(cloned.wrapped, offset, offset+length, cloned.GetAllocator()); err != nil {
+	v, err := vec.wrapped.CloneWindow(offset, offset+length, cloned.GetAllocator())
+	if err != nil {
 		panic(err)
 	}
+	cloned.setDownstreamVector(v)
 	return cloned
 }
 

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -1533,6 +1533,7 @@ func (data *CheckpointData) WriteTo(
 				if err != nil {
 					break
 				}
+				defer bat.Close()
 				if block, size, err = writer.WriteSubBatch(containers.ToCNBatch(bat), objectio.ConvertToSchemaType(uint16(i))); err != nil {
 					return
 				}
@@ -2317,6 +2318,7 @@ func (collector *BaseCollector) VisitTable(entry *catalog.TableEntry) (err error
 			for _, name := range tblNode.BaseNode.Schema.Extra.DroppedAttrs {
 				tableColDelBat.GetVectorByName(catalog.AttrRowID).Append(objectio.HackBytes2Rowid([]byte(fmt.Sprintf("%d-%s", entry.GetID(), name))), false)
 				tableColDelBat.GetVectorByName(catalog.AttrCommitTs).Append(tblNode.GetEnd(), false)
+				tableColDelBat.GetVectorByName(pkgcatalog.SystemColAttr_UniqName).Append([]byte(fmt.Sprintf("%d-%s", entry.GetID(), name)), false)
 			}
 			rowidVec := tableColInsBat.GetVectorByName(catalog.AttrRowID)
 			commitVec := tableColInsBat.GetVectorByName(catalog.AttrCommitTs)


### PR DESCRIPTION
When writing checkpoint, mo needs to split the vector into multiple small vectors according to 10,000 rows before writing. Now use the windown interface to split it, causing each small vector of 10,000 lines to reference the same Vector.area. Causes the vector's writing size to expand 10 times. fix now

Approved by: @aunjgr, @XuPeng-SH

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: