### PR TITLE
[bug] proxy: re-execute use statement after session is transferred.

### DIFF
--- a/pkg/proxy/client_conn.go
+++ b/pkg/proxy/client_conn.go
@@ -123,12 +123,12 @@ type clientConn struct {
 	router Router
 	// tun is the tunnel which this client connection belongs to.
 	tun *tunnel
-	// setVarStmts keeps all set user variable statements. When connection
-	// is transferred, set all these variables first.
-	setVarStmts []string
-	// prepareStmts keeps all prepare statements. When connection
-	// is transferred, execute all these prepare statements first.
-	prepareStmts []string
+	// redoStmts keeps all the statements that need to re-execute in the
+	// new session after it is transferred. It should contain:
+	// 1. set variable stmts
+	// 2. prepare stmts
+	// 3. use stmts
+	redoStmts []string
 	// tlsConfig is the config of TLS.
 	tlsConfig *tls.Config
 	// ipNetList is the list of ip net, which is parsed from CIDRs.
@@ -266,6 +266,8 @@ func (c *clientConn) HandleEvent(ctx context.Context, e IEvent, resp chan<- []by
 		return c.handleSetVar(ev)
 	case *prepareEvent:
 		return c.handlePrepare(ev)
+	case *useEvent:
+		return c.handleUse(ev)
 	default:
 	}
 	return nil
@@ -347,13 +349,19 @@ func (c *clientConn) handleKillQuery(e *killQueryEvent, resp chan<- []byte) erro
 
 // handleSetVar handles the set variable event.
 func (c *clientConn) handleSetVar(e *setVarEvent) error {
-	c.setVarStmts = append(c.setVarStmts, e.stmt)
+	c.redoStmts = append(c.redoStmts, e.stmt)
 	return nil
 }
 
 // handleSetVar handles the prepare event.
 func (c *clientConn) handlePrepare(e *prepareEvent) error {
-	c.prepareStmts = append(c.prepareStmts, e.stmt)
+	c.redoStmts = append(c.redoStmts, e.stmt)
+	return nil
+}
+
+// handleUse handles the use event.
+func (c *clientConn) handleUse(e *useEvent) error {
+	c.redoStmts = append(c.redoStmts, e.stmt)
 	return nil
 }
 
@@ -432,19 +440,13 @@ func (c *clientConn) connectToBackend(sendToClient bool) (ServerConn, error) {
 			codeAuthFailed)
 	}
 
-	// Set the use defined variables, including session variables and user variables.
-	for _, stmt := range c.setVarStmts {
+	// Re-execute the statements.
+	for _, stmt := range c.redoStmts {
 		if _, err := sc.ExecStmt(stmt, nil); err != nil {
 			return nil, err
 		}
 	}
 
-	// Execute the prepare statements.
-	for _, stmt := range c.prepareStmts {
-		if _, err := sc.ExecStmt(stmt, nil); err != nil {
-			return nil, err
-		}
-	}
 	return sc, nil
 }
 

--- a/pkg/proxy/event.go
+++ b/pkg/proxy/event.go
@@ -34,6 +34,8 @@ func (t eventType) String() string {
 		return "SetVar"
 	case TypePrepare:
 		return "Prepare"
+	case TypeUse:
+		return "Use"
 	}
 	return "Unknown"
 }
@@ -47,6 +49,8 @@ const (
 	TypeSetVar eventType = 2
 	// TypePrepare indicates the prepare statement.
 	TypePrepare eventType = 5
+	// TypeUse indicates the use database statement.
+	TypeUse eventType = 6
 )
 
 // IEvent is the event interface.
@@ -101,6 +105,8 @@ func makeEvent(msg []byte) (IEvent, bool) {
 			return makeSetVarEvent(sql), false
 		case *tree.PrepareString:
 			return makePrepareEvent(sql), false
+		case *tree.Use:
+			return makeUseEvent(sql), false
 		default:
 			return nil, false
 		}
@@ -175,4 +181,24 @@ func makePrepareEvent(stmt string) IEvent {
 // eventType implements the IEvent interface.
 func (e *prepareEvent) eventType() eventType {
 	return TypePrepare
+}
+
+// useEvent is the event that execute a use statement.
+type useEvent struct {
+	baseEvent
+	stmt string
+}
+
+// makeUseEvent creates an event with TypeUse type.
+func makeUseEvent(stmt string) IEvent {
+	e := &prepareEvent{
+		stmt: stmt,
+	}
+	e.typ = TypeUse
+	return e
+}
+
+// eventType implements the IEvent interface.
+func (e *useEvent) eventType() eventType {
+	return TypeUse
 }

--- a/pkg/proxy/event.go
+++ b/pkg/proxy/event.go
@@ -191,7 +191,7 @@ type useEvent struct {
 
 // makeUseEvent creates an event with TypeUse type.
 func makeUseEvent(stmt string) IEvent {
-	e := &prepareEvent{
+	e := &useEvent{
 		stmt: stmt,
 	}
 	e.typ = TypeUse

--- a/pkg/proxy/event_test.go
+++ b/pkg/proxy/event_test.go
@@ -413,7 +413,7 @@ func TestSetVarEvent(t *testing.T) {
 
 	// wait for result
 	<-res
-	require.Equal(t, 1, len(cc2.(*mockClientConn).setVarStmts))
+	require.Equal(t, 1, len(cc2.(*mockClientConn).redoStmts))
 
 	select {
 	case err = <-errChan:
@@ -569,7 +569,163 @@ func TestPrepareEvent(t *testing.T) {
 
 	// wait for result
 	<-res
-	require.Equal(t, 1, len(cc2.(*mockClientConn).prepareStmts))
+	require.Equal(t, 1, len(cc2.(*mockClientConn).redoStmts))
+
+	select {
+	case err = <-errChan:
+		t.Fatalf("require no error, but got %v", err)
+	default:
+	}
+}
+
+func TestUseEvent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	temp := os.TempDir()
+	tp := newTestProxyHandler(t)
+	defer tp.closeFn()
+
+	addr1 := fmt.Sprintf("%s/%d.sock", temp, time.Now().Nanosecond())
+	require.NoError(t, os.RemoveAll(addr1))
+	cn1 := testMakeCNServer("uuid1", addr1, 10, "", labelInfo{})
+	stopFn1 := startTestCNServer(t, tp.ctx, addr1, nil)
+	defer func() {
+		require.NoError(t, stopFn1())
+	}()
+
+	addr2 := fmt.Sprintf("%s/%d.sock", temp, time.Now().Nanosecond())
+	require.NoError(t, os.RemoveAll(addr2))
+	cn2 := testMakeCNServer("uuid2", addr2, 20, "", labelInfo{})
+	stopFn2 := startTestCNServer(t, tp.ctx, addr2, nil)
+	defer func() {
+		require.NoError(t, stopFn2())
+	}()
+
+	tu1 := newTunnel(tp.ctx, tp.logger, nil)
+	defer func() { _ = tu1.Close() }()
+	tu2 := newTunnel(tp.ctx, tp.logger, nil)
+	defer func() { _ = tu2.Close() }()
+
+	// Client2 will send "kill query 10", which will route to the server which
+	// has connection ID 10. In this case, the connection is server1.
+	clientProxy1, _ := net.Pipe()
+	serverProxy1, _ := net.Pipe()
+
+	cc1 := newMockClientConn(clientProxy1, "t1", clientInfo{}, tp.ru, tu1)
+	require.NotNil(t, cc1)
+	sc1 := newMockServerConn(serverProxy1)
+	require.NotNil(t, sc1)
+
+	clientProxy2, client2 := net.Pipe()
+	serverProxy2, _ := net.Pipe()
+
+	cc2 := newMockClientConn(clientProxy2, "t1", clientInfo{}, tp.ru, tu2)
+	require.NotNil(t, cc2)
+	sc2 := newMockServerConn(serverProxy2)
+	require.NotNil(t, sc2)
+
+	res := make(chan []byte)
+	st := stopper.NewStopper("test-event", stopper.WithLogger(tp.logger.RawLogger()))
+	defer st.Stop()
+	err := st.RunNamedTask("test-event-handler", func(ctx context.Context) {
+		for {
+			select {
+			case e := <-tu2.reqC:
+				_ = cc2.HandleEvent(ctx, e, tu2.respC)
+			case r := <-tu2.respC:
+				if len(r) > 0 {
+					res <- r
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+	require.NoError(t, err)
+
+	// tunnel1 is on cn1, connection ID is 10.
+	_, _, err = tp.ru.Connect(cn1, testPacket, tu1)
+	require.NoError(t, err)
+
+	// tunnel2 is on cn2, connection ID is 20.
+	_, _, err = tp.ru.Connect(cn2, testPacket, tu2)
+	require.NoError(t, err)
+
+	err = tu1.run(cc1, sc1)
+	require.NoError(t, err)
+	require.Nil(t, tu1.ctx.Err())
+
+	func() {
+		tu1.mu.Lock()
+		defer tu1.mu.Unlock()
+		require.True(t, tu1.mu.started)
+	}()
+
+	err = tu2.run(cc2, sc2)
+	require.NoError(t, err)
+	require.Nil(t, tu2.ctx.Err())
+
+	func() {
+		tu2.mu.Lock()
+		defer tu2.mu.Unlock()
+		require.True(t, tu2.mu.started)
+	}()
+
+	tu1.mu.Lock()
+	csp1 := tu1.mu.csp
+	scp1 := tu1.mu.scp
+	tu1.mu.Unlock()
+
+	tu2.mu.Lock()
+	csp2 := tu2.mu.csp
+	scp2 := tu2.mu.scp
+	tu2.mu.Unlock()
+
+	barrierStart1, barrierEnd1 := make(chan struct{}), make(chan struct{})
+	barrierStart2, barrierEnd2 := make(chan struct{}), make(chan struct{})
+	csp1.testHelper.beforeSend = func() {
+		<-barrierStart1
+		<-barrierEnd1
+	}
+	csp2.testHelper.beforeSend = func() {
+		<-barrierStart2
+		<-barrierEnd2
+	}
+
+	csp1.mu.Lock()
+	require.True(t, csp1.mu.started)
+	csp1.mu.Unlock()
+
+	scp1.mu.Lock()
+	require.True(t, scp1.mu.started)
+	scp1.mu.Unlock()
+
+	csp2.mu.Lock()
+	require.True(t, csp2.mu.started)
+	csp2.mu.Unlock()
+
+	scp2.mu.Lock()
+	require.True(t, scp2.mu.started)
+	scp2.mu.Unlock()
+
+	// Client2 writes some MySQL packets.
+	sendEventCh := make(chan struct{}, 1)
+	errChan := make(chan error, 1)
+	go func() {
+		<-sendEventCh
+		if _, err := client2.Write(makeSimplePacket("use d1")); err != nil {
+			errChan <- err
+			return
+		}
+	}()
+
+	sendEventCh <- struct{}{}
+	barrierStart2 <- struct{}{}
+	barrierEnd2 <- struct{}{}
+
+	// wait for result
+	<-res
+	require.Equal(t, 1, len(cc2.(*mockClientConn).redoStmts))
 
 	select {
 	case err = <-errChan:
@@ -590,4 +746,7 @@ func TestEventType_String(t *testing.T) {
 
 	e6 := prepareEvent{}
 	require.Equal(t, "Prepare", e6.eventType().String())
+
+	e7 := useEvent{}
+	require.Equal(t, "Use", e7.eventType().String())
 }

--- a/pkg/proxy/server_conn_test.go
+++ b/pkg/proxy/server_conn_test.go
@@ -120,7 +120,7 @@ type testHandler struct {
 	conn        goetty.IOSession
 	sessionVars map[string]string
 	prepareStmt map[string]struct{}
-	useStmt     map[string]string
+	useStmt     map[string]struct{}
 	labels      map[string]string
 	server      *testCNServer
 	status      uint16
@@ -237,6 +237,7 @@ func (s *testCNServer) Start() error {
 						cid, c, 0, &fp),
 					sessionVars: make(map[string]string),
 					prepareStmt: make(map[string]struct{}),
+					useStmt:     make(map[string]struct{}),
 					labels:      make(map[string]string),
 					server:      s,
 				}
@@ -343,7 +344,7 @@ func (h *testHandler) handleUse(packet *frontend.Packet) {
 	if len(words) < 2 {
 		_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeErrPayload(0, "", "invalid stmt"))
 	}
-	h.prepareStmt[words[1]] = struct{}{}
+	h.useStmt[words[1]] = struct{}{}
 	h.mysqlProto.SetSequenceID(1)
 	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeOKPayload(0, uint64(h.connID), h.status, 0, ""))
 }

--- a/pkg/proxy/server_conn_test.go
+++ b/pkg/proxy/server_conn_test.go
@@ -120,6 +120,7 @@ type testHandler struct {
 	conn        goetty.IOSession
 	sessionVars map[string]string
 	prepareStmt map[string]struct{}
+	useStmt     map[string]string
 	labels      map[string]string
 	server      *testCNServer
 	status      uint16
@@ -277,6 +278,8 @@ func testHandle(h *testHandler) {
 				h.handlePrepare(packet)
 			} else if strings.HasPrefix(string(packet.Payload[1:]), "execute") {
 				h.handleExecute(packet)
+			} else if strings.HasPrefix(string(packet.Payload[1:]), "use") {
+				h.handleUse(packet)
 			} else if string(packet.Payload[1:]) == "show session variables" {
 				h.handleShowVar()
 			} else if string(packet.Payload[1:]) == "show global variables" {
@@ -333,6 +336,16 @@ func (h *testHandler) handleExecute(packet *frontend.Packet) {
 		_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeErrPayload(0, "",
 			fmt.Sprintf("no such prepared stmt %s", words[1])))
 	}
+}
+
+func (h *testHandler) handleUse(packet *frontend.Packet) {
+	words := strings.Split(string(packet.Payload[1:]), " ")
+	if len(words) < 2 {
+		_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeErrPayload(0, "", "invalid stmt"))
+	}
+	h.prepareStmt[words[1]] = struct{}{}
+	h.mysqlProto.SetSequenceID(1)
+	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeOKPayload(0, uint64(h.connID), h.status, 0, ""))
 }
 
 func (h *testHandler) handleKillConn() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/1563

## What this PR does / why we need it:
When proxy transfer a connection to a new CN server, use statement
should be re-executed to make sure the tables could be found in session.