### PR TITLE
[bug] logtail: fix hang when logtail consumer reconnect.

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -206,6 +206,7 @@ const (
 	ErrTxnCannotRetry             uint16 = 20630
 	ErrTxnNeedRetryWithDefChanged uint16 = 20631
 	ErrTxnStale                   uint16 = 20632
+	ErrWaiterCanceled             uint16 = 20633
 
 	// Group 7: lock service
 	// ErrDeadLockDetected lockservice has detected a deadlock and should abort the transaction if it receives this error
@@ -414,6 +415,7 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	ErrTxnCannotRetry:             {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "txn s3 writes can not retry in rc mode"},
 	ErrTxnNeedRetryWithDefChanged: {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "txn need retry in rc mode, def changed"},
 	ErrTxnStale:                   {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "txn is stale: timestamp is too small"},
+	ErrWaiterCanceled:             {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "waiter is canceled"},
 
 	// Group 7: lock service
 	ErrDeadLockDetected:     {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "deadlock detected"},

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -270,6 +270,10 @@ func NewTxnStaleNoCtx() *Error {
 	return newError(Context(), ErrTxnStale)
 }
 
+func NewWaiterCanceledNoCtx() *Error {
+	return newError(Context(), ErrWaiterCanceled)
+}
+
 func NewNotFoundNoCtx() *Error {
 	return newError(Context(), ErrNotFound)
 }

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -495,6 +495,12 @@ func (client *txnClient) AbortAllRunningTxn() {
 	client.mu.waitActiveTxns = client.mu.waitActiveTxns[:0]
 	client.mu.Unlock()
 
+	if client.timestampWaiter != nil {
+		// Cancel all waiters, means that all waiters do not need to wait for
+		// the newer timestamp from logtail consumer.
+		client.timestampWaiter.Cancel()
+	}
+
 	for _, op := range ops {
 		tempWorkspace := op.workspace
 

--- a/pkg/txn/client/timestamp_waiter.go
+++ b/pkg/txn/client/timestamp_waiter.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/txn/util"
@@ -32,6 +33,7 @@ const (
 type timestampWaiter struct {
 	stopper   stopper.Stopper
 	notifiedC chan timestamp.Timestamp
+	cancelC   chan struct{}
 	latestTS  atomic.Pointer[timestamp.Timestamp]
 	mu        struct {
 		sync.Mutex
@@ -46,8 +48,9 @@ func NewTimestampWaiter() TimestampWaiter {
 		stopper: *stopper.NewStopper("timestamp-waiter",
 			stopper.WithLogger(util.GetLogger().RawLogger())),
 		notifiedC: make(chan timestamp.Timestamp, maxNotifiedCount),
+		cancelC:   make(chan struct{}, 1),
 	}
-	if err := tw.stopper.RunTask(tw.handleNotify); err != nil {
+	if err := tw.stopper.RunTask(tw.handleEvent); err != nil {
 		panic(err)
 	}
 	return tw
@@ -73,6 +76,14 @@ func (tw *timestampWaiter) GetTimestamp(ctx context.Context, ts timestamp.Timest
 func (tw *timestampWaiter) NotifyLatestCommitTS(ts timestamp.Timestamp) {
 	util.LogTxnPushedTimestampUpdated(ts)
 	tw.notifiedC <- ts
+}
+
+func (tw *timestampWaiter) Cancel() {
+	select {
+	case tw.cancelC <- struct{}{}:
+		util.LogTimestampWaiterCanceled()
+	default:
+	}
 }
 
 func (tw *timestampWaiter) Close() {
@@ -113,7 +124,20 @@ func (tw *timestampWaiter) notifyWaiters(ts timestamp.Timestamp) {
 	tw.mu.lastNotified = ts
 }
 
-func (tw *timestampWaiter) handleNotify(ctx context.Context) {
+func (tw *timestampWaiter) cancelWaiters() {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	for idx, w := range tw.mu.waiters {
+		if w != nil {
+			w.cancel()
+			w.unref()
+			tw.mu.waiters[idx] = nil
+		}
+	}
+	tw.mu.waiters = tw.mu.waiters[:0]
+}
+
+func (tw *timestampWaiter) handleEvent(ctx context.Context) {
 	var latest timestamp.Timestamp
 	for {
 		select {
@@ -126,6 +150,8 @@ func (tw *timestampWaiter) handleNotify(ctx context.Context) {
 				tw.latestTS.Store(&ts)
 				tw.notifyWaiters(ts)
 			}
+		case <-tw.cancelC:
+			tw.cancelWaiters()
 		}
 	}
 }
@@ -147,10 +173,12 @@ var (
 	waitersPool = sync.Pool{
 		New: func() any {
 			w := &waiter{
-				c: make(chan struct{}, 1),
+				notifyC: make(chan struct{}, 1),
+				cancelC: make(chan struct{}, 1),
 			}
 			runtime.SetFinalizer(w, func(w *waiter) {
-				close(w.c)
+				close(w.notifyC)
+				close(w.cancelC)
 			})
 			return w
 		},
@@ -159,8 +187,11 @@ var (
 
 type waiter struct {
 	waitAfter timestamp.Timestamp
-	c         chan struct{}
+	notifyC   chan struct{}
 	refCount  atomic.Int32
+	// cancelC is the channel which is used to notify there is no
+	// need to wait anymore.
+	cancelC chan struct{}
 }
 
 func newWaiter(ts timestamp.Timestamp) *waiter {
@@ -180,13 +211,19 @@ func (w *waiter) wait(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-w.c:
+	case <-w.notifyC:
 		return nil
+	case <-w.cancelC:
+		return moerr.NewWaiterCanceledNoCtx()
 	}
 }
 
 func (w *waiter) notify() {
-	w.c <- struct{}{}
+	w.notifyC <- struct{}{}
+}
+
+func (w *waiter) cancel() {
+	w.cancelC <- struct{}{}
 }
 
 func (w *waiter) ref() int32 {
@@ -211,7 +248,8 @@ func (w *waiter) close() {
 func (w *waiter) reset() {
 	for {
 		select {
-		case <-w.c:
+		case <-w.notifyC:
+		case <-w.cancelC:
 		default:
 			return
 		}

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -178,6 +178,9 @@ type TimestampWaiter interface {
 	// commit ts is corresponds to an epoch. Whenever the connection of logtail of cn and tn is
 	// reset, the epoch will be reset and all the ts of the old epoch should be invalidated.
 	NotifyLatestCommitTS(appliedTS timestamp.Timestamp)
+	// Cancel cancels all waiters in timestamp waiter. They will not wait for the newer
+	// timestamp anymore.
+	Cancel()
 	// Close close the timestamp waiter
 	Close()
 }

--- a/pkg/txn/util/log.go
+++ b/pkg/txn/util/log.go
@@ -75,6 +75,13 @@ func LogTxnPushedTimestampUpdated(
 	}
 }
 
+func LogTimestampWaiterCanceled() {
+	logger := getSkipLogger()
+	if logger.Enabled(zap.InfoLevel) {
+		logger.Debug("timestamp waiter canceled")
+	}
+}
+
 // LogTxnRead log txn read
 func LogTxnRead(txnMeta txn.TxnMeta) {
 	logger := getSkipLogger()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12166 #12263 #11838

## What this PR does / why we need it:
When logtail resumer occurs some kind of error, it will try to reconnect
to logtail server. Before reconnect, it aborts all running transactions.
Before rollback txns, txn client should cancel all timestamp waiters,
because there may be some transactions are trying to commit and
waiting for the new TS, but they cannot wait for any new TS as the
logtail consumer is in the status of reconnecting.