### PR TITLE
sync the txn and task metrics on tn side between main and 1.0-dev.

### DIFF
--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
@@ -31,6 +31,7 @@ func (c *DashboardCreator) initTaskDashboard() error {
 		c.withRowOptions(
 			c.initTaskFlushTableTailRow(),
 			c.initTaskCkpEntryPendingRow(),
+			c.initTaskMergeRow(),
 		)...)
 
 	if err != nil {
@@ -52,10 +53,31 @@ func (c *DashboardCreator) initTaskFlushTableTailRow() dashboard.Option {
 
 func (c *DashboardCreator) initTaskCkpEntryPendingRow() dashboard.Option {
 	return dashboard.Row(
-		"Flush Table Tail Duration",
+		"Checkpoint Entry Pending Time",
 		c.getHistogram(
 			c.getMetricWithFilter(`mo_task_duration_seconds_bucket`, `type="ckp_entry_pending"`),
 			[]float64{0.50, 0.8, 0.90, 0.99},
 			[]float32{3, 3, 3, 3})...,
+	)
+}
+
+func (c *DashboardCreator) initTaskMergeRow() dashboard.Option {
+	return dashboard.Row(
+		"Task Merge Related Status",
+		c.withGraph(
+			"Scheduled By Counting",
+			4,
+			`sum(rate(`+c.getMetricWithFilter("mo_task_scheduled_by_total", `type="merge"`)+`[$interval])) by (`+c.by+`, type)`,
+			"{{"+c.by+"-type }}"),
+		c.withGraph(
+			"Merged Blocks Each Schedule",
+			4,
+			`sum(rate(`+c.getMetricWithFilter("mo_task_execute_results_total", `type="merged_block"`)+`[$interval])) by (`+c.by+`, type)`,
+			"{{"+c.by+"-type }}"),
+		c.withGraph(
+			"Merged Size Each Schedule",
+			4,
+			`sum(rate(`+c.getMetricWithFilter("mo_task_execute_results_total", `type="merged_size"`)+`[$interval])) by (`+c.by+`, type)`,
+			"{{ "+c.by+"-type }}"),
 	)
 }

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
@@ -304,3 +304,14 @@ func (c *DashboardCreator) initTxnHoldLockRow() dashboard.Option {
 			[]float32{3, 3, 3, 3})...,
 	)
 }
+
+func (c *DashboardCreator) initTxnFastLoadObjectMetaRow() dashboard.Option {
+	return dashboard.Row(
+		"Txn Fast Load Object Meta",
+		c.withGraph(
+			"Fast Load Object Meta",
+			12,
+			`sum(rate(`+c.getMetricWithFilter("tn_side_fast_load_object_meta_total", "")+`[$interval])) by (`+c.by+`, type)`,
+			"{{ "+c.by+"-type }}"),
+	)
+}

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
@@ -50,6 +50,7 @@ func (c *DashboardCreator) initTxnDashboard() error {
 			c.initTxnBeforeCommitRow(),
 			c.initTxnDequeuePreparedRow(),
 			c.initTxnDequeuePreparingRow(),
+			c.initTxnFastLoadObjectMetaRow(),
 		)...)
 	if err != nil {
 		return err

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
@@ -46,7 +46,10 @@ func (c *DashboardCreator) initTxnDashboard() error {
 			c.initTxnHoldLockRow(),
 			c.initTxnUnlockRow(),
 			c.initTxnTableRangesRow(),
-			c.initTxnPrePrepareRow(),
+			c.initTxnOnPrepareWALRow(),
+			c.initTxnBeforeCommitRow(),
+			c.initTxnDequeuePreparedRow(),
+			c.initTxnDequeuePreparingRow(),
 		)...)
 	if err != nil {
 		return err
@@ -90,11 +93,41 @@ func (c *DashboardCreator) initTxnOverviewRow() dashboard.Option {
 	)
 }
 
-func (c *DashboardCreator) initTxnPrePrepareRow() dashboard.Option {
+func (c *DashboardCreator) initTxnOnPrepareWALRow() dashboard.Option {
 	return dashboard.Row(
-		"txn pre-prepare duration",
+		"txn on prepare wal duration",
 		c.getHistogram(
-			c.getMetricWithFilter("mo_txn_pre_prepare_duration_seconds_bucket", ""),
+			c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal"`),
+			[]float64{0.50, 0.8, 0.90, 0.99},
+			[]float32{3, 3, 3, 3})...,
+	)
+}
+
+func (c *DashboardCreator) initTxnDequeuePreparingRow() dashboard.Option {
+	return dashboard.Row(
+		"txn dequeue preparing duration",
+		c.getHistogram(
+			c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="dequeue_preparing"`),
+			[]float64{0.50, 0.8, 0.90, 0.99},
+			[]float32{3, 3, 3, 3})...,
+	)
+}
+
+func (c *DashboardCreator) initTxnDequeuePreparedRow() dashboard.Option {
+	return dashboard.Row(
+		"txn dequeue prepared duration",
+		c.getHistogram(
+			c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="dequeue_prepared"`),
+			[]float64{0.50, 0.8, 0.90, 0.99},
+			[]float32{3, 3, 3, 3})...,
+	)
+}
+
+func (c *DashboardCreator) initTxnBeforeCommitRow() dashboard.Option {
+	return dashboard.Row(
+		"txn handle commit but before txn.commit duration",
+		c.getHistogram(
+			c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="before_txn_commit"`),
 			[]float64{0.50, 0.8, 0.90, 0.99},
 			[]float32{3, 3, 3, 3})...,
 	)

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -87,6 +87,8 @@ func initTxnMetrics() {
 	registry.MustRegister(txnLockDurationHistogram)
 	registry.MustRegister(TxnUnlockDurationHistogram)
 	registry.MustRegister(TxnTableRangeDurationHistogram)
+
+	registry.MustRegister(TxnFastLoadObjectMetaTotalCounter)
 }
 
 func initRPCMetrics() {

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -36,7 +36,11 @@ func init() {
 }
 
 func initTaskMetrics() {
-	registry.MustRegister(taskDurationHistogram)
+	registry.MustRegister(taskShortDurationHistogram)
+	registry.MustRegister(taskLongDurationHistogram)
+
+	registry.MustRegister(taskScheduledByCounter)
+	registry.MustRegister(taskGeneratedStuffCounter)
 }
 
 func initFileServiceMetrics() {
@@ -64,7 +68,7 @@ func initLogtailMetrics() {
 
 	registry.MustRegister(LogTailCollectDurationHistogram)
 	registry.MustRegister(LogTailSubscriptionCounter)
-	registry.MustRegister(TxnPrePrepareDurationHistogram)
+	registry.MustRegister(txnTNSideDurationHistogram)
 }
 
 func initTxnMetrics() {

--- a/pkg/util/metric/v2/task.go
+++ b/pkg/util/metric/v2/task.go
@@ -19,15 +19,48 @@ import (
 )
 
 var (
-	taskDurationHistogram = prometheus.NewHistogramVec(
+	taskShortDurationHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "mo",
 			Subsystem: "task",
-			Name:      "duration_seconds",
-			Help:      "Bucketed histogram of tn task execute duration.",
+			Name:      "short_duration_seconds",
+			Help:      "Bucketed histogram of short tn task execute duration.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2.0, 20),
 		}, []string{"type"})
 
-	TaskFlushTableTailDurationHistogram  = taskDurationHistogram.WithLabelValues("flush_table_tail")
-	TaskCkpEntryPendingDurationHistogram = taskDurationHistogram.WithLabelValues("ckp_entry_pending")
+	TaskFlushTableTailDurationHistogram = taskShortDurationHistogram.WithLabelValues("flush_table_tail")
+
+	taskLongDurationHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "mo",
+			Subsystem: "task",
+			Name:      "long_duration_seconds",
+			Help:      "Bucketed histogram of long tn task execute duration.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2.0, 13),
+		}, []string{"type"})
+
+	TaskCkpEntryPendingDurationHistogram = taskLongDurationHistogram.WithLabelValues("ckp_entry_pending")
+)
+
+var (
+	taskScheduledByCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "task",
+			Name:      "scheduled_by_total",
+			Help:      "Total number of task have been scheduled.",
+		}, []string{"type"})
+
+	TaskMergeScheduledByCounter = taskScheduledByCounter.WithLabelValues("merge")
+
+	taskGeneratedStuffCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "task",
+			Name:      "execute_results_total",
+			Help:      "Total number of stuff a task have generated",
+		}, []string{"type"})
+
+	TaskMergedBlocksCounter = taskGeneratedStuffCounter.WithLabelValues("merged_block")
+	TasKMergedSizeCounter   = taskGeneratedStuffCounter.WithLabelValues("merged_size")
 )

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -68,6 +68,14 @@ var (
 	TxnLockTotalCounter       = txnLockCounter.WithLabelValues("total")
 	TxnLocalLockTotalCounter  = txnLockCounter.WithLabelValues("local")
 	TxnRemoteLockTotalCounter = txnLockCounter.WithLabelValues("remote")
+
+	TxnFastLoadObjectMetaTotalCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "txn",
+			Name:      "tn_side_fast_load_object_meta_total",
+			Help:      "Total number of fast loaded object meta on tn side.",
+		})
 )
 
 var (

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -159,12 +159,17 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2.0, 20),
 		})
 
-	TxnPrePrepareDurationHistogram = prometheus.NewHistogram(
+	txnTNSideDurationHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "mo",
 			Subsystem: "txn",
-			Name:      "pre_prepare_duration_seconds",
-			Help:      "Bucketed histogram of txn pre-prepare duration.",
+			Name:      "tn_side_duration_seconds",
+			Help:      "Bucketed histogram of txn duration on tn side.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2.0, 20),
-		})
+		}, []string{"step"})
+
+	TxnOnPrepareWALDurationHistogram     = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal")
+	TxnDequeuePreparingDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("dequeue_preparing")
+	TxnDequeuePreparedDurationHistogram  = txnTNSideDurationHistogram.WithLabelValues("dequeue_prepared")
+	TxnBeforeCommitDurationHistogram     = txnTNSideDurationHistogram.WithLabelValues("before_txn_commit")
 )

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -767,6 +767,7 @@ func (tbl *txnTable) rangesOnePart(
 			//     2. if skipped, skip this block
 			//     3. if not skipped, eval expr on the block
 			if !objectio.IsSameObjectLocVsMeta(location, objDataMeta) {
+				v2.TxnFastLoadObjectMetaTotalCounter.Inc()
 				if objMeta, err = objectio.FastLoadObjectMeta(ctx, &location, false, fs); err != nil {
 					return
 				}

--- a/pkg/vm/engine/tae/db/merge/executor.go
+++ b/pkg/vm/engine/tae/db/merge/executor.go
@@ -17,6 +17,7 @@ package merge
 import (
 	"bytes"
 	"fmt"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"sync"
 	"sync/atomic"
 
@@ -234,6 +235,10 @@ func expandObjectList(segs []*catalog.SegmentEntry) (
 }
 
 func logMergeTask(name string, taskId uint64, dels, merges []*catalog.SegmentEntry, blkn, osize, esize int) {
+	v2.TaskMergeScheduledByCounter.Inc()
+	v2.TaskMergedBlocksCounter.Add(float64(blkn))
+	v2.TasKMergedSizeCounter.Add(float64(osize))
+
 	infoBuf := &bytes.Buffer{}
 	infoBuf.WriteString("merged:")
 	for _, seg := range merges {

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 
 	"os"
 	"strings"
@@ -184,6 +185,9 @@ func (h *Handle) HandleCommit(
 	if txn.Is2PC() {
 		txn.SetCommitTS(types.TimestampToTS(meta.GetCommitTS()))
 	}
+
+	v2.TxnBeforeCommitDurationHistogram.Observe(time.Since(start).Seconds())
+
 	err = txn.Commit(ctx)
 	cts = txn.GetCommitTS().ToTimestamp()
 

--- a/pkg/vm/engine/tae/txn/txnimpl/store.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/store.go
@@ -16,7 +16,6 @@ package txnimpl
 
 import (
 	"context"
-	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -677,7 +676,6 @@ func (store *txnStore) PrePrepare(ctx context.Context) (err error) {
 		if enable && prePrepareDuration > threshold && store.GetContext() != nil {
 			store.SetContext(context.WithValue(store.GetContext(), common.StorePrePrepare, &common.DurationRecords{Duration: prePrepareDuration}))
 		}
-		v2.TxnPrePrepareDurationHistogram.Observe(prePrepareDuration.Seconds())
 
 	}()
 	for _, db := range store.dbs {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12223 

## What this PR does / why we need it:

add some metrics:

1. txn OnPrepareWal duration Histogram
2. txn Dequeue Preparing Duration Histogram
3. txn Dequeue Prepared Duration Histogram
4. txn Handle Commit But Before Txn.Commit Duration Histogram
5. task Merge Scheduled times Counter
6. task Merged Block count Each Schedule Counter
7. task Merged Size Each Scheduler Counter
8. txn fast loading object meta counter in oneRangePart