### PR TITLE
[opt] column pruning for foreign key insert/update

### DIFF
--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -206,7 +206,7 @@ func (s *Scope) AlterTableInplace(c *Compile) error {
 		return err
 	}
 
-	tableDef := plan2.DeepCopyTableDef(qry.TableDef)
+	tableDef := plan2.DeepCopyTableDef(qry.TableDef, true)
 	oldDefs, err := rel.TableDefs(c.ctx)
 	if err != nil {
 		return err
@@ -974,7 +974,7 @@ func (s *Scope) CreateIndex(c *Compile) error {
 	}
 	tableId := r.GetTableID(c.ctx)
 
-	tableDef := plan2.DeepCopyTableDef(qry.TableDef)
+	tableDef := plan2.DeepCopyTableDef(qry.TableDef, true)
 	indexDef := qry.GetIndex().GetTableDef().Indexes[0]
 
 	if indexDef.Unique {

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -19,6 +19,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
+	"strings"
+
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -26,8 +29,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
-	"math"
-	"strings"
 )
 
 func buildAlterTableCopy(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, error) {
@@ -536,7 +537,7 @@ func initAlterTableContext(originTableDef *TableDef, copyTableDef *TableDef, sch
 }
 
 func buildCopyTableDef(ctx context.Context, tableDef *TableDef) (*TableDef, error) {
-	replicaTableDef := DeepCopyTableDef(tableDef)
+	replicaTableDef := DeepCopyTableDef(tableDef, true)
 
 	id, err := uuid.NewUUID()
 	if err != nil {

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -566,7 +566,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 			stmt.OnDuplicateUpdate = nil
 		}
 
-		rightTableDef := DeepCopyTableDef(tableDef)
+		rightTableDef := DeepCopyTableDef(tableDef, true)
 		rightObjRef := DeepCopyObjectRef(tableObjRef)
 		uniqueCols := GetUniqueColAndIdxFromTableDef(rightTableDef)
 		if rightTableDef.Pkey != nil && rightTableDef.Pkey.PkeyColName == catalog.CPrimaryKeyColName {

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -332,10 +332,10 @@ func buildDeletePlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindC
 							return err
 						}
 
-						insertUniqueTableDef := DeepCopyTableDef(uniqueTableDef)
-						for j, col := range insertUniqueTableDef.Cols {
-							if col.Name == catalog.Row_ID {
-								insertUniqueTableDef.Cols = append(insertUniqueTableDef.Cols[:j], insertUniqueTableDef.Cols[j+1:]...)
+						insertUniqueTableDef := DeepCopyTableDef(uniqueTableDef, false)
+						for _, col := range uniqueTableDef.Cols {
+							if col.Name != catalog.Row_ID {
+								insertUniqueTableDef.Cols = append(insertUniqueTableDef.Cols, DeepCopyColDef(col))
 							}
 						}
 						err = makeInsertPlan(ctx, builder, bindCtx, uniqueObjRef, insertUniqueTableDef, 1, preUKStep, false, false, true, true, nil, false)
@@ -589,7 +589,7 @@ func buildDeletePlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindC
 							NodeType:    plan.Node_TABLE_SCAN,
 							Stats:       &plan.Stats{},
 							ObjRef:      childObjRef,
-							TableDef:    DeepCopyTableDef(childTableDef),
+							TableDef:    DeepCopyTableDef(childTableDef, true),
 							ProjectList: childProjectList,
 						}, bindCtx)
 						lastNodeId = builder.appendNode(&plan.Node{
@@ -666,7 +666,7 @@ func buildDeletePlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindC
 
 							upPlanCtx := getDmlPlanCtx()
 							upPlanCtx.objRef = childObjRef
-							upPlanCtx.tableDef = DeepCopyTableDef(childTableDef)
+							upPlanCtx.tableDef = DeepCopyTableDef(childTableDef, true)
 							upPlanCtx.updateColLength = len(rightConds)
 							upPlanCtx.isMulti = false
 							upPlanCtx.rowIdPos = childRowIdPos
@@ -889,7 +889,7 @@ func makeInsertPlan(
 				Expr: &plan.Expr_Col{
 					Col: &plan.ColRef{
 						ColPos: int32(beginIdx + i),
-						Name:   catalog.Row_ID,
+						//Name:   catalog.Row_ID,
 					},
 				},
 			}
@@ -985,37 +985,19 @@ func makeInsertPlan(
 
 			if isUpdate && updatePkCol { // update stmt && pk included in update cols
 				lastNodeId = appendSinkScanNode(builder, bindCtx, sourceStep)
+				scanTableDef := DeepCopyTableDef(tableDef, false)
+
+				rowIdIdx := len(tableDef.Cols)
 				rowIdDef := MakeRowIdColDef()
 				tableDef.Cols = append(tableDef.Cols, rowIdDef)
-				scanTableDef := DeepCopyTableDef(tableDef)
 
-				colPos := make(map[int32]int32)
-				colPos[int32(pkPos)] = 0
-				// if len(pkFilterExprs) > 0 {
-				// 	for _, e := range pkFilterExprs {
-				// 		getColPos(e, colPos)
-				// 	}
-				// }
-				var newCols []*ColDef
-				rowIdIdx := len(scanTableDef.Cols) - 1
-				for idx, col := range scanTableDef.Cols {
-					if _, ok := colPos[int32(idx)]; ok {
-						colPos[int32(idx)] = int32(len(newCols))
-						newCols = append(newCols, col)
-					}
-					if col.Name == catalog.Row_ID {
-						colPos[int32(idx)] = int32(len(newCols))
-						newCols = append(newCols, col)
-					}
-				}
-				scanTableDef.Cols = newCols
+				scanTableDef.Cols = []*plan.ColDef{DeepCopyColDef(tableDef.Cols[pkPos]), DeepCopyColDef(rowIdDef)}
 
 				scanPkExpr := &Expr{
 					Typ: pkTyp,
 					Expr: &plan.Expr_Col{
 						Col: &ColRef{
-							ColPos: colPos[int32(pkPos)],
-							Name:   tableDef.Pkey.PkeyColName,
+							Name: tableDef.Pkey.PkeyColName,
 						},
 					},
 				}
@@ -1023,7 +1005,7 @@ func makeInsertPlan(
 					Typ: rowIdDef.Typ,
 					Expr: &plan.Expr_Col{
 						Col: &ColRef{
-							ColPos: colPos[int32(rowIdIdx)],
+							ColPos: 1,
 							Name:   rowIdDef.Name,
 						},
 					},
@@ -1041,9 +1023,7 @@ func makeInsertPlan(
 								Typ: DeepCopyType(pkTyp),
 								Expr: &plan.Expr_Col{
 									Col: &plan.ColRef{
-										RelPos: 0,
-										ColPos: 0,
-										Name:   tableDef.Pkey.PkeyColName,
+										Name: tableDef.Pkey.PkeyColName,
 									},
 								},
 							},
@@ -1051,17 +1031,6 @@ func makeInsertPlan(
 					},
 				}
 				rightId := builder.appendNode(scanNode, bindCtx)
-				// if len(pkFilterExprs) > 0 {
-				// 	for _, e := range pkFilterExprs {
-				// 		resetColPos(e, colPos)
-				// 	}
-				// 	blockFilters := make([]*Expr, len(pkFilterExprs))
-				// 	for i, e := range pkFilterExprs {
-				// 		blockFilters[i] = DeepCopyExpr(e)
-				// 	}
-				// 	scanNode.FilterList = pkFilterExprs
-				// 	scanNode.BlockFilterList = blockFilters
-				// }
 
 				pkColExpr := &Expr{
 					Typ: pkTyp,
@@ -1099,7 +1068,7 @@ func makeInsertPlan(
 					Expr: &plan.Expr_Col{
 						Col: &ColRef{
 							RelPos: 1,
-							ColPos: int32(len(tableDef.Cols) - 1),
+							ColPos: int32(rowIdIdx),
 							Name:   rowIdDef.Name,
 						},
 					},
@@ -1160,7 +1129,7 @@ func makeInsertPlan(
 						Typ: rowIdExpr.Typ,
 						Expr: &plan.Expr_Col{
 							Col: &ColRef{
-								RelPos: 1,
+								RelPos: -1,
 								ColPos: 0,
 								Name:   catalog.Row_ID,
 							},
@@ -1169,7 +1138,7 @@ func makeInsertPlan(
 						Typ: rowIdExpr.Typ,
 						Expr: &plan.Expr_Col{
 							Col: &ColRef{
-								RelPos: 1,
+								RelPos: -1,
 								ColPos: 1,
 								Name:   catalog.Row_ID,
 							},
@@ -1178,7 +1147,7 @@ func makeInsertPlan(
 						Typ: pkColExpr.Typ,
 						Expr: &plan.Expr_Col{
 							Col: &ColRef{
-								RelPos: 1,
+								RelPos: -1,
 								ColPos: 2,
 								Name:   tableDef.Pkey.PkeyColName,
 							},
@@ -1266,27 +1235,24 @@ func makeInsertPlan(
 			// insert stmt but not load stmt, not insert without auto incr pk col
 			if !isUpdate && !builder.qry.LoadTag && !isInsertWithoutAutoPkCol {
 				if len(pkFilterExprs) > 0 {
-					scanTableDef := DeepCopyTableDef(tableDef)
-					// scanTableDef.Cols = []*ColDef{scanTableDef.Cols[pkPos]}
 					pkNameMap := make(map[string]int)
 					for i, n := range tableDef.Pkey.Names {
 						pkNameMap[n] = i
 					}
-					newCols := make([]*ColDef, len(scanTableDef.Pkey.Names))
-					for _, def := range scanTableDef.Cols {
-						if i, ok := pkNameMap[def.Name]; ok {
-							newCols[i] = def
+					pkSize := len(tableDef.Pkey.Names)
+					if pkSize > 1 {
+						pkSize++
+					}
+					scanTableDef := DeepCopyTableDef(tableDef, false)
+					scanTableDef.Cols = make([]*ColDef, pkSize)
+					for _, col := range tableDef.Cols {
+						if i, ok := pkNameMap[col.Name]; ok {
+							scanTableDef.Cols[i] = DeepCopyColDef(col)
+						} else if col.Name == scanTableDef.Pkey.PkeyColName {
+							scanTableDef.Cols[pkSize-1] = DeepCopyColDef(col)
+							break
 						}
 					}
-					if len(newCols) > 1 {
-						for _, col := range scanTableDef.Cols {
-							if col.Name == scanTableDef.Pkey.PkeyColName {
-								newCols = append(newCols, col)
-								break
-							}
-						}
-					}
-					scanTableDef.Cols = newCols
 					scanNode := &plan.Node{
 						NodeType: plan.Node_TABLE_SCAN,
 						Stats:    &plan.Stats{},
@@ -1312,8 +1278,8 @@ func makeInsertPlan(
 					scanNode.BlockFilterList = blockFilterList
 				} else {
 					lastNodeId = appendSinkScanNode(builder, bindCtx, sourceStep)
-					scanTableDef := DeepCopyTableDef(tableDef)
-					scanTableDef.Cols = []*ColDef{scanTableDef.Cols[pkPos]}
+					scanTableDef := DeepCopyTableDef(tableDef, false)
+					scanTableDef.Cols = []*ColDef{DeepCopyColDef(tableDef.Cols[pkPos])}
 					scanNode := &plan.Node{
 						NodeType: plan.Node_TABLE_SCAN,
 						Stats:    &plan.Stats{},
@@ -1848,16 +1814,51 @@ func appendJoinNodeForParentFkCheck(builder *QueryBuilder, bindCtx *BindContext,
 
 	lastNodeId := baseNodeId
 	for _, fk := range tableDef.Fkeys {
-		parentObjRef, parentTableDef := builder.compCtx.ResolveById(fk.ForeignTbl)
-		parentPosMap := make(map[string]int32)
-		parentTypMap := make(map[string]*plan.Type)
-		parentId2name := make(map[uint64]string)
-		for idx, col := range parentTableDef.Cols {
-			parentPosMap[col.Name] = int32(idx)
-			parentTypMap[col.Name] = col.Typ
-			parentId2name[col.ColId] = col.Name
+		fkeyId2Idx := make(map[uint64]int)
+		for i, colId := range fk.ForeignCols {
+			fkeyId2Idx[colId] = i
 		}
-		projectList := getProjectionByLastNode(builder, lastNodeId)
+
+		parentObjRef, parentTableDef := builder.compCtx.ResolveById(fk.ForeignTbl)
+		newTableDef := DeepCopyTableDef(parentTableDef, false)
+		joinConds := make([]*plan.Expr, 0)
+		for _, col := range parentTableDef.Cols {
+			if fkIdx, ok := fkeyId2Idx[col.ColId]; ok {
+				rightPos := len(newTableDef.Cols)
+				newTableDef.Cols = append(newTableDef.Cols, DeepCopyColDef(col))
+
+				parentColumnName := col.Name
+				childColumnName := id2name[fk.Cols[fkIdx]]
+
+				leftExpr := &Expr{
+					Typ: typMap[childColumnName],
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{
+							RelPos: 0,
+							ColPos: int32(name2pos[childColumnName]),
+							Name:   childColumnName,
+						},
+					},
+				}
+				rightExpr := &plan.Expr{
+					Typ: DeepCopyType(col.Typ),
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{
+							RelPos: 1,
+							ColPos: int32(rightPos),
+							Name:   parentColumnName,
+						},
+					},
+				}
+				condExpr, err := bindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{leftExpr, rightExpr})
+				if err != nil {
+					return -1, err
+				}
+				joinConds = append(joinConds, condExpr)
+			}
+		}
+
+		parentTableDef = newTableDef
 
 		// append table scan node
 		scanNodeProject := make([]*Expr, len(parentTableDef.Cols))
@@ -1880,52 +1881,16 @@ func appendJoinNodeForParentFkCheck(builder *QueryBuilder, bindCtx *BindContext,
 			ProjectList: scanNodeProject,
 		}, bindCtx)
 
-		// build join conds
-		joinConds := make([]*Expr, len(fk.Cols))
-		for i, colId := range fk.ForeignCols {
-			for _, col := range parentTableDef.Cols {
-				if col.ColId == colId {
-					parentColumnName := col.Name
-					childColumnName := id2name[fk.Cols[i]]
-
-					leftExpr := &Expr{
-						Typ: typMap[childColumnName],
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: 0,
-								ColPos: int32(name2pos[childColumnName]),
-								Name:   childColumnName,
-							},
-						},
-					}
-					rightExpr := &plan.Expr{
-						Typ: parentTypMap[parentColumnName],
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: 1,
-								ColPos: parentPosMap[parentColumnName],
-								Name:   parentColumnName,
-							},
-						},
-					}
-					condExpr, err := bindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{leftExpr, rightExpr})
-					if err != nil {
-						return -1, err
-					}
-					joinConds[i] = condExpr
-					break
-				}
-			}
-		}
+		projectList := getProjectionByLastNode(builder, lastNodeId)
 
 		// append project
 		projectList = append(projectList, &Expr{
-			Typ: parentTypMap[catalog.Row_ID],
+			Typ: DeepCopyType(parentTableDef.Cols[0].Typ),
 			Expr: &plan.Expr_Col{
 				Col: &plan.ColRef{
 					RelPos: 1,
-					ColPos: parentPosMap[catalog.Row_ID],
-					Name:   catalog.Row_ID,
+					ColPos: 0,
+					Name:   parentTableDef.Cols[0].Name,
 				},
 			},
 		})
@@ -1995,7 +1960,7 @@ func appendPreInsertNode(builder *QueryBuilder, bindCtx *BindContext,
 		ProjectList: preInsertProjection,
 		PreInsertCtx: &plan.PreInsertCtx{
 			Ref:        objRef,
-			TableDef:   DeepCopyTableDef(tableDef),
+			TableDef:   DeepCopyTableDef(tableDef, true),
 			HasAutoCol: hashAutoCol,
 			IsUpdate:   isUpdate,
 		},

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -87,7 +87,7 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 	objRef := tblInfo.objRef[0]
 	if len(rewriteInfo.onDuplicateIdx) > 0 {
 		// append on duplicate key node
-		tableDef = DeepCopyTableDef(tableDef)
+		tableDef = DeepCopyTableDef(tableDef, true)
 		if tableDef.Pkey != nil && tableDef.Pkey.PkeyColName == catalog.CPrimaryKeyColName {
 			tableDef.Cols = append(tableDef.Cols, tableDef.Pkey.CompPkeyCol)
 		}
@@ -176,7 +176,7 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 		updateColPosMap := make(map[string]int)
 		var insertColPos []int
 		var projectProjection []*Expr
-		tableDef = DeepCopyTableDef(tableDef)
+		tableDef = DeepCopyTableDef(tableDef, true)
 		tableDef.Cols = append(tableDef.Cols, MakeRowIdColDef())
 		colLength := len(tableDef.Cols)
 		rowIdPos := colLength - 1

--- a/pkg/sql/plan/build_load.go
+++ b/pkg/sql/plan/build_load.go
@@ -134,7 +134,7 @@ func buildLoad(stmt *tree.Load, ctx CompilerContext, isPrepareStmt bool) (*Plan,
 	// }
 
 	// append hidden column to tableDef
-	newTableDef := DeepCopyTableDef(tableDef)
+	newTableDef := DeepCopyTableDef(tableDef, true)
 	checkInsertPkDup := false
 	err = buildInsertPlans(ctx, builder, bindCtx, objRef, newTableDef, lastNodeId, checkInsertPkDup, nil, isInsertWithoutAutoPkCol)
 	if err != nil {

--- a/pkg/sql/plan/deepcopy.go
+++ b/pkg/sql/plan/deepcopy.go
@@ -63,7 +63,7 @@ func DeepCopyOnDupliateKeyCtx(ctx *plan.OnDuplicateKeyCtx) *plan.OnDuplicateKeyC
 		return nil
 	}
 	newCtx := &plan.OnDuplicateKeyCtx{
-		TableDef:       DeepCopyTableDef(ctx.TableDef),
+		TableDef:       DeepCopyTableDef(ctx.TableDef, true),
 		OnDuplicateIdx: make([]int32, len(ctx.OnDuplicateIdx)),
 	}
 
@@ -87,7 +87,7 @@ func DeepCopyInsertCtx(ctx *plan.InsertCtx) *plan.InsertCtx {
 		Ref:                 DeepCopyObjectRef(ctx.Ref),
 		AddAffectedRows:     ctx.AddAffectedRows,
 		IsClusterTable:      ctx.IsClusterTable,
-		TableDef:            DeepCopyTableDef(ctx.TableDef),
+		TableDef:            DeepCopyTableDef(ctx.TableDef, true),
 		PartitionTableIds:   make([]uint64, len(ctx.PartitionTableIds)),
 		PartitionTableNames: make([]string, len(ctx.PartitionTableNames)),
 		PartitionIdx:        ctx.PartitionIdx,
@@ -123,7 +123,7 @@ func DeepCopyPreInsertCtx(ctx *plan.PreInsertCtx) *plan.PreInsertCtx {
 	}
 	newCtx := &plan.PreInsertCtx{
 		Ref:        DeepCopyObjectRef(ctx.Ref),
-		TableDef:   DeepCopyTableDef(ctx.TableDef),
+		TableDef:   DeepCopyTableDef(ctx.TableDef, true),
 		HasAutoCol: ctx.HasAutoCol,
 		IsUpdate:   ctx.IsUpdate,
 	}
@@ -140,7 +140,7 @@ func DeepCopyPreInsertUkCtx(ctx *plan.PreInsertUkCtx) *plan.PreInsertUkCtx {
 		PkColumn: ctx.PkColumn,
 		PkType:   DeepCopyType(ctx.PkType),
 		UkType:   DeepCopyType(ctx.UkType),
-		TableDef: DeepCopyTableDef(ctx.TableDef),
+		TableDef: DeepCopyTableDef(ctx.TableDef, true),
 	}
 	copy(newCtx.Columns, ctx.Columns)
 
@@ -252,7 +252,7 @@ func DeepCopyNode(node *plan.Node) *plan.Node {
 	}
 
 	for i, tbl := range node.TableDefVec {
-		newNode.TableDefVec[i] = DeepCopyTableDef(tbl)
+		newNode.TableDefVec[i] = DeepCopyTableDef(tbl, true)
 	}
 
 	newNode.Stats = DeepCopyStats(node.Stats)
@@ -267,7 +267,7 @@ func DeepCopyNode(node *plan.Node) *plan.Node {
 	}
 
 	if node.TableDef != nil {
-		newNode.TableDef = DeepCopyTableDef(node.TableDef)
+		newNode.TableDef = DeepCopyTableDef(node.TableDef, true)
 	}
 
 	if node.RowsetData != nil {
@@ -382,7 +382,7 @@ func DeepCopyTableDefList(src []*plan.TableDef) []*plan.TableDef {
 	}
 	ret := make([]*plan.TableDef, len(src))
 	for i, def := range src {
-		ret[i] = DeepCopyTableDef(def)
+		ret[i] = DeepCopyTableDef(def, true)
 	}
 	return ret
 }
@@ -409,7 +409,7 @@ func DeepCopyPartitionPrune(partitionPrune *plan.PartitionPrune) *plan.Partition
 	return newPartitionPrune
 }
 
-func DeepCopyTableDef(table *plan.TableDef) *plan.TableDef {
+func DeepCopyTableDef(table *plan.TableDef, withCols bool) *plan.TableDef {
 	if table == nil {
 		return nil
 	}
@@ -417,7 +417,6 @@ func DeepCopyTableDef(table *plan.TableDef) *plan.TableDef {
 		TblId:          table.TblId,
 		Name:           table.Name,
 		Hidden:         table.Hidden,
-		Cols:           make([]*plan.ColDef, len(table.Cols)),
 		TableType:      table.TableType,
 		Createsql:      table.Createsql,
 		Version:        table.Version,
@@ -437,8 +436,11 @@ func DeepCopyTableDef(table *plan.TableDef) *plan.TableDef {
 
 	copy(newTable.RefChildTbls, table.RefChildTbls)
 
-	for idx, col := range table.Cols {
-		newTable.Cols[idx] = DeepCopyColDef(col)
+	if withCols {
+		newTable.Cols = make([]*plan.ColDef, len(table.Cols))
+		for idx, col := range table.Cols {
+			newTable.Cols[idx] = DeepCopyColDef(col)
+		}
 	}
 
 	for idx, fkey := range table.Fkeys {
@@ -650,7 +652,7 @@ func DeepCopyDataDefinition(old *plan.DataDefinition) *plan.DataDefinition {
 			IfNotExists:     df.CreateTable.IfNotExists,
 			Temporary:       df.CreateTable.Temporary,
 			Database:        df.CreateTable.Database,
-			TableDef:        DeepCopyTableDef(df.CreateTable.TableDef),
+			TableDef:        DeepCopyTableDef(df.CreateTable.TableDef, true),
 			IndexTables:     DeepCopyTableDefList(df.CreateTable.GetIndexTables()),
 			FkDbs:           make([]string, len(df.CreateTable.FkDbs)),
 			FkTables:        make([]string, len(df.CreateTable.FkTables)),
@@ -671,8 +673,8 @@ func DeepCopyDataDefinition(old *plan.DataDefinition) *plan.DataDefinition {
 	case *plan.DataDefinition_AlterTable:
 		AlterTable := &plan.AlterTable{
 			Database:       df.AlterTable.Database,
-			TableDef:       DeepCopyTableDef(df.AlterTable.TableDef),
-			CopyTableDef:   DeepCopyTableDef(df.AlterTable.CopyTableDef),
+			TableDef:       DeepCopyTableDef(df.AlterTable.TableDef, true),
+			CopyTableDef:   DeepCopyTableDef(df.AlterTable.CopyTableDef, true),
 			IsClusterTable: df.AlterTable.IsClusterTable,
 			AlgorithmType:  df.AlterTable.AlgorithmType,
 			CreateTableSql: df.AlterTable.CreateTableSql,
@@ -722,7 +724,7 @@ func DeepCopyDataDefinition(old *plan.DataDefinition) *plan.DataDefinition {
 				ForeignTbl:          DeepCopyNumberList(df.DropTable.GetForeignTbl()),
 				PartitionTableNames: DeepCopyStringList(df.DropTable.GetPartitionTableNames()),
 				IsView:              df.DropTable.IsView,
-				TableDef:            DeepCopyTableDef(df.DropTable.GetTableDef()),
+				TableDef:            DeepCopyTableDef(df.DropTable.GetTableDef(), true),
 			},
 		}
 
@@ -735,7 +737,7 @@ func DeepCopyDataDefinition(old *plan.DataDefinition) *plan.DataDefinition {
 					IfNotExists: df.CreateIndex.Index.IfNotExists,
 					Temporary:   df.CreateIndex.Index.Temporary,
 					Database:    df.CreateIndex.Index.Database,
-					TableDef:    DeepCopyTableDef(df.CreateIndex.Index.TableDef),
+					TableDef:    DeepCopyTableDef(df.CreateIndex.Index.TableDef, true),
 				},
 				OriginTablePrimaryKey: df.CreateIndex.OriginTablePrimaryKey,
 			},

--- a/pkg/sql/plan/mock.go
+++ b/pkg/sql/plan/mock.go
@@ -807,7 +807,7 @@ func (m *MockCompilerContext) GetUserName() string {
 
 func (m *MockCompilerContext) Resolve(dbName string, tableName string) (*ObjectRef, *TableDef) {
 	name := strings.ToLower(tableName)
-	tableDef := DeepCopyTableDef(m.tables[name])
+	tableDef := DeepCopyTableDef(m.tables[name], true)
 	if tableDef != nil && !m.isDml {
 		for i, col := range tableDef.Cols {
 			if col.Typ.Id == int32(types.T_Rowid) {
@@ -829,7 +829,7 @@ func (m *MockCompilerContext) Resolve(dbName string, tableName string) (*ObjectR
 
 func (m *MockCompilerContext) ResolveById(tableId uint64) (*ObjectRef, *TableDef) {
 	name := m.id2name[tableId]
-	tableDef := DeepCopyTableDef(m.tables[name])
+	tableDef := DeepCopyTableDef(m.tables[name], true)
 	if tableDef != nil && !m.isDml {
 		for i, col := range tableDef.Cols {
 			if col.Typ.Id == int32(types.T_Rowid) {

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -142,15 +142,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 		}
 
 		tag := node.BindingTags[0]
-		newTableDef := &plan.TableDef{
-			Name:          node.TableDef.Name,
-			Defs:          node.TableDef.Defs,
-			Name2ColIndex: node.TableDef.Name2ColIndex,
-			Createsql:     node.TableDef.Createsql,
-			TblFunc:       node.TableDef.TblFunc,
-			TableType:     node.TableDef.TableType,
-			Partition:     node.TableDef.Partition,
-		}
+		newTableDef := DeepCopyTableDef(node.TableDef, false)
 
 		for i, col := range node.TableDef.Cols {
 			globalRef := [2]int32{tag, int32(i)}
@@ -160,12 +152,12 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 
 			internalRemapping.addColRef(globalRef)
 
-			newTableDef.Cols = append(newTableDef.Cols, col)
+			newTableDef.Cols = append(newTableDef.Cols, DeepCopyColDef(col))
 		}
 
 		if len(newTableDef.Cols) == 0 {
 			internalRemapping.addColRef([2]int32{tag, 0})
-			newTableDef.Cols = append(newTableDef.Cols, node.TableDef.Cols[0])
+			newTableDef.Cols = append(newTableDef.Cols, DeepCopyColDef(node.TableDef.Cols[0]))
 		}
 
 		node.TableDef = newTableDef
@@ -267,30 +259,7 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 		}
 
 		tag := node.BindingTags[0]
-		newTableDef := &plan.TableDef{
-			TblId:          node.TableDef.TblId,
-			Name:           node.TableDef.Name,
-			Hidden:         node.TableDef.Hidden,
-			TableType:      node.TableDef.TableType,
-			Createsql:      node.TableDef.Createsql,
-			TblFunc:        node.TableDef.TblFunc,
-			Version:        node.TableDef.Version,
-			Pkey:           node.TableDef.Pkey,
-			Indexes:        node.TableDef.Indexes,
-			Fkeys:          node.TableDef.Fkeys,
-			RefChildTbls:   node.TableDef.RefChildTbls,
-			Checks:         node.TableDef.Checks,
-			Partition:      node.TableDef.Partition,
-			ClusterBy:      node.TableDef.ClusterBy,
-			Props:          node.TableDef.Props,
-			ViewSql:        node.TableDef.ViewSql,
-			Defs:           node.TableDef.Defs,
-			Name2ColIndex:  node.TableDef.Name2ColIndex,
-			IsLocked:       node.TableDef.IsLocked,
-			TableLockType:  node.TableDef.TableLockType,
-			IsTemporary:    node.TableDef.IsTemporary,
-			AutoIncrOffset: node.TableDef.AutoIncrOffset,
-		}
+		newTableDef := DeepCopyTableDef(node.TableDef, false)
 
 		for i, col := range node.TableDef.Cols {
 			globalRef := [2]int32{tag, int32(i)}
@@ -300,12 +269,12 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 
 			internalRemapping.addColRef(globalRef)
 
-			newTableDef.Cols = append(newTableDef.Cols, col)
+			newTableDef.Cols = append(newTableDef.Cols, DeepCopyColDef(col))
 		}
 
 		if len(newTableDef.Cols) == 0 {
 			internalRemapping.addColRef([2]int32{tag, 0})
-			newTableDef.Cols = append(newTableDef.Cols, node.TableDef.Cols[0])
+			newTableDef.Cols = append(newTableDef.Cols, DeepCopyColDef(node.TableDef.Cols[0]))
 		}
 
 		node.TableDef = newTableDef


### PR DESCRIPTION
This PR adds proper column pruning for joins which are implicitly spawned by INSERT/UPDATE statements when foreign key exists in order to resolve memory issues.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12358 matrixorigin/MO-Cloud#1531

## What this PR does / why we need it: