### PR TITLE
fix-issue-11856

### DIFF
--- a/pkg/sql/colexec/deletion/types.go
+++ b/pkg/sql/colexec/deletion/types.go
@@ -282,8 +282,12 @@ func collectBatchInfo(proc *process.Process, arg *Argument, destBatch *batch.Bat
 		if offsetFlag {
 			continue
 		}
-		arg.ctr.batch_size += 24
 	}
+	var batchSize int
+	for _, bat := range arg.ctr.partitionId_blockId_rowIdBatch[pIdx] {
+		batchSize += bat.Size()
+	}
+	arg.ctr.batch_size = uint32(batchSize)
 }
 
 func getNonNullValue(col *vector.Vector, row uint32) any {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11856 

## What this PR does / why we need it:

`arg.ctr.batch_size` is defined as a uint32, but it was incorrectly calculated and was smaller than the actual data size. When `arg.ctr.batch_size` reaches a certain threshold (currently set at 32MB), the data is flushed to disk. During each flush operation, the real batch size is subtracted from arg.ctr.batch_size. This subtraction causes an overflow issue, causing arg.ctr.batch_size to become excessively large. As a result, every subsequent check to determine whether data should be flushed also triggers a flush operation, even when the actual data size is not significant. This behavior leads to the creation of a large number of small files.