### PR TITLE
change to load specified ckp data batch when `show accounts` to avoid possible oom. 

### DIFF
--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -183,7 +183,6 @@ func handleStorageUsageResponse(ctx context.Context, fs fileservice.FileService,
 
 		ckpData, err := logtail.LoadSpecifiedCkpBatch(ctx, location, fs, version, logtail.SEGStorageUsageIDX)
 		if err != nil {
-			ckpData.Close()
 			return nil, err
 		}
 

--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -173,15 +173,6 @@ func handleStorageUsageResponse(ctx context.Context, fs fileservice.FileService,
 		version := usage.CkpEntries[idx].Version
 		location := usage.CkpEntries[idx].Location
 
-		ckpData, err := logtail.LoadSpecifiedCkpBatch(ctx, location, fs, version, logtail.SEGStorageUsageIDX)
-		if err != nil {
-			return nil, err
-		}
-
-		storageUsageBat := ckpData.GetBatches()[logtail.SEGStorageUsageIDX]
-		accIDVec := storageUsageBat.GetVectorByName(catalog.SystemColAttr_AccID)
-		sizeVec := storageUsageBat.GetVectorByName(logtail.CheckpointMetaAttr_ObjectSize)
-
 		// storage usage was introduced after `CheckpointVersion9`
 		if version < logtail.CheckpointVersion9 {
 			// exist old version checkpoint which hasn't storage usage data in it,
@@ -190,12 +181,24 @@ func handleStorageUsageResponse(ctx context.Context, fs fileservice.FileService,
 			return map[int32]uint64{}, nil
 		}
 
+		ckpData, err := logtail.LoadSpecifiedCkpBatch(ctx, location, fs, version, logtail.SEGStorageUsageIDX)
+		if err != nil {
+			ckpData.Close()
+			return nil, err
+		}
+
+		storageUsageBat := ckpData.GetBatches()[logtail.SEGStorageUsageIDX]
+		accIDVec := storageUsageBat.GetVectorByName(catalog.SystemColAttr_AccID)
+		sizeVec := storageUsageBat.GetVectorByName(logtail.CheckpointMetaAttr_ObjectSize)
+
 		size := uint64(0)
 		length := accIDVec.Length()
 		for i := 0; i < length; i++ {
 			result[int32(accIDVec.Get(i).(uint64))] += sizeVec.Get(i).(uint64)
 			size += sizeVec.Get(i).(uint64)
 		}
+
+		ckpData.Close()
 	}
 
 	// [account_id, db_id, table_id, obj_id, table_total_size]

--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -17,6 +17,7 @@ package frontend
 import (
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"math"
 	"strings"
 	"time"
@@ -172,7 +173,7 @@ func handleStorageUsageResponse(ctx context.Context, fs fileservice.FileService,
 		version := usage.CkpEntries[idx].Version
 		location := usage.CkpEntries[idx].Location
 
-		_, ckpData, err := logtail.LoadCheckpointEntriesFromKey(ctx, fs, location, version)
+		ckpData, err := logtail.LoadSpecifiedCkpBatch(ctx, location, fs, version, logtail.SEGStorageUsageIDX)
 		if err != nil {
 			return nil, err
 		}
@@ -185,6 +186,7 @@ func handleStorageUsageResponse(ctx context.Context, fs fileservice.FileService,
 		if version < logtail.CheckpointVersion9 {
 			// exist old version checkpoint which hasn't storage usage data in it,
 			// to avoid inaccurate info leading misunderstand, we chose to return empty result
+			logutil.Info("[storage usage]: found older ckp when handle storage usage response")
 			return map[int32]uint64{}, nil
 		}
 

--- a/pkg/vm/engine/tae/logtail/storage_usage.go
+++ b/pkg/vm/engine/tae/logtail/storage_usage.go
@@ -158,6 +158,7 @@ func collectUsageDataFromICkp(ctx context.Context, fs fileservice.FileService,
 	for idx := range locations {
 		incrData, err := LoadSpecifiedCkpBatch(ctx, locations[idx], fs, versions[idx], SEGStorageUsageIDX)
 		if err != nil {
+			incrData.Close()
 			logutil.Warn(fmt.Sprintf("[storage usage]: load increment checkpoint failed: %v", err))
 			return nil
 		}
@@ -179,6 +180,8 @@ func collectUsageDataFromICkp(ctx context.Context, fs fileservice.FileService,
 				tmpRest[objId] = &UsageData{accId, dbId, tblId, [16]byte{0}, size}
 			}
 		}
+
+		incrData.Close()
 	}
 
 	return tmpRest

--- a/pkg/vm/engine/tae/logtail/storage_usage.go
+++ b/pkg/vm/engine/tae/logtail/storage_usage.go
@@ -158,7 +158,6 @@ func collectUsageDataFromICkp(ctx context.Context, fs fileservice.FileService,
 	for idx := range locations {
 		incrData, err := LoadSpecifiedCkpBatch(ctx, locations[idx], fs, versions[idx], SEGStorageUsageIDX)
 		if err != nil {
-			incrData.Close()
 			logutil.Warn(fmt.Sprintf("[storage usage]: load increment checkpoint failed: %v", err))
 			return nil
 		}

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -1987,39 +1987,42 @@ func (data *CheckpointData) ReadFrom(
 // LoadSpecifiedCkpBatch loads a specified checkpoint data batch
 func LoadSpecifiedCkpBatch(
 	ctx context.Context, location objectio.Location,
-	fs fileservice.FileService, version uint32, batchIdx uint16) (*CheckpointData, error) {
+	fs fileservice.FileService, version uint32, batchIdx uint16) (data *CheckpointData, err error) {
+	data = NewCheckpointData()
+	defer func() {
+		if err != nil {
+			data.Close()
+			data = nil
+		}
+	}()
 
 	if batchIdx >= MaxIDX {
-		return nil, moerr.NewInvalidArgNoCtx("out of bound batchIdx", batchIdx)
+		err = moerr.NewInvalidArgNoCtx("out of bound batchIdx", batchIdx)
+		return
+	}
+	var reader *blockio.BlockReader
+	if reader, err = blockio.NewObjectReader(fs, location); err != nil {
+		return
 	}
 
-	data := NewCheckpointData()
-	reader, err := blockio.NewObjectReader(fs, location)
-	if err != nil {
-		return nil, err
-	}
-	err = data.readMetaBatch(ctx, version, reader, nil)
-	if err != nil {
-		return nil, err
+	if err = data.readMetaBatch(ctx, version, reader, nil); err != nil {
+		return
 	}
 
 	data.replayMetaBatch()
 	for _, val := range data.locations {
-		var reader *blockio.BlockReader
-		reader, err = blockio.NewObjectReader(fs, val)
-		if err != nil {
-			return nil, err
+		if reader, err = blockio.NewObjectReader(fs, val); err != nil {
+			return
 		}
 		var bats []*containers.Batch
 		item := checkpointDataReferVersions[version][batchIdx]
-		bats, err = LoadBlkColumnsByMeta(version, ctx, item.types, item.attrs, batchIdx, reader)
-		if err != nil {
-			return nil, err
+		if bats, err = LoadBlkColumnsByMeta(version, ctx, item.types, item.attrs, batchIdx, reader); err != nil {
+			return
 		}
 
 		for i := range bats {
-			if err := data.bats[batchIdx].Append(bats[i]); err != nil {
-				return nil, err
+			if err = data.bats[batchIdx].Append(bats[i]); err != nil {
+				return
 			}
 		}
 	}

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -1993,8 +1993,6 @@ func LoadSpecifiedCkpBatch(
 		return nil, moerr.NewInvalidArgNoCtx("out of bound batchIdx", batchIdx)
 	}
 
-	locations := make([]objectio.Location, 0)
-	locations = append(locations, location)
 	data := NewCheckpointData()
 	reader, err := blockio.NewObjectReader(fs, location)
 	if err != nil {

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -1984,6 +1984,51 @@ func (data *CheckpointData) ReadFrom(
 	return
 }
 
+// LoadSpecifiedCkpBatch loads a specified checkpoint data batch
+func LoadSpecifiedCkpBatch(
+	ctx context.Context, location objectio.Location,
+	fs fileservice.FileService, version uint32, batchIdx uint16) (*CheckpointData, error) {
+
+	if batchIdx >= MaxIDX {
+		return nil, moerr.NewInvalidArgNoCtx("out of bound batchIdx", batchIdx)
+	}
+
+	locations := make([]objectio.Location, 0)
+	locations = append(locations, location)
+	data := NewCheckpointData()
+	reader, err := blockio.NewObjectReader(fs, location)
+	if err != nil {
+		return nil, err
+	}
+	err = data.readMetaBatch(ctx, version, reader, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	data.replayMetaBatch()
+	for _, val := range data.locations {
+		var reader *blockio.BlockReader
+		reader, err = blockio.NewObjectReader(fs, val)
+		if err != nil {
+			return nil, err
+		}
+		var bats []*containers.Batch
+		item := checkpointDataReferVersions[version][batchIdx]
+		bats, err = LoadBlkColumnsByMeta(version, ctx, item.types, item.attrs, batchIdx, reader)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range bats {
+			if err := data.bats[batchIdx].Append(bats[i]); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return data, nil
+}
+
 func (data *CheckpointData) readMetaBatch(
 	ctx context.Context,
 	version uint32,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12483 

## What this PR does / why we need it:

change to load specified ckp data batch when `show accounts` to avoid possible oom. 

the previous implementation is loading the whole ckp data.