### PR TITLE
Fix resource cleanup issue after recover

### DIFF
--- a/pkg/sql/colexec/rightsemi/join.go
+++ b/pkg/sql/colexec/rightsemi/join.go
@@ -146,7 +146,8 @@ func (ctr *container) sendLast(ap *Argument, proc *process.Process, analyze proc
 			return true, nil
 		} else {
 			cnt := 1
-			for {
+			// The original code didn't handle the context correctly and would cause the system to HUNG!
+			for completed := true; completed; {
 				select {
 				case <-proc.Ctx.Done():
 					return true, moerr.NewInternalError(proc.Ctx, "query has been closed early")
@@ -155,7 +156,7 @@ func (ctr *container) sendLast(ap *Argument, proc *process.Process, analyze proc
 					cnt++
 					if cnt == int(ap.NumCPU) {
 						close(ap.Channel)
-						break
+						completed = false
 					}
 				}
 			}

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -73,6 +73,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/panjf2000/ants/v2"
+	"go.uber.org/zap"
 )
 
 // Note: Now the cost going from stat is actually the number of rows, so we can only estimate a number for the size of each row.
@@ -466,12 +467,13 @@ func (c *Compile) runOnce() error {
 			defer func() {
 				if e := recover(); e != nil {
 					err := moerr.ConvertPanicError(c.ctx, e)
+					getLogger().Error("panic in run",
+						zap.String("error", err.Error()))
 					errC <- err
-					wg.Done()
 				}
+				wg.Done()
 			}()
 			errC <- c.run(scope)
-			wg.Done()
 		})
 	}
 	wg.Wait()

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -67,6 +67,8 @@ func (s *Scope) Run(c *Compile) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = moerr.ConvertPanicError(s.Proc.Ctx, e)
+			getLogger().Error("panic in scope run",
+				zap.String("error", err.Error()))
 		}
 		p.Cleanup(s.Proc, err != nil, err)
 	}()
@@ -113,6 +115,15 @@ func (s *Scope) MergeRun(c *Compile) error {
 		scope := s.PreScopes[i]
 		wg.Add(1)
 		ants.Submit(func() {
+			defer func() {
+				if e := recover(); e != nil {
+					err := moerr.ConvertPanicError(c.ctx, e)
+					getLogger().Error("panic in merge run run",
+						zap.String("error", err.Error()))
+					wg.Done()
+				}
+				wg.Done()
+			}()
 			switch scope.Magic {
 			case Normal:
 				errChan <- scope.Run(c)
@@ -125,7 +136,6 @@ func (s *Scope) MergeRun(c *Compile) error {
 			case Pushdown:
 				errChan <- scope.PushdownRun()
 			}
-			wg.Done()
 		})
 	}
 	defer wg.Wait()

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -53,6 +54,7 @@ func Run(ins Instructions, proc *process.Process) (end bool, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = moerr.ConvertPanicError(proc.Ctx, e)
+			logutil.Errorf("panic in vm.Run: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11966, #12385

## What this PR does / why we need it:
* Currently there are some missing resource cleanups after recover, the pr makes up for the missing resource cleanups
* Fix a case where right join didn't handle context correctly