### PR TITLE
[enhancement] hakeeper: Do not perform repeated restore operation.

### DIFF
--- a/pkg/logservice/config.go
+++ b/pkg/logservice/config.go
@@ -51,6 +51,8 @@ const (
 	DefaultListenHost     = "0.0.0.0"
 	DefaultServiceHost    = "127.0.0.1"
 	DefaultLogServicePort = 32001
+
+	defaultRestoreFilePath = "hk_data"
 )
 
 var (
@@ -188,6 +190,9 @@ type Config struct {
 			// FilePath is the path of the file, which contains the backup data.
 			// If is not set, nothing will be done for restore.
 			FilePath string `toml:"file-path"`
+			// Force means that we force to do restore even if RESTORED tag file
+			// already exists.
+			Force bool `toml:"force"`
 		} `toml:"restore"`
 	}
 
@@ -405,6 +410,7 @@ func DefaultConfig() Config {
 			InitHAKeeperMembers   []string `toml:"init-hakeeper-members"`
 			Restore               struct {
 				FilePath string `toml:"file-path"`
+				Force    bool   `toml:"force"`
 			} `toml:"restore"`
 		}(struct {
 			BootstrapCluster      bool
@@ -414,6 +420,7 @@ func DefaultConfig() Config {
 			InitHAKeeperMembers   []string
 			Restore               struct {
 				FilePath string
+				Force    bool
 			}
 		}{
 			BootstrapCluster:      true,
@@ -421,7 +428,13 @@ func DefaultConfig() Config {
 			NumOfTNShards:         1,
 			NumOfLogShardReplicas: 1,
 			InitHAKeeperMembers:   []string{"131072:" + uid},
-			Restore:               struct{ FilePath string }{FilePath: ""},
+			Restore: struct {
+				FilePath string
+				Force    bool
+			}{
+				FilePath: defaultRestoreFilePath,
+				Force:    false,
+			},
 		}),
 		HAKeeperConfig: struct {
 			TickPerSecond   int           `toml:"tick-per-second"`

--- a/pkg/logservice/service_bootstrap_test.go
+++ b/pkg/logservice/service_bootstrap_test.go
@@ -45,6 +45,14 @@ func TestGetBackupData(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, fs)
 
+	s := &Service{
+		fileService: fs,
+	}
+	// If the file do not exist, do not return error.
+	restore, err := s.getBackupData(ctx)
+	assert.NoError(t, err)
+	assert.Nil(t, restore)
+
 	ioVec := fileservice.IOVector{
 		FilePath: path.Join(dir, name),
 		Entries:  make([]fileservice.IOEntry, 1),
@@ -57,10 +65,7 @@ func TestGetBackupData(t *testing.T) {
 	err = fs.Write(ctx, ioVec)
 	assert.NoError(t, err)
 
-	s := &Service{
-		fileService: fs,
-	}
-	restore, err := s.getBackupData(ctx)
+	restore, err = s.getBackupData(ctx)
 	assert.NoError(t, err)
 	assert.Nil(t, restore)
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12437 

## What this PR does / why we need it:
1. set a default value to restore file path. If the file does not exist,
  do not restore.
2. do not perform repeated restore operation by checking the restore
  tag file. This file is created when we do restore the first time.
3. If something wrong happens and a new restore have to be done, then
  set "force" to true.