### PR TITLE
[Bug]: After a long run, the tpch get wrong result

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -78,10 +78,9 @@ import (
 // Note: Now the cost going from stat is actually the number of rows, so we can only estimate a number for the size of each row.
 // The current insertion of around 200,000 rows triggers cn to write s3 directly
 const (
-	DistributedThreshold              uint64 = 10 * mpool.MB
-	SingleLineSizeEstimate            uint64 = 300 * mpool.B
-	shuffleJoinMergeChannelBufferSize        = 4
-	shuffleJoinProbeChannelBufferSize        = 16
+	DistributedThreshold     uint64 = 10 * mpool.MB
+	SingleLineSizeEstimate   uint64 = 300 * mpool.B
+	shuffleChannelBufferSize        = 16
 )
 
 var (
@@ -2677,7 +2676,7 @@ func (c *Compile) newScopeListForShuffleGroup(childrenCount int, blocks int) ([]
 		scopes := c.newScopeListWithNode(c.generateCPUNumber(n.Mcpu, blocks), childrenCount, n.Addr)
 		for _, s := range scopes {
 			for _, rr := range s.Proc.Reg.MergeReceivers {
-				rr.Ch = make(chan *batch.Batch, 16)
+				rr.Ch = make(chan *batch.Batch, shuffleChannelBufferSize)
 			}
 		}
 		children = append(children, scopes...)
@@ -2833,7 +2832,7 @@ func (c *Compile) newShuffleJoinScopeList(left, right []*Scope, n *plan.Node) ([
 			ss[i].BuildIdx = lnum
 			ss[i].ShuffleCnt = dop
 			for _, rr := range ss[i].Proc.Reg.MergeReceivers {
-				rr.Ch = make(chan *batch.Batch, shuffleJoinMergeChannelBufferSize)
+				rr.Ch = make(chan *batch.Batch, shuffleChannelBufferSize)
 			}
 		}
 		children = append(children, ss...)

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -512,8 +512,6 @@ func (s *Scope) JoinRun(c *Compile) error {
 			probeScope := c.newJoinProbeScope(s, nil)
 			s.PreScopes = append(s.PreScopes, probeScope)
 		}
-		// this is for shuffle join probe scope
-		s.Proc.Reg.MergeReceivers[0].Ch = make(chan *batch.Batch, shuffleJoinProbeChannelBufferSize)
 		return s.MergeRun(c)
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12449

## What this PR does / why we need it:
should not set channel buffer size in runtime