### PR TITLE
do not record rowid transfer history for tables without primary key

### DIFF
--- a/pkg/vm/engine/tae/options/options.go
+++ b/pkg/vm/engine/tae/options/options.go
@@ -130,7 +130,7 @@ func (o *Options) FillDefaults(dirname string) *Options {
 	}
 
 	if o.TransferTableTTL == time.Duration(0) {
-		o.TransferTableTTL = time.Second * 120
+		o.TransferTableTTL = time.Second * 90
 	}
 
 	if o.CacheCfg == nil {

--- a/pkg/vm/engine/tae/tables/txnentries/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/txnentries/flushTableTail.go
@@ -95,6 +95,9 @@ func NewFlushTableTailEntry(
 
 // add transfer pages for dropped ablocks
 func (entry *flushTableTailEntry) addTransferPages() {
+	if !entry.tableEntry.GetLastestSchema().HasPK() {
+		return
+	}
 	for i, m := range entry.transMappings.Mappings {
 		if len(m) == 0 {
 			continue


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

1. Do not record rowid transfer history for tables without primary key
2. Change the history retention time from 120s to 90s