### PR TITLE
record rowid transfer history for a short time for the table without primary key

### DIFF
--- a/pkg/vm/engine/tae/model/pages.go
+++ b/pkg/vm/engine/tae/model/pages.go
@@ -28,16 +28,18 @@ type HashPageTable = TransferTable[*TransferHashPage]
 
 type TransferHashPage struct {
 	common.RefHelper
-	bornTS  time.Time
-	id      *common.ID
-	hashmap map[uint32]types.Rowid
+	bornTS      time.Time
+	id          *common.ID
+	hashmap     map[uint32]types.Rowid
+	isTransient bool
 }
 
-func NewTransferHashPage(id *common.ID, ts time.Time) *TransferHashPage {
+func NewTransferHashPage(id *common.ID, ts time.Time, isTransient bool) *TransferHashPage {
 	page := &TransferHashPage{
-		bornTS:  ts,
-		id:      id,
-		hashmap: make(map[uint32]types.Rowid),
+		bornTS:      ts,
+		id:          id,
+		hashmap:     make(map[uint32]types.Rowid),
+		isTransient: isTransient,
 	}
 	page.OnZeroCB = page.Close
 	return page
@@ -47,6 +49,9 @@ func (page *TransferHashPage) ID() *common.ID    { return page.id }
 func (page *TransferHashPage) BornTS() time.Time { return page.bornTS }
 
 func (page *TransferHashPage) TTL(now time.Time, ttl time.Duration) bool {
+	if page.isTransient {
+		ttl /= 2
+	}
 	return now.After(page.bornTS.Add(ttl))
 }
 

--- a/pkg/vm/engine/tae/model/transfer_test.go
+++ b/pkg/vm/engine/tae/model/transfer_test.go
@@ -33,7 +33,7 @@ func TestTransferPage(t *testing.T) {
 		BlockID: *objectio.NewBlockid(sid, 2, 0),
 	}
 
-	memo1 := NewTransferHashPage(&src, time.Now())
+	memo1 := NewTransferHashPage(&src, time.Now(), false)
 	assert.Zero(t, memo1.RefCount())
 
 	for i := 0; i < 10; i++ {
@@ -47,7 +47,7 @@ func TestTransferPage(t *testing.T) {
 
 	ttl := time.Millisecond * 10
 	now := time.Now()
-	memo2 := NewTransferHashPage(&src, now)
+	memo2 := NewTransferHashPage(&src, now, false)
 	defer memo2.Close()
 	assert.Zero(t, memo2.RefCount())
 
@@ -77,7 +77,7 @@ func TestTransferTable(t *testing.T) {
 	id2 := common.ID{BlockID: *objectio.NewBlockid(sid, 2, 0)}
 
 	now := time.Now()
-	page1 := NewTransferHashPage(&id1, now)
+	page1 := NewTransferHashPage(&id1, now, false)
 	for i := 0; i < 10; i++ {
 		rowID := *objectio.NewRowid(&id2.BlockID, uint32(i))
 		page1.Train(uint32(i), rowID)

--- a/pkg/vm/engine/tae/tables/txnentries/compactblk.go
+++ b/pkg/vm/engine/tae/tables/txnentries/compactblk.go
@@ -52,7 +52,7 @@ func NewCompactBlockEntry(
 	rt *dbutils.Runtime,
 ) *compactBlockEntry {
 
-	page := model.NewTransferHashPage(from.Fingerprint(), time.Now())
+	page := model.NewTransferHashPage(from.Fingerprint(), time.Now(), false)
 	if to != nil {
 		toId := to.Fingerprint()
 		offsetMapping := compute.GetOffsetMapBeforeApplyDeletes(deletes)

--- a/pkg/vm/engine/tae/tables/txnentries/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/txnentries/flushTableTail.go
@@ -95,16 +95,14 @@ func NewFlushTableTailEntry(
 
 // add transfer pages for dropped ablocks
 func (entry *flushTableTailEntry) addTransferPages() {
-	if !entry.tableEntry.GetLastestSchema().HasPK() {
-		return
-	}
+	isTransient := !entry.tableEntry.GetLastestSchema().HasPK()
 	for i, m := range entry.transMappings.Mappings {
 		if len(m) == 0 {
 			continue
 		}
 		id := entry.ablksHandles[i].Fingerprint()
 		entry.pageIds = append(entry.pageIds, id)
-		page := model.NewTransferHashPage(id, time.Now())
+		page := model.NewTransferHashPage(id, time.Now(), isTransient)
 		for srcRow, dst := range m {
 			blkid := entry.createdBlkHandles[dst.Idx].ID()
 			page.Train(uint32(srcRow), *objectio.NewRowid(&blkid, uint32(dst.Row)))

--- a/pkg/vm/engine/tae/tables/txnentries/mergeblocks.go
+++ b/pkg/vm/engine/tae/tables/txnentries/mergeblocks.go
@@ -147,15 +147,14 @@ func (entry *mergeBlocksEntry) transferBlockDeletes(
 		panic("cannot tranfer empty block")
 	}
 	tblEntry := dropped.GetSegment().GetTable()
-	if tblEntry.GetLastestSchema().HasPK() {
-		id := dropped.AsCommonID()
-		page := model.NewTransferHashPage(id, time.Now())
-		for srcRow, dst := range mapping {
-			blkid := blks[dst.Idx].ID()
-			page.Train(uint32(srcRow), *objectio.NewRowid(&blkid, uint32(dst.Row)))
-		}
-		_ = entry.rt.TransferTable.AddPage(page)
+	isTransient := !tblEntry.GetLastestSchema().HasPK()
+	id := dropped.AsCommonID()
+	page := model.NewTransferHashPage(id, time.Now(), isTransient)
+	for srcRow, dst := range mapping {
+		blkid := blks[dst.Idx].ID()
+		page.Train(uint32(srcRow), *objectio.NewRowid(&blkid, uint32(dst.Row)))
 	}
+	_ = entry.rt.TransferTable.AddPage(page)
 
 	dataBlock := dropped.GetBlockData()
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12660 

## What this PR does / why we need it:
Record the transfer history for a short time to avoid r-w errors in BVT. 