### PR TITLE
fix wrong unique index prefix

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -38,10 +38,14 @@ const (
 	// locks to the Lock operator in pessimistic transaction mode.
 	FakePrimaryKeyColName = "__mo_fake_pk_col"
 	// IndexTable has two column at most, the first is idx col, the second is origin table primary col
-	IndexTableIndexColName   = "__mo_index_idx_col"
-	IndexTablePrimaryColName = "__mo_index_pri_col"
-	ExternalFilePath         = "__mo_filepath"
-	IndexTableNamePrefix     = "__mo_index_unique__"
+	IndexTableIndexColName        = "__mo_index_idx_col"
+	IndexTablePrimaryColName      = "__mo_index_pri_col"
+	ExternalFilePath              = "__mo_filepath"
+	UniqueIndexSuffix             = "unique_"
+	SecondaryIndexSuffix          = "secondary_"
+	UniqueIndexTableNamePrefix    = PrefixIndexTableName + UniqueIndexSuffix
+	SecondaryIndexTableNamePrefix = PrefixIndexTableName + SecondaryIndexSuffix
+	IndexTableNamePrefix          = PrefixIndexTableName
 	// MOAutoIncrTable mo auto increment table name
 	MOAutoIncrTable = "mo_increment_columns"
 )

--- a/pkg/sql/plan/mock.go
+++ b/pkg/sql/plan/mock.go
@@ -450,7 +450,7 @@ func NewMockCompilerContext(isDml bool) *MockCompilerContext {
 		idxs: []index{
 			{
 				indexName: "",
-				tableName: catalog.IndexTableNamePrefix + "412f4fad-77ba-11ed-b347-000c29847904",
+				tableName: catalog.UniqueIndexTableNamePrefix + "412f4fad-77ba-11ed-b347-000c29847904",
 				parts:     []string{"ename", "job"},
 				cols: []col{
 					{catalog.IndexTableIndexColName, types.T_varchar, true, 65535, 0},
@@ -462,7 +462,7 @@ func NewMockCompilerContext(isDml bool) *MockCompilerContext {
 	}
 
 	// index table
-	constraintTestSchema[catalog.IndexTableNamePrefix+"412f4fad-77ba-11ed-b347-000c29847904"] = &Schema{
+	constraintTestSchema[catalog.UniqueIndexTableNamePrefix+"412f4fad-77ba-11ed-b347-000c29847904"] = &Schema{
 		cols: []col{
 			{catalog.IndexTableIndexColName, types.T_varchar, true, 65535, 0},
 			{catalog.IndexTablePrimaryColName, types.T_uint32, true, 32, 0},
@@ -493,7 +493,7 @@ func NewMockCompilerContext(isDml bool) *MockCompilerContext {
 		idxs: []index{
 			{
 				indexName: "",
-				tableName: catalog.IndexTableNamePrefix + "8e3246dd-7a19-11ed-ba7d-000c29847904",
+				tableName: catalog.UniqueIndexTableNamePrefix + "8e3246dd-7a19-11ed-ba7d-000c29847904",
 				parts:     []string{"dname"},
 				cols: []col{
 					{catalog.IndexTableIndexColName, types.T_varchar, true, 15, 0},
@@ -505,7 +505,7 @@ func NewMockCompilerContext(isDml bool) *MockCompilerContext {
 	}
 
 	// index table
-	constraintTestSchema[catalog.IndexTableNamePrefix+"8e3246dd-7a19-11ed-ba7d-000c29847904"] = &Schema{
+	constraintTestSchema[catalog.UniqueIndexTableNamePrefix+"8e3246dd-7a19-11ed-ba7d-000c29847904"] = &Schema{
 		cols: []col{
 			{catalog.IndexTableIndexColName, types.T_varchar, true, 15, 0},
 			{catalog.IndexTablePrimaryColName, types.T_uint32, true, 32, 0},
@@ -565,7 +565,7 @@ func NewMockCompilerContext(isDml bool) *MockCompilerContext {
 		idxs: []index{
 			{
 				indexName: "",
-				tableName: catalog.IndexTableNamePrefix + "6380d30e-79f8-11ed-9c02-000c29847904",
+				tableName: catalog.UniqueIndexTableNamePrefix + "6380d30e-79f8-11ed-9c02-000c29847904",
 				parts:     []string{"empno", "ename"},
 				cols: []col{
 					{catalog.IndexTableIndexColName, types.T_varchar, true, 65535, 0},
@@ -576,7 +576,7 @@ func NewMockCompilerContext(isDml bool) *MockCompilerContext {
 		outcnt: 14,
 	}
 
-	constraintTestSchema[catalog.IndexTableNamePrefix+"6380d30e-79f8-11ed-9c02-000c29847904"] = &Schema{
+	constraintTestSchema[catalog.UniqueIndexTableNamePrefix+"6380d30e-79f8-11ed-9c02-000c29847904"] = &Schema{
 		cols: []col{
 			{catalog.IndexTableIndexColName, types.T_varchar, true, 65535, 0},
 			{catalog.Row_ID, types.T_Rowid, false, 16, 0},

--- a/pkg/sql/util/index_util.go
+++ b/pkg/sql/util/index_util.go
@@ -33,11 +33,10 @@ var CompactPrimaryCol = compactPrimaryCol
 
 func BuildIndexTableName(ctx context.Context, unique bool) (string, error) {
 	var name string
-	name = catalog.PrefixIndexTableName
 	if unique {
-		name += "unique_"
+		name = catalog.UniqueIndexTableNamePrefix
 	} else {
-		name += "secondary_"
+		name = catalog.SecondaryIndexTableNamePrefix
 	}
 	id, err := uuid.NewUUID()
 	if err != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #1686 https://github.com/matrixorigin/MO-Cloud/issues/1686

## What this PR does / why we need it:
修改 unique index 前缀名错误导致show accounts失败问题。

原因：
1，unique index 前缀名错误使得索引表被误判为cluster table。
2，普通租户的索引表被切换到sys租户取统计信息。因此出错。

索引表名称定义时只有单个下划线：
![image](https://github.com/matrixorigin/matrixone/assets/60595215/73e8d244-469f-4509-8a9d-ac2c2f048ae3)

错误使用双下划线：
![image](https://github.com/matrixorigin/matrixone/assets/60595215/caa9eb72-d0e0-412c-9e3c-6c5ccf668315)
