### PR TITLE
cherry pick: fix wrong unique table name

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -41,9 +41,11 @@ const (
 	IndexTableIndexColName        = "__mo_index_idx_col"
 	IndexTablePrimaryColName      = "__mo_index_pri_col"
 	ExternalFilePath              = "__mo_filepath"
-	IndexTableNamePrefix          = "__mo_index_"
-	UniqueIndexTableNamePrefix    = "__mo_index_unique__"
-	SecondaryIndexTableNamePrefix = "__mo_index_secondary__"
+	UniqueIndexSuffix             = "unique_"
+	SecondaryIndexSuffix          = "secondary_"
+	UniqueIndexTableNamePrefix    = PrefixIndexTableName + UniqueIndexSuffix
+	SecondaryIndexTableNamePrefix = PrefixIndexTableName + SecondaryIndexSuffix
+	IndexTableNamePrefix          = PrefixIndexTableName
 	// MOAutoIncrTable mo auto increment table name
 	MOAutoIncrTable = "mo_increment_columns"
 )

--- a/pkg/sql/util/index_util.go
+++ b/pkg/sql/util/index_util.go
@@ -35,11 +35,10 @@ var CompactPrimaryCol = compactPrimaryCol
 
 func BuildIndexTableName(ctx context.Context, unique bool) (string, error) {
 	var name string
-	name = catalog.PrefixIndexTableName
 	if unique {
-		name += "unique_"
+		name = catalog.UniqueIndexTableNamePrefix
 	} else {
-		name += "secondary_"
+		name = catalog.SecondaryIndexTableNamePrefix
 	}
 	id, err := uuid.NewUUID()
 	if err != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/1686 https://github.com/matrixorigin/MO-Cloud/issues/1686

## What this PR does / why we need it:

修改 unique index 前缀名错误导致show accounts失败问题。

原因：
1，unique index 前缀名错误使得索引表被误判为cluster table。
2，普通租户的索引表被切换到sys租户取统计信息。因此出错。

索引表名称定义时只有单个下划线：
![image](https://github.com/matrixorigin/matrixone/assets/60595215/73e8d244-469f-4509-8a9d-ac2c2f048ae3)

错误使用双下划线：
![image](https://github.com/matrixorigin/matrixone/assets/60595215/caa9eb72-d0e0-412c-9e3c-6c5ccf668315)
