### PR TITLE
add info cmd and various improvement

### DIFF
--- a/pkg/vm/engine/tae/catalog/table.go
+++ b/pkg/vm/engine/tae/catalog/table.go
@@ -320,6 +320,10 @@ func (entry *TableEntry) ObjectStatsString(level common.PPLevel) string {
 			_, _ = w.WriteString("    ")
 			_, _ = w.WriteString(segment.Stat.String(composeSortKey))
 		}
+		if w.Len() > 8*1024*1024 {
+			w.WriteString("\n...(truncated for too long, more than 8 MB)")
+			break
+		}
 	}
 	if level > common.PPL0 && cnt > 0 {
 		w.WriteByte('\n')

--- a/pkg/vm/engine/tae/common/stats.go
+++ b/pkg/vm/engine/tae/common/stats.go
@@ -61,6 +61,15 @@ func (h *MergeHistory) IsLastBefore(d time.Duration) bool {
 	return h.LastTime.Before(time.Now().Add(-d))
 }
 
+func (h *MergeHistory) String() string {
+	return fmt.Sprintf(
+		"(%v) no%v nb%v osize%v",
+		h.LastTime.Format("2006-01-02_15:04:05"),
+		h.NObj, h.NBlk,
+		HumanReadableBytes(h.OSize),
+	)
+}
+
 type TableCompactStat struct {
 	sync.RWMutex
 
@@ -101,6 +110,12 @@ func (s *TableCompactStat) AddMerge(osize, nobj, nblk int) {
 	s.Lock()
 	defer s.Unlock()
 	s.MergeHist.Add(osize, nobj, nblk)
+}
+
+func (s *TableCompactStat) GetLastFlush() types.TS {
+	s.RLock()
+	defer s.RUnlock()
+	return s.LastFlush
 }
 
 func (s *TableCompactStat) GetLastMerge() *MergeHistory {

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -436,9 +436,10 @@ func initCommand(ctx context.Context, inspectCtx *inspectContext) *cobra.Command
 		Run:   RunFactory(&compactPolicyArg{}),
 	}
 	policyCmd.Flags().StringP("target", "t", "*", "format: db.table")
-	policyCmd.Flags().Int32P("maxMergeObjN", "o", common.DefaultMaxMergeObjN, "max number of objects merged for one")
-	policyCmd.Flags().Int32P("minRowsQualified", "m", common.DefaultMinRowsQualified, "object with a few rows will be picked up to merge")
+	policyCmd.Flags().Int32P("maxMergeObjN", "o", common.DefaultMaxMergeObjN, "max number of objects merged for one run")
+	policyCmd.Flags().Int32P("minRowsQualified", "m", common.DefaultMinRowsQualified, "objects which are less than minRowsQualified will be picked up to merge")
 	policyCmd.Flags().Int32P("notLoadMoreThan", "l", common.DefaultNotLoadMoreThan, "not load metadata if table has too much objects. Only works for rawlog table")
+	policyCmd.Flags().MarkHidden("notLoadMoreThan")
 	rootCmd.AddCommand(policyCmd)
 
 	mmCmd := &cobra.Command{

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db"
@@ -191,6 +192,61 @@ func (c *manualyIgnoreArg) String() string {
 
 func (c *manualyIgnoreArg) Run() error {
 	logtail.TempF.Add(c.id)
+	return nil
+}
+
+type infoArg struct {
+	ctx *inspectContext
+	tbl *catalog.TableEntry
+	blk *catalog.BlockEntry
+}
+
+func (c *infoArg) FromCommand(cmd *cobra.Command) (err error) {
+	c.ctx = cmd.Flag("ictx").Value.(*inspectContext)
+
+	address, _ := cmd.Flags().GetString("target")
+	c.tbl, err = parseTableTarget(address, c.ctx.acinfo, c.ctx.db)
+	if err != nil {
+		return err
+	}
+	if c.tbl == nil {
+		return moerr.NewInvalidInputNoCtx("need table target")
+	}
+
+	baddress, _ := cmd.Flags().GetString("blk")
+	c.blk, err = parseBlkTarget(baddress, c.tbl)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *infoArg) String() string {
+	t := "*"
+	if c.tbl != nil {
+		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchema().Name)
+	}
+
+	if c.blk != nil {
+		t = fmt.Sprintf("%s %s", t, c.blk.ID.String())
+	}
+
+	return fmt.Sprintf("info: %v", t)
+}
+
+func (c *infoArg) Run() error {
+	b := &bytes.Buffer{}
+	if c.tbl != nil {
+		b.WriteString(fmt.Sprintf("last_merge: %v\n", c.tbl.Stats.GetLastMerge().String()))
+		b.WriteString(fmt.Sprintf("last_flush: %v\n", c.tbl.Stats.GetLastFlush().ToString()))
+	}
+	if c.blk != nil {
+		b.WriteRune('\n')
+		b.WriteString(fmt.Sprintf("persisted_ts: %v\n", c.blk.GetDeltaPersistedTS().ToString()))
+		b.WriteString(fmt.Sprintf("delchain: %v\n", c.blk.GetBlockData().DeletesInfo()))
+	}
+	c.ctx.resp.Payload = b.Bytes()
 	return nil
 }
 
@@ -395,6 +451,17 @@ func initCommand(ctx context.Context, inspectCtx *inspectContext) *cobra.Command
 	mmCmd.Flags().StringSliceP("objects", "o", nil, "format: object_id_0000,object_id_0000")
 	rootCmd.AddCommand(mmCmd)
 
+	infoCmd := &cobra.Command{
+		Use:   "info",
+		Short: "get dedicated debug info",
+		Run:   RunFactory(&infoArg{}),
+	}
+
+	infoCmd.Flags().StringP("target", "t", "*", "format: table-id")
+	infoCmd.Flags().StringP("blk", "b", "", "format: <objectId>_<fineN>_<blkN>")
+
+	rootCmd.AddCommand(infoCmd)
+
 	miCmd := &cobra.Command{
 		Use:   "ckpignore",
 		Short: "manually ignore table when checking checkpoint entry",
@@ -410,6 +477,38 @@ func initCommand(ctx context.Context, inspectCtx *inspectContext) *cobra.Command
 func RunInspect(ctx context.Context, inspectCtx *inspectContext) {
 	rootCmd := initCommand(ctx, inspectCtx)
 	rootCmd.Execute()
+}
+
+func parseBlkTarget(address string, tbl *catalog.TableEntry) (*catalog.BlockEntry, error) {
+	if address == "" {
+		return nil, nil
+	}
+	parts := strings.Split(address, "_")
+	if len(parts) != 3 {
+		return nil, moerr.NewInvalidInputNoCtx(fmt.Sprintf("invalid db.table: %q", address))
+	}
+	uid, err := types.ParseUuid(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	fn, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, err
+	}
+	bn, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, err
+	}
+	bid := objectio.NewBlockid(&uid, uint16(fn), uint16(bn))
+	sentry, err := tbl.GetSegmentByID(&uid)
+	if err != nil {
+		return nil, err
+	}
+	bentry, err := sentry.GetBlockEntryByID(bid)
+	if err != nil {
+		return nil, err
+	}
+	return bentry, nil
 }
 
 func parseTableTarget(address string, ac *db.AccessInfo, db *db.DB) (*catalog.TableEntry, error) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12645

## What this PR does / why we need it:

add an interface to get info on the delete chain for debugging

```sh
*************************** 1. row ***************************
mo_ctl(dn, inspect, info -t db.t -b 81a6fb82-82aa-11ee-a8c2-acde48001122_0_0): 
msg: success. arg info: 272472-t 81a6fb82-82aa-11ee-a8c2-acde48001122-0-0

last_merge: (0001-01-01_00:00:00) no0 nb0 osize0B
last_flush: 0-1

persisted_ts: 0-0
delchain: DeleteChain:
1. [TXN:C:N][1:{1}][1699938229578336000-1,1699938229586875000-0]
```