### PR TITLE
[bug] txn client: fix hang issue.

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -210,7 +210,7 @@ const (
 	ErrTxnCannotRetry             uint16 = 20630
 	ErrTxnNeedRetryWithDefChanged uint16 = 20631
 	ErrTxnStale                   uint16 = 20632
-	ErrWaiterCanceled             uint16 = 20633
+	ErrWaiterPaused               uint16 = 20633
 
 	// Group 7: lock service
 	// ErrDeadLockDetected lockservice has detected a deadlock and should abort the transaction if it receives this error
@@ -418,7 +418,7 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	ErrTxnCannotRetry:             {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "txn s3 writes can not retry in rc mode"},
 	ErrTxnNeedRetryWithDefChanged: {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "txn need retry in rc mode, def changed"},
 	ErrTxnStale:                   {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "txn is stale: timestamp is too small"},
-	ErrWaiterCanceled:             {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "waiter is canceled"},
+	ErrWaiterPaused:               {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "waiter is paused"},
 
 	// Group 7: lock service
 	ErrDeadLockDetected:     {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "deadlock detected"},

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -265,8 +265,8 @@ func NewTxnStaleNoCtx() *Error {
 	return newError(Context(), ErrTxnStale)
 }
 
-func NewWaiterCanceledNoCtx() *Error {
-	return newError(Context(), ErrWaiterCanceled)
+func NewWaiterPausedNoCtx() *Error {
+	return newError(Context(), ErrWaiterPaused)
 }
 
 func NewNotFoundNoCtx() *Error {

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -408,7 +408,14 @@ func (client *txnClient) openTxn(op *txnOperator) error {
 			client.addActiveTxnLocked(op)
 			return nil
 		}
-		op.waiter = newWaiter(timestamp.Timestamp{})
+		var cancelC chan struct{}
+		if client.timestampWaiter != nil {
+			cancelC = client.timestampWaiter.CancelC()
+			if cancelC == nil {
+				return moerr.NewWaiterPausedNoCtx()
+			}
+		}
+		op.waiter = newWaiter(timestamp.Timestamp{}, cancelC)
 		op.waiter.ref()
 		client.mu.waitActiveTxns = append(client.mu.waitActiveTxns, op)
 		return nil
@@ -497,7 +504,7 @@ func (client *txnClient) AbortAllRunningTxn() {
 	if client.timestampWaiter != nil {
 		// Cancel all waiters, means that all waiters do not need to wait for
 		// the newer timestamp from logtail consumer.
-		client.timestampWaiter.Cancel()
+		client.timestampWaiter.Pause()
 	}
 
 	for _, op := range ops {
@@ -514,6 +521,11 @@ func (client *txnClient) AbortAllRunningTxn() {
 		_ = op.Rollback(context.Background())
 		op.workspace = tempWorkspace
 		op.notifyActive()
+	}
+
+	if client.timestampWaiter != nil {
+		// After rollback all transactions, resume the timestamp waiter channel.
+		client.timestampWaiter.Resume()
 	}
 }
 

--- a/pkg/txn/client/timestamp_waiter.go
+++ b/pkg/txn/client/timestamp_waiter.go
@@ -33,10 +33,10 @@ const (
 type timestampWaiter struct {
 	stopper   stopper.Stopper
 	notifiedC chan timestamp.Timestamp
-	cancelC   chan struct{}
 	latestTS  atomic.Pointer[timestamp.Timestamp]
 	mu        struct {
 		sync.Mutex
+		cancelC      chan struct{}
 		waiters      []*waiter
 		lastNotified timestamp.Timestamp
 	}
@@ -48,8 +48,8 @@ func NewTimestampWaiter() TimestampWaiter {
 		stopper: *stopper.NewStopper("timestamp-waiter",
 			stopper.WithLogger(util.GetLogger().RawLogger())),
 		notifiedC: make(chan timestamp.Timestamp, maxNotifiedCount),
-		cancelC:   make(chan struct{}, 1),
 	}
+	tw.mu.cancelC = make(chan struct{}, 1)
 	if err := tw.stopper.RunTask(tw.handleEvent); err != nil {
 		panic(err)
 	}
@@ -62,7 +62,10 @@ func (tw *timestampWaiter) GetTimestamp(ctx context.Context, ts timestamp.Timest
 		return latest.Next(), nil
 	}
 
-	w := tw.addToWait(ts)
+	w, err := tw.addToWait(ts)
+	if err != nil {
+		return timestamp.Timestamp{}, err
+	}
 	if w != nil {
 		defer w.close()
 		if err := w.wait(ctx); err != nil {
@@ -78,30 +81,54 @@ func (tw *timestampWaiter) NotifyLatestCommitTS(ts timestamp.Timestamp) {
 	tw.notifiedC <- ts
 }
 
-func (tw *timestampWaiter) Cancel() {
+func (tw *timestampWaiter) Pause() {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
 	select {
-	case tw.cancelC <- struct{}{}:
-		util.LogTimestampWaiterCanceled()
+	case _, ok := <-tw.mu.cancelC:
+		if !ok {
+			// The channel is already closed.
+			return
+		}
 	default:
 	}
+	close(tw.mu.cancelC)
+	tw.mu.cancelC = nil
+	tw.removeWaitersLocked()
+	util.LogTimestampWaiterCanceled()
+}
+
+func (tw *timestampWaiter) Resume() {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	tw.mu.cancelC = make(chan struct{}, 1)
+}
+
+func (tw *timestampWaiter) CancelC() chan struct{} {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	return tw.mu.cancelC
 }
 
 func (tw *timestampWaiter) Close() {
 	tw.stopper.Stop()
 }
 
-func (tw *timestampWaiter) addToWait(ts timestamp.Timestamp) *waiter {
+func (tw *timestampWaiter) addToWait(ts timestamp.Timestamp) (*waiter, error) {
 	tw.mu.Lock()
 	defer tw.mu.Unlock()
 	if !tw.mu.lastNotified.IsEmpty() &&
 		tw.mu.lastNotified.GreaterEq(ts) {
-		return nil
+		return nil, nil
 	}
 
-	w := newWaiter(ts)
+	if tw.mu.cancelC == nil {
+		return nil, moerr.NewWaiterPausedNoCtx()
+	}
+	w := newWaiter(ts, tw.mu.cancelC)
 	w.ref()
 	tw.mu.waiters = append(tw.mu.waiters, w)
-	return w
+	return w, nil
 }
 
 func (tw *timestampWaiter) notifyWaiters(ts timestamp.Timestamp) {
@@ -124,12 +151,9 @@ func (tw *timestampWaiter) notifyWaiters(ts timestamp.Timestamp) {
 	tw.mu.lastNotified = ts
 }
 
-func (tw *timestampWaiter) cancelWaiters() {
-	tw.mu.Lock()
-	defer tw.mu.Unlock()
+func (tw *timestampWaiter) removeWaitersLocked() {
 	for idx, w := range tw.mu.waiters {
 		if w != nil {
-			w.cancel()
 			w.unref()
 			tw.mu.waiters[idx] = nil
 		}
@@ -150,8 +174,6 @@ func (tw *timestampWaiter) handleEvent(ctx context.Context) {
 				tw.latestTS.Store(&ts)
 				tw.notifyWaiters(ts)
 			}
-		case <-tw.cancelC:
-			tw.cancelWaiters()
 		}
 	}
 }
@@ -174,11 +196,9 @@ var (
 		New: func() any {
 			w := &waiter{
 				notifyC: make(chan struct{}, 1),
-				cancelC: make(chan struct{}, 1),
 			}
 			runtime.SetFinalizer(w, func(w *waiter) {
 				close(w.notifyC)
-				close(w.cancelC)
 			})
 			return w
 		},
@@ -194,14 +214,15 @@ type waiter struct {
 	cancelC chan struct{}
 }
 
-func newWaiter(ts timestamp.Timestamp) *waiter {
+func newWaiter(ts timestamp.Timestamp, c chan struct{}) *waiter {
 	w := waitersPool.Get().(*waiter)
-	w.init(ts)
+	w.init(ts, c)
 	return w
 }
 
-func (w *waiter) init(ts timestamp.Timestamp) {
+func (w *waiter) init(ts timestamp.Timestamp, c chan struct{}) {
 	w.waitAfter = ts
+	w.cancelC = c
 	if w.ref() != 1 {
 		panic("BUG: waiter init must has ref count 1")
 	}
@@ -214,16 +235,12 @@ func (w *waiter) wait(ctx context.Context) error {
 	case <-w.notifyC:
 		return nil
 	case <-w.cancelC:
-		return moerr.NewWaiterCanceledNoCtx()
+		return moerr.NewWaiterPausedNoCtx()
 	}
 }
 
 func (w *waiter) notify() {
 	w.notifyC <- struct{}{}
-}
-
-func (w *waiter) cancel() {
-	w.cancelC <- struct{}{}
 }
 
 func (w *waiter) ref() int32 {
@@ -249,7 +266,10 @@ func (w *waiter) reset() {
 	for {
 		select {
 		case <-w.notifyC:
-		case <-w.cancelC:
+		case _, ok := <-w.cancelC:
+			if !ok {
+				return
+			}
 		default:
 			return
 		}

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -178,9 +178,16 @@ type TimestampWaiter interface {
 	// commit ts is corresponds to an epoch. Whenever the connection of logtail of cn and tn is
 	// reset, the epoch will be reset and all the ts of the old epoch should be invalidated.
 	NotifyLatestCommitTS(appliedTS timestamp.Timestamp)
-	// Cancel cancels all waiters in timestamp waiter. They will not wait for the newer
-	// timestamp anymore.
-	Cancel()
+	// Pause pauses the timestamp waiter and cancel all waiters in timestamp waiter.
+	// They will not wait for the newer timestamp anymore.
+	Pause()
+	// Resume resumes the cancel channel in the timestamp waiter after all transactions are
+	// aborted.
+	Resume()
+	// CancelC returns the cancel channel of timestamp waiter. If it is nil, means that
+	// the logtail consumer is reconnecting to logtail server and is aborting all transaction.
+	// At this time, we cannot open new transactions.
+	CancelC() chan struct{}
 	// Close close the timestamp waiter
 	Close()
 }

--- a/pkg/txn/util/log.go
+++ b/pkg/txn/util/log.go
@@ -78,7 +78,7 @@ func LogTxnPushedTimestampUpdated(
 func LogTimestampWaiterCanceled() {
 	logger := getSkipLogger()
 	if logger.Enabled(zap.InfoLevel) {
-		logger.Debug("timestamp waiter canceled")
+		logger.Info("timestamp waiter canceled")
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/1733

## What this PR does / why we need it:
some sequence bug results to the hang issue, fix:
1. timestamp waiter and single txn waiter share the same channel 
2. add lock for the cancel channel. If pause the timestamp waiter,
  set the cancel channel to nil in timestamp waiter. If some new txns
  comes, refuse its creation because the channel is nil. After rollback
  all txns, resume the timestamp waiter and create a new cancel channel.