### PR TITLE
return error when trigger times does not match

### DIFF
--- a/pkg/taskservice/mysql_task_storage.go
+++ b/pkg/taskservice/mysql_task_storage.go
@@ -676,8 +676,8 @@ func (m *mysqlTaskStorage) UpdateCronTask(ctx context.Context, cronTask task.Cro
 	}
 
 	triggerTimes, err := m.getTriggerTimes(ctx, conn, cronTask.Metadata.ID)
-	if err == sql.ErrNoRows || triggerTimes != cronTask.TriggerTimes-1 {
-		return 0, nil
+	if errors.Is(err, sql.ErrNoRows) || triggerTimes != cronTask.TriggerTimes-1 {
+		return 0, moerr.NewInternalError(ctx, "cron task trigger times not match")
 	}
 
 	tx, err := conn.BeginTx(ctx, &sql.TxOptions{})
@@ -752,9 +752,6 @@ func (m *mysqlTaskStorage) getTriggerTimes(ctx context.Context, conn *sql.Conn, 
 	var triggerTimes uint64
 	err := conn.QueryRowContext(ctx, fmt.Sprintf(getTriggerTimes, m.dbname), taskMetadataID).Scan(&triggerTimes)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return 0, nil
-		}
 		return 0, err
 	}
 	return triggerTimes, nil

--- a/pkg/taskservice/task_service_cron.go
+++ b/pkg/taskservice/task_service_cron.go
@@ -308,7 +308,7 @@ func (j *cronJob) doRun() {
 	_, err := j.s.store.UpdateCronTask(ctx, newTask, value)
 	if err != nil {
 		j.s.rt.Logger().Error("trigger cron task failed",
-			zap.String("cron-task", j.task.Metadata.ID),
+			zap.String("cron-task", j.task.DebugString()),
 			zap.Error(err))
 		j.s.addToRetrySchedule(j.task)
 		return


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/1746

## What this PR does / why we need it:

Return error when trigger time does not match.
Print more info when trigger cron tasks failed.