### PR TITLE
remove some metric

### DIFF
--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -71,8 +71,11 @@ func (mixin *withFilterMixin) tryUpdateColumns(cols []string) {
 	// record the column selectivity
 	chit, ctotal := len(cols), len(mixin.tableDef.Cols)
 	v2.TaskSelColumnTotal.Add(float64(ctotal))
-	v2.TaskSelColumnHit.Add(float64(ctotal - chit))
-	blockio.RecordColumnSelectivity(chit, ctotal)
+	// TAG FOR bug:12797  need remove this tag after bug fixed
+	if ctotal > chit {
+		v2.TaskSelColumnHit.Add(float64(ctotal - chit))
+		blockio.RecordColumnSelectivity(chit, ctotal)
+	}
 
 	mixin.columns.seqnums = make([]uint16, len(cols))
 	mixin.columns.colTypes = make([]types.Type, len(cols))

--- a/test/distributed/cases/dml/delete/delete.result
+++ b/test/distributed/cases/dml/delete/delete.result
@@ -286,4 +286,14 @@ delete from t2 where b in (c in (select 1) and d in (select 1));
 select * from t2;
 a    b    c    d
 1    2    1    2
+drop table if exists t7;
+create table t7(a int primary key, b int unique key, c varchar(20) unique key);
+insert into t7 select result, result, "a"||result from generate_series(1,2000000) g;
+select count(*) from t7;
+count(*)
+2000000
+delete from t7;
+select count(*) from t7;
+count(*)
+0
 drop database if exists `delete`;

--- a/test/distributed/cases/dml/delete/delete.test
+++ b/test/distributed/cases/dml/delete/delete.test
@@ -216,4 +216,11 @@ insert into t2 values (1,2,1,2);
 delete from t2 where b in (c in (select 1) and d in (select 1));
 select * from t2;
 
+drop table if exists t7;
+create table t7(a int primary key, b int unique key, c varchar(20) unique key);
+insert into t7 select result, result, "a"||result from generate_series(1,2000000) g;
+select count(*) from t7;
+delete from t7;
+select count(*) from t7;
+
 drop database if exists `delete`;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12797

## What this PR does / why we need it:
临时移除一个统计信息。
目前大部分compile构建的source中的tableDef都是没有row_id的。
这里的统计信息的代码会默认它是包含row_id的，所以会对不上，于是panic了。
而block reader捕获到这个panic会跳过不读这个block。于是造成reader读不到数据。

复现步骤：
```
drop table if exists t7;
create table t7(a int primary key, b int unique key, c varchar(20) unique key);
insert into t7 select result, result, "a"||result from generate_series(1,2000000) g;
select count(*) from t7;
delete from t7;    // delete zero row.
select count(*) from t7;
```

先临时移除了，等明天再跟大家讨论处理方案