### PR TITLE
improve mem usage of PrimaryKeysMayBeModified

### DIFF
--- a/pkg/vm/engine/disttae/logtailreplay/rows_iter_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/rows_iter_test.go
@@ -112,7 +112,7 @@ func TestPartitionStateRowsIter(t *testing.T) {
 		}
 		require.Equal(t, 1, n)
 		require.Nil(t, iter.Close())
-		modified := state.PrimaryKeyMayBeModified(ts.Prev(), ts.Next(), bs)
+		modified := state.PrimaryKeyMayBeModified(ts.Prev(), ts.Next(), [][]byte{bs})
 		require.True(t, modified)
 	}
 
@@ -207,7 +207,7 @@ func TestPartitionStateRowsIter(t *testing.T) {
 			modified := state.PrimaryKeyMayBeModified(
 				types.BuildTS(int64(deleteAt+i), 0).Prev(),
 				types.BuildTS(int64(deleteAt+i), 0).Next(),
-				key,
+				[][]byte{key},
 			)
 			require.True(t, modified)
 		}
@@ -349,7 +349,7 @@ func TestInsertAndDeleteAtTheSameTimestamp(t *testing.T) {
 	for i := 0; i < num; i++ {
 		ts := types.BuildTS(int64(i), 0)
 		key := EncodePrimaryKey(int64(i), packer)
-		modified := state.PrimaryKeyMayBeModified(ts.Prev(), ts.Next(), key)
+		modified := state.PrimaryKeyMayBeModified(ts.Prev(), ts.Next(), [][]byte{key})
 		require.True(t, modified)
 	}
 
@@ -441,7 +441,7 @@ func TestDeleteBeforeInsertAtTheSameTime(t *testing.T) {
 	for i := 0; i < num; i++ {
 		ts := types.BuildTS(int64(i), 0)
 		key := EncodePrimaryKey(int64(i), packer)
-		modified := state.PrimaryKeyMayBeModified(ts.Prev(), ts.Next(), key)
+		modified := state.PrimaryKeyMayBeModified(ts.Prev(), ts.Next(), [][]byte{key})
 		require.True(t, modified)
 	}
 
@@ -486,7 +486,7 @@ func TestPrimaryKeyModifiedWithDeleteOnly(t *testing.T) {
 	for i := 0; i < num; i++ {
 		ts := types.BuildTS(int64(i), 0)
 		key := EncodePrimaryKey(int64(i), packer)
-		modified := state.PrimaryKeyMayBeModified(ts.Prev(), ts.Next(), key)
+		modified := state.PrimaryKeyMayBeModified(ts.Prev(), ts.Next(), [][]byte{key})
 		require.True(t, modified)
 	}
 

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1870,12 +1870,9 @@ func (tbl *txnTable) PrimaryKeysMayBeModified(ctx context.Context, from types.TS
 	packer.Reset()
 
 	keys := logtailreplay.EncodePrimaryKeyVector(keysVector, packer)
-	for _, key := range keys {
-		if snap.PrimaryKeyMayBeModified(from, to, key) {
-			return true, nil
-		}
+	if snap.PrimaryKeyMayBeModified(from, to, keys) {
+		return true, nil
 	}
-
 	return false, nil
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/1574

## What this PR does / why we need it:
improve mem usage of PrimaryKeysMayBeModified
在处理 https://github.com/matrixorigin/matrixone/pull/12818  这个的时候。
在profile中看到这个方法占用时间会多一些。所以做了简单的优化。
主要是改了一下函数参数，把一个batch的数据都传进去，这样部分函数就只需要执行一次了。主要是这个
p.primaryIndex.Copy().Iter()   主要是这个一个批次只要执行一次了。
另外就是去掉了  p.rows.Copy().Iter() 的Copy()