### PR TITLE
fix: time-sensitive case NEEDs enough cpu

### DIFF
--- a/pkg/util/metric/mometric/metric_collector_test.go
+++ b/pkg/util/metric/mometric/metric_collector_test.go
@@ -85,7 +85,8 @@ func TestCollector(t *testing.T) {
 	t.Logf("runtime.NumCPU: %d", runtime.NumCPU())
 	sqlch := make(chan string, 100)
 	factory := newExecutorFactory(sqlch)
-	collector := newMetricCollector(factory, WithFlushInterval(200*time.Millisecond), WithMetricThreshold(2))
+	collector := newMetricCollector(factory, WithFlushInterval(200*time.Millisecond), WithMetricThreshold(2),
+		WithSqlWorkerNum(runtime.NumCPU()))
 	collector.Start(context.TODO())
 	defer collector.Stop(false)
 	names := []string{"m1", "m2"}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/9259#issuecomment-1820510193

## What this PR does / why we need it:

changs:
1. 根据cpu个数启动对应数量的 MetricCollector  worker 。

background:
1. #12819 合并后, MetricCollector 默认只有 `#cpu * 0.1` 个 worker。