### PR TITLE
flush deletes more timely

### DIFF
--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
@@ -64,7 +64,8 @@ func (c *DashboardCreator) initTaskFlushTableTailRow() dashboard.Option {
 		c.getTimeSeries(
 			"Flush table tail Count",
 			[]string{fmt.Sprintf(
-				"increase(%s[$interval])",
+				"sum by (%s) (increase(%s[$interval]))",
+				c.by,
 				c.getMetricWithFilter(`mo_task_short_duration_seconds_count`, `type="flush_table_tail"`),
 			)},
 			[]string{"Count"},
@@ -85,11 +86,13 @@ func (c *DashboardCreator) initTaskMergeRow() dashboard.Option {
 			"Merge Count",
 			[]string{
 				fmt.Sprintf(
-					"increase(%s[$interval])",
+					"sum by (%s) (increase(%s[$interval]))",
+					c.by,
 					c.getMetricWithFilter(`mo_task_execute_results_total`, `type="merged_block"`)),
 
 				fmt.Sprintf(
-					"increase(%s[$interval])",
+					"sum by (%s) (increase(%s[$interval]))",
+					c.by,
 					c.getMetricWithFilter(`mo_task_scheduled_by_total`, `type="merge"`)),
 			},
 			[]string{
@@ -100,7 +103,8 @@ func (c *DashboardCreator) initTaskMergeRow() dashboard.Option {
 		c.getTimeSeries(
 			"Merge Batch Size",
 			[]string{fmt.Sprintf(
-				"increase(%s[$interval])",
+				"sum by (%s) (increase(%s[$interval]))",
+				c.by,
 				c.getMetricWithFilter(`mo_task_execute_results_total`, `type="merged_size"`))},
 			[]string{"Size"},
 			timeseries.Axis(tsaxis.Unit("decbytes")),
@@ -129,11 +133,13 @@ func (c *DashboardCreator) initTaskCheckpointRow() dashboard.Option {
 			"Checkpoint Load Object Count",
 			[]string{
 				fmt.Sprintf(
-					"increase(%s[$interval])",
+					"sum by (%s) (increase(%s[$interval]))",
+					c.by,
 					c.getMetricWithFilter(`mo_task_execute_results_total`, `type="gckp_load_object"`)),
 
 				fmt.Sprintf(
-					"increase(%s[$interval])",
+					"sum by (%s) (increase(%s[$interval]))",
+					c.by,
 					c.getMetricWithFilter(`mo_task_execute_results_total`, `type="ickp_load_object"`)),
 			},
 			[]string{

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_test.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_test.go
@@ -26,6 +26,6 @@ func TestCreateCloudDashboard(t *testing.T) {
 		return
 	}
 
-	c := NewCloudDashboardCreator("http://127.0.0.1", "admin", "admin", "Prometheus")
+	c := NewCloudDashboardCreator("http://127.0.0.1:3000", "admin", "admin", "Prometheus")
 	require.NoError(t, c.Create())
 }

--- a/pkg/util/metric/v2/task.go
+++ b/pkg/util/metric/v2/task.go
@@ -38,10 +38,12 @@ var (
 			Subsystem: "task",
 			Name:      "long_duration_seconds",
 			Help:      "Bucketed histogram of long tn task execute duration.",
-			Buckets:   prometheus.ExponentialBuckets(1, 2.0, 13),
+			Buckets:   prometheus.ExponentialBuckets(1, 2.0, 20),
 		}, []string{"type"})
 
 	TaskCkpEntryPendingDurationHistogram = taskLongDurationHistogram.WithLabelValues("ckp_entry_pending")
+	TaskLoadMemDeletesPerBlockHistogram  = taskLongDurationHistogram.WithLabelValues("load_mem_deletes_per_block")
+	TaskFlushDeletesHistogram            = taskLongDurationHistogram.WithLabelValues("flush_deletes")
 )
 
 var (

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -508,11 +508,13 @@ func (r *blockMergeReader) loadDeletes(ctx context.Context) error {
 		}
 		ts := types.TimestampToTS(r.ts)
 		iter := state.NewRowsIter(ts, &info.BlockID, true)
+		currlen := len(r.buffer)
 		for iter.Next() {
 			entry := iter.Entry()
 			_, offset := entry.RowID.Decode()
 			r.buffer = append(r.buffer, int64(offset))
 		}
+		v2.TaskLoadMemDeletesPerBlockHistogram.Observe(float64(len(r.buffer) - currlen))
 		iter.Close()
 	}
 

--- a/pkg/vm/engine/tae/catalog/table.go
+++ b/pkg/vm/engine/tae/catalog/table.go
@@ -320,7 +320,7 @@ func (entry *TableEntry) ObjectStatsString(level common.PPLevel) string {
 			_, _ = w.WriteString("    ")
 			_, _ = w.WriteString(segment.Stat.String(composeSortKey))
 		}
-		if w.Len() > 8*1024*1024 {
+		if w.Len() > 8*common.Const1MBytes {
 			w.WriteString("\n...(truncated for too long, more than 8 MB)")
 			break
 		}

--- a/pkg/vm/engine/tae/common/stats.go
+++ b/pkg/vm/engine/tae/common/stats.go
@@ -29,6 +29,9 @@ const (
 	DefaultNotLoadMoreThan  = 4096
 	DefaultMinRowsQualified = 40960
 	DefaultMaxMergeObjN     = 2
+
+	Const1GBytes = 1 << 30
+	Const1MBytes = 1 << 20
 )
 
 var (
@@ -128,10 +131,10 @@ func HumanReadableBytes(bytes int) string {
 	if bytes < 1024 {
 		return fmt.Sprintf("%dB", bytes)
 	}
-	if bytes < 1024*1024 {
+	if bytes < Const1MBytes {
 		return fmt.Sprintf("%.2fKB", float64(bytes)/1024)
 	}
-	if bytes < 1024*1024*1024 {
+	if bytes < Const1GBytes {
 		return fmt.Sprintf("%.2fMB", float64(bytes)/1024/1024)
 	}
 	return fmt.Sprintf("%.2fGB", float64(bytes)/1024/1024/1024)

--- a/pkg/vm/engine/tae/db/checkpoint/runner.go
+++ b/pkg/vm/engine/tae/db/checkpoint/runner.go
@@ -844,8 +844,7 @@ func (r *runner) fireFlushTabletail(table *catalog.TableEntry, tree *model.Table
 	return nil
 }
 
-func (r *runner) EstimateTableMemSize(table *catalog.TableEntry, tree *model.TableTree) int {
-	size := 0
+func (r *runner) EstimateTableMemSize(table *catalog.TableEntry, tree *model.TableTree) (asize int, dsize int) {
 	for _, seg := range tree.Segs {
 		segment, err := table.GetSegmentByID(seg.ID)
 		if err != nil {
@@ -857,10 +856,12 @@ func (r *runner) EstimateTableMemSize(table *catalog.TableEntry, tree *model.Tab
 			if err != nil {
 				panic(err)
 			}
-			size += block.GetBlockData().EstimateMemSize()
+			a, d := block.GetBlockData().EstimateMemSize()
+			asize += a
+			dsize += d
 		}
 	}
-	return size
+	return
 }
 
 func (r *runner) tryCompactTree(entry *logtail.DirtyTreeEntry, force bool) {
@@ -889,17 +890,18 @@ func (r *runner) tryCompactTree(entry *logtail.DirtyTreeEntry, force bool) {
 		dirtyTree := entry.GetTree().GetTable(tableID)
 		_, endTs := entry.GetTimeRange()
 
-		size := r.EstimateTableMemSize(table, dirtyTree)
+		asize, dsize := r.EstimateTableMemSize(table, dirtyTree)
 
 		stats := &table.Stats
 		stats.Lock()
 		defer stats.Unlock()
 
 		// debug log, delete later
-		if !stats.LastFlush.IsEmpty() && size > 2*1000*1024 {
-			logutil.Infof("[flushtabletail] %s(%s)  FlushCountDown %v",
+		if !stats.LastFlush.IsEmpty() && asize+dsize > 2*1000*1024 {
+			logutil.Infof("[flushtabletail] %v(%v) %v dels  FlushCountDown %v",
 				table.GetLastestSchema().Name,
-				common.HumanReadableBytes(size),
+				common.HumanReadableBytes(asize+dsize),
+				common.HumanReadableBytes(dsize),
 				time.Until(stats.FlushDeadline))
 		}
 
@@ -918,7 +920,20 @@ func (r *runner) tryCompactTree(entry *logtail.DirtyTreeEntry, force bool) {
 			return moerr.GetOkStopCurrRecur()
 		}
 
-		if stats.FlushDeadline.Before(time.Now()) || size > stats.FlushMemCapacity {
+		flushReady := func() bool {
+			if stats.FlushDeadline.Before(time.Now()) {
+				return true
+			}
+			if asize+dsize > stats.FlushMemCapacity {
+				return true
+			}
+			if asize < common.Const1MBytes && dsize > 2*common.Const1MBytes+common.Const1MBytes/2 {
+				return true
+			}
+			return false
+		}
+
+		if flushReady() {
 			if err := r.fireFlushTabletail(table, dirtyTree, endTs); err == nil {
 				stats.ResetDeadlineWithLock()
 			}

--- a/pkg/vm/engine/tae/db/merge/executor.go
+++ b/pkg/vm/engine/tae/db/merge/executor.go
@@ -69,7 +69,7 @@ func (e *MergeExecutor) RefreshMemInfo() {
 
 func (e *MergeExecutor) PrintStats() {
 	cnt := atomic.LoadInt32(&e.activeMergeBlkCount)
-	if cnt == 0 && e.MemAvailBytes() > 512*const1MBytes {
+	if cnt == 0 && e.MemAvailBytes() > 512*common.Const1MBytes {
 		return
 	}
 

--- a/pkg/vm/engine/tae/db/merge/mod.go
+++ b/pkg/vm/engine/tae/db/merge/mod.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
 )
 
@@ -26,10 +27,8 @@ var StopMerge atomic.Bool
 
 const (
 	constMergeMinBlks       = 5
-	const1GBytes            = 1 << 30
-	const1MBytes            = 1 << 20
 	constMergeExpansionRate = 6
-	constMaxMemCap          = 4 * constMergeExpansionRate * const1GBytes // max orginal memory for a object
+	constMaxMemCap          = 4 * constMergeExpansionRate * common.Const1GBytes // max orginal memory for a object
 	constSmallMergeGap      = 3 * time.Minute
 )
 

--- a/pkg/vm/engine/tae/db/scannerop.go
+++ b/pkg/vm/engine/tae/db/scannerop.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/merge"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
 )
@@ -201,7 +202,7 @@ func (s *MergeTaskBuilder) onDataBase(dbEntry *catalog.DBEntry) (err error) {
 	if merge.StopMerge.Load() {
 		return moerr.GetOkStopCurrRecur()
 	}
-	if s.executor.MemAvailBytes() < 100*1024*1024 {
+	if s.executor.MemAvailBytes() < 100*common.Const1MBytes {
 		return moerr.GetOkStopCurrRecur()
 	}
 	return

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -8662,21 +8662,22 @@ func TestEstimateMemSize(t *testing.T) {
 		testutil.CreateRelationAndAppend(t, 0, tae.DB, "db", schema, bat, true)
 		txn, rel := tae.GetRelation()
 		blk := testutil.GetOneBlockMeta(rel)
-		size1 := blk.GetBlockData().EstimateMemSize()
+		size1, ds1 := blk.GetBlockData().EstimateMemSize()
 		schema50rowSize = size1
 
 		err := rel.DeleteByPhyAddrKey(*objectio.NewRowid(&blk.ID, 1))
 		require.NoError(t, err)
-		size2 := blk.GetBlockData().EstimateMemSize()
+		size2, ds2 := blk.GetBlockData().EstimateMemSize()
 
 		err = rel.DeleteByPhyAddrKey(*objectio.NewRowid(&blk.ID, 5))
 		require.NoError(t, err)
-		size3 := blk.GetBlockData().EstimateMemSize()
-		require.Less(t, size1, size2)
-		require.Less(t, size2, size3)
+		size3, ds3 := blk.GetBlockData().EstimateMemSize()
+		// require.Less(t, size1, size2)
+		// require.Less(t, size2, size3)
 		require.NoError(t, txn.Rollback(ctx))
-		size4 := blk.GetBlockData().EstimateMemSize()
+		size4, ds4 := blk.GetBlockData().EstimateMemSize()
 		t.Log(size1, size2, size3, size4)
+		t.Log(ds1, ds2, ds3, ds4)
 	}
 
 	{
@@ -8685,20 +8686,22 @@ func TestEstimateMemSize(t *testing.T) {
 		testutil.CreateRelationAndAppend(t, 0, tae.DB, "db", schemaBig, bat, false)
 		txn, rel := tae.GetRelation()
 		blk := testutil.GetOneBlockMeta(rel)
-		size1 := blk.GetBlockData().EstimateMemSize()
+		size1, d1 := blk.GetBlockData().EstimateMemSize()
 
 		err := rel.DeleteByPhyAddrKey(*objectio.NewRowid(&blk.ID, 1))
 		require.NoError(t, err)
 
-		size2 := blk.GetBlockData().EstimateMemSize()
+		size2, d2 := blk.GetBlockData().EstimateMemSize()
 
 		err = rel.DeleteByPhyAddrKey(*objectio.NewRowid(&blk.ID, 5))
 		require.NoError(t, err)
-		size3 := blk.GetBlockData().EstimateMemSize()
+		size3, d3 := blk.GetBlockData().EstimateMemSize()
 
 		t.Log(size1, size2, size3)
-		require.Less(t, size1, size2)
-		require.Less(t, size2, size3)
+		t.Log(d1, d2, d3)
+		require.Equal(t, size1, size2)
+		require.Equal(t, size2, size3)
+		require.Less(t, d1, d2)
 		require.Less(t, schema50rowSize, size1)
 		require.NoError(t, txn.Commit(ctx))
 	}

--- a/pkg/vm/engine/tae/iface/data/block.go
+++ b/pkg/vm/engine/tae/iface/data/block.go
@@ -127,7 +127,7 @@ type Block interface {
 		mp *mpool.MPool,
 	) error
 	PPString(level common.PPLevel, depth int, prefix string) string
-	EstimateMemSize() int
+	EstimateMemSize() (int, int)
 	GetRuntime() *dbutils.Runtime
 
 	Init() error

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -84,16 +84,16 @@ func (blk *baseBlock) GetRuntime() *dbutils.Runtime {
 	return blk.rt
 }
 
-func (blk *baseBlock) EstimateMemSize() int {
+func (blk *baseBlock) EstimateMemSize() (int, int) {
 	node := blk.PinNode()
 	defer node.Unref()
 	blk.RLock()
 	defer blk.RUnlock()
-	size := blk.mvcc.EstimateMemSizeLocked()
+	asize, dsize := blk.mvcc.EstimateMemSizeLocked()
 	if !node.IsPersisted() {
-		size += node.MustMNode().EstimateMemSize()
+		asize += node.MustMNode().EstimateMemSize()
 	}
-	return size
+	return asize, dsize
 }
 
 func (blk *baseBlock) PinNode() *Node {

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -307,6 +307,7 @@ func (task *flushTableTailTask) Execute(ctx context.Context) (err error) {
 		common.OperandField(task))
 
 	v2.TaskFlushTableTailDurationHistogram.Observe(duration.Seconds())
+	v2.TaskFlushDeletesHistogram.Observe(float64(task.nblksDeletesCnt))
 
 	sleep, name, exist := fault.TriggerFault("slow_flush")
 	if exist && name == task.schema.Name {

--- a/pkg/vm/engine/tae/tables/txnentries/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/txnentries/flushTableTail.go
@@ -125,7 +125,6 @@ func (entry *flushTableTailEntry) PrepareCommit() error {
 			}
 		}
 	}
-	logutil.Infof("[FlushTabletail] task %d has write-write conflict on %d nblk", entry.taskID, nconflictCnt)
 	var aconflictCnt, totalTrans int
 	// transfer deletes in (startts .. committs] for ablocks
 	delTbls := make([]*model.TransDels, len(entry.createdBlkHandles))
@@ -174,7 +173,6 @@ func (entry *flushTableTailEntry) PrepareCommit() error {
 		found = true
 		entry.nextRoundDirties = append(entry.nextRoundDirties, blk)
 	}
-	logutil.Infof("[FlushTabletail] task %d has write-write conflict on %d ablk, total trans cnt %d ", entry.taskID, aconflictCnt, totalTrans)
 	for i, delTbl := range delTbls {
 		if delTbl != nil {
 			destid := entry.createdBlkHandles[i].ID()
@@ -183,7 +181,10 @@ func (entry *flushTableTailEntry) PrepareCommit() error {
 	}
 
 	if found {
-		logutil.Infof("[FlushTabletail] task %d ww (%s .. %s)", entry.taskID, entry.txn.GetStartTS().ToString(), entry.txn.GetPrepareTS().ToString())
+		logutil.Infof(
+			"[FlushTabletail] task %d ww (%s .. %s): on %d ablk, transfer %v rows; on %v nblk, no tranfer, don't worry",
+			entry.taskID, entry.txn.GetStartTS().ToString(), entry.txn.GetPrepareTS().ToString(),
+			aconflictCnt, totalTrans, nconflictCnt)
 	}
 	return nil
 }

--- a/pkg/vm/engine/tae/tables/updates/mvcc.go
+++ b/pkg/vm/engine/tae/tables/updates/mvcc.go
@@ -91,12 +91,12 @@ func (n *MVCCHandle) StringLocked() string {
 	return s
 }
 
-func (n *MVCCHandle) EstimateMemSizeLocked() int {
-	size := n.deletes.Load().EstimateMemSizeLocked()
+func (n *MVCCHandle) EstimateMemSizeLocked() (asize int, dsize int) {
+	dsize += n.deletes.Load().EstimateMemSizeLocked()
 	if n.appends != nil {
-		size += len(n.appends.MVCC) * AppendNodeApproxSize
+		asize += len(n.appends.MVCC) * AppendNodeApproxSize
 	}
-	return size + MVCCHandleApproxSize
+	return asize, dsize + MVCCHandleApproxSize
 }
 
 // ==========================================================


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12775

## What this PR does / why we need it:

flush 2.5MB pure delete nodes in TN and truncate memory deletes in CN more timely

In my local settings, sysbench 100000-10terminals case performance increases about 40% 