### PR TITLE
Fix PrefetchFile interface:1.0-dev (#12906)

### DIFF
--- a/pkg/vm/engine/tae/blockio/pipeline.go
+++ b/pkg/vm/engine/tae/blockio/pipeline.go
@@ -152,7 +152,13 @@ func prefetchJob(ctx context.Context, params PrefetchParams) *tasks.Job {
 		func(_ context.Context) (res *tasks.JobResult) {
 			// TODO
 			res = &tasks.JobResult{}
-			err := reader.GetFs().PrefetchFile(ctx, params.key.Name().String())
+			var name string
+			if params.reader == nil {
+				name = params.key.Name().String()
+			} else {
+				name = params.reader.GetName()
+			}
+			err := reader.GetFs().PrefetchFile(ctx, name)
 			if err != nil {
 				res.Err = err
 				return


### PR DESCRIPTION
Some prefetch requests do not have keys, but the reader is set, and judgment conditions need to be added.

Approved by: @XuPeng-SH

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12912

## What this PR does / why we need it: