### PR TITLE
[bug] BR: fix bug when restore data

### DIFF
--- a/pkg/logservice/service_bootstrap_test.go
+++ b/pkg/logservice/service_bootstrap_test.go
@@ -50,7 +50,7 @@ func TestGetBackupData(t *testing.T) {
 		fileService: fs,
 	}
 	// If the file do not exist, do not return error.
-	restore, err := s.getBackupData(ctx)
+	restore, err := s.getBackupData(ctx, fs)
 	assert.NoError(t, err)
 	assert.Nil(t, restore)
 
@@ -66,12 +66,12 @@ func TestGetBackupData(t *testing.T) {
 	err = fs.Write(ctx, ioVec)
 	assert.NoError(t, err)
 
-	restore, err = s.getBackupData(ctx)
+	restore, err = s.getBackupData(ctx, fs)
 	assert.NoError(t, err)
 	assert.Nil(t, restore)
 
 	s.cfg.BootstrapConfig.Restore.FilePath = path.Join(dir, name)
-	restore, err = s.getBackupData(ctx)
+	restore, err = s.getBackupData(ctx, fs)
 	assert.NoError(t, err)
 	assert.NotNil(t, restore)
 	assert.Equal(t, nextID, restore.NextID)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12891

## What this PR does / why we need it:
there is no default fileservice instance, so we need to get a fileservice
instance explicitly, otherwise, a "service not found" error will be raised.