### PR TITLE
fix build plan func not set in sql executor to 1.1-dev

### DIFF
--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -238,6 +238,11 @@ func (exec *txnExecutor) Exec(sql string) (executor.Result, error) {
 	}
 
 	c := New(exec.s.addr, exec.opts.Database(), sql, "", "", exec.ctx, exec.s.eng, proc, stmts[0], false, nil, receiveAt)
+	c.SetBuildPlanFunc(func() (*plan.Plan, error) {
+		return plan.BuildPlan(
+			exec.s.getCompileContext(exec.ctx, proc, exec.opts),
+			stmts[0], false)
+	})
 
 	result := executor.NewResult(exec.s.mp)
 	var batches []*batch.Batch


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
fix build plan func not set in sql executor, cherry pick