### PR TITLE
[cheey pick] add filter condition push down for sample function (#12950)

### DIFF
--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -670,6 +670,10 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 			return nil, err
 		}
 
+		for _, expr := range node.FilterList {
+			builder.remapHavingClause(expr, groupTag, sampleTag, int32(len(node.GroupBy)))
+		}
+
 		// deal with group col and sample col.
 		for i, expr := range node.GroupBy {
 			increaseRefCnt(expr, -1, colRefCnt)

--- a/test/distributed/cases/sample/sample_func.result
+++ b/test/distributed/cases/sample/sample_func.result
@@ -99,6 +99,13 @@ c1    c3
 2    0
 2    0
 3    null
+/* 12. sample as and outer filter */
+select * from (select c1, sample(c3, 3 rows) as k from s_t1 group by c1) where k < 2 order by c1, k;
+c1    k
+1    0
+1    1
+2    0
+2    0
 /* data prepare for sample from multi columns */
 drop table if exists s_t2;
 create table s_t2 (cc1 int, cc2 int);

--- a/test/distributed/cases/sample/sample_func.sql
+++ b/test/distributed/cases/sample/sample_func.sql
@@ -49,6 +49,8 @@ select sample(c3, 1 rows) from s_t1 where c1 = 3;
 select sample(c3, 2 rows) from s_t1 where c1 = 3;
 select c1, sample(c3, 3 rows) from s_t1 where c1 = 3 group by c1;
 select c1, sample(c3, 3 rows) from s_t1 group by c1 order by c1, c3;
+/* 12. sample as and outer filter */
+select * from (select c1, sample(c3, 3 rows) as k from s_t1 group by c1) where k < 2 order by c1, k;
 
 /* data prepare for sample from multi columns */
 drop table if exists s_t2;


### PR DESCRIPTION
add filter condition push down rule for sample function to make sure some sql like `select * from (select sample(col, 1 rows) as k from t) where k > 10` can run succeed.

Approved by: @heni02, @ouyuanning, @aunjgr

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12826 

## What this PR does / why we need it: