### PR TITLE
cherry-pick: remove unused tag logic

### DIFF
--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -71,11 +71,8 @@ func (mixin *withFilterMixin) tryUpdateColumns(cols []string) {
 	// record the column selectivity
 	chit, ctotal := len(cols), len(mixin.tableDef.Cols)
 	v2.TaskSelColumnTotal.Add(float64(ctotal))
-	// TAG FOR bug:12797  need remove this tag after bug fixed
-	if ctotal > chit {
-		v2.TaskSelColumnHit.Add(float64(ctotal - chit))
-		blockio.RecordColumnSelectivity(chit, ctotal)
-	}
+	v2.TaskSelColumnHit.Add(float64(ctotal - chit))
+	blockio.RecordColumnSelectivity(chit, ctotal)
 
 	mixin.columns.seqnums = make([]uint16, len(cols))
 	mixin.columns.colTypes = make([]types.Type, len(cols))


### PR DESCRIPTION
this PR: https://github.com/matrixorigin/matrixone/pull/12896 had make all TableDef in disttae as the same. then this bug was fixed.

Approved by: @nnsgmsone

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/12797

## What this PR does / why we need it:
cherry-pick PR 12983