### PR TITLE
[BugFix]: Multi-Tenant upgrade logic for `mo_catalog.mo_indexes` 

### DIFF
--- a/pkg/cnservice/upgrader/upgrader.go
+++ b/pkg/cnservice/upgrader/upgrader.go
@@ -188,7 +188,7 @@ func (u *Upgrader) Upgrade(ctx context.Context) error {
 		errors = append(errors, errs...)
 	}
 
-	if errs := u.UpgradeMoIndexesSchema(ctx); len(errs) > 0 {
+	if errs := u.UpgradeMoIndexesSchema(ctx, allTenants); len(errs) > 0 {
 		logutil.Errorf("upgrade mo_indexes failed")
 		errors = append(errors, errs...)
 	}
@@ -382,14 +382,15 @@ func (u *Upgrader) UpgradeNewView(ctx context.Context, tenants []*frontend.Tenan
 // 1. boostrap.go builds mo_catalog.mo_indexes table
 // 2. sysview.InitSchema builds INFORMATION_SCHEMA.columns table that will have columns in mo_indexes table
 // 3. UpgradeMoIndexesSchema adds 3 new columns to mo_indexes table
-func (u *Upgrader) UpgradeMoIndexesSchema(ctx context.Context) []error {
+// NOTE: mo_indexes is a multi-tenant table, so we need to upgrade (add column) for all tenants.
+func (u *Upgrader) UpgradeMoIndexesSchema(ctx context.Context, tenants []*frontend.TenantInfo) []error {
 	exec := u.IEFactory()
 	if exec == nil {
 		return nil
 	}
 
-	ifEmpty := func(sql string) (bool, error) {
-		result := exec.Query(ctx, sql, ie.NewOptsBuilder().Finish())
+	ifEmpty := func(sql string, opts *ie.OptsBuilder) (bool, error) {
+		result := exec.Query(ctx, sql, opts.Finish())
 
 		if err := result.Error(); err != nil {
 			return false, moerr.NewUpgrateError(ctx, "mo_catalog", "mo_indexes", frontend.GetDefaultTenant(), catalog.System_Account, err.Error())
@@ -399,7 +400,7 @@ func (u *Upgrader) UpgradeMoIndexesSchema(ctx context.Context) []error {
 
 	}
 
-	execTxn := func(sqls []string) error {
+	execTxn := func(sqls []string, opts *ie.OptsBuilder) error {
 
 		stmt := []string{"begin;"}
 		stmt = append(stmt, sqls...)
@@ -407,7 +408,7 @@ func (u *Upgrader) UpgradeMoIndexesSchema(ctx context.Context) []error {
 
 		upgradeSQL := strings.Join(stmt, "\n")
 
-		err := exec.Exec(ctx, upgradeSQL, ie.NewOptsBuilder().Finish())
+		err := exec.Exec(ctx, upgradeSQL, opts.Finish())
 		if err != nil {
 			return err
 		}
@@ -416,14 +417,19 @@ func (u *Upgrader) UpgradeMoIndexesSchema(ctx context.Context) []error {
 	}
 
 	var errors []error
-	for _, conditionalUpgradeSQL := range conditionalUpgradeV1SQLs {
+	for _, tenant := range tenants {
+		ctx = attachAccount(ctx, tenant)
+		opts := makeOptions(tenant)
 
-		if columnNotPresent, err1 := ifEmpty(conditionalUpgradeSQL.ifEmpty); err1 != nil {
-			errors = append(errors, moerr.NewUpgrateError(ctx, "mo_catalog", "mo_indexes", frontend.GetDefaultTenant(), catalog.System_Account, err1.Error()))
-		} else if columnNotPresent {
-			err2 := execTxn(conditionalUpgradeSQL.then)
-			if err2 != nil {
-				errors = append(errors, moerr.NewUpgrateError(ctx, "mo_catalog", "mo_indexes", frontend.GetDefaultTenant(), catalog.System_Account, err2.Error()))
+		for _, conditionalUpgradeSQL := range conditionalUpgradeV1SQLs {
+
+			if columnNotPresent, err1 := ifEmpty(conditionalUpgradeSQL.ifEmpty, opts); err1 != nil {
+				errors = append(errors, moerr.NewUpgrateError(ctx, "mo_catalog", "mo_indexes", frontend.GetDefaultTenant(), catalog.System_Account, err1.Error()))
+			} else if columnNotPresent {
+				err2 := execTxn(conditionalUpgradeSQL.then, opts)
+				if err2 != nil {
+					errors = append(errors, moerr.NewUpgrateError(ctx, "mo_catalog", "mo_indexes", frontend.GetDefaultTenant(), catalog.System_Account, err2.Error()))
+				}
 			}
 		}
 	}

--- a/pkg/util/internalExecutor/internal_executor.go
+++ b/pkg/util/internalExecutor/internal_executor.go
@@ -71,6 +71,7 @@ func (s *OptsBuilder) DefaultRoleId(id uint32) *OptsBuilder {
 	return s
 }
 
+// Finish returns the final SessionOverrideOptions. Ideally should be called Build() in reference to Builder pattern.
 func (s *OptsBuilder) Finish() SessionOverrideOptions {
 	return *s.opts
 }

--- a/pkg/util/internalExecutor/internal_executor.go
+++ b/pkg/util/internalExecutor/internal_executor.go
@@ -71,7 +71,6 @@ func (s *OptsBuilder) DefaultRoleId(id uint32) *OptsBuilder {
 	return s
 }
 
-// Finish returns the final SessionOverrideOptions. Ideally should be called Build() in reference to Builder pattern.
 func (s *OptsBuilder) Finish() SessionOverrideOptions {
 	return *s.opts
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/1859

## What this PR does / why we need it:

`mo_indexes` is a multi-tenant table. so the upgrade should happen for all the tenants. Previously, the upgrade was run without tenant info.