### PR TITLE
[bug] proxy: rebalance connections to wrong cns.

### DIFF
--- a/pkg/proxy/rebalancer_test.go
+++ b/pkg/proxy/rebalancer_test.go
@@ -45,11 +45,12 @@ func testRebalancer(
 }
 
 func TestCollectTunnels(t *testing.T) {
-	runtime.SetupProcessLevelRuntime(runtime.DefaultRuntime())
+	rt := runtime.DefaultRuntime()
+	runtime.SetupProcessLevelRuntime(rt)
 	hc := &mockHAKeeperClient{}
 	mc := clusterservice.NewMOCluster(hc, 3*time.Second)
 	defer mc.Close()
-	rt := runtime.DefaultRuntime()
+	rt.SetGlobalVariables(runtime.ClusterService, mc)
 	logger := rt.Logger()
 	st := stopper.NewStopper("test-proxy", stopper.WithLogger(rt.Logger().RawLogger()))
 	defer st.Stop()
@@ -124,8 +125,8 @@ func TestCollectTunnels(t *testing.T) {
 }
 
 func TestCollectTunnels_Mixed(t *testing.T) {
-	runtime.SetupProcessLevelRuntime(runtime.DefaultRuntime())
 	rt := runtime.DefaultRuntime()
+	runtime.SetupProcessLevelRuntime(rt)
 	logger := rt.Logger()
 	st := stopper.NewStopper("test-proxy", stopper.WithLogger(rt.Logger().RawLogger()))
 	defer st.Stop()
@@ -145,6 +146,7 @@ func TestCollectTunnels_Mixed(t *testing.T) {
 		hc := &mockHAKeeperClient{}
 		mc := clusterservice.NewMOCluster(hc, 3*time.Second)
 		defer mc.Close()
+		rt.SetGlobalVariables(runtime.ClusterService, mc)
 
 		shared01 := prepareCN("shared01", hc, ha, reqLabel, nil)
 		shared02 := prepareCN("shared02", hc, ha, reqLabel, nil)
@@ -169,6 +171,7 @@ func TestCollectTunnels_Mixed(t *testing.T) {
 		hc := &mockHAKeeperClient{}
 		mc := clusterservice.NewMOCluster(hc, 3*time.Second)
 		defer mc.Close()
+		rt.SetGlobalVariables(runtime.ClusterService, mc)
 
 		_ = prepareCN("shared01", hc, ha, reqLabel, nil)
 		_ = prepareCN("shared02", hc, ha, reqLabel, nil)
@@ -195,6 +198,7 @@ func TestCollectTunnels_Mixed(t *testing.T) {
 		hc := &mockHAKeeperClient{}
 		mc := clusterservice.NewMOCluster(hc, 3*time.Second)
 		defer mc.Close()
+		rt.SetGlobalVariables(runtime.ClusterService, mc)
 
 		shared01 := prepareCN("shared01", hc, ha, reqLabel, nil)
 		shared02 := prepareCN("shared02", hc, ha, reqLabel, nil)
@@ -220,6 +224,7 @@ func TestCollectTunnels_Mixed(t *testing.T) {
 		hc := &mockHAKeeperClient{}
 		mc := clusterservice.NewMOCluster(hc, 3*time.Second)
 		defer mc.Close()
+		rt.SetGlobalVariables(runtime.ClusterService, mc)
 
 		shared01 := prepareCN("shared01", hc, ha, reqLabel, nil)
 		_ = prepareCN("shared02", hc, ha, reqLabel, nil)

--- a/pkg/proxy/tunnel.go
+++ b/pkg/proxy/tunnel.go
@@ -235,10 +235,19 @@ func (t *tunnel) transfer(ctx context.Context) error {
 		t.counterSet.connMigrationCannotStart.Add(1)
 		return moerr.GetOkExpectedNotSafeToStartTransfer()
 	}
+	start := time.Now()
 	defer func() {
 		t.mu.Lock()
 		defer t.mu.Unlock()
 		t.mu.inTransfer = false
+
+		duration := time.Since(start)
+		if duration > time.Second {
+			t.logger.Info("slow transfer for tunnel",
+				zap.Any("tunnel", t),
+				zap.Duration("transfer duration", duration),
+			)
+		}
 	}()
 
 	ctx, cancel := context.WithTimeout(ctx, defaultTransferTimeout)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/1834 https://github.com/matrixorigin/MO-Cloud/issues/1463

## What this PR does / why we need it:
when proxy do rebalance and try to transfer some connections to
other CNs, the connections turns out to be some should not be transferred.
So we should pick up some correct connections to do the transferring.