### PR TITLE
cherrypick: fix max packet len (#13086)

### DIFF
--- a/pkg/frontend/server.go
+++ b/pkg/frontend/server.go
@@ -145,7 +145,6 @@ func (mo *MOServer) handleMessage(rs goetty.IOSession) error {
 		err = mo.rm.Handler(rs, msg, received)
 		if err != nil {
 			if strings.Contains(err.Error(), quitStr) {
-				logutil.Warn("mo quit", zap.Error(err))
 				return nil
 			} else {
 				logutil.Error("session handle failed, close this session", zap.Error(err))

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -16,6 +16,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -172,9 +173,9 @@ func (h *handler) handle(c goetty.IOSession) error {
 	h.logger.Debug("server conn created")
 	defer func() { _ = sc.Close() }()
 
-	h.logger.Debug("build connection successfully",
-		zap.String("client", cc.RawConn().RemoteAddr().String()),
-		zap.String("server", sc.RawConn().RemoteAddr().String()),
+	h.logger.Info("build connection",
+		zap.String("client->proxy", fmt.Sprintf("%s -> %s", cc.RawConn().RemoteAddr(), cc.RawConn().LocalAddr())),
+		zap.String("proxy->server", fmt.Sprintf("%s -> %s", sc.RawConn().LocalAddr(), sc.RawConn().RemoteAddr())),
 	)
 
 	st := stopper.NewStopper("proxy-conn-handle", stopper.WithLogger(h.logger.RawLogger()))

--- a/pkg/proxy/mysql_conn_buf.go
+++ b/pkg/proxy/mysql_conn_buf.go
@@ -144,8 +144,9 @@ func (b *msgBuf) preRecv() (int, error) {
 		return mysqlHeadLen, nil
 	}
 
-	// Max length is 3 bytes.
-	if bodyLen < 1 || bodyLen >= 1<<24-1 {
+	// Max length is 3 bytes. 26MB-1 is the legal max length of a MySQL packet.
+	// Reference To : https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_packets.html
+	if bodyLen < 1 || bodyLen > 1<<24-1 {
 		return 0, moerr.NewInternalErrorNoCtx("mysql protocol error: body length %d", bodyLen)
 	}
 

--- a/pkg/proxy/mysql_conn_buf_test.go
+++ b/pkg/proxy/mysql_conn_buf_test.go
@@ -54,8 +54,8 @@ func TestMySQLConnPreRecv(t *testing.T) {
 		}()
 		sc := newMySQLConn("source", src, 10, nil, nil)
 		size, err := sc.preRecv()
-		require.ErrorContains(t, err, "mysql protocol error")
-		require.Equal(t, 0, size)
+		require.NoError(t, err)
+		require.Equal(t, mysqlHeadLen+(1<<24-1), size)
 	})
 
 	t.Run("protocol_error/length-normal", func(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #1781 moc1781

## What this PR does / why we need it:
1，最大数据包长度判断错误。
2，增加proxy 连接日志