### PR TITLE
make lock op can deal with const null

### DIFF
--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -381,6 +381,12 @@ func doLock(
 		return false, false, timestamp.Timestamp{}, nil
 	}
 
+	//in this case:
+	// create table t1 (a int primary key, b int ,c int, unique key(b,c));
+	// insert into t1 values (1,1,null);
+	// update t1 set b = b+1 where a = 1;
+	//    here MO will use 't1 left join hidden_tbl' to fetch the PK in hidden table to lock,
+	//    but the result will be ConstNull vector
 	if vec != nil && vec.IsConstNull() {
 		return false, false, timestamp.Timestamp{}, nil
 	}

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -381,6 +381,10 @@ func doLock(
 		return false, false, timestamp.Timestamp{}, nil
 	}
 
+	if vec.IsConstNull() {
+		return false, false, timestamp.Timestamp{}, nil
+	}
+
 	if opts.maxCountPerLock == 0 {
 		opts.maxCountPerLock = int(lockService.GetConfig().MaxLockRowCount)
 	}

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -381,7 +381,7 @@ func doLock(
 		return false, false, timestamp.Timestamp{}, nil
 	}
 
-	if vec.IsConstNull() {
+	if vec != nil && vec.IsConstNull() {
 		return false, false, timestamp.Timestamp{}, nil
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/1884

## What this PR does / why we need it:
make lock op can deal with const null

当update一个包含unique key表的时候。
我们会用原表left join unique key的隐藏表来找到要更新的pk。但是有时候left join的隐藏表的数据为空，这个时候 left join是把它置为 const null。
这里增加了对这种情况的处理