### PR TITLE
[BugFix]: Deep Copy missing parts + Panic suppression + Adding a debug log.

### DIFF
--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -91,6 +91,12 @@ func (s *Scope) Run(c *Compile) (err error) {
 
 	select {
 	case <-s.Proc.Ctx.Done():
+		if err != nil {
+			//TODO: @arjun remove this after debugging the panic suppression issue.
+			getLogger().Error("error in scope run suppressed to nil",
+				zap.String("sql", c.sql),
+				zap.String("error", err.Error()))
+		}
 		err = nil
 	default:
 	}

--- a/pkg/sql/compile/scopeRemoteRun.go
+++ b/pkg/sql/compile/scopeRemoteRun.go
@@ -16,6 +16,7 @@ package compile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/sample"
 	"hash/crc32"
@@ -115,13 +116,13 @@ func CnServerMessageHandler(
 	udfService udf.Service,
 	cli client.TxnClient,
 	aicm *defines.AutoIncrCacheManager,
-	messageAcquirer func() morpc.Message) error {
+	messageAcquirer func() morpc.Message) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			err := moerr.ConvertPanicError(ctx, e)
+			err = moerr.ConvertPanicError(ctx, e)
 			getLogger().Error("panic in cn message handler",
 				zap.String("error", err.Error()))
-			cs.Close()
+			err = errors.Join(err, cs.Close())
 		}
 	}()
 
@@ -135,7 +136,7 @@ func CnServerMessageHandler(
 		cs, messageAcquirer, storeEngine, fileService, lockService, queryService, hakeeper, udfService, cli, aicm)
 
 	// rebuild pipeline to run and send query result back.
-	err := cnMessageHandle(&receiver)
+	err = cnMessageHandle(&receiver)
 	if err != nil {
 		return receiver.sendError(err)
 	}

--- a/pkg/sql/plan/deepcopy.go
+++ b/pkg/sql/plan/deepcopy.go
@@ -359,15 +359,28 @@ func DeepCopyIndexDef(indexDef *plan.IndexDef) *plan.IndexDef {
 		TableExist:         indexDef.TableExist,
 		IndexTableName:     indexDef.IndexTableName,
 		Comment:            indexDef.Comment,
+		Visible:            indexDef.Visible,
 		IndexAlgo:          indexDef.IndexAlgo,
 		IndexAlgoParams:    indexDef.IndexAlgoParams,
 		IndexAlgoTableType: indexDef.IndexAlgoTableType,
 	}
+	newindexDef.Option = DeepCopyIndexOption(indexDef.Option)
 
 	newParts := make([]string, len(indexDef.Parts))
 	copy(newParts, indexDef.Parts)
 	newindexDef.Parts = newParts
 	return newindexDef
+}
+
+func DeepCopyIndexOption(indexOption *plan.IndexOption) *plan.IndexOption {
+	if indexOption == nil {
+		return nil
+	}
+	newIndexOption := &plan.IndexOption{
+		CreateExtraTable: indexOption.CreateExtraTable,
+	}
+
+	return newIndexOption
 }
 
 func DeepCopyOnUpdate(old *plan.OnUpdate) *plan.OnUpdate {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring


## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/1881

## What this PR does / why we need it:

1. The panic is converted to moerror. However, this moerror is not returned to the callee, resulting in suppression of panic.
2. The internal executor returns `err = nil`, even when the pipeline panics. Introducing a logger to verify the root cause for this issue.


NOTE: I will cherry-pick this PR to master.