### PR TITLE
[cherry-pick] some pipeline cannot execute remotely (#13166)

### DIFF
--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -199,14 +199,8 @@ func (s *Scope) MergeRun(c *Compile) error {
 }
 
 // RemoteRun send the scope to a remote node for execution.
-// if no target node information, just execute it at local.
 func (s *Scope) RemoteRun(c *Compile) error {
-	// if send to itself, just run it parallel at local.
-	if len(s.NodeInfo.Addr) == 0 || len(c.addr) == 0 || isSameCN(c.addr, s.NodeInfo.Addr) {
-		return s.ParallelRun(c, s.IsRemote)
-	}
-
-	if !cnclient.IsCNClientReady() {
+	if !s.canRemote(c) || !cnclient.IsCNClientReady() {
 		return s.ParallelRun(c, s.IsRemote)
 	}
 
@@ -218,7 +212,7 @@ func (s *Scope) RemoteRun(c *Compile) error {
 	err := s.remoteRun(c)
 	select {
 	case <-s.Proc.Ctx.Done():
-		// if context has done, it means other pipeline stop the query normally.
+		// if context has done, it means another pipeline stops the query.
 		// so there is no need to return the error again.
 		return nil
 

--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -135,6 +135,28 @@ type Scope struct {
 	PartialResults []any
 }
 
+// canRemote checks whether the current scope can be executed remotely.
+func (s *Scope) canRemote(c *Compile) bool {
+	// check the remote address.
+	// if it was empty or equal to the current address, return false.
+	if len(s.NodeInfo.Addr) == 0 || len(c.addr) == 0 {
+		return false
+	}
+	if isSameCN(c.addr, s.NodeInfo.Addr) {
+		return false
+	}
+
+	// some operators cannot be remote.
+	// todo: it is not a good way to check the operator type here.
+	//  cannot generate this remote pipeline if the operator type is not supported.
+	for _, op := range s.Instructions {
+		if op.CannotRemote() {
+			return false
+		}
+	}
+	return true
+}
+
 // scopeContext contextual information to assist in the generation of pipeline.Pipeline.
 type scopeContext struct {
 	id       int32

--- a/pkg/vm/types.go
+++ b/pkg/vm/types.go
@@ -197,6 +197,11 @@ func (ins *Instruction) IsBrokenNode() bool {
 	return false
 }
 
+func (ins *Instruction) CannotRemote() bool {
+	// todo: I think we should add more operators here.
+	return ins.Op == LockOp
+}
+
 type ModificationArgument interface {
 	AffectedRows() uint64
 }


### PR DESCRIPTION
some pipeline (with lock_op operator) cannot execute remotely.

Approved by: @nnsgmsone

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13119

## What this PR does / why we need it:
cherry-pick the pr #13166 