### PR TITLE
pick: fix DATA RACE

### DIFF
--- a/pkg/util/trace/config.go
+++ b/pkg/util/trace/config.go
@@ -100,6 +100,13 @@ type SpanContext struct {
 	Kind SpanKind `json:"span_kind"`
 }
 
+func (c *SpanContext) Clone() (sc SpanContext) {
+	copy(sc.TraceID[:], c.TraceID[:])
+	copy(sc.SpanID[:], c.SpanID[:])
+	sc.Kind = c.Kind
+	return
+}
+
 func (c *SpanContext) Size() (n int) {
 	return 24
 }


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/12491

## What this PR does / why we need it:
pick From #13100
change:
1. copy Span.SpanContext if passing Error to MOCollector.

fix DATA RACE case, between
- span.Reset(), after release MOSpan after in span.End()
- span.SpanContext(), after passing Error to MOCollector. The collector will get the span's Context info, which may already reset by span.Reset().

Approved by: @zhangxu19830126