### PR TITLE
make shared table segregation by tenant in lock to 1.0

### DIFF
--- a/pkg/lockservice/lock_table_allocator_test.go
+++ b/pkg/lockservice/lock_table_allocator_test.go
@@ -170,7 +170,7 @@ func TestValid(t *testing.T) {
 		t,
 		time.Hour,
 		func(a *lockTableAllocator) {
-			b := a.Get("s1", 1)
+			b := a.Get("s1", 4)
 			assert.Empty(t, a.Valid([]pb.LockTable{b}))
 		})
 }
@@ -180,7 +180,7 @@ func TestValidWithServiceInvalid(t *testing.T) {
 		t,
 		time.Hour,
 		func(a *lockTableAllocator) {
-			b := a.Get("s1", 1)
+			b := a.Get("s1", 4)
 			b.ServiceID = "s2"
 			assert.NotEmpty(t, a.Valid([]pb.LockTable{b}))
 		})
@@ -191,7 +191,7 @@ func TestValidWithVersionChanged(t *testing.T) {
 		t,
 		time.Hour,
 		func(a *lockTableAllocator) {
-			b := a.Get("s1", 1)
+			b := a.Get("s1", 4)
 			b.Version++
 			assert.NotEmpty(t, a.Valid([]pb.LockTable{b}))
 		})

--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -24,12 +24,24 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/matrixorigin/matrixone/pkg/util/list"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
+)
+
+var (
+	// All shared tables is shared by all tenants. We will use 1+TableID(high 4 bytes) + tenantID(low 4 bytes)
+	// as table id to avoid conflict.
+	sharedTables = map[uint64]uint64{
+		// can not use catalog.MO_TABLES_ID, because cycle import.
+		1: 1<<63 | 1<<32,
+		2: 1<<63 | 2<<32,
+		3: 1<<63 | 3<<32,
+	}
 )
 
 type service struct {
@@ -104,6 +116,7 @@ func (s *service) Lock(
 	ctx, span := trace.Debug(ctx, "lockservice.lock")
 	defer span.End()
 
+	tableID = encodeSharedTableID(ctx, tableID)
 	if options.ForwardTo != "" {
 		return s.forwardLock(ctx, tableID, rows, txnID, options)
 	}
@@ -510,4 +523,33 @@ func getUUIDFromServiceIdentifier(id string) string {
 		return id
 	}
 	return id[19:]
+}
+
+func encodeSharedTableID(
+	ctx context.Context,
+	tableID uint64) uint64 {
+	v, ok := sharedTables[tableID]
+	if !ok {
+		return tableID
+	}
+
+	tenantID, ok := ctx.Value(defines.TenantIDKey{}).(uint32)
+	if !ok {
+		tenantID = 0
+	}
+
+	return v | uint64(tenantID)
+}
+
+func decodeSharedTableID(tableID uint64) (tenantID uint32, sharedTableID uint64, ok bool) {
+	if tableID&(1<<63) == 0 {
+		return 0, 0, false
+	}
+	tableID = tableID << 1 >> 1
+	return uint32(tableID << 32 >> 32), tableID >> 32, true
+}
+
+func isSharedTable(id uint64) bool {
+	_, ok := sharedTables[id]
+	return ok
 }

--- a/pkg/lockservice/service_forward_test.go
+++ b/pkg/lockservice/service_forward_test.go
@@ -30,18 +30,20 @@ func TestForwardLock(t *testing.T) {
 		t,
 		[]string{"s1", "s2"},
 		func(alloc *lockTableAllocator, s []*service) {
+			tableID := uint64(10)
+
 			l1 := s[0]
 			l2 := s[1]
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 			defer cancel()
 
-			_, err := l2.getLockTableWithCreate(1, true)
+			_, err := l2.getLockTableWithCreate(tableID, true)
 			require.NoError(t, err)
 
 			txn1 := []byte("txn1")
 			row1 := []byte{1}
 
-			_, err = l1.Lock(ctx, 1, [][]byte{row1}, txn1, pb.LockOptions{
+			_, err = l1.Lock(ctx, tableID, [][]byte{row1}, txn1, pb.LockOptions{
 				Granularity: pb.Granularity_Row,
 				Mode:        pb.LockMode_Exclusive,
 				Policy:      pb.WaitPolicy_Wait,

--- a/pkg/lockservice/service_observability_test.go
+++ b/pkg/lockservice/service_observability_test.go
@@ -145,7 +145,7 @@ func TestGetLockTableBind(t *testing.T) {
 }
 
 func TestIterLocks(t *testing.T) {
-	table := uint64(1)
+	table := uint64(10)
 	getRunner(false)(
 		t,
 		table,

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lni/goutils/leaktest"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/stretchr/testify/assert"
@@ -1561,4 +1562,15 @@ func mustAddTestLock(t *testing.T,
 		txnID,
 		lock,
 		granularity)
+}
+
+func TestSharedTableID(t *testing.T) {
+	tenantID := uint32(955)
+	tableID := uint64(2)
+
+	ctx := context.WithValue(context.Background(), defines.TenantIDKey{}, tenantID)
+	tenantID2, tableID2, ok := decodeSharedTableID(encodeSharedTableID(ctx, tableID))
+	require.True(t, ok)
+	require.Equal(t, tenantID, tenantID2)
+	require.Equal(t, tableID, tableID2)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue [#1869](https://github.com/matrixorigin/MO-Cloud/issues/1869)

## What this PR does / why we need it:
make shared table segregation by tenant in lock to 1.0