### PR TITLE
Remove object's bloom filter

### DIFF
--- a/pkg/vm/engine/tae/blockio/writer.go
+++ b/pkg/vm/engine/tae/blockio/writer.go
@@ -163,16 +163,6 @@ func (w *BlockWriter) Sync(ctx context.Context) ([]objectio.BlockObject, objecti
 		}
 		cnt, meta := w.objMetaBuilder.Build()
 		w.writer.WriteObjectMeta(ctx, cnt, meta)
-		columnsData := w.objMetaBuilder.GetPKData()
-		bf, err := index.NewBinaryFuseFilterByVectors(columnsData)
-		if err != nil {
-			return nil, nil, err
-		}
-		buf, err := bf.Marshal()
-		if err != nil {
-			return nil, nil, err
-		}
-		w.writer.WriteObjectMetaBF(buf)
 	}
 	blocks, err := w.writer.WriteEnd(ctx)
 	if len(blocks) == 0 {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12741 

## What this PR does / why we need it:
The bf of the current object is not used, but it is written and read every time to occupy memory space, so it is removed.