### PR TITLE
[enhancement] system: support resource in cgroup v2.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 replace github.com/hashicorp/memberlist => github.com/matrixorigin/memberlist v0.5.1-0.20230322082342-95015c95ee76
 
 replace (
-	github.com/elastic/gosigar v0.14.2 => github.com/matrixorigin/gosigar v0.14.3-0.20231121102214-89a79017cdcd
+	github.com/elastic/gosigar v0.14.2 => github.com/matrixorigin/gosigar v0.14.3-0.20231205085924-69ea5558fb97
 	github.com/fagongzi/goetty/v2 v2.0.3-0.20230628075727-26c9a2fd5fb8 => github.com/matrixorigin/goetty/v2 v2.0.0-20231122095211-6a25dc9130ca
 	github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef => github.com/matrixorigin/dragonboat/v4 v4.0.0-20230426084722-d189534f8004
 	github.com/lni/goutils v1.3.1-0.20220604063047-388d67b4dbc4 => github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4

--- a/go.sum
+++ b/go.sum
@@ -1457,8 +1457,8 @@ github.com/matrixorigin/dragonboat/v4 v4.0.0-20230426084722-d189534f8004 h1:Hwxz
 github.com/matrixorigin/dragonboat/v4 v4.0.0-20230426084722-d189534f8004/go.mod h1:bR6ZGoUwApH4/P4+AezNGT0xehljg+j+Z/Q2Fz+Y4a0=
 github.com/matrixorigin/goetty/v2 v2.0.0-20231122095211-6a25dc9130ca h1:Umz9yzhDh/wxoZxUePptSGZN9fim7cq9u0EowC/QYo0=
 github.com/matrixorigin/goetty/v2 v2.0.0-20231122095211-6a25dc9130ca/go.mod h1:OwIBpVwRW1HjF/Jhc2Av3UvG2NygMg+bdqGxZaqwhU0=
-github.com/matrixorigin/gosigar v0.14.3-0.20231121102214-89a79017cdcd h1:YuVxj5IXtF/sznOW1LDbW+TN8LDFpsOf9Fhn7Fzj0eM=
-github.com/matrixorigin/gosigar v0.14.3-0.20231121102214-89a79017cdcd/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
+github.com/matrixorigin/gosigar v0.14.3-0.20231205085924-69ea5558fb97 h1:yx+DAToxqqOCHLiHiA1TDMkT+dESg5DaaLPayZJgPa0=
+github.com/matrixorigin/gosigar v0.14.3-0.20231205085924-69ea5558fb97/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4 h1:+SmZP2bG+YcO/ntzjCleCu6hFTJiue7Oj2tftpJKTlU=
 github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4/go.mod h1:LIHvF0fflR+zyXUQFQOiHPpKANf3UIr7DFIv5CBPOoU=
 github.com/matrixorigin/memberlist v0.5.1-0.20230322082342-95015c95ee76 h1:MpmqMPooJ0Ea7W4ldIGbQV4D3z+sEiCu6C6aTibiwiQ=

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -469,10 +469,6 @@ func MoMemory(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc 
 			return int64(system.MemoryUsed()), nil
 		case "available":
 			return int64(system.MemoryAvailable()), nil
-		case "max-usage":
-			return int64(system.MemoryMaxUsage()), nil
-		case "fail-count":
-			return int64(system.MemoryFailCount()), nil
 		default:
 			return -1, moerr.NewInvalidInput(proc.Ctx, "unsupported memory command: %s", v)
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13170

## What this PR does / why we need it:
- support getting resources in cgroup v2 environment.
- remove two functions: mo_memory("max-usage") and mo_memory("fail-count"),
   as there are no data in cgroup v2.