### PR TITLE
fileservice: add ObjectStorageArguments.CertFiles

### DIFF
--- a/etc/launch-tae-compose/config/cn-0.toml
+++ b/etc/launch-tae-compose/config/cn-0.toml
@@ -18,6 +18,7 @@ name = "SHARED"
 bucket = "mo-test"
 endpoint = "http://minio:9000"
 key-prefix = "server/data"
+cert-files = ["/etc/ssl/cert.pem"]
 
 [fileservice.cache]
 memory-capacity = "512MB"

--- a/etc/launch-tae-compose/config/cn-1.toml
+++ b/etc/launch-tae-compose/config/cn-1.toml
@@ -18,6 +18,7 @@ name = "SHARED"
 bucket = "mo-test"
 endpoint = "http://minio:9000"
 key-prefix = "server/data"
+cert-files = ["/etc/ssl/cert.pem"]
 
 [fileservice.cache]
 memory-capacity = "512MB"

--- a/etc/launch-tae-compose/config/log.toml
+++ b/etc/launch-tae-compose/config/log.toml
@@ -19,6 +19,7 @@ name = "SHARED"
 bucket = "mo-test"
 endpoint = "http://minio:9000"
 key-prefix = "server/data"
+cert-files = ["/etc/ssl/cert.pem"]
 
 [fileservice.cache]
 memory-capacity = "512MB"

--- a/etc/launch-tae-compose/config/tn.toml
+++ b/etc/launch-tae-compose/config/tn.toml
@@ -18,6 +18,7 @@ name = "SHARED"
 bucket = "mo-test"
 endpoint = "http://minio:9000"
 key-prefix = "server/data"
+cert-files = ["/etc/ssl/cert.pem"]
 
 [fileservice.cache]
 memory-capacity = "512MB"

--- a/pkg/fileservice/aws_sdk_v1.go
+++ b/pkg/fileservice/aws_sdk_v1.go
@@ -16,11 +16,14 @@ package fileservice
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	stdhttp "net/http"
+	"os"
 	gotrace "runtime/trace"
 	"strings"
 	"time"
@@ -75,18 +78,42 @@ func NewAwsSDKv1(
 	dialer := &net.Dialer{
 		KeepAlive: 5 * time.Second,
 	}
+	transport := &stdhttp.Transport{
+		Proxy:                 stdhttp.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       180 * time.Second,
+		MaxIdleConnsPerHost:   100,
+		MaxConnsPerHost:       1000,
+		TLSHandshakeTimeout:   3 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     true,
+	}
+	if len(args.CertFiles) > 0 {
+		// custom certs
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			panic(err)
+		}
+		for _, path := range args.CertFiles {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				// ignore
+				continue
+			}
+			logutil.Info("file service: load cert file",
+				zap.Any("path", path),
+			)
+			pool.AppendCertsFromPEM(content)
+		}
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: true,
+			RootCAs:            pool,
+		}
+		transport.TLSClientConfig = tlsConfig
+	}
 	httpClient := &stdhttp.Client{
-		Transport: &stdhttp.Transport{
-			Proxy:                 stdhttp.ProxyFromEnvironment,
-			DialContext:           dialer.DialContext,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       180 * time.Second,
-			MaxIdleConnsPerHost:   100,
-			MaxConnsPerHost:       1000,
-			TLSHandshakeTimeout:   3 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-			ForceAttemptHTTP2:     true,
-		},
+		Transport: transport,
 	}
 	config.HTTPClient = httpClient
 

--- a/pkg/fileservice/aws_sdk_v2.go
+++ b/pkg/fileservice/aws_sdk_v2.go
@@ -16,11 +16,14 @@ package fileservice
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	stdhttp "net/http"
+	"os"
 	gotrace "runtime/trace"
 	"strings"
 	"time"
@@ -66,18 +69,42 @@ func NewAwsSDKv2(
 	dialer := &net.Dialer{
 		KeepAlive: 5 * time.Second,
 	}
+	transport := &stdhttp.Transport{
+		Proxy:                 stdhttp.ProxyFromEnvironment,
+		DialContext:           dialer.DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       180 * time.Second,
+		MaxIdleConnsPerHost:   100,
+		MaxConnsPerHost:       1000,
+		TLSHandshakeTimeout:   3 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     true,
+	}
+	if len(args.CertFiles) > 0 {
+		// custom certs
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			panic(err)
+		}
+		for _, path := range args.CertFiles {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				// ignore
+				continue
+			}
+			logutil.Info("file service: load cert file",
+				zap.Any("path", path),
+			)
+			pool.AppendCertsFromPEM(content)
+		}
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: true,
+			RootCAs:            pool,
+		}
+		transport.TLSClientConfig = tlsConfig
+	}
 	httpClient := &stdhttp.Client{
-		Transport: &stdhttp.Transport{
-			Proxy:                 stdhttp.ProxyFromEnvironment,
-			DialContext:           dialer.DialContext,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       180 * time.Second,
-			MaxIdleConnsPerHost:   100,
-			MaxConnsPerHost:       1000,
-			TLSHandshakeTimeout:   3 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-			ForceAttemptHTTP2:     true,
-		},
+		Transport: transport,
 	}
 
 	// options for loading configs

--- a/pkg/fileservice/object_storage_arguments.go
+++ b/pkg/fileservice/object_storage_arguments.go
@@ -29,10 +29,11 @@ type ObjectStorageArguments struct {
 	SharedConfigProfile string `toml:"shared-config-profile"`
 
 	// s3
-	Bucket   string `toml:"bucket"`
-	Endpoint string `toml:"endpoint"`
-	IsMinio  bool   `toml:"is-minio"`
-	Region   string `toml:"region"`
+	Bucket    string   `toml:"bucket"`
+	Endpoint  string   `toml:"endpoint"`
+	IsMinio   bool     `toml:"is-minio"`
+	Region    string   `toml:"region"`
+	CertFiles []string `toml:"cert-files"`
 
 	// credentials
 	AssumeRoleARN     string `toml:"role-arn"`


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13164 

## What this PR does / why we need it:
fileservice: load custom ca files in NewAwsSDKv2

etc: add cert-files configs

fileservice: more logs

fileservice: load custom cert files in AwsSDKv1 and MinioSDK