### PR TITLE
slow down prefetch speed for 1.1-dev

### DIFF
--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -47,8 +47,8 @@ import (
 )
 
 const (
-	PREFETCH_THRESHOLD = 512
-	PREFETCH_ROUNDS    = 32
+	PREFETCH_THRESHOLD = 128
+	PREFETCH_ROUNDS    = 16
 )
 
 const (


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12876

## What this PR does / why we need it:
slow down prefetch speed to reduce memory allocation for 1.1-dev