### PR TITLE
mo_table_size adding the size of the hidden col

### DIFF
--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -264,7 +264,7 @@ func (tbl *txnTable) Size(ctx context.Context, name string) (int64, error) {
 	found := false
 
 	for i := range cols {
-		if !cols[i].Hidden && (name == AllColumns || cols[i].Name == name) {
+		if name == AllColumns || cols[i].Name == name {
 			neededCols[cols[i].Name] = cols[i]
 			found = true
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13284 

## What this PR does / why we need it:
the result of mo_table_size(db, rel) is smaller than a table actually has.