### PR TITLE
[BugFix]: Lock original table during create index

### DIFF
--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -971,8 +971,8 @@ func (s *Scope) CreateIndex(c *Compile) error {
 	qry := s.Plan.GetDdl().GetCreateIndex()
 
 	{
-		// Lock Original Table first before creating
-		// reference to rel by using d.Relation(c.ctx, qry.Table, nil)
+		// lockMoTable will lock Table  mo_catalog.mo_tables
+		// for the row with db_name=dbName & table_name = tblName。
 		dbName := c.db
 		if qry.GetDatabase() != "" {
 			dbName = qry.GetDatabase()

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -981,6 +981,16 @@ func (s *Scope) CreateIndex(c *Compile) error {
 	}
 	tableId := r.GetTableID(c.ctx)
 
+	dbName := c.db
+	if qry.GetDatabase() != "" {
+		dbName = qry.GetDatabase()
+	}
+	tblName := qry.GetTableDef().GetName()
+
+	if err = lockMoTable(c, dbName, tblName, lock.LockMode_Exclusive); err != nil {
+		return err
+	}
+
 	tableDef := plan2.DeepCopyTableDef(qry.TableDef, true)
 	indexDef := qry.GetIndex().GetTableDef().Indexes[0]
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring



## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/13238

## What this PR does / why we need it:
- We need to lock the original table during create index to avoid `missing data` .