### PR TITLE
fix bug: throw incorrect err type (#13300)

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -676,7 +676,15 @@ func (c *Compile) lockMetaTables() error {
 
 		err := lockMoTable(c, names[0], names[1], lock.LockMode_Shared)
 		if err != nil {
-			return moerr.NewTxnNeedRetryWithDefChangedNoCtx()
+			// if get error in locking mocatalog.mo_tables by it's dbName & tblName
+			// that means the origin table's schema was changed. then return NeedRetryWithDefChanged err
+			if moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetry) ||
+				moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetryWithDefChanged) {
+				return moerr.NewTxnNeedRetryWithDefChangedNoCtx()
+			}
+
+			// other errors, just throw  out
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
fix bug: throw incorrect err type.
在Compile.runonce之前执行的lock metatable，应该是只有 ErrTxnNeedRetry 或者 ErrTxnNeedRetryWithDefChanged 这两种情况才表明原始表的表结构或者名字有变更。其他情况应该正常抛出异常。

Approved by: @nnsgmsone

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/13152

## What this PR does / why we need it:
fix bug: throw incorrect err type.