### PR TITLE
clone zonemap to avoid reference the whole object metadata  (#13334) to 1.1-dev

### DIFF
--- a/pkg/vm/engine/tae/catalog/segment.go
+++ b/pkg/vm/engine/tae/catalog/segment.go
@@ -87,7 +87,7 @@ func (s *SegStat) loadObjectInfo(blk *BlockEntry) error {
 
 	if schema.HasSortKey() {
 		col := schema.GetSingleSortKey()
-		s.sortKeyZonemap = meta.MustGetColumn(col.SeqNum).ZoneMap()
+		s.sortKeyZonemap = meta.MustGetColumn(col.SeqNum).ZoneMap().Clone()
 	}
 
 	s.loaded = true


### PR DESCRIPTION
w/o clone, it will always reference the whole object metadata

Approved by: @LeftHandCold

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13147 

## What this PR does / why we need it:

clone zonemap to avoid reference the whole object metadata 