### PR TITLE
[bug] proxy: fix mysql protocal parsing issue.

### DIFF
--- a/pkg/proxy/client_conn_test.go
+++ b/pkg/proxy/client_conn_test.go
@@ -100,7 +100,7 @@ type mockClientConn struct {
 	clientInfo clientInfo // need to set it explicitly
 	router     Router
 	tun        *tunnel
-	redoStmts  []string
+	redoStmts  []internalStmt
 }
 
 var _ ClientConn = (*mockClientConn)(nil)
@@ -154,15 +154,15 @@ func (c *mockClientConn) HandleEvent(ctx context.Context, e IEvent, resp chan<- 
 		sendResp([]byte(cn.addr), resp)
 		return nil
 	case *setVarEvent:
-		c.redoStmts = append(c.redoStmts, ev.stmt)
+		c.redoStmts = append(c.redoStmts, internalStmt{cmdType: cmdQuery, s: ev.stmt})
 		sendResp([]byte("ok"), resp)
 		return nil
 	case *prepareEvent:
-		c.redoStmts = append(c.redoStmts, ev.stmt)
+		c.redoStmts = append(c.redoStmts, internalStmt{cmdType: cmdQuery, s: ev.stmt})
 		sendResp([]byte("ok"), resp)
 		return nil
-	case *useEvent:
-		c.redoStmts = append(c.redoStmts, ev.stmt)
+	case *initDBEvent:
+		c.redoStmts = append(c.redoStmts, internalStmt{cmdType: cmdInitDB, s: ev.db})
 		sendResp([]byte("ok"), resp)
 		return nil
 	default:

--- a/pkg/proxy/event_test.go
+++ b/pkg/proxy/event_test.go
@@ -713,7 +713,7 @@ func TestUseEvent(t *testing.T) {
 	errChan := make(chan error, 1)
 	go func() {
 		<-sendEventCh
-		if _, err := client2.Write(makeSimplePacket("use d1")); err != nil {
+		if _, err := client2.Write(makeInitDBPacket("d1")); err != nil {
 			errChan <- err
 			return
 		}
@@ -747,6 +747,6 @@ func TestEventType_String(t *testing.T) {
 	e6 := prepareEvent{}
 	require.Equal(t, "Prepare", e6.eventType().String())
 
-	e7 := useEvent{}
+	e7 := initDBEvent{}
 	require.Equal(t, "Use", e7.eventType().String())
 }

--- a/pkg/proxy/mysql_conn_buf.go
+++ b/pkg/proxy/mysql_conn_buf.go
@@ -43,7 +43,10 @@ const (
 type MySQLCmd byte
 
 // cmdQuery is a query cmd.
-const cmdQuery MySQLCmd = 0x03
+const (
+	cmdQuery  MySQLCmd = 0x03
+	cmdInitDB MySQLCmd = 0x02
+)
 
 // MySQLConn contains a buffer to save data which may be only part
 // of a packet.
@@ -213,7 +216,7 @@ func (b *msgBuf) handleOKPacket(msg []byte) {
 
 // handleEOFPacket handles the EOF packet from server to update the txn state.
 func (b *msgBuf) handleEOFPacket(msg []byte) {
-	status := binary.LittleEndian.Uint16(msg[3:])
+	status := binary.LittleEndian.Uint16(msg[7:])
 	b.setTxnStatus(status)
 }
 

--- a/pkg/proxy/server_conn.go
+++ b/pkg/proxy/server_conn.go
@@ -43,7 +43,7 @@ type ServerConn interface {
 	// After it finished, server connection should be closed immediately because
 	// it is a temp connection.
 	// The first return value indicates that if the execution result is OK.
-	ExecStmt(stmt string, resp chan<- []byte) (bool, error)
+	ExecStmt(stmt internalStmt, resp chan<- []byte) (bool, error)
 	// Close closes the connection to CN server.
 	Close() error
 }
@@ -154,10 +154,10 @@ func (s *serverConn) HandleHandshake(handshakeResp *frontend.Packet) (*frontend.
 }
 
 // ExecStmt implements the ServerConn interface.
-func (s *serverConn) ExecStmt(stmt string, resp chan<- []byte) (bool, error) {
-	req := make([]byte, 1, len(stmt)+1)
-	req[0] = byte(cmdQuery)
-	req = append(req, []byte(stmt)...)
+func (s *serverConn) ExecStmt(stmt internalStmt, resp chan<- []byte) (bool, error) {
+	req := make([]byte, 1, len(stmt.s)+1)
+	req[0] = byte(stmt.cmdType)
+	req = append(req, []byte(stmt.s)...)
 	s.mysqlProto.SetSequenceID(0)
 	if err := s.mysqlProto.WritePacket(req); err != nil {
 		return false, err

--- a/pkg/proxy/server_conn_test.go
+++ b/pkg/proxy/server_conn_test.go
@@ -78,7 +78,7 @@ func (s *mockServerConn) RawConn() net.Conn { return s.conn }
 func (s *mockServerConn) HandleHandshake(_ *frontend.Packet) (*frontend.Packet, error) {
 	return nil, nil
 }
-func (s *mockServerConn) ExecStmt(stmt string, resp chan<- []byte) (bool, error) {
+func (s *mockServerConn) ExecStmt(stmt internalStmt, resp chan<- []byte) (bool, error) {
 	sendResp(makeOKPacket(), resp)
 	return true, nil
 }
@@ -573,7 +573,7 @@ func TestServerConn_ExecStmt(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, 0, int(sc.ConnID()))
 	resp := make(chan []byte, 10)
-	_, err = sc.ExecStmt("kill query", resp)
+	_, err = sc.ExecStmt(internalStmt{cmdType: cmdQuery, s: "kill query"}, resp)
 	require.NoError(t, err)
 	res := <-resp
 	ok := isOKPacket(res)

--- a/pkg/proxy/util.go
+++ b/pkg/proxy/util.go
@@ -43,6 +43,13 @@ func isCmdQuery(p []byte) bool {
 	return false
 }
 
+func isCmdInitDB(p []byte) bool {
+	if len(p) > 4 && p[4] == byte(cmdInitDB) {
+		return true
+	}
+	return false
+}
+
 // isOKPacket returns true if []byte is a MySQL OK packet.
 func isOKPacket(p []byte) bool {
 	if len(p) > 4 && p[4] == 0 {
@@ -87,7 +94,7 @@ func bytesToPacket(bs []byte) *frontend.Packet {
 		return nil
 	}
 	p := &frontend.Packet{
-		Length:     int32(bs[0]) | int32(bs[1])<<8 | int32(bs[2])<<8,
+		Length:     int32(bs[0]) | int32(bs[1])<<8 | int32(bs[2])<<16,
 		SequenceID: int8(bs[3]),
 		Payload:    bs[4:],
 	}

--- a/pkg/proxy/util_test.go
+++ b/pkg/proxy/util_test.go
@@ -39,6 +39,18 @@ func makeSimplePacket(payload string) []byte {
 	return data
 }
 
+func makeInitDBPacket(db string) []byte {
+	l := 1 + len(db)
+	data := make([]byte, l+4)
+	data[4] = byte(cmdInitDB)
+	copy(data[5:], db)
+	data[0] = byte(l)
+	data[1] = byte(l >> 8)
+	data[2] = byte(l >> 16)
+	data[3] = 0
+	return data
+}
+
 func packetLen(data []byte) (int32, error) {
 	if len(data) < 3 {
 		return 0, moerr.NewInternalErrorNoCtx("invalid data")


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12955

## What this PR does / why we need it:
proxy cannot parse `use db` statement correctly, which
cause session info missing when proxy transfers connections.