### PR TITLE
update mo_sessions view (#1.0-dev)

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2590,7 +2590,10 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 		trace.WithKind(trace.SpanKindStatement))
 	defer span.End(trace.WithStatementExtra(ses.GetTxnId(), ses.GetStmtId(), ses.GetSqlOfStmt()))
 
+	ses.SetQueryInProgress(true)
 	ses.SetQueryStart(time.Now())
+	defer ses.SetQueryEnd(time.Now())
+	defer ses.SetQueryInProgress(false)
 	ses.SetQueryInExecute(true)
 
 	// per statement profiler

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -245,6 +245,10 @@ type Session struct {
 	buf *buffer.Buffer
 
 	stmtProfile process.StmtProfile
+	// queryEnd is the time when the query ends
+	queryEnd time.Time
+	// queryInProgress indicates whether the query is in progress
+	queryInProgress atomic.Bool
 	// queryInExecute indicates whether the query is in execute
 	queryInExecute atomic.Bool
 }
@@ -305,6 +309,26 @@ func (ses *Session) SetQueryStart(t time.Time) {
 
 func (ses *Session) GetQueryStart() time.Time {
 	return ses.stmtProfile.GetQueryStart()
+}
+
+func (ses *Session) SetQueryEnd(t time.Time) {
+	ses.mu.Lock()
+	defer ses.mu.Unlock()
+	ses.queryEnd = t
+}
+
+func (ses *Session) GetQueryEnd() time.Time {
+	ses.mu.Lock()
+	defer ses.mu.Unlock()
+	return ses.queryEnd
+}
+
+func (ses *Session) SetQueryInProgress(b bool) {
+	ses.queryInProgress.Store(b)
+}
+
+func (ses *Session) GetQueryInProgress() bool {
+	return ses.queryInProgress.Load()
 }
 
 func (ses *Session) SetQueryInExecute(b bool) {
@@ -2158,6 +2182,36 @@ func (ses *Session) StatusSession() *status.Session {
 	)
 
 	accountName, userName, roleName = getUserProfile(ses.GetTenantInfo())
+	//if the query is processing, the end time is invalid.
+	//we can not clear the session info under this condition.
+	if !ses.GetQueryInProgress() {
+		endAt := ses.GetQueryEnd()
+		//if the current time is more than 3 second after the query end time, the session is timeout.
+		//we clear the session statement info
+		//for issue 11976
+		if time.Since(endAt) > 3*time.Second {
+			return &status.Session{
+				NodeID:        ses.getRoutineManager().baseService.ID(),
+				ConnID:        ses.GetConnectionID(),
+				SessionID:     ses.GetUUIDString(),
+				Account:       accountName,
+				User:          userName,
+				Host:          ses.getRoutineManager().baseService.SQLAddress(),
+				DB:            ses.GetDatabaseName(),
+				SessionStart:  ses.GetSessionStart(),
+				Command:       "",
+				Info:          "",
+				TxnID:         uuid2Str(ses.GetTxnId()),
+				StatementID:   "",
+				StatementType: "",
+				QueryType:     "",
+				SQLSourceType: "",
+				QueryStart:    time.Time{},
+				ClientHost:    ses.GetMysqlProtocol().Peer(),
+				Role:          roleName,
+			}
+		}
+	}
 	return &status.Session{
 		NodeID:        ses.getRoutineManager().baseService.ID(),
 		ConnID:        ses.GetConnectionID(),
@@ -2169,7 +2223,7 @@ func (ses *Session) StatusSession() *status.Session {
 		SessionStart:  ses.GetSessionStart(),
 		Command:       ses.GetCmd().String(),
 		Info:          ses.GetSqlOfStmt(),
-		TxnID:         ses.GetTxnId().String(),
+		TxnID:         uuid2Str(ses.GetTxnId()),
 		StatementID:   ses.GetStmtId().String(),
 		StatementType: ses.GetStmtType(),
 		QueryType:     ses.GetQueryType(),
@@ -2178,6 +2232,13 @@ func (ses *Session) StatusSession() *status.Session {
 		ClientHost:    ses.GetMysqlProtocol().Peer(),
 		Role:          roleName,
 	}
+}
+
+func uuid2Str(uid uuid.UUID) string {
+	if bytes.Equal(uid[:], dumpUUID[:]) {
+		return ""
+	}
+	return uid.String()
 }
 
 func (ses *Session) SetSessionRoutineStatus(status string) error {

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -35,6 +35,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
 
+var (
+	dumpUUID = uuid.UUID{}
+)
+
 type TxnHandler struct {
 	storage     engine.Engine
 	txnClient   TxnClient
@@ -233,7 +237,11 @@ func (th *TxnHandler) NewTxn() (context.Context, TxnOperator, error) {
 	//	txnOp.GetWorkspace().StartStatement()
 	//	th.enableStartStmt()
 	//}
-	th.ses.SetTxnId(txnOp.Txn().ID)
+	if err != nil {
+		th.ses.SetTxnId(dumpUUID[:])
+	} else {
+		th.ses.SetTxnId(txnOp.Txn().ID)
+	}
 	return txnCtx, txnOp, err
 }
 
@@ -341,6 +349,7 @@ func (th *TxnHandler) CommitTxn() error {
 		ses.updateLastCommitTS(txnOp.Txn().CommitTS)
 	}
 	th.SetTxnOperatorInvalid()
+	th.ses.SetTxnId(dumpUUID[:])
 	return err
 }
 
@@ -405,6 +414,7 @@ func (th *TxnHandler) RollbackTxn() error {
 		}
 	}
 	th.SetTxnOperatorInvalid()
+	th.ses.SetTxnId(dumpUUID[:])
 	return err
 }
 


### PR DESCRIPTION
讨论见：https://github.com/matrixorigin/docs/blob/main/design/system_view.md#%E4%BC%9A%E8%AF%9D

策略调整：
1, 信息最多持续时间3秒。

一个语句执行完成，最多3秒后，相关的信息会被清空。
一个语句执行完成，如果下一条语句在3秒内开始执行，部分信息就是下一条的。
```
//例子
|---sql---|--空闲3s---|---下一个sql---|
/|\        /|\     /|\
|          |       |
|          |       |---------看到部分信息被更新，不是所有信息同时更新。
|          |
|          |-------------看不到第一个sql的信息
|
看到第一个sql的信息。

```

2. txn_id。

- 事务的生命周期可能长于sql语句。例如：begin开启事务后，执行了一些语句。但是在commit/rollback之前事务一直存在。但此时可能没有执行语句。
- commit/rollback之后，不论成果与否，事务都会结束。此时txn_id会被清空。
- 事务创建失败。txn_id也为空

Approved by: @qingxinhome

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/1932

## What this PR does / why we need it:
update mo_sessions view