### PR TITLE
do not write memcache for normal scan

### DIFF
--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -358,7 +358,7 @@ func (r *blockReader) Read(
 
 	// read the block
 	var policy fileservice.Policy
-	if r.scanType == LARGE {
+	if r.scanType == LARGE || r.scanType == NORMAL {
 		policy = fileservice.SkipMemoryCacheWrites
 	}
 	bat, err := blockio.BlockRead(


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12876

## What this PR does / why we need it:
since prefetch already write memcache, do not need to write again when read