### PR TITLE
cn-service use the global log level

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -95,6 +95,7 @@ func NewService(
 			Role: metadata.MustParseCNRole(cfg.Role),
 		},
 		cfg:         cfg,
+		logger:      logutil.GetGlobalLogger().Named("cn-service"),
 		metadataFS:  metadataFS,
 		etlFS:       etlFS,
 		fileService: fileService,
@@ -108,7 +109,6 @@ func NewService(
 	}
 	srv.initQueryService()
 
-	srv.logger = logutil.Adjust(srv.logger)
 	srv.stopper = stopper.NewStopper("cn-service", stopper.WithLogger(srv.logger))
 
 	if err := srv.initCacheServer(); err != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13399 

## What this PR does / why we need it:
cn service should get the global logger.