### PR TITLE
1.1 cherry pick stmt racing fix

### DIFF
--- a/pkg/util/trace/impl/motrace/Aggr.go
+++ b/pkg/util/trace/impl/motrace/Aggr.go
@@ -55,6 +55,12 @@ func NewAggregator(ctx context.Context, windowSize time.Duration, newItemFunc fu
 var ErrFilteredOut = moerr.NewInternalError(context.Background(), "filtered out")
 
 func (a *Aggregator) Close() {
+	// Free the StatementInfo in the Grouped
+	for _, item := range a.Grouped {
+		if stmt, ok := item.(*StatementInfo); ok {
+			stmt.freeNoLocked()
+		}
+	}
 	// clean up the Grouped map
 	a.Grouped = make(map[interface{}]Item)
 	// release resources related to the context if necessary


### PR DESCRIPTION
…ing the incorrect statementinfo (#12619)

There are data racings in the bufferpipe - aggregator step.

1.
If the statementinfo object being added to the aggregator, then statementinfo might be modified outside.

So take a clone here,

2. Free the statementinfo afterwards

Approved by: @xzxiong

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring



## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/12432
https://github.com/matrixorigin/matrixone/issues/10382
https://github.com/matrixorigin/matrixone/issues/10382
## What this PR does / why we need it:

fit the aggregator stmt racing 

add logs for further investigation