### PR TITLE
Relate frontend query and background session query, v1.1

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -6364,8 +6364,13 @@ func determineUserHasPrivilegeSet(ctx context.Context, ses *Session, priv *privi
 
 	tenant := ses.GetTenantInfo()
 	bh := ses.GetBackgroundExec(ctx)
-	ses.tStmt.SetSkipTxn(true) // for reset frontend query's txn-id
 	defer bh.Close()
+
+	if ses.tStmt != nil {
+		// for reset frontend query's txn-id
+		// NEED to skip this background session txn, which used by authenticateUserCanExecuteStatement()
+		ses.tStmt.SetSkipTxn(true)
+	}
 
 	//the set of roles the (k+1) th iteration during the execution
 	roleSetOfKPlusOneThIteration := &btree.Set[int64]{}

--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -6364,6 +6364,7 @@ func determineUserHasPrivilegeSet(ctx context.Context, ses *Session, priv *privi
 
 	tenant := ses.GetTenantInfo()
 	bh := ses.GetBackgroundExec(ctx)
+	ses.tStmt.SkipTxnOnce = true
 	defer bh.Close()
 
 	//the set of roles the (k+1) th iteration during the execution

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -361,7 +361,9 @@ var RecordStatementTxnID = func(ctx context.Context, ses *Session) {
 	}
 	// set frontend statement's txn-id
 	if upSes := ses.upstream; upSes != nil && upSes.tStmt != nil && upSes.tStmt.IsZeroTxnID() {
-		if handler := ses.GetTxnHandler(); handler.IsValidTxnOperator() {
+		if upSes.tStmt.SkipTxnOnce {
+			upSes.tStmt.SkipTxnOnce = false
+		} else if handler := ses.GetTxnHandler(); handler.IsValidTxnOperator() {
 			_, txn, err = handler.GetTxn()
 			if err != nil {
 				logError(ses, ses.GetDebugString(),

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -258,17 +258,9 @@ var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Proc
 	stm := motrace.NewStatementInfo()
 	// set TransactionID
 	var txn TxnOperator
-	var err error
 	if handler := ses.GetTxnHandler(); handler.IsValidTxnOperator() {
-		_, txn, err = handler.GetTxn()
-		if err != nil {
-			logError(ses, ses.GetDebugString(),
-				"Failed to record statement",
-				zap.Error(err))
-			copy(stm.TransactionID[:], motrace.NilTxnID[:])
-		} else {
-			copy(stm.TransactionID[:], txn.Txn().ID)
-		}
+		_, txn = handler.GetTxnOperator()
+		copy(stm.TransactionID[:], txn.Txn().ID)
 	}
 	// set SessionID
 	copy(stm.SessionID[:], ses.GetUUID())
@@ -343,18 +335,12 @@ var RecordParseErrorStatement = func(ctx context.Context, ses *Session, proc *pr
 
 // RecordStatementTxnID record txnID after TxnBegin or Compile(autocommit=1)
 var RecordStatementTxnID = func(ctx context.Context, ses *Session) {
-	var err error
 	var txn TxnOperator
 	if stm := motrace.StatementFromContext(ctx); ses != nil && stm != nil && stm.IsZeroTxnID() {
 		if handler := ses.GetTxnHandler(); handler.IsValidTxnOperator() {
-			_, txn, err = handler.GetTxn()
-			if err != nil {
-				logError(ses, ses.GetDebugString(),
-					"Failed to record statement transaction ID",
-					zap.Error(err))
-			} else {
-				stm.SetTxnID(txn.Txn().ID)
-			}
+			// 简化获取TxnOperator 逻辑, 详见 https://github.com/matrixorigin/matrixone/pull/13436#pullrequestreview-1779063200
+			_, txn = handler.GetTxnOperator()
+			stm.SetTxnID(txn.Txn().ID)
 			ses.SetTxnId(txn.Txn().ID)
 		}
 		stm.Report(ctx)
@@ -364,21 +350,15 @@ var RecordStatementTxnID = func(ctx context.Context, ses *Session) {
 	if upSes := ses.upstream; upSes != nil && upSes.tStmt != nil && upSes.tStmt.IsZeroTxnID() /* not record txn-id */ {
 		// background session has valid txn
 		if handler := ses.GetTxnHandler(); handler.IsValidTxnOperator() {
-			_, txn, err = handler.GetTxn()
-			if err != nil {
-				logError(ses, ses.GetDebugString(),
-					"Failed to record statement transaction ID",
-					zap.Error(err))
-			} else {
-				// set upstream (the frontend session) statement's txn-id
-				// PS: only skip ONE txn
-				if stmt := upSes.tStmt; stmt.NeedSkipTxn() /* normally set by determineUserHasPrivilegeSet */ {
-					// need to skip the whole txn, so it records the skipped txn-id
-					stmt.SetSkipTxn(false)
-					stmt.SetSkipTxnId(txn.Txn().ID)
-				} else if txnId := txn.Txn().ID; !stmt.SkipTxnId(txnId) {
-					upSes.tStmt.SetTxnID(txnId)
-				}
+			_, txn = handler.GetTxnOperator()
+			// set upstream (the frontend session) statement's txn-id
+			// PS: only skip ONE txn
+			if stmt := upSes.tStmt; stmt.NeedSkipTxn() /* normally set by determineUserHasPrivilegeSet */ {
+				// need to skip the whole txn, so it records the skipped txn-id
+				stmt.SetSkipTxn(false)
+				stmt.SetSkipTxnId(txn.Txn().ID)
+			} else if txnId := txn.Txn().ID; !stmt.SkipTxnId(txnId) {
+				upSes.tStmt.SetTxnID(txnId)
 			}
 		}
 	}

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -359,6 +359,19 @@ var RecordStatementTxnID = func(ctx context.Context, ses *Session) {
 		}
 		stm.Report(ctx)
 	}
+	// set frontend statement's txn-id
+	if upSes := ses.upstream; upSes != nil && upSes.tStmt != nil && upSes.tStmt.IsZeroTxnID() {
+		if handler := ses.GetTxnHandler(); handler.IsValidTxnOperator() {
+			_, txn, err = handler.GetTxn()
+			if err != nil {
+				logError(ses, ses.GetDebugString(),
+					"Failed to record statement transaction ID",
+					zap.Error(err))
+			} else {
+				upSes.tStmt.SetTxnID(txn.Txn().ID)
+			}
+		}
+	}
 }
 
 func handleShowTableStatus(ses *Session, stmt *tree.ShowTableStatus, proc *process.Process) error {

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -671,6 +671,8 @@ func NewBackgroundSession(reqCtx context.Context, upstream *Session, mp *mpool.M
 	ses.upstream = upstream
 	ses.SetOutputCallback(fakeDataSetFetcher)
 	if stmt := motrace.StatementFromContext(reqCtx); stmt != nil {
+		// Reset background session id as frontend stmt id
+		ses.uuid = stmt.StatementID
 		logutil.Debugf("session uuid: %s -> background session uuid: %s", uuid.UUID(stmt.SessionID).String(), ses.uuid.String())
 	}
 	cancelBackgroundCtx, cancelBackgroundFunc := context.WithCancel(reqCtx)

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -74,6 +74,7 @@ func StatementInfoNew(i Item, ctx context.Context) Item {
 		// copy value
 		stmt.StatementID = s.StatementID
 		stmt.SessionID = s.SessionID
+		stmt.TransactionID = s.TransactionID
 		stmt.Account = s.Account
 		stmt.User = s.User
 		stmt.Host = s.Host

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -310,18 +310,33 @@ func (s *StatementInfo) freeNoLocked() {
 }
 
 func (s *StatementInfo) free() {
+	s.StatementID = NilStmtID
+	s.TransactionID = NilTxnID
+	s.SessionID = NilSesID
+	s.Account = ""
+	s.User = ""
+	s.Host = ""
 	s.RoleId = 0
+	s.Database = ""
 	s.Statement = ""
+	s.StmtBuilder.Reset()
 	s.StatementFingerprint = ""
 	s.StatementTag = ""
-	s.FreeExecPlan()
+	s.SqlSourceType = ""
 	s.RequestAt = time.Time{}
-	s.ResponseAt = time.Time{}
+	s.StatementType = ""
+	s.QueryType = ""
 	s.Status = StatementStatusRunning
 	s.Error = nil
+	s.ResponseAt = time.Time{}
+	s.Duration = 0
+	s.FreeExecPlan() // handle s.ExecPlan
 	s.RowsRead = 0
 	s.BytesScan = 0
+	s.AggrCount = 0
+	// s.AggrMemoryTime // skip
 	s.ResultCount = 0
+	s.ConnType = 0
 	s.end = false
 	s.reported = false
 	s.exported = false

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -505,7 +505,7 @@ func (s *StatementInfo) SetSkipTxnId(id []byte) { s.skipTxnID = id }
 func (s *StatementInfo) NeedSkipTxn() bool      { return s.skipTxnOnce }
 func (s *StatementInfo) SkipTxnId(id []byte) bool {
 	// s.skipTxnID == nil, means NO skipTxnId
-	return s.skipTxnID != nil && bytes.Compare(s.skipTxnID, id) == 0
+	return s.skipTxnID != nil && bytes.Equal(s.skipTxnID, id)
 }
 
 func GetLongQueryTime() time.Duration {

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -94,8 +94,8 @@ func StatementInfoNew(i Item, ctx context.Context) Item {
 		stmt.ResponseAt = s.ResponseAt
 		stmt.end = s.end
 
-		// remove the TransactionID
-		stmt.TransactionID = NilTxnID
+		// stmt.TransactionID = NilTxnID /* try hard to keep the txn-id. more in StatementInfoUpdate() */
+
 		// modified value
 		stmt.StatementTag = ""
 		stmt.StatementFingerprint = ""
@@ -117,6 +117,10 @@ func StatementInfoUpdate(existing, new Item) {
 
 	e := existing.(*StatementInfo)
 	n := new.(*StatementInfo)
+	// nil aggregated stmt record's txn-id, if including diff transactions.
+	if e.TransactionID != n.TransactionID {
+		e.TransactionID = NilTxnID
+	}
 	// update the stats
 	if GetTracerProvider().enableStmtMerge {
 		e.StmtBuilder.WriteString(";\n")

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -229,6 +229,9 @@ type StatementInfo struct {
 	// keep []byte as elem
 	jsonByte   []byte
 	statsArray statistic.StatsArray
+
+	// SkipTxnOnce, only for flow control
+	SkipTxnOnce bool
 }
 
 type Key struct {

--- a/pkg/util/trace/impl/motrace/statistic/stats_array.go
+++ b/pkg/util/trace/impl/motrace/statistic/stats_array.go
@@ -93,12 +93,8 @@ func (s *StatsArray) InitIfEmpty() *StatsArray {
 }
 
 func (s *StatsArray) Reset() *StatsArray {
-	return s.WithVersion(StatsArrayVersion).
-		// StatsArrayVersion1
-		WithTimeConsumed(0).WithMemorySize(0).WithS3IOInputCount(0).WithS3IOOutputCount(0).
-		// StatsArrayVersion2
-		WithOutTrafficBytes(0)
-	// Next Version
+	*s = *initStatsArray
+	return s
 }
 
 func (s *StatsArray) GetVersion() float64         { return (*s)[StatsArrayIndexVersion] }
@@ -207,9 +203,9 @@ func StatsArrayToJsonString(arr []float64) []byte {
 
 var initStatsArray = NewStatsArray()
 
-var DefaultStatsArray = *initStatsArray.Init()
+var DefaultStatsArray = *initStatsArray
 
-var DefaultStatsArrayJsonString = initStatsArray.Init().ToJsonString()
+var DefaultStatsArrayJsonString = initStatsArray.ToJsonString()
 
 type statsInfoKey struct{}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13384

## What this PR does / why we need it:
changes:
1. reset backgroud session id as frontend query's statement id.
2. reset fronted query's txn-id if the txn-id is non-setted, by using background session txn-id
    - default skip the background transaction, which DO check privileges. 
3. fix stmt reset while do free
4. improve statement aggr logic, if all aggr stmts in the same txn, not reset the txn-id. @gavinyue 