### PR TITLE
sync to 1.0: adding more metrics and log for onPrepareWAL

### DIFF
--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
@@ -190,13 +190,23 @@ func (c *DashboardCreator) initTxnCommitDurationRow() dashboard.Option {
 func (c *DashboardCreator) initTxnOnPrepareWALRow() dashboard.Option {
 	return dashboard.Row(
 		"txn on prepare wal duration",
-		c.getHistogram(
-			"txn on prepare wal duration",
-			c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal"`),
-			[]float64{0.50, 0.8, 0.90, 0.99},
-			12,
+		c.getMultiHistogram(
+			[]string{
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_total"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_prepare_wal"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_end_prepare"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_flush_queue"`),
+			},
+			[]string{
+				"total",
+				"prepare wal",
+				"end prepare",
+				"enqueue flush",
+			},
+			[]float64{0.80, 0.90, 0.95, 0.99},
+			[]float32{3, 3, 3, 3},
 			axis.Unit("s"),
-			axis.Min(0)),
+			axis.Min(0))...,
 	)
 }
 

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -231,7 +231,11 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.00001, 2.0, 20),
 		}, []string{"step"})
 
-	TxnOnPrepareWALDurationHistogram     = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal")
+	TxnOnPrepareWALPrepareWALDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_prepare_wal")
+	TxnOnPrepareWALEndPrepareDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_end_prepare")
+	TxnOnPrepareWALFlushQueueDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_flush_queue")
+	TxnOnPrepareWALTotalDurationHistogram      = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_total")
+
 	TxnDequeuePreparingDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("dequeue_preparing")
 	TxnDequeuePreparedDurationHistogram  = txnTNSideDurationHistogram.WithLabelValues("dequeue_prepared")
 	TxnBeforeCommitDurationHistogram     = txnTNSideDurationHistogram.WithLabelValues("before_txn_commit")

--- a/pkg/vm/engine/tae/db/test/util_test.go
+++ b/pkg/vm/engine/tae/db/test/util_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/model"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -374,13 +373,4 @@ func Test_LoadSpecifiedCkpData(t *testing.T) {
 	require.NotNil(t, data)
 
 	data.Close()
-}
-
-func Benchmark_StagesDuration(b *testing.B) {
-	testStages := txnbase.NewStagesDurationWithLogThreshold(1000, "test stage")
-	for idx := 0; idx < b.N; idx++ {
-		testStages.Record(0, "test")
-		testStages.Log()
-		testStages.ClearOnlyElapsed()
-	}
 }

--- a/pkg/vm/engine/tae/db/test/util_test.go
+++ b/pkg/vm/engine/tae/db/test/util_test.go
@@ -16,25 +16,26 @@ package test
 
 import (
 	"context"
-	"github.com/matrixorigin/matrixone/pkg/logutil"
-	"github.com/matrixorigin/matrixone/pkg/objectio"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/checkpoint"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/testutil"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
-	"github.com/stretchr/testify/require"
 	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/checkpoint"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/model"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testRows struct {
@@ -373,4 +374,13 @@ func Test_LoadSpecifiedCkpData(t *testing.T) {
 	require.NotNil(t, data)
 
 	data.Close()
+}
+
+func Benchmark_StagesDuration(b *testing.B) {
+	testStages := txnbase.NewStagesDurationWithLogThreshold(1000, "test stage")
+	for idx := 0; idx < b.N; idx++ {
+		testStages.Record(0, "test")
+		testStages.Log()
+		testStages.ClearOnlyElapsed()
+	}
 }

--- a/pkg/vm/engine/tae/txn/txnbase/helper.go
+++ b/pkg/vm/engine/tae/txn/txnbase/helper.go
@@ -16,11 +16,8 @@ package txnbase
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
-	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
-	"sync"
 )
 
 const (
@@ -47,53 +44,3 @@ func UnmarshalID(buf []byte) *common.ID {
 	}
 	return &id
 }
-
-// for debug
-type StagesDuration struct {
-	mu   sync.Mutex
-	name string
-	// stage name --> duration (ms)
-	stages map[string]int64
-	// total stages duration ms
-	total int64
-	// the threshold to print log (ms)
-	logThreshold int64
-}
-
-func NewStagesDurationWithLogThreshold(ms int64, name string) *StagesDuration {
-	sd := new(StagesDuration)
-	sd.logThreshold = ms
-	sd.name = name
-	sd.stages = make(map[string]int64, 0)
-	return sd
-}
-
-func (sd *StagesDuration) Log() {
-	sd.mu.Lock()
-	defer sd.mu.Unlock()
-
-	if sd.total >= sd.logThreshold {
-		logutil.Info(fmt.Sprintf(
-			"[stages durations]: %s elapsed %d ms; stages: %v", sd.name, sd.total, sd.stages))
-	}
-}
-
-func (sd *StagesDuration) Record(elapsed int64, stage string) {
-	sd.mu.Lock()
-	defer sd.mu.Unlock()
-
-	sd.total += elapsed
-	sd.stages[stage] += elapsed
-}
-
-func (sd *StagesDuration) ClearOnlyElapsed() {
-	sd.mu.Lock()
-	defer sd.mu.Unlock()
-
-	sd.total = 0
-	for k := range sd.stages {
-		sd.stages[k] = 0
-	}
-}
-
-var onPrepareWALStages = NewStagesDurationWithLogThreshold(1000, "onPrepareWAL")

--- a/pkg/vm/engine/tae/txn/txnbase/helper.go
+++ b/pkg/vm/engine/tae/txn/txnbase/helper.go
@@ -80,7 +80,7 @@ func (sd *StagesDuration) Record(elapsed int64, stage string) {
 
 func (sd *StagesDuration) ClearOnlyElapsed() {
 	sd.total = 0
-	for k, _ := range sd.stages {
+	for k := range sd.stages {
 		sd.stages[k] = 0
 	}
 }

--- a/pkg/vm/engine/tae/txn/txnbase/helper.go
+++ b/pkg/vm/engine/tae/txn/txnbase/helper.go
@@ -80,7 +80,7 @@ func (sd *StagesDuration) Log() {
 
 func (sd *StagesDuration) Record(elapsed int64, stage string) {
 	sd.mu.Lock()
-	sd.mu.Unlock()
+	defer sd.mu.Unlock()
 
 	sd.total += elapsed
 	sd.stages[stage] += elapsed

--- a/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
+++ b/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
@@ -530,10 +530,12 @@ func (mgr *TxnManager) dequeuePreparing(items ...any) {
 
 func (mgr *TxnManager) onPrepareWAL(items ...any) {
 	now := time.Now()
+
+	var t1 time.Time
 	var debugT1, debugT2, debugT3 int64
 
 	for _, item := range items {
-		t0, t1 := time.Now(), time.Now()
+		t0 := time.Now()
 		op := item.(*OpTxn)
 		if op.Txn.GetError() == nil && op.Op == OpCommit || op.Op == OpPrepare {
 			t1 = time.Now()

--- a/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
+++ b/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
@@ -576,7 +576,7 @@ func (mgr *TxnManager) onPrepareWAL(items ...any) {
 		v2.TxnOnPrepareWALFlushQueueDurationHistogram.Observe(dur.Seconds())
 		debugT3 = dur.Milliseconds()
 
-		if total := debugT1 + debugT3 + debugT3; total > time.Second.Milliseconds() {
+		if total := debugT1 + debugT2 + debugT3; total > time.Second.Milliseconds() {
 			logutil.Info(fmt.Sprintf(
 				"[onPrepareWAL durations]: total = %d ms; prepare wal = %d; end prepare wal = %d; enqueue flush = %d",
 				total, debugT1, debugT2, debugT3))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2010

## What this PR does / why we need it:
adding  some metrics and logs to inspect why situations like this occurred:
|
<img width="1739" alt="截屏2023-12-13 19 08 28" src="https://github.com/matrixorigin/matrixone/assets/26336316/b95d84f3-8e3c-43fc-975c-af5fbe59debc">

