### PR TITLE
adding more metrics and log for onPrepareWAL

### DIFF
--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
@@ -254,13 +254,23 @@ func (c *DashboardCreator) initTxnCommitDurationRow() dashboard.Option {
 func (c *DashboardCreator) initTxnOnPrepareWALRow() dashboard.Option {
 	return dashboard.Row(
 		"txn on prepare wal duration",
-		c.getHistogram(
-			"txn on prepare wal duration",
-			c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal"`),
-			[]float64{0.50, 0.8, 0.90, 0.99},
-			12,
+		c.getMultiHistogram(
+			[]string{
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_total"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_prepare_wal"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_end_prepare"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_flush_queue"`),
+			},
+			[]string{
+				"total",
+				"prepare wal",
+				"end prepare",
+				"enqueue flush",
+			},
+			[]float64{0.80, 0.90, 0.95, 0.99},
+			[]float32{3, 3, 3, 3},
 			axis.Unit("s"),
-			axis.Min(0)),
+			axis.Min(0))...,
 	)
 }
 

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -255,7 +255,11 @@ var (
 			Buckets:   getDurationBuckets(),
 		}, []string{"step"})
 
-	TxnOnPrepareWALDurationHistogram     = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal")
+	TxnOnPrepareWALPrepareWALDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_prepare_wal")
+	TxnOnPrepareWALEndPrepareDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_end_prepare")
+	TxnOnPrepareWALFlushQueueDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_flush_queue")
+	TxnOnPrepareWALTotalDurationHistogram      = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_total")
+
 	TxnDequeuePreparingDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("dequeue_preparing")
 	TxnDequeuePreparedDurationHistogram  = txnTNSideDurationHistogram.WithLabelValues("dequeue_prepared")
 	TxnBeforeCommitDurationHistogram     = txnTNSideDurationHistogram.WithLabelValues("before_txn_commit")

--- a/pkg/vm/engine/tae/db/test/util_test.go
+++ b/pkg/vm/engine/tae/db/test/util_test.go
@@ -16,7 +16,6 @@ package test
 
 import (
 	"context"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
 	"math/rand"
 	"testing"
 	"time"
@@ -358,13 +357,4 @@ func Test_FillSEGStorageUsageBatOfGlobal(t *testing.T) {
 		require.Equal(t, len(rels), sizeVec.Length())
 	})
 
-}
-
-func Benchmark_StagesDuration(b *testing.B) {
-	testStages := txnbase.NewStagesDurationWithLogThreshold(1000, "test stage")
-	for idx := 0; idx < b.N; idx++ {
-		testStages.Record(0, "test")
-		testStages.Log()
-		testStages.ClearOnlyElapsed()
-	}
 }

--- a/pkg/vm/engine/tae/db/test/util_test.go
+++ b/pkg/vm/engine/tae/db/test/util_test.go
@@ -16,6 +16,7 @@ package test
 
 import (
 	"context"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
 	"math/rand"
 	"testing"
 	"time"
@@ -357,4 +358,13 @@ func Test_FillSEGStorageUsageBatOfGlobal(t *testing.T) {
 		require.Equal(t, len(rels), sizeVec.Length())
 	})
 
+}
+
+func Benchmark_StagesDuration(b *testing.B) {
+	testStages := txnbase.NewStagesDurationWithLogThreshold(1000, "test stage")
+	for idx := 0; idx < b.N; idx++ {
+		testStages.Record(0, "test")
+		testStages.Log()
+		testStages.ClearOnlyElapsed()
+	}
 }

--- a/pkg/vm/engine/tae/txn/txnbase/helper.go
+++ b/pkg/vm/engine/tae/txn/txnbase/helper.go
@@ -80,7 +80,7 @@ func (sd *StagesDuration) Log() {
 
 func (sd *StagesDuration) Record(elapsed int64, stage string) {
 	sd.mu.Lock()
-	sd.mu.Unlock()
+	defer sd.mu.Unlock()
 
 	sd.total += elapsed
 	sd.stages[stage] += elapsed
@@ -91,7 +91,7 @@ func (sd *StagesDuration) ClearOnlyElapsed() {
 	defer sd.mu.Unlock()
 
 	sd.total = 0
-	for k, _ := range sd.stages {
+	for k := range sd.stages {
 		sd.stages[k] = 0
 	}
 }

--- a/pkg/vm/engine/tae/txn/txnbase/helper.go
+++ b/pkg/vm/engine/tae/txn/txnbase/helper.go
@@ -16,11 +16,8 @@ package txnbase
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
-	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
-	"sync"
 )
 
 const (
@@ -47,53 +44,3 @@ func UnmarshalID(buf []byte) *common.ID {
 	}
 	return &id
 }
-
-// for debug
-type StagesDuration struct {
-	mu   sync.Mutex
-	name string
-	// stage name --> duration (ms)
-	stages map[string]int64
-	// total stages duration ms
-	total int64
-	// the threshold to print log (ms)
-	logThreshold int64
-}
-
-func NewStagesDurationWithLogThreshold(ms int64, name string) *StagesDuration {
-	sd := new(StagesDuration)
-	sd.logThreshold = ms
-	sd.name = name
-	sd.stages = make(map[string]int64, 0)
-	return sd
-}
-
-func (sd *StagesDuration) Log() {
-	sd.mu.Lock()
-	defer sd.mu.Unlock()
-
-	if sd.total >= sd.logThreshold {
-		logutil.Info(fmt.Sprintf(
-			"[stages durations]: %s elapsed %d ms; stages: %v", sd.name, sd.total, sd.stages))
-	}
-}
-
-func (sd *StagesDuration) Record(elapsed int64, stage string) {
-	sd.mu.Lock()
-	defer sd.mu.Unlock()
-
-	sd.total += elapsed
-	sd.stages[stage] += elapsed
-}
-
-func (sd *StagesDuration) ClearOnlyElapsed() {
-	sd.mu.Lock()
-	defer sd.mu.Unlock()
-
-	sd.total = 0
-	for k := range sd.stages {
-		sd.stages[k] = 0
-	}
-}
-
-var onPrepareWALStages = NewStagesDurationWithLogThreshold(1000, "onPrepareWAL")

--- a/pkg/vm/engine/tae/txn/txnbase/helper.go
+++ b/pkg/vm/engine/tae/txn/txnbase/helper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"sync"
 )
 
 const (
@@ -49,6 +50,7 @@ func UnmarshalID(buf []byte) *common.ID {
 
 // for debug
 type StagesDuration struct {
+	mu   sync.Mutex
 	name string
 	// stage name --> duration (ms)
 	stages map[string]int64
@@ -67,6 +69,9 @@ func NewStagesDurationWithLogThreshold(ms int64, name string) *StagesDuration {
 }
 
 func (sd *StagesDuration) Log() {
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
 	if sd.total >= sd.logThreshold {
 		logutil.Info(fmt.Sprintf(
 			"[stages durations]: %s elapsed %d ms; stages: %v", sd.name, sd.total, sd.stages))
@@ -74,11 +79,17 @@ func (sd *StagesDuration) Log() {
 }
 
 func (sd *StagesDuration) Record(elapsed int64, stage string) {
+	sd.mu.Lock()
+	sd.mu.Unlock()
+
 	sd.total += elapsed
 	sd.stages[stage] += elapsed
 }
 
 func (sd *StagesDuration) ClearOnlyElapsed() {
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
 	sd.total = 0
 	for k, _ := range sd.stages {
 		sd.stages[k] = 0

--- a/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
+++ b/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
@@ -530,10 +530,12 @@ func (mgr *TxnManager) dequeuePreparing(items ...any) {
 
 func (mgr *TxnManager) onPrepareWAL(items ...any) {
 	now := time.Now()
+
+	var t1 time.Time
 	var debugT1, debugT2, debugT3 int64
 
 	for _, item := range items {
-		t0, t1 := time.Now(), time.Now()
+		t0 := time.Now()
 		op := item.(*OpTxn)
 		if op.Txn.GetError() == nil && op.Op == OpCommit || op.Op == OpPrepare {
 			t1 = time.Now()

--- a/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
+++ b/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
@@ -576,7 +576,7 @@ func (mgr *TxnManager) onPrepareWAL(items ...any) {
 		v2.TxnOnPrepareWALFlushQueueDurationHistogram.Observe(dur.Seconds())
 		debugT3 = dur.Milliseconds()
 
-		if total := debugT1 + debugT3 + debugT3; total > time.Second.Milliseconds() {
+		if total := debugT1 + debugT2 + debugT3; total > time.Second.Milliseconds() {
 			logutil.Info(fmt.Sprintf(
 				"[onPrepareWAL durations]: total = %d ms; prepare wal = %d; end prepare wal = %d; enqueue flush = %d",
 				total, debugT1, debugT2, debugT3))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:


issue #https://github.com/matrixorigin/MO-Cloud/issues/2010

## What this PR does / why we need it:
cherry-pick to 1.0: #13443
cherry-pick to 1.1:  #13446

adding  some metrics and logs to inspect why situations like this occurred:
|
<img width="1739" alt="截屏2023-12-13 19 08 28" src="https://github.com/matrixorigin/matrixone/assets/26336316/b95d84f3-8e3c-43fc-975c-af5fbe59debc">