### PR TITLE
fix wrong rowpackage encoding for double and float types

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -4273,7 +4273,7 @@ func convertEngineTypeToMysqlType(ctx context.Context, engineType types.T, col *
 	case types.T_char:
 		col.SetColumnType(defines.MYSQL_TYPE_STRING)
 	case types.T_varchar:
-		col.SetColumnType(defines.MYSQL_TYPE_VARCHAR)
+		col.SetColumnType(defines.MYSQL_TYPE_VAR_STRING)
 	case types.T_array_float32, types.T_array_float64:
 		col.SetColumnType(defines.MYSQL_TYPE_VARCHAR)
 	case types.T_binary:

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -653,7 +653,7 @@ func Test_typeconvert(t *testing.T) {
 			{tp: defines.MYSQL_TYPE_FLOAT, signed: true},
 			{tp: defines.MYSQL_TYPE_DOUBLE, signed: true},
 			{tp: defines.MYSQL_TYPE_STRING, signed: true},
-			{tp: defines.MYSQL_TYPE_VARCHAR, signed: true},
+			{tp: defines.MYSQL_TYPE_VAR_STRING, signed: true},
 			{tp: defines.MYSQL_TYPE_DATE, signed: true},
 			{tp: defines.MYSQL_TYPE_TIME, signed: true},
 			{tp: defines.MYSQL_TYPE_DATETIME, signed: true},

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -2027,7 +2027,11 @@ func (mp *MysqlProtocolImpl) makeResultSetBinaryRow(data []byte, mrs *MysqlResul
 				case float64:
 					data = mp.appendUint64(data, math.Float64bits(v))
 				case string:
-					data = mp.appendStringLenEnc(data, v)
+					val, err := strconv.ParseFloat(v, 64)
+					if err != nil {
+						return nil, err
+					}
+					data = mp.appendUint64(data, math.Float64bits(val))
 				default:
 				}
 			}

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -22,6 +22,15 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"math"
+	"math/rand"
+	"net"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+	"unicode"
+
 	"github.com/fagongzi/goetty/v2"
 	goetty_buf "github.com/fagongzi/goetty/v2/buf"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -36,14 +45,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"go.uber.org/zap"
-	"math"
-	"math/rand"
-	"net"
-	"strconv"
-	"strings"
-	"sync/atomic"
-	"time"
-	"unicode"
 )
 
 // DefaultCapability means default capabilities of the server
@@ -1803,7 +1804,7 @@ func setColFlag(column *MysqlColumn) {
 func setCharacter(column *MysqlColumn) {
 	switch column.columnType {
 	// blob type should use 0x3f to show the binary data
-	case defines.MYSQL_TYPE_VARCHAR, defines.MYSQL_TYPE_STRING, defines.MYSQL_TYPE_TEXT:
+	case defines.MYSQL_TYPE_VARCHAR, defines.MYSQL_TYPE_STRING, defines.MYSQL_TYPE_TEXT, defines.MYSQL_TYPE_VAR_STRING:
 		column.SetCharset(charsetVarchar)
 	default:
 		column.SetCharset(charsetBinary)

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -2013,7 +2013,11 @@ func (mp *MysqlProtocolImpl) makeResultSetBinaryRow(data []byte, mrs *MysqlResul
 				case float64:
 					data = mp.appendUint32(data, math.Float32bits(float32(v)))
 				case string:
-					data = mp.appendStringLenEnc(data, v)
+					val, err := strconv.ParseFloat(v, 32)
+					if err != nil {
+						return nil, err
+					}
+					data = mp.appendUint32(data, math.Float32bits(float32(val)))
 				default:
 				}
 			}

--- a/pkg/frontend/resultset.go
+++ b/pkg/frontend/resultset.go
@@ -224,6 +224,14 @@ func (mc *MysqlColumn) GetAutoIncr() bool {
 	return mc.auto_incr
 }
 
+func (mc *MysqlColumn) Length() uint32 {
+	return mc.length
+}
+
+func (mc *MysqlColumn) SetLength(length uint32) {
+	mc.length = length
+}
+
 // Discussion: for some MatrixOne types and Type.Scale value are needed for stringification, I think we
 // need to add a field
 // MoTypes []types.Type

--- a/pkg/frontend/resultset.go
+++ b/pkg/frontend/resultset.go
@@ -224,14 +224,6 @@ func (mc *MysqlColumn) GetAutoIncr() bool {
 	return mc.auto_incr
 }
 
-func (mc *MysqlColumn) Length() uint32 {
-	return mc.length
-}
-
-func (mc *MysqlColumn) SetLength(length uint32) {
-	mc.length = length
-}
-
 // Discussion: for some MatrixOne types and Type.Scale value are needed for stringification, I think we
 // need to add a field
 // MoTypes []types.Type


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/1897

## What this PR does / why we need it:
 double and float 类型编码不对会导致jdbc对后面的数据读取的时候越界，所以对这两种类型的编码进行修复
