### PR TITLE
Fix the data race of lru

### DIFF
--- a/pkg/fileservice/lrucache/shard.go
+++ b/pkg/fileservice/lrucache/shard.go
@@ -29,14 +29,13 @@ func (s *shard[K, V]) Set(ctx context.Context, h uint64, key K, value V) {
 	item.Key = key
 	item.Value = value
 	item.Size = size
+	s.Lock()
+	defer s.Unlock()
 	if ok := s.kv.Set(h, key, item); ok {
 		return
 	}
-	atomic.AddInt64(&s.size, size)
+	s.size += size
 	s.evicts.PushFront(item)
-	// because the overlap check is not atomic, we need to lock
-	s.checkMu.Lock()
-	defer s.checkMu.Unlock()
 	if s.postSet != nil {
 		s.postSet(key, value)
 	}
@@ -55,14 +54,9 @@ func (s *shard[K, V]) evict(ctx context.Context) {
 			})
 		}
 	}()
-	// only one goroutine can evict at a time
-	if !s.evicting.CompareAndSwap(false, true) {
-		return
-	}
-	defer s.evicting.Store(false)
 
 	for {
-		if atomic.LoadInt64(&s.size) <= s.capacity {
+		if s.size <= s.capacity {
 			return
 		}
 		if s.kv.Len() == 0 {
@@ -75,7 +69,7 @@ func (s *shard[K, V]) evict(ctx context.Context) {
 				return
 			}
 			s.kv.Delete(elem.h, elem.Key)
-			atomic.AddInt64(&s.size, -elem.Size)
+			s.size -= elem.Size
 			s.evicts.Remove(elem)
 			if s.postEvict != nil {
 				s.postEvict(elem.Key, elem.Value)
@@ -92,6 +86,8 @@ func (s *shard[K, V]) evict(ctx context.Context) {
 }
 
 func (s *shard[K, V]) Get(ctx context.Context, h uint64, key K) (value V, ok bool) {
+	s.RLock()
+	defer s.RUnlock()
 	if elem, ok := s.kv.Get(h, key); ok {
 		atomic.AddInt64(&elem.NumRead, 1)
 		if s.postGet != nil {
@@ -103,6 +99,8 @@ func (s *shard[K, V]) Get(ctx context.Context, h uint64, key K) (value V, ok boo
 }
 
 func (s *shard[K, V]) Flush() {
+	s.Lock()
+	defer s.Unlock()
 	s.size = 0
 	s.evicts = newList[K, V]()
 	s.kv = hashmap.New[K, lruItem[K, V]](int(s.capacity))

--- a/pkg/fileservice/lrucache/shard.go
+++ b/pkg/fileservice/lrucache/shard.go
@@ -111,11 +111,15 @@ func (s *shard[K, V]) Capacity() int64 {
 }
 
 func (s *shard[K, V]) Used() int64 {
-	return atomic.LoadInt64(&s.size)
+	s.RLock()
+	defer s.RUnlock()
+	return s.size
 }
 
 func (s *shard[K, V]) Available() int64 {
-	return s.capacity - s.Used()
+	s.RLock()
+	defer s.RUnlock()
+	return s.capacity - s.size
 }
 
 func (s *shard[K, V]) allocItem() *lruItem[K, V] {

--- a/pkg/fileservice/lrucache/types.go
+++ b/pkg/fileservice/lrucache/types.go
@@ -16,7 +16,6 @@ package lrucache
 
 import (
 	"sync"
-	"sync/atomic"
 
 	"github.com/dolthub/maphash"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/lrucache/internal/hashmap"
@@ -29,9 +28,7 @@ type LRU[K comparable, V BytesLike] struct {
 }
 
 type shard[K comparable, V BytesLike] struct {
-	checkMu sync.Mutex
-	// only allow one goroutine to evicting at a time
-	evicting  atomic.Bool
+	sync.RWMutex
 	capacity  int64
 	size      int64
 	evicts    *list[K, V]


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13434

## What this PR does / why we need it:
* 目前的代码存在data race，导致出现这个问题的原因是内存复用导致的，主要是freeItem的时候无法保证item没有被其他地方引用，先临时增大了锁的粒度来处理这个问题。后续考虑增加一个reference count来确保可以正确释放