### PR TITLE
Cherry pick max package size change

### DIFF
--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -1074,7 +1074,7 @@ var gSysVarsDefs = map[string]SystemVariable{
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              InitSystemVariableIntType("max_allowed_packet", 1024, 1073741824, false),
-		Default:           int64(16777216),
+		Default:           int64(67108864),
 	},
 	"version_comment": {
 		Name:              "version_comment",

--- a/test/distributed/cases/database/system_variables.result
+++ b/test/distributed/cases/database/system_variables.result
@@ -422,7 +422,7 @@ Variable_name    Value
 sql_select_limit    18446744073709551615
 show variables like 'max_allowed_packet';
 Variable_name    Value
-max_allowed_packet    16777216
+max_allowed_packet    67108864
 set max_allowed_packet = 10000;
 show variables like 'max_allowed_packet';
 Variable_name    Value
@@ -430,7 +430,7 @@ max_allowed_packet    10000
 set max_allowed_packet = default;
 show variables like 'max_allowed_packet';
 Variable_name    Value
-max_allowed_packet    16777216
+max_allowed_packet    67108864
 show variables like 'wait_timeout';
 Variable_name    Value
 wait_timeout    10


### PR DESCRIPTION
…… (#12682)

MySql server default setting is 64mb

The server's default [max_allowed_packet](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet) value is 64MB

Approved by: @fengttt, @daviszhen, @heni02

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/12489

## What this PR does / why we need it:
MySql server default setting is 64mb

The server's default [max_allowed_packet](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet) value is 64MB