### PR TITLE
fileservice: strip credential arguments from logs (#13492)

### DIFF
--- a/pkg/fileservice/object_storage_arguments.go
+++ b/pkg/fileservice/object_storage_arguments.go
@@ -15,6 +15,7 @@
 package fileservice
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"strings"
@@ -36,18 +37,26 @@ type ObjectStorageArguments struct {
 	CertFiles []string `toml:"cert-files"`
 
 	// credentials
-	AssumeRoleARN     string `toml:"role-arn"`
-	BearerToken       string `toml:"bearer-token"`
-	ExternalID        string `toml:"external-id"`
-	KeyID             string `toml:"key-id"`
-	KeySecret         string `toml:"key-secret"`
-	OIDCProviderARN   string `toml:"oidc-provider-arn"`
-	OIDCRoleARN       string `toml:"oidc-role-arn"`
-	OIDCTokenFilePath string `toml:"oidc-token-file-path"`
-	RAMRole           string `toml:"ram-role"`
-	RoleSessionName   string `toml:"role-session-name"`
-	SecurityToken     string `toml:"security-token"`
-	SessionToken      string `toml:"session-token"`
+	AssumeRoleARN     string `json:"-" toml:"role-arn"`
+	BearerToken       string `json:"-" toml:"bearer-token"`
+	ExternalID        string `json:"-" toml:"external-id"`
+	KeyID             string `json:"-" toml:"key-id"`
+	KeySecret         string `json:"-" toml:"key-secret"`
+	OIDCProviderARN   string `json:"-" toml:"oidc-provider-arn"`
+	OIDCRoleARN       string `json:"-" toml:"oidc-role-arn"`
+	OIDCTokenFilePath string `json:"-" toml:"oidc-token-file-path"`
+	RAMRole           string `json:"-" toml:"ram-role"`
+	RoleSessionName   string `json:"-" toml:"role-session-name"`
+	SecurityToken     string `json:"-" toml:"security-token"`
+	SessionToken      string `json:"-" toml:"session-token"`
+}
+
+func (o ObjectStorageArguments) String() string {
+	bs, err := json.Marshal(o)
+	if err != nil {
+		panic(err)
+	}
+	return string(bs)
 }
 
 func (o *ObjectStorageArguments) SetFromString(arguments []string) error {

--- a/pkg/fileservice/object_storage_arguments_test.go
+++ b/pkg/fileservice/object_storage_arguments_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestObjectStorageArguments(t *testing.T) {
+
+	t.Run("no api key", func(t *testing.T) {
+		args := ObjectStorageArguments{
+			KeyID: "foo",
+		}
+		field := zap.Any("arguments", args)
+
+		{
+			encoder := zapcore.NewConsoleEncoder(zapcore.EncoderConfig{})
+			buf, err := encoder.EncodeEntry(zapcore.Entry{}, []zap.Field{field})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(buf.String(), "foo") {
+				t.Fatal()
+			}
+		}
+
+		{
+			encoder := zapcore.NewJSONEncoder(zapcore.EncoderConfig{})
+			buf, err := encoder.EncodeEntry(zapcore.Entry{}, []zap.Field{field})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(buf.String(), "foo") {
+				t.Fatal()
+			}
+		}
+
+	})
+}


### PR DESCRIPTION




## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13468 

## What this PR does / why we need it:
do not leak credentials arguments to logs.