### PR TITLE
[enhancement] proxy: make a timeout value configurable.

### DIFF
--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -44,6 +44,8 @@ var (
 	defaultConnectTimeout = time.Second * 3
 	// The default value of handshake auth timeout.
 	defaultAuthTimeout = time.Second * 10
+	// The default value of TSL connect timeout.
+	defaultTLSConnectTimeout = time.Second * 10
 )
 
 // Config is the configuration of proxy server.
@@ -66,6 +68,8 @@ type Config struct {
 	// CN servers. If proxy handshakes with cn timeout, it will return a retryable
 	// error and try to connect to other cn servers.
 	AuthTimeout toml.Duration `toml:"auth-timeout" user_setting:"advanced"`
+	// TLSConnectTimeout is the timeout duration when TLS connect to server.
+	TLSConnectTimeout toml.Duration `toml:"tls-connect-timeout" user_setting:"advanced"`
 
 	// Default is false. With true. Server will support tls.
 	// This value should be ths same with all CN servers, and the name
@@ -169,6 +173,9 @@ func (c *Config) FillDefault() {
 	}
 	if c.AuthTimeout.Duration == 0 {
 		c.AuthTimeout.Duration = defaultAuthTimeout
+	}
+	if c.TLSConnectTimeout.Duration == 0 {
+		c.TLSConnectTimeout.Duration = defaultTLSConnectTimeout
 	}
 	if c.RebalanceInterval.Duration == 0 {
 		c.RebalanceInterval.Duration = defaultRebalanceInterval

--- a/pkg/proxy/handshake.go
+++ b/pkg/proxy/handshake.go
@@ -20,8 +20,6 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"github.com/fagongzi/goetty/v2"
-	"time"
-
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/frontend"
 )
@@ -76,7 +74,7 @@ func (c *clientConn) upgradeToTLS() error {
 	// TLS handshake packet from client might have been read into the buffer, use a wrapped conn to
 	// avoid losing handshake packets.
 	tlsConn := tls.Server(c.conn.(goetty.BufferedIOSession).BufferedConn(), c.tlsConfig)
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), c.tlsConnectTimeout)
 	defer cancel()
 	if err := tlsConn.HandshakeContext(ctx); err != nil {
 		return moerr.NewInternalError(ctx, "TSL handshake error: %v", err)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/1899

## What this PR does / why we need it:
make a TLS connect timeout value configurable.