### PR TITLE
add more log info when scan workload among multi CNs not balanced

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -3867,7 +3867,7 @@ func shuffleBlocksToMultiCN(c *Compile, ranges [][]byte, rel engine.Relation, n 
 		}
 	}
 	if minWorkLoad*2 < maxWorkLoad {
-		logutil.Warnf("workload among CNs not balanced, max %v, min %v", maxWorkLoad, minWorkLoad)
+		logutil.Warnf("read table %v ,workload among %v nodes not balanced, max %v, min %v, cnlist : %v", n.TableDef.Name, len(newNodes), maxWorkLoad, minWorkLoad, c.cnList)
 	}
 	return newNodes, nil
 }

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -3867,7 +3867,12 @@ func shuffleBlocksToMultiCN(c *Compile, ranges [][]byte, rel engine.Relation, n 
 		}
 	}
 	if minWorkLoad*2 < maxWorkLoad {
-		logutil.Warnf("read table %v ,workload among %v nodes not balanced, max %v, min %v, cnlist : %v", n.TableDef.Name, len(newNodes), maxWorkLoad, minWorkLoad, c.cnList)
+		logstring := fmt.Sprintf("read table %v ,workload among %v nodes not balanced, max %v, min %v,", n.TableDef.Name, len(newNodes), maxWorkLoad, minWorkLoad)
+		logstring = logstring + " cnlist: "
+		for i := range c.cnList {
+			logstring = logstring + c.cnList[i].Addr + " "
+		}
+		logutil.Warnf(logstring)
 	}
 	return newNodes, nil
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13527 

## What this PR does / why we need it:
add more log info when scan workload among multi CNs not balanced