### PR TITLE
fix rollback statement incorrect to 1.1

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -19,7 +19,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec/sample"
 	"math"
 	"net"
 	"runtime"
@@ -62,6 +61,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/mergedelete"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/mergerecursive"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/output"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/sample"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
@@ -490,7 +490,7 @@ func (c *Compile) ifNeedRerun(err error) bool {
 	if (moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetry) ||
 		moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetryWithDefChanged)) &&
 		c.proc.TxnOperator.Txn().IsRCIsolation() {
-		return true
+		return !c.disableRetry
 	}
 	return false
 }

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -422,7 +422,7 @@ func (c *Compile) Run(_ uint64) (*util2.RunResult, error) {
 	_, task := gotrace.NewTask(context.TODO(), "pipeline.Run")
 	defer func() {
 		putCompile(c)
-		putCompile(runC)
+		releaseRunC()
 
 		task.End()
 		span.End(trace.WithStatementExtra(sp.GetTxnId(), sp.GetStmtId(), sp.GetSqlOfStmt()))

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -238,6 +238,7 @@ func (exec *txnExecutor) Exec(sql string) (executor.Result, error) {
 	}
 
 	c := New(exec.s.addr, exec.opts.Database(), sql, "", "", exec.ctx, exec.s.eng, proc, stmts[0], false, nil, receiveAt)
+	c.disableRetry = exec.opts.DisableIncrStatement()
 	c.SetBuildPlanFunc(func() (*plan.Plan, error) {
 		return plan.BuildPlan(
 			exec.s.getCompileContext(exec.ctx, proc, exec.opts),

--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"
@@ -249,6 +250,7 @@ type Compile struct {
 
 	needLockMeta bool
 	metaTables   map[string]struct{}
+	disableRetry bool
 }
 
 type runtimeFilterReceiver struct {

--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -416,7 +416,7 @@ func (db *txnDatabase) Create(ctx context.Context, name string, defs []engine.Ta
 	tbl.tableId = tableId
 	tbl.GetTableDef(ctx)
 	key := genTableKey(ctx, name, db.databaseId)
-	db.txn.createMap.Store(key, tbl)
+	db.txn.addCreateTable(key, tbl)
 	//CORNER CASE
 	//begin;
 	//create table t1(a int);

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -344,6 +344,8 @@ func (txn *Transaction) RollbackLastStatement(ctx context.Context) error {
 
 	txn.rollbackCount++
 	if txn.statementID > 0 {
+		txn.rollbackCreateTableLocked()
+
 		txn.statementID--
 		end := txn.statements[txn.statementID]
 		for i := end; i < len(txn.writes); i++ {
@@ -511,6 +513,8 @@ type txnTable struct {
 	// process for statement
 	//proc *process.Process
 	proc atomic.Pointer[process.Process]
+
+	createByStatementID int
 }
 
 type column struct {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11917

## What this PR does / why we need it:
When processing a user-entered sql, if another sql is executed using the internal executor, if a conflict occurs and retry is required in RC mode, it will be retried in the internal sql executor, resulting in the user-entered sql not being retried