### PR TITLE
cherry pick "deduce predicates to improve performance for more join types" to 1.0-dev

### DIFF
--- a/pkg/sql/plan/opt_misc.go
+++ b/pkg/sql/plan/opt_misc.go
@@ -460,9 +460,16 @@ func (builder *QueryBuilder) pushdownFilters(nodeID int32, filters []*plan.Expr,
 			}
 		}
 
-		if node.JoinType == plan.Node_INNER {
-			//only inner join can deduce new predicate
+		switch node.JoinType {
+		case plan.Node_INNER, plan.Node_SEMI:
+			//inner and semi join can deduce new predicate from both side
 			builder.pushdownFilters(node.Children[0], deduceNewFilterList(rightPushdown, node.OnList), separateNonEquiConds)
+			builder.pushdownFilters(node.Children[1], deduceNewFilterList(leftPushdown, node.OnList), separateNonEquiConds)
+		case plan.Node_RIGHT:
+			//right join can deduce new predicate only from right side to left
+			builder.pushdownFilters(node.Children[0], deduceNewFilterList(rightPushdown, node.OnList), separateNonEquiConds)
+		case plan.Node_LEFT:
+			//left join can deduce new predicate only from left side to right
 			builder.pushdownFilters(node.Children[1], deduceNewFilterList(leftPushdown, node.OnList), separateNonEquiConds)
 		}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13566 #6561

## What this PR does / why we need it:
[Bug]: Query all the fields of one statement_info record is very slow
deduce predicates to improve performance for more join types