### PR TITLE
add blk info tool

### DIFF
--- a/pkg/vm/engine/tae/catalog/segment.go
+++ b/pkg/vm/engine/tae/catalog/segment.go
@@ -158,8 +158,8 @@ func (s *SegStat) String(composeSortKey bool) string {
 			zonemapStr = s.sortKeyZonemap.String()
 		}
 	}
-	return fmt.Sprintf("loaded:%t, oSize:%s, rows:%d, remainingRows:%d, zm: %s",
-		s.loaded, common.HumanReadableBytes(s.originSize), s.rows, s.remainingRows, zonemapStr,
+	return fmt.Sprintf("loaded:%t, oSize:%s, cSize %v,  rows:%d, remainingRows:%d, zm: %s",
+		s.loaded, common.HumanReadableBytes(s.originSize), common.HumanReadableBytes(s.compSize), s.rows, s.remainingRows, zonemapStr,
 	)
 }
 

--- a/pkg/vm/engine/tae/iface/data/block.go
+++ b/pkg/vm/engine/tae/iface/data/block.go
@@ -71,6 +71,7 @@ type Block interface {
 	GetID() *common.ID
 	IsAppendable() bool
 	PrepareCompact() bool
+	PrepareCompactInfo() (bool, string)
 
 	Rows() int
 	GetColumnDataById(

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -550,6 +550,15 @@ func (h *Handle) HandleInspectTN(
 	meta txn.TxnMeta,
 	req *db.InspectTN,
 	resp *db.InspectResp) (cb func(), err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = moerr.ConvertPanicError(ctx, e)
+			logutil.Error(
+				"panic in inspect dn",
+				zap.String("cmd", req.Operation),
+				zap.String("error", err.Error()))
+		}
+	}()
 	args, _ := shlex.Split(req.Operation)
 	common.DoIfDebugEnabled(func() {
 		logutil.Debug("Inspect", zap.Strings("args", args))

--- a/pkg/vm/engine/tae/rpc/utils.go
+++ b/pkg/vm/engine/tae/rpc/utils.go
@@ -175,3 +175,39 @@ func AttrFromColDef(col *catalog.ColDef) (attrs *engine.Attribute, err error) {
 	}
 	return attr, nil
 }
+
+type mItem struct {
+	objcnt   int
+	did, tid uint64
+}
+
+type itemSet []mItem
+
+func (is itemSet) Len() int { return len(is) }
+
+func (is itemSet) Less(i, j int) bool {
+	return is[i].objcnt < is[j].objcnt
+}
+
+func (is itemSet) Swap(i, j int) {
+	is[i], is[j] = is[j], is[i]
+}
+
+func (is *itemSet) Push(x any) {
+	item := x.(mItem)
+	*is = append(*is, item)
+}
+
+func (is *itemSet) Pop() any {
+	old := *is
+	n := len(old)
+	item := old[n-1]
+	// old[n-1] = nil // avoid memory leak
+	*is = old[0 : n-1]
+	return item
+}
+
+func (is *itemSet) Clear() {
+	old := *is
+	*is = old[:0]
+}

--- a/pkg/vm/engine/tae/tables/blk.go
+++ b/pkg/vm/engine/tae/tables/blk.go
@@ -66,6 +66,10 @@ func (blk *block) PrepareCompact() bool {
 	return blk.meta.PrepareCompact()
 }
 
+func (blk *block) PrepareCompactInfo() (result bool, reason string) {
+	return blk.meta.PrepareCompact(), ""
+}
+
 func (blk *block) FreezeAppend() {}
 
 func (blk *block) Pin() *common.PinnedItem[*block] {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13513

## What this PR does / why we need it:

- get block information at runtime
- recover panic in tn when executing mo-ctl inspect cmd