### PR TITLE
Fix the bug of DirtyBlocks removing wrong block

### DIFF
--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -658,6 +658,7 @@ func (p *PartitionState) HandleMetadataInsert(
 
 			{
 				scanCnt := int64(0)
+				blockDeleted := int64(0)
 				trunctPoint := memTruncTSVector[i]
 				iter := p.rows.Copy().Iter()
 				pivot := RowEntry{
@@ -699,13 +700,14 @@ func (p *PartitionState) HandleMetadataInsert(
 								})
 							}
 							numDeleted++
+							blockDeleted++
 						}
 					}
 				}
 				iter.Release()
 
 				// if there are no rows for the block, delete the block from the dirty
-				if scanCnt == numDeleted && p.dirtyBlocks.Len() > 0 {
+				if scanCnt == blockDeleted && p.dirtyBlocks.Len() > 0 {
 					p.dirtyBlocks.Delete(blockID)
 				}
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13643 

## What this PR does / why we need it:
The deletes calculation error in PartitionState caused the block to be accidentally deleted in DirtyBlocks. In the end, mergeread is not executed, and there will be two rows of the same pk.