### PR TITLE
fileservice: ignore invalid symlink in LocalFS.List and LocalETLFS

### DIFF
--- a/pkg/fileservice/local_etl_fs_test.go
+++ b/pkg/fileservice/local_etl_fs_test.go
@@ -127,3 +127,17 @@ func TestLocalETLFSEmptyRootPath(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, fs)
 }
+
+func TestLocalETLFSWithBadSymlink(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	err := os.Symlink(
+		"file-not-exists-fdsafdsafdsa",
+		filepath.Join(dir, "foo"),
+	)
+	assert.Nil(t, err)
+	fs, err := NewLocalETLFS("test", dir)
+	assert.Nil(t, err)
+	_, err = fs.List(ctx, "")
+	assert.Nil(t, err)
+}

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -959,6 +959,10 @@ func entryIsDir(path string, name string, entry fs.FileInfo) (bool, error) {
 	if entry.Mode().Type()&fs.ModeSymlink > 0 {
 		stat, err := os.Stat(filepath.Join(path, name))
 		if err != nil {
+			if os.IsNotExist(err) {
+				// invalid sym link
+				return false, nil
+			}
 			return false, err
 		}
 		return entryIsDir(path, name, stat)


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12052 

## What this PR does / why we need it:

ignore invalid symlink in local fs list.