### PR TITLE
improve lock rows

### DIFF
--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -215,6 +215,7 @@ func performLock(
 			proc.Ctx,
 			arg.block,
 			arg.engine,
+			nil,
 			target.tableID,
 			proc,
 			priVec,
@@ -297,6 +298,7 @@ func LockTable(
 		proc.Ctx,
 		false,
 		eng,
+		nil,
 		tableID,
 		proc,
 		nil,
@@ -319,6 +321,7 @@ func LockTable(
 func LockRows(
 	eng engine.Engine,
 	proc *process.Process,
+	rel engine.Relation,
 	tableID uint64,
 	vec *vector.Vector,
 	pkType types.Type,
@@ -339,6 +342,7 @@ func LockRows(
 		proc.Ctx,
 		false,
 		eng,
+		rel,
 		tableID,
 		proc,
 		vec,
@@ -365,6 +369,7 @@ func doLock(
 	ctx context.Context,
 	blocking bool,
 	eng engine.Engine,
+	rel engine.Relation,
 	tableID uint64,
 	proc *process.Process,
 	vec *vector.Vector,
@@ -467,7 +472,7 @@ func doLock(
 		}
 
 		// if [snapshotTS, newSnapshotTS] has been modified, need retry at new snapshot ts
-		changed, err := fn(proc, tableID, eng, vec, snapshotTS, newSnapshotTS)
+		changed, err := fn(proc, rel, tableID, eng, vec, snapshotTS, newSnapshotTS)
 		if err != nil {
 			return false, false, timestamp.Timestamp{}, err
 		}
@@ -779,6 +784,7 @@ func getRowsFilter(
 // 2. otherwise return true, changed
 func hasNewVersionInRange(
 	proc *process.Process,
+	rel engine.Relation,
 	tableID uint64,
 	eng engine.Engine,
 	vec *vector.Vector,
@@ -787,13 +793,16 @@ func hasNewVersionInRange(
 		return false, nil
 	}
 
-	txnOp := proc.TxnOperator
-	_, _, rel, err := eng.GetRelationById(proc.Ctx, txnOp, tableID)
-	if err != nil {
-		if strings.Contains(err.Error(), "can not find table by id") {
-			return false, nil
+	if rel == nil {
+		var err error
+		txnOp := proc.TxnOperator
+		_, _, rel, err = eng.GetRelationById(proc.Ctx, txnOp, tableID)
+		if err != nil {
+			if strings.Contains(err.Error(), "can not find table by id") {
+				return false, nil
+			}
+			return false, err
 		}
-		return false, err
 	}
 	fromTS := types.BuildTS(from.PhysicalTime, from.LogicalTime)
 	toTS := types.BuildTS(to.PhysicalTime, to.LogicalTime)

--- a/pkg/sql/colexec/lockop/lock_op_no_txn.go
+++ b/pkg/sql/colexec/lockop/lock_op_no_txn.go
@@ -59,6 +59,7 @@ func LockTableWithUniqueID(
 		WithLockTable(true, true).
 		WithHasNewVersionInRangeFunc(func(
 			proc *process.Process,
+			rel engine.Relation,
 			tableID uint64,
 			eng engine.Engine,
 			vec *vector.Vector,
@@ -70,6 +71,7 @@ func LockTableWithUniqueID(
 		proc.Ctx,
 		false,
 		eng,
+		nil,
 		tableID,
 		proc,
 		nil,

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -44,6 +44,7 @@ import (
 
 var testFunc = func(
 	proc *process.Process,
+	rel engine.Relation,
 	tableID uint64,
 	eng engine.Engine,
 	vec *vector.Vector,
@@ -417,6 +418,7 @@ func TestLockWithHasNewVersionInLockedTS(t *testing.T) {
 			require.NoError(t, arg.Prepare(proc))
 			arg.rt.hasNewVersionInRange = func(
 				proc *process.Process,
+				rel engine.Relation,
 				tableID uint64,
 				eng engine.Engine,
 				vec *vector.Vector,

--- a/pkg/sql/colexec/lockop/types.go
+++ b/pkg/sql/colexec/lockop/types.go
@@ -96,6 +96,7 @@ type RowsFilter func(row int, filterCols []int32) bool
 
 type hasNewVersionInRangeFunc func(
 	proc *process.Process,
+	rel engine.Relation,
 	tableID uint64,
 	eng engine.Engine,
 	vec *vector.Vector,

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -2599,6 +2599,7 @@ func lockRows(
 	err := lockop.LockRows(
 		eng,
 		proc,
+		rel,
 		id,
 		vec,
 		*vec.GetType(),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13714

## What this PR does / why we need it:
在lock meta table的时候，relation 其实已经取出来过一次了。
在这种情况下，可以传进去，避免在  hasNewVersionInRangeFunc  再通过 GetRelationById 再获取一次

所以修改了 hasNewVersionInRangeFunc 实现的参数，增加了relation的传入，其他的普通lock的话，relation传入nil，跟旧逻辑保持一致。