### PR TITLE
fix unlock with bind changed to 1.1

### DIFF
--- a/pkg/lockservice/lock_table_remote.go
+++ b/pkg/lockservice/lock_table_remote.go
@@ -105,14 +105,14 @@ func (l *remoteLockTable) lock(
 			return
 		}
 
-		txn.lockAdded(l.bind.Table, rows)
+		txn.lockAdded(l.bind, rows)
 		logRemoteLockAdded(txn, rows, opts, l.bind)
 		cb(resp.Lock.Result, nil)
 		return
 	}
 
 	// encounter any error, we also added lock to txn, because we need unlock on remote
-	txn.lockAdded(l.bind.Table, rows)
+	txn.lockAdded(l.bind, rows)
 
 	logRemoteLockFailed(txn, rows, opts, l.bind, err)
 	// encounter any error, we need try to check bind is valid.

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -1324,6 +1324,46 @@ func TestHasAnyHolderCannotNotifyWaiters(t *testing.T) {
 	}
 }
 
+func TestTxnUnlockWithBindChanged(t *testing.T) {
+	for name, runner := range runners {
+		t.Run(name, func(t *testing.T) {
+			table := uint64(10)
+			runner(
+				t,
+				table,
+				func(
+					ctx context.Context,
+					s *service,
+					lt *localLockTable) {
+					option := newTestRowExclusiveOptions()
+					rows := newTestRows(1)
+					txn1 := newTestTxnID(1)
+					txn2 := newTestTxnID(2)
+
+					// txn1 get lock
+					_, err := s.Lock(ctx, table, rows, txn1, option)
+					require.NoError(t, err)
+					checkLock(t, lt, rows[0], [][]byte{txn1}, nil, nil)
+
+					// changed bind
+					bind := lt.getBind()
+					bind.Version = bind.Version + 1
+					new := newLocalLockTable(bind, s.fsp, s.events, s.clock)
+					s.tables.Store(table, new)
+					lt.close()
+
+					// txn2 get lock, shared
+					_, err = s.Lock(ctx, table, rows, txn2, option)
+					require.NoError(t, err)
+					checkLock(t, new.(*localLockTable), rows[0], [][]byte{txn2}, nil, nil)
+
+					require.NoError(t, s.Unlock(ctx, txn1, timestamp.Timestamp{}))
+					require.NoError(t, s.Unlock(ctx, txn2, timestamp.Timestamp{}))
+				})
+		})
+	}
+}
+
 func BenchmarkWithoutConflict(b *testing.B) {
 	runBenchmark(b, "1-table", 1)
 	runBenchmark(b, "unlimited-table", 32)

--- a/pkg/lockservice/txn_test.go
+++ b/pkg/lockservice/txn_test.go
@@ -30,9 +30,9 @@ func TestLockAdded(t *testing.T) {
 	fsp := newFixedSlicePool(2)
 	txn := newActiveTxn(id, string(id), fsp, "")
 
-	txn.lockAdded(1, [][]byte{[]byte("k1")})
-	txn.lockAdded(1, [][]byte{[]byte("k11")})
-	txn.lockAdded(2, [][]byte{[]byte("k2"), []byte("k22")})
+	txn.lockAdded(pb.LockTable{Table: 1}, [][]byte{[]byte("k1")})
+	txn.lockAdded(pb.LockTable{Table: 1}, [][]byte{[]byte("k11")})
+	txn.lockAdded(pb.LockTable{Table: 2}, [][]byte{[]byte("k2"), []byte("k22")})
 
 	assert.Equal(t, 2, len(txn.holdLocks))
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13444

## What this PR does / why we need it:
fix unlock with bind changed.

txn1 hold key1 on bind version 0
txn1 commit success
dn restart
txn2 hold key1 on bind version 1
txn1 unlock.