### PR TITLE
Replay name and extent for old object, cherry-pick #13795

### DIFF
--- a/pkg/vm/engine/tae/catalog/catalog.go
+++ b/pkg/vm/engine/tae/catalog/catalog.go
@@ -627,10 +627,10 @@ func (catalog *Catalog) replayObjectByBlock(
 	// create
 	if create {
 		if obj == nil {
-			obj = NewObjectEntryOnReplay(
+			obj = NewObjectEntryByMetaLocation(
 				tbl,
 				ObjectID,
-				start, end, state)
+				start, end, state, metaLocation)
 			tbl.AddEntryLocked(obj)
 		}
 	}
@@ -648,6 +648,9 @@ func (catalog *Catalog) replayObjectByBlock(
 			node.Start = start
 			node.Prepare = end
 			node.End = end
+			if node.BaseNode.IsEmpty() {
+				node.BaseNode = NewObjectInfoWithMetaLocation(metaLocation, ObjectID)
+			}
 			obj.Insert(node)
 			node.DeletedAt = end
 		}

--- a/pkg/vm/engine/tae/catalog/metamvccnode.go
+++ b/pkg/vm/engine/tae/catalog/metamvccnode.go
@@ -101,10 +101,21 @@ func NewEmptyObjectMVCCNode() *ObjectMVCCNode {
 	}
 }
 
-func NewObjectInfoWithMetaLocation(metalocation objectio.Location) *ObjectMVCCNode {
-	obj := NewEmptyObjectMVCCNode()
-	objectio.SetObjectStatsObjectName(&obj.ObjectStats, metalocation.Name())
-	return obj
+func NewObjectInfoWithMetaLocation(metaLoc objectio.Location, id *objectio.ObjectId) *ObjectMVCCNode {
+	node := NewEmptyObjectMVCCNode()
+	if metaLoc.IsEmpty() {
+		objectio.SetObjectStatsObjectName(&node.ObjectStats, objectio.BuildObjectNameWithObjectID(id))
+		return node
+	}
+	objectio.SetObjectStatsObjectName(&node.ObjectStats, metaLoc.Name())
+	objectio.SetObjectStatsExtent(&node.ObjectStats, metaLoc.Extent())
+	return node
+}
+
+func NewObjectInfoWithObjectID(id *objectio.ObjectId) *ObjectMVCCNode {
+	node := NewEmptyObjectMVCCNode()
+	objectio.SetObjectStatsObjectName(&node.ObjectStats, objectio.BuildObjectNameWithObjectID(id))
+	return node
 }
 
 func NewObjectInfoWithObjectStats(stats *objectio.ObjectStats) *ObjectMVCCNode {

--- a/pkg/vm/engine/tae/catalog/object.go
+++ b/pkg/vm/engine/tae/catalog/object.go
@@ -117,12 +117,12 @@ func NewObjectEntry(table *TableEntry, id *objectio.ObjectId, txn txnif.AsyncTxn
 			SortHint: table.GetDB().catalog.NextObject(),
 		},
 	}
-	e.CreateWithTxn(txn, &ObjectMVCCNode{*objectio.NewObjectStats()})
+	e.CreateWithTxn(txn, NewObjectInfoWithObjectID(id))
 	e.Stat.entry = e
 	return e
 }
 
-func NewObjectEntryOnReplay(table *TableEntry, id *objectio.ObjectId, start, end types.TS, state EntryState) *ObjectEntry {
+func NewObjectEntryByMetaLocation(table *TableEntry, id *objectio.ObjectId, start, end types.TS, state EntryState, metalocation objectio.Location) *ObjectEntry {
 	e := &ObjectEntry{
 		ID: *id,
 		BaseEntryImpl: NewBaseEntry(
@@ -136,7 +136,7 @@ func NewObjectEntryOnReplay(table *TableEntry, id *objectio.ObjectId, start, end
 			SortHint: table.GetDB().catalog.NextObject(),
 		},
 	}
-	e.CreateWithStartAndEnd(start, end, &ObjectMVCCNode{*objectio.NewObjectStats()})
+	e.CreateWithStartAndEnd(start, end, NewObjectInfoWithMetaLocation(metalocation, id))
 	e.Stat.entry = e
 	return e
 }
@@ -234,7 +234,7 @@ func (entry *ObjectEntry) NeedPrefetchObjectMetaForObjectInfo(nodes []*MVCCNode[
 			lastNode = n
 		}
 	}
-	if !lastNode.BaseNode.ObjectStats.IsZero() {
+	if !lastNode.BaseNode.IsEmpty() {
 		return
 	}
 	blk = entry.GetFirstBlkEntry()
@@ -258,7 +258,7 @@ func (entry *ObjectEntry) LoadObjectInfoWithTxnTS(startTS types.TS) (objectio.Ob
 	blk := entry.GetFirstBlkEntry()
 	// for gc in test
 	if blk == nil {
-		return *objectio.NewObjectStats(), nil
+		return stats, nil
 	}
 	blk.RLock()
 	node := blk.SearchNode(&MVCCNode[*MetadataMVCCNode]{
@@ -273,7 +273,7 @@ func (entry *ObjectEntry) LoadObjectInfoWithTxnTS(startTS types.TS) (objectio.Ob
 
 	entry.RLock()
 	entry.LoopChain(func(n *MVCCNode[*ObjectMVCCNode]) bool {
-		if !n.BaseNode.ObjectStats.IsZero() {
+		if !n.BaseNode.IsEmpty() {
 			stats = *n.BaseNode.ObjectStats.Clone()
 			return false
 		}

--- a/pkg/vm/engine/tae/db/test/compatibility/cases.go
+++ b/pkg/vm/engine/tae/db/test/compatibility/cases.go
@@ -546,9 +546,10 @@ func testObjectInfo(tc TestCase, t *testing.T) {
 	tae := initTestEngine(tc, t)
 	defer tae.Close()
 	t.Log(tae.Catalog.SimplePPString(3))
+	tae.CheckObjectInfo(true)
 
 	tae.ForceCheckpoint()
 	tae.Restart(context.TODO())
 	t.Log(tae.Catalog.SimplePPString(3))
-	tae.CheckObjectInfo()
+	tae.CheckObjectInfo(false)
 }

--- a/pkg/vm/engine/tae/db/testutil/engine.go
+++ b/pkg/vm/engine/tae/db/testutil/engine.go
@@ -721,13 +721,29 @@ func (e *TestEngine) CheckCollectDeleteInRange() {
 	assert.NoError(e.t, err)
 }
 
-func (e *TestEngine) CheckObjectInfo() {
+func (e *TestEngine) CheckObjectInfo(onlyCheckName bool) {
 	p := &catalog.LoopProcessor{}
 	p.ObjectFn = func(se *catalog.ObjectEntry) error {
 		se.LoopChain(func(node *catalog.MVCCNode[*catalog.ObjectMVCCNode]) bool {
+			if se.GetTable().GetDB().ID == pkgcatalog.MO_CATALOG_ID {
+				return true
+			}
 			stats, err := se.LoadObjectInfoWithTxnTS(node.Start)
 			assert.NoError(e.t, err)
-			assert.Equal(e.t, stats, node.BaseNode.ObjectStats, "load %v, get %v", stats, node.BaseNode.ObjectStats)
+			if onlyCheckName {
+				assert.Equal(e.t, stats.ObjectLocation().Name(),
+					node.BaseNode.ObjectStats.ObjectLocation().Name(),
+					"load %v, get %v",
+					stats.String(),
+					node.BaseNode.ObjectStats.String())
+				assert.Equal(e.t, stats.ObjectLocation().Extent(),
+					node.BaseNode.ObjectStats.ObjectLocation().Extent(),
+					"load %v, get %v",
+					stats.String(),
+					node.BaseNode.ObjectStats.String())
+			} else {
+				assert.Equal(e.t, stats, node.BaseNode.ObjectStats, "load %v, get %v", stats.String(), node.BaseNode.ObjectStats.String())
+			}
 			return true
 		})
 		return nil

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -2763,11 +2763,15 @@ func (collector *BaseCollector) loadObjectInfo() error {
 			mvccNodes := obj.ClonePreparedInRange(collector.start, collector.end)
 			obj.RUnlock()
 			for _, node := range mvccNodes {
-				stats, err := obj.LoadObjectInfoWithTxnTS(node.Start)
-				if err != nil {
-					return err
+				if node.BaseNode.IsEmpty() {
+					stats, err := obj.LoadObjectInfoWithTxnTS(node.Start)
+					if err != nil {
+						return err
+					}
+					obj.Lock()
+					obj.SearchNode(node).BaseNode.ObjectStats = stats
+					obj.Unlock()
 				}
-				obj.SearchNode(node).BaseNode.ObjectStats = stats
 
 			}
 			i++
@@ -2779,12 +2783,15 @@ func (collector *BaseCollector) loadObjectInfo() error {
 		mvccNodes := obj.ClonePreparedInRange(collector.start, collector.end)
 		obj.RUnlock()
 		for _, node := range mvccNodes {
-			stats, err := obj.LoadObjectInfoWithTxnTS(node.Start)
-			if err != nil {
-				return err
+			if node.BaseNode.IsEmpty() {
+				stats, err := obj.LoadObjectInfoWithTxnTS(node.Start)
+				if err != nil {
+					return err
+				}
+				obj.Lock()
+				obj.SearchNode(node).BaseNode.ObjectStats = stats
+				obj.Unlock()
 			}
-			obj.SearchNode(node).BaseNode.ObjectStats = stats
-
 		}
 	}
 	logutil.Infof("checkpoint %v->%v, load %d object meta takes %v",


### PR DESCRIPTION
Replay name and extent of old objects from meta location

Approved by: @XuPeng-SH

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13793 

## What this PR does / why we need it:
Replay name and extent for old object