### PR TITLE
fileservice: add IOVectorCache.DeletePath; add DataCache.DeletePath

### DIFF
--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -124,6 +124,11 @@ type IOVectorCache interface {
 		async bool,
 	) error
 	Flush()
+	//TODO file contents may change, so we still need this s.
+	DeletePaths(
+		ctx context.Context,
+		paths []string,
+	) error
 }
 
 type CacheKey = pb.CacheKey
@@ -132,6 +137,8 @@ type CacheKey = pb.CacheKey
 type DataCache interface {
 	Set(ctx context.Context, key CacheKey, value CacheData)
 	Get(ctx context.Context, key CacheKey) (value CacheData, ok bool)
+	//TODO file contents may change, so we still need this s.
+	DeletePaths(ctx context.Context, paths []string)
 	Flush()
 	Capacity() int64
 	Used() int64

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -549,3 +549,27 @@ func (d *DiskCache) SetFile(
 	}
 	return nil
 }
+
+func (d *DiskCache) DeletePaths(
+	ctx context.Context,
+	paths []string,
+) error {
+
+	for _, path := range paths {
+		diskPath := d.pathForFile(path)
+		//TODO also delete IOEntry files
+
+		doneUpdate := d.startUpdate(diskPath)
+		defer doneUpdate()
+
+		d.fileExists.Delete(diskPath)
+
+		if err := os.Remove(diskPath); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -130,6 +130,10 @@ func TestDiskCache(t *testing.T) {
 	testUpdate(cache)
 
 	assert.Equal(t, 1, numWritten)
+
+	// delete file
+	err = cache.DeletePaths(ctx, []string{"foo"})
+	assert.Nil(t, err)
 }
 
 func TestDiskCacheWriteAgain(t *testing.T) {

--- a/pkg/fileservice/lrucache/lru.go
+++ b/pkg/fileservice/lrucache/lru.go
@@ -174,6 +174,9 @@ func (l *LRU[K, V]) Flush() {
 	l.kv = make(map[K]*list.Element)
 }
 
+func (l *LRU[K, V]) DeletePaths(ctx context.Context, paths []string) {
+}
+
 func (l *LRU[K, V]) Capacity() int64 {
 	return l.capacity
 }

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -192,3 +192,11 @@ func (m *MemCache) Update(
 func (m *MemCache) Flush() {
 	m.cache.Flush()
 }
+
+func (m *MemCache) DeletePaths(
+	ctx context.Context,
+	paths []string,
+) error {
+	m.cache.DeletePaths(ctx, paths)
+	return nil
+}

--- a/pkg/fileservice/remote_cache.go
+++ b/pkg/fileservice/remote_cache.go
@@ -159,6 +159,11 @@ func (r *RemoteCache) Update(ctx context.Context, vector *IOVector, async bool) 
 
 func (r *RemoteCache) Flush() {}
 
+func (r *RemoteCache) DeletePaths(ctx context.Context, paths []string) error {
+	//TODO
+	return nil
+}
+
 func HandleRemoteRead(
 	ctx context.Context, fs FileService, req *pb.Request, resp *pb.CacheResponse,
 ) error {

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"io"
 	"math"
 	"net/http/httptrace"
@@ -761,7 +762,27 @@ func (s *S3FS) Delete(ctx context.Context, filePaths ...string) error {
 		keys = append(keys, s.pathToKey(path.File))
 	}
 
-	return s.storage.Delete(ctx, keys...)
+	return errors.Join(
+		s.storage.Delete(ctx, keys...),
+		func() error {
+			if s.memCache == nil {
+				return nil
+			}
+			return s.memCache.DeletePaths(ctx, filePaths)
+		}(),
+		func() error {
+			if s.diskCache == nil {
+				return nil
+			}
+			return s.diskCache.DeletePaths(ctx, filePaths)
+		}(),
+		func() error {
+			if s.remoteCache == nil {
+				return nil
+			}
+			return s.remoteCache.DeletePaths(ctx, filePaths)
+		}(),
+	)
 }
 
 var _ ETLFileService = new(S3FS)

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -785,6 +785,7 @@ func TestSequentialS3Read(t *testing.T) {
 }
 
 func TestS3RestoreFromCache(t *testing.T) {
+	t.Skip("no longer valid since we delete cache files when calling Delete")
 	ctx := context.Background()
 
 	config, err := loadS3TestConfig()
@@ -859,8 +860,8 @@ func TestS3RestoreFromCache(t *testing.T) {
 	ctx = perfcounter.WithCounterSet(ctx, counterSet)
 	fs.restoreFromDiskCache(ctx)
 
-	if counterSet.FileService.S3.Put.Load() != 1 {
-		t.Fatal()
+	if n := counterSet.FileService.S3.Put.Load(); n != 1 {
+		t.Fatalf("got %v", n)
 	}
 
 	vec := &IOVector{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13773

## What this PR does / why we need it:
delete cache files when calling Delete