### PR TITLE
CI: increase the timeout of upgrade ci for 1.1-dev

### DIFF
--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -7,7 +7,7 @@ jobs:
   upgrade-ci-linux-x86:
     runs-on: ubuntu-latest
     name: Compatibility Test on Linux/x64(LAUNCH)
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - name: checkout head


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it: