### PR TITLE
fix account decode err when replay usage from old ckp

### DIFF
--- a/pkg/vm/engine/tae/catalog/database.go
+++ b/pkg/vm/engine/tae/catalog/database.go
@@ -634,13 +634,13 @@ func (e *DBEntry) IsActive() bool {
 }
 
 // only for test
-func MockDBEntryWithAccInfo(accId uint32, dbId uint64) *DBEntry {
+func MockDBEntryWithAccInfo(accId uint64, dbId uint64) *DBEntry {
 	entry := &DBEntry{
 		ID: dbId,
 	}
 
 	entry.DBNode = &DBNode{}
-	entry.DBNode.acInfo.TenantID = accId
+	entry.DBNode.acInfo.TenantID = uint32(accId)
 
 	return entry
 }

--- a/pkg/vm/engine/tae/logtail/storage_usage.go
+++ b/pkg/vm/engine/tae/logtail/storage_usage.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
@@ -29,6 +30,7 @@ import (
 	"math"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -89,7 +91,7 @@ const (
 const StorageUsageMagic uint64 = 0x1A2B3C4D5E6F
 
 type UsageData struct {
-	AccId uint32
+	AccId uint64
 	DbId  uint64
 	TblId uint64
 	Size  uint64
@@ -98,19 +100,21 @@ type UsageData struct {
 var zeroUsageData UsageData = UsageData{math.MaxUint32, math.MaxUint64, math.MaxUint64, math.MaxInt64}
 
 // MockUsageData generates accCnt * dbCnt * tblCnt UsageDatas.
-// the accIds, dbIds and tblIds are random produced
+// the accIds, dbIds and tblIds are random produced.
+// this func ensure that all ids are different.
 func MockUsageData(accCnt, dbCnt, tblCnt int) (result []UsageData) {
+	allocator := atomic.Uint64{}
 	for x := 0; x < accCnt; x++ {
-		accId := rand.Uint32()
+		accId := allocator.Add(1)
 
 		for y := 0; y < dbCnt; y++ {
-			dbId := rand.Uint64()
+			dbId := allocator.Add(1)
 
 			for z := 0; z < tblCnt; z++ {
 				result = append(result, UsageData{
 					AccId: accId,
 					DbId:  dbId,
-					TblId: rand.Uint64(),
+					TblId: allocator.Add(1),
 					Size:  uint64(rand.Int63() % 0x3ffff),
 				})
 			}
@@ -234,8 +238,8 @@ func (c *StorageUsageCache) ClearForUpdate() {
 	c.data.Clear()
 }
 
-func (c *StorageUsageCache) GatherAllAccSize() (usages map[uint32]uint64) {
-	usages = make(map[uint32]uint64)
+func (c *StorageUsageCache) GatherAllAccSize() (usages map[uint64]uint64) {
+	usages = make(map[uint64]uint64)
 	c.data.Scan(func(item UsageData) bool {
 		usages[item.AccId] += item.Size
 		return true
@@ -244,7 +248,7 @@ func (c *StorageUsageCache) GatherAllAccSize() (usages map[uint32]uint64) {
 	return
 }
 
-func (c *StorageUsageCache) GatherAccountSize(id uint32) (size uint64, exist bool) {
+func (c *StorageUsageCache) GatherAccountSize(id uint64) (size uint64, exist bool) {
 	iter := c.data.Iter()
 	defer iter.Release()
 
@@ -278,12 +282,13 @@ func (c *StorageUsageCache) Delete(usage UsageData) {
 
 type TNUsageMemo struct {
 	sync.Mutex
-	cache    *StorageUsageCache
+	cache *StorageUsageCache
+	// has update
 	pending  bool
 	reqTrace []struct {
 		hint      string
 		timeStamp time.Time
-		accountId uint32
+		accountId uint64
 		totalSize uint64
 	}
 
@@ -293,6 +298,10 @@ type TNUsageMemo struct {
 		datas   []*CheckpointData
 		vers    []uint32
 		delayed map[uint64]UsageData
+	}
+
+	pendingTransfer struct {
+		inserts, deletes []UsageData
 	}
 }
 
@@ -308,6 +317,10 @@ func (m *TNUsageMemo) PrepareReplay(datas []*CheckpointData, vers []uint32) {
 	m.pendingReplay.vers = vers
 }
 
+func (m *TNUsageMemo) GetDelayed() map[uint64]UsageData {
+	return m.pendingReplay.delayed
+}
+
 func (m *TNUsageMemo) GetNewAccCacheLatestUpdate() types.TS {
 	return types.BuildTS(m.newAccCache.lastUpdate.UnixNano(), 0)
 }
@@ -320,12 +333,12 @@ func (m *TNUsageMemo) ClearNewAccCache() {
 	m.newAccCache.ClearForUpdate()
 }
 
-func (m *TNUsageMemo) AddReqTrace(accountId uint32, tSize uint64, t time.Time, hint string) {
+func (m *TNUsageMemo) AddReqTrace(accountId uint64, tSize uint64, t time.Time, hint string) {
 	m.reqTrace = append(m.reqTrace,
 		struct {
 			hint      string
 			timeStamp time.Time
-			accountId uint32
+			accountId uint64
 			totalSize uint64
 		}{
 			hint:      hint,
@@ -335,7 +348,7 @@ func (m *TNUsageMemo) AddReqTrace(accountId uint32, tSize uint64, t time.Time, h
 		})
 }
 
-func (m *TNUsageMemo) GetAllReqTrace() (accountIds []uint32, timestamps []time.Time, sizes []uint64, hints []string) {
+func (m *TNUsageMemo) GetAllReqTrace() (accountIds []uint64, timestamps []time.Time, sizes []uint64, hints []string) {
 	m.EnterProcessing()
 	defer m.LeaveProcessing()
 
@@ -389,19 +402,19 @@ func (m *TNUsageMemo) HasUpdate() bool {
 	return m.pending
 }
 
-func (m *TNUsageMemo) gatherAccountSizeHelper(cache *StorageUsageCache, id uint32) (size uint64, exist bool) {
+func (m *TNUsageMemo) gatherAccountSizeHelper(cache *StorageUsageCache, id uint64) (size uint64, exist bool) {
 	return cache.GatherAccountSize(id)
 }
 
-func (m *TNUsageMemo) GatherAccountSize(id uint32) (size uint64, exist bool) {
+func (m *TNUsageMemo) GatherAccountSize(id uint64) (size uint64, exist bool) {
 	return m.gatherAccountSizeHelper(m.cache, id)
 }
 
-func (m *TNUsageMemo) GatherNewAccountSize(id uint32) (size uint64, exist bool) {
+func (m *TNUsageMemo) GatherNewAccountSize(id uint64) (size uint64, exist bool) {
 	return m.gatherAccountSizeHelper(m.newAccCache, id)
 }
 
-func (m *TNUsageMemo) GatherAllAccSize() (usages map[uint32]uint64) {
+func (m *TNUsageMemo) GatherAllAccSize() (usages map[uint64]uint64) {
 	return m.cache.GatherAllAccSize()
 }
 
@@ -452,31 +465,36 @@ func (m *TNUsageMemo) applyDeletes(
 			dbs = append(dbs, e)
 		case *catalog.TableEntry:
 			piovt := UsageData{
-				e.GetDB().GetTenantID(),
+				uint64(e.GetDB().GetTenantID()),
 				e.GetDB().GetID(), e.GetID(), 0}
 			if usage, exist := m.cache.Get(piovt); exist {
 				appendToStorageUsageBat(ckpData, usage, true, mp)
 				m.Delete(usage)
-				buf.WriteString(fmt.Sprintf("[tbl]%s_%d_%d_%d_%d; ",
+				buf.WriteString(fmt.Sprintf("[d-tbl]%s_%d_%d_%d_%d; ",
 					e.GetFullName(), usage.AccId, usage.DbId, usage.TblId, usage.Size))
 			}
 		}
 	}
 
+	isSameDBFunc := func(a UsageData, db *catalog.DBEntry) bool {
+		return a.AccId == uint64(db.GetTenantID()) && a.DbId == db.ID
+	}
+
 	usages := make([]UsageData, 0)
 	for _, db := range dbs {
 		iter := m.cache.Iter()
-		iter.Seek(UsageData{db.GetTenantID(), db.ID, 0, 0})
+		iter.Seek(UsageData{uint64(db.GetTenantID()), db.ID, 0, 0})
 
-		if iter.Item().DbId != db.ID || iter.Item().AccId != db.GetTenantID() {
+		if !isSameDBFunc(iter.Item(), db) {
 			iter.Release()
-			buf.WriteString(fmt.Sprintf("[db]%s_%d_%d_%d; ",
+			// db not found in cache
+			buf.WriteString(fmt.Sprintf("[n-db]%s_%d_%d_%d; ",
 				db.GetFullName(), db.GetTenantID(), db.GetID(), 0))
 			continue
 		}
 
 		usages = append(usages, iter.Item())
-		for iter.Next() && iter.Item().DbId == db.ID && iter.Item().AccId == db.GetTenantID() {
+		for iter.Next() && isSameDBFunc(iter.Item(), db) {
 			usages = append(usages, iter.Item())
 		}
 
@@ -489,7 +507,7 @@ func (m *TNUsageMemo) applyDeletes(
 			totalSize += usages[idx].Size
 		}
 
-		buf.WriteString(fmt.Sprintf("[db]%s_%d_%d_%d; ",
+		buf.WriteString(fmt.Sprintf("[d-db]%s_%d_%d_%d; ",
 			db.GetFullName(), db.GetTenantID(), db.GetID(), totalSize))
 
 		usages = usages[:0]
@@ -524,9 +542,9 @@ func (m *TNUsageMemo) replayIntoGCKP(collector *GlobalCollector) {
 	iter.Release()
 }
 
-func try2RemoveStaleData(usage UsageData, c *catalog.Catalog) (UsageData, bool) {
+func try2RemoveStaleData(usage UsageData, c *catalog.Catalog) (UsageData, string, bool) {
 	if c == nil {
-		return usage, false
+		return usage, "", false
 	}
 
 	var err error
@@ -536,19 +554,29 @@ func try2RemoveStaleData(usage UsageData, c *catalog.Catalog) (UsageData, bool) 
 	dbEntry, err = c.GetDatabaseByID(usage.DbId)
 	if err != nil || dbEntry.HasDropCommitted() {
 		// the db has been deleted
-		return usage, true
+		name := "deleted"
+		if dbEntry != nil {
+			name = dbEntry.GetName()
+		}
+		log := fmt.Sprintf("[d-db]%s_%d_%d_%d; ", name, usage.AccId, usage.DbId, usage.Size)
+		return usage, log, true
 	}
 
 	tblEntry, err = dbEntry.GetTableEntryByID(usage.TblId)
 	if err != nil || tblEntry.HasDropCommitted() {
 		// the tbl has been deleted
-		return usage, true
+		name := "deleted"
+		if tblEntry != nil {
+			name = tblEntry.GetFullName()
+		}
+		log := fmt.Sprintf("[d-tbl]%s_%d_%d_%d_%d; ", name, usage.AccId, usage.DbId, usage.TblId, usage.Size)
+		return usage, log, true
 	}
 
-	return usage, false
+	return usage, "", false
 }
 
-func (m *TNUsageMemo) deleteAccount(accId uint32) (cleaned int) {
+func (m *TNUsageMemo) deleteAccount(accId uint64) {
 	trash := make([]UsageData, 0)
 	povit := UsageData{accId, 0, 0, 0}
 
@@ -558,7 +586,7 @@ func (m *TNUsageMemo) deleteAccount(accId uint32) (cleaned int) {
 
 	if iter.Item().AccId != accId {
 		iter.Release()
-		return 0
+		return
 	}
 
 	trash = append(trash, iter.Item())
@@ -575,23 +603,24 @@ func (m *TNUsageMemo) deleteAccount(accId uint32) (cleaned int) {
 	for idx := range trash {
 		m.Delete(trash[idx])
 	}
-
-	return len(trash)
 }
 
-func (m *TNUsageMemo) ClearDroppedAccounts(reserved map[uint32]struct{}) (cleaned int) {
+func (m *TNUsageMemo) ClearDroppedAccounts(reserved map[uint64]struct{}) string {
 	if reserved == nil {
-		return
+		return ""
 	}
+
+	var buf bytes.Buffer
 
 	usages := m.GatherAllAccSize()
 	for accId := range usages {
 		if _, ok := reserved[accId]; !ok {
 			// this account has been deleted
-			cleaned += m.deleteAccount(accId)
+			m.deleteAccount(accId)
+			buf.WriteString(fmt.Sprintf("%d; ", accId))
 		}
 	}
-	return
+	return buf.String()
 }
 
 // EstablishFromCKPs replays usage info which stored in ckps into the tn cache
@@ -599,12 +628,18 @@ func (m *TNUsageMemo) EstablishFromCKPs(c *catalog.Catalog) {
 	m.EnterProcessing()
 	defer m.LeaveProcessing()
 
+	var buf bytes.Buffer
+
 	defer func() {
-		for _, data := range m.pendingReplay.datas {
-			if data != nil {
-				data.Close()
+		for idx := range m.pendingReplay.datas {
+			if m.pendingReplay.datas[idx] != nil {
+				m.pendingReplay.datas[idx].Close()
 			}
+			m.pendingReplay.datas[idx] = nil
 		}
+		logutil.Info("[storage usage] replay:",
+			zap.String("remove old deleted db/tbl", buf.String()),
+			zap.Int("delayed %d tbl", len(m.pendingReplay.delayed)))
 	}()
 
 	for x := range m.pendingReplay.datas {
@@ -618,7 +653,8 @@ func (m *TNUsageMemo) EstablishFromCKPs(c *catalog.Catalog) {
 		accCol, dbCol, tblCol, sizeCol := getStorageUsageVectorCols(insVecs)
 
 		var skip bool
-		for y := 0; y < insVecs[UsageAccID].Length(); y++ {
+		var log string
+		for y := 0; y < len(accCol); y++ {
 			usage := UsageData{accCol[y], dbCol[y], tblCol[y], sizeCol[y]}
 
 			// these ckps, older than version 11, haven't del bat, we need clear the
@@ -629,8 +665,9 @@ func (m *TNUsageMemo) EstablishFromCKPs(c *catalog.Catalog) {
 			if m.pendingReplay.vers[x] < CheckpointVersion11 {
 				// here only remove the deleted db and table.
 				// if table has deletes, we update it in gckp
-				usage, skip = try2RemoveStaleData(usage, c)
+				usage, log, skip = try2RemoveStaleData(usage, c)
 				if skip {
+					buf.WriteString(log)
 					continue
 				}
 				if m.pendingReplay.delayed == nil {
@@ -672,12 +709,16 @@ func getStorageUsageBatVectors(bat *containers.Batch) []*vector.Vector {
 }
 
 func getStorageUsageVectorCols(vecs []*vector.Vector) (
-	accCol []uint32, dbCol []uint64, tblCol []uint64, sizeCol []uint64) {
+	accCol []uint64, dbCol []uint64, tblCol []uint64, sizeCol []uint64) {
 
 	dbCol = vector.MustFixedCol[uint64](vecs[UsageDBID])
-	accCol = vector.MustFixedCol[uint32](vecs[UsageAccID])
+	accCol = vector.MustFixedCol[uint64](vecs[UsageAccID])
 	tblCol = vector.MustFixedCol[uint64](vecs[UsageTblID])
 	sizeCol = vector.MustFixedCol[uint64](vecs[UsageSize])
+
+	//for idx := range accCol1 {
+	//	accCol = append(accCol, uint64(accCol1[idx]))
+	//}
 
 	return
 }
@@ -694,7 +735,7 @@ var lastDelUsage UsageData = zeroUsageData
 func appendToStorageUsageBat(data *CheckpointData, usage UsageData, del bool, mp *mpool.MPool) {
 	appendFunc := func(vecs []*vector.Vector) {
 		vector.AppendFixed[uint64](vecs[UsageSize], usage.Size, false, mp)
-		vector.AppendFixed[uint32](vecs[UsageAccID], usage.AccId, false, mp)
+		vector.AppendFixed[uint64](vecs[UsageAccID], usage.AccId, false, mp)
 		vector.AppendFixed[uint64](vecs[UsageDBID], usage.DbId, false, mp)
 		vector.AppendFixed[uint64](vecs[UsageTblID], usage.TblId, false, mp)
 	}
@@ -739,7 +780,7 @@ func objects2Usages(objs []*catalog.ObjectEntry) (usages []UsageData) {
 			DbId:  obj.GetTable().GetDB().GetID(),
 			Size:  uint64(obj.Stat.GetCompSize()),
 			TblId: obj.GetTable().GetID(),
-			AccId: obj.GetTable().GetDB().GetTenantID(),
+			AccId: uint64(obj.GetTable().GetDB().GetTenantID()),
 		}
 	}
 
@@ -759,7 +800,7 @@ func updateStorageUsageMeta(data *CheckpointData, tid uint64, start, end int32, 
 	}
 }
 
-func tryClearDataFromOldVersion(collector *GlobalCollector) string {
+func tryUpdateDataFromOldVersion(collector *GlobalCollector) string {
 	memo := collector.UsageMemo
 	if len(memo.pendingReplay.delayed) == 0 {
 		return ""
@@ -784,7 +825,7 @@ func tryClearDataFromOldVersion(collector *GlobalCollector) string {
 			size = 0
 		}
 		if usage, ok := memo.pendingReplay.delayed[id]; ok {
-			memo.Delete(usage)
+			memo.Update(usage, true)
 			usage.Size = uint64(size)
 			memo.Update(usage, false)
 			delete(memo.pendingReplay.delayed, id)
@@ -814,6 +855,26 @@ func applyChanges(collector *BaseCollector, tnUsageMemo *TNUsageMemo) string {
 	return log
 }
 
+//func applyTransfer(collector *BaseCollector, memo *TNUsageMemo) string {
+//	var buf bytes.Buffer
+//	if len(memo.pendingTransfer.deletes) != 0 {
+//		memo.applySegDeletes(memo.pendingTransfer.deletes, collector.data, collector.Allocator())
+//		for _, usage := range memo.pendingTransfer.deletes {
+//			buf.WriteString(fmt.Sprintf("[td-tbl]%d_%d_%d_%d; ",
+//				usage.AccId, usage.DbId, usage.TblId, usage.Size))
+//		}
+//	}
+//	if len(memo.pendingTransfer.inserts) != 0 {
+//		memo.applySegInserts(memo.pendingTransfer.inserts, collector.data, collector.Allocator())
+//		for _, usage := range memo.pendingTransfer.inserts {
+//			buf.WriteString(fmt.Sprintf("[ti-tbl]%d_%d_%d_%d; ",
+//				usage.AccId, usage.DbId, usage.TblId, usage.Size))
+//		}
+//	}
+//
+//	return buf.String()
+//}
+
 func FillUsageBatOfGlobal(collector *GlobalCollector) {
 	start := time.Now()
 
@@ -823,13 +884,13 @@ func FillUsageBatOfGlobal(collector *GlobalCollector) {
 		v2.TaskGCkpCollectUsageDurationHistogram.Observe(time.Since(start).Seconds())
 	}()
 
-	log := tryClearDataFromOldVersion(collector)
-	cleaned := collector.UsageMemo.ClearDroppedAccounts(collector.Usage.ReservedAccIds)
+	log1 := tryUpdateDataFromOldVersion(collector)
+	log2 := collector.UsageMemo.ClearDroppedAccounts(collector.Usage.ReservedAccIds)
 	collector.UsageMemo.replayIntoGCKP(collector)
 
 	logutil.Info("[storage usage] CKP[G]",
-		zap.Int("accounts cleaned", cleaned),
-		zap.String("update old data", log))
+		zap.String("update old data", log1),
+		zap.String("accounts cleaned", log2))
 }
 
 func FillUsageBatOfIncremental(collector *IncrementalCollector) {
@@ -842,11 +903,12 @@ func FillUsageBatOfIncremental(collector *IncrementalCollector) {
 		v2.TaskICkpCollectUsageDurationHistogram.Observe(time.Since(start).Seconds())
 	}()
 
-	log := applyChanges(collector.BaseCollector, collector.UsageMemo)
+	log1 := applyChanges(collector.BaseCollector, collector.UsageMemo)
+	//log2 := applyTransfer(collector.BaseCollector, collector.UsageMemo)
 
 	logutil.Info("[storage usage] CKP[I]",
 		zap.Float64("cache mem used", collector.UsageMemo.MemoryUsed()),
-		zap.String("applied deletes", log))
+		zap.String("applied deletes", log1))
 }
 
 // GetStorageUsageHistory is for debug to show these storage usage changes.
@@ -926,7 +988,7 @@ func GetStorageUsageHistory(
 }
 
 func cnBatchToUsageDatas(bat *batch.Batch) []UsageData {
-	accCol := vector.MustFixedCol[uint32](bat.GetVector(2))
+	accCol := vector.MustFixedCol[uint64](bat.GetVector(2))
 	dbCol := vector.MustFixedCol[uint64](bat.GetVector(3))
 	tblCol := vector.MustFixedCol[uint64](bat.GetVector(4))
 	sizeCol := vector.MustFixedCol[uint64](bat.GetVector(6))
@@ -1012,4 +1074,59 @@ func loadStorageUsageBatch(
 		}
 	}
 	return bats, nil
+}
+
+func PairAccountVsDB(c *catalog.Catalog) map[uint64]uint64 {
+	pairs := make(map[uint64]uint64)
+
+	processor := new(catalog.LoopProcessor)
+	processor.DatabaseFn = func(entry *catalog.DBEntry) error {
+		pairs[entry.GetID()] = uint64(entry.GetTenantID())
+		return nil
+	}
+
+	c.RecurLoop(processor)
+	return pairs
+}
+
+func CorrectUsageWrongPlacement(c *catalog.Catalog) (error, int, float64) {
+	memo := c.GetUsageMemo().(*TNUsageMemo)
+	if memo == nil {
+		return moerr.NewInternalErrorNoCtx("tn usage cache is nil"), 0, 0
+	}
+
+	var buf bytes.Buffer
+
+	pairs := PairAccountVsDB(c)
+
+	memo.EnterProcessing()
+	defer memo.LeaveProcessing()
+
+	usages := memo.cache.data.Items()
+
+	anyTransferred := int(0)
+	transferredSize := float64(0)
+	for idx := range usages {
+		if pairs[usages[idx].DbId] != usages[idx].AccId {
+			anyTransferred++
+			transferredSize += float64(usages[idx].Size)
+
+			memo.Update(usages[idx], true)
+			buf.WriteString(fmt.Sprintf("[td-tbl]%d_%d_%d_%d; ",
+				usages[idx].AccId, usages[idx].DbId, usages[idx].TblId, usages[idx].Size))
+			//memo.pendingTransfer.deletes = append(memo.pendingTransfer.deletes, usages[idx])
+
+			usages[idx].AccId = pairs[usages[idx].DbId]
+			memo.Update(usages[idx], false)
+			buf.WriteString(fmt.Sprintf("[ti-tbl]%d_%d_%d_%d; ",
+				usages[idx].AccId, usages[idx].DbId, usages[idx].TblId, usages[idx].Size))
+			//memo.pendingTransfer.inserts = append(memo.pendingTransfer.inserts, usages[idx])
+		}
+	}
+
+	transferredSize /= 1024 * 1024
+	logutil.Info("[storage usage] apply transfer: ",
+		zap.String(fmt.Sprintf("transferred %d tbl, %f mb", anyTransferred, transferredSize), buf.String()))
+
+	return nil, anyTransferred, transferredSize
 }

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -712,7 +712,7 @@ type BaseCollector struct {
 		Deletes        []interface{}
 		SegInserts     []*catalog.ObjectEntry
 		SegDeletes     []*catalog.ObjectEntry
-		ReservedAccIds map[uint32]struct{}
+		ReservedAccIds map[uint64]struct{}
 	}
 
 	UsageMemo *TNUsageMemo
@@ -773,7 +773,7 @@ func NewGlobalCollector(end types.TS, versionInterval time.Duration) *GlobalColl
 	collector.ObjectFn = collector.VisitObj
 	collector.BlockFn = collector.VisitBlk
 
-	collector.Usage.ReservedAccIds = make(map[uint32]struct{})
+	collector.Usage.ReservedAccIds = make(map[uint64]struct{})
 
 	return collector
 }
@@ -2698,7 +2698,7 @@ func (collector *GlobalCollector) VisitDB(entry *catalog.DBEntry) error {
 	}
 
 	currAccId := uint32(entry.GetTenantID())
-	collector.Usage.ReservedAccIds[currAccId] = struct{}{}
+	collector.Usage.ReservedAccIds[uint64(currAccId)] = struct{}{}
 
 	return collector.BaseCollector.VisitDB(entry)
 }

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -1234,7 +1234,8 @@ func traverseCatalogForNewAccounts(c *catalog2.Catalog, memo *logtail.TNUsageMem
 
 		tblIt := entry.MakeTableIt(true)
 		for tblIt.Valid() {
-			insUsage := logtail.UsageData{AccId: accId, DbId: entry.ID, TblId: tblIt.Get().GetPayload().ID}
+			insUsage := logtail.UsageData{
+				AccId: uint64(accId), DbId: entry.ID, TblId: tblIt.Get().GetPayload().ID}
 
 			tblEntry := tblIt.Get().GetPayload()
 			if tblEntry.HasDropCommitted() {
@@ -1286,11 +1287,11 @@ func (h *Handle) HandleStorageUsage(ctx context.Context, meta txn.TxnMeta,
 	newIds := make([]uint32, 0)
 	for _, id := range req.AccIds {
 		if usages != nil {
-			if size, exist := usages[uint32(id)]; exist {
-				memo.AddReqTrace(uint32(id), size, start, "req")
+			if size, exist := usages[uint64(id)]; exist {
+				memo.AddReqTrace(uint64(id), size, start, "req")
 				resp.AccIds = append(resp.AccIds, int32(id))
 				resp.Sizes = append(resp.Sizes, size)
-				delete(usages, uint32(id))
+				delete(usages, uint64(id))
 				continue
 			}
 		}
@@ -1299,7 +1300,7 @@ func (h *Handle) HandleStorageUsage(ctx context.Context, meta txn.TxnMeta,
 	}
 
 	for accId, size := range usages {
-		memo.AddReqTrace(accId, size, start, "oth")
+		memo.AddReqTrace(uint64(accId), size, start, "oth")
 		resp.AccIds = append(resp.AccIds, int32(accId))
 		resp.Sizes = append(resp.Sizes, size)
 	}
@@ -1308,10 +1309,10 @@ func (h *Handle) HandleStorageUsage(ctx context.Context, meta txn.TxnMeta,
 	traverseCatalogForNewAccounts(h.db.Catalog, memo, newIds)
 
 	for idx := range newIds {
-		if size, exist := memo.GatherNewAccountSize(newIds[idx]); exist {
+		if size, exist := memo.GatherNewAccountSize(uint64(newIds[idx])); exist {
 			resp.AccIds = append(resp.AccIds, int32(newIds[idx]))
 			resp.Sizes = append(resp.Sizes, size)
-			memo.AddReqTrace(newIds[idx], size, start, "new")
+			memo.AddReqTrace(uint64(newIds[idx]), size, start, "new")
 		}
 	}
 

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -194,15 +194,17 @@ func (c *objStatArg) Run() error {
 type storageUsageHistoryArg struct {
 	ctx    *inspectContext
 	detail *struct {
-		accId uint32
+		accId uint64
 		dbI   uint64
 		tblId uint64
 	}
 
 	trace *struct {
 		tStart, tEnd time.Time
-		accounts     map[uint32]struct{}
+		accounts     map[uint64]struct{}
 	}
+
+	transfer bool
 }
 
 func (c *storageUsageHistoryArg) FromCommand(cmd *cobra.Command) (err error) {
@@ -215,7 +217,7 @@ func (c *storageUsageHistoryArg) FromCommand(cmd *cobra.Command) (err error) {
 			return err
 		}
 		c.detail = &struct {
-			accId uint32
+			accId uint64
 			dbI   uint64
 			tblId uint64
 		}{accId: accId, dbI: dbId, tblId: tblId}
@@ -230,8 +232,17 @@ func (c *storageUsageHistoryArg) FromCommand(cmd *cobra.Command) (err error) {
 
 		c.trace = &struct {
 			tStart, tEnd time.Time
-			accounts     map[uint32]struct{}
+			accounts     map[uint64]struct{}
 		}{tStart: start, tEnd: end, accounts: accs}
+	}
+
+	expr, _ = cmd.Flags().GetString("transfer")
+	if expr != "" {
+		if expr == "*" {
+			c.transfer = true
+		} else {
+			return moerr.NewInvalidArgNoCtx(expr, "`storage_usage -f *` expected")
+		}
 	}
 
 	return nil
@@ -242,6 +253,8 @@ func (c *storageUsageHistoryArg) Run() (err error) {
 		return storageUsageDetails(c)
 	} else if c.trace != nil {
 		return storageTrace(c)
+	} else if c.transfer {
+		return storageTransfer(c)
 	}
 	return moerr.NewInvalidArgNoCtx("", c.ctx.args)
 }
@@ -635,9 +648,11 @@ func initCommand(ctx context.Context, inspectCtx *inspectContext) *cobra.Command
 		Run:   RunFactory(&storageUsageHistoryArg{}),
 	}
 
+	// storage usage request history
 	storageUsageCmd.Flags().StringP("trace", "t", "", "format: -time time range or -acc account id list")
 	// storage usage details in ckp
 	storageUsageCmd.Flags().StringP("detail", "d", "", "format: accId{.dbName{.tableName}}")
+	storageUsageCmd.Flags().StringP("transfer", "f", "", "format: *")
 	rootCmd.AddCommand(storageUsageCmd)
 
 	return rootCmd
@@ -772,7 +787,7 @@ func (o *objectVisitor) OnTable(table *catalog.TableEntry) error {
 // the history of all
 // mo_ctl("dn", "inspect", "storage_usage -t *");
 func parseStorageUsageDetail(expr string, ac *db.AccessInfo, db *db.DB) (
-	accId uint32, dbId uint64, tblId uint64, err error) {
+	accId uint64, dbId uint64, tblId uint64, err error) {
 	strs := strings.Split(expr, ".")
 
 	if len(strs) == 0 || len(strs) > 3 {
@@ -796,7 +811,7 @@ func parseStorageUsageDetail(expr string, ac *db.AccessInfo, db *db.DB) (
 		return 0, 0, 0, err
 	}
 
-	accId = uint32(id)
+	accId = uint64(id)
 	dbId, tblId = math.MaxUint64, math.MaxUint64
 
 	var dbHdl handle.Database
@@ -845,7 +860,7 @@ func subString(src string, pos1, pos2 int) (string, error) {
 // no limit, show all request trace info
 // select mo_ctl("dn", "inspect", "-t ");
 func parseStorageUsageTrace(expr string, ac *db.AccessInfo, db *db.DB) (
-	tStart, tEnd time.Time, accounts map[uint32]struct{}, err error) {
+	tStart, tEnd time.Time, accounts map[uint64]struct{}, err error) {
 
 	var str string
 	tIdx := strings.Index(expr, "-time")
@@ -887,7 +902,7 @@ func parseStorageUsageTrace(expr string, ac *db.AccessInfo, db *db.DB) (
 		}
 		accs := strings.Split(str, " ")
 
-		accounts = make(map[uint32]struct{})
+		accounts = make(map[uint64]struct{})
 
 		var id int
 		for i := range accs {
@@ -895,7 +910,7 @@ func parseStorageUsageTrace(expr string, ac *db.AccessInfo, db *db.DB) (
 			if err != nil {
 				return
 			}
-			accounts[uint32(id)] = struct{}{}
+			accounts[uint64(id)] = struct{}{}
 		}
 	}
 
@@ -1045,7 +1060,7 @@ func storageUsageDetails(c *storageUsageHistoryArg) (err error) {
 
 func storageTrace(c *storageUsageHistoryArg) (err error) {
 
-	filter := func(accId uint32, stamp time.Time) bool {
+	filter := func(accId uint64, stamp time.Time) bool {
 		if !c.trace.tStart.IsZero() {
 			if stamp.UTC().Add(time.Hour*8).Before(c.trace.tStart) ||
 				stamp.UTC().Add(time.Hour*8).After(c.trace.tEnd) {
@@ -1086,4 +1101,14 @@ func storageTrace(c *storageUsageHistoryArg) (err error) {
 	c.ctx.resp.Payload = b.Bytes()
 
 	return nil
+}
+
+func storageTransfer(c *storageUsageHistoryArg) (err error) {
+	err, cnt, size := logtail.CorrectUsageWrongPlacement(c.ctx.db.Catalog)
+	if err != nil {
+		return err
+	}
+
+	c.ctx.out.Write([]byte(fmt.Sprintf("transferred %d tbl, %f mb; ", cnt, size)))
+	return
 }

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -1104,7 +1104,7 @@ func storageTrace(c *storageUsageHistoryArg) (err error) {
 }
 
 func storageTransfer(c *storageUsageHistoryArg) (err error) {
-	err, cnt, size := logtail.CorrectUsageWrongPlacement(c.ctx.db.Catalog)
+	cnt, size, err := logtail.CorrectUsageWrongPlacement(c.ctx.db.Catalog)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2146

## What this PR does / why we need it:
1. correct the account type in the storage usage bat to uint64.
2. adding more tests to test the behavior of the usage cache.
3. one way to provide support is to transfer the usage to the right account.

