### PR TITLE
[enhancement] txnClient: it waits until txn client is in normal state.

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -607,7 +607,10 @@ func (s *service) getTxnClient() (c client.TxnClient, err error) {
 			opts = append(opts,
 				client.WithMaxActiveTxn(s.cfg.Txn.MaxActive))
 		}
-		opts = append(opts, client.WithLockService(s.lockService))
+		opts = append(opts,
+			client.WithLockService(s.lockService),
+			client.WithNormalStateNoWait(s.cfg.Txn.NormalStateNoWait),
+		)
 		c = client.NewTxnClient(
 			sender,
 			opts...)

--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -221,6 +221,11 @@ type Config struct {
 		// MaxActive is the count of max active txn in current cn.  If reached max value, the txn
 		// is added to a FIFO queue. Default is unlimited.
 		MaxActive int `toml:"max-active"`
+		// NormalStateNoWait is the config to control if it waits for the transaction client
+		// to be normal state. If the value is false, it waits until the transaction client to be
+		// normal state; if the value is true, it does not wait and just return an error to the
+		// client. Default value is false.
+		NormalStateNoWait bool `toml:"normal-state-no-wait"`
 	} `toml:"txn"`
 
 	// AutoIncrement auto increment config
@@ -493,6 +498,7 @@ func (c *Config) SetDefaultValue() {
 	if c.Txn.MaxActive == 0 {
 		c.Txn.MaxActive = runtime.NumCPU() * 4
 	}
+	c.Txn.NormalStateNoWait = false
 	c.LockService.ServiceID = "temp"
 	c.LockService.Validate()
 	c.LockService.ServiceID = c.UUID

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -126,6 +126,13 @@ func WithMaxActiveTxn(n int) TxnClientCreateOption {
 	}
 }
 
+// WithNormalStateNoWait sets the normalStateNoWait value of txnClient.
+func WithNormalStateNoWait(t bool) TxnClientCreateOption {
+	return func(tc *txnClient) {
+		tc.normalStateNoWait = t
+	}
+}
+
 var _ TxnClient = (*txnClient)(nil)
 
 type status int
@@ -148,6 +155,12 @@ type txnClient struct {
 	enableSacrificingFreshness bool
 	enableRefreshExpression    bool
 
+	// normalStateNoWait is used to control if wait for the txn client's
+	// state to be normal. If it is false, which is default value, wait
+	// until the txn client's state to be normal; otherwise, if it is true,
+	// do not wait, and just return an error.
+	normalStateNoWait bool
+
 	atomic struct {
 		// we maintain a CN-based last commit timestamp to ensure that
 		// a txn with that CN can see previous writes.
@@ -161,6 +174,9 @@ type txnClient struct {
 
 	mu struct {
 		sync.RWMutex
+		// cond is used to control if we can create new txn and notify
+		// if the state is changed.
+		cond *sync.Cond
 		// indicate whether the CN can provide service normally.
 		state status
 		// user active txns
@@ -201,6 +217,7 @@ func NewTxnClient(
 		sender: sender,
 	}
 	c.mu.state = paused
+	c.mu.cond = sync.NewCond(&c.mu)
 	c.mu.activeTxns = make(map[string]*txnOperator, 100000)
 	for _, opt := range options {
 		opt(c)
@@ -423,25 +440,36 @@ func (client *txnClient) openTxn(op *txnOperator) error {
 		client.mu.Unlock()
 	}()
 
-	if client.mu.state == normal {
-		if !op.isUserTxn() ||
-			client.mu.users < client.maxActiveTxn {
-			client.addActiveTxnLocked(op)
-			return nil
+	for client.mu.state == paused {
+		if client.normalStateNoWait {
+			return moerr.NewInternalErrorNoCtx("cn service is not ready, retry later")
 		}
-		var cancelC chan struct{}
-		if client.timestampWaiter != nil {
-			cancelC = client.timestampWaiter.CancelC()
-			if cancelC == nil {
-				return moerr.NewWaiterPausedNoCtx()
-			}
-		}
-		op.waiter = newWaiter(timestamp.Timestamp{}, cancelC)
-		op.waiter.ref()
-		client.mu.waitActiveTxns = append(client.mu.waitActiveTxns, op)
+
+		util.GetLogger().Warn("txn client is in pause state, wait for it to be ready",
+			zap.String("txn ID", hex.EncodeToString(op.txnID)))
+		// Wait until the txn client's state changed to normal, and it will probably take
+		// no more than 5 seconds in theory.
+		client.mu.cond.Wait()
+		util.GetLogger().Warn("txn client is in ready state",
+			zap.String("txn ID", hex.EncodeToString(op.txnID)))
+	}
+
+	if !op.isUserTxn() ||
+		client.mu.users < client.maxActiveTxn {
+		client.addActiveTxnLocked(op)
 		return nil
 	}
-	return moerr.NewInternalErrorNoCtx("cn service is not ready, retry later")
+	var cancelC chan struct{}
+	if client.timestampWaiter != nil {
+		cancelC = client.timestampWaiter.CancelC()
+		if cancelC == nil {
+			return moerr.NewWaiterPausedNoCtx()
+		}
+	}
+	op.waiter = newWaiter(timestamp.Timestamp{}, cancelC)
+	op.waiter.ref()
+	client.mu.waitActiveTxns = append(client.mu.waitActiveTxns, op)
+	return nil
 }
 
 func (client *txnClient) closeTxn(txn txn.TxnMeta) {
@@ -510,6 +538,11 @@ func (client *txnClient) Resume() {
 
 	util.GetLogger().Info("txn client status changed to normal")
 	client.mu.state = normal
+
+	// Notify all waiting transactions to goon with the opening operation.
+	if !client.normalStateNoWait {
+		client.mu.cond.Broadcast()
+	}
 }
 
 func (client *txnClient) AbortAllRunningTxn() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13115

## What this PR does / why we need it:
Add a new config "normal-state-no-wait" in CN to control whether it
returns an error or waits when the txn client is in pause state.

The configuration value is false by default, which means that if the txn
client is in pause state, it will wait until it changes to nromal state. Otherwise,
just return an error.