### PR TITLE
fix checkAddNameConflictLocked

### DIFF
--- a/pkg/vm/engine/tae/catalog/database.go
+++ b/pkg/vm/engine/tae/catalog/database.go
@@ -557,6 +557,10 @@ func (e *DBEntry) checkAddNameConflictLocked(name string, tid uint64, nn *nodeLi
 	if nn == nil {
 		return nil
 	}
+	node := nn.GetNode()
+	if node == nil {
+		return nil
+	}
 	// check ww conflict
 	tbl := nn.GetNode().GetPayload()
 	// skip the same table entry


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13915

## What this PR does / why we need it:

When rollback transactions of creating table, nn.Node() may be nil. 