### PR TITLE
sync_to_1.1: adding lock to cn storage usage cache to avoid data race 

### DIFF
--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -189,6 +189,9 @@ func handleStorageUsageResponse(
 }
 
 func checkStorageUsageCache(accIds [][]int32) (result map[int32]uint64, succeed bool) {
+	cnUsageCache.Lock()
+	defer cnUsageCache.Unlock()
+
 	if cnUsageCache.IsExpired() {
 		return nil, false
 	}
@@ -214,6 +217,9 @@ func updateStorageUsageCache(accIds []int32, sizes []uint64) {
 	if len(accIds) == 0 {
 		return
 	}
+
+	cnUsageCache.Lock()
+	defer cnUsageCache.Unlock()
 
 	// step 1: delete stale accounts
 	cnUsageCache.ClearForUpdate()

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
@@ -17,6 +17,7 @@ package dashboard
 import (
 	"context"
 	"fmt"
+	"github.com/K-Phoen/grabana/axis"
 	"github.com/K-Phoen/grabana/dashboard"
 	"github.com/K-Phoen/grabana/row"
 	"github.com/K-Phoen/grabana/timeseries"
@@ -37,7 +38,7 @@ func (c *DashboardCreator) initTaskDashboard() error {
 			c.initTaskCheckpointRow(),
 			c.initTaskSelectivityRow(),
 			c.initTaskMergeTransferPageRow(),
-			c.initStorageUsageMemUsedRow(),
+			c.initTaskStorageUsageRow(),
 		)...)
 
 	if err != nil {
@@ -45,17 +46,6 @@ func (c *DashboardCreator) initTaskDashboard() error {
 	}
 	_, err = c.cli.UpsertDashboard(context.Background(), folder, build)
 	return err
-}
-
-func (c *DashboardCreator) initStorageUsageMemUsedRow() dashboard.Option {
-	return dashboard.Row(
-		"Storage Usage Cache Mem Used",
-		c.withGraph(
-			"cache mem used",
-			12,
-			`sum(`+c.getMetricWithFilter("mo_task_storage_usage_cache_size", ``)+`)`,
-			""),
-	)
 }
 
 func (c *DashboardCreator) initTaskMergeTransferPageRow() dashboard.Option {
@@ -150,31 +140,45 @@ func (c *DashboardCreator) initTaskCheckpointRow() dashboard.Option {
 			c.getMetricWithFilter(`mo_task_long_duration_seconds_bucket`, `type="ckp_entry_pending"`),
 			[]float64{0.50, 0.8, 0.90, 0.99},
 			SpanNulls(true),
-			timeseries.Span(3),
-		),
-		c.getPercentHist(
-			"ICheckpoint Collecting Duration",
-			c.getMetricWithFilter(`mo_task_short_duration_seconds_bucket`, `type="ickp_collect_uage"`),
-			[]float64{0.50, 0.8, 0.90, 0.99},
-			SpanNulls(true),
-			timeseries.Span(3),
-		),
-		c.getPercentHist(
-			"GCheckpoint Collecting Duration",
-			c.getMetricWithFilter(`mo_task_short_duration_seconds_bucket`, `type="gckp_collect_uage"`),
-			[]float64{0.50, 0.8, 0.90, 0.99},
-			SpanNulls(true),
-			timeseries.Span(3),
-		),
-
-		c.getPercentHist(
-			"GCheckpoint Collecting Duration",
-			c.getMetricWithFilter(`mo_task_short_duration_seconds_bucket`, `type="handle_usage_request"`),
-			[]float64{0.50, 0.8, 0.90, 0.99},
-			SpanNulls(true),
-			timeseries.Span(3),
+			timeseries.Span(12),
 		),
 	)
+}
+
+func (c *DashboardCreator) initTaskStorageUsageRow() dashboard.Option {
+	rows := c.getMultiHistogram(
+		[]string{
+			c.getMetricWithFilter(`mo_task_short_duration_seconds_bucket`, `type="gckp_collect_usage"`),
+			c.getMetricWithFilter(`mo_task_short_duration_seconds_bucket`, `type="ickp_collect_usage"`),
+			c.getMetricWithFilter(`mo_task_short_duration_seconds_bucket`, `type="handle_usage_request"`),
+			c.getMetricWithFilter(`mo_task_short_duration_seconds_bucket`, `type="show_accounts_get_table_stats"`),
+			c.getMetricWithFilter(`mo_task_short_duration_seconds_bucket`, `type="show_accounts_get_storage_usage"`),
+			c.getMetricWithFilter(`mo_task_short_duration_seconds_bucket`, `type="show_accounts_total_duration"`),
+		},
+		[]string{
+			"gckp_collect_usage",
+			"ickp_collect_usage",
+			"handle_usage_request",
+			"show_accounts_get_table_stats",
+			"show_accounts_get_storage_usage",
+			"show_accounts_total_duration",
+		},
+		[]float64{0.50, 0.8, 0.90, 0.99},
+		[]float32{3, 3, 3, 3},
+		axis.Unit("s"),
+		axis.Min(0))
+
+	rows = append(rows, c.withGraph(
+		"tn storage usage cache mem used",
+		12,
+		`sum(`+c.getMetricWithFilter("mo_task_storage_usage_cache_size", ``)+`)`,
+		"mb"))
+
+	return dashboard.Row(
+		"Storage Usage Overview",
+		rows...,
+	)
+
 }
 
 func (c *DashboardCreator) initTaskSelectivityRow() dashboard.Option {

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
@@ -172,7 +172,8 @@ func (c *DashboardCreator) initTaskStorageUsageRow() dashboard.Option {
 		"tn storage usage cache mem used",
 		12,
 		`sum(`+c.getMetricWithFilter("mo_task_storage_usage_cache_size", ``)+`)`,
-		"mb"))
+		"cache mem used",
+		axis.Unit("mb")))
 
 	return dashboard.Row(
 		"Storage Usage Overview",

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -101,8 +101,6 @@ func initLogtailMetrics() {
 	registry.MustRegister(LogTailCollectDurationHistogram)
 	registry.MustRegister(LogTailSubscriptionCounter)
 	registry.MustRegister(txnTNSideDurationHistogram)
-
-	registry.MustRegister(TxnShowAccountsDurationHistogram)
 }
 
 func initTxnMetrics() {

--- a/pkg/util/metric/v2/task.go
+++ b/pkg/util/metric/v2/task.go
@@ -28,11 +28,16 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.00001, 2.0, 20),
 		}, []string{"type"})
 
-	TaskFlushTableTailDurationHistogram   = taskShortDurationHistogram.WithLabelValues("flush_table_tail")
-	TaskGCkpCollectUsageDurationHistogram = taskShortDurationHistogram.WithLabelValues("gckp_collect_usage")
-	TaskICkpCollectUsageDurationHistogram = taskShortDurationHistogram.WithLabelValues("ickp_collect_uage")
-	GetObjectStatsDurationHistogram       = taskShortDurationHistogram.WithLabelValues("get_object_stats")
-	TaskStorageUsageReqDurationHistogram  = taskShortDurationHistogram.WithLabelValues("handle_usage_request")
+	TaskFlushTableTailDurationHistogram = taskShortDurationHistogram.WithLabelValues("flush_table_tail")
+	GetObjectStatsDurationHistogram     = taskShortDurationHistogram.WithLabelValues("get_object_stats")
+
+	// storage usage / show accounts metrics
+	TaskGCkpCollectUsageDurationHistogram          = taskShortDurationHistogram.WithLabelValues("gckp_collect_usage")
+	TaskICkpCollectUsageDurationHistogram          = taskShortDurationHistogram.WithLabelValues("ickp_collect_usage")
+	TaskStorageUsageReqDurationHistogram           = taskShortDurationHistogram.WithLabelValues("handle_usage_request")
+	TaskShowAccountsGetTableStatsDurationHistogram = taskShortDurationHistogram.WithLabelValues("show_accounts_get_table_stats")
+	TaskShowAccountsGetUsageDurationHistogram      = taskShortDurationHistogram.WithLabelValues("show_accounts_get_storage_usage")
+	TaskShowAccountsTotalDurationHistogram         = taskShortDurationHistogram.WithLabelValues("show_accounts_total_duration")
 
 	taskLongDurationHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -241,15 +241,6 @@ var (
 	TxnDequeuePreparedDurationHistogram  = txnTNSideDurationHistogram.WithLabelValues("dequeue_prepared")
 	TxnBeforeCommitDurationHistogram     = txnTNSideDurationHistogram.WithLabelValues("before_txn_commit")
 
-	TxnShowAccountsDurationHistogram = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: "mo",
-			Subsystem: "txn",
-			Name:      "show_accounts_duration_seconds",
-			Help:      "Bucketed histogram of show accounts duration.",
-			Buckets:   prometheus.ExponentialBuckets(0.00001, 2.0, 20),
-		})
-
 	txnMpoolDurationHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "mo",

--- a/pkg/vm/engine/tae/db/test/storage_usage_test.go
+++ b/pkg/vm/engine/tae/db/test/storage_usage_test.go
@@ -39,6 +39,9 @@ import (
 func Test_StorageUsageCache(t *testing.T) {
 	// new cache with no option
 	cache := logtail.NewStorageUsageCache(logtail.WithLazyThreshold(1))
+	cache.Lock()
+	defer cache.Unlock()
+
 	require.True(t, cache.IsExpired())
 
 	allocator := atomic.Uint64{}
@@ -646,5 +649,4 @@ func Test_UpdateDataFromOldVersion(t *testing.T) {
 			require.Equal(t, uint64(0), size)
 		}
 	}
-
 }

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -1006,7 +1006,7 @@ func storageUsageDetails(c *storageUsageHistoryArg) (err error) {
 
 		size := float64(data.Size) / 1048576
 
-		dst.WriteString(fmt.Sprintf("\t[(acc)-%-8d (%*s)-%-8d (%*s)-%-8d] %s -> %12.6f (mb)\n",
+		dst.WriteString(fmt.Sprintf("\t[(acc)-%-10d (%*s)-%-10d (%*s)-%-10d] %s -> %15.6f (mb)\n",
 			data.AccId, maxDbLen, dbName, data.DbId,
 			maxTblLen, tblName, data.TblId, hint, size))
 
@@ -1092,7 +1092,7 @@ func storageTrace(c *storageUsageHistoryArg) (err error) {
 		}
 
 		size := float64(sizes[idx]) / 1048576
-		b.WriteString(fmt.Sprintf("\taccount id: %-8d\tsize: %12.6f\thint: %s\n",
+		b.WriteString(fmt.Sprintf("\taccount id: %-10d\tsize: %15.6f\thint: %s\n",
 			accIds[idx], size, hints[idx]))
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13920

## What this PR does / why we need it:
1. add sync.lock to avoid data race when cache.IsExpired().
2. split the show accounts duration metric to different phases.