### PR TITLE
fileservice: use direct io in disk cache read and write

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/matrixorigin/simdcsv v0.0.0-20230210060146-09b8e45209dd
 	github.com/minio/minio-go/v7 v7.0.63
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
+	github.com/ncw/directio v1.0.5-0.20220118110502-743c0ba8bd96
 	github.com/panjf2000/ants/v2 v2.7.4
 	github.com/petermattis/goid v0.0.0-20230518223814-80aa455d8761
 	github.com/pierrec/lz4/v4 v4.1.17

--- a/go.sum
+++ b/go.sum
@@ -418,6 +418,8 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/ncw/directio v1.0.5-0.20220118110502-743c0ba8bd96 h1:TywQJFKTpfATN/R2TzLQMwJg44thV4gjgFixtGboWPI=
+github.com/ncw/directio v1.0.5-0.20220118110502-743c0ba8bd96/go.mod h1:CKGdcN7StAaqjT7Qack3lAXeX4pjnyc46YeqZH1yWVY=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -36,6 +36,7 @@ type CacheConfig struct {
 	DiskCapacity         *toml.ByteSize `toml:"disk-capacity"`
 	DiskMinEvictInterval *toml.Duration `toml:"disk-min-evict-interval"`
 	DiskEvictTarget      *float64       `toml:"disk-evict-target"`
+	UseDirectIO          bool           `toml:"use-directio"`
 	RemoteCacheEnabled   bool           `toml:"remote-cache-enabled"`
 	RPC                  morpc.Config   `toml:"rpc"`
 

--- a/pkg/fileservice/io_entry.go
+++ b/pkg/fileservice/io_entry.go
@@ -42,7 +42,10 @@ func (i *IOEntry) ReadFromOSFile(file *os.File) error {
 		i.Data = make([]byte, i.Size)
 	}
 
-	n, err := io.ReadFull(r, i.Data)
+	var buf []byte
+	put := directioBufferPool.Get(&buf)
+	defer put.Put()
+	n, err := ReadFullBuffer(r, i.Data, buf)
 	if err != nil {
 		return err
 	}

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -140,6 +140,7 @@ func (l *LocalFS) initCaches(ctx context.Context, config CacheConfig) error {
 				*config.DiskPath,
 				int(*config.DiskCapacity),
 				l.perfCounterSets,
+				config.UseDirectIO,
 			)
 			if err != nil {
 				return err

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -143,6 +143,7 @@ func (s *S3FS) initCaches(ctx context.Context, config CacheConfig) error {
 			*config.DiskPath,
 			int(*config.DiskCapacity),
 			s.perfCounterSets,
+			config.UseDirectIO,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13010 

## What this PR does / why we need it:
add support for direct I/O in file service