### PR TITLE
Add memory leak for mpool

### DIFF
--- a/pkg/common/mpool/alloc.go
+++ b/pkg/common/mpool/alloc.go
@@ -1,0 +1,36 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !race
+// +build !race
+
+package mpool
+
+import (
+	"unsafe"
+)
+
+func alloc(sz, requiredSpaceWithoutHeader int, mp *MPool) []byte {
+	bs := make([]byte, requiredSpaceWithoutHeader+kMemHdrSz)
+	hdr := unsafe.Pointer(&bs[0])
+	pHdr := (*memHdr)(hdr)
+	pHdr.poolId = mp.id
+	pHdr.fixedPoolIdx = NumFixedPool
+	pHdr.allocSz = int32(sz)
+	pHdr.SetGuard()
+	if mp.details != nil {
+		mp.details.recordAlloc(int64(pHdr.allocSz))
+	}
+	return pHdr.ToSlice(sz, requiredSpaceWithoutHeader)
+}

--- a/pkg/common/mpool/alloc_tracing.go
+++ b/pkg/common/mpool/alloc_tracing.go
@@ -1,0 +1,53 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build race
+// +build race
+
+package mpool
+
+import (
+	"runtime"
+	"runtime/debug"
+	"unsafe"
+
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"go.uber.org/zap"
+)
+
+func alloc(sz, requiredSpaceWithoutHeader int, mp *MPool) []byte {
+	bs := make([]byte, requiredSpaceWithoutHeader+kMemHdrSz)
+	hdr := unsafe.Pointer(&bs[0])
+	pHdr := (*memHdr)(hdr)
+	pHdr.poolId = mp.id
+	pHdr.fixedPoolIdx = NumFixedPool
+	pHdr.allocSz = int32(sz)
+	pHdr.SetGuard()
+	if mp.details != nil {
+		mp.details.recordAlloc(int64(pHdr.allocSz))
+	}
+	b := pHdr.ToSlice(sz, requiredSpaceWithoutHeader)
+	stack := string(debug.Stack())
+	runtime.SetFinalizer(b, func(hdr unsafe.Pointer) {
+		pHdr := (*memHdr)(hdr)
+		if atomic.LoadInt32(&pHdr.allocSz) >= 0 {
+			logutil.Error("memory leak detected",
+				zap.Any("ptr", pHdr),
+				zap.Int("size", int(pHdr.allocSz)),
+				zap.String("stack", stack),
+			)
+		}
+	})
+	return b
+}

--- a/pkg/common/mpool/mpool.go
+++ b/pkg/common/mpool/mpool.go
@@ -157,6 +157,12 @@ func (pHdr *memHdr) CheckGuard() bool {
 	return pHdr.guard[0] == 0xDE && pHdr.guard[1] == 0xAD && pHdr.guard[2] == 0xBF
 }
 
+func (pHdr *memHdr) ClearGuard() {
+	pHdr.guard[0] = 0
+	pHdr.guard[1] = 0
+	pHdr.guard[2] = 0
+}
+
 func (pHdr *memHdr) ToSlice(sz, cap int) []byte {
 	ptr := unsafe.Add(unsafe.Pointer(pHdr), kMemHdrSz)
 	bs := unsafe.Slice((*byte)(ptr), cap)
@@ -595,18 +601,7 @@ func (mp *MPool) Alloc(sz int) ([]byte, error) {
 		return bs.ToSlice(sz, int(mp.pools[idx].eleSz)), nil
 	}
 
-	// allocate.
-	bs := make([]byte, requiredSpaceWithoutHeader+kMemHdrSz)
-	hdr := unsafe.Pointer(&bs[0])
-	pHdr := (*memHdr)(hdr)
-	pHdr.poolId = mp.id
-	pHdr.fixedPoolIdx = NumFixedPool
-	pHdr.allocSz = int32(sz)
-	pHdr.SetGuard()
-	if mp.details != nil {
-		mp.details.recordAlloc(int64(pHdr.allocSz))
-	}
-	return pHdr.ToSlice(sz, requiredSpaceWithoutHeader), nil
+	return alloc(sz, requiredSpaceWithoutHeader, mp), nil
 }
 
 func (mp *MPool) Free(bs []byte) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [X] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13897

## What this PR does / why we need it:
* 使用mpool的调用方目前存在不少泄漏，最终会导致报oom
* 增加一个可选的leak检测开关，在开启race后，这个检测会自动开启