### PR TITLE
sync_to_1.1: avoiding load object meta when object stats are valid in `mo_table_size` and `metadata_scan`

### DIFF
--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -187,6 +187,7 @@ func MoTableSize(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 			if err != nil {
 				if moerr.IsMoErrCode(err, moerr.OkExpectedEOB) {
 					DebugGetDatabaseExpectedEOB("MoTableSize", proc)
+					return moerr.NewBadDBNoCtx(dbStr)
 				}
 				return err
 			}

--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -143,6 +143,10 @@ func MoTableRows(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 	return nil
 }
 
+// TODO(ghs)
+// is debug for #13151, will remove later
+var DebugGetDatabaseExpectedEOB func(caller string, proc *process.Process)
+
 // MoTableSize returns an estimated size of a table.
 func MoTableSize(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int) error {
 	rs := vector.MustFunctionResult[int64](result)
@@ -181,6 +185,9 @@ func MoTableSize(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 			ctx := proc.Ctx
 			dbo, err := e.Database(ctx, dbStr, txn)
 			if err != nil {
+				if moerr.IsMoErrCode(err, moerr.OkExpectedEOB) {
+					DebugGetDatabaseExpectedEOB("MoTableSize", proc)
+				}
 				return err
 			}
 			rel, err = dbo.Relation(ctx, tblStr, nil)

--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -78,6 +78,12 @@ func MoTableRows(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 			ctx := proc.Ctx
 			dbo, err := e.Database(ctx, dbStr, txn)
 			if err != nil {
+				if moerr.IsMoErrCode(err, moerr.OkExpectedEOB) {
+					if DebugGetDatabaseExpectedEOB != nil {
+						DebugGetDatabaseExpectedEOB("MoTableRows", proc)
+					}
+					return moerr.NewInvalidArgNoCtx("db not found when mo_table_rows", dbStr)
+				}
 				return err
 			}
 			rel, err = dbo.Relation(ctx, tblStr, nil)
@@ -186,8 +192,10 @@ func MoTableSize(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 			dbo, err := e.Database(ctx, dbStr, txn)
 			if err != nil {
 				if moerr.IsMoErrCode(err, moerr.OkExpectedEOB) {
-					DebugGetDatabaseExpectedEOB("MoTableSize", proc)
-					return moerr.NewBadDBNoCtx(dbStr)
+					if DebugGetDatabaseExpectedEOB != nil {
+						DebugGetDatabaseExpectedEOB("MoTableSize", proc)
+					}
+					return moerr.NewInvalidArgNoCtx("db not found when mo_table_size", dbStr)
 				}
 				return err
 			}

--- a/pkg/vm/engine/disttae/cache/catalog.go
+++ b/pkg/vm/engine/disttae/cache/catalog.go
@@ -794,7 +794,7 @@ type DebugTableItem struct {
 
 func (dt *DebugTableItem) String() string {
 	return fmt.Sprintf("%d-%d-%d-%s-%v-%s",
-		dt.AccountId, dt.DatabaseId, dt.Id, dt.Name, dt.Deleted, dt.Ts.String())
+		dt.AccountId, dt.DatabaseId, dt.Id, dt.Name, dt.Deleted, types.TimestampToTS(dt.Ts).ToString())
 }
 
 type DebugDatabaseItem struct {
@@ -807,7 +807,7 @@ type DebugDatabaseItem struct {
 
 func (dd *DebugDatabaseItem) String() string {
 	return fmt.Sprintf("%d-%d-%s-%v-%s",
-		dd.AccountId, dd.Id, dd.Name, dd.Deleted, dd.Ts.String())
+		dd.AccountId, dd.Id, dd.Name, dd.Deleted, types.TimestampToTS(dd.Ts).ToString())
 }
 
 func (c *tableCache) TraverseTableCache() (ret []DebugTableItem) {

--- a/pkg/vm/engine/disttae/cache/catalog.go
+++ b/pkg/vm/engine/disttae/cache/catalog.go
@@ -774,3 +774,67 @@ func getTableDef(tblItem *TableItem, coldefs []engine.TableDef) *plan.TableDef {
 		Version:       tblItem.Version,
 	}
 }
+
+// TODO(ghs)
+// is debug for #13151, will remove later
+func (cc *CatalogCache) TraverseDbAndTbl() (dbs []DebugDatabaseItem, tbls []DebugTableItem) {
+	dbs = cc.databases.TraverseDatabaseCache()
+	tbls = cc.tables.TraverseTableCache()
+	return
+}
+
+type DebugTableItem struct {
+	AccountId  uint32
+	DatabaseId uint64
+	Name       string
+	Ts         timestamp.Timestamp
+	Id         uint64
+	Deleted    bool
+}
+
+func (dt *DebugTableItem) String() string {
+	return fmt.Sprintf("%d-%d-%d-%s-%v-%s",
+		dt.AccountId, dt.DatabaseId, dt.Id, dt.Name, dt.Deleted, dt.Ts.String())
+}
+
+type DebugDatabaseItem struct {
+	AccountId uint32
+	Name      string
+	Ts        timestamp.Timestamp
+	Id        uint64
+	Deleted   bool
+}
+
+func (dd *DebugDatabaseItem) String() string {
+	return fmt.Sprintf("%d-%d-%s-%v-%s",
+		dd.AccountId, dd.Id, dd.Name, dd.Deleted, dd.Ts.String())
+}
+
+func (c *tableCache) TraverseTableCache() (ret []DebugTableItem) {
+	c.data.Scan(func(tblItem *TableItem) bool {
+		ret = append(ret, DebugTableItem{
+			Ts:         tblItem.Ts,
+			Id:         tblItem.Id,
+			Name:       tblItem.Name,
+			Deleted:    tblItem.deleted,
+			AccountId:  tblItem.AccountId,
+			DatabaseId: tblItem.DatabaseId,
+		})
+		return true
+	})
+	return
+}
+
+func (t *databaseCache) TraverseDatabaseCache() (ret []DebugDatabaseItem) {
+	t.data.Scan(func(dbItem *DatabaseItem) bool {
+		ret = append(ret, DebugDatabaseItem{
+			Ts:        dbItem.Ts,
+			Id:        dbItem.Id,
+			Name:      dbItem.Name,
+			Deleted:   dbItem.deleted,
+			AccountId: dbItem.AccountId,
+		})
+		return true
+	})
+	return
+}

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -15,15 +15,14 @@
 package disttae
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/matrixorigin/matrixone/pkg/logservice"
-
-	txn2 "github.com/matrixorigin/matrixone/pkg/pb/txn"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
@@ -35,12 +34,15 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/lockservice"
+	"github.com/matrixorigin/matrixone/pkg/logservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	txn2 "github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/util/errutil"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
@@ -103,7 +105,62 @@ func New(
 		panic(err)
 	}
 
+	// TODO(ghs)
+	// is debug for #13151, will remove later
+	e.enableDebug()
+
 	return e
+}
+
+func (e *Engine) enableDebug() {
+	function.DebugGetDatabaseExpectedEOB = func(caller string, proc *process.Process) {
+		txnState := fmt.Sprintf("account-%s, accId-%d, user-%s, role-%s, timezone-%s, txn-%s",
+			proc.SessionInfo.Account, proc.SessionInfo.AccountId,
+			proc.SessionInfo.User, proc.SessionInfo.Role,
+			proc.SessionInfo.TimeZone.String(),
+			proc.TxnOperator.Txn().DebugString(),
+		)
+		e.DebugGetDatabaseExpectedEOB(caller, txnState)
+	}
+}
+
+func (e *Engine) DebugGetDatabaseExpectedEOB(caller string, txnState string) {
+	dbs, tbls := e.catalog.TraverseDbAndTbl()
+	sort.Slice(dbs, func(i, j int) bool {
+		if dbs[i].AccountId != dbs[j].AccountId {
+			return dbs[i].AccountId < dbs[j].AccountId
+		}
+		return dbs[i].Id < dbs[j].Id
+	})
+
+	sort.Slice(tbls, func(i, j int) bool {
+		if tbls[i].AccountId != tbls[j].AccountId {
+			return tbls[i].AccountId < tbls[j].AccountId
+		}
+
+		if tbls[i].DatabaseId != tbls[j].DatabaseId {
+			return tbls[i].DatabaseId < tbls[j].DatabaseId
+		}
+
+		return tbls[i].Id < tbls[j].Id
+	})
+
+	var out bytes.Buffer
+	tIdx := 0
+	for idx := range dbs {
+		out.WriteString(fmt.Sprintf("%s\n", dbs[idx].String()))
+		for ; tIdx < len(tbls); tIdx++ {
+			if tbls[tIdx].AccountId != dbs[idx].AccountId ||
+				tbls[tIdx].DatabaseId != dbs[idx].Id {
+				break
+			}
+
+			out.WriteString(fmt.Sprintf("\t%s\n", tbls[tIdx].String()))
+		}
+	}
+
+	logutil.Infof("%s.Database got ExpectEOB, current txn state: \n%s\n%s",
+		caller, txnState, out.String())
 }
 
 func (e *Engine) Create(ctx context.Context, name string, op client.TxnOperator) error {

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -192,6 +192,10 @@ func (o ObjectEntry) Location() objectio.Location {
 	return o.ObjectLocation()
 }
 
+func (o ObjectInfo) StatsValid() bool {
+	return o.ObjectStats.Rows() != 0
+}
+
 type ObjectIndexByCreateTSEntry struct {
 	ObjectInfo
 }

--- a/test/distributed/cases/function/table_func_metadata_scan.sql
+++ b/test/distributed/cases/function/table_func_metadata_scan.sql
@@ -22,7 +22,9 @@ select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g;
 select count(*) from metadata_scan('table_func_metadata_scan.t', 'a') g;
 select count(*) from metadata_scan('table_func_metadata_scan.t', 'f') g;
 select col_name, rows_cnt, null_cnt, origin_size from metadata_scan('table_func_metadata_scan.t', 'a') g;
+-- @ignore:2,3
 select col_name, rows_cnt, null_cnt, origin_size from metadata_scan('table_func_metadata_scan.t', '*') g;
+-- @ignore:0
 select sum(origin_size) from metadata_scan('table_func_metadata_scan.t', '*') g;
 select min(bit_cast(`min` as int)), max(bit_cast(`max` as int)), sum(bit_cast(`sum` as bigint)) from metadata_scan('table_func_metadata_scan.t', 'a') g;
 select sum(bit_cast(`sum` as double)) from metadata_scan('table_func_metadata_scan.t', 'c') g;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:


issue #13013 #13151 

## What this PR does / why we need it:
1. adding debug log to dump catalog cache  when `ExpectedEOB` for #13151 
2. avoid loading object meta when object stats are valid when `mo_table_size` and `metadata_scan`.