### PR TITLE
enable pkfilter for auto incr type

### DIFF
--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -465,9 +465,9 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 				}
 				// one of pk cols is incr col and this col was not in values.
 				// we can not use the values of other cols as filterExpr.
-				if len(tableDef.Pkey.Names) != len(pkPosInValues) {
-					pkPosInValues = make(map[int]int)
-				}
+				// if len(tableDef.Pkey.Names) != len(pkPosInValues) {
+				// 	pkPosInValues = make(map[int]int)
+				// }
 			}
 		}
 

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -274,15 +274,12 @@ func getPkValueExpr(builder *QueryBuilder, ctx CompilerContext, tableDef *TableD
 	if builder.qry.Nodes[0].NodeType != plan.Node_VALUE_SCAN {
 		return nil
 	}
-	pkPos, pkTyp := getPkPos(tableDef, true)
+	pkPos, _ := getPkPos(tableDef, true)
 	if pkPos == -1 {
 		if tableDef.Pkey.PkeyColName != catalog.CPrimaryKeyColName {
 			return nil
 		}
-	} else if pkTyp.AutoIncr {
-		return nil
 	}
-
 	node := builder.qry.Nodes[0]
 
 	proc := ctx.GetProcess()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue#13918

## What this PR does / why we need it:

cloud_device.real_time_position的表结构在修改之后primary key是包含auto increment的, 发现它没有打开pkfilter, 现在先打开来试试

https://github.com/matrixorigin/MO-Cloud/issues/1329#issuecomment-1873285416