### PR TITLE
update default global version interval

### DIFF
--- a/pkg/vm/engine/tae/options/types.go
+++ b/pkg/vm/engine/tae/options/types.go
@@ -38,7 +38,7 @@ const (
 	DefaultCheckpointMinCount           = int64(100)
 	DefaultCheckpointIncremetalInterval = time.Minute
 	DefaultCheckpointGlobalMinCount     = 10
-	DefaultGlobalVersionInterval        = time.Hour
+	DefaultGlobalVersionInterval        = time.Minute * 5
 	DefaultGCCheckpointInterval         = time.Minute
 
 	DefaultScanGCInterval = time.Minute * 30


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13956 

## What this PR does / why we need it:
Set DefaultGlobalVersionInterval = 5min to skip more blk meta