### PR TITLE
fileservice: do not set default role arn from os env

### DIFF
--- a/pkg/fileservice/aliyun_sdk.go
+++ b/pkg/fileservice/aliyun_sdk.go
@@ -54,11 +54,6 @@ func NewAliyunSDK(
 	}
 
 	// env vars
-	if args.RoleARN == "" {
-		if v := os.Getenv("ALIBABA_CLOUD_ROLE_ARN"); v != "" {
-			args.RoleARN = v
-		}
-	}
 	if args.OIDCProviderARN == "" {
 		if v := os.Getenv("ALIBABA_CLOUD_OIDC_PROVIDER_ARN"); v != "" {
 			args.OIDCProviderARN = v
@@ -591,9 +586,18 @@ func (o ObjectStorageArguments) credentialProviderForAliyunSDK(
 		if o.ExternalID != "" {
 			config.ExternalId = &o.ExternalID
 		}
+
+		var roleARN string
+		// either from args or os env
 		if o.RoleARN != "" {
-			config.SetRoleArn(o.RoleARN)
+			roleARN = o.RoleARN
+		} else if v := os.Getenv("ALIBABA_CLOUD_ROLE_ARN"); v != "" {
+			roleARN = v
 		}
+		if roleARN != "" {
+			config.SetRoleArn(roleARN)
+		}
+
 		config.SetSessionExpiration(3600)
 
 	} else if o.RAMRole != "" {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13906 

## What this PR does / why we need it:
do not set role arn from env if not oidc credential