### PR TITLE
[cherry-pick] #13941 Remove an incorrectly timed dropout update that invalidates a live probe

### DIFF
--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -76,7 +76,6 @@ func (l *lockTableAllocator) Get(
 	if binds == nil {
 		binds = l.registerService(serviceID, tableID)
 	}
-	binds.active()
 	return l.registerBind(binds, tableID)
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13789

## What this PR does / why we need it:
* 在不需要更新时间的时候不应该更新时间，以免导致探活失效