### PR TITLE
fileservice: refine disk cache with fifo cache

### DIFF
--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +27,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/fileservice/fifocache"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
@@ -34,61 +35,78 @@ import (
 )
 
 type DiskCache struct {
-	capacity        int64
-	evictInterval   time.Duration
-	evictTarget     float64
 	path            string
-	fileExists      sync.Map
 	perfCounterSets []*perfcounter.CounterSet
-
-	evictState struct {
-		sync.Mutex
-		timer        *time.Timer
-		newlyWritten int64
-	}
-	noAutoEviction bool
 
 	updatingPaths struct {
 		*sync.Cond
 		m map[string]bool
 	}
+
+	cache *fifocache.Cache[string, struct{}]
 }
 
 func NewDiskCache(
 	ctx context.Context,
 	path string,
-	capacity int64,
-	evictInterval time.Duration,
-	evictTarget float64,
+	capacity int,
 	perfCounterSets []*perfcounter.CounterSet,
-) (*DiskCache, error) {
+) (ret *DiskCache, err error) {
 
-	if evictInterval == 0 {
-		panic("zero evict interval")
-	}
-	if evictTarget == 0 {
-		panic("zero evict target")
-	}
-	if evictTarget > 1 {
-		panic("evict target greater than 1")
-	}
-
-	err := os.MkdirAll(path, 0755)
+	err = os.MkdirAll(path, 0755)
 	if err != nil {
 		return nil, err
 	}
-	ret := &DiskCache{
-		capacity:        capacity,
-		evictInterval:   evictInterval,
-		evictTarget:     evictTarget,
+	ret = &DiskCache{
 		path:            path,
 		perfCounterSets: perfCounterSets,
+
+		cache: fifocache.New[string, struct{}](
+			capacity,
+			func(path string, _ struct{}) {
+				err := os.Remove(path)
+				if err == nil {
+					perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
+						set.FileService.Cache.Disk.Evict.Add(1)
+					}, perfCounterSets...)
+				}
+			},
+		),
 	}
-	ret.triggerEvict(ctx, 0)
-	ret.triggerEvict(ctx, capacity) // trigger an immediately eviction
 	ret.updatingPaths.Cond = sync.NewCond(new(sync.Mutex))
 	ret.updatingPaths.m = make(map[string]bool)
+
+	ret.loadCache()
+
 	return ret, nil
+}
+
+func (d *DiskCache) loadCache() {
+
+	_ = filepath.WalkDir(d.path, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return nil //ignore
+		}
+		if entry.IsDir() {
+			// try remove if empty. for cleaning old structure
+			if path != d.path {
+				os.Remove(path)
+			}
+			return nil
+		}
+		if !strings.HasSuffix(entry.Name(), cacheFileSuffix) {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil // ignore
+		}
+
+		d.cache.Set(path, struct{}{}, int(fileSize(info)))
+
+		return nil
+	})
+
 }
 
 var _ IOVectorCache = new(DiskCache)
@@ -149,7 +167,7 @@ func (d *DiskCache) Read(
 
 		if file == nil {
 			// full file
-			diskPath := d.pathForFile(path.File)
+			diskPath = d.pathForFile(path.File)
 			d.waitUpdateComplete(diskPath)
 			diskFile, err := os.Open(diskPath)
 			if err == nil {
@@ -166,6 +184,15 @@ func (d *DiskCache) Read(
 		if file == nil {
 			// no file available
 			continue
+		}
+
+		if _, ok := d.cache.Get(diskPath); !ok {
+			// set cache
+			stat, err := file.Stat()
+			if err != nil {
+				return err
+			}
+			d.cache.Set(diskPath, struct{}{}, int(fileSize(stat)))
 		}
 
 		if err := entry.ReadFromOSFile(file); err != nil {
@@ -262,14 +289,14 @@ func (d *DiskCache) writeFile(
 	doneUpdate := d.startUpdate(diskPath)
 	defer doneUpdate()
 
-	if _, ok := d.fileExists.Load(diskPath); ok {
+	if _, ok := d.cache.Get(diskPath); ok {
 		// already exists
 		return false, nil
 	}
-	_, err := os.Stat(diskPath)
+	stat, err := os.Stat(diskPath)
 	if err == nil {
 		// file exists
-		d.fileExists.Store(diskPath, true)
+		d.cache.Set(diskPath, struct{}{}, int(fileSize(stat)))
 		numStat++
 		return false, nil
 	}
@@ -299,7 +326,7 @@ func (d *DiskCache) writeFile(
 	var buf []byte
 	put := ioBufferPool.Get(&buf)
 	defer put.Put()
-	n, err := io.CopyBuffer(f, from, buf)
+	_, err = io.CopyBuffer(f, from, buf)
 	if err != nil {
 		f.Close()
 		os.Remove(f.Name())
@@ -307,6 +334,22 @@ func (d *DiskCache) writeFile(
 		logutil.Warn("write disk cache error", zap.Any("error", err))
 		return false, nil // ignore error
 	}
+
+	if err := f.Sync(); err != nil {
+		numError++
+		logutil.Warn("write disk cache error", zap.Any("error", err))
+		return false, nil // ignore error
+	}
+
+	// set cache
+	stat, err = f.Stat()
+	if err != nil {
+		numError++
+		logutil.Warn("write disk cache error", zap.Any("error", err))
+		return false, nil // ignore error
+	}
+	d.cache.Set(diskPath, struct{}{}, int(fileSize(stat)))
+
 	if err := f.Close(); err != nil {
 		numError++
 		logutil.Warn("write disk cache error", zap.Any("error", err))
@@ -322,159 +365,11 @@ func (d *DiskCache) writeFile(
 	)
 
 	numWrite++
-	d.triggerEvict(ctx, int64(n))
-	d.fileExists.Store(diskPath, true)
 
 	return true, nil
 }
 
 func (d *DiskCache) Flush() {
-	//TODO
-}
-
-func (d *DiskCache) triggerEvict(ctx context.Context, bytesWritten int64) {
-	if d.noAutoEviction {
-		return
-	}
-
-	d.evictState.Lock()
-	defer d.evictState.Unlock()
-
-	d.evictState.newlyWritten += bytesWritten
-
-	if d.evictState.timer != nil {
-		// has pending eviction
-
-		newlyWrittenThreshold := int64(math.Ceil(float64(d.capacity) * (1 - d.evictTarget)))
-		if newlyWrittenThreshold > 0 && d.evictState.newlyWritten >= newlyWrittenThreshold {
-			if d.evictState.timer.Stop() {
-				// evict immediately
-				logutil.Info("disk cache: newly written bytes may excceeds eviction target, start immediately",
-					zap.Any("newly-written", d.evictState.newlyWritten),
-					zap.Any("newly-written-threshold", newlyWrittenThreshold),
-				)
-				// timer stopped, start eviction
-				// before the following eviction is end, further calls of triggerEvict will not go this path, since timer.Stop will return false
-				perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
-					set.FileService.Cache.Disk.EvictImmediately.Add(1)
-				}, d.perfCounterSets...)
-				go func() {
-					defer func() {
-						d.evictState.Lock()
-						d.evictState.timer = nil
-						d.evictState.newlyWritten = 0
-						d.evictState.Unlock()
-					}()
-					d.evict(ctx)
-				}()
-			}
-			return
-		}
-
-		return
-	}
-
-	perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
-		set.FileService.Cache.Disk.EvictPending.Add(1)
-	}, d.perfCounterSets...)
-	d.evictState.timer = time.AfterFunc(
-		d.evictInterval,
-		func() {
-			defer func() {
-				d.evictState.Lock()
-				d.evictState.timer = nil
-				d.evictState.newlyWritten = 0
-				d.evictState.Unlock()
-			}()
-			d.evict(ctx)
-		},
-	)
-}
-
-func (d *DiskCache) evict(ctx context.Context) {
-	paths := make(map[string]int64)
-	var sumSize int64
-
-	_ = filepath.WalkDir(d.path, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return nil //ignore
-		}
-		if entry.IsDir() {
-			// try remove if empty. for cleaning old structure
-			if path != d.path {
-				os.Remove(path)
-			}
-			return nil
-		}
-		if !strings.HasSuffix(entry.Name(), cacheFileSuffix) {
-			return nil
-		}
-		info, err := entry.Info()
-		if err != nil {
-			return nil // ignore
-		}
-
-		var size int64
-		if sys, ok := info.Sys().(*syscall.Stat_t); ok {
-			size = int64(sys.Blocks) * 512 // it's always 512, not sys.Blksize
-		} else {
-			size = info.Size()
-		}
-
-		if _, ok := paths[path]; !ok {
-			paths[path] = size
-			sumSize += size
-		}
-		return nil
-	})
-
-	target := int64(float64(d.capacity) * d.evictTarget)
-
-	logutil.Info("disk cache eviction check",
-		zap.Any("used bytes", sumSize),
-		zap.Any("target", target),
-	)
-
-	var numDeleted int64
-	var bytesDeleted int64
-	defer func() {
-		if numDeleted > 0 {
-			perfcounter.Update(ctx, func(set *perfcounter.CounterSet) {
-				set.FileService.Cache.Disk.Evict.Add(numDeleted)
-			}, d.perfCounterSets...)
-			logutil.Info("disk cache eviction finished",
-				zap.Any("deleted files", numDeleted),
-				zap.Any("deleted bytes", bytesDeleted),
-			)
-		}
-	}()
-
-	var onEvict []OnDiskCacheEvictFunc
-	if v := ctx.Value(CtxKeyDiskCacheCallbacks); v != nil {
-		onEvict = v.(*DiskCacheCallbacks).OnEvict
-	}
-
-	for path, size := range paths {
-		if sumSize <= target {
-			break
-		}
-		if err := os.Remove(path); err != nil {
-			continue // ignore
-		} else {
-			logutil.Debug("disk cache file removed",
-				zap.Any("path", path),
-			)
-		}
-		d.fileExists.Delete(path)
-		sumSize -= size
-		numDeleted++
-		bytesDeleted += size
-
-		for _, fn := range onEvict {
-			fn(path)
-		}
-
-	}
 }
 
 const cacheFileSuffix = ".mofscache"
@@ -562,8 +457,6 @@ func (d *DiskCache) DeletePaths(
 		doneUpdate := d.startUpdate(diskPath)
 		defer doneUpdate()
 
-		d.fileExists.Delete(diskPath)
-
 		if err := os.Remove(diskPath); err != nil {
 			if !os.IsNotExist(err) {
 				return err
@@ -572,4 +465,11 @@ func (d *DiskCache) DeletePaths(
 	}
 
 	return nil
+}
+
+func fileSize(info fs.FileInfo) int64 {
+	if sys, ok := info.Sys().(*syscall.Stat_t); ok {
+		return int64(sys.Blocks) * 512 // it's always 512, not sys.Blksize
+	}
+	return info.Size()
 }

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -17,9 +17,11 @@ package fileservice
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"io/fs"
+	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +38,7 @@ func TestDiskCache(t *testing.T) {
 	})
 
 	// new
-	cache, err := NewDiskCache(ctx, dir, 1024, time.Second, 1, nil)
+	cache, err := NewDiskCache(ctx, dir, 1<<20, nil)
 	assert.Nil(t, err)
 
 	// update
@@ -102,6 +104,7 @@ func TestDiskCache(t *testing.T) {
 		}
 		err = cache.Read(ctx, vec)
 		assert.Nil(t, err)
+		assert.NotNil(t, r)
 		defer r.Close()
 		assert.True(t, vec.Entries[0].done)
 		assert.Equal(t, []byte("a"), vec.Entries[0].Data)
@@ -118,14 +121,14 @@ func TestDiskCache(t *testing.T) {
 	testRead(cache)
 
 	// new cache instance and read
-	cache, err = NewDiskCache(ctx, dir, 1024, time.Second, 1, nil)
+	cache, err = NewDiskCache(ctx, dir, 1<<20, nil)
 	assert.Nil(t, err)
 	testRead(cache)
 
 	assert.Equal(t, 1, numWritten)
 
 	// new cache instance and update
-	cache, err = NewDiskCache(ctx, dir, 1024, time.Second, 1, nil)
+	cache, err = NewDiskCache(ctx, dir, 1<<20, nil)
 	assert.Nil(t, err)
 	testUpdate(cache)
 
@@ -137,15 +140,14 @@ func TestDiskCache(t *testing.T) {
 }
 
 func TestDiskCacheWriteAgain(t *testing.T) {
+
 	dir := t.TempDir()
 	ctx := context.Background()
 	var counterSet perfcounter.CounterSet
 	ctx = perfcounter.WithCounterSet(ctx, &counterSet)
 
-	evictInterval := time.Hour * 1
-	cache, err := NewDiskCache(ctx, dir, 3, evictInterval, 0.8, nil)
+	cache, err := NewDiskCache(ctx, dir, 4096, nil)
 	assert.Nil(t, err)
-	cache.noAutoEviction = true
 
 	// update
 	err = cache.Update(ctx, &IOVector{
@@ -159,6 +161,7 @@ func TestDiskCacheWriteAgain(t *testing.T) {
 	}, false)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), counterSet.FileService.Cache.Disk.WriteFile.Load())
+	assert.Equal(t, int64(0), counterSet.FileService.Cache.Disk.Evict.Load())
 
 	// update another entry
 	err = cache.Update(ctx, &IOVector{
@@ -173,8 +176,7 @@ func TestDiskCacheWriteAgain(t *testing.T) {
 	}, false)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(2), counterSet.FileService.Cache.Disk.WriteFile.Load())
-
-	cache.evict(ctx)
+	assert.Equal(t, int64(1), counterSet.FileService.Cache.Disk.Evict.Load())
 
 	// update again, should write cache file again
 	err = cache.Update(ctx, &IOVector{
@@ -188,6 +190,7 @@ func TestDiskCacheWriteAgain(t *testing.T) {
 	}, false)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(3), counterSet.FileService.Cache.Disk.WriteFile.Load())
+	assert.Equal(t, int64(2), counterSet.FileService.Cache.Disk.Evict.Load())
 
 	err = cache.Read(ctx, &IOVector{
 		FilePath: "foo",
@@ -205,7 +208,7 @@ func TestDiskCacheWriteAgain(t *testing.T) {
 func TestDiskCacheFileCache(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
-	cache, err := NewDiskCache(ctx, dir, 1024, time.Second, 1, nil)
+	cache, err := NewDiskCache(ctx, dir, 1<<20, nil)
 	assert.Nil(t, err)
 
 	vector := IOVector{
@@ -254,4 +257,53 @@ func TestDiskCacheFileCache(t *testing.T) {
 	assert.Equal(t, []byte("ob"), readVector.Entries[1].Data)
 	assert.Equal(t, []byte("ar"), readVector.Entries[2].Data)
 
+}
+
+func TestDiskCacheDirSize(t *testing.T) {
+	ctx := context.Background()
+	var counter perfcounter.CounterSet
+	ctx = perfcounter.WithCounterSet(ctx, &counter)
+
+	dir := t.TempDir()
+	capacity := 1 << 20
+	cache, err := NewDiskCache(ctx, dir, capacity, nil)
+	assert.Nil(t, err)
+
+	data := bytes.Repeat([]byte("a"), capacity/128)
+	for i := 0; i < capacity/len(data)*64; i++ {
+		err := cache.Update(ctx, &IOVector{
+			FilePath: fmt.Sprintf("%v", i),
+			Entries: []IOEntry{
+				{
+					Offset: 0,
+					Size:   int64(len(data)),
+					Data:   data,
+				},
+			},
+		}, false)
+		assert.Nil(t, err)
+		size := dirSize(dir)
+		assert.LessOrEqual(t, size, capacity)
+	}
+	assert.True(t, counter.FileService.Cache.Disk.Evict.Load() > 0)
+}
+
+func dirSize(path string) (ret int) {
+	if err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		stat, err := d.Info()
+		if err != nil {
+			return err
+		}
+		ret += int(fileSize(stat))
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+	return
 }

--- a/pkg/fileservice/fifocache/bench_test.go
+++ b/pkg/fileservice/fifocache/bench_test.go
@@ -1,0 +1,85 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fifocache
+
+import (
+	"testing"
+)
+
+func BenchmarkSequentialSet(b *testing.B) {
+	size := 65536
+	cache := New[int, int](size, nil)
+	nElements := size * 16
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Set(i%nElements, i, 1+i%3)
+	}
+}
+
+func BenchmarkParallelSet(b *testing.B) {
+	size := 65536
+	cache := New[int, int](size, nil)
+	nElements := size * 16
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for i := 0; pb.Next(); i++ {
+			cache.Set(i%nElements, i, 1+i%3)
+		}
+	})
+}
+
+func BenchmarkGet(b *testing.B) {
+	size := 65536
+	cache := New[int, int](size, nil)
+	nElements := size * 16
+	for i := 0; i < b.N; i++ {
+		cache.Set(i%nElements, i, 1+i%3)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Get(i % nElements)
+	}
+}
+
+func BenchmarkParallelGet(b *testing.B) {
+	size := 65536
+	cache := New[int, int](size, nil)
+	nElements := size * 16
+	for i := 0; i < b.N; i++ {
+		cache.Set(i%nElements, i, 1+i%3)
+	}
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for i := 0; pb.Next(); i++ {
+			cache.Get(i % nElements)
+		}
+	})
+}
+
+func BenchmarkParallelGetOrSet(b *testing.B) {
+	size := 65536
+	cache := New[int, int](size, nil)
+	nElements := size * 16
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for i := 0; pb.Next(); i++ {
+			if i%2 == 0 {
+				cache.Get(i % nElements)
+			} else {
+				cache.Set(i%nElements, i, 1+i%3)
+			}
+		}
+	})
+}

--- a/pkg/fileservice/fifocache/fifo.go
+++ b/pkg/fileservice/fifocache/fifo.go
@@ -1,0 +1,184 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fifocache
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Cache implements an in-memory cache with FIFO-based eviction
+// it's mostly like the S3-fifo, only without the ghost queue part
+type Cache[K comparable, V any] struct {
+	capacity  int
+	capacity1 int
+	onEvict   func(K, V)
+
+	mapLock sync.RWMutex
+	values  map[K]*_CacheItem[K, V]
+
+	queueLock sync.Mutex
+	used1     int
+	queue1    Queue[*_CacheItem[K, V]]
+	used2     int
+	queue2    Queue[*_CacheItem[K, V]]
+}
+
+type _CacheItem[K comparable, V any] struct {
+	key   K
+	value V
+	size  int
+	count atomic.Int32
+}
+
+func (c *_CacheItem[K, V]) inc() {
+	for {
+		cur := c.count.Load()
+		if cur >= 3 {
+			return
+		}
+		if c.count.CompareAndSwap(cur, cur+1) {
+			return
+		}
+	}
+}
+
+func (c *_CacheItem[K, V]) dec() {
+	for {
+		cur := c.count.Load()
+		if cur <= 0 {
+			return
+		}
+		if c.count.CompareAndSwap(cur, cur-1) {
+			return
+		}
+	}
+}
+
+func New[K comparable, V any](
+	capacity int,
+	onEvict func(K, V),
+) *Cache[K, V] {
+	return &Cache[K, V]{
+		capacity:  capacity,
+		capacity1: capacity / 10,
+		values:    make(map[K]*_CacheItem[K, V]),
+		queue1:    *NewQueue[*_CacheItem[K, V]](),
+		queue2:    *NewQueue[*_CacheItem[K, V]](),
+		onEvict:   onEvict,
+	}
+}
+
+func (c *Cache[K, V]) Set(key K, value V, size int) {
+	c.mapLock.Lock()
+	_, ok := c.values[key]
+	if ok {
+		// existed
+		c.mapLock.Unlock()
+		return
+	}
+
+	item := &_CacheItem[K, V]{
+		key:   key,
+		value: value,
+		size:  size,
+	}
+	c.values[key] = item
+	c.mapLock.Unlock()
+
+	c.queueLock.Lock()
+	defer c.queueLock.Unlock()
+	c.queue1.enqueue(item)
+	c.used1 += size
+	if c.used1+c.used2 > c.capacity {
+		c.evict()
+	}
+}
+
+func (c *Cache[K, V]) Get(key K) (value V, ok bool) {
+	c.mapLock.RLock()
+	var item *_CacheItem[K, V]
+	item, ok = c.values[key]
+	if !ok {
+		c.mapLock.RUnlock()
+		return
+	}
+	c.mapLock.RUnlock()
+	item.inc()
+	return item.value, true
+}
+
+func (c *Cache[K, V]) evict() {
+	for c.used1+c.used2 > c.capacity {
+		if c.used1 > c.capacity1 {
+			c.evict1()
+		} else {
+			c.evict2()
+		}
+	}
+}
+
+func (c *Cache[K, V]) evict1() {
+	// queue 1
+	for {
+		item, ok := c.queue1.dequeue()
+		if !ok {
+			// queue empty
+			return
+		}
+		if item.count.Load() > 1 {
+			// put queue2
+			c.queue2.enqueue(item)
+			c.used1 -= item.size
+			c.used2 += item.size
+		} else {
+			// evict
+			c.mapLock.Lock()
+			delete(c.values, item.key)
+			c.mapLock.Unlock()
+			if c.onEvict != nil {
+				c.onEvict(item.key, item.value)
+			}
+			c.used1 -= item.size
+			return
+		}
+	}
+}
+
+func (c *Cache[K, V]) evict2() {
+	// queue 2
+	for {
+		item, ok := c.queue2.dequeue()
+		if !ok {
+			// empty queue
+			break
+		}
+		if item.count.Load() > 0 {
+			// re-enqueue
+			c.queue2.enqueue(item)
+			item.dec()
+		} else {
+			// evict
+			c.mapLock.Lock()
+			delete(c.values, item.key)
+			c.mapLock.Unlock()
+			if c.onEvict != nil {
+				c.onEvict(item.key, item.value)
+			}
+			c.used2 -= item.size
+			return
+		}
+	}
+}

--- a/pkg/fileservice/fifocache/fifo_test.go
+++ b/pkg/fileservice/fifocache/fifo_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fifocache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheSetGet(t *testing.T) {
+	cache := New[int, int](8, nil)
+
+	cache.Set(1, 1, 1)
+	n, ok := cache.Get(1)
+	assert.True(t, ok)
+	assert.Equal(t, 1, n)
+
+	cache.Set(1, 1, 1)
+	n, ok = cache.Get(1)
+	assert.True(t, ok)
+	assert.Equal(t, 1, n)
+
+	_, ok = cache.Get(2)
+	assert.False(t, ok)
+}
+
+func TestCacheEvict(t *testing.T) {
+	cache := New[int, int](8, nil)
+	for i := 0; i < 64; i++ {
+		cache.Set(i, i, 1)
+		if cache.used1+cache.used2 > cache.capacity {
+			t.Fatalf("capacity %v, used1 %v used2 %v", cache.capacity, cache.used1, cache.used2)
+		}
+	}
+}
+
+func TestCacheEvict2(t *testing.T) {
+	cache := New[int, int](2, nil)
+	cache.Set(1, 1, 1)
+	cache.Set(2, 2, 1)
+
+	// 1 will be evicted
+	cache.Set(3, 3, 1)
+	assert.Equal(t, 2, len(cache.values))
+	assert.Equal(t, 2, cache.values[2].value)
+	assert.Equal(t, 3, cache.values[3].value)
+
+	// get 2, set 4, 3 will be evicted first
+	cache.Get(2)
+	cache.Get(2)
+	cache.Set(4, 4, 1)
+	assert.Equal(t, 2, len(cache.values))
+	assert.Equal(t, 2, cache.values[2].value)
+	assert.Equal(t, 4, cache.values[4].value)
+	assert.Equal(t, 1, cache.used1)
+	assert.Equal(t, 1, cache.used2)
+}
+
+func TestCacheEvict3(t *testing.T) {
+	nEvict := 0
+	cache := New[int, bool](1024, func(_ int, _ bool) {
+		nEvict++
+	})
+	for i := 0; i < 1024; i++ {
+		cache.Set(i, true, 1)
+		cache.Get(i)
+		cache.Get(i)
+		assert.True(t, cache.used1+cache.used2 <= 1024)
+		assert.True(t, len(cache.values) <= 1024)
+	}
+	assert.Equal(t, 0, nEvict)
+
+	for i := 0; i < 1024; i++ {
+		cache.Set(10000+i, true, 1)
+		assert.True(t, cache.used1+cache.used2 <= 1024)
+		assert.True(t, len(cache.values) <= 1024)
+	}
+	assert.Equal(t, 102, cache.used1)
+	assert.Equal(t, 922, cache.used2)
+	assert.Equal(t, 1024, nEvict)
+}

--- a/pkg/fileservice/fifocache/queue.go
+++ b/pkg/fileservice/fifocache/queue.go
@@ -1,0 +1,90 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fifocache
+
+import "sync"
+
+type Queue[T any] struct {
+	head     *queuePart[T]
+	tail     *queuePart[T]
+	partPool sync.Pool
+}
+
+type queuePart[T any] struct {
+	values []T
+	begin  int
+	next   *queuePart[T]
+}
+
+const maxQueuePartCapacity = 256
+
+func NewQueue[T any]() *Queue[T] {
+	queue := &Queue[T]{
+		partPool: sync.Pool{
+			New: func() any {
+				return &queuePart[T]{
+					values: make([]T, 0, maxQueuePartCapacity),
+				}
+			},
+		},
+	}
+	part := queue.partPool.Get().(*queuePart[T])
+	queue.head = part
+	queue.tail = part
+	return queue
+}
+
+func (p *Queue[T]) empty() bool {
+	return p.head == p.tail &&
+		p.head.begin == len(p.head.values)
+}
+
+func (p *queuePart[T]) reset() {
+	p.values = p.values[:0]
+	p.begin = 0
+	p.next = nil
+}
+
+func (p *Queue[T]) enqueue(v T) {
+	if len(p.head.values) >= maxQueuePartCapacity {
+		// extend
+		newPart := p.partPool.Get().(*queuePart[T])
+		newPart.reset()
+		p.head.next = newPart
+		p.head = newPart
+	}
+	p.head.values = append(p.head.values, v)
+}
+
+func (p *Queue[T]) dequeue() (ret T, ok bool) {
+	if p.empty() {
+		return
+	}
+
+	if p.tail.begin >= len(p.tail.values) {
+		// shrink
+		if p.tail.next == nil {
+			panic("impossible")
+		}
+		part := p.tail
+		p.tail = p.tail.next
+		p.partPool.Put(part)
+	}
+
+	ret = p.tail.values[p.tail.begin]
+	p.tail.begin++
+	ok = true
+	return
+}

--- a/pkg/fileservice/fifocache/queue_test.go
+++ b/pkg/fileservice/fifocache/queue_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fifocache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueue(t *testing.T) {
+	queue := NewQueue[int]()
+	for i := 0; i < maxQueuePartCapacity*1024; i++ {
+		queue.enqueue(i)
+	}
+	for i := 0; i < maxQueuePartCapacity*1024; i++ {
+		n, ok := queue.dequeue()
+		assert.True(t, ok)
+		assert.Equal(t, i, n)
+	}
+}

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -137,9 +137,7 @@ func (l *LocalFS) initCaches(ctx context.Context, config CacheConfig) error {
 			l.diskCache, err = NewDiskCache(
 				ctx,
 				*config.DiskPath,
-				int64(*config.DiskCapacity),
-				config.DiskMinEvictInterval.Duration,
-				*config.DiskEvictTarget,
+				int(*config.DiskCapacity),
 				l.perfCounterSets,
 			)
 			if err != nil {

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -150,9 +150,7 @@ func (s *S3FS) initCaches(ctx context.Context, config CacheConfig) error {
 		s.diskCache, err = NewDiskCache(
 			ctx,
 			*config.DiskPath,
-			int64(*config.DiskCapacity),
-			config.DiskMinEvictInterval.Duration,
-			*config.DiskEvictTarget,
+			int(*config.DiskCapacity),
 			s.perfCounterSets,
 		)
 		if err != nil {


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12506 

## What this PR does / why we need it:
fileservice: add fifocache package

fifocache: add get benchmarks

fifocache: naming fixes

fifocache: add Cache.capacity, used

fifocache: add Queue

fifocache: implement evict

fifocache: add Get Set mixed benchmark

fifocache: refine eviction

fifocache: refine eviction

fileservice: refine disk cache with fifo cache

fileservice: refine disk cache

fileservice: delete DiskCache.fileExists

