### PR TITLE
sync_to_1.1: defer on time.since not work

### DIFF
--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -1269,7 +1269,9 @@ func (h *Handle) HandleStorageUsage(ctx context.Context, meta txn.TxnMeta,
 	memo := h.db.GetUsageMemo()
 
 	start := time.Now()
-	defer v2.TaskStorageUsageReqDurationHistogram.Observe(time.Since(start).Seconds())
+	defer func() {
+		v2.TaskStorageUsageReqDurationHistogram.Observe(time.Since(start).Seconds())
+	}()
 
 	memo.EnterProcessing()
 	defer func() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13983 

## What this PR does / why we need it:
fix the time.Since not deferred

