### PR TITLE
fix panic if allocating lock table from dn failed to 1.1

### DIFF
--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -302,7 +302,7 @@ func (s *service) getLockTableWithCreate(tableID uint64, create bool) (lockTable
 		if waitC != nil {
 			s.mu.Unlock()
 			<-waitC
-			return s.loadLockTable(tableID)
+			s.mu.Lock()
 		}
 
 		v := s.loadLockTable(tableID)

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/fagongzi/goetty/v2/buf"
 	"github.com/lni/goutils/leaktest"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
@@ -1362,6 +1363,34 @@ func TestTxnUnlockWithBindChanged(t *testing.T) {
 				})
 		})
 	}
+}
+
+func TestIssue14008(t *testing.T) {
+	runLockServiceTests(
+		t,
+		[]string{"s1"},
+		func(alloc *lockTableAllocator, ss []*service) {
+			s1 := ss[0]
+			alloc.server.RegisterMethodHandler(pb.Method_GetBind,
+				func(
+					ctx context.Context,
+					cf context.CancelFunc,
+					r1 *pb.Request,
+					r2 *pb.Response,
+					cs morpc.ClientSession) {
+					writeResponse(ctx, cf, r2, ErrTxnNotFound, cs)
+				})
+			var wg sync.WaitGroup
+			for i := 0; i < 20; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_, err := s1.getLockTableWithCreate(10, true)
+					require.Error(t, err)
+				}()
+			}
+			wg.Wait()
+		})
 }
 
 func BenchmarkWithoutConflict(b *testing.B) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14008

## What this PR does / why we need it:
fix panic if allocating lock table from dn failed