### PR TITLE
fix panic if allocating lock table from dn failed

### DIFF
--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -319,7 +319,7 @@ func (s *service) getLockTableWithCreate(
 		if waitC != nil {
 			s.mu.Unlock()
 			<-waitC
-			return s.loadLockTable(group, tableID)
+			s.mu.Lock()
 		}
 
 		v := s.loadLockTable(group, tableID)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14008

## What this PR does / why we need it:
fix panic if allocating lock table from dn failed