### PR TITLE
[cherry-pick] #14052 removed a context done error at the remote run stage.

### DIFF
--- a/pkg/sql/colexec/server.go
+++ b/pkg/sql/colexec/server.go
@@ -41,7 +41,8 @@ func NewServer(client logservice.CNHAKeeperClient) *Server {
 	return Srv
 }
 
-// GetProcByUuid used the uuid to get a process from the srv, decrease its referenceCount by 1.
+// GetProcByUuid used the uuid to get a process from the srv.
+// if the process is nil, it means the process has done.
 // if forcedDelete, do an action to avoid another routine to put a new item.
 func (srv *Server) GetProcByUuid(u uuid.UUID, forcedDelete bool) (*process.Process, bool) {
 	srv.uuidCsChanMap.Lock()
@@ -55,7 +56,6 @@ func (srv *Server) GetProcByUuid(u uuid.UUID, forcedDelete bool) (*process.Proce
 	}
 
 	result := p.proc
-	// if a proc is nil or its referenceCount is 0, it means the process hash done.
 	if p.proc == nil {
 		delete(srv.uuidCsChanMap.mp, u)
 	} else {

--- a/pkg/sql/compile/scopeRemoteRun.go
+++ b/pkg/sql/compile/scopeRemoteRun.go
@@ -157,17 +157,18 @@ func cnMessageHandle(receiver *messageReceiverOnServer) error {
 			Err:   make(chan error, 1),
 		}
 
+		// todo : the timeout should be removed.
+		//		but I keep it here because I don't know whether it will cause hung sometimes.
 		timeLimit, cancel := context.WithTimeout(context.TODO(), HandleNotifyTimeout)
 
 		succeed := false
 		select {
 		case <-timeLimit.Done():
 			err = moerr.NewInternalError(receiver.ctx, "send notify msg to dispatch operator timeout")
-		case <-dispatchProc.Ctx.Done():
-			err = moerr.NewInternalError(receiver.ctx, "send notify msg to dispatch operator failed, dispatch operator has done")
 		case dispatchProc.DispatchNotifyCh <- infoToDispatchOperator:
 			succeed = true
 		case <-receiver.ctx.Done():
+		case <-dispatchProc.Ctx.Done():
 		}
 		cancel()
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14009 #14024 #14032

## What this PR does / why we need it:
remove an error when the required process was done.