### PR TITLE
lock meta table for DQL

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -230,17 +230,8 @@ func (c *Compile) Compile(ctx context.Context, pn *plan.Plan, u any, fill func(a
 	}()
 
 	if c.proc.TxnOperator != nil && c.proc.TxnOperator.Txn().IsPessimistic() {
-		if qry, ok := pn.Plan.(*plan.Plan_Query); ok {
-			if qry.Query.StmtType == plan.Query_SELECT {
-				for _, n := range qry.Query.Nodes {
-					if n.NodeType == plan.Node_LOCK_OP {
-						c.needLockMeta = true
-						break
-					}
-				}
-			} else {
-				c.needLockMeta = true
-			}
+		if _, ok := pn.Plan.(*plan.Plan_Query); ok {
+			c.needLockMeta = true
 		}
 	}
 

--- a/test/distributed/cases/pessimistic_transaction/autocommit_isolation_1.result
+++ b/test/distributed/cases/pessimistic_transaction/autocommit_isolation_1.result
@@ -525,6 +525,7 @@ select * from test_11;
 c    d
 1    1
 2    2
+use autocommit_isolation_1;
 set autocommit=0;
 select * from test_11;
 c    d
@@ -533,24 +534,21 @@ c    d
 set autocommit=0;
 drop table test_11;
 select * from test_11;
+c    d
+1    1
+2    2
+commit;
+commit;
+select * from test_11;
 SQL parser error: table "test_11" does not exist
 Previous DML conflicts with existing constraints or data format. This transaction has to be aborted
+set autocommit=1;
 select * from test_11;
-c    d
-1    1
-2    2
+SQL parser error: table "test_11" does not exist
 commit;
 set autocommit=1;
 select * from test_11;
-c    d
-1    1
-2    2
-commit;
-set autocommit=1;
-select * from test_11;
-c    d
-1    1
-2    2
+SQL parser error: table "test_11" does not exist
 drop table if exists test_11;
 set autocommit=0;
 create table test_11 (c int primary key,d int);

--- a/test/distributed/cases/pessimistic_transaction/autocommit_isolation_1.sql
+++ b/test/distributed/cases/pessimistic_transaction/autocommit_isolation_1.sql
@@ -326,18 +326,20 @@ Insert into test_11 values(1,1);
 Insert into test_11 values(2,2);
 select * from test_11;
 -- @session:id=1{
+use autocommit_isolation_1;
 set autocommit=0;
 select * from test_11;
 -- @session}
 
 set autocommit=0;
+-- @wait:1:commit
 drop table test_11;
-select * from test_11;
 -- @session:id=1{
 select * from test_11;
--- @session}
-
 commit;
+-- @session}
+commit;
+select * from test_11;
 set autocommit=1;
 select * from test_11;
 -- @session:id=1{

--- a/test/distributed/cases/pessimistic_transaction/drop_table_truncate.sql
+++ b/test/distributed/cases/pessimistic_transaction/drop_table_truncate.sql
@@ -20,7 +20,6 @@ drop table if exists t5;
 drop table if exists dis_table_02;
 drop table if exists dis_table_03;
 
--- @bvt:issue#10316
 create table dis_table_02(a int not null auto_increment,b varchar(25) not null,c datetime,primary key(a),key bstr (b),key cdate (c) );
 insert into dis_table_02(b,c) values ('aaaa','2020-09-08');
 insert into dis_table_02(b,c) values ('aaaa','2020-09-08');
@@ -47,9 +46,7 @@ insert into t1 values (1);
 drop table t1;
 show tables;
 commit;
--- @bvt:issue
 
--- @bvt:issue#10316
 create table t1(a int);
 begin;
 insert into t1 values (1);
@@ -74,4 +71,3 @@ select * from t2;
 drop table t2;
 show tables;
 commit;
--- @bvt:issue

--- a/test/distributed/cases/pessimistic_transaction/isolation_1.sql
+++ b/test/distributed/cases/pessimistic_transaction/isolation_1.sql
@@ -310,6 +310,7 @@ select * from test_11;
 -- @session}
 
 begin;
+-- @wait:1:commit
 drop table test_11;
 select * from test_11;
 -- @session:id=1{

--- a/test/distributed/cases/pessimistic_transaction/isolation_2.sql
+++ b/test/distributed/cases/pessimistic_transaction/isolation_2.sql
@@ -219,7 +219,6 @@ select b, c from dis_table_02;
 select * from dis_view_02;
 drop table dis_view_02;
 
--- @bvt:issue#10316
 begin ;
 select * from dis_table_01;
 -- @session:id=1{
@@ -259,7 +258,6 @@ select b, c from dis_table_02;
 -- @session:id=1{
 select b, c from dis_table_02;
 -- @session}
--- @bvt:issue
 --------------------------------
 -- @bvt:issue#10585
 create database if not exists iso_db_02;

--- a/test/distributed/cases/pessimistic_transaction/transaction_enhance.result
+++ b/test/distributed/cases/pessimistic_transaction/transaction_enhance.result
@@ -249,6 +249,7 @@ insert into atomic_table_16 values (6,"a"),(7,"b");
 drop table atomic_table_16;
 use transaction_enhance;
 drop table atomic_table_16;
+no such table transaction_enhance.atomic_table_16
 commit;
 select * from atomic_table_16;
 SQL parser error: table "atomic_table_16" does not exist
@@ -259,9 +260,10 @@ insert into atomic_table_17 values (6,"a"),(7,"b");
 drop table atomic_table_17;
 use transaction_enhance;
 alter table atomic_table_17 add constraint unique key (c1);
+no such table transaction_enhance.atomic_table_17
 update atomic_table_17 set c1=8 where c2="b";
+no such table transaction_enhance.atomic_table_17
 commit;
-w-w conflict
 select * from atomic_table_17;
 SQL parser error: table "atomic_table_17" does not exist
 start transaction ;
@@ -346,7 +348,6 @@ create table alter01(col1 int primary key,col2 varchar(25));
 insert into alter01 values (3,"a"),(4,"b"),(5,"c");
 begin;
 alter table alter01 modify col1 float;
-use transaction_enhance;
 insert into alter01 values (8,"h");
 select * from alter01;
 col1    col2
@@ -369,7 +370,6 @@ create table alter01(col1 int not null ,col2 varchar(25));
 insert into alter01 values (3,"a"),(4,"b"),(5,"c");
 begin;
 alter table alter01 modify col1 float;
-use transaction_enhance;
 insert into alter01 values (8,"h");
 select * from alter01;
 col1    col2
@@ -411,7 +411,6 @@ create table alter01(col1 int primary key,col2 varchar(25));
 insert into alter01 values (3,"a"),(4,"b"),(5,"c");
 begin;
 alter table alter01 change col1 col1New float;
-use transaction_enhance;
 insert into alter01 values (8,"h");
 select * from alter01;
 col1new    col2
@@ -452,7 +451,6 @@ create table alter01(col1 int primary key,col2 varchar(25));
 insert into alter01 values (3,"a"),(4,"b"),(5,"c");
 begin;
 alter table alter01 rename column col1 to col1New;
-use transaction_enhance;
 insert into alter01 values (8,"h");
 select * from alter01;
 col1new    col2

--- a/test/distributed/cases/pessimistic_transaction/transaction_enhance.sql
+++ b/test/distributed/cases/pessimistic_transaction/transaction_enhance.sql
@@ -88,6 +88,7 @@ drop table atomic_table_11;
 drop table atomic_table_11;
 commit;
 
+-- @bvt:issue#10316
 --alter table
 drop table if exists atomic_table_12;
 create table atomic_table_12(c1 int,c2 varchar(25));
@@ -183,10 +184,12 @@ alter table atomic_table_12_5 drop index key1;
 -- @session:id=1{
 use transaction_enhance;
 show create table atomic_table_12_5;
+-- @wait:0:commit
 select * from atomic_table_12_5;
 -- @session}
 commit;
 show index from atomic_table_12_5;
+-- @bvt:issue
 
 -- w-w conflict
 drop table if exists atomic_table_14;
@@ -218,6 +221,7 @@ drop table atomic_table_15;
 select * from atomic_table_15;
 commit;
 select * from atomic_table_15;
+-- @bvt:issue
 
 drop table if exists atomic_table_16;
 create table atomic_table_16(c1 int,c2 varchar(25));
@@ -238,8 +242,8 @@ begin;
 insert into atomic_table_17 values (6,"a"),(7,"b");
 drop table atomic_table_17;
 -- @session:id=1{
-use transaction_enhance;
 -- @wait:0:commit
+use transaction_enhance;
 alter table atomic_table_17 add constraint unique key (c1);
 update atomic_table_17 set c1=8 where c2="b";
 -- @session}
@@ -276,6 +280,7 @@ select count(*) from mo_catalog.mo_account where account_name='trans_acc1';
 commit;
 select count(*) from mo_catalog.mo_account where account_name='trans_acc1';
 
+-- @bvt:issue#10316
 -- autocommit
 drop table if exists atomic_table_18;
 create table atomic_table_18(c1 int,c2 varchar(25));
@@ -317,6 +322,7 @@ commit;
 select * from atomic_table_18;
 set autocommit=1;
 drop account if exists trans_acc1;
+-- @bvt:issue
 
 -- alter table modify column primary key
 drop table if exists alter01;
@@ -327,7 +333,6 @@ begin;
 alter table alter01 modify col1 float;
 -- @session:id=1{
 -- @wait:0:commit
-use transaction_enhance;
 insert into alter01 values (8,"h");
 select * from alter01;
 -- @session
@@ -344,7 +349,6 @@ begin;
 alter table alter01 modify col1 float;
 -- @session:id=1{
 -- @wait:0:commit
-use transaction_enhance;
 insert into alter01 values (8,"h");
 select * from alter01;
 -- @session
@@ -352,6 +356,7 @@ insert into alter01 values (6,"h");
 commit;
 select * from alter01;
 
+-- @bvt:issue#10316
 -- alter table change column
 drop table if exists atomic_table_12_5;
 create table atomic_table_12_5(c1 int,c2 varchar(25));
@@ -367,6 +372,7 @@ show create table atomic_table_12_5;
 select * from atomic_table_12_5;
 -- @session}
 show create table atomic_table_12_5;
+-- @bvt:issue
 
 -- alter table change primary key column
 drop table if exists alter01;
@@ -376,13 +382,13 @@ begin;
 alter table alter01 change col1 col1New float;
 -- @session:id=1{
 -- @wait:0:commit
-use transaction_enhance;
 insert into alter01 values (8,"h");
 select * from alter01;
 -- @session
 insert into alter01 values (6,"h");
 select * from alter01;
 
+-- @bvt:issue#10316
 -- alter table rename column
 drop table if exists atomic_table_12_5;
 create table atomic_table_12_5(c1 int,c2 varchar(25));
@@ -398,6 +404,7 @@ show create table atomic_table_12_5;
 select * from atomic_table_12_5;
 -- @session}
 show create table atomic_table_12_5;
+-- @bvt:issue
 
 -- alter table rename primary key column
 drop table if exists alter01;
@@ -407,7 +414,6 @@ begin;
 alter table alter01 rename column col1 to col1New;
 -- @session:id=1{
 -- @wait:0:commit
-use transaction_enhance;
 insert into alter01 values (8,"h");
 select * from alter01;
 -- @session


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #10316

## What this PR does / why we need it:

The previous DQL did not always lock the shared lock. This PR corrected the relevant behavior, but did not completely fix it. SQL similar to show table xxx still does not lock, and will be further fixed in the future.
