### PR TITLE
fileservice: fix DiskCache.DeletePaths

### DIFF
--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -469,6 +469,7 @@ func (d *DiskCache) DeletePaths(
 				return err
 			}
 		}
+		d.cache.Delete(diskPath)
 	}
 
 	return nil

--- a/pkg/fileservice/fifocache/fifo.go
+++ b/pkg/fileservice/fifocache/fifo.go
@@ -130,6 +130,14 @@ func (c *Cache[K, V]) Get(key K) (value V, ok bool) {
 	return item.value, true
 }
 
+func (c *Cache[K, V]) Delete(key K) {
+	shard := &c.shards[c.keyShardFunc(key)]
+	shard.Lock()
+	defer shard.Unlock()
+	delete(shard.values, key)
+	// we don't update queues
+}
+
 func (c *Cache[K, V]) evict() {
 	for c.used1+c.used2 > c.capacity {
 		if c.used1 > c.capacity1 {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12739 

## What this PR does / why we need it:
The disk cache may delete files, and also delete the cache.