### PR TITLE
disable auto create backend automatically in background by default to 1.1

### DIFF
--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -126,7 +126,10 @@ func TestCanGetBackendIfALLLockedAndNotReachMaxPerHost(t *testing.T) {
 }
 
 func TestMaybeCreateLockedWithEmptyBackends(t *testing.T) {
-	rc, err := NewClient("", newTestBackendFactory(), WithClientMaxBackendPerHost(1))
+	rc, err := NewClient("",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		WithClientEnableAutoCreateBackend())
 	assert.NoError(t, err)
 	c := rc.(*client)
 	defer func() {
@@ -137,7 +140,10 @@ func TestMaybeCreateLockedWithEmptyBackends(t *testing.T) {
 }
 
 func TestMaybeCreateLockedWithNotFullBackendsAndHasAnyBusy(t *testing.T) {
-	rc, err := NewClient("", newTestBackendFactory(), WithClientMaxBackendPerHost(3))
+	rc, err := NewClient("",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(3),
+		WithClientEnableAutoCreateBackend())
 	assert.NoError(t, err)
 	c := rc.(*client)
 	defer func() {
@@ -164,7 +170,10 @@ func TestMaybeCreateLockedWithNotFullBackendsAndNoBusy(t *testing.T) {
 }
 
 func TestMaybeCreateLockedWithFullBackends(t *testing.T) {
-	rc, err := NewClient("", newTestBackendFactory(), WithClientMaxBackendPerHost(1))
+	rc, err := NewClient("",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		WithClientEnableAutoCreateBackend())
 	assert.NoError(t, err)
 	c := rc.(*client)
 	defer func() {
@@ -214,7 +223,8 @@ func TestCloseIdleBackends(t *testing.T) {
 		newTestBackendFactory(),
 		WithClientMaxBackendPerHost(2),
 		WithClientMaxBackendMaxIdleDuration(time.Millisecond*100),
-		WithClientCreateTaskChanSize(1))
+		WithClientCreateTaskChanSize(1),
+		WithClientEnableAutoCreateBackend())
 	assert.NoError(t, err)
 	c := rc.(*client)
 	defer func() {
@@ -283,7 +293,7 @@ func TestCloseIdleBackends(t *testing.T) {
 	}
 }
 
-func TestLockedbackendCannotClosedWithGCIdleTask(t *testing.T) {
+func TestLockedBackendCannotClosedWithGCIdleTask(t *testing.T) {
 	rc, err := NewClient(
 		"",
 		newTestBackendFactory(),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14149

## What this PR does / why we need it:
disable auto create backend automatically in background by default