### PR TITLE
Cherry-pick[#14067] Fix the mesa in workspace

### DIFF
--- a/pkg/frontend/test/engine_mock.go
+++ b/pkg/frontend/test/engine_mock.go
@@ -184,6 +184,123 @@ func (mr *MockConstraintMockRecorder) constraint() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "constraint", reflect.TypeOf((*MockConstraint)(nil).constraint))
 }
 
+// MockRanges is a mock of Ranges interface.
+type MockRanges struct {
+	ctrl     *gomock.Controller
+	recorder *MockRangesMockRecorder
+}
+
+// MockRangesMockRecorder is the mock recorder for MockRanges.
+type MockRangesMockRecorder struct {
+	mock *MockRanges
+}
+
+// NewMockRanges creates a new mock instance.
+func NewMockRanges(ctrl *gomock.Controller) *MockRanges {
+	mock := &MockRanges{ctrl: ctrl}
+	mock.recorder = &MockRangesMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRanges) EXPECT() *MockRangesMockRecorder {
+	return m.recorder
+}
+
+// Append mocks base method.
+func (m *MockRanges) Append(arg0 []byte) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Append", arg0)
+}
+
+// Append indicates an expected call of Append.
+func (mr *MockRangesMockRecorder) Append(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Append", reflect.TypeOf((*MockRanges)(nil).Append), arg0)
+}
+
+// GetAllBytes mocks base method.
+func (m *MockRanges) GetAllBytes() []byte {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllBytes")
+	ret0, _ := ret[0].([]byte)
+	return ret0
+}
+
+// GetAllBytes indicates an expected call of GetAllBytes.
+func (mr *MockRangesMockRecorder) GetAllBytes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllBytes", reflect.TypeOf((*MockRanges)(nil).GetAllBytes))
+}
+
+// GetBytes mocks base method.
+func (m *MockRanges) GetBytes(i int) []byte {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBytes", i)
+	ret0, _ := ret[0].([]byte)
+	return ret0
+}
+
+// GetBytes indicates an expected call of GetBytes.
+func (mr *MockRangesMockRecorder) GetBytes(i interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBytes", reflect.TypeOf((*MockRanges)(nil).GetBytes), i)
+}
+
+// Len mocks base method.
+func (m *MockRanges) Len() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Len")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Len indicates an expected call of Len.
+func (mr *MockRangesMockRecorder) Len() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockRanges)(nil).Len))
+}
+
+// SetBytes mocks base method.
+func (m *MockRanges) SetBytes(arg0 []byte) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetBytes", arg0)
+}
+
+// SetBytes indicates an expected call of SetBytes.
+func (mr *MockRangesMockRecorder) SetBytes(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBytes", reflect.TypeOf((*MockRanges)(nil).SetBytes), arg0)
+}
+
+// Size mocks base method.
+func (m *MockRanges) Size() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Size")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Size indicates an expected call of Size.
+func (mr *MockRangesMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockRanges)(nil).Size))
+}
+
+// Slice mocks base method.
+func (m *MockRanges) Slice(i, j int) []byte {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Slice", i, j)
+	ret0, _ := ret[0].([]byte)
+	return ret0
+}
+
+// Slice indicates an expected call of Slice.
+func (mr *MockRangesMockRecorder) Slice(i, j interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Slice", reflect.TypeOf((*MockRanges)(nil).Slice), i, j)
+}
+
 // MockRelation is a mock of Relation interface.
 type MockRelation struct {
 	ctrl     *gomock.Controller

--- a/pkg/frontend/test/txn_mock.go
+++ b/pkg/frontend/test/txn_mock.go
@@ -755,17 +755,17 @@ func (m *MockWorkspace) EXPECT() *MockWorkspaceMockRecorder {
 }
 
 // Adjust mocks base method.
-func (m *MockWorkspace) Adjust() error {
+func (m *MockWorkspace) Adjust(writeOffset uint64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Adjust")
+	ret := m.ctrl.Call(m, "Adjust", writeOffset)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Adjust indicates an expected call of Adjust.
-func (mr *MockWorkspaceMockRecorder) Adjust() *gomock.Call {
+func (mr *MockWorkspaceMockRecorder) Adjust(writeOffset interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Adjust", reflect.TypeOf((*MockWorkspace)(nil).Adjust))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Adjust", reflect.TypeOf((*MockWorkspace)(nil).Adjust), writeOffset)
 }
 
 // Commit mocks base method.
@@ -873,4 +873,18 @@ func (m *MockWorkspace) StartStatement() {
 func (mr *MockWorkspaceMockRecorder) StartStatement() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartStatement", reflect.TypeOf((*MockWorkspace)(nil).StartStatement))
+}
+
+// WriteOffset mocks base method.
+func (m *MockWorkspace) WriteOffset() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteOffset")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// WriteOffset indicates an expected call of WriteOffset.
+func (mr *MockWorkspaceMockRecorder) WriteOffset() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteOffset", reflect.TypeOf((*MockWorkspace)(nil).WriteOffset))
 }

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -24,6 +24,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/memoryengine"
+
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/util/toml"
@@ -627,7 +630,8 @@ func TestGetExprValue(t *testing.T) {
 		ws.EXPECT().GetSQLCount().AnyTimes()
 		ws.EXPECT().StartStatement().AnyTimes()
 		ws.EXPECT().EndStatement().AnyTimes()
-		ws.EXPECT().Adjust().AnyTimes()
+		ws.EXPECT().WriteOffset().Return(uint64(0)).AnyTimes()
+		ws.EXPECT().Adjust(gomock.Any()).AnyTimes()
 
 		txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
 		txnOperator.EXPECT().Commit(gomock.Any()).Return(nil).AnyTimes()
@@ -726,7 +730,8 @@ func TestGetExprValue(t *testing.T) {
 		ws.EXPECT().IncrStatementID(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		ws.EXPECT().StartStatement().AnyTimes()
 		ws.EXPECT().EndStatement().AnyTimes()
-		ws.EXPECT().Adjust().AnyTimes()
+		ws.EXPECT().WriteOffset().Return(uint64(0)).AnyTimes()
+		ws.EXPECT().Adjust(uint64(0)).AnyTimes()
 		ws.EXPECT().IncrSQLCount().AnyTimes()
 		ws.EXPECT().GetSQLCount().AnyTimes()
 

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -99,7 +99,11 @@ func (w *Ws) Rollback(ctx context.Context) error {
 	return nil
 }
 
-func (w *Ws) Adjust() error {
+func (w *Ws) WriteOffset() uint64 {
+	return 0
+}
+
+func (w *Ws) Adjust(_ uint64) error {
 	return nil
 }
 

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -222,8 +222,10 @@ type Workspace interface {
 	// RollbackLastStatement rollback the last statement.
 	RollbackLastStatement(ctx context.Context) error
 
+	WriteOffset() uint64
+
 	// Adjust adjust workspace, adjust update's delete+insert to correct order and merge workspace.
-	Adjust() error
+	Adjust(writeOffset uint64) error
 
 	Commit(ctx context.Context) ([]txn.TxnRequest, error)
 	Rollback(ctx context.Context) error

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -225,7 +225,6 @@ func (txn *Transaction) dumpBatchLocked(offset int) error {
 			}
 		}
 		txn.writes = writes
-		txn.statements[txn.statementID-1] = len(txn.writes)
 	} else {
 		txn.workspaceSize -= size
 	}
@@ -447,7 +446,6 @@ func (txn *Transaction) deleteTableWrites(
 			}
 			if len(sels) != len(vs) {
 				txn.batchSelectList[e.bat] = append(txn.batchSelectList[e.bat], sels...)
-
 			}
 		}
 	}

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -297,11 +297,18 @@ func (txn *Transaction) IncrStatementID(ctx context.Context, commit bool) error 
 	return txn.handleRCSnapshot(ctx, commit)
 }
 
-// Adjust adjust writes order
-func (txn *Transaction) Adjust() error {
+// writeOffset returns the offset of the first write in the workspace
+func (txn *Transaction) WriteOffset() uint64 {
 	txn.Lock()
 	defer txn.Unlock()
-	if err := txn.adjustUpdateOrderLocked(); err != nil {
+	return uint64(len(txn.writes))
+}
+
+// Adjust adjust writes order
+func (txn *Transaction) Adjust(writeOffset uint64) error {
+	txn.Lock()
+	defer txn.Unlock()
+	if err := txn.adjustUpdateOrderLocked(writeOffset); err != nil {
 		return err
 	}
 	if err := txn.mergeTxnWorkspaceLocked(); err != nil {
@@ -312,23 +319,20 @@ func (txn *Transaction) Adjust() error {
 
 // The current implementation, update's delete and insert are executed concurrently, inside workspace it
 // may be the order of insert+delete that needs to be adjusted.
-func (txn *Transaction) adjustUpdateOrderLocked() error {
+func (txn *Transaction) adjustUpdateOrderLocked(writeOffset uint64) error {
 	if txn.statementID > 0 {
-		start := txn.statements[txn.statementID-1]
-		writes := make([]Entry, 0, len(txn.writes[start:]))
-		for i := start; i < len(txn.writes); i++ {
-			if txn.writes[i].typ == DELETE {
+		writes := make([]Entry, 0, len(txn.writes[writeOffset:]))
+		for i := writeOffset; i < uint64(len(txn.writes)); i++ {
+			if !txn.writes[i].isCatalog() && txn.writes[i].typ == DELETE {
 				writes = append(writes, txn.writes[i])
 			}
 		}
-		for i := start; i < len(txn.writes); i++ {
-			if txn.writes[i].typ != DELETE {
+		for i := writeOffset; i < uint64(len(txn.writes)); i++ {
+			if txn.writes[i].isCatalog() || txn.writes[i].typ != DELETE {
 				writes = append(writes, txn.writes[i])
 			}
 		}
-		txn.writes = append(txn.writes[:start], writes...)
-		// restore the scope of the statement
-		txn.statements[txn.statementID-1] = len(txn.writes)
+		txn.writes = append(txn.writes[:writeOffset], writes...)
 	}
 	return nil
 }
@@ -431,6 +435,13 @@ func (e *Entry) isGeneratedByTruncate() bool {
 		e.databaseId == catalog.MO_CATALOG_ID &&
 		e.tableId == catalog.MO_TABLES_ID &&
 		e.truncate
+}
+
+// isCatalog denotes the entry is apply the tree tables
+func (e *Entry) isCatalog() bool {
+	return e.tableId == catalog.MO_TABLES_ID ||
+		e.tableId == catalog.MO_COLUMNS_ID ||
+		e.tableId == catalog.MO_DATABASE_ID
 }
 
 // txnDatabase represents an opened database in a transaction


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13900

## What this PR does / why we need it:
* Fix the issue of wrong statementid due to order adjustment
* Fixed a rollback issue introduced by the removal of deleted data from a cn internal workspace.（  dn can't handle accepting that cn inserts a row of data into a workspace and then deletes a row of data, and then pushes an insert+delete, which requires cn to merge the two ops into one, and then this merged operation is recorded in a cache, which doesn't have an associated statementid, and so will cause the rollback to be invalidated)