### PR TITLE
cp to 1.1: fix create account timeout

### DIFF
--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/defines"
+
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -166,7 +168,7 @@ func NewBootstrapper(
 
 func (b *bootstrapper) Bootstrap(ctx context.Context) error {
 	getLogger().Info("start to check bootstrap state")
-
+	ctx = defines.AttachAccount(ctx, catalog.System_Account, catalog.System_User, catalog.System_Role)
 	if ok, err := b.checkAlreadyBootstrapped(ctx); ok {
 		getLogger().Info("mo already boostrapped")
 		return nil

--- a/pkg/cnservice/upgrader/upgrader.go
+++ b/pkg/cnservice/upgrader/upgrader.go
@@ -156,6 +156,15 @@ func (u *Upgrader) GenerateUpgradeSQL(diff table.SchemaDiff) (string, error) {
 }
 
 func (u *Upgrader) Upgrade(ctx context.Context) error {
+	sysAcc := &frontend.TenantInfo{
+		Tenant:        frontend.GetUserRoot(),
+		TenantID:      frontend.GetSysTenantId(),
+		User:          frontend.GetUserRoot(),
+		UserID:        frontend.GetUserRootId(),
+		DefaultRoleID: frontend.GetDefaultRoleId(),
+		DefaultRole:   frontend.GetDefaultRole(),
+	}
+	ctx = attachAccount(ctx, sysAcc)
 	allTenants, err := u.GetAllTenantInfo(ctx)
 	if err != nil {
 		return err
@@ -544,7 +553,6 @@ func (u *Upgrader) GetAllTenantInfo(ctx context.Context) ([]*frontend.TenantInfo
 		DefaultRoleID: frontend.GetDefaultRoleId(),
 		DefaultRole:   frontend.GetDefaultRole(),
 	}
-	ctx = attachAccount(ctx, sysAcc)
 	result := exec.Query(ctx, query, makeOptions(sysAcc).Finish())
 
 	errors := []error{}

--- a/pkg/cnservice/upgrader/upgrader_util.go
+++ b/pkg/cnservice/upgrader/upgrader_util.go
@@ -58,10 +58,7 @@ func ParseDataTypeToColType(dataType string) (table.ColType, error) {
 }
 
 func attachAccount(ctx context.Context, tenant *frontend.TenantInfo) context.Context {
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, tenant.GetTenantID())
-	ctx = context.WithValue(ctx, defines.UserIDKey{}, tenant.GetUserID())
-	ctx = context.WithValue(ctx, defines.RoleIDKey{}, tenant.GetDefaultRoleID())
-	return ctx
+	return defines.AttachAccount(ctx, tenant.GetTenantID(), tenant.GetUserID(), tenant.GetDefaultRoleID())
 }
 
 func makeOptions(tenant *frontend.TenantInfo) *ie.OptsBuilder {

--- a/pkg/defines/type.go
+++ b/pkg/defines/type.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"math"
 	"sync"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 )
 
 // information from: https://dev.mysql.com/doc/internals/en/com-query-response.html
@@ -166,11 +168,44 @@ type UserIDKey struct{}
 type RoleIDKey struct{}
 type NodeIDKey struct{}
 
-func GetAccountId(ctx context.Context) uint32 {
+func GetAccountId(ctx context.Context) (uint32, error) {
 	if v := ctx.Value(TenantIDKey{}); v != nil {
+		return v.(uint32), nil
+	} else {
+		return 0, moerr.NewInternalError(ctx, "no account id in context")
+	}
+}
+
+func GetUserId(ctx context.Context) uint32 {
+	if v := ctx.Value(UserIDKey{}); v != nil {
 		return v.(uint32)
 	}
+	//zero means root user
 	return 0
+}
+
+func GetRoleId(ctx context.Context) uint32 {
+	if v := ctx.Value(RoleIDKey{}); v != nil {
+		return v.(uint32)
+	}
+	//zero means mo admin role
+	return 0
+}
+
+func AttachAccount(ctx context.Context, accId uint32, userId uint32, roleId uint32) context.Context {
+	return AttachRoleId(AttachUserId(AttachAccountId(ctx, accId), userId), roleId)
+}
+
+func AttachAccountId(ctx context.Context, accId uint32) context.Context {
+	return context.WithValue(ctx, TenantIDKey{}, accId)
+}
+
+func AttachUserId(ctx context.Context, userId uint32) context.Context {
+	return context.WithValue(ctx, UserIDKey{}, userId)
+}
+
+func AttachRoleId(ctx context.Context, roleId uint32) context.Context {
+	return context.WithValue(ctx, RoleIDKey{}, roleId)
 }
 
 // EngineKey use EngineKey{} to get engine from Context

--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -2968,7 +2968,7 @@ func doAlterAccount(ctx context.Context, ses *Session, aa *tree.AlterAccount) (e
 			//Option 1: alter the password of admin for the account
 			if aa.AuthOption.Exist {
 				//!!!NOTE!!!:switch into the target account's context, then update the table mo_user.
-				accountCtx := context.WithValue(ctx, defines.TenantIDKey{}, uint32(targetAccountId))
+				accountCtx := defines.AttachAccountId(ctx, uint32(targetAccountId))
 
 				//1, check the admin exists or not
 				sql, rtnErr = getSqlForPasswordOfUser(ctx, aa.AuthOption.AdminName)
@@ -3296,7 +3296,7 @@ func checkSubscriptionValidCommon(ctx context.Context, ses *Session, subName, ac
 		return nil, moerr.NewInternalError(ctx, "can not subscribe to self")
 	}
 
-	newCtx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+	newCtx = defines.AttachAccountId(ctx, catalog.System_Account)
 
 	//get pubAccountId from publication info
 	sql, err = getSqlForAccountIdAndStatus(newCtx, accName, true)
@@ -3340,7 +3340,7 @@ func checkSubscriptionValidCommon(ctx context.Context, ses *Session, subName, ac
 
 	//check the publication is already exist or not
 
-	newCtx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(accId))
+	newCtx = defines.AttachAccountId(ctx, uint32(accId))
 	sql, err = getSqlForPubInfoForSub(newCtx, pubName, true)
 	if err != nil {
 		return nil, err
@@ -3369,33 +3369,32 @@ func checkSubscriptionValidCommon(ctx context.Context, ses *Session, subName, ac
 	}
 
 	if tenantInfo == nil {
-		if ctx.Value(defines.TenantIDKey{}) != nil {
-			value := ctx.Value(defines.TenantIDKey{})
-			if tenantId, ok := value.(uint32); ok {
-				sql = getSqlForGetAccountName(tenantId)
-				bh.ClearExecResultSet()
-				newCtx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
-				err = bh.Exec(newCtx, sql)
-				if err != nil {
-					return nil, err
-				}
-				if erArray, err = getResultSet(newCtx, bh); err != nil {
-					return nil, err
-				}
-				if !execResultArrayHasData(erArray) {
-					return nil, moerr.NewInternalError(newCtx, "there is no account, account id %d ", tenantId)
-				}
+		var tenantId uint32
+		tenantId, err = defines.GetAccountId(ctx)
+		if err != nil {
+			return nil, err
+		}
 
-				tenantName, err = erArray[0].GetString(newCtx, 0, 0)
-				if err != nil {
-					return nil, err
-				}
-				if !isSubscriptionValid(accountList, tenantName) {
-					return nil, moerr.NewInternalError(newCtx, "the account %s is not allowed to subscribe the publication %s", tenantName, pubName)
-				}
-			}
-		} else {
-			return nil, moerr.NewInternalError(newCtx, "the subscribe %s is not valid", pubName)
+		sql = getSqlForGetAccountName(tenantId)
+		bh.ClearExecResultSet()
+		newCtx = defines.AttachAccountId(ctx, catalog.System_Account)
+		err = bh.Exec(newCtx, sql)
+		if err != nil {
+			return nil, err
+		}
+		if erArray, err = getResultSet(newCtx, bh); err != nil {
+			return nil, err
+		}
+		if !execResultArrayHasData(erArray) {
+			return nil, moerr.NewInternalError(newCtx, "there is no account, account id %d ", tenantId)
+		}
+
+		tenantName, err = erArray[0].GetString(newCtx, 0, 0)
+		if err != nil {
+			return nil, err
+		}
+		if !isSubscriptionValid(accountList, tenantName) {
+			return nil, moerr.NewInternalError(newCtx, "the account %s is not allowed to subscribe the publication %s", tenantName, pubName)
 		}
 	} else if !isSubscriptionValid(accountList, tenantInfo.GetTenant()) {
 		logError(ses, ses.GetDebugString(),
@@ -4155,7 +4154,7 @@ func doDropAccount(ctx context.Context, ses *Session, da *tree.DropAccount) (err
 		//drop tables of the tenant
 		//NOTE!!!: single DDL drop statement per single transaction
 		//SWITCH TO THE CONTEXT of the deleted context
-		deleteCtx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(accountId))
+		deleteCtx = defines.AttachAccountId(ctx, uint32(accountId))
 
 		//step 2 : drop table mo_user
 		//step 3 : drop table mo_role
@@ -4970,10 +4969,7 @@ func doGrantPrivilege(ctx context.Context, ses *Session, gp *tree.GrantPrivilege
 
 	account := ses.GetTenantInfo()
 	if account == nil {
-		ctxUserId := ctx.Value(defines.UserIDKey{})
-		if id, ok := ctxUserId.(uint32); ok {
-			userId = id
-		}
+		userId = defines.GetUserId(ctx)
 	} else {
 		userId = account.GetUserID()
 	}
@@ -7498,9 +7494,7 @@ func InitSysTenant(ctx context.Context, aicm *defines.AutoIncrCacheManager) (err
 		DefaultRoleID: moAdminRoleID,
 	}
 
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(sysAccountID))
-	ctx = context.WithValue(ctx, defines.UserIDKey{}, uint32(rootID))
-	ctx = context.WithValue(ctx, defines.RoleIDKey{}, uint32(moAdminRoleID))
+	ctx = defines.AttachAccount(ctx, uint32(sysAccountID), uint32(rootID), uint32(moAdminRoleID))
 
 	mp, err = mpool.NewMPool("init_system_tenant", 0, mpool.NoFixed)
 	if err != nil {
@@ -7715,9 +7709,7 @@ func InitGeneralTenant(ctx context.Context, ses *Session, ca *tree.CreateAccount
 		}
 	}
 
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(tenant.GetTenantID()))
-	ctx = context.WithValue(ctx, defines.UserIDKey{}, uint32(tenant.GetUserID()))
-	ctx = context.WithValue(ctx, defines.RoleIDKey{}, uint32(tenant.GetDefaultRoleID()))
+	ctx = defines.AttachAccount(ctx, uint32(tenant.GetTenantID()), uint32(tenant.GetUserID()), uint32(tenant.GetDefaultRoleID()))
 
 	_, st := trace.Debug(ctx, "InitGeneralTenant.init_general_tenant")
 	mp, err = mpool.NewMPool("init_general_tenant", 0, mpool.NoFixed)
@@ -7800,11 +7792,11 @@ func InitGeneralTenant(ctx context.Context, ses *Session, ca *tree.CreateAccount
 		if rtnErr != nil {
 			return rtnErr
 		}
-		rtnErr = createTablesInSystemOfGeneralTenant(ctx, bh, newTenant)
+		rtnErr = createTablesInSystemOfGeneralTenant(newTenantCtx, bh, newTenant)
 		if rtnErr != nil {
 			return rtnErr
 		}
-		rtnErr = createTablesInInformationSchemaOfGeneralTenant(ctx, bh, newTenant)
+		rtnErr = createTablesInInformationSchemaOfGeneralTenant(newTenantCtx, bh, newTenant)
 		if rtnErr != nil {
 			return rtnErr
 		}
@@ -7906,9 +7898,7 @@ func createTablesInMoCatalogOfGeneralTenant(ctx context.Context, bh BackgroundEx
 		DefaultRoleID: accountAdminRoleID,
 	}
 	//with new tenant
-	newTenantCtx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(newTenantID))
-	newTenantCtx = context.WithValue(newTenantCtx, defines.UserIDKey{}, uint32(newUserId))
-	newTenantCtx = context.WithValue(newTenantCtx, defines.RoleIDKey{}, uint32(accountAdminRoleID))
+	newTenantCtx = defines.AttachAccount(ctx, uint32(newTenantID), uint32(newUserId), uint32(accountAdminRoleID))
 	return newTenant, newTenantCtx, err
 }
 
@@ -8024,10 +8014,6 @@ func createTablesInMoCatalogOfGeneralTenant2(bh BackgroundExec, ca *tree.CreateA
 func createTablesInSystemOfGeneralTenant(ctx context.Context, bh BackgroundExec, newTenant *TenantInfo) error {
 	ctx, span := trace.Debug(ctx, "createTablesInSystemOfGeneralTenant")
 	defer span.End()
-	//with new tenant
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, newTenant.GetTenantID())
-	ctx = context.WithValue(ctx, defines.UserIDKey{}, newTenant.GetUserID())
-	ctx = context.WithValue(ctx, defines.RoleIDKey{}, newTenant.GetDefaultRoleID())
 
 	var err error
 	sqls := make([]string, 0)
@@ -8054,9 +8040,6 @@ func createTablesInInformationSchemaOfGeneralTenant(ctx context.Context, bh Back
 	defer span.End()
 	//with new tenant
 	//TODO: when we have the auto_increment column, we need new strategy.
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, newTenant.GetTenantID())
-	ctx = context.WithValue(ctx, defines.UserIDKey{}, newTenant.GetUserID())
-	ctx = context.WithValue(ctx, defines.RoleIDKey{}, newTenant.GetDefaultRoleID())
 
 	var err error
 	sqls := make([]string, 0, len(sysview.InitInformationSchemaSysTables)+len(sysview.InitMysqlSysTables)+4)
@@ -8097,9 +8080,7 @@ func createSubscriptionDatabase(ctx context.Context, bh BackgroundExec, newTenan
 	}
 
 	//with new tenant
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, newTenant.GetTenantID())
-	ctx = context.WithValue(ctx, defines.UserIDKey{}, newTenant.GetUserID())
-	ctx = context.WithValue(ctx, defines.RoleIDKey{}, newTenant.GetDefaultRoleID())
+	ctx = defines.AttachAccount(ctx, uint32(newTenant.GetTenantID()), uint32(newTenant.GetUserID()), uint32(newTenant.GetDefaultRoleID()))
 
 	createSubscriptionFormat := `create database %s from sys publication %s;`
 	sqls := make([]string, 0, len(subscriptions))
@@ -8817,7 +8798,7 @@ func doAlterAccountConfig(ctx context.Context, ses *Session, stmt *tree.AlterDat
 		}
 
 		// step 1: check account exists or not
-		newCtx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+		newCtx = defines.AttachAccountId(ctx, catalog.System_Account)
 		isExist, rtnErr = checkTenantExistsOrNot(newCtx, bh, accountName)
 		if rtnErr != nil {
 			return rtnErr
@@ -9112,13 +9093,9 @@ func doGrantPrivilegeImplicitly(ctx context.Context, ses *Session, stmt tree.Sta
 	tenantInfo = ses.GetTenantInfo()
 	// if is system account
 	if tenantInfo.IsSysTenant() {
-		tenantCtx = context.WithValue(ses.GetRequestContext(), defines.TenantIDKey{}, uint32(sysAccountID))
-		tenantCtx = context.WithValue(tenantCtx, defines.UserIDKey{}, uint32(rootID))
-		tenantCtx = context.WithValue(tenantCtx, defines.RoleIDKey{}, uint32(moAdminRoleID))
+		tenantCtx = defines.AttachAccount(ses.GetRequestContext(), uint32(sysAccountID), uint32(rootID), uint32(moAdminRoleID))
 	} else {
-		tenantCtx = context.WithValue(ses.GetRequestContext(), defines.TenantIDKey{}, tenantInfo.GetTenantID())
-		tenantCtx = context.WithValue(tenantCtx, defines.UserIDKey{}, tenantInfo.GetUserID())
-		tenantCtx = context.WithValue(tenantCtx, defines.RoleIDKey{}, uint32(accountAdminRoleID))
+		tenantCtx = defines.AttachAccount(ses.GetRequestContext(), tenantInfo.GetTenantID(), tenantInfo.GetUserID(), uint32(accountAdminRoleID))
 	}
 
 	// 2.grant database privilege
@@ -9163,13 +9140,9 @@ func doRevokePrivilegeImplicitly(ctx context.Context, ses *Session, stmt tree.St
 	tenantInfo = ses.GetTenantInfo()
 	// if is system account
 	if tenantInfo.IsSysTenant() {
-		tenantCtx = context.WithValue(ses.GetRequestContext(), defines.TenantIDKey{}, uint32(sysAccountID))
-		tenantCtx = context.WithValue(tenantCtx, defines.UserIDKey{}, uint32(rootID))
-		tenantCtx = context.WithValue(tenantCtx, defines.RoleIDKey{}, uint32(moAdminRoleID))
+		tenantCtx = defines.AttachAccount(ses.GetRequestContext(), uint32(sysAccountID), uint32(rootID), uint32(moAdminRoleID))
 	} else {
-		tenantCtx = context.WithValue(ses.GetRequestContext(), defines.TenantIDKey{}, tenantInfo.GetTenantID())
-		tenantCtx = context.WithValue(tenantCtx, defines.UserIDKey{}, tenantInfo.GetUserID())
-		tenantCtx = context.WithValue(tenantCtx, defines.RoleIDKey{}, uint32(accountAdminRoleID))
+		tenantCtx = defines.AttachAccount(ses.GetRequestContext(), tenantInfo.GetTenantID(), tenantInfo.GetUserID(), uint32(accountAdminRoleID))
 	}
 
 	// 2.grant database privilege

--- a/pkg/frontend/cmd_executor.go
+++ b/pkg/frontend/cmd_executor.go
@@ -180,7 +180,10 @@ var _ StmtExecutor = &resultSetStmtExecutor{}
 func Execute(ctx context.Context, ses *Session, proc *process.Process, stmtExec StmtExecutor, beginInstant time.Time, envStmt, sqlType string, useEnv bool) error {
 	var err, err2 error
 	var cmpBegin, runBegin time.Time
-	ctx = RecordStatement(ctx, ses, proc, stmtExec, beginInstant, envStmt, sqlType, useEnv)
+	ctx, err = RecordStatement(ctx, ses, proc, stmtExec, beginInstant, envStmt, sqlType, useEnv)
+	if err != nil {
+		return err
+	}
 	err = stmtExec.Setup(ctx, ses)
 	if err != nil {
 		goto handleRet

--- a/pkg/frontend/compiler_context.go
+++ b/pkg/frontend/compiler_context.go
@@ -118,8 +118,8 @@ func (tcc *TxnCompilerContext) GetRootSql() string {
 	return tcc.GetSession().GetSql()
 }
 
-func (tcc *TxnCompilerContext) GetAccountId() uint32 {
-	return tcc.ses.accountId
+func (tcc *TxnCompilerContext) GetAccountId() (uint32, error) {
+	return tcc.ses.accountId, nil
 }
 
 func (tcc *TxnCompilerContext) GetContext() context.Context {
@@ -184,15 +184,15 @@ func (tcc *TxnCompilerContext) getRelation(dbName string, tableName string, sub 
 	if isClusterTable(dbName, tableName) {
 		//if it is the cluster table in the general account, switch into the sys account
 		if account != nil && account.GetTenantID() != sysAccountID {
-			txnCtx = context.WithValue(txnCtx, defines.TenantIDKey{}, uint32(sysAccountID))
+			txnCtx = defines.AttachAccountId(txnCtx, sysAccountID)
 		}
 	}
 	if sub != nil {
-		txnCtx = context.WithValue(txnCtx, defines.TenantIDKey{}, uint32(sub.AccountId))
+		txnCtx = defines.AttachAccountId(txnCtx, uint32(sub.AccountId))
 		dbName = sub.DbName
 	}
 	if dbName == catalog.MO_SYSTEM && tableName == catalog.MO_STATEMENT {
-		txnCtx = context.WithValue(txnCtx, defines.TenantIDKey{}, uint32(sysAccountID))
+		txnCtx = defines.AttachAccountId(txnCtx, uint32(sysAccountID))
 	}
 
 	//open database

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -242,7 +242,10 @@ func (cwft *TxnComputationWrapper) Compile(requestCtx context.Context, u interfa
 	if !cacheHit {
 		cwft.plan, err = buildPlan(requestCtx, cwft.ses, cwft.ses.GetTxnCompileCtx(), cwft.stmt)
 	} else if cwft.ses != nil && cwft.ses.GetTenantInfo() != nil {
-		cwft.ses.accountId = defines.GetAccountId(requestCtx)
+		cwft.ses.accountId, err = defines.GetAccountId(requestCtx)
+		if err != nil {
+			return nil, err
+		}
 		err = authenticateCanExecuteStatementAndPlan(requestCtx, cwft.ses, cwft.stmt, cwft.plan)
 	}
 	if err != nil {

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -223,7 +223,7 @@ func transferSessionConnType2StatisticConnType(c ConnType) statistic.ConnType {
 	}
 }
 
-var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Process, cw ComputationWrapper, envBegin time.Time, envStmt, sqlType string, useEnv bool) context.Context {
+var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Process, cw ComputationWrapper, envBegin time.Time, envStmt, sqlType string, useEnv bool) (context.Context, error) {
 	// set StatementID
 	var stmID uuid.UUID
 	var statement tree.Statement = nil
@@ -260,7 +260,7 @@ var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Proc
 	}
 
 	if !motrace.GetTracerProvider().IsEnable() {
-		return ctx
+		return ctx, nil
 	}
 	tenant := ses.GetTenantInfo()
 	if tenant == nil {
@@ -269,8 +269,12 @@ var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Proc
 	stm := motrace.NewStatementInfo()
 	// set TransactionID
 	var txn TxnOperator
+	var err error
 	if handler := ses.GetTxnHandler(); handler.IsValidTxnOperator() {
-		_, txn = handler.GetTxnOperator()
+		_, txn, err = handler.GetTxnOperator()
+		if err != nil {
+			return nil, err
+		}
 		copy(stm.TransactionID[:], txn.Txn().ID)
 	}
 	// set SessionID
@@ -306,11 +310,11 @@ var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Proc
 		stm.Report(ctx)
 	}
 
-	return motrace.ContextWithStatement(ctx, stm)
+	return motrace.ContextWithStatement(ctx, stm), nil
 }
 
 var RecordParseErrorStatement = func(ctx context.Context, ses *Session, proc *process.Process, envBegin time.Time,
-	envStmt []string, sqlTypes []string, err error) context.Context {
+	envStmt []string, sqlTypes []string, err error) (context.Context, error) {
 	retErr := moerr.NewParseError(ctx, err.Error())
 	/*
 		!!!NOTE: the sql may be empty string.
@@ -327,11 +331,17 @@ var RecordParseErrorStatement = func(ctx context.Context, ses *Session, proc *pr
 			if i < len(sqlTypes) {
 				sqlType = sqlTypes[i]
 			}
-			ctx = RecordStatement(ctx, ses, proc, nil, envBegin, sql, sqlType, true)
+			ctx, err = RecordStatement(ctx, ses, proc, nil, envBegin, sql, sqlType, true)
+			if err != nil {
+				return nil, err
+			}
 			motrace.EndStatement(ctx, retErr, 0, 0)
 		}
 	} else {
-		ctx = RecordStatement(ctx, ses, proc, nil, envBegin, "", sqlType, true)
+		ctx, err = RecordStatement(ctx, ses, proc, nil, envBegin, "", sqlType, true)
+		if err != nil {
+			return nil, err
+		}
 		motrace.EndStatement(ctx, retErr, 0, 0)
 	}
 
@@ -341,16 +351,20 @@ var RecordParseErrorStatement = func(ctx context.Context, ses *Session, proc *pr
 	}
 	incStatementCounter(tenant.GetTenant(), nil)
 	incStatementErrorsCounter(tenant.GetTenant(), nil)
-	return ctx
+	return ctx, nil
 }
 
 // RecordStatementTxnID record txnID after TxnBegin or Compile(autocommit=1)
-var RecordStatementTxnID = func(ctx context.Context, ses *Session) {
+var RecordStatementTxnID = func(ctx context.Context, ses *Session) error {
 	var txn TxnOperator
+	var err error
 	if stm := motrace.StatementFromContext(ctx); ses != nil && stm != nil && stm.IsZeroTxnID() {
 		if handler := ses.GetTxnHandler(); handler.IsValidTxnOperator() {
-			// 简化获取TxnOperator 逻辑, 详见 https://github.com/matrixorigin/matrixone/pull/13436#pullrequestreview-1779063200
-			_, txn = handler.GetTxnOperator()
+			// simplify the logic of TxnOperator. refer to https://github.com/matrixorigin/matrixone/pull/13436#pullrequestreview-1779063200
+			_, txn, err = handler.GetTxnOperator()
+			if err != nil {
+				return err
+			}
 			stm.SetTxnID(txn.Txn().ID)
 			ses.SetTxnId(txn.Txn().ID)
 		}
@@ -361,7 +375,10 @@ var RecordStatementTxnID = func(ctx context.Context, ses *Session) {
 	if upSes := ses.upstream; upSes != nil && upSes.tStmt != nil && upSes.tStmt.IsZeroTxnID() /* not record txn-id */ {
 		// background session has valid txn
 		if handler := ses.GetTxnHandler(); handler.IsValidTxnOperator() {
-			_, txn = handler.GetTxnOperator()
+			_, txn, err = handler.GetTxnOperator()
+			if err != nil {
+				return err
+			}
 			// set upstream (the frontend session) statement's txn-id
 			// PS: only skip ONE txn
 			if stmt := upSes.tStmt; stmt.NeedSkipTxn() /* normally set by determineUserHasPrivilegeSet */ {
@@ -373,6 +390,7 @@ var RecordStatementTxnID = func(ctx context.Context, ses *Session) {
 			}
 		}
 	}
+	return nil
 }
 
 func handleShowTableStatus(ses *Session, stmt *tree.ShowTableStatus, proc *process.Process) error {
@@ -1657,7 +1675,10 @@ func buildPlan(requestCtx context.Context, ses *Session, ctx plan2.CompilerConte
 	var err error
 	isPrepareStmt := false
 	if ses != nil {
-		ses.accountId = defines.GetAccountId(requestCtx)
+		ses.accountId, err = defines.GetAccountId(requestCtx)
+		if err != nil {
+			return nil, err
+		}
 		if len(ses.sql) > 8 {
 			prefix := strings.ToLower(ses.sql[:8])
 			isPrepareStmt = prefix == "execute " || prefix == "prepare "
@@ -1712,6 +1733,9 @@ func buildPlan(requestCtx context.Context, ses *Session, ctx plan2.CompilerConte
 }
 
 func checkModify(plan2 *plan.Plan, proc *process.Process, ses *Session) bool {
+	if plan2 == nil {
+		return true
+	}
 	checkFn := func(db string, def *plan.TableDef) bool {
 		_, tableDef := ses.GetTxnCompileCtx().Resolve(db, def.Name)
 		if tableDef == nil {
@@ -1776,6 +1800,10 @@ var GetComputationWrapper = func(db string, input *UserInput, user string, eng e
 		for i, stmt := range cached.stmts {
 			tcw := InitTxnComputationWrapper(ses, stmt, proc)
 			tcw.plan = cached.plans[i]
+			if tcw.plan == nil {
+				modify = true
+				break
+			}
 			if checkModify(tcw.plan, proc, ses) {
 				modify = true
 				break
@@ -2862,7 +2890,10 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 		return err
 	}
 
-	_, txnOp := ses.GetTxnHandler().GetTxnOperator()
+	_, txnOp, err := ses.GetTxnHandler().GetTxnOperator()
+	if err != nil {
+		return err
+	}
 	ses.GetTxnHandler().disableStartStmt()
 	if txnOp != nil && !ses.IsDerivedStmt() {
 		txnOp.GetWorkspace().StartStatement()
@@ -2873,7 +2904,12 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 	defer func() {
 		// move finishTxnFunc() out to another defer so that if finishTxnFunc
 		// paniced, the following is still called.
-		_, txnOp := ses.GetTxnHandler().GetTxnOperator()
+		var err3 error
+		_, txnOp, err3 = ses.GetTxnHandler().GetTxnOperator()
+		if err3 != nil {
+			logError(ses, ses.GetDebugString(), err3.Error())
+			return
+		}
 		if txnOp != nil && !ses.IsDerivedStmt() {
 			ok, id := ses.GetTxnHandler().calledStartStmt()
 			if ok && bytes.Equal(txnOp.Txn().ID, id) {
@@ -3789,10 +3825,14 @@ func (mce *MysqlCmdExecutor) doComQuery(requestCtx context.Context, input *UserI
 		}
 		userNameOnly = ses.GetTenantInfo().GetUser()
 	} else {
-		proc.SessionInfo.Account = sysAccountName
-		proc.SessionInfo.AccountId = sysAccountID
-		proc.SessionInfo.RoleId = moAdminRoleID
-		proc.SessionInfo.UserId = rootID
+		var accountId uint32
+		accountId, retErr = defines.GetAccountId(requestCtx)
+		if retErr != nil {
+			return retErr
+		}
+		proc.SessionInfo.AccountId = accountId
+		proc.SessionInfo.UserId = defines.GetUserId(requestCtx)
+		proc.SessionInfo.RoleId = defines.GetRoleId(requestCtx)
 	}
 	var span trace.Span
 	requestCtx, span = trace.Start(requestCtx, "MysqlCmdExecutor.doComQuery",
@@ -3817,7 +3857,11 @@ func (mce *MysqlCmdExecutor) doComQuery(requestCtx context.Context, input *UserI
 
 	if err != nil {
 		statsInfo.ParseDuration = ParseDuration
-		requestCtx = RecordParseErrorStatement(requestCtx, ses, proc, beginInstant, parsers.HandleSqlForRecord(input.getSql()), input.getSqlSourceTypes(), err)
+		var err2 error
+		requestCtx, err2 = RecordParseErrorStatement(requestCtx, ses, proc, beginInstant, parsers.HandleSqlForRecord(input.getSql()), input.getSqlSourceTypes(), err)
+		if err2 != nil {
+			return err2
+		}
 		retErr = err
 		if _, ok := err.(*moerr.Error); !ok {
 			retErr = moerr.NewParseError(requestCtx, err.Error())
@@ -3856,7 +3900,11 @@ func (mce *MysqlCmdExecutor) doComQuery(requestCtx context.Context, input *UserI
 		proto.ResetStatistics() // move from getDataFromPipeline, for record column fields' data
 		stmt := cw.GetAst()
 		sqlType := input.getSqlSourceType(i)
-		requestCtx = RecordStatement(requestCtx, ses, proc, cw, beginInstant, sqlRecord[i], sqlType, singleStatement)
+		var err2 error
+		requestCtx, err2 = RecordStatement(requestCtx, ses, proc, cw, beginInstant, sqlRecord[i], sqlType, singleStatement)
+		if err2 != nil {
+			return err2
+		}
 
 		statsInfo.Reset()
 		//average parse duration
@@ -4004,7 +4052,11 @@ func (mce *MysqlCmdExecutor) doComQueryInProgress(requestCtx context.Context, in
 		pu.StorageEngine,
 		proc, ses)
 	if err != nil {
-		requestCtx = RecordParseErrorStatement(requestCtx, ses, proc, beginInstant, parsers.HandleSqlForRecord(input.getSql()), input.getSqlSourceTypes(), err)
+		var err2 error
+		requestCtx, err2 = RecordParseErrorStatement(requestCtx, ses, proc, beginInstant, parsers.HandleSqlForRecord(input.getSql()), input.getSqlSourceTypes(), err)
+		if err2 != nil {
+			return err2
+		}
 		retErr = moerr.NewParseError(requestCtx, err.Error())
 		logStatementStringStatus(requestCtx, ses, input.getSql(), fail, retErr)
 		return retErr

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -17,6 +17,7 @@ package frontend
 import (
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"io"
 	"testing"
 	"time"
@@ -62,14 +63,14 @@ func init() {
 func mockRecordStatement(ctx context.Context) (context.Context, *gostub.Stubs) {
 	stm := &motrace.StatementInfo{}
 	ctx = motrace.ContextWithStatement(ctx, stm)
-	stubs := gostub.Stub(&RecordStatement, func(context.Context, *Session, *process.Process, ComputationWrapper, time.Time, string, string, bool) context.Context {
-		return ctx
+	stubs := gostub.Stub(&RecordStatement, func(context.Context, *Session, *process.Process, ComputationWrapper, time.Time, string, string, bool) (context.Context, error) {
+		return ctx, nil
 	})
 	return ctx, stubs
 }
 
 func Test_mce(t *testing.T) {
-	ctx := context.TODO()
+	ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
 	convey.Convey("boot mce succ", t, func() {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -291,7 +292,7 @@ func Test_mce(t *testing.T) {
 }
 
 func Test_mce_selfhandle(t *testing.T) {
-	ctx := context.TODO()
+	ctx := defines.AttachAccountId(context.TODO(), catalog.System_Account)
 	convey.Convey("handleChangeDB", t, func() {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -871,32 +872,32 @@ func runTestHandle(funName string, t *testing.T, handleFun func(*MysqlCmdExecuto
 }
 
 func Test_HandlePrepareStmt(t *testing.T) {
-	ctx := context.TODO()
+	ctx := defines.AttachAccountId(context.TODO(), catalog.System_Account)
 	stmt, err := parsers.ParseOne(ctx, dialect.MYSQL, "Prepare stmt1 from select 1, 2", 1)
 	if err != nil {
 		t.Errorf("parser sql error %v", err)
 	}
 	runTestHandle("handlePrepareStmt", t, func(mce *MysqlCmdExecutor) error {
 		stmt := stmt.(*tree.PrepareStmt)
-		_, err := mce.handlePrepareStmt(context.TODO(), stmt, "")
+		_, err := mce.handlePrepareStmt(ctx, stmt, "")
 		return err
 	})
 }
 
 func Test_HandleDeallocate(t *testing.T) {
-	ctx := context.TODO()
+	ctx := defines.AttachAccountId(context.TODO(), catalog.System_Account)
 	stmt, err := parsers.ParseOne(ctx, dialect.MYSQL, "deallocate Prepare stmt1", 1)
 	if err != nil {
 		t.Errorf("parser sql error %v", err)
 	}
 	runTestHandle("handleDeallocate", t, func(mce *MysqlCmdExecutor) error {
 		stmt := stmt.(*tree.Deallocate)
-		return mce.handleDeallocate(context.TODO(), stmt)
+		return mce.handleDeallocate(ctx, stmt)
 	})
 }
 
 func Test_CMD_FIELD_LIST(t *testing.T) {
-	ctx := context.TODO()
+	ctx := defines.AttachAccountId(context.TODO(), catalog.System_Account)
 	convey.Convey("cmd field list", t, func() {
 		runtime.SetupProcessLevelRuntime(runtime.DefaultRuntime())
 		queryData := []byte("A")
@@ -1328,11 +1329,13 @@ func Test_RecordParseErrorStatement(t *testing.T) {
 	}
 
 	motrace.GetTracerProvider().SetEnable(true)
-	ctx := RecordParseErrorStatement(context.TODO(), ses, proc, time.Now(), nil, nil, moerr.NewInternalErrorNoCtx("test"))
+	ctx, err := RecordParseErrorStatement(context.TODO(), ses, proc, time.Now(), nil, nil, moerr.NewInternalErrorNoCtx("test"))
+	assert.Nil(t, err)
 	si := motrace.StatementFromContext(ctx)
 	require.NotNil(t, si)
 
-	ctx = RecordParseErrorStatement(context.TODO(), ses, proc, time.Now(), []string{"abc", "def"}, []string{constant.ExternSql, constant.ExternSql}, moerr.NewInternalErrorNoCtx("test"))
+	ctx, err = RecordParseErrorStatement(context.TODO(), ses, proc, time.Now(), []string{"abc", "def"}, []string{constant.ExternSql, constant.ExternSql}, moerr.NewInternalErrorNoCtx("test"))
+	assert.Nil(t, err)
 	si = motrace.StatementFromContext(ctx)
 	require.NotNil(t, si)
 

--- a/pkg/frontend/plan_cache.go
+++ b/pkg/frontend/plan_cache.go
@@ -16,7 +16,6 @@ package frontend
 
 import (
 	"container/list"
-
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 )
@@ -44,6 +43,11 @@ func (pc *planCache) cache(sql string, stmts []tree.Statement, plans []*plan.Pla
 	if pc.cachePool == nil {
 		pc.cachePool = make(map[string]*list.Element)
 		pc.lruList = list.New()
+	}
+	for i := range stmts {
+		if plans[i] == nil {
+			return
+		}
 	}
 	element := pc.lruList.PushFront(&cachedPlan{sql: sql, stmts: stmts, plans: plans})
 	pc.cachePool[sql] = element

--- a/pkg/frontend/routine.go
+++ b/pkg/frontend/routine.go
@@ -229,9 +229,7 @@ func (rt *Routine) handleRequest(req *Request) error {
 	if ses.getRoutineManager().baseService != nil {
 		nodeCtx = context.WithValue(cancelRequestCtx, defines.NodeIDKey{}, ses.getRoutineManager().baseService.ID())
 	}
-	tenantCtx := context.WithValue(nodeCtx, defines.TenantIDKey{}, tenant.GetTenantID())
-	tenantCtx = context.WithValue(tenantCtx, defines.UserIDKey{}, tenant.GetUserID())
-	tenantCtx = context.WithValue(tenantCtx, defines.RoleIDKey{}, tenant.GetDefaultRoleID())
+	tenantCtx := defines.AttachAccount(nodeCtx, tenant.GetTenantID(), tenant.GetUserID(), tenant.GetDefaultRoleID())
 	ses.SetRequestContext(tenantCtx)
 	executor.SetSession(ses)
 

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -545,11 +545,15 @@ func NewSession(proto Protocol, mp *mpool.MPool, pu *config.ParameterUnit,
 	//Currently, we only use the sharedTxnHandler in the background session.
 	var txnCtx context.Context
 	var txnOp TxnOperator
+	var err error
 	if sharedTxnHandler != nil {
 		if !sharedTxnHandler.IsValidTxnOperator() {
 			panic("shared txn is invalid")
 		}
-		txnCtx, txnOp = sharedTxnHandler.GetTxnOperator()
+		txnCtx, txnOp, err = sharedTxnHandler.GetTxnOperator()
+		if err != nil {
+			panic(err)
+		}
 	}
 	txnHandler := InitTxnHandler(pu.StorageEngine, pu.TxnClient, txnCtx, txnOp)
 
@@ -599,8 +603,6 @@ func NewSession(proto Protocol, mp *mpool.MPool, pu *config.ParameterUnit,
 	ses.GetTxnCompileCtx().SetSession(ses)
 	ses.GetTxnHandler().SetSession(ses)
 	ses.SetAutoIncrCacheManager(aicm)
-
-	var err error
 	if ses.mp == nil {
 		// If no mp, we create one for session.  Use GuestMmuLimitation as cap.
 		// fixed pool size can be another param, or should be computed from cap,
@@ -1394,7 +1396,10 @@ func (ses *Session) GetTxnInfo() string {
 	if txnH == nil {
 		return ""
 	}
-	_, txnOp := txnH.GetTxnOperator()
+	_, txnOp, err := txnH.GetTxnOperator()
+	if err != nil {
+		return ""
+	}
 	if txnOp == nil {
 		return ""
 	}
@@ -1527,9 +1532,7 @@ func (ses *Session) AuthenticateUser(userInput string, dbName string, authRespon
 
 	//step1 : check tenant exists or not in SYS tenant context
 	ses.timestampMap[TSCheckTenantStart] = time.Now()
-	sysTenantCtx := context.WithValue(ses.GetRequestContext(), defines.TenantIDKey{}, uint32(sysAccountID))
-	sysTenantCtx = context.WithValue(sysTenantCtx, defines.UserIDKey{}, uint32(rootID))
-	sysTenantCtx = context.WithValue(sysTenantCtx, defines.RoleIDKey{}, uint32(moAdminRoleID))
+	sysTenantCtx := defines.AttachAccount(ses.GetRequestContext(), uint32(sysAccountID), uint32(rootID), uint32(moAdminRoleID))
 	sqlForCheckTenant, err := getSqlForCheckTenant(sysTenantCtx, tenant.GetTenant())
 	if err != nil {
 		return nil, err
@@ -1586,7 +1589,7 @@ func (ses *Session) AuthenticateUser(userInput string, dbName string, authRespon
 	//step3 : get the password of the user
 
 	ses.timestampMap[TSCheckUserStart] = time.Now()
-	tenantCtx := context.WithValue(ses.GetRequestContext(), defines.TenantIDKey{}, uint32(tenantID))
+	tenantCtx := defines.AttachAccountId(ses.GetRequestContext(), uint32(tenantID))
 
 	logDebugf(sessionInfo, "check user of %s exists", tenant)
 	//Get the password of the user in an independent session
@@ -1760,9 +1763,7 @@ func (ses *Session) InitGlobalSystemVariables() error {
 	tenantInfo := ses.GetTenantInfo()
 	// if is system account
 	if tenantInfo.IsSysTenant() {
-		sysTenantCtx := context.WithValue(ses.GetRequestContext(), defines.TenantIDKey{}, uint32(sysAccountID))
-		sysTenantCtx = context.WithValue(sysTenantCtx, defines.UserIDKey{}, uint32(rootID))
-		sysTenantCtx = context.WithValue(sysTenantCtx, defines.RoleIDKey{}, uint32(moAdminRoleID))
+		sysTenantCtx := defines.AttachAccount(ses.GetRequestContext(), uint32(sysAccountID), uint32(rootID), uint32(moAdminRoleID))
 
 		// get system variable from mo_mysql_compatibility mode
 		sqlForGetVariables := getSystemVariablesWithAccount(sysAccountID)
@@ -1808,9 +1809,7 @@ func (ses *Session) InitGlobalSystemVariables() error {
 			return moerr.NewInternalError(sysTenantCtx, "there is no data in mo_mysql_compatibility_mode table for account %s", sysAccountName)
 		}
 	} else {
-		tenantCtx := context.WithValue(ses.GetRequestContext(), defines.TenantIDKey{}, tenantInfo.GetTenantID())
-		tenantCtx = context.WithValue(tenantCtx, defines.UserIDKey{}, tenantInfo.GetUserID())
-		tenantCtx = context.WithValue(tenantCtx, defines.RoleIDKey{}, uint32(accountAdminRoleID))
+		tenantCtx := defines.AttachAccount(ses.GetRequestContext(), tenantInfo.GetTenantID(), tenantInfo.GetUserID(), uint32(accountAdminRoleID))
 
 		// get system variable from mo_mysql_compatibility mode
 		sqlForGetVariables := getSystemVariablesWithAccount(uint64(tenantInfo.GetTenantID()))
@@ -2041,6 +2040,10 @@ func (bh *BackgroundHandler) Exec(ctx context.Context, sql string) error {
 	} else {
 		bh.ses.SetRequestContext(ctx)
 	}
+	_, err := defines.GetAccountId(ctx)
+	if err != nil {
+		return err
+	}
 	bh.mce.ChooseDoQueryFunc(bh.ses.GetParameterUnit().SV.EnableDoComQueryInProgress)
 
 	// For determine this is a background sql.
@@ -2080,6 +2083,10 @@ func (bh *BackgroundHandler) ExecStmt(ctx context.Context, stmt tree.Statement) 
 		ctx = bh.ses.GetRequestContext()
 	} else {
 		bh.ses.SetRequestContext(ctx)
+	}
+	_, err := defines.GetAccountId(ctx)
+	if err != nil {
+		return err
 	}
 	bh.mce.ChooseDoQueryFunc(bh.ses.GetParameterUnit().SV.EnableDoComQueryInProgress)
 

--- a/pkg/frontend/session_test.go
+++ b/pkg/frontend/session_test.go
@@ -45,7 +45,7 @@ func TestTxnHandler_NewTxn(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		ctx := context.TODO()
+		ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
 		txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
 		txnOperator.EXPECT().Txn().Return(txn.TxnMeta{}).AnyTimes()
 		txnOperator.EXPECT().Rollback(gomock.Any()).Return(nil).AnyTimes()
@@ -101,7 +101,7 @@ func TestTxnHandler_CommitTxn(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		ctx := context.TODO()
+		ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
 		idx := int64(1)
 		txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
 		txnOperator.EXPECT().Txn().Return(txn.TxnMeta{
@@ -171,7 +171,7 @@ func TestTxnHandler_RollbackTxn(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		ctx := context.TODO()
+		ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
 		txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
 		txnOperator.EXPECT().Txn().Return(txn.TxnMeta{}).AnyTimes()
 		cnt := 0
@@ -236,8 +236,9 @@ func TestSession_TxnBegin(t *testing.T) {
 		eng.EXPECT().Hints().Return(hints).AnyTimes()
 		eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		session := NewSession(proto, nil, config.NewParameterUnit(&config.FrontendParameters{}, eng, txnClient, nil), gSysVars, false, nil, nil)
-		session.SetRequestContext(context.Background())
-		session.SetConnectContext(context.Background())
+		ctx := defines.AttachAccountId(context.Background(), sysAccountID)
+		session.SetRequestContext(ctx)
+		session.SetConnectContext(ctx)
 		return session
 	}
 	convey.Convey("new session", t, func() {
@@ -543,8 +544,9 @@ func TestSession_TxnCompilerContext(t *testing.T) {
 		}
 		proto := NewMysqlClientProtocol(0, ioses, 1024, sv)
 		session := NewSession(proto, nil, pu, gSysVars, false, nil, nil)
-		session.SetRequestContext(context.Background())
-		session.SetConnectContext(context.Background())
+		ctx := defines.AttachAccountId(context.Background(), sysAccountID)
+		session.SetRequestContext(ctx)
+		session.SetConnectContext(ctx)
 		return session
 	}
 

--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -17,11 +17,12 @@ package frontend
 import (
 	"context"
 	"fmt"
-	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
 	"math"
 	"strings"
 	"time"
+
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -343,7 +344,7 @@ func doShowAccounts(ctx context.Context, ses *Session, sa *tree.ShowAccounts) (e
 			return moerr.NewInternalError(ctx, "only sys account can use LIKE clause")
 		}
 		// switch to the sys account to get account info
-		newCtx := context.WithValue(ctx, defines.TenantIDKey{}, uint32(sysAccountID))
+		newCtx := defines.AttachAccountId(ctx, uint32(sysAccountID))
 		sql = getSqlForAccountInfo(uint64(account.GetTenantID()))
 		if allAccountInfo, accountIds, err = getAccountInfo(newCtx, bh, sql, true); err != nil {
 			return err
@@ -373,7 +374,7 @@ func doShowAccounts(ctx context.Context, ses *Session, sa *tree.ShowAccounts) (e
 	for i, ids := range accountIds {
 		for _, id := range ids {
 			//step 3.1: get the admin_name, db_count, table_count for each account
-			newCtx := context.WithValue(ctx, defines.TenantIDKey{}, uint32(id))
+			newCtx := defines.AttachAccountId(ctx, uint32(id))
 
 			tt = time.Now()
 			if tempBatch, err = getTableStats(newCtx, bh, id); err != nil {

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -71,7 +71,7 @@ func InitTxnHandler(storage engine.Engine, txnClient TxnClient, txnCtx context.C
 	return h
 }
 
-func (th *TxnHandler) createTxnCtx() context.Context {
+func (th *TxnHandler) createTxnCtx() (context.Context, error) {
 	if th.txnCtx == nil {
 		th.txnCtx, th.txnCtxCancel = context.WithTimeout(th.ses.GetConnectContext(),
 			th.ses.GetParameterUnit().SV.SessionTimeout.Duration)
@@ -80,15 +80,13 @@ func (th *TxnHandler) createTxnCtx() context.Context {
 	reqCtx := th.ses.GetRequestContext()
 	retTxnCtx := th.txnCtx
 
-	if v := reqCtx.Value(defines.TenantIDKey{}); v != nil {
-		retTxnCtx = context.WithValue(retTxnCtx, defines.TenantIDKey{}, v)
+	accountId, err := defines.GetAccountId(reqCtx)
+	if err != nil {
+		return nil, err
 	}
-	if v := reqCtx.Value(defines.UserIDKey{}); v != nil {
-		retTxnCtx = context.WithValue(retTxnCtx, defines.UserIDKey{}, v)
-	}
-	if v := reqCtx.Value(defines.RoleIDKey{}); v != nil {
-		retTxnCtx = context.WithValue(retTxnCtx, defines.RoleIDKey{}, v)
-	}
+	retTxnCtx = defines.AttachAccountId(retTxnCtx, accountId)
+	retTxnCtx = defines.AttachUserId(retTxnCtx, defines.GetUserId(reqCtx))
+	retTxnCtx = defines.AttachRoleId(retTxnCtx, defines.GetRoleId(reqCtx))
 	if v := reqCtx.Value(defines.NodeIDKey{}); v != nil {
 		retTxnCtx = context.WithValue(retTxnCtx, defines.NodeIDKey{}, v)
 	}
@@ -102,13 +100,18 @@ func (th *TxnHandler) createTxnCtx() context.Context {
 	} else if th.ses.IfInitedTempEngine() {
 		retTxnCtx = context.WithValue(retTxnCtx, defines.TemporaryTN{}, th.ses.GetTempTableStorage())
 	}
-	return retTxnCtx
+	return retTxnCtx, nil
 }
 
-func (th *TxnHandler) AttachTempStorageToTxnCtx() {
+func (th *TxnHandler) AttachTempStorageToTxnCtx() error {
 	th.mu.Lock()
 	defer th.mu.Unlock()
-	th.txnCtx = context.WithValue(th.createTxnCtx(), defines.TemporaryTN{}, th.ses.GetTempTableStorage())
+	ctx, err := th.createTxnCtx()
+	if err != nil {
+		return err
+	}
+	th.txnCtx = context.WithValue(ctx, defines.TemporaryTN{}, th.ses.GetTempTableStorage())
+	return nil
 }
 
 // we don't need to lock. TxnHandler is holded by one session.
@@ -146,7 +149,10 @@ func (th *TxnHandler) NewTxnOperator() (context.Context, TxnOperator, error) {
 		}
 	}
 
-	txnCtx := th.createTxnCtx()
+	txnCtx, err := th.createTxnCtx()
+	if err != nil {
+		return nil, nil, err
+	}
 	if txnCtx == nil {
 		panic("context should not be nil")
 	}
@@ -261,10 +267,14 @@ func (th *TxnHandler) SetTxnOperatorInvalid() {
 	th.txnCtx = nil
 }
 
-func (th *TxnHandler) GetTxnOperator() (context.Context, TxnOperator) {
+func (th *TxnHandler) GetTxnOperator() (context.Context, TxnOperator, error) {
 	th.mu.Lock()
 	defer th.mu.Unlock()
-	return th.createTxnCtx(), th.txnOperator
+	ctx, err := th.createTxnCtx()
+	if err != nil {
+		return nil, nil, err
+	}
+	return ctx, th.txnOperator, nil
 }
 
 func (th *TxnHandler) SetSession(ses *Session) {
@@ -291,7 +301,10 @@ func (th *TxnHandler) CommitTxn() error {
 	}
 	ses := th.GetSession()
 	sessionInfo := ses.GetDebugString()
-	txnCtx, txnOp := th.GetTxnOperator()
+	txnCtx, txnOp, err := th.GetTxnOperator()
+	if err != nil {
+		return err
+	}
 	if txnOp == nil {
 		th.SetTxnOperatorInvalid()
 		logError(ses, sessionInfo, "CommitTxn: txn operator is null")
@@ -315,7 +328,6 @@ func (th *TxnHandler) CommitTxn() error {
 	if val != nil {
 		ctx2 = context.WithValue(ctx2, defines.PkCheckByTN{}, val.(int8))
 	}
-	var err error
 	defer func() {
 		// metric count
 		tenant := ses.GetTenantName()
@@ -362,7 +374,10 @@ func (th *TxnHandler) RollbackTxn() error {
 	}
 	ses := th.GetSession()
 	sessionInfo := ses.GetDebugString()
-	txnCtx, txnOp := th.GetTxnOperator()
+	txnCtx, txnOp, err := th.GetTxnOperator()
+	if err != nil {
+		return err
+	}
 	if txnOp == nil {
 		th.SetTxnOperatorInvalid()
 		logError(ses, ses.GetDebugString(),
@@ -381,7 +396,6 @@ func (th *TxnHandler) RollbackTxn() error {
 		storage.Hints().CommitOrRollbackTimeout,
 	)
 	defer cancel()
-	var err error
 	defer func() {
 		// metric count
 		tenant := ses.GetTenantName()
@@ -567,8 +581,8 @@ func (ses *Session) TxnCreate() (context.Context, TxnOperator, error) {
 		return ses.GetTxnHandler().NewTxn()
 	}
 	txnHandler := ses.GetTxnHandler()
-	txnCtx, txnOp := txnHandler.GetTxnOperator()
-	return txnCtx, txnOp, nil
+	txnCtx, txnOp, err := txnHandler.GetTxnOperator()
+	return txnCtx, txnOp, err
 }
 
 /*

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"math"
 	"sort"
 	"strings"
@@ -506,7 +507,7 @@ func TestGetSimpleExprValue(t *testing.T) {
 }
 
 func TestGetExprValue(t *testing.T) {
-	ctx := context.TODO()
+	ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
 	cvey.Convey("", t, func() {
 		type args struct {
 			sql     string

--- a/pkg/incrservice/allocator_test.go
+++ b/pkg/incrservice/allocator_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	"github.com/lni/goutils/leaktest"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,7 +30,7 @@ func TestAlloc(t *testing.T) {
 	runAllocatorTests(
 		t,
 		func(a valueAllocator) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(defines.AttachAccountId(context.Background(), catalog.System_Account))
 			defer cancel()
 
 			cases := []struct {
@@ -100,7 +102,7 @@ func TestAsyncAlloc(t *testing.T) {
 	runAllocatorTests(
 		t,
 		func(a valueAllocator) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(defines.AttachAccountId(context.Background(), catalog.System_Account))
 			defer cancel()
 
 			cases := []struct {

--- a/pkg/incrservice/column_cache_test.go
+++ b/pkg/incrservice/column_cache_test.go
@@ -22,10 +22,12 @@ import (
 	"testing"
 
 	"github.com/lni/goutils/leaktest"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/constraints"
@@ -517,7 +519,7 @@ func runColumnCacheTestsWithInitOffset(
 	runAllocatorTests(
 		t,
 		func(a valueAllocator) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(defines.AttachAccountId(context.Background(), catalog.System_Account))
 			defer cancel()
 			col := AutoColumn{
 				ColName: "k1",

--- a/pkg/incrservice/service_test.go
+++ b/pkg/incrservice/service_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/lni/goutils/leaktest"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
@@ -201,7 +203,7 @@ func runServiceTests(
 		tc client.TxnClient,
 		ts rpc.TxnSender) {
 		defer leaktest.AfterTest(t)()
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(defines.AttachAccountId(context.Background(), catalog.System_Account), 10*time.Second)
 		defer cancel()
 
 		ss := make([]*service, 0, n)

--- a/pkg/incrservice/store_sql.go
+++ b/pkg/incrservice/store_sql.go
@@ -122,9 +122,13 @@ func (s *sqlStore) Allocate(
 				res.Close()
 
 				if rows != 1 {
+					accountId, err := defines.GetAccountId(ctx)
+					if err != nil {
+						return err
+					}
 					getLogger().Fatal("BUG: read incr record invalid",
 						zap.String("fetch-sql", fetchSQL),
-						zap.Any("account", ctx.Value(defines.TenantIDKey{})),
+						zap.Any("account", accountId),
 						zap.Uint64("table", tableID),
 						zap.String("col", colName),
 						zap.Int("rows", rows),
@@ -149,9 +153,13 @@ func (s *sqlStore) Allocate(
 				if res.AffectedRows == 1 {
 					ok = true
 				} else {
+					accountId, err := defines.GetAccountId(ctx)
+					if err != nil {
+						return err
+					}
 					getLogger().Fatal("BUG: update incr record returns invalid affected rows",
 						zap.String("update-sql", sql),
-						zap.Any("account", ctx.Value(defines.TenantIDKey{})),
+						zap.Any("account", accountId),
 						zap.Uint64("table", tableID),
 						zap.String("col", colName),
 						zap.Uint64("affected-rows", res.AffectedRows),

--- a/pkg/incrservice/types.go
+++ b/pkg/incrservice/types.go
@@ -121,7 +121,7 @@ type incrTableCache interface {
 
 type valueAllocator interface {
 	allocate(ctx context.Context, tableID uint64, col string, count int, txnOp client.TxnOperator) (uint64, uint64, error)
-	asyncAllocate(ctx context.Context, tableID uint64, col string, count int, txnOp client.TxnOperator, cb func(uint64, uint64, error))
+	asyncAllocate(ctx context.Context, tableID uint64, col string, count int, txnOp client.TxnOperator, cb func(uint64, uint64, error)) error
 	updateMinValue(ctx context.Context, tableID uint64, col string, minValue uint64, txnOp client.TxnOperator) error
 	close()
 }

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -1965,10 +1965,10 @@ func (c *Compile) compileTableScanWithNode(n *plan.Node, node engine.Node, filte
 	{
 		ctx := c.ctx
 		if util.TableIsClusterTable(n.TableDef.GetTableType()) {
-			ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+			ctx = defines.AttachAccountId(ctx, catalog.System_Account)
 		}
 		if n.ObjRef.PubInfo != nil {
-			ctx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(n.ObjRef.PubInfo.TenantId))
+			ctx = defines.AttachAccountId(ctx, uint32(n.ObjRef.PubInfo.TenantId))
 		}
 		db, err = c.e.Database(ctx, n.ObjRef.SchemaName, c.proc.TxnOperator)
 		if err != nil {
@@ -3392,13 +3392,13 @@ func (c *Compile) generateNodes(n *plan.Node) (engine.Nodes, []any, []types.T, e
 
 	ctx := c.ctx
 	if util.TableIsClusterTable(n.TableDef.GetTableType()) {
-		ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+		ctx = defines.AttachAccountId(ctx, catalog.System_Account)
 	}
 	if n.ObjRef.PubInfo != nil {
-		ctx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(n.ObjRef.PubInfo.GetTenantId()))
+		ctx = defines.AttachAccountId(ctx, uint32(n.ObjRef.PubInfo.GetTenantId()))
 	}
 	if util.TableIsLoggingTable(n.ObjRef.SchemaName, n.ObjRef.ObjName) {
-		ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+		ctx = defines.AttachAccountId(ctx, catalog.System_Account)
 	}
 	db, err = c.e.Database(ctx, n.ObjRef.SchemaName, c.proc.TxnOperator)
 	if err != nil {

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -17,6 +17,8 @@ package compile
 import (
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"os"
 	"testing"
 	"time"
@@ -111,7 +113,7 @@ func (w *Ws) GetSQLCount() uint64 { return 0 }
 func TestCompile(t *testing.T) {
 	cnclient.NewCNClient("test", new(cnclient.ClientConfig))
 	ctrl := gomock.NewController(t)
-	ctx := context.TODO()
+	ctx := defines.AttachAccountId(context.TODO(), catalog.System_Account)
 	txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
 	txnOperator.EXPECT().Commit(gomock.Any()).Return(nil).AnyTimes()
 	txnOperator.EXPECT().Rollback(ctx).Return(nil).AnyTimes()
@@ -124,7 +126,8 @@ func TestCompile(t *testing.T) {
 	for _, tc := range tcs {
 		tc.proc.TxnClient = txnClient
 		tc.proc.TxnOperator = txnOperator
-		c := New("test", "test", tc.sql, "", "", context.TODO(), tc.e, tc.proc, tc.stmt, false, nil, time.Now())
+		tc.proc.Ctx = ctx
+		c := New("test", "test", tc.sql, "", "", ctx, tc.e, tc.proc, tc.stmt, false, nil, time.Now())
 		err := c.Compile(ctx, tc.pn, nil, testPrint)
 		require.NoError(t, err)
 		c.getAffectedRows()
@@ -140,11 +143,12 @@ func TestCompile(t *testing.T) {
 func TestCompileWithFaults(t *testing.T) {
 	// Enable this line to trigger the Hung.
 	// fault.Enable()
-	var ctx = context.Background()
+	var ctx = defines.AttachAccountId(context.Background(), catalog.System_Account)
 	cnclient.NewCNClient("test", new(cnclient.ClientConfig))
 	fault.AddFaultPoint(ctx, "panic_in_batch_append", ":::", "panic", 0, "")
 	tc := newTestCase("select * from R join S on R.uid = S.uid", t)
-	c := New("test", "test", tc.sql, "", "", context.TODO(), tc.e, tc.proc, nil, false, nil, time.Now())
+	tc.proc.Ctx = ctx
+	c := New("test", "test", tc.sql, "", "", ctx, tc.e, tc.proc, nil, false, nil, time.Now())
 	err := c.Compile(ctx, tc.pn, nil, testPrint)
 	require.NoError(t, err)
 	c.getAffectedRows()
@@ -155,7 +159,7 @@ func TestCompileWithFaults(t *testing.T) {
 func newTestCase(sql string, t *testing.T) compileTestCase {
 	proc := testutil.NewProcess()
 	proc.SessionInfo.Buf = buffer.New()
-	e, _, compilerCtx := testengine.New(context.Background())
+	e, _, compilerCtx := testengine.New(defines.AttachAccountId(context.Background(), catalog.System_Account))
 	stmts, err := mysql.Parse(compilerCtx.GetContext(), sql, 1)
 	require.NoError(t, err)
 	pn, err := plan2.BuildPlan(compilerCtx, stmts[0], false)

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -17,9 +17,6 @@ package compile
 import (
 	"context"
 	"fmt"
-	"math"
-	"strings"
-
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/compress"
@@ -41,6 +38,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"go.uber.org/zap"
 	"golang.org/x/exp/constraints"
+	"math"
+	"strings"
 )
 
 func (s *Scope) CreateDatabase(c *Compile) error {

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -352,10 +352,11 @@ func (s *Scope) ParallelRun(c *Compile, remote bool) error {
 	case remote:
 		ctx := c.ctx
 		if util.TableIsClusterTable(s.DataSource.TableDef.GetTableType()) {
-			ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+			ctx = defines.AttachAccountId(ctx, catalog.System_Account)
+
 		}
 		if s.DataSource.AccountId != nil {
-			ctx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(s.DataSource.AccountId.GetTenantId()))
+			ctx = defines.AttachAccountId(ctx, uint32(s.DataSource.AccountId.GetTenantId()))
 		}
 		rds, err = c.e.NewBlockReader(ctx, mcpu, s.DataSource.Timestamp, s.DataSource.Expr,
 			s.NodeInfo.Data, s.DataSource.TableDef, c.proc)
@@ -377,7 +378,7 @@ func (s *Scope) ParallelRun(c *Compile, remote bool) error {
 
 		ctx := c.ctx
 		if util.TableIsClusterTable(s.DataSource.TableDef.GetTableType()) {
-			ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+			ctx = defines.AttachAccountId(ctx, catalog.System_Account)
 		}
 		db, err = c.e.Database(ctx, s.DataSource.SchemaName, s.Proc.TxnOperator)
 		if err != nil {

--- a/pkg/sql/compile/scopeRemoteRun.go
+++ b/pkg/sql/compile/scopeRemoteRun.go
@@ -372,7 +372,11 @@ func encodeProcessInfo(proc *process.Process, sql string) ([]byte, error) {
 		procInfo.Sql = sql
 		procInfo.Lim = convertToPipelineLimitation(proc.Lim)
 		procInfo.UnixTime = proc.UnixTime
-		procInfo.AccountId = defines.GetAccountId(proc.Ctx)
+		accountId, err := defines.GetAccountId(proc.Ctx)
+		if err != nil {
+			return nil, err
+		}
+		procInfo.AccountId = accountId
 		snapshot, err := proc.TxnOperator.Snapshot()
 		if err != nil {
 			return nil, err

--- a/pkg/sql/compile/scopeRemoteRunTypes.go
+++ b/pkg/sql/compile/scopeRemoteRunTypes.go
@@ -390,7 +390,7 @@ func (receiver *messageReceiverOnServer) newCompile() *Compile {
 		addr: receiver.cnInformation.cnAddr,
 	}
 	c.proc.Ctx = perfcounter.WithCounterSet(c.proc.Ctx, &c.counterSet)
-	c.ctx = context.WithValue(c.proc.Ctx, defines.TenantIDKey{}, pHelper.accountId)
+	c.ctx = defines.AttachAccountId(c.proc.Ctx, pHelper.accountId)
 
 	c.fill = func(_ any, b *batch.Batch) error {
 		return receiver.sendBatch(b)

--- a/pkg/sql/compile/scopeRemoteRun_test.go
+++ b/pkg/sql/compile/scopeRemoteRun_test.go
@@ -16,6 +16,8 @@ package compile
 
 import (
 	"context"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"hash/crc32"
 	"testing"
 	"time"
@@ -282,7 +284,7 @@ func Test_EncodeProcessInfo(t *testing.T) {
 		Id:          "1",
 		Lim:         process.Limitation{},
 		UnixTime:    1000000,
-		Ctx:         context.TODO(),
+		Ctx:         defines.AttachAccountId(context.TODO(), catalog.System_Account),
 		TxnOperator: txnOperator,
 		AnalInfos:   []*process.AnalyzeInfo{a},
 		SessionInfo: process.SessionInfo{

--- a/pkg/sql/compile/sql_executor_context.go
+++ b/pkg/sql/compile/sql_executor_context.go
@@ -179,11 +179,8 @@ func (c *compilerContext) GetUserName() string {
 	return "root"
 }
 
-func (c *compilerContext) GetAccountId() uint32 {
-	if v := c.ctx.Value(defines.TenantIDKey{}); v != nil {
-		return v.(uint32)
-	}
-	return 0
+func (c *compilerContext) GetAccountId() (uint32, error) {
+	return defines.GetAccountId(c.ctx)
 }
 
 func (c *compilerContext) GetContext() context.Context {

--- a/pkg/sql/parsers/tree/expr.go
+++ b/pkg/sql/parsers/tree/expr.go
@@ -817,6 +817,10 @@ func (node *Subquery) Accept(v Visitor) (Expr, bool) {
 	panic("unimplement Subquery Accept")
 }
 
+func (node *Subquery) String() string {
+	return "subquery"
+}
+
 func NewSubquery(s SelectStatement, e bool) *Subquery {
 	return &Subquery{
 		Select: s,

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -43,7 +43,11 @@ func buildAlterTableCopy(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, err
 	}
 
 	isClusterTable := util.TableIsClusterTable(tableDef.GetTableType())
-	if isClusterTable && ctx.GetAccountId() != catalog.System_Account {
+	accountId, err := ctx.GetAccountId()
+	if err != nil {
+		return nil, err
+	}
+	if isClusterTable && accountId != catalog.System_Account {
 		return nil, moerr.NewInternalError(ctx.GetContext(), "only the sys account can alter the cluster table")
 	}
 
@@ -203,9 +207,13 @@ func restoreDDL(ctx CompilerContext, tableDef *TableDef, schemaName string, tblN
 			continue
 		}
 		//the non-sys account skips the column account_id of the cluster table
+		accountId, err := ctx.GetAccountId()
+		if err != nil {
+			return "", err
+		}
 		if util.IsClusterTableAttribute(colName) &&
 			isClusterTable &&
-			ctx.GetAccountId() != catalog.System_Account {
+			accountId != catalog.System_Account {
 			continue
 		}
 		nullOrNot := "NOT NULL"
@@ -584,7 +592,11 @@ func buildAlterTable(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, error) 
 		return nil, moerr.NewInternalError(ctx.GetContext(), "cannot alter table in subscription database")
 	}
 	isClusterTable := util.TableIsClusterTable(tableDef.GetTableType())
-	if isClusterTable && ctx.GetAccountId() != catalog.System_Account {
+	accountId, err := ctx.GetAccountId()
+	if err != nil {
+		return nil, err
+	}
+	if isClusterTable && accountId != catalog.System_Account {
 		return nil, moerr.NewInternalError(ctx.GetContext(), "only the sys account can alter the cluster table")
 	}
 	if tableDef.Partition != nil {

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -275,11 +275,15 @@ func setTableExprToDmlTableInfo(ctx CompilerContext, tbl tree.TableExpr, tblInfo
 	tableDef.Cols = newCols
 
 	isClusterTable := util.TableIsClusterTable(tableDef.GetTableType())
-	if isClusterTable && ctx.GetAccountId() != catalog.System_Account {
+	accountId, err := ctx.GetAccountId()
+	if err != nil {
+		return err
+	}
+	if isClusterTable && accountId != catalog.System_Account {
 		return moerr.NewInternalError(ctx.GetContext(), "only the sys account can insert/update/delete the cluster table")
 	}
 
-	if util.TableIsClusterTable(tableDef.GetTableType()) && ctx.GetAccountId() != catalog.System_Account {
+	if util.TableIsClusterTable(tableDef.GetTableType()) && accountId != catalog.System_Account {
 		return moerr.NewInternalError(ctx.GetContext(), "only the sys account can insert/update/delete the cluster table %s", tableDef.GetName())
 	}
 	if obj.PubInfo != nil {

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1510,7 +1510,11 @@ func buildTruncateTable(stmt *tree.TruncateTable, ctx CompilerContext) (*Plan, e
 		}
 
 		//non-sys account can not truncate the cluster table
-		if truncateTable.GetClusterTable().GetIsClusterTable() && ctx.GetAccountId() != catalog.System_Account {
+		accountId, err := ctx.GetAccountId()
+		if err != nil {
+			return nil, err
+		}
+		if truncateTable.GetClusterTable().GetIsClusterTable() && accountId != catalog.System_Account {
 			return nil, moerr.NewInternalError(ctx.GetContext(), "only the sys account can truncate the cluster table")
 		}
 
@@ -1593,7 +1597,11 @@ func buildDropTable(stmt *tree.DropTable, ctx CompilerContext) (*Plan, error) {
 		}
 
 		//non-sys account can not drop the cluster table
-		if dropTable.GetClusterTable().GetIsClusterTable() && ctx.GetAccountId() != catalog.System_Account {
+		accountId, err := ctx.GetAccountId()
+		if err != nil {
+			return nil, err
+		}
+		if dropTable.GetClusterTable().GetIsClusterTable() && accountId != catalog.System_Account {
 			return nil, moerr.NewInternalError(ctx.GetContext(), "only the sys account can drop the cluster table")
 		}
 
@@ -1973,7 +1981,11 @@ func buildAlterTableInplace(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, 
 
 	alterTable.Database = databaseName
 	alterTable.IsClusterTable = util.TableIsClusterTable(tableDef.GetTableType())
-	if alterTable.IsClusterTable && ctx.GetAccountId() != catalog.System_Account {
+	accountId, err := ctx.GetAccountId()
+	if err != nil {
+		return nil, err
+	}
+	if alterTable.IsClusterTable && accountId != catalog.System_Account {
 		return nil, moerr.NewInternalError(ctx.GetContext(), "only the sys account can alter the cluster table")
 	}
 
@@ -2351,7 +2363,7 @@ func buildAlterTableInplace(stmt *tree.AlterTable, ctx CompilerContext) (*Plan, 
 	}
 
 	// check Constraint Name (include index/ unique)
-	err := checkConstraintNames(uniqueIndexInfos, secondaryIndexInfos, ctx.GetContext())
+	err = checkConstraintNames(uniqueIndexInfos, secondaryIndexInfos, ctx.GetContext())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -105,7 +105,7 @@ func TestBuildAlterView(t *testing.T) {
 		}).AnyTimes()
 	ctx.EXPECT().SetBuildingAlterView(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	ctx.EXPECT().ResolveVariable(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
-	ctx.EXPECT().GetAccountId().Return(catalog.System_Account).AnyTimes()
+	ctx.EXPECT().GetAccountId().Return(catalog.System_Account, nil).AnyTimes()
 	ctx.EXPECT().GetContext().Return(context.Background()).AnyTimes()
 	ctx.EXPECT().GetProcess().Return(nil).AnyTimes()
 	ctx.EXPECT().Stats(gomock.Any()).Return(false).AnyTimes()
@@ -190,7 +190,7 @@ func TestBuildLockTables(t *testing.T) {
 			return x.obj, x.table
 		}).AnyTimes()
 	ctx.EXPECT().ResolveVariable(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
-	ctx.EXPECT().GetAccountId().Return(catalog.System_Account).AnyTimes()
+	ctx.EXPECT().GetAccountId().Return(catalog.System_Account, nil).AnyTimes()
 	ctx.EXPECT().GetContext().Return(context.Background()).AnyTimes()
 	ctx.EXPECT().GetProcess().Return(nil).AnyTimes()
 	ctx.EXPECT().Stats(gomock.Any()).Return(false).AnyTimes()

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -47,7 +47,10 @@ func buildShowCreateDatabase(stmt *tree.ShowCreateDatabase,
 	if sub, err := ctx.GetSubscriptionMeta(name); err != nil {
 		return nil, err
 	} else if sub != nil {
-		accountId := ctx.GetAccountId()
+		accountId, err := ctx.GetAccountId()
+		if err != nil {
+			return nil, err
+		}
 		// get data from schema
 		//sql := fmt.Sprintf("SELECT md.datname as `Database` FROM %s.mo_database md WHERE md.datname = '%s'", MO_CATALOG_DB_NAME, stmt.Name)
 		sql := fmt.Sprintf("SELECT md.datname as `Database`,dat_createsql as `Create Database` FROM %s.mo_database md WHERE md.datname = '%s' and account_id=%d", MO_CATALOG_DB_NAME, stmt.Name, accountId)
@@ -132,9 +135,13 @@ func buildShowCreateTable(stmt *tree.ShowCreateTable, ctx CompilerContext) (*Pla
 			continue
 		}
 		//the non-sys account skips the column account_id of the cluster table
+		accountId, err := ctx.GetAccountId()
+		if err != nil {
+			return nil, err
+		}
 		if util.IsClusterTableAttribute(colName) &&
 			isClusterTable &&
-			ctx.GetAccountId() != catalog.System_Account {
+			accountId != catalog.System_Account {
 			continue
 		}
 		nullOrNot := "NOT NULL"
@@ -414,7 +421,10 @@ func buildShowDatabases(stmt *tree.ShowDatabases, ctx CompilerContext) (*Plan, e
 		return nil, moerr.NewSyntaxError(ctx.GetContext(), "like clause and where clause cannot exist at the same time")
 	}
 
-	accountId := ctx.GetAccountId()
+	accountId, err := ctx.GetAccountId()
+	if err != nil {
+		return nil, err
+	}
 	ddlType := plan.DataDefinition_SHOW_DATABASES
 
 	var sql string
@@ -467,7 +477,10 @@ func buildShowTables(stmt *tree.ShowTables, ctx CompilerContext) (*Plan, error) 
 		return nil, moerr.NewNYI(ctx.GetContext(), "statement: '%v'", tree.String(stmt, dialect.MYSQL))
 	}
 
-	accountId := ctx.GetAccountId()
+	accountId, err := ctx.GetAccountId()
+	if err != nil {
+		return nil, err
+	}
 	dbName, err := databaseIsValid(stmt.DBName, ctx)
 	if err != nil {
 		return nil, err
@@ -533,7 +546,10 @@ func buildShowTables(stmt *tree.ShowTables, ctx CompilerContext) (*Plan, error) 
 }
 
 func buildShowTableNumber(stmt *tree.ShowTableNumber, ctx CompilerContext) (*Plan, error) {
-	accountId := ctx.GetAccountId()
+	accountId, err := ctx.GetAccountId()
+	if err != nil {
+		return nil, err
+	}
 	dbName, err := databaseIsValid(stmt.DbName, ctx)
 	if err != nil {
 		return nil, err
@@ -583,7 +599,10 @@ func buildShowTableNumber(stmt *tree.ShowTableNumber, ctx CompilerContext) (*Pla
 }
 
 func buildShowColumnNumber(stmt *tree.ShowColumnNumber, ctx CompilerContext) (*Plan, error) {
-	accountId := ctx.GetAccountId()
+	accountId, err := ctx.GetAccountId()
+	if err != nil {
+		return nil, err
+	}
 	dbName, err := databaseIsValid(getSuitableDBName(stmt.Table.GetDBName(), stmt.DbName), ctx)
 	if err != nil {
 		return nil, err
@@ -684,7 +703,10 @@ func buildShowColumns(stmt *tree.ShowColumns, ctx CompilerContext) (*Plan, error
 		return nil, moerr.NewSyntaxError(ctx.GetContext(), "like clause and where clause cannot exist at the same time")
 	}
 
-	accountId := ctx.GetAccountId()
+	accountId, err := ctx.GetAccountId()
+	if err != nil {
+		return nil, err
+	}
 	dbName, err := databaseIsValid(getSuitableDBName(stmt.Table.GetDBName(), stmt.DBName), ctx)
 	if err != nil {
 		return nil, err
@@ -813,7 +835,10 @@ func buildShowTableStatus(stmt *tree.ShowTableStatus, ctx CompilerContext) (*Pla
 	stmt.DbName = dbName
 
 	ddlType := plan.DataDefinition_SHOW_TABLE_STATUS
-	accountId := ctx.GetAccountId()
+	accountId, err := ctx.GetAccountId()
+	if err != nil {
+		return nil, err
+	}
 
 	sub, err := ctx.GetSubscriptionMeta(dbName)
 	if err != nil {

--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -15,7 +15,6 @@
 package function
 
 import (
-	"context"
 	"strconv"
 	"strings"
 
@@ -68,8 +67,12 @@ func MoTableRows(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 
 			if isClusterTable(dbStr, tblStr) {
 				//if it is the cluster table in the general account, switch into the sys account
-				if v := proc.Ctx.Value(defines.TenantIDKey{}); v == nil || v != uint32(sysAccountID) {
-					proc.Ctx = context.WithValue(proc.Ctx, defines.TenantIDKey{}, uint32(sysAccountID))
+				accountId, err := defines.GetAccountId(proc.Ctx)
+				if err != nil {
+					return err
+				}
+				if accountId != uint32(sysAccountID) {
+					proc.Ctx = defines.AttachAccountId(proc.Ctx, uint32(sysAccountID))
 				}
 			}
 			ctx := proc.Ctx
@@ -167,8 +170,12 @@ func MoTableSize(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 
 			if isClusterTable(dbStr, tblStr) {
 				//if it is the cluster table in the general account, switch into the sys account
-				if v := proc.Ctx.Value(defines.TenantIDKey{}); v == nil || v != uint32(sysAccountID) {
-					proc.Ctx = context.WithValue(proc.Ctx, defines.TenantIDKey{}, uint32(sysAccountID))
+				accountId, err := defines.GetAccountId(proc.Ctx)
+				if err != nil {
+					return err
+				}
+				if accountId != uint32(sysAccountID) {
+					proc.Ctx = defines.AttachAccountId(proc.Ctx, uint32(sysAccountID))
 				}
 			}
 			ctx := proc.Ctx
@@ -287,8 +294,12 @@ func moTableColMaxMinImpl(fnName string, parameters []*vector.Vector, result vec
 
 			if isClusterTable(dbStr, tableStr) {
 				//if it is the cluster table in the general account, switch into the sys account
-				if v := proc.Ctx.Value(defines.TenantIDKey{}); v == nil || v != uint32(sysAccountID) {
-					proc.Ctx = context.WithValue(proc.Ctx, defines.TenantIDKey{}, uint32(sysAccountID))
+				accountId, err := defines.GetAccountId(proc.Ctx)
+				if err != nil {
+					return err
+				}
+				if accountId != uint32(sysAccountID) {
+					proc.Ctx = defines.AttachAccountId(proc.Ctx, uint32(sysAccountID))
 				}
 			}
 			ctx := proc.Ctx

--- a/pkg/sql/plan/mock.go
+++ b/pkg/sql/plan/mock.go
@@ -860,8 +860,8 @@ func (m *MockCompilerContext) GetStatsCache() *StatsCache {
 	return nil
 }
 
-func (m *MockCompilerContext) GetAccountId() uint32 {
-	return 0
+func (m *MockCompilerContext) GetAccountId() (uint32, error) {
+	return 0, nil
 }
 
 func (m *MockCompilerContext) GetContext() context.Context {

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -93,7 +93,7 @@ type CompilerContext interface {
 	GetRootSql() string
 	// get username of current session
 	GetUserName() string
-	GetAccountId() uint32
+	GetAccountId() (uint32, error)
 	// GetContext get raw context.Context
 	GetContext() context.Context
 	// GetDatabaseId Get database id

--- a/pkg/sql/plan/types_mock.go
+++ b/pkg/sql/plan/types_mock.go
@@ -95,11 +95,12 @@ func (mr *MockCompilerContext2MockRecorder) DefaultDatabase() *gomock.Call {
 }
 
 // GetAccountId mocks base method.
-func (m *MockCompilerContext2) GetAccountId() uint32 {
+func (m *MockCompilerContext2) GetAccountId() (uint32, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountId")
 	ret0, _ := ret[0].(uint32)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetAccountId indicates an expected call of GetAccountId.
@@ -154,10 +155,10 @@ func (mr *MockCompilerContext2MockRecorder) GetDatabaseId(dbName interface{}) *g
 }
 
 // GetPrimaryKeyDef mocks base method.
-func (m *MockCompilerContext2) GetPrimaryKeyDef(dbName, tableName string) []*ColDef {
+func (m *MockCompilerContext2) GetPrimaryKeyDef(dbName, tableName string) []*plan.ColDef {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPrimaryKeyDef", dbName, tableName)
-	ret0, _ := ret[0].([]*ColDef)
+	ret0, _ := ret[0].([]*plan.ColDef)
 	return ret0
 }
 
@@ -182,10 +183,10 @@ func (mr *MockCompilerContext2MockRecorder) GetProcess() *gomock.Call {
 }
 
 // GetQueryResultMeta mocks base method.
-func (m *MockCompilerContext2) GetQueryResultMeta(uuid string) ([]*ColDef, string, error) {
+func (m *MockCompilerContext2) GetQueryResultMeta(uuid string) ([]*plan.ColDef, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetQueryResultMeta", uuid)
-	ret0, _ := ret[0].([]*ColDef)
+	ret0, _ := ret[0].([]*plan.ColDef)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -198,10 +199,10 @@ func (mr *MockCompilerContext2MockRecorder) GetQueryResultMeta(uuid interface{})
 }
 
 // GetQueryingSubscription mocks base method.
-func (m *MockCompilerContext2) GetQueryingSubscription() *SubscriptionMeta {
+func (m *MockCompilerContext2) GetQueryingSubscription() *plan.SubscriptionMeta {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetQueryingSubscription")
-	ret0, _ := ret[0].(*SubscriptionMeta)
+	ret0, _ := ret[0].(*plan.SubscriptionMeta)
 	return ret0
 }
 
@@ -240,10 +241,10 @@ func (mr *MockCompilerContext2MockRecorder) GetStatsCache() *gomock.Call {
 }
 
 // GetSubscriptionMeta mocks base method.
-func (m *MockCompilerContext2) GetSubscriptionMeta(dbName string) (*SubscriptionMeta, error) {
+func (m *MockCompilerContext2) GetSubscriptionMeta(dbName string) (*plan.SubscriptionMeta, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSubscriptionMeta", dbName)
-	ret0, _ := ret[0].(*SubscriptionMeta)
+	ret0, _ := ret[0].(*plan.SubscriptionMeta)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -284,11 +285,11 @@ func (mr *MockCompilerContext2MockRecorder) IsPublishing(dbName interface{}) *go
 }
 
 // Resolve mocks base method.
-func (m *MockCompilerContext2) Resolve(schemaName, tableName string) (*ObjectRef, *TableDef) {
+func (m *MockCompilerContext2) Resolve(schemaName, tableName string) (*plan.ObjectRef, *plan.TableDef) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Resolve", schemaName, tableName)
-	ret0, _ := ret[0].(*ObjectRef)
-	ret1, _ := ret[1].(*TableDef)
+	ret0, _ := ret[0].(*plan.ObjectRef)
+	ret1, _ := ret[1].(*plan.TableDef)
 	return ret0, ret1
 }
 
@@ -314,11 +315,11 @@ func (mr *MockCompilerContext2MockRecorder) ResolveAccountIds(accountNames inter
 }
 
 // ResolveById mocks base method.
-func (m *MockCompilerContext2) ResolveById(tableId uint64) (*ObjectRef, *TableDef) {
+func (m *MockCompilerContext2) ResolveById(tableId uint64) (*plan.ObjectRef, *plan.TableDef) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveById", tableId)
-	ret0, _ := ret[0].(*ObjectRef)
-	ret1, _ := ret[1].(*TableDef)
+	ret0, _ := ret[0].(*plan.ObjectRef)
+	ret1, _ := ret[1].(*plan.TableDef)
 	return ret0, ret1
 }
 
@@ -329,7 +330,7 @@ func (mr *MockCompilerContext2MockRecorder) ResolveById(tableId interface{}) *go
 }
 
 // ResolveUdf mocks base method.
-func (m *MockCompilerContext2) ResolveUdf(name string, args []*Expr) (*function.Udf, error) {
+func (m *MockCompilerContext2) ResolveUdf(name string, args []*plan.Expr) (*function.Udf, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveUdf", name, args)
 	ret0, _ := ret[0].(*function.Udf)
@@ -371,7 +372,7 @@ func (mr *MockCompilerContext2MockRecorder) SetBuildingAlterView(yesOrNo, dbName
 }
 
 // SetQueryingSubscription mocks base method.
-func (m *MockCompilerContext2) SetQueryingSubscription(meta *SubscriptionMeta) {
+func (m *MockCompilerContext2) SetQueryingSubscription(meta *plan.SubscriptionMeta) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetQueryingSubscription", meta)
 }
@@ -383,7 +384,7 @@ func (mr *MockCompilerContext2MockRecorder) SetQueryingSubscription(meta interfa
 }
 
 // Stats mocks base method.
-func (m *MockCompilerContext2) Stats(obj *ObjectRef) bool {
+func (m *MockCompilerContext2) Stats(obj *plan.ObjectRef) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stats", obj)
 	ret0, _ := ret[0].(bool)
@@ -434,10 +435,10 @@ func (mr *MockOptimizer2MockRecorder) CurrentContext() *gomock.Call {
 }
 
 // Optimize mocks base method.
-func (m *MockOptimizer2) Optimize(stmt tree.Statement) (*Query, error) {
+func (m *MockOptimizer2) Optimize(stmt tree.Statement) (*plan.Query, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Optimize", stmt)
-	ret0, _ := ret[0].(*Query)
+	ret0, _ := ret[0].(*plan.Query)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -472,7 +473,7 @@ func (m *MockRule) EXPECT() *MockRuleMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockRule) Apply(arg0 *Node, arg1 *Query, arg2 *process.Process) {
+func (m *MockRule) Apply(arg0 *plan.Node, arg1 *plan.Query, arg2 *process.Process) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Apply", arg0, arg1, arg2)
 }
@@ -484,7 +485,7 @@ func (mr *MockRuleMockRecorder) Apply(arg0, arg1, arg2 interface{}) *gomock.Call
 }
 
 // Match mocks base method.
-func (m *MockRule) Match(arg0 *Node) bool {
+func (m *MockRule) Match(arg0 *plan.Node) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Match", arg0)
 	ret0, _ := ret[0].(bool)
@@ -578,6 +579,21 @@ func (m *MockBinder) BindSubquery(arg0 *tree.Subquery, arg1 bool) (*plan.Expr, e
 func (mr *MockBinderMockRecorder) BindSubquery(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindSubquery", reflect.TypeOf((*MockBinder)(nil).BindSubquery), arg0, arg1)
+}
+
+// BindTimeWindowFunc mocks base method.
+func (m *MockBinder) BindTimeWindowFunc(arg0 string, arg1 *tree.FuncExpr, arg2 int32, arg3 bool) (*plan.Expr, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BindTimeWindowFunc", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*plan.Expr)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BindTimeWindowFunc indicates an expected call of BindTimeWindowFunc.
+func (mr *MockBinderMockRecorder) BindTimeWindowFunc(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindTimeWindowFunc", reflect.TypeOf((*MockBinder)(nil).BindTimeWindowFunc), arg0, arg1, arg2, arg3)
 }
 
 // BindWinFunc mocks base method.

--- a/pkg/testutil/testengine/testengine.go
+++ b/pkg/testutil/testengine/testengine.go
@@ -16,6 +16,8 @@ package testengine
 
 import (
 	"context"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
@@ -37,6 +39,7 @@ func New(
 	client client.TxnClient,
 	compilerContext plan.CompilerContext,
 ) {
+	ctx = defines.AttachAccountId(ctx, catalog.System_Account)
 	runtime.SetupProcessLevelRuntime(runtime.DefaultRuntime())
 	ck := runtime.ProcessLevelRuntime().Clock()
 	addr := "1"

--- a/pkg/util/export/merge.go
+++ b/pkg/util/export/merge.go
@@ -26,6 +26,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+
 	"github.com/matrixorigin/matrixone/pkg/common/log"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -725,6 +728,7 @@ func CreateCronTask(ctx context.Context, executorID task.TaskCode, taskService t
 	var err error
 	ctx, span := trace.Start(ctx, "ETLMerge.CreateCronTask")
 	defer span.End()
+	ctx = defines.AttachAccount(ctx, catalog.System_Account, catalog.System_User, catalog.System_Role)
 	logger := runtime.ProcessLevelRuntime().Logger().WithContext(ctx)
 	logger.Info(fmt.Sprintf("init merge task with CronExpr: %s", MergeTaskCronExpr))
 	if err = taskService.CreateCronTask(ctx, MergeTaskMetadata(executorID), MergeTaskCronExpr); err != nil {

--- a/pkg/util/metric/mometric/cron_task.go
+++ b/pkg/util/metric/mometric/cron_task.go
@@ -22,6 +22,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+
 	"github.com/matrixorigin/matrixone/pkg/common/log"
 	"github.com/matrixorigin/matrixone/pkg/util/export/table"
 	"github.com/matrixorigin/matrixone/pkg/util/metric"
@@ -61,6 +64,7 @@ func CreateCronTask(ctx context.Context, executorID task.TaskCode, taskService t
 	var err error
 	ctx, span := trace.Start(ctx, "MetricCreateCronTask")
 	defer span.End()
+	ctx = defines.AttachAccount(ctx, catalog.System_Account, catalog.System_User, catalog.System_Role)
 	logger := runtime.ProcessLevelRuntime().Logger().WithContext(ctx).Named(LoggerName)
 	logger.Debug(fmt.Sprintf("init metric task with CronExpr: %s", StorageUsageTaskCronExpr))
 	if err = taskService.CreateCronTask(ctx, TaskMetadata(StorageUsageCronTask, executorID), StorageUsageTaskCronExpr); err != nil {
@@ -112,6 +116,7 @@ func cleanStorageUsageMetric(logger *log.MOLogger, actor string) {
 func CalculateStorageUsage(ctx context.Context, sqlExecutor func() ie.InternalExecutor) (err error) {
 	ctx, span := trace.Start(ctx, "MetricStorageUsage")
 	defer span.End()
+	ctx = defines.AttachAccount(ctx, catalog.System_Account, catalog.System_User, catalog.System_Role)
 	ctx, cancel := context.WithCancel(ctx)
 	logger := runtime.ProcessLevelRuntime().Logger().WithContext(ctx).Named(LoggerNameMetricStorage)
 	logger.Info("started")

--- a/pkg/util/metric/mometric/metric.go
+++ b/pkg/util/metric/mometric/metric.go
@@ -23,6 +23,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
@@ -236,6 +239,7 @@ func initConfigByParameterUnit(SV *config.ObservabilityParameters) {
 }
 
 func InitSchema(ctx context.Context, ieFactory func() ie.InternalExecutor) error {
+	ctx = defines.AttachAccount(ctx, catalog.System_Account, catalog.System_User, catalog.System_Role)
 	initTables(ctx, ieFactory)
 	return nil
 }

--- a/pkg/util/sysview/sysview.go
+++ b/pkg/util/sysview/sysview.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/defines"
+
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	ie "github.com/matrixorigin/matrixone/pkg/util/internalExecutor"
@@ -429,6 +431,7 @@ var (
 )
 
 func InitSchema(ctx context.Context, ieFactory func() ie.InternalExecutor) error {
+	ctx = defines.AttachAccount(ctx, catalog.System_Account, catalog.System_User, catalog.System_Role)
 	initMysqlTables(ctx, ieFactory)
 	initInformationSchemaTables(ctx, ieFactory)
 	return nil

--- a/pkg/util/trace/impl/motrace/trace.go
+++ b/pkg/util/trace/impl/motrace/trace.go
@@ -26,6 +26,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -150,6 +153,7 @@ func initExporter(ctx context.Context, config *tracerProviderConfig) error {
 // InitSchema
 // PS: only in standalone or CN node can init schema
 func InitSchema(ctx context.Context, sqlExecutor func() ie.InternalExecutor) error {
+	ctx = defines.AttachAccount(ctx, catalog.System_Account, catalog.System_User, catalog.System_Role)
 	c := &GetTracerProvider().tracerProviderConfig
 	WithSQLExecutor(sqlExecutor).apply(c)
 	if err := InitSchemaByInnerExecutor(ctx, sqlExecutor); err != nil {

--- a/pkg/vm/engine/disttae/tools.go
+++ b/pkg/vm/engine/disttae/tools.go
@@ -1221,7 +1221,7 @@ func genTableKey(id uint32, name string, databaseId uint64) tableKey {
 	return tableKey{
 		name:       name,
 		databaseId: databaseId,
-		accountId: id,
+		accountId:  id,
 	}
 }
 

--- a/pkg/vm/engine/disttae/tools.go
+++ b/pkg/vm/engine/disttae/tools.go
@@ -1127,19 +1127,17 @@ func getTyp(ctx context.Context) string {
 	return ""
 }
 
-func getAccessInfo(ctx context.Context) (uint32, uint32, uint32) {
+func getAccessInfo(ctx context.Context) (uint32, uint32, uint32, error) {
 	var accountId, userId, roleId uint32
+	var err error
 
-	if v := ctx.Value(defines.TenantIDKey{}); v != nil {
-		accountId = v.(uint32)
+	accountId, err = defines.GetAccountId(ctx)
+	if err != nil {
+		return 0, 0, 0, err
 	}
-	if v := ctx.Value(defines.UserIDKey{}); v != nil {
-		userId = v.(uint32)
-	}
-	if v := ctx.Value(defines.RoleIDKey{}); v != nil {
-		roleId = v.(uint32)
-	}
-	return accountId, userId, roleId
+	userId = defines.GetUserId(ctx)
+	roleId = defines.GetRoleId(ctx)
+	return accountId, userId, roleId, nil
 }
 
 /*
@@ -1212,18 +1210,18 @@ func partitionBatch(bat *batch.Batch, expr *plan.Expr, proc *process.Process, dn
 // 	return bats, nil
 // }
 
-func genDatabaseKey(ctx context.Context, name string) databaseKey {
+func genDatabaseKey(id uint32, name string) databaseKey {
 	return databaseKey{
 		name:      name,
-		accountId: defines.GetAccountId(ctx),
+		accountId: id,
 	}
 }
 
-func genTableKey(ctx context.Context, name string, databaseId uint64) tableKey {
+func genTableKey(id uint32, name string, databaseId uint64) tableKey {
 	return tableKey{
 		name:       name,
 		databaseId: databaseId,
-		accountId:  defines.GetAccountId(ctx),
+		accountId: id,
 	}
 }
 

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -643,7 +643,7 @@ func (txn *Transaction) getCachedTable(
 		val := txn.engine.catalog.GetSchemaVersion(tblKey)
 		if val != nil {
 			if val.Ts.Greater(tbl.lastTS) && val.Version != tbl.version {
-				txn.tableCache.tableMap.Delete(genTableKey(ctx, k.name, k.databaseId))
+				txn.tableCache.tableMap.Delete(genTableKey(k.accountId, k.name, k.databaseId))
 				return nil
 			}
 		}

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -182,10 +182,7 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 		Ts:         db.txn.op.SnapshotTS(),
 	}
 	if ok := db.txn.engine.catalog.GetTable(item); !ok {
-		logutil.Debugf("txnDatabase.Relation table %q(acc %d db %d) does not exist",
-			name,
-			accountId,
-			db.databaseId)
+		logutil.Debugf("txnDatabase.Relation table %q(acc %d db %d) does not exist", name, accountId, db.databaseId)
 		return nil, moerr.NewParseError(ctx, "table %q does not exist", name)
 	}
 

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -178,7 +178,7 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 	item := &cache.TableItem{
 		Name:       name,
 		DatabaseId: db.databaseId,
-		AccountId: accountId,
+		AccountId:  accountId,
 		Ts:         db.txn.op.SnapshotTS(),
 	}
 	if ok := db.txn.engine.catalog.GetTable(item); !ok {
@@ -255,7 +255,7 @@ func (db *txnDatabase) Delete(ctx context.Context, name string) error {
 		item := &cache.TableItem{
 			Name:       name,
 			DatabaseId: db.databaseId,
-			AccountId: accountId,
+			AccountId:  accountId,
 			Ts:         db.txn.op.SnapshotTS(),
 		}
 		if ok := db.txn.engine.catalog.GetTable(item); !ok {
@@ -324,7 +324,7 @@ func (db *txnDatabase) Truncate(ctx context.Context, name string) (uint64, error
 		item := &cache.TableItem{
 			Name:       name,
 			DatabaseId: db.databaseId,
-			AccountId: accountId,
+			AccountId:  accountId,
 			Ts:         db.txn.op.SnapshotTS(),
 		}
 		if ok := db.txn.engine.catalog.GetTable(item); !ok {

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -54,7 +54,11 @@ func (db *txnDatabase) Relations(ctx context.Context) ([]string, error) {
 		}
 		return true
 	})
-	tbls, _ := db.txn.engine.catalog.Tables(defines.GetAccountId(ctx), db.databaseId, db.txn.op.SnapshotTS())
+	accountId, err := defines.GetAccountId(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tbls, _ := db.txn.engine.catalog.Tables(accountId, db.databaseId, db.txn.op.SnapshotTS())
 	for _, tbl := range tbls {
 		//if the table is deleted, do not save it.
 		if _, exist := deleteTables[tbl]; !exist {
@@ -64,7 +68,7 @@ func (db *txnDatabase) Relations(ctx context.Context) ([]string, error) {
 	return rels, nil
 }
 
-func (db *txnDatabase) getTableNameById(ctx context.Context, id uint64) string {
+func (db *txnDatabase) getTableNameById(ctx context.Context, id uint64) (string, error) {
 	tblName := ""
 	//first check the tableID is deleted or not
 	deleted := false
@@ -78,7 +82,7 @@ func (db *txnDatabase) getTableNameById(ctx context.Context, id uint64) string {
 		return true
 	})
 	if deleted {
-		return ""
+		return "", nil
 	}
 	db.txn.createMap.Range(func(k, v any) bool {
 		key := k.(tableKey)
@@ -91,7 +95,12 @@ func (db *txnDatabase) getTableNameById(ctx context.Context, id uint64) string {
 	})
 
 	if tblName == "" {
-		tbls, tblIds := db.txn.engine.catalog.Tables(defines.GetAccountId(ctx), db.databaseId, db.txn.op.SnapshotTS())
+		accountId, err := defines.GetAccountId(ctx)
+		if err != nil {
+			return "", err
+		}
+
+		tbls, tblIds := db.txn.engine.catalog.Tables(accountId, db.databaseId, db.txn.op.SnapshotTS())
 		for idx, tblId := range tblIds {
 			if tblId == id {
 				tblName = tbls[idx]
@@ -99,16 +108,19 @@ func (db *txnDatabase) getTableNameById(ctx context.Context, id uint64) string {
 			}
 		}
 	}
-	return tblName
+	return tblName, nil
 }
 
-func (db *txnDatabase) getRelationById(ctx context.Context, id uint64) (string, engine.Relation) {
-	tblName := db.getTableNameById(ctx, id)
+func (db *txnDatabase) getRelationById(ctx context.Context, id uint64) (string, engine.Relation, error) {
+	tblName, err := db.getTableNameById(ctx, id)
+	if err != nil {
+		return "", nil, err
+	}
 	if tblName == "" {
-		return "", nil
+		return "", nil, nil
 	}
 	rel, _ := db.Relation(ctx, tblName, nil)
-	return tblName, rel
+	return tblName, rel, nil
 }
 
 func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (engine.Relation, error) {
@@ -117,16 +129,20 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 	if txn.op.Status() == txn2.TxnStatus_Aborted {
 		return nil, moerr.NewTxnClosedNoCtx(txn.op.Txn().ID)
 	}
-
+	accountId, err := defines.GetAccountId(ctx)
+	if err != nil {
+		return nil, err
+	}
+	key := genTableKey(accountId, name, db.databaseId)
 	// check the table is deleted or not
-	if _, exist := db.txn.deletedTableMap.Load(genTableKey(ctx, name, db.databaseId)); exist {
+	if _, exist := db.txn.deletedTableMap.Load(key); exist {
 		return nil, moerr.NewParseError(ctx, "table %q does not exist", name)
 	}
 	p := db.txn.proc
 	if proc != nil {
 		p = proc.(*process.Process)
 	}
-	rel := db.txn.getCachedTable(ctx, genTableKey(ctx, name, db.databaseId),
+	rel := db.txn.getCachedTable(ctx, key,
 		db.txn.op.SnapshotTS())
 	if rel != nil {
 		//rel.Lock()
@@ -136,7 +152,7 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 		return rel, nil
 	}
 	// get relation from the txn created tables cache: created by this txn
-	if v, ok := db.txn.createMap.Load(genTableKey(ctx, name, db.databaseId)); ok {
+	if v, ok := db.txn.createMap.Load(key); ok {
 		//v.(*txnTable).proc = p
 		v.(*txnTable).proc.Store(p)
 		return v.(*txnTable), nil
@@ -148,25 +164,28 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 		case catalog.MO_DATABASE:
 			id := uint64(catalog.MO_DATABASE_ID)
 			defs := catalog.MoDatabaseTableDefs
-			return db.openSysTable(p, genTableKey(ctx, name, db.databaseId), id, name, defs), nil
+			return db.openSysTable(p, key, id, name, defs), nil
 		case catalog.MO_TABLES:
 			id := uint64(catalog.MO_TABLES_ID)
 			defs := catalog.MoTablesTableDefs
-			return db.openSysTable(p, genTableKey(ctx, name, db.databaseId), id, name, defs), nil
+			return db.openSysTable(p, key, id, name, defs), nil
 		case catalog.MO_COLUMNS:
 			id := uint64(catalog.MO_COLUMNS_ID)
 			defs := catalog.MoColumnsTableDefs
-			return db.openSysTable(p, genTableKey(ctx, name, db.databaseId), id, name, defs), nil
+			return db.openSysTable(p, key, id, name, defs), nil
 		}
 	}
 	item := &cache.TableItem{
 		Name:       name,
 		DatabaseId: db.databaseId,
-		AccountId:  defines.GetAccountId(ctx),
+		AccountId: accountId,
 		Ts:         db.txn.op.SnapshotTS(),
 	}
 	if ok := db.txn.engine.catalog.GetTable(item); !ok {
-		logutil.Debugf("txnDatabase.Relation table %q(acc %d db %d) does not exist", name, defines.GetAccountId(ctx), db.databaseId)
+		logutil.Debugf("txnDatabase.Relation table %q(acc %d db %d) does not exist",
+			name,
+			accountId,
+			db.databaseId)
 		return nil, moerr.NewParseError(ctx, "table %q does not exist", name)
 	}
 
@@ -194,7 +213,7 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 	}
 	tbl.proc.Store(p)
 
-	db.txn.tableCache.tableMap.Store(genTableKey(ctx, name, db.databaseId), tbl)
+	db.txn.tableCache.tableMap.Store(key, tbl)
 	return tbl, nil
 }
 
@@ -202,7 +221,11 @@ func (db *txnDatabase) Delete(ctx context.Context, name string) error {
 	var id uint64
 	var rowid types.Rowid
 	var rowids []types.Rowid
-	k := genTableKey(ctx, name, db.databaseId)
+	accountId, err := defines.GetAccountId(ctx)
+	if err != nil {
+		return err
+	}
+	k := genTableKey(accountId, name, db.databaseId)
 	if v, ok := db.txn.createMap.Load(k); ok {
 		db.txn.createMap.Delete(k)
 		table := v.(*txnTable)
@@ -232,7 +255,7 @@ func (db *txnDatabase) Delete(ctx context.Context, name string) error {
 		item := &cache.TableItem{
 			Name:       name,
 			DatabaseId: db.databaseId,
-			AccountId:  defines.GetAccountId(ctx),
+			AccountId: accountId,
 			Ts:         db.txn.op.SnapshotTS(),
 		}
 		if ok := db.txn.engine.catalog.GetTable(item); !ok {
@@ -282,7 +305,11 @@ func (db *txnDatabase) Truncate(ctx context.Context, name string) (uint64, error
 	if err != nil {
 		return 0, err
 	}
-	k := genTableKey(ctx, name, db.databaseId)
+	accountId, err := defines.GetAccountId(ctx)
+	if err != nil {
+		return 0, err
+	}
+	k := genTableKey(accountId, name, db.databaseId)
 	v, ok = db.txn.createMap.Load(k)
 	if !ok {
 		v, ok = db.txn.tableCache.tableMap.Load(k)
@@ -297,7 +324,7 @@ func (db *txnDatabase) Truncate(ctx context.Context, name string) (uint64, error
 		item := &cache.TableItem{
 			Name:       name,
 			DatabaseId: db.databaseId,
-			AccountId:  defines.GetAccountId(ctx),
+			AccountId: accountId,
 			Ts:         db.txn.op.SnapshotTS(),
 		}
 		if ok := db.txn.engine.catalog.GetTable(item); !ok {
@@ -333,7 +360,10 @@ func (db *txnDatabase) IsSubscription(ctx context.Context) bool {
 }
 
 func (db *txnDatabase) Create(ctx context.Context, name string, defs []engine.TableDef) error {
-	accountId, userId, roleId := getAccessInfo(ctx)
+	accountId, userId, roleId, err := getAccessInfo(ctx)
+	if err != nil {
+		return err
+	}
 	tableId, err := db.txn.allocateID(ctx)
 	if err != nil {
 		return err
@@ -416,7 +446,7 @@ func (db *txnDatabase) Create(ctx context.Context, name string, defs []engine.Ta
 	tbl.tableName = name
 	tbl.tableId = tableId
 	tbl.GetTableDef(ctx)
-	key := genTableKey(ctx, name, db.databaseId)
+	key := genTableKey(accountId, name, db.databaseId)
 	db.txn.addCreateTable(key, tbl)
 	//CORNER CASE
 	//begin;

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1916,7 +1916,11 @@ func (tbl *txnTable) getPartitionState(ctx context.Context) (*logtailreplay.Part
 func (tbl *txnTable) UpdateObjectInfos(ctx context.Context) (err error) {
 	tbl.tnList = []int{0}
 
-	_, created := tbl.db.txn.createMap.Load(genTableKey(ctx, tbl.tableName, tbl.db.databaseId))
+	accountId, err := defines.GetAccountId(ctx)
+	if err != nil {
+		return err
+	}
+	_, created := tbl.db.txn.createMap.Load(genTableKey(accountId, tbl.tableName, tbl.db.databaseId))
 	// check if the table is not created in this txn, and the block infos are not updated, then update:
 	// 1. update logtail
 	// 2. generate block infos
@@ -1937,7 +1941,12 @@ func (tbl *txnTable) updateLogtail(ctx context.Context) (err error) {
 	}
 
 	// if the table is created in this txn, skip
-	if _, created := tbl.db.txn.createMap.Load(genTableKey(ctx, tbl.tableName, tbl.db.databaseId)); created {
+	accountId, err := defines.GetAccountId(ctx)
+	if err != nil {
+		return err
+	}
+	if _, created := tbl.db.txn.createMap.Load(
+		genTableKey(accountId, tbl.tableName, tbl.db.databaseId)); created {
 		return
 	}
 

--- a/pkg/vm/engine/memoryengine/access_info.go
+++ b/pkg/vm/engine/memoryengine/access_info.go
@@ -26,15 +26,12 @@ type AccessInfo struct {
 	RoleID    uint32
 }
 
-func getAccessInfo(ctx context.Context) (info AccessInfo) {
-	if v := ctx.Value(defines.TenantIDKey{}); v != nil {
-		info.AccountID = v.(uint32)
+func getAccessInfo(ctx context.Context) (info AccessInfo, err error) {
+	info.AccountID, err = defines.GetAccountId(ctx)
+	if err != nil {
+		return
 	}
-	if v := ctx.Value(defines.UserIDKey{}); v != nil {
-		info.UserID = v.(uint32)
-	}
-	if v := ctx.Value(defines.RoleIDKey{}); v != nil {
-		info.RoleID = v.(uint32)
-	}
+	info.UserID = defines.GetUserId(ctx)
+	info.RoleID = defines.GetRoleId(ctx)
 	return
 }

--- a/pkg/vm/engine/memoryengine/compiler_context.go
+++ b/pkg/vm/engine/memoryengine/compiler_context.go
@@ -147,11 +147,8 @@ func (*CompilerContext) GetUserName() string {
 	return "root"
 }
 
-func (c *CompilerContext) GetAccountId() uint32 {
-	if v := c.ctx.Value(defines.TenantIDKey{}); v != nil {
-		return v.(uint32)
-	}
-	return 0
+func (c *CompilerContext) GetAccountId() (uint32, error) {
+	return defines.GetAccountId(c.ctx)
 }
 
 func (c *CompilerContext) GetContext() context.Context {

--- a/pkg/vm/engine/memoryengine/engine.go
+++ b/pkg/vm/engine/memoryengine/engine.go
@@ -78,6 +78,10 @@ func (e *Engine) Create(ctx context.Context, dbName string, txnOperator client.T
 		return err
 	}
 
+	access, err := getAccessInfo(ctx)
+	if err != nil {
+		return err
+	}
 	_, err = DoTxnRequest[CreateDatabaseResp](
 		ctx,
 		txnOperator,
@@ -86,7 +90,7 @@ func (e *Engine) Create(ctx context.Context, dbName string, txnOperator client.T
 		OpCreateDatabase,
 		&CreateDatabaseReq{
 			ID:         id,
-			AccessInfo: getAccessInfo(ctx),
+			AccessInfo: access,
 			Name:       dbName,
 		},
 	)
@@ -98,7 +102,10 @@ func (e *Engine) Create(ctx context.Context, dbName string, txnOperator client.T
 }
 
 func (e *Engine) Database(ctx context.Context, dbName string, txnOperator client.TxnOperator) (engine.Database, error) {
-
+	access, err := getAccessInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
 	resps, err := DoTxnRequest[OpenDatabaseResp](
 		ctx,
 		txnOperator,
@@ -106,7 +113,7 @@ func (e *Engine) Database(ctx context.Context, dbName string, txnOperator client
 		e.anyShard,
 		OpOpenDatabase,
 		&OpenDatabaseReq{
-			AccessInfo: getAccessInfo(ctx),
+			AccessInfo: access,
 			Name:       dbName,
 		},
 	)
@@ -129,7 +136,10 @@ func (e *Engine) Database(ctx context.Context, dbName string, txnOperator client
 }
 
 func (e *Engine) Databases(ctx context.Context, txnOperator client.TxnOperator) ([]string, error) {
-
+	access, err := getAccessInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
 	resps, err := DoTxnRequest[GetDatabasesResp](
 		ctx,
 		txnOperator,
@@ -137,7 +147,7 @@ func (e *Engine) Databases(ctx context.Context, txnOperator client.TxnOperator) 
 		e.anyShard,
 		OpGetDatabases,
 		&GetDatabasesReq{
-			AccessInfo: getAccessInfo(ctx),
+			AccessInfo: access,
 		},
 	)
 	if err != nil {
@@ -148,15 +158,18 @@ func (e *Engine) Databases(ctx context.Context, txnOperator client.TxnOperator) 
 }
 
 func (e *Engine) Delete(ctx context.Context, dbName string, txnOperator client.TxnOperator) error {
-
-	_, err := DoTxnRequest[DeleteDatabaseResp](
+	access, err := getAccessInfo(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = DoTxnRequest[DeleteDatabaseResp](
 		ctx,
 		txnOperator,
 		false,
 		e.allShards,
 		OpDeleteDatabase,
 		&DeleteDatabaseReq{
-			AccessInfo: getAccessInfo(ctx),
+			AccessInfo: access,
 			Name:       dbName,
 		},
 	)

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -863,9 +863,7 @@ func (h *Handle) HandleCreateDatabase(
 		})
 	}()
 
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, req.AccessInfo.AccountID)
-	ctx = context.WithValue(ctx, defines.UserIDKey{}, req.AccessInfo.UserID)
-	ctx = context.WithValue(ctx, defines.RoleIDKey{}, req.AccessInfo.RoleID)
+	ctx = defines.AttachAccount(ctx, req.AccessInfo.AccountID, req.AccessInfo.UserID, req.AccessInfo.RoleID)
 	ctx = context.WithValue(ctx, defines.DatTypKey{}, req.DatTyp)
 	if _, err = txn.CreateDatabaseWithCtx(
 		ctx,
@@ -917,9 +915,7 @@ func (h *Handle) HandleCreateRelation(
 		})
 	}()
 
-	ctx = context.WithValue(ctx, defines.TenantIDKey{}, req.AccessInfo.AccountID)
-	ctx = context.WithValue(ctx, defines.UserIDKey{}, req.AccessInfo.UserID)
-	ctx = context.WithValue(ctx, defines.RoleIDKey{}, req.AccessInfo.RoleID)
+	ctx = defines.AttachAccount(ctx, req.AccessInfo.AccountID, req.AccessInfo.UserID, req.AccessInfo.RoleID)
 	dbH, err := txn.GetDatabaseWithCtx(ctx, req.DatabaseName)
 	if err != nil {
 		return


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13944 

## What this PR does / why we need it:

原因：
传给cn，tn的context，某些情况下没有带上accountid。原先没带上accountid，默认就是sys租户。

mo后台任务线程默认就是sys租户。创建普通租户时，普通租户会创建一些表。如果此时accountid没设置， 就会被当作sys租户，来创建一些表。会与后台线程冲突。如果后台线程执行时间长，表现为创建租户时卡住。

修改：
在context没有设置accountid时，立即报错。避免进一步出错。
后续根据报错，修改代码，传入accountid。

影响：
修改了所有从context取accountid的地方。改动较多位置。但是改动都很直观。
