### PR TITLE
sync to 1.1: adding RWMutex to avoid concurrent map write

### DIFF
--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -415,13 +415,19 @@ func (e *Engine) New(ctx context.Context, op client.TxnOperator) error {
 		deletedBlocks: &deletedBlocks{
 			offsets: map[types.Blockid][]int64{},
 		},
-		cnBlkId_Pos:                     map[types.Blockid]Pos{},
-		blockId_raw_batch:               make(map[types.Blockid]*batch.Batch),
-		blockId_tn_delete_metaLoc_batch: make(map[types.Blockid][]*batch.Batch),
-		batchSelectList:                 make(map[*batch.Batch][]int64),
-		toFreeBatches:                   make(map[[2]string][]*batch.Batch),
-		syncCommittedTSCount:            e.cli.GetSyncLatestCommitTSTimes(),
+
+		cnBlkId_Pos:          map[types.Blockid]Pos{},
+		blockId_raw_batch:    make(map[types.Blockid]*batch.Batch),
+		batchSelectList:      make(map[*batch.Batch][]int64),
+		toFreeBatches:        make(map[[2]string][]*batch.Batch),
+		syncCommittedTSCount: e.cli.GetSyncLatestCommitTSTimes(),
 	}
+
+	txn.blockId_tn_delete_metaLoc_batch = struct {
+		sync.RWMutex
+		data map[types.Blockid][]*batch.Batch
+	}{data: make(map[types.Blockid][]*batch.Batch)}
+
 	txn.readOnly.Store(true)
 	// transaction's local segment for raw batch.
 	colexec.Srv.PutCnSegment(id, colexec.TxnWorkSpaceIdType)

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -445,9 +445,13 @@ func (r *blockMergeReader) Close() error {
 
 func (r *blockMergeReader) prefetchDeletes() error {
 	//load delta locations for r.blocks.
+	r.table.db.txn.blockId_tn_delete_metaLoc_batch.RLock()
+	defer r.table.db.txn.blockId_tn_delete_metaLoc_batch.RUnlock()
+
 	if !r.loaded {
 		for _, info := range r.blks {
-			bats, ok := r.table.db.txn.blockId_tn_delete_metaLoc_batch[info.BlockID]
+			bats, ok := r.table.db.txn.blockId_tn_delete_metaLoc_batch.data[info.BlockID]
+
 			if !ok {
 				return nil
 			}
@@ -462,8 +466,8 @@ func (r *blockMergeReader) prefetchDeletes() error {
 						append(r.deletaLocs[location.Name().String()], location)
 				}
 			}
-
 		}
+
 		// Get Single Col pk index
 		for idx, colDef := range r.tableDef.Cols {
 			if colDef.Name == r.tableDef.Pkey.PkeyColName {

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -696,8 +696,9 @@ func (txn *Transaction) delTransaction() {
 	txn.createMap = nil
 	txn.databaseMap = nil
 	txn.deletedTableMap = nil
-	txn.blockId_tn_delete_metaLoc_batch = nil
 	txn.blockId_raw_batch = nil
+
+	txn.blockId_tn_delete_metaLoc_batch.data = nil
 	txn.deletedBlocks = nil
 	segmentnames := make([]objectio.Segmentid, 0, len(txn.cnBlkId_Pos)+1)
 	segmentnames = append(segmentnames, txn.segId)

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -174,7 +174,11 @@ type Transaction struct {
 	//TODO::remove it
 	blockId_raw_batch map[types.Blockid]*batch.Batch
 	// committed block belongs to txn's snapshot data -> delta locations for committed block's deletes.
-	blockId_tn_delete_metaLoc_batch map[types.Blockid][]*batch.Batch
+	blockId_tn_delete_metaLoc_batch struct {
+		sync.RWMutex
+		data map[types.Blockid][]*batch.Batch
+	}
+	//blockId_tn_delete_metaLoc_batch map[types.Blockid][]*batch.Batch
 	//select list for raw batch comes from txn.writes.batch.
 	batchSelectList map[*batch.Batch][]int64
 	toFreeBatches   map[[2]string][]*batch.Batch


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/14138

## What this PR does / why we need it:
there is a tiny probability that concurrent write on the map txn.blockId_tn_delete_metaLoc_batch.

this PR adds an RWMutex to protect it