### PR TITLE
sync to 1.1: augment the hakeeperDefaultTimeout in ut to avoid TestHAKeeperCanBootstrapAndRepairShards failed

### DIFF
--- a/pkg/logservice/store_hakeeper_check.go
+++ b/pkg/logservice/store_hakeeper_check.go
@@ -30,11 +30,13 @@ import (
 )
 
 const (
-	minIDAllocCapacity uint64 = 1024
-	defaultIDBatchSize uint64 = 1024 * 10
+	minIDAllocCapacity   uint64 = 1024
+	defaultIDBatchSize   uint64 = 1024 * 10
+	checkBootstrapCycles        = 100
+)
 
+var (
 	hakeeperDefaultTimeout = 2 * time.Second
-	checkBootstrapCycles   = 100
 )
 
 type idAllocator struct {

--- a/pkg/logservice/store_hakeeper_check_test.go
+++ b/pkg/logservice/store_hakeeper_check_test.go
@@ -277,6 +277,8 @@ func TestHAKeeperCanBootstrapAndRepairShards(t *testing.T) {
 	fn := func(t *testing.T, services []*Service) {
 		// bootstrap the cluster, 1 TN 1 Log shard, Log and HAKeeper have
 		// 3 replicas
+		hakeeperDefaultTimeout = 10 * time.Second
+
 		store1 := services[0].store
 		state, err := store1.getCheckerState()
 		require.NoError(t, err)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:


issue #https://github.com/matrixorigin/matrixone/issues/8438

## What this PR does / why we need it:

augment the `hakeeperDefaultTimeout` to avoid `TestHAKeeperCanBootstrapAndRepairShards` failed.

this change only happened when UT.