### PR TITLE
fix bug: delete incorrect rows for hidden tables

### DIFF
--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -1531,6 +1531,27 @@ func makeOneDeletePlan(
 	isSK bool,
 ) (int32, error) {
 	if isUK || isSK {
+		// append filter
+		rowIdTyp := types.T_Rowid.ToType()
+		rowIdColExpr := &plan.Expr{
+			Typ: makePlan2Type(&rowIdTyp),
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{
+					ColPos: int32(delNodeInfo.deleteIndex),
+				},
+			},
+		}
+		filterExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "is_not_null", []*Expr{rowIdColExpr})
+		if err != nil {
+			return -1, err
+		}
+		filterNode := &Node{
+			NodeType:   plan.Node_FILTER,
+			Children:   []int32{lastNodeId},
+			FilterList: []*plan.Expr{filterExpr},
+		}
+		lastNodeId = builder.appendNode(filterNode, bindCtx)
+
 		// append lock
 		lockTarget := &plan.LockTarget{
 			TableId:            delNodeInfo.tableDef.TblId,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/14137 https://github.com/matrixorigin/matrixone/issues/14139

## What this PR does / why we need it:
当 更新/删除 unique key和2cnd key隐藏表的时候，是用 原表 left join隐藏表 ,取出隐藏表要更新/删除的 row id。
这个时候隐藏表的数据可能是null， 于是删除的batch的这一列的值全部是null，
（但是实际删的时候，不会去读null的那个属性，而是直接用的data里的数据，而这些数据都是vector被复用之前的错误数据。

这里在delete算子前加个filter算子筛选掉null值的行