### PR TITLE
Fix mpool leak for remote run

### DIFF
--- a/pkg/sql/compile/scopeRemoteRun.go
+++ b/pkg/sql/compile/scopeRemoteRun.go
@@ -189,6 +189,9 @@ func cnMessageHandle(receiver *messageReceiverOnServer) error {
 
 	case pipeline.Method_PipelineMessage:
 		c := receiver.newCompile()
+		defer func() {
+			mpool.DeleteMPool(c.proc.Mp())
+		}()
 
 		// decode and rewrite the scope.
 		s, err := decodeScope(receiver.scopeData, c.proc, true, c.e)

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -366,6 +366,11 @@ func (e *Engine) GetRelationById(ctx context.Context, op client.TxnOperator, tab
 	}
 
 	if rel == nil {
+		if tableId == 2 {
+			logutil.Errorf("can not find table by id %d: accountId: %v", tableId, accountId)
+			tbls, tblIds := e.catalog.Tables(accountId, 1, op.SnapshotTS())
+			logutil.Errorf("tables: %v, tableIds: %v", tbls, tblIds)
+		}
 		return "", "", nil, moerr.NewInternalError(ctx, "can not find table by id %d", tableId)
 	}
 	return


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14263

## What this PR does / why we need it:
* mpool现在都存在一个大map里，需要清理
* 将cannot find table by 2的日志也增加到1.1(因为没有core dump，所以改成日志)