### PR TITLE
cherry-pick to main : fix setvar in the active transaction

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -748,6 +748,7 @@ func doSetVar(ctx context.Context, mce *MysqlCmdExecutor, ses *Session, sv *tree
 	var err error = nil
 	var ok bool
 	setVarFunc := func(system, global bool, name string, value interface{}, sql string) error {
+		var oldValueRaw interface{}
 		if system {
 			if global {
 				err = doCheckRole(ctx, ses)
@@ -763,6 +764,12 @@ func doSetVar(ctx context.Context, mce *MysqlCmdExecutor, ses *Session, sv *tree
 					return err
 				}
 			} else {
+				if strings.ToLower(name) == "autocommit" {
+					oldValueRaw, err = ses.GetSessionVar("autocommit")
+					if err != nil {
+						return err
+					}
+				}
 				err = ses.SetSessionVar(name, value)
 				if err != nil {
 					return err
@@ -770,11 +777,15 @@ func doSetVar(ctx context.Context, mce *MysqlCmdExecutor, ses *Session, sv *tree
 			}
 
 			if strings.ToLower(name) == "autocommit" {
-				newValue, err2 := valueIsBoolTrue(value)
-				if err2 != nil {
-					return err2
+				oldValue, err := valueIsBoolTrue(oldValueRaw)
+				if err != nil {
+					return err
 				}
-				err = ses.SetAutocommit(newValue)
+				newValue, err := valueIsBoolTrue(value)
+				if err != nil {
+					return err
+				}
+				err = ses.SetAutocommit(oldValue, newValue)
 				if err != nil {
 					return err
 				}
@@ -2550,8 +2561,6 @@ func (mce *MysqlCmdExecutor) canExecuteStatementInUncommittedTransaction(request
 			return moerr.NewInternalError(requestCtx, onlyCreateStatementErrorInfo())
 		} else if IsAdministrativeStatement(stmt) {
 			return moerr.NewInternalError(requestCtx, administrativeCommandIsUnsupportedInTxnErrorInfo())
-		} else if IsParameterModificationStatement(stmt) {
-			return moerr.NewInternalError(requestCtx, parameterModificationInTxnErrorInfo())
 		} else {
 			return moerr.NewInternalError(requestCtx, unclassifiedStatementInUncommittedTxnErrorInfo())
 		}
@@ -2934,10 +2943,13 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 	if err != nil {
 		return err
 	}
-	ses.GetTxnHandler().disableStartStmt()
+
 	if txnOp != nil && !ses.IsDerivedStmt() {
-		txnOp.GetWorkspace().StartStatement()
-		ses.GetTxnHandler().enableStartStmt(txnOp.Txn().ID)
+		ok, _ := ses.GetTxnHandler().calledStartStmt()
+		if !ok {
+			txnOp.GetWorkspace().StartStatement()
+			ses.GetTxnHandler().enableStartStmt(txnOp.Txn().ID)
+		}
 	}
 
 	// defer Start/End Statement management, called after finishTxnFunc()

--- a/pkg/frontend/session_test.go
+++ b/pkg/frontend/session_test.go
@@ -259,8 +259,8 @@ func TestSession_TxnBegin(t *testing.T) {
 		convey.So(err, convey.ShouldBeNil)
 		err = ses.TxnBegin()
 		convey.So(err, convey.ShouldBeNil)
-		err = ses.SetAutocommit(false)
-		convey.So(err, convey.ShouldNotBeNil)
+		err = ses.SetAutocommit(true, false)
+		convey.So(err, convey.ShouldBeNil)
 		err = ses.TxnCommit()
 		convey.So(err, convey.ShouldBeNil)
 		_, _, err = ses.GetTxnHandler().GetTxn()
@@ -269,10 +269,10 @@ func TestSession_TxnBegin(t *testing.T) {
 		err = ses.TxnCommit()
 		convey.So(err, convey.ShouldBeNil)
 
-		err = ses.SetAutocommit(true)
+		err = ses.SetAutocommit(false, true)
 		convey.So(err, convey.ShouldBeNil)
 
-		err = ses.SetAutocommit(false)
+		err = ses.SetAutocommit(false, false)
 		convey.So(err, convey.ShouldBeNil)
 	})
 }

--- a/pkg/frontend/stmt_kind.go
+++ b/pkg/frontend/stmt_kind.go
@@ -207,6 +207,8 @@ func statementCanBeExecutedInUncommittedTransaction(ses *Session, stmt tree.Stat
 	case *tree.DropDatabase, *tree.DropSequence: //Case1, Case3 above
 		//background transaction can execute the DROPxxx in one transaction
 		return ses.IsBackgroundSession() || !ses.OptionBitsIsSet(OPTION_BEGIN), nil
+	case *tree.SetVar:
+		return true, nil
 	}
 
 	return false, nil

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -743,14 +743,27 @@ SetAutocommit sets the value of the system variable 'autocommit'.
 The rule is that we can not execute the statement 'set parameter = value' in
 an active transaction whichever it is started by BEGIN or in 'set autocommit = 0;'.
 */
-func (ses *Session) SetAutocommit(on bool) error {
-	if ses.InActiveTransaction() {
-		return moerr.NewInternalError(ses.requestCtx, parameterModificationInTxnErrorInfo())
-	}
-	if on {
+func (ses *Session) SetAutocommit(old, on bool) error {
+	//on -> on : do nothing
+	//off -> on : commit active txn
+	//	if commit failed, clean OPTION_AUTOCOMMIT
+	//	if commit succeeds, clean OPTION_BEGIN | OPTION_NOT_AUTOCOMMIT
+	//		and set SERVER_STATUS_AUTOCOMMIT
+	//on -> off :
+	//	clean OPTION_AUTOCOMMIT
+	//	clean SERVER_STATUS_AUTOCOMMIT
+	//	set OPTION_NOT_AUTOCOMMIT
+	//off -> off : do nothing
+	if !old && on { //off -> on
+		//activating autocommit
+		err := ses.txnHandler.CommitTxn()
+		if err != nil {
+			ses.ClearOptionBits(OPTION_AUTOCOMMIT)
+			return err
+		}
 		ses.ClearOptionBits(OPTION_BEGIN | OPTION_NOT_AUTOCOMMIT)
 		ses.SetServerStatus(SERVER_STATUS_AUTOCOMMIT)
-	} else {
+	} else if old && !on { //on -> off
 		ses.ClearServerStatus(SERVER_STATUS_AUTOCOMMIT)
 		ses.SetOptionBits(OPTION_NOT_AUTOCOMMIT)
 	}

--- a/test/distributed/cases/optimistic/autocommit.result
+++ b/test/distributed/cases/optimistic/autocommit.result
@@ -29,11 +29,10 @@ drop table t1;
 commit;
 start transaction;
 set autocommit=1;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 commit;
 start transaction;
 show tables;
-tables_in_autocommit
+Tables_in_autocommit
 commit;
 set autocommit=0;
 drop table if exists t1;
@@ -46,7 +45,6 @@ a
 insert into t1 values(1);
 insert into t1 values(2);
 set autocommit=1;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 commit;
 set autocommit=1;
 set autocommit=0;
@@ -63,7 +61,7 @@ Previous DML conflicts with existing constraints or data format. This transactio
 insert into t1 values(3);
 use autocommit;
 show tables;
-tables_in_autocommit
+Tables_in_autocommit
 t1
 commit;
 set autocommit = 1;

--- a/test/distributed/cases/optimistic/autocommit_1.result
+++ b/test/distributed/cases/optimistic/autocommit_1.result
@@ -134,22 +134,18 @@ drop table if exists t3;
 create table t3(a int);
 insert into t3 values (10),(20),(30);
 set @@autocommit=ON;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 select @@autocommit;
 @@autocommit
-0
+1
 set @@autocommit=OFF;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 select @@autocommit;
 @@autocommit
 0
 set @@autocommit=1;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 select @@autocommit;
 @@autocommit
-0
+1
 set @@autocommit=0;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 select @@autocommit;
 @@autocommit
 0
@@ -158,22 +154,18 @@ drop table if exists tab3;
 create table tab3 (a int, b varchar(25));
 insert into tab3 values (10, 'aa'),(20, 'bb'),(30, 'cc');
 set @@autocommit=ON;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 select @@autocommit;
 @@autocommit
-0
+1
 set @@autocommit=OFF;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 select @@autocommit;
 @@autocommit
 0
 set @@autocommit=1;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 select @@autocommit;
 @@autocommit
-0
+1
 set @@autocommit=0;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 commit;
 select * from tab3;
 a    b
@@ -253,22 +245,18 @@ begin;
 create database test_xx;
 internal error: CREATE/DROP of database is not supported in transactions
 SET @@session.autocommit=1;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 SELECT @@session.autocommit;
 @@autocommit
 1
 SET @@session.autocommit= 0;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 SELECT @@session.autocommit;
 @@autocommit
-1
+0
 SET @@session.autocommit=OFF;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 SELECT @@session.autocommit;
 @@autocommit
-1
+0
 SET @@session.autocommit=ON;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 SELECT @@session.autocommit;
 @@autocommit
 1

--- a/test/distributed/cases/optimistic/autocommit_1.sql
+++ b/test/distributed/cases/optimistic/autocommit_1.sql
@@ -131,19 +131,19 @@ drop table if exists t3;
 create table t3(a int);
 insert into t3 values (10),(20),(30);
 
--- echo mo throw exception
+-- no error. autocommit from OFF to ON. Commit the transaction.
 set @@autocommit=ON;
 select @@autocommit;
 
--- echo mo throw exception
+-- no error. autocommit from ON to OFF.
 set @@autocommit=OFF;
 select @@autocommit;
 
--- echo mo throw exception
+-- no error. autocommit from OFF to ON. Commit the transaction.
 set @@autocommit=1;
 select @@autocommit;
 
--- echo mo throw exception
+-- no error. autocommit from ON to OFF.
 set @@autocommit=0;
 select @@autocommit;
 
@@ -153,19 +153,19 @@ rollback;
 drop table if exists tab3;
 create table tab3 (a int, b varchar(25));
 insert into tab3 values (10, 'aa'),(20, 'bb'),(30, 'cc');
--- echo mo throw exception
+-- no error. autocommit from OFF to ON. Commit the transaction.
 set @@autocommit=ON;
 select @@autocommit;
 
--- echo mo throw exception
+-- no error. autocommit from ON to OFF.
 set @@autocommit=OFF;
 select @@autocommit;
 
--- echo mo throw exception
+-- no error. autocommit from OFF to ON. Commit the transaction.
 set @@autocommit=1;
 select @@autocommit;
 
--- echo mo throw exception
+-- no error. autocommit from ON to OFF.
 set @@autocommit=0;
 commit;
 
@@ -223,19 +223,19 @@ drop database if exists test_xx;
 begin;
 create database test_xx;
 
--- echo internal error: Uncommitted transaction exists. Please commit or rollback first.
+-- no error. autocommit from ON to ON.
 SET @@session.autocommit=1;
 SELECT @@session.autocommit;
 
--- echo internal error: Uncommitted transaction exists. Please commit or rollback first.
+-- no error. autocommit from ON to OFF.
 SET @@session.autocommit= 0;
 SELECT @@session.autocommit;
 
--- echo internal error: Uncommitted transaction exists. Please commit or rollback first.
+-- no error. autocommit from OFF to OFF.
 SET @@session.autocommit=OFF;
 SELECT @@session.autocommit;
 
--- echo internal error: Uncommitted transaction exists. Please commit or rollback first.
+-- no error. autocommit from OFF to ON. Commit the transaction.
 SET @@session.autocommit=ON;
 SELECT @@session.autocommit;
 commit;

--- a/test/distributed/cases/optimistic/transaction_enhance.result
+++ b/test/distributed/cases/optimistic/transaction_enhance.result
@@ -38,6 +38,7 @@ insert into atomic_table_10 values (3,"a"),(4,"b"),(5,"c");
 begin ;
 truncate table atomic_table_10;
 insert into atomic_table_10 values (6,"a"),(7,"b"),(8,"c");
+
 select * from atomic_table_10;
 c1    c2
 3    a
@@ -57,6 +58,7 @@ insert into atomic_table_11 values (3,"a"),(4,"b"),(5,"c");
 begin;
 drop table atomic_table_11;
 insert into atomic_table_11 values (6,"a");
+
 select * from atomic_table_11;
 c1    c2
 3    a
@@ -72,6 +74,7 @@ insert into atomic_table_11 values (3,"a"),(4,"b"),(5,"c");
 begin;
 drop table atomic_table_11;
 insert into atomic_table_11 values (6,"a");
+
 select * from atomic_table_11;
 c1    c2
 3    a
@@ -79,6 +82,7 @@ c1    c2
 5    c
 6    a
 rollback ;
+
 select * from atomic_table_11;
 c1    c2
 3    a
@@ -107,8 +111,8 @@ show create table atomic_table_12;
 Table    Create Table
 atomic_table_12    CREATE TABLE `atomic_table_12` (\n`c1` INT DEFAULT NULL,\n`c2` VARCHAR(25) DEFAULT NULL,\nKEY `key1` (`c1`)\n)
 show index from atomic_table_12;
-Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Visible    Expression
-atomic_table_12    1    key1    1    c1    A    0    NULL    NULL    YES                YES    NULL
+Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Index_params    Visible    Expression
+atomic_table_12    1    key1    1    c1    A    0    NULL    NULL    YES                    YES    NULL
 use transaction_enhance;
 drop table if exists atomic_table_12_1;
 create table atomic_table_12_1(c1 int,c2 varchar(25));
@@ -124,7 +128,7 @@ show create table atomic_table_12_1;
 Table    Create Table
 atomic_table_12_1    CREATE TABLE `atomic_table_12_1` (\n`c1` INT DEFAULT NULL,\n`c2` VARCHAR(25) DEFAULT NULL\n)
 show index from atomic_table_12_1;
-Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Visible    Expression
+Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Index_params    Visible    Expression
 use transaction_enhance;
 drop table if exists atomic_table_12_2;
 drop table if exists atomic_table_13;
@@ -208,7 +212,7 @@ c1    c2
 5    c
 commit;
 show index from atomic_table_12_5;
-Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Visible    Expression
+Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Index_params    Visible    Expression
 drop table if exists atomic_table_14;
 create table atomic_table_14(c1 int,c2 varchar(25));
 insert into atomic_table_14 values (3,"a"),(4,"b"),(5,"c");
@@ -216,7 +220,9 @@ start transaction ;
 alter table atomic_table_14 add  index key1(c1);
 drop table atomic_table_14;
 insert into atomic_table_14 values (6,"a"),(7,"b");
+
 select * from atomic_table_14;
+
 commit;
 w-w conflict
 select * from atomic_table_14;
@@ -297,7 +303,7 @@ show create table atomic_table_18;
 Table    Create Table
 atomic_table_18    CREATE TABLE `atomic_table_18` (\n`c1` INT DEFAULT NULL,\n`c2` VARCHAR(25) DEFAULT NULL\n)
 show index from atomic_table_18;
-Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Visible    Expression
+Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Index_params    Visible    Expression
 truncate table atomic_table_18;
 drop table atomic_table_18;
 select * from atomic_table_18;

--- a/test/distributed/cases/pessimistic_transaction/isolation_2.result
+++ b/test/distributed/cases/pessimistic_transaction/isolation_2.result
@@ -343,7 +343,7 @@ commit ;
 select * from dis_table_01;
 a    b
 begin ;
-delete from dis_table_02 where a>1;;
+delete from dis_table_02 where a>1;
 select b, c from dis_table_02;
 b    c
 pppp    2020-09-08 00:00:00

--- a/test/distributed/cases/statement_query_type/statement_query_type.result
+++ b/test/distributed/cases/statement_query_type/statement_query_type.result
@@ -202,7 +202,6 @@ drop database db2;
 internal error: CREATE/DROP of database is not supported in transactions
 prepare s1 from select * from test_table where col1=?;
 set @a=2;
-internal error: Uncommitted transaction exists. Please commit or rollback first.
 execute s1 using @a;
 col1    col2
 2    b


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2343
issue #https://github.com/matrixorigin/MO-Cloud/issues/2048

## What this PR does / why we need it:

之前的设计，限制set 用在活跃事务中。原因是早期mo的bug奇多，为了避免踩坑，做了限制。
现在由于与mysql 应用的兼容性原因。尝试放开。

1，set @autocommit = ON:
从  OFF 到 ON，mo会commit事务。如果commit失败，autocommit 标志不会设置成功。
