### PR TITLE
fileservice: add NoDefaultCredentialsForETL

### DIFF
--- a/pkg/fileservice/aliyun_sdk.go
+++ b/pkg/fileservice/aliyun_sdk.go
@@ -536,6 +536,9 @@ func (o ObjectStorageArguments) credentialProviderForAliyunSDK(
 ) (ret oss.CredentialsProvider, err error) {
 
 	defer func() {
+		if err != nil {
+			return
+		}
 		// chain assume role provider
 		if o.RoleARN != "" {
 			logutil.Info("with role arn")
@@ -578,6 +581,12 @@ func (o ObjectStorageArguments) credentialProviderForAliyunSDK(
 	}
 
 	if config.Type == nil {
+
+		if o.NoDefaultCredentials {
+			return nil, moerr.NewInvalidInputNoCtx(
+				"no valid credentials",
+			)
+		}
 
 		// check aws env
 		awsCredentials := awscredentials.NewEnvCredentials()

--- a/pkg/fileservice/aws_sdk_v2.go
+++ b/pkg/fileservice/aws_sdk_v2.go
@@ -132,7 +132,10 @@ func NewAwsSDKv2(
 		)
 	}
 
-	credentialProvider := args.credentialsProviderForAwsSDKv2(ctx)
+	credentialProvider, err := args.credentialsProviderForAwsSDKv2(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	// validate
 	if credentialProvider != nil {
@@ -689,6 +692,7 @@ func (o ObjectStorageArguments) credentialsProviderForAwsSDKv2(
 	ctx context.Context,
 ) (
 	ret aws.CredentialsProvider,
+	err error,
 ) {
 
 	// cache
@@ -750,7 +754,13 @@ func (o ObjectStorageArguments) credentialsProviderForAwsSDKv2(
 	if o.KeyID != "" && o.KeySecret != "" {
 		// static
 		logutil.Info("static credential")
-		return credentials.NewStaticCredentialsProvider(o.KeyID, o.KeySecret, o.SessionToken)
+		return credentials.NewStaticCredentialsProvider(o.KeyID, o.KeySecret, o.SessionToken), nil
+	}
+
+	if o.NoDefaultCredentials {
+		return nil, moerr.NewInvalidInputNoCtx(
+			"no valid credentials",
+		)
 	}
 
 	return

--- a/pkg/fileservice/config.go
+++ b/pkg/fileservice/config.go
@@ -117,11 +117,13 @@ func newMinioFileService(
 	ctx context.Context, cfg Config, perfCounters []*perfcounter.CounterSet,
 ) (FileService, error) {
 	cfg.S3.Name = cfg.Name
-	fs, err := NewS3FSOnMinio(
+	cfg.S3.IsMinio = true
+	fs, err := NewS3FS(
 		ctx,
 		cfg.S3,
 		cfg.Cache,
 		perfCounters,
+		false,
 		false,
 	)
 	if err != nil {
@@ -140,6 +142,7 @@ func newS3FileService(
 		cfg.S3,
 		cfg.Cache,
 		perfCounters,
+		false,
 		false,
 	)
 	if err != nil {

--- a/pkg/fileservice/get.go
+++ b/pkg/fileservice/get.go
@@ -16,6 +16,7 @@ package fileservice
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -49,6 +50,8 @@ func Get[T any](fs FileService, name string) (res T, err error) {
 	}
 	return
 }
+
+var NoDefaultCredentialsForETL = os.Getenv("MO_NO_DEFAULT_CREDENTIALS") != ""
 
 // GetForETL get or creates a FileService instance for ETL operations
 // if service part of path is empty, a LocalETLFS will be created
@@ -110,6 +113,7 @@ func GetForETL(ctx context.Context, fs FileService, path string) (res ETLFileSer
 				DisabledCacheConfig,
 				nil,
 				true,
+				NoDefaultCredentialsForETL,
 			)
 			if err != nil {
 				return
@@ -141,6 +145,7 @@ func GetForETL(ctx context.Context, fs FileService, path string) (res ETLFileSer
 				DisabledCacheConfig,
 				nil,
 				true,
+				NoDefaultCredentialsForETL,
 			)
 
 		case "s3-opts":
@@ -154,6 +159,7 @@ func GetForETL(ctx context.Context, fs FileService, path string) (res ETLFileSer
 				DisabledCacheConfig,
 				nil,
 				true,
+				NoDefaultCredentialsForETL,
 			)
 			if err != nil {
 				return
@@ -176,7 +182,7 @@ func GetForETL(ctx context.Context, fs FileService, path string) (res ETLFileSer
 				name = arguments[6]
 			}
 
-			res, err = NewS3FSOnMinio(
+			res, err = NewS3FS(
 				ctx,
 				ObjectStorageArguments{
 					Endpoint:  endpoint,
@@ -186,10 +192,12 @@ func GetForETL(ctx context.Context, fs FileService, path string) (res ETLFileSer
 					KeySecret: accessSecret,
 					KeyPrefix: keyPrefix,
 					Name:      name,
+					IsMinio:   true,
 				},
 				DisabledCacheConfig,
 				nil,
 				true,
+				NoDefaultCredentialsForETL,
 			)
 			if err != nil {
 				return
@@ -246,6 +254,7 @@ func GetForBackup(ctx context.Context, spec string) (res FileService, err error)
 				DisabledCacheConfig,
 				nil,
 				true,
+				false,
 			)
 			if err != nil {
 				return

--- a/pkg/fileservice/minio_sdk.go
+++ b/pkg/fileservice/minio_sdk.go
@@ -59,11 +59,14 @@ func NewMinioSDK(
 	options := new(minio.Options)
 
 	// credentials
-	credentialProviders := []credentials.Provider{
-		// aws env
-		new(credentials.EnvAWS),
-		// minio env
-		new(credentials.EnvMinio),
+	var credentialProviders []credentials.Provider
+	if !args.NoDefaultCredentials {
+		credentialProviders = append(credentialProviders,
+			// aws env
+			new(credentials.EnvAWS),
+			// minio env
+			new(credentials.EnvMinio),
+		)
 	}
 	if args.KeyID != "" && args.KeySecret != "" {
 		// static

--- a/pkg/fileservice/object_storage_arguments.go
+++ b/pkg/fileservice/object_storage_arguments.go
@@ -25,9 +25,10 @@ import (
 
 type ObjectStorageArguments struct {
 	// misc
-	Name                string `toml:"name"`
-	KeyPrefix           string `toml:"key-prefix"`
-	SharedConfigProfile string `toml:"shared-config-profile"`
+	Name                 string `toml:"name"`
+	KeyPrefix            string `toml:"key-prefix"`
+	SharedConfigProfile  string `toml:"shared-config-profile"`
+	NoDefaultCredentials bool   `toml:"no-default-credentials"`
 
 	// s3
 	Bucket    string   `toml:"bucket"`

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -65,7 +65,10 @@ func NewS3FS(
 	cacheConfig CacheConfig,
 	perfCounterSets []*perfcounter.CounterSet,
 	noCache bool,
+	noDefaultCredential bool,
 ) (*S3FS, error) {
+
+	args.NoDefaultCredentials = noDefaultCredential
 
 	fs := &S3FS{
 		name:            args.Name,
@@ -104,19 +107,6 @@ func NewS3FS(
 	}
 
 	return fs, nil
-}
-
-// NewS3FSOnMinio creates S3FS on minio server
-// this is needed because the URL scheme of minio server does not compatible with AWS'
-func NewS3FSOnMinio(
-	ctx context.Context,
-	args ObjectStorageArguments,
-	cacheConfig CacheConfig,
-	perfCounterSets []*perfcounter.CounterSet,
-	noCache bool,
-) (*S3FS, error) {
-	args.IsMinio = true
-	return NewS3FS(ctx, args, cacheConfig, perfCounterSets, noCache)
 }
 
 func (s *S3FS) initCaches(ctx context.Context, config CacheConfig) error {

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	"github.com/matrixorigin/matrixone/pkg/util/toml"
@@ -126,6 +127,7 @@ func testS3FS(
 				DisabledCacheConfig,
 				nil,
 				true,
+				false,
 			)
 			assert.Nil(t, err)
 
@@ -154,6 +156,7 @@ func testS3FS(
 			DisabledCacheConfig,
 			nil,
 			true,
+			false,
 		)
 		assert.Nil(t, err)
 		var counterSet, counterSet2 perfcounter.CounterSet
@@ -183,6 +186,7 @@ func testS3FS(
 				},
 				nil,
 				false,
+				false,
 			)
 			assert.Nil(t, err)
 			return fs
@@ -207,6 +211,7 @@ func testS3FS(
 					DiskPath:       ptrTo(t.TempDir()),
 				},
 				nil,
+				false,
 				false,
 			)
 			assert.Nil(t, err)
@@ -457,19 +462,21 @@ func TestS3FSMinioServer(t *testing.T) {
 		cacheDir := t.TempDir()
 		testFileService(t, 0, func(name string) FileService {
 			ctx := context.Background()
-			fs, err := NewS3FSOnMinio(
+			fs, err := NewS3FS(
 				ctx,
 				ObjectStorageArguments{
 					Name:      name,
 					Endpoint:  endpoint,
 					Bucket:    "test",
 					KeyPrefix: time.Now().Format("2006-01-02.15:04:05.000000"),
+					IsMinio:   true,
 				},
 				CacheConfig{
 					DiskPath: ptrTo(cacheDir),
 				},
 				nil,
 				true,
+				false,
 			)
 			assert.Nil(t, err)
 			return fs
@@ -510,6 +517,7 @@ func BenchmarkS3FS(b *testing.B) {
 			},
 			nil,
 			true,
+			false,
 		)
 		assert.Nil(b, err)
 		return fs
@@ -542,6 +550,7 @@ func TestS3FSWithSubPath(t *testing.T) {
 			DisabledCacheConfig,
 			nil,
 			true,
+			false,
 		)
 		assert.Nil(t, err)
 		return SubPath(fs, "foo/")
@@ -619,6 +628,7 @@ func BenchmarkS3ConcurrentRead(b *testing.B) {
 		DisabledCacheConfig,
 		nil,
 		true,
+		false,
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -746,6 +756,7 @@ func TestSequentialS3Read(t *testing.T) {
 		DisabledCacheConfig,
 		nil,
 		true,
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -814,6 +825,7 @@ func TestS3RestoreFromCache(t *testing.T) {
 			DiskPath: ptrTo(cacheDir),
 		},
 		nil,
+		false,
 		false,
 	)
 	assert.Nil(t, err)
@@ -910,6 +922,7 @@ func TestS3PrefetchFile(t *testing.T) {
 		},
 		nil,
 		false,
+		false,
 	)
 	assert.Nil(t, err)
 
@@ -957,25 +970,36 @@ func TestS3PrefetchFile(t *testing.T) {
 
 }
 
-func TestNewS3FSFromSpec(t *testing.T) {
+type S3CredentialTestCase struct {
+	Skip bool
+	ObjectStorageArguments
+}
+
+var s3CredentialTestCases = func() []S3CredentialTestCase {
 	content, err := os.ReadFile("s3_fs_test_new.xml")
 	if os.IsNotExist(err) {
-		t.Skip("no spec file, skip")
+		return nil
 	}
-	assert.Nil(t, err)
-
-	type Case struct {
-		Skip bool
-		ObjectStorageArguments
+	if err != nil {
+		panic(err)
 	}
 	var spec struct {
-		XMLName xml.Name `xml:"Spec"`
-		Cases   []Case   `xml:"Case"`
+		XMLName xml.Name               `xml:"Spec"`
+		Cases   []S3CredentialTestCase `xml:"Case"`
 	}
 	err = xml.Unmarshal(content, &spec)
-	assert.Nil(t, err)
+	if err != nil {
+		panic(err)
+	}
+	return spec.Cases
+}()
 
-	for _, kase := range spec.Cases {
+func TestNewS3FSFromSpec(t *testing.T) {
+	if len(s3CredentialTestCases) == 0 {
+		t.Skip("no case")
+	}
+
+	for _, kase := range s3CredentialTestCases {
 		if kase.Skip {
 			continue
 		}
@@ -989,6 +1013,7 @@ func TestNewS3FSFromSpec(t *testing.T) {
 				DisabledCacheConfig,
 				nil,
 				true,
+				false,
 			)
 			assert.Nil(t, err)
 			_ = fs
@@ -996,4 +1021,20 @@ func TestNewS3FSFromSpec(t *testing.T) {
 		})
 	}
 
+}
+
+func TestNewS3NoDefaultCredential(t *testing.T) {
+	ctx := context.Background()
+	_, err := NewS3FS(
+		ctx,
+		ObjectStorageArguments{
+			Endpoint: "aliyuncs.com",
+		},
+		DisabledCacheConfig,
+		nil,
+		true,
+		true,
+	)
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrInvalidInput))
+	assert.True(t, strings.Contains(err.Error(), "no valid credentials"))
 }


### PR DESCRIPTION
fileservice: add ObjectStorageArguments.NoDefaultCredentials

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14113

## What this PR does / why we need it:
add config to disable default credentials.