### PR TITLE
allow serial/serial_full to be constant-folded

### DIFF
--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1224,7 +1224,7 @@ func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name s
 	}
 
 	switch retExpr.GetF().GetFunc().GetObjName() {
-	case "+", "-", "*", "/", "unary_minus", "unary_plus", "unary_tilde", "in", "prefix_in":
+	case "+", "-", "*", "/", "unary_minus", "unary_plus", "unary_tilde", "in", "prefix_in", "serial", "serial_full":
 		if proc != nil {
 			tmpexpr, _ := ConstantFold(batch.EmptyForConstFoldBatch, DeepCopyExpr(retExpr), proc, false)
 			if tmpexpr != nil {
@@ -1636,9 +1636,9 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 						return nil, err
 					}
 					inExprList = append(inExprList, inExpr)
-					continue
+				} else {
+					orExprList = append(orExprList, rightVal)
 				}
-				orExprList = append(orExprList, rightVal)
 			}
 
 			var newExpr *plan.Expr

--- a/pkg/sql/plan/function/function.go
+++ b/pkg/sql/plan/function/function.go
@@ -394,7 +394,7 @@ type overload struct {
 }
 
 func (ov *overload) CannotFold() bool {
-	return ov.volatile
+	return ov.volatile || ov.isAgg || ov.isWin
 }
 
 func (ov *overload) IsRealTimeRelated() bool {

--- a/pkg/sql/plan/function/function.go
+++ b/pkg/sql/plan/function/function.go
@@ -394,7 +394,7 @@ type overload struct {
 }
 
 func (ov *overload) CannotFold() bool {
-	return ov.volatile || ov.isAgg || ov.isWin
+	return ov.volatile
 }
 
 func (ov *overload) IsRealTimeRelated() bool {

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1101,7 +1101,7 @@ func ConstantFold(bat *batch.Batch, expr *plan.Expr, proc *process.Process, varA
 	if err != nil {
 		return nil, err
 	}
-	if fn.Func.ObjName != "cast" && f.CannotFold() { // function cannot be fold
+	if f.CannotFold() || f.IsRealTimeRelated() {
 		return expr, nil
 	}
 	for i := range fn.Args {
@@ -1202,11 +1202,7 @@ func checkNoNeedCast(constT, columnT types.Type, constExpr *plan.Literal) bool {
 	case types.T_char, types.T_varchar, types.T_text:
 		switch columnT.Oid {
 		case types.T_char, types.T_varchar:
-			if constT.Width <= columnT.Width {
-				return true
-			} else {
-				return false
-			}
+			return constT.Width <= columnT.Width
 		case types.T_text:
 			return true
 		default:


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13987

## What this PR does / why we need it:
serial must be constant-folded, to allow IN filter on composed primary key