### PR TITLE
clean up func getPkValueExpr to use IN instead of OR for cpk

### DIFF
--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -210,14 +210,14 @@ func setTableExprToDmlTableInfo(ctx CompilerContext, tbl tree.TableExpr, tblInfo
 		tbl = aliasTbl.Expr
 	}
 
-	if jionTbl, ok := tbl.(*tree.JoinTableExpr); ok {
+	if joinTbl, ok := tbl.(*tree.JoinTableExpr); ok {
 		tblInfo.needAggFilter = true
-		err := setTableExprToDmlTableInfo(ctx, jionTbl.Left, tblInfo, aliasMap, withMap)
+		err := setTableExprToDmlTableInfo(ctx, joinTbl.Left, tblInfo, aliasMap, withMap)
 		if err != nil {
 			return err
 		}
-		if jionTbl.Right != nil {
-			return setTableExprToDmlTableInfo(ctx, jionTbl.Right, tblInfo, aliasMap, withMap)
+		if joinTbl.Right != nil {
+			return setTableExprToDmlTableInfo(ctx, joinTbl.Right, tblInfo, aliasMap, withMap)
 		}
 		return nil
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13987

## What this PR does / why we need it:

use IN instead of OR for cpk and fix a typo