### PR TITLE
Revert "clean up func getPkValueExpr to use IN instead of OR for cpk …

### DIFF
--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -210,14 +210,14 @@ func setTableExprToDmlTableInfo(ctx CompilerContext, tbl tree.TableExpr, tblInfo
 		tbl = aliasTbl.Expr
 	}
 
-	if joinTbl, ok := tbl.(*tree.JoinTableExpr); ok {
+	if jionTbl, ok := tbl.(*tree.JoinTableExpr); ok {
 		tblInfo.needAggFilter = true
-		err := setTableExprToDmlTableInfo(ctx, joinTbl.Left, tblInfo, aliasMap, withMap)
+		err := setTableExprToDmlTableInfo(ctx, jionTbl.Left, tblInfo, aliasMap, withMap)
 		if err != nil {
 			return err
 		}
-		if joinTbl.Right != nil {
-			return setTableExprToDmlTableInfo(ctx, joinTbl.Right, tblInfo, aliasMap, withMap)
+		if jionTbl.Right != nil {
+			return setTableExprToDmlTableInfo(ctx, jionTbl.Right, tblInfo, aliasMap, withMap)
 		}
 		return nil
 	}

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -301,8 +301,6 @@ func getPkValueExpr(builder *QueryBuilder, ctx CompilerContext, tableDef *TableD
 	var insertRowIdx int
 	var pkColIdx int
 
-	// handles UUID types specifically by creating a VARCHAR type and casting the UUID to a string.
-	// If the expression is nil, it creates a constant expression with either the UUID value or a constant value.
 	for insertRowIdx, pkColIdx = range pkPosInValues {
 		valExprs := make([]*Expr, rowsCount)
 		rowTyp := bat.Vecs[insertRowIdx].GetType()
@@ -360,43 +358,67 @@ func getPkValueExpr(builder *QueryBuilder, ctx CompilerContext, tableDef *TableD
 	}
 
 	if pkColLength == 1 {
-		// pk in (a1, a2, a3)
-		// args in list must be constant
-		expr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "in", []*Expr{{
-			Typ: colTyp,
-			Expr: &plan.Expr_Col{
-				Col: &ColRef{
-					ColPos: int32(pkColIdx),
-					Name:   tableDef.Pkey.PkeyColName,
+		if rowsCount > 1 {
+			// args in list must be constant
+			expr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "in", []*Expr{{
+				Typ: colTyp,
+				Expr: &plan.Expr_Col{
+					Col: &ColRef{
+						ColPos: int32(pkColIdx),
+						Name:   tableDef.Pkey.PkeyColName,
+					},
 				},
-			},
-		}, {
-			Expr: &plan.Expr_List{
-				List: &plan.ExprList{
-					List: colExprs[0],
+			}, {
+				Expr: &plan.Expr_List{
+					List: &plan.ExprList{
+						List: colExprs[0],
+					},
 				},
-			},
-			Typ: &plan.Type{
-				Id: int32(types.T_tuple),
-			},
-		}})
-		if err != nil {
-			return nil
-		}
-		expr, err = ConstantFold(batch.EmptyForConstFoldBatch, expr, proc, false)
-		if err != nil {
-			return nil
-		}
-		return []*Expr{expr}
-	} else {
-		//  __cpkey__ in (serial(a1,b1,c1,d1),serial(a2,b2,c2,d2),xxx)
-		inExprs := make([]*plan.Expr, rowsCount)
+				Typ: &plan.Type{
+					Id: int32(types.T_tuple),
+				},
+			}})
+			if err != nil {
+				return nil
+			}
+			expr, err = ConstantFold(batch.EmptyForConstFoldBatch, expr, proc, false)
+			if err != nil {
+				return nil
+			}
+			return []*Expr{expr}
+		} else {
+			var orExpr *Expr
+			for i := 0; i < rowsCount; i++ {
+				expr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{{
+					Typ: colTyp,
+					Expr: &plan.Expr_Col{
+						Col: &ColRef{
+							ColPos: int32(pkColIdx),
+							Name:   tableDef.Pkey.PkeyColName,
+						},
+					},
+				}, colExprs[0][i]})
+				if err != nil {
+					return nil
+				}
 
-		// serialize
-		for i := 0; i < rowsCount; i++ {
-			serExprs := make([]*plan.Expr, 0, len(pkPosInValues))
-			for insertRowIdx, pkColIdx := range pkPosInValues {
-				serExprs = append(serExprs, &plan.Expr{
+				if i == 0 {
+					orExpr = expr
+				} else {
+					orExpr, err = BindFuncExprImplByPlanExpr(builder.GetContext(), "or", []*Expr{orExpr, expr})
+					if err != nil {
+						return nil
+					}
+				}
+			}
+			return []*Expr{orExpr}
+		}
+	} else {
+		// multi cols pk & one row for insert
+		if rowsCount == 1 {
+			filterExprs := make([]*Expr, pkColLength)
+			for insertRowIdx, pkColIdx = range pkPosInValues {
+				expr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{{
 					Typ: tableDef.Cols[insertRowIdx].Typ,
 					Expr: &plan.Expr_Col{
 						Col: &ColRef{
@@ -404,56 +426,53 @@ func getPkValueExpr(builder *QueryBuilder, ctx CompilerContext, tableDef *TableD
 							Name:   tableDef.Cols[insertRowIdx].Name,
 						},
 					},
-				})
+				}, colExprs[pkColIdx][0]})
+				if err != nil {
+					return nil
+				}
+				filterExprs[pkColIdx] = expr
 			}
-			cpk, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*Expr{
-				{
-					Expr: &plan.Expr_List{
-						List: &plan.ExprList{
-							List: serExprs,
+			return filterExprs
+		} else {
+			// seems serial function have poor performance. we have to use or function
+			var orExpr *Expr
+			for i := 0; i < rowsCount; i++ {
+				var andExpr *Expr
+				for insertRowIdx, pkColIdx = range pkPosInValues {
+					eqExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{{
+						Typ: tableDef.Cols[insertRowIdx].Typ,
+						Expr: &plan.Expr_Col{
+							Col: &ColRef{
+								ColPos: int32(pkColIdx),
+								Name:   tableDef.Cols[insertRowIdx].Name,
+							},
 						},
-					},
-					Typ: &plan.Type{
-						Id: int32(types.T_tuple),
-					},
-				},
-			})
-			if err != nil {
-				return nil
+					}, colExprs[pkColIdx][i]})
+					if err != nil {
+						return nil
+					}
+
+					if andExpr == nil {
+						andExpr = eqExpr
+					} else {
+						andExpr, err = BindFuncExprImplByPlanExpr(builder.GetContext(), "and", []*Expr{andExpr, eqExpr})
+						if err != nil {
+							return nil
+						}
+					}
+				}
+
+				if i == 0 {
+					orExpr = andExpr
+				} else {
+					orExpr, err = BindFuncExprImplByPlanExpr(builder.GetContext(), "or", []*Expr{orExpr, andExpr})
+					if err != nil {
+						return nil
+					}
+				}
 			}
-			inExprs[i] = cpk
+			return []*Expr{orExpr}
 		}
-
-		expr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "in", []*Expr{
-			{
-				Typ: colTyp,
-				Expr: &plan.Expr_Col{
-					Col: &ColRef{
-						ColPos: int32(len(pkPosInValues)),
-						Name:   tableDef.Pkey.PkeyColName,
-					},
-				},
-			}, {
-				Expr: &plan.Expr_List{
-					List: &plan.ExprList{
-						List: inExprs,
-					},
-				},
-				Typ: &plan.Type{
-					Id: int32(types.T_tuple),
-				},
-			},
-		})
-		if err != nil {
-			return nil
-		}
-
-		expr2, err := ConstantFold(batch.EmptyForConstFoldBatch, expr, proc, false)
-		if err != nil {
-			return nil
-		}
-
-		return []*Expr{expr2}
 	}
 }
 


### PR DESCRIPTION
…(#14342)"

This reverts commit 856c480960c6125fd756159dda316f5ff25ce459.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13987

## What this PR does / why we need it:

说这个pr会导致tpcc性能降5倍, 先撤掉