### PR TITLE
clean up func getPkValueExpr

### DIFF
--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -210,14 +210,14 @@ func setTableExprToDmlTableInfo(ctx CompilerContext, tbl tree.TableExpr, tblInfo
 		tbl = aliasTbl.Expr
 	}
 
-	if jionTbl, ok := tbl.(*tree.JoinTableExpr); ok {
+	if joinTbl, ok := tbl.(*tree.JoinTableExpr); ok {
 		tblInfo.needAggFilter = true
-		err := setTableExprToDmlTableInfo(ctx, jionTbl.Left, tblInfo, aliasMap, withMap)
+		err := setTableExprToDmlTableInfo(ctx, joinTbl.Left, tblInfo, aliasMap, withMap)
 		if err != nil {
 			return err
 		}
-		if jionTbl.Right != nil {
-			return setTableExprToDmlTableInfo(ctx, jionTbl.Right, tblInfo, aliasMap, withMap)
+		if joinTbl.Right != nil {
+			return setTableExprToDmlTableInfo(ctx, joinTbl.Right, tblInfo, aliasMap, withMap)
 		}
 		return nil
 	}

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -360,20 +360,33 @@ func getPkValueExpr(builder *QueryBuilder, ctx CompilerContext, tableDef *TableD
 	}
 
 	if pkColLength == 1 {
-		if rowsCount == 1 {
-			filterExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{{
-				Typ: colTyp,
-				Expr: &plan.Expr_Col{
-					Col: &ColRef{
-						ColPos: int32(pkColIdx),
-						Name:   tableDef.Pkey.PkeyColName,
+		if rowsCount <= 3 {
+			// pk = a1 or pk = a2 or pk = a3
+			var orExpr *Expr
+			for i := 0; i < rowsCount; i++ {
+				expr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{{
+					Typ: colTyp,
+					Expr: &plan.Expr_Col{
+						Col: &ColRef{
+							ColPos: int32(pkColIdx),
+							Name:   tableDef.Pkey.PkeyColName,
+						},
 					},
-				},
-			}, colExprs[0][0]})
-			if err != nil {
-				return nil
+				}, colExprs[0][i]})
+				if err != nil {
+					return nil
+				}
+
+				if i == 0 {
+					orExpr = expr
+				} else {
+					orExpr, err = BindFuncExprImplByPlanExpr(builder.GetContext(), "or", []*Expr{orExpr, expr})
+					if err != nil {
+						return nil
+					}
+				}
 			}
-			return []*Expr{filterExpr}
+			return []*Expr{orExpr}
 		} else {
 			// pk in (a1, a2, a3)
 			// args in list must be constant
@@ -405,24 +418,43 @@ func getPkValueExpr(builder *QueryBuilder, ctx CompilerContext, tableDef *TableD
 			return []*Expr{expr}
 		}
 	} else {
-		if rowsCount == 1 {
-			filterExprs := make([]*Expr, pkColLength)
-			for insertRowIdx, pkColIdx = range pkPosInValues {
-				expr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{{
-					Typ: tableDef.Cols[insertRowIdx].Typ,
-					Expr: &plan.Expr_Col{
-						Col: &ColRef{
-							ColPos: int32(pkColIdx),
-							Name:   tableDef.Cols[insertRowIdx].Name,
+		var orExpr *Expr
+		if rowsCount <= 3 {
+			// ppk1 = a1 and ppk2 = a2 or ppk1 = b1 and ppk2 = b2 or ppk1 = c1 and ppk2 = c2
+			var andExpr *Expr
+			for i := 0; i < rowsCount; i++ {
+				for insertRowIdx, pkColIdx = range pkPosInValues {
+					eqExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{{
+						Typ: tableDef.Cols[insertRowIdx].Typ,
+						Expr: &plan.Expr_Col{
+							Col: &ColRef{
+								ColPos: int32(pkColIdx),
+								Name:   tableDef.Cols[insertRowIdx].Name,
+							},
 						},
-					},
-				}, colExprs[pkColIdx][0]})
-				if err != nil {
-					return nil
+					}, colExprs[pkColIdx][i]})
+					if err != nil {
+						return nil
+					}
+					if andExpr == nil {
+						andExpr = eqExpr
+					} else {
+						andExpr, err = BindFuncExprImplByPlanExpr(builder.GetContext(), "and", []*Expr{andExpr, eqExpr})
+						if err != nil {
+							return nil
+						}
+					}
 				}
-				filterExprs[pkColIdx] = expr
+				if i == 0 {
+					orExpr = andExpr
+				} else {
+					orExpr, err = BindFuncExprImplByPlanExpr(builder.GetContext(), "or", []*Expr{orExpr, andExpr})
+					if err != nil {
+						return nil
+					}
+				}
 			}
-			return filterExprs
+			return []*Expr{orExpr}
 		} else {
 			//  __cpkey__ in (serial(a1,b1,c1,d1),serial(a2,b2,c2,d2),xxx)
 			inExprs := make([]*plan.Expr, rowsCount)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #13987

## What this PR does / why we need it:

use IN instead of OR for cpk and fix a typo

the special case of rowCnt == 1 is retained, otherwise the performance of tpcc will be significantly reduced.