### PR TITLE
[bug] the txn status is not correct in single statment.

### DIFF
--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -574,9 +574,9 @@ When it is not in single statement transaction mode:
 	Starts a new transaction if there is none. Reuse the current transaction if there is one.
 */
 func (ses *Session) TxnCreate() (context.Context, TxnOperator, error) {
-	if ses.InMultiStmtTransactionMode() {
-		ses.SetServerStatus(SERVER_STATUS_IN_TRANS)
-	}
+	// SERVER_STATUS_IN_TRANS should be set to true regardless of whether autocommit is equal to 1.
+	ses.SetServerStatus(SERVER_STATUS_IN_TRANS)
+
 	if !ses.GetTxnHandler().IsValidTxnOperator() {
 		return ses.GetTxnHandler().NewTxn()
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/1997 https://github.com/matrixorigin/MO-Cloud/issues/2413

## What this PR does / why we need it:
MO should set txn state to true if autocommit is true when client send a SQL to server.