### PR TITLE
sync to 1.1: fix the bug of storage usage double counting

### DIFF
--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -232,7 +232,7 @@ func updateStorageUsageCache(accIds []int32, sizes []uint64) {
 			usage.Size += old.Size
 		}
 
-		cnUsageCache.Update(usage)
+		cnUsageCache.SetOrReplace(usage)
 	}
 }
 

--- a/pkg/vm/engine/tae/catalog/dbmvccnode.go
+++ b/pkg/vm/engine/tae/catalog/dbmvccnode.go
@@ -95,3 +95,8 @@ func (node *DBNode) WriteTo(w io.Writer) (n int64, err error) {
 	n += sn
 	return
 }
+
+// only used in ut test
+func (node *DBNode) TestSetAccId(id uint32) {
+	node.acInfo.TenantID = id
+}

--- a/pkg/vm/engine/tae/db/test/storage_usage_test.go
+++ b/pkg/vm/engine/tae/db/test/storage_usage_test.go
@@ -49,7 +49,7 @@ func Test_StorageUsageCache(t *testing.T) {
 	accCnt, dbCnt, tblCnt := 10, 10, 10
 	usages := logtail.MockUsageData(accCnt, dbCnt, tblCnt, &allocator)
 	for idx := range usages {
-		cache.Update(usages[idx])
+		cache.SetOrReplace(usages[idx])
 	}
 
 	fmt.Println(cache.String())
@@ -246,8 +246,8 @@ func Test_FillUsageBatOfIncremental(t *testing.T) {
 	defer iCollector.Close()
 
 	iCollector.Usage.Deletes = deletes
-	iCollector.Usage.SegDeletes = segDeletes
-	iCollector.Usage.SegInserts = segInserts
+	iCollector.Usage.ObjDeletes = segDeletes
+	iCollector.Usage.ObjInserts = segInserts
 
 	logtail.FillUsageBatOfIncremental(iCollector)
 
@@ -345,7 +345,7 @@ func Test_FillUsageBatOfGlobal(t *testing.T) {
 	defer gCollector.Close()
 
 	for idx := range usages {
-		memo.Update(usages[idx], false)
+		memo.DeltaUpdate(usages[idx], false)
 		gCollector.Usage.ReservedAccIds[usages[idx].AccId] = struct{}{}
 	}
 
@@ -454,11 +454,11 @@ func Test_EstablishFromCheckpoints(t *testing.T) {
 
 	memoShadow := logtail.NewTNUsageMemo()
 	for idx := range usageIns {
-		memoShadow.Update(usageIns[idx], false)
+		memoShadow.DeltaUpdate(usageIns[idx], false)
 	}
 
 	for idx := range usageDel {
-		memoShadow.Update(usageDel[idx], true)
+		memoShadow.DeltaUpdate(usageDel[idx], true)
 	}
 
 	require.Equal(t, memo.CacheLen(), memoShadow.CacheLen())
@@ -486,7 +486,7 @@ func Test_RemoveStaleAccounts(t *testing.T) {
 	defer gCollector.Close()
 
 	for idx := range usages {
-		gCollector.UsageMemo.Update(usages[idx], false)
+		gCollector.UsageMemo.DeltaUpdate(usages[idx], false)
 		if rand.Int()%3 == 0 {
 			// mock the accounts deletion
 			continue
@@ -571,6 +571,7 @@ func Test_UpdateDataFromOldVersion(t *testing.T) {
 				db, err := ctlog.GetDatabaseByID(usages[xx][yy].DbId)
 				if moerr.IsMoErrCode(err, moerr.OkExpectedEOB) || db == nil {
 					db, err = ctlog.CreateDBEntryWithID(usages[xx][yy].String(), "", "", usages[xx][yy].DbId, txn)
+					db.TestSetAccId(uint32(usages[xx][yy].AccId))
 				}
 
 				require.Nil(t, err)
@@ -632,7 +633,7 @@ func Test_UpdateDataFromOldVersion(t *testing.T) {
 
 			// double the size
 			obj := catalog.MockObjEntryWithTbl(tbl, usage.Size*2)
-			gCollector.Usage.SegInserts = append(gCollector.Usage.SegInserts, obj)
+			gCollector.Usage.ObjInserts = append(gCollector.Usage.ObjInserts, obj)
 		}
 
 		logtail.FillUsageBatOfGlobal(gCollector)

--- a/pkg/vm/engine/tae/logtail/storage_usage.go
+++ b/pkg/vm/engine/tae/logtail/storage_usage.go
@@ -299,6 +299,8 @@ type TNUsageMemo struct {
 		vers    []uint32
 		delayed map[uint64]UsageData
 	}
+
+	eliminated [2]types.TS
 }
 
 func NewTNUsageMemo() *TNUsageMemo {
@@ -679,9 +681,13 @@ func (m *TNUsageMemo) EstablishFromCKPs(c *catalog.Catalog) {
 				if m.pendingReplay.delayed == nil {
 					m.pendingReplay.delayed = make(map[uint64]UsageData)
 				}
-				m.pendingReplay.delayed[usage.TblId] = usage
+				if old, ok := m.pendingReplay.delayed[usage.TblId]; !ok {
+					m.pendingReplay.delayed[usage.TblId] = usage
+				} else {
+					old.Size += usage.Size
+					m.pendingReplay.delayed[usage.TblId] = old
+				}
 			}
-
 			m.DeltaUpdate(usage, false)
 		}
 
@@ -805,9 +811,6 @@ func updateStorageUsageMeta(data *CheckpointData, tid uint64, start, end int32, 
 // putCacheBack2Track correct the margin of error happened in incremental checkpoint
 func putCacheBack2Track(collector *BaseCollector) (string, int) {
 	memo := collector.UsageMemo
-	//if len(memo.pendingReplay.delayed) == 0 {
-	//	return "", 0
-	//}
 
 	var buf bytes.Buffer
 
@@ -825,9 +828,34 @@ func putCacheBack2Track(collector *BaseCollector) (string, int) {
 		tblChanges[uniqueTbl] += int64(usages[idx].Size)
 	}
 
+	delDbs := make(map[uint64]struct{})
+	delTbls := make(map[uint64]struct{})
+	for _, del := range collector.Usage.Deletes {
+		switch e := del.(type) {
+		case *catalog.DBEntry:
+			delDbs[e.ID] = struct{}{}
+		case *catalog.TableEntry:
+			delTbls[e.ID] = struct{}{}
+		}
+	}
+
+	if len(tblChanges) == 0 {
+		return "", 0
+	}
+
+	memo.GetCache().ClearForUpdate()
+
 	for uniqueTbl, size := range tblChanges {
 		if size <= 0 {
 			size = 0
+		}
+
+		if _, ok := delDbs[uniqueTbl[1]]; ok {
+			continue
+		}
+
+		if _, ok := delTbls[uniqueTbl[2]]; ok {
+			continue
 		}
 
 		memo.Replace(UsageData{
@@ -846,7 +874,8 @@ func putCacheBack2Track(collector *BaseCollector) (string, int) {
 				usage.AccId, usage.DbId, usage.TblId, usage.Size, size))
 		}
 	}
-	return buf.String(), len(tblChanges)
+
+	return buf.String(), memo.CacheLen()
 }
 
 func applyChanges(collector *BaseCollector, tnUsageMemo *TNUsageMemo) string {
@@ -1124,15 +1153,24 @@ func CorrectUsageWrongPlacement(c *catalog.Catalog) (int, float64, error) {
 	return anyTransferred, transferredSize, nil
 }
 
-func EliminateErrorsOnCache(c *catalog.Catalog) int {
-	cnt2 := 0
+func EliminateErrorsOnCache(c *catalog.Catalog, end types.TS) int {
 	collector := BaseCollector{}
 	loop := catalog.LoopProcessor{}
 	loop.ObjectFn = func(entry *catalog.ObjectEntry) error {
-		cnt2++
+		if entry.GetTable().GetDB().HasDropCommitted() || entry.GetTable().HasDropCommitted() {
+			return nil
+		}
+
 		if entry.IsAppendable() || !entry.IsCommitted() {
 			return nil
 		}
+
+		entry.Lock()
+		if entry.GetCreatedAtLocked().GreaterEq(end) {
+			entry.Unlock()
+			return nil
+		}
+		entry.Unlock()
 
 		if entry.HasDropCommitted() {
 			collector.Usage.ObjDeletes = append(collector.Usage.ObjDeletes, entry)
@@ -1146,8 +1184,10 @@ func EliminateErrorsOnCache(c *catalog.Catalog) int {
 	c.RecurLoop(&loop)
 
 	collector.UsageMemo = c.GetUsageMemo().(*TNUsageMemo)
+
+	collector.UsageMemo.EnterProcessing()
+	defer collector.UsageMemo.LeaveProcessing()
 	_, cnt := putCacheBack2Track(&collector)
 
-	fmt.Println(cnt2, len(collector.Usage.ObjInserts), cnt)
 	return cnt
 }

--- a/pkg/vm/engine/tae/logtail/storage_usage.go
+++ b/pkg/vm/engine/tae/logtail/storage_usage.go
@@ -299,8 +299,6 @@ type TNUsageMemo struct {
 		vers    []uint32
 		delayed map[uint64]UsageData
 	}
-
-	eliminated [2]types.TS
 }
 
 func NewTNUsageMemo() *TNUsageMemo {

--- a/pkg/vm/engine/tae/logtail/storage_usage.go
+++ b/pkg/vm/engine/tae/logtail/storage_usage.go
@@ -229,7 +229,7 @@ func (c *StorageUsageCache) setUpdateTime(t time.Time) {
 	c.lastUpdate = t
 }
 
-func (c *StorageUsageCache) Update(usage UsageData) {
+func (c *StorageUsageCache) SetOrReplace(usage UsageData) {
 	c.data.Set(usage)
 	c.setUpdateTime(time.Now())
 }
@@ -435,13 +435,19 @@ func (m *TNUsageMemo) updateHelper(cache *StorageUsageCache, usage UsageData, de
 		usage.Size = size + usage.Size
 	}
 
-	cache.Update(usage)
+	cache.SetOrReplace(usage)
 }
 
-// Update does setting or updating
-func (m *TNUsageMemo) Update(usage UsageData, del bool) {
+// DeltaUpdate does setting or updating with delta size (delta.Size)
+func (m *TNUsageMemo) DeltaUpdate(delta UsageData, del bool) {
 	m.pending = true
-	m.updateHelper(m.cache, usage, del)
+	m.updateHelper(m.cache, delta, del)
+}
+
+// Replace replaces the old usage with newUsage
+func (m *TNUsageMemo) Replace(new UsageData) {
+	m.pending = true
+	m.cache.SetOrReplace(new)
 }
 
 func (m *TNUsageMemo) Delete(usage UsageData) {
@@ -517,7 +523,7 @@ func (m *TNUsageMemo) applyDeletes(
 func (m *TNUsageMemo) applySegInserts(inserts []UsageData, ckpData *CheckpointData, mp *mpool.MPool) {
 	for _, usage := range inserts {
 		appendToStorageUsageBat(ckpData, usage, false, mp)
-		m.Update(usage, false)
+		m.DeltaUpdate(usage, false)
 	}
 }
 
@@ -526,7 +532,7 @@ func (m *TNUsageMemo) applySegDeletes(deletes []UsageData, ckpData *CheckpointDa
 		// can not delete a non-exist usage, right?
 		if _, exist := m.cache.Get(usage); exist {
 			appendToStorageUsageBat(ckpData, usage, true, mp)
-			m.Update(usage, true)
+			m.DeltaUpdate(usage, true)
 		}
 	}
 }
@@ -676,7 +682,7 @@ func (m *TNUsageMemo) EstablishFromCKPs(c *catalog.Catalog) {
 				m.pendingReplay.delayed[usage.TblId] = usage
 			}
 
-			m.Update(usage, false)
+			m.DeltaUpdate(usage, false)
 		}
 
 		if m.pendingReplay.vers[x] < CheckpointVersion11 {
@@ -689,7 +695,7 @@ func (m *TNUsageMemo) EstablishFromCKPs(c *catalog.Catalog) {
 
 		for y := 0; y < len(accCol); y++ {
 			usage := UsageData{accCol[y], dbCol[y], tblCol[y], sizeCol[y]}
-			m.Update(usage, true)
+			m.DeltaUpdate(usage, true)
 		}
 	}
 
@@ -796,41 +802,51 @@ func updateStorageUsageMeta(data *CheckpointData, tid uint64, start, end int32, 
 	}
 }
 
-func tryUpdateDataFromOldVersion(collector *GlobalCollector) string {
+// putCacheBack2Track correct the margin of error happened in incremental checkpoint
+func putCacheBack2Track(collector *BaseCollector) (string, int) {
 	memo := collector.UsageMemo
-	if len(memo.pendingReplay.delayed) == 0 {
-		return ""
-	}
+	//if len(memo.pendingReplay.delayed) == 0 {
+	//	return "", 0
+	//}
 
 	var buf bytes.Buffer
 
-	tblChanges := make(map[uint64]int64)
+	tblChanges := make(map[[3]uint64]int64)
 
-	usages := objects2Usages(collector.Usage.SegDeletes)
+	usages := objects2Usages(collector.Usage.ObjDeletes)
 	for idx := range usages {
-		tblChanges[usages[idx].TblId] -= int64(usages[idx].Size)
+		uniqueTbl := [3]uint64{usages[idx].AccId, usages[idx].DbId, usages[idx].TblId}
+		tblChanges[uniqueTbl] -= int64(usages[idx].Size)
 	}
 
-	usages = objects2Usages(collector.Usage.SegInserts)
+	usages = objects2Usages(collector.Usage.ObjInserts)
 	for idx := range usages {
-		tblChanges[usages[idx].TblId] += int64(usages[idx].Size)
+		uniqueTbl := [3]uint64{usages[idx].AccId, usages[idx].DbId, usages[idx].TblId}
+		tblChanges[uniqueTbl] += int64(usages[idx].Size)
 	}
 
-	for id, size := range tblChanges {
+	for uniqueTbl, size := range tblChanges {
 		if size <= 0 {
 			size = 0
 		}
-		if usage, ok := memo.pendingReplay.delayed[id]; ok {
-			memo.Update(usage, true)
-			usage.Size = uint64(size)
-			memo.Update(usage, false)
-			delete(memo.pendingReplay.delayed, id)
 
-			buf.WriteString(fmt.Sprintf("[u-tbl]%d_%d_%d_%d; ",
-				usage.AccId, usage.DbId, usage.TblId, usage.Size))
+		memo.Replace(UsageData{
+			Size:  uint64(size),
+			TblId: uniqueTbl[2],
+			DbId:  uniqueTbl[1],
+			AccId: uniqueTbl[0],
+		})
+
+		if len(memo.pendingReplay.delayed) == 0 {
+			continue
+		}
+
+		if usage, ok := memo.pendingReplay.delayed[uniqueTbl[2]]; ok {
+			buf.WriteString(fmt.Sprintf("[u-tbl]%d_%d_%d_(o)%d_(n)%d; ",
+				usage.AccId, usage.DbId, usage.TblId, usage.Size, size))
 		}
 	}
-	return buf.String()
+	return buf.String(), len(tblChanges)
 }
 
 func applyChanges(collector *BaseCollector, tnUsageMemo *TNUsageMemo) string {
@@ -838,14 +854,14 @@ func applyChanges(collector *BaseCollector, tnUsageMemo *TNUsageMemo) string {
 
 	// must apply seg insert first
 	// step 1: apply seg insert (non-appendable, committed)
-	usage := objects2Usages(collector.Usage.SegInserts)
+	usage := objects2Usages(collector.Usage.ObjInserts)
 	tnUsageMemo.applySegInserts(usage, collector.data, collector.Allocator())
 
 	// step 2: apply db, tbl deletes
 	log := tnUsageMemo.applyDeletes(collector.Usage.Deletes, collector.data, collector.Allocator())
 
 	// step 3: apply seg deletes
-	usage = objects2Usages(collector.Usage.SegDeletes)
+	usage = objects2Usages(collector.Usage.ObjDeletes)
 	tnUsageMemo.applySegDeletes(usage, collector.data, collector.Allocator())
 
 	return log
@@ -860,12 +876,13 @@ func FillUsageBatOfGlobal(collector *GlobalCollector) {
 		v2.TaskGCkpCollectUsageDurationHistogram.Observe(time.Since(start).Seconds())
 	}()
 
-	log1 := tryUpdateDataFromOldVersion(collector)
+	log1, cnt := putCacheBack2Track(collector.BaseCollector)
 	log2 := collector.UsageMemo.ClearDroppedAccounts(collector.Usage.ReservedAccIds)
 	collector.UsageMemo.replayIntoGCKP(collector)
 
 	logutil.Info("[storage usage] CKP[G]",
 		zap.String("update old data", log1),
+		zap.Int("tables back to track", cnt),
 		zap.String("accounts cleaned", log2))
 }
 
@@ -1087,13 +1104,13 @@ func CorrectUsageWrongPlacement(c *catalog.Catalog) (int, float64, error) {
 			anyTransferred++
 			transferredSize += float64(usages[idx].Size)
 
-			memo.Update(usages[idx], true)
+			memo.DeltaUpdate(usages[idx], true)
 			buf.WriteString(fmt.Sprintf("[td-tbl]%d_%d_%d_%d; ",
 				usages[idx].AccId, usages[idx].DbId, usages[idx].TblId, usages[idx].Size))
 			//memo.pendingTransfer.deletes = append(memo.pendingTransfer.deletes, usages[idx])
 
 			usages[idx].AccId = pairs[usages[idx].DbId]
-			memo.Update(usages[idx], false)
+			memo.DeltaUpdate(usages[idx], false)
 			buf.WriteString(fmt.Sprintf("[ti-tbl]%d_%d_%d_%d; ",
 				usages[idx].AccId, usages[idx].DbId, usages[idx].TblId, usages[idx].Size))
 			//memo.pendingTransfer.inserts = append(memo.pendingTransfer.inserts, usages[idx])
@@ -1105,4 +1122,32 @@ func CorrectUsageWrongPlacement(c *catalog.Catalog) (int, float64, error) {
 		zap.String(fmt.Sprintf("transferred %d tbl, %f mb", anyTransferred, transferredSize), buf.String()))
 
 	return anyTransferred, transferredSize, nil
+}
+
+func EliminateErrorsOnCache(c *catalog.Catalog) int {
+	cnt2 := 0
+	collector := BaseCollector{}
+	loop := catalog.LoopProcessor{}
+	loop.ObjectFn = func(entry *catalog.ObjectEntry) error {
+		cnt2++
+		if entry.IsAppendable() || !entry.IsCommitted() {
+			return nil
+		}
+
+		if entry.HasDropCommitted() {
+			collector.Usage.ObjDeletes = append(collector.Usage.ObjDeletes, entry)
+		} else {
+			collector.Usage.ObjInserts = append(collector.Usage.ObjInserts, entry)
+		}
+
+		return nil
+	}
+
+	c.RecurLoop(&loop)
+
+	collector.UsageMemo = c.GetUsageMemo().(*TNUsageMemo)
+	_, cnt := putCacheBack2Track(&collector)
+
+	fmt.Println(cnt2, len(collector.Usage.ObjInserts), cnt)
+	return cnt
 }

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -785,8 +785,8 @@ type BaseCollector struct {
 	Usage struct {
 		// db, tbl deletes
 		Deletes        []interface{}
-		SegInserts     []*catalog.ObjectEntry
-		SegDeletes     []*catalog.ObjectEntry
+		ObjInserts     []*catalog.ObjectEntry
+		ObjDeletes     []*catalog.ObjectEntry
 		ReservedAccIds map[uint64]struct{}
 	}
 
@@ -3041,12 +3041,12 @@ func (collector *BaseCollector) fillObjectInfoBatch(entry *catalog.ObjectEntry, 
 		if objNode.HasDropCommitted() {
 			// deleted and non-append, record into the usage del bat
 			if !entry.IsAppendable() && objNode.IsCommitted() {
-				collector.Usage.SegDeletes = append(collector.Usage.SegDeletes, entry)
+				collector.Usage.ObjDeletes = append(collector.Usage.ObjDeletes, entry)
 			}
 		} else {
 			// create and non-append, record into the usage ins bat
 			if !entry.IsAppendable() && objNode.IsCommitted() {
-				collector.Usage.SegInserts = append(collector.Usage.SegInserts, entry)
+				collector.Usage.ObjInserts = append(collector.Usage.ObjInserts, entry)
 			}
 		}
 
@@ -3073,7 +3073,7 @@ func (collector *BaseCollector) VisitObj(entry *catalog.ObjectEntry) (err error)
 
 func (collector *GlobalCollector) VisitObj(entry *catalog.ObjectEntry) error {
 	if collector.isEntryDeletedBeforeThreshold(entry.BaseEntryImpl) {
-		collector.Usage.SegDeletes = append(collector.Usage.SegDeletes, entry)
+		collector.Usage.ObjDeletes = append(collector.Usage.ObjDeletes, entry)
 		return nil
 	}
 	if collector.isEntryDeletedBeforeThreshold(entry.GetTable().BaseEntryImpl) {

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -2787,6 +2787,7 @@ func (collector *GlobalCollector) isEntryDeletedBeforeThreshold(entry catalog.Ba
 }
 func (collector *GlobalCollector) VisitDB(entry *catalog.DBEntry) error {
 	if collector.isEntryDeletedBeforeThreshold(entry.BaseEntryImpl) {
+		collector.Usage.Deletes = append(collector.Usage.Deletes, entry)
 		return nil
 	}
 
@@ -2908,6 +2909,7 @@ func (collector *BaseCollector) VisitTable(entry *catalog.TableEntry) (err error
 
 func (collector *GlobalCollector) VisitTable(entry *catalog.TableEntry) error {
 	if collector.isEntryDeletedBeforeThreshold(entry.BaseEntryImpl) {
+		collector.Usage.Deletes = append(collector.Usage.Deletes, entry)
 		return nil
 	}
 	if collector.isEntryDeletedBeforeThreshold(entry.GetDB().BaseEntryImpl) {

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -1127,8 +1127,12 @@ func storageUsageTransfer(c *storageUsageHistoryArg) (err error) {
 }
 
 func storageUsageEliminateErrors(c *storageUsageHistoryArg) (err error) {
-	cnt := logtail.EliminateErrorsOnCache(c.ctx.db.Catalog)
-
+	entries := c.ctx.db.BGCheckpointRunner.GetAllCheckpoints()
+	if len(entries) == 0 {
+		return moerr.NewNotSupportedNoCtx("please execute this cmd after at least one checkpoint has been generated")
+	}
+	end := entries[len(entries)-1].GetEnd()
+	cnt := logtail.EliminateErrorsOnCache(c.ctx.db.Catalog, end)
 	c.ctx.out.Write([]byte(fmt.Sprintf("%d tables backed to the track. ", cnt)))
 
 	return nil

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -204,7 +204,8 @@ type storageUsageHistoryArg struct {
 		accounts     map[uint64]struct{}
 	}
 
-	transfer bool
+	transfer        bool
+	eliminateErrors bool
 }
 
 func (c *storageUsageHistoryArg) FromCommand(cmd *cobra.Command) (err error) {
@@ -245,6 +246,15 @@ func (c *storageUsageHistoryArg) FromCommand(cmd *cobra.Command) (err error) {
 		}
 	}
 
+	expr, _ = cmd.Flags().GetString("eliminate_errors")
+	if expr != "" {
+		if expr == "*" {
+			c.eliminateErrors = true
+		} else {
+			return moerr.NewInvalidArgNoCtx(expr, "`storage_usage -e *` expected")
+		}
+	}
+
 	return nil
 }
 
@@ -254,7 +264,9 @@ func (c *storageUsageHistoryArg) Run() (err error) {
 	} else if c.trace != nil {
 		return storageTrace(c)
 	} else if c.transfer {
-		return storageTransfer(c)
+		return storageUsageTransfer(c)
+	} else if c.eliminateErrors {
+		return storageUsageEliminateErrors(c)
 	}
 	return moerr.NewInvalidArgNoCtx("", c.ctx.args)
 }
@@ -653,6 +665,7 @@ func initCommand(ctx context.Context, inspectCtx *inspectContext) *cobra.Command
 	// storage usage details in ckp
 	storageUsageCmd.Flags().StringP("detail", "d", "", "format: accId{.dbName{.tableName}}")
 	storageUsageCmd.Flags().StringP("transfer", "f", "", "format: *")
+	storageUsageCmd.Flags().StringP("eliminate_errors", "e", "", "format: *")
 	rootCmd.AddCommand(storageUsageCmd)
 
 	return rootCmd
@@ -1103,7 +1116,7 @@ func storageTrace(c *storageUsageHistoryArg) (err error) {
 	return nil
 }
 
-func storageTransfer(c *storageUsageHistoryArg) (err error) {
+func storageUsageTransfer(c *storageUsageHistoryArg) (err error) {
 	cnt, size, err := logtail.CorrectUsageWrongPlacement(c.ctx.db.Catalog)
 	if err != nil {
 		return err
@@ -1111,4 +1124,12 @@ func storageTransfer(c *storageUsageHistoryArg) (err error) {
 
 	c.ctx.out.Write([]byte(fmt.Sprintf("transferred %d tbl, %f mb; ", cnt, size)))
 	return
+}
+
+func storageUsageEliminateErrors(c *storageUsageHistoryArg) (err error) {
+	cnt := logtail.EliminateErrorsOnCache(c.ctx.db.Catalog)
+
+	c.ctx.out.Write([]byte(fmt.Sprintf("%d tables backed to the track. ", cnt)))
+
+	return nil
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2439

## What this PR does / why we need it:

in the old version, the sizes of a single table were stored in several vector rows, but in the new implementation, all table sizes accumulated in one row.

the new decode code ignores this difference causing some storage usage data to be counted twice.