### PR TITLE
sync to 1.1: compatible backwards, the old storage usage reqeust method

### DIFF
--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -21,9 +21,6 @@ import (
 	"strings"
 	"time"
 
-	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
-
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"

--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -30,12 +30,16 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/ctl"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -132,7 +136,7 @@ func getSqlForTableStats(accountId int32) string {
 	return fmt.Sprintf(getTableStatsFormatV2, catalog.SystemPartitionRel, accountId)
 }
 
-func requestStorageUsage(ses *Session, accIds [][]int32) (resp any, err error) {
+func requestStorageUsage(ses *Session, accIds [][]int32) (resp any, tried bool, err error) {
 	whichTN := func(string) ([]uint64, error) { return nil, nil }
 	payload := func(tnShardID uint64, parameter string, proc *process.Process) ([]byte, error) {
 		req := db.StorageUsageReq{}
@@ -154,7 +158,7 @@ func requestStorageUsage(ses *Session, accIds [][]int32) (resp any, err error) {
 	var ctx context.Context
 	var txnOperator client.TxnOperator
 	if ctx, txnOperator, err = ses.txnHandler.GetTxn(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// create a new proc for `handler`
@@ -168,12 +172,77 @@ func requestStorageUsage(ses *Session, accIds [][]int32) (resp any, err error) {
 	handler := ctl.GetTNHandlerFunc(api.OpCode_OpStorageUsage, whichTN, payload, responseUnmarshaler)
 	result, err := handler(proc, "DN", "", ctl.MoCtlTNCmdSender)
 	if moerr.IsMoErrCode(err, moerr.ErrNotSupported) {
-		return nil, moerr.NewNotSupportedNoCtx("current tn version not supported `show accounts`")
-	} else if err != nil {
-		return nil, err
+		// try the previous RPC method
+		payload_V0 := func(tnShardID uint64, parameter string, proc *process.Process) ([]byte, error) { return nil, nil }
+		responseUnmarshaler_V0 := func(payload []byte) (interface{}, error) {
+			usage := &db.StorageUsageResp_V0{}
+			if err := usage.Unmarshal(payload); err != nil {
+				return nil, err
+			}
+			return usage, nil
+		}
+
+		tried = true
+		CmdMethod_StorageUsage := api.OpCode(14)
+		handler = ctl.GetTNHandlerFunc(CmdMethod_StorageUsage, whichTN, payload_V0, responseUnmarshaler_V0)
+		result, err = handler(proc, "DN", "", ctl.MoCtlTNCmdSender)
+
+		if moerr.IsMoErrCode(err, moerr.ErrNotSupported) {
+			return nil, tried, moerr.NewNotSupportedNoCtx("current tn version not supported `show accounts`")
+		}
 	}
 
-	return result.Data.([]any)[0], nil
+	if err != nil {
+		return nil, tried, err
+	}
+
+	return result.Data.([]any)[0], tried, nil
+}
+
+func handleStorageUsageResponse_V0(ctx context.Context, fs fileservice.FileService,
+	usage *db.StorageUsageResp_V0) (map[int32]uint64, error) {
+	result := make(map[int32]uint64, 0)
+	for idx := range usage.CkpEntries {
+		version := usage.CkpEntries[idx].Version
+		location := usage.CkpEntries[idx].Location
+
+		// storage usage was introduced after `CheckpointVersion9`
+		if version < logtail.CheckpointVersion9 {
+			// exist old version checkpoint which hasn't storage usage data in it,
+			// to avoid inaccurate info leading misunderstand, we chose to return empty result
+			logutil.Info("[storage usage]: found older ckp when handle storage usage response")
+			return map[int32]uint64{}, nil
+		}
+
+		ckpData, err := logtail.LoadSpecifiedCkpBatch(ctx, location, version, logtail.StorageUsageInsIDX, fs)
+		if err != nil {
+			return nil, err
+		}
+
+		storageUsageBat := ckpData.GetBatches()[logtail.StorageUsageInsIDX]
+		accIDVec := vector.MustFixedCol[uint64](
+			storageUsageBat.GetVectorByName(catalog.SystemColAttr_AccID).GetDownstreamVector(),
+		)
+		sizeVec := vector.MustFixedCol[uint64](
+			storageUsageBat.GetVectorByName(logtail.CheckpointMetaAttr_ObjectSize).GetDownstreamVector(),
+		)
+
+		size := uint64(0)
+		length := len(accIDVec)
+		for i := 0; i < length; i++ {
+			result[int32(accIDVec[i])] += sizeVec[i]
+			size += sizeVec[i]
+		}
+
+		ckpData.Close()
+	}
+
+	// [account_id, db_id, table_id, obj_id, table_total_size]
+	for _, info := range usage.BlockEntries {
+		result[int32(info.Info[0])] += info.Info[3]
+	}
+
+	return result, nil
 }
 
 func handleStorageUsageResponse(
@@ -249,20 +318,36 @@ func getAccountsStorageUsage(ctx context.Context, ses *Session, accIds [][]int32
 	}
 
 	// step 2: query to tn
-	response, err := requestStorageUsage(ses, accIds)
+	response, tried, err := requestStorageUsage(ses, accIds)
 	if err != nil {
 		return nil, err
 	}
 
-	usage, ok := response.(*db.StorageUsageResp)
-	if !ok || usage.Magic != logtail.StorageUsageMagic {
-		return nil, moerr.NewNotSupportedNoCtx("cn version newer than tn, retry later")
+	if tried {
+		usage, ok := response.(*db.StorageUsageResp_V0)
+		if !ok {
+			return nil, moerr.NewInternalErrorNoCtx("storage usage response decode failed, retry later")
+		}
+
+		fs, err := fileservice.Get[fileservice.FileService](ses.GetParameterUnit().FileService, defines.SharedFileServiceName)
+		if err != nil {
+			return nil, err
+		}
+
+		// step 3: handling these pulled data
+		return handleStorageUsageResponse_V0(ctx, fs, usage)
+
+	} else {
+		usage, ok := response.(*db.StorageUsageResp)
+		if !ok || usage.Magic != logtail.StorageUsageMagic {
+			return nil, moerr.NewInternalErrorNoCtx("storage usage response decode failed, retry later")
+		}
+
+		updateStorageUsageCache(usage.AccIds, usage.Sizes)
+
+		// step 3: handling these pulled data
+		return handleStorageUsageResponse(ctx, usage)
 	}
-
-	updateStorageUsageCache(usage.AccIds, usage.Sizes)
-
-	// step 3: handling these pulled data
-	return handleStorageUsageResponse(ctx, usage)
 }
 
 func embeddingSizeToBatch(ori *batch.Batch, size uint64, mp *mpool.MPool) {

--- a/pkg/vm/engine/tae/db/operations.go
+++ b/pkg/vm/engine/tae/db/operations.go
@@ -315,6 +315,37 @@ func (s *StorageUsageReq) UnmarshalBinary(data []byte) error {
 	return s.Unmarshal(data)
 }
 
+type BlockMetaInfo struct {
+	Info []uint64
+}
+
+func (b *BlockMetaInfo) MarshalBinary() ([]byte, error) {
+	return b.Marshal()
+}
+
+func (b *BlockMetaInfo) UnmarshalBinary(data []byte) error {
+	return b.Unmarshal(data)
+}
+
+type CkpMetaInfo struct {
+	Version  uint32
+	Location []byte
+}
+
+func (c *CkpMetaInfo) MarshalBinary() ([]byte, error) {
+	return c.Marshal()
+}
+
+func (c *CkpMetaInfo) UnmarshalBinary(data []byte) error {
+	return c.Unmarshal(data)
+}
+
+type StorageUsageResp_V0 struct {
+	Succeed      bool
+	CkpEntries   []*CkpMetaInfo
+	BlockEntries []*BlockMetaInfo
+}
+
 type StorageUsageResp struct {
 	Succeed bool
 	AccIds  []int32

--- a/pkg/vm/engine/tae/db/operations.pb.go
+++ b/pkg/vm/engine/tae/db/operations.pb.go
@@ -505,11 +505,152 @@ func (m *TraceSpan) GetThreshold() int64 {
 	return 0
 }
 
+func (m *BlockMetaInfo) Reset()         { *m = BlockMetaInfo{} }
+func (m *BlockMetaInfo) String() string { return proto.CompactTextString(m) }
+func (*BlockMetaInfo) ProtoMessage()    {}
+func (*BlockMetaInfo) Descriptor() ([]byte, []int) {
+	return fileDescriptor_1b4a5877375e491e, []int{9}
+}
+func (m *BlockMetaInfo) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *BlockMetaInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_BlockMetaInfo.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *BlockMetaInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BlockMetaInfo.Merge(m, src)
+}
+func (m *BlockMetaInfo) XXX_Size() int {
+	return m.ProtoSize()
+}
+func (m *BlockMetaInfo) XXX_DiscardUnknown() {
+	xxx_messageInfo_BlockMetaInfo.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BlockMetaInfo proto.InternalMessageInfo
+
+func (m *BlockMetaInfo) GetInfo() []uint64 {
+	if m != nil {
+		return m.Info
+	}
+	return nil
+}
+
+func (m *CkpMetaInfo) Reset()         { *m = CkpMetaInfo{} }
+func (m *CkpMetaInfo) String() string { return proto.CompactTextString(m) }
+func (*CkpMetaInfo) ProtoMessage()    {}
+func (*CkpMetaInfo) Descriptor() ([]byte, []int) {
+	return fileDescriptor_1b4a5877375e491e, []int{10}
+}
+func (m *CkpMetaInfo) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *CkpMetaInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_CkpMetaInfo.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *CkpMetaInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CkpMetaInfo.Merge(m, src)
+}
+func (m *CkpMetaInfo) XXX_Size() int {
+	return m.ProtoSize()
+}
+func (m *CkpMetaInfo) XXX_DiscardUnknown() {
+	xxx_messageInfo_CkpMetaInfo.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CkpMetaInfo proto.InternalMessageInfo
+
+func (m *CkpMetaInfo) GetVersion() uint32 {
+	if m != nil {
+		return m.Version
+	}
+	return 0
+}
+
+func (m *CkpMetaInfo) GetLocation() []byte {
+	if m != nil {
+		return m.Location
+	}
+	return nil
+}
+
+func (m *StorageUsageResp_V0) Reset()         { *m = StorageUsageResp_V0{} }
+func (m *StorageUsageResp_V0) String() string { return proto.CompactTextString(m) }
+func (*StorageUsageResp_V0) ProtoMessage()    {}
+func (*StorageUsageResp_V0) Descriptor() ([]byte, []int) {
+	return fileDescriptor_1b4a5877375e491e, []int{11}
+}
+func (m *StorageUsageResp_V0) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *StorageUsageResp_V0) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_StorageUsageResp_V0.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *StorageUsageResp_V0) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageUsageResp_V0.Merge(m, src)
+}
+func (m *StorageUsageResp_V0) XXX_Size() int {
+	return m.ProtoSize()
+}
+func (m *StorageUsageResp_V0) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorageUsageResp_V0.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StorageUsageResp_V0 proto.InternalMessageInfo
+
+func (m *StorageUsageResp_V0) GetSucceed() bool {
+	if m != nil {
+		return m.Succeed
+	}
+	return false
+}
+
+func (m *StorageUsageResp_V0) GetCkpEntries() []*CkpMetaInfo {
+	if m != nil {
+		return m.CkpEntries
+	}
+	return nil
+}
+
+func (m *StorageUsageResp_V0) GetBlockEntries() []*BlockMetaInfo {
+	if m != nil {
+		return m.BlockEntries
+	}
+	return nil
+}
+
 func (m *StorageUsageReq) Reset()         { *m = StorageUsageReq{} }
 func (m *StorageUsageReq) String() string { return proto.CompactTextString(m) }
 func (*StorageUsageReq) ProtoMessage()    {}
 func (*StorageUsageReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1b4a5877375e491e, []int{9}
+	return fileDescriptor_1b4a5877375e491e, []int{12}
 }
 func (m *StorageUsageReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -549,7 +690,7 @@ func (m *StorageUsageResp) Reset()         { *m = StorageUsageResp{} }
 func (m *StorageUsageResp) String() string { return proto.CompactTextString(m) }
 func (*StorageUsageResp) ProtoMessage()    {}
 func (*StorageUsageResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1b4a5877375e491e, []int{10}
+	return fileDescriptor_1b4a5877375e491e, []int{13}
 }
 func (m *StorageUsageResp) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -616,6 +757,9 @@ func init() {
 	proto.RegisterType((*CatalogResp)(nil), "db.CatalogResp")
 	proto.RegisterType((*FaultPoint)(nil), "db.FaultPoint")
 	proto.RegisterType((*TraceSpan)(nil), "db.TraceSpan")
+	proto.RegisterType((*BlockMetaInfo)(nil), "db.BlockMetaInfo")
+	proto.RegisterType((*CkpMetaInfo)(nil), "db.CkpMetaInfo")
+	proto.RegisterType((*StorageUsageResp_V0)(nil), "db.StorageUsageResp_V0")
 	proto.RegisterType((*StorageUsageReq)(nil), "db.StorageUsageReq")
 	proto.RegisterType((*StorageUsageResp)(nil), "db.StorageUsageResp")
 }
@@ -623,48 +767,54 @@ func init() {
 func init() { proto.RegisterFile("operations.proto", fileDescriptor_1b4a5877375e491e) }
 
 var fileDescriptor_1b4a5877375e491e = []byte{
-	// 643 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x54, 0x4d, 0x4f, 0xdb, 0x4c,
-	0x10, 0x8e, 0x63, 0x07, 0xde, 0x4c, 0x5e, 0x5e, 0x60, 0xf5, 0xaa, 0x72, 0x2b, 0xe4, 0xa4, 0x9c,
-	0x72, 0x69, 0x90, 0x68, 0xa5, 0x4a, 0xbd, 0x11, 0x22, 0x24, 0xb7, 0x82, 0xa2, 0x75, 0x50, 0xaf,
-	0x5d, 0x6f, 0x16, 0xc7, 0xaa, 0xe3, 0x35, 0xde, 0x75, 0x25, 0x38, 0xf6, 0x17, 0xf4, 0x27, 0x94,
-	0x7f, 0xc3, 0x91, 0x63, 0x4f, 0xa8, 0x25, 0x7f, 0xa0, 0x67, 0x4e, 0xd5, 0x7e, 0x58, 0x31, 0x57,
-	0x6e, 0xf3, 0x3c, 0x93, 0x99, 0xe7, 0xd9, 0x99, 0x89, 0x61, 0x8b, 0x17, 0xac, 0x24, 0x32, 0xe5,
-	0xb9, 0x18, 0x15, 0x25, 0x97, 0x1c, 0xb5, 0x67, 0xf1, 0x8b, 0x57, 0x49, 0x2a, 0xe7, 0x55, 0x3c,
-	0xa2, 0x7c, 0xb1, 0x97, 0xf0, 0x84, 0xef, 0xe9, 0x54, 0x5c, 0x9d, 0x6b, 0xa4, 0x81, 0x8e, 0x4c,
-	0xc9, 0xee, 0x67, 0x80, 0x03, 0x4a, 0x99, 0x10, 0x61, 0x7e, 0xce, 0xd1, 0x0e, 0x74, 0x0f, 0x28,
-	0xe5, 0x55, 0x2e, 0xc3, 0x89, 0xef, 0x0c, 0x9c, 0xe1, 0x06, 0x5e, 0x11, 0xe8, 0x19, 0xac, 0x9d,
-	0x09, 0x56, 0x86, 0x13, 0xbf, 0xad, 0x53, 0x16, 0x29, 0x1e, 0xf3, 0x8c, 0x85, 0x13, 0xdf, 0x35,
-	0xbc, 0x41, 0xef, 0xbc, 0x3f, 0xd7, 0xfd, 0xd6, 0xee, 0xb5, 0x03, 0xdb, 0x87, 0x25, 0x23, 0x92,
-	0x4d, 0x88, 0x24, 0x31, 0x11, 0x0c, 0xb3, 0x0b, 0xf4, 0xa6, 0xa9, 0xab, 0xa5, 0x7a, 0xfb, 0xff,
-	0x8d, 0x66, 0xf1, 0x68, 0xc5, 0x8e, 0xbd, 0x9b, 0xbb, 0x7e, 0x0b, 0x37, 0xfd, 0x21, 0xf0, 0x72,
-	0xb2, 0x60, 0x5a, 0xbf, 0x8b, 0x75, 0xac, 0x3c, 0x9b, 0xf6, 0xd1, 0x45, 0xa6, 0x0d, 0x74, 0xf1,
-	0x8a, 0x40, 0x01, 0x40, 0x2d, 0x1b, 0xce, 0x7c, 0x6f, 0xe0, 0x0c, 0x3d, 0xdc, 0x60, 0xac, 0xc7,
-	0x6f, 0x0e, 0xc0, 0x51, 0x56, 0x89, 0xf9, 0x94, 0xc4, 0x19, 0x7b, 0xa2, 0xb9, 0xa6, 0x94, 0x19,
-	0x51, 0x53, 0x6a, 0x82, 0x7c, 0x58, 0xd7, 0xed, 0xed, 0x9c, 0x3c, 0x5c, 0x43, 0x6b, 0xe2, 0x03,
-	0xc0, 0xe1, 0x9c, 0xd1, 0x2f, 0x05, 0x4f, 0x73, 0x89, 0xde, 0xc2, 0x86, 0x76, 0x34, 0xa9, 0xcc,
-	0x8e, 0xb5, 0x0d, 0x77, 0xbc, 0xfd, 0x70, 0xd7, 0xdf, 0x90, 0xe9, 0x82, 0x8d, 0xea, 0x04, 0x7e,
-	0xfc, 0x3b, 0xdb, 0x8c, 0x41, 0x37, 0xcc, 0x45, 0xc1, 0xa8, 0x9c, 0x9e, 0x3c, 0xf1, 0x3d, 0x3b,
-	0xd0, 0xfd, 0x58, 0x5f, 0x98, 0x9d, 0xf8, 0x8a, 0xb0, 0x32, 0x31, 0xf4, 0xac, 0x0c, 0x66, 0xa2,
-	0x40, 0xcf, 0xc1, 0x9d, 0x5e, 0x16, 0x5a, 0xa1, 0x33, 0x5e, 0x7f, 0xb8, 0xeb, 0xbb, 0x69, 0x2e,
-	0xb1, 0xe2, 0xd4, 0xeb, 0x8f, 0x99, 0x10, 0x24, 0xa9, 0xb7, 0x57, 0x43, 0x95, 0x39, 0x25, 0x97,
-	0x19, 0x27, 0x33, 0x3d, 0x97, 0x7f, 0x71, 0x0d, 0xad, 0xc6, 0x7b, 0xe8, 0x1d, 0x12, 0x49, 0x32,
-	0x9e, 0x68, 0x0d, 0x04, 0x5e, 0x28, 0xd9, 0x42, 0x8b, 0x74, 0xb1, 0x8e, 0xd1, 0x4b, 0x70, 0xa3,
-	0x2a, 0xf6, 0xdb, 0x03, 0x77, 0xd8, 0xdb, 0xdf, 0x54, 0x2f, 0x6b, 0x54, 0x60, 0x95, 0xb3, 0xbd,
-	0xae, 0x00, 0x8e, 0x48, 0x95, 0xc9, 0x53, 0x3d, 0x63, 0x04, 0xde, 0x89, 0x3a, 0x27, 0xdb, 0x4a,
-	0xc5, 0x8a, 0x3b, 0x2a, 0xd9, 0x45, 0x7d, 0x62, 0x2a, 0x56, 0x07, 0x7e, 0x40, 0xf5, 0x18, 0xcc,
-	0x7d, 0x59, 0xa4, 0xad, 0x90, 0x32, 0xd1, 0x67, 0xe5, 0x62, 0x1d, 0x2b, 0x2e, 0x52, 0x5c, 0xc7,
-	0xd4, 0xab, 0xd8, 0x6a, 0x7f, 0x82, 0xee, 0xb4, 0x24, 0x94, 0x45, 0x05, 0xc9, 0xd1, 0x16, 0xb8,
-	0x74, 0x31, 0xb3, 0xca, 0x2a, 0x44, 0xff, 0x43, 0x47, 0x14, 0x24, 0x17, 0x56, 0xd9, 0x00, 0xb5,
-	0x04, 0x39, 0x2f, 0x99, 0x98, 0xf3, 0xcc, 0x8c, 0xc7, 0xc5, 0x2b, 0xc2, 0x36, 0xde, 0x83, 0xcd,
-	0x48, 0xf2, 0x92, 0x24, 0xec, 0x4c, 0x0d, 0x14, 0xd7, 0x8e, 0x69, 0x38, 0x13, 0xbe, 0x33, 0x70,
-	0x87, 0x1d, 0x6c, 0x91, 0x2d, 0xf8, 0x0a, 0x5b, 0x8f, 0x0b, 0x84, 0xde, 0x4f, 0x54, 0x51, 0xca,
-	0x98, 0x31, 0xf5, 0x0f, 0xae, 0x61, 0xa3, 0x57, 0xbb, 0xd9, 0x4b, 0x19, 0x8e, 0xd2, 0x2b, 0x26,
-	0x7c, 0x77, 0xe0, 0x0e, 0x3d, 0x6c, 0x80, 0x62, 0x8f, 0x49, 0x92, 0x52, 0xfb, 0x5f, 0x33, 0xc0,
-	0xe8, 0x8e, 0x07, 0xb7, 0xbf, 0x83, 0xd6, 0xcd, 0x7d, 0xe0, 0xdc, 0xde, 0x07, 0xce, 0xaf, 0xfb,
-	0xa0, 0xf5, 0x7d, 0x19, 0xb4, 0x7e, 0x2c, 0x03, 0xe7, 0x76, 0x19, 0xb4, 0x7e, 0x2e, 0x83, 0x56,
-	0xbc, 0xa6, 0xbf, 0x4a, 0xaf, 0xff, 0x06, 0x00, 0x00, 0xff, 0xff, 0xd7, 0x9c, 0x64, 0x1e, 0xdc,
-	0x04, 0x00, 0x00,
+	// 744 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x54, 0xcd, 0x6e, 0xf3, 0x44,
+	0x14, 0x8d, 0x63, 0xe7, 0x6b, 0x73, 0xd3, 0xd0, 0x76, 0x40, 0x28, 0x54, 0x95, 0x13, 0xba, 0x0a,
+	0x0b, 0x12, 0x54, 0x40, 0x48, 0xec, 0x9a, 0x84, 0x4a, 0x06, 0xb5, 0x54, 0x93, 0x14, 0x96, 0x30,
+	0x9e, 0x4c, 0x1d, 0x2b, 0x8e, 0xc7, 0xf5, 0x8c, 0x2b, 0xb5, 0x4b, 0x9e, 0x80, 0x17, 0x40, 0xa2,
+	0x6f, 0xd3, 0x65, 0x97, 0xac, 0x2a, 0x68, 0x5e, 0x80, 0x75, 0x57, 0x68, 0xc6, 0xe3, 0xda, 0x61,
+	0xf1, 0x2d, 0xba, 0xbb, 0xe7, 0xcc, 0xcc, 0x3d, 0xe7, 0xfe, 0xd8, 0xb0, 0xc7, 0x13, 0x96, 0x12,
+	0x19, 0xf2, 0x58, 0x0c, 0x92, 0x94, 0x4b, 0x8e, 0xea, 0x73, 0xff, 0xe0, 0xf3, 0x20, 0x94, 0x8b,
+	0xcc, 0x1f, 0x50, 0xbe, 0x1a, 0x06, 0x3c, 0xe0, 0x43, 0x7d, 0xe4, 0x67, 0x57, 0x1a, 0x69, 0xa0,
+	0xa3, 0xfc, 0xc9, 0xd1, 0xaf, 0x00, 0x27, 0x94, 0x32, 0x21, 0xbc, 0xf8, 0x8a, 0xa3, 0x43, 0x68,
+	0x9e, 0x50, 0xca, 0xb3, 0x58, 0x7a, 0x93, 0x8e, 0xd5, 0xb3, 0xfa, 0x6d, 0x5c, 0x12, 0xe8, 0x63,
+	0x78, 0x77, 0x29, 0x58, 0xea, 0x4d, 0x3a, 0x75, 0x7d, 0x64, 0x90, 0xe2, 0x31, 0x8f, 0x98, 0x37,
+	0xe9, 0xd8, 0x39, 0x9f, 0xa3, 0x6f, 0x9d, 0x7f, 0xef, 0xbb, 0xb5, 0xa3, 0x7b, 0x0b, 0xf6, 0xc7,
+	0x29, 0x23, 0x92, 0x4d, 0x88, 0x24, 0x3e, 0x11, 0x0c, 0xb3, 0x6b, 0xf4, 0x55, 0x55, 0x57, 0x4b,
+	0xb5, 0x8e, 0x3f, 0x18, 0xcc, 0xfd, 0x41, 0xc9, 0x8e, 0x9c, 0x87, 0xa7, 0x6e, 0x0d, 0x57, 0xfd,
+	0x21, 0x70, 0x62, 0xb2, 0x62, 0x5a, 0xbf, 0x89, 0x75, 0xac, 0x3c, 0xe7, 0xe9, 0xa7, 0xd7, 0x91,
+	0x36, 0xd0, 0xc4, 0x25, 0x81, 0x5c, 0x80, 0x42, 0xd6, 0x9b, 0x77, 0x9c, 0x9e, 0xd5, 0x77, 0x70,
+	0x85, 0x31, 0x1e, 0x7f, 0xb3, 0x00, 0x4e, 0xa3, 0x4c, 0x2c, 0x66, 0xc4, 0x8f, 0xd8, 0x1b, 0xcd,
+	0x55, 0xa5, 0xf2, 0x16, 0x55, 0xa5, 0x26, 0xa8, 0x03, 0x5b, 0x3a, 0xbd, 0xe9, 0x93, 0x83, 0x0b,
+	0x68, 0x4c, 0xfc, 0x00, 0x30, 0x5e, 0x30, 0xba, 0x4c, 0x78, 0x18, 0x4b, 0xf4, 0x0d, 0xb4, 0xb5,
+	0xa3, 0x49, 0x96, 0xcf, 0x58, 0xdb, 0xb0, 0x47, 0xfb, 0x2f, 0x4f, 0xdd, 0xb6, 0x0c, 0x57, 0x6c,
+	0x50, 0x1c, 0xe0, 0xcd, 0x7b, 0x26, 0x19, 0x83, 0xa6, 0x17, 0x8b, 0x84, 0x51, 0x39, 0x3b, 0x7f,
+	0x63, 0x3d, 0x87, 0xd0, 0xfc, 0xb1, 0xd8, 0x30, 0xd3, 0xf1, 0x92, 0x30, 0x32, 0x3e, 0xb4, 0x8c,
+	0x0c, 0x66, 0x22, 0x41, 0x9f, 0x80, 0x3d, 0xbb, 0x4d, 0xb4, 0x42, 0x63, 0xb4, 0xf5, 0xf2, 0xd4,
+	0xb5, 0xc3, 0x58, 0x62, 0xc5, 0xa9, 0xea, 0xcf, 0x98, 0x10, 0x24, 0x28, 0xa6, 0x57, 0x40, 0x75,
+	0x72, 0x41, 0x6e, 0x23, 0x4e, 0xe6, 0xba, 0x2f, 0x3b, 0xb8, 0x80, 0x46, 0xe3, 0x7b, 0x68, 0x8d,
+	0x89, 0x24, 0x11, 0x0f, 0xb4, 0x06, 0x02, 0xc7, 0x93, 0x6c, 0xa5, 0x45, 0x9a, 0x58, 0xc7, 0xe8,
+	0x53, 0xb0, 0xa7, 0x99, 0xdf, 0xa9, 0xf7, 0xec, 0x7e, 0xeb, 0x78, 0x57, 0x55, 0x56, 0x79, 0x81,
+	0xd5, 0x99, 0xc9, 0x75, 0x07, 0x70, 0x4a, 0xb2, 0x48, 0x5e, 0xe8, 0x1e, 0x23, 0x70, 0xce, 0xd5,
+	0x3a, 0x99, 0x54, 0x2a, 0x56, 0xdc, 0x69, 0xca, 0xae, 0x8b, 0x15, 0x53, 0xb1, 0x5a, 0xf0, 0x13,
+	0xaa, 0xdb, 0x90, 0xef, 0x97, 0x41, 0xda, 0x0a, 0x49, 0x03, 0xbd, 0x56, 0x36, 0xd6, 0xb1, 0xe2,
+	0xa6, 0x8a, 0x6b, 0xe4, 0xef, 0x55, 0x6c, 0xb4, 0x7f, 0x86, 0xe6, 0x2c, 0x25, 0x94, 0x4d, 0x13,
+	0x12, 0xa3, 0x3d, 0xb0, 0xe9, 0x6a, 0x6e, 0x94, 0x55, 0x88, 0x3e, 0x82, 0x86, 0x48, 0x48, 0x2c,
+	0x8c, 0x72, 0x0e, 0xd4, 0x10, 0xe4, 0x22, 0x65, 0x62, 0xc1, 0xa3, 0xbc, 0x3d, 0x36, 0x2e, 0x09,
+	0x93, 0xf8, 0x33, 0x68, 0x8f, 0x22, 0x4e, 0x97, 0x67, 0x4c, 0x92, 0xe2, 0x33, 0x09, 0xf3, 0x49,
+	0xdb, 0x7d, 0x07, 0xeb, 0xd8, 0x5c, 0xf5, 0xa0, 0x35, 0x5e, 0x26, 0xaf, 0x17, 0x3b, 0xb0, 0x75,
+	0xc3, 0x52, 0x51, 0xac, 0x57, 0x1b, 0x17, 0x10, 0x1d, 0xc0, 0x76, 0xc4, 0x69, 0x39, 0xfb, 0x1d,
+	0xfc, 0x8a, 0x4d, 0xaa, 0x3f, 0x2c, 0xf8, 0x70, 0x2a, 0x79, 0x4a, 0x02, 0x76, 0xa9, 0xe6, 0xa8,
+	0x5a, 0xfd, 0xcb, 0x4f, 0x5f, 0xa8, 0x9c, 0xd3, 0x8c, 0x52, 0xc6, 0xf2, 0xea, 0xb6, 0x71, 0x01,
+	0xd1, 0x10, 0x60, 0xbc, 0x4c, 0xbe, 0x8b, 0x65, 0x1a, 0x32, 0xb1, 0x31, 0xac, 0xd2, 0x12, 0xae,
+	0x5c, 0x41, 0x5f, 0xc3, 0x8e, 0x2e, 0xac, 0x78, 0x62, 0xeb, 0x27, 0xfb, 0xea, 0xc9, 0x46, 0xc1,
+	0x78, 0xe3, 0x9a, 0xf1, 0x37, 0x84, 0xdd, 0x4d, 0x7b, 0x66, 0x8e, 0xd4, 0x9b, 0x0b, 0xdd, 0x99,
+	0x06, 0x36, 0xc8, 0x3c, 0xb8, 0x81, 0xbd, 0xff, 0xd7, 0xf3, 0x9e, 0x62, 0xca, 0x5c, 0xf5, 0x6a,
+	0x2e, 0x35, 0xc6, 0x69, 0x78, 0x67, 0xcc, 0x3a, 0x38, 0x07, 0x8a, 0x3d, 0x23, 0x41, 0x48, 0xcd,
+	0x1f, 0x28, 0x07, 0xb9, 0xee, 0xa8, 0xf7, 0xf8, 0x8f, 0x5b, 0x7b, 0x78, 0x76, 0xad, 0xc7, 0x67,
+	0xd7, 0xfa, 0xfb, 0xd9, 0xad, 0xfd, 0xbe, 0x76, 0x6b, 0x7f, 0xae, 0x5d, 0xeb, 0x71, 0xed, 0xd6,
+	0xfe, 0x5a, 0xbb, 0x35, 0xff, 0x9d, 0xfe, 0x57, 0x7f, 0xf9, 0x5f, 0x00, 0x00, 0x00, 0xff, 0xff,
+	0x94, 0x28, 0xdf, 0x1d, 0xf2, 0x05, 0x00, 0x00,
 }
 
 func (m *AccessInfo) Marshal() (dAtA []byte, err error) {
@@ -1052,6 +1202,143 @@ func (m *TraceSpan) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *BlockMetaInfo) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BlockMetaInfo) MarshalTo(dAtA []byte) (int, error) {
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BlockMetaInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Info) > 0 {
+		dAtA5 := make([]byte, len(m.Info)*10)
+		var j4 int
+		for _, num := range m.Info {
+			for num >= 1<<7 {
+				dAtA5[j4] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j4++
+			}
+			dAtA5[j4] = uint8(num)
+			j4++
+		}
+		i -= j4
+		copy(dAtA[i:], dAtA5[:j4])
+		i = encodeVarintOperations(dAtA, i, uint64(j4))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *CkpMetaInfo) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CkpMetaInfo) MarshalTo(dAtA []byte) (int, error) {
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *CkpMetaInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Location) > 0 {
+		i -= len(m.Location)
+		copy(dAtA[i:], m.Location)
+		i = encodeVarintOperations(dAtA, i, uint64(len(m.Location)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Version != 0 {
+		i = encodeVarintOperations(dAtA, i, uint64(m.Version))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *StorageUsageResp_V0) Marshal() (dAtA []byte, err error) {
+	size := m.ProtoSize()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *StorageUsageResp_V0) MarshalTo(dAtA []byte) (int, error) {
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *StorageUsageResp_V0) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.BlockEntries) > 0 {
+		for iNdEx := len(m.BlockEntries) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.BlockEntries[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintOperations(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.CkpEntries) > 0 {
+		for iNdEx := len(m.CkpEntries) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.CkpEntries[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintOperations(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.Succeed {
+		i--
+		if m.Succeed {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *StorageUsageReq) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
@@ -1073,21 +1360,21 @@ func (m *StorageUsageReq) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	var l int
 	_ = l
 	if len(m.AccIds) > 0 {
-		dAtA5 := make([]byte, len(m.AccIds)*10)
-		var j4 int
+		dAtA7 := make([]byte, len(m.AccIds)*10)
+		var j6 int
 		for _, num1 := range m.AccIds {
 			num := uint64(num1)
 			for num >= 1<<7 {
-				dAtA5[j4] = uint8(uint64(num)&0x7f | 0x80)
+				dAtA7[j6] = uint8(uint64(num)&0x7f | 0x80)
 				num >>= 7
-				j4++
+				j6++
 			}
-			dAtA5[j4] = uint8(num)
-			j4++
+			dAtA7[j6] = uint8(num)
+			j6++
 		}
-		i -= j4
-		copy(dAtA[i:], dAtA5[:j4])
-		i = encodeVarintOperations(dAtA, i, uint64(j4))
+		i -= j6
+		copy(dAtA[i:], dAtA7[:j6])
+		i = encodeVarintOperations(dAtA, i, uint64(j6))
 		i--
 		dAtA[i] = 0xa
 	}
@@ -1120,28 +1407,9 @@ func (m *StorageUsageResp) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		dAtA[i] = 0x20
 	}
 	if len(m.Sizes) > 0 {
-		dAtA7 := make([]byte, len(m.Sizes)*10)
-		var j6 int
-		for _, num := range m.Sizes {
-			for num >= 1<<7 {
-				dAtA7[j6] = uint8(uint64(num)&0x7f | 0x80)
-				num >>= 7
-				j6++
-			}
-			dAtA7[j6] = uint8(num)
-			j6++
-		}
-		i -= j6
-		copy(dAtA[i:], dAtA7[:j6])
-		i = encodeVarintOperations(dAtA, i, uint64(j6))
-		i--
-		dAtA[i] = 0x1a
-	}
-	if len(m.AccIds) > 0 {
-		dAtA9 := make([]byte, len(m.AccIds)*10)
+		dAtA9 := make([]byte, len(m.Sizes)*10)
 		var j8 int
-		for _, num1 := range m.AccIds {
-			num := uint64(num1)
+		for _, num := range m.Sizes {
 			for num >= 1<<7 {
 				dAtA9[j8] = uint8(uint64(num)&0x7f | 0x80)
 				num >>= 7
@@ -1153,6 +1421,25 @@ func (m *StorageUsageResp) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i -= j8
 		copy(dAtA[i:], dAtA9[:j8])
 		i = encodeVarintOperations(dAtA, i, uint64(j8))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.AccIds) > 0 {
+		dAtA11 := make([]byte, len(m.AccIds)*10)
+		var j10 int
+		for _, num1 := range m.AccIds {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA11[j10] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j10++
+			}
+			dAtA11[j10] = uint8(num)
+			j10++
+		}
+		i -= j10
+		copy(dAtA[i:], dAtA11[:j10])
+		i = encodeVarintOperations(dAtA, i, uint64(j10))
 		i--
 		dAtA[i] = 0x12
 	}
@@ -1347,6 +1634,62 @@ func (m *TraceSpan) ProtoSize() (n int) {
 	}
 	if m.Threshold != 0 {
 		n += 1 + sovOperations(uint64(m.Threshold))
+	}
+	return n
+}
+
+func (m *BlockMetaInfo) ProtoSize() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Info) > 0 {
+		l = 0
+		for _, e := range m.Info {
+			l += sovOperations(uint64(e))
+		}
+		n += 1 + sovOperations(uint64(l)) + l
+	}
+	return n
+}
+
+func (m *CkpMetaInfo) ProtoSize() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Version != 0 {
+		n += 1 + sovOperations(uint64(m.Version))
+	}
+	l = len(m.Location)
+	if l > 0 {
+		n += 1 + l + sovOperations(uint64(l))
+	}
+	return n
+}
+
+func (m *StorageUsageResp_V0) ProtoSize() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Succeed {
+		n += 2
+	}
+	if len(m.CkpEntries) > 0 {
+		for _, e := range m.CkpEntries {
+			l = e.ProtoSize()
+			n += 1 + l + sovOperations(uint64(l))
+		}
+	}
+	if len(m.BlockEntries) > 0 {
+		for _, e := range m.BlockEntries {
+			l = e.ProtoSize()
+			n += 1 + l + sovOperations(uint64(l))
+		}
 	}
 	return n
 }
@@ -2540,6 +2883,373 @@ func (m *TraceSpan) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipOperations(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthOperations
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BlockMetaInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowOperations
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BlockMetaInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BlockMetaInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType == 0 {
+				var v uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowOperations
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.Info = append(m.Info, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowOperations
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return ErrInvalidLengthOperations
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return ErrInvalidLengthOperations
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				var count int
+				for _, integer := range dAtA[iNdEx:postIndex] {
+					if integer < 128 {
+						count++
+					}
+				}
+				elementCount = count
+				if elementCount != 0 && len(m.Info) == 0 {
+					m.Info = make([]uint64, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowOperations
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.Info = append(m.Info, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field Info", wireType)
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipOperations(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthOperations
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CkpMetaInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowOperations
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CkpMetaInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CkpMetaInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			m.Version = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowOperations
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Version |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Location", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowOperations
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthOperations
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthOperations
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Location = append(m.Location[:0], dAtA[iNdEx:postIndex]...)
+			if m.Location == nil {
+				m.Location = []byte{}
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipOperations(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthOperations
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *StorageUsageResp_V0) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowOperations
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: StorageUsageResp_V0: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: StorageUsageResp_V0: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Succeed", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowOperations
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Succeed = bool(v != 0)
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field CkpEntries", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowOperations
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthOperations
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthOperations
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.CkpEntries = append(m.CkpEntries, &CkpMetaInfo{})
+			if err := m.CkpEntries[len(m.CkpEntries)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BlockEntries", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowOperations
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthOperations
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthOperations
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BlockEntries = append(m.BlockEntries, &BlockMetaInfo{})
+			if err := m.BlockEntries[len(m.BlockEntries)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipOperations(dAtA[iNdEx:])

--- a/pkg/vm/engine/tae/db/operations.proto
+++ b/pkg/vm/engine/tae/db/operations.proto
@@ -88,6 +88,24 @@ message TraceSpan {
     int64 threshold = 3;
 }
 
+message BlockMetaInfo {
+    option (gogoproto.typedecl)     = false;
+    repeated uint64 info            = 1;
+}
+
+message CkpMetaInfo {
+    option (gogoproto.typedecl)     = false;
+    uint32 version                  =1;
+    bytes location                 =2;
+}
+
+message StorageUsageResp_V0 {
+    option (gogoproto.typedecl)     = false;
+    bool Succeed                    = 1;
+    repeated CkpMetaInfo CkpEntries = 2;
+    repeated BlockMetaInfo BlockEntries   = 3;
+}
+
 message StorageUsageReq {
     option (gogoproto.typedecl) = false;
     repeated int32 AccIds = 1;

--- a/pkg/vm/engine/tae/logtail/storage_usage.go
+++ b/pkg/vm/engine/tae/logtail/storage_usage.go
@@ -639,7 +639,7 @@ func (m *TNUsageMemo) EstablishFromCKPs(c *catalog.Catalog) {
 		}
 		logutil.Info("[storage usage] replay:",
 			zap.String("remove old deleted db/tbl", buf.String()),
-			zap.Int("delayed %d tbl", len(m.pendingReplay.delayed)))
+			zap.Int("delayed tbl", len(m.pendingReplay.delayed)))
 	}()
 
 	for x := range m.pendingReplay.datas {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2196

## What this PR does / why we need it:

compatible backward, the old storage usage request method.

two changes in the new version:

all the RPC method codes have been changed.
unable to handle the response of the old version tn.
this fix adds a retry with the old method and handler when a not supported error occurs.