### PR TITLE
don't assume input vector to be sorted in prefix_eq

### DIFF
--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -22,6 +22,12 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/bytejson"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -35,11 +41,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"golang.org/x/exp/constraints"
-	"math"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
 )
 
 func AddFaultPoint(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int) (err error) {
@@ -2165,6 +2166,10 @@ func PrefixEq(parameters []*vector.Vector, result vector.FunctionResultWrapper, 
 	lvec := parameters[0]
 	rval := parameters[1].GetBytesAt(0)
 	res := vector.MustFixedCol[bool](result.GetResultVector())
+
+	if !lvec.GetSorted() {
+		return StartsWith(parameters, result, proc, length)
+	}
 
 	lcol, larea := vector.MustVarlenaRawData(lvec)
 	lowerBound := sort.Search(len(lcol), func(i int) bool {


### PR DESCRIPTION
for unflushed rows in memtable, even primary key column is not sorted

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/2408

## What this PR does / why we need it:
fix wrong output