### PR TITLE
sync to 1.1: fix data race when ickp

### DIFF
--- a/pkg/vm/engine/tae/logtail/storage_usage.go
+++ b/pkg/vm/engine/tae/logtail/storage_usage.go
@@ -899,8 +899,8 @@ func FillUsageBatOfGlobal(collector *GlobalCollector) {
 
 	collector.UsageMemo.EnterProcessing()
 	defer func() {
-		collector.UsageMemo.LeaveProcessing()
 		v2.TaskGCkpCollectUsageDurationHistogram.Observe(time.Since(start).Seconds())
+		collector.UsageMemo.LeaveProcessing()
 	}()
 
 	log1, cnt := putCacheBack2Track(collector.BaseCollector)
@@ -918,9 +918,9 @@ func FillUsageBatOfIncremental(collector *IncrementalCollector) {
 
 	collector.UsageMemo.EnterProcessing()
 	defer func() {
-		collector.UsageMemo.LeaveProcessing()
 		v2.TaskStorageUsageCacheMemUsedGauge.Set(collector.UsageMemo.MemoryUsed())
 		v2.TaskICkpCollectUsageDurationHistogram.Observe(time.Since(start).Seconds())
+		collector.UsageMemo.LeaveProcessing()
 	}()
 
 	log1 := applyChanges(collector.BaseCollector, collector.UsageMemo)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/14456

## What this PR does / why we need it:
fix the data race when ickp