### PR TITLE
don't assume input vector to be sorted in prefix_*

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -54,7 +54,7 @@ func (builder *QueryBuilder) applyIndicesForFilters(nodeID int32, node *plan.Nod
 
 	indexes := node.TableDef.Indexes
 	sort.Slice(indexes, func(i, j int) bool {
-		return indexes[i].Unique && !indexes[j].Unique
+		return (indexes[i].Unique && !indexes[j].Unique) || (indexes[i].Unique == indexes[j].Unique && len(indexes[i].Parts) > len(indexes[j].Parts))
 	})
 
 	// Apply unique/secondary indices if only indexed column is referenced
@@ -284,7 +284,7 @@ END0:
 			}
 		}
 
-		if len(filterIdx) < numParts && !usePartialIndex {
+		if len(filterIdx) < numParts && (idxDef.Unique || !usePartialIndex) {
 			continue
 		}
 

--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -88,7 +88,8 @@ func PrefixBetween(parameters []*vector.Vector, result vector.FunctionResultWrap
 		}
 	} else {
 		for i := 0; i < length; i++ {
-			res[i] = index.PrefixCompare(icol[i].GetByteSlice(iarea), lval) >= 0 && index.PrefixCompare(icol[i].GetByteSlice(iarea), rval) <= 0
+			val := icol[i].GetByteSlice(iarea)
+			res[i] = index.PrefixCompare(val, lval) >= 0 && index.PrefixCompare(val, rval) <= 0
 		}
 	}
 

--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -1,0 +1,139 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+func PrefixEq(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int) error {
+	lvec := parameters[0]
+	rval := parameters[1].GetBytesAt(0)
+	res := vector.MustFixedCol[bool](result.GetResultVector())
+
+	lcol, larea := vector.MustVarlenaRawData(lvec)
+
+	if lvec.GetSorted() {
+		lowerBound := sort.Search(len(lcol), func(i int) bool {
+			return bytes.Compare(rval, lcol[i].GetByteSlice(larea)) <= 0
+		})
+
+		upperBound := lowerBound
+		for upperBound < len(lcol) && bytes.HasPrefix(lcol[upperBound].GetByteSlice(larea), rval) {
+			upperBound++
+		}
+
+		for i := 0; i < lowerBound; i++ {
+			res[i] = false
+		}
+		for i := lowerBound; i < upperBound; i++ {
+			res[i] = true
+		}
+		for i := upperBound; i < length; i++ {
+			res[i] = false
+		}
+	} else {
+		for i := 0; i < length; i++ {
+			if bytes.HasPrefix(lcol[i].GetByteSlice(larea), rval) {
+				res[i] = true
+			}
+		}
+	}
+
+	return nil
+}
+
+func PrefixBetween(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int) error {
+	ivec := parameters[0]
+	lval := parameters[1].GetBytesAt(0)
+	rval := parameters[2].GetBytesAt(0)
+	res := vector.MustFixedCol[bool](result.GetResultVector())
+
+	icol, iarea := vector.MustVarlenaRawData(ivec)
+
+	if ivec.GetSorted() {
+		lowerBound := sort.Search(len(icol), func(i int) bool {
+			return index.PrefixCompare(icol[i].GetByteSlice(iarea), lval) >= 0
+		})
+
+		upperBound := sort.Search(len(icol), func(i int) bool {
+			return index.PrefixCompare(icol[i].GetByteSlice(iarea), rval) > 0
+		})
+
+		for i := 0; i < lowerBound; i++ {
+			res[i] = false
+		}
+		for i := lowerBound; i < upperBound; i++ {
+			res[i] = true
+		}
+		for i := upperBound; i < length; i++ {
+			res[i] = false
+		}
+	} else {
+		for i := 0; i < length; i++ {
+			res[i] = index.PrefixCompare(icol[i].GetByteSlice(iarea), lval) >= 0 && index.PrefixCompare(icol[i].GetByteSlice(iarea), rval) <= 0
+		}
+	}
+
+	return nil
+}
+
+func PrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int) error {
+	lvec := parameters[0]
+	rvec := parameters[1]
+	res := vector.MustFixedCol[bool](result.GetResultVector())
+
+	lcol, larea := vector.MustVarlenaRawData(lvec)
+	rcol, rarea := vector.MustVarlenaRawData(rvec)
+
+	if lvec.GetSorted() {
+		rval := rcol[0].GetByteSlice(rarea)
+		rpos := 0
+		rlen := rvec.Length()
+
+		for i := 0; i < length; i++ {
+			lval := lcol[i].GetByteSlice(larea)
+			for index.PrefixCompare(lval, rval) > 0 {
+				rpos++
+				if rpos == rlen {
+					for j := i; j < length; j++ {
+						res[j] = false
+					}
+					return nil
+				}
+
+				rval = rcol[rpos].GetByteSlice(rarea)
+			}
+
+			res[i] = bytes.HasPrefix(lval, rval)
+		}
+	} else {
+		for i := range lcol {
+			lval := lcol[i].GetByteSlice(larea)
+			rpos, _ := sort.Find(len(rcol), func(j int) int {
+				return bytes.Compare(rcol[j].GetByteSlice(rarea), lval)
+			})
+
+			res[i] = bytes.HasPrefix(lval, rcol[rpos].GetByteSlice(rarea))
+		}
+	}
+
+	return nil
+}

--- a/pkg/sql/plan/function/operator_between.go
+++ b/pkg/sql/plan/function/operator_between.go
@@ -16,12 +16,10 @@ package function
 
 import (
 	"bytes"
-	"sort"
 
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"golang.org/x/exp/constraints"
 )
@@ -305,34 +303,5 @@ func opBetweenBytes(
 		v0, _ := p0.GetStrValue(i)
 		rss[i] = bytes.Compare(v0, lb) >= 0 && bytes.Compare(v0, ub) <= 0
 	}
-	return nil
-}
-
-func PrefixBetween(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int) error {
-	ivec := parameters[0]
-	lval := parameters[1].GetBytesAt(0)
-	rval := parameters[2].GetBytesAt(0)
-	res := vector.MustFixedCol[bool](result.GetResultVector())
-
-	icol, iarea := vector.MustVarlenaRawData(ivec)
-	lowerBound := sort.Search(len(icol), func(i int) bool {
-		return index.PrefixCompare(icol[i].GetByteSlice(iarea), lval) >= 0
-	})
-
-	upperBound := lowerBound
-	for upperBound < len(icol) && index.PrefixCompare(icol[upperBound].GetByteSlice(iarea), rval) <= 0 {
-		upperBound++
-	}
-
-	for i := 0; i < lowerBound; i++ {
-		res[i] = false
-	}
-	for i := lowerBound; i < upperBound; i++ {
-		res[i] = true
-	}
-	for i := upperBound; i < len(res); i++ {
-		res[i] = false
-	}
-
 	return nil
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12517 https://github.com/matrixorigin/MO-Cloud/issues/2408

## What this PR does / why we need it:
memtable is not sorted by primary keys