### PR TITLE
fix a panic caused by prefix_in on memtable

### DIFF
--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -132,7 +132,7 @@ func PrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, 
 				return bytes.Compare(rcol[j].GetByteSlice(rarea), lval)
 			})
 
-			res[i] = bytes.HasPrefix(lval, rcol[rpos].GetByteSlice(rarea))
+			res[i] = rpos < len(rcol) && bytes.HasPrefix(lval, rcol[rpos].GetByteSlice(rarea))
 		}
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14509

## What this PR does / why we need it:
fix a panic caused by prefix_in on memtable