### PR TITLE
Move writeoffset update from Ranges to Relation (#14434)

### DIFF
--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -149,12 +149,15 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 		//defer rel.Unlock()
 		//rel.proc = p
 		rel.proc.Store(p)
+		rel.updateWriteOffset()
 		return rel, nil
 	}
 	// get relation from the txn created tables cache: created by this txn
 	if v, ok := db.txn.createMap.Load(key); ok {
 		//v.(*txnTable).proc = p
 		v.(*txnTable).proc.Store(p)
+		tbl := v.(*txnTable)
+		tbl.updateWriteOffset()
 		return v.(*txnTable), nil
 	}
 
@@ -209,6 +212,7 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 		lastTS: txn.op.SnapshotTS(),
 	}
 	tbl.proc.Store(p)
+	tbl.updateWriteOffset()
 
 	db.txn.tableCache.tableMap.Store(key, tbl)
 	return tbl, nil

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -16,11 +16,12 @@ package disttae
 
 import (
 	"context"
-	"github.com/matrixorigin/matrixone/pkg/pb/api"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/cache"
 	"strconv"
 	"time"
 	"unsafe"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/api"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/cache"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -603,7 +604,6 @@ func (tbl *txnTable) Ranges(ctx context.Context, exprs []*plan.Expr) (ranges [][
 	}()
 
 	tbl.writes = tbl.writes[:0]
-	tbl.writesOffset = tbl.db.txn.statements[tbl.db.txn.statementID-1]
 
 	tbl.writes = tbl.db.txn.getTableWrites(tbl.db.databaseId, tbl.tableId, tbl.writes)
 
@@ -2397,4 +2397,11 @@ func (tbl *txnTable) readNewRowid(vec *vector.Vector, row int,
 
 func (tbl *txnTable) newPkFilter(pkExpr, constExpr *plan.Expr) (*plan.Expr, error) {
 	return plan2.BindFuncExprImplByPlanExpr(tbl.proc.Load().Ctx, "=", []*plan.Expr{pkExpr, constExpr})
+}
+
+// get the table's snapshot.
+func (tbl *txnTable) updateWriteOffset() {
+	if tbl.db.txn.statementID > 0 {
+		tbl.writesOffset = tbl.db.txn.statements[tbl.db.txn.statementID-1]
+	}
 }


### PR DESCRIPTION
* 因为不是所有的操作都会调用ranges，所以将更新table的wirteoffset的操作从ranges改为获取table的时候更新

Approved by: @triump2020

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/14282

## What this PR does / why we need it:
* 因为不是所有的操作都会调用ranges，所以将更新table的wirteoffset的操作从ranges改为获取table的时候更新