### PR TITLE
[opt] allow filters with parameter/variable to use index

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -21,6 +21,16 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 )
 
+func isRuntimeConstExpr(expr *plan.Expr) bool {
+	switch expr.Expr.(type) {
+	case *plan.Expr_Lit, *plan.Expr_P, *plan.Expr_V:
+		return true
+
+	default:
+		return false
+	}
+}
+
 func (builder *QueryBuilder) applyIndices(nodeID int32, colRefCnt map[[2]int32]int, idxColMap map[[2]int32]*plan.Expr) int32 {
 	node := builder.qry.Nodes[nodeID]
 
@@ -69,11 +79,11 @@ func (builder *QueryBuilder) applyIndicesForFilters(nodeID int32, node *plan.Nod
 
 			switch fn.Func.ObjName {
 			case "=":
-				if (fn.Args[0].GetLit() != nil || fn.Args[0].GetP() != nil) && fn.Args[1].GetCol() != nil {
+				if isRuntimeConstExpr(fn.Args[0]) && fn.Args[1].GetCol() != nil {
 					fn.Args[0], fn.Args[1] = fn.Args[1], fn.Args[0]
 				}
 
-				if fn.Args[1].GetLit() == nil && fn.Args[1].GetP() == nil {
+				if !isRuntimeConstExpr(fn.Args[1]) {
 					goto END0
 				}
 
@@ -225,12 +235,12 @@ END0:
 			continue
 		}
 
-		if (fn.Args[0].GetLit() != nil || fn.Args[0].GetP() != nil) && fn.Args[1].GetCol() != nil {
+		if isRuntimeConstExpr(fn.Args[0]) && fn.Args[1].GetCol() != nil {
 			fn.Args[0], fn.Args[1] = fn.Args[1], fn.Args[0]
 		}
 
 		col := fn.Args[0].GetCol()
-		if col == nil || (fn.Args[1].GetLit() == nil && fn.Args[1].GetP() == nil) {
+		if col == nil || !isRuntimeConstExpr(fn.Args[1]) {
 			continue
 		}
 

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -69,11 +69,11 @@ func (builder *QueryBuilder) applyIndicesForFilters(nodeID int32, node *plan.Nod
 
 			switch fn.Func.ObjName {
 			case "=":
-				if fn.Args[0].GetLit() != nil && fn.Args[1].GetCol() != nil {
+				if (fn.Args[0].GetLit() != nil || fn.Args[0].GetP() != nil) && fn.Args[1].GetCol() != nil {
 					fn.Args[0], fn.Args[1] = fn.Args[1], fn.Args[0]
 				}
 
-				if fn.Args[1].GetLit() == nil {
+				if fn.Args[1].GetLit() == nil && fn.Args[1].GetP() == nil {
 					goto END0
 				}
 
@@ -225,12 +225,12 @@ END0:
 			continue
 		}
 
-		if fn.Args[0].GetLit() != nil && fn.Args[1].GetCol() != nil {
+		if (fn.Args[0].GetLit() != nil || fn.Args[0].GetP() != nil) && fn.Args[1].GetCol() != nil {
 			fn.Args[0], fn.Args[1] = fn.Args[1], fn.Args[0]
 		}
 
 		col := fn.Args[0].GetCol()
-		if col == nil || fn.Args[1].GetLit() == nil {
+		if col == nil || (fn.Args[1].GetLit() == nil && fn.Args[1].GetP() == nil) {
 			continue
 		}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/2495

## What this PR does / why we need it:
trigger index mechanism when we encounter filters like `a = ?` or `a = @some_var` on indexed column `a`