### PR TITLE
fix wrong result caused by prefix_eq

### DIFF
--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -51,9 +51,7 @@ func PrefixEq(parameters []*vector.Vector, result vector.FunctionResultWrapper, 
 		}
 	} else {
 		for i := 0; i < length; i++ {
-			if bytes.HasPrefix(lcol[i].GetByteSlice(larea), rval) {
-				res[i] = true
-			}
+			res[i] = bytes.HasPrefix(lcol[i].GetByteSlice(larea), rval)
 		}
 	}
 
@@ -126,7 +124,7 @@ func PrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, 
 			res[i] = bytes.HasPrefix(lval, rval)
 		}
 	} else {
-		for i := range lcol {
+		for i := 0; i < length; i++ {
 			lval := lcol[i].GetByteSlice(larea)
 			rpos, _ := sort.Find(len(rcol), func(j int) int {
 				return bytes.Compare(rcol[j].GetByteSlice(rarea), lval)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12517

## What this PR does / why we need it:
vectors allocated from mempool are not zero-initialized and MUST be overwritten in function implementation.