### PR TITLE
fix a bug of semi join when semi join can skip probe

### DIFF
--- a/pkg/sql/colexec/semi/join.go
+++ b/pkg/sql/colexec/semi/join.go
@@ -95,7 +95,20 @@ func (arg *Argument) Call(proc *process.Process) (vm.CallResult, error) {
 				continue
 			}
 			if ctr.skipProbe {
+				vecused := make([]bool, len(bat.Vecs))
+				newvecs := make([]*vector.Vector, len(ap.Result))
+				for i, pos := range ap.Result {
+					vecused[pos] = true
+					newvecs[i] = bat.Vecs[pos]
+				}
+				for i := range bat.Vecs {
+					if !vecused[i] {
+						bat.Vecs[i].Free(proc.Mp())
+					}
+				}
+				bat.Vecs = newvecs
 				result.Batch = bat
+				anal.Output(ctr.rbat, arg.GetIsLast())
 				return result, nil
 			}
 			if ctr.mp == nil {

--- a/pkg/sql/colexec/semi/join.go
+++ b/pkg/sql/colexec/semi/join.go
@@ -108,7 +108,7 @@ func (arg *Argument) Call(proc *process.Process) (vm.CallResult, error) {
 				}
 				bat.Vecs = newvecs
 				result.Batch = bat
-				anal.Output(ctr.rbat, arg.GetIsLast())
+				anal.Output(bat, arg.GetIsLast())
 				return result, nil
 			}
 			if ctr.mp == nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14530

## What this PR does / why we need it:
semi join can skip probe if runtime filter push in_pred to probe side, but the vecs need to be adjusted according to output vecs