### PR TITLE
[opt] ensure runtime filter is deduced after applying index

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -359,6 +359,8 @@ END0:
 			node.FilterList = newFilterList
 		}
 
+		calcScanStats(node, builder)
+
 		idxTableNodeID := builder.appendNode(&plan.Node{
 			NodeType:     plan.Node_TABLE_SCAN,
 			TableDef:     idxTableDef,
@@ -481,6 +483,7 @@ END0:
 		}
 
 		node.FilterList = append(node.FilterList[:i], node.FilterList[i+1:]...)
+		calcScanStats(node, builder)
 
 		idxTableNodeID := builder.appendNode(&plan.Node{
 			NodeType:     plan.Node_TABLE_SCAN,

--- a/pkg/sql/plan/runtime_filter.go
+++ b/pkg/sql/plan/runtime_filter.go
@@ -79,7 +79,7 @@ func (builder *QueryBuilder) pushdownRuntimeFilters(nodeID int32) {
 	leftChild := builder.qry.Nodes[node.Children[0]]
 
 	// TODO: build runtime filters deeper than 1 level
-	if leftChild.NodeType != plan.Node_TABLE_SCAN {
+	if leftChild.NodeType != plan.Node_TABLE_SCAN || leftChild.Limit != nil {
 		return
 	}
 

--- a/pkg/sql/plan/runtime_filter.go
+++ b/pkg/sql/plan/runtime_filter.go
@@ -22,8 +22,6 @@ import (
 const (
 	InFilterCardLimit    = 10000
 	BloomFilterCardLimit = 100 * InFilterCardLimit
-
-	MinProbeTableRows    = 8192 * 20 // Don't generate runtime filter for small tables
 	SelectivityThreshold = 0.5
 )
 
@@ -81,7 +79,7 @@ func (builder *QueryBuilder) pushdownRuntimeFilters(nodeID int32) {
 	leftChild := builder.qry.Nodes[node.Children[0]]
 
 	// TODO: build runtime filters deeper than 1 level
-	if leftChild.NodeType != plan.Node_TABLE_SCAN || leftChild.Stats.Cost < MinProbeTableRows {
+	if leftChild.NodeType != plan.Node_TABLE_SCAN {
 		return
 	}
 
@@ -169,7 +167,6 @@ func (builder *QueryBuilder) pushdownRuntimeFilters(nodeID int32) {
 	}
 
 	tableDef := leftChild.TableDef
-
 	if tableDef.Pkey == nil || len(tableDef.Pkey.Names) < len(probeExprs) {
 		return
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14516 https://github.com/matrixorigin/MO-Cloud/issues/2495

## What this PR does / why we need it:
cleanup the dummy items in BlockFilterList, and don't prevent runtime filter on small table