### PR TITLE
[Tech Request]: don't display too long vector in explain

### DIFF
--- a/pkg/sql/plan/explain/explain_expr.go
+++ b/pkg/sql/plan/explain/explain_expr.go
@@ -161,7 +161,12 @@ func describeExpr(ctx context.Context, expr *plan.Expr, options *ExplainOptions,
 	case *plan.Expr_Vec:
 		vec := vector.NewVec(types.T_any.ToType())
 		vec.UnmarshalBinary(exprImpl.Vec.Data)
+		if vec.Length() > 16 {
+			//don't display too long data in explain
+			vec.SetLength(16)
+		}
 		buf.WriteString(vec.String())
+		buf.WriteString("......")
 	default:
 		panic("unsupported expr")
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14560

## What this PR does / why we need it:
runtime filter could push a in predicate with thousands of values.
don't display all of that in explain.