### PR TITLE
[Bug]: [regression 2.7] internal error: send notify msg to dispatch operator timeout during tpch 1T queries and TPCH cost increaseed more than 25%

### DIFF
--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -951,7 +951,7 @@ func recalcStatsByRuntimeFilter(node *plan.Node, runtimeFilterSel float64) {
 	if node.Stats.Cost < 1 {
 		node.Stats.Cost = 1
 	}
-	node.Stats.BlockNum = int32(float64(node.Stats.BlockNum)*runtimeFilterSel) + 1
+	node.Stats.BlockNum = int32(node.Stats.Outcnt/2) + 1
 }
 
 func calcScanStats(node *plan.Node, builder *QueryBuilder) *plan.Stats {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14559

## What this PR does / why we need it:
blocknum in stats estimated too small, cause bad performance