### PR TITLE
sync to 1.1: increase the default val of the tn rpc worker

### DIFF
--- a/pkg/common/morpc/cfg.go
+++ b/pkg/common/morpc/cfg.go
@@ -15,6 +15,8 @@
 package morpc
 
 import (
+	"math"
+	"runtime"
 	"time"
 
 	"github.com/fagongzi/goetty/v2"
@@ -99,7 +101,7 @@ func (c *Config) Adjust() {
 		c.SendQueueSize = 100000
 	}
 	if c.ServerWorkers == 0 {
-		c.ServerWorkers = 50
+		c.ServerWorkers = int(math.Max(100, float64(8*runtime.NumCPU())))
 	}
 	if c.ServerBufferQueueSize == 0 {
 		c.ServerBufferQueueSize = 100000

--- a/pkg/tnservice/cfg.go
+++ b/pkg/tnservice/cfg.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	logservicepb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 	"github.com/matrixorigin/matrixone/pkg/util"
+	"math"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -273,7 +275,7 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	c.RPC.Adjust()
+	c.TNRPCAdjust()
 	c.LockService.ServiceID = c.UUID
 	c.LockService.Validate()
 
@@ -283,6 +285,13 @@ func (c *Config) Validate() error {
 		}
 	}
 	return nil
+}
+
+func (c *Config) TNRPCAdjust() {
+	if c.RPC.ServerWorkers == 0 {
+		c.RPC.ServerWorkers = int(math.Max(100, float64(8*runtime.NumCPU())))
+	}
+	c.RPC.Adjust()
 }
 
 func (c *Config) SetDefaultValue() {

--- a/pkg/tnservice/cfg.go
+++ b/pkg/tnservice/cfg.go
@@ -18,9 +18,7 @@ import (
 	"context"
 	logservicepb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 	"github.com/matrixorigin/matrixone/pkg/util"
-	"math"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -275,7 +273,7 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	c.TNRPCAdjust()
+	c.RPC.Adjust()
 	c.LockService.ServiceID = c.UUID
 	c.LockService.Validate()
 
@@ -285,13 +283,6 @@ func (c *Config) Validate() error {
 		}
 	}
 	return nil
-}
-
-func (c *Config) TNRPCAdjust() {
-	if c.RPC.ServerWorkers == 0 {
-		c.RPC.ServerWorkers = int(math.Max(100, float64(8*runtime.NumCPU())))
-	}
-	c.RPC.Adjust()
 }
 
 func (c *Config) SetDefaultValue() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/14471

## What this PR does / why we need it:
increasing the number of RPC server workers to allow higher parallel sessions.