### PR TITLE
Get rid of per table writeOffset

### DIFF
--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -239,15 +239,12 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 	rel := db.txn.getCachedTable(key, db.txn.op.SnapshotTS())
 	if rel != nil {
 		rel.proc.Store(p)
-		rel.updateWriteOffset()
 		return rel, nil
 	}
 
 	// get relation from the txn created tables cache: created by this txn
 	if v, ok := db.txn.createMap.Load(key); ok {
 		v.(*txnTable).proc.Store(p)
-		tbl := v.(*txnTable)
-		tbl.updateWriteOffset()
 		return v.(*txnTable), nil
 	}
 
@@ -305,7 +302,6 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 		lastTS:        txn.op.SnapshotTS(),
 	}
 	tbl.proc.Store(p)
-	tbl.updateWriteOffset()
 
 	db.txn.tableCache.tableMap.Store(key, tbl)
 	return tbl, nil

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1560,7 +1560,7 @@ func (tbl *txnTable) Write(ctx context.Context, bat *batch.Batch) error {
 		ibat.Clean(tbl.db.txn.proc.Mp())
 		return err
 	}
-	return tbl.db.txn.dumpBatch(tbl.writesOffset)
+	return tbl.db.txn.dumpBatch(tbl.getTableWriteOffset())
 }
 
 func (tbl *txnTable) Update(ctx context.Context, bat *batch.Batch) error {
@@ -2309,11 +2309,4 @@ func (tbl *txnTable) readNewRowid(vec *vector.Vector, row int,
 
 func (tbl *txnTable) newPkFilter(pkExpr, constExpr *plan.Expr) (*plan.Expr, error) {
 	return plan2.BindFuncExprImplByPlanExpr(tbl.proc.Load().Ctx, "=", []*plan.Expr{pkExpr, constExpr})
-}
-
-// get the table's snapshot.
-func (tbl *txnTable) updateWriteOffset() {
-	if tbl.db.txn.statementID > 0 {
-		tbl.writesOffset = tbl.db.txn.statements[tbl.db.txn.statementID-1]
-	}
 }


### PR DESCRIPTION
Read it from transaction when it is needed.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #14552

## What this PR does / why we need it:

Code refactor.   Unnecessary caching is a data consistency problem.