### PR TITLE
[Bug]: Incorrect explain in bvt with race enabled to 1.1-dev

### DIFF
--- a/test/distributed/cases/join/leftjoin.result
+++ b/test/distributed/cases/join/leftjoin.result
@@ -22,6 +22,9 @@ mo_ctl(dn, flush, d1.t2)
 select mo_ctl('dn', 'flush', 'd1.t3');
 mo_ctl(dn, flush, d1.t3)
 {\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select Sleep(5);
+sleep(5)
+0
 explain select t2.c1 from t2 left join t1 on t1.c1 =t2.c1;
 QUERY PLAN
 Project

--- a/test/distributed/cases/join/leftjoin.test
+++ b/test/distributed/cases/join/leftjoin.test
@@ -19,6 +19,7 @@ select mo_ctl('dn', 'flush', 'd1.t1');
 select mo_ctl('dn', 'flush', 'd1.t2');
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t3');
+select Sleep(5);
 -- @separator:table
 explain select t2.c1 from t2 left join t1 on t1.c1 =t2.c1;
 -- @separator:table


### PR DESCRIPTION
need to wait for flush complete in race mode

Approved by: @aressu1985

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14108

## What this PR does / why we need it:
[Bug]: Incorrect explain in bvt with race enabled to 1.1-dev