### PR TITLE
sync to 1.1: an interface for copy-on-write of table def

### DIFF
--- a/pkg/frontend/compiler_context.go
+++ b/pkg/frontend/compiler_context.go
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
-
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"

--- a/pkg/frontend/compiler_context.go
+++ b/pkg/frontend/compiler_context.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -284,7 +286,7 @@ func (tcc *TxnCompilerContext) ResolveById(tableId uint64) (*plan2.ObjectRef, *p
 		ObjName:    tableName,
 		Obj:        int64(tableId),
 	}
-	tableDef := table.GetTableDef(txnCtx)
+	tableDef := table.CopyTableDef(txnCtx)
 	return obj, tableDef
 }
 
@@ -302,7 +304,7 @@ func (tcc *TxnCompilerContext) Resolve(dbName string, tableName string) (*plan2.
 	if err != nil {
 		return nil, nil
 	}
-	tableDef := table.GetTableDef(ctx)
+	tableDef := table.CopyTableDef(ctx)
 	if tableDef.IsTemporary {
 		tableDef.Name = tableName
 	}

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -123,7 +123,6 @@ func Test_mce(t *testing.T) {
 		}
 		create_1.EXPECT().GetAst().Return(stmts[0]).AnyTimes()
 		create_1.EXPECT().GetUUID().Return(make([]byte, 16)).AnyTimes()
-		create_1.EXPECT().SetDatabaseName(gomock.Any()).Return(nil).AnyTimes()
 		create_1.EXPECT().Compile(gomock.Any(), gomock.Any(), gomock.Any()).Return(runner, nil).AnyTimes()
 		create_1.EXPECT().Run(gomock.Any()).Return(nil, nil).AnyTimes()
 		create_1.EXPECT().GetLoadTag().Return(false).AnyTimes()
@@ -136,7 +135,6 @@ func Test_mce(t *testing.T) {
 		}
 		select_1.EXPECT().GetAst().Return(stmts[0]).AnyTimes()
 		select_1.EXPECT().GetUUID().Return(make([]byte, 16)).AnyTimes()
-		select_1.EXPECT().SetDatabaseName(gomock.Any()).Return(nil).AnyTimes()
 		select_1.EXPECT().Compile(gomock.Any(), gomock.Any(), gomock.Any()).Return(runner, nil).AnyTimes()
 		select_1.EXPECT().Run(gomock.Any()).Return(nil, nil).AnyTimes()
 		select_1.EXPECT().GetLoadTag().Return(false).AnyTimes()
@@ -214,7 +212,6 @@ func Test_mce(t *testing.T) {
 			convey.So(err, convey.ShouldBeNil)
 			select_2.EXPECT().GetAst().Return(stmts[0]).AnyTimes()
 			select_2.EXPECT().GetUUID().Return(make([]byte, 16)).AnyTimes()
-			select_2.EXPECT().SetDatabaseName(gomock.Any()).Return(nil).AnyTimes()
 			select_2.EXPECT().Compile(gomock.Any(), gomock.Any(), gomock.Any()).Return(runner, nil).AnyTimes()
 			select_2.EXPECT().Run(gomock.Any()).Return(nil, nil).AnyTimes()
 			select_2.EXPECT().GetLoadTag().Return(false).AnyTimes()

--- a/pkg/frontend/routine_test.go
+++ b/pkg/frontend/routine_test.go
@@ -126,7 +126,6 @@ var newMockWrapper = func(ctrl *gomock.Controller, ses *Session,
 	mcw := mock_frontend.NewMockComputationWrapper(ctrl)
 	mcw.EXPECT().GetAst().Return(stmt).AnyTimes()
 	mcw.EXPECT().GetProcess().Return(proc).AnyTimes()
-	mcw.EXPECT().SetDatabaseName(gomock.Any()).Return(nil).AnyTimes()
 	mcw.EXPECT().GetColumns().Return(columns, nil).AnyTimes()
 	mcw.EXPECT().Compile(gomock.Any(), gomock.Any(), gomock.Any()).Return(runner, nil).AnyTimes()
 	mcw.EXPECT().GetUUID().Return(uuid[:]).AnyTimes()

--- a/pkg/frontend/session_test.go
+++ b/pkg/frontend/session_test.go
@@ -574,6 +574,7 @@ func TestSession_TxnCompilerContext(t *testing.T) {
 		table.EXPECT().Ranges(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		table.EXPECT().TableDefs(gomock.Any()).Return(nil, nil).AnyTimes()
 		table.EXPECT().GetTableDef(gomock.Any()).Return(&plan.TableDef{}).AnyTimes()
+		table.EXPECT().CopyTableDef(gomock.Any()).Return(&plan.TableDef{}).AnyTimes()
 		table.EXPECT().GetPrimaryKeys(gomock.Any()).Return(nil, nil).AnyTimes()
 		table.EXPECT().GetHideKeys(gomock.Any()).Return(nil, nil).AnyTimes()
 		table.EXPECT().Stats(gomock.Any(), gomock.Any(), gomock.Any()).Return(false).AnyTimes()

--- a/pkg/frontend/test/engine_mock.go
+++ b/pkg/frontend/test/engine_mock.go
@@ -184,123 +184,6 @@ func (mr *MockConstraintMockRecorder) constraint() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "constraint", reflect.TypeOf((*MockConstraint)(nil).constraint))
 }
 
-// MockRanges is a mock of Ranges interface.
-type MockRanges struct {
-	ctrl     *gomock.Controller
-	recorder *MockRangesMockRecorder
-}
-
-// MockRangesMockRecorder is the mock recorder for MockRanges.
-type MockRangesMockRecorder struct {
-	mock *MockRanges
-}
-
-// NewMockRanges creates a new mock instance.
-func NewMockRanges(ctrl *gomock.Controller) *MockRanges {
-	mock := &MockRanges{ctrl: ctrl}
-	mock.recorder = &MockRangesMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRanges) EXPECT() *MockRangesMockRecorder {
-	return m.recorder
-}
-
-// Append mocks base method.
-func (m *MockRanges) Append(arg0 []byte) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Append", arg0)
-}
-
-// Append indicates an expected call of Append.
-func (mr *MockRangesMockRecorder) Append(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Append", reflect.TypeOf((*MockRanges)(nil).Append), arg0)
-}
-
-// GetAllBytes mocks base method.
-func (m *MockRanges) GetAllBytes() []byte {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllBytes")
-	ret0, _ := ret[0].([]byte)
-	return ret0
-}
-
-// GetAllBytes indicates an expected call of GetAllBytes.
-func (mr *MockRangesMockRecorder) GetAllBytes() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllBytes", reflect.TypeOf((*MockRanges)(nil).GetAllBytes))
-}
-
-// GetBytes mocks base method.
-func (m *MockRanges) GetBytes(i int) []byte {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBytes", i)
-	ret0, _ := ret[0].([]byte)
-	return ret0
-}
-
-// GetBytes indicates an expected call of GetBytes.
-func (mr *MockRangesMockRecorder) GetBytes(i interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBytes", reflect.TypeOf((*MockRanges)(nil).GetBytes), i)
-}
-
-// Len mocks base method.
-func (m *MockRanges) Len() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Len")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// Len indicates an expected call of Len.
-func (mr *MockRangesMockRecorder) Len() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockRanges)(nil).Len))
-}
-
-// SetBytes mocks base method.
-func (m *MockRanges) SetBytes(arg0 []byte) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetBytes", arg0)
-}
-
-// SetBytes indicates an expected call of SetBytes.
-func (mr *MockRangesMockRecorder) SetBytes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBytes", reflect.TypeOf((*MockRanges)(nil).SetBytes), arg0)
-}
-
-// Size mocks base method.
-func (m *MockRanges) Size() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Size")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// Size indicates an expected call of Size.
-func (mr *MockRangesMockRecorder) Size() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockRanges)(nil).Size))
-}
-
-// Slice mocks base method.
-func (m *MockRanges) Slice(i, j int) []byte {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Slice", i, j)
-	ret0, _ := ret[0].([]byte)
-	return ret0
-}
-
-// Slice indicates an expected call of Slice.
-func (mr *MockRangesMockRecorder) Slice(i, j interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Slice", reflect.TypeOf((*MockRanges)(nil).Slice), i, j)
-}
-
 // MockRelation is a mock of Relation interface.
 type MockRelation struct {
 	ctrl     *gomock.Controller
@@ -350,6 +233,20 @@ func (m *MockRelation) AlterTable(ctx context.Context, c *engine.ConstraintDef, 
 func (mr *MockRelationMockRecorder) AlterTable(ctx, c, constraint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AlterTable", reflect.TypeOf((*MockRelation)(nil).AlterTable), ctx, c, constraint)
+}
+
+// CopyTableDef mocks base method.
+func (m *MockRelation) CopyTableDef(arg0 context.Context) *plan.TableDef {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CopyTableDef", arg0)
+	ret0, _ := ret[0].(*plan.TableDef)
+	return ret0
+}
+
+// CopyTableDef indicates an expected call of CopyTableDef.
+func (mr *MockRelationMockRecorder) CopyTableDef(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyTableDef", reflect.TypeOf((*MockRelation)(nil).CopyTableDef), arg0)
 }
 
 // DelTableDef mocks base method.

--- a/pkg/frontend/test/types_mock.go
+++ b/pkg/frontend/test/types_mock.go
@@ -206,20 +206,6 @@ func (mr *MockComputationWrapperMockRecorder) Run(ts interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockComputationWrapper)(nil).Run), ts)
 }
 
-// SetDatabaseName mocks base method.
-func (m *MockComputationWrapper) SetDatabaseName(db string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDatabaseName", db)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetDatabaseName indicates an expected call of SetDatabaseName.
-func (mr *MockComputationWrapperMockRecorder) SetDatabaseName(db interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDatabaseName", reflect.TypeOf((*MockComputationWrapper)(nil).SetDatabaseName), db)
-}
-
 // MockColumnInfo is a mock of ColumnInfo interface.
 type MockColumnInfo struct {
 	ctrl     *gomock.Controller

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1370,8 +1370,12 @@ func (tbl *txnTable) GetTableDef(ctx context.Context) *plan.TableDef {
 		}
 	}
 	tableDef := plan2.DeepCopyTableDef(tbl.tableDef, true)
-	tableDef.IsTemporary = tbl.GetEngineType() == engine.Memory
 	return tableDef
+}
+
+func (tbl *txnTable) CopyTableDef(ctx context.Context) *plan.TableDef {
+	tbl.GetTableDef(ctx)
+	return plan2.DeepCopyTableDef(tbl.tableDef, true)
 }
 
 func (tbl *txnTable) UpdateConstraint(ctx context.Context, c *engine.ConstraintDef) error {
@@ -1536,7 +1540,7 @@ func (tbl *txnTable) TableRenameInTxn(ctx context.Context, constraint [][]byte) 
 	newtbl.defs = tbl.defs
 	newtbl.tableName = tbl.tableName
 	newtbl.tableId = tbl.tableId
-	newtbl.GetTableDef(ctx)
+	newtbl.CopyTableDef(ctx)
 
 	{
 		sql := getSql(ctx)

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1369,8 +1369,7 @@ func (tbl *txnTable) GetTableDef(ctx context.Context) *plan.TableDef {
 			Version:       tbl.version,
 		}
 	}
-	tableDef := plan2.DeepCopyTableDef(tbl.tableDef, true)
-	return tableDef
+	return tbl.tableDef
 }
 
 func (tbl *txnTable) CopyTableDef(ctx context.Context) *plan.TableDef {

--- a/pkg/vm/engine/memoryengine/table.go
+++ b/pkg/vm/engine/memoryengine/table.go
@@ -238,6 +238,9 @@ func (t *Table) TableDefs(ctx context.Context) ([]engine.TableDef, error) {
 	return defs, nil
 }
 
+func (t *Table) CopyTableDef(ctx context.Context) *plan.TableDef {
+	return t.GetTableDef(ctx)
+}
 func (t *Table) GetTableDef(ctx context.Context) *plan.TableDef {
 	engineDefs, err := t.TableDefs(ctx)
 	if err != nil {

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -578,6 +578,7 @@ type Relation interface {
 
 	// Get complete tableDef information, including columns, constraints, partitions, version, comments, etc
 	GetTableDef(context.Context) *plan.TableDef
+	CopyTableDef(context.Context) *plan.TableDef
 
 	GetPrimaryKeys(context.Context) ([]*Attribute, error)
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/14614

## What this PR does / why we need it:
the copy or not of table def should decided by users, this PR provides an interface for copy-on-write.