### PR TITLE
fix bug: get incorrect result for "in" expr  in some case (#14602)

### DIFF
--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -17,9 +17,10 @@ package vector
 import (
 	"bytes"
 	"fmt"
-	"slices"
 	"sort"
 	"unsafe"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"

--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -17,6 +17,8 @@ package vector
 import (
 	"bytes"
 	"fmt"
+	"slices"
+	"sort"
 	"unsafe"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -3284,6 +3286,286 @@ func (v *Vector) GetMinMaxValue() (ok bool, minv, maxv []byte) {
 		panic(fmt.Sprintf("unsupported type %s", v.GetType().String()))
 	}
 	return
+}
+
+// InplaceSortAndCompact @todo optimization in the future
+func (v *Vector) InplaceSortAndCompact() {
+	switch v.GetType().Oid {
+	case types.T_bool:
+		col := MustFixedCol[bool](v)
+		sort.Slice(col, func(i, j int) bool {
+			return !col[i] && col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_int8:
+		col := MustFixedCol[int8](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_int16:
+		col := MustFixedCol[int16](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_int32:
+		col := MustFixedCol[int32](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_int64:
+		col := MustFixedCol[int64](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_uint8:
+		col := MustFixedCol[uint8](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_uint16:
+		col := MustFixedCol[uint16](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_uint32:
+		col := MustFixedCol[uint32](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_uint64:
+		col := MustFixedCol[uint64](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_float32:
+		col := MustFixedCol[float32](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_float64:
+		col := MustFixedCol[float64](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_date:
+		col := MustFixedCol[types.Date](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_datetime:
+		col := MustFixedCol[types.Datetime](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_time:
+		col := MustFixedCol[types.Time](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_timestamp:
+		col := MustFixedCol[types.Timestamp](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_enum:
+		col := MustFixedCol[types.Enum](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i] < col[j]
+		})
+		newCol := slices.Compact(col)
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_decimal64:
+		col := MustFixedCol[types.Decimal64](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i].Less(col[j])
+		})
+		newCol := slices.CompactFunc(col, func(a, b types.Decimal64) bool {
+			return a.Compare(b) == 0
+		})
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_decimal128:
+		col := MustFixedCol[types.Decimal128](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i].Less(col[j])
+		})
+		newCol := slices.CompactFunc(col, func(a, b types.Decimal128) bool {
+			return a.Compare(b) == 0
+		})
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_TS:
+		col := MustFixedCol[types.TS](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i].Less(col[j])
+		})
+		newCol := slices.CompactFunc(col, func(a, b types.TS) bool {
+			return a.Equal(b)
+		})
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_uuid:
+		col := MustFixedCol[types.Uuid](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i].Lt(col[j])
+		})
+		newCol := slices.CompactFunc(col, func(a, b types.Uuid) bool {
+			return a.Compare(b) == 0
+		})
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+	case types.T_Rowid:
+		col := MustFixedCol[types.Rowid](v)
+		sort.Slice(col, func(i, j int) bool {
+			return col[i].Less(col[j])
+		})
+		newCol := slices.CompactFunc(col, func(a, b types.Rowid) bool {
+			return a.Equal(b)
+		})
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+
+	case types.T_char, types.T_varchar, types.T_json, types.T_binary, types.T_varbinary, types.T_blob, types.T_text:
+		col, area := MustVarlenaRawData(v)
+		sort.Slice(col, func(i, j int) bool {
+			return bytes.Compare(col[i].GetByteSlice(area), col[j].GetByteSlice(area)) < 0
+		})
+		newCol := slices.CompactFunc(col, func(a, b types.Varlena) bool {
+			return bytes.Equal(a.GetByteSlice(area), b.GetByteSlice(area))
+		})
+		if len(newCol) != len(col) {
+			v.CleanOnlyData()
+			v.SetSorted(true)
+			appendList(v, newCol, nil, nil)
+		}
+	}
 }
 
 func BuildVarlenaInline(v1, v2 *types.Varlena) {

--- a/pkg/sql/plan/rule/constant_fold.go
+++ b/pkg/sql/plan/rule/constant_fold.go
@@ -91,7 +91,8 @@ func (r *ConstantFold) constantFold(e *plan.Expr, proc *process.Process) *plan.E
 			}
 			defer vec.Free(proc.Mp())
 
-			colexec.SortInFilter(vec)
+			vec.InplaceSortAndCompact()
+
 			data, err := vec.MarshalBinary()
 			if err != nil {
 				return e

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1111,7 +1111,7 @@ func ConstantFold(bat *batch.Batch, e *plan.Expr, proc *process.Process, varAndP
 		}
 		defer vec.Free(proc.Mp())
 
-		colexec.SortInFilter(vec)
+		vec.InplaceSortAndCompact()
 		data, err := vec.MarshalBinary()
 		if err != nil {
 			return nil, err

--- a/test/distributed/cases/dml/select/select.result
+++ b/test/distributed/cases/dml/select/select.result
@@ -467,3 +467,24 @@ select 1 > 0;
 true
 SELECT TABLE_SCHEMA AS TABLE_CAT, NULL AS TABLE_SCHEM, TABLE_NAME, CASE WHEN TABLE_TYPE='BASE TABLE' THEN CASE WHEN TABLE_SCHEMA = 'mysql' OR TABLE_SCHEMA = 'performance_schema' THEN 'SYSTEM TABLE' ELSE 'TABLE' END WHEN TABLE_TYPE='TEMPORARY' THEN 'LOCAL_TEMPORARY' ELSE TABLE_TYPE END AS TABLE_TYPE, TABLE_COMMENT AS REMARKS, NULL AS TYPE_CAT, NULL AS TYPE_SCHEM, NULL AS TYPE_NAME, NULL AS SELF_REFERENCING_COL_NAME, NULL AS REF_GENERATION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'abc' group by null HAVING TABLE_TYPE IN ('LOCAL TEMPORARY','TABLE','VIEW',null,null) ORDER BY TABLE_TYPE, TABLE_SCHEMA, TABLE_NAME;
 internal error: Invalid GROUP BY NULL
+use db1;
+drop table if exists t11;
+create table t11 (a int, b int, primary key (a));
+insert into t11 (select *,* from generate_series(1, 50000, 1)g);
+select count(*) from t11 where a=20000;
+count(*)
+1
+select count(*) from t11 where a in (1,20000);
+count(*)
+2
+drop table if exists t1;
+create table t1(a int primary key, b int);
+insert into t1 values (1,1),(2,2),(3,3);
+select mo_ctl('dn', 'flush', 'select.t1');
+mo_ctl(dn, flush, select.t1)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select * from t1 where a in (3,3,3,2,1);
+a    b
+1    1
+2    2
+3    3

--- a/test/distributed/cases/dml/select/select.test
+++ b/test/distributed/cases/dml/select/select.test
@@ -249,3 +249,17 @@ select count(*) from t1 where a = null;
 select 1 > 0;
 
 SELECT TABLE_SCHEMA AS TABLE_CAT, NULL AS TABLE_SCHEM, TABLE_NAME, CASE WHEN TABLE_TYPE='BASE TABLE' THEN CASE WHEN TABLE_SCHEMA = 'mysql' OR TABLE_SCHEMA = 'performance_schema' THEN 'SYSTEM TABLE' ELSE 'TABLE' END WHEN TABLE_TYPE='TEMPORARY' THEN 'LOCAL_TEMPORARY' ELSE TABLE_TYPE END AS TABLE_TYPE, TABLE_COMMENT AS REMARKS, NULL AS TYPE_CAT, NULL AS TYPE_SCHEM, NULL AS TYPE_NAME, NULL AS SELF_REFERENCING_COL_NAME, NULL AS REF_GENERATION FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'abc' group by null HAVING TABLE_TYPE IN ('LOCAL TEMPORARY','TABLE','VIEW',null,null) ORDER BY TABLE_TYPE, TABLE_SCHEMA, TABLE_NAME;
+
+use db1;
+drop table if exists t11;
+create table t11 (a int, b int, primary key (a));
+insert into t11 (select *,* from generate_series(1, 50000, 1)g);
+select count(*) from t11 where a=20000;
+select count(*) from t11 where a in (1,20000);
+
+drop table if exists t1;
+create table t1(a int primary key, b int);
+insert into t1 values (1,1),(2,2),(3,3);
+-- @separator:table
+select mo_ctl('dn', 'flush', 'select.t1');
+select * from t1 where a in (3,3,3,2,1);


### PR DESCRIPTION
fix bug: get incorrect result for "in" expr  in some case.

bug case:
```sql
drop table if exists t1;
create table t1(a int primary key, b int);
insert into t1 values (1,1),(2,2),(3,3);
select mo_ctl('dn', 'flush', 'select.t1');
select * from t1 where a in (3,3,3,2,1);
-- here, we should get 3 rows. but 5 rows now
```

Approved by: @badboynt1, @XuPeng-SH, @nnsgmsone, @heni02, @aunjgr

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/2533

## What this PR does / why we need it:
cherry pick 14602 to 1.0