### PR TITLE
logtailreplay: tune btree degree to lower allocations

### DIFF
--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -280,7 +280,7 @@ func (b ObjectIndexByTSEntry) Less(than ObjectIndexByTSEntry) bool {
 
 func NewPartitionState(noData bool) *PartitionState {
 	opts := btree.Options{
-		Degree: 4,
+		Degree: 64,
 	}
 	return &PartitionState{
 		noData:                noData,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12820

## What this PR does / why we need it:
use a larger degree to reduce node allocations