### PR TITLE
disttae: call packer.FreeMem in pool reset function

### DIFF
--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -96,8 +96,10 @@ func New(
 			},
 			func(packer *types.Packer) {
 				packer.Reset()
+				packer.FreeMem()
 			},
 			func(packer *types.Packer) {
+				packer.Reset()
 				packer.FreeMem()
 			},
 		),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14086 

## What this PR does / why we need it:
free packer memory