### PR TITLE
1.1: check nil vector before flushing blk & print w-w detail in pessimistic mode

### DIFF
--- a/pkg/vm/engine/tae/common/print.go
+++ b/pkg/vm/engine/tae/common/print.go
@@ -176,7 +176,7 @@ func TypeStringValue(t types.Type, v any, isNull bool, opts ...TypePrintOpt) str
 	}
 }
 
-func vec2Str[T any](vec []T, v *vector.Vector) string {
+func vec2Str[T any](vec []T, v *vector.Vector, opts ...TypePrintOpt) string {
 	var w bytes.Buffer
 	_, _ = w.WriteString(fmt.Sprintf("[%d]: ", v.Length()))
 	first := true
@@ -187,14 +187,14 @@ func vec2Str[T any](vec []T, v *vector.Vector) string {
 		if v.GetNulls().Contains(uint64(i)) {
 			_, _ = w.WriteString(TypeStringValue(*v.GetType(), nil, true))
 		} else {
-			_, _ = w.WriteString(TypeStringValue(*v.GetType(), vec[i], false, WithDoNotPrintBin{}))
+			_, _ = w.WriteString(TypeStringValue(*v.GetType(), vec[i], false, opts...))
 		}
 		first = false
 	}
 	return w.String()
 }
 
-func MoVectorToString(v *vector.Vector, printN int) string {
+func MoVectorToString(v *vector.Vector, printN int, opts ...TypePrintOpt) string {
 	switch v.GetType().Oid {
 	case types.T_bool:
 		return vec2Str(vector.MustFixedCol[bool](v)[:printN], v)
@@ -242,7 +242,7 @@ func MoVectorToString(v *vector.Vector, printN int) string {
 		return vec2Str(vector.MustFixedCol[types.Blockid](v)[:printN], v)
 	}
 	if v.GetType().IsVarlen() {
-		return vec2Str(vector.MustBytesCol(v)[:printN], v)
+		return vec2Str(vector.MustBytesCol(v)[:printN], v, opts...)
 	}
 	return fmt.Sprintf("unkown type vec... %v", *v.GetType())
 }
@@ -254,7 +254,7 @@ func MoBatchToString(moBat *batch.Batch, printN int) string {
 	}
 	buf := new(bytes.Buffer)
 	for i, vec := range moBat.Vecs {
-		fmt.Fprintf(buf, "[%v] = %v\n", moBat.Attrs[i], MoVectorToString(vec, n))
+		fmt.Fprintf(buf, "[%v] = %v\n", moBat.Attrs[i], MoVectorToString(vec, n, WithDoNotPrintBin{}))
 	}
 	return buf.String()
 }

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -783,6 +783,7 @@ func relaseFlushDelTask(task *flushDeletesTask, err error) {
 func releaseFlushBlkTasks(subtasks []*flushBlkTask, err error) {
 	if err != nil {
 		logutil.Infof("[FlushTabletail] release flush ablk bat because of err %v", err)
+		// add a timeout to avoid WaitDone block the whole process
 		ictx, cancel := context.WithTimeout(
 			context.Background(),
 			10*time.Second, /*6*time.Minute,*/

--- a/pkg/vm/engine/tae/tables/jobs/flushblk.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushblk.go
@@ -91,7 +91,14 @@ func (task *flushBlkTask) Execute(ctx context.Context) (err error) {
 		writer.SetSortKey(uint16(task.meta.GetSchema().GetSingleSortKeyIdx()))
 	}
 
-	_, err = writer.WriteBatch(containers.ToCNBatch(task.data))
+	cnBatch := containers.ToCNBatch(task.data)
+	for _, vec := range cnBatch.Vecs {
+		if vec == nil {
+			// this task has been canceled
+			return nil
+		}
+	}
+	_, err = writer.WriteBatch(cnBatch)
 	if err != nil {
 		return err
 	}

--- a/pkg/vm/engine/tae/tables/jobs/flushdeletes.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushdeletes.go
@@ -57,7 +57,14 @@ func (task *flushDeletesTask) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, err = writer.WriteTombstoneBatch(containers.ToCNBatch(task.delta))
+	cnBatch := containers.ToCNBatch(task.delta)
+	for _, vec := range cnBatch.Vecs {
+		if vec == nil {
+			// this task has been canceled
+			return nil
+		}
+	}
+	_, err = writer.WriteTombstoneBatch(cnBatch)
 	if err != nil {
 		return err
 	}

--- a/pkg/vm/engine/tae/txn/txnimpl/table.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table.go
@@ -783,6 +783,16 @@ func (tbl *txnTable) RangeDelete(
 				start,
 				end,
 				err)
+			if tbl.store.rt.Options.IncrementalDedup && moerr.IsMoErrCode(err, moerr.ErrTxnWWConflict) {
+				logutil.Warnf("[txn%X,ts=%s]: table-%d blk-%s delete rows [%d,%d] pk %s",
+					tbl.store.txn.GetID(),
+					tbl.store.txn.GetStartTS().ToString(),
+					id.TableID,
+					id.BlockID.String(),
+					start, end,
+					pk.PPString(int(start-end+1)),
+				)
+			}
 		}
 	}()
 	if tbl.tableSpace != nil && id.ObjectID().Eq(tbl.tableSpace.entry.ID) {


### PR DESCRIPTION




Approved by: @XuPeng-SH

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14576 

## What this PR does / why we need it:

- skip the async flush task if the root task encounters an error