### PR TITLE
sync to 1.1: adding detailed phased trace in the TN commit routine helps us catch the time killer when TN commits.

### DIFF
--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
@@ -44,7 +44,6 @@ func (c *DashboardCreator) initTxnDashboard() error {
 			c.initTxnOnPrepareWALRow(),
 			c.initTxnBeforeCommitRow(),
 			c.initTxnDequeuePreparedRow(),
-			c.initTxnDequeuePreparingRow(),
 			c.initTxnRangesLoadedObjectMetaRow(),
 			c.initTxnShowAccountsRow(),
 			c.initCNCommittedObjectQuantityRow(),
@@ -191,36 +190,25 @@ func (c *DashboardCreator) initTxnOnPrepareWALRow() dashboard.Option {
 		"txn on prepare wal duration",
 		c.getMultiHistogram(
 			[]string{
-				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_total"`),
-				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_prepare_wal"`),
-				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_end_prepare"`),
-				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_flush_queue"`),
-				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="on_prepare_wal_get_prepare_ts"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="1-PreparingWait"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="2-Preparing"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="3-PrepareWalWait"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="4-PrepareWal"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="5-PreparedWait"`),
+				c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="6-Prepared"`),
 			},
 			[]string{
-				"total",
-				"prepare wal",
-				"end prepare",
-				"enqueue flush",
-				"get prepare ts",
+				"1-PreparingWait",
+				"2-Preparing",
+				"3-PrepareWalWait",
+				"4-PrepareWal",
+				"5-PreparedWait",
+				"6-Prepared",
 			},
 			[]float64{0.80, 0.90, 0.95, 0.99},
 			[]float32{3, 3, 3, 3},
 			axis.Unit("s"),
 			axis.Min(0))...,
-	)
-}
-
-func (c *DashboardCreator) initTxnDequeuePreparingRow() dashboard.Option {
-	return dashboard.Row(
-		"txn dequeue preparing duration",
-		c.getHistogram(
-			"txn dequeue preparing duration",
-			c.getMetricWithFilter("mo_txn_tn_side_duration_seconds_bucket", `step="dequeue_preparing"`),
-			[]float64{0.50, 0.8, 0.90, 0.99},
-			12,
-			axis.Unit("s"),
-			axis.Min(0)),
 	)
 }
 

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -252,15 +252,15 @@ var (
 			Buckets:   getDurationBuckets(),
 		}, []string{"step"})
 
-	TxnOnPrepareWALPrepareWALDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_prepare_wal")
-	TxnOnPrepareWALEndPrepareDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_end_prepare")
-	TxnOnPrepareWALFlushQueueDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_flush_queue")
-	TxnOnPrepareWALTotalDurationHistogram      = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_total")
-	TxnOnPrepareWALGetPrepareTSHistogram       = txnTNSideDurationHistogram.WithLabelValues("on_prepare_wal_get_prepare_ts")
+	TxnPreparingWaitDurationHistogram  = txnTNSideDurationHistogram.WithLabelValues("1-PreparingWait")
+	TxnPreparingDurationHistogram      = txnTNSideDurationHistogram.WithLabelValues("2-Preparing")
+	TxnPrepareWalWaitDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("3-PrepareWalWait")
+	TxnPrepareWalDurationHistogram     = txnTNSideDurationHistogram.WithLabelValues("4-PrepareWal")
+	TxnPreparedWaitDurationHistogram   = txnTNSideDurationHistogram.WithLabelValues("5-PreparedWait")
+	TxnPreparedDurationHistogram       = txnTNSideDurationHistogram.WithLabelValues("6-Prepared")
 
-	TxnDequeuePreparingDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("dequeue_preparing")
-	TxnDequeuePreparedDurationHistogram  = txnTNSideDurationHistogram.WithLabelValues("dequeue_prepared")
-	TxnBeforeCommitDurationHistogram     = txnTNSideDurationHistogram.WithLabelValues("before_txn_commit")
+	TxnDequeuePreparedDurationHistogram = txnTNSideDurationHistogram.WithLabelValues("dequeue_prepared")
+	TxnBeforeCommitDurationHistogram    = txnTNSideDurationHistogram.WithLabelValues("before_txn_commit")
 
 	txnMpoolDurationHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/pkg/vm/engine/tae/iface/txnif/consts.go
+++ b/pkg/vm/engine/tae/iface/txnif/consts.go
@@ -86,3 +86,12 @@ const (
 	PreApplyCommitPhase = "Phase_PreApplyCommit"
 	ApplyCommitPhase    = "Phase_ApplyCommit"
 )
+
+const (
+	TraceStart = iota
+	TracePreparing
+	TracePrepareWalWait
+	TracePrepareWal
+	TracePreapredWait
+	TracePrepared
+)

--- a/pkg/vm/engine/tae/iface/txnif/types.go
+++ b/pkg/vm/engine/tae/iface/txnif/types.go
@@ -243,8 +243,15 @@ type DeleteNode interface {
 	OnApply() error
 }
 
+type Tracer interface {
+	StartTrace()
+	TriggerTrace(state uint8)
+	EndTrace()
+}
+
 type TxnStore interface {
 	io.Closer
+	Tracer
 	Txn2PC
 	TxnUnsafe
 	WaitPrepared(ctx context.Context) error

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/appender.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/appender.go
@@ -16,6 +16,7 @@ package logservicedriver
 
 import (
 	"context"
+	gotrace "runtime/trace"
 	"sync"
 	"time"
 
@@ -46,9 +47,11 @@ func (a *driverAppender) appendEntry(e *entry.Entry) {
 }
 
 func (a *driverAppender) append(retryTimout, appendTimeout time.Duration) {
+	_, task := gotrace.NewTask(context.Background(), "logservice.append")
 	start := time.Now()
 	defer func() {
 		v2.LogTailAppendDurationHistogram.Observe(time.Since(start).Seconds())
+		task.End()
 	}()
 
 	size := a.entry.prepareRecord()

--- a/pkg/vm/engine/tae/txn/txnbase/impl.go
+++ b/pkg/vm/engine/tae/txn/txnbase/impl.go
@@ -58,6 +58,7 @@ func (txn *Txn) commit1PC(ctx context.Context, _ bool) (err error) {
 	}
 	txn.Add(1)
 	if err = txn.Freeze(); err == nil {
+		txn.GetStore().StartTrace()
 		err = txn.Mgr.OnOpTxn(&OpTxn{
 			ctx: ctx,
 			Txn: txn,

--- a/pkg/vm/engine/tae/txn/txnbase/store.go
+++ b/pkg/vm/engine/tae/txn/txnbase/store.go
@@ -30,6 +30,10 @@ var NoopStoreFactory = func() txnif.TxnStore { return new(NoopTxnStore) }
 
 type NoopTxnStore struct{}
 
+func (store *NoopTxnStore) StartTrace()        {}
+func (store *NoopTxnStore) TriggerTrace(uint8) {}
+func (store *NoopTxnStore) EndTrace()          {}
+
 func (store *NoopTxnStore) Freeze() error                                { return nil }
 func (store *NoopTxnStore) WaitPrepared(ctx context.Context) (err error) { return }
 func (store *NoopTxnStore) GetLSN() uint64                               { return 0 }

--- a/pkg/vm/engine/tae/txn/txnbase/txn.go
+++ b/pkg/vm/engine/tae/txn/txnbase/txn.go
@@ -315,6 +315,7 @@ func (txn *Txn) DoneWithErr(err error, isAbort bool) {
 		return
 	}
 	txn.done1PCWithErr(err)
+	txn.GetStore().EndTrace()
 }
 
 func (txn *Txn) PrepareCommit() (err error) {

--- a/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
+++ b/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
@@ -484,7 +484,7 @@ func (mgr *TxnManager) dequeuePreparing(items ...any) {
 		op := item.(*OpTxn)
 		store := op.Txn.GetStore()
 		store.TriggerTrace(txnif.TracePreparing)
-		t0 := time.Now()
+
 		// Idempotent check
 		if state := op.Txn.GetTxnState(false); state != txnif.TxnStateActive {
 			op.Txn.WaitDone(moerr.NewTxnNotActiveNoCtx(txnif.TxnStrState(state)), false)
@@ -519,8 +519,6 @@ func (mgr *TxnManager) dequeuePreparing(items ...any) {
 		if err := mgr.EnqueueFlushing(op); err != nil {
 			panic(err)
 		}
-
-		v2.TxnDequeuePreparingDurationHistogram.Observe(time.Since(t0).Seconds())
 	}
 	common.DoIfDebugEnabled(func() {
 		logutil.Debug("[dequeuePreparing]",
@@ -545,7 +543,6 @@ func (mgr *TxnManager) onPrepareWAL(items ...any) {
 			}
 
 			t2 = time.Now()
-			v2.TxnOnPrepareWALPrepareWALDurationHistogram.Observe(t2.Sub(t1).Seconds())
 
 			if !op.Txn.IsReplay() {
 				if !mgr.prevPrepareTSInPrepareWAL.IsEmpty() {
@@ -558,8 +555,6 @@ func (mgr *TxnManager) onPrepareWAL(items ...any) {
 
 			mgr.CommitListener.OnEndPrepareWAL(op.Txn)
 			t3 = time.Now()
-
-			v2.TxnOnPrepareWALEndPrepareDurationHistogram.Observe(t3.Sub(t2).Seconds())
 		}
 
 		t4 = time.Now()
@@ -568,7 +563,6 @@ func (mgr *TxnManager) onPrepareWAL(items ...any) {
 			panic(err)
 		}
 		t5 = time.Now()
-		v2.TxnOnPrepareWALFlushQueueDurationHistogram.Observe(t5.Sub(t4).Seconds())
 
 		if t5.Sub(t1) > time.Second {
 			logutil.Warn(
@@ -579,7 +573,6 @@ func (mgr *TxnManager) onPrepareWAL(items ...any) {
 				zap.Duration("enqueue-flush-duration", t5.Sub(t4)),
 			)
 		}
-		v2.TxnOnPrepareWALTotalDurationHistogram.Observe(t5.Sub(t1).Seconds())
 	}
 	common.DoIfDebugEnabled(func() {
 		logutil.Debug("[prepareWAL]",

--- a/pkg/vm/engine/tae/txn/txnimpl/store.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/store.go
@@ -68,36 +68,37 @@ type txnTracer struct {
 func (tracer *txnTracer) Trigger(state uint8) {
 	switch state {
 	case 0: // start preparing wait
-		_, tracer.task = trace.NewTask(context.Background(), "PreparingWait")
+		_, tracer.task = trace.NewTask(context.Background(), "1-PreparingWait")
+		tracer.state = 0
 	case 1: // end preparing wait and start preparing
 		if tracer.task != nil && tracer.state == 0 {
 			tracer.task.End()
 		}
-		_, tracer.task = trace.NewTask(context.Background(), "Preparing")
+		_, tracer.task = trace.NewTask(context.Background(), "2-Preparing")
 		tracer.state = 1
 	case 2: // end preparing and start prepare wal wait
 		if tracer.task != nil && tracer.state == 1 {
 			tracer.task.End()
 		}
-		_, tracer.task = trace.NewTask(context.Background(), "PrepareWalWait")
+		_, tracer.task = trace.NewTask(context.Background(), "3-PrepareWalWait")
 		tracer.state = 2
 	case 3: // end prepare wal wait and start prepare wal
 		if tracer.task != nil && tracer.state == 2 {
 			tracer.task.End()
 		}
-		_, tracer.task = trace.NewTask(context.Background(), "PrepareWal")
+		_, tracer.task = trace.NewTask(context.Background(), "4-PrepareWal")
 		tracer.state = 3
 	case 4: // end prepare wal and start prepared wait
 		if tracer.task != nil && tracer.state == 3 {
 			tracer.task.End()
 		}
-		_, tracer.task = trace.NewTask(context.Background(), "PreparedWait")
+		_, tracer.task = trace.NewTask(context.Background(), "5-PreparedWait")
 		tracer.state = 4
 	case 5: // end prepared wait and start prepared
 		if tracer.task != nil && tracer.state == 4 {
 			tracer.task.End()
 		}
-		_, tracer.task = trace.NewTask(context.Background(), "Prepared")
+		_, tracer.task = trace.NewTask(context.Background(), "6-Prepared")
 		tracer.state = 5
 	}
 }
@@ -166,7 +167,7 @@ func (store *txnStore) StartTrace() {
 		return
 	}
 	store.tracer = getTracer()
-	store.tracer.Trigger(0)
+	store.tracer.Trigger(txnif.TraceStart)
 }
 
 func (store *txnStore) EndTrace() {
@@ -175,6 +176,7 @@ func (store *txnStore) EndTrace() {
 	}
 	tracer := store.tracer
 	store.tracer = nil
+	tracer.Stop()
 	putTracer(tracer)
 }
 

--- a/pkg/vm/engine/tae/txn/txnimpl/store.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/store.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
-	"github.com/matrixorigin/matrixone/pkg/util/trace"
+	motrace "github.com/matrixorigin/matrixone/pkg/util/trace"
 	"go.uber.org/zap"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -762,7 +762,7 @@ func (store *txnStore) ApplyCommit() (err error) {
 	now := time.Now()
 	defer func() {
 		applyCommitDuration := time.Since(now)
-		_, enable, threshold := trace.IsMOCtledSpan(trace.SpanKindTNRPCHandle)
+		_, enable, threshold := motrace.IsMOCtledSpan(motrace.SpanKindTNRPCHandle)
 		if enable && applyCommitDuration > threshold && store.GetContext() != nil {
 			store.SetContext(context.WithValue(store.GetContext(), common.StoreApplyCommit, &common.DurationRecords{Duration: applyCommitDuration}))
 		}
@@ -796,7 +796,7 @@ func (store *txnStore) PrePrepare(ctx context.Context) (err error) {
 	now := time.Now()
 	defer func() {
 		prePrepareDuration := time.Since(now)
-		_, enable, threshold := trace.IsMOCtledSpan(trace.SpanKindTNRPCHandle)
+		_, enable, threshold := motrace.IsMOCtledSpan(motrace.SpanKindTNRPCHandle)
 		if enable && prePrepareDuration > threshold && store.GetContext() != nil {
 			store.SetContext(context.WithValue(store.GetContext(), common.StorePrePrepare, &common.DurationRecords{Duration: prePrepareDuration}))
 		}
@@ -814,7 +814,7 @@ func (store *txnStore) PrepareCommit() (err error) {
 	now := time.Now()
 	defer func() {
 		prepareCommitDuration := time.Since(now)
-		_, enable, threshold := trace.IsMOCtledSpan(trace.SpanKindTNRPCHandle)
+		_, enable, threshold := motrace.IsMOCtledSpan(motrace.SpanKindTNRPCHandle)
 		if enable && prepareCommitDuration > threshold && store.GetContext() != nil {
 			store.SetContext(context.WithValue(store.GetContext(), common.StorePreApplyCommit, &common.DurationRecords{Duration: prepareCommitDuration}))
 		}
@@ -843,7 +843,7 @@ func (store *txnStore) PreApplyCommit() (err error) {
 		}
 	}
 	preApplyCommitDuration := time.Since(now)
-	_, enable, threshold := trace.IsMOCtledSpan(trace.SpanKindTNRPCHandle)
+	_, enable, threshold := motrace.IsMOCtledSpan(motrace.SpanKindTNRPCHandle)
 	if enable && preApplyCommitDuration > threshold && store.GetContext() != nil {
 		store.SetContext(context.WithValue(store.GetContext(), common.StorePreApplyCommit, &common.DurationRecords{Duration: preApplyCommitDuration}))
 	}

--- a/pkg/vm/engine/tae/txn/txnimpl/store.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/store.go
@@ -16,7 +16,6 @@ package txnimpl
 
 import (
 	"context"
-	"fmt"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"runtime/trace"
 	"sync"
@@ -126,7 +125,6 @@ func (tracer *txnTracer) Stop() {
 	if tracer.task != nil && tracer.state == 5 {
 		tracer.task.End()
 		v2.TxnPreparedDurationHistogram.Observe(time.Since(tracer.stamp).Seconds())
-		fmt.Println("Prepared")
 	}
 	tracer.task = nil
 	tracer.state = 0

--- a/pkg/vm/engine/tae/txn/txnimpl/store.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/store.go
@@ -16,6 +16,8 @@ package txnimpl
 
 import (
 	"context"
+	"fmt"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"runtime/trace"
 	"sync"
 	"sync/atomic"
@@ -63,42 +65,59 @@ func putTracer(tracer *txnTracer) {
 type txnTracer struct {
 	state uint8
 	task  *trace.Task
+	stamp time.Time
 }
 
 func (tracer *txnTracer) Trigger(state uint8) {
 	switch state {
 	case 0: // start preparing wait
 		_, tracer.task = trace.NewTask(context.Background(), "1-PreparingWait")
+		tracer.stamp = time.Now()
 		tracer.state = 0
+
 	case 1: // end preparing wait and start preparing
 		if tracer.task != nil && tracer.state == 0 {
 			tracer.task.End()
+			v2.TxnPreparingWaitDurationHistogram.Observe(time.Since(tracer.stamp).Seconds())
 		}
 		_, tracer.task = trace.NewTask(context.Background(), "2-Preparing")
+		tracer.stamp = time.Now()
 		tracer.state = 1
+
 	case 2: // end preparing and start prepare wal wait
 		if tracer.task != nil && tracer.state == 1 {
 			tracer.task.End()
+			v2.TxnPreparingDurationHistogram.Observe(time.Since(tracer.stamp).Seconds())
 		}
 		_, tracer.task = trace.NewTask(context.Background(), "3-PrepareWalWait")
+		tracer.stamp = time.Now()
 		tracer.state = 2
+
 	case 3: // end prepare wal wait and start prepare wal
 		if tracer.task != nil && tracer.state == 2 {
 			tracer.task.End()
+			v2.TxnPrepareWalWaitDurationHistogram.Observe(time.Since(tracer.stamp).Seconds())
 		}
 		_, tracer.task = trace.NewTask(context.Background(), "4-PrepareWal")
+		tracer.stamp = time.Now()
 		tracer.state = 3
+
 	case 4: // end prepare wal and start prepared wait
 		if tracer.task != nil && tracer.state == 3 {
 			tracer.task.End()
+			v2.TxnPrepareWalDurationHistogram.Observe(time.Since(tracer.stamp).Seconds())
 		}
 		_, tracer.task = trace.NewTask(context.Background(), "5-PreparedWait")
+		tracer.stamp = time.Now()
 		tracer.state = 4
+
 	case 5: // end prepared wait and start prepared
 		if tracer.task != nil && tracer.state == 4 {
 			tracer.task.End()
+			v2.TxnPreparedWaitDurationHistogram.Observe(time.Since(tracer.stamp).Seconds())
 		}
 		_, tracer.task = trace.NewTask(context.Background(), "6-Prepared")
+		tracer.stamp = time.Now()
 		tracer.state = 5
 	}
 }
@@ -106,6 +125,8 @@ func (tracer *txnTracer) Trigger(state uint8) {
 func (tracer *txnTracer) Stop() {
 	if tracer.task != nil && tracer.state == 5 {
 		tracer.task.End()
+		v2.TxnPreparedDurationHistogram.Observe(time.Since(tracer.stamp).Seconds())
+		fmt.Println("Prepared")
 	}
 	tracer.task = nil
 	tracer.state = 0


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/13987

## What this PR does / why we need it:
adding detailed phased trace in the TN commit routine helps us catch the time killer when TN commits.