### PR TITLE
optimize stats calculation for block filters

### DIFF
--- a/pkg/pb/statsinfo/shuffle.go
+++ b/pkg/pb/statsinfo/shuffle.go
@@ -219,7 +219,6 @@ func (s *ShuffleRange) Eval() {
 		}
 	}
 	s.Overlap /= float64(s.Sz) * float64(s.Sz)
-	s.Overlap = math.Sqrt(s.Overlap)
 
 	step := float64(s.Sz) / float64(k)
 	if float64(nulls) >= step {

--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -532,7 +532,7 @@ func shouldUseHashShuffle(s *pb.ShuffleRange) bool {
 	if s.Uniform > 0.3 {
 		return false
 	}
-	if s.Overlap > 0.6 {
+	if s.Overlap > 0.5 {
 		return true
 	}
 	return true

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"math"
 	"sort"
 	"strings"
@@ -36,7 +37,6 @@ import (
 )
 
 const BlockNumForceOneCN = 200
-const blockSelectivityThreshHold = 0.95
 const highNDVcolumnThreshHold = 0.95
 
 func NewStatsInfo() *pb.StatsInfo {
@@ -527,23 +527,22 @@ func estimateFilterWeight(expr *plan.Expr, w float64) float64 {
 }
 
 // harsh estimate of block selectivity, will improve it in the future
-func estimateFilterBlockSelectivity(ctx context.Context, expr *plan.Expr, tableDef *plan.TableDef) float64 {
+func estimateFilterBlockSelectivity(ctx context.Context, expr *plan.Expr, tableDef *plan.TableDef, s *pb.StatsInfo) float64 {
 	if !ExprIsZonemappable(ctx, expr) {
 		return 1
 	}
-	if expr.Selectivity < 0.01 {
-		return expr.Selectivity * 100
-	}
 	col := extractColRefInFilter(expr)
 	if col != nil {
+		blocksel := calcBlockSelectivityUsingShuffleRange(s.ShuffleRangeMap[col.Name], expr.Selectivity)
 		switch GetSortOrder(tableDef, col.ColPos) {
 		case 0:
-			return math.Min(expr.Selectivity, 0.5)
+			blocksel = math.Min(blocksel, 0.2)
 		case 1:
-			return math.Min(expr.Selectivity*3, 0.5)
+			return math.Min(blocksel, 0.5)
 		case 2:
-			return math.Min(expr.Selectivity*10, 0.5)
+			return math.Min(blocksel, 0.7)
 		}
+		return blocksel
 	}
 	return 1
 }
@@ -964,8 +963,8 @@ func calcScanStats(node *plan.Node, builder *QueryBuilder) *plan.Stats {
 	var blockExprList []*plan.Expr
 	for i := range node.FilterList {
 		node.FilterList[i].Selectivity = estimateExprSelectivity(node.FilterList[i], builder)
-		currentBlockSel := estimateFilterBlockSelectivity(builder.GetContext(), node.FilterList[i], node.TableDef)
-		if currentBlockSel < blockSelectivityThreshHold {
+		currentBlockSel := estimateFilterBlockSelectivity(builder.GetContext(), node.FilterList[i], node.TableDef, s)
+		if currentBlockSel < 1 {
 			copyOfExpr := DeepCopyExpr(node.FilterList[i])
 			copyOfExpr.Selectivity = currentBlockSel
 			blockExprList = append(blockExprList, copyOfExpr)
@@ -973,8 +972,7 @@ func calcScanStats(node *plan.Node, builder *QueryBuilder) *plan.Stats {
 		blockSel = andSelectivity(blockSel, currentBlockSel)
 	}
 	node.BlockFilterList = blockExprList
-	expr := rewriteFiltersForStats(node.FilterList, builder.compCtx.GetProcess())
-	stats.Selectivity = estimateExprSelectivity(expr, builder)
+	stats.Selectivity = estimateExprSelectivity(colexec.RewriteFilterExprList(node.FilterList), builder)
 	stats.Outcnt = stats.Selectivity * stats.TableCnt
 	stats.Cost = stats.TableCnt * blockSel
 	stats.BlockNum = int32(float64(s.BlockNumber)*blockSel) + 1
@@ -1178,4 +1176,15 @@ func DeepCopyStats(stats *plan.Stats) *plan.Stats {
 		Selectivity:  stats.Selectivity,
 		HashmapStats: hashmapStats,
 	}
+}
+
+func calcBlockSelectivityUsingShuffleRange(s *pb.ShuffleRange, sel float64) float64 {
+	if s == nil {
+		return 1
+	}
+	ret := sel * math.Pow(500, math.Pow(s.Overlap, 2))
+	if ret > 1 {
+		ret = 1
+	}
+	return ret
 }

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1054,14 +1054,6 @@ func GetSortOrder(tableDef *plan.TableDef, colPos int32) int {
 	return GetSortOrderByName(tableDef, colName)
 }
 
-// handle the filter list for Stats. rewrite and constFold
-func rewriteFiltersForStats(exprList []*plan.Expr, proc *process.Process) *plan.Expr {
-	if proc == nil {
-		return nil
-	}
-	return colexec.RewriteFilterExprList(exprList)
-}
-
 func ConstantFold(bat *batch.Batch, expr *plan.Expr, proc *process.Process, varAndParamIsConst bool) (*plan.Expr, error) {
 	// If it is Expr_List, perform constant folding on its elements
 	if elist := expr.GetList(); elist != nil {

--- a/pkg/vm/engine/disttae/stats.go
+++ b/pkg/vm/engine/disttae/stats.go
@@ -522,6 +522,12 @@ func getMinMaxValueByFloat64(typ types.Type, buf []byte) float64 {
 		return float64(types.DecodeUint64(buf))
 	case types.T_date:
 		return float64(types.DecodeDate(buf))
+	case types.T_time:
+		return float64(types.DecodeTime(buf))
+	case types.T_timestamp:
+		return float64(types.DecodeTimestamp(buf))
+	case types.T_datetime:
+		return float64(types.DecodeDatetime(buf))
 	//case types.T_char, types.T_varchar, types.T_text:
 	//return float64(plan2.ByteSliceToUint64(buf)), true
 	default:
@@ -568,7 +574,7 @@ func updateInfoFromZoneMap(ctx context.Context, req *updateStatsRequest, info *p
 					meta.BlockHeader().BFExtent().Length() + objColMeta.Location().Length())
 				if info.ColumnNDVs[idx] > 100 || info.ColumnNDVs[idx] > 0.1*float64(meta.BlockHeader().Rows()) {
 					switch info.DataTypes[idx].Oid {
-					case types.T_int64, types.T_int32, types.T_int16, types.T_uint64, types.T_uint32, types.T_uint16, types.T_bit:
+					case types.T_int64, types.T_int32, types.T_int16, types.T_uint64, types.T_uint32, types.T_uint16, types.T_time, types.T_timestamp, types.T_date, types.T_datetime:
 						info.ShuffleRanges[idx] = plan2.NewShuffleRange(false)
 						if info.ColumnZMs[idx].IsInited() {
 							minvalue := getMinMaxValueByFloat64(info.DataTypes[idx], info.ColumnZMs[idx].GetMinBuf())
@@ -597,7 +603,7 @@ func updateInfoFromZoneMap(ctx context.Context, req *updateStatsRequest, info *p
 				info.ColumnSize[idx] += int64(objColMeta.Location().Length())
 				if info.ShuffleRanges[idx] != nil {
 					switch info.DataTypes[idx].Oid {
-					case types.T_int64, types.T_int32, types.T_int16, types.T_uint64, types.T_uint32, types.T_uint16, types.T_bit:
+					case types.T_int64, types.T_int32, types.T_int16, types.T_uint64, types.T_uint32, types.T_uint16, types.T_time, types.T_timestamp, types.T_date, types.T_datetime:
 						minvalue := getMinMaxValueByFloat64(info.DataTypes[idx], zm.GetMinBuf())
 						maxvalue := getMinMaxValueByFloat64(info.DataTypes[idx], zm.GetMaxBuf())
 						info.ShuffleRanges[idx].Update(minvalue, maxvalue, int64(meta.BlockHeader().Rows()), int64(objColMeta.NullCnt()))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14682

## What this PR does / why we need it:
利用stats中shuffleRange字段来帮助计算block filter的过滤性。
当某一列数据分布比较均匀时，下推block filter去过滤zonemap效率会比较高。
当某一列数据接近正态分布时，下推block filter大概率不能过滤掉任何zonemap。