### PR TITLE
parallelize `getTableStats` when `show accounts`

### DIFF
--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -114,7 +114,7 @@ const (
 
 var cnUsageCache = logtail.NewStorageUsageCache(
 	logtail.WithLazyThreshold(5),
-	logtail.WithWorkers(runtime.NumCPU()))
+	logtail.WithWorkers(runtime.NumCPU()*2))
 
 func getSqlForAllAccountInfo(like *tree.ComparisonExpr) string {
 	var likePattern = ""
@@ -390,7 +390,7 @@ func getTableStatsParallel(
 	wg := sync.WaitGroup{}
 	var err error
 	var sqlResSet *MysqlResultSet
-	outCh := make(chan tableStatsResult)
+	outCh := make(chan tableStatsResult, 100)
 
 	accLen, totalNum := len(accountIds), 0
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2564

## What this PR does / why we need it:
one `getTableStats` execution may take 10ms to 100ms, and `show accounts` will spend 1s to10s with 100 accounts. this is even worse when MO has been high pressure.

this PR parallelized `getTableStats` making it 3x~5x faster than before.

however, `show accounts` still could exceed 30 seconds if there are more accounts and a high load.

cherry-pick to 1.1: https://github.com/matrixorigin/matrixone/pull/14718
