### PR TITLE
Revert the replace `StartTxnWithLatestTS` with `StartTxn`

### DIFF
--- a/pkg/vm/engine/tae/db/db.go
+++ b/pkg/vm/engine/tae/db/db.go
@@ -133,7 +133,11 @@ func (db *DB) StartTxn(info []byte) (txnif.AsyncTxn, error) {
 }
 
 func (db *DB) StartTxnWithLatestTS(info []byte) (txnif.AsyncTxn, error) {
+<<<<<<< HEAD
 	return db.TxnMgr.StartTxnWithLatestTS(info)
+=======
+	return db.TxnMgr.StartTxn(info)
+>>>>>>> parent of 5a247fb4b (ignore TestHandle_MVCCVisibility (#14694))
 }
 
 func (db *DB) CommitTxn(txn txnif.AsyncTxn) (err error) {

--- a/pkg/vm/engine/tae/db/db.go
+++ b/pkg/vm/engine/tae/db/db.go
@@ -132,6 +132,10 @@ func (db *DB) StartTxn(info []byte) (txnif.AsyncTxn, error) {
 	return db.TxnMgr.StartTxn(info)
 }
 
+func (db *DB) StartTxnWithLatestTS(info []byte) (txnif.AsyncTxn, error) {
+	return db.TxnMgr.StartTxnWithLatestTS(info)
+}
+
 func (db *DB) CommitTxn(txn txnif.AsyncTxn) (err error) {
 	return txn.Commit(context.Background())
 }

--- a/pkg/vm/engine/tae/db/db.go
+++ b/pkg/vm/engine/tae/db/db.go
@@ -133,11 +133,7 @@ func (db *DB) StartTxn(info []byte) (txnif.AsyncTxn, error) {
 }
 
 func (db *DB) StartTxnWithLatestTS(info []byte) (txnif.AsyncTxn, error) {
-<<<<<<< HEAD
 	return db.TxnMgr.StartTxnWithLatestTS(info)
-=======
-	return db.TxnMgr.StartTxn(info)
->>>>>>> parent of 5a247fb4b (ignore TestHandle_MVCCVisibility (#14694))
 }
 
 func (db *DB) CommitTxn(txn txnif.AsyncTxn) (err error) {

--- a/pkg/vm/engine/tae/db/task.go
+++ b/pkg/vm/engine/tae/db/task.go
@@ -48,7 +48,7 @@ func (task *ScheduledTxnTask) Scope() *common.ID {
 }
 
 func (task *ScheduledTxnTask) Execute(ctx context.Context) (err error) {
-	txn, err := task.db.TxnMgr.StartTxn(nil)
+	txn, err := task.db.TxnMgr.StartTxnWithLatestTS(nil)
 	if err != nil {
 		return
 	}

--- a/pkg/vm/engine/tae/db/test/tables_test.go
+++ b/pkg/vm/engine/tae/db/test/tables_test.go
@@ -683,7 +683,7 @@ func TestCompaction2(t *testing.T) {
 		return dirty.GetTree().Compact()
 	})
 	{
-		txn, _ := db.TxnMgr.StartTxn(nil)
+		txn, _ := db.TxnMgr.StartTxnWithLatestTS(nil)
 		database, _ := txn.GetDatabase("db")
 		rel, _ := database.GetRelationByName(schema.Name)
 		it := rel.MakeBlockIt()
@@ -698,7 +698,7 @@ func TestCompaction2(t *testing.T) {
 		}
 	}
 	{
-		txn, _ := db.TxnMgr.StartTxn(nil)
+		txn, _ := db.TxnMgr.StartTxnWithLatestTS(nil)
 		database, _ := txn.GetDatabase("db")
 		rel, _ := database.GetRelationByName(schema.Name)
 		it := rel.MakeBlockIt()

--- a/pkg/vm/engine/tae/rpc/rpc_test.go
+++ b/pkg/vm/engine/tae/rpc/rpc_test.go
@@ -1437,7 +1437,6 @@ func TestHandle_HandlePreCommit2PCForParticipant(t *testing.T) {
 }
 
 func TestHandle_MVCCVisibility(t *testing.T) {
-	t.Skip("debug later")
 	defer testutils.AfterTest(t)()
 	ctx := context.Background()
 	opts := config.WithLongScanAndCKPOpts(nil)
@@ -1500,7 +1499,7 @@ func TestHandle_MVCCVisibility(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		//start 1pc txn ,read "dbtest"'s ID
-		txn, err := handle.db.StartTxn(nil)
+		txn, err := handle.db.StartTxnWithLatestTS(nil)
 		assert.Nil(t, err)
 		//reader should wait until the writer committed.
 		dbNames = txn.DatabaseNames()
@@ -1588,7 +1587,7 @@ func TestHandle_MVCCVisibility(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		//start 1pc txn ,read table ID
-		txn, err := handle.db.StartTxn(nil)
+		txn, err := handle.db.StartTxnWithLatestTS(nil)
 		assert.Nil(t, err)
 		dbH, err := txn.GetDatabase(dbName)
 		assert.NoError(t, err)
@@ -1644,7 +1643,7 @@ func TestHandle_MVCCVisibility(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		//start 1PC txn , read table
-		txn, err := handle.db.StartTxn(nil)
+		txn, err := handle.db.StartTxnWithLatestTS(nil)
 		assert.NoError(t, err)
 		dbH, err := txn.GetDatabase(dbName)
 		assert.NoError(t, err)
@@ -1733,7 +1732,7 @@ func TestHandle_MVCCVisibility(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		//read, there should be 80 rows left.
-		txn, err := handle.db.StartTxn(nil)
+		txn, err := handle.db.StartTxnWithLatestTS(nil)
 		assert.NoError(t, err)
 		dbH, err := txn.GetDatabase(dbName)
 		assert.NoError(t, err)

--- a/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
+++ b/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
@@ -186,6 +186,25 @@ func (mgr *TxnManager) StartTxn(info []byte) (txn txnif.AsyncTxn, err error) {
 	return
 }
 
+// StartTxn starts a local transaction initiated by DN
+func (mgr *TxnManager) StartTxnWithLatestTS(info []byte) (txn txnif.AsyncTxn, err error) {
+	if exp := mgr.Exception.Load(); exp != nil {
+		err = exp.(error)
+		logutil.Warnf("StartTxn: %v", err)
+		return
+	}
+	mgr.Lock()
+	defer mgr.Unlock()
+	txnId := mgr.IdAlloc.Alloc()
+	startTs := mgr.TsAlloc.Alloc()
+
+	store := mgr.TxnStoreFactory()
+	txn = mgr.TxnFactory(mgr, store, txnId, startTs, types.TS{})
+	store.BindTxn(txn)
+	mgr.IDMap[string(txnId)] = txn
+	return
+}
+
 func (mgr *TxnManager) StartTxnWithStartTSAndSnapshotTS(
 	info []byte,
 	startTS, snapshotTS types.TS,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/14680

## What this PR does / why we need it:

Revert "clean all usage of the StartTxnWithLastestTs"