### PR TITLE
Fix memory leak caused by fuzzyfilter

### DIFF
--- a/pkg/sql/colexec/fuzzyfilter/types.go
+++ b/pkg/sql/colexec/fuzzyfilter/types.go
@@ -84,6 +84,9 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		arg.rbat.Clean(proc.GetMPool())
 		arg.rbat = nil
 	}
+	if arg.pass2RuntimeFilter != nil {
+		proc.PutVector(arg.pass2RuntimeFilter)
+	}
 
 	arg.FreeAllReg()
 }


### PR DESCRIPTION
free a vector that missed before

Approved by: @m-schen, @fengttt

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14081

## What this PR does / why we need it:
free a vector that missed before