### PR TITLE
sync to 1.1: fix the logic err in PrefixIn when vector unsorted

### DIFF
--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -129,7 +129,7 @@ func PrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, 
 		for i := range lcol {
 			lval := lcol[i].GetByteSlice(larea)
 			rpos, _ := sort.Find(len(rcol), func(j int) int {
-				return bytes.Compare(rcol[j].GetByteSlice(rarea), lval)
+				return index.PrefixCompare(lval, rcol[j].GetByteSlice(rarea))
 			})
 
 			res[i] = rpos < len(rcol) && bytes.HasPrefix(lval, rcol[rpos].GetByteSlice(rarea))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/14778

## What this PR does / why we need it:
see the issue for more details