### PR TITLE
Fix datarace

### DIFF
--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -889,7 +889,7 @@ func (txn *Transaction) getCachedTable(
 		}
 		val := txn.engine.catalog.GetSchemaVersion(tblKey)
 		if val != nil {
-			if val.Ts.Greater(tbl.lastTS) && val.Version != tbl.version {
+			if val.Ts.Greater(tbl.lastTs.Load().(timestamp.Timestamp)) && val.Version != tbl.version {
 				txn.tableCache.tableMap.Delete(genTableKey(k.accountId, k.name, k.databaseId))
 				return nil
 			}

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -889,7 +889,11 @@ func (txn *Transaction) getCachedTable(
 		}
 		val := txn.engine.catalog.GetSchemaVersion(tblKey)
 		if val != nil {
-			if val.Ts.Greater(tbl.lastTs.Load().(timestamp.Timestamp)) && val.Version != tbl.version {
+			lastTs := timestamp.Timestamp{}
+			if v := tbl.lastTs.Load(); v != nil {
+				lastTs = v.(timestamp.Timestamp)
+			}
+			if val.Ts.Greater(lastTs) && val.Version != tbl.version {
 				txn.tableCache.tableMap.Delete(genTableKey(k.accountId, k.name, k.databaseId))
 				return nil
 			}

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -207,8 +207,8 @@ func (db *txnDatabase) RelationByAccountID(
 		constraint:    item.Constraint,
 		rowid:         item.Rowid,
 		rowids:        item.Rowids,
-		lastTS:        txn.op.SnapshotTS(),
 	}
+	tbl.lastTs.Store(txn.op.SnapshotTS())
 	tbl.proc.Store(p)
 
 	db.txn.tableCache.tableMap.Store(key, tbl)
@@ -299,8 +299,8 @@ func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (eng
 		constraint:    item.Constraint,
 		rowid:         item.Rowid,
 		rowids:        item.Rowids,
-		lastTS:        txn.op.SnapshotTS(),
 	}
+	tbl.lastTs.Store(txn.op.SnapshotTS())
 	tbl.proc.Store(p)
 
 	db.txn.tableCache.tableMap.Store(key, tbl)

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -647,13 +647,17 @@ func (tbl *txnTable) rangesOnePart(
 		if err != nil {
 			return err
 		}
+		lastTs := timestamp.Timestamp{}
+		if v := tbl.lastTs.Load(); v != nil {
+			lastTs = v.(timestamp.Timestamp)
+		}
 		deleteObjs, createObjs := state.GetChangedObjsBetween(
-			types.TimestampToTS(tbl.lastTs.Load().(timestamp.Timestamp)),
+			types.TimestampToTS(lastTs),
 			types.TimestampToTS(tbl.db.txn.op.SnapshotTS()))
 		trace.GetService().ApplyFlush(
 			tbl.db.txn.op.Txn().ID,
 			tbl.tableId,
-			tbl.lastTs.Load().(timestamp.Timestamp),
+			lastTs,
 			tbl.db.txn.op.SnapshotTS(),
 			len(deleteObjs))
 		if len(deleteObjs) > 0 {

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -613,7 +613,7 @@ type txnTable struct {
 	constraint    []byte
 
 	// timestamp of the last operation on this table
-	lastTS timestamp.Timestamp
+	lastTs atomic.Value
 
 	// this should be the statement id
 	// but seems that we're not maintaining it at the moment


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14820 

## What this PR does / why we need it:
1. Fix datarace comes from tbl.lastTs  since this  [PR](https://github.com/matrixorigin/matrixone/pull/14776) delays the call of `Ranges`