### PR TITLE
Estimate the tcp packet num response in 1.1

### DIFF
--- a/pkg/frontend/internal_executor.go
+++ b/pkg/frontend/internal_executor.go
@@ -419,7 +419,7 @@ func (ip *internalProtocol) ResetStatistics() {
 
 func (ip *internalProtocol) GetStats() string { return "internal unknown stats" }
 
-func (ip *internalProtocol) CalculateOutTrafficBytes() int64 { return 0 }
+func (ip *internalProtocol) CalculateOutTrafficBytes(reset bool) (int64, int64) { return 0, 0 }
 
 func (ip *internalProtocol) sendLocalInfileRequest(filename string) error {
 	return nil

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -335,14 +335,14 @@ var RecordParseErrorStatement = func(ctx context.Context, ses *Session, proc *pr
 			if err != nil {
 				return nil, err
 			}
-			motrace.EndStatement(ctx, retErr, 0, 0)
+			motrace.EndStatement(ctx, retErr, 0, 0, 0)
 		}
 	} else {
 		ctx, err = RecordStatement(ctx, ses, proc, nil, envBegin, "", sqlType, true)
 		if err != nil {
 			return nil, err
 		}
-		motrace.EndStatement(ctx, retErr, 0, 0)
+		motrace.EndStatement(ctx, retErr, 0, 0, 0)
 	}
 
 	tenant := ses.GetTenantInfo()
@@ -2793,6 +2793,7 @@ func (mce *MysqlCmdExecutor) processLoadLocal(ctx context.Context, param *tree.E
 	if length == 0 {
 		return
 	}
+	ses.CountPayload(len(packet.Payload))
 
 	skipWrite := false
 	// If inner error occurs(unexpected or expected(ctrl-c)), proc.LoadLocalReader will be closed.
@@ -2836,6 +2837,7 @@ func (mce *MysqlCmdExecutor) processLoadLocal(ctx context.Context, param *tree.E
 		}
 		seq = uint8(packet.SequenceID + 1)
 		proto.SetSequenceID(seq)
+		ses.CountPayload(len(packet.Payload))
 
 		writeStart := time.Now()
 		if !skipWrite {

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -195,7 +195,9 @@ type MysqlProtocol interface {
 
 	GetStats() string
 
-	CalculateOutTrafficBytes() int64
+	// CalculateOutTrafficBytes return bytes, mysql packet num send back to client
+	// reset marks Do reset counter after calculation or not.
+	CalculateOutTrafficBytes(reset bool) (int64, int64)
 
 	ParseExecuteData(ctx context.Context, proc *process.Process, stmt *PrepareStmt, data []byte, pos int) error
 
@@ -368,7 +370,13 @@ func (mp *MysqlProtocolImpl) SetCapability(cap uint32) {
 }
 
 func (mp *MysqlProtocolImpl) AddSequenceId(a uint8) {
+	mp.ses.CountPacket(int64(a))
 	mp.sequenceId.Add(uint32(a))
+}
+
+func (mp *MysqlProtocolImpl) SetSequenceID(value uint8) {
+	mp.ses.CountPacket(1)
+	mp.sequenceId.Store(uint32(value))
 }
 
 func (mp *MysqlProtocolImpl) GetDatabaseName() string {
@@ -401,12 +409,19 @@ func (mp *MysqlProtocolImpl) GetStats() string {
 		mp.String())
 }
 
-// CalculateOutTrafficBytes calculate the bytes of the last out traffic
-func (mp *MysqlProtocolImpl) CalculateOutTrafficBytes() int64 {
+// CalculateOutTrafficBytes calculate the bytes of the last out traffic, the number of mysql packets
+func (mp *MysqlProtocolImpl) CalculateOutTrafficBytes(reset bool) (bytes int64, packets int64) {
+	ses := mp.GetSession()
 	// Case 1: send data as ResultSet
-	return int64(mp.writeBytes) + int64(mp.bytesInOutBuffer-mp.startOffsetInBuffer) +
+	bytes = int64(mp.writeBytes) + int64(mp.bytesInOutBuffer-mp.startOffsetInBuffer) +
 		// Case 2: send data as CSV
-		mp.GetSession().writeCsvBytes.Load()
+		ses.writeCsvBytes.Load()
+	// mysql packet num + length(sql) / 16KiB + payload / 16 KiB
+	packets = ses.GetPacketCnt() + int64(len(ses.sql)>>14) + int64(ses.payloadCounter>>14)
+	if reset {
+		ses.ResetPacketCounter()
+	}
+	return
 }
 
 func (mp *MysqlProtocolImpl) ResetStatistics() {

--- a/pkg/frontend/protocol.go
+++ b/pkg/frontend/protocol.go
@@ -239,10 +239,6 @@ func (pi *ProtocolImpl) GetSequenceId() uint8 {
 	return uint8(pi.sequenceId.Load())
 }
 
-func (pi *ProtocolImpl) SetSequenceID(value uint8) {
-	pi.sequenceId.Store(uint32(value))
-}
-
 func (pi *ProtocolImpl) getDebugStringUnsafe() string {
 	if pi.tcpConn != nil {
 		return fmt.Sprintf("connectionId %d|%s", pi.connectionID, pi.tcpConn.RemoteAddress())
@@ -505,7 +501,7 @@ func (fp *FakeProtocol) GetStats() string {
 	return ""
 }
 
-func (fp *FakeProtocol) CalculateOutTrafficBytes() int64 { return 0 }
+func (fp *FakeProtocol) CalculateOutTrafficBytes(reset bool) (int64, int64) { return 0, 0 }
 
 func (fp *FakeProtocol) IsEstablished() bool {
 	return true

--- a/pkg/frontend/routine.go
+++ b/pkg/frontend/routine.go
@@ -211,8 +211,6 @@ func (rt *Routine) handleRequest(req *Request) error {
 	defer span.End()
 
 	parameters := rt.getParameters()
-	mpi := rt.getProtocol()
-	mpi.SetSequenceID(req.seq)
 	cancelRequestCtx, cancelRequestFunc := context.WithTimeout(routineCtx, parameters.SessionTimeout.Duration)
 	executor := rt.getCmdExecutor()
 	executor.SetCancelFunc(cancelRequestFunc)

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -210,6 +210,10 @@ type Session struct {
 	sentRows atomic.Int64
 	// writeCsvBytes is used to record bytes sent by `select ... into 'file.csv'` for motrace.StatementInfo
 	writeCsvBytes atomic.Int64
+	// packetCounter count the packet communicated with client.
+	packetCounter atomic.Int64
+	// payloadCounter count the payload send by `load data`
+	payloadCounter int64
 
 	createdTime time.Time
 
@@ -473,6 +477,32 @@ func (ses *Session) GetSqlHelper() *SqlHelper {
 	ses.mu.Lock()
 	defer ses.mu.Unlock()
 	return ses.sqlHelper
+}
+
+func (ses *Session) CountPayload(length int) {
+	if ses == nil {
+		return
+	}
+	ses.payloadCounter += int64(length)
+}
+func (ses *Session) CountPacket(delta int64) {
+	if ses == nil {
+		return
+	}
+	ses.packetCounter.Add(delta)
+}
+func (ses *Session) GetPacketCnt() int64 {
+	if ses == nil {
+		return 0
+	}
+	return ses.packetCounter.Load()
+}
+func (ses *Session) ResetPacketCounter() {
+	if ses == nil {
+		return
+	}
+	ses.packetCounter.Store(0)
+	ses.payloadCounter = 0
 }
 
 // The update version. Four function.

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -503,7 +503,7 @@ func logStatementStatus(ctx context.Context, ses *Session, stmt tree.Statement, 
 
 func logStatementStringStatus(ctx context.Context, ses *Session, stmtStr string, status statementStatus, err error) {
 	str := SubStringFromBegin(stmtStr, int(ses.GetParameterUnit().SV.LengthOfQueryPrinted))
-	outBytes := ses.GetMysqlProtocol().CalculateOutTrafficBytes()
+	outBytes, outPacket := ses.GetMysqlProtocol().CalculateOutTrafficBytes(true)
 	if status == success {
 		logDebug(ses, ses.GetDebugString(), "query trace status", logutil.ConnectionIdField(ses.GetConnectionID()), logutil.StatementField(str), logutil.StatusField(status.String()), trace.ContextField(ctx))
 		err = nil // make sure: it is nil for EndStatement
@@ -511,7 +511,7 @@ func logStatementStringStatus(ctx context.Context, ses *Session, stmtStr string,
 		logError(ses, ses.GetDebugString(), "query trace status", logutil.ConnectionIdField(ses.GetConnectionID()), logutil.StatementField(str), logutil.StatusField(status.String()), logutil.ErrorField(err), trace.ContextField(ctx))
 	}
 	// pls make sure: NO ONE use the ses.tStmt after EndStatement
-	motrace.EndStatement(ctx, err, ses.sentRows.Load(), outBytes)
+	motrace.EndStatement(ctx, err, ses.sentRows.Load(), outBytes, outPacket)
 	// need just below EndStatement
 	ses.SetTStmt(nil)
 }

--- a/pkg/util/trace/impl/motrace/Aggr_test.go
+++ b/pkg/util/trace/impl/motrace/Aggr_test.go
@@ -196,20 +196,21 @@ func TestAggregator(t *testing.T) {
 	assert.Equal(t, 50*time.Millisecond, results[1].(*StatementInfo).Duration)
 	assert.Equal(t, 50*time.Millisecond, results[2].(*StatementInfo).Duration)
 	assert.Equal(t, 50*time.Millisecond, results[3].(*StatementInfo).Duration)
-	require.Equal(t, []byte(`[3,5,10.000,15,20,25,2]`), results[0].(*StatementInfo).ExecPlan2Stats(ctx))
-	require.Equal(t, []byte(`[3,5,10.000,15,20,25,2]`), results[1].(*StatementInfo).ExecPlan2Stats(ctx))
-	require.Equal(t, []byte(`[3,5,10.000,15,20,25,2]`), results[2].(*StatementInfo).ExecPlan2Stats(ctx))
-	require.Equal(t, []byte(`[3,5,10.000,15,20,25,2]`), results[3].(*StatementInfo).ExecPlan2Stats(ctx))
+	require.Equal(t, []byte(`[4,5,10.000,15,20,25,2,0]`), results[0].(*StatementInfo).ExecPlan2Stats(ctx))
+	require.Equal(t, []byte(`[4,5,10.000,15,20,25,2,0]`), results[1].(*StatementInfo).ExecPlan2Stats(ctx))
+	require.Equal(t, []byte(`[4,5,10.000,15,20,25,2,0]`), results[2].(*StatementInfo).ExecPlan2Stats(ctx))
+	require.Equal(t, []byte(`[4,5,10.000,15,20,25,2,0]`), results[3].(*StatementInfo).ExecPlan2Stats(ctx))
 	item, _ := results[0].(*StatementInfo)
 	row := item.GetTable().GetRow(ctx)
+	targetBytes := []byte(`[4,5,2.000,15,20,25,2,0]`)
 	results[0].(*StatementInfo).FillRow(ctx, row)
-	require.Equal(t, []byte(`[3,5,2.000,15,20,25,2]`), results[0].(*StatementInfo).ExecPlan2Stats(ctx))
+	require.Equal(t, targetBytes, results[0].(*StatementInfo).ExecPlan2Stats(ctx))
 	results[1].(*StatementInfo).FillRow(ctx, row)
-	require.Equal(t, []byte(`[3,5,2.000,15,20,25,2]`), results[1].(*StatementInfo).ExecPlan2Stats(ctx))
+	require.Equal(t, targetBytes, results[1].(*StatementInfo).ExecPlan2Stats(ctx))
 	results[2].(*StatementInfo).FillRow(ctx, row)
-	require.Equal(t, []byte(`[3,5,2.000,15,20,25,2]`), results[2].(*StatementInfo).ExecPlan2Stats(ctx))
+	require.Equal(t, targetBytes, results[2].(*StatementInfo).ExecPlan2Stats(ctx))
 	results[3].(*StatementInfo).FillRow(ctx, row)
-	require.Equal(t, []byte(`[3,5,2.000,15,20,25,2]`), results[3].(*StatementInfo).ExecPlan2Stats(ctx))
+	require.Equal(t, targetBytes, results[3].(*StatementInfo).ExecPlan2Stats(ctx))
 
 	aggregator.Close()
 
@@ -274,9 +275,9 @@ func TestAggregator(t *testing.T) {
 	assert.Equal(t, fixedTime.Add(4*time.Second), results[0].(*StatementInfo).RequestAt)
 	// ResponseAt should be end of the window
 	assert.Equal(t, fixedTime.Add(9*time.Second), results[0].(*StatementInfo).ResponseAt)
-	require.Equal(t, []byte(`[3,5,10.000,15,20,25,0]`), results[0].(*StatementInfo).ExecPlan2Stats(ctx))
+	require.Equal(t, []byte(`[4,5,10.000,15,20,25,0,0]`), results[0].(*StatementInfo).ExecPlan2Stats(ctx))
 	results[0].(*StatementInfo).FillRow(ctx, row)
-	require.Equal(t, []byte(`[3,5,2.000,15,20,25,0]`), results[0].(*StatementInfo).ExecPlan2Stats(ctx))
+	require.Equal(t, []byte(`[4,5,2.000,15,20,25,0,0]`), results[0].(*StatementInfo).ExecPlan2Stats(ctx))
 
 	_, err = aggregator.AddItem(&StatementInfo{
 		Account:       "MO",

--- a/pkg/util/trace/impl/motrace/buffer_pipe_test.go
+++ b/pkg/util/trace/impl/motrace/buffer_pipe_test.go
@@ -448,7 +448,7 @@ log_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000
 				},
 				buf: buf,
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[4,0,0,0,0,0,0,0]",,,0,,0,0
 `,
 		},
 		{
@@ -489,8 +489,8 @@ log_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000
 				},
 				buf: buf,
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
-00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[4,0,0,0,0,0,0,0]",,,0,,0,0
+00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,"[4,0,0,0,0,0,0,0]",,,0,,0,0
 `,
 		},
 		{
@@ -567,7 +567,7 @@ func Test_genCsvData_diffAccount(t *testing.T) {
 				buf: buf,
 			},
 			wantReqCnt: 1,
-			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
+			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[4,0,0,0,0,0,0,0]",,,0,,0,0
 `},
 		},
 		{
@@ -609,8 +609,8 @@ func Test_genCsvData_diffAccount(t *testing.T) {
 				buf: buf,
 			},
 			wantReqCnt: 1,
-			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
-`, `00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,sys,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,0
+			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[4,0,0,0,0,0,0,0]",,,0,,0,0
+`, `00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,sys,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000002""}",0,0,"[4,0,0,0,0,0,0,0]",,,0,,0,0
 `},
 		},
 	}
@@ -707,9 +707,9 @@ func Test_genCsvData_LongQueryTime(t *testing.T) {
 				buf:    buf,
 				queryT: int64(time.Second),
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,1
-00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""no exec plan""}",0,0,"[3,0,0,0,0,0,0]",,,0,,0,2
-00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000000000,Failed,20101,internal error: test error,"{""key"":""val""}",1,1,"[3,1,2.000,3,4,5,0]",,,0,internal,0,3
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null,""uuid"":""00000000-0000-0000-0000-000000000001""}",0,0,"[4,0,0,0,0,0,0,0]",,,0,,0,1
+00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""no exec plan""}",0,0,"[4,0,0,0,0,0,0,0]",,,0,,0,2
+00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000000000,Failed,20101,internal error: test error,"{""key"":""val""}",1,1,"[4,1,2.000,3,4,5,0,0]",,,0,internal,0,3
 `,
 		},
 	}

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -550,12 +550,15 @@ func (s *StatementInfo) MarkResponseAt() {
 	}
 }
 
-// ErrorPkgConst = 56 + 13
-// 56: empty mysql tcp package size
-// 13: avg payload prefix of err msg
-const ErrorPkgConst = 69
+// TcpIpv4HeaderSize default tcp header bytes.
+const TcpIpv4HeaderSize = 66
 
-var EndStatement = func(ctx context.Context, err error, sentRows int64, outBytes int64) {
+// ResponseErrPacketSize avg prefix size for mysql packet response error.
+// 66: default tcp header bytes.
+// 13: avg payload prefix of err response
+const ResponseErrPacketSize = TcpIpv4HeaderSize + 13
+
+func EndStatement(ctx context.Context, err error, sentRows int64, outBytes int64, outPacket int64) {
 	if !GetTracerProvider().IsEnable() {
 		return
 	}
@@ -572,9 +575,10 @@ var EndStatement = func(ctx context.Context, err error, sentRows int64, outBytes
 		s.AggrCount = 0
 		s.MarkResponseAt()
 		if err != nil {
-			outBytes += ErrorPkgConst + int64(len(err.Error()))
+			outBytes += ResponseErrPacketSize + int64(len(err.Error()))
 		}
-		s.statsArray.InitIfEmpty().WithOutTrafficBytes(float64(outBytes))
+		outBytes += TcpIpv4HeaderSize * outPacket
+		s.statsArray.InitIfEmpty().WithOutTrafficBytes(float64(outBytes)).WithOutPacketCount(float64(outPacket))
 		s.Status = StatementStatusSuccess
 		if err != nil {
 			s.Error = err

--- a/pkg/util/trace/impl/motrace/report_statement_test.go
+++ b/pkg/util/trace/impl/motrace/report_statement_test.go
@@ -176,7 +176,7 @@ func TestStatementInfo_Report_EndStatement(t *testing.T) {
 			require.Equal(t, tt.fields.doExport, s.exported)
 
 			stmCtx := ContextWithStatement(tt.args.ctx, s)
-			EndStatement(stmCtx, tt.args.err, 0, 0)
+			EndStatement(stmCtx, tt.args.err, 0, 0, 0)
 			require.Equal(t, tt.wantReportCntAfterEnd, gotCnt)
 		})
 	}
@@ -311,28 +311,28 @@ func (p *dummySerializableExecPlan) Stats(ctx context.Context) (statistic.StatsA
 
 func TestMergeStats(t *testing.T) {
 	e := &StatementInfo{}
-	e.statsArray.Init().WithTimeConsumed(80335).WithMemorySize(1800).WithS3IOInputCount(1).WithS3IOOutputCount(0).WithConnType(statistic.ConnTypeInternal)
+	e.statsArray.Init().WithTimeConsumed(80335).WithMemorySize(1800).WithS3IOInputCount(1).WithS3IOOutputCount(0).WithConnType(statistic.ConnTypeInternal).WithOutPacketCount(1)
 
 	n := &StatementInfo{}
-	n.statsArray.Init().WithTimeConsumed(147960).WithMemorySize(1800).WithS3IOInputCount(0).WithS3IOOutputCount(0)
+	n.statsArray.Init().WithTimeConsumed(147960).WithMemorySize(1800).WithS3IOInputCount(0).WithS3IOOutputCount(0).WithOutPacketCount(2)
 
 	err := mergeStats(e, n)
 	if err != nil {
 		t.Fatalf("mergeStats failed: %v", err)
 	}
 
-	wantBytes := []byte("[3,228295,3600.000,1,0,0,1]")
+	wantBytes := []byte("[4,228295,3600.000,1,0,0,1,3]")
 	require.Equal(t, wantBytes, e.statsArray.ToJsonString())
 
 	n = &StatementInfo{}
-	n.statsArray.Init().WithTimeConsumed(1).WithMemorySize(1).WithS3IOInputCount(0).WithS3IOOutputCount(0)
+	n.statsArray.Init().WithTimeConsumed(1).WithMemorySize(1).WithS3IOInputCount(0).WithS3IOOutputCount(0).WithOutPacketCount(10)
 
 	err = mergeStats(e, n)
 	if err != nil {
 		t.Fatalf("mergeStats failed: %v", err)
 	}
 
-	wantBytes = []byte("[3,228296,3601.000,1,0,0,1]")
+	wantBytes = []byte("[4,228296,3601.000,1,0,0,1,13]")
 	require.Equal(t, wantBytes, e.statsArray.ToJsonString())
 
 }

--- a/pkg/util/trace/impl/motrace/statistic/stats_array.go
+++ b/pkg/util/trace/impl/motrace/statistic/stats_array.go
@@ -28,13 +28,17 @@ const (
 	Float64PrecForMemorySize = 3
 )
 
-const (
-	StatsArrayVersion = StatsArrayVersion3
+const StatsArrayVersion = StatsArrayVersionLatest
 
-	StatsArrayVersion0 = 0 // raw statistics
+const (
+	StatsArrayVersion0 = iota // raw statistics
+
 	StatsArrayVersion1 = 1 // float64 array
 	StatsArrayVersion2 = 2 // float64 array + plus one elem OutTrafficBytes
 	StatsArrayVersion3 = 3 // ... + one elem: ConnType
+	StatsArrayVersion4 = 4 // ... + one elem: OutPacketCount
+
+	StatsArrayVersionLatest // same value as last variable StatsArrayVersion#
 )
 
 const (
@@ -45,6 +49,7 @@ const (
 	StatsArrayIndexS3IOOutputCount // index: 4
 	StatsArrayIndexOutTrafficBytes // index: 5
 	StatsArrayIndexConnType        // index: 6
+	StatsArrayIndexOutPacketCnt    // index: 7
 
 	StatsArrayLength
 )
@@ -53,6 +58,7 @@ const (
 	StatsArrayLengthV1 = 5
 	StatsArrayLengthV2 = 6
 	StatsArrayLengthV3 = 7
+	StatsArrayLengthV4 = 8
 )
 
 type ConnType float64
@@ -77,7 +83,11 @@ func NewStatsArrayV2() *StatsArray {
 }
 
 func NewStatsArrayV3() *StatsArray {
-	return NewStatsArray()
+	return NewStatsArray().WithVersion(StatsArrayVersion3)
+}
+
+func NewStatsArrayV4() *StatsArray {
+	return NewStatsArray().WithVersion(StatsArrayVersion4)
 }
 
 func (s *StatsArray) Init() *StatsArray {
@@ -115,6 +125,12 @@ func (s *StatsArray) GetConnType() float64 {
 	}
 	return (*s)[StatsArrayIndexConnType]
 }
+func (s *StatsArray) GetOutPacketCount() float64 {
+	if s.GetVersion() < StatsArrayVersion4 {
+		return 0
+	}
+	return s[StatsArrayIndexOutPacketCnt]
+}
 
 // WithVersion set the version array in StatsArray, please carefully to use.
 func (s *StatsArray) WithVersion(v float64) *StatsArray { (*s)[StatsArrayIndexVersion] = v; return s }
@@ -148,6 +164,11 @@ func (s *StatsArray) WithConnType(v ConnType) *StatsArray {
 	return s
 }
 
+func (s *StatsArray) WithOutPacketCount(v float64) *StatsArray {
+	s[StatsArrayIndexOutPacketCnt] = v
+	return s
+}
+
 func (s *StatsArray) ToJsonString() []byte {
 	switch s.GetVersion() {
 	case StatsArrayVersion1:
@@ -156,6 +177,8 @@ func (s *StatsArray) ToJsonString() []byte {
 		return StatsArrayToJsonString((*s)[:StatsArrayLengthV2])
 	case StatsArrayVersion3:
 		return StatsArrayToJsonString((*s)[:StatsArrayLengthV3])
+	case StatsArrayVersion4:
+		return StatsArrayToJsonString((*s)[:StatsArrayLengthV4])
 	default:
 		return StatsArrayToJsonString((*s)[:])
 	}


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/1911

## What this PR does / why we need it:
cherry-pick form https://github.com/matrixorigin/matrixone/pull/13801

there are 3 different cases :
1. normally query
- in: short statment
- out: response data to client throught mysql packet.
3. batch insert
- in: long statement, send data throught statement
- out: number of `Affected Rows`.
5. load data
- in: short statement, send data as payload
- out: number of `Affected Rows`.

changes:
1. Estimate the tcp packet num response to client including 3 parts, as show in function `MysqlProtocolImpl::CalculateOutTrafficBytes`
- mysqlPacket count
- length(statement) / 16 KiB
- lenght(payload) / 16 KiB
2. add `packetCounter` in Session, count the mysql packet between client and server
3. add `payloadCounter` in Session, count the payload send by client while exec `load data` command
