### PR TITLE
cherrypick to 1.1-dev: add statement latency metric

### DIFF
--- a/pkg/cnservice/upgrader/new_add_table.go
+++ b/pkg/cnservice/upgrader/new_add_table.go
@@ -346,6 +346,16 @@ var MoCacheView = &table.Table{
 	CreateTableSql: "drop view if exists `mo_catalog`.`mo_cache`;",
 }
 
+var transactionMetricView = &table.Table{
+	Account:  table.AccountAll,
+	Database: catalog.MO_SYSTEM_METRICS,
+	Table:    "sql_statement_duration_total",
+	CreateViewSql: "CREATE VIEW IF NOT EXISTS `system_metrics`.`sql_statement_duration_total` as " +
+		"SELECT `collecttime`, `value`, `node`, `role`, `account`, `type` " +
+		"from `system_metrics`.`metric` " +
+		"where `metric_name` = 'sql_statement_duration_total'",
+}
+
 var registeredViews = []*table.Table{processlistView, MoLocksView, MoVariablesView, MoTransactionsView, MoCacheView}
 var needUpgradeNewView = []*table.Table{transactionMetricView, PARTITIONSView, STATISTICSView, MoSessionsView, SqlStatementHotspotView, MoLocksView, MoConfigurationsView, MoVariablesView, MoTransactionsView, MoCacheView}
 

--- a/pkg/cnservice/upgrader/new_add_table.go
+++ b/pkg/cnservice/upgrader/new_add_table.go
@@ -347,7 +347,7 @@ var MoCacheView = &table.Table{
 }
 
 var registeredViews = []*table.Table{processlistView, MoLocksView, MoVariablesView, MoTransactionsView, MoCacheView}
-var needUpgradeNewView = []*table.Table{PARTITIONSView, STATISTICSView, MoSessionsView, SqlStatementHotspotView, MoLocksView, MoConfigurationsView, MoVariablesView, MoTransactionsView, MoCacheView}
+var needUpgradeNewView = []*table.Table{transactionMetricView, PARTITIONSView, STATISTICSView, MoSessionsView, SqlStatementHotspotView, MoLocksView, MoConfigurationsView, MoVariablesView, MoTransactionsView, MoCacheView}
 
 var InformationSchemaSCHEMATA = &table.Table{
 	Account:  table.AccountAll,

--- a/pkg/util/metric/m_register.go
+++ b/pkg/util/metric/m_register.go
@@ -30,6 +30,7 @@ var InitCollectors = []Collector{
 	StatementCUCounterFactory,
 	TransactionCounterFactory,
 	TransactionErrorsFactory,
+	StatementDurationFactory,
 	// server metric
 	ConnFactory,
 	StorageUsageFactory,

--- a/pkg/util/metric/m_sql.go
+++ b/pkg/util/metric/m_sql.go
@@ -25,6 +25,16 @@ var (
 		false,
 	)
 
+	StatementDurationFactory = NewCounterVec(
+		CounterOpts{
+			Subsystem: "sql",
+			Name:      "statement_duration_total",
+			Help:      "Statement duration of each query type for each account",
+		},
+		[]string{constTenantKey, "type"},
+		false,
+	)
+
 	TransactionCounterFactory = NewCounterVec(
 		CounterOpts{
 			Subsystem: "sql",
@@ -85,6 +95,10 @@ var (
 // StatementCounter accept t as tree.QueryType
 func StatementCounter(tenant string, t string) Counter {
 	return StatementCounterFactory.WithLabelValues(tenant, t)
+}
+
+func StatementDuration(tenant string, t string) Counter {
+	return StatementDurationFactory.WithLabelValues(tenant, t)
 }
 
 func TransactionCounter(tenant string) Counter {

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -592,6 +592,8 @@ func EndStatement(ctx context.Context, err error, sentRows int64, outBytes int64
 		s.ResultCount = sentRows
 		s.AggrCount = 0
 		s.MarkResponseAt()
+		// duration is filled in s.MarkResponseAt()
+		addStatementDurationCounter(s.Account, s.QueryType, s.Duration)
 		if err != nil {
 			outBytes += ResponseErrPacketSize + int64(len(err.Error()))
 		}
@@ -614,6 +616,10 @@ func EndStatement(ctx context.Context, err error, sentRows int64, outBytes int64
 			s.Report(ctx)
 		}
 	}
+}
+
+func addStatementDurationCounter(tenant, querytype string, duration time.Duration) {
+	metric.StatementDuration(tenant, querytype).Add(float64(duration))
 }
 
 type StatementInfoStatus int

--- a/test/distributed/cases/dml/show/database_statistics.result
+++ b/test/distributed/cases/dml/show/database_statistics.result
@@ -12,7 +12,7 @@ Number of tables in mo_catalog
 22
 show table_number from system_metrics;
 Number of tables in system_metrics
-21
+22
 show table_number from system;
 Number of tables in system
 6
@@ -355,7 +355,7 @@ Number of tables in mo_catalog
 21
 show table_number from system_metrics;
 Number of tables in system_metrics
-8
+9
 show table_number from system;
 Number of tables in system
 1

--- a/test/distributed/cases/mo_cloud/mo_cloud.result
+++ b/test/distributed/cases/mo_cloud/mo_cloud.result
@@ -671,6 +671,7 @@ sql_statement_total    accountadmin
 sql_statement_errors    accountadmin
 sql_transaction_total    accountadmin
 sql_transaction_errors    accountadmin
+sql_statement_duration_total    accountadmin
 server_connections    accountadmin
 server_storage_usage    accountadmin
 SELECT relname AS `name`, mo_table_rows(reldatabase, relname) AS `rows`, mo_table_size(reldatabase, relname) AS `size`, if (role_name IS NULL, '-', role_name) AS `owner` FROM mo_catalog.mo_tables LEFT JOIN mo_catalog.mo_role ON mo_catalog.mo_tables.owner=role_id WHERE relkind IN ('r','e','cluster') AND reldatabase='information_schema';

--- a/test/distributed/cases/mo_cloud/mo_cloud.result
+++ b/test/distributed/cases/mo_cloud/mo_cloud.result
@@ -647,6 +647,7 @@ system_metrics    server_connections    v    accountadmin
 system_metrics    server_storage_usage    v    accountadmin
 system_metrics    sql_statement_cu    r    accountadmin
 system_metrics    sql_statement_errors    v    accountadmin
+system_metrics    sql_statement_duration_total    v    accountadmin
 system_metrics    sql_statement_total    v    accountadmin
 system_metrics    sql_transaction_errors    v    accountadmin
 system_metrics    sql_transaction_total    v    accountadmin

--- a/test/distributed/cases/mo_cloud/mo_cloud.result
+++ b/test/distributed/cases/mo_cloud/mo_cloud.result
@@ -594,7 +594,7 @@ mo_catalog    21    -
 mo_mo    0    accountadmin
 mysql    5    accountadmin
 system    1    accountadmin
-system_metrics    8    accountadmin
+system_metrics    9    accountadmin
 SELECT mo_catalog.mo_database.datname,mo_catalog.mo_tables.relname,mo_catalog.mo_tables.relkind, if (role_name IS NULL,'-', role_name) AS `owner` FROM mo_catalog.mo_database LEFT JOIN mo_catalog.mo_tables ON mo_catalog.mo_database.datname = mo_catalog.mo_tables.reldatabase LEFT JOIN mo_catalog.mo_role ON mo_catalog.mo_tables.owner=role_id WHERE (relname NOT LIKE "__mo_index_secondary_%" AND relname NOT LIKE "__mo_index_unique_%" OR relname IS NULL) ORDER BY reldatabase, relname;
 datname    relname    relkind    owner
 mo_mo    null    null    -

--- a/test/distributed/cases/tenant/tenant.result
+++ b/test/distributed/cases/tenant/tenant.result
@@ -8,8 +8,8 @@ create account tenant_test admin_name = 'root' open comment 'tenant_test';
 SQL parser error: You have an error in your SQL syntax; check the manual that corresponds to your MatrixOne server version for the right syntax to use. syntax error at line 1 column 51 near " open comment 'tenant_test';";
 show accounts;
 account_name    admin_name    created    status    suspended_time    db_count    table_count    size    comment
-tenant_test    root    2023-11-12 12:43:41    open    null    5    51    0.0    tenant_test
-sys    root    2023-11-12 03:33:41    open    null    7    73    13.256612    system account
+tenant_test    root    2023-11-12 12:43:41    open    null    5    52    0.0    tenant_test
+sys    root    2023-11-12 03:33:41    open    null    7    74    13.256612    system account
 drop account if exists tenant_test;
 select account_id,relname,relkind from mo_catalog.mo_tables where reldatabase = 'mo_catalog' and relname not like '__mo_index_unique__%' order by relname;
 account_id    relname    relkind


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/12904

## What this PR does / why we need it:

add a metric about statement_duration which could come up with query_latency