### PR TITLE
[BugFix]: Upgrade Not getting applied to System Tenant

### DIFF
--- a/pkg/cnservice/upgrader/upgrader.go
+++ b/pkg/cnservice/upgrader/upgrader.go
@@ -430,12 +430,12 @@ func (u *Upgrader) UpgradeMoIndexesSchema(ctx context.Context, tenants []*fronte
 		ctx = attachAccount(ctx, tenant)
 		opts := makeOptions(tenant)
 
-		for _, conditionalUpgradeSQL := range conditionalUpgradeV1SQLs {
-
-			if columnNotPresent, err1 := ifEmpty(conditionalUpgradeSQL.ifEmpty, opts); err1 != nil {
+		ifEmptyStmt, thenStmt := conditionalUpgradeV1SQLs(int(tenant.TenantID))
+		for i := 0; i < len(ifEmptyStmt); i++ {
+			if columnNotPresent, err1 := ifEmpty(ifEmptyStmt[i], opts); err1 != nil {
 				errors = append(errors, moerr.NewUpgrateError(ctx, "mo_catalog", "mo_indexes", frontend.GetDefaultTenant(), catalog.System_Account, err1.Error()))
 			} else if columnNotPresent {
-				err2 := execTxn(conditionalUpgradeSQL.then, opts)
+				err2 := execTxn(thenStmt[i], opts)
 				if err2 != nil {
 					errors = append(errors, moerr.NewUpgrateError(ctx, "mo_catalog", "mo_indexes", frontend.GetDefaultTenant(), catalog.System_Account, err2.Error()))
 				}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/14846

## What this PR does / why we need it:
Previously system tenant had access to all the column names of "mo_catalog.mo_indexes" via "INFORMATION_SCHEMA.COLUMNS".

```sql
mysql> SELECT COLUMN_NAME, COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA ="mo_catalog" AND TABLE_NAME ="mo_indexes" GROUP BY COLUMN_NAME;
+------------------+----------+
| column_name      | count(*) |
+------------------+----------+
| __mo_cpkey_col   |       35 |
| column_name      |       35 |
| comment          |       35 |
| database_id      |       35 |
| hidden           |       35 |
| id               |       35 |
| index_table_name |       35 |
| is_visible       |       35 |
| name             |       35 |
| options          |       35 |
| ordinal_position |       35 |
| table_id         |       35 |
| type             |       35 |
| algo             |       34 |<-------
| algo_params      |       34 |<-------
| algo_table_type  |       34 |<-------
+------------------+----------+

```

Due to this, `algo` column though not present in `mo_catalog.mo_indexes` of the system tenant, was shown as present. Hence upgrade logic for system tenant was skipped.

To prevent this from happening, we are using `mo_catalog.mo_columns`, which has `account_id` field showing the tenant information. We make sure that, the even system tenant sees the columns of its own tenant id. This ensures the column's absence and will trigger the Upgrade Logic.
