### PR TITLE
adding sync interface for GetLatestSchema

### DIFF
--- a/pkg/vm/engine/tae/catalog/block.go
+++ b/pkg/vm/engine/tae/catalog/block.go
@@ -260,7 +260,9 @@ func (entry *BlockEntry) InitData(factory DataFactory) {
 	entry.blkData = dataFactory(entry)
 }
 func (entry *BlockEntry) GetBlockData() data.Block { return entry.blkData }
-func (entry *BlockEntry) GetSchema() *Schema       { return entry.GetObject().GetTable().GetLastestSchema() }
+func (entry *BlockEntry) GetSchema() *Schema {
+	return entry.GetObject().GetTable().GetLastestSchemaLocked()
+}
 func (entry *BlockEntry) PrepareRollback() (err error) {
 	var empty bool
 	empty, err = entry.BaseEntryImpl.PrepareRollback()

--- a/pkg/vm/engine/tae/catalog/catalog.go
+++ b/pkg/vm/engine/tae/catalog/catalog.go
@@ -627,7 +627,7 @@ func (catalog *Catalog) onReplayCheckpointObject(
 			blkCount = 1
 		}
 		leftRows := stats.Rows()
-		blkMaxRow := rel.GetLastestSchema().BlockMaxRows
+		blkMaxRow := rel.GetLastestSchemaLocked().BlockMaxRows
 		for i := 0; i < int(blkCount); i++ {
 			blkID := objectio.NewBlockidWithObjectID(objid, uint16(i))
 			rows := blkMaxRow
@@ -645,7 +645,7 @@ func (catalog *Catalog) onReplayCheckpointObject(
 		stats := objNode.ObjectStats
 		blkCount := stats.BlkCnt()
 		leftRows := stats.Rows()
-		blkMaxRow := rel.GetLastestSchema().BlockMaxRows
+		blkMaxRow := rel.GetLastestSchemaLocked().BlockMaxRows
 		for i := 0; i < int(blkCount); i++ {
 			blkID := objectio.NewBlockidWithObjectID(objid, uint16(i))
 			rows := blkMaxRow

--- a/pkg/vm/engine/tae/catalog/database.go
+++ b/pkg/vm/engine/tae/catalog/database.go
@@ -540,7 +540,7 @@ func (e *DBEntry) AddEntryLocked(table *TableEntry, txn txnif.TxnReader, skipDed
 		nn.CreateNode(table.ID)
 	} else {
 		if !skipDedup {
-			name := table.GetLastestSchema().Name
+			name := table.GetLastestSchemaLocked().Name
 			err = e.checkAddNameConflictLocked(name, table.ID, nn, txn)
 			if err != nil {
 				return

--- a/pkg/vm/engine/tae/catalog/object.go
+++ b/pkg/vm/engine/tae/catalog/object.go
@@ -174,7 +174,7 @@ func NewSysObjectEntry(table *TableEntry, id types.Uuid) *ObjectEntry {
 	}
 	e.CreateWithTS(types.SystemDBTS, &ObjectMVCCNode{*objectio.NewObjectStats()})
 	var bid types.Blockid
-	schema := table.GetLastestSchema()
+	schema := table.GetLastestSchemaLocked()
 	if schema.Name == SystemTableSchema.Name {
 		bid = SystemBlock_Table_ID
 	} else if schema.Name == SystemDBSchema.Name {

--- a/pkg/vm/engine/tae/db/checkpoint/runner.go
+++ b/pkg/vm/engine/tae/db/checkpoint/runner.go
@@ -863,7 +863,7 @@ func (r *runner) fireFlushTabletail(table *catalog.TableEntry, tree *model.Table
 	scopes := make([]common.ID, 0, len(metas))
 	for _, meta := range metas {
 		if !meta.GetBlockData().PrepareCompact() {
-			logutil.Infof("[FlushTabletail] %d-%s / %s false prepareCompact ", table.ID, table.GetLastestSchema().Name, meta.ID.String())
+			logutil.Infof("[FlushTabletail] %d-%s / %s false prepareCompact ", table.ID, table.GetLastestSchemaLocked().Name, meta.ID.String())
 			return moerr.GetOkExpectedEOB()
 		}
 		scopes = append(scopes, *meta.AsCommonID())
@@ -872,7 +872,7 @@ func (r *runner) fireFlushTabletail(table *catalog.TableEntry, tree *model.Table
 	factory := jobs.FlushTableTailTaskFactory(metas, r.rt, endTs)
 	if _, err := r.rt.Scheduler.ScheduleMultiScopedTxnTask(nil, tasks.DataCompactionTask, scopes, factory); err != nil {
 		if err != tasks.ErrScheduleScopeConflict {
-			logutil.Infof("[FlushTabletail] %d-%s %v", table.ID, table.GetLastestSchema().Name, err)
+			logutil.Infof("[FlushTabletail] %d-%s %v", table.ID, table.GetLastestSchemaLocked().Name, err)
 		}
 		return moerr.GetOkExpectedEOB()
 	}
@@ -934,14 +934,14 @@ func (r *runner) tryCompactTree(entry *logtail.DirtyTreeEntry, force bool) {
 		// debug log, delete later
 		if !stats.LastFlush.IsEmpty() && asize+dsize > 2*1000*1024 {
 			logutil.Infof("[flushtabletail] %v(%v) %v dels  FlushCountDown %v",
-				table.GetLastestSchema().Name,
+				table.GetLastestSchemaLocked().Name,
 				common.HumanReadableBytes(asize+dsize),
 				common.HumanReadableBytes(dsize),
 				time.Until(stats.FlushDeadline))
 		}
 
 		if force {
-			logutil.Infof("[flushtabletail] force flush %v-%s", table.ID, table.GetLastestSchema().Name)
+			logutil.Infof("[flushtabletail] force flush %v-%s", table.ID, table.GetLastestSchemaLocked().Name)
 			if err := r.fireFlushTabletail(table, dirtyTree, endTs); err == nil {
 				stats.ResetDeadlineWithLock()
 			}

--- a/pkg/vm/engine/tae/db/merge/executor.go
+++ b/pkg/vm/engine/tae/db/merge/executor.go
@@ -140,7 +140,7 @@ func (e *MergeExecutor) ManuallyExecute(entry *catalog.TableEntry, objs []*catal
 	} else if err != nil {
 		return moerr.NewInternalErrorNoCtx("schedule error: %v", err)
 	}
-	logMergeTask(entry.GetLastestSchema().Name, task.ID(), mobjs, len(mergedBlks), osize, esize)
+	logMergeTask(entry.GetLastestSchemaLocked().Name, task.ID(), mobjs, len(mergedBlks), osize, esize)
 	if err = task.WaitDone(context.Background()); err != nil {
 		return moerr.NewInternalErrorNoCtx("merge error: %v", err)
 	}

--- a/pkg/vm/engine/tae/db/merge/policyBasic.go
+++ b/pkg/vm/engine/tae/db/merge/policyBasic.go
@@ -65,7 +65,7 @@ func (o *customConfigProvider) GetConfig(tbl *catalog.TableEntry) *BasicPolicyCo
 	defer o.Unlock()
 	p, ok := o.configs[tbl.ID]
 	if !ok {
-		extra := tbl.GetLastestSchema().Extra
+		extra := tbl.GetLastestSchemaLocked().Extra
 		if extra.MaxObjOnerun != 0 || extra.MinRowsQuailifed != 0 {
 			p = &BasicPolicyConfig{
 				ObjectMinRows:    int(extra.MinRowsQuailifed),
@@ -182,7 +182,7 @@ func (o *Basic) SetConfig(tbl *catalog.TableEntry, f func() txnif.AsyncTxn, c an
 		ctx,
 		api.NewUpdatePolicyReq(cfg.ObjectMinRows, cfg.MergeMaxOneRun, cfg.MaxRowsMergedObj, cfg.MergeHints...),
 	)
-	logutil.Infof("mergeblocks set %v-%v config: %v", tbl.ID, tbl.GetLastestSchema().Name, cfg)
+	logutil.Infof("mergeblocks set %v-%v config: %v", tbl.ID, tbl.GetLastestSchemaLocked().Name, cfg)
 	txn.Commit(ctx)
 	o.configProvider.InvalidCache(tbl)
 }
@@ -290,7 +290,7 @@ func (o *Basic) controlMem(objs []*catalog.ObjectEntry, mem int64) []*catalog.Ob
 
 func (o *Basic) ResetForTable(entry *catalog.TableEntry) {
 	o.id = entry.ID
-	o.schema = entry.GetLastestSchema()
+	o.schema = entry.GetLastestSchemaLocked()
 	o.hist = entry.Stats.GetLastMerge()
 	o.objHeap.reset()
 

--- a/pkg/vm/engine/tae/db/merge/policyOverlap.go
+++ b/pkg/vm/engine/tae/db/merge/policyOverlap.go
@@ -66,7 +66,7 @@ func (o *Overlap) Revise(cpu, mem int64) []*catalog.ObjectEntry {
 
 func (o *Overlap) ResetForTable(entry *catalog.TableEntry) {
 	o.id = entry.ID
-	o.schema = entry.GetLastestSchema()
+	o.schema = entry.GetLastestSchemaLocked()
 	o.analyzer.reset()
 }
 

--- a/pkg/vm/engine/tae/db/scannerop.go
+++ b/pkg/vm/engine/tae/db/scannerop.go
@@ -188,7 +188,7 @@ func (s *MergeTaskBuilder) resetForTable(entry *catalog.TableEntry) {
 	if entry != nil {
 		s.tid = entry.ID
 		s.tbl = entry
-		s.name = entry.GetLastestSchema().Name
+		s.name = entry.GetLastestSchemaLocked().Name
 		s.tableRowCnt = 0
 		s.tableRowDel = 0
 	}

--- a/pkg/vm/engine/tae/db/testutil/engine.go
+++ b/pkg/vm/engine/tae/db/testutil/engine.go
@@ -209,7 +209,7 @@ func (e *TestEngine) TryAppend(bat *containers.Batch) {
 }
 func (e *TestEngine) DeleteAll(skipConflict bool) error {
 	txn, rel := e.GetRelation()
-	schema := rel.GetMeta().(*catalog.TableEntry).GetLastestSchema()
+	schema := rel.GetMeta().(*catalog.TableEntry).GetLastestSchemaLocked()
 	pkName := schema.GetPrimaryKey().Name
 	it := rel.MakeBlockIt()
 	for it.Valid() {

--- a/pkg/vm/engine/tae/logtail/collector.go
+++ b/pkg/vm/engine/tae/logtail/collector.go
@@ -422,7 +422,7 @@ func (d *dirtyCollector) tryCompactTree(
 		tbl.Stats.RUnlock()
 
 		if x := ctx.Value(TempFKey{}); x != nil && TempF.Check(tbl.ID) {
-			logutil.Infof("temp filter skip table %v-%v", tbl.ID, tbl.GetLastestSchema().Name)
+			logutil.Infof("temp filter skip table %v-%v", tbl.ID, tbl.GetLastestSchemaLocked().Name)
 			tree.Shrink(id)
 			continue
 		}

--- a/pkg/vm/engine/tae/logtail/handle.go
+++ b/pkg/vm/engine/tae/logtail/handle.go
@@ -185,7 +185,7 @@ func HandleSyncLogTailReq(
 
 	if canRetry && scope == ScopeUserTables { // check simple conditions first
 		_, name, forceFlush := fault.TriggerFault("logtail_max_size")
-		if (forceFlush && name == tableEntry.GetLastestSchema().Name) || resp.ProtoSize() > Size90M {
+		if (forceFlush && name == tableEntry.GetLastestSchemaLocked().Name) || resp.ProtoSize() > Size90M {
 			_ = ckpClient.FlushTable(ctx, did, tid, end)
 			// try again after flushing
 			newResp, closeCB, err := HandleSyncLogTailReq(ctx, ckpClient, mgr, c, req, false)
@@ -464,7 +464,7 @@ func NewTableLogtailRespBuilder(ctx context.Context, ckp string, start, end type
 	b.did = tbl.GetDB().GetID()
 	b.tid = tbl.ID
 	b.dname = tbl.GetDB().GetName()
-	b.tname = tbl.GetLastestSchema().Name
+	b.tname = tbl.GetLastestSchemaLocked().Name
 
 	b.dataInsBatches = make(map[uint32]*containers.Batch)
 	b.dataDelBatch = makeRespBatchFromSchema(DelSchema, common.LogtailAllocator)
@@ -537,7 +537,7 @@ func visitObject(batch *containers.Batch, entry *catalog.ObjectEntry, node *cata
 	batch.GetVectorByName(SnapshotAttr_TID).Append(entry.GetTable().ID, false)
 	batch.GetVectorByName(ObjectAttr_State).Append(entry.IsAppendable(), false)
 	sorted := false
-	if entry.GetTable().GetLastestSchema().HasSortKey() && !entry.IsAppendable() {
+	if entry.GetTable().GetLastestSchemaLocked().HasSortKey() && !entry.IsAppendable() {
 		sorted = true
 	}
 	batch.GetVectorByName(ObjectAttr_Sorted).Append(sorted, false)

--- a/pkg/vm/engine/tae/logtail/utils.go
+++ b/pkg/vm/engine/tae/logtail/utils.go
@@ -2886,9 +2886,9 @@ func (collector *BaseCollector) VisitTable(entry *catalog.TableEntry) (err error
 			}
 
 			tableColInsTxnBat.GetVectorByName(
-				SnapshotAttr_BlockMaxRow).Append(entry.GetLastestSchema().BlockMaxRows, false)
+				SnapshotAttr_BlockMaxRow).Append(entry.GetLastestSchemaLocked().BlockMaxRows, false)
 			tableColInsTxnBat.GetVectorByName(
-				SnapshotAttr_ObjectMaxBlock).Append(entry.GetLastestSchema().ObjectMaxBlocks, false)
+				SnapshotAttr_ObjectMaxBlock).Append(entry.GetLastestSchemaLocked().ObjectMaxBlocks, false)
 			tableColInsTxnBat.GetVectorByName(
 				SnapshotAttr_SchemaExtra).Append(tblNode.BaseNode.Schema.MustGetExtraBytes(), false)
 

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -180,7 +180,7 @@ func (c *catalogArg) FromCommand(cmd *cobra.Command) (err error) {
 func (c *catalogArg) String() string {
 	t := "*"
 	if c.tbl != nil {
-		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchema().Name)
+		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchemaLocked().Name)
 	}
 	f := "nil"
 	if c.outfile != nil {
@@ -256,7 +256,7 @@ func (c *objStatArg) FromCommand(cmd *cobra.Command) (err error) {
 func (c *objStatArg) String() string {
 	t := "*"
 	if c.tbl != nil {
-		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchema().Name)
+		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchemaLocked().Name)
 	}
 	return t
 }
@@ -470,7 +470,7 @@ func (c *infoArg) FromCommand(cmd *cobra.Command) (err error) {
 func (c *infoArg) String() string {
 	t := "*"
 	if c.tbl != nil {
-		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchema().Name)
+		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchemaLocked().Name)
 	}
 
 	if c.blk != nil {
@@ -584,7 +584,7 @@ func (c *manuallyMergeArg) FromCommand(cmd *cobra.Command) (err error) {
 func (c *manuallyMergeArg) String() string {
 	t := "*"
 	if c.tbl != nil {
-		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchema().Name)
+		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchemaLocked().Name)
 	}
 
 	b := &bytes.Buffer{}
@@ -602,7 +602,7 @@ func (c *manuallyMergeArg) Run() error {
 	}
 	c.ctx.resp.Payload = []byte(fmt.Sprintf(
 		"success. see more to run select mo_ctl('dn', 'inspect', 'object -t %s.%s')\\G",
-		c.tbl.GetDB().GetName(), c.tbl.GetLastestSchema().Name,
+		c.tbl.GetDB().GetName(), c.tbl.GetLastestSchemaLocked().Name,
 	))
 	return nil
 }
@@ -653,7 +653,7 @@ func (c *compactPolicyArg) FromCommand(cmd *cobra.Command) (err error) {
 func (c *compactPolicyArg) String() string {
 	t := "*"
 	if c.tbl != nil {
-		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchema().Name)
+		t = fmt.Sprintf("%d-%s", c.tbl.ID, c.tbl.GetLastestSchemaLocked().Name)
 	}
 	return fmt.Sprintf(
 		"(%s) maxMergeObjN: %v, minRowsQualified: %v, hints: %v",
@@ -713,7 +713,7 @@ func (c *RenameColArg) PrepareCommand() *cobra.Command {
 }
 
 func (c *RenameColArg) String() string {
-	return fmt.Sprintf("rename col: %v, %v,%v,%v", c.tbl.GetLastestSchema().Name, c.oldName, c.newName, c.seq)
+	return fmt.Sprintf("rename col: %v, %v,%v,%v", c.tbl.GetLastestSchemaLocked().Name, c.oldName, c.newName, c.seq)
 }
 
 func (c *RenameColArg) Run() (err error) {
@@ -727,7 +727,7 @@ func (c *RenameColArg) Run() (err error) {
 	if err != nil {
 		return err
 	}
-	tblHdl, err := dbHdl.GetRelationByName(c.tbl.GetLastestSchema().Name)
+	tblHdl, err := dbHdl.GetRelationByName(c.tbl.GetLastestSchemaLocked().Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/vm/engine/tae/rpc/rpc_test.go
+++ b/pkg/vm/engine/tae/rpc/rpc_test.go
@@ -368,7 +368,7 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 	// set blockmaxrow as 10
 	p := &catalog.LoopProcessor{}
 	p.TableFn = func(te *catalog.TableEntry) error {
-		schema := te.GetLastestSchema()
+		schema := te.GetLastestSchemaLocked()
 		if schema.Name == "tbtest" {
 			schema.BlockMaxRows = 10
 		}

--- a/pkg/vm/engine/tae/tables/blk.go
+++ b/pkg/vm/engine/tae/tables/blk.go
@@ -133,7 +133,7 @@ func (blk *block) BatchDedup(
 ) (err error) {
 	defer func() {
 		if moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry) {
-			logutil.Infof("BatchDedup %s (%v)BLK-%s: %v", blk.meta.GetObject().GetTable().GetLastestSchema().Name, blk.IsAppendable(), blk.meta.ID.String(), err)
+			logutil.Infof("BatchDedup %s (%v)BLK-%s: %v", blk.meta.GetObject().GetTable().GetLastestSchemaLocked().Name, blk.IsAppendable(), blk.meta.ID.String(), err)
 		}
 	}()
 	return blk.PersistedBatchDedup(

--- a/pkg/vm/engine/tae/tables/object.go
+++ b/pkg/vm/engine/tae/tables/object.go
@@ -40,7 +40,7 @@ func BuildObjectCompactionTaskFactory(meta *catalog.ObjectEntry, rt *dbutils.Run
 	filter.AddBlockFilter(catalog.NonAppendableBlkFilter)
 	filter.AddCommitFilter(catalog.ActiveWithNoTxnFilter)
 	blks := meta.CollectBlockEntries(filter.FilteCommit, filter.FilteBlock)
-	if len(blks) < int(meta.GetTable().GetLastestSchema().ObjectMaxBlocks) {
+	if len(blks) < int(meta.GetTable().GetLastestSchemaLocked().ObjectMaxBlocks) {
 		return
 	}
 	for _, blk := range blks {

--- a/pkg/vm/engine/tae/tables/txnentries/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/txnentries/flushTableTail.go
@@ -95,7 +95,7 @@ func NewFlushTableTailEntry(
 
 // add transfer pages for dropped ablocks
 func (entry *flushTableTailEntry) addTransferPages() {
-	isTransient := !entry.tableEntry.GetLastestSchema().HasPK()
+	isTransient := !entry.tableEntry.GetLastestSchemaLocked().HasPK()
 	for i, mcontainer := range entry.transMappings.Mappings {
 		m := mcontainer.M
 		if len(m) == 0 {

--- a/pkg/vm/engine/tae/tables/txnentries/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/txnentries/mergeobjects.go
@@ -77,7 +77,7 @@ func (entry *mergeObjectsEntry) prepareTransferPage() {
 			panic("cannot tranfer empty block")
 		}
 		tblEntry := blk.GetObject().GetTable()
-		isTransient := !tblEntry.GetLastestSchema().HasPK()
+		isTransient := !tblEntry.GetLastestSchemaLocked().HasPK()
 		id := blk.AsCommonID()
 		page := model.NewTransferHashPage(id, time.Now(), isTransient)
 		for srcRow, dst := range mapping {

--- a/pkg/vm/engine/tae/txn/txnimpl/database.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/database.go
@@ -128,7 +128,7 @@ func cloneLatestSchema(meta *catalog.TableEntry) *catalog.Schema {
 	if latest != nil {
 		return latest.BaseNode.Schema.Clone()
 	}
-	return meta.GetLastestSchema().Clone()
+	return meta.GetLastestSchemaLocked().Clone()
 }
 
 func (db *txnDatabase) TruncateByName(name string) (rel handle.Relation, err error) {

--- a/pkg/vm/engine/tae/txn/txnimpl/relation.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/relation.go
@@ -82,8 +82,8 @@ func (it *txnRelationIt) Next() {
 		entry.RLock()
 		// SystemDB can hold table created by different tenant, filter needed.
 		// while the 3 shared tables are not affected
-		if it.txnDB.entry.IsSystemDB() && !isSysTable(entry.GetLastestSchema().Name) &&
-			entry.GetLastestSchema().AcInfo.TenantID != txn.GetTenantID() {
+		if it.txnDB.entry.IsSystemDB() && !isSysTable(entry.GetLastestSchemaLocked().Name) &&
+			entry.GetLastestSchemaLocked().AcInfo.TenantID != txn.GetTenantID() {
 			entry.RUnlock()
 			continue
 		}
@@ -154,7 +154,7 @@ func (h *txnRelation) BatchDedup(col containers.Vector) error {
 }
 
 func (h *txnRelation) Append(ctx context.Context, data *containers.Batch) error {
-	if !h.table.GetLocalSchema().IsSameColumns(h.table.GetMeta().GetLastestSchema()) {
+	if !h.table.GetLocalSchema().IsSameColumns(h.table.GetMeta().GetLastestSchemaLocked()) {
 		return moerr.NewInternalErrorNoCtx("schema changed, please rollback and retry")
 	}
 	return h.Txn.GetStore().Append(ctx, h.table.entry.GetDB().ID, h.table.entry.GetID(), data)

--- a/pkg/vm/engine/tae/txn/txnimpl/sysblock.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/sysblock.go
@@ -52,7 +52,7 @@ func bool2i8(v bool) int8 {
 }
 
 func (blk *txnSysBlock) isSysTable() bool {
-	return isSysTable(blk.table.entry.GetLastestSchema().Name)
+	return isSysTable(blk.table.entry.GetLastestSchemaLocked().Name)
 }
 
 func (blk *txnSysBlock) GetTotalChanges() int {
@@ -127,7 +127,7 @@ func (blk *txnSysBlock) processTable(entry *catalog.DBEntry, fn func(*catalog.Ta
 func (blk *txnSysBlock) columnRows() int {
 	rows := 0
 	fn := func(table *catalog.TableEntry) error {
-		rows += len(table.GetLastestSchema().ColDefs)
+		rows += len(table.GetLastestSchemaLocked().ColDefs)
 		return nil
 	}
 	dbFn := func(db *catalog.DBEntry) error {

--- a/pkg/vm/engine/tae/txn/txnimpl/table_space.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table_space.go
@@ -488,12 +488,12 @@ func (space *tableSpace) GetByFilter(filter *handle.Filter) (id *common.ID, offs
 }
 
 func (space *tableSpace) GetPKColumn() containers.Vector {
-	schema := space.table.entry.GetLastestSchema()
+	schema := space.table.entry.GetLastestSchemaLocked()
 	return space.index.KeyToVector(schema.GetSingleSortKeyType())
 }
 
 func (space *tableSpace) GetPKVecs() []containers.Vector {
-	schema := space.table.entry.GetLastestSchema()
+	schema := space.table.entry.GetLastestSchemaLocked()
 	return space.index.KeyToVectors(schema.GetSingleSortKeyType())
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/14974

## What this PR does / why we need it:
has concurrent read-write on `TableEntry.schema.Name`

Add an interface to let users choose to lock or not when using `TableEntry.schema.Name`.