### PR TITLE
bugfix: account access table in `metric` db missing sys accountId

### DIFF
--- a/pkg/sql/util/util.go
+++ b/pkg/sql/util/util.go
@@ -67,6 +67,8 @@ func TableIsLoggingTable(dbName string, tableName string) bool {
 		return true
 	} else if tableName == "metric" && dbName == "system_metrics" {
 		return true
+	} else if tableName == catalog.MO_SQL_STMT_CU && dbName == catalog.MO_SYSTEM_METRICS {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2693

## What this PR does / why we need it:
changes:
1. mark table `sysetem_metrics.sql_statement_cu` as `LoggingTable`.