### PR TITLE
use max memory size of Operator to compute CU

### DIFF
--- a/pkg/sql/colexec/anti/join.go
+++ b/pkg/sql/colexec/anti/join.go
@@ -120,7 +120,7 @@ func (ctr *container) receiveHashMap(proc *process.Process, anal process.Analyze
 	if bat != nil && bat.AuxData != nil {
 		ctr.mp = bat.DupJmAuxData()
 		ctr.hasNull = ctr.mp.HasNull()
-		anal.Alloc(ctr.mp.Size())
+		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil
 }

--- a/pkg/sql/colexec/anti/types.go
+++ b/pkg/sql/colexec/anti/types.go
@@ -59,6 +59,8 @@ type container struct {
 	vecs            []*vector.Vector
 
 	mp *hashmap.JoinMap
+
+	maxAllocSize int64
 }
 
 type Argument struct {
@@ -116,6 +118,9 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		ctr.cleanHashMap()
 		ctr.cleanExprExecutor()
 		ctr.FreeAllReg()
+
+		anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+		anal.Alloc(ctr.maxAllocSize)
 	}
 }
 

--- a/pkg/sql/colexec/external/external.go
+++ b/pkg/sql/colexec/external/external.go
@@ -172,7 +172,7 @@ func (arg *Argument) Call(proc *process.Process) (vm.CallResult, error) {
 
 	if arg.buf != nil {
 		anal.Output(arg.buf, arg.GetIsLast())
-		anal.Alloc(int64(arg.buf.Size()))
+		arg.maxAllocSize = max(arg.maxAllocSize, arg.buf.Size())
 	}
 	result.Batch = arg.buf
 	if result.Batch != nil {

--- a/pkg/sql/colexec/external/types.go
+++ b/pkg/sql/colexec/external/types.go
@@ -99,6 +99,9 @@ type FilterParam struct {
 type Argument struct {
 	Es  *ExternalParam
 	buf *batch.Batch
+
+	maxAllocSize int
+
 	vm.OperatorBase
 }
 
@@ -143,6 +146,8 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		arg.buf.Clean(proc.Mp())
 		arg.buf = nil
 	}
+	anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+	anal.Alloc(int64(arg.maxAllocSize))
 }
 
 type ParseLineHandler struct {

--- a/pkg/sql/colexec/indexbuild/build.go
+++ b/pkg/sql/colexec/indexbuild/build.go
@@ -104,7 +104,7 @@ func (ctr *container) collectBuildBatches(ap *Argument, proc *process.Process, a
 			continue
 		}
 		anal.Input(currentBatch, isFirst)
-		anal.Alloc(int64(currentBatch.Size()))
+		// anal.Alloc(int64(currentBatch.Size())) @todo we need to redesin annalyze memory size
 		ctr.batch, err = ctr.batch.AppendWithCopy(proc.Ctx, proc.Mp(), currentBatch)
 		if err != nil {
 			return err

--- a/pkg/sql/colexec/join/join.go
+++ b/pkg/sql/colexec/join/join.go
@@ -127,7 +127,7 @@ func (ctr *container) receiveHashMap(proc *process.Process, anal process.Analyze
 	}
 	if bat != nil && bat.AuxData != nil {
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Size())
+		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil
 }

--- a/pkg/sql/colexec/join/types.go
+++ b/pkg/sql/colexec/join/types.go
@@ -62,6 +62,8 @@ type container struct {
 	vecs  []*vector.Vector
 
 	mp *hashmap.JoinMap
+
+	maxAllocSize int64
 }
 
 type Argument struct {
@@ -123,6 +125,9 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		ctr.cleanHashMap()
 		ctr.cleanExprExecutor()
 		ctr.FreeAllReg()
+
+		anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+		anal.Alloc(ctr.maxAllocSize)
 	}
 }
 

--- a/pkg/sql/colexec/left/join.go
+++ b/pkg/sql/colexec/left/join.go
@@ -117,7 +117,7 @@ func (ctr *container) receiveHashMap(proc *process.Process, anal process.Analyze
 	}
 	if bat != nil && bat.AuxData != nil {
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Size())
+		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil
 }

--- a/pkg/sql/colexec/left/types.go
+++ b/pkg/sql/colexec/left/types.go
@@ -62,6 +62,8 @@ type container struct {
 	vecs  []*vector.Vector
 
 	mp *hashmap.JoinMap
+
+	maxAllocSize int64
 }
 
 type Argument struct {
@@ -124,6 +126,9 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		ctr.cleanExprExecutor()
 		ctr.cleanEvalVectors()
 		ctr.FreeAllReg()
+
+		anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+		anal.Alloc(ctr.maxAllocSize)
 	}
 }
 

--- a/pkg/sql/colexec/mark/join.go
+++ b/pkg/sql/colexec/mark/join.go
@@ -144,7 +144,7 @@ func (ctr *container) receiveHashMap(proc *process.Process, anal process.Analyze
 	}
 	if bat != nil && bat.AuxData != nil {
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Size())
+		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil
 }

--- a/pkg/sql/colexec/mark/types.go
+++ b/pkg/sql/colexec/mark/types.go
@@ -107,6 +107,8 @@ type container struct {
 
 	nullWithBatch *batch.Batch
 	rewriteCond   *plan.Expr
+
+	maxAllocSize int64
 }
 
 // // for join operator, it's a two-ary operator, we will reference to two table
@@ -203,6 +205,9 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		ctr.cleanHashMap()
 		ctr.cleanExprExecutor()
 		ctr.FreeAllReg()
+
+		anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+		anal.Alloc(ctr.maxAllocSize)
 		arg.ctr = nil
 	}
 }

--- a/pkg/sql/colexec/projection/projection.go
+++ b/pkg/sql/colexec/projection/projection.go
@@ -94,7 +94,7 @@ func (arg *Argument) Call(proc *process.Process) (vm.CallResult, error) {
 	if err != nil {
 		return result, err
 	}
-	anal.Alloc(int64(newAlloc))
+	arg.maxAllocSize = max(arg.maxAllocSize, newAlloc)
 	arg.buf.SetRowCount(bat.RowCount())
 
 	anal.Output(arg.buf, arg.GetIsLast())

--- a/pkg/sql/colexec/projection/types.go
+++ b/pkg/sql/colexec/projection/types.go
@@ -31,6 +31,8 @@ type Argument struct {
 	Es  []*plan.Expr
 	buf *batch.Batch
 	vm.OperatorBase
+
+	maxAllocSize int
 }
 
 func (arg *Argument) GetOperatorBase() *vm.OperatorBase {
@@ -82,4 +84,6 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		arg.buf.Clean(proc.Mp())
 		arg.buf = nil
 	}
+	anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+	anal.Alloc(int64(arg.maxAllocSize))
 }

--- a/pkg/sql/colexec/right/join.go
+++ b/pkg/sql/colexec/right/join.go
@@ -150,7 +150,7 @@ func (ctr *container) receiveHashMap(proc *process.Process, anal process.Analyze
 	}
 	if bat != nil && bat.AuxData != nil {
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Size())
+		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil
 }

--- a/pkg/sql/colexec/right/types.go
+++ b/pkg/sql/colexec/right/types.go
@@ -68,6 +68,8 @@ type container struct {
 	matched *bitmap.Bitmap
 
 	handledLast bool
+
+	maxAllocSize int64
 }
 
 type Argument struct {
@@ -147,6 +149,9 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		ctr.cleanExprExecutor()
 		ctr.FreeAllReg()
 		ctr.cleanEvalVectors()
+
+		anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+		anal.Alloc(ctr.maxAllocSize)
 	}
 }
 

--- a/pkg/sql/colexec/rightanti/join.go
+++ b/pkg/sql/colexec/rightanti/join.go
@@ -143,7 +143,7 @@ func (ctr *container) receiveHashMap(proc *process.Process, anal process.Analyze
 	}
 	if bat != nil && bat.AuxData != nil {
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Size())
+		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil
 }

--- a/pkg/sql/colexec/rightanti/types.go
+++ b/pkg/sql/colexec/rightanti/types.go
@@ -70,6 +70,8 @@ type container struct {
 	handledLast bool
 
 	tmpBatches []*batch.Batch // for reuse
+
+	maxAllocSize int64
 }
 
 type Argument struct {
@@ -146,6 +148,9 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		ctr.cleanExprExecutor()
 		ctr.FreeAllReg()
 		ctr.tmpBatches = nil
+
+		anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+		anal.Alloc(ctr.maxAllocSize)
 	}
 }
 

--- a/pkg/sql/colexec/rightsemi/join.go
+++ b/pkg/sql/colexec/rightsemi/join.go
@@ -144,7 +144,7 @@ func (ctr *container) receiveHashMap(proc *process.Process, anal process.Analyze
 	}
 	if bat != nil && bat.AuxData != nil {
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Size())
+		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil
 }

--- a/pkg/sql/colexec/rightsemi/types.go
+++ b/pkg/sql/colexec/rightsemi/types.go
@@ -70,6 +70,8 @@ type container struct {
 	handledLast bool
 
 	tmpBatches []*batch.Batch // for reuse
+
+	maxAllocSize int64
 }
 
 type Argument struct {
@@ -146,6 +148,9 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		ctr.cleanExprExecutor()
 		ctr.FreeAllReg()
 		ctr.tmpBatches = nil
+
+		anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+		anal.Alloc(ctr.maxAllocSize)
 	}
 }
 

--- a/pkg/sql/colexec/semi/join.go
+++ b/pkg/sql/colexec/semi/join.go
@@ -138,7 +138,7 @@ func (ctr *container) receiveHashMap(proc *process.Process, anal process.Analyze
 	}
 	if bat != nil && bat.AuxData != nil {
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Size())
+		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil
 }

--- a/pkg/sql/colexec/semi/types.go
+++ b/pkg/sql/colexec/semi/types.go
@@ -63,6 +63,8 @@ type container struct {
 
 	mp        *hashmap.JoinMap
 	skipProbe bool
+
+	maxAllocSize int64
 }
 
 type Argument struct {
@@ -120,6 +122,9 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		ctr.cleanHashMap()
 		ctr.cleanExprExecutor()
 		ctr.FreeAllReg()
+
+		anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+		anal.Alloc(ctr.maxAllocSize)
 	}
 }
 

--- a/pkg/sql/colexec/single/join.go
+++ b/pkg/sql/colexec/single/join.go
@@ -122,7 +122,7 @@ func (ctr *container) receiveHashMap(proc *process.Process, anal process.Analyze
 	}
 	if bat != nil && bat.AuxData != nil {
 		ctr.mp = bat.DupJmAuxData()
-		anal.Alloc(ctr.mp.Size())
+		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil
 }

--- a/pkg/sql/colexec/single/types.go
+++ b/pkg/sql/colexec/single/types.go
@@ -62,6 +62,8 @@ type container struct {
 	vecs  []*vector.Vector
 
 	mp *hashmap.JoinMap
+
+	maxAllocSize int64
 }
 
 type Argument struct {
@@ -118,6 +120,9 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 		ctr.cleanHashMap()
 		ctr.cleanExprExecutor()
 		ctr.FreeAllReg()
+
+		anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+		anal.Alloc(ctr.maxAllocSize)
 	}
 }
 

--- a/pkg/sql/colexec/table_scan/table_scan.go
+++ b/pkg/sql/colexec/table_scan/table_scan.go
@@ -138,7 +138,8 @@ func (arg *Argument) Call(proc *process.Process) (vm.CallResult, error) {
 
 		bat.Cnt = 1
 		anal.S3IOByte(bat)
-		anal.Alloc(int64(bat.Size()))
+		batSize := bat.Size()
+		arg.maxAllocSize = max(arg.maxAllocSize, batSize)
 
 		if arg.tmpBuf == nil {
 			arg.tmpBuf = bat
@@ -146,7 +147,6 @@ func (arg *Argument) Call(proc *process.Process) (vm.CallResult, error) {
 		}
 
 		tmpSize := arg.tmpBuf.Size()
-		batSize := bat.Size()
 		if arg.tmpBuf.RowCount()+bat.RowCount() < colexec.DefaultBatchSize && tmpSize+batSize < maxBatchMemSize {
 			_, err := arg.tmpBuf.Append(proc.Ctx, proc.GetMPool(), bat)
 			proc.PutBatch(bat)

--- a/pkg/sql/colexec/table_scan/types.go
+++ b/pkg/sql/colexec/table_scan/types.go
@@ -36,6 +36,8 @@ type Argument struct {
 	buf    *batch.Batch
 	tmpBuf *batch.Batch
 
+	maxAllocSize int
+
 	vm.OperatorBase
 }
 
@@ -84,4 +86,6 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 	if arg.msgReceiver != nil {
 		arg.msgReceiver.Free()
 	}
+	anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+	anal.Alloc(int64(arg.maxAllocSize))
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/2351

## What this PR does / why we need it:
现在table_scan算子在计算内存占用的时候，是使用累计的方式。
修改为取单次batch的最高值的方式计算内存占用