### PR TITLE
fix metric, stats in 1.1

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -540,6 +540,9 @@ type ObservabilityParameters struct {
 	// LabelSelector
 	LabelSelector map[string]string `toml:"labelSelector"`
 
+	// estimate tcp network packet cost
+	TCPPacket bool `toml:"tcpPacket"`
+
 	// for cu calculation
 	CU   OBCUConfig `toml:"cu"`
 	CUv1 OBCUConfig `toml:"cu_v1"`
@@ -573,6 +576,7 @@ func NewObservabilityParameters() *ObservabilityParameters {
 		SelectAggrThreshold:                toml.Duration{},
 		EnableStmtMerge:                    false,
 		LabelSelector:                      map[string]string{defaultLoggerLabelKey: defaultLoggerLabelVal}, /*role=logging_cn*/
+		TCPPacket:                          false,
 		CU:                                 *NewOBCUConfig(),
 		CUv1:                               *NewOBCUConfig(),
 		OBCollectorConfig:                  *NewOBCollectorConfig(),

--- a/pkg/frontend/cmd_executor.go
+++ b/pkg/frontend/cmd_executor.go
@@ -279,7 +279,6 @@ func (bse *baseStmtExecutor) CommitOrRollbackTxn(ctx context.Context, ses *Sessi
 	var txnErr error
 	stmt := bse.GetAst()
 	tenant := bse.tenantName
-	incStatementCounter(tenant, stmt)
 	if bse.GetStatus() == stmtExecSuccess {
 		txnErr = ses.TxnCommitSingleStatement(stmt)
 		if txnErr != nil {

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2653,11 +2653,6 @@ var GetStmtExecList = func(db, sql, user string, eng engine.Engine, proc *proces
 	return stmtExecList, nil
 }
 
-// Deprecated
-func incStatementCounter(tenant string, stmt tree.Statement) {
-	metric.StatementCounter(tenant, getStatementType(stmt).GetQueryType()).Inc()
-}
-
 func incTransactionCounter(tenant string) {
 	metric.TransactionCounter(tenant).Inc()
 }

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -360,7 +360,6 @@ var RecordParseErrorStatement = func(ctx context.Context, ses *Session, proc *pr
 	if tenant == nil {
 		tenant, _ = GetTenantInfo(ctx, "internal")
 	}
-	incStatementCounter(tenant.GetTenant(), nil)
 	incStatementErrorsCounter(tenant.GetTenant(), nil)
 	return ctx, nil
 }
@@ -2654,6 +2653,7 @@ var GetStmtExecList = func(db, sql, user string, eng engine.Engine, proc *proces
 	return stmtExecList, nil
 }
 
+// Deprecated
 func incStatementCounter(tenant string, stmt tree.Statement) {
 	metric.StatementCounter(tenant, getStatementType(stmt).GetQueryType()).Inc()
 }
@@ -3082,7 +3082,6 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 
 	//get errors during the transaction. rollback the transaction
 	rollbackTxnFunc := func() error {
-		incStatementCounter(tenant, stmt)
 		incStatementErrorsCounter(tenant, stmt)
 		/*
 			Cases    | set Autocommit = 1/0 | BEGIN statement |
@@ -3118,7 +3117,6 @@ func (mce *MysqlCmdExecutor) executeStmt(requestCtx context.Context,
 		}()
 
 		//load data handle txn failure internally
-		incStatementCounter(tenant, stmt)
 		retErr = ses.TxnCommitSingleStatement(stmt)
 		if retErr != nil {
 			logStatementStatus(requestCtx, ses, stmt, fail, retErr)

--- a/pkg/frontend/status_stmt.go
+++ b/pkg/frontend/status_stmt.go
@@ -498,7 +498,6 @@ type LoadExecutor struct {
 func (le *LoadExecutor) CommitOrRollbackTxn(ctx context.Context, ses *Session) error {
 	stmt := le.GetAst()
 	tenant := le.tenantName
-	incStatementCounter(tenant, stmt)
 	if le.GetStatus() == stmtExecSuccess {
 		logStatementStatus(ctx, ses, stmt, success, nil)
 	} else {

--- a/pkg/util/trace/impl/motrace/config.go
+++ b/pkg/util/trace/impl/motrace/config.go
@@ -86,6 +86,8 @@ type tracerProviderConfig struct {
 	cuConfig   config.OBCUConfig // WithCUConfig
 	cuConfigV1 config.OBCUConfig // WithCUConfig
 
+	tcpPacket bool // WithTCPPacket
+
 	mux sync.RWMutex
 }
 
@@ -208,6 +210,12 @@ func WithCUConfig(cu config.OBCUConfig, cuv1 config.OBCUConfig) tracerProviderOp
 	return func(cfg *tracerProviderConfig) {
 		cfg.cuConfig = cu
 		cfg.cuConfigV1 = cuv1
+	}
+}
+
+func WithTCPPacket(count bool) tracerProviderOption {
+	return func(cfg *tracerProviderConfig) {
+		cfg.tcpPacket = count
 	}
 }
 

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -597,7 +597,9 @@ func EndStatement(ctx context.Context, err error, sentRows int64, outBytes int64
 		if err != nil {
 			outBytes += ResponseErrPacketSize + int64(len(err.Error()))
 		}
-		outBytes += TcpIpv4HeaderSize * outPacket
+		if GetTracerProvider().tcpPacket {
+			outBytes += TcpIpv4HeaderSize * outPacket
+		}
 		s.statsArray.InitIfEmpty().WithOutTrafficBytes(float64(outBytes)).WithOutPacketCount(float64(outPacket))
 		s.ExecPlan2Stats(ctx)
 		if s.statsArray.GetCU() < 0 {

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -592,8 +592,11 @@ func EndStatement(ctx context.Context, err error, sentRows int64, outBytes int64
 		s.ResultCount = sentRows
 		s.AggrCount = 0
 		s.MarkResponseAt()
+		// --- Start of metric part
 		// duration is filled in s.MarkResponseAt()
+		incStatementCounter(s.Account, s.QueryType)
 		addStatementDurationCounter(s.Account, s.QueryType, s.Duration)
+		// --- END of metric part
 		if err != nil {
 			outBytes += ResponseErrPacketSize + int64(len(err.Error()))
 		}
@@ -620,8 +623,11 @@ func EndStatement(ctx context.Context, err error, sentRows int64, outBytes int64
 	}
 }
 
-func addStatementDurationCounter(tenant, querytype string, duration time.Duration) {
-	metric.StatementDuration(tenant, querytype).Add(float64(duration))
+func addStatementDurationCounter(tenant, queryType string, duration time.Duration) {
+	metric.StatementDuration(tenant, queryType).Add(float64(duration))
+}
+func incStatementCounter(tenant, queryType string) {
+	metric.StatementCounter(tenant, queryType).Inc()
 }
 
 type StatementInfoStatus int

--- a/pkg/util/trace/impl/motrace/trace.go
+++ b/pkg/util/trace/impl/motrace/trace.go
@@ -68,6 +68,7 @@ func InitWithConfig(ctx context.Context, SV *config.ObservabilityParameters, opt
 		WithSelectThreshold(SV.SelectAggrThreshold.Duration),
 		WithStmtMergeEnable(SV.EnableStmtMerge),
 		WithCUConfig(SV.CU, SV.CUv1),
+		WithTCPPacket(SV.TCPPacket),
 
 		DebugMode(SV.EnableTraceDebug),
 		WithBufferSizeThreshold(SV.BufferSize),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2734, https://github.com/matrixorigin/MO-Cloud/issues/2726

## What this PR does / why we need it:
changes:
1. move StatmentCounter above StatementDurationCounter, corrent the acount & query_type `metric/sql_statement_total` count
2. disable tcp packet estimate in network traffic stats.

- New config item
```diff
[observability]
+ tcpPacket = false   // false: disable tcp packet estimate in network traffic stats
```