### PR TITLE
[fix] : prevent table scan for fuzzy filter from running on multiple CNs to fix moc2765

### DIFF
--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -1373,6 +1373,10 @@ func appendPrimaryConstrantPlan(
 				scanNode.RuntimeFilterProbeList = nil // can not use both
 			} else {
 				tableScanId = builder.appendNode(scanNode, bindCtx)
+				// temporary solution for the plan of dml go without optimizer
+				// prevent table scan from running on multiple CNs.
+				// because the runtime filter can only run on one now.
+				scanNode.Stats = DefaultMinimalStats()
 			}
 
 			// Perform partition pruning on the full table scan of the partitioned table in the insert statement


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2765

## What this PR does / why we need it:

dml的plan都是手写的，没有过优化器计算, fuzzy filter复用runtime filter的逻辑有误。最简单的改发是让scan限定在单并发