### PR TITLE
fileservice: add ObjectStorageArguments.shouldLoadDefaultCredentials

### DIFF
--- a/pkg/fileservice/aliyun_sdk.go
+++ b/pkg/fileservice/aliyun_sdk.go
@@ -586,7 +586,7 @@ func (o ObjectStorageArguments) credentialProviderForAliyunSDK(
 
 	if config.Type == nil {
 
-		if o.NoDefaultCredentials {
+		if !o.shouldLoadDefaultCredentials() {
 			return nil, moerr.NewInvalidInputNoCtx(
 				"no valid credentials",
 			)

--- a/pkg/fileservice/aws_sdk_v2.go
+++ b/pkg/fileservice/aws_sdk_v2.go
@@ -759,7 +759,7 @@ func (o ObjectStorageArguments) credentialsProviderForAwsSDKv2(
 		return credentials.NewStaticCredentialsProvider(o.KeyID, o.KeySecret, o.SessionToken), nil
 	}
 
-	if o.NoDefaultCredentials {
+	if !o.shouldLoadDefaultCredentials() {
 		return nil, moerr.NewInvalidInputNoCtx(
 			"no valid credentials",
 		)

--- a/pkg/fileservice/minio_sdk.go
+++ b/pkg/fileservice/minio_sdk.go
@@ -60,7 +60,7 @@ func NewMinioSDK(
 
 	// credentials
 	var credentialProviders []credentials.Provider
-	if !args.NoDefaultCredentials {
+	if args.shouldLoadDefaultCredentials() {
 		credentialProviders = append(credentialProviders,
 			// aws env
 			new(credentials.EnvAWS),

--- a/pkg/fileservice/object_storage_arguments.go
+++ b/pkg/fileservice/object_storage_arguments.go
@@ -158,3 +158,18 @@ func (o *ObjectStorageArguments) validate() error {
 
 	return nil
 }
+
+func (o *ObjectStorageArguments) shouldLoadDefaultCredentials() bool {
+
+	// default credentials enabled
+	if !o.NoDefaultCredentials {
+		return true
+	}
+
+	// default credentials disabled, but role arn is not empty
+	if o.RoleARN != "" {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15154 

## What this PR does / why we need it:
refine no credentials rules.