### PR TITLE
remove metrics in `mpool.Free` and `mpool.Alloc`

### DIFF
--- a/pkg/common/mpool/mpool.go
+++ b/pkg/common/mpool/mpool.go
@@ -541,11 +541,6 @@ func sizeToIdx(size int) int {
 }
 
 func (mp *MPool) Alloc(sz int) ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		v2.TxnMpoolAllocDurationHistogram.Observe(time.Since(start).Seconds())
-	}()
-
 	// reject unexpected alloc size.
 	if sz < 0 || sz > GB {
 		logutil.Errorf("Invalid alloc size %d: %s", sz, string(debug.Stack()))
@@ -599,11 +594,6 @@ func (mp *MPool) Alloc(sz int) ([]byte, error) {
 }
 
 func (mp *MPool) Free(bs []byte) {
-	start := time.Now()
-	defer func() {
-		v2.TxnMpoolFreeDurationHistogram.Observe(time.Since(start).Seconds())
-	}()
-
 	if bs == nil || cap(bs) == 0 {
 		return
 	}

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
@@ -469,14 +469,10 @@ func (c *DashboardCreator) initTxnMpoolRow() dashboard.Option {
 		c.getMultiHistogram(
 			[]string{
 				c.getMetricWithFilter(`mo_txn_mpool_duration_seconds_bucket`, `type="new"`),
-				c.getMetricWithFilter(`mo_txn_mpool_duration_seconds_bucket`, `type="alloc"`),
-				c.getMetricWithFilter(`mo_txn_mpool_duration_seconds_bucket`, `type="free"`),
 				c.getMetricWithFilter(`mo_txn_mpool_duration_seconds_bucket`, `type="delete"`),
 			},
 			[]string{
 				"new",
-				"alloc",
-				"free",
 				"delete",
 			},
 			[]float64{0.50, 0.8, 0.90, 0.99},

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -287,8 +287,6 @@ var (
 			Buckets:   getDurationBuckets(),
 		}, []string{"type"})
 	TxnMpoolNewDurationHistogram    = txnMpoolDurationHistogram.WithLabelValues("new")
-	TxnMpoolAllocDurationHistogram  = txnMpoolDurationHistogram.WithLabelValues("alloc")
-	TxnMpoolFreeDurationHistogram   = txnMpoolDurationHistogram.WithLabelValues("free")
 	TxnMpoolDeleteDurationHistogram = txnMpoolDurationHistogram.WithLabelValues("delete")
 
 	txnReaderDurationHistogram = prometheus.NewHistogramVec(


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2578 https://github.com/matrixorigin/matrixone/issues/14843

## What this PR does / why we need it:
ZYWL-insert benchmarking on 129 shows that nearly 30%/100% CPU usage is spent on metrics within `MPool.Free`

<img width="1594" alt="image" src="https://github.com/matrixorigin/matrixone/assets/26336316/54335e7f-96c4-4c48-8aca-463eed419b0e">
