### PR TITLE
not to lock when create and delete a txn during commit

### DIFF
--- a/pkg/vm/engine/tae/db/scheduler.go
+++ b/pkg/vm/engine/tae/db/scheduler.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"github.com/matrixorigin/matrixone/pkg/container/types"
 
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
@@ -109,10 +108,6 @@ func (s *taskScheduler) ScheduleMultiScopedFn(
 	task = tasks.NewMultiScopedFnTask(ctx, taskType, scopes, fn)
 	err = s.Schedule(task)
 	return
-}
-
-func (s *taskScheduler) GetCheckpointTS() types.TS {
-	return s.db.TxnMgr.StatMaxCommitTS()
 }
 
 func (s *taskScheduler) GetPenddingLSNCnt() uint64 {

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -2469,7 +2469,7 @@ func TestSegDelLogtail(t *testing.T) {
 	testutil.CheckAllColRowsByScan(t, rel, bat.Length()-5, false)
 	assert.Nil(t, txn.Commit(context.Background()))
 
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	require.NoError(t, err)
 
 	check := func() {
@@ -5858,7 +5858,7 @@ func TestAlterRenameTbl(t *testing.T) {
 	t.Log(dbentry.PrettyNameIndex())
 	require.NoError(t, txn.Commit(context.Background()))
 
-	require.NoError(t, tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false))
+	require.NoError(t, tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false))
 	tae.Restart(ctx)
 
 	txn, _ = tae.StartTxn(nil)
@@ -5961,7 +5961,7 @@ func TestAlterRenameTbl2(t *testing.T) {
 		t.Log(dbentry.PrettyNameIndex())
 	}
 
-	require.NoError(t, tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false))
+	require.NoError(t, tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false))
 
 	tae.Restart(ctx)
 	{
@@ -7186,9 +7186,9 @@ func TestForceCheckpoint(t *testing.T) {
 
 	tae.CreateRelAndAppend(bat, true)
 
-	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.StatMaxCommitTS(), context.Background(), time.Second*2, time.Millisecond*10)
+	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.Now(), context.Background(), time.Second*2, time.Millisecond*10)
 	assert.Error(t, err)
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
 }
 
@@ -7282,9 +7282,9 @@ func TestMarshalPartioned(t *testing.T) {
 	partioned = rel.Schema().(*catalog.Schema).Partitioned
 	assert.Equal(t, int8(1), partioned)
 
-	err := tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err := tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
-	lsn := tae.BGCheckpointRunner.MaxLSNInRange(tae.TxnMgr.StatMaxCommitTS())
+	lsn := tae.BGCheckpointRunner.MaxLSNInRange(tae.TxnMgr.Now())
 	entry, err := tae.Wal.RangeCheckpoint(1, lsn)
 	assert.NoError(t, err)
 	assert.NoError(t, entry.WaitDone())
@@ -8087,7 +8087,7 @@ func TestCheckpointReadWrite(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, txn.Commit(context.Background()))
 
-	t1 := tae.TxnMgr.StatMaxCommitTS()
+	t1 := tae.TxnMgr.Now()
 	testutil.CheckCheckpointReadWrite(t, types.TS{}, t1, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 
 	txn, err = tae.StartTxn(nil)
@@ -8100,7 +8100,7 @@ func TestCheckpointReadWrite(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, txn.Commit(context.Background()))
 
-	t2 := tae.TxnMgr.StatMaxCommitTS()
+	t2 := tae.TxnMgr.Now()
 	testutil.CheckCheckpointReadWrite(t, types.TS{}, t2, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 	testutil.CheckCheckpointReadWrite(t, t1, t2, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 
@@ -8109,7 +8109,7 @@ func TestCheckpointReadWrite(t *testing.T) {
 	_, err = txn.DropDatabase("db")
 	assert.NoError(t, err)
 	assert.NoError(t, txn.Commit(context.Background()))
-	t3 := tae.TxnMgr.StatMaxCommitTS()
+	t3 := tae.TxnMgr.Now()
 	testutil.CheckCheckpointReadWrite(t, types.TS{}, t3, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 	testutil.CheckCheckpointReadWrite(t, t2, t3, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 
@@ -8120,12 +8120,12 @@ func TestCheckpointReadWrite(t *testing.T) {
 	bat := catalog.MockBatch(schema, 10)
 
 	tae.CreateRelAndAppend(bat, true)
-	t4 := tae.TxnMgr.StatMaxCommitTS()
+	t4 := tae.TxnMgr.Now()
 	testutil.CheckCheckpointReadWrite(t, types.TS{}, t4, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 	testutil.CheckCheckpointReadWrite(t, t3, t4, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 
 	tae.CompactBlocks(false)
-	t5 := tae.TxnMgr.StatMaxCommitTS()
+	t5 := tae.TxnMgr.Now()
 	testutil.CheckCheckpointReadWrite(t, types.TS{}, t5, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 	testutil.CheckCheckpointReadWrite(t, t4, t5, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 }
@@ -8151,7 +8151,7 @@ func TestCheckpointReadWrite2(t *testing.T) {
 		tae.CompactBlocks(false)
 	}
 
-	t1 := tae.TxnMgr.StatMaxCommitTS()
+	t1 := tae.TxnMgr.Now()
 	testutil.CheckCheckpointReadWrite(t, types.TS{}, t1, tae.Catalog, smallCheckpointBlockRows, smallCheckpointSize, tae.Opts.Fs)
 }
 

--- a/pkg/vm/engine/tae/db/test/replay_test.go
+++ b/pkg/vm/engine/tae/db/test/replay_test.go
@@ -83,7 +83,7 @@ func TestReplayCatalog1(t *testing.T) {
 			}
 			assert.Nil(t, txn.Commit(context.Background()))
 			if forceCkp || rand.Intn(100) > 80 {
-				err := tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+				err := tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 				assert.NoError(t, err)
 			}
 		}
@@ -183,7 +183,7 @@ func TestReplayCatalog2(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, txn.Commit(context.Background()))
 	t.Log(tae.Catalog.SimplePPString(common.PPL1))
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
 	tae.Close()
 
@@ -474,9 +474,9 @@ func TestReplay2(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, txn.Commit(context.Background()))
 
-	err = tae2.BGCheckpointRunner.ForceFlush(tae2.TxnMgr.StatMaxCommitTS(), context.Background(), time.Second*10)
+	err = tae2.BGCheckpointRunner.ForceFlush(tae2.TxnMgr.Now(), context.Background(), time.Second*10)
 	assert.NoError(t, err)
-	err = tae2.BGCheckpointRunner.ForceIncrementalCheckpoint(tae2.TxnMgr.StatMaxCommitTS(), false)
+	err = tae2.BGCheckpointRunner.ForceIncrementalCheckpoint(tae2.TxnMgr.Now(), false)
 	assert.NoError(t, err)
 
 	txn, err = tae2.StartTxn(nil)
@@ -587,7 +587,7 @@ func TestReplay3(t *testing.T) {
 	assert.NoError(t, txn.Commit(context.Background()))
 
 	txn, _ = tae.GetRelation()
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
 	assert.NoError(t, txn.Commit(context.Background()))
 }
@@ -841,11 +841,11 @@ func TestReplay5(t *testing.T) {
 	assert.NoError(t, txn.Commit(context.Background()))
 
 	testutil.CompactBlocks(t, 0, tae, testutil.DefaultTestDB, schema, false)
-	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.StatMaxCommitTS(), context.Background(), time.Second*2, time.Millisecond*10)
+	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.Now(), context.Background(), time.Second*2, time.Millisecond*10)
 	assert.NoError(t, err)
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
-	lsn := tae.BGCheckpointRunner.MaxLSNInRange(tae.TxnMgr.StatMaxCommitTS())
+	lsn := tae.BGCheckpointRunner.MaxLSNInRange(tae.TxnMgr.Now())
 	entry, err := tae.Wal.RangeCheckpoint(1, lsn)
 	assert.NoError(t, err)
 	err = entry.WaitDone()
@@ -868,11 +868,11 @@ func TestReplay5(t *testing.T) {
 	}
 	assert.NoError(t, txn.Commit(context.Background()))
 	testutil.CompactBlocks(t, 0, tae, testutil.DefaultTestDB, schema, false)
-	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.StatMaxCommitTS(), context.Background(), time.Second*2, time.Millisecond*10)
+	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.Now(), context.Background(), time.Second*2, time.Millisecond*10)
 	assert.NoError(t, err)
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
-	lsn = tae.BGCheckpointRunner.MaxLSNInRange(tae.TxnMgr.StatMaxCommitTS())
+	lsn = tae.BGCheckpointRunner.MaxLSNInRange(tae.TxnMgr.Now())
 	entry, err = tae.Wal.RangeCheckpoint(1, lsn)
 	assert.NoError(t, err)
 	assert.NoError(t, entry.WaitDone())
@@ -905,11 +905,11 @@ func TestReplay5(t *testing.T) {
 	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry))
 	assert.NoError(t, txn.Commit(context.Background()))
 
-	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.StatMaxCommitTS(), context.Background(), time.Second*2, time.Millisecond*10)
+	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.Now(), context.Background(), time.Second*2, time.Millisecond*10)
 	assert.NoError(t, err)
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
-	lsn = tae.BGCheckpointRunner.MaxLSNInRange(tae.TxnMgr.StatMaxCommitTS())
+	lsn = tae.BGCheckpointRunner.MaxLSNInRange(tae.TxnMgr.Now())
 	entry, err = tae.Wal.RangeCheckpoint(1, lsn)
 	assert.NoError(t, err)
 	assert.NoError(t, entry.WaitDone())
@@ -966,9 +966,9 @@ func TestReplay6(t *testing.T) {
 	assert.NoError(t, txn.Commit(context.Background()))
 	testutil.CompactBlocks(t, 0, tae, testutil.DefaultTestDB, schema, false)
 	testutil.MergeBlocks(t, 0, tae, testutil.DefaultTestDB, schema, false)
-	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.StatMaxCommitTS(), context.Background(), time.Second*2, time.Millisecond*10)
+	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.Now(), context.Background(), time.Second*2, time.Millisecond*10)
 	assert.NoError(t, err)
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
 
 	_ = tae.Close()
@@ -1125,7 +1125,7 @@ func TestReplay8(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, txn.Commit(context.Background()))
 	// t.Log(tae.Catalog.SimplePPString(common.PPL1))
-	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.StatMaxCommitTS(), context.Background(), time.Second*2, time.Millisecond*10)
+	err = tae.BGCheckpointRunner.ForceFlushWithInterval(tae.TxnMgr.Now(), context.Background(), time.Second*2, time.Millisecond*10)
 	assert.NoError(t, err)
 
 	tae.Restart(ctx)
@@ -1148,7 +1148,7 @@ func TestReplay8(t *testing.T) {
 	_ = txn.Rollback(context.Background())
 
 	tae.CompactBlocks(false)
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
 	tae.Restart(ctx)
 
@@ -1349,7 +1349,7 @@ func TestReplaySnapshots(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, txn.Commit(context.Background()))
 
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
 
 	txn, err = tae.StartTxn(nil)
@@ -1371,7 +1371,7 @@ func TestReplaySnapshots(t *testing.T) {
 	objMeta.Unlock()
 	assert.NoError(t, txn.Commit(context.Background()))
 
-	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.StatMaxCommitTS(), false)
+	err = tae.BGCheckpointRunner.ForceIncrementalCheckpoint(tae.TxnMgr.Now(), false)
 	assert.NoError(t, err)
 	t.Log(tae.Catalog.SimplePPString(3))
 

--- a/pkg/vm/engine/tae/db/test/scheduler_test.go
+++ b/pkg/vm/engine/tae/db/test/scheduler_test.go
@@ -151,22 +151,6 @@ func TestCheckpoint2(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Nil(t, txn.Commit(context.Background()))
 	}
-
-	// testutils.WaitExpect(1000, func() bool {
-	// 	return tae.Wal.GetPenddingCnt() == 1
-	// })
-	// t.Log(tae.Wal.GetPenddingCnt())
-	// err := meta.GetObjectData().Destroy()
-	// assert.Nil(t, err)
-	// task, err := tae.Runtime.Scheduler.ScheduleScopedFn(tasks.WaitableCtx, tasks.CheckpointTask, nil, tae.Catalog.CheckpointClosure(tae.Runtime.Scheduler.GetCheckpointTS()))
-	// assert.Nil(t, err)
-	// err = task.WaitDone()
-	// assert.Nil(t, err)
-	// testutils.WaitExpect(1000, func() bool {
-	// 	return tae.Wal.GetPenddingCnt() == 4
-	// })
-	// t.Log(tae.Wal.GetPenddingCnt())
-	// assert.Equal(t, uint64(4), tae.Wal.GetPenddingCnt())
 }
 
 func TestSchedule1(t *testing.T) {

--- a/pkg/vm/engine/tae/db/testutil/engine.go
+++ b/pkg/vm/engine/tae/db/testutil/engine.go
@@ -123,16 +123,16 @@ func (e *TestEngine) CheckRowsByScan(exp int, applyDelete bool) {
 	assert.NoError(e.t, txn.Commit(context.Background()))
 }
 func (e *TestEngine) ForceCheckpoint() {
-	err := e.BGCheckpointRunner.ForceFlushWithInterval(e.TxnMgr.StatMaxCommitTS(), context.Background(), time.Second*2, time.Millisecond*10)
+	err := e.BGCheckpointRunner.ForceFlushWithInterval(e.TxnMgr.Now(), context.Background(), time.Second*2, time.Millisecond*10)
 	assert.NoError(e.t, err)
-	err = e.BGCheckpointRunner.ForceIncrementalCheckpoint(e.TxnMgr.StatMaxCommitTS(), false)
+	err = e.BGCheckpointRunner.ForceIncrementalCheckpoint(e.TxnMgr.Now(), false)
 	assert.NoError(e.t, err)
 }
 
 func (e *TestEngine) ForceLongCheckpoint() {
-	err := e.BGCheckpointRunner.ForceFlush(e.TxnMgr.StatMaxCommitTS(), context.Background(), 20*time.Second)
+	err := e.BGCheckpointRunner.ForceFlush(e.TxnMgr.Now(), context.Background(), 20*time.Second)
 	assert.NoError(e.t, err)
-	err = e.BGCheckpointRunner.ForceIncrementalCheckpoint(e.TxnMgr.StatMaxCommitTS(), false)
+	err = e.BGCheckpointRunner.ForceIncrementalCheckpoint(e.TxnMgr.Now(), false)
 	assert.NoError(e.t, err)
 }
 

--- a/pkg/vm/engine/tae/rpc/base_test.go
+++ b/pkg/vm/engine/tae/rpc/base_test.go
@@ -168,7 +168,7 @@ func mockTAEHandle(ctx context.Context, t *testing.T, opts *options.Options) *mo
 func mock1PCTxn(db *db.DB) *txn.TxnMeta {
 	txnMeta := &txn.TxnMeta{}
 	txnMeta.ID = db.TxnMgr.IdAlloc.Alloc()
-	txnMeta.SnapshotTS = db.TxnMgr.TsAlloc.Alloc().ToTimestamp()
+	txnMeta.SnapshotTS = db.TxnMgr.Now().ToTimestamp()
 	return txnMeta
 }
 
@@ -186,7 +186,7 @@ func mockTNShard(id uint64) metadata.TNShard {
 func mock2PCTxn(db *db.DB) *txn.TxnMeta {
 	txnMeta := &txn.TxnMeta{}
 	txnMeta.ID = db.TxnMgr.IdAlloc.Alloc()
-	txnMeta.SnapshotTS = db.TxnMgr.TsAlloc.Alloc().ToTimestamp()
+	txnMeta.SnapshotTS = db.TxnMgr.Now().ToTimestamp()
 	txnMeta.TNShards = append(txnMeta.TNShards, mockTNShard(1))
 	txnMeta.TNShards = append(txnMeta.TNShards, mockTNShard(2))
 	return txnMeta

--- a/pkg/vm/engine/tae/tasks/scheduler.go
+++ b/pkg/vm/engine/tae/tasks/scheduler.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"github.com/matrixorigin/matrixone/pkg/container/types"
 
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
@@ -47,7 +46,6 @@ type TaskScheduler interface {
 
 	GetCheckpointedLSN() uint64
 	GetPenddingLSNCnt() uint64
-	GetCheckpointTS() types.TS
 }
 
 type BaseScheduler struct {

--- a/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
+++ b/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 
@@ -82,13 +83,11 @@ type TxnStoreFactory = func() txnif.TxnStore
 type TxnFactory = func(*TxnManager, txnif.TxnStore, []byte, types.TS, types.TS) txnif.AsyncTxn
 
 type TxnManager struct {
-	sync.RWMutex
 	sm.ClosedState
 	PreparingSM     sm.StateMachine
 	FlushQueue      sm.Queue
-	IDMap           map[string]txnif.AsyncTxn
+	IDMap           *sync.Map
 	IdAlloc         *common.TxnIDAllocator
-	TsAlloc         *types.TsAlloctor
 	MaxCommittedTS  atomic.Pointer[types.TS]
 	TxnStoreFactory TxnStoreFactory
 	TxnFactory      TxnFactory
@@ -98,6 +97,11 @@ type TxnManager struct {
 	cancel          context.CancelFunc
 	wg              sync.WaitGroup
 	workers         *ants.Pool
+
+	ts struct {
+		mu        sync.Mutex
+		allocator *types.TsAlloctor
+	}
 
 	// for debug
 	prevPrepareTS             types.TS
@@ -110,15 +114,15 @@ func NewTxnManager(txnStoreFactory TxnStoreFactory, txnFactory TxnFactory, clock
 		txnFactory = DefaultTxnFactory
 	}
 	mgr := &TxnManager{
-		IDMap:           make(map[string]txnif.AsyncTxn),
+		IDMap:           new(sync.Map),
 		IdAlloc:         common.NewTxnIDAllocator(),
-		TsAlloc:         types.NewTsAlloctor(clock),
 		TxnStoreFactory: txnStoreFactory,
 		TxnFactory:      txnFactory,
 		Exception:       new(atomic.Value),
 		CommitListener:  newBatchCommitListener(),
 		wg:              sync.WaitGroup{},
 	}
+	mgr.ts.allocator = types.NewTsAlloctor(clock)
 	mgr.initMaxCommittedTS()
 	pqueue := sm.NewSafeQueue(20000, 1000, mgr.dequeuePreparing)
 	prepareWALQueue := sm.NewSafeQueue(20000, 1000, mgr.onPrepareWAL)
@@ -139,31 +143,21 @@ func (mgr *TxnManager) initMaxCommittedTS() {
 // all timestamps allocated before have been assigned to txn, which means those
 // txn are visible for the returned timestamp.
 func (mgr *TxnManager) Now() types.TS {
-	mgr.Lock()
-	defer mgr.Unlock()
-	return mgr.TsAlloc.Alloc()
+	mgr.ts.mu.Lock()
+	defer mgr.ts.mu.Unlock()
+	return mgr.ts.allocator.Alloc()
 }
 
 func (mgr *TxnManager) Init(prevTs types.TS) error {
 	logutil.Infof("init ts to %v", prevTs.ToString())
-	mgr.TsAlloc.SetStart(prevTs)
+	mgr.ts.allocator.SetStart(prevTs)
 	logutil.Debug("[INIT]", TxnMgrField(mgr))
 	return nil
 }
 
-func (mgr *TxnManager) StatMaxCommitTS() (ts types.TS) {
-	mgr.RLock()
-	ts = mgr.TsAlloc.Alloc()
-	mgr.RUnlock()
-	return
-}
-
 // Note: Replay should always runs in a single thread
 func (mgr *TxnManager) OnReplayTxn(txn txnif.AsyncTxn) (err error) {
-	mgr.Lock()
-	defer mgr.Unlock()
-	// TODO: idempotent check
-	mgr.IDMap[txn.GetID()] = txn
+	mgr.IDMap.Store(txn.GetID(), txn)
 	return
 }
 
@@ -174,15 +168,13 @@ func (mgr *TxnManager) StartTxn(info []byte) (txn txnif.AsyncTxn, err error) {
 		logutil.Warnf("StartTxn: %v", err)
 		return
 	}
-	mgr.Lock()
-	defer mgr.Unlock()
 	txnId := mgr.IdAlloc.Alloc()
 	startTs := *mgr.MaxCommittedTS.Load()
 
 	store := mgr.TxnStoreFactory()
 	txn = mgr.TxnFactory(mgr, store, txnId, startTs, types.TS{})
 	store.BindTxn(txn)
-	mgr.IDMap[string(txnId)] = txn
+	mgr.IDMap.Store(util.UnsafeBytesToString(txnId), txn)
 	return
 }
 
@@ -195,13 +187,11 @@ func (mgr *TxnManager) StartTxnWithStartTSAndSnapshotTS(
 		logutil.Warnf("StartTxn: %v", err)
 		return
 	}
-	mgr.Lock()
-	defer mgr.Unlock()
 	store := mgr.TxnStoreFactory()
 	txnId := mgr.IdAlloc.Alloc()
 	txn = mgr.TxnFactory(mgr, store, txnId, startTS, snapshotTS)
 	store.BindTxn(txn)
-	mgr.IDMap[string(txnId)] = txn
+	mgr.IDMap.Store(util.UnsafeBytesToString(txnId), txn)
 	return
 }
 
@@ -215,28 +205,21 @@ func (mgr *TxnManager) GetOrCreateTxnWithMeta(
 		logutil.Warnf("StartTxn: %v", err)
 		return
 	}
-	mgr.Lock()
-	defer mgr.Unlock()
-	txn, ok := mgr.IDMap[string(id)]
-	if !ok {
+	if _, ok := mgr.IDMap.Load(util.UnsafeBytesToString(id)); !ok {
 		store := mgr.TxnStoreFactory()
 		txn = mgr.TxnFactory(mgr, store, id, ts, ts)
 		store.BindTxn(txn)
-		mgr.IDMap[string(id)] = txn
+		mgr.IDMap.Store(util.UnsafeBytesToString(id), txn)
 	}
 	return
 }
 
 func (mgr *TxnManager) DeleteTxn(id string) (err error) {
-	mgr.Lock()
-	defer mgr.Unlock()
-	txn := mgr.IDMap[id]
-	if txn == nil {
+	if _, ok := mgr.IDMap.LoadAndDelete(id); !ok {
 		err = moerr.NewTxnNotFoundNoCtx()
 		logutil.Warnf("Txn %s not found", id)
 		return
 	}
-	delete(mgr.IDMap, id)
 	return
 }
 
@@ -245,9 +228,10 @@ func (mgr *TxnManager) GetTxnByCtx(ctx []byte) txnif.AsyncTxn {
 }
 
 func (mgr *TxnManager) GetTxn(id string) txnif.AsyncTxn {
-	mgr.RLock()
-	defer mgr.RUnlock()
-	return mgr.IDMap[id]
+	if res, ok := mgr.IDMap.Load(id); ok {
+		return res.(txnif.AsyncTxn)
+	}
+	return nil
 }
 
 func (mgr *TxnManager) EnqueueFlushing(op any) (err error) {
@@ -279,11 +263,8 @@ func (mgr *TxnManager) newHeartbeatOpTxn(ctx context.Context) *OpTxn {
 		logutil.Warnf("StartTxn: %v", err)
 		return nil
 	}
-	mgr.Lock()
-	defer mgr.Unlock()
+	startTs := mgr.Now()
 	txnId := mgr.IdAlloc.Alloc()
-	startTs := mgr.TsAlloc.Alloc()
-
 	store := &heartbeatStore{}
 	txn := DefaultTxnFactory(mgr, store, txnId, startTs, types.TS{})
 	store.BindTxn(txn)
@@ -340,10 +321,10 @@ func (mgr *TxnManager) onBindPrepareTimeStamp(op *OpTxn) (ts types.TS) {
 		return
 	}
 
-	mgr.Lock()
-	defer mgr.Unlock()
+	mgr.ts.mu.Lock()
+	defer mgr.ts.mu.Unlock()
 
-	ts = mgr.TsAlloc.Alloc()
+	ts = mgr.ts.allocator.Alloc()
 	if !mgr.prevPrepareTS.IsEmpty() {
 		if ts.Less(&mgr.prevPrepareTS) {
 			panic(fmt.Sprintf("timestamp rollback current %v, previous %v", ts.ToString(), mgr.prevPrepareTS.ToString()))
@@ -614,15 +595,15 @@ func (mgr *TxnManager) OnException(new error) {
 // MinTSForTest is only be used in ut to ensure that
 // files that have been gc will not be used.
 func (mgr *TxnManager) MinTSForTest() types.TS {
-	mgr.RLock()
-	defer mgr.RUnlock()
 	minTS := types.MaxTs()
-	for _, txn := range mgr.IDMap {
+	mgr.IDMap.Range(func(key, value any) bool {
+		txn := value.(txnif.AsyncTxn)
 		startTS := txn.GetStartTS()
 		if startTS.Less(&minTS) {
 			minTS = startTS
 		}
-	}
+		return true
+	})
 	return minTS
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14579 

## What this PR does / why we need it:
not to lock when create and delete a txn during commit