### PR TITLE
MOLogger conn run with cn-labelSelector while do Compile

### DIFF
--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -1593,7 +1593,7 @@ func (ses *Session) AuthenticateUser(userInput string, dbName string, authRespon
 	isSpecial, pwdBytes, specialAccount = isSpecialUser(tenant.GetUser())
 	if isSpecial && specialAccount.IsMoAdminRole() {
 		ses.SetTenantInfo(specialAccount)
-		if specialAccount.User == db_holder.MOLoggerUser {
+		if len(ses.requestLabel) == 0 {
 			ses.requestLabel = db_holder.GetLabelSelector()
 		}
 		return GetPassWord(HashPassWordWithByte(pwdBytes))

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -44,6 +44,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/matrixorigin/matrixone/pkg/txn/storage/memorystorage"
 	"github.com/matrixorigin/matrixone/pkg/util/errutil"
+	db_holder "github.com/matrixorigin/matrixone/pkg/util/export/etl/db"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -1592,6 +1593,9 @@ func (ses *Session) AuthenticateUser(userInput string, dbName string, authRespon
 	isSpecial, pwdBytes, specialAccount = isSpecialUser(tenant.GetUser())
 	if isSpecial && specialAccount.IsMoAdminRole() {
 		ses.SetTenantInfo(specialAccount)
+		if specialAccount.User == db_holder.MOLoggerUser {
+			ses.requestLabel = db_holder.GetLabelSelector()
+		}
 		return GetPassWord(HashPassWordWithByte(pwdBytes))
 	}
 

--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -304,7 +304,7 @@ func isStatementExisted(ctx context.Context, db *sql.DB, stmtId string, status s
 var gLabels map[string]string = nil
 
 func SetLabelSelector(labels map[string]string) {
-	if labels == nil || len(labels) == 0 {
+	if len(labels) == 0 {
 		return
 	}
 	labels["account"] = "sys"

--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -128,6 +129,10 @@ func GetOrInitDBConn(forceNewConn bool, randomCN bool) (*sql.DB, error) {
 		if err != nil {
 			return err
 		}
+		if _, err := newDBConn.Exec("set session disable_txn_trace=1"); err != nil {
+			return errors.Join(err, newDBConn.Close())
+		}
+
 		//45s suggest by xzxiong
 		newDBConn.SetConnMaxLifetime(45 * time.Second)
 		newDBConn.SetMaxOpenConns(MaxConnectionNumber)
@@ -298,4 +303,14 @@ func isStatementExisted(ctx context.Context, db *sql.DB, stmtId string, status s
 		return false, err
 	}
 	return exists, nil
+}
+
+var gLabels map[string]string = nil
+
+func SetLabelSelector(labels map[string]string) {
+	gLabels = labels
+}
+
+func GetLabelSelector() map[string]string {
+	return gLabels
 }

--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -304,14 +304,15 @@ func isStatementExisted(ctx context.Context, db *sql.DB, stmtId string, status s
 var gLabels map[string]string = nil
 
 func SetLabelSelector(labels map[string]string) {
+	labels["account"] = "sys"
 	gLabels = labels
 }
 
 // GetLabelSelector
 // Tips: more details in route.RouteForSuperTenant function. It mainly depends on S1.
-// Tips: gLabels MUST NOT contain {"account":"sys"}.
-// - Because clusterservice.Selector not support regex-match in route.RouteForSuperTenant
-// - If you use labels{"account":"sys", "role":"ob"}, the Selector will NOT match those pods, which have labels{"account":"*", "role":"ob"}
+// Tips: gLabels better contain {"account":"sys"}.
+// - Because clusterservice.Selector using clusterservice.globbing do regex-match in route.RouteForSuperTenant
+// - If you use labels{"account":"sys", "role":"ob"}, the Selector can match those pods, which have labels{"account":"*", "role":"ob"}
 func GetLabelSelector() map[string]string {
 	return gLabels
 }

--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -307,6 +307,11 @@ func SetLabelSelector(labels map[string]string) {
 	gLabels = labels
 }
 
+// GetLabelSelector
+// Tips: more details in route.RouteForSuperTenant function. It mainly depends on S1.
+// Tips: gLabels MUST NOT contain {"account":"sys"}.
+// - Because clusterservice.Selector not support regex-match in route.RouteForSuperTenant
+// - If you use labels{"account":"sys", "role":"ob"}, the Selector will NOT match those pods, which have labels{"account":"*", "role":"ob"}
 func GetLabelSelector() map[string]string {
 	return gLabels
 }

--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -304,6 +304,9 @@ func isStatementExisted(ctx context.Context, db *sql.DB, stmtId string, status s
 var gLabels map[string]string = nil
 
 func SetLabelSelector(labels map[string]string) {
+	if labels == nil || len(labels) == 0 {
+		return
+	}
 	labels["account"] = "sys"
 	gLabels = labels
 }

--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/csv"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -128,9 +127,6 @@ func GetOrInitDBConn(forceNewConn bool, randomCN bool) (*sql.DB, error) {
 		newDBConn, err := sql.Open("mysql", dsn)
 		if err != nil {
 			return err
-		}
-		if _, err := newDBConn.Exec("set session disable_txn_trace=1"); err != nil {
-			return errors.Join(err, newDBConn.Close())
 		}
 
 		//45s suggest by xzxiong

--- a/pkg/util/trace/impl/motrace/config.go
+++ b/pkg/util/trace/impl/motrace/config.go
@@ -88,6 +88,8 @@ type tracerProviderConfig struct {
 
 	tcpPacket bool // WithTCPPacket
 
+	labels map[string]string
+
 	mux sync.RWMutex
 }
 
@@ -216,6 +218,12 @@ func WithCUConfig(cu config.OBCUConfig, cuv1 config.OBCUConfig) tracerProviderOp
 func WithTCPPacket(count bool) tracerProviderOption {
 	return func(cfg *tracerProviderConfig) {
 		cfg.tcpPacket = count
+	}
+}
+
+func WithLabels(l map[string]string) tracerProviderOption {
+	return func(cfg *tracerProviderConfig) {
+		cfg.labels = l
 	}
 }
 

--- a/pkg/util/trace/impl/motrace/trace.go
+++ b/pkg/util/trace/impl/motrace/trace.go
@@ -34,6 +34,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/util/batchpipe"
 	"github.com/matrixorigin/matrixone/pkg/util/errutil"
+	db_holder "github.com/matrixorigin/matrixone/pkg/util/export/etl/db"
 	ie "github.com/matrixorigin/matrixone/pkg/util/internalExecutor"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 )
@@ -69,6 +70,7 @@ func InitWithConfig(ctx context.Context, SV *config.ObservabilityParameters, opt
 		WithStmtMergeEnable(SV.EnableStmtMerge),
 		WithCUConfig(SV.CU, SV.CUv1),
 		WithTCPPacket(SV.TCPPacket),
+		WithLabels(SV.LabelSelector),
 
 		DebugMode(SV.EnableTraceDebug),
 		WithBufferSizeThreshold(SV.BufferSize),
@@ -119,6 +121,9 @@ func Init(ctx context.Context, opts ...TracerProviderOption) (err error, act boo
 	logutil.SetLogReporter(&logutil.TraceReporter{ReportZap: ReportZap, ContextField: trace.ContextField})
 	logutil.SpanFieldKey.Store(trace.SpanFieldKey)
 	errutil.SetErrorReporter(ReportError)
+
+	// init db_hodler
+	db_holder.SetLabelSelector(config.labels)
 
 	logutil.Debugf("trace with LongQueryTime: %v", time.Duration(GetTracerProvider().longQueryTime))
 	logutil.Debugf("trace with LongSpanTime: %v", GetTracerProvider().longSpanTime)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2848

## What this PR does / why we need it:
changes:
1. set the `session.requestLabel` while do `AuthenticateUser`.
    - Then cn can use it as LabelSelector in `Compile::getCNList` to select the dedicated CN set

> TIPs: directly access CN without proxy, those labels setting within username have been ignored.