### PR TITLE
[fix] let runtime filter use prefix match if necessary

### DIFF
--- a/pkg/sql/plan/explain/explain_node.go
+++ b/pkg/sql/plan/explain/explain_node.go
@@ -559,6 +559,9 @@ func (ndesc *NodeDescribeImpl) GetRuntimeFilteProbeInfo(ctx context.Context, opt
 			if err != nil {
 				return "", err
 			}
+			if v.MatchPrefix {
+				buf.WriteString(" Match Prefix")
+			}
 		}
 	} else if options.Format == EXPLAIN_FORMAT_JSON {
 		return "", moerr.NewNYI(ctx, "explain format json")

--- a/pkg/sql/plan/runtime_filter.go
+++ b/pkg/sql/plan/runtime_filter.go
@@ -242,7 +242,8 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 	}
 
 	leftChild.RuntimeFilterProbeList = append(leftChild.RuntimeFilterProbeList, &plan.RuntimeFilterSpec{
-		Tag: rfTag,
+		Tag:         rfTag,
+		MatchPrefix: cnt < len(tableDef.Pkey.Names),
 		Expr: &plan.Expr{
 			Typ: tableDef.Cols[pkIdx].Typ,
 			Expr: &plan.Expr_Col{
@@ -270,9 +271,10 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 
 	buildExpr, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", buildArgs)
 	node.RuntimeFilterBuildList = append(node.RuntimeFilterBuildList, &plan.RuntimeFilterSpec{
-		Tag:        rfTag,
-		UpperLimit: GetInFilterCardLimitOnPK(leftChild.Stats.TableCnt), // multicol pk, must hit all pk cols for now
-		Expr:       buildExpr,
+		Tag:         rfTag,
+		MatchPrefix: cnt < len(tableDef.Pkey.Names),
+		UpperLimit:  GetInFilterCardLimitOnPK(leftChild.Stats.TableCnt), // multicol pk, must hit all pk cols for now
+		Expr:        buildExpr,
 	})
 	recalcStatsByRuntimeFilter(leftChild, rightChild.Stats.Selectivity)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15196

## What this PR does / why we need it:
if joined columns are the prefix of primary key, we should set MatchPrefix
flag on RuntimeFilterSpec