### PR TITLE
MOLogger query run with specified labelSelector while do Compile

### DIFF
--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -44,6 +44,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/matrixorigin/matrixone/pkg/txn/storage/memorystorage"
 	"github.com/matrixorigin/matrixone/pkg/util/errutil"
+	db_holder "github.com/matrixorigin/matrixone/pkg/util/export/etl/db"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -1602,6 +1603,9 @@ func (ses *Session) AuthenticateUser(userInput string, dbName string, authRespon
 	isSpecial, pwdBytes, specialAccount = isSpecialUser(tenant.GetUser())
 	if isSpecial && specialAccount.IsMoAdminRole() {
 		ses.SetTenantInfo(specialAccount)
+		if len(ses.requestLabel) == 0 {
+			ses.requestLabel = db_holder.GetLabelSelector()
+		}
 		return GetPassWord(HashPassWordWithByte(pwdBytes))
 	}
 

--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -304,3 +304,22 @@ func isStatementExisted(ctx context.Context, db *sql.DB, stmtId string, status s
 	}
 	return exists, nil
 }
+
+var gLabels map[string]string = nil
+
+func SetLabelSelector(labels map[string]string) {
+	if len(labels) == 0 {
+		return
+	}
+	labels["account"] = "sys"
+	gLabels = labels
+}
+
+// GetLabelSelector
+// Tips: more details in route.RouteForSuperTenant function. It mainly depends on S1.
+// Tips: gLabels better contain {"account":"sys"}.
+// - Because clusterservice.Selector using clusterservice.globbing do regex-match in route.RouteForSuperTenant
+// - If you use labels{"account":"sys", "role":"ob"}, the Selector can match those pods, which have labels{"account":"*", "role":"ob"}
+func GetLabelSelector() map[string]string {
+	return gLabels
+}

--- a/pkg/util/trace/impl/motrace/config.go
+++ b/pkg/util/trace/impl/motrace/config.go
@@ -86,6 +86,8 @@ type tracerProviderConfig struct {
 	cuConfig   config.OBCUConfig // WithCUConfig
 	cuConfigV1 config.OBCUConfig // WithCUConfig
 
+	labels map[string]string
+
 	mux sync.RWMutex
 }
 
@@ -208,6 +210,12 @@ func WithCUConfig(cu config.OBCUConfig, cuv1 config.OBCUConfig) tracerProviderOp
 	return func(cfg *tracerProviderConfig) {
 		cfg.cuConfig = cu
 		cfg.cuConfigV1 = cuv1
+	}
+}
+
+func WithLabels(l map[string]string) tracerProviderOption {
+	return func(cfg *tracerProviderConfig) {
+		cfg.labels = l
 	}
 }
 

--- a/pkg/util/trace/impl/motrace/trace.go
+++ b/pkg/util/trace/impl/motrace/trace.go
@@ -34,6 +34,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/util/batchpipe"
 	"github.com/matrixorigin/matrixone/pkg/util/errutil"
+	db_holder "github.com/matrixorigin/matrixone/pkg/util/export/etl/db"
 	ie "github.com/matrixorigin/matrixone/pkg/util/internalExecutor"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 )
@@ -68,6 +69,7 @@ func InitWithConfig(ctx context.Context, SV *config.ObservabilityParameters, opt
 		WithSelectThreshold(SV.SelectAggrThreshold.Duration),
 		WithStmtMergeEnable(SV.EnableStmtMerge),
 		WithCUConfig(SV.CU, SV.CUv1),
+		WithLabels(SV.LabelSelector),
 
 		DebugMode(SV.EnableTraceDebug),
 		WithBufferSizeThreshold(SV.BufferSize),
@@ -118,6 +120,9 @@ func Init(ctx context.Context, opts ...TracerProviderOption) (err error, act boo
 	logutil.SetLogReporter(&logutil.TraceReporter{ReportZap: ReportZap, ContextField: trace.ContextField})
 	logutil.SpanFieldKey.Store(trace.SpanFieldKey)
 	errutil.SetErrorReporter(ReportError)
+
+	// init db_hodler
+	db_holder.SetLabelSelector(config.labels)
 
 	logutil.Debugf("trace with LongQueryTime: %v", time.Duration(GetTracerProvider().longQueryTime))
 	logutil.Debugf("trace with LongSpanTime: %v", GetTracerProvider().longSpanTime)


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2848

## What this PR does / why we need it:
changes:
1. set the `session.requestLabel` while do `AuthenticateUser`.
- Then cn can use it as LabelSelector in `Compile::getCNList` to select the dedicated CN set

> TIPs: directly access CN without proxy, those labels setting within username have been ignored.
