### PR TITLE
Revert "unlimited the RPC msg body size (#15250)"

### DIFF
--- a/pkg/tnservice/factory.go
+++ b/pkg/tnservice/factory.go
@@ -16,7 +16,6 @@ package tnservice
 
 import (
 	"context"
-	"math"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -157,11 +156,6 @@ func (s *store) newTAEStorage(ctx context.Context, shard metadata.TNShard, facto
 		return nil, err
 	}
 
-	// the previous values
-	//max2LogServiceMsgSizeLimit := s.cfg.RPC.MaxMessageSize
-	// unlimited, divided by 2 to avoid overflow
-	max2LogServiceMsgSizeLimit := uint64(math.MaxUint64 / 2)
-
 	return taestorage.NewTAEStorage(
 		ctx,
 		s.cfg.Txn.Storage.dataDir,
@@ -174,6 +168,6 @@ func (s *store) newTAEStorage(ctx context.Context, shard metadata.TNShard, facto
 		logtailServerAddr,
 		logtailServerCfg,
 		s.cfg.Txn.IncrementalDedup == "true",
-		max2LogServiceMsgSizeLimit,
+		uint64(s.cfg.RPC.MaxMessageSize),
 	)
 }


### PR DESCRIPTION
This reverts commit 6920986641050527e79339993501e57a3e4b813a.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/15288

## What this PR does / why we need it:
see the issue for more detail