### PR TITLE
[cherry-pick-1.1-dev] improve delete from table without where & limit (#13120)

### DIFF
--- a/pkg/pb/plan/plan.pb.go
+++ b/pkg/pb/plan/plan.pb.go
@@ -6708,10 +6708,12 @@ type DeleteCtx struct {
 	AddAffectedRows bool       `protobuf:"varint,4,opt,name=add_affected_rows,json=addAffectedRows,proto3" json:"add_affected_rows,omitempty"`
 	IsClusterTable  bool       `protobuf:"varint,5,opt,name=is_cluster_table,json=isClusterTable,proto3" json:"is_cluster_table,omitempty"`
 	// Align array index with the partition number
-	PartitionTableIds    []uint64 `protobuf:"varint,6,rep,packed,name=partition_table_ids,json=partitionTableIds,proto3" json:"partition_table_ids,omitempty"`
-	PartitionTableNames  []string `protobuf:"bytes,7,rep,name=partition_table_names,json=partitionTableNames,proto3" json:"partition_table_names,omitempty"`
-	PartitionIdx         int32    `protobuf:"varint,8,opt,name=partition_idx,json=partitionIdx,proto3" json:"partition_idx,omitempty"`
-	PrimaryKeyIdx        int32    `protobuf:"varint,9,opt,name=primary_key_idx,json=primaryKeyIdx,proto3" json:"primary_key_idx,omitempty"`
+	PartitionTableIds   []uint64       `protobuf:"varint,6,rep,packed,name=partition_table_ids,json=partitionTableIds,proto3" json:"partition_table_ids,omitempty"`
+	PartitionTableNames []string       `protobuf:"bytes,7,rep,name=partition_table_names,json=partitionTableNames,proto3" json:"partition_table_names,omitempty"`
+	PartitionIdx        int32          `protobuf:"varint,8,opt,name=partition_idx,json=partitionIdx,proto3" json:"partition_idx,omitempty"`
+	PrimaryKeyIdx       int32          `protobuf:"varint,9,opt,name=primary_key_idx,json=primaryKeyIdx,proto3" json:"primary_key_idx,omitempty"`
+	TruncateTable       *TruncateTable `protobuf:"bytes,12,opt,name=truncate_table,json=truncateTable,proto3,oneof" json:"truncate_table,omitempty"`
+
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -9633,6 +9635,7 @@ type TruncateTable struct {
 	ClusterTable         *ClusterTable `protobuf:"bytes,5,opt,name=cluster_table,json=clusterTable,proto3" json:"cluster_table,omitempty"`
 	TableId              uint64        `protobuf:"varint,6,opt,name=table_id,json=tableId,proto3" json:"table_id,omitempty"`
 	ForeignTbl           []uint64      `protobuf:"varint,7,rep,packed,name=foreign_tbl,json=foreignTbl,proto3" json:"foreign_tbl,omitempty"`
+	IsDelete             bool          `protobuf:"varint,6,opt,name=is_delete,json=isDelete,proto3" json:"is_delete,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
 	XXX_unrecognized     []byte        `json:"-"`
 	XXX_sizecache        int32         `json:"-"`

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -568,7 +568,9 @@ func (c *Compile) compileScope(ctx context.Context, pn *plan.Plan) ([]*Scope, er
 			return nil, err
 		}
 		for _, s := range scopes {
-			s.Plan = pn
+			if s.Plan == nil {
+				s.Plan = pn
+			}
 		}
 		return scopes, nil
 	case *plan.Plan_Ddl:
@@ -1138,6 +1140,21 @@ func (c *Compile) compilePlanScope(ctx context.Context, step int32, curNodeIdx i
 		c.setAnalyzeCurrent(right, curr)
 		return c.compileSort(n, c.compileUnionAll(left, right)), nil
 	case plan.Node_DELETE:
+		if n.DeleteCtx.CanTruncate {
+			return []*Scope{{
+				Magic: TruncateTable,
+				Plan: &plan.Plan{
+					Plan: &plan.Plan_Ddl{
+						Ddl: &plan.DataDefinition{
+							DdlType: plan.DataDefinition_TRUNCATE_TABLE,
+							Definition: &plan.DataDefinition_TruncateTable{
+								TruncateTable: n.DeleteCtx.TruncateTable,
+							},
+						},
+					},
+				},
+			}}, nil
+		}
 		c.appendMetaTables(n.DeleteCtx.Ref)
 		curr := c.anal.curr
 		c.setAnalyzeCurrent(nil, int(n.Children[0]))

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -1264,6 +1264,8 @@ func (s *Scope) TruncateTable(c *Compile) error {
 	dbName := tqry.GetDatabase()
 	tblName := tqry.GetTable()
 	oldId := tqry.GetTableId()
+	keepAutoIncrement := false
+	affectedRows := int64(0)
 
 	dbSource, err = c.e.Database(c.ctx, dbName, c.proc.TxnOperator)
 	if err != nil {
@@ -1300,6 +1302,14 @@ func (s *Scope) TruncateTable(c *Compile) error {
 			}
 			err = e
 		}
+		if err != nil {
+			return err
+		}
+	}
+
+	if tqry.IsDelete {
+		keepAutoIncrement = true
+		affectedRows, err = rel.Rows(c.ctx)
 		if err != nil {
 			return err
 		}
@@ -1388,7 +1398,7 @@ func (s *Scope) TruncateTable(c *Compile) error {
 		c.ctx,
 		oldId,
 		newId,
-		false,
+		keepAutoIncrement,
 		c.proc.TxnOperator)
 	if err != nil {
 		return err
@@ -1400,6 +1410,7 @@ func (s *Scope) TruncateTable(c *Compile) error {
 	if err != nil {
 		return err
 	}
+	c.addAffectedRows(uint64(affectedRows))
 	return nil
 }
 

--- a/proto/plan.proto
+++ b/proto/plan.proto
@@ -867,6 +867,7 @@ message DeleteCtx {
 	repeated string partition_table_names = 7;
 	int32 partition_idx = 8;
 	int32 primary_key_idx = 9;
+	TruncateTable truncate_table = 10;
 }
 
 message Query {
@@ -1248,6 +1249,7 @@ message TruncateTable {
 	ClusterTable cluster_table = 5;
 	uint64 table_id = 6;
 	repeated uint64 foreign_tbl = 7;
+	bool	is_delete = 8;
 }
 
 message ClusterTable{


### PR DESCRIPTION
When a table does not have a foreign key. So for delete from table, it can be optimized to truncate.

Approved by: @m-schen, @nnsgmsone, @badboynt1, @aunjgr, @ouyuanning

(cherry picked from commit 118e5776c53ae2d034352dd2fd330634dbdf050a)

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2919

## What this PR does / why we need it:
improve delete from table without where & limit (#13120)