### PR TITLE
fix wait too long to 1.1

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -666,6 +666,8 @@ func (rb *remoteBackend) makeAllWaitingFutureFailed() {
 			if f.waiting.Load() {
 				waitings = append(waitings, f)
 				ids = append(ids, id)
+			} else {
+				f.messageSent(backendClosed)
 			}
 		}
 	}()

--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -663,17 +663,17 @@ func (rb *remoteBackend) makeAllWaitingFutureFailed() {
 		ids = make([]uint64, 0, len(rb.mu.futures))
 		waitings = make([]*Future, 0, len(rb.mu.futures))
 		for id, f := range rb.mu.futures {
-			if f.waiting.Load() {
-				waitings = append(waitings, f)
-				ids = append(ids, id)
-			} else {
-				f.messageSent(backendClosed)
-			}
+			waitings = append(waitings, f)
+			ids = append(ids, id)
 		}
 	}()
 
 	for i, f := range waitings {
-		f.error(ids[i], backendClosed, nil)
+		if f.waiting.Load() {
+			f.error(ids[i], backendClosed, nil)
+		} else {
+			f.messageSent(backendClosed)
+		}
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15348 

## What this PR does / why we need it:
Avoid rpc waiting too long after connection disconnected. Currently, when a broken link is detected, all the futures waiting for a response wait until the ctx times out