### PR TITLE
support push from_unixtime to block filters

### DIFF
--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -3588,7 +3588,7 @@ var supportedDateAndTimeBuiltIns = []FuncNew{
 	// function `from_unixtime`
 	{
 		functionId: FROM_UNIXTIME,
-		class:      plan.Function_STRICT,
+		class:      plan.Function_STRICT | plan.Function_ZONEMAPPABLE,
 		layout:     STANDARD_FUNCTION,
 		checkFn:    fixedTypeMatch,
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/2914

## What this PR does / why we need it:
support push from_unixtime to block filters