### PR TITLE
a quick fix that avoids the failure of `mo_table_size` when the index table name is empty.

### DIFF
--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -18,8 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/logutil"
-	"go.uber.org/zap"
 	"strconv"
 	"strings"
 
@@ -29,10 +27,12 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/functionUtil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"go.uber.org/zap"
 )
 
 const (
@@ -348,7 +348,7 @@ func indexesTableSize(ctx context.Context, db engine.Database, rel engine.Relati
 	// this is a quick fix for the issue of the indexTableName is empty.
 	// the empty indexTableName causes the `SQL parser err: table "" does not exist` err and
 	// then the mo_table_size call will fail.
-	// this fix does not fix the issue but only to avoid the failure caused by it.
+	// this fix does not fix the issue but only avoids the failure caused by it.
 	err = nil
 	return totalSize, err
 }

--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -92,7 +92,19 @@ func MoTableRows(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 			dbo, err = e.Database(ctx, dbStr, txn)
 			if err != nil {
 				if moerr.IsMoErrCode(err, moerr.OkExpectedEOB) {
-					return moerr.NewInvalidArgNoCtx("db not found when mo_table_rows", dbStr)
+					var buf bytes.Buffer
+					for j := uint64(0); j < uint64(length); j++ {
+						db2, _ := dbs.GetStrValue(i)
+						tbl2, _ := tbls.GetStrValue(i)
+
+						dbStr2 := functionUtil.QuickBytesToStr(db2)
+						tblStr2 := functionUtil.QuickBytesToStr(tbl2)
+
+						buf.WriteString(fmt.Sprintf("%s-%s; ", dbStr2, tblStr2))
+					}
+
+					return moerr.NewInvalidArgNoCtx("db not found when mo_table_rows",
+						fmt.Sprintf("%s-%s, extra: %s", dbStr, tblStr, buf.String()))
 				}
 				return err
 			}

--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -94,8 +94,8 @@ func MoTableRows(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 				if moerr.IsMoErrCode(err, moerr.OkExpectedEOB) {
 					var buf bytes.Buffer
 					for j := uint64(0); j < uint64(length); j++ {
-						db2, _ := dbs.GetStrValue(i)
-						tbl2, _ := tbls.GetStrValue(i)
+						db2, _ := dbs.GetStrValue(j)
+						tbl2, _ := tbls.GetStrValue(j)
 
 						dbStr2 := functionUtil.QuickBytesToStr(db2)
 						tblStr2 := functionUtil.QuickBytesToStr(tbl2)
@@ -103,8 +103,8 @@ func MoTableRows(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 						buf.WriteString(fmt.Sprintf("%s-%s; ", dbStr2, tblStr2))
 					}
 
-					return moerr.NewInvalidArgNoCtx("db not found when mo_table_rows",
-						fmt.Sprintf("%s-%s, extra: %s", dbStr, tblStr, buf.String()))
+					logutil.Errorf(fmt.Sprintf("db not found when mo_table_size: %s-%s, extra: %s", dbStr, tblStr, buf.String()))
+					return moerr.NewInvalidArgNoCtx("db not found when mo_table_size", fmt.Sprintf("%s-%s", dbStr, tblStr))
 				}
 				return err
 			}
@@ -231,8 +231,8 @@ func MoTableSize(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 				if moerr.IsMoErrCode(err, moerr.OkExpectedEOB) {
 					var buf bytes.Buffer
 					for j := uint64(0); j < uint64(length); j++ {
-						db2, _ := dbs.GetStrValue(i)
-						tbl2, _ := tbls.GetStrValue(i)
+						db2, _ := dbs.GetStrValue(j)
+						tbl2, _ := tbls.GetStrValue(j)
 
 						dbStr2 := functionUtil.QuickBytesToStr(db2)
 						tblStr2 := functionUtil.QuickBytesToStr(tbl2)
@@ -240,8 +240,8 @@ func MoTableSize(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 						buf.WriteString(fmt.Sprintf("%s-%s; ", dbStr2, tblStr2))
 					}
 
-					return moerr.NewInvalidArgNoCtx("db not found when mo_table_size",
-						fmt.Sprintf("%s-%s, extra: %s", dbStr, tblStr, buf.String()))
+					logutil.Errorf(fmt.Sprintf("db not found when mo_table_size: %s-%s, extra: %s", dbStr, tblStr, buf.String()))
+					return moerr.NewInvalidArgNoCtx("db not found when mo_table_size", fmt.Sprintf("%s-%s", dbStr, tblStr))
 				}
 				return err
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/15331 https://github.com/matrixorigin/MO-Cloud/issues/2918

## What this PR does / why we need it:

this is a quick fix for the issue of the indexTableName is empty.
the empty indexTableName causes the `SQL parser err: table "" does not exist` err and
then the mo_table_size call will fail.
this fix does not fix the issue but only avoids the failure caused by it.