### PR TITLE
always try to push block filter for 1.1

### DIFF
--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -974,7 +974,7 @@ func calcScanStats(node *plan.Node, builder *QueryBuilder) *plan.Stats {
 	for i := range node.FilterList {
 		node.FilterList[i].Selectivity = estimateExprSelectivity(node.FilterList[i], builder)
 		currentBlockSel := estimateFilterBlockSelectivity(builder.GetContext(), node.FilterList[i], node.TableDef, builder)
-		if currentBlockSel < blockSelectivityThreshHold {
+		if currentBlockSel < blockSelectivityThreshHold && stats.TableCnt > 10000 {
 			copyOfExpr := DeepCopyExpr(node.FilterList[i])
 			copyOfExpr.Selectivity = currentBlockSel
 			blockExprList = append(blockExprList, copyOfExpr)

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -37,7 +37,6 @@ const DefaultBlockMaxRows = 8192
 const BlockNumForceOneCN = 200
 const blockSelectivityThreshHold = 0.95
 const highNDVcolumnThreshHold = 0.95
-const blockNDVThreshHold = 100
 
 // stats cache is small, no need to use LRU for now
 type StatsCache struct {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -532,9 +532,6 @@ func estimateFilterBlockSelectivity(ctx context.Context, expr *plan.Expr, tableD
 	if !ExprIsZonemappable(ctx, expr) {
 		return 1
 	}
-	if expr.Selectivity < 0.01 {
-		return expr.Selectivity * 100
-	}
 	col := extractColRefInFilter(expr)
 	if col != nil {
 		switch GetSortOrder(tableDef, col.Name) {
@@ -545,9 +542,6 @@ func estimateFilterBlockSelectivity(ctx context.Context, expr *plan.Expr, tableD
 		case 2:
 			return math.Min(expr.Selectivity*10, 0.5)
 		}
-	}
-	if getExprNdv(expr, builder) < blockNDVThreshHold {
-		return 1
 	}
 	return 0.5
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2946

## What this PR does / why we need it:
1.1版本的stats计算不够准确，导致经常有该下推block filter的时候没有下推。
对于所有这类问题，在1.1里总是下推。从1.2版本开始计算更加准确，应该可以彻底解决问题