### PR TITLE
Fix segment falut bug for hyperloglog

### DIFF
--- a/pkg/vm/engine/tae/blockio/write_index.go
+++ b/pkg/vm/engine/tae/blockio/write_index.go
@@ -16,6 +16,7 @@ package blockio
 
 import (
 	hll "github.com/axiomhq/hyperloglog"
+	"github.com/cespare/xxhash/v2"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
@@ -73,7 +74,7 @@ func (b *ObjectColumnMetasBuilder) InspectVector(idx int, vec containers.Vector,
 		if isNull {
 			return
 		}
-		b.sks[idx].Insert(v)
+		b.sks[idx].InsertHash(xxhash.Sum64(v))
 		return
 	}, nil)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15288 #14151

## What this PR does / why we need it:
The hash function has been replaced and the assembly hash function is no longer used.