### PR TITLE
fix date_add with param input (#1.1-dev)

### DIFF
--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -3290,6 +3290,16 @@ var supportedDateAndTimeBuiltIns = []FuncNew{
 					return TimeAdd
 				},
 			},
+			{
+				overloadId: 6,
+				args:       []types.T{types.T_text, types.T_int64, types.T_int64},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_datetime.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return DateStringAdd
+				},
+			},
 		},
 	},
 
@@ -3380,6 +3390,16 @@ var supportedDateAndTimeBuiltIns = []FuncNew{
 				},
 				newOp: func() executeLogicOfOverload {
 					return TimestampSub
+				},
+			},
+			{
+				overloadId: 5,
+				args:       []types.T{types.T_text, types.T_int64, types.T_int64},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_datetime.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return DateStringSub
 				},
 			},
 		},

--- a/test/distributed/cases/expression/temporal_interval.result
+++ b/test/distributed/cases/expression/temporal_interval.result
@@ -593,3 +593,13 @@ null
 null
 null
 drop table t1;
+set @tt=now();
+select @tt;
+@tt
+2024-04-09 16:58:58.056874
+select date_add(@tt, Interval 30 SECOND);
+date_add(@tt, interval(30, second))
+2024-04-09 16:59:28.056874000
+select date_sub(@tt, Interval 30 SECOND);
+date_sub(@tt, interval(30, second))
+2024-04-09 16:58:28.056874000

--- a/test/distributed/cases/expression/temporal_interval.sql
+++ b/test/distributed/cases/expression/temporal_interval.sql
@@ -282,3 +282,11 @@ insert into t1 select date_add('2000-01-04', INTERVAL NULL DAY);
 select * from t1;
 drop table t1;
 
+
+set @tt=now();
+-- @ignore:0
+select @tt;
+-- @ignore:0
+select date_add(@tt, Interval 30 SECOND);
+-- @ignore:0
+select date_sub(@tt, Interval 30 SECOND);


### PR DESCRIPTION
fix date_add with param input

Approved by: @heni02, @m-schen

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15081 

## What this PR does / why we need it:
fix date_add with param input