### PR TITLE
fix bvt/purge_log  (#1.1-dev)

### DIFF
--- a/test/distributed/cases/function/func_purge_log.result
+++ b/test/distributed/cases/function/func_purge_log.result
@@ -27,11 +27,11 @@ NULL
 select purge_log(NULL, NULL) a;
 a
 NULL
-set @ts=now();
+set @ts=(select IFNULL(max(collecttime), now()) from system_metrics.metric);
 select purge_log('statement_info,metric', DATE_ADD( @ts, interval 1 day)) a;
 a
 0
-select count(1) val from system_metrics.metric where `collecttime` <  DATE_ADD( @ts, interval 1 minute);
+select count(1) val from system_metrics.metric where `collecttime` <  DATE_ADD( @ts, interval 5 minute);
 val
 0
 drop account if exists bvt_purge_log;

--- a/test/distributed/cases/function/func_purge_log.sql
+++ b/test/distributed/cases/function/func_purge_log.sql
@@ -22,10 +22,10 @@ select purge_log('rawlog_not_exist', NULL) a;
 select purge_log(NULL, '2023-06-30') a;
 select purge_log(NULL, NULL) a;
 
--- case for issue 10421
-set @ts=now();
+-- case for issue 10421, 15,455
+set @ts=(select IFNULL(max(collecttime), now()) from system_metrics.metric);
 select purge_log('statement_info,metric', DATE_ADD( @ts, interval 1 day)) a;
-select count(1) val from system_metrics.metric where `collecttime` <  DATE_ADD( @ts, interval 1 minute);
+select count(1) val from system_metrics.metric where `collecttime` <  DATE_ADD( @ts, interval 5 minute);
 
 -- clean
 drop account if exists bvt_purge_log;

--- a/test/distributed/cases/table/system_table_cases.sql
+++ b/test/distributed/cases/table/system_table_cases.sql
@@ -36,14 +36,15 @@ SELECT COUNT(NULL) FROM (SELECT * FROM error_info LIMIT 10) AS temp;
 -- @bvt:issue
 
 -- span_info
--- issue 11,947
--- for now, span_info is mostly close by default, so here is NO enough reocrds in table.
--- keep query to check table is exist.
-SELECT COUNT(*) FROM (SELECT * FROM span_info LIMIT 0) AS temp;
-SELECT COUNT(0) FROM (SELECT * FROM span_info LIMIT 0) AS temp;
-SELECT COUNT('') FROM (SELECT * FROM span_info LIMIT 0) AS temp;
-SELECT COUNT(NULL) FROM (SELECT * FROM span_info LIMIT 0) AS temp;
--- issue 11,947 end.
+-- for now, currently no graceful way to
+-- ensure that records already flushed into span_info
+
+-- @bvt:issue#11947
+SELECT COUNT(*) FROM (SELECT * FROM span_info LIMIT 10) AS temp;
+SELECT COUNT(0) FROM (SELECT * FROM span_info LIMIT 10) AS temp;
+SELECT COUNT('') FROM (SELECT * FROM span_info LIMIT 10) AS temp;
+SELECT COUNT(NULL) FROM (SELECT * FROM span_info LIMIT 10) AS temp;
+-- @bvt:issue
 
 -- tables in system_metrics
 USE system_metrics;

--- a/test/distributed/cases/table/system_table_cases.sql
+++ b/test/distributed/cases/table/system_table_cases.sql
@@ -36,15 +36,14 @@ SELECT COUNT(NULL) FROM (SELECT * FROM error_info LIMIT 10) AS temp;
 -- @bvt:issue
 
 -- span_info
--- for now, currently no graceful way to
--- ensure that records already flushed into span_info
-
--- @bvt:issue#11947
-SELECT COUNT(*) FROM (SELECT * FROM span_info LIMIT 10) AS temp;
-SELECT COUNT(0) FROM (SELECT * FROM span_info LIMIT 10) AS temp;
-SELECT COUNT('') FROM (SELECT * FROM span_info LIMIT 10) AS temp;
-SELECT COUNT(NULL) FROM (SELECT * FROM span_info LIMIT 10) AS temp;
--- @bvt:issue
+-- issue 11,947
+-- for now, span_info is mostly close by default, so here is NO enough reocrds in table.
+-- keep query to check table is exist.
+SELECT COUNT(*) FROM (SELECT * FROM span_info LIMIT 0) AS temp;
+SELECT COUNT(0) FROM (SELECT * FROM span_info LIMIT 0) AS temp;
+SELECT COUNT('') FROM (SELECT * FROM span_info LIMIT 0) AS temp;
+SELECT COUNT(NULL) FROM (SELECT * FROM span_info LIMIT 0) AS temp;
+-- issue 11,947 end.
 
 -- tables in system_metrics
 USE system_metrics;


### PR DESCRIPTION
changes:
1. get the newest `collecttime` as target time to check result.

Approved by: @heni02

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15455

## What this PR does / why we need it:
fix bvt/purge_log