### PR TITLE
fileservice: call IOEntry.ToCacheData only when necessary

### DIFF
--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -132,6 +132,7 @@ type IOVectorCache interface {
 	Read(
 		ctx context.Context,
 		vector *IOVector,
+		needCacheData bool,
 	) error
 	Update(
 		ctx context.Context,
@@ -144,17 +145,20 @@ type IOVectorCache interface {
 		ctx context.Context,
 		paths []string,
 	) error
+	SkipReadPolicy() Policy
+	SkipWritePolicy() Policy
+	SkipPolicy() Policy
 }
 
 var slowCacheReadThreshold = time.Second * 0
 
-func readCache(ctx context.Context, cache IOVectorCache, vector *IOVector) error {
+func readCache(ctx context.Context, cache IOVectorCache, vector *IOVector, needCacheData bool) error {
 	if slowCacheReadThreshold > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, slowCacheReadThreshold)
 		defer cancel()
 	}
-	err := cache.Read(ctx, vector)
+	err := cache.Read(ctx, vector, needCacheData)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			logutil.Warn("cache read exceed deadline",

--- a/pkg/fileservice/caching_file_service_test.go
+++ b/pkg/fileservice/caching_file_service_test.go
@@ -81,10 +81,6 @@ func testCachingFileService(
 	err = fs.Read(ctx, vec)
 	assert.Nil(t, err)
 
-	err = m.Unmarshal(vec.Entries[0].CachedData.Bytes())
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(m.M))
-	assert.Equal(t, int64(42), m.M[42])
 	assert.Equal(t, int64(0), counterSet.FileService.Cache.Read.Load())
 	assert.Equal(t, int64(0), counterSet.FileService.Cache.Hit.Load())
 

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -105,7 +105,7 @@ func TestDiskCache(t *testing.T) {
 				},
 			},
 		}
-		err = cache.Read(ctx, vec)
+		err = cache.Read(ctx, vec, true)
 		assert.Nil(t, err)
 		assert.NotNil(t, r)
 		defer r.Close()
@@ -202,7 +202,7 @@ func TestDiskCacheWriteAgain(t *testing.T) {
 				Size: 3,
 			},
 		},
-	})
+	}, true)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1), counterSet.FileService.Cache.Disk.Hit.Load())
 
@@ -254,7 +254,7 @@ func TestDiskCacheFileCache(t *testing.T) {
 			},
 		},
 	}
-	err = cache.Read(ctx, readVector)
+	err = cache.Read(ctx, readVector, true)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("fo"), readVector.Entries[0].Data)
 	assert.Equal(t, []byte("ob"), readVector.Entries[1].Data)
@@ -372,6 +372,7 @@ func benchmarkDiskCacheWriteThenRead(
 			err = cache.Read(
 				ctx,
 				vec,
+				true,
 			)
 			if err != nil {
 				b.Fatal(err)
@@ -452,6 +453,7 @@ func benchmarkDiskCacheReadRandomOffsetAtLargeFile(
 			err = cache.Read(
 				ctx,
 				vec,
+				true,
 			)
 			if err != nil {
 				b.Fatal(err)
@@ -516,6 +518,7 @@ func BenchmarkDiskCacheMultipleIOEntries(b *testing.B) {
 				FilePath: "foo",
 				Entries:  entries,
 			},
+			true,
 		)
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/fileservice/file_service_test.go
+++ b/pkg/fileservice/file_service_test.go
@@ -701,6 +701,10 @@ func testFileService(
 				},
 			},
 			Policy: policy,
+			Caches: []IOVectorCache{
+				// to ensure ToCacheData will be called
+				NewMemCache(NewMemoryCache(1<<30, true, nil), nil),
+			},
 		}
 		err = fs.Read(ctx, vec)
 		assert.Nil(t, err)

--- a/pkg/fileservice/file_services_test.go
+++ b/pkg/fileservice/file_services_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,7 +28,9 @@ func TestFileServices(t *testing.T) {
 		testFileService(t, 0, func(name string) FileService {
 			ctx := context.Background()
 			dir := t.TempDir()
-			fs, err := NewLocalFS(ctx, name, dir, DisabledCacheConfig, nil)
+			fs, err := NewLocalFS(ctx, name, dir, CacheConfig{
+				MemoryCapacity: ptrTo(toml.ByteSize(1 << 30)),
+			}, nil)
 			assert.Nil(t, err)
 			fs2, err := NewFileServices(name, fs)
 			assert.Nil(t, err)

--- a/pkg/fileservice/io_entry.go
+++ b/pkg/fileservice/io_entry.go
@@ -22,7 +22,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memorycache"
 )
 
-func (i *IOEntry) setCachedData() error {
+func (i *IOEntry) setCachedData(need bool) error {
+	if !need {
+		return nil
+	}
 	if i.ToCacheData == nil {
 		return nil
 	}
@@ -40,7 +43,7 @@ func (i *IOEntry) setCachedData() error {
 	return nil
 }
 
-func (i *IOEntry) ReadFromOSFile(file *os.File) error {
+func (i *IOEntry) readFromOSFile(file *os.File, needCacheData bool) error {
 	r := io.LimitReader(file, i.Size)
 
 	if cap(i.Data) < int(i.Size) {
@@ -65,7 +68,7 @@ func (i *IOEntry) ReadFromOSFile(file *os.File) error {
 	if i.ReadCloserForRead != nil {
 		*i.ReadCloserForRead = io.NopCloser(bytes.NewReader(i.Data))
 	}
-	if err := i.setCachedData(); err != nil {
+	if err := i.setCachedData(needCacheData); err != nil {
 		return err
 	}
 

--- a/pkg/fileservice/io_vector.go
+++ b/pkg/fileservice/io_vector.go
@@ -85,3 +85,25 @@ func (i *IOVector) ioLockKey() IOLockKey {
 	}
 	return key
 }
+
+func (i *IOVector) needCacheData(
+	memoryCache *MemCache,
+	diskCache *DiskCache,
+) bool {
+
+	if memoryCache != nil && !i.Policy.Any(memoryCache.SkipWritePolicy()) {
+		return true
+	}
+
+	if diskCache != nil && !i.Policy.Any(diskCache.SkipWritePolicy()) {
+		return true
+	}
+
+	for _, cache := range i.Caches {
+		if cache != nil && !i.Policy.Any(cache.SkipWritePolicy()) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -97,11 +97,12 @@ func (m *MemCache) Alloc(n int) memorycache.CacheData {
 func (m *MemCache) Read(
 	ctx context.Context,
 	vector *IOVector,
+	needCacheData bool,
 ) (
 	err error,
 ) {
 
-	if vector.Policy.Any(SkipMemoryCacheReads) {
+	if vector.Policy.Any(m.SkipReadPolicy()) {
 		return nil
 	}
 
@@ -152,7 +153,7 @@ func (m *MemCache) Update(
 	async bool,
 ) error {
 
-	if vector.Policy.Any(SkipMemoryCacheWrites) {
+	if vector.Policy.Any(m.SkipWritePolicy()) {
 		return nil
 	}
 
@@ -190,4 +191,16 @@ func (m *MemCache) DeletePaths(
 ) error {
 	m.cache.DeletePaths(ctx, paths)
 	return nil
+}
+
+func (m *MemCache) SkipReadPolicy() Policy {
+	return SkipMemoryCacheReads
+}
+
+func (m *MemCache) SkipWritePolicy() Policy {
+	return SkipMemoryCacheWrites
+}
+
+func (m *MemCache) SkipPolicy() Policy {
+	return SkipMemoryCache
 }

--- a/pkg/fileservice/mem_cache_test.go
+++ b/pkg/fileservice/mem_cache_test.go
@@ -61,7 +61,7 @@ func TestMemCacheLeak(t *testing.T) {
 			},
 		},
 	}
-	err = m.Read(ctx, vec)
+	err = m.Read(ctx, vec, true)
 	assert.Nil(t, err)
 	vec.Release()
 	err = fs.Read(ctx, vec)
@@ -87,7 +87,7 @@ func TestMemCacheLeak(t *testing.T) {
 			},
 		},
 	}
-	err = m.Read(ctx, vec)
+	err = m.Read(ctx, vec, true)
 	assert.Nil(t, err)
 	vec.Release()
 	err = fs.Read(ctx, vec)

--- a/pkg/fileservice/memory_fs.go
+++ b/pkg/fileservice/memory_fs.go
@@ -191,7 +191,7 @@ func (m *MemoryFS) Read(ctx context.Context, vector *IOVector) (err error) {
 	}
 	for _, cache := range m.caches {
 		cache := cache
-		if err := cache.Read(ctx, vector); err != nil {
+		if err := cache.Read(ctx, vector, vector.needCacheData(m.memCache, nil)); err != nil {
 			return err
 		}
 		defer func() {
@@ -222,6 +222,8 @@ func (m *MemoryFS) Read(ctx context.Context, vector *IOVector) (err error) {
 	if !ok {
 		return moerr.NewFileNotFoundNoCtx(path.File)
 	}
+
+	needCacheData := vector.needCacheData(m.memCache, nil)
 
 	for i, entry := range vector.Entries {
 		if entry.done {
@@ -265,7 +267,7 @@ func (m *MemoryFS) Read(ctx context.Context, vector *IOVector) (err error) {
 			}
 		}
 
-		if err := entry.setCachedData(); err != nil {
+		if err := entry.setCachedData(needCacheData); err != nil {
 			return err
 		}
 

--- a/pkg/fileservice/policy.go
+++ b/pkg/fileservice/policy.go
@@ -21,15 +21,18 @@ const (
 	SkipMemoryCacheWrites
 	SkipDiskCacheReads
 	SkipDiskCacheWrites
+	SkipRemoteCacheReads
+	SkipRemoteCacheWrites
 	SkipFullFilePreloads
 )
 
 const (
-	SkipCacheReads  = SkipMemoryCacheReads | SkipDiskCacheReads
-	SkipCacheWrites = SkipMemoryCacheWrites | SkipDiskCacheWrites
 	SkipDiskCache   = SkipDiskCacheReads | SkipDiskCacheWrites
 	SkipMemoryCache = SkipMemoryCacheReads | SkipMemoryCacheWrites
-	SkipAllCache    = SkipDiskCache | SkipMemoryCache
+	SkipRemoteCache = SkipRemoteCacheReads | SkipRemoteCacheWrites
+	SkipCacheReads  = SkipMemoryCacheReads | SkipDiskCacheReads | SkipRemoteCacheReads
+	SkipCacheWrites = SkipMemoryCacheWrites | SkipDiskCacheWrites | SkipRemoteCacheWrites
+	SkipAllCache    = SkipDiskCache | SkipMemoryCache | SkipRemoteCache
 )
 
 func (c Policy) Any(policies ...Policy) bool {

--- a/pkg/fileservice/remote_cache.go
+++ b/pkg/fileservice/remote_cache.go
@@ -52,7 +52,7 @@ func NewRemoteCache(client client.QueryClient, factory KeyRouterFactory[query.Ca
 	}
 }
 
-func (r *RemoteCache) Read(ctx context.Context, vector *IOVector) error {
+func (r *RemoteCache) Read(ctx context.Context, vector *IOVector, needCacheData bool) error {
 	if r.keyRouterFactory == nil {
 		return nil
 	}
@@ -148,6 +148,18 @@ func (r *RemoteCache) Flush() {}
 func (r *RemoteCache) DeletePaths(ctx context.Context, paths []string) error {
 	//TODO
 	return nil
+}
+
+func (r *RemoteCache) SkipReadPolicy() Policy {
+	return SkipRemoteCacheReads
+}
+
+func (r *RemoteCache) SkipWritePolicy() Policy {
+	return SkipRemoteCacheWrites
+}
+
+func (r *RemoteCache) SkipPolicy() Policy {
+	return SkipRemoteCache
 }
 
 func HandleRemoteRead(

--- a/pkg/fileservice/remote_cache_test.go
+++ b/pkg/fileservice/remote_cache_test.go
@@ -84,7 +84,7 @@ func TestRemoteCache(t *testing.T) {
 				},
 			},
 		}
-		err = sf2.rc.Read(ctx, ioVec2)
+		err = sf2.rc.Read(ctx, ioVec2, true)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(ioVec2.Entries))
 		assert.Equal(t, Bytes{1, 2}, ioVec2.Entries[0].CachedData)


### PR DESCRIPTION
fileservice: add IOVectorCache.SkipReadPolicy, SkipWritePolicy, SkipPolicy

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15488 

## What this PR does / why we need it:
ToCacheData is not always required to call.