### PR TITLE
Table or field names enclosed in reverse quotation marks will retain …

### DIFF
--- a/pkg/sql/parsers/dialect/mysql/mysql_sql.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql.go
@@ -20102,7 +20102,7 @@ yydefault:
 		var yyLOCAL *tree.CStr
 //line mysql_sql.y:8412
 		{
-			yyLOCAL = tree.NewCStr(yyDollar[1].str, yylex.(*Lexer).lower)
+			yyLOCAL = tree.NewCStrWithQuoted(yyDollar[1].str, yylex.(*Lexer).lower, true)
 		}
 		yyVAL.union = yyLOCAL
 	case 1292:

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql.y
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql.y
@@ -8406,11 +8406,11 @@ column_name_unresolved:
 ident:
     ID
     {
-		$$ = tree.NewCStr($1, yylex.(*Lexer).lower)
+	$$ = tree.NewCStr($1, yylex.(*Lexer).lower)
     }
-|	QUOTE_ID
+|   QUOTE_ID
 	{
-    	$$ = tree.NewCStr($1, yylex.(*Lexer).lower)
+    	$$ = tree.NewCStrWithQuoted($1, yylex.(*Lexer).lower, true)
     }
 |   not_keyword
 	{

--- a/pkg/sql/parsers/dialect/mysql/scanner_test.go
+++ b/pkg/sql/parsers/dialect/mysql/scanner_test.go
@@ -62,6 +62,10 @@ func TestLiteralID(t *testing.T) {
 		in:  "```",
 		id:  LEX_ERROR,
 		out: "`",
+	}, {
+		in:  "`Tt`",
+		id:  QUOTE_ID,
+		out: "Tt",
 	}}
 
 	for _, tcase := range testcases {

--- a/pkg/sql/parsers/tree/cstr.go
+++ b/pkg/sql/parsers/tree/cstr.go
@@ -20,9 +20,9 @@ import (
 
 type CStrParts [4]*CStr
 type CStr struct {
-	o string
-	c string
-	// quote bool
+	o      string
+	c      string
+	quoted bool // Has the token been processed with backquotes
 }
 
 func NewCStr(str string, lower int64) *CStr {
@@ -32,6 +32,15 @@ func NewCStr(str string, lower int64) *CStr {
 		return cs
 	}
 	cs.c = strings.ToLower(cs.o)
+	return cs
+}
+
+func NewCStrWithQuoted(str string, lower int64, quoted bool) *CStr {
+	cs := &CStr{
+		o:      str,
+		c:      str,
+		quoted: quoted,
+	}
 	return cs
 }
 

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"


### PR DESCRIPTION
…their original capitalization for precise matching

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15482

## What this PR does / why we need it:
在SQL 中，使用反引号（`）将表名或字段名括起来的作用是告诉SQL 解析器将其中的内容作为一个整体进行处理，
而不会被解释为关键字或函数名。

1. 保留字和关键字的使用： 可以使用保留字或关键字作为表名或字段名，只要将其用反引号括起来，就不会将其解释为保留字或关键字，而是将其视为普通的表名或字段名。

2. 特殊字符和空格的使用： 如果表名或字段名中包含特殊字符或空格，可以使用反引号将其括起来，使解析器正确识别这些字符。

3. 大小写敏感： mo默认是大小写不敏感的，但如果使用反引号括起来的表名或字段名，则会保留其原始的大小写形式，使得可以精确匹配。

如果在 mo中将 `lower_case_table_names` 设置为 1，即将所有数据库对象名转换为小写，但在 SQL 查询中使用了反引号来处理数据库对象，那么反引号将会覆盖 `lower_case_table_names` 的设置，保留原始的大小写形式。