### PR TITLE
fix a bug that cause workload unbalance in 1.1

### DIFF
--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -370,6 +370,9 @@ func determinShuffleForScan(n *plan.Node, builder *QueryBuilder) {
 	if n.TableDef.Pkey != nil {
 		firstColName := n.TableDef.Pkey.Names[0]
 		firstColID := n.TableDef.Name2ColIndex[firstColName]
+		if n.TableDef.Cols[firstColID].Typ.AutoIncr {
+			return
+		}
 		s := getStatsInfoByTableID(n.TableDef.TblId, builder)
 		if s == nil {
 			return


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3038

## What this PR does / why we need it:
由于自增列在某些情况下会跳过很多值，导致分布不均匀。
1.1里没有对不均匀数据的处理逻辑，因此回导致负载在多cn上分布不均匀。1.2里已经解决了这个问题。
现在改成在1.1里，对自增列默认走hash shuffle，避免负载不均匀的问题