### PR TITLE
fix bvt with correct datetime in 1.1

### DIFF
--- a/test/distributed/cases/function/func_purge_log.result
+++ b/test/distributed/cases/function/func_purge_log.result
@@ -31,7 +31,7 @@ set @ts=(select IFNULL(max(collecttime), now()) from system_metrics.metric);
 select purge_log('statement_info,metric', DATE_ADD( @ts, interval 1 day)) a;
 a
 0
-select count(1) val from system_metrics.metric where `collecttime` <  DATE_ADD( @ts, interval 5 minute);
+select count(1) val from system_metrics.metric where `collecttime` <  DATE_SUB( @ts, interval 3 minute);
 val
 0
 drop account if exists bvt_purge_log;

--- a/test/distributed/cases/function/func_purge_log.sql
+++ b/test/distributed/cases/function/func_purge_log.sql
@@ -25,7 +25,7 @@ select purge_log(NULL, NULL) a;
 -- case for issue 10421, 15,455
 set @ts=(select IFNULL(max(collecttime), now()) from system_metrics.metric);
 select purge_log('statement_info,metric', DATE_ADD( @ts, interval 1 day)) a;
-select count(1) val from system_metrics.metric where `collecttime` <  DATE_ADD( @ts, interval 5 minute);
+select count(1) val from system_metrics.metric where `collecttime` <  DATE_SUB( @ts, interval 3 minute);
 
 -- clean
 drop account if exists bvt_purge_log;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/15455

## What this PR does / why we need it:
ref: https://github.com/matrixorigin/matrixone/pull/15593
changes:
1. correct target time to check result, by using date_sub.