### PR TITLE
[cherry-pick-15603] fix issue #15543

### DIFF
--- a/pkg/common/mpool/mpool.go
+++ b/pkg/common/mpool/mpool.go
@@ -374,14 +374,15 @@ func (mp *MPool) Cap() int64 {
 	return mp.cap
 }
 
-func (mp *MPool) destroy() {
-	if atomic.LoadInt32(&mp.inUseCount) != 0 {
-		logutil.Errorf("Mpool %s already in use", mp.tag)
-		return
-	}
-	if !atomic.CompareAndSwapInt32(&mp.available, 0, 1) {
+func (mp *MPool) destroy() (succeed bool) {
+	if !atomic.CompareAndSwapInt32(&mp.available, Available, Unavailable) {
 		logutil.Errorf("Mpool %s double destroy", mp.tag)
-		return
+		return false
+	}
+	if atomic.LoadInt32(&mp.inUseCount) != 0 {
+		logutil.Errorf("Mpool %s was still in use", mp.tag)
+		atomic.StoreInt32(&mp.available, Available)
+		return false
 	}
 	if mp.stats.NumAlloc.Load() < mp.stats.NumFree.Load() {
 		logutil.Errorf("mp error: %s", mp.stats.Report(""))
@@ -395,6 +396,7 @@ func (mp *MPool) destroy() {
 	globalStats.RecordManyFrees(mp.tag,
 		mp.stats.NumAlloc.Load()-mp.stats.NumFree.Load(),
 		mp.stats.NumCurrBytes.Load())
+	return true
 }
 
 // New a MPool.   Tag is user supplied, used for debugging/diagnostics.
@@ -499,8 +501,9 @@ func DeleteMPool(mp *MPool) {
 	}
 
 	// logutil.Infof("destroy mpool %s, cap %d, stats\n%s", mp.tag, mp.cap, mp.Report())
-	globalPools.Delete(mp.id)
-	mp.destroy()
+	if mp.destroy() {
+		globalPools.Delete(mp.id)
+	}
 }
 
 var nextPool int64

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -141,14 +141,15 @@ func (s *Scope) MergeRun(c *Compile) error {
 			wg.Done()
 		}
 	}
-	defer wg.Wait()
 
 	s.Proc.Ctx = context.WithValue(s.Proc.Ctx, defines.EngineKey{}, c.e)
 	var errReceiveChan chan error
 	if len(s.RemoteReceivRegInfos) > 0 {
 		errReceiveChan = make(chan error, len(s.RemoteReceivRegInfos))
-		s.notifyAndReceiveFromRemote(errReceiveChan)
+		s.notifyAndReceiveFromRemote(&wg, errReceiveChan)
 	}
+	defer wg.Wait()
+
 	p := pipeline.NewMerge(s.Instructions, s.Reg)
 	if _, err := p.MergeRun(s.Proc); err != nil {
 		select {
@@ -819,62 +820,77 @@ func (s *Scope) appendInstruction(in vm.Instruction) {
 	}
 }
 
-func (s *Scope) notifyAndReceiveFromRemote(errChan chan error) {
+func (s *Scope) notifyAndReceiveFromRemote(wg *sync.WaitGroup, errChan chan error) {
+	// if context has done, it means other pipeline stop the query normally.
+	closeWithError := func(err error, reg *process.WaitRegister) {
+		if reg != nil {
+			select {
+			case <-s.Proc.Ctx.Done():
+			case reg.Ch <- nil:
+			}
+			close(reg.Ch)
+		}
+
+		select {
+		case <-s.Proc.Ctx.Done():
+			errChan <- nil
+		default:
+			errChan <- err
+		}
+		wg.Done()
+	}
+
+	// start N goroutines to send notifications to remote nodes.
+	// to notify the remote dispatch executor where its remote receivers are.
+	// dispatch operator will use this stream connection to send data back.
+	//
+	// function `cnMessageHandle` at file `scopeRemoteRun.go` will handle the notification.
 	for i := range s.RemoteReceivRegInfos {
-		op := &s.RemoteReceivRegInfos[i]
+		wg.Add(1)
 
-		go func(info *RemoteReceivRegInfo, reg *process.WaitRegister) {
-			// if context has done, it means other pipeline stop the query normally.
-			closeWithError := func(err error) {
-				if reg != nil {
-					select {
-					case <-s.Proc.Ctx.Done():
-					case reg.Ch <- nil:
-					}
-					close(reg.Ch)
+		errSubmit := ants.Submit(
+			func() {
+				defer func() {
+					wg.Done()
+				}()
+
+				op := &s.RemoteReceivRegInfos[i]
+
+				streamSender, errStream := cnclient.GetStreamSender(op.FromAddr)
+				if errStream != nil {
+					logutil.Errorf("Failed to get stream sender txnID=%s, err=%v",
+						s.Proc.TxnOperator.Txn().DebugString(), errStream)
+					closeWithError(errStream, s.Proc.Reg.MergeReceivers[op.Idx])
+					return
 				}
+				defer streamSender.Close(true)
 
-				select {
-				case <-s.Proc.Ctx.Done():
-					errChan <- nil
-				default:
-					errChan <- err
-				}
-			}
-
-			streamSender, errStream := cnclient.GetStreamSender(info.FromAddr)
-			if errStream != nil {
-				logutil.Errorf("Failed to get stream sender txnID=%s, err=%v",
-					s.Proc.TxnOperator.Txn().DebugString(), errStream)
-				closeWithError(errStream)
-				return
-			}
-			defer streamSender.Close(true)
-
-			message := cnclient.AcquireMessage()
-			{
+				message := cnclient.AcquireMessage()
 				message.Id = streamSender.ID()
 				message.Cmd = pbpipeline.Method_PrepareDoneNotifyMessage
 				message.Sid = pbpipeline.Status_Last
-				message.Uuid = info.Uuid[:]
-			}
-			if errSend := streamSender.Send(s.Proc.Ctx, message); errSend != nil {
-				closeWithError(errSend)
-				return
-			}
+				message.Uuid = op.Uuid[:]
 
-			messagesReceive, errReceive := streamSender.Receive()
-			if errReceive != nil {
-				closeWithError(errReceive)
-				return
-			}
-			var ch chan *batch.Batch
-			if reg != nil {
-				ch = reg.Ch
-			}
-			err := receiveMsgAndForward(s.Proc, messagesReceive, ch)
-			closeWithError(err)
-		}(op, s.Proc.Reg.MergeReceivers[op.Idx])
+				if errSend := streamSender.Send(s.Proc.Ctx, message); errSend != nil {
+					closeWithError(errSend, s.Proc.Reg.MergeReceivers[op.Idx])
+					return
+				}
+
+				messagesReceive, errReceive := streamSender.Receive()
+				if errReceive != nil {
+					closeWithError(errReceive, s.Proc.Reg.MergeReceivers[op.Idx])
+					return
+				}
+
+				err := receiveMsgAndForward(s.Proc, messagesReceive, s.Proc.Reg.MergeReceivers[op.Idx].Ch)
+				closeWithError(err, s.Proc.Reg.MergeReceivers[op.Idx])
+			},
+		)
+
+		if errSubmit != nil {
+			errChan <- errSubmit
+			wg.Done()
+		}
 	}
 }
 
@@ -887,8 +903,8 @@ func receiveMsgAndForward(proc *process.Process, receiveCh chan morpc.Message, f
 	for {
 		select {
 		case <-proc.Ctx.Done():
-			logutil.Warnf("proc ctx done during forward")
 			return nil
+
 		case val, ok = <-receiveCh:
 			if val == nil || !ok {
 				return moerr.NewStreamClosedNoCtx()
@@ -934,8 +950,9 @@ func receiveMsgAndForward(proc *process.Process, receiveCh chan morpc.Message, f
 			} else {
 				select {
 				case <-proc.Ctx.Done():
-					logutil.Warnf("proc ctx done during forward")
+					bat.Clean(proc.Mp())
 					return nil
+
 				case forwardCh <- bat:
 				}
 			}

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -850,10 +850,6 @@ func (s *Scope) notifyAndReceiveFromRemote(wg *sync.WaitGroup, errChan chan erro
 
 		errSubmit := ants.Submit(
 			func() {
-				defer func() {
-					wg.Done()
-				}()
-
 				op := &s.RemoteReceivRegInfos[i]
 
 				streamSender, errStream := cnclient.GetStreamSender(op.FromAddr)

--- a/pkg/sql/compile/scopeRemoteRun.go
+++ b/pkg/sql/compile/scopeRemoteRun.go
@@ -1672,6 +1672,7 @@ func convertToPlanAnalyzeInfo(info *process.AnalyzeInfo) *plan.AnalyzeInfo {
 // func decodeBatch(proc *process.Process, data []byte) (*batch.Batch, error) {
 func decodeBatch(mp *mpool.MPool, vp engine.VectorPool, data []byte) (*batch.Batch, error) {
 	bat := new(batch.Batch)
+
 	err := types.Decode(data, bat)
 	if err != nil {
 		return nil, err
@@ -1687,7 +1688,8 @@ func decodeBatch(mp *mpool.MPool, vp engine.VectorPool, data []byte) (*batch.Bat
 		if vp != nil {
 			rvec = vp.GetVector(typ)
 		}
-		if err := vector.GetUnionAllFunction(typ, mp)(rvec, vec); err != nil {
+		if err = vector.GetUnionAllFunction(typ, mp)(rvec, vec); err != nil {
+			rvec.Free(mp)
 			bat.Clean(mp)
 			return nil, err
 		}

--- a/pkg/sql/compile/scopeRemoteRunTypes.go
+++ b/pkg/sql/compile/scopeRemoteRunTypes.go
@@ -217,11 +217,7 @@ func (sender *messageSenderOnClient) receiveBatch() (bat *batch.Batch, over bool
 		}
 
 		bat, err = decodeBatch(sender.c.proc.Mp(), sender.c.proc, dataBuffer)
-		if err != nil {
-			return nil, false, err
-		}
-
-		return bat, false, nil
+		return bat, false, err
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15543 

## What this PR does / why we need it:
fix the order of mpool destroy.
fix a bug that will cause pipelines still running for a moment after query return.