### PR TITLE
[cherry-pick] :  fix issue moc3006 and moc3039 (#15578)

### DIFF
--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -40,7 +40,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/queryservice"
-	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/taskservice"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
@@ -363,9 +362,9 @@ func (c *Config) Validate() error {
 
 	// pessimistic mode implies primary key check
 	if txn.GetTxnMode(c.Txn.Mode) == txn.TxnMode_Pessimistic || c.PrimaryKeyCheck {
-		plan.CNPrimaryCheck = true
+		config.CNPrimaryCheck = true
 	} else {
-		plan.CNPrimaryCheck = false
+		config.CNPrimaryCheck = false
 	}
 
 	if c.MaxPreparedStmtCount > 0 {

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -165,9 +165,6 @@ var (
 	// default lower_case_table_names
 	defaultLowerCaseTableNames = "1"
 
-	// default sql_mode
-	dafaultSqlMode = "ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES"
-
 	CNPrimaryCheck = false
 )
 

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -164,6 +164,11 @@ var (
 
 	// default lower_case_table_names
 	defaultLowerCaseTableNames = "1"
+
+	// default sql_mode
+	dafaultSqlMode = "ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES"
+
+	CNPrimaryCheck = false
 )
 
 // FrontendParameters of the frontend

--- a/pkg/lockservice/cfg.go
+++ b/pkg/lockservice/cfg.go
@@ -87,6 +87,9 @@ func (c *Config) Validate() {
 	if c.MaxFixedSliceSize == 0 {
 		c.MaxFixedSliceSize = toml.ByteSize(defaultMaxFixedSliceSize)
 	}
+	if c.MaxLockRowCount > c.MaxFixedSliceSize {
+		panic("This parameter configuration may trigger scenarios that violate MaxFixedSliceSize")
+	}
 	if c.KeepBindDuration.Duration == 0 {
 		c.KeepBindDuration.Duration = time.Second
 	}

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -422,7 +423,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 			return false, nil, false, nil, nil, moerr.NewInvalidInput(builder.GetContext(), "insert values does not match the number of columns")
 		}
 		checkInsertPkDup = len(slt.Rows) > 1
-		if CNPrimaryCheck {
+		if config.CNPrimaryCheck {
 			CanUsePkFilter := false
 
 			if len(tableDef.Pkey.Names) == 1 {

--- a/pkg/sql/plan/build_delete.go
+++ b/pkg/sql/plan/build_delete.go
@@ -67,7 +67,7 @@ func buildDelete(stmt *tree.Delete, ctx CompilerContext, isPrepareStmt bool) (*P
 	// needLockTable := !tblInfo.isMulti && stmt.Where == nil && stmt.Limit == nil
 	// todo will do not lock table now.
 	isDeleteWithoutFilters := !tblInfo.isMulti && stmt.Where == nil && stmt.Limit == nil
-	needLockTable := isDeleteWithoutFilters
+	needLockTable := isDeleteWithoutFilters || ifNeedLockWholeTable(builder, lastNodeId)
 	for i, tableDef := range tblInfo.tableDefs {
 		deleteBindCtx := NewBindContext(builder, nil)
 		delPlanCtx := getDmlPlanCtx()

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/uuid"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 
@@ -33,13 +34,12 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var CNPrimaryCheck = false
-
 var dmlPlanCtxPool = sync.Pool{
 	New: func() any {
 		return &dmlPlanCtx{}
 	},
 }
+
 var deleteNodeInfoPool = sync.Pool{
 	New: func() any {
 		return &deleteNodeInfo{}
@@ -791,6 +791,7 @@ func buildDeletePlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindC
 						upPlanCtx.insertColPos = insertColPos
 						upPlanCtx.isFkRecursionCall = true
 						upPlanCtx.updatePkCol = updatePk
+						upPlanCtx.lockTable = ifNeedLockWholeTable(builder, lastNodeId)
 
 						err = buildUpdatePlans(ctx, builder, bindCtx, upPlanCtx, false)
 						putDmlPlanCtx(upPlanCtx)
@@ -836,6 +837,7 @@ func buildDeletePlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindC
 								upPlanCtx.allDelTableIDs = map[uint64]struct{}{}
 								upPlanCtx.isFkRecursionCall = true
 								upPlanCtx.updatePkCol = updatePk
+								upPlanCtx.lockTable = ifNeedLockWholeTable(builder, lastNodeId)
 
 								err = buildUpdatePlans(ctx, builder, bindCtx, upPlanCtx, false)
 								putDmlPlanCtx(upPlanCtx)
@@ -866,6 +868,7 @@ func buildDeletePlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindC
 								upPlanCtx.sourceStep = newSourceStep
 								upPlanCtx.beginIdx = 0
 								upPlanCtx.allDelTableIDs = allDelTableIDs
+								upPlanCtx.lockTable = ifNeedLockWholeTable(builder, lastNodeId)
 
 								err := buildDeletePlans(ctx, builder, bindCtx, upPlanCtx)
 								putDmlPlanCtx(upPlanCtx)
@@ -1175,7 +1178,7 @@ func makeInsertPlan(
 	if pkPos, pkTyp := getPkPos(tableDef, true); pkPos != -1 && checkInsertPkDupForHiddenIndexTable {
 		// needCheck := true
 		needCheck := !builder.qry.LoadTag
-		useFuzzyFilter := CNPrimaryCheck
+		useFuzzyFilter := config.CNPrimaryCheck
 		if isUpdate {
 			needCheck = updatePkCol
 			useFuzzyFilter = false
@@ -1376,7 +1379,7 @@ func makeInsertPlan(
 	// The refactor that using fuzzy filter has not been completely finished, Update type Insert cannot directly use fuzzy filter for duplicate detection.
 	//  so the original logic is retained. should be deleted later
 	// make plan: sink_scan -> join -> filter	// check if pk is unique in rows & snapshot
-	if CNPrimaryCheck && checkInsertPkDupForHiddenIndexTable {
+	if config.CNPrimaryCheck && checkInsertPkDupForHiddenIndexTable {
 		if pkPos, pkTyp := getPkPos(tableDef, true); pkPos != -1 {
 			rfTag := builder.genNewTag()
 
@@ -2331,12 +2334,13 @@ func appendPreInsertNode(builder *QueryBuilder, bindCtx *BindContext,
 	}
 
 	if !isUpdate {
+		ifLockTable := ifNeedLockWholeTable(builder, lastNodeId)
 		if lockNodeId, ok := appendLockNode(
 			builder,
 			bindCtx,
 			lastNodeId,
 			tableDef,
-			false,
+			ifLockTable,
 			false,
 			partitionIdx,
 			partTableIds,
@@ -2531,12 +2535,13 @@ func appendPreInsertUkPlan(
 	}
 	lastNodeId = builder.appendNode(preInsertUkNode, bindCtx)
 
+	ifLockTable := ifNeedLockWholeTable(builder, lastNodeId)
 	if lockNodeId, ok := appendLockNode(
 		builder,
 		bindCtx,
 		lastNodeId,
 		uniqueTableDef,
-		false,
+		ifLockTable,
 		false,
 		-1,
 		nil,
@@ -2919,7 +2924,7 @@ func makePreUpdateDeletePlan(
 		PrimaryColIdxInBat: int32(pkPos),
 		PrimaryColTyp:      pkTyp,
 		RefreshTsIdxInBat:  -1,
-		LockTable:          false,
+		LockTable:          delCtx.lockTable,
 	}
 	if delCtx.tableDef.Partition != nil {
 		lockTarget.IsPartitionTable = true
@@ -3008,7 +3013,7 @@ func makePreUpdateDeletePlan(
 			PrimaryColIdxInBat: newPkPos,
 			PrimaryColTyp:      pkTyp,
 			RefreshTsIdxInBat:  -1, //unsupport now
-			LockTable:          false,
+			LockTable:          delCtx.lockTable,
 		}
 		if delCtx.tableDef.Partition != nil {
 			lockTarget.IsPartitionTable = true
@@ -3086,10 +3091,6 @@ func appendLockNode(
 	}
 	pkPos, pkTyp := getPkPos(tableDef, false)
 	if pkPos == -1 {
-		return -1, false
-	}
-
-	if builder.qry.LoadTag && !lockTable {
 		return -1, false
 	}
 

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -87,7 +88,7 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 	}
 	var pkFilterExprs []*Expr
 	var newPartitionExpr *Expr
-	if CNPrimaryCheck && len(pkPosInValues) > 0 {
+	if config.CNPrimaryCheck && len(pkPosInValues) > 0 {
 		pkFilterExprs = getPkValueExpr(builder, ctx, tableDef, pkPosInValues)
 		// The insert statement subplan with a primary key has undergone manual column pruning in advance,
 		// so the partition expression needs to be remapped and judged whether partition pruning can be performed
@@ -246,6 +247,7 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 		upPlanCtx.insertColPos = insertColPos
 		upPlanCtx.updateColPosMap = updateColPosMap
 		upPlanCtx.checkInsertPkDup = checkInsertPkDup
+		upPlanCtx.lockTable = ifNeedLockWholeTable(builder, lastNodeId)
 
 		err = buildUpdatePlans(ctx, builder, updateBindCtx, upPlanCtx, true)
 		if err != nil {

--- a/pkg/sql/plan/build_update.go
+++ b/pkg/sql/plan/build_update.go
@@ -69,6 +69,7 @@ func buildTableUpdate(stmt *tree.Update, ctx CompilerContext, isPrepareStmt bool
 		upPlanCtx := updatePlanCtxs[i]
 		upPlanCtx.beginIdx = beginIdx
 		upPlanCtx.sourceStep = sourceStep
+		upPlanCtx.lockTable = ifNeedLockWholeTable(builder, lastNodeId)
 
 		updateBindCtx := NewBindContext(builder, nil)
 		beginIdx = beginIdx + upPlanCtx.updateColLength + len(tableDef.Cols)

--- a/pkg/sql/plan/build_util.go
+++ b/pkg/sql/plan/build_util.go
@@ -39,6 +39,23 @@ import (
 // 	return nodeID
 // }
 
+// ifNeedLockWholeTable checks if the whole table needs to be locked based on the last node's statistics.
+// It returns true if the out count of the last node is greater than the maximum lock count, otherwise it returns false.
+func ifNeedLockWholeTable(builder *QueryBuilder, lastNodeId int32) bool {
+	lastNode := builder.qry.Nodes[lastNodeId]
+	if lastNode == nil {
+		return false
+	}
+
+	lockService := builder.compCtx.GetProcess().LockService
+	if lockService == nil {
+		// MockCompilerContext
+		return false
+	}
+	lockconfig := lockService.GetConfig()
+	return lastNode.Stats.Outcnt > float64(lockconfig.MaxLockRowCount)
+}
+
 // GetFunctionArgTypeStrFromAst function arg type do not have scale and width, it depends on the data that it process
 func GetFunctionArgTypeStrFromAst(arg tree.FunctionArg) (string, error) {
 	argDecl := arg.(*tree.FunctionArgDecl)

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -2219,11 +2219,13 @@ func (builder *QueryBuilder) buildSelect(stmt *tree.Select, ctx *BindContext, is
 		if builder.isForUpdate {
 			tableDef := builder.qry.Nodes[nodeID].GetTableDef()
 			pkPos, pkTyp := getPkPos(tableDef, false)
+			ifLockTable := ifNeedLockWholeTable(builder, nodeID)
 			lockTarget := &plan.LockTarget{
 				TableId:            tableDef.TblId,
 				PrimaryColIdxInBat: int32(pkPos),
 				PrimaryColTyp:      pkTyp,
 				Block:              true,
+				LockTable:          ifLockTable,
 				RefreshTsIdxInBat:  -1, //unsupport now
 				FilterColIdxInBat:  -1, //unsupport now
 			}


### PR DESCRIPTION
sql like `insert into A select * from B`, will try to lock the value in `B`. When the number of these locks is too much, it will lead to bugs reflected in the issue. In the context of range locks being temporarily unavailable, use table lock to replace point lock

Approved by: @ouyuanning, @daviszhen, @zhangxu19830126

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/3039 https://github.com/matrixorigin/MO-Cloud/issues/3006

## What this PR does / why we need it:

replace point locks with table lock in some cases