### PR TITLE
[Feature]: Prune Older Vector Index Version

### DIFF
--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -1555,6 +1555,16 @@ func (s *Scope) handleVectorIvfFlatIndex(c *Compile, indexDefs map[string]*plan.
 		return err
 	}
 
+	// 4.d delete older entries in index table.
+	err = s.handleIvfIndexDeleteOldEntries(c,
+		indexDefs[catalog.SystemSI_IVFFLAT_TblType_Metadata].IndexTableName,
+		indexDefs[catalog.SystemSI_IVFFLAT_TblType_Centroids].IndexTableName,
+		indexDefs[catalog.SystemSI_IVFFLAT_TblType_Entries].IndexTableName,
+		qryDatabase)
+	if err != nil {
+		return err
+	}
+
 	return nil
 
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/10634

## What this PR does / why we need it:

Prune Older Vector Index Versions from `Centroids` and `Entries` Table.