### PR TITLE
Adapt purge log etl merge

### DIFF
--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -283,7 +283,10 @@ func (exec *txnExecutor) Exec(sql string) (executor.Result, error) {
 
 	logutil.Info("sql_executor exec",
 		zap.String("sql", sql),
-		zap.String("txn-id", hex.EncodeToString(exec.opts.Txn().Txn().ID)))
+		zap.String("txn-id", hex.EncodeToString(exec.opts.Txn().Txn().ID)),
+		zap.Duration("duration", time.Since(receiveAt)),
+		zap.Uint64("AffectedRows", runResult.AffectRows),
+	)
 	result.Batches = batches
 	result.AffectedRows = runResult.AffectRows
 	return result, nil

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -16,6 +16,7 @@ package compile
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"time"
 
@@ -38,6 +39,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
+
+	"go.uber.org/zap"
 )
 
 type sqlExecutor struct {
@@ -278,6 +281,9 @@ func (exec *txnExecutor) Exec(sql string) (executor.Result, error) {
 		return executor.Result{}, err
 	}
 
+	logutil.Info("sql_executor exec",
+		zap.String("sql", sql),
+		zap.String("txn-id", hex.EncodeToString(exec.opts.Txn().Txn().ID)))
 	result.Batches = batches
 	result.AffectedRows = runResult.AffectRows
 	return result, nil

--- a/pkg/sql/plan/function/func_builtin.go
+++ b/pkg/sql/plan/function/func_builtin.go
@@ -523,6 +523,7 @@ func builtInPurgeLog(parameters []*vector.Vector, result vector.FunctionResultWr
 				return moerr.NewNotSupported(proc.Ctx, "purge '%s'", tblName)
 			}
 		}
+
 		for _, tblName := range tableNames {
 			for _, tbl := range tables {
 				if strings.TrimSpace(tblName) == tbl.Table {
@@ -531,6 +532,9 @@ func builtInPurgeLog(parameters []*vector.Vector, result vector.FunctionResultWr
 					opts := executor.Options{}.WithDatabase(tbl.Database).
 						WithTxn(proc.TxnOperator).
 						WithTimeZone(proc.SessionInfo.TimeZone)
+					if proc.TxnOperator != nil {
+						opts = opts.WithDisableIncrStatement() // this option always with WithTxn()
+					}
 					res, err := exec.Exec(proc.Ctx, sql, opts)
 					if err != nil {
 						return err

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -3650,7 +3650,7 @@ var supportedDateAndTimeBuiltIns = []FuncNew{
 					return types.T_uint8.ToType()
 				},
 				newOp: func() executeLogicOfOverload {
-					return buildInPurgeLog
+					return builtInPurgeLog
 				},
 			},
 		},

--- a/test/distributed/cases/function/func_purge_log.result
+++ b/test/distributed/cases/function/func_purge_log.result
@@ -31,7 +31,7 @@ set @ts=(select IFNULL(max(collecttime), now()) from system_metrics.metric);
 select purge_log('statement_info,metric', DATE_ADD( @ts, interval 1 day)) a;
 a
 0
-select count(1) val from system_metrics.metric where `collecttime` <  DATE_SUB( @ts, interval 3 minute);
-val
-0
+select count(1) val, @ts from system_metrics.metric where `collecttime` <  DATE_SUB( @ts, interval 3 minute);
+val    @ts
+0    2024-04-21 13:47:38
 drop account if exists bvt_purge_log;

--- a/test/distributed/cases/function/func_purge_log.result
+++ b/test/distributed/cases/function/func_purge_log.result
@@ -27,11 +27,13 @@ NULL
 select purge_log(NULL, NULL) a;
 a
 NULL
-set @ts=(select IFNULL(max(collecttime), now()) from system_metrics.metric);
+set @ts=(select max(collecttime) from system_metrics.metric);
+set @metric_name=(select metric_name from system_metrics.metric where collecttime between @ts and date_add(@ts, interval 1 second) limit 1);
+set @node=(select node from system_metrics.metric where collecttime between @ts and date_add(@ts, interval 1 second) and metric_name=@metric_name limit 1);
 select purge_log('statement_info,metric', DATE_ADD( @ts, interval 1 day)) a;
 a
 0
-select count(1) val, @ts from system_metrics.metric where `collecttime` <  DATE_SUB( @ts, interval 3 minute);
-val    @ts
-0    2024-04-21 13:47:38
+select count(1) cnt, @ts, @metric_name, @node from  system_metrics.metric where collecttime between @ts and date_add(@ts, interval 1 second) and metric_name=@metric_name and node=@node;
+cnt    @ts    @metric_name    @node
+0    date time    any_value    any_value
 drop account if exists bvt_purge_log;

--- a/test/distributed/cases/function/func_purge_log.sql
+++ b/test/distributed/cases/function/func_purge_log.sql
@@ -25,7 +25,8 @@ select purge_log(NULL, NULL) a;
 -- case for issue 10421, 15,455
 set @ts=(select IFNULL(max(collecttime), now()) from system_metrics.metric);
 select purge_log('statement_info,metric', DATE_ADD( @ts, interval 1 day)) a;
-select count(1) val from system_metrics.metric where `collecttime` <  DATE_SUB( @ts, interval 3 minute);
+-- @ignore:1
+select count(1) val, @ts from system_metrics.metric where `collecttime` <  DATE_SUB( @ts, interval 3 minute);
 
 -- clean
 drop account if exists bvt_purge_log;

--- a/test/distributed/cases/function/func_purge_log.sql
+++ b/test/distributed/cases/function/func_purge_log.sql
@@ -23,10 +23,13 @@ select purge_log(NULL, '2023-06-30') a;
 select purge_log(NULL, NULL) a;
 
 -- case for issue 10421, 15,455
-set @ts=(select IFNULL(max(collecttime), now()) from system_metrics.metric);
+-- case for issue 15,455 - ETLMerge casse
+set @ts=(select max(collecttime) from system_metrics.metric);
+set @metric_name=(select metric_name from system_metrics.metric where collecttime between @ts and date_add(@ts, interval 1 second) limit 1);
+set @node=(select node from system_metrics.metric where collecttime between @ts and date_add(@ts, interval 1 second) and metric_name=@metric_name limit 1);
 select purge_log('statement_info,metric', DATE_ADD( @ts, interval 1 day)) a;
--- @ignore:1
-select count(1) val, @ts from system_metrics.metric where `collecttime` <  DATE_SUB( @ts, interval 3 minute);
+-- @ignore:1,2,3
+select count(1) cnt, @ts, @metric_name, @node from  system_metrics.metric where collecttime between @ts and date_add(@ts, interval 1 second) and metric_name=@metric_name and node=@node;
 
 -- clean
 drop account if exists bvt_purge_log;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/15455#issuecomment-2069049962

## What this PR does / why we need it:
changes:
1. keep  purge_log's backgroud sql in the frontend txn.
2. modify ut func_purge_log by checking specified one record.