### PR TITLE
[fix] : replace point locks with table lock in some cases (1.1-dev)

### DIFF
--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -40,7 +40,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/queryservice"
-	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/taskservice"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
@@ -363,9 +362,9 @@ func (c *Config) Validate() error {
 
 	// pessimistic mode implies primary key check
 	if txn.GetTxnMode(c.Txn.Mode) == txn.TxnMode_Pessimistic || c.PrimaryKeyCheck {
-		plan.CNPrimaryCheck = true
+		config.CNPrimaryCheck = true
 	} else {
-		plan.CNPrimaryCheck = false
+		config.CNPrimaryCheck = false
 	}
 
 	if c.MaxPreparedStmtCount > 0 {

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -164,6 +164,8 @@ var (
 
 	// default lower_case_table_names
 	defaultLowerCaseTableNames = "1"
+
+	CNPrimaryCheck = false
 )
 
 // FrontendParameters of the frontend

--- a/pkg/lockservice/cfg.go
+++ b/pkg/lockservice/cfg.go
@@ -87,6 +87,9 @@ func (c *Config) Validate() {
 	if c.MaxFixedSliceSize == 0 {
 		c.MaxFixedSliceSize = toml.ByteSize(defaultMaxFixedSliceSize)
 	}
+	if c.MaxLockRowCount > c.MaxFixedSliceSize {
+		panic("This parameter configuration may trigger scenarios that violate MaxFixedSliceSize")
+	}
 	if c.KeepBindDuration.Duration == 0 {
 		c.KeepBindDuration.Duration = time.Second
 	}

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -422,7 +423,7 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 			return false, nil, false, nil, nil, moerr.NewInvalidInput(builder.GetContext(), "insert values does not match the number of columns")
 		}
 		checkInsertPkDup = len(slt.Rows) > 1
-		if CNPrimaryCheck {
+		if config.CNPrimaryCheck {
 			CanUsePkFilter := false
 
 			if len(tableDef.Pkey.Names) == 1 {

--- a/pkg/sql/plan/build_delete.go
+++ b/pkg/sql/plan/build_delete.go
@@ -117,6 +117,7 @@ func buildDelete(stmt *tree.Delete, ctx CompilerContext, isPrepareStmt bool) (*P
 
 	reduceSinkSinkScanNodes(query)
 	ReCalcQueryStats(builder, query)
+	reCheckifNeedLockWholeTable(builder)
 	query.StmtType = plan.Query_DELETE
 	return &Plan{
 		Plan: &plan.Plan_Query{

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/uuid"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 
@@ -33,13 +34,12 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var CNPrimaryCheck = false
-
 var dmlPlanCtxPool = sync.Pool{
 	New: func() any {
 		return &dmlPlanCtx{}
 	},
 }
+
 var deleteNodeInfoPool = sync.Pool{
 	New: func() any {
 		return &deleteNodeInfo{}
@@ -1175,7 +1175,7 @@ func makeInsertPlan(
 	if pkPos, pkTyp := getPkPos(tableDef, true); pkPos != -1 && checkInsertPkDupForHiddenIndexTable {
 		// needCheck := true
 		needCheck := !builder.qry.LoadTag
-		useFuzzyFilter := CNPrimaryCheck
+		useFuzzyFilter := config.CNPrimaryCheck
 		if isUpdate {
 			needCheck = updatePkCol
 			useFuzzyFilter = false
@@ -1376,7 +1376,7 @@ func makeInsertPlan(
 	// The refactor that using fuzzy filter has not been completely finished, Update type Insert cannot directly use fuzzy filter for duplicate detection.
 	//  so the original logic is retained. should be deleted later
 	// make plan: sink_scan -> join -> filter	// check if pk is unique in rows & snapshot
-	if CNPrimaryCheck && checkInsertPkDupForHiddenIndexTable {
+	if config.CNPrimaryCheck && checkInsertPkDupForHiddenIndexTable {
 		if pkPos, pkTyp := getPkPos(tableDef, true); pkPos != -1 {
 			rfTag := builder.genNewTag()
 

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -87,7 +88,7 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 	}
 	var pkFilterExprs []*Expr
 	var newPartitionExpr *Expr
-	if CNPrimaryCheck && len(pkPosInValues) > 0 {
+	if config.CNPrimaryCheck && len(pkPosInValues) > 0 {
 		pkFilterExprs = getPkValueExpr(builder, ctx, tableDef, pkPosInValues)
 		// The insert statement subplan with a primary key has undergone manual column pruning in advance,
 		// so the partition expression needs to be remapped and judged whether partition pruning can be performed
@@ -269,6 +270,7 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 	query.DetectSqls = sqls
 	reduceSinkSinkScanNodes(query)
 	ReCalcQueryStats(builder, query)
+	reCheckifNeedLockWholeTable(builder)
 	return &Plan{
 		Plan: &plan.Plan_Query{
 			Query: query,

--- a/pkg/sql/plan/build_update.go
+++ b/pkg/sql/plan/build_update.go
@@ -90,6 +90,7 @@ func buildTableUpdate(stmt *tree.Update, ctx CompilerContext, isPrepareStmt bool
 	query.DetectSqls = detectSqls
 	reduceSinkSinkScanNodes(query)
 	ReCalcQueryStats(builder, query)
+	reCheckifNeedLockWholeTable(builder)
 	query.StmtType = plan.Query_UPDATE
 	return &Plan{
 		Plan: &plan.Plan_Query{

--- a/pkg/sql/plan/explain/explain_query.go
+++ b/pkg/sql/plan/explain/explain_query.go
@@ -203,6 +203,19 @@ func explainStep(ctx context.Context, step *plan.Node, settings *FormatSettings,
 					settings.buffer.PushNewLine(buf.String(), false, settings.level)
 				}
 			}
+
+			if nodedescImpl.Node.NodeType == plan.Node_LOCK_OP {
+				if nodedescImpl.Node.LockTargets != nil {
+					buf := bytes.NewBuffer(make([]byte, 0, 360))
+					buf.WriteString("Lock level: ")
+					if nodedescImpl.Node.LockTargets[0].LockTable {
+						buf.WriteString("Table level lock")
+					} else {
+						buf.WriteString("Row level lock")
+					}
+					settings.buffer.PushNewLine(buf.String(), false, settings.level)
+				}
+			}			
 		}
 
 		// print out the actual operation information

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -2862,6 +2862,10 @@ func (builder *QueryBuilder) buildSelect(stmt *tree.Select, ctx *BindContext, is
 		builder.qry.Headings = append(builder.qry.Headings, ctx.headings...)
 	}
 
+	if builder.isForUpdate {
+		reCheckifNeedLockWholeTable(builder)
+	}
+
 	return nodeID, nil
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/3039

## What this PR does / why we need it:

too avoid the number of row lock is too large, and fix can not load varbinary data