### PR TITLE
[fix] : let lock op can handle varbinary

### DIFF
--- a/pkg/sql/colexec/lockop/fetch.go
+++ b/pkg/sql/colexec/lockop/fetch.go
@@ -87,7 +87,7 @@ func GetFetchRowsFunc(t types.Type) FetchLockRowsFunc {
 		return fetchDecimal128Rows
 	case types.T_uuid:
 		return fetchUUIDRows
-	case types.T_char, types.T_varchar, types.T_binary:
+	case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary:
 		return fetchVarlenaRows
 		// T_json, T_blob, T_array_float32 etc. cannot be PK.
 	case types.T_enum:


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/3067

## What this PR does / why we need it:

let lock op can handle varbinary