### PR TITLE
fix panic in cn merge & support avoiding transfer by changing table comment

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -105,6 +105,10 @@ const (
 )
 
 const (
+	MO_COMMENT_NO_DEL_HINT = "[mo_no_del_hint]"
+)
+
+const (
 	// Non-hard-coded data dictionary table
 	MO_INDEXES = "mo_indexes"
 

--- a/pkg/util/export/table/table.go
+++ b/pkg/util/export/table/table.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -445,7 +446,8 @@ func (tbl *Table) ToCreateSql(ctx context.Context, ifNotExists bool) string {
 		sb.WriteString(`)`)
 	}
 	sb.WriteString("\n)")
-	if len(tbl.Comment) > 0 {
+
+	if len(tbl.Comment) > 0 && slices.Contains([]string{"statement_info", "rawlog"}, tbl.Table) {
 		sb.WriteString(fmt.Sprintf(" COMMENT %q ", tbl.Comment))
 	}
 	// cluster by

--- a/pkg/util/export/table/table.go
+++ b/pkg/util/export/table/table.go
@@ -445,6 +445,9 @@ func (tbl *Table) ToCreateSql(ctx context.Context, ifNotExists bool) string {
 		sb.WriteString(`)`)
 	}
 	sb.WriteString("\n)")
+	if len(tbl.Comment) > 0 {
+		sb.WriteString(fmt.Sprintf(" COMMENT %q ", tbl.Comment))
+	}
 	// cluster by
 	if len(tbl.ClusterBy) > 0 && tbl.Engine != ExternalTableEngine {
 		sb.WriteString(" cluster by (")

--- a/pkg/util/trace/impl/motrace/schema.go
+++ b/pkg/util/trace/impl/motrace/schema.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace/statistic"
 
 	"github.com/matrixorigin/matrixone/pkg/util/export/table"
@@ -112,7 +113,7 @@ var (
 		ClusterBy:        []table.Column{reqAtCol},
 		// Engine
 		Engine:        table.NormalTableEngine,
-		Comment:       "record each statement and stats info",
+		Comment:       "record each statement and stats info" + catalog.MO_COMMENT_NO_DEL_HINT,
 		PathBuilder:   table.NewAccountDatePathBuilder(),
 		AccountColumn: &accountCol,
 		// TimestampColumn
@@ -184,7 +185,7 @@ var (
 		PrimaryKeyColumn: nil,
 		ClusterBy:        []table.Column{timestampCol},
 		Engine:           table.NormalTableEngine,
-		Comment:          "read merge data from log, error, span",
+		Comment:          "read merge data from log, error, span" + catalog.MO_COMMENT_NO_DEL_HINT,
 		PathBuilder:      table.NewAccountDatePathBuilder(),
 		AccountColumn:    nil,
 		// TimestampColumn

--- a/pkg/vm/engine/disttae/merge.go
+++ b/pkg/vm/engine/disttae/merge.go
@@ -16,7 +16,9 @@ package disttae
 
 import (
 	"context"
+	"strings"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
@@ -48,6 +50,8 @@ type CNMergeTask struct {
 	colattrs    []string     // no rowid column
 	sortkeyPos  int          // (composite) primary key, cluster by etc. -1 meas no sort key
 	sortkeyIsPK bool
+
+	doTransfer bool
 
 	// targets
 	targets []logtailreplay.ObjectInfo
@@ -108,9 +112,13 @@ func NewCNMergeTask(
 		fs:          fs,
 		blkCnts:     blkCnts,
 		blkIters:    blkIters,
+		doTransfer:  !strings.Contains(tbl.comment, catalog.MO_COMMENT_NO_DEL_HINT),
 	}, nil
 }
 
+func (t *CNMergeTask) DoTransfer() bool {
+	return t.doTransfer
+}
 func (t *CNMergeTask) GetObjectCnt() int {
 	return len(t.targets)
 }

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -2775,23 +2776,67 @@ func (tbl *txnTable) MergeObjects(ctx context.Context, objstats []objectio.Objec
 		return nil, err
 	}
 
+	if taskHost.DoTransfer() {
+		return taskHost.commitEntry, nil
+	}
+
 	// if transfer info is too large, write it down to s3
-	if size := taskHost.commitEntry.Booking.ProtoSize(); size > 60*common.Const1MBytes {
-		logutil.Infof("mergeblocks on cn: write s3 transfer info %v", common.HumanReadableBytes(size))
-		t := types.T_varchar.ToType()
-		v, releasev := taskHost.GetVector(&t)
-		defer releasev()
-		vectorRowCnt := 1
-		data, err := taskHost.commitEntry.Booking.Marshal()
-		if err != nil {
+	if size := taskHost.commitEntry.Booking.ProtoSize(); size > 80*common.Const1MBytes {
+		if err := dumpTransferInfo(ctx, taskHost); err != nil {
 			return taskHost.commitEntry, err
 		}
-		vector.AppendBytes(v, data, false, taskHost.GetMPool())
-		taskHost.commitEntry.Booking.Marshal()
-		name := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
-		writer, err := blockio.NewBlockWriterNew(taskHost.fs, name, 0, nil)
+		idx := 0
+		locstr := ""
+		locations := taskHost.commitEntry.BookingLoc
+		for ; idx < len(locations); idx += objectio.LocationLen {
+			loc := objectio.Location(locations[idx : idx+objectio.LocationLen])
+			locstr += loc.String() + ","
+		}
+		logutil.Infof("mergeblocks %v-%v on cn: write s3 transfer info (%v) %v",
+			tbl.tableId, tbl.tableName, common.HumanReadableBytes(size), locstr)
+	}
+
+	// commit this to tn
+	return taskHost.commitEntry, nil
+}
+
+func dumpTransferInfo(ctx context.Context, taskHost *CNMergeTask) (err error) {
+	defer func() {
 		if err != nil {
-			return taskHost.commitEntry, err
+			idx := 0
+			locations := taskHost.commitEntry.BookingLoc
+			for ; idx < len(locations); idx += objectio.LocationLen {
+				loc := objectio.Location(locations[idx : idx+objectio.LocationLen])
+				taskHost.fs.Delete(ctx, loc.Name().String())
+			}
+		}
+	}()
+	data, err := taskHost.commitEntry.Booking.Marshal()
+	if err != nil {
+		return
+	}
+	taskHost.commitEntry.BookingLoc = make([]byte, 0, objectio.LocationLen)
+	chunkSize := 1000 * mpool.MB
+	for len(data) > 0 {
+		var chunck []byte
+		if len(data) > chunkSize {
+			chunck = data[:chunkSize]
+			data = data[chunkSize:]
+		} else {
+			chunck = data
+			data = nil
+		}
+
+		t := types.T_varchar.ToType()
+		v, releasev := taskHost.GetVector(&t)
+		vectorRowCnt := 1
+		vector.AppendBytes(v, chunck, false, taskHost.GetMPool())
+		name := objectio.BuildObjectName(objectio.NewSegmentid(), 0)
+		var writer *blockio.BlockWriter
+		writer, err = blockio.NewBlockWriterNew(taskHost.fs, name, 0, nil)
+		if err != nil {
+			releasev()
+			return
 		}
 
 		batch := batch.New(true, []string{"payload"})
@@ -2799,22 +2844,23 @@ func (tbl *txnTable) MergeObjects(ctx context.Context, objstats []objectio.Objec
 		batch.Vecs[0] = v
 		_, err = writer.WriteTombstoneBatch(batch)
 		if err != nil {
-			return taskHost.commitEntry, err
+			releasev()
+			return
 		}
-		blocks, _, err := writer.Sync(ctx)
+		var blocks []objectio.BlockObject
+		blocks, _, err = writer.Sync(ctx)
+		releasev()
 		if err != nil {
-			return taskHost.commitEntry, err
+			return
 		}
 		location := blockio.EncodeLocation(
 			name,
 			blocks[0].GetExtent(),
 			uint32(vectorRowCnt),
 			blocks[0].GetID())
-		taskHost.commitEntry.BookingLoc = make([]byte, len(location))
-		copy(taskHost.commitEntry.BookingLoc[:], location[:])
-		taskHost.commitEntry.Booking = nil
+		taskHost.commitEntry.BookingLoc = append(taskHost.commitEntry.BookingLoc, location...)
 	}
 
-	// commit this to tn
-	return taskHost.commitEntry, nil
+	taskHost.commitEntry.Booking = nil
+	return
 }

--- a/pkg/vm/engine/tae/db/checkpoint/runner.go
+++ b/pkg/vm/engine/tae/db/checkpoint/runner.go
@@ -948,7 +948,7 @@ func (r *runner) tryCompactTree(entry *logtail.DirtyTreeEntry, force bool) {
 		}
 	})
 
-	pressure := float64(totalSize) / float64(common.RuntimeCNMergeMemControl.Load())
+	pressure := float64(totalSize) / float64(common.RuntimeOverallFlushMemCap.Load())
 	if pressure > 1.0 {
 		pressure = 1.0
 	}

--- a/pkg/vm/engine/tae/db/open.go
+++ b/pkg/vm/engine/tae/db/open.go
@@ -53,7 +53,7 @@ func fillRuntimeOptions(opts *options.Options) {
 	common.RuntimeCNMergeMemControl.Store(opts.MergeCfg.CNMergeMemControlHint)
 	common.RuntimeMinCNMergeSize.Store(opts.MergeCfg.CNTakeOverExceed)
 	common.RuntimeCNTakeOverAll.Store(opts.MergeCfg.CNTakeOverAll)
-	common.RuntimeCNMergeMemControl.Store(opts.CheckpointCfg.OverallFlushMemControl)
+	common.RuntimeOverallFlushMemCap.Store(opts.CheckpointCfg.OverallFlushMemControl)
 	if opts.IsStandalone {
 		common.IsStandaloneBoost.Store(true)
 	}

--- a/pkg/vm/engine/tae/mergesort/merger.go
+++ b/pkg/vm/engine/tae/mergesort/merger.go
@@ -17,6 +17,7 @@ package mergesort
 import (
 	"context"
 	"errors"
+
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -88,7 +89,9 @@ func newMerger[T any](host MergeTaskHost, lessFunc lessFunc[T], sortKeyPos int, 
 		m.totalBlkCnt += cnt
 	}
 
-	initTransferMapping(host.GetCommitEntry(), m.totalBlkCnt)
+	if host.DoTransfer() {
+		initTransferMapping(host.GetCommitEntry(), m.totalBlkCnt)
+	}
 
 	return m
 }
@@ -135,10 +138,12 @@ func (m *merger[T]) Merge(ctx context.Context) {
 			}
 		}
 
-		commitEntry.Booking.Mappings[m.accObjBlkCnts[objIdx]+m.loadedObjBlkCnts[objIdx]-1].M[int32(rowIdx)] = api.TransDestPos{
-			ObjIdx: int32(objCnt),
-			BlkIdx: int32(uint32(blkCnt)),
-			RowIdx: int32(bufferRowCnt),
+		if m.host.DoTransfer() {
+			commitEntry.Booking.Mappings[m.accObjBlkCnts[objIdx]+m.loadedObjBlkCnts[objIdx]-1].M[int32(rowIdx)] = api.TransDestPos{
+				ObjIdx: int32(objCnt),
+				BlkIdx: int32(uint32(blkCnt)),
+				RowIdx: int32(bufferRowCnt),
+			}
 		}
 
 		bufferRowCnt++

--- a/pkg/vm/engine/tae/mergesort/task.go
+++ b/pkg/vm/engine/tae/mergesort/task.go
@@ -49,6 +49,7 @@ type MergeTaskHost interface {
 	PrepareCommitEntry() *api.MergeCommitEntry
 	GetCommitEntry() *api.MergeCommitEntry
 	PrepareNewWriter() *blockio.BlockWriter
+	DoTransfer() bool
 	GetObjectCnt() int
 	GetBlkCnts() []int
 	GetAccBlkCnts() []int
@@ -226,7 +227,9 @@ func DoMergeAndWrite(
 	}
 	defer release()
 
-	initTransferMapping(commitEntry, len(batches))
+	if mergehost.DoTransfer() {
+		initTransferMapping(commitEntry, len(batches))
+	}
 
 	fromLayout := make([]uint32, len(batches))
 	totalRowCount := 0
@@ -250,7 +253,9 @@ func DoMergeAndWrite(
 				continue
 			}
 		}
-		AddSortPhaseMapping(commitEntry.Booking, i, rowCntBeforeApplyDelete, del, nil)
+		if mergehost.DoTransfer() {
+			AddSortPhaseMapping(commitEntry.Booking, i, rowCntBeforeApplyDelete, del, nil)
+		}
 		fromLayout[i] = uint32(batches[i].RowCount())
 		totalRowCount += batches[i].RowCount()
 	}
@@ -259,7 +264,9 @@ func DoMergeAndWrite(
 		logutil.Info("[Done] Mergeblocks due to all deleted",
 			zap.String("table", tableDesc),
 			zap.String("txn-start-ts", commitEntry.StartTs.DebugString()))
-		CleanTransMapping(commitEntry.Booking)
+		if mergehost.DoTransfer() {
+			CleanTransMapping(commitEntry.Booking)
+		}
 		return
 	}
 
@@ -269,7 +276,9 @@ func DoMergeAndWrite(
 
 	retBatches, releaseF := ReshapeBatches(batches, fromLayout, toLayout, mergehost)
 	defer releaseF()
-	UpdateMappingAfterMerge(commitEntry.Booking, nil, toLayout)
+	if mergehost.DoTransfer() {
+		UpdateMappingAfterMerge(commitEntry.Booking, nil, toLayout)
+	}
 
 	// -------------------------- phase 2
 	phaseDesc = "new writer to write down"

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -441,22 +441,47 @@ func (h *Handle) HandleCommitMerge(
 		if req.Booking != nil {
 			logutil.Error("mergeblocks err booking loc is not empty, but booking is not nil")
 		}
-		loc := objectio.Location(req.BookingLoc)
-		var bat *batch.Batch
-		var release func()
-		bat, release, err = blockio.LoadTombstoneColumns(ctx, []uint16{0}, nil, h.db.Runtime.Fs.Service, loc, nil)
-		if err != nil {
-			return
-		}
-		req.Booking = &api.BlkTransferBooking{}
-		err = req.Booking.Unmarshal(bat.Vecs[0].GetBytesAt(0))
-		if err != nil {
+		if len(req.BookingLoc) == objectio.LocationLen {
+			loc := objectio.Location(req.BookingLoc)
+			var bat *batch.Batch
+			var release func()
+			bat, release, err = blockio.LoadTombstoneColumns(ctx, []uint16{0}, nil, h.db.Runtime.Fs.Service, loc, nil)
+			if err != nil {
+				return
+			}
+			req.Booking = &api.BlkTransferBooking{}
+			err = req.Booking.Unmarshal(bat.Vecs[0].GetBytesAt(0))
+			if err != nil {
+				release()
+				return
+			}
 			release()
-			return
+			h.db.Runtime.Fs.Service.Delete(ctx, loc.Name().String())
+			bat = nil
+		} else {
+			// it has to copy to concat
+			idx := 0
+			locations := req.BookingLoc
+			data := make([]byte, 0, 2<<30)
+			for ; idx < len(locations); idx += objectio.LocationLen {
+				loc := objectio.Location(locations[idx : idx+objectio.LocationLen])
+				var bat *batch.Batch
+				var release func()
+				bat, release, err = blockio.LoadTombstoneColumns(ctx, []uint16{0}, nil, h.db.Runtime.Fs.Service, loc, nil)
+				if err != nil {
+					return
+				}
+				data = append(data, bat.Vecs[0].GetBytesAt(0)...)
+				release()
+				h.db.Runtime.Fs.Service.Delete(ctx, loc.Name().String())
+				bat = nil
+			}
+			req.Booking = &api.BlkTransferBooking{}
+			if err = req.Booking.Unmarshal(data); err != nil {
+				return
+			}
+			data = nil
 		}
-		release()
-		h.db.Runtime.Fs.Service.Delete(ctx, loc.Name().String())
-		bat = nil
 	}
 
 	_, err = jobs.HandleMergeEntryInTxn(txn, req, h.db.Runtime)

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -480,7 +480,6 @@ func (h *Handle) HandleCommitMerge(
 			if err = req.Booking.Unmarshal(data); err != nil {
 				return
 			}
-			data = nil
 		}
 	}
 

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -17,6 +17,10 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/bitmap"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -40,7 +44,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tasks"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"time"
 )
 
 type TestFlushBailoutPos1 struct{}
@@ -68,6 +71,7 @@ type flushTableTailTask struct {
 
 	// record the row mapping from deleted blocks to created blocks
 	transMappings *api.BlkTransferBooking
+	doTransfer    bool
 
 	aObjMetas         []*catalog.ObjectEntry
 	delSrcMetas       []*catalog.ObjectEntry
@@ -168,7 +172,11 @@ func NewFlushTableTailTask(
 			task.delSrcHandles = append(task.delSrcHandles, hdl)
 		}
 	}
-	task.transMappings = mergesort.NewBlkTransferBooking(len(task.aObjHandles))
+
+	task.doTransfer = !strings.Contains(task.schema.Comment, pkgcatalog.MO_COMMENT_NO_DEL_HINT)
+	if task.doTransfer {
+		task.transMappings = mergesort.NewBlkTransferBooking(len(task.aObjHandles))
+	}
 
 	task.BaseTask = tasks.NewBaseTask(task, tasks.DataCompactionTask, ctx)
 
@@ -411,7 +419,9 @@ func (task *flushTableTailTask) prepareAObjSortedData(
 			return
 		}
 	}
-	mergesort.AddSortPhaseMapping(task.transMappings, objIdx, rowCntBeforeApplyDelete, deletes, sortMapping)
+	if task.doTransfer {
+		mergesort.AddSortPhaseMapping(task.transMappings, objIdx, rowCntBeforeApplyDelete, deletes, sortMapping)
+	}
 	return
 }
 
@@ -474,7 +484,9 @@ func (task *flushTableTailTask) mergeAObjs(ctx context.Context) (err error) {
 				return err
 			}
 		}
-		mergesort.CleanTransMapping(task.transMappings)
+		if task.doTransfer {
+			mergesort.CleanTransMapping(task.transMappings)
+		}
 		return nil
 	}
 
@@ -519,7 +531,9 @@ func (task *flushTableTailTask) mergeAObjs(ctx context.Context) (err error) {
 		writtenBatches, releaseF = mergesort.ReshapeBatches(cnBatches, fromLayout, toLayout, task)
 	}
 	defer releaseF()
-	mergesort.UpdateMappingAfterMerge(task.transMappings, mapping, toLayout)
+	if task.doTransfer {
+		mergesort.UpdateMappingAfterMerge(task.transMappings, mapping, toLayout)
+	}
 
 	// write!
 	// create new object to hold merged blocks

--- a/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
@@ -17,7 +17,9 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
@@ -51,6 +53,8 @@ type mergeObjectsTask struct {
 	commitEntry       *api.MergeCommitEntry
 	rel               handle.Relation
 	did, tid          uint64
+
+	doTransfer bool
 
 	blkCnt     []int
 	nMergedBlk []int
@@ -100,6 +104,7 @@ func NewMergeObjectsTask(
 		task.mergedObjsHandle = append(task.mergedObjsHandle, obj)
 	}
 	task.schema = task.rel.Schema().(*catalog.Schema)
+	task.doTransfer = !strings.Contains(task.schema.Comment, pkgcatalog.MO_COMMENT_NO_DEL_HINT)
 	task.idxs = make([]int, 0, len(task.schema.ColDefs)-1)
 	task.attrs = make([]string, 0, len(task.schema.ColDefs)-1)
 	for _, def := range task.schema.ColDefs {
@@ -295,6 +300,10 @@ func (task *mergeObjectsTask) PrepareNewWriter() *blockio.BlockWriter {
 	}
 
 	return mergesort.GetNewWriter(task.rt.Fs.Service, schema.Version, seqnums, sortkeyPos, sortkeyIsPK)
+}
+
+func (task *mergeObjectsTask) DoTransfer() bool {
+	return task.doTransfer
 }
 
 func (task *mergeObjectsTask) Execute(ctx context.Context) (err error) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3069

## What this PR does / why we need it:

- fix transfer panic
- table comment `[mo_no_del_hint]` will skip transfer, which saves memory usage.
- mark `statement_info` & `rawlog` as `[mo_no_del_hint]`