### PR TITLE
[opt] : when composite primary key has a column that is auto-incr, and this column does not specify a value, no dup check is needed

### DIFF
--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -522,9 +522,19 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 			if err != nil {
 				return false, nil, err
 			}
-
-			if col.Typ.AutoIncr && col.Name == tableDef.Pkey.PkeyColName {
-				ifExistAutoPkCol = true
+			if col.Typ.AutoIncr {
+				if tableDef.Pkey.PkeyColName == catalog.CPrimaryKeyColName {
+					for _, name := range tableDef.Pkey.Names {
+						if col.Name == name {
+							ifExistAutoPkCol = true
+							break
+						}
+					}
+				} else {
+					if col.Name == tableDef.Pkey.PkeyColName {
+						ifExistAutoPkCol = true
+					}
+				}
 			}
 
 			projectList = append(projectList, defExpr)

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -1519,15 +1519,15 @@ func makeOneInsertPlan(
 
 	// there will be some cases that no need to check if primary key is duplicate
 	//  case 1: For SQL that contains on duplicate update
-	//  case 2: the only primary key is auto increment type
+	//  case 2: (the only primary key is auto increment type or auto increment is part of compound primary key) AND auto incr col has no value
 	//  case 3: create hidden table for secondary index
 
 	isSecondaryHidden := strings.Contains(tableDef.Name, catalog.SecondaryIndexTableNamePrefix)
-	if isSecondaryHidden {
+	if isSecondaryHidden || ifExistAutoPkCol {
 		return nil
 	}
 
-	if ifCheckPkDup && !ifExistAutoPkCol {
+	if ifCheckPkDup {
 		if err = appendPrimaryConstrantPlan(builder, bindCtx, tableDef, objRef, partitionExpr, pkFilterExprs,
 			indexSourceColTypes, sourceStep, updateColLength > 0, updatePkCol, fuzzymessage); err != nil {
 			return err


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/3038

## What this PR does / why we need it:

to opt sysbench insert performance