### PR TITLE
bugfix: GetSQLWriterDBAddressFunc if not set, return nil

### DIFF
--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -82,7 +82,11 @@ func SetSQLWriterDBAddressFunc(f func(context.Context, bool) (string, error)) {
 }
 
 func GetSQLWriterDBAddressFunc() func(context.Context, bool) (string, error) {
-	return dbAddressFunc.Load().(func(context.Context, bool) (string, error))
+	if f := dbAddressFunc.Load(); f == nil {
+		return nil
+	} else {
+		return f.(func(context.Context, bool) (string, error))
+	}
 }
 
 func SetDBConn(conn *sql.DB) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3166

## What this PR does / why we need it:
changes:
1. GetSQLWriterDBAddressFunc return nil if SetSQLWriterDBAddressFunc not set.