### PR TITLE
disttae: cache result of GetTableById in PartitionState

### DIFF
--- a/pkg/vm/engine/disttae/logtailreplay/partition.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition.go
@@ -31,6 +31,15 @@ type Partition struct {
 
 	// assuming checkpoints will be consumed once
 	checkpointConsumed atomic.Bool
+
+	TableInfo   TableInfo
+	TableInfoOK bool
+}
+
+type TableInfo struct {
+	ID            uint64
+	Name          string
+	PrimarySeqnum int
 }
 
 func NewPartition() *Partition {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/3114

## What this PR does / why we need it:
GetTableById is too slow, cache its results.