### PR TITLE
mo-service: set mutex and block profile rate/fraction

### DIFF
--- a/cmd/mo-service/debug.go
+++ b/cmd/mo-service/debug.go
@@ -42,6 +42,13 @@ var (
 	statusServer          = status.NewServer()
 )
 
+func init() {
+	// mutex profile
+	runtime.SetMutexProfileFraction(256)
+	// block profile
+	runtime.SetBlockProfileRate(100)
+}
+
 func startCPUProfile() func() {
 	cpuProfilePath := *cpuProfilePathFlag
 	if cpuProfilePath == "" {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/3114

## What this PR does / why we need it:
set mutex and block profile options to enable further collecting.