### PR TITLE
fix wrong usage of vector.PreExtend

### DIFF
--- a/pkg/container/vector/functionTools.go
+++ b/pkg/container/vector/functionTools.go
@@ -392,36 +392,26 @@ func newResultFunc[T types.FixedSizeT](
 	return f
 }
 
-func (fr *FunctionResult[T]) PreExtendAndReset(size int) error {
+func (fr *FunctionResult[T]) PreExtendAndReset(targetSize int) error {
 	if fr.vec == nil {
 		fr.vec = fr.getVectorMethod(fr.typ)
 	}
 
-	if fr.isVarlena {
-		if err := fr.vec.PreExtend(size, fr.mp); err != nil {
-			return err
-		}
-		fr.vec.Reset(fr.typ)
-		return nil
-	}
-
-	fr.length = 0
-	if fr.vec.Capacity() < size {
-		if err := fr.vec.PreExtend(size, fr.mp); err != nil {
-			return err
-		}
-		fr.vec.Reset(fr.typ)
-		fr.vec.SetLength(size)
-		fr.cols = MustFixedCol[T](fr.vec)
-		return nil
-	}
-
 	oldLength := fr.vec.Length()
-	fr.vec.Reset(fr.typ)
-	fr.vec.SetLength(size)
-	// if fr.cols == nil, means the vector is first time to be sent to structure `FunctionResult`.
-	if (fr.cols == nil) || (len(fr.cols) > 0 && size > oldLength) {
-		fr.cols = MustFixedCol[T](fr.vec)
+
+	if more := targetSize - oldLength; more > 0 {
+		if err := fr.vec.PreExtend(more, fr.mp); err != nil {
+			return err
+		}
+		fr.vec.Reset(fr.typ)
+	}
+
+	if !fr.isVarlena {
+		fr.length = 0
+		fr.vec.SetLength(targetSize)
+		if targetSize > oldLength {
+			fr.cols = MustFixedCol[T](fr.vec)
+		}
 	}
 	return nil
 }

--- a/pkg/container/vector/functionTools.go
+++ b/pkg/container/vector/functionTools.go
@@ -403,8 +403,8 @@ func (fr *FunctionResult[T]) PreExtendAndReset(targetSize int) error {
 		if err := fr.vec.PreExtend(more, fr.mp); err != nil {
 			return err
 		}
-		fr.vec.Reset(fr.typ)
 	}
+	fr.vec.Reset(fr.typ)
 
 	if !fr.isVarlena {
 		fr.length = 0

--- a/pkg/sql/colexec/aggexec/aggResult.go
+++ b/pkg/sql/colexec/aggexec/aggResult.go
@@ -50,10 +50,10 @@ func (r *basicResult) init(
 
 func (r *basicResult) extend(more int) (oldLen, newLen int, err error) {
 	oldLen, newLen = r.res.Length(), r.res.Length()+more
-	if err = r.res.PreExtend(newLen, r.mp); err != nil {
+	if err = r.res.PreExtend(more, r.mp); err != nil {
 		return oldLen, oldLen, err
 	}
-	if err = r.ess.PreExtend(newLen, r.mp); err != nil {
+	if err = r.ess.PreExtend(more, r.mp); err != nil {
 		return oldLen, oldLen, err
 	}
 	r.res.SetLength(newLen)
@@ -67,11 +67,11 @@ func (r *basicResult) extend(more int) (oldLen, newLen int, err error) {
 }
 
 func (r *basicResult) preAllocate(more int) (err error) {
-	oldLen, newLen := r.res.Length(), r.res.Length()+more
-	if err = r.res.PreExtend(newLen, r.mp); err != nil {
+	oldLen := r.res.Length()
+	if err = r.res.PreExtend(more, r.mp); err != nil {
 		return err
 	}
-	if err = r.ess.PreExtend(newLen, r.mp); err != nil {
+	if err = r.ess.PreExtend(more, r.mp); err != nil {
 		return err
 	}
 	r.res.SetLength(oldLen)

--- a/pkg/sql/colexec/external/external.go
+++ b/pkg/sql/colexec/external/external.go
@@ -789,11 +789,12 @@ func makeBatch(param *ExternalParam, batchSize int, proc *process.Process) (bat 
 	for i := range param.Attrs {
 		typ := makeType(&param.Cols[i].Typ, param.ParallelLoad)
 		bat.Vecs[i] = proc.GetVector(typ)
-		err = bat.Vecs[i].PreExtend(batchSize, proc.GetMPool())
-		if err != nil {
-			bat.Clean(proc.GetMPool())
-			return nil, err
-		}
+	}
+	if err = bat.PreExtend(proc.GetMPool(), batchSize); err != nil {
+		bat.Clean(proc.GetMPool())
+		return nil, err
+	}
+	for i := range bat.Vecs {
 		bat.Vecs[i].SetLength(batchSize)
 	}
 	return bat, nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15669 

## What this PR does / why we need it:
聚合函数，表达式计算过程中对于vector.PreExtend方法使用有误，导致额外分配了多余的内存。