### PR TITLE
Support mo_logger disable ErrorCollection in 1.2

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -517,6 +517,9 @@ type ObservabilityParameters struct {
 	// DisableSpan default: false. Disable span collection
 	DisableSpan bool `toml:"disableSpan"`
 
+	// DisableError default: false. Disable error collection
+	DisableError bool `toml:"disableError"`
+
 	// LongSpanTime default: 500 ms. Only record span, which duration >= LongSpanTime
 	LongSpanTime toml.Duration `toml:"longSpanTime"`
 
@@ -570,6 +573,7 @@ func NewObservabilityParameters() *ObservabilityParameters {
 		MetricStorageUsageCheckNewInterval: toml.Duration{},
 		MergeCycle:                         toml.Duration{},
 		DisableSpan:                        false,
+		DisableError:                       false,
 		LongSpanTime:                       toml.Duration{},
 		SkipRunningStmt:                    defaultSkipRunningStmt,
 		DisableSqlWriter:                   false,

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -3403,7 +3403,7 @@ func (h *marshalPlanHandler) Marshal(ctx context.Context) (jsonBytes []byte) {
 	return
 }
 
-var sqlQueryIgnoreExecPlan = []byte(`{"code":200,"message":"sql query ignore execution plan"}`)
+var sqlQueryIgnoreExecPlan = []byte(`{}`)
 var sqlQueryNoRecordExecPlan = []byte(`{"code":200,"message":"sql query no record execution plan"}`)
 
 func (h *marshalPlanHandler) Stats(ctx context.Context) (statsByte statistic.StatsArray, stats motrace.Statistic) {

--- a/pkg/frontend/test/types_mock.go
+++ b/pkg/frontend/test/types_mock.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-
 	gomock "github.com/golang/mock/gomock"
 	batch "github.com/matrixorigin/matrixone/pkg/container/batch"
 	types "github.com/matrixorigin/matrixone/pkg/container/types"

--- a/pkg/util/errutil/context.go
+++ b/pkg/util/errutil/context.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/errors/errbase"
+
 	"github.com/matrixorigin/matrixone/pkg/util/stack"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 )
@@ -32,6 +33,9 @@ func WithContext(ctx context.Context, err error) error {
 
 func WithContextWithDepth(ctx context.Context, err error, depth int) error {
 	if err == nil {
+		return nil
+	}
+	if NoReportFromContext(ctx) {
 		return nil
 	}
 	if _, ok := err.(StackTracer); !ok {

--- a/pkg/util/trace/impl/motrace/buffer_pipe_test.go
+++ b/pkg/util/trace/impl/motrace/buffer_pipe_test.go
@@ -23,25 +23,22 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
-
-	"github.com/matrixorigin/matrixone/pkg/config"
-	"github.com/matrixorigin/matrixone/pkg/util/batchpipe"
-	"github.com/matrixorigin/matrixone/pkg/util/export/etl"
-	"github.com/matrixorigin/matrixone/pkg/util/export/table"
-	"github.com/matrixorigin/matrixone/pkg/util/trace"
-
-	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"github.com/stretchr/testify/require"
-
-	"github.com/matrixorigin/matrixone/pkg/common/mpool"
-	"github.com/matrixorigin/matrixone/pkg/util/errutil"
-	"github.com/matrixorigin/matrixone/pkg/util/internalExecutor"
-
 	"github.com/google/gops/agent"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/config"
+	"github.com/matrixorigin/matrixone/pkg/util/batchpipe"
+	"github.com/matrixorigin/matrixone/pkg/util/errutil"
+	"github.com/matrixorigin/matrixone/pkg/util/export/etl"
+	"github.com/matrixorigin/matrixone/pkg/util/export/table"
+	"github.com/matrixorigin/matrixone/pkg/util/internalExecutor"
+	"github.com/matrixorigin/matrixone/pkg/util/trace"
 )
 
 var buf = new(bytes.Buffer)
@@ -448,7 +445,7 @@ log_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000
 				},
 				buf: buf,
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null}",0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,{},0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
 `,
 		},
 		{
@@ -489,8 +486,8 @@ log_info,node_uuid,Standalone,0000000000000001,00000000-0000-0000-0000-000000000
 				},
 				buf: buf,
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null}",0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
-00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null}",0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,{},0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
+00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,{},0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
 `,
 		},
 		{
@@ -567,7 +564,7 @@ func Test_genCsvData_diffAccount(t *testing.T) {
 				buf: buf,
 			},
 			wantReqCnt: 1,
-			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null}",0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
+			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,{},0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
 `},
 		},
 		{
@@ -609,8 +606,8 @@ func Test_genCsvData_diffAccount(t *testing.T) {
 				buf: buf,
 			},
 			wantReqCnt: 1,
-			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null}",0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
-`, `00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,sys,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null}",0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
+			want: []string{`00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,0,Running,0,,{},0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
+`, `00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,sys,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000001000,Failed,20101,internal error: test error,{},0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,0
 `},
 		},
 	}
@@ -714,7 +711,7 @@ func Test_genCsvData_LongQueryTime(t *testing.T) {
 				buf:    buf,
 				queryT: int64(time.Second),
 			},
-			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""NO ExecPlan Serialize function"",""steps"":null}",0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,1
+			want: `00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,0001-01-01 00:00:00.000000,0001-01-01 00:00:00.000000,999999999,Running,0,,{},0,0,"[0,0,0,0,0,0,0,0,0]",,,0,,0,1
 00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show tables,,show tables,node_uuid,Standalone,1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000,999999999,Running,0,,"{""code"":200,""message"":""no exec plan""}",0,0,"[4,0,0,0,0,0,0,0,0]",,,0,,0,2
 00000000-0000-0000-0000-000000000002,00000000-0000-0000-0000-000000000001,00000000-0000-0000-0000-000000000001,MO,moroot,,system,show databases,dcl,show databases,node_uuid,Standalone,1970-01-01 00:00:00.000001,1970-01-01 00:00:01.000001,1000000000,Failed,20101,internal error: test error,"{""key"":""val""}",1,1,"[4,1,2.000,3,4,5,0,0,44.0161]",,,0,internal,0,3
 `,

--- a/pkg/util/trace/impl/motrace/config.go
+++ b/pkg/util/trace/impl/motrace/config.go
@@ -53,6 +53,8 @@ type tracerProviderConfig struct {
 
 	// disableSpan
 	disableSpan bool
+	// disableError
+	disableError bool
 	// debugMode used in Tracer.Debug
 	debugMode bool // DebugMode
 
@@ -181,6 +183,12 @@ func WithLongSpanTime(d time.Duration) tracerProviderOption {
 func WithSpanDisable(disable bool) tracerProviderOption {
 	return func(cfg *tracerProviderConfig) {
 		cfg.disableSpan = disable
+	}
+}
+
+func WithErrorDisable(disable bool) tracerProviderOption {
+	return func(cfg *tracerProviderConfig) {
+		cfg.disableError = disable
 	}
 }
 

--- a/pkg/util/trace/impl/motrace/report_statement.go
+++ b/pkg/util/trace/impl/motrace/report_statement.go
@@ -464,7 +464,7 @@ func mergeStats(e, n *StatementInfo) error {
 	return nil
 }
 
-var noExecPlan = []byte(`{"code":200,"message":"NO ExecPlan Serialize function","steps":null}`)
+var noExecPlan = []byte(`{}`)
 
 // ExecPlan2Json return ExecPlan Serialized json-str //
 // please used in s.mux.Lock()

--- a/pkg/util/trace/impl/motrace/trace.go
+++ b/pkg/util/trace/impl/motrace/trace.go
@@ -62,6 +62,7 @@ func InitWithConfig(ctx context.Context, SV *config.ObservabilityParameters, opt
 		WithLongQueryTime(SV.LongQueryTime),
 		WithLongSpanTime(SV.LongSpanTime.Duration),
 		WithSpanDisable(SV.DisableSpan),
+		WithErrorDisable(SV.DisableError),
 		WithSkipRunningStmt(SV.SkipRunningStmt),
 		WithSQLWriterDisable(SV.DisableSqlWriter),
 		WithAggregatorDisable(SV.DisableStmtAggregation),
@@ -98,6 +99,9 @@ func Init(ctx context.Context, opts ...TracerProviderOption) (err error, act boo
 		_, span := gTracer.Start(ctx, "TraceInit")
 		defer span.End()
 		defer trace.SetDefaultTracer(gTracer)
+	}
+	if config.disableError {
+		DisableLogErrorReport(true)
 	}
 
 	// init DefaultContext / DefaultSpanContext

--- a/pkg/vm/engine/tae/blockio/pipeline.go
+++ b/pkg/vm/engine/tae/blockio/pipeline.go
@@ -299,11 +299,12 @@ func NewIOPipeline(
 }
 
 func (p *IoPipeline) fillDefaults() {
+	procs := runtime.GOMAXPROCS(0)
 	if p.options.fetchParallism <= 0 {
-		p.options.fetchParallism = runtime.NumCPU() * 4
+		p.options.fetchParallism = procs * 4
 	}
 	if p.options.prefetchParallism <= 0 {
-		p.options.prefetchParallism = runtime.NumCPU() * 4
+		p.options.prefetchParallism = procs * 4
 	}
 	if p.options.queueDepth <= 0 {
 		p.options.queueDepth = 100000

--- a/pkg/vm/engine/tae/catalog/catalog.go
+++ b/pkg/vm/engine/tae/catalog/catalog.go
@@ -20,21 +20,13 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/matrixorigin/matrixone/pkg/objectio"
-	"go.uber.org/zap"
-
-	// "time"
-
 	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/data"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/wal"
 )
 
 // +--------+---------+----------+----------+------------+
@@ -77,13 +69,6 @@ type Catalog struct {
 	nodesMu   sync.RWMutex
 }
 
-func genDBFullName(tenantID uint32, name string) string {
-	if name == pkgcatalog.MO_CATALOG {
-		tenantID = 0
-	}
-	return fmt.Sprintf("%d-%s", tenantID, name)
-}
-
 func MockCatalog() *Catalog {
 	catalog := &Catalog{
 		RWMutex:    new(sync.RWMutex),
@@ -94,16 +79,6 @@ func MockCatalog() *Catalog {
 	}
 	catalog.InitSystemDB()
 	return catalog
-}
-
-func NewEmptyCatalog() *Catalog {
-	return &Catalog{
-		RWMutex:    new(sync.RWMutex),
-		IDAlloctor: NewIDAllocator(),
-		entries:    make(map[uint64]*common.GenericDLNode[*DBEntry]),
-		nameNodes:  make(map[string]*nodeList[*DBEntry]),
-		link:       common.NewGenericSortedDList((*DBEntry).Less),
-	}
 }
 
 func OpenCatalog(usageMemo any) (*Catalog, error) {
@@ -117,6 +92,15 @@ func OpenCatalog(usageMemo any) (*Catalog, error) {
 	}
 	catalog.InitSystemDB()
 	return catalog, nil
+}
+
+//#region Catalog Manipulation
+
+func genDBFullName(tenantID uint32, name string) string {
+	if name == pkgcatalog.MO_CATALOG {
+		tenantID = 0
+	}
+	return fmt.Sprintf("%d-%s", tenantID, name)
 }
 
 func (catalog *Catalog) SetUsageMemo(memo any) {
@@ -146,13 +130,14 @@ func (catalog *Catalog) InitSystemDB() {
 		panic(err)
 	}
 }
+
 func (catalog *Catalog) GCByTS(ctx context.Context, ts types.TS) {
 	logutil.Infof("GC Catalog %v", ts.ToString())
 	processor := LoopProcessor{}
 	processor.DatabaseFn = func(d *DBEntry) error {
 		needGC := d.DeleteBefore(ts)
 		if needGC {
-			catalog.RemoveEntry(d)
+			catalog.RemoveDBEntry(d)
 		}
 		return nil
 	}
@@ -190,696 +175,9 @@ func (catalog *Catalog) GCByTS(ctx context.Context, ts types.TS) {
 		panic(err)
 	}
 }
-func (catalog *Catalog) ReplayCmd(
-	txncmd txnif.TxnCmd,
-	dataFactory DataFactory,
-	observer wal.ReplayObserver) {
-	switch txncmd.GetType() {
-	case txnbase.IOET_WALTxnCommand_Composed:
-		cmds := txncmd.(*txnbase.ComposedCmd)
-		for _, cmds := range cmds.Cmds {
-			catalog.ReplayCmd(cmds, dataFactory, observer)
-		}
-	case IOET_WALTxnCommand_Database:
-		cmd := txncmd.(*EntryCommand[*EmptyMVCCNode, *DBNode])
-		catalog.onReplayUpdateDatabase(cmd, observer)
-	case IOET_WALTxnCommand_Table:
-		cmd := txncmd.(*EntryCommand[*TableMVCCNode, *TableNode])
-		catalog.onReplayUpdateTable(cmd, dataFactory, observer)
-	case IOET_WALTxnCommand_Object:
-		cmd := txncmd.(*EntryCommand[*ObjectMVCCNode, *ObjectNode])
-		catalog.onReplayUpdateObject(cmd, dataFactory, observer)
-	case IOET_WALTxnCommand_Block:
-		cmd := txncmd.(*EntryCommand[*MetadataMVCCNode, *BlockNode])
-		catalog.onReplayUpdateBlock(cmd, dataFactory, observer)
-	case IOET_WALTxnCommand_Segment:
-		// segment is deprecated
-		return
-	default:
-		panic("unsupport")
-	}
-}
 
-func (catalog *Catalog) onReplayUpdateDatabase(cmd *EntryCommand[*EmptyMVCCNode, *DBNode], observer wal.ReplayObserver) {
-	catalog.OnReplayDBID(cmd.ID.DbID)
-	var err error
-	un := cmd.mvccNode
-	if un.Is1PC() {
-		if err := un.ApplyCommit(); err != nil {
-			panic(err)
-		}
-	}
-
-	db, err := catalog.GetDatabaseByID(cmd.ID.DbID)
-	if err != nil {
-		db = NewReplayDBEntry()
-		db.ID = cmd.ID.DbID
-		db.catalog = catalog
-		db.DBNode = cmd.node
-		db.Insert(un)
-		err = catalog.AddEntryLocked(db, un.GetTxn(), false)
-		if err != nil {
-			panic(err)
-		}
-		return
-	}
-
-	dbun := db.SearchNodeLocked(un)
-	if dbun == nil {
-		db.Insert(un)
-	} else {
-		return
-		// panic(fmt.Sprintf("logic err: duplicate node %v and %v", dbun.String(), un.String()))
-	}
-}
-
-func (catalog *Catalog) OnReplayDatabaseBatch(ins, insTxn, del, delTxn *containers.Batch) {
-	for i := 0; i < ins.Length(); i++ {
-		dbid := ins.GetVectorByName(pkgcatalog.SystemDBAttr_ID).Get(i).(uint64)
-		name := string(ins.GetVectorByName(pkgcatalog.SystemDBAttr_Name).Get(i).([]byte))
-		txnNode := txnbase.ReadTuple(insTxn, i)
-		tenantID := ins.GetVectorByName(pkgcatalog.SystemDBAttr_AccID).Get(i).(uint32)
-		userID := ins.GetVectorByName(pkgcatalog.SystemDBAttr_Creator).Get(i).(uint32)
-		roleID := ins.GetVectorByName(pkgcatalog.SystemDBAttr_Owner).Get(i).(uint32)
-		createAt := ins.GetVectorByName(pkgcatalog.SystemDBAttr_CreateAt).Get(i).(types.Timestamp)
-		createSql := string(ins.GetVectorByName(pkgcatalog.SystemDBAttr_CreateSQL).Get(i).([]byte))
-		datType := string(ins.GetVectorByName(pkgcatalog.SystemDBAttr_Type).Get(i).([]byte))
-		catalog.onReplayCreateDB(dbid, name, txnNode, tenantID, userID, roleID, createAt, createSql, datType)
-	}
-	for i := 0; i < del.Length(); i++ {
-		dbid := delTxn.GetVectorByName(SnapshotAttr_DBID).Get(i).(uint64)
-		txnNode := txnbase.ReadTuple(delTxn, i)
-		catalog.onReplayDeleteDB(dbid, txnNode)
-	}
-}
-
-func (catalog *Catalog) onReplayCreateDB(
-	dbid uint64, name string, txnNode *txnbase.TxnMVCCNode,
-	tenantID, userID, roleID uint32, createAt types.Timestamp, createSql, datType string) {
-	catalog.OnReplayDBID(dbid)
-	db, _ := catalog.GetDatabaseByID(dbid)
-	if db != nil {
-		dbCreatedAt := db.GetCreatedAtLocked()
-		if !dbCreatedAt.Equal(&txnNode.End) {
-			panic(moerr.NewInternalErrorNoCtx("logic err expect %s, get %s",
-				txnNode.End.ToString(), dbCreatedAt.ToString()))
-		}
-		return
-	}
-	db = NewReplayDBEntry()
-	db.catalog = catalog
-	db.ID = dbid
-	db.DBNode = &DBNode{
-		acInfo: accessInfo{
-			TenantID: tenantID,
-			UserID:   userID,
-			RoleID:   roleID,
-			CreateAt: createAt,
-		},
-		createSql: createSql,
-		datType:   datType,
-		name:      name,
-	}
-	_ = catalog.AddEntryLocked(db, nil, true)
-	un := &MVCCNode[*EmptyMVCCNode]{
-		EntryMVCCNode: &EntryMVCCNode{
-			CreatedAt: txnNode.End,
-		},
-		TxnMVCCNode: txnNode,
-	}
-	db.Insert(un)
-}
-func (catalog *Catalog) onReplayDeleteDB(dbid uint64, txnNode *txnbase.TxnMVCCNode) {
-	catalog.OnReplayDBID(dbid)
-	db, err := catalog.GetDatabaseByID(dbid)
-	if err != nil {
-		logutil.Info("delete %d", zap.Uint64("dbid", dbid), zap.String("catalog pp", catalog.SimplePPString(common.PPL3)))
-		panic(err)
-	}
-	dbDeleteAt := db.GetDeleteAtLocked()
-	if !dbDeleteAt.IsEmpty() {
-		if !dbDeleteAt.Equal(&txnNode.End) {
-			panic(moerr.NewInternalErrorNoCtx("logic err expect %s, get %s", txnNode.End.ToString(), dbDeleteAt.ToString()))
-		}
-		return
-	}
-	prev := db.MVCCChain.GetLatestNodeLocked()
-	un := &MVCCNode[*EmptyMVCCNode]{
-		EntryMVCCNode: &EntryMVCCNode{
-			CreatedAt: db.GetCreatedAtLocked(),
-			DeletedAt: txnNode.End,
-		},
-		TxnMVCCNode: txnNode,
-		BaseNode:    prev.BaseNode.CloneAll(),
-	}
-	db.Insert(un)
-}
-func (catalog *Catalog) onReplayUpdateTable(cmd *EntryCommand[*TableMVCCNode, *TableNode], dataFactory DataFactory, observer wal.ReplayObserver) {
-	catalog.OnReplayTableID(cmd.ID.TableID)
-	// prepareTS := cmd.GetTs()
-	// if prepareTS.LessEq(catalog.GetCheckpointed().MaxTS) {
-	// 	if observer != nil {
-	// 		observer.OnStaleIndex(idx)
-	// 	}
-	// 	return
-	// }
-	db, err := catalog.GetDatabaseByID(cmd.ID.DbID)
-	if err != nil {
-		panic(err)
-	}
-	tbl, err := db.GetTableEntryByID(cmd.ID.TableID)
-
-	un := cmd.mvccNode
-	if un.Is1PC() {
-		if err := un.ApplyCommit(); err != nil {
-			panic(err)
-		}
-	}
-
-	if err != nil {
-		tbl = NewReplayTableEntry()
-		tbl.ID = cmd.ID.TableID
-		tbl.db = db
-		tbl.tableData = dataFactory.MakeTableFactory()(tbl)
-		tbl.TableNode = cmd.node
-		tbl.TableNode.schema.Store(un.BaseNode.Schema)
-		tbl.Insert(un)
-		err = db.AddEntryLocked(tbl, un.GetTxn(), true)
-		if err != nil {
-			logutil.Warn(catalog.SimplePPString(common.PPL3))
-			panic(err)
-		}
-		return
-	}
-	tblun := tbl.SearchNodeLocked(un)
-	if tblun == nil {
-		tbl.Insert(un) //TODO isvalid
-		if tbl.isColumnChangedInSchema() {
-			tbl.FreezeAppend()
-		}
-		schema := un.BaseNode.Schema
-		tbl.TableNode.schema.Store(schema)
-		// alter table rename
-		if schema.Extra.OldName != "" && un.DeletedAt.IsEmpty() {
-			err := tbl.db.RenameTableInTxn(schema.Extra.OldName, schema.Name, tbl.ID, schema.AcInfo.TenantID, un.GetTxn(), true)
-			if err != nil {
-				logutil.Warn(schema.String())
-				panic(err)
-			}
-		}
-	}
-
-}
-
-func (catalog *Catalog) OnReplayTableBatch(ins, insTxn, insCol, del, delTxn *containers.Batch, dataFactory DataFactory) {
-	schemaOffset := 0
-	for i := 0; i < ins.Length(); i++ {
-		tid := ins.GetVectorByName(pkgcatalog.SystemRelAttr_ID).Get(i).(uint64)
-		dbid := ins.GetVectorByName(pkgcatalog.SystemRelAttr_DBID).Get(i).(uint64)
-		name := string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_Name).Get(i).([]byte))
-		schema := NewEmptySchema(name)
-		schemaOffset = schema.ReadFromBatch(insCol, schemaOffset, tid)
-		schema.Comment = string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_Comment).Get(i).([]byte))
-		schema.Version = ins.GetVectorByName(pkgcatalog.SystemRelAttr_Version).Get(i).(uint32)
-		schema.CatalogVersion = ins.GetVectorByName(pkgcatalog.SystemRelAttr_CatalogVersion).Get(i).(uint32)
-		schema.Partitioned = ins.GetVectorByName(pkgcatalog.SystemRelAttr_Partitioned).Get(i).(int8)
-		schema.Partition = string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_Partition).Get(i).([]byte))
-		schema.Relkind = string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_Kind).Get(i).([]byte))
-		schema.Createsql = string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_CreateSQL).Get(i).([]byte))
-		schema.View = string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_ViewDef).Get(i).([]byte))
-		schema.Constraint = ins.GetVectorByName(pkgcatalog.SystemRelAttr_Constraint).Get(i).([]byte)
-		schema.AcInfo = accessInfo{}
-		schema.AcInfo.RoleID = ins.GetVectorByName(pkgcatalog.SystemRelAttr_Owner).Get(i).(uint32)
-		schema.AcInfo.UserID = ins.GetVectorByName(pkgcatalog.SystemRelAttr_Creator).Get(i).(uint32)
-		schema.AcInfo.CreateAt = ins.GetVectorByName(pkgcatalog.SystemRelAttr_CreateAt).Get(i).(types.Timestamp)
-		schema.AcInfo.TenantID = ins.GetVectorByName(pkgcatalog.SystemRelAttr_AccID).Get(i).(uint32)
-		schema.BlockMaxRows = insTxn.GetVectorByName(SnapshotAttr_BlockMaxRow).Get(i).(uint32)
-		schema.ObjectMaxBlocks = insTxn.GetVectorByName(SnapshotAttr_ObjectMaxBlock).Get(i).(uint16)
-		extra := insTxn.GetVectorByName(SnapshotAttr_SchemaExtra).Get(i).([]byte)
-		schema.MustRestoreExtra(extra)
-		schema.Finalize(true)
-		txnNode := txnbase.ReadTuple(insTxn, i)
-		catalog.onReplayCreateTable(dbid, tid, schema, txnNode, dataFactory)
-	}
-	for i := 0; i < del.Length(); i++ {
-		dbid := delTxn.GetVectorByName(SnapshotAttr_DBID).Get(i).(uint64)
-		tid := delTxn.GetVectorByName(SnapshotAttr_TID).Get(i).(uint64)
-		txnNode := txnbase.ReadTuple(delTxn, i)
-		catalog.onReplayDeleteTable(dbid, tid, txnNode)
-	}
-}
-
-func (catalog *Catalog) onReplayCreateTable(dbid, tid uint64, schema *Schema, txnNode *txnbase.TxnMVCCNode, dataFactory DataFactory) {
-	catalog.OnReplayTableID(tid)
-	db, err := catalog.GetDatabaseByID(dbid)
-	if err != nil {
-		logutil.Info(catalog.SimplePPString(common.PPL3))
-		panic(err)
-	}
-	tbl, _ := db.GetTableEntryByID(tid)
-	if tbl != nil {
-		tblCreatedAt := tbl.GetCreatedAtLocked()
-		if tblCreatedAt.Greater(&txnNode.End) {
-			panic(moerr.NewInternalErrorNoCtx("logic err expect %s, get %s", txnNode.End.ToString(), tblCreatedAt.ToString()))
-		}
-		// alter table
-		un := &MVCCNode[*TableMVCCNode]{
-			EntryMVCCNode: &EntryMVCCNode{
-				CreatedAt: tblCreatedAt,
-			},
-			TxnMVCCNode: txnNode,
-			BaseNode: &TableMVCCNode{
-				Schema: schema,
-			},
-		}
-		tbl.Insert(un)
-		if tbl.isColumnChangedInSchema() {
-			tbl.FreezeAppend()
-		}
-		tbl.TableNode.schema.Store(schema)
-		if schema.Extra.OldName != "" {
-			logutil.Infof("replay rename %v from %v -> %v", tid, schema.Extra.OldName, schema.Name)
-			err := tbl.db.RenameTableInTxn(schema.Extra.OldName, schema.Name, tbl.ID, schema.AcInfo.TenantID, un.GetTxn(), true)
-			if err != nil {
-				logutil.Warn(schema.String())
-				panic(err)
-			}
-		}
-
-		return
-	}
-	tbl = NewReplayTableEntry()
-	tbl.TableNode = &TableNode{}
-	tbl.TableNode.schema.Store(schema)
-	tbl.db = db
-	tbl.ID = tid
-	tbl.tableData = dataFactory.MakeTableFactory()(tbl)
-	_ = db.AddEntryLocked(tbl, nil, true)
-	un := &MVCCNode[*TableMVCCNode]{
-		EntryMVCCNode: &EntryMVCCNode{
-			CreatedAt: txnNode.End,
-		},
-		TxnMVCCNode: txnNode,
-		BaseNode: &TableMVCCNode{
-			Schema: schema,
-		},
-	}
-	tbl.Insert(un)
-}
-func (catalog *Catalog) onReplayDeleteTable(dbid, tid uint64, txnNode *txnbase.TxnMVCCNode) {
-	catalog.OnReplayTableID(tid)
-	db, err := catalog.GetDatabaseByID(dbid)
-	if err != nil {
-		logutil.Info(catalog.SimplePPString(common.PPL3))
-		panic(err)
-	}
-	tbl, err := db.GetTableEntryByID(tid)
-	if err != nil {
-		logutil.Info(catalog.SimplePPString(common.PPL3))
-		panic(err)
-	}
-	tableDeleteAt := tbl.GetDeleteAtLocked()
-	if !tableDeleteAt.IsEmpty() {
-		if !tableDeleteAt.Equal(&txnNode.End) {
-			panic(moerr.NewInternalErrorNoCtx("logic err expect %s, get %s", txnNode.End.ToString(), tableDeleteAt.ToString()))
-		}
-		return
-	}
-	prev := tbl.MVCCChain.GetLatestCommittedNodeLocked()
-	un := &MVCCNode[*TableMVCCNode]{
-		EntryMVCCNode: &EntryMVCCNode{
-			CreatedAt: prev.CreatedAt,
-			DeletedAt: txnNode.End,
-		},
-		TxnMVCCNode: txnNode,
-		BaseNode:    prev.BaseNode.CloneAll(),
-	}
-	tbl.Insert(un)
-
-}
-func (catalog *Catalog) onReplayUpdateObject(
-	cmd *EntryCommand[*ObjectMVCCNode, *ObjectNode],
-	dataFactory DataFactory,
-	observer wal.ReplayObserver) {
-	catalog.OnReplayObjectID(cmd.node.SortHint)
-
-	db, err := catalog.GetDatabaseByID(cmd.ID.DbID)
-	if err != nil {
-		panic(err)
-	}
-	tbl, err := db.GetTableEntryByID(cmd.ID.TableID)
-	if err != nil {
-		logutil.Debugf("tbl %d-%d", cmd.ID.DbID, cmd.ID.TableID)
-		logutil.Info(catalog.SimplePPString(3))
-		panic(err)
-	}
-	obj, err := tbl.GetObjectByID(cmd.ID.ObjectID())
-	un := cmd.mvccNode
-	if un.Is1PC() {
-		if err := un.ApplyCommit(); err != nil {
-			panic(err)
-		}
-	}
-	if err != nil {
-		obj = NewReplayObjectEntry()
-		obj.ID = *cmd.ID.ObjectID()
-		obj.table = tbl
-		obj.Insert(un)
-		obj.ObjectNode = cmd.node
-		tbl.AddEntryLocked(obj)
-	} else {
-		node := obj.SearchNodeLocked(un)
-		if node == nil {
-			obj.Insert(un)
-		} else {
-			node.BaseNode.Update(un.BaseNode)
-		}
-	}
-	if obj.objData == nil {
-		obj.objData = dataFactory.MakeObjectFactory()(obj)
-	} else {
-		deleteAt := obj.GetDeleteAtLocked()
-		if !obj.IsAppendable() || (obj.IsAppendable() && !deleteAt.IsEmpty()) {
-			obj.objData.TryUpgrade()
-			obj.objData.UpgradeAllDeleteChain()
-		}
-	}
-}
-
-func (catalog *Catalog) OnReplayObjectBatch(objectInfo *containers.Batch, dataFactory DataFactory) {
-	dbidVec := objectInfo.GetVectorByName(SnapshotAttr_DBID)
-	for i := 0; i < dbidVec.Length(); i++ {
-		dbid := objectInfo.GetVectorByName(SnapshotAttr_DBID).Get(i).(uint64)
-		tid := objectInfo.GetVectorByName(SnapshotAttr_TID).Get(i).(uint64)
-		objectNode := ReadObjectInfoTuple(objectInfo, i)
-		sid := objectNode.ObjectName().ObjectId()
-		txnNode := txnbase.ReadTuple(objectInfo, i)
-		entryNode := ReadEntryNodeTuple(objectInfo, i)
-		state := objectInfo.GetVectorByName(ObjectAttr_State).Get(i).(bool)
-		entryState := ES_Appendable
-		if !state {
-			entryState = ES_NotAppendable
-		}
-		catalog.onReplayCheckpointObject(dbid, tid, sid, objectNode, entryNode, txnNode, entryState, dataFactory)
-	}
-}
-
-func (catalog *Catalog) onReplayCheckpointObject(
-	dbid, tbid uint64,
-	objid *types.Objectid,
-	objNode *ObjectMVCCNode,
-	entryNode *EntryMVCCNode,
-	txnNode *txnbase.TxnMVCCNode,
-	state EntryState,
-	dataFactory DataFactory,
-) {
-	db, err := catalog.GetDatabaseByID(dbid)
-	if err != nil {
-		logutil.Info(catalog.SimplePPString(common.PPL3))
-		panic(err)
-	}
-	rel, err := db.GetTableEntryByID(tbid)
-	if err != nil {
-		logutil.Info(catalog.SimplePPString(common.PPL3))
-		panic(err)
-	}
-	obj, _ := rel.GetObjectByID(objid)
-	if obj == nil {
-		obj = NewReplayObjectEntry()
-		obj.ID = *objid
-		obj.table = rel
-		obj.ObjectNode = &ObjectNode{
-			state:    state,
-			sorted:   state == ES_NotAppendable,
-			SortHint: catalog.NextObject(),
-		}
-		rel.AddEntryLocked(obj)
-	}
-	un := &MVCCNode[*ObjectMVCCNode]{
-		EntryMVCCNode: entryNode,
-		BaseNode:      objNode,
-		TxnMVCCNode:   txnNode,
-	}
-	node := obj.SearchNodeLocked(un)
-	if node == nil {
-		obj.Insert(un)
-	} else {
-		node.BaseNode.Update(un.BaseNode)
-	}
-	if obj.objData == nil {
-		obj.objData = dataFactory.MakeObjectFactory()(obj)
-	} else {
-		deleteAt := obj.GetDeleteAtLocked()
-		if !obj.IsAppendable() || (obj.IsAppendable() && !deleteAt.IsEmpty()) {
-			obj.objData.TryUpgrade()
-			obj.objData.UpgradeAllDeleteChain()
-		}
-	}
-}
-
-// Before ckp version 10 and IOET_WALTxnCommand_Object, object info doesn't exist.
-// Replay Object by block.
-// Original Size, Compressed Size and Block Number is skipped.
-func (catalog *Catalog) replayObjectByBlock(
-	tbl *TableEntry,
-	blkID types.Blockid,
-	state EntryState,
-	start, end types.TS,
-	metaLocation objectio.Location,
-	needApplyCommit bool,
-	create, delete bool,
-	txn txnif.TxnReader,
-	dataFactory DataFactory) {
-	ObjectID := blkID.Object()
-	obj, _ := tbl.GetObjectByID(ObjectID)
-	// create
-	if create {
-		if obj == nil {
-			obj = NewObjectEntryByMetaLocation(
-				tbl,
-				ObjectID,
-				start, end, state, metaLocation, dataFactory.MakeObjectFactory())
-			tbl.AddEntryLocked(obj)
-		}
-	}
-	// delete
-	if delete {
-		node := obj.SearchNodeLocked(
-			&MVCCNode[*ObjectMVCCNode]{
-				TxnMVCCNode: &txnbase.TxnMVCCNode{
-					Start: start,
-				},
-			},
-		)
-		if node == nil {
-			node = obj.GetLatestNodeLocked().CloneData()
-			node.Start = start
-			node.Prepare = end
-			node.End = end
-			if node.BaseNode.IsEmpty() {
-				node.BaseNode = NewObjectInfoWithMetaLocation(metaLocation, ObjectID)
-			}
-			obj.Insert(node)
-			node.DeletedAt = end
-		}
-	}
-	_, blkOffset := blkID.Offsets()
-	obj.tryUpdateBlockCnt(int(blkOffset) + 1)
-	if obj.objData == nil {
-		obj.objData = dataFactory.MakeObjectFactory()(obj)
-	} else {
-		deleteAt := obj.GetDeleteAtLocked()
-		if !obj.IsAppendable() || (obj.IsAppendable() && !deleteAt.IsEmpty()) {
-			obj.objData.TryUpgrade()
-			obj.objData.UpgradeAllDeleteChain()
-		}
-	}
-}
-func (catalog *Catalog) onReplayUpdateBlock(
-	cmd *EntryCommand[*MetadataMVCCNode, *BlockNode],
-	dataFactory DataFactory,
-	observer wal.ReplayObserver) {
-	// catalog.OnReplayBlockID(cmd.ID.BlockID)
-	db, err := catalog.GetDatabaseByID(cmd.ID.DbID)
-	if err != nil {
-		panic(err)
-	}
-	tbl, err := db.GetTableEntryByID(cmd.ID.TableID)
-	if err != nil {
-		panic(err)
-	}
-	catalog.replayObjectByBlock(
-		tbl,
-		cmd.ID.BlockID,
-		cmd.node.state,
-		cmd.mvccNode.Start,
-		cmd.mvccNode.Prepare,
-		cmd.mvccNode.BaseNode.MetaLoc,
-		true,
-		cmd.mvccNode.CreatedAt.Equal(&txnif.UncommitTS),
-		cmd.mvccNode.DeletedAt.Equal(&txnif.UncommitTS),
-		cmd.mvccNode.Txn,
-		dataFactory)
-	if !cmd.mvccNode.BaseNode.DeltaLoc.IsEmpty() {
-		obj, err := tbl.GetObjectByID(cmd.ID.ObjectID())
-		if err != nil {
-			panic(err)
-		}
-		tombstone := tbl.GetOrCreateTombstone(obj, dataFactory.MakeTombstoneFactory())
-		_, blkOffset := cmd.ID.BlockID.Offsets()
-		tombstone.ReplayDeltaLoc(cmd.mvccNode, blkOffset)
-	}
-}
-
-func (catalog *Catalog) OnReplayBlockBatch(ins, insTxn, del, delTxn *containers.Batch, dataFactory DataFactory) {
-	for i := 0; i < ins.Length(); i++ {
-		dbid := insTxn.GetVectorByName(SnapshotAttr_DBID).Get(i).(uint64)
-		tid := insTxn.GetVectorByName(SnapshotAttr_TID).Get(i).(uint64)
-		appendable := ins.GetVectorByName(pkgcatalog.BlockMeta_EntryState).Get(i).(bool)
-		state := ES_NotAppendable
-		if appendable {
-			state = ES_Appendable
-		}
-		blkID := ins.GetVectorByName(pkgcatalog.BlockMeta_ID).Get(i).(types.Blockid)
-		sid := blkID.Object()
-		metaLoc := ins.GetVectorByName(pkgcatalog.BlockMeta_MetaLoc).Get(i).([]byte)
-		deltaLoc := ins.GetVectorByName(pkgcatalog.BlockMeta_DeltaLoc).Get(i).([]byte)
-		txnNode := txnbase.ReadTuple(insTxn, i)
-		catalog.onReplayCreateBlock(dbid, tid, sid, &blkID, state, metaLoc, deltaLoc, txnNode, dataFactory)
-	}
-	for i := 0; i < del.Length(); i++ {
-		dbid := delTxn.GetVectorByName(SnapshotAttr_DBID).Get(i).(uint64)
-		tid := delTxn.GetVectorByName(SnapshotAttr_TID).Get(i).(uint64)
-		rid := del.GetVectorByName(AttrRowID).Get(i).(types.Rowid)
-		blkID := rid.BorrowBlockID()
-		sid := rid.BorrowObjectID()
-		un := txnbase.ReadTuple(delTxn, i)
-		metaLoc := delTxn.GetVectorByName(pkgcatalog.BlockMeta_MetaLoc).Get(i).([]byte)
-		deltaLoc := delTxn.GetVectorByName(pkgcatalog.BlockMeta_DeltaLoc).Get(i).([]byte)
-		catalog.onReplayDeleteBlock(dbid, tid, sid, blkID, metaLoc, deltaLoc, un)
-	}
-}
-func (catalog *Catalog) onReplayCreateBlock(
-	dbid, tid uint64,
-	objid *types.Objectid,
-	blkid *types.Blockid,
-	state EntryState,
-	metaloc, deltaloc objectio.Location,
-	txnNode *txnbase.TxnMVCCNode,
-	dataFactory DataFactory) {
-	// catalog.OnReplayBlockID(blkid)
-	db, err := catalog.GetDatabaseByID(dbid)
-	if err != nil {
-		logutil.Info(catalog.SimplePPString(common.PPL3))
-		panic(err)
-	}
-	rel, err := db.GetTableEntryByID(tid)
-	if err != nil {
-		logutil.Info(catalog.SimplePPString(common.PPL3))
-		panic(err)
-	}
-	catalog.replayObjectByBlock(
-		rel,
-		*blkid,
-		state,
-		txnNode.Start,
-		txnNode.End,
-		metaloc,
-		false,
-		true,
-		false,
-		nil,
-		dataFactory)
-	if !deltaloc.IsEmpty() {
-		obj, err := rel.GetObjectByID(objid)
-		if err != nil {
-			panic(err)
-		}
-		tombstone := rel.GetOrCreateTombstone(obj, dataFactory.MakeTombstoneFactory())
-		_, blkOffset := blkid.Offsets()
-		mvccNode := &MVCCNode[*MetadataMVCCNode]{
-			EntryMVCCNode: &EntryMVCCNode{},
-			TxnMVCCNode:   txnNode,
-			BaseNode: &MetadataMVCCNode{
-				DeltaLoc: deltaloc,
-			},
-		}
-		tombstone.ReplayDeltaLoc(mvccNode, blkOffset)
-	}
-}
-
-func (catalog *Catalog) onReplayDeleteBlock(
-	dbid, tid uint64,
-	objid *types.Objectid,
-	blkid *types.Blockid,
-	metaloc,
-	deltaloc objectio.Location,
-	txnNode *txnbase.TxnMVCCNode,
-) {
-	// catalog.OnReplayBlockID(blkid)
-	db, err := catalog.GetDatabaseByID(dbid)
-	if err != nil {
-		logutil.Info(catalog.SimplePPString(common.PPL3))
-		panic(err)
-	}
-	rel, err := db.GetTableEntryByID(tid)
-	if err != nil {
-		logutil.Info(catalog.SimplePPString(common.PPL3))
-		panic(err)
-	}
-	catalog.replayObjectByBlock(
-		rel,
-		*blkid,
-		ES_Appendable, // state is not used when delete
-		txnNode.Start,
-		txnNode.End,
-		metaloc,
-		false,
-		false,
-		true,
-		nil,
-		nil)
-}
-func (catalog *Catalog) ReplayTableRows() {
-	rows := uint64(0)
-	tableProcessor := new(LoopProcessor)
-	tableProcessor.ObjectFn = func(be *ObjectEntry) error {
-		if !be.IsActive() {
-			return nil
-		}
-		rows += be.GetObjectData().GetRowsOnReplay()
-		return nil
-	}
-	tableProcessor.TombstoneFn = func(t data.Tombstone) error {
-		rows -= uint64(t.GetDeleteCnt())
-		return nil
-	}
-	processor := new(LoopProcessor)
-	processor.TableFn = func(tbl *TableEntry) error {
-		if tbl.db.name == pkgcatalog.MO_CATALOG {
-			return nil
-		}
-		rows = 0
-		err := tbl.RecurLoop(tableProcessor)
-		if err != nil {
-			panic(err)
-		}
-		tbl.rows.Store(rows)
-		return nil
-	}
-	err := catalog.RecurLoop(processor)
-	if err != nil {
-		panic(err)
-	}
-}
 func (catalog *Catalog) Close() error {
 	return nil
-}
-
-func (catalog *Catalog) CoarseDBCnt() int {
-	catalog.RLock()
-	defer catalog.RUnlock()
-	return len(catalog.entries)
 }
 
 func (catalog *Catalog) GetItemNodeByIDLocked(id uint64) *common.GenericDLNode[*DBEntry] {
@@ -927,35 +225,35 @@ func (catalog *Catalog) AddEntryLocked(database *DBEntry, txn txnif.TxnReader, s
 	return nil
 }
 
-func (catalog *Catalog) MakeDBIt(reverse bool) *common.GenericSortedDListIt[*DBEntry] {
+func (catalog *Catalog) TxnGetDBEntryByName(name string, txn txnif.AsyncTxn) (*DBEntry, error) {
 	catalog.RLock()
 	defer catalog.RUnlock()
-	return common.NewGenericSortedDListIt(catalog.RWMutex, catalog.link, reverse)
-}
-
-func (catalog *Catalog) SimplePPString(level common.PPLevel) string {
-	return catalog.PPString(level, 0, "")
-}
-
-func (catalog *Catalog) PPString(level common.PPLevel, depth int, prefix string) string {
-	var w bytes.Buffer
-	cnt := 0
-	it := catalog.MakeDBIt(true)
-	for it.Valid() {
-		cnt++
-		entry := it.Get().GetPayload()
-		_ = w.WriteByte('\n')
-		_, _ = w.WriteString(entry.PPString(level, depth+1, ""))
-		it.Next()
+	fullName := genDBFullName(txn.GetTenantID(), name)
+	node := catalog.nameNodes[fullName]
+	if node == nil {
+		return nil, moerr.NewBadDBNoCtx(name)
 	}
-
-	var w2 bytes.Buffer
-	_, _ = w2.WriteString(fmt.Sprintf("CATALOG[CNT=%d]", cnt))
-	_, _ = w2.WriteString(w.String())
-	return w2.String()
+	n, err := node.TxnGetNodeLocked(txn, "")
+	if err != nil {
+		return nil, err
+	}
+	return n.GetPayload(), nil
 }
 
-func (catalog *Catalog) RemoveEntry(database *DBEntry) error {
+func (catalog *Catalog) TxnGetDBEntryByID(id uint64, txn txnif.AsyncTxn) (*DBEntry, error) {
+	dbEntry, err := catalog.GetDatabaseByID(id)
+	if err != nil {
+		return nil, err
+	}
+	visiable, dropped := dbEntry.GetVisibility(txn)
+	if !visiable || dropped {
+		return nil, moerr.GetOkExpectedEOB()
+	}
+	return dbEntry, nil
+}
+
+// RemoveDBEntry removes a database entry from the catalog physically, triggered by GC Task
+func (catalog *Catalog) RemoveDBEntry(database *DBEntry) error {
 	if database.IsSystemDB() {
 		logutil.Warnf("system db cannot be removed")
 		return moerr.NewTAEErrorNoCtx("not permitted")
@@ -978,97 +276,40 @@ func (catalog *Catalog) RemoveEntry(database *DBEntry) error {
 	return nil
 }
 
-func (catalog *Catalog) txnGetNodeByName(
-	tenantID uint32,
-	name string,
-	txn txnif.TxnReader) (*common.GenericDLNode[*DBEntry], error) {
-	catalog.RLock()
-	defer catalog.RUnlock()
-	fullName := genDBFullName(tenantID, name)
-	node := catalog.nameNodes[fullName]
-	if node == nil {
-		return nil, moerr.NewBadDBNoCtx(name)
-	}
-	return node.TxnGetNodeLocked(txn, "")
-}
-
-func (catalog *Catalog) GetDBEntryByName(
-	tenantID uint32,
-	name string,
-	txn txnif.TxnReader) (db *DBEntry, err error) {
-	n, err := catalog.txnGetNodeByName(tenantID, name, txn)
-	if err != nil {
-		return
-	}
-	db = n.GetPayload()
-	return
-}
-
-func (catalog *Catalog) TxnGetDBEntryByName(name string, txn txnif.AsyncTxn) (*DBEntry, error) {
-	n, err := catalog.txnGetNodeByName(txn.GetTenantID(), name, txn)
-	if err != nil {
-		return nil, err
-	}
-	return n.GetPayload(), nil
-}
-
-func (catalog *Catalog) TxnGetDBEntryByID(id uint64, txn txnif.AsyncTxn) (*DBEntry, error) {
-	dbEntry, err := catalog.GetDatabaseByID(id)
-	if err != nil {
-		return nil, err
-	}
-	visiable, dropped := dbEntry.GetVisibility(txn)
-	if !visiable || dropped {
-		return nil, moerr.GetOkExpectedEOB()
-	}
-	return dbEntry, nil
-}
-
-func (catalog *Catalog) DropDBEntry(
-	name string,
-	txn txnif.AsyncTxn) (newEntry bool, deleted *DBEntry, err error) {
-	if name == pkgcatalog.MO_CATALOG {
-		err = moerr.NewTAEErrorNoCtx("not permitted")
-		return
-	}
-	tn, err := catalog.txnGetNodeByName(txn.GetTenantID(), name, txn)
-	if err != nil {
-		return
-	}
-	entry := tn.GetPayload()
-	entry.Lock()
-	defer entry.Unlock()
-	if newEntry, err = entry.DropEntryLocked(txn); err == nil {
-		deleted = entry
-	}
-	return
-}
-
-func (catalog *Catalog) DropDBEntryByID(id uint64, txn txnif.AsyncTxn) (newEntry bool, deleted *DBEntry, err error) {
-	if id == pkgcatalog.MO_CATALOG_ID {
-		err = moerr.NewTAEErrorNoCtx("not permitted")
-		return
-	}
-	entry, err := catalog.GetDatabaseByID(id)
-	if err != nil {
-		return
+// DropDBEntry attach a drop mvvc node the entry.
+func (catalog *Catalog) DropDBEntry(entry *DBEntry, txn txnif.AsyncTxn) (isNewMVCCNode bool, err error) {
+	if entry.IsSystemDB() {
+		return false, moerr.NewTAEErrorNoCtx("not permitted")
 	}
 	entry.Lock()
 	defer entry.Unlock()
-	if newEntry, err = entry.DropEntryLocked(txn); err == nil {
-		deleted = entry
+	isNewMVCCNode, err = entry.DropEntryLocked(txn)
+	return
+}
+
+func (catalog *Catalog) DropDBEntryByName(
+	name string,
+	txn txnif.AsyncTxn) (isNewMVCCNode bool, deleted *DBEntry, err error) {
+	deleted, err = catalog.TxnGetDBEntryByName(name, txn)
+	if err != nil {
+		return
 	}
+	isNewMVCCNode, err = catalog.DropDBEntry(deleted, txn)
+	return
+}
+
+func (catalog *Catalog) DropDBEntryByID(id uint64, txn txnif.AsyncTxn) (isNewMVCCNode bool, deleted *DBEntry, err error) {
+	deleted, err = catalog.TxnGetDBEntryByID(id, txn)
+	if err != nil {
+		return
+	}
+	isNewMVCCNode, err = catalog.DropDBEntry(deleted, txn)
 	return
 }
 
 func (catalog *Catalog) CreateDBEntry(name, createSql, datTyp string, txn txnif.AsyncTxn) (*DBEntry, error) {
-	var err error
-	catalog.Lock()
-	defer catalog.Unlock()
-	entry := NewDBEntry(catalog, name, createSql, datTyp, txn)
-	err = catalog.AddEntryLocked(entry, txn, false)
-
-	return entry, err
+	id := catalog.NextDB()
+	return catalog.CreateDBEntryWithID(name, createSql, datTyp, id, txn)
 }
 
 func (catalog *Catalog) CreateDBEntryWithID(name, createSql, datTyp string, id uint64, txn txnif.AsyncTxn) (*DBEntry, error) {
@@ -1084,22 +325,44 @@ func (catalog *Catalog) CreateDBEntryWithID(name, createSql, datTyp string, id u
 	return entry, err
 }
 
-func (catalog *Catalog) CreateDBEntryByTS(name string, ts types.TS) (*DBEntry, error) {
-	entry := NewDBEntryByTS(catalog, name, ts)
-	err := catalog.AddEntryLocked(entry, nil, false)
-	return entry, err
+//#endregion
+
+//#region - Utils for Catalog
+
+func (catalog *Catalog) MakeDBIt(reverse bool) *common.GenericSortedDListIt[*DBEntry] {
+	catalog.RLock()
+	defer catalog.RUnlock()
+	return common.NewGenericSortedDListIt(catalog.RWMutex, catalog.link, reverse)
+}
+
+func (catalog *Catalog) SimplePPString(level common.PPLevel) string {
+	return catalog.PPString(level, 0, "")
+}
+
+func (catalog *Catalog) PPString(level common.PPLevel, depth int, prefix string) string {
+	var w bytes.Buffer
+	cnt := 0
+	it := catalog.MakeDBIt(true)
+	for ; it.Valid(); it.Next() {
+		cnt++
+		entry := it.Get().GetPayload()
+		_ = w.WriteByte('\n')
+		_, _ = w.WriteString(entry.PPString(level, depth+1, ""))
+	}
+
+	var w2 bytes.Buffer
+	_, _ = w2.WriteString(fmt.Sprintf("CATALOG[CNT=%d]", cnt))
+	_, _ = w2.WriteString(w.String())
+	return w2.String()
 }
 
 func (catalog *Catalog) RecurLoop(processor Processor) (err error) {
 	dbIt := catalog.MakeDBIt(true)
-	for dbIt.Valid() {
+	for ; dbIt.Valid(); dbIt.Next() {
 		dbEntry := dbIt.Get().GetPayload()
 		if err = processor.OnDatabase(dbEntry); err != nil {
-			// XXX: Performance problem.   Error should not be used
-			// to handle normal return code.
 			if moerr.IsMoErrCode(err, moerr.OkStopCurrRecur) {
 				err = nil
-				dbIt.Next()
 				continue
 			}
 			break
@@ -1110,10 +373,11 @@ func (catalog *Catalog) RecurLoop(processor Processor) (err error) {
 		if err = processor.OnPostDatabase(dbEntry); err != nil {
 			break
 		}
-		dbIt.Next()
 	}
 	if moerr.IsMoErrCode(err, moerr.OkStopCurrRecur) {
 		err = nil
 	}
 	return err
 }
+
+//#endregion

--- a/pkg/vm/engine/tae/catalog/catalogreplay.go
+++ b/pkg/vm/engine/tae/catalog/catalogreplay.go
@@ -1,0 +1,717 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package catalog
+
+import (
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/data"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/wal"
+
+	"go.uber.org/zap"
+)
+
+//#region Replay related
+
+func (catalog *Catalog) ReplayCmd(
+	txncmd txnif.TxnCmd,
+	dataFactory DataFactory,
+	observer wal.ReplayObserver) {
+	switch txncmd.GetType() {
+	case txnbase.IOET_WALTxnCommand_Composed:
+		cmds := txncmd.(*txnbase.ComposedCmd)
+		for _, cmds := range cmds.Cmds {
+			catalog.ReplayCmd(cmds, dataFactory, observer)
+		}
+	case IOET_WALTxnCommand_Database:
+		cmd := txncmd.(*EntryCommand[*EmptyMVCCNode, *DBNode])
+		catalog.onReplayUpdateDatabase(cmd, observer)
+	case IOET_WALTxnCommand_Table:
+		cmd := txncmd.(*EntryCommand[*TableMVCCNode, *TableNode])
+		catalog.onReplayUpdateTable(cmd, dataFactory, observer)
+	case IOET_WALTxnCommand_Object:
+		cmd := txncmd.(*EntryCommand[*ObjectMVCCNode, *ObjectNode])
+		catalog.onReplayUpdateObject(cmd, dataFactory, observer)
+	case IOET_WALTxnCommand_Block:
+		cmd := txncmd.(*EntryCommand[*MetadataMVCCNode, *BlockNode])
+		catalog.onReplayUpdateBlock(cmd, dataFactory, observer)
+	case IOET_WALTxnCommand_Segment:
+		// segment is deprecated
+		return
+	default:
+		panic("unsupport")
+	}
+}
+
+func (catalog *Catalog) onReplayUpdateDatabase(cmd *EntryCommand[*EmptyMVCCNode, *DBNode], observer wal.ReplayObserver) {
+	catalog.OnReplayDBID(cmd.ID.DbID)
+	var err error
+	un := cmd.mvccNode
+	if un.Is1PC() {
+		if err := un.ApplyCommit(); err != nil {
+			panic(err)
+		}
+	}
+
+	db, err := catalog.GetDatabaseByID(cmd.ID.DbID)
+	if err != nil {
+		db = NewReplayDBEntry()
+		db.ID = cmd.ID.DbID
+		db.catalog = catalog
+		db.DBNode = cmd.node
+		db.Insert(un)
+		err = catalog.AddEntryLocked(db, un.GetTxn(), false)
+		if err != nil {
+			panic(err)
+		}
+		return
+	}
+
+	dbun := db.SearchNodeLocked(un)
+	if dbun == nil {
+		db.Insert(un)
+	} else {
+		return
+		// panic(fmt.Sprintf("logic err: duplicate node %v and %v", dbun.String(), un.String()))
+	}
+}
+
+func (catalog *Catalog) OnReplayDatabaseBatch(ins, insTxn, del, delTxn *containers.Batch) {
+	for i := 0; i < ins.Length(); i++ {
+		dbid := ins.GetVectorByName(pkgcatalog.SystemDBAttr_ID).Get(i).(uint64)
+		name := string(ins.GetVectorByName(pkgcatalog.SystemDBAttr_Name).Get(i).([]byte))
+		txnNode := txnbase.ReadTuple(insTxn, i)
+		tenantID := ins.GetVectorByName(pkgcatalog.SystemDBAttr_AccID).Get(i).(uint32)
+		userID := ins.GetVectorByName(pkgcatalog.SystemDBAttr_Creator).Get(i).(uint32)
+		roleID := ins.GetVectorByName(pkgcatalog.SystemDBAttr_Owner).Get(i).(uint32)
+		createAt := ins.GetVectorByName(pkgcatalog.SystemDBAttr_CreateAt).Get(i).(types.Timestamp)
+		createSql := string(ins.GetVectorByName(pkgcatalog.SystemDBAttr_CreateSQL).Get(i).([]byte))
+		datType := string(ins.GetVectorByName(pkgcatalog.SystemDBAttr_Type).Get(i).([]byte))
+		catalog.onReplayCreateDB(dbid, name, txnNode, tenantID, userID, roleID, createAt, createSql, datType)
+	}
+	for i := 0; i < del.Length(); i++ {
+		dbid := delTxn.GetVectorByName(SnapshotAttr_DBID).Get(i).(uint64)
+		txnNode := txnbase.ReadTuple(delTxn, i)
+		catalog.onReplayDeleteDB(dbid, txnNode)
+	}
+}
+
+func (catalog *Catalog) onReplayCreateDB(
+	dbid uint64, name string, txnNode *txnbase.TxnMVCCNode,
+	tenantID, userID, roleID uint32, createAt types.Timestamp, createSql, datType string) {
+	catalog.OnReplayDBID(dbid)
+	db, _ := catalog.GetDatabaseByID(dbid)
+	if db != nil {
+		dbCreatedAt := db.GetCreatedAtLocked()
+		if !dbCreatedAt.Equal(&txnNode.End) {
+			panic(moerr.NewInternalErrorNoCtx("logic err expect %s, get %s",
+				txnNode.End.ToString(), dbCreatedAt.ToString()))
+		}
+		return
+	}
+	db = NewReplayDBEntry()
+	db.catalog = catalog
+	db.ID = dbid
+	db.DBNode = &DBNode{
+		acInfo: accessInfo{
+			TenantID: tenantID,
+			UserID:   userID,
+			RoleID:   roleID,
+			CreateAt: createAt,
+		},
+		createSql: createSql,
+		datType:   datType,
+		name:      name,
+	}
+	_ = catalog.AddEntryLocked(db, nil, true)
+	un := &MVCCNode[*EmptyMVCCNode]{
+		EntryMVCCNode: &EntryMVCCNode{
+			CreatedAt: txnNode.End,
+		},
+		TxnMVCCNode: txnNode,
+	}
+	db.Insert(un)
+}
+func (catalog *Catalog) onReplayDeleteDB(dbid uint64, txnNode *txnbase.TxnMVCCNode) {
+	catalog.OnReplayDBID(dbid)
+	db, err := catalog.GetDatabaseByID(dbid)
+	if err != nil {
+		logutil.Info("delete %d", zap.Uint64("dbid", dbid), zap.String("catalog pp", catalog.SimplePPString(common.PPL3)))
+		panic(err)
+	}
+	dbDeleteAt := db.GetDeleteAtLocked()
+	if !dbDeleteAt.IsEmpty() {
+		if !dbDeleteAt.Equal(&txnNode.End) {
+			panic(moerr.NewInternalErrorNoCtx("logic err expect %s, get %s", txnNode.End.ToString(), dbDeleteAt.ToString()))
+		}
+		return
+	}
+	prev := db.MVCCChain.GetLatestNodeLocked()
+	un := &MVCCNode[*EmptyMVCCNode]{
+		EntryMVCCNode: &EntryMVCCNode{
+			CreatedAt: db.GetCreatedAtLocked(),
+			DeletedAt: txnNode.End,
+		},
+		TxnMVCCNode: txnNode,
+		BaseNode:    prev.BaseNode.CloneAll(),
+	}
+	db.Insert(un)
+}
+func (catalog *Catalog) onReplayUpdateTable(cmd *EntryCommand[*TableMVCCNode, *TableNode], dataFactory DataFactory, observer wal.ReplayObserver) {
+	catalog.OnReplayTableID(cmd.ID.TableID)
+	// prepareTS := cmd.GetTs()
+	// if prepareTS.LessEq(catalog.GetCheckpointed().MaxTS) {
+	// 	if observer != nil {
+	// 		observer.OnStaleIndex(idx)
+	// 	}
+	// 	return
+	// }
+	db, err := catalog.GetDatabaseByID(cmd.ID.DbID)
+	if err != nil {
+		panic(err)
+	}
+	tbl, err := db.GetTableEntryByID(cmd.ID.TableID)
+
+	un := cmd.mvccNode
+	if un.Is1PC() {
+		if err := un.ApplyCommit(); err != nil {
+			panic(err)
+		}
+	}
+
+	if err != nil {
+		tbl = NewReplayTableEntry()
+		tbl.ID = cmd.ID.TableID
+		tbl.db = db
+		tbl.tableData = dataFactory.MakeTableFactory()(tbl)
+		tbl.TableNode = cmd.node
+		tbl.TableNode.schema.Store(un.BaseNode.Schema)
+		tbl.Insert(un)
+		err = db.AddEntryLocked(tbl, un.GetTxn(), true)
+		if err != nil {
+			logutil.Warn(catalog.SimplePPString(common.PPL3))
+			panic(err)
+		}
+		return
+	}
+	tblun := tbl.SearchNodeLocked(un)
+	if tblun == nil {
+		tbl.Insert(un) //TODO isvalid
+		if tbl.isColumnChangedInSchema() {
+			tbl.FreezeAppend()
+		}
+		schema := un.BaseNode.Schema
+		tbl.TableNode.schema.Store(schema)
+		// alter table rename
+		if schema.Extra.OldName != "" && un.DeletedAt.IsEmpty() {
+			err := tbl.db.RenameTableInTxn(schema.Extra.OldName, schema.Name, tbl.ID, schema.AcInfo.TenantID, un.GetTxn(), true)
+			if err != nil {
+				logutil.Warn(schema.String())
+				panic(err)
+			}
+		}
+	}
+
+}
+
+func (catalog *Catalog) OnReplayTableBatch(ins, insTxn, insCol, del, delTxn *containers.Batch, dataFactory DataFactory) {
+	schemaOffset := 0
+	for i := 0; i < ins.Length(); i++ {
+		tid := ins.GetVectorByName(pkgcatalog.SystemRelAttr_ID).Get(i).(uint64)
+		dbid := ins.GetVectorByName(pkgcatalog.SystemRelAttr_DBID).Get(i).(uint64)
+		name := string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_Name).Get(i).([]byte))
+		schema := NewEmptySchema(name)
+		schemaOffset = schema.ReadFromBatch(insCol, schemaOffset, tid)
+		schema.Comment = string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_Comment).Get(i).([]byte))
+		schema.Version = ins.GetVectorByName(pkgcatalog.SystemRelAttr_Version).Get(i).(uint32)
+		schema.CatalogVersion = ins.GetVectorByName(pkgcatalog.SystemRelAttr_CatalogVersion).Get(i).(uint32)
+		schema.Partitioned = ins.GetVectorByName(pkgcatalog.SystemRelAttr_Partitioned).Get(i).(int8)
+		schema.Partition = string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_Partition).Get(i).([]byte))
+		schema.Relkind = string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_Kind).Get(i).([]byte))
+		schema.Createsql = string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_CreateSQL).Get(i).([]byte))
+		schema.View = string(ins.GetVectorByName(pkgcatalog.SystemRelAttr_ViewDef).Get(i).([]byte))
+		schema.Constraint = ins.GetVectorByName(pkgcatalog.SystemRelAttr_Constraint).Get(i).([]byte)
+		schema.AcInfo = accessInfo{}
+		schema.AcInfo.RoleID = ins.GetVectorByName(pkgcatalog.SystemRelAttr_Owner).Get(i).(uint32)
+		schema.AcInfo.UserID = ins.GetVectorByName(pkgcatalog.SystemRelAttr_Creator).Get(i).(uint32)
+		schema.AcInfo.CreateAt = ins.GetVectorByName(pkgcatalog.SystemRelAttr_CreateAt).Get(i).(types.Timestamp)
+		schema.AcInfo.TenantID = ins.GetVectorByName(pkgcatalog.SystemRelAttr_AccID).Get(i).(uint32)
+		schema.BlockMaxRows = insTxn.GetVectorByName(SnapshotAttr_BlockMaxRow).Get(i).(uint32)
+		schema.ObjectMaxBlocks = insTxn.GetVectorByName(SnapshotAttr_ObjectMaxBlock).Get(i).(uint16)
+		extra := insTxn.GetVectorByName(SnapshotAttr_SchemaExtra).Get(i).([]byte)
+		schema.MustRestoreExtra(extra)
+		schema.Finalize(true)
+		txnNode := txnbase.ReadTuple(insTxn, i)
+		catalog.onReplayCreateTable(dbid, tid, schema, txnNode, dataFactory)
+	}
+	for i := 0; i < del.Length(); i++ {
+		dbid := delTxn.GetVectorByName(SnapshotAttr_DBID).Get(i).(uint64)
+		tid := delTxn.GetVectorByName(SnapshotAttr_TID).Get(i).(uint64)
+		txnNode := txnbase.ReadTuple(delTxn, i)
+		catalog.onReplayDeleteTable(dbid, tid, txnNode)
+	}
+}
+
+func (catalog *Catalog) onReplayCreateTable(dbid, tid uint64, schema *Schema, txnNode *txnbase.TxnMVCCNode, dataFactory DataFactory) {
+	catalog.OnReplayTableID(tid)
+	db, err := catalog.GetDatabaseByID(dbid)
+	if err != nil {
+		logutil.Info(catalog.SimplePPString(common.PPL3))
+		panic(err)
+	}
+	tbl, _ := db.GetTableEntryByID(tid)
+	if tbl != nil {
+		tblCreatedAt := tbl.GetCreatedAtLocked()
+		if tblCreatedAt.Greater(&txnNode.End) {
+			panic(moerr.NewInternalErrorNoCtx("logic err expect %s, get %s", txnNode.End.ToString(), tblCreatedAt.ToString()))
+		}
+		// alter table
+		un := &MVCCNode[*TableMVCCNode]{
+			EntryMVCCNode: &EntryMVCCNode{
+				CreatedAt: tblCreatedAt,
+			},
+			TxnMVCCNode: txnNode,
+			BaseNode: &TableMVCCNode{
+				Schema: schema,
+			},
+		}
+		tbl.Insert(un)
+		if tbl.isColumnChangedInSchema() {
+			tbl.FreezeAppend()
+		}
+		tbl.TableNode.schema.Store(schema)
+		if schema.Extra.OldName != "" {
+			logutil.Infof("replay rename %v from %v -> %v", tid, schema.Extra.OldName, schema.Name)
+			err := tbl.db.RenameTableInTxn(schema.Extra.OldName, schema.Name, tbl.ID, schema.AcInfo.TenantID, un.GetTxn(), true)
+			if err != nil {
+				logutil.Warn(schema.String())
+				panic(err)
+			}
+		}
+
+		return
+	}
+	tbl = NewReplayTableEntry()
+	tbl.TableNode = &TableNode{}
+	tbl.TableNode.schema.Store(schema)
+	tbl.db = db
+	tbl.ID = tid
+	tbl.tableData = dataFactory.MakeTableFactory()(tbl)
+	_ = db.AddEntryLocked(tbl, nil, true)
+	un := &MVCCNode[*TableMVCCNode]{
+		EntryMVCCNode: &EntryMVCCNode{
+			CreatedAt: txnNode.End,
+		},
+		TxnMVCCNode: txnNode,
+		BaseNode: &TableMVCCNode{
+			Schema: schema,
+		},
+	}
+	tbl.Insert(un)
+}
+func (catalog *Catalog) onReplayDeleteTable(dbid, tid uint64, txnNode *txnbase.TxnMVCCNode) {
+	catalog.OnReplayTableID(tid)
+	db, err := catalog.GetDatabaseByID(dbid)
+	if err != nil {
+		logutil.Info(catalog.SimplePPString(common.PPL3))
+		panic(err)
+	}
+	tbl, err := db.GetTableEntryByID(tid)
+	if err != nil {
+		logutil.Info(catalog.SimplePPString(common.PPL3))
+		panic(err)
+	}
+	tableDeleteAt := tbl.GetDeleteAtLocked()
+	if !tableDeleteAt.IsEmpty() {
+		if !tableDeleteAt.Equal(&txnNode.End) {
+			panic(moerr.NewInternalErrorNoCtx("logic err expect %s, get %s", txnNode.End.ToString(), tableDeleteAt.ToString()))
+		}
+		return
+	}
+	prev := tbl.MVCCChain.GetLatestCommittedNodeLocked()
+	un := &MVCCNode[*TableMVCCNode]{
+		EntryMVCCNode: &EntryMVCCNode{
+			CreatedAt: prev.CreatedAt,
+			DeletedAt: txnNode.End,
+		},
+		TxnMVCCNode: txnNode,
+		BaseNode:    prev.BaseNode.CloneAll(),
+	}
+	tbl.Insert(un)
+
+}
+func (catalog *Catalog) onReplayUpdateObject(
+	cmd *EntryCommand[*ObjectMVCCNode, *ObjectNode],
+	dataFactory DataFactory,
+	observer wal.ReplayObserver) {
+	catalog.OnReplayObjectID(cmd.node.SortHint)
+
+	db, err := catalog.GetDatabaseByID(cmd.ID.DbID)
+	if err != nil {
+		panic(err)
+	}
+	tbl, err := db.GetTableEntryByID(cmd.ID.TableID)
+	if err != nil {
+		logutil.Debugf("tbl %d-%d", cmd.ID.DbID, cmd.ID.TableID)
+		logutil.Info(catalog.SimplePPString(3))
+		panic(err)
+	}
+	obj, err := tbl.GetObjectByID(cmd.ID.ObjectID())
+	un := cmd.mvccNode
+	if un.Is1PC() {
+		if err := un.ApplyCommit(); err != nil {
+			panic(err)
+		}
+	}
+	if err != nil {
+		obj = NewReplayObjectEntry()
+		obj.ID = *cmd.ID.ObjectID()
+		obj.table = tbl
+		obj.Insert(un)
+		obj.ObjectNode = cmd.node
+		tbl.AddEntryLocked(obj)
+	} else {
+		node := obj.SearchNodeLocked(un)
+		if node == nil {
+			obj.Insert(un)
+		} else {
+			node.BaseNode.Update(un.BaseNode)
+		}
+	}
+	if obj.objData == nil {
+		obj.objData = dataFactory.MakeObjectFactory()(obj)
+	} else {
+		deleteAt := obj.GetDeleteAtLocked()
+		if !obj.IsAppendable() || (obj.IsAppendable() && !deleteAt.IsEmpty()) {
+			obj.objData.TryUpgrade()
+			obj.objData.UpgradeAllDeleteChain()
+		}
+	}
+}
+
+func (catalog *Catalog) OnReplayObjectBatch(objectInfo *containers.Batch, dataFactory DataFactory) {
+	dbidVec := objectInfo.GetVectorByName(SnapshotAttr_DBID)
+	for i := 0; i < dbidVec.Length(); i++ {
+		dbid := objectInfo.GetVectorByName(SnapshotAttr_DBID).Get(i).(uint64)
+		tid := objectInfo.GetVectorByName(SnapshotAttr_TID).Get(i).(uint64)
+		objectNode := ReadObjectInfoTuple(objectInfo, i)
+		sid := objectNode.ObjectName().ObjectId()
+		txnNode := txnbase.ReadTuple(objectInfo, i)
+		entryNode := ReadEntryNodeTuple(objectInfo, i)
+		state := objectInfo.GetVectorByName(ObjectAttr_State).Get(i).(bool)
+		entryState := ES_Appendable
+		if !state {
+			entryState = ES_NotAppendable
+		}
+		catalog.onReplayCheckpointObject(dbid, tid, sid, objectNode, entryNode, txnNode, entryState, dataFactory)
+	}
+}
+
+func (catalog *Catalog) onReplayCheckpointObject(
+	dbid, tbid uint64,
+	objid *types.Objectid,
+	objNode *ObjectMVCCNode,
+	entryNode *EntryMVCCNode,
+	txnNode *txnbase.TxnMVCCNode,
+	state EntryState,
+	dataFactory DataFactory,
+) {
+	db, err := catalog.GetDatabaseByID(dbid)
+	if err != nil {
+		logutil.Info(catalog.SimplePPString(common.PPL3))
+		panic(err)
+	}
+	rel, err := db.GetTableEntryByID(tbid)
+	if err != nil {
+		logutil.Info(catalog.SimplePPString(common.PPL3))
+		panic(err)
+	}
+	obj, _ := rel.GetObjectByID(objid)
+	if obj == nil {
+		obj = NewReplayObjectEntry()
+		obj.ID = *objid
+		obj.table = rel
+		obj.ObjectNode = &ObjectNode{
+			state:    state,
+			sorted:   state == ES_NotAppendable,
+			SortHint: catalog.NextObject(),
+		}
+		rel.AddEntryLocked(obj)
+	}
+	un := &MVCCNode[*ObjectMVCCNode]{
+		EntryMVCCNode: entryNode,
+		BaseNode:      objNode,
+		TxnMVCCNode:   txnNode,
+	}
+	node := obj.SearchNodeLocked(un)
+	if node == nil {
+		obj.Insert(un)
+	} else {
+		node.BaseNode.Update(un.BaseNode)
+	}
+	if obj.objData == nil {
+		obj.objData = dataFactory.MakeObjectFactory()(obj)
+	} else {
+		deleteAt := obj.GetDeleteAtLocked()
+		if !obj.IsAppendable() || (obj.IsAppendable() && !deleteAt.IsEmpty()) {
+			obj.objData.TryUpgrade()
+			obj.objData.UpgradeAllDeleteChain()
+		}
+	}
+}
+
+// Before ckp version 10 and IOET_WALTxnCommand_Object, object info doesn't exist.
+// Replay Object by block.
+// Original Size, Compressed Size and Block Number is skipped.
+func (catalog *Catalog) replayObjectByBlock(
+	tbl *TableEntry,
+	blkID types.Blockid,
+	state EntryState,
+	start, end types.TS,
+	metaLocation objectio.Location,
+	needApplyCommit bool,
+	create, delete bool,
+	txn txnif.TxnReader,
+	dataFactory DataFactory) {
+	ObjectID := blkID.Object()
+	obj, _ := tbl.GetObjectByID(ObjectID)
+	// create
+	if create {
+		if obj == nil {
+			obj = NewObjectEntryByMetaLocation(
+				tbl,
+				ObjectID,
+				start, end, state, metaLocation, dataFactory.MakeObjectFactory())
+			tbl.AddEntryLocked(obj)
+		}
+	}
+	// delete
+	if delete {
+		node := obj.SearchNodeLocked(
+			&MVCCNode[*ObjectMVCCNode]{
+				TxnMVCCNode: &txnbase.TxnMVCCNode{
+					Start: start,
+				},
+			},
+		)
+		if node == nil {
+			node = obj.GetLatestNodeLocked().CloneData()
+			node.Start = start
+			node.Prepare = end
+			node.End = end
+			if node.BaseNode.IsEmpty() {
+				node.BaseNode = NewObjectInfoWithMetaLocation(metaLocation, ObjectID)
+			}
+			obj.Insert(node)
+			node.DeletedAt = end
+		}
+	}
+	_, blkOffset := blkID.Offsets()
+	obj.tryUpdateBlockCnt(int(blkOffset) + 1)
+	if obj.objData == nil {
+		obj.objData = dataFactory.MakeObjectFactory()(obj)
+	} else {
+		deleteAt := obj.GetDeleteAtLocked()
+		if !obj.IsAppendable() || (obj.IsAppendable() && !deleteAt.IsEmpty()) {
+			obj.objData.TryUpgrade()
+			obj.objData.UpgradeAllDeleteChain()
+		}
+	}
+}
+func (catalog *Catalog) onReplayUpdateBlock(
+	cmd *EntryCommand[*MetadataMVCCNode, *BlockNode],
+	dataFactory DataFactory,
+	observer wal.ReplayObserver) {
+	// catalog.OnReplayBlockID(cmd.ID.BlockID)
+	db, err := catalog.GetDatabaseByID(cmd.ID.DbID)
+	if err != nil {
+		panic(err)
+	}
+	tbl, err := db.GetTableEntryByID(cmd.ID.TableID)
+	if err != nil {
+		panic(err)
+	}
+	catalog.replayObjectByBlock(
+		tbl,
+		cmd.ID.BlockID,
+		cmd.node.state,
+		cmd.mvccNode.Start,
+		cmd.mvccNode.Prepare,
+		cmd.mvccNode.BaseNode.MetaLoc,
+		true,
+		cmd.mvccNode.CreatedAt.Equal(&txnif.UncommitTS),
+		cmd.mvccNode.DeletedAt.Equal(&txnif.UncommitTS),
+		cmd.mvccNode.Txn,
+		dataFactory)
+	if !cmd.mvccNode.BaseNode.DeltaLoc.IsEmpty() {
+		obj, err := tbl.GetObjectByID(cmd.ID.ObjectID())
+		if err != nil {
+			panic(err)
+		}
+		tombstone := tbl.GetOrCreateTombstone(obj, dataFactory.MakeTombstoneFactory())
+		_, blkOffset := cmd.ID.BlockID.Offsets()
+		tombstone.ReplayDeltaLoc(cmd.mvccNode, blkOffset)
+	}
+}
+
+func (catalog *Catalog) OnReplayBlockBatch(ins, insTxn, del, delTxn *containers.Batch, dataFactory DataFactory) {
+	for i := 0; i < ins.Length(); i++ {
+		dbid := insTxn.GetVectorByName(SnapshotAttr_DBID).Get(i).(uint64)
+		tid := insTxn.GetVectorByName(SnapshotAttr_TID).Get(i).(uint64)
+		appendable := ins.GetVectorByName(pkgcatalog.BlockMeta_EntryState).Get(i).(bool)
+		state := ES_NotAppendable
+		if appendable {
+			state = ES_Appendable
+		}
+		blkID := ins.GetVectorByName(pkgcatalog.BlockMeta_ID).Get(i).(types.Blockid)
+		sid := blkID.Object()
+		metaLoc := ins.GetVectorByName(pkgcatalog.BlockMeta_MetaLoc).Get(i).([]byte)
+		deltaLoc := ins.GetVectorByName(pkgcatalog.BlockMeta_DeltaLoc).Get(i).([]byte)
+		txnNode := txnbase.ReadTuple(insTxn, i)
+		catalog.onReplayCreateBlock(dbid, tid, sid, &blkID, state, metaLoc, deltaLoc, txnNode, dataFactory)
+	}
+	for i := 0; i < del.Length(); i++ {
+		dbid := delTxn.GetVectorByName(SnapshotAttr_DBID).Get(i).(uint64)
+		tid := delTxn.GetVectorByName(SnapshotAttr_TID).Get(i).(uint64)
+		rid := del.GetVectorByName(AttrRowID).Get(i).(types.Rowid)
+		blkID := rid.BorrowBlockID()
+		sid := rid.BorrowObjectID()
+		un := txnbase.ReadTuple(delTxn, i)
+		metaLoc := delTxn.GetVectorByName(pkgcatalog.BlockMeta_MetaLoc).Get(i).([]byte)
+		deltaLoc := delTxn.GetVectorByName(pkgcatalog.BlockMeta_DeltaLoc).Get(i).([]byte)
+		catalog.onReplayDeleteBlock(dbid, tid, sid, blkID, metaLoc, deltaLoc, un)
+	}
+}
+func (catalog *Catalog) onReplayCreateBlock(
+	dbid, tid uint64,
+	objid *types.Objectid,
+	blkid *types.Blockid,
+	state EntryState,
+	metaloc, deltaloc objectio.Location,
+	txnNode *txnbase.TxnMVCCNode,
+	dataFactory DataFactory) {
+	// catalog.OnReplayBlockID(blkid)
+	db, err := catalog.GetDatabaseByID(dbid)
+	if err != nil {
+		logutil.Info(catalog.SimplePPString(common.PPL3))
+		panic(err)
+	}
+	rel, err := db.GetTableEntryByID(tid)
+	if err != nil {
+		logutil.Info(catalog.SimplePPString(common.PPL3))
+		panic(err)
+	}
+	catalog.replayObjectByBlock(
+		rel,
+		*blkid,
+		state,
+		txnNode.Start,
+		txnNode.End,
+		metaloc,
+		false,
+		true,
+		false,
+		nil,
+		dataFactory)
+	if !deltaloc.IsEmpty() {
+		obj, err := rel.GetObjectByID(objid)
+		if err != nil {
+			panic(err)
+		}
+		tombstone := rel.GetOrCreateTombstone(obj, dataFactory.MakeTombstoneFactory())
+		_, blkOffset := blkid.Offsets()
+		mvccNode := &MVCCNode[*MetadataMVCCNode]{
+			EntryMVCCNode: &EntryMVCCNode{},
+			TxnMVCCNode:   txnNode,
+			BaseNode: &MetadataMVCCNode{
+				DeltaLoc: deltaloc,
+			},
+		}
+		tombstone.ReplayDeltaLoc(mvccNode, blkOffset)
+	}
+}
+
+func (catalog *Catalog) onReplayDeleteBlock(
+	dbid, tid uint64,
+	objid *types.Objectid,
+	blkid *types.Blockid,
+	metaloc,
+	deltaloc objectio.Location,
+	txnNode *txnbase.TxnMVCCNode,
+) {
+	// catalog.OnReplayBlockID(blkid)
+	db, err := catalog.GetDatabaseByID(dbid)
+	if err != nil {
+		logutil.Info(catalog.SimplePPString(common.PPL3))
+		panic(err)
+	}
+	rel, err := db.GetTableEntryByID(tid)
+	if err != nil {
+		logutil.Info(catalog.SimplePPString(common.PPL3))
+		panic(err)
+	}
+	catalog.replayObjectByBlock(
+		rel,
+		*blkid,
+		ES_Appendable, // state is not used when delete
+		txnNode.Start,
+		txnNode.End,
+		metaloc,
+		false,
+		false,
+		true,
+		nil,
+		nil)
+}
+func (catalog *Catalog) ReplayTableRows() {
+	rows := uint64(0)
+	tableProcessor := new(LoopProcessor)
+	tableProcessor.ObjectFn = func(be *ObjectEntry) error {
+		if !be.IsActive() {
+			return nil
+		}
+		rows += be.GetObjectData().GetRowsOnReplay()
+		return nil
+	}
+	tableProcessor.TombstoneFn = func(t data.Tombstone) error {
+		rows -= uint64(t.GetDeleteCnt())
+		return nil
+	}
+	processor := new(LoopProcessor)
+	processor.TableFn = func(tbl *TableEntry) error {
+		if tbl.db.name == pkgcatalog.MO_CATALOG {
+			return nil
+		}
+		rows = 0
+		err := tbl.RecurLoop(tableProcessor)
+		if err != nil {
+			panic(err)
+		}
+		tbl.rows.Store(rows)
+		return nil
+	}
+	err := catalog.RecurLoop(processor)
+	if err != nil {
+		panic(err)
+	}
+}
+
+//#endregion

--- a/pkg/vm/engine/tae/catalog/mock.go
+++ b/pkg/vm/engine/tae/catalog/mock.go
@@ -260,7 +260,7 @@ func (txn *mockTxn) GetDatabaseByID(id uint64) (handle.Database, error) {
 }
 
 func (txn *mockTxn) DropDatabase(name string) (handle.Database, error) {
-	_, entry, err := txn.catalog.DropDBEntry(name, txn)
+	_, entry, err := txn.catalog.DropDBEntryByName(name, txn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vm/engine/tae/db/open.go
+++ b/pkg/vm/engine/tae/db/open.go
@@ -42,7 +42,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnimpl"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/wal"
-	"go.uber.org/zap"
 )
 
 const (
@@ -60,9 +59,6 @@ func fillRuntimeOptions(opts *options.Options) {
 	if opts.MergeCfg.CNStandaloneTake {
 		common.ShouldStandaloneCNTakeOver.Store(true)
 	}
-	w := &bytes.Buffer{}
-	toml.NewEncoder(w).Encode(opts.MergeCfg)
-	logutil.Info("mergeblocks options", zap.String("toml", w.String()), zap.Bool("standalone", opts.IsStandalone))
 }
 
 func Open(ctx context.Context, dirname string, opts *options.Options) (db *DB, err error) {
@@ -88,6 +84,10 @@ func Open(ctx context.Context, dirname string, opts *options.Options) (db *DB, e
 	opts = opts.FillDefaults(dirname)
 	fillRuntimeOptions(opts)
 
+	wbuf := &bytes.Buffer{}
+	werr := toml.NewEncoder(wbuf).Encode(opts)
+	logutil.Info("open-tae", common.OperationField("Config"),
+		common.AnyField("toml", wbuf.String()), common.ErrorField(werr))
 	serviceDir := path.Join(dirname, "data")
 	if opts.Fs == nil {
 		// TODO:fileservice needs to be passed in as a parameter

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -3416,25 +3416,6 @@ func TestDropCreated4(t *testing.T) {
 	tae.Restart(ctx)
 }
 
-// records create at 1 and commit
-// read by ts 1, err should be nil
-func TestReadEqualTS(t *testing.T) {
-	defer testutils.AfterTest(t)()
-	ctx := context.Background()
-
-	opts := config.WithLongScanAndCKPOpts(nil)
-	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
-	defer tae.Close()
-
-	txn, err := tae.StartTxn(nil)
-	tae.Catalog.Lock()
-	tae.Catalog.CreateDBEntryByTS("db", txn.GetStartTS())
-	tae.Catalog.Unlock()
-	assert.Nil(t, err)
-	_, err = txn.GetDatabase("db")
-	assert.Nil(t, err)
-}
-
 func TestTruncateZonemap(t *testing.T) {
 	defer testutils.AfterTest(t)()
 	ctx := context.Background()

--- a/pkg/vm/engine/tae/options/options.go
+++ b/pkg/vm/engine/tae/options/options.go
@@ -201,10 +201,11 @@ func (o *Options) FillDefaults(dirname string) *Options {
 
 	if o.SchedulerCfg == nil {
 		ioworkers := DefaultIOWorkers
-		if ioworkers < runtime.NumCPU() {
-			ioworkers = min(runtime.NumCPU(), 100)
+		procs := runtime.GOMAXPROCS(0)
+		if ioworkers < procs {
+			ioworkers = min(procs, 100)
 		}
-		workers := min(runtime.NumCPU()/2, 100)
+		workers := min(procs/2, 100)
 		if workers < 1 {
 			workers = 1
 		}

--- a/pkg/vm/engine/tae/options/types.go
+++ b/pkg/vm/engine/tae/options/types.go
@@ -74,19 +74,17 @@ type Options struct {
 	MergeCfg      *MergeConfig
 	CatalogCfg    *CatalogCfg
 
+	// MaxMessageSize is the size of max message which is sent to log-service.
+	MaxMessageSize   uint64
 	TransferTableTTL time.Duration
-
 	IncrementalDedup bool
 	IsStandalone     bool
+	LogStoreT        LogstoreType
 
-	Clock     clock.Clock
-	Fs        fileservice.FileService
-	Lc        logservicedriver.LogServiceClientFactory
-	Shard     metadata.TNShard
-	LogStoreT LogstoreType
-	Ctx       context.Context
-	// MaxMessageSize is the size of max message which is sent to log-service.
-	MaxMessageSize uint64
-
-	TaskServiceGetter taskservice.Getter
+	Fs                fileservice.FileService                  `toml:"-"`
+	Lc                logservicedriver.LogServiceClientFactory `toml:"-"`
+	Ctx               context.Context                          `toml:"-"`
+	Shard             metadata.TNShard                         `toml:"-"`
+	Clock             clock.Clock                              `toml:"-"`
+	TaskServiceGetter taskservice.Getter                       `toml:"-"`
 }

--- a/pkg/vm/engine/tae/rpc/base_test.go
+++ b/pkg/vm/engine/tae/rpc/base_test.go
@@ -161,7 +161,7 @@ func mockTAEHandle(ctx context.Context, t *testing.T, opts *options.Options) *mo
 	mh.Handle = &Handle{
 		db: tae,
 	}
-	mh.Handle.txnCtxs = common.NewMap[string, *txnContext](runtime.NumCPU())
+	mh.Handle.txnCtxs = common.NewMap[string, *txnContext](runtime.GOMAXPROCS(0))
 	return mh
 }
 

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -121,7 +121,7 @@ func NewTAEHandle(ctx context.Context, path string, opt *options.Options) *Handl
 	h := &Handle{
 		db: tae,
 	}
-	h.txnCtxs = common.NewMap[string, *txnContext](runtime.NumCPU())
+	h.txnCtxs = common.NewMap[string, *txnContext](runtime.GOMAXPROCS(0))
 
 	h.GCManager = gc.NewManager(
 		gc.WithCronJob(

--- a/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
+++ b/pkg/vm/engine/tae/txn/txnbase/txnmgr.go
@@ -130,7 +130,7 @@ func NewTxnManager(txnStoreFactory TxnStoreFactory, txnFactory TxnFactory, clock
 	mgr.PreparingSM = sm.NewStateMachine(new(sync.WaitGroup), mgr, pqueue, prepareWALQueue)
 
 	mgr.ctx, mgr.cancel = context.WithCancel(context.Background())
-	mgr.workers, _ = ants.NewPool(runtime.NumCPU())
+	mgr.workers, _ = ants.NewPool(runtime.GOMAXPROCS(0))
 	return mgr
 }
 

--- a/pkg/vm/engine/tae/txn/txnimpl/store.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/store.go
@@ -458,7 +458,7 @@ func (store *txnStore) CreateDatabaseWithID(name, createSql, datTyp string, id u
 }
 
 func (store *txnStore) DropDatabase(name string) (h handle.Database, err error) {
-	hasNewEntry, meta, err := store.catalog.DropDBEntry(name, store.txn)
+	hasNewEntry, meta, err := store.catalog.DropDBEntryByName(name, store.txn)
 	if err != nil {
 		return
 	}

--- a/test/distributed/cases/log/query_version.result
+++ b/test/distributed/cases/log/query_version.result
@@ -2,18 +2,9 @@ set @ts=now();
 select @@version_comment limit 1;
 @@version_comment
 MatrixOne
-select sleep(15) as s;
-s
-0
 use system;
 use mysql;
-select * from user limit 0;
+/* cloud_user */select * from user limit 0;
 host    user    select_priv    insert_priv    update_priv    delete_priv    create_priv    drop_priv    reload_priv    shutdown_priv    process_priv    file_priv    grant_priv    references_priv    index_priv    alter_priv    show_db_priv    super_priv    create_tmp_table_priv    lock_tables_priv    execute_priv    repl_slave_priv    repl_client_priv    create_view_priv    show_view_priv    create_routine_priv    alter_routine_priv    create_user_priv    event_priv    trigger_priv    create_tablespace_priv    ssl_type    ssl_cipher    x509_issuer    x509_subject    max_questions    max_updates    max_connections    max_user_connections    plugin    authentication_string    password_expired    password_last_changed    password_lifetime    account_locked    create_role_priv    drop_role_priv    password_reuse_history    password_reuse_time    password_require_current    user_attributes
-select sleep(15) as s;
-s
-0
 select count(1) as cnt, statement_id, statement, status from system.statement_info group by statement_id, statement, status having count(1) > 1;
 cnt    statement_id    statement    status
-select `database`, `aggr_count` from system.statement_info where statement LIKE '%select * from user limit 0%' order by request_at desc limit 1;
-database    aggr_count
-mysql    0

--- a/test/distributed/cases/log/query_version.sql
+++ b/test/distributed/cases/log/query_version.sql
@@ -2,13 +2,12 @@
 set @ts=now();
 select @@version_comment limit 1;
 
-select sleep(15) as s;
+-- fir pr #7971
 use system;
 use mysql;
-select * from user limit 0;
-
-select sleep(15) as s;
+/* cloud_user */select * from user limit 0;
 
 select count(1) as cnt, statement_id, statement, status from system.statement_info group by statement_id, statement, status having count(1) > 1;
 
-select `database`, `aggr_count` from system.statement_info where statement LIKE '%select * from user limit 0%' order by request_at desc limit 1;
+-- fix issue 14,836: move check-sql into ../zz_statement_query_type/query_version.*
+-- select `database`, `aggr_count` from system.statement_info where statement LIKE '%select * from user limit 0%' order by request_at desc limit 1;

--- a/test/distributed/cases/result_count/result_count.result
+++ b/test/distributed/cases/result_count/result_count.result
@@ -136,8 +136,8 @@ UNNEST_DEFAULT    0    a    $.a    null    1    {"a": 1}
 use system;
 /* cloud_user */create account test_tenant_1 admin_name 'test_account' identified by '111';
 /* cloud_user */drop account test_tenant_1;
-select sleep(16);
-sleep(16)
+select sleep(18) s;
+s
 0
 use system;
 select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' and length(statement) > 0 and status != 'Running' and aggr_count < 1 order by request_at desc limit 50;

--- a/test/distributed/cases/result_count/result_count.sql
+++ b/test/distributed/cases/result_count/result_count.sql
@@ -109,7 +109,7 @@ use system;
 -- case 2: END
 
 -- result check
-select sleep(16);
+select sleep(18) s;
 use system;
 -- check case 1
 -- Reason for changing the sql.

--- a/test/distributed/cases/sql_source_type/sql_source_type.result
+++ b/test/distributed/cases/sql_source_type/sql_source_type.result
@@ -9,13 +9,4 @@ use ssb;
 a
 1
 /* cloud_nonuser */ use system;/* cloud_user */show tables;
-select sleep(16);
-sleep(16)
-0
-select statement, sql_source_type from system.statement_info where account="bvt_sql_source_type" and status != 'Running' and statement not like '%mo_ctl%' order by request_at desc limit 4;
-statement    sql_source_type
-show tables    cloud_user_sql
-use system    cloud_nonuser_sql
-select * from __mo_t1    cloud_user_sql
-insert into __mo_t1 values(1)    cloud_user_sql
 drop account if exists bvt_sql_source_type;

--- a/test/distributed/cases/sql_source_type/sql_source_type.sql
+++ b/test/distributed/cases/sql_source_type/sql_source_type.sql
@@ -13,9 +13,8 @@ use ssb;
 /* cloud_nonuser */ use system;/* cloud_user */show tables;
 -- @session
 
--- result check
-select sleep(16);
-select statement, sql_source_type from system.statement_info where account="bvt_sql_source_type" and status != 'Running' and statement not like '%mo_ctl%' order by request_at desc limit 4;
+-- result check, issue 14,836 move into ../zz_statement_query_type
+-- select statement, sql_source_type from system.statement_info where account="bvt_sql_source_type" and status != 'Running' and statement not like '%mo_ctl%' order by request_at desc limit 4;
 
 -- cleanup
 drop account if exists bvt_sql_source_type;

--- a/test/distributed/cases/zz_statement_query_type/query_version.result
+++ b/test/distributed/cases/zz_statement_query_type/query_version.result
@@ -1,0 +1,3 @@
+select `database`, `aggr_count` from system.statement_info where statement = 'select * from user limit 0' and sql_source_type = 'cloud_user_sql' order by request_at desc limit 1;
+database    aggr_count
+mysql    0

--- a/test/distributed/cases/zz_statement_query_type/query_version.sql
+++ b/test/distributed/cases/zz_statement_query_type/query_version.sql
@@ -1,0 +1,2 @@
+-- for issue 14,836, prepare op in ../log/query_version.sql
+select `database`, `aggr_count` from system.statement_info where statement = 'select * from user limit 0' and sql_source_type = 'cloud_user_sql' order by request_at desc limit 1;

--- a/test/distributed/cases/zz_statement_query_type/sql_source_type.result
+++ b/test/distributed/cases/zz_statement_query_type/sql_source_type.result
@@ -1,0 +1,6 @@
+select statement, sql_source_type from system.statement_info where account="bvt_sql_source_type" and status != 'Running' and statement not like '%mo_ctl%' order by request_at desc limit 4;
+statement    sql_source_type
+show tables    cloud_user_sql
+use system    cloud_nonuser_sql
+select * from __mo_t1    cloud_user_sql
+insert into __mo_t1 values(1)    cloud_user_sql

--- a/test/distributed/cases/zz_statement_query_type/sql_source_type.sql
+++ b/test/distributed/cases/zz_statement_query_type/sql_source_type.sql
@@ -1,0 +1,2 @@
+-- result check, issue 14,836
+select statement, sql_source_type from system.statement_info where account="bvt_sql_source_type" and status != 'Running' and statement not like '%mo_ctl%' order by request_at desc limit 4;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3225

## What this PR does / why we need it:
ref: #15955
changes:
1. add new config `observability:disableError` default: false. 
2. bugfix: if NoReportFromContext(ctx), ignore error log output and collection.