### PR TITLE
fix hung

### DIFF
--- a/pkg/frontend/result_row_stmt.go
+++ b/pkg/frontend/result_row_stmt.go
@@ -171,7 +171,7 @@ func respColumnDefsWithoutFlush(ses *Session, execCtx *ExecCtx, columns []any) (
 		mysql COM_QUERY response: End after the column has been sent.
 		send EOF packet
 	*/
-	err = execCtx.proto.SendEOFPacketIf(0, ses.getStatusWithTxnEnd(execCtx.reqCtx))
+	err = execCtx.proto.SendEOFPacketIf(0, ses.GetTxnHandler().GetServerStatus())
 	if err != nil {
 		return
 	}
@@ -189,7 +189,7 @@ func respStreamResultRow(ses *Session,
 			ses.AddSeqValues(execCtx.proc)
 		}
 		ses.SetSeqLastValue(execCtx.proc)
-		err2 := execCtx.proto.sendEOFOrOkPacket(0, ses.getStatusWithTxnEnd(execCtx.reqCtx))
+		err2 := execCtx.proto.sendEOFOrOkPacket(0, ses.getStatusAfterTxnIsEnded(execCtx.reqCtx))
 		if err2 != nil {
 			err = moerr.NewInternalError(execCtx.reqCtx, "routine send response failed. error:%v ", err2)
 			logStatementStatus(execCtx.reqCtx, ses, execCtx.stmt, fail, err)
@@ -229,13 +229,13 @@ func respStreamResultRow(ses *Session,
 				return
 			}
 
-			err = execCtx.proto.sendEOFOrOkPacket(0, ses.getStatusWithTxnEnd(execCtx.reqCtx))
+			err = execCtx.proto.sendEOFOrOkPacket(0, ses.getStatusAfterTxnIsEnded(execCtx.reqCtx))
 			if err != nil {
 				return
 			}
 		}
 	default:
-		err = execCtx.proto.sendEOFOrOkPacket(0, ses.getStatusWithTxnEnd(execCtx.reqCtx))
+		err = execCtx.proto.sendEOFOrOkPacket(0, ses.getStatusAfterTxnIsEnded(execCtx.reqCtx))
 		if err != nil {
 			return
 		}
@@ -269,7 +269,7 @@ func respMixedResultRow(ses *Session,
 			zap.Error(err))
 		return err
 	}
-	err = execCtx.proto.sendEOFOrOkPacket(0, ses.getStatusWithTxnEnd(execCtx.reqCtx))
+	err = execCtx.proto.sendEOFOrOkPacket(0, ses.getStatusAfterTxnIsEnded(execCtx.reqCtx))
 	if err != nil {
 		return
 	}

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -1699,7 +1699,9 @@ func (ses *Session) StatusSession() *status.Session {
 	}
 }
 
-func (ses *Session) getStatusWithTxnEnd(ctx context.Context) uint16 {
+// getStatusAfterTxnIsEnded
+// !!! only used after the txn is ended.
+func (ses *Session) getStatusAfterTxnIsEnded(ctx context.Context) uint16 {
 	ses.maybeUnsetTxnStatus(ctx)
 	return extendStatus(ses.GetTxnHandler().GetServerStatus())
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16013

https://github.com/matrixorigin/matrixone/issues/15960

## What this PR does / why we need it:

问题原因：
在发送列定义时，用getStatusWithTxnEnd取server status了。
对getStatusWithTxnEnd 使用有错误。只能在事务结束后才能用。在事务中使用时，proxy会把session迁移走，导致没数据响应client。而卡住。

修改方案：
在发送列定义时，改用handler.GetServerStatus取server status
