### PR TITLE
Revert "[Bug]: pipeline client max connections is too large (#15713)"

### DIFF
--- a/pkg/cnservice/cnclient/client.go
+++ b/pkg/cnservice/cnclient/client.go
@@ -81,7 +81,7 @@ func (c *CNClient) NewStream(backend string) (morpc.Stream, error) {
 	if backend == c.localServiceAddress {
 		return nil, moerr.NewInternalErrorNoCtx(fmt.Sprintf("remote run pipeline in local: %s", backend))
 	}
-	return c.client.NewStream(backend, false)
+	return c.client.NewStream(backend, true)
 }
 
 func (c *CNClient) Close() error {
@@ -96,7 +96,7 @@ func (c *CNClient) Close() error {
 }
 
 const (
-	dfMaxSenderNumber       = 10
+	dfMaxSenderNumber       = 100000
 	dfConnectTimeout        = 5 * time.Second
 	dfClientReadBufferSize  = 1 << 10
 	dfClientWriteBufferSize = 1 << 10

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -1059,7 +1059,7 @@ func (s *Scope) notifyAndReceiveFromRemote(wg *sync.WaitGroup, errChan chan erro
 					closeWithError(errStream, s.Proc.Reg.MergeReceivers[receiverIdx])
 					return
 				}
-				defer streamSender.Close(false)
+				defer streamSender.Close(true)
 
 				message := cnclient.AcquireMessage()
 				message.Id = streamSender.ID()

--- a/pkg/sql/compile/scopeRemoteRunTypes.go
+++ b/pkg/sql/compile/scopeRemoteRunTypes.go
@@ -254,7 +254,7 @@ func (sender *messageSenderOnClient) close() {
 		sender.ctxCancel()
 	}
 	// XXX not a good way to deal it if close failed.
-	_ = sender.streamSender.Close(false)
+	_ = sender.streamSender.Close(true)
 }
 
 // messageReceiverOnServer is a structure


### PR DESCRIPTION
This reverts commit 2576dbd7fd963ca4ad0d6fac707f7e6371a44312.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12652

## What this PR does / why we need it:
Revert "[Bug]: pipeline client max connections is too large (#15713)"