### PR TITLE
[config] : add LargestEntryLimit to control the maximum amount of data allowed to be read when checking if a line can be legally clipped

### DIFF
--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -253,6 +253,9 @@ type Config struct {
 	// PrimaryKeyCheck
 	PrimaryKeyCheck bool `toml:"primary-key-check"`
 
+	// LargestEntryLimit is the max size for reading file to buf
+	LargestEntryLimit int `toml:"largest-entry-limit"`
+
 	// MaxPreparedStmtCount
 	MaxPreparedStmtCount int `toml:"max_prepared_stmt_count"`
 
@@ -389,6 +392,10 @@ func (c *Config) Validate() error {
 		config.CNPrimaryCheck = true
 	} else {
 		config.CNPrimaryCheck = false
+	}
+
+	if c.LargestEntryLimit > 0 {
+		config.LargestEntryLimit = c.LargestEntryLimit
 	}
 
 	if c.MaxPreparedStmtCount > 0 {

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -165,6 +165,9 @@ var (
 	// default lower_case_table_names
 	defaultLowerCaseTableNames = "1"
 
+	// largestEntryLimit is the max size for reading file to csv buf
+	LargestEntryLimit = 10 * 1024 * 1024
+
 	CNPrimaryCheck = false
 )
 

--- a/pkg/sql/util/csvparser/csv_parser.go
+++ b/pkg/sql/util/csvparser/csv_parser.go
@@ -25,6 +25,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/spkg/bom"
 )
 
@@ -34,8 +35,6 @@ var (
 	errUnexpectedQuoteField          = moerr.NewInvalidInputNoCtx("csvParser error: cannot have consecutive fields without separator")
 	BufferSizeScale                  = int64(5)
 	ReadBlockSize              int64 = 64 * 1024
-	// LargestEntryLimit is the max size for reading file to buf
-	LargestEntryLimit = 10 * 1024 * 1024
 )
 
 type Field struct {
@@ -504,7 +503,7 @@ func (parser *CSVParser) readUntil(chars *byteSet) ([]byte, byte, error) {
 	var buf []byte
 	for {
 		buf = append(buf, parser.buf...)
-		if len(buf) > LargestEntryLimit {
+		if len(buf) > config.LargestEntryLimit {
 			return buf, 0, moerr.NewInternalErrorNoCtx("size of row cannot exceed the max value of txn-entry-size-limit")
 		}
 		parser.buf = nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/3175

## What this PR does / why we need it:

moc3175一开始反映的问题是, 在检测一行是否可以合法的做切割的时候，按照了1M作为行大小进行读取, 在一些场景下给的太小了. 现在默认csv一行能读取的容量上限是10M.

在这个基础上, 添加了一个`LargestEntryLimit`的配置, 如果真遇到了单行超过10M的情况, 可以通过这个东西解决