### PR TITLE
support restore table with foreign keys

### DIFF
--- a/test/distributed/cases/snapshot/snapshot_restore_table_with_fk.result
+++ b/test/distributed/cases/snapshot/snapshot_restore_table_with_fk.result
@@ -1,5 +1,4 @@
 create account acc1 ADMIN_NAME 'admin1' IDENTIFIED BY 'test123';
-internal error: the tenant acc1 exists
 show databases;
 Database
 information_schema
@@ -71,7 +70,7 @@ a
 create snapshot sn1 for account acc1;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-sn1    2024-05-15 14:24:40.780678    account    acc1        
+sn1    2024-05-15 14:54:00.906635    account    acc1        
 drop database fk_test;
 restore account acc1 from snapshot sn1;
 show databases;

--- a/test/distributed/cases/snapshot/snapshot_restore_table_with_fk.result
+++ b/test/distributed/cases/snapshot/snapshot_restore_table_with_fk.result
@@ -1,0 +1,135 @@
+create account acc1 ADMIN_NAME 'admin1' IDENTIFIED BY 'test123';
+internal error: the tenant acc1 exists
+show databases;
+Database
+information_schema
+mo_catalog
+mysql
+system
+system_metrics
+create database fk_test;
+use fk_test;
+create table t1 (a int primary key);
+insert into t1 values (1);
+create table t2 (a int primary key, b int, FOREIGN KEY (b) REFERENCES t2(a));
+insert into t2 values (1, 1);
+create table t3 (a int primary key, b int unique key, FOREIGN KEY (a) REFERENCES t1(a), FOREIGN KEY (b) REFERENCES t2(a));
+insert into t3 values (1, 1);
+create table t4 (a int primary key, b int, FOREIGN KEY (b) REFERENCES t3(b));
+insert into t4 values (2, 1);
+create table t5 (a int, FOREIGN KEY (a) REFERENCES t4(a));
+insert into t5 values (2);
+create table t6 (a int, FOREIGN KEY (a) REFERENCES t4(a));
+insert into t6 values (2);
+show full tables;
+Tables_in_fk_test    Table_type
+t1    BASE TABLE
+t2    BASE TABLE
+t3    BASE TABLE
+t4    BASE TABLE
+t5    BASE TABLE
+t6    BASE TABLE
+desc t1;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    NO    PRI    null        
+desc t2;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    NO    PRI    null        
+b    INT(32)    YES    MUL    null        
+desc t3;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    NO    PRI    null        
+b    INT(32)    YES    MUL    null        
+desc t4;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    NO    PRI    null        
+b    INT(32)    YES    MUL    null        
+desc t5;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    YES    MUL    null        
+desc t6;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    YES    MUL    null        
+select * from t1;
+a
+1
+select * from t2;
+a    b
+1    1
+select * from t3;
+a    b
+1    1
+select * from t4;
+a    b
+2    1
+select * from t5;
+a
+2
+select * from t6;
+a
+2
+create snapshot sn1 for account acc1;
+show snapshots;
+SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
+sn1    2024-05-15 14:24:40.780678    account    acc1        
+drop database fk_test;
+restore account acc1 from snapshot sn1;
+show databases;
+Database
+fk_test
+information_schema
+mo_catalog
+mysql
+system
+system_metrics
+use fk_test;
+show full tables;
+Tables_in_fk_test    Table_type
+t1    BASE TABLE
+t2    BASE TABLE
+t3    BASE TABLE
+t4    BASE TABLE
+t5    BASE TABLE
+t6    BASE TABLE
+desc t1;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    NO    PRI    null        
+desc t2;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    NO    PRI    null        
+b    INT(32)    YES    MUL    null        
+desc t3;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    NO    PRI    null        
+b    INT(32)    YES    MUL    null        
+desc t4;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    NO    PRI    null        
+b    INT(32)    YES    MUL    null        
+desc t5;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    YES    MUL    null        
+desc t6;
+Field    Type    Null    Key    Default    Extra    Comment
+a    INT(32)    YES    MUL    null        
+select * from t1;
+a
+1
+select * from t2;
+a    b
+1    1
+select * from t3;
+a    b
+1    1
+select * from t4;
+a    b
+2    1
+select * from t5;
+a
+2
+select * from t6;
+a
+2
+drop snapshot sn1;
+drop database fk_test;
+drop account acc1;

--- a/test/distributed/cases/snapshot/snapshot_restore_table_with_fk.sql
+++ b/test/distributed/cases/snapshot/snapshot_restore_table_with_fk.sql
@@ -1,0 +1,61 @@
+create account acc1 ADMIN_NAME 'admin1' IDENTIFIED BY 'test123';
+
+-- @session:id=2&user=acc1:admin1&password=test123
+show databases;
+create database fk_test;
+use fk_test;
+create table t1 (a int primary key);
+insert into t1 values (1);
+create table t2 (a int primary key, b int, FOREIGN KEY (b) REFERENCES t2(a));
+insert into t2 values (1, 1);
+create table t3 (a int primary key, b int unique key, FOREIGN KEY (a) REFERENCES t1(a), FOREIGN KEY (b) REFERENCES t2(a));
+insert into t3 values (1, 1);
+create table t4 (a int primary key, b int, FOREIGN KEY (b) REFERENCES t3(b));
+insert into t4 values (2, 1);
+create table t5 (a int, FOREIGN KEY (a) REFERENCES t4(a));
+insert into t5 values (2);
+create table t6 (a int, FOREIGN KEY (a) REFERENCES t4(a));
+insert into t6 values (2);
+
+show full tables;
+desc t1;
+desc t2;
+desc t3;
+desc t4;
+desc t5;
+desc t6;
+select * from t1;
+select * from t2;
+select * from t3;
+select * from t4;
+select * from t5;
+select * from t6;
+
+create snapshot sn1 for account acc1;
+-- @ignore:1
+show snapshots;
+
+drop database fk_test;
+restore account acc1 from snapshot sn1;
+
+show databases;
+use fk_test;
+show full tables;
+desc t1;
+desc t2;
+desc t3;
+desc t4;
+desc t5;
+desc t6;
+select * from t1;
+select * from t2;
+select * from t3;
+select * from t4;
+select * from t5;
+select * from t6;
+
+drop snapshot sn1;
+drop database fk_test;
+-- @session
+
+drop account acc1;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15653 #15971 

## What this PR does / why we need it:
- build foreign key dependency graph from mo_foreign_keys table
- restore tables with foreign keys in order of dependency graph topological sorting