### PR TITLE
report error for standalone INTERVAL expression

### DIFF
--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1284,7 +1284,7 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 	// deal with some special function
 	switch name {
 	case "interval":
-		// rewrite interval function to ListExpr, and retrun directly
+		// rewrite interval function to ListExpr, and return directly
 		return &plan.Expr{
 			Typ: plan.Type{
 				Id: int32(types.T_interval),

--- a/pkg/sql/plan/rule/constant_fold.go
+++ b/pkg/sql/plan/rule/constant_fold.go
@@ -15,6 +15,7 @@
 package rule
 
 import (
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -77,6 +78,10 @@ func (r *ConstantFold) Apply(n *plan.Node, _ *plan.Query, proc *process.Process)
 }
 
 func (r *ConstantFold) constantFold(expr *plan.Expr, proc *process.Process) *plan.Expr {
+	if expr.Typ.Id == int32(types.T_interval) {
+		panic(moerr.NewInternalError(proc.Ctx, "not supported type INTERVAL"))
+	}
+
 	fn := expr.GetF()
 	if fn == nil {
 		if elist := expr.GetList(); elist != nil {

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1095,6 +1095,10 @@ func ConstandFoldList(exprs []*plan.Expr, proc *process.Process, varAndParamIsCo
 }
 
 func ConstantFold(bat *batch.Batch, expr *plan.Expr, proc *process.Process, varAndParamIsConst bool) (*plan.Expr, error) {
+	if expr.Typ.Id == int32(types.T_interval) {
+		panic(moerr.NewInternalError(proc.Ctx, "not supported type INTERVAL"))
+	}
+
 	// If it is Expr_List, perform constant folding on its elements
 	if elist := expr.GetList(); elist != nil {
 		exprList := elist.List


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15648

## What this PR does / why we need it:
MO has no INTERVAL type. INTERVAL expressions are rewritten to date_add/date_sub. Standalone INTERVAL expressions should report error.