### PR TITLE
fileservice: reuse more memory

### DIFF
--- a/cmd/mo-service/config.go
+++ b/cmd/mo-service/config.go
@@ -292,8 +292,6 @@ func (c *Config) setDefaultValue() error {
 	//no default proxy config
 	// Observability has been set in NewConfig
 	c.initMetaCache()
-	// set malloc default config
-	malloc.SetDefaultConfig(c.Malloc)
 	return nil
 }
 

--- a/cmd/mo-service/main.go
+++ b/cmd/mo-service/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
 	"github.com/matrixorigin/matrixone/pkg/cnservice"
 	"github.com/matrixorigin/matrixone/pkg/cnservice/cnclient"
+	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
@@ -168,6 +169,8 @@ func startService(
 		return err
 	}
 	setupProcessLevelRuntime(cfg, stopper)
+
+	malloc.SetDefaultConfig(cfg.Malloc)
 
 	setupStatusServer(runtime.ProcessLevelRuntime())
 

--- a/pkg/common/malloc/allocator_bench_test.go
+++ b/pkg/common/malloc/allocator_bench_test.go
@@ -14,28 +14,36 @@
 
 package malloc
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
+
+var benchNs = []uint64{
+	64, 4096, 2 * MB,
+}
 
 func benchmarkAllocator(
 	b *testing.B,
 	newAllocator func() Allocator,
+	n uint64,
 ) {
 
-	b.Run("allocate", func(b *testing.B) {
+	b.Run(fmt.Sprintf("allocate: n %v", n), func(b *testing.B) {
 		allcator := newAllocator()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			ptr, dec := allcator.Allocate(4096)
+			ptr, dec := allcator.Allocate(n)
 			dec.Deallocate(ptr)
 		}
 	})
 
-	b.Run("parallel", func(b *testing.B) {
+	b.Run(fmt.Sprintf("parallel: n %v", n), func(b *testing.B) {
 		allcator := newAllocator()
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				ptr, dec := allcator.Allocate(4096)
+				ptr, dec := allcator.Allocate(n)
 				dec.Deallocate(ptr)
 			}
 		})

--- a/pkg/common/malloc/c_allocator_test.go
+++ b/pkg/common/malloc/c_allocator_test.go
@@ -23,9 +23,11 @@ func TestCAllocator(t *testing.T) {
 }
 
 func BenchmarkCAllocator(b *testing.B) {
-	benchmarkAllocator(b, func() Allocator {
-		return NewCAllocator()
-	})
+	for _, n := range benchNs {
+		benchmarkAllocator(b, func() Allocator {
+			return NewCAllocator()
+		}, n)
+	}
 }
 
 func FuzzCAllocator(f *testing.F) {

--- a/pkg/common/malloc/config.go
+++ b/pkg/common/malloc/config.go
@@ -14,6 +14,11 @@
 
 package malloc
 
+import (
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"go.uber.org/zap"
+)
+
 type Config struct {
 	// CheckFraction controls the fraction of checked deallocations
 	// On average, 1 / fraction of deallocations will be checked for double free or missing free
@@ -24,4 +29,5 @@ var defaultConfig Config
 
 func SetDefaultConfig(c Config) {
 	defaultConfig = c
+	logutil.Info("malloc: set default config", zap.Any("config", c))
 }

--- a/pkg/common/malloc/default_test.go
+++ b/pkg/common/malloc/default_test.go
@@ -25,9 +25,11 @@ func TestDefaultAllocator(t *testing.T) {
 }
 
 func BenchmarkDefaultAllocator(b *testing.B) {
-	benchmarkAllocator(b, func() Allocator {
-		return NewDefault(nil)
-	})
+	for _, n := range benchNs {
+		benchmarkAllocator(b, func() Allocator {
+			return NewDefault(nil)
+		}, n)
+	}
 }
 
 func FuzzDefaultAllocator(f *testing.F) {

--- a/pkg/fileservice/bytes.go
+++ b/pkg/fileservice/bytes.go
@@ -14,32 +14,49 @@
 
 package fileservice
 
-import "github.com/matrixorigin/matrixone/pkg/fileservice/memorycache"
+import (
+	"unsafe"
 
-type Bytes []byte
+	"github.com/matrixorigin/matrixone/pkg/common/malloc"
+	"github.com/matrixorigin/matrixone/pkg/fileservice/memorycache"
+)
+
+type Bytes struct {
+	bytes       []byte
+	ptr         unsafe.Pointer
+	deallocator malloc.Deallocator
+}
 
 func (b Bytes) Size() int64 {
-	return int64(len(b))
+	return int64(len(b.bytes))
 }
 
 func (b Bytes) Bytes() []byte {
-	return b
+	return b.bytes
 }
 
 func (b Bytes) Slice(length int) memorycache.CacheData {
-	return b[:length]
+	b.bytes = b.bytes[:length]
+	return b
 }
 
 func (b Bytes) Release() {
+	if b.deallocator != nil {
+		b.deallocator.Deallocate(b.ptr)
+	}
 }
 
-func (b Bytes) Retain() {
+type bytesAllocator struct {
+	allocator malloc.Allocator
 }
-
-type bytesAllocator struct{}
 
 var _ CacheDataAllocator = new(bytesAllocator)
 
 func (b *bytesAllocator) Alloc(size int) memorycache.CacheData {
-	return make(Bytes, size)
+	ptr, dec := b.allocator.Allocate(uint64(size))
+	return Bytes{
+		bytes:       unsafe.Slice((*byte)(ptr), size),
+		ptr:         ptr,
+		deallocator: dec,
+	}
 }

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -124,8 +124,18 @@ var DisabledCacheConfig = CacheConfig{
 
 const DisableCacheCapacity = 1
 
-// var DefaultCacheDataAllocator = RCBytesPool
-var DefaultCacheDataAllocator = new(bytesAllocator)
+var initDefaultCacheDataAllocator sync.Once
+
+var _defaultCacheDataAllocator CacheDataAllocator
+
+func GetDefaultCacheDataAllocator() CacheDataAllocator {
+	initDefaultCacheDataAllocator.Do(func() {
+		_defaultCacheDataAllocator = &bytesAllocator{
+			allocator: getMallocAllocator(),
+		}
+	})
+	return _defaultCacheDataAllocator
+}
 
 // VectorCache caches IOVector
 type IOVectorCache interface {

--- a/pkg/fileservice/file_service.go
+++ b/pkg/fileservice/file_service.go
@@ -138,6 +138,8 @@ type IOEntry struct {
 	fromCache IOVectorCache
 
 	allocator CacheDataAllocator
+
+	releaseFuncs []func()
 }
 
 func (i IOEntry) String() string {

--- a/pkg/fileservice/io_vector.go
+++ b/pkg/fileservice/io_vector.go
@@ -30,6 +30,9 @@ func (i *IOVector) Release() {
 		if entry.CachedData != nil {
 			entry.CachedData.Release()
 		}
+		for _, fn := range entry.releaseFuncs {
+			fn()
+		}
 	}
 }
 

--- a/pkg/fileservice/local_etl_fs.go
+++ b/pkg/fileservice/local_etl_fs.go
@@ -237,7 +237,7 @@ func (l *LocalETLFS) Read(ctx context.Context, vector *IOVector) error {
 					R: r,
 					C: counter,
 				}
-				cacheData, err := entry.ToCacheData(cr, nil, DefaultCacheDataAllocator)
+				cacheData, err := entry.ToCacheData(cr, nil, GetDefaultCacheDataAllocator())
 				if err != nil {
 					return err
 				}
@@ -287,7 +287,7 @@ func (l *LocalETLFS) Read(ctx context.Context, vector *IOVector) error {
 					r: io.TeeReader(r, buf),
 					closeFunc: func() error {
 						defer f.Close()
-						cacheData, err := entry.ToCacheData(buf, buf.Bytes(), DefaultCacheDataAllocator)
+						cacheData, err := entry.ToCacheData(buf, buf.Bytes(), GetDefaultCacheDataAllocator())
 						if err != nil {
 							return err
 						}

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memorycache"
@@ -112,7 +113,7 @@ func NewLocalFS(
 	if fs.memCache != nil {
 		fs.allocator = fs.memCache
 	} else {
-		fs.allocator = DefaultCacheDataAllocator
+		fs.allocator = GetDefaultCacheDataAllocator()
 	}
 
 	return fs, nil
@@ -319,7 +320,7 @@ func (l *LocalFS) Read(ctx context.Context, vector *IOVector) (err error) {
 
 	allocator := l.allocator
 	if vector.Policy.Any(SkipMemoryCache) {
-		allocator = DefaultCacheDataAllocator
+		allocator = GetDefaultCacheDataAllocator()
 	}
 	for i := range vector.Entries {
 		vector.Entries[i].allocator = allocator
@@ -481,7 +482,7 @@ func (l *LocalFS) read(ctx context.Context, vector *IOVector, bytesCounter *atom
 					C: counter,
 				}
 				var bs memorycache.CacheData
-				bs, err = entry.ToCacheData(cr, nil, DefaultCacheDataAllocator)
+				bs, err = entry.ToCacheData(cr, nil, GetDefaultCacheDataAllocator())
 				if err != nil {
 					return err
 				}
@@ -541,7 +542,7 @@ func (l *LocalFS) read(ctx context.Context, vector *IOVector, bytesCounter *atom
 					closeFunc: func() error {
 						defer file.Close()
 						var bs memorycache.CacheData
-						bs, err = entry.ToCacheData(buf, buf.Bytes(), DefaultCacheDataAllocator)
+						bs, err = entry.ToCacheData(buf, buf.Bytes(), GetDefaultCacheDataAllocator())
 						if err != nil {
 							return err
 						}
@@ -581,7 +582,11 @@ func (l *LocalFS) read(ctx context.Context, vector *IOVector, bytesCounter *atom
 
 			} else {
 				if int64(len(entry.Data)) < entry.Size {
-					entry.Data = make([]byte, entry.Size)
+					ptr, dec := getMallocAllocator().Allocate(uint64(entry.Size))
+					entry.Data = unsafe.Slice((*byte)(ptr), entry.Size)
+					entry.releaseFuncs = append(entry.releaseFuncs, func() {
+						dec.Deallocate(ptr)
+					})
 				}
 				var n int
 				n, err = io.ReadFull(r, entry.Data)

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -85,7 +85,7 @@ func NewMemoryCache(
 			}
 		}
 	}
-	return memorycache.NewCache(capacity, postSetFn, postGetFn, postEvictFn)
+	return memorycache.NewCache(capacity, postSetFn, postGetFn, postEvictFn, getMallocAllocator())
 }
 
 var _ IOVectorCache = new(MemCache)

--- a/pkg/fileservice/memorycache/cache.go
+++ b/pkg/fileservice/memorycache/cache.go
@@ -27,6 +27,7 @@ func NewCache(
 	postSet func(key cache.CacheKey, value CacheData),
 	postGet func(key cache.CacheKey, value CacheData),
 	postEvict func(key cache.CacheKey, value CacheData),
+	allocator malloc.Allocator,
 ) *Cache {
 	var c Cache
 
@@ -61,7 +62,7 @@ func NewCache(
 		}
 	}
 	c.l = lrucache.New(capacity, setFunc, getFunc, evictFunc)
-	c.allocator = malloc.NewDefault(nil)
+	c.allocator = allocator
 	return &c
 }
 

--- a/pkg/fileservice/memorycache/cache_test.go
+++ b/pkg/fileservice/memorycache/cache_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 	cache "github.com/matrixorigin/matrixone/pkg/pb/query"
 	"github.com/stretchr/testify/require"
 )
@@ -29,6 +30,7 @@ func TestCache(t *testing.T) {
 		func(key cache.CacheKey, value CacheData) {},
 		func(key cache.CacheKey, value CacheData) {},
 		func(key cache.CacheKey, value CacheData) {},
+		malloc.NewDefault(nil),
 	)
 	// test Alloc and Set
 	key := cache.CacheKey{Path: "x", Sz: 1}

--- a/pkg/fileservice/remote_cache.go
+++ b/pkg/fileservice/remote_cache.go
@@ -128,7 +128,7 @@ func (r *RemoteCache) Read(ctx context.Context, vector *IOVector) error {
 					idx := int(cacheData.Index)
 					if cacheData.Hit {
 						vector.Entries[idx].done = true
-						vector.Entries[idx].CachedData = Bytes(cacheData.Data)
+						vector.Entries[idx].CachedData = Bytes{bytes: cacheData.Data}
 						vector.Entries[idx].fromCache = r
 						numHit++
 					}

--- a/pkg/fileservice/remote_cache_test.go
+++ b/pkg/fileservice/remote_cache_test.go
@@ -87,7 +87,7 @@ func TestRemoteCache(t *testing.T) {
 		err = sf2.rc.Read(ctx, ioVec2)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(ioVec2.Entries))
-		assert.Equal(t, Bytes{1, 2}, ioVec2.Entries[0].CachedData)
+		assert.Equal(t, Bytes{bytes: []byte{1, 2}}, ioVec2.Entries[0].CachedData)
 		assert.Equal(t, true, ioVec2.Entries[0].done)
 		assert.NotNil(t, ioVec2.Entries[0].fromCache)
 

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -109,7 +109,7 @@ func NewS3FS(
 	if fs.memCache != nil {
 		fs.allocator = fs.memCache
 	} else {
-		fs.allocator = DefaultCacheDataAllocator
+		fs.allocator = GetDefaultCacheDataAllocator()
 	}
 
 	return fs, nil
@@ -414,7 +414,7 @@ func (s *S3FS) Read(ctx context.Context, vector *IOVector) (err error) {
 
 	allocator := s.allocator
 	if vector.Policy.Any(SkipMemoryCache) {
-		allocator = DefaultCacheDataAllocator
+		allocator = GetDefaultCacheDataAllocator()
 	}
 	for i := range vector.Entries {
 		vector.Entries[i].allocator = allocator

--- a/pkg/objectio/funcs.go
+++ b/pkg/objectio/funcs.go
@@ -28,10 +28,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 )
 
-func ReleaseIOEntry(entry *fileservice.IOEntry) {
-	entry.CachedData.Release()
-}
-
 func ReleaseIOVector(vector *fileservice.IOVector) {
 	vector.Release()
 }
@@ -62,7 +58,7 @@ func ReadExtent(
 	v := ioVec.Entries[0].CachedData.Bytes()
 	buf = make([]byte, len(v))
 	copy(buf, v)
-	ReleaseIOEntry(&ioVec.Entries[0])
+	ReleaseIOVector(ioVec)
 	return
 }
 
@@ -220,7 +216,7 @@ func ReadOneBlockWithMeta(
 				if err = vector.NewConstNull(typs[i], length, m).MarshalBinaryWithBuffer(buf); err != nil {
 					return
 				}
-				cacheData := fileservice.DefaultCacheDataAllocator.Alloc(buf.Len())
+				cacheData := fileservice.GetDefaultCacheDataAllocator().Alloc(buf.Len())
 				copy(cacheData.Bytes(), buf.Bytes())
 				filledEntries[i].CachedData = cacheData
 			}


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15566

https://github.com/matrixorigin/MO-Cloud/issues/3253

https://github.com/matrixorigin/matrixone/issues/16291

## What this PR does / why we need it:

fileservice: refactor bytesAllocator to reuse memory

objectio: remove ReleaseIOEntry

fileservice: add global malloc.Allocator

fileservice: allocate bytes in malloc allocator in LocalFS

fileservice: allocate from global allocator in IOEntry.ReadFromOSFile

malloc: add checked deallocator

malloc: add TestCheckedDeallocator

malloc: more logs

mo-service: fix malloc.SetDefaultConfig

fileservice: delay initialization of allocators

malloc: refine benchmarks