### PR TITLE
[fix] : mergeDelete on hidden table should not update affect Rows

### DIFF
--- a/pkg/sql/colexec/deletion/types.go
+++ b/pkg/sql/colexec/deletion/types.go
@@ -129,7 +129,7 @@ type DeleteCtx struct {
 	// PartitionSources      []engine.Relation // Align array index with the partition number
 	// Source                engine.Relation
 	Ref             *plan.ObjectRef
-	AddAffectedRows bool
+	AddAffectedRows bool // for hidden table, should not update affect Rows
 	PrimaryKeyIdx   int
 
 	Engine engine.Engine

--- a/pkg/sql/colexec/insert/types.go
+++ b/pkg/sql/colexec/insert/types.go
@@ -85,7 +85,7 @@ type InsertCtx struct {
 	// insert data into Rel.
 	Engine                engine.Engine
 	Ref                   *plan.ObjectRef
-	AddAffectedRows       bool
+	AddAffectedRows       bool // for hidden table, should not update affect Rows
 	Attrs                 []string
 	PartitionTableIDs     []uint64 // Align array index with the partition number
 	PartitionTableNames   []string // Align array index with the partition number

--- a/pkg/sql/colexec/mergedelete/types.go
+++ b/pkg/sql/colexec/mergedelete/types.go
@@ -25,6 +25,7 @@ import (
 var _ vm.Operator = new(Argument)
 
 type Argument struct {
+	AddAffectedRows     bool
 	AffectedRows        uint64
 	Ref                 *plan.ObjectRef
 	Engine              engine.Engine
@@ -75,6 +76,11 @@ func (arg *Argument) WithParitionNames(names []string) *Argument {
 
 func (arg *Argument) WithEngine(eng engine.Engine) *Argument {
 	arg.Engine = eng
+	return arg
+}
+
+func (arg *Argument) WithAddAffectedRows(addAffectedRows bool) *Argument {
+	arg.AddAffectedRows = addAffectedRows
 	return arg
 }
 

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -356,7 +356,10 @@ func (c *Compile) run(s *Scope) error {
 		if err != nil {
 			return err
 		}
-		c.setAffectedRows(s.Instructions[len(s.Instructions)-1].Arg.(*mergedelete.Argument).AffectedRows)
+		mergeArg := s.Instructions[len(s.Instructions)-1].Arg.(*mergedelete.Argument)
+		if mergeArg.AddAffectedRows {
+			c.addAffectedRows(mergeArg.AffectedRows)
+		}
 		return nil
 	case Remote:
 		defer c.fillAnalyzeInfo()
@@ -1427,7 +1430,8 @@ func (c *Compile) compilePlanScope(ctx context.Context, step int32, curNodeIdx i
 				Arg: mergedelete.NewArgument().
 					WithObjectRef(arg.DeleteCtx.Ref).
 					WithParitionNames(arg.DeleteCtx.PartitionTableNames).
-					WithEngine(c.e),
+					WithEngine(c.e).
+					WithAddAffectedRows(arg.DeleteCtx.AddAffectedRows),
 			})
 			rs.Magic = MergeDelete
 			ss = []*Scope{rs}

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -109,7 +109,7 @@ type deleteNodeInfo struct {
 	partitionIdx    int      // The array index position of the partition expression column
 	indexTableNames []string
 	foreignTbl      []uint64
-	addAffectedRows bool
+	addAffectedRows bool // for hidden table, should not update affect Rows, e.g. delete 1 row from table t with schema like a int, b unique key, c key, affact rows should be 1 instead of 3
 	pkPos           int
 	pkTyp           plan.Type
 	lockTable       bool


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16168

## What this PR does / why we need it:

mergeDelete on hidden table should not update affect Rows