### PR TITLE
fileservice: add i/o timeout as retryable error

### DIFF
--- a/pkg/fileservice/error.go
+++ b/pkg/fileservice/error.go
@@ -37,6 +37,7 @@ func IsRetryableError(err error) bool {
 		strings.Contains(str, "connection reset by peer") ||
 		strings.Contains(str, "connection timed out") ||
 		strings.Contains(str, "dial tcp: lookup") ||
+		strings.Contains(str, "i/o timeout") ||
 		strings.Contains(str, "write: broken pipe") ||
 		strings.Contains(str, "use of closed network connection") {
 		return true


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15307 

## What this PR does / why we need it:
retry on i/o timeout