### PR TITLE
update save profile

### DIFF
--- a/cmd/mo-service/debug.go
+++ b/cmd/mo-service/debug.go
@@ -399,7 +399,9 @@ func saveProfilesLoop(sigs chan os.Signal) {
 	for {
 		select {
 		case <-tk.C:
+			logutil.GetGlobalLogger().Info("save profiles start")
 			saveProfiles()
+			logutil.GetGlobalLogger().Info("save profiles end")
 		case <-sigs:
 			quit = true
 		}
@@ -418,7 +420,8 @@ func saveProfiles() {
 
 func saveProfile(typ string) string {
 	name, _ := uuid.NewV7()
-	profilePath := catalog.BuildProfilePath(typ, name.String())
+	profilePath := catalog.BuildProfilePath(typ, name.String()) + ".gz"
+	logutil.GetGlobalLogger().Info("save profiles ", zap.String("path", profilePath))
 	cnservice.SaveProfile(profilePath, typ, globalEtlFS)
 	return profilePath
 }

--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -15,10 +15,11 @@
 package cnservice
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"sync"
 	"time"
 
@@ -654,7 +655,7 @@ func (s *service) getTxnClient() (c client.TxnClient, err error) {
 				s.cfg.Txn.MaxActiveAges.Duration,
 				func(actives []client.ActiveTxn) {
 					name, _ := uuid.NewV7()
-					profPath := catalog.BuildProfilePath("routine", name.String())
+					profPath := catalog.BuildProfilePath("routine", name.String()) + ".gz"
 
 					for _, txn := range actives {
 						fields := []zap.Field{
@@ -870,28 +871,39 @@ func SaveProfile(profilePath string, profileType string, etlFS fileservice.FileS
 	if len(profilePath) == 0 || len(profileType) == 0 || etlFS == nil {
 		return
 	}
-	reader, writer := io.Pipe()
-	go func() {
-		debug := 0
-		if profile.GOROUTINE == profileType {
-			debug = 2
-		}
-		_ = profile.ProfileRuntime(profileType, writer, debug)
-		_ = writer.Close()
-	}()
+
+	//gzip compress
+	buf := bytes.Buffer{}
+	gzWriter := gzip.NewWriter(&buf)
+
+	debug := 0
+	if profile.GOROUTINE == profileType {
+		debug = 2
+	}
+	err := profile.ProfileRuntime(profileType, gzWriter, debug)
+	if err != nil {
+		logutil.Errorf("get profile of %s failed. err:%v", profilePath, err)
+		return
+	}
+	err = gzWriter.Close()
+	if err != nil {
+		logutil.Errorf("close gzip write of %s failed. err:%v", profilePath, err)
+		return
+	}
+
 	writeVec := fileservice.IOVector{
 		FilePath: profilePath,
 		Entries: []fileservice.IOEntry{
 			{
-				Offset:         0,
-				ReaderForWrite: reader,
-				Size:           -1,
+				Offset: 0,
+				Data:   buf.Bytes(),
+				Size:   int64(len(buf.Bytes())),
 			},
 		},
 	}
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Minute*3)
 	defer cancel()
-	err := etlFS.Write(ctx, writeVec)
+	err = etlFS.Write(ctx, writeVec)
 	if err != nil {
 		logutil.Errorf("save profile %s failed. err:%v", profilePath, err)
 		return

--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -890,7 +890,7 @@ func SaveProfile(profilePath string, profileType string, etlFS fileservice.FileS
 		logutil.Errorf("close gzip write of %s failed. err:%v", profilePath, err)
 		return
 	}
-
+	logutil.Info("get profile done. save profiles ", zap.String("path", profilePath))
 	writeVec := fileservice.IOVector{
 		FilePath: profilePath,
 		Entries: []fileservice.IOEntry{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/15982

## What this PR does / why we need it:

定时profile存在的问题：
系统压力大时，profile保存不了。

可能的原因：
开启新routine取profile，再流式写入fileservice。在mo压力大时，新goroutine可能得不到调度，而导致profile取不出来。
在mo压力大时，也有可能取从go系统取profile本身取不出来。

改进定时profile

1.将原先proile流式写入改为同步写入。
    不再开启新routine。
    同时，profile要先保存到buf,再将buf写入fileservice。

2.对profile文件gzip压缩。profile名称带后缀gz。

解压方法
```
gzip -d xxx.gz
```

3. 测试结果。

在mo没什么压力的情况下。保存heap和goroutine，大概要50ms。
在mo跑sysbench 1000w 1000线程时。保存heap和goroutine，大概要2.5s。
heap文件压缩率为50%左右。goroutine文件压缩率更高。profile文件整体<= 500KB。


4. 用法
mo-service启动时增加参数。 -profile-interval "10s"
会在mo-data/etl/profile中每隔10s保存heap和goroutine。

例如：

```
./mo-service -profile-interval "10s" -debug-http 127.0.0.1:6060 -launch etc/launch/launch.toml > log.txt
```

启动成功后会有下面的效果

```
xxxx@xxxx:~/Documents/temp/matrixone-temp/mo-data/etl/profile$ ls
goroutine_018fa488-7b2e-725e-859f-2e71279a8f70.gz  goroutine_018fa48d-2270-7bfb-a67d-8eb7edad4a7b.gz  goroutine_018fa490-ce2b-7aac-a7b3-4055d3c02699.gz  heap_018fa48b-c2ce-75e3-97ee-6451e2ca6dad.gz  heap_018fa48f-6c55-7e65-87bd-3ad2cc4c6bed.gz
goroutine_018fa488-f063-7711-99c4-3531764fa470.gz  goroutine_018fa48d-9a01-7260-8e31-b04698aced33.gz  goroutine_018fa491-4382-75d5-9d1e-3ad77b1c768f.gz  heap_018fa48c-37fe-7690-ad58-003a75e97d21.gz  heap_018fa48f-e18a-7887-a99f-63eaf310432d.gz
goroutine_018fa488-f704-797c-a065-11bb6ca2a0e4.gz  goroutine_018fa48e-0ee6-7b5e-b2ac-d133c4e32ac2.gz  goroutine_018fa491-b939-7052-b6d5-17c43f5cd9de.gz  heap_018fa48c-ad2e-7d32-8b0e-db2d8a5ed220.gz  heap_018fa490-56b5-709b-806a-a6ace08d316d.gz


```