### PR TITLE
[BugFix]: Use L2DistanceSq instead of L2Distance during IndexScan

### DIFF
--- a/pkg/sql/colexec/productl2/product_l2.go
+++ b/pkg/sql/colexec/productl2/product_l2.go
@@ -191,7 +191,7 @@ func (ctr *container) probe(ap *Argument, proc *process.Process, anal process.An
 
 			for i = 0; i < buildCount; i++ {
 				clusterEmbeddingF32 = types.BytesToArray[float32](ctr.bat.Vecs[centroidColPos].GetBytesAt(i))
-				dist, _ := moarray.L2Distance[float32](clusterEmbeddingF32, normalizeTblEmbeddingF32)
+				dist, _ := moarray.L2DistanceSq[float32](clusterEmbeddingF32, normalizeTblEmbeddingF32)
 				if dist < leastDistance {
 					leastDistance = dist
 					leastClusterIndex = i
@@ -214,7 +214,7 @@ func (ctr *container) probe(ap *Argument, proc *process.Process, anal process.An
 
 			for i = 0; i < buildCount; i++ {
 				clusterEmbeddingF64 = types.BytesToArray[float64](ctr.bat.Vecs[centroidColPos].GetBytesAt(i))
-				dist, _ := moarray.L2Distance[float64](clusterEmbeddingF64, normalizeTblEmbeddingF64)
+				dist, _ := moarray.L2DistanceSq[float64](clusterEmbeddingF64, normalizeTblEmbeddingF64)
 				if dist < leastDistance {
 					leastDistance = dist
 					leastClusterIndex = i

--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -2898,6 +2898,14 @@ func L2DistanceArray[T types.RealNumbers](ivecs []*vector.Vector, result vector.
 	})
 }
 
+func L2DistanceSqArray[T types.RealNumbers](ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int) error {
+	return opBinaryBytesBytesToFixedWithErrorCheck[float64](ivecs, result, proc, length, func(v1, v2 []byte) (out float64, err error) {
+		_v1 := types.BytesToArray[T](v1)
+		_v2 := types.BytesToArray[T](v2)
+		return moarray.L2DistanceSq[T](_v1, _v2)
+	})
+}
+
 func CosineDistanceArray[T types.RealNumbers](ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int) error {
 	return opBinaryBytesBytesToFixedWithErrorCheck[float64](ivecs, result, proc, length, func(v1, v2 []byte) (out float64, err error) {
 		_v1 := types.BytesToArray[T](v1)

--- a/pkg/sql/plan/function/function_id.go
+++ b/pkg/sql/plan/function/function_id.go
@@ -354,6 +354,7 @@ const (
 	VECTOR_DIMS     //VECTOR DIMENSIONS
 	NORMALIZE_L2    //NORMALIZE L2
 	L2_DISTANCE     //L2_DISTANCE
+	L2_DISTANCE_SQ  //L2_DISTANCE
 	COSINE_DISTANCE //COSINE_DISTANCE
 	CLUSTER_CENTERS // CLUSTER_CENTERS
 	SUB_VECTOR      // SUB_VECTOR
@@ -662,6 +663,7 @@ var functionIdRegister = map[string]int32{
 	"vector_dims":       VECTOR_DIMS,
 	"normalize_l2":      NORMALIZE_L2,
 	"l2_distance":       L2_DISTANCE,
+	"l2_distance_sq":    L2_DISTANCE_SQ,
 	"cosine_distance":   COSINE_DISTANCE,
 
 	"python_user_defined_function": PYTHON_UDF,

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -1974,6 +1974,36 @@ var supportedArrayOperations = []FuncNew{
 			},
 		},
 	},
+	// function `l2_distance_sq`
+	{
+		functionId: L2_DISTANCE_SQ,
+		class:      plan.Function_STRICT,
+		layout:     STANDARD_FUNCTION,
+		checkFn:    fixedTypeMatch,
+
+		Overloads: []overload{
+			{
+				overloadId: 0,
+				args:       []types.T{types.T_array_float32, types.T_array_float32},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_float64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return L2DistanceSqArray[float32]
+				},
+			},
+			{
+				overloadId: 1,
+				args:       []types.T{types.T_array_float64, types.T_array_float64},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_float64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return L2DistanceSqArray[float64]
+				},
+			},
+		},
+	},
 	// function `cosine_distance`
 	{
 		functionId: COSINE_DISTANCE,

--- a/pkg/vectorize/moarray/external.go
+++ b/pkg/vectorize/moarray/external.go
@@ -121,6 +121,21 @@ func L2Distance[T types.RealNumbers](v1, v2 []T) (float64, error) {
 	return math.Sqrt(float64(sumOfSquares)), nil
 }
 
+// L2DistanceSq returns the squared L2 distance between two vectors.
+// It is an optimized version of L2Distance used in Index Scan
+func L2DistanceSq[T types.RealNumbers](v1, v2 []T) (float64, error) {
+	if len(v1) != len(v2) {
+		return 0, moerr.NewArrayInvalidOpNoCtx(len(v1), len(v2))
+	}
+	var sumOfSquares T
+	var difference T
+	for i := range v1 {
+		difference = v1[i] - v2[i]
+		sumOfSquares += difference * difference
+	}
+	return float64(sumOfSquares), nil
+}
+
 func CosineDistance[T types.RealNumbers](v1, v2 []T) (float64, error) {
 	cosineSimilarity, err := CosineSimilarity[T](v1, v2)
 	if err != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/16124

## What this PR does / why we need it:

During `KNN Select` and `Mapping Entries to Centroids via CROSS_JOIN_L2`, we can make use of L2DistanceSq instead of L2Distance, as it avoids `Sqrt()`. We can see the improvement in QPS for SIFT128 from 90 to 100. However, for GIST960, the QPS did not change much.

L2DistanceSq is suitable only when there is a comparison (ie Sort). 
- In the case of `CROSS JOIN L2` we find the nearest centroid for the Entry using `L2DistanceSq`. `CROSS JOIN L2` is used in both INSERT and CREATE INDEX.
- In the case of `KNN SELECT`, our query has ORDER BY L2_DISTANCE(...), which can make use of `L2DistanceSq` as the L2Distance value is not explicitly required.

**NOTE:** L2DistanceSq is not suitable in Kmenas++ for Centroid Computation, as it will impact the centroids picked.
