### PR TITLE
fix rollback create table

### DIFF
--- a/pkg/vm/engine/tae/catalog/database.go
+++ b/pkg/vm/engine/tae/catalog/database.go
@@ -447,6 +447,16 @@ func (e *DBEntry) RemoveEntry(table *TableEntry) (err error) {
 			}
 			return true
 		})
+
+		// When Rollback, the last mvcc has already removed
+		fullname := table.GetFullName()
+		nn := e.nameNodes[fullname]
+		if nn != nil {
+			nn.DeleteNode(table.ID)
+			if nn.Length() == 0 {
+				delete(e.nameNodes, fullname)
+			}
+		}
 		e.link.Delete(n)
 		delete(e.entries, table.ID)
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16282

## What this PR does / why we need it:
Fix rollback create table.
When rollback, the last MVCC node has already removed. Remove related name list node with table.FullName.