### PR TITLE
Optimize QueryResult decoupling from motrace in mo1.2

### DIFF
--- a/pkg/frontend/query_result.go
+++ b/pkg/frontend/query_result.go
@@ -48,13 +48,14 @@ func getPathOfQueryResultFile(fileName string) string {
 }
 
 func openSaveQueryResult(ctx context.Context, ses *Session) bool {
-	if ses.ast == nil || ses.tStmt == nil {
+	if ses.ast == nil {
 		return false
 	}
-	if ses.tStmt.SqlSourceType == constant.InternalSql {
+	stmtProfile := ses.GetStmtProfile()
+	if stmtProfile.GetSqlSourceType() == constant.InternalSql {
 		return false
 	}
-	if ses.tStmt.StatementType == "Select" && ses.tStmt.SqlSourceType != constant.CloudUserSql {
+	if stmtProfile.GetStmtType() == "Select" && stmtProfile.GetSqlSourceType() != constant.CloudUserSql {
 		return false
 	}
 	val, err := ses.GetGlobalVar(ctx, "save_query_result")
@@ -107,8 +108,8 @@ func saveQueryResult(ctx context.Context, ses *Session, bat *batch.Batch) error 
 	}
 	fs := getGlobalPu().FileService
 	// write query result
-	path := catalog.BuildQueryResultPath(ses.GetTenantInfo().GetTenant(), uuid.UUID(ses.tStmt.StatementID).String(), ses.GetIncBlockIdx())
-	logInfo(ses, ses.GetDebugString(), "open save query result", zap.String("statemant id is:", uuid.UUID(ses.tStmt.StatementID).String()), zap.String("fileservice name is:", fs.Name()), zap.String("write path is:", path), zap.Float64("current result size:", s))
+	path := catalog.BuildQueryResultPath(ses.GetTenantInfo().GetTenant(), uuid.UUID(ses.GetStmtId()).String(), ses.GetIncBlockIdx())
+	logInfo(ses, ses.GetDebugString(), "open save query result", zap.String("statemant id is:", uuid.UUID(ses.GetStmtId()).String()), zap.String("fileservice name is:", fs.Name()), zap.String("write path is:", path), zap.Float64("current result size:", s))
 	writer, err := objectio.NewObjectWriterSpecial(objectio.WriterQueryResult, path, fs)
 	if err != nil {
 		return err
@@ -135,7 +136,7 @@ func saveQueryResultMeta(ctx context.Context, ses *Session) error {
 		ses.p = nil
 		// TIPs: Session.SetTStmt() do reset the tStmt while query is DONE.
 		// Be careful, if you want to do async op.
-		ses.tStmt = nil
+		// ses.tStmt = nil /* #16028: QueryResult independent of ses.tStmt */
 		ses.curResultSize = 0
 	}()
 	fs := getGlobalPu().FileService
@@ -154,7 +155,7 @@ func saveQueryResultMeta(ctx context.Context, ses *Session) error {
 		if i > 1 {
 			buf.WriteString(prefix)
 		}
-		buf.WriteString(catalog.BuildQueryResultPath(ses.GetTenantInfo().GetTenant(), uuid.UUID(ses.tStmt.StatementID).String(), i))
+		buf.WriteString(catalog.BuildQueryResultPath(ses.GetTenantInfo().GetTenant(), uuid.UUID(ses.GetStmtId()).String(), i))
 	}
 
 	var sp []byte
@@ -170,10 +171,10 @@ func saveQueryResultMeta(ctx context.Context, ses *Session) error {
 		return err
 	}
 	m := &catalog.Meta{
-		QueryId:     ses.tStmt.StatementID,
-		Statement:   ses.tStmt.Statement,
+		QueryId:     ses.GetStmtId(),
+		Statement:   ses.GetSql(),
 		AccountId:   ses.GetTenantInfo().GetTenantID(),
-		RoleId:      ses.tStmt.RoleId,
+		RoleId:      ses.proc.SessionInfo.RoleId,
 		ResultPath:  buf.String(),
 		CreateTime:  types.UnixToTimestamp(ses.createdTime.Unix()),
 		ResultSize:  ses.curResultSize,
@@ -189,7 +190,7 @@ func saveQueryResultMeta(ctx context.Context, ses *Session) error {
 	if err != nil {
 		return err
 	}
-	metaPath := catalog.BuildQueryResultMetaPath(ses.GetTenantInfo().GetTenant(), uuid.UUID(ses.tStmt.StatementID).String())
+	metaPath := catalog.BuildQueryResultMetaPath(ses.GetTenantInfo().GetTenant(), uuid.UUID(ses.GetStmtId()).String())
 	metaWriter, err := objectio.NewObjectWriterSpecial(objectio.WriterQueryResult, metaPath, fs)
 	if err != nil {
 		return err

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -135,7 +135,10 @@ type Session struct {
 
 	isNotBackgroundSession bool
 	lastInsertID           uint64
-	tStmt                  *motrace.StatementInfo
+
+	// tStmt is used only to record the StatementInfo
+	// QueryResult please use feSessionImpl.stmtProfile instead.
+	tStmt *motrace.StatementInfo
 
 	ast tree.Statement
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16028
https://github.com/matrixorigin/MO-Cloud/issues/3084

## What this PR does / why we need it:
ref: https://github.com/matrixorigin/matrixone/pull/16422
changes:
1. QueryResult get query's meta from StmtProfile
    - Session.tStmt is used only to record the StatementInfo.
2. QueryResult runs fine under situation: tStmt is nil.
3. Logutil runs fine if tStmt is nil.