### PR TITLE
[BugFix]: Fix failed BVT query in Secondary Index

### DIFF
--- a/test/distributed/cases/ddl/secondary_index_create.result
+++ b/test/distributed/cases/ddl/secondary_index_create.result
@@ -84,7 +84,7 @@ name    type    column_name
 idx4    MULTIPLE    name
 idx4    MULTIPLE    __mo_alias_id
 drop table if exists t1;
-create table t1(id VARCHAR(255) PRIMARY KEY,name VARCHAR(255),age int, index(name));
+create table t1(id VARCHAR(255) PRIMARY KEY,name VARCHAR(255),age int, index idx5(name));
 insert into t1 values("a","Abby", 24);
 insert into t1 values("b","Bob", 25);
 insert into t1 values("c","Carol", 23);
@@ -95,19 +95,15 @@ b    Bob    25
 c    Carol    23
 show index from t1;
 Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Index_params    Visible    Expression
-t1    1    name    1    name    A    0    NULL    NULL    YES                    YES    NULL
+t1    1    idx5    1    name    A    0    NULL    NULL    YES                    YES    NULL
 t1    0    PRIMARY    1    id    A    0    NULL    NULL                        YES    NULL
 show create table t1;
 Table    Create Table
-t1    CREATE TABLE `t1` (\n  `id` VARCHAR(255) NOT NULL,\n  `name` VARCHAR(255) DEFAULT NULL,\n  `age` INT DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  KEY `name` (`name`)\n)
-select name, type, column_name from mo_catalog.mo_indexes mi where mi.column_name ="name" or mi.column_name="__mo_alias_id";
+t1    CREATE TABLE `t1` (\n  `id` VARCHAR(255) NOT NULL,\n  `name` VARCHAR(255) DEFAULT NULL,\n  `age` INT DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx5` (`name`)\n)
+select name, type, column_name from mo_catalog.mo_indexes mi where name="idx5";
 name    type    column_name
-name    MULTIPLE    name
-name    MULTIPLE    __mo_alias_id
-PRIMARY    PRIMARY    name
-PRIMARY    PRIMARY    name
-name    UNIQUE    name
-name    UNIQUE    name
+idx5    MULTIPLE    name
+idx5    MULTIPLE    __mo_alias_id
 drop table if exists t1;
 create table t1(a double primary key, b int);
 insert into t1 values(1.5,100);

--- a/test/distributed/cases/ddl/secondary_index_create.sql
+++ b/test/distributed/cases/ddl/secondary_index_create.sql
@@ -51,14 +51,14 @@ select name, type, column_name from mo_catalog.mo_indexes mi where name="idx4";
 
 -- 1.e Create Table syntax
 drop table if exists t1;
-create table t1(id VARCHAR(255) PRIMARY KEY,name VARCHAR(255),age int, index(name));
+create table t1(id VARCHAR(255) PRIMARY KEY,name VARCHAR(255),age int, index idx5(name));
 insert into t1 values("a","Abby", 24);
 insert into t1 values("b","Bob", 25);
 insert into t1 values("c","Carol", 23);
 select * from t1;
 show index from t1;
 show create table t1;
-select name, type, column_name from mo_catalog.mo_indexes mi where mi.column_name ="name" or mi.column_name="__mo_alias_id";
+select name, type, column_name from mo_catalog.mo_indexes mi where name="idx5";
 
 -- 1.f Create Secondary Index on PK alone. ie SK = PK.
 drop table if exists t1;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/16427

## What this PR does / why we need it:

Replace 
```sql
select name, type, column_name from mo_catalog.mo_indexes mi where mi.column_name ="name" or mi.column_name="__mo_alias_id";
```
To
```sql
select name, type, column_name from mo_catalog.mo_indexes mi where name="idx5";
```

to match the set of other queries in that BVT file.