### PR TITLE
Fix fifocache evict

### DIFF
--- a/pkg/fileservice/fifocache/queue.go
+++ b/pkg/fileservice/fifocache/queue.go
@@ -84,6 +84,8 @@ func (p *Queue[T]) dequeue() (ret T, ok bool) {
 	}
 
 	ret = p.tail.values[p.tail.begin]
+	var zero T
+	p.tail.values[p.tail.begin] = zero
 	p.tail.begin++
 	ok = true
 	return


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/16443

## What this PR does / why we need it:
When the cache evicts, although the values in cache's shards are deleted, 
there are still references in queue1, so fix.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue in the FIFO cache eviction process where dequeued values were not reset, causing lingering references in the queue.
- Ensured that the dequeued value is set to its zero value after removal.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>queue.go</strong><dd><code>Fix lingering references in FIFO cache eviction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/fifocache/queue.go

<li>Reset the dequeued value to its zero value to ensure no lingering <br>references.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16450/files#diff-d12dc3e07f526032523b1f79c92551e4794b2a6f61b662e766ca4d9464c183de">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

