### PR TITLE
[cherry-pick-16445] : use ctx instead of proc.ctx for rangesOnePart

### DIFF
--- a/pkg/vm/engine/disttae/filter.go
+++ b/pkg/vm/engine/disttae/filter.go
@@ -977,6 +977,7 @@ func CompileFilterExpr(
 }
 
 func TryFastFilterBlocks(
+	ctx context.Context,
 	snapshotTS timestamp.Timestamp,
 	tableDef *plan.TableDef,
 	exprs []*plan.Expr,
@@ -992,6 +993,7 @@ func TryFastFilterBlocks(
 		return false, nil
 	}
 	err = ExecuteBlockFilter(
+		ctx,
 		snapshotTS,
 		fastFilterOp,
 		loadOp,
@@ -1009,6 +1011,7 @@ func TryFastFilterBlocks(
 }
 
 func ExecuteBlockFilter(
+	ctx context.Context,
 	snapshotTS timestamp.Timestamp,
 	fastFilterOp FastFilterOp,
 	loadOp LoadOp,
@@ -1068,7 +1071,7 @@ func ExecuteBlockFilter(
 			if loadOp != nil {
 				loadHit++
 				if meta, bf, err2 = loadOp(
-					proc.Ctx, objStats, meta, bf,
+					ctx, objStats, meta, bf,
 				); err2 != nil {
 					return
 				}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -724,6 +724,7 @@ func (tbl *txnTable) rangesOnePart(
 	var done bool
 
 	if done, err = TryFastFilterBlocks(
+		ctx,
 		tbl.db.op.SnapshotTS(),
 		tbl.tableDef,
 		exprs,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3321

## What this PR does / why we need it:

use ctx instead of proc.ctx for rangesOnePart


___

### **PR Type**
Bug fix


___

### **Description**
- Added `ctx context.Context` parameter to several functions and methods in `filter.go` and `txn_table.go`.
- Replaced usage of `proc.Ctx` with the new `ctx` parameter to ensure proper context handling.
- Updated function and method calls to include the new `ctx` parameter.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filter.go</strong><dd><code>Add context parameter to filter functions and replace proc.Ctx usage</code></dd></summary>
<hr>
      
pkg/vm/engine/disttae/filter.go

<li>Added <code>ctx context.Context</code> parameter to <code>TryFastFilterBlocks</code> and <br><code>ExecuteBlockFilter</code> functions.<br> <li> Replaced usage of <code>proc.Ctx</code> with <code>ctx</code> in <code>ExecuteBlockFilter</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16465/files#diff-72c361bf0d27d0fe7b5cf43fb240c632bd12050ce7ea432075c6e29af161586f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Add context parameter to txnTable methods and update calls</code></dd></summary>
<hr>
      
pkg/vm/engine/disttae/txn_table.go

<li>Added <code>ctx context.Context</code> parameter to <code>rangesOnePart</code> method.<br> <li> Updated call to <code>TryFastFilterBlocks</code> to include the new <code>ctx</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16465/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

