### PR TITLE
making collect dirty blocks lazily.

### DIFF
--- a/pkg/vm/engine/disttae/filter.go
+++ b/pkg/vm/engine/disttae/filter.go
@@ -16,6 +16,8 @@ package disttae
 
 import (
 	"context"
+	"sort"
+
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -30,7 +32,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
-	"sort"
 )
 
 type FastFilterOp func(objectio.ObjectStats) (bool, error)
@@ -1006,12 +1007,6 @@ func TryFastFilterBlocks(
 	if !ok {
 		return false, nil
 	}
-
-	//if highSelectivityHint {
-	//	fmt.Println("has high selectivity", tbl.tableName, plan2.FormatExprs(exprs))
-	//} else {
-	//	fmt.Println("has not high selectivity", tbl.tableName, plan2.FormatExprs(exprs))
-	//}
 
 	err = ExecuteBlockFilter(
 		ctx,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16463

## What this PR does / why we need it:
making the dirty blocks collect lazily.


___

### **PR Type**
Enhancement


___

### **Description**
- Added `highSelectivityHint` parameter to various functions to optimize block filtering.
- Modified `CompileFilterExprs` and `CompileFilterExpr` to handle high selectivity hints for better performance.
- Updated `TryFastFilterBlocks` and `ExecuteBlockFilter` to collect dirty blocks lazily, improving efficiency.
- Adjusted logic in `rangesOnePart` to conditionally collect dirty blocks, ensuring they are only collected when necessary.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filter.go</strong><dd><code>Optimize block filtering with high selectivity hints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/filter.go

<li>Added <code>highSelectivityHint</code> parameter to various functions to optimize <br>filtering.<br> <li> Modified <code>CompileFilterExprs</code> and <code>CompileFilterExpr</code> to handle high <br>selectivity hints.<br> <li> Updated <code>TryFastFilterBlocks</code> and <code>ExecuteBlockFilter</code> to collect dirty <br>blocks lazily.<br> <li> Adjusted logic for handling dirty blocks and high selectivity hints in <br>block filtering.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16482/files#diff-72c361bf0d27d0fe7b5cf43fb240c632bd12050ce7ea432075c6e29af161586f">+56/-25</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Lazy collection of dirty blocks in transaction table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/txn_table.go

<li>Modified <code>rangesOnePart</code> to collect dirty blocks lazily.<br> <li> Updated <code>TryFastFilterBlocks</code> call to pass table reference and handle <br>dirty blocks pointer.<br> <li> Added conditional collection of dirty blocks if not already collected.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16482/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

