### PR TITLE
Support upgrading to skip Genesis version functionality-1.2-dev

### DIFF
--- a/pkg/bootstrap/upgrade.go
+++ b/pkg/bootstrap/upgrade.go
@@ -31,6 +31,14 @@ func (s *service) getFinalVersionHandle() VersionHandle {
 	return s.handles[len(s.handles)-1]
 }
 
+// Get the original version of the upgrade framework
+func (s *service) getFounderVersionHandle() VersionHandle {
+	if len(s.handles) == 0 {
+		panic("Waring: no upgrade version handles available, please check the code")
+	}
+	return s.handles[0]
+}
+
 // GetFinalVersion Get mo final version
 func (s *service) GetFinalVersion() string {
 	return s.handles[len(s.handles)-1].Metadata().Version

--- a/pkg/sql/parsers/tree/stmt.go
+++ b/pkg/sql/parsers/tree/stmt.go
@@ -326,6 +326,10 @@ func (node *ShowDatabases) StmtKind() StmtKind {
 	return defaultResRowTyp
 }
 
+func (node *ShowAccountUpgrade) StmtKind() StmtKind {
+	return defaultResRowTyp
+}
+
 func (node *ShowTables) StmtKind() StmtKind {
 	return defaultResRowTyp
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:
issue #16339
issue #https://github.com/matrixorigin/MO-Cloud/issues/3314

## What this PR does / why we need it:
Support upgrading to skip Genesis version functionality


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced the upgrade framework initialization process to include logging for the founder version.
- Modified the upgrade process to use the founder version handle for creating framework dependencies.
- Added a new function `getFounderVersionHandle` to retrieve the original version handle.
- Added `StmtKind` method for `ShowAccountUpgrade` node in SQL parser.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_upgrade.go</strong><dd><code>Enhance upgrade framework initialization and logging.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/bootstrap/service_upgrade.go

<li>Added logging for founder version during upgrade initialization.<br> <li> Modified to use founder version handle for creating upgrade framework <br>dependencies.<br> <li> Changed error logging to info logging for final version addition.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16486/files#diff-4b6da7148283ba47003cf808e7995c492f42b66480ab464d6d19b9463305c9d4">+11/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>upgrade.go</strong><dd><code>Add function to get founder version handle.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/bootstrap/upgrade.go

<li>Added <code>getFounderVersionHandle</code> function to retrieve the original <br>version handle.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16486/files#diff-2508419c202d65dbdd8d59b5e24d6e747fa415d835b65ced062ad34c70d80b4c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stmt.go</strong><dd><code>Add StmtKind method for ShowAccountUpgrade node.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/parsers/tree/stmt.go

- Added `StmtKind` method for `ShowAccountUpgrade` node.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16486/files#diff-3d4254b1b28fbb954eadeb8bb47183ce92ce493e878638fdabad3e9169880f78">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

