### PR TITLE
fix update stats too late

### DIFF
--- a/pkg/cnservice/distributed_tae.go
+++ b/pkg/cnservice/distributed_tae.go
@@ -69,6 +69,7 @@ func (s *service) initDistributedTAE(
 		hakeeper,
 		s.gossipNode.StatsKeyRouter(),
 		s.cfg.LogtailUpdateStatsThreshold,
+		s.cfg.LogtailUpdateStatsMaxLatency.Duration,
 	)
 	pu.StorageEngine = s.storeEngine
 

--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -266,6 +266,10 @@ type Config struct {
 	// to trigger stats updating.
 	LogtailUpdateStatsThreshold int `toml:"logtail-update-stats-threshold"`
 
+	// LogtailUpdateStatsMaxLatency is the maximum latency threshold
+	// for updating stats.
+	LogtailUpdateStatsMaxLatency toml.Duration `toml:"logtail-update-stats-max-latency"`
+
 	// Whether to automatically upgrade when system startup
 	AutomaticUpgrade       bool `toml:"auto-upgrade"`
 	UpgradeTenantBatchSize int  `toml:"upgrade-tenant-batch"`

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -68,6 +68,7 @@ func New(
 	hakeeper logservice.CNHAKeeperClient,
 	keyRouter client2.KeyRouter[pb.StatsInfoKey],
 	threshold int,
+	maxLatency time.Duration,
 ) *Engine {
 	cluster := clusterservice.GetMOCluster()
 	services := cluster.GetAllTNServices()
@@ -122,6 +123,7 @@ func New(
 
 	e.globalStats = NewGlobalStats(ctx, e, keyRouter,
 		WithLogtailUpdateStatsThreshold(threshold),
+		WithLogtailUpdateStatsMaxLatency(maxLatency),
 	)
 
 	if err := e.init(ctx); err != nil {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2920

## What this PR does / why we need it:

Add max latency for updating stats. Avoid long-term neglect of updating stats.


___

### **PR Type**
Enhancement


___

### **Description**
- Added `LogtailUpdateStatsMaxLatency` parameter to various functions and structs to handle maximum latency for updating stats.
- Introduced a ticker mechanism in `consumeWorker` to trigger updates based on the maximum latency.
- Updated `GlobalStats` methods to incorporate the new max latency configuration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>distributed_tae.go</strong><dd><code>Add max latency parameter to initDistributedTAE function.</code></dd></summary>
<hr>
      
pkg/cnservice/distributed_tae.go

<li>Added <code>LogtailUpdateStatsMaxLatency</code> parameter to the <code>initDistributedTAE</code> <br>function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16506/files#diff-f6e698740fe49564af6e68322725db22f8ed76b887e6024e95f0e1a48a70b7aa">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add max latency field to Config struct.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/cnservice/types.go

- Added `LogtailUpdateStatsMaxLatency` field to the `Config` struct.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16506/files#diff-c56eb6fda22c38dc1c392ffd5c3db229784e540bb03decf970e86b05657f73b7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>engine.go</strong><dd><code>Add max latency parameter to New function.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/engine.go

<li>Added <code>maxLatency</code> parameter to the <code>New</code> function.<br> <li> Passed <code>maxLatency</code> to <code>WithLogtailUpdateStatsMaxLatency</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16506/files#diff-66bacd74568edffe090130ffc5d235b4771a4707612b56145288d4e7119be4a2">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stats.go</strong><dd><code>Add max latency handling to GlobalStats.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/stats.go

<li>Added <code>defaultLogtailUpdateStatsMaxLatency</code> constant.<br> <li> Added <code>LogtailUpdateStatsMaxLatency</code> field to <code>GlobalStatsConfig</code>.<br> <li> Added <code>WithLogtailUpdateStatsMaxLatency</code> option function.<br> <li> Updated <code>GlobalStats</code> struct and methods to handle max latency.<br> <li> Added ticker to <code>consumeWorker</code> for triggering updates based on max <br>latency.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16506/files#diff-d0f8ce84135a062e5992dcb3d1175993ee396beae48de126969255cd9240d02b">+31/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

