### PR TITLE
skip collecting `mo_tables, mo_databases, mo_columns` and cluster tables for non-sys.

### DIFF
--- a/pkg/vm/engine/tae/rpc/handle_debug.go
+++ b/pkg/vm/engine/tae/rpc/handle_debug.go
@@ -114,7 +114,7 @@ func (h *Handle) HandleStorageUsage(ctx context.Context, meta txn.TxnMeta,
 		resp.Sizes = append(resp.Sizes, size)
 	}
 
-	var notReadyNewAcc []uint64
+	//var notReadyNewAcc []uint64
 
 	// new accounts
 	traverseCatalogForNewAccounts(h.db.Catalog, memo, newIds)
@@ -124,9 +124,10 @@ func (h *Handle) HandleStorageUsage(ctx context.Context, meta txn.TxnMeta,
 			resp.AccIds = append(resp.AccIds, int64(newIds[idx]))
 			resp.Sizes = append(resp.Sizes, size)
 			memo.AddReqTrace(uint64(newIds[idx]), size, start, "new, ready")
-		} else {
-			notReadyNewAcc = append(notReadyNewAcc, newIds[idx])
 		}
+		//else {
+		//	notReadyNewAcc = append(notReadyNewAcc, newIds[idx])
+		//}
 	}
 
 	memo.ClearNewAccCache()

--- a/pkg/vm/engine/tae/rpc/handle_debug.go
+++ b/pkg/vm/engine/tae/rpc/handle_debug.go
@@ -84,7 +84,8 @@ func (h *Handle) HandleStorageUsage(ctx context.Context, meta txn.TxnMeta,
 		memo.LeaveProcessing()
 	}()
 
-	specialSize := memo.GatherSpecialTableSize()
+	//specialSize := memo.GatherSpecialTableSize()
+	specialSize := uint64(0)
 	usages := memo.GatherAllAccSize()
 	for accId := range usages {
 		if accId != uint64(catalog.System_Account) {
@@ -130,11 +131,11 @@ func (h *Handle) HandleStorageUsage(ctx context.Context, meta txn.TxnMeta,
 
 	memo.ClearNewAccCache()
 
-	for idx := range notReadyNewAcc {
-		resp.AccIds = append(resp.AccIds, int64(notReadyNewAcc[idx]))
-		resp.Sizes = append(resp.Sizes, specialSize)
-		memo.AddReqTrace(uint64(newIds[idx]), specialSize, start, " new, not ready, only special")
-	}
+	//for idx := range notReadyNewAcc {
+	//	resp.AccIds = append(resp.AccIds, int64(notReadyNewAcc[idx]))
+	//	resp.Sizes = append(resp.Sizes, specialSize)
+	//	memo.AddReqTrace(uint64(newIds[idx]), specialSize, start, "new, not ready, only special")
+	//}
 
 	resp.Succeed = true
 


### PR DESCRIPTION
### **User description**

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16419

## What this PR does / why we need it:
skip collecting `mo_tables, mo_databases, mo_columns` and cluster tables for non-sys when `mo_table_size, mo_table_rows and show accounts`.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `specialTableFilterForNonSys` function to filter out `mo_tables`, `mo_databases`, `mo_columns`, and cluster tables for non-sys accounts.
- Removed unnecessary account switching logic for cluster tables in `MoTableRows` and `MoTableSize` functions.
- Replaced context `ctx` with `foolCtx` for database operations to ensure proper context handling.
- Simplified logic for handling partitioned tables in `MoTableRows`.
- Commented out the gathering of special table sizes in `HandleStorageUsage` to prevent incorrect size calculations.
- Disabled handling of special sizes for new accounts that are not ready in `HandleStorageUsage`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>func_mo.go</strong><dd><code>Filter special tables for non-sys accounts and simplify context </code><br><code>handling</code></dd></summary>
<hr>
      
pkg/sql/plan/function/func_mo.go

<li>Added <code>specialTableFilterForNonSys</code> function to filter special tables <br>for non-sys accounts.<br> <li> Removed account switching logic for cluster tables.<br> <li> Replaced context <code>ctx</code> with <code>foolCtx</code> for database operations.<br> <li> Simplified logic for handling partitioned tables.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16512/files#diff-b553fa8d20dd9d505e58e3272ad74d359a50ce56152e523c8886ef1316b14ed9">+45/-30</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handle_debug.go</strong><dd><code>Disable special table size handling in storage usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/rpc/handle_debug.go

<li>Commented out the gathering of special table sizes.<br> <li> Disabled handling of special sizes for new accounts not ready.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16512/files#diff-84a35de8da537271fc3642ed0a8d1f4615d2dc52e687074464abfe904742badf">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

