### PR TITLE
add hidden force option for objprune 1.2

### DIFF
--- a/pkg/vm/engine/tae/db/dbutils/mem.go
+++ b/pkg/vm/engine/tae/db/dbutils/mem.go
@@ -120,9 +120,10 @@ func PrintMemStats() {
 		heapp.WriteTo(buf, 0)
 		mlimit := debug.SetMemoryLimit(-1)
 		log := buf.Bytes()
-		for len(log) > 200*1024 {
-			logutil.Info(base64.RawStdEncoding.EncodeToString(log[:200*1024]))
-			log = log[200*1024:]
+		chunkSize := 150 * 1024
+		for len(log) > chunkSize {
+			logutil.Info(base64.RawStdEncoding.EncodeToString(log[:chunkSize]))
+			log = log[chunkSize:]
 		}
 		logutil.Info(
 			base64.RawStdEncoding.EncodeToString(log),


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3199

## What this PR does / why we need it:

add -f option to execute pruning without ack


___

### **PR Type**
Enhancement


___

### **Description**
- Added a `force` flag to the `objectPruneArg` struct and the corresponding command to allow forced pruning without acknowledgment.
- Adjusted the log chunk size from 200KB to 150KB in the `PrintMemStats` function for better memory stats logging.
- Refactored the `executePrune` method to accept a list of objects as a parameter instead of using a task cache.
- Improved the formatting of response payloads to handle multiple lines more gracefully.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mem.go</strong><dd><code>Adjust log chunk size for memory stats logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/db/dbutils/mem.go

<li>Changed log chunk size from 200KB to 150KB for memory stats logging.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16514/files#diff-42521fe099284de2587d3fbf19d9b3282741c053402a91197dbe2e70ec667a30">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inspect.go</strong><dd><code>Add force flag and refactor object pruning logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/rpc/inspect.go

<li>Added <code>force</code> flag to <code>objectPruneArg</code> struct and command.<br> <li> Implemented logic to handle <code>force</code> flag in pruning process.<br> <li> Refactored <code>executePrune</code> method to accept objects as a parameter.<br> <li> Improved response payload formatting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16514/files#diff-a7350916eefe8e5ceea15f65874fa0f87b7e68c2127ea19dd0ce33b5520ccf5f">+55/-34</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

