### PR TITLE
fix lock service ut

### DIFF
--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -1317,7 +1317,7 @@ func TestWaiterAwakeOnDeadLock(t *testing.T) {
 					}
 					t2.Unlock()
 
-					require.NoError(t, s.Unlock(ctx, txn1, timestamp.Timestamp{}))
+					require.NoError(t, s.Unlock(ctx, txn2, timestamp.Timestamp{}))
 					for {
 						t3 := lt.txnHolder.getActiveTxn(txn3, false, "")
 						t3.Lock()
@@ -1368,6 +1368,7 @@ func TestLockSuccWithKeepBindTimeout(t *testing.T) {
 				[]byte("txn1"),
 				option)
 			require.NoError(t, err)
+			require.NoError(t, l.Unlock(ctx, []byte("txn1"), timestamp.Timestamp{}))
 
 			for i := 0; i < 10; i++ {
 				p := alloc.GetLatest(0, 0)

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -1322,6 +1322,7 @@ func TestWaiterAwakeOnDeadLock(t *testing.T) {
 						t3 := lt.txnHolder.getActiveTxn(txn3, false, "")
 						t3.Lock()
 						if len(t3.getHoldLocksLocked(0).tableBinds) > 0 {
+							t3.Unlock()
 							break
 						}
 						t3.Unlock()
@@ -1347,7 +1348,7 @@ func TestLockSuccWithKeepBindTimeout(t *testing.T) {
 		t,
 		zapcore.DebugLevel,
 		[]string{"s1"},
-		time.Millisecond,
+		time.Millisecond*200,
 		func(alloc *lockTableAllocator, s []*service) {
 			l := s[0]
 
@@ -1657,7 +1658,7 @@ func TestReLockSuccWithKeepBindTimeout(t *testing.T) {
 		t,
 		zapcore.DebugLevel,
 		[]string{"s1", "s2"},
-		time.Millisecond,
+		time.Millisecond*200,
 		func(alloc *lockTableAllocator, s []*service) {
 			l1 := s[0]
 			l2 := s[1]


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15757 

## What this PR does / why we need it:

fix lock service ut


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Reduced timeout durations from seconds to milliseconds to speed up test execution.
- Replaced `time.Sleep` calls with loops that check conditions to improve test reliability.
- Added additional assertions to ensure the lock service functions correctly under various conditions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_test.go</strong><dd><code>Improve reliability and speed of lock service unit tests</code>&nbsp; </dd></summary>
<hr>
      
pkg/lockservice/service_test.go

<li>Reduced timeout durations to milliseconds for faster test execution.<br> <li> Replaced sleep calls with loops checking conditions for more reliable <br>tests.<br> <li> Added additional assertions to ensure proper functionality.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16518/files#diff-e94812797c8b26ff0499bd86698dbc4371dd72642267baa535a7ecc7f8bf3981">+18/-22</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

