### PR TITLE
fix collecting dirty block lazily.

### DIFF
--- a/pkg/vm/engine/disttae/filter.go
+++ b/pkg/vm/engine/disttae/filter.go
@@ -677,7 +677,7 @@ func CompileFilterExpr(
 				return
 			}
 			colDef := getColDefByName(colExpr.Col.Name, tableDef)
-			isPK, isSorted := isSortedKey(colDef)
+			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj objectio.ObjectStats) (bool, error) {
 					if obj.ZMIsEmpty() {
@@ -686,8 +686,6 @@ func CompileFilterExpr(
 					return obj.SortKeyZoneMap().PrefixEq(vals[0]), nil
 				}
 			}
-
-			highSelectivityHint = isPK
 
 			loadOp = loadMetadataOnlyOpFactory(fs)
 			seqNum := colDef.Seqnum
@@ -788,7 +786,7 @@ func CompileFilterExpr(
 					return obj.SortKeyZoneMap().PrefixIn(vec), nil
 				}
 			}
-			highSelectivityHint = isSorted
+
 			loadOp = loadMetadataOnlyOpFactory(fs)
 			seqNum := colDef.Seqnum
 			objectFilterOp = func(meta objectio.ObjectMeta, _ objectio.BloomFilter) (bool, error) {
@@ -873,8 +871,6 @@ func CompileFilterExpr(
 			} else {
 				loadOp = loadMetadataOnlyOpFactory(fs)
 			}
-
-			highSelectivityHint = isSorted
 
 			seqNum := colDef.Seqnum
 			objectFilterOp = func(meta objectio.ObjectMeta, _ objectio.BloomFilter) (bool, error) {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16463

## What this PR does / why we need it:
skip collecting dirty blks only when `=`, or in and prefix_in a small set.


___

### **PR Type**
Enhancement


___

### **Description**
- Improved the performance of composite index selection by modifying the logic for setting `highSelectivityHint`.
- Changed the condition for `highSelectivityHint` to use logical OR instead of AND in some cases.
- Updated the handling of primary keys (`isPK`) and sorted keys to optimize performance.
- Adjusted the condition for `highSelectivityHint` to consider vector length for better efficiency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filter.go</strong><dd><code>Improve filter expression compilation for better performance</code></dd></summary>
<hr>
      
pkg/vm/engine/disttae/filter.go

<li>Changed the logic for setting <code>highSelectivityHint</code> in multiple places.<br> <li> Modified conditions for <code>highSelectivityHint</code> to improve performance.<br> <li> Updated the handling of primary keys and sorted keys.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16525/files#diff-72c361bf0d27d0fe7b5cf43fb240c632bd12050ce7ea432075c6e29af161586f">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

