### PR TITLE
sync to 1.2: making collect dirty blocks lazily

### DIFF
--- a/pkg/vm/engine/disttae/filter.go
+++ b/pkg/vm/engine/disttae/filter.go
@@ -677,7 +677,7 @@ func CompileFilterExpr(
 				return
 			}
 			colDef := getColDefByName(colExpr.Col.Name, tableDef)
-			isPK, isSorted := isSortedKey(colDef)
+			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj objectio.ObjectStats) (bool, error) {
 					if obj.ZMIsEmpty() {
@@ -686,8 +686,6 @@ func CompileFilterExpr(
 					return obj.SortKeyZoneMap().PrefixEq(vals[0]), nil
 				}
 			}
-
-			highSelectivityHint = isPK
 
 			loadOp = loadMetadataOnlyOpFactory(fs)
 			seqNum := colDef.Seqnum
@@ -788,7 +786,7 @@ func CompileFilterExpr(
 					return obj.SortKeyZoneMap().PrefixIn(vec), nil
 				}
 			}
-			highSelectivityHint = isSorted
+
 			loadOp = loadMetadataOnlyOpFactory(fs)
 			seqNum := colDef.Seqnum
 			objectFilterOp = func(meta objectio.ObjectMeta, _ objectio.BloomFilter) (bool, error) {
@@ -873,8 +871,6 @@ func CompileFilterExpr(
 			} else {
 				loadOp = loadMetadataOnlyOpFactory(fs)
 			}
-
-			highSelectivityHint = isSorted
 
 			seqNum := colDef.Seqnum
 			objectFilterOp = func(meta objectio.ObjectMeta, _ objectio.BloomFilter) (bool, error) {

--- a/pkg/vm/engine/disttae/filter.go
+++ b/pkg/vm/engine/disttae/filter.go
@@ -16,6 +16,8 @@ package disttae
 
 import (
 	"context"
+	"sort"
+
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -30,7 +32,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
-	"sort"
 )
 
 type FastFilterOp func(objectio.ObjectStats) (bool, error)
@@ -1006,12 +1007,6 @@ func TryFastFilterBlocks(
 	if !ok {
 		return false, nil
 	}
-
-	//if highSelectivityHint {
-	//	fmt.Println("has high selectivity", tbl.tableName, plan2.FormatExprs(exprs))
-	//} else {
-	//	fmt.Println("has not high selectivity", tbl.tableName, plan2.FormatExprs(exprs))
-	//}
 
 	err = ExecuteBlockFilter(
 		ctx,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16463

## What this PR does / why we need it:
making the dirty blocks collect lazily.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `highSelectivityHint` parameter to several functions to improve filtering performance.
- Modified `CompileFilterExprs` and `CompileFilterExpr` to handle `highSelectivityHint`.
- Updated `TryFastFilterBlocks` and `ExecuteBlockFilter` to use `highSelectivityHint`.
- Changed `dirtyBlocks` from a map to a pointer to a map for lazy collection.
- Modified `rangesOnePart` in `txn_table.go` to collect dirty blocks lazily.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filter.go</strong><dd><code>Improve filter performance with high selectivity hint</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/filter.go

<li>Added <code>highSelectivityHint</code> parameter to several functions to improve <br>filtering performance.<br> <li> Modified <code>CompileFilterExprs</code> and <code>CompileFilterExpr</code> to handle <br><code>highSelectivityHint</code>.<br> <li> Updated <code>TryFastFilterBlocks</code> and <code>ExecuteBlockFilter</code> to use <br><code>highSelectivityHint</code>.<br> <li> Changed <code>dirtyBlocks</code> from a map to a pointer to a map for lazy <br>collection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16527/files#diff-72c361bf0d27d0fe7b5cf43fb240c632bd12050ce7ea432075c6e29af161586f">+49/-24</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Collect dirty blocks lazily in txnTable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/txn_table.go

<li>Modified <code>rangesOnePart</code> to collect dirty blocks lazily.<br> <li> Updated <code>TryFastFilterBlocks</code> call to pass a pointer to <code>dirtyBlks</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16527/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

