### PR TITLE
Remove releaseFuncs.

### DIFF
--- a/pkg/fileservice/aliyun_sdk.go
+++ b/pkg/fileservice/aliyun_sdk.go
@@ -386,7 +386,7 @@ func (a *AliyunSDK) putObject(
 	ctx context.Context,
 	key string,
 	r io.Reader,
-	size int64,
+	_ int64, // size is not used
 	expire *time.Time,
 ) (err error) {
 	defer catch(&err)
@@ -512,7 +512,7 @@ func (a *AliyunSDK) is404(err error) bool {
 }
 
 func (o ObjectStorageArguments) credentialProviderForAliyunSDK(
-	ctx context.Context,
+	_ context.Context, // ctx is not used
 ) (ret oss.CredentialsProvider, err error) {
 
 	defer func() {

--- a/pkg/fileservice/file_service.go
+++ b/pkg/fileservice/file_service.go
@@ -139,7 +139,7 @@ type IOEntry struct {
 
 	allocator CacheDataAllocator
 
-	releaseFuncs []func()
+	releaseFunc func()
 }
 
 func (i IOEntry) String() string {

--- a/pkg/fileservice/io_entry.go
+++ b/pkg/fileservice/io_entry.go
@@ -53,9 +53,10 @@ func (i *IOEntry) ReadFromOSFile(file *os.File) error {
 	if cap(i.Data) < int(i.Size) {
 		ptr, dec := getMallocAllocator().Allocate(uint64(i.Size))
 		i.Data = unsafe.Slice((*byte)(ptr), i.Size)
-		i.releaseFuncs = append(i.releaseFuncs, func() {
-			dec.Deallocate(ptr)
-		})
+		if i.releaseFunc != nil {
+			i.releaseFunc()
+		}
+		i.releaseFunc = func() { dec.Deallocate(ptr) }
 	} else {
 		i.Data = i.Data[:i.Size]
 	}

--- a/pkg/fileservice/io_vector.go
+++ b/pkg/fileservice/io_vector.go
@@ -30,8 +30,8 @@ func (i *IOVector) Release() {
 		if entry.CachedData != nil {
 			entry.CachedData.Release()
 		}
-		for _, fn := range entry.releaseFuncs {
-			fn()
+		if entry.releaseFunc != nil {
+			entry.releaseFunc()
 		}
 	}
 }

--- a/pkg/fileservice/local_etl_fs.go
+++ b/pkg/fileservice/local_etl_fs.go
@@ -462,7 +462,9 @@ func (l *LocalETLFS) Delete(ctx context.Context, filePaths ...string) error {
 	return nil
 }
 
-func (l *LocalETLFS) deleteSingle(ctx context.Context, filePath string) error {
+func (l *LocalETLFS) deleteSingle(
+	_ context.Context, // ctx is not used
+	filePath string) error {
 	path, err := ParsePathAtService(filePath, l.name)
 	if err != nil {
 		return err

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -603,9 +603,10 @@ func (l *LocalFS) read(ctx context.Context, vector *IOVector, bytesCounter *atom
 				if int64(len(entry.Data)) < entry.Size {
 					ptr, dec := getMallocAllocator().Allocate(uint64(entry.Size))
 					entry.Data = unsafe.Slice((*byte)(ptr), entry.Size)
-					entry.releaseFuncs = append(entry.releaseFuncs, func() {
-						dec.Deallocate(ptr)
-					})
+					if entry.releaseFunc != nil {
+						entry.releaseFunc()
+					}
+					entry.releaseFunc = func() { dec.Deallocate(ptr) }
 				}
 				var n int
 				n, err = io.ReadFull(r, entry.Data)

--- a/pkg/fileservice/memory_fs.go
+++ b/pkg/fileservice/memory_fs.go
@@ -331,7 +331,9 @@ func (m *MemoryFS) Delete(ctx context.Context, filePaths ...string) error {
 	return nil
 }
 
-func (m *MemoryFS) deleteSingle(ctx context.Context, filePath string) error {
+func (m *MemoryFS) deleteSingle(
+	_ context.Context, // ctx not used
+	filePath string) error {
 
 	path, err := ParsePathAtService(filePath, m.name)
 	if err != nil {

--- a/pkg/fileservice/minio_sdk.go
+++ b/pkg/fileservice/minio_sdk.go
@@ -474,7 +474,7 @@ func (a *MinioSDK) putObject(
 	key string,
 	r io.Reader,
 	size int64,
-	expire *time.Time,
+	_ *time.Time, // expire not used
 ) (minio.UploadInfo, error) {
 	ctx, task := gotrace.NewTask(ctx, "MinioSDK.putObject")
 	defer task.End()
@@ -493,7 +493,10 @@ func (a *MinioSDK) putObject(
 	)
 }
 
-func (a *MinioSDK) getObject(ctx context.Context, key string, min *int64, max *int64) (io.ReadCloser, error) {
+func (a *MinioSDK) getObject(
+	ctx context.Context, key string, min *int64,
+	_ *int64, // max not used
+) (io.ReadCloser, error) {
 	ctx, task := gotrace.NewTask(ctx, "MinioSDK.getObject")
 	defer task.End()
 	perfcounter.Update(ctx, func(counter *perfcounter.CounterSet) {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #16529

## What this PR does / why we need it:

Release memory as soon as possible.

___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Removed unused parameters in various functions across multiple files and added comments to indicate unused parameters.
- Simplified release function handling by replacing `releaseFuncs` slice with a single `releaseFunc` in `IOEntry` and `IOVector`.
- Updated memory deallocation logic to use a single `releaseFunc` in `IOEntry` and `LocalFS`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aliyun_sdk.go</strong><dd><code>Remove unused parameters and add comments in Aliyun SDK.</code>&nbsp; </dd></summary>
<hr>
      
pkg/fileservice/aliyun_sdk.go

<li>Removed unused parameters in <code>putObject</code> and <br><code>credentialProviderForAliyunSDK</code> functions.<br> <li> Added comments to indicate unused parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16528/files#diff-53c458acf1a3339cd979fff55fe0f53e01073eadae1e21b997ff1933461b6539">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>file_service.go</strong><dd><code>Simplify release function handling in IOEntry.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/file_service.go

- Replaced `releaseFuncs` slice with a single `releaseFunc`.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16528/files#diff-cba83fb4b16d96a27458ce6152cd5e35784deca1afadd1a9a3872ed0c91465e2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>io_entry.go</strong><dd><code>Update memory deallocation logic in IOEntry.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/io_entry.go

- Updated memory deallocation logic to use a single `releaseFunc`.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16528/files#diff-5cd70a296d2136384584d0a9b3b18a9c04768f6861cc802417dd5482ccb4c61e">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>io_vector.go</strong><dd><code>Simplify release function handling in IOVector.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/io_vector.go

<li>Updated <code>Release</code> method to use a single <code>releaseFunc</code> instead of a slice.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16528/files#diff-195c89ef7787f2e24037b7f95e2f657a6ad63d224bba61dbe38f971dbfa437ed">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>local_etl_fs.go</strong><dd><code>Remove unused context parameter in LocalETLFS.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/local_etl_fs.go

<li>Removed unused <code>ctx</code> parameter in <code>deleteSingle</code> function.<br> <li> Added comment to indicate unused parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16528/files#diff-b90ba633569254a43a06fc9b92ac8ee188015de63840e78b57c7fb4749ed9511">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>local_fs.go</strong><dd><code>Update memory deallocation logic in LocalFS.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/local_fs.go

- Updated memory deallocation logic to use a single `releaseFunc`.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16528/files#diff-bc086aa870f34585ab047b49edf44e6b55699be741653321dcf574b4bc5d1b00">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>memory_fs.go</strong><dd><code>Remove unused context parameter in MemoryFS.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/memory_fs.go

<li>Removed unused <code>ctx</code> parameter in <code>deleteSingle</code> function.<br> <li> Added comment to indicate unused parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16528/files#diff-598e3259be29bc1b460a4a6af62ce0dd6a267bb32aff38ef84dcea6ebb3ea357">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>minio_sdk.go</strong><dd><code>Remove unused parameters and add comments in Minio SDK.</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/minio_sdk.go

<li>Removed unused parameters in <code>putObject</code> and <code>getObject</code> functions.<br> <li> Added comments to indicate unused parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16528/files#diff-0205f479990293595ed646b9bb0b66a697951d629b522d0c1ae2f9300117826c">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

