### PR TITLE
fileservice: add IOVector.prepareData

### DIFF
--- a/pkg/fileservice/file_service.go
+++ b/pkg/fileservice/file_service.go
@@ -105,7 +105,8 @@ type IOEntry struct {
 
 	// raw content
 	// when reading, if len(Data) < Size, a new Size-lengthed byte slice will be allocated
-	Data []byte
+	Data        []byte
+	releaseData func()
 
 	// when reading, if Writer is not nil, write data to it instead of setting Data field
 	WriterForRead io.Writer
@@ -138,8 +139,6 @@ type IOEntry struct {
 	fromCache IOVectorCache
 
 	allocator CacheDataAllocator
-
-	releaseFuncs []func()
 }
 
 func (i IOEntry) String() string {

--- a/pkg/fileservice/io_entry.go
+++ b/pkg/fileservice/io_entry.go
@@ -47,19 +47,10 @@ func (i *IOEntry) setCachedData() error {
 	return nil
 }
 
-func (i *IOEntry) ReadFromOSFile(file *os.File) error {
+func (i *IOEntry) ReadFromOSFile(file *os.File) (err error) {
+	finally := i.prepareData()
+	defer finally(&err)
 	r := io.LimitReader(file, i.Size)
-
-	if cap(i.Data) < int(i.Size) {
-		ptr, dec := getMallocAllocator().Allocate(uint64(i.Size))
-		i.Data = unsafe.Slice((*byte)(ptr), i.Size)
-		i.releaseFuncs = append(i.releaseFuncs, func() {
-			dec.Deallocate(ptr)
-		})
-	} else {
-		i.Data = i.Data[:i.Size]
-	}
-
 	n, err := io.ReadFull(r, i.Data)
 	if err != nil {
 		return err
@@ -96,3 +87,29 @@ func CacheOriginalData(r io.Reader, data []byte, allocator CacheDataAllocator) (
 	copy(cacheData.Bytes(), data)
 	return
 }
+
+func (i *IOEntry) prepareData() (finally func(err *error)) {
+	if cap(i.Data) < int(i.Size) {
+		ptr, dec := getMallocAllocator().Allocate(uint64(i.Size))
+		i.Data = unsafe.Slice((*byte)(ptr), i.Size)
+		if i.releaseData != nil {
+			i.releaseData()
+		}
+		i.releaseData = func() {
+			dec.Deallocate(ptr)
+		}
+		finally = func(err *error) {
+			if err != nil && *err != nil {
+				dec.Deallocate(ptr)
+			}
+		}
+
+	} else {
+		i.Data = i.Data[:i.Size]
+		finally = noopFinally
+	}
+
+	return
+}
+
+func noopFinally(*error) {}

--- a/pkg/fileservice/io_vector.go
+++ b/pkg/fileservice/io_vector.go
@@ -30,8 +30,8 @@ func (i *IOVector) Release() {
 		if entry.CachedData != nil {
 			entry.CachedData.Release()
 		}
-		for _, fn := range entry.releaseFuncs {
-			fn()
+		if entry.releaseData != nil {
+			entry.releaseData()
 		}
 	}
 }

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -29,7 +29,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memorycache"
@@ -600,13 +599,8 @@ func (l *LocalFS) read(ctx context.Context, vector *IOVector, bytesCounter *atom
 				entry.Size = int64(len(data))
 
 			} else {
-				if int64(len(entry.Data)) < entry.Size {
-					ptr, dec := getMallocAllocator().Allocate(uint64(entry.Size))
-					entry.Data = unsafe.Slice((*byte)(ptr), entry.Size)
-					entry.releaseFuncs = append(entry.releaseFuncs, func() {
-						dec.Deallocate(ptr)
-					})
-				}
+				finally := entry.prepareData()
+				defer finally(&err)
 				var n int
 				n, err = io.ReadFull(r, entry.Data)
 				if err != nil {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16379 

## What this PR does / why we need it:
deallocate when error


___

### **PR Type**
Bug fix


___

### **Description**
- Added `releaseData` function to `IOEntry` struct and removed `releaseFuncs` slice.
- Implemented `prepareData` function in `IOEntry` to handle data allocation and deallocation with error handling.
- Updated `ReadFromOSFile` method to use `prepareData` for better error handling.
- Modified `Release` method in `IOVector` to use `releaseData` instead of `releaseFuncs`.
- Updated `read` method in `LocalFS` to use `prepareData` for error handling, removing manual allocation and deallocation logic.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>file_service.go</strong><dd><code>Add releaseData function and remove releaseFuncs slice in IOEntry </code><br><code>struct</code></dd></summary>
<hr>
      
pkg/fileservice/file_service.go

<li>Added <code>releaseData</code> function to <code>IOEntry</code> struct.<br> <li> Removed <code>releaseFuncs</code> slice from <code>IOEntry</code> struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16532/files#diff-cba83fb4b16d96a27458ce6152cd5e35784deca1afadd1a9a3872ed0c91465e2">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>io_entry.go</strong><dd><code>Implement prepareData function for error handling in IOEntry</code></dd></summary>
<hr>
      
pkg/fileservice/io_entry.go

<li>Modified <code>ReadFromOSFile</code> to use <code>prepareData</code> for error handling.<br> <li> Added <code>prepareData</code> function to handle data allocation and deallocation.<br> <li> Added <code>noopFinally</code> function as a no-operation finalizer.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16532/files#diff-5cd70a296d2136384584d0a9b3b18a9c04768f6861cc802417dd5482ccb4c61e">+29/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>io_vector.go</strong><dd><code>Update Release method to use releaseData in IOVector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/io_vector.go

<li>Updated <code>Release</code> method to use <code>releaseData</code> instead of <code>releaseFuncs</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16532/files#diff-195c89ef7787f2e24037b7f95e2f657a6ad63d224bba61dbe38f971dbfa437ed">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>local_fs.go</strong><dd><code>Use prepareData for error handling in LocalFS read method</code></dd></summary>
<hr>
      
pkg/fileservice/local_fs.go

<li>Modified <code>read</code> method to use <code>prepareData</code> for error handling.<br> <li> Removed manual allocation and deallocation logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16532/files#diff-bc086aa870f34585ab047b49edf44e6b55699be741653321dcf574b4bc5d1b00">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

