### PR TITLE
chore: make sure no aggr in bvt result_count

### DIFF
--- a/test/distributed/cases/result_count/result_count.result
+++ b/test/distributed/cases/result_count/result_count.result
@@ -8,7 +8,7 @@ commit;
 create database db1;
 use db1;
 create table t1(a int, b varchar);
-insert into t1 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e');
+/* cloud_user */insert into t1 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e');
 update t1 set b='xx' where a=5;
 update t1 set b='yy' where a=1;
 select * from t1;

--- a/test/distributed/cases/result_count/result_count.sql
+++ b/test/distributed/cases/result_count/result_count.sql
@@ -15,7 +15,8 @@ commit;
 create database db1;
 use db1;
 create table t1(a int, b varchar);
-insert into t1 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e');
+-- issue 16,530: ensure 'insert into t1 ...' and 'insert into t2 ...' NOT Aggred.
+/* cloud_user */insert into t1 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e');
 update t1 set b='xx' where a=5;
 update t1 set b='yy' where a=1;
 select * from t1;

--- a/test/distributed/cases/zz_statement_query_type/result_count.result
+++ b/test/distributed/cases/zz_statement_query_type/result_count.result
@@ -1,6 +1,6 @@
 use system;
 set @case_name="case1";
-select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' and length(statement) > 0 and status != 'Running' and aggr_count < 1 order by request_at desc limit 50;
+select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' and length(statement) > 0 and status != 'Running' and aggr_count < 1 order by request_at desc limit 52;
 statement    result_count
 use system    0
 values row(1,1), row(2,2), row(3,3) order by column_0 desc    3
@@ -17,6 +17,7 @@ use db2    0
 create database db2    0
 drop database db2    0
 commit    0
+insert into t2 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e')    0
 begin    0
 create table t2(a int, b varchar)    0
 use db2    0
@@ -46,6 +47,7 @@ prepare s1 from "select * from t1 where a>?"    0
 set @a=1    0
 create view v2 as select * from t1 limit 1    0
 create view v1 as select * from t1    0
+insert into t1 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e')    0
 create table t1(a int, b varchar)    0
 use db1    0
 create database db1    0

--- a/test/distributed/cases/zz_statement_query_type/result_count.sql
+++ b/test/distributed/cases/zz_statement_query_type/result_count.sql
@@ -8,7 +8,7 @@ use system;
 --     So the statement_info.statement for 'select (select 1) from dual' only is empty string.
 --     ==> NEED condition filter: length(statement) > 0
 set @case_name="case1";
-select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' and length(statement) > 0 and status != 'Running' and aggr_count < 1 order by request_at desc limit 50;
+select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' and length(statement) > 0 and status != 'Running' and aggr_count < 1 order by request_at desc limit 52;
 
 -- check case 2
 set @case_name="case2";


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/14836, https://github.com/matrixorigin/matrixone/issues/16530

## What this PR does / why we need it:
changes:
1. use hint `/*cloud_user*/` mark query DO NOT aggr.