### PR TITLE
chore: make sure no aggr in bvt result_count in 1.2

### DIFF
--- a/test/distributed/cases/result_count/result_count.result
+++ b/test/distributed/cases/result_count/result_count.result
@@ -8,7 +8,7 @@ commit;
 create database db1;
 use db1;
 create table t1(a int, b varchar);
-insert into t1 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e');
+/* cloud_user */insert into t1 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e');
 update t1 set b='xx' where a=5;
 update t1 set b='yy' where a=1;
 select * from t1;

--- a/test/distributed/cases/result_count/result_count.sql
+++ b/test/distributed/cases/result_count/result_count.sql
@@ -15,7 +15,8 @@ commit;
 create database db1;
 use db1;
 create table t1(a int, b varchar);
-insert into t1 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e');
+-- issue 16,530: ensure 'insert into t1 ...' and 'insert into t2 ...' NOT Aggred.
+/* cloud_user */insert into t1 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e');
 update t1 set b='xx' where a=5;
 update t1 set b='yy' where a=1;
 select * from t1;

--- a/test/distributed/cases/zz_statement_query_type/result_count.result
+++ b/test/distributed/cases/zz_statement_query_type/result_count.result
@@ -1,6 +1,6 @@
 use system;
 set @case_name="case1";
-select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' and length(statement) > 0 and status != 'Running' and aggr_count < 1 order by request_at desc limit 50;
+select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' and length(statement) > 0 and status != 'Running' and aggr_count < 1 order by request_at desc limit 52;
 statement    result_count
 use system    0
 values row(1,1), row(2,2), row(3,3) order by column_0 desc    3
@@ -17,6 +17,7 @@ use db2    0
 create database db2    0
 drop database db2    0
 commit    0
+insert into t2 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e')    0
 begin    0
 create table t2(a int, b varchar)    0
 use db2    0
@@ -46,6 +47,7 @@ prepare s1 from "select * from t1 where a>?"    0
 set @a=1    0
 create view v2 as select * from t1 limit 1    0
 create view v1 as select * from t1    0
+insert into t1 values (1, 'a'),(1, 'b'),(3, 'c'),(4,'d'),(5,'e')    0
 create table t1(a int, b varchar)    0
 use db1    0
 create database db1    0

--- a/test/distributed/cases/zz_statement_query_type/result_count.sql
+++ b/test/distributed/cases/zz_statement_query_type/result_count.sql
@@ -8,7 +8,7 @@ use system;
 --     So the statement_info.statement for 'select (select 1) from dual' only is empty string.
 --     ==> NEED condition filter: length(statement) > 0
 set @case_name="case1";
-select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' and length(statement) > 0 and status != 'Running' and aggr_count < 1 order by request_at desc limit 50;
+select statement, result_count from statement_info where account="bvt_result_count" and statement not like '%mo_ctl%' and length(statement) > 0 and status != 'Running' and aggr_count < 1 order by request_at desc limit 52;
 
 -- check case 2
 set @case_name="case2";


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/14836, https://github.com/matrixorigin/matrixone/issues/16530

## What this PR does / why we need it:
ref: https://github.com/matrixorigin/matrixone/pull/16534
changes:
- use hint `/*cloud_user*/` mark query DO NOT aggr.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `/* cloud_user */` hint to `insert into t1` statements to prevent aggregation.
- Updated select statement limit from 50 to 52 in `result_count.result` and `result_count.sql`.
- Added comments and additional insert statements to ensure no aggregation in test cases.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>result_count.result</strong><dd><code>Add hint to prevent aggregation in result_count.result</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/distributed/cases/result_count/result_count.result

- Added `/* cloud_user */` hint to `insert into t1` statement.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16536/files#diff-ecf968a6cabc7ce4f61b9fcd12020afffac6708a05524436be05df75f657dbac">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>result_count.sql</strong><dd><code>Add hint and comment to prevent aggregation in result_count.sql</code></dd></summary>
<hr>
      
test/distributed/cases/result_count/result_count.sql

<li>Added <code>/* cloud_user */</code> hint to <code>insert into t1</code> statement.<br> <li> Added comment to ensure no aggregation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16536/files#diff-e2b271c7875446831ad9d14d210c620379da79b71ba382c36084115025d6ba4a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>result_count.result</strong><dd><code>Update select limit and add insert statements in result_count.result</code></dd></summary>
<hr>
      
test/distributed/cases/zz_statement_query_type/result_count.result

<li>Modified limit in select statement from 50 to 52.<br> <li> Added <code>insert into t2</code> and <code>insert into t1</code> statements.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16536/files#diff-ac5557e3f8fd12bfa0a56d9ec1cbc3c2c455ae682499b7e7f47211d41ea5158b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>result_count.sql</strong><dd><code>Update select limit in result_count.sql</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/distributed/cases/zz_statement_query_type/result_count.sql

- Modified limit in select statement from 50 to 52.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16536/files#diff-49a9fa31c7dc2c692eddf676957524c5028a954986ba72ccd7394d826afee892">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

