### PR TITLE
remove log print from automaxprocs to 1.2-dev

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"go.uber.org/automaxprocs/maxprocs"
 	"math"
 	"net"
 	"runtime"
@@ -31,7 +32,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/panjf2000/ants/v2"
-	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -88,6 +88,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
+
+func init() {
+	maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
+}
 
 // Note: Now the cost going from stat is actually the number of rows, so we can only estimate a number for the size of each row.
 // The current insertion of around 200,000 rows triggers cn to write s3 directly

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -17,6 +17,12 @@ package compile
 import (
 	"context"
 	"fmt"
+	"go.uber.org/automaxprocs/maxprocs"
+	"hash/crc32"
+	goruntime "runtime"
+	"runtime/debug"
+	"sync"
+
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/bitmap"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
@@ -28,10 +34,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/memoryengine"
-	"hash/crc32"
-	goruntime "runtime"
-	"runtime/debug"
-	"sync"
 
 	"github.com/matrixorigin/matrixone/pkg/cnservice/cnclient"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -60,10 +62,12 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 
 	"github.com/panjf2000/ants/v2"
-	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap"
 )
 
+func init() {
+	maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
+}
 func newScope(magic magicType) *Scope {
 	s := reuse.Alloc[Scope](nil)
 	s.Magic = magic

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -17,11 +17,12 @@ package compile
 import (
 	"context"
 	"fmt"
-	"go.uber.org/automaxprocs/maxprocs"
 	"hash/crc32"
 	goruntime "runtime"
 	"runtime/debug"
 	"sync"
+
+	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/bitmap"

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -21,8 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/automaxprocs/maxprocs"
+
 	"github.com/panjf2000/ants/v2"
-	_ "go.uber.org/automaxprocs"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
@@ -56,6 +57,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/route"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
+
+func init() {
+	maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
+}
 
 var _ engine.Engine = new(Engine)
 var ncpu = runtime.GOMAXPROCS(0)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3374

## What this PR does / why we need it:
remove log print from automaxprocs to 1.2-dev


___

### **PR Type**
Bug fix


___

### **Description**
- Added initialization for `maxprocs` with a no-op logger in multiple files to suppress log output.
- Removed unused import for `automaxprocs` in multiple files.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compile.go</strong><dd><code>Suppress `maxprocs` log output and clean up imports.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/compile.go

<li>Added initialization for <code>maxprocs</code> with a no-op logger to suppress log <br>output.<br> <li> Removed unused import for <code>automaxprocs</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16547/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scope.go</strong><dd><code>Suppress `maxprocs` log output and clean up imports.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/scope.go

<li>Added initialization for <code>maxprocs</code> with a no-op logger to suppress log <br>output.<br> <li> Removed unused import for <code>automaxprocs</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16547/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>engine.go</strong><dd><code>Suppress `maxprocs` log output and clean up imports.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/engine.go

<li>Added initialization for <code>maxprocs</code> with a no-op logger to suppress log <br>output.<br> <li> Removed unused import for <code>automaxprocs</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16547/files#diff-66bacd74568edffe090130ffc5d235b4771a4707612b56145288d4e7119be4a2">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

