### PR TITLE
Revert "remove log print from automaxprocs to 1.2-dev"

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -19,7 +19,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"go.uber.org/automaxprocs/maxprocs"
 	"math"
 	"net"
 	"runtime"
@@ -32,6 +31,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/panjf2000/ants/v2"
+	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -88,10 +88,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
-
-func init() {
-	maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
-}
 
 // Note: Now the cost going from stat is actually the number of rows, so we can only estimate a number for the size of each row.
 // The current insertion of around 200,000 rows triggers cn to write s3 directly

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -17,13 +17,6 @@ package compile
 import (
 	"context"
 	"fmt"
-	"hash/crc32"
-	goruntime "runtime"
-	"runtime/debug"
-	"sync"
-
-	"go.uber.org/automaxprocs/maxprocs"
-
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/bitmap"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
@@ -35,6 +28,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/memoryengine"
+	"hash/crc32"
+	goruntime "runtime"
+	"runtime/debug"
+	"sync"
 
 	"github.com/matrixorigin/matrixone/pkg/cnservice/cnclient"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -63,12 +60,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 
 	"github.com/panjf2000/ants/v2"
+	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap"
 )
 
-func init() {
-	maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
-}
 func newScope(magic magicType) *Scope {
 	s := reuse.Alloc[Scope](nil)
 	s.Magic = magic

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -21,9 +21,8 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/automaxprocs/maxprocs"
-
 	"github.com/panjf2000/ants/v2"
+	_ "go.uber.org/automaxprocs"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/clusterservice"
@@ -57,10 +56,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/route"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
-
-func init() {
-	maxprocs.Set(maxprocs.Logger(func(string, ...interface{}) {}))
-}
 
 var _ engine.Engine = new(Engine)
 var ncpu = runtime.GOMAXPROCS(0)


### PR DESCRIPTION
### **User description**
Reverts matrixorigin/matrixone#16547


___

### **PR Type**
enhancement


___

### **Description**
- Removed the initialization of `maxprocs` with a custom logger in multiple files.
- Adjusted imports to include `automaxprocs` without initialization.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compile.go</strong><dd><code>Remove `maxprocs` initialization and adjust imports.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/compile.go

<li>Removed the initialization of <code>maxprocs</code> with a custom logger.<br> <li> Added an import for <code>automaxprocs</code> without initialization.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16562/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scope.go</strong><dd><code>Remove `maxprocs` initialization and reorder imports.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/scope.go

<li>Removed the initialization of <code>maxprocs</code> with a custom logger.<br> <li> Reordered imports to accommodate the removal.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16562/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+5/-10</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>engine.go</strong><dd><code>Remove `maxprocs` initialization and adjust imports.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/engine.go

<li>Removed the initialization of <code>maxprocs</code> with a custom logger.<br> <li> Added an import for <code>automaxprocs</code> without initialization.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16562/files#diff-66bacd74568edffe090130ffc5d235b4771a4707612b56145288d4e7119be4a2">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

