### PR TITLE
fileservice: refactor read write duration metrics

### DIFF
--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -182,7 +182,7 @@ func (l *LocalFS) Write(ctx context.Context, vector IOVector) error {
 	defer func() {
 		// cover another func to catch the err when process Write
 		span.End(trace.WithFSReadWriteExtra(vector.FilePath, err, int64(bytesWritten)))
-		metric.LocalWriteIODurationHistogram.Observe(time.Since(start).Seconds())
+		metric.FSWriteDurationWrite.Observe(time.Since(start).Seconds())
 		metric.LocalWriteIOBytesHistogram.Observe(float64(bytesWritten))
 	}()
 
@@ -292,12 +292,10 @@ func (l *LocalFS) Read(ctx context.Context, vector *IOVector) (err error) {
 	}
 
 	bytesCounter := new(atomic.Int64)
-	start := time.Now()
+	t0 := time.Now()
 	defer func() {
-		LocalReadIODuration := time.Since(start)
-
-		metric.LocalReadIODurationHistogram.Observe(LocalReadIODuration.Seconds())
 		metric.LocalReadIOBytesHistogram.Observe(float64(bytesCounter.Load()))
+		metric.FSReadDurationGetContent.Observe(time.Since(t0).Seconds())
 	}()
 
 	if len(vector.Entries) == 0 {

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -181,7 +181,7 @@ func (s *S3FS) List(ctx context.Context, dirPath string) (entries []DirEntry, er
 	defer span.End()
 	start := time.Now()
 	defer func() {
-		metric.S3ListIODurationHistogram.Observe(time.Since(start).Seconds())
+		metric.FSReadDurationList.Observe(time.Since(start).Seconds())
 	}()
 
 	path, err := ParsePathAtService(dirPath, s.name)
@@ -228,7 +228,7 @@ func (s *S3FS) StatFile(ctx context.Context, filePath string) (*DirEntry, error)
 	defer span.End()
 	start := time.Now()
 	defer func() {
-		metric.S3StatIODurationHistogram.Observe(time.Since(start).Seconds())
+		metric.FSReadDurationStat.Observe(time.Since(start).Seconds())
 	}()
 	path, err := ParsePathAtService(filePath, s.name)
 	if err != nil {
@@ -308,7 +308,7 @@ func (s *S3FS) Write(ctx context.Context, vector IOVector) error {
 	var bytesWritten int
 	start := time.Now()
 	defer func() {
-		metric.S3WriteIODurationHistogram.Observe(time.Since(start).Seconds())
+		metric.FSWriteDurationWrite.Observe(time.Since(start).Seconds())
 		metric.S3WriteIOBytesHistogram.Observe(float64(bytesWritten))
 	}()
 
@@ -567,8 +567,6 @@ func (s *S3FS) read(ctx context.Context, vector *IOVector) (err error) {
 				C: bytesCounter,
 			},
 			closeFunc: func() error {
-				s3ReadIODuration := time.Since(t0)
-				metric.S3ReadIODurationHistogram.Observe(s3ReadIODuration.Seconds())
 				metric.S3ReadIOBytesHistogram.Observe(float64(bytesCounter.Load()))
 				return r.Close()
 			},

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_fs.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_fs.go
@@ -31,12 +31,11 @@ func (c *DashboardCreator) initFileServiceDashboard() error {
 		"FileService Metrics",
 		c.withRowOptions(
 			c.initFSOverviewRow(),
-			c.initFSReadWriteDurationRow(),
 			c.initFSReadWriteBytesRow(),
 			c.initFSS3ConnOverviewRow(),
 			c.initFSS3ConnDurationRow(),
 			c.initFSIOMergerDurationRow(),
-			c.initFSReadDurationRow(),
+			c.initFSReadWriteDurationRow(),
 			c.initFSMallocRow(),
 		)...)
 	if err != nil {
@@ -76,33 +75,6 @@ func (c *DashboardCreator) initFSOverviewRow() dashboard.Option {
 				"s3",
 				"local",
 			}),
-	)
-}
-
-func (c *DashboardCreator) initFSReadWriteDurationRow() dashboard.Option {
-	return dashboard.Row(
-		"FileService read write duration",
-		c.getMultiHistogram(
-			[]string{
-				c.getMetricWithFilter(`mo_fs_s3_io_duration_seconds_bucket`, `type="read"`),
-				c.getMetricWithFilter(`mo_fs_s3_io_duration_seconds_bucket`, `type="write"`),
-				c.getMetricWithFilter(`mo_fs_local_io_duration_seconds_bucket`, `type="read"`),
-				c.getMetricWithFilter(`mo_fs_local_io_duration_seconds_bucket`, `type="write"`),
-				c.getMetricWithFilter(`mo_fs_s3_io_duration_seconds_bucket`, `type="list"`),
-				c.getMetricWithFilter(`mo_fs_s3_io_duration_seconds_bucket`, `type="stat"`),
-			},
-			[]string{
-				"s3-read",
-				"s3-write",
-				"local-read",
-				"local-write",
-				"s3-list",
-				"s3-stat",
-			},
-			[]float64{0.50, 0.8, 0.90, 0.99},
-			[]float32{3, 3, 3, 3},
-			axis.Unit("s"),
-			axis.Min(0))...,
 	)
 }
 
@@ -187,24 +159,27 @@ func (c *DashboardCreator) initFSIOMergerDurationRow() dashboard.Option {
 	)
 }
 
-func (c *DashboardCreator) initFSReadDurationRow() dashboard.Option {
+func (c *DashboardCreator) initFSReadWriteDurationRow() dashboard.Option {
 	return dashboard.Row(
-		"FileService read duration",
+		"FileService read write duration",
 		c.getMultiHistogram(
 			[]string{
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="read-vector-cache"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="update-vector-cache"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="read-memory-cache"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="update-memory-cache"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="read-disk-cache"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="update-disk-cache"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="read-remote-cache"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="get-reader"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="get-content"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="get-entry-data "`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="write-to-writer"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="set-cached-data"`),
-				c.getMetricWithFilter(`mo_fs_read_duration_bucket`, `type="disk-cache-set-file"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="read-vector-cache"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="update-vector-cache"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="read-memory-cache"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="update-memory-cache"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="read-disk-cache"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="update-disk-cache"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="read-remote-cache"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="get-reader"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="get-content"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="get-entry-data "`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="write-to-writer"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="set-cached-data"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="disk-cache-set-file"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="list"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="stat"`),
+				c.getMetricWithFilter(`mo_fs_read_write_duration_bucket`, `type="write"`),
 			},
 			[]string{
 				"read-vector-cache",
@@ -220,6 +195,9 @@ func (c *DashboardCreator) initFSReadDurationRow() dashboard.Option {
 				"write-to-writer",
 				"set-cached-data",
 				"disk-cache-set-file",
+				"list",
+				"stat",
+				"write",
 			},
 			[]float64{0.50, 0.8, 0.90, 0.99, 1},
 			[]float32{3, 3, 3, 3, 3},

--- a/pkg/util/metric/v2/fileservice.go
+++ b/pkg/util/metric/v2/fileservice.go
@@ -70,19 +70,6 @@ var (
 	S3WriteIOBytesHistogram = s3IOBytesHistogram.WithLabelValues("write")
 	S3ReadIOBytesHistogram  = s3IOBytesHistogram.WithLabelValues("read")
 
-	s3IODurationHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "mo",
-			Subsystem: "fs",
-			Name:      "s3_io_duration_seconds",
-			Help:      "Bucketed histogram of s3 io duration.",
-			Buckets:   getDurationBuckets(),
-		}, []string{"type"})
-	S3WriteIODurationHistogram = s3IODurationHistogram.WithLabelValues("write")
-	S3ReadIODurationHistogram  = s3IODurationHistogram.WithLabelValues("read")
-	S3ListIODurationHistogram  = s3IODurationHistogram.WithLabelValues("list")
-	S3StatIODurationHistogram  = s3IODurationHistogram.WithLabelValues("stat")
-
 	s3ConnDurationHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "mo",
@@ -106,17 +93,6 @@ var (
 		}, []string{"type"})
 	LocalWriteIOBytesHistogram = localIOBytesHistogram.WithLabelValues("write")
 	LocalReadIOBytesHistogram  = localIOBytesHistogram.WithLabelValues("read")
-
-	localIODurationHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "mo",
-			Subsystem: "fs",
-			Name:      "local_io_duration_seconds",
-			Help:      "Bucketed histogram of local io duration.",
-			Buckets:   getDurationBuckets(),
-		}, []string{"type"})
-	LocalWriteIODurationHistogram = localIODurationHistogram.WithLabelValues("write")
-	LocalReadIODurationHistogram  = localIODurationHistogram.WithLabelValues("read")
 )
 
 var (
@@ -145,29 +121,32 @@ var (
 )
 
 var (
-	fsReadDuration = prometheus.NewHistogramVec(
+	fsReadWriteDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "mo",
 			Subsystem: "fs",
-			Name:      "read_duration",
-			Help:      "read duration",
+			Name:      "read_write_duration",
+			Help:      "read write duration",
 			Buckets:   getDurationBuckets(),
 		},
 		[]string{"type"},
 	)
-	FSReadDurationReadVectorCache   = fsReadDuration.WithLabelValues("read-vector-cache")
-	FSReadDurationUpdateVectorCache = fsReadDuration.WithLabelValues("update-vector-cache")
-	FSReadDurationReadMemoryCache   = fsReadDuration.WithLabelValues("read-memory-cache")
-	FSReadDurationUpdateMemoryCache = fsReadDuration.WithLabelValues("update-memory-cache")
-	FSReadDurationReadDiskCache     = fsReadDuration.WithLabelValues("read-disk-cache")
-	FSReadDurationUpdateDiskCache   = fsReadDuration.WithLabelValues("update-disk-cache")
-	FSReadDurationReadRemoteCache   = fsReadDuration.WithLabelValues("read-remote-cache")
-	FSReadDurationGetReader         = fsReadDuration.WithLabelValues("get-reader")
-	FSReadDurationGetContent        = fsReadDuration.WithLabelValues("get-content")
-	FSReadDurationGetEntryData      = fsReadDuration.WithLabelValues("get-entry-data")
-	FSReadDurationWriteToWriter     = fsReadDuration.WithLabelValues("write-to-writer")
-	FSReadDurationSetCachedData     = fsReadDuration.WithLabelValues("set-cached-data")
-	FSReadDurationDiskCacheSetFile  = fsReadDuration.WithLabelValues("disk-cache-set-file")
+	FSReadDurationReadVectorCache   = fsReadWriteDuration.WithLabelValues("read-vector-cache")
+	FSReadDurationUpdateVectorCache = fsReadWriteDuration.WithLabelValues("update-vector-cache")
+	FSReadDurationReadMemoryCache   = fsReadWriteDuration.WithLabelValues("read-memory-cache")
+	FSReadDurationUpdateMemoryCache = fsReadWriteDuration.WithLabelValues("update-memory-cache")
+	FSReadDurationReadDiskCache     = fsReadWriteDuration.WithLabelValues("read-disk-cache")
+	FSReadDurationUpdateDiskCache   = fsReadWriteDuration.WithLabelValues("update-disk-cache")
+	FSReadDurationReadRemoteCache   = fsReadWriteDuration.WithLabelValues("read-remote-cache")
+	FSReadDurationGetReader         = fsReadWriteDuration.WithLabelValues("get-reader")
+	FSReadDurationGetContent        = fsReadWriteDuration.WithLabelValues("get-content")
+	FSReadDurationGetEntryData      = fsReadWriteDuration.WithLabelValues("get-entry-data")
+	FSReadDurationWriteToWriter     = fsReadWriteDuration.WithLabelValues("write-to-writer")
+	FSReadDurationSetCachedData     = fsReadWriteDuration.WithLabelValues("set-cached-data")
+	FSReadDurationDiskCacheSetFile  = fsReadWriteDuration.WithLabelValues("disk-cache-set-file")
+	FSReadDurationList              = fsReadWriteDuration.WithLabelValues("list")
+	FSReadDurationStat              = fsReadWriteDuration.WithLabelValues("stat")
+	FSWriteDurationWrite            = fsReadWriteDuration.WithLabelValues("write")
 )
 
 var (

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -84,15 +84,13 @@ func initFileServiceMetrics() {
 	registry.MustRegister(S3DNSResolveCounter)
 
 	registry.MustRegister(s3IOBytesHistogram)
-	registry.MustRegister(s3IODurationHistogram)
 	registry.MustRegister(s3ConnDurationHistogram)
 	registry.MustRegister(localIOBytesHistogram)
-	registry.MustRegister(localIODurationHistogram)
 
 	registry.MustRegister(ioMergerCounter)
 	registry.MustRegister(ioMergerDuration)
-	registry.MustRegister(fsReadDuration)
 	registry.MustRegister(fsMallocLiveObjects)
+	registry.MustRegister(fsReadWriteDuration)
 }
 
 func initLogtailMetrics() {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15509

## What this PR does / why we need it:
refactor old metrics


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored metric observation in `LocalFS` and `S3FS` to use new consolidated metric names.
- Updated Grafana dashboard to merge read and write duration rows and use new metric names.
- Consolidated read and write duration metrics into a single histogram in `fileservice.go`.
- Registered new consolidated read/write duration metric and removed old individual metrics in `metrics.go`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local_fs.go</strong><dd><code>Refactor metric observation in LocalFS operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/local_fs.go

<li>Refactored metric observation for write and read operations.<br> <li> Replaced old metric names with new ones for consistency.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16637/files#diff-bc086aa870f34585ab047b49edf44e6b55699be741653321dcf574b4bc5d1b00">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>s3_fs.go</strong><dd><code>Refactor metric observation in S3FS operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/fileservice/s3_fs.go

<li>Updated metric observation for S3 operations.<br> <li> Replaced old metric names with new ones for consistency.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16637/files#diff-907e5658def7c03142291742cb81fdc3d3590d95678e916e95daf13283a2f86f">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>grafana_dashboard_fs.go</strong><dd><code>Update Grafana dashboard for read/write duration metrics</code>&nbsp; </dd></summary>
<hr>
      
pkg/util/metric/v2/dashboard/grafana_dashboard_fs.go

<li>Merged read and write duration rows in the Grafana dashboard.<br> <li> Updated metric names for consistency.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16637/files#diff-150a2d0e9e7884f246192255bceb432b8eff0f74015e938db8e21f9bf0b6d6d8">+22/-44</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fileservice.go</strong><dd><code>Consolidate read/write duration metrics in fileservice</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/util/metric/v2/fileservice.go

<li>Consolidated read and write duration metrics into a single histogram.<br> <li> Removed old individual duration histograms.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16637/files#diff-40c4045e01211017f7ffa2d3be743d46f32abff373c9fc5ec5e4a5fee0eb4ae6">+19/-40</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metrics.go</strong><dd><code>Register consolidated read/write duration metric</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/util/metric/v2/metrics.go

<li>Registered new consolidated read/write duration metric.<br> <li> Removed old individual duration metric registrations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16637/files#diff-97ea305cc79979fa7db0a8fd618613cdda1c9bda32e6aa91847d8a754de671f3">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

