### PR TITLE
bump go to 1.22.3, fix make compose and optimize ut script for 1.2-dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,7 @@ mo-server
 gen_config
 store/
 mo-data/
+**/scratch/
 
 # cgo compiler files linked system lib, so ignore it
 **/*.o

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pkg/udf/pythonservice/pyserver/udf/
 pkg/udf/pythonservice/pyserver/__pycache__/
 path_to_file
 tester-log/
+**/scratch/
 pkg/util/trace/impl/motrace/pprof/
 
 # bvt generate files

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ ci-clean:
 # docker compose bvt test
 ###############################################################################
 
-COMPOSE_LAUNCH := "launch-multi-cn"
+COMPOSE_LAUNCH := "launch"
 
 .PHONY: compose
 compose:
@@ -204,8 +204,11 @@ compose:
 .PHONY: compose-clean
 compose-clean:
 	@docker compose -f etc/launch-tae-compose/compose.yaml --profile $(COMPOSE_LAUNCH) down --remove-orphans
-	@docker volume rm launch-tae-compose_minio_storage
+	@docker volume rm -f launch-tae-compose_minio_storage
 	@docker image prune -f
+	@cd $(ROOT_DIR) && rm -rf docker-compose-log && rm -rf test/distributed/resources/json/export*
+	@cd $(ROOT_DIR) && rm -rf test/distributed/resources/into_outfile/*.csv
+	@cd $(ROOT_DIR) && rm -rf test/distributed/resources/into_outfile_2/*.csv
 
 ###############################################################################
 # clean

--- a/etc/launch-tae-compose/compose.yaml
+++ b/etc/launch-tae-compose/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 # docker compose extension fields
 # https://github.com/docker/compose/pull/5140
 # https://stackoverflow.com/questions/45805380/meaning-of-ampersand-in-docker-compose-yml-file

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matrixorigin/matrixone
 
-go 1.21.5
+go 1.22.3
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/optools/bvt_ut/Dockerfile
+++ b/optools/bvt_ut/Dockerfile
@@ -1,4 +1,4 @@
-FROM matrixorigin/tester:go1.21.5-jdk8
+FROM matrixorigin/tester:go1.22.3-jdk8
 
 ARG GOPROXY="https://proxy.golang.org,direct"
 

--- a/optools/compose_bvt/Dockerfile.tester
+++ b/optools/compose_bvt/Dockerfile.tester
@@ -1,9 +1,8 @@
-FROM matrixorigin/tester:go1.21.5-jdk8
+FROM matrixorigin/tester:go1.22.3-jdk8
 
 WORKDIR /
 
-RUN git clone https://github.com/matrixorigin/mo-tester.git && apt update && apt install -y mariadb-client
-
+RUN git clone https://github.com/matrixorigin/mo-tester.git
 COPY . /matrixone
 
 RUN cd mo-tester && sed -i 's/127.0.0.1/cn0/g' mo.yml

--- a/optools/compose_bvt/compose_bvt.sh
+++ b/optools/compose_bvt/compose_bvt.sh
@@ -7,9 +7,8 @@ COMPOSE_LAUNCH=$2
 
 function export_logs() {
     cd ${MO_WORKSPACE}
-    rm -f ./etc/launch-tae-compose/config/*.bak
-    curl http://localhost:12345/debug/pprof/goroutine\?debug=2 -o docker-compose-log/cn-0-dump-stacks.log
-    curl http://localhost:22345/debug/pprof/goroutine\?debug=2 -o docker-compose-log/cn-1-dump-stacks.log
+    curl http://localhost:12345/debug/pprof/goroutine\?debug=2 -o docker-compose-log/cn-0-dump-stacks
+    curl http://localhost:22345/debug/pprof/goroutine\?debug=2 -o docker-compose-log/cn-1-dump-stacks
 
 }
 
@@ -19,8 +18,8 @@ function compose_bvt() {
     cd ${MO_WORKSPACE}
 
     docker compose -f etc/launch-tae-compose/compose.yaml --profile "${COMPOSE_LAUNCH}" up -d --build
-    docker build -t matrixorigin/compose_tester:local -f optools/compose_bvt/Dockerfile.tester .
-    docker run -it --name compose-tester --privileged --network launch-tae-compose_monet -v ${MO_WORKSPACE}/docker-compose-log:/test --rm matrixorigin/compose_tester:local
+    docker build -t matrixorigin/compose-tester:local -f optools/compose_bvt/Dockerfile.tester .
+    docker run -it --name compose-tester --privileged --network launch-tae-compose_monet -v ${MO_WORKSPACE}/docker-compose-log:/test --rm matrixorigin/compose-tester:local
     exit 0
 }
 
@@ -28,5 +27,3 @@ function compose_bvt() {
 rm -rf ${MO_WORKSPACE}/docker-compose-log && mkdir -p ${MO_WORKSPACE}/docker-compose-log
 
 compose_bvt
-
-exit $?

--- a/optools/compose_bvt/entrypoint.sh
+++ b/optools/compose_bvt/entrypoint.sh
@@ -16,8 +16,10 @@ function run_bvt() {
     trap packLog EXIT
     # wait for ready
     i=0
-    while [ $(mysql -h cn0 -P 6001 -u dump -p111 --execute 'create database if not exists compose_test;use compose_test; create table if not exists compose_test_table(col1 int auto_increment primary key);show tables;' 2>&1 | tee /dev/stderr | grep 'compose_test_table' | wc -l) -lt 1 ]; do
-      echo "wait mo init finished...$i"
+    while true; do
+      if mysql -h cn0 -P 6001 -u dump -p111 --execute "show databases;"; then
+        break;
+      fi
       if [ $i -ge 300 ]; then
         echo "wait for $i seconds, mo init not finish, so exit 1"
         docker ps
@@ -26,7 +28,7 @@ function run_bvt() {
       i=$(($i+1))
       sleep 1
     done
-    cd /mo-tester && ./run.sh -n -g -p /matrixone/test/distributed/cases/ -s /matrixone/test/distributed/resources/ -e optimistic 2>&1
+    cd /mo-tester && ./run.sh -n -g -p /matrixone/test/distributed/cases/ -s /test/distributed/resources -e optimistic 2>&1
 }
 
 run_bvt

--- a/optools/images/Dockerfile
+++ b/optools/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5-bookworm as builder
+FROM golang:1.22.3-bookworm as builder
 
 # goproxy
 ARG GOPROXY="https://proxy.golang.org,direct"

--- a/optools/utilities.sh
+++ b/optools/utilities.sh
@@ -74,7 +74,7 @@ function cmd_timeout {
 }
 
 G_TS=`date +%Y%m%d%H%M%S`
-G_STAGE="$HOME/scratch"
+G_STAGE="${UT_WORKDIR:-$HOME}/scratch"
 if [[ ! -d $G_STAGE ]]; then mkdir -p $G_STAGE; fi
 
 G_CONT_ID=$(get_container_id)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/3413

## What this PR does / why we need it:
1. bump go version from 1.21.5 to 1.22.3
2. fix `make compose` to make it work
3. `make ut` will read `UT_WORKDIR` env variable to store report, it will be `$HOME` if `UT_WORKDIR` is empty


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Bumped Go version from 1.21.5 to 1.22.3.
- Fixed and optimized Docker Compose BVT script.
- Improved MySQL readiness check and updated paths in entrypoint script.
- Added support for `UT_WORKDIR` environment variable.
- Updated `.dockerignore` to exclude scratch directories.
- Changed default `COMPOSE_LAUNCH` profile and added additional cleanup commands in Makefile.
- Removed version declaration from Docker Compose file.
- Updated base images in Dockerfiles to use Go 1.22.3.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>compose_bvt.sh</strong><dd><code>Fix and optimize Docker Compose BVT script.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
optools/compose_bvt/compose_bvt.sh

<li>Removed <code>.bak</code> file deletion.<br> <li> Updated file extensions for stack dumps.<br> <li> Fixed Docker image name and volume removal command.<br> <li> Removed redundant <code>exit $?</code> statement.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16644/files#diff-0b585810054dae6aac3b3030ecaf01539afd05df248a755e07e46808b452d1e4">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement
</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Improve MySQL readiness check and update paths.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
optools/compose_bvt/entrypoint.sh

<li>Improved MySQL readiness check.<br> <li> Updated paths for test resources.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16644/files#diff-5579d7188c871b94dd232f539d859c5f713d7a2152ac535c57c2c15c4526c0c1">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utilities.sh</strong><dd><code>Add support for `UT_WORKDIR` environment variable.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
optools/utilities.sh

- Added support for `UT_WORKDIR` environment variable.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16644/files#diff-097116cadc044eebd3d802f7abf3271075a7d07d45de7e338bef1ba448a27cd8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Update Docker Compose launch profile and cleanup commands.</code></dd></summary>
<hr>
      
Makefile

<li>Changed default <code>COMPOSE_LAUNCH</code> profile.<br> <li> Added force removal of Docker volumes and additional cleanup commands.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16644/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>.dockerignore</strong><dd><code>Update `.dockerignore` to exclude scratch directories.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.dockerignore

- Added `**/scratch/` to ignore list.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16644/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>compose.yaml</strong><dd><code>Remove version declaration from Docker Compose file.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
etc/launch-tae-compose/compose.yaml

- Removed version declaration.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16644/files#diff-614637aebd609b775997a36deb13ee9ec3ac4e7a3f7a2ace72edcb86768e6d0a">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Dependencies
</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Bump Go version to 1.22.3.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
go.mod

- Bumped Go version from 1.21.5 to 1.22.3.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16644/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update base image to Go 1.22.3.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
optools/bvt_ut/Dockerfile

- Updated base image to use Go 1.22.3.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16644/files#diff-6203d1985f996fa83281df70527347b87d8de762516b21b937ccb8ccb934ec9a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.tester</strong><dd><code>Update base image and remove redundant installation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
optools/compose_bvt/Dockerfile.tester

<li>Updated base image to use Go 1.22.3.<br> <li> Removed redundant <code>apt</code> installation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16644/files#diff-024845ca393bea6b99cd7df0a07539d8e897f989f37246be12684d2b2c732d0f">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update base image to Go 1.22.3.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
optools/images/Dockerfile

- Updated base image to use Go 1.22.3.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16644/files#diff-ab78a60ede0c02df8bc2df87f932ec9213ed9837b8e2c4921331cc17c1628f3d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

