### PR TITLE
fix bvt error caused by global variable setting

### DIFF
--- a/test/distributed/cases/auto_increment/auto_increment.result
+++ b/test/distributed/cases/auto_increment/auto_increment.result
@@ -682,7 +682,7 @@ SQL parser error: You have an error in your SQL syntax; check the manual that co
 Drop table auto_increment16;
 no such table auto_increment.auto_increment16
 drop table if exists auto_increment17;
-set global auto_increment_offset= 10;
+set auto_increment_offset= 10;
 create table auto_increment17(col1 int auto_increment);
 insert into auto_increment17 values();
 select * from auto_increment17;
@@ -697,4 +697,3 @@ col1
 100
 drop table auto_increment17;
 set auto_increment_offset = 1;
-set global auto_increment_offset= 1;

--- a/test/distributed/cases/auto_increment/auto_increment.sql
+++ b/test/distributed/cases/auto_increment/auto_increment.sql
@@ -449,9 +449,9 @@ Drop table if exists auto_increment16;
 Create temporary table auto_increment16(col1 int auto_increment)auto_increment < 0;
 Drop table auto_increment16;
 
--- global variable: auto_increment_increment
+-- variable: auto_increment_increment
 drop table if exists auto_increment17;
-set global auto_increment_offset= 10;
+set auto_increment_offset= 10;
 create table auto_increment17(col1 int auto_increment);
 insert into auto_increment17 values();
 select * from auto_increment17;
@@ -462,4 +462,3 @@ insert into auto_increment17 values();
 select * from auto_increment17;
 drop table auto_increment17;
 set auto_increment_offset = 1;
-set global auto_increment_offset= 1;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16658

## What this PR does / why we need it:

do not set global variable in auto increment bvt test.


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the use of `set global` for `auto_increment_offset` in test cases to avoid errors.
- Updated SQL test files to reflect the changes in variable setting.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auto_increment.result</strong><dd><code>Fix global variable setting in auto_increment test results</code></dd></summary>
<hr>
      
test/distributed/cases/auto_increment/auto_increment.result

<li>Removed <code>set global</code> statements and replaced with <code>set</code> for <br><code>auto_increment_offset</code>.<br> <li> Adjusted SQL syntax to avoid setting global variables.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16664/files#diff-ff3d327f7d8a4e060abafa939e508700f5ec29274b20f8500ec9118da6293a10">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>auto_increment.sql</strong><dd><code>Correct global variable setting in auto_increment SQL test</code></dd></summary>
<hr>
      
test/distributed/cases/auto_increment/auto_increment.sql

<li>Replaced <code>set global</code> statements with <code>set</code> for <code>auto_increment_offset</code>.<br> <li> Updated comments to reflect changes in variable setting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16664/files#diff-d6bf0f315f2d260cc1b57624efc4830e5dd2e12df8b2b305a8178ebc40d236c7">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

