### PR TITLE
Support merge policy parameter 1.2 dev

### DIFF
--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -23,6 +23,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/docker/go-units"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -2549,7 +2550,7 @@ func (tbl *txnTable) MergeObjects(ctx context.Context, objstats []objectio.Objec
 			objInfos = append(objInfos, info)
 		}
 	} else {
-		objInfos = make([]logtailreplay.ObjectInfo, 0)
+		objInfos = make([]logtailreplay.ObjectInfo, 0, len(objstats))
 		iter, err := state.NewObjectsIter(snapshot)
 		if err != nil {
 			return nil, err
@@ -2568,14 +2569,9 @@ func (tbl *txnTable) MergeObjects(ctx context.Context, objstats []objectio.Objec
 			objInfos = append(objInfos, obj)
 		}
 		if len(policyName) != 0 {
-			if strings.HasPrefix(policyName, "small") {
-				objInfos = logtailreplay.NewSmall(110 * common.Const1MBytes).Filter(objInfos)
-			} else if strings.HasPrefix(policyName, "overlap") {
-				if sortkeyPos != -1 {
-					objInfos = logtailreplay.NewOverlap(100).Filter(objInfos)
-				}
-			} else {
-				return nil, moerr.NewInvalidInput(ctx, "invalid merge policy name")
+			objInfos, err = applyMergePolicy(ctx, policyName, sortkeyPos, objInfos)
+			if err != nil {
+				return nil, err
 			}
 		}
 	}
@@ -2687,4 +2683,39 @@ func dumpTransferInfo(ctx context.Context, taskHost *cnMergeTask) (err error) {
 
 	taskHost.commitEntry.Booking = nil
 	return
+}
+
+func applyMergePolicy(ctx context.Context, policyName string, sortKeyPos int, objInfos []logtailreplay.ObjectInfo) ([]logtailreplay.ObjectInfo, error) {
+	arg := cutBetween(policyName, "(", ")")
+	if strings.HasPrefix(policyName, "small") {
+		size := uint32(110 * common.Const1MBytes)
+		i, err := units.RAMInBytes(arg)
+		if err == nil && 10*common.Const1MBytes < i && i < 250*common.Const1MBytes {
+			size = uint32(i)
+		}
+		return logtailreplay.NewSmall(size).Filter(objInfos), nil
+	} else if strings.HasPrefix(policyName, "overlap") {
+		if sortKeyPos == -1 {
+			return objInfos, nil
+		}
+		maxObjects := 100
+		i, err := strconv.Atoi(arg)
+		if err == nil {
+			maxObjects = i
+		}
+		return logtailreplay.NewOverlap(maxObjects).Filter(objInfos), nil
+	}
+
+	return nil, moerr.NewInvalidInput(ctx, "invalid merge policy name")
+}
+
+func cutBetween(s, start, end string) string {
+	i := strings.Index(s, start)
+	if i >= 0 {
+		j := strings.Index(s[i:], end)
+		if j >= 0 {
+			return s[i+len(start) : i+j]
+		}
+	}
+	return ""
 }

--- a/test/distributed/cases/function/mo_ctl/mo_ctl_merge.result
+++ b/test/distributed/cases/function/mo_ctl/mo_ctl_merge.result
@@ -19,6 +19,9 @@ mo_ctl(dn, flush, mo_ctl_merge.t1)
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:small');
 mo_ctl(dn, mergeobjects, mo_ctl_merge.t1:all:small)
 \nmsg: merged success\n018f2834-dcb3-7e7d-8ae5-215ad781e835_00000, rows 2, blks 1, osize 1.54KB, csize 687B\n\n\n
+select sleep(1);
+sleep(1)
+0
 select rows_cnt from metadata_scan('mo_ctl_merge.t1', 'a') g;
 rows_cnt
 2
@@ -35,6 +38,9 @@ mo_ctl(dn, flush, mo_ctl_merge.t1)
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:overlap');
 mo_ctl(dn, mergeobjects, mo_ctl_merge.t1:all:overlap)
 \nmsg: merged success\n018f283b-2dcd-78db-9399-df2bd74d53e5_00000, rows 4, blks 1, osize 1.60KB, csize 704B\n\n\n
+select sleep(1);
+sleep(1)
+0
 select rows_cnt, bit_cast(`min` as int), bit_cast(`max` as int) from metadata_scan('mo_ctl_merge.t1', 'a') g;
 rows_cnt    bit_cast(min as int)    bit_cast(max as int)
 4    100    115
@@ -55,6 +61,9 @@ mo_ctl(dn, flush, mo_ctl_merge.t1)
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:small');
 mo_ctl(dn, mergeobjects, mo_ctl_merge.t1:all:small)
 \nmsg: merged success\n018f2834-dcb3-7e7d-8ae5-215ad781e835_00000, rows 2, blks 1, osize 1.54KB, csize 687B\n\n\n
+select sleep(1);
+sleep(1)
+0
 select rows_cnt from metadata_scan('mo_ctl_merge.t1', 'a') g;
 rows_cnt
 2
@@ -71,6 +80,9 @@ mo_ctl(dn, flush, mo_ctl_merge.t1)
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:overlap');
 mo_ctl(dn, mergeobjects, mo_ctl_merge.t1:all:overlap)
 \nmsg: merged success\n018f283b-2dcd-78db-9399-df2bd74d53e5_00000, rows 4, blks 1, osize 1.60KB, csize 704B\n\n\n
+select sleep(1);
+sleep(1)
+0
 select rows_cnt, bit_cast(`min` as int), bit_cast(`max` as int) from metadata_scan('mo_ctl_merge.t1', 'a') g;
 rows_cnt    bit_cast(min as int)    bit_cast(max as int)
 6    100    125
@@ -90,6 +102,9 @@ mo_ctl(dn, flush, mo_ctl_merge.t1)
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:small');
 mo_ctl(dn, mergeobjects, mo_ctl_merge.t1:all:small)
 \nmsg: merged success\n018f2834-dcb3-7e7d-8ae5-215ad781e835_00000, rows 2, blks 1, osize 1.54KB, csize 687B\n\n\n
+select sleep(1);
+sleep(1)
+0
 select rows_cnt from metadata_scan('mo_ctl_merge.t1', 'a') g;
 rows_cnt
 2
@@ -106,9 +121,42 @@ mo_ctl(dn, flush, mo_ctl_merge.t1)
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:overlap');
 mo_ctl(dn, mergeobjects, mo_ctl_merge.t1:all:overlap)
 \nmsg: merged success\n018f283b-2dcd-78db-9399-df2bd74d53e5_00000, rows 4, blks 1, osize 1.60KB, csize 704B\n\n\n
+select sleep(1);
+sleep(1)
+0
 select rows_cnt, min, max from metadata_scan('mo_ctl_merge.t1', 'a') g;
 rows_cnt    min    max
 6    abcdefghijklmnopqrstuvwxyzabcd    abcdefghijklmnopqrstuvwxyzabce
+drop table t1;
+create table t1(
+a int primary key,
+b varchar(10)
+);
+insert into t1 values (105, 'a');
+insert into t1 values (115, 'a');
+select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
+mo_ctl(dn, flush, mo_ctl_merge.t1)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+insert into t1 values (110, 'a');
+insert into t1 values (120, 'a');
+select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
+mo_ctl(dn, flush, mo_ctl_merge.t1)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+insert into t1 values (116, 'a');
+insert into t1 values (126, 'a');
+select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
+mo_ctl(dn, flush, mo_ctl_merge.t1)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:overlap(2)');
+mo_ctl(dn, mergeobjects, mo_ctl_merge.t1:all:overlap(2))
+\nmsg: merged success\n018f283b-2dcd-78db-9399-df2bd74d53e5_00000, rows 4, blks 1, osize 1.60KB, csize 704B\n\n\n
+select sleep(1);
+sleep(1)
+0
+select rows_cnt, bit_cast(`min` as int), bit_cast(`max` as int) from metadata_scan('mo_ctl_merge.t1', 'a') g;
+rows_cnt    bit_cast(min as int)    bit_cast(max as int)
+4    105    120
+2    116    126
 drop table t1;
 select mo_ctl('dn', 'inspect', 'policy');
 mo_ctl(dn, inspect, policy)

--- a/test/distributed/cases/function/mo_ctl/mo_ctl_merge.test
+++ b/test/distributed/cases/function/mo_ctl/mo_ctl_merge.test
@@ -14,9 +14,8 @@ insert into t1 values (110, 'a');
 select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
 -- @ignore:0
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:small');
--- @bvt:issue#15807
+select sleep(1);
 select rows_cnt from metadata_scan('mo_ctl_merge.t1', 'a') g;
--- @bvt:issue
 
 insert into t1 values (105, 'a');
 insert into t1 values (115, 'a');
@@ -28,9 +27,8 @@ insert into t1 values (125, 'a');
 select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
 -- @ignore:0
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:overlap');
--- @bvt:issue#15807
+select sleep(1);
 select rows_cnt, bit_cast(`min` as int), bit_cast(`max` as int) from metadata_scan('mo_ctl_merge.t1', 'a') g;
--- @bvt:issue
 drop table t1;
 
 create table t1(
@@ -45,9 +43,8 @@ insert into t1 values (110, 'a');
 select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
 -- @ignore:0
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:small');
--- @bvt:issue#15807
+select sleep(1);
 select rows_cnt from metadata_scan('mo_ctl_merge.t1', 'a') g;
--- @bvt:issue
 
 insert into t1 values (105, 'a');
 insert into t1 values (115, 'a');
@@ -59,11 +56,9 @@ insert into t1 values (125, 'a');
 select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
 -- @ignore:0
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:overlap');
--- @bvt:issue#15807
+select sleep(1);
 select rows_cnt, bit_cast(`min` as int), bit_cast(`max` as int) from metadata_scan('mo_ctl_merge.t1', 'a') g;
--- @bvt:issue
 drop table t1;
-
 create table t1(
 a varchar(100) primary key,
 b varchar(10)
@@ -76,9 +71,8 @@ insert into t1 values ('abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcd
 select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
 -- @ignore:0
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:small');
--- @bvt:issue#15807
+select sleep(1);
 select rows_cnt from metadata_scan('mo_ctl_merge.t1', 'a') g;
--- @bvt:issue
 
 insert into t1 values ('abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyb', 'b');
 insert into t1 values ('abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyc', 'b');
@@ -90,10 +84,28 @@ insert into t1 values ('abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcd
 select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
 -- @ignore:0
 select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:overlap');
--- @bvt:issue#15807
+select sleep(1);
 select rows_cnt, min, max from metadata_scan('mo_ctl_merge.t1', 'a') g;
--- @bvt:issue
 drop table t1;
-
-
+create table t1(
+a int primary key,
+b varchar(10)
+);
+insert into t1 values (105, 'a');
+insert into t1 values (115, 'a');
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
+insert into t1 values (110, 'a');
+insert into t1 values (120, 'a');
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
+insert into t1 values (116, 'a');
+insert into t1 values (126, 'a');
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'mo_ctl_merge.t1');
+-- @ignore:0
+select mo_ctl('dn', 'mergeobjects', 'mo_ctl_merge.t1:all:overlap(2)');
+select sleep(1);
+select rows_cnt, bit_cast(`min` as int), bit_cast(`max` as int) from metadata_scan('mo_ctl_merge.t1', 'a') g;
+drop table t1;
 select mo_ctl('dn', 'inspect', 'policy');


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #11891 #15807

## What this PR does / why we need it:

support some policy parameters.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enhanced the `MergeObjects` function to support additional merge policy parameters by introducing the `applyMergePolicy` function.
- Added `cutBetween` utility function to extract parameters from policy names.
- Updated test cases to include `sleep(1)` statements after merge operations to ensure proper timing.
- Added new test cases to validate the `overlap` merge policy with parameters.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Implement merge policy parameter handling in txnTable</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/txn_table.go

<li>Added new import for <code>github.com/docker/go-units</code>.<br> <li> Modified <code>MergeObjects</code> function to use <code>applyMergePolicy</code>.<br> <li> Introduced <code>applyMergePolicy</code> function to handle different merge <br>policies.<br> <li> Added <code>cutBetween</code> utility function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16669/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+40/-9</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mo_ctl_merge.result</strong><dd><code>Update merge policy test results with sleep and new cases</code></dd></summary>
<hr>
      
test/distributed/cases/function/mo_ctl/mo_ctl_merge.result

<li>Added <code>sleep(1)</code> statements after merge operations.<br> <li> Added new test cases for <code>overlap</code> policy with parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16669/files#diff-3a4c9135f39a9fdd33977fe6936b8ab27d342b60ae8114d042006391ccde1830">+48/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mo_ctl_merge.test</strong><dd><code>Add sleep and new test cases for merge policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/distributed/cases/function/mo_ctl/mo_ctl_merge.test

<li>Added <code>sleep(1)</code> statements after merge operations.<br> <li> Added new test cases for <code>overlap</code> policy with parameters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16669/files#diff-5d0c1f13b214775d4d75d89e3f7ec90f99ddc959cc986c340fd0aac38bef1f68">+27/-15</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

