### PR TITLE
remove duplicates in object list for flushing

### DIFF
--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -154,6 +154,7 @@ func NewFlushTableTailTask(
 	}
 	task.schema = rel.Schema().(*catalog.Schema)
 
+	objSeen := make(map[*catalog.ObjectEntry]struct{})
 	for _, obj := range objs {
 		task.scopes = append(task.scopes, *obj.AsCommonID())
 		var hdl handle.Object
@@ -161,6 +162,10 @@ func NewFlushTableTailTask(
 		if err != nil {
 			return
 		}
+		if _, ok := objSeen[obj]; ok {
+			continue
+		}
+		objSeen[obj] = struct{}{}
 		if hdl.IsAppendable() && !obj.HasDropCommitted() {
 			task.aObjMetas = append(task.aObjMetas, obj)
 			task.aObjHandles = append(task.aObjHandles, hdl)
@@ -192,6 +197,10 @@ func NewFlushTableTailTask(
 		if err != nil {
 			return
 		}
+		if _, ok := objSeen[obj]; ok {
+			continue
+		}
+		objSeen[obj] = struct{}{}
 		task.delSrcMetas = append(task.delSrcMetas, obj)
 		task.delSrcHandles = append(task.delSrcHandles, hdl)
 	}

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -37,6 +37,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/data"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/mergesort"
@@ -687,16 +688,37 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 		}
 	}()
 	emtpyDelObjIdx = make([]*bitmap.Bitmap, len(task.delSrcMetas))
+	var (
+		enableDeltaStat = task.schema.Name == "bmsql_stock"
+		tbl             *catalog.TableEntry
+		tombstone       data.Tombstone
+		locMap          = make(map[string]int)
+		now             time.Time
+	)
+
+	if enableDeltaStat {
+		tbl = task.rel.GetMeta().(*catalog.TableEntry)
+		now = time.Now()
+	}
 	for i, obj := range task.delSrcMetas {
 		objData := obj.GetObjectData()
 		var deletes *containers.Batch
 		emptyDelObjs := &bitmap.Bitmap{}
 		emptyDelObjs.InitWithSize(int64(obj.BlockCnt()))
+		if enableDeltaStat {
+			tombstone = tbl.TryGetTombstone(obj.ID)
+		}
 		for j := 0; j < obj.BlockCnt(); j++ {
 			found, _ := objData.HasDeleteIntentsPreparedInByBlock(uint16(j), types.TS{}, task.txn.GetStartTS())
 			if !found {
 				emptyDelObjs.Add(uint64(j))
 				continue
+			}
+			if enableDeltaStat && tombstone != nil {
+				loc := tombstone.GetLatestDeltaloc(uint16(j))
+				if loc != nil {
+					locMap[loc.String()]++
+				}
 			}
 			if deletes, err = objData.CollectDeleteInRangeByBlock(
 				ctx, uint16(j), types.TS{}, task.txn.GetStartTS(), true, common.MergeAllocator,
@@ -715,6 +737,11 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 			bufferBatch.Extend(deletes)
 		}
 		emtpyDelObjIdx[i] = emptyDelObjs
+	}
+	if enableDeltaStat {
+		cost := time.Since(now)
+		logutil.Infof("[FlushTabletail] task %d collect tombstone for %s cost %v, location distribution(%v):%v",
+			task.ID(), task.schema.Name, cost, len(locMap), locMap)
 	}
 	if bufferBatch != nil {
 		// make sure every batch in deltaloc object is sorted by rowid

--- a/pkg/vm/engine/tae/tables/updates/mvcc.go
+++ b/pkg/vm/engine/tae/tables/updates/mvcc.go
@@ -546,9 +546,10 @@ func (n *ObjectMVCCHandle) GetObject() any {
 }
 func (n *ObjectMVCCHandle) GetLatestDeltaloc(blkOffset uint16) objectio.Location {
 	mvcc := n.TryGetDeleteChain(blkOffset)
-	if mvcc == nil {
+	if mvcc == nil || mvcc.deltaloc == nil || mvcc.deltaloc.GetLatestNodeLocked() == nil {
 		return nil
 	}
+
 	return mvcc.deltaloc.GetLatestNodeLocked().BaseNode.DeltaLoc
 }
 func (n *ObjectMVCCHandle) GetLatestMVCCNode(blkOffset uint16) *catalog.MVCCNode[*catalog.MetadataMVCCNode] {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16630

## What this PR does / why we need it:

- reduce the size of tombstone files


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added deduplication logic to avoid processing duplicate objects in `NewFlushTableTailTask`.
- Introduced delta statistics collection for the `bmsql_stock` schema, including logging of tombstone collection time and location distribution.
- Enhanced `GetLatestDeltaloc` method in `ObjectMVCCHandle` to include safety checks for `deltaloc` and its latest node.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flushTableTail.go</strong><dd><code>Deduplicate objects and add delta statistics in flushTableTailTask</code></dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/jobs/flushTableTail.go

<li>Added deduplication for objects in <code>NewFlushTableTailTask</code>.<br> <li> Introduced delta statistics collection for <code>bmsql_stock</code> schema.<br> <li> Enhanced logging for tombstone collection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16677/files#diff-0b958d0044e734c5cb32254c0e45c0beaf0e4fdc1f4c846c0bde0fd917da63b0">+36/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mvcc.go</strong><dd><code>Add safety checks in GetLatestDeltaloc method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/updates/mvcc.go

<li>Added checks for <code>deltaloc</code> and its latest node in <code>GetLatestDeltaloc</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16677/files#diff-35522fd6f558c0ad470badaca3c1f13dfc0cc81aad5e9f0bd120197a18628a87">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

