### PR TITLE
Fix enumtype system variable check

### DIFF
--- a/pkg/frontend/types.go
+++ b/pkg/frontend/types.go
@@ -733,19 +733,22 @@ func (ses *feSessionImpl) GetGlobalSysVar(name string) (interface{}, error) {
 
 func (ses *Session) SetGlobalSysVar(ctx context.Context, name string, val interface{}) (err error) {
 	name = strings.ToLower(name)
-	if sv, ok := gSysVarsDefs[name]; !ok {
-		return moerr.NewInternalErrorNoCtx(errorSystemVariableDoesNotExist())
-	} else {
-		if sv.Scope == ScopeSession {
-			return moerr.NewInternalErrorNoCtx(errorSystemVariableIsSession())
-		}
-		if !sv.GetDynamic() {
-			return moerr.NewInternalErrorNoCtx(errorSystemVariableIsReadOnly())
-		}
 
-		if val, err = sv.GetType().Convert(val); err != nil {
-			return err
-		}
+	def, ok := gSysVarsDefs[name]
+	if !ok {
+		return moerr.NewInternalErrorNoCtx(errorSystemVariableDoesNotExist())
+	}
+
+	if def.Scope == ScopeSession {
+		return moerr.NewInternalErrorNoCtx(errorSystemVariableIsSession())
+	}
+
+	if !def.GetDynamic() {
+		return moerr.NewInternalErrorNoCtx(errorSystemVariableIsReadOnly())
+	}
+
+	if val, err = def.GetType().Convert(val); err != nil {
+		return err
 	}
 
 	// save to table first

--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -594,7 +594,7 @@ func (svet SystemVariableEnumType) String() string {
 
 func (svet SystemVariableEnumType) Convert(value interface{}) (interface{}, error) {
 	cv1 := func(x int) (interface{}, error) {
-		if x >= 0 && x <= len(svet.id2TagName) {
+		if x >= 0 && x < len(svet.id2TagName) {
 			return svet.id2TagName[x], nil
 		}
 		return nil, errorConvertToEnumFailed


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16686 

## What this PR does / why we need it:
Fix enumtype system variable check


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the logic for checking system variable definitions in `SetGlobalSysVar`.
- Improved error handling for session scope and read-only variables.
- Refactored the variable conversion process in `SetGlobalSysVar`.
- Corrected the range check in `SystemVariableEnumType.Convert` method.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Fix and refactor global system variable checks and conversions.</code></dd></summary>
<hr>
      
pkg/frontend/types.go

<li>Fixed the logic for checking system variable definitions.<br> <li> Improved error handling for session scope and read-only variables.<br> <li> Refactored variable conversion process.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16692/files#diff-5426ed8bd66760011299bcef0a9d1d552477eaae49a8451e16b8ec5bf7d7310f">+14/-11</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>variables.go</strong><dd><code>Fix range check in SystemVariableEnumType conversion.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/frontend/variables.go

<li>Corrected the range check in <code>SystemVariableEnumType.Convert</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16692/files#diff-07649adc637b0268b12ec915ec819f66db3a4e4375bfc77291116bfa06c4432f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

