### PR TITLE
[opt] merge filters on composite primary keys in plan (1.2-dev)

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -24,13 +24,27 @@ import (
 )
 
 func isRuntimeConstExpr(expr *plan.Expr) bool {
-	switch expr.Expr.(type) {
-	case *plan.Expr_Lit, *plan.Expr_P, *plan.Expr_V:
+	switch exprImpl := expr.Expr.(type) {
+	case *plan.Expr_Lit, *plan.Expr_P, *plan.Expr_V, *plan.Expr_Vec, *plan.Expr_T:
 		return true
 
 	case *plan.Expr_F:
-		fn := expr.GetF()
-		return fn.Func.ObjName == "cast" && isRuntimeConstExpr(fn.Args[0])
+		for _, subExpr := range exprImpl.F.Args {
+			if !isRuntimeConstExpr(subExpr) {
+				return false
+			}
+		}
+
+		return true
+
+	case *plan.Expr_List:
+		for _, subExpr := range exprImpl.List.List {
+			if !isRuntimeConstExpr(subExpr) {
+				return false
+			}
+		}
+
+		return true
 
 	default:
 		return false
@@ -453,11 +467,11 @@ func (builder *QueryBuilder) applyIndicesForFiltersRegularIndex(nodeID int32, no
 						case "between":
 							fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[1]})
 							fn.Args[2], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[2]})
-							node.FilterList[i], _ = bindFuncExprAndConstFold(builder.GetContext(), builder.compCtx.GetProcess(), "prefix_between", fn.Args)
+							node.FilterList[i], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "prefix_between", fn.Args)
 
 						case "in":
 							fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[1]})
-							node.FilterList[i], _ = bindFuncExprAndConstFold(builder.GetContext(), builder.compCtx.GetProcess(), "prefix_in", fn.Args)
+							node.FilterList[i], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "prefix_in", fn.Args)
 						}
 					}
 				}
@@ -780,12 +794,12 @@ END0:
 			switch fn.Func.ObjName {
 			case "in":
 				fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[1]})
-				idxFilter, _ = bindFuncExprAndConstFold(builder.GetContext(), builder.compCtx.GetProcess(), "prefix_in", fn.Args)
+				idxFilter, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "prefix_in", fn.Args)
 
 			case "between":
 				fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[1]})
 				fn.Args[2], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[2]})
-				idxFilter, _ = bindFuncExprAndConstFold(builder.GetContext(), builder.compCtx.GetProcess(), "prefix_between", fn.Args)
+				idxFilter, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "prefix_between", fn.Args)
 			}
 		}
 

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1207,7 +1207,7 @@ func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name s
 	}
 
 	switch retExpr.GetF().GetFunc().GetObjName() {
-	case "+", "-", "*", "/", "unary_minus", "unary_plus", "unary_tilde", "in", "prefix_in", "serial", "serial_full":
+	case "+", "-", "*", "/", "unary_minus", "unary_plus", "unary_tilde", "cast", "serial", "serial_full":
 		if proc != nil {
 			tmpexpr, _ := ConstantFold(batch.EmptyForConstFoldBatch, DeepCopyExpr(retExpr), proc, false)
 			if tmpexpr != nil {
@@ -1513,6 +1513,76 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 				return nil, err
 			}
 		}
+
+	case "in", "not_in":
+		//if all the expr in the in list can safely cast to left type, we call it safe
+		if rightList := args[1].GetList(); rightList != nil {
+			typLeft := makeTypeByPlan2Expr(args[0])
+			var inExprList, orExprList []*plan.Expr
+
+			for _, rightVal := range rightList.List {
+				if checkNoNeedCast(makeTypeByPlan2Expr(rightVal), typLeft, rightVal.GetLit()) {
+					inExpr, err := appendCastBeforeExpr(ctx, rightVal, args[0].Typ)
+					if err != nil {
+						return nil, err
+					}
+					inExprList = append(inExprList, inExpr)
+				} else {
+					orExprList = append(orExprList, rightVal)
+				}
+			}
+
+			var newExpr *plan.Expr
+
+			if len(inExprList) > 1 {
+				leftType := makeTypeByPlan2Expr(args[0])
+				argsType := []types.Type{leftType, leftType}
+				fGet, err := function.GetFunctionByName(ctx, name, argsType)
+				if err != nil {
+					return nil, err
+				}
+
+				funcID := fGet.GetEncodedOverloadID()
+				returnType := fGet.GetReturnType()
+				rightList.List = inExprList
+				exprType := makePlan2Type(&returnType)
+				exprType.NotNullable = function.DeduceNotNullable(funcID, args)
+				newExpr = &Expr{
+					Typ: exprType,
+					Expr: &plan.Expr_F{
+						F: &plan.Function{
+							Func: getFunctionObjRef(funcID, name),
+							Args: args,
+						},
+					},
+				}
+			} else if len(inExprList) > 0 {
+				orExprList = append(inExprList, orExprList...)
+			}
+
+			//expand the in list to col=a or col=b or ......
+			if name == "in" {
+				for _, expr := range orExprList {
+					tmpExpr, _ := BindFuncExprImplByPlanExpr(ctx, "=", []*Expr{DeepCopyExpr(args[0]), expr})
+					if newExpr == nil {
+						newExpr = tmpExpr
+					} else {
+						newExpr, _ = BindFuncExprImplByPlanExpr(ctx, "or", []*Expr{newExpr, tmpExpr})
+					}
+				}
+			} else {
+				for _, expr := range orExprList {
+					tmpExpr, _ := BindFuncExprImplByPlanExpr(ctx, "!=", []*Expr{DeepCopyExpr(args[0]), expr})
+					if newExpr == nil {
+						newExpr = tmpExpr
+					} else {
+						newExpr, _ = BindFuncExprImplByPlanExpr(ctx, "and", []*Expr{newExpr, tmpExpr})
+					}
+				}
+			}
+
+			return newExpr, nil
+		}
 	}
 
 	// get args(exprs) & types
@@ -1594,67 +1664,6 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 				return nil, err
 			}
 			funcID = fGet.GetEncodedOverloadID()
-		}
-
-	case "in", "not_in":
-		//if all the expr in the in list can safely cast to left type, we call it safe
-		if rightList := args[1].GetList(); rightList != nil {
-			typLeft := makeTypeByPlan2Expr(args[0])
-			var inExprList, orExprList []*plan.Expr
-
-			for _, rightVal := range rightList.List {
-				if checkNoNeedCast(makeTypeByPlan2Expr(rightVal), typLeft, rightVal.GetLit()) {
-					inExpr, err := appendCastBeforeExpr(ctx, rightVal, args[0].Typ)
-					if err != nil {
-						return nil, err
-					}
-					inExprList = append(inExprList, inExpr)
-				} else {
-					orExprList = append(orExprList, rightVal)
-				}
-			}
-
-			var newExpr *plan.Expr
-
-			if len(inExprList) > 1 {
-				rightList.List = inExprList
-				typ := makePlan2Type(&returnType)
-				typ.NotNullable = function.DeduceNotNullable(funcID, args)
-				newExpr = &Expr{
-					Expr: &plan.Expr_F{
-						F: &plan.Function{
-							Func: getFunctionObjRef(funcID, name),
-							Args: args,
-						},
-					},
-					Typ: typ,
-				}
-			} else if len(inExprList) > 0 {
-				orExprList = append(inExprList, orExprList...)
-			}
-
-			//expand the in list to col=a or col=b or ......
-			if name == "in" {
-				for _, expr := range orExprList {
-					tmpExpr, _ := BindFuncExprImplByPlanExpr(ctx, "=", []*Expr{DeepCopyExpr(args[0]), expr})
-					if newExpr == nil {
-						newExpr = tmpExpr
-					} else {
-						newExpr, _ = BindFuncExprImplByPlanExpr(ctx, "or", []*Expr{newExpr, tmpExpr})
-					}
-				}
-			} else {
-				for _, expr := range orExprList {
-					tmpExpr, _ := BindFuncExprImplByPlanExpr(ctx, "!=", []*Expr{DeepCopyExpr(args[0]), expr})
-					if newExpr == nil {
-						newExpr = tmpExpr
-					} else {
-						newExpr, _ = BindFuncExprImplByPlanExpr(ctx, "and", []*Expr{newExpr, tmpExpr})
-					}
-				}
-			}
-
-			return newExpr, nil
 		}
 
 	case "timediff":

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -1198,7 +1198,7 @@ func appendForeignConstrantPlan(
 //
 //	case 1: For SQL that contains on duplicate update
 //	case 2: the only primary key is auto increment type
-func appendPrimaryConstrantPlan(
+func appendPrimaryConstraintPlan(
 	builder *QueryBuilder,
 	bindCtx *BindContext,
 	tableDef *TableDef,

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -1538,7 +1538,7 @@ func makeOneInsertPlan(
 	}
 
 	if ifCheckPkDup && !ifExistAutoPkCol {
-		if err = appendPrimaryConstrantPlan(builder, bindCtx, tableDef, objRef, partitionExpr, pkFilterExprs,
+		if err = appendPrimaryConstraintPlan(builder, bindCtx, tableDef, objRef, partitionExpr, pkFilterExprs,
 			indexSourceColTypes, sourceStep, updateColLength > 0, updatePkCol, fuzzymessage); err != nil {
 			return err
 		}

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -758,9 +758,7 @@ func getPkValueExpr(builder *QueryBuilder, ctx CompilerContext, tableDef *TableD
 			filterExpr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "in", []*Expr{
 				pkExpr,
 				{
-					Typ: plan.Type{
-						Id: int32(types.T_tuple),
-					},
+					Typ: pkExpr.Typ,
 					Expr: &plan.Expr_List{
 						List: &plan.ExprList{
 							List: colExprs[0],
@@ -825,9 +823,7 @@ func getPkValueExpr(builder *QueryBuilder, ctx CompilerContext, tableDef *TableD
 			filterExpr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "in", []*Expr{
 				pkExpr,
 				{
-					Typ: plan.Type{
-						Id: int32(types.T_tuple),
-					},
+					Typ: pkExpr.Typ,
 					Expr: &plan.Expr_Vec{
 						Vec: &plan.LiteralVec{
 							Len:  int32(vec.Length()),

--- a/pkg/sql/plan/function/func_get_admin.go
+++ b/pkg/sql/plan/function/func_get_admin.go
@@ -19,7 +19,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
-	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/functionUtil"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
@@ -52,12 +51,12 @@ func builtInInternalGetAdminName(parameters []*vector.Vector, result vector.Func
 		}
 		defer res.Close()
 
-		var adminNme string
+		var adminNme []byte
 		res.ReadRows(func(rows int, cols []*vector.Vector) bool {
-			adminNme = cols[0].UnsafeGetStringAt(0)
+			adminNme = cols[0].GetBytesAt(0)
 			return true
 		})
-		if err = rs.AppendBytes(functionUtil.QuickStrToBytes(adminNme), false); err != nil {
+		if err = rs.AppendBytes(adminNme, false); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/plan/function/list_operator.go
+++ b/pkg/sql/plan/function/list_operator.go
@@ -480,7 +480,7 @@ var supportedOperators = []FuncNew{
 		Overloads: []overload{
 			{
 				overloadId: 0,
-				args:       []types.T{types.T_uint8, types.T_tuple},
+				args:       []types.T{types.T_uint8, types.T_uint8},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -490,7 +490,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 1,
-				args:       []types.T{types.T_uint16, types.T_tuple},
+				args:       []types.T{types.T_uint16, types.T_uint16},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -500,7 +500,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 2,
-				args:       []types.T{types.T_uint32, types.T_tuple},
+				args:       []types.T{types.T_uint32, types.T_uint32},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -510,7 +510,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 3,
-				args:       []types.T{types.T_uint64, types.T_tuple},
+				args:       []types.T{types.T_uint64, types.T_uint64},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -520,7 +520,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 4,
-				args:       []types.T{types.T_int8, types.T_tuple},
+				args:       []types.T{types.T_int8, types.T_int8},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -530,7 +530,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 5,
-				args:       []types.T{types.T_int16, types.T_tuple},
+				args:       []types.T{types.T_int16, types.T_int16},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -540,7 +540,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 6,
-				args:       []types.T{types.T_int32, types.T_tuple},
+				args:       []types.T{types.T_int32, types.T_int32},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -550,7 +550,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 7,
-				args:       []types.T{types.T_int64, types.T_tuple},
+				args:       []types.T{types.T_int64, types.T_int64},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -560,7 +560,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 8,
-				args:       []types.T{types.T_float32, types.T_tuple},
+				args:       []types.T{types.T_float32, types.T_float32},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -570,7 +570,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 9,
-				args:       []types.T{types.T_float64, types.T_tuple},
+				args:       []types.T{types.T_float64, types.T_float64},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -580,7 +580,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 10,
-				args:       []types.T{types.T_decimal64, types.T_tuple},
+				args:       []types.T{types.T_decimal64, types.T_decimal64},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -590,7 +590,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 11,
-				args:       []types.T{types.T_decimal128, types.T_tuple},
+				args:       []types.T{types.T_decimal128, types.T_decimal128},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -600,7 +600,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 12,
-				args:       []types.T{types.T_varchar, types.T_tuple},
+				args:       []types.T{types.T_varchar, types.T_varchar},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -610,7 +610,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 13,
-				args:       []types.T{types.T_char, types.T_tuple},
+				args:       []types.T{types.T_char, types.T_char},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -620,7 +620,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 14,
-				args:       []types.T{types.T_date, types.T_tuple},
+				args:       []types.T{types.T_date, types.T_date},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -630,7 +630,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 15,
-				args:       []types.T{types.T_datetime, types.T_tuple},
+				args:       []types.T{types.T_datetime, types.T_datetime},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -640,7 +640,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 16,
-				args:       []types.T{types.T_bool, types.T_tuple},
+				args:       []types.T{types.T_bool, types.T_bool},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -650,7 +650,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 17,
-				args:       []types.T{types.T_timestamp, types.T_tuple},
+				args:       []types.T{types.T_timestamp, types.T_timestamp},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -660,7 +660,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 18,
-				args:       []types.T{types.T_blob, types.T_tuple},
+				args:       []types.T{types.T_blob, types.T_blob},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -670,7 +670,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 19,
-				args:       []types.T{types.T_uuid, types.T_tuple},
+				args:       []types.T{types.T_uuid, types.T_uuid},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -680,7 +680,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 20,
-				args:       []types.T{types.T_text, types.T_tuple},
+				args:       []types.T{types.T_text, types.T_text},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -690,7 +690,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 21,
-				args:       []types.T{types.T_time, types.T_tuple},
+				args:       []types.T{types.T_time, types.T_time},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -700,7 +700,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 22,
-				args:       []types.T{types.T_binary, types.T_tuple},
+				args:       []types.T{types.T_binary, types.T_binary},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -710,7 +710,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 23,
-				args:       []types.T{types.T_varbinary, types.T_tuple},
+				args:       []types.T{types.T_varbinary, types.T_varbinary},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -731,7 +731,7 @@ var supportedOperators = []FuncNew{
 		Overloads: []overload{
 			{
 				overloadId: 0,
-				args:       []types.T{types.T_uint8, types.T_tuple},
+				args:       []types.T{types.T_uint8, types.T_uint8},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -741,7 +741,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 1,
-				args:       []types.T{types.T_uint16, types.T_tuple},
+				args:       []types.T{types.T_uint16, types.T_uint16},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -751,7 +751,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 2,
-				args:       []types.T{types.T_uint32, types.T_tuple},
+				args:       []types.T{types.T_uint32, types.T_uint32},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -761,7 +761,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 3,
-				args:       []types.T{types.T_uint64, types.T_tuple},
+				args:       []types.T{types.T_uint64, types.T_uint64},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -771,7 +771,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 4,
-				args:       []types.T{types.T_int8, types.T_tuple},
+				args:       []types.T{types.T_int8, types.T_int8},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -781,7 +781,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 5,
-				args:       []types.T{types.T_int16, types.T_tuple},
+				args:       []types.T{types.T_int16, types.T_int16},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -791,7 +791,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 6,
-				args:       []types.T{types.T_int32, types.T_tuple},
+				args:       []types.T{types.T_int32, types.T_int32},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -801,7 +801,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 7,
-				args:       []types.T{types.T_int64, types.T_tuple},
+				args:       []types.T{types.T_int64, types.T_int64},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -811,7 +811,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 8,
-				args:       []types.T{types.T_float32, types.T_tuple},
+				args:       []types.T{types.T_float32, types.T_float32},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -821,7 +821,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 9,
-				args:       []types.T{types.T_float64, types.T_tuple},
+				args:       []types.T{types.T_float64, types.T_float64},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -831,7 +831,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 10,
-				args:       []types.T{types.T_decimal64, types.T_tuple},
+				args:       []types.T{types.T_decimal64, types.T_decimal64},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -841,7 +841,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 11,
-				args:       []types.T{types.T_decimal128, types.T_tuple},
+				args:       []types.T{types.T_decimal128, types.T_decimal128},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -851,7 +851,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 12,
-				args:       []types.T{types.T_varchar, types.T_tuple},
+				args:       []types.T{types.T_varchar, types.T_varchar},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -861,7 +861,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 13,
-				args:       []types.T{types.T_char, types.T_tuple},
+				args:       []types.T{types.T_char, types.T_char},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -871,7 +871,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 14,
-				args:       []types.T{types.T_date, types.T_tuple},
+				args:       []types.T{types.T_date, types.T_date},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -881,7 +881,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 15,
-				args:       []types.T{types.T_datetime, types.T_tuple},
+				args:       []types.T{types.T_datetime, types.T_datetime},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -891,7 +891,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 16,
-				args:       []types.T{types.T_bool, types.T_tuple},
+				args:       []types.T{types.T_bool, types.T_bool},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -901,7 +901,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 17,
-				args:       []types.T{types.T_timestamp, types.T_tuple},
+				args:       []types.T{types.T_timestamp, types.T_timestamp},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -911,7 +911,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 18,
-				args:       []types.T{types.T_blob, types.T_tuple},
+				args:       []types.T{types.T_blob, types.T_blob},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -921,7 +921,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 19,
-				args:       []types.T{types.T_uuid, types.T_tuple},
+				args:       []types.T{types.T_uuid, types.T_uuid},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -931,7 +931,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 20,
-				args:       []types.T{types.T_text, types.T_tuple},
+				args:       []types.T{types.T_text, types.T_text},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -941,7 +941,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 21,
-				args:       []types.T{types.T_time, types.T_tuple},
+				args:       []types.T{types.T_time, types.T_time},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -951,7 +951,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 22,
-				args:       []types.T{types.T_binary, types.T_tuple},
+				args:       []types.T{types.T_binary, types.T_binary},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},
@@ -961,7 +961,7 @@ var supportedOperators = []FuncNew{
 			},
 			{
 				overloadId: 23,
-				args:       []types.T{types.T_varbinary, types.T_tuple},
+				args:       []types.T{types.T_varbinary, types.T_varbinary},
 				retType: func(parameters []types.Type) types.Type {
 					return types.T_bool.ToType()
 				},

--- a/pkg/sql/plan/make.go
+++ b/pkg/sql/plan/make.go
@@ -199,16 +199,14 @@ func makePlan2Vecf32ConstExpr(v string) *plan.Expr_Lit {
 var MakePlan2StringVecExprWithType = makePlan2StringVecExprWithType
 
 func makePlan2StringVecExprWithType(mp *mpool.MPool, vals ...string) *plan.Expr {
-	vec := vector.NewVec(types.T_char.ToType())
+	vec := vector.NewVec(types.T_varchar.ToType())
 	for _, val := range vals {
 		vector.AppendBytes(vec, []byte(val), false, mp)
 	}
 	data, _ := vec.MarshalBinary()
 	vec.Free(mp)
 	return &plan.Expr{
-		Typ: plan.Type{
-			Id: int32(types.T_tuple),
-		},
+		Typ: makePlan2Type(vec.GetType()),
 		Expr: &plan.Expr_Vec{
 			Vec: &plan.LiteralVec{
 				Len:  int32(len(vals)),
@@ -228,9 +226,7 @@ func makePlan2Int64VecExprWithType(mp *mpool.MPool, vals ...int64) *plan.Expr {
 	data, _ := vec.MarshalBinary()
 	vec.Free(mp)
 	return &plan.Expr{
-		Typ: plan.Type{
-			Id: int32(types.T_tuple),
-		},
+		Typ: makePlan2Type(vec.GetType()),
 		Expr: &plan.Expr_Vec{
 			Vec: &plan.LiteralVec{
 				Len:  int32(len(vals)),

--- a/pkg/sql/plan/partition_list.go
+++ b/pkg/sql/plan/partition_list.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
@@ -142,6 +143,8 @@ func (lpb *listPartitionBuilder) checkPartitionIntegrity(ctx context.Context, pa
 }
 
 func (lpb *listPartitionBuilder) buildEvalPartitionExpression(ctx context.Context, partitionBinder *PartitionBinder, stmt *tree.PartitionOption, partitionDef *plan.PartitionByDef) error {
+	proc := partitionBinder.builder.compCtx.GetProcess()
+
 	partitionType := stmt.PartBy.PType.(*tree.ListType)
 	// For the List partition, convert the partition information into the expression, such as:
 	// case when expr in (1, 5, 9, 13, 17) then 0 when expr in (2, 6, 10, 14, 18) then 1 else -1 end
@@ -159,6 +162,10 @@ func (lpb *listPartitionBuilder) buildEvalPartitionExpression(ctx context.Contex
 			Id:          int32(types.T_int32),
 			NotNullable: true,
 		})
+		if err != nil {
+			return err
+		}
+		partitionExpression, err = ConstantFold(batch.EmptyForConstFoldBatch, partitionExpression, proc, false)
 		if err != nil {
 			return err
 		}
@@ -185,8 +192,13 @@ func (lpb *listPartitionBuilder) buildEvalPartitionExpression(ctx context.Contex
 		if err != nil {
 			return err
 		}
+		partitionExpression, err = ConstantFold(batch.EmptyForConstFoldBatch, partitionExpression, proc, false)
+		if err != nil {
+			return err
+		}
 		partitionDef.PartitionExpression = partitionExpression
 	}
+
 	return nil
 }
 

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -1433,6 +1433,7 @@ func (builder *QueryBuilder) createQuery() (*Query, error) {
 		builder.rewriteDistinctToAGG(rootID)
 		builder.rewriteEffectlessAggToProject(rootID)
 		rootID, _ = builder.pushdownFilters(rootID, nil, false)
+		builder.mergeFiltersOnCompositeKey(rootID)
 		err := foldTableScanFilters(builder.compCtx.GetProcess(), builder.qry, rootID)
 		if err != nil {
 			return nil, err
@@ -1480,7 +1481,6 @@ func (builder *QueryBuilder) createQuery() (*Query, error) {
 		builder.partitionPrune(rootID)
 
 		builder.optimizeLikeExpr(rootID)
-		builder.mergeFiltersOnCompositeKey(rootID)
 		rootID = builder.applyIndices(rootID, colRefCnt, make(map[[2]int32]*plan.Expr))
 		ReCalcNodeStats(rootID, builder, true, false, true)
 

--- a/pkg/sql/plan/rule/constant_fold.go
+++ b/pkg/sql/plan/rule/constant_fold.go
@@ -316,7 +316,7 @@ func GetConstantValue(vec *vector.Vector, transAll bool, row uint64) *plan.Liter
 		}
 		return &plan.Literal{
 			Value: &plan.Literal_Sval{
-				Sval: vec.GetStringAt(0),
+				Sval: vec.GetStringAt(int(row)),
 			},
 		}
 	case types.T_timestamp:

--- a/pkg/sql/plan/runtime_filter.go
+++ b/pkg/sql/plan/runtime_filter.go
@@ -120,9 +120,9 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 
 	rfTag := builder.genNewMsgTag()
 
-	type_tuple := types.New(types.T_tuple, 0, 0)
 	for i := range probeExprs {
-		args := []types.Type{makeTypeByPlan2Expr(probeExprs[i]), type_tuple}
+		exprType := makeTypeByPlan2Expr(probeExprs[i])
+		args := []types.Type{exprType, exprType}
 		_, err := function.GetFunctionByName(builder.GetContext(), "in", args)
 		if err != nil {
 			//don't support this type

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -505,18 +505,21 @@ func estimateExprSelectivity(expr *plan.Expr, builder *QueryBuilder) float64 {
 				return 10 / ndv
 			}
 			return 0.5
-		case "in":
-			card := float64(exprImpl.F.Args[1].GetVec().Len)
+		case "in", "prefix_in":
+			card := float64(1)
+			switch arg1Impl := exprImpl.F.Args[1].Expr.(type) {
+			case *plan.Expr_Vec:
+				card = float64(arg1Impl.Vec.Len)
+
+			case *plan.Expr_List:
+				card = float64(len(arg1Impl.List.List))
+			}
+			if funcName == "prefix_in" {
+				card *= 10
+			}
 			ndv := getExprNdv(expr, builder)
 			if ndv > card {
 				return card / ndv
-			}
-			return 1
-		case "prefix_in":
-			card := float64(exprImpl.F.Args[1].GetVec().Len)
-			ndv := getExprNdv(expr, builder)
-			if ndv > 10*card {
-				return 10 * card / ndv
 			}
 			return 0.5
 		case "prefix_between":

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -2021,12 +2021,8 @@ func MakeIntervalExpr(num int64, str string) *Expr {
 }
 
 func MakeInExpr(ctx context.Context, left *Expr, length int32, data []byte, matchPrefix bool) *Expr {
-	rightType := plan.Type{Id: int32(types.T_tuple)}
-	if matchPrefix {
-		rightType = left.Typ
-	}
 	rightArg := &plan.Expr{
-		Typ: rightType,
+		Typ: left.Typ,
 		Expr: &plan.Expr_Vec{
 			Vec: &plan.LiteralVec{
 				Len:  length,

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -98,9 +98,7 @@ func getPkExpr(
 						List: []*plan.Expr{leftPK, rightPK},
 					},
 				},
-				Typ: plan.Type{
-					Id: int32(types.T_tuple),
-				},
+				Typ: leftPK.Typ,
 			}
 
 		case "and":

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -101,9 +101,7 @@ func makeInExprForTest[T any](arg0 *plan.Expr, vals []T, oid types.T, mp *mpool.
 				Args: []*plan.Expr{
 					arg0,
 					{
-						Typ: plan.Type{
-							Id: int32(types.T_tuple),
-						},
+						Typ: plan2.MakePlan2Type(vec.GetType()),
 						Expr: &plan.Expr_Vec{
 							Vec: &plan.LiteralVec{
 								Len:  int32(len(vals)),
@@ -657,7 +655,8 @@ func TestGetPKExpr(t *testing.T) {
 					},
 				},
 				Typ: plan.Type{
-					Id: int32(types.T_tuple),
+					Id:          int32(types.T_int64),
+					NotNullable: true,
 				},
 			},
 			{
@@ -670,7 +669,8 @@ func TestGetPKExpr(t *testing.T) {
 					},
 				},
 				Typ: plan.Type{
-					Id: int32(types.T_tuple),
+					Id:          int32(types.T_int64),
+					NotNullable: true,
 				},
 			},
 			nil,
@@ -685,7 +685,8 @@ func TestGetPKExpr(t *testing.T) {
 					},
 				},
 				Typ: plan.Type{
-					Id: int32(types.T_tuple),
+					Id:          int32(types.T_int64),
+					NotNullable: true,
 				},
 			},
 		},


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16146

## What this PR does / why we need it:
(a,b,c) are composite keys

a=? and b in (?,?...) ==> __mo_cpkey_col prefix_in (?,?...) a=? and b = ? and c in (?,?...) ==> __mo_cpkey_col in (?,?...)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced expression handling and function binding in various parts of the SQL planner.
- Improved handling of `in` and `not_in` functions to safely cast expressions.
- Fixed typos in function names.
- Updated type assignments to use specific types instead of `T_tuple`.
- Added constant folding for partition expressions.
- Improved selectivity estimation for `in` and `prefix_in` functions.
- Updated test cases to reflect changes in type assignment.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>apply_indices.go</strong><dd><code>Enhance expression handling and function binding in apply indices.</code></dd></summary>
<hr>
      
pkg/sql/plan/apply_indices.go

<li>Added support for additional expression types in <code>isRuntimeConstExpr</code>.<br> <li> Replaced <code>bindFuncExprAndConstFold</code> with <code>BindFuncExprImplByPlanExpr</code> for <br><code>prefix_between</code> and <code>prefix_in</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-b92e434ebc0c08092943a8c5a8abaed315f3e5722db3ffde4e3fbbb878d325b2">+22/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base_binder.go</strong><dd><code>Improve handling of `in` and `not_in` functions in base binder.</code></dd></summary>
<hr>
      
pkg/sql/plan/base_binder.go

<li>Added handling for <code>in</code> and <code>not_in</code> functions to safely cast expressions.<br> <li> Removed redundant code for <code>in</code> and <code>not_in</code> functions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-d2c4ebed110cf4c8982fa501ff026b2d518810445a72f51eac3021b51396e7b0">+71/-62</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>build_insert.go</strong><dd><code>Update type assignment for `in` expressions in build insert.</code></dd></summary>
<hr>
      
pkg/sql/plan/build_insert.go

<li>Updated type assignment for <code>in</code> expressions to match primary key <br>expression type.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-9d0fd08ed4afb7ebd89ebb05190cd8900fd133473e4ef2e795dd5cea28ddce40">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expr_opt.go</strong><dd><code>Enhance merging of filters on composite keys in expression </code><br><code>optimization.</code></dd></summary>
<hr>
      
pkg/sql/plan/expr_opt.go

<li>Enhanced merging of filters on composite keys to handle <code>in</code> <br>expressions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-d74b004ceea0444039926cf26e70fba9951154ce59241418d3f0db00f411cabe">+87/-29</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>func_get_admin.go</strong><dd><code>Change admin name retrieval to use byte slices.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/function/func_get_admin.go

- Changed handling of admin name retrieval to use byte slices.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-0b81d83c6b90d87dce8dbb05f7544cc39ca5e089fc0393e88a354a9382ce30fa">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>list_operator.go</strong><dd><code>Update supported operators to use specific types.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/function/list_operator.go

<li>Updated supported operators to use specific types instead of <code>T_tuple</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-bd7c6d5e26e241a477ae069e4640c05df9d2fd05f48e158e31ef5d918cd3ede0">+48/-48</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>make.go</strong><dd><code>Update vector creation functions to use specific types.</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/make.go

<li>Updated vector creation functions to use specific types instead of <br><code>T_tuple</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-fa30c68057b1c12eab9307a82edcd85856ff0be45225df355477cb0b88a154d8">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>partition_list.go</strong><dd><code>Add constant folding for partition expressions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/partition_list.go

- Added constant folding for partition expressions.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-8176f69dd25cf4fd29cff5762489363cc0f1ca5a0fd6385d8a5d434fa34e979e">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>query_builder.go</strong><dd><code>Move mergeFiltersOnCompositeKey call to earlier stage in query </code><br><code>creation.</code></dd></summary>
<hr>
      
pkg/sql/plan/query_builder.go

<li>Moved <code>mergeFiltersOnCompositeKey</code> call to an earlier stage in query <br>creation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-144e02a38da50867dc021b9254d10a5fd131671cca344c2323337ba2141440f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>runtime_filter.go</strong><dd><code>Update type handling for runtime filters.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/runtime_filter.go

<li>Updated type handling for runtime filters to use specific types <br>instead of <code>T_tuple</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-597fe1a4b6c932d815482502c1ae60c5f8c69921e00b27dba2f5e4ea5b25b54b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stats.go</strong><dd><code>Improve selectivity estimation for `in` and `prefix_in` functions.</code></dd></summary>
<hr>
      
pkg/sql/plan/stats.go

<li>Improved selectivity estimation for <code>in</code> and <code>prefix_in</code> functions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-3b3d55fa9884dcf8980f90043a05b26a04d0153ae89fcf032cec998752c0cafa">+12/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Update MakeInExpr to use specific types.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/utils.go

- Updated `MakeInExpr` to use specific types instead of `T_tuple`.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-4086cbd1a662ffb2a7761174da95abee51e3e0cc7e4ab796e2ec6ef82983ab45">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Update type assignment for primary key expressions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/util.go

<li>Updated type assignment for primary key expressions to use specific <br>types instead of <code>T_tuple</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-6808a91f32ea7065cd63ff5887ac4600b5b6744b6cd2bb12859a0e4a5fb0efd2">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug fix
</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>build_constraint_util.go</strong><dd><code>Fix typo in function name in build constraint utility.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/build_constraint_util.go

<li>Fixed typo in function name from <code>appendPrimaryConstrantPlan</code> to <br><code>appendPrimaryConstraintPlan</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-6eb56175b52eb3302f1d9ae1cde88ced82c25bb8dd90562238cc8d9757adb76b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>build_dml_util.go</strong><dd><code>Fix typo in function name in build DML utility.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/build_dml_util.go

<li>Fixed typo in function name from <code>appendPrimaryConstrantPlan</code> to <br><code>appendPrimaryConstraintPlan</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-095fb233d51021791cb24454839b013236680bbc6bbc22e0d2f6741ac8fe7dff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>constant_fold.go</strong><dd><code>Fix retrieval of string values in constant folding.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/rule/constant_fold.go

- Fixed retrieval of string values from vectors in constant folding.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-f3c5d6ce0a9d06da042c24fbe3348fa71cff4b03584c98dfb1cf9476b2a2ecfa">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>util_test.go</strong><dd><code>Update test cases for primary key expression type assignment.</code></dd></summary>
<hr>
      
pkg/vm/engine/disttae/util_test.go

<li>Updated test cases to reflect changes in type assignment for primary <br>key expressions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16693/files#diff-4a57b25c93a1c472f029d8c29f9c300e78779b9a22061b1af626220d80c802af">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

