### PR TITLE
add optimizer hint exectype to force query to be ap or tp

### DIFF
--- a/pkg/sql/plan/opt_misc.go
+++ b/pkg/sql/plan/opt_misc.go
@@ -851,6 +851,8 @@ func handleOptimizerHints(str string, builder *QueryBuilder) {
 		builder.optimizerHints.joinOrdering = value
 	case "forceOneCN":
 		builder.optimizerHints.forceOneCN = value
+	case "execType":
+		builder.optimizerHints.execType = value
 	}
 }
 

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -193,6 +193,7 @@ type OptimizerHints struct {
 	runtimeFilter              int
 	joinOrdering               int
 	forceOneCN                 int
+	execType                   int
 }
 
 type CTERef struct {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16542 

## What this PR does / why we need it:
add optimizer hint exectype to force query to be ap or tp