### PR TITLE
[bug] launch: fix timeout mechanism when TN service startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/google/btree v1.1.2
 	github.com/google/gofuzz v1.2.0
 	github.com/google/gops v0.3.25
+	github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/memberlist v0.3.1
@@ -84,7 +85,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect
-	github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3 // indirect
 	github.com/gosimple/slug v1.13.1 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/pkg/logservice/hakeeper_client.go
+++ b/pkg/logservice/hakeeper_client.go
@@ -548,14 +548,15 @@ type hakeeperClient struct {
 func newHAKeeperClient(ctx context.Context,
 	cfg HAKeeperClientConfig) (*hakeeperClient, error) {
 	var err error
+	var c *hakeeperClient
 	// If the discovery address is configured, we used it first.
 	if len(cfg.DiscoveryAddress) > 0 {
-		c, err := connectByReverseProxy(ctx, cfg.DiscoveryAddress, cfg)
+		c, err = connectByReverseProxy(ctx, cfg.DiscoveryAddress, cfg)
 		if c != nil && err == nil {
 			return c, nil
 		}
 	} else if len(cfg.ServiceAddresses) > 0 {
-		c, err := connectToHAKeeper(ctx, cfg.ServiceAddresses, cfg)
+		c, err = connectToHAKeeper(ctx, cfg.ServiceAddresses, cfg)
 		if c != nil && err == nil {
 			return c, nil
 		}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/3450

## What this PR does / why we need it:
fix timeout mechanism when TN service startup:
5m timeout for total wait and 5s timeout for each request.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed the timeout mechanism when starting the TN service by implementing a retry mechanism with a 5-second timeout for each request and a total timeout of 5 minutes.
- Improved error handling in the `startService` function by returning the actual error instead of `nil`.
- Enhanced the robustness of the `newHAKeeperClient` function in `hakeeper_client.go`.
- Updated dependencies in the `go.mod` file by adding `github.com/google/pprof` as a direct dependency and removing a duplicate indirect dependency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>launch.go</strong><dd><code>Fix timeout mechanism and improve error handling in service startup</code></dd></summary>
<hr>
      
cmd/mo-service/launch.go

<li>Changed return value from <code>nil</code> to <code>err</code> in <code>startService</code> function.<br> <li> Implemented a retry mechanism with a 5-second timeout for each request <br>in <code>waitHAKeeperReady</code>.<br> <li> Added a total timeout of 5 minutes for waiting for HAKeeper to be <br>ready.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16760/files#diff-6247ef95ea72c5554a28815b41518af3417822dd0ffa657e0e218c45cc2882f0">+21/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hakeeper_client.go</strong><dd><code>Improve HAKeeper client creation robustness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/logservice/hakeeper_client.go

<li>Modified <code>newHAKeeperClient</code> to handle <code>hakeeperClient</code> creation more <br>robustly.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16760/files#diff-c7331e35f5f5a11d64de6e28748b7272b3e79764e9329e64fd3f48d1acc971b1">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update dependencies in go.mod file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
go.mod

<li>Added <code>github.com/google/pprof</code> as a direct dependency.<br> <li> Removed duplicate indirect dependency on <code>github.com/google/pprof</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16760/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

