### PR TITLE
[bug] launch: fix timeout mechanism when TN service startup

### DIFF
--- a/pkg/logservice/hakeeper_client.go
+++ b/pkg/logservice/hakeeper_client.go
@@ -548,14 +548,15 @@ type hakeeperClient struct {
 func newHAKeeperClient(ctx context.Context,
 	cfg HAKeeperClientConfig) (*hakeeperClient, error) {
 	var err error
+	var c *hakeeperClient
 	// If the discovery address is configured, we used it first.
 	if len(cfg.DiscoveryAddress) > 0 {
-		c, err := connectByReverseProxy(ctx, cfg.DiscoveryAddress, cfg)
+		c, err = connectByReverseProxy(ctx, cfg.DiscoveryAddress, cfg)
 		if c != nil && err == nil {
 			return c, nil
 		}
 	} else if len(cfg.ServiceAddresses) > 0 {
-		c, err := connectToHAKeeper(ctx, cfg.ServiceAddresses, cfg)
+		c, err = connectToHAKeeper(ctx, cfg.ServiceAddresses, cfg)
 		if c != nil && err == nil {
 			return c, nil
 		}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/3450

## What this PR does / why we need it:
fix timeout mechanism when TN service startup:
5m timeout for total wait and 5s timeout for each request.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the timeout mechanism when starting the TN service by implementing a retry mechanism with a 5-second timeout for each request and a total wait time of 5 minutes.
- Changed the return value in the `startTNServiceCluster` function to return an error instead of nil.
- Improved the client connection logic in the `newHAKeeperClient` function to handle discovery and service addresses more robustly.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>launch.go</strong><dd><code>Fix timeout and retry mechanism for TN service startup</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
cmd/mo-service/launch.go

<li>Changed return value in <code>startTNServiceCluster</code> function to return an <br>error instead of nil.<br> <li> Implemented a retry mechanism with a 5-second timeout for each request <br>and a total wait time of 5 minutes in <code>waitHAKeeperReady</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16761/files#diff-6247ef95ea72c5554a28815b41518af3417822dd0ffa657e0e218c45cc2882f0">+21/-10</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hakeeper_client.go</strong><dd><code>Improve client connection logic in HAKeeper client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/logservice/hakeeper_client.go

<li>Modified <code>newHAKeeperClient</code> to handle the discovery address and service <br>addresses more robustly.<br> <li> Ensured that the client is returned only if it is successfully <br>created.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16761/files#diff-c7331e35f5f5a11d64de6e28748b7272b3e79764e9329e64fd3f48d1acc971b1">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

