### PR TITLE
[BugFix]: Remove unnecessary projections in master index

### DIFF
--- a/pkg/sql/plan/runtime_filter.go
+++ b/pkg/sql/plan/runtime_filter.go
@@ -15,6 +15,7 @@
 package plan
 
 import (
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -53,6 +54,10 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 
 	for _, childID := range node.Children {
 		builder.generateRuntimeFilters(childID)
+	}
+
+	if builder.isMasterIndexInnerJoin(node) {
+		return
 	}
 
 	// Build runtime filters only for broadcast join
@@ -258,4 +263,66 @@ func (builder *QueryBuilder) generateRuntimeFilters(nodeID int32) {
 
 	node.RuntimeFilterBuildList = append(node.RuntimeFilterBuildList, MakeRuntimeFilter(rfTag, cnt < len(tableDef.Pkey.Names), GetInFilterCardLimitOnPK(leftChild.Stats.TableCnt), buildExpr))
 	recalcStatsByRuntimeFilter(leftChild, node, builder)
+}
+
+func (builder *QueryBuilder) isMasterIndexInnerJoin(node *plan.Node) bool {
+	// In Master Index, INNER Joins in the query plan should not have runtime filters, as it sets
+	// input rows to 0 for right child, which is not expected.
+	// https://github.com/matrixorigin/matrixone/issues/14876#issuecomment-2148824892
+	if !(node.JoinType == plan.Node_INNER && len(node.Children) == 2) {
+		return false
+	}
+
+	leftChild := builder.qry.Nodes[node.Children[0]]
+	rightChild := builder.qry.Nodes[node.Children[1]]
+
+	if leftChild.TableDef == nil || leftChild.TableDef.Cols == nil || len(leftChild.TableDef.Cols) != 3 {
+		return false
+	}
+
+	if rightChild.TableDef == nil || rightChild.TableDef.Cols == nil || len(rightChild.TableDef.Cols) != 3 {
+		return false
+	}
+
+	// In Master Index, both the children are from the same master index table.
+	if leftChild.TableDef.Name != rightChild.TableDef.Name {
+		return false
+	}
+
+	// Check if left child is a master/secondary index table
+	//TODO: verify if Cols will contain  __mo_cpkey
+	leftIsSecondaryIndexOrMasterIndexHiddenTable := true
+	for _, column := range leftChild.TableDef.Cols {
+		if column.Name == catalog.MasterIndexTablePrimaryColName {
+			continue
+		}
+		if column.Name == catalog.MasterIndexTableIndexColName {
+			continue
+		}
+		if column.Name == catalog.Row_ID {
+			continue
+		}
+		leftIsSecondaryIndexOrMasterIndexHiddenTable = false
+	}
+
+	// Check if right child is a master/secondary index table
+	rightIsSecondaryIndexOrMasterIndexHiddenTable := true
+	for _, column := range rightChild.TableDef.Cols {
+		if column.Name == catalog.MasterIndexTablePrimaryColName {
+			continue
+		}
+		if column.Name == catalog.MasterIndexTableIndexColName {
+			continue
+		}
+		if column.Name == catalog.Row_ID {
+			continue
+		}
+		rightIsSecondaryIndexOrMasterIndexHiddenTable = false
+	}
+
+	if leftIsSecondaryIndexOrMasterIndexHiddenTable && rightIsSecondaryIndexOrMasterIndexHiddenTable {
+		return true
+	}
+
+	return false
 }

--- a/pkg/sql/plan/runtime_filter.go
+++ b/pkg/sql/plan/runtime_filter.go
@@ -291,7 +291,6 @@ func (builder *QueryBuilder) isMasterIndexInnerJoin(node *plan.Node) bool {
 
 	// Check if left child is a master/secondary index table
 	//TODO: verify if Cols will contain  __mo_cpkey
-	leftIsSecondaryIndexOrMasterIndexHiddenTable := true
 	for _, column := range leftChild.TableDef.Cols {
 		if column.Name == catalog.MasterIndexTablePrimaryColName {
 			continue
@@ -302,11 +301,10 @@ func (builder *QueryBuilder) isMasterIndexInnerJoin(node *plan.Node) bool {
 		if column.Name == catalog.Row_ID {
 			continue
 		}
-		leftIsSecondaryIndexOrMasterIndexHiddenTable = false
+		return false
 	}
 
 	// Check if right child is a master/secondary index table
-	rightIsSecondaryIndexOrMasterIndexHiddenTable := true
 	for _, column := range rightChild.TableDef.Cols {
 		if column.Name == catalog.MasterIndexTablePrimaryColName {
 			continue
@@ -317,12 +315,9 @@ func (builder *QueryBuilder) isMasterIndexInnerJoin(node *plan.Node) bool {
 		if column.Name == catalog.Row_ID {
 			continue
 		}
-		rightIsSecondaryIndexOrMasterIndexHiddenTable = false
+		return false
 	}
 
-	if leftIsSecondaryIndexOrMasterIndexHiddenTable && rightIsSecondaryIndexOrMasterIndexHiddenTable {
-		return true
-	}
+	return true
 
-	return false
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/14876

## What this PR does / why we need it:

Remove unnecessary projects from Master Index.

```sql
mysql> explain analyze SELECT tbl.a100  FROM tbl  WHERE tbl.a75 = 'I2nJ0RqIQu';
+---------------------------------------------------------------------------------------------------------------------------------------------------------+
| AP QUERY PLAN ON MULTICN(10 core)                                                                                                                       |
+---------------------------------------------------------------------------------------------------------------------------------------------------------+
| Project                                                                                                                                                 |
|   Analyze: timeConsumed=0ms waitTime=6ms inputRows=2 outputRows=1 InputSize=48bytes OutputSize=24bytes MemorySize=0bytes                                |
|   ->  Join                                                                                                                                              |
|         Analyze: timeConsumed=2ms waitTime=44ms inputRows=2 outputRows=1 InputSize=48bytes OutputSize=24bytes MemorySize=0bytes                         |
|         Join Type: INDEX                                                                                                                                |
|         Join Cond: (tbl.a100 = #[1,0])                                                                                                                  |
|         Runtime Filter Build: #[-1,0]                                                                                                                   |
|         ->  Table Scan on a.tbl [ForceOneCN]                                                                                                            |
|               Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=1 inputRows=1 outputRows=1 InputSize=48bytes OutputSize=24bytes MemorySize=50bytes     |
|               Filter Cond: (tbl.a75 = 'I2nJ0RqIQu')                                                                                                     |
|               Block Filter Cond: (tbl.a75 = 'I2nJ0RqIQu')                                                                                               |
|               Runtime Filter Probe: tbl.a100                                                                                                            |
|         ->  Table Scan on a.__mo_index_secondary_019003d8-3fd8-7455-b750-bd977ca13178 [ForceOneCN]                                                      |
|               Analyze: timeConsumed=2ms waitTime=0ms inputBlocks=6 inputRows=49152 outputRows=1 InputSize=3mb OutputSize=24bytes MemorySize=696320bytes |
|               Filter Cond: prefix_eq(#[0,0], 'F74 FI2nJ0RqIQu ')                                                                                      |
|               Block Filter Cond: prefix_eq(#[0,0], 'F74 FI2nJ0RqIQu ')                                                                                |
+---------------------------------------------------------------------------------------------------------------------------------------------------------+
16 rows in set (0.01 sec)


mysql> explain analyze SELECT tbl.a100  FROM tbl  WHERE tbl.a37 = '3Tfm6CEXy5' AND tbl.a94 = '6PRBdXpsVB';
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| AP QUERY PLAN ON MULTICN(10 core)                                                                                                                                                                         |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Project                                                                                                                                                                                                   |
|   Analyze: timeConsumed=0ms waitTime=15ms inputRows=3 outputRows=1 InputSize=72bytes OutputSize=24bytes MemorySize=0bytes                                                                                 |
|   ->  Join                                                                                                                                                                                                |
|         Analyze: timeConsumed=4ms waitTime=72ms inputRows=2 outputRows=1 InputSize=48bytes OutputSize=24bytes MemorySize=0bytes                                                                           |
|         Join Type: INDEX                                                                                                                                                                                  |
|         Join Cond: (tbl.a100 = #[1,0])                                                                                                                                                                    |
|         Runtime Filter Build: #[-1,0]                                                                                                                                                                     |
|         ->  Table Scan on a.tbl [ForceOneCN]                                                                                                                                                              |
|               Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=1 inputRows=1 outputRows=1 InputSize=72bytes OutputSize=24bytes MemorySize=75bytes                                                       |
|               Filter Cond: (tbl.a94 = '6PRBdXpsVB'), (tbl.a37 = '3Tfm6CEXy5')                                                                                                                             |
|               Block Filter Cond: (tbl.a94 = '6PRBdXpsVB'), (tbl.a37 = '3Tfm6CEXy5')                                                                                                                       |
|               Runtime Filter Probe: tbl.a100                                                                                                                                                              |
|         ->  Join                                                                                                                                                                                          |
|               Analyze: timeConsumed=4ms probe_time=[total=0ms,min=0ms,max=0ms,dop=10] build_time=[4ms] waitTime=57ms inputRows=2 outputRows=1 InputSize=48bytes OutputSize=24bytes MemorySize=361187bytes |
|               Join Type: INNER                                                                                                                                                                            |
|               Join Cond: (#[0,0] = #[1,0])                                                                                                                                                                |
|               ->  Table Scan on a.__mo_index_secondary_019003d8-3fd8-7455-b750-bd977ca13178 [ForceOneCN]                                                                                                  |
|                     Analyze: timeConsumed=3ms waitTime=0ms inputBlocks=4 inputRows=32768 outputRows=1 InputSize=2mb OutputSize=24bytes MemorySize=679936bytes                                             |
|                     Filter Cond: prefix_eq(#[0,0], 'F36 F3Tfm6CEXy5 ')                                                                                                                                  |
|                     Block Filter Cond: prefix_eq(#[0,0], 'F36 F3Tfm6CEXy5 ')                                                                                                                            |
|               ->  Table Scan on a.__mo_index_secondary_019003d8-3fd8-7455-b750-bd977ca13178 [ForceOneCN]                                                                                                  |
|                     Analyze: timeConsumed=3ms waitTime=0ms inputBlocks=6 inputRows=49152 outputRows=1 InputSize=3mb OutputSize=24bytes MemorySize=696320bytes                                             |
|                     Filter Cond: prefix_eq(#[0,0], 'F93 F6PRBdXpsVB ')                                                                                                                                  |
|                     Block Filter Cond: prefix_eq(#[0,0], 'F93 F6PRBdXpsVB ')                                                                                                                            |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
24 rows in set (0.00 sec)

```


___

### **PR Type**
Bug fix


___

### **Description**
- Removed unnecessary projections from index table scans in `apply_indices_master.go`.
- Adjusted column positions for primary key columns in `apply_indices_master.go`.
- Added a check in `runtime_filter.go` to skip runtime filter generation for Master Index INNER Joins.
- Implemented `isMasterIndexInnerJoin` function to identify Master Index INNER Joins and prevent runtime filter application.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>apply_indices_master.go</strong><dd><code>Remove unnecessary projections and adjust column positions</code></dd></summary>
<hr>
      
pkg/sql/plan/apply_indices_master.go

<li>Removed unnecessary projections from index table scans.<br> <li> Adjusted column positions for primary key columns.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16766/files#diff-54eef50579b1530b896371b1ac32b6e0a743cf473b18410ca47a0059b3facc50">+5/-23</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>runtime_filter.go</strong><dd><code>Skip runtime filters for Master Index INNER Joins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/runtime_filter.go

<li>Added a check to skip runtime filter generation for Master Index INNER <br>Joins.<br> <li> Implemented <code>isMasterIndexInnerJoin</code> function to identify such joins.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16766/files#diff-597fe1a4b6c932d815482502c1ae60c5f8c69921e00b27dba2f5e4ea5b25b54b">+62/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

