### PR TITLE
malloc: various changes and optimizations

### DIFF
--- a/pkg/common/malloc/allocator.go
+++ b/pkg/common/malloc/allocator.go
@@ -17,7 +17,7 @@ package malloc
 import "unsafe"
 
 type Allocator interface {
-	Allocate(size uint64) (unsafe.Pointer, Deallocator)
+	Allocate(size uint64) (unsafe.Pointer, Deallocator, error)
 }
 
 type Deallocator interface {

--- a/pkg/common/malloc/allocator_bench_test.go
+++ b/pkg/common/malloc/allocator_bench_test.go
@@ -33,7 +33,10 @@ func benchmarkAllocator(
 		allcator := newAllocator()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			ptr, dec := allcator.Allocate(n)
+			ptr, dec, err := allcator.Allocate(n)
+			if err != nil {
+				b.Fatal(err)
+			}
 			dec.Deallocate(ptr)
 		}
 	})
@@ -43,7 +46,10 @@ func benchmarkAllocator(
 		b.ResetTimer()
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
-				ptr, dec := allcator.Allocate(n)
+				ptr, dec, err := allcator.Allocate(n)
+				if err != nil {
+					b.Fatal(err)
+				}
 				dec.Deallocate(ptr)
 			}
 		})

--- a/pkg/common/malloc/allocator_test.go
+++ b/pkg/common/malloc/allocator_test.go
@@ -29,7 +29,10 @@ func testAllocator(
 	t.Run("allocate", func(t *testing.T) {
 		allocator := newAllocator()
 		for i := uint64(1); i < 128*MB; i = uint64(math.Ceil(float64(i) * 1.1)) {
-			ptr, dec := allocator.Allocate(i)
+			ptr, dec, err := allocator.Allocate(i)
+			if err != nil {
+				t.Fatal(err)
+			}
 			slice := unsafe.Slice((*byte)(ptr), i)
 			for _, i := range slice {
 				if i != 0 {

--- a/pkg/common/malloc/c_allocator.go
+++ b/pkg/common/malloc/c_allocator.go
@@ -30,10 +30,10 @@ func NewCAllocator() *CAllocator {
 
 var _ Allocator = new(CAllocator)
 
-func (c *CAllocator) Allocate(size uint64) (unsafe.Pointer, Deallocator) {
+func (c *CAllocator) Allocate(size uint64) (unsafe.Pointer, Deallocator, error) {
 	ptr := C.malloc(C.ulong(size))
 	clear(unsafe.Slice((*byte)(ptr), size))
-	return ptr, c
+	return ptr, c, nil
 }
 
 var _ Deallocator = new(CAllocator)

--- a/pkg/common/malloc/checked_deallocator_test.go
+++ b/pkg/common/malloc/checked_deallocator_test.go
@@ -35,15 +35,21 @@ func TestCheckedDeallocator(t *testing.T) {
 				t.Fatalf("got %v", msg)
 			}
 		}()
-		ptr, dec := allocator.Allocate(42)
+		ptr, dec, err := allocator.Allocate(42)
+		if err != nil {
+			t.Fatal(err)
+		}
 		dec.Deallocate(ptr)
 		dec.Deallocate(ptr)
 	}()
 
 	func() {
-		ptr, dec := allocator.Allocate(42)
+		ptr, dec, err := allocator.Allocate(42)
 		_ = ptr
 		_ = dec
+		if err != nil {
+			t.Fatal(err)
+		}
 		dec.Deallocate(ptr) // comment out this line to trigger memory leak panic
 	}()
 	runtime.GC()

--- a/pkg/common/malloc/config.go
+++ b/pkg/common/malloc/config.go
@@ -41,7 +41,7 @@ var defaultConfig = func() *atomic.Pointer[Config] {
 	ret.Store(&Config{
 		CheckFraction:     ptrTo(uint32(65536)),
 		EnableMetrics:     ptrTo(true),
-		FullStackFraction: ptrTo(uint32(16)),
+		FullStackFraction: ptrTo(uint32(10)),
 	})
 
 	return ret

--- a/pkg/common/malloc/default_test.go
+++ b/pkg/common/malloc/default_test.go
@@ -20,20 +20,20 @@ import (
 
 func TestDefaultAllocator(t *testing.T) {
 	testAllocator(t, func() Allocator {
-		return NewDefault(nil)
+		return GetDefault(nil)
 	})
 }
 
 func BenchmarkDefaultAllocator(b *testing.B) {
 	for _, n := range benchNs {
 		benchmarkAllocator(b, func() Allocator {
-			return NewDefault(nil)
+			return GetDefault(nil)
 		}, n)
 	}
 }
 
 func FuzzDefaultAllocator(f *testing.F) {
 	fuzzAllocator(f, func() Allocator {
-		return NewDefault(nil)
+		return GetDefault(nil)
 	})
 }

--- a/pkg/common/malloc/fuzz_test.go
+++ b/pkg/common/malloc/fuzz_test.go
@@ -32,7 +32,10 @@ func fuzzAllocator(
 		}
 
 		size := i % (8 * GB)
-		ptr, dec := allocator.Allocate(size)
+		ptr, dec, err := allocator.Allocate(size)
+		if err != nil {
+			t.Fatal(err)
+		}
 		defer dec.Deallocate(ptr)
 
 		slice := unsafe.Slice((*byte)(ptr), size)
@@ -50,7 +53,7 @@ func fuzzAllocator(
 			}
 		}
 
-		time.Sleep(time.Duration(i) % (time.Millisecond * 50))
+		time.Sleep(time.Duration(i) % (time.Microsecond * 50))
 
 	})
 }

--- a/pkg/common/malloc/profile_allocator.go
+++ b/pkg/common/malloc/profile_allocator.go
@@ -15,6 +15,7 @@
 package malloc
 
 import (
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -23,13 +24,20 @@ import (
 )
 
 type HeapSampleValues struct {
-	AllocatedObjects atomic.Int64
-	AllocatedBytes   atomic.Int64
-	InuseObjects     atomic.Int64
-	InuseBytes       atomic.Int64
+	AllocatedObjects ShardedCounter[int64, atomic.Int64, *atomic.Int64]
+	AllocatedBytes   ShardedCounter[int64, atomic.Int64, *atomic.Int64]
+	InuseObjects     ShardedCounter[int64, atomic.Int64, *atomic.Int64]
+	InuseBytes       ShardedCounter[int64, atomic.Int64, *atomic.Int64]
 }
 
 var _ SampleValues = new(HeapSampleValues)
+
+func (h *HeapSampleValues) Init() {
+	h.AllocatedObjects = *NewShardedCounter[int64, atomic.Int64](runtime.GOMAXPROCS(0))
+	h.AllocatedBytes = *NewShardedCounter[int64, atomic.Int64](runtime.GOMAXPROCS(0))
+	h.InuseObjects = *NewShardedCounter[int64, atomic.Int64](runtime.GOMAXPROCS(0))
+	h.InuseBytes = *NewShardedCounter[int64, atomic.Int64](runtime.GOMAXPROCS(0))
+}
 
 func (h *HeapSampleValues) DefaultSampleType() string {
 	return "inuse_bytes"
@@ -105,9 +113,13 @@ type profileDeallocateArgs struct {
 
 var _ Allocator = new(ProfileAllocator)
 
-func (p *ProfileAllocator) Allocate(size uint64) (unsafe.Pointer, Deallocator) {
-	ptr, dec := p.upstream.Allocate(size)
-	values := p.profiler.Sample(1, p.profileFraction)
+func (p *ProfileAllocator) Allocate(size uint64) (unsafe.Pointer, Deallocator, error) {
+	ptr, dec, err := p.upstream.Allocate(size)
+	if err != nil {
+		return nil, nil, err
+	}
+	const skip = 1 // p.Allocate
+	values := p.profiler.Sample(skip, p.profileFraction)
 	values.AllocatedBytes.Add(int64(size))
 	values.AllocatedObjects.Add(1)
 	values.InuseBytes.Add(int64(size))
@@ -117,5 +129,5 @@ func (p *ProfileAllocator) Allocate(size uint64) (unsafe.Pointer, Deallocator) {
 		values: values,
 		size:   size,
 	})
-	return ptr, ChainDeallocator(dec, fn)
+	return ptr, ChainDeallocator(dec, fn), nil
 }

--- a/pkg/common/malloc/profile_allocator_test.go
+++ b/pkg/common/malloc/profile_allocator_test.go
@@ -19,7 +19,7 @@ import "testing"
 func TestProfileAllocator(t *testing.T) {
 	testAllocator(t, func() Allocator {
 		return NewProfileAllocator(
-			NewDefault(nil),
+			GetDefault(nil),
 			NewProfiler[HeapSampleValues](),
 			1,
 		)
@@ -30,7 +30,7 @@ func BenchmarkProfileAllocator(b *testing.B) {
 	for _, n := range benchNs {
 		benchmarkAllocator(b, func() Allocator {
 			return NewProfileAllocator(
-				NewDefault(nil),
+				GetDefault(nil),
 				NewProfiler[HeapSampleValues](),
 				1,
 			)
@@ -41,7 +41,7 @@ func BenchmarkProfileAllocator(b *testing.B) {
 func FuzzProfileAllocator(f *testing.F) {
 	fuzzAllocator(f, func() Allocator {
 		return NewProfileAllocator(
-			NewDefault(nil),
+			GetDefault(nil),
 			NewProfiler[HeapSampleValues](),
 			1,
 		)

--- a/pkg/common/malloc/profiler_test.go
+++ b/pkg/common/malloc/profiler_test.go
@@ -17,6 +17,7 @@ package malloc
 import (
 	"io"
 	"os"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -28,6 +29,8 @@ type testSampleValues struct {
 	N atomic.Int64
 	A atomic.Int64
 }
+
+func (t *testSampleValues) Init() {}
 
 func (t *testSampleValues) SampleTypes() []*profile.ValueType {
 	return []*profile.ValueType{
@@ -130,4 +133,12 @@ func BenchmarkProfilerWrite(b *testing.B) {
 			}
 		}
 	})
+}
+
+func BenchmarkCallers(b *testing.B) {
+	pcs := make([]uintptr, 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime.Callers(1, pcs)
+	}
 }

--- a/pkg/common/malloc/pure_go_class_allocator.go
+++ b/pkg/common/malloc/pure_go_class_allocator.go
@@ -119,16 +119,16 @@ func (p *PureGoClassAllocator) classAllocate(class int) *pureGoClassAllocatorHan
 	}
 }
 
-func (p *PureGoClassAllocator) Allocate(size uint64) (unsafe.Pointer, Deallocator) {
+func (p *PureGoClassAllocator) Allocate(size uint64) (unsafe.Pointer, Deallocator, error) {
 	if size == 0 {
-		return nil, dumbHandle
+		return nil, dumbHandle, nil
 	}
 	class := p.requestSizeToClass(size)
 	if class == -1 {
-		return unsafe.Pointer(unsafe.SliceData(make([]byte, size))), dumbHandle
+		return unsafe.Pointer(unsafe.SliceData(make([]byte, size))), dumbHandle, nil
 	}
 	handle := p.classAllocate(class)
-	return handle.ptr, handle
+	return handle.ptr, handle, nil
 }
 
 func (h *pureGoClassAllocatorHandle) Deallocate(_ unsafe.Pointer) {

--- a/pkg/common/malloc/sharded_allocator.go
+++ b/pkg/common/malloc/sharded_allocator.go
@@ -28,7 +28,7 @@ func NewShardedAllocator(numShards int, newShard func() Allocator) ShardedAlloca
 
 var _ Allocator = ShardedAllocator{}
 
-func (s ShardedAllocator) Allocate(size uint64) (unsafe.Pointer, Deallocator) {
+func (s ShardedAllocator) Allocate(size uint64) (unsafe.Pointer, Deallocator, error) {
 	pid := runtime_procPin()
 	runtime_procUnpin()
 	return s[pid%len(s)].Allocate(size)

--- a/pkg/common/malloc/sharded_counter.go
+++ b/pkg/common/malloc/sharded_counter.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+type AtomicInteger[T any] interface {
+	Add(T) T
+	Load() T
+}
+
+type CounterInteger interface {
+	int32 | int64 | uint32 | uint64
+}
+
+type ShardedCounter[T CounterInteger, A any, P interface {
+	*A
+	AtomicInteger[T]
+}] struct {
+	shards []A
+}
+
+func NewShardedCounter[T CounterInteger, A any, P interface {
+	*A
+	AtomicInteger[T]
+}](shards int) *ShardedCounter[T, A, P] {
+	return &ShardedCounter[T, A, P]{
+		shards: make([]A, shards),
+	}
+}
+
+func (s *ShardedCounter[T, A, P]) Add(v T) {
+	pid := runtime_procPin()
+	runtime_procUnpin()
+	shard := pid % len(s.shards)
+	P(&s.shards[shard]).Add(v)
+}
+
+func (s *ShardedCounter[T, A, P]) Load() (ret T) {
+	for i := 0; i < len(s.shards); i++ {
+		ret += P(&s.shards[i]).Load()
+	}
+	return ret
+}

--- a/pkg/common/malloc/sharded_counter_test.go
+++ b/pkg/common/malloc/sharded_counter_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestShardedCounter(t *testing.T) {
+	counter := NewShardedCounter[int64, atomic.Int64](128)
+	wg := new(sync.WaitGroup)
+	n := 128
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1024; i++ {
+				counter.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if n := counter.Load(); n != 128*1024 {
+		t.Fatalf("got %v\n", n)
+	}
+}
+
+func BenchmarkShardedCounter(b *testing.B) {
+	counter := NewShardedCounter[int64, atomic.Int64](runtime.GOMAXPROCS(0))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			counter.Add(1)
+		}
+	})
+}
+
+func BenchmarkAtomicCounter(b *testing.B) {
+	counter := new(atomic.Int64)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			counter.Add(1)
+		}
+	})
+}

--- a/pkg/common/malloc/size_bounded_allocator.go
+++ b/pkg/common/malloc/size_bounded_allocator.go
@@ -1,0 +1,85 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+)
+
+type SizeBoundedAllocator struct {
+	upstream Allocator
+	max      uint64
+	counter  *atomic.Uint64
+	funcPool sync.Pool
+}
+
+func NewSizeBoundedAllocator(upstream Allocator, maxSize uint64, counter *atomic.Uint64) *SizeBoundedAllocator {
+	if counter == nil {
+		counter = new(atomic.Uint64)
+	}
+
+	ret := &SizeBoundedAllocator{
+		max:      maxSize,
+		upstream: upstream,
+		counter:  counter,
+	}
+
+	ret.funcPool = sync.Pool{
+		New: func() any {
+			argumented := new(argumentedFuncDeallocator[uint64])
+			argumented.fn = func(_ unsafe.Pointer, size uint64) {
+				ret.counter.Add(-size)
+				ret.funcPool.Put(argumented)
+			}
+			return argumented
+		},
+	}
+
+	return ret
+}
+
+var _ Allocator = new(SizeBoundedAllocator)
+
+func (s *SizeBoundedAllocator) Allocate(size uint64) (unsafe.Pointer, Deallocator, error) {
+	for {
+
+		cur := s.counter.Load()
+		newInuse := cur + size
+		if newInuse > s.max {
+			return nil, nil, moerr.NewInternalErrorNoCtx("out of space")
+		}
+
+		swapped := s.counter.CompareAndSwap(cur, newInuse)
+		if !swapped {
+			continue
+		}
+
+		ptr, dec, err := s.upstream.Allocate(size)
+		if err != nil {
+			// give back
+			s.counter.Add(-size)
+			return nil, nil, err
+		}
+
+		fn := s.funcPool.Get().(*argumentedFuncDeallocator[uint64])
+		fn.SetArgument(size)
+		return ptr, ChainDeallocator(dec, fn), nil
+	}
+
+}

--- a/pkg/common/malloc/size_bounded_allocator_test.go
+++ b/pkg/common/malloc/size_bounded_allocator_test.go
@@ -14,30 +14,53 @@
 
 package malloc
 
-import "testing"
+import (
+	"testing"
 
-func TestMetricsAllocator(t *testing.T) {
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSizeBoundedAllocator(t *testing.T) {
 	testAllocator(t, func() Allocator {
-		return NewMetricsAllocator(
+		return NewSizeBoundedAllocator(
 			GetDefault(nil),
+			1<<40,
+			nil,
 		)
+	})
+
+	t.Run("out of space", func(t *testing.T) {
+		allocator := NewSizeBoundedAllocator(GetDefault(nil), 24, nil)
+		p1, d1, err := allocator.Allocate(12)
+		assert.Nil(t, err)
+		_, _, err = allocator.Allocate(12)
+		assert.Nil(t, err)
+		_, _, err = allocator.Allocate(12)
+		assert.ErrorContains(t, err, "out of space")
+		d1.Deallocate(p1)
+		_, _, err = allocator.Allocate(12)
+		assert.Nil(t, err)
 	})
 }
 
-func BenchmarkMetricsAllocator(b *testing.B) {
+func BenchmarkSizeBoundedAllocator(b *testing.B) {
 	for _, n := range benchNs {
 		benchmarkAllocator(b, func() Allocator {
-			return NewMetricsAllocator(
+			return NewSizeBoundedAllocator(
 				GetDefault(nil),
+				1<<40,
+				nil,
 			)
 		}, n)
 	}
 }
 
-func FuzzMetricsAllocator(f *testing.F) {
+func FuzzSizeBoundedAllocator(f *testing.F) {
 	fuzzAllocator(f, func() Allocator {
-		return NewMetricsAllocator(
+		return NewSizeBoundedAllocator(
 			GetDefault(nil),
+			1<<40,
+			nil,
 		)
 	})
 }

--- a/pkg/fileservice/bytes.go
+++ b/pkg/fileservice/bytes.go
@@ -55,7 +55,10 @@ type bytesAllocator struct {
 var _ CacheDataAllocator = new(bytesAllocator)
 
 func (b *bytesAllocator) Alloc(size int) memorycache.CacheData {
-	ptr, dec := b.allocator.Allocate(uint64(size))
+	ptr, dec, err := b.allocator.Allocate(uint64(size))
+	if err != nil {
+		panic(err)
+	}
 	metric.FSMallocLiveObjectsBytes.Inc()
 	return Bytes{
 		bytes:       unsafe.Slice((*byte)(ptr), size),

--- a/pkg/fileservice/io_entry.go
+++ b/pkg/fileservice/io_entry.go
@@ -90,7 +90,10 @@ func CacheOriginalData(r io.Reader, data []byte, allocator CacheDataAllocator) (
 
 func (i *IOEntry) prepareData() (finally func(err *error)) {
 	if cap(i.Data) < int(i.Size) {
-		ptr, dec := getMallocAllocator().Allocate(uint64(i.Size))
+		ptr, dec, err := getMallocAllocator().Allocate(uint64(i.Size))
+		if err != nil {
+			panic(err)
+		}
 		metric.FSMallocLiveObjectsIOEntryData.Inc()
 		i.Data = unsafe.Slice((*byte)(ptr), i.Size)
 		if i.releaseData != nil {

--- a/pkg/fileservice/malloc.go
+++ b/pkg/fileservice/malloc.go
@@ -28,7 +28,7 @@ func getMallocAllocator() malloc.Allocator {
 	// delay initialization of global allocator
 	// ugly, but we tend to read malloc config from files instead of env vars
 	initMallocAllocatorOnce.Do(func() {
-		_mallocAllocator = malloc.NewDefault(nil)
+		_mallocAllocator = malloc.GetDefault(nil)
 	})
 	return _mallocAllocator
 }

--- a/pkg/fileservice/memorycache/cache_test.go
+++ b/pkg/fileservice/memorycache/cache_test.go
@@ -30,7 +30,7 @@ func TestCache(t *testing.T) {
 		func(key cache.CacheKey, value CacheData) {},
 		func(key cache.CacheKey, value CacheData) {},
 		func(key cache.CacheKey, value CacheData) {},
-		malloc.NewDefault(nil),
+		malloc.GetDefault(nil),
 	)
 	// test Alloc and Set
 	key := cache.CacheKey{Path: "x", Sz: 1}

--- a/pkg/fileservice/memorycache/data.go
+++ b/pkg/fileservice/memorycache/data.go
@@ -49,7 +49,11 @@ func newData(
 		size:       size,
 		globalSize: globalSize,
 	}
-	data.ptr, data.deallocator = allocator.Allocate(uint64(size))
+	var err error
+	data.ptr, data.deallocator, err = allocator.Allocate(uint64(size))
+	if err != nil {
+		panic(err)
+	}
 	metric.FSMallocLiveObjectsMemoryCache.Inc()
 	data.buf = unsafe.Slice((*byte)(data.ptr), size)
 	data.ref.init(1)

--- a/pkg/fileservice/memorycache/data_test.go
+++ b/pkg/fileservice/memorycache/data_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestData(t *testing.T) {
-	allocator := malloc.NewDefault(nil)
+	allocator := malloc.GetDefault(nil)
 
 	var size atomic.Int64
 	d := newData(allocator, 1, &size)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16667 

## What this PR does / why we need it:
more optimizations for malloc profile

performance comparison
```
goos: linux
goarch: amd64
pkg: github.com/matrixorigin/matrixone/pkg/common/malloc
cpu: AMD Ryzen 9 7900 12-Core Processor             
                                        │      b1      │                  b2                   │
                                        │    sec/op    │    sec/op     vs base                 │
DefaultAllocator/allocate:_n_64-24        222.0n ± ∞ ¹   120.1n ± ∞ ¹        ~ (p=1.000 n=1) ²
DefaultAllocator/parallel:_n_64-24        30.90n ± ∞ ¹   29.84n ± ∞ ¹        ~ (p=1.000 n=1) ²
DefaultAllocator/allocate:_n_4096-24      256.1n ± ∞ ¹   139.8n ± ∞ ¹        ~ (p=1.000 n=1) ²
DefaultAllocator/parallel:_n_4096-24      34.70n ± ∞ ¹   32.21n ± ∞ ¹        ~ (p=1.000 n=1) ²
DefaultAllocator/allocate:_n_2097152-24   400.2n ± ∞ ¹   254.6n ± ∞ ¹        ~ (p=1.000 n=1) ²
DefaultAllocator/parallel:_n_2097152-24   801.9n ± ∞ ¹   803.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                   164.2n         122.0n        -25.66%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                        │      b1      │                  b2                  │
                                        │     B/op     │    B/op      vs base                 │
DefaultAllocator/allocate:_n_64-24        27.000 ± ∞ ¹   1.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
DefaultAllocator/parallel:_n_64-24        27.000 ± ∞ ¹   1.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
DefaultAllocator/allocate:_n_4096-24      27.000 ± ∞ ¹   1.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
DefaultAllocator/parallel:_n_4096-24      27.000 ± ∞ ¹   1.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
DefaultAllocator/allocate:_n_2097152-24   27.000 ± ∞ ¹   1.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
DefaultAllocator/parallel:_n_2097152-24   28.000 ± ∞ ¹   1.000 ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                    27.16         1.000        -96.32%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                        │     b1      │                b2                │
                                        │  allocs/op  │  allocs/op   vs base             │
DefaultAllocator/allocate:_n_64-24        1.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
DefaultAllocator/parallel:_n_64-24        1.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
DefaultAllocator/allocate:_n_4096-24      1.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
DefaultAllocator/parallel:_n_4096-24      1.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
DefaultAllocator/allocate:_n_2097152-24   1.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
DefaultAllocator/parallel:_n_2097152-24   1.000 ± ∞ ¹   0.000 ± ∞ ¹  ~ (p=1.000 n=1) ²
geomean                                   1.000                      ?               ³ ⁴
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
³ summaries must be >0 to compute geomean
⁴ ratios must be >0 to compute geomean

```