### PR TITLE
Cherry-pick-for-snapshot-read-bug

### DIFF
--- a/pkg/vm/engine/disttae/db.go
+++ b/pkg/vm/engine/disttae/db.go
@@ -395,6 +395,16 @@ func (e *Engine) getOrCreateSnapPart(
 	ctx context.Context,
 	tbl *txnTable,
 	ts types.TS) (*logtailreplay.Partition, error) {
+
+	//check whether the latest partition is available for reuse.
+	err := tbl.updateLogtail(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if p := e.getOrCreateLatestPart(tbl.db.databaseId, tbl.tableId); p.CanServe(ts) {
+		return p, nil
+	}
+
 	//check whether the snapshot partitions are available for reuse.
 	e.mu.Lock()
 	tblSnaps, ok := e.mu.snapParts[[2]uint64{tbl.db.databaseId, tbl.tableId}]

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -266,9 +266,6 @@ func (db *txnDatabase) RelationByAccountID(
 }
 
 func (db *txnDatabase) Relation(ctx context.Context, name string, proc any) (engine.Relation, error) {
-	if db.databaseName == "test" && name == "bugt" && db.op.IsSnapOp() {
-		logutil.Infof("xxxx open relation, txn:%s", db.op.Txn().DebugString())
-	}
 	logDebugf(db.op.Txn(), "txnDatabase.Relation table %s", name)
 	txn := db.getTxn()
 	if txn.op.Status() == txn2.TxnStatus_Aborted {

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/docker/go-units"
+
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -1711,7 +1712,12 @@ func (tbl *txnTable) GetDBID(ctx context.Context) uint64 {
 //   - orderedScan: Whether to scan the data in order.
 //   - txnOffset: Transaction offset used to specify the starting position for reading data.
 func (tbl *txnTable) NewReader(
-	ctx context.Context, num int, expr *plan.Expr, ranges []byte, orderedScan bool,
+	ctx context.Context,
+	num int,
+	expr *plan.Expr,
+	ranges []byte,
+	orderedScan bool,
+	txnOffset int,
 ) ([]engine.Reader, error) {
 	pkFilter := tbl.tryExtractPKFilter(expr)
 	blkArray := objectio.BlockInfoSlice(ranges)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16620 

## What this PR does / why we need it:

1. fix bug for snapshot read


___

### **PR Type**
Bug fix


___

### **Description**
- Added a check to update logtail before reusing the latest partition in `getOrCreateSnapPart` method.
- Removed debug logging for specific test conditions in `txnDatabase.Relation` method.
- Refactored partition state retrieval to use `getPartitionState` method and removed snapshot operation checks in `txnTable`.
- Simplified the `NewReader` method signature in `txnTable`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db.go</strong><dd><code>Add logtail update and reuse latest partition if possible</code></dd></summary>
<hr>
      
pkg/vm/engine/disttae/db.go

<li>Added a check to update logtail before reusing the latest partition.<br> <li> Added error handling for the logtail update.<br> <li> Added a condition to reuse the latest partition if it can serve the <br>timestamp.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16777/files#diff-510a93692a080e19d5377a183f951910b64d0f4ce39c0ac7607b6c7f9b64ccaf">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Refactor partition state retrieval and simplify NewReader method</code></dd></summary>
<hr>
      
pkg/vm/engine/disttae/txn_table.go

<li>Refactored to use <code>getPartitionState</code> method for partition state <br>retrieval.<br> <li> Removed snapshot operation checks and related logic.<br> <li> Simplified the <code>NewReader</code> method signature.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16777/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+4/-19</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Miscellaneous
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>txn_database.go</strong><dd><code>Remove debug logging for test conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/txn_database.go

- Removed debug logging for specific test conditions.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16777/files#diff-b601c249931141c71a36363da54e7072bbe6330d471fdafeaec001b7a23d529f">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

