### PR TITLE
do not rewrite on duplicate key stmt to replace for prepare

### DIFF
--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -98,7 +98,7 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 	if err != nil {
 		return nil, err
 	}
-	replaceStmt := getRewriteToReplaceStmt(tableDef, stmt, rewriteInfo)
+	replaceStmt := getRewriteToReplaceStmt(tableDef, stmt, rewriteInfo, isPrepareStmt)
 	if replaceStmt != nil {
 		return buildReplace(replaceStmt, ctx, isPrepareStmt, true)
 	}
@@ -901,11 +901,14 @@ func remapPartExprColRef(expr *Expr, colMap map[int]int, tableDef *TableDef) boo
 	return true
 }
 
-func getRewriteToReplaceStmt(tableDef *TableDef, stmt *tree.Insert, info *dmlSelectInfo) *tree.Replace {
+func getRewriteToReplaceStmt(tableDef *TableDef, stmt *tree.Insert, info *dmlSelectInfo, isPrepareStmt bool) *tree.Replace {
 	if len(info.onDuplicateIdx) == 0 {
 		return nil
 	}
 	if _, ok := stmt.Rows.Select.(*tree.ValuesClause); !ok {
+		return nil
+	}
+	if isPrepareStmt {
 		return nil
 	}
 	canUpdateCols := make([]string, 0, len(tableDef.Cols))


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16540

## What this PR does / why we need it:
when prepare from on duplicate key statement. we can not rewrite it to replace


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `isPrepareStmt` parameter to the `getRewriteToReplaceStmt` function to handle prepared statements correctly.
- Modified `buildInsert` function to pass the `isPrepareStmt` parameter to `getRewriteToReplaceStmt`.
- Updated `getRewriteToReplaceStmt` to avoid rewriting to replace statement if `isPrepareStmt` is true.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_insert.go</strong><dd><code>Fix and enhance duplicate key handling in prepared statements</code></dd></summary>
<hr>
      
pkg/sql/plan/build_insert.go

<li>Added <code>isPrepareStmt</code> parameter to <code>getRewriteToReplaceStmt</code> function.<br> <li> Modified <code>buildInsert</code> function to pass <code>isPrepareStmt</code> to <br><code>getRewriteToReplaceStmt</code>.<br> <li> Updated <code>getRewriteToReplaceStmt</code> to return <code>nil</code> if <code>isPrepareStmt</code> is <br>true.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16793/files#diff-9d0fd08ed4afb7ebd89ebb05190cd8900fd133473e4ef2e795dd5cea28ddce40">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

