### PR TITLE
[opt] retain IN expression in prepared stmt (cp to 1.2-dev)

### DIFF
--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1661,7 +1661,7 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 		// and constant's value in range of column's type, then no cast was needed
 		switch args[0].Expr.(type) {
 		case *plan.Expr_Col:
-			if checkNoNeedCast(argsType[1], argsType[0], args[1]) {
+			if argsType[0].IsVarlen() && checkNoNeedCast(argsType[1], argsType[0], args[1]) {
 				argsCastType = []types.Type{argsType[0], argsType[0]}
 				fGet, err = function.GetFunctionByName(ctx, name, argsCastType)
 				if err != nil {

--- a/pkg/sql/plan/rule/constant_fold.go
+++ b/pkg/sql/plan/rule/constant_fold.go
@@ -86,8 +86,16 @@ func (r *ConstantFold) constantFold(expr *plan.Expr, proc *process.Process) *pla
 	if fn == nil {
 		if elist := expr.GetList(); elist != nil {
 			exprList := elist.List
+			cannotFold := false
 			for i := range exprList {
 				exprList[i] = r.constantFold(exprList[i], proc)
+				if exprList[i].GetLit() == nil {
+					cannotFold = true
+				}
+			}
+
+			if cannotFold {
+				return expr
 			}
 
 			vec, err := colexec.GenerateConstListExpressionExecutor(proc, exprList)

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -628,7 +628,7 @@ func extractColRefInFilter(expr *plan.Expr) *ColRef {
 		switch exprImpl.F.Func.ObjName {
 		case "=", ">", "<", ">=", "<=", "prefix_eq", "between", "in", "prefix_in":
 			switch e := exprImpl.F.Args[1].Expr.(type) {
-			case *plan.Expr_Lit, *plan.Expr_P, *plan.Expr_V, *plan.Expr_Vec:
+			case *plan.Expr_Lit, *plan.Expr_P, *plan.Expr_V, *plan.Expr_Vec, *plan.Expr_List:
 				return extractColRefInFilter(exprImpl.F.Args[0])
 			case *plan.Expr_F:
 				switch e.F.Func.ObjName {
@@ -1245,7 +1245,7 @@ func unwindTupleComparison(ctx context.Context, nonEqOp, op string, leftExprs, r
 // if constant's type higher than column's type
 // and constant's value in range of column's type, then no cast was needed
 func checkNoNeedCast(constT, columnT types.Type, constExpr *plan.Expr) bool {
-	if constExpr.GetP() != nil && constT.IsNumeric() && columnT.IsNumeric() {
+	if constExpr.GetP() != nil && columnT.IsNumeric() {
 		return true
 	}
 

--- a/pkg/sql/plan/visit_plan_rule.go
+++ b/pkg/sql/plan/visit_plan_rule.go
@@ -97,6 +97,11 @@ func (rule *GetParamRule) ApplyExpr(e *plan.Expr) (*plan.Expr, error) {
 			}
 		*/
 		return e, nil
+	case *plan.Expr_List:
+		for i := range exprImpl.List.List {
+			exprImpl.List.List[i], _ = rule.ApplyExpr(exprImpl.List.List[i])
+		}
+		return e, nil
 	default:
 		return e, nil
 	}
@@ -149,6 +154,11 @@ func (rule *ResetParamOrderRule) ApplyExpr(e *plan.Expr) (*plan.Expr, error) {
 		return e, nil
 	case *plan.Expr_P:
 		exprImpl.P.Pos = int32(rule.params[int(exprImpl.P.Pos)])
+		return e, nil
+	case *plan.Expr_List:
+		for i := range exprImpl.List.List {
+			exprImpl.List.List[i], _ = rule.ApplyExpr(exprImpl.List.List[i])
+		}
 		return e, nil
 	default:
 		return e, nil
@@ -206,6 +216,14 @@ func (rule *ResetParamRefRule) ApplyExpr(e *plan.Expr) (*plan.Expr, error) {
 			Typ:  e.Typ,
 			Expr: rule.params[int(exprImpl.P.Pos)].Expr,
 		}, nil
+	case *plan.Expr_List:
+		for i, arg := range exprImpl.List.List {
+			exprImpl.List.List[i], err = rule.ApplyExpr(arg)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return e, nil
 	default:
 		return e, nil
 	}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16730

## What this PR does / why we need it:
don't convert IN expression to OR list in prepared statement


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced expression binding and type checking logic by modifying `checkNoNeedCast` function calls and adjusting case handling for the `like` operator.
- Improved merging filters on composite keys with added checks for multi-part primary keys.
- Enhanced constant folding for expression lists by avoiding folding non-literal expressions.
- Improved type checking utility functions to handle `plan.Expr` and added checks for numeric types.
- Added handling for `Expr_List` in various expression rules to ensure proper processing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_binder.go</strong><dd><code>Enhance expression binding and type checking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/base_binder.go

<li>Modified <code>checkNoNeedCast</code> function calls to pass <code>plan.Expr</code> instead of <br><code>plan.Literal</code>.<br> <li> Adjusted case handling for <code>like</code> operator to avoid unnecessary casts.<br> <li> Improved handling of composite key filters.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16800/files#diff-d2c4ebed110cf4c8982fa501ff026b2d518810445a72f51eac3021b51396e7b0">+21/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expr_opt.go</strong><dd><code>Optimize filter merging for composite keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/expr_opt.go

<li>Improved merging filters on composite keys.<br> <li> Added checks for multi-part primary keys.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16800/files#diff-d74b004ceea0444039926cf26e70fba9951154ce59241418d3f0db00f411cabe">+11/-5</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>constant_fold.go</strong><dd><code>Enhance constant folding for expression lists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/rule/constant_fold.go

- Added handling to avoid folding non-literal expressions in lists.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16800/files#diff-f3c5d6ce0a9d06da042c24fbe3348fa71cff4b03584c98dfb1cf9476b2a2ecfa">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Improve type checking utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/utils.go

<li>Modified <code>checkNoNeedCast</code> to handle <code>plan.Expr</code> instead of <code>plan.Literal</code>.<br> <li> Added checks for numeric types in <code>checkNoNeedCast</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16800/files#diff-4086cbd1a662ffb2a7761174da95abee51e3e0cc7e4ab796e2ec6ef82983ab45">+18/-5</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>visit_plan_rule.go</strong><dd><code>Enhance expression rule handling for lists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/visit_plan_rule.go

- Added handling for `Expr_List` in various expression rules.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16800/files#diff-504b00b0bb0a3ffacf24d17418d8472f8dea50b82577c6b05fa1d02f2cc69388">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

