### PR TITLE
add deug log

### DIFF
--- a/pkg/vm/engine/tae/catalog/object.go
+++ b/pkg/vm/engine/tae/catalog/object.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 
@@ -40,6 +41,8 @@ type ObjectEntry struct {
 	table *TableEntry
 	*ObjectNode
 	objData data.Object
+
+	hasPrintedPrepareComapct bool
 }
 
 func (entry *ObjectEntry) GetLoaded() bool {
@@ -647,6 +650,50 @@ func (entry *ObjectEntry) GetPKZoneMap(
 	}
 	return stats.SortKeyZoneMap(), nil
 }
+
+func (entry *ObjectEntry) CheckPrintPrepareCompact() bool {
+	entry.RLock()
+	defer entry.RUnlock()
+	return entry.CheckPrintPrepareCompactLocked()
+}
+
+func (entry *ObjectEntry) CheckPrintPrepareCompactLocked() bool {
+	lastNode := entry.GetLatestNodeLocked()
+	startTS := lastNode.GetStart()
+	return startTS.Physical() < time.Now().UTC().UnixNano()-(time.Minute*30).Nanoseconds()
+}
+
+func (entry *ObjectEntry) PrintPrepareCompactDebugLog() {
+	if entry.hasPrintedPrepareComapct {
+		return
+	}
+	entry.hasPrintedPrepareComapct = true
+	s := fmt.Sprintf("prepare compact failed, obj %v", entry.PPString(3, 0, ""))
+	lastNode := entry.GetLatestNodeLocked()
+	startTS := lastNode.GetStart()
+	if lastNode.Txn != nil {
+		s = fmt.Sprintf("%s txn is %x.", s, lastNode.Txn.GetID())
+	}
+	it := entry.GetTable().MakeObjectIt(false)
+	for ; it.Valid(); it.Next() {
+		obj := it.Get().GetPayload()
+		obj.RLock()
+		sameTxn := false
+		obj.LoopChainLocked(func(m *MVCCNode[*ObjectMVCCNode]) bool {
+			if m.Start.Equal(&startTS) {
+				sameTxn = true
+				return false
+			}
+			return true
+		})
+		obj.RUnlock()
+		if sameTxn {
+			s = fmt.Sprintf("%s %v.", s, obj.PPString(3, 0, ""))
+		}
+	}
+	logutil.Infof(s)
+}
+
 func MockObjEntryWithTbl(tbl *TableEntry, size uint64) *ObjectEntry {
 	stats := objectio.NewObjectStats()
 	objectio.SetObjectStatsSize(stats, uint32(size))

--- a/pkg/vm/engine/tae/tables/obj.go
+++ b/pkg/vm/engine/tae/tables/obj.go
@@ -63,7 +63,11 @@ func (obj *object) OnApplyDelete(
 }
 
 func (obj *object) PrepareCompact() bool {
-	return obj.meta.PrepareCompact()
+	prepareCompact := obj.meta.PrepareCompact()
+	if !prepareCompact && obj.meta.CheckPrintPrepareCompact() {
+		obj.meta.PrintPrepareCompactDebugLog()
+	}
+	return prepareCompact
 }
 
 func (obj *object) PrepareCompactInfo() (result bool, reason string) {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16812 

## What this PR does / why we need it:
add debug log


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added methods `CheckPrintPrepareCompact` and `PrintPrepareCompactDebugLog` to `ObjectEntry` for logging debug information related to compact operations.
- Enhanced `PrepareCompact` methods in `aobject` and `object` to include debug logging.
- Introduced a boolean flag `hasPrintedPrepareComapct` to track if the debug log has already been printed.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>object.go</strong><dd><code>Add debug logging for compact operations in ObjectEntry</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/catalog/object.go

<li>Added <code>CheckPrintPrepareCompact</code> method to check if a compact operation <br>should be logged.<br> <li> Added <code>PrintPrepareCompactDebugLog</code> method to log debug information for <br>compact operations.<br> <li> Introduced <code>hasPrintedPrepareComapct</code> boolean to track if the debug log <br>has been printed.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16820/files#diff-ba7fd83dfa69f768d750e0f59e376d51dac7cc880bbb5c0702141d06bb26689e">+45/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aobj.go</strong><dd><code>Enhance PrepareCompact with debug logging in aobject</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/aobj.go

<li>Enhanced <code>PrepareCompact</code> method to include debug logging for compact <br>operations.<br> <li> Added calls to <code>CheckPrintPrepareCompact</code> and <br><code>PrintPrepareCompactDebugLog</code> methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16820/files#diff-cd11bed21d1df45b0585f408e1959ab95b025ede9e42787497867545d6803513">+11/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>obj.go</strong><dd><code>Enhance PrepareCompact with debug logging in object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/obj.go

<li>Enhanced <code>PrepareCompact</code> method to include debug logging for compact <br>operations.<br> <li> Added calls to <code>CheckPrintPrepareCompact</code> and <br><code>PrintPrepareCompactDebugLog</code> methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16820/files#diff-239653450726b88805e127224387a559988bde1fe1bf4973b042c50b816708ba">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

