### PR TITLE
change some UnsafeGetStringAt to GetStringAt

### DIFF
--- a/pkg/sql/colexec/external/parquet_test.go
+++ b/pkg/sql/colexec/external/parquet_test.go
@@ -89,7 +89,7 @@ func Test_getMapper(t *testing.T) {
 			if v.IsNull() {
 				require.True(t, vec.IsNull(uint64(i)))
 			} else {
-				require.Equal(t, v.String(), vec.UnsafeGetStringAt(i))
+				require.Equal(t, v.String(), vec.GetStringAt(i))
 			}
 		}
 	})

--- a/pkg/sql/colexec/table_function/generate_series.go
+++ b/pkg/sql/colexec/table_function/generate_series.go
@@ -107,16 +107,13 @@ func resetGenerateSeriesState(proc *process.Process, arg *Argument) error {
 			if stepVec == nil {
 				return moerr.NewInvalidInput(proc.Ctx, "generate_series datetime must specify step")
 			}
-			stepSlice := vector.MustStrCol(stepVec)
-			arg.generateSeries.step = stepSlice[0]
+			arg.generateSeries.step = stepVec.GetStringAt(0)
 		case types.T_varchar:
 			if stepVec == nil {
 				return moerr.NewInvalidInput(proc.Ctx, "generate_series must specify step")
 			}
-			startSlice := vector.MustStrCol(startVec)
-			endSlice := vector.MustStrCol(endVec)
-			startStr := startSlice[0]
-			endStr := endSlice[0]
+			startStr := startVec.GetStringAt(0)
+			endStr := endVec.GetStringAt(0)
 			scale := int32(findScale(startStr, endStr))
 			startTmp, err := types.ParseDatetime(startStr, scale)
 			if err != nil {
@@ -140,8 +137,7 @@ func resetGenerateSeriesState(proc *process.Process, arg *Argument) error {
 			arg.generateSeries.start = newStartSlice[0]
 			arg.generateSeries.end = newEndSlice[0]
 			arg.generateSeries.last = newEndSlice[0]
-			stepSlice := vector.MustStrCol(stepVec)
-			arg.generateSeries.step = stepSlice[0]
+			arg.generateSeries.step = stepVec.GetStringAt(0)
 		default:
 			return moerr.NewNotSupported(proc.Ctx, "generate_series not support type %s", arg.generateSeries.startVecType.Oid.String())
 

--- a/pkg/sql/colexec/table_function/metadata_scan.go
+++ b/pkg/sql/colexec/table_function/metadata_scan.go
@@ -70,7 +70,7 @@ func metadataScan(_ int, proc *process.Process, arg *Argument, result *vm.CallRe
 		return false, err
 	}
 
-	dbname, tablename, colname, err := handleDatasource(vector.MustStrCol(source), vector.MustStrCol(col))
+	dbname, tablename, colname, err := handleDatasource(source, col)
 	logutil.Infof("db: %s, table: %s, col: %s in metadataScan", dbname, tablename, colname)
 	if err != nil {
 		return false, err
@@ -101,16 +101,15 @@ func metadataScan(_ int, proc *process.Process, arg *Argument, result *vm.CallRe
 	return false, nil
 }
 
-func handleDatasource(first []string, second []string) (string, string, string, error) {
-	if len(first) != 1 || len(second) != 1 {
+func handleDatasource(source, col *vector.Vector) (string, string, string, error) {
+	if source.Length() != 1 || col.Length() != 1 {
 		return "", "", "", moerr.NewInternalErrorNoCtx("wrong input len")
 	}
-	s := first[0]
-	strs := strings.Split(s, ".")
+	strs := strings.Split(source.GetStringAt(0), ".")
 	if len(strs) != 2 {
 		return "", "", "", moerr.NewInternalErrorNoCtx("wrong len of db and tbl input")
 	}
-	return strs[0], strs[1], second[0], nil
+	return strs[0], strs[1], col.GetStringAt(0), nil
 }
 
 func genRetBatch(proc process.Process, arg *Argument, metaInfos []*plan.MetadataScanInfo) (*batch.Batch, error) {

--- a/pkg/sql/compile/fuzzyCheck.go
+++ b/pkg/sql/compile/fuzzyCheck.go
@@ -450,7 +450,7 @@ func vectorToString(vec *vector.Vector, rowIndex int) (string, error) {
 	case types.T_float64:
 		return fmt.Sprintf("%v", vector.GetFixedAt[float64](vec, rowIndex)), nil
 	case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary, types.T_text, types.T_blob:
-		return vec.UnsafeGetStringAt(rowIndex), nil
+		return vec.GetStringAt(rowIndex), nil
 	case types.T_array_float32:
 		return types.ArrayToString[float32](vector.GetArrayAt[float32](vec, rowIndex)), nil
 	case types.T_array_float64:

--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -1083,7 +1083,7 @@ func constructWindow(_ context.Context, n *plan.Node, proc *process.Process) *wi
 				if err != nil {
 					panic(err)
 				}
-				cfg = []byte(vec.UnsafeGetStringAt(0))
+				cfg = []byte(vec.GetStringAt(0))
 				vec.Free(proc.Mp())
 
 				args = f.F.Args[:len(f.F.Args)-1]
@@ -1152,7 +1152,7 @@ func constructGroup(_ context.Context, n, cn *plan.Node, ibucket, nbucket int, n
 					if err != nil {
 						panic(err)
 					}
-					cfg = []byte(vec.UnsafeGetStringAt(0))
+					cfg = []byte(vec.GetStringAt(0))
 					vec.Free(proc.Mp())
 
 					args = f.F.Args[:len(f.F.Args)-1]


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/16235

## What this PR does / why we need it:
change some UnsafeGetStringAt to GetStringAt


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced `UnsafeGetStringAt` with `GetStringAt` in multiple files to improve safety and consistency.
- Updated test assertions in `parquet_test.go`.
- Modified `resetGenerateSeriesState` function in `generate_series.go`.
- Updated `metadataScan` and `handleDatasource` functions in `metadata_scan.go`.
- Changed `vectorToString` function in `fuzzyCheck.go`.
- Updated `constructWindow` and `constructGroup` functions in `operator.go`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parquet_test.go</strong><dd><code>Replace UnsafeGetStringAt with GetStringAt in parquet_test.go</code></dd></summary>
<hr>
      
pkg/sql/colexec/external/parquet_test.go

<li>Replaced <code>UnsafeGetStringAt</code> with <code>GetStringAt</code> in test assertions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16821/files#diff-eb5f6ea710eeec39116894cf19581271da4944470eba4b9ad139005b302adf70">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>generate_series.go</strong><dd><code>Replace UnsafeGetStringAt with GetStringAt in generate_series.go</code></dd></summary>
<hr>
      
pkg/sql/colexec/table_function/generate_series.go

<li>Replaced <code>UnsafeGetStringAt</code> with <code>GetStringAt</code> in <br><code>resetGenerateSeriesState</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16821/files#diff-4f3891864518cc5142fc741a38568d5af2e6aca563829283358540625a75c99b">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metadata_scan.go</strong><dd><code>Replace UnsafeGetStringAt with GetStringAt in metadata_scan.go</code></dd></summary>
<hr>
      
pkg/sql/colexec/table_function/metadata_scan.go

<li>Replaced <code>UnsafeGetStringAt</code> with <code>GetStringAt</code> in <code>metadataScan</code> and <br><code>handleDatasource</code> functions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16821/files#diff-7ac3b08989292ff3d220868f7a111a768e112c1580cc47e4f5633b3bd182b349">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fuzzyCheck.go</strong><dd><code>Replace UnsafeGetStringAt with GetStringAt in fuzzyCheck.go</code></dd></summary>
<hr>
      
pkg/sql/compile/fuzzyCheck.go

<li>Replaced <code>UnsafeGetStringAt</code> with <code>GetStringAt</code> in <code>vectorToString</code> <br>function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16821/files#diff-0a5999cd1b0501054b8486fdf8ef7f2746da5817f55371d59182fb2044536b44">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>operator.go</strong><dd><code>Replace UnsafeGetStringAt with GetStringAt in operator.go</code></dd></summary>
<hr>
      
pkg/sql/compile/operator.go

<li>Replaced <code>UnsafeGetStringAt</code> with <code>GetStringAt</code> in <code>constructWindow</code> and <br><code>constructGroup</code> functions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16821/files#diff-24c2df3f5c8c484aab6845aa35e6426ba672758aea5c19bb680c08eadec260ee">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

