### PR TITLE
sync to 1.2: fix sysbench random points ranges slow

### DIFF
--- a/pkg/vm/engine/disttae/filter.go
+++ b/pkg/vm/engine/disttae/filter.go
@@ -16,6 +16,7 @@ package disttae
 
 import (
 	"context"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"sort"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -126,11 +127,12 @@ func getConstBytesFromExpr(exprs []*plan.Expr, colDef *plan.ColDef, proc *proces
 	return vals, true
 }
 
-func mustColVecValueFromBinaryFuncExpr(expr *plan.Expr_F) (*plan.Expr_Col, []byte, bool) {
+func mustColVecValueFromBinaryFuncExpr(proc *process.Process, expr *plan.Expr_F) (*plan.Expr_Col, []byte, bool) {
 	var (
-		colExpr *plan.Expr_Col
-		valExpr *plan.Expr
-		ok      bool
+		colExpr  *plan.Expr_Col
+		valExpr  *plan.Expr
+		ok       bool
+		exprImpl *plan.Expr_Vec
 	)
 	if colExpr, ok = expr.F.Args[0].Expr.(*plan.Expr_Col); ok {
 		valExpr = expr.F.Args[1]
@@ -140,11 +142,20 @@ func mustColVecValueFromBinaryFuncExpr(expr *plan.Expr_F) (*plan.Expr_Col, []byt
 		return nil, nil, false
 	}
 
-	switch exprImpl := valExpr.Expr.(type) {
-	case *plan.Expr_Vec:
-		return colExpr, exprImpl.Vec.Data, true
+	if exprImpl, ok = valExpr.Expr.(*plan.Expr_Vec); !ok {
+		foldedExprs, err := plan2.ConstandFoldList([]*plan.Expr{valExpr}, proc, true)
+		if err != nil {
+			logutil.Errorf("try const fold val expr failed: %s", plan2.FormatExpr(valExpr))
+			return nil, nil, false
+		}
+
+		if exprImpl, ok = foldedExprs[0].Expr.(*plan.Expr_Vec); !ok {
+			logutil.Errorf("const folded val expr is not a vec expr: %s\n", plan2.FormatExpr(valExpr))
+			return nil, nil, false
+		}
 	}
-	return nil, nil, false
+
+	return colExpr, exprImpl.Vec.Data, ok
 }
 
 func mustColConstValueFromBinaryFuncExpr(
@@ -770,7 +781,7 @@ func CompileFilterExpr(
 			}
 			// TODO: define seekOp
 		case "prefix_in":
-			colExpr, val, ok := mustColVecValueFromBinaryFuncExpr(exprImpl)
+			colExpr, val, ok := mustColVecValueFromBinaryFuncExpr(proc, exprImpl)
 			if !ok {
 				canCompile = false
 				return
@@ -850,7 +861,7 @@ func CompileFilterExpr(
 			}
 
 		case "in":
-			colExpr, val, ok := mustColVecValueFromBinaryFuncExpr(exprImpl)
+			colExpr, val, ok := mustColVecValueFromBinaryFuncExpr(proc, exprImpl)
 			if !ok {
 				canCompile = false
 				return

--- a/pkg/vm/engine/disttae/filter.go
+++ b/pkg/vm/engine/disttae/filter.go
@@ -16,7 +16,6 @@ package disttae
 
 import (
 	"context"
-	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"sort"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -27,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/util"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/logtailreplay"

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -93,7 +93,7 @@ func evalValue(exprImpl *plan.Expr_F, tblDef *plan.TableDef, isVec bool, pkName 
 	if !isVec {
 		col, vals, ok = mustColConstValueFromBinaryFuncExpr(exprImpl, tblDef, proc)
 	} else {
-		col, val, ok = mustColVecValueFromBinaryFuncExpr(exprImpl)
+		col, val, ok = mustColVecValueFromBinaryFuncExpr(proc, exprImpl)
 	}
 
 	if !ok {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16816

## What this PR does / why we need it:
const fold val expr lazily