### PR TITLE
[bug] clusterservice: add lock for refresh() to protect cn services.

### DIFF
--- a/pkg/clusterservice/cluster.go
+++ b/pkg/clusterservice/cluster.go
@@ -70,6 +70,7 @@ func WithDisableRefresh() Option {
 type cluster struct {
 	logger          *log.MOLogger
 	stopper         *stopper.Stopper
+	mu              sync.Mutex
 	client          ClusterClient
 	refreshInterval time.Duration
 	forceRefreshC   chan struct{}
@@ -269,6 +270,11 @@ func (c *cluster) refreshTask(ctx context.Context) {
 func (c *cluster) refresh() {
 	defer c.logger.LogAction("refresh from hakeeper",
 		log.DefaultLogOptions().WithLevel(zap.DebugLevel))()
+
+	// There is data race as ForceRefresh and refreshTask may call this function
+	// at the same time, which will cause inconsistent CN services.
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), c.refreshInterval)
 	defer cancel()


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16480 

## What this PR does / why we need it:
add lock for refresh() to protect cn services.


___

### **PR Type**
Bug fix


___

### **Description**
- Added a mutex (`mu`) to the `cluster` struct to prevent data races.
- Locked the `refresh` method using the mutex to ensure thread safety.
- Added comments to explain the necessity of the lock in the `refresh` method.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cluster.go</strong><dd><code>Add mutex to cluster struct and lock refresh method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/clusterservice/cluster.go

<li>Added a mutex (<code>mu</code>) to the <code>cluster</code> struct.<br> <li> Locked the <code>refresh</code> method to prevent data races.<br> <li> Added comments explaining the reason for the lock.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16840/files#diff-7b5573810b07a4665c06c877f6404188b0479f535784e4e2baed3d438948e020">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

