### PR TITLE
constant fold more expr

### DIFF
--- a/pkg/sql/plan/rule/constant_fold.go
+++ b/pkg/sql/plan/rule/constant_fold.go
@@ -54,26 +54,67 @@ func (r *ConstantFold) Apply(n *plan.Node, _ *plan.Query, proc *process.Process)
 	if n.Offset != nil {
 		n.Offset = r.constantFold(n.Offset, proc)
 	}
-	if len(n.OnList) > 0 {
-		for i := range n.OnList {
-			n.OnList[i] = r.constantFold(n.OnList[i], proc)
-		}
+	if n.Interval != nil {
+		n.Interval = r.constantFold(n.Interval, proc)
 	}
-	if len(n.FilterList) > 0 {
-		for i := range n.FilterList {
-			n.FilterList[i] = r.constantFold(n.FilterList[i], proc)
-		}
+	if n.Sliding != nil {
+		n.Sliding = r.constantFold(n.Sliding, proc)
 	}
-	if len(n.BlockFilterList) > 0 {
-		for i := range n.BlockFilterList {
-			n.BlockFilterList[i] = r.constantFold(n.BlockFilterList[i], proc)
+
+	for i := range n.ProjectList {
+		n.ProjectList[i] = r.constantFold(n.ProjectList[i], proc)
+	}
+
+	for i := range n.OnList {
+		n.OnList[i] = r.constantFold(n.OnList[i], proc)
+	}
+
+	for i := range n.FilterList {
+		n.FilterList[i] = r.constantFold(n.FilterList[i], proc)
+	}
+
+	for i := range n.GroupBy {
+		n.GroupBy[i] = r.constantFold(n.GroupBy[i], proc)
+	}
+
+	for i := range n.GroupingSet {
+		n.GroupingSet[i] = r.constantFold(n.GroupingSet[i], proc)
+	}
+
+	for i := range n.AggList {
+		if fn, ok := n.AggList[i].Expr.(*plan.Expr_F); ok {
+			for i := range fn.F.Args {
+				fn.F.Args[i] = r.constantFold(fn.F.Args[i], proc)
+			}
 		}
 	}
 
-	if len(n.ProjectList) > 0 {
-		for i := range n.ProjectList {
-			n.ProjectList[i] = r.constantFold(n.ProjectList[i], proc)
+	for i := range n.WinSpecList {
+		if fn, ok := n.AggList[i].Expr.(*plan.Expr_F); ok {
+			for i := range fn.F.Args {
+				fn.F.Args[i] = r.constantFold(fn.F.Args[i], proc)
+			}
 		}
+	}
+
+	for _, orderBy := range n.OrderBy {
+		orderBy.Expr = r.constantFold(orderBy.Expr, proc)
+	}
+
+	for i := range n.TblFuncExprList {
+		n.TblFuncExprList[i] = r.constantFold(n.TblFuncExprList[i], proc)
+	}
+
+	for i := range n.BlockFilterList {
+		n.BlockFilterList[i] = r.constantFold(n.BlockFilterList[i], proc)
+	}
+
+	for i := range n.FillVal {
+		n.FillVal[i] = r.constantFold(n.FillVal[i], proc)
+	}
+
+	for i := range n.OnUpdateExprs {
+		n.OnUpdateExprs[i] = r.constantFold(n.OnUpdateExprs[i], proc)
 	}
 }
 

--- a/pkg/sql/plan/rule/constant_fold.go
+++ b/pkg/sql/plan/rule/constant_fold.go
@@ -90,7 +90,7 @@ func (r *ConstantFold) Apply(n *plan.Node, _ *plan.Query, proc *process.Process)
 	}
 
 	for i := range n.WinSpecList {
-		if fn, ok := n.AggList[i].Expr.(*plan.Expr_F); ok {
+		if fn, ok := n.WinSpecList[i].Expr.(*plan.Expr_F); ok {
 			for i := range fn.F.Args {
 				fn.F.Args[i] = r.constantFold(fn.F.Args[i], proc)
 			}

--- a/test/distributed/cases/optimizer/index.result
+++ b/test/distributed/cases/optimizer/index.result
@@ -172,4 +172,9 @@ select * from t1 where b in (1,2) for update;
 a    b
 1    1
 2    2
+create view v1 as select (case when a in (1,2,3) then 'y' else 'n' end) as a from t1;
+select count(a) from v1;
+count(a)
+10000
+drop table t1;
 drop database if exists d1;

--- a/test/distributed/cases/optimizer/index.test
+++ b/test/distributed/cases/optimizer/index.test
@@ -63,5 +63,7 @@ insert into t1 select result, result from generate_series(1,10000)g;
 -- @separator:table
 select mo_ctl('dn','flush','d1.t1');
 select * from t1 where b in (1,2) for update;
+create view v1 as select (case when a in (1,2,3) then 'y' else 'n' end) as a from t1;
+select count(a) from v1;
+drop table t1;
 drop database if exists d1;
-


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #3444

## What this PR does / why we need it:
constant fold more expr


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Extended constant folding to additional expressions in SQL plan nodes, including `Interval`, `Sliding`, `ProjectList`, `GroupBy`, `GroupingSet`, `AggList`, `WinSpecList`, `OrderBy`, `TblFuncExprList`, `BlockFilterList`, `FillVal`, and `OnUpdateExprs`.
- Added new test cases to validate the creation of views and counting their elements.
- Ensured proper cleanup of test databases by dropping tables before dropping the database.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constant_fold.go</strong><dd><code>Extend constant folding to additional expressions in SQL plan nodes</code></dd></summary>
<hr>
      
pkg/sql/plan/rule/constant_fold.go

<li>Added constant folding for <code>Interval</code>, <code>Sliding</code>, <code>ProjectList</code>, <code>GroupBy</code>, <br><code>GroupingSet</code>, <code>AggList</code>, <code>WinSpecList</code>, <code>OrderBy</code>, <code>TblFuncExprList</code>, <br><code>BlockFilterList</code>, <code>FillVal</code>, and <code>OnUpdateExprs</code>.<br> <li> Refactored existing constant folding logic to include additional <br>expressions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16849/files#diff-f3c5d6ce0a9d06da042c24fbe3348fa71cff4b03584c98dfb1cf9476b2a2ecfa">+55/-14</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.result</strong><dd><code>Add test case for view creation and element counting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/distributed/cases/optimizer/index.result

<li>Added test case for creating a view and counting its elements.<br> <li> Dropped table <code>t1</code> before dropping database <code>d1</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16849/files#diff-6681b2ca0c84cb5b3e7aea5301e29ce2183b97e196320f689b79d6d4c4ed2f7d">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.test</strong><dd><code>Add test case for view creation and element counting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/distributed/cases/optimizer/index.test

<li>Added test case for creating a view and counting its elements.<br> <li> Dropped table <code>t1</code> before dropping database <code>d1</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16849/files#diff-4c4fbe175b643249cf2a81dd48014391c2121a73be00e8bb13b90dd2b097aa96">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

