### PR TITLE
fix validate timeout lock table

### DIFF
--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -455,7 +455,10 @@ func (l *lockTableAllocator) checkInvalidBinds(ctx context.Context) {
 					b.getServiceID(),
 					l.client,
 				)
-				if !valid || !isRetryError(err) {
+				if isRetryError(err) {
+					continue
+				}
+				if !valid {
 					b.disable()
 					l.disableTableBinds(b)
 				}

--- a/pkg/lockservice/lock_table_allocator_test.go
+++ b/pkg/lockservice/lock_table_allocator_test.go
@@ -142,7 +142,7 @@ func TestCheckTimeoutServiceTask(t *testing.T) {
 		time.Millisecond,
 		func(a *lockTableAllocator) {
 			// create s1 bind
-			a.Get("s1", 0, 1, 0, pb.Sharding_None)
+			a.Get("s2", 0, 1, 0, pb.Sharding_None)
 
 			for {
 				bind := a.GetLatest(0, 1)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16732 

## What this PR does / why we need it:

fix validate timeout lock table


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed the validation logic in `checkInvalidBinds` method to properly handle retry errors and only disable binds when necessary.
- Added a new test `TestRetryValidateService` to ensure the retry logic for service validation works correctly.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lock_table_allocator.go</strong><dd><code>Fix validation logic for lock table binds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/lockservice/lock_table_allocator.go

<li>Added a check to continue loop if <code>isRetryError</code> returns true.<br> <li> Modified condition to disable bind only if <code>valid</code> is false.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16862/files#diff-6be1ca324d0b56411e41ec19a99ea21442f80563429ee4964aedef60424413a1">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_test.go</strong><dd><code>Add test for retry logic in service validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/lockservice/rpc_test.go

<li>Added a new test <code>TestRetryValidateService</code> to check retry logic for <br>service validation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16862/files#diff-42ee96474cacf3ad69ffd4ee7f476f9deae83856b7c50dc05d784fee568ef124">+26/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

