### PR TITLE
fix a ut bug will cause vector free twice

### DIFF
--- a/pkg/sql/colexec/aggexec/exec_test.go
+++ b/pkg/sql/colexec/aggexec/exec_test.go
@@ -255,12 +255,20 @@ func TestMultiAggFuncExec1(t *testing.T) {
 		var err error
 
 		// prepare the input data.
-		vec1 := vector.NewVec(inputType1)
-		require.NoError(t, vector.AppendFixedList[int64](vec1, []int64{0, 1}, []bool{true, false}, mg.Mp()))
-		vec2 := vector.NewVec(inputType2)
-		require.NoError(t, vector.AppendFixedList[bool](vec2, []bool{false, true}, nil, mg.Mp()))
-		inputs[0] = [2]*vector.Vector{vec1, vec2}
-		inputs[1] = [2]*vector.Vector{vec1, vec2}
+		{
+			vec1 := vector.NewVec(inputType1)
+			require.NoError(t, vector.AppendFixedList[int64](vec1, []int64{0, 1}, []bool{true, false}, mg.Mp()))
+			vec2 := vector.NewVec(inputType2)
+			require.NoError(t, vector.AppendFixedList[bool](vec2, []bool{false, true}, nil, mg.Mp()))
+			inputs[0] = [2]*vector.Vector{vec1, vec2}
+		}
+		{
+			vec1 := vector.NewVec(inputType1)
+			require.NoError(t, vector.AppendFixedList[int64](vec1, []int64{0, 1}, []bool{true, false}, mg.Mp()))
+			vec2 := vector.NewVec(inputType2)
+			require.NoError(t, vector.AppendFixedList[bool](vec2, []bool{false, true}, nil, mg.Mp()))
+			inputs[1] = [2]*vector.Vector{vec1, vec2}
+		}
 
 		inputs[2] = [2]*vector.Vector{nil, nil}
 		inputs[2][0] = vector.NewConstNull(inputType1, 2, mg.Mp())


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16825 #16835 #16838 

## What this PR does / why we need it:
修复一个vector重复调用free的问题，由于vector的指针池子是全局的，会导致同一个vector被多人持有，发生意想不到的错误。


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in `TestMultiAggFuncExec1` that caused vectors to be freed twice.
- Ensured that vectors are not shared across multiple inputs by creating separate instances.
- Modified the test setup to prevent unexpected errors due to shared vector pointers.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exec_test.go</strong><dd><code>Fix vector double free issue in unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/colexec/aggexec/exec_test.go

<li>Fixed a bug causing vectors to be freed twice by creating separate <br>instances for each input.<br> <li> Modified the test setup to ensure vectors are not shared across <br>multiple inputs.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16870/files#diff-385ead23bce77f8f8f696d77ca48d99d5d281afd832911c3f23df261b12c1173">+14/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

