### PR TITLE
trace slow flush

### DIFF
--- a/pkg/vm/engine/tae/common/stats.go
+++ b/pkg/vm/engine/tae/common/stats.go
@@ -27,6 +27,50 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
+type DeletesCollectRecorder struct {
+	LoadCost   time.Duration
+	LoadAfter  time.Duration
+	BisectCost time.Duration
+	MemCost    time.Duration
+}
+
+type DeletesCollectBoard struct {
+	DeletesCollectRecorder
+	LoadMax, LoadAfterMax, BisectMax, MemMax time.Duration
+	LoadCnt                                  int
+}
+
+func (r *DeletesCollectBoard) Add(other *DeletesCollectRecorder) {
+	r.LoadCost += other.LoadCost
+	r.LoadAfter += other.LoadAfter
+	r.BisectCost += other.BisectCost
+	r.MemCost += other.MemCost
+
+	if other.LoadCost > r.LoadMax {
+		r.LoadMax = other.LoadCost
+	}
+	if other.LoadAfter > r.LoadAfterMax {
+		r.LoadAfterMax = other.LoadAfter
+	}
+	if other.BisectCost > r.BisectMax {
+		r.BisectMax = other.BisectCost
+	}
+	if other.MemCost > r.MemMax {
+		r.MemMax = other.MemCost
+	}
+	if other.LoadCost > 0 {
+		r.LoadCnt++
+	}
+}
+
+func (r *DeletesCollectBoard) String() string {
+	return fmt.Sprintf(
+		"LoadCost:%v LoadAfter:%v BisectCost:%v MemCost:%v LoadMax:%v LoadAfterMax:%v BisectMax:%v MemMax:%v LoadCnt:%v",
+		r.LoadCost, r.LoadAfter, r.BisectCost, r.MemCost, r.LoadMax, r.LoadAfterMax, r.BisectMax, r.MemMax, r.LoadCnt)
+}
+
+type RecorderKey struct{}
+
 const (
 	DefaultMinOsizeQualifiedMB   = 110   // MB
 	DefaultMaxOsizeObjMB         = 128   // MB

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -757,7 +757,6 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 					sloc := loc.String()
 					locMap[sloc]++
 					if locMap[sloc] == 10 { // trigger cache only once
-						logutil.Infof("slowflush: task %d trigger cache for %s", task.ID(), sloc)
 						recorder.TempCache[sloc] = common.TempDelCacheEntry{}
 					}
 				}

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -257,10 +257,10 @@ func (task *flushTableTailTask) MarshalLogObject(enc zapcore.ObjectEncoder) (err
 }
 
 var (
-	SlowFlushIOTask      = 3 * time.Second
+	SlowFlushIOTask      = 10 * time.Second
 	SlowFlushTaskOverall = 60 * time.Second
 	SlowDelCollect       = 10 * time.Second
-	SlowDelCollectNObj   = 50
+	SlowDelCollectNObj   = 20
 )
 
 func (task *flushTableTailTask) Execute(ctx context.Context) (err error) {

--- a/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -63,6 +64,8 @@ type mergeObjectsTask struct {
 	attrs      []string
 
 	targetObjSize uint32
+
+	createAt time.Time
 }
 
 func NewMergeObjectsTask(
@@ -84,6 +87,8 @@ func NewMergeObjectsTask(
 		blkCnt:       make([]int, len(mergedObjs)),
 
 		targetObjSize: targetObjSize,
+
+		createAt: time.Now(),
 	}
 	for i, obj := range mergedObjs {
 		task.mergedBlkCnt[i] = task.totalMergedBlkCnt
@@ -271,6 +276,12 @@ func (task *mergeObjectsTask) Execute(ctx context.Context) (err error) {
 			)
 		}
 	}()
+
+	if time.Since(task.createAt) > time.Second*10 {
+		logutil.Warn("[Slow] Mergeblocks wait", common.OperationField(task.Name()),
+			common.AnyField("duration", time.Since(task.createAt)),
+		)
+	}
 
 	schema := task.rel.Schema().(*catalog.Schema)
 	sortkeyPos := -1

--- a/pkg/vm/engine/tae/tables/utils.go
+++ b/pkg/vm/engine/tae/tables/utils.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
@@ -138,21 +139,42 @@ func LoadPersistedDeletesBySchema(
 	isPersistedByCN bool,
 	mp *mpool.MPool,
 ) (bat *containers.Batch, release func(), err error) {
-	var recorder *common.DeletesCollectRecorder
-	var inst time.Time
+	var (
+		recorder *common.DeletesCollectRecorder
+		movbat   *batch.Batch
+	)
+
 	if v := ctx.Value(common.RecorderKey{}); v != nil {
 		recorder = v.(*common.DeletesCollectRecorder)
-		inst = time.Now()
+		inst := time.Now()
+		defer func() {
+			recorder.LoadCost = time.Since(inst)
+		}()
+		sloc := location.String()
+		entry, ok := recorder.TempCache[sloc]
+		if ok && entry.Bat != nil { // hit cache
+			movbat = entry.Bat
+		}
+
+		if ok && entry.Bat == nil { // cache enable and first call
+			movbat, release, err = blockio.ReadBlockDeleteBySchema(ctx, location, fs.Service, isPersistedByCN)
+			if err != nil {
+				return nil, nil, err
+			}
+			recorder.TempCache[sloc] = common.TempDelCacheEntry{
+				Bat:     movbat,
+				Release: release,
+			}
+		}
+		release = func() {}
+	}
+	if movbat == nil { // cache disabled
+		movbat, release, err = blockio.ReadBlockDeleteBySchema(ctx, location, fs.Service, isPersistedByCN)
+		if err != nil {
+			return
+		}
 	}
 
-	movbat, release, err := blockio.ReadBlockDeleteBySchema(ctx, location, fs.Service, isPersistedByCN)
-	if err != nil {
-		return
-	}
-	if recorder != nil {
-		recorder.LoadCost = time.Since(inst)
-		inst = time.Now()
-	}
 	bat = containers.NewBatch()
 	if isPersistedByCN {
 		colNames := []string{catalog.PhyAddrColumnName, catalog.AttrPKVal}
@@ -164,9 +186,6 @@ func LoadPersistedDeletesBySchema(
 		for i := 0; i < 4; i++ {
 			bat.AddVector(colNames[i], containers.ToTNVector(movbat.Vecs[i], mp))
 		}
-	}
-	if recorder != nil {
-		recorder.LoadAfter = time.Since(inst)
 	}
 	return
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16716

## What this PR does / why we need it:

add logs to diagnose slow flush task


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `DeletesCollectRecorder` and `DeletesCollectBoard` structs for recording and aggregating delete collection metrics.
- Integrated context-based recording for delete collection metrics in base object methods.
- Added detailed timing and logging for various phases of the flush table tail task, including slow flush detection.
- Enhanced logging for slow flush detection in flush deletes and flush object tasks.
- Added timing and logging for the merge objects task, including slow merge detection.
- Integrated delete collection metrics recording in utility functions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stats.go</strong><dd><code>Add structs for recording delete collection metrics.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/common/stats.go

<li>Added <code>DeletesCollectRecorder</code> and <code>DeletesCollectBoard</code> structs for <br>recording and aggregating delete collection metrics.<br> <li> Implemented methods for adding records and converting the board to a <br>string.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16878/files#diff-42814881be4affbdb3a8105f1abc0db8b23aa0ef4b0323862f838730a414fe9e">+44/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.go</strong><dd><code>Integrate delete collection metrics recording in base object methods.</code></dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/base.go

<li>Added context-based recording for delete collection metrics.<br> <li> Updated <code>foreachPersistedDeletes</code> and <code>CollectDeleteInRangeByBlock</code> to <br>record metrics.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16878/files#diff-3c80f8bc185316e9da7a7199207f6a2b8eabfb303402aa9473443482aabcac59">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>flushTableTail.go</strong><dd><code>Add detailed timing and logging for flush table tail task.</code></dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/jobs/flushTableTail.go

<li>Added timing and logging for various phases of the flush table tail <br>task.<br> <li> Introduced constants for slow task thresholds.<br> <li> Enhanced logging for slow flush detection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16878/files#diff-0b958d0044e734c5cb32254c0e45c0beaf0e4fdc1f4c846c0bde0fd917da63b0">+67/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>flushdeletes.go</strong><dd><code>Add detailed timing and logging for flush deletes task.</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/jobs/flushdeletes.go

<li>Added timing and logging for the flush deletes task.<br> <li> Enhanced logging for slow flush detection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16878/files#diff-da70ae14204f33ab4ff12a73b476540795c6df1e7f7f32b215b93662d220029f">+21/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>flushobj.go</strong><dd><code>Add detailed timing and logging for flush object task.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/jobs/flushobj.go

<li>Added timing and logging for the flush object task.<br> <li> Enhanced logging for slow flush detection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16878/files#diff-cbafd27616f1e6dbc54578c219bf70ba1b13bbabf1c46c172cd78be286a71f54">+27/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mergeobjects.go</strong><dd><code>Add detailed timing and logging for merge objects task.</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/jobs/mergeobjects.go

<li>Added timing and logging for the merge objects task.<br> <li> Enhanced logging for slow merge detection.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16878/files#diff-e20c21589a463a1bcbf015f3cf20b1f972455f9f000611f28f886b4d3ba6721e">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Integrate delete collection metrics recording in utility functions.</code></dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/utils.go

<li>Added context-based recording for loading persisted deletes.<br> <li> Updated <code>LoadPersistedDeletesBySchema</code> to record metrics.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16878/files#diff-51306a90ccac77b64bcb3159a92f6e86bb3ab86094073ceaca2e844a5c3abfde">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

