### PR TITLE
fix: check protocol quit before CalculateOutTrafficBytes

### DIFF
--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -493,6 +493,9 @@ func logStatementStringStatus(ctx context.Context, ses FeSession, stmtStr string
 	switch resper := ses.GetResponser().(type) {
 	case *MysqlResp:
 		outBytes, outPacket = resper.mysqlRrWr.CalculateOutTrafficBytes(true)
+		if outBytes == 0 && outPacket == 0 {
+			ses.Warnf(ctx, "unexpected protocol closed")
+		}
 	default:
 
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16844

## What this PR does / why we need it:
changes:
1. check if protocal is quit, skip CalculateOutTrafficBytes op.
    - if NOT quit, logs the unexpected case.