### PR TITLE
Fix panic: out of range in EvalExpression.go

### DIFF
--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -537,8 +537,7 @@ func (expr *FunctionExpressionExecutor) EvalCase(proc *process.Process, batches 
 			return err
 		}
 		if i != len(expr.parameterExecutor)-1 {
-			rsRowCount := min(rowCount, expr.parameterResults[i].Length())
-			for j := 0; i < rsRowCount; j++ {
+			for j := 0; j < RowCount; j++ {
 				b, null := vector.GenerateFunctionFixedTypeParameter[bool](expr.parameterResults[i]).GetValue(uint64(j))
 				if !null && b {
 					expr.selectList1[j] = false

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -490,12 +490,12 @@ func (expr *FunctionExpressionExecutor) EvalIff(proc *process.Process, batches [
 	if err != nil {
 		return err
 	}
-	if len(expr.selectList1) < batches[0].RowCount() {
-		expr.selectList1 = make([]bool, batches[0].RowCount())
-		expr.selectList2 = make([]bool, batches[0].RowCount())
+	rowCount := batches[0].RowCount()
+	if len(expr.selectList1) < rowCount {
+		expr.selectList1 = make([]bool, rowCount)
+		expr.selectList2 = make([]bool, rowCount)
 	}
-
-	for i := range expr.selectList1 {
+	for i := 0; i < rowCount; i++ {
 		b, null := vector.GenerateFunctionFixedTypeParameter[bool](expr.parameterResults[0]).GetValue(uint64(i))
 		if selectList != nil {
 			expr.selectList1[i] = selectList[i]
@@ -519,9 +519,10 @@ func (expr *FunctionExpressionExecutor) EvalIff(proc *process.Process, batches [
 }
 
 func (expr *FunctionExpressionExecutor) EvalCase(proc *process.Process, batches []*batch.Batch, selectList []bool) (err error) {
-	if len(expr.selectList1) < batches[0].RowCount() {
-		expr.selectList1 = make([]bool, batches[0].RowCount())
-		expr.selectList2 = make([]bool, batches[0].RowCount())
+	rowCount := batches[0].RowCount()
+	if len(expr.selectList1) < rowCount {
+		expr.selectList1 = make([]bool, rowCount)
+		expr.selectList2 = make([]bool, rowCount)
 	}
 	if selectList != nil {
 		copy(expr.selectList1, selectList)
@@ -536,7 +537,7 @@ func (expr *FunctionExpressionExecutor) EvalCase(proc *process.Process, batches 
 			return err
 		}
 		if i != len(expr.parameterExecutor)-1 {
-			for j := range expr.selectList1 {
+			for j := 0; i < rowCount; j++ {
 				b, null := vector.GenerateFunctionFixedTypeParameter[bool](expr.parameterResults[i]).GetValue(uint64(j))
 				if !null && b {
 					expr.selectList1[j] = false

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -537,7 +537,7 @@ func (expr *FunctionExpressionExecutor) EvalCase(proc *process.Process, batches 
 			return err
 		}
 		if i != len(expr.parameterExecutor)-1 {
-			for j := 0; j < RowCount; j++ {
+			for j := 0; j < rowCount; j++ {
 				b, null := vector.GenerateFunctionFixedTypeParameter[bool](expr.parameterResults[i]).GetValue(uint64(j))
 				if !null && b {
 					expr.selectList1[j] = false

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -537,7 +537,8 @@ func (expr *FunctionExpressionExecutor) EvalCase(proc *process.Process, batches 
 			return err
 		}
 		if i != len(expr.parameterExecutor)-1 {
-			for j := 0; i < rowCount; j++ {
+			rsRowCount := min(rowCount, expr.parameterResults[i].Length())
+			for j := 0; i < rsRowCount; j++ {
 				b, null := vector.GenerateFunctionFixedTypeParameter[bool](expr.parameterResults[i]).GetValue(uint64(j))
 				if !null && b {
 					expr.selectList1[j] = false


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14989

## What this PR does / why we need it:
fix out of range


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed out-of-range errors in `EvalIff` and `EvalCase` functions by ensuring loops iterate within the correct bounds.
- Replaced range-based loops with index-based loops for better control.
- Added variable `rowCount` to store the row count and use it for array initializations and loop bounds.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evalExpression.go</strong><dd><code>Fix out-of-range errors in `EvalIff` and `EvalCase` functions</code></dd></summary>
<hr>
      
pkg/sql/colexec/evalExpression.go

<li>Fixed out-of-range errors by ensuring loops iterate within the correct <br>bounds.<br> <li> Replaced range-based loops with index-based loops for better control.<br> <li> Added variable <code>rowCount</code> to store the row count and use it for array <br>initializations and loop bounds.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16885/files#diff-096074b4e06b58b1b2144cc4b4d91fe38b5c4ced8bfd165e7cfc66bd31aa341d">+10/-9</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

