### PR TITLE
update debug log, print appendnodes

### DIFF
--- a/pkg/vm/engine/tae/catalog/object.go
+++ b/pkg/vm/engine/tae/catalog/object.go
@@ -42,7 +42,7 @@ type ObjectEntry struct {
 	*ObjectNode
 	objData data.Object
 
-	hasPrintedPrepareComapct bool
+	HasPrintedPrepareComapct bool
 }
 
 func (entry *ObjectEntry) GetLoaded() bool {
@@ -664,10 +664,10 @@ func (entry *ObjectEntry) CheckPrintPrepareCompactLocked() bool {
 }
 
 func (entry *ObjectEntry) PrintPrepareCompactDebugLog() {
-	if entry.hasPrintedPrepareComapct {
+	if entry.HasPrintedPrepareComapct {
 		return
 	}
-	entry.hasPrintedPrepareComapct = true
+	entry.HasPrintedPrepareComapct = true
 	s := fmt.Sprintf("prepare compact failed, obj %v", entry.PPString(3, 0, ""))
 	lastNode := entry.GetLatestNodeLocked()
 	startTS := lastNode.GetStart()

--- a/pkg/vm/engine/tae/tables/aobj.go
+++ b/pkg/vm/engine/tae/tables/aobj.go
@@ -129,10 +129,19 @@ func (obj *aobject) PrepareCompact() bool {
 			return false
 		}
 	} else {
-		if !obj.meta.PrepareCompactLocked() ||
-			!obj.appendMVCC.PrepareCompactLocked() /* all appends are committed */ {
+		if !obj.meta.PrepareCompactLocked() {
+			if obj.meta.CheckPrintPrepareCompactLocked() {
+				obj.meta.PrintPrepareCompactDebugLog()
+			}
+			return false
+		}
+		if !obj.appendMVCC.PrepareCompactLocked() /* all appends are committed */ {
 			if obj.meta.CheckPrintPrepareCompactLocked() {
 				logutil.Infof("obj %v, data prepare compact failed", obj.meta.ID.String())
+				if !obj.meta.HasPrintedPrepareComapct {
+					obj.meta.HasPrintedPrepareComapct = true
+					logutil.Infof("append MVCC %v", obj.appendMVCC.StringLocked())
+				}
 			}
 			return false
 		}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16812 

## What this PR does / why we need it:
update debug log, print appendnodes


___

### **PR Type**
Bug fix


___

### **Description**
- Enhanced the `PrepareCompact` method with additional debug logging.
- Added checks for `PrepareCompactLocked` and corresponding debug logs.
- Introduced a flag `HasPrintedPrepareComapct` to ensure specific logs are printed only once.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aobj.go</strong><dd><code>Enhanced debug logging in `PrepareCompact` method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/aobj.go

<li>Added debug logging for <code>PrepareCompact</code> method.<br> <li> Introduced checks and logging for <code>PrepareCompactLocked</code> failures.<br> <li> Ensured <code>HasPrintedPrepareComapct</code> flag is set and logged appropriately.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16890/files#diff-cd11bed21d1df45b0585f408e1959ab95b025ede9e42787497867545d6803513">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

