### PR TITLE
Update txn print

### DIFF
--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -266,8 +266,8 @@ func NewTAENeedRetryNoCtx() *Error {
 	return newError(Context(), ErrTAENeedRetry)
 }
 
-func NewTxnStaleNoCtx() *Error {
-	return newError(Context(), ErrTxnStale)
+func NewTxnStaleNoCtx(msg string) *Error {
+	return newError(Context(), ErrTxnStale, msg)
 }
 
 func NewWaiterPausedNoCtx() *Error {

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2173,6 +2174,11 @@ func processLoadLocal(ses FeSession, execCtx *ExecCtx, param *tree.ExternParam, 
 	return
 }
 
+func makeCompactTxnInfo(op TxnOperator) string {
+	txn := op.Txn()
+	return fmt.Sprintf("%s:%s", hex.EncodeToString(txn.ID), txn.SnapshotTS.DebugString())
+}
+
 func executeStmtWithResponse(ses *Session,
 	execCtx *ExecCtx,
 ) (err error) {
@@ -2293,7 +2299,7 @@ func executeStmtWithWorkspace(ses FeSession,
 
 	//refresh txn id
 	ses.SetTxnId(txnOp.Txn().ID)
-	ses.SetStaticTxnId(txnOp.Txn().ID)
+	ses.SetStaticTxnInfo(makeCompactTxnInfo(txnOp))
 
 	//refresh proc txnOp
 	execCtx.proc.TxnOperator = txnOp

--- a/pkg/frontend/types.go
+++ b/pkg/frontend/types.go
@@ -334,8 +334,8 @@ type FeSession interface {
 	ResetFPrints()
 	EnterFPrint(idx int)
 	ExitFPrint(idx int)
-	SetStaticTxnId(id []byte)
-	GetStaticTxnId() uuid.UUID
+	SetStaticTxnInfo(string)
+	GetStaticTxnInfo() string
 	GetShareTxnBackgroundExec(ctx context.Context, newRawBatch bool) BackgroundExec
 	SessionLogger
 }
@@ -453,7 +453,7 @@ type feSessionImpl struct {
 	fprints      footPrints
 	respr        Responser
 	//refreshed once
-	staticTxnId uuid.UUID
+	staticTxnInfo string
 }
 
 func (ses *feSessionImpl) ResetFPrints() {
@@ -853,11 +853,11 @@ func (ses *feSessionImpl) GetResponser() Responser {
 	return ses.respr
 }
 
-func (ses *feSessionImpl) SetStaticTxnId(id []byte) {
-	copy(ses.staticTxnId[:], id)
+func (ses *feSessionImpl) SetStaticTxnInfo(info string) {
+	ses.staticTxnInfo = info
 }
-func (ses *feSessionImpl) GetStaticTxnId() uuid.UUID {
-	return ses.staticTxnId
+func (ses *feSessionImpl) GetStaticTxnInfo() string {
+	return ses.staticTxnInfo
 }
 
 func (ses *Session) GetDebugString() string {

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -501,9 +501,14 @@ func logStatementStringStatus(ctx context.Context, ses FeSession, stmtStr string
 		ses.Debug(ctx, "query trace status", logutil.StatementField(str), logutil.StatusField(status.String()))
 		err = nil // make sure: it is nil for EndStatement
 	} else {
-		txnId := ses.GetStaticTxnId()
-		ses.Error(ctx, "query trace status", logutil.StatementField(str), logutil.StatusField(status.String()), logutil.ErrorField(err),
-			logutil.TxnIdField(hex.EncodeToString(txnId[:])))
+		ses.Error(
+			ctx,
+			"query trace status",
+			logutil.StatementField(str),
+			logutil.StatusField(status.String()),
+			logutil.ErrorField(err),
+			logutil.TxnInfoField(ses.GetStaticTxnInfo()),
+		)
 	}
 
 	// pls make sure: NO ONE use the ses.tStmt after EndStatement

--- a/pkg/logutil/fields.go
+++ b/pkg/logutil/fields.go
@@ -32,6 +32,7 @@ func PathField(val string) zap.Field         { return zap.String("path", val) }
 
 func SessionIdField(val string) zap.Field   { return zap.String("session_id", val) }
 func TxnIdField(val string) zap.Field       { return zap.String("txn_id", val) }
+func TxnInfoField(val string) zap.Field     { return zap.String("txn_info", val) }
 func StatementIdField(val string) zap.Field { return zap.String("statement_id", val) }
 
 func NoReportFiled() zap.Field { return zap.Bool(MOInternalFiledKeyNoopReport, true) }

--- a/pkg/vm/engine/disttae/logtailreplay/blocks_iter.go
+++ b/pkg/vm/engine/disttae/logtailreplay/blocks_iter.go
@@ -16,6 +16,7 @@ package logtailreplay
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -41,7 +42,8 @@ func (p *PartitionState) ApproxObjectsNum() int {
 
 func (p *PartitionState) NewObjectsIter(ts types.TS) (ObjectsIter, error) {
 	if ts.Less(&p.minTS) {
-		return nil, moerr.NewTxnStaleNoCtx()
+		msg := fmt.Sprintf("(%s<%s)", ts.ToString(), p.minTS.ToString())
+		return nil, moerr.NewTxnStaleNoCtx(msg)
 	}
 	iter := p.dataObjects.Copy().Iter()
 	ret := &objectsIter{

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -658,6 +658,9 @@ func (tbl *txnTable) Ranges(ctx context.Context, exprs []*plan.Expr, txnOffset i
 			err)
 
 		v2.TxnTableRangeDurationHistogram.Observe(cost.Seconds())
+		if err != nil {
+			logutil.Errorf("txn: %s, error: %v", tbl.db.op.Txn().DebugString(), err)
+		}
 	}()
 
 	var blocks objectio.BlockInfoSlice
@@ -2585,6 +2588,7 @@ func (tbl *txnTable) MergeObjects(ctx context.Context, objstats []objectio.Objec
 		objInfos = make([]logtailreplay.ObjectInfo, 0, len(objstats))
 		iter, err := state.NewObjectsIter(snapshot)
 		if err != nil {
+			logutil.Errorf("txn: %s, error: %v", tbl.db.op.Txn().DebugString(), err)
 			return nil, err
 		}
 		for iter.Next() {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #16883 

## What this PR does / why we need it:

print more detailed info


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced `NewTxnStaleNoCtx` function to accept a message string for better error context.
- Added `makeCompactTxnInfo` function to format transaction info and updated related transaction ID handling.
- Replaced `SetStaticTxnId` and `GetStaticTxnId` with `SetStaticTxnInfo` and `GetStaticTxnInfo` in session handling.
- Improved error logging to use transaction info instead of transaction ID.
- Added `TxnInfoField` for logging transaction info.
- Enhanced `NewObjectsIter` to include detailed error message.
- Added error logging with transaction details in `Ranges` and `MergeObjects` functions in transaction table.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error_no_ctx.go</strong><dd><code>Enhance `NewTxnStaleNoCtx` with message parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/common/moerr/error_no_ctx.go

<li>Modified <code>NewTxnStaleNoCtx</code> function to accept a message string.<br> <li> Enhanced error handling with additional context.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16894/files#diff-ca37f540e6e78236250aa1377226580d516bf5f0bc80d8d74d837f5b3519b9e0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mysql_cmd_executor.go</strong><dd><code>Add compact transaction info formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/frontend/mysql_cmd_executor.go

<li>Added <code>makeCompactTxnInfo</code> function to format transaction info.<br> <li> Updated transaction ID handling to use compact transaction info.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16894/files#diff-af2611d5fc89704398fe09d09644efa41fec8931b395eda292f2f474f1216275">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Update session transaction info handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/frontend/types.go

<li>Replaced <code>SetStaticTxnId</code> and <code>GetStaticTxnId</code> with <code>SetStaticTxnInfo</code> and <br><code>GetStaticTxnInfo</code>.<br> <li> Updated session implementation to handle transaction info as string.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16894/files#diff-5426ed8bd66760011299bcef0a9d1d552477eaae49a8451e16b8ec5bf7d7310f">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Improve error logging with transaction info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/frontend/util.go

<li>Updated error logging to use transaction info instead of transaction <br>ID.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16894/files#diff-005617216374ac58bf3cf72b81841d5cb6a17495d1d7b36ff387e294a0d6e043">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fields.go</strong><dd><code>Add logging field for transaction info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/logutil/fields.go

- Added `TxnInfoField` for logging transaction info.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16894/files#diff-cfa1fc47c44fe1415d6ffb8cb2341253c31941e89d54fc2d0f0f4215564e5cca">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>blocks_iter.go</strong><dd><code>Improve error message in `NewObjectsIter`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/logtailreplay/blocks_iter.go

- Enhanced `NewObjectsIter` to include detailed error message.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16894/files#diff-2a65096be82448984c3028029297fa50357275c6dafbb8747f64a0a340629d40">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Enhance error logging in transaction table operations</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/disttae/txn_table.go

<li>Added error logging with transaction details in <code>Ranges</code> and <br><code>MergeObjects</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16894/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

