### PR TITLE
sync to 1.2: refactor in memory reader filter and simplify reader filters. 

### DIFF
--- a/pkg/frontend/test/engine_mock.go
+++ b/pkg/frontend/test/engine_mock.go
@@ -1171,9 +1171,9 @@ func (mr *MockEngineMockRecorder) New(ctx, op interface{}) *gomock.Call {
 }
 
 // NewBlockReader mocks base method.
-func (m *MockEngine) NewBlockReader(ctx context.Context, num int, ts timestamp.Timestamp, expr *plan.Expr, ranges []byte, tblDef *plan.TableDef, proc any) ([]engine.Reader, error) {
+func (m *MockEngine) NewBlockReader(ctx context.Context, num int, ts timestamp.Timestamp, expr *plan.Expr, filter any, ranges []byte, tblDef *plan.TableDef, proc any) ([]engine.Reader, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewBlockReader", ctx, num, ts, expr, ranges, tblDef, proc)
+	ret := m.ctrl.Call(m, "NewBlockReader", ctx, num, ts, expr, filter, ranges, tblDef, proc)
 	ret0, _ := ret[0].([]engine.Reader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -522,7 +522,7 @@ func buildScanParallelRun(s *Scope, c *Compile) (*Scope, error) {
 
 		readers, err = c.e.NewBlockReader(
 			ctx, scanUsedCpuNumber,
-			s.DataSource.Timestamp, s.DataSource.FilterExpr, s.NodeInfo.Data, s.DataSource.TableDef, c.proc)
+			s.DataSource.Timestamp, s.DataSource.FilterExpr, nil, s.NodeInfo.Data, s.DataSource.TableDef, c.proc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -16,7 +16,6 @@ package disttae
 
 import (
 	"context"
-	"fmt"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
 	"runtime"
 	"strings"
@@ -745,7 +744,7 @@ func (e *Engine) NewBlockReader(ctx context.Context, num int, ts timestamp.Times
 		// remote block reader
 		basePKFilter := constructBasePKFilter(expr, tblDef, proc.(*process.Process))
 		blockReadPKFilter = constructBlockReadPKFilter(tblDef.Pkey.PkeyColName, basePKFilter)
-		fmt.Println("remote filter: ", basePKFilter.String(), blockReadPKFilter)
+		//fmt.Println("remote filter: ", basePKFilter.String(), blockReadPKFilter)
 	}
 
 	blkSlice := objectio.BlockInfoSlice(ranges)

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -16,6 +16,7 @@ package disttae
 
 import (
 	"context"
+	"fmt"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
 	"runtime"
 	"strings"
@@ -744,6 +745,7 @@ func (e *Engine) NewBlockReader(ctx context.Context, num int, ts timestamp.Times
 		// remote block reader
 		basePKFilter := constructBasePKFilter(expr, tblDef, proc.(*process.Process))
 		blockReadPKFilter = constructBlockReadPKFilter(tblDef.Pkey.PkeyColName, basePKFilter)
+		fmt.Println("remote filter: ", basePKFilter.String(), blockReadPKFilter)
 	}
 
 	blkSlice := objectio.BlockInfoSlice(ranges)

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -16,6 +16,7 @@ package disttae
 
 import (
 	"context"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
 	"runtime"
 	"strings"
 	"sync"
@@ -737,7 +738,14 @@ func (e *Engine) Hints() (h engine.Hints) {
 }
 
 func (e *Engine) NewBlockReader(ctx context.Context, num int, ts timestamp.Timestamp,
-	expr *plan.Expr, ranges []byte, tblDef *plan.TableDef, proc any) ([]engine.Reader, error) {
+	expr *plan.Expr, filter any, ranges []byte, tblDef *plan.TableDef, proc any) ([]engine.Reader, error) {
+	var blockReadPKFilter blockio.BlockReadFilter
+	if filter == nil {
+		// remote block reader
+		basePKFilter := constructBasePKFilter(expr, tblDef, proc.(*process.Process))
+		blockReadPKFilter = constructBlockReadPKFilter(tblDef.Pkey.PkeyColName, basePKFilter)
+	}
+
 	blkSlice := objectio.BlockInfoSlice(ranges)
 	rds := make([]engine.Reader, num)
 	blkInfos := make([]*objectio.BlockInfo, 0, blkSlice.Len())
@@ -749,7 +757,7 @@ func (e *Engine) NewBlockReader(ctx context.Context, num int, ts timestamp.Times
 			//FIXME::why set blk.EntryState = false ?
 			blk.EntryState = false
 			rds[i] = newBlockReader(
-				ctx, tblDef, ts, []*objectio.BlockInfo{blk}, expr, e.fs, proc.(*process.Process),
+				ctx, tblDef, ts, []*objectio.BlockInfo{blk}, expr, blockReadPKFilter, e.fs, proc.(*process.Process),
 			)
 		}
 		for j := len(blkInfos); j < num; j++ {
@@ -763,7 +771,7 @@ func (e *Engine) NewBlockReader(ctx context.Context, num int, ts timestamp.Times
 	if err != nil {
 		return nil, err
 	}
-	blockReaders := newBlockReaders(ctx, fs, tblDef, ts, num, expr, proc.(*process.Process))
+	blockReaders := newBlockReaders(ctx, fs, tblDef, ts, num, expr, blockReadPKFilter, proc.(*process.Process))
 	distributeBlocksToBlockReaders(blockReaders, num, len(blkInfos), infos, steps)
 	for i := 0; i < num; i++ {
 		rds[i] = blockReaders[i]

--- a/pkg/vm/engine/disttae/logtailreplay/rows_iter.go
+++ b/pkg/vm/engine/disttae/logtailreplay/rows_iter.go
@@ -16,8 +16,8 @@ package logtailreplay
 
 import (
 	"bytes"
-
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/tidwall/btree"
 )
@@ -218,6 +218,10 @@ func BetweenKind(lb, ub []byte, kind int) PrimaryKeyMatchSpec {
 		}
 	case 4:
 		validCheck = func(bb []byte) bool { return types.PrefixCompare(bb, ub) <= 0 }
+		seek2First = func(iter *btree.IterG[*PrimaryIndexEntry]) bool { return true }
+	default:
+		logutil.Infof("between kind missed: kind: %d, lb=%v, ub=%v\n", kind, lb, ub)
+		validCheck = func(bb []byte) bool { return true }
 		seek2First = func(iter *btree.IterG[*PrimaryIndexEntry]) bool { return true }
 	}
 

--- a/pkg/vm/engine/disttae/logtailreplay/rows_iter.go
+++ b/pkg/vm/engine/disttae/logtailreplay/rows_iter.go
@@ -16,9 +16,9 @@ package logtailreplay
 
 import (
 	"bytes"
-	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/tidwall/btree"
 )
 
@@ -302,11 +302,6 @@ func GreatKind(lb []byte, closed bool) PrimaryKeyMatchSpec {
 
 func InKind(encodes [][]byte, kind int) PrimaryKeyMatchSpec {
 	var encoded []byte
-	//var debug bool
-
-	if kind == function.PREFIX_IN {
-		//debug = true
-	}
 
 	first := true
 	iterateAll := false
@@ -326,11 +321,6 @@ func InKind(encodes [][]byte, kind int) PrimaryKeyMatchSpec {
 
 	match := func(key []byte) bool {
 		if kind == function.PREFIX_IN {
-			//if debug {
-			//	xx, _ := types.Unpack(encoded)
-			//	yy, _ := types.Unpack(key)
-			//	fmt.Printf("%v-%v; %v-%v\n", encoded, xx, key, yy)
-			//}
 			return bytes.HasPrefix(key, encoded)
 		} else {
 			// in
@@ -342,24 +332,6 @@ func InKind(encodes [][]byte, kind int) PrimaryKeyMatchSpec {
 		Name: "InKind",
 		Move: func(p *primaryKeyIter) bool {
 			if first {
-				if kind == function.PREFIX_IN {
-					//var buf bytes.Buffer
-					//buf.WriteString("want: ")
-					//for r := range encodes {
-					//	xx, _ := types.Unpack(encodes[r])
-					//	buf.WriteString(fmt.Sprintf("%v-%v; ", encodes[r], xx))
-					//}
-					//
-					//buf.WriteString("\n has: ")
-					//p.primaryIndex.Scan(func(item *PrimaryIndexEntry) bool {
-					//	xx, _ := types.Unpack(item.Bytes)
-					//	buf.WriteString(fmt.Sprintf("%v-%v; ", item.Bytes, xx))
-					//	return true
-					//})
-
-					//fmt.Println(buf.String(), "\n")
-				}
-
 				first = false
 				// each seek may visit height items
 				// we choose to scan all if the seek is more expensive

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -19,8 +19,6 @@ import (
 	"sort"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -42,6 +40,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"go.uber.org/zap"
 )
 
 // -----------------------------------------------------------------
@@ -62,7 +61,7 @@ func (mixin *withFilterMixin) reset() {
 // call tryUpdate to update the seqnums
 // NOTE: here we assume the tryUpdate is always called with the same cols
 // for all blocks and it will only be updated once
-func (mixin *withFilterMixin) tryUpdateColumns(cols []string) {
+func (mixin *withFilterMixin) tryUpdateColumns(cols []string, blkCnt int) {
 	if len(cols) == len(mixin.columns.seqnums) {
 		return
 	}
@@ -100,68 +99,20 @@ func (mixin *withFilterMixin) tryUpdateColumns(cols []string) {
 			mixin.columns.colTypes[i] = types.T(colDef.Typ.Id).ToType()
 		}
 	}
-}
 
-func (mixin *withFilterMixin) getReadFilter(proc *process.Process, blkCnt int) (
-	filter blockio.BlockReadFilter,
-) {
-	if mixin.filterState.evaluated {
-		filter = mixin.filterState.filter
-		return
-	}
-	pk := mixin.tableDef.Pkey
-	if mixin.filterState.expr == nil || pk == nil {
+	if mixin.columns.pkPos != -1 {
+		// here we will select the primary key column from the vectors, and
+		// use the search function to find the offset of the primary key.
+		// it returns the offset of the primary key in the pk vector.
+		// if the primary key is not found, it returns empty slice
 		mixin.filterState.evaluated = true
-		mixin.filterState.filter = blockio.BlockReadFilter{}
-		return
+		//mixin.filterState.filter = filter
+		mixin.filterState.seqnums = []uint16{mixin.columns.seqnums[mixin.columns.pkPos]}
+		mixin.filterState.colTypes = mixin.columns.colTypes[mixin.columns.pkPos : mixin.columns.pkPos+1]
+
+		// records how many blks one reader needs to read when having filter
+		objectio.BlkReadStats.BlksByReaderStats.Record(1, blkCnt)
 	}
-	return mixin.getPKFilter(proc, blkCnt)
-}
-
-func (mixin *withFilterMixin) getPKFilter(
-	proc *process.Process, blkCnt int,
-) blockio.BlockReadFilter {
-	// if no primary key is included in the columns or no filter expr is given,
-	// no filter is needed
-	if mixin.columns.pkPos == -1 || mixin.filterState.expr == nil {
-		mixin.filterState.evaluated = true
-		mixin.filterState.filter = blockio.BlockReadFilter{}
-		return blockio.BlockReadFilter{}
-	}
-
-	// evaluate the search function for the filter
-	// if the search function is not found, no filter is needed
-	// primary key must be used by the expr in one of the following patterns:
-	// A: $pk = const_value
-	// B: const_value = $pk
-	// C: {A|B} and {A|B}
-	// D: {A|B|C} [and {A|B|C}]*
-	// for other patterns, no filter is needed
-	ok, hasNull, filter := getNonCompositePKSearchFuncByExpr(
-		mixin.filterState.expr,
-		mixin.tableDef,
-		mixin.tableDef.Pkey.PkeyColName,
-		proc,
-	)
-	if !ok || !filter.Valid {
-		mixin.filterState.evaluated = true
-		mixin.filterState.filter = blockio.BlockReadFilter{}
-		mixin.filterState.hasNull = hasNull
-		return blockio.BlockReadFilter{}
-	}
-
-	// here we will select the primary key column from the vectors, and
-	// use the search function to find the offset of the primary key.
-	// it returns the offset of the primary key in the pk vector.
-	// if the primary key is not found, it returns empty slice
-	mixin.filterState.evaluated = true
-	mixin.filterState.filter = filter
-	mixin.filterState.seqnums = []uint16{mixin.columns.seqnums[mixin.columns.pkPos]}
-	mixin.filterState.colTypes = mixin.columns.colTypes[mixin.columns.pkPos : mixin.columns.pkPos+1]
-
-	// records how many blks one reader needs to read when having filter
-	objectio.BlkReadStats.BlksByReaderStats.Record(1, blkCnt)
-	return filter
 }
 
 // -----------------------------------------------------------------
@@ -197,6 +148,7 @@ func newBlockReader(
 	ts timestamp.Timestamp,
 	blks []*objectio.BlockInfo,
 	filterExpr *plan.Expr,
+	filter blockio.BlockReadFilter,
 	fs fileservice.FileService,
 	proc *process.Process,
 ) *blockReader {
@@ -217,6 +169,7 @@ func newBlockReader(
 		blks: blks,
 	}
 	r.filterState.expr = filterExpr
+	r.filterState.filter = filter
 	return r
 }
 
@@ -375,10 +328,9 @@ func (r *blockReader) Read(
 
 	// try to update the columns
 	// the columns is only updated once for all blocks
-	r.tryUpdateColumns(cols)
+	r.tryUpdateColumns(cols, len(r.blks))
 
-	// get the block read filter
-	filter := r.getReadFilter(r.proc, len(r.blks))
+	filter := r.withFilterMixin.filterState.filter
 
 	// if any null expr is found in the primary key (composite primary keys), quick return
 	if r.filterState.hasNull {
@@ -473,7 +425,7 @@ func (r *blockReader) gatherStats(lastNumRead, lastNumHit int64) {
 func newBlockMergeReader(
 	ctx context.Context,
 	txnTable *txnTable,
-	pkFilter InMemPKFilter,
+	pkFilter PKFilters,
 	ts timestamp.Timestamp,
 	dirtyBlks []*objectio.BlockInfo,
 	filterExpr *plan.Expr,
@@ -490,10 +442,11 @@ func newBlockMergeReader(
 			ts,
 			dirtyBlks,
 			filterExpr,
+			pkFilter.blockReadPKFilter,
 			fs,
 			proc,
 		),
-		pkFilter:   pkFilter,
+		pkFilter:   pkFilter.inMemPKFilter,
 		deletaLocs: make(map[string][]objectio.Location),
 	}
 	return r
@@ -562,15 +515,12 @@ func (r *blockMergeReader) loadDeletes(ctx context.Context, cols []string) error
 	}
 	info := r.blks[0]
 
-	r.tryUpdateColumns(cols)
+	r.tryUpdateColumns(cols, len(r.blks))
 	// load deletes from txn.blockId_dn_delete_metaLoc_batch
 	err := r.table.LoadDeletesForBlock(info.BlockID, &r.buffer)
 	if err != nil {
 		return err
 	}
-
-	// load deletes from partition state for the specified block
-	//filter := r.getReadFilter(r.proc, len(r.blks))
 
 	state, err := r.table.getPartitionState(ctx)
 	if err != nil {
@@ -579,14 +529,9 @@ func (r *blockMergeReader) loadDeletes(ctx context.Context, cols []string) error
 	ts := types.TimestampToTS(r.ts)
 
 	var iter logtailreplay.RowsIter
-	//if r.pkFilter.isValid {
-	//	switch r.pkFilter.op {
-	//	case function.EQUAL, function.PREFIX_EQ:
-	//		iter = state.NewPrimaryKeyDelIter(ts, logtailreplay.Prefix(r.pkFilter.packed[0]), info.BlockID)
-	//	case function.IN:
-	//		iter = state.NewPrimaryKeyDelIter(ts, logtailreplay.InKind(r.pkFilter.packed, r.pkFilter.op), info.BlockID)
-	//	}
-	//}
+	if r.pkFilter.delIterFactory != nil {
+		iter = r.pkFilter.delIterFactory(info.BlockID)
+	}
 
 	if iter != nil {
 		for iter.Next() {

--- a/pkg/vm/engine/disttae/tools.go
+++ b/pkg/vm/engine/disttae/tools.go
@@ -17,6 +17,7 @@ package disttae
 import (
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -1494,12 +1495,12 @@ func groupBlocksToObjects(blkInfos []*objectio.BlockInfo, dop int) ([][]*objecti
 }
 
 func newBlockReaders(ctx context.Context, fs fileservice.FileService, tblDef *plan.TableDef,
-	ts timestamp.Timestamp, num int, expr *plan.Expr,
+	ts timestamp.Timestamp, num int, expr *plan.Expr, filter blockio.BlockReadFilter,
 	proc *process.Process) []*blockReader {
 	rds := make([]*blockReader, num)
 	for i := 0; i < num; i++ {
 		rds[i] = newBlockReader(
-			ctx, tblDef, ts, nil, expr, fs, proc,
+			ctx, tblDef, ts, nil, expr, filter, fs, proc,
 		)
 	}
 	return rds

--- a/pkg/vm/engine/disttae/tools.go
+++ b/pkg/vm/engine/disttae/tools.go
@@ -17,7 +17,6 @@ package disttae
 import (
 	"context"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -38,6 +37,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/trace"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2185,7 +2185,7 @@ func (tbl *txnTable) PKPersistedBetween(
 		//keys must be sorted.
 		keys.InplaceSort()
 		bytes, _ := keys.MarshalBinary()
-		colExpr := newColumnExpr(0, plan2.MakePlan2Type(keys.GetType()), "pk")
+		colExpr := newColumnExpr(0, plan2.MakePlan2Type(keys.GetType()), tbl.tableDef.Pkey.PkeyColName)
 		inExpr := plan2.MakeInExpr(
 			tbl.proc.Load().Ctx,
 			colExpr,
@@ -2193,8 +2193,13 @@ func (tbl *txnTable) PKPersistedBetween(
 			bytes,
 			false)
 
+		fmt.Println("YYY")
 		basePKFilter := constructBasePKFilter(inExpr, tbl.tableDef, tbl.proc.Load())
 		blockReadPKFilter := constructBlockReadPKFilter(tbl.tableDef.Pkey.PkeyColName, basePKFilter)
+
+		if blockReadPKFilter.SortedSearchFunc == nil {
+			fmt.Println(basePKFilter.String(), plan2.FormatExpr(inExpr))
+		}
 
 		return blockReadPKFilter.SortedSearchFunc
 	}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1726,7 +1726,7 @@ func (tbl *txnTable) NewReader(
 		return nil, err
 	}
 
-	pkFilters := ConstructPKFilters(tbl.tableDef, ts, state, expr, tbl.proc.Load(), txn.engine.packerPool)
+	pkFilters := ConstructPKFilters(tbl.tableDef, tbl.db.databaseName, ts, state, expr, tbl.proc.Load(), txn.engine.packerPool)
 
 	blkArray := objectio.BlockInfoSlice(ranges)
 	if !pkFilters.inMemPKFilter.isValid || plan2.IsFalseExpr(expr) {
@@ -2193,7 +2193,6 @@ func (tbl *txnTable) PKPersistedBetween(
 			bytes,
 			false)
 
-		fmt.Println("YYY")
 		basePKFilter := constructBasePKFilter(inExpr, tbl.tableDef, tbl.proc.Load())
 		blockReadPKFilter := constructBlockReadPKFilter(tbl.tableDef.Pkey.PkeyColName, basePKFilter)
 

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2196,10 +2196,6 @@ func (tbl *txnTable) PKPersistedBetween(
 		basePKFilter := constructBasePKFilter(inExpr, tbl.tableDef, tbl.proc.Load())
 		blockReadPKFilter := constructBlockReadPKFilter(tbl.tableDef.Pkey.PkeyColName, basePKFilter)
 
-		if blockReadPKFilter.SortedSearchFunc == nil {
-			fmt.Println(basePKFilter.String(), plan2.FormatExpr(inExpr))
-		}
-
 		return blockReadPKFilter.SortedSearchFunc
 	}
 

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -748,7 +748,7 @@ type withFilterMixin struct {
 		evaluated bool
 		//point select for primary key
 		expr     *plan.Expr
-		filter   blockio.ReadFilter
+		filter   blockio.BlockReadFilter
 		seqnums  []uint16 // seqnums of the columns in the filter
 		colTypes []types.Type
 		hasNull  bool
@@ -789,7 +789,7 @@ type blockMergeReader struct {
 	*blockReader
 	table     *txnTable
 	txnOffset int // Transaction writes offset used to specify the starting position for reading data.
-	pkFilter  PKFilter
+	pkFilter  InMemPKFilter
 	//for perfetch deletes
 	loaded     bool
 	pkidx      int

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -700,14 +700,15 @@ func constructInMemPKFilter(
 			lbVal = types.DecodeDecimal64(basePKFilter.lb)
 		case types.T_decimal128:
 			lbVal = types.DecodeDecimal128(basePKFilter.lb)
-		case types.T_varchar:
+		case types.T_varchar, types.T_char:
 			lbVal = basePKFilter.lb
 		case types.T_json:
 			lbVal = types.DecodeJson(basePKFilter.lb)
 		case types.T_enum:
 			lbVal = types.DecodeEnum(basePKFilter.lb)
 		default:
-			panic(basePKFilter.oid.String())
+			return
+			//panic(basePKFilter.oid.String())
 		}
 
 		packed = append(packed, logtailreplay.EncodePrimaryKey(lbVal, packer))

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -82,6 +82,10 @@ type BasePKFilter struct {
 
 func (b *BasePKFilter) String() string {
 	name := map[int]string{
+		function.LESS_EQUAL:     "less_eq",
+		function.LESS_THAN:      "less_than",
+		function.GREAT_THAN:     "great_than",
+		function.GREAT_EQUAL:    "great_eq",
 		rangeLeftOpen:           "range_left_open",
 		rangeRightOpen:          "range_right_open",
 		rangeBothOpen:           "range_both_open",

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -887,7 +887,7 @@ func tryConstructPrimaryKeyIndexIter(
 		delIterFactory = func(blkId types.Blockid) logtailreplay.RowsIter {
 			return state.NewPrimaryKeyDelIter(
 				types.TimestampToTS(ts),
-				logtailreplay.BetweenKind(pkFilter.packed[0], pkFilter.packed[1], pkFilter.op), blkId)
+				logtailreplay.BetweenKind(pkFilter.packed[0], pkFilter.packed[1], kind), blkId)
 		}
 	}
 

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -470,6 +470,7 @@ func ConstructPKFilters(tableDef *plan.TableDef,
 	ts timestamp.Timestamp, state *logtailreplay.PartitionState,
 	expr *plan.Expr, proc *process.Process,
 	packerPool *fileservice.Pool[*types.Packer]) (filters PKFilters) {
+
 	basePKFilter := constructBasePKFilter(expr, tableDef, proc)
 
 	filters.inMemPKFilter = constructInMemPKFilter(tableDef, ts, state, packerPool, basePKFilter)
@@ -479,6 +480,10 @@ func ConstructPKFilters(tableDef *plan.TableDef,
 }
 
 func constructBasePKFilter(expr *plan.Expr, tblDef *plan.TableDef, proc *process.Process) (filter BasePKFilter) {
+	if expr == nil {
+		return
+	}
+
 	defer func() {
 		if tblDef.Pkey.CompPkeyCol != nil {
 			filter.oid = types.T_varchar

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -471,9 +471,6 @@ func ConstructPKFilters(tableDef *plan.TableDef,
 	expr *plan.Expr, proc *process.Process,
 	packerPool *fileservice.Pool[*types.Packer]) (filters PKFilters) {
 	basePKFilter := constructBasePKFilter(expr, tableDef, proc)
-	if tableDef.Pkey.CompPkeyCol != nil {
-		basePKFilter.oid = types.T_varchar
-	}
 
 	filters.inMemPKFilter = constructInMemPKFilter(tableDef, ts, state, packerPool, basePKFilter)
 	filters.blockReadPKFilter = constructBlockReadPKFilter(tableDef.Pkey.PkeyColName, basePKFilter)
@@ -482,6 +479,12 @@ func ConstructPKFilters(tableDef *plan.TableDef,
 }
 
 func constructBasePKFilter(expr *plan.Expr, tblDef *plan.TableDef, proc *process.Process) (filter BasePKFilter) {
+	defer func() {
+		if tblDef.Pkey.CompPkeyCol != nil {
+			filter.oid = types.T_varchar
+		}
+	}()
+
 	switch exprImpl := expr.Expr.(type) {
 	case *plan.Expr_F:
 		switch name := exprImpl.F.Func.ObjName; name {

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -72,7 +72,7 @@ const (
 	//emptySet
 )
 
-type blockReaderPKFilter struct {
+type BasePKFilter struct {
 	valid bool
 	op    int
 	lb    []byte
@@ -80,7 +80,7 @@ type blockReaderPKFilter struct {
 	oid   types.T
 }
 
-func (b *blockReaderPKFilter) String() string {
+func (b *BasePKFilter) String() string {
 	return fmt.Sprintf("valid = %v, op = %d, lb = %v, ub = %v, oid = %s",
 		b.valid, b.op, b.lb, b.ub, b.oid)
 }
@@ -125,7 +125,7 @@ func evalValue(exprImpl *plan.Expr_F, tblDef *plan.TableDef, isVec bool, pkName 
 // left op in (">", ">=", "=", "<", "<="), right op in (">", ">=", "=", "<", "<=")
 // left op AND right op
 // left op OR right op
-func mergeFilters(left, right blockReaderPKFilter, connector int) (finalFilter blockReaderPKFilter) {
+func mergeFilters(left, right BasePKFilter, connector int) (finalFilter BasePKFilter) {
 	switch connector {
 	case function.AND:
 		switch left.op {
@@ -455,13 +455,13 @@ func mergeFilters(left, right blockReaderPKFilter, connector int) (finalFilter b
 	return
 }
 
-func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, proc *process.Process) (filter blockReaderPKFilter) {
+func constructBasePKFilter(expr *plan.Expr, tblDef *plan.TableDef, proc *process.Process) (filter BasePKFilter) {
 	switch exprImpl := expr.Expr.(type) {
 	case *plan.Expr_F:
 		switch name := exprImpl.F.Func.ObjName; name {
 		case "and":
-			leftFilter := constructPKFilter(exprImpl.F.Args[0], tblDef, pkName, proc)
-			rightFilter := constructPKFilter(exprImpl.F.Args[1], tblDef, pkName, proc)
+			leftFilter := constructBasePKFilter(exprImpl.F.Args[0], tblDef, proc)
+			rightFilter := constructBasePKFilter(exprImpl.F.Args[1], tblDef, proc)
 			if !leftFilter.valid {
 				return rightFilter
 			}
@@ -474,8 +474,8 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 			filter.oid = leftFilter.oid
 
 		case "or":
-			leftFilter := constructPKFilter(exprImpl.F.Args[0], tblDef, pkName, proc)
-			rightFilter := constructPKFilter(exprImpl.F.Args[1], tblDef, pkName, proc)
+			leftFilter := constructBasePKFilter(exprImpl.F.Args[0], tblDef, proc)
+			rightFilter := constructBasePKFilter(exprImpl.F.Args[1], tblDef, proc)
 			if !leftFilter.valid {
 				return rightFilter
 			}
@@ -489,7 +489,7 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 
 		case ">=":
 			//a >= ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, pkName, proc)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, proc)
 			if !ok {
 				return
 			}
@@ -500,7 +500,7 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 
 		case "<=":
 			//a <= ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, pkName, proc)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, proc)
 			if !ok {
 				return
 			}
@@ -511,7 +511,7 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 
 		case ">":
 			//a > ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, pkName, proc)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, proc)
 			if !ok {
 				return
 			}
@@ -522,7 +522,7 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 
 		case "<":
 			//a < ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, pkName, proc)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, proc)
 			if !ok {
 				return
 			}
@@ -533,7 +533,7 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 
 		case "=":
 			// a = ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, pkName, proc)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, proc)
 			if !ok {
 				return
 			}
@@ -543,7 +543,7 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 			filter.oid = oid
 
 		case "prefix_eq":
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, pkName, proc)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, proc)
 			if !ok {
 				return
 			}
@@ -553,7 +553,7 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 			filter.oid = oid
 
 		case "in":
-			ok, oid, vals := evalValue(exprImpl, tblDef, true, pkName, proc)
+			ok, oid, vals := evalValue(exprImpl, tblDef, true, tblDef.Pkey.PkeyColName, proc)
 			if !ok {
 				return
 			}
@@ -563,7 +563,7 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 			filter.oid = oid
 
 		case "prefix_in":
-			ok, oid, vals := evalValue(exprImpl, tblDef, true, pkName, proc)
+			ok, oid, vals := evalValue(exprImpl, tblDef, true, tblDef.Pkey.PkeyColName, proc)
 			if !ok {
 				return
 			}
@@ -573,7 +573,7 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 			filter.oid = oid
 
 		case "between":
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, pkName, proc)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, proc)
 			if !ok {
 				return
 			}
@@ -584,7 +584,7 @@ func constructPKFilter(expr *plan.Expr, tblDef *plan.TableDef, pkName string, pr
 			filter.oid = oid
 
 		case "prefix_between":
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, pkName, proc)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, proc)
 			if !ok {
 				return
 			}
@@ -1066,17 +1066,17 @@ func getNonSortedPKSearchFuncByPKVec(
 
 func getNonCompositePKSearchFuncByExpr(
 	expr *plan.Expr, tblDef *plan.TableDef, pkName string, proc *process.Process,
-) (bool, bool, blockio.ReadFilter) {
-	pkFilter := constructPKFilter(expr, tblDef, pkName, proc)
+) (bool, bool, blockio.BlockReadFilter) {
+	pkFilter := constructBasePKFilter(expr, tblDef, proc)
 	if !pkFilter.valid {
-		return false, false, blockio.ReadFilter{}
+		return false, false, blockio.BlockReadFilter{}
 	}
 
 	if tblDef.Pkey.CompPkeyCol != nil {
 		pkFilter.oid = types.T_varchar
 	}
 
-	var readFilter blockio.ReadFilter
+	var readFilter blockio.BlockReadFilter
 	var sortedSearchFunc, unSortedSearchFunc func(*vector.Vector) []int32
 
 	readFilter.HasFakePK = pkName == catalog.FakePrimaryKeyColName
@@ -1470,30 +1470,30 @@ func evalLiteralExpr(expr *plan.Literal, oid types.T) (canEval bool, val any) {
 	return
 }
 
-type PKFilter struct {
-	op      uint8
-	val     any
+type InMemPKFilter struct {
+	op int
+	//val     any
 	packed  [][]byte
 	isVec   bool
 	isValid bool
-	isNull  bool
+	iter    logtailreplay.RowsIter
+	//isNull  bool
 }
 
-func (f *PKFilter) String() string {
+func (f *InMemPKFilter) String() string {
 	var buf bytes.Buffer
 	buf.WriteString(
-		fmt.Sprintf("PKFilter{op: %d, isVec: %v, isValid: %v, isNull: %v, val: %v, data(len=%d)",
-			f.op, f.isVec, f.isValid, f.isNull, f.val, len(f.packed),
+		fmt.Sprintf("InMemPKFilter{op: %d, isVec: %v, isValid: %v, val: %v, data(len=%d)",
+			f.op, f.isVec, f.isValid, len(f.packed),
 		))
 	return buf.String()
 }
 
-func (f *PKFilter) SetNull() {
-	f.isNull = true
+func (f *InMemPKFilter) SetNull() {
 	f.isValid = false
 }
 
-func (f *PKFilter) SetFullData(op uint8, isVec bool, val ...[]byte) {
+func (f *InMemPKFilter) SetFullData(op int, isVec bool, val ...[]byte) {
 	f.packed = append(f.packed, val...)
 	f.op = op
 	f.isVec = isVec
@@ -1509,54 +1509,62 @@ func (f *PKFilter) SetVal(op uint8, isVec bool, val any) {
 	f.isNull = false
 }
 
-func getPKFilterByExpr(
-	expr *plan.Expr,
-	pkName string,
-	oid types.T,
-	tbl *txnTable,
-) (retFilter PKFilter) {
-	valExpr := getPkExpr(expr, pkName, tbl.proc.Load())
-	if valExpr == nil {
-		return
-	}
-	switch exprImpl := valExpr.Expr.(type) {
-	case *plan.Expr_Lit:
-		if exprImpl.Lit.Isnull {
-			retFilter.SetNull()
-			return
-		}
+//func (f *InMemPKFilter) SetVal(op uint8, isVec bool, val any) {
+//	f.op = op
+//	f.val = val
+//	f.isVec = isVec
+//	f.isValid = true
+//	f.isNull = false
+//}
 
-		canEval, val := evalLiteralExpr(exprImpl.Lit, oid)
-		if !canEval {
-			return
-		}
-		retFilter.SetVal(function.EQUAL, false, val)
-		return
-	case *plan.Expr_Vec:
-		var packed [][]byte
-		var packer *types.Packer
-
-		vec := vector.NewVec(types.T_any.ToType())
-		vec.UnmarshalBinary(exprImpl.Vec.Data)
-
-		put := tbl.getTxn().engine.packerPool.Get(&packer)
-		packed = logtailreplay.EncodePrimaryKeyVector(vec, packer)
-		put.Put()
-
-		retFilter.SetFullData(function.IN, true, packed...)
-		return
-	case *plan.Expr_F:
-		switch exprImpl.F.Func.ObjName {
-		case "prefix_eq":
-			val := util.UnsafeStringToBytes(exprImpl.F.Args[1].GetLit().GetSval())
-			retFilter.SetVal(function.PREFIX_EQ, false, val)
-			return
-			// case "prefix_between":
-			// case "prefix_in":
-		}
-	}
-	return
-}
+//func getPKFilterByExpr(
+//	expr *plan.Expr,
+//	pkName string,
+//	oid types.T,
+//	tbl *txnTable,
+//) (retFilter InMemPKFilter) {
+//	valExpr := getPkExpr(expr, pkName, tbl.proc.Load())
+//	if valExpr == nil {
+//		return
+//	}
+//	switch exprImpl := valExpr.Expr.(type) {
+//	case *plan.Expr_Lit:
+//		if exprImpl.Lit.Isnull {
+//			retFilter.SetNull()
+//			return
+//		}
+//
+//		canEval, val := evalLiteralExpr(exprImpl.Lit, oid)
+//		if !canEval {
+//			return
+//		}
+//		retFilter.SetVal(function.EQUAL, false, val)
+//		return
+//	case *plan.Expr_Vec:
+//		var packed [][]byte
+//		var packer *types.Packer
+//
+//		vec := vector.NewVec(types.T_any.ToType())
+//		vec.UnmarshalBinary(exprImpl.Vec.Data)
+//
+//		put := tbl.getTxn().engine.packerPool.Get(&packer)
+//		packed = logtailreplay.EncodePrimaryKeyVector(vec, packer)
+//		put.Put()
+//
+//		retFilter.SetFullData(function.IN, true, packed...)
+//		return
+//	case *plan.Expr_F:
+//		switch exprImpl.F.Func.ObjName {
+//		case "prefix_eq":
+//			val := []byte(exprImpl.F.Args[1].GetLit().GetSval())
+//			retFilter.SetVal(function.PREFIX_EQ, false, val)
+//			return
+//			// case "prefix_between":
+//			// case "prefix_in":
+//		}
+//	}
+//	return
+//}
 
 // return canEval, isNull, isVec, evaledVal
 func getPkValueByExpr(

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -1492,8 +1492,8 @@ func constructBlockReadPKFilter(pkName string, basePKFilter BasePKFilter) blocki
 			unSortedSearchFunc = vector.FixedSizeLinearSearchOffsetByValFactory(vector.MustFixedCol[types.Decimal128](vec), types.CompareDecimal128)
 		case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary, types.T_json, types.T_blob, types.T_text,
 			types.T_array_float32, types.T_array_float64:
-			sortedSearchFunc = vector.VarlenBinarySearchOffsetByValFactory(vector.InefficientMustBytesCol(vec))
-			unSortedSearchFunc = vector.VarlenLinearSearchOffsetByValFactory(vector.InefficientMustBytesCol(vec))
+			sortedSearchFunc = vector.VarlenBinarySearchOffsetByValFactory(vector.MustBytesCol(vec))
+			unSortedSearchFunc = vector.VarlenLinearSearchOffsetByValFactory(vector.MustBytesCol(vec))
 		case types.T_enum:
 			sortedSearchFunc = vector.OrderedBinarySearchOffsetByValFactory(vector.MustFixedCol[types.Enum](vec))
 			unSortedSearchFunc = vector.OrderedLinearSearchOffsetByValFactory(vector.MustFixedCol[types.Enum](vec), nil)

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -476,14 +476,6 @@ func ConstructPKFilters(tableDef *plan.TableDef, dbName string,
 	filters.inMemPKFilter = constructInMemPKFilter(tableDef, ts, state, packerPool, basePKFilter)
 	filters.blockReadPKFilter = constructBlockReadPKFilter(tableDef.Pkey.PkeyColName, basePKFilter)
 
-	//if dbName == "a" {
-	//	ee := "nil"
-	//	if expr != nil {
-	//		ee = plan2.FormatExpr(expr)
-	//	}
-	//	fmt.Println(tableDef.Name, basePKFilter.String(), filters.inMemPKFilter.String(), filters.blockReadPKFilter, ee)
-	//}
-
 	return
 }
 
@@ -762,7 +754,6 @@ func constructInMemPKFilter(
 			ubVal = types.DecodeEnum(basePKFilter.ub)
 		}
 	default:
-		// >, >=, <, <=
 		return
 		//panic(basePKFilter.oid.String())
 	}
@@ -785,7 +776,7 @@ func constructInMemPKFilter(
 		vec := vector.NewVec(types.T_any.ToType())
 		vec.UnmarshalBinary(basePKFilter.lb)
 		packed = logtailreplay.EncodePrimaryKeyVector(vec, packer)
-		if tableDef.Pkey.CompPkeyCol != nil && basePKFilter.op == function.PREFIX_IN {
+		if basePKFilter.op == function.PREFIX_IN {
 			for x := range packed {
 				packed[x] = packed[x][0 : len(packed[x])-1]
 			}
@@ -799,7 +790,7 @@ func constructInMemPKFilter(
 	case function.PREFIX_BETWEEN, function.BETWEEN, rangeLeftOpen, rangeRightOpen, rangeBothOpen:
 		packed = append(packed, logtailreplay.EncodePrimaryKey(lbVal, packer))
 		packed = append(packed, logtailreplay.EncodePrimaryKey(ubVal, packer))
-		if tableDef.Pkey.CompPkeyCol != nil && basePKFilter.op == function.PREFIX_BETWEEN {
+		if basePKFilter.op == function.PREFIX_BETWEEN {
 			packed[0] = packed[0][0 : len(packed[0])-1]
 			packed[1] = packed[1][0 : len(packed[1])-1]
 		}

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -1031,7 +1031,7 @@ func Test_ConstructBlockReaderPKFilter(t *testing.T) {
 		return bb
 	}
 
-	filters := []blockReaderPKFilter{
+	filters := []BasePKFilter{
 		// "a=10",
 		{op: function.EQUAL, valid: true, lb: encodeVal(10)},
 		{valid: false},
@@ -1635,7 +1635,7 @@ func Test_ConstructBlockReaderPKFilter(t *testing.T) {
 
 	pkName := "a"
 	for i, expr := range exprs {
-		ret := constructPKFilter(expr, tableDef, pkName, proc)
+		ret := constructBasePKFilter(expr, tableDef, pkName, proc)
 		require.Equal(t, filters[i].valid, ret.valid, exprStrings[i])
 		if filters[i].valid {
 			require.Equal(t, filters[i].op, ret.op, exprStrings[i])

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -953,7 +953,7 @@ func Test_removeIf(t *testing.T) {
 	assert.Equal(t, []string(nil), removeIf[string](nil, nil))
 }
 
-func Test_ConstructBlockReaderPKFilter(t *testing.T) {
+func Test_ConstructBasePKFilter(t *testing.T) {
 	m := mpool.MustNewNoFixed(t.Name())
 	proc := testutil.NewProcessWithMPool(m)
 	exprStrings := []string{
@@ -1013,6 +1013,11 @@ func Test_ConstructBlockReaderPKFilter(t *testing.T) {
 		"a>10 or a=15",
 		"a>=10 or a=10",
 		"a<=10 or a=10",
+
+		"a<99",
+		"a<=99",
+		"a>99",
+		"a>=99",
 	}
 
 	encodeVal := func(val int64) []byte {
@@ -1037,8 +1042,8 @@ func Test_ConstructBlockReaderPKFilter(t *testing.T) {
 		{valid: false},
 		{valid: false},
 		{op: function.IN, valid: true, lb: encodeVec([]int64{1, 2})},
-		{op: function.EQUAL, valid: true, lb: encodeVal(50)},
-		{op: function.EQUAL, valid: true, lb: encodeVal(60)},
+		{valid: false},
+		{valid: false},
 		{valid: false},
 		{valid: false},
 		{valid: false},
@@ -1090,6 +1095,11 @@ func Test_ConstructBlockReaderPKFilter(t *testing.T) {
 		{valid: true, op: function.GREAT_THAN, lb: encodeVal(10)},
 		{valid: true, op: function.GREAT_EQUAL, lb: encodeVal(10)},
 		{valid: true, op: function.LESS_EQUAL, lb: encodeVal(10)},
+
+		{valid: true, op: function.LESS_THAN, lb: encodeVal(99)},
+		{valid: true, op: function.LESS_EQUAL, lb: encodeVal(99)},
+		{valid: true, op: function.GREAT_THAN, lb: encodeVal(99)},
+		{valid: true, op: function.GREAT_EQUAL, lb: encodeVal(99)},
 	}
 
 	exprs := []*plan.Expr{
@@ -1633,14 +1643,14 @@ func Test_ConstructBlockReaderPKFilter(t *testing.T) {
 		},
 	})
 
-	pkName := "a"
+	tableDef.Pkey.PkeyColName = "a"
 	for i, expr := range exprs {
-		ret := constructBasePKFilter(expr, tableDef, pkName, proc)
-		require.Equal(t, filters[i].valid, ret.valid, exprStrings[i])
+		basePKFilter := constructBasePKFilter(expr, tableDef, proc)
+		require.Equal(t, filters[i].valid, basePKFilter.valid, exprStrings[i])
 		if filters[i].valid {
-			require.Equal(t, filters[i].op, ret.op, exprStrings[i])
-			require.Equal(t, filters[i].lb, ret.lb, exprStrings[i])
-			require.Equal(t, filters[i].ub, ret.ub, exprStrings[i])
+			require.Equal(t, filters[i].op, basePKFilter.op, exprStrings[i])
+			require.Equal(t, filters[i].lb, basePKFilter.lb, exprStrings[i])
+			require.Equal(t, filters[i].ub, basePKFilter.ub, exprStrings[i])
 		}
 	}
 

--- a/pkg/vm/engine/entire_engine.go
+++ b/pkg/vm/engine/entire_engine.go
@@ -72,8 +72,8 @@ func (e *EntireEngine) Hints() Hints {
 }
 
 func (e *EntireEngine) NewBlockReader(ctx context.Context, num int, ts timestamp.Timestamp,
-	expr *plan.Expr, ranges []byte, tblDef *plan.TableDef, proc any) ([]Reader, error) {
-	return e.Engine.NewBlockReader(ctx, num, ts, expr, ranges, tblDef, proc)
+	expr *plan.Expr, filter any, ranges []byte, tblDef *plan.TableDef, proc any) ([]Reader, error) {
+	return e.Engine.NewBlockReader(ctx, num, ts, expr, filter, ranges, tblDef, proc)
 }
 
 func (e *EntireEngine) GetNameById(ctx context.Context, op client.TxnOperator, tableId uint64) (dbName string, tblName string, err error) {

--- a/pkg/vm/engine/entire_engine_test.go
+++ b/pkg/vm/engine/entire_engine_test.go
@@ -140,10 +140,10 @@ func TestEntireEngineHints(t *testing.T) {
 func TestEntireEngineNewBlockReader(t *testing.T) {
 	ctx := context.TODO()
 	ee := buildEntireEngineWithoutTempEngine()
-	ee.NewBlockReader(ctx, 1, timestamp.Timestamp{}, nil, nil, nil, nil)
+	ee.NewBlockReader(ctx, 1, timestamp.Timestamp{}, nil, nil, nil, nil, nil)
 	assert.Equal(t, only_engine, ee.state)
 	ee = buildEntireEngineWithTempEngine()
-	ee.NewBlockReader(ctx, 1, timestamp.Timestamp{}, nil, nil, nil, nil)
+	ee.NewBlockReader(ctx, 1, timestamp.Timestamp{}, nil, nil, nil, nil, nil)
 	assert.Equal(t, only_engine, ee.state)
 }
 
@@ -272,7 +272,7 @@ func (e *testEngine) Hints() (h Hints) {
 }
 
 func (e *testEngine) NewBlockReader(_ context.Context, _ int, _ timestamp.Timestamp,
-	_ *plan.Expr, _ []byte, _ *plan.TableDef, proc any) ([]Reader, error) {
+	_ *plan.Expr, _ any, _ []byte, _ *plan.TableDef, proc any) ([]Reader, error) {
 	e.parent.step = e.parent.step + 1
 	if e.name == origin {
 		e.parent.state = e.parent.state + e.parent.step*e.parent.state

--- a/pkg/vm/engine/memoryengine/binded.go
+++ b/pkg/vm/engine/memoryengine/binded.go
@@ -63,7 +63,7 @@ func (b *BindedEngine) Hints() engine.Hints {
 }
 
 func (b *BindedEngine) NewBlockReader(_ context.Context, _ int, _ timestamp.Timestamp,
-	_ *plan.Expr, _ []byte, _ *plan.TableDef, _ any) ([]engine.Reader, error) {
+	_ *plan.Expr, filter any, _ []byte, _ *plan.TableDef, _ any) ([]engine.Reader, error) {
 	return nil, nil
 }
 

--- a/pkg/vm/engine/memoryengine/engine.go
+++ b/pkg/vm/engine/memoryengine/engine.go
@@ -68,7 +68,7 @@ func (e *Engine) Rollback(_ context.Context, _ client.TxnOperator) error {
 }
 
 func (e *Engine) NewBlockReader(_ context.Context, _ int, _ timestamp.Timestamp,
-	_ *plan.Expr, _ []byte, _ *plan.TableDef, _ any) ([]engine.Reader, error) {
+	_ *plan.Expr, _ any, _ []byte, _ *plan.TableDef, _ any) ([]engine.Reader, error) {
 	return nil, nil
 }
 

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -35,7 +35,7 @@ import (
 
 type ReadFilterSearchFuncType func([]*vector.Vector) []int32
 
-type ReadFilter struct {
+type BlockReadFilter struct {
 	HasFakePK          bool
 	Valid              bool
 	SortedSearchFunc   ReadFilterSearchFuncType
@@ -122,7 +122,7 @@ func BlockRead(
 	ts timestamp.Timestamp,
 	filterSeqnums []uint16,
 	filterColTypes []types.Type,
-	filter ReadFilter,
+	filter BlockReadFilter,
 	fs fileservice.FileService,
 	mp *mpool.MPool,
 	vp engine.VectorPool,

--- a/pkg/vm/engine/tae/logtail/snapshot.go
+++ b/pkg/vm/engine/tae/logtail/snapshot.go
@@ -308,7 +308,7 @@ func (sm *SnapshotMeta) GetSnapshot(ctx context.Context, fs fileservice.FileServ
 				}
 				checkpointTS := types.BuildTS(time.Now().UTC().UnixNano(), 0)
 				bat, err := blockio.BlockRead(ctx, &blk, nil, idxes, colTypes, checkpointTS.ToTimestamp(),
-					nil, nil, blockio.ReadFilter{}, fs, mp, nil, fileservice.Policy(0))
+					nil, nil, blockio.BlockReadFilter{}, fs, mp, nil, fileservice.Policy(0))
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -715,7 +715,7 @@ type Engine interface {
 	// since implementations may update hints after engine had initialized
 	Hints() Hints
 
-	NewBlockReader(ctx context.Context, num int, ts timestamp.Timestamp, expr *plan.Expr, ranges []byte, tblDef *plan.TableDef, proc any) ([]Reader, error)
+	NewBlockReader(ctx context.Context, num int, ts timestamp.Timestamp, expr *plan.Expr, blockReadPKFilter any, ranges []byte, tblDef *plan.TableDef, proc any) ([]Reader, error)
 
 	// Get database name & table name by table id
 	GetNameById(ctx context.Context, op client.TxnOperator, tableId uint64) (dbName string, tblName string, err error)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16654

## What this PR does / why we need it:
1. Compiling the expression once to generate the in-memory and block reader filters.
2. Supporting: in, prefix_in, eq, prefix_eq, between, prefix_between, >, >=, <, <=.