### PR TITLE
Test incre fatal

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"regexp"
 	"runtime"
 	gotrace "runtime/trace"
 	"sort"
@@ -476,6 +477,15 @@ func (c *Compile) Run(_ uint64) (result *util2.RunResult, err error) {
 		c.proc.SetPrepareBatch(nil)
 		c.proc.SetPrepareExprList(nil)
 	}()
+
+	if c.proc.SessionInfo.User != "mo_logger" {
+		if regexp.MustCompile(`.*mo_increment_columns.*`).MatchString(sql) {
+			fmt.Printf("xxxx txnid:%x, snapshot ts:%s, run sql: %s\n",
+				txnOp.Txn().ID,
+				txnOp.Txn().SnapshotTS.DebugString(),
+				sql)
+		}
+	}
 
 	var writeOffset uint64
 

--- a/pkg/vm/engine/disttae/partition_reader.go
+++ b/pkg/vm/engine/disttae/partition_reader.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 
 	"go.uber.org/zap"
 
@@ -131,6 +132,26 @@ func (p *PartitionReader) Read(
 	_ *plan.Expr,
 	mp *mpool.MPool,
 	pool engine.VectorPool) (result *batch.Batch, err error) {
+
+	defer func() {
+		if p.table.tableName == "mo_increment_columns" {
+			bat := ""
+			len := 0
+			if result != nil {
+				bat = common.MoBatchToString(result, 10)
+				len = result.RowCount()
+			}
+			logutil.Infof("xxxx partititonReader reads:"+
+				"txn:%s, table:%s, batch:%s, len:%d, err:%v",
+				p.table.db.op.Txn().DebugString(),
+				p.table.tableName,
+				bat,
+				len,
+				err)
+		}
+
+	}()
+
 	if p == nil {
 		return
 	}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/docker/go-units"
+
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -641,6 +642,27 @@ func (tbl *txnTable) Ranges(ctx context.Context, exprs []*plan.Expr, txnOffset i
 	); err != nil {
 		return
 	}
+
+	if tbl.tableName == "mo_increment_columns" {
+		blkstr := ""
+		for i := 1; i < blocks.Len(); i++ {
+			blk := blocks.Get(i)
+			blkstr = fmt.Sprintf("%s, [%s,%v,%v]",
+				blkstr,
+				blk.BlockID.String(),
+				blk.EntryState,
+				blk.CanRemote)
+		}
+		if blkstr == "" {
+			blkstr = "no blocks"
+		}
+		logutil.Infof("xxxx table:%s txn:%s call ranges return blks:%s, state:%p",
+			tbl.tableName,
+			tbl.db.op.Txn().DebugString(),
+			blkstr,
+			tbl._partState.Load())
+	}
+
 	return
 }
 

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -302,6 +302,9 @@ func (h *Handle) HandleCommit(
 			//delete the txn's context.
 			h.txnCtxs.Delete(util.UnsafeBytesToString(meta.GetID()))
 		}
+
+		logutil.Infof("xxxx txn :%s committed", meta.DebugString())
+
 		common.DoIfInfoEnabled(func() {
 			if time.Since(start) > MAX_ALLOWED_TXN_LATENCY {
 				logutil.Info("Commit with long latency", zap.Duration("duration", time.Since(start)), zap.String("debug", meta.DebugString()))


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:


___

### **PR Type**
enhancement, tests


___

### **Description**
- Added detailed logging for SQL execution, reads, and transaction handling specifically for the `mo_increment_columns` table.
- Introduced a flag in `txnContext` to facilitate conditional logging.
- Enhanced various functions to log batch details using `common.MoBatchToString`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compile.go</strong><dd><code>Add logging for SQL execution and specific table checks.</code>&nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/compile.go

<li>Added logging for SQL execution when the user is not <code>mo_logger</code>.<br> <li> Introduced a regular expression check for <code>mo_increment_columns</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16916/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>partition_reader.go</strong><dd><code>Add logging for PartitionReader reads for specific table.</code></dd></summary>
<hr>
      
pkg/vm/engine/disttae/partition_reader.go

<li>Added logging for <code>PartitionReader</code> reads for <code>mo_increment_columns</code> <br>table.<br> <li> Utilized <code>common.MoBatchToString</code> for batch logging.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16916/files#diff-fa5dfc6974a232ae26525cdccc74e7ef36df841971b202191aa3bfb00fad46f7">+21/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reader.go</strong><dd><code>Add logging for blockMergeReader reads for specific table.</code></dd></summary>
<hr>
      
pkg/vm/engine/disttae/reader.go

<li>Added logging for <code>blockMergeReader</code> reads for <code>mo_increment_columns</code> <br>table.<br> <li> Utilized <code>common.MoBatchToString</code> for batch logging.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16916/files#diff-5f335fb89fac8ac177b315588d5714e5dddd3a470baf6bc199aa1689fc351b25">+22/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Add logging for Ranges function in txnTable for specific table.</code></dd></summary>
<hr>
      
pkg/vm/engine/disttae/txn_table.go

<li>Added logging for <code>Ranges</code> function in <code>txnTable</code> for <code>mo_increment_columns</code> <br>table.<br> <li> Logged block information and transaction state.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16916/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+22/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handle.go</strong><dd><code>Add logging and flag for transaction context in HandleWrite.</code></dd></summary>
<hr>
      
pkg/vm/engine/tae/rpc/handle.go

<li>Added a flag to <code>txnContext</code> for logging purposes.<br> <li> Enhanced <code>HandleWrite</code> to log information for <code>mo_increment_columns</code> <br>table.<br> <li> Added logging for transaction commits when the flag is set.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16916/files#diff-98c036f2b292191124a927608e91efd81ad24feebc0b8dd44a2aa1c9cffe6f91">+18/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

