### PR TITLE
fix slow flush 1.2

### DIFF
--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -257,10 +257,10 @@ func (task *flushTableTailTask) MarshalLogObject(enc zapcore.ObjectEncoder) (err
 }
 
 var (
-	SlowFlushIOTask      = 3 * time.Second
+	SlowFlushIOTask      = 10 * time.Second
 	SlowFlushTaskOverall = 60 * time.Second
 	SlowDelCollect       = 10 * time.Second
-	SlowDelCollectNObj   = 50
+	SlowDelCollectNObj   = 10
 )
 
 func (task *flushTableTailTask) Execute(ctx context.Context) (err error) {
@@ -716,23 +716,25 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 	}()
 	emtpyDelObjIdx = make([]*bitmap.Bitmap, len(task.delSrcMetas))
 	var (
-		enableDeltaStat    = task.schema.Name == "bmsql_stock"
 		enableDetailRecord = len(task.delSrcMetas) > SlowDelCollectNObj
 		tbl                *catalog.TableEntry
 		tombstone          data.Tombstone
 		locMap             = make(map[string]int)
 		now                = time.Now()
-		recorder           = &common.DeletesCollectRecorder{}
+		recorder           = &common.DeletesCollectRecorder{TempCache: make(map[string]common.TempDelCacheEntry)}
 		totalRecorder      = &common.DeletesCollectBoard{}
 		loopCnt, readCnt   int
 	)
 
-	if enableDeltaStat {
-		tbl = task.rel.GetMeta().(*catalog.TableEntry)
-	}
-
 	if enableDetailRecord {
 		ctx = context.WithValue(ctx, common.RecorderKey{}, recorder)
+		tbl = task.rel.GetMeta().(*catalog.TableEntry)
+		defer func() {
+			for _, v := range recorder.TempCache {
+				v.Bat = nil
+				v.Release()
+			}
+		}()
 	}
 
 	for i, obj := range task.delSrcMetas {
@@ -740,7 +742,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 		var deletes *containers.Batch
 		emptyDelObjs := &bitmap.Bitmap{}
 		emptyDelObjs.InitWithSize(int64(obj.BlockCnt()))
-		if enableDeltaStat {
+		if enableDetailRecord {
 			tombstone = tbl.TryGetTombstone(obj.ID)
 		}
 		for j := 0; j < obj.BlockCnt(); j++ {
@@ -750,10 +752,13 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 				emptyDelObjs.Add(uint64(j))
 				continue
 			}
-			if enableDeltaStat && tombstone != nil {
-				loc := tombstone.GetLatestDeltaloc(uint16(j))
-				if loc != nil {
-					locMap[loc.String()]++
+			if enableDetailRecord && tombstone != nil {
+				if loc := tombstone.GetLatestDeltaloc(uint16(j)); loc != nil {
+					sloc := loc.String()
+					locMap[sloc]++
+					if locMap[sloc] == 10 { // trigger cache only once
+						recorder.TempCache[sloc] = common.TempDelCacheEntry{}
+					}
 				}
 			}
 			recorder.LoadCost = 0
@@ -786,10 +791,8 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 			fmt.Sprintf("slowflush: task %d collect tombstone for %d-%s cost %v, loopN %d, readN %d",
 				task.ID(), task.rel.ID(), task.schema.Name, cost, loopCnt, readCnt))
 		if enableDetailRecord {
-			buf.WriteString(fmt.Sprintf(" | %s", totalRecorder.String()))
-		}
-		if enableDeltaStat {
-			buf.WriteString(fmt.Sprintf(" | location distribution(%v):%v", len(locMap), locMap))
+			buf.WriteString(fmt.Sprintf(" | %s | location distribution(%v):%v",
+				totalRecorder.String(), len(locMap), locMap))
 		}
 		logutil.Infof(buf.String())
 	}

--- a/pkg/vm/engine/tae/tables/utils.go
+++ b/pkg/vm/engine/tae/tables/utils.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
@@ -138,21 +139,42 @@ func LoadPersistedDeletesBySchema(
 	isPersistedByCN bool,
 	mp *mpool.MPool,
 ) (bat *containers.Batch, release func(), err error) {
-	var recorder *common.DeletesCollectRecorder
-	var inst time.Time
+	var (
+		recorder *common.DeletesCollectRecorder
+		movbat   *batch.Batch
+	)
+
 	if v := ctx.Value(common.RecorderKey{}); v != nil {
 		recorder = v.(*common.DeletesCollectRecorder)
-		inst = time.Now()
+		inst := time.Now()
+		defer func() {
+			recorder.LoadCost = time.Since(inst)
+		}()
+		sloc := location.String()
+		entry, ok := recorder.TempCache[sloc]
+		if ok && entry.Bat != nil { // hit cache
+			movbat = entry.Bat
+		}
+
+		if ok && entry.Bat == nil { // cache enable and first call
+			movbat, release, err = blockio.ReadBlockDeleteBySchema(ctx, location, fs.Service, isPersistedByCN)
+			if err != nil {
+				return nil, nil, err
+			}
+			recorder.TempCache[sloc] = common.TempDelCacheEntry{
+				Bat:     movbat,
+				Release: release,
+			}
+		}
+		release = func() {}
+	}
+	if movbat == nil { // cache disabled
+		movbat, release, err = blockio.ReadBlockDeleteBySchema(ctx, location, fs.Service, isPersistedByCN)
+		if err != nil {
+			return
+		}
 	}
 
-	movbat, release, err := blockio.ReadBlockDeleteBySchema(ctx, location, fs.Service, isPersistedByCN)
-	if err != nil {
-		return
-	}
-	if recorder != nil {
-		recorder.LoadCost = time.Since(inst)
-		inst = time.Now()
-	}
 	bat = containers.NewBatch()
 	if isPersistedByCN {
 		colNames := []string{catalog.PhyAddrColumnName, catalog.AttrPKVal}

--- a/pkg/vm/engine/tae/tables/utils.go
+++ b/pkg/vm/engine/tae/tables/utils.go
@@ -187,9 +187,6 @@ func LoadPersistedDeletesBySchema(
 			bat.AddVector(colNames[i], containers.ToTNVector(movbat.Vecs[i], mp))
 		}
 	}
-	if recorder != nil {
-		recorder.LoadAfter = time.Since(inst)
-	}
 	return
 }
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16716

## What this PR does / why we need it:

Cache the decompressed batch when reading a deltaloc file over 10 times in a flush table task.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a caching mechanism for delete collection to improve performance.
- Adjusted timing constants for slow flush tasks to better diagnose issues.
- Enhanced logging details for better traceability of slow flush tasks.
- Removed unused `LoadAfter` fields and related logic.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stats.go</strong><dd><code>Add caching mechanism and remove unused fields.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/common/stats.go

<li>Added <code>TempDelCacheEntry</code> struct for caching.<br> <li> Introduced <code>TempCache</code> map in <code>DeletesCollectRecorder</code>.<br> <li> Removed <code>LoadAfter</code> related fields and logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16937/files#diff-42814881be4affbdb3a8105f1abc0db8b23aa0ef4b0323862f838730a414fe9e">+11/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>flushTableTail.go</strong><dd><code>Improve slow flush task handling and logging.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/jobs/flushTableTail.go

<li>Adjusted slow flush task timing constants.<br> <li> Added caching logic for delete collection.<br> <li> Enhanced logging details for slow flush tasks.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16937/files#diff-0b958d0044e734c5cb32254c0e45c0beaf0e4fdc1f4c846c0bde0fd917da63b0">+20/-17</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Implement caching in LoadPersistedDeletesBySchema.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/tables/utils.go

<li>Implemented caching logic in <code>LoadPersistedDeletesBySchema</code>.<br> <li> Added conditional cache checks and updates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16937/files#diff-51306a90ccac77b64bcb3159a92f6e86bb3ab86094073ceaca2e844a5c3abfde">+32/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

