### PR TITLE
fix: load data infile with columnlist error

### DIFF
--- a/test/distributed/cases/load_data/load_data.result
+++ b/test/distributed/cases/load_data/load_data.result
@@ -731,3 +731,15 @@ select * from load_data_t1;
 name    age    city
 XiAn     26     zhangsan
 drop table load_data_t1;
+drop table if exists load_data_t2;
+create table load_data_t2(id int, name varchar(20), age int);
+LOAD DATA infile '$resources/load_data/test_columnlist_01.csv' into table load_data_t2 FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n' (id,   name , age);
+select * from load_data_t2 order by id;
+id    name    age
+1     aron    32
+2     ben    35
+3     cindy    22
+4     david    33
+5     emma    18
+6     frank    59
+drop table load_data_t2;

--- a/test/distributed/cases/load_data/load_data.sql
+++ b/test/distributed/cases/load_data/load_data.sql
@@ -338,3 +338,9 @@ CREATE TABLE load_data_t1 (
 load data inline format='csv', data=$XXX$ zhangsan,26,XiAn $XXX$ into table load_data_t1 fields terminated by ',' lines terminated by '\r\n' (city,age,name);
 select * from load_data_t1;
 drop table load_data_t1;
+
+drop table if exists load_data_t2;
+create table load_data_t2(id int, name varchar(20), age int);
+LOAD DATA infile '$resources/load_data/test_columnlist_01.csv' into table load_data_t2 FIELDS TERMINATED BY ',' LINES TERMINATED BY '\n' (id,   name , age);
+select * from load_data_t2 order by id;
+drop table load_data_t2;

--- a/test/distributed/resources/load_data/test_columnlist_01.csv
+++ b/test/distributed/resources/load_data/test_columnlist_01.csv
@@ -1,0 +1,6 @@
+1, aron, 32
+2, ben, 35
+3, cindy, 22
+4, david, 33
+5, emma, 18
+6, frank, 59


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3522

## What this PR does / why we need it:
fix load data infill with columnist error


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug in the `buildLoad` function where `ColumnList` was not handled correctly.
- Updated the `getProjectNode` function to accept `columnList` as a parameter and modified its logic accordingly.
- Added new test cases in `load_data.result` to verify the correct loading of data with a column list.
- Included corresponding SQL commands in `load_data.sql` to test the new functionality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_load.go</strong><dd><code>Fix <code>ColumnList</code> handling in <code>buildLoad</code> and <code>getProjectNode</code> functions.</code></dd></summary>
<hr>
      
pkg/sql/plan/build_load.go

<li>Fixed handling of <code>ColumnList</code> in <code>buildLoad</code> function.<br> <li> Updated <code>getProjectNode</code> function to accept <code>columnList</code> as a parameter.<br> <li> Ensured <code>ColumnList</code> is set to <code>nil</code> after being passed to <code>getProjectNode</code>.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16950/files#diff-f4d97d7b39aceecc7483340bc220e0f473127b8251fcf147361c90fd6c0f1b8c">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>load_data.result</strong><dd><code>Add test cases for loading data with column list.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
test/distributed/cases/load_data/load_data.result

<li>Added test cases for loading data with a column list.<br> <li> Verified data loading and ordering in <code>load_data_t2</code> table.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16950/files#diff-b72da059e6d9bf7b50b14ab7a73e6ef60c1f408eece4fc911680459b524463f6">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>load_data.sql</strong><dd><code>Add SQL commands for testing data load with column list.</code>&nbsp; </dd></summary>
<hr>
      
test/distributed/cases/load_data/load_data.sql

<li>Added SQL commands to test loading data with a column list.<br> <li> Included creation and dropping of <code>load_data_t2</code> table.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16950/files#diff-159ff6babbf8ace74799ad58c4c9b005f2c0dc2c5276512e1bfd186d19c43424">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

