### PR TITLE
fix check invalid binds

### DIFF
--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -455,7 +455,7 @@ func (l *lockTableAllocator) checkInvalidBinds(ctx context.Context) {
 					b.getServiceID(),
 					l.client,
 				)
-				if isRetryError(err) {
+				if err != nil && isRetryError(err) {
 					continue
 				}
 				if !valid {

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -265,14 +265,37 @@ func TestRetryValidateService(t *testing.T) {
 					writeResponse(ctx, cancel, resp, nil, cs)
 				})
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
-			defer cancel()
-			_, err := c.Send(ctx, &lock.Request{
-				ValidateService: lock.ValidateServiceRequest{ServiceID: "s1"},
-				Method:          lock.Method_ValidateService})
-			require.True(t, isRetryError(err))
+			_, err := validateService(time.Millisecond*100, "s1", c)
+			require.True(t, err != nil && isRetryError(err))
 		},
 		WithServerMessageFilter(func(r *lock.Request) bool { return false }),
+	)
+}
+
+func TestValidateService(t *testing.T) {
+	runRPCTests(
+		t,
+		func(c Client, s Server) {
+			s.RegisterMethodHandler(
+				lock.Method_ValidateService,
+				func(
+					ctx context.Context,
+					cancel context.CancelFunc,
+					req *lock.Request,
+					resp *lock.Response,
+					cs morpc.ClientSession) {
+					resp.ValidateService.OK = true
+					writeResponse(ctx, cancel, resp, nil, cs)
+				})
+
+			valid, err := validateService(time.Millisecond*100, "UNKNOWN", c)
+			require.False(t, err != nil && isRetryError(err))
+			require.True(t, !valid)
+
+			valid, err = validateService(time.Millisecond*100, "s1", c)
+			require.False(t, err != nil && isRetryError(err))
+			require.False(t, !valid)
+		},
 	)
 }
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3490 #https://github.com/matrixorigin/MO-Cloud/issues/3530
#https://github.com/matrixorigin/MO-Cloud/issues/3521 #https://github.com/matrixorigin/MO-Cloud/issues/3512

## What this PR does / why we need it:

fix check invalid binds


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a nil check before calling `isRetryError` in the `checkInvalidBinds` method to prevent potential errors.
- Updated `TestRetryValidateService` to include a nil check before calling `isRetryError`.
- Added a new test `TestValidateService` to validate service responses and ensure correct behavior.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lock_table_allocator.go</strong><dd><code>Add nil check before retry error validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/lockservice/lock_table_allocator.go

<li>Added a nil check before calling <code>isRetryError</code> in <code>checkInvalidBinds</code> <br>method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16958/files#diff-6be1ca324d0b56411e41ec19a99ea21442f80563429ee4964aedef60424413a1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rpc_test.go</strong><dd><code>Update and add tests for service validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/lockservice/rpc_test.go

<li>Updated <code>TestRetryValidateService</code> to include a nil check before calling <br><code>isRetryError</code>.<br> <li> Added a new test <code>TestValidateService</code> to validate service responses.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/16958/files#diff-42ee96474cacf3ad69ffd4ee7f476f9deae83856b7c50dc05d784fee568ef124">+29/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

