### PR TITLE
remove tmp buf from table_scan

### DIFF
--- a/pkg/sql/colexec/table_scan/types.go
+++ b/pkg/sql/colexec/table_scan/types.go
@@ -33,8 +33,7 @@ type Argument struct {
 	Attrs          []string
 	TableID        uint64
 
-	buf    *batch.Batch
-	tmpBuf *batch.Batch
+	buf *batch.Batch
 
 	maxAllocSize int
 
@@ -80,11 +79,6 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 	if arg.buf != nil {
 		arg.buf.Clean(proc.Mp())
 		arg.buf = nil
-	}
-
-	if arg.tmpBuf != nil {
-		arg.tmpBuf.Clean(proc.Mp())
-		arg.tmpBuf = nil
 	}
 
 	if arg.msgReceiver != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #14940 

## What this PR does / why we need it:
这个原来是因为有时reader返回的数据量较小，使得可以上范围锁的变成上点锁。容易造成点锁数量较大时加的。

现在一个是没有范围锁了，另外当点锁太大会转表锁，这部分逻辑应该没有必要存在了，徒增复杂度。