### PR TITLE
don't duplicate hashmap in broadcast joins

### DIFF
--- a/pkg/sql/colexec/anti/join.go
+++ b/pkg/sql/colexec/anti/join.go
@@ -119,7 +119,7 @@ func (ctr *container) receiveHashMap(anal process.Analyze) error {
 	}
 	bat := msg.Batch
 	if bat != nil && bat.AuxData != nil {
-		ctr.mp = bat.DupJmAuxData()
+		ctr.mp = bat.AuxData.(*hashmap.JoinMap)
 		ctr.hasNull = ctr.mp.HasNull()
 		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}

--- a/pkg/sql/colexec/join/join.go
+++ b/pkg/sql/colexec/join/join.go
@@ -129,7 +129,7 @@ func (ctr *container) receiveHashMap(anal process.Analyze) error {
 	}
 	bat := msg.Batch
 	if bat != nil && bat.AuxData != nil {
-		ctr.mp = bat.DupJmAuxData()
+		ctr.mp = bat.AuxData.(*hashmap.JoinMap)
 		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil

--- a/pkg/sql/colexec/left/join.go
+++ b/pkg/sql/colexec/left/join.go
@@ -121,7 +121,7 @@ func (ctr *container) receiveHashMap(anal process.Analyze) error {
 	}
 	bat := msg.Batch
 	if bat != nil && bat.AuxData != nil {
-		ctr.mp = bat.DupJmAuxData()
+		ctr.mp = bat.AuxData.(*hashmap.JoinMap)
 		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil

--- a/pkg/sql/colexec/mark/join.go
+++ b/pkg/sql/colexec/mark/join.go
@@ -144,7 +144,7 @@ func (ctr *container) receiveHashMap(anal process.Analyze) error {
 	}
 	bat := msg.Batch
 	if bat != nil && bat.AuxData != nil {
-		ctr.mp = bat.DupJmAuxData()
+		ctr.mp = bat.AuxData.(*hashmap.JoinMap)
 		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil

--- a/pkg/sql/colexec/right/join.go
+++ b/pkg/sql/colexec/right/join.go
@@ -143,7 +143,7 @@ func (ctr *container) receiveHashMap(anal process.Analyze) error {
 	}
 	bat := msg.Batch
 	if bat != nil && bat.AuxData != nil {
-		ctr.mp = bat.DupJmAuxData()
+		ctr.mp = bat.AuxData.(*hashmap.JoinMap)
 		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil

--- a/pkg/sql/colexec/rightanti/join.go
+++ b/pkg/sql/colexec/rightanti/join.go
@@ -141,7 +141,7 @@ func (ctr *container) receiveHashMap(anal process.Analyze) error {
 	}
 	bat := msg.Batch
 	if bat != nil && bat.AuxData != nil {
-		ctr.mp = bat.DupJmAuxData()
+		ctr.mp = bat.AuxData.(*hashmap.JoinMap)
 		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil

--- a/pkg/sql/colexec/rightsemi/join.go
+++ b/pkg/sql/colexec/rightsemi/join.go
@@ -144,7 +144,7 @@ func (ctr *container) receiveHashMap(anal process.Analyze) error {
 	}
 	bat := msg.Batch
 	if bat != nil && bat.AuxData != nil {
-		ctr.mp = bat.DupJmAuxData()
+		ctr.mp = bat.AuxData.(*hashmap.JoinMap)
 		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil

--- a/pkg/sql/colexec/semi/join.go
+++ b/pkg/sql/colexec/semi/join.go
@@ -137,7 +137,7 @@ func (ctr *container) receiveHashMap(anal process.Analyze) error {
 	}
 	bat := msg.Batch
 	if bat != nil && bat.AuxData != nil {
-		ctr.mp = bat.DupJmAuxData()
+		ctr.mp = bat.AuxData.(*hashmap.JoinMap)
 		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil

--- a/pkg/sql/colexec/single/join.go
+++ b/pkg/sql/colexec/single/join.go
@@ -121,7 +121,7 @@ func (ctr *container) receiveHashMap(anal process.Analyze) error {
 	}
 	bat := msg.Batch
 	if bat != nil && bat.AuxData != nil {
-		ctr.mp = bat.DupJmAuxData()
+		ctr.mp = bat.AuxData.(*hashmap.JoinMap)
 		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
 	}
 	return nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #16659 #16936

## What this PR does / why we need it:
to reduce majority of memory cost in sysbench workloads