### PR TITLE
[bug] txn: do not fatal if waiter is paused when wait for the ts.

### DIFF
--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -429,9 +429,19 @@ func (client *txnClient) SyncLatestCommitTS(ts timestamp.Timestamp) {
 	if client.timestampWaiter != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 		defer cancel()
-		_, err := client.timestampWaiter.GetTimestamp(ctx, ts)
-		if err != nil {
-			util.GetLogger().Fatal("wait latest commit ts failed", zap.Error(err))
+		for {
+			_, err := client.timestampWaiter.GetTimestamp(ctx, ts)
+			if err != nil {
+				// If the error is moerr.ErrWaiterPaused, retry to get the timestamp,
+				// but not FATAL immediately.
+				if moerr.IsMoErrCode(err, moerr.ErrWaiterPaused) {
+					time.Sleep(time.Second)
+					continue
+				} else {
+					util.GetLogger().Fatal("wait latest commit ts failed", zap.Error(err))
+				}
+			}
+			break
 		}
 	}
 	client.atomic.forceSyncCommitTimes.Add(1)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16716

## What this PR does / why we need it:
retry to get latest ts, but do not fatal if waiter is paused when wait for the ts.