### PR TITLE
fix incorrect use of connection ctx during remote run.

### DIFF
--- a/pkg/common/morpc/mock_morpc/types_mock.go
+++ b/pkg/common/morpc/mock_morpc/types_mock.go
@@ -49,6 +49,20 @@ func (m *MockClientSession) EXPECT() *MockClientSessionMockRecorder {
 	return m.recorder
 }
 
+// AsyncWrite mocks base method.
+func (m *MockClientSession) AsyncWrite(response morpc.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AsyncWrite", response)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AsyncWrite indicates an expected call of AsyncWrite.
+func (mr *MockClientSessionMockRecorder) AsyncWrite(response interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AsyncWrite", reflect.TypeOf((*MockClientSession)(nil).AsyncWrite), response)
+}
+
 // Close mocks base method.
 func (m *MockClientSession) Close() error {
 	m.ctrl.T.Helper()
@@ -64,45 +78,45 @@ func (mr *MockClientSessionMockRecorder) Close() *gomock.Call {
 }
 
 // CreateCache mocks base method.
-func (m *MockClientSession) CreateCache(arg0 context.Context, arg1 uint64) (morpc.MessageCache, error) {
+func (m *MockClientSession) CreateCache(ctx context.Context, cacheID uint64) (morpc.MessageCache, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateCache", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateCache", ctx, cacheID)
 	ret0, _ := ret[0].(morpc.MessageCache)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateCache indicates an expected call of CreateCache.
-func (mr *MockClientSessionMockRecorder) CreateCache(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientSessionMockRecorder) CreateCache(ctx, cacheID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCache", reflect.TypeOf((*MockClientSession)(nil).CreateCache), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCache", reflect.TypeOf((*MockClientSession)(nil).CreateCache), ctx, cacheID)
 }
 
 // DeleteCache mocks base method.
-func (m *MockClientSession) DeleteCache(arg0 uint64) {
+func (m *MockClientSession) DeleteCache(cacheID uint64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "DeleteCache", arg0)
+	m.ctrl.Call(m, "DeleteCache", cacheID)
 }
 
 // DeleteCache indicates an expected call of DeleteCache.
-func (mr *MockClientSessionMockRecorder) DeleteCache(arg0 interface{}) *gomock.Call {
+func (mr *MockClientSessionMockRecorder) DeleteCache(cacheID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCache", reflect.TypeOf((*MockClientSession)(nil).DeleteCache), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCache", reflect.TypeOf((*MockClientSession)(nil).DeleteCache), cacheID)
 }
 
 // GetCache mocks base method.
-func (m *MockClientSession) GetCache(arg0 uint64) (morpc.MessageCache, error) {
+func (m *MockClientSession) GetCache(cacheID uint64) (morpc.MessageCache, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCache", arg0)
+	ret := m.ctrl.Call(m, "GetCache", cacheID)
 	ret0, _ := ret[0].(morpc.MessageCache)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCache indicates an expected call of GetCache.
-func (mr *MockClientSessionMockRecorder) GetCache(arg0 interface{}) *gomock.Call {
+func (mr *MockClientSessionMockRecorder) GetCache(cacheID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCache", reflect.TypeOf((*MockClientSession)(nil).GetCache), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCache", reflect.TypeOf((*MockClientSession)(nil).GetCache), cacheID)
 }
 
 // RemoteAddress mocks base method.
@@ -119,23 +133,32 @@ func (mr *MockClientSessionMockRecorder) RemoteAddress() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteAddress", reflect.TypeOf((*MockClientSession)(nil).RemoteAddress))
 }
 
-// Write mocks base method.
-func (m *MockClientSession) Write(arg0 context.Context, arg1 morpc.Message) error {
+// SessionCtx mocks base method.
+func (m *MockClientSession) SessionCtx() context.Context {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Write", arg0, arg1)
+	ret := m.ctrl.Call(m, "SessionCtx")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// SessionCtx indicates an expected call of SessionCtx.
+func (mr *MockClientSessionMockRecorder) SessionCtx() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SessionCtx", reflect.TypeOf((*MockClientSession)(nil).SessionCtx))
+}
+
+// Write mocks base method.
+func (m *MockClientSession) Write(ctx context.Context, response morpc.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Write", ctx, response)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AsyncWrite mocks base method.
-func (m *MockClientSession) AsyncWrite(arg1 morpc.Message) error {
-	panic("not supported")
-}
-
 // Write indicates an expected call of Write.
-func (mr *MockClientSessionMockRecorder) Write(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientSessionMockRecorder) Write(ctx, response interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockClientSession)(nil).Write), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockClientSession)(nil).Write), ctx, response)
 }
 
 // MockStream is a mock of Stream interface.
@@ -162,17 +185,17 @@ func (m *MockStream) EXPECT() *MockStreamMockRecorder {
 }
 
 // Close mocks base method.
-func (m *MockStream) Close(arg0 bool) error {
+func (m *MockStream) Close(closeConn bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close", arg0)
+	ret := m.ctrl.Call(m, "Close", closeConn)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockStreamMockRecorder) Close(arg0 interface{}) *gomock.Call {
+func (mr *MockStreamMockRecorder) Close(closeConn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStream)(nil).Close), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStream)(nil).Close), closeConn)
 }
 
 // ID mocks base method.
@@ -205,15 +228,15 @@ func (mr *MockStreamMockRecorder) Receive() *gomock.Call {
 }
 
 // Send mocks base method.
-func (m *MockStream) Send(arg0 context.Context, arg1 morpc.Message) error {
+func (m *MockStream) Send(ctx context.Context, request morpc.Message) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Send", arg0, arg1)
+	ret := m.ctrl.Call(m, "Send", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Send indicates an expected call of Send.
-func (mr *MockStreamMockRecorder) Send(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStreamMockRecorder) Send(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockStream)(nil).Send), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockStream)(nil).Send), ctx, request)
 }

--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -561,6 +561,10 @@ func (cs *clientSession) Close() error {
 	return cs.conn.Close()
 }
 
+func (cs *clientSession) SessionCtx() context.Context {
+	return cs.ctx
+}
+
 func (cs *clientSession) cleanSend() {
 	for {
 		select {

--- a/pkg/common/morpc/types.go
+++ b/pkg/common/morpc/types.go
@@ -105,6 +105,8 @@ type RPCClient interface {
 type ClientSession interface {
 	// Close close the client session
 	Close() error
+	// SessionCtx get the session context, if session is closed the context will be canceled.
+	SessionCtx() context.Context
 	// Write writing the response message to the client.
 	Write(ctx context.Context, response Message) error
 	// AsyncWrite only put message into write queue, and return immediately.

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -108,7 +108,7 @@ func CnServerMessageHandler(
 		// keep listening until connection was closed
 		// to prevent some strange handle order between 'stop sending message' and others.
 		if err == nil {
-			<-ctx.Done()
+			<-receiver.connectionCtx.Done()
 		}
 		colexec.Get().RemoveRunningPipeline(receiver.clientSession)
 	}
@@ -142,10 +142,10 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) error {
 		succeed := false
 		select {
 		case <-timeLimit.Done():
-			err = moerr.NewInternalError(receiver.ctx, "send notify msg to dispatch operator timeout")
+			err = moerr.NewInternalError(receiver.messageCtx, "send notify msg to dispatch operator timeout")
 		case dispatchProc.DispatchNotifyCh <- infoToDispatchOperator:
 			succeed = true
-		case <-receiver.ctx.Done():
+		case <-receiver.connectionCtx.Done():
 		case <-dispatchProc.Ctx.Done():
 		}
 		cancel()
@@ -156,7 +156,7 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) error {
 		}
 
 		select {
-		case <-receiver.ctx.Done():
+		case <-receiver.connectionCtx.Done():
 			dispatchProc.Cancel()
 
 		// there is no need to check the dispatchProc.Ctx.Done() here.
@@ -263,7 +263,9 @@ type processHelper struct {
 
 // messageReceiverOnServer supported a series methods to write back results.
 type messageReceiverOnServer struct {
-	ctx         context.Context
+	messageCtx    context.Context
+	connectionCtx context.Context
+
 	messageId   uint64
 	messageTyp  pipeline.Method
 	messageUuid uuid.UUID
@@ -299,7 +301,8 @@ func newMessageReceiverOnServer(
 	aicm *defines.AutoIncrCacheManager) messageReceiverOnServer {
 
 	receiver := messageReceiverOnServer{
-		ctx:             ctx,
+		messageCtx:      ctx,
+		connectionCtx:   cs.SessionCtx(),
 		messageId:       m.GetId(),
 		messageTyp:      m.GetCmd(),
 		clientSession:   cs,
@@ -343,7 +346,7 @@ func newMessageReceiverOnServer(
 func (receiver *messageReceiverOnServer) acquireMessage() (*pipeline.Message, error) {
 	message, ok := receiver.messageAcquirer().(*pipeline.Message)
 	if !ok {
-		return nil, moerr.NewInternalError(receiver.ctx, "get a message with wrong type.")
+		return nil, moerr.NewInternalError(receiver.messageCtx, "get a message with wrong type.")
 	}
 	message.SetID(receiver.messageId)
 	return message, nil
@@ -357,8 +360,10 @@ func (receiver *messageReceiverOnServer) newCompile() *Compile {
 		panic(err)
 	}
 	pHelper, cnInfo := receiver.procBuildHelper, receiver.cnInformation
+
+	runningCtx, runningCancel := context.WithCancel(receiver.connectionCtx)
 	proc := process.New(
-		receiver.ctx,
+		runningCtx,
 		mp,
 		pHelper.txnClient,
 		pHelper.txnOperator,
@@ -368,6 +373,7 @@ func (receiver *messageReceiverOnServer) newCompile() *Compile {
 		cnInfo.hakeeper,
 		cnInfo.udfService,
 		cnInfo.aicm)
+	proc.Cancel = runningCancel
 	proc.UnixTime = pHelper.unixTime
 	proc.Id = pHelper.id
 	proc.Lim = pHelper.lim
@@ -410,9 +416,9 @@ func (receiver *messageReceiverOnServer) sendError(
 	message.SetID(receiver.messageId)
 	message.SetSid(pipeline.Status_MessageEnd)
 	if errInfo != nil {
-		message.SetMoError(receiver.ctx, errInfo)
+		message.SetMoError(receiver.messageCtx, errInfo)
 	}
-	return receiver.clientSession.Write(receiver.ctx, message)
+	return receiver.clientSession.Write(receiver.messageCtx, message)
 }
 
 func (receiver *messageReceiverOnServer) sendBatch(
@@ -436,7 +442,7 @@ func (receiver *messageReceiverOnServer) sendBatch(
 		m.SetMessageType(pipeline.Method_BatchMessage)
 		m.SetData(data)
 		m.SetSid(pipeline.Status_Last)
-		return receiver.clientSession.Write(receiver.ctx, m)
+		return receiver.clientSession.Write(receiver.messageCtx, m)
 	}
 	// if data is too large, cut and send
 	for start, end := 0, 0; start < dataLen; start = end {
@@ -454,7 +460,7 @@ func (receiver *messageReceiverOnServer) sendBatch(
 		m.SetMessageType(pipeline.Method_BatchMessage)
 		m.SetData(data[start:end])
 
-		if errW := receiver.clientSession.Write(receiver.ctx, m); errW != nil {
+		if errW := receiver.clientSession.Write(receiver.messageCtx, m); errW != nil {
 			return errW
 		}
 	}
@@ -484,7 +490,7 @@ func (receiver *messageReceiverOnServer) sendEndMessage() error {
 		}
 		message.SetAnalysis(data)
 	}
-	return receiver.clientSession.Write(receiver.ctx, message)
+	return receiver.clientSession.Write(receiver.messageCtx, message)
 }
 
 func generateProcessHelper(data []byte, cli client.TxnClient) (processHelper, error) {
@@ -533,9 +539,9 @@ func (receiver *messageReceiverOnServer) GetProcByUuid(uid uuid.UUID) (*process.
 		case <-getCtx.Done():
 			colexec.Get().GetProcByUuid(uid, true)
 			getCancel()
-			return nil, moerr.NewInternalError(receiver.ctx, "get dispatch process by uuid timeout")
+			return nil, moerr.NewInternalError(receiver.messageCtx, "get dispatch process by uuid timeout")
 
-		case <-receiver.ctx.Done():
+		case <-receiver.connectionCtx.Done():
 			colexec.Get().GetProcByUuid(uid, true)
 			getCancel()
 			return nil, nil

--- a/pkg/txn/rpc/server_test.go
+++ b/pkg/txn/rpc/server_test.go
@@ -212,6 +212,10 @@ func (cs *testClientSession) Close() error {
 	return nil
 }
 
+func (cs *testClientSession) SessionCtx() context.Context {
+	return nil
+}
+
 func (cs *testClientSession) Write(ctx context.Context, response morpc.Message) error {
 	cs.c <- response
 	return nil

--- a/pkg/vm/engine/tae/logtail/service/session_test.go
+++ b/pkg/vm/engine/tae/logtail/service/session_test.go
@@ -302,6 +302,10 @@ func (m *blockStream) RemoteAddress() string {
 	return "block"
 }
 
+func (m *blockStream) SessionCtx() context.Context {
+	return nil
+}
+
 func (m *blockStream) Write(ctx context.Context, message morpc.Message) error {
 	<-m.ch
 	return moerr.NewStreamClosedNoCtx()
@@ -343,6 +347,10 @@ func (m *brokenStream) RemoteAddress() string {
 	return "broken"
 }
 
+func (m *brokenStream) SessionCtx() context.Context {
+	return nil
+}
+
 func (m *brokenStream) Write(ctx context.Context, message morpc.Message) error {
 	return moerr.NewStreamClosedNoCtx()
 }
@@ -381,6 +389,10 @@ func mockNormalClientSession(logger *zap.Logger) morpc.ClientSession {
 
 func (m *normalStream) RemoteAddress() string {
 	return "normal"
+}
+
+func (m *normalStream) SessionCtx() context.Context {
+	return nil
 }
 
 func (m *normalStream) Write(ctx context.Context, message morpc.Message) error {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

https://github.com/matrixorigin/MO-Cloud/issues/3542
https://github.com/matrixorigin/MO-Cloud/issues/2788
https://github.com/matrixorigin/MO-Cloud/issues/3281

## What this PR does / why we need it:
fix a bug that the TCP context was incorrectly used as a STREAM context during the remote run, 
this will cause an inability to properly determine whether the stream had been disconnected.


___

### **PR Type**
Bug fix


___

### **Description**
- Added `SessionCtx` method to `clientSession` and `ClientSession` interface to retrieve the session context.
- Replaced incorrect usage of `ctx` with `connectionCtx` and `messageCtx` in `remoterunServer.go`.
- Updated `messageReceiverOnServer` struct and related functions to properly handle connection and message contexts.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Add method to retrieve session context in client session</code>&nbsp; </dd></summary>
<hr>
      
pkg/common/morpc/server.go

<li>Added <code>SessionCtx</code> method to <code>clientSession</code> to return the session <br>context.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17002/files#diff-6643c29b89ad98795ea1a8e7037a9326765af7f7ffd5fedad16ed57191368e40">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add session context retrieval method to ClientSession interface</code></dd></summary>
<hr>
      
pkg/common/morpc/types.go

- Added `SessionCtx` method to `ClientSession` interface.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17002/files#diff-a9bb06d67b25d2d031d6c3d74c050fec8969261cf4bca454167c2f9637ebedfc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remoterunServer.go</strong><dd><code>Fix incorrect context usage in remote run server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/remoterunServer.go

<li>Replaced usage of <code>ctx</code> with <code>connectionCtx</code> and <code>messageCtx</code> in various <br>functions.<br> <li> Updated <code>messageReceiverOnServer</code> struct to include <code>connectionCtx</code> and <br><code>messageCtx</code>.<br> <li> Modified <code>newMessageReceiverOnServer</code> to initialize <code>connectionCtx</code> using <br><code>SessionCtx</code>.<br> <li> Updated error handling and message sending functions to use <br><code>messageCtx</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17002/files#diff-d73b7f89321871c12e2595b1b3fd175f2f3a8a3cff9e153f69c02f23cd650d6f">+21/-15</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

