### PR TITLE
add log to debug lock table create multi times

### DIFF
--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -264,6 +264,7 @@ func (l *localLockTable) unlock(
 					zap.Int("keys-count", locks.len()),
 					zap.String("hold-bind", b.DebugString()),
 					zap.String("bind", l.bind.DebugString()),
+					zap.String("current", fmt.Sprintf("%p", l)),
 					waitTxnArrayField("holders", lock.holders.txns),
 					txnField(txn))
 			}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue [#3530](https://github.com/matrixorigin/MO-Cloud/issues/3530)

## What this PR does / why we need it:
add log to debug lock table create multi times


___

### **PR Type**
Bug fix


___

### **Description**
- Added logging to debug lock table creation in `localLockTable` and `service` components.
- Included current and new lock table pointers in log output for better debugging.
- Added logging for lock table removal to track when tables are deleted.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lock_table_local.go</strong><dd><code>Add logging for lock table creation in local lock table</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/lockservice/lock_table_local.go

<li>Added logging to debug lock table creation.<br> <li> Included current lock table pointer in log output.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17010/files#diff-58b0bb851b3377534881bd5d6ef248e668d5a5081e2f11f2dbd3e3289c9c2f8d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>service.go</strong><dd><code>Add logging for lock table creation, binding changes, and removal</code></dd></summary>
<hr>
      
pkg/lockservice/service.go

<li>Added logging to debug lock table creation and binding changes.<br> <li> Included current and new lock table pointers in log output.<br> <li> Added logging for lock table removal.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17010/files#diff-f8576fb3bde3c3d79c8eddae5a143aa626eb43d94ea121c9a59e440a76e4bf40">+21/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

