### PR TITLE
fix a bug that cause the remote-run context lost a deadline

### DIFF
--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -32,6 +32,10 @@ import (
 	"time"
 )
 
+// MaxRpcTime is a default timeout time to rpc context if user never set this deadline.
+// this is just a number I casually wrote, the purpose of doing this is that any message sent through rpc need a clear deadline.
+const MaxRpcTime = time.Hour * 24
+
 // remoteRun sends a scope to remote node for running.
 // and keep receiving the back results.
 //
@@ -204,7 +208,7 @@ func newMessageSenderOnClient(
 
 	sender.streamSender = streamSender
 	if _, ok := ctx.Deadline(); !ok {
-		sender.ctx, sender.ctxCancel = context.WithTimeout(ctx, time.Second*10000)
+		sender.ctx, sender.ctxCancel = context.WithTimeout(ctx, MaxRpcTime)
 	} else {
 		sender.ctx = ctx
 	}

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -1208,7 +1208,7 @@ func (s *Scope) sendNotifyMessage(wg *sync.WaitGroup, resultChan chan notifyMess
 				message.NeedNotReply = false
 				message.Uuid = uuid
 
-				if errSend := sender.streamSender.Send(s.Proc.Ctx, message); errSend != nil {
+				if errSend := sender.streamSender.Send(sender.ctx, message); errSend != nil {
 					closeWithError(errSend, s.Proc.Reg.MergeReceivers[receiverIdx], sender)
 					return
 				}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

https://github.com/matrixorigin/matrixone/issues/17015
https://github.com/matrixorigin/MO-Cloud/issues/3542
https://github.com/matrixorigin/MO-Cloud/issues/2788

## What this PR does / why we need it:
修改了一个远端执行的context没有指定deadline导致的错误。


___

### **PR Type**
Bug fix


___

### **Description**
- Introduced a `MaxRpcTime` constant to set a default RPC timeout if none is specified.
- Updated the `newMessageSenderOnClient` function to use `MaxRpcTime` for context timeout.
- Modified the `newCompile` function to ensure the message context has a deadline and return an error if it does not.
- Updated `handlePipelineMessage` to handle errors from `newCompile`.
- Changed the context used in `sendNotifyMessage` to `sender.ctx` to ensure consistency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remoterunClient.go</strong><dd><code>Set default RPC timeout using MaxRpcTime constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/remoterunClient.go

<li>Introduced <code>MaxRpcTime</code> constant for default RPC timeout.<br> <li> Updated context timeout in <code>newMessageSenderOnClient</code> to use <code>MaxRpcTime</code>.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17017/files#diff-e027434536257765c13ae824cfa8138e56c758db4365d2706ae5889ed1db14e2">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>remoterunServer.go</strong><dd><code>Ensure message context has a deadline and handle errors</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/remoterunServer.go

<li>Modified <code>newCompile</code> to return an error if message context lacks a <br>deadline.<br> <li> Updated <code>newCompile</code> to use <code>context.WithDeadline</code> instead of <br><code>context.WithCancel</code>.<br> <li> Added error handling for <code>newCompile</code> in <code>handlePipelineMessage</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17017/files#diff-d73b7f89321871c12e2595b1b3fd175f2f3a8a3cff9e153f69c02f23cd650d6f">+17/-5</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scope.go</strong><dd><code>Use sender context in sendNotifyMessage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/scope.go

- Changed context used in `sendNotifyMessage` to `sender.ctx`.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17017/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

