### PR TITLE
Fix memory leak for partition state

### DIFF
--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -23,6 +23,8 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	"github.com/tidwall/btree"
+
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -33,7 +35,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	txnTrace "github.com/matrixorigin/matrixone/pkg/txn/trace"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
-	"github.com/tidwall/btree"
 )
 
 type PartitionState struct {
@@ -526,7 +527,7 @@ func (p *PartitionState) HandleObjectInsert(ctx context.Context, bat *api.Batch,
 						p.rows.Delete(entry)
 
 						// delete the row's primary index
-						if objEntry.EntryState && len(entry.PrimaryIndexBytes) > 0 {
+						if len(entry.PrimaryIndexBytes) > 0 {
 							p.primaryIndex.Delete(&PrimaryIndexEntry{
 								Bytes:      entry.PrimaryIndexBytes,
 								RowEntryID: entry.ID,
@@ -797,7 +798,7 @@ func (p *PartitionState) HandleMetadataInsert(
 						p.rows.Delete(entry)
 
 						// delete the row's primary index
-						if isAppendable && len(entry.PrimaryIndexBytes) > 0 {
+						if len(entry.PrimaryIndexBytes) > 0 {
 							p.primaryIndex.Delete(&PrimaryIndexEntry{
 								Bytes:      entry.PrimaryIndexBytes,
 								RowEntryID: entry.ID,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16942 

## What this PR does / why we need it:
1.  The entries in PartitionState.primaryIndex  are not deleted in some case, leads to memory leak.
