### PR TITLE
fix: external free

### DIFF
--- a/pkg/sql/colexec/external/types.go
+++ b/pkg/sql/colexec/external/types.go
@@ -156,11 +156,10 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 			arg.ctr.buf.Clean(proc.Mp())
 			arg.ctr.buf = nil
 		}
+		anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
+		anal.Alloc(int64(arg.ctr.maxAllocSize))
+		arg.ctr = nil
 	}
-
-	anal := proc.GetAnalyze(arg.GetIdx(), arg.GetParallelIdx(), arg.GetParallelMajor())
-	anal.Alloc(int64(arg.ctr.maxAllocSize))
-	arg.ctr = nil
 }
 
 type ParseLineHandler struct {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:
#16725

issue #

## What this PR does / why we need it:
fix external_scan free panic when MO Checkin Regression On TKE


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a panic issue in the `Free` method of `pkg/sql/colexec/external/types.go` by reordering the operations.
- Ensured allocation analysis is performed before setting `arg.ctr` to nil.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Fix panic in `Free` method by reordering operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/colexec/external/types.go

<li>Fixed the order of operations in the <code>Free</code> method to prevent panic.<br> <li> Moved the allocation analysis to occur before setting <code>arg.ctr</code> to nil.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17074/files#diff-df82d1bd232b927b9c30126bc8cf018e204507d6bab896b3a2375833eac69968">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

