### PR TITLE
Set transfer page limit

### DIFF
--- a/pkg/vm/engine/tae/db/scannerop.go
+++ b/pkg/vm/engine/tae/db/scannerop.go
@@ -15,13 +15,14 @@
 package db
 
 import (
-	"sync/atomic"
-
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/merge"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
+	dto "github.com/prometheus/client_model/go"
 )
 
 type ScannerOp interface {
@@ -42,9 +43,7 @@ type MergeTaskBuilder struct {
 	tableRowCnt int
 	tableRowDel int
 
-	// concurrecy control
-	suspend    atomic.Bool
-	suspendCnt atomic.Int32
+	skipForTransPageLimit bool
 }
 
 func newMergeTaskBuilder(db *DB) *MergeTaskBuilder {
@@ -98,6 +97,19 @@ func (s *MergeTaskBuilder) resetForTable(entry *catalog.TableEntry) {
 
 func (s *MergeTaskBuilder) PreExecute() error {
 	s.executor.RefreshMemInfo()
+	s.skipForTransPageLimit = false
+	m := &dto.Metric{}
+	v2.TaskMergeTransferPageLengthGauge.Write(m)
+	pagesize := m.GetGauge().GetValue() * 28 /*int32 + rowid(24b)*/ * 1.3 /*map inflationg factor*/
+	if pagesize > float64(s.executor.TransferPageSizeLimit()) {
+		logutil.Infof("[mergeblocks] skip merge scanning due to transfer page %s, limit %s",
+			common.HumanReadableBytes(int(pagesize)),
+			common.HumanReadableBytes(int(s.executor.TransferPageSizeLimit())))
+		s.skipForTransPageLimit = true
+	} else {
+		logutil.Infof("[mergeblocks]: transfer page %v",
+			common.HumanReadableBytes(int(pagesize)))
+	}
 	return nil
 }
 
@@ -106,27 +118,28 @@ func (s *MergeTaskBuilder) PostExecute() error {
 	return nil
 }
 func (s *MergeTaskBuilder) onDataBase(dbEntry *catalog.DBEntry) (err error) {
-	if s.suspend.Load() {
-		s.suspendCnt.Add(1)
-		return moerr.GetOkStopCurrRecur()
-	}
-	s.suspendCnt.Store(0)
 	if merge.StopMerge.Load() {
 		return moerr.GetOkStopCurrRecur()
 	}
 	if s.executor.MemAvailBytes() < 100*common.Const1MBytes {
 		return moerr.GetOkStopCurrRecur()
 	}
+
+	if s.skipForTransPageLimit {
+		return moerr.GetOkStopCurrRecur()
+	}
+
 	return
 }
 
 func (s *MergeTaskBuilder) onTable(tableEntry *catalog.TableEntry) (err error) {
-	if merge.StopMerge.Load() || s.suspend.Load() {
+	if merge.StopMerge.Load() {
 		return moerr.GetOkStopCurrRecur()
 	}
 	if !tableEntry.IsActive() {
 		return moerr.GetOkStopCurrRecur()
 	}
+
 	tableEntry.RLock()
 	// this table is creating or altering
 	if !tableEntry.IsCommittedLocked() {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16942

## What this PR does / why we need it:

To avoid transfer pages to occupy too much memory. The limit is set concerning available memory for the TN process, to be specific:
- for 200+GB memory, take 8%
- for 100+GB, 12%
- for 40+GB, 16%


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new field `transPageLimit` to the `MergeExecutor` struct to manage transfer page limits based on available memory.
- Implemented logic in `setSpareMem` method to set the transfer page limit dynamically.
- Introduced `TransferPageSizeLimit` method to retrieve the current transfer page limit.
- Added a new field `skipForTransPageLimit` to the `MergeTaskBuilder` struct to control merge scanning based on the transfer page size limit.
- Implemented logic in `PreExecute` method of `MergeTaskBuilder` to skip merge scanning if the transfer page size exceeds the limit.
- Removed unused concurrency control fields (`suspend` and `suspendCnt`) from `MergeTaskBuilder`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.go</strong><dd><code>Add transfer page limit logic to MergeExecutor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/db/merge/executor.go

<li>Added <code>transPageLimit</code> field to <code>MergeExecutor</code> struct.<br> <li> Implemented logic to set transfer page limit based on available <br>memory.<br> <li> Introduced <code>TransferPageSizeLimit</code> method to retrieve the transfer page <br>limit.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17076/files#diff-e9134fa072053b9ad4aa76535cf21f869315f286535007500176e915668636f0">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scannerop.go</strong><dd><code>Implement transfer page limit check in MergeTaskBuilder</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/db/scannerop.go

<li>Added <code>skipForTransPageLimit</code> field to <code>MergeTaskBuilder</code> struct.<br> <li> Implemented logic to skip merge scanning based on transfer page size <br>limit.<br> <li> Removed unused concurrency control fields.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17076/files#diff-cddf8a53c6707c9650c8e9741943663705fa6a551e2b91eeb86b297a6cd20b6f">+20/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

