### PR TITLE
[opt] : remove output operator after fuzzy filter

### DIFF
--- a/pkg/sql/colexec/fuzzyfilter/filter.go
+++ b/pkg/sql/colexec/fuzzyfilter/filter.go
@@ -210,6 +210,8 @@ func (arg *Argument) Call(proc *process.Process) (vm.CallResult, error) {
 
 				// send collisionKeys to output operator to run background SQL
 				ctr.rbat.SetRowCount(ctr.rbat.Vecs[0].Length())
+				arg.Callback(ctr.rbat)
+
 				result.Batch = ctr.rbat
 				result.Status = vm.ExecStop
 				ctr.state = End

--- a/pkg/sql/colexec/fuzzyfilter/filter.go
+++ b/pkg/sql/colexec/fuzzyfilter/filter.go
@@ -210,12 +210,14 @@ func (arg *Argument) Call(proc *process.Process) (vm.CallResult, error) {
 
 				// send collisionKeys to output operator to run background SQL
 				ctr.rbat.SetRowCount(ctr.rbat.Vecs[0].Length())
-				arg.Callback(ctr.rbat)
-
 				result.Batch = ctr.rbat
 				result.Status = vm.ExecStop
 				ctr.state = End
-				return result, nil
+				if err := arg.Callback(ctr.rbat); err != nil {
+					return result, err
+				} else {
+					return result, nil
+				}
 			}
 
 			if bat.IsEmpty() {

--- a/pkg/sql/colexec/fuzzyfilter/types.go
+++ b/pkg/sql/colexec/fuzzyfilter/types.go
@@ -61,6 +61,7 @@ type Argument struct {
 	PkName             string
 	PkTyp              plan.Type
 	BuildIdx           int
+	Callback           func(bat *batch.Batch) error
 	IfInsertFromUnique bool
 
 	RuntimeFilterSpec *plan.RuntimeFilterSpec

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -3165,29 +3165,25 @@ func (c *Compile) compileFuzzyFilter(n *plan.Node, ns []*plan.Node, left []*Scop
 		Arg: arg,
 	})
 
-	outData, err := newFuzzyCheck(n)
+	fuzzyCheck, err := newFuzzyCheck(n)
 	if err != nil {
 		return nil, err
 	}
-	c.fuzzys = append(c.fuzzys, outData)
+	c.fuzzys = append(c.fuzzys, fuzzyCheck)
+
 	// wrap the collision key into c.fuzzy, for more information,
 	// please refer fuzzyCheck.go
-	rs.appendInstruction(vm.Instruction{
-		Op: vm.Output,
-		Arg: output.NewArgument().
-			WithFunc(
-				func(bat *batch.Batch) error {
-					if bat == nil || bat.IsEmpty() {
-						return nil
-					}
-					// the batch will contain the key that fuzzyCheck
-					if err := outData.fill(c.ctx, bat); err != nil {
-						return err
-					}
+	arg.Callback = func(bat *batch.Batch) error {
+		if bat == nil || bat.IsEmpty() {
+			return nil
+		}
+		// the batch will contain the key that fuzzyCheck
+		if err := fuzzyCheck.fill(c.ctx, bat); err != nil {
+			return err
+		}
 
-					return nil
-				}),
-	})
+		return nil
+	}
 
 	return []*Scope{rs}, nil
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17075

## What this PR does / why we need it:

prepare for the subsequent TP performance improvement


___

### **PR Type**
Enhancement


___

### **Description**
- Added a callback function execution after setting the row count in the fuzzy filter process.
- Introduced a new `Callback` function field in the `Argument` struct to handle batch processing.
- Replaced the output operator with a callback function in the fuzzy filter compilation process, simplifying the code.
- Simplified struct initialization syntax in the MySQL parser for better readability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filter.go</strong><dd><code>Add callback execution after setting row count in fuzzy filter</code></dd></summary>
<hr>
      
pkg/sql/colexec/fuzzyfilter/filter.go

<li>Added a callback function call after setting row count.<br> <li> Ensured the callback function is executed before setting the result <br>status.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17077/files#diff-1813d802e4307f38830c0ae6969859a5555ebf13463078695b93cad9a77151fc">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Introduce Callback function field in Argument struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/colexec/fuzzyfilter/types.go

<li>Introduced a new <code>Callback</code> function field in the <code>Argument</code> struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17077/files#diff-93108ef7af95c0ad2bd1bc9b996cc8f038a93265b1fb2a02cb0ccdbfe09aeb6c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>compile.go</strong><dd><code>Replace output operator with callback in fuzzy filter compilation</code></dd></summary>
<hr>
      
pkg/sql/compile/compile.go

<li>Replaced output operator with a callback function for fuzzy filter.<br> <li> Simplified the fuzzy filter compilation process.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17077/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+13/-17</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mysql_sql.go</strong><dd><code>Simplify struct initialization in MySQL parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/parsers/dialect/mysql/mysql_sql.go

- Simplified struct initialization syntax in MySQL parser.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17077/files#diff-6aa8b3d2cec1bd35bafe74d27392cee02153f7b4ec574d40eff17db7c30d41e2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

