### PR TITLE
Set transfer page limit 1.2

### DIFF
--- a/pkg/vm/engine/tae/db/merge/executor.go
+++ b/pkg/vm/engine/tae/db/merge/executor.go
@@ -50,9 +50,11 @@ type MergeExecutor struct {
 	cnSched             CNMergeScheduler
 	memAvail            int
 	memSpare            int // 10% of total memory or container memory limit
+	transPageLimit      uint64
 	cpuPercent          float64
 	activeMergeBlkCount int32
 	activeEstimateBytes int64
+	roundMergeRows      uint64
 	taskConsume         struct {
 		sync.Mutex
 		o map[objectio.ObjectId]struct{}
@@ -83,6 +85,18 @@ func (e *MergeExecutor) setSpareMem(total uint64) {
 	} else {
 		e.memSpare = tenth
 	}
+
+	availTotal := total - uint64(e.memSpare)
+
+	if availTotal > 200*common.Const1GBytes {
+		e.transPageLimit = availTotal / 25 * 2 // 8%
+	} else if availTotal > 100*common.Const1GBytes {
+		e.transPageLimit = availTotal / 25 * 3 // 12%
+	} else if availTotal > 40*common.Const1GBytes {
+		e.transPageLimit = availTotal / 25 * 4 // 16%
+	} else {
+		e.transPageLimit = math.MaxUint64 // no limit
+	}
 }
 
 func (e *MergeExecutor) RefreshMemInfo() {
@@ -95,6 +109,7 @@ func (e *MergeExecutor) RefreshMemInfo() {
 	if percents, err := cpu.Percent(0, false); err == nil {
 		e.cpuPercent = percents[0]
 	}
+	e.roundMergeRows = 0
 }
 
 func (e *MergeExecutor) PrintStats() {
@@ -138,6 +153,9 @@ func (e *MergeExecutor) OnExecDone(v any) {
 }
 
 func (e *MergeExecutor) ExecuteFor(entry *catalog.TableEntry, policy Policy) {
+	if e.roundMergeRows*36 /*28 * 1.3 */ > e.transPageLimit/8 {
+		return
+	}
 	e.tableName = fmt.Sprintf("%v-%v", entry.ID, entry.GetLastestSchema().Name)
 
 	mobjs, kind := policy.Revise(e.CPUPercent(), int64(e.MemAvailBytes()))
@@ -202,6 +220,9 @@ func (e *MergeExecutor) ExecuteFor(entry *catalog.TableEntry, policy Policy) {
 			return
 		}
 		e.AddActiveTask(task.ID(), blkCnt, esize)
+		for _, obj := range mobjs {
+			e.roundMergeRows += uint64(obj.GetRemainingRows())
+		}
 		logMergeTask(e.tableName, task.ID(), mobjs, blkCnt, osize, esize)
 	}
 
@@ -215,6 +236,10 @@ func (e *MergeExecutor) MemAvailBytes() int {
 		avail = 0
 	}
 	return avail
+}
+
+func (e *MergeExecutor) TransferPageSizeLimit() uint64 {
+	return e.transPageLimit
 }
 
 func (e *MergeExecutor) CPUPercent() int64 {

--- a/pkg/vm/engine/tae/db/merge/executor.go
+++ b/pkg/vm/engine/tae/db/merge/executor.go
@@ -71,10 +71,6 @@ func NewMergeExecutor(rt *dbutils.Runtime, sched CNMergeScheduler) *MergeExecuto
 
 func (e *MergeExecutor) setSpareMem(total uint64) {
 	containerMLimit, err := memlimit.FromCgroup()
-	logutil.Infof("[Mergeblocks] constainer memory limit %v, host mem %v, err %v",
-		common.HumanReadableBytes(int(containerMLimit)),
-		common.HumanReadableBytes(int(total)),
-		err)
 	tenth := int(float64(total) * 0.1)
 	limitdiff := 0
 	if containerMLimit > 0 {
@@ -97,6 +93,12 @@ func (e *MergeExecutor) setSpareMem(total uint64) {
 	} else {
 		e.transPageLimit = math.MaxUint64 // no limit
 	}
+	logutil.Infof("[Mergeblocks] constainer memory limit %v, host mem %v, spare mem %v, trans limit %v, err %v",
+		common.HumanReadableBytes(int(containerMLimit)),
+		common.HumanReadableBytes(int(total)),
+		common.HumanReadableBytes(e.memSpare),
+		common.HumanReadableBytes(int(e.transPageLimit)),
+		err)
 }
 
 func (e *MergeExecutor) RefreshMemInfo() {

--- a/pkg/vm/engine/tae/db/scannerop.go
+++ b/pkg/vm/engine/tae/db/scannerop.go
@@ -106,6 +106,9 @@ func (s *MergeTaskBuilder) PreExecute() error {
 			common.HumanReadableBytes(int(pagesize)),
 			common.HumanReadableBytes(int(s.executor.TransferPageSizeLimit())))
 		s.skipForTransPageLimit = true
+	} else {
+		logutil.Infof("[mergeblocks]: transfer page %v",
+			common.HumanReadableBytes(int(pagesize)))
 	}
 	return nil
 }

--- a/pkg/vm/engine/tae/db/scannerop.go
+++ b/pkg/vm/engine/tae/db/scannerop.go
@@ -15,13 +15,14 @@
 package db
 
 import (
-	"sync/atomic"
-
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/merge"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
+	dto "github.com/prometheus/client_model/go"
 )
 
 type ScannerOp interface {
@@ -42,9 +43,7 @@ type MergeTaskBuilder struct {
 	tableRowCnt int
 	tableRowDel int
 
-	// concurrecy control
-	suspend    atomic.Bool
-	suspendCnt atomic.Int32
+	skipForTransPageLimit bool
 }
 
 func newMergeTaskBuilder(db *DB) *MergeTaskBuilder {
@@ -98,6 +97,16 @@ func (s *MergeTaskBuilder) resetForTable(entry *catalog.TableEntry) {
 
 func (s *MergeTaskBuilder) PreExecute() error {
 	s.executor.RefreshMemInfo()
+	s.skipForTransPageLimit = false
+	m := &dto.Metric{}
+	v2.TaskMergeTransferPageLengthGauge.Write(m)
+	pagesize := m.GetGauge().GetValue() * 28 /*int32 + rowid(24b)*/ * 1.3 /*map inflationg factor*/
+	if pagesize > float64(s.executor.TransferPageSizeLimit()) {
+		logutil.Infof("[mergeblocks] skip merge scanning due to transfer page %s, limit %s",
+			common.HumanReadableBytes(int(pagesize)),
+			common.HumanReadableBytes(int(s.executor.TransferPageSizeLimit())))
+		s.skipForTransPageLimit = true
+	}
 	return nil
 }
 
@@ -106,27 +115,28 @@ func (s *MergeTaskBuilder) PostExecute() error {
 	return nil
 }
 func (s *MergeTaskBuilder) onDataBase(dbEntry *catalog.DBEntry) (err error) {
-	if s.suspend.Load() {
-		s.suspendCnt.Add(1)
-		return moerr.GetOkStopCurrRecur()
-	}
-	s.suspendCnt.Store(0)
 	if merge.StopMerge.Load() {
 		return moerr.GetOkStopCurrRecur()
 	}
 	if s.executor.MemAvailBytes() < 100*common.Const1MBytes {
 		return moerr.GetOkStopCurrRecur()
 	}
+
+	if s.skipForTransPageLimit {
+		return moerr.GetOkStopCurrRecur()
+	}
+
 	return
 }
 
 func (s *MergeTaskBuilder) onTable(tableEntry *catalog.TableEntry) (err error) {
-	if merge.StopMerge.Load() || s.suspend.Load() {
+	if merge.StopMerge.Load() {
 		return moerr.GetOkStopCurrRecur()
 	}
 	if !tableEntry.IsActive() {
 		return moerr.GetOkStopCurrRecur()
 	}
+
 	tableEntry.RLock()
 	// this table is creating or altering
 	if !tableEntry.IsCommittedLocked() {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16942

## What this PR does / why we need it:

To avoid transfer pages to occupy too much memory. The limit is set concerning available memory for the TN process, to be specific:
- for 200+GB memory, take 10%
- for 100+GB, 15%
- for 40+GB, 20%


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new `transPageLimit` field to the `MergeExecutor` struct to control the memory usage for transfer pages.
- Implemented logic in `MergeExecutor` to set `transPageLimit` based on available memory thresholds.
- Introduced a `TransferPageSizeLimit` method in `MergeExecutor` to retrieve the transfer page size limit.
- Updated `MergeTaskBuilder` to include a `skipForTransPageLimit` field and logic to skip merge scanning if the transfer page size exceeds the limit.
- Removed unused concurrency control fields (`suspend` and `suspendCnt`) from `MergeTaskBuilder`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.go</strong><dd><code>Add transfer page limit logic to MergeExecutor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/db/merge/executor.go

<li>Added <code>transPageLimit</code> field to <code>MergeExecutor</code> struct.<br> <li> Implemented logic to set <code>transPageLimit</code> based on available memory.<br> <li> Introduced <code>TransferPageSizeLimit</code> method to retrieve <code>transPageLimit</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17078/files#diff-e9134fa072053b9ad4aa76535cf21f869315f286535007500176e915668636f0">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scannerop.go</strong><dd><code>Implement transfer page limit check in MergeTaskBuilder</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/vm/engine/tae/db/scannerop.go

<li>Added <code>skipForTransPageLimit</code> field to <code>MergeTaskBuilder</code> struct.<br> <li> Implemented logic to skip merge scanning based on transfer page size <br>limit.<br> <li> Removed unused concurrency control fields.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17078/files#diff-cddf8a53c6707c9650c8e9741943663705fa6a551e2b91eeb86b297a6cd20b6f">+20/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

