### PR TITLE
Fix rightjoin.Free hung

### DIFF
--- a/pkg/sql/colexec/right/types.go
+++ b/pkg/sql/colexec/right/types.go
@@ -128,14 +128,8 @@ func (arg *Argument) Release() {
 func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error) {
 	ctr := arg.ctr
 	if ctr != nil {
-		if !ctr.handledLast && arg.NumCPU > 1 {
-			if arg.IsMerger {
-				for i := uint64(1); i < arg.NumCPU; i++ {
-					<-arg.Channel
-				}
-			} else {
-				arg.Channel <- nil
-			}
+		if !ctr.handledLast && arg.NumCPU > 1 && !arg.IsMerger {
+			arg.Channel <- nil
 		}
 		ctr.cleanBatch(proc)
 		ctr.cleanHashMap()

--- a/pkg/sql/colexec/rightanti/types.go
+++ b/pkg/sql/colexec/rightanti/types.go
@@ -128,14 +128,8 @@ func (arg *Argument) Release() {
 func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error) {
 	ctr := arg.ctr
 	if ctr != nil {
-		if !ctr.handledLast && arg.NumCPU > 1 {
-			if arg.IsMerger {
-				for i := uint64(1); i < arg.NumCPU; i++ {
-					<-arg.Channel
-				}
-			} else {
-				arg.Channel <- nil
-			}
+		if !ctr.handledLast && arg.NumCPU > 1 && !arg.IsMerger {
+			arg.Channel <- nil
 		}
 		ctr.cleanBatch(proc)
 		ctr.cleanEvalVectors()

--- a/pkg/sql/colexec/rightsemi/types.go
+++ b/pkg/sql/colexec/rightsemi/types.go
@@ -128,14 +128,8 @@ func (arg *Argument) Release() {
 func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error) {
 	ctr := arg.ctr
 	if ctr != nil {
-		if !ctr.handledLast && arg.NumCPU > 1 {
-			if arg.IsMerger {
-				for i := uint64(1); i < arg.NumCPU; i++ {
-					<-arg.Channel
-				}
-			} else {
-				arg.Channel <- nil
-			}
+		if !ctr.handledLast && arg.NumCPU > 1 && !arg.IsMerger {
+			arg.Channel <- nil
 		}
 		ctr.cleanBatch(proc)
 		ctr.cleanEvalVectors()


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/3338

## What this PR does / why we need it:
Do not read from channel in Free()


___

### **PR Type**
Bug fix


___

### **Description**
- Simplified the condition for sending to the channel in the `Free` method across multiple files.
- Removed unnecessary channel reads for merger cases to prevent hanging.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Simplify channel handling logic in `Free` method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/colexec/right/types.go

<li>Simplified the condition for sending to the channel in the <code>Free</code> <br>method.<br> <li> Removed unnecessary channel reads for merger cases.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17107/files#diff-8ca420f45bfc8a20d2d3ea22159ff6c0564aa9aef574cbe869de92958dbbe281">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Simplify channel handling logic in `Free` method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/colexec/rightanti/types.go

<li>Simplified the condition for sending to the channel in the <code>Free</code> <br>method.<br> <li> Removed unnecessary channel reads for merger cases.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17107/files#diff-1b858d19d24303025f70ea7b8f0b6f2cbd544503d08075095f6474c92284ebe6">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Simplify channel handling logic in `Free` method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/colexec/rightsemi/types.go

<li>Simplified the condition for sending to the channel in the <code>Free</code> <br>method.<br> <li> Removed unnecessary channel reads for merger cases.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17107/files#diff-031ae690ad55b3be0fe934b79dbcb3a3474deb450d8e012650373164cf7b662f">+2/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

