### PR TITLE
fix can restart cn when tn crash

### DIFF
--- a/pkg/lockservice/lock_table_keeper.go
+++ b/pkg/lockservice/lock_table_keeper.go
@@ -16,6 +16,7 @@ package lockservice
 
 import (
 	"context"
+	"go.uber.org/zap"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
@@ -209,6 +210,12 @@ func (k *lockTableKeeper) doKeepLockTableBind(ctx context.Context) {
 	if resp.KeepLockTableBind.OK {
 		switch resp.KeepLockTableBind.Status {
 		case pb.Status_ServiceLockEnable:
+			if !k.service.isStatus(pb.Status_ServiceLockEnable) {
+				getLogger().Error("tn has abnormal lock service status",
+					zap.String("serviceID", k.serviceID),
+					zap.String("status", k.service.getStatus().String()))
+			}
+			return
 		case pb.Status_ServiceLockWaiting:
 			// maybe pb.Status_ServiceUnLockSucc
 			if k.service.isStatus(pb.Status_ServiceLockEnable) {

--- a/pkg/lockservice/log.go
+++ b/pkg/lockservice/log.go
@@ -369,10 +369,12 @@ func logPingFailed(
 	}
 }
 
-func logCanLockOnService() {
+func logCanLockOnService(
+	serviceID string) {
 	logger := getWithSkipLogger()
 	if logger.Enabled(zap.InfoLevel) {
-		logger.Error("if lock on service")
+		logger.Error("if lock on service",
+			zap.String("serviceID", serviceID))
 	}
 }
 
@@ -496,6 +498,19 @@ func logStatus(
 	logger := getWithSkipLogger()
 	if logger.Enabled(zap.InfoLevel) {
 		logger.Info("service status",
+			zap.String("status", status.String()))
+	}
+}
+
+func logServiceStatus(
+	info string,
+	serviceID string,
+	status pb.Status) {
+	logger := getWithSkipLogger()
+	if logger.Enabled(zap.InfoLevel) {
+		logger.Info("service status",
+			zap.String("info", info),
+			zap.String("serviceID", serviceID),
 			zap.String("status", status.String()))
 	}
 }

--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -319,11 +319,11 @@ func (s *service) canLockOnServiceStatus(
 	if s.isStatus(pb.Status_ServiceLockEnable) {
 		return true
 	}
-	defer logCanLockOnService()
 	if opts.Sharding == pb.Sharding_ByRow {
 		tableID = shardingByRow(rows[0])
 	}
 	if !s.validGroupTable(opts.Group, tableID) {
+		logCanLockOnService(s.serviceID)
 		return false
 	}
 	if s.activeTxnHolder.hasActiveTxn(txnID) {
@@ -391,8 +391,8 @@ func (s *service) Close() error {
 func (s *service) setStatus(status pb.Status) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.mu.status = status
 	logStatusChange(s.mu.status, status)
+	s.mu.status = status
 }
 
 func (s *service) getStatus() pb.Status {

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -1430,6 +1430,193 @@ func TestReLockSuccWithLockTableBindChanged(t *testing.T) {
 	)
 }
 
+func TestIssue3537(t *testing.T) {
+	runLockServiceTestsWithLevel(
+		t,
+		zapcore.DebugLevel,
+		[]string{"s1"},
+		time.Second*1,
+		func(alloc *lockTableAllocator, s []*service) {
+			l1 := s[0]
+
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				time.Second*10)
+			defer cancel()
+			option := pb.LockOptions{
+				Granularity: pb.Granularity_Row,
+				Mode:        pb.LockMode_Exclusive,
+				Policy:      pb.WaitPolicy_Wait,
+			}
+
+			_, err := l1.Lock(
+				ctx,
+				0,
+				[][]byte{{1}},
+				[]byte("txn1"),
+				option)
+			require.NoError(t, err)
+
+			alloc.setRestartService("s1")
+			for {
+				if l1.isStatus(pb.Status_ServiceLockWaiting) {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					panic("timeout bug")
+				default:
+				}
+			}
+
+			b := alloc.getServiceBindsWithoutPrefix("s1")
+			b.setStatus(pb.Status_ServiceLockEnable)
+
+			for {
+				if b.isStatus(pb.Status_ServiceLockWaiting) {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					panic("timeout bug")
+				default:
+				}
+			}
+
+			require.NoError(t, l1.Unlock(ctx, []byte("txn1"), timestamp.Timestamp{}))
+			for {
+				if b.isStatus(pb.Status_ServiceCanRestart) {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					panic("timeout bug")
+				default:
+				}
+			}
+		},
+		nil,
+	)
+}
+
+func TestIssue3537_2(t *testing.T) {
+	runLockServiceTestsWithLevel(
+		t,
+		zapcore.DebugLevel,
+		[]string{"s1"},
+		time.Second*1,
+		func(alloc *lockTableAllocator, s []*service) {
+			l1 := s[0]
+
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				time.Second*10)
+			defer cancel()
+			option := pb.LockOptions{
+				Granularity: pb.Granularity_Row,
+				Mode:        pb.LockMode_Exclusive,
+				Policy:      pb.WaitPolicy_Wait,
+			}
+
+			_, err := l1.Lock(
+				ctx,
+				0,
+				[][]byte{{1}},
+				[]byte("txn1"),
+				option)
+			require.NoError(t, err)
+
+			alloc.setRestartService("s1")
+			for {
+				if l1.isStatus(pb.Status_ServiceLockWaiting) {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					panic("timeout bug")
+				default:
+				}
+			}
+
+			b := alloc.getServiceBindsWithoutPrefix("s1")
+			b.setStatus(pb.Status_ServiceLockEnable)
+
+			require.NoError(t, l1.Unlock(ctx, []byte("txn1"), timestamp.Timestamp{}))
+
+			for {
+				if b.isStatus(pb.Status_ServiceCanRestart) {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					panic("timeout bug")
+				default:
+				}
+			}
+		},
+		nil,
+	)
+}
+
+func TestIssue3537_3(t *testing.T) {
+	runLockServiceTestsWithLevel(
+		t,
+		zapcore.DebugLevel,
+		[]string{"s1"},
+		time.Second*1,
+		func(alloc *lockTableAllocator, s []*service) {
+			l1 := s[0]
+
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				time.Second*10)
+			defer cancel()
+			option := pb.LockOptions{
+				Granularity: pb.Granularity_Row,
+				Mode:        pb.LockMode_Exclusive,
+				Policy:      pb.WaitPolicy_Wait,
+			}
+
+			_, err := l1.Lock(
+				ctx,
+				0,
+				[][]byte{{1}},
+				[]byte("txn1"),
+				option)
+			require.NoError(t, err)
+
+			alloc.setRestartService("s1")
+			for {
+				if l1.isStatus(pb.Status_ServiceLockWaiting) {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					panic("timeout bug")
+				default:
+				}
+			}
+
+			require.NoError(t, l1.Unlock(ctx, []byte("txn1"), timestamp.Timestamp{}))
+
+			b := alloc.getServiceBindsWithoutPrefix("s1")
+			b.setStatus(pb.Status_ServiceLockEnable)
+
+			for {
+				if b.isStatus(pb.Status_ServiceCanRestart) {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					panic("timeout bug")
+				default:
+				}
+			}
+		},
+		nil,
+	)
+}
+
 func TestIssue3288(t *testing.T) {
 	runLockServiceTestsWithLevel(
 		t,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3516 #https://github.com/matrixorigin/MO-Cloud/issues/3537

## What this PR does / why we need it:

fix can restart cn when tn crash


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Improved logging and status handling in `lock_table_allocator.go` by adding service status details and new logging functions.
- Added error logging for abnormal lock service status in `lock_table_keeper.go`.
- Introduced new logging functions and enhanced existing ones in `log.go` to include service ID and status.
- Enhanced logging in service status management in `service.go`.
- Added new tests in `service_test.go` to verify the service restart behavior related to issue #3537.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lock_table_allocator.go</strong><dd><code>Improve logging and status handling in lock table allocator</code></dd></summary>
<hr>
      
pkg/lockservice/lock_table_allocator.go

<li>Added logging for service status changes.<br> <li> Enhanced error logging with service status details.<br> <li> Introduced <code>getStatus</code> method to retrieve the current status of a <br>service.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17114/files#diff-6be1ca324d0b56411e41ec19a99ea21442f80563429ee4964aedef60424413a1">+25/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lock_table_keeper.go</strong><dd><code>Add error logging for abnormal lock service status in lock table </code><br><code>keeper</code></dd></summary>
<hr>
      
pkg/lockservice/lock_table_keeper.go

- Added error logging for abnormal lock service status.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17114/files#diff-5af69981988fb4d1a3a415cdfa9239b01aa00ae7323ff5a5e36fb9e253fde9c1">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>log.go</strong><dd><code>Add and enhance logging functions for service status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/lockservice/log.go

<li>Added <code>logServiceStatus</code> function for logging service status.<br> <li> Enhanced <code>logCanLockOnService</code> to include service ID.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17114/files#diff-810cd800b6dec0afe01c14f8f4cab0c5753d28d30ea19970d17dfdd81906fa1d">+17/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>service.go</strong><dd><code>Enhance logging in service status management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/lockservice/service.go

<li>Enhanced <code>canLockOnServiceStatus</code> to log service ID.<br> <li> Added logging for status changes in <code>setStatus</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17114/files#diff-f8576fb3bde3c3d79c8eddae5a143aa626eb43d94ea121c9a59e440a76e4bf40">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_test.go</strong><dd><code>Add tests for service restart behavior (issue #3537)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/lockservice/service_test.go

- Added tests for issue #3537 to verify service restart behavior.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17114/files#diff-e94812797c8b26ff0499bd86698dbc4371dd72642267baa535a7ecc7f8bf3981">+187/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

