### PR TITLE
[cherry-pick-16310] : mergeDelete on hidden table should not update affactRows

### DIFF
--- a/pkg/sql/colexec/insert/types.go
+++ b/pkg/sql/colexec/insert/types.go
@@ -82,7 +82,7 @@ type InsertCtx struct {
 	// insert data into Rel.
 	Rel                   engine.Relation
 	Ref                   *plan.ObjectRef
-	AddAffectedRows       bool
+	AddAffectedRows       bool // for hidden table, should not update affect Rows
 	Attrs                 []string
 	PartitionTableIDs     []uint64          // Align array index with the partition number
 	PartitionTableNames   []string          // Align array index with the partition number

--- a/pkg/sql/colexec/mergedelete/types.go
+++ b/pkg/sql/colexec/mergedelete/types.go
@@ -24,7 +24,8 @@ import (
 var _ vm.Operator = new(Argument)
 
 type Argument struct {
-	AffectedRows uint64
+	AddAffectedRows bool
+	AffectedRows    uint64
 	// 1. single table's delete (main table)
 	DelSource engine.Relation
 	// 2. partition sub tables
@@ -65,6 +66,11 @@ func (arg *Argument) WithDelSource(delSource engine.Relation) *Argument {
 
 func (arg *Argument) WithPartitionSources(partitionSources []engine.Relation) *Argument {
 	arg.PartitionSources = partitionSources
+	return arg
+}
+
+func (arg *Argument) WithAddAffectedRows(addAffectedRows bool) *Argument {
+	arg.AddAffectedRows = addAffectedRows
 	return arg
 }
 

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -358,7 +358,10 @@ func (c *Compile) run(s *Scope) error {
 		if err != nil {
 			return err
 		}
-		c.setAffectedRows(s.Instructions[len(s.Instructions)-1].Arg.(*mergedelete.Argument).AffectedRows)
+		mergeArg := s.Instructions[len(s.Instructions)-1].Arg.(*mergedelete.Argument)
+		if mergeArg.AddAffectedRows {
+			c.addAffectedRows(mergeArg.AffectedRows)
+		}
 		return nil
 	case Remote:
 		defer c.fillAnalyzeInfo()
@@ -1453,7 +1456,8 @@ func (c *Compile) compilePlanScope(ctx context.Context, step int32, curNodeIdx i
 				Op: vm.MergeDelete,
 				Arg: mergedelete.NewArgument().
 					WithDelSource(arg.DeleteCtx.Source).
-					WithPartitionSources(arg.DeleteCtx.PartitionSources),
+					WithPartitionSources(arg.DeleteCtx.PartitionSources).
+					WithAddAffectedRows(arg.DeleteCtx.AddAffectedRows),
 			})
 			rs.Magic = MergeDelete
 			ss = []*Scope{rs}

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -110,7 +110,7 @@ type deleteNodeInfo struct {
 	partitionIdx    int      // The array index position of the partition expression column
 	indexTableNames []string
 	foreignTbl      []uint64
-	addAffectedRows bool
+	addAffectedRows bool // for hidden table, should not update affect Rows, e.g. delete 1 row from table t with schema like a int, b unique key, c key, affact rows should be 1 instead of 3
 	pkPos           int
 	pkTyp           plan.Type
 	lockTable       bool


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3575#issuecomment-2185753388

## What this PR does / why we need it:

make delete rowCount right