### PR TITLE
Return error when cast empty string to Decimal

### DIFF
--- a/pkg/container/types/decimal.go
+++ b/pkg/container/types/decimal.go
@@ -1487,6 +1487,9 @@ func Decimal256ToFloat64(x Decimal256, scale int32) float64 {
 }
 
 func Parse64(x string) (y Decimal64, scale int32, err error) {
+	if x == "" {
+		return 0, 0, moerr.NewInvalidInputNoCtx("can't cast empty string to Decimal64")
+	}
 	y = Decimal64(0)
 	z := Decimal64(0)
 	scale = -1
@@ -1617,6 +1620,9 @@ func Parse64(x string) (y Decimal64, scale int32, err error) {
 }
 
 func ParseDecimal64(x string, width, scale int32) (y Decimal64, err error) {
+	if x == "" {
+		return 0, moerr.NewInvalidInputNoCtx("can't cast empty string to Decimal64")
+	}
 	if width > 18 {
 		width = 18
 	}
@@ -1650,6 +1656,9 @@ func ParseDecimal64(x string, width, scale int32) (y Decimal64, err error) {
 }
 
 func ParseDecimal64FromByte(x string, width, scale int32) (y Decimal64, err error) {
+	if x == "" {
+		return 0, moerr.NewInvalidInputNoCtx("can't cast empty string to Decimal64")
+	}
 	y = 0
 	err = nil
 	n := len(x)
@@ -1667,6 +1676,9 @@ func ParseDecimal64FromByte(x string, width, scale int32) (y Decimal64, err erro
 }
 
 func Parse128(x string) (y Decimal128, scale int32, err error) {
+	if x == "" {
+		return Decimal128{0, 0}, 0, moerr.NewInvalidInputNoCtx("can't cast empty string to Decimal128")
+	}
 	var z Decimal128
 	width := 0
 	t := false
@@ -1797,6 +1809,9 @@ func Parse128(x string) (y Decimal128, scale int32, err error) {
 }
 
 func ParseDecimal128(x string, width, scale int32) (y Decimal128, err error) {
+	if x == "" {
+		return Decimal128{0, 0}, moerr.NewInvalidInputNoCtx("can't cast empty string to Decimal128")
+	}
 	if width > 38 {
 		width = 38
 	}
@@ -1836,6 +1851,9 @@ func ParseDecimal128(x string, width, scale int32) (y Decimal128, err error) {
 }
 
 func ParseDecimal128FromByte(x string, width, scale int32) (y Decimal128, err error) {
+	if x == "" {
+		return Decimal128{0, 0}, moerr.NewInvalidInputNoCtx("can't cast empty string to Decimal128")
+	}
 	y = Decimal128{0, 0}
 	err = nil
 	n := len(x)

--- a/test/distributed/cases/dtype/decimal.result
+++ b/test/distributed/cases/dtype/decimal.result
@@ -1276,6 +1276,8 @@ cast(10101010010101010101010101 as decimal(26))
 SELECT CAST('0101010' AS decimal);
 cast(0101010 as decimal(38))
 101010
+SELECT CAST('' AS decimal);
+invalid input: can't cast empty string to Decimal128
 DROP TABLE IF EXISTS decimal20;
 CREATE TABLE decimal20(v varchar(40), tt tinytext, t text, mt mediumtext, lt longtext);
 INSERT INTO decimal20 VALUES('1.01415', '2.02115', '-3.03', '444.04', '4515.05');

--- a/test/distributed/cases/dtype/decimal.test
+++ b/test/distributed/cases/dtype/decimal.test
@@ -675,6 +675,7 @@ SELECT 10.0 + CAST('aaa' AS decimal);
 SELECT CAST('101010101001' AS decimal);
 SELECT CAST('10101010010101010101010101' AS decimal(26));
 SELECT CAST('0101010' AS decimal);
+SELECT CAST('' AS decimal);
 
 DROP TABLE IF EXISTS decimal20;
 CREATE TABLE decimal20(v varchar(40), tt tinytext, t text, mt mediumtext, lt longtext);


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16869

## What this PR does / why we need it:
Return error when cast empty string to Decimal


___

### **PR Type**
Bug fix


___

### **Description**
- Added error handling for empty string inputs in various decimal parsing functions to prevent invalid conversions.
- Functions `Parse64`, `ParseDecimal64`, `ParseDecimal64FromByte`, `Parse128`, `ParseDecimal128`, and `ParseDecimal128FromByte` now return an error when the input string is empty.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>decimal.go</strong><dd><code>Add error handling for empty string inputs in decimal parsing </code><br><code>functions</code></dd></summary>
<hr>
      
pkg/container/types/decimal.go

<li>Added error handling for empty string inputs in various decimal <br>parsing functions.<br> <li> Updated <code>Parse64</code>, <code>ParseDecimal64</code>, <code>ParseDecimal64FromByte</code>, <code>Parse128</code>, <br><code>ParseDecimal128</code>, and <code>ParseDecimal128FromByte</code> to return an error when <br>the input string is empty.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17118/files#diff-8d5b2690a1f9d8ca0a5ff6c1b48195a2fb10a30db49e3f5f04e528ef2a33a463">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

