### PR TITLE
Fix ww/dup- caused by lost deletes  in rangesOnePart

### DIFF
--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -767,7 +767,7 @@ func (tbl *txnTable) rangesOnePart(
 	}
 
 	if dirtyBlks == nil {
-		tbl.collectDirtyBlocks(state, uncommittedObjects, txnOffset)
+		dirtyBlks = tbl.collectDirtyBlocks(state, uncommittedObjects, txnOffset)
 	}
 
 	// for dynamic parameter, substitute param ref and const fold cast expression here to improve performance


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16948  #16938 #16577  #16421 #15844  #14890 #14880 #14405 #14160 #16701 #15843 

## What this PR does / why we need it:
1.  Fix  dup/ww when `rangesOnePart `goes slow path, since lost deletes.