### PR TITLE
sync to 1.2: fix `Size()` duplicate counting rows size.

### DIFF
--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -700,10 +700,10 @@ var slowPathCounter atomic.Int64
 func (tbl *txnTable) rangesOnePart(
 	ctx context.Context,
 	state *logtailreplay.PartitionState, // snapshot state of this transaction
-	tableDef *plan.TableDef,             // table definition (schema)
-	exprs []*plan.Expr,                  // filter expression
-	outBlocks *objectio.BlockInfoSlice,  // output marshaled block list after filtering
-	proc *process.Process,               // process of this transaction
+	tableDef *plan.TableDef, // table definition (schema)
+	exprs []*plan.Expr, // filter expression
+	outBlocks *objectio.BlockInfoSlice, // output marshaled block list after filtering
+	proc *process.Process, // process of this transaction
 	txnOffset int,
 ) (err error) {
 	var done bool

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -15,7 +15,6 @@
 package disttae
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strconv"
@@ -204,11 +203,6 @@ func (tbl *txnTable) Rows(ctx context.Context) (uint64, error) {
 }
 
 func (tbl *txnTable) Size(ctx context.Context, columnName string) (uint64, error) {
-	var buf bytes.Buffer
-	defer func() {
-		logutil.Info("txnTable.Size", zap.String("", buf.String()))
-	}()
-
 	ts := types.TimestampToTS(tbl.db.op.SnapshotTS())
 	part, err := tbl.getPartitionState(ctx)
 	if err != nil {
@@ -231,7 +225,6 @@ func (tbl *txnTable) Size(ctx context.Context, columnName string) (uint64, error
 		return 0, moerr.NewInvalidInput(ctx, "bad input column name %v", columnName)
 	}
 
-	buf.WriteString("workspace: ")
 	deletes := make(map[types.Rowid]struct{})
 	tbl.getTxn().forEachTableWrites(
 		tbl.db.databaseId,
@@ -243,7 +236,6 @@ func (tbl *txnTable) Size(ctx context.Context, columnName string) (uint64, error
 					if _, ok := neededCols[s]; ok {
 						delta := uint64(entry.bat.Vecs[i].Size())
 						szInPart += delta
-						buf.WriteString(fmt.Sprintf("(I)%s-%d; ", s, delta))
 					}
 				}
 			} else {
@@ -261,19 +253,10 @@ func (tbl *txnTable) Size(ctx context.Context, columnName string) (uint64, error
 					vs := vector.MustFixedCol[types.Rowid](entry.bat.GetVector(0))
 					for _, v := range vs {
 						deletes[v] = struct{}{}
-						buf.WriteString(fmt.Sprintf("(D)%s; ", v.String()))
 					}
 				}
 			}
 		})
-
-	// Different rows may belong to same batch. So we have
-	// to record the batch which we have already handled to avoid
-	// repetitive computation
-	handled := make(map[*batch.Batch]struct{})
-	// Calculate the in mem size
-	// TODO: It might includ some deleted row size
-	buf.WriteString("\npartition rows: ")
 
 	iter := part.NewRowsIter(ts, nil, false)
 	defer func() { _ = iter.Close() }()
@@ -282,24 +265,15 @@ func (tbl *txnTable) Size(ctx context.Context, columnName string) (uint64, error
 		if _, ok := deletes[entry.RowID]; ok {
 			continue
 		}
-		if _, ok := handled[entry.Batch]; ok {
-			continue
-		}
+
 		for i, s := range entry.Batch.Attrs {
 			if _, ok := neededCols[s]; ok {
-				delta := uint64(entry.Batch.Vecs[i].Size())
+				delta := uint64(entry.Batch.Vecs[i].Size() / entry.Batch.Vecs[i].Length())
 				szInPart += delta
-				buf.WriteString(fmt.Sprintf("%s-%d; ", s, entry.Batch.Vecs[i].Size()))
 			}
 		}
-		handled[entry.Batch] = struct{}{}
 	}
 
-	//s := e.Stats(ctx, pb.StatsInfoKey{
-	//	DatabaseID: tbl.db.databaseId,
-	//	TableID:    tbl.tableId,
-	//}, true)
-	buf.WriteString("\nstats: ")
 	s, _ := tbl.Stats(ctx, true)
 	if s == nil {
 		return szInPart, nil
@@ -309,14 +283,13 @@ func (tbl *txnTable) Size(ctx context.Context, columnName string) (uint64, error
 		for _, z := range s.SizeMap {
 			ret += z
 		}
-		buf.WriteString(fmt.Sprintf("%d\n", ret))
 		return ret + szInPart, nil
 	}
 	sz, ok := s.SizeMap[columnName]
 	if !ok {
 		return 0, moerr.NewInvalidInput(ctx, "bad input column name %v", columnName)
 	}
-	buf.WriteString(fmt.Sprintf("%d\n", sz))
+
 	return sz + szInPart, nil
 }
 
@@ -727,10 +700,10 @@ var slowPathCounter atomic.Int64
 func (tbl *txnTable) rangesOnePart(
 	ctx context.Context,
 	state *logtailreplay.PartitionState, // snapshot state of this transaction
-	tableDef *plan.TableDef, // table definition (schema)
-	exprs []*plan.Expr, // filter expression
-	outBlocks *objectio.BlockInfoSlice, // output marshaled block list after filtering
-	proc *process.Process, // process of this transaction
+	tableDef *plan.TableDef,             // table definition (schema)
+	exprs []*plan.Expr,                  // filter expression
+	outBlocks *objectio.BlockInfoSlice,  // output marshaled block list after filtering
+	proc *process.Process,               // process of this transaction
 	txnOffset int,
 ) (err error) {
 	var done bool

--- a/test/distributed/cases/mo_cloud/mo_cloud.result
+++ b/test/distributed/cases/mo_cloud/mo_cloud.result
@@ -697,7 +697,7 @@ triggers    0    0    accountadmin
 engines    0    0    accountadmin
 routines    0    0    accountadmin
 parameters    0    0    accountadmin
-keywords    747    45171    accountadmin
+keywords    747    44820    accountadmin
 schema_privileges    0    0    accountadmin
 table_privileges    0    0    accountadmin
 column_privileges    0    0    accountadmin


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/17024

## What this PR does / why we need it:
之前统计 partition state 里面的 rows 时，使用的是 row.Batch 的地址昨晚去重的手段，绝大多数情况下没有问题，但一条记录也可能会重复推到 CN，不属于同一个 logtail, 自然也不属于同一个 batch，所以就做不到去重的目的。现在使用 rowid 去重。