### PR TITLE
fix stats for OR expression with more than 2 arguments

### DIFF
--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -1382,7 +1382,7 @@ func GetExprZoneMap(
 				}
 				zmRes := zms[args[0].AuxId]
 				for i := 1; i < len(args); i++ {
-					if res, ok = zmRes.And(zms[args[1].AuxId]); !ok {
+					if res, ok = zmRes.And(zms[args[i].AuxId]); !ok {
 						zmRes.Reset()
 						break
 					} else {
@@ -1397,7 +1397,7 @@ func GetExprZoneMap(
 				}
 				zmRes := zms[args[0].AuxId]
 				for i := 1; i < len(args); i++ {
-					if res, ok = zmRes.Or(zms[args[1].AuxId]); !ok {
+					if res, ok = zmRes.Or(zms[args[i].AuxId]); !ok {
 						zmRes.Reset()
 						break
 					} else {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -503,17 +503,26 @@ func estimateExprSelectivity(expr *plan.Expr, builder *QueryBuilder) float64 {
 		case ">", "<", ">=", "<=", "between":
 			ret = estimateNonEqualitySelectivity(expr, funcName, builder)
 		case "and":
-			sel1 := estimateExprSelectivity(exprImpl.F.Args[0], builder)
-			sel2 := estimateExprSelectivity(exprImpl.F.Args[1], builder)
-			if canMergeToBetweenAnd(exprImpl.F.Args[0], exprImpl.F.Args[1]) && (sel1+sel2) > 1 {
-				ret = sel1 + sel2 - 1
+			ret = estimateExprSelectivity(exprImpl.F.Args[0], builder)
+			if len(exprImpl.F.Args) == 2 {
+				sel2 := estimateExprSelectivity(exprImpl.F.Args[1], builder)
+				if canMergeToBetweenAnd(exprImpl.F.Args[0], exprImpl.F.Args[1]) && (ret+sel2) > 1 {
+					ret = ret + sel2 - 1
+				} else {
+					ret = andSelectivity(ret, sel2)
+				}
 			} else {
-				ret = andSelectivity(sel1, sel2)
+				for i := 1; i < len(exprImpl.F.Args); i++ {
+					sel2 := estimateExprSelectivity(exprImpl.F.Args[i], builder)
+					ret = andSelectivity(ret, sel2)
+				}
 			}
 		case "or":
-			sel1 := estimateExprSelectivity(exprImpl.F.Args[0], builder)
-			sel2 := estimateExprSelectivity(exprImpl.F.Args[1], builder)
-			ret = orSelectivity(sel1, sel2)
+			ret = estimateExprSelectivity(exprImpl.F.Args[0], builder)
+			for i := 1; i < len(exprImpl.F.Args); i++ {
+				sel2 := estimateExprSelectivity(exprImpl.F.Args[i], builder)
+				ret = orSelectivity(ret, sel2)
+			}
 		case "not":
 			ret = 1 - estimateExprSelectivity(exprImpl.F.Args[0], builder)
 		case "like":


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #16976

## What this PR does / why we need it:
some current code doesn't properly handle logical expression with more than 2 arguments


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed handling of `AND` and `OR` expressions with more than 2 arguments in `evalExpression.go`.
- Enhanced merging of filters to support `IN` operator and improved handling of composite key filters in `expr_opt.go`.
- Fixed selectivity estimation for `AND` and `OR` expressions with more than 2 arguments in `stats.go`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evalExpression.go</strong><dd><code>Fix handling of multi-argument AND/OR expressions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/colexec/evalExpression.go

<li>Fixed handling of <code>AND</code> and <code>OR</code> expressions with more than 2 arguments.<br> <li> Corrected loop index to use the current index instead of a hardcoded <br>value.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17184/files#diff-096074b4e06b58b1b2144cc4b4d91fe38b5c4ced8bfd165e7cfc66bd31aa341d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stats.go</strong><dd><code>Fix selectivity estimation for multi-argument expressions</code></dd></summary>
<hr>
      
pkg/sql/plan/stats.go

<li>Fixed selectivity estimation for <code>AND</code> and <code>OR</code> expressions with more than <br>2 arguments.<br> <li> Adjusted logic to handle multiple arguments in selectivity <br>calculations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17184/files#diff-3b3d55fa9884dcf8980f90043a05b26a04d0153ae89fcf032cec998752c0cafa">+17/-8</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expr_opt.go</strong><dd><code>Enhance filter merging and support for IN operator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/expr_opt.go

<li>Enhanced merging of filters to support <code>IN</code> operator.<br> <li> Improved handling of composite key filters.<br> <li> Added support for dynamically determining function types and IDs.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17184/files#diff-d74b004ceea0444039926cf26e70fba9951154ce59241418d3f0db00f411cabe">+26/-8</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

