### PR TITLE
[fix] remove unnecessary values from the second parameter of prefix_in (cp #17111 to 1.2)

### DIFF
--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -837,7 +837,7 @@ func getPkValueExpr(builder *QueryBuilder, ctx CompilerContext, tableDef *TableD
 			if err != nil {
 				return nil, err
 			}
-			vec.InplaceSort()
+			vec.InplaceSortAndCompact()
 			data, err := vec.MarshalBinary()
 			if err != nil {
 				return nil, err

--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -99,18 +99,44 @@ func PrefixBetween(parameters []*vector.Vector, result vector.FunctionResultWrap
 	return nil
 }
 
-func PrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int) error {
+type implPrefixIn struct {
+	ready bool
+	vals  [][]byte
+}
+
+func newImplPrefixIn() *implPrefixIn {
+	return &implPrefixIn{ready: false}
+}
+
+func (op *implPrefixIn) init(rvec *vector.Vector) {
+	op.ready = true
+	op.vals = make([][]byte, rvec.Length())
+	vlen := 0
+	rcol, rarea := vector.MustVarlenaRawData(rvec)
+	for i := 0; i < rvec.Length(); i++ {
+		rval := rcol[i].GetByteSlice(rarea)
+		if vlen == 0 || !bytes.HasPrefix(rval, op.vals[vlen-1]) {
+			op.vals[vlen] = rval
+			vlen++
+		}
+	}
+	op.vals = op.vals[:vlen]
+}
+
+func (op *implPrefixIn) doPrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	if !op.ready {
+		op.init(parameters[1])
+	}
+
 	lvec := parameters[0]
-	rvec := parameters[1]
 	res := vector.MustFixedCol[bool](result.GetResultVector())
 
 	lcol, larea := vector.MustVarlenaRawData(lvec)
-	rcol, rarea := vector.MustVarlenaRawData(rvec)
 
 	if lvec.GetSorted() {
-		rval := rcol[0].GetByteSlice(rarea)
+		rval := op.vals[0]
 		rpos := 0
-		rlen := rvec.Length()
+		rlen := len(op.vals)
 
 		for i := 0; i < length; i++ {
 			lval := lcol[i].GetByteSlice(larea)
@@ -123,7 +149,7 @@ func PrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, 
 					return nil
 				}
 
-				rval = rcol[rpos].GetByteSlice(rarea)
+				rval = op.vals[rpos]
 			}
 
 			res[i] = bytes.HasPrefix(lval, rval)
@@ -131,11 +157,11 @@ func PrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, 
 	} else {
 		for i := 0; i < length; i++ {
 			lval := lcol[i].GetByteSlice(larea)
-			rpos, _ := sort.Find(len(rcol), func(j int) int {
-				return types.PrefixCompare(lval, rcol[j].GetByteSlice(rarea))
+			rpos, _ := sort.Find(len(op.vals), func(j int) int {
+				return types.PrefixCompare(lval, op.vals[j])
 			})
 
-			res[i] = rpos < len(rcol) && bytes.HasPrefix(lval, rcol[rpos].GetByteSlice(rarea))
+			res[i] = rpos < len(op.vals) && bytes.HasPrefix(lval, op.vals[rpos])
 		}
 	}
 

--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -123,7 +123,7 @@ func (op *implPrefixIn) init(rvec *vector.Vector) {
 	op.vals = op.vals[:vlen]
 }
 
-func (op *implPrefixIn) doPrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+func (op *implPrefixIn) doPrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int) error {
 	if !op.ready {
 		op.init(parameters[1])
 	}

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -1410,7 +1410,7 @@ var supportedStringBuiltIns = []FuncNew{
 					return types.T_bool.ToType()
 				},
 				newOp: func() executeLogicOfOverload {
-					return PrefixIn
+					return newImplPrefixIn().doPrefixIn
 				},
 			},
 		},


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16964

## What this PR does / why we need it:
PrefixCompare doesn't satisfy transitivity of order. For a = '0', b = '0-catalog', c = '0-mysql', we have PrefixCompare(a, b) < 0, PrefixCompare(b, c) < 0, but PrefixCompare(a, c) = 0. If '0' and '0-catalog' co-exists in the second parameter, we remove the latter one.