### PR TITLE
change metadata cache size and policy

### DIFF
--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -89,7 +89,10 @@ func metaCacheSize() int64 {
 	if total < 32*mpool.GB {
 		return 1 * mpool.GB
 	}
-	return 2 * mpool.GB
+	if total < 48*mpool.GB {
+		return 2 * mpool.GB
+	}
+	return 4 * mpool.GB
 }
 
 func shardMetaCacheKey(key mataCacheKey) uint8 {
@@ -200,7 +203,7 @@ func LoadBFWithMeta(
 		return v, nil
 	}
 	extent := meta.BlockHeader().BFExtent()
-	bf, err := ReadBloomFilter(ctx, location.Name().String(), &extent, fileservice.SkipMemoryCache|fileservice.SkipFullFilePreloads, fs)
+	bf, err := ReadBloomFilter(ctx, location.Name().String(), &extent, fileservice.SkipFullFilePreloads, fs)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +221,7 @@ func FastLoadObjectMeta(
 	extent := location.Extent()
 	name := location.Name()
 	var metaReadPolicy fileservice.Policy
-	metaReadPolicy = fileservice.SkipMemoryCache
+	// metaReadPolicy = fileservice.SkipMemoryCache
 	metaReadPolicy |= fileservice.SkipFullFilePreloads
 	return LoadObjectMetaByExtent(ctx, &name, &extent, prefetch, metaReadPolicy, fs)
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3526

## What this PR does / why we need it:

Change metadata cache size:
Change the max size for a host with a high memory capacity from 2g to 4g.

Change the metadata cache policy:
Read from disk cache -> Read from memory cache


___

### **PR Type**
Enhancement


___

### **Description**
- Increased metadata cache size for hosts with high memory capacity from 2GB to 4GB.
- Adjusted cache size thresholds to better utilize available memory.
- Changed metadata cache policy to prioritize reading from memory cache over disk cache.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Update metadata cache size and policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/objectio/cache.go

<li>Increased metadata cache size for high memory capacity hosts from 2GB <br>to 4GB.<br> <li> Adjusted cache size thresholds for different memory capacities.<br> <li> Modified metadata cache policy to prioritize reading from memory cache <br>over disk cache.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17187/files#diff-52fcef3b7679892e22f8b7dceac1470fb5bbe77090833eafc9b2136d9560ccdc">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

