### PR TITLE
Fix force merge big data bug&objectIO add object size limit

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -275,6 +275,9 @@ const (
 	ErrKeyAlreadyExists uint16 = 21001
 	ErrArenaFull        uint16 = 21002
 
+	// Group 11: The error code that rarely appears
+	ErrTooLargeObjectSize uint16 = 22001
+
 	// ErrEnd, the max value of MOErrorCode
 	ErrEnd uint16 = 65535
 )
@@ -494,6 +497,9 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	// Group 10: skip list
 	ErrKeyAlreadyExists: {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "record with this key already exists"},
 	ErrArenaFull:        {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "allocation failed because arena is full"},
+
+	// Group 11: The error code that rarely appears
+	ErrTooLargeObjectSize: {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "objectio: too large object size %d"},
 
 	// Group End: max value of MOErrorCode
 	ErrEnd: {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "internal error: end of errcode code"},

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -375,6 +375,10 @@ func NewKeyAlreadyExistsNoCtx() *Error {
 	return newError(Context(), ErrKeyAlreadyExists)
 }
 
+func NewErrTooLargeObjectSizeNoCtx(option uint64) *Error {
+	return newError(Context(), ErrTooLargeObjectSize, option)
+}
+
 func NewArenaFullNoCtx() *Error {
 	return newError(Context(), ErrArenaFull)
 }

--- a/pkg/objectio/writer.go
+++ b/pkg/objectio/writer.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"go.uber.org/zap"
 	"math"
 	"sync"
@@ -70,6 +71,10 @@ const (
 	WriterGC
 	WriterETL
 )
+
+const ObjectSizeLimit = 3 * mpool.GB
+
+var ErrObjectSizeLimit = moerr.NewInternalErrorNoCtx("objectio: object size exceeds the limit")
 
 func newObjectWriterSpecialV1(wt WriterType, fileName string, fs fileservice.FileService) (*objectWriterV1, error) {
 	var name ObjectName
@@ -390,16 +395,25 @@ func (w *objectWriterV1) getMaxIndex(blocks []blockData) uint16 {
 	return uint16(maxIndex)
 }
 
-func (w *objectWriterV1) writerBlocks(blocks []blockData) {
+// writerBlocks writes blocks to object file
+// If the compressed data exceeds 3G,
+// an error of limited writing is returned
+func (w *objectWriterV1) writerBlocks(blocks []blockData) error {
 	maxIndex := w.getMaxIndex(blocks)
+	size := uint64(0)
 	for idx := uint16(0); idx < maxIndex; idx++ {
 		for _, block := range blocks {
 			if block.meta.BlockHeader().ColumnCount() <= idx {
 				continue
 			}
 			w.buffer.Write(block.data[idx])
+			size += uint64(len(block.data[idx]))
+			if size > ObjectSizeLimit {
+				return ErrObjectSizeLimit
+			}
 		}
 	}
+	return nil
 }
 
 func (w *objectWriterV1) WriteEnd(ctx context.Context, items ...WriteOptions) ([]BlockObject, error) {
@@ -498,7 +512,10 @@ func (w *objectWriterV1) WriteEnd(ctx context.Context, items ...WriteOptions) ([
 
 	// writer data
 	for i := range w.blocks {
-		w.writerBlocks(w.blocks[i])
+		err = w.writerBlocks(w.blocks[i])
+		if err != nil {
+			return nil, err
+		}
 	}
 	// writer bloom filter
 	for i := range bloomFilterDatas {

--- a/pkg/objectio/writer.go
+++ b/pkg/objectio/writer.go
@@ -74,8 +74,6 @@ const (
 
 const ObjectSizeLimit = 3 * mpool.GB
 
-var ErrObjectSizeLimit = moerr.NewInternalErrorNoCtx("objectio: object size exceeds the limit")
-
 func newObjectWriterSpecialV1(wt WriterType, fileName string, fs fileservice.FileService) (*objectWriterV1, error) {
 	var name ObjectName
 	object := NewObject(fileName, fs)
@@ -408,10 +406,10 @@ func (w *objectWriterV1) writerBlocks(blocks []blockData) error {
 			}
 			w.buffer.Write(block.data[idx])
 			size += uint64(len(block.data[idx]))
-			if size > ObjectSizeLimit {
-				return ErrObjectSizeLimit
-			}
 		}
+	}
+	if size > ObjectSizeLimit {
+		return moerr.NewErrTooLargeObjectSizeNoCtx(size)
 	}
 	return nil
 }

--- a/pkg/vm/engine/disttae/merge.go
+++ b/pkg/vm/engine/disttae/merge.go
@@ -200,10 +200,10 @@ func (t *cnMergeTask) GetMPool() *mpool.MPool {
 
 func (t *cnMergeTask) HostHintName() string { return "CN" }
 
-func (t *cnMergeTask) GetTotalSize() uint32 {
-	totalSize := uint32(0)
+func (t *cnMergeTask) GetTotalSize() uint64 {
+	totalSize := uint64(0)
 	for _, obj := range t.targets {
-		totalSize += obj.OriginSize()
+		totalSize += uint64(obj.OriginSize())
 	}
 	return totalSize
 }

--- a/pkg/vm/engine/tae/mergesort/reshaper.go
+++ b/pkg/vm/engine/tae/mergesort/reshaper.go
@@ -33,10 +33,10 @@ func reshape(ctx context.Context, host MergeTaskHost) error {
 		}
 		initTransferMapping(host.GetCommitEntry(), totalBlkCnt)
 	}
-
+	rowSizeU64 := host.GetTotalSize() / uint64(host.GetTotalRowCnt())
 	stats := mergeStats{
 		totalRowCnt:   host.GetTotalRowCnt(),
-		rowSize:       host.GetTotalSize() / host.GetTotalRowCnt(),
+		rowSize:       uint32(rowSizeU64),
 		targetObjSize: host.GetTargetObjSize(),
 		blkPerObj:     host.GetObjectMaxBlocks(),
 	}

--- a/pkg/vm/engine/tae/mergesort/task.go
+++ b/pkg/vm/engine/tae/mergesort/task.go
@@ -53,7 +53,7 @@ type MergeTaskHost interface {
 	GetAccBlkCnts() []int
 	GetSortKeyType() types.Type
 	LoadNextBatch(ctx context.Context, objIdx uint32) (*batch.Batch, *nulls.Nulls, func(), error)
-	GetTotalSize() uint32
+	GetTotalSize() uint64 // total size of all objects, definitely there are cases where the size exceeds 4G, so use uint64
 	GetTotalRowCnt() uint32
 	GetBlockMaxRows() uint32
 	GetObjectMaxBlocks() uint16

--- a/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
@@ -368,10 +368,10 @@ func HandleMergeEntryInTxn(txn txnif.AsyncTxn, entry *api.MergeCommitEntry, rt *
 	return createdObjs, nil
 }
 
-func (task *mergeObjectsTask) GetTotalSize() uint32 {
-	totalSize := uint32(0)
+func (task *mergeObjectsTask) GetTotalSize() uint64 {
+	totalSize := uint64(0)
 	for _, obj := range task.mergedObjs {
-		totalSize += uint32(obj.GetOriginSize())
+		totalSize += uint64(obj.GetOriginSize())
 	}
 	return totalSize
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17188

## What this PR does / why we need it:
objectIO write add object size limit.
If the compressed data exceeds 3G, an error of limited writing is returned