### PR TITLE
fix a bug that should not use index when right child's selectivity is too high

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -888,6 +888,10 @@ func (builder *QueryBuilder) applyIndicesForJoins(nodeID int32, node *plan.Node,
 
 	rightChild := builder.qry.Nodes[node.Children[1]]
 
+	if rightChild.Stats.Selectivity > 0.5 {
+		return nodeID
+	}
+
 	if rightChild.Stats.Outcnt > float64(GetInFilterCardLimitOnPK(leftChild.Stats.TableCnt)) || rightChild.Stats.Outcnt > leftChild.Stats.Cost*0.1 {
 		return nodeID
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3194

## What this PR does / why we need it:
fix a bug that should not use index when right child's selectivity is too high