### PR TITLE
fix: test

### DIFF
--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -41,7 +41,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/anti"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec/connector"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/deletion"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/dispatch"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/external"
@@ -421,7 +420,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.Offset = t.Offset
 		arg.Configs = t.Configs
 		res.Arg = arg
-	case vm.Connector:
+		/* 	case vm.Connector:
 		ok := false
 		if regMap != nil {
 			arg := connector.NewArgument()
@@ -430,7 +429,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 				panic("nonexistent wait register")
 			}
 			res.Arg = arg
-		}
+		} */
 	case vm.Shuffle:
 		sourceArg := sourceIns.Arg.(*shuffle.Argument)
 		arg := shuffle.NewArgument()
@@ -443,7 +442,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.ShuffleRangeUint64 = sourceArg.ShuffleRangeUint64
 		arg.RuntimeFilterSpec = plan2.DeepCopyRuntimeFilterSpec(sourceArg.RuntimeFilterSpec)
 		res.Arg = arg
-	case vm.Dispatch:
+		/* 	case vm.Dispatch:
 		ok := false
 		if regMap != nil {
 			sourceArg := sourceIns.Arg.(*dispatch.Argument)
@@ -463,7 +462,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 				arg.RemoteRegs[j] = sourceArg.RemoteRegs[j]
 			}
 			res.Arg = arg
-		}
+		} */
 	case vm.Insert:
 		t := sourceIns.Arg.(*insert.Argument)
 		arg := insert.NewArgument()

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -1079,6 +1079,9 @@ func newParallelScope(c *Compile, s *Scope, ss []*Scope) (*Scope, error) {
 			}
 			arg.Release()
 		case vm.Output:
+		case vm.Connector:
+		case vm.Dispatch:
+			continue
 		default:
 			for j := range ss {
 				ss[j].appendInstruction(dupInstruction(&in, nil, j))
@@ -1086,12 +1089,12 @@ func newParallelScope(c *Compile, s *Scope, ss []*Scope) (*Scope, error) {
 		}
 	}
 	if !flg {
-		for i := range ss {
+		/* 		for i := range ss {
 			if arg := ss[i].Instructions[len(ss[i].Instructions)-1].Arg; arg != nil {
 				arg.Release()
 			}
 			ss[i].Instructions = ss[i].Instructions[:len(ss[i].Instructions)-1]
-		}
+		} */
 		if arg := s.Instructions[0].Arg; arg != nil {
 			arg.Release()
 		}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Commented out unused `vm.Connector` and `vm.Dispatch` cases in `dupInstruction` function in `operator.go`.
- Added cases for `vm.Connector` and `vm.Dispatch` in `newParallelScope` function in `scope.go`.
- Commented out code that releases arguments for scopes in `newParallelScope` function in `scope.go`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator.go</strong><dd><code>Comment out unused vm.Connector and vm.Dispatch cases</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/operator.go

<li>Removed import of <code>connector</code> package.<br> <li> Commented out code related to <code>vm.Connector</code> and <code>vm.Dispatch</code> cases in <br><code>dupInstruction</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17212/files#diff-24c2df3f5c8c484aab6845aa35e6426ba672758aea5c19bb680c08eadec260ee">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scope.go</strong><dd><code>Add and comment out cases in newParallelScope function</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/compile/scope.go

<li>Added cases for <code>vm.Connector</code> and <code>vm.Dispatch</code> in <code>newParallelScope</code> <br>function.<br> <li> Commented out code that releases arguments for scopes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17212/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

