### PR TITLE
fix: scope.instruction as tree

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -2600,14 +2600,14 @@ func (c *Compile) compileShuffleJoin(node, left, right *plan.Node, lefts, rights
 			rootOp.GetOperatorBase().SetChildren(nil)
 			lastOperator = append(lastOperator, rootOp)
 		}
-	}
 
-	defer func() {
-		// recovery the children's last operator
-		for i := range children {
-			children[i].appendOperator(lastOperator[i])
-		}
-	}()
+		defer func() {
+			// recovery the children's last operator
+			for i := range children {
+				children[i].appendOperator(lastOperator[i])
+			}
+		}()
+	}
 
 	switch node.JoinType {
 	case plan.Node_INNER:

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -401,7 +401,7 @@ func (c *Compile) run(s *Scope) error {
 		if err != nil {
 			return err
 		}
-		mergeArg := s.Instructions[len(s.Instructions)-1].Arg.(*mergedelete.Argument)
+		mergeArg := s.RootOp.(*mergedelete.Argument)
 		if mergeArg.AddAffectedRows {
 			c.addAffectedRows(mergeArg.AffectedRows)
 		}
@@ -1480,12 +1480,11 @@ func (c *Compile) compilePlanScope(step int32, curNodeIdx int32, ns []*plan.Node
 		c.setAnalyzeCurrent(ss, curr)
 
 		rs := c.newMergeScope(ss)
-		rs.Instructions[0].Arg.Release()
-		rs.Instructions[0] = vm.Instruction{
-			Op:  vm.OnDuplicateKey,
-			Idx: c.anal.curr,
-			Arg: constructOnduplicateKey(n, c.e),
-		}
+		arg := constructOnduplicateKey(n, c.e)
+		arg.SetOpType(vm.OnDuplicateKey)
+		arg.SetIdx(c.anal.curr)
+		rs.ReplaceLeafOp(arg)
+
 		ss = []*Scope{rs}
 		return ss, nil
 	case plan.Node_FUZZY_FILTER:
@@ -1604,7 +1603,7 @@ func (c *Compile) compilePlanScope(step int32, curNodeIdx int32, ns []*plan.Node
 				regs := make([]*process.WaitRegister, 0, parallelSize)
 				for i := 0; i < parallelSize; i++ {
 					s := newScope(Merge)
-					s.Instructions = []vm.Instruction{{Op: vm.Merge, Arg: merge.NewArgument()}}
+					s.appendInstruction(vm.Instruction{Op: vm.Merge, Arg: merge.NewArgument()})
 					scopes = append(scopes, s)
 					scopes[i].Proc = process.NewFromProc(c.proc, c.proc.Ctx, 1)
 					if c.anal.qry.LoadTag {
@@ -1720,21 +1719,15 @@ func (c *Compile) compilePlanScope(step int32, curNodeIdx int32, ns []*plan.Node
 				return nil, err
 			}
 			lockOpArg.SetBlock(block)
+			lockOpArg.Op = vm.LockOp
+			lockOpArg.Idx = c.anal.curr
+			lockOpArg.IsFirst = currentFirstFlag
 			if block {
-				ss[i].Instructions[len(ss[i].Instructions)-1].Arg.Release()
-				ss[i].Instructions[len(ss[i].Instructions)-1] = vm.Instruction{
-					Op:      vm.LockOp,
-					Idx:     c.anal.curr,
-					IsFirst: currentFirstFlag,
-					Arg:     lockOpArg,
-				}
+				lockOpArg.SetChildren(ss[i].RootOp.GetOperatorBase().Children)
+				ss[i].RootOp.Release()
+				ss[i].RootOp = lockOpArg
 			} else {
-				ss[i].appendInstruction(vm.Instruction{
-					Op:      vm.LockOp,
-					Idx:     c.anal.curr,
-					IsFirst: currentFirstFlag,
-					Arg:     lockOpArg,
-				})
+				ss[i].appendOperator(lockOpArg)
 			}
 		}
 		ss = c.compileProjection(n, ss)
@@ -1761,7 +1754,7 @@ func (c *Compile) compilePlanScope(step int32, curNodeIdx int32, ns []*plan.Node
 		rs := newScope(Merge)
 		rs.NodeInfo = getEngineNode(c)
 		rs.Proc = process.NewFromProc(c.proc, c.proc.Ctx, 1)
-		rs.Instructions = []vm.Instruction{{Op: vm.Merge, Arg: merge.NewArgument().WithSinkScan(true)}}
+		rs.appendInstruction(vm.Instruction{Op: vm.Merge, Arg: merge.NewArgument().WithSinkScan(true)})
 		for _, r := range receivers {
 			r.Ctx = rs.Proc.Ctx
 		}
@@ -1779,7 +1772,7 @@ func (c *Compile) compilePlanScope(step int32, curNodeIdx int32, ns []*plan.Node
 		rs := newScope(Merge)
 		rs.NodeInfo = engine.Node{Addr: c.addr, Mcpu: 1}
 		rs.Proc = process.NewFromProc(c.proc, c.proc.Ctx, len(receivers))
-		rs.Instructions = []vm.Instruction{{Op: vm.MergeRecursive, Arg: mergerecursive.NewArgument()}}
+		rs.appendInstruction(vm.Instruction{Op: vm.MergeRecursive, Arg: mergerecursive.NewArgument()})
 
 		for _, r := range receivers {
 			r.Ctx = rs.Proc.Ctx
@@ -1798,7 +1791,7 @@ func (c *Compile) compilePlanScope(step int32, curNodeIdx int32, ns []*plan.Node
 		rs := newScope(Merge)
 		rs.NodeInfo = getEngineNode(c)
 		rs.Proc = process.NewFromProc(c.proc, c.proc.Ctx, len(receivers))
-		rs.Instructions = []vm.Instruction{{Op: vm.MergeCTE, Arg: mergecte.NewArgument()}}
+		rs.appendInstruction(vm.Instruction{Op: vm.MergeCTE, Arg: mergecte.NewArgument()})
 
 		for _, r := range receivers {
 			r.Ctx = rs.Proc.Ctx
@@ -2434,7 +2427,7 @@ func (c *Compile) compileTPUnion(n *plan.Node, ss []*Scope, children []*Scope) [
 		gn.GroupBy[i] = plan2.DeepCopyExpr(n.ProjectList[i])
 		gn.GroupBy[i].Typ.NotNullable = false
 	}
-	rs[0].Instructions = append(rs[0].Instructions, vm.Instruction{
+	rs[0].appendInstruction(vm.Instruction{
 		Op:  vm.Group,
 		Idx: c.anal.curr,
 		Arg: constructGroup(c.proc.Ctx, gn, n, true, 0, c.proc),
@@ -2498,26 +2491,20 @@ func (c *Compile) compileTpMinusAndIntersect(n *plan.Node, left []*Scope, right 
 	})
 	switch nodeType {
 	case plan.Node_MINUS:
-		rs[0].Instructions[0].Arg.Release()
-		rs[0].Instructions[0] = vm.Instruction{
-			Op:  vm.Minus,
-			Idx: c.anal.curr,
-			Arg: minus.NewArgument(),
-		}
+		arg := minus.NewArgument()
+		arg.Op = vm.Minus
+		arg.Idx = c.anal.curr
+		rs[0].ReplaceLeafOp(arg)
 	case plan.Node_INTERSECT:
-		rs[0].Instructions[0].Arg.Release()
-		rs[0].Instructions[0] = vm.Instruction{
-			Op:  vm.Intersect,
-			Idx: c.anal.curr,
-			Arg: intersect.NewArgument(),
-		}
+		arg := intersect.NewArgument()
+		arg.Op = vm.Intersect
+		arg.Idx = c.anal.curr
+		rs[0].ReplaceLeafOp(arg)
 	case plan.Node_INTERSECT_ALL:
-		rs[0].Instructions[0].Arg.Release()
-		rs[0].Instructions[0] = vm.Instruction{
-			Op:  vm.IntersectAll,
-			Idx: c.anal.curr,
-			Arg: intersectall.NewArgument(),
-		}
+		arg := intersectall.NewArgument()
+		arg.Op = vm.IntersectAll
+		arg.Idx = c.anal.curr
+		rs[0].ReplaceLeafOp(arg)
 	}
 	return rs
 }
@@ -2531,30 +2518,24 @@ func (c *Compile) compileMinusAndIntersect(n *plan.Node, left []*Scope, right []
 	switch nodeType {
 	case plan.Node_MINUS:
 		for i := range rs {
-			rs[i].Instructions[0].Arg.Release()
-			rs[i].Instructions[0] = vm.Instruction{
-				Op:  vm.Minus,
-				Idx: c.anal.curr,
-				Arg: minus.NewArgument(),
-			}
+			arg := minus.NewArgument()
+			arg.Op = vm.Minus
+			arg.Idx = c.anal.curr
+			rs[i].ReplaceLeafOp(arg)
 		}
 	case plan.Node_INTERSECT:
 		for i := range rs {
-			rs[i].Instructions[0].Arg.Release()
-			rs[i].Instructions[0] = vm.Instruction{
-				Op:  vm.Intersect,
-				Idx: c.anal.curr,
-				Arg: intersect.NewArgument(),
-			}
+			arg := intersect.NewArgument()
+			arg.Op = vm.Intersect
+			arg.Idx = c.anal.curr
+			rs[i].ReplaceLeafOp(arg)
 		}
 	case plan.Node_INTERSECT_ALL:
 		for i := range rs {
-			rs[i].Instructions[0].Arg.Release()
-			rs[i].Instructions[0] = vm.Instruction{
-				Op:  vm.IntersectAll,
-				Idx: c.anal.curr,
-				Arg: intersectall.NewArgument(),
-			}
+			arg := intersectall.NewArgument()
+			arg.Op = vm.IntersectAll
+			arg.Idx = c.anal.curr
+			rs[i].ReplaceLeafOp(arg)
 		}
 	}
 	return rs
@@ -2562,7 +2543,7 @@ func (c *Compile) compileMinusAndIntersect(n *plan.Node, left []*Scope, right []
 
 func (c *Compile) compileUnionAll(ss []*Scope, children []*Scope) []*Scope {
 	rs := c.newMergeScope(append(ss, children...))
-	rs.Instructions[0].Idx = c.anal.curr
+	vm.GetLeafOp(rs.RootOp).GetOperatorBase().SetIdx(c.anal.curr)
 	return []*Scope{rs}
 }
 
@@ -2573,7 +2554,7 @@ func (c *Compile) compileJoin(node, left, right *plan.Node, ns []*plan.Node, pro
 	rs := c.compileBroadcastJoin(node, left, right, ns, probeScopes, buildScopes)
 	if c.IsTpQuery() {
 		//construct join build operator for tp join
-		buildScopes[0].appendInstruction(constructJoinBuildInstruction(c, rs[0].Instructions[0], false, false))
+		buildScopes[0].appendInstruction(constructJoinBuildOperator(c, vm.GetLeafOp(rs[0].RootOp), false, false))
 		rs[0].Proc.Reg.MergeReceivers[1] = &process.WaitRegister{
 			Ctx: rs[0].Proc.Ctx,
 			Ch:  make(chan *process.RegisterMessage, 1),
@@ -2606,19 +2587,26 @@ func (c *Compile) compileShuffleJoin(node, left, right *plan.Node, lefts, rights
 	}
 
 	parent, children := c.newShuffleJoinScopeList(lefts, rights, node)
-	if parent != nil {
-		lastOperator := make([]vm.Instruction, 0, len(children))
-		for i := range children {
-			ilen := len(children[i].Instructions) - 1
-			lastOperator = append(lastOperator, children[i].Instructions[ilen])
-			children[i].Instructions = children[i].Instructions[:ilen]
-		}
 
-		defer func() {
-			// recovery the children's last operator
-			for i := range children {
-				children[i].appendInstruction(lastOperator[i])
+	lastOperator := make([]vm.Operator, 0, len(children))
+	if parent != nil {
+		for i := range children {
+			rootOp := children[i].RootOp
+			if rootOp.GetOperatorBase().NumChildren() == 0 {
+				children[i].RootOp = nil
+			} else {
+				children[i].RootOp = rootOp.GetOperatorBase().GetChildren(0)
 			}
+			rootOp.GetOperatorBase().SetChildren(nil)
+			lastOperator = append(lastOperator, rootOp)
+		}
+	}
+
+	defer func() {
+		// recovery the children's last operator
+		for i := range children {
+			children[i].appendOperator(lastOperator[i])
+		}
 		}()
 	}
 
@@ -2924,12 +2912,11 @@ func (c *Compile) compilePartition(n *plan.Node, ss []*Scope) []*Scope {
 	c.anal.isFirst = false
 
 	rs := c.newMergeScope(ss)
-	rs.Instructions[0].Arg.Release()
-	rs.Instructions[0] = vm.Instruction{
-		Op:  vm.Partition,
-		Idx: c.anal.curr,
-		Arg: constructPartition(n),
-	}
+
+	arg := constructPartition(n)
+	arg.Op = vm.Partition
+	arg.Idx = c.anal.curr
+	rs.ReplaceLeafOp(arg)
 	return []*Scope{rs}
 }
 
@@ -2987,13 +2974,24 @@ func (c *Compile) compileSort(n *plan.Node, ss []*Scope) []*Scope {
 	}
 }
 
-func containBrokenNode(s *Scope) bool {
-	for i := range s.Instructions {
-		if s.Instructions[i].IsBrokenNode() {
+func containBrokenNode2(op vm.Operator) bool {
+	if op.GetOperatorBase().IsBrokenNode() {
+		return true
+	}
+	numChildren := op.GetOperatorBase().NumChildren()
+	if numChildren == 0 {
+		return false
+	}
+	for i := 0; i < numChildren; i++ {
+		if res := containBrokenNode2(op.GetOperatorBase().GetChildren(i)); res {
 			return true
 		}
 	}
 	return false
+}
+
+func containBrokenNode(s *Scope) bool {
+	return containBrokenNode2(s.RootOp)
 }
 
 func (c *Compile) compileTop(n *plan.Node, topN *plan.Expr, ss []*Scope) []*Scope {
@@ -3024,12 +3022,10 @@ func (c *Compile) compileTop(n *plan.Node, topN *plan.Expr, ss []*Scope) []*Scop
 	c.anal.isFirst = false
 
 	rs := c.newMergeScope(ss)
-	rs.Instructions[0].Arg.Release()
-	rs.Instructions[0] = vm.Instruction{
-		Op:  vm.MergeTop,
-		Idx: c.anal.curr,
-		Arg: constructMergeTop(n, topN),
-	}
+	arg := constructMergeTop(n, topN)
+	arg.Op = vm.MergeTop
+	arg.Idx = c.anal.curr
+	rs.ReplaceLeafOp(arg)
 	return []*Scope{rs}
 }
 
@@ -3074,34 +3070,31 @@ func (c *Compile) compileOrder(n *plan.Node, ss []*Scope) []*Scope {
 
 func (c *Compile) compileWin(n *plan.Node, ss []*Scope) []*Scope {
 	rs := c.newMergeScope(ss)
-	rs.Instructions[0].Arg.Release()
-	rs.Instructions[0] = vm.Instruction{
-		Op:  vm.Window,
-		Idx: c.anal.curr,
-		Arg: constructWindow(c.proc.Ctx, n, c.proc),
-	}
+	arg := constructWindow(c.proc.Ctx, n, c.proc)
+	arg.Op = vm.Window
+	arg.Idx = c.anal.curr
+	rs.ReplaceLeafOp(arg)
+
 	return []*Scope{rs}
 }
 
 func (c *Compile) compileTimeWin(n *plan.Node, ss []*Scope) []*Scope {
 	rs := c.newMergeScope(ss)
-	rs.Instructions[0].Arg.Release()
-	rs.Instructions[0] = vm.Instruction{
-		Op:  vm.TimeWin,
-		Idx: c.anal.curr,
-		Arg: constructTimeWindow(c.proc.Ctx, n),
-	}
+	arg := constructTimeWindow(c.proc.Ctx, n)
+	arg.Op = vm.TimeWin
+	arg.Idx = c.anal.curr
+	rs.ReplaceLeafOp(arg)
+
 	return []*Scope{rs}
 }
 
 func (c *Compile) compileFill(n *plan.Node, ss []*Scope) []*Scope {
 	rs := c.newMergeScope(ss)
-	rs.Instructions[0].Arg.Release()
-	rs.Instructions[0] = vm.Instruction{
-		Op:  vm.Fill,
-		Idx: c.anal.curr,
-		Arg: constructFill(n),
-	}
+	arg := constructFill(n)
+	arg.Op = vm.Fill
+	arg.Idx = c.anal.curr
+	rs.ReplaceLeafOp(arg)
+
 	return []*Scope{rs}
 }
 
@@ -3125,12 +3118,11 @@ func (c *Compile) compileOffset(n *plan.Node, ss []*Scope) []*Scope {
 	}
 
 	rs := c.newMergeScope(ss)
-	rs.Instructions[0].Arg.Release()
-	rs.Instructions[0] = vm.Instruction{
-		Op:  vm.MergeOffset,
-		Idx: c.anal.curr,
-		Arg: constructMergeOffset(n),
-	}
+	arg := constructMergeOffset(n)
+	arg.Op = vm.MergeOffset
+	arg.Idx = c.anal.curr
+	rs.ReplaceLeafOp(arg)
+
 	return []*Scope{rs}
 }
 
@@ -3161,12 +3153,11 @@ func (c *Compile) compileLimit(n *plan.Node, ss []*Scope) []*Scope {
 	c.anal.isFirst = false
 
 	rs := c.newMergeScope(ss)
-	rs.Instructions[0].Arg.Release()
-	rs.Instructions[0] = vm.Instruction{
-		Op:  vm.MergeLimit,
-		Idx: c.anal.curr,
-		Arg: constructMergeLimit(n),
-	}
+	arg := constructMergeLimit(n)
+	arg.Op = vm.MergeLimit
+	arg.Idx = c.anal.curr
+	rs.ReplaceLeafOp(arg)
+
 	return []*Scope{rs}
 }
 
@@ -3183,7 +3174,7 @@ func (c *Compile) compileFuzzyFilter(n *plan.Node, ns []*plan.Node, left []*Scop
 	all := []*Scope{l, r}
 	rs := c.newMergeScope(all)
 
-	rs.Instructions[0].Idx = c.anal.curr
+	vm.GetLeafOp(rs.RootOp).GetOperatorBase().SetIdx(c.anal.curr)
 
 	arg := constructFuzzyFilter(n, ns[n.Children[0]], ns[n.Children[1]])
 
@@ -3295,12 +3286,11 @@ func (c *Compile) compileMergeGroup(n *plan.Node, ss []*Scope, ns []*plan.Node, 
 			ss[0].PartialResults = nil
 			ss[0].PartialResultTypes = nil
 		}
-		rs.Instructions[0].Arg.Release()
-		rs.Instructions[0] = vm.Instruction{
-			Op:  vm.MergeGroup,
-			Idx: c.anal.curr,
-			Arg: arg,
-		}
+
+		arg.Op = vm.MergeGroup
+		arg.Idx = c.anal.curr
+		rs.ReplaceLeafOp(arg)
+
 		return []*Scope{rs}
 	}
 
@@ -3326,12 +3316,10 @@ func (c *Compile) compileMergeGroup(n *plan.Node, ss []*Scope, ns []*plan.Node, 
 		ss[0].PartialResults = nil
 		ss[0].PartialResultTypes = nil
 	}
-	rs.Instructions[0].Arg.Release()
-	rs.Instructions[0] = vm.Instruction{
-		Op:  vm.MergeGroup,
-		Idx: c.anal.curr,
-		Arg: arg,
-	}
+	arg.Op = vm.MergeGroup
+	arg.Idx = c.anal.curr
+	rs.ReplaceLeafOp(arg)
+
 	return []*Scope{rs}
 }
 
@@ -3386,11 +3374,16 @@ func (c *Compile) compileShuffleGroup(n *plan.Node, ss []*Scope, ns []*plan.Node
 		parent, children := c.newScopeListForShuffleGroup(1)
 		// saving the last operator of all children to make sure the connector setting in
 		// the right place
-		lastOperator := make([]vm.Instruction, 0, len(children))
+		lastOperator := make([]vm.Operator, 0, len(children))
 		for i := range children {
-			ilen := len(children[i].Instructions) - 1
-			lastOperator = append(lastOperator, children[i].Instructions[ilen])
-			children[i].Instructions = children[i].Instructions[:ilen]
+			rootOp := children[i].RootOp
+			if rootOp.GetOperatorBase().NumChildren() == 0 {
+				children[i].RootOp = nil
+			} else {
+				children[i].RootOp = rootOp.GetOperatorBase().GetChildren(0)
+			}
+			rootOp.GetOperatorBase().SetChildren(nil)
+			lastOperator = append(lastOperator, rootOp)
 		}
 
 		for i := range children {
@@ -3404,7 +3397,7 @@ func (c *Compile) compileShuffleGroup(n *plan.Node, ss []*Scope, ns []*plan.Node
 		children = c.compileProjection(n, c.compileRestrict(n, children))
 		// recovery the children's last operator
 		for i := range children {
-			children[i].appendInstruction(lastOperator[i])
+			children[i].appendOperator(lastOperator[i])
 		}
 
 		for i := range ss {
@@ -3440,11 +3433,16 @@ func (c *Compile) compileShuffleGroup(n *plan.Node, ss []*Scope, ns []*plan.Node
 
 		// saving the last operator of all children to make sure the connector setting in
 		// the right place
-		lastOperator := make([]vm.Instruction, 0, len(children))
+		lastOperator := make([]vm.Operator, 0, len(children))
 		for i := range children {
-			ilen := len(children[i].Instructions) - 1
-			lastOperator = append(lastOperator, children[i].Instructions[ilen])
-			children[i].Instructions = children[i].Instructions[:ilen]
+			rootOp := children[i].RootOp
+			if rootOp.GetOperatorBase().NumChildren() == 0 {
+				children[i].RootOp = nil
+			} else {
+				children[i].RootOp = rootOp.GetOperatorBase().GetChildren(0)
+			}
+			rootOp.GetOperatorBase().SetChildren(nil)
+			lastOperator = append(lastOperator, rootOp)
 		}
 
 		for i := range children {
@@ -3458,7 +3456,7 @@ func (c *Compile) compileShuffleGroup(n *plan.Node, ss []*Scope, ns []*plan.Node
 		children = c.compileProjection(n, c.compileRestrict(n, children))
 		// recovery the children's last operator
 		for i := range children {
-			children[i].appendInstruction(lastOperator[i])
+			children[i].appendOperator(lastOperator[i])
 		}
 
 		for i := range ss {
@@ -3511,10 +3509,8 @@ func (c *Compile) newDeleteMergeScope(arg *deletion.Argument, ss []*Scope) *Scop
 	for i := 0; i < len(ss2); i++ {
 		constructDeleteDispatchAndLocal(i, rs, ss2, uuids, c)
 	}
-	delete := &vm.Instruction{
-		Op:  vm.Deletion,
-		Arg: arg,
-	}
+
+	arg.Op = vm.Deletion
 	for i := range rs {
 		// use distributed delete
 		arg.RemoteDelete = true
@@ -3522,7 +3518,7 @@ func (c *Compile) newDeleteMergeScope(arg *deletion.Argument, ss []*Scope) *Scop
 		arg.SegmentMap = colexec.Get().GetCnSegmentMap()
 		arg.IBucket = uint32(i)
 		arg.Nbucket = uint32(len(rs))
-		rs[i].appendInstruction(dupInstruction(delete, nil, 0))
+		rs[i].appendInstruction(dupInstruction(arg, nil, 0))
 	}
 	return c.newMergeScope(rs)
 }
@@ -3846,7 +3842,7 @@ func (c *Compile) newJoinProbeScope(s *Scope, ss []*Scope) *Scope {
 	rs := newScope(Merge)
 	rs.appendInstruction(vm.Instruction{
 		Op:      vm.Merge,
-		Idx:     s.Instructions[0].Idx,
+		Idx:     vm.GetLeafOp(s.RootOp).GetOperatorBase().GetIdx(),
 		IsFirst: true,
 		Arg:     merge.NewArgument(),
 	})
@@ -3891,7 +3887,7 @@ func (c *Compile) newJoinBuildScope(s *Scope, ss []*Scope) *Scope {
 		IsFirst: c.anal.isFirst,
 		Arg:     merge.NewArgument(),
 	})
-	rs.appendInstruction(constructJoinBuildInstruction(c, s.Instructions[0], ss != nil, s.ShuffleCnt > 0))
+	rs.appendInstruction(constructJoinBuildOperator(c, vm.GetLeafOp(s.RootOp), ss != nil, s.ShuffleCnt > 0))
 
 	if ss == nil { // unparallel, send the hashtable to join scope directly
 		s.Proc.Reg.MergeReceivers[s.BuildIdx] = &process.WaitRegister{
@@ -4825,11 +4821,10 @@ func (c *Compile) setAnalyzeCurrent(updateScopes []*Scope, nextId int) {
 
 func updateScopesLastFlag(updateScopes []*Scope) {
 	for _, s := range updateScopes {
-		if len(s.Instructions) == 0 {
+		if s.RootOp == nil {
 			continue
 		}
-		last := len(s.Instructions) - 1
-		s.Instructions[last].IsLast = true
+		s.RootOp.GetOperatorBase().IsLast = true
 	}
 }
 
@@ -4859,13 +4854,20 @@ func isSameCN(addr string, currentCNAddr string) bool {
 }
 
 func (s *Scope) affectedRows() uint64 {
+	op := s.RootOp
 	affectedRows := uint64(0)
-	for _, in := range s.Instructions {
-		if arg, ok := in.Arg.(vm.ModificationArgument); ok {
+
+	for op != nil {
+		if arg, ok := op.(vm.ModificationArgument); ok {
 			if marg, ok := arg.(*mergeblock.Argument); ok {
 				return marg.AffectedRows()
 			}
 			affectedRows += arg.AffectedRows()
+		}
+		if op.GetOperatorBase().NumChildren() == 0 {
+			op = nil
+		} else {
+			op = op.GetOperatorBase().GetChildren(0)
 		}
 	}
 	return affectedRows
@@ -4949,12 +4951,10 @@ func (c *Compile) newInsertMergeScope(arg *insert.Argument, ss []*Scope) *Scope 
 			ss2 = append(ss2, s)
 		}
 	}
-	insert := &vm.Instruction{
-		Op:  vm.Insert,
-		Arg: arg,
-	}
+
+	arg.Op = vm.Insert
 	for i := range ss2 {
-		ss2[i].appendInstruction(dupInstruction(insert, nil, i))
+		ss2[i].appendInstruction(dupInstruction(arg, nil, i))
 	}
 	return c.newMergeScope(ss2)
 }

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -2607,8 +2607,7 @@ func (c *Compile) compileShuffleJoin(node, left, right *plan.Node, lefts, rights
 		for i := range children {
 			children[i].appendOperator(lastOperator[i])
 		}
-		}()
-	}
+	}()
 
 	switch node.JoinType {
 	case plan.Node_INNER:

--- a/pkg/sql/compile/debugTools.go
+++ b/pkg/sql/compile/debugTools.go
@@ -191,21 +191,21 @@ func debugShowScopes(ss []*Scope, gap int, rmp map[*process.WaitRegister]int) st
 	}
 
 	// explain the operator information
-	showInstruction := func(instruction vm.Instruction, mp map[*process.WaitRegister]int) string {
-		id := instruction.Op
+	showOperator := func(op vm.Operator, mp map[*process.WaitRegister]int) string {
+		id := op.GetOperatorBase().Op
 		name, ok := debugInstructionNames[id]
 		if ok {
 			str := name
 			if id == vm.Connector {
 				var receiver = "unknown"
-				arg := instruction.Arg.(*connector.Argument)
+				arg := op.(*connector.Argument)
 				if receiverId, okk := mp[arg.Reg]; okk {
 					receiver = fmt.Sprintf("%d", receiverId)
 				}
 				str += fmt.Sprintf(" to MergeReceiver %s", receiver)
 			}
 			if id == vm.Dispatch {
-				arg := instruction.Arg.(*dispatch.Argument)
+				arg := op.(*dispatch.Argument)
 				chs := ""
 				for i := range arg.LocalRegs {
 					if i != 0 {
@@ -252,12 +252,15 @@ func debugShowScopes(ss []*Scope, gap int, rmp map[*process.WaitRegister]int) st
 			receiverStr = getReceiverStr(ss[i], ss[i].Proc.Reg.MergeReceivers)
 		}
 		str += fmt.Sprintf("Scope %d (Magic: %s, Receiver: %s): [", i+1, magicShow(ss[i].Magic), receiverStr)
-		for j, instruction := range ss[i].Instructions {
-			if j != 0 {
+
+		vm.HandleAllOp(ss[i].RootOp, func(parentOp vm.Operator, op vm.Operator) error {
+			if op.GetOperatorBase().NumChildren() != 0 {
 				str += " -> "
 			}
-			str += showInstruction(instruction, rmp)
-		}
+			str += showOperator(op, rmp)
+			return nil
+		})
+
 		str += "]"
 		if ss[i].DataSource != nil {
 			str += gapNextLine()

--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -109,20 +109,21 @@ func init() {
 	constBat.SetRowCount(1)
 }
 
-func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]*process.WaitRegister, index int) vm.Instruction {
+func dupInstruction(sourceOp vm.Operator, regMap map[*process.WaitRegister]*process.WaitRegister, index int) vm.Instruction {
+	srcOpBase := sourceOp.GetOperatorBase()
 	res := vm.Instruction{
-		Op:          sourceIns.Op,
-		Idx:         sourceIns.Idx,
-		IsFirst:     sourceIns.IsFirst,
-		IsLast:      sourceIns.IsLast,
-		CnAddr:      sourceIns.CnAddr,
-		OperatorID:  sourceIns.OperatorID,
-		MaxParallel: sourceIns.MaxParallel,
-		ParallelID:  sourceIns.ParallelID,
+		Op:          srcOpBase.Op,
+		Idx:         srcOpBase.Idx,
+		IsFirst:     srcOpBase.IsFirst,
+		IsLast:      srcOpBase.IsLast,
+		CnAddr:      srcOpBase.CnAddr,
+		OperatorID:  srcOpBase.OperatorID,
+		MaxParallel: srcOpBase.MaxParallel,
+		ParallelID:  srcOpBase.ParallelID,
 	}
-	switch sourceIns.Op {
+	switch srcOpBase.Op {
 	case vm.Anti:
-		t := sourceIns.Arg.(*anti.Argument)
+		t := sourceOp.(*anti.Argument)
 		arg := anti.NewArgument()
 		arg.Cond = t.Cond
 		arg.Typs = t.Typs
@@ -133,7 +134,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.RuntimeFilterSpecs = t.RuntimeFilterSpecs
 		res.Arg = arg
 	case vm.Group:
-		t := sourceIns.Arg.(*group.Argument)
+		t := sourceOp.(*group.Argument)
 		arg := group.NewArgument()
 		arg.IsShuffle = t.IsShuffle
 		arg.PreAllocSize = t.PreAllocSize
@@ -143,10 +144,10 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.Aggs = t.Aggs
 		res.Arg = arg
 	case vm.Sample:
-		t := sourceIns.Arg.(*sample.Argument)
+		t := sourceOp.(*sample.Argument)
 		res.Arg = t.SimpleDup()
 	case vm.Join:
-		t := sourceIns.Arg.(*join.Argument)
+		t := sourceOp.(*join.Argument)
 		arg := join.NewArgument()
 		arg.Result = t.Result
 		arg.Cond = t.Cond
@@ -157,7 +158,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.IsShuffle = t.IsShuffle
 		res.Arg = arg
 	case vm.Left:
-		t := sourceIns.Arg.(*left.Argument)
+		t := sourceOp.(*left.Argument)
 		arg := left.NewArgument()
 		arg.Cond = t.Cond
 		arg.Result = t.Result
@@ -168,7 +169,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.IsShuffle = t.IsShuffle
 		res.Arg = arg
 	case vm.Right:
-		t := sourceIns.Arg.(*right.Argument)
+		t := sourceOp.(*right.Argument)
 		arg := right.NewArgument()
 		arg.Cond = t.Cond
 		arg.Result = t.Result
@@ -180,7 +181,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.IsShuffle = t.IsShuffle
 		res.Arg = arg
 	case vm.RightSemi:
-		t := sourceIns.Arg.(*rightsemi.Argument)
+		t := sourceOp.(*rightsemi.Argument)
 		arg := rightsemi.NewArgument()
 		arg.Cond = t.Cond
 		arg.Result = t.Result
@@ -191,7 +192,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.IsShuffle = t.IsShuffle
 		res.Arg = arg
 	case vm.RightAnti:
-		t := sourceIns.Arg.(*rightanti.Argument)
+		t := sourceOp.(*rightanti.Argument)
 		arg := rightanti.NewArgument()
 		arg.Cond = t.Cond
 		arg.Result = t.Result
@@ -202,90 +203,90 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.IsShuffle = t.IsShuffle
 		res.Arg = arg
 	case vm.Limit:
-		t := sourceIns.Arg.(*limit.Argument)
+		t := sourceOp.(*limit.Argument)
 		arg := limit.NewArgument()
 		arg.LimitExpr = t.LimitExpr
 		res.Arg = arg
 	case vm.LoopAnti:
-		t := sourceIns.Arg.(*loopanti.Argument)
+		t := sourceOp.(*loopanti.Argument)
 		arg := loopanti.NewArgument()
 		arg.Result = t.Result
 		arg.Cond = t.Cond
 		arg.Typs = t.Typs
 		res.Arg = arg
 	case vm.LoopJoin:
-		t := sourceIns.Arg.(*loopjoin.Argument)
+		t := sourceOp.(*loopjoin.Argument)
 		arg := loopjoin.NewArgument()
 		arg.Result = t.Result
 		arg.Cond = t.Cond
 		arg.Typs = t.Typs
 		res.Arg = arg
 	case vm.IndexJoin:
-		t := sourceIns.Arg.(*indexjoin.Argument)
+		t := sourceOp.(*indexjoin.Argument)
 		arg := indexjoin.NewArgument()
 		arg.Result = t.Result
 		arg.Typs = t.Typs
 		arg.RuntimeFilterSpecs = t.RuntimeFilterSpecs
 		res.Arg = arg
 	case vm.LoopLeft:
-		t := sourceIns.Arg.(*loopleft.Argument)
+		t := sourceOp.(*loopleft.Argument)
 		arg := loopleft.NewArgument()
 		arg.Cond = t.Cond
 		arg.Typs = t.Typs
 		arg.Result = t.Result
 		res.Arg = arg
 	case vm.LoopSemi:
-		t := sourceIns.Arg.(*loopsemi.Argument)
+		t := sourceOp.(*loopsemi.Argument)
 		arg := loopsemi.NewArgument()
 		arg.Result = t.Result
 		arg.Cond = t.Cond
 		arg.Typs = t.Typs
 		res.Arg = arg
 	case vm.LoopSingle:
-		t := sourceIns.Arg.(*loopsingle.Argument)
+		t := sourceOp.(*loopsingle.Argument)
 		arg := loopsingle.NewArgument()
 		arg.Result = t.Result
 		arg.Cond = t.Cond
 		arg.Typs = t.Typs
 		res.Arg = arg
 	case vm.LoopMark:
-		t := sourceIns.Arg.(*loopmark.Argument)
+		t := sourceOp.(*loopmark.Argument)
 		arg := loopmark.NewArgument()
 		arg.Result = t.Result
 		arg.Cond = t.Cond
 		arg.Typs = t.Typs
 		res.Arg = arg
 	case vm.Offset:
-		t := sourceIns.Arg.(*offset.Argument)
+		t := sourceOp.(*offset.Argument)
 		arg := offset.NewArgument()
 		arg.OffsetExpr = t.OffsetExpr
 		res.Arg = arg
 	case vm.Order:
-		t := sourceIns.Arg.(*order.Argument)
+		t := sourceOp.(*order.Argument)
 		arg := order.NewArgument()
 		arg.OrderBySpec = t.OrderBySpec
 		res.Arg = arg
 	case vm.Product:
-		t := sourceIns.Arg.(*product.Argument)
+		t := sourceOp.(*product.Argument)
 		arg := product.NewArgument()
 		arg.Result = t.Result
 		arg.Typs = t.Typs
 		arg.IsShuffle = t.IsShuffle
 		res.Arg = arg
 	case vm.ProductL2:
-		t := sourceIns.Arg.(*productl2.Argument)
+		t := sourceOp.(*productl2.Argument)
 		arg := productl2.NewArgument()
 		arg.Result = t.Result
 		arg.Typs = t.Typs
 		arg.OnExpr = t.OnExpr
 		res.Arg = arg
 	case vm.Projection:
-		t := sourceIns.Arg.(*projection.Argument)
+		t := sourceOp.(*projection.Argument)
 		arg := projection.NewArgument()
 		arg.Es = t.Es
 		res.Arg = arg
 	case vm.Filter:
-		t := sourceIns.Arg.(*filter.Argument)
+		t := sourceOp.(*filter.Argument)
 		arg := filter.NewArgument()
 		arg.E = t.GetExeExpr()
 		if arg.E == nil {
@@ -293,7 +294,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		}
 		res.Arg = arg
 	case vm.Semi:
-		t := sourceIns.Arg.(*semi.Argument)
+		t := sourceOp.(*semi.Argument)
 		arg := semi.NewArgument()
 		arg.Result = t.Result
 		arg.Cond = t.Cond
@@ -304,7 +305,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.IsShuffle = t.IsShuffle
 		res.Arg = arg
 	case vm.Single:
-		t := sourceIns.Arg.(*single.Argument)
+		t := sourceOp.(*single.Argument)
 		arg := single.NewArgument()
 		arg.Result = t.Result
 		arg.Cond = t.Cond
@@ -314,7 +315,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.HashOnPK = t.HashOnPK
 		res.Arg = arg
 	case vm.Top:
-		t := sourceIns.Arg.(*top.Argument)
+		t := sourceOp.(*top.Argument)
 		arg := top.NewArgument()
 		arg.Limit = t.Limit
 		arg.TopValueTag = t.TopValueTag
@@ -330,7 +331,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg := intersectall.NewArgument()
 		res.Arg = arg
 	case vm.Merge:
-		t := sourceIns.Arg.(*merge.Argument)
+		t := sourceOp.(*merge.Argument)
 		arg := merge.NewArgument()
 		arg.SinkScan = t.SinkScan
 		res.Arg = arg
@@ -339,35 +340,35 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 	case vm.MergeCTE:
 		res.Arg = mergecte.NewArgument()
 	case vm.MergeGroup:
-		t := sourceIns.Arg.(*mergegroup.Argument)
+		t := sourceOp.(*mergegroup.Argument)
 		arg := mergegroup.NewArgument()
 		arg.NeedEval = t.NeedEval
 		arg.PartialResults = t.PartialResults
 		arg.PartialResultTypes = t.PartialResultTypes
 		res.Arg = arg
 	case vm.MergeLimit:
-		t := sourceIns.Arg.(*mergelimit.Argument)
+		t := sourceOp.(*mergelimit.Argument)
 		arg := mergelimit.NewArgument()
 		arg.Limit = t.Limit
 		res.Arg = arg
 	case vm.MergeOffset:
-		t := sourceIns.Arg.(*mergeoffset.Argument)
+		t := sourceOp.(*mergeoffset.Argument)
 		arg := mergeoffset.NewArgument()
 		arg.Offset = t.Offset
 		res.Arg = arg
 	case vm.MergeTop:
-		t := sourceIns.Arg.(*mergetop.Argument)
+		t := sourceOp.(*mergetop.Argument)
 		arg := mergetop.NewArgument()
 		arg.Limit = t.Limit
 		arg.Fs = t.Fs
 		res.Arg = arg
 	case vm.MergeOrder:
-		t := sourceIns.Arg.(*mergeorder.Argument)
+		t := sourceOp.(*mergeorder.Argument)
 		arg := mergeorder.NewArgument()
 		arg.OrderBySpecs = t.OrderBySpecs
 		res.Arg = arg
 	case vm.Mark:
-		t := sourceIns.Arg.(*mark.Argument)
+		t := sourceOp.(*mark.Argument)
 		arg := mark.NewArgument()
 		arg.Result = t.Result
 		arg.Conditions = t.Conditions
@@ -377,7 +378,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.HashOnPK = t.HashOnPK
 		res.Arg = arg
 	case vm.TableFunction:
-		t := sourceIns.Arg.(*table_function.Argument)
+		t := sourceOp.(*table_function.Argument)
 		arg := table_function.NewArgument()
 		arg.FuncName = t.FuncName
 		arg.Args = t.Args
@@ -386,7 +387,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.Params = t.Params
 		res.Arg = arg
 	case vm.External:
-		t := sourceIns.Arg.(*external.Argument)
+		t := sourceOp.(*external.Argument)
 		res.Arg = external.NewArgument().WithEs(
 			&external.ExternalParam{
 				ExParamConst: external.ExParamConst{
@@ -414,7 +415,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 			},
 		)
 	case vm.Source:
-		t := sourceIns.Arg.(*source.Argument)
+		t := sourceOp.(*source.Argument)
 		arg := source.NewArgument()
 		arg.TblDef = t.TblDef
 		arg.Limit = t.Limit
@@ -425,14 +426,14 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		ok := false
 		if regMap != nil {
 			arg := connector.NewArgument()
-			sourceReg := sourceIns.Arg.(*connector.Argument).Reg
+			sourceReg := sourceOp.(*connector.Argument).Reg
 			if arg.Reg, ok = regMap[sourceReg]; !ok {
 				panic("nonexistent wait register")
 			}
 			res.Arg = arg
 		}
 	case vm.Shuffle:
-		sourceArg := sourceIns.Arg.(*shuffle.Argument)
+		sourceArg := sourceOp.(*shuffle.Argument)
 		arg := shuffle.NewArgument()
 		arg.ShuffleType = sourceArg.ShuffleType
 		arg.ShuffleColIdx = sourceArg.ShuffleColIdx
@@ -446,7 +447,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 	case vm.Dispatch:
 		ok := false
 		if regMap != nil {
-			sourceArg := sourceIns.Arg.(*dispatch.Argument)
+			sourceArg := sourceOp.(*dispatch.Argument)
 			arg := dispatch.NewArgument()
 			arg.IsSink = sourceArg.IsSink
 			arg.RecSink = sourceArg.RecSink
@@ -465,13 +466,13 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 			res.Arg = arg
 		}
 	case vm.Insert:
-		t := sourceIns.Arg.(*insert.Argument)
+		t := sourceOp.(*insert.Argument)
 		arg := insert.NewArgument()
 		arg.InsertCtx = t.InsertCtx
 		arg.ToWriteS3 = t.ToWriteS3
 		res.Arg = arg
 	case vm.PreInsert:
-		t := sourceIns.Arg.(*preinsert.Argument)
+		t := sourceOp.(*preinsert.Argument)
 		arg := preinsert.NewArgument()
 		arg.SchemaName = t.SchemaName
 		arg.TableDef = t.TableDef
@@ -481,7 +482,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.EstimatedRowCount = t.EstimatedRowCount
 		res.Arg = arg
 	case vm.Deletion:
-		t := sourceIns.Arg.(*deletion.Argument)
+		t := sourceOp.(*deletion.Argument)
 		arg := deletion.NewArgument()
 		arg.IBucket = t.IBucket
 		arg.Nbucket = t.Nbucket
@@ -490,12 +491,13 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg.SegmentMap = t.SegmentMap
 		res.Arg = arg
 	case vm.LockOp:
-		t := sourceIns.Arg.(*lockop.Argument)
+		t := sourceOp.(*lockop.Argument)
 		arg := lockop.NewArgument()
 		*arg = *t
+		arg.SetChildren(nil) // make sure res.arg.children is nil
 		res.Arg = arg
 	case vm.FuzzyFilter:
-		t := sourceIns.Arg.(*fuzzyfilter.Argument)
+		t := sourceOp.(*fuzzyfilter.Argument)
 		arg := fuzzyfilter.NewArgument()
 		arg.N = t.N
 		arg.PkName = t.PkName
@@ -509,7 +511,7 @@ func dupInstruction(sourceIns *vm.Instruction, regMap map[*process.WaitRegister]
 		arg := value_scan.NewArgument()
 		res.Arg = arg
 	default:
-		panic(fmt.Sprintf("unexpected instruction type '%d' to dup", sourceIns.Op))
+		panic(fmt.Sprintf("unexpected instruction type '%d' to dup", srcOpBase.Op))
 	}
 	return res
 }
@@ -1532,17 +1534,17 @@ func constructLoopMark(n *plan.Node, typs []types.Type, proc *process.Process) *
 	return arg
 }
 
-func constructJoinBuildInstruction(c *Compile, in vm.Instruction, isDup bool, isShuffle bool) vm.Instruction {
-	switch in.Op {
+func constructJoinBuildOperator(c *Compile, op vm.Operator, isDup bool, isShuffle bool) vm.Instruction {
+	switch op.GetOperatorBase().Op {
 	case vm.IndexJoin:
-		arg := in.Arg.(*indexjoin.Argument)
+		arg := op.(*indexjoin.Argument)
 		ret := indexbuild.NewArgument()
 		if len(arg.RuntimeFilterSpecs) > 0 {
 			ret.RuntimeFilterSpec = arg.RuntimeFilterSpecs[0]
 		}
 		return vm.Instruction{
 			Op:      vm.IndexBuild,
-			Idx:     in.Idx,
+			Idx:     op.GetOperatorBase().GetIdx(),
 			IsFirst: true,
 			Arg:     ret,
 		}
@@ -1550,28 +1552,28 @@ func constructJoinBuildInstruction(c *Compile, in vm.Instruction, isDup bool, is
 		if isShuffle {
 			return vm.Instruction{
 				Op:      vm.ShuffleBuild,
-				Idx:     in.Idx,
+				Idx:     op.GetOperatorBase().GetIdx(),
 				IsFirst: true,
-				Arg:     constructShuffleBuild(in, c.proc, isDup),
+				Arg:     constructShuffleBuild(op, c.proc, isDup),
 			}
 		}
 		return vm.Instruction{
 			Op:      vm.HashBuild,
-			Idx:     in.Idx,
+			Idx:     op.GetOperatorBase().GetIdx(),
 			IsFirst: true,
-			Arg:     constructHashBuild(in, c.proc, isDup),
+			Arg:     constructHashBuild(op, c.proc, isDup),
 		}
 	}
 }
 
-func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *hashbuild.Argument {
+func constructHashBuild(op vm.Operator, proc *process.Process, isDup bool) *hashbuild.Argument {
 	// XXX BUG
 	// relation index of arg.Conditions should be rewritten to 0 here.
 	ret := hashbuild.NewArgument()
 
-	switch in.Op {
+	switch op.GetOperatorBase().Op {
 	case vm.Anti:
-		arg := in.Arg.(*anti.Argument)
+		arg := op.(*anti.Argument)
 		ret.NeedHashMap = true
 		ret.Typs = arg.Typs
 		ret.Conditions = arg.Conditions[1]
@@ -1586,7 +1588,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		}
 
 	case vm.Mark:
-		arg := in.Arg.(*mark.Argument)
+		arg := op.(*mark.Argument)
 		ret.NeedHashMap = true
 		ret.Typs = arg.Typs
 		ret.Conditions = arg.Conditions[1]
@@ -1596,7 +1598,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		ret.NeedAllocateSels = true
 
 	case vm.Join:
-		arg := in.Arg.(*join.Argument)
+		arg := op.(*join.Argument)
 		ret.NeedHashMap = true
 		ret.Typs = arg.Typs
 		ret.Conditions = arg.Conditions[1]
@@ -1621,7 +1623,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		}
 
 	case vm.Left:
-		arg := in.Arg.(*left.Argument)
+		arg := op.(*left.Argument)
 		ret.NeedHashMap = true
 		ret.Typs = arg.Typs
 		ret.Conditions = arg.Conditions[1]
@@ -1634,7 +1636,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		}
 
 	case vm.Right:
-		arg := in.Arg.(*right.Argument)
+		arg := op.(*right.Argument)
 		ret.NeedHashMap = true
 		ret.Typs = arg.RightTypes
 		ret.Conditions = arg.Conditions[1]
@@ -1647,7 +1649,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		}
 
 	case vm.RightSemi:
-		arg := in.Arg.(*rightsemi.Argument)
+		arg := op.(*rightsemi.Argument)
 		ret.NeedHashMap = true
 		ret.Typs = arg.RightTypes
 		ret.Conditions = arg.Conditions[1]
@@ -1660,7 +1662,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		}
 
 	case vm.RightAnti:
-		arg := in.Arg.(*rightanti.Argument)
+		arg := op.(*rightanti.Argument)
 		ret.NeedHashMap = true
 		ret.Typs = arg.RightTypes
 		ret.Conditions = arg.Conditions[1]
@@ -1673,7 +1675,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		}
 
 	case vm.Semi:
-		arg := in.Arg.(*semi.Argument)
+		arg := op.(*semi.Argument)
 		ret.NeedHashMap = true
 		ret.Typs = arg.Typs
 		ret.Conditions = arg.Conditions[1]
@@ -1691,7 +1693,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		}
 
 	case vm.Single:
-		arg := in.Arg.(*single.Argument)
+		arg := op.(*single.Argument)
 		ret.NeedHashMap = true
 		ret.Typs = arg.Typs
 		ret.Conditions = arg.Conditions[1]
@@ -1703,21 +1705,21 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 			ret.RuntimeFilterSpec = arg.RuntimeFilterSpecs[0]
 		}
 	case vm.Product:
-		arg := in.Arg.(*product.Argument)
+		arg := op.(*product.Argument)
 		ret.NeedHashMap = false
 		ret.Typs = arg.Typs
 		ret.IsDup = isDup
 		ret.NeedMergedBatch = true
 		ret.NeedAllocateSels = true
 	case vm.ProductL2:
-		arg := in.Arg.(*productl2.Argument)
+		arg := op.(*productl2.Argument)
 		ret.NeedHashMap = false
 		ret.Typs = arg.Typs
 		ret.IsDup = isDup
 		ret.NeedMergedBatch = true
 		ret.NeedAllocateSels = true
 	case vm.LoopAnti:
-		arg := in.Arg.(*loopanti.Argument)
+		arg := op.(*loopanti.Argument)
 		ret.NeedHashMap = false
 		ret.Typs = arg.Typs
 		ret.IsDup = isDup
@@ -1725,7 +1727,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		ret.NeedAllocateSels = true
 
 	case vm.LoopJoin:
-		arg := in.Arg.(*loopjoin.Argument)
+		arg := op.(*loopjoin.Argument)
 		ret.NeedHashMap = false
 		ret.Typs = arg.Typs
 		ret.IsDup = isDup
@@ -1733,7 +1735,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		ret.NeedAllocateSels = true
 
 	case vm.LoopLeft:
-		arg := in.Arg.(*loopleft.Argument)
+		arg := op.(*loopleft.Argument)
 		ret.NeedHashMap = false
 		ret.Typs = arg.Typs
 		ret.IsDup = isDup
@@ -1741,7 +1743,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		ret.NeedAllocateSels = true
 
 	case vm.LoopSemi:
-		arg := in.Arg.(*loopsemi.Argument)
+		arg := op.(*loopsemi.Argument)
 		ret.NeedHashMap = false
 		ret.Typs = arg.Typs
 		ret.IsDup = isDup
@@ -1749,7 +1751,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		ret.NeedAllocateSels = true
 
 	case vm.LoopSingle:
-		arg := in.Arg.(*loopsingle.Argument)
+		arg := op.(*loopsingle.Argument)
 		ret.NeedHashMap = false
 		ret.Typs = arg.Typs
 		ret.IsDup = isDup
@@ -1757,7 +1759,7 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 		ret.NeedAllocateSels = true
 
 	case vm.LoopMark:
-		arg := in.Arg.(*loopmark.Argument)
+		arg := op.(*loopmark.Argument)
 		ret.NeedHashMap = false
 		ret.Typs = arg.Typs
 		ret.IsDup = isDup
@@ -1766,17 +1768,17 @@ func constructHashBuild(in vm.Instruction, proc *process.Process, isDup bool) *h
 
 	default:
 		ret.Release()
-		panic(moerr.NewInternalError(proc.Ctx, "unsupport join type '%v'", in.Op))
+		panic(moerr.NewInternalError(proc.Ctx, "unsupport join type '%v'", op.GetOperatorBase().Op))
 	}
 	return ret
 }
 
-func constructShuffleBuild(in vm.Instruction, proc *process.Process, isDup bool) *shufflebuild.Argument {
+func constructShuffleBuild(op vm.Operator, proc *process.Process, isDup bool) *shufflebuild.Argument {
 	ret := shufflebuild.NewArgument()
 
-	switch in.Op {
+	switch op.GetOperatorBase().Op {
 	case vm.Anti:
-		arg := in.Arg.(*anti.Argument)
+		arg := op.(*anti.Argument)
 		ret.Typs = arg.Typs
 		ret.Conditions = arg.Conditions[1]
 		ret.IsDup = isDup
@@ -1793,7 +1795,7 @@ func constructShuffleBuild(in vm.Instruction, proc *process.Process, isDup bool)
 		}
 
 	case vm.Join:
-		arg := in.Arg.(*join.Argument)
+		arg := op.(*join.Argument)
 		ret.Typs = arg.Typs
 		ret.Conditions = arg.Conditions[1]
 		ret.IsDup = isDup
@@ -1817,7 +1819,7 @@ func constructShuffleBuild(in vm.Instruction, proc *process.Process, isDup bool)
 		}
 
 	case vm.Left:
-		arg := in.Arg.(*left.Argument)
+		arg := op.(*left.Argument)
 		ret.Typs = arg.Typs
 		ret.Conditions = arg.Conditions[1]
 		ret.IsDup = isDup
@@ -1829,7 +1831,7 @@ func constructShuffleBuild(in vm.Instruction, proc *process.Process, isDup bool)
 		}
 
 	case vm.Right:
-		arg := in.Arg.(*right.Argument)
+		arg := op.(*right.Argument)
 		ret.Typs = arg.RightTypes
 		ret.Conditions = arg.Conditions[1]
 		ret.IsDup = isDup
@@ -1841,7 +1843,7 @@ func constructShuffleBuild(in vm.Instruction, proc *process.Process, isDup bool)
 		}
 
 	case vm.RightSemi:
-		arg := in.Arg.(*rightsemi.Argument)
+		arg := op.(*rightsemi.Argument)
 		ret.Typs = arg.RightTypes
 		ret.Conditions = arg.Conditions[1]
 		ret.IsDup = isDup
@@ -1853,7 +1855,7 @@ func constructShuffleBuild(in vm.Instruction, proc *process.Process, isDup bool)
 		}
 
 	case vm.RightAnti:
-		arg := in.Arg.(*rightanti.Argument)
+		arg := op.(*rightanti.Argument)
 		ret.Typs = arg.RightTypes
 		ret.Conditions = arg.Conditions[1]
 		ret.IsDup = isDup
@@ -1865,7 +1867,7 @@ func constructShuffleBuild(in vm.Instruction, proc *process.Process, isDup bool)
 		}
 
 	case vm.Semi:
-		arg := in.Arg.(*semi.Argument)
+		arg := op.(*semi.Argument)
 		ret.Typs = arg.Typs
 		ret.Conditions = arg.Conditions[1]
 		ret.IsDup = isDup
@@ -1883,7 +1885,7 @@ func constructShuffleBuild(in vm.Instruction, proc *process.Process, isDup bool)
 
 	default:
 		ret.Release()
-		panic(moerr.NewInternalError(proc.Ctx, "unsupported type for shuffle join: '%v'", in.Op))
+		panic(moerr.NewInternalError(proc.Ctx, "unsupported type for shuffle join: '%v'", op.GetOperatorBase().Op))
 	}
 	return ret
 }

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -144,7 +144,7 @@ func Test_refactorScope(t *testing.T) {
 	c.proc = proc
 	c.proc.Ctx = ctx
 	rs := appendWriteBackOperator(c, s)
-	require.Equal(t, rs.Instructions[1].Idx, -1)
+	require.Equal(t, vm.GetLeafOpParent(nil, rs.RootOp).GetOperatorBase().Idx, -1)
 }
 
 func Test_convertPipelineUuid(t *testing.T) {
@@ -174,172 +174,82 @@ func Test_convertToPipelineInstruction(t *testing.T) {
 	exParam := external.ExParam{
 		Filter: &external.FilterParam{},
 	}
-	instructions := []*vm.Instruction{
-		{
-			Arg: &insert.Argument{
-				InsertCtx: &insert.InsertCtx{},
+	ops := []vm.Operator{
+		&insert.Argument{
+			InsertCtx: &insert.InsertCtx{},
+		},
+		&deletion.Argument{
+			DeleteCtx: &deletion.DeleteCtx{},
+		},
+		&onduplicatekey.Argument{},
+		&preinsert.Argument{},
+		&lockop.Argument{},
+		&preinsertunique.Argument{},
+		&anti.Argument{
+			Conditions: [][]*plan.Expr{nil, nil},
+		},
+		&shuffle.Argument{},
+		&dispatch.Argument{},
+		&group.Argument{},
+		&join.Argument{
+			Conditions: [][]*plan.Expr{nil, nil},
+		},
+		&left.Argument{
+			Conditions: [][]*plan.Expr{nil, nil},
+		},
+		&right.Argument{
+			Conditions: [][]*plan.Expr{nil, nil},
+		},
+		&rightsemi.Argument{
+			Conditions: [][]*plan.Expr{nil, nil},
+		},
+		&rightanti.Argument{
+			Conditions: [][]*plan.Expr{nil, nil},
+		},
+		&limit.Argument{},
+		&loopanti.Argument{},
+		&loopjoin.Argument{},
+		&loopleft.Argument{},
+		&loopsemi.Argument{},
+		&loopsingle.Argument{},
+		&loopmark.Argument{},
+		&offset.Argument{},
+		&order.Argument{},
+		&product.Argument{},
+		&projection.Argument{},
+		&filter.Argument{},
+		&semi.Argument{
+			Conditions: [][]*plan.Expr{nil, nil},
+		},
+		&single.Argument{
+			Conditions: [][]*plan.Expr{nil, nil},
+		},
+		&top.Argument{},
+		&intersect.Argument{},
+		&minus.Argument{},
+		&intersectall.Argument{},
+		&merge.Argument{},
+		&mergerecursive.Argument{},
+		&mergegroup.Argument{},
+		&mergelimit.Argument{},
+		&mergelimit.Argument{},
+		&mergeoffset.Argument{},
+		&mergetop.Argument{},
+		&mergeorder.Argument{},
+		&mark.Argument{
+			Conditions: [][]*plan.Expr{nil, nil},
+		},
+		&table_function.Argument{},
+		&external.Argument{
+			Es: &external.ExternalParam{
+				ExParam: exParam,
 			},
-		},
-		{
-			Arg: &deletion.Argument{
-				DeleteCtx: &deletion.DeleteCtx{},
-			},
-		},
-		{
-			Arg: &onduplicatekey.Argument{},
-		},
-		{
-			Arg: &preinsert.Argument{},
-		},
-		{
-			Arg: &lockop.Argument{},
-		},
-		{
-			Arg: &preinsertunique.Argument{},
-		},
-		{
-			Arg: &anti.Argument{
-				Conditions: [][]*plan.Expr{nil, nil},
-			},
-		},
-		{
-			Arg: &shuffle.Argument{},
-		},
-		{
-			Arg: &dispatch.Argument{},
-		},
-		{
-			Arg: &group.Argument{},
-		},
-		{
-			Arg: &join.Argument{
-				Conditions: [][]*plan.Expr{nil, nil},
-			},
-		},
-		{
-			Arg: &left.Argument{
-				Conditions: [][]*plan.Expr{nil, nil},
-			},
-		},
-		{
-			Arg: &right.Argument{
-				Conditions: [][]*plan.Expr{nil, nil},
-			},
-		},
-		{
-			Arg: &rightsemi.Argument{
-				Conditions: [][]*plan.Expr{nil, nil},
-			},
-		},
-		{
-			Arg: &rightanti.Argument{
-				Conditions: [][]*plan.Expr{nil, nil},
-			},
-		},
-		{
-			Arg: &limit.Argument{},
-		},
-		{
-			Arg: &loopanti.Argument{},
-		},
-		{
-			Arg: &loopjoin.Argument{},
-		},
-		{
-			Arg: &loopleft.Argument{},
-		},
-		{
-			Arg: &loopsemi.Argument{},
-		},
-		{
-			Arg: &loopsingle.Argument{},
-		},
-		{
-			Arg: &loopmark.Argument{},
-		},
-		{
-			Arg: &offset.Argument{},
-		},
-		{
-			Arg: &order.Argument{},
-		},
-		{
-			Arg: &product.Argument{},
-		},
-		{
-			Arg: &projection.Argument{},
-		},
-		{
-			Arg: &filter.Argument{},
-		},
-		{
-			Arg: &semi.Argument{
-				Conditions: [][]*plan.Expr{nil, nil},
-			},
-		},
-		{
-			Arg: &single.Argument{
-				Conditions: [][]*plan.Expr{nil, nil},
-			},
-		},
-		{
-			Arg: &top.Argument{},
-		},
-		{
-			Arg: &intersect.Argument{},
-		},
-		{
-			Arg: &minus.Argument{},
-		},
-		{
-			Arg: &intersectall.Argument{},
-		},
-		{
-			Arg: &merge.Argument{},
-		},
-		{
-			Arg: &mergerecursive.Argument{},
-		},
-		{
-			Arg: &mergegroup.Argument{},
-		},
-		{
-			Arg: &mergelimit.Argument{},
-		},
-		{
-			Arg: &mergeoffset.Argument{},
-		},
-		{
-			Arg: &mergetop.Argument{},
-		},
-		{
-			Arg: &mergeorder.Argument{},
-		},
-		//{
-		//	Arg: &connector.Argument{},
-		//},
-		{
-			Arg: &mark.Argument{
-				Conditions: [][]*plan.Expr{nil, nil},
-			},
-		},
-		{
-			Arg: &table_function.Argument{},
 		},
 		//hashbuild operator dont need to serialize
 		//{
 		//	Arg: &hashbuild.Argument{},
 		//},
-		{
-			Arg: &external.Argument{
-				Es: &external.ExternalParam{
-					ExParam: exParam,
-				},
-			},
-		},
-		{
-			Arg: &source.Argument{},
-		},
+		&source.Argument{},
 	}
 	ctx := &scopeContext{
 		id:       1,
@@ -351,8 +261,8 @@ func Test_convertToPipelineInstruction(t *testing.T) {
 		pipe:     nil,
 		regs:     nil,
 	}
-	for _, instruction := range instructions {
-		_, _, err := convertToPipelineInstruction(instruction, ctx, 1)
+	for _, op := range ops {
+		_, _, err := convertToPipelineInstruction(op, ctx, 1)
 		require.Nil(t, err)
 	}
 }

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -328,7 +328,7 @@ func Test_convertToVmInstruction(t *testing.T) {
 		{Op: int32(vm.Source), StreamScan: &pipeline.StreamScan{}},
 	}
 	for _, instruction := range instructions {
-		_, err := convertToVmInstruction(instruction, ctx, nil)
+		_, err := convertToVmOperator(instruction, ctx, nil)
 		require.Nil(t, err)
 	}
 }

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -27,11 +27,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/bitmap"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec/output"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec/right"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec/rightanti"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec/rightsemi"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec/table_scan"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
@@ -55,7 +50,12 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/mergeoffset"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/mergetop"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/offset"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/output"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/right"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/rightanti"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/rightsemi"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/sample"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/table_scan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/top"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm"
@@ -90,10 +90,14 @@ func (s *Scope) release() {
 	for i := range s.PreScopes {
 		s.PreScopes[i].release()
 	}
-	for i := range s.Instructions {
-		s.Instructions[i].Arg.Release()
-		s.Instructions[i].Arg = nil
-	}
+	vm.HandleAllOp(s.RootOp, func(parentOp vm.Operator, op vm.Operator) error {
+		op.Release()
+		if parentOp != nil {
+			parentOp.GetOperatorBase().SetChild(nil, 0)
+		}
+		return nil
+	})
+
 	reuse.Free[Scope](s, nil)
 }
 
@@ -118,11 +122,14 @@ func (s *Scope) resetForReuse(c *Compile) (err error) {
 		s.Proc.Ctx = newctx
 		s.Proc.Cancel = cancel
 	}
-	for _, ins := range s.Instructions {
-		if ins.Op == vm.Output {
-			ins.Arg.(*output.Argument).Func = c.fill
+
+	vm.HandleAllOp(s.RootOp, func(parentOp vm.Operator, op vm.Operator) error {
+		if op.GetOperatorBase().Op == vm.Output {
+			op.(*output.Argument).Func = c.fill
 		}
-	}
+		return nil
+	})
+
 	if s.DataSource != nil {
 		if s.DataSource.isConst {
 			s.DataSource.Bat = nil
@@ -143,15 +150,21 @@ func (s *Scope) initDataSource(c *Compile) (err error) {
 			return
 		}
 
-		if len(s.Instructions) > 0 && s.Instructions[0].Op == vm.ValueScan {
-			if s.DataSource.node.NodeType == plan.Node_VALUE_SCAN {
-				bat, err := constructValueScanBatch(c.proc, s.DataSource.node)
-				if err != nil {
-					return err
+		if err := vm.HandleLeafOp(nil, s.RootOp, func(leafOpParent vm.Operator, leafOp vm.Operator) error {
+			if leafOp.GetOperatorBase().GetOpType() == vm.ValueScan {
+				if s.DataSource.node.NodeType == plan.Node_VALUE_SCAN {
+					bat, err := constructValueScanBatch(c.proc, s.DataSource.node)
+					if err != nil {
+						return err
+					}
+					s.DataSource.Bat = bat
 				}
-				s.DataSource.Bat = bat
 			}
+			return nil
+		}); err != nil {
+			return err
 		}
+
 	} else {
 		if s.DataSource.Rel != nil {
 			return nil
@@ -182,7 +195,7 @@ func (s *Scope) Run(c *Compile) (err error) {
 	if s.DataSource.TableDef != nil {
 		id = s.DataSource.TableDef.TblId
 	}
-	p = pipeline.New(id, s.DataSource.Attributes, s.Instructions, s.Reg)
+	p = pipeline.New(id, s.DataSource.Attributes, s.RootOp, s.Reg)
 	if s.DataSource.isConst {
 		_, err = p.ConstRun(s.DataSource.Bat, s.Proc)
 	} else {
@@ -226,12 +239,14 @@ func (s *Scope) InitAllDataSource(c *Compile) error {
 }
 
 func (s *Scope) SetOperatorInfoRecursively(cb func() int32) {
-	for i := 0; i < len(s.Instructions); i++ {
-		s.Instructions[i].CnAddr = s.NodeInfo.Addr
-		s.Instructions[i].OperatorID = cb()
-		s.Instructions[i].ParallelID = 0
-		s.Instructions[i].MaxParallel = 1
-	}
+	vm.HandleAllOp(s.RootOp, func(parentOp vm.Operator, op vm.Operator) error {
+		opBase := op.GetOperatorBase()
+		opBase.SetCnAddr(s.NodeInfo.Addr)
+		opBase.SetOperatorID(cb())
+		opBase.SetParalleID(0)
+		opBase.SetMaxParallel(1)
+		return nil
+	})
 
 	for _, scope := range s.PreScopes {
 		scope.SetOperatorInfoRecursively(cb)
@@ -295,7 +310,7 @@ func (s *Scope) MergeRun(c *Compile) error {
 		}
 	}()
 
-	p := pipeline.NewMerge(s.Instructions, s.Reg)
+	p := pipeline.NewMerge(s.RootOp, s.Reg)
 	if _, err := p.MergeRun(s.Proc); err != nil {
 		select {
 		case <-s.Proc.Ctx.Done():
@@ -353,7 +368,7 @@ func (s *Scope) RemoteRun(c *Compile) error {
 			zap.String("local-address", c.addr),
 			zap.String("remote-address", s.NodeInfo.Addr))
 
-	p := pipeline.New(0, nil, s.Instructions, s.Reg)
+	p := pipeline.New(0, nil, s.RootOp, s.Reg)
 	sender, err := s.remoteRun(c)
 
 	runErr := err
@@ -390,7 +405,7 @@ func (s *Scope) ParallelRun(c *Compile) (err error) {
 		// if codes run here, it means some error happens during build the parallel scope.
 		// we should do clean work for source-scope to avoid receiver hung.
 		if parallelScope == nil {
-			pipeline.NewMerge(s.Instructions, s.Reg).Cleanup(s.Proc, true, c.isPrepare, err)
+			pipeline.NewMerge(s.RootOp, s.Reg).Cleanup(s.Proc, true, c.isPrepare, err)
 		}
 	}()
 
@@ -467,7 +482,8 @@ func buildJoinParallelRun(s *Scope, c *Compile) (*Scope, error) {
 	if isRight {
 		channel := make(chan *bitmap.Bitmap, mcpu)
 		for i := range ns.PreScopes {
-			switch arg := ns.PreScopes[i].Instructions[0].Arg.(type) {
+			s := ns.PreScopes[i]
+			switch arg := vm.GetLeafOp(s.RootOp).(type) {
 			case *right.Argument:
 				arg.Channel = channel
 				arg.NumCPU = uint64(mcpu)
@@ -650,12 +666,11 @@ func (s *Scope) handleRuntimeFilter(c *Compile) error {
 		isFilterOnPK := s.DataSource.TableDef.Pkey != nil && col.Name == s.DataSource.TableDef.Pkey.PkeyColName
 		if !isFilterOnPK {
 			// put expr in filter instruction
-			idx := 0
-			if _, ok := s.Instructions[0].Arg.(*table_scan.Argument); ok {
-				idx = 1
+			op := vm.GetLeafOp(s.RootOp)
+			if _, ok := op.(*table_scan.Argument); ok {
+				op = vm.GetLeafOpParent(nil, s.RootOp)
 			}
-			ins := s.Instructions[idx]
-			arg, ok := ins.Arg.(*filter.Argument)
+			arg, ok := op.(*filter.Argument)
 			if !ok {
 				panic("missing instruction for runtime filter!")
 			}
@@ -696,62 +711,71 @@ func (s *Scope) handleRuntimeFilter(c *Compile) error {
 
 func (s *Scope) isShuffle() bool {
 	// the pipeline is merge->group->xxx
-	if s != nil && len(s.Instructions) > 1 && (s.Instructions[1].Op == vm.Group) {
-		arg := s.Instructions[1].Arg.(*group.Argument)
-		return arg.IsShuffle
+	if s != nil && s.RootOp != nil && s.RootOp.GetOperatorBase().NumChildren() > 0 {
+		op := vm.GetLeafOpParent(nil, s.RootOp)
+		if op.GetOperatorBase().GetOpType() == vm.Group {
+			return op.(*group.Argument).IsShuffle
+		}
 	}
 	return false
 }
 
 func (s *Scope) isRight() bool {
-	return s != nil && (s.Instructions[0].Op == vm.Right || s.Instructions[0].Op == vm.RightSemi || s.Instructions[0].Op == vm.RightAnti)
+	if s == nil {
+		return false
+	}
+	OpType := vm.GetLeafOp(s.RootOp).GetOperatorBase().GetOpType()
+	return OpType == vm.Right || OpType == vm.RightSemi || OpType == vm.RightAnti
 }
 
 func newParallelScope(c *Compile, s *Scope, ss []*Scope) (*Scope, error) {
 	var flg bool
+	var toReleaseOpRoot vm.Operator
+	defer func() {
+		vm.HandleAllOp(toReleaseOpRoot, func(parentOp, op vm.Operator) error {
+			op.Release()
+			return nil
+		})
+	}()
 
-	idx := 0
-	defer func(ins vm.Instructions) {
-		for i := 0; i < idx; i++ {
-			if ins[i].Arg != nil {
-				ins[i].Arg.Release()
-			}
-		}
-	}(s.Instructions)
-
-	for i, in := range s.Instructions {
+	vm.HandleAllOp(s.RootOp, func(parentOp vm.Operator, op vm.Operator) error {
 		if flg {
-			break
+			return nil
 		}
-		switch in.Op {
+		opBase := op.GetOperatorBase()
+		switch opBase.Op {
 		case vm.Top:
 			flg = true
-			idx = i
-			arg := in.Arg.(*top.Argument)
+			arg := op.(*top.Argument)
+			toReleaseOpRoot = arg.GetChildren(0)
 			// release the useless arg
-			s.Instructions = s.Instructions[i:]
-			s.Instructions[0] = vm.Instruction{
-				Op:  vm.MergeTop,
-				Idx: in.Idx,
-				Arg: mergetop.NewArgument().
-					WithFs(arg.Fs).
-					WithLimit(arg.Limit),
-
-				CnAddr:      in.CnAddr,
+			newArg := mergetop.NewArgument().
+				WithFs(arg.Fs).
+				WithLimit(arg.Limit)
+			newArg.SetInfo(&vm.OperatorInfo{
+				Op:          vm.MergeTop,
+				Idx:         arg.Idx,
+				CnAddr:      arg.CnAddr,
 				OperatorID:  c.allocOperatorID(),
 				ParallelID:  0,
 				MaxParallel: 1,
+			})
+			if parentOp == nil {
+				s.RootOp = newArg
+			} else {
+				parentOp.GetOperatorBase().SetChild(newArg, 0)
 			}
+
 			for j := range ss {
 				newarg := top.NewArgument().WithFs(arg.Fs).WithLimit(arg.Limit)
 				newarg.TopValueTag = arg.TopValueTag
 				ss[j].appendInstruction(vm.Instruction{
 					Op:          vm.Top,
-					Idx:         in.Idx,
-					IsFirst:     in.IsFirst,
+					Idx:         arg.Idx,
+					IsFirst:     arg.IsFirst,
 					Arg:         newarg,
-					CnAddr:      in.CnAddr,
-					OperatorID:  in.OperatorID,
+					CnAddr:      arg.CnAddr,
+					OperatorID:  arg.OperatorID,
 					MaxParallel: int32(len(ss)),
 					ParallelID:  int32(j),
 				})
@@ -761,30 +785,34 @@ func newParallelScope(c *Compile, s *Scope, ss []*Scope) (*Scope, error) {
 		// there is no need to do special merge for order, because the behavior of order is just sort for each batch.
 		case vm.Limit:
 			flg = true
-			idx = i
-			arg := in.Arg.(*limit.Argument)
-			s.Instructions = s.Instructions[i:]
-			s.Instructions[0] = vm.Instruction{
-				Op:  vm.MergeLimit,
-				Idx: in.Idx,
-				Arg: mergelimit.NewArgument().
-					WithLimit(arg.LimitExpr),
-
-				CnAddr:      in.CnAddr,
+			arg := op.(*limit.Argument)
+			toReleaseOpRoot = arg.GetChildren(0)
+			newArg := mergelimit.NewArgument().
+				WithLimit(arg.LimitExpr)
+			newArg.SetInfo(&vm.OperatorInfo{
+				Op:          vm.MergeLimit,
+				Idx:         arg.Idx,
+				CnAddr:      arg.CnAddr,
 				OperatorID:  c.allocOperatorID(),
 				ParallelID:  0,
 				MaxParallel: 1,
+			})
+			if parentOp == nil {
+				s.RootOp = newArg
+			} else {
+				parentOp.GetOperatorBase().SetChild(newArg, 0)
 			}
+
 			for j := range ss {
 				ss[j].appendInstruction(vm.Instruction{
 					Op:      vm.Limit,
-					Idx:     in.Idx,
-					IsFirst: in.IsFirst,
+					Idx:     arg.Idx,
+					IsFirst: arg.IsFirst,
 					Arg: limit.NewArgument().
 						WithLimit(arg.LimitExpr),
 
-					CnAddr:      in.CnAddr,
-					OperatorID:  in.OperatorID,
+					CnAddr:      arg.CnAddr,
+					OperatorID:  arg.OperatorID,
 					MaxParallel: int32(len(ss)),
 					ParallelID:  int32(j),
 				})
@@ -792,164 +820,182 @@ func newParallelScope(c *Compile, s *Scope, ss []*Scope) (*Scope, error) {
 			arg.Release()
 		case vm.Group:
 			flg = true
-			idx = i
-			arg := in.Arg.(*group.Argument)
+			arg := op.(*group.Argument)
+			toReleaseOpRoot = arg.GetChildren(0)
 			if arg.AnyDistinctAgg() {
-				continue
+				return nil
 			}
-			s.Instructions = s.Instructions[i:]
-			s.Instructions[0] = vm.Instruction{
-				Op:  vm.MergeGroup,
-				Idx: in.Idx,
-				Arg: mergegroup.NewArgument().
-					WithNeedEval(false),
 
-				CnAddr:      in.CnAddr,
+			newArg := mergegroup.NewArgument().
+				WithNeedEval(false)
+			newArg.SetInfo(&vm.OperatorInfo{
+				Op:          vm.MergeGroup,
+				Idx:         arg.Idx,
+				CnAddr:      arg.CnAddr,
 				OperatorID:  c.allocOperatorID(),
 				ParallelID:  0,
 				MaxParallel: 1,
+			})
+			if parentOp == nil {
+				s.RootOp = newArg
+			} else {
+				parentOp.GetOperatorBase().SetChild(newArg, 0)
 			}
+
 			for j := range ss {
 				ss[j].appendInstruction(vm.Instruction{
 					Op:      vm.Group,
-					Idx:     in.Idx,
-					IsFirst: in.IsFirst,
+					Idx:     arg.Idx,
+					IsFirst: arg.IsFirst,
 					Arg: group.NewArgument().
 						WithExprs(arg.Exprs).
 						WithTypes(arg.Types).
 						WithAggsNew(arg.Aggs),
 
-					CnAddr:      in.CnAddr,
-					OperatorID:  in.OperatorID,
+					CnAddr:      arg.CnAddr,
+					OperatorID:  arg.OperatorID,
 					MaxParallel: int32(len(ss)),
 					ParallelID:  int32(j),
 				})
 			}
 			arg.Release()
 		case vm.Sample:
-			arg := in.Arg.(*sample.Argument)
+			arg := op.(*sample.Argument)
 			if !arg.IsMergeSampleByRow() {
 				flg = true
-				idx = i
+				toReleaseOpRoot = arg.GetChildren(0)
 				// if by percent, there is no need to do merge sample.
 				if arg.IsByPercent() {
-					s.Instructions = s.Instructions[i:]
-				} else {
-					s.Instructions = append(make([]vm.Instruction, 1), s.Instructions[i:]...)
-					s.Instructions[1] = vm.Instruction{
-						Op:      vm.Sample,
-						Idx:     in.Idx,
-						IsFirst: false,
-						Arg:     sample.NewMergeSample(arg, arg.NeedOutputRowSeen),
-
-						CnAddr:      in.CnAddr,
+					newArg := merge.NewArgument()
+					newArg.SetInfo(&vm.OperatorInfo{
+						Op:          vm.Merge,
+						Idx:         arg.Idx,
+						CnAddr:      arg.CnAddr,
 						OperatorID:  c.allocOperatorID(),
 						ParallelID:  0,
 						MaxParallel: 1,
+					})
+					if parentOp == nil {
+						s.RootOp = newArg
+					} else {
+						parentOp.GetOperatorBase().SetChild(newArg, 0)
 					}
-				}
-				s.Instructions[0] = vm.Instruction{
-					Op:  vm.Merge,
-					Idx: s.Instructions[0].Idx,
-					Arg: merge.NewArgument(),
 
-					CnAddr:      in.CnAddr,
-					OperatorID:  c.allocOperatorID(),
-					ParallelID:  0,
-					MaxParallel: 1,
+				} else {
+					tempArg := sample.NewMergeSample(arg, arg.NeedOutputRowSeen)
+					tempArg.SetInfo(&vm.OperatorInfo{
+						Op:          vm.Sample,
+						Idx:         arg.Idx,
+						IsFirst:     false,
+						CnAddr:      arg.CnAddr,
+						OperatorID:  c.allocOperatorID(),
+						ParallelID:  0,
+						MaxParallel: 1,
+					})
+					if parentOp == nil {
+						s.RootOp = tempArg
+					} else {
+						parentOp.GetOperatorBase().SetChild(tempArg, 0)
+					}
+
+					newArg := merge.NewArgument()
+					newArg.SetInfo(&vm.OperatorInfo{
+						Op:          vm.Merge,
+						Idx:         0,
+						CnAddr:      arg.CnAddr,
+						OperatorID:  c.allocOperatorID(),
+						ParallelID:  0,
+						MaxParallel: 1,
+					})
+					tempArg.AppendChild(newArg)
 				}
 
 				for j := range ss {
 					ss[j].appendInstruction(vm.Instruction{
 						Op:      vm.Sample,
-						Idx:     in.Idx,
-						IsFirst: in.IsFirst,
+						Idx:     arg.Idx,
+						IsFirst: arg.IsFirst,
 						Arg:     arg.SimpleDup(),
 
-						CnAddr:      in.CnAddr,
-						OperatorID:  in.OperatorID,
+						CnAddr:      arg.CnAddr,
+						OperatorID:  arg.OperatorID,
 						MaxParallel: int32(len(ss)),
 						ParallelID:  int32(j),
 					})
 				}
+				arg.Release()
 			}
-			arg.Release()
+
 		case vm.Offset:
 			flg = true
-			idx = i
-			arg := in.Arg.(*offset.Argument)
-			s.Instructions = s.Instructions[i:]
-			s.Instructions[0] = vm.Instruction{
-				Op:  vm.MergeOffset,
-				Idx: in.Idx,
-				Arg: mergeoffset.NewArgument().
-					WithOffset(arg.OffsetExpr),
-
-				CnAddr:      in.CnAddr,
+			arg := op.(*offset.Argument)
+			toReleaseOpRoot = arg.GetChildren(0)
+			newArg := mergeoffset.NewArgument().
+				WithOffset(arg.OffsetExpr)
+			newArg.SetInfo(&vm.OperatorInfo{
+				Op:          vm.MergeOffset,
+				Idx:         arg.Idx,
+				CnAddr:      arg.CnAddr,
 				OperatorID:  c.allocOperatorID(),
 				ParallelID:  0,
 				MaxParallel: 1,
+			})
+			if parentOp == nil {
+				s.RootOp = newArg
+			} else {
+				parentOp.GetOperatorBase().SetChild(newArg, 0)
 			}
+
 			for j := range ss {
 				ss[j].appendInstruction(vm.Instruction{
 					Op:      vm.Offset,
-					Idx:     in.Idx,
-					IsFirst: in.IsFirst,
+					Idx:     arg.Idx,
+					IsFirst: arg.IsFirst,
 					Arg: offset.NewArgument().
 						WithOffset(arg.OffsetExpr),
 
-					CnAddr:      in.CnAddr,
-					OperatorID:  in.OperatorID,
+					CnAddr:      arg.CnAddr,
+					OperatorID:  arg.OperatorID,
 					MaxParallel: int32(len(ss)),
 					ParallelID:  int32(j),
 				})
 			}
 			arg.Release()
 		case vm.Output:
+		case vm.Connector:
+		case vm.Dispatch:
 		default:
 			for j := range ss {
-				ss[j].appendInstruction(dupInstruction(&in, nil, j))
+				ss[j].appendInstruction(dupInstruction(op, nil, j))
 			}
 		}
-	}
-	if !flg {
-		for i := range ss {
-			if arg := ss[i].Instructions[len(ss[i].Instructions)-1].Arg; arg != nil {
-				arg.Release()
-			}
-			ss[i].Instructions = ss[i].Instructions[:len(ss[i].Instructions)-1]
-		}
-		if arg := s.Instructions[0].Arg; arg != nil {
-			arg.Release()
-		}
-		s.Instructions[0] = vm.Instruction{
-			Op:  vm.Merge,
-			Idx: s.Instructions[0].Idx, // TODO: remove it
-			Arg: merge.NewArgument(),
+		return nil
+	})
 
-			CnAddr:      s.Instructions[0].CnAddr,
-			OperatorID:  c.allocOperatorID(),
-			ParallelID:  0,
-			MaxParallel: 1,
-		}
+	if !flg {
+		newArg := merge.NewArgument()
+		newArg.Op = vm.Merge
+		leafOp := vm.GetLeafOp(s.RootOp)
+		newArg.Idx = leafOp.GetOperatorBase().Idx // TODO: remove it
+		newArg.CnAddr = leafOp.GetOperatorBase().CnAddr
+		newArg.OperatorID = c.allocOperatorID()
+		newArg.ParallelID = 0
+		newArg.MaxParallel = 1
+
 		// Add log for cn panic which reported on issue 10656
 		// If you find this log is printed, please report the repro details
-		if len(s.Instructions) < 2 {
+		if s.RootOp == nil || s.RootOp.GetOperatorBase().NumChildren() == 0 {
 			c.proc.Error(c.proc.Ctx, "the length of s.Instructions is too short!"+DebugShowScopes([]*Scope{s}),
 				zap.String("stack", string(debug.Stack())),
 			)
 			return nil, moerr.NewInternalErrorNoCtx("the length of s.Instructions is too short !")
 		}
-		if len(s.Instructions)-1 != 1 && s.Instructions[1].Arg != nil {
-			s.Instructions[1].Arg.Release()
-		}
-		s.Instructions[1] = s.Instructions[len(s.Instructions)-1]
-		for i := 2; i < len(s.Instructions)-1; i++ {
-			if arg := s.Instructions[i].Arg; arg != nil {
-				arg.Release()
-			}
-		}
-		s.Instructions = s.Instructions[:2]
+		otherOp := s.RootOp.GetOperatorBase().GetChildren(0)
+		s.RootOp.GetOperatorBase().SetChild(newArg, 0)
+		vm.HandleAllOp(otherOp, func(parentOp vm.Operator, op vm.Operator) error {
+			op.Release()
+			return nil
+		})
 	}
 	s.Magic = Merge
 	s.PreScopes = ss
@@ -977,7 +1023,7 @@ func newParallelScope(c *Compile, s *Scope, ss []*Scope) (*Scope, error) {
 				Arg: connector.NewArgument().
 					WithReg(s.Proc.Reg.MergeReceivers[j]),
 
-				CnAddr:      ss[i].Instructions[0].CnAddr,
+				CnAddr:      vm.GetLeafOp(ss[i].RootOp).GetOperatorBase().CnAddr,
 				OperatorID:  c.allocOperatorID(),
 				ParallelID:  0,
 				MaxParallel: 1,
@@ -985,12 +1031,27 @@ func newParallelScope(c *Compile, s *Scope, ss []*Scope) (*Scope, error) {
 			j++
 		}
 	}
+
 	return s, nil
 }
 
 func (s *Scope) appendInstruction(in vm.Instruction) {
 	if !s.IsEnd {
-		s.Instructions = append(s.Instructions, in)
+		opBase := in.Arg.GetOperatorBase()
+		opBase.SetInfo(&vm.OperatorInfo{
+			Op:          in.Op,
+			Idx:         in.Idx,
+			IsFirst:     in.IsFirst,
+			IsLast:      in.IsLast,
+			CnAddr:      in.CnAddr,
+			OperatorID:  in.OperatorID,
+			ParallelID:  in.ParallelID,
+			MaxParallel: in.MaxParallel,
+		})
+		if s.RootOp != nil {
+			in.Arg.AppendChild(s.RootOp)
+		}
+		s.RootOp = in.Arg
 	}
 }
 
@@ -1000,6 +1061,27 @@ func (s *Scope) appendInstruction(in vm.Instruction) {
 type notifyMessageResult struct {
 	sender *messageSenderOnClient
 	err    error
+}
+
+func (s *Scope) appendOperator(op vm.Operator) {
+	if !s.IsEnd {
+		if s.RootOp != nil {
+			op.AppendChild(s.RootOp)
+		}
+		s.RootOp = op
+	}
+}
+
+func (s *Scope) ReplaceLeafOp(dstLeafOp vm.Operator) {
+	vm.HandleLeafOp(nil, s.RootOp, func(leafOpParent vm.Operator, leafOp vm.Operator) error {
+		leafOp.Release()
+		if leafOpParent == nil {
+			s.RootOp = dstLeafOp
+		} else {
+			leafOpParent.GetOperatorBase().SetChild(dstLeafOp, 0)
+		}
+		return nil
+	})
 }
 
 // sendNotifyMessage create n routines to notify the remote nodes where their receivers are.

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -1064,12 +1064,10 @@ type notifyMessageResult struct {
 }
 
 func (s *Scope) appendOperator(op vm.Operator) {
-	if !s.IsEnd {
-		if s.RootOp != nil {
-			op.AppendChild(s.RootOp)
-		}
-		s.RootOp = op
+	if s.RootOp != nil {
+		op.AppendChild(s.RootOp)
 	}
+	s.RootOp = op
 }
 
 func (s *Scope) ReplaceLeafOp(dstLeafOp vm.Operator) {

--- a/pkg/vm/pipeline/pipeline.go
+++ b/pkg/vm/pipeline/pipeline.go
@@ -26,26 +26,26 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
-func New(tableID uint64, attrs []string, ins vm.Instructions, reg *process.WaitRegister) *Pipeline {
+func New(tableID uint64, attrs []string, op vm.Operator, reg *process.WaitRegister) *Pipeline {
 	return &Pipeline{
-		reg:          reg,
-		instructions: ins,
-		attrs:        attrs,
-		tableID:      tableID,
+		reg:     reg,
+		rootOp:  op,
+		attrs:   attrs,
+		tableID: tableID,
 	}
 }
 
-func NewMerge(ins vm.Instructions, reg *process.WaitRegister) *Pipeline {
+func NewMerge(op vm.Operator, reg *process.WaitRegister) *Pipeline {
 	return &Pipeline{
-		reg:          reg,
-		instructions: ins,
+		reg:    reg,
+		rootOp: op,
 	}
 }
 
 func (p *Pipeline) String() string {
 	var buf bytes.Buffer
 
-	vm.String(p.instructions, &buf)
+	vm.String(p.rootOp, &buf)
 	return buf.String()
 }
 
@@ -66,18 +66,18 @@ func (p *Pipeline) Run(r engine.Reader, topValueMsgTag int32, proc *process.Proc
 		}
 	}
 
-	if tableScanOperator, ok := p.instructions[0].Arg.(*table_scan.Argument); ok {
+	if tableScanOperator, ok := vm.GetLeafOp(p.rootOp).(*table_scan.Argument); ok {
 		tableScanOperator.Reader = r
 		tableScanOperator.TopValueMsgTag = topValueMsgTag
 		tableScanOperator.Attrs = p.attrs
 		tableScanOperator.TableID = p.tableID
 	}
 
-	if err = vm.Prepare(p.instructions, proc); err != nil {
+	if err = vm.Prepare(p.rootOp, proc); err != nil {
 		return false, err
 	}
 	for {
-		end, err = vm.Run(p.instructions, proc)
+		end, err = vm.Run(p.rootOp, proc)
 		if err != nil {
 			return end, err
 		}
@@ -97,7 +97,7 @@ func (p *Pipeline) ConstRun(bat *batch.Batch, proc *process.Process) (end bool, 
 		}
 	}
 
-	if valueScanOperator, ok := p.instructions[0].Arg.(*value_scan.Argument); ok {
+	if valueScanOperator, ok := vm.GetLeafOp(p.rootOp).(*value_scan.Argument); ok {
 		pipelineInputBatches := []*batch.Batch{bat}
 		if bat != nil {
 			pipelineInputBatches = append(pipelineInputBatches, nil)
@@ -105,12 +105,12 @@ func (p *Pipeline) ConstRun(bat *batch.Batch, proc *process.Process) (end bool, 
 		valueScanOperator.Batchs = pipelineInputBatches
 	}
 
-	if err = vm.Prepare(p.instructions, proc); err != nil {
+	if err = vm.Prepare(p.rootOp, proc); err != nil {
 		return false, err
 	}
 
 	for {
-		end, err = vm.Run(p.instructions, proc)
+		end, err = vm.Run(p.rootOp, proc)
 		if err != nil {
 			return end, err
 		}
@@ -129,11 +129,11 @@ func (p *Pipeline) MergeRun(proc *process.Process) (end bool, err error) {
 		}
 	}
 
-	if err = vm.Prepare(p.instructions, proc); err != nil {
+	if err = vm.Prepare(p.rootOp, proc); err != nil {
 		return false, err
 	}
 	for {
-		end, err = vm.Run(p.instructions, proc)
+		end, err = vm.Run(p.rootOp, proc)
 		if err != nil {
 			return end, err
 		}

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -31,53 +31,54 @@ func (ins *Instruction) UnmarshalBinary(_ []byte) error {
 }
 
 // String range instructions and call each operator's string function to show a query plan
-func String(ins Instructions, buf *bytes.Buffer) {
-	for i, in := range ins {
-		if i > 0 {
+func String(rootOp Operator, buf *bytes.Buffer) {
+	HandleAllOp(rootOp, func(parentOp Operator, op Operator) error {
+		if op.GetOperatorBase().NumChildren() > 0 {
 			buf.WriteString(" -> ")
 		}
-		in.Arg.String(buf)
-	}
+		op.String(buf)
+		return nil
+	})
 }
 
 // Prepare range instructions and do init work for each operator's argument by calling its prepare function
-func Prepare(ins Instructions, proc *process.Process) error {
-	for _, in := range ins {
-		if err := in.Arg.Prepare(proc); err != nil {
-			return err
-		}
-	}
-	return nil
+func Prepare(op Operator, proc *process.Process) error {
+	return HandleAllOp(op, func(parentOp Operator, op Operator) error {
+		return op.Prepare(proc)
+	})
 }
 
-func setAnalyzeInfo(ins Instructions, proc *process.Process) {
-	for i := 0; i < len(ins); i++ {
-		switch ins[i].Op {
+func setAnalyzeInfo(rootOp Operator, proc *process.Process) {
+	HandleAllOp(rootOp, func(parentOp Operator, op Operator) error {
+		switch op.GetOperatorBase().Op {
 		case Output:
-			ins[i].Idx = -1
+			op.GetOperatorBase().SetIdx(-1)
 		case TableScan:
-			ins[i].Idx = ins[i+1].Idx
+			op.GetOperatorBase().SetIdx(parentOp.GetOperatorBase().Idx)
 		}
-	}
+		return nil
+	})
 
 	idxMapMajor := make(map[int]int, 0)
 	idxMapMinor := make(map[int]int, 0)
-	for i := 0; i < len(ins); i++ {
+	HandleAllOp(rootOp, func(parentOp Operator, op Operator) error {
+		opBase := op.GetOperatorBase()
 		info := &OperatorInfo{
-			Idx:     ins[i].Idx,
-			IsFirst: ins[i].IsFirst,
-			IsLast:  ins[i].IsLast,
+			Idx:     opBase.Idx,
+			IsFirst: opBase.IsFirst,
+			IsLast:  opBase.IsLast,
 
-			CnAddr:      ins[i].CnAddr,
-			OperatorID:  ins[i].OperatorID,
-			ParallelID:  ins[i].ParallelID,
-			MaxParallel: ins[i].MaxParallel,
+			CnAddr:      opBase.CnAddr,
+			OperatorID:  opBase.OperatorID,
+			ParallelID:  opBase.ParallelID,
+			MaxParallel: opBase.MaxParallel,
 		}
-		switch ins[i].Op {
+		opType := opBase.Op
+		switch opType {
 		case HashBuild, ShuffleBuild, IndexBuild, Filter, MergeGroup, MergeOrder:
 			isMinor := true
-			if ins[i].Op == Filter {
-				if ins[0].Op != TableScan && ins[0].Op != External {
+			if opType == Filter {
+				if opType != TableScan && opType != External {
 					isMinor = false // restrict operator is minor only for scan
 				}
 			}
@@ -111,11 +112,12 @@ func setAnalyzeInfo(ins Instructions, proc *process.Process) {
 		default:
 			info.ParallelIdx = -1 // do nothing for parallel analyze info
 		}
-		ins[i].Arg.SetInfo(info)
-	}
+		opBase.SetInfo(info)
+		return nil
+	})
 }
 
-func Run(ins Instructions, proc *process.Process) (end bool, err error) {
+func Run(rootOp Operator, proc *process.Process) (end bool, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = moerr.ConvertPanicError(proc.Ctx, e)
@@ -123,16 +125,11 @@ func Run(ins Instructions, proc *process.Process) (end bool, err error) {
 		}
 	}()
 
-	setAnalyzeInfo(ins, proc)
+	setAnalyzeInfo(rootOp, proc)
 
-	for i := 1; i < len(ins); i++ {
-		ins[i].Arg.AppendChild(ins[i-1].Arg)
-	}
-
-	root := ins[len(ins)-1].Arg
 	end = false
 	for !end {
-		result, err := root.Call(proc)
+		result, err := rootOp.Call(proc)
 		if err != nil {
 			return true, err
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16727

## What this PR does / why we need it:
make scope.Instructions as tree, not array any more