### PR TITLE
Revert "fix stats for OR expression with more than 2 arguments"

### DIFF
--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -1382,7 +1382,7 @@ func GetExprZoneMap(
 				}
 				zmRes := zms[args[0].AuxId]
 				for i := 1; i < len(args); i++ {
-					if res, ok = zmRes.And(zms[args[i].AuxId]); !ok {
+					if res, ok = zmRes.And(zms[args[1].AuxId]); !ok {
 						zmRes.Reset()
 						break
 					} else {
@@ -1397,7 +1397,7 @@ func GetExprZoneMap(
 				}
 				zmRes := zms[args[0].AuxId]
 				for i := 1; i < len(args); i++ {
-					if res, ok = zmRes.Or(zms[args[i].AuxId]); !ok {
+					if res, ok = zmRes.Or(zms[args[1].AuxId]); !ok {
 						zmRes.Reset()
 						break
 					} else {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -503,26 +503,17 @@ func estimateExprSelectivity(expr *plan.Expr, builder *QueryBuilder) float64 {
 		case ">", "<", ">=", "<=", "between":
 			ret = estimateNonEqualitySelectivity(expr, funcName, builder)
 		case "and":
-			ret = estimateExprSelectivity(exprImpl.F.Args[0], builder)
-			if len(exprImpl.F.Args) == 2 {
-				sel2 := estimateExprSelectivity(exprImpl.F.Args[1], builder)
-				if canMergeToBetweenAnd(exprImpl.F.Args[0], exprImpl.F.Args[1]) && (ret+sel2) > 1 {
-					ret = ret + sel2 - 1
-				} else {
-					ret = andSelectivity(ret, sel2)
-				}
+			sel1 := estimateExprSelectivity(exprImpl.F.Args[0], builder)
+			sel2 := estimateExprSelectivity(exprImpl.F.Args[1], builder)
+			if canMergeToBetweenAnd(exprImpl.F.Args[0], exprImpl.F.Args[1]) && (sel1+sel2) > 1 {
+				ret = sel1 + sel2 - 1
 			} else {
-				for i := 1; i < len(exprImpl.F.Args); i++ {
-					sel2 := estimateExprSelectivity(exprImpl.F.Args[i], builder)
-					ret = andSelectivity(ret, sel2)
-				}
+				ret = andSelectivity(sel1, sel2)
 			}
 		case "or":
-			ret = estimateExprSelectivity(exprImpl.F.Args[0], builder)
-			for i := 1; i < len(exprImpl.F.Args); i++ {
-				sel2 := estimateExprSelectivity(exprImpl.F.Args[i], builder)
-				ret = orSelectivity(ret, sel2)
-			}
+			sel1 := estimateExprSelectivity(exprImpl.F.Args[0], builder)
+			sel2 := estimateExprSelectivity(exprImpl.F.Args[1], builder)
+			ret = orSelectivity(sel1, sel2)
 		case "not":
 			ret = 1 - estimateExprSelectivity(exprImpl.F.Args[0], builder)
 		case "like":


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17200 

## What this PR does / why we need it:
Revert #17184


___

### **PR Type**
Bug fix


___

### **Description**
- Reverted changes in `pkg/sql/colexec/evalExpression.go` to use `args[1]` instead of `args[i]` in `And` and `Or` operations.
- Removed handling for `in` function in composite key filters and simplified the merging filters logic in `pkg/sql/plan/expr_opt.go`.
- Simplified selectivity estimation for `and` and `or` expressions in `pkg/sql/plan/stats.go`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evalExpression.go</strong><dd><code>Revert changes in `And` and `Or` operations handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/colexec/evalExpression.go

<li>Reverted changes in <code>And</code> and <code>Or</code> operations to use <code>args[1]</code> instead of <br><code>args[i]</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17236/files#diff-096074b4e06b58b1b2144cc4b4d91fe38b5c4ced8bfd165e7cfc66bd31aa341d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>expr_opt.go</strong><dd><code>Revert composite key filters merging logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pkg/sql/plan/expr_opt.go

<li>Removed handling for <code>in</code> function in composite key filters.<br> <li> Simplified merging filters logic.<br>


</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17236/files#diff-d74b004ceea0444039926cf26e70fba9951154ce59241418d3f0db00f411cabe">+8/-26</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stats.go</strong><dd><code>Revert selectivity estimation logic for `and` and `or` expressions</code></dd></summary>
<hr>
      
pkg/sql/plan/stats.go

- Simplified selectivity estimation for `and` and `or` expressions.



</details>
    

  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17236/files#diff-3b3d55fa9884dcf8980f90043a05b26a04d0153ae89fcf032cec998752c0cafa">+8/-17</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

