### PR TITLE
fix bugs for between function in prepare mode

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -23,10 +23,16 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 )
 
-func isDynamicParam(expr *plan.Expr) bool {
-	switch expr.Expr.(type) {
+func containsDynamicParam(expr *plan.Expr) bool {
+	switch exprImpl := expr.Expr.(type) {
 	case *plan.Expr_P, *plan.Expr_V:
 		return true
+	case *plan.Expr_F:
+		for _, subExpr := range exprImpl.F.Args {
+			if containsDynamicParam(subExpr) {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -23,6 +23,14 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 )
 
+func isDynamicParam(expr *plan.Expr) bool {
+	switch expr.Expr.(type) {
+	case *plan.Expr_P, *plan.Expr_V:
+		return true
+	}
+	return false
+}
+
 func isRuntimeConstExpr(expr *plan.Expr) bool {
 	switch exprImpl := expr.Expr.(type) {
 	case *plan.Expr_Lit, *plan.Expr_P, *plan.Expr_V, *plan.Expr_Vec, *plan.Expr_T:

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1228,7 +1228,9 @@ func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name s
 
 		lit0 := arg1.GetLit()
 		if arg1.Typ.Id == int32(types.T_any) || lit0 == nil {
-			goto between_fallback
+			if !isRuntimeConstExpr(arg1) {
+				goto between_fallback
+			}
 		}
 
 		arg2, err := ConstantFold(batch.EmptyForConstFoldBatch, fnArgs[2], proc, false, true)
@@ -1237,16 +1239,20 @@ func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name s
 		}
 		fnArgs[2] = arg2
 
-		lit1 := arg1.GetLit()
-		if arg1.Typ.Id == int32(types.T_any) || lit1 == nil {
-			goto between_fallback
+		lit1 := arg2.GetLit()
+		if arg2.Typ.Id == int32(types.T_any) || lit1 == nil {
+			if !isRuntimeConstExpr(arg2) {
+				goto between_fallback
+			}
 		}
 
 		rangeCheckFn, _ := BindFuncExprImplByPlanExpr(ctx, "<=", []*plan.Expr{arg1, arg2})
 		rangeCheckRes, _ := ConstantFold(batch.EmptyForConstFoldBatch, rangeCheckFn, proc, false, true)
 		rangeCheckVal := rangeCheckRes.GetLit()
 		if rangeCheckVal == nil || !rangeCheckVal.GetBval() {
-			goto between_fallback
+			if !isRuntimeConstExpr(arg1) && !isRuntimeConstExpr(arg2) {
+				goto between_fallback
+			}
 		}
 
 		retExpr, _ = ConstantFold(batch.EmptyForConstFoldBatch, retExpr, proc, false, true)

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1228,7 +1228,7 @@ func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name s
 
 		lit0 := arg1.GetLit()
 		if arg1.Typ.Id == int32(types.T_any) || lit0 == nil {
-			if !isRuntimeConstExpr(arg1) {
+			if !isDynamicParam(arg1) {
 				goto between_fallback
 			}
 		}
@@ -1241,7 +1241,7 @@ func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name s
 
 		lit1 := arg2.GetLit()
 		if arg2.Typ.Id == int32(types.T_any) || lit1 == nil {
-			if !isRuntimeConstExpr(arg2) {
+			if !isDynamicParam(arg2) {
 				goto between_fallback
 			}
 		}
@@ -1250,7 +1250,7 @@ func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name s
 		rangeCheckRes, _ := ConstantFold(batch.EmptyForConstFoldBatch, rangeCheckFn, proc, false, true)
 		rangeCheckVal := rangeCheckRes.GetLit()
 		if rangeCheckVal == nil || !rangeCheckVal.GetBval() {
-			if !isRuntimeConstExpr(arg1) && !isRuntimeConstExpr(arg2) {
+			if !isDynamicParam(arg1) && !isDynamicParam(arg2) {
 				goto between_fallback
 			}
 		}

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1228,7 +1228,7 @@ func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name s
 
 		lit0 := arg1.GetLit()
 		if arg1.Typ.Id == int32(types.T_any) || lit0 == nil {
-			if !isDynamicParam(arg1) {
+			if !containsDynamicParam(arg1) {
 				goto between_fallback
 			}
 		}
@@ -1241,7 +1241,7 @@ func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name s
 
 		lit1 := arg2.GetLit()
 		if arg2.Typ.Id == int32(types.T_any) || lit1 == nil {
-			if !isDynamicParam(arg2) {
+			if !containsDynamicParam(arg2) {
 				goto between_fallback
 			}
 		}
@@ -1250,7 +1250,7 @@ func bindFuncExprAndConstFold(ctx context.Context, proc *process.Process, name s
 		rangeCheckRes, _ := ConstantFold(batch.EmptyForConstFoldBatch, rangeCheckFn, proc, false, true)
 		rangeCheckVal := rangeCheckRes.GetLit()
 		if rangeCheckVal == nil || !rangeCheckVal.GetBval() {
-			if !isDynamicParam(arg1) && !isDynamicParam(arg2) {
+			if !containsDynamicParam(arg1) && !containsDynamicParam(arg2) {
 				goto between_fallback
 			}
 		}

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -457,8 +457,16 @@ func estimateNonEqualitySelectivity(expr *plan.Expr, funcName string, builder *Q
 	if s == nil {
 		return 0.1
 	}
+
 	//check strict filter, otherwise can not estimate outcnt by min/max val
-	col, litType, literals, colFnName := extractColRefAndLiteralsInFilter(expr)
+	col, litType, literals, colFnName, hasDynamicParam := extractColRefAndLiteralsInFilter(expr)
+	if hasDynamicParam {
+		if colFnName == "between" {
+			return 0.001
+		} else {
+			return 0.1
+		}
+	}
 	if col != nil && len(literals) > 0 {
 		typ := types.T(s.DataTypeMap[col.Name])
 		if !(typ.IsInteger() || typ.IsDateRelate()) {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -461,10 +461,11 @@ func estimateNonEqualitySelectivity(expr *plan.Expr, funcName string, builder *Q
 	//check strict filter, otherwise can not estimate outcnt by min/max val
 	col, litType, literals, colFnName, hasDynamicParam := extractColRefAndLiteralsInFilter(expr)
 	if hasDynamicParam {
-		if colFnName == "between" {
-			return 0.001
+		// assume dynamic parameter always has low selectivity
+		if funcName == "between" {
+			return 0.0001
 		} else {
-			return 0.1
+			return 0.01
 		}
 	}
 	if col != nil && len(literals) > 0 {

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -589,7 +589,7 @@ func extractColRefAndLiteralsInFilter(expr *plan.Expr) (col *ColRef, litType typ
 		return
 	}
 	for i := range fn.Args {
-		if isRuntimeConstExpr(fn.Args[i]) {
+		if isDynamicParam(fn.Args[i]) {
 			hasDynamicParam = true
 			break
 		}

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -563,8 +563,8 @@ func deduceNewFilterList(filters, onList []*plan.Expr) []*plan.Expr {
 }
 
 func canMergeToBetweenAnd(expr1, expr2 *plan.Expr) bool {
-	col1, _, _, _ := extractColRefAndLiteralsInFilter(expr1)
-	col2, _, _, _ := extractColRefAndLiteralsInFilter(expr2)
+	col1, _, _, _, _ := extractColRefAndLiteralsInFilter(expr1)
+	col2, _, _, _, _ := extractColRefAndLiteralsInFilter(expr2)
 	if col1 == nil || col2 == nil {
 		return false
 	}
@@ -583,10 +583,16 @@ func canMergeToBetweenAnd(expr1, expr2 *plan.Expr) bool {
 	return false
 }
 
-func extractColRefAndLiteralsInFilter(expr *plan.Expr) (col *ColRef, litType types.T, literals []*Const, colFnName string) {
+func extractColRefAndLiteralsInFilter(expr *plan.Expr) (col *ColRef, litType types.T, literals []*Const, colFnName string, hasDynamicParam bool) {
 	fn := expr.GetF()
 	if fn == nil || len(fn.Args) == 0 {
 		return
+	}
+	for i := range fn.Args {
+		if isRuntimeConstExpr(fn.Args[i]) {
+			hasDynamicParam = true
+			break
+		}
 	}
 
 	col = fn.Args[0].GetCol()

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -589,7 +589,7 @@ func extractColRefAndLiteralsInFilter(expr *plan.Expr) (col *ColRef, litType typ
 		return
 	}
 	for i := range fn.Args {
-		if isDynamicParam(fn.Args[i]) {
+		if containsDynamicParam(fn.Args[i]) {
 			hasDynamicParam = true
 			break
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17292 

## What this PR does / why we need it:
在prepare语句下，between and会错误的退化成> and <
另外由于动态参数无法准确预估stats，导致执行计划不优。
假定存在动态参数时，between的过滤度总是比较高的