### PR TITLE
log some filter exprs

### DIFF
--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -707,6 +707,7 @@ type txnTable struct {
 	proc atomic.Pointer[process.Process]
 
 	createByStatementID int
+	enableLogFilterExpr atomic.Bool
 }
 
 type column struct {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14518 

## What this PR does / why we need it:

log some slow ranges expr
log some exprs


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced `traceFilterExprInterval` to manage logging intervals for filter expressions.
- Added logic in `Ranges` method to conditionally log filter expressions based on the length of ranges.
- Implemented logging for filter expressions in `NewReader` method when `enableLogFilterExpr` is set.
- Added `enableLogFilterExpr` atomic boolean to `txnTable` struct to control logging behavior.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Add conditional logging for filter expressions based on range length</code></dd></summary>
<hr>

pkg/vm/engine/disttae/txn_table.go

<li>Introduced <code>traceFilterExprInterval</code> to manage logging intervals.<br> <li> Added logic to conditionally log filter expressions based on range <br>length.<br> <li> Implemented logging for filter expressions in <code>Ranges</code> and <code>NewReader</code> <br>methods.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17351/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+47/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add atomic boolean for enabling filter expression logging</code></dd></summary>
<hr>

pkg/vm/engine/disttae/types.go

- Added `enableLogFilterExpr` atomic boolean to `txnTable` struct.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17351/files#diff-2d4ca99c63be4d7a3464a5089669767530c849522edfe3030145a5b059775852">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

