### PR TITLE
[pick to main] fix Compile clear() bug.

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -228,7 +228,6 @@ func (c *Compile) clear() {
 	c.originSQL = ""
 	c.anal = nil
 	c.e = nil
-	c.proc.Ctx = nil
 	c.proc = nil
 	c.cnList = c.cnList[:0]
 	c.stmt = nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17350 

## What this PR does / why we need it:
the clear method of the Compile structure ,which will be called after query done, should not modify the internal properties of the proc, because this attribute is directly passed in from the outside. When a query fails and a retry occurs, this attribute will still be used.