### PR TITLE
add filter expr log and optimize expr print

### DIFF
--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1804,6 +1804,8 @@ func doFormatExpr(expr *plan.Expr, out *bytes.Buffer, depth int) {
 		out.WriteString(fmt.Sprintf("%sExpr_P(%d)", prefix, t.P.Pos))
 	case *plan.Expr_T:
 		out.WriteString(fmt.Sprintf("%sExpr_T(%s)", prefix, t.T.String()))
+	case *plan.Expr_Vec:
+		out.WriteString(fmt.Sprintf("%sExpr_Vec(len=%d)", prefix, t.Vec.Len))
 	default:
 		out.WriteString(fmt.Sprintf("%sExpr_Unknown(%s)", prefix, expr.String()))
 	}

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -707,6 +707,7 @@ type txnTable struct {
 	proc atomic.Pointer[process.Process]
 
 	createByStatementID int
+	enableLogFilterExpr atomic.Bool
 }
 
 type column struct {

--- a/pkg/vm/engine/tae/rpc/utils.go
+++ b/pkg/vm/engine/tae/rpc/utils.go
@@ -22,6 +22,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
@@ -31,6 +32,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
+	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 )
 
@@ -280,6 +282,12 @@ func (h *Handle) prefetchMetadata(_ context.Context, req *db.WriteReq) (int, err
 			objectName = *loc.Name().Short()
 		}
 	}
+	logutil.Info(
+		"CN-COMMIT-S3",
+		zap.Int("table-id", int(req.TableID)),
+		zap.Int("table-name", int(req.TableName)),
+		zap.Int("obj-cnt", objCnt),
+	)
 	return objCnt, nil
 }
 

--- a/pkg/vm/engine/tae/rpc/utils.go
+++ b/pkg/vm/engine/tae/rpc/utils.go
@@ -285,7 +285,7 @@ func (h *Handle) prefetchMetadata(_ context.Context, req *db.WriteReq) (int, err
 	logutil.Info(
 		"CN-COMMIT-S3",
 		zap.Int("table-id", int(req.TableID)),
-		zap.Int("table-name", int(req.TableName)),
+		zap.String("table-name", req.TableName),
 		zap.Int("obj-cnt", objCnt),
 	)
 	return objCnt, nil


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14518 

## What this PR does / why we need it:

optimize expr print and reduce filter expr prints


___

### **PR Type**
Enhancement


___

### **Description**
- Added handling for vector expressions in the `doFormatExpr` function in `pkg/sql/plan/utils.go`.
- Introduced a new atomic variable `traceFilterExprInterval2` in `pkg/vm/engine/disttae/txn_table.go`.
- Modified the `Ranges` function to optimize filter expression logging based on new conditions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Add handling for vector expressions in `doFormatExpr`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/utils.go

<li>Added a new case for <code>Expr_Vec</code> in the <code>doFormatExpr</code> function to handle <br>vector expressions.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17356/files#diff-4086cbd1a662ffb2a7761174da95abee51e3e0cc7e4ab796e2ec6ef82983ab45">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Optimize filter expression logging in `Ranges` function</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/txn_table.go

<li>Introduced a new atomic variable <code>traceFilterExprInterval2</code>.<br> <li> Modified the <code>Ranges</code> function to include logic for <br><code>traceFilterExprInterval2</code>.<br> <li> Adjusted the logic for enabling logging of filter expressions based on <br>new conditions.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17356/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+12/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

