### PR TITLE
Revert "fix Compile clear() method bug and [pick to 1.2] fix a bug that process's cancel not match to its context "

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -166,6 +166,7 @@ func (c *Compile) reset() {
 	c.originSQL = ""
 	c.anal = nil
 	c.e = nil
+	c.proc.Ctx = nil
 	c.proc = nil
 	c.cnList = c.cnList[:0]
 	c.stmt = nil

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -387,7 +387,6 @@ func (receiver *messageReceiverOnServer) newCompile() (*Compile, error) {
 		cnInfo.hakeeper,
 		cnInfo.udfService,
 		cnInfo.aicm)
-	proc.Ctx = runningCtx
 	proc.Cancel = runningCancel
 	proc.UnixTime = pHelper.unixTime
 	proc.Id = pHelper.id

--- a/pkg/vm/process/process.go
+++ b/pkg/vm/process/process.go
@@ -60,18 +60,13 @@ func New(
 	hakeeper logservice.CNHAKeeperClient,
 	udfService udf.Service,
 	aicm *defines.AutoIncrCacheManager) *Process {
-
-	// process should always have a cancel context to help we close this query.
-	processCtx, processCancel := context.WithCancel(ctx)
-
 	return &Process{
 		mp:           m,
-		Ctx:          processCtx,
-		Cancel:       processCancel,
+		Ctx:          ctx,
 		TxnClient:    txnClient,
 		TxnOperator:  txnOperator,
 		FileService:  fileService,
-		IncrService:  incrservice.GetAutoIncrementService(processCtx),
+		IncrService:  incrservice.GetAutoIncrementService(ctx),
 		UnixTime:     time.Now().UnixNano(),
 		LastInsertID: new(uint64),
 		LockService:  lockService,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17358 

## What this PR does / why we need it:
These two pr will cause :
1、the sysbench test hung 
2、lots of orphan transaction during stability test on distributed mode
3、mo hung during stability test on distributed mode


___

### **PR Type**
Bug fix


___

### **Description**
- Reverted changes to the `reset` method in the `Compile` class to avoid setting `proc.Ctx` to `nil`.
- Reverted changes to the `newCompile` method in the `messageReceiverOnServer` class to restore `proc.Ctx` assignment.
- Reverted context handling changes in the `New` method of the `Process` class to use the original context handling.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compile.go</strong><dd><code>Revert changes to `reset` method in `Compile` class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/compile.go

- Reverted setting `proc.Ctx` to `nil` in `reset` method.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17362/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>remoterunServer.go</strong><dd><code>Revert changes to <code>newCompile</code> method in <code>messageReceiverOnServer</code> class</code></dd></summary>
<hr>

pkg/sql/compile/remoterunServer.go

- Reverted removal of `proc.Ctx` assignment in `newCompile` method.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17362/files#diff-d73b7f89321871c12e2595b1b3fd175f2f3a8a3cff9e153f69c02f23cd650d6f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>process.go</strong><dd><code>Revert context handling changes in `New` method of `Process` class</code></dd></summary>
<hr>

pkg/vm/process/process.go

- Reverted changes to context handling in `New` method.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17362/files#diff-db4c1a0b813fd787a11136eef5742470f6ddc271ddf9381349fbac9b454d6e18">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

