### PR TITLE
cp to 1.2-dev "release unused memory in shuffleRange"

### DIFF
--- a/pkg/pb/statsinfo/shuffle.go
+++ b/pkg/pb/statsinfo/shuffle.go
@@ -374,4 +374,11 @@ func (s *ShuffleRange) Eval() {
 			return
 		}
 	}
+	//release memory in shuffleRange
+	s.Mins = nil
+	s.Maxs = nil
+	s.Rows = nil
+	s.Nulls = nil
+	s.Flags = nil
+	s.Tree = nil
 }

--- a/pkg/pb/statsinfo/shuffle.go
+++ b/pkg/pb/statsinfo/shuffle.go
@@ -133,6 +133,15 @@ func (s *ShuffleRange) Update(zmmin float64, zmmax float64, rowCount int64, null
 	}
 }
 
+func (s *ShuffleRange) ReleaseUnused() {
+	s.Mins = nil
+	s.Maxs = nil
+	s.Rows = nil
+	s.Nulls = nil
+	s.Flags = nil
+	s.Tree = nil
+}
+
 func (s *ShuffleRange) Eval() {
 	k := DefaultEvalSize
 	if s.Sz == 0 {
@@ -374,11 +383,4 @@ func (s *ShuffleRange) Eval() {
 			return
 		}
 	}
-	//release memory in shuffleRange
-	s.Mins = nil
-	s.Maxs = nil
-	s.Rows = nil
-	s.Nulls = nil
-	s.Flags = nil
-	s.Tree = nil
 }

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -175,6 +175,7 @@ func TestShuffleRange(t *testing.T) {
 			shufflerange.Update(testcase[i].min[j], testcase[i].max[j], 1000, 1)
 		}
 		shufflerange.Eval()
+		shufflerange.ReleaseUnused()
 	}
 	shufflerange := NewShuffleRange(true)
 	shufflerange.UpdateString([]byte("0000"), []byte("1000"), 1000, 1)

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -183,6 +183,7 @@ func TestShuffleRange(t *testing.T) {
 	shufflerange.UpdateString([]byte("6000"), []byte("7000"), 1000, 1)
 	shufflerange.UpdateString([]byte("8000"), []byte("9000"), 1000, 1)
 	shufflerange.Eval()
+	shufflerange.ReleaseUnused()
 }
 
 func TestRangeShuffleSlice(t *testing.T) {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -198,6 +198,7 @@ func UpdateStatsInfo(info *InfoFromZoneMap, tableDef *plan.TableDef, s *pb.Stats
 				!util.JudgeIsCompositeClusterByColumn(colName) &&
 				colName != catalog.CPrimaryKeyColName {
 				info.ShuffleRanges[i].Eval()
+				info.ShuffleRanges[i].ReleaseUnused()
 				s.ShuffleRangeMap[colName] = info.ShuffleRanges[i]
 			}
 			info.ShuffleRanges[i] = nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/3678

## What this PR does / why we need it:
release unused memory in shuffleRange