### PR TITLE
[fix] don't push LIMIT clause to index table if main table has filters

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -708,19 +708,17 @@ END0:
 			idxFilter.Selectivity = compositeFilterSel
 		}
 
-		idxTableNodeID := builder.appendNode(&plan.Node{
+		idxTableNode := &plan.Node{
 			NodeType:     plan.Node_TABLE_SCAN,
 			TableDef:     idxTableDef,
 			ObjRef:       idxObjRef,
 			ParentObjRef: DeepCopyObjectRef(node.ObjRef),
 			FilterList:   []*plan.Expr{idxFilter},
-			Limit:        node.Limit,
-			Offset:       node.Offset,
 			BindingTags:  []int32{idxTag},
 			ScanSnapshot: node.ScanSnapshot,
-		}, builder.ctxByNode[nodeID])
+		}
 
-		node.Limit, node.Offset = nil, nil
+		idxTableNodeID := builder.appendNode(idxTableNode, builder.ctxByNode[nodeID])
 
 		pkIdx := node.TableDef.Name2ColIndex[node.TableDef.Pkey.PkeyColName]
 		pkExpr := &plan.Expr{
@@ -745,12 +743,21 @@ END0:
 				},
 			},
 		})
-		joinNodeID := builder.appendNode(&plan.Node{
+
+		joinNode := &plan.Node{
 			NodeType: plan.Node_JOIN,
 			Children: []int32{nodeID, idxTableNodeID},
 			JoinType: plan.Node_INDEX,
 			OnList:   []*plan.Expr{joinCond},
-		}, builder.ctxByNode[nodeID])
+		}
+		joinNodeID := builder.appendNode(joinNode, builder.ctxByNode[nodeID])
+
+		if len(node.FilterList) == 0 {
+			idxTableNode.Limit, idxTableNode.Offset = node.Limit, node.Offset
+		} else {
+			joinNode.Limit, joinNode.Offset = node.Limit, node.Offset
+		}
+		node.Limit, node.Offset = nil, nil
 
 		return joinNodeID
 	}
@@ -831,19 +838,16 @@ END0:
 		}
 		idxFilter.Selectivity = expr.Selectivity
 
-		idxTableNodeID := builder.appendNode(&plan.Node{
+		idxTableNode := &plan.Node{
 			NodeType:     plan.Node_TABLE_SCAN,
 			TableDef:     idxTableDef,
 			ObjRef:       idxObjRef,
 			ParentObjRef: DeepCopyObjectRef(node.ObjRef),
 			FilterList:   []*plan.Expr{idxFilter},
-			Limit:        node.Limit,
-			Offset:       node.Offset,
 			BindingTags:  []int32{idxTag},
 			ScanSnapshot: node.ScanSnapshot,
-		}, builder.ctxByNode[nodeID])
-
-		node.Limit, node.Offset = nil, nil
+		}
+		idxTableNodeID := builder.appendNode(idxTableNode, builder.ctxByNode[nodeID])
 
 		pkIdx := node.TableDef.Name2ColIndex[node.TableDef.Pkey.PkeyColName]
 		pkExpr := &plan.Expr{
@@ -868,12 +872,20 @@ END0:
 				},
 			},
 		})
-		joinNodeID := builder.appendNode(&plan.Node{
+		joinNode := &plan.Node{
 			NodeType: plan.Node_JOIN,
 			Children: []int32{nodeID, idxTableNodeID},
 			JoinType: plan.Node_INDEX,
 			OnList:   []*plan.Expr{joinCond},
-		}, builder.ctxByNode[nodeID])
+		}
+		joinNodeID := builder.appendNode(joinNode, builder.ctxByNode[nodeID])
+
+		if len(node.FilterList) == 0 {
+			idxTableNode.Limit, idxTableNode.Offset = node.Limit, node.Offset
+		} else {
+			joinNode.Limit, joinNode.Offset = node.Limit, node.Offset
+		}
+		node.Limit, node.Offset = nil, nil
 
 		return joinNodeID
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/3713

## What this PR does / why we need it:
When main table has both filters and limit, we can't move limit to index table