### PR TITLE
using process memory usage for background task memory throttle 1.2

### DIFF
--- a/pkg/vm/engine/tae/db/merge/policyBasic.go
+++ b/pkg/vm/engine/tae/db/merge/policyBasic.go
@@ -86,16 +86,15 @@ func (o *customConfigProvider) GetConfig(tbl *catalog.TableEntry) *BasicPolicyCo
 			if cnSize == 0 {
 				cnSize = common.DefaultMinCNMergeSize * common.Const1MBytes
 			}
-			// if the values are smaller than default, it map old rows -> bytes size
+			// compatible codes: remap old rows -> default bytes size
 			minOsize := extra.MinOsizeQuailifed
-			if v := uint32(80 * 8192); minOsize < v {
-				minOsize = v
+			if minOsize < 80*8192 {
+				minOsize = common.DefaultMinOsizeQualifiedMB * common.Const1MBytes
 			}
 			maxOsize := extra.MaxOsizeMergedObj
-			if v := uint32(500 * 8192); maxOsize < v {
-				maxOsize = v
+			if maxOsize < 500*8192 {
+				maxOsize = common.DefaultMaxOsizeObjMB * common.Const1MBytes
 			}
-
 			p = &BasicPolicyConfig{
 				ObjectMinOsize:    minOsize,
 				MergeMaxOneRun:    int(extra.MaxObjOnerun),


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/17416

## What this PR does / why we need it:
- using process memory to do control merge tasks, expecting better behavior in container


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced process memory usage tracking using the `gopsutil` library to improve memory management for merge tasks.
- Replaced the `memSpare` variable with `memLimit` and `memUsing` to better reflect the new memory management strategy.
- Updated the logic for calculating memory limits, considering both container memory limits and host memory.
- Enhanced logging to include new memory metrics such as process memory limit and usage.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>executor.go</strong><dd><code>Implement process memory usage for merge task control</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/merge/executor.go

<li>Added process memory usage tracking using <code>gopsutil</code>.<br> <li> Replaced <code>memSpare</code> with <code>memLimit</code> and <code>memUsing</code>.<br> <li> Updated memory limit calculation logic.<br> <li> Modified logging to reflect new memory metrics.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17436/files#diff-e9134fa072053b9ad4aa76535cf21f869315f286535007500176e915668636f0">+41/-35</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

