### PR TITLE
[BugFix]: Reduce mp.Grow2 in SEMI Join and TableScan Operator

### DIFF
--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -652,6 +652,48 @@ func (v *Vector) PreExtend(rows int, mp *mpool.MPool) error {
 	return extend(v, rows, mp)
 }
 
+// PreExtendArea use to expand the mpool and area of vector
+func (v *Vector) PreExtendArea(rows int, mp *mpool.MPool) error {
+
+	// expand mpool
+	if err := v.PreExtend(rows, mp); err != nil {
+		return err
+	}
+
+	// get the size required for storing new rows
+	var vSize int
+	switch v.typ.Oid {
+	case types.T_array_float32:
+		vSize = 4 * int(v.typ.Width)
+	case types.T_array_float64:
+		vSize = 8 * int(v.typ.Width)
+	default:
+		vSize = v.typ.TypeSize()
+	}
+	vlen := vSize * rows
+
+	// check if required size is already satisfied
+	area1 := v.GetArea()
+	voff := len(area1)
+	if voff+vlen <= cap(area1) {
+		return nil
+	}
+
+	// grow area
+	var err error
+	oldSz := len(area1)
+	area1, err = mp.Grow(area1, voff+vlen)
+	if err != nil {
+		return err
+	}
+	area1 = area1[:oldSz] // This is important.
+
+	// set area
+	v.SetArea(area1)
+
+	return nil
+}
+
 // Dup use to copy an identical vector
 func (v *Vector) Dup(mp *mpool.MPool) (*Vector, error) {
 	if v.IsConstNull() {

--- a/pkg/sql/colexec/semi/join.go
+++ b/pkg/sql/colexec/semi/join.go
@@ -271,7 +271,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *SemiJoin, proc *process.Proces
 		//eligible = eligible[:0]
 	}
 
-	for j, _ := range ap.Result {
+	for j := range ap.Result {
 		if err := ctr.rbat.Vecs[j].PreExtendArea(len(eligible), proc.Mp()); err != nil {
 			return err
 		}

--- a/pkg/sql/colexec/semi/join.go
+++ b/pkg/sql/colexec/semi/join.go
@@ -199,7 +199,7 @@ func (ctr *container) probe(bat *batch.Batch, ap *SemiJoin, proc *process.Proces
 	itr := ctr.mp.NewIterator()
 
 	rowCountIncrease := 0
-	eligible := make([]int32, 0, hashmap.UnitLimit)
+	eligible := make([]int32, 0) // eligible := make([]int32, 0, hashmap.UnitLimit)
 	for i := 0; i < count; i += hashmap.UnitLimit {
 		n := count - i
 		if n > hashmap.UnitLimit {
@@ -268,12 +268,19 @@ func (ctr *container) probe(bat *batch.Batch, ap *SemiJoin, proc *process.Proces
 			eligible = append(eligible, int32(i+k))
 			rowCountIncrease++
 		}
-		for j, pos := range ap.Result {
-			if err := ctr.rbat.Vecs[j].Union(bat.Vecs[pos], eligible, proc.Mp()); err != nil {
-				return err
-			}
+		//eligible = eligible[:0]
+	}
+
+	for j, _ := range ap.Result {
+		if err := ctr.rbat.Vecs[j].PreExtendArea(len(eligible), proc.Mp()); err != nil {
+			return err
 		}
-		eligible = eligible[:0]
+	}
+
+	for j, pos := range ap.Result {
+		if err := ctr.rbat.Vecs[j].Union(bat.Vecs[pos], eligible, proc.Mp()); err != nil {
+			return err
+		}
 	}
 
 	ctr.rbat.AddRowCount(rowCountIncrease)

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -281,6 +281,9 @@ func BlockReadInner(
 			} else {
 				result.Vecs[i] = vp.GetVector(typ)
 			}
+			if err = result.Vecs[i].PreExtendArea(len(selectRows), mp); err != nil {
+				break
+			}
 			if err = result.Vecs[i].Union(col, selectRows, mp); err != nil {
 				break
 			}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/16124

## What this PR does / why we need it:

Reduce `mpool.Grow()` calls in `SEMI Join` and `TableScan` operators.
QPS of Vector Index KNN queries improved from 25 to 78 (5 concurrent clients)

Previous Profile
![image](https://github.com/matrixorigin/matrixone/assets/9638314/2d37e528-7300-4d5f-bc32-d12099eb6c1c)


New Profile
![image](https://github.com/matrixorigin/matrixone/assets/9638314/d52bcb06-14ed-4564-a174-10380a626842)


___

### **PR Type**
Bug fix


___

### **Description**
- Added `PreExtendArea` function to the vector package to optimize memory pool and area expansion.
- Modified the SEMI Join operator to use `PreExtendArea` for better memory management.
- Updated `BlockReadInner` function to call `PreExtendArea` before performing union operations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vector.go</strong><dd><code>Add `PreExtendArea` function to vector for memory optimization</code></dd></summary>
<hr>

pkg/container/vector/vector.go

<li>Added <code>PreExtendArea</code> function to expand the memory pool and area of a <br>vector.<br> <li> Implemented logic to calculate required size and grow the area if <br>necessary.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17466/files#diff-28ac70822524921592389604c9d3caa2e7c488a52b02d22fe9bdc35f8d808d5f">+42/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>join.go</strong><dd><code>Optimize memory allocation in SEMI Join operator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/semi/join.go

<li>Modified <code>probe</code> function to use <code>PreExtendArea</code> for memory optimization.<br> <li> Removed preallocation of <code>eligible</code> slice with <code>hashmap.UnitLimit</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17466/files#diff-9d43ce448fda34d9ed66281be3a4968b6f195467d3bfb1f9904a67f189686de4">+13/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>read.go</strong><dd><code>Use `PreExtendArea` in BlockReadInner for memory optimization</code></dd></summary>
<hr>

pkg/vm/engine/tae/blockio/read.go

<li>Added call to <code>PreExtendArea</code> before union operation in <code>BlockReadInner</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17466/files#diff-e90a1b44f23a26266c0f82ac5b90aa7cfa3d4faef05ceff130c664ef1b37f497">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

