### PR TITLE
fix TestReadWithSpecialShard

### DIFF
--- a/pkg/shardservice/service_read_test.go
+++ b/pkg/shardservice/service_read_test.go
@@ -159,10 +159,13 @@ func TestReadWithSpecialShard(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			fn(s1, 1, newTestTimestamp(2), s1v1)
-			fn(s1, 2, newTestTimestamp(3), s2v2)
-			fn(s2, 1, newTestTimestamp(2), s1v1)
-			fn(s2, 2, newTestTimestamp(3), s2v2)
+			shard1 := s1.getAllocatedShards()[0].ShardID
+			shard2 := s2.getAllocatedShards()[0].ShardID
+
+			fn(s1, shard1, newTestTimestamp(2), s1v1)
+			fn(s1, shard2, newTestTimestamp(3), s2v2)
+			fn(s2, shard1, newTestTimestamp(2), s1v1)
+			fn(s2, shard2, newTestTimestamp(3), s2v2)
 		},
 		nil,
 	)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16683 

## What this PR does / why we need it:
The rebalance schedules shards between service nodes randomly. The test cannot assume that shard1 is in service1