### PR TITLE
improvement when filter expr is nil

### DIFF
--- a/pkg/sql/colexec/filter/filter.go
+++ b/pkg/sql/colexec/filter/filter.go
@@ -45,10 +45,12 @@ func (filter *Filter) Prepare(proc *process.Process) (err error) {
 	filter.ctr = new(container)
 	var filterExpr *plan.Expr
 
+	if filter.exeExpr == nil && filter.E == nil {
+		return nil
+	}
+
 	if filter.exeExpr == nil {
-		if filter.E != nil {
-			filterExpr, err = plan2.ConstantFold(batch.EmptyForConstFoldBatch, plan2.DeepCopyExpr(filter.E), proc, true, true)
-		}
+		filterExpr, err = plan2.ConstantFold(batch.EmptyForConstFoldBatch, plan2.DeepCopyExpr(filter.E), proc, true, true)
 	} else {
 		filterExpr, err = plan2.ConstantFold(batch.EmptyForConstFoldBatch, plan2.DeepCopyExpr(filter.exeExpr), proc, true, true)
 	}
@@ -73,7 +75,7 @@ func (filter *Filter) Call(proc *process.Process) (vm.CallResult, error) {
 	anal.Start()
 	defer anal.Stop()
 
-	if result.Batch == nil || result.Batch.IsEmpty() || result.Batch.Last() {
+	if result.Batch == nil || result.Batch.IsEmpty() || result.Batch.Last() || len(filter.ctr.executors) == 0 {
 		return result, nil
 	}
 	if filter.ctr.buf != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/16994

## What this PR does / why we need it:
when filter expo is nil, return children call's result in advance 