### PR TITLE
fileservice, metric: various optimizations

### DIFF
--- a/pkg/fileservice/bytes.go
+++ b/pkg/fileservice/bytes.go
@@ -17,7 +17,6 @@ package fileservice
 import (
 	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/memorycache"
-	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 )
 
 type Bytes struct {
@@ -41,7 +40,6 @@ func (b Bytes) Slice(length int) memorycache.CacheData {
 func (b Bytes) Release() {
 	if b.deallocator != nil {
 		b.deallocator.Deallocate(malloc.NoHints)
-		metric.FSMallocLiveObjectsBytes.Dec()
 	}
 }
 
@@ -56,7 +54,6 @@ func (b *bytesAllocator) Alloc(size int) memorycache.CacheData {
 	if err != nil {
 		panic(err)
 	}
-	metric.FSMallocLiveObjectsBytes.Inc()
 	return Bytes{
 		bytes:       slice,
 		deallocator: dec,

--- a/pkg/fileservice/io_entry.go
+++ b/pkg/fileservice/io_entry.go
@@ -102,19 +102,16 @@ func (i *IOEntry) prepareData() (finally func(err *error)) {
 		if err != nil {
 			panic(err)
 		}
-		metric.FSMallocLiveObjectsIOEntryData.Inc()
 		i.Data = slice
 		if i.releaseData != nil {
 			i.releaseData()
 		}
 		i.releaseData = func() {
 			dec.Deallocate(malloc.NoHints)
-			metric.FSMallocLiveObjectsIOEntryData.Dec()
 		}
 		finally = func(err *error) {
 			if err != nil && *err != nil {
 				dec.Deallocate(malloc.NoHints)
-				metric.FSMallocLiveObjectsIOEntryData.Dec()
 			}
 		}
 

--- a/pkg/fileservice/memorycache/data.go
+++ b/pkg/fileservice/memorycache/data.go
@@ -18,7 +18,6 @@ import (
 	"sync/atomic"
 
 	"github.com/matrixorigin/matrixone/pkg/common/malloc"
-	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 )
 
 // Data is a reference counted byte buffer
@@ -51,7 +50,6 @@ func newData(
 			panic(err)
 		}
 	}
-	metric.FSMallocLiveObjectsMemoryCache.Inc()
 	data.ref.init(1)
 	return data
 }
@@ -62,7 +60,6 @@ func (d *Data) free() {
 	if d.deallocator != nil {
 		d.deallocator.Deallocate(malloc.NoHints)
 	}
-	metric.FSMallocLiveObjectsMemoryCache.Dec()
 }
 
 func (d *Data) Bytes() []byte {

--- a/pkg/fileservice/object_storage_metrics.go
+++ b/pkg/fileservice/object_storage_metrics.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"context"
+	"io"
+	"time"
+
+	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// objectStorageMetrics tracks operations and expose to prometheus
+type objectStorageMetrics struct {
+	upstream ObjectStorage
+
+	numDelete prometheus.Gauge
+	numExists prometheus.Gauge
+	numList   prometheus.Gauge
+	numRead   prometheus.Gauge
+	numStat   prometheus.Gauge
+	numWrite  prometheus.Gauge
+}
+
+func newObjectStorageMetrics(
+	upstream ObjectStorage,
+	name string,
+) *objectStorageMetrics {
+	return &objectStorageMetrics{
+		upstream: upstream,
+
+		numRead:   metric.FSObjectStorageOperations.WithLabelValues(name, "read"),
+		numWrite:  metric.FSObjectStorageOperations.WithLabelValues(name, "write"),
+		numDelete: metric.FSObjectStorageOperations.WithLabelValues(name, "delete"),
+		numList:   metric.FSObjectStorageOperations.WithLabelValues(name, "list"),
+		numExists: metric.FSObjectStorageOperations.WithLabelValues(name, "exists"),
+		numStat:   metric.FSObjectStorageOperations.WithLabelValues(name, "stat"),
+	}
+}
+
+var _ ObjectStorage = new(objectStorageMetrics)
+
+func (o *objectStorageMetrics) Delete(ctx context.Context, keys ...string) (err error) {
+	o.numDelete.Add(1)
+	return o.upstream.Delete(ctx, keys...)
+}
+
+func (o *objectStorageMetrics) Exists(ctx context.Context, key string) (bool, error) {
+	o.numExists.Add(1)
+	return o.upstream.Exists(ctx, key)
+}
+
+func (o *objectStorageMetrics) List(ctx context.Context, prefix string, fn func(isPrefix bool, key string, size int64) (bool, error)) (err error) {
+	o.numList.Add(1)
+	return o.upstream.List(ctx, prefix, fn)
+}
+
+func (o *objectStorageMetrics) Read(ctx context.Context, key string, min *int64, max *int64) (r io.ReadCloser, err error) {
+	o.numRead.Add(1)
+	return o.upstream.Read(ctx, key, min, max)
+}
+
+func (o *objectStorageMetrics) Stat(ctx context.Context, key string) (size int64, err error) {
+	o.numStat.Add(1)
+	return o.upstream.Stat(ctx, key)
+}
+
+func (o *objectStorageMetrics) Write(ctx context.Context, key string, r io.Reader, size int64, expire *time.Time) (err error) {
+	o.numWrite.Add(1)
+	return o.upstream.Write(ctx, key, r, size, expire)
+}

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -118,11 +118,20 @@ func NewS3FS(
 		concurrency,
 	)
 
+	// metrics
+	fs.storage = newObjectStorageMetrics(
+		fs.storage,
+		"s3",
+	)
+
+	// cache
 	if !noCache {
 		if err := fs.initCaches(ctx, cacheConfig); err != nil {
 			return nil, err
 		}
 	}
+
+	// allocator
 	if fs.memCache != nil {
 		fs.allocator = fs.memCache
 	} else {
@@ -321,7 +330,6 @@ func (s *S3FS) Write(ctx context.Context, vector IOVector) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	metric.FSWriteS3Counter.Add(float64(len(vector.Entries)))
 
 	tp := reuse.Alloc[tracePoint](nil)
 	defer reuse.Free(tp, nil)

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_fs.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_fs.go
@@ -31,6 +31,7 @@ func (c *DashboardCreator) initFileServiceDashboard() error {
 		"FileService Metrics",
 		c.withRowOptions(
 			c.initFSOverviewRow(),
+			c.initFSObjectStorageRow(),
 			c.initFSIOMergerDurationRow(),
 			c.initFSReadWriteDurationRow(),
 			c.initFSMallocRow(),
@@ -53,27 +54,17 @@ func (c *DashboardCreator) initFSOverviewRow() dashboard.Option {
 			6,
 			[]string{
 				`sum(rate(` + c.getMetricWithFilter("mo_fs_read_total", `type="s3"`) + `[$interval]))`,
+				`sum(rate(` + c.getMetricWithFilter("mo_fs_read_total", `type="local"`) + `[$interval]))`,
 				`sum(rate(` + c.getMetricWithFilter("mo_fs_read_total", `type="hit-mem"`) + `[$interval]))`,
 				`sum(rate(` + c.getMetricWithFilter("mo_fs_read_total", `type="hit-disk"`) + `[$interval]))`,
 				`sum(rate(` + c.getMetricWithFilter("mo_fs_read_total", `type="hit-remote"`) + `[$interval]))`,
 			},
 			[]string{
 				"s3",
+				"local",
 				"hit-mem",
 				"hit-disk",
 				"hit-remote",
-			}),
-
-		c.withMultiGraph(
-			"S3 Write requests",
-			6,
-			[]string{
-				`sum(rate(` + c.getMetricWithFilter("mo_fs_write_total", `type="s3"`) + `[$interval]))`,
-				`sum(rate(` + c.getMetricWithFilter("mo_fs_write_total", `type="local"`) + `[$interval]))`,
-			},
-			[]string{
-				"s3",
-				"local",
 			}),
 	)
 }
@@ -225,5 +216,53 @@ func (c *DashboardCreator) initFSMallocRow() dashboard.Option {
 				"bytes",
 				"memory_cache",
 			}),
+	)
+}
+
+func (c *DashboardCreator) initFSObjectStorageRow() dashboard.Option {
+	return dashboard.Row(
+		"Object Storage",
+
+		c.withMultiGraph(
+			"s3 operations",
+			3,
+			[]string{
+				c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="read"`),
+				c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="write"`),
+				c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="delete"`),
+				c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="list"`),
+				c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="exists"`),
+				c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="stat"`),
+			},
+			[]string{
+				"read",
+				"write",
+				"delete",
+				"list",
+				"exists",
+				"stat",
+			},
+		),
+
+		c.withMultiGraph(
+			"s3 operations rate",
+			3,
+			[]string{
+				`rate(` + c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="read"`) + `[$interval])`,
+				`rate(` + c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="write"`) + `[$interval])`,
+				`rate(` + c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="delete"`) + `[$interval])`,
+				`rate(` + c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="list"`) + `[$interval])`,
+				`rate(` + c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="exists"`) + `[$interval])`,
+				`rate(` + c.getMetricWithFilter("mo_fs_object_storage_operations", `name="s3",op="stat"`) + `[$interval])`,
+			},
+			[]string{
+				"read",
+				"write",
+				"delete",
+				"list",
+				"exists",
+				"stat",
+			},
+		),
 	)
 }

--- a/pkg/util/metric/v2/fileservice.go
+++ b/pkg/util/metric/v2/fileservice.go
@@ -43,19 +43,10 @@ var (
 			Help:      "Total number of read count.",
 		}, []string{"type"})
 	FSReadS3Counter        = fsReadCounter.WithLabelValues("s3")
+	FSReadLocalCounter     = fsReadCounter.WithLabelValues("local")
 	FSReadHitMemCounter    = fsReadCounter.WithLabelValues("hit-mem")
 	FSReadHitDiskCounter   = fsReadCounter.WithLabelValues("hit-disk")
 	FSReadHitRemoteCounter = fsReadCounter.WithLabelValues("hit-remote")
-
-	fsWriteCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "mo",
-			Subsystem: "fs",
-			Name:      "write_total",
-			Help:      "Total number of write count.",
-		}, []string{"type"})
-	FSWriteS3Counter    = fsWriteCounter.WithLabelValues("s3")
-	FSWriteLocalCounter = fsWriteCounter.WithLabelValues("local")
 )
 
 var (
@@ -152,16 +143,16 @@ var (
 )
 
 var (
-	fsMallocLiveObjects = prometheus.NewGaugeVec(
+	FSObjectStorageOperations = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "mo",
 			Subsystem: "fs",
-			Name:      "malloc_live_objects",
-			Help:      "malloc live objects",
+			Name:      "object_storage_operations",
+			Help:      "object storage operations",
 		},
-		[]string{"type"},
+		[]string{
+			"name",
+			"op",
+		},
 	)
-	FSMallocLiveObjectsIOEntryData = fsMallocLiveObjects.WithLabelValues("io_entry_data")
-	FSMallocLiveObjectsBytes       = fsMallocLiveObjects.WithLabelValues("bytes")
-	FSMallocLiveObjectsMemoryCache = fsMallocLiveObjects.WithLabelValues("memory_cache")
 )

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -81,7 +81,6 @@ func initTaskMetrics() {
 
 func initFileServiceMetrics() {
 	registry.MustRegister(fsReadCounter)
-	registry.MustRegister(fsWriteCounter)
 	registry.MustRegister(S3ConnectCounter)
 	registry.MustRegister(S3DNSResolveCounter)
 
@@ -91,8 +90,8 @@ func initFileServiceMetrics() {
 
 	registry.MustRegister(ioMergerCounter)
 	registry.MustRegister(ioMergerDuration)
-	registry.MustRegister(fsMallocLiveObjects)
 	registry.MustRegister(fsReadWriteDuration)
+	registry.MustRegister(FSObjectStorageOperations)
 }
 
 func initLogtailMetrics() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17504 

## What this PR does / why we need it:
replace existing write metrics with general metrics for all object storage operations.

fileservice: add metrics for object storage

fileservice: remove fsMallocLiveObjects, duplicated with malloc metrics

fileservice: add FSReadLocalCounter