### PR TITLE
remove useless data structure from proc

### DIFF
--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -1131,11 +1131,7 @@ func receiveMsgAndForward(proc *process.Process, sender *messageSenderOnClient, 
 			return nil
 		}
 
-		if forwardCh == nil {
-			// used for delete.
-			// I don't know what is that.
-			proc.SetInputBatch(bat)
-		} else {
+		if forwardCh != nil {
 			msg := &process.RegisterMessage{Batch: bat}
 			select {
 			case <-proc.Ctx.Done():

--- a/pkg/vm/process/process.go
+++ b/pkg/vm/process/process.go
@@ -226,14 +226,6 @@ func (proc *Process) OperatorOutofMemory(size int64) bool {
 	return proc.Mp().Cap() < size
 }
 
-func (proc *Process) SetInputBatch(bat *batch.Batch) {
-	proc.Reg.InputBatch = bat
-}
-
-func (proc *Process) InputBatch() *batch.Batch {
-	return proc.Reg.InputBatch
-}
-
 func (proc *Process) ResetContextFromParent(parent context.Context) context.Context {
 	newctx, cancel := context.WithCancel(parent)
 

--- a/pkg/vm/process/types.go
+++ b/pkg/vm/process/types.go
@@ -96,11 +96,6 @@ type WaitRegister struct {
 
 // Register used in execution pipeline and shared with all operators of the same pipeline.
 type Register struct {
-	// Ss, temporarily stores the row number list in the execution of operators,
-	// and it can be reused in the future execution.
-	Ss [][]int64
-	// InputBatch, stores the result of the previous operator.
-	InputBatch *batch.Batch
 	// MergeReceivers, receives result of multi previous operators from other pipelines
 	// e.g. merge operator.
 	MergeReceivers []*WaitRegister


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16542 

## What this PR does / why we need it:
remove useless data structure from proc, for furthur refactoring of proc and merge operator