### PR TITLE
reduce mp.Grow2 by call PreExtendArea

### DIFF
--- a/pkg/sql/colexec/semi/join.go
+++ b/pkg/sql/colexec/semi/join.go
@@ -239,12 +239,6 @@ func (ctr *container) probe(bat *batch.Batch, ap *SemiJoin, proc *process.Proces
 	}
 
 	for j, pos := range ap.Result {
-		if err := ctr.rbat.Vecs[j].PreExtendWithArea(len(eligible), len(bat.Vecs[pos].GetArea()), proc.Mp()); err != nil {
-			return err
-		}
-	}
-
-	for j, pos := range ap.Result {
 		if err := ctr.rbat.Vecs[j].Union(bat.Vecs[pos], eligible, proc.Mp()); err != nil {
 			return err
 		}

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -273,7 +273,6 @@ func BlockReadInner(
 		}
 
 		// assemble result batch only with selected rows
-		doExtendArea := len(selectRows) > 100
 		for i, col := range loaded.Vecs {
 			typ := *col.GetType()
 			if typ.Oid == types.T_Rowid {
@@ -285,13 +284,7 @@ func BlockReadInner(
 			} else {
 				result.Vecs[i] = vp.GetVector(typ)
 			}
-			extendAreaSize := 0
-			if doExtendArea {
-				extendAreaSize = len(col.GetArea())
-			}
-			if err = result.Vecs[i].PreExtendWithArea(len(selectRows), extendAreaSize, mp); err != nil {
-				break
-			}
+
 			if err = result.Vecs[i].Union(col, selectRows, mp); err != nil {
 				break
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17579 #17657

## What this PR does / why we need it:
reduce mp.Grow2 in external operator