### PR TITLE
[bug] proxy: proxy get connection ids from backend servers

### DIFF
--- a/pkg/cnservice/server_heartbeat.go
+++ b/pkg/cnservice/server_heartbeat.go
@@ -122,6 +122,7 @@ func (s *service) handleCommands(cmds []logservicepb.ScheduleCommand) {
 		if cmd.CreateTaskService != nil {
 			s.createTaskService(cmd.CreateTaskService)
 			s.createSQLLogger(cmd.CreateTaskService)
+			s.createProxyUser(cmd.CreateTaskService)
 		} else if s.gossipNode.Created() && cmd.JoinGossipCluster != nil {
 			s.gossipNode.SetJoined()
 

--- a/pkg/cnservice/server_task.go
+++ b/pkg/cnservice/server_task.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
 	logservicepb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/task"
+	"github.com/matrixorigin/matrixone/pkg/proxy"
 	moconnector "github.com/matrixorigin/matrixone/pkg/stream/connector"
 	"github.com/matrixorigin/matrixone/pkg/taskservice"
 	"github.com/matrixorigin/matrixone/pkg/util"
@@ -175,6 +176,10 @@ func (s *service) canClaimDaemonTask(taskAccount string) bool {
 
 	// 4. Otherwise, we could not run this task.
 	return false
+}
+
+func (s *service) createProxyUser(command *logservicepb.CreateTaskService) {
+	frontend.SetSpecialUser(proxy.SQLUsername, []byte(command.User.Password))
 }
 
 func (s *service) startTaskRunner() {

--- a/pkg/proxy/bootstrap.go
+++ b/pkg/proxy/bootstrap.go
@@ -51,6 +51,8 @@ func (h *handler) bootstrap(ctx context.Context) {
 			if state.TaskTableUser.GetUsername() != "" && state.TaskTableUser.GetPassword() != "" {
 				db_holder.SetSQLWriterDBUser(db_holder.MOLoggerUser, state.TaskTableUser.GetPassword())
 				db_holder.SetSQLWriterDBAddressFunc(util.AddressFunc(h.config.UUID, getClient))
+				h.sqlWorker.SetSQLUser(SQLUsername, state.TaskTableUser.GetPassword())
+				h.sqlWorker.SetAddressFn(util.AddressFunc(h.config.UUID, getClient))
 				return
 			}
 		case <-ctx.Done():

--- a/pkg/proxy/bootstrap_test.go
+++ b/pkg/proxy/bootstrap_test.go
@@ -37,7 +37,7 @@ func TestBootstrap(t *testing.T) {
 		RebalanceInterval: toml.Duration{Duration: time.Second},
 	}
 	cfg.Cluster.RefreshInterval = toml.Duration{Duration: defaultRefreshInterval}
-	h, err := newProxyHandler(ctx, rt, cfg, st, nil, &c)
+	h, err := newProxyHandler(ctx, rt, cfg, st, nil, &c, true)
 	require.NoError(t, err)
 	h.bootstrap(ctx)
 

--- a/pkg/proxy/client_conn.go
+++ b/pkg/proxy/client_conn.go
@@ -381,7 +381,7 @@ func (c *clientConn) handleKillQuery(e *killQueryEvent, resp chan<- []byte) erro
 	}
 	cn.connID = cid
 
-	return c.connAndExec(cn, fmt.Sprintf("KILL QUERY %d", e.connID), resp)
+	return c.connAndExec(cn, e.stmt, resp)
 }
 
 // handleSetVar handles the set variable event.

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -181,6 +181,13 @@ func WithConfigData(data map[string]*logservicepb.ConfigItem) Option {
 	}
 }
 
+// WithTest set the test field to true.
+func WithTest() Option {
+	return func(s *Server) {
+		s.test = true
+	}
+}
+
 // FillDefault fill the default config values of proxy server.
 func (c *Config) FillDefault() {
 	if c.ListenAddress == "" {

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -49,6 +49,9 @@ type handler struct {
 	haKeeperClient logservice.ProxyHAKeeperClient
 	// ipNetList is the list of ip net, which is parsed from CIDRs.
 	ipNetList []*net.IPNet
+	// SQLWorker works for the SQL selection. It connects to some
+	// CN server and query for some information.
+	sqlWorker SQLWorker
 }
 
 var ErrNoAvailableCNServers = moerr.NewInternalErrorNoCtx("no available CN servers")
@@ -61,6 +64,7 @@ func newProxyHandler(
 	st *stopper.Stopper,
 	cs *counterSet,
 	haKeeperClient logservice.ProxyHAKeeperClient,
+	test bool,
 ) (*handler, error) {
 	// Create the MO cluster.
 	mc := clusterservice.NewMOCluster(cfg.UUID, haKeeperClient, cfg.Cluster.RefreshInterval.Duration)
@@ -81,10 +85,19 @@ func newProxyHandler(
 		return nil, err
 	}
 
-	ru := newRouter(mc, re, false,
-		withConnectTimeout(cfg.ConnectTimeout.Duration),
-		withAuthTimeout(cfg.AuthTimeout.Duration),
-	)
+	// The SQL worker is mainly used in router currently.
+	sw := newSQLWorker()
+
+	var ru Router
+	if test {
+		ru = newRouter(mc, re, re.connManager, false)
+	} else {
+		ru = newRouter(mc, re, sw, false,
+			withConnectTimeout(cfg.ConnectTimeout.Duration),
+			withAuthTimeout(cfg.AuthTimeout.Duration),
+		)
+	}
+
 	// Decorate the router if plugin is enabled
 	if cfg.Plugin != nil {
 		p, err := newRPCPlugin(cfg.UUID, cfg.Plugin.Backend, cfg.Plugin.Timeout)
@@ -116,6 +129,7 @@ func newProxyHandler(
 		rebalancer:     re,
 		haKeeperClient: haKeeperClient,
 		ipNetList:      ipNetList,
+		sqlWorker:      sw,
 	}, nil
 }
 

--- a/pkg/proxy/handler_test.go
+++ b/pkg/proxy/handler_test.go
@@ -68,7 +68,7 @@ func newTestProxyHandler(t *testing.T) *testProxyHandler {
 		hc:     hc,
 		mc:     mc,
 		re:     re,
-		ru:     newRouter(mc, re, false),
+		ru:     newRouter(mc, re, re.connManager, false),
 		closeFn: func() {
 			mc.Close()
 			st.Stop()
@@ -419,7 +419,7 @@ func testWithServer(t *testing.T, fn func(*testing.T, string, *Server)) {
 
 	// start proxy.
 	s, err := NewServer(ctx, cfg, WithRuntime(runtime.DefaultRuntime()),
-		WithHAKeeperClient(hc))
+		WithHAKeeperClient(hc), WithTest())
 	defer func() {
 		err := s.Close()
 		require.NoError(t, err)

--- a/pkg/proxy/router_test.go
+++ b/pkg/proxy/router_test.go
@@ -29,6 +29,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type mockSQLWorker struct{}
+
+func newMockSQLWorker() *mockSQLWorker {
+	return &mockSQLWorker{}
+}
+
+func (w *mockSQLWorker) GetCNServerByConnID(_ uint32) (*CNServer, error) {
+	return nil, nil
+}
+
 func TestCNServer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	temp := os.TempDir()
@@ -75,7 +85,7 @@ func TestRouter_SelectEmptyCN(t *testing.T) {
 	mc.ForceRefresh(true)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 
 	li1 := labelInfo{
 		Tenant: "t1",
@@ -110,7 +120,7 @@ func TestRouter_RouteForCommon(t *testing.T) {
 	mc.ForceRefresh(true)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 	ctx := context.TODO()
 
 	li1 := labelInfo{
@@ -187,7 +197,7 @@ func TestRouter_RouteForSys(t *testing.T) {
 	defer mc.Close()
 	rt.SetGlobalVariables(runtime.ClusterService, mc)
 	re := testRebalancer(t, st, logger, mc)
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 	li1 := labelInfo{
 		Tenant: "sys",
 	}
@@ -251,7 +261,7 @@ func TestRouter_SelectByConnID(t *testing.T) {
 	defer func() {
 		require.NoError(t, stopFn1())
 	}()
-	ru := newRouter(nil, re, true)
+	ru := newRouter(nil, re, re.connManager, true)
 
 	cn1 := testMakeCNServer("uuid1", addr1, 10, "", labelInfo{})
 	_, _, err := ru.Connect(cn1, testPacket, nil)
@@ -323,7 +333,7 @@ func TestRouter_ConnectAndSelectBalanced(t *testing.T) {
 	mc.ForceRefresh(true)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 
 	connResult := make(map[string]struct{})
 	li1 := labelInfo{
@@ -433,7 +443,7 @@ func TestRouter_ConnectAndSelectSpecify(t *testing.T) {
 	mc.ForceRefresh(true)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 
 	connResult := make(map[string]struct{})
 	li1 := labelInfo{
@@ -529,7 +539,7 @@ func TestRouter_Filter(t *testing.T) {
 	mc.ForceRefresh(true)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, true)
+	ru := newRouter(mc, re, newMockSQLWorker(), true)
 
 	cn, err := ru.Route(ctx, "", clientInfo{username: "dump"}, func(s string) bool {
 		return s == addr1
@@ -587,7 +597,7 @@ func TestRouter_RetryableConnect(t *testing.T) {
 	mc.ForceRefresh(true)
 	re := testRebalancer(t, st, logger, mc)
 
-	ru := newRouter(mc, re, false)
+	ru := newRouter(mc, re, newMockSQLWorker(), false)
 
 	li1 := labelInfo{
 		Tenant: "t1",

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -44,6 +44,7 @@ type Server struct {
 	haKeeperClient logservice.ProxyHAKeeperClient
 	// configData will be sent to HAKeeper.
 	configData *util.ConfigData
+	test       bool
 }
 
 // NewServer creates the proxy server.
@@ -85,7 +86,15 @@ func NewServer(ctx context.Context, config Config, opts ...Option) (*Server, err
 	stats.Register(statsFamilyName, stats.WithLogExporter(logExporter))
 
 	s.stopper = stopper.NewStopper("mo-proxy", stopper.WithLogger(s.runtime.Logger().RawLogger()))
-	h, err := newProxyHandler(ctx, s.runtime, s.config, s.stopper, s.counterSet, s.haKeeperClient)
+	h, err := newProxyHandler(
+		ctx,
+		s.runtime,
+		s.config,
+		s.stopper,
+		s.counterSet,
+		s.haKeeperClient,
+		s.test,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/proxy/server_conn_test.go
+++ b/pkg/proxy/server_conn_test.go
@@ -287,6 +287,8 @@ func testHandle(h *testHandler) {
 				h.handleStopTxn()
 			} else if strings.HasPrefix(string(packet.Payload[1:]), "kill connection") {
 				h.handleKillConn()
+			} else if strings.Contains(string(packet.Payload[1:]), "processlist") {
+				h.handleShowProcesslist()
 			} else {
 				h.handleCommon()
 			}
@@ -418,6 +420,51 @@ func (h *testHandler) handleStartTxn() {
 func (h *testHandler) handleStopTxn() {
 	h.status &= ^frontend.SERVER_STATUS_IN_TRANS
 	h.handleCommon()
+}
+
+func (h *testHandler) handleShowProcesslist() {
+	h.mysqlProto.SetSequenceID(1)
+	err := h.mysqlProto.SendColumnCountPacket(2)
+	if err != nil {
+		_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeErrPayload(0, "", err.Error()))
+		return
+	}
+	cols := []*plan.ColDef{
+		{Typ: plan.Type{Id: int32(types.T_varchar)}, Name: "node_id"},
+		{Typ: plan.Type{Id: int32(types.T_varchar)}, Name: "host"},
+	}
+	columns := make([]interface{}, len(cols))
+	res := &frontend.MysqlResultSet{}
+	for i, col := range cols {
+		c := new(frontend.MysqlColumn)
+		c.SetName(col.Name)
+		c.SetOrgName(col.Name)
+		c.SetTable(col.Typ.Table)
+		c.SetOrgTable(col.Typ.Table)
+		c.SetAutoIncr(col.Typ.AutoIncr)
+		c.SetSchema("")
+		c.SetDecimal(col.Typ.Scale)
+		columns[i] = c
+		res.AddColumn(c)
+	}
+	for _, c := range columns {
+		if err := h.mysqlProto.SendColumnDefinitionPacket(context.TODO(), c.(frontend.Column), 3); err != nil {
+			_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeErrPayload(0, "", err.Error()))
+			return
+		}
+	}
+	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeEOFPayload(0, h.status))
+	row := make([]interface{}, 2)
+	row[0] = "node1"
+	row[1] = "host1"
+	res.AddRow(row)
+	ses := &frontend.Session{}
+	h.mysqlProto.SetSession(ses)
+	if err := h.mysqlProto.SendResultSetTextBatchRow(res, res.GetRowCount()); err != nil {
+		_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeErrPayload(0, "", err.Error()))
+		return
+	}
+	_ = h.mysqlProto.WritePacket(h.mysqlProto.MakeEOFPayload(0, h.status))
 }
 
 func (s *testCNServer) Stop() error {

--- a/pkg/proxy/sql_worker.go
+++ b/pkg/proxy/sql_worker.go
@@ -1,0 +1,154 @@
+// Copyright 2021 - 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+)
+
+const SQLUsername = "proxy_user"
+
+// SQLRouter routes connections with SQL query. It executes some queries to
+// get information about tenant, connection ID or others and returns the
+// property CN servers.
+type SQLRouter interface {
+	// GetCNServerByConnID gets CN server by connection ID.
+	// It connects to CN backend server to query data.
+	GetCNServerByConnID(uint32) (*CNServer, error)
+}
+
+// SQLWorker is the interface which contains methods to init the SQL worker.
+type SQLWorker interface {
+	// SetSQLUser sets up the auth information to connect to backend servers.
+	// The information comes from TaskTableUser which is in HAKeeper.
+	SetSQLUser(username, password string)
+	// SetAddressFn sets up the function which returns the backend server address.
+	// The information comes from TaskTableUser which is in HAKeeper.
+	SetAddressFn(f sqlAddressFn)
+}
+
+// sqlUser defines the structure which contains username and password
+// that is used to connect to backend server.
+type sqlUser struct {
+	username string
+	password string
+}
+
+// sqlAddressFn is the function that would return the backend server address.
+type sqlAddressFn func(context.Context, bool) (string, error)
+
+// sqlWorker is the type of SQL worker, which do some SQL query jobs.
+type sqlWorker struct {
+	mu struct {
+		sync.RWMutex
+		sqlUser       sqlUser
+		addressGetter sqlAddressFn
+	}
+}
+
+// newSQLWorker creates a new sqlWorker instance.
+func newSQLWorker() *sqlWorker {
+	return &sqlWorker{}
+}
+
+// readyRLocked checks if the worker is ready. It checks its username
+// and address getter function, if they are both not empty, the worker
+// is ready. It requires the read lock.
+func (w *sqlWorker) readyRLocked() bool {
+	return w.mu.sqlUser.username != "" && w.mu.addressGetter != nil
+}
+
+// SetSQLUser implements the SQLWorker interface.
+func (w *sqlWorker) SetSQLUser(username, password string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.mu.sqlUser.username = username
+	w.mu.sqlUser.password = password
+}
+
+// SetAddressFn implements the SQLWorker interface.
+func (w *sqlWorker) SetAddressFn(f sqlAddressFn) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.mu.addressGetter = f
+}
+
+// initDB uses user info and address getter function to open the connection to
+// backend server and returns the sql.DB instance.
+func (w *sqlWorker) initDB() (*sql.DB, error) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if !w.readyRLocked() {
+		return nil, moerr.NewInternalErrorNoCtx("SQL worker is not ready yet")
+	}
+	dbAddress, err := w.mu.addressGetter(context.Background(), true)
+	if err != nil {
+		return nil, err
+	}
+	sock := "tcp"
+	if strings.Contains(dbAddress, "sock") {
+		sock = "unix"
+	}
+	dsn := fmt.Sprintf("%s:%s@%s(%s)/?timeout=5s",
+		w.mu.sqlUser.username, w.mu.sqlUser.password, sock, dbAddress)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// GetCNServerByConnID implements the SQLWorker interface.
+func (w *sqlWorker) GetCNServerByConnID(connID uint32) (*CNServer, error) {
+	db, err := w.initDB()
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	// The special user has the highest priority to fetch all tenants' information.
+	// So we filter with tenant name.
+	rows, err := db.Query(
+		fmt.Sprintf("select node_id, host from processlist() a where conn_id='%d'", connID))
+	if err != nil {
+		return nil, err
+	}
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+	defer rows.Close()
+	if rows.Next() {
+		var (
+			nodeID string
+			host   string
+		)
+		err := rows.Scan(&nodeID, &host)
+		if err != nil {
+			return nil, err
+		}
+		return &CNServer{
+			connID: connID,
+			uuid:   nodeID,
+			addr:   host,
+		}, nil
+	}
+	return nil, nil
+}

--- a/pkg/proxy/sql_worker_test.go
+++ b/pkg/proxy/sql_worker_test.go
@@ -1,0 +1,60 @@
+// Copyright 2021 - 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSqlWorker_InitDBNotReady(t *testing.T) {
+	testWithServer(t, func(t *testing.T, addr string, server *Server) {
+		w := newSQLWorker()
+		db, err := w.initDB()
+		require.Error(t, err)
+		require.Nil(t, db)
+	})
+}
+
+func TestSqlWorker_InitDB(t *testing.T) {
+	testWithServer(t, func(t *testing.T, addr string, server *Server) {
+		w := newSQLWorker()
+		w.SetSQLUser("dump", "111")
+		w.SetAddressFn(func(ctx context.Context, b bool) (string, error) {
+			return addr, nil
+		})
+		db, err := w.initDB()
+		require.NoError(t, err)
+		require.NotNil(t, db)
+		defer func() {
+			_ = db.Close()
+		}()
+	})
+}
+
+func TestSqlWorker_GetCNServerByConnID(t *testing.T) {
+	testWithServer(t, func(t *testing.T, addr string, server *Server) {
+		w := newSQLWorker()
+		w.SetSQLUser("dump", "111")
+		w.SetAddressFn(func(ctx context.Context, b bool) (string, error) {
+			return addr, nil
+		})
+		cn, err := w.GetCNServerByConnID(9)
+		require.NoError(t, err)
+		require.NotNil(t, cn)
+	})
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16824

## What this PR does / why we need it:
proxy get connection ids from backend servers rather than from conn manager