### PR TITLE
fix upgrade framework panic

### DIFF
--- a/pkg/bootstrap/service_upgrade_tenant.go
+++ b/pkg/bootstrap/service_upgrade_tenant.go
@@ -247,7 +247,11 @@ func (s *service) asyncUpgradeTenantTask(ctx context.Context) {
 
 				upgrade.ReadyTenant += updated
 				if upgrade.TotalTenant < upgrade.ReadyTenant {
-					panic(fmt.Sprintf("BUG: invalid upgrade tenant, upgrade %s, updated %d", upgrade.String(), updated))
+					s.logger.Error("invalid upgrade tenant",
+						zap.String("upgrade", upgrade.String()),
+						zap.Int32("updated", updated),
+					)
+					return moerr.NewInvalidStateNoCtx("orphan txn or pre lock released by lock table changed")
 				}
 
 				s.logger.Info("upgrade tenant ready count changed",


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue [#3757](https://github.com/matrixorigin/MO-Cloud/issues/3757)

## What this PR does / why we need it:
Return error instead of panic. Because the txn maybe orphan or pre lock release (lock table changed), the txn cannot commit successfully. 