### PR TITLE
do not use transfer map generated by protobuf

### DIFF
--- a/pkg/pb/api/api.go
+++ b/pkg/pb/api/api.go
@@ -168,3 +168,11 @@ func (m *MergeCommitEntry) MarshalBinary() ([]byte, error) {
 func (m *MergeCommitEntry) UnmarshalBinary(data []byte) error {
 	return m.Unmarshal(data)
 }
+
+// To reduce memory consumption
+
+type TransferMaps []TransferMap
+type TransferMap map[int32]TransferDestPos
+type TransferDestPos struct {
+	ObjIdx, BlkIdx, RowIdx int32
+}

--- a/pkg/vm/engine/disttae/merge.go
+++ b/pkg/vm/engine/disttae/merge.go
@@ -61,7 +61,8 @@ type cnMergeTask struct {
 	targets []logtailreplay.ObjectInfo
 
 	// commit things
-	commitEntry *api.MergeCommitEntry
+	commitEntry  *api.MergeCommitEntry
+	transferMaps api.TransferMaps
 
 	// auxiliaries
 	fs fileservice.FileService
@@ -195,6 +196,17 @@ func (t *cnMergeTask) GetCommitEntry() *api.MergeCommitEntry {
 		return t.prepareCommitEntry()
 	}
 	return t.commitEntry
+}
+
+func (t *cnMergeTask) InitTransferMaps(blkCnt int) {
+	t.transferMaps = make(api.TransferMaps, blkCnt)
+	for i := range t.transferMaps {
+		t.transferMaps[i] = make(api.TransferMap)
+	}
+}
+
+func (t *cnMergeTask) GetTransferMaps() *api.TransferMaps {
+	return &t.transferMaps
 }
 
 // impl DisposableVecPool

--- a/pkg/vm/engine/tae/mergesort/merger.go
+++ b/pkg/vm/engine/tae/mergesort/merger.go
@@ -98,7 +98,7 @@ func newMerger[T any](host MergeTaskHost, lessFunc sort.LessFunc[T], sortKeyPos 
 		totalBlkCnt += cnt
 	}
 	if host.DoTransfer() {
-		initTransferMapping(host.GetCommitEntry(), totalBlkCnt)
+		host.InitTransferMaps(totalBlkCnt)
 	}
 
 	return m
@@ -134,7 +134,7 @@ func (m *merger[T]) merge(ctx context.Context) error {
 	}
 	defer releaseF()
 
-	commitEntry := m.host.GetCommitEntry()
+	transferMaps := m.host.GetTransferMaps()
 	for m.heap.Len() != 0 {
 		select {
 		case <-ctx.Done():
@@ -158,7 +158,7 @@ func (m *merger[T]) merge(ctx context.Context) error {
 		}
 
 		if m.host.DoTransfer() {
-			commitEntry.Booking.Mappings[m.accObjBlkCnts[objIdx]+m.loadedObjBlkCnts[objIdx]-1].M[int32(rowIdx)] = api.TransDestPos{
+			(*transferMaps)[m.accObjBlkCnts[objIdx]+m.loadedObjBlkCnts[objIdx]-1][int32(rowIdx)] = api.TransferDestPos{
 				ObjIdx: int32(m.stats.objCnt),
 				BlkIdx: int32(uint32(m.stats.objBlkCnt)),
 				RowIdx: int32(m.stats.blkRowCnt),

--- a/pkg/vm/engine/tae/mergesort/reshaper.go
+++ b/pkg/vm/engine/tae/mergesort/reshaper.go
@@ -31,7 +31,7 @@ func reshape(ctx context.Context, host MergeTaskHost) error {
 		for _, cnt := range objBlkCnts {
 			totalBlkCnt += cnt
 		}
-		initTransferMapping(host.GetCommitEntry(), totalBlkCnt)
+		host.InitTransferMaps(totalBlkCnt)
 	}
 	rowSizeU64 := host.GetTotalSize() / uint64(host.GetTotalRowCnt())
 	stats := mergeStats{
@@ -43,7 +43,7 @@ func reshape(ctx context.Context, host MergeTaskHost) error {
 	originalObjCnt := host.GetObjectCnt()
 	maxRowCnt := host.GetBlockMaxRows()
 	accObjBlkCnts := host.GetAccBlkCnts()
-	commitEntry := host.GetCommitEntry()
+	transferMaps := host.GetTransferMaps()
 
 	var writer *blockio.BlockWriter
 	var buffer *batch.Batch
@@ -75,7 +75,7 @@ func reshape(ctx context.Context, host MergeTaskHost) error {
 				}
 
 				if host.DoTransfer() {
-					commitEntry.Booking.Mappings[accObjBlkCnts[i]+loadedBlkCnt-1].M[int32(j)] = api.TransDestPos{
+					(*transferMaps)[accObjBlkCnts[i]+loadedBlkCnt-1][int32(j)] = api.TransferDestPos{
 						ObjIdx: int32(stats.objCnt),
 						BlkIdx: int32(uint32(stats.objBlkCnt)),
 						RowIdx: int32(stats.blkRowCnt),
@@ -101,7 +101,7 @@ func reshape(ctx context.Context, host MergeTaskHost) error {
 					buffer.CleanOnlyData()
 
 					if stats.needNewObject() {
-						if err := syncObject(ctx, writer, commitEntry); err != nil {
+						if err := syncObject(ctx, writer, host.GetCommitEntry()); err != nil {
 							return err
 						}
 						writer = nil
@@ -133,7 +133,7 @@ func reshape(ctx context.Context, host MergeTaskHost) error {
 		buffer.CleanOnlyData()
 	}
 	if stats.objBlkCnt > 0 {
-		if err := syncObject(ctx, writer, commitEntry); err != nil {
+		if err := syncObject(ctx, writer, host.GetCommitEntry()); err != nil {
 			return err
 		}
 		writer = nil

--- a/pkg/vm/engine/tae/mergesort/task.go
+++ b/pkg/vm/engine/tae/mergesort/task.go
@@ -47,6 +47,8 @@ type MergeTaskHost interface {
 	Name() string
 	HostHintName() string
 	GetCommitEntry() *api.MergeCommitEntry
+	InitTransferMaps(blkCnt int)
+	GetTransferMaps() *api.TransferMaps
 	PrepareNewWriter() *blockio.BlockWriter
 	DoTransfer() bool
 	GetObjectCnt() int
@@ -59,10 +61,6 @@ type MergeTaskHost interface {
 	GetBlockMaxRows() uint32
 	GetObjectMaxBlocks() uint16
 	GetTargetObjSize() uint32
-}
-
-func initTransferMapping(e *api.MergeCommitEntry, blkcnt int) {
-	e.Booking = NewBlkTransferBooking(blkcnt)
 }
 
 func getSimilarBatch(bat *batch.Batch, capacity int, vpool DisposableVecPool) (*batch.Batch, func()) {

--- a/pkg/vm/engine/tae/rpc/handle_debug.go
+++ b/pkg/vm/engine/tae/rpc/handle_debug.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"strconv"
 	"strings"
 	"time"
@@ -375,54 +376,66 @@ func (h *Handle) HandleCommitMerge(
 		}
 	}()
 
+	var booking api.TransferMaps
 	if len(req.BookingLoc) > 0 {
 		// load transfer info from s3
 		if req.Booking != nil {
 			logutil.Error("mergeblocks err booking loc is not empty, but booking is not nil")
 		}
-		if len(req.BookingLoc) == objectio.LocationLen {
-			loc := objectio.Location(req.BookingLoc)
+
+		blkCnt := types.DecodeInt32(req.BookingLoc)
+		rowsCnt := make([]int32, blkCnt)
+		idx := 1
+		for i := range blkCnt {
+			rowsCnt[i] = types.DecodeInt32(req.BookingLoc[idx*4:])
+			idx++
+		}
+		booking = make(api.TransferMaps, blkCnt)
+		for i := range blkCnt {
+			booking[i] = make(api.TransferMap, rowsCnt[i])
+		}
+
+		locations := req.BookingLoc[idx*4:]
+		for p := 0; p < len(locations); p += objectio.LocationLen {
+			loc := objectio.Location(locations[p : p+objectio.LocationLen])
 			var bat *batch.Batch
 			var release func()
-			bat, release, err = blockio.LoadTombstoneColumns(ctx, []uint16{0}, nil, h.db.Runtime.Fs.Service, loc, nil)
+			bat, release, err = blockio.LoadTombstoneColumns(ctx, []uint16{0, 1, 2, 3, 4}, nil, h.db.Runtime.Fs.Service, loc, nil)
 			if err != nil {
 				return
 			}
-			req.Booking = &api.BlkTransferBooking{}
-			err = req.Booking.Unmarshal(bat.Vecs[0].GetBytesAt(0))
-			if err != nil {
-				release()
-				return
+
+			for i := range bat.RowCount() {
+				srcBlk := vector.GetFixedAt[int32](bat.Vecs[0], i)
+				srcRow := vector.GetFixedAt[int32](bat.Vecs[1], i)
+				destObj := vector.GetFixedAt[int32](bat.Vecs[2], i)
+				destBlk := vector.GetFixedAt[int32](bat.Vecs[3], i)
+				destRow := vector.GetFixedAt[int32](bat.Vecs[4], i)
+
+				booking[srcBlk][srcRow] = api.TransferDestPos{
+					ObjIdx: destObj,
+					BlkIdx: destBlk,
+					RowIdx: destRow,
+				}
 			}
 			release()
 			h.db.Runtime.Fs.Service.Delete(ctx, loc.Name().String())
 			bat = nil
-		} else {
-			// it has to copy to concat
-			idx := 0
-			locations := req.BookingLoc
-			data := make([]byte, 0, 2<<30)
-			for ; idx < len(locations); idx += objectio.LocationLen {
-				loc := objectio.Location(locations[idx : idx+objectio.LocationLen])
-				var bat *batch.Batch
-				var release func()
-				bat, release, err = blockio.LoadTombstoneColumns(ctx, []uint16{0}, nil, h.db.Runtime.Fs.Service, loc, nil)
-				if err != nil {
-					return
+		}
+	} else if req.Booking != nil {
+		booking = make(api.TransferMaps, len(req.Booking.Mappings))
+		for i, m := range req.Booking.Mappings {
+			for r, pos := range m.M {
+				booking[i][r] = api.TransferDestPos{
+					ObjIdx: pos.ObjIdx,
+					BlkIdx: pos.BlkIdx,
+					RowIdx: pos.RowIdx,
 				}
-				data = append(data, bat.Vecs[0].GetBytesAt(0)...)
-				release()
-				h.db.Runtime.Fs.Service.Delete(ctx, loc.Name().String())
-				bat = nil
-			}
-			req.Booking = &api.BlkTransferBooking{}
-			if err = req.Booking.Unmarshal(data); err != nil {
-				return
 			}
 		}
 	}
 
-	_, err = jobs.HandleMergeEntryInTxn(ctx, txn, txn.String(), req, h.db.Runtime)
+	_, err = jobs.HandleMergeEntryInTxn(ctx, txn, txn.String(), req, booking, h.db.Runtime)
 	if err != nil {
 		return
 	}

--- a/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
@@ -53,6 +53,7 @@ type mergeObjectsTask struct {
 	totalMergedBlkCnt int
 	createdBObjs      []*catalog.ObjectEntry
 	commitEntry       *api.MergeCommitEntry
+	transferMaps      api.TransferMaps
 	rel               handle.Relation
 	did, tid          uint64
 
@@ -225,6 +226,17 @@ func (task *mergeObjectsTask) GetCommitEntry() *api.MergeCommitEntry {
 	return task.commitEntry
 }
 
+func (task *mergeObjectsTask) InitTransferMaps(blkCnt int) {
+	task.transferMaps = make(api.TransferMaps, blkCnt)
+	for i := range task.transferMaps {
+		task.transferMaps[i] = make(api.TransferMap)
+	}
+}
+
+func (task *mergeObjectsTask) GetTransferMaps() *api.TransferMaps {
+	return &task.transferMaps
+}
+
 func (task *mergeObjectsTask) prepareCommitEntry() *api.MergeCommitEntry {
 	schema := task.rel.Schema().(*catalog.Schema)
 	commitEntry := &api.MergeCommitEntry{}
@@ -302,7 +314,7 @@ func (task *mergeObjectsTask) Execute(ctx context.Context) (err error) {
 	}
 
 	phaseDesc = "2-HandleMergeEntryInTxn"
-	if task.createdBObjs, err = HandleMergeEntryInTxn(ctx, task.txn, task.Name(), task.commitEntry, task.rt); err != nil {
+	if task.createdBObjs, err = HandleMergeEntryInTxn(ctx, task.txn, task.Name(), task.commitEntry, task.transferMaps, task.rt); err != nil {
 		return err
 	}
 
@@ -312,7 +324,14 @@ func (task *mergeObjectsTask) Execute(ctx context.Context) (err error) {
 	return nil
 }
 
-func HandleMergeEntryInTxn(ctx context.Context, txn txnif.AsyncTxn, taskName string, entry *api.MergeCommitEntry, rt *dbutils.Runtime) ([]*catalog.ObjectEntry, error) {
+func HandleMergeEntryInTxn(
+	ctx context.Context,
+	txn txnif.AsyncTxn,
+	taskName string,
+	entry *api.MergeCommitEntry,
+	booking api.TransferMaps,
+	rt *dbutils.Runtime,
+) ([]*catalog.ObjectEntry, error) {
 	database, err := txn.GetDatabaseByID(entry.DbId)
 	if err != nil {
 		return nil, err
@@ -364,7 +383,7 @@ func HandleMergeEntryInTxn(ctx context.Context, txn txnif.AsyncTxn, taskName str
 		rel,
 		mergedObjs,
 		createdObjs,
-		entry.Booking,
+		booking,
 		rt,
 	)
 	if err != nil {

--- a/pkg/vm/engine/tae/tables/txnentries/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/txnentries/mergeobjects.go
@@ -43,7 +43,7 @@ type mergeObjectsEntry struct {
 	relation      handle.Relation
 	droppedObjs   []*catalog.ObjectEntry
 	createdObjs   []*catalog.ObjectEntry
-	transMappings *api.BlkTransferBooking
+	transMappings api.TransferMaps
 	skipTransfer  bool
 
 	rt                   *dbutils.Runtime
@@ -60,7 +60,7 @@ func NewMergeObjectsEntry(
 	taskName string,
 	relation handle.Relation,
 	droppedObjs, createdObjs []*catalog.ObjectEntry,
-	transMappings *api.BlkTransferBooking,
+	transMappings api.TransferMaps,
 	rt *dbutils.Runtime,
 ) (*mergeObjectsEntry, error) {
 	totalCreatedBlkCnt := 0
@@ -102,7 +102,7 @@ func (entry *mergeObjectsEntry) prepareTransferPage(ctx context.Context) {
 		var duration time.Duration
 		var start time.Time
 		for j := 0; j < obj.BlockCnt(); j++ {
-			m := entry.transMappings.Mappings[k].M
+			m := entry.transMappings[k]
 			k++
 			if len(m) == 0 {
 				continue
@@ -138,8 +138,8 @@ func (entry *mergeObjectsEntry) prepareTransferPage(ctx context.Context) {
 		duration += time.Since(start)
 		v2.TransferPageMergeLatencyHistogram.Observe(duration.Seconds())
 	}
-	if k != len(entry.transMappings.Mappings) {
-		logutil.Fatal(fmt.Sprintf("k %v, mapping %v", k, len(entry.transMappings.Mappings)))
+	if k != len(entry.transMappings) {
+		logutil.Fatal(fmt.Sprintf("k %v, mapping %v", k, len(entry.transMappings)))
 	}
 }
 
@@ -223,7 +223,7 @@ func (entry *mergeObjectsEntry) transferObjectDeletes(
 		row := rowid[i].GetRowOffset()
 		blkOffsetInObj := int(rowid[i].GetBlockOffset())
 		blkOffset := blkOffsetBase + blkOffsetInObj
-		mapping := entry.transMappings.Mappings[blkOffset].M
+		mapping := entry.transMappings[blkOffset]
 		if len(mapping) == 0 {
 			// this block had been all deleted, skip
 			// Note: it is possible that the block is empty, but not the object
@@ -290,7 +290,7 @@ func (entry *mergeObjectsEntry) collectDelsAndTransfer(from, to types.TS) (trans
 		hasMappingInThisObj := false
 		blkCnt := dropped.BlockCnt()
 		for iblk := 0; iblk < blkCnt; iblk++ {
-			if len(entry.transMappings.Mappings[blksOffsetBase+iblk].M) != 0 {
+			if len(entry.transMappings[blksOffsetBase+iblk]) != 0 {
 				hasMappingInThisObj = true
 				break
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16653

## What this PR does / why we need it:

The Protobuf-generated api.TransDestPos structure consumes 48 bytes of memory, despite the fact that we only utilize 3 int32 fields within it. To address this inefficiency and reduce memory consumption, in this pull request, I've implemented a hand-crafted api.TransDestPos structure that requires only 12 bytes.

In the previous codebase, during the merging process on the CN, large transfer maps would be marshaled into binary format using Protobuf and then written to an S3 file. In this pull request, I use batches with 5 columns to write down.