### PR TITLE
abort txn if it tries to create locktable bind on a CN in restarting …

### DIFF
--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -772,7 +772,7 @@ func (l *lockTableAllocator) handleGetBind(
 	resp *pb.Response,
 	cs morpc.ClientSession) {
 	if !l.canGetBind(req.GetBind.ServiceID) {
-		writeResponse(ctx, l.logger, cancel, resp, moerr.NewRetryForCNRollingRestart(), cs)
+		writeResponse(ctx, l.logger, cancel, resp, moerr.NewNewTxnInCNRollingRestart(), cs)
 		return
 	}
 	resp.GetBind.LockTable = l.Get(

--- a/pkg/lockservice/log.go
+++ b/pkg/lockservice/log.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/common/util"
 
 	"github.com/matrixorigin/matrixone/pkg/common/log"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
@@ -762,7 +763,7 @@ func logCleanCannotCommitTxn(
 	logger.Log(
 		"clean cannot commit txn",
 		getLogOptions(zap.InfoLevel),
-		zap.String("txnID", txnID),
+		zap.String("txnID", hex.EncodeToString(util.UnsafeStringToBytes(txnID))),
 		zap.Int("state", state),
 	)
 }


### PR DESCRIPTION
…state

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17655 
## What this PR does / why we need it:
abort txn if it tries to create locktable bind on a CN in restarting …