### PR TITLE
fix: add sleep before using metadata_scan to let results stable in bvt

### DIFF
--- a/test/distributed/cases/function/table_func_metadata_scan.result
+++ b/test/distributed/cases/function/table_func_metadata_scan.result
@@ -22,6 +22,9 @@ count(*)
 select mo_ctl('dn', 'flush', 'table_func_metadata_scan.t');
 mo_ctl(dn, flush, table_func_metadata_scan.t)
 {\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select sleep(1);
+sleep(1)
+0
 select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g;
 count(*)
 5
@@ -85,6 +88,9 @@ count(*)
 select mo_ctl('dn', 'flush', 'table_func_metadata_scan.t');
 mo_ctl(dn, flush, table_func_metadata_scan.t)
 {\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select sleep(1);
+sleep(1)
+0
 select bit_cast(`sum` as bigint) from metadata_scan('table_func_metadata_scan.t', 'a') g;
 bit_cast(sum as bigint)
 2147483648

--- a/test/distributed/cases/function/table_func_metadata_scan.sql
+++ b/test/distributed/cases/function/table_func_metadata_scan.sql
@@ -18,6 +18,7 @@ insert into t select * from t;
 select count(*) from t;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'table_func_metadata_scan.t');
+select sleep(1);
 select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g;
 select count(*) from metadata_scan('table_func_metadata_scan.t', 'a') g;
 select count(*) from metadata_scan('table_func_metadata_scan.t', 'f') g;
@@ -51,6 +52,7 @@ insert into t values(1, 1);
 select count(*) from t;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'table_func_metadata_scan.t');
+select sleep(1);
 select bit_cast(`sum` as bigint) from metadata_scan('table_func_metadata_scan.t', 'a') g;
 select sum(a) from t;
 select bit_cast(`sum` as bigint) from metadata_scan('table_func_metadata_scan.t', 'b') g;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/3777

## What this PR does / why we need it:
sleep(1) before using metadata_scan to let results stable in table_func_metadata_scan.sql