### PR TITLE
Clean up expr eval.

### DIFF
--- a/pkg/container/types/bytes.go
+++ b/pkg/container/types/bytes.go
@@ -62,6 +62,14 @@ func (v *Varlena) SetOffsetLen(voff, vlen uint32) {
 	s[2] = vlen
 }
 
+func (v *Varlena) AddOffset(off uint32) {
+	if v.IsSmall() {
+		return
+	}
+	s := v.U32Slice()
+	s[1] += off
+}
+
 // do not use this function, will be deleted in the future
 // use BuildVarlenaFromValena or BuildVarlenaFromByteSlice instead
 func BuildVarlena(bs []byte, area []byte, m *mpool.MPool) (Varlena, []byte, error) {

--- a/pkg/sql/colexec/mergeorder/order.go
+++ b/pkg/sql/colexec/mergeorder/order.go
@@ -33,6 +33,7 @@ const opName = "merge_order"
 
 func (ctr *container) mergeAndEvaluateOrderColumn(proc *process.Process, bat *batch.Batch) error {
 	ctr.batchList = append(ctr.batchList, bat)
+	// WTF is the following?
 	ctr.orderCols = append(ctr.orderCols, nil)
 	// if only one batch, no need to evaluate the order column.
 	if len(ctr.batchList) == 1 {
@@ -48,6 +49,8 @@ func (ctr *container) evaluateOrderColumn(proc *process.Process, index int) erro
 
 	ctr.orderCols[index] = make([]*vector.Vector, len(ctr.executors))
 	for i := 0; i < len(ctr.executors); i++ {
+		// XXX: this one eval is good enough, but what do I know.
+		// vec, err := ctr.executors[i].Eval(proc, inputs, nil)
 		vec, err := ctr.executors[i].EvalWithoutResultReusing(proc, inputs, nil)
 		if err != nil {
 			return err

--- a/pkg/sql/colexec/mergetop/top.go
+++ b/pkg/sql/colexec/mergetop/top.go
@@ -122,6 +122,7 @@ func (ctr *container) build(ap *MergeTop, proc *process.Process, anal process.An
 			return false, nil
 		}
 
+		// XXX FUBAR
 		bat := msg.Batch
 		anal.Input(bat, isFirst)
 
@@ -132,6 +133,10 @@ func (ctr *container) build(ap *MergeTop, proc *process.Process, anal process.An
 				colIndex := ctr.executorsForOrderList[i].(*colexec.ColumnExpressionExecutor).GetColIndex()
 				ctr.poses = append(ctr.poses, int32(colIndex))
 			} else {
+				// XXX FUBAR
+				// We already checked IsColumnExpr, this must be some other expr vec, and it will
+				// be evaluated and added to bat.Vecs.   So large copy won't happen.  So the code
+				// is more or less OK but the API abstraction is so bad, it's hard to understand.
 				vec, err := ctr.executorsForOrderList[i].EvalWithoutResultReusing(proc, []*batch.Batch{bat}, nil)
 				if err != nil {
 					return false, err

--- a/pkg/sql/colexec/partition/partition.go
+++ b/pkg/sql/colexec/partition/partition.go
@@ -125,6 +125,8 @@ func (ctr *container) evaluateOrderColumn(proc *process.Process, index int) erro
 
 	ctr.orderCols[index] = make([]*vector.Vector, len(ctr.executors))
 	for i := 0; i < len(ctr.executors); i++ {
+		// XXX: we should be able to reuse the vectors in the input batch, but who knows ...
+		// vec, err := ctr.executors[i].Eval(proc, inputs, nil)
 		vec, err := ctr.executors[i].EvalWithoutResultReusing(proc, inputs, nil)
 		if err != nil {
 			return err

--- a/pkg/sql/colexec/reuse.go
+++ b/pkg/sql/colexec/reuse.go
@@ -88,8 +88,12 @@ func (expr ColumnExpressionExecutor) TypeName() string {
 	return "ColumnExpressionExecutor"
 }
 
-func NewColumnExpressionExecutor() *ColumnExpressionExecutor {
+func NewColumnExpressionExecutor(mp *mpool.MPool, ridx, cidx int, typ types.Type) *ColumnExpressionExecutor {
 	ce := reuse.Alloc[ColumnExpressionExecutor](nil)
+	ce.mp = mp
+	ce.relIndex = ridx
+	ce.colIndex = cidx
+	ce.typ = typ
 	return ce
 }
 
@@ -111,8 +115,13 @@ func (expr VarExpressionExecutor) TypeName() string {
 	return "VarExpressionExecutor"
 }
 
-func NewVarExpressionExecutor() *VarExpressionExecutor {
+func NewVarExpressionExecutor(mp *mpool.MPool, name string, sys, global bool, typ types.Type) *VarExpressionExecutor {
 	ve := reuse.Alloc[VarExpressionExecutor](nil)
+	ve.mp = mp
+	ve.name = name
+	ve.system = sys
+	ve.global = global
+	ve.typ = typ
 	return ve
 }
 


### PR DESCRIPTION
### **User description**
Clean up the code.   The big problem is EvalWithoutResultReusing.
Need people's feedback on how to fix it.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #17750

## What this PR does / why we need it:

Code refactor and understanding.


___

### **PR Type**
Enhancement, Code Refactoring


___

### **Description**
- Added `AddOffset` method to `Varlena` struct.
- Refactored `GetUnionAllFunction` to improve vector handling and added null handling.
- Enhanced `ExpressionExecutor` interface with `Reset` method and refactored various `EvalWithoutResultReusing` methods for safety and clarity.
- Improved handling of `EvalWithoutResultReusing` in `Fill`, `MergeTop`, `mergeorder`, and `partition` packages.
- Simplified constructors for `ColumnExpressionExecutor` and `VarExpressionExecutor`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bytes.go</strong><dd><code>Add `AddOffset` method to `Varlena` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/types/bytes.go

- Added `AddOffset` method to `Varlena` struct.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17751/files#diff-c22928161c30c086c2cc6b04ada7fd52fd2b8ff70f9948d2b6441c48ead78e3a">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vector.go</strong><dd><code>Refactor `GetUnionAllFunction` for better vector handling</code></dd></summary>
<hr>

pkg/container/vector/vector.go

<li>Refactored <code>GetUnionAllFunction</code> to improve vector handling.<br> <li> Added null handling and optimized vector extension.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17751/files#diff-28ac70822524921592389604c9d3caa2e7c488a52b02d22fe9bdc35f8d808d5f">+17/-20</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>evalExpression.go</strong><dd><code>Enhance `ExpressionExecutor` interface and refactor methods</code></dd></summary>
<hr>

pkg/sql/colexec/evalExpression.go

<li>Added <code>Reset</code> method to <code>ExpressionExecutor</code> interface.<br> <li> Refactored various <code>EvalWithoutResultReusing</code> methods for safety and <br>clarity.<br> <li> Simplified constructors for expression executors.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17751/files#diff-096074b4e06b58b1b2144cc4b4d91fe38b5c4ced8bfd165e7cfc66bd31aa341d">+90/-99</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fill.go</strong><dd><code>Improve `EvalWithoutResultReusing` handling in `Fill`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/fill/fill.go

- Improved handling of `EvalWithoutResultReusing` in `Fill` struct.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17751/files#diff-aa15abed44aa6d7f944efdd2c2a090bdae777f103e8bcfcc281e8cd297e688dd">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>order.go</strong><dd><code>Improve order column evaluation in `mergeorder`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/mergeorder/order.go

- Added comments and improved handling of order column evaluation.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17751/files#diff-03dce6b47ef9452f552f884948d69d94c785eaafbc24f53b849c79bacf2df09e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>top.go</strong><dd><code>Improve `EvalWithoutResultReusing` handling in `MergeTop`</code></dd></summary>
<hr>

pkg/sql/colexec/mergetop/top.go

<li>Added comments and improved handling of <code>EvalWithoutResultReusing</code> in <br><code>MergeTop</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17751/files#diff-bf5aba02b33641f6dfc7d6de259cfee522f5438969ef44d3e32034f4ff1c572e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>partition.go</strong><dd><code>Improve order column evaluation in `partition`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/partition/partition.go

- Added comments and improved handling of order column evaluation.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17751/files#diff-8eb280ebfd645b3269f78b457a1e3469c482573c0c277f4ff25df7fb87c42492">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reuse.go</strong><dd><code>Simplify constructors for expression executors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/reuse.go

<li>Simplified constructors for <code>ColumnExpressionExecutor</code> and <br><code>VarExpressionExecutor</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17751/files#diff-81101e314837e2f6580be1cdc1502017f30a62d6ed485a20bf725911855020c6">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

