### PR TITLE
container/types: make empty Packer valid for use

### DIFF
--- a/pkg/container/types/packer.go
+++ b/pkg/container/types/packer.go
@@ -83,7 +83,9 @@ func (p *Packer) ensureSizeSlow(n int) {
 	}
 	newBuffer = newBuffer[:len(p.buffer)]
 	copy(newBuffer, p.buffer)
-	p.bufferDeallocator.Deallocate(malloc.NoHints)
+	if p.bufferDeallocator != nil {
+		p.bufferDeallocator.Deallocate(malloc.NoHints)
+	}
 	p.buffer = newBuffer
 	p.bufferDeallocator = newDec
 }

--- a/pkg/container/types/packer_test.go
+++ b/pkg/container/types/packer_test.go
@@ -16,6 +16,31 @@ package types
 
 import "testing"
 
+func TestPacker(t *testing.T) {
+	packer := NewPacker()
+	defer packer.Close()
+	for i := 0; i < 65536; i++ {
+		packer.EncodeInt64(int64(i))
+	}
+	bs := packer.Bytes()
+	if len(bs) != 261887 {
+		t.Fatalf("got %v", len(bs))
+	}
+}
+
+func TestClosedPackerIsOK(t *testing.T) {
+	packer := NewPacker()
+	packer.Close()
+	for i := 0; i < 65536; i++ {
+		packer.EncodeInt64(int64(i))
+	}
+	bs := packer.Bytes()
+	if len(bs) != 261887 {
+		t.Fatalf("got %v", len(bs))
+	}
+	packer.Close()
+}
+
 func BenchmarkPacker(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		packer := NewPacker()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/3815

## What this PR does / why we need it:
Some packers may be used after Close. Make them work.