### PR TITLE
fix bug: get empty record from special table by new account

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -2089,6 +2089,9 @@ func (c *Compile) compileTableScanDataSource(s *Scope) error {
 		if n.ObjRef.PubInfo != nil {
 			ctx = defines.AttachAccountId(ctx, uint32(n.ObjRef.PubInfo.TenantId))
 		}
+		if util.TableIsLoggingTable(n.ObjRef.SchemaName, n.ObjRef.ObjName) {
+			ctx = defines.AttachAccountId(ctx, catalog.System_Account)
+		}
 		db, err = c.e.Database(ctx, n.ObjRef.SchemaName, txnOp)
 		if err != nil {
 			panic(err)

--- a/test/distributed/cases/zz_accesscontrol/account_restricted.result
+++ b/test/distributed/cases/zz_accesscontrol/account_restricted.result
@@ -230,6 +230,9 @@ create table r1(c1 int,c2 varchar(20));
 insert into res_test.r_test values(8,'c');
 update res_test.r_test set c1=5 where c2='h';
 delete from res_test.r_test where c1=4;
+select count(*) > 0 from system.statement_info;
+count( * ) > 0
+true
 delete from system.statement_info;
 internal error: do not have privilege to execute the statement
 select * from res_test.r_test;

--- a/test/distributed/cases/zz_accesscontrol/account_restricted.sql
+++ b/test/distributed/cases/zz_accesscontrol/account_restricted.sql
@@ -94,6 +94,7 @@ create table r1(c1 int,c2 varchar(20));
 insert into res_test.r_test values(8,'c');
 update res_test.r_test set c1=5 where c2='h';
 delete from res_test.r_test where c1=4;
+select count(*) > 0 from system.statement_info;
 delete from system.statement_info;
 select * from res_test.r_test;
 truncate table res_test.r_test;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17605

## What this PR does / why we need it:
fix bug: get empty record from special table by new account