### PR TITLE
Minor.

### DIFF
--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -672,7 +672,7 @@ func (v *Vector) ToConst(row, length int, mp *mpool.MPool) *Vector {
 // PreExtend use to expand the capacity of the vector
 func (v *Vector) PreExtend(rows int, mp *mpool.MPool) error {
 	if v.class == CONSTANT {
-		return nil
+		panic(moerr.NewInternalErrorNoCtx("cannot extend a const vector"))
 	}
 
 	return extend(v, rows, mp)
@@ -682,10 +682,6 @@ func (v *Vector) PreExtend(rows int, mp *mpool.MPool) error {
 // extraAreaSize: the size of area to be extended
 // mp: mpool
 func (v *Vector) PreExtendWithArea(rows int, extraAreaSize int, mp *mpool.MPool) error {
-	if v.class == CONSTANT {
-		return nil
-	}
-
 	// pre-extend vector, the fixed len part
 	if err := v.PreExtend(rows, mp); err != nil {
 		return err

--- a/pkg/txn/storage/memorystorage/mem_handler.go
+++ b/pkg/txn/storage/memorystorage/mem_handler.go
@@ -1107,9 +1107,6 @@ func (m *MemHandler) HandleRead(ctx context.Context, meta txn.TxnMeta, req *memo
 		if err != nil {
 			return err
 		}
-		if err != nil {
-			return err
-		}
 		if key.tableID != iter.TableID {
 			break
 		}

--- a/pkg/vm/engine/disttae/txn_table_sharding_handle.go
+++ b/pkg/vm/engine/disttae/txn_table_sharding_handle.go
@@ -16,6 +16,7 @@ package disttae
 
 import (
 	"context"
+
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -134,9 +135,6 @@ func HandleShardingReadApproxObjectsNum(
 	num := tbl.ApproxObjectsNum(
 		ctx,
 	)
-	if err != nil {
-		return nil, err
-	}
 	return buffer.EncodeInt(num), nil
 }
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes: 

issue #17813

## What this PR does / why we need it:

Minor update.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replaced the return statement with a panic in `PreExtend` method for constant vectors to ensure proper error handling.
- Removed unnecessary condition check in `PreExtendWithArea` method to streamline the code.
- Cleaned up redundant error handling code in `HandleRead` method of memory storage handler.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vector.go</strong><dd><code>Improve error handling in vector pre-extension methods</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/vector/vector.go

<li>Replaced return statement with panic for constant vectors in <br><code>PreExtend</code>.<br> <li> Removed unnecessary condition check in <code>PreExtendWithArea</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17814/files#diff-28ac70822524921592389604c9d3caa2e7c488a52b02d22fe9bdc35f8d808d5f">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mem_handler.go</strong><dd><code>Clean up redundant error handling in memory storage handler</code></dd></summary>
<hr>

pkg/txn/storage/memorystorage/mem_handler.go

- Removed redundant error handling code in `HandleRead`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17814/files#diff-357f1879ba0756c1b72f2f1bef1037667dec3d6d6e56af26dae9bfe1c6149476">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

