### PR TITLE
Add proxy configurations

### DIFF
--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -4,6 +4,40 @@ metadata:
   name: mo-checkin-regression
   namespace: nsformocheckin
 spec:
+  proxy:
+  exportToPrometheus: true
+  nodeSelector:
+    tke.matrixorigin.io/mo-checkin-regression-proxy: true
+  overlay:
+    tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/mo-checkin-regression-proxy
+        operator: Exists
+    imagePullSecrets:
+      - name: tke-registry
+    podAnnotations:
+      profiles.grafana.com/memory.scrape: "true"
+      profiles.grafana.com/memory.port: "6060"
+      profiles.grafana.com/cpu.scrape: "true"
+      profiles.grafana.com/cpu.port: "6060"
+      profiles.grafana.com/goroutine.scrape: "true"
+      profiles.grafana.com/goroutine.port: "6060"
+  config: |
+    # TOML format config file below
+    [log]
+    level="info"
+    [observability]
+    metricUpdateStorageUsageInterval = "15m"
+    enableStmtMerge = true
+    enableMetricToProm = true
+  replicas: 2
+  resources:
+    requests:
+      cpu: 1.5
+      memory: 2Gi
+    limits:
+      cpu: 1.5
+      memory: 2Gi
   dn:
     exportToPrometheus: true
     nodeSelector:

--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -5,39 +5,45 @@ metadata:
   namespace: nsformocheckin
 spec:
   proxy:
-  exportToPrometheus: true
-  nodeSelector:
-    tke.matrixorigin.io/mo-checkin-regression-proxy: true
-  overlay:
-    tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/mo-checkin-regression-proxy
-        operator: Exists
-    imagePullSecrets:
-      - name: tke-registry
-    podAnnotations:
-      profiles.grafana.com/memory.scrape: "true"
-      profiles.grafana.com/memory.port: "6060"
-      profiles.grafana.com/cpu.scrape: "true"
-      profiles.grafana.com/cpu.port: "6060"
-      profiles.grafana.com/goroutine.scrape: "true"
-      profiles.grafana.com/goroutine.port: "6060"
-  config: |
-    # TOML format config file below
-    [log]
-    level="info"
-    [observability]
-    metricUpdateStorageUsageInterval = "15m"
-    enableStmtMerge = true
-    enableMetricToProm = true
-  replicas: 2
-  resources:
-    requests:
-      cpu: 1.5
-      memory: 2Gi
-    limits:
-      cpu: 1.5
-      memory: 2Gi
+    exportToPrometheus: true
+    nodeSelector:
+      tke.matrixorigin.io/mo-checkin-regression-proxy: true
+    overlay:
+      securityContext:
+        sysctls:
+          - name: net.ipv4.tcp_fin_timeout
+            value: "30"
+          - name: net.ipv4.tcp_tw_reuse
+            value: "1"
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/mo-checkin-regression-proxy
+          operator: Exists
+      imagePullSecrets:
+        - name: tke-registry
+      podAnnotations:
+        profiles.grafana.com/memory.scrape: "true"
+        profiles.grafana.com/memory.port: "6060"
+        profiles.grafana.com/cpu.scrape: "true"
+        profiles.grafana.com/cpu.port: "6060"
+        profiles.grafana.com/goroutine.scrape: "true"
+        profiles.grafana.com/goroutine.port: "6060"
+    config: |
+      # TOML format config file below
+      [log]
+      level="info"
+      [observability]
+      metricUpdateStorageUsageInterval = "15m"
+      enableStmtMerge = true
+      enableMetricToProm = true
+    replicas: 2
+    resources:
+      requests:
+        cpu: 1.5
+        memory: 2Gi
+      limits:
+        cpu: 1.5
+        memory: 2Gi
   dn:
     exportToPrometheus: true
     nodeSelector:


### PR DESCRIPTION
### **User description**
Set content about the proxy module to use the proxy module in `MergeRun` process

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:
issue #

## What this PR does / why we need it:
Proxy module is not enabled in the `MergeRun` process before. This time, we need to add related content of the proxy module to use the proxy module in the `MergeRun` process.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added proxy configuration to the `mo_checkin_regression_tke.yaml` file to enable the proxy module in the `MergeRun` process.
- Configured nodeSelector and overlay settings specific to the proxy.
- Set resource requests and limits for the proxy.
- Enabled export to Prometheus for the proxy module.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mo_checkin_regression_tke.yaml</strong><dd><code>Add proxy configurations to mo_checkin_regression_tke.yaml</code></dd></summary>
<hr>

optools/mo_checkin_regression/mo_checkin_regression_tke.yaml

<li>Added proxy configuration section.<br> <li> Included nodeSelector and overlay settings for proxy.<br> <li> Configured resource requests and limits for proxy.<br> <li> Enabled export to Prometheus for proxy.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17874/files#diff-c31cbca87355a4a99ce221e86f31f59c4aeda31064093a04cee02e6cf76dab01">+34/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

