### PR TITLE
Add proxy configurations for 1.2-dev

### DIFF
--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -7,7 +7,7 @@ spec:
     proxy:
     exportToPrometheus: true
     nodeSelector:
-      tke.matrixorigin.io/mo-checkin-regression-proxy: true
+      tke.matrixorigin.io/mo-checkin-regression-proxy: "true"
     overlay:
       securityContext:
         sysctls:

--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -4,6 +4,46 @@ metadata:
   name: mo-checkin-regression
   namespace: nsformocheckin
 spec:
+    proxy:
+    exportToPrometheus: true
+    nodeSelector:
+      tke.matrixorigin.io/mo-checkin-regression-proxy: true
+    overlay:
+      securityContext:
+        sysctls:
+          - name: net.ipv4.tcp_fin_timeout
+            value: "30"
+          - name: net.ipv4.tcp_tw_reuse
+            value: "1"
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/mo-checkin-regression-proxy
+          operator: Exists
+      imagePullSecrets:
+        - name: tke-registry
+      podAnnotations:
+        profiles.grafana.com/memory.scrape: "true"
+        profiles.grafana.com/memory.port: "6060"
+        profiles.grafana.com/cpu.scrape: "true"
+        profiles.grafana.com/cpu.port: "6060"
+        profiles.grafana.com/goroutine.scrape: "true"
+        profiles.grafana.com/goroutine.port: "6060"
+    config: |
+      # TOML format config file below
+      [log]
+      level="info"
+      [observability]
+      metricUpdateStorageUsageInterval = "15m"
+      enableStmtMerge = true
+      enableMetricToProm = true
+    replicas: 2
+    resources:
+      requests:
+        cpu: 1.5
+        memory: 2Gi
+      limits:
+        cpu: 1.5
+        memory: 2Gi
   dn:
     exportToPrometheus: true
     nodeSelector:

--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mo-checkin-regression
   namespace: nsformocheckin
 spec:
-    proxy:
+  proxy:
     exportToPrometheus: true
     nodeSelector:
       tke.matrixorigin.io/mo-checkin-regression-proxy: "true"


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
Proxy module is not enabled in the MergeRun 1.2-dev before. This time, we need to add related content of the proxy module to use the proxy module in the MergeRun 1.2-dev.