### PR TITLE
bugfix: panic if ContentBuffer is empty.

### DIFF
--- a/pkg/util/trace/impl/motrace/buffer_content.go
+++ b/pkg/util/trace/impl/motrace/buffer_content.go
@@ -44,6 +44,7 @@ type ContentBuffer struct {
 	tbl *table.Table
 	mux sync.Mutex
 
+	// formatter init-ed while alloc buf
 	formatter *db_holder.CSVWriter
 
 	checkWriteHook []table.AckHook
@@ -138,6 +139,9 @@ func (b *ContentBuffer) IsEmpty() bool {
 }
 
 func (b *ContentBuffer) isEmpty() bool {
+	if b.buf == nil {
+		return true
+	}
 	b.formatter.Flush()
 	return b.buf.Len() == 0
 }
@@ -145,12 +149,18 @@ func (b *ContentBuffer) isEmpty() bool {
 func (b *ContentBuffer) ShouldFlush() bool {
 	b.mux.Lock()
 	defer b.mux.Unlock()
+	if b.buf == nil {
+		return false
+	}
 	return b.buf.Len()+thresholdDelta > b.sizeThreshold
 }
 
 func (b *ContentBuffer) Size() int64 {
 	b.mux.Lock()
 	defer b.mux.Unlock()
+	if b.buf == nil {
+		return 0
+	}
 	return int64(b.buf.Len())
 }
 

--- a/pkg/util/trace/impl/motrace/buffer_content_test.go
+++ b/pkg/util/trace/impl/motrace/buffer_content_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package motrace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContentBuffer_isEmpty(t *testing.T) {
+	type fields struct {
+		options []BufferOption
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		run    func(buf *ContentBuffer)
+		want   bool
+	}{
+		{
+			name: "empty",
+			fields: fields{
+				options: []BufferOption{BufferWithGenBatchFunc(noopGenBatchSQL), BufferWithType("test")},
+			},
+			run:  func(buf *ContentBuffer) { /*none op*/ },
+			want: true,
+		},
+		{
+			name: "not_empty",
+			fields: fields{
+				options: []BufferOption{BufferWithGenBatchFunc(noopGenBatchSQL), BufferWithType("test")},
+			},
+			run:  func(buf *ContentBuffer) { buf.Add(&StatementInfo{}) },
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewContentBuffer(tt.fields.options...)
+			tt.run(b)
+			_ = b.ShouldFlush()
+			_ = b.Size()
+			assert.Equalf(t, tt.want, b.isEmpty(), "isEmpty()")
+		})
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/17893

## What this PR does / why we need it:
1. add ut `TestContentBuffer_isEmpty` to fix empty buffer case.