### PR TITLE
[proxy] enhancement: don't change txn status if it is error packet

### DIFF
--- a/pkg/proxy/tunnel.go
+++ b/pkg/proxy/tunnel.go
@@ -576,7 +576,10 @@ func (p *pipe) kickoff(ctx context.Context, peer *pipe) (e error) {
 				rotated = false
 			}
 
-			p.mu.inTxn = checkTxnStatus(buf)
+			inTxn, ok := checkTxnStatus(buf)
+			if ok {
+				p.mu.inTxn = inTxn
+			}
 			if !p.mu.inTxn && p.tun.transferIntent.Load() && !rotated {
 				peer.wg.Add(1)
 				p.transferred = true
@@ -741,7 +744,11 @@ func handleEOFPacket(msg []byte) bool {
 	return txnStatus(binary.LittleEndian.Uint16(msg[7:]))
 }
 
-func checkTxnStatus(msg []byte) bool {
+// the first return value is the txn status, and the second return value
+// indicates if we can get the txn status from the packet. If it is a ERROR
+// packet, the second return value is false.
+func checkTxnStatus(msg []byte) (bool, bool) {
+	ok := true
 	inTxn := true
 	// For the server->client pipe, we get the transaction status from the
 	// OK and EOF packet, which is used in connection transfer. If the session
@@ -750,6 +757,8 @@ func checkTxnStatus(msg []byte) bool {
 		inTxn = handleOKPacket(msg)
 	} else if isEOFPacket(msg) {
 		inTxn = handleEOFPacket(msg)
+	} else if isErrPacket(msg) {
+		ok = false
 	}
-	return inTxn
+	return inTxn, ok
 }

--- a/pkg/proxy/tunnel_test.go
+++ b/pkg/proxy/tunnel_test.go
@@ -17,6 +17,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"math/rand"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/lni/goutils/leaktest"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/frontend"
 	"github.com/stretchr/testify/require"
 )
 
@@ -686,4 +688,27 @@ func TestReplaceServerConn(t *testing.T) {
 	n, err := newServer.Read(buf)
 	require.NoError(t, err)
 	require.Equal(t, "select 1", string(buf[5:n]))
+}
+
+func TestCheckTxnStatus(t *testing.T) {
+	inTxn, ok := checkTxnStatus(nil)
+	require.True(t, ok)
+	require.True(t, inTxn)
+
+	inTxn, ok = checkTxnStatus(makeErrPacket(8))
+	require.False(t, ok)
+	require.True(t, inTxn)
+
+	p1 := makeOKPacket(5)
+	value := frontend.SERVER_QUERY_WAS_SLOW | frontend.SERVER_STATUS_NO_GOOD_INDEX_USED
+	binary.LittleEndian.PutUint16(p1[7:], value)
+	inTxn, ok = checkTxnStatus(p1)
+	require.True(t, ok)
+	require.False(t, inTxn)
+
+	value |= frontend.SERVER_STATUS_IN_TRANS
+	binary.LittleEndian.PutUint16(p1[7:], value)
+	inTxn, ok = checkTxnStatus(p1)
+	require.True(t, ok)
+	require.True(t, inTxn)
 }

--- a/pkg/proxy/util.go
+++ b/pkg/proxy/util.go
@@ -35,6 +35,17 @@ func makeOKPacket(l int) []byte {
 	return data
 }
 
+// makeErrPacket returns an ERROR packet
+func makeErrPacket(l int) []byte {
+	data := make([]byte, l+4)
+	data[4] = 0xFF
+	data[0] = byte(l)
+	data[1] = byte(l >> 8)
+	data[2] = byte(l >> 16)
+	data[3] = 1
+	return data
+}
+
 func isCmdQuery(p []byte) bool {
 	if len(p) > 4 && p[4] == byte(cmdQuery) {
 		return true


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/17688

## What this PR does / why we need it:
don't change txn status if it is error packet