### PR TITLE
refactor Innerjoin

### DIFF
--- a/pkg/sql/colexec/evalProjection.go
+++ b/pkg/sql/colexec/evalProjection.go
@@ -46,10 +46,7 @@ func (projection *Projection) PrepareProjection(proc *process.Process) (err erro
 }
 
 func (projection *Projection) EvalProjection(bat *batch.Batch, proc *process.Process) (*batch.Batch, error) {
-	if bat == nil || bat.IsEmpty() || bat.Last() {
-		return bat, nil
-	}
-	if len(projection.ProjectExecutors) == 0 {
+	if len(projection.ProjectExecutors) == 0 || bat == nil || bat.IsEmpty() || bat.Last() {
 		return bat, nil
 	}
 

--- a/pkg/sql/colexec/join/join.go
+++ b/pkg/sql/colexec/join/join.go
@@ -42,7 +42,6 @@ func (innerJoin *InnerJoin) OpType() vm.OpType {
 
 func (innerJoin *InnerJoin) Prepare(proc *process.Process) (err error) {
 	if innerJoin.ctr.vecs == nil {
-
 		innerJoin.ctr.vecs = make([]*vector.Vector, len(innerJoin.Conditions[0]))
 		innerJoin.ctr.executor = make([]colexec.ExpressionExecutor, len(innerJoin.Conditions[0]))
 		for i := range innerJoin.ctr.executor {

--- a/pkg/sql/colexec/join/join_test.go
+++ b/pkg/sql/colexec/join/join_test.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec/merge"
-
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -41,13 +39,13 @@ const (
 
 // add unit tests for cases
 type joinTestCase struct {
-	arg    *InnerJoin
-	flgs   []bool // flgs[i] == true: nullable
-	types  []types.Type
-	proc   *process.Process
-	cancel context.CancelFunc
-	barg   *hashbuild.HashBuild
-	marg   *merge.Merge
+	arg         *InnerJoin
+	flgs        []bool // flgs[i] == true: nullable
+	types       []types.Type
+	proc        *process.Process
+	cancel      context.CancelFunc
+	barg        *hashbuild.HashBuild
+	resultBatch *batch.Batch
 }
 
 var (
@@ -56,22 +54,22 @@ var (
 
 func init() {
 	tcs = []joinTestCase{
-		newTestCase([]bool{false}, []types.Type{types.T_int8.ToType()}, []colexec.ResultPos{colexec.NewResultPos(0, 0)},
+		newTestCase(2, []bool{false}, []types.Type{types.T_int32.ToType()}, []colexec.ResultPos{colexec.NewResultPos(0, 0)},
 			[][]*plan.Expr{
 				{
-					newExpr(0, types.T_int8.ToType()),
+					newExpr(0, types.T_int32.ToType()),
 				},
 				{
-					newExpr(0, types.T_int8.ToType()),
+					newExpr(0, types.T_int32.ToType()),
 				},
 			}),
-		newTestCase([]bool{true}, []types.Type{types.T_int8.ToType()}, []colexec.ResultPos{colexec.NewResultPos(0, 0), colexec.NewResultPos(1, 0)},
+		newTestCase(2, []bool{true}, []types.Type{types.T_int32.ToType()}, []colexec.ResultPos{colexec.NewResultPos(0, 0), colexec.NewResultPos(1, 0)},
 			[][]*plan.Expr{
 				{
-					newExpr(0, types.T_int8.ToType()),
+					newExpr(0, types.T_int32.ToType()),
 				},
 				{
-					newExpr(0, types.T_int8.ToType()),
+					newExpr(0, types.T_int32.ToType()),
 				},
 			}),
 	}
@@ -84,58 +82,66 @@ func TestString(t *testing.T) {
 	}
 }
 
-/*
 func TestJoin(t *testing.T) {
 	for _, tc := range tcs {
-		nb0 := tc.proc.Mp().CurrNB()
-		bats := hashBuild(t, tc)
+
+		resetChildren(tc.arg)
+		resetHashBuildChildren(tc.barg)
 		err := tc.arg.Prepare(tc.proc)
 		require.NoError(t, err)
-		tc.proc.Reg.MergeReceivers[0].Ch <- testutil.NewRegMsg(newBatch(tc.types, tc.proc, Rows))
-		tc.proc.Reg.MergeReceivers[0].Ch <- testutil.NewRegMsg(batch.EmptyBatch)
-		tc.proc.Reg.MergeReceivers[0].Ch <- testutil.NewRegMsg(newBatch(tc.types, tc.proc, Rows))
-		tc.proc.Reg.MergeReceivers[0].Ch <- testutil.NewRegMsg(newBatch(tc.types, tc.proc, Rows))
-		tc.proc.Reg.MergeReceivers[0].Ch <- testutil.NewRegMsg(newBatch(tc.types, tc.proc, Rows))
-		tc.proc.Reg.MergeReceivers[0].Ch <- nil
-		tc.proc.Reg.MergeReceivers[1].Ch <- testutil.NewRegMsg(bats[0])
-		tc.proc.Reg.MergeReceivers[1].Ch <- testutil.NewRegMsg(bats[1])
-		tc.proc.Reg.MergeReceivers[0].Ch <- nil
-		tc.proc.Reg.MergeReceivers[1].Ch <- nil
-		for {
-			ok, err := tc.arg.Call(tc.proc)
-			if ok.Status == vm.ExecStop || err != nil {
-				break
-			}
+		err = tc.barg.Prepare(tc.proc)
+		require.NoError(t, err)
+
+		res, err := tc.barg.Call(tc.proc)
+		require.NoError(t, err)
+		require.Equal(t, res.Batch == nil, true)
+		res, err = tc.arg.Call(tc.proc)
+		require.NoError(t, err)
+		require.Equal(t, res.Batch.RowCount(), tc.resultBatch.RowCount())
+		require.Equal(t, len(res.Batch.Vecs), len(tc.resultBatch.Vecs))
+		for i := range res.Batch.Vecs {
+			vec1 := res.Batch.Vecs[i]
+			vec2 := tc.resultBatch.Vecs[i]
+			require.Equal(t, vec1.GetType().Oid, vec2.GetType().Oid)
+			require.Equal(t, bytes.Compare(vec1.GetArea(), vec2.GetArea()), 0)
+			require.Equal(t, bytes.Compare(vec1.UnsafeGetRawData(), vec2.UnsafeGetRawData()), 0)
 		}
 
 		tc.arg.Reset(tc.proc, false, nil)
+		tc.barg.Reset(tc.proc, false, nil)
 
-		bats = hashBuild(t, tc)
+		resetChildren(tc.arg)
+		resetHashBuildChildren(tc.barg)
 		err = tc.arg.Prepare(tc.proc)
 		require.NoError(t, err)
-		tc.proc.Reg.MergeReceivers[0].Ch <- testutil.NewRegMsg(newBatch(tc.types, tc.proc, Rows))
-		tc.proc.Reg.MergeReceivers[0].Ch <- testutil.NewRegMsg(batch.EmptyBatch)
-		tc.proc.Reg.MergeReceivers[0].Ch <- testutil.NewRegMsg(newBatch(tc.types, tc.proc, Rows))
-		tc.proc.Reg.MergeReceivers[0].Ch <- testutil.NewRegMsg(newBatch(tc.types, tc.proc, Rows))
-		tc.proc.Reg.MergeReceivers[0].Ch <- testutil.NewRegMsg(newBatch(tc.types, tc.proc, Rows))
-		tc.proc.Reg.MergeReceivers[0].Ch <- nil
-		tc.proc.Reg.MergeReceivers[1].Ch <- testutil.NewRegMsg(bats[0])
-		tc.proc.Reg.MergeReceivers[1].Ch <- testutil.NewRegMsg(bats[1])
-		tc.proc.Reg.MergeReceivers[0].Ch <- nil
-		tc.proc.Reg.MergeReceivers[1].Ch <- nil
-		for {
-			ok, err := tc.arg.Call(tc.proc)
-			if ok.Status == vm.ExecStop || err != nil {
-				break
-			}
+		err = tc.barg.Prepare(tc.proc)
+		require.NoError(t, err)
+
+		res, err = tc.barg.Call(tc.proc)
+		require.NoError(t, err)
+		require.Equal(t, res.Batch == nil, true)
+		res, err = tc.arg.Call(tc.proc)
+		require.NoError(t, err)
+		require.Equal(t, res.Batch.RowCount(), tc.resultBatch.RowCount())
+		require.Equal(t, len(res.Batch.Vecs), len(tc.resultBatch.Vecs))
+		for i := range res.Batch.Vecs {
+			vec1 := res.Batch.Vecs[i]
+			vec2 := tc.resultBatch.Vecs[i]
+			require.Equal(t, vec1.GetType().Oid, vec2.GetType().Oid)
+			require.Equal(t, bytes.Compare(vec1.GetArea(), vec2.GetArea()), 0)
+			require.Equal(t, bytes.Compare(vec1.UnsafeGetRawData(), vec2.UnsafeGetRawData()), 0)
 		}
+
+		tc.arg.Reset(tc.proc, false, nil)
+		tc.barg.Reset(tc.proc, false, nil)
+
 		tc.arg.Free(tc.proc, false, nil)
-		tc.proc.FreeVectors()
-		nb1 := tc.proc.Mp().CurrNB()
-		require.Equal(t, nb0, nb1)
+		tc.barg.Free(tc.proc, false, nil)
+		tc.proc.Free()
+		require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
 	}
 }
-*/
+
 /*
 func TestLowCardinalityJoin(t *testing.T) {
 	tc := newTestCase([]bool{false}, []types.Type{types.T_varchar.ToType()}, []colexec.ResultPos{colexec.NewResultPos(1, 0)},
@@ -210,7 +216,7 @@ func TestLowCardinalityIndexesJoin(t *testing.T) {
 	)
 }
 */
-
+/*
 func BenchmarkJoin(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tcs = []joinTestCase{
@@ -257,6 +263,7 @@ func BenchmarkJoin(b *testing.B) {
 		}
 	}
 }
+*/
 
 func newExpr(pos int32, typ types.Type) *plan.Expr {
 	return &plan.Expr{
@@ -273,18 +280,9 @@ func newExpr(pos int32, typ types.Type) *plan.Expr {
 	}
 }
 
-func newTestCase(flgs []bool, ts []types.Type, rp []colexec.ResultPos, cs [][]*plan.Expr) joinTestCase {
+func newTestCase(rows int, flgs []bool, ts []types.Type, rp []colexec.ResultPos, cs [][]*plan.Expr) joinTestCase {
 	proc := testutil.NewProcessWithMPool("", mpool.MustNewZero())
-	proc.Reg.MergeReceivers = make([]*process.WaitRegister, 2)
 	ctx, cancel := context.WithCancel(context.Background())
-	proc.Reg.MergeReceivers[0] = &process.WaitRegister{
-		Ctx: ctx,
-		Ch:  make(chan *process.RegisterMessage, 10),
-	}
-	proc.Reg.MergeReceivers[1] = &process.WaitRegister{
-		Ctx: ctx,
-		Ch:  make(chan *process.RegisterMessage, 3),
-	}
 	fr, _ := function.GetFunctionByName(ctx, "=", ts)
 	fid := fr.GetEncodedOverloadID()
 	args := make([]*plan.Expr, 0, 2)
@@ -321,6 +319,12 @@ func newTestCase(flgs []bool, ts []types.Type, rp []colexec.ResultPos, cs [][]*p
 			},
 		},
 	}
+	resultBatch := batch.NewWithSize(len(rp))
+	resultBatch.SetRowCount(rows)
+	for i := range rp {
+		bat := colexec.MakeMockBatchs()
+		resultBatch.Vecs[i] = bat.Vecs[rp[i].Pos]
+	}
 	return joinTestCase{
 		types:  ts,
 		flgs:   flgs,
@@ -353,10 +357,11 @@ func newTestCase(flgs []bool, ts []types.Type, rp []colexec.ResultPos, cs [][]*p
 			},
 			NeedAllocateSels: true,
 		},
-		marg: &merge.Merge{},
+		resultBatch: resultBatch,
 	}
 }
 
+/*
 func hashBuild(t *testing.T, tc joinTestCase) []*batch.Batch {
 	return hashBuildWithBatch(t, tc, newBatch(tc.types, tc.proc, Rows))
 }
@@ -384,7 +389,7 @@ func hashBuildWithBatch(t *testing.T, tc joinTestCase, bat *batch.Batch) []*batc
 func newBatch(ts []types.Type, proc *process.Process, rows int64) *batch.Batch {
 	return testutil.NewBatch(ts, false, int(rows), proc.Mp())
 }
-
+*/
 /*
 func constructIndex(t *testing.T, v *vector.Vector, m *mpool.MPool) {
 	idx, err := index.New(*v.GetType(), m)
@@ -396,3 +401,17 @@ func constructIndex(t *testing.T, v *vector.Vector, m *mpool.MPool) {
 	v.SetIndex(idx)
 }
 */
+
+func resetChildren(arg *InnerJoin) {
+	bat := colexec.MakeMockBatchs()
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.Children = nil
+	arg.AppendChild(op)
+}
+
+func resetHashBuildChildren(arg *hashbuild.HashBuild) {
+	bat := colexec.MakeMockBatchs()
+	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
+	arg.Children = nil
+	arg.AppendChild(op)
+}

--- a/pkg/sql/colexec/join/types.go
+++ b/pkg/sql/colexec/join/types.go
@@ -127,6 +127,7 @@ func (innerJoin *InnerJoin) Reset(proc *process.Process, pipelineFailed bool, er
 	ctr.cleanHashMap()
 	ctr.inbat = nil
 	ctr.lastrow = 0
+	ctr.state = Build
 
 	if innerJoin.ProjectList != nil {
 		anal.Alloc(innerJoin.ProjectAllocSize + innerJoin.ctr.maxAllocSize)

--- a/pkg/sql/colexec/join/types.go
+++ b/pkg/sql/colexec/join/types.go
@@ -37,7 +37,6 @@ const (
 type container struct {
 	state int
 
-	batches       []*batch.Batch
 	batchRowCount int64
 	lastrow       int
 	inbat         *batch.Batch
@@ -61,7 +60,7 @@ type container struct {
 
 /*
 InnerJoin.container has 5 *batch or []*batch
-1. batches means the data of right table. It's created by HashBuild operator and cleaned by cleanHashMap() in InnerJoin.Reset().
+1.
 2. inbat means the data of left table. It's created by InnerJoin.Children[0] and cleaned by InnerJoin.Children[0].
 3. rbat means the result of InnerJoin. InnerJoin.Probe() create rbat once when it's called first time and use CleanOnlyData() after that.
    InnerJoin.Reset() doesn't need to reset or clean rbat, because the result always has same types. InnerJoin.Free() will clean rbat.
@@ -127,7 +126,6 @@ func (innerJoin *InnerJoin) Reset(proc *process.Process, pipelineFailed bool, er
 	ctr.resetExprExecutor()
 	ctr.cleanHashMap()
 	ctr.inbat = nil
-	ctr.batches = nil
 	ctr.lastrow = 0
 
 	if innerJoin.ProjectList != nil {

--- a/pkg/vm/message/joinMapMsg.go
+++ b/pkg/vm/message/joinMapMsg.go
@@ -36,7 +36,7 @@ type JoinMap struct {
 	ihm              *hashmap.IntHashMap
 	mpool            *mpool.MPool
 	multiSels        [][]int32
-	Batches          []*batch.Batch
+	batches          []*batch.Batch
 }
 
 func NewJoinMap(sels [][]int32, ihm *hashmap.IntHashMap, shm *hashmap.StrHashMap, batches []*batch.Batch, m *mpool.MPool) *JoinMap {
@@ -44,7 +44,7 @@ func NewJoinMap(sels [][]int32, ihm *hashmap.IntHashMap, shm *hashmap.StrHashMap
 		shm:       shm,
 		ihm:       ihm,
 		multiSels: sels,
-		Batches:   batches,
+		batches:   batches,
 		mpool:     m,
 		valid:     true,
 	}
@@ -54,7 +54,7 @@ func (jm *JoinMap) GetBatches() []*batch.Batch {
 	if jm == nil {
 		return nil
 	}
-	return jm.Batches
+	return jm.batches
 }
 
 func (jm *JoinMap) SetRowCount(cnt int64) {
@@ -109,10 +109,10 @@ func (jm *JoinMap) Free() {
 	} else {
 		jm.shm.Free()
 	}
-	for i := range jm.Batches {
-		jm.Batches[i].Clean(jm.mpool)
+	for i := range jm.batches {
+		jm.batches[i].Clean(jm.mpool)
 	}
-	jm.Batches = nil
+	jm.batches = nil
 	jm.valid = false
 }
 

--- a/pkg/vm/message/joinMapMsg.go
+++ b/pkg/vm/message/joinMapMsg.go
@@ -36,7 +36,7 @@ type JoinMap struct {
 	ihm              *hashmap.IntHashMap
 	mpool            *mpool.MPool
 	multiSels        [][]int32
-	batches          []*batch.Batch
+	Batches          []*batch.Batch
 }
 
 func NewJoinMap(sels [][]int32, ihm *hashmap.IntHashMap, shm *hashmap.StrHashMap, batches []*batch.Batch, m *mpool.MPool) *JoinMap {
@@ -44,7 +44,7 @@ func NewJoinMap(sels [][]int32, ihm *hashmap.IntHashMap, shm *hashmap.StrHashMap
 		shm:       shm,
 		ihm:       ihm,
 		multiSels: sels,
-		batches:   batches,
+		Batches:   batches,
 		mpool:     m,
 		valid:     true,
 	}
@@ -54,7 +54,7 @@ func (jm *JoinMap) GetBatches() []*batch.Batch {
 	if jm == nil {
 		return nil
 	}
-	return jm.batches
+	return jm.Batches
 }
 
 func (jm *JoinMap) SetRowCount(cnt int64) {
@@ -109,10 +109,10 @@ func (jm *JoinMap) Free() {
 	} else {
 		jm.shm.Free()
 	}
-	for i := range jm.batches {
-		jm.batches[i].Clean(jm.mpool)
+	for i := range jm.Batches {
+		jm.Batches[i].Clean(jm.mpool)
 	}
-	jm.batches = nil
+	jm.Batches = nil
 	jm.valid = false
 }
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored `InnerJoin` struct to use a container struct instead of a pointer.
- Optimized initialization in the `Prepare` method to avoid redundant allocations.
- Updated `Call` and `build` methods to use a pointer to the container for consistency.
- Improved memory management in `Reset` and `Free` methods by cleaning up resources more effectively.
- Enhanced `cleanBatch` method to ensure proper batch cleanup.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>join.go</strong><dd><code>Refactor InnerJoin methods for optimized initialization and pointer </code><br><code>usage</code></dd></summary>
<hr>

pkg/sql/colexec/join/join.go

<li>Refactored <code>Prepare</code> method to initialize vectors and executors only if <br>they are nil.<br> <li> Modified <code>Call</code> method to use a pointer to <code>innerJoin.ctr</code>.<br> <li> Adjusted <code>build</code> method to use a pointer to <code>innerJoin.ctr</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17927/files#diff-2a43ca762c59d0ece91404da915aa519c35db896df1ec228aab36a10e7dbc1dd">+15/-11</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Refactor InnerJoin struct and methods for improved memory management</code></dd></summary>
<hr>

pkg/sql/colexec/join/types.go

<li>Changed <code>ctr</code> from a pointer to a struct in <code>InnerJoin</code>.<br> <li> Refactored <code>Reset</code> and <code>Free</code> methods to use a pointer to <code>innerJoin.ctr</code>.<br> <li> Enhanced <code>cleanBatch</code> method to handle batch cleanup properly.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17927/files#diff-67c85cf1b10e35ddf7ac938c17226a987e5548785b126d8c3929a26874fa1d78">+21/-18</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

