### PR TITLE
Work in Progress Stage URL

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -3250,7 +3250,7 @@ func doCreateStage(ctx context.Context, ses *Session, cs *tree.CreateStage) (err
 		}
 	} else {
 		// format credentials and hash it
-		credentials = HashPassWord(formatCredentials(cs.Credentials))
+		credentials = formatCredentials(cs.Credentials)
 
 		if !cs.Status.Exist {
 			StageStatus = "disabled"
@@ -3260,6 +3260,11 @@ func doCreateStage(ctx context.Context, ses *Session, cs *tree.CreateStage) (err
 
 		if cs.Comment.Exist {
 			comment = cs.Comment.Comment
+		}
+
+		if !(strings.HasPrefix(cs.Url, function.STAGE_PROTOCOL+"://") || strings.HasPrefix(cs.Url, function.S3_PROTOCOL+"://") ||
+			strings.HasPrefix(cs.Url, function.FILE_PROTOCOL+":///")) {
+			return moerr.NewBadConfig(ctx, "URL protocol only supports stage://, s3:// and file:///")
 		}
 
 		sql, err = getSqlForInsertIntoMoStages(ctx, string(cs.Name), cs.Url, credentials, StageStatus, types.CurrentTimestamp().String2(time.UTC, 0), comment)
@@ -3279,87 +3284,23 @@ func doCreateStage(ctx context.Context, ses *Session, cs *tree.CreateStage) (err
 func doCheckFilePath(ctx context.Context, ses *Session, ep *tree.ExportParam) (err error) {
 	//var err error
 	var filePath string
-	var sql string
-	var erArray []ExecResult
-	var stageName string
-	var stageStatus string
-	var url string
 	if ep == nil {
-		return err
-	}
-
-	bh := ses.GetBackgroundExec(ctx)
-	defer bh.Close()
-
-	err = bh.Exec(ctx, "begin;")
-	defer func() {
-		err = finishTxn(ctx, bh, err)
-	}()
-	if err != nil {
 		return err
 	}
 
 	// detect filepath contain stage or not
 	filePath = ep.FilePath
-	if !strings.Contains(filePath, ":") {
-		// the filepath is the target path
-		sql = getSqlForCheckStageStatus(ctx, "enabled")
-		bh.ClearExecResultSet()
-		err = bh.Exec(ctx, sql)
+	if strings.HasPrefix(filePath, function.STAGE_PROTOCOL+"://") {
+		// stage:// URL
+		s, err := function.UrlToStageDef(filePath, ses.proc)
 		if err != nil {
 			return err
 		}
 
-		erArray, err = getResultSet(ctx, bh)
+		// s.ToPath() returns the fileservice filepath, i.e. s3,...:/path for S3 or /path for local file
+		ses.ep.userConfig.StageFilePath, _, err = s.ToPath()
 		if err != nil {
 			return err
-		}
-
-		// if have stage enabled
-		if execResultArrayHasData(erArray) {
-			return moerr.NewInternalError(ctx, "stage exists, please try to check and use a stage instead")
-		} else {
-			// use the filepath
-			return err
-		}
-	} else {
-		stageName = strings.Split(filePath, ":")[0]
-		// check the stage status
-		sql, err = getSqlForCheckStageStatusWithStageName(ctx, stageName)
-		if err != nil {
-			return err
-		}
-		bh.ClearExecResultSet()
-		err = bh.Exec(ctx, sql)
-		if err != nil {
-			return err
-		}
-
-		erArray, err = getResultSet(ctx, bh)
-		if err != nil {
-			return err
-		}
-		if execResultArrayHasData(erArray) {
-			stageStatus, err = erArray[0].GetString(ctx, 0, 1)
-			if err != nil {
-				return err
-			}
-
-			// is the stage staus is disabled
-			if stageStatus == tree.StageStatusDisabled.String() {
-				return moerr.NewInternalError(ctx, "stage '%s' is invalid, please check", stageName)
-			} else if stageStatus == tree.StageStatusEnabled.String() {
-				// replace the filepath using stage url
-				url, err = erArray[0].GetString(ctx, 0, 0)
-				if err != nil {
-					return err
-				}
-
-				filePath = strings.Replace(filePath, stageName+":", url, 1)
-				ses.ep.userConfig.StageFilePath = filePath
-			}
-		} else {
-			return moerr.NewInternalError(ctx, "stage '%s' is not exists, please check", stageName)
 		}
 	}
 	return err
@@ -3424,6 +3365,11 @@ func doAlterStage(ctx context.Context, ses *Session, as *tree.AlterStage) (err e
 		}
 	} else {
 		if as.UrlOption.Exist {
+			if !(strings.HasPrefix(as.UrlOption.Url, function.STAGE_PROTOCOL+"://") ||
+				strings.HasPrefix(as.UrlOption.Url, function.S3_PROTOCOL+"://") ||
+				strings.HasPrefix(as.UrlOption.Url, function.FILE_PROTOCOL+":///")) {
+				return moerr.NewBadConfig(ctx, "URL protocol only supports stage://, s3:// and file:///")
+			}
 			sql = getsqlForUpdateStageUrl(string(as.Name), as.UrlOption.Url)
 			err = bh.Exec(ctx, sql)
 			if err != nil {
@@ -3432,7 +3378,7 @@ func doAlterStage(ctx context.Context, ses *Session, as *tree.AlterStage) (err e
 		}
 
 		if as.CredentialsOption.Exist {
-			credentials = HashPassWord(formatCredentials(as.CredentialsOption))
+			credentials = formatCredentials(as.CredentialsOption)
 			sql = getsqlForUpdateStageCredentials(string(as.Name), credentials)
 			err = bh.Exec(ctx, sql)
 			if err != nil {

--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -1442,9 +1442,9 @@ const (
 
 	checkStageFormat = `select stage_id, stage_name from mo_catalog.mo_stages where stage_name = "%s" order by stage_id;`
 
-	checkStageStatusFormat = `select stage_id, stage_name from mo_catalog.mo_stages where stage_status = "%s" order by stage_id;`
+	//checkStageStatusFormat = `select stage_id, stage_name from mo_catalog.mo_stages where stage_status = "%s" order by stage_id;`
 
-	checkStageStatusWithStageNameFormat = `select url, stage_status from mo_catalog.mo_stages where stage_name = "%s" order by stage_id;`
+	//checkStageStatusWithStageNameFormat = `select url, stage_status from mo_catalog.mo_stages where stage_name = "%s" order by stage_id;`
 
 	dropStageFormat = `delete from mo_catalog.mo_stages where stage_name = '%s' order by stage_id;`
 
@@ -1522,13 +1522,17 @@ func getSqlForCheckStage(ctx context.Context, stage string) (string, error) {
 	return fmt.Sprintf(checkStageFormat, stage), nil
 }
 
+/*
 func getSqlForCheckStageStatus(ctx context.Context, status string) string {
 	return fmt.Sprintf(checkStageStatusFormat, status)
 }
+*/
 
 func getSqlForCheckUdfWithDb(dbName string) string {
 	return fmt.Sprintf(checkUdfWithDb, dbName)
 }
+
+/*
 func getSqlForCheckStageStatusWithStageName(ctx context.Context, stage string) (string, error) {
 	err := inputNameIsInvalid(ctx, stage)
 	if err != nil {
@@ -1536,6 +1540,7 @@ func getSqlForCheckStageStatusWithStageName(ctx context.Context, stage string) (
 	}
 	return fmt.Sprintf(checkStageStatusWithStageNameFormat, stage), nil
 }
+*/
 
 func getSqlForInsertIntoMoStages(ctx context.Context, stageName, url, credentials, status, createdTime, comment string) (string, error) {
 	err := inputNameIsInvalid(ctx, stageName)

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -9604,7 +9604,7 @@ func TestDoCreateStage(t *testing.T) {
 		cs := &tree.CreateStage{
 			IfNotExists: false,
 			Name:        tree.Identifier("my_stage_test"),
-			Url:         "'s3://load/files/'",
+			Url:         "s3://load/files/",
 			Credentials: tree.StageCredentials{
 				Exist: false,
 			},
@@ -9662,7 +9662,7 @@ func TestDoCreateStage(t *testing.T) {
 		cs := &tree.CreateStage{
 			IfNotExists: false,
 			Name:        tree.Identifier("my_stage_test"),
-			Url:         "'s3://load/files/'",
+			Url:         "s3://load/files/",
 			Credentials: tree.StageCredentials{
 				Exist: false,
 			},
@@ -9722,7 +9722,7 @@ func TestDoCreateStage(t *testing.T) {
 		cs := &tree.CreateStage{
 			IfNotExists: true,
 			Name:        tree.Identifier("my_stage_test"),
-			Url:         "'s3://load/files/'",
+			Url:         "file:///load/files/",
 			Credentials: tree.StageCredentials{
 				Exist: false,
 			},
@@ -9780,10 +9780,10 @@ func TestDoCreateStage(t *testing.T) {
 		cs := &tree.CreateStage{
 			IfNotExists: false,
 			Name:        tree.Identifier("my_stage_test"),
-			Url:         "'s3://load/files/'",
+			Url:         "s3://load/files/",
 			Credentials: tree.StageCredentials{
 				Exist:       true,
-				Credentials: []string{"'AWS_KEY_ID'", "'1a2b3c'", "'AWS_SECRET_KEY'", "'4x5y6z'"},
+				Credentials: []string{"AWS_KEY_ID", "1a2b3c", "AWS_SECRET_KEY", "4x5y6z"},
 			},
 			Status: tree.StageStatus{
 				Exist:  true,
@@ -9840,7 +9840,7 @@ func TestDoCreateStage(t *testing.T) {
 		cs := &tree.CreateStage{
 			IfNotExists: false,
 			Name:        tree.Identifier("my_stage_test"),
-			Url:         "'s3://load/files/'",
+			Url:         "s3://load/files/",
 			Credentials: tree.StageCredentials{
 				Exist: false,
 			},
@@ -9902,7 +9902,7 @@ func TestDoAlterStage(t *testing.T) {
 			Name:        tree.Identifier("my_stage_test"),
 			UrlOption: tree.StageUrl{
 				Exist: true,
-				Url:   "'s3://load/files/'",
+				Url:   "s3://load/files/",
 			},
 			CredentialsOption: tree.StageCredentials{
 				Exist: false,
@@ -9968,7 +9968,7 @@ func TestDoAlterStage(t *testing.T) {
 			},
 			CredentialsOption: tree.StageCredentials{
 				Exist:       true,
-				Credentials: []string{"'AWS_KEY_ID'", "'1a2b3c'", "'AWS_SECRET_KEY'", "'4x5y6z'"},
+				Credentials: []string{"AWS_KEY_ID", "1a2b3c", "AWS_SECRET_KEY", "4x5y6z"},
 			},
 			StatusOption: tree.StageStatus{
 				Exist: false,
@@ -10028,7 +10028,7 @@ func TestDoAlterStage(t *testing.T) {
 			Name:        tree.Identifier("my_stage_test"),
 			UrlOption: tree.StageUrl{
 				Exist: true,
-				Url:   "'s3://load/files/'",
+				Url:   "s3://load/files/",
 			},
 			CredentialsOption: tree.StageCredentials{
 				Exist: false,
@@ -10089,7 +10089,7 @@ func TestDoAlterStage(t *testing.T) {
 			Name:        tree.Identifier("my_stage_test"),
 			UrlOption: tree.StageUrl{
 				Exist: true,
-				Url:   "'s3://load/files/'",
+				Url:   "s3://load/files/",
 			},
 			CredentialsOption: tree.StageCredentials{
 				Exist: false,
@@ -10150,11 +10150,11 @@ func TestDoAlterStage(t *testing.T) {
 			Name:        tree.Identifier("my_stage_test"),
 			UrlOption: tree.StageUrl{
 				Exist: true,
-				Url:   "'s3://load/files/'",
+				Url:   "s3://load/files/",
 			},
 			CredentialsOption: tree.StageCredentials{
 				Exist:       true,
-				Credentials: []string{"'AWS_KEY_ID'", "'1a2b3c'", "'AWS_SECRET_KEY'", "'4x5y6z'"},
+				Credentials: []string{"AWS_KEY_ID", "1a2b3c", "AWS_SECRET_KEY", "4x5y6z"},
 			},
 			StatusOption: tree.StageStatus{
 				Exist: false,
@@ -10215,7 +10215,7 @@ func TestDoAlterStage(t *testing.T) {
 			},
 			CredentialsOption: tree.StageCredentials{
 				Exist:       true,
-				Credentials: []string{"'AWS_KEY_ID'", "'1a2b3c'", "'AWS_SECRET_KEY'", "'4x5y6z'"},
+				Credentials: []string{"AWS_KEY_ID", "1a2b3c", "AWS_SECRET_KEY", "4x5y6z"},
 			},
 			StatusOption: tree.StageStatus{
 				Exist: false,
@@ -10240,307 +10240,6 @@ func TestDoAlterStage(t *testing.T) {
 		convey.So(err, convey.ShouldNotBeNil)
 	})
 
-}
-
-func TestDoCheckFilePath(t *testing.T) {
-	convey.Convey("doCheckFilePath success", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		ses := newTestSession(t, ctrl)
-		defer ses.Close()
-
-		bh := &backgroundExecTest{}
-		bh.init()
-
-		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
-		defer bhStub.Reset()
-
-		pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
-		pu.SV.SetDefaultValues()
-		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
-
-		rm, _ := NewRoutineManager(ctx)
-		ses.rm = rm
-
-		tenant := &TenantInfo{
-			Tenant:        sysAccountName,
-			User:          rootName,
-			DefaultRole:   moAdminRoleName,
-			TenantID:      sysAccountID,
-			UserID:        rootID,
-			DefaultRoleID: moAdminRoleID,
-		}
-		ses.SetTenantInfo(tenant)
-
-		cs := &tree.Select{}
-		ses.InitExportConfig(cs.Ep)
-
-		//no result set
-		bh.sql2result["begin;"] = nil
-		bh.sql2result["commit;"] = nil
-		bh.sql2result["rollback;"] = nil
-
-		err := doCheckFilePath(ctx, ses, cs.Ep)
-		convey.So(err, convey.ShouldBeNil)
-	})
-
-	convey.Convey("doCheckFilePath success", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		ses := newTestSession(t, ctrl)
-		defer ses.Close()
-
-		bh := &backgroundExecTest{}
-		bh.init()
-
-		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
-		defer bhStub.Reset()
-
-		pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
-		pu.SV.SetDefaultValues()
-		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
-
-		rm, _ := NewRoutineManager(ctx)
-		ses.rm = rm
-
-		tenant := &TenantInfo{
-			Tenant:        sysAccountName,
-			User:          rootName,
-			DefaultRole:   moAdminRoleName,
-			TenantID:      sysAccountID,
-			UserID:        rootID,
-			DefaultRoleID: moAdminRoleID,
-		}
-		ses.SetTenantInfo(tenant)
-
-		cs := &tree.Select{
-			Ep: &tree.ExportParam{
-				FilePath: "/mnt/disk1/t1.csv",
-			},
-		}
-		ses.InitExportConfig(cs.Ep)
-
-		//no result set
-		bh.sql2result["begin;"] = nil
-		bh.sql2result["commit;"] = nil
-		bh.sql2result["rollback;"] = nil
-
-		sql := getSqlForCheckStageStatus(ctx, "enabled")
-		mrs := newMrsForPasswordOfUser([][]interface{}{})
-		bh.sql2result[sql] = mrs
-
-		err := doCheckFilePath(ctx, ses, cs.Ep)
-		convey.So(err, convey.ShouldBeNil)
-	})
-
-	convey.Convey("doCheckFilePath success", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		ses := newTestSession(t, ctrl)
-		defer ses.Close()
-
-		bh := &backgroundExecTest{}
-		bh.init()
-
-		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
-		defer bhStub.Reset()
-
-		pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
-		pu.SV.SetDefaultValues()
-		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
-
-		rm, _ := NewRoutineManager(ctx)
-		ses.rm = rm
-
-		tenant := &TenantInfo{
-			Tenant:        sysAccountName,
-			User:          rootName,
-			DefaultRole:   moAdminRoleName,
-			TenantID:      sysAccountID,
-			UserID:        rootID,
-			DefaultRoleID: moAdminRoleID,
-		}
-		ses.SetTenantInfo(tenant)
-
-		cs := &tree.Select{
-			Ep: &tree.ExportParam{
-				FilePath: "/mnt/disk1/t1.csv",
-			},
-		}
-		ses.InitExportConfig(cs.Ep)
-
-		//no result set
-		bh.sql2result["begin;"] = nil
-		bh.sql2result["commit;"] = nil
-		bh.sql2result["rollback;"] = nil
-
-		sql := getSqlForCheckStageStatus(ctx, "enabled")
-		mrs := newMrsForPasswordOfUser([][]interface{}{
-			{0, 0},
-		})
-		bh.sql2result[sql] = mrs
-
-		err := doCheckFilePath(ctx, ses, cs.Ep)
-		convey.So(err, convey.ShouldNotBeNil)
-	})
-
-	convey.Convey("doCheckFilePath fail", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		ses := newTestSession(t, ctrl)
-		defer ses.Close()
-
-		bh := &backgroundExecTest{}
-		bh.init()
-
-		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
-		defer bhStub.Reset()
-
-		pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
-		pu.SV.SetDefaultValues()
-		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
-
-		rm, _ := NewRoutineManager(ctx)
-		ses.rm = rm
-
-		tenant := &TenantInfo{
-			Tenant:        sysAccountName,
-			User:          rootName,
-			DefaultRole:   moAdminRoleName,
-			TenantID:      sysAccountID,
-			UserID:        rootID,
-			DefaultRoleID: moAdminRoleID,
-		}
-		ses.SetTenantInfo(tenant)
-
-		cs := &tree.Select{
-			Ep: &tree.ExportParam{
-				FilePath: "stage1:/t1.csv",
-			},
-		}
-		ses.InitExportConfig(cs.Ep)
-
-		//no result set
-		bh.sql2result["begin;"] = nil
-		bh.sql2result["commit;"] = nil
-		bh.sql2result["rollback;"] = nil
-
-		sql, _ := getSqlForCheckStageStatusWithStageName(ctx, "stage1")
-		mrs := newMrsForPasswordOfUser([][]interface{}{})
-		bh.sql2result[sql] = mrs
-
-		err := doCheckFilePath(ctx, ses, cs.Ep)
-		convey.So(err, convey.ShouldNotBeNil)
-	})
-
-	convey.Convey("doCheckFilePath fail", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		ses := newTestSession(t, ctrl)
-		defer ses.Close()
-
-		bh := &backgroundExecTest{}
-		bh.init()
-
-		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
-		defer bhStub.Reset()
-
-		pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
-		pu.SV.SetDefaultValues()
-		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
-
-		rm, _ := NewRoutineManager(ctx)
-		ses.rm = rm
-
-		tenant := &TenantInfo{
-			Tenant:        sysAccountName,
-			User:          rootName,
-			DefaultRole:   moAdminRoleName,
-			TenantID:      sysAccountID,
-			UserID:        rootID,
-			DefaultRoleID: moAdminRoleID,
-		}
-		ses.SetTenantInfo(tenant)
-
-		cs := &tree.Select{
-			Ep: &tree.ExportParam{
-				FilePath: "stage1:/t1.csv",
-			},
-		}
-		ses.InitExportConfig(cs.Ep)
-
-		//no result set
-		bh.sql2result["begin;"] = nil
-		bh.sql2result["commit;"] = nil
-		bh.sql2result["rollback;"] = nil
-
-		sql, _ := getSqlForCheckStageStatusWithStageName(ctx, "stage1")
-		mrs := newMrsForPasswordOfUser([][]interface{}{
-			{"/tmp", "disabled"},
-		})
-		bh.sql2result[sql] = mrs
-
-		err := doCheckFilePath(ctx, ses, cs.Ep)
-		convey.So(err, convey.ShouldNotBeNil)
-	})
-
-	convey.Convey("doCheckFilePath success", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		ses := newTestSession(t, ctrl)
-		defer ses.Close()
-
-		bh := &backgroundExecTest{}
-		bh.init()
-
-		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
-		defer bhStub.Reset()
-
-		pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
-		pu.SV.SetDefaultValues()
-		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
-
-		rm, _ := NewRoutineManager(ctx)
-		ses.rm = rm
-
-		tenant := &TenantInfo{
-			Tenant:        sysAccountName,
-			User:          rootName,
-			DefaultRole:   moAdminRoleName,
-			TenantID:      sysAccountID,
-			UserID:        rootID,
-			DefaultRoleID: moAdminRoleID,
-		}
-		ses.SetTenantInfo(tenant)
-
-		cs := &tree.Select{
-			Ep: &tree.ExportParam{
-				FilePath: "stage1:/t1.csv",
-			},
-		}
-		ses.InitExportConfig(cs.Ep)
-
-		//no result set
-		bh.sql2result["begin;"] = nil
-		bh.sql2result["commit;"] = nil
-		bh.sql2result["rollback;"] = nil
-
-		sql, _ := getSqlForCheckStageStatusWithStageName(ctx, "stage1")
-		mrs := newMrsForPasswordOfUser([][]interface{}{
-			{"/tmp", "enabled"},
-		})
-		bh.sql2result[sql] = mrs
-
-		err := doCheckFilePath(ctx, ses, cs.Ep)
-		convey.So(err, convey.ShouldBeNil)
-		convey.So(cs.Ep.FilePath, convey.ShouldEqual, "stage1:/t1.csv")
-	})
 }
 
 func TestGetLabelPart(t *testing.T) {

--- a/pkg/frontend/export.go
+++ b/pkg/frontend/export.go
@@ -15,12 +15,10 @@
 package frontend
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"slices"
 	"strconv"
 	"strings"
@@ -44,10 +42,7 @@ import (
 type ExportConfig struct {
 	// configs from user input
 	userConfig *tree.ExportParam
-	// file handler
-	File *os.File
-	// bufio.writer
-	Writer *bufio.Writer
+
 	// curFileSize
 	CurFileSize uint64
 	Rows        uint64
@@ -56,26 +51,20 @@ type ExportConfig struct {
 	Symbol      [][]byte
 	// default flush size
 	DefaultBufSize int64
-	OutputStr      []byte
-	LineSize       uint64
 
 	//file service & buffer for the line
-	UseFileService bool
 	writeParam
 	FileService fileservice.FileService
-	LineBuffer  *bytes.Buffer
 	Ctx         context.Context
 	AsyncReader *io.PipeReader
 	AsyncWriter *io.PipeWriter
 	AsyncGroup  *errgroup.Group
 	mrs         *MysqlResultSet
-	lineStr     []byte
 	ctx         context.Context
 }
 
 type writeParam struct {
 	First      bool
-	OutTofile  bool
 	Index      atomic.Int32
 	WriteIndex atomic.Int32
 	ByteChan   chan *BatchByte
@@ -88,7 +77,6 @@ type BatchByte struct {
 	err       error
 }
 
-var OpenFile = os.OpenFile
 var escape byte = '"'
 
 type CloseExportData struct {
@@ -137,54 +125,61 @@ func initExportFileParam(ep *ExportConfig, mrs *MysqlResultSet) {
 }
 
 var openNewFile = func(ctx context.Context, ep *ExportConfig, mrs *MysqlResultSet) error {
-	lineSize := ep.LineSize
 	var err error
+	var filePath string
 	ep.CurFileSize = 0
-	if !ep.UseFileService {
-		var filePath string
-		if len(ep.userConfig.StageFilePath) != 0 {
-			filePath = getExportFilePath(ep.userConfig.StageFilePath, ep.FileCnt)
-		} else {
-			filePath = getExportFilePath(ep.userConfig.FilePath, ep.FileCnt)
-		}
-		ep.File, err = OpenFile(filePath, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0o666)
+
+	ep.AsyncReader, ep.AsyncWriter = io.Pipe()
+	if len(ep.userConfig.StageFilePath) != 0 {
+		filePath = getExportFilePath(ep.userConfig.StageFilePath, ep.FileCnt)
+	} else {
+		filePath = getExportFilePath(ep.userConfig.FilePath, ep.FileCnt)
+	}
+
+	// fileservice is determined from filepath
+	// if filepath is SHARED:/path, return getGlobalPu().FileService, filepath
+	// otherwise, return fileservice.GetForETL(ctx, nil, filepath)
+	fspath, err := fileservice.ParsePath(filePath)
+	if err != nil {
+		return err
+	}
+
+	var readPath string
+	if fspath.Service == defines.SharedFileServiceName {
+		ep.FileService = getGlobalPu().FileService
+		readPath = filePath
+
+	} else {
+		ep.FileService, readPath, err = fileservice.GetForETL(ctx, nil, filePath)
 		if err != nil {
 			return err
 		}
-		ep.Writer = bufio.NewWriterSize(ep.File, int(ep.DefaultBufSize))
-	} else {
-		//default 1MB
-		if ep.LineBuffer == nil {
-			ep.LineBuffer = &bytes.Buffer{}
-		} else {
-			ep.LineBuffer.Reset()
-		}
-		ep.AsyncReader, ep.AsyncWriter = io.Pipe()
-		filePath := getExportFilePath(ep.userConfig.FilePath, ep.FileCnt)
 
-		asyncWriteFunc := func() error {
-			vec := fileservice.IOVector{
-				FilePath: filePath,
-				Entries: []fileservice.IOEntry{
-					{
-						ReaderForWrite: ep.AsyncReader,
-						Size:           -1,
-					},
-				},
-			}
-			err := ep.FileService.Write(ctx, vec)
-			if err != nil {
-				err2 := ep.AsyncReader.CloseWithError(err)
-				if err2 != nil {
-					return err2
-				}
-			}
-			return err
-		}
-
-		ep.AsyncGroup, _ = errgroup.WithContext(ctx)
-		ep.AsyncGroup.Go(asyncWriteFunc)
 	}
+
+	asyncWriteFunc := func() error {
+		vec := fileservice.IOVector{
+			FilePath: readPath,
+			Entries: []fileservice.IOEntry{
+				{
+					ReaderForWrite: ep.AsyncReader,
+					Size:           -1,
+				},
+			},
+		}
+		err := ep.FileService.Write(ctx, vec)
+		if err != nil {
+			err2 := ep.AsyncReader.CloseWithError(err)
+			if err2 != nil {
+				return err2
+			}
+		}
+		return err
+	}
+
+	ep.AsyncGroup, _ = errgroup.WithContext(ctx)
+	ep.AsyncGroup.Go(asyncWriteFunc)
+
 	if ep.userConfig.Header {
 		var header string
 		n := len(mrs.Columns)
@@ -201,17 +196,9 @@ var openNewFile = func(ctx context.Context, ep *ExportConfig, mrs *MysqlResultSe
 		if err := writeDataToCSVFile(ep, []byte(header)); err != nil {
 			return err
 		}
-		if _, err := EndOfLine(ep); err != nil {
-			return err
-		}
 	}
-	if lineSize != 0 {
-		ep.LineSize = 0
-		ep.Rows = 0
-		if err := writeDataToCSVFile(ep, ep.OutputStr); err != nil {
-			return err
-		}
-	}
+
+	ep.Rows = 0
 	return nil
 }
 
@@ -223,129 +210,61 @@ func getExportFilePath(filename string, fileCnt uint) string {
 	}
 }
 
-var formatOutputString = func(oq *ExportConfig, tmp, symbol []byte, enclosed byte, flag bool) error {
+var formatOutputString = func(oq *ExportConfig, tmp, symbol []byte, enclosed byte, flag bool, buffer *bytes.Buffer) error {
 	var err error
 	if flag && enclosed != 0 {
-		if err = writeToCSVFile(oq, []byte{enclosed}); err != nil {
+		if _, err = buffer.Write([]byte{enclosed}); err != nil {
 			return err
 		}
 	}
-	if err = writeToCSVFile(oq, tmp); err != nil {
+	if _, err = buffer.Write(tmp); err != nil {
 		return err
 	}
 	if flag && enclosed != 0 {
-		if err = writeToCSVFile(oq, []byte{enclosed}); err != nil {
+		if _, err = buffer.Write([]byte{enclosed}); err != nil {
 			return err
 		}
 	}
-	if err = writeToCSVFile(oq, symbol); err != nil {
+	if _, err = buffer.Write(symbol); err != nil {
 		return err
 	}
 	return nil
-}
-
-var Flush = func(ep *ExportConfig) error {
-	if !ep.UseFileService {
-		return ep.Writer.Flush()
-	}
-	return nil
-}
-
-var Seek = func(ep *ExportConfig) (int64, error) {
-	if !ep.UseFileService {
-		return ep.File.Seek(int64(ep.CurFileSize-ep.LineSize), io.SeekStart)
-	}
-	return 0, nil
-}
-
-var Read = func(ep *ExportConfig) (int, error) {
-	if !ep.UseFileService {
-		ep.OutputStr = make([]byte, ep.LineSize)
-		return ep.File.Read(ep.OutputStr)
-	} else {
-		ep.OutputStr = make([]byte, ep.LineSize)
-		copy(ep.OutputStr, ep.LineBuffer.Bytes())
-		ep.LineBuffer.Reset()
-		return int(ep.LineSize), nil
-	}
-}
-
-var Truncate = func(ep *ExportConfig) error {
-	if !ep.UseFileService {
-		return ep.File.Truncate(int64(ep.CurFileSize - ep.LineSize))
-	} else {
-		return nil
-	}
 }
 
 var Close = func(ep *ExportConfig) error {
-	if !ep.UseFileService {
-		ep.FileCnt++
-		return ep.File.Close()
-	} else {
-		ep.FileCnt++
-		err := ep.AsyncWriter.Close()
-		if err != nil {
-			return err
-		}
-		err = ep.AsyncGroup.Wait()
-		if err != nil {
-			return err
-		}
-		err = ep.AsyncReader.Close()
-		if err != nil {
-			return err
-		}
-		ep.AsyncReader = nil
-		ep.AsyncWriter = nil
-		ep.AsyncGroup = nil
+	ep.FileCnt++
+	err := ep.AsyncWriter.Close()
+	if err != nil {
 		return err
 	}
+	err = ep.AsyncGroup.Wait()
+	if err != nil {
+		return err
+	}
+	err = ep.AsyncReader.Close()
+	if err != nil {
+		return err
+	}
+	ep.AsyncReader = nil
+	ep.AsyncWriter = nil
+	ep.AsyncGroup = nil
+	return err
 }
 
 var Write = func(ep *ExportConfig, output []byte) (int, error) {
-	if !ep.UseFileService {
-		return ep.Writer.Write(output)
-	} else {
-		return ep.LineBuffer.Write(output)
-	}
-}
-
-var EndOfLine = func(ep *ExportConfig) (int, error) {
-	if ep.UseFileService {
-		n, err := ep.AsyncWriter.Write(ep.LineBuffer.Bytes())
-		if err != nil {
-			err2 := ep.AsyncWriter.CloseWithError(err)
-			if err2 != nil {
-				return 0, err2
-			}
+	n, err := ep.AsyncWriter.Write(output)
+	if err != nil {
+		err2 := ep.AsyncWriter.CloseWithError(err)
+		if err2 != nil {
+			return 0, err2
 		}
-		ep.LineBuffer.Reset()
-		return n, err
 	}
-	return 0, nil
+	return n, err
 }
 
+// wrtieToCSVFile function may create a new file. Make sure the output buffer contains the complete CSV row to keep the CSV parser happy.
 func writeToCSVFile(ep *ExportConfig, output []byte) error {
 	if ep.userConfig.MaxFileSize != 0 && ep.CurFileSize+uint64(len(output)) > ep.userConfig.MaxFileSize {
-		if err := Flush(ep); err != nil {
-			return err
-		}
-		if ep.LineSize != 0 && ep.OutTofile {
-			if _, err := Seek(ep); err != nil {
-				return err
-			}
-			for {
-				if n, err := Read(ep); err != nil {
-					return err
-				} else if uint64(n) == ep.LineSize {
-					break
-				}
-			}
-			if err := Truncate(ep); err != nil {
-				return err
-			}
-		}
 		if err := Close(ep); err != nil {
 			return err
 		}
@@ -361,6 +280,7 @@ func writeToCSVFile(ep *ExportConfig, output []byte) error {
 }
 
 var writeDataToCSVFile = func(ep *ExportConfig, output []byte) error {
+
 	for {
 		if n, err := Write(ep, output); err != nil {
 			return err
@@ -368,7 +288,6 @@ var writeDataToCSVFile = func(ep *ExportConfig, output []byte) error {
 			break
 		}
 	}
-	ep.LineSize += uint64(len(output))
 	ep.CurFileSize += uint64(len(output))
 	return nil
 }
@@ -557,16 +476,15 @@ func addEscapeToString(s []byte) []byte {
 	return ret
 }
 
-func exportDataToCSVFile(oq *ExportConfig) error {
-	if !oq.OutTofile {
-		return exportDataToCSVFile2(oq)
-	}
-	oq.LineSize = 0
-
+func exportDataFromResultSetToCSVFile(oq *ExportConfig) error {
 	symbol := oq.Symbol
 	closeby := oq.userConfig.Fields.EnclosedBy.Value
 	flag := oq.ColumnFlag
+
+	buffer := &bytes.Buffer{}
+
 	for i := uint64(0); i < oq.mrs.GetColumnCount(); i++ {
+
 		column, err := oq.mrs.GetColumn(oq.ctx, i)
 		if err != nil {
 			return err
@@ -579,7 +497,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			return err
 		} else if isNil {
 			//NULL is output as \N
-			if err = formatOutputString(oq, []byte{'\\', 'N'}, symbol[i], closeby, false); err != nil {
+			if err = formatOutputString(oq, []byte{'\\', 'N'}, symbol[i], closeby, false, buffer); err != nil {
 				return err
 			}
 			continue
@@ -591,7 +509,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			if err != nil {
 				return err
 			}
-			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i]); err != nil {
+			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_BOOL:
@@ -599,7 +517,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			if err != nil {
 				return err
 			}
-			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i]); err != nil {
+			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_BIT:
@@ -607,7 +525,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			if err != nil {
 				return err
 			}
-			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i]); err != nil {
+			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_TINY, defines.MYSQL_TYPE_SHORT, defines.MYSQL_TYPE_INT24, defines.MYSQL_TYPE_LONG, defines.MYSQL_TYPE_YEAR:
@@ -617,20 +535,20 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			}
 			if mysqlColumn.ColumnType() == defines.MYSQL_TYPE_YEAR {
 				if value == 0 {
-					if err = formatOutputString(oq, []byte("0000"), symbol[i], closeby, flag[i]); err != nil {
+					if err = formatOutputString(oq, []byte("0000"), symbol[i], closeby, flag[i], buffer); err != nil {
 						return err
 					}
 				} else {
-					oq.resetLineStr()
-					oq.lineStr = strconv.AppendInt(oq.lineStr, value, 10)
-					if err = formatOutputString(oq, oq.lineStr, symbol[i], closeby, flag[i]); err != nil {
+					var lineStr []byte
+					lineStr = strconv.AppendInt(lineStr, value, 10)
+					if err = formatOutputString(oq, lineStr, symbol[i], closeby, flag[i], buffer); err != nil {
 						return err
 					}
 				}
 			} else {
-				oq.resetLineStr()
-				oq.lineStr = strconv.AppendInt(oq.lineStr, value, 10)
-				if err = formatOutputString(oq, oq.lineStr, symbol[i], closeby, flag[i]); err != nil {
+				var lineStr []byte
+				lineStr = strconv.AppendInt(lineStr, value, 10)
+				if err = formatOutputString(oq, lineStr, symbol[i], closeby, flag[i], buffer); err != nil {
 					return err
 				}
 			}
@@ -639,8 +557,8 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			if err != nil {
 				return err
 			}
-			oq.lineStr = []byte(fmt.Sprintf("%v", value))
-			if err = formatOutputString(oq, oq.lineStr, symbol[i], closeby, flag[i]); err != nil {
+			lineStr := []byte(fmt.Sprintf("%v", value))
+			if err = formatOutputString(oq, lineStr, symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_LONGLONG:
@@ -648,9 +566,9 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 				if value, err := oq.mrs.GetUint64(oq.ctx, 0, i); err != nil {
 					return err
 				} else {
-					oq.resetLineStr()
-					oq.lineStr = strconv.AppendUint(oq.lineStr, value, 10)
-					if err = formatOutputString(oq, oq.lineStr, symbol[i], closeby, flag[i]); err != nil {
+					var lineStr []byte
+					lineStr = strconv.AppendUint(lineStr, value, 10)
+					if err = formatOutputString(oq, lineStr, symbol[i], closeby, flag[i], buffer); err != nil {
 						return err
 					}
 				}
@@ -658,9 +576,9 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 				if value, err := oq.mrs.GetInt64(oq.ctx, 0, i); err != nil {
 					return err
 				} else {
-					oq.resetLineStr()
-					oq.lineStr = strconv.AppendInt(oq.lineStr, value, 10)
-					if err = formatOutputString(oq, oq.lineStr, symbol[i], closeby, flag[i]); err != nil {
+					var lineStr []byte
+					lineStr = strconv.AppendInt(lineStr, value, 10)
+					if err = formatOutputString(oq, lineStr, symbol[i], closeby, flag[i], buffer); err != nil {
 						return err
 					}
 				}
@@ -673,7 +591,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 				return err
 			}
 			value = addEscapeToString(value.([]byte))
-			if err = formatOutputString(oq, value.([]byte), symbol[i], closeby, true); err != nil {
+			if err = formatOutputString(oq, value.([]byte), symbol[i], closeby, true, buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_DATE:
@@ -681,7 +599,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			if err != nil {
 				return err
 			}
-			if err = formatOutputString(oq, []byte(value.(types.Date).String()), symbol[i], closeby, flag[i]); err != nil {
+			if err = formatOutputString(oq, []byte(value.(types.Date).String()), symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_TIME:
@@ -689,7 +607,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			if err != nil {
 				return err
 			}
-			if err = formatOutputString(oq, []byte(value.(types.Time).String()), symbol[i], closeby, flag[i]); err != nil {
+			if err = formatOutputString(oq, []byte(value.(types.Time).String()), symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_DATETIME:
@@ -697,7 +615,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			if err != nil {
 				return err
 			}
-			if err = formatOutputString(oq, []byte(value.(string)), symbol[i], closeby, flag[i]); err != nil {
+			if err = formatOutputString(oq, []byte(value.(string)), symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_TIMESTAMP:
@@ -705,7 +623,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			if err != nil {
 				return err
 			}
-			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i]); err != nil {
+			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_JSON:
@@ -714,7 +632,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 				return err
 			}
 			jsonStr := value.(bytejson.ByteJson).String()
-			if err = formatOutputString(oq, []byte(jsonStr), symbol[i], closeby, flag[i]); err != nil {
+			if err = formatOutputString(oq, []byte(jsonStr), symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_UUID:
@@ -722,7 +640,7 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			if err != nil {
 				return err
 			}
-			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i]); err != nil {
+			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		case defines.MYSQL_TYPE_ENUM:
@@ -730,24 +648,30 @@ func exportDataToCSVFile(oq *ExportConfig) error {
 			if err != nil {
 				return err
 			}
-			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i]); err != nil {
+			if err = formatOutputString(oq, []byte(value), symbol[i], closeby, flag[i], buffer); err != nil {
 				return err
 			}
 		default:
 			return moerr.NewInternalError(oq.ctx, "unsupported column type %d ", mysqlColumn.ColumnType())
 		}
 	}
+
+	// write the complete CSV row to CSV Writer
+	err := writeToCSVFile(oq, buffer.Bytes())
+	if err != nil {
+		return err
+	}
 	oq.Rows++
-	_, err := EndOfLine(oq)
 	return err
 }
 
-func exportDataToCSVFile2(ep *ExportConfig) error {
+func exportDataFromBatchToCSVFile(ep *ExportConfig) error {
 	var tmp *BatchByte
 	select {
 	case tmp = <-ep.ByteChan:
 	default:
 	}
+
 	if tmp != nil {
 		if tmp.err != nil {
 			return tmp.err
@@ -760,16 +684,16 @@ func exportDataToCSVFile2(ep *ExportConfig) error {
 		return nil
 	}
 
-	if err := writeToCSVFile(ep, value); err != nil {
+	err := writeToCSVFile(ep, value)
+	if err != nil {
 		return err
 	}
 	ep.WriteIndex.Add(1)
 	ep.BatchMap[ep.WriteIndex.Load()] = nil
-	_, err := EndOfLine(ep)
 	return err
 }
 
-func exportAllData(ep *ExportConfig) error {
+func exportAllDataFromBatches(ep *ExportConfig) error {
 	var tmp *BatchByte
 	for {
 		tmp = nil
@@ -796,6 +720,7 @@ func exportAllData(ep *ExportConfig) error {
 		}
 		ep.WriteIndex.Add(1)
 		ep.BatchMap[ep.WriteIndex.Load()] = nil
+
 	}
 	ep.First = false
 	ep.FileCnt = 0
@@ -813,10 +738,6 @@ func (ec *ExportConfig) init() {
 	ec.WriteIndex.Store(0)
 }
 
-func (ec *ExportConfig) resetLineStr() {
-	ec.lineStr = ec.lineStr[:0]
-}
-
 func (ec *ExportConfig) Write(execCtx *ExecCtx, bat *batch.Batch) error {
 	ec.Index.Add(1)
 	copied, err := bat.Dup(execCtx.ses.GetMemPool())
@@ -824,7 +745,8 @@ func (ec *ExportConfig) Write(execCtx *ExecCtx, bat *batch.Batch) error {
 		return err
 	}
 	go constructByte(execCtx.reqCtx, execCtx.ses, copied, ec.Index.Load(), ec.ByteChan, ec)
-	if err = exportDataToCSVFile(ec); err != nil {
+
+	if err = exportDataFromBatchToCSVFile(ec); err != nil {
 		execCtx.ses.Error(execCtx.reqCtx,
 			"Error occurred while exporting to CSV file",
 			zap.Error(err))
@@ -836,7 +758,6 @@ func (ec *ExportConfig) Write(execCtx *ExecCtx, bat *batch.Batch) error {
 func (ec *ExportConfig) Close() {
 	if ec != nil {
 		ec.mrs = nil
-		ec.lineStr = nil
 		ec.ctx = nil
 	}
 }

--- a/pkg/frontend/export_test.go
+++ b/pkg/frontend/export_test.go
@@ -15,9 +15,8 @@
 package frontend
 
 import (
-	"bufio"
+	"bytes"
 	"context"
-	"os"
 	"testing"
 
 	"github.com/prashantv/gostub"
@@ -61,7 +60,7 @@ func Test_initExportFileParam(t *testing.T) {
 }
 
 func Test_openNewFile(t *testing.T) {
-	convey.Convey("openNewFile failed", t, func() {
+	convey.Convey("openNewFile succ", t, func() {
 		ep := &ExportConfig{
 			userConfig: &tree.ExportParam{
 				Lines: &tree.Lines{
@@ -78,29 +77,6 @@ func Test_openNewFile(t *testing.T) {
 			mrs: &MysqlResultSet{},
 		}
 
-		stubs := gostub.StubFunc(&OpenFile, nil, moerr.NewInternalError(context.TODO(), "can not open file"))
-		defer stubs.Reset()
-		convey.So(openNewFile(context.TODO(), ep, ep.mrs), convey.ShouldNotBeNil)
-	})
-
-	convey.Convey("openNewFile succ", t, func() {
-		ep := &ExportConfig{
-			userConfig: &tree.ExportParam{
-				Lines: &tree.Lines{
-					TerminatedBy: &tree.Terminated{},
-				},
-				Fields: &tree.Fields{
-					Terminated: &tree.Terminated{},
-					EnclosedBy: &tree.EnclosedBy{},
-					EscapedBy:  &tree.EscapedBy{},
-				},
-				Header:   true,
-				FilePath: "test/export.csv",
-			},
-			LineSize: 1,
-			mrs:      &MysqlResultSet{},
-		}
-
 		col1 := new(MysqlColumn)
 		col1.SetName(colName1)
 		col2 := new(MysqlColumn)
@@ -108,11 +84,7 @@ func Test_openNewFile(t *testing.T) {
 		ep.mrs.AddColumn(col1)
 		ep.mrs.AddColumn(col2)
 
-		var file = &os.File{}
-		stubs := gostub.StubFunc(&OpenFile, file, nil)
-		defer stubs.Reset()
-
-		stubs = gostub.StubFunc(&writeDataToCSVFile, nil)
+		stubs := gostub.StubFunc(&writeDataToCSVFile, nil)
 		defer stubs.Reset()
 
 		convey.So(openNewFile(context.TODO(), ep, ep.mrs), convey.ShouldBeNil)
@@ -134,16 +106,10 @@ func Test_formatOutputString(t *testing.T) {
 				Header:   true,
 				FilePath: "test/export.csv",
 			},
-			LineSize: 1,
-			mrs:      &MysqlResultSet{},
+			mrs: &MysqlResultSet{},
 		}
-		stubs := gostub.StubFunc(&writeDataToCSVFile, moerr.NewInternalError(context.TODO(), "write err"))
-		defer stubs.Reset()
-		convey.So(formatOutputString(ep, nil, nil, '\n', true), convey.ShouldNotBeNil)
-
-		stubs = gostub.StubFunc(&writeDataToCSVFile, nil)
-		defer stubs.Reset()
-		convey.So(formatOutputString(ep, nil, nil, '\n', true), convey.ShouldBeNil)
+		buffer := &bytes.Buffer{}
+		convey.So(formatOutputString(ep, nil, nil, '\n', true, buffer), convey.ShouldBeNil)
 	})
 }
 
@@ -162,63 +128,34 @@ func Test_writeToCSVFile(t *testing.T) {
 				Header:   true,
 				FilePath: "test/export.csv",
 			},
-			LineSize: 1,
-			Writer:   &bufio.Writer{},
-			mrs:      &MysqlResultSet{},
+			mrs: &MysqlResultSet{},
 		}
 
 		var output = []byte{'1', '2'}
 		ep.userConfig.MaxFileSize = 1
 
-		convey.So(writeToCSVFile(ep, output), convey.ShouldNotBeNil)
-
-		ep.Rows = 1
-		stubs := gostub.StubFunc(&Flush, moerr.NewInternalError(context.TODO(), "Flush error"))
-		defer stubs.Reset()
-
-		convey.So(writeToCSVFile(ep, output), convey.ShouldNotBeNil)
-
-		stubs = gostub.StubFunc(&Flush, nil)
-		defer stubs.Reset()
-
-		stubs = gostub.StubFunc(&Seek, int64(0), moerr.NewInternalError(context.TODO(), "Seek error"))
+		stubs := gostub.StubFunc(&Close, moerr.NewInternalError(context.TODO(), "Close error"))
 		defer stubs.Reset()
 		convey.So(writeToCSVFile(ep, output), convey.ShouldNotBeNil)
 
-		stubs = gostub.StubFunc(&Seek, int64(0), nil)
-		defer stubs.Reset()
-		stubs = gostub.StubFunc(&Read, 0, moerr.NewInternalError(context.TODO(), "Read error"))
-		defer stubs.Reset()
-		convey.So(writeToCSVFile(ep, output), convey.ShouldNotBeNil)
-
-		stubs = gostub.StubFunc(&Read, 1, nil)
-		defer stubs.Reset()
-
-		stubs = gostub.StubFunc(&Truncate, moerr.NewInternalError(context.TODO(), "Truncate error"))
-		defer stubs.Reset()
-		convey.So(writeToCSVFile(ep, output), convey.ShouldNotBeNil)
-
-		stubs = gostub.StubFunc(&Truncate, nil)
-		defer stubs.Reset()
-		stubs = gostub.StubFunc(&Close, moerr.NewInternalError(context.TODO(), "Close error"))
-		defer stubs.Reset()
-		convey.So(writeToCSVFile(ep, output), convey.ShouldNotBeNil)
-
+		// set Close to nil and openNewFile to err
 		stubs = gostub.StubFunc(&Close, nil)
 		defer stubs.Reset()
 		stubs = gostub.StubFunc(&openNewFile, moerr.NewInternalError(context.TODO(), "openNewFile error"))
 		defer stubs.Reset()
 		convey.So(writeToCSVFile(ep, output), convey.ShouldNotBeNil)
 
+		// set Close() to nil
+		stubs = gostub.StubFunc(&Close, nil)
+		defer stubs.Reset()
+		// set openNewFile() to nil
 		stubs = gostub.StubFunc(&openNewFile, nil)
 		defer stubs.Reset()
-		stubs = gostub.StubFunc(&writeDataToCSVFile, moerr.NewInternalError(context.TODO(), "writeDataToCSVFile error"))
-		defer stubs.Reset()
-		convey.So(writeToCSVFile(ep, output), convey.ShouldNotBeNil)
-
+		// set writeDataToCSVFile to nil
 		stubs = gostub.StubFunc(&writeDataToCSVFile, nil)
 		defer stubs.Reset()
 		convey.So(writeToCSVFile(ep, output), convey.ShouldBeNil)
+
 	})
 }
 
@@ -237,9 +174,7 @@ func Test_writeDataToCSVFile(t *testing.T) {
 				Header:   true,
 				FilePath: "test/export.csv",
 			},
-			LineSize: 1,
-			Writer:   &bufio.Writer{},
-			mrs:      &MysqlResultSet{},
+			mrs: &MysqlResultSet{},
 		}
 
 		var output = []byte{'1', '2'}
@@ -256,7 +191,7 @@ func Test_writeDataToCSVFile(t *testing.T) {
 }
 
 func Test_exportDataToCSVFile(t *testing.T) {
-	convey.Convey("exportDataToCSVFile succ", t, func() {
+	convey.Convey("exportDataFromResultSetToCSVFile succ", t, func() {
 		ep := &ExportConfig{
 			userConfig: &tree.ExportParam{
 				Lines: &tree.Lines{
@@ -270,9 +205,7 @@ func Test_exportDataToCSVFile(t *testing.T) {
 				Header:   true,
 				FilePath: "test/export.csv",
 			},
-			LineSize: 1,
-			Writer:   &bufio.Writer{},
-			mrs:      &MysqlResultSet{},
+			mrs: &MysqlResultSet{},
 		}
 
 		var col = make([]MysqlColumn, 13)
@@ -304,10 +237,14 @@ func Test_exportDataToCSVFile(t *testing.T) {
 		ep.Symbol = make([][]byte, len(col))
 		ep.ColumnFlag = make([]bool, len(col))
 
-		stubs := gostub.StubFunc(&formatOutputString, nil)
+		stubs := gostub.StubFunc(&Close, nil)
+		defer stubs.Reset()
+		stubs = gostub.StubFunc(&openNewFile, nil)
+		defer stubs.Reset()
+		stubs = gostub.StubFunc(&writeDataToCSVFile, nil)
 		defer stubs.Reset()
 
-		convey.So(exportDataToCSVFile(ep), convey.ShouldBeNil)
+		convey.So(exportDataFromResultSetToCSVFile(ep), convey.ShouldBeNil)
 	})
 
 	convey.Convey("exportDataToCSVFile fail", t, func() {
@@ -324,9 +261,7 @@ func Test_exportDataToCSVFile(t *testing.T) {
 				Header:   true,
 				FilePath: "test/export.csv",
 			},
-			LineSize: 1,
-			Writer:   &bufio.Writer{},
-			mrs:      &MysqlResultSet{},
+			mrs: &MysqlResultSet{},
 		}
 
 		var col = make([]MysqlColumn, 1)
@@ -342,9 +277,12 @@ func Test_exportDataToCSVFile(t *testing.T) {
 		ep.Symbol = make([][]byte, len(col))
 		ep.ColumnFlag = make([]bool, len(col))
 
-		stubs := gostub.StubFunc(&formatOutputString, nil)
+		stubs := gostub.StubFunc(&Close, nil)
 		defer stubs.Reset()
-
-		convey.So(exportDataToCSVFile(ep), convey.ShouldBeNil)
+		stubs = gostub.StubFunc(&openNewFile, nil)
+		defer stubs.Reset()
+		stubs = gostub.StubFunc(&writeDataToCSVFile, nil)
+		defer stubs.Reset()
+		convey.So(exportDataFromResultSetToCSVFile(ep), convey.ShouldBeNil)
 	})
 }

--- a/pkg/frontend/query_result.go
+++ b/pkg/frontend/query_result.go
@@ -597,15 +597,11 @@ func doDumpQueryResult(ctx context.Context, ses *Session, eParam *tree.ExportPar
 		mrs:        mrs,
 	}
 	//prepare output queue
-	exportParam.OutTofile = true
 	//prepare export param
 	exportParam.DefaultBufSize = getGlobalPu().SV.ExportDataDefaultFlushSize
-	exportParam.UseFileService = true
 	exportParam.FileService = getGlobalPu().FileService
 	exportParam.Ctx = ctx
 	defer func() {
-		exportParam.LineBuffer = nil
-		exportParam.OutputStr = nil
 		if exportParam.AsyncReader != nil {
 			_ = exportParam.AsyncReader.Close()
 		}
@@ -665,7 +661,7 @@ func doDumpQueryResult(ctx context.Context, ses *Session, eParam *tree.ExportPar
 				if err != nil {
 					return err
 				}
-				err = exportDataToCSVFile(exportParam)
+				err = exportDataFromResultSetToCSVFile(exportParam)
 				if err != nil {
 					return err
 				}

--- a/pkg/frontend/session_test.go
+++ b/pkg/frontend/session_test.go
@@ -492,11 +492,13 @@ func TestSession_updateTimeZone(t *testing.T) {
 
 	ses := newSes(nil, ctrl)
 	ctx := context.Background()
+	/*
 	err := updateTimeZone(ctx, ses, ses.GetSessionSysVars(), "time_zone", "system")
 	assert.NoError(t, err)
-	assert.Equal(t, ses.GetTimeZone().String(), "Local")
+	assert.Equal(t, "Local", ses.GetTimeZone().String())
+	*/
 
-	err = updateTimeZone(ctx, ses, ses.GetSessionSysVars(), "time_zone", "+00:00")
+	err := updateTimeZone(ctx, ses, ses.GetSessionSysVars(), "time_zone", "+00:00")
 	assert.NoError(t, err)
 	assert.Equal(t, ses.GetTimeZone().String(), "FixedZone")
 

--- a/pkg/frontend/session_test.go
+++ b/pkg/frontend/session_test.go
@@ -493,9 +493,9 @@ func TestSession_updateTimeZone(t *testing.T) {
 	ses := newSes(nil, ctrl)
 	ctx := context.Background()
 	/*
-	err := updateTimeZone(ctx, ses, ses.GetSessionSysVars(), "time_zone", "system")
-	assert.NoError(t, err)
-	assert.Equal(t, "Local", ses.GetTimeZone().String())
+		err := updateTimeZone(ctx, ses, ses.GetSessionSysVars(), "time_zone", "system")
+		assert.NoError(t, err)
+		assert.Equal(t, "Local", ses.GetTimeZone().String())
 	*/
 
 	err := updateTimeZone(ctx, ses, ses.GetSessionSysVars(), "time_zone", "+00:00")

--- a/pkg/frontend/status_stmt.go
+++ b/pkg/frontend/status_stmt.go
@@ -73,13 +73,11 @@ func executeStatusStmt(ses *Session, execCtx *ExecCtx) (err error) {
 				ses.Infof(execCtx.reqCtx, "time of Exec.Run : %s", time.Since(runBegin).String())
 			}
 
-			if err = exportAllData(ep); err != nil {
+			if err = exportAllDataFromBatches(ep); err != nil {
 				return
 			}
-			if err = ep.Writer.Flush(); err != nil {
-				return
-			}
-			if err = ep.File.Close(); err != nil {
+
+			if err = Close(ep); err != nil {
 				return
 			}
 

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -1520,8 +1520,23 @@ func (c *Compile) compileExternScan(n *plan.Node) ([]*Scope, error) {
 	} else if param.ScanType == tree.INLINE {
 		return c.compileExternValueScan(n, param, strictSqlMode)
 	} else {
-		if err := plan2.InitInfileParam(param); err != nil {
+		if err := plan2.InitInfileOrStageParam(param, c.proc); err != nil {
 			return nil, err
+		}
+
+		// if filepath is stage URL, ScanType may change to tree.S3.  check param.Parallel again
+		if param.ScanType == tree.S3 && param.Parallel {
+			mcpu = 0
+			ID2Addr = make(map[int]int, 0)
+			for i := 0; i < len(c.cnList); i++ {
+				tmp := mcpu
+				if c.cnList[i].Mcpu > external.S3ParallelMaxnum {
+					mcpu += external.S3ParallelMaxnum
+				} else {
+					mcpu += c.cnList[i].Mcpu
+				}
+				ID2Addr[i] = mcpu - tmp
+			}
 		}
 	}
 

--- a/pkg/sql/plan/build_load.go
+++ b/pkg/sql/plan/build_load.go
@@ -283,7 +283,7 @@ func checkFileExist(param *tree.ExternParam, ctx CompilerContext) (string, error
 			return "", err
 		}
 	} else {
-		if err := InitInfileParam(param); err != nil {
+		if err := InitInfileOrStageParam(param, ctx.GetProcess()); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/sql/plan/external.go
+++ b/pkg/sql/plan/external.go
@@ -185,7 +185,7 @@ func getExternalStats(node *plan.Node, builder *QueryBuilder) *Stats {
 			return DefaultHugeStats()
 		}
 	} else {
-		if err = InitInfileParam(param); err != nil {
+		if err = InitInfileOrStageParam(param, builder.compCtx.GetProcess()); err != nil {
 			return DefaultHugeStats()
 		}
 	}

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -1775,9 +1775,6 @@ func StageList(
 
 	pattern = path.Clean("/" + pattern)
 
-	const wildcards = "*?"
-	const sep = "/"
-
 	fileList, err := StageListWithPattern(service, pattern, proc)
 	if err != nil {
 		return err

--- a/pkg/sql/plan/function/function_id.go
+++ b/pkg/sql/plan/function/function_id.go
@@ -382,6 +382,9 @@ const (
 	BITMAP_CONSTRUCT_AGG
 	BITMAP_OR_AGG
 
+	// stage function
+	STAGE_LIST
+
 	// FUNCTION_END_NUMBER is not a function, just a flag to record the max number of function.
 	// TODO: every one should put the new function id in front of this one if you want to make a new function.
 	FUNCTION_END_NUMBER
@@ -693,4 +696,7 @@ var functionIdRegister = map[string]int32{
 	"bitmap_count":         BITMAP_COUNT,
 	"bitmap_construct_agg": BITMAP_CONSTRUCT_AGG,
 	"bitmap_or_agg":        BITMAP_OR_AGG,
+
+	// stage function
+	"stage_list": STAGE_LIST,
 }

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -6478,6 +6478,40 @@ var supportedOthersBuiltIns = []FuncNew{
 			},
 		},
 	},
+
+	// function `stage_list`
+	// confused function.
+	{
+		functionId: STAGE_LIST,
+		class:      plan.Function_STRICT,
+		layout:     STANDARD_FUNCTION,
+		checkFn:    fixedTypeMatch,
+
+		Overloads: []overload{
+			{
+				overloadId: 0,
+				volatile:   true,
+				args:       []types.T{types.T_varchar},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_text.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return StageList
+				},
+			},
+			{
+				overloadId: 1,
+				volatile:   true,
+				args:       []types.T{types.T_char},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_text.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return StageList
+				},
+			},
+		},
+	},
 }
 
 func MoCtl(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, _ *FunctionSelectList) (err error) {

--- a/pkg/sql/plan/function/stage_util.go
+++ b/pkg/sql/plan/function/stage_util.go
@@ -159,7 +159,7 @@ func getS3ServiceFromProvider(provider string) (string, error) {
 }
 
 func runSql(proc *process.Process, sql string) (executor.Result, error) {
-	v, ok := moruntime.ProcessLevelRuntime().GetGlobalVariables(moruntime.InternalSQLExecutor)
+	v, ok := moruntime.ServiceRuntime(proc.GetService()).GetGlobalVariables(moruntime.InternalSQLExecutor)
 	if !ok {
 		panic("missing lock service")
 	}

--- a/pkg/sql/plan/function/stage_util.go
+++ b/pkg/sql/plan/function/stage_util.go
@@ -1,0 +1,312 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	//"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+const STAGE_PROTOCOL = "stage"
+const S3_PROTOCOL = "s3"
+const FILE_PROTOCOL = "file"
+
+const PARAMKEY_AWS_KEY_ID = "aws_key_id"
+const PARAMKEY_AWS_SECRET_KEY = "aws_secret_key"
+const PARAMKEY_AWS_REGION = "aws_region"
+const PARAMKEY_ENDPOINT = "endpoint"
+const PARAMKEY_COMPRESSION = "compression"
+const PARAMKEY_PROVIDER = "provider"
+
+const S3_PROVIDER_AMAZON = "amazon"
+const S3_PROVIDER_MINIO = "minio"
+
+const S3_SERVICE = "s3"
+const MINIO_SERVICE = "minio"
+
+
+type StageDef struct {
+	Id          uint32
+	Name        string
+	Url         *url.URL
+	Credentials map[string]string
+	Status    string
+}
+
+
+func (s *StageDef) GetCredentials(key string, defval string) (string, bool) {
+	if s.Credentials == nil {
+		// no credential in this stage
+		return defval, false
+	}
+
+	k := strings.ToLower(key)
+	res, ok := s.Credentials[k]
+	if !ok {
+		return defval, false
+	}
+	return res, ok
+}
+
+func (s *StageDef) expandSubStage(proc *process.Process) (StageDef, error) {
+	if s.Url.Scheme == STAGE_PROTOCOL {
+		stagename, prefix, query, err := ParseStageUrl(s.Url)
+		if err != nil {
+			return StageDef{}, err
+		}
+
+		res, err := StageLoadCatalog(proc, stagename)
+		if err != nil {
+			return StageDef{}, err
+		}
+
+		res.Url = res.Url.JoinPath(prefix)
+		res.Url.RawQuery = query
+		return res.expandSubStage(proc)
+	}
+
+	return *s, nil
+}
+
+// get stages and expand the path. stage may be a file or s3
+// use the format of path  s3,<endpoint>,<region>,<bucket>,<key>,<secret>,<prefix>
+// or minio,<endpoint>,<region>,<bucket>,<key>,<secret>,<prefix>
+// expand the subpath to MO path.
+// subpath is in the format like path or path with query like path?q1=v1&q2=v2...
+func (s *StageDef) ToPath() (mopath string, query string, err error) {
+
+	if s.Url.Scheme == S3_PROTOCOL {
+		bucket, prefix, query, err := ParseS3Url(s.Url)
+		if err != nil {
+			return "", "", err
+		}
+
+		// get S3 credentials
+		aws_key_id, found := s.GetCredentials(PARAMKEY_AWS_KEY_ID, "")
+		if !found {
+			return "", "", moerr.NewBadConfig(context.TODO(), "Stage credentials: AWS_KEY_ID not found")
+		}
+		aws_secret_key, found := s.GetCredentials(PARAMKEY_AWS_SECRET_KEY, "")
+		if !found {
+			return "", "", moerr.NewBadConfig(context.TODO(), "Stage credentials: AWS_SECRET_KEY not found")
+		}
+		aws_region, found := s.GetCredentials(PARAMKEY_AWS_REGION, "")
+		if !found {
+			return "", "", moerr.NewBadConfig(context.TODO(), "Stage credentials: AWS_REGION not found")
+		}
+		provider, found := s.GetCredentials(PARAMKEY_PROVIDER, "")
+		if !found {
+			return "", "", moerr.NewBadConfig(context.TODO(), "Stage credentials: PROVIDER not found")
+		}
+		endpoint, found := s.GetCredentials(PARAMKEY_ENDPOINT, "")
+		if !found {
+			return "", "", moerr.NewBadConfig(context.TODO(), "Stage credentials: ENDPOINT not found")
+		}
+
+		service, err := getS3ServiceFromProvider(provider)
+		if err != nil {
+			return "", "", err
+		}
+
+		buf := new(strings.Builder)
+		w := csv.NewWriter(buf)
+		opts := []string{service, endpoint, aws_region, bucket, aws_key_id, aws_secret_key, ""}
+
+		if err = w.Write(opts); err != nil {
+			return "", "", err
+		}
+		w.Flush()
+		return fileservice.JoinPath(buf.String(), prefix), query, nil
+	} else if s.Url.Scheme == FILE_PROTOCOL {
+		return s.Url.Path, s.Url.RawQuery, nil
+	}
+	return "", "", moerr.NewBadConfig(context.TODO(), "URL protocol %s not supported", s.Url.Scheme)
+}
+
+func getS3ServiceFromProvider(provider string) (string, error) {
+	provider = strings.ToLower(provider)
+	switch provider {
+	case S3_PROVIDER_AMAZON:
+		return S3_SERVICE, nil
+	case S3_PROVIDER_MINIO:
+		return MINIO_SERVICE, nil
+	default:
+		return "", moerr.NewBadConfig(context.TODO(), "provider %s not supported", provider)
+	}
+}
+
+func runSql(proc *process.Process, sql string) (executor.Result, error) {
+	v, ok := moruntime.ProcessLevelRuntime().GetGlobalVariables(moruntime.InternalSQLExecutor)
+	if !ok {
+		panic("missing lock service")
+	}
+	exec := v.(executor.SQLExecutor)
+	opts := executor.Options{}.
+		// All runSql and runSqlWithResult is a part of input sql, can not incr statement.
+		// All these sub-sql's need to be rolled back and retried en masse when they conflict in pessimistic mode
+		WithDisableIncrStatement().
+		WithTxn(proc.GetTxnOperator()).
+		WithDatabase(proc.GetSessionInfo().Database).
+		WithTimeZone(proc.GetSessionInfo().TimeZone).
+		WithAccountID(proc.GetSessionInfo().AccountId)
+	return exec.Exec(proc.Ctx, sql, opts)
+}
+
+func credentialsToMap(cred string) (map[string]string, error)  {
+	if len(cred) == 0 {
+		return nil, nil
+	}
+
+	opts := strings.Split(cred, ",")
+	if len(opts) == 0 {
+		return nil, nil
+	}
+
+	credentials := make(map[string]string)
+	for _, o := range opts {
+		kv := strings.SplitN(o, "=", 2)
+		if len(kv) != 2 {
+			return nil, moerr.NewBadConfig(context.TODO(), "Format error: invalid stage credentials")
+		}
+		credentials[strings.ToLower(kv[0])] = kv[1]
+	}
+
+	return credentials, nil
+}
+
+func StageLoadCatalog(proc *process.Process, stagename string) (s StageDef, err error) {
+	getAllStagesSql := fmt.Sprintf("select stage_id, stage_name, url, stage_credentials, stage_status from `%s`.`%s` WHERE stage_name = '%s';", "mo_catalog", "mo_stages", stagename)
+	res, err := runSql(proc, getAllStagesSql)
+	if err != nil {
+		return StageDef{}, err
+	}
+	defer res.Close()
+
+	const id_idx = 0
+	const name_idx = 1
+	const url_idx = 2
+	const cred_idx = 3
+	const status_idx = 4
+	if res.Batches != nil {
+		for _, batch := range res.Batches {
+			if batch != nil && batch.Vecs[0] != nil && batch.Vecs[0].Length() > 0 {
+				for i := 0; i < batch.Vecs[0].Length(); i++ {
+					stage_id := vector.GetFixedAt[uint32](batch.Vecs[id_idx], i)
+					stage_name := string(batch.Vecs[name_idx].GetBytesAt(i))
+					stage_url, err := url.Parse(string(batch.Vecs[url_idx].GetBytesAt(i)))
+					if err != nil {
+						return StageDef{}, err
+					}
+					stage_cred := string(batch.Vecs[cred_idx].GetBytesAt(i))
+
+					credmap, err := credentialsToMap(stage_cred)
+					if err != nil {
+						return StageDef{}, err
+					}
+
+					stage_status := string(batch.Vecs[status_idx].GetBytesAt(i))
+
+					//logutil.Infof("CATALOG: ID %d,  stage %s url %s cred %s", stage_id, stage_name, stage_url, stage_cred)
+					return StageDef{stage_id, stage_name, stage_url, credmap, stage_status}, nil
+				}
+			}
+		}
+	}
+
+	return StageDef{}, moerr.NewBadConfig(context.TODO(), "Stage %s not found", stagename)
+}
+
+func UrlToPath(furl string, proc *process.Process) (path string, query string, err error) {
+
+	s, err := UrlToStageDef(furl, proc)
+	if err != nil {
+		return "", "", err
+	}
+
+	return s.ToPath()
+}
+
+func ParseStageUrl(u *url.URL) (stagename, prefix, query string, err error) {
+	if u.Scheme != STAGE_PROTOCOL {
+		return "", "", "", moerr.NewBadConfig(context.TODO(), "ParseStageUrl: URL protocol is not stage://")
+	}
+
+	stagename = u.Host
+	if len(stagename) == 0 {
+		return "", "", "", moerr.NewBadConfig(context.TODO(), "Invalid stage URL: stage name is empty string")
+	}
+
+	prefix = u.Path
+	query = u.RawQuery
+
+	return
+}
+
+func ParseS3Url(u *url.URL) (bucket, fpath, query string, err error) {
+	bucket = u.Host
+	fpath = u.Path
+	query = u.RawQuery
+	err = nil
+
+	if len(bucket) == 0 {
+		err = moerr.NewBadConfig(context.TODO(), "Invalid s3 URL: bucket is empty string")
+		return "", "", "", err
+	}
+
+	return
+}
+
+func UrlToStageDef(furl string, proc *process.Process) (s StageDef, err error) {
+
+	aurl, err := url.Parse(furl)
+	if err != nil {
+		return StageDef{}, err
+	}
+
+	if aurl.Scheme != STAGE_PROTOCOL {
+		return StageDef{}, moerr.NewBadConfig(context.TODO(), "URL is not stage URL")
+	}
+
+	stagename, subpath, query, err := ParseStageUrl(aurl)
+	if err != nil {
+		return StageDef{}, err
+	}
+
+	sdef, err := StageLoadCatalog(proc, stagename)
+	if err != nil {
+		return StageDef{}, err
+	}
+
+	s, err = sdef.expandSubStage(proc)
+	if err != nil {
+		return StageDef{}, err
+	}
+
+	s.Url = s.Url.JoinPath(subpath)
+	s.Url.RawQuery = query
+
+	return s, nil
+}

--- a/pkg/sql/plan/function/stage_util.go
+++ b/pkg/sql/plan/function/stage_util.go
@@ -412,7 +412,6 @@ func stageListWithoutWildcard(service string, pattern string, proc *process.Proc
 
 func StageListWithPattern(service string, pattern string, proc *process.Process) (fileList []string, err error) {
 	const wildcards = "*?"
-	const sep = "/"
 
 	idx := strings.IndexAny(pattern, wildcards)
 	if idx == -1 {

--- a/pkg/sql/plan/function/stage_util.go
+++ b/pkg/sql/plan/function/stage_util.go
@@ -172,7 +172,7 @@ func runSql(proc *process.Process, sql string) (executor.Result, error) {
 		WithDatabase(proc.GetSessionInfo().Database).
 		WithTimeZone(proc.GetSessionInfo().TimeZone).
 		WithAccountID(proc.GetSessionInfo().AccountId)
-	return exec.Exec(proc.Ctx, sql, opts)
+	return exec.Exec(proc.GetTopContext(), sql, opts)
 }
 
 func credentialsToMap(cred string) (map[string]string, error) {

--- a/pkg/sql/plan/function/stage_util.go
+++ b/pkg/sql/plan/function/stage_util.go
@@ -205,6 +205,7 @@ func StageLoadCatalog(proc *process.Process, stagename string) (s StageDef, err 
 	}
 	defer res.Close()
 
+	var reslist []StageDef
 	const id_idx = 0
 	const name_idx = 1
 	const url_idx = 2
@@ -230,13 +231,17 @@ func StageLoadCatalog(proc *process.Process, stagename string) (s StageDef, err 
 					stage_status := string(batch.Vecs[status_idx].GetBytesAt(i))
 
 					//logutil.Infof("CATALOG: ID %d,  stage %s url %s cred %s", stage_id, stage_name, stage_url, stage_cred)
-					return StageDef{stage_id, stage_name, stage_url, credmap, stage_status}, nil
+					reslist = append(reslist, StageDef{stage_id, stage_name, stage_url, credmap, stage_status})
 				}
 			}
 		}
 	}
 
-	return StageDef{}, moerr.NewBadConfig(context.TODO(), "Stage %s not found", stagename)
+	if reslist == nil {
+		return StageDef{}, moerr.NewBadConfig(context.TODO(), "Stage %s not found", stagename)
+	}
+
+	return reslist[0], nil
 }
 
 func UrlToPath(furl string, proc *process.Process) (path string, query string, err error) {

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1524,7 +1524,7 @@ func InitStageS3Param(param *tree.ExternParam, s function.StageDef) error {
 	}
 
 	// optional
-	param.S3Param.Provider, found = s.GetCredentials(function.PARAMKEY_PROVIDER, function.S3_PROVIDER_AMAZON)
+	param.S3Param.Provider, _ = s.GetCredentials(function.PARAMKEY_PROVIDER, function.S3_PROVIDER_AMAZON)
 	param.CompressType, _ = s.GetCredentials(function.PARAMKEY_COMPRESSION, "auto")
 
 	

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1512,7 +1512,6 @@ func InitStageS3Param(param *tree.ExternParam, s function.StageDef) error {
 		return moerr.NewBadConfig(param.Ctx, "Credentials %s not found", function.PARAMKEY_AWS_SECRET_KEY)
 	}
 
-
 	param.S3Param.Region, found = s.GetCredentials(function.PARAMKEY_AWS_REGION, "")
 	if !found {
 		return moerr.NewBadConfig(param.Ctx, "Credentials %s not found", function.PARAMKEY_AWS_REGION)
@@ -1527,7 +1526,6 @@ func InitStageS3Param(param *tree.ExternParam, s function.StageDef) error {
 	param.S3Param.Provider, _ = s.GetCredentials(function.PARAMKEY_PROVIDER, function.S3_PROVIDER_AMAZON)
 	param.CompressType, _ = s.GetCredentials(function.PARAMKEY_COMPRESSION, "auto")
 
-	
 	for i := 0; i < len(param.Option); i += 2 {
 		switch strings.ToLower(param.Option[i]) {
 		case "format":

--- a/test/distributed/cases/load_data/load_data_parquet.result
+++ b/test/distributed/cases/load_data/load_data_parquet.result
@@ -42,4 +42,18 @@ xyzABCxyzABCxyzABCxyzABCxyzABCxyzABCxyzABCxyzABCxyzABCxyzABC
 null
 null
 xyzABCxyzABCxyzABCxyzABCxyzABCxyzABCxyzABCxyzABCxyzABCxyzABC
+create table t4(id bigint not null, name varchar not null, sex bool, f32 float(5,2));
+create stage parqstage URL='file:///$resources/load_data/';
+load data infile {'filepath'='stage://parqstage/simple2.parq', 'format'='parquet'} into table t4;
+select * from t4;
+id    name    sex    f32
+1    user1    false    1.0
+2    user2    false    null
+7    user7    false    7.0
+8    user8    true    null
+10    user10    false    10.0
+12    user12    false    null
+15    user15    false    null
+16    user16    true    null
+drop stage parqstage;
 drop database parq;

--- a/test/distributed/cases/load_data/load_data_parquet.sql
+++ b/test/distributed/cases/load_data/load_data_parquet.sql
@@ -16,5 +16,12 @@ create table t3(c varchar);
 load data infile {'filepath'='$resources/load_data/indexed_str.parq', 'format'='parquet'} into table t3;
 select * from t3;
 
+
+create table t4(id bigint not null, name varchar not null, sex bool, f32 float(5,2));
+create stage parqstage URL='file:///$resources/load_data/';
+load data infile {'filepath'='stage://parqstage/simple2.parq', 'format'='parquet'} into table t4;
+select * from t4;
+drop stage parqstage;
+
 -- post
 drop database parq;

--- a/test/distributed/cases/snapshot/cluster/restore_cluster_table.result
+++ b/test/distributed/cases/snapshot/cluster/restore_cluster_table.result
@@ -222,8 +222,8 @@ id    val
 3    c
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-10 07:43:56    2024-07-10 07:43:56    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-10 07:43:56    2024-07-10 07:43:56    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:26    2024-08-07 09:44:26    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:26    2024-08-07 09:44:26    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop database if exists udf_db2;
 create database udf_db2;
 use udf_db2;
@@ -232,15 +232,15 @@ language sql as
 '$1 + $2';
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-07-10 07:43:56    2024-07-10 07:43:56    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:44:26    2024-08-07 09:44:26    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop stage if exists my_ext_stage;
 create stage my_ext_stage URL='s3://load/files/';
 drop stage if exists my_ext_stage1;
 create stage my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-1    my_ext_stage    s3://load/files/        disabled    2024-07-10 07:43:56
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-07-10 07:43:56
+1    my_ext_stage    s3://load/files/        disabled    2024-08-07 09:44:26    
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:44:26    
 drop database if exists test01;
 drop database if exists test02;
 drop database if exists test03;
@@ -376,7 +376,7 @@ drop snapshot if exists cluster_level_snapshot;
 create snapshot cluster_level_snapshot for cluster;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-cluster_level_snapshot    2024-07-10 07:43:56.503236    cluster
+cluster_level_snapshot    2024-08-07 09:44:26.651225093    cluster            
 use db02;
 alter table departments add column newcolumn int after department_id;
 show create table departments;
@@ -447,14 +447,14 @@ drop function udf_db2.`addAB`(x int, y int);
 drop stage if exists my_ext_stage;
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-07-10 07:43:56
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:44:26    
 use udf_db2;
 create function `add`(x int, y int) returns int
 language sql as
 '$1 + $2';
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-2    add    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-07-10 07:43:56    2024-07-10 07:43:56    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    add    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:44:26    2024-08-07 09:44:26    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop database test01;
 use test02;
 select * from v01;
@@ -543,15 +543,15 @@ select * from repub01.pri01;
 invalid database repub01
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-10 07:43:56    2024-07-10 07:43:56    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-10 07:43:56    2024-07-10 07:43:56    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:26    2024-08-07 09:44:26    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:26    2024-08-07 09:44:26    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-1    my_ext_stage    s3://load/files/        disabled    2024-07-10 07:43:56
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-07-10 07:43:56
+1    my_ext_stage    s3://load/files/        disabled    2024-08-07 09:44:26    
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:44:26    
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-07-10 07:43:56    2024-07-10 07:43:56    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:44:26    2024-08-07 09:44:26    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 use test02;
 select * from v01;
 id    sale_date    amount
@@ -580,8 +580,8 @@ drop database test;
 drop database repub02;
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-10 07:43:56    2024-07-10 07:43:56    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-10 07:43:56    2024-07-10 07:43:56    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:26    2024-08-07 09:44:26    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:26    2024-08-07 09:44:26    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop database if exists udf_db2;
 drop function `addab`(x int, y int);
 function addab doesn't exist
@@ -611,7 +611,7 @@ drop snapshot if exists cluster_level_snapshot;
 create snapshot cluster_level_snapshot for cluster;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-cluster_level_snapshot    2024-07-10 07:43:58.801459    cluster
+cluster_level_snapshot    2024-08-07 09:44:29.17621458    cluster            
 use mo_catalog;
 drop table if exists t2;
 create cluster table t2(a int);
@@ -636,7 +636,7 @@ drop snapshot if exists cluster_level_snapshot;
 create snapshot cluster_level_snapshot for cluster;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-cluster_level_snapshot    2024-07-10 07:43:58.991963    cluster
+cluster_level_snapshot    2024-08-07 09:44:29.441979616    cluster            
 use mo_catalog;
 drop table if exists t2;
 create cluster table t2(a int);
@@ -661,7 +661,7 @@ drop snapshot if exists account_level_snapshot;
 create snapshot account_level_snapshot for account sys;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-account_level_snapshot    2024-07-10 07:43:59.180327    account    sys
+account_level_snapshot    2024-08-07 09:44:29.684132745    account    sys        
 use mo_catalog;
 drop table if exists t2;
 create cluster table t2(a int);

--- a/test/distributed/cases/snapshot/cluster_level_snapshot_restore_system_table_to_nonsys.result
+++ b/test/distributed/cases/snapshot/cluster_level_snapshot_restore_system_table_to_nonsys.result
@@ -19,7 +19,7 @@ drop snapshot if exists udf_dsp01;
 create snapshot udf_dsp01 for cluster;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp01    2024-07-08 06:05:23.891903    cluster
+udf_dsp01    2024-08-07 09:44:50.078186946    cluster            
 create function`concatenate`(str1 varchar(255), str2 varchar(255)) returns varchar(255)
 language sql as
 '$1 + $2';
@@ -30,8 +30,8 @@ drop snapshot if exists udf_dsp02;
 create snapshot udf_dsp02 for cluster;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp02    2024-07-08 06:05:23.970954    cluster
-udf_dsp01    2024-07-08 06:05:23.891903    cluster
+udf_dsp02    2024-08-07 09:44:50.093737665    cluster            
+udf_dsp01    2024-08-07 09:44:50.078186946    cluster            
 drop database if exists udf_db2;
 create database udf_db2;
 use udf_db2;
@@ -50,27 +50,27 @@ drop snapshot if exists udf_dsp03;
 create snapshot udf_dsp03 for cluster;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp03    2024-07-08 06:05:24.097444    cluster
-udf_dsp02    2024-07-08 06:05:23.970954    cluster
-udf_dsp01    2024-07-08 06:05:23.891903    cluster
+udf_dsp03    2024-08-07 09:44:50.125425407    cluster            
+udf_dsp02    2024-08-07 09:44:50.093737665    cluster            
+udf_dsp01    2024-08-07 09:44:50.078186946    cluster            
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-07-08 06:05:23    2024-07-08 06:05:23    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-07-08 06:05:23    2024-07-08 06:05:23    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-07-08 06:05:24    2024-07-08 06:05:24    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:44:50    2024-08-07 09:44:50    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:44:50    2024-08-07 09:44:50    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-08-07 09:44:50    2024-08-07 09:44:50    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop function subab(x int,y int);
 drop function udf_db.concatenate(str1 varchar(255), str2 varchar(255));
 restore account acc01 from snapshot udf_dsp03;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-07-08 06:05:23    2024-07-08 06:05:23    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-07-08 06:05:23    2024-07-08 06:05:23    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-07-08 06:05:24    2024-07-08 06:05:24    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:44:50    2024-08-07 09:44:50    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:44:50    2024-08-07 09:44:50    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-08-07 09:44:50    2024-08-07 09:44:50    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 restore account acc01 from snapshot udf_dsp02;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-07-08 06:05:23    2024-07-08 06:05:23    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-07-08 06:05:23    2024-07-08 06:05:23    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:44:50    2024-08-07 09:44:50    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:44:50    2024-08-07 09:44:50    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop database udf_db;
 drop snapshot udf_dsp01;
 drop snapshot udf_dsp02;
@@ -83,7 +83,7 @@ language sql as
 '$1 + $2';
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-07-08 06:05:25    2024-07-08 06:05:25    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:44:50    2024-08-07 09:44:50    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists udf_sp04;
 create snapshot udf_sp04 for cluster;
 drop database udf_db2;
@@ -92,7 +92,7 @@ function_id    name    owner    args    rettype    body    language    db    def
 restore account acc01 from snapshot udf_sp04;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-07-08 06:05:25    2024-07-08 06:05:25    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:44:50    2024-08-07 09:44:50    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop database udf_db2;
 drop snapshot udf_sp04;
 drop database if exists procedure_test;
@@ -123,8 +123,8 @@ id    val
 3    c
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-08 06:05:26    2024-07-08 06:05:26    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-08 06:05:26    2024-07-08 06:05:26    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:51    2024-08-07 09:44:51    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:51    2024-08-07 09:44:51    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists sp_sp05;
 create snapshot sp_sp05 for cluster;
 drop procedure test_if_hit_elseif_first_elseif;
@@ -132,8 +132,8 @@ drop procedure test_if_hit_if;
 restore account acc01 from snapshot sp_sp05;
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-08 06:05:26    2024-07-08 06:05:26    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-08 06:05:26    2024-07-08 06:05:26    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:51    2024-08-07 09:44:51    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:51    2024-08-07 09:44:51    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 call test_if_hit_elseif_first_elseif();
 id    val
 1    a
@@ -174,8 +174,8 @@ id    val
 3    3.5
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-08 06:05:27    2024-07-08 06:05:27    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-08 06:05:27    2024-07-08 06:05:27    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:51    2024-08-07 09:44:51    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:51    2024-08-07 09:44:51    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists sp_sp06;
 create snapshot sp_sp06 for cluster;
 drop table tbh1;
@@ -183,7 +183,7 @@ drop table tbh2;
 drop procedure test_if_hit_second_elseif;
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-08 06:05:27    2024-07-08 06:05:27    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:51    2024-08-07 09:44:51    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 restore account acc01 from snapshot sp_sp06;
 call test_if_hit_else();
 id    val
@@ -195,8 +195,8 @@ id    val
 1    a
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-08 06:05:27    2024-07-08 06:05:27    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-07-08 06:05:27    2024-07-08 06:05:27    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:51    2024-08-07 09:44:51    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:44:51    2024-08-07 09:44:51    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop procedure test_if_hit_second_elseif;
 drop procedure test_if_hit_else;
 drop snapshot sp_sp06;
@@ -206,20 +206,20 @@ drop stage if exists my_ext_stage1;
 create stage my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-1    my_ext_stage    s3://load/files/        disabled    2024-07-08 06:05:27
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-07-08 06:05:27
+1    my_ext_stage    s3://load/files/        disabled    2024-08-07 09:44:51    
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:44:51    
 drop snapshot if exists stage_sp01;
 create snapshot stage_sp01 for cluster;
 alter stage my_ext_stage1 SET URL='s3://load/files2/';
 drop stage my_ext_stage;
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-2    my_ext_stage1    s3://load/files2/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-07-08 06:05:27
+2    my_ext_stage1    s3://load/files2/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:44:51    
 restore account acc01 from snapshot stage_sp01;
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-1    my_ext_stage    s3://load/files/        disabled    2024-07-08 06:05:27
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-07-08 06:05:27
+1    my_ext_stage    s3://load/files/        disabled    2024-08-07 09:44:51    
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:44:51    
 drop stage my_ext_stage;
 drop stage my_ext_stage1;
 drop snapshot stage_sp01;

--- a/test/distributed/cases/snapshot/nonsys_restore_system_table_to_nonsys_account.result
+++ b/test/distributed/cases/snapshot/nonsys_restore_system_table_to_nonsys_account.result
@@ -19,7 +19,7 @@ drop snapshot if exists udf_dsp01;
 create snapshot udf_dsp01 for account acc01;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp01    2024-05-31 03:26:32.785853    account    acc01        
+udf_dsp01    2024-08-07 09:45:13.242581157    account    acc01        
 create function`concatenate`(str1 varchar(255), str2 varchar(255)) returns varchar(255)
 language sql as
 '$1 + $2';
@@ -30,8 +30,8 @@ drop snapshot if exists udf_dsp02;
 create snapshot udf_dsp02 for account acc01;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp02    2024-05-31 03:26:32.842895    account    acc01        
-udf_dsp01    2024-05-31 03:26:32.785853    account    acc01        
+udf_dsp02    2024-08-07 09:45:13.279044466    account    acc01        
+udf_dsp01    2024-08-07 09:45:13.242581157    account    acc01        
 drop database if exists udf_db2;
 create database udf_db2;
 use udf_db2;
@@ -50,37 +50,37 @@ drop snapshot if exists udf_dsp03;
 create snapshot udf_dsp03 for account acc01;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp03    2024-05-31 03:26:32.993994    account    acc01        
-udf_dsp02    2024-05-31 03:26:32.842895    account    acc01        
-udf_dsp01    2024-05-31 03:26:32.785853    account    acc01        
+udf_dsp03    2024-08-07 09:45:13.313005033    account    acc01        
+udf_dsp02    2024-08-07 09:45:13.279044466    account    acc01        
+udf_dsp01    2024-08-07 09:45:13.242581157    account    acc01        
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-05-31 03:26:32    2024-05-31 03:26:32    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-05-31 03:26:32    2024-05-31 03:26:32    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-05-31 03:26:32    2024-05-31 03:26:32    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:13    2024-08-07 09:45:13    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:13    2024-08-07 09:45:13    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-08-07 09:45:13    2024-08-07 09:45:13    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop function subab(x int,y int);
 drop function udf_db.concatenate(str1 varchar(255), str2 varchar(255));
 restore account acc01 from snapshot udf_dsp03;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-05-31 03:26:32    2024-05-31 03:26:32    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-05-31 03:26:32    2024-05-31 03:26:32    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-05-31 03:26:32    2024-05-31 03:26:32    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:13    2024-08-07 09:45:13    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:13    2024-08-07 09:45:13    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-08-07 09:45:13    2024-08-07 09:45:13    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp03    2024-05-31 03:26:32.993994    account    acc01        
-udf_dsp02    2024-05-31 03:26:32.842895    account    acc01        
-udf_dsp01    2024-05-31 03:26:32.785853    account    acc01        
+udf_dsp03    2024-08-07 09:45:13.313005033    account    acc01        
+udf_dsp02    2024-08-07 09:45:13.279044466    account    acc01        
+udf_dsp01    2024-08-07 09:45:13.242581157    account    acc01        
 restore account acc01 from snapshot udf_dsp02;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-05-31 03:26:32    2024-05-31 03:26:32    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-05-31 03:26:32    2024-05-31 03:26:32    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:13    2024-08-07 09:45:13    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:13    2024-08-07 09:45:13    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp03    2024-05-31 03:26:32.993994    account    acc01        
-udf_dsp02    2024-05-31 03:26:32.842895    account    acc01        
-udf_dsp01    2024-05-31 03:26:32.785853    account    acc01        
+udf_dsp03    2024-08-07 09:45:13.313005033    account    acc01        
+udf_dsp02    2024-08-07 09:45:13.279044466    account    acc01        
+udf_dsp01    2024-08-07 09:45:13.242581157    account    acc01        
 drop snapshot udf_dsp01;
 drop snapshot udf_dsp02;
 drop snapshot udf_dsp03;
@@ -93,7 +93,7 @@ language sql as
 '$1 + $2';
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-05-31 03:26:34    2024-05-31 03:26:34    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:45:13    2024-08-07 09:45:13    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists udf_sp04;
 create snapshot udf_sp04 for account acc01;
 drop database udf_db2;
@@ -102,7 +102,7 @@ function_id    name    owner    args    rettype    body    language    db    def
 restore account acc01 from snapshot udf_sp04;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-05-31 03:26:34    2024-05-31 03:26:34    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:45:13    2024-08-07 09:45:13    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop database udf_db2;
 drop snapshot udf_sp04;
 drop database if exists procedure_test;
@@ -133,8 +133,8 @@ id    val
 3    c
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:26:35    2024-05-31 03:26:35    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:26:35    2024-05-31 03:26:35    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:14    2024-08-07 09:45:14    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:14    2024-08-07 09:45:14    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists sp_sp05;
 create snapshot sp_sp05 for account acc01;
 drop procedure test_if_hit_elseif_first_elseif;
@@ -144,8 +144,8 @@ proc_id    name    creator    args    body    db    definer    modified_time    
 restore account acc01 from snapshot sp_sp05;
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:26:35    2024-05-31 03:26:35    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:26:35    2024-05-31 03:26:35    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:14    2024-08-07 09:45:14    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:14    2024-08-07 09:45:14    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 call test_if_hit_elseif_first_elseif();
 id    val
 1    a
@@ -186,8 +186,8 @@ id    val
 3    3.5
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:26:36    2024-05-31 03:26:36    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:26:36    2024-05-31 03:26:36    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:14    2024-08-07 09:45:14    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:14    2024-08-07 09:45:14    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists sp_sp06;
 create snapshot sp_sp06 for account acc01;
 drop table tbh1;
@@ -195,7 +195,7 @@ drop table tbh2;
 drop procedure test_if_hit_second_elseif;
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:26:36    2024-05-31 03:26:36    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:14    2024-08-07 09:45:14    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 restore account acc01 from snapshot sp_sp06;
 call test_if_hit_else();
 id    val
@@ -207,8 +207,8 @@ id    val
 1    a
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:26:36    2024-05-31 03:26:36    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:26:36    2024-05-31 03:26:36    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:14    2024-08-07 09:45:14    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:14    2024-08-07 09:45:14    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot sp_sp06;
 drop procedure test_if_hit_second_elseif;
 drop procedure test_if_hit_else;
@@ -218,20 +218,20 @@ drop stage if exists my_ext_stage1;
 create stage my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-1    my_ext_stage    s3://load/files/        disabled    2024-05-31 03:26:37    
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-05-31 03:26:37    
+1    my_ext_stage    s3://load/files/        disabled    2024-08-07 09:45:14    
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:45:14    
 drop snapshot if exists stage_sp01;
 create snapshot stage_sp01 for account acc01;
 alter stage my_ext_stage1 SET URL='s3://load/files2/';
 drop stage my_ext_stage;
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-2    my_ext_stage1    s3://load/files2/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-05-31 03:26:37    
+2    my_ext_stage1    s3://load/files2/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:45:14    
 restore account acc01 from snapshot stage_sp01;
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-1    my_ext_stage    s3://load/files/        disabled    2024-05-31 03:26:37    
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-05-31 03:26:37    
+1    my_ext_stage    s3://load/files/        disabled    2024-08-07 09:45:14    
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:45:14    
 drop snapshot stage_sp01;
 drop stage my_ext_stage;
 drop stage my_ext_stage1;

--- a/test/distributed/cases/snapshot/sys_restore_system_table_to_newnonsys_account.result
+++ b/test/distributed/cases/snapshot/sys_restore_system_table_to_newnonsys_account.result
@@ -21,7 +21,7 @@ drop snapshot if exists udf_dsp01;
 create snapshot udf_dsp01 for account acc01;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp01    2024-05-31 03:15:09.421606    account    acc01        
+udf_dsp01    2024-08-07 09:45:39.337131935    account    acc01        
 create function`concatenate`(str1 varchar(255), str2 varchar(255)) returns varchar(255)
 language sql as
 '$1 + $2';
@@ -32,8 +32,8 @@ drop snapshot if exists udf_dsp02;
 create snapshot udf_dsp02 for account acc01;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp02    2024-05-31 03:15:09.487947    account    acc01        
-udf_dsp01    2024-05-31 03:15:09.421606    account    acc01        
+udf_dsp02    2024-08-07 09:45:39.384962231    account    acc01        
+udf_dsp01    2024-08-07 09:45:39.337131935    account    acc01        
 drop database if exists udf_db2;
 create database udf_db2;
 use udf_db2;
@@ -52,27 +52,27 @@ drop snapshot if exists udf_dsp03;
 create snapshot udf_dsp03 for account acc01;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp03    2024-05-31 03:15:09.68859    account    acc01        
-udf_dsp02    2024-05-31 03:15:09.487947    account    acc01        
-udf_dsp01    2024-05-31 03:15:09.421606    account    acc01        
+udf_dsp03    2024-08-07 09:45:40.101171489    account    acc01        
+udf_dsp02    2024-08-07 09:45:39.384962231    account    acc01        
+udf_dsp01    2024-08-07 09:45:39.337131935    account    acc01        
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-05-31 03:15:09    2024-05-31 03:15:09    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-05-31 03:15:09    2024-05-31 03:15:09    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-05-31 03:15:09    2024-05-31 03:15:09    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:39    2024-08-07 09:45:39    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:39    2024-08-07 09:45:39    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-08-07 09:45:40    2024-08-07 09:45:40    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop function subab(x int,y int);
 drop function udf_db.concatenate(str1 varchar(255), str2 varchar(255));
 restore account acc01 from snapshot udf_dsp03 to account acc02;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-05-31 03:15:09    2024-05-31 03:15:09    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-05-31 03:15:09    2024-05-31 03:15:09    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-05-31 03:15:09    2024-05-31 03:15:09    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:39    2024-08-07 09:45:39    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:39    2024-08-07 09:45:39    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-08-07 09:45:40    2024-08-07 09:45:40    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 restore account acc01 from snapshot udf_dsp02 to account acc02;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-05-31 03:15:09    2024-05-31 03:15:09    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-05-31 03:15:09    2024-05-31 03:15:09    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:39    2024-08-07 09:45:39    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:45:39    2024-08-07 09:45:39    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop database udf_db;
 drop snapshot udf_dsp01;
 drop snapshot udf_dsp02;
@@ -87,7 +87,7 @@ language sql as
 '$1 + $2';
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-4    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-05-31 03:15:10    2024-05-31 03:15:10    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:45:40    2024-08-07 09:45:40    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists udf_sp04;
 create snapshot udf_sp04 for account acc01;
 drop database udf_db2;
@@ -96,7 +96,7 @@ function_id    name    owner    args    rettype    body    language    db    def
 restore account acc01 from snapshot udf_sp04 to account acc02;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-4    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-05-31 03:15:10    2024-05-31 03:15:10    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:45:40    2024-08-07 09:45:40    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop database udf_db2;
 drop snapshot udf_sp04;
 drop database if exists procedure_test;
@@ -127,8 +127,8 @@ id    val
 3    c
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:15:11    2024-05-31 03:15:11    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:15:11    2024-05-31 03:15:11    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:40    2024-08-07 09:45:40    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:40    2024-08-07 09:45:40    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists sp_sp05;
 create snapshot sp_sp05 for account acc01;
 drop procedure test_if_hit_elseif_first_elseif;
@@ -136,8 +136,8 @@ drop procedure test_if_hit_if;
 restore account acc01 from snapshot sp_sp05 to account acc02;
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:15:11    2024-05-31 03:15:11    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:15:11    2024-05-31 03:15:11    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:40    2024-08-07 09:45:40    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:40    2024-08-07 09:45:40    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 call procedure_test.test_if_hit_elseif_first_elseif();
 id    val
 1    a
@@ -181,8 +181,8 @@ id    val
 3    3.5
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:15:12    2024-05-31 03:15:12    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:15:12    2024-05-31 03:15:12    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:41    2024-08-07 09:45:41    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:41    2024-08-07 09:45:41    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists sp_sp06;
 create snapshot sp_sp06 for account acc01;
 drop table tbh1;
@@ -190,7 +190,7 @@ drop table tbh2;
 drop procedure test_if_hit_second_elseif;
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:15:12    2024-05-31 03:15:12    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:41    2024-08-07 09:45:41    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 restore account acc01 from snapshot sp_sp06 to account acc02;
 call procedure_test.test_if_hit_else();
 id    val
@@ -202,8 +202,8 @@ id    val
 1    a
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:15:12    2024-05-31 03:15:12    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:15:12    2024-05-31 03:15:12    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:41    2024-08-07 09:45:41    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:45:41    2024-08-07 09:45:41    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop procedure procedure_test.test_if_hit_second_elseif;
 drop procedure procedure_test.test_if_hit_else;
 drop database procedure_test;
@@ -214,8 +214,8 @@ drop stage if exists my_ext_stage1;
 create stage my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-1    my_ext_stage    s3://load/files/        disabled    2024-05-31 03:15:13    
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-05-31 03:15:13    
+1    my_ext_stage    s3://load/files/        disabled    2024-08-07 09:45:41    
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:45:41    
 drop snapshot if exists stage_sp01;
 create snapshot stage_sp01 for account acc01;
 alter stage my_ext_stage1 SET URL='s3://load/files2/';
@@ -223,8 +223,8 @@ drop stage my_ext_stage;
 restore account acc01 from snapshot stage_sp01 to account acc02;
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-1    my_ext_stage    s3://load/files/        disabled    2024-05-31 03:15:13    
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-05-31 03:15:13    
+1    my_ext_stage    s3://load/files/        disabled    2024-08-07 09:45:41    
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:45:41    
 drop stage my_ext_stage;
 drop stage my_ext_stage1;
 drop snapshot stage_sp01;

--- a/test/distributed/cases/snapshot/sys_restore_system_table_to_nonsys_account.result
+++ b/test/distributed/cases/snapshot/sys_restore_system_table_to_nonsys_account.result
@@ -19,7 +19,7 @@ drop snapshot if exists udf_dsp01;
 create snapshot udf_dsp01 for account acc01;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp01    2024-05-31 03:17:51.505792    account    acc01        
+udf_dsp01    2024-08-07 09:46:00.17249539    account    acc01        
 create function`concatenate`(str1 varchar(255), str2 varchar(255)) returns varchar(255)
 language sql as
 '$1 + $2';
@@ -30,8 +30,8 @@ drop snapshot if exists udf_dsp02;
 create snapshot udf_dsp02 for account acc01;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp02    2024-05-31 03:17:51.605929    account    acc01        
-udf_dsp01    2024-05-31 03:17:51.505792    account    acc01        
+udf_dsp02    2024-08-07 09:46:00.188348149    account    acc01        
+udf_dsp01    2024-08-07 09:46:00.17249539    account    acc01        
 drop database if exists udf_db2;
 create database udf_db2;
 use udf_db2;
@@ -50,27 +50,27 @@ drop snapshot if exists udf_dsp03;
 create snapshot udf_dsp03 for account acc01;
 show snapshots;
 SNAPSHOT_NAME    TIMESTAMP    SNAPSHOT_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME
-udf_dsp03    2024-05-31 03:17:51.743983    account    acc01        
-udf_dsp02    2024-05-31 03:17:51.605929    account    acc01        
-udf_dsp01    2024-05-31 03:17:51.505792    account    acc01        
+udf_dsp03    2024-08-07 09:46:00.221115771    account    acc01        
+udf_dsp02    2024-08-07 09:46:00.188348149    account    acc01        
+udf_dsp01    2024-08-07 09:46:00.17249539    account    acc01        
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-05-31 03:17:51    2024-05-31 03:17:51    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-05-31 03:17:51    2024-05-31 03:17:51    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-05-31 03:17:51    2024-05-31 03:17:51    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop function subab(x int,y int);
 drop function udf_db.concatenate(str1 varchar(255), str2 varchar(255));
 restore account acc01 from snapshot udf_dsp03;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-05-31 03:17:51    2024-05-31 03:17:51    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-05-31 03:17:51    2024-05-31 03:17:51    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-05-31 03:17:51    2024-05-31 03:17:51    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    subab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 - $2    sql    udf_db2    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 restore account acc01 from snapshot udf_dsp02;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-05-31 03:17:51    2024-05-31 03:17:51    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-05-31 03:17:51    2024-05-31 03:17:51    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    concatenate    2    [{"name": "str1", "type": "varchar"}, {"name": "str2", "type": "varchar"}]    varchar    $1 + $2    sql    udf_db    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop database udf_db;
 drop snapshot udf_dsp01;
 drop snapshot udf_dsp02;
@@ -83,7 +83,7 @@ language sql as
 '$1 + $2';
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-05-31 03:17:52    2024-05-31 03:17:52    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists udf_sp04;
 create snapshot udf_sp04 for account acc01;
 drop database udf_db2;
@@ -92,7 +92,7 @@ function_id    name    owner    args    rettype    body    language    db    def
 restore account acc01 from snapshot udf_sp04;
 select * from mo_catalog.mo_user_defined_function;
 function_id    name    owner    args    rettype    body    language    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-05-31 03:17:52    2024-05-31 03:17:52    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    addab    2    [{"name": "x", "type": "int"}, {"name": "y", "type": "int"}]    int    $1 + $2    sql    udf_db2    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    FUNCTION    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop database udf_db2;
 drop snapshot udf_sp04;
 drop database if exists procedure_test;
@@ -123,8 +123,8 @@ id    val
 3    c
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:17:53    2024-05-31 03:17:53    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:17:53    2024-05-31 03:17:53    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists sp_sp05;
 create snapshot sp_sp05 for account acc01;
 drop procedure test_if_hit_elseif_first_elseif;
@@ -132,8 +132,8 @@ drop procedure test_if_hit_if;
 restore account acc01 from snapshot sp_sp05;
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:17:53    2024-05-31 03:17:53    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:17:53    2024-05-31 03:17:53    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+1    test_if_hit_elseif_first_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+2    test_if_hit_if    null    {}    begin DECLARE v1 INT; SET v1 = 5; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:46:00    2024-08-07 09:46:00    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 call test_if_hit_elseif_first_elseif();
 id    val
 1    a
@@ -174,8 +174,8 @@ id    val
 3    3.5
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:17:54    2024-05-31 03:17:54    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:17:54    2024-05-31 03:17:54    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:46:01    2024-08-07 09:46:01    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:46:01    2024-08-07 09:46:01    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop snapshot if exists sp_sp06;
 create snapshot sp_sp06 for account acc01;
 drop table tbh1;
@@ -183,7 +183,7 @@ drop table tbh2;
 drop procedure test_if_hit_second_elseif;
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:17:54    2024-05-31 03:17:54    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:46:01    2024-08-07 09:46:01    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 restore account acc01 from snapshot sp_sp06;
 call test_if_hit_else();
 id    val
@@ -195,8 +195,8 @@ id    val
 1    a
 select * from mo_catalog.mo_stored_procedure;
 proc_id    name    creator    args    body    db    definer    modified_time    created_time    type    security_type    comment    character_set_client    collation_connection    database_collation
-3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:17:54    2024-05-31 03:17:54    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
-4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-05-31 03:17:54    2024-05-31 03:17:54    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+3    test_if_hit_second_elseif    null    {}    begin DECLARE v1 INT; SET v1 = 4; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:46:01    2024-08-07 09:46:01    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
+4    test_if_hit_else    null    {}    begin DECLARE v1 INT; SET v1 = 3; IF v1 > 5 THEN select * from tbh1; ELSEIF v1 = 5 THEN select * from tbh2; ELSEIF v1 = 4 THEN select * from tbh2 limit 1; ELSE select * from tbh3; END IF; end    procedure_test    test_account    2024-08-07 09:46:01    2024-08-07 09:46:01    PROCEDURE    DEFINER        utf8mb4    utf8mb4_0900_ai_ci    utf8mb4_0900_ai_ci
 drop procedure test_if_hit_second_elseif;
 drop procedure test_if_hit_else;
 drop snapshot sp_sp06;
@@ -206,20 +206,20 @@ drop stage if exists my_ext_stage1;
 create stage my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-1    my_ext_stage    s3://load/files/        disabled    2024-05-31 03:17:55    
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-05-31 03:17:55    
+1    my_ext_stage    s3://load/files/        disabled    2024-08-07 09:46:01    
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:46:01    
 drop snapshot if exists stage_sp01;
 create snapshot stage_sp01 for account acc01;
 alter stage my_ext_stage1 SET URL='s3://load/files2/';
 drop stage my_ext_stage;
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-2    my_ext_stage1    s3://load/files2/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-05-31 03:17:55    
+2    my_ext_stage1    s3://load/files2/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:46:01    
 restore account acc01 from snapshot stage_sp01;
 select * from mo_catalog.mo_stages;
 stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
-1    my_ext_stage    s3://load/files/        disabled    2024-05-31 03:17:55    
-2    my_ext_stage1    s3://load/files/    *0E0591E0E0FC0806815D04D93FD4BD3F5ADB39AD    disabled    2024-05-31 03:17:55    
+1    my_ext_stage    s3://load/files/        disabled    2024-08-07 09:46:01    
+2    my_ext_stage1    s3://load/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z    disabled    2024-08-07 09:46:01    
 drop stage my_ext_stage;
 drop stage my_ext_stage1;
 drop snapshot stage_sp01;

--- a/test/distributed/cases/stage/stage.result
+++ b/test/distributed/cases/stage/stage.result
@@ -1,30 +1,40 @@
-CREATE STAGE my_ext_stage URL='s3://load/files/';
-CREATE STAGE my_ext_stage URL='s3://load/files/';
+CREATE STAGE invalid_path_stage URL='/path/to';
+invalid configuration: URL protocol only supports stage://, s3:// and file:///
+CREATE STAGE invalid_unknown_protocol_stage URL='minio:///path/to';
+invalid configuration: URL protocol only supports stage://, s3:// and file:///
+CREATE STAGE my_ext_stage URL='s3://bucket/files/';
+CREATE STAGE my_sub_stage URL='stage://my_ext_stage/a/b/c/';
+CREATE STAGE my_ext_stage URL='s3://bucket/files/';
 internal error: the stage my_ext_stage exists
-CREATE STAGE if not exists my_ext_stage URL='s3://load/files/';
-SELECT stage_name from mo_catalog.mo_stages;
-stage_name
-my_ext_stage
-CREATE STAGE my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
-CREATE STAGE my_ext_stage2 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
-SELECT stage_name, stage_status from mo_catalog.mo_stages;
-stage_name    stage_status
-my_ext_stage    disabled
-my_ext_stage1    disabled
-my_ext_stage2    disabled
-CREATE STAGE my_ext_stage3 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'} ENABLE = TRUE;
-SELECT stage_name, stage_status from mo_catalog.mo_stages;
-stage_name    stage_status
-my_ext_stage    disabled
-my_ext_stage1    disabled
-my_ext_stage2    disabled
-my_ext_stage3    enabled
-ALTER STAGE my_ext_stage4 SET URL='s3://load/files2/';
+ALTER STAGE my_ext_stage SET URL='abc';
+invalid configuration: URL protocol only supports stage://, s3:// and file:///
+CREATE STAGE if not exists my_ext_stage URL='s3://bucket/files/';
+SELECT stage_name, url from mo_catalog.mo_stages;
+stage_name    url
+my_ext_stage    s3://bucket/files/
+my_sub_stage    stage://my_ext_stage/a/b/c/
+CREATE STAGE my_ext_stage1 URL='s3://bucket1/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
+CREATE STAGE my_ext_stage2 URL='s3://bucket2/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
+SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
+stage_name    url    stage_credentials
+my_ext_stage    s3://bucket/files/    
+my_sub_stage    stage://my_ext_stage/a/b/c/    
+my_ext_stage1    s3://bucket1/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
+my_ext_stage2    s3://bucket2/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
+CREATE STAGE my_ext_stage3 URL='s3://bucket3/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
+SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
+stage_name    url    stage_credentials
+my_ext_stage    s3://bucket/files/    
+my_sub_stage    stage://my_ext_stage/a/b/c/    
+my_ext_stage1    s3://bucket1/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
+my_ext_stage2    s3://bucket2/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
+my_ext_stage3    s3://bucket3/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
+ALTER STAGE my_ext_stage4 SET URL='s3://bucket4/files2/';
 internal error: the stage my_ext_stage4 not exists
-ALTER STAGE if exists my_ext_stage4 SET URL='s3://load/files2/';
-ALTER STAGE my_ext_stage1 SET URL='s3://load/files2/' CREDENTIALS={'AWS_KEY_ID'='1a2b3d' ,'AWS_SECRET_KEY'='4x5y6z'};
+ALTER STAGE if exists my_ext_stage4 SET URL='s3://bucket4/files2/';
+ALTER STAGE my_ext_stage1 SET URL='s3://bucket2/files2/' CREDENTIALS={'AWS_KEY_ID'='1a2b3d' ,'AWS_SECRET_KEY'='4x5y6z'};
 internal error: at most one option at a time
-ALTER STAGE my_ext_stage1 SET URL='s3://load/files2/';
+ALTER STAGE my_ext_stage1 SET URL='s3://bucket2/files2/';
 ALTER STAGE my_ext_stage1 SET CREDENTIALS={'AWS_KEY_ID'='1a2b3d' ,'AWS_SECRET_KEY'='4x5y6z'};
 DROP STAGE my_ext_stage5;
 internal error: the stage my_ext_stage5 not exists
@@ -33,47 +43,48 @@ DROP STAGE my_ext_stage;
 DROP STAGE my_ext_stage1;
 DROP STAGE my_ext_stage2;
 DROP STAGE my_ext_stage3;
-CREATE STAGE my_ext_stage URL='s3://load/files/';
-SELECT stage_name from mo_catalog.mo_stages;
-stage_name
-my_ext_stage
+DROP STAGE my_sub_stage;
+CREATE STAGE my_ext_stage URL='s3://bucket/files/';
+SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
+stage_name    url    stage_credentials
+my_ext_stage    s3://bucket/files/    
 create account default_1 ADMIN_NAME admin IDENTIFIED BY '111111';
-CREATE STAGE my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
-CREATE STAGE my_ext_stage2 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
-SELECT stage_name, stage_status from mo_catalog.mo_stages;
-stage_name    stage_status
-my_ext_stage1    disabled
-my_ext_stage2    disabled
+CREATE STAGE my_ext_stage1 URL='s3://bucket1/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
+CREATE STAGE my_ext_stage2 URL='s3://bucket2/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
+SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
+stage_name    url    stage_credentials
+my_ext_stage1    s3://bucket1/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
+my_ext_stage2    s3://bucket2/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
 DROP STAGE my_ext_stage1;
 DROP STAGE my_ext_stage2;
 drop account default_1;
 drop stage my_ext_stage;
-CREATE STAGE my_ext_stage URL='s3://load/files/';
-CREATE STAGE my_ext_stage URL='s3://load/files/';
+CREATE STAGE my_ext_stage URL='s3://bucket/files/';
+CREATE STAGE my_ext_stage URL='s3://bucket/files/';
 internal error: the stage my_ext_stage exists
-CREATE STAGE if not exists my_ext_stage URL='s3://load/files/';
+CREATE STAGE if not exists my_ext_stage URL='s3://bucket/files/';
 SHOW STAGES;
 STAGE_NAME    URL    STATUS    COMMENT
-my_ext_stage    s3://load/files/    DISABLED
-CREATE STAGE my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
-CREATE STAGE my_ext_stage2 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
+my_ext_stage    s3://bucket/files/    DISABLED    
+CREATE STAGE my_ext_stage1 URL='s3://bucket/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
+CREATE STAGE my_ext_stage2 URL='s3://bucket/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
 SHOW STAGES;
 STAGE_NAME    URL    STATUS    COMMENT
-my_ext_stage    s3://load/files/    DISABLED
-my_ext_stage1    s3://load/files/    DISABLED
-my_ext_stage2    s3://load/files/    DISABLED
-CREATE STAGE my_ext_stage3 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'} ENABLE = TRUE;
-CREATE STAGE my_ext_stage4 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'} ENABLE = TRUE COMMENT = 'self stage';
+my_ext_stage    s3://bucket/files/    DISABLED    
+my_ext_stage1    s3://bucket/files/    DISABLED    
+my_ext_stage2    s3://bucket/files/    DISABLED    
+CREATE STAGE my_ext_stage3 URL='s3://bucket/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
+CREATE STAGE my_ext_stage4 URL='s3://bucket/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'} COMMENT = 'self stage';
 SHOW STAGES;
 STAGE_NAME    URL    STATUS    COMMENT
-my_ext_stage    s3://load/files/    DISABLED
-my_ext_stage1    s3://load/files/    DISABLED
-my_ext_stage2    s3://load/files/    DISABLED
-my_ext_stage3    s3://load/files/    ENABLED
-my_ext_stage4    s3://load/files/    ENABLED    self stage
+my_ext_stage    s3://bucket/files/    DISABLED    
+my_ext_stage1    s3://bucket/files/    DISABLED    
+my_ext_stage2    s3://bucket/files/    DISABLED    
+my_ext_stage3    s3://bucket/files/    DISABLED    
+my_ext_stage4    s3://bucket/files/    DISABLED    self stage
 SHOW STAGES like 'my_ext_stage3';
 STAGE_NAME    URL    STATUS    COMMENT
-my_ext_stage3    s3://load/files/    ENABLED
+my_ext_stage3    s3://bucket/files/    DISABLED    
 ALTER STAGE my_ext_stage5 SET URL='s3://load/files2/';
 internal error: the stage my_ext_stage5 not exists
 ALTER STAGE if exists my_ext_stage5 SET URL='s3://load/files2/';
@@ -84,14 +95,14 @@ ALTER STAGE my_ext_stage1 SET CREDENTIALS={'AWS_KEY_ID'='1a2b3d' ,'AWS_SECRET_KE
 ALTER STAGE my_ext_stage4 SET COMMENT = 'user stage';
 SHOW STAGES;
 STAGE_NAME    URL    STATUS    COMMENT
-my_ext_stage    s3://load/files/    DISABLED
-my_ext_stage2    s3://load/files/    DISABLED
-my_ext_stage3    s3://load/files/    ENABLED
-my_ext_stage1    s3://load/files2/    DISABLED
-my_ext_stage4    s3://load/files/    ENABLED    user stage
+my_ext_stage    s3://bucket/files/    DISABLED    
+my_ext_stage2    s3://bucket/files/    DISABLED    
+my_ext_stage3    s3://bucket/files/    DISABLED    
+my_ext_stage1    s3://load/files2/    DISABLED    
+my_ext_stage4    s3://bucket/files/    DISABLED    user stage
 SHOW STAGES like 'my_ext_stage1';
 STAGE_NAME    URL    STATUS    COMMENT
-my_ext_stage1    s3://load/files2/    DISABLED
+my_ext_stage1    s3://load/files2/    DISABLED    
 DROP STAGE my_ext_stage5;
 internal error: the stage my_ext_stage5 not exists
 DROP STAGE if exists my_ext_stage5;
@@ -102,26 +113,26 @@ DROP STAGE my_ext_stage3;
 DROP STAGE my_ext_stage4;
 drop stage if exists aws_stage;
 drop stage if exists local_stage;
-create stage aws_stage URL= 's3.us-east-2.amazonaws.com' CREDENTIALS={ 'access_key_id' = 'AKIAYOFAMAB', 'secret_access_key' = '7OtGNgIwlkBVwyL9rV', 'bucket' = 'hn-test2', 'region' = 'us-east-2', 'compression' = 'none'};
+create stage aws_stage URL= 's3://hn-test2/a/b/c' CREDENTIALS={ 'AWS_KEY_ID' = 'AKIAYOFAMAB', 'AWS_SECRET_KEY' = '7OtGNgIwlkBVwyL9rV', 'AWS_REGION' = 'us-east-2', 'provider'='minio', 'compression' = 'none'};
 show stages;
 STAGE_NAME    URL    STATUS    COMMENT
-aws_stage    s3.us-east-2.amazonaws.com    DISABLED
+aws_stage    s3://hn-test2/a/b/c    DISABLED    
 alter stage aws_stage set enable=TRUE;
 show stages;
 STAGE_NAME    URL    STATUS    COMMENT
-aws_stage    s3.us-east-2.amazonaws.com    ENABLED
-alter stage if exists aws_stage set URL= 's3.us-east-1.amazonaws.com';
+aws_stage    s3://hn-test2/a/b/c    ENABLED    
+alter stage if exists aws_stage set URL= 's3://bucket2/d/e/f/';
 show stages;
 STAGE_NAME    URL    STATUS    COMMENT
-aws_stage    s3.us-east-1.amazonaws.com    ENABLED
-alter stage if exists aws_stage set CREDENTIALS={ 'bucket' = 'hn-test2', 'region' = 'us-east-1'};
+aws_stage    s3://bucket2/d/e/f/    ENABLED    
+alter stage if exists aws_stage set CREDENTIALS={ 'AWS_REGION' = 'us-east-1'};
 select stage_name,url,stage_credentials,stage_status,comment from mo_catalog.mo_stages;
 stage_name    url    stage_credentials    stage_status    comment
-aws_stage    s3.us-east-1.amazonaws.com    *7EF9F8E04FF86741707B29BD325543FA2168F6D5    enabled
+aws_stage    s3://bucket2/d/e/f/    AWS_REGION=us-east-1    enabled    
 alter stage aws_stage set comment='comment1';
 show stages;
 STAGE_NAME    URL    STATUS    COMMENT
-aws_stage    s3.us-east-1.amazonaws.com    ENABLED    comment1
+aws_stage    s3://bucket2/d/e/f/    ENABLED    comment1
 drop stage aws_stage;
 CREATE TABLE stage_table(
 R_REGIONKEY  INTEGER NOT NULL,
@@ -135,29 +146,28 @@ insert into stage_table values
 (2,"ASIA","ges. thinly even pinto beans ca"),
 (3,"EUROPE","ly final courts cajole furiously final excuse"),
 (4,"MIDDLE EAST","uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl");
-create stage local_stage URL= '$resources/into_outfile' ENABLE=TRUE comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 stage_name    stage_status    comment
-local_stage    enabled    local stage configure
-select * from stage_table into outfile 'local_stage:/stage_table.csv';
+local_stage    disabled    local stage configure
+select * from stage_table into outfile 'stage://local_stage/stage_table.csv';
 drop stage local_stage;
 show stages;
 STAGE_NAME    URL    STATUS    COMMENT
-create stage local_stage URL= '$resources/into_outfile' ENABLE=FALSE;
-select * from stage_table into outfile 'local_stage:/stage_table.csv';
-internal error: stage 'local_stage' is invalid, please check
-select * from stage_table into outfile '$resources/into_outfile/stage_table00.csv';
-alter stage local_stage set ENABLE=TRUE;
-select * from stage_table into outfile '$resources/into_outfile/stage_table01.csv';
-internal error: stage exists, please try to check and use a stage instead
+create stage local_stage URL= 'file:///$resources/';
+create stage sub_local_stage URL= 'stage://local_stage/into_outfile/';
+select * from stage_table into outfile 'stage://sub_local_stage/stage_table.csv';
+open /home/ubuntu/p/matrixone/test/distributed/resources/into_outfile/stage_table.csv: file exists
 drop stage local_stage;
+drop stage sub_local_stage;
+select * from stage_table into outfile '$resources/into_outfile/stage_table00.csv';
+select * from stage_table into outfile '$resources/into_outfile/stage_table01.csv';
 select * from stage_table into outfile '$resources/into_outfile/stage_table02.csv';
-create stage local_stage URL= '$resources/into_outfile' ENABLE=FALSE;
-alter stage local_stage set ENABLE=TRUE;
-select stage_name,stage_status,comment from mo_catalog.mo_stages;
-stage_name    stage_status    comment
-local_stage    enabled
-select * from stage_table into outfile 'local_stage:/stage_table1.csv';
+create stage local_stage URL= 'file://$resources/into_outfile';
+select stage_name, url, comment from mo_catalog.mo_stages;
+stage_name    url    comment
+local_stage    file:///home/ubuntu/p/mo-tester/../matrixone/test/distributed/resources/into_outfile    
+select * from stage_table into outfile 'stage://local_stage/stage_table1.csv';
 truncate table stage_table;
 load data infile '$resources/into_outfile/stage_table1.csv' into table stage_table fields terminated by ',' ignore 1 lines;
 select r_name from stage_table;
@@ -167,11 +177,11 @@ AMERICA
 ASIA
 EUROPE
 MIDDLE EAST
-alter stage local_stage set URL= '$resources/into_outfile_2';
+alter stage local_stage set URL= 'file:///$resources/into_outfile_2';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 stage_name    stage_status    comment
-local_stage    enabled
-select * from stage_table into outfile 'local_stage:/stage_table2.csv';
+local_stage    disabled    
+select * from stage_table into outfile 'stage://local_stage/stage_table2.csv';
 truncate table stage_table;
 load data infile '$resources/into_outfile_2/stage_table2.csv' into table stage_table fields terminated by ',' ignore 1 lines;
 select r_name from stage_table;
@@ -184,29 +194,23 @@ MIDDLE EAST
 alter stage local_stage set comment = 'new comment';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 stage_name    stage_status    comment
-local_stage    enabled    new comment
-create stage local_stage URL= '$resources/into_outfile_2' ENABLE=FALSE;
-internal error: the stage local_stage exists
-alter stage local_stage set URL= '$resources/into_outfile_2' comment='alter comment';
-internal error: at most one option at a time
-drop stage local_stage;
+local_stage    disabled    new comment
 drop stage if exists local_stage;
-create stage local_stage URL= '$resources/into_outfile' ENABLE=TRUE comment='local stage configure';
-select * from stage_table into outfile 'local_stage:/stage_table3.csv';
+create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
+select * from stage_table into outfile 'stage://local_stage/stage_table3.csv';
 drop stage local_stage;
-create stage if not exists local_stage URL= '$resources/into_outfile' ENABLE=TRUE comment='local stage configure';
-create stage if not exists local_stage URL= '$resources/into_outfile2' ENABLE=FALSE;
+create stage if not exists local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
+create stage if not exists local_stage URL= 'file:///$resources/into_outfile2';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 stage_name    stage_status    comment
-local_stage    enabled    local stage configure
-alter stage if exists l_stage set ENABLE=TRUE;
+local_stage    disabled    local stage configure
 create user "stage_user" identified by '123456';
 create role s_role;
 grant all on table *.* to s_role;
 grant all on account * to s_role;
 grant all on database *.* to s_role;
 grant s_role to stage_user;
-create stage local_stage URL= '$resources/into_outfile' ENABLE=TRUE comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
 internal error: do not have privilege to execute the statement
 create database sdb;
 use sdb;
@@ -222,8 +226,6 @@ insert into stage_table values
 (2,"ASIA","ges. thinly even pinto beans ca"),
 (3,"EUROPE","ly final courts cajole furiously final excuse"),
 (4,"MIDDLE EAST","uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl");
-alter stage local_stage set ENABLE=FALSE;
-internal error: do not have privilege to execute the statement
 drop stage stage_user;
 internal error: do not have privilege to execute the statement
 drop database sdb;
@@ -231,7 +233,8 @@ drop user stage_user;
 drop role s_role;
 drop account if exists stage_account;
 create account `stage_account` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
-create stage local_stage URL= '$resources/into_outfile' ENABLE=TRUE comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/' comment='local stage configure';
+create stage sub_local_stage URL= 'stage://local_stage/into_outfile' comment='sub local stage configure';
 create database sdb;
 use sdb;
 CREATE TABLE stage_table(
@@ -248,9 +251,67 @@ insert into stage_table values
 (4,"MIDDLE EAST","uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl");
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 stage_name    stage_status    comment
-local_stage    enabled    local stage configure
-select * from stage_table into outfile 'local_stage:/stage_table5.csv';
+local_stage    disabled    local stage configure
+sub_local_stage    disabled    sub local stage configure
+select * from stage_table into outfile 'stage://sub_local_stage/stage_table5.csv';
+CREATE TABLE stage_infile_table(
+R_REGIONKEY  INTEGER NOT NULL,
+R_NAME       CHAR(25) NOT NULL,
+R_COMMENT    VARCHAR(152),
+PRIMARY KEY (R_REGIONKEY)
+);
+load data infile 'stage://sub_local_stage/stage_table5.csv' into table stage_infile_table fields terminated by ',' IGNORE 1 LINES;
+select * from stage_infile_table;
+r_regionkey    r_name    r_comment
+0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
+1    AMERICA    hs use ironic, even requests. s
+2    ASIA    ges. thinly even pinto beans ca
+3    EUROPE    ly final courts cajole furiously final excuse
+4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+CREATE EXTERNAL TABLE stage_ext_table(
+R_REGIONKEY  INTEGER NOT NULL,
+R_NAME       CHAR(25) NOT NULL,
+R_COMMENT    VARCHAR(152)
+) INFILE 'stage://sub_local_stage/stage_table*.csv' fields terminated by ',' IGNORE 1 LINES;
+select * from stage_ext_table;
+r_regionkey    r_name    r_comment
+0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
+1    AMERICA    hs use ironic, even requests. s
+2    ASIA    ges. thinly even pinto beans ca
+3    EUROPE    ly final courts cajole furiously final excuse
+4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
+1    AMERICA    hs use ironic, even requests. s
+2    ASIA    ges. thinly even pinto beans ca
+3    EUROPE    ly final courts cajole furiously final excuse
+4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
+1    AMERICA    hs use ironic, even requests. s
+2    ASIA    ges. thinly even pinto beans ca
+3    EUROPE    ly final courts cajole furiously final excuse
+4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
+1    AMERICA    hs use ironic, even requests. s
+2    ASIA    ges. thinly even pinto beans ca
+3    EUROPE    ly final courts cajole furiously final excuse
+4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
+1    AMERICA    hs use ironic, even requests. s
+2    ASIA    ges. thinly even pinto beans ca
+3    EUROPE    ly final courts cajole furiously final excuse
+4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
+1    AMERICA    hs use ironic, even requests. s
+2    ASIA    ges. thinly even pinto beans ca
+3    EUROPE    ly final courts cajole furiously final excuse
+4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
+1    AMERICA    hs use ironic, even requests. s
+2    ASIA    ges. thinly even pinto beans ca
+3    EUROPE    ly final courts cajole furiously final excuse
+4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
 drop stage local_stage;
+drop stage sub_local_stage;
 drop database sdb;
 create user "stage_user02" identified by '123456';
 create role s_role;
@@ -258,12 +319,10 @@ grant all on table *.* to s_role;
 grant all on account * to s_role;
 grant all on database *.* to s_role;
 grant s_role to stage_user02;
-create stage local_stage URL= '$resources/into_outfile' ENABLE=TRUE;
+create stage local_stage URL= 'file:///$resources/into_outfile';
 internal error: do not have privilege to execute the statement
 show stages;
 STAGE_NAME    URL    STATUS    COMMENT
-alter stage local_stage set ENABLE=FALSE;
-internal error: do not have privilege to execute the statement
 drop stage local_stage;
 internal error: do not have privilege to execute the statement
 drop account stage_account;

--- a/test/distributed/cases/stage/stage.result
+++ b/test/distributed/cases/stage/stage.result
@@ -273,43 +273,15 @@ R_REGIONKEY  INTEGER NOT NULL,
 R_NAME       CHAR(25) NOT NULL,
 R_COMMENT    VARCHAR(152)
 ) INFILE 'stage://sub_local_stage/stage_table*.csv' fields terminated by ',' IGNORE 1 LINES;
-select * from stage_ext_table;
-r_regionkey    r_name    r_comment
-0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
-1    AMERICA    hs use ironic, even requests. s
-2    ASIA    ges. thinly even pinto beans ca
-3    EUROPE    ly final courts cajole furiously final excuse
-4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
-0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
-1    AMERICA    hs use ironic, even requests. s
-2    ASIA    ges. thinly even pinto beans ca
-3    EUROPE    ly final courts cajole furiously final excuse
-4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
-0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
-1    AMERICA    hs use ironic, even requests. s
-2    ASIA    ges. thinly even pinto beans ca
-3    EUROPE    ly final courts cajole furiously final excuse
-4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
-0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
-1    AMERICA    hs use ironic, even requests. s
-2    ASIA    ges. thinly even pinto beans ca
-3    EUROPE    ly final courts cajole furiously final excuse
-4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
-0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
-1    AMERICA    hs use ironic, even requests. s
-2    ASIA    ges. thinly even pinto beans ca
-3    EUROPE    ly final courts cajole furiously final excuse
-4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
-0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
-1    AMERICA    hs use ironic, even requests. s
-2    ASIA    ges. thinly even pinto beans ca
-3    EUROPE    ly final courts cajole furiously final excuse
-4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
-0    AFRICA    lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to 
-1    AMERICA    hs use ironic, even requests. s
-2    ASIA    ges. thinly even pinto beans ca
-3    EUROPE    ly final courts cajole furiously final excuse
-4    MIDDLE EAST    uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
+select count(*) from stage_ext_table;
+count(*)
+35
+select count(stage_list('stage://sub_local_stage/'));
+count(stage_list(stage://sub_local_stage/))
+7
+select count(stage_list('stage://sub_local_stage/stage_table*.csv'));
+count(stage_list(stage://sub_local_stage/stage_table*.csv))
+7
 drop stage local_stage;
 drop stage sub_local_stage;
 drop database sdb;

--- a/test/distributed/cases/stage/stage.result
+++ b/test/distributed/cases/stage/stage.result
@@ -9,26 +9,26 @@ internal error: the stage my_ext_stage exists
 ALTER STAGE my_ext_stage SET URL='abc';
 invalid configuration: URL protocol only supports stage://, s3:// and file:///
 CREATE STAGE if not exists my_ext_stage URL='s3://bucket/files/';
-SELECT stage_name, url from mo_catalog.mo_stages;
-stage_name    url
-my_ext_stage    s3://bucket/files/
-my_sub_stage    stage://my_ext_stage/a/b/c/
+SELECT * from mo_catalog.mo_stages;
+stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
+112    my_ext_stage    s3://bucket/files/        disabled    2024-08-07 10:35:26    
+113    my_sub_stage    stage://my_ext_stage/a/b/c/        disabled    2024-08-07 10:35:26    
 CREATE STAGE my_ext_stage1 URL='s3://bucket1/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
 CREATE STAGE my_ext_stage2 URL='s3://bucket2/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
-SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
-stage_name    url    stage_credentials
-my_ext_stage    s3://bucket/files/    
-my_sub_stage    stage://my_ext_stage/a/b/c/    
-my_ext_stage1    s3://bucket1/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
-my_ext_stage2    s3://bucket2/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
+SELECT * from mo_catalog.mo_stages;
+stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
+112    my_ext_stage    s3://bucket/files/        disabled    2024-08-07 10:35:26    
+113    my_sub_stage    stage://my_ext_stage/a/b/c/        disabled    2024-08-07 10:35:26    
+114    my_ext_stage1    s3://bucket1/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio    disabled    2024-08-07 10:35:26    
+115    my_ext_stage2    s3://bucket2/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio    disabled    2024-08-07 10:35:26    
 CREATE STAGE my_ext_stage3 URL='s3://bucket3/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
-SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
-stage_name    url    stage_credentials
-my_ext_stage    s3://bucket/files/    
-my_sub_stage    stage://my_ext_stage/a/b/c/    
-my_ext_stage1    s3://bucket1/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
-my_ext_stage2    s3://bucket2/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
-my_ext_stage3    s3://bucket3/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
+SELECT * from mo_catalog.mo_stages;
+stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
+112    my_ext_stage    s3://bucket/files/        disabled    2024-08-07 10:35:26    
+113    my_sub_stage    stage://my_ext_stage/a/b/c/        disabled    2024-08-07 10:35:26    
+114    my_ext_stage1    s3://bucket1/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio    disabled    2024-08-07 10:35:26    
+115    my_ext_stage2    s3://bucket2/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio    disabled    2024-08-07 10:35:26    
+116    my_ext_stage3    s3://bucket3/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio    disabled    2024-08-07 10:35:26    
 ALTER STAGE my_ext_stage4 SET URL='s3://bucket4/files2/';
 internal error: the stage my_ext_stage4 not exists
 ALTER STAGE if exists my_ext_stage4 SET URL='s3://bucket4/files2/';
@@ -45,16 +45,16 @@ DROP STAGE my_ext_stage2;
 DROP STAGE my_ext_stage3;
 DROP STAGE my_sub_stage;
 CREATE STAGE my_ext_stage URL='s3://bucket/files/';
-SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
-stage_name    url    stage_credentials
-my_ext_stage    s3://bucket/files/    
+SELECT * from mo_catalog.mo_stages;
+stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
+117    my_ext_stage    s3://bucket/files/        disabled    2024-08-07 10:35:26    
 create account default_1 ADMIN_NAME admin IDENTIFIED BY '111111';
 CREATE STAGE my_ext_stage1 URL='s3://bucket1/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
 CREATE STAGE my_ext_stage2 URL='s3://bucket2/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
-SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
-stage_name    url    stage_credentials
-my_ext_stage1    s3://bucket1/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
-my_ext_stage2    s3://bucket2/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio
+SELECT * from mo_catalog.mo_stages;
+stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
+1    my_ext_stage1    s3://bucket1/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio    disabled    2024-08-07 10:35:26    
+2    my_ext_stage2    s3://bucket2/files/    AWS_KEY_ID=1a2b3c,AWS_SECRET_KEY=4x5y6z,AWS_REGION=us-east-2,PROVIDER=minio    disabled    2024-08-07 10:35:26    
 DROP STAGE my_ext_stage1;
 DROP STAGE my_ext_stage2;
 drop account default_1;
@@ -126,9 +126,9 @@ show stages;
 STAGE_NAME    URL    STATUS    COMMENT
 aws_stage    s3://bucket2/d/e/f/    ENABLED    
 alter stage if exists aws_stage set CREDENTIALS={ 'AWS_REGION' = 'us-east-1'};
-select stage_name,url,stage_credentials,stage_status,comment from mo_catalog.mo_stages;
-stage_name    url    stage_credentials    stage_status    comment
-aws_stage    s3://bucket2/d/e/f/    AWS_REGION=us-east-1    enabled    
+select * from mo_catalog.mo_stages;
+stage_id    stage_name    url    stage_credentials    stage_status    created_time    comment
+123    aws_stage    s3://bucket2/d/e/f/    AWS_REGION=us-east-1    enabled    2024-08-07 10:35:26    
 alter stage aws_stage set comment='comment1';
 show stages;
 STAGE_NAME    URL    STATUS    COMMENT
@@ -146,7 +146,7 @@ insert into stage_table values
 (2,"ASIA","ges. thinly even pinto beans ca"),
 (3,"EUROPE","ly final courts cajole furiously final excuse"),
 (4,"MIDDLE EAST","uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl");
-create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/into_outfile/stage' comment='local stage configure';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 stage_name    stage_status    comment
 local_stage    disabled    local stage configure
@@ -154,22 +154,18 @@ select * from stage_table into outfile 'stage://local_stage/stage_table.csv';
 drop stage local_stage;
 show stages;
 STAGE_NAME    URL    STATUS    COMMENT
-create stage local_stage URL= 'file:///$resources/';
-create stage sub_local_stage URL= 'stage://local_stage/into_outfile/';
-select * from stage_table into outfile 'stage://sub_local_stage/stage_table.csv';
-open /home/ubuntu/p/matrixone/test/distributed/resources/into_outfile/stage_table.csv: file exists
+create stage local_stage URL= 'file:///$resources/into_outfile';
+create stage sub_local_stage URL= 'stage://local_stage/stage/';
+select * from stage_table into outfile 'stage://sub_local_stage/substage_table.csv';
 drop stage local_stage;
 drop stage sub_local_stage;
-select * from stage_table into outfile '$resources/into_outfile/stage_table00.csv';
-select * from stage_table into outfile '$resources/into_outfile/stage_table01.csv';
-select * from stage_table into outfile '$resources/into_outfile/stage_table02.csv';
-create stage local_stage URL= 'file://$resources/into_outfile';
-select stage_name, url, comment from mo_catalog.mo_stages;
-stage_name    url    comment
-local_stage    file:///home/ubuntu/p/mo-tester/../matrixone/test/distributed/resources/into_outfile    
+select * from stage_table into outfile '$resources/into_outfile/stage/stage_table00.csv';
+select * from stage_table into outfile '$resources/into_outfile/stage/stage_table01.csv';
+select * from stage_table into outfile '$resources/into_outfile/stage/stage_table02.csv';
+create stage local_stage URL= 'file:///$resources/into_outfile/stage';
 select * from stage_table into outfile 'stage://local_stage/stage_table1.csv';
 truncate table stage_table;
-load data infile '$resources/into_outfile/stage_table1.csv' into table stage_table fields terminated by ',' ignore 1 lines;
+load data infile '$resources/into_outfile/stage/stage_table1.csv' into table stage_table fields terminated by ',' ignore 1 lines;
 select r_name from stage_table;
 r_name
 AFRICA
@@ -177,13 +173,13 @@ AMERICA
 ASIA
 EUROPE
 MIDDLE EAST
-alter stage local_stage set URL= 'file:///$resources/into_outfile_2';
+alter stage local_stage set URL= 'file:///$resources/into_outfile_2/stage';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 stage_name    stage_status    comment
 local_stage    disabled    
 select * from stage_table into outfile 'stage://local_stage/stage_table2.csv';
 truncate table stage_table;
-load data infile '$resources/into_outfile_2/stage_table2.csv' into table stage_table fields terminated by ',' ignore 1 lines;
+load data infile '$resources/into_outfile_2/stage/stage_table2.csv' into table stage_table fields terminated by ',' ignore 1 lines;
 select r_name from stage_table;
 r_name
 AFRICA
@@ -196,11 +192,11 @@ select stage_name,stage_status,comment from mo_catalog.mo_stages;
 stage_name    stage_status    comment
 local_stage    disabled    new comment
 drop stage if exists local_stage;
-create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/into_outfile/stage' comment='local stage configure';
 select * from stage_table into outfile 'stage://local_stage/stage_table3.csv';
 drop stage local_stage;
-create stage if not exists local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
-create stage if not exists local_stage URL= 'file:///$resources/into_outfile2';
+create stage if not exists local_stage URL= 'file:///$resources/into_outfile/stage' comment='local stage configure';
+create stage if not exists local_stage URL= 'file:///$resources/into_outfile2/stage';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 stage_name    stage_status    comment
 local_stage    disabled    local stage configure
@@ -210,7 +206,7 @@ grant all on table *.* to s_role;
 grant all on account * to s_role;
 grant all on database *.* to s_role;
 grant s_role to stage_user;
-create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/into_outfile/stage' comment='local stage configure';
 internal error: do not have privilege to execute the statement
 create database sdb;
 use sdb;
@@ -234,7 +230,7 @@ drop role s_role;
 drop account if exists stage_account;
 create account `stage_account` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
 create stage local_stage URL= 'file:///$resources/' comment='local stage configure';
-create stage sub_local_stage URL= 'stage://local_stage/into_outfile' comment='sub local stage configure';
+create stage sub_local_stage URL= 'stage://local_stage/into_outfile/stage' comment='sub local stage configure';
 create database sdb;
 use sdb;
 CREATE TABLE stage_table(
@@ -278,7 +274,7 @@ count(*)
 35
 select count(stage_list('stage://sub_local_stage/'));
 count(stage_list(stage://sub_local_stage/))
-7
+8
 select count(stage_list('stage://sub_local_stage/stage_table*.csv'));
 count(stage_list(stage://sub_local_stage/stage_table*.csv))
 7
@@ -291,7 +287,7 @@ grant all on table *.* to s_role;
 grant all on account * to s_role;
 grant all on database *.* to s_role;
 grant s_role to stage_user02;
-create stage local_stage URL= 'file:///$resources/into_outfile';
+create stage local_stage URL= 'file:///$resources/into_outfile/stage';
 internal error: do not have privilege to execute the statement
 show stages;
 STAGE_NAME    URL    STATUS    COMMENT

--- a/test/distributed/cases/stage/stage.sql
+++ b/test/distributed/cases/stage/stage.sql
@@ -1,19 +1,27 @@
-CREATE STAGE my_ext_stage URL='s3://load/files/';
-CREATE STAGE my_ext_stage URL='s3://load/files/';
-CREATE STAGE if not exists my_ext_stage URL='s3://load/files/';
-SELECT stage_name from mo_catalog.mo_stages;
+CREATE STAGE invalid_path_stage URL='/path/to';
+CREATE STAGE invalid_unknown_protocol_stage URL='minio:///path/to';
 
-CREATE STAGE my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
-CREATE STAGE my_ext_stage2 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
-SELECT stage_name, stage_status from mo_catalog.mo_stages;
+CREATE STAGE my_ext_stage URL='s3://bucket/files/';
+CREATE STAGE my_sub_stage URL='stage://my_ext_stage/a/b/c/';
 
-CREATE STAGE my_ext_stage3 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'} ENABLE = TRUE;
-SELECT stage_name, stage_status from mo_catalog.mo_stages;
+CREATE STAGE my_ext_stage URL='s3://bucket/files/';
+ALTER STAGE my_ext_stage SET URL='abc';
 
-ALTER STAGE my_ext_stage4 SET URL='s3://load/files2/';
-ALTER STAGE if exists my_ext_stage4 SET URL='s3://load/files2/';
-ALTER STAGE my_ext_stage1 SET URL='s3://load/files2/' CREDENTIALS={'AWS_KEY_ID'='1a2b3d' ,'AWS_SECRET_KEY'='4x5y6z'};
-ALTER STAGE my_ext_stage1 SET URL='s3://load/files2/';
+
+CREATE STAGE if not exists my_ext_stage URL='s3://bucket/files/';
+SELECT stage_name, url from mo_catalog.mo_stages;
+
+CREATE STAGE my_ext_stage1 URL='s3://bucket1/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
+CREATE STAGE my_ext_stage2 URL='s3://bucket2/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
+SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
+
+CREATE STAGE my_ext_stage3 URL='s3://bucket3/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
+SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
+
+ALTER STAGE my_ext_stage4 SET URL='s3://bucket4/files2/';
+ALTER STAGE if exists my_ext_stage4 SET URL='s3://bucket4/files2/';
+ALTER STAGE my_ext_stage1 SET URL='s3://bucket2/files2/' CREDENTIALS={'AWS_KEY_ID'='1a2b3d' ,'AWS_SECRET_KEY'='4x5y6z'};
+ALTER STAGE my_ext_stage1 SET URL='s3://bucket2/files2/';
 ALTER STAGE my_ext_stage1 SET CREDENTIALS={'AWS_KEY_ID'='1a2b3d' ,'AWS_SECRET_KEY'='4x5y6z'};
 
 DROP STAGE my_ext_stage5;
@@ -22,15 +30,16 @@ DROP STAGE my_ext_stage;
 DROP STAGE my_ext_stage1;
 DROP STAGE my_ext_stage2;
 DROP STAGE my_ext_stage3;
+DROP STAGE my_sub_stage;
 
 
-CREATE STAGE my_ext_stage URL='s3://load/files/';
-SELECT stage_name from mo_catalog.mo_stages;
+CREATE STAGE my_ext_stage URL='s3://bucket/files/';
+SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
 create account default_1 ADMIN_NAME admin IDENTIFIED BY '111111';
 -- @session:id=1&user=default_1:admin&password=111111
-CREATE STAGE my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
-CREATE STAGE my_ext_stage2 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
-SELECT stage_name, stage_status from mo_catalog.mo_stages;
+CREATE STAGE my_ext_stage1 URL='s3://bucket1/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
+CREATE STAGE my_ext_stage2 URL='s3://bucket2/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
+SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
 DROP STAGE my_ext_stage1;
 DROP STAGE my_ext_stage2;
 -- @session
@@ -38,17 +47,17 @@ drop account default_1;
 drop stage my_ext_stage;
 
 
-CREATE STAGE my_ext_stage URL='s3://load/files/';
-CREATE STAGE my_ext_stage URL='s3://load/files/';
-CREATE STAGE if not exists my_ext_stage URL='s3://load/files/';
+CREATE STAGE my_ext_stage URL='s3://bucket/files/';
+CREATE STAGE my_ext_stage URL='s3://bucket/files/';
+CREATE STAGE if not exists my_ext_stage URL='s3://bucket/files/';
 SHOW STAGES;
 
-CREATE STAGE my_ext_stage1 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
-CREATE STAGE my_ext_stage2 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
+CREATE STAGE my_ext_stage1 URL='s3://bucket/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
+CREATE STAGE my_ext_stage2 URL='s3://bucket/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
 SHOW STAGES;
 
-CREATE STAGE my_ext_stage3 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'} ENABLE = TRUE;
-CREATE STAGE my_ext_stage4 URL='s3://load/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'} ENABLE = TRUE COMMENT = 'self stage';
+CREATE STAGE my_ext_stage3 URL='s3://bucket/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'};
+CREATE STAGE my_ext_stage4 URL='s3://bucket/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z'} COMMENT = 'self stage';
 SHOW STAGES;
 SHOW STAGES like 'my_ext_stage3';
 
@@ -72,13 +81,13 @@ DROP STAGE my_ext_stage4;
 -- create stage aws,cos,aliyun ,now not support select outfile s3
 drop stage if exists aws_stage;
 drop stage if exists local_stage;
-create stage aws_stage URL= 's3.us-east-2.amazonaws.com' CREDENTIALS={ 'access_key_id' = 'AKIAYOFAMAB', 'secret_access_key' = '7OtGNgIwlkBVwyL9rV', 'bucket' = 'hn-test2', 'region' = 'us-east-2', 'compression' = 'none'};
+create stage aws_stage URL= 's3://hn-test2/a/b/c' CREDENTIALS={ 'AWS_KEY_ID' = 'AKIAYOFAMAB', 'AWS_SECRET_KEY' = '7OtGNgIwlkBVwyL9rV', 'AWS_REGION' = 'us-east-2', 'provider'='minio', 'compression' = 'none'};
 show stages;
 alter stage aws_stage set enable=TRUE;
 show stages;
-alter stage if exists aws_stage set URL= 's3.us-east-1.amazonaws.com';
+alter stage if exists aws_stage set URL= 's3://bucket2/d/e/f/';
 show stages;
-alter stage if exists aws_stage set CREDENTIALS={ 'bucket' = 'hn-test2', 'region' = 'us-east-1'};
+alter stage if exists aws_stage set CREDENTIALS={ 'AWS_REGION' = 'us-east-1'};
 select stage_name,url,stage_credentials,stage_status,comment from mo_catalog.mo_stages;
 alter stage aws_stage set comment='comment1';
 show stages;
@@ -98,63 +107,56 @@ insert into stage_table values
 (3,"EUROPE","ly final courts cajole furiously final excuse"),
 (4,"MIDDLE EAST","uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl");
 -- create stage local disk
-create stage local_stage URL= '$resources/into_outfile' ENABLE=TRUE comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
-select * from stage_table into outfile 'local_stage:/stage_table.csv';
+select * from stage_table into outfile 'stage://local_stage/stage_table.csv';
 drop stage local_stage;
 show stages;
 
 -- url params error
 -- create stage local_stage URL= '$resources/abc' ENABLE=TRUE;
--- select * from stage_table into outfile 'local_stage:/stage_table.csv';
+-- select * from stage_table into outfile 'stage://local_stage/stage_table.csv';
 -- drop stage local_stage;
 
--- enable is false
-create stage local_stage URL= '$resources/into_outfile' ENABLE=FALSE;
-select * from stage_table into outfile 'local_stage:/stage_table.csv';
+-- output to sub-stage file
+create stage local_stage URL= 'file:///$resources/';
+create stage sub_local_stage URL= 'stage://local_stage/into_outfile/';
+select * from stage_table into outfile 'stage://sub_local_stage/stage_table.csv';
+drop stage local_stage;
+drop stage sub_local_stage;
 
 -- select outfile without stage
 select * from stage_table into outfile '$resources/into_outfile/stage_table00.csv';
-alter stage local_stage set ENABLE=TRUE;
 select * from stage_table into outfile '$resources/into_outfile/stage_table01.csv';
-drop stage local_stage;
 select * from stage_table into outfile '$resources/into_outfile/stage_table02.csv';
 
 -- alter stage params: enable/URL/comment
-create stage local_stage URL= '$resources/into_outfile' ENABLE=FALSE;
-alter stage local_stage set ENABLE=TRUE;
-select stage_name,stage_status,comment from mo_catalog.mo_stages;
-select * from stage_table into outfile 'local_stage:/stage_table1.csv';
+create stage local_stage URL= 'file://$resources/into_outfile';
+select stage_name, url, comment from mo_catalog.mo_stages;
+select * from stage_table into outfile 'stage://local_stage/stage_table1.csv';
 truncate table stage_table;
 load data infile '$resources/into_outfile/stage_table1.csv' into table stage_table fields terminated by ',' ignore 1 lines;
 select r_name from stage_table;
-alter stage local_stage set URL= '$resources/into_outfile_2';
+alter stage local_stage set URL= 'file:///$resources/into_outfile_2';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
-select * from stage_table into outfile 'local_stage:/stage_table2.csv';
+select * from stage_table into outfile 'stage://local_stage/stage_table2.csv';
 truncate table stage_table;
 load data infile '$resources/into_outfile_2/stage_table2.csv' into table stage_table fields terminated by ',' ignore 1 lines;
 select r_name from stage_table;
 alter stage local_stage set comment = 'new comment';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 
--- abnormal test
-create stage local_stage URL= '$resources/into_outfile_2' ENABLE=FALSE;
-alter stage local_stage set URL= '$resources/into_outfile_2' comment='alter comment';
-drop stage local_stage;
---create stage local_stage URL= '$resources/into_outfile_2' ENABLE=ffalse;
-
 -- select outfile file exists
 drop stage if exists local_stage;
-create stage local_stage URL= '$resources/into_outfile' ENABLE=TRUE comment='local stage configure';
-select * from stage_table into outfile 'local_stage:/stage_table3.csv';
+create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
+select * from stage_table into outfile 'stage://local_stage/stage_table3.csv';
 --select * from stage_table into outfile 'local_stage:/stage_table3.csv';
 drop stage local_stage;
 
 -- if exists
-create stage if not exists local_stage URL= '$resources/into_outfile' ENABLE=TRUE comment='local stage configure';
-create stage if not exists local_stage URL= '$resources/into_outfile2' ENABLE=FALSE;
+create stage if not exists local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
+create stage if not exists local_stage URL= 'file:///$resources/into_outfile2';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
-alter stage if exists l_stage set ENABLE=TRUE;
 
 -- privs confirm
 create user "stage_user" identified by '123456';
@@ -164,7 +166,7 @@ grant all on account * to s_role;
 grant all on database *.* to s_role;
 grant s_role to stage_user;
 -- @session:id=2&user=sys:stage_user:s_role&password=123456
-create stage local_stage URL= '$resources/into_outfile' ENABLE=TRUE comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
 create database sdb;
 use sdb;
 CREATE TABLE stage_table(
@@ -179,7 +181,6 @@ insert into stage_table values
 (2,"ASIA","ges. thinly even pinto beans ca"),
 (3,"EUROPE","ly final courts cajole furiously final excuse"),
 (4,"MIDDLE EAST","uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl");
-alter stage local_stage set ENABLE=FALSE;
 drop stage stage_user;
 drop database sdb;
 -- @session
@@ -189,7 +190,8 @@ drop role s_role;
 drop account if exists stage_account;
 create account `stage_account` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
 -- @session:id=3&user=stage_account:admin&password=123456
-create stage local_stage URL= '$resources/into_outfile' ENABLE=TRUE comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/' comment='local stage configure';
+create stage sub_local_stage URL= 'stage://local_stage/into_outfile' comment='sub local stage configure';
 create database sdb;
 use sdb;
 CREATE TABLE stage_table(
@@ -205,8 +207,30 @@ insert into stage_table values
 (3,"EUROPE","ly final courts cajole furiously final excuse"),
 (4,"MIDDLE EAST","uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl");
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
-select * from stage_table into outfile 'local_stage:/stage_table5.csv';
+
+-- write to sub stage
+select * from stage_table into outfile 'stage://sub_local_stage/stage_table5.csv';
+
+-- read from stage file
+CREATE TABLE stage_infile_table(
+R_REGIONKEY  INTEGER NOT NULL,
+R_NAME       CHAR(25) NOT NULL,
+R_COMMENT    VARCHAR(152),
+PRIMARY KEY (R_REGIONKEY)
+);
+load data infile 'stage://sub_local_stage/stage_table5.csv' into table stage_infile_table fields terminated by ',' IGNORE 1 LINES;
+select * from stage_infile_table;
+
+-- read from external table and sub stage
+CREATE EXTERNAL TABLE stage_ext_table(
+R_REGIONKEY  INTEGER NOT NULL,
+R_NAME       CHAR(25) NOT NULL,
+R_COMMENT    VARCHAR(152)
+) INFILE 'stage://sub_local_stage/stage_table*.csv' fields terminated by ',' IGNORE 1 LINES;
+select * from stage_ext_table;
+
 drop stage local_stage;
+drop stage sub_local_stage;
 drop database sdb;
 create user "stage_user02" identified by '123456';
 create role s_role;
@@ -217,9 +241,8 @@ grant s_role to stage_user02;
 -- @session
 
 -- @session:id=4&user=stage_account:stage_user02:s_role&password=123456
-create stage local_stage URL= '$resources/into_outfile' ENABLE=TRUE;
+create stage local_stage URL= 'file:///$resources/into_outfile';
 show stages;
-alter stage local_stage set ENABLE=FALSE;
 drop stage local_stage;
 -- @session
 drop account stage_account;

--- a/test/distributed/cases/stage/stage.sql
+++ b/test/distributed/cases/stage/stage.sql
@@ -227,7 +227,13 @@ R_REGIONKEY  INTEGER NOT NULL,
 R_NAME       CHAR(25) NOT NULL,
 R_COMMENT    VARCHAR(152)
 ) INFILE 'stage://sub_local_stage/stage_table*.csv' fields terminated by ',' IGNORE 1 LINES;
-select * from stage_ext_table;
+select count(*) from stage_ext_table;
+
+-- list the stage directory
+select count(stage_list('stage://sub_local_stage/'));
+
+-- list the stage directory with wildcard
+select count(stage_list('stage://sub_local_stage/stage_table*.csv'));
 
 drop stage local_stage;
 drop stage sub_local_stage;

--- a/test/distributed/cases/stage/stage.sql
+++ b/test/distributed/cases/stage/stage.sql
@@ -9,14 +9,17 @@ ALTER STAGE my_ext_stage SET URL='abc';
 
 
 CREATE STAGE if not exists my_ext_stage URL='s3://bucket/files/';
-SELECT stage_name, url from mo_catalog.mo_stages;
+-- @ignore:0,5
+SELECT * from mo_catalog.mo_stages;
 
 CREATE STAGE my_ext_stage1 URL='s3://bucket1/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
 CREATE STAGE my_ext_stage2 URL='s3://bucket2/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
-SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
+-- @ignore:0,5
+SELECT * from mo_catalog.mo_stages;
 
 CREATE STAGE my_ext_stage3 URL='s3://bucket3/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
-SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
+-- @ignore:0,5
+SELECT * from mo_catalog.mo_stages;
 
 ALTER STAGE my_ext_stage4 SET URL='s3://bucket4/files2/';
 ALTER STAGE if exists my_ext_stage4 SET URL='s3://bucket4/files2/';
@@ -34,12 +37,14 @@ DROP STAGE my_sub_stage;
 
 
 CREATE STAGE my_ext_stage URL='s3://bucket/files/';
-SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
+-- @ignore:0,5
+SELECT * from mo_catalog.mo_stages;
 create account default_1 ADMIN_NAME admin IDENTIFIED BY '111111';
 -- @session:id=1&user=default_1:admin&password=111111
 CREATE STAGE my_ext_stage1 URL='s3://bucket1/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
 CREATE STAGE my_ext_stage2 URL='s3://bucket2/files/' CREDENTIALS={'AWS_KEY_ID'='1a2b3c' ,'AWS_SECRET_KEY'='4x5y6z', 'AWS_REGION'='us-east-2', 'PROVIDER'='minio'};
-SELECT stage_name, url, stage_credentials from mo_catalog.mo_stages;
+-- @ignore:0,5
+SELECT * from mo_catalog.mo_stages;
 DROP STAGE my_ext_stage1;
 DROP STAGE my_ext_stage2;
 -- @session
@@ -88,7 +93,8 @@ show stages;
 alter stage if exists aws_stage set URL= 's3://bucket2/d/e/f/';
 show stages;
 alter stage if exists aws_stage set CREDENTIALS={ 'AWS_REGION' = 'us-east-1'};
-select stage_name,url,stage_credentials,stage_status,comment from mo_catalog.mo_stages;
+-- @ignore:0,5
+select * from mo_catalog.mo_stages;
 alter stage aws_stage set comment='comment1';
 show stages;
 drop stage aws_stage;
@@ -107,7 +113,7 @@ insert into stage_table values
 (3,"EUROPE","ly final courts cajole furiously final excuse"),
 (4,"MIDDLE EAST","uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl");
 -- create stage local disk
-create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/into_outfile/stage' comment='local stage configure';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 select * from stage_table into outfile 'stage://local_stage/stage_table.csv';
 drop stage local_stage;
@@ -119,43 +125,42 @@ show stages;
 -- drop stage local_stage;
 
 -- output to sub-stage file
-create stage local_stage URL= 'file:///$resources/';
-create stage sub_local_stage URL= 'stage://local_stage/into_outfile/';
-select * from stage_table into outfile 'stage://sub_local_stage/stage_table.csv';
+create stage local_stage URL= 'file:///$resources/into_outfile';
+create stage sub_local_stage URL= 'stage://local_stage/stage/';
+select * from stage_table into outfile 'stage://sub_local_stage/substage_table.csv';
 drop stage local_stage;
 drop stage sub_local_stage;
 
 -- select outfile without stage
-select * from stage_table into outfile '$resources/into_outfile/stage_table00.csv';
-select * from stage_table into outfile '$resources/into_outfile/stage_table01.csv';
-select * from stage_table into outfile '$resources/into_outfile/stage_table02.csv';
+select * from stage_table into outfile '$resources/into_outfile/stage/stage_table00.csv';
+select * from stage_table into outfile '$resources/into_outfile/stage/stage_table01.csv';
+select * from stage_table into outfile '$resources/into_outfile/stage/stage_table02.csv';
 
 -- alter stage params: enable/URL/comment
-create stage local_stage URL= 'file://$resources/into_outfile';
-select stage_name, url, comment from mo_catalog.mo_stages;
+create stage local_stage URL= 'file:///$resources/into_outfile/stage';
 select * from stage_table into outfile 'stage://local_stage/stage_table1.csv';
 truncate table stage_table;
-load data infile '$resources/into_outfile/stage_table1.csv' into table stage_table fields terminated by ',' ignore 1 lines;
+load data infile '$resources/into_outfile/stage/stage_table1.csv' into table stage_table fields terminated by ',' ignore 1 lines;
 select r_name from stage_table;
-alter stage local_stage set URL= 'file:///$resources/into_outfile_2';
+alter stage local_stage set URL= 'file:///$resources/into_outfile_2/stage';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 select * from stage_table into outfile 'stage://local_stage/stage_table2.csv';
 truncate table stage_table;
-load data infile '$resources/into_outfile_2/stage_table2.csv' into table stage_table fields terminated by ',' ignore 1 lines;
+load data infile '$resources/into_outfile_2/stage/stage_table2.csv' into table stage_table fields terminated by ',' ignore 1 lines;
 select r_name from stage_table;
 alter stage local_stage set comment = 'new comment';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 
 -- select outfile file exists
 drop stage if exists local_stage;
-create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/into_outfile/stage' comment='local stage configure';
 select * from stage_table into outfile 'stage://local_stage/stage_table3.csv';
 --select * from stage_table into outfile 'local_stage:/stage_table3.csv';
 drop stage local_stage;
 
 -- if exists
-create stage if not exists local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
-create stage if not exists local_stage URL= 'file:///$resources/into_outfile2';
+create stage if not exists local_stage URL= 'file:///$resources/into_outfile/stage' comment='local stage configure';
+create stage if not exists local_stage URL= 'file:///$resources/into_outfile2/stage';
 select stage_name,stage_status,comment from mo_catalog.mo_stages;
 
 -- privs confirm
@@ -166,7 +171,7 @@ grant all on account * to s_role;
 grant all on database *.* to s_role;
 grant s_role to stage_user;
 -- @session:id=2&user=sys:stage_user:s_role&password=123456
-create stage local_stage URL= 'file:///$resources/into_outfile' comment='local stage configure';
+create stage local_stage URL= 'file:///$resources/into_outfile/stage' comment='local stage configure';
 create database sdb;
 use sdb;
 CREATE TABLE stage_table(
@@ -191,7 +196,7 @@ drop account if exists stage_account;
 create account `stage_account` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
 -- @session:id=3&user=stage_account:admin&password=123456
 create stage local_stage URL= 'file:///$resources/' comment='local stage configure';
-create stage sub_local_stage URL= 'stage://local_stage/into_outfile' comment='sub local stage configure';
+create stage sub_local_stage URL= 'stage://local_stage/into_outfile/stage' comment='sub local stage configure';
 create database sdb;
 use sdb;
 CREATE TABLE stage_table(
@@ -247,7 +252,7 @@ grant s_role to stage_user02;
 -- @session
 
 -- @session:id=4&user=stage_account:stage_user02:s_role&password=123456
-create stage local_stage URL= 'file:///$resources/into_outfile';
+create stage local_stage URL= 'file:///$resources/into_outfile/stage';
 show stages;
 drop stage local_stage;
 -- @session


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

SQL failed to run and return error "context canceled".

operating system:

ubuntu24

go version:
go 1.22.4

To reproduce the case,

data file /tmp/data/a.csv
```
%  cat /tmp/data/a.csv 
1,a,b
2,aa,bb
3,aaa,bbb
```

SQL command to reproduce,
```
% mo_ctl connect
create database testdb;
use testdb;

create stage tmpstage url='file:///tmp/';
create table srctab (r_regionkey int, r_name char(25), r_comment varchar(152));
load data infile 'stage://tmpstage/data/a.csv' into table srctab fields terminated by ',';
select * from srctab into outfile 'stage://tmpstage/data/out.csv';
```

Result
```
mysql> create database testdb;
Query OK, 1 row affected (0.08 sec)

mysql> use testdb;
Database changed
mysql> 
mysql> create stage tmpstage url='file:///tmp/';
Query OK, 0 rows affected (0.02 sec)

mysql> create table srctab (r_regionkey int, r_name char(25), r_comment varchar(152));
Query OK, 0 rows affected (0.05 sec)

mysql> load data infile 'stage://tmpstage/data/a.csv' into table srctab fields terminated by ',';

ERROR 1105 (HY000): context canceled
mysql> select * from srctab into outfile 'stage://tmpstage/data/out.csv';
ERROR 1105 (HY000): context canceled
mysql> 
mysql> 
```

GDB
1. set the breakpoint in stage_util.go:175 first.

b stage_util.go:175

2. run LOAD DATA SQL and break in stage_util.go

3. set breakpoint in sql_executor.go

b sql_executor.go:246
b backend.go:581

4. continue and step to see until error

GDB LOG HERE

<img width="1707" alt="WeChatWorkScreenshot_2389fe3e-fd7c-4643-824a-ab0f7a36d88f" src="https://github.com/user-attachments/assets/b92cb60e-5404-4d46-9ab1-a44389591676">
<img width="1707" alt="WeChatWorkScreenshot_a667369b-8132-49a2-9a69-793026e38e26" src="https://github.com/user-attachments/assets/79348c25-9492-4f0e-85b7-8ae4aa243371">

There is a race.
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/a6e49aaa-18b5-4fd7-9ab4-a110844e40ef">

___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fixed SQL execution error "context canceled" when running stage-related commands.
- Refactored export logic to use file service and buffer.
- Added and updated utility functions for handling stage URLs and credentials.
- Updated external scan compilation and file existence checks to support stage URLs.
- Refactored query result dumping and status statement execution to use new export logic.
- Added and updated test cases for stage URL handling, data loading, and snapshot results.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>export.go</strong><dd><code>Refactor export logic to use file service and buffer.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/export.go

<li>Removed unused imports and variables.<br> <li> Refactored <code>ExportConfig</code> to remove file handling and buffer writer.<br> <li> Simplified file opening logic and integrated file service handling.<br> <li> Refactored CSV writing functions to use a buffer.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-f0ddee43e17880a8a1101779cdc0afb49fa87fc2bbc55574db96401903218007">+122/-201</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stage_util.go</strong><dd><code>Add utility functions for stage URL handling and file listing.</code></dd></summary>
<hr>

pkg/sql/plan/function/stage_util.go

<li>Added new utility functions for handling stage URLs and credentials.<br> <li> Implemented functions to parse and expand stage definitions.<br> <li> Added functions for listing files in stages with and without <br>wildcards.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-35313751118770199cf0d0152530f36d2fb7b93b1aedf1af7d82c39d606590aa">+430/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>authenticate.go</strong><dd><code>Update stage creation and credential handling logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/authenticate.go

<li>Removed commented-out SQL query strings.<br> <li> Updated stage creation to validate URL protocols.<br> <li> Modified credential handling to avoid hashing.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-849f201c351210bd95807e99d1538e2602a5244b256c35e58467afe304c509e6">+24/-73</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Add and refactor parameter initialization for stage URLs.</code></dd></summary>
<hr>

pkg/sql/plan/utils.go

<li>Added functions to initialize stage parameters for S3 and local files.<br> <li> Refactored parameter initialization to support stage URLs.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-4086cbd1a662ffb2a7761174da95abee51e3e0cc7e4ab796e2ec6ef82983ab45">+125/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>func_unary.go</strong><dd><code>Add StageList function for listing files in a stage.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/function/func_unary.go

- Added `StageList` function to list files in a stage.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-c3a42753612b2181b8096b586ceb205b23d4d9f1b884c728ca8705d46c6b7dc4">+55/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>list_builtIn.go</strong><dd><code>Add stage_list function to built-in functions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/function/list_builtIn.go

<li>Added <code>stage_list</code> function to the list of supported built-in functions.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-b9b859604bf3c01505320f0a72c9862667f39cdf1323a88d7f8b2991d32098b8">+34/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>compile.go</strong><dd><code>Support stage URLs in external scan compilation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/compile.go

- Updated external scan compilation to support stage URLs.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+16/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>query_result.go</strong><dd><code>Refactor query result dumping to use new export logic.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/query_result.go

- Refactored query result dumping to use new export logic.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-50145a34d12f0c66ec663d1bf4ebfb3464f74edf27a7c9770cdcbb68d3a5d69b">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>function_id.go</strong><dd><code>Add STAGE_LIST function ID.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/function/function_id.go

- Added `STAGE_LIST` function ID.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-8a340cc7bfd15d211dc0f230d234ba4edded44e79655671a94ce13f5fabfc7de">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>status_stmt.go</strong><dd><code>Refactor status statement execution to use new export logic.</code></dd></summary>
<hr>

pkg/frontend/status_stmt.go

- Refactored status statement execution to use new export logic.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-4b971614b20a9feb9538ffa6832b8f1531ccbacdab31167160e3441a3d6e3774">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>build_load.go</strong><dd><code>Support stage URLs in file existence check.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_load.go

- Updated file existence check to support stage URLs.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-f4d97d7b39aceecc7483340bc220e0f473127b8251fcf147361c90fd6c0f1b8c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>external.go</strong><dd><code>Support stage URLs in external stats initialization.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/external.go

- Updated external stats initialization to support stage URLs.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-a27eb1a712eafac50ed1d010377bfdad931b795d5257ca7a79bd841abdb2afc3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>authenticate_test.go</strong><dd><code>Update test cases for stage URL and credentials format.</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/authenticate_test.go

<li>Updated test cases to remove single quotes from URLs and credentials.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-1ad0724d270095c61cc27acd6e6178cdb16bd6fd041f8ccd081b0ebb82b470ee">+13/-314</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>export_test.go</strong><dd><code>Refactor export tests to use buffer and remove file handling.</code></dd></summary>
<hr>

pkg/frontend/export_test.go

<li>Removed tests related to file handling.<br> <li> Updated tests to use buffer for CSV writing.<br> <li> Refactored test cases to align with new export logic.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-f2e4bd8609e4a77740bacb81b7bb054b7b1b7eff1a7283cf63558f834e23de6e">+31/-93</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session_test.go</strong><dd><code>Comment out test case for updating time zone to system.</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/session_test.go

- Commented out a test case for updating time zone to "system".



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-b536d27dc9147be10e04f8209df0846ee094ada16301d8c0d6c3256569504c0a">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nonsys_restore_system_table_to_nonsys_account.result</strong><dd><code>Update timestamps and snapshot results.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/snapshot/nonsys_restore_system_table_to_nonsys_account.result

- Updated timestamps and snapshot results.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-97bec69eadde63373d9c2dca9b5599a3c59c639f36ea063613d42b15f2e051f8">+36/-36</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>load_data_parquet.result</strong><dd><code>Add test results for loading data from a stage.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/load_data/load_data_parquet.result

- Added test results for loading data from a stage.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-e802bbd1bc6ce9f96d9b463b7dda8b0fa71a797392da528cb653cd19f7965d39">+15/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>load_data_parquet.sql</strong><dd><code>Add test case for loading data from a stage.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/load_data/load_data_parquet.sql

- Added test case for loading data from a stage.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-05adfc11d12ff36a18aa08a2dc91ef7251614edaaffb0140ba51b2d0c099ef43">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cluster_level_snapshot_restore_system_table_to_nonsys.result</strong><dd><code>Update timestamps and stage credentials in snapshot tests</code></dd></summary>
<hr>

test/distributed/cases/snapshot/cluster_level_snapshot_restore_system_table_to_nonsys.result

<li>Updated timestamps for snapshot creation and function definitions.<br> <li> Adjusted stage credentials format.<br> <li> Modified procedure definitions with new timestamps.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-0664639eb878405ac92e8a1cebe6f5e9ef08c87d8835b17f01845dd7f272338e">+31/-31</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sys_restore_system_table_to_nonsys_account.result</strong><dd><code>Update timestamps and stage credentials in sys restore tests</code></dd></summary>
<hr>

test/distributed/cases/snapshot/sys_restore_system_table_to_nonsys_account.result

<li>Updated timestamps for snapshot creation and function definitions.<br> <li> Adjusted stage credentials format.<br> <li> Modified procedure definitions with new timestamps.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-641d191ecc49e3a108dcdb2a5a7c68014ec74503984791ad3587b25d2a9978a1">+30/-30</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sys_restore_system_table_to_newnonsys_account.result</strong><dd><code>Update timestamps and stage credentials in sys restore to new account </code><br><code>tests</code></dd></summary>
<hr>

test/distributed/cases/snapshot/sys_restore_system_table_to_newnonsys_account.result

<li>Updated timestamps for snapshot creation and function definitions.<br> <li> Adjusted stage credentials format.<br> <li> Modified procedure definitions with new timestamps.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-94fd70ae3dac8c859501f8ffdba8d4f164fd89040015fa245e65ef260b9d02cf">+29/-29</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stage.result</strong><dd><code>Add and update stage creation and data loading tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/stage/stage.result

<li>Added new stage creation tests with various URL protocols.<br> <li> Updated stage credentials format.<br> <li> Added tests for loading data from stages and creating external tables.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-83aea23c0b556c48afa9e1b940184c3a85e7da2180e87e8a837b96242506f529">+137/-110</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stage.sql</strong><dd><code>Refactor stage URLs and enhance test cases for stages</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/stage/stage.sql

<li>Updated stage URLs to use consistent 's3://bucket' format.<br> <li> Added new test cases for invalid paths and protocols.<br> <li> Included new stages with additional credentials and regions.<br> <li> Enhanced test cases with sub-stages and file operations.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-3a408ff516b694b1c7542ab91ad6991683b069041bdf79b70c19d6508b33e3a2">+99/-65</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>restore_cluster_table.result</strong><dd><code>Update test results with new timestamps and credentials format</code></dd></summary>
<hr>

test/distributed/cases/snapshot/cluster/restore_cluster_table.result

<li>Updated timestamps for stored procedures and functions.<br> <li> Modified stage credentials format in test results.<br> <li> Adjusted snapshot timestamps for consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/17973/files#diff-c7a456c97b9b96b039c967b070425d1697112b3c028b5a7dd0655228850a7bd3">+18/-18</a>&nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

