### PR TITLE
malloc: reduce memory usages of stacktrace

### DIFF
--- a/pkg/common/malloc/checked_allocator.go
+++ b/pkg/common/malloc/checked_allocator.go
@@ -27,11 +27,11 @@ type CheckedAllocator struct {
 }
 
 type checkedAllocatorArgs struct {
-	deallocated  *atomic.Bool
-	deallocator  Deallocator
-	stacktraceID StacktraceID
-	size         uint64
-	ptr          unsafe.Pointer
+	deallocated *atomic.Bool
+	deallocator Deallocator
+	allocatePCs []uintptr
+	size        uint64
+	ptr         unsafe.Pointer
 }
 
 func (checkedAllocatorArgs) As(Trait) bool {
@@ -52,7 +52,7 @@ func NewCheckedAllocator(
 						"double free: address %p, size %v, allocated at %s",
 						args.ptr,
 						args.size,
-						args.stacktraceID,
+						pcsToString(args.allocatePCs),
 					))
 				}
 
@@ -75,25 +75,35 @@ func (c *CheckedAllocator) Allocate(size uint64, hints Hints) ([]byte, Deallocat
 		return nil, nil, err
 	}
 
-	stacktraceID := GetStacktraceID(0)
 	deallocated := new(atomic.Bool) // this will not be GC until deallocator is called
+	var pcs []uintptr
+	dec = c.deallocatorPool.Get2(func(args *checkedAllocatorArgs) checkedAllocatorArgs {
+		pcs = args.allocatePCs
+		if cap(pcs) < 32 {
+			pcs = make([]uintptr, 32)
+		} else {
+			pcs = pcs[:cap(pcs)]
+		}
+		n := runtime.Callers(1, pcs)
+		pcs = pcs[:n]
+		return checkedAllocatorArgs{
+			deallocated: deallocated,
+			deallocator: dec,
+			allocatePCs: pcs,
+			size:        size,
+			ptr:         unsafe.Pointer(unsafe.SliceData(ptr)),
+		}
+	})
+
 	runtime.SetFinalizer(deallocated, func(deallocated *atomic.Bool) {
 		if !deallocated.Load() {
 			panic(fmt.Sprintf(
 				"missing free: address %p, size %v, allocated at %s",
 				ptr,
 				size,
-				stacktraceID,
+				pcsToString(pcs),
 			))
 		}
-	})
-
-	dec = c.deallocatorPool.Get(checkedAllocatorArgs{
-		deallocated:  deallocated,
-		deallocator:  dec,
-		stacktraceID: stacktraceID,
-		size:         size,
-		ptr:          unsafe.Pointer(unsafe.SliceData(ptr)),
 	})
 
 	return ptr, dec, nil

--- a/pkg/common/malloc/closure_deallocator.go
+++ b/pkg/common/malloc/closure_deallocator.go
@@ -70,3 +70,9 @@ func (c *ClosureDeallocatorPool[T, P]) Get(args T) Deallocator {
 	closure.SetArgument(args)
 	return closure
 }
+
+func (c *ClosureDeallocatorPool[T, P]) Get2(fn func(*T) T) Deallocator {
+	closure := c.pool.Get().(*ClosureDeallocator[T, P])
+	closure.SetArgument(fn(&closure.argument))
+	return closure
+}

--- a/pkg/common/malloc/config.go
+++ b/pkg/common/malloc/config.go
@@ -44,7 +44,7 @@ var defaultConfig = func() *atomic.Pointer[Config] {
 
 	// default config
 	ret.Store(&Config{
-		CheckFraction:     ptrTo(uint32(512)),
+		CheckFraction:     ptrTo(uint32(4096)),
 		EnableMetrics:     ptrTo(true),
 		FullStackFraction: ptrTo(uint32(10)),
 	})

--- a/pkg/common/malloc/stacktrace.go
+++ b/pkg/common/malloc/stacktrace.go
@@ -17,7 +17,8 @@ package malloc
 import (
 	"hash/maphash"
 	"runtime"
-	"runtime/debug"
+	"strconv"
+	"strings"
 	"sync"
 	"unsafe"
 )
@@ -26,10 +27,6 @@ type StacktraceID uint64
 
 func GetStacktraceID(skip int) StacktraceID {
 	pcs := pcs1024Pool.Get().(*[]uintptr)
-	defer func() {
-		*pcs = (*pcs)[:cap(*pcs)]
-		pcs1024Pool.Put(pcs)
-	}()
 
 	n := runtime.Callers(2+skip, *pcs)
 	*pcs = (*pcs)[:n]
@@ -47,27 +44,56 @@ func GetStacktraceID(skip int) StacktraceID {
 	id := StacktraceID(hasher.Sum64())
 
 	if _, ok := stackIDToInfo.Load(id); ok {
+		// recycle
+		*pcs = (*pcs)[:cap(*pcs)]
+		pcs1024Pool.Put(pcs)
 		return id
 	}
 
-	info := debug.Stack()
-	stackIDToInfo.LoadOrStore(id, info)
+	_, loaded := stackIDToInfo.LoadOrStore(id, pcs)
+	if loaded {
+		// recycle
+		*pcs = (*pcs)[:cap(*pcs)]
+		pcs1024Pool.Put(pcs)
+	}
 
 	return id
 }
 
-var stackIDToInfo sync.Map
+var stackIDToInfo sync.Map // StacktraceID -> []uintptr
 
 var pcs1024Pool = sync.Pool{
 	New: func() any {
-		slice := make([]uintptr, 1024)
+		slice := make([]uintptr, 64)
 		return &slice
 	},
 }
 
 func (s StacktraceID) String() string {
-	if v, ok := stackIDToInfo.Load(s); ok {
-		return string(v.([]byte))
+	v, ok := stackIDToInfo.Load(s)
+	if !ok {
+		panic("bad stack id")
 	}
-	panic("bad stack id")
+
+	buf := new(strings.Builder)
+
+	pcs := v.(*[]uintptr)
+	frames := runtime.CallersFrames(*pcs)
+	for {
+		frame, more := frames.Next()
+
+		buf.WriteString(frame.Function)
+		buf.WriteString("\n")
+		buf.WriteString("\t")
+		buf.WriteString(frame.File)
+		buf.WriteString(":")
+		buf.WriteString(strconv.Itoa(frame.Line))
+		buf.WriteString("\n")
+
+		if !more {
+			break
+		}
+	}
+
+	return buf.String()
 }

--- a/pkg/common/malloc/stacktrace.go
+++ b/pkg/common/malloc/stacktrace.go
@@ -74,11 +74,13 @@ func (s StacktraceID) String() string {
 	if !ok {
 		panic("bad stack id")
 	}
+	return pcsToString(*(v.(*[]uintptr)))
+}
 
+func pcsToString(pcs []uintptr) string {
 	buf := new(strings.Builder)
 
-	pcs := v.(*[]uintptr)
-	frames := runtime.CallersFrames(*pcs)
+	frames := runtime.CallersFrames(pcs)
 	for {
 		frame, more := frames.Next()
 

--- a/pkg/common/malloc/stacktrace_test.go
+++ b/pkg/common/malloc/stacktrace_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetStacktrace(t *testing.T) {
+	ids := make([]StacktraceID, 0, 1024)
+	for range 1024 {
+		ids = append(ids, GetStacktraceID(0))
+	}
+	for _, id := range ids {
+		msg := id.String()
+		if !strings.Contains(msg, "TestGetStacktrace") {
+			t.Fatalf("got %v\n", msg)
+		}
+	}
+}
+
+func BenchmarkGetStacktraceID(b *testing.B) {
+	for range b.N {
+		GetStacktraceID(0)
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3775 https://github.com/matrixorigin/MO-Cloud/issues/3882

## What this PR does / why we need it:
stacktrace info in malloc package is using too much memory, reduce.