### PR TITLE
Fix watchDirty stop 1.2

### DIFF
--- a/pkg/vm/engine/tae/tables/aobj.go
+++ b/pkg/vm/engine/tae/tables/aobj.go
@@ -109,6 +109,12 @@ func (obj *aobject) PrepareCompactInfo() (result bool, reason string) {
 
 func (obj *aobject) PrepareCompact() bool {
 	if obj.RefCount() > 0 {
+		if obj.meta.Load().CheckPrintPrepareCompactLocked(1 * time.Second) {
+			if !obj.meta.Load().HasPrintedPrepareComapct.Load() {
+				logutil.Infof("object ref count is %d", obj.RefCount())
+			}
+			obj.meta.Load().PrintPrepareCompactDebugLog()
+		}
 		return false
 	}
 

--- a/pkg/vm/engine/tae/txn/txnimpl/table_space.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table_space.go
@@ -178,6 +178,8 @@ func (space *tableSpace) prepareApplyANode(node *anode) error {
 		if appender.CheckFreeze() {
 			// freezed, try to find another ablock
 			appender.UnlockFreeze()
+			// Unref the appender, otherwise it can't be PrepareCompact(ed) successfully
+			appender.Close()
 			continue
 		}
 


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18037 

## What this PR does / why we need it:
Unref the appender if it is found frozen by checkpoint runner, otherwise flush will be blocked forever
