### PR TITLE
fix: insert newParallelScope

### DIFF
--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -911,11 +911,11 @@ func newParallelScope(c *Compile, s *Scope, ss []*Scope) (*Scope, error) {
 			}
 			arg.Release()
 		case vm.Output:
-		case vm.Connector:
-		case vm.Dispatch:
 		default:
-			for j := range ss {
-				ss[j].setRootOperator(dupOperator(op, nil, j))
+			if op != s.RootOp {
+				for j := range ss {
+					ss[j].setRootOperator(dupOperator(op, nil, j))
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/18097

## What this PR does / why we need it:
在改scope.instructions改为tree的commit的时候，修改newParallelScope函数，复制n条pipeline的时候，如果是dispatch和Connector，Output算子，不复制这个op， 接下来也不删除pipeline的最后一个op（之前是复制整个pipeline，然后删除最后一个op）， 这个issue insert pipeline 最上层op是insert， 所以insert op复制了，但是并没有删除最后一个op， 导致issue里面后台跑的insert into select到表里面的数据多了一份，走了两次insert write