### PR TITLE
enable ut TestMultiClusterCanWork and TestBaseClusterCanWorkWithNewCluster

### DIFF
--- a/pkg/embed/cluster_test.go
+++ b/pkg/embed/cluster_test.go
@@ -38,8 +38,6 @@ func TestBasicCluster(t *testing.T) {
 }
 
 func TestMultiClusterCanWork(t *testing.T) {
-	// TODO(fagongzi) wait may data race fixed
-	t.SkipNow()
 	new := func() Cluster {
 		c, err := NewCluster(WithCNCount(3))
 		require.NoError(t, err)
@@ -59,9 +57,6 @@ func TestMultiClusterCanWork(t *testing.T) {
 }
 
 func TestBaseClusterCanWorkWithNewCluster(t *testing.T) {
-	// TODO(fagongzi) wait may data race fixed
-	t.SkipNow()
-
 	RunBaseClusterTests(
 		func(c Cluster) {
 			validCNCanWork(t, c, 0)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18002 

## What this PR does / why we need it:
enable ut TestMultiClusterCanWork and TestBaseClusterCanWorkWithNewCluster