### PR TITLE
Update checkin max-active to 100

### DIFF
--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -183,6 +183,7 @@ spec:
       [cn.txn]
       enable-leak-check = 1
       max-active-ages = "20m"
+      max-active = 100
       [cn.txn.trace]
       buffer-size = 100000
       flush-bytes = "64M"


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:

set CN max-active txn to 100.
In the CI environment, sometimes TPCC and mixed sysbench start to run at the same time. the default max-active txn is too small that it will take almost 10 mins before it starts to run.