### PR TITLE
fix TestShardCanBeAllocatedToMultiCN

### DIFF
--- a/pkg/shardservice/service_test.go
+++ b/pkg/shardservice/service_test.go
@@ -317,7 +317,7 @@ func TestShardCanBeAllocatedToMultiCN(t *testing.T) {
 			s2 := services[1]
 			table := uint64(1)
 			shards := uint32(2)
-			mustAddTestShards(t, ctx, s1, table, shards, 1)
+			mustAddTestShards(t, ctx, s1, table, shards, 1, s2)
 
 			waitReplicaCount(table, s1, 1)
 			waitReplicaCount(table, s2, 1)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17011

## What this PR does / why we need it:
Fix ut. Make cn1 and cn2 shared committed tables. Avoid check table deleted checker triggered.