### PR TITLE
fix: buildload

### DIFF
--- a/pkg/sql/plan/build_load.go
+++ b/pkg/sql/plan/build_load.go
@@ -144,6 +144,10 @@ func buildLoad(stmt *tree.Load, ctx CompilerContext, isPrepareStmt bool) (*Plan,
 		return nil, err
 	}
 
+	if stmt.Param.FileSize < LoadParallelMinSize {
+		stmt.Param.Parallel = false
+	}
+
 	stmt.Param.LoadFile = true
 	stmt.Param.Tail.ColumnList = nil
 	if stmt.Param.ScanType != tree.INLINE {
@@ -205,9 +209,6 @@ func buildLoad(stmt *tree.Load, ctx CompilerContext, isPrepareStmt bool) (*Plan,
 
 	if err != nil {
 		return nil, err
-	}
-	if stmt.Param.FileSize < LoadParallelMinSize {
-		stmt.Param.Parallel = false
 	}
 
 	inlineDataSize := unsafe.Sizeof(stmt.Param.Data)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/3924

## What this PR does / why we need it:
buildload里面当文件大小比较小，设置parallel为false的代码，这段逻辑有两处一样的代码，所以在之前一个commit，就删掉了一处，删错了位置，因为原本删除的地方紧接着会marshal，encode这个字段，由于删除了，导致有种情况，encode的parallel为true，实际接下来buildload里面按照parallel为false处理的