### PR TITLE
[fix] : remove meaningless panic of mpool.Alloc

### DIFF
--- a/pkg/common/mpool/mpool.go
+++ b/pkg/common/mpool/mpool.go
@@ -583,7 +583,7 @@ func (mp *MPool) Alloc(sz int) ([]byte, error) {
 		more info : https://github.com/matrixorigin/matrixone/issues/18240#issuecomment-2308223191
 	*/
 
-	// gcurr := globalStats.RecordAlloc("global", tempSize)
+	_ = globalStats.RecordAlloc("global", tempSize)
 	// if gcurr > GlobalCap() {
 	// 	globalStats.RecordFree("global", tempSize)
 	// 	return nil, moerr.NewOOMNoCtx()

--- a/pkg/common/mpool/mpool.go
+++ b/pkg/common/mpool/mpool.go
@@ -578,7 +578,7 @@ func (mp *MPool) Alloc(sz int) ([]byte, error) {
 			1. the stats are not correct, the correct fix for this problem depends on correct calls to Vector.Free and Batch.Free, and refactoring of the pipeline
 			2. GlobalCap is completely meaningless, because almost all mpools have a capacity limit of PB (this is probably also due to the first point, wrong statistics).
 
-		The fundamental fix to this problem depends on a complete refactoring of the mpool, 
+		The fundamental fix to this problem depends on a complete refactoring of the mpool,
 		which is already tracked in the issue, until then, comment out the moerr.NewOOMNoCtx() error, as it does not reflect the real problem and can cause the cluster to crash.
 		more info : https://github.com/matrixorigin/matrixone/issues/18240#issuecomment-2308223191
 	*/


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18240 https://github.com/matrixorigin/MO-Cloud/issues/3928

## What this PR does / why we need it:

At present, the problems of the mpool framework itself can lead to meaningless oom situations.