### PR TITLE
isEnd property should not affect pipelines

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -3309,14 +3309,8 @@ func (c *Compile) newMergeScope(ss []*Scope) *Scope {
 	rs.NodeInfo = getEngineNode(c)
 	rs.NodeInfo.Mcpu = 1 //merge scope is single parallel by default
 	rs.PreScopes = ss
-	cnt := 0
-	for _, s := range ss {
-		if s.IsEnd {
-			continue
-		}
-		cnt++
-	}
-	rs.Proc = c.proc.NewNoContextChildProc(cnt)
+
+	rs.Proc = c.proc.NewNoContextChildProc(len(ss))
 	if len(ss) > 0 {
 		rs.Proc.Base.LoadTag = ss[0].Proc.Base.LoadTag
 	}
@@ -3330,14 +3324,12 @@ func (c *Compile) newMergeScope(ss []*Scope) *Scope {
 
 	j := 0
 	for i := range ss {
-		if !ss[i].IsEnd {
-			// waring: `connector` operator is not used as an input/output analyze,
-			// and `connector` operator cannot play the role of IsFirst/IsLast
-			connArg := connector.NewArgument().WithReg(rs.Proc.Reg.MergeReceivers[j])
-			connArg.SetAnalyzeControl(c.anal.curNodeIdx, false)
-			ss[i].setRootOperator(connArg)
-			j++
-		}
+		// waring: `connector` operator is not used as an input/output analyze,
+		// and `connector` operator cannot play the role of IsFirst/IsLast
+		connArg := connector.NewArgument().WithReg(rs.Proc.Reg.MergeReceivers[j])
+		connArg.SetAnalyzeControl(c.anal.curNodeIdx, false)
+		ss[i].setRootOperator(connArg)
+		j++
 	}
 	return rs
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #16542 

## What this PR does / why we need it:
isEnd property is used for analyze. should not affect pipelines. remove this logic.