### PR TITLE
add log for record affected rows when restore (#1.2-dev)

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -547,6 +547,9 @@ func (c *Compile) Run(_ uint64) (result *util2.RunResult, err error) {
 		return nil, c.proc.Ctx.Err()
 	}
 	result.AffectRows = runC.getAffectedRows()
+	if c.uid != "mo_logger" && strings.Contains(strings.ToLower(c.sql), "insert") && (strings.Contains(c.sql, "{MO_TS =") || strings.Contains(c.sql, "{SNAPSHOT =")) {
+		getLogger().Info("insert into with snapshot", zap.String("sql", c.sql), zap.Uint64("affectRows", result.AffectRows))
+	}
 
 	if c.proc.TxnOperator != nil {
 		return result, c.proc.TxnOperator.GetWorkspace().Adjust(writeOffset)


### PR DESCRIPTION
add log for record affected rows when restore

Approved by: @ouyuanning

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18237 

## What this PR does / why we need it:
add log for record affected rows when restore 