### PR TITLE
fileservice: do disk cache eviction after loading and before writing file

### DIFF
--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -399,7 +399,7 @@ func TestS3FSMinioServer(t *testing.T) {
 	exePath, err := exec.LookPath("minio")
 	if errors.Is(err, exec.ErrNotFound) {
 		// minio not found in machine
-		return
+		t.Skip("minio executable not found")
 	}
 
 	// start minio


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/18388 

## What this PR does / why we need it:
more eviction