### PR TITLE
fix delete routine log

### DIFF
--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -94,7 +94,6 @@ func (ar *AccountRoutineManager) deleteRoutine(tenantID int64, rt *Routine) {
 
 	ar.accountRoutineMu.Lock()
 	defer ar.accountRoutineMu.Unlock()
-	logutil.Infof("[delete account] delete account id %d, connection id %d from account routine map", tenantID, rt.getConnectionID())
 	_, ok := ar.accountId2Routine[tenantID]
 	if ok {
 		delete(ar.accountId2Routine[tenantID], rt)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18487 

## What this PR does / why we need it:
fix delete routine log

在 KillRoutineConnections的地方已经kill connection了，如果后面deleteRoutine 的时候再获取connectionid就会panic


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the logging of connection ID in the `deleteRoutine` function to prevent errors when the connection has already been killed.
- This change addresses issue #18487 by ensuring that accessing the connection ID after it has been killed does not cause errors.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routine_manager.go</strong><dd><code>Remove logging of connection ID in deleteRoutine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/routine_manager.go

<li>Removed logging of connection ID during routine deletion.<br> <li> Ensured no error occurs by avoiding access to connection ID after <br>connection is killed.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18488/files#diff-511d6a4e67914d6a32b75c81d76cf23e8d6d255822eb34ccc298b84acfb52e8e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

