### PR TITLE
fix disttae memory leak

### DIFF
--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -503,10 +503,12 @@ func (txn *Transaction) dumpBatchLocked(offset int) error {
 		}
 		blockInfos, stats, err := s3Writer.SortAndSync(txn.proc)
 		if err != nil {
+			s3Writer.Free(txn.proc)
 			return err
 		}
 		err = s3Writer.FillBlockInfoBat(blockInfos, stats, txn.proc.GetMPool())
 		if err != nil {
+			s3Writer.Free(txn.proc)
 			return err
 		}
 		blockInfo := s3Writer.GetBlockInfoBat()

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -483,6 +483,13 @@ func (txn *Transaction) dumpBatchLocked(offset int) error {
 			lastTxnWritesIndex++
 		}
 	}
+
+	for i := lastTxnWritesIndex; i < len(txn.writes); i++ {
+		if txn.writes[i].bat != nil {
+			txn.writes[i].bat.Clean(txn.proc.GetMPool())
+			txn.writes[i].bat = nil
+		}
+	}
 	txn.writes = txn.writes[:lastTxnWritesIndex]
 
 	for tbKey := range mp {
@@ -549,6 +556,12 @@ func (txn *Transaction) dumpBatchLocked(offset int) error {
 		txn.workspaceSize = 0
 		txn.pkCount -= pkCount
 		// modifies txn.writes.
+		for i := 0; i < len(txn.writes); i++ {
+			if txn.writes[i].bat != nil {
+				txn.writes[i].bat.Clean(txn.proc.GetMPool())
+				txn.writes[i].bat = nil
+			}
+		}
 		writes := txn.writes[:0]
 		for i, write := range txn.writes {
 			if write.bat != nil {

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -556,12 +556,6 @@ func (txn *Transaction) dumpBatchLocked(offset int) error {
 		txn.workspaceSize = 0
 		txn.pkCount -= pkCount
 		// modifies txn.writes.
-		for i := 0; i < len(txn.writes); i++ {
-			if txn.writes[i].bat != nil {
-				txn.writes[i].bat.Clean(txn.proc.GetMPool())
-				txn.writes[i].bat = nil
-			}
-		}
 		writes := txn.writes[:0]
 		for i, write := range txn.writes {
 			if write.bat != nil {

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -498,7 +498,6 @@ func (txn *Transaction) dumpBatchLocked(offset int) error {
 		if err != nil {
 			return err
 		}
-		defer s3Writer.Free(txn.proc)
 		for i := 0; i < len(mp[tbKey]); i++ {
 			s3Writer.StashBatch(txn.proc, mp[tbKey][i])
 		}
@@ -538,6 +537,7 @@ func (txn *Transaction) dumpBatchLocked(offset int) error {
 			blockInfo,
 			table.getTxn().tnStores[0],
 		)
+		s3Writer.Free(txn.proc)
 		if err != nil {
 			return err
 		}

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -276,6 +276,7 @@ func (db *txnDatabase) deleteTable(ctx context.Context, name string, forAlter bo
 			txn.tablesInVain[id] = txn.statementID
 			txn.Unlock()
 		}
+		bat.Clean(txn.proc.Mp())
 	}
 
 	{ // 3. delete rows from mo_columns
@@ -296,6 +297,7 @@ func (db *txnDatabase) deleteTable(ctx context.Context, name string, forAlter bo
 				return nil, err
 			}
 		}
+		bat.Clean(txn.proc.Mp())
 	}
 
 	// 4. handle map cache

--- a/pkg/vm/engine/disttae/txn_database.go
+++ b/pkg/vm/engine/disttae/txn_database.go
@@ -276,7 +276,6 @@ func (db *txnDatabase) deleteTable(ctx context.Context, name string, forAlter bo
 			txn.tablesInVain[id] = txn.statementID
 			txn.Unlock()
 		}
-		bat.Clean(txn.proc.Mp())
 	}
 
 	{ // 3. delete rows from mo_columns
@@ -297,7 +296,6 @@ func (db *txnDatabase) deleteTable(ctx context.Context, name string, forAlter bo
 				return nil, err
 			}
 		}
-		bat.Clean(txn.proc.Mp())
 	}
 
 	// 4. handle map cache


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18364

## What this PR does / why we need it:
fix disttae memory leak


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a memory leak in the `dumpBatchLocked` function by removing the deferred call to `s3Writer.Free` and adding an explicit call after the writer is used.
- Improved resource management in the `deleteTable` function by adding explicit calls to `bat.Clean` to ensure memory is freed after operations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>txn.go</strong><dd><code>Fix memory leak by managing S3Writer resource lifecycle</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/txn.go

<li>Removed deferred call to <code>s3Writer.Free</code> and added explicit call after <br>use.<br> <li> Ensured resources are freed immediately after writing files.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18497/files#diff-3b3158eacf342a1a2d00fa78724245821aa8bd8f08bb52e7e7acc76ec16e4744">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>txn_database.go</strong><dd><code>Ensure batch memory is cleaned after operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/txn_database.go

<li>Added explicit calls to <code>bat.Clean</code> to ensure memory is freed.<br> <li> Improved resource management in <code>deleteTable</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18497/files#diff-b601c249931141c71a36363da54e7072bbe6330d471fdafeaec001b7a23d529f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

