### PR TITLE
fix drop account error

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -4285,6 +4285,9 @@ func doDropAccount(ctx context.Context, ses *Session, da *dropAccount) (err erro
 		return err
 	}
 
+	if !hasAccount {
+		return err
+	}
 	// if drop the account, add the account to kill queue
 	ses.getRoutineManager().accountRoutine.EnKillQueue(accountId, version)
 
@@ -4298,6 +4301,9 @@ func doDropAccount(ctx context.Context, ses *Session, da *dropAccount) (err erro
 func postDropSuspendAccount(
 	ctx context.Context, ses *Session, accountName string, accountID int64, version uint64,
 ) (err error) {
+	if accountID == 0 {
+		return err
+	}
 	qc := getGlobalPu().QueryClient
 	if qc == nil {
 		return moerr.NewInternalError(ctx, "query client is not initialized")

--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -94,7 +94,6 @@ func (ar *AccountRoutineManager) deleteRoutine(tenantID int64, rt *Routine) {
 
 	ar.accountRoutineMu.Lock()
 	defer ar.accountRoutineMu.Unlock()
-	logutil.Infof("[delete account] delete account id %d, connection id %d from account routine map", tenantID, rt.getConnectionID())
 	_, ok := ar.accountId2Routine[tenantID]
 	if ok {
 		delete(ar.accountId2Routine[tenantID], rt)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18499 #18475

## What this PR does / why we need it:
fix drop account error
drop account if not exists will post drop sys account request and add sys account to kill queue


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in `doDropAccount` by adding a check to return an error if the account does not exist.
- Added a condition in `postDropSuspendAccount` to return an error if the account ID is zero.
- Removed unnecessary logging in `deleteRoutine` method of `AccountRoutineManager`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authenticate.go</strong><dd><code>Add error checks in account drop logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/authenticate.go

<li>Added a check to return error if account does not exist.<br> <li> Added a check to return error if account ID is zero.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18500/files#diff-849f201c351210bd95807e99d1538e2602a5244b256c35e58467afe304c509e6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>routine_manager.go</strong><dd><code>Remove logging for account deletion routine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/routine_manager.go

- Removed logging statement for account deletion.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18500/files#diff-511d6a4e67914d6a32b75c81d76cf23e8d6d255822eb34ccc298b84acfb52e8e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

