### PR TITLE
fileservice: also acquire semaphore in List and Write

### DIFF
--- a/pkg/fileservice/object_storage_semaphore.go
+++ b/pkg/fileservice/object_storage_semaphore.go
@@ -58,7 +58,8 @@ func (o *objectStorageSemaphore) Exists(ctx context.Context, key string) (bool, 
 }
 
 func (o *objectStorageSemaphore) List(ctx context.Context, prefix string, fn func(isPrefix bool, key string, size int64) (bool, error)) (err error) {
-	// this operation may block for a long time, and less used, skip semaphore
+	o.acquire()
+	defer o.release()
 	return o.upstream.List(ctx, prefix, fn)
 }
 
@@ -89,6 +90,7 @@ func (o *objectStorageSemaphore) Stat(ctx context.Context, key string) (size int
 }
 
 func (o *objectStorageSemaphore) Write(ctx context.Context, key string, r io.Reader, size int64, expire *time.Time) (err error) {
-	// this operation may block for a long time, and less used, skip semaphore
+	o.acquire()
+	defer o.release()
 	return o.upstream.Write(ctx, key, r, size, expire)
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17001 #17793 

## What this PR does / why we need it:
acquire semaphore when doing List and Write to limit concurrent connections


___

### **PR Type**
Bug fix


___

### **Description**
- Added semaphore acquisition and release in the `List` method to limit concurrent connections and prevent potential blocking issues.
- Added semaphore acquisition and release in the `Write` method to ensure consistent handling of concurrent operations.
- These changes address issues #17001 and #17793 by ensuring that semaphore control is applied to operations that may block for a long time.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>object_storage_semaphore.go</strong><dd><code>Add semaphore control to List and Write methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/object_storage_semaphore.go

<li>Added semaphore acquisition and release in <code>List</code> method.<br> <li> Added semaphore acquisition and release in <code>Write</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18522/files#diff-9c6b3f0761f2f6f358bc1c375ef9956e34a6d77b56ed9bb925d59e3c8088570b">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

