### PR TITLE
adding flag to block info and object info

### DIFF
--- a/pkg/objectio/block.go
+++ b/pkg/objectio/block.go
@@ -148,10 +148,13 @@ func (bm BlockObject) GenerateBlockInfo(objName ObjectName, sorted bool) BlockIn
 			&sid,
 			location.Name().Num(),
 			location.ID()),
-		//non-appendable block
-		Appendable: false,
-		Sorted:     sorted,
 	}
 	blkInfo.SetMetaLocation(location)
+
+	blkInfo.StateFlag |= CNCreatedFlag
+	if sorted {
+		blkInfo.StateFlag |= SortedFlag
+	}
+
 	return blkInfo
 }

--- a/pkg/objectio/block_info.go
+++ b/pkg/objectio/block_info.go
@@ -55,19 +55,48 @@ const (
 )
 
 type BlockInfo struct {
-	BlockID types.Blockid
-	//It's used to indicate whether the block is appendable block or non-appendable blk for reader.
-	// for appendable block, the data visibility in the block is determined by the commit ts and abort ts.
-	Appendable bool
-	Sorted     bool
-	MetaLoc    ObjectLocation
+	BlockID   types.Blockid
+	MetaLoc   ObjectLocation
+	StateFlag int8
 
 	//TODO:: remove it.
 	PartitionNum int16
 }
 
+func (b *BlockInfo) SetFlagByObjStats(stats ObjectStats) {
+	b.StateFlag = stats.GetFlag()
+}
+
+func (b *BlockInfo) IsAppendable() bool {
+	return b.StateFlag&AppendableFlag != 0
+}
+
+func (b *BlockInfo) IsSorted() bool {
+	return b.StateFlag&SortedFlag != 0
+}
+
+func (b *BlockInfo) IsCNCreated() bool {
+	return b.StateFlag&CNCreatedFlag != 0
+}
+
 func (b *BlockInfo) String() string {
-	return fmt.Sprintf("[A-%v]blk-%s", b.Appendable, b.BlockID.ShortStringEx())
+	flag := ""
+	if b.IsAppendable() {
+		flag = flag + "A"
+	}
+	if b.IsSorted() {
+		flag = flag + "S"
+	}
+	if b.IsCNCreated() {
+		flag = flag + "C"
+	}
+
+	return fmt.Sprintf(
+		"[%s]ID-%s, MetaLoc: %s, PartitionNum: %d",
+		flag,
+		b.BlockID.ShortStringEx(),
+		b.MetaLocation().String(),
+		b.PartitionNum)
 }
 
 func (b *BlockInfo) MarshalWithBuf(w *bytes.Buffer) (uint32, error) {
@@ -77,20 +106,15 @@ func (b *BlockInfo) MarshalWithBuf(w *bytes.Buffer) (uint32, error) {
 	}
 	space += uint32(types.BlockidSize)
 
-	if _, err := w.Write(types.EncodeBool(&b.Appendable)); err != nil {
-		return 0, err
-	}
-	space++
-
-	if _, err := w.Write(types.EncodeBool(&b.Sorted)); err != nil {
-		return 0, err
-	}
-	space++
-
 	if _, err := w.Write(types.EncodeSlice(b.MetaLoc[:])); err != nil {
 		return 0, err
 	}
 	space += uint32(LocationLen)
+
+	if _, err := w.Write(types.EncodeInt8(&b.StateFlag)); err != nil {
+		return 0, err
+	}
+	space++
 
 	if _, err := w.Write(types.EncodeInt16(&b.PartitionNum)); err != nil {
 		return 0, err
@@ -103,13 +127,12 @@ func (b *BlockInfo) MarshalWithBuf(w *bytes.Buffer) (uint32, error) {
 func (b *BlockInfo) Unmarshal(buf []byte) error {
 	b.BlockID = types.DecodeFixed[types.Blockid](buf[:types.BlockidSize])
 	buf = buf[types.BlockidSize:]
-	b.Appendable = types.DecodeFixed[bool](buf)
-	buf = buf[1:]
-	b.Sorted = types.DecodeFixed[bool](buf)
-	buf = buf[1:]
 
 	copy(b.MetaLoc[:], buf[:LocationLen])
 	buf = buf[LocationLen:]
+
+	b.StateFlag = types.DecodeInt8(buf[:1])
+	buf = buf[1:]
 
 	b.PartitionNum = types.DecodeFixed[int16](buf[:2])
 	return nil

--- a/pkg/objectio/block_info_test.go
+++ b/pkg/objectio/block_info_test.go
@@ -82,18 +82,21 @@ func TestBlockInfoSliceTraverse(t *testing.T) {
 	for i := 0; i < s.Len(); i++ {
 		blkInfo := s.Get(i)
 		require.Equal(t, intToBlockid(int32(i)), blkInfo.BlockID)
-		require.Equal(t, false, blkInfo.Appendable)
-		blkInfo.Appendable = true
+		require.Equal(t, false, blkInfo.IsAppendable())
+		blkInfo.StateFlag |= AppendableFlag
 	}
 
 	for i := 0; i < s.Len(); i++ {
-		require.Equal(t, true, s.Get(i).Appendable)
+		require.Equal(t, true, s.Get(i).IsAppendable())
 	}
 
-	s.AppendBlockInfo(BlockInfo{BlockID: intToBlockid(1000), Appendable: true})
+	blk := BlockInfo{BlockID: intToBlockid(1000)}
+	blk.StateFlag |= AppendableFlag
+
+	s.AppendBlockInfo(blk)
 
 	for i := 0; i < s.Len(); i++ {
-		require.Equal(t, true, s.Get(i).Appendable)
+		require.Equal(t, true, s.Get(i).IsAppendable())
 	}
 }
 
@@ -109,14 +112,16 @@ func TestBytesToBlockInfoSlice(t *testing.T) {
 	for i := 0; i < s.Len(); i++ {
 		blkInfo := s.Get(i)
 		require.Equal(t, intToBlockid(int32(i)), blkInfo.BlockID)
-		require.Equal(t, false, blkInfo.Appendable)
-		blkInfo.Appendable = true
+		require.Equal(t, false, blkInfo.IsAppendable())
+		blkInfo.StateFlag |= AppendableFlag
 	}
 
-	s.AppendBlockInfo(BlockInfo{BlockID: intToBlockid(1000), Appendable: true})
+	blk := BlockInfo{BlockID: intToBlockid(1000)}
+	blk.StateFlag |= AppendableFlag
+	s.AppendBlockInfo(blk)
 
 	for i := 0; i < s.Len(); i++ {
-		require.Equal(t, true, s.Get(i).Appendable)
+		require.Equal(t, true, s.Get(i).IsAppendable())
 	}
 
 	require.Equal(t, 1000*BlockInfoSize, len(bs))
@@ -125,10 +130,10 @@ func TestBytesToBlockInfoSlice(t *testing.T) {
 	require.Equal(t, 1001*BlockInfoSize, len(bs))
 	require.Equal(t, s.GetAllBytes(), bs)
 
-	s.Get(999).Appendable = false
-	require.Equal(t, false, s.Get(999).Appendable)
+	s.Get(999).StateFlag &= ^AppendableFlag
+	require.Equal(t, false, s.Get(999).IsAppendable())
 	blkInfo := DecodeBlockInfo(bs[999*BlockInfoSize:])
-	require.Equal(t, false, blkInfo.Appendable)
+	require.Equal(t, false, blkInfo.IsAppendable())
 }
 
 func TestBlockInfoSlice_Slice(t *testing.T) {

--- a/pkg/objectio/object_stats.go
+++ b/pkg/objectio/object_stats.go
@@ -60,6 +60,14 @@ type ObjectStats [ObjectStatsLen]byte
 
 type ObjectStatsOptions func(*ObjectStats)
 
+func WithFlags(flags ...int) ObjectStatsOptions {
+	return func(o *ObjectStats) {
+		for _, f := range flags {
+			o[reservedOffset] |= byte(f)
+		}
+	}
+}
+
 func WithCNCreated() ObjectStatsOptions {
 	return func(o *ObjectStats) {
 		o[reservedOffset] |= CNCreatedFlag

--- a/pkg/objectio/object_stats.go
+++ b/pkg/objectio/object_stats.go
@@ -23,7 +23,7 @@ import (
 )
 
 type ObjectDescriber interface {
-	DescribeObject() ([]ObjectStats, error)
+	DescribeObject() (ObjectStats, error)
 }
 
 const (
@@ -44,6 +44,12 @@ const (
 	ObjectStatsLen         = reservedOffset + reservedLen
 )
 
+const (
+	AppendableFlag = 0x1
+	SortedFlag     = 0x2
+	CNCreatedFlag  = 0x4
+)
+
 var ZeroObjectStats ObjectStats
 
 // ObjectStats has format:
@@ -51,6 +57,26 @@ var ZeroObjectStats ObjectStats
 // |object_name(60B)|extent(13B)|row_cnt(4B)|block_cnt(4B)|zone_map(64B)|objectSize|objectOriginSize|reserved|
 // +------------------------------------------------------------------------------------------------+--------+
 type ObjectStats [ObjectStatsLen]byte
+
+type ObjectStatsOptions func(*ObjectStats)
+
+func WithCNCreated() ObjectStatsOptions {
+	return func(o *ObjectStats) {
+		o[reservedOffset] |= CNCreatedFlag
+	}
+}
+
+func WithSorted() ObjectStatsOptions {
+	return func(o *ObjectStats) {
+		o[reservedOffset] |= SortedFlag
+	}
+}
+
+func WithAppendable() ObjectStatsOptions {
+	return func(o *ObjectStats) {
+		o[reservedOffset] |= AppendableFlag
+	}
+}
 
 func NewObjectStats() *ObjectStats {
 	return new(ObjectStats)
@@ -60,14 +86,17 @@ func NewObjectStatsWithObjectID(id *ObjectId, appendable, sorted, cnCreated bool
 	stats := new(ObjectStats)
 	SetObjectStatsObjectName(stats, BuildObjectNameWithObjectID(id))
 	if appendable {
-		stats.setAppendable()
+		stats[reservedOffset] = stats[reservedOffset] | AppendableFlag
 	}
+
 	if sorted {
-		stats.SetSorted()
+		stats[reservedOffset] = stats[reservedOffset] | SortedFlag
 	}
+
 	if cnCreated {
-		stats.SetCNCreated()
+		stats[reservedOffset] = stats[reservedOffset] | CNCreatedFlag
 	}
+
 	return stats
 }
 func (des *ObjectStats) Marshal() []byte {
@@ -78,29 +107,27 @@ func (des *ObjectStats) UnMarshal(data []byte) {
 	copy(des[:], data)
 }
 
+func (des *ObjectStats) GetFlag() int8 {
+	return int8(des[reservedOffset])
+}
+
 // Clone deep copies the stats and returns its pointer
 func (des *ObjectStats) Clone() *ObjectStats {
 	copied := NewObjectStats()
 	copy(copied[:], des[:])
 	return copied
 }
-func (des *ObjectStats) setAppendable() {
-	des[reservedOffset] = des[reservedOffset] | 0x1
-}
+
 func (des *ObjectStats) GetAppendable() bool {
-	return des[reservedOffset]&0x1 != 0
+	return des[reservedOffset]&AppendableFlag != 0
 }
-func (des *ObjectStats) SetSorted() {
-	des[reservedOffset] = des[reservedOffset] | 0x2
-}
+
 func (des *ObjectStats) GetSorted() bool {
-	return des[reservedOffset]&0x2 != 0
+	return des[reservedOffset]&SortedFlag != 0
 }
-func (des *ObjectStats) SetCNCreated() {
-	des[reservedOffset] = des[reservedOffset] | 0x4
-}
+
 func (des *ObjectStats) GetCNCreated() bool {
-	return des[reservedOffset]&0x4 != 0
+	return des[reservedOffset]&CNCreatedFlag != 0
 }
 func (des *ObjectStats) IsZero() bool {
 	return bytes.Equal(des[:], ZeroObjectStats[:])

--- a/pkg/objectio/object_stats.go
+++ b/pkg/objectio/object_stats.go
@@ -60,14 +60,6 @@ type ObjectStats [ObjectStatsLen]byte
 
 type ObjectStatsOptions func(*ObjectStats)
 
-func WithFlags(flags ...int) ObjectStatsOptions {
-	return func(o *ObjectStats) {
-		for _, f := range flags {
-			o[reservedOffset] |= byte(f)
-		}
-	}
-}
-
 func WithCNCreated() ObjectStatsOptions {
 	return func(o *ObjectStats) {
 		o[reservedOffset] |= CNCreatedFlag

--- a/pkg/objectio/object_stats_test.go
+++ b/pkg/objectio/object_stats_test.go
@@ -96,3 +96,20 @@ func TestObjectStats_Marshal_UnMarshal(t *testing.T) {
 	require.True(t, bytes.Equal(stats.Marshal(), rawBytes))
 	fmt.Println(stats.String())
 }
+
+func TestObjectStatsOptions(t *testing.T) {
+	stats := NewObjectStats()
+	require.True(t, stats.IsZero())
+	require.False(t, stats.GetAppendable())
+	require.False(t, stats.GetCNCreated())
+	require.False(t, stats.GetSorted())
+
+	WithCNCreated()(stats)
+	require.True(t, stats.GetCNCreated())
+
+	WithSorted()(stats)
+	require.True(t, stats.GetSorted())
+
+	WithAppendable()(stats)
+	require.True(t, stats.GetAppendable())
+}

--- a/pkg/objectio/writer.go
+++ b/pkg/objectio/writer.go
@@ -48,7 +48,7 @@ type objectWriterV1 struct {
 	name              ObjectName
 	compressBuf       []byte
 	bloomFilter       []byte
-	objStats          []ObjectStats
+	objStats          ObjectStats
 	sortKeySeqnum     uint16
 	appendable        bool
 	originSize        uint32
@@ -132,8 +132,14 @@ func newObjectWriterV1(name ObjectName, fs fileservice.FileService, schemaVersio
 	return writer, nil
 }
 
-func (w *objectWriterV1) GetObjectStats() []ObjectStats {
-	return w.objStats
+func (w *objectWriterV1) GetObjectStats(opts ...ObjectStatsOptions) (copied ObjectStats) {
+	copied = w.objStats
+
+	for _, opt := range opts {
+		opt(&copied)
+	}
+
+	return copied
 }
 
 func describeObjectHelper(w *objectWriterV1, colmeta []ColumnMeta, idx DataMetaType) ObjectStats {
@@ -163,14 +169,18 @@ func describeObjectHelper(w *objectWriterV1, colmeta []ColumnMeta, idx DataMetaT
 // if an object only has deletes, only the tombstone object stats valid.
 //
 // if an object has both inserts and deletes, both stats are valid.
-func (w *objectWriterV1) DescribeObject() ([]ObjectStats, error) {
-	stats := make([]ObjectStats, 2)
+func (w *objectWriterV1) DescribeObject() (ObjectStats, error) {
+	var stats ObjectStats
+
 	if len(w.blocks[SchemaData]) != 0 {
-		stats[SchemaData] = describeObjectHelper(w, w.colmeta, SchemaData)
+		stats = describeObjectHelper(w, w.colmeta, SchemaData)
 	}
 
 	if len(w.blocks[SchemaTombstone]) != 0 {
-		stats[SchemaTombstone] = describeObjectHelper(w, w.tombstonesColmeta, SchemaTombstone)
+		if !stats.IsZero() {
+			panic("schema data and schema tombstone should not all be valid at the same time")
+		}
+		stats = describeObjectHelper(w, w.tombstonesColmeta, SchemaTombstone)
 	}
 
 	return stats, nil
@@ -611,7 +621,7 @@ func (w *objectWriterV1) Sync(ctx context.Context, items ...WriteOptions) error 
 }
 
 func (w *objectWriterV1) GetDataStats() ObjectStats {
-	return w.objStats[SchemaData]
+	return w.objStats
 }
 
 func (w *objectWriterV1) WriteWithCompress(offset uint32, buf []byte) (data []byte, extent Extent, err error) {

--- a/pkg/objectio/writer_test.go
+++ b/pkg/objectio/writer_test.go
@@ -105,7 +105,7 @@ func TestNewObjectWriter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(blocks))
 	assert.Nil(t, objectWriter.buffer)
-	require.Equal(t, objectWriter.objStats[0].Size(), blocks[0].GetExtent().End()+FooterSize)
+	require.Equal(t, objectWriter.objStats.Size(), blocks[0].GetExtent().End()+FooterSize)
 
 	objectReader, _ := NewObjectReaderWithStr(name, service)
 	extents := make([]Extent, 3)
@@ -130,7 +130,7 @@ func TestNewObjectWriter(t *testing.T) {
 	oSize += meta.BlockHeader().ZoneMapArea().OriginSize()
 	// 24 is the size of empty bf and zm
 	oSize += HeaderSize + FooterSize + 24 + extents[0].OriginSize()
-	require.Equal(t, objectWriter.objStats[0].OriginSize(), oSize)
+	require.Equal(t, objectWriter.objStats.OriginSize(), oSize)
 	assert.Equal(t, uint32(3), meta.BlockCount())
 	assert.True(t, meta.BlockHeader().Appendable())
 	assert.Equal(t, uint16(math.MaxUint16), meta.BlockHeader().SortKey())

--- a/pkg/sql/colexec/mergeblock/mergeblock_test.go
+++ b/pkg/sql/colexec/mergeblock/mergeblock_test.go
@@ -63,7 +63,7 @@ func TestMergeBlock(t *testing.T) {
 			loc1.Name().Num(),
 			loc1.ID()),
 		//non-appendable block
-		Appendable: false,
+		//Appendable: false,
 	}
 	blkInfo1.SetMetaLocation(loc1)
 
@@ -74,7 +74,7 @@ func TestMergeBlock(t *testing.T) {
 			loc2.Name().Num(),
 			loc2.ID()),
 		//non-appendable block
-		Appendable: false,
+		//Appendable: false,
 	}
 	blkInfo2.SetMetaLocation(loc2)
 
@@ -85,7 +85,7 @@ func TestMergeBlock(t *testing.T) {
 			loc3.Name().Num(),
 			loc3.ID()),
 		//non-appendable block
-		Appendable: false,
+		//Appendable: false,
 	}
 	blkInfo3.SetMetaLocation(loc3)
 

--- a/pkg/sql/colexec/s3util.go
+++ b/pkg/sql/colexec/s3util.go
@@ -547,23 +547,12 @@ func (w *S3Writer) sync(proc *process.Process) ([]objectio.BlockInfo, objectio.O
 		)
 	}
 
-	opts := []objectio.ObjectStatsOptions{
-		objectio.WithCNCreated(),
-	}
-
-	if w.sortIndex != -1 {
-		opts = append(opts, objectio.WithSorted())
-	}
-
 	var stats objectio.ObjectStats
 	if w.sortIndex != -1 {
-		stats = w.writer.GetObjectStats(
-			objectio.WithFlags(
-				objectio.CNCreatedFlag,
-				objectio.SortedFlag))
+		stats = w.writer.GetObjectStats(objectio.WithCNCreated(), objectio.WithSorted())
 	} else {
 		stats = w.writer.GetObjectStats(objectio.WithCNCreated())
 	}
-	
+
 	return blkInfos, stats, err
 }

--- a/pkg/sql/colexec/s3util.go
+++ b/pkg/sql/colexec/s3util.go
@@ -547,18 +547,15 @@ func (w *S3Writer) sync(proc *process.Process) ([]objectio.BlockInfo, objectio.O
 		)
 	}
 
-	stats := w.writer.GetObjectStats()
-
-	var i = -1
-	for i = range stats {
-		if !stats[i].IsZero() {
-			stats[i].SetCNCreated()
-			if w.sortIndex != -1 {
-				stats[i].SetSorted()
-			}
-			break
-		}
+	opts := []objectio.ObjectStatsOptions{
+		objectio.WithCNCreated(),
 	}
 
-	return blkInfos, stats[i], err
+	if w.sortIndex != -1 {
+		opts = append(opts, objectio.WithSorted())
+	}
+
+	stats := w.writer.GetObjectStats(opts...)
+
+	return blkInfos, stats, err
 }

--- a/pkg/sql/colexec/s3util.go
+++ b/pkg/sql/colexec/s3util.go
@@ -555,7 +555,15 @@ func (w *S3Writer) sync(proc *process.Process) ([]objectio.BlockInfo, objectio.O
 		opts = append(opts, objectio.WithSorted())
 	}
 
-	stats := w.writer.GetObjectStats(opts...)
-
+	var stats objectio.ObjectStats
+	if w.sortIndex != -1 {
+		stats = w.writer.GetObjectStats(
+			objectio.WithFlags(
+				objectio.CNCreatedFlag,
+				objectio.SortedFlag))
+	} else {
+		stats = w.writer.GetObjectStats(objectio.WithCNCreated())
+	}
+	
 	return blkInfos, stats, err
 }

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -3856,7 +3856,7 @@ func (c *Compile) generateNodes(n *plan.Node) (engine.Nodes, []any, []types.T, e
 					ctx, blk.BlockID, fs,
 				); err2 != nil {
 					return false, err2
-				} else if blk.Appendable || hasTombstone {
+				} else if blk.IsAppendable() || hasTombstone {
 					newRelData.AppendBlockInfo(blk)
 					return true, nil
 				}

--- a/pkg/vm/engine/disttae/datasource.go
+++ b/pkg/vm/engine/disttae/datasource.go
@@ -210,7 +210,6 @@ func (rs *RemoteDataSource) applyPersistedTombstones(
 func (rs *RemoteDataSource) ApplyTombstones(
 	ctx context.Context,
 	bid objectio.Blockid,
-	byCN bool,
 	rowsOffset []int64,
 	applyPolicy engine.TombstoneApplyPolicy,
 ) (left []int64, err error) {
@@ -229,7 +228,7 @@ func (rs *RemoteDataSource) ApplyTombstones(
 }
 
 func (rs *RemoteDataSource) GetTombstones(
-	ctx context.Context, bid objectio.Blockid, byCN bool,
+	ctx context.Context, bid objectio.Blockid,
 ) (mask *nulls.Nulls, err error) {
 
 	mask = &nulls.Nulls{}
@@ -609,7 +608,7 @@ func (ls *LocalDataSource) filterInMemUnCommittedInserts(
 
 		b, _ := retainedRowIds[0].Decode()
 		sels, err := ls.ApplyTombstones(
-			ls.ctx, b, false, offsets, engine.Policy_CheckUnCommittedOnly)
+			ls.ctx, b, offsets, engine.Policy_CheckUnCommittedOnly)
 		if err != nil {
 			return err
 		}
@@ -709,7 +708,7 @@ func (ls *LocalDataSource) filterInMemCommittedInserts(
 			//	minTS = entry.Time
 			//}
 
-			sel, err = ls.ApplyTombstones(ls.ctx, b, false, []int64{int64(o)}, applyPolicy)
+			sel, err = ls.ApplyTombstones(ls.ctx, b, []int64{int64(o)}, applyPolicy)
 			if err != nil {
 				return err
 			}
@@ -779,7 +778,6 @@ func (ls *LocalDataSource) filterInMemCommittedInserts(
 func (ls *LocalDataSource) ApplyTombstones(
 	ctx context.Context,
 	bid objectio.Blockid,
-	byCN bool,
 	rowsOffset []int64,
 	dynamicPolicy engine.TombstoneApplyPolicy,
 ) ([]int64, error) {
@@ -838,7 +836,7 @@ func (ls *LocalDataSource) ApplyTombstones(
 }
 
 func (ls *LocalDataSource) GetTombstones(
-	ctx context.Context, bid objectio.Blockid, byCN bool,
+	ctx context.Context, bid objectio.Blockid,
 ) (deletedRows *nulls.Nulls, err error) {
 
 	deletedRows = &nulls.Nulls{}

--- a/pkg/vm/engine/disttae/datasource_test.go
+++ b/pkg/vm/engine/disttae/datasource_test.go
@@ -240,11 +240,10 @@ func TestRelationDataV2_MarshalAndUnMarshal(t *testing.T) {
 		blkID := types.NewBlockidWithObjectID(&objID, uint16(blkNum))
 		blkInfo := objectio.BlockInfo{
 			BlockID:      *blkID,
-			Appendable:   true,
-			Sorted:       false,
 			MetaLoc:      metaLoc,
 			PartitionNum: int16(i),
 		}
+		blkInfo.StateFlag |= objectio.AppendableFlag
 		relData.AppendBlockInfo(blkInfo)
 	}
 

--- a/pkg/vm/engine/disttae/logtailreplay/change_handle.go
+++ b/pkg/vm/engine/disttae/logtailreplay/change_handle.go
@@ -402,7 +402,7 @@ func sortBatch(bat *batch.Batch, sortIdx int, mp *mpool.MPool) error {
 }
 
 func checkObjectEntry(entry *ObjectEntry, start, end types.TS) bool {
-	if entry.Appendable {
+	if entry.GetAppendable() {
 		if entry.CreateTime.Greater(&end) {
 			return false
 		}

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -139,10 +139,8 @@ func (p *PartitionState) HandleDataObjectList(
 			continue
 		}
 
-		objEntry.Appendable = objEntry.ObjectStats.GetAppendable()
 		objEntry.CreateTime = createTSCol[idx]
 		objEntry.DeleteTime = deleteTSCol[idx]
-		objEntry.Sorted = objEntry.ObjectStats.GetSorted()
 
 		old, exist := p.dataObjects.Get(objEntry)
 		if exist {
@@ -163,7 +161,7 @@ func (p *PartitionState) HandleDataObjectList(
 				Time:         createTSCol[idx],
 				ShortObjName: *objEntry.ObjectShortName(),
 				IsDelete:     false,
-				IsAppendable: objEntry.Appendable,
+				IsAppendable: objEntry.GetAppendable(),
 			}
 			p.objectIndexByTS.Set(e)
 		}
@@ -176,12 +174,12 @@ func (p *PartitionState) HandleDataObjectList(
 				Time:         deleteTSCol[idx],
 				IsDelete:     true,
 				ShortObjName: *objEntry.ObjectShortName(),
-				IsAppendable: objEntry.Appendable,
+				IsAppendable: objEntry.GetAppendable(),
 			}
 			p.objectIndexByTS.Set(e)
 		}
 
-		if objEntry.Appendable && objEntry.DeleteTime.IsEmpty() {
+		if objEntry.GetAppendable() && objEntry.DeleteTime.IsEmpty() {
 			panic("logic error")
 		}
 
@@ -211,7 +209,7 @@ func (p *PartitionState) HandleDataObjectList(
 				// if the inserting block is appendable, need to delete the rows for it;
 				// if the inserting block is non-appendable and has delta location, need to delete
 				// the deletes for it.
-				if objEntry.Appendable {
+				if objEntry.GetAppendable() {
 					if entry.Time.LessEq(&trunctPoint) {
 						// delete the row
 						p.rows.Delete(entry)
@@ -297,10 +295,8 @@ func (p *PartitionState) HandleTombstoneObjectList(
 			continue
 		}
 
-		objEntry.Appendable = objEntry.ObjectStats.GetAppendable()
 		objEntry.CreateTime = createTSCol[idx]
 		objEntry.DeleteTime = deleteTSCol[idx]
-		objEntry.Sorted = objEntry.ObjectStats.GetSorted()
 
 		old, exist := p.tombstoneObjects.Get(objEntry)
 		if exist {
@@ -320,12 +316,12 @@ func (p *PartitionState) HandleTombstoneObjectList(
 
 		p.tombstoneObjects.Set(objEntry)
 
-		if objEntry.Appendable && objEntry.DeleteTime.IsEmpty() {
+		if objEntry.GetAppendable() && objEntry.DeleteTime.IsEmpty() {
 			panic("logic error")
 		}
 
 		// for appendable object, gc rows when delete object
-		if !objEntry.Appendable {
+		if !objEntry.GetAppendable() {
 			continue
 		}
 

--- a/pkg/vm/engine/disttae/logtailreplay/types.go
+++ b/pkg/vm/engine/disttae/logtailreplay/types.go
@@ -26,9 +26,6 @@ import (
 
 type ObjectInfo struct {
 	objectio.ObjectStats
-
-	Appendable bool
-	Sorted     bool
 	CreateTime types.TS
 	DeleteTime types.TS
 }
@@ -36,8 +33,11 @@ type ObjectInfo struct {
 func (o ObjectInfo) String() string {
 	return fmt.Sprintf(
 		"%s; appendable: %v; sorted: %v; createTS: %s; deleteTS: %s",
-		o.ObjectStats.String(), o.Appendable, o.Sorted,
-		o.CreateTime.ToString(), o.DeleteTime.ToString())
+		o.ObjectStats.String(),
+		o.ObjectStats.GetAppendable(),
+		o.ObjectStats.GetSorted(),
+		o.CreateTime.ToString(),
+		o.DeleteTime.ToString())
 }
 
 func (o ObjectInfo) Location() objectio.Location {

--- a/pkg/vm/engine/disttae/merge.go
+++ b/pkg/vm/engine/disttae/merge.go
@@ -183,8 +183,7 @@ func (t *cnMergeTask) LoadNextBatch(ctx context.Context, objIdx uint32) (*batch.
 		blk := iter.Entry()
 		// update delta location
 		obj := t.targets[objIdx]
-		blk.Sorted = obj.Sorted
-		blk.Appendable = obj.Appendable
+		blk.SetFlagByObjStats(obj.ObjectStats)
 		return t.readblock(ctx, &blk)
 	}
 	return nil, nil, nil, mergesort.ErrNoMoreBlocks

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -397,7 +397,7 @@ func (r *reader) Read(
 
 	bat.SetAttributes(cols)
 
-	if blkInfo.Sorted && r.columns.indexOfFirstSortedColumn != -1 {
+	if blkInfo.IsSorted() && r.columns.indexOfFirstSortedColumn != -1 {
 		bat.GetVector(int32(r.columns.indexOfFirstSortedColumn)).SetSorted(true)
 	}
 

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -815,8 +815,7 @@ func (tbl *txnTable) rangesOnePart(
 					}
 				}
 
-				blk.Sorted = obj.Sorted
-				blk.Appendable = obj.Appendable
+				blk.SetFlagByObjStats(obj.ObjectStats)
 
 				outBlocks.AppendBlockInfo(blk)
 
@@ -1890,8 +1889,8 @@ func (tbl *txnTable) PKPersistedBetween(
 						}
 					}
 
-					blk.Sorted = obj.Sorted
-					blk.Appendable = obj.Appendable
+					blk.SetFlagByObjStats(obj.ObjectStats)
+
 					blk.PartitionNum = -1
 					candidateBlks[blk.BlockID] = &blk
 					return true
@@ -1952,7 +1951,7 @@ func (tbl *txnTable) PKPersistedBetween(
 		}
 		defer release()
 
-		if !blk.Sorted {
+		if !blk.IsSorted() {
 			if unsortedFilter == nil {
 				unsortedFilter = buildUnsortedFilter()
 			}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2094,7 +2094,7 @@ func (tbl *txnTable) GetNonAppendableObjectStats(ctx context.Context) ([]objecti
 	objStats := make([]objectio.ObjectStats, 0, tbl.ApproxObjectsNum(ctx))
 
 	err = ForeachVisibleDataObject(state, snapshot, func(obj logtailreplay.ObjectEntry) error {
-		if obj.Appendable {
+		if obj.GetAppendable() {
 			return nil
 		}
 		if sortKeyPos != -1 {

--- a/pkg/vm/engine/engine_util/exec_util.go
+++ b/pkg/vm/engine/engine_util/exec_util.go
@@ -163,8 +163,7 @@ func FilterObjects(
 				MetaLoc: objectio.ObjectLocation(loc),
 			}
 
-			blk.Sorted = objStats.GetSorted()
-			blk.Appendable = objStats.GetAppendable()
+			blk.SetFlagByObjStats(objStats)
 			outBlocks.AppendBlockInfo(blk)
 		}
 

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -83,7 +83,7 @@ func ReadDataByFilter(
 	if len(sels) == 0 {
 		return
 	}
-	sels, err = ds.ApplyTombstones(ctx, info.BlockID, info.IsCNCreated(), sels, engine.Policy_CheckAll)
+	sels, err = ds.ApplyTombstones(ctx, info.BlockID, sels, engine.Policy_CheckAll)
 	return
 }
 
@@ -126,7 +126,7 @@ func BlockDataReadNoCopy(
 	); err != nil {
 		return nil, nil, nil, err
 	}
-	tombstones, err := ds.GetTombstones(ctx, info.BlockID, info.IsCNCreated())
+	tombstones, err := ds.GetTombstones(ctx, info.BlockID)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -301,7 +301,7 @@ func BlockDataReadBackup(
 			}
 		}
 	}
-	tombstones, err := ds.GetTombstones(ctx, info.BlockID, info.IsCNCreated())
+	tombstones, err := ds.GetTombstones(ctx, info.BlockID)
 	if err != nil {
 		return
 	}
@@ -381,7 +381,7 @@ func BlockDataReadInner(
 		return
 	}
 
-	tombstones, err := ds.GetTombstones(ctx, info.BlockID, info.IsCNCreated())
+	tombstones, err := ds.GetTombstones(ctx, info.BlockID)
 	if err != nil {
 		return
 	}

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -83,7 +83,7 @@ func ReadDataByFilter(
 	if len(sels) == 0 {
 		return
 	}
-	sels, err = ds.ApplyTombstones(ctx, info.BlockID, sels, engine.Policy_CheckAll)
+	sels, err = ds.ApplyTombstones(ctx, info.BlockID, info.IsCNCreated(), sels, engine.Policy_CheckAll)
 	return
 }
 
@@ -126,7 +126,7 @@ func BlockDataReadNoCopy(
 	); err != nil {
 		return nil, nil, nil, err
 	}
-	tombstones, err := ds.GetTombstones(ctx, info.BlockID)
+	tombstones, err := ds.GetTombstones(ctx, info.BlockID, info.IsCNCreated())
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -179,9 +179,9 @@ func BlockDataRead(
 	)
 
 	var searchFunc objectio.ReadFilterSearchFuncType
-	if (filter.HasFakePK || !info.Sorted) && filter.UnSortedSearchFunc != nil {
+	if (filter.HasFakePK || !info.IsSorted()) && filter.UnSortedSearchFunc != nil {
 		searchFunc = filter.UnSortedSearchFunc
-	} else if info.Sorted && filter.SortedSearchFunc != nil {
+	} else if info.IsSorted() && filter.SortedSearchFunc != nil {
 		searchFunc = filter.SortedSearchFunc
 	}
 
@@ -301,7 +301,7 @@ func BlockDataReadBackup(
 			}
 		}
 	}
-	tombstones, err := ds.GetTombstones(ctx, info.BlockID)
+	tombstones, err := ds.GetTombstones(ctx, info.BlockID, info.IsCNCreated())
 	if err != nil {
 		return
 	}
@@ -381,7 +381,7 @@ func BlockDataReadInner(
 		return
 	}
 
-	tombstones, err := ds.GetTombstones(ctx, info.BlockID)
+	tombstones, err := ds.GetTombstones(ctx, info.BlockID, info.IsCNCreated())
 	if err != nil {
 		return
 	}
@@ -536,7 +536,7 @@ func readBlockData(
 		return
 	}
 
-	if info.Appendable {
+	if info.IsAppendable() {
 		bat, deleteMask, err = readABlkColumns(idxes)
 	} else {
 		bat, _, err = readColumns(idxes)
@@ -545,20 +545,13 @@ func readBlockData(
 	return
 }
 
-func ReadBlockDelete(
-	ctx context.Context, deltaloc objectio.Location, fs fileservice.FileService,
-) (bat *batch.Batch, isPersistedByCN bool, release func(), err error) {
-	isPersistedByCN, err = IsPersistedByCN(ctx, deltaloc, fs)
-	if err != nil {
-		return
-	}
-	bat, release, err = ReadBlockDeleteBySchema(ctx, deltaloc, fs, isPersistedByCN)
-	return
-}
-
-func ReadBlockDeleteBySchema(
-	ctx context.Context, deltaloc objectio.Location, fs fileservice.FileService, isPersistedByCN bool,
+func ReadDeletes(
+	ctx context.Context,
+	deltaLoc objectio.Location,
+	fs fileservice.FileService,
+	isPersistedByCN bool,
 ) (bat *batch.Batch, release func(), err error) {
+
 	var cols []uint16
 	var typs []types.Type
 
@@ -569,24 +562,8 @@ func ReadBlockDeleteBySchema(
 		cols = []uint16{0, objectio.SEQNUM_COMMITTS}
 		typs = []types.Type{types.T_Rowid.ToType(), types.T_TS.ToType()}
 	}
-	bat, release, err = LoadTombstoneColumns(ctx, cols, typs, fs, deltaloc, nil, fileservice.Policy(0))
+	bat, release, err = LoadTombstoneColumns(ctx, cols, typs, fs, deltaLoc, nil, fileservice.Policy(0))
 	return
-}
-
-func IsPersistedByCN(
-	ctx context.Context, deltaloc objectio.Location, fs fileservice.FileService,
-) (bool, error) {
-	objectMeta, err := objectio.FastLoadObjectMeta(ctx, &deltaloc, false, fs)
-	if err != nil {
-		return false, err
-	}
-	meta, ok := objectMeta.TombstoneMeta()
-	if !ok {
-		meta = objectMeta.MustDataMeta()
-	}
-	blkmeta := meta.GetBlockMeta(uint32(deltaloc.ID()))
-	columnCount := blkmeta.GetColumnCount()
-	return columnCount == 2, nil
 }
 
 func EvalDeleteRowsByTimestamp(
@@ -702,31 +679,24 @@ func FillBlockDeleteMask(
 	blockId types.Blockid,
 	location objectio.Location,
 	fs fileservice.FileService,
+	createdByCN bool,
 ) (deleteMask *nulls.Nulls, err error) {
 	var (
-		rows *nulls.Nulls
-		//bisect           time.Duration
+		rows             *nulls.Nulls
 		release          func()
-		persistedByCN    bool
 		persistedDeletes *batch.Batch
 	)
 
 	if !location.IsEmpty() {
-		//t1 := time.Now()
-
-		if persistedDeletes, persistedByCN, release, err = ReadBlockDelete(ctx, location, fs); err != nil {
+		if persistedDeletes, release, err = ReadDeletes(ctx, location, fs, createdByCN); err != nil {
 			return nil, err
 		}
 		defer release()
 
-		//readCost := time.Since(t1)
-
-		if persistedByCN {
+		if createdByCN {
 			rows = EvalDeleteRowsByTimestampForDeletesPersistedByCN(blockId, persistedDeletes)
 		} else {
-			//t2 := time.Now()
 			rows = EvalDeleteRowsByTimestamp(persistedDeletes, snapshotTS, &blockId)
-			//bisect = time.Since(t2)
 		}
 
 		if rows != nil {

--- a/pkg/vm/engine/tae/blockio/utils.go
+++ b/pkg/vm/engine/tae/blockio/utils.go
@@ -38,7 +38,7 @@ func GetTombstonesByBlockId(
 	onBlockSelectedFn := func(tombstoneObject *objectio.ObjectStats, pos int) (bool, error) {
 		location := tombstoneObject.BlockLocation(uint16(pos), objectio.BlockMaxRows)
 		if mask, err := FillBlockDeleteMask(
-			ctx, ts, blockId, location, fs,
+			ctx, ts, blockId, location, fs, tombstoneObject.GetCNCreated(),
 		); err != nil {
 			return false, err
 		} else {

--- a/pkg/vm/engine/tae/blockio/writer.go
+++ b/pkg/vm/engine/tae/blockio/writer.go
@@ -101,8 +101,8 @@ func (w *BlockWriter) SetAppendable() {
 	w.writer.SetAppendable()
 }
 
-func (w *BlockWriter) GetObjectStats() []objectio.ObjectStats {
-	return w.objectStats
+func (w *BlockWriter) GetObjectStats(opts ...objectio.ObjectStatsOptions) objectio.ObjectStats {
+	return w.writer.GetObjectStats(opts...)
 }
 
 // WriteBatch write a batch whose schema is decribed by seqnum in NewBlockWriterNew
@@ -203,8 +203,6 @@ func (w *BlockWriter) Sync(ctx context.Context) ([]objectio.BlockObject, objecti
 			common.OperandField("[Size=0]"), common.OperandField(w.writer.GetSeqnums()))
 		return blocks, objectio.Extent{}, err
 	}
-
-	w.objectStats = w.writer.GetObjectStats()
 
 	logutil.Debug("[WriteEnd]",
 		common.OperationField(w.String(blocks)),

--- a/pkg/vm/engine/tae/blockio/writer.go
+++ b/pkg/vm/engine/tae/blockio/writer.go
@@ -38,7 +38,6 @@ type BlockWriter struct {
 	sortKeyIdx     uint16
 	nameStr        string
 	name           objectio.ObjectName
-	objectStats    []objectio.ObjectStats
 	prefix         []index.PrefixFn
 
 	// schema data

--- a/pkg/vm/engine/tae/db/gc/v2/table.go
+++ b/pkg/vm/engine/tae/db/gc/v2/table.go
@@ -293,7 +293,8 @@ func (t *GCTable) SaveFullTable(start, end types.TS, fs *objectio.ObjectFS, file
 		objectCount := 0
 		tombstoneCount := 0
 		if len(blocks) > 0 && err == nil {
-			size = writer.GetObjectStats()[0].OriginSize()
+			ss := writer.GetObjectStats()
+			size = ss.OriginSize()
 		}
 		if bats != nil {
 			objectCount = bats[ObjectList].Length()

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -4197,8 +4197,7 @@ func TestBlockRead(t *testing.T) {
 			bid, _ := blkEntry.ID(), blkEntry.ID()
 
 			info := &objectio.BlockInfo{
-				BlockID:    *objectio.NewBlockidWithObjectID(bid, 0),
-				Appendable: false, // TODO: jxm
+				BlockID: *objectio.NewBlockidWithObjectID(bid, 0),
 			}
 			metaloc := objectEntry.ObjectLocation()
 			metaloc.SetRows(schema.BlockMaxRows)
@@ -4275,7 +4274,7 @@ func TestBlockRead(t *testing.T) {
 			assert.Equal(t, 16, b4.Vecs[0].Length())
 
 			// read rowid column only
-			info.Appendable = false
+			//info.Appendable = false
 			b5 := buildBatch([]types.Type{types.T_Rowid.ToType()})
 			err = blockio.BlockDataReadInner(
 				context.Background(), "", info,
@@ -4997,7 +4996,8 @@ func TestMergeMemsize(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, batCnt, len(blocks))
 	statsVec := containers.MakeVector(types.T_varchar.ToType(), common.DefaultAllocator)
-	statsVec.Append(writer.GetObjectStats()[objectio.SchemaData][:], false)
+	ss := writer.GetObjectStats()
+	statsVec.Append(ss[:], false)
 	{
 		txn, _ := tae.StartTxn(nil)
 		txn.SetDedupType(txnif.DedupPolicy_CheckIncremental)
@@ -5067,7 +5067,8 @@ func TestCollectDeletesAfterCKP(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(blocks))
 	statsVec := containers.MakeVector(types.T_varchar.ToType(), common.DefaultAllocator)
-	statsVec.Append(writer.GetObjectStats()[objectio.SchemaData][:], false)
+	ss := writer.GetObjectStats()
+	statsVec.Append(ss[:], false)
 	defer statsVec.Close()
 	{
 		txn, _ := tae.StartTxn(nil)
@@ -5169,7 +5170,8 @@ func TestAlwaysUpdate(t *testing.T) {
 		blocks, _, err := writer.Sync(context.Background())
 		assert.Nil(t, err)
 		assert.Equal(t, 25, len(blocks))
-		statsVec.Append(writer.GetObjectStats()[objectio.SchemaData][:], false)
+		ss := writer.GetObjectStats()
+		statsVec.Append(ss[:], false)
 	}
 
 	// var did, tid uint64
@@ -7572,7 +7574,8 @@ func TestCommitS3Blocks(t *testing.T) {
 		assert.Equal(t, 50, len(blocks))
 		statsVec := containers.MakeVector(types.T_varchar.ToType(), common.DefaultAllocator)
 		defer statsVec.Close()
-		statsVec.Append(writer.GetObjectStats()[objectio.SchemaData][:], false)
+		ss := writer.GetObjectStats()
+		statsVec.Append(ss[:], false)
 		statsVecs = append(statsVecs, statsVec)
 	}
 
@@ -7646,7 +7649,8 @@ func TestDedupSnapshot2(t *testing.T) {
 	assert.Equal(t, 1, len(blocks))
 	statsVec := containers.MakeVector(types.T_varchar.ToType(), common.DefaultAllocator)
 	defer statsVec.Close()
-	statsVec.Append(writer.GetObjectStats()[objectio.SchemaData][:], false)
+	ss := writer.GetObjectStats()
+	statsVec.Append(ss[:], false)
 
 	name2 := objectio.BuildObjectNameWithObjectID(objectio.NewObjectid())
 	writer, err = blockio.NewBlockWriterNew(tae.Runtime.Fs.Service, name2, 0, nil)
@@ -7659,7 +7663,8 @@ func TestDedupSnapshot2(t *testing.T) {
 	assert.Equal(t, 1, len(blocks))
 	statsVec2 := containers.MakeVector(types.T_varchar.ToType(), common.DefaultAllocator)
 	defer statsVec2.Close()
-	statsVec2.Append(writer.GetObjectStats()[objectio.SchemaData][:], false)
+	ss = writer.GetObjectStats()
+	statsVec2.Append(ss[:], false)
 
 	txn, rel := tae.GetRelation()
 	err = rel.AddObjsWithMetaLoc(context.Background(), statsVec)
@@ -7821,7 +7826,8 @@ func TestDeduplication(t *testing.T) {
 
 	statsVec := containers.MakeVector(types.T_varchar.ToType(), common.DefaultAllocator)
 	defer statsVec.Close()
-	statsVec.Append(writer.GetObjectStats()[objectio.SchemaData][:], false)
+	ss := writer.GetObjectStats()
+	statsVec.Append(ss[:], false)
 
 	txn, rel := tae.GetRelation()
 	err = rel.AddObjsWithMetaLoc(context.Background(), statsVec)

--- a/pkg/vm/engine/tae/db/testutil/funcs.go
+++ b/pkg/vm/engine/tae/db/testutil/funcs.go
@@ -418,8 +418,7 @@ func MockCNDeleteInS3(
 	_, _, err = writer.Sync(context.Background())
 	//location = blockio.EncodeLocation(name, blks[0].GetExtent(), uint32(bat.Length()), blks[0].GetID())
 
-	stats = writer.GetObjectStats()[0]
-	stats.SetCNCreated()
+	stats = writer.GetObjectStats(objectio.WithCNCreated())
 
 	return
 }

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -96,7 +96,6 @@ func (d *BackupDeltaLocDataSource) Close() {
 func (d *BackupDeltaLocDataSource) ApplyTombstones(
 	_ context.Context,
 	_ objectio.Blockid,
-	_ bool,
 	_ []int64,
 	_ engine.TombstoneApplyPolicy,
 ) ([]int64, error) {
@@ -173,7 +172,7 @@ func GetTombstonesByBlockId(
 }
 
 func (d *BackupDeltaLocDataSource) GetTombstones(
-	_ context.Context, bid objectio.Blockid, byCN bool,
+	_ context.Context, bid objectio.Blockid,
 ) (deletedRows *nulls.Nulls, err error) {
 	deletedRows = &nulls.Nulls{}
 	deletedRows.InitWithSize(8192)

--- a/pkg/vm/engine/tae/logtail/snapshot.go
+++ b/pkg/vm/engine/tae/logtail/snapshot.go
@@ -187,11 +187,10 @@ func (d *DeltaLocDataSource) Close() {
 func (d *DeltaLocDataSource) ApplyTombstones(
 	ctx context.Context,
 	bid objectio.Blockid,
-	byCN bool,
 	rowsOffset []int64,
 	applyPolicy engine.TombstoneApplyPolicy,
 ) ([]int64, error) {
-	deleteMask, err := d.getAndApplyTombstones(ctx, bid, byCN)
+	deleteMask, err := d.getAndApplyTombstones(ctx, bid)
 	if err != nil {
 		return nil, err
 	}
@@ -207,10 +206,10 @@ func (d *DeltaLocDataSource) ApplyTombstones(
 }
 
 func (d *DeltaLocDataSource) GetTombstones(
-	ctx context.Context, bid objectio.Blockid, byCN bool,
+	ctx context.Context, bid objectio.Blockid,
 ) (deletedRows *nulls.Nulls, err error) {
 	var rows *nulls.Bitmap
-	rows, err = d.getAndApplyTombstones(ctx, bid, byCN)
+	rows, err = d.getAndApplyTombstones(ctx, bid)
 	if err != nil {
 		return
 	}
@@ -221,14 +220,14 @@ func (d *DeltaLocDataSource) GetTombstones(
 }
 
 func (d *DeltaLocDataSource) getAndApplyTombstones(
-	ctx context.Context, bid objectio.Blockid, createdByCN bool,
+	ctx context.Context, bid objectio.Blockid,
 ) (*nulls.Bitmap, error) {
 	deltaLoc, ts := d.ds.GetDeltaLoc(bid)
 	if deltaLoc.IsEmpty() {
 		return nil, nil
 	}
 	logutil.Infof("deltaLoc: %v, id is %d", deltaLoc.String(), bid.Sequence())
-	deletes, release, err := blockio.ReadDeletes(ctx, deltaLoc, d.fs, createdByCN)
+	deletes, release, err := blockio.ReadDeletes(ctx, deltaLoc, d.fs, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vm/engine/tae/mergesort/merger.go
+++ b/pkg/vm/engine/tae/mergesort/merger.go
@@ -296,11 +296,9 @@ func (m *merger[T]) syncObject(ctx context.Context) error {
 	if _, _, err := m.writer.Sync(ctx); err != nil {
 		return err
 	}
-	cobjstats := m.writer.GetObjectStats()[:objectio.SchemaTombstone]
+	cobjstats := m.writer.GetObjectStats()
 	commitEntry := m.host.GetCommitEntry()
-	for _, cobj := range cobjstats {
-		commitEntry.CreatedObjs = append(commitEntry.CreatedObjs, cobj.Clone().Marshal())
-	}
+	commitEntry.CreatedObjs = append(commitEntry.CreatedObjs, cobjstats.Clone().Marshal())
 	m.writer = nil
 	return nil
 }

--- a/pkg/vm/engine/tae/mergesort/reshaper.go
+++ b/pkg/vm/engine/tae/mergesort/reshaper.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
-	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/blockio"
 )
@@ -146,9 +145,7 @@ func syncObject(ctx context.Context, writer *blockio.BlockWriter, commitEntry *a
 	if _, _, err := writer.Sync(ctx); err != nil {
 		return err
 	}
-	cobjstats := writer.GetObjectStats()[:objectio.SchemaTombstone]
-	for _, cobj := range cobjstats {
-		commitEntry.CreatedObjs = append(commitEntry.CreatedObjs, cobj.Clone().Marshal())
-	}
+	cobjstats := writer.GetObjectStats()
+	commitEntry.CreatedObjs = append(commitEntry.CreatedObjs, cobjstats.Clone().Marshal())
 	return nil
 }

--- a/pkg/vm/engine/tae/rpc/rpc_test.go
+++ b/pkg/vm/engine/tae/rpc/rpc_test.go
@@ -112,7 +112,7 @@ func TestHandle_HandleCommitPerformanceForS3Load(t *testing.T) {
 				blk.GetID())
 			assert.Nil(t, err)
 			blkMetas = append(blkMetas, metaLoc.String())
-			stats = append(stats, writer.GetObjectStats()[objectio.SchemaData])
+			stats = append(stats, writer.GetObjectStats(objectio.WithCNCreated()))
 		}
 	}
 
@@ -182,7 +182,7 @@ func TestHandle_HandleCommitPerformanceForS3Load(t *testing.T) {
 		metaLocBat := containers.BuildBatch(attrs, vecTypes, vecOpts)
 		for i := 0; i < 50; i++ {
 			metaLocBat.Vecs[0].Append([]byte(blkMetas[offset+i]), false)
-			stats[offset+i].SetCNCreated()
+			//stats[offset+i].SetCNCreated()
 			metaLocBat.Vecs[1].Append([]byte(stats[offset+i][:]), false)
 		}
 		offset += 50
@@ -278,7 +278,7 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 		blocks[1].GetID(),
 	).String()
 	assert.Nil(t, err)
-	stats1 := writer.GetObjectStats()[objectio.SchemaData]
+	stats1 := writer.GetObjectStats(objectio.WithCNCreated())
 
 	//write taeBats[3] into file service
 	objName2 := objectio.BuildObjectNameWithObjectID(objectio.NewObjectid())
@@ -296,7 +296,7 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 		uint32(taeBats[3].Vecs[0].Length()),
 		blocks[0].GetID(),
 	).String()
-	stats3 := writer.GetObjectStats()[objectio.SchemaData]
+	stats3 := writer.GetObjectStats(objectio.WithCNCreated())
 	assert.Nil(t, err)
 
 	//create db;
@@ -395,7 +395,7 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 	metaLocBat1 := containers.BuildBatch(attrs, vecTypes, vecOpts)
 	metaLocBat1.Vecs[0].Append([]byte(metaLoc1), false)
 	metaLocBat1.Vecs[0].Append([]byte(metaLoc2), false)
-	stats1.SetCNCreated()
+	//stats1.SetCNCreated()
 	metaLocBat1.Vecs[1].Append([]byte(stats1[:]), false)
 	metaLocBat1.Vecs[1].Append([]byte(stats1[:]), false)
 	metaLocMoBat1 := containers.ToCNBatch(metaLocBat1)
@@ -411,7 +411,7 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 	//add one non-appendable block from S3 into "tbtest" table
 	metaLocBat2 := containers.BuildBatch(attrs, vecTypes, vecOpts)
 	metaLocBat2.Vecs[0].Append([]byte(metaLoc3), false)
-	stats3.SetCNCreated()
+	//stats3.SetCNCreated()
 	metaLocBat2.Vecs[1].Append([]byte(stats3[:]), false)
 	metaLocMoBat2 := containers.ToCNBatch(metaLocBat2)
 	addS3BlkEntry2, err := makePBEntry(INSERT, dbTestID,
@@ -499,7 +499,7 @@ func TestHandle_HandlePreCommitWriteS3(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, len(physicals), len(blocks))
 
-	stats := writer.GetObjectStats()[0]
+	stats := writer.GetObjectStats()
 	require.False(t, stats.IsZero())
 
 	//prepare delete locations.

--- a/pkg/vm/engine/tae/tables/jobs/flushobj.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushobj.go
@@ -160,7 +160,7 @@ func (task *flushObjTask) Execute(ctx context.Context) (err error) {
 			common.AnyField("delete-rows", drow),
 		)
 	}
-	task.Stats = writer.GetObjectStats()[objectio.SchemaData]
+	task.Stats = writer.GetObjectStats()
 
 	perfcounter.Update(ctx, func(counter *perfcounter.CounterSet) {
 		counter.TAE.Block.Flush.Add(1)

--- a/pkg/vm/engine/test/disttae_engine_test.go
+++ b/pkg/vm/engine/test/disttae_engine_test.go
@@ -886,12 +886,12 @@ func TestObjectStats1(t *testing.T) {
 		obj := iter.Entry()
 		objCount++
 		if bytes.Equal(obj.ObjectInfo.ObjectStats.ObjectName().ObjectId()[:], appendableObjectID[:]) {
-			assert.True(t, obj.Appendable)
-			assert.False(t, obj.Sorted)
+			assert.True(t, obj.GetAppendable())
+			assert.False(t, obj.GetSorted())
 			assert.False(t, obj.ObjectStats.GetCNCreated())
 		} else {
-			assert.False(t, obj.Appendable)
-			assert.True(t, obj.Sorted)
+			assert.False(t, obj.GetAppendable())
+			assert.True(t, obj.GetSorted())
 			assert.False(t, obj.ObjectStats.GetCNCreated())
 		}
 	}
@@ -904,10 +904,10 @@ func TestObjectStats1(t *testing.T) {
 	for iter.Next() {
 		obj := iter.Entry()
 		objCount++
-		if obj.Appendable {
+		if obj.GetAppendable() {
 			appendableCount++
 		}
-		assert.True(t, obj.Sorted)
+		assert.True(t, obj.GetSorted())
 		assert.False(t, obj.ObjectStats.GetCNCreated())
 	}
 	assert.Equal(t, appendableCount, 1)
@@ -925,8 +925,8 @@ func TestObjectStats1(t *testing.T) {
 	for iter.Next() {
 		obj := iter.Entry()
 		objCount++
-		assert.False(t, obj.Appendable)
-		assert.True(t, obj.Sorted)
+		assert.False(t, obj.GetAppendable())
+		assert.True(t, obj.GetSorted())
 		assert.False(t, obj.ObjectStats.GetCNCreated())
 	}
 	assert.Equal(t, objCount, 1)
@@ -973,12 +973,12 @@ func TestObjectStats2(t *testing.T) {
 		obj := iter.Entry()
 		objCount++
 		if bytes.Equal(obj.ObjectInfo.ObjectStats.ObjectName().ObjectId()[:], appendableObjectID[:]) {
-			assert.True(t, obj.Appendable)
-			assert.False(t, obj.Sorted)
+			assert.True(t, obj.GetAppendable())
+			assert.False(t, obj.GetSorted())
 			assert.False(t, obj.ObjectStats.GetCNCreated())
 		} else {
-			assert.False(t, obj.Appendable)
-			assert.False(t, obj.Sorted)
+			assert.False(t, obj.GetAppendable())
+			assert.False(t, obj.GetSorted())
 			assert.False(t, obj.ObjectStats.GetCNCreated())
 		}
 	}
@@ -991,10 +991,10 @@ func TestObjectStats2(t *testing.T) {
 	for iter.Next() {
 		obj := iter.Entry()
 		objCount++
-		if obj.Appendable {
+		if obj.GetAppendable() {
 			appendableCount++
 		}
-		assert.True(t, obj.Sorted)
+		assert.True(t, obj.GetSorted())
 		assert.False(t, obj.ObjectStats.GetCNCreated())
 	}
 	assert.Equal(t, appendableCount, 1)
@@ -1012,8 +1012,8 @@ func TestObjectStats2(t *testing.T) {
 	for iter.Next() {
 		obj := iter.Entry()
 		objCount++
-		assert.False(t, obj.Appendable)
-		assert.False(t, obj.Sorted)
+		assert.False(t, obj.GetAppendable())
+		assert.False(t, obj.GetSorted())
 		assert.False(t, obj.ObjectStats.GetCNCreated())
 	}
 	iter.Close()

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -742,13 +742,12 @@ type DataSource interface {
 	ApplyTombstones(
 		ctx context.Context,
 		bid objectio.Blockid,
-		byCN bool,
 		rowsOffset []int64,
 		applyPolicy TombstoneApplyPolicy,
 	) ([]int64, error)
 
 	GetTombstones(
-		ctx context.Context, bid objectio.Blockid, byCN bool,
+		ctx context.Context, bid objectio.Blockid,
 	) (deletedRows *nulls.Nulls, err error)
 
 	SetOrderBy(orderby []*plan.OrderBySpec)

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -742,12 +742,13 @@ type DataSource interface {
 	ApplyTombstones(
 		ctx context.Context,
 		bid objectio.Blockid,
+		byCN bool,
 		rowsOffset []int64,
 		applyPolicy TombstoneApplyPolicy,
 	) ([]int64, error)
 
 	GetTombstones(
-		ctx context.Context, bid objectio.Blockid,
+		ctx context.Context, bid objectio.Blockid, byCN bool,
 	) (deletedRows *nulls.Nulls, err error)
 
 	SetOrderBy(orderby []*plan.OrderBySpec)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/11471

## What this PR does / why we need it:
flag:
1. dependable
2. sorted
3. by cn created.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Introduced `StateFlag` in `BlockInfo` to manage block states, replacing `Appendable` and `Sorted` fields.
- Added methods to `BlockInfo` to check for specific state flags.
- Updated `ObjectStats` to include flags and options for setting these flags.
- Refactored object writer to handle `ObjectStats` as a single entity with options.
- Enhanced tombstone handling by adding a `byCN` parameter to relevant methods.
- Updated tests to reflect changes in block state management and object stats.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>block.go</strong><dd><code>Add state flags to BlockInfo for block management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/block.go

<li>Added <code>StateFlag</code> to <code>BlockInfo</code> to manage block states.<br> <li> Updated <code>GenerateBlockInfo</code> to set <code>CNCreatedFlag</code> and <code>SortedFlag</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18527/files#diff-bfb14c6e9293edcfeedb83ea37e50018bc6cbcfa0c49093552f22f53c14d9eaf">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>block_info.go</strong><dd><code>Refactor BlockInfo to use state flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/block_info.go

<li>Replaced <code>Appendable</code> and <code>Sorted</code> fields with <code>StateFlag</code>.<br> <li> Added methods to check block state flags.<br> <li> Updated <code>String</code> method to reflect new flags.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18527/files#diff-78fa0c7339ee60d72be54ce3d65111ec6fb472d0273912f6bdbb055d2f5db95c">+42/-19</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>object_stats.go</strong><dd><code>Add flags and options for ObjectStats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/object_stats.go

<li>Introduced flags for object stats.<br> <li> Added options for setting flags on <code>ObjectStats</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18527/files#diff-ee4043182eb602ba7e2808a244a58b0524d4ab8be8157faf7e755e422ca2265d">+43/-16</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>writer.go</strong><dd><code>Refactor object writer to use single ObjectStats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/writer.go

<li>Changed <code>objStats</code> to a single <code>ObjectStats</code>.<br> <li> Updated methods to handle <code>ObjectStats</code> with options.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18527/files#diff-6d22078db63ca9c9ab2e2993404b26986918b776429dda9f1b4af83e5ff481f6">+18/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>s3util.go</strong><dd><code>Use ObjectStatsOptions in S3Writer sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/s3util.go

- Updated `sync` method to use `ObjectStatsOptions`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18527/files#diff-df5f720cc405f3e54f67fa856d10f804d605ef16b99747db5a40b2406d8fc1d3">+9/-12</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>datasource.go</strong><dd><code>Add byCN parameter to tombstone methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/datasource.go

- Added `byCN` parameter to `ApplyTombstones` and `GetTombstones`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18527/files#diff-d522a8add454281ead9a9b12c561e1ed74af0f1de69279a16bc2b3f29662782a">+11/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>read.go</strong><dd><code>Update tombstone reading with byCN flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/blockio/read.go

- Updated tombstone reading functions to use `byCN` flag.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18527/files#diff-e90a1b44f23a26266c0f82ac5b90aa7cfa3d4faef05ceff130c664ef1b37f497">+18/-48</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Use GetCNCreated flag in tombstone retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/blockio/utils.go

- Updated `GetTombstonesByBlockId` to use `GetCNCreated` flag.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18527/files#diff-a30e45aacfc4cdded399f9125d8740a4db49a8c20c2d1a702580a43220f5326b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>block_info_test.go</strong><dd><code>Update tests for BlockInfo state flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/block_info_test.go

- Updated tests to use `StateFlag` for block state checks.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18527/files#diff-51ae409949c40f082f3e45c9998e1cf5b294e78f3abf5e05d76d6c1b1d4ba289">+17/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>object_stats_test.go</strong><dd><code>Add tests for ObjectStats flag options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/object_stats_test.go

- Added tests for `ObjectStats` options and flags.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18527/files#diff-858bbcbd8a859e7b9570478ae2e473d95d1036cee48f38631d99ee66420e9ea1">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

