### PR TITLE
Io access time consumptionissue 1.2 dev

### DIFF
--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -29,6 +29,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -36,7 +38,6 @@ import (
 	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace/statistic"
-	"go.uber.org/zap"
 )
 
 // LocalFS is a FileService implementation backed by local file system
@@ -360,11 +361,6 @@ read_memory_cache:
 		}()
 	}
 
-	ioStart := time.Now()
-	defer func() {
-		stats.AddIOAccessTimeConsumption(time.Since(ioStart))
-	}()
-
 	startLock := time.Now()
 	done, wait := l.ioMerger.Merge(vector.ioMergeKey())
 	if done != nil {
@@ -375,6 +371,12 @@ read_memory_cache:
 		stats.AddLocalFSReadIOMergerTimeConsumption(time.Since(startLock))
 		goto read_memory_cache
 	}
+
+	// Record diskIO and netwokIO(un memory IO) resource
+	ioStart := time.Now()
+	defer func() {
+		stats.AddIOAccessTimeConsumption(time.Since(ioStart))
+	}()
 
 	if l.diskCache != nil {
 

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -28,6 +28,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
@@ -36,7 +38,6 @@ import (
 	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace/statistic"
-	"go.uber.org/zap"
 )
 
 // S3FS is a FileService implementation backed by S3
@@ -497,11 +498,6 @@ read_memory_cache:
 	}
 
 	stats := statistic.StatsInfoFromContext(ctx)
-	ioStart := time.Now()
-	defer func() {
-		stats.AddIOAccessTimeConsumption(time.Since(ioStart))
-	}()
-
 	LogEvent(ctx, str_ioMerger_Merge_begin)
 	startLock := time.Now()
 	done, wait := s.ioMerger.Merge(vector.ioMergeKey())
@@ -517,6 +513,12 @@ read_memory_cache:
 		LogEvent(ctx, str_ioMerger_Merge_end)
 		goto read_memory_cache
 	}
+
+	// Record diskIO and netwokIO(un memory IO) resource
+	ioStart := time.Now()
+	defer func() {
+		stats.AddIOAccessTimeConsumption(time.Since(ioStart))
+	}()
 
 	if s.diskCache != nil {
 

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -3359,8 +3359,9 @@ func (h *marshalPlanHandler) Stats(ctx context.Context, ses FeSession) (statsByt
 				statsInfo.CompileDuration+
 				statsInfo.PlanDuration) - (statsInfo.IOAccessTimeConsumption + statsInfo.IOMergerTimeConsumption())
 		if val < 0 {
-			ses.Warnf(ctx, " negative cpu (%s) + statsInfo(%d + %d + %d - %d - %d) = %d",
+			ses.Warnf(ctx, " negative cpu (%s) + statsInfo(%d + %d + %d + %d - %d - %d) = %d",
 				uuid.UUID(h.stmt.StatementID).String(),
+				statsByte.GetTimeConsumed(),
 				statsInfo.ParseDuration,
 				statsInfo.CompileDuration,
 				statsInfo.PlanDuration,

--- a/pkg/util/trace/impl/motrace/statistic/stats_array.go
+++ b/pkg/util/trace/impl/motrace/statistic/stats_array.go
@@ -264,12 +264,12 @@ type StatsInfo struct {
 	//S3ReadBytes             uint
 	//S3WriteBytes            uint
 
-	LocalFSReadIOMergerTimeConsumption      int64
-	LocalFSReadCacheIOMergerTimeConsumption int64
+	// Local FileService blocking wait time
+	LocalFSReadIOMergerTimeConsumption int64
 
+	// S3 FileService blocking wait time
 	S3FSPrefetchFileIOMergerTimeConsumption int64
 	S3FSReadIOMergerTimeConsumption         int64
-	S3FSReadCacheIOMergerTimeConsumption    int64
 
 	ParseStartTime     time.Time `json:"ParseStartTime"`
 	PlanStartTime      time.Time `json:"PlanStartTime"`
@@ -340,12 +340,6 @@ func (stats *StatsInfo) AddIOAccessTimeConsumption(d time.Duration) {
 	atomic.AddInt64(&stats.IOAccessTimeConsumption, int64(d))
 }
 
-func (stats *StatsInfo) AddLocalFSReadCacheIOMergerTimeConsumption(d time.Duration) {
-	if stats == nil {
-		return
-	}
-	atomic.AddInt64(&stats.LocalFSReadCacheIOMergerTimeConsumption, int64(d))
-}
 func (stats *StatsInfo) AddLocalFSReadIOMergerTimeConsumption(d time.Duration) {
 	if stats == nil {
 		return
@@ -364,21 +358,13 @@ func (stats *StatsInfo) AddS3FSReadIOMergerTimeConsumption(d time.Duration) {
 	}
 	atomic.AddInt64(&stats.S3FSReadIOMergerTimeConsumption, int64(d))
 }
-func (stats *StatsInfo) AddS3FSReadCacheIOMergerTimeConsumption(d time.Duration) {
-	if stats == nil {
-		return
-	}
-	atomic.AddInt64(&stats.S3FSReadCacheIOMergerTimeConsumption, int64(d))
-}
 
 func (stats *StatsInfo) IOMergerTimeConsumption() int64 {
 	if stats == nil {
 		return 0
 	}
-	return stats.LocalFSReadCacheIOMergerTimeConsumption +
-		stats.LocalFSReadIOMergerTimeConsumption +
+	return stats.LocalFSReadIOMergerTimeConsumption +
 		stats.S3FSPrefetchFileIOMergerTimeConsumption +
-		stats.S3FSReadCacheIOMergerTimeConsumption +
 		stats.S3FSReadIOMergerTimeConsumption
 }
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:
issue https://github.com/matrixorigin/matrixone/issues/14926

## What this PR does / why we need it:
fix IOAccessTimeConsumption Statistics Duplicate


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the duplication issue in IOAccessTimeConsumption statistics by relocating the recording logic in `local_fs.go` and `s3_fs.go`.
- Added comments to clarify the recording of diskIO and networkIO resources.
- Corrected the format of warning messages in `mysql_cmd_executor.go` for negative CPU calculations.
- Removed unused methods related to cache IO merger time consumption in `stats_array.go` and simplified the IO merger time consumption calculation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>local_fs.go</strong><dd><code>Fix and relocate IO access time consumption recording</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/local_fs.go

<li>Moved IO access time consumption recording to a more appropriate <br>location.<br> <li> Added comments for diskIO and networkIO resource recording.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18532/files#diff-bc086aa870f34585ab047b49edf44e6b55699be741653321dcf574b4bc5d1b00">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>s3_fs.go</strong><dd><code>Fix and relocate IO access time consumption recording</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/s3_fs.go

<li>Moved IO access time consumption recording to a more appropriate <br>location.<br> <li> Added comments for diskIO and networkIO resource recording.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18532/files#diff-907e5658def7c03142291742cb81fdc3d3590d95678e916e95daf13283a2f86f">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mysql_cmd_executor.go</strong><dd><code>Fix warning message format in CPU calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/mysql_cmd_executor.go

- Corrected the warning message format for negative CPU calculation.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18532/files#diff-af2611d5fc89704398fe09d09644efa41fec8931b395eda292f2f474f1216275">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stats_array.go</strong><dd><code>Remove unused methods and simplify IO merger calculation</code>&nbsp; </dd></summary>
<hr>

pkg/util/trace/impl/motrace/statistic/stats_array.go

<li>Removed unused cache IO merger time consumption methods.<br> <li> Simplified IO merger time consumption calculation.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18532/files#diff-ffbafe7bb5fd5225eb5ee9f8bd98a1f6107789298c38734c0925997e6037cdd6">+4/-18</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

