### PR TITLE
container/hashtable: replace mpool with malloc

### DIFF
--- a/pkg/common/hashmap/inthashmap.go
+++ b/pkg/common/hashmap/inthashmap.go
@@ -17,7 +17,6 @@ package hashmap
 import (
 	"unsafe"
 
-	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/hashtable"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -28,13 +27,12 @@ func init() {
 	zeroUint32 = make([]uint32, UnitLimit)
 }
 
-func NewIntHashMap(hasNull bool, m *mpool.MPool) (*IntHashMap, error) {
+func NewIntHashMap(hasNull bool) (*IntHashMap, error) {
 	mp := &hashtable.Int64HashMap{}
-	if err := mp.Init(m); err != nil {
+	if err := mp.Init(); err != nil {
 		return nil, err
 	}
 	return &IntHashMap{
-		m:       m,
 		rows:    0,
 		hasNull: hasNull,
 		hashMap: mp,
@@ -44,7 +42,6 @@ func NewIntHashMap(hasNull bool, m *mpool.MPool) (*IntHashMap, error) {
 func (m *IntHashMap) NewIterator() *intHashMapIterator {
 	return &intHashMapIterator{
 		mp:      m,
-		m:       m.m,
 		keys:    make([]uint64, UnitLimit),
 		keyOffs: make([]uint32, UnitLimit),
 		values:  make([]uint64, UnitLimit),
@@ -58,11 +55,11 @@ func (m *IntHashMap) HasNull() bool {
 }
 
 func (m *IntHashMap) Free() {
-	m.hashMap.Free(m.m)
+	m.hashMap.Free()
 }
 
-func (m *IntHashMap) PreAlloc(n uint64, mp *mpool.MPool) error {
-	return m.hashMap.ResizeOnDemand(int(n), mp)
+func (m *IntHashMap) PreAlloc(n uint64) error {
+	return m.hashMap.ResizeOnDemand(int(n))
 }
 
 func (m *IntHashMap) GroupCount() uint64 {

--- a/pkg/common/hashmap/inthashmap_test.go
+++ b/pkg/common/hashmap/inthashmap_test.go
@@ -26,7 +26,7 @@ import (
 func TestIntHashMap_Iterator(t *testing.T) {
 	{
 		m := mpool.MustNewZero()
-		mp, err := NewIntHashMap(false, m)
+		mp, err := NewIntHashMap(false)
 		require.NoError(t, err)
 		rowCount := 10
 		vecs := []*vector.Vector{
@@ -51,7 +51,7 @@ func TestIntHashMap_Iterator(t *testing.T) {
 	}
 	{
 		m := mpool.MustNewZero()
-		mp, err := NewIntHashMap(true, m)
+		mp, err := NewIntHashMap(true)
 		require.NoError(t, err)
 		ts := []types.Type{
 			types.New(types.T_int8, 0, 0),
@@ -72,7 +72,7 @@ func TestIntHashMap_Iterator(t *testing.T) {
 	}
 	{
 		m := mpool.MustNewZero()
-		mp, err := NewIntHashMap(true, m)
+		mp, err := NewIntHashMap(true)
 		require.NoError(t, err)
 		ts := []types.Type{
 			types.New(types.T_int64, 0, 0),
@@ -92,7 +92,7 @@ func TestIntHashMap_Iterator(t *testing.T) {
 	}
 	{
 		m := mpool.MustNewZero()
-		mp, err := NewIntHashMap(true, m)
+		mp, err := NewIntHashMap(true)
 		require.NoError(t, err)
 		ts := []types.Type{
 			types.New(types.T_char, 1, 0),
@@ -112,7 +112,7 @@ func TestIntHashMap_Iterator(t *testing.T) {
 	}
 	{
 		m := mpool.MustNewZero()
-		mp, err := NewIntHashMap(true, m)
+		mp, err := NewIntHashMap(true)
 		require.NoError(t, err)
 		ts := []types.Type{
 			types.New(types.T_char, 1, 0),
@@ -132,7 +132,7 @@ func TestIntHashMap_Iterator(t *testing.T) {
 	}
 	{
 		m := mpool.MustNewZero()
-		mp, err := NewIntHashMap(false, m)
+		mp, err := NewIntHashMap(false)
 		require.NoError(t, err)
 		ts := []types.Type{
 			types.New(types.T_char, 1, 0),

--- a/pkg/common/hashmap/iterator.go
+++ b/pkg/common/hashmap/iterator.go
@@ -37,7 +37,7 @@ func (itr *strHashmapIterator) DetectDup(vecs []*vector.Vector, row int) (bool, 
 	keys := itr.keys
 	defer func() { keys[0] = keys[0][:0] }()
 	itr.encodeHashKeys(vecs, row, 1)
-	if err := itr.mp.hashMap.InsertStringBatch(itr.strHashStates, keys[:1], itr.values[:1], itr.m); err != nil {
+	if err := itr.mp.hashMap.InsertStringBatch(itr.strHashStates, keys[:1], itr.values[:1]); err != nil {
 		return false, err
 	}
 	if itr.values[0] > itr.mp.rows {
@@ -59,9 +59,9 @@ func (itr *strHashmapIterator) Insert(start, count int, vecs []*vector.Vector) (
 	itr.encodeHashKeys(vecs, start, count)
 
 	if itr.mp.hasNull {
-		err = itr.mp.hashMap.InsertStringBatch(itr.strHashStates, itr.keys[:count], itr.values, itr.m)
+		err = itr.mp.hashMap.InsertStringBatch(itr.strHashStates, itr.keys[:count], itr.values)
 	} else {
-		err = itr.mp.hashMap.InsertStringBatchWithRing(itr.zValues, itr.strHashStates, itr.keys[:count], itr.values, itr.m)
+		err = itr.mp.hashMap.InsertStringBatchWithRing(itr.zValues, itr.strHashStates, itr.keys[:count], itr.values)
 	}
 
 	vs, zvs := itr.values[:count], itr.zValues[:count]
@@ -101,9 +101,9 @@ func (itr *intHashMapIterator) Insert(start, count int, vecs []*vector.Vector) (
 	itr.encodeHashKeys(vecs, start, count)
 	copy(itr.hashes[:count], zeroUint64[:count])
 	if itr.mp.hasNull {
-		err = itr.mp.hashMap.InsertBatch(count, itr.hashes[:count], unsafe.Pointer(&itr.keys[0]), itr.values, itr.m)
+		err = itr.mp.hashMap.InsertBatch(count, itr.hashes[:count], unsafe.Pointer(&itr.keys[0]), itr.values)
 	} else {
-		err = itr.mp.hashMap.InsertBatchWithRing(count, itr.zValues, itr.hashes[:count], unsafe.Pointer(&itr.keys[0]), itr.values, itr.m)
+		err = itr.mp.hashMap.InsertBatchWithRing(count, itr.zValues, itr.hashes[:count], unsafe.Pointer(&itr.keys[0]), itr.values)
 	}
 	vs, zvs := itr.values[:count], itr.zValues[:count]
 	updateHashTableRows(itr.mp, vs, zvs)

--- a/pkg/common/hashmap/strhashmap.go
+++ b/pkg/common/hashmap/strhashmap.go
@@ -17,7 +17,6 @@ package hashmap
 import (
 	"unsafe"
 
-	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/hashtable"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 )
@@ -33,13 +32,12 @@ func init() {
 	}
 }
 
-func NewStrMap(hasNull bool, m *mpool.MPool) (*StrHashMap, error) {
+func NewStrMap(hasNull bool) (*StrHashMap, error) {
 	mp := &hashtable.StringHashMap{}
-	if err := mp.Init(m); err != nil {
+	if err := mp.Init(); err != nil {
 		return nil, err
 	}
 	return &StrHashMap{
-		m:       m,
 		hashMap: mp,
 		hasNull: hasNull,
 	}, nil
@@ -48,7 +46,6 @@ func NewStrMap(hasNull bool, m *mpool.MPool) (*StrHashMap, error) {
 func (m *StrHashMap) NewIterator() Iterator {
 	return &strHashmapIterator{
 		mp:            m,
-		m:             m.m,
 		values:        make([]uint64, UnitLimit),
 		zValues:       make([]int64, UnitLimit),
 		keys:          make([][]byte, UnitLimit),
@@ -61,11 +58,11 @@ func (m *StrHashMap) HasNull() bool {
 }
 
 func (m *StrHashMap) Free() {
-	m.hashMap.Free(m.m)
+	m.hashMap.Free()
 }
 
-func (m *StrHashMap) PreAlloc(n uint64, mp *mpool.MPool) error {
-	return m.hashMap.ResizeOnDemand(n, mp)
+func (m *StrHashMap) PreAlloc(n uint64) error {
+	return m.hashMap.ResizeOnDemand(n)
 }
 
 func (m *StrHashMap) GroupCount() uint64 {

--- a/pkg/common/hashmap/strhashmap_test.go
+++ b/pkg/common/hashmap/strhashmap_test.go
@@ -32,7 +32,7 @@ const (
 
 func TestInsert(t *testing.T) {
 	m := mpool.MustNewZero()
-	mp, err := NewStrMap(false, m)
+	mp, err := NewStrMap(false)
 	itr := mp.NewIterator()
 	require.NoError(t, err)
 	ts := []types.Type{
@@ -59,7 +59,7 @@ func TestInsert(t *testing.T) {
 func TestIterator(t *testing.T) {
 	{
 		m := mpool.MustNewZero()
-		mp, err := NewStrMap(false, m)
+		mp, err := NewStrMap(false)
 		require.NoError(t, err)
 		ts := []types.Type{
 			types.New(types.T_int8, 0, 0),
@@ -84,7 +84,7 @@ func TestIterator(t *testing.T) {
 	}
 	{
 		m := mpool.MustNewZero()
-		mp, err := NewStrMap(true, m)
+		mp, err := NewStrMap(true)
 		require.NoError(t, err)
 		ts := []types.Type{
 			types.New(types.T_int8, 0, 0),
@@ -109,7 +109,7 @@ func TestIterator(t *testing.T) {
 	}
 	{
 		m := mpool.MustNewZero()
-		mp, err := NewStrMap(true, m)
+		mp, err := NewStrMap(true)
 		require.NoError(t, err)
 		ts := []types.Type{
 			types.New(types.T_int8, 0, 0),

--- a/pkg/common/hashmap/types.go
+++ b/pkg/common/hashmap/types.go
@@ -15,7 +15,6 @@
 package hashmap
 
 import (
-	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/hashtable"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 )
@@ -74,7 +73,6 @@ type Iterator interface {
 type StrHashMap struct {
 	hasNull bool
 	rows    uint64
-	m       *mpool.MPool
 	hashMap *hashtable.StringHashMap
 }
 
@@ -84,12 +82,10 @@ type StrHashMap struct {
 type IntHashMap struct {
 	hasNull bool
 	rows    uint64
-	m       *mpool.MPool
 	hashMap *hashtable.Int64HashMap
 }
 
 type strHashmapIterator struct {
-	m      *mpool.MPool
 	mp     *StrHashMap
 	keys   [][]byte
 	values []uint64
@@ -99,7 +95,6 @@ type strHashmapIterator struct {
 }
 
 type intHashMapIterator struct {
-	m       *mpool.MPool
 	mp      *IntHashMap
 	keys    []uint64
 	keyOffs []uint32

--- a/pkg/common/malloc/config.go
+++ b/pkg/common/malloc/config.go
@@ -46,7 +46,7 @@ var defaultConfig = func() *atomic.Pointer[Config] {
 	ret.Store(&Config{
 		CheckFraction:     ptrTo(uint32(4096)),
 		EnableMetrics:     ptrTo(true),
-		FullStackFraction: ptrTo(uint32(10)),
+		FullStackFraction: ptrTo(uint32(100)),
 	})
 
 	return ret

--- a/pkg/container/hashtable/common.go
+++ b/pkg/container/hashtable/common.go
@@ -16,14 +16,12 @@ package hashtable
 
 import (
 	"unsafe"
-
-	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 )
 
 const (
 	kInitialCellCntBits = 10
 	kInitialCellCnt     = 1 << kInitialCellCntBits
-	maxBlockSize        = mpool.GB / 4
+	maxBlockSize        = 256 * (1 << 20)
 )
 
 func maxElemCnt(cellCnt, cellSize uint64) uint64 {

--- a/pkg/container/hashtable/int64_hash_map.go
+++ b/pkg/container/hashtable/int64_hash_map.go
@@ -17,8 +17,8 @@ package hashtable
 import (
 	"unsafe"
 
+	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 )
 
 type Int64HashMapCell struct {
@@ -31,10 +31,11 @@ type Int64HashMap struct {
 	blockMaxElemCnt uint64
 	cellCntMask     uint64
 
-	cellCnt uint64
-	elemCnt uint64
-	rawData [][]byte
-	cells   [][]Int64HashMapCell
+	cellCnt             uint64
+	elemCnt             uint64
+	rawData             [][]byte
+	rawDataDeallocators []malloc.Deallocator
+	cells               [][]Int64HashMapCell
 }
 
 var (
@@ -47,17 +48,17 @@ func init() {
 	maxIntCellCntPerBlock = maxBlockSize / intCellSize
 }
 
-func (ht *Int64HashMap) Free(m *mpool.MPool) {
-	for i := range ht.rawData {
-		if len(ht.rawData[i]) > 0 {
-			m.Free(ht.rawData[i])
+func (ht *Int64HashMap) Free() {
+	for i, de := range ht.rawDataDeallocators {
+		if de != nil {
+			de.Deallocate(malloc.NoHints)
 		}
 		ht.rawData[i], ht.cells[i] = nil, nil
 	}
 	ht.rawData, ht.cells = nil, nil
 }
 
-func (ht *Int64HashMap) Init(m *mpool.MPool) (err error) {
+func (ht *Int64HashMap) Init() (err error) {
 	ht.blockCellCnt = kInitialCellCnt
 	ht.blockMaxElemCnt = maxElemCnt(kInitialCellCnt, intCellSize)
 	ht.cellCntMask = kInitialCellCnt - 1
@@ -65,15 +66,22 @@ func (ht *Int64HashMap) Init(m *mpool.MPool) (err error) {
 	ht.cellCnt = kInitialCellCnt
 
 	ht.rawData = make([][]byte, 1)
+	ht.rawDataDeallocators = make([]malloc.Deallocator, 1)
 	ht.cells = make([][]Int64HashMapCell, 1)
-	if ht.rawData[0], err = m.Alloc(int(ht.blockCellCnt * intCellSize)); err == nil {
-		ht.cells[0] = unsafe.Slice((*Int64HashMapCell)(unsafe.Pointer(&ht.rawData[0][0])), ht.blockCellCnt)
+
+	bs, de, err := getAllocator().Allocate(uint64(ht.blockCellCnt*strCellSize), malloc.NoHints)
+	if err != nil {
+		return err
 	}
+	ht.rawData[0] = bs
+	ht.rawDataDeallocators[0] = de
+	ht.cells[0] = unsafe.Slice((*Int64HashMapCell)(unsafe.Pointer(&ht.rawData[0][0])), ht.blockCellCnt)
+
 	return
 }
 
-func (ht *Int64HashMap) InsertBatch(n int, hashes []uint64, keysPtr unsafe.Pointer, values []uint64, m *mpool.MPool) error {
-	if err := ht.ResizeOnDemand(n, m); err != nil {
+func (ht *Int64HashMap) InsertBatch(n int, hashes []uint64, keysPtr unsafe.Pointer, values []uint64) error {
+	if err := ht.ResizeOnDemand(n); err != nil {
 		return err
 	}
 
@@ -93,8 +101,8 @@ func (ht *Int64HashMap) InsertBatch(n int, hashes []uint64, keysPtr unsafe.Point
 	return nil
 }
 
-func (ht *Int64HashMap) InsertBatchWithRing(n int, zValues []int64, hashes []uint64, keysPtr unsafe.Pointer, values []uint64, m *mpool.MPool) error {
-	if err := ht.ResizeOnDemand(n, m); err != nil {
+func (ht *Int64HashMap) InsertBatchWithRing(n int, zValues []int64, hashes []uint64, keysPtr unsafe.Pointer, values []uint64) error {
+	if err := ht.ResizeOnDemand(n); err != nil {
 		return err
 	}
 
@@ -167,8 +175,7 @@ func (ht *Int64HashMap) findEmptyCell(hash uint64) *Int64HashMapCell {
 	return nil
 }
 
-func (ht *Int64HashMap) ResizeOnDemand(n int, m *mpool.MPool) error {
-	var err error
+func (ht *Int64HashMap) ResizeOnDemand(n int) error {
 
 	targetCnt := ht.elemCnt + uint64(n)
 	if targetCnt <= uint64(len(ht.rawData))*ht.blockMaxElemCnt {
@@ -189,15 +196,18 @@ func (ht *Int64HashMap) ResizeOnDemand(n int, m *mpool.MPool) error {
 		newBlockNum := newAlloc / maxBlockSize
 
 		ht.rawData = append(ht.rawData, make([][]byte, newBlockNum-oldBlockNum)...)
+		ht.rawDataDeallocators = append(ht.rawDataDeallocators, make([]malloc.Deallocator, newBlockNum-oldBlockNum)...)
 		ht.cells = append(ht.cells, make([][]Int64HashMapCell, newBlockNum-oldBlockNum)...)
 		ht.cellCnt = ht.blockCellCnt * uint64(newBlockNum)
 		ht.cellCntMask = ht.cellCnt - 1
 
 		for i := oldBlockNum; i < newBlockNum; i++ {
-			ht.rawData[i], err = m.Alloc(int(ht.blockCellCnt * intCellSize))
+			bs, de, err := getAllocator().Allocate(uint64(ht.blockCellCnt*strCellSize), malloc.NoHints)
 			if err != nil {
 				return err
 			}
+			ht.rawData[i] = bs
+			ht.rawDataDeallocators[i] = de
 			ht.cells[i] = unsafe.Slice((*Int64HashMapCell)(unsafe.Pointer(&ht.rawData[i][0])), ht.blockCellCnt)
 		}
 
@@ -234,7 +244,7 @@ func (ht *Int64HashMap) ResizeOnDemand(n int, m *mpool.MPool) error {
 		}
 	} else {
 		oldCells0 := ht.cells[0]
-		oldData0 := ht.rawData[0]
+		oldDeallocator := ht.rawDataDeallocators[0]
 		ht.cellCnt = newCellCnt
 		ht.cellCntMask = newCellCnt - 1
 
@@ -242,26 +252,32 @@ func (ht *Int64HashMap) ResizeOnDemand(n int, m *mpool.MPool) error {
 			ht.blockCellCnt = newCellCnt
 			ht.blockMaxElemCnt = newMaxElemCnt
 
-			ht.rawData[0], err = m.Alloc(newAlloc)
+			bs, de, err := getAllocator().Allocate(uint64(newAlloc), malloc.NoHints)
 			if err != nil {
 				return err
 			}
+			ht.rawData[0] = bs
+			ht.rawDataDeallocators[0] = de
 			ht.cells[0] = unsafe.Slice((*Int64HashMapCell)(unsafe.Pointer(&ht.rawData[0][0])), ht.blockCellCnt)
+
 		} else {
 			ht.blockCellCnt = maxIntCellCntPerBlock
 			ht.blockMaxElemCnt = maxElemCnt(ht.blockCellCnt, intCellSize)
 
 			newBlockNum := newAlloc / maxBlockSize
 			ht.rawData = make([][]byte, newBlockNum)
+			ht.rawDataDeallocators = make([]malloc.Deallocator, newBlockNum)
 			ht.cells = make([][]Int64HashMapCell, newBlockNum)
 			ht.cellCnt = ht.blockCellCnt * uint64(newBlockNum)
 			ht.cellCntMask = ht.cellCnt - 1
 
 			for i := 0; i < newBlockNum; i++ {
-				ht.rawData[i], err = m.Alloc(int(ht.blockCellCnt * intCellSize))
+				bs, de, err := getAllocator().Allocate(uint64(ht.blockCellCnt*strCellSize), malloc.NoHints)
 				if err != nil {
 					return err
 				}
+				ht.rawData[i] = bs
+				ht.rawDataDeallocators[i] = de
 				ht.cells[i] = unsafe.Slice((*Int64HashMapCell)(unsafe.Pointer(&ht.rawData[i][0])), ht.blockCellCnt)
 			}
 		}
@@ -275,7 +291,7 @@ func (ht *Int64HashMap) ResizeOnDemand(n int, m *mpool.MPool) error {
 			}
 		}
 
-		m.Free(oldData0)
+		oldDeallocator.Deallocate(malloc.NoHints)
 	}
 
 	return nil

--- a/pkg/container/hashtable/malloc.go
+++ b/pkg/container/hashtable/malloc.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hashtable
+
+import (
+	"sync"
+
+	"github.com/matrixorigin/matrixone/pkg/common/malloc"
+)
+
+var getAllocator = func() func() malloc.Allocator {
+	var allocator malloc.Allocator
+	var initOnce sync.Once
+	return func() malloc.Allocator {
+		initOnce.Do(func() {
+			allocator = malloc.GetDefault(nil)
+			// with metrics TODO
+			//allocator = malloc.NewMetricsAllocator(
+			//	allocator,
+			//	metric.MallocCounterMemoryCacheAllocateBytes,
+			//	metric.MallocGaugeMemoryCacheInuseBytes,
+			//	metric.MallocCounterMemoryCacheAllocateObjects,
+			//	metric.MallocGaugeMemoryCacheInuseObjects,
+			//)
+		})
+		return allocator
+	}
+}()

--- a/pkg/sql/colexec/aggexec/distinct.go
+++ b/pkg/sql/colexec/aggexec/distinct.go
@@ -48,7 +48,7 @@ func (d *distinctHash) grows(more int) error {
 
 	var err error
 	for i := oldLen; i < newLen; i++ {
-		if d.maps[i], err = hashmap.NewStrMap(true, d.mp); err != nil {
+		if d.maps[i], err = hashmap.NewStrMap(true); err != nil {
 			return err
 		}
 		d.itrs[i] = d.maps[i].NewIterator()

--- a/pkg/sql/colexec/group/group.go
+++ b/pkg/sql/colexec/group/group.go
@@ -455,21 +455,21 @@ func (ctr *container) initHashMap(proc *process.Process, config *Group) (err err
 	// init the hashmap.
 	switch {
 	case ctr.keyWidth <= 8:
-		if ctr.intHashMap, err = hashmap.NewIntHashMap(ctr.groupVecsNullable, proc.Mp()); err != nil {
+		if ctr.intHashMap, err = hashmap.NewIntHashMap(ctr.groupVecsNullable); err != nil {
 			return err
 		}
 		if config.PreAllocSize > 0 {
-			if err = ctr.intHashMap.PreAlloc(config.PreAllocSize, proc.Mp()); err != nil {
+			if err = ctr.intHashMap.PreAlloc(config.PreAllocSize); err != nil {
 				return err
 			}
 		}
 
 	default:
-		if ctr.strHashMap, err = hashmap.NewStrMap(ctr.groupVecsNullable, proc.Mp()); err != nil {
+		if ctr.strHashMap, err = hashmap.NewStrMap(ctr.groupVecsNullable); err != nil {
 			return err
 		}
 		if config.PreAllocSize > 0 {
-			if err = ctr.strHashMap.PreAlloc(config.PreAllocSize, proc.Mp()); err != nil {
+			if err = ctr.strHashMap.PreAlloc(config.PreAllocSize); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/colexec/hashmap_util/hashmap_util.go
+++ b/pkg/sql/colexec/hashmap_util/hashmap_util.go
@@ -80,15 +80,7 @@ func (hb *HashmapBuilder) Prepare(Conditions []*plan.Expr, proc *process.Process
 			}
 		}
 	}
-	if hb.keyWidth <= 8 {
-		if hb.IntHashMap, err = hashmap.NewIntHashMap(false); err != nil {
-			return err
-		}
-	} else {
-		if hb.StrHashMap, err = hashmap.NewStrMap(false); err != nil {
-			return err
-		}
-	}
+
 	return nil
 }
 
@@ -188,26 +180,33 @@ func (hb *HashmapBuilder) BuildHashmap(hashOnPK bool, needAllocateSels bool, run
 		return nil
 	}
 
-	if err := hb.evalJoinCondition(proc); err != nil {
+	var err error
+	if err = hb.evalJoinCondition(proc); err != nil {
 		return err
 	}
 
 	var itr hashmap.Iterator
 	if hb.keyWidth <= 8 {
+		if hb.IntHashMap, err = hashmap.NewIntHashMap(false); err != nil {
+			return err
+		}
 		itr = hb.IntHashMap.NewIterator()
 	} else {
+		if hb.StrHashMap, err = hashmap.NewStrMap(false); err != nil {
+			return err
+		}
 		itr = hb.StrHashMap.NewIterator()
 	}
 
 	if hashOnPK {
 		// if hash on primary key, prealloc hashmap size to the count of batch
 		if hb.keyWidth <= 8 {
-			err := hb.IntHashMap.PreAlloc(uint64(hb.InputBatchRowCount))
+			err = hb.IntHashMap.PreAlloc(uint64(hb.InputBatchRowCount))
 			if err != nil {
 				return err
 			}
 		} else {
-			err := hb.StrHashMap.PreAlloc(uint64(hb.InputBatchRowCount))
+			err = hb.StrHashMap.PreAlloc(uint64(hb.InputBatchRowCount))
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/colexec/hashmap_util/hashmap_util.go
+++ b/pkg/sql/colexec/hashmap_util/hashmap_util.go
@@ -81,11 +81,11 @@ func (hb *HashmapBuilder) Prepare(Conditions []*plan.Expr, proc *process.Process
 		}
 	}
 	if hb.keyWidth <= 8 {
-		if hb.IntHashMap, err = hashmap.NewIntHashMap(false, proc.Mp()); err != nil {
+		if hb.IntHashMap, err = hashmap.NewIntHashMap(false); err != nil {
 			return err
 		}
 	} else {
-		if hb.StrHashMap, err = hashmap.NewStrMap(false, proc.Mp()); err != nil {
+		if hb.StrHashMap, err = hashmap.NewStrMap(false); err != nil {
 			return err
 		}
 	}
@@ -202,12 +202,12 @@ func (hb *HashmapBuilder) BuildHashmap(hashOnPK bool, needAllocateSels bool, run
 	if hashOnPK {
 		// if hash on primary key, prealloc hashmap size to the count of batch
 		if hb.keyWidth <= 8 {
-			err := hb.IntHashMap.PreAlloc(uint64(hb.InputBatchRowCount), proc.Mp())
+			err := hb.IntHashMap.PreAlloc(uint64(hb.InputBatchRowCount))
 			if err != nil {
 				return err
 			}
 		} else {
-			err := hb.StrHashMap.PreAlloc(uint64(hb.InputBatchRowCount), proc.Mp())
+			err := hb.StrHashMap.PreAlloc(uint64(hb.InputBatchRowCount))
 			if err != nil {
 				return err
 			}
@@ -240,7 +240,7 @@ func (hb *HashmapBuilder) BuildHashmap(hashOnPK bool, needAllocateSels bool, run
 				rate := float64(groupCount) / float64(i)
 				hashmapCount := uint64(float64(hb.InputBatchRowCount) * rate)
 				if hashmapCount > groupCount {
-					err := hb.IntHashMap.PreAlloc(hashmapCount-groupCount, proc.Mp())
+					err := hb.IntHashMap.PreAlloc(hashmapCount - groupCount)
 					if err != nil {
 						return err
 					}
@@ -250,7 +250,7 @@ func (hb *HashmapBuilder) BuildHashmap(hashOnPK bool, needAllocateSels bool, run
 				rate := float64(groupCount) / float64(i)
 				hashmapCount := uint64(float64(hb.InputBatchRowCount) * rate)
 				if hashmapCount > groupCount {
-					err := hb.StrHashMap.PreAlloc(hashmapCount-groupCount, proc.Mp())
+					err := hb.StrHashMap.PreAlloc(hashmapCount - groupCount)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/colexec/intersect/intersect.go
+++ b/pkg/sql/colexec/intersect/intersect.go
@@ -38,7 +38,7 @@ func (intersect *Intersect) OpType() vm.OpType {
 func (intersect *Intersect) Prepare(proc *process.Process) error {
 	var err error
 
-	intersect.ctr.hashTable, err = hashmap.NewStrMap(true, proc.Mp())
+	intersect.ctr.hashTable, err = hashmap.NewStrMap(true)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/colexec/intersectall/intersectall.go
+++ b/pkg/sql/colexec/intersectall/intersectall.go
@@ -43,7 +43,7 @@ func (intersectAll *IntersectAll) OpType() vm.OpType {
 
 func (intersectAll *IntersectAll) Prepare(proc *process.Process) error {
 	var err error
-	if intersectAll.ctr.hashTable, err = hashmap.NewStrMap(true, proc.Mp()); err != nil {
+	if intersectAll.ctr.hashTable, err = hashmap.NewStrMap(true); err != nil {
 		return err
 	}
 	if len(intersectAll.ctr.inserted) == 0 {

--- a/pkg/sql/colexec/mergegroup/group.go
+++ b/pkg/sql/colexec/mergegroup/group.go
@@ -188,7 +188,7 @@ func (ctr *container) process(bat *batch.Batch, proc *process.Process) error {
 
 	case H8:
 		if ctr.intHashMap == nil {
-			if ctr.intHashMap, err = hashmap.NewIntHashMap(ctr.keyNullability, proc.Mp()); err != nil {
+			if ctr.intHashMap, err = hashmap.NewIntHashMap(ctr.keyNullability); err != nil {
 				return err
 			}
 		}
@@ -196,7 +196,7 @@ func (ctr *container) process(bat *batch.Batch, proc *process.Process) error {
 
 	default:
 		if ctr.strHashMap == nil {
-			if ctr.strHashMap, err = hashmap.NewStrMap(ctr.keyNullability, proc.Mp()); err != nil {
+			if ctr.strHashMap, err = hashmap.NewStrMap(ctr.keyNullability); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/colexec/minus/minus.go
+++ b/pkg/sql/colexec/minus/minus.go
@@ -37,7 +37,7 @@ func (minus *Minus) OpType() vm.OpType {
 
 func (minus *Minus) Prepare(proc *process.Process) error {
 	var err error
-	minus.ctr.hashTable, err = hashmap.NewStrMap(true, proc.Mp())
+	minus.ctr.hashTable, err = hashmap.NewStrMap(true)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/colexec/sample/sample.go
+++ b/pkg/sql/colexec/sample/sample.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -155,7 +154,7 @@ func (sample *Sample) Call(proc *process.Process) (vm.CallResult, error) {
 		}
 
 		if ctr.isGroupBy {
-			err = ctr.hashAndSample(bat, proc.Mp())
+			err = ctr.hashAndSample(bat)
 		} else {
 			err = ctr.samplePool.Sample(1, ctr.sampleVectors, nil, bat)
 		}
@@ -218,14 +217,14 @@ func (ctr *container) evaluateSampleAndGroupByColumns(proc *process.Process, bat
 	return nil
 }
 
-func (ctr *container) hashAndSample(bat *batch.Batch, mp *mpool.MPool) (err error) {
+func (ctr *container) hashAndSample(bat *batch.Batch) (err error) {
 	var iterator hashmap.Iterator
 	var groupList []uint64
 	count := bat.RowCount()
 
 	if ctr.useIntHashMap {
 		if ctr.intHashMap == nil {
-			ctr.intHashMap, err = hashmap.NewIntHashMap(ctr.groupVectorsNullable, mp)
+			ctr.intHashMap, err = hashmap.NewIntHashMap(ctr.groupVectorsNullable)
 			if err != nil {
 				return err
 			}
@@ -233,7 +232,7 @@ func (ctr *container) hashAndSample(bat *batch.Batch, mp *mpool.MPool) (err erro
 		iterator = ctr.intHashMap.NewIterator()
 	} else {
 		if ctr.strHashMap == nil {
-			ctr.strHashMap, err = hashmap.NewStrMap(ctr.groupVectorsNullable, mp)
+			ctr.strHashMap, err = hashmap.NewStrMap(ctr.groupVectorsNullable)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/colexec/table_scan/types.go
+++ b/pkg/sql/colexec/table_scan/types.go
@@ -92,7 +92,6 @@ func (tableScan *TableScan) Reset(proc *process.Process, pipelineFailed bool, er
 	}
 	tableScan.ctr.maxAllocSize = 0
 	anal.Alloc(allocSize)
-	tableScan.freeReceiver()
 	tableScan.closeReader()
 }
 
@@ -100,13 +99,6 @@ func (tableScan *TableScan) Free(proc *process.Process, pipelineFailed bool, err
 	if tableScan.ctr.buf != nil {
 		tableScan.ctr.buf.Clean(proc.Mp())
 		tableScan.ctr.buf = nil
-	}
-}
-
-func (tableScan *TableScan) freeReceiver() {
-	if tableScan.ctr.msgReceiver != nil {
-		tableScan.ctr.msgReceiver.Free()
-		tableScan.ctr.msgReceiver = nil
 	}
 }
 

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -534,7 +534,6 @@ func (s *Scope) handleRuntimeFilter(c *Compile) error {
 				exprs = append(exprs, spec.Expr)
 				filters = append(filters, msg)
 			}
-			msgReceiver.Free()
 		}
 	}
 

--- a/pkg/vm/message/joinMapMsg.go
+++ b/pkg/vm/message/joinMapMsg.go
@@ -105,24 +105,30 @@ func (jm *JoinMap) IsValid() bool {
 	return jm.valid
 }
 
-func (jm *JoinMap) Free() {
-	if atomic.AddInt64(&jm.refCnt, -1) != 0 {
-		return
-	}
+func (jm *JoinMap) FreeMemory() {
 	for i := range jm.multiSels {
 		jm.multiSels[i] = nil
 	}
 	jm.multiSels = nil
 	if jm.ihm != nil {
 		jm.ihm.Free()
+		jm.ihm = nil
 	} else if jm.shm != nil {
 		jm.shm.Free()
+		jm.shm = nil
 	}
 	for i := range jm.batches {
 		jm.batches[i].Clean(jm.mpool)
 	}
 	jm.batches = nil
 	jm.valid = false
+}
+
+func (jm *JoinMap) Free() {
+	if atomic.AddInt64(&jm.refCnt, -1) != 0 {
+		return
+	}
+	jm.FreeMemory()
 }
 
 func (jm *JoinMap) Size() int64 {
@@ -154,6 +160,12 @@ func (t JoinMapMsg) Deserialize([]byte) Message {
 
 func (t JoinMapMsg) NeedBlock() bool {
 	return true
+}
+
+func (t JoinMapMsg) Destroy() {
+	if t.JoinMapPtr != nil {
+		t.JoinMapPtr.FreeMemory()
+	}
 }
 
 func (t JoinMapMsg) GetMsgTag() int32 {

--- a/pkg/vm/message/runtimeFilterMsg.go
+++ b/pkg/vm/message/runtimeFilterMsg.go
@@ -55,6 +55,9 @@ func (rt RuntimeFilterMessage) GetMsgTag() int32 {
 	return rt.Tag
 }
 
+func (rt RuntimeFilterMessage) Destroy() {
+}
+
 func (rt RuntimeFilterMessage) GetReceiverAddr() MessageAddress {
 	return AddrBroadCastOnCurrentCN()
 }

--- a/pkg/vm/message/topValueMsg.go
+++ b/pkg/vm/message/topValueMsg.go
@@ -15,8 +15,9 @@
 package message
 
 import (
-	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"strconv"
+
+	"github.com/matrixorigin/matrixone/pkg/objectio"
 )
 
 var _ Message = new(TopValueMessage)
@@ -40,6 +41,9 @@ func (t TopValueMessage) NeedBlock() bool {
 
 func (t TopValueMessage) GetMsgTag() int32 {
 	return t.Tag
+}
+
+func (t TopValueMessage) Destroy() {
 }
 
 func (t TopValueMessage) GetReceiverAddr() MessageAddress {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #18365

## What this PR does / why we need it:
hashtable: add getAllocator

container/hashtable: use malloc in string hashtable

container/hashtable: use malloc in int64 hashtable

fix a bug that sometimes hashtable is not freed, free them when query finished


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored hashmaps to replace `mpool` with `malloc` for memory allocation, improving memory management and removing dependencies.
- Updated various SQL execution components to use the new malloc-based hashmaps.
- Added new memory allocation handling in `malloc.go` for hashtable package.
- Updated tests to reflect changes in memory allocation strategy.
- Fixed potential memory leaks by ensuring proper deallocation in hashmaps.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>inthashmap.go</strong><dd><code>Refactor IntHashMap to use malloc instead of mpool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/hashmap/inthashmap.go

<li>Removed <code>mpool</code> dependency from <code>NewIntHashMap</code> function.<br> <li> Updated <code>Free</code> and <code>PreAlloc</code> methods to not require <code>mpool</code>.<br> <li> Simplified initialization of <code>IntHashMap</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-7e8abadc4d3cc207abaf1800a83c03c5fe1972de2295977eb2b9545131fb2436">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>iterator.go</strong><dd><code>Refactor iterator methods to remove mpool dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/hashmap/iterator.go

<li>Removed <code>mpool</code> parameter from <code>InsertStringBatch</code> and <code>InsertBatch</code> <br>methods.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-076226b852dd6f825853e3be6c80a57937515ac61a2fe8e3105e5d9b71763f56">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>strhashmap.go</strong><dd><code>Refactor StrHashMap to use malloc instead of mpool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/hashmap/strhashmap.go

<li>Removed <code>mpool</code> dependency from <code>NewStrMap</code> function.<br> <li> Updated <code>Free</code> and <code>PreAlloc</code> methods to not require <code>mpool</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-1fb4b0a8973834c903c3e3daf4b56603affa2f0588fcb4d8b4da37ac1cf75ad5">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Remove mpool from hashmap types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/hashmap/types.go

- Removed `mpool` from `StrHashMap` and `IntHashMap` structs.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-4a969d4043c68b6fc4c695a2f7385eebfbf0b7b86f56beac5ce96c052c854b7d">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>malloc.go</strong><dd><code>Introduce malloc-based allocator for hashtable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/malloc.go

- Added new file to handle memory allocation using `malloc`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-19946c6236c39e59182736f8ae376be1742733102e27f1335c5e2883c8c5ca33">+40/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>int64_hash_map.go</strong><dd><code>Refactor Int64HashMap to use malloc for memory management</code></dd></summary>
<hr>

pkg/container/hashtable/int64_hash_map.go

<li>Replaced <code>mpool</code> with <code>malloc</code> for memory allocation.<br> <li> Added deallocator handling for <code>rawData</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-772d0fd88084fa275aea0e5fd881966931ca7c5f7459220992d5df6eca565564">+39/-23</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>string_hash_map.go</strong><dd><code>Refactor StringHashMap to use malloc for memory management</code></dd></summary>
<hr>

pkg/container/hashtable/string_hash_map.go

<li>Replaced <code>mpool</code> with <code>malloc</code> for memory allocation.<br> <li> Added deallocator handling for <code>rawData</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-1e80a3584223d76a842b76dd5fc96065b2b7d0c0e5bf69d5b439591cf59af273">+39/-23</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>distinct.go</strong><dd><code>Use malloc in distinctHash initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/aggexec/distinct.go

- Updated `distinctHash` to use `malloc` instead of `mpool`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-9fc31975350f4eef676f2ee4ca5992d5e37af247f6d2934b60ba083a67d2af71">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>group.go</strong><dd><code>Refactor group initialization to use malloc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/group/group.go

- Updated group initialization to use `malloc` instead of `mpool`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-7dbdbce3ed6c3f03c5a3bd5419acf07e900f03ff08ebcc118e26ee5fa4611bd8">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Refactor HashmapBuilder to use malloc and improve memory management</code></dd></summary>
<hr>

pkg/sql/colexec/hashbuild/types.go

<li>Updated <code>HashmapBuilder</code> to use <code>malloc</code> instead of <code>mpool</code>.<br> <li> Added <code>Reset</code> method to handle memory cleanup.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-270d27fc945ebbe16cfb88efa16c176856d021853abfe9c6429a8d7ca48d6c5f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>intersect.go</strong><dd><code>Use malloc in Intersect initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/intersect/intersect.go

- Updated `Intersect` to use `malloc` instead of `mpool`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-a7a2596d3645f35e337c0f81f33548eace38392d086cd4c343c6a95fcce72616">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>intersectall.go</strong><dd><code>Use malloc in IntersectAll initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/intersectall/intersectall.go

- Updated `IntersectAll` to use `malloc` instead of `mpool`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-dc1c74a58558d6e5fe11e60187e9f2b6259f8834f783fdae228b780856a59ee7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>group.go</strong><dd><code>Refactor merge group processing to use malloc</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/mergegroup/group.go

- Updated merge group processing to use `malloc` instead of `mpool`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-879ea38b434d82cd5a0927f349a6a79f6c955faf5dc97c23d9e38c5a348faa8d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>inthashmap_test.go</strong><dd><code>Update IntHashMap tests for malloc refactoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/hashmap/inthashmap_test.go

- Updated tests to reflect removal of `mpool` from `NewIntHashMap`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-8ca75a66143f961ca3f2deb17fc4ba2bf385263523f03c2d4c693423e960b037">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>strhashmap_test.go</strong><dd><code>Update StrHashMap tests for malloc refactoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/hashmap/strhashmap_test.go

- Updated tests to reflect removal of `mpool` from `NewStrMap`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18553/files#diff-646bb7e4a4b7b39ee66ed3687a1c94b23f94e88bd2ed4e0bcae7ec3721af22f8">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

