### PR TITLE
Refactor snapshot

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -45,7 +45,6 @@ const (
 )
 
 func TestBackupData(t *testing.T) {
-	t.Skipf("Skip TestBackupData")
 	defer testutils.AfterTest(t)()
 	testutils.EnsureNoLeak(t)
 	ctx := context.Background()

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -45,6 +45,7 @@ const (
 )
 
 func TestBackupData(t *testing.T) {
+	t.Skipf("Skip TestBackupData")
 	defer testutils.AfterTest(t)()
 	testutils.EnsureNoLeak(t)
 	ctx := context.Background()

--- a/pkg/vm/engine/tae/blockio/funcs.go
+++ b/pkg/vm/engine/tae/blockio/funcs.go
@@ -194,3 +194,24 @@ func LoadOneBlock(
 		uint32(key.ID()), idxes, fileservice.SkipAllCache, fs)
 	return bat, sortKey, err
 }
+
+func LoadOneBlockWithIndex(
+	ctx context.Context,
+	fs fileservice.FileService,
+	idxes []uint16,
+	key objectio.Location,
+	metaType objectio.DataMetaType,
+) (*batch.Batch, uint16, error) {
+	sortKey := uint16(math.MaxUint16)
+	meta, err := objectio.FastLoadObjectMeta(ctx, &key, false, fs)
+	if err != nil {
+		return nil, sortKey, err
+	}
+	data := meta.MustGetMeta(metaType)
+	if data.BlockHeader().Appendable() {
+		sortKey = data.BlockHeader().SortKey()
+	}
+	bat, err := objectio.ReadOneBlockAllColumns(ctx, &data, key.Name().String(),
+		uint32(key.ID()), idxes, fileservice.SkipAllCache, fs)
+	return bat, sortKey, err
+}

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -284,11 +284,16 @@ func BlockDataReadBackup(
 	sid string,
 	info *objectio.BlockInfo,
 	ds engine.DataSource,
+	idxes []uint16,
 	ts types.TS,
 	fs fileservice.FileService,
 ) (loaded *batch.Batch, sortKey uint16, err error) {
+	if len(idxes) == 0 {
+		loaded, sortKey, err = LoadOneBlock(ctx, fs, info.MetaLocation(), objectio.SchemaData)
+	} else {
+		loaded, sortKey, err = LoadOneBlockWithIndex(ctx, fs, idxes, info.MetaLocation(), objectio.SchemaData)
+	}
 	// read block data from storage specified by meta location
-	loaded, sortKey, err = LoadOneBlock(ctx, fs, info.MetaLocation(), objectio.SchemaData)
 	if err != nil {
 		return
 	}

--- a/pkg/vm/engine/tae/db/gc/v2/table.go
+++ b/pkg/vm/engine/tae/db/gc/v2/table.go
@@ -167,13 +167,24 @@ func isSnapshotRefers(obj *ObjectEntry, snapVec []types.TS, name string) bool {
 	if len(snapVec) == 0 {
 		return false
 	}
+	if obj.dropTS.IsEmpty() {
+		logutil.Debug("[soft GC]Snapshot Refers",
+			zap.String("name", name),
+			zap.String("snapTS", snapVec[0].ToString()),
+			zap.String("createTS", obj.createTS.ToString()),
+			zap.String("dropTS", obj.dropTS.ToString()))
+		return true
+	}
 	left, right := 0, len(snapVec)-1
 	for left <= right {
 		mid := left + (right-left)/2
 		snapTS := snapVec[mid]
-		if snapTS.GreaterEq(&obj.createTS) && (obj.dropTS.IsEmpty() || snapTS.Less(&obj.dropTS)) {
-			logutil.Debug("[soft GC]Snapshot Refers", zap.String("name", name), zap.String("snapTS", snapTS.ToString()),
-				zap.String("createTS", obj.createTS.ToString()), zap.String("dropTS", obj.dropTS.ToString()))
+		if snapTS.GreaterEq(&obj.createTS) && snapTS.Less(&obj.dropTS) {
+			logutil.Debug("[soft GC]Snapshot Refers",
+				zap.String("name", name),
+				zap.String("snapTS", snapTS.ToString()),
+				zap.String("createTS", obj.createTS.ToString()),
+				zap.String("dropTS", obj.dropTS.ToString()))
 			return true
 		} else if snapTS.Less(&obj.createTS) {
 			left = mid + 1
@@ -429,7 +440,8 @@ func (t *GCTable) compareObjects(objects, compareObjects map[string]*ObjectEntry
 	for name, entry := range compareObjects {
 		object := objects[name]
 		if object == nil {
-			logutil.Infof("object %s is nil, create %v, drop %v", name, entry.createTS.ToString(), entry.dropTS.ToString())
+			logutil.Infof("object %s is nil, create %v, drop %v",
+				name, entry.createTS.ToString(), entry.dropTS.ToString())
 			return false
 		}
 		if !entry.commitTS.Equal(&object.commitTS) {

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -6504,6 +6504,9 @@ func TestSnapshotMeta(t *testing.T) {
 		rel5, err = database3.CreateRelation(snapshotSchema2)
 		assert.Nil(t, err)
 		assert.Nil(t, txn.Commit(context.Background()))
+		db.DiskCleaner.GetCleaner().SetTid(rel3.ID())
+		db.DiskCleaner.GetCleaner().SetTid(rel4.ID())
+		db.DiskCleaner.GetCleaner().SetTid(rel5.ID())
 	}
 	//db.DiskCleaner.GetCleaner().DisableGCForTest()
 

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -4068,25 +4068,6 @@ func TestDirtyWatchRace(t *testing.T) {
 	wg.Wait()
 }
 
-type TestBlockReadDeltaSource struct {
-	deltaLoc objectio.Location
-	testTs   types.TS
-}
-
-func (b *TestBlockReadDeltaSource) SetTS(ts types.TS) {
-	b.testTs = ts
-}
-
-func (b *TestBlockReadDeltaSource) GetDeltaLoc(bid objectio.Blockid) (objectio.Location, types.TS) {
-	return b.deltaLoc, b.testTs
-}
-
-func NewTestBlockReadSource(deltaLoc objectio.Location) logtail.DeltaSource {
-	return &TestBlockReadDeltaSource{
-		deltaLoc: deltaLoc,
-	}
-}
-
 func TestBlockRead(t *testing.T) {
 	blockio.RunPipelineTest(
 		func() {
@@ -4126,8 +4107,7 @@ func TestBlockRead(t *testing.T) {
 			tombstoneObjectEntry := testutil.GetOneTombstoneMeta(rel)
 			objectEntry := testutil.GetOneBlockMeta(rel)
 			objStats := tombstoneObjectEntry.ObjectMVCCNode
-			testDS := NewTestBlockReadSource(objStats.ObjectLocation())
-			ds := logtail.NewDeltaLocDataSource(ctx, tae.DB.Runtime.Fs.Service, beforeDel, testDS)
+			ds := logtail.NewSnapshotDataSource(ctx, tae.DB.Runtime.Fs.Service, beforeDel, []objectio.ObjectStats{objStats.ObjectStats})
 			bid, _ := blkEntry.ID(), blkEntry.ID()
 
 			info := &objectio.BlockInfo{
@@ -4180,7 +4160,7 @@ func TestBlockRead(t *testing.T) {
 			assert.Equal(t, len(columns), len(b1.Vecs))
 			assert.Equal(t, 20, b1.Vecs[0].Length())
 
-			testDS.SetTS(afterFirstDel)
+			ds.SetTS(afterFirstDel)
 
 			b2 := buildBatch(colTyps)
 			err = blockio.BlockDataReadInner(
@@ -4190,7 +4170,7 @@ func TestBlockRead(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, 19, b2.Vecs[0].Length())
 
-			testDS.SetTS(afterSecondDel)
+			ds.SetTS(afterSecondDel)
 
 			b3 := buildBatch(colTyps)
 			err = blockio.BlockDataReadInner(

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -57,10 +57,12 @@ type tableOffset struct {
 }
 
 type BackupDeltaLocDataSource struct {
-	ctx context.Context
-	fs  fileservice.FileService
-	ts  types.TS
-	ds  map[string]*objData
+	ctx        context.Context
+	fs         fileservice.FileService
+	ts         types.TS
+	ds         map[string]*objData
+	tombstones []objectio.ObjectStats
+	needShrink bool
 }
 
 func NewBackupDeltaLocDataSource(
@@ -70,11 +72,18 @@ func NewBackupDeltaLocDataSource(
 	ds map[string]*objData,
 ) *BackupDeltaLocDataSource {
 	return &BackupDeltaLocDataSource{
-		ctx: ctx,
-		fs:  fs,
-		ts:  ts,
-		ds:  ds,
+		ctx:        ctx,
+		fs:         fs,
+		ts:         ts,
+		ds:         ds,
+		needShrink: true,
 	}
+}
+
+func (d *BackupDeltaLocDataSource) SetTS(
+	ts types.TS,
+) {
+	d.ts = ts
 }
 
 func (d *BackupDeltaLocDataSource) Next(
@@ -92,15 +101,6 @@ func (d *BackupDeltaLocDataSource) Next(
 
 func (d *BackupDeltaLocDataSource) Close() {
 
-}
-
-func (d *BackupDeltaLocDataSource) ApplyTombstones(
-	_ context.Context,
-	_ objectio.Blockid,
-	_ []int64,
-	_ engine.TombstoneApplyPolicy,
-) ([]int64, error) {
-	panic("Not Support ApplyTombstones")
 }
 
 func (d *BackupDeltaLocDataSource) SetOrderBy(orderby []*plan.OrderBySpec) {
@@ -126,14 +126,47 @@ func ForeachTombstoneObject(
 			}
 		}
 	}
-
 	return nil
+}
+
+func buildDS(
+	onTombstone func(tombstone objectio.ObjectStats) (next bool, err error),
+	ds []objectio.ObjectStats,
+) error {
+	for _, d := range ds {
+		if next, err := onTombstone(d); !next || err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *BackupDeltaLocDataSource) ApplyTombstones(
+	ctx context.Context,
+	bid objectio.Blockid,
+	rowsOffset []int64,
+	applyPolicy engine.TombstoneApplyPolicy,
+) ([]int64, error) {
+	deleteMask, err := d.GetTombstones(ctx, bid)
+	if err != nil {
+		return nil, err
+	}
+	var rows []int64
+	if !deleteMask.IsEmpty() {
+		for _, row := range rowsOffset {
+			if !deleteMask.Contains(uint64(row)) {
+				rows = append(rows, row)
+			}
+		}
+	}
+	return rows, nil
 }
 
 func GetTombstonesByBlockId(
 	bid objectio.Blockid,
 	deleteMask *nulls.Nulls,
 	scanOp func(func(tombstone *objData) (bool, error)) error,
+	needShrink bool,
 ) (err error) {
 
 	onTombstone := func(oData *objData) (bool, error) {
@@ -163,7 +196,9 @@ func GetTombstonesByBlockId(
 
 			// Shrink the tombstone batch, Because the rowid in the tombstone is no longer needed after apply,
 			// it cannot be written to disk
-			oData.data[idx].Shrink(deleteRows, true)
+			if needShrink {
+				oData.data[idx].Shrink(deleteRows, true)
+			}
 		}
 		return true, nil
 	}
@@ -173,11 +208,57 @@ func GetTombstonesByBlockId(
 }
 
 func (d *BackupDeltaLocDataSource) GetTombstones(
-	_ context.Context, bid objectio.Blockid,
+	ctx context.Context, bid objectio.Blockid,
 ) (deletedRows *nulls.Nulls, err error) {
 	deletedRows = &nulls.Nulls{}
 	deletedRows.InitWithSize(8192)
-
+	if len(d.tombstones) > 0 {
+		if err := buildDS(
+			func(tombstone objectio.ObjectStats) (bool, error) {
+				if !tombstone.ZMIsEmpty() {
+					objZM := tombstone.SortKeyZoneMap()
+					if skip := !objZM.PrefixEq(bid[:]); skip {
+						return true, nil
+					}
+				}
+				name := tombstone.ObjectName()
+				logutil.Infof("[GetSnapshot] tombstone object %v", name.String())
+				bat, _, err := blockio.LoadOneBlock(ctx, d.fs, tombstone.ObjectLocation(), objectio.SchemaData)
+				if err != nil {
+					return false, err
+				}
+				if !tombstone.GetCNCreated() {
+					deleteRow := make([]int64, 0)
+					for v := 0; v < bat.Vecs[0].Length(); v++ {
+						var commitTs types.TS
+						err = commitTs.Unmarshal(bat.Vecs[len(bat.Vecs)-1].GetRawBytesAt(v))
+						if err != nil {
+							return false, err
+						}
+						if commitTs.Greater(&d.ts) {
+							logutil.Debugf("delete row %v, commitTs %v, location %v",
+								v, commitTs.ToString(), name.String())
+						} else {
+							deleteRow = append(deleteRow, int64(v))
+						}
+					}
+					if len(deleteRow) != bat.Vecs[0].Length() {
+						bat.Shrink(deleteRow, false)
+					}
+				}
+				d.ds[name.String()] = &objData{
+					stats:      &tombstone,
+					dataType:   objectio.SchemaData,
+					sortKey:    uint16(math.MaxUint16),
+					data:       make([]*batch.Batch, 0),
+					appendable: true,
+				}
+				d.ds[name.String()].data = append(d.ds[name.String()].data, bat)
+				return true, nil
+			}, d.tombstones); err != nil {
+			return nil, err
+		}
+	}
 	scanOp := func(onTombstone func(tombstone *objData) (bool, error)) (err error) {
 		return ForeachTombstoneObject(onTombstone, d.ds)
 	}
@@ -185,7 +266,8 @@ func (d *BackupDeltaLocDataSource) GetTombstones(
 	if err := GetTombstonesByBlockId(
 		bid,
 		deletedRows,
-		scanOp); err != nil {
+		scanOp,
+		d.needShrink); err != nil {
 		return nil, err
 	}
 	return
@@ -569,7 +651,7 @@ func ReWriteCheckpointAndBlockFromKey(
 				BlockID: *objectio.BuildObjectBlockid(name, uint16(0)),
 				MetaLoc: objectio.ObjectLocation(metaLoc),
 			}
-			bat, sortKey, err := blockio.BlockDataReadBackup(ctx, sid, &blk, ds, ts, fs)
+			bat, sortKey, err := blockio.BlockDataReadBackup(ctx, sid, &blk, ds, nil, ts, fs)
 			if err != nil {
 				return true, err
 			}

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -142,24 +142,12 @@ func buildDS(
 }
 
 func (d *BackupDeltaLocDataSource) ApplyTombstones(
-	ctx context.Context,
-	bid objectio.Blockid,
-	rowsOffset []int64,
-	applyPolicy engine.TombstoneApplyPolicy,
+	_ context.Context,
+	_ objectio.Blockid,
+	_ []int64,
+	_ engine.TombstoneApplyPolicy,
 ) ([]int64, error) {
-	deleteMask, err := d.GetTombstones(ctx, bid)
-	if err != nil {
-		return nil, err
-	}
-	var rows []int64
-	if !deleteMask.IsEmpty() {
-		for _, row := range rowsOffset {
-			if !deleteMask.Contains(uint64(row)) {
-				rows = append(rows, row)
-			}
-		}
-	}
-	return rows, nil
+	panic("Not Support ApplyTombstones")
 }
 
 func GetTombstonesByBlockId(

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -103,6 +103,14 @@ func (d *BackupDeltaLocDataSource) Close() {
 
 }
 
+func (d *BackupDeltaLocDataSource) ApplyTombstones(
+	_ context.Context,
+	_ objectio.Blockid,
+	_ []int64,
+	_ engine.TombstoneApplyPolicy,
+) ([]int64, error) {
+	panic("Not Support ApplyTombstones")
+}
 func (d *BackupDeltaLocDataSource) SetOrderBy(orderby []*plan.OrderBySpec) {
 	panic("Not Support order by")
 }
@@ -139,15 +147,6 @@ func buildDS(
 		}
 	}
 	return nil
-}
-
-func (d *BackupDeltaLocDataSource) ApplyTombstones(
-	_ context.Context,
-	_ objectio.Blockid,
-	_ []int64,
-	_ engine.TombstoneApplyPolicy,
-) ([]int64, error) {
-	panic("Not Support ApplyTombstones")
 }
 
 func GetTombstonesByBlockId(

--- a/pkg/vm/engine/tae/logtail/snapshot.go
+++ b/pkg/vm/engine/tae/logtail/snapshot.go
@@ -222,7 +222,6 @@ func (sm *SnapshotMeta) updateTableInfo(ctx context.Context, fs fileservice.File
 			createAt: createTS,
 			deleteAt: deleteTS,
 		}
-		return
 	}
 	collectObjects(&objects, data.GetObjectBatchs(), collector)
 	collectObjects(&tombstones, data.GetTombstoneObjectBatchs(), collector)
@@ -428,8 +427,9 @@ func (sm *SnapshotMeta) Update(
 		}
 		logutil.Info("[UpdateSnapshot] Delete object",
 			zap.Uint64("table id", tid),
-			zap.String("object name", id.String()))
-		zap.String("delete at", deleteTS.ToString())
+			zap.String("object name", id.String()),
+			zap.String("delete at", deleteTS.ToString()))
+
 		delete(oMap, id)
 	}
 	collectObjects(&sm.objects, data.GetObjectBatchs(), collector)

--- a/pkg/vm/engine/tae/logtail/snapshot.go
+++ b/pkg/vm/engine/tae/logtail/snapshot.go
@@ -18,12 +18,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
-	"github.com/matrixorigin/matrixone/pkg/container/nulls"
-	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 
 	"go.uber.org/zap"
@@ -39,7 +38,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
 )
 
 const (
@@ -76,18 +74,6 @@ var (
 		types.New(types.T_uint64, 0, 0),
 	}
 
-	objectDeltaSchemaAttr = []string{
-		catalog2.BlockMeta_ID,
-		catalog2.BlockMeta_DeltaLoc,
-		SnapshotAttr_TID,
-	}
-
-	objectDeltaSchemaTypes = []types.Type{
-		types.New(types.T_Blockid, 0, 0),
-		types.New(types.T_varchar, types.MaxVarcharLen, 0),
-		types.New(types.T_uint64, 0, 0),
-	}
-
 	tableInfoSchemaAttr = []string{
 		catalog2.SystemColAttr_AccID,
 		catalog2.SystemRelAttr_DBID,
@@ -116,189 +102,75 @@ var (
 	}
 )
 
-type DeltaSource interface {
-	GetDeltaLoc(bid objectio.Blockid) (objectio.Location, types.TS)
-	SetTS(ts types.TS)
-}
-
-type ObjectMapDeltaSource struct {
-	objectMeta map[objectio.Segmentid]*objectInfo
-}
-
-func NewOMapDeltaSource(objectMeta map[objectio.Segmentid]*objectInfo) DeltaSource {
-	return &ObjectMapDeltaSource{
-		objectMeta: objectMeta,
-	}
-}
-
-func (m *ObjectMapDeltaSource) GetDeltaLoc(bid objectio.Blockid) (objectio.Location, types.TS) {
-	segment := bid.Segment()
-	oInfo, ok := m.objectMeta[*segment]
-	if !ok {
-		return objectio.Location{}, types.TS{}
-	}
-	if oInfo.deltaLocation == nil {
-		return objectio.Location{}, types.TS{}
-	}
-	return *oInfo.deltaLocation[uint32(bid.Sequence())], types.TS{}
-}
-
-func (m *ObjectMapDeltaSource) SetTS(ts types.TS) {
-	panic("implement me")
-}
-
-type DeltaLocDataSource struct {
-	ctx context.Context
-	fs  fileservice.FileService
-	ts  types.TS
-	ds  DeltaSource
-}
-
-func NewDeltaLocDataSource(
-	ctx context.Context,
-	fs fileservice.FileService,
-	ts types.TS,
-	ds DeltaSource,
-) *DeltaLocDataSource {
-	return &DeltaLocDataSource{
-		ctx: ctx,
-		fs:  fs,
-		ts:  ts,
-		ds:  ds,
-	}
-}
-
-func (d *DeltaLocDataSource) Next(
-	_ context.Context,
-	_ []string,
-	_ []types.Type,
-	_ []uint16,
-	_ any,
-	_ *mpool.MPool,
-	_ engine.VectorPool,
-	_ *batch.Batch,
-) (*objectio.BlockInfo, engine.DataState, error) {
-	return nil, engine.Persisted, nil
-}
-
-func (d *DeltaLocDataSource) Close() {
-
-}
-
-func (d *DeltaLocDataSource) ApplyTombstones(
-	ctx context.Context,
-	bid objectio.Blockid,
-	rowsOffset []int64,
-	applyPolicy engine.TombstoneApplyPolicy,
-) ([]int64, error) {
-	deleteMask, err := d.getAndApplyTombstones(ctx, bid)
-	if err != nil {
-		return nil, err
-	}
-	var rows []int64
-	if !deleteMask.IsEmpty() {
-		for _, row := range rowsOffset {
-			if !deleteMask.Contains(uint64(row)) {
-				rows = append(rows, row)
-			}
-		}
-	}
-	return rows, nil
-}
-
-func (d *DeltaLocDataSource) GetTombstones(
-	ctx context.Context, bid objectio.Blockid,
-) (deletedRows *nulls.Nulls, err error) {
-	var rows *nulls.Bitmap
-	rows, err = d.getAndApplyTombstones(ctx, bid)
-	if err != nil {
-		return
-	}
-	if rows == nil || rows.IsEmpty() {
-		return
-	}
-	return rows, nil
-}
-
-func (d *DeltaLocDataSource) getAndApplyTombstones(
-	ctx context.Context, bid objectio.Blockid,
-) (*nulls.Bitmap, error) {
-	deltaLoc, ts := d.ds.GetDeltaLoc(bid)
-	if deltaLoc.IsEmpty() {
-		return nil, nil
-	}
-	logutil.Infof("deltaLoc: %v, id is %d", deltaLoc.String(), bid.Sequence())
-	deletes, _, release, err := blockio.ReadBlockDelete(ctx, deltaLoc, d.fs)
-	if err != nil {
-		return nil, err
-	}
-	defer release()
-	if ts.IsEmpty() {
-		ts = d.ts
-	}
-	return blockio.EvalDeleteRowsByTimestamp(deletes, ts, &bid), nil
-}
-
-func (d *DeltaLocDataSource) SetOrderBy(orderby []*plan.OrderBySpec) {
-	panic("Not Support order by")
-}
-
-func (d *DeltaLocDataSource) GetOrderBy() []*plan.OrderBySpec {
-	panic("Not Support order by")
-}
-
-func (d *DeltaLocDataSource) SetFilterZM(zm objectio.ZoneMap) {
-	panic("Not Support order by")
-}
-
 type objectInfo struct {
-	stats         objectio.ObjectStats
-	deltaLocation map[uint32]*objectio.Location
-	createAt      types.TS
-	deleteAt      types.TS
+	stats    objectio.ObjectStats
+	createAt types.TS
+	deleteAt types.TS
+}
+
+type tableInfo struct {
+	accountID uint32
+	dbID      uint64
+	tid       uint64
+	createAt  types.TS
+	deleteAt  types.TS
 }
 
 type SnapshotMeta struct {
 	sync.RWMutex
-	objects     map[uint64]map[objectio.Segmentid]*objectInfo
-	tid         uint64
-	tables      map[uint32]map[uint64]*TableInfo
-	acctIndexes map[uint64]*TableInfo
-	tides       map[uint64]struct{}
-}
 
-type TableInfo struct {
-	accID    uint32
-	dbID     uint64
-	tid      uint64
-	createAt types.TS
-	deleteAt types.TS
+	// all objects&tombstones in the mo_snapshots table, because there
+	// will be multiple mo_snapshots, so here is a map, the key is tid.
+	objects    map[uint64]map[objectio.Segmentid]*objectInfo
+	tombstones map[uint64]map[objectio.Segmentid]*objectInfo
+
+	// tables records all the table information of mo, the key is account id,
+	// and the map is the mapping of table id and table information.
+	//
+	// tables is used to facilitate the use of an account id to obtain
+	// all table information under the account.
+	tables map[uint32]map[uint64]*tableInfo
+
+	// acctIndexes records all the index information of mo, the key is
+	// account id, and the value is the index information.
+	acctIndexes map[uint64]*tableInfo
+
+	// pkIndexes records all the index information of mo, the key is
+	// the mo_table pk, and the value is the index information.
+	pkIndexes map[string][]*tableInfo
+
+	// tides is used to consume the object and tombstone of the checkpoint.
+	tides map[uint64]struct{}
 }
 
 func NewSnapshotMeta() *SnapshotMeta {
 	return &SnapshotMeta{
 		objects:     make(map[uint64]map[objectio.Segmentid]*objectInfo),
-		tables:      make(map[uint32]map[uint64]*TableInfo),
-		acctIndexes: make(map[uint64]*TableInfo),
+		tombstones:  make(map[uint64]map[objectio.Segmentid]*objectInfo),
+		tables:      make(map[uint32]map[uint64]*tableInfo),
+		acctIndexes: make(map[uint64]*tableInfo),
 		tides:       make(map[uint64]struct{}),
+		pkIndexes:   make(map[string][]*tableInfo),
 	}
 }
 
-func (sm *SnapshotMeta) CopyObjectsLocked() map[uint64]map[objectio.Segmentid]*objectInfo {
-	objects := make(map[uint64]map[objectio.Segmentid]*objectInfo)
-	for k, v := range sm.objects {
-		objects[k] = make(map[objectio.Segmentid]*objectInfo)
+func copyObjectsLocked(
+	objects map[uint64]map[objectio.Segmentid]*objectInfo,
+) map[uint64]map[objectio.Segmentid]*objectInfo {
+	newMap := make(map[uint64]map[objectio.Segmentid]*objectInfo)
+	for k, v := range objects {
+		newMap[k] = make(map[objectio.Segmentid]*objectInfo)
 		for kk, vv := range v {
-			objects[k][kk] = vv
+			newMap[k][kk] = vv
 		}
 	}
-	return objects
+	return newMap
 }
 
-func (sm *SnapshotMeta) CopyTablesLocked() map[uint32]map[uint64]*TableInfo {
-	tables := make(map[uint32]map[uint64]*TableInfo)
+func (sm *SnapshotMeta) copyTablesLocked() map[uint32]map[uint64]*tableInfo {
+	tables := make(map[uint32]map[uint64]*tableInfo)
 	for k, v := range sm.tables {
-		tables[k] = make(map[uint64]*TableInfo)
+		tables[k] = make(map[uint64]*tableInfo)
 		for kk, vv := range v {
 			tables[k][kk] = vv
 		}
@@ -306,148 +178,296 @@ func (sm *SnapshotMeta) CopyTablesLocked() map[uint32]map[uint64]*TableInfo {
 	return tables
 }
 
-func (sm *SnapshotMeta) updateTableInfo(data *CheckpointData) {
-	insTable, insTableTxn, _, _, delTableTxn := data.GetTblBatchs()
-	insAccIDs := vector.MustFixedColWithTypeCheck[uint32](insTable.GetVectorByName(catalog2.SystemColAttr_AccID).GetDownstreamVector())
-	insTIDs := vector.MustFixedColWithTypeCheck[uint64](insTable.GetVectorByName(catalog2.SystemRelAttr_ID).GetDownstreamVector())
-	insDBIDs := vector.MustFixedColWithTypeCheck[uint64](insTable.GetVectorByName(catalog2.SystemRelAttr_DBID).GetDownstreamVector())
-	insCreateAts := vector.MustFixedColWithTypeCheck[types.TS](insTableTxn.GetVectorByName(txnbase.SnapshotAttr_CommitTS).GetDownstreamVector())
-	insTableNameVec := insTable.GetVectorByName(catalog2.SystemRelAttr_Name).GetDownstreamVector()
-	insTableArea := insTableNameVec.GetArea()
-	insTableNames := vector.MustFixedColWithTypeCheck[types.Varlena](insTableNameVec)
-	for i := 0; i < insTable.Length(); i++ {
-		tid := insTIDs[i]
-		name := string(insTableNames[i].GetByteSlice(insTableArea))
-		if name == "mo_snapshots" {
-			if sm.tid == 0 {
-				//for ut
-				sm.SetTid(tid)
-			}
-			logutil.Info("[UpdateSnapTable]", zap.Uint64("tid", tid))
-			sm.tides[tid] = struct{}{}
-		}
-		accID := insAccIDs[i]
-		if sm.tables[accID] == nil {
-			sm.tables[accID] = make(map[uint64]*TableInfo)
-		}
-		dbid := insDBIDs[i]
-		createAt := insCreateAts[i]
-		if sm.tables[accID][tid] != nil {
-			continue
-		}
-		table := &TableInfo{
-			accID:    accID,
-			dbID:     dbid,
-			tid:      tid,
-			createAt: createAt,
-		}
-		sm.tables[accID][tid] = table
+func isMoTable(tid uint64) bool {
+	return tid == catalog2.MO_TABLES_ID
+}
 
-		if sm.acctIndexes[tid] == nil {
+type tombstone struct {
+	pk types.Tuple
+	ts types.TS
+}
+
+func (sm *SnapshotMeta) updateTableInfo(ctx context.Context, fs fileservice.FileService, data *CheckpointData) error {
+	var objects map[uint64]map[objectio.Segmentid]*objectInfo
+	var tombstones map[uint64]map[objectio.Segmentid]*objectInfo
+	objects = make(map[uint64]map[objectio.Segmentid]*objectInfo, 1)
+	tombstones = make(map[uint64]map[objectio.Segmentid]*objectInfo, 1)
+	objects[catalog2.MO_TABLES_ID] = make(map[objectio.Segmentid]*objectInfo)
+	tombstones[catalog2.MO_TABLES_ID] = make(map[objectio.Segmentid]*objectInfo)
+	collector := func(
+		objects *map[uint64]map[objectio.Segmentid]*objectInfo,
+		tid uint64,
+		stats objectio.ObjectStats,
+		createTS types.TS, deleteTS types.TS,
+	) {
+		if !isMoTable(tid) {
+			return
+		}
+		if !stats.GetAppendable() {
+			// mo_table only consumes appendable object
+			return
+		}
+		id := stats.ObjectName().SegmentId()
+		if deleteTS.IsEmpty() {
+			return
+		}
+		moTable := (*objects)[tid]
+		if moTable[id] != nil {
+			// mo_table only consumes  appendable object that is
+			// soft deleted once, otherwise panic
+			panic(fmt.Sprintf("duplicate object %v", id.String()))
+		}
+		moTable[id] = &objectInfo{
+			stats:    stats,
+			createAt: createTS,
+			deleteAt: deleteTS,
+		}
+		return
+	}
+	collectObjects(&objects, data.GetObjectBatchs(), collector)
+	collectObjects(&tombstones, data.GetTombstoneObjectBatchs(), collector)
+	tObjects := objects[catalog2.MO_TABLES_ID]
+	tTombstones := tombstones[catalog2.MO_TABLES_ID]
+	for _, info := range tObjects {
+		if info.stats.BlkCnt() != 1 {
+			panic(fmt.Sprintf("mo_table object %v blk cnt %v",
+				info.stats.ObjectName(), info.stats.BlkCnt()))
+		}
+		objectBat, _, err := blockio.LoadOneBlock(
+			ctx, fs, info.stats.ObjectLocation(), objectio.SchemaData)
+		if err != nil {
+			return err
+		}
+		// 0 is table id
+		// 1 is table name
+		// 11 is account id
+		// len(objectBat.Vecs)-1 is commit ts
+		ids := vector.MustFixedColWithTypeCheck[uint64](objectBat.Vecs[0])
+		nameVarlena := vector.MustFixedColWithTypeCheck[types.Varlena](objectBat.Vecs[1])
+		nameArea := objectBat.Vecs[1].GetArea()
+		dbs := vector.MustFixedColWithTypeCheck[uint64](objectBat.Vecs[3])
+		accounts := vector.MustFixedColWithTypeCheck[uint32](objectBat.Vecs[11])
+		creates := vector.MustFixedColWithTypeCheck[types.TS](objectBat.Vecs[len(objectBat.Vecs)-1])
+		for i := 0; i < len(ids); i++ {
+			name := string(nameVarlena[i].GetByteSlice(nameArea))
+			tid := ids[i]
+			account := accounts[i]
+			db := dbs[i]
+			createAt := creates[i]
+			tuple, _, _, err := types.DecodeTuple(
+				objectBat.Vecs[len(objectBat.Vecs)-3].GetRawBytesAt(i))
+			if err != nil {
+				return err
+			}
+			pk := tuple.String()
+			if name == catalog2.MO_SNAPSHOTS {
+				sm.tides[tid] = struct{}{}
+				logutil.Info("[UpdateSnapTable]",
+					zap.Uint64("tid", tid),
+					zap.Uint32("account id", account),
+					zap.String("create at", createAt.ToString()))
+			}
+			if sm.tables[account] == nil {
+				sm.tables[account] = make(map[uint64]*tableInfo)
+			}
+			table := sm.tables[account][tid]
+			if table != nil {
+				if table.createAt.Greater(&createAt) {
+					panic(fmt.Sprintf("table %v create at %v is greater than %v",
+						tid, table.createAt.ToString(), createAt.ToString()))
+				}
+				sm.pkIndexes[pk] = append(sm.pkIndexes[pk], table)
+				continue
+			}
+			table = &tableInfo{
+				accountID: account,
+				dbID:      db,
+				tid:       tid,
+				createAt:  createAt,
+			}
+			sm.tables[account][tid] = table
 			sm.acctIndexes[tid] = table
+			if sm.pkIndexes[pk] == nil {
+				sm.pkIndexes[pk] = make([]*tableInfo, 0)
+			}
+			sm.pkIndexes[pk] = append(sm.pkIndexes[pk], table)
 		}
 	}
 
-	delTableIDs := vector.MustFixedColWithTypeCheck[uint64](delTableTxn.GetVectorByName(SnapshotAttr_TID).GetDownstreamVector())
-	delDropAts := vector.MustFixedColWithTypeCheck[types.TS](delTableTxn.GetVectorByName(txnbase.SnapshotAttr_CommitTS).GetDownstreamVector())
-	for i := 0; i < delTableTxn.Length(); i++ {
-		tid := delTableIDs[i]
-		dropAt := delDropAts[i]
-		if sm.acctIndexes[tid] == nil {
+	deletes := make([]tombstone, 0)
+	for _, info := range tTombstones {
+		if info.stats.BlkCnt() != 1 {
+			panic(fmt.Sprintf("mo_table tombstone %v blk cnt %v",
+				info.stats.ObjectName(), info.stats.BlkCnt()))
+		}
+
+		objectBat, _, err := blockio.LoadOneBlock(
+			ctx, fs, info.stats.ObjectLocation(), objectio.SchemaData)
+		if err != nil {
+			return err
+		}
+
+		commitTsVec := vector.MustFixedColWithTypeCheck[types.TS](objectBat.Vecs[len(objectBat.Vecs)-1])
+		for i := 0; i < len(commitTsVec); i++ {
+			pk, _, _, _ := types.DecodeTuple(objectBat.Vecs[1].GetRawBytesAt(i))
+			commitTs := commitTsVec[i]
+			deletes = append(deletes, tombstone{
+				pk: pk,
+				ts: commitTs,
+			})
+		}
+	}
+	sort.Slice(deletes, func(i, j int) bool {
+		ts2 := deletes[j].ts
+		return deletes[i].ts.Less(&ts2)
+	})
+
+	for _, del := range deletes {
+		pk := del.pk.String()
+		if sm.pkIndexes[pk] == nil {
+			continue
+		}
+		if len(sm.pkIndexes[pk]) == 0 {
+			panic(fmt.Sprintf("delete table %v not found", del.pk.SQLStrings(nil)))
+		}
+		table := sm.pkIndexes[pk][0]
+		if !table.deleteAt.IsEmpty() && table.deleteAt.Greater(&del.ts) {
+			panic(fmt.Sprintf("table %v delete at %v is greater than %v", table.tid, table.deleteAt, del.ts))
+		}
+		table.deleteAt = del.ts
+		sm.pkIndexes[pk] = sm.pkIndexes[pk][1:]
+		if sm.acctIndexes[table.tid] == nil {
 			//In the upgraded cluster, because the inc checkpoint is consumed halfway,
 			// there may be no record of the create table entry, only the delete entry
 			continue
 		}
-		table := sm.acctIndexes[tid]
-		table.deleteAt = dropAt
-		sm.acctIndexes[tid] = table
-		sm.tables[table.accID][tid] = table
+		sm.acctIndexes[table.tid] = table
+		sm.tables[table.accountID][table.tid] = table
+	}
+	return nil
+}
+
+func collectObjects(
+	objects *map[uint64]map[objectio.Segmentid]*objectInfo,
+	ins *containers.Batch,
+	collector func(
+		*map[uint64]map[objectio.Segmentid]*objectInfo,
+		uint64,
+		objectio.ObjectStats,
+		types.TS, types.TS,
+	),
+) {
+	insDeleteTSs := vector.MustFixedColWithTypeCheck[types.TS](
+		ins.GetVectorByName(catalog.EntryNode_DeleteAt).GetDownstreamVector())
+	insCreateTSs := vector.MustFixedColWithTypeCheck[types.TS](
+		ins.GetVectorByName(catalog.EntryNode_CreateAt).GetDownstreamVector())
+	insTableIDs := vector.MustFixedColWithTypeCheck[uint64](
+		ins.GetVectorByName(SnapshotAttr_TID).GetDownstreamVector())
+	insStats := ins.GetVectorByName(catalog.ObjectAttr_ObjectStats).GetDownstreamVector()
+
+	for i := 0; i < ins.Length(); i++ {
+		table := insTableIDs[i]
+		deleteTS := insDeleteTSs[i]
+		createTS := insCreateTSs[i]
+		objectStats := (objectio.ObjectStats)(insStats.GetBytesAt(i))
+		collector(objects, table, objectStats, createTS, deleteTS)
 	}
 }
 
-func (sm *SnapshotMeta) Update(data *CheckpointData) *SnapshotMeta {
+func (sm *SnapshotMeta) Update(
+	ctx context.Context,
+	fs fileservice.FileService,
+	data *CheckpointData,
+) (*SnapshotMeta, error) {
 	sm.Lock()
 	defer sm.Unlock()
 	now := time.Now()
 	defer func() {
 		logutil.Infof("[UpdateSnapshot] cost %v", time.Since(now))
 	}()
-	sm.updateTableInfo(data)
-	if sm.tid == 0 && len(sm.tides) == 0 {
-		return sm
+	err := sm.updateTableInfo(ctx, fs, data)
+	if err != nil {
+		logutil.Errorf("[UpdateSnapshot] updateTableInfo failed %v", err)
+		return sm, err
 	}
-	ins := data.GetObjectBatchs()
-	insDeleteTSs := vector.MustFixedColWithTypeCheck[types.TS](ins.GetVectorByName(catalog.EntryNode_DeleteAt).GetDownstreamVector())
-	insCreateTSs := vector.MustFixedColWithTypeCheck[types.TS](ins.GetVectorByName(catalog.EntryNode_CreateAt).GetDownstreamVector())
-	insTableIDs := vector.MustFixedColWithTypeCheck[uint64](ins.GetVectorByName(SnapshotAttr_TID).GetDownstreamVector())
-	for i := 0; i < ins.Length(); i++ {
-		table := insTableIDs[i]
-		if _, ok := sm.tides[table]; !ok {
-			continue
+	if len(sm.tides) == 0 {
+		return sm, nil
+	}
+
+	collector := func(
+		objects *map[uint64]map[objectio.Segmentid]*objectInfo,
+		tid uint64,
+		stats objectio.ObjectStats,
+		createTS types.TS, deleteTS types.TS,
+	) {
+		if _, ok := sm.tides[tid]; !ok {
+			return
 		}
-		var objectStats objectio.ObjectStats
-		buf := ins.GetVectorByName(catalog.ObjectAttr_ObjectStats).Get(i).([]byte)
-		objectStats.UnMarshal(buf)
-		deleteTS := insDeleteTSs[i]
-		createTS := insCreateTSs[i]
-		if sm.objects[table] == nil {
-			sm.objects[table] = make(map[objectio.Segmentid]*objectInfo)
+		if (*objects)[tid] == nil {
+			(*objects)[tid] = make(map[objectio.Segmentid]*objectInfo)
 		}
-		if sm.objects[table][objectStats.ObjectName().SegmentId()] == nil {
+		oMap := (*objects)[tid]
+		id := stats.ObjectName().SegmentId()
+		if oMap[id] == nil {
 			if !deleteTS.IsEmpty() {
-				continue
+				return
 			}
-			sm.objects[table][objectStats.ObjectName().SegmentId()] = &objectInfo{
-				stats:    objectStats,
+			oMap[id] = &objectInfo{
+				stats:    stats,
 				createAt: createTS,
 			}
 			logutil.Info("[UpdateSnapshot] Add object",
-				zap.Uint64("table id", table),
-				zap.String("object name", objectStats.ObjectName().String()),
+				zap.Uint64("table id", tid),
+				zap.String("object name", id.String()),
 				zap.String("create at", createTS.ToString()))
 
-			continue
+			return
 		}
 		if deleteTS.IsEmpty() {
 			panic(any("deleteTS is empty"))
 		}
 		logutil.Info("[UpdateSnapshot] Delete object",
-			zap.Uint64("table id", table),
-			zap.String("object name", objectStats.ObjectName().String()))
-		delete(sm.objects[table], objectStats.ObjectName().SegmentId())
+			zap.Uint64("table id", tid),
+			zap.String("object name", id.String()))
+		zap.String("delete at", deleteTS.ToString())
+		delete(oMap, id)
 	}
-	// TODO
-	// del, delTxn, _, _ := data.GetBlkBatchs()
-	// delBlockIDs := vector.MustFixedColWithTypeCheck[types.Blockid](del.GetVectorByName(catalog2.BlockMeta_ID).GetDownstreamVector())
-	// delTableIDs := vector.MustFixedColWithTypeCheck[uint64](delTxn.GetVectorByName(SnapshotAttr_TID).GetDownstreamVector())
-	// for i := 0; i < del.Length(); i++ {
-	// 	blockID := delBlockIDs[i]
-	// 	tableID := delTableIDs[i]
-	// 	deltaLoc := objectio.Location(del.GetVectorByName(catalog2.BlockMeta_DeltaLoc).Get(i).([]byte))
-	// 	if _, ok := sm.tides[tableID]; !ok {
-	// 		continue
-	// 	}
-	// 	if sm.objects[tableID] == nil {
-	// 		panic(any(fmt.Sprintf("tableID %d not found", tableID)))
-	// 	}
-	// 	if sm.objects[tableID][*blockID.Segment()] != nil {
-	// 		if sm.objects[tableID][*blockID.Segment()].deltaLocation == nil {
-	// 			sm.objects[tableID][*blockID.Segment()].deltaLocation = make(map[uint32]*objectio.Location)
-	// 		}
-	// 		sm.objects[tableID][*blockID.Segment()].deltaLocation[uint32(blockID.Sequence())] = &deltaLoc
-	// 	}
-	// }
-	return nil
+	collectObjects(&sm.objects, data.GetObjectBatchs(), collector)
+	collectObjects(&sm.tombstones, data.GetTombstoneObjectBatchs(), collector)
+	return nil, nil
 }
 
-func (sm *SnapshotMeta) GetSnapshot(ctx context.Context, sid string, fs fileservice.FileService, mp *mpool.MPool) (map[uint32]containers.Vector, error) {
+func NewSnapshotDataSource(
+	ctx context.Context,
+	fs fileservice.FileService,
+	ts types.TS,
+	stats []objectio.ObjectStats,
+) *BackupDeltaLocDataSource {
+	ds := make(map[string]*objData)
+	return &BackupDeltaLocDataSource{
+		ctx:        ctx,
+		fs:         fs,
+		ts:         ts,
+		ds:         ds,
+		tombstones: stats,
+		needShrink: false,
+	}
+}
+
+func (sm *SnapshotMeta) GetSnapshot(
+	ctx context.Context,
+	sid string,
+	fs fileservice.FileService,
+	mp *mpool.MPool,
+) (map[uint32]containers.Vector, error) {
 	now := time.Now()
 	defer func() {
 		logutil.Infof("[GetSnapshot] cost %v", time.Since(now))
 	}()
 	sm.RLock()
-	objects := sm.CopyObjectsLocked()
-	tables := sm.CopyTablesLocked()
+	objects := copyObjectsLocked(sm.objects)
+	tombstones := copyObjectsLocked(sm.tombstones)
+	tables := sm.copyTablesLocked()
 	sm.RUnlock()
 	snapshotList := make(map[uint32]containers.Vector)
 	idxes := []uint16{ColTS, ColLevel, ColObjId}
@@ -456,9 +476,19 @@ func (sm *SnapshotMeta) GetSnapshot(ctx context.Context, sid string, fs fileserv
 		snapshotSchemaTypes[ColLevel],
 		snapshotSchemaTypes[ColObjId],
 	}
-	for _, objectMap := range objects {
+	for tid, objectMap := range objects {
+		tombstonesStats := make([]objectio.ObjectStats, 0)
+		for ttid, tombstoneMap := range tombstones {
+			if ttid != tid {
+				continue
+			}
+			for _, object := range tombstoneMap {
+				tombstonesStats = append(tombstonesStats, object.stats)
+			}
+			break
+		}
 		checkpointTS := types.BuildTS(time.Now().UTC().UnixNano(), 0)
-		ds := NewDeltaLocDataSource(ctx, fs, checkpointTS, NewOMapDeltaSource(objectMap))
+		ds := NewSnapshotDataSource(ctx, fs, checkpointTS, tombstonesStats)
 		for _, object := range objectMap {
 			location := object.stats.ObjectLocation()
 			name := object.stats.ObjectName()
@@ -484,8 +514,7 @@ func (sm *SnapshotMeta) GetSnapshot(ctx context.Context, sid string, fs fileserv
 
 				bat := buildBatch()
 				defer bat.Clean(mp)
-				err := blockio.BlockDataRead(ctx, sid, &blk, ds, idxes, colTypes, checkpointTS.ToTimestamp(),
-					nil, nil, blockio.BlockReadFilter{}, fs, mp, nil, fileservice.Policy(0), "", bat)
+				bat, _, err := blockio.BlockDataReadBackup(ctx, sid, &blk, ds, idxes, types.TS{}, fs)
 				if err != nil {
 					return nil, err
 				}
@@ -535,7 +564,6 @@ func (sm *SnapshotMeta) GetSnapshot(ctx context.Context, sid string, fs fileserv
 }
 
 func (sm *SnapshotMeta) SetTid(tid uint64) {
-	sm.tid = tid
 }
 
 func (sm *SnapshotMeta) SaveMeta(name string, fs fileservice.FileService) (uint32, error) {
@@ -547,35 +575,31 @@ func (sm *SnapshotMeta) SaveMeta(name string, fs fileservice.FileService) (uint3
 		bat.AddVector(attr, containers.MakeVector(objectInfoSchemaTypes[i], common.DebugAllocator))
 	}
 	deltaBat := containers.NewBatch()
-	for i, attr := range objectDeltaSchemaAttr {
-		deltaBat.AddVector(attr, containers.MakeVector(objectDeltaSchemaTypes[i], common.DebugAllocator))
+	for i, attr := range objectInfoSchemaAttr {
+		deltaBat.AddVector(attr, containers.MakeVector(objectInfoSchemaTypes[i], common.DebugAllocator))
 	}
-	for tid, objectMap := range sm.objects {
-		for _, entry := range objectMap {
-			vector.AppendBytes(
-				bat.GetVectorByName(catalog.ObjectAttr_ObjectStats).GetDownstreamVector(),
-				entry.stats[:], false, common.DebugAllocator)
-			vector.AppendFixed[types.TS](
-				bat.GetVectorByName(catalog.EntryNode_CreateAt).GetDownstreamVector(),
-				entry.createAt, false, common.DebugAllocator)
-			vector.AppendFixed[types.TS](
-				bat.GetVectorByName(catalog.EntryNode_DeleteAt).GetDownstreamVector(),
-				entry.deleteAt, false, common.DebugAllocator)
-			for id, delta := range entry.deltaLocation {
-				blockID := objectio.BuildObjectBlockid(entry.stats.ObjectName(), uint16(id))
-				vector.AppendFixed[types.Blockid](deltaBat.GetVectorByName(catalog2.BlockMeta_ID).GetDownstreamVector(),
-					*blockID, false, common.DebugAllocator)
-				vector.AppendBytes(deltaBat.GetVectorByName(catalog2.BlockMeta_DeltaLoc).GetDownstreamVector(),
-					[]byte(*delta), false, common.DebugAllocator)
+	appendBat := func(
+		bat *containers.Batch,
+		objects map[uint64]map[objectio.Segmentid]*objectInfo) {
+		for tid, objectMap := range objects {
+			for _, entry := range objectMap {
+				vector.AppendBytes(
+					bat.GetVectorByName(catalog.ObjectAttr_ObjectStats).GetDownstreamVector(),
+					entry.stats[:], false, common.DebugAllocator)
+				vector.AppendFixed[types.TS](
+					bat.GetVectorByName(catalog.EntryNode_CreateAt).GetDownstreamVector(),
+					entry.createAt, false, common.DebugAllocator)
+				vector.AppendFixed[types.TS](
+					bat.GetVectorByName(catalog.EntryNode_DeleteAt).GetDownstreamVector(),
+					entry.deleteAt, false, common.DebugAllocator)
 				vector.AppendFixed[uint64](
-					deltaBat.GetVectorByName(SnapshotAttr_TID).GetDownstreamVector(),
+					bat.GetVectorByName(SnapshotAttr_TID).GetDownstreamVector(),
 					tid, false, common.DebugAllocator)
 			}
-			vector.AppendFixed[uint64](
-				bat.GetVectorByName(SnapshotAttr_TID).GetDownstreamVector(),
-				tid, false, common.DebugAllocator)
 		}
 	}
+	appendBat(bat, sm.objects)
+	appendBat(deltaBat, sm.tombstones)
 	defer bat.Close()
 	defer deltaBat.Close()
 	writer, err := objectio.NewObjectWriterSpecial(objectio.WriterGC, name, fs)
@@ -586,7 +610,6 @@ func (sm *SnapshotMeta) SaveMeta(name string, fs fileservice.FileService) (uint3
 		return 0, err
 	}
 	if deltaBat.Length() > 0 {
-		logutil.Infof("deltaBat length is %d", deltaBat.Length())
 		if _, err = writer.WriteWithoutSeqnum(containers.ToCNBatch(deltaBat)); err != nil {
 			return 0, err
 		}
@@ -614,7 +637,7 @@ func (sm *SnapshotMeta) SaveTableInfo(name string, fs fileservice.FileService) (
 		for _, table := range entry {
 			vector.AppendFixed[uint32](
 				bat.GetVectorByName(catalog2.SystemColAttr_AccID).GetDownstreamVector(),
-				table.accID, false, common.DebugAllocator)
+				table.accountID, false, common.DebugAllocator)
 			vector.AppendFixed[uint64](
 				bat.GetVectorByName(catalog2.SystemRelAttr_DBID).GetDownstreamVector(),
 				table.dbID, false, common.DebugAllocator)
@@ -631,7 +654,7 @@ func (sm *SnapshotMeta) SaveTableInfo(name string, fs fileservice.FileService) (
 			if _, ok := sm.tides[table.tid]; ok {
 				vector.AppendFixed[uint32](
 					snapTableBat.GetVectorByName(catalog2.SystemColAttr_AccID).GetDownstreamVector(),
-					table.accID, false, common.DebugAllocator)
+					table.accountID, false, common.DebugAllocator)
 				vector.AppendFixed[uint64](
 					snapTableBat.GetVectorByName(catalog2.SystemRelAttr_DBID).GetDownstreamVector(),
 					table.dbID, false, common.DebugAllocator)
@@ -683,14 +706,14 @@ func (sm *SnapshotMeta) RebuildTableInfo(ins *containers.Batch) {
 		createTS := insCreateTSs[i]
 		deleteTS := insDeleteTSs[i]
 		if sm.tables[accid] == nil {
-			sm.tables[accid] = make(map[uint64]*TableInfo)
+			sm.tables[accid] = make(map[uint64]*tableInfo)
 		}
-		table := &TableInfo{
-			tid:      tid,
-			dbID:     dbid,
-			accID:    accid,
-			createAt: createTS,
-			deleteAt: deleteTS,
+		table := &tableInfo{
+			tid:       tid,
+			dbID:      dbid,
+			accountID: accid,
+			createAt:  createTS,
+			deleteAt:  deleteTS,
 		}
 		sm.tables[accid][tid] = table
 		sm.acctIndexes[tid] = table
@@ -707,7 +730,6 @@ func (sm *SnapshotMeta) RebuildTid(ins *containers.Batch) {
 		return
 	}
 	logutil.Infof("RebuildTid tid %d", insTIDs[0])
-	sm.SetTid(insTIDs[0])
 	for i := 0; i < ins.Length(); i++ {
 		tid := insTIDs[i]
 		accid := accIDs[i]
@@ -718,7 +740,7 @@ func (sm *SnapshotMeta) RebuildTid(ins *containers.Batch) {
 	}
 }
 
-func (sm *SnapshotMeta) Rebuild(ins *containers.Batch) {
+func (sm *SnapshotMeta) Rebuild(ins *containers.Batch, objects *map[uint64]map[objectio.Segmentid]*objectInfo) {
 	sm.Lock()
 	defer sm.Unlock()
 	insCreateTSs := vector.MustFixedColWithTypeCheck[types.TS](ins.GetVectorByName(catalog.EntryNode_CreateAt).GetDownstreamVector())
@@ -729,21 +751,15 @@ func (sm *SnapshotMeta) Rebuild(ins *containers.Batch) {
 		objectStats.UnMarshal(buf)
 		createTS := insCreateTSs[i]
 		tid := insTides[i]
-		if sm.tid == 0 {
-			if tid == 0 {
-				panic("tid is 0")
-			}
-			sm.SetTid(tid)
-		}
 		if _, ok := sm.tides[tid]; !ok {
 			sm.tides[tid] = struct{}{}
 			logutil.Info("[RebuildSnapTable]", zap.Uint64("tid", tid))
 		}
-		if sm.objects[tid] == nil {
-			sm.objects[tid] = make(map[objectio.Segmentid]*objectInfo)
+		if (*objects)[tid] == nil {
+			(*objects)[tid] = make(map[objectio.Segmentid]*objectInfo)
 		}
-		if sm.objects[tid][objectStats.ObjectName().SegmentId()] == nil {
-			sm.objects[tid][objectStats.ObjectName().SegmentId()] = &objectInfo{
+		if (*objects)[tid][objectStats.ObjectName().SegmentId()] == nil {
+			(*objects)[tid][objectStats.ObjectName().SegmentId()] = &objectInfo{
 				stats:    objectStats,
 				createAt: createTS,
 			}
@@ -752,30 +768,6 @@ func (sm *SnapshotMeta) Rebuild(ins *containers.Batch) {
 				zap.String("object name", objectStats.ObjectName().String()),
 				zap.String("create at", createTS.ToString()))
 			continue
-		}
-	}
-}
-
-func (sm *SnapshotMeta) RebuildDelta(ins *containers.Batch) {
-	sm.Lock()
-	defer sm.Unlock()
-	insBlockIDs := vector.MustFixedColWithTypeCheck[types.Blockid](ins.GetVectorByName(catalog2.BlockMeta_ID).GetDownstreamVector())
-	insTides := vector.MustFixedColWithTypeCheck[uint64](ins.GetVectorByName(SnapshotAttr_TID).GetDownstreamVector())
-	for i := 0; i < ins.Length(); i++ {
-		blockID := insBlockIDs[i]
-		tid := insTides[i]
-		deltaLoc := objectio.Location(ins.GetVectorByName(catalog2.BlockMeta_DeltaLoc).Get(i).([]byte))
-		if sm.objects[tid] == nil {
-			panic(any(fmt.Sprintf("tableID %d not found", tid)))
-		}
-		if sm.objects[tid][*blockID.Segment()] != nil {
-			if sm.objects[tid][*blockID.Segment()].deltaLocation == nil {
-				sm.objects[tid][*blockID.Segment()].deltaLocation = make(map[uint32]*objectio.Location)
-			}
-			logutil.Infof("RebuildDelta: %v, loc is %v", blockID.String(), deltaLoc.String())
-			sm.objects[tid][*blockID.Segment()].deltaLocation[uint32(blockID.Sequence())] = &deltaLoc
-		} else {
-			panic(any(fmt.Sprintf("blockID %s not found", blockID.String())))
 		}
 	}
 }
@@ -810,14 +802,14 @@ func (sm *SnapshotMeta) ReadMeta(ctx context.Context, name string, fs fileservic
 		}
 		bat.AddVector(objectInfoSchemaAttr[i], vec)
 	}
-	sm.Rebuild(bat)
+	sm.Rebuild(bat, &sm.objects)
 
 	if len(bs) == 1 {
 		return nil
 	}
 
-	idxes = make([]uint16, len(objectDeltaSchemaAttr))
-	for i := range objectDeltaSchemaAttr {
+	idxes = make([]uint16, len(objectInfoSchemaAttr))
+	for i := range objectInfoSchemaAttr {
 		idxes[i] = uint16(i)
 	}
 	moDeltaBat, releaseDelta, err := reader.LoadColumns(ctx, idxes, nil, bs[1].GetID(), common.DebugAllocator)
@@ -827,17 +819,17 @@ func (sm *SnapshotMeta) ReadMeta(ctx context.Context, name string, fs fileservic
 	defer releaseDelta()
 	deltaBat := containers.NewBatch()
 	defer deltaBat.Close()
-	for i := range objectDeltaSchemaAttr {
+	for i := range objectInfoSchemaAttr {
 		pkgVec := moDeltaBat.Vecs[i]
 		var vec containers.Vector
 		if pkgVec.Length() == 0 {
-			vec = containers.MakeVector(objectDeltaSchemaTypes[i], common.DebugAllocator)
+			vec = containers.MakeVector(objectInfoSchemaTypes[i], common.DebugAllocator)
 		} else {
 			vec = containers.ToTNVector(pkgVec, common.DebugAllocator)
 		}
-		deltaBat.AddVector(objectDeltaSchemaAttr[i], vec)
+		deltaBat.AddVector(objectInfoSchemaAttr[i], vec)
 	}
-	sm.RebuildDelta(deltaBat)
+	sm.Rebuild(deltaBat, &sm.tombstones)
 	return nil
 }
 
@@ -881,10 +873,10 @@ func (sm *SnapshotMeta) ReadTableInfo(ctx context.Context, name string, fs files
 	return nil
 }
 
-func (sm *SnapshotMeta) InitTableInfo(data *CheckpointData) {
+func (sm *SnapshotMeta) InitTableInfo(ctx context.Context, fs fileservice.FileService, data *CheckpointData) {
 	sm.Lock()
 	defer sm.Unlock()
-	sm.updateTableInfo(data)
+	sm.updateTableInfo(ctx, fs, data)
 }
 
 func (sm *SnapshotMeta) TableInfoString() string {
@@ -907,7 +899,7 @@ func (sm *SnapshotMeta) GetSnapshotList(SnapshotList map[uint32][]types.TS, tid 
 	if sm.acctIndexes[tid] == nil {
 		return nil
 	}
-	accID := sm.acctIndexes[tid].accID
+	accID := sm.acctIndexes[tid].accountID
 	return SnapshotList[accID]
 }
 
@@ -915,7 +907,7 @@ func (sm *SnapshotMeta) GetSnapshotListLocked(SnapshotList map[uint32][]types.TS
 	if sm.acctIndexes[tid] == nil {
 		return nil
 	}
-	accID := sm.acctIndexes[tid].accID
+	accID := sm.acctIndexes[tid].accountID
 	return SnapshotList[accID]
 }
 
@@ -960,7 +952,7 @@ func (sm *SnapshotMeta) String() string {
 		len(sm.tables), len(sm.acctIndexes), len(sm.objects))
 }
 
-func isSnapshotRefers(table *TableInfo, snapVec []types.TS) bool {
+func isSnapshotRefers(table *tableInfo, snapVec []types.TS) bool {
 	if len(snapVec) == 0 {
 		return false
 	}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/17971

## What this PR does / why we need it:
Refactor snapshot for 3 tables refactor


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Added `LoadOneBlockWithIndex` function to support loading blocks with specific indexes, enhancing the block loading functionality.
- Modified `BlockDataReadBackup` to conditionally use the new block loading function based on index presence.
- Refactored checkpoint handling in `checkpoint.go` to include context and file service parameters, improving the integration and flexibility.
- Improved snapshot reference checking and added debug logging in `table.go`.
- Removed obsolete test structures and updated tests to use the new snapshot data source.
- Enhanced `BackupDeltaLocDataSource` with tombstone handling and added a method to set timestamps.
- Refactored snapshot metadata handling, improving the update logic and adding a new data source for snapshots.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>funcs.go</strong><dd><code>Add block loading with index support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/blockio/funcs.go

<li>Added <code>LoadOneBlockWithIndex</code> function to load blocks with index.<br> <li> Enhanced block loading functionality with index support.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18563/files#diff-9fd868e101c6ec45186f8cee0653fc53b2070039826f593110d7776707a3e1ea">+21/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>read.go</strong><dd><code>Enhance block data reading with index support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/blockio/read.go

<li>Modified <code>BlockDataReadBackup</code> to support index-based block loading.<br> <li> Integrated <code>LoadOneBlockWithIndex</code> for conditional block loading.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18563/files#diff-e90a1b44f23a26266c0f82ac5b90aa7cfa3d4faef05ceff130c664ef1b37f497">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>checkpoint.go</strong><dd><code>Refactor checkpoint handling with context and service parameters</code></dd></summary>
<hr>

pkg/vm/engine/tae/db/gc/v2/checkpoint.go

<li>Updated <code>Replay</code> and <code>createNewInput</code> methods to include context and file <br>service parameters.<br> <li> Refactored <code>updateSnapshot</code> to accept additional parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18563/files#diff-577d9dcfba04922415343abda8665d868bdc512db384c7fa8ab2861175da31a0">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>table.go</strong><dd><code>Improve snapshot reference checking and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/gc/v2/table.go

<li>Added debug logging for snapshot references.<br> <li> Improved snapshot reference checking logic.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18563/files#diff-a57e277339b6d47cf0a9ed6427435e3bcb8ec6cc4462b9238b3b13740c952494">+16/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>backup.go</strong><dd><code>Enhance backup data source with tombstone handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/backup.go

<li>Added <code>SetTS</code> method to <code>BackupDeltaLocDataSource</code>.<br> <li> Implemented tombstone application logic.<br> <li> Enhanced tombstone handling and data source building.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18563/files#diff-e7bff0b56a15ebd4683008a551e30d4fe7bc361b65f1ab42cfbb254b0cd69dde">+104/-22</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>snapshot.go</strong><dd><code>Refactor snapshot metadata and enhance data source handling</code></dd></summary>
<hr>

pkg/vm/engine/tae/logtail/snapshot.go

<li>Refactored snapshot metadata handling and object collection.<br> <li> Improved table info update logic with context and file service.<br> <li> Added new data source for snapshots.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18563/files#diff-111781ff442a07a8deefe4a9fa1e799b2b5da03309f03c042a9b9b83e33a21be">+352/-360</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db_test.go</strong><dd><code>Refactor block read tests with new data source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/test/db_test.go

<li>Removed <code>TestBlockReadDeltaSource</code> and related functions.<br> <li> Updated <code>TestBlockRead</code> to use <code>NewSnapshotDataSource</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18563/files#diff-858060e31b5a9bf1276488170b96f1f70e3d50b9ef08c44bba5d7acf5778d0a3">+3/-23</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

