### PR TITLE
fix panic in ut

### DIFF
--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -139,11 +139,8 @@ func (obj *baseObject) TryUpgrade() (err error) {
 
 func (obj *baseObject) GetMeta() any { return obj.meta.Load() }
 func (obj *baseObject) CheckFlushTaskRetry(startts types.TS) bool {
-	if !obj.meta.Load().IsAppendable() {
-		panic("not support")
-	}
 	if obj.meta.Load().HasDropCommitted() {
-		panic("not support")
+		return false
 	}
 	obj.RLock()
 	defer obj.RUnlock()

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -181,9 +181,6 @@ func NewFlushTableTailTask(
 		if !hdl.IsAppendable() {
 			panic(fmt.Sprintf("logic err %v is nonappendable", hdl.GetID().String()))
 		}
-		if obj.HasDropCommitted() {
-			continue
-		}
 		if obj.GetObjectData().CheckFlushTaskRetry(txn.GetStartTS()) {
 			logutil.Info(
 				"[FLUSH-NEED-RETRY]",
@@ -191,6 +188,9 @@ func NewFlushTableTailTask(
 				common.AnyField("obj", obj.ID().String()),
 			)
 			return nil, txnif.ErrTxnNeedRetry
+		}
+		if obj.HasDropCommitted() {
+			continue
 		}
 		task.aObjMetas = append(task.aObjMetas, obj)
 		task.aObjHandles = append(task.aObjHandles, hdl)
@@ -211,12 +211,12 @@ func NewFlushTableTailTask(
 		if !hdl.IsAppendable() {
 			panic(fmt.Sprintf("logic err %v is nonappendable", hdl.GetID().String()))
 		}
-		if obj.HasDropCommitted() {
-			continue
-		}
 		if obj.GetObjectData().CheckFlushTaskRetry(txn.GetStartTS()) {
 			logutil.Infof("[FlushTabletail] obj %v needs retry", obj.ID().String())
 			return nil, txnif.ErrTxnNeedRetry
+		}
+		if obj.HasDropCommitted() {
+			continue
 		}
 		task.aTombstoneMetas = append(task.aTombstoneMetas, obj)
 		task.aTombstoneHandles = append(task.aTombstoneHandles, hdl)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15918

## What this PR does / why we need it:
- Remove the panic check inside CheckFlushTaskRetry and collectDelsAndTransfer. It's safe to retry this task.


___

### **PR Type**
Bug fix


___

### **Description**
- Removed panic checks in `CheckFlushTaskRetry` and replaced them with safe return statements.
- Adjusted logic in `NewFlushTableTailTask` to handle non-appendable objects without panicking.
- Replaced panic with an error return in `collectDelsAndTransfer` to handle missing transfer mappings gracefully.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.go</strong><dd><code>Remove panic checks in CheckFlushTaskRetry method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/tables/base.go

<li>Removed panic checks in <code>CheckFlushTaskRetry</code>.<br> <li> Added a return statement for false condition.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18582/files#diff-3c80f8bc185316e9da7a7199207f6a2b8eabfb303402aa9473443482aabcac59">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>flushTableTail.go</strong><dd><code>Adjust logic to handle non-appendable objects safely</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/tables/jobs/flushTableTail.go

<li>Removed panic checks for non-appendable objects.<br> <li> Adjusted logic to continue if <code>HasDropCommitted</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18582/files#diff-0b958d0044e734c5cb32254c0e45c0beaf0e4fdc1f4c846c0bde0fd917da63b0">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>flushTableTail.go</strong><dd><code>Replace panic with error return in collectDelsAndTransfer</code></dd></summary>
<hr>

pkg/vm/engine/tae/tables/txnentries/flushTableTail.go

- Replaced panic with error return in `collectDelsAndTransfer`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18582/files#diff-332ca4c3c8fedfcc6098138df055ae1ad545222f5f00c7c2a60f1d41e7df8b22">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

