### PR TITLE
Aggr statements with same error msg to keep error msg in 1.2-dev

### DIFF
--- a/pkg/util/trace/impl/motrace/report_statement_test.go
+++ b/pkg/util/trace/impl/motrace/report_statement_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"github.com/matrixorigin/matrixone/pkg/util/export/table"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace/statistic"
 
 	"github.com/google/uuid"
@@ -401,7 +400,7 @@ func TestStatementInfo_Key(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   table.WindowKey
+		want   any
 	}{
 		{
 			name: "normal",

--- a/test/distributed/cases/statement_query_type/aggr_error_stmt.result
+++ b/test/distributed/cases/statement_query_type/aggr_error_stmt.result
@@ -1,0 +1,33 @@
+drop account if exists bvt_aggr_error_stmt;
+create account if not exists `bvt_aggr_error_stmt` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+/* cloud_nonuser */ select * from system.statement_not_exist;
+SQL parser error: table "statement_not_exist" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist;
+SQL parser error: table "statement_not_exist" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist;
+SQL parser error: table "statement_not_exist" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist_2;
+SQL parser error: table "statement_not_exist_2" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist_2;
+SQL parser error: table "statement_not_exist_2" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist_2;
+SQL parser error: table "statement_not_exist_2" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist;
+SQL parser error: table "statement_not_exist" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist;
+SQL parser error: table "statement_not_exist" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist;
+SQL parser error: table "statement_not_exist" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist_3;
+SQL parser error: table "statement_not_exist_3" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist_3;
+SQL parser error: table "statement_not_exist_3" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist_3;
+SQL parser error: table "statement_not_exist_3" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist;
+SQL parser error: table "statement_not_exist" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist;
+SQL parser error: table "statement_not_exist" does not exist
+/* cloud_nonuser */ select * from system.statement_not_exist;
+SQL parser error: table "statement_not_exist" does not exist
+drop account if exists bvt_aggr_error_stmt;

--- a/test/distributed/cases/statement_query_type/aggr_error_stmt.sql
+++ b/test/distributed/cases/statement_query_type/aggr_error_stmt.sql
@@ -1,0 +1,32 @@
+-- prepare
+drop account if exists bvt_aggr_error_stmt;
+create account if not exists `bvt_aggr_error_stmt` ADMIN_NAME 'admin' IDENTIFIED BY '123456';
+
+-- Login bvt_aggr_error_stmt account
+-- @session:id=1&user=bvt_aggr_error_stmt:admin:accountadmin&password=123456
+
+/* cloud_nonuser */ select * from system.statement_not_exist;
+/* cloud_nonuser */ select * from system.statement_not_exist;
+/* cloud_nonuser */ select * from system.statement_not_exist;
+
+/* cloud_nonuser */ select * from system.statement_not_exist_2;
+/* cloud_nonuser */ select * from system.statement_not_exist_2;
+/* cloud_nonuser */ select * from system.statement_not_exist_2;
+
+/* cloud_nonuser */ select * from system.statement_not_exist;
+/* cloud_nonuser */ select * from system.statement_not_exist;
+/* cloud_nonuser */ select * from system.statement_not_exist;
+
+/* cloud_nonuser */ select * from system.statement_not_exist_3;
+/* cloud_nonuser */ select * from system.statement_not_exist_3;
+/* cloud_nonuser */ select * from system.statement_not_exist_3;
+
+/* cloud_nonuser */ select * from system.statement_not_exist;
+/* cloud_nonuser */ select * from system.statement_not_exist;
+/* cloud_nonuser */ select * from system.statement_not_exist;
+
+-- @session
+-- END
+
+-- cleanup
+drop account if exists bvt_aggr_error_stmt;

--- a/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.result
+++ b/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.result
@@ -1,0 +1,5 @@
+select statement, error, count(1) < sum(aggr_count) check_result, count(1) cnt, sum(aggr_count) sum from system.statement_info where account="bvt_aggr_error_stmt" and sql_source_type="cloud_nonuser_sql" group by `statement`, error;
+statement    error    check_result    cnt    sum
+select * from system.statement_not_exist_2    SQL parser error: table "statement_not_exist_2" does not exist    true    1    3
+select * from system.statement_not_exist_3    SQL parser error: table "statement_not_exist_3" does not exist    true    1    3
+select * from system.statement_not_exist    SQL parser error: table "statement_not_exist" does not exist    true    1    9

--- a/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.result
+++ b/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.result
@@ -1,5 +1,5 @@
-select statement, error, count(1) < sum(aggr_count) check_result, count(1) cnt, sum(aggr_count) sum from system.statement_info where account="bvt_aggr_error_stmt" and sql_source_type="cloud_nonuser_sql" group by `statement`, error;
-statement    error    check_result    cnt    sum
-select * from system.statement_not_exist_2    SQL parser error: table "statement_not_exist_2" does not exist    true    1    3
-select * from system.statement_not_exist_3    SQL parser error: table "statement_not_exist_3" does not exist    true    1    3
-select * from system.statement_not_exist    SQL parser error: table "statement_not_exist" does not exist    true    1    9
+select error, count(1) < sum(aggr_count) check_result, count(1) cnt, sum(aggr_count) sum, statement from system.statement_info where account="bvt_aggr_error_stmt" and sql_source_type="cloud_nonuser_sql" group by `statement`, error;
+error    check_result    cnt    sum    statement
+SQL parser error: table "statement_not_exist_2" does not exist    true    1    3    select * from system.statement_not_exist_2
+SQL parser error: table "statement_not_exist_3" does not exist    true    1    3    select * from system.statement_not_exist_3
+SQL parser error: table "statement_not_exist" does not exist    true    1    9    select * from system.statement_not_exist

--- a/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.sql
+++ b/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.sql
@@ -2,5 +2,5 @@
 -- check result of statement_query_type/aggr_error_stmt.sql
 
 -- Tips: cnt +1000, sum + 1000 both make sure result format is current.
--- @ignore:3,4
-select statement, error, count(1) < sum(aggr_count) check_result, count(1) cnt, sum(aggr_count) sum from system.statement_info where account="bvt_aggr_error_stmt" and sql_source_type="cloud_nonuser_sql" group by `statement`, error;
+-- @ignore:2,3,4
+select error, count(1) < sum(aggr_count) check_result, count(1) cnt, sum(aggr_count) sum, statement from system.statement_info where account="bvt_aggr_error_stmt" and sql_source_type="cloud_nonuser_sql" group by `statement`, error;

--- a/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.sql
+++ b/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.sql
@@ -1,0 +1,6 @@
+-- check result at the end of bvt.
+-- check result of statement_query_type/aggr_error_stmt.sql
+
+-- Tips: cnt +1000, sum + 1000 both make sure result format is current.
+-- @ignore:3,4
+select statement, error, count(1) < sum(aggr_count) check_result, count(1) cnt, sum(aggr_count) sum from system.statement_info where account="bvt_aggr_error_stmt" and sql_source_type="cloud_nonuser_sql" group by `statement`, error;


### PR DESCRIPTION
### **User description**
Aggr statements with same error msg and keep the error msg info #18537

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4005

ref pr : #18537

## What this PR does / why we need it:
changes:
- aggr erorr statement filter with same error msg.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced error handling by retaining error messages in statement aggregation.
- Added a new `Error` field in the `Key` struct to include error messages.
- Implemented a function to convert error objects to strings for consistent key generation.
- Introduced comprehensive tests to verify the handling of error messages in statement keys.
- Added SQL test cases and expected results to validate the aggregation of error statements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>report_statement.go</strong><dd><code>Enhance error handling in statement aggregation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/util/trace/impl/motrace/report_statement.go

<li>Retained error message in statement aggregation.<br> <li> Added <code>Error</code> field to <code>Key</code> struct.<br> <li> Introduced <code>getErrorString</code> function to handle error messages.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18588/files#diff-6bb6c3e48a06b6a752b1a028ea13f3f2973f20039dcbce2759e65cf30e50da2a">+18/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>report_statement_test.go</strong><dd><code>Add tests for statement key error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/util/trace/impl/motrace/report_statement_test.go

<li>Added tests for <code>StatementInfo.Key</code> function.<br> <li> Verified error message handling in key generation.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18588/files#diff-50fa7d8ea76a187f3460166bd285e9c75254ab6c531fb66d76bd83478ef60273">+105/-1</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aggr_error_stmt.result</strong><dd><code>Add expected results for error statement aggregation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/statement_query_type/aggr_error_stmt.result

<li>Added expected results for aggregated error statements.<br> <li> Included multiple SQL parser error scenarios.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18588/files#diff-2025e1892d1a3d65acda8c753d0c2c26010764a6145900fb777f280f9bbc27f3">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aggr_error_stmt.sql</strong><dd><code>Add test cases for error statement aggregation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/statement_query_type/aggr_error_stmt.sql

<li>Added test cases for error statement aggregation.<br> <li> Simulated multiple SQL parser error scenarios.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18588/files#diff-c35644255deeab3ae81691ba61e4980edcf0d9a7abf87fc22b21a93f40fc85f7">+32/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aggr_error_stmt.result</strong><dd><code>Add summary results for error statement aggregation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/zz_statement_query_type/aggr_error_stmt.result

<li>Added summary results for aggregated error statements.<br> <li> Validated count and sum of aggregated errors.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18588/files#diff-31fcea4422c7c1e8676ceb6228277a5ec178cf39e35d84fe6da6c5d77e1b4b64">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aggr_error_stmt.sql</strong><dd><code>Add SQL to verify error statement aggregation results</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/zz_statement_query_type/aggr_error_stmt.sql

<li>Added SQL to check aggregated error statement results.<br> <li> Ensured result format consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18588/files#diff-927fe66238ef7f8db0c41a74f2ec7ee760b57b0db3b1391f00d691b329f9b7be">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

