### PR TITLE
fileservice: fix object storage semaphore

### DIFF
--- a/pkg/fileservice/io.go
+++ b/pkg/fileservice/io.go
@@ -70,3 +70,11 @@ var ioBufferPool = NewPool(
 	nil,
 	nil,
 )
+
+type readerFunc func([]byte) (int, error)
+
+var _ io.Reader = readerFunc(nil)
+
+func (r readerFunc) Read(p []byte) (n int, err error) {
+	return r(p)
+}

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -113,7 +113,7 @@ func NewS3FS(
 	// limit number of concurrent operations
 	concurrency := args.Concurrency
 	if concurrency == 0 {
-		concurrency = 100
+		concurrency = 1024
 	}
 	fs.storage = newObjectStorageSemaphore(
 		fs.storage,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/17001 https://github.com/matrixorigin/matrixone/issues/17793

## What this PR does / why we need it:
fix object storage semaphore


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a new `readerFunc` type that implements the `io.Reader` interface to improve code modularity.
- Enhanced the `objectStorageSemaphore` to safely release resources using `sync.OnceFunc`, ensuring release on errors and closure.
- Increased the default concurrency limit for S3FS from 100 to 1024, allowing more concurrent operations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>io.go</strong><dd><code>Add `readerFunc` type implementing `io.Reader`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/io.go

<li>Added a new type <code>readerFunc</code> implementing <code>io.Reader</code>.<br> <li> Implemented the <code>Read</code> method for <code>readerFunc</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18589/files#diff-71e5636cb5b7c8eb668c28299a4370e2fe3c70979eac292f325c9bf512f8055b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>s3_fs.go</strong><dd><code>Increase default concurrency limit for S3FS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/s3_fs.go

- Increased default concurrency limit from 100 to 1024.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18589/files#diff-907e5658def7c03142291742cb81fdc3d3590d95678e916e95daf13283a2f86f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>object_storage_semaphore.go</strong><dd><code>Improve resource release in object storage semaphore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/object_storage_semaphore.go

<li>Introduced <code>sync.OnceFunc</code> for safe release of resources.<br> <li> Modified <code>Read</code> method to ensure release on error.<br> <li> Updated <code>readCloser</code> to use <code>readerFunc</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18589/files#diff-9c6b3f0761f2f6f358bc1c375ef9956e34a6d77b56ed9bb925d59e3c8088570b">+16/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

