### PR TITLE
[bug] proxy: session does not transfer after COM_STMT_CLOSE.

### DIFF
--- a/pkg/proxy/tunnel.go
+++ b/pkg/proxy/tunnel.go
@@ -553,15 +553,15 @@ func (p *pipe) kickoff(ctx context.Context, peer *pipe) (e error) {
 			return false, moerr.NewInternalErrorf(errutil.ContextWithNoReport(ctx, true),
 				"preRecv message: %s, name %s", re.Error(), p.name)
 		}
+		tempBuf := p.src.readAvailBuf()
 		// set txn status and cmd time within the mutex together.
 		// only server->client pipe need to set the txn status.
 		if p.name == pipeServerToClient {
 			var currSeq int16
-			buf := p.src.readAvailBuf()
 
 			// issue#16042
-			if len(buf) > 3 {
-				currSeq = int16(buf[3])
+			if len(tempBuf) > 3 {
+				currSeq = int16(tempBuf[3])
 			}
 
 			// last sequence id is 255 and current sequence id is 0, the
@@ -576,7 +576,7 @@ func (p *pipe) kickoff(ctx context.Context, peer *pipe) (e error) {
 				rotated = false
 			}
 
-			inTxn, ok := checkTxnStatus(buf)
+			inTxn, ok := checkTxnStatus(tempBuf)
 			if ok {
 				p.mu.inTxn = inTxn
 			}
@@ -584,11 +584,18 @@ func (p *pipe) kickoff(ctx context.Context, peer *pipe) (e error) {
 				peer.wg.Add(1)
 				p.transferred = true
 			}
-			if len(buf) > 3 {
-				lastSeq = int16(buf[3])
+			if len(tempBuf) > 3 {
+				lastSeq = int16(tempBuf[3])
+			}
+			p.mu.lastCmdTime = time.Now()
+		} else {
+			if isEmptyPacket(tempBuf) {
+				p.logger.Warn("there comes an empty packet from client")
+			}
+			if !isEmptyPacket(tempBuf) && !isDeallocatePacket(tempBuf) {
+				p.mu.lastCmdTime = time.Now()
 			}
 		}
-		p.mu.lastCmdTime = time.Now()
 		return false, nil
 	}
 

--- a/pkg/proxy/util.go
+++ b/pkg/proxy/util.go
@@ -98,6 +98,19 @@ func isErrPacket(p []byte) bool {
 	return false
 }
 
+// isEmptyPacket returns true if []byte is an empty packet.
+func isEmptyPacket(p []byte) bool {
+	return len(p) == 0
+}
+
+// isDeallocatePacket returns true if []byte is a MySQL
+func isDeallocatePacket(p []byte) bool {
+	if len(p) > 4 && p[4] == 0x19 {
+		return true
+	}
+	return false
+}
+
 // packetToBytes convert Packet to bytes.
 func packetToBytes(p *frontend.Packet) []byte {
 	if p == nil || len(p.Payload) == 0 {

--- a/pkg/proxy/util_test.go
+++ b/pkg/proxy/util_test.go
@@ -200,6 +200,33 @@ func TestIsErrPacket(t *testing.T) {
 	require.True(t, ret)
 }
 
+func TestIsDeallocatePacket(t *testing.T) {
+	var data []byte
+	ret := isDeallocatePacket(data)
+	require.False(t, ret)
+
+	data = []byte{0, 0, 0, 0, 2, 0}
+	ret = isDeallocatePacket(data)
+	require.False(t, ret)
+
+	data = []byte{0, 0, 0, 0, 25, 0}
+	ret = isDeallocatePacket(data)
+	require.True(t, ret)
+}
+
+func TestIsEmptyPacket(t *testing.T) {
+	ret := isEmptyPacket(nil)
+	require.True(t, ret)
+
+	var data []byte
+	ret = isEmptyPacket(data)
+	require.True(t, ret)
+
+	data = []byte{0, 0}
+	ret = isEmptyPacket(data)
+	require.False(t, ret)
+}
+
 func TestContainIP(t *testing.T) {
 	cidrs := []string{"192.168.20.0/24", "192.168.10.0/24"}
 	ipNetList := make([]*net.IPNet, 0, 2)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/4022

## What this PR does / why we need it:
there is no response from server after client send a COM_STMT_CLOSE cmd,
which will cause the session cannot be transferred forever. So ignore the
send time when client send a COM_STMT_CLOSE cmd.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug where sessions did not transfer after a `COM_STMT_CLOSE` command by ignoring the send time for such commands.
- Introduced a buffer variable `tempBuf` to improve buffer handling.
- Added utility functions `isEmptyPacket` and `isDeallocatePacket` to identify packet types.
- Updated logic to conditionally set `lastCmdTime` based on packet type.
- Added unit tests for the new utility functions to ensure correct packet type identification.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tunnel.go</strong><dd><code>Improve session handling and command time management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/proxy/tunnel.go

<li>Introduced <code>tempBuf</code> to hold buffer data for processing.<br> <li> Added checks for empty and deallocate packets.<br> <li> Updated logic to set <code>lastCmdTime</code> conditionally.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18613/files#diff-bc73469b2ea679aa5c437b8954aa9eeb7657a8fa92d131f797314188ecd57ba0">+14/-7</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Add utility functions for packet type checking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/proxy/util.go

<li>Added <code>isEmptyPacket</code> function to check for empty packets.<br> <li> Added <code>isDeallocatePacket</code> function to identify deallocate packets.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18613/files#diff-8a42a753a6dfa6ae6f203fbbc57ee1af10236bdd91937ddf21c8eac1012c12f4">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>util_test.go</strong><dd><code>Add tests for packet utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/proxy/util_test.go

<li>Added tests for <code>isDeallocatePacket</code> function.<br> <li> Added tests for <code>isEmptyPacket</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18613/files#diff-219e2e3f70fe70f638d10b0c3e064e3249daad8013a72b72c273743f7a6b5fdb">+27/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

