### PR TITLE
add lockmerge to prevent intensive transfer

### DIFF
--- a/pkg/vm/engine/tae/catalog/table.go
+++ b/pkg/vm/engine/tae/catalog/table.go
@@ -347,6 +347,13 @@ type TableStat struct {
 	Csize     int
 }
 
+func (entry *TableEntry) ObjectCnt(isTombstone bool) int {
+	if isTombstone {
+		return entry.tombstoneObjects.tree.Load().Len()
+	}
+	return entry.dataObjects.tree.Load().Len()
+}
+
 func (entry *TableEntry) ObjectStats(level common.PPLevel, start, end int) (stat TableStat, w bytes.Buffer) {
 
 	it := entry.MakeDataObjectIt()

--- a/pkg/vm/engine/tae/db/dbutils/runtime.go
+++ b/pkg/vm/engine/tae/db/dbutils/runtime.go
@@ -17,6 +17,8 @@ package dbutils
 import (
 	"bytes"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -26,6 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/model"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tasks"
+	"go.uber.org/zap"
 )
 
 type RuntimeOption func(*Runtime)
@@ -72,6 +75,84 @@ func WithRuntimeOptions(opts *options.Options) RuntimeOption {
 	}
 }
 
+type lockedTableInfo struct {
+	lockedAt   time.Time // user txn lock time
+	lockStatus int       // 0 no lock. above 1 user txn lock count
+}
+
+type LockMergeService struct {
+	rwlock sync.RWMutex
+	locked map[uint64]*lockedTableInfo // map table id to lockedTableInfo
+}
+
+func NewLockMergeService() *LockMergeService {
+	return &LockMergeService{
+		locked: make(map[uint64]*lockedTableInfo),
+	}
+}
+
+func (l *LockMergeService) IsLockedByUser(id uint64) (isLocked bool) {
+	l.rwlock.RLock()
+	defer l.rwlock.RUnlock()
+	info, existed := l.locked[id]
+	return existed && info.lockStatus > 0
+}
+
+func (l *LockMergeService) LockFromUser(id uint64) {
+	l.rwlock.Lock()
+	defer l.rwlock.Unlock()
+	if info, ok := l.locked[id]; ok {
+		info.lockStatus++
+	} else {
+		l.locked[id] = &lockedTableInfo{
+			lockStatus: 1,
+			lockedAt:   time.Now(),
+		}
+	}
+}
+
+func (l *LockMergeService) UnlockFromUser(id uint64) {
+	l.rwlock.Lock()
+	defer l.rwlock.Unlock()
+	if info, ok := l.locked[id]; ok {
+		if info.lockStatus <= 0 {
+			panic("bad lock status")
+		}
+		info.lockStatus--
+	} else {
+		panic("Before UnlockFromUser, call LockFromUser")
+	}
+}
+
+func (l *LockMergeService) Prune() {
+	l.rwlock.RLock()
+	pruned := make([]uint64, 0)
+	for id, info := range l.locked {
+		if !info.lockedAt.IsZero() && time.Since(info.lockedAt) > time.Minute*10 {
+			if info.lockStatus == 0 {
+				pruned = append(pruned, id)
+			} else {
+				logutil.Warn(
+					"LockMerge abnormally stale",
+					zap.Uint64("tableId", id),
+					zap.Duration("ago", time.Since(info.lockedAt)),
+					zap.Int("lockStatus", info.lockStatus),
+				)
+			}
+		}
+	}
+	l.rwlock.RUnlock()
+
+	if len(pruned) > 0 {
+		logutil.Info("LockMerge prune", zap.Int("count", len(pruned)))
+		l.rwlock.Lock()
+		defer l.rwlock.Unlock()
+		for _, id := range pruned {
+			delete(l.locked, id)
+		}
+	}
+}
+
 type Runtime struct {
 	Now        func() types.TS
 	VectorPool struct {
@@ -86,6 +167,8 @@ type Runtime struct {
 	TransferDelsMap *model.TransDelsForBlks
 	Scheduler       tasks.TaskScheduler
 
+	LockMergeService *LockMergeService
+
 	Options *options.Options
 
 	Logtail struct {
@@ -96,6 +179,7 @@ type Runtime struct {
 func NewRuntime(opts ...RuntimeOption) *Runtime {
 	r := new(Runtime)
 	r.TransferDelsMap = model.NewTransDelsForBlks()
+	r.LockMergeService = NewLockMergeService()
 	for _, opt := range opts {
 		opt(r)
 	}

--- a/pkg/vm/engine/tae/db/merge/scheduler.go
+++ b/pkg/vm/engine/tae/db/merge/scheduler.go
@@ -118,6 +118,12 @@ func (s *Scheduler) onTable(tableEntry *catalog.TableEntry) (err error) {
 	if StopMerge.Load() {
 		return moerr.GetOkStopCurrRecur()
 	}
+
+	if s.executor.rt.LockMergeService.IsLockedByUser(tableEntry.ID) {
+		logutil.Infof("LockMerge skip table scan due to user lock %d", tableEntry.ID)
+		return moerr.GetOkStopCurrRecur()
+	}
+
 	if !tableEntry.IsActive() {
 		return moerr.GetOkStopCurrRecur()
 	}

--- a/pkg/vm/engine/tae/db/open.go
+++ b/pkg/vm/engine/tae/db/open.go
@@ -278,7 +278,16 @@ func Open(ctx context.Context, dirname string, opts *options.Options) (db *DB, e
 				}
 				return nil
 			},
-		)}
+		),
+		gc.WithCronJob(
+			"prune-lockmerge",
+			options.DefaultLockMergePruneInterval,
+			func(ctx context.Context) error {
+				db.Runtime.LockMergeService.Prune()
+				return nil
+			},
+		),
+	}
 	if opts.CheckpointCfg.MetadataCheckInterval != 0 {
 		cronJobs = append(cronJobs,
 			gc.WithCronJob(

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -9493,9 +9493,10 @@ func TestRollbackMergeInQueue(t *testing.T) {
 	tae.Runtime.LockMergeService.LockFromUser(rel.ID())
 	require.Error(t, txn.Commit(ctx)) // rollback
 
-	txn, rel = tae.GetRelation()
-
+	_, rel = tae.GetRelation()
 	objH, err := rel.GetObject(obj.ID(), false)
+	require.NoError(t, err)
+
 	meta := objH.GetMeta().(*catalog.ObjectEntry)
 	require.Equal(t, catalog.ObjectState_Create_ApplyCommit, meta.ObjectState)
 	require.True(t, meta.DeletedAt.IsEmpty())

--- a/pkg/vm/engine/tae/options/options.go
+++ b/pkg/vm/engine/tae/options/options.go
@@ -142,6 +142,10 @@ func (o *Options) FillDefaults(dirname string) *Options {
 		}
 	}
 
+	if o.BulkTomestoneTxnThreshold == 0 {
+		o.BulkTomestoneTxnThreshold = DefaultBulkTomestoneTxnThreshold
+	}
+
 	if o.CheckpointCfg == nil {
 		o.CheckpointCfg = new(CheckpointCfg)
 	}

--- a/pkg/vm/engine/tae/options/types.go
+++ b/pkg/vm/engine/tae/options/types.go
@@ -32,6 +32,9 @@ import (
 const (
 	DefaultIndexCacheSize = 256 * mpool.MB
 
+	DefaultBulkTomestoneTxnThreshold = 10000 // rows
+	DefaultLockMergePruneInterval    = time.Minute
+
 	DefaultBlockMaxRows    = objectio.BlockMaxRows
 	DefaultBlocksPerObject = uint16(256)
 
@@ -74,6 +77,7 @@ type Options struct {
 	MergeCfg      *MergeConfig
 	CatalogCfg    *CatalogCfg
 
+	BulkTomestoneTxnThreshold uint64
 	// MaxMessageSize is the size of max message which is sent to log-service.
 	MaxMessageSize   uint64
 	TransferTableTTL time.Duration

--- a/pkg/vm/engine/tae/rpc/handle_2pc.go
+++ b/pkg/vm/engine/tae/rpc/handle_2pc.go
@@ -61,6 +61,7 @@ func (h *Handle) HandlePrepare(
 			return
 		}
 		h.handleRequests(ctx, txn, txnCtx)
+		panic("NYI")
 	}
 	txn, err = h.db.GetTxnByID(meta.GetID())
 	if err != nil {

--- a/pkg/vm/engine/tae/rpc/handle_2pc.go
+++ b/pkg/vm/engine/tae/rpc/handle_2pc.go
@@ -61,7 +61,6 @@ func (h *Handle) HandlePrepare(
 			return
 		}
 		h.handleRequests(ctx, txn, txnCtx)
-		panic("NYI")
 	}
 	txn, err = h.db.GetTxnByID(meta.GetID())
 	if err != nil {

--- a/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
@@ -404,6 +404,9 @@ func HandleMergeEntryInTxn(
 		objID := drop.ObjectName().ObjectId()
 		obj, err := rel.GetObject(objID, isTombstone)
 		if err != nil {
+			if moerr.IsMoErrCode(err, moerr.OkExpectedEOB) {
+				logutil.Infof("[MERGE-EOB] LockMerge %v %v", objID.ShortStringEx(), err)
+			}
 			return nil, err
 		}
 		mergedObjs = append(mergedObjs, obj.GetMeta().(*catalog.ObjectEntry))

--- a/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/jobs/mergeobjects.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
@@ -355,6 +356,9 @@ func (task *mergeObjectsTask) Execute(ctx context.Context) (err error) {
 	sortkeyPos := -1
 	if schema.HasSortKey() {
 		sortkeyPos = schema.GetSingleSortKeyIdx()
+	}
+	if task.rt.LockMergeService.IsLockedByUser(task.rel.ID()) {
+		return moerr.NewInternalErrorNoCtxf("LockMerge give up in exec %v", task.Name())
 	}
 	phaseDesc = "1-DoMergeAndWrite"
 	if err = mergesort.DoMergeAndWrite(ctx, task.txn.String(), sortkeyPos, task, task.isTombstone); err != nil {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18286

## What this PR does / why we need it:

- If a large delete txn occurs, attempt to stop merging on this table to prevent intensive delete transfer
- Fix a rollback bug leading to duplicate ObjectEntry


___

### **PR Type**
enhancement


___

### **Description**
- Introduced `LockMergeService` to manage table locks, preventing merge operations during intensive delete transactions.
- Added methods to lock and unlock tables, with a pruning mechanism for stale locks.
- Integrated locking mechanism into various components to control merge operations based on lock status.
- Implemented logic to lock tables during bulk delete operations and release locks after transaction commits.
- Added configuration constants for bulk tombstone transaction threshold and lock merge prune interval.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>runtime.go</strong><dd><code>Add LockMergeService for managing table locks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/dbutils/runtime.go

<li>Introduced <code>LockMergeService</code> to manage table locks.<br> <li> Added methods for locking and unlocking tables by users.<br> <li> Implemented a pruning mechanism for stale locks.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18615/files#diff-f56f42d6b5f7a68c82063ec005ee0a73d287133b6c5495d5960ee3ff77806d70">+84/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>open.go</strong><dd><code>Add cron job for pruning stale locks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/open.go

- Added a cron job for pruning stale locks in `LockMergeService`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18615/files#diff-70f750e6241afa9a68b84ae68293c78c247640ee87b5225c5d3b7265ca531797">+10/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scannerop.go</strong><dd><code>Integrate LockMergeService to control merge operations</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/scannerop.go

<li>Integrated <code>LockMergeService</code> to stop merge operations if a table is <br>locked.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18615/files#diff-cddf8a53c6707c9650c8e9741943663705fa6a551e2b91eeb86b297a6cd20b6f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handle.go</strong><dd><code>Implement table locking for bulk delete operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/rpc/handle.go

<li>Implemented logic to lock tables during bulk delete operations.<br> <li> Added release function to unlock tables after transaction commit.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18615/files#diff-98c036f2b292191124a927608e91efd81ad24feebc0b8dd44a2aa1c9cffe6f91">+38/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mergeobjects.go</strong><dd><code>Check table lock status before merge execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/tables/jobs/mergeobjects.go

- Added check for table lock status before executing merge tasks.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18615/files#diff-e20c21589a463a1bcbf015f3cf20b1f972455f9f000611f28f886b4d3ba6721e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mergeobjects.go</strong><dd><code>Check table lock status before merge commit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/tables/txnentries/mergeobjects.go

- Added check for table lock status before committing merge entries.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18615/files#diff-ef36687940ace38467e7048dd18a1cbc36d8eeeefc02ce86fd606f7d0cd30ee6">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>options.go</strong><dd><code>Add default bulk tombstone transaction threshold</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/options/options.go

- Added default threshold for bulk tombstone transactions.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18615/files#diff-7a129eb095032535e9454cee079a7ead8816ab669e0ee616b78e020cb6191364">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Define constants for transaction threshold and prune interval</code></dd></summary>
<hr>

pkg/vm/engine/tae/options/types.go

<li>Defined constants for bulk tombstone transaction threshold and lock <br>merge prune interval.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18615/files#diff-1c42bccfaae4daf20288fbaf1a80905d600284be96bec190643fd6496eae5bf2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>handle_2pc.go</strong><dd><code>Add panic for NYI in 2PC handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/rpc/handle_2pc.go

- Added panic for unimplemented functionality in 2PC handling.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18615/files#diff-6d913fc1c352aab43172494f34077a3bc05d52e7e2b28b4c86b3a64a78947536">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

