### PR TITLE
hashtable: add memory limit checks

### DIFF
--- a/pkg/common/hashmap/inthashmap.go
+++ b/pkg/common/hashmap/inthashmap.go
@@ -29,7 +29,7 @@ func init() {
 
 func NewIntHashMap(hasNull bool) (*IntHashMap, error) {
 	mp := &hashtable.Int64HashMap{}
-	if err := mp.Init(); err != nil {
+	if err := mp.Init(nil); err != nil {
 		return nil, err
 	}
 	return &IntHashMap{

--- a/pkg/common/hashmap/strhashmap.go
+++ b/pkg/common/hashmap/strhashmap.go
@@ -34,7 +34,7 @@ func init() {
 
 func NewStrMap(hasNull bool) (*StrHashMap, error) {
 	mp := &hashtable.StringHashMap{}
-	if err := mp.Init(); err != nil {
+	if err := mp.Init(nil); err != nil {
 		return nil, err
 	}
 	return &StrHashMap{

--- a/pkg/common/malloc/config.go
+++ b/pkg/common/malloc/config.go
@@ -89,3 +89,11 @@ func SetDefaultConfig(delta Config) {
 func GetDefaultConfig() Config {
 	return *defaultConfig.Load()
 }
+
+func WithTempDefaultConfig(config Config, fn func()) {
+	old := defaultConfig.Swap(&config)
+	defer func() {
+		defaultConfig.Store(old)
+	}()
+	fn()
+}

--- a/pkg/common/malloc/config.go
+++ b/pkg/common/malloc/config.go
@@ -60,21 +60,27 @@ var defaultConfig = func() *atomic.Pointer[Config] {
 func patchConfig(config Config, delta Config) Config {
 	if delta.CheckFraction != nil {
 		config.CheckFraction = delta.CheckFraction
+		logutil.Info("malloc set config", zap.Any("CheckFraction", *delta.CheckFraction))
 	}
 	if delta.EnableMetrics != nil {
 		config.EnableMetrics = delta.EnableMetrics
+		logutil.Info("malloc set config", zap.Any("EnableMetrics", *delta.EnableMetrics))
 	}
 	if delta.FullStackFraction != nil {
 		config.FullStackFraction = delta.FullStackFraction
+		logutil.Info("malloc set config", zap.Any("FullStackFraction", *delta.FullStackFraction))
 	}
 	if delta.Allocator != nil {
 		config.Allocator = delta.Allocator
+		logutil.Info("malloc set config", zap.Any("Allocator", *delta.Allocator))
 	}
 	if delta.HashmapSoftLimit != nil {
 		config.HashmapSoftLimit = delta.HashmapSoftLimit
+		logutil.Info("malloc set config", zap.Any("HashmapSoftLimit", *delta.HashmapSoftLimit))
 	}
 	if delta.HashmapHardLimit != nil {
 		config.HashmapHardLimit = delta.HashmapHardLimit
+		logutil.Info("malloc set config", zap.Any("HashmapHardLimit", *delta.HashmapHardLimit))
 	}
 	return config
 }

--- a/pkg/common/malloc/config.go
+++ b/pkg/common/malloc/config.go
@@ -37,6 +37,9 @@ type Config struct {
 
 	// EnableMetrics indicates whether to expose metrics to prometheus
 	EnableMetrics *bool `toml:"enable-metrics"`
+
+	HashmapSoftLimit *uint64 `toml:"hashmap-soft-limit"`
+	HashmapHardLimit *uint64 `toml:"hashmap-hard-limit"`
 }
 
 var defaultConfig = func() *atomic.Pointer[Config] {
@@ -47,6 +50,8 @@ var defaultConfig = func() *atomic.Pointer[Config] {
 		CheckFraction:     ptrTo(uint32(4096)),
 		EnableMetrics:     ptrTo(true),
 		FullStackFraction: ptrTo(uint32(100)),
+		HashmapSoftLimit:  ptrTo(uint64(48 * (1 << 30))),
+		HashmapHardLimit:  ptrTo(uint64(64 * (1 << 30))),
 	})
 
 	return ret
@@ -65,6 +70,12 @@ func patchConfig(config Config, delta Config) Config {
 	if delta.Allocator != nil {
 		config.Allocator = delta.Allocator
 	}
+	if delta.HashmapSoftLimit != nil {
+		config.HashmapSoftLimit = delta.HashmapSoftLimit
+	}
+	if delta.HashmapHardLimit != nil {
+		config.HashmapHardLimit = delta.HashmapHardLimit
+	}
 	return config
 }
 
@@ -73,4 +84,8 @@ func SetDefaultConfig(delta Config) {
 	config = patchConfig(config, delta)
 	defaultConfig.Store(&config)
 	logutil.Info("malloc: set default config", zap.Any("config", delta))
+}
+
+func GetDefaultConfig() Config {
+	return *defaultConfig.Load()
 }

--- a/pkg/common/malloc/inuse_tracking_allocator.go
+++ b/pkg/common/malloc/inuse_tracking_allocator.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+import (
+	"sync/atomic"
+)
+
+type InuseTrackingAllocator struct {
+	upstream        Allocator
+	inUse           atomic.Uint64
+	onChange        func(uint64)
+	deallocatorPool *ClosureDeallocatorPool[inuseTrackingDeallocatorArgs, *inuseTrackingDeallocatorArgs]
+}
+
+type inuseTrackingDeallocatorArgs struct {
+	size uint64
+}
+
+func (inuseTrackingDeallocatorArgs) As(Trait) bool {
+	return false
+}
+
+func NewInuseTrackingAllocator(
+	upstream Allocator,
+	onChange func(uint64),
+) (ret *InuseTrackingAllocator) {
+	ret = &InuseTrackingAllocator{
+		upstream: upstream,
+		onChange: onChange,
+		deallocatorPool: NewClosureDeallocatorPool(
+			func(hints Hints, args *inuseTrackingDeallocatorArgs) {
+				n := ret.inUse.Add(-args.size)
+				if onChange != nil {
+					onChange(n)
+				}
+			},
+		),
+	}
+	return ret
+}
+
+var _ Allocator = new(InuseTrackingAllocator)
+
+func (s *InuseTrackingAllocator) Allocate(size uint64, hints Hints) ([]byte, Deallocator, error) {
+	ptr, dec, err := s.upstream.Allocate(size, hints)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	n := s.inUse.Add(size)
+	if s.onChange != nil {
+		s.onChange(n)
+	}
+
+	return ptr, ChainDeallocator(
+		dec,
+		s.deallocatorPool.Get(inuseTrackingDeallocatorArgs{
+			size: size,
+		}),
+	), nil
+}

--- a/pkg/common/malloc/inuse_tracking_allocator_test.go
+++ b/pkg/common/malloc/inuse_tracking_allocator_test.go
@@ -1,0 +1,48 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+import (
+	"testing"
+)
+
+func TestInuseTrackingAllocator(t *testing.T) {
+	testAllocator(t, func() Allocator {
+		return NewInuseTrackingAllocator(
+			newUpstreamAllocatorForTest(),
+			func(inUse uint64) {},
+		)
+	})
+}
+
+func BenchmarkInuseTrackingAllocator(b *testing.B) {
+	for _, n := range benchNs {
+		benchmarkAllocator(b, func() Allocator {
+			return NewInuseTrackingAllocator(
+				newUpstreamAllocatorForTest(),
+				func(inUse uint64) {},
+			)
+		}, n)
+	}
+}
+
+func FuzzInuseTrackingAllocator(f *testing.F) {
+	fuzzAllocator(f, func() Allocator {
+		return NewInuseTrackingAllocator(
+			newUpstreamAllocatorForTest(),
+			func(inUse uint64) {},
+		)
+	})
+}

--- a/pkg/container/hashtable/int64_hash_map.go
+++ b/pkg/container/hashtable/int64_hash_map.go
@@ -27,6 +27,8 @@ type Int64HashMapCell struct {
 }
 
 type Int64HashMap struct {
+	allocator malloc.Allocator
+
 	blockCellCnt    uint64
 	blockMaxElemCnt uint64
 	cellCntMask     uint64
@@ -62,7 +64,7 @@ func (ht *Int64HashMap) allocate(index int, size uint64) error {
 	if ht.rawDataDeallocators[index] != nil {
 		panic("overwriting")
 	}
-	bs, de, err := allocator().Allocate(size, malloc.NoHints)
+	bs, de, err := ht.allocator.Allocate(size, malloc.NoHints)
 	if err != nil {
 		return err
 	}
@@ -72,7 +74,11 @@ func (ht *Int64HashMap) allocate(index int, size uint64) error {
 	return nil
 }
 
-func (ht *Int64HashMap) Init() (err error) {
+func (ht *Int64HashMap) Init(allocator malloc.Allocator) (err error) {
+	if allocator == nil {
+		allocator = defaultAllocator()
+	}
+	ht.allocator = allocator
 	ht.blockCellCnt = kInitialCellCnt
 	ht.blockMaxElemCnt = maxElemCnt(kInitialCellCnt, intCellSize)
 	ht.cellCntMask = kInitialCellCnt - 1

--- a/pkg/container/hashtable/malloc_test.go
+++ b/pkg/container/hashtable/malloc_test.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hashtable
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/malloc"
+)
+
+func TestLimits(t *testing.T) {
+	softLimit := uint64(1 << 10)
+	hardLimit := uint64(2 * (1 << 10))
+	malloc.WithTempDefaultConfig(malloc.Config{
+		HashmapSoftLimit: &softLimit,
+		HashmapHardLimit: &hardLimit,
+	}, func() {
+
+		func() {
+			defer func() {
+				p := recover()
+				if p == nil {
+					t.Fatal("should panic")
+				}
+				msg := fmt.Sprintf("%v", p)
+				if !strings.Contains(msg, "exceed hard limit") {
+					t.Fatalf("got %v", msg)
+				}
+			}()
+
+			var hashmap StringHashMap
+			hashmap.Init(newAllocator())
+			hashmap.ResizeOnDemand(2 * (1 << 10))
+		}()
+
+	})
+}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18150 

## What this PR does / why we need it:
to ensure the hashtable is not allocating excessive memory.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added `HashmapSoftLimit` and `HashmapHardLimit` to the memory configuration to control memory usage.
- Introduced `InuseTrackingAllocator` to track and manage memory allocations with callbacks.
- Integrated memory limit checks in the hashtable allocator, including logging and panic mechanisms.
- Added unit, benchmark, and fuzz tests for the new allocator to ensure reliability and performance.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Add memory limit configurations for hashmaps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/malloc/config.go

<li>Added <code>HashmapSoftLimit</code> and <code>HashmapHardLimit</code> to the <code>Config</code> struct.<br> <li> Updated default configuration to include soft and hard limits.<br> <li> Implemented <code>GetDefaultConfig</code> function to retrieve the current <br>configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18646/files#diff-027c638b29ffcd6238052355868e13dcfc3bc8eb6d082b9b64e167f656146ac4">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inuse_tracking_allocator.go</strong><dd><code>Introduce InuseTrackingAllocator for memory usage tracking</code></dd></summary>
<hr>

pkg/common/malloc/inuse_tracking_allocator.go

<li>Introduced <code>InuseTrackingAllocator</code> to track memory usage.<br> <li> Implemented allocation and deallocation tracking with callbacks.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18646/files#diff-5c671f1bf8b1cf89046f5a6f1ed019b24969f47dddee91008b31568e88e16da8">+74/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>malloc.go</strong><dd><code>Implement memory limit checks in hashtable allocator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/malloc.go

<li>Integrated memory limit checks in hashtable allocator.<br> <li> Added logging for soft limit exceedance and panic for hard limit.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18646/files#diff-19946c6236c39e59182736f8ae376be1742733102e27f1335c5e2883c8c5ca33">+44/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inuse_tracking_allocator_test.go</strong><dd><code>Add tests for InuseTrackingAllocator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/malloc/inuse_tracking_allocator_test.go

<li>Added unit tests for <code>InuseTrackingAllocator</code>.<br> <li> Included benchmark and fuzz tests for allocator.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18646/files#diff-ebc5a7d6211b8cf4dac71b9f85b8671eb64c3994457de7c9e14fc3bd6ca5974b">+48/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

