### PR TITLE
fix replay incomplete data to catalog cache

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -339,6 +339,10 @@ const (
 	MO_RESERVED_MAX = 100
 )
 
+func IsSystemTable(id uint64) bool {
+	return id == MO_DATABASE_ID || id == MO_TABLES_ID || id == MO_COLUMNS_ID
+}
+
 // index use to update constraint
 const (
 	MO_TABLES_ALTER_TABLE       = 0

--- a/pkg/vm/engine/disttae/db.go
+++ b/pkg/vm/engine/disttae/db.go
@@ -331,7 +331,8 @@ func (e *Engine) getOrCreateSnapPart(
 				e,
 				nil,
 				state,
-				entry); err != nil {
+				entry,
+				false); err != nil {
 				return err
 			}
 		}
@@ -423,7 +424,7 @@ func (e *Engine) LazyLoadLatestCkp(
 				}
 			}()
 			for _, entry := range entries {
-				if err = consumeEntry(ctx, tbl.primarySeqnum, e, cache, state, entry); err != nil {
+				if err = consumeEntry(ctx, tbl.primarySeqnum, e, cache, state, entry, false); err != nil {
 					return err
 				}
 			}

--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -165,7 +165,7 @@ type delayedCacheApply struct {
 
 func (c *PushClient) dcaTryDelay(isSub bool, f func()) (delayed bool) {
 	c.dca.Lock()
-	c.dca.Unlock()
+	defer c.dca.Unlock()
 	if c.dca.replayed {
 		// replay finished, no need to delay
 		return false
@@ -179,7 +179,7 @@ func (c *PushClient) dcaTryDelay(isSub bool, f func()) (delayed bool) {
 
 func (c *PushClient) dcaConfirmAndApply() {
 	c.dca.Lock()
-	c.dca.Unlock()
+	defer c.dca.Unlock()
 	c.dca.replayed = true
 	for _, f := range c.dca.flist {
 		f()

--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -117,6 +117,7 @@ type PushClient struct {
 
 	// Record the timestamp of last log received by CN.
 	receivedLogTailTime syncLogTailTimestamp
+	dca                 delayedCacheApply
 
 	// Record the subscription status of a tables.
 	subscribed subscribedTable
@@ -144,6 +145,46 @@ type PushClient struct {
 	eng         *Engine
 
 	LogtailRPCClientFactory func(string, string, morpc.RPCClient) (morpc.RPCClient, morpc.Stream, error)
+}
+
+type delayedCacheApply struct {
+	// replayCatalogCache and consumeEntry may be called concurrently.
+	// In consumeEntry, update logtail entries of the three tables should be applied to the catalog cache AFTER
+	// replayCatalogCache is finished.
+	// Note: Do not let consumeEntry wait for replayCatalogCache
+	// because replayCatalogCache will be wating for consumeEntry's goroutine to change subcribing status.
+
+	// Consider the lock contention:
+	// consumeEntry handling the three tables will run on a single goroutine,
+	// and on the other goroutine, replayCatalogCache will attempt to acquire the lock only once.
+	// Therefore, the lock contention is not serious.
+	sync.Mutex
+	replayed bool
+	flist    []func()
+}
+
+func (c *PushClient) dcaTryDelay(isSub bool, f func()) (delayed bool) {
+	c.dca.Lock()
+	c.dca.Unlock()
+	if c.dca.replayed {
+		// replay finished, no need to delay
+		return false
+	}
+	if isSub {
+		return true
+	}
+	c.dca.flist = append(c.dca.flist, f)
+	return true
+}
+
+func (c *PushClient) dcaConfirmAndApply() {
+	c.dca.Lock()
+	c.dca.Unlock()
+	c.dca.replayed = true
+	for _, f := range c.dca.flist {
+		f()
+	}
+	c.dca.flist = c.dca.flist[:0]
 }
 
 type State struct {
@@ -229,6 +270,7 @@ func (c *PushClient) init(
 	// release subscriber lock when we received enough response from service.
 	c.receivedLogTailTime.e = e
 	c.receivedLogTailTime.ready.Store(false)
+	c.dca = delayedCacheApply{}
 	c.subscriber.setNotReady()
 	c.subscribed.mutex.Lock()
 	defer func() {
@@ -710,6 +752,7 @@ func (c *PushClient) replayCatalogCache(ctx context.Context, e *Engine) (err err
 	}
 
 	e.catalog.UpdateStart(typeTs)
+	c.dcaConfirmAndApply()
 	return nil
 
 }
@@ -1752,7 +1795,7 @@ func (e *Engine) consumeSubscribeResponse(
 	lazyLoad bool,
 	receiveAt time.Time) error {
 	lt := rp.GetLogtail()
-	return updatePartitionOfPush(ctx, e, &lt, lazyLoad, receiveAt)
+	return updatePartitionOfPush(ctx, e, &lt, lazyLoad, receiveAt, true)
 }
 
 func (e *Engine) consumeUpdateLogTail(
@@ -1760,7 +1803,7 @@ func (e *Engine) consumeUpdateLogTail(
 	rp logtail.TableLogtail,
 	lazyLoad bool,
 	receiveAt time.Time) error {
-	return updatePartitionOfPush(ctx, e, &rp, lazyLoad, receiveAt)
+	return updatePartitionOfPush(ctx, e, &rp, lazyLoad, receiveAt, false)
 }
 
 // updatePartitionOfPush is the partition update method of log tail push model.
@@ -1769,7 +1812,8 @@ func updatePartitionOfPush(
 	e *Engine,
 	tl *logtail.TableLogtail,
 	lazyLoad bool,
-	receiveAt time.Time) (err error) {
+	receiveAt time.Time,
+	isSub bool) (err error) {
 	start := time.Now()
 	v2.LogTailApplyLatencyDurationHistogram.Observe(start.Sub(receiveAt).Seconds())
 	defer func() {
@@ -1831,6 +1875,7 @@ func updatePartitionOfPush(
 			e,
 			state,
 			tl,
+			isSub,
 		)
 		v2.LogtailUpdatePartitonConsumeLogtailDurationHistogram.Observe(time.Since(t0).Seconds())
 
@@ -1842,7 +1887,7 @@ func updatePartitionOfPush(
 			v2.LogtailUpdatePartitonHandleCheckpointDurationHistogram.Observe(time.Since(t0).Seconds())
 		}
 		t0 = time.Now()
-		err = consumeCkpsAndLogTail(ctx, partition.TableInfo.PrimarySeqnum, e, state, tl, dbId, tblId, partition.TableInfo.Name)
+		err = consumeCkpsAndLogTail(ctx, partition.TableInfo.PrimarySeqnum, e, state, tl, dbId, tblId, isSub)
 		v2.LogtailUpdatePartitonConsumeLogtailDurationHistogram.Observe(time.Since(t0).Seconds())
 	}
 
@@ -1875,8 +1920,26 @@ func consumeLogTail(
 	engine *Engine,
 	state *logtailreplay.PartitionState,
 	lt *logtail.TableLogtail,
+	isSub bool,
 ) error {
-	return hackConsumeLogtail(ctx, primarySeqnum, engine, state, lt)
+	// return hackConsumeLogtail(ctx, primarySeqnum, engine, state, lt)
+	if lt.Table.DbName == "" {
+		panic(fmt.Sprintf("missing fields %v", lt.Table.String()))
+	}
+	t0 := time.Now()
+	for i := 0; i < len(lt.Commands); i++ {
+		if err := consumeEntry(ctx, primarySeqnum,
+			engine, engine.GetLatestCatalogCache(), state, &lt.Commands[i], isSub); err != nil {
+			return err
+		}
+	}
+
+	if catalog.IsSystemTable(lt.Table.TbId) {
+		v2.LogtailUpdatePartitonConsumeLogtailCatalogTableDurationHistogram.Observe(time.Since(t0).Seconds())
+	} else {
+		v2.LogtailUpdatePartitonConsumeLogtailDurationHistogram.Observe(time.Since(t0).Seconds())
+	}
+	return nil
 }
 
 func parseCkpDuration(lt *logtail.TableLogtail) (start types.TS, end types.TS) {
@@ -1905,7 +1968,7 @@ func consumeCkpsAndLogTail(
 	lt *logtail.TableLogtail,
 	databaseId uint64,
 	tableId uint64,
-	tableName string,
+	isSub bool,
 ) (err error) {
 	var entries []*api.Entry
 	var closeCBs []func()
@@ -1913,7 +1976,7 @@ func consumeCkpsAndLogTail(
 		ctx,
 		engine.service,
 		lt.CkpLocation,
-		tableId, tableName,
+		tableId, "",
 		databaseId, "", engine.mp, engine.fs); err != nil {
 		return
 	}
@@ -1926,36 +1989,9 @@ func consumeCkpsAndLogTail(
 	}()
 	for _, entry := range entries {
 		if err = consumeEntry(ctx, primarySeqnum,
-			engine, engine.GetLatestCatalogCache(), state, entry); err != nil {
+			engine, engine.GetLatestCatalogCache(), state, entry, isSub); err != nil {
 			return
 		}
 	}
-	return hackConsumeLogtail(ctx, primarySeqnum, engine, state, lt)
-}
-
-func hackConsumeLogtail(
-	ctx context.Context,
-	primarySeqnum int,
-	engine *Engine,
-	state *logtailreplay.PartitionState,
-	lt *logtail.TableLogtail) error {
-
-	if lt.Table.DbName == "" {
-		panic(fmt.Sprintf("missing fields %v", lt.Table.String()))
-	}
-	t0 := time.Now()
-	for i := 0; i < len(lt.Commands); i++ {
-		if err := consumeEntry(ctx, primarySeqnum,
-			engine, engine.GetLatestCatalogCache(), state, &lt.Commands[i]); err != nil {
-			return err
-		}
-	}
-
-	if lt.Table.TbId == catalog.MO_DATABASE_ID || lt.Table.TbId == catalog.MO_TABLES_ID || lt.Table.TbId == catalog.MO_COLUMNS_ID {
-		v2.LogtailUpdatePartitonConsumeLogtailCatalogTableDurationHistogram.Observe(time.Since(t0).Seconds())
-	} else {
-		v2.LogtailUpdatePartitonConsumeLogtailCatalogTableDurationHistogram.Observe(time.Since(t0).Seconds())
-	}
-
-	return nil
+	return consumeLogTail(ctx, primarySeqnum, engine, state, lt, isSub)
 }

--- a/pkg/vm/engine/disttae/logtail_consumer_test.go
+++ b/pkg/vm/engine/disttae/logtail_consumer_test.go
@@ -77,3 +77,15 @@ func TestBlockInfoSlice(t *testing.T) {
 	require.Equal(t, 0, len(data1))
 
 }
+
+func TestDca(t *testing.T) {
+	pClient := &PushClient{}
+
+	signalCnt := 0
+	require.True(t, pClient.dcaTryDelay(true, func() { signalCnt++ }))  // skip for sub response
+	require.True(t, pClient.dcaTryDelay(false, func() { signalCnt++ })) // delay
+	pClient.dcaConfirmAndApply()
+	require.Equal(t, 1, signalCnt)
+	require.False(t, pClient.dcaTryDelay(false, func() {})) // skip for finished replay
+
+}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18632 

## What this PR does / why we need it:

The system must complete the catalog cache replay before it can process the push logtail for the three tables.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a new function `IsSystemTable` to identify system tables by their ID.
- Enhanced the `setPushClientStatus` function to manage signaling for readiness and closing the signal channel when not ready.
- Implemented `tryWaitThreeTablesReplayReady` to handle the readiness check for logtail replay.
- Introduced a signal channel in `syncLogTailTimestamp` to notify when the log tail client is ready.
- Added a test `TestWait` to verify the behavior of the readiness function.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add function to identify system tables by ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/catalog/types.go

<li>Added a function <code>IsSystemTable</code> to check if a table ID corresponds to a <br>system table.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18662/files#diff-1695ed5765b08f4366c290109026c6d6d3ce15b7a0fc0a5ad86b6646c92e81a7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>engine.go</strong><dd><code>Enhance push client status handling with signaling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/engine.go

<li>Modified <code>setPushClientStatus</code> to handle signaling when the client is <br>ready.<br> <li> Added logic to close the signal channel when not ready.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18662/files#diff-66bacd74568edffe090130ffc5d235b4771a4707612b56145288d4e7119be4a2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>logtail.go</strong><dd><code>Implement readiness check for logtail replay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/logtail.go

<li>Added <code>tryWaitThreeTablesReplayReady</code> function to manage replay <br>readiness.<br> <li> Updated <code>consumeEntry</code> to use the new readiness function.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18662/files#diff-d97e4fd62193bdf727f8d1ee2d9edbfaca735fa2261c913775872c7136763d04">+16/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>logtail_consumer.go</strong><dd><code>Add signaling mechanism for log tail readiness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/logtail_consumer.go

<li>Introduced a signal channel in <code>syncLogTailTimestamp</code> to notify <br>readiness.<br> <li> Initialized the signal channel in <code>PushClient.init</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18662/files#diff-e17810b9da4ab05c897d8066bbc421520cdaea7c577d50dc64b31ec3aa8d295f">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logtail_consumer_test.go</strong><dd><code>Add test for logtail replay readiness function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/logtail_consumer_test.go

<li>Added <code>TestWait</code> to test the <code>tryWaitThreeTablesReplayReady</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18662/files#diff-b7d865ce7c4fc1a611e36d748d2379dccbe47754bac0379c908480b4bf34e6c6">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

