### PR TITLE
[bug] logtail: clear the tables in global stats when logtail re-connect

### DIFF
--- a/pkg/vm/engine/disttae/db.go
+++ b/pkg/vm/engine/disttae/db.go
@@ -257,6 +257,9 @@ func (e *Engine) init(ctx context.Context) error {
 		bat.Clean(m)
 	}
 
+	// clear all tables in global stats.
+	e.globalStats.clearTables()
+
 	return nil
 }
 

--- a/pkg/vm/engine/disttae/stats.go
+++ b/pkg/vm/engine/disttae/stats.go
@@ -266,6 +266,15 @@ func (gs *GlobalStats) RemoveTid(tid uint64) {
 	delete(gs.logtailUpdate.mu.updated, tid)
 }
 
+// clearTables clears the tables in the map if there are any tables in it.
+func (gs *GlobalStats) clearTables() {
+	gs.logtailUpdate.mu.Lock()
+	defer gs.logtailUpdate.mu.Unlock()
+	if len(gs.logtailUpdate.mu.updated) > 0 {
+		gs.logtailUpdate.mu.updated = make(map[uint64]struct{})
+	}
+}
+
 func (gs *GlobalStats) enqueue(tail *logtail.TableLogtail) {
 	select {
 	case gs.tailC <- tail:

--- a/pkg/vm/engine/disttae/stats_test.go
+++ b/pkg/vm/engine/disttae/stats_test.go
@@ -74,3 +74,16 @@ func TestGlobalStats_ShouldUpdate(t *testing.T) {
 		assert.Equal(t, 1, int(count.Load()))
 	})
 }
+
+func TestGlobalStats_ClearTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	gs := NewGlobalStats(ctx, nil, nil)
+	for i := 0; i < 10; i++ {
+		gs.notifyLogtailUpdate(uint64(2000 + i))
+	}
+	assert.Equal(t, 10, len(gs.logtailUpdate.mu.updated))
+	gs.clearTables()
+	assert.Equal(t, 0, len(gs.logtailUpdate.mu.updated))
+}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/4045

## What this PR does / why we need it:
clear the tables in global stats when logtail re-connect.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added a `clearTables` method in `GlobalStats` to clear the tables in the map.
- Integrated the `clearTables` method into the engine initialization process to ensure tables are cleared in global stats when logtail reconnects.
- Added a unit test to verify the functionality of the `clearTables` method.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db.go</strong><dd><code>Clear tables in global stats during engine initialization</code></dd></summary>
<hr>

pkg/vm/engine/disttae/db.go

<li>Added a call to clear all tables in global stats during <br>initialization.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18674/files#diff-510a93692a080e19d5377a183f951910b64d0f4ce39c0ac7607b6c7f9b64ccaf">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stats.go</strong><dd><code>Implement clearTables method in GlobalStats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/stats.go

<li>Implemented <code>clearTables</code> method to clear tables in the global stats <br>map.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18674/files#diff-d0f8ce84135a062e5992dcb3d1175993ee396beae48de126969255cd9240d02b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stats_test.go</strong><dd><code>Add test for clearTables method in GlobalStats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/stats_test.go

- Added a test for the `clearTables` method in GlobalStats.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18674/files#diff-5a180d6cc7bed3d03a8f45d2ceb0a95a41bcb192162481f0dd52d4db5f119896">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

