### PR TITLE
update CollectDeletesLocked

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -224,6 +224,7 @@ const (
 	ErrNewTxnInCNRollingRestart   uint16 = 20635
 	ErrPrevCheckpointNotFinished  uint16 = 20636
 	ErrCantDelGCChecker           uint16 = 20637
+	ErrPossibleDuplicate          uint16 = 20638
 
 	// Group 7: lock service
 	// ErrDeadLockDetected lockservice has detected a deadlock and should abort the transaction if it receives this error
@@ -454,6 +455,7 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	ErrNewTxnInCNRollingRestart:   {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "new txn in CN rolling restart"},
 	ErrPrevCheckpointNotFinished:  {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "prev checkpoint not finished"},
 	ErrCantDelGCChecker:           {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "can't delete gc checker"},
+	ErrPossibleDuplicate:          {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "possible duplicate"},
 
 	// Group 7: lock service
 	ErrDeadLockDetected:     {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "deadlock detected"},

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -285,6 +285,10 @@ func NewTAEPrepareNoCtx(msg string) *Error {
 	return newError(Context(), ErrTAEPrepare, msg)
 }
 
+func NewTAEPossibleDuplicateNoCtx() *Error {
+	return newError(Context(), ErrTAEPossibleDuplicate)
+}
+
 func NewTxnRWConflictNoCtx() *Error {
 	return newError(Context(), ErrTxnRWConflict)
 }

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -285,8 +285,8 @@ func NewTAEPrepareNoCtx(msg string) *Error {
 	return newError(Context(), ErrTAEPrepare, msg)
 }
 
-func NewTAEPossibleDuplicateNoCtx() *Error {
-	return newError(Context(), ErrTAEPossibleDuplicate)
+func NewPossibleDuplicateNoCtx() *Error {
+	return newError(Context(), ErrPossibleDuplicate)
 }
 
 func NewTxnRWConflictNoCtx() *Error {

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -9091,6 +9091,7 @@ func TestDedupObject(t *testing.T) {
 	}
 	getObjTxn, getObjRel := tae.GetRelation()
 	obj := testutil.GetOneBlockMeta(getObjRel)
+	mergeBlockID := *objectio.NewBlockidWithObjectID(&obj.ID, 0)
 	getObjTxn.Commit(ctx)
 	pkVec := bat.Vecs[1]
 	pkType := pkVec.GetType()
@@ -9103,6 +9104,9 @@ func TestDedupObject(t *testing.T) {
 		false,
 		tae.Runtime.Fs.Service,
 	)
+	{
+		tae.Runtime.TransferDelsMap.Delete(mergeBlockID)
+	}
 	err := obj.GetObjectData().BatchDedup(ctx, dedupTxn, pkVec, keysZM, nil, true, bf, common.DebugAllocator)
 	t.Log(err)
 	dedupTxn.Commit(ctx)

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/gc"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
 
@@ -9054,4 +9055,55 @@ func TestVisitTombstone(t *testing.T) {
 	t.Log(tae.Catalog.SimplePPString(3))
 	tae.Restart(context.Background())
 	t.Log(tae.Catalog.SimplePPString(3))
+}
+
+func TestDedupObject(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	ctx := context.Background()
+	opts := config.WithLongScanAndCKPOpts(nil)
+	options.WithGlobalVersionInterval(time.Microsecond)(opts)
+	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
+	defer tae.Close()
+	schema := catalog.MockSchemaAll(2, 1)
+	schema.BlockMaxRows = 50
+	tae.BindSchema(schema)
+	bat := catalog.MockBatch(schema, 50)
+	defer bat.Close()
+
+	tae.CreateRelAndAppend(bat, true)
+
+	tae.CompactBlocks(true)
+
+	var dedupTxn txnif.AsyncTxn
+	// var dedupRel handle.Relation
+	{
+		txn2, rel2 := tae.GetRelation()
+		obj := testutil.GetOneBlockMeta(rel2)
+		task, err := jobs.NewMergeObjectsTask(nil, txn2, []*catalog.ObjectEntry{obj}, tae.Runtime, 0)
+		assert.NoError(t, err)
+		err = task.OnExec(context.Background())
+		assert.NoError(t, err)
+		{
+			tae.DeleteAll(true)
+		}
+		dedupTxn, _ = tae.GetRelation()
+		txn2.Commit(ctx)
+	}
+	getObjTxn, getObjRel := tae.GetRelation()
+	obj := testutil.GetOneBlockMeta(getObjRel)
+	getObjTxn.Commit(ctx)
+	pkVec := bat.Vecs[1]
+	pkType := pkVec.GetType()
+	keysZM := index.NewZM(pkType.Oid, pkType.Scale)
+	index.BatchUpdateZM(keysZM, pkVec.GetDownstreamVector())
+	location := obj.GetLatestCommittedNodeLocked().BaseNode.ObjectLocation()
+	bf, _ := objectio.FastLoadBF(
+		ctx,
+		location,
+		false,
+		tae.Runtime.Fs.Service,
+	)
+	err := obj.GetObjectData().BatchDedup(ctx, dedupTxn, pkVec, keysZM, nil, true, bf, common.DebugAllocator)
+	t.Log(err)
+	dedupTxn.Commit(ctx)
 }

--- a/pkg/vm/engine/tae/model/transferdels.go
+++ b/pkg/vm/engine/tae/model/transferdels.go
@@ -82,3 +82,9 @@ func (t *TransDelsForBlks) Prune(gap time.Duration) {
 		}
 	}
 }
+
+func (t *TransDelsForBlks) Delete(blkID types.Blockid) {
+	t.Lock()
+	defer t.Unlock()
+	delete(t.dels, blkID)
+}

--- a/pkg/vm/engine/tae/tables/updates/delchain.go
+++ b/pkg/vm/engine/tae/tables/updates/delchain.go
@@ -396,7 +396,7 @@ func (chain *DeleteChain) CollectDeletesLocked(
 					blockID := *objectio.NewBlockidWithObjectID(&chain.mvcc.meta.ID, chain.mvcc.blkID)
 					delsMap := rt.TransferDelsMap.GetDelsForBlk(blockID)
 					if delsMap == nil {
-						err = moerr.NewTAEPossibleDuplicateNoCtx()
+						err = moerr.NewPossibleDuplicateNoCtx()
 						return false
 					}
 					tsMapping := delsMap.Mapping

--- a/pkg/vm/engine/tae/tables/updates/delchain.go
+++ b/pkg/vm/engine/tae/tables/updates/delchain.go
@@ -396,8 +396,8 @@ func (chain *DeleteChain) CollectDeletesLocked(
 					blockID := *objectio.NewBlockidWithObjectID(&chain.mvcc.meta.ID, chain.mvcc.blkID)
 					delsMap := rt.TransferDelsMap.GetDelsForBlk(blockID)
 					if delsMap == nil {
-						err = moerr.NewInternalErrorNoCtx(fmt.Sprintf("deletes for block %v not found", blockID.String()))
-						return true
+						err = moerr.NewTAEPossibleDuplicateNoCtx()
+						return false
 					}
 					tsMapping := delsMap.Mapping
 					if tsMapping == nil {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4044

## What this PR does / why we need it:
update CollectDeletesLocked, return tae possible duplicate if delsMap is nil


___

### **PR Type**
Bug fix


___

### **Description**
- Updated the default `TransferTableTTL` value in the `Options` struct from 60 seconds to 5 minutes to address a bug.
- This change ensures that the transfer table time-to-live is set to a more appropriate duration by default.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>options.go</strong><dd><code>Update default `TransferTableTTL` value to 5 minutes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/options/options.go

<li>Updated the default value of <code>TransferTableTTL</code>.<br> <li> Changed from 60 seconds to 5 minutes.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18677/files#diff-7a129eb095032535e9454cee079a7ead8816ab669e0ee616b78e020cb6191364">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

