### PR TITLE
mo-service: fix default cache configs

### DIFF
--- a/cmd/mo-service/config.go
+++ b/cmd/mo-service/config.go
@@ -583,6 +583,7 @@ func dumpCommonConfig(cfg Config) (map[string]*logservicepb.ConfigItem, error) {
 }
 
 func (c *Config) setFileserviceDefaultValues() {
+
 	for i := 0; i < len(c.FileServices); i++ {
 		config := &c.FileServices[i]
 
@@ -603,12 +604,6 @@ func (c *Config) setFileserviceDefaultValues() {
 			} else {
 				config.DataDir = c.defaultFileServiceDataDir(config.Name)
 			}
-		}
-
-		// set default disk cache dir
-		if config.Cache.DiskPath == nil {
-			path := config.DataDir + "-cache"
-			config.Cache.DiskPath = &path
 		}
 
 	}
@@ -662,6 +657,43 @@ func (c *Config) setFileserviceDefaultValues() {
 			Backend: "DISK-ETL", // must be ETL
 			DataDir: c.defaultFileServiceDataDir(defines.ETLFileServiceName),
 		})
+	}
+
+	for i := 0; i < len(c.FileServices); i++ {
+		config := &c.FileServices[i]
+
+		// cache configs
+		switch config.Name {
+
+		case defines.LocalFileServiceName:
+			// memory
+			if config.Cache.MemoryCapacity == nil {
+				capacity := tomlutil.ByteSize(512 * (1 << 20))
+				config.Cache.MemoryCapacity = &capacity
+			}
+			// no disk
+
+		case defines.SharedFileServiceName:
+			// memory
+			if config.Cache.MemoryCapacity == nil {
+				capacity := tomlutil.ByteSize(512 * (1 << 20))
+				config.Cache.MemoryCapacity = &capacity
+			}
+			// disk
+			if config.Cache.DiskPath == nil {
+				path := config.DataDir + "-cache"
+				config.Cache.DiskPath = &path
+			}
+			if config.Cache.DiskCapacity == nil {
+				capacity := tomlutil.ByteSize(8 * (1 << 30))
+				config.Cache.DiskCapacity = &capacity
+			}
+
+		case defines.ETLFileServiceName:
+			// no caches
+
+		}
+
 	}
 
 }

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -60,23 +60,6 @@ type CacheCallbacks struct {
 type CacheCallbackFunc = func(fscache.CacheKey, fscache.Data)
 
 func (c *CacheConfig) setDefaults() {
-	if c.MemoryCapacity == nil {
-		size := toml.ByteSize(512 << 20)
-		c.MemoryCapacity = &size
-	}
-	if c.DiskCapacity == nil {
-		size := toml.ByteSize(8 << 30)
-		c.DiskCapacity = &size
-	}
-	if c.DiskMinEvictInterval == nil {
-		c.DiskMinEvictInterval = &toml.Duration{
-			Duration: time.Minute * 7,
-		}
-	}
-	if c.DiskEvictTarget == nil {
-		target := 0.8
-		c.DiskEvictTarget = &target
-	}
 	c.RPC.Adjust()
 }
 

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -121,6 +121,7 @@ func (l *LocalFS) AllocateCacheData(size int) fscache.Data {
 func (l *LocalFS) initCaches(ctx context.Context, config CacheConfig) error {
 	config.setDefaults()
 
+	// remote
 	if config.RemoteCacheEnabled {
 		if config.QueryClient == nil {
 			return moerr.NewInternalError(ctx, "query client is nil")
@@ -131,7 +132,9 @@ func (l *LocalFS) initCaches(ctx context.Context, config CacheConfig) error {
 		)
 	}
 
-	if *config.MemoryCapacity > DisableCacheCapacity { // 1 means disable
+	// memory
+	if config.MemoryCapacity != nil &&
+		*config.MemoryCapacity > DisableCacheCapacity { // 1 means disable
 		l.memCache = NewMemCache(
 			fscache.ConstCapacity(int64(*config.MemoryCapacity)),
 			&config.CacheCallbacks,
@@ -144,26 +147,28 @@ func (l *LocalFS) initCaches(ctx context.Context, config CacheConfig) error {
 		)
 	}
 
-	if config.enableDiskCacheForLocalFS {
-		if *config.DiskCapacity > DisableCacheCapacity && config.DiskPath != nil {
-			var err error
-			l.diskCache, err = NewDiskCache(
-				ctx,
-				*config.DiskPath,
-				fscache.ConstCapacity(int64(*config.DiskCapacity)),
-				l.perfCounterSets,
-				true,
-				l.name,
-				l,
-			)
-			if err != nil {
-				return err
-			}
-			logutil.Info("fileservice: disk cache initialized",
-				zap.Any("fs-name", l.name),
-				zap.Any("config", config),
-			)
+	// disk
+	if config.enableDiskCacheForLocalFS &&
+		config.DiskCapacity != nil &&
+		*config.DiskCapacity > DisableCacheCapacity &&
+		config.DiskPath != nil {
+		var err error
+		l.diskCache, err = NewDiskCache(
+			ctx,
+			*config.DiskPath,
+			fscache.ConstCapacity(int64(*config.DiskCapacity)),
+			l.perfCounterSets,
+			true,
+			l.name,
+			l,
+		)
+		if err != nil {
+			return err
 		}
+		logutil.Info("fileservice: disk cache initialized",
+			zap.Any("fs-name", l.name),
+			zap.Any("config", config),
+		)
 	}
 
 	return nil

--- a/pkg/fileservice/remote_cache_test.go
+++ b/pkg/fileservice/remote_cache_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/query"
 	"github.com/matrixorigin/matrixone/pkg/queryservice"
 	"github.com/matrixorigin/matrixone/pkg/queryservice/client"
+	"github.com/matrixorigin/matrixone/pkg/util/toml"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -121,7 +122,8 @@ func runTestWithTwoFileServices(t *testing.T, fn func(sf1 *cacheFs, sf2 *cacheFs
 			KeyRouterFactory: func() client.KeyRouter[query.CacheKey] {
 				return keyRouter
 			},
-			QueryClient: qt,
+			QueryClient:    qt,
+			MemoryCapacity: ptrTo[toml.ByteSize](1 << 30),
 		}
 		cacheCfg.setDefaults()
 		cacheCfg.SetRemoteCacheCallback()

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -150,7 +150,8 @@ func (s *S3FS) initCaches(ctx context.Context, config CacheConfig) error {
 	}
 
 	// memory cache
-	if *config.MemoryCapacity > DisableCacheCapacity {
+	if config.MemoryCapacity != nil &&
+		*config.MemoryCapacity > DisableCacheCapacity {
 		s.memCache = NewMemCache(
 			fscache.ConstCapacity(int64(*config.MemoryCapacity)),
 			&config.CacheCallbacks,
@@ -164,7 +165,9 @@ func (s *S3FS) initCaches(ctx context.Context, config CacheConfig) error {
 	}
 
 	// disk cache
-	if *config.DiskCapacity > DisableCacheCapacity && config.DiskPath != nil {
+	if config.DiskCapacity != nil &&
+		*config.DiskCapacity > DisableCacheCapacity &&
+		config.DiskPath != nil {
 		var err error
 		s.diskCache, err = NewDiskCache(
 			ctx,

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -968,7 +968,8 @@ func TestS3PrefetchFile(t *testing.T) {
 			RoleARN:   config.RoleARN,
 		},
 		CacheConfig{
-			DiskPath: ptrTo(cacheDir),
+			DiskCapacity: ptrTo[toml.ByteSize](1 << 30),
+			DiskPath:     ptrTo(cacheDir),
 		},
 		nil,
 		false,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18688 

## What this PR does / why we need it:
fileservice: do not set default memory and disk config in setDefaults


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed default settings for memory and disk cache capacities to prevent unintended configurations.
- Introduced specific cache configurations for different file service names, enhancing flexibility and control.
- Improved conditional logic for initializing memory and disk caches across various file services.
- Updated tests to include explicit memory and disk capacity settings, ensuring accurate test conditions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.go</strong><dd><code>Refactor file service default cache configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/mo-service/config.go

<li>Removed setting of default disk cache directory.<br> <li> Added specific cache configurations for different file service names.<br> <li> Introduced conditional checks for cache memory and disk capacities.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18690/files#diff-99a8567c0dda455a59872c1f58887ac436445b16bb464d7d44d944caaf2f7c1d">+38/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>local_fs.go</strong><dd><code>Enhance local file service cache initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/local_fs.go

<li>Added checks for memory and disk cache initialization.<br> <li> Improved conditional logic for cache configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18690/files#diff-bc086aa870f34585ab047b49edf44e6b55699be741653321dcf574b4bc5d1b00">+25/-20</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>s3_fs.go</strong><dd><code>Enhance S3 file service cache initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/s3_fs.go

<li>Added checks for memory and disk cache initialization.<br> <li> Improved conditional logic for cache configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18690/files#diff-907e5658def7c03142291742cb81fdc3d3590d95678e916e95daf13283a2f86f">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Remove default cache capacity settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/cache.go

<li>Removed default memory and disk capacity settings.<br> <li> Adjusted cache configuration defaults.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18690/files#diff-0095bacc8927fb4d8cc5a9ceddcfb8159997cdbc3ab18e9d3e2a180b865b7bc1">+0/-17</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_cache_test.go</strong><dd><code>Update remote cache test with memory capacity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/remote_cache_test.go

- Added memory capacity configuration in test setup.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18690/files#diff-7f5b02a66d67dcf121dd2dd5aae423b74389d90374d4fc7f1653d43381b8061b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>s3_fs_test.go</strong><dd><code>Update S3 file service test with disk capacity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/fileservice/s3_fs_test.go

- Added disk capacity configuration in test setup.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18690/files#diff-ec3d3d18205db8a6f3f4909866eb8333e48f0cbb366bfa63a1107dccc3bdeda6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

