### PR TITLE
add summary for txnBlock(1.2-dev only)

### DIFF
--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_logtail.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_logtail.go
@@ -70,6 +70,20 @@ func (c *DashboardCreator) initLogtailCollectRow() dashboard.Option {
 			4,
 			axis.Unit("s"),
 			axis.Min(0)),
+
+		c.getHistogram(
+			"pull scan row count",
+			c.getMetricWithFilter("mo_logtail_pull_scan_txn_count_bucket", `type="scan-row"`),
+			[]float64{0.50, 0.7, 0.8, 0.90},
+			6,
+			axis.Min(0)),
+
+		c.getHistogram(
+			"pull skip blk count",
+			c.getMetricWithFilter("mo_logtail_pull_scan_txn_count_bucket", `type="skip-blk"`),
+			[]float64{0.50, 0.7, 0.8, 0.90},
+			6,
+			axis.Min(0)),
 	)
 }
 

--- a/pkg/util/metric/v2/logtail.go
+++ b/pkg/util/metric/v2/logtail.go
@@ -119,6 +119,18 @@ var (
 	LogtailSendLatencyHistogram = logTailSendDurationHistogram.WithLabelValues("latency")
 	LogtailSendNetworkHistogram = logTailSendDurationHistogram.WithLabelValues("network")
 
+	LogtailPullScanTxnCountHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "mo",
+			Subsystem: "logtail",
+			Name:      "pull_scan_txn_count",
+			Help:      "Bucketed histogram of pull scan txn count.",
+			Buckets:   prometheus.ExponentialBuckets(1, 3.0, 20),
+		}, []string{"type"})
+
+	LogTailPullScanSkipBlkCountHistogram = LogtailPullScanTxnCountHistogram.WithLabelValues("skip-blk")
+	LogTailPullScanScanRowCountHistogram = LogtailPullScanTxnCountHistogram.WithLabelValues("scan-row")
+
 	LogTailLoadCheckpointDurationHistogram = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "mo",

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -109,6 +109,7 @@ func initLogtailMetrics() {
 	registry.MustRegister(logTailSendDurationHistogram)
 	registry.MustRegister(LogTailLoadCheckpointDurationHistogram)
 
+	registry.MustRegister(LogtailPullScanTxnCountHistogram)
 	registry.MustRegister(LogTailPushCollectionDurationHistogram)
 	registry.MustRegister(LogTailPullCollectionPhase1DurationHistogram)
 	registry.MustRegister(LogTailPullCollectionPhase2DurationHistogram)

--- a/pkg/vm/engine/tae/logtail/mgr.go
+++ b/pkg/vm/engine/tae/logtail/mgr.go
@@ -199,7 +199,7 @@ func (mgr *Manager) GCByTS(ctx context.Context, ts types.TS) {
 	}
 	mgr.truncated = ts
 	cnt := mgr.table.TruncateByTimeStamp(ts)
-	logutil.Info("[logtail] GC", zap.String("ts", ts.ToString()), zap.Int("deleted", cnt))
+	logutil.Info("[logtail] GC", zap.String("ts", ts.ToString()), zap.Int("deleted-blk", cnt), zap.Int("remaining-row", mgr.table.BlockCount()))
 }
 
 func (mgr *Manager) TryCompactTable() {

--- a/pkg/vm/engine/tae/logtail/mgr.go
+++ b/pkg/vm/engine/tae/logtail/mgr.go
@@ -199,7 +199,7 @@ func (mgr *Manager) GCByTS(ctx context.Context, ts types.TS) {
 	}
 	mgr.truncated = ts
 	cnt := mgr.table.TruncateByTimeStamp(ts)
-	logutil.Info("[logtail] GC", zap.String("ts", ts.ToString()), zap.Int("deleted-blk", cnt), zap.Int("remaining-row", mgr.table.BlockCount()))
+	logutil.Info("[logtail] GC", zap.String("ts", ts.ToString()), zap.Int("deleted-blk", cnt), zap.Int("remaining-blk", mgr.table.BlockCount()))
 }
 
 func (mgr *Manager) TryCompactTable() {

--- a/pkg/vm/engine/tae/logtail/reader.go
+++ b/pkg/vm/engine/tae/logtail/reader.go
@@ -16,6 +16,7 @@ package logtail
 
 import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/model"
 )
@@ -77,7 +78,9 @@ func (r *Reader) GetDirtyByTable(
 	dbID, id uint64,
 ) (tree *model.TableTree) {
 	tree = model.NewTableTree(dbID, id)
+	var rowScan, blkSkip int
 	op := func(row RowT) (moveOn bool) {
+		rowScan++
 		if memo := row.GetMemo(); memo.HasTableDataChanges(id) {
 			tree.Merge(memo.GetDirtyTableByID(id))
 		}
@@ -89,9 +92,14 @@ func (r *Reader) GetDirtyByTable(
 			return false
 		}
 		_, exist := summary.tids[id]
+		if !exist {
+			blkSkip++
+		}
 		return !exist
 	}
 	r.table.ForeachRowInBetween(r.from, r.to, skipFn, op)
+	v2.LogTailPullScanSkipBlkCountHistogram.Observe(float64(blkSkip))
+	v2.LogTailPullScanScanRowCountHistogram.Observe(float64(rowScan))
 	return
 }
 

--- a/pkg/vm/engine/tae/logtail/reader.go
+++ b/pkg/vm/engine/tae/logtail/reader.go
@@ -83,7 +83,15 @@ func (r *Reader) GetDirtyByTable(
 		}
 		return true
 	}
-	r.table.ForeachRowInBetween(r.from, r.to, nil, op)
+	skipFn := func(blk BlockT) bool {
+		summary := blk.summary.Load()
+		if summary == nil {
+			return false
+		}
+		_, exist := summary.tids[id]
+		return !exist
+	}
+	r.table.ForeachRowInBetween(r.from, r.to, skipFn, op)
 	return
 }
 

--- a/pkg/vm/engine/tae/options/types.go
+++ b/pkg/vm/engine/tae/options/types.go
@@ -53,7 +53,7 @@ const (
 	DefaultIOWorkers    = int(16)
 	DefaultAsyncWorkers = int(16)
 
-	DefaultLogtailTxnPageSize = 100
+	DefaultLogtailTxnPageSize = 256
 
 	DefaultLogstoreType = LogstoreBatchStore
 )


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/3925

## What this PR does / why we need it:

Add summary to speed up scanning txn during pull logtail


___

### **PR Type**
enhancement


___

### **Description**
- Added a `skipFn` function in `reader.go` to filter blocks based on the presence of summaries, optimizing the scanning process during logtail operations.
- Enhanced the `summary` struct in `table.go` by introducing a `tids` map to track table IDs, improving the efficiency of transaction block summaries.
- Updated the `DefaultLogtailTxnPageSize` in `types.go` from 100 to 256 to accommodate larger transaction pages.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>reader.go</strong><dd><code>Add block filtering logic in logtail reader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/reader.go

<li>Added a <code>skipFn</code> function to filter blocks based on summary presence.<br> <li> Modified <code>ForeachRowInBetween</code> to use <code>skipFn</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18691/files#diff-a8b46846eeef91cc680c8080b3f83d8dc6d0a941c7636856d9c5e3362ca04cb9">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>table.go</strong><dd><code>Enhance summary struct with table IDs tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/table.go

<li>Introduced <code>tids</code> map in <code>summary</code> struct.<br> <li> Updated <code>trySumary</code> to populate <code>tids</code> with table IDs.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18691/files#diff-257845aca93c57bebdabfaa4ab16ad6431acedbd477c8ef7ff33a78a8864c5ec">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Update default logtail transaction page size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/options/types.go

- Increased `DefaultLogtailTxnPageSize` from 100 to 256.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18691/files#diff-1c42bccfaae4daf20288fbaf1a80905d600284be96bec190643fd6496eae5bf2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

