### PR TITLE
avoid metadata cache access heap allocation

### DIFF
--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -124,13 +124,7 @@ func LoadObjectMetaByExtent(
 	key := encodeCacheKey(*name.Short(), cacheKeyTypeMeta)
 	v, ok := metaCache.Get(key)
 	if ok {
-		var obj any
-		obj, err = Decode(v)
-		if err != nil {
-			return
-		}
-		meta = obj.(ObjectMeta)
-		return
+		return MustObjectMeta(v), nil
 	}
 	if extent.Length() == 0 {
 		logutil.Warn("[LoadObjectMetaByExtent]",

--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -134,12 +134,7 @@ func LoadObjectMetaByExtent(
 	if v, err = ReadExtent(ctx, name.String(), extent, policy, fs, constructorFactory); err != nil {
 		return
 	}
-	var obj any
-	obj, err = Decode(v)
-	if err != nil {
-		return
-	}
-	meta = obj.(ObjectMeta)
+	meta = MustObjectMeta(v)
 	metaCache.Set(key, v[:], int64(len(v)))
 	return
 }

--- a/pkg/objectio/constructors.go
+++ b/pkg/objectio/constructors.go
@@ -15,6 +15,7 @@
 package objectio
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/matrixorigin/matrixone/pkg/compress"
@@ -64,4 +65,12 @@ func Decode(buf []byte) (any, error) {
 		return nil, err
 	}
 	return v, nil
+}
+
+func MustObjectMeta(buf []byte) ObjectMeta {
+	header := DecodeIOEntryHeader(buf)
+	if header.Type != IOET_ObjMeta {
+		panic(fmt.Sprintf("invalid object meta: %s", header.String()))
+	}
+	return ObjectMeta(buf)
 }

--- a/pkg/objectio/funcs.go
+++ b/pkg/objectio/funcs.go
@@ -110,14 +110,7 @@ func ReadObjectMeta(
 	if v, err = ReadExtent(ctx, name, extent, policy, fs, constructorFactory); err != nil {
 		return
 	}
-
-	var obj any
-	obj, err = Decode(v)
-	if err != nil {
-		return
-	}
-
-	meta = obj.(ObjectMeta)
+	meta = MustObjectMeta(v)
 	return
 }
 

--- a/pkg/objectio/meta_entry.go
+++ b/pkg/objectio/meta_entry.go
@@ -20,16 +20,8 @@ func (e ObjectMeta) MustGetMeta(metaType DataMetaType) ObjectDataMeta {
 	return objectMetaV3(e[IOEntryHeaderSize:]).MustGetMeta(metaType)
 }
 
-func (e ObjectMeta) HeaderLength() uint32 {
-	return objectMetaV3(e[IOEntryHeaderSize:]).HeaderLength()
-}
-
 func (e ObjectMeta) DataMetaCount() uint16 {
 	return objectMetaV3(e[IOEntryHeaderSize:]).DataMetaCount()
-}
-
-func (e ObjectMeta) TombstoneMetaCount() uint16 {
-	return objectMetaV3(e[IOEntryHeaderSize:]).TombstoneMetaCount()
 }
 
 func (e ObjectMeta) DataMeta() (ObjectDataMeta, bool) {
@@ -40,26 +32,10 @@ func (e ObjectMeta) MustDataMeta() ObjectDataMeta {
 	return objectMetaV3(e[IOEntryHeaderSize:]).MustDataMeta()
 }
 
-func (e ObjectMeta) TombstoneMeta() (ObjectDataMeta, bool) {
-	return objectMetaV3(e[IOEntryHeaderSize:]).TombstoneMeta()
-}
-
 func (e ObjectMeta) MustTombstoneMeta() ObjectDataMeta {
 	return objectMetaV3(e[IOEntryHeaderSize:]).MustTombstoneMeta()
 }
 
 func (e ObjectMeta) SubMeta(pos uint16) (ObjectDataMeta, bool) {
 	return objectMetaV3(e[IOEntryHeaderSize:]).SubMeta(pos)
-}
-
-func (e ObjectMeta) SubMetaCount() uint16 {
-	return objectMetaV3(e[IOEntryHeaderSize:]).SubMetaCount()
-}
-
-func (e ObjectMeta) SubMetaIndex() SubMetaIndex {
-	return objectMetaV3(e[IOEntryHeaderSize:]).SubMetaIndex()
-}
-
-func (e ObjectMeta) SubMetaTypes() []uint16 {
-	return objectMetaV3(e[IOEntryHeaderSize:]).SubMetaTypes()
 }

--- a/pkg/objectio/meta_entry.go
+++ b/pkg/objectio/meta_entry.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectio
+
+type ObjectMeta []byte
+
+func (e ObjectMeta) MustGetMeta(metaType DataMetaType) ObjectDataMeta {
+	return objectMetaV3(e[IOEntryHeaderSize:]).MustGetMeta(metaType)
+}
+
+func (e ObjectMeta) HeaderLength() uint32 {
+	return objectMetaV3(e[IOEntryHeaderSize:]).HeaderLength()
+}
+
+func (e ObjectMeta) DataMetaCount() uint16 {
+	return objectMetaV3(e[IOEntryHeaderSize:]).DataMetaCount()
+}
+
+func (e ObjectMeta) TombstoneMetaCount() uint16 {
+	return objectMetaV3(e[IOEntryHeaderSize:]).TombstoneMetaCount()
+}
+
+func (e ObjectMeta) DataMeta() (ObjectDataMeta, bool) {
+	return objectMetaV3(e[IOEntryHeaderSize:]).DataMeta()
+}
+
+func (e ObjectMeta) MustDataMeta() ObjectDataMeta {
+	return objectMetaV3(e[IOEntryHeaderSize:]).MustDataMeta()
+}
+
+func (e ObjectMeta) TombstoneMeta() (ObjectDataMeta, bool) {
+	return objectMetaV3(e[IOEntryHeaderSize:]).TombstoneMeta()
+}
+
+func (e ObjectMeta) MustTombstoneMeta() ObjectDataMeta {
+	return objectMetaV3(e[IOEntryHeaderSize:]).MustTombstoneMeta()
+}
+
+func (e ObjectMeta) SubMeta(pos uint16) (ObjectDataMeta, bool) {
+	return objectMetaV3(e[IOEntryHeaderSize:]).SubMeta(pos)
+}
+
+func (e ObjectMeta) SubMetaCount() uint16 {
+	return objectMetaV3(e[IOEntryHeaderSize:]).SubMetaCount()
+}
+
+func (e ObjectMeta) SubMetaIndex() SubMetaIndex {
+	return objectMetaV3(e[IOEntryHeaderSize:]).SubMetaIndex()
+}
+
+func (e ObjectMeta) SubMetaTypes() []uint16 {
+	return objectMetaV3(e[IOEntryHeaderSize:]).SubMetaTypes()
+}

--- a/pkg/objectio/types.go
+++ b/pkg/objectio/types.go
@@ -110,36 +110,3 @@ type Reader interface {
 
 	GetObject() *Object
 }
-
-type ObjectMeta interface {
-	MustGetMeta(metaType DataMetaType) ObjectDataMeta
-
-	HeaderLength() uint32
-
-	DataMetaCount() uint16
-	TombstoneMetaCount() uint16
-
-	DataMeta() (ObjectDataMeta, bool)
-
-	MustDataMeta() ObjectDataMeta
-
-	TombstoneMeta() (ObjectDataMeta, bool)
-
-	MustTombstoneMeta() ObjectDataMeta
-
-	SetDataMetaCount(count uint16)
-
-	SetDataMetaOffset(offset uint32)
-
-	SetTombstoneMetaCount(count uint16)
-
-	SetTombstoneMetaOffset(offset uint32)
-
-	SubMeta(pos uint16) (ObjectDataMeta, bool)
-
-	SubMetaCount() uint16
-
-	SubMetaIndex() SubMetaIndex
-
-	SubMetaTypes() []uint16
-}

--- a/pkg/vm/engine/disttae/datasource.go
+++ b/pkg/vm/engine/disttae/datasource.go
@@ -1220,7 +1220,7 @@ func (ls *LocalDataSource) batchApplyTombstoneObjects(
 			}
 
 			for i := range rowIds {
-				s, e := blockio.FindIntervalForBlock(deletedRowIds, rowIds[i].BorrowBlockID())
+				s, e := blockio.FindStartEndOfBlockFromSortedRowids(deletedRowIds, rowIds[i].BorrowBlockID())
 				for j := s; j < e; j++ {
 					if rowIds[i].EQ(&deletedRowIds[j]) && (commit == nil || commit[j].LessEq(&ls.snapshotTS)) {
 						deleted = append(deleted, int64(i))

--- a/pkg/vm/engine/disttae/tombstones.go
+++ b/pkg/vm/engine/disttae/tombstones.go
@@ -156,7 +156,7 @@ func (tomb *tombstoneData) HasBlockTombstone(
 	}
 	if len(tomb.rowids) > 0 {
 		// TODO: optimize binary search once
-		start, end := blockio.FindIntervalForBlock(tomb.rowids, &blockId)
+		start, end := blockio.FindStartEndOfBlockFromSortedRowids(tomb.rowids, &blockId)
 		if end > start {
 			return true, nil
 		}
@@ -234,7 +234,7 @@ func (tomb *tombstoneData) ApplyInMemTombstones(
 		return
 	}
 
-	start, end := blockio.FindIntervalForBlock(tomb.rowids, &bid)
+	start, end := blockio.FindStartEndOfBlockFromSortedRowids(tomb.rowids, &bid)
 
 	for i := start; i < end; i++ {
 		offset := tomb.rowids[i].GetRowOffset()

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -149,7 +149,7 @@ func GetTombstonesByBlockId(
 
 		for idx := 0; idx < int(obj.BlkCnt()); idx++ {
 			rowids := vector.MustFixedColWithTypeCheck[types.Rowid](oData.data[idx].Vecs[0])
-			start, end := blockio.FindIntervalForBlock(rowids, &bid)
+			start, end := blockio.FindStartEndOfBlockFromSortedRowids(rowids, &bid)
 			if start == end {
 				continue
 			}

--- a/pkg/vm/engine/tae/logtail/snapshot.go
+++ b/pkg/vm/engine/tae/logtail/snapshot.go
@@ -235,7 +235,7 @@ func (d *DeltaLocDataSource) getAndApplyTombstones(
 	if ts.IsEmpty() {
 		ts = d.ts
 	}
-	return blockio.EvalDeleteRowsByTimestamp(deletes, ts, &bid), nil
+	return blockio.EvalDeleteMaskFromDNCreatedTombstones(deletes, ts, &bid), nil
 }
 
 func (d *DeltaLocDataSource) SetOrderBy(orderby []*plan.OrderBySpec) {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18432 

## What this PR does / why we need it:

Prev:
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/b5927e30-6a6d-4a30-8d68-8d67b5085f38">

Now:
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/72dc4b1c-b9be-4f9a-9709-9f28fdfc72cc">


___

### **PR Type**
enhancement


___

### **Description**
- Optimized metadata cache access by using the `MustObjectMeta` function, reducing heap allocations.
- Introduced the `MustObjectMeta` function for safer and more efficient metadata handling, with validation checks.
- Defined a new `ObjectMeta` type with methods for accessing and manipulating metadata, replacing the previous interface.
- Removed the `ObjectMeta` interface definition, simplifying the code structure.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.go</strong><dd><code>Optimize metadata cache access by using MustObjectMeta</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/cache.go

<li>Replaced manual decoding with <code>MustObjectMeta</code> function.<br> <li> Simplified object metadata retrieval.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18699/files#diff-52fcef3b7679892e22f8b7dceac1470fb5bbe77090833eafc9b2136d9560ccdc">+2/-13</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>constructors.go</strong><dd><code>Add MustObjectMeta function for metadata validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/constructors.go

<li>Added <code>MustObjectMeta</code> function for safer metadata handling.<br> <li> Introduced panic for invalid object metadata.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18699/files#diff-f816170f0ecb9deffe27d8ccd09f394d834833d09e075ac776d642640c4c3a76">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>funcs.go</strong><dd><code>Use MustObjectMeta for metadata retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/funcs.go

<li>Replaced manual decoding with <code>MustObjectMeta</code> function.<br> <li> Simplified object metadata retrieval.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18699/files#diff-0b284bf4f01b41909aae99fc1febabec4478ae4129ba97c0e083df4c8afea8ec">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>meta_entry.go</strong><dd><code>Define ObjectMeta type with metadata methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/meta_entry.go

<li>Introduced <code>ObjectMeta</code> type with various metadata methods.<br> <li> Implemented methods for accessing and manipulating metadata.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18699/files#diff-7cb75a2b235ce7db4d007b6548dc082ef9af0360539aac0a91f5c2d8eb3024a5">+65/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Remove ObjectMeta interface definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/types.go

- Removed `ObjectMeta` interface definition.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18699/files#diff-956eba85583e8cc078d94c52e876a512616631e22ed77acbb9092348c9e49e09">+0/-33</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

