### PR TITLE
bug fix: unique key/secondary key get incorrect value (#18711)

### DIFF
--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -2758,15 +2758,14 @@ func recomputeMoCPKeyViaProjection(builder *QueryBuilder, bindCtx *BindContext, 
 		}
 
 		if tableDef.Pkey.PkeyColName == catalog.CPrimaryKeyColName {
-			pkNamesMap := make(map[string]int)
-			for _, name := range tableDef.Pkey.Names {
-				pkNamesMap[name] = 1
-			}
-
+			// pkNamesMap := make(map[string]int)
 			prikeyPos := make([]int, 0)
-			for i, coldef := range tableDef.Cols {
-				if _, ok := pkNamesMap[coldef.Name]; ok {
-					prikeyPos = append(prikeyPos, i)
+			for _, name := range tableDef.Pkey.Names {
+				for i, coldef := range tableDef.Cols {
+					if coldef.Name == name {
+						prikeyPos = append(prikeyPos, i)
+						break
+					}
 				}
 			}
 

--- a/test/distributed/cases/dml/select/select.result
+++ b/test/distributed/cases/dml/select/select.result
@@ -488,3 +488,10 @@ a    b
 1    1
 2    2
 3    3
+drop table if exists t1;
+create table t1 (a int, b varchar, c int, primary key (c,a), key idx_b(b));
+insert into t1 select result, result || "_a",result+100000000 from generate_series(1,10000) g;
+select * from t1 where b in ("11_a","21_a");
+a    b    c
+11    11_a    100000011
+21    21_a    100000021

--- a/test/distributed/cases/dml/select/select.test
+++ b/test/distributed/cases/dml/select/select.test
@@ -263,3 +263,8 @@ insert into t1 values (1,1),(2,2),(3,3);
 -- @separator:table
 select mo_ctl('dn', 'flush', 'select.t1');
 select * from t1 where a in (3,3,3,2,1);
+
+drop table if exists t1;
+create table t1 (a int, b varchar, c int, primary key (c,a), key idx_b(b));
+insert into t1 select result, result || "_a",result+100000000 from generate_series(1,10000) g;
+select * from t1 where b in ("11_a","21_a");


### PR DESCRIPTION
### **User description**
bug fix: unique key/secondary key get incorrect value

Approved by: @heni02, @badboynt1, @aunjgr

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/4059

## What this PR does / why we need it:
bug fix: unique key/secondary key get incorrect value


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug where unique and secondary keys were getting incorrect values by simplifying the logic for computing primary key positions.
- Removed unnecessary map creation and redundant loops to improve code efficiency.
- Added new test cases to verify the correctness of queries involving composite primary keys.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_dml_util.go</strong><dd><code>Simplify primary key position computation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_dml_util.go

<li>Removed unnecessary map creation for primary key names.<br> <li> Simplified logic to find primary key positions in columns.<br> <li> Improved efficiency by removing redundant loops.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18717/files#diff-095fb233d51021791cb24454839b013236680bbc6bbc22e0d2f6741ac8fe7dff">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>select.result</strong><dd><code>Add test cases for composite primary key queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/dml/select/select.result

<li>Added test cases for new table structure with composite primary key.<br> <li> Verified query results for specific conditions.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18717/files#diff-9d1c96ff936faf78217cae250d9e27a06adc785ed76e88c4a3cb8d23f5a5ac19">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>select.test</strong><dd><code>Introduce tests for tables with composite primary keys</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/dml/select/select.test

<li>Introduced new test setup for tables with composite primary keys.<br> <li> Included test queries to validate new logic.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18717/files#diff-056a1bbc967a0fb3ea95a929e08a3952a633052d1be0af3b736a262c5fd9af29">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

