### PR TITLE
Revert "add new ExpressionExecutor for plan.Expr_List (#18698)"

### DIFF
--- a/pkg/sql/colexec/evalExpression_test.go
+++ b/pkg/sql/colexec/evalExpression_test.go
@@ -27,62 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestListExpressionExecutor(t *testing.T) {
-	proc := testutil.NewProcess()
-
-	bat := testutil.NewBatch(
-		[]types.Type{types.T_int64.ToType()},
-		true, 10, proc.Mp())
-
-	//build plan_list
-	exprList := []*plan.Expr{
-		makePlan2Int64ConstExprWithType(1),
-		makePlan2Int64ConstExprWithType(2),
-	}
-
-	evalExpr := &plan.Expr{
-		Expr: &plan.Expr_List{
-			List: &plan.ExprList{
-				List: exprList,
-			},
-		},
-		Typ: plan.Type{
-			Id:          int32(types.T_int64),
-			NotNullable: true,
-		},
-	}
-	curr := proc.Mp().CurrNB()
-
-	listExprExecutor, err := NewExpressionExecutor(proc, evalExpr)
-	require.NoError(t, err)
-	require.Equal(t, listExprExecutor.IsColumnExpr(), false)
-
-	vec, err := listExprExecutor.Eval(proc, []*batch.Batch{bat}, nil)
-	require.NoError(t, err)
-	vals := vector.MustFixedColNoTypeCheck[int64](vec)
-	require.Equal(t, int64(1), vals[0])
-	require.Equal(t, int64(2), vals[1])
-
-	listExprExecutor.ResetForNextQuery()
-
-	vec, err = listExprExecutor.Eval(proc, []*batch.Batch{bat}, nil)
-	require.NoError(t, err)
-	vals = vector.MustFixedColNoTypeCheck[int64](vec)
-	require.Equal(t, int64(1), vals[0])
-	require.Equal(t, int64(2), vals[1])
-
-	vec, err = listExprExecutor.EvalWithoutResultReusing(proc, []*batch.Batch{bat}, nil)
-	require.NoError(t, err)
-	vals = vector.MustFixedColNoTypeCheck[int64](vec)
-	require.Equal(t, int64(1), vals[0])
-	require.Equal(t, int64(2), vals[1])
-	vec.Free(proc.GetMPool())
-
-	listExprExecutor.Free()
-
-	require.Equal(t, curr, proc.Mp().CurrNB())
-}
-
 func TestFixedExpressionExecutor(t *testing.T) {
 	proc := testutil.NewProcess()
 

--- a/pkg/sql/colexec/reuse.go
+++ b/pkg/sql/colexec/reuse.go
@@ -68,14 +68,6 @@ func init() {
 			WithEnableChecker(),
 	)
 
-	reuse.CreatePool[ListExpressionExecutor](
-		func() *ListExpressionExecutor {
-			return &ListExpressionExecutor{}
-		},
-		func(s *ListExpressionExecutor) { *s = ListExpressionExecutor{} },
-		reuse.DefaultOptions[ListExpressionExecutor]().
-			WithEnableChecker(),
-	)
 }
 
 func (expr FixedVectorExpressionExecutor) TypeName() string {
@@ -130,14 +122,5 @@ func (expr FunctionExpressionExecutor) TypeName() string {
 
 func NewFunctionExpressionExecutor() *FunctionExpressionExecutor {
 	fe := reuse.Alloc[FunctionExpressionExecutor](nil)
-	return fe
-}
-
-func (expr ListExpressionExecutor) TypeName() string {
-	return "ListExpressionExecutor"
-}
-
-func NewListExpressionExecutor() *ListExpressionExecutor {
-	fe := reuse.Alloc[ListExpressionExecutor](nil)
 	return fe
 }


### PR DESCRIPTION
### **User description**
This reverts commit 7d313f16c8d81a5235d09372f113778fc0682f44.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/18697

## What this PR does / why we need it:
 reverts commit 7d313f16c8d81a5235d09372f113778fc0682f44.


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the `ListExpressionExecutor` implementation from the codebase, including its initialization, evaluation, and memory management logic.
- Deleted the associated test `TestListExpressionExecutor` to reflect the removal of the executor.
- Removed the pool creation and related methods for `ListExpressionExecutor` in the reuse.go file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evalExpression.go</strong><dd><code>Remove ListExpressionExecutor implementation from evalExpression.go</code></dd></summary>
<hr>

pkg/sql/colexec/evalExpression.go

<li>Removed the <code>ListExpressionExecutor</code> case from the <code>NewExpressionExecutor</code> <br>function.<br> <li> Deleted the <code>ListExpressionExecutor</code> struct and its associated methods.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18728/files#diff-096074b4e06b58b1b2144cc4b4d91fe38b5c4ced8bfd165e7cfc66bd31aa341d">+0/-87</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reuse.go</strong><dd><code>Remove ListExpressionExecutor pool and methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/reuse.go

<li>Removed the pool creation and methods related to <br><code>ListExpressionExecutor</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18728/files#diff-81101e314837e2f6580be1cdc1502017f30a62d6ed485a20bf725911855020c6">+0/-17</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>evalExpression_test.go</strong><dd><code>Remove test for ListExpressionExecutor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/evalExpression_test.go

- Removed the `TestListExpressionExecutor` test function.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18728/files#diff-f98b8d63c73a672a92da3a404fce145662b7e2b268962b505cd3c6f686c03acc">+0/-56</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

