### PR TITLE
Method for reading query results during upgrade modification

### DIFF
--- a/pkg/bootstrap/versions/upgrade_strategy.go
+++ b/pkg/bootstrap/versions/upgrade_strategy.go
@@ -240,15 +240,15 @@ func CheckTableColumn(txn executor.TxnExecutor,
 
 	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
 		data_type := cols[0].UnsafeGetStringAt(0)
-		is_nullable := cols[1].UnsafeGetStringAt(0)
+		is_nullable := cols[1].GetStringAt(0)
 		character_length := vector.GetFixedAt[int64](cols[2], 0)
 		numeric_precision := vector.GetFixedAt[int64](cols[3], 0)
 		numeric_scale := vector.GetFixedAt[int64](cols[4], 0)
 		datetime_precision := vector.GetFixedAt[int64](cols[5], 0)
 		ordinal_position := vector.GetFixedAt[int32](cols[6], 0)
-		column_default := cols[7].UnsafeGetStringAt(0)
-		extra := cols[8].UnsafeGetStringAt(0)
-		column_comment := cols[9].UnsafeGetStringAt(0)
+		column_default := cols[7].GetStringAt(0)
+		extra := cols[8].GetStringAt(0)
+		column_comment := cols[9].GetStringAt(0)
 
 		colInfo.IsExits = true
 		colInfo.ColType = data_type
@@ -284,7 +284,7 @@ func CheckViewDefinition(txn executor.TxnExecutor, accountId uint32, schema stri
 	loaded := false
 	n := 0
 	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		view_def = cols[0].UnsafeGetStringAt(0)
+		view_def = cols[0].GetStringAt(0)
 		n++
 		loaded = true
 		return false
@@ -353,7 +353,7 @@ func CheckTableComment(txn executor.TxnExecutor, accountId uint32, schema string
 	comment := ""
 	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
 		loaded = true
-		comment = cols[3].UnsafeGetStringAt(0)
+		comment = cols[3].GetStringAt(0)
 		return false
 	})
 

--- a/pkg/bootstrap/versions/upgrade_tenant_task.go
+++ b/pkg/bootstrap/versions/upgrade_tenant_task.go
@@ -111,7 +111,7 @@ func GetUpgradeTenantTasks(
 		res.ReadRows(func(rows int, cols []*vector.Vector) bool {
 			for i := 0; i < rows; i++ {
 				tenants = append(tenants, vector.GetFixedAt[int32](cols[0], i))
-				versions = append(versions, cols[1].UnsafeGetStringAt(i))
+				versions = append(versions, cols[1].GetStringAt(i))
 			}
 			return true
 		})
@@ -131,7 +131,7 @@ func GetTenantCreateVersionForUpdate(
 	defer res.Close()
 	version := ""
 	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		version = cols[0].UnsafeGetStringAt(0)
+		version = cols[0].GetStringAt(0)
 		return true
 	})
 	if version == "" {
@@ -174,7 +174,7 @@ func GetTenantVersion(
 	defer res.Close()
 	version := ""
 	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		version = cols[0].UnsafeGetStringAt(0)
+		version = cols[0].GetStringAt(0)
 		return true
 	})
 	if version == "" {

--- a/pkg/bootstrap/versions/version.go
+++ b/pkg/bootstrap/versions/version.go
@@ -82,7 +82,7 @@ func GetLatestVersion(txn executor.TxnExecutor) (Version, error) {
 
 	var version Version
 	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		version.Version = cols[0].UnsafeGetStringAt(0)
+		version.Version = cols[0].GetStringAt(0)
 		version.VersionOffset = vector.GetFixedAt[uint32](cols[1], 0)
 		version.State = vector.GetFixedAt[int32](cols[2], 0)
 		return true
@@ -102,7 +102,7 @@ func GetLatestUpgradeVersion(txn executor.TxnExecutor) (Version, error) {
 
 	var version Version
 	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		version.Version = cols[0].UnsafeGetStringAt(0)
+		version.Version = cols[0].GetStringAt(0)
 		return true
 	})
 	return version, nil
@@ -124,7 +124,7 @@ func MustGetLatestReadyVersion(
 
 	version := ""
 	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
-		version = cols[0].UnsafeGetStringAt(0)
+		version = cols[0].GetStringAt(0)
 		return true
 	})
 	if version == "" {

--- a/pkg/bootstrap/versions/version_upgrade.go
+++ b/pkg/bootstrap/versions/version_upgrade.go
@@ -241,9 +241,9 @@ func getVersionUpgradesBySQL(
 		for i := 0; i < rows; i++ {
 			value := VersionUpgrade{}
 			value.ID = vector.GetFixedAt[uint64](cols[0], i)
-			value.FromVersion = cols[1].UnsafeGetStringAt(i)
-			value.ToVersion = cols[2].UnsafeGetStringAt(i)
-			value.FinalVersion = cols[3].UnsafeGetStringAt(i)
+			value.FromVersion = cols[1].GetStringAt(i)
+			value.ToVersion = cols[2].GetStringAt(i)
+			value.FinalVersion = cols[3].GetStringAt(i)
 			value.FinalVersionOffset = vector.GetFixedAt[uint32](cols[4], i)
 			value.State = vector.GetFixedAt[int32](cols[5], i)
 			value.UpgradeOrder = vector.GetFixedAt[int32](cols[6], i)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4067

## What this PR does / why we need it:
Method for reading query results during upgrade modification
Change from `UnsafeStringAt()` to call `GetStringAt()`


___

### **PR Type**
Bug fix


___

### **Description**
- Replaced `UnsafeGetStringAt` with `GetStringAt` across multiple files for safer string retrieval.
- Improved safety in handling query results during upgrade modifications.
- Addressed issue #4067 by ensuring safer string operations in various functions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upgrade_strategy.go</strong><dd><code>Replace Unsafe String Retrieval with Safe Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/bootstrap/versions/upgrade_strategy.go

<li>Replaced <code>UnsafeGetStringAt</code> with <code>GetStringAt</code> for safer string <br>retrieval.<br> <li> Updated multiple instances within <code>CheckTableColumn</code>, <br><code>CheckViewDefinition</code>, and <code>CheckTableComment</code> functions.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18731/files#diff-d4ee9888c609f1df8e3ccec8ef31486b562d3f21103855fb88bf0daf63e23e9a">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>upgrade_tenant_task.go</strong><dd><code>Improve String Handling Safety in Tenant Tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/bootstrap/versions/upgrade_tenant_task.go

<li>Changed <code>UnsafeGetStringAt</code> to <code>GetStringAt</code> for safer string handling.<br> <li> Applied changes in <code>GetUpgradeTenantTasks</code>, <br><code>GetTenantCreateVersionForUpdate</code>, and <code>GetTenantVersion</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18731/files#diff-b939fba3b21b00a0db5629374e8c919fe31a879fccbf22d0c4e82b37693f141e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version.go</strong><dd><code>Enhance Version Retrieval Safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/bootstrap/versions/version.go

<li>Updated <code>UnsafeGetStringAt</code> to <code>GetStringAt</code> for safer operations.<br> <li> Modified in <code>GetLatestVersion</code>, <code>GetLatestUpgradeVersion</code>, and <br><code>MustGetLatestReadyVersion</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18731/files#diff-e190d96c15c743315b21ca1fd60aa9e7cc38be9f34925a50d51744e010c1f67c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

