### PR TITLE
add merge log & tombstone obj stats

### DIFF
--- a/pkg/vm/engine/tae/catalog/database.go
+++ b/pkg/vm/engine/tae/catalog/database.go
@@ -592,6 +592,8 @@ func MockDBEntryWithAccInfo(accId uint64, dbId uint64) *DBEntry {
 
 	entry.DBNode = &DBNode{}
 	entry.DBNode.acInfo.TenantID = uint32(accId)
+	entry.BaseEntryImpl = NewBaseEntry(
+		func() *EmptyMVCCNode { return &EmptyMVCCNode{} })
 
 	return entry
 }

--- a/pkg/vm/engine/tae/catalog/table_test.go
+++ b/pkg/vm/engine/tae/catalog/table_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package catalog
 
 import (

--- a/pkg/vm/engine/tae/catalog/table_test.go
+++ b/pkg/vm/engine/tae/catalog/table_test.go
@@ -1,0 +1,24 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
+)
+
+func TestTableObjectStats(t *testing.T) {
+	db := MockDBEntryWithAccInfo(0, 0)
+	tbl := MockTableEntryWithDB(db, 1)
+	_, detail := tbl.ObjectStats(common.PPL4, 0, 1, false)
+	require.Equal(t, "DATA\n", detail.String())
+
+	tbl.dataObjects.Set(MockObjEntryWithTbl(tbl, 10), true)
+	_, detail = tbl.ObjectStats(common.PPL4, 0, 1, false)
+	require.Equal(t, "DATA\n\n00000000-0000-0000-0000-000000000000_0\n    loaded:true, oSize:0B, cSzie:10B rows:1, zm: ZM(ANY)0[<nil>,<nil>]--\n", detail.String())
+
+	tbl.tombstoneObjects.Set(MockTombstoneEntryWithTbl(tbl, 20), true)
+	_, detail = tbl.ObjectStats(common.PPL4, 0, 1, true)
+	require.Equal(t, "TOMBSTONES\n\n00000000-0000-0000-0000-000000000000_0\n    loaded:true, oSize:0B, cSzie:20B rows:1, zm: ZM(ANY)0[<nil>,<nil>]--\n", detail.String())
+}

--- a/pkg/vm/engine/tae/rpc/inspect.go
+++ b/pkg/vm/engine/tae/rpc/inspect.go
@@ -277,7 +277,10 @@ func (c *objStatArg) Run() error {
 	if c.tbl != nil {
 		b := &bytes.Buffer{}
 		p := c.ctx.db.MergeScheduler.GetPolicy(c.tbl)
-		b.WriteString(c.tbl.ObjectStatsString(c.verbose, c.start, c.end))
+		b.WriteString(c.tbl.ObjectStatsString(c.verbose, c.start, c.end, false))
+		b.WriteByte('\n')
+		b.WriteByte('\n')
+		b.WriteString(c.tbl.ObjectStatsString(c.verbose, c.start, c.end, true))
 		b.WriteByte('\n')
 		b.WriteString(fmt.Sprintf("\n%s", p.String()))
 		c.ctx.resp.Payload = b.Bytes()
@@ -1039,7 +1042,7 @@ func (o *objectVisitor) OnTable(table *catalog.TableEntry) error {
 	}
 	o.tbl++
 
-	stat, _ := table.ObjectStats(common.PPL0, 0, -1)
+	stat, _ := table.ObjectStats(common.PPL0, 0, -1, false)
 	heap.Push(&o.candidates, mItem{objcnt: stat.ObjectCnt, did: table.GetDB().ID, tid: table.ID})
 	if o.candidates.Len() > o.topk {
 		heap.Pop(&o.candidates)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16854

## What this PR does / why we need it:

add merge log & tombstone obj stats


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the `ObjectStats` and `ObjectStatsString` functions to handle tombstone objects by adding a new `isTombstone` parameter.
- Improved logging in the `DoMergeAndWrite` function to include detailed descriptions of merged and created objects, along with their sizes.
- Updated the inspection logic to include statistics for tombstone objects, ensuring comprehensive data analysis.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>table.go</strong><dd><code>Enhance object statistics functions to handle tombstones</code>&nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/catalog/table.go

<li>Added <code>isTombstone</code> parameter to <code>ObjectStats</code> and <code>ObjectStatsString</code> <br>functions.<br> <li> Implemented logic to handle tombstone objects in <code>ObjectStats</code>.<br> <li> Updated function calls to include the new parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18732/files#diff-e8150a24b9afd22197ca003bbc47e435ee0357a8b96474a0a118a8e8222c7dd7">+11/-5</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>task.go</strong><dd><code>Improve logging for merge operations with detailed stats</code>&nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/mergesort/task.go

<li>Enhanced logging for merge operations with detailed object <br>descriptions.<br> <li> Added total size calculation for merged and created objects.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18732/files#diff-13e455d6d93ef022ecdce55092e0bb8454f3c6c04267dbf9f816a516b3a5cbbf">+17/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inspect.go</strong><dd><code>Update inspection to include tombstone statistics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/rpc/inspect.go

<li>Modified <code>Run</code> method to include tombstone object stats.<br> <li> Updated <code>OnTable</code> method to call <code>ObjectStats</code> with new parameter.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18732/files#diff-a7350916eefe8e5ceea15f65874fa0f87b7e68c2127ea19dd0ce33b5520ccf5f">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

