### PR TITLE
update delete flushThreshold

### DIFF
--- a/pkg/sql/colexec/deletion/types.go
+++ b/pkg/sql/colexec/deletion/types.go
@@ -36,7 +36,7 @@ var _ vm.Operator = new(Deletion)
 
 // make it mutable in ut
 var (
-	flushThreshold = 32 * mpool.MB
+	flushThreshold = 5 * mpool.MB
 )
 
 // SetCNFlushDeletesThreshold update threshold to n MB


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/4050

## What this PR does / why we need it:
update delete flushThreshold


___

### **PR Type**
Bug fix


___

### **Description**
- Updated the `flushThreshold` value in `pkg/sql/colexec/deletion/types.go` from 32 MB to 5 MB to address a bug.
- This change is necessary to fix issue #4050 in the MO-Cloud repository.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Update `flushThreshold` value in deletion types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/deletion/types.go

- Updated the `flushThreshold` value from 32 MB to 5 MB.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18758/files#diff-417eebdbc9616544122d887970e657db9a20483716361572891533e58c19793b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

