### PR TITLE
[tech] pprof: dump malloc profile

### DIFF
--- a/pkg/common/malloc/default.go
+++ b/pkg/common/malloc/default.go
@@ -15,6 +15,7 @@
 package malloc
 
 import (
+	"io"
 	"net/http"
 	"os"
 	"runtime"
@@ -143,4 +144,8 @@ func init() {
 	http.HandleFunc("/debug/malloc", func(w http.ResponseWriter, req *http.Request) {
 		globalProfiler.Write(w)
 	})
+}
+
+func WriteProfileData(w io.Writer) error {
+	return globalProfiler.Write(w)
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18096

## What this PR does / why we need it:
pprof: dump malloc profile


___

### **PR Type**
Enhancement


___

### **Description**
- Added functionality to dump malloc profiles in the `cmd/mo-service/debug.go` file.
- Introduced a new function `saveMallocProfile` to handle the dumping of malloc profiles.
- Integrated the malloc profile dumping process into the existing `saveProfiles` function.
- Implemented `WriteProfileData` function in `pkg/common/malloc/default.go` to facilitate writing malloc profile data.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>debug.go</strong><dd><code>Add malloc profile dumping functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/mo-service/debug.go

<li>Added imports for <code>bytes</code>, <code>compress/gzip</code>, <code>context</code>, and <code>malloc</code>.<br> <li> Implemented <code>saveMallocProfile</code> function to dump malloc profile.<br> <li> Integrated malloc profile dumping into the <code>saveProfiles</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18768/files#diff-1932ee5d4c3eaee815950d1afbbc966661ef6afa8373377a3d783fca2201eb70">+37/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>default.go</strong><dd><code>Implement WriteProfileData for malloc profiling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/malloc/default.go

<li>Added <code>WriteProfileData</code> function to write malloc profile data.<br> <li> Imported <code>io</code> package for writing operations.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18768/files#diff-110177878567ae1db46fdf591a13b48924175e186c7ec2057cf2c8cd7b2fe60e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

