### PR TITLE
add support rollback running txn to 1.2

### DIFF
--- a/pkg/incrservice/column_cache.go
+++ b/pkg/incrservice/column_cache.go
@@ -495,9 +495,7 @@ func (col *columnCache) waitPrevAllocatingLocked(ctx context.Context) error {
 }
 
 func (col *columnCache) close() error {
-	col.Lock()
-	defer col.Unlock()
-	return col.waitPrevAllocatingLocked(context.Background())
+	return nil
 }
 
 func insertAutoValues[T constraints.Integer](

--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -519,7 +519,7 @@ func (tc *txnOperator) WriteAndCommit(ctx context.Context, requests []txn.TxnReq
 
 func (tc *txnOperator) Commit(ctx context.Context) (err error) {
 	if tc.runningSQL.Load() {
-		tc.logger.Fatal("commit on running txn")
+		util.GetLogger().Fatal("commit on running txn")
 	}
 
 	tc.commitCounter.addEnter()
@@ -558,7 +558,7 @@ func (tc *txnOperator) Commit(ctx context.Context) (err error) {
 
 func (tc *txnOperator) Rollback(ctx context.Context) (err error) {
 	if tc.runningSQL.Load() {
-		tc.logger.Fatal("commit on running txn")
+		util.GetLogger().Fatal("commit on running txn")
 	}
 
 	tc.rollbackCounter.addEnter()

--- a/pkg/txn/client/operator_test.go
+++ b/pkg/txn/client/operator_test.go
@@ -545,6 +545,109 @@ func TestWaitCommittedLogAppliedInRCMode(t *testing.T) {
 		nil)
 }
 
+func TestCannotCommitRunningSQLTxn(t *testing.T) {
+	runOperatorTests(
+		t,
+		func(
+			ctx context.Context,
+			tc *txnOperator,
+			_ *testTxnSender,
+		) {
+			defer func() {
+				if err := recover(); err != nil {
+					require.NotNil(t, err)
+				}
+			}()
+
+			tc.EnterRunSql()
+			_ = tc.Commit(ctx)
+		},
+	)
+}
+
+func TestCannotRollbackRunningSQLTxn(t *testing.T) {
+	runOperatorTests(
+		t,
+		func(
+			ctx context.Context,
+			tc *txnOperator,
+			_ *testTxnSender,
+		) {
+			defer func() {
+				if err := recover(); err != nil {
+					require.NotNil(t, err)
+				}
+			}()
+
+			tc.EnterRunSql()
+			_ = tc.Rollback(ctx)
+		},
+	)
+}
+
+func TestEmptyLockSkipped(t *testing.T) {
+	runOperatorTests(
+		t,
+		func(
+			ctx context.Context,
+			tc *txnOperator,
+			_ *testTxnSender,
+		) {
+			require.False(t, tc.LockSkipped(1, lock.LockMode_Exclusive))
+		},
+	)
+}
+
+func TestLockSkipped(t *testing.T) {
+	runOperatorTests(
+		t,
+		func(
+			ctx context.Context,
+			tc *txnOperator,
+			_ *testTxnSender,
+		) {
+			require.True(t, tc.LockSkipped(1, lock.LockMode_Exclusive))
+			require.False(t, tc.LockSkipped(1, lock.LockMode_Shared))
+			require.False(t, tc.LockSkipped(2, lock.LockMode_Exclusive))
+		},
+		WithTxnSkipLock(
+			[]uint64{1},
+			[]lock.LockMode{lock.LockMode_Exclusive},
+		),
+	)
+}
+
+func TestHasLockTable(t *testing.T) {
+	runOperatorTests(
+		t,
+		func(
+			ctx context.Context,
+			tc *txnOperator,
+			_ *testTxnSender,
+		) {
+			require.NoError(t, tc.AddLockTable(lock.LockTable{Table: 1}))
+			require.True(t, tc.HasLockTable(1))
+			require.False(t, tc.HasLockTable(2))
+		},
+	)
+}
+
+func TestBase(t *testing.T) {
+	runOperatorTests(
+		t,
+		func(
+			ctx context.Context,
+			tc *txnOperator,
+			_ *testTxnSender,
+		) {
+			require.NotNil(t, tc.TxnRef())
+			require.Equal(t, tc.Txn().SnapshotTS, tc.SnapshotTS())
+			require.NotEqual(t, timestamp.Timestamp{}, tc.CreateTS())
+			require.Equal(t, txn.TxnStatus_Active, tc.Status())
+		},
+	)
+}
+
 func runOperatorTests(
 	t *testing.T,
 	tc func(context.Context, *txnOperator, *testTxnSender),


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue [#4083](https://github.com/matrixorigin/MO-Cloud/issues/4083)

## What this PR does / why we need it:
add support rollback running txn


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Simplified the `close` method in `column_cache.go` by removing the locking mechanism and returning `nil`.
- Introduced a `runningSQL` atomic boolean in `operator.go` to track the execution state of SQL transactions.
- Enhanced `Commit` and `Rollback` methods to prevent operations if SQL is currently running.
- Updated `EnterRunSql` and `ExitRunSql` methods to modify the `runningSQL` state.
- Added comprehensive tests in `operator_test.go` to verify the new behavior of transaction operators, including checks for running SQL, lock skipping, and lock table presence.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>column_cache.go</strong><dd><code>Simplify column cache close method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/incrservice/column_cache.go

<li>Removed locking mechanism in the <code>close</code> method.<br> <li> Simplified the <code>close</code> method to return <code>nil</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18775/files#diff-fcf6d693b06dbd358de6692d4728cce3a103d2c0de430140dfca1ef9dc59165e">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>operator.go</strong><dd><code>Add state tracking for running SQL transactions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/txn/client/operator.go

<li>Added <code>runningSQL</code> atomic boolean to track SQL execution state.<br> <li> Added checks in <code>Commit</code> and <code>Rollback</code> to prevent operations during <br>running SQL.<br> <li> Updated <code>EnterRunSql</code> and <code>ExitRunSql</code> to modify <code>runningSQL</code> state.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18775/files#diff-43f44107ace02cc2170c3138f30bd1e0ba258be040543c7e43e3a49b89d67c99">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator_test.go</strong><dd><code>Add tests for transaction operator enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/txn/client/operator_test.go

<li>Added tests to ensure <code>Commit</code> and <code>Rollback</code> cannot be performed during <br>running SQL.<br> <li> Added tests for lock skipping and lock table presence.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18775/files#diff-cc8530d0fbe91edcde0f3189966ae64a0ca01e228e4202df540267af64ba8084">+103/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

