### PR TITLE
cp to 1.2-dev 'fix a bug that cause hashmap data wrong'

### DIFF
--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -39,8 +39,8 @@ const (
 
 type container struct {
 	colexec.ReceiverOperator
-
-	state int
+	needDupVec bool
+	state      int
 
 	hasNull            bool
 	isMerge            bool
@@ -114,6 +114,13 @@ func (arg *Argument) Free(proc *process.Process, pipelineFailed bool, err error)
 	ctr := arg.ctr
 	proc.FinalizeRuntimeFilter(arg.RuntimeFilterSpec)
 	if ctr != nil {
+		if ctr.needDupVec {
+			for i := range ctr.vecs {
+				for j := range ctr.vecs[i] {
+					ctr.vecs[i][j].Free(proc.Mp())
+				}
+			}
+		}
 		ctr.cleanBatches(proc)
 		ctr.cleanEvalVectors()
 		if !arg.NeedHashMap {

--- a/test/distributed/cases/dml/delete/delete.result
+++ b/test/distributed/cases/dml/delete/delete.result
@@ -413,6 +413,13 @@ id    t5_id
 4    null
 5    null
 6    null
+DROP TABLE IF EXISTS `t3`;
+CREATE TABLE t3 ( id INT PRIMARY KEY,col1 INT,key idx_col1 (col1));
+INSERT INTO t3 (SELECT *,1 FROM generate_series(0,8192,1)g);
+DELETE FROM t3 WHERE col1=1;
+SELECT COUNT(*) FROM t3 WHERE col1=1;
+count(*)
+0
 drop table if exists t1;
 drop table if exists t2;
 drop table if exists t3;

--- a/test/distributed/cases/dml/delete/delete.test
+++ b/test/distributed/cases/dml/delete/delete.test
@@ -303,6 +303,11 @@ select * from t6;
 delete from t5;
 select * from t6;
 
+DROP TABLE IF EXISTS `t3`;
+CREATE TABLE t3 ( id INT PRIMARY KEY,col1 INT,key idx_col1 (col1));
+INSERT INTO t3 (SELECT *,1 FROM generate_series(0,8192,1)g);
+DELETE FROM t3 WHERE col1=1;
+SELECT COUNT(*) FROM t3 WHERE col1=1;
 drop table if exists t1;
 drop table if exists t2;
 drop table if exists t3;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4049

## What this PR does / why we need it:
cp to 1.2-dev 'fix a bug that cause hashmap data wrong'


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug in the hashmap data handling by introducing a `needDupVec` flag to manage vector duplication when evaluating join conditions.
- Enhanced the `container` struct to include logic for freeing duplicated vectors, ensuring proper memory management.
- Added new test cases to verify the delete operation on a newly created table `t3`, ensuring the correctness of the delete functionality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.go</strong><dd><code>Fix hashmap data issue by handling vector duplication</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/hashbuild/build.go

<li>Added import for <code>pbplan</code>.<br> <li> Introduced <code>needDupVec</code> flag to handle condition expressions.<br> <li> Modified logic to duplicate vectors based on <code>needDupVec</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18779/files#diff-0c2753ffdc4ccc951ac44650817da1d8ffe37631363a440b8b55732bb0e2b839">+14/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Enhance container struct with vector duplication handling</code></dd></summary>
<hr>

pkg/sql/colexec/hashbuild/types.go

<li>Added <code>needDupVec</code> field to <code>container</code> struct.<br> <li> Implemented logic to free duplicated vectors.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18779/files#diff-270d27fc945ebbe16cfb88efa16c176856d021853abfe9c6429a8d7ca48d6c5f">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>delete.result</strong><dd><code>Add test case for delete operation on table t3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/dml/delete/delete.result

<li>Added test case for deleting entries in table <code>t3</code>.<br> <li> Verified count after deletion.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18779/files#diff-2695cc4b5a2c02b0ce2a5f568b726e492741732b364bb24e4d5dde44bde2f43b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>delete.test</strong><dd><code>Implement delete operation test for table t3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/dml/delete/delete.test

- Added setup and execution for delete test on table `t3`.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18779/files#diff-e59fbf4657499ef05814802b335f9b5c00109a6e91b5f06b9c6ac5e73888dc76">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

