### PR TITLE
add summary for txnBlock

### DIFF
--- a/pkg/vm/engine/tae/logtail/mgr.go
+++ b/pkg/vm/engine/tae/logtail/mgr.go
@@ -199,7 +199,7 @@ func (mgr *Manager) GCByTS(ctx context.Context, ts types.TS) {
 	}
 	mgr.truncated = ts
 	cnt := mgr.table.TruncateByTimeStamp(ts)
-	logutil.Info("[logtail] GC", zap.String("ts", ts.ToString()), zap.Int("deleted", cnt))
+	logutil.Info("[logtail] GC", zap.String("ts", ts.ToString()), zap.Int("deleted-blk", cnt), zap.Int("remaining-blk", mgr.table.BlockCount()))
 }
 
 func (mgr *Manager) TryCompactTable() {

--- a/pkg/vm/engine/tae/logtail/reader.go
+++ b/pkg/vm/engine/tae/logtail/reader.go
@@ -84,7 +84,15 @@ func (r *Reader) GetDirtyByTable(
 		}
 		return true
 	}
-	r.table.ForeachRowInBetween(r.from, r.to, nil, op)
+	skipFn := func(blk BlockT) bool {
+		summary := blk.summary.Load()
+		if summary == nil {
+			return false
+		}
+		_, exist := summary.tids[id]
+		return !exist
+	}
+	r.table.ForeachRowInBetween(r.from, r.to, skipFn, op)
 	return
 }
 

--- a/pkg/vm/engine/tae/options/types.go
+++ b/pkg/vm/engine/tae/options/types.go
@@ -56,7 +56,7 @@ const (
 	DefaultIOWorkers    = int(16)
 	DefaultAsyncWorkers = int(16)
 
-	DefaultLogtailTxnPageSize = 100
+	DefaultLogtailTxnPageSize = 256
 
 	DefaultLogstoreType = LogstoreBatchStore
 )


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/3925

## What this PR does / why we need it:

Add summary to speed up scanning txn during pulling logtail


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the logging in the `GCByTS` function to include the count of remaining blocks after garbage collection.
- Optimized the `GetDirtyByTable` method by adding a skip function to avoid processing blocks without relevant table IDs.
- Introduced a `tids` map in the `summary` struct to track table IDs, and updated the `trySumary` method to populate this map.
- Increased the default transaction page size from 100 to 256 to improve performance.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mgr.go</strong><dd><code>Improve logging for garbage collection process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/mgr.go

- Enhanced logging in `GCByTS` function to include remaining blocks.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18780/files#diff-e7cd8f1fa8d2421022a494fc8a0322096a37464b2844c5b8db4b7ba503bf2f5a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reader.go</strong><dd><code>Optimize row iteration with block skipping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/reader.go

<li>Added a skip function to optimize row iteration.<br> <li> Skip blocks without relevant table IDs during iteration.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18780/files#diff-a8b46846eeef91cc680c8080b3f83d8dc6d0a941c7636856d9c5e3362ca04cb9">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>table.go</strong><dd><code>Add table ID tracking in transaction summary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/table.go

<li>Introduced <code>tids</code> map in <code>summary</code> struct.<br> <li> Updated <code>trySumary</code> method to populate <code>tids</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18780/files#diff-257845aca93c57bebdabfaa4ab16ad6431acedbd477c8ef7ff33a78a8864c5ec">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Update default transaction page size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/options/types.go

- Increased `DefaultLogtailTxnPageSize` from 100 to 256.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18780/files#diff-1c42bccfaae4daf20288fbaf1a80905d600284be96bec190643fd6496eae5bf2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

