### PR TITLE
remove the 1024bytes limit for group_concat result.

### DIFF
--- a/pkg/sql/colexec/aggexec/concat.go
+++ b/pkg/sql/colexec/aggexec/concat.go
@@ -23,10 +23,6 @@ import (
 	"math"
 )
 
-const (
-	groupConcatMaxLen = 1024
-)
-
 // group_concat is a special string aggregation function.
 type groupConcatExec struct {
 	multiAggInfo
@@ -116,9 +112,6 @@ func (exec *groupConcatExec) Fill(groupIndex int, row int, vectors []*vector.Vec
 	exec.ret.groupToSet = groupIndex
 	exec.ret.setGroupNotEmpty(groupIndex)
 	r := exec.ret.aggGet()
-	if len(r) > groupConcatMaxLen {
-		return nil
-	}
 	if len(r) > 0 {
 		r = append(r, exec.separator...)
 	}
@@ -172,7 +165,7 @@ func (exec *groupConcatExec) merge(other *groupConcatExec, idx1, idx2 int) error
 
 	v1 := exec.ret.aggGet()
 	v2 := other.ret.aggGet()
-	if len(v2) == 0 || len(v1) > groupConcatMaxLen {
+	if len(v2) == 0 {
 		return nil
 	}
 	if len(v1) > 0 && len(v2) > 0 {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

https://github.com/matrixorigin/MO-Cloud/issues/4084

## What this PR does / why we need it:
移除了group_concat每行结果不能超过1024的限制


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the 1024-byte length limit for each row content in the `group_concat` function, allowing for longer concatenated strings.
- Simplified the code by removing unnecessary checks related to the previous length limit.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>concat.go</strong><dd><code>Remove length limit for group_concat results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/aggexec/concat.go

<li>Removed the 1024-byte length limit for <code>group_concat</code> results.<br> <li> Simplified logic by eliminating checks against the removed limit.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18786/files#diff-4db0b097c2469c1a33765c2e86a41304a2b6f594468b6616deab24e26f0afc59">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

