### PR TITLE
fix range checkpoint

### DIFF
--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/info.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/info.go
@@ -31,9 +31,8 @@ var ErrDriverLsnNotFound = moerr.NewInternalErrorNoCtx("driver info: driver lsn 
 var ErrRetryTimeOut = moerr.NewInternalErrorNoCtx("driver info: retry time out")
 
 type driverInfo struct {
-	addr     map[uint64]*common.ClosedIntervals //logservicelsn-driverlsn TODO drop on truncate
-	validLsn *roaring64.Bitmap
-
+	addr                   map[uint64]*common.ClosedIntervals //logservicelsn-driverlsn TODO drop on truncate
+	validLsn               *roaring64.Bitmap
 	addrMu                 sync.RWMutex
 	driverLsn              uint64 //
 	syncing                uint64

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/info.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/info.go
@@ -31,15 +31,15 @@ var ErrDriverLsnNotFound = moerr.NewInternalErrorNoCtx("driver info: driver lsn 
 var ErrRetryTimeOut = moerr.NewInternalErrorNoCtx("driver info: retry time out")
 
 type driverInfo struct {
-	addr        map[uint64]*common.ClosedIntervals //logservicelsn-driverlsn TODO drop on truncate
-	validLsn    *roaring64.Bitmap
-	addrMu      sync.RWMutex
-	driverLsn   uint64 //
-	syncing     uint64
-	synced      uint64
-	syncedMu    sync.RWMutex
-	driverLsnMu sync.RWMutex
+	addr     map[uint64]*common.ClosedIntervals //logservicelsn-driverlsn TODO drop on truncate
+	validLsn *roaring64.Bitmap
 
+	addrMu                 sync.RWMutex
+	driverLsn              uint64 //
+	syncing                uint64
+	synced                 uint64
+	syncedMu               sync.RWMutex
+	driverLsnMu            sync.RWMutex
 	truncating             atomic.Uint64 //
 	truncatedLogserviceLsn uint64        //
 
@@ -96,7 +96,7 @@ func (info *driverInfo) onReplayRecordEntry(lsn uint64, driverLsns *common.Close
 func (info *driverInfo) getNextValidLogserviceLsn(lsn uint64) uint64 {
 	info.addrMu.Lock()
 	defer info.addrMu.Unlock()
-	if info.validLsn.GetCardinality() == 0 {
+	if info.validLsn.IsEmpty() {
 		return 0
 	}
 	max := info.validLsn.Maximum()
@@ -209,6 +209,7 @@ func (info *driverInfo) gcAddr(logserviceLsn uint64) {
 			lsnToDelete = append(lsnToDelete, serviceLsn)
 		}
 	}
+	info.validLsn.RemoveRange(0, logserviceLsn)
 	for _, lsn := range lsnToDelete {
 		delete(info.addr, lsn)
 	}

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/truncate.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/truncate.go
@@ -26,7 +26,7 @@ import (
 
 // driver lsn -> entry lsn
 func (d *LogServiceDriver) Truncate(lsn uint64) error {
-	logutil.Info("LogService Driver", zap.Uint64(" driver start truncate", lsn))
+	logutil.Info("TRACE-WAL-TRUNCATE", zap.Uint64(" driver start truncate", lsn))
 	if lsn > d.truncating.Load() {
 		d.truncating.Store(lsn)
 	}
@@ -66,7 +66,7 @@ func (d *LogServiceDriver) doTruncate() {
 	min := d.validLsn.Minimum()
 	max := d.validLsn.Maximum()
 	d.addrMu.RUnlock()
-	logutil.Info("LogService Driver: get LogService lsn",
+	logutil.Info("TRACE-WAL-TRUNCATE-Get LogService lsn",
 		zap.Int("loop count", loopCount),
 		zap.Uint64("driver lsn", target),
 		zap.Uint64("min", min),
@@ -82,7 +82,7 @@ func (d *LogServiceDriver) doTruncate() {
 }
 
 func (d *LogServiceDriver) truncateLogservice(lsn uint64) {
-	logutil.Info("LogService Driver: Start Truncate", zap.Uint64("lsn", lsn))
+	logutil.Info("TRACE-WAL-TRUNCATE-Start Truncate", zap.Uint64("lsn", lsn))
 	t0 := time.Now()
 	client, err := d.clientPool.Get()
 	if err == ErrClientPoolClosed {
@@ -119,7 +119,7 @@ func (d *LogServiceDriver) truncateLogservice(lsn uint64) {
 			panic(err)
 		}
 	}
-	logutil.Info("LogService Driver: Truncate successfully",
+	logutil.Info("TRACE-WAL-TRUNCATE-Truncate successfully",
 		zap.Uint64("lsn", lsn),
 		zap.String("duration",
 			time.Since(t0).String()))
@@ -148,6 +148,6 @@ func (d *LogServiceDriver) getLogserviceTruncate() (lsn uint64) {
 			panic(err)
 		}
 	}
-	logutil.Infof("Logservice Driver: Get Truncate %d", lsn)
+	logutil.Infof("TRACE-WAL-TRUNCATE-Get Truncate %d", lsn)
 	return
 }

--- a/pkg/vm/engine/tae/logstore/store/checkpoint.go
+++ b/pkg/vm/engine/tae/logstore/store/checkpoint.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (w *StoreImpl) RangeCheckpoint(gid uint32, start, end uint64) (ckpEntry entry.Entry, err error) {
-	logutil.Info("LogService Driver: RangeCheckpoint", zap.Uint32("group", gid), zap.Uint64("lsn", end))
+	logutil.Info("TRACE-WAL-TRUNCATE-RangeCheckpoint", zap.Uint32("group", gid), zap.Uint64("lsn", end))
 	ckpEntry = w.makeRangeCheckpointEntry(gid, start, end)
 	drentry, _, err := w.doAppend(GroupCKP, ckpEntry)
 	if err == sm.ErrClose {
@@ -63,7 +63,7 @@ func (w *StoreImpl) onLogCKPInfoQueue(items ...any) {
 		if err != nil {
 			panic(err)
 		}
-		logutil.Info("LogService Driver: ckp entry is done",
+		logutil.Info("TRACE-WAL-TRUNCATE-CKP-Entry",
 			zap.Uint32("group", e.Info.Checkpoints[0].Group),
 			zap.Uint64("lsn", e.Info.Checkpoints[0].Ranges.GetMax()))
 		w.logCheckpointInfo(e.Info)
@@ -86,7 +86,7 @@ func (w *StoreImpl) ckpCkp() {
 	if err != nil {
 		panic(err)
 	}
-	logutil.Info("LogService Driver: append internal entry",
+	logutil.Info("TRACE-WAL-TRUNCATE-Internal-Entry",
 		zap.String("duration", time.Since(t0).String()))
 	w.truncatingQueue.Enqueue(driverEntry)
 	err = e.WaitDone()
@@ -110,7 +110,7 @@ func (w *StoreImpl) onTruncatingQueue(items ...any) {
 	t0 = time.Now()
 	gid, driverLsn := w.getDriverCheckpointed()
 	tGetDriverEntry := time.Since(t0)
-	logutil.Info("Logservice Driver",
+	logutil.Info("TRACE-WAL-TRUNCATE",
 		zap.String("wait truncating entry takes", tTruncateEntry.String()),
 		zap.String("get driver lsn takes", tGetDriverEntry.String()),
 		zap.Uint64("driver lsn", driverLsn))
@@ -134,7 +134,7 @@ func (w *StoreImpl) onTruncateQueue(items ...any) {
 		}
 		t := time.Now()
 		w.gcWalDriverLsnMap(lsn)
-		logutil.Info("LogService Driver: gc store info", zap.String("duration", time.Since(t).String()))
+		logutil.Info("TRACE-WAL-TRUNCATE-GC-Store", zap.String("duration", time.Since(t).String()))
 		w.driverCheckpointed = lsn
 	}
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4098

## What this PR does / why we need it:
1. fix range checkpoint
2. add log


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved synchronization and LSN management in `driverInfo` by adjusting mutex usage and adding removal of log service LSN range.
- Enhanced logging and added detailed metrics for the truncation process in `LogServiceDriver`, including loop count and duration.
- Added logging with timing metrics for checkpoint operations in `StoreImpl`, improving visibility into checkpoint and truncation processes.
- Improved logging format across modified files using `zap` for better clarity and consistency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>info.go</strong><dd><code>Improve synchronization and LSN management in driverInfo</code>&nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logstore/driver/logservicedriver/info.go

<li>Improved synchronization by adjusting mutex usage.<br> <li> Replaced <code>GetCardinality</code> with <code>IsEmpty</code> for better clarity.<br> <li> Added removal of log service LSN range from <code>validLsn</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18799/files#diff-1c67af5f690f4d3b51a7b610ea1ca548ea786fa40893d86958d56b82b3d5e0fd">+10/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>truncate.go</strong><dd><code>Enhance logging and metrics in truncation process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logstore/driver/logservicedriver/truncate.go

<li>Added logging for truncation process with detailed metrics.<br> <li> Introduced loop count and duration logging for truncation.<br> <li> Improved logging format using <code>zap</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18799/files#diff-996fd476c61e0bb12d604fb0fccd01759eec8c8108ac006b947b877f5b4c4ddf">+23/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>checkpoint.go</strong><dd><code>Add detailed logging and metrics for checkpoint operations</code></dd></summary>
<hr>

pkg/vm/engine/tae/logstore/store/checkpoint.go

<li>Added logging for checkpoint operations with timing metrics.<br> <li> Improved logging format using <code>zap</code>.<br> <li> Enhanced visibility into checkpoint and truncation processes.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18799/files#diff-4bc28fcdc24464bc239107ed8534c49e64aa5cc105daaaf0cc6a75c197651e6e">+21/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

