### PR TITLE
make query with limit run in single parallel

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -2403,6 +2403,9 @@ func (c *Compile) compileTableScanDataSource(s *Scope) error {
 	s.DataSource.FilterExpr = filterExpr
 	s.DataSource.RuntimeFilterSpecs = n.RuntimeFilterProbeList
 	s.DataSource.OrderBy = n.OrderBy
+	if len(n.OrderBy) > 0 || n.Limit != nil {
+		s.DataSource.hasLimit = true
+	}
 
 	return nil
 }

--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -68,7 +68,8 @@ const (
 
 // Source contains information of a relation which will be used in execution.
 type Source struct {
-	isConst bool
+	isConst  bool
+	hasLimit bool
 
 	PushdownId             uint64
 	PushdownAddr           string

--- a/pkg/vm/engine/disttae/tools.go
+++ b/pkg/vm/engine/disttae/tools.go
@@ -1520,7 +1520,9 @@ func distributeBlocksToBlockReaders(rds []*blockReader, numOfReaders int, numOfB
 		}
 	}
 	scanType := NORMAL
-	if numOfBlocks < numOfReaders*SMALLSCAN_THRESHOLD {
+	if numOfReaders == 1 {
+		scanType = SMALL
+	} else if numOfBlocks < numOfReaders*SMALLSCAN_THRESHOLD {
 		scanType = SMALL
 	} else if (numOfReaders * LARGESCAN_THRESHOLD) <= numOfBlocks {
 		scanType = LARGE


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4107

## What this PR does / why we need it:
make query with limit run in single parallel


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a `hasLimit` flag in the `Source` struct to optimize query execution when `OrderBy` or `Limit` is present.
- Modified the `DetermineRuntimeDOP` function to adjust CPU usage based on the presence of query limits.
- Updated the logic for distributing blocks to block readers to handle single reader scenarios more effectively.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compile.go</strong><dd><code>Add `hasLimit` flag for query optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/compile.go

- Added a check for `OrderBy` and `Limit` to set `hasLimit` flag.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18803/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scope.go</strong><dd><code>Optimize CPU usage based on query limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/scope.go

<li>Modified <code>DetermineRuntimeDOP</code> to consider <code>hasLimit</code>.<br> <li> Adjusted CPU determination logic for different engine types.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18803/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add `hasLimit` field to `Source` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/types.go

- Introduced `hasLimit` field in `Source` struct.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18803/files#diff-a4dcef274017300a3251138d7116e56db5c8749ac87367179081cd6caabb3a60">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tools.go</strong><dd><code>Refine block reader distribution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/tools.go

<li>Adjusted scan type determination logic for single reader scenarios.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18803/files#diff-9f173a6c762766883dd2cf2903892ee23223381f92bb6aaa1ca64b9e3702dbff">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

