### PR TITLE
Fix 18810

### DIFF
--- a/pkg/objectio/object_stats.go
+++ b/pkg/objectio/object_stats.go
@@ -214,22 +214,36 @@ func (des *ObjectStats) Rows() uint32 {
 	return types.DecodeUint32(des[rowCntOffset : rowCntOffset+rowCntLen])
 }
 
-func (des *ObjectStats) String() string {
-	reserved := ""
+func (des *ObjectStats) FlagString() string {
+	flags := ""
 	if des.GetAppendable() {
-		reserved = reserved + "A"
+		flags += "1"
+	} else {
+		flags += "0"
 	}
 	if des.GetSorted() {
-		reserved = reserved + "S"
+		flags += "1"
+	} else {
+		flags += "0"
 	}
 	if des.GetCNCreated() {
-		reserved = reserved + "C"
+		flags += "1"
+	} else {
+		flags += "0"
 	}
-	return fmt.Sprintf("[object stats]: %v; objName: %s; extent: %v; "+
-		"rowCnt: %d; blkCnt: %d; sortKey zoneMap: %v; size: %d; originSize: %d",
-		reserved, des.ObjectName().String(), des.Extent().String(),
-		des.Rows(), des.BlkCnt(), des.SortKeyZoneMap(),
-		des.Size(), des.OriginSize())
+	return flags
+}
+
+func (des *ObjectStats) String() string {
+	flags := des.FlagString()
+	if des.Extent().Length() == 0 {
+		return fmt.Sprintf("[OBJ(%s)-(%s)|NoExt]", flags, des.ObjectName().String())
+	}
+	return fmt.Sprintf(
+		"[OBJ(%s)-(%s)|Ext(%s)|Rows(%d)|Blks(%d)|Size(%d)|OSize(%d)]",
+		flags, des.ObjectName().String(), des.Extent().String(),
+		des.Rows(), des.BlkCnt(), des.Size(), des.OriginSize(),
+	)
 }
 
 func setHelper(stats *ObjectStats, offset int, data []byte) error {

--- a/pkg/vm/engine/tae/catalog/metamvccnode.go
+++ b/pkg/vm/engine/tae/catalog/metamvccnode.go
@@ -138,8 +138,8 @@ func (e *ObjectMVCCNode) CloneData() *ObjectMVCCNode {
 	}
 }
 func (e *ObjectMVCCNode) String() string {
-	if e == nil || e.IsEmpty() {
-		return "empty"
+	if e == nil {
+		return "[OBJ(nil)]"
 	}
 	return e.ObjectStats.String()
 }

--- a/pkg/vm/engine/tae/catalog/object.go
+++ b/pkg/vm/engine/tae/catalog/object.go
@@ -361,28 +361,23 @@ func (entry *ObjectEntry) String() string {
 }
 
 func (entry *ObjectEntry) StringWithLevel(level common.PPLevel) string {
-	nameStr := "OBJ"
+	nameStr := "DATA"
 	if entry.IsTombstone {
 		nameStr = "TOMBSTONE"
 	}
-	state := "A"
-	if !entry.IsAppendable() {
-		state = "NA"
-	}
-	sorted := "S"
-	if !entry.IsSorted() {
-		sorted = "US"
-	}
+	s := fmt.Sprintf(
+		"%s|OS(%d)|Hint(%d)|%s|%s",
+		nameStr, entry.ObjectState, entry.ObjectNode.SortHint,
+		entry.ObjectStats.String(), entry.ObjectMVCCNode.String(),
+	)
 	if level <= common.PPL1 {
-		return fmt.Sprintf("%v[%s-%s%d]%v[%s]%v",
-			entry.ObjectState, state, sorted, entry.ObjectNode.SortHint, nameStr, entry.ID().String(), entry.EntryMVCCNode.String())
+		return s
 	}
-	s := fmt.Sprintf("[%s-%s%d]%s[%s]%v%v", state, sorted, entry.ObjectNode.SortHint, nameStr, entry.ID().String(), entry.EntryMVCCNode.String(), entry.ObjectMVCCNode.String())
 	if !entry.DeleteNode.IsEmpty() {
-		s = fmt.Sprintf("%s -> %s", s, entry.DeleteNode.String())
+		s = fmt.Sprintf("%s -> [DNODE]:%s", s, entry.DeleteNode.String())
 	}
 
-	s = fmt.Sprintf("%s -> %s", s, entry.CreateNode.String())
+	s = fmt.Sprintf("%s -> [CNODE]:%s", s, entry.CreateNode.String())
 	return s
 }
 func (entry *ObjectEntry) IsVisible(txn txnif.TxnReader) bool {

--- a/pkg/vm/engine/tae/model/pages.go
+++ b/pkg/vm/engine/tae/model/pages.go
@@ -161,7 +161,6 @@ func (page *TransferHashPage) Clear() {
 	}
 	page.hashmap.Store(nil)
 	v2.TaskMergeTransferPageLengthGauge.Sub(float64(len(*m)))
-	clear(*m)
 }
 
 func (page *TransferHashPage) Train(m api.TransferMap) {

--- a/pkg/vm/engine/tae/txn/txnbase/mvccnode.go
+++ b/pkg/vm/engine/tae/txn/txnbase/mvccnode.go
@@ -400,7 +400,7 @@ func (un *TxnMVCCNode) CloneAll() *TxnMVCCNode {
 }
 
 func (un *TxnMVCCNode) String() string {
-	return fmt.Sprintf("[%s,%s][%v]",
+	return fmt.Sprintf("[%s,%s][Committed(%v)]",
 		un.Start.ToString(),
 		un.End.ToString(), un.Txn == nil)
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18810 

## What this PR does / why we need it:

fix 18810


___

### **PR Type**
Bug fix


___

### **Description**
- Refactored the string representation of object stats to use a new `FlagString` method for better flag handling and formatting.
- Improved the `String` method in `ObjectMVCCNode` to handle nil and empty cases more explicitly.
- Simplified and enhanced the `StringWithLevel` method in `ObjectEntry` to improve readability and state representation.
- Optimized the `Clear` method in `TransferHashPage` by removing an unnecessary function call.
- Enhanced the `String` method in `TxnMVCCNode` to include committed status in the output for better clarity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>object_stats.go</strong><dd><code>Refactor object stats string representation and flag handling</code></dd></summary>
<hr>

pkg/objectio/object_stats.go

<li>Added <code>FlagString</code> method to generate a flag string for object stats.<br> <li> Updated <code>String</code> method to use the new <code>FlagString</code> and improved <br>formatting.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18811/files#diff-ee4043182eb602ba7e2808a244a58b0524d4ab8be8157faf7e755e422ca2265d">+24/-10</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metamvccnode.go</strong><dd><code>Improve string representation for ObjectMVCCNode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/catalog/metamvccnode.go

<li>Updated <code>String</code> method to handle nil and empty cases more explicitly.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18811/files#diff-2ae8db170d79a92e6793e4611909d094a693234863042d033b49df8bbc6b3bd2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>object.go</strong><dd><code>Refactor ObjectEntry string representation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/catalog/object.go

<li>Simplified <code>StringWithLevel</code> method and improved string formatting.<br> <li> Enhanced handling of tombstone and node states in string <br>representation.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18811/files#diff-ba7fd83dfa69f768d750e0f59e376d51dac7cc880bbb5c0702141d06bb26689e">+9/-14</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pages.go</strong><dd><code>Optimize TransferHashPage clear method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/model/pages.go

- Removed unnecessary `clear` function call in `Clear` method.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18811/files#diff-44086321e3493435f1083550a3a7c8d9f6a2799300ff20ac03d3bb41ef08c4fb">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mvccnode.go</strong><dd><code>Enhance MVCCNode string representation with commit status</code></dd></summary>
<hr>

pkg/vm/engine/tae/txn/txnbase/mvccnode.go

- Updated `String` method to include committed status in output.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18811/files#diff-93d060a56515c3e4dfb5f4276c0d709bb2ce7eea30f43a9a19b780533f38c74a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

