### PR TITLE
Improve incremental dedup 2

### DIFF
--- a/pkg/vm/engine/tae/txn/txnimpl/table.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table.go
@@ -1010,7 +1010,7 @@ func (tbl *txnTable) findDeletes(
 		if obj.DeletedAt.Less(&snapshotTS) && !obj.DeletedAt.IsEmpty() {
 			continue
 		}
-		if dedupAfterSnapshotTS && objData.CoarseCheckAllRowsCommittedBefore(tbl.store.txn.GetSnapshotTS()) {
+		if dedupAfterSnapshotTS && objData.CoarseCheckAllRowsCommittedBefore(snapshotTS) {
 			continue
 		}
 		skip := obj.IsCreatingOrAborted()


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18432 

## What this PR does / why we need it:

improve incremental dedup


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced `snapshotTS` to optimize deduplication logic in `base_table.go` and `table.go`.
- Added conditions to skip processing of objects deleted before `snapshotTS`.
- Refactored deduplication checks to use `snapshotTS` for improved efficiency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_table.go</strong><dd><code>Optimize deduplication logic with snapshot timestamp</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/txn/txnimpl/base_table.go

<li>Introduced <code>snapshotTS</code> to optimize deduplication logic.<br> <li> Added condition to skip processing of objects deleted before <br><code>snapshotTS</code>.<br> <li> Refactored deduplication check to use <code>snapshotTS</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18815/files#diff-0ff62af24a993feb3e79f6b988eb71a2af336707cb8aa05a5bc0f7c9247e6b6f">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>table.go</strong><dd><code>Refactor deduplication logic using snapshot timestamp</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/txn/txnimpl/table.go

<li>Introduced <code>snapshotTS</code> for deduplication logic.<br> <li> Added condition to skip objects deleted before <code>snapshotTS</code>.<br> <li> Refactored deduplication check to use <code>snapshotTS</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18815/files#diff-971b05c2446e17a0d69e884b519bc80d53143a6f05fa991c88e9b6c0c38b3f33">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

