### PR TITLE
fix using too much memory to store orphan txns

### DIFF
--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -17,7 +17,6 @@ package lockservice
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/log"
@@ -37,6 +36,7 @@ type lockTableAllocator struct {
 	address         string
 	server          Server
 	client          Client
+	inactiveService sync.Map // lock service id -> inactive time
 	ctl             sync.Map // lock service id -> *commitCtl
 	version         uint64
 	mu              struct {
@@ -162,6 +162,12 @@ func (l *lockTableAllocator) Valid(
 
 	if len(invalid) > 0 {
 		return invalid, nil
+	}
+
+	if _, ok := l.inactiveService.Load(serviceID); ok {
+		l.logger.Info("inactive service",
+			zap.String("serviceID", serviceID))
+		return nil, moerr.NewCannotCommitOrphanNoCtx()
 	}
 
 	c := l.getCtl(serviceID)
@@ -527,43 +533,62 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-timer.C:
+			l.logger.Info("clean commit state")
+
 			var services []string
 			var invalidServices []string
 			activeTxnMap := make(map[string]map[string]struct{})
 
 			l.ctl.Range(func(key, value any) bool {
-				c := value.(*commitCtl)
-				ok, at := c.disconnected()
-				if !ok {
-					services = append(services, key.(string))
-				} else if time.Since(at) > removeDisconnectDuration {
-					c.states.Range(func(key, value any) bool {
-						if value.(ctlState) == cannotCommitState {
-							logCleanCannotCommitTxn(key.(string), int(value.(ctlState)))
-						}
-						return true
-					})
-					l.ctl.Delete(key)
+				services = append(services, key.(string))
+				return true
+			})
+
+			l.inactiveService.Range(func(key, value any) bool {
+				if time.Since(value.(time.Time)) > removeDisconnectDuration {
+					l.logger.Error("remove inactive service",
+						zap.String("serviceID", key.(string)))
+					l.inactiveService.Delete(key)
 				}
 				return true
 			})
 
+			retry := false
 			for _, sid := range services {
-				valid, actives, err := getActiveTxnFunc(sid)
-				if err == nil {
-					if !valid {
-						invalidServices = append(invalidServices, sid)
-					} else {
-						m := make(map[string]struct{}, len(actives))
-						for _, txn := range actives {
-							m[util.UnsafeBytesToString(txn)] = struct{}{}
+				for {
+					valid, actives, err := getActiveTxnFunc(sid)
+					if isRetryError(err) {
+						// retry err
+						l.logger.Error("retry to check service if alive",
+							zap.String("serviceID", sid),
+							zap.Error(err))
+						if !retry {
+							// retry
+							retry = true
+							continue
 						}
-						activeTxnMap[sid] = m
+						retry = false
+						l.inactiveService.Store(sid, time.Now())
+						l.ctl.Delete(sid)
+					} else if err == nil {
+						if !valid {
+							invalidServices = append(invalidServices, sid)
+						} else {
+							m := make(map[string]struct{}, len(actives))
+							for _, txn := range actives {
+								m[util.UnsafeBytesToString(txn)] = struct{}{}
+							}
+							activeTxnMap[sid] = m
+						}
+					} else {
+						// is not retry err
+						l.logger.Error("get active txn failed",
+							zap.String("serviceID", sid),
+							zap.Error(err))
+						l.inactiveService.Store(sid, struct{}{})
+						l.ctl.Delete(sid)
 					}
-				} else if !isRetryError(err) {
-					l.logger.Error("get cannot commit txn failed",
-						zap.String("serviceID", sid))
-					l.getCtl(sid).disconnect()
+					break
 				}
 			}
 
@@ -924,9 +949,6 @@ var (
 )
 
 type commitCtl struct {
-	// disconnectAt indicates whether the service is disconnected, never connect
-	// to the service again.
-	disconnectAt atomic.Pointer[time.Time]
 	// txn id -> state, 0: cannot commit, 1: committed
 	states sync.Map
 }
@@ -947,19 +969,6 @@ func (c *commitCtl) getCtlState(
 		return old.(ctlState), true
 	}
 	return ctlState(0), false
-}
-
-func (c *commitCtl) disconnect() {
-	at := time.Now()
-	c.disconnectAt.Store(&at)
-}
-
-func (c *commitCtl) disconnected() (bool, time.Time) {
-	v := c.disconnectAt.Load()
-	if v == nil {
-		return false, time.Time{}
-	}
-	return true, *v
 }
 
 func (l *lockTableAllocator) canGetBind(serviceID string) bool {

--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -553,15 +553,17 @@ func (l *lockTableAllocator) cleanCommitState(ctx context.Context) {
 				return true
 			})
 
+			retryCount := 1
+
 			for _, sid := range services {
-				for i := 0; i < 2; i++ {
+				for i := 0; i < retryCount+1; i++ {
 					valid, actives, err := getActiveTxnFunc(sid)
 					if isRetryError(err) {
 						// retry err
 						l.logger.Error("retry to check service if alive",
 							zap.String("serviceID", sid),
 							zap.Error(err))
-						if i < 1 {
+						if i < retryCount {
 							// retry
 							continue
 						}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4056

## What this PR does / why we need it:

fix using too much memory to store orphan txns


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed the `disconnectAt` mechanism and replaced it with an `inactiveService` map to better manage inactive services.
- Enhanced logging to provide more detailed information about service state changes and retry attempts.
- Improved the logic for cleaning up commit states and handling inactive services, reducing memory usage.
- Fixed potential issues with retry logic when checking if a service is alive.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lock_table_allocator.go</strong><dd><code>Optimize memory usage and enhance service state management</code></dd></summary>
<hr>

pkg/lockservice/lock_table_allocator.go

<li>Removed the use of <code>sync/atomic</code> for managing disconnection state.<br> <li> Introduced <code>inactiveService</code> map to track inactive services.<br> <li> Enhanced logging for service state changes and retries.<br> <li> Improved handling of inactive services and cleanup logic.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18834/files#diff-6be1ca324d0b56411e41ec19a99ea21442f80563429ee4964aedef60424413a1">+51/-42</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

