### PR TITLE
set default value of kek

### DIFF
--- a/etc/launch-dynamic-cn/cn.toml.base
+++ b/etc/launch-dynamic-cn/cn.toml.base
@@ -45,4 +45,3 @@ type = "distributed-tae"
 [cn.frontend]
 port = %d
 unix-socket = "/tmp/mysql%d.sock"
-key-encryption-key = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"

--- a/etc/launch-dynamic-with-proxy/cn.toml.base
+++ b/etc/launch-dynamic-with-proxy/cn.toml.base
@@ -46,4 +46,3 @@ type = "distributed-tae"
 port = %d
 unix-socket = "/tmp/mysql%d.sock"
 proxy-enabled = true
-key-encryption-key = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"

--- a/etc/launch-multi-cn/cn1.toml
+++ b/etc/launch-multi-cn/cn1.toml
@@ -42,4 +42,3 @@ type = "distributed-tae"
 
 [cn.frontend]
 port = 16001
-key-encryption-key = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"

--- a/etc/launch-multi-cn/cn2.toml
+++ b/etc/launch-multi-cn/cn2.toml
@@ -43,4 +43,3 @@ type = "distributed-tae"
 [cn.frontend]
 port = 16002
 unix-socket = "/tmp/mysql2.sock"
-key-encryption-key = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"

--- a/etc/launch-tae-compose/config/cn-0.toml
+++ b/etc/launch-tae-compose/config/cn-0.toml
@@ -54,4 +54,3 @@ type = "distributed-tae"
 
 [cn.frontend]
 port = 6001
-key-encryption-key = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"

--- a/etc/launch-tae-compose/config/cn-1.toml
+++ b/etc/launch-tae-compose/config/cn-1.toml
@@ -54,4 +54,4 @@ type = "distributed-tae"
 
 [cn.frontend]
 port = 6001
-key-encryption-key = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"
+

--- a/etc/launch-with-proxy/cn1.toml
+++ b/etc/launch-with-proxy/cn1.toml
@@ -43,4 +43,3 @@ type = "distributed-tae"
 [cn.frontend]
 port = 16001
 proxy-enabled = true
-key-encryption-key = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"

--- a/etc/launch-with-proxy/cn2.toml
+++ b/etc/launch-with-proxy/cn2.toml
@@ -44,4 +44,3 @@ type = "distributed-tae"
 port = 16002
 unix-socket = "/tmp/mysql2.sock"
 proxy-enabled = true
-key-encryption-key = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"

--- a/etc/launch-with-python-udf-server/cn.toml
+++ b/etc/launch-with-python-udf-server/cn.toml
@@ -10,6 +10,3 @@ port-base = 18000
 
 [cn.python-udf-client]
 server-address = "127.0.0.1:50051"
-
-[cn.frontend]
-key-encryption-key = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"

--- a/etc/launch/cn.toml
+++ b/etc/launch/cn.toml
@@ -12,5 +12,3 @@ port-base = 18000
 check-fraction = 65536
 enable-metrics = true
 
-[cn.frontend]
-key-encryption-key = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -407,6 +407,10 @@ func (fp *FrontendParameters) SetDefaultValues() {
 	if fp.CleanKillQueueInterval == 0 {
 		fp.CleanKillQueueInterval = defaultCleanKillQueueInterval
 	}
+
+	if len(fp.KeyEncryptionKey) == 0 {
+		fp.KeyEncryptionKey = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"
+	}
 }
 
 func (fp *FrontendParameters) SetMaxMessageSize(size uint64) {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18877

## What this PR does / why we need it:
set default value of kek


___

### **PR Type**
Enhancement


___

### **Description**
- Set a default value for `KeyEncryptionKey` in the `SetDefaultValues` function of `FrontendParameters` if it is not already set.
- Removed hardcoded `key-encryption-key` from various configuration files to ensure the default value is used.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.go</strong><dd><code>Set default value for KeyEncryptionKey in configuration</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/config/configuration.go

<li>Set a default value for <code>KeyEncryptionKey</code> if it is not already set.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-35ceccc6a9d5bda0966a79f612e9ca3e331cc2e2e53567745876538bd08445f8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>cn.toml.base</strong><dd><code>Remove hardcoded key-encryption-key from dynamic CN config</code></dd></summary>
<hr>

etc/launch-dynamic-cn/cn.toml.base

- Removed hardcoded `key-encryption-key` configuration.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-7de8fc83a6dd32ca1eceeb0de5b93af42081e8185ebba395e857361f5778eaa5">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cn.toml.base</strong><dd><code>Remove hardcoded key-encryption-key from dynamic CN with proxy config</code></dd></summary>
<hr>

etc/launch-dynamic-with-proxy/cn.toml.base

- Removed hardcoded `key-encryption-key` configuration.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-4985a27de315d712f011668acbb56f703e5993eae082da9a219c6808dcfff83c">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cn1.toml</strong><dd><code>Remove hardcoded key-encryption-key from multi CN config</code>&nbsp; </dd></summary>
<hr>

etc/launch-multi-cn/cn1.toml

- Removed hardcoded `key-encryption-key` configuration.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-814d6815b9abe36024f684bcb51c90817a2894d8fce9b8e0af5287394ad7f8ee">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cn2.toml</strong><dd><code>Remove hardcoded key-encryption-key from multi CN config</code>&nbsp; </dd></summary>
<hr>

etc/launch-multi-cn/cn2.toml

- Removed hardcoded `key-encryption-key` configuration.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-2d76ac273f8c8eb61694e2580f68f34b1ae16c52e6a72402cab0b38b0172fd65">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cn-0.toml</strong><dd><code>Remove hardcoded key-encryption-key from TAE compose config</code></dd></summary>
<hr>

etc/launch-tae-compose/config/cn-0.toml

- Removed hardcoded `key-encryption-key` configuration.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-bf733dbfbcf2ca89533057f7113e8dd87c0d1846b81972656c7dd294a53afa99">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cn-1.toml</strong><dd><code>Remove hardcoded key-encryption-key from TAE compose config</code></dd></summary>
<hr>

etc/launch-tae-compose/config/cn-1.toml

- Removed hardcoded `key-encryption-key` configuration.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-6e2f48f959f3767bc394f176f75de412d7b7ed938385b799d06416849c11255d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cn1.toml</strong><dd><code>Remove hardcoded key-encryption-key from CN with proxy config</code></dd></summary>
<hr>

etc/launch-with-proxy/cn1.toml

- Removed hardcoded `key-encryption-key` configuration.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-0091445ba9db2a66eaae2280d0c4cdb3a1b35b1372835345c10718e91bd206bb">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cn2.toml</strong><dd><code>Remove hardcoded key-encryption-key from CN with proxy config</code></dd></summary>
<hr>

etc/launch-with-proxy/cn2.toml

- Removed hardcoded `key-encryption-key` configuration.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-479100f28f80f08ee50f5ead02de3d65355b2bec02db4d9ce27fa7f44e728a9c">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cn.toml</strong><dd><code>Remove hardcoded key-encryption-key from Python UDF server config</code></dd></summary>
<hr>

etc/launch-with-python-udf-server/cn.toml

- Removed hardcoded `key-encryption-key` configuration.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-dc18e62f1b2df2f918ac0fd04a7b2a9472fb7d13a089a09985fdbd1bf2c81acd">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cn.toml</strong><dd><code>Remove hardcoded key-encryption-key from launch config</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

etc/launch/cn.toml

- Removed hardcoded `key-encryption-key` configuration.



</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18923/files#diff-d19a9d5ce28886197f25a7a772e39b836a8300b13adac462bc9db570bcea06a5">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information