### PR TITLE
[pick to 1.2] fix Agg bug will cause memory contamination.

### DIFF
--- a/pkg/sql/colexec/aggexec/aggResult.go
+++ b/pkg/sql/colexec/aggexec/aggResult.go
@@ -339,10 +339,12 @@ func (r *aggFuncBytesResult) grows(more int) error {
 }
 
 func (r *aggFuncBytesResult) aggGet() []byte {
-	// todo: we cannot do simple optimization to get bytes here because result was not read-only.
-	//  the set method may change the max length of the vector.
-	//  if we want, we should add a flag to indicate that the vector item's length is <= types.VarlenaInlineSize.
-	return r.res.GetBytesAt(r.groupToSet)
+	// never return the source pointer directly.
+	//
+	// if not, append action outside like `r = append(r, "more")` will cause memory contamination to other row.
+	newr := r.res.GetBytesAt(r.groupToSet)
+	newr = newr[:len(newr):len(newr)]
+	return newr
 }
 
 func (r *aggFuncBytesResult) aggSet(v []byte) error {

--- a/pkg/sql/colexec/aggexec/concat.go
+++ b/pkg/sql/colexec/aggexec/concat.go
@@ -46,7 +46,7 @@ func (exec *groupConcatExec) marshal() ([]byte, error) {
 	return encoded.Marshal()
 }
 
-func (exec *groupConcatExec) unmarshal(mp *mpool.MPool, result []byte, groups [][]byte) error {
+func (exec *groupConcatExec) unmarshal(_ *mpool.MPool, result []byte, groups [][]byte) error {
 	if err := exec.SetExtraInformation(groups[0], 0); err != nil {
 		return err
 	}
@@ -122,10 +122,7 @@ func (exec *groupConcatExec) Fill(groupIndex int, row int, vectors []*vector.Vec
 			return err
 		}
 	}
-	if err = exec.ret.aggSet(r); err != nil {
-		return err
-	}
-	return nil
+	return exec.ret.aggSet(r)
 }
 
 func (exec *groupConcatExec) BulkFill(groupIndex int, vectors []*vector.Vector) error {
@@ -150,7 +147,7 @@ func (exec *groupConcatExec) BatchFill(offset int, groups []uint64, vectors []*v
 	return nil
 }
 
-func (exec *groupConcatExec) SetExtraInformation(partialResult any, groupIndex int) error {
+func (exec *groupConcatExec) SetExtraInformation(partialResult any, _ int) error {
 	// todo: too bad here.
 	exec.separator = partialResult.([]byte)
 	return nil
@@ -162,20 +159,19 @@ func (exec *groupConcatExec) merge(other *groupConcatExec, idx1, idx2 int) error
 	if err := exec.distinctHash.merge(&other.distinctHash); err != nil {
 		return err
 	}
+	empty1, empty2 := exec.ret.groupIsEmpty(idx1), other.ret.groupIsEmpty(idx2)
 
-	v1 := exec.ret.aggGet()
-	v2 := other.ret.aggGet()
-	if len(v2) == 0 {
+	if empty2 {
 		return nil
 	}
-	if len(v1) > 0 && len(v2) > 0 {
-		v1 = append(v1, exec.separator...)
-		v1 = append(v1, v2...)
-		return exec.ret.aggSet(v1)
-	}
-	if len(v1) == 0 {
+	exec.ret.mergeEmpty(other.ret.basicResult, idx1, idx2)
+	v2 := other.ret.aggGet()
+	if empty1 {
 		return exec.ret.aggSet(v2)
 	}
+	v1 := exec.ret.aggGet()
+	v1 = append(v1, exec.separator...)
+	v1 = append(v1, v2...)
 	return exec.ret.aggSet(v1)
 }
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [X] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17518 
https://github.com/matrixorigin/MO-Cloud/issues/4092

## What this PR does / why we need it:
修复了一个agg的bytes结果进行append时会覆写到其他group结果的bug.
修复了group_concat进行merge时没有更新null值位图的错误。


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in `aggFuncBytesResult` where returning the source pointer directly could cause memory contamination.
- Enhanced the `groupConcatExec` to correctly handle empty groups during merging and simplified error handling.
- Removed unnecessary parameter usage in several methods to improve code clarity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aggResult.go</strong><dd><code>Fix memory contamination in aggFuncBytesResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/aggexec/aggResult.go

<li>Prevented memory contamination by not returning source pointer <br>directly.<br> <li> Modified the <code>aggGet</code> method to ensure safe byte slice handling.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18934/files#diff-ce9462fd60cb5524ea41a1cd928d0fa1223806c84e936afd767041fcdf39043b">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>concat.go</strong><dd><code>Improve groupConcatExec error handling and merging logic</code>&nbsp; </dd></summary>
<hr>

pkg/sql/colexec/aggexec/concat.go

<li>Simplified error handling in <code>Fill</code> method.<br> <li> Improved <code>merge</code> method to handle empty groups correctly.<br> <li> Removed unnecessary parameter usage in <code>unmarshal</code> and <br><code>SetExtraInformation</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/18934/files#diff-4db0b097c2469c1a33765c2e86a41304a2b6f594468b6616deab24e26f0afc59">+11/-15</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information