### PR TITLE
check msgOption is Valid before convert it to msg

### DIFF
--- a/pkg/taskservice/mysql_task_storage.go
+++ b/pkg/taskservice/mysql_task_storage.go
@@ -23,8 +23,6 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
-	"go.uber.org/zap"
-
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -306,7 +304,6 @@ func (m *mysqlTaskStorage) UpdateAsyncTask(ctx context.Context, tasks []task.Asy
 			return nil
 		}()
 		if err != nil {
-			logutil.Error("failed to update async task:", zap.Error(err))
 			if e := tx.Rollback(); e != nil {
 				return 0, errors.Join(e, err)
 			}
@@ -531,7 +528,6 @@ func (m *mysqlTaskStorage) UpdateCronTask(ctx context.Context, cronTask task.Cro
 		asyncTask.CreateAt,
 		asyncTask.CompletedAt)
 	if err != nil {
-		logutil.Error("failed to update cron task:", zap.Error(err))
 		return 0, err
 	}
 
@@ -548,7 +544,6 @@ func (m *mysqlTaskStorage) UpdateCronTask(ctx context.Context, cronTask task.Cro
 		cronTask.UpdateAt,
 		cronTask.ID)
 	if err != nil {
-		logutil.Error("failed to update cron task:", zap.Error(err))
 		return 0, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -758,7 +753,6 @@ func (m *mysqlTaskStorage) UpdateDaemonTask(ctx context.Context, tasks []task.Da
 
 	n, err := m.RunUpdateDaemonTask(ctx, tasks, tx, condition...)
 	if err != nil {
-		logutil.Error("failed to update daemon task:", zap.Error(err))
 		if e := tx.Rollback(); e != nil {
 			return 0, errors.Join(e, err)
 		}
@@ -1001,7 +995,6 @@ func (m *mysqlTaskStorage) HeartbeatDaemonTask(ctx context.Context, tasks []task
 			return nil
 		}()
 		if err != nil {
-			logutil.Error("failed to heartbeat daemon task:", zap.Error(err))
 			if e := tx.Rollback(); e != nil {
 				return 0, errors.Join(e, err)
 			}

--- a/pkg/taskservice/mysql_task_storage_test.go
+++ b/pkg/taskservice/mysql_task_storage_test.go
@@ -124,10 +124,29 @@ var (
 		"last_run",
 		"details",
 	}
+
+	daemonRows = []string{
+		"task_id",
+		"task_metadata_id",
+		"task_metadata_executor",
+		"task_metadata_context",
+		"task_metadata_option",
+		"account_id",
+		"account",
+		"task_type",
+		"task_runner",
+		"task_status",
+		"last_heartbeat",
+		"create_at",
+		"update_at",
+		"end_at",
+		"last_run",
+		"details",
+	}
 )
 
 func TestAsyncTaskInSqlMock(t *testing.T) {
-	storage, mock := newMockStorage(t, "sqlmock")
+	storage, mock := newMockStorage(t)
 	mock.ExpectExec(insertAsyncTask+"(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").
 		WithArgs("a", 0, []byte(nil), "{}", "", 0, "", 0, 0, sqlmock.AnyArg(), 0).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -145,7 +164,6 @@ func TestAsyncTaskInSqlMock(t *testing.T) {
 	assert.Equal(t, "a", asyncTask[0].Metadata.ID)
 
 	mock.ExpectBegin()
-	mock.ExpectPrepare(updateAsyncTask + " AND task_epoch=0")
 	mock.ExpectExec(updateAsyncTask+" AND task_epoch=0").
 		WithArgs(0, []byte(nil), "{}", "", 0, "c1", 0, 0, 0, "", 0, 0, 1).
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -160,7 +178,7 @@ func TestAsyncTaskInSqlMock(t *testing.T) {
 }
 
 func TestCronTaskInSqlMock(t *testing.T) {
-	storage, mock := newMockStorage(t, "sqlmock")
+	storage, mock := newMockStorage(t)
 	mock.ExpectExec(insertCronTask+"(?, ?, ?, ?, ?, ?, ?, ?, ?)").
 		WithArgs("a", 0, []byte(nil), "{}", "mock_cron_expr", sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -181,8 +199,8 @@ func TestCronTaskInSqlMock(t *testing.T) {
 	require.NoError(t, storage.Close())
 }
 
-func newMockStorage(t *testing.T, dsn string) (*mysqlTaskStorage, sqlmock.Sqlmock) {
-	db, mock, err := sqlmock.NewWithDSN(dsn, sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+func newMockStorage(t *testing.T) (*mysqlTaskStorage, sqlmock.Sqlmock) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	require.NoError(t, err)
 	return &mysqlTaskStorage{
 		db: db,
@@ -262,7 +280,7 @@ func newInsertDaemonTaskExpect(t *testing.T, mock sqlmock.Sqlmock) {
 }
 
 func TestAddCdcTask(t *testing.T) {
-	storage, mock := newMockStorage(t, "sqlmock")
+	storage, mock := newMockStorage(t)
 
 	dt := newCdcInfo(t)
 
@@ -287,7 +305,6 @@ func TestAddCdcTask(t *testing.T) {
 		newDaemonTaskRows(t, dt),
 	)
 
-	mock.ExpectPrepare(updateDaemonTask)
 	mock.ExpectExec(updateDaemonTask).WithArgs(
 		sqlmock.AnyArg(),
 		sqlmock.AnyArg(),
@@ -338,7 +355,7 @@ func TestAddCdcTask(t *testing.T) {
 }
 
 func Test_AddDaemonTask(t *testing.T) {
-	storage, mock := newMockStorage(t, "sqlmock")
+	storage, mock := newMockStorage(t)
 
 	details := &task.Details{
 		AccountID: catalog.System_Account,
@@ -385,7 +402,6 @@ func Test_AddDaemonTask(t *testing.T) {
 	assert.Greater(t, cnt, 0)
 
 	mock.ExpectBegin()
-	mock.ExpectPrepare(updateDaemonTask)
 	mock.ExpectExec(updateDaemonTask).WithArgs(
 		sqlmock.AnyArg(),
 		sqlmock.AnyArg(),
@@ -417,7 +433,7 @@ func Test_AddDaemonTask(t *testing.T) {
 }
 
 func Test_labels(t *testing.T) {
-	storage, mock := newMockStorage(t, "sqlmock")
+	storage, mock := newMockStorage(t)
 
 	dt := newCdcInfo(t)
 
@@ -445,4 +461,86 @@ func Test_labels(t *testing.T) {
 
 	_ = mock.ExpectClose()
 	_ = storage.Close()
+}
+
+func TestUpdateAsyncTaskInSqlMock(t *testing.T) {
+	storage, mock := newMockStorage(t)
+	mock.ExpectExec(insertAsyncTask+"(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").
+		WithArgs("a", 0, []byte(nil), "{}", "", 0, "", 0, 0, sqlmock.AnyArg(), 0).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	affected, err := storage.AddAsyncTask(context.Background(), newTaskFromMetadata(task.TaskMetadata{ID: "a"}))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, affected)
+
+	mock.ExpectQuery(selectAsyncTask + " AND task_id=1 order by task_id").
+		WillReturnRows(sqlmock.NewRows(asyncRows).
+			AddRow(1, "a", 0, []byte(nil), "{}", "", 0, "", 0, 0, 0, "", 0, 0))
+	asyncTask, err := storage.QueryAsyncTask(context.Background(), WithTaskIDCond(EQ, 1))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(asyncTask))
+	assert.Equal(t, "a", asyncTask[0].Metadata.ID)
+
+	mock.ExpectBegin()
+	updateSql := "update sys_async_task set error_msg=NULL where task_id=1"
+	mock.ExpectExec(updateSql).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	asyncTask[0].TaskRunner = "c1"
+	tx, err := storage.db.Begin()
+	assert.NoError(t, err)
+	_, err = tx.ExecContext(context.Background(), updateSql)
+	assert.NoError(t, err)
+	assert.NoError(t, tx.Commit())
+
+	mock.ExpectQuery(selectAsyncTask + " AND task_id=1 order by task_id").
+		WillReturnRows(sqlmock.NewRows(asyncRows).
+			AddRow(1, "a", 0, []byte(nil), "{}", "", 0, "", 0, 0, 0, nil, 0, 0))
+	_, err = storage.QueryAsyncTask(context.Background(), WithTaskIDCond(EQ, 1))
+	assert.NoError(t, err)
+
+	mock.ExpectClose()
+	require.NoError(t, storage.Close())
+}
+
+func TestDaemonTaskInSqlMock(t *testing.T) {
+	storage, mock := newMockStorage(t)
+	mock.ExpectExec(insertDaemonTask+"(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)").
+		WithArgs("-", 4, []byte(nil), "{}", 0, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	affected, err := storage.AddDaemonTask(context.Background(), newDaemonTaskForTest(1, task.TaskStatus_Created, ""))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, affected)
+
+	mock.ExpectQuery(selectDaemonTask + " AND task_id=1 order by task_id").
+		WillReturnRows(sqlmock.NewRows(daemonRows).
+			AddRow(1, "a", 0, []byte(nil), "{}", 0, 0, "", 0, 0, time.Time{}, time.Time{}, time.Time{}, time.Time{}, time.Time{}, 0))
+
+	daemonTask, err := storage.QueryDaemonTask(context.Background(), WithTaskIDCond(EQ, 1))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(daemonTask))
+	assert.Equal(t, "a", daemonTask[0].Metadata.ID)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(updateDaemonTask).
+		WithArgs(0, []byte(nil), "{}", "Unknown", 0, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+	update, err := storage.UpdateDaemonTask(context.Background(), []task.DaemonTask{{
+		ID: 0, Metadata: task.TaskMetadata{ID: "test"}, Details: &task.Details{},
+	}})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, update)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(heartbeatDaemonTask).WithArgs(time.Time{}, 0).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	heartbeat, err := storage.HeartbeatDaemonTask(context.Background(), []task.DaemonTask{{
+		ID: 0, Metadata: task.TaskMetadata{ID: "test"},
+	}})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, heartbeat)
+
+	mock.ExpectClose()
 }

--- a/pkg/taskservice/task_service_holder_test.go
+++ b/pkg/taskservice/task_service_holder_test.go
@@ -138,7 +138,7 @@ func TestRefreshTaskStorageCanClose(t *testing.T) {
 }
 
 func Test_refreshAddCdcTask(t *testing.T) {
-	storage, mock := newMockStorage(t, "sqlmock")
+	storage, mock := newMockStorage(t)
 
 	stores := map[string]TaskStorage{
 		"s1": storage,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18472

## What this PR does / why we need it:

check error_msg is valid before converting it to string.