### PR TITLE
Fix bug: prepare for on duplicate key can not get Parameter (#18995)

### DIFF
--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -1060,12 +1060,61 @@ func TestVisitRule(t *testing.T) {
 		makePlan2Int64ConstExprWithType(10),
 	}
 	resetParamRule := NewResetParamRefRule(ctx, params)
-	resetVarRule := NewResetVarRefRule(&mock.ctxt, testutil.NewProc())
-	constantFoldRule := NewConstantFoldRule(&mock.ctxt)
-	vp = NewVisitPlan(plan, []VisitPlanRule{resetParamRule, resetVarRule, constantFoldRule})
+	vp = NewVisitPlan(plan, []VisitPlanRule{resetParamRule})
 	err = vp.Visit(ctx)
 	if err != nil {
 		t.Fatalf("should not error, sql=%s", sql)
+	}
+}
+
+func TestVisitRule2(t *testing.T) {
+	sql := "select * from nation where n_nationkey > 10"
+	mock := NewMockOptimizer(false)
+	ctx := context.TODO()
+	queryPlan, err := runOneStmt(mock, t, sql)
+	if err != nil {
+		t.Fatalf("should not error, sql=%s", sql)
+	}
+	getParamRule := NewGetParamRule()
+	vp := NewVisitPlan(queryPlan, []VisitPlanRule{getParamRule})
+	err = vp.Visit(context.TODO())
+	if err != nil {
+		t.Fatalf("should not error, sql=%s", sql)
+	}
+	getParamRule.SetParamOrder()
+	args := getParamRule.params
+
+	resetParamOrderRule := NewResetParamOrderRule(args)
+	vp = NewVisitPlan(queryPlan, []VisitPlanRule{resetParamOrderRule})
+	err = vp.Visit(ctx)
+	if err != nil {
+		t.Fatalf("should not error, sql=%s", sql)
+	}
+
+	if qry, ok := queryPlan.Plan.(*Plan_Query); ok {
+		if f, ok := qry.Query.Nodes[1].FilterList[0].Expr.(*plan.Expr_F); ok {
+			f.F.Args[1] = &plan.Expr{
+				Typ: plan.Type{
+					Id:          int32(types.T_int64),
+					NotNullable: true,
+				},
+				Expr: &plan.Expr_P{
+					P: &plan.ParamRef{
+						Pos: 1,
+					},
+				},
+			}
+		}
+
+	}
+	params := []*Expr{
+		makePlan2Int64ConstExprWithType(10),
+	}
+	resetParamRule := NewResetParamRefRule(ctx, params)
+	vp = NewVisitPlan(queryPlan, []VisitPlanRule{resetParamRule})
+	err = vp.Visit(ctx)
+	if err == nil {
+		t.Fatalf("param 1 not exist, should error")
 	}
 }
 

--- a/pkg/sql/plan/visit_plan.go
+++ b/pkg/sql/plan/visit_plan.go
@@ -66,7 +66,7 @@ func (vq *VisitPlan) visitNode(ctx context.Context, qry *Query, node *Node, idx 
 	return nil
 }
 
-func (vq *VisitPlan) exploreNode(ctx context.Context, rule VisitPlanRule, node *Node, idx int32) error {
+func (vq *VisitPlan) exploreNode(ctx context.Context, rule VisitPlanRule, node *Node, _ int32) error {
 	var err error
 	if node.Limit != nil {
 		node.Limit, err = rule.ApplyExpr(node.Limit)
@@ -110,7 +110,15 @@ func (vq *VisitPlan) exploreNode(ctx context.Context, rule VisitPlanRule, node *
 		}
 	}
 
-	if node.OnUpdateExprs != nil {
+	if node.OnDuplicateKey != nil {
+		for key := range node.OnDuplicateKey.OnDuplicateExpr {
+			oldExpr := node.OnDuplicateKey.OnDuplicateExpr[key]
+			node.OnDuplicateKey.OnDuplicateExpr[key], err = rule.ApplyExpr(oldExpr)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
 		for i := range node.OnUpdateExprs {
 			node.OnUpdateExprs[i], err = rule.ApplyExpr(node.OnUpdateExprs[i])
 			if err != nil {

--- a/pkg/sql/plan/visit_plan_rule.go
+++ b/pkg/sql/plan/visit_plan_rule.go
@@ -17,27 +17,15 @@ package plan
 import (
 	"context"
 	"sort"
-	"strconv"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"github.com/matrixorigin/matrixone/pkg/container/batch"
-	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
-	"github.com/matrixorigin/matrixone/pkg/sql/plan/rule"
-	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
 var (
 	_ VisitPlanRule = &GetParamRule{}
 	_ VisitPlanRule = &ResetParamOrderRule{}
 	_ VisitPlanRule = &ResetParamRefRule{}
-	_ VisitPlanRule = &ResetVarRefRule{}
-	_ VisitPlanRule = &ConstantFoldRule{}
-)
-
-var (
-	constantFoldRule = rule.NewConstantFold(false)
 )
 
 type GetParamRule struct {
@@ -212,6 +200,9 @@ func (rule *ResetParamRefRule) ApplyExpr(e *plan.Expr) (*plan.Expr, error) {
 		}
 		return e, nil
 	case *plan.Expr_P:
+		if int(exprImpl.P.Pos) >= len(rule.params) {
+			return nil, moerr.NewInternalErrorf(context.TODO(), "get prepare params error, index %d not exists", int(exprImpl.P.Pos))
+		}
 		return &plan.Expr{
 			Typ:  e.Typ,
 			Expr: rule.params[int(exprImpl.P.Pos)].Expr,
@@ -221,252 +212,6 @@ func (rule *ResetParamRefRule) ApplyExpr(e *plan.Expr) (*plan.Expr, error) {
 			exprImpl.List.List[i], err = rule.ApplyExpr(arg)
 			if err != nil {
 				return nil, err
-			}
-		}
-		return e, nil
-	default:
-		return e, nil
-	}
-}
-
-// ---------------------------
-
-type ResetVarRefRule struct {
-	compCtx CompilerContext
-	proc    *process.Process
-	bat     *batch.Batch
-}
-
-func NewResetVarRefRule(compCtx CompilerContext, proc *process.Process) *ResetVarRefRule {
-	bat := batch.NewWithSize(0)
-	bat.SetRowCount(1)
-	return &ResetVarRefRule{
-		compCtx: compCtx,
-		proc:    proc,
-		bat:     bat,
-	}
-}
-
-func (rule *ResetVarRefRule) MatchNode(_ *Node) bool {
-	return false
-}
-
-func (rule *ResetVarRefRule) IsApplyExpr() bool {
-	return true
-}
-
-func (rule *ResetVarRefRule) ApplyNode(node *Node) error {
-	return nil
-}
-
-func (rule *ResetVarRefRule) ApplyExpr(e *plan.Expr) (*plan.Expr, error) {
-	var err error
-	switch exprImpl := e.Expr.(type) {
-	case *plan.Expr_F:
-		needResetFunction := false
-		for i, arg := range exprImpl.F.Args {
-			if _, ok := arg.Expr.(*plan.Expr_V); ok {
-				needResetFunction = true
-			}
-			exprImpl.F.Args[i], err = rule.ApplyExpr(arg)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		// reset function
-		if needResetFunction {
-			return BindFuncExprImplByPlanExpr(rule.getContext(), exprImpl.F.Func.GetObjName(), exprImpl.F.Args)
-		}
-		return e, nil
-	case *plan.Expr_V:
-		return GetVarValue(rule.getContext(), rule.compCtx, rule.proc, rule.bat, e)
-	case *plan.Expr_Lit:
-		if exprImpl.Lit.Src != nil {
-			if _, ok := exprImpl.Lit.Src.Expr.(*plan.Expr_V); ok {
-				return GetVarValue(rule.getContext(), rule.compCtx, rule.proc, rule.bat, exprImpl.Lit.Src)
-			}
-		}
-		return e, nil
-	default:
-		return e, nil
-	}
-}
-
-func (rule *ResetVarRefRule) getContext() context.Context { return rule.compCtx.GetContext() }
-
-func GetVarValue(
-	ctx context.Context,
-	compCtx CompilerContext,
-	proc *process.Process,
-	emptyBat *batch.Batch,
-	e *Expr,
-) (*plan.Expr, error) {
-	exprImpl := e.Expr.(*plan.Expr_V)
-	var expr *plan.Expr
-	getVal, err := compCtx.ResolveVariable(exprImpl.V.Name, exprImpl.V.System, exprImpl.V.Global)
-	if err != nil {
-		return nil, err
-	}
-
-	switch val := getVal.(type) {
-	case string:
-		expr = makePlan2StringConstExprWithType(val)
-	case int:
-		expr = makePlan2Int64ConstExprWithType(int64(val))
-	case uint8:
-		expr = makePlan2Int64ConstExprWithType(int64(val))
-	case uint16:
-		expr = makePlan2Int64ConstExprWithType(int64(val))
-	case uint32:
-		expr = makePlan2Int64ConstExprWithType(int64(val))
-	case int8:
-		expr = makePlan2Int64ConstExprWithType(int64(val))
-	case int16:
-		expr = makePlan2Int64ConstExprWithType(int64(val))
-	case int32:
-		expr = makePlan2Int64ConstExprWithType(int64(val))
-	case int64:
-		expr = makePlan2Int64ConstExprWithType(val)
-	case uint64:
-		expr = makePlan2Uint64ConstExprWithType(val)
-	case float32:
-		// when we build plan with constant in float, we cast them to decimal.
-		// so we cast @float_var to decimal too.
-		strVal := strconv.FormatFloat(float64(val), 'f', -1, 64)
-		expr, err = makePlan2DecimalExprWithType(ctx, strVal)
-	case float64:
-		// when we build plan with constant in float, we cast them to decimal.
-		// so we cast @float_var to decimal too.
-		strVal := strconv.FormatFloat(val, 'f', -1, 64)
-		expr, err = makePlan2DecimalExprWithType(ctx, strVal)
-	case bool:
-		expr = makePlan2BoolConstExprWithType(val)
-	case nil:
-		if e.Typ.Id == int32(types.T_any) {
-			expr = makePlan2NullConstExprWithType()
-		} else {
-			expr = &plan.Expr{
-				Expr: &plan.Expr_Lit{
-					Lit: &Const{
-						Isnull: true,
-					},
-				},
-				Typ: e.Typ,
-			}
-		}
-	case *Expr:
-		expr = DeepCopyExpr(val)
-	case types.Decimal64, types.Decimal128:
-		err = moerr.NewNYI(ctx, "decimal var")
-	default:
-		err = moerr.NewParseErrorf(ctx, "type of var %q is not supported now", exprImpl.V.Name)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if e.Typ.Id != int32(types.T_any) && expr.Typ.Id != e.Typ.Id {
-		expr, err = appendCastBeforeExpr(ctx, expr, e.Typ)
-	}
-	if err != nil {
-		return nil, err
-	}
-	if c, ok := expr.Expr.(*plan.Expr_Lit); ok {
-		c.Lit.Src = e
-	} else if _, ok = expr.Expr.(*plan.Expr_F); ok {
-		vec, err1 := colexec.EvalExpressionOnce(proc, expr, []*batch.Batch{emptyBat})
-		if err1 != nil {
-			return nil, err1
-		}
-		constValue := rule.GetConstantValue(vec, true, 0)
-		constValue.Src = e
-		expr.Typ = plan.Type{Id: int32(vec.GetType().Oid), Scale: vec.GetType().Scale, Width: vec.GetType().Width}
-		expr.Expr = &plan.Expr_Lit{
-			Lit: constValue,
-		}
-		vec.Free(proc.Mp())
-	}
-	return expr, err
-}
-
-type ConstantFoldRule struct {
-	compCtx CompilerContext
-	rule    *rule.ConstantFold
-}
-
-func NewConstantFoldRule(compCtx CompilerContext) *ConstantFoldRule {
-	return &ConstantFoldRule{
-		compCtx: compCtx,
-		rule:    constantFoldRule,
-	}
-}
-
-func (r *ConstantFoldRule) MatchNode(node *Node) bool {
-	return r.rule.Match(node)
-}
-
-func (r *ConstantFoldRule) IsApplyExpr() bool {
-	return false
-}
-
-func (r *ConstantFoldRule) ApplyNode(node *Node) error {
-	r.rule.Apply(node, nil, r.compCtx.GetProcess())
-	return nil
-}
-
-func (r *ConstantFoldRule) ApplyExpr(e *plan.Expr) (*plan.Expr, error) {
-	return e, nil
-}
-
-type RecomputeRealTimeRelatedFuncRule struct {
-	bat  *batch.Batch
-	proc *process.Process
-}
-
-func NewRecomputeRealTimeRelatedFuncRule(proc *process.Process) *RecomputeRealTimeRelatedFuncRule {
-	bat := batch.NewWithSize(0)
-	bat.SetRowCount(1)
-	return &RecomputeRealTimeRelatedFuncRule{bat, proc}
-}
-
-func (r *RecomputeRealTimeRelatedFuncRule) MatchNode(_ *Node) bool {
-	return false
-}
-
-func (r *RecomputeRealTimeRelatedFuncRule) IsApplyExpr() bool {
-	return true
-}
-
-func (r *RecomputeRealTimeRelatedFuncRule) ApplyNode(_ *Node) error {
-	return nil
-}
-
-func (r *RecomputeRealTimeRelatedFuncRule) ApplyExpr(e *plan.Expr) (*plan.Expr, error) {
-	var err error
-	switch exprImpl := e.Expr.(type) {
-	case *plan.Expr_F:
-		for i, arg := range exprImpl.F.Args {
-			exprImpl.F.Args[i], err = r.ApplyExpr(arg)
-			if err != nil {
-				return nil, err
-			}
-		}
-		return e, nil
-	case *plan.Expr_Lit:
-		if exprImpl.Lit.Src != nil {
-			if _, ok := exprImpl.Lit.Src.Expr.(*plan.Expr_F); ok {
-				executor, err := colexec.NewExpressionExecutor(r.proc, exprImpl.Lit.Src)
-				if err != nil {
-					return nil, err
-				}
-				defer executor.Free()
-				vec, err := executor.Eval(r.proc, []*batch.Batch{r.bat})
-				if err != nil {
-					return nil, err
-				}
-				constValue := rule.GetConstantValue(vec, false, 0)
-				constValue.Src = exprImpl.Lit.Src
-				exprImpl.Lit = constValue
 			}
 		}
 		return e, nil

--- a/test/distributed/cases/pessimistic_transaction/prepare.result
+++ b/test/distributed/cases/pessimistic_transaction/prepare.result
@@ -61,3 +61,12 @@ select * from t1;
 a    b
 1    2
 commit;
+delete from t1;
+insert into t1 values (1,1);
+prepare s1 from insert into t1 values (?,1) on duplicate key update b = ?;
+set @a=1;
+set @b=10;
+execute s1 using @a, @b;
+select * from t1;
+a    b
+1    10

--- a/test/distributed/cases/pessimistic_transaction/prepare.sql
+++ b/test/distributed/cases/pessimistic_transaction/prepare.sql
@@ -64,3 +64,11 @@ execute s1 using @a;
 select * from t1;
 -- @session}
 commit;
+
+delete from t1;
+insert into t1 values (1,1);
+prepare s1 from insert into t1 values (?,1) on duplicate key update b = ?;
+set @a=1;
+set @b=10;
+execute s1 using @a, @b;
+select * from t1;


### PR DESCRIPTION
Fix bug: prepare for on duplicate key can not get Parameter

Approved by: @heni02, @badboynt1

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18957

## What this PR does / why we need it:
Fix bug: prepare for on duplicate key can not get Parameter