### PR TITLE
hack column data unmarshal from cache to avoid heap allocation

### DIFF
--- a/pkg/container/batch/batch.go
+++ b/pkg/container/batch/batch.go
@@ -71,11 +71,44 @@ func NewWithSchema(ro bool, offHeap bool, attrs []string, attTypes []types.Type)
 	return bat
 }
 
+func EmptyBatchWithSize(n int) Batch {
+	bat := Batch{
+		Vecs: make([]*vector.Vector, n),
+	}
+	for i := range bat.Vecs {
+		bat.Vecs[i] = vector.NewVec(types.T_any.ToType())
+	}
+	return bat
+}
+
+func EmptyBatchWithAttrs(attrs []string) Batch {
+	bat := Batch{
+		Attrs: attrs,
+		Vecs:  make([]*vector.Vector, len(attrs)),
+	}
+	for i := range attrs {
+		bat.Vecs[i] = vector.NewVec(types.T_any.ToType())
+	}
+
+	return bat
+}
+
 func SetLength(bat *Batch, n int) {
 	for _, vec := range bat.Vecs {
 		vec.SetLength(n)
 	}
 	bat.rowCount = n
+}
+
+func (bat *Batch) Slice(from, to int) *Batch {
+	return &Batch{
+		Ro:       bat.Ro,
+		Attrs:    bat.Attrs[from:to],
+		Vecs:     bat.Vecs[from:to],
+		rowCount: bat.rowCount,
+		Cnt:      1,
+	}
+
 }
 
 func (bat *Batch) MarshalBinary() ([]byte, error) {
@@ -344,6 +377,15 @@ func (bat *Batch) CleanOnlyData() {
 		}
 	}
 	bat.rowCount = 0
+}
+
+func (bat *Batch) FreeColumns(m *mpool.MPool) {
+	for _, vec := range bat.Vecs {
+		if vec != nil {
+			vec.Free(m)
+		}
+	}
+	return
 }
 
 func (bat *Batch) String() string {

--- a/pkg/container/batch/batch.go
+++ b/pkg/container/batch/batch.go
@@ -385,7 +385,6 @@ func (bat *Batch) FreeColumns(m *mpool.MPool) {
 			vec.Free(m)
 		}
 	}
-	return
 }
 
 func (bat *Batch) String() string {

--- a/pkg/objectio/const.go
+++ b/pkg/objectio/const.go
@@ -77,6 +77,13 @@ var (
 
 const ZoneMapSize = index.ZMSize
 
+func GetTombstoneAttrs(withHidden bool) []string {
+	if withHidden {
+		return TombstoneAttrs_TN_Created
+	}
+	return TombstoneAttrs_CN_Created
+}
+
 func GetTombstoneCommitTSAttrIdx(columnCnt uint16) uint16 {
 	if columnCnt == 3 {
 		return TombstoneAttr_NA_CommitTs_Idx

--- a/pkg/objectio/constructors.go
+++ b/pkg/objectio/constructors.go
@@ -70,9 +70,9 @@ func Decode(buf []byte) (any, error) {
 }
 
 // NOTE: hack way to get vector
-func MustVector(vec *vector.Vector, buf []byte) (err error) {
+func MustVectorTo(toVec *vector.Vector, buf []byte) (err error) {
 	// check if vector is empty
-	if vec.Allocated() > 0 {
+	if toVec.Allocated() > 0 {
 		logutil.Fatal("vector is not empty")
 	}
 	header := DecodeIOEntryHeader(buf)
@@ -80,10 +80,10 @@ func MustVector(vec *vector.Vector, buf []byte) (err error) {
 		panic(fmt.Sprintf("invalid object meta: %s", header.String()))
 	}
 	if header.Version != IOET_ColumnData_V2 {
-		err = vec.UnmarshalBinary(buf[IOEntryHeaderSize:])
+		err = toVec.UnmarshalBinary(buf[IOEntryHeaderSize:])
 		return
 	} else if header.Version != IOET_ColumnData_V1 {
-		err = vec.UnmarshalBinaryV1(buf[IOEntryHeaderSize:])
+		err = toVec.UnmarshalBinaryV1(buf[IOEntryHeaderSize:])
 		return
 	}
 	panic(fmt.Sprintf("invalid column data: %s", header.String()))

--- a/pkg/objectio/constructors.go
+++ b/pkg/objectio/constructors.go
@@ -79,10 +79,10 @@ func MustVectorTo(toVec *vector.Vector, buf []byte) (err error) {
 	if header.Type != IOET_ColData {
 		panic(fmt.Sprintf("invalid object meta: %s", header.String()))
 	}
-	if header.Version != IOET_ColumnData_V2 {
+	if header.Version == IOET_ColumnData_V2 {
 		err = toVec.UnmarshalBinary(buf[IOEntryHeaderSize:])
 		return
-	} else if header.Version != IOET_ColumnData_V1 {
+	} else if header.Version == IOET_ColumnData_V1 {
 		err = toVec.UnmarshalBinaryV1(buf[IOEntryHeaderSize:])
 		return
 	}

--- a/pkg/objectio/versions.go
+++ b/pkg/objectio/versions.go
@@ -53,6 +53,8 @@ func init() {
 	RegisterIOEnrtyCodec(IOEntryHeader{IOET_ObjMeta, IOET_ObjectMeta_V1}, nil, DecodeObjectMetaV1)
 	RegisterIOEnrtyCodec(IOEntryHeader{IOET_ObjMeta, IOET_ObjectMeta_V2}, nil, DecodeObjectMetaV2)
 	RegisterIOEnrtyCodec(IOEntryHeader{IOET_ObjMeta, IOET_ObjectMeta_V3}, nil, DecodeObjectMetaV3)
+	// NOTE:
+	// Break by MustVector. Need to update MustVector to support new version.
 	RegisterIOEnrtyCodec(IOEntryHeader{IOET_ColData, IOET_ColumnData_V1}, EncodeColumnDataV1, DecodeColumnDataV1)
 	RegisterIOEnrtyCodec(IOEntryHeader{IOET_ColData, IOET_ColumnData_V2}, EncodeColumnDataV1, DecodeColumnDataV2)
 	RegisterIOEnrtyCodec(IOEntryHeader{IOET_BF, IOET_BloomFilter_V1}, nil, nil)
@@ -64,6 +66,8 @@ func EncodeColumnDataV1(ioe any) (buf []byte, err error) {
 	return ioe.(*vector.Vector).MarshalBinary()
 }
 
+// NOTE:
+// Break by MustVector. Need to update MustVector to support new version.
 func DecodeColumnDataV1(buf []byte) (ioe any, err error) {
 	vec := vector.NewVec(types.Type{})
 	if err = vec.UnmarshalBinaryV1(buf); err != nil {
@@ -72,6 +76,8 @@ func DecodeColumnDataV1(buf []byte) (ioe any, err error) {
 	return vec, err
 }
 
+// NOTE:
+// Break by MustVector. Need to update MustVector to support new version.
 func DecodeColumnDataV2(buf []byte) (ioe any, err error) {
 	vec := vector.NewVec(types.Type{})
 	if err = vec.UnmarshalBinary(buf); err != nil {

--- a/pkg/vm/engine/disttae/datasource.go
+++ b/pkg/vm/engine/disttae/datasource.go
@@ -1206,7 +1206,6 @@ func (ls *LocalDataSource) batchApplyTombstoneObjects(
 	var (
 		location objectio.Location
 
-		loaded  *batch.Batch
 		release func()
 	)
 
@@ -1218,6 +1217,9 @@ func (ls *LocalDataSource) batchApplyTombstoneObjects(
 		}
 		return false
 	}
+
+	attrs := objectio.GetTombstoneAttrs(true)
+	emptyBatch := batch.EmptyBatchWithAttrs(attrs)
 
 	for iter.Next() && len(deleted) < len(rowIds) {
 		obj := iter.Entry()
@@ -1241,16 +1243,18 @@ func (ls *LocalDataSource) batchApplyTombstoneObjects(
 		for idx := 0; idx < int(obj.BlkCnt()) && len(rowIds) > len(deleted); idx++ {
 			location = obj.ObjectStats.BlockLocation(uint16(idx), objectio.BlockMaxRows)
 
-			if loaded, _, release, err = blockio.ReadDeletes(ls.ctx, location, ls.fs, obj.GetCNCreated()); err != nil {
+			if _, release, err = blockio.ReadDeletes(
+				ls.ctx, location, ls.fs, obj.GetCNCreated(), &emptyBatch,
+			); err != nil {
 				return nil, err
 			}
 
 			var deletedRowIds []objectio.Rowid
 			var commit []types.TS
 
-			deletedRowIds = vector.MustFixedColWithTypeCheck[objectio.Rowid](loaded.Vecs[0])
+			deletedRowIds = vector.MustFixedColWithTypeCheck[objectio.Rowid](emptyBatch.Vecs[0])
 			if !obj.GetCNCreated() {
-				commit = vector.MustFixedColWithTypeCheck[types.TS](loaded.Vecs[1])
+				commit = vector.MustFixedColWithTypeCheck[types.TS](emptyBatch.Vecs[1])
 			}
 
 			for i := 0; i < len(rowIds); i++ {

--- a/pkg/vm/engine/disttae/reader.go
+++ b/pkg/vm/engine/disttae/reader.go
@@ -318,6 +318,12 @@ func NewReader(
 func (r *reader) Close() error {
 	r.source.Close()
 	r.withFilterMixin.reset()
+	if r.cacheBatch != nil {
+		if r.cacheBatch.Allocated() > 0 {
+			logutil.Fatal("cache batch is not empty")
+		}
+		r.cacheBatch = nil
+	}
 	return nil
 }
 
@@ -389,6 +395,11 @@ func (r *reader) Read(
 		policy = fileservice.SkipMemoryCacheWrites
 	}
 
+	if r.cacheBatch == nil {
+		cacheBatch := batch.EmptyBatchWithSize(len(r.columns.seqnums) + 1)
+		r.cacheBatch = &cacheBatch
+	}
+
 	err = blockio.BlockDataRead(
 		statsCtx,
 		r.isTombstone,
@@ -403,6 +414,7 @@ func (r *reader) Read(
 		policy,
 		r.name,
 		outBatch,
+		r.cacheBatch,
 		mp,
 		r.fs,
 	)

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1968,17 +1968,19 @@ func (tbl *txnTable) PKPersistedBetween(
 		return getNonSortedPKSearchFuncByPKVec(keys)
 	}
 
+	cacheBat := batch.EmptyBatchWithSize(1)
 	//read block ,check if keys exist in the block.
 	pkDef := tbl.tableDef.Cols[tbl.primaryIdx]
 	pkSeq := pkDef.Seqnum
 	pkType := plan2.ExprType2Type(&pkDef.Typ)
 	for _, blk := range candidateBlks {
-		bat, release, err := blockio.LoadColumns(
+		release, err := blockio.LoadColumns(
 			ctx,
 			[]uint16{uint16(pkSeq)},
 			[]types.Type{pkType},
 			fs,
 			blk.MetaLocation(),
+			&cacheBat,
 			tbl.proc.Load().GetMPool(),
 			fileservice.Policy(0),
 		)
@@ -1992,7 +1994,7 @@ func (tbl *txnTable) PKPersistedBetween(
 			searchFunc = buildUnsortedFilter()
 		}
 
-		sels := searchFunc(bat.Vecs)
+		sels := searchFunc(cacheBat.Vecs)
 		if len(sels) > 0 {
 			return true, nil
 		}

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -921,7 +921,8 @@ type reader struct {
 
 	memFilter MemPKFilter
 
-	scanType int
+	scanType   int
+	cacheBatch *batch.Batch
 }
 
 type mergeReader struct {

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -4265,9 +4265,10 @@ func TestBlockRead(t *testing.T) {
 				return bat
 			}
 			b1 := buildBatch(colTyps)
+			cacheBat := batch.EmptyBatchWithSize(len(colIdxs) + 1)
 			err = blockio.BlockDataReadInner(
 				context.Background(), false, info, ds, colIdxs, colTyps,
-				beforeDel, nil, fileservice.Policy(0), b1, pool, fs,
+				beforeDel, nil, fileservice.Policy(0), b1, &cacheBat, pool, fs,
 			)
 			assert.NoError(t, err)
 			assert.Equal(t, len(columns), len(b1.Vecs))
@@ -4278,7 +4279,7 @@ func TestBlockRead(t *testing.T) {
 			b2 := buildBatch(colTyps)
 			err = blockio.BlockDataReadInner(
 				context.Background(), false, info, ds, colIdxs, colTyps,
-				afterFirstDel, nil, fileservice.Policy(0), b2, pool, fs,
+				afterFirstDel, nil, fileservice.Policy(0), b2, &cacheBat, pool, fs,
 			)
 			assert.NoError(t, err)
 			assert.Equal(t, 19, b2.Vecs[0].Length())
@@ -4288,7 +4289,7 @@ func TestBlockRead(t *testing.T) {
 			b3 := buildBatch(colTyps)
 			err = blockio.BlockDataReadInner(
 				context.Background(), false, info, ds, colIdxs, colTyps,
-				afterSecondDel, nil, fileservice.Policy(0), b3, pool, fs,
+				afterSecondDel, nil, fileservice.Policy(0), b3, &cacheBat, pool, fs,
 			)
 			assert.NoError(t, err)
 			assert.Equal(t, len(columns), len(b2.Vecs))
@@ -4300,7 +4301,7 @@ func TestBlockRead(t *testing.T) {
 				ds,
 				[]uint16{2},
 				[]types.Type{types.T_Rowid.ToType()},
-				afterSecondDel, nil, fileservice.Policy(0), b4, pool, fs,
+				afterSecondDel, nil, fileservice.Policy(0), b4, &cacheBat, pool, fs,
 			)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(b4.Vecs))
@@ -4313,7 +4314,7 @@ func TestBlockRead(t *testing.T) {
 				context.Background(), false, info,
 				ds, []uint16{2},
 				[]types.Type{types.T_Rowid.ToType()},
-				afterSecondDel, nil, fileservice.Policy(0), b5, pool, fs,
+				afterSecondDel, nil, fileservice.Policy(0), b5, &cacheBat, pool, fs,
 			)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(b5.Vecs))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18432 

## What this PR does / why we need it:

hack column data unmarshal from cache to avoid heap allocation