### PR TITLE
CI: add capabilities to cn pod and init conntrack collect

### DIFF
--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -10,24 +10,6 @@ spec:
     nodeSelector:
       tke.matrixorigin.io/mo-checkin-regression-proxy: "true"
     overlay:
-      initContainers:
-        - image: ccr.ccs.tencentyun.com/matrixone-dev/matrixone:imagetag
-          command:
-            - sh
-            - -c
-            - |
-              apt update -y;
-              apt install -y iptables conntrack;
-              iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT;
-          imagePullPolicy: IfNotPresent
-          terminationMessagePolicy: File
-          securityContext:
-            capabilities:
-              add: ["NET_ADMIN","SYS_ADMIN"]
-          name: enable-conntrack
-      mainContainerSecurityContext:
-        capabilities:
-          add: ["NET_ADMIN","NET_RAW"]
       securityContext:
         sysctls:
           - name: net.ipv4.tcp_fin_timeout
@@ -129,24 +111,6 @@ spec:
     nodeSelector:
       tke.matrixorigin.io/mo-checkin-regression-log: "true"
     overlay:
-      initContainers:
-        - image: ccr.ccs.tencentyun.com/matrixone-dev/matrixone:imagetag
-          command:
-            - sh
-            - -c
-            - |
-              apt update -y;
-              apt install -y iptables conntrack;
-              iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT;
-          imagePullPolicy: IfNotPresent
-          terminationMessagePolicy: File
-          securityContext:
-            capabilities:
-              add: ["NET_ADMIN","SYS_ADMIN"]
-          name: enable-conntrack
-      mainContainerSecurityContext:
-        capabilities:
-          add: ["NET_ADMIN","NET_RAW"]
       envFrom:
         - configMapRef:
             name: proxy-env

--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -4,11 +4,30 @@ metadata:
   name: mo-checkin-regression
   namespace: nsformocheckin
 spec:
+  semanticVersion: 1.3.0
   proxy:
     exportToPrometheus: true
     nodeSelector:
       tke.matrixorigin.io/mo-checkin-regression-proxy: "true"
     overlay:
+      initContainers:
+        - image: ccr.ccs.tencentyun.com/matrixone-dev/matrixone:imagetag
+          command:
+            - sh
+            - -c
+            - |
+              apt update -y;
+              apt install -y iptables conntrack;
+              iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT;
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: File
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN","SYS_ADMIN"]
+          name: enable-conntrack
+      mainContainerSecurityContext:
+        capabilities:
+          add: ["NET_ADMIN","NET_RAW"]
       securityContext:
         sysctls:
           - name: net.ipv4.tcp_fin_timeout
@@ -110,6 +129,24 @@ spec:
     nodeSelector:
       tke.matrixorigin.io/mo-checkin-regression-log: "true"
     overlay:
+      initContainers:
+        - image: ccr.ccs.tencentyun.com/matrixone-dev/matrixone:imagetag
+          command:
+            - sh
+            - -c
+            - |
+              apt update -y;
+              apt install -y iptables conntrack;
+              iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT;
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: File
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN","SYS_ADMIN"]
+          name: enable-conntrack
+      mainContainerSecurityContext:
+        capabilities:
+          add: ["NET_ADMIN","NET_RAW"]
       envFrom:
         - configMapRef:
             name: proxy-env
@@ -192,6 +229,24 @@ spec:
     nodeSelector:
       tke.matrixorigin.io/mo-checkin-regression: "true"
     overlay:
+      initContainers:
+        - image: ccr.ccs.tencentyun.com/matrixone-dev/matrixone:imagetag
+          command:
+            - sh
+            - -c
+            - |
+              apt update -y;
+              apt install -y iptables conntrack;
+              iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT;
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: File
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN","SYS_ADMIN"]
+          name: enable-conntrack
+      mainContainerSecurityContext:
+        capabilities:
+          add: ["NET_ADMIN","NET_RAW"]
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/mo-checkin-regression


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
This yaml is compatible with the current operator version, but cannot be collected using conntrack. The operator needs to be upgraded to support it. It will be fine after this PR https://github.com/matrixorigin/ops/pull/328


___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the YAML configuration by adding `initContainers` to install necessary packages like `iptables` and `conntrack`.
- Introduced security capabilities `NET_ADMIN` and `SYS_ADMIN` to the `initContainers` for better network management.
- Updated the `mainContainerSecurityContext` to include additional capabilities `NET_ADMIN` and `NET_RAW`.
- Added a `semanticVersion` field to specify the version as `1.3.0`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mo_checkin_regression_tke.yaml</strong><dd><code>Enhance YAML with init containers and security capabilities</code></dd></summary>
<hr>

optools/mo_checkin_regression/mo_checkin_regression_tke.yaml

<li>Added <code>semanticVersion</code> field with value <code>1.3.0</code>.<br> <li> Introduced <code>initContainers</code> to install <code>iptables</code> and <code>conntrack</code>.<br> <li> Added security capabilities <code>NET_ADMIN</code> and <code>SYS_ADMIN</code> to <code>initContainers</code>.<br> <li> Updated <code>mainContainerSecurityContext</code> to include <code>NET_ADMIN</code> and <code>NET_RAW</code>.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/19036/files#diff-c31cbca87355a4a99ce221e86f31f59c4aeda31064093a04cee02e6cf76dab01">+19/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information