### PR TITLE
CI: modify mo-checkin yaml for  1.2-dev

### DIFF
--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mo-checkin-regression
   namespace: nsformocheckin
 spec:
+  semanticVersion: 1.3.0
   proxy:
     exportToPrometheus: true
     nodeSelector:

--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -183,6 +183,24 @@ spec:
     nodeSelector:
       tke.matrixorigin.io/mo-checkin-regression: "true"
     overlay:
+      initContainers:
+        - image: ccr.ccs.tencentyun.com/matrixone-dev/matrixone:imagetag
+          command:
+            - sh
+            - -c
+            - |
+              apt update -y;
+              apt install -y iptables conntrack;
+              iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT;
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: File
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN","SYS_ADMIN"]
+          name: enable-conntrack
+      mainContainerSecurityContext:
+        capabilities:
+          add: ["NET_ADMIN","NET_RAW"]
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/mo-checkin-regression


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:
This yaml is compatible with the current operator version, but cannot be collected using conntrack. The operator needs to be upgraded to support it. It will be fine after this PR https://github.com/matrixorigin/ops/pull/328


___

### **PR Type**
tests, enhancement


___

### **Description**
- Added an `initContainers` section to the YAML configuration to enable conntrack, which includes installing `iptables` and `conntrack`.
- Configured security context capabilities for the init container to allow network administration tasks.
- Updated the main container's security context to include additional capabilities (`NET_ADMIN` and `NET_RAW`) necessary for the changes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mo_checkin_regression_tke.yaml</strong><dd><code>Add init container and security context for conntrack support</code></dd></summary>
<hr>

optools/mo_checkin_regression/mo_checkin_regression_tke.yaml

<li>Added <code>initContainers</code> configuration for enabling conntrack.<br> <li> Installed <code>iptables</code> and <code>conntrack</code> in the init container.<br> <li> Set security context capabilities for network administration.<br> <li> Updated main container security context to include NET_ADMIN and <br>NET_RAW.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/19038/files#diff-c31cbca87355a4a99ce221e86f31f59c4aeda31064093a04cee02e6cf76dab01">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information