### PR TITLE
optimize memory allocation in hash build operator by preallocate buffer

### DIFF
--- a/pkg/sql/colexec/join_util.go
+++ b/pkg/sql/colexec/join_util.go
@@ -82,7 +82,11 @@ func (bs *Batches) CopyIntoBatches(src *batch.Batch, proc *process.Process) (err
 		if lenBuf > 0 && bs.Buf[lenBuf-1].RowCount() != DefaultBatchSize {
 			tmp = bs.Buf[lenBuf-1]
 		} else {
-			tmp, err = proc.NewBatchFromSrc(src, 0)
+			preAllocSize := length - offset
+			if len(bs.Buf) > 1 {
+				preAllocSize = DefaultBatchSize
+			}
+			tmp, err = proc.NewBatchFromSrc(src, preAllocSize)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19054 

## What this PR does / why we need it:
optimize memory allocation in hash build operator by preallocate buffer