### PR TITLE
fix bvt: sum(aggr_count) need consider aggr_count eq 0 in 1.2-dev

### DIFF
--- a/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.result
+++ b/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.result
@@ -1,5 +1,5 @@
-select error, count(1) < sum(aggr_count) check_result, count(1) cnt, sum(aggr_count) sum, statement from system.statement_info where account="bvt_aggr_error_stmt" and sql_source_type="cloud_nonuser_sql" group by `statement`, error;
+select error, count(1) < sum(IF(aggr_count=0, 1, aggr_count)) check_result, count(1) cnt, sum(IF(aggr_count=0, 1, aggr_count)) sum, statement from system.statement_info where account="bvt_aggr_error_stmt" and sql_source_type="cloud_nonuser_sql" group by `statement`, error;
 error    check_result    cnt    sum    statement
-SQL parser error: table "statement_not_exist_2" does not exist    true    1    3    select * from system.statement_not_exist_2
-SQL parser error: table "statement_not_exist_3" does not exist    true    1    3    select * from system.statement_not_exist_3
-SQL parser error: table "statement_not_exist" does not exist    true    1    9    select * from system.statement_not_exist
+SQL parser error: table "statement_not_exist_3" does not exist    true    1    3    /* 3 queries */ \nselect * from system.statement_not_exist_3
+SQL parser error: table "statement_not_exist_2" does not exist    true    1    3    /* 3 queries */ \nselect * from system.statement_not_exist_2
+SQL parser error: table "statement_not_exist" does not exist    true    1    9    /* 9 queries */ \nselect * from system.statement_not_exist

--- a/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.sql
+++ b/test/distributed/cases/zz_statement_query_type/aggr_error_stmt.sql
@@ -3,4 +3,4 @@
 
 -- Tips: cnt +1000, sum + 1000 both make sure result format is current.
 -- @ignore:2,3,4
-select error, count(1) < sum(aggr_count) check_result, count(1) cnt, sum(aggr_count) sum, statement from system.statement_info where account="bvt_aggr_error_stmt" and sql_source_type="cloud_nonuser_sql" group by `statement`, error;
+select error, count(1) < sum(IF(aggr_count=0, 1, aggr_count)) check_result, count(1) cnt, sum(IF(aggr_count=0, 1, aggr_count)) sum, statement from system.statement_info where account="bvt_aggr_error_stmt" and sql_source_type="cloud_nonuser_sql" group by `statement`, error;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/18793
ref: https://github.com/matrixorigin/matrixone/pull/18796

## What this PR does / why we need it:
fix bvt: sum(aggr_count) need consider aggr_count eq 0