### PR TITLE
move vectors from go heap to offheap

### DIFF
--- a/pkg/sql/colexec/aggexec/aggResult.go
+++ b/pkg/sql/colexec/aggexec/aggResult.go
@@ -45,8 +45,8 @@ func (r *basicResult) init(
 	}
 	r.mg = mg
 	r.mp = mg.Mp()
-	r.res = vector.NewVec(typ)
-	r.ess = vector.NewVec(types.T_bool.ToType())
+	r.res = vector.NewOffHeapVecWithType(typ)
+	r.ess = vector.NewOffHeapVecWithType(types.T_bool.ToType())
 }
 
 func (r *basicResult) extend(more int) (oldLen, newLen int, err error) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19054 

## What this PR does / why we need it:
move vector in agg  operator from go heap to offheap