### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/logservice/snapshot.go
+++ b/pkg/logservice/snapshot.go
@@ -235,7 +235,7 @@ func newSnapshotManager(cfg *Config) *snapshotManager {
 }
 
 func (sm *snapshotManager) exportPath(shardID uint64, replicaID uint64) string {
-	parts := make([]string, 3)
+	parts := make([]string, 0, 3)
 	dir := sm.cfg.SnapshotExportDir
 	shardPart := fmt.Sprintf("shard-%d", shardID)
 	replicaPart := fmt.Sprintf("replica-%d", replicaID)
@@ -244,7 +244,7 @@ func (sm *snapshotManager) exportPath(shardID uint64, replicaID uint64) string {
 }
 
 func (sm *snapshotManager) snapshotPath(nodeID nodeID, index snapshotIndex) string {
-	parts := make([]string, 2)
+	parts := make([]string, 0, 2)
 	snapshotPart := fmt.Sprintf(snapshotPathPattern, index)
 	parts = append(parts, sm.exportPath(nodeID.shardID, nodeID.replicaID), snapshotPart)
 	return filepath.Join(parts...)
@@ -283,7 +283,7 @@ func (sm *snapshotManager) Init(shardID uint64, replicaID uint64) error {
 	if err != nil {
 		return err
 	}
-	indexes := make([]int, len(names))
+	indexes := make([]int, 0, len(names))
 	for _, name := range names {
 		index, err := sm.parse(name)
 		if err != nil {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [x] BUG

## Which issue(s) this PR fixes:



## What this PR does / why we need it:

The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed slice initialization by using capacity instead of length in the `snapshot.go` file.
- Updated the `exportPath`, `snapshotPath`, and `Init` methods to correctly initialize slices with a capacity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapshot.go</strong><dd><code>Correct slice initialization to use capacity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/logservice/snapshot.go

<li>Changed slice initialization to use capacity instead of length.<br> <li> Updated slice creation in <code>exportPath</code>, <code>snapshotPath</code>, and <code>Init</code> methods.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/19139/files#diff-0aef715ea0a8e9777d7a5958b8db8994ae47fd17b30a3cb7d742477ff0a300fd">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information