### PR TITLE
Revert "fix shufflerange miss strvalue (#19083)"

### DIFF
--- a/pkg/pb/statsinfo/shuffle.go
+++ b/pkg/pb/statsinfo/shuffle.go
@@ -183,16 +183,8 @@ func (s *ShuffleRange) Eval() {
 			}
 			if s.Tree == nil {
 				s.Tree = node
-				s.Min = node.Value
-				s.Max = node.Key
 			} else {
 				s.Tree = s.Tree.Merge(node)
-				if s.Min > node.Value {
-					s.Min = node.Value
-				}
-				if s.Max < node.Key {
-					s.Max = node.Key
-				}
 			}
 		}
 	}


### PR DESCRIPTION
This reverts commit 9e65c7d99c93c180b32c9f6a69888212a872117d.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4196

## What this PR does / why we need it:
Revert "fix shufflerange miss strvalue (#19083)"