### PR TITLE
[enhancement] logservice: add retry if ut failed as port is inuse

### DIFF
--- a/pkg/logservice/client_test.go
+++ b/pkg/logservice/client_test.go
@@ -87,9 +87,14 @@ func TestClientCanBeCreated(t *testing.T) {
 
 func TestClientCanBeConnectedByReverseProxy(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cfg := getServiceTestConfig()
+	var cfg Config
+	genCfg := func() Config {
+		cfg = getServiceTestConfig()
+		return cfg
+	}
 	defer vfs.ReportLeakedFD(cfg.FS, t)
-	service, err := NewService(cfg,
+	service, err := NewServiceWithRetry(
+		genCfg,
 		newFS(),
 		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {

--- a/pkg/logservice/service_commands_test.go
+++ b/pkg/logservice/service_commands_test.go
@@ -418,9 +418,13 @@ func TestServiceAddLogShard(t *testing.T) {
 
 func TestServiceBootstrapShard(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cfg := getServiceTestConfig()
+	var cfg Config
+	genCfg := func() Config {
+		cfg = getServiceTestConfig()
+		return cfg
+	}
 	defer vfs.ReportLeakedFD(cfg.FS, t)
-	service, err := NewService(cfg,
+	service, err := NewServiceWithRetry(genCfg,
 		newFS(),
 		nil,
 		WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {

--- a/pkg/logservice/test_utils.go
+++ b/pkg/logservice/test_utils.go
@@ -121,9 +121,13 @@ func RunClientTest(
 		sid,
 		func(rt runtime.Runtime) {
 			defer leaktest.AfterTest(t)()
-			cfg := getServiceTestConfig()
+			var cfg Config
+			genCfg := func() Config {
+				cfg = getServiceTestConfig()
+				return cfg
+			}
 			defer vfs.ReportLeakedFD(cfg.FS, t)
-			service, err := NewService(cfg,
+			service, err := NewServiceWithRetry(genCfg,
 				newFS(),
 				nil,
 				WithBackendFilter(func(msg morpc.Message, backendAddr string) bool {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19129

## What this PR does / why we need it:
add retry if ut failed as port is inuse