### PR TITLE
[enhancement] logservice: add retry if port is inuse for store instance

### DIFF
--- a/pkg/logservice/service_commands_test.go
+++ b/pkg/logservice/service_commands_test.go
@@ -182,20 +182,24 @@ func TestHandleAddNonVotingReplica(t *testing.T) {
 func TestHandleStartNonVotingReplica(t *testing.T) {
 	t.Skip() // pls re-open after https://github.com/matrixorigin/matrixone/pull/19025
 	fn := func(t *testing.T, s *Service) {
-		cfg := getStoreTestConfig()
-		gPort := getTestGossipPort()
-		cfg.GossipAddress = fmt.Sprintf("0.0.0.0:%d", gPort)
-		cfg.GossipSeedAddresses = []string{getTestGossipAddress(gPort)}
-		cfg.GossipPort = getTestGossipPort()
-		cfg.GossipSeedAddresses = []string{
-			s.store.cfg.GossipAddress,
-			getTestGossipAddress(cfg.GossipPort),
+		var cfg Config
+		genCfg := func() Config {
+			cfg = getStoreTestConfig()
+			gPort := getTestGossipPort()
+			cfg.GossipAddress = fmt.Sprintf("0.0.0.0:%d", gPort)
+			cfg.GossipSeedAddresses = []string{getTestGossipAddress(gPort)}
+			cfg.GossipPort = getTestGossipPort()
+			cfg.GossipSeedAddresses = []string{
+				s.store.cfg.GossipAddress,
+				getTestGossipAddress(cfg.GossipPort),
+			}
+			cfg.RaftAddress = getTestRaftAddress()
+			svcPort := getTestServicePort()
+			cfg.ServiceListenAddress = fmt.Sprintf("0.0.0.0:%d", svcPort)
+			cfg.ServiceAddress = getTestServiceAddress(svcPort)
+			return cfg
 		}
-		cfg.RaftAddress = getTestRaftAddress()
-		svcPort := getTestServicePort()
-		cfg.ServiceListenAddress = fmt.Sprintf("0.0.0.0:%d", svcPort)
-		cfg.ServiceAddress = getTestServiceAddress(svcPort)
-		newStore, err := getTestStore(cfg, false, nil)
+		newStore, err := getTestStore(genCfg, false, nil)
 		assert.NoError(t, err)
 		defer func() {
 			assert.NoError(t, newStore.close())


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19180 

## What this PR does / why we need it:
add retry if port is inuse for store instance