### PR TITLE
remove redundant mo_table_size, rows bvt case

### DIFF
--- a/test/distributed/cases/function/builtin.result
+++ b/test/distributed/cases/function/builtin.result
@@ -764,18 +764,4 @@ null
 null
 null
 drop table t1;
-select mo_table_size(reldatabase, relname)=0 from (select reldatabase, relname, relkind from mo_catalog.mo_tables where relname in ('mo_sessions', 'log_info', 'sys_memory_used', 'rawlog', 'statement_info') order by relkind);
-mo_table_size(reldatabase, relname) = 0
-false
-false
-true
-true
-true
-select mo_table_rows(reldatabase, relname)=0 from (select reldatabase, relname, relkind from mo_catalog.mo_tables where relname in ('mo_sessions', 'log_info', 'sys_memory_used', 'rawlog', 'statement_info') order by relkind);
-mo_table_size(reldatabase, relname) = 0
-false
-false
-true
-true
-true
 drop database test01;

--- a/test/distributed/cases/function/builtin.sql
+++ b/test/distributed/cases/function/builtin.sql
@@ -496,12 +496,4 @@ select trim(null from b) from t1;
 select trim('a' from null) from t1;
 select trim(null from null) from t1;
 drop table t1;
-
--- test mo_table_size/rows/min/mix view and normal table
--- view: mo_sessions, log_info, sys_memory_used
--- normal: rawlog, statement_info
-select mo_table_size(reldatabase, relname)=0 from (select reldatabase, relname, relkind from mo_catalog.mo_tables where relname in ('mo_sessions', 'log_info', 'sys_memory_used', 'rawlog', 'statement_info') order by relkind);
-select mo_table_rows(reldatabase, relname)=0 from (select reldatabase, relname, relkind from mo_catalog.mo_tables where relname in ('mo_sessions', 'log_info', 'sys_memory_used', 'rawlog', 'statement_info') order by relkind);
-
-
 drop database test01;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4223

## What this PR does / why we need it:
the behaviour of mo_table_size, rows not change, remove the redundant bvt case