### PR TITLE
Fix panic cause miss stmt info and log in 1.2

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2888,6 +2888,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 			} else {
 				resp = NewGeneralErrorResponse(COM_QUERY, ses.txnHandler.GetServerStatus(), moe)
 			}
+			logStatementStatus(execCtx.reqCtx, ses, execCtx.stmt, fail, err)
 		}
 	}()
 	ses.EnterFPrint(1)

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -520,8 +520,9 @@ func logStatementStringStatus(ctx context.Context, ses FeSession, stmtStr string
 
 	// pls make sure: NO ONE use the ses.tStmt after EndStatement
 	if !ses.IsBackgroundSession() {
-		stmt := ses.GetStmtInfo()
-		stmt.EndStatement(ctx, err, ses.SendRows(), outBytes, outPacket)
+		if stmt := ses.GetStmtInfo(); stmt != nil {
+			stmt.EndStatement(ctx, err, ses.SendRows(), outBytes, outPacket)
+		}
 	}
 	// need just below EndStatement
 	ses.SetTStmt(nil)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4254

ref: https://github.com/matrixorigin/matrixone/pull/19369

## What this PR does / why we need it:
1. log the query's statement and error info, while panic-catch at `ExecRequest` func.