### PR TITLE
fix: binary execute bug

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2635,9 +2635,17 @@ func executeStmt(ses *Session,
 	var cmpBegin time.Time
 	var ret interface{}
 
-	switch execCtx.stmt.StmtKind().ExecLocation() {
+	getExecLocation := func() tree.ExecLocation {
+		// because when isBinaryProtExecute is true, execCtx.stmt is preparestmt, actually it's execute
+		if execCtx.input.isBinaryProtExecute {
+			return tree.EXEC_IN_ENGINE
+		}
+		return execCtx.stmt.StmtKind().ExecLocation()
+	}
+	switch getExecLocation() {
 	case tree.EXEC_IN_FRONTEND:
 		return execInFrontend(ses, execCtx)
+
 	case tree.EXEC_IN_ENGINE:
 		//in the computation engine
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/19368

## What this PR does / why we need it:
binary execute 上次重构后，不重新build，execute.stmt放的是prepareStmt, 本issue，在executeStmt里面拿ExecLocation拿的是prepare stmt的，本issue prepare是alterccount的，拿到的是EXEC_IN_FRONTEND，本来execute语句应该是EXEC_IN_ENGINE，导致走了EXEC_IN_FRONTEND的流程