### PR TITLE
make txn do not wait in incrservice while the logtail is paused 

### DIFF
--- a/pkg/pb/txn/txn_option.go
+++ b/pkg/pb/txn/txn_option.go
@@ -15,13 +15,19 @@
 package txn
 
 var (
-	txnFeatureUserTxn      = uint32(1 << 0)
-	txnFeatureReadOnly     = uint32(1 << 1)
-	txnFeatureCacheWrite   = uint32(1 << 2)
-	txnFeatureDisable1PC   = uint32(1 << 3)
-	txnFeatureCheckDup     = uint32(1 << 4)
-	txnFeatureDisableTrace = uint32(1 << 5)
+	txnFeatureUserTxn           = uint32(1 << 0)
+	txnFeatureReadOnly          = uint32(1 << 1)
+	txnFeatureCacheWrite        = uint32(1 << 2)
+	txnFeatureDisable1PC        = uint32(1 << 3)
+	txnFeatureCheckDup          = uint32(1 << 4)
+	txnFeatureDisableTrace      = uint32(1 << 5)
+	txnFeatureDisableWaitPaused = uint32(1 << 6)
 )
+
+func (m TxnOptions) WithDisableWaitPaused() TxnOptions {
+	m.Features |= txnFeatureDisableWaitPaused
+	return m
+}
 
 func (m TxnOptions) WithDisableTrace() TxnOptions {
 	m.Features |= txnFeatureDisableTrace
@@ -59,6 +65,10 @@ func (m TxnOptions) CacheWriteEnabled() bool {
 
 func (m TxnOptions) TraceDisabled() bool {
 	return m.featureEnabled(txnFeatureDisableTrace)
+}
+
+func (m TxnOptions) WaitPausedDisabled() bool {
+	return m.featureEnabled(txnFeatureDisableWaitPaused)
 }
 
 func (m TxnOptions) UserTxn() bool {

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -501,6 +501,10 @@ func (client *txnClient) openTxn(op *txnOperator) error {
 				return moerr.NewInternalErrorNoCtx("cn service is not ready, retry later")
 			}
 
+			if !op.opts.options.UserTxn() {
+				return moerr.NewInvalidStateNoCtx("txn client is in pause state")
+			}
+
 			client.logger.Warn("txn client is in pause state, wait for it to be ready",
 				zap.String("txn ID", hex.EncodeToString(op.reset.txnID)))
 			// Wait until the txn client's state changed to normal, and it will probably take

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -501,7 +501,7 @@ func (client *txnClient) openTxn(op *txnOperator) error {
 				return moerr.NewInternalErrorNoCtx("cn service is not ready, retry later")
 			}
 
-			if !op.opts.options.UserTxn() {
+			if op.opts.options.WaitPausedDisabled() {
 				return moerr.NewInvalidStateNoCtx("txn client is in pause state")
 			}
 

--- a/pkg/txn/client/client_test.go
+++ b/pkg/txn/client/client_test.go
@@ -262,3 +262,10 @@ func TestMaxActiveTxnWithWaitTimeout(t *testing.T) {
 		},
 		WithMaxActiveTxn(1))
 }
+
+func TestOpenInternalTxnCannotBlockWithPausedState(t *testing.T) {
+	c := &txnClient{}
+	c.mu.state = paused
+	op := &txnOperator{}
+	require.Error(t, c.openTxn(op))
+}

--- a/pkg/txn/client/client_test.go
+++ b/pkg/txn/client/client_test.go
@@ -263,9 +263,12 @@ func TestMaxActiveTxnWithWaitTimeout(t *testing.T) {
 		WithMaxActiveTxn(1))
 }
 
-func TestOpenInternalTxnCannotBlockWithPausedState(t *testing.T) {
+func TestOpenTxnWithWaitPausedDisabled(t *testing.T) {
 	c := &txnClient{}
 	c.mu.state = paused
+
 	op := &txnOperator{}
+	op.opts.options = op.opts.options.WithDisableWaitPaused()
+
 	require.Error(t, c.openTxn(op))
 }

--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -188,6 +188,12 @@ func WithDisableTrace(value bool) TxnOption {
 	}
 }
 
+func WithDisableWaitPaused() TxnOption {
+	return func(tc *txnOperator) {
+		tc.opts.options = tc.opts.options.WithDisableWaitPaused()
+	}
+}
+
 func WithSessionInfo(info string) TxnOption {
 	return func(tc *txnOperator) {
 		tc.opts.options.SessionInfo = info

--- a/pkg/util/executor/options.go
+++ b/pkg/util/executor/options.go
@@ -177,6 +177,11 @@ func (opts Options) WithDisableTrace() Options {
 	return opts
 }
 
+func (opts Options) WithDisableWaitPaused() Options {
+	opts.txnOpts = append(opts.txnOpts, client.WithDisableWaitPaused())
+	return opts
+}
+
 func (opts Options) ExtraTxnOptions() []client.TxnOption {
 	return opts.txnOpts
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19394

## What this PR does / why we need it:
Fix hung.  Consider the following timing:
1. logtail paused
2. cancel all active pipelines
3. reset logtail state to normal

When a pipeline in 2 is executing and a new transaction is opened in another goroutine to do something (e.g., update the cache of a auto-increment), the new transaction is blocked until the logtail state returns to normal. This creates a circular wait. 