### PR TITLE
make txn do not wait in incrservice while the logtail is paused to 1.2

### DIFF
--- a/pkg/incrservice/store_sql.go
+++ b/pkg/incrservice/store_sql.go
@@ -72,7 +72,7 @@ func (s *sqlStore) Create(
 	if txnOp != nil {
 		opts = opts.WithDisableIncrStatement()
 	} else {
-		opts = opts.WithEnableTrace()
+		opts = opts.WithEnableTrace().WithDisableWaitPaused()
 	}
 
 	return s.exec.ExecTxn(
@@ -111,7 +111,7 @@ func (s *sqlStore) Allocate(
 	if txnOp != nil {
 		opts = opts.WithDisableIncrStatement()
 	} else {
-		opts = opts.WithEnableTrace()
+		opts = opts.WithEnableTrace().WithDisableWaitPaused()
 	}
 
 	ctxDone := func() bool {
@@ -238,8 +238,10 @@ func (s *sqlStore) UpdateMinValue(
 	// So updateMinValue will use a new txn to update the min value. To avoid w-w conflict, we need to wait this
 	// committed log tail applied to ensure subsequence txn must get a snapshot ts which is large than this commit.
 	if txnOp == nil {
-		opts = opts.WithWaitCommittedLogApplied().
-			WithEnableTrace()
+		opts = opts.
+			WithWaitCommittedLogApplied().
+			WithEnableTrace().
+			WithDisableWaitPaused()
 	} else {
 		opts = opts.WithDisableIncrStatement()
 	}
@@ -265,6 +267,7 @@ func (s *sqlStore) Delete(
 	opts := executor.Options{}.
 		WithDatabase(database).
 		WithEnableTrace().
+		WithDisableWaitPaused().
 		WithWaitCommittedLogApplied()
 	res, err := s.exec.Exec(
 		ctx,
@@ -292,7 +295,7 @@ func (s *sqlStore) GetColumns(
 	if txnOp != nil {
 		opts = opts.WithDisableIncrStatement()
 	} else {
-		opts = opts.WithEnableTrace()
+		opts = opts.WithEnableTrace().WithDisableWaitPaused()
 	}
 
 	res, err := s.exec.Exec(ctx, fetchSQL, opts)

--- a/pkg/pb/txn/txn_option.go
+++ b/pkg/pb/txn/txn_option.go
@@ -15,13 +15,19 @@
 package txn
 
 var (
-	txnFeatureUserTxn      = uint32(1 << 0)
-	txnFeatureReadOnly     = uint32(1 << 1)
-	txnFeatureCacheWrite   = uint32(1 << 2)
-	txnFeatureDisable1PC   = uint32(1 << 3)
-	txnFeatureCheckDup     = uint32(1 << 4)
-	txnFeatureDisableTrace = uint32(1 << 5)
+	txnFeatureUserTxn           = uint32(1 << 0)
+	txnFeatureReadOnly          = uint32(1 << 1)
+	txnFeatureCacheWrite        = uint32(1 << 2)
+	txnFeatureDisable1PC        = uint32(1 << 3)
+	txnFeatureCheckDup          = uint32(1 << 4)
+	txnFeatureDisableTrace      = uint32(1 << 5)
+	txnFeatureDisableWaitPaused = uint32(1 << 6)
 )
+
+func (m TxnOptions) WithDisableWaitPaused() TxnOptions {
+	m.Features |= txnFeatureDisableWaitPaused
+	return m
+}
 
 func (m TxnOptions) WithDisableTrace() TxnOptions {
 	m.Features |= txnFeatureDisableTrace
@@ -59,6 +65,10 @@ func (m TxnOptions) CacheWriteEnabled() bool {
 
 func (m TxnOptions) TraceDisabled() bool {
 	return m.featureEnabled(txnFeatureDisableTrace)
+}
+
+func (m TxnOptions) WaitPausedDisabled() bool {
+	return m.featureEnabled(txnFeatureDisableWaitPaused)
 }
 
 func (m TxnOptions) UserTxn() bool {

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -464,7 +464,7 @@ func (client *txnClient) openTxn(op *txnOperator) error {
 			return moerr.NewInternalErrorNoCtx("cn service is not ready, retry later")
 		}
 
-		if !op.options.WaitPausedDisabled() {
+		if op.options.WaitPausedDisabled() {
 			return moerr.NewInvalidStateNoCtx("txn client is in pause state")
 		}
 

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -464,6 +464,10 @@ func (client *txnClient) openTxn(op *txnOperator) error {
 			return moerr.NewInternalErrorNoCtx("cn service is not ready, retry later")
 		}
 
+		if !op.options.UserTxn() {
+			return moerr.NewInvalidStateNoCtx("txn client is in pause state")
+		}
+
 		util.GetLogger().Warn("txn client is in pause state, wait for it to be ready",
 			zap.String("txn ID", hex.EncodeToString(op.txnID)))
 		// Wait until the txn client's state changed to normal, and it will probably take

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -464,7 +464,7 @@ func (client *txnClient) openTxn(op *txnOperator) error {
 			return moerr.NewInternalErrorNoCtx("cn service is not ready, retry later")
 		}
 
-		if !op.options.UserTxn() {
+		if !op.options.WaitPausedDisabled() {
 			return moerr.NewInvalidStateNoCtx("txn client is in pause state")
 		}
 

--- a/pkg/txn/client/client_test.go
+++ b/pkg/txn/client/client_test.go
@@ -253,3 +253,10 @@ func TestMaxActiveTxnWithWaitTimeout(t *testing.T) {
 		},
 		WithMaxActiveTxn(1))
 }
+
+func TestOpenInternalTxnCannotBlockWithPausedState(t *testing.T) {
+	c := &txnClient{}
+	c.mu.state = paused
+	op := &txnOperator{}
+	require.Error(t, c.openTxn(op))
+}

--- a/pkg/txn/client/client_test.go
+++ b/pkg/txn/client/client_test.go
@@ -254,9 +254,12 @@ func TestMaxActiveTxnWithWaitTimeout(t *testing.T) {
 		WithMaxActiveTxn(1))
 }
 
-func TestOpenInternalTxnCannotBlockWithPausedState(t *testing.T) {
+func TestOpenTxnWithWaitPausedDisabled(t *testing.T) {
 	c := &txnClient{}
 	c.mu.state = paused
+
 	op := &txnOperator{}
+	op.opts.options = op.opts.options.WithDisableWaitPaused()
+
 	require.Error(t, c.openTxn(op))
 }

--- a/pkg/txn/client/client_test.go
+++ b/pkg/txn/client/client_test.go
@@ -259,7 +259,7 @@ func TestOpenTxnWithWaitPausedDisabled(t *testing.T) {
 	c.mu.state = paused
 
 	op := &txnOperator{}
-	op.opts.options = op.opts.options.WithDisableWaitPaused()
+	op.options = op.options.WithDisableWaitPaused()
 
 	require.Error(t, c.openTxn(op))
 }

--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -187,6 +187,12 @@ func WithDisableTrace(value bool) TxnOption {
 	}
 }
 
+func WithDisableWaitPaused() TxnOption {
+	return func(tc *txnOperator) {
+		tc.opts.options = tc.opts.options.WithDisableWaitPaused()
+	}
+}
+
 func WithSessionInfo(info string) TxnOption {
 	return func(tc *txnOperator) {
 		tc.options.SessionInfo = info

--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -189,7 +189,7 @@ func WithDisableTrace(value bool) TxnOption {
 
 func WithDisableWaitPaused() TxnOption {
 	return func(tc *txnOperator) {
-		tc.opts.options = tc.opts.options.WithDisableWaitPaused()
+		tc.options = tc.options.WithDisableWaitPaused()
 	}
 }
 

--- a/pkg/util/executor/options.go
+++ b/pkg/util/executor/options.go
@@ -164,6 +164,11 @@ func (opts Options) WithDisableTrace() Options {
 	return opts
 }
 
+func (opts Options) WithDisableWaitPaused() Options {
+	opts.txnOpts = append(opts.txnOpts, client.WithDisableWaitPaused())
+	return opts
+}
+
 func (opts Options) ExtraTxnOptions() []client.TxnOption {
 	return opts.txnOpts
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19394 

## What this PR does / why we need it:
Fix hung. Consider the following timing:

logtail paused
cancel all active pipelines
reset logtail state to normal
When a pipeline in 2 is executing and a new transaction is opened in another goroutine to do something (e.g., update the cache of a auto-increment), the new transaction is blocked until the logtail state returns to normal. This creates a circular wait.