### PR TITLE
[fix] : ignore FakePrimaryKeyColName when update last insert id

### DIFF
--- a/pkg/incrservice/table_cache.go
+++ b/pkg/incrservice/table_cache.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/log"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
@@ -125,6 +126,9 @@ func (c *tableCache) insertAutoValues(
 		if v, err := cc.insertAutoValues(ctx, tableID, vec, rows, txnOp); err != nil {
 			return 0, err
 		} else {
+			if col.ColName == catalog.FakePrimaryKeyColName {
+				continue
+			}
 			lastInsert = v
 		}
 	}

--- a/test/distributed/cases/auto_increment/auto_increment_columns.result
+++ b/test/distributed/cases/auto_increment/auto_increment_columns.result
@@ -829,3 +829,31 @@ select last_insert_id();
 last_insert_id()
 10
 Drop table auto_increment02;
+Drop table if exists auto_increment03;
+Create table auto_increment03(col1 int auto_increment unique key, col2 int auto_increment unique)auto_increment = 10;
+Select * from auto_increment03;
+col1    col2
+select last_insert_id();
+last_insert_id()
+10
+Insert into auto_increment03 values();
+Select * from auto_increment03;
+col1    col2
+10    10
+select last_insert_id();
+last_insert_id()
+10
+insert into auto_increment03 values(100,100);
+select last_insert_id();
+last_insert_id()
+10
+insert into auto_increment03 (col1)values(1000);
+select last_insert_id();
+last_insert_id()
+101
+Select * from auto_increment03;
+col1    col2
+10    10
+100    100
+1000    101
+Drop table auto_increment03;

--- a/test/distributed/cases/auto_increment/auto_increment_columns.sql
+++ b/test/distributed/cases/auto_increment/auto_increment_columns.sql
@@ -484,3 +484,17 @@ Insert into auto_increment02 values(10);
 Select * from auto_increment02;
 select last_insert_id();
 Drop table auto_increment02;
+
+Drop table if exists auto_increment03;
+Create table auto_increment03(col1 int auto_increment unique key, col2 int auto_increment unique)auto_increment = 10;
+Select * from auto_increment03;
+select last_insert_id();
+Insert into auto_increment03 values();
+Select * from auto_increment03;
+select last_insert_id();
+insert into auto_increment03 values(100,100);
+select last_insert_id();
+insert into auto_increment03 (col1)values(1000);
+select last_insert_id();
+Select * from auto_increment03;
+Drop table auto_increment03;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19317

## What this PR does / why we need it:

not need to update last_insert_id when no need to generate auto increment value