### PR TITLE
fix TestDaemonTaskInSqlMock FAIL

### DIFF
--- a/pkg/taskservice/mysql_task_storage_test.go
+++ b/pkg/taskservice/mysql_task_storage_test.go
@@ -543,4 +543,5 @@ func TestDaemonTaskInSqlMock(t *testing.T) {
 	assert.Equal(t, 1, heartbeat)
 
 	mock.ExpectClose()
+	require.NoError(t, storage.Close())
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/19445

## What this PR does / why we need it:
fix TestDaemonTaskInSqlMock FAIL in Matrixone Utils CI  ut-test


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the `TestDaemonTaskInSqlMock` test by adding error handling for the `storage.Close()` operation.
- Ensured that the test properly checks for errors when closing the storage to prevent test failures.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mysql_task_storage_test.go</strong><dd><code>Add error handling for storage closure in test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/taskservice/mysql_task_storage_test.go

<li>Added a check to ensure no error occurs when closing the storage.<br> <li> Used <code>require.NoError</code> to validate the <code>storage.Close()</code> operation.<br>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/19443/files#diff-ac3b8046d4c322ba2c942823600788bbfc08cffa4a659f5fc4d272778259d15b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information