### PR TITLE
fix: execute insert panic after change table

### DIFF
--- a/pkg/sql/plan/visit_plan_rule.go
+++ b/pkg/sql/plan/visit_plan_rule.go
@@ -43,7 +43,7 @@ func NewGetParamRule() *GetParamRule {
 }
 
 func (rule *GetParamRule) MatchNode(node *Node) bool {
-	if node.NodeType == plan.Node_TABLE_SCAN {
+	if node.NodeType == plan.Node_TABLE_SCAN || node.NodeType == plan.Node_INSERT || node.NodeType == plan.Node_MULTI_UPDATE {
 		rule.schemas = append(rule.schemas, &plan.ObjectRef{
 			Server:     int64(node.TableDef.Version), //we use this unused field to store table's version
 			Db:         node.ObjRef.Db,

--- a/test/distributed/cases/prepare/prepare.result
+++ b/test/distributed/cases/prepare/prepare.result
@@ -553,4 +553,17 @@ set @a=23456;
 execute s using @a;
 a    b    c    a    b
 46712    21712    46712    46712    23456
+drop table if exists prepare_test_t1;
+create table prepare_test_t1(col1 int, col2 int);
+prepare s_pre from insert into prepare_test_t1 values(1, ?);
+set @var = 2;
+execute s_pre using @var;
+select * from prepare_test_t1;
+col1    col2
+1    2
+alter table prepare_test_t1 add col3 int;
+execute s_pre using @var;
+internal error: table 'prepare_test_t1' has been changed, please reset prepare statement 's_pre'
+deallocate prepare s_pre;
+drop table prepare_test_t1;
 drop database if exists db1;

--- a/test/distributed/cases/prepare/prepare.test
+++ b/test/distributed/cases/prepare/prepare.test
@@ -413,4 +413,16 @@ set @a=10000;
 execute s using @a;
 set @a=23456;
 execute s using @a;
+
+drop table if exists prepare_test_t1;
+create table prepare_test_t1(col1 int, col2 int);
+prepare s_pre from insert into prepare_test_t1 values(1, ?);
+set @var = 2;
+execute s_pre using @var;
+select * from prepare_test_t1;
+alter table prepare_test_t1 add col3 int;
+execute s_pre using @var;
+deallocate prepare s_pre;
+drop table prepare_test_t1;
+
 drop database if exists db1;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/19512

## What this PR does / why we need it:
execute insert的时候也需要检查prepare plan的table有没有发生变化