### PR TITLE
fileservice: try to extract region from endpoint in QCloud SDK

### DIFF
--- a/pkg/fileservice/object_storage_arguments_test.go
+++ b/pkg/fileservice/object_storage_arguments_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -138,4 +139,20 @@ func objectStorageArgumentsForTest(defaultName string, t *testing.T) (ret []Obje
 	}
 
 	return ret
+}
+
+func TestQCloudRegion(t *testing.T) {
+	args := ObjectStorageArguments{
+		Endpoint: "http://cos.foobar.myqcloud.com",
+	}
+	args.validate()
+	assert.Equal(t, "foobar", args.Region)
+}
+
+func TestAWSRegion(t *testing.T) {
+	args := ObjectStorageArguments{
+		Bucket: "aws", // hope it will not change its region
+	}
+	args.validate()
+	assert.Equal(t, "us-east-1", args.Region)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19488 

## What this PR does / why we need it:
try to extract region from endpoint if not provided