### PR TITLE
fileservice: use AWS env vars to set credential key id and secret in QCloud SDK

### DIFF
--- a/pkg/fileservice/object_storage_arguments.go
+++ b/pkg/fileservice/object_storage_arguments.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -178,6 +179,20 @@ func (o *ObjectStorageArguments) validate() error {
 	// role session name
 	if o.RoleSessionName == "" {
 		o.RoleSessionName = "mo-service"
+	}
+
+	// 腾讯云使用 AWS 环境变量配置 key id/secret
+	if strings.Contains(o.Endpoint, "myqcloud.com") {
+		if o.KeyID == "" {
+			if value := os.Getenv("AWS_ACCESS_KEY_ID"); value != "" {
+				o.KeyID = value
+			}
+		}
+		if o.KeySecret == "" {
+			if value := os.Getenv("AWS_SECRET_ACCESS_KEY"); value != "" {
+				o.KeySecret = value
+			}
+		}
 	}
 
 	return nil

--- a/pkg/fileservice/object_storage_arguments_test.go
+++ b/pkg/fileservice/object_storage_arguments_test.go
@@ -156,3 +156,14 @@ func TestAWSRegion(t *testing.T) {
 	args.validate()
 	assert.Equal(t, "us-east-1", args.Region)
 }
+
+func TestQCloudKeyIDSecretFromAwsEnv(t *testing.T) {
+	args := ObjectStorageArguments{
+		Endpoint: "http://cos.foobar.myqcloud.com",
+	}
+	t.Setenv("AWS_ACCESS_KEY_ID", "foo")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "bar")
+	args.validate()
+	assert.Equal(t, "foo", args.KeyID)
+	assert.Equal(t, "bar", args.KeySecret)
+}


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19488 

## What this PR does / why we need it:
use AWS env vars to get credentials info if not provide in QCloud SDK