### PR TITLE
fileservice: avoid MinIO SDK for now

### DIFF
--- a/pkg/fileservice/aliyun_sdk.go
+++ b/pkg/fileservice/aliyun_sdk.go
@@ -100,7 +100,9 @@ func NewAliyunSDK(
 
 	if !args.NoBucketValidation {
 		// validate bucket
-		_, err := client.GetBucketInfo(args.Bucket)
+		reqCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+		defer cancel()
+		_, err := client.GetBucketInfo(args.Bucket, oss.WithContext(reqCtx))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/fileservice/aws_sdk_v2.go
+++ b/pkg/fileservice/aws_sdk_v2.go
@@ -169,7 +169,9 @@ func NewAwsSDKv2(
 
 	if !args.NoBucketValidation {
 		// head bucket to validate
-		_, err = client.HeadBucket(ctx, &s3.HeadBucketInput{
+		reqCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+		defer cancel()
+		_, err = client.HeadBucket(reqCtx, &s3.HeadBucketInput{
 			Bucket: ptrTo(args.Bucket),
 		})
 		if err != nil {

--- a/pkg/fileservice/minio_sdk.go
+++ b/pkg/fileservice/minio_sdk.go
@@ -167,7 +167,9 @@ func NewMinioSDK(
 
 	if !args.NoBucketValidation {
 		// validate
-		ok, err := client.BucketExists(ctx, args.Bucket)
+		reqCtx, cancel := context.WithTimeout(ctx, time.Second*5)
+		defer cancel()
+		ok, err := client.BucketExists(reqCtx, args.Bucket)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/fileservice/object_storage_test.go
+++ b/pkg/fileservice/object_storage_test.go
@@ -58,6 +58,14 @@ func testObjectStorage[T ObjectStorage](
 			assert.Nil(t, err)
 			assert.Equal(t, 1, n)
 
+			// list empty
+			prefix2 := time.Now().Format("2006-01-02-15-04-05.000000")
+			err = storage.List(ctx, prefix2+"/", func(isPrefix bool, key string, size int64) (bool, error) {
+				t.Fatal()
+				return true, nil
+			})
+			assert.Nil(t, err)
+
 			// stat
 			size, err := storage.Stat(ctx, name)
 			assert.Nil(t, err)
@@ -175,6 +183,13 @@ func TestObjectStorages(t *testing.T) {
 				// qiniu
 				testObjectStorage(t, "minio", func(t *testing.T) *MinioSDK {
 					storage, err := NewMinioSDK(context.Background(), args, nil)
+					if err != nil {
+						t.Fatal(err)
+					}
+					return storage
+				})
+				testObjectStorage(t, "aws", func(t *testing.T) *AwsSDKv2 {
+					storage, err := NewAwsSDKv2(context.Background(), args, nil)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -83,10 +83,8 @@ func NewS3FS(
 	var err error
 	switch {
 
-	case args.IsMinio ||
-		// 天翼云
-		strings.Contains(args.Endpoint, "ctyunapi.cn"):
-		// MinIO SDK
+	case strings.Contains(args.Endpoint, "ctyunapi.cn"):
+		// 天翼云，只能用signaturev2验证，其他sdk已不支持
 		fs.storage, err = NewMinioSDK(ctx, args, perfCounterSets)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19488 

## What this PR does / why we need it:
avoid using MinIO SDK to workaround memory leaks