### PR TITLE
fix an expression bug for hashbuild operator.

### DIFF
--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -656,10 +656,6 @@ func (expr *FunctionExpressionExecutor) IsColumnExpr() bool {
 
 func (expr *ColumnExpressionExecutor) Eval(_ *process.Process, batches []*batch.Batch, _ []bool) (*vector.Vector, error) {
 	relIndex := expr.relIndex
-	// XXX it's a bad hack here. root cause is pipeline set a wrong relation index here.
-	if len(batches) == 1 {
-		relIndex = 0
-	}
 
 	// [hack-#002] our `select * from external table` is `select * from EmptyForConstFoldBatch`.
 	if batches[relIndex] == batch.EmptyForConstFoldBatch {

--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -1522,16 +1522,42 @@ func constructJoinBuildOperator(c *Compile, op vm.Operator, mcpu int32) vm.Opera
 	}
 }
 
+// If the join condition is table1.col = table2.col.
+// for hash build operator, we only get table2's data, the origin relation index for right-condition is 1 but wrong.
+//
+// rewriteJoinExprToHashBuildExpr set the relation index to be 0 for resolving this problem.
+func rewriteJoinExprToHashBuildExpr(src []*plan.Expr) []*plan.Expr {
+	var doRelIndexRewrite func(expr *plan.Expr)
+	doRelIndexRewrite = func(expr *plan.Expr) {
+		switch t := expr.Expr.(type) {
+		case *plan.Expr_F:
+			for i := range t.F.Args {
+				doRelIndexRewrite(t.F.Args[i])
+			}
+		case *plan.Expr_List:
+			for i := range t.List.List {
+				doRelIndexRewrite(t.List.List[i])
+			}
+		case *plan.Expr_Col:
+			t.Col.RelPos = 0
+		}
+	}
+
+	dst := make([]*plan.Expr, len(src))
+	for i := range src {
+		doRelIndexRewrite(plan2.DeepCopyExpr(src[i]))
+	}
+	return dst
+}
+
 func constructHashBuild(op vm.Operator, proc *process.Process, mcpu int32) *hashbuild.HashBuild {
-	// XXX BUG
-	// relation index of arg.Conditions should be rewritten to 0 here.
 	ret := hashbuild.NewArgument()
 
 	switch op.OpType() {
 	case vm.Anti:
 		arg := op.(*anti.AntiJoin)
 		ret.NeedHashMap = true
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.HashOnPK = arg.HashOnPK
 		if arg.Cond == nil {
 			ret.NeedBatches = false
@@ -1545,7 +1571,7 @@ func constructHashBuild(op vm.Operator, proc *process.Process, mcpu int32) *hash
 	case vm.Join:
 		arg := op.(*join.InnerJoin)
 		ret.NeedHashMap = true
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.HashOnPK = arg.HashOnPK
 
 		// to find if hashmap need to keep build batches for probe
@@ -1569,7 +1595,7 @@ func constructHashBuild(op vm.Operator, proc *process.Process, mcpu int32) *hash
 	case vm.Left:
 		arg := op.(*left.LeftJoin)
 		ret.NeedHashMap = true
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.NeedBatches = true
 		ret.HashOnPK = arg.HashOnPK
 		ret.NeedAllocateSels = true
@@ -1581,7 +1607,7 @@ func constructHashBuild(op vm.Operator, proc *process.Process, mcpu int32) *hash
 	case vm.Right:
 		arg := op.(*right.RightJoin)
 		ret.NeedHashMap = true
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.NeedBatches = true
 		ret.HashOnPK = arg.HashOnPK
 		ret.NeedAllocateSels = true
@@ -1593,7 +1619,7 @@ func constructHashBuild(op vm.Operator, proc *process.Process, mcpu int32) *hash
 	case vm.RightSemi:
 		arg := op.(*rightsemi.RightSemi)
 		ret.NeedHashMap = true
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.NeedBatches = true
 		ret.HashOnPK = arg.HashOnPK
 		ret.NeedAllocateSels = true
@@ -1605,7 +1631,7 @@ func constructHashBuild(op vm.Operator, proc *process.Process, mcpu int32) *hash
 	case vm.RightAnti:
 		arg := op.(*rightanti.RightAnti)
 		ret.NeedHashMap = true
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.NeedBatches = true
 		ret.HashOnPK = arg.HashOnPK
 		ret.NeedAllocateSels = true
@@ -1617,7 +1643,7 @@ func constructHashBuild(op vm.Operator, proc *process.Process, mcpu int32) *hash
 	case vm.Semi:
 		arg := op.(*semi.SemiJoin)
 		ret.NeedHashMap = true
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.HashOnPK = arg.HashOnPK
 		if arg.Cond == nil {
 			ret.NeedBatches = false
@@ -1634,7 +1660,7 @@ func constructHashBuild(op vm.Operator, proc *process.Process, mcpu int32) *hash
 	case vm.Single:
 		arg := op.(*single.SingleJoin)
 		ret.NeedHashMap = true
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.NeedBatches = true
 		ret.HashOnPK = arg.HashOnPK
 		ret.NeedAllocateSels = true
@@ -1674,7 +1700,7 @@ func constructShuffleBuild(op vm.Operator, proc *process.Process) *shufflebuild.
 	switch op.OpType() {
 	case vm.Anti:
 		arg := op.(*anti.AntiJoin)
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.HashOnPK = arg.HashOnPK
 		if arg.Cond == nil {
 			ret.NeedBatches = false
@@ -1691,7 +1717,7 @@ func constructShuffleBuild(op vm.Operator, proc *process.Process) *shufflebuild.
 
 	case vm.Join:
 		arg := op.(*join.InnerJoin)
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.HashOnPK = arg.HashOnPK
 
 		// to find if hashmap need to keep build batches for probe
@@ -1715,7 +1741,7 @@ func constructShuffleBuild(op vm.Operator, proc *process.Process) *shufflebuild.
 
 	case vm.Left:
 		arg := op.(*left.LeftJoin)
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.NeedBatches = true
 		ret.HashOnPK = arg.HashOnPK
 		ret.NeedAllocateSels = true
@@ -1727,7 +1753,7 @@ func constructShuffleBuild(op vm.Operator, proc *process.Process) *shufflebuild.
 
 	case vm.Right:
 		arg := op.(*right.RightJoin)
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.NeedBatches = true
 		ret.HashOnPK = arg.HashOnPK
 		ret.NeedAllocateSels = true
@@ -1739,7 +1765,7 @@ func constructShuffleBuild(op vm.Operator, proc *process.Process) *shufflebuild.
 
 	case vm.RightSemi:
 		arg := op.(*rightsemi.RightSemi)
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.NeedBatches = true
 		ret.HashOnPK = arg.HashOnPK
 		ret.NeedAllocateSels = true
@@ -1751,7 +1777,7 @@ func constructShuffleBuild(op vm.Operator, proc *process.Process) *shufflebuild.
 
 	case vm.RightAnti:
 		arg := op.(*rightanti.RightAnti)
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.NeedBatches = true
 		ret.HashOnPK = arg.HashOnPK
 		ret.NeedAllocateSels = true
@@ -1763,7 +1789,7 @@ func constructShuffleBuild(op vm.Operator, proc *process.Process) *shufflebuild.
 
 	case vm.Semi:
 		arg := op.(*semi.SemiJoin)
-		ret.Conditions = arg.Conditions[1]
+		ret.Conditions = rewriteJoinExprToHashBuildExpr(arg.Conditions[1])
 		ret.HashOnPK = arg.HashOnPK
 		if arg.Cond == nil {
 			ret.NeedBatches = false


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #17749 

## What this PR does / why we need it:
hashbuild算子持有的expression有relation index错误的问题，在之前都是靠表达式计算框架的hack hold住的。