### PR TITLE
hashbuild / shufflebuild operator should use state to determind reset / free action.

### DIFF
--- a/pkg/sql/colexec/fuzzyfilter/types.go
+++ b/pkg/sql/colexec/fuzzyfilter/types.go
@@ -107,7 +107,9 @@ func (fuzzyFilter *FuzzyFilter) getProbeIdx() int {
 }
 
 func (fuzzyFilter *FuzzyFilter) Reset(proc *process.Process, pipelineFailed bool, err error) {
-	message.FinalizeRuntimeFilter(fuzzyFilter.RuntimeFilterSpec, pipelineFailed, err, proc.GetMessageBoard())
+	runtimeSucced := fuzzyFilter.ctr.state > HandleRuntimeFilter
+
+	message.FinalizeRuntimeFilter(fuzzyFilter.RuntimeFilterSpec, runtimeSucced, proc.GetMessageBoard())
 	ctr := &fuzzyFilter.ctr
 	ctr.state = Build
 	ctr.collisionCnt = 0

--- a/pkg/sql/colexec/hashbuild/build.go
+++ b/pkg/sql/colexec/hashbuild/build.go
@@ -91,7 +91,9 @@ func (hashBuild *HashBuild) Call(proc *process.Process) (vm.CallResult, error) {
 				panic("wrong joinmap message tag!")
 			}
 			message.SendMessage(message.JoinMapMsg{JoinMapPtr: jm, Tag: ap.JoinMapTag}, proc.GetMessageBoard())
+			ctr.state = SendSucceed
 
+		case SendSucceed:
 			result.Batch = nil
 			result.Status = vm.ExecStop
 			analyzer.Output(result.Batch)

--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -84,7 +84,10 @@ func (hashBuild *HashBuild) Release() {
 }
 
 func (hashBuild *HashBuild) Reset(proc *process.Process, pipelineFailed bool, err error) {
-	if hashBuild.ctr.state != SendSucceed {
+	runtimeSucced := hashBuild.ctr.state > HandleRuntimeFilter
+	mapSucceed := hashBuild.ctr.state == SendSucceed
+
+	if !mapSucceed && hashBuild.ctr.hashmapBuilder.InputBatchRowCount > 0{
 		hashBuild.ctr.hashmapBuilder.FreeWithError(proc)
 	} else {
 		hashBuild.ctr.hashmapBuilder.Reset(proc)
@@ -92,8 +95,8 @@ func (hashBuild *HashBuild) Reset(proc *process.Process, pipelineFailed bool, er
 
 	hashBuild.ctr.state = BuildHashMap
 	hashBuild.ctr.runtimeFilterIn = false
-	message.FinalizeRuntimeFilter(hashBuild.RuntimeFilterSpec, pipelineFailed, err, proc.GetMessageBoard())
-	message.FinalizeJoinMapMessage(proc.GetMessageBoard(), hashBuild.JoinMapTag, false, 0, pipelineFailed, err)
+	message.FinalizeRuntimeFilter(hashBuild.RuntimeFilterSpec, runtimeSucced, proc.GetMessageBoard())
+	message.FinalizeJoinMapMessage(proc.GetMessageBoard(), hashBuild.JoinMapTag, false, 0, mapSucceed)
 }
 func (hashBuild *HashBuild) Free(proc *process.Process, pipelineFailed bool, err error) {
 	hashBuild.ctr.hashmapBuilder.Free(proc)

--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -30,6 +30,7 @@ const (
 	BuildHashMap = iota
 	HandleRuntimeFilter
 	SendJoinMap
+	SendSucceed
 )
 
 type container struct {
@@ -83,21 +84,17 @@ func (hashBuild *HashBuild) Release() {
 }
 
 func (hashBuild *HashBuild) Reset(proc *process.Process, pipelineFailed bool, err error) {
-	hashBuild.ctr.state = BuildHashMap
-	hashBuild.ctr.runtimeFilterIn = false
-	message.FinalizeRuntimeFilter(hashBuild.RuntimeFilterSpec, pipelineFailed, err, proc.GetMessageBoard())
-	message.FinalizeJoinMapMessage(proc.GetMessageBoard(), hashBuild.JoinMapTag, false, 0, pipelineFailed, err)
-	if pipelineFailed || err != nil {
+	if hashBuild.ctr.state != SendSucceed {
 		hashBuild.ctr.hashmapBuilder.FreeWithError(proc)
 	} else {
 		hashBuild.ctr.hashmapBuilder.Reset(proc)
 	}
+
+	hashBuild.ctr.state = BuildHashMap
+	hashBuild.ctr.runtimeFilterIn = false
+	message.FinalizeRuntimeFilter(hashBuild.RuntimeFilterSpec, pipelineFailed, err, proc.GetMessageBoard())
+	message.FinalizeJoinMapMessage(proc.GetMessageBoard(), hashBuild.JoinMapTag, false, 0, pipelineFailed, err)
 }
 func (hashBuild *HashBuild) Free(proc *process.Process, pipelineFailed bool, err error) {
-
-	if pipelineFailed || err != nil {
-		hashBuild.ctr.hashmapBuilder.FreeWithError(proc)
-	} else {
-		hashBuild.ctr.hashmapBuilder.Free(proc)
-	}
+	hashBuild.ctr.hashmapBuilder.Free(proc)
 }

--- a/pkg/sql/colexec/indexbuild/types.go
+++ b/pkg/sql/colexec/indexbuild/types.go
@@ -74,7 +74,9 @@ func (indexBuild *IndexBuild) Release() {
 }
 
 func (indexBuild *IndexBuild) Reset(proc *process.Process, pipelineFailed bool, err error) {
-	message.FinalizeRuntimeFilter(indexBuild.RuntimeFilterSpec, pipelineFailed, err, proc.GetMessageBoard())
+	runtimeSucced := indexBuild.ctr.state > HandleRuntimeFilter
+
+	message.FinalizeRuntimeFilter(indexBuild.RuntimeFilterSpec, runtimeSucced, proc.GetMessageBoard())
 	indexBuild.ctr.state = ReceiveBatch
 	if indexBuild.ctr.buf != nil {
 		indexBuild.ctr.buf.CleanOnlyData()

--- a/pkg/sql/colexec/shufflebuild/build.go
+++ b/pkg/sql/colexec/shufflebuild/build.go
@@ -98,7 +98,9 @@ func (shuffleBuild *ShuffleBuild) Call(proc *process.Process) (vm.CallResult, er
 				jm.IncRef(1)
 			}
 			message.SendMessage(message.JoinMapMsg{JoinMapPtr: jm, IsShuffle: true, ShuffleIdx: ap.ShuffleIdx, Tag: ap.JoinMapTag}, proc.GetMessageBoard())
+			ctr.state = SendSucceed
 
+		case SendSucceed:
 			result.Batch = nil
 			result.Status = vm.ExecStop
 			analyzer.Output(result.Batch)

--- a/pkg/vm/message/joinMapMsg.go
+++ b/pkg/vm/message/joinMapMsg.go
@@ -259,8 +259,8 @@ func ReceiveJoinMap(tag int32, isShuffle bool, shuffleIdx int32, mb *MessageBoar
 	}
 }
 
-func FinalizeJoinMapMessage(mb *MessageBoard, tag int32, isShuffle bool, shuffleIdx int32, pipelineFailed bool, err error) {
-	if pipelineFailed || err != nil {
+func FinalizeJoinMapMessage(mb *MessageBoard, tag int32, isShuffle bool, shuffleIdx int32, sendMapSucceed bool) {
+	if !sendMapSucceed {
 		SendMessage(JoinMapMsg{JoinMapPtr: nil, IsShuffle: isShuffle, ShuffleIdx: shuffleIdx, Tag: tag}, mb)
 	}
 }

--- a/pkg/vm/message/runtimeFilterMsg.go
+++ b/pkg/vm/message/runtimeFilterMsg.go
@@ -77,9 +77,9 @@ func SendRuntimeFilter(rt RuntimeFilterMessage, m *plan.RuntimeFilterSpec, mb *M
 	}
 }
 
-func FinalizeRuntimeFilter(m *plan.RuntimeFilterSpec, pipelineFailed bool, err error, mb *MessageBoard) {
+func FinalizeRuntimeFilter(m *plan.RuntimeFilterSpec, sendSucceed bool, mb *MessageBoard) {
 	if m != nil {
-		if pipelineFailed || err != nil {
+		if !sendSucceed {
 			var runtimeFilter RuntimeFilterMessage
 			runtimeFilter.Tag = m.Tag
 			runtimeFilter.Typ = RuntimeFilter_DROP


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19665 

## What this PR does / why we need it:
之前的某个pr合入后，pipeline的error信息会往后透传，hashbuild算子不能通过是否传入了error来确定map的归属权。
这块代码后续建议改成类似spool的做法，不再区分情况，统一由发送端进行清理。