### PR TITLE
Revert "not fold prepare parameter twice"

### DIFF
--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -2439,8 +2439,6 @@ func ReplaceFoldExpr(proc *process.Process, expr *Expr, exes *[]colexec.Expressi
 			return false, nil
 		case *plan.Expr_Vec:
 			return false, nil
-		case *plan.Expr_P:
-			return false, nil
 		default:
 			return true, nil
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19678 

## What this PR does / why we need it:
Reverts matrixorigin/matrixone#19666