### PR TITLE
[bug] logtail/stats: do not unsubscribe table before it finished waited

### DIFF
--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -738,6 +738,10 @@ func (e *Engine) cleanMemoryTableWithTable(dbId, tblId uint64) {
 	logutil.Debugf("clean memory table of tbl[dbId: %d, tblId: %d]", dbId, tblId)
 }
 
+func (e *Engine) safeToUnsubscribe(tid uint64) bool {
+	return e.globalStats.safeToUnsubscribe(tid)
+}
+
 func (e *Engine) PushClient() *PushClient {
 	return &e.pClient
 }

--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -947,6 +947,10 @@ func (c *PushClient) unusedTableGCTicker(ctx context.Context) {
 						// never unsubscribe the mo_databases, mo_tables, mo_columns.
 						continue
 					}
+					if !c.eng.safeToUnsubscribe(k) {
+						logutil.Infof("%s table [%d-%d] is not safe to unsubscribe", logTag, v.DBID, k)
+						continue
+					}
 					if !v.LatestTime.After(shouldClean) {
 						if v.SubState != Subscribed {
 							continue

--- a/pkg/vm/engine/disttae/logtail_consumer_test.go
+++ b/pkg/vm/engine/disttae/logtail_consumer_test.go
@@ -32,6 +32,7 @@ func TestSubscribedTable(t *testing.T) {
 		partitions: make(map[[2]uint64]*logtailreplay.Partition),
 		globalStats: &GlobalStats{
 			logtailUpdate: newLogtailUpdate(),
+			waitKeeper:    newWaitKeeper(),
 		},
 	}
 	require.Equal(t, 0, len(subscribeRecord.m))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19653

## What this PR does / why we need it:
do not unsubscribe table before it finished waited, otherwise,
it will never stop waiting for the table's first logtail as it is subscribed.