### PR TITLE
[bug] txn client: push the txn's snapshot ts

### DIFF
--- a/pkg/cnservice/distributed_tae.go
+++ b/pkg/cnservice/distributed_tae.go
@@ -76,6 +76,7 @@ func (s *service) initDistributedTAE(
 			s.cfg.Engine.CNTransferTxnLifespanThreshold),
 	)
 	pu.StorageEngine = s.storeEngine
+	client.SetCacheTSGetter(s.storeEngine)
 
 	// cdc mp
 	if s.cdcMp, err = mpool.NewMPool("cdc", 0, mpool.NoFixed); err != nil {

--- a/pkg/frontend/test/engine_mock.go
+++ b/pkg/frontend/test/engine_mock.go
@@ -455,17 +455,17 @@ func (mr *MockRelDataMockRecorder) AttachTombstones(tombstones interface{}) *gom
 }
 
 // BuildEmptyRelData mocks base method.
-func (m *MockRelData) BuildEmptyRelData() engine.RelData {
+func (m *MockRelData) BuildEmptyRelData(preAllocSize int) engine.RelData {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildEmptyRelData")
+	ret := m.ctrl.Call(m, "BuildEmptyRelData", preAllocSize)
 	ret0, _ := ret[0].(engine.RelData)
 	return ret0
 }
 
 // BuildEmptyRelData indicates an expected call of BuildEmptyRelData.
-func (mr *MockRelDataMockRecorder) BuildEmptyRelData() *gomock.Call {
+func (mr *MockRelDataMockRecorder) BuildEmptyRelData(preAllocSize interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildEmptyRelData", reflect.TypeOf((*MockRelData)(nil).BuildEmptyRelData))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildEmptyRelData", reflect.TypeOf((*MockRelData)(nil).BuildEmptyRelData), preAllocSize)
 }
 
 // DataCnt mocks base method.
@@ -1454,6 +1454,58 @@ func (mr *MockRelationMockRecorder) Write(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockRelation)(nil).Write), arg0, arg1)
 }
 
+// MockBaseReader is a mock of BaseReader interface.
+type MockBaseReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockBaseReaderMockRecorder
+}
+
+// MockBaseReaderMockRecorder is the mock recorder for MockBaseReader.
+type MockBaseReaderMockRecorder struct {
+	mock *MockBaseReader
+}
+
+// NewMockBaseReader creates a new mock instance.
+func NewMockBaseReader(ctrl *gomock.Controller) *MockBaseReader {
+	mock := &MockBaseReader{ctrl: ctrl}
+	mock.recorder = &MockBaseReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockBaseReader) EXPECT() *MockBaseReaderMockRecorder {
+	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockBaseReader) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockBaseReaderMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockBaseReader)(nil).Close))
+}
+
+// Read mocks base method.
+func (m *MockBaseReader) Read(arg0 context.Context, arg1 []string, arg2 *plan.Expr, arg3 *mpool.MPool, arg4 *batch.Batch) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Read", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Read indicates an expected call of Read.
+func (mr *MockBaseReaderMockRecorder) Read(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockBaseReader)(nil).Read), arg0, arg1, arg2, arg3, arg4)
+}
+
 // MockReader is a mock of Reader interface.
 type MockReader struct {
 	ctrl     *gomock.Controller
@@ -1842,6 +1894,20 @@ func (m *MockEngine) Delete(ctx context.Context, databaseName string, op client.
 func (mr *MockEngineMockRecorder) Delete(ctx, databaseName, op interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEngine)(nil).Delete), ctx, databaseName, op)
+}
+
+// GetCacheTS mocks base method.
+func (m *MockEngine) GetCacheTS() timestamp.Timestamp {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCacheTS")
+	ret0, _ := ret[0].(timestamp.Timestamp)
+	return ret0
+}
+
+// GetCacheTS indicates an expected call of GetCacheTS.
+func (mr *MockEngineMockRecorder) GetCacheTS() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCacheTS", reflect.TypeOf((*MockEngine)(nil).GetCacheTS))
 }
 
 // GetMessageCenter mocks base method.

--- a/pkg/frontend/test/txn_mock.go
+++ b/pkg/frontend/test/txn_mock.go
@@ -392,6 +392,18 @@ func (mr *MockTxnClientMockRecorder) Resume() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resume", reflect.TypeOf((*MockTxnClient)(nil).Resume))
 }
 
+// SetCacheTSGetter mocks base method.
+func (m *MockTxnClient) SetCacheTSGetter(t client.CacheTSGetter) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCacheTSGetter", t)
+}
+
+// SetCacheTSGetter indicates an expected call of SetCacheTSGetter.
+func (mr *MockTxnClientMockRecorder) SetCacheTSGetter(t interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCacheTSGetter", reflect.TypeOf((*MockTxnClient)(nil).SetCacheTSGetter), t)
+}
+
 // SyncLatestCommitTS mocks base method.
 func (m *MockTxnClient) SyncLatestCommitTS(arg0 timestamp.Timestamp) {
 	m.ctrl.T.Helper()
@@ -1335,4 +1347,41 @@ func (m *MockWorkspace) UpdateSnapshotWriteOffset() {
 func (mr *MockWorkspaceMockRecorder) UpdateSnapshotWriteOffset() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSnapshotWriteOffset", reflect.TypeOf((*MockWorkspace)(nil).UpdateSnapshotWriteOffset))
+}
+
+// MockCacheTSGetter is a mock of CacheTSGetter interface.
+type MockCacheTSGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockCacheTSGetterMockRecorder
+}
+
+// MockCacheTSGetterMockRecorder is the mock recorder for MockCacheTSGetter.
+type MockCacheTSGetterMockRecorder struct {
+	mock *MockCacheTSGetter
+}
+
+// NewMockCacheTSGetter creates a new mock instance.
+func NewMockCacheTSGetter(ctrl *gomock.Controller) *MockCacheTSGetter {
+	mock := &MockCacheTSGetter{ctrl: ctrl}
+	mock.recorder = &MockCacheTSGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCacheTSGetter) EXPECT() *MockCacheTSGetterMockRecorder {
+	return m.recorder
+}
+
+// GetCacheTS mocks base method.
+func (m *MockCacheTSGetter) GetCacheTS() timestamp.Timestamp {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCacheTS")
+	ret0, _ := ret[0].(timestamp.Timestamp)
+	return ret0
+}
+
+// GetCacheTS indicates an expected call of GetCacheTS.
+func (mr *MockCacheTSGetterMockRecorder) GetCacheTS() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCacheTS", reflect.TypeOf((*MockCacheTSGetter)(nil).GetCacheTS))
 }

--- a/pkg/txn/client/client_test.go
+++ b/pkg/txn/client/client_test.go
@@ -278,5 +278,6 @@ func TestOpenTxnWithWaitPausedDisabled(t *testing.T) {
 	op := &txnOperator{}
 	op.opts.options = op.opts.options.WithDisableWaitPaused()
 
-	require.Error(t, c.openTxn(op))
+	_, err := c.openTxn(op)
+	require.Error(t, err)
 }

--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -530,6 +530,16 @@ func (tc *txnOperator) UpdateSnapshot(
 	return err
 }
 
+// TryPushSnapshot tries to push the snapshot ts byb the cache ts, which is
+// from catalog. If the current snapshot ts is smaller than cache ts, push it.
+func (tc *txnOperator) TryPushSnapshot(cacheTS timestamp.Timestamp) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	if cacheTS.Greater(tc.mu.txn.SnapshotTS) {
+		tc.mu.txn.SnapshotTS = cacheTS
+	}
+}
+
 func (tc *txnOperator) ApplySnapshot(data []byte) error {
 	if !tc.opts.coordinator {
 		tc.logger.Fatal("apply snapshot on non-coordinator txn operator")

--- a/pkg/txn/client/operator_test.go
+++ b/pkg/txn/client/operator_test.go
@@ -650,6 +650,23 @@ func TestBase(t *testing.T) {
 	)
 }
 
+func TestPushSnapshot(t *testing.T) {
+	runOperatorTests(t, func(
+		ctx context.Context,
+		tc *txnOperator,
+		_ *testTxnSender,
+	) {
+		require.NotNil(t, tc.TxnRef())
+		require.Equal(t, tc.Txn().SnapshotTS, tc.SnapshotTS())
+		cacheTS := timestamp.Timestamp{
+			PhysicalTime: 10,
+			LogicalTime:  10,
+		}
+		tc.TryPushSnapshot(cacheTS)
+		require.Equal(t, tc.SnapshotTS(), cacheTS)
+	})
+}
+
 func runOperatorTests(
 	t *testing.T,
 	tc func(context.Context, *txnOperator, *testTxnSender),

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -96,6 +96,12 @@ type TxnClient interface {
 	IterTxns(func(TxnOverview) bool)
 	// GetState returns the current state of txn client.
 	GetState() TxnState
+	// SetCacheTSGetter set the CacheTSGetter to the client.
+	// The CacheTSGetter gets the start ts of catalog. When TN first
+	// starts or restarts, some transactions wait for the TN ready,
+	// the snapshot TS of those transactions should be after the
+	// start ts of catalog.
+	SetCacheTSGetter(t CacheTSGetter)
 }
 
 type TxnState struct {
@@ -337,4 +343,8 @@ func (e TxnEvent) Committed() bool {
 
 func (e TxnEvent) Aborted() bool {
 	return e.Txn.Status == txn.TxnStatus_Aborted
+}
+
+type CacheTSGetter interface {
+	GetCacheTS() timestamp.Timestamp
 }

--- a/pkg/txn/storage/memorystorage/storage_txn_client.go
+++ b/pkg/txn/storage/memorystorage/storage_txn_client.go
@@ -76,6 +76,10 @@ func (s *StorageTxnClient) GetState() client.TxnState {
 	panic("unimplemented")
 }
 
+func (s *StorageTxnClient) SetCacheTSGetter(t client.CacheTSGetter) {
+	panic("unimplemented")
+}
+
 func (s *StorageTxnClient) IterTxns(func(client.TxnOverview) bool) {
 	panic("unimplemented")
 }

--- a/pkg/vm/engine/disttae/cache/catalog.go
+++ b/pkg/vm/engine/disttae/cache/catalog.go
@@ -84,6 +84,12 @@ func (cc *CatalogCache) CanServe(ts types.TS) bool {
 	return ts.GE(&cc.mu.start) && ts.LE(&cc.mu.end)
 }
 
+func (cc *CatalogCache) GetStartTs() types.TS {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	return cc.mu.start
+}
+
 type GCReport struct {
 	TScanItem  int
 	TStaleItem int

--- a/pkg/vm/engine/disttae/db.go
+++ b/pkg/vm/engine/disttae/db.go
@@ -369,6 +369,10 @@ func (e *Engine) GetLatestCatalogCache() *cache.CatalogCache {
 	return e.catalog
 }
 
+func (e *Engine) GetCacheTS() timestamp.Timestamp {
+	return e.catalog.GetStartTs().ToTimestamp()
+}
+
 func requestSnapshotRead(ctx context.Context, tbl *txnTable, snapshot *types.TS) (resp any, err error) {
 	whichTN := func(string) ([]uint64, error) { return nil, nil }
 	payload := func(tnShardID uint64, parameter string, proc *process.Process) ([]byte, error) {

--- a/pkg/vm/engine/entire_engine.go
+++ b/pkg/vm/engine/entire_engine.go
@@ -117,3 +117,7 @@ func (e *EntireEngine) GetMessageCenter() any {
 func (e *EntireEngine) GetService() string {
 	return e.Engine.GetService()
 }
+
+func (e *EntireEngine) GetCacheTS() timestamp.Timestamp {
+	return e.Engine.GetCacheTS()
+}

--- a/pkg/vm/engine/entire_engine_test.go
+++ b/pkg/vm/engine/entire_engine_test.go
@@ -350,6 +350,10 @@ func (e *testEngine) GetService() string {
 	return ""
 }
 
+func (e *testEngine) GetCacheTS() timestamp.Timestamp {
+	return timestamp.Timestamp{}
+}
+
 func (e *testEngine) LatestLogtailAppliedTime() timestamp.Timestamp {
 	return timestamp.Timestamp{}
 }

--- a/pkg/vm/engine/memoryengine/binded.go
+++ b/pkg/vm/engine/memoryengine/binded.go
@@ -120,3 +120,7 @@ func (b *BindedEngine) GetMessageCenter() any {
 func (b *BindedEngine) GetService() string {
 	return b.engine.GetService()
 }
+
+func (b *BindedEngine) GetCacheTS() timestamp.Timestamp {
+	return b.engine.GetCacheTS()
+}

--- a/pkg/vm/engine/memoryengine/engine.go
+++ b/pkg/vm/engine/memoryengine/engine.go
@@ -262,3 +262,7 @@ func getTNServices(cluster clusterservice.MOCluster) []metadata.TNService {
 func (e *Engine) GetMessageCenter() any {
 	return nil
 }
+
+func (e *Engine) GetCacheTS() timestamp.Timestamp {
+	return timestamp.Timestamp{}
+}

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -989,6 +989,8 @@ type Engine interface {
 	GetService() string
 
 	LatestLogtailAppliedTime() timestamp.Timestamp
+
+	GetCacheTS() timestamp.Timestamp
 }
 
 type VectorPool interface {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19247

## What this PR does / why we need it:
If TN is restarted by some reason, we should check the transactions
which are creating. If the snapshot TS is smaller than ts of catalog,
push the snapshot ts.