### PR TITLE
refactor: remove openSysTable 2.0

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -170,6 +170,10 @@ func IsSystemTable(id uint64) bool {
 	return id == MO_DATABASE_ID || id == MO_TABLES_ID || id == MO_COLUMNS_ID
 }
 
+func IsSystemTableByName(name string) bool {
+	return name == MO_DATABASE || name == MO_TABLES || name == MO_COLUMNS
+}
+
 const (
 	// Metrics and Trace related
 
@@ -539,9 +543,10 @@ var (
 		MoDatabaseAllColsString, MO_CATALOG, MO_DATABASE,
 		SystemDBAttr_AccID, SystemDBAttr_Name)
 
+	// exclude mo_catlaog
 	MoDatabaseBatchQuery = fmt.Sprintf(
-		"select %s from `%s`.`%s`",
-		MoDatabaseAllColsString, MO_CATALOG, MO_DATABASE)
+		"select %s from `%s`.`%s` where %s > 1",
+		MoDatabaseAllColsString, MO_CATALOG, MO_DATABASE, SystemDBAttr_ID)
 
 	MoDatabasesInEngineQueryFormat = fmt.Sprintf(
 		"select %s from `%s`.`%s` where %s = %%d",
@@ -585,9 +590,10 @@ var (
 		MoTablesAllColsString, MO_CATALOG, MO_TABLES,
 		SystemRelAttr_AccID, SystemRelAttr_DBName, SystemRelAttr_Name)
 
+	// exclude mo_database mo_tables mo_columns
 	MoTablesBatchQuery = fmt.Sprintf(
-		"select %s from `%s`.`%s`",
-		MoTablesAllColsString, MO_CATALOG, MO_TABLES)
+		"select %s from `%s`.`%s` where %s > 3",
+		MoTablesAllColsString, MO_CATALOG, MO_TABLES, SystemRelAttr_ID)
 
 	MoTablesInDBQueryFormat = fmt.Sprintf(
 		"select %s from `%s`.`%s` where %s = %%d and %s = %%q",
@@ -637,9 +643,10 @@ var (
 		MoColumnsAllColsString, MO_CATALOG, MO_COLUMNS,
 		SystemColAttr_AccID, SystemColAttr_DBName, SystemColAttr_RelName, SystemColAttr_RelID)
 
+	// exclude mo_database mo_tables mo_columns
 	MoColumnsBatchQuery = fmt.Sprintf(
-		"select %s from `%s`.`%s` order by %s, %s, %s",
-		MoColumnsAllColsString, MO_CATALOG, MO_COLUMNS,
+		"select %s from `%s`.`%s` where %s > 3 order by %s, %s, %s",
+		MoColumnsAllColsString, MO_CATALOG, MO_COLUMNS, SystemColAttr_RelID,
 		SystemColAttr_AccID, SystemColAttr_DBName, SystemColAttr_RelName)
 
 	MoColumnsRowidsQueryFormat = fmt.Sprintf(

--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -21,8 +21,6 @@ import (
 	"slices"
 	"sort"
 
-	"go.uber.org/zap"
-
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"

--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -21,6 +21,8 @@ import (
 	"slices"
 	"sort"
 
+	"go.uber.org/zap"
+
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -85,6 +85,10 @@ func (p *PartitionState) LogEntry(entry *api.Entry, msg string) {
 	)
 }
 
+func (p *PartitionState) Desc() string {
+	return fmt.Sprintf("PartitionState(tid:%d) objLen %v, rowsLen %v", p.tid, p.dataObjectsNameIndex.Len(), p.rows.Len())
+}
+
 func (p *PartitionState) HandleLogtailEntry(
 	ctx context.Context,
 	fs fileservice.FileService,

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -764,7 +764,7 @@ func fillTsVecForSysTableQueryBatch(bat *batch.Batch, ts types.TS, m *mpool.MPoo
 
 func isColumnsBatchPerfectlySplitted(bs []*batch.Batch) bool {
 	tidIdx := 1 /*rowid*/ + catalog.MO_COLUMNS_ATT_RELNAME_ID_IDX
-	if len(bs) == 1 {
+	if len(bs) <= 1 {
 		return true
 	}
 	prevTableId := vector.GetFixedAtNoTypeCheck[uint64](bs[0].Vecs[tidIdx], bs[0].RowCount()-1)

--- a/pkg/vm/engine/engine_util/datasource.go
+++ b/pkg/vm/engine/engine_util/datasource.go
@@ -52,6 +52,10 @@ type RemoteDataSource struct {
 	data                engine.RelData
 }
 
+func (rs *RemoteDataSource) String() string {
+	return "RemoteDataSource"
+}
+
 func (rs *RemoteDataSource) Next(
 	_ context.Context,
 	_ []string,

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -78,6 +78,10 @@ func NewBackupDeltaLocDataSource(
 	}
 }
 
+func (d *BackupDeltaLocDataSource) String() string {
+	return "BackupDeltaLocDataSource"
+}
+
 func (d *BackupDeltaLocDataSource) SetTS(
 	ts types.TS,
 ) {

--- a/pkg/vm/engine/test/disttae_engine_test.go
+++ b/pkg/vm/engine/test/disttae_engine_test.go
@@ -1116,3 +1116,27 @@ func TestApplyDeletesForWorkspaceAndPart(t *testing.T) {
 	}
 	require.Equal(t, int16(5 /*2+3*/), pkSum)
 }
+
+func TestCache3Tables(t *testing.T) {
+	opts := config.WithLongScanAndCKPOpts(nil)
+	p := testutil.InitEnginePack(testutil.TestOptions{TaeEngineOptions: opts}, t)
+	defer p.Close()
+	txnop := p.StartCNTxn()
+	dbname, tname, rel, err := p.D.Engine.GetRelationById(p.Ctx, txnop, catalog.MO_DATABASE_ID)
+	require.NoError(t, err)
+	require.Equal(t, catalog.MO_CATALOG, dbname)
+	require.Equal(t, catalog.MO_DATABASE, tname)
+	require.NotNil(t, rel)
+
+	dbname, tname, rel, err = p.D.Engine.GetRelationById(p.Ctx, txnop, catalog.MO_TABLES_ID)
+	require.NoError(t, err)
+	require.Equal(t, catalog.MO_CATALOG, dbname)
+	require.Equal(t, catalog.MO_TABLES, tname)
+	require.NotNil(t, rel)
+
+	dbname, tname, rel, err = p.D.Engine.GetRelationById(p.Ctx, txnop, catalog.MO_COLUMNS_ID)
+	require.NoError(t, err)
+	require.Equal(t, catalog.MO_CATALOG, dbname)
+	require.Equal(t, catalog.MO_COLUMNS, tname)
+	require.NotNil(t, rel)
+}

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -774,6 +774,7 @@ type DataSource interface {
 	SetFilterZM(zm objectio.ZoneMap)
 
 	Close()
+	String() string
 }
 
 type Ranges interface {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #15431 #19787

## What this PR does / why we need it:
- open the three tables like a normal table, sharing the benefits of cache in a txn