### PR TITLE
sql/plan/function: use vector.GetData instead of unsafe.Slice

### DIFF
--- a/pkg/sql/plan/function/func_builtin.go
+++ b/pkg/sql/plan/function/func_builtin.go
@@ -23,7 +23,6 @@ import (
 	"math/rand"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/google/uuid"
 
@@ -1078,7 +1077,7 @@ func builtInHash(parameters []*vector.Vector, result vector.FunctionResultWrappe
 	}
 
 	fillGroupStr := func(keys [][]byte, vec *vector.Vector, n int, sz int, start int) {
-		data := unsafe.Slice(vector.GetPtrAt[byte](vec, 0), (n+start)*sz)
+		data := vec.GetData()[:(n+start)*sz]
 		if !vec.GetNulls().Any() {
 			for i := 0; i < n; i++ {
 				keys[i] = append(keys[i], byte(0))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19807 

## What this PR does / why we need it:
Use vector.GetData to get the data field