### PR TITLE
clean cached un-commit tombstone files when retrying statement.

### DIFF
--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -849,13 +849,7 @@ func (ls *LocalDisttaeDataSource) applyWorkspaceFlushedS3Deletes(
 
 	leftRows = offsets
 
-	s3FlushedDeletes := &ls.table.getTxn().cn_flushed_s3_tombstone_object_stats_list
-	s3FlushedDeletes.RWMutex.Lock()
-	defer s3FlushedDeletes.RWMutex.Unlock()
-
-	if len(s3FlushedDeletes.data) == 0 {
-		return
-	}
+	s3FlushedDeletes := ls.table.getTxn().cn_flushed_s3_tombstone_object_stats_list
 
 	release := func() {}
 	if deletedRows == nil {
@@ -865,24 +859,33 @@ func (ls *LocalDisttaeDataSource) applyWorkspaceFlushedS3Deletes(
 	}
 	defer release()
 
-	var curr int
-	getTombstone := func() (*objectio.ObjectStats, error) {
-		if curr >= len(s3FlushedDeletes.data) {
+	s3FlushedDeletes.Range(func(key, value any) bool {
+		first := true
+		getTombstone := func() (*objectio.ObjectStats, error) {
+			if first {
+				first = false
+				ss := key.(objectio.ObjectStats)
+				return &ss, nil
+			}
+
 			return nil, nil
 		}
-		i := curr
-		curr++
-		return &s3FlushedDeletes.data[i], nil
-	}
 
-	if err = blockio.GetTombstonesByBlockId(
-		ls.ctx,
-		&ls.snapshotTS,
-		bid,
-		getTombstone,
-		deletedRows,
-		ls.fs,
-	); err != nil {
+		if err = blockio.GetTombstonesByBlockId(
+			ls.ctx,
+			&ls.snapshotTS,
+			bid,
+			getTombstone,
+			deletedRows,
+			ls.fs,
+		); err != nil {
+			return false
+		}
+
+		return true
+	})
+
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/vm/engine/disttae/local_disttae_datasource_test.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource_test.go
@@ -16,6 +16,7 @@ package disttae
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -83,7 +84,9 @@ func TestLocalDatasource_ApplyWorkspaceFlushedS3Deletes(t *testing.T) {
 	txnOp, closeFunc := client.NewTestTxnOperator(ctx)
 	defer closeFunc()
 
-	txnOp.AddWorkspace(&Transaction{})
+	txnOp.AddWorkspace(&Transaction{
+		cn_flushed_s3_tombstone_object_stats_list: new(sync.Map),
+	})
 
 	txnDB := txnDatabase{
 		op: txnOp,
@@ -162,6 +165,7 @@ func TestBigS3WorkspaceIterMissingData(t *testing.T) {
 	s3Bat.SetRowCount(8193)
 	s3Bat.SetAttributes([]string{catalog.BlockMeta_MetaLoc, catalog.ObjectMeta_ObjectStats})
 	txn := &Transaction{
+		cn_flushed_s3_tombstone_object_stats_list: new(sync.Map),
 		op:            txnOp,
 		deletedBlocks: &deletedBlocks{},
 		writes: []Entry{

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -1443,6 +1443,7 @@ func (txn *Transaction) CloneSnapshotWS() client.Workspace {
 		cnBlkId_Pos:     map[types.Blockid]Pos{},
 		batchSelectList: make(map[*batch.Batch][]int64),
 		toFreeBatches:   make(map[tableKey][]*batch.Batch),
+		cn_flushed_s3_tombstone_object_stats_list: new(sync.Map),
 	}
 
 	ws.readOnly.Store(true)

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -1125,12 +1125,12 @@ func (txn *Transaction) compactionBlksLocked(ctx context.Context) error {
 func (txn *Transaction) getUncommittedS3Tombstone(
 	appendTo func(stats *objectio.ObjectStats),
 ) (err error) {
-	txn.cn_flushed_s3_tombstone_object_stats_list.RLock()
-	defer txn.cn_flushed_s3_tombstone_object_stats_list.RUnlock()
 
-	for _, stats := range txn.cn_flushed_s3_tombstone_object_stats_list.data {
-		appendTo(&stats)
-	}
+	txn.cn_flushed_s3_tombstone_object_stats_list.Range(func(k, v any) bool {
+		ss := k.(objectio.ObjectStats)
+		appendTo(&ss)
+		return true
+	})
 
 	return nil
 }
@@ -1373,7 +1373,7 @@ func (txn *Transaction) delTransaction() {
 	txn.tableOps = nil
 	txn.databaseMap = nil
 	txn.deletedDatabaseMap = nil
-	txn.cn_flushed_s3_tombstone_object_stats_list.data = nil
+	txn.cn_flushed_s3_tombstone_object_stats_list = nil
 	txn.deletedBlocks = nil
 	txn.haveDDL.Store(false)
 	segmentnames := make([]objectio.Segmentid, 0, len(txn.cnBlkId_Pos)+1)

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -291,10 +291,11 @@ type Transaction struct {
 	// notice that it's guarded by txn.Lock() and has the same lifecycle as transaction.
 	cnBlkId_Pos map[types.Blockid]Pos
 	// committed block belongs to txn's snapshot data -> delta locations for committed block's deletes.
-	cn_flushed_s3_tombstone_object_stats_list struct {
-		sync.RWMutex
-		data []objectio.ObjectStats
-	}
+	cn_flushed_s3_tombstone_object_stats_list *sync.Map
+	//cn_flushed_s3_tombstone_object_stats_list struct {
+	//	sync.RWMutex
+	//	data []objectio.ObjectStats
+	//}
 	//select list for raw batch comes from txn.writes.batch.
 	batchSelectList map[*batch.Batch][]int64
 	toFreeBatches   map[tableKey][]*batch.Batch
@@ -410,6 +411,7 @@ func NewTxnWorkSpace(eng *Engine, proc *process.Process) *Transaction {
 		batchSelectList:      make(map[*batch.Batch][]int64),
 		toFreeBatches:        make(map[tableKey][]*batch.Batch),
 		syncCommittedTSCount: eng.cli.GetSyncLatestCommitTSTimes(),
+		cn_flushed_s3_tombstone_object_stats_list: new(sync.Map),
 	}
 
 	//txn.transfer.workerPool, _ = ants.NewPool(min(runtime.NumCPU(), 4))
@@ -425,11 +427,7 @@ func (txn *Transaction) PutCnBlockDeletes(blockId *types.Blockid, offsets []int6
 }
 
 func (txn *Transaction) StashFlushedTombstones(stats objectio.ObjectStats) {
-	txn.cn_flushed_s3_tombstone_object_stats_list.Lock()
-	defer txn.cn_flushed_s3_tombstone_object_stats_list.Unlock()
-
-	txn.cn_flushed_s3_tombstone_object_stats_list.data =
-		append(txn.cn_flushed_s3_tombstone_object_stats_list.data, stats)
+	txn.cn_flushed_s3_tombstone_object_stats_list.Store(stats, nil)
 }
 
 func (txn *Transaction) Readonly() bool {
@@ -654,6 +652,9 @@ func (txn *Transaction) gcObjs(start int) error {
 
 			for j := range vec.Length() {
 				ss := objectio.ObjectStats(vec.GetBytesAt(j))
+				if txn.writes[i].typ == DELETE {
+					txn.cn_flushed_s3_tombstone_object_stats_list.Delete(ss)
+				}
 				objsName = append(objsName, ss.ObjectName().String())
 			}
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/19863

## What this PR does / why we need it:
clean cached un-commit tombstone files when retrying statement.