### PR TITLE
[Bug]: use load_file() function to load stage data, mo report 'ERROR 20101 (HY000): internal error: Invalid alloc size 7775731712

### DIFF
--- a/pkg/common/mpool/mpool.go
+++ b/pkg/common/mpool/mpool.go
@@ -545,8 +545,8 @@ func sizeToIdx(size int) int {
 func (mp *MPool) Alloc(sz int, offHeap bool) ([]byte, error) {
 	// reject unexpected alloc size.
 	if sz < 0 || sz > GB {
-		logutil.Errorf("Invalid alloc size %d: %s", sz, string(debug.Stack()))
-		return nil, moerr.NewInternalErrorNoCtxf("Invalid alloc size %d", sz)
+		logutil.Errorf("mpool memory allocation exceed limit with requested size %d: %s", sz, string(debug.Stack()))
+		return nil, moerr.NewInternalErrorNoCtxf("mpool memory allocation exceed limit with requested size %d", sz)
 	}
 
 	if sz == 0 {

--- a/pkg/common/mpool/mpool_test.go
+++ b/pkg/common/mpool/mpool_test.go
@@ -21,6 +21,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMPoolLimitExceed(t *testing.T) {
+	m, err := NewMPool("test-mpool-small", 0, 0)
+	require.Nil(t, err)
+
+	_, err = m.Alloc(7775731712, false)
+	require.NotNil(t, err)
+}
+
 func TestMPool(t *testing.T) {
 	m, err := NewMPool("test-mpool-small", 0, 0)
 	require.True(t, err == nil, "new mpool failed %v", err)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18862

## What this PR does / why we need it:

Invalid alloc size is a bad error message.  Message changed to "memory allocation exceed limit with requested size.."
