### PR TITLE
cherry pick 'support pushdown cast expression to block filters for date time type'

### DIFF
--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -3774,7 +3774,7 @@ var supportedDateAndTimeBuiltIns = []FuncNew{
 	// function `date_sub`
 	{
 		functionId: DATE_SUB,
-		class:      plan.Function_STRICT,
+		class:      plan.Function_STRICT | plan.Function_ZONEMAPPABLE,
 		layout:     STANDARD_FUNCTION,
 		checkFn:    fixedTypeMatch,
 

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -640,13 +640,13 @@ func extractColRefInFilter(expr *plan.Expr) *ColRef {
 	switch exprImpl := expr.Expr.(type) {
 	case *plan.Expr_F:
 		switch exprImpl.F.Func.ObjName {
-		case "=", ">", "<", ">=", "<=", "prefix_eq", "between", "in", "prefix_in":
+		case "=", ">", "<", ">=", "<=", "prefix_eq", "between", "in", "prefix_in", "cast":
 			switch e := exprImpl.F.Args[1].Expr.(type) {
-			case *plan.Expr_Lit, *plan.Expr_P, *plan.Expr_V, *plan.Expr_Vec, *plan.Expr_List:
+			case *plan.Expr_Lit, *plan.Expr_P, *plan.Expr_V, *plan.Expr_Vec, *plan.Expr_List, *plan.Expr_T:
 				return extractColRefInFilter(exprImpl.F.Args[0])
 			case *plan.Expr_F:
 				switch e.F.Func.ObjName {
-				case "cast", "serial":
+				case "cast", "serial", "date_sub":
 					return extractColRefInFilter(exprImpl.F.Args[0])
 				}
 				return nil
@@ -1060,6 +1060,16 @@ func ExprIsZonemappable(ctx context.Context, expr *plan.Expr) bool {
 		}
 		if isConst {
 			return true
+		}
+
+		if exprImpl.F.Func.ObjName == "cast" {
+			switch exprImpl.F.Args[0].Typ.Id {
+			case int32(types.T_date), int32(types.T_time), int32(types.T_datetime), int32(types.T_timestamp):
+				if exprImpl.F.Args[1].Typ.Id == int32(types.T_timestamp) {
+					//this cast is monotonic, can safely pushdown to block filters
+					return true
+				}
+			}
 		}
 
 		isZonemappable, _ := function.GetFunctionIsZonemappableById(ctx, exprImpl.F.Func.GetObj())

--- a/test/distributed/cases/optimizer/pushdown.result
+++ b/test/distributed/cases/optimizer/pushdown.result
@@ -132,4 +132,16 @@ c1    c1    c2    c3
 33    33    33    33
 34    34    34    34
 35    35    35    35
+explain select user from system.statement_info where request_at > date_sub(now(), interval 10 second) order by request_at desc limit 1;
+TP QUERY PLAN
+Project
+  ->  Sort
+        Sort Key: statement_info.request_at DESC
+        Limit: 1
+        Send Message: [tag 1 , type MsgTopValue]
+        ->  Table Scan on system.statement_info
+              Sort Key: request_at DESC
+              Filter Cond: (cast(statement_info.request_at AS TIMESTAMP) > date_sub(now(), 10, 2))
+              Block Filter Cond: (cast(statement_info.request_at AS TIMESTAMP) > date_sub(now(), 10, 2))
+              Recv Message: [tag 1 , type MsgTopValue]
 drop database if exists d1;

--- a/test/distributed/cases/optimizer/pushdown.test
+++ b/test/distributed/cases/optimizer/pushdown.test
@@ -33,4 +33,6 @@ prepare s from select * from t1 left join t2 on t1.c1=t2.c1 order by t1.c1 limit
 set @a_var = 5;
 set @b_var = 30;
 execute s using @a_var,@b_var;
+-- @separator:table
+explain select user from system.statement_info where request_at > date_sub(now(), interval 10 second) order by request_at desc limit 1;
 drop database if exists d1;


### PR DESCRIPTION
…(#19922)

support pushdown cast expression to block filters for date time type

Approved by: @m-schen, @heni02, @ouyuanning

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/2761

## What this PR does / why we need it:
cherry pick 'support pushdown cast expression to block filters for date time type'