### PR TITLE
cherry-pick: couple of updates

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -4156,7 +4156,7 @@ func doDropFunction(ctx context.Context, ses *Session, df *tree.DropFunction, rm
 	}
 
 	// authticate db exists
-	dbExists, err = checkDatabaseExistsOrNot(ctx, ses.GetBackgroundExec(ctx), dbName)
+	dbExists, err = checkDatabaseExistsOrNot(ctx, bh, dbName)
 	if err != nil {
 		return err
 	}
@@ -8177,17 +8177,17 @@ func InitFunction(ses *Session, execCtx *ExecCtx, tenant *TenantInfo, cf *tree.C
 		dbName = string(cf.Name.Name.SchemaName)
 	}
 
+	bh := ses.GetBackgroundExec(execCtx.reqCtx)
+	defer bh.Close()
+
 	// authticate db exists
-	dbExists, err = checkDatabaseExistsOrNot(execCtx.reqCtx, ses.GetBackgroundExec(execCtx.reqCtx), dbName)
+	dbExists, err = checkDatabaseExistsOrNot(execCtx.reqCtx, bh, dbName)
 	if err != nil {
 		return err
 	}
 	if !dbExists {
 		return moerr.NewBadDB(execCtx.reqCtx, dbName)
 	}
-
-	bh := ses.GetBackgroundExec(execCtx.reqCtx)
-	defer bh.Close()
 
 	// format return type
 	fmtctx = tree.NewFmtCtx(dialect.MYSQL, tree.WithQuoteString(true))

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -7418,7 +7418,7 @@ func newSes(priv *privilege, ctrl *gomock.Controller) *Session {
 	stubs := gostub.StubFunc(&ExeSqlInBgSes, nil, nil)
 	defer stubs.Reset()
 
-	_ = ses.InitSystemVariables(ctx)
+	_ = ses.InitSystemVariables(ctx, nil)
 
 	rm, _ := NewRoutineManager(ctx, "")
 	rm.baseService = new(MockBaseService)

--- a/pkg/frontend/back_exec.go
+++ b/pkg/frontend/back_exec.go
@@ -519,19 +519,15 @@ var NewBackgroundExec = func(
 }
 
 // ExeSqlInBgSes for mock stub
-var ExeSqlInBgSes = func(reqCtx context.Context, upstream *Session, sql string) ([]ExecResult, error) {
-	return executeSQLInBackgroundSession(reqCtx, upstream, sql)
+var ExeSqlInBgSes = func(reqCtx context.Context, bh BackgroundExec, sql string) ([]ExecResult, error) {
+	return executeSQLInBackgroundSession(reqCtx, bh, sql)
 }
 
 // executeSQLInBackgroundSession executes the sql in an independent session and transaction.
 // It sends nothing to the client.
-func executeSQLInBackgroundSession(reqCtx context.Context, upstream *Session, sql string) ([]ExecResult, error) {
-	bh := NewBackgroundExec(reqCtx, upstream)
-	defer bh.Close()
-
-	upstream.Debugf(reqCtx, "background exec sql:%v", sql)
+func executeSQLInBackgroundSession(reqCtx context.Context, bh BackgroundExec, sql string) ([]ExecResult, error) {
+	bh.ClearExecResultSet()
 	err := bh.Exec(reqCtx, sql)
-	upstream.Debug(reqCtx, "background exec sql done")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/frontend/compiler_context.go
+++ b/pkg/frontend/compiler_context.go
@@ -1024,11 +1024,15 @@ func (tcc *TxnCompilerContext) GetSubscriptionMeta(dbName string, snapshot *plan
 		}
 	}
 
-	return getSubscriptionMeta(tempCtx, dbName, tcc.GetSession(), txn)
+	bh := tcc.execCtx.ses.GetShareTxnBackgroundExec(tempCtx, false)
+	defer bh.Close()
+	return getSubscriptionMeta(tempCtx, dbName, tcc.GetSession(), txn, bh)
 }
 
 func (tcc *TxnCompilerContext) CheckSubscriptionValid(subName, accName, pubName string) error {
-	_, err := checkSubscriptionValidCommon(tcc.GetContext(), tcc.GetSession(), subName, accName, pubName)
+	bh := tcc.execCtx.ses.GetShareTxnBackgroundExec(tcc.GetContext(), false)
+	defer bh.Close()
+	_, err := checkSubscriptionValidCommon(tcc.GetContext(), tcc.GetSession(), subName, accName, pubName, bh)
 	return err
 }
 

--- a/pkg/frontend/mysql_buffer.go
+++ b/pkg/frontend/mysql_buffer.go
@@ -817,3 +817,28 @@ func (c *Conn) Reset() {
 	c.packetInBuf = 0
 	c.loadLocalBuf.freeBuffUnsafe(c.allocator)
 }
+
+var dumpConn = &Conn{}
+
+var ExecuteFuncWithRecover = func(fun func() error) (err error, hasRecovered bool) {
+	return dumpConn.ExecuteFuncWithRecover(fun)
+}
+
+// ExecuteFuncWithRecover executes the function and recover the panic
+func (c *Conn) ExecuteFuncWithRecover(fun func() error) (err error, hasRecovered bool) {
+	defer func() {
+		if rErr := recover(); rErr != nil {
+			hasRecovered = true
+			_, ok := rErr.(*moerr.Error)
+			if !ok {
+				err = errors.Join(err, moerr.ConvertPanicError(context.Background(), rErr))
+			} else {
+				err = errors.Join(err, rErr.(error))
+			}
+		}
+	}()
+	if err = fun(); err != nil {
+		return err, false
+	}
+	return nil, false
+}

--- a/pkg/frontend/mysql_buffer.go
+++ b/pkg/frontend/mysql_buffer.go
@@ -818,14 +818,8 @@ func (c *Conn) Reset() {
 	c.loadLocalBuf.freeBuffUnsafe(c.allocator)
 }
 
-var dumpConn = &Conn{}
-
-var ExecuteFuncWithRecover = func(fun func() error) (err error, hasRecovered bool) {
-	return dumpConn.ExecuteFuncWithRecover(fun)
-}
-
 // ExecuteFuncWithRecover executes the function and recover the panic
-func (c *Conn) ExecuteFuncWithRecover(fun func() error) (err error, hasRecovered bool) {
+func ExecuteFuncWithRecover(fun func() error) (err error, hasRecovered bool) {
 	defer func() {
 		if rErr := recover(); rErr != nil {
 			hasRecovered = true
@@ -838,7 +832,7 @@ func (c *Conn) ExecuteFuncWithRecover(fun func() error) (err error, hasRecovered
 		}
 	}()
 	if err = fun(); err != nil {
-		return err, false
+		return
 	}
-	return nil, false
+	return
 }

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -261,7 +261,7 @@ func Test_mce(t *testing.T) {
 
 		sysVarStubs := gostub.StubFunc(&ExeSqlInBgSes, nil, nil)
 		defer sysVarStubs.Reset()
-		_ = ses.InitSystemVariables(ctx)
+		_ = ses.InitSystemVariables(ctx, nil)
 
 		ctx = context.WithValue(ctx, config.ParameterUnitKey, pu)
 
@@ -435,7 +435,7 @@ func Test_mce_selfhandle(t *testing.T) {
 		})
 		sysVarStubs := gostub.StubFunc(&ExeSqlInBgSes, nil, nil)
 		defer sysVarStubs.Reset()
-		_ = ses.InitSystemVariables(ctx)
+		_ = ses.InitSystemVariables(ctx, nil)
 
 		err = handleCmdFieldList(ses, ec, cflStmt)
 		convey.So(err, convey.ShouldBeNil)
@@ -744,7 +744,7 @@ func Test_handleShowVariables(t *testing.T) {
 
 		sysVarStubs := gostub.StubFunc(&ExeSqlInBgSes, nil, nil)
 		defer sysVarStubs.Reset()
-		_ = ses.InitSystemVariables(ctx)
+		_ = ses.InitSystemVariables(ctx, nil)
 
 		proto.SetSession(ses)
 		ec := newTestExecCtx(ctx, ctrl)

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -1434,7 +1434,9 @@ func (mp *MysqlProtocolImpl) authenticateUser(ctx context.Context, authResponse 
 		//TO Check password
 		if CheckPassword(psw, mp.GetSalt(), authResponse) {
 			ses.Debugf(ctx, "check password succeeded")
-			if err = ses.InitSystemVariables(ctx); err != nil {
+			bh := ses.GetBackgroundExec(ctx)
+			defer bh.Close()
+			if err = ses.InitSystemVariables(ctx, bh); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -186,19 +186,17 @@ func TestKill(t *testing.T) {
 	eng.EXPECT().Hints().Return(engine.Hints{CommitOrRollbackTimeout: time.Second * 10}).AnyTimes()
 
 	txnClient := mock_frontend.NewMockTxnClient(ctrl)
-	txnClient.EXPECT().New(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, commitTS any, options ...any) (client.TxnOperator, error) {
-		wp := newTestWorkspace()
-		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
-		txnOp.EXPECT().Txn().Return(txn.TxnMeta{}).AnyTimes()
-		txnOp.EXPECT().GetWorkspace().Return(wp).AnyTimes()
-		txnOp.EXPECT().Commit(gomock.Any()).Return(nil).AnyTimes()
-		txnOp.EXPECT().Rollback(gomock.Any()).Return(nil).AnyTimes()
-		txnOp.EXPECT().SetFootPrints(gomock.Any(), gomock.Any()).Return().AnyTimes()
-		txnOp.EXPECT().Status().Return(txn.TxnStatus_Active).AnyTimes()
-		txnOp.EXPECT().EnterRunSql().Return().AnyTimes()
-		txnOp.EXPECT().ExitRunSql().Return().AnyTimes()
-		return txnOp, nil
-	}).AnyTimes()
+	txnClient.EXPECT().New(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, commitTS any, options ...any) (client.TxnOperator, error) {
+			txnOp := newTestTxnOp()
+			return txnOp, nil
+		}).AnyTimes()
+	txnClient.EXPECT().RestartTxn(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, txnOp TxnOperator, commitTS any, options ...any) (client.TxnOperator, error) {
+			tTxnOp := txnOp.(*testTxnOp)
+			tTxnOp.meta.Status = txn.TxnStatus_Active
+			return txnOp, nil
+		}).AnyTimes()
 	pu, err := getParameterUnit("test/system_vars_config.toml", eng, txnClient)
 	require.NoError(t, err)
 	pu.SV.SkipCheckUser = true

--- a/pkg/frontend/query_result_test.go
+++ b/pkg/frontend/query_result_test.go
@@ -93,7 +93,7 @@ func newTestSession(t *testing.T, ctrl *gomock.Controller) *Session {
 
 	stubs := gostub.StubFunc(&ExeSqlInBgSes, nil, nil)
 	defer stubs.Reset()
-	_ = ses.InitSystemVariables(context.TODO())
+	_ = ses.InitSystemVariables(context.TODO(), nil)
 	ses.mrs = &MysqlResultSet{}
 
 	return ses

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -261,9 +261,9 @@ func (ses *Session) GetMySQLParser() *mysql.MySQLParser {
 	return &ses.mysqlParser
 }
 
-func (ses *Session) InitSystemVariables(ctx context.Context) (err error) {
+func (ses *Session) InitSystemVariables(ctx context.Context, bh BackgroundExec) (err error) {
 	var sv *SystemVariables
-	if sv, err = GSysVarsMgr.Get(ses.GetTenantInfo().TenantID, ses, ctx); err != nil {
+	if sv, err = GSysVarsMgr.Get(ses.GetTenantInfo().TenantID, ses, ctx, bh); err != nil {
 		return
 	}
 	ses.mu.Lock()
@@ -1151,15 +1151,27 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 		return GetPassWord(HashPassWordWithByte(pwdBytes))
 	}
 
+	bh := ses.GetBackgroundExec(ctx)
+	defer bh.Close()
+
 	//step1 : check tenant exists or not in SYS tenant context
 	ses.timestampMap[TSCheckTenantStart] = time.Now()
 	sysTenantCtx := defines.AttachAccount(ctx, uint32(sysAccountID), uint32(rootID), uint32(moAdminRoleID))
+
+	err = bh.Exec(sysTenantCtx, "begin;")
+	defer func() {
+		err = finishTxn(sysTenantCtx, bh, err)
+	}()
+	if err != nil {
+		return nil, err
+	}
+
 	sqlForCheckTenant, err = getSqlForCheckTenant(sysTenantCtx, tenant.GetTenant())
 	if err != nil {
 		return nil, err
 	}
 	ses.Debugf(ctx, "check tenant %s exists", tenant)
-	rsset, err = executeSQLInBackgroundSession(sysTenantCtx, ses, sqlForCheckTenant)
+	rsset, err = executeSQLInBackgroundSession(sysTenantCtx, bh, sqlForCheckTenant)
 	if err != nil {
 		return nil, err
 	}
@@ -1218,7 +1230,7 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 	if err != nil {
 		return nil, err
 	}
-	userRsset, err = executeSQLInBackgroundSession(tenantCtx, ses, sqlForPasswordOfUser)
+	userRsset, err = executeSQLInBackgroundSession(tenantCtx, bh, sqlForPasswordOfUser)
 	if err != nil {
 		return nil, err
 	}
@@ -1267,7 +1279,7 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 		if err != nil {
 			return nil, err
 		}
-		rsset, err = executeSQLInBackgroundSession(tenantCtx, ses, sqlForCheckRoleExists)
+		rsset, err = executeSQLInBackgroundSession(tenantCtx, bh, sqlForCheckRoleExists)
 		if err != nil {
 			return nil, err
 		}
@@ -1282,7 +1294,7 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 		if err != nil {
 			return nil, err
 		}
-		rsset, err = executeSQLInBackgroundSession(tenantCtx, ses, sqlForRoleOfUser)
+		rsset, err = executeSQLInBackgroundSession(tenantCtx, bh, sqlForRoleOfUser)
 		if err != nil {
 			return nil, err
 		}
@@ -1303,7 +1315,7 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 		ses.Debugf(tenantCtx, "check designated role of user %s.", tenant)
 		//the get name of default_role from mo_role
 		sql := getSqlForRoleNameOfRoleId(defaultRoleID)
-		rsset, err = executeSQLInBackgroundSession(tenantCtx, ses, sql)
+		rsset, err = executeSQLInBackgroundSession(tenantCtx, bh, sql)
 		if err != nil {
 			return nil, err
 		}
@@ -1326,7 +1338,7 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 	}
 
 	// TO Check password
-	if err = ses.InitSystemVariables(tenantCtx); err != nil {
+	if err = ses.InitSystemVariables(tenantCtx, bh); err != nil {
 		return nil, err
 	}
 
@@ -1351,7 +1363,7 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 	if needCheckLock {
 		// get user status, login_attempts, lock_time
 		userLockInfoSql := getLockInfoOfUserSql(tenant.GetUser())
-		userRsset, err = executeSQLInBackgroundSession(tenantCtx, ses, userLockInfoSql)
+		userRsset, err = executeSQLInBackgroundSession(tenantCtx, bh, userLockInfoSql)
 		if err != nil {
 			return nil, err
 		}
@@ -1386,16 +1398,6 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 	}
 
 	// make update user login info in one transaction
-	bh := ses.GetBackgroundExec(tenantCtx)
-	defer bh.Close()
-
-	err = bh.Exec(tenantCtx, "begin;")
-	defer func() {
-		err = finishTxn(tenantCtx, bh, err)
-	}()
-	if err != nil {
-		return nil, err
-	}
 
 	if checkPassword(psw, salt, authResponse) {
 		ses.Debug(tenantCtx, "check password succeeded")
@@ -1410,7 +1412,7 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 
 			if defPwdLife > 0 {
 				userExpiredSql := getExpiredTimeOfUserSql(tenant.GetUser())
-				userRsset, err = executeSQLInBackgroundSession(tenantCtx, ses, userExpiredSql)
+				userRsset, err = executeSQLInBackgroundSession(tenantCtx, bh, userExpiredSql)
 				if err != nil {
 					return nil, err
 				}
@@ -1468,7 +1470,7 @@ func (ses *Session) AuthenticateUser(ctx context.Context, userInput string, dbNa
 	// If the login information contains the database name, verify if the database exists
 	if dbName != "" {
 		ses.timestampMap[TSCheckDbNameStart] = time.Now()
-		_, err = executeSQLInBackgroundSession(tenantCtx, ses, "use `"+dbName+"`")
+		_, err = executeSQLInBackgroundSession(tenantCtx, bh, "use `"+dbName+"`")
 		if err != nil {
 			return nil, err
 		}
@@ -1499,7 +1501,7 @@ func (ses *Session) UpgradeTenant(ctx context.Context, tenantName string, retryC
 	return ses.rm.baseService.UpgradeTenant(ctx, tenantName, retryCount, isALLAccount)
 }
 
-func (ses *Session) getGlobalSysVars(ctx context.Context) (gSysVars map[string]interface{}, err error) {
+func (ses *Session) getGlobalSysVars(ctx context.Context, bh BackgroundExec) (gSysVars map[string]interface{}, err error) {
 	var execResults []ExecResult
 
 	tenantInfo := ses.GetTenantInfo()
@@ -1507,7 +1509,7 @@ func (ses *Session) getGlobalSysVars(ctx context.Context) (gSysVars map[string]i
 	// get system variable from mo_mysql_compatibility mode
 	sqlForGetVariables := getSqlForGetSystemVariablesWithAccount(uint64(tenantInfo.GetTenantID()))
 
-	if execResults, err = ExeSqlInBgSes(tenantCtx, ses, sqlForGetVariables); err != nil {
+	if execResults, err = ExeSqlInBgSes(tenantCtx, bh, sqlForGetVariables); err != nil {
 		return
 	}
 

--- a/pkg/frontend/test/Makefile
+++ b/pkg/frontend/test/Makefile
@@ -1,10 +1,14 @@
 CURRENT_DIR = $(shell pwd)
 
 .PHONY: generate_mock
-generate_mock:
+generate_mock: ../../../pkg/txn/client/types.go ../../../pkg/vm/engine/types.go
 	@go install github.com/golang/mock/mockgen@v1.6.0
 	@echo "Current Directory " $(CURRENT_DIR)
 	@mockgen -source ../../../pkg/txn/client/types.go -package mock_frontend > txn_mock.go
 	@mockgen -source ../../../pkg/vm/engine/types.go -package mock_frontend > engine_mock.go
+
+#tricky
+generate_fe_mock: ../types.go
+	@go install github.com/golang/mock/mockgen@v1.6.0
 	@mockgen -source ../types.go -package mock_frontend > types_mock.go
 

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -28,6 +28,7 @@ import (
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
 	"github.com/matrixorigin/matrixone/pkg/txn/storage/memorystorage"
@@ -235,7 +236,6 @@ func (th *TxnHandler) GetTxnCtx() context.Context {
 
 // invalidateTxnUnsafe releases the txnOp and clears the server status bit SERVER_STATUS_IN_TRANS
 func (th *TxnHandler) invalidateTxnUnsafe() {
-	th.txnOp = nil
 	resetBits(&th.serverStatus, defaultServerStatus)
 	resetBits(&th.optionBits, defaultOptionBits)
 }
@@ -252,7 +252,7 @@ func (th *TxnHandler) inActiveTxnUnsafe() bool {
 	if th.txnOp != nil && th.txnCtx == nil {
 		panic("txnOp != nil and txnCtx == nil")
 	}
-	return th.txnOp != nil && th.txnCtx != nil
+	return th.txnOp != nil && th.txnOp.Txn().Status == txn.TxnStatus_Active && th.txnCtx != nil
 }
 
 // Create starts a new txn.
@@ -411,13 +411,27 @@ func (th *TxnHandler) createTxnOpUnsafe(execCtx *ExecCtx) error {
 		}
 	}
 
-	err, hasRecovered = ExecuteFuncWithRecover(func() error {
-		th.txnOp, err2 = getPu(execCtx.ses.GetService()).TxnClient.New(
-			th.txnCtx,
-			execCtx.ses.getLastCommitTS(),
-			opts...)
-		return err2
-	})
+	txnClient := getPu(execCtx.ses.GetService()).TxnClient
+	if th.txnOp == nil {
+		err, hasRecovered = ExecuteFuncWithRecover(func() error {
+			th.txnOp, err2 = txnClient.New(
+				th.txnCtx,
+				execCtx.ses.getLastCommitTS(),
+				opts...)
+			return err2
+		})
+	} else if th.txnOp.Txn().Status != txn.TxnStatus_Active {
+		err, hasRecovered = ExecuteFuncWithRecover(func() error {
+			_, err2 = txnClient.RestartTxn(
+				th.txnCtx,
+				th.txnOp,
+				execCtx.ses.getLastCommitTS(),
+				opts...)
+			return err2
+		})
+	} else {
+		return moerr.NewInternalError(execCtx.reqCtx, "NewTxnOperator: txn is already active")
+	}
 	if err != nil || hasRecovered {
 		return err
 	}

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -123,9 +123,9 @@ func finishTxnFunc(ses FeSession, execErr error, execCtx *ExecCtx) (err error) {
 				return err
 			}
 			// if commitTxnFunc failed, we will roll back the transaction.
+			// if commit panic, rollback below executed at the second time.
 			execErr = err
 		}
-
 		return rollbackTxnFunc(ses, execErr, execCtx)
 	}
 	return

--- a/pkg/frontend/types.go
+++ b/pkg/frontend/types.go
@@ -187,6 +187,7 @@ const (
 	FPRestartCDC
 	FPResumeCDC
 	FPShowCDC
+	FPCommitUnsafeBeforeRollbackWhenCommitPanic
 )
 
 type (

--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -956,8 +956,8 @@ type GlobalSysVarsMgr struct {
 }
 
 // Get return sys vars of accountId
-func (m *GlobalSysVarsMgr) Get(accountId uint32, ses *Session, ctx context.Context) (*SystemVariables, error) {
-	sysVarsMp, err := ses.getGlobalSysVars(ctx)
+func (m *GlobalSysVarsMgr) Get(accountId uint32, ses *Session, ctx context.Context, bh BackgroundExec) (*SystemVariables, error) {
+	sysVarsMp, err := ses.getGlobalSysVars(ctx, bh)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/19589

https://github.com/matrixorigin/matrixone/issues/18601

https://github.com/matrixorigin/matrixone/issues/19764


## What this PR does / why we need it:

1, 处理rollback,commit,new txn,IncrStatementID,RollbackLastStatement的接口panic
2, 复用txnop的对象。每个前台session只创建一次。
3,
原因：parseStmtExecute可能返回error了。导致prepareStmt为nil. 从prepareStmt取值放到了err判断之前。

修改：从prepareStmt取值放到了err判断之后。

4,

-  修改recover捕获后，err被吞了。
-  修改lint的recover加错的白名单。

5, 改进 后台sql的执行。

