### PR TITLE
[cherry-pick-20025] : Make insert value execute correctly on retry.

### DIFF
--- a/pkg/sql/compile/compile2.go
+++ b/pkg/sql/compile/compile2.go
@@ -343,7 +343,8 @@ func (c *Compile) prepareRetry(defChanged bool) (*Compile, error) {
 			runC.Release()
 		}
 	}()
-	if defChanged {
+	// temporary workaround for issue #20005, will be remove soon
+	if defChanged || true {
 		var pn *plan2.Plan
 		pn, e = c.buildPlanFunc(topContext)
 		if e != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20005 

## What this PR does / why we need it:

目前的valueScanBatch是process级别的, 所以在诸如insert values 的sql重试1次以上的时候, 会因为process被误清除了, 导致valueScan 算子拿不到batch, 从而报错.

临时的解决方案是每次retry的时候都重新构建一遍逻辑计划, 这样会把valueScanBatch给重新生成. 根本的解决方案依赖后续valueScan的重构