### PR TITLE
[enhancement] tn/log: unlimit the RPC message size.

### DIFF
--- a/pkg/logservice/config.go
+++ b/pkg/logservice/config.go
@@ -16,6 +16,7 @@ package logservice
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -46,7 +47,7 @@ const (
 	defaultLogDBBufferSize     = 768 * 1024
 	defaultTruncateInterval    = 10 * time.Second
 	defaultMaxExportedSnapshot = 20
-	defaultMaxMessageSize      = 1024 * 1024 * 100
+	defaultMaxMessageSize      = math.MaxInt32
 	// The default value for HAKeeper truncate interval.
 	defaultHAKeeperTruncateInterval = 24 * time.Hour
 

--- a/pkg/tnservice/cfg.go
+++ b/pkg/tnservice/cfg.go
@@ -16,6 +16,7 @@ package tnservice
 
 import (
 	"context"
+	"math"
 	"path/filepath"
 	"strings"
 	"time"
@@ -67,6 +68,8 @@ var (
 	// Service ports related.
 	defaultServiceHost = "127.0.0.1"
 	defaultTxnMode     = txn.TxnMode_Pessimistic
+	// defaultMaxMessageSize is the default message size of RPC.
+	defaultMaxMessageSize = math.MaxInt32
 )
 
 // Config tn store configuration
@@ -311,6 +314,7 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	c.RPC.MaxMessageSize = toml.ByteSize(defaultMaxMessageSize)
 	c.RPC.Adjust()
 	c.LockService.ServiceID = c.UUID
 	c.LockService.Validate()
@@ -416,6 +420,7 @@ func (c *Config) SetDefaultValue() {
 		c.Txn.IncrementalDedup = strings.ToLower(c.Txn.IncrementalDedup)
 	}
 
+	c.RPC.MaxMessageSize = toml.ByteSize(defaultMaxMessageSize)
 	c.RPC.Adjust()
 	c.LockService.ServiceID = c.UUID
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20031

## What this PR does / why we need it:
unlimit the RPC message size between tn and log.