### PR TITLE
fix: prepare stmt checkTableDefChange should switch to sys account fo…

### DIFF
--- a/pkg/frontend/compiler_context.go
+++ b/pkg/frontend/compiler_context.go
@@ -273,6 +273,19 @@ func (tcc *TxnCompilerContext) GetConfig(varName string, dbName string, tblName 
 	return "", moerr.NewInternalErrorf(tcc.GetContext(), "The variable '%s' is not a valid database level variable", varName)
 }
 
+// for system_metrics.metric and system.statement_info,
+// it is special under the no sys account, should switch into the sys account first.
+func ShouldSwitchToSysAccount(dbName string, tableName string) bool {
+	if dbName == catalog.MO_SYSTEM && tableName == catalog.MO_STATEMENT {
+		return true
+	}
+
+	if dbName == catalog.MO_SYSTEM_METRICS && (tableName == catalog.MO_METRIC || tableName == catalog.MO_SQL_STMT_CU) {
+		return true
+	}
+	return false
+}
+
 // getRelation returns the context (maybe updated) and the relation
 func (tcc *TxnCompilerContext) getRelation(dbName string, tableName string, sub *plan.SubscriptionMeta, snapshot *plan2.Snapshot) (context.Context, engine.Relation, error) {
 	dbName, _, err := tcc.ensureDatabaseIsNotEmpty(dbName, false, snapshot)
@@ -309,13 +322,7 @@ func (tcc *TxnCompilerContext) getRelation(dbName string, tableName string, sub 
 		dbName = sub.DbName
 	}
 
-	//for system_metrics.metric and system.statement_info,
-	//it is special under the no sys account, should switch into the sys account first.
-	if dbName == catalog.MO_SYSTEM && tableName == catalog.MO_STATEMENT {
-		tempCtx = defines.AttachAccountId(tempCtx, uint32(sysAccountID))
-	}
-
-	if dbName == catalog.MO_SYSTEM_METRICS && (tableName == catalog.MO_METRIC || tableName == catalog.MO_SQL_STMT_CU) {
+	if ShouldSwitchToSysAccount(dbName, tableName) {
 		tempCtx = defines.AttachAccountId(tempCtx, uint32(sysAccountID))
 	}
 

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -356,8 +356,12 @@ func initExecuteStmtParam(reqCtx context.Context, ses *Session, cwft *TxnComputa
 	catalogCache := eng.(*disttae.Engine).GetLatestCatalogCache()
 
 	for _, obj := range preparePlan.GetSchemas() {
+		accountId := ses.GetAccountId()
+		if ShouldSwitchToSysAccount(obj.SchemaName, obj.ObjName) {
+			accountId = uint32(sysAccountID)
+		}
 		tblKey := &cache.TableChangeQuery{
-			AccountId:  ses.GetAccountId(),
+			AccountId:  accountId,
 			DatabaseId: uint64(obj.Db),
 			Name:       obj.ObjName,
 			Version:    uint32(obj.Server),

--- a/test/distributed/cases/prepare/prepare.result
+++ b/test/distributed/cases/prepare/prepare.result
@@ -597,3 +597,11 @@ col1    col2
 1    2
 drop database db1;
 drop database db2;
+drop account if exists prepare_acc01;
+create account prepare_acc01 admin_name = 'test_prepare_account' identified by '111';
+create database db1;
+use db1;
+prepare stmt1x from 'select count(*) from system.statement_info limit 0';
+execute stmt1x;
+count(*)
+drop account prepare_acc01;

--- a/test/distributed/cases/prepare/prepare.test
+++ b/test/distributed/cases/prepare/prepare.test
@@ -452,3 +452,17 @@ use db2;
 execute s_pre;
 drop database db1;
 drop database db2;
+
+
+drop account if exists prepare_acc01;
+create account prepare_acc01 admin_name = 'test_prepare_account' identified by '111';
+
+-- @session:id=2&user=prepare_acc01:test_prepare_account&password=111
+create database db1;
+use db1;
+prepare stmt1x from 'select count(*) from system.statement_info limit 0';
+execute stmt1x;
+
+-- @session
+
+drop account prepare_acc01;


### PR DESCRIPTION
…r specail tb

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/20032#issuecomment-2472879805

## What this PR does / why we need it:
cherry-pick
prepare stmt checkTableDefChange should switch to sys account for special table