### PR TITLE
add timeout

### DIFF
--- a/pkg/common/moerr/cause.go
+++ b/pkg/common/moerr/cause.go
@@ -82,6 +82,8 @@ var (
 	CauseMigrate               = NewInternalError(context.Background(), "migrate")
 	CauseCommitUnsafe          = NewInternalError(context.Background(), "commitUnsafe")
 	CauseRollbackUnsafe        = NewInternalError(context.Background(), "rollbackUnsafe")
+	CauseCreateTxnOpUnsafe     = NewInternalError(context.Background(), "createTxnOpUnsafe")
+	CauseCreateUnsafe          = NewInternalError(context.Background(), "createUnsafe")
 	//pkg/hakeeper/task
 	CauseQueryTasks    = NewInternalError(context.Background(), "queryTasks")
 	CauseAllocateTasks = NewInternalError(context.Background(), "allocateTask")

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -170,6 +170,10 @@ var (
 	LargestEntryLimit = 10 * 1024 * 1024
 
 	CNPrimaryCheck atomic.Bool
+
+	defaultCreateTxnOpTimeout = time.Minute
+
+	defaultConnectTimeout = time.Minute
 )
 
 // FrontendParameters of the frontend
@@ -298,6 +302,16 @@ type FrontendParameters struct {
 
 	// KeyEncryptionKey is the key for encrypt key
 	KeyEncryptionKey string `toml:"key-encryption-key"`
+
+	// timeout of create txn.
+	// txnclient.New
+	// txnclient.RestartTxn
+	// engine.New
+	CreateTxnOpTimeout toml.Duration `toml:"createTxnOpTimeout" user_setting:"advanced"`
+
+	// timeout of authenticating user. different from session timeout
+	// including mysql protocol handshake, checking user, loading session variables
+	ConnectTimeout toml.Duration `toml:"connectTimeout" user_setting:"advanced"`
 }
 
 func (fp *FrontendParameters) SetDefaultValues() {
@@ -412,6 +426,14 @@ func (fp *FrontendParameters) SetDefaultValues() {
 
 	if len(fp.KeyEncryptionKey) == 0 {
 		fp.KeyEncryptionKey = "JlxRbXjFGnCsvbsFQSJFvhMhDLaAXq5y"
+	}
+
+	if fp.CreateTxnOpTimeout.Duration == 0 {
+		fp.CreateTxnOpTimeout.Duration = defaultCreateTxnOpTimeout
+	}
+
+	if fp.ConnectTimeout.Duration == 0 {
+		fp.ConnectTimeout.Duration = defaultConnectTimeout
 	}
 }
 

--- a/pkg/frontend/server.go
+++ b/pkg/frontend/server.go
@@ -222,7 +222,8 @@ func (mo *MOServer) handshake(rs *Conn) error {
 		trace.WithKind(trace.SpanKindStatement))
 	defer span.End()
 
-	tempCtx, tempCancel := context.WithTimeoutCause(ctx, getPu(mo.service).SV.SessionTimeout.Duration, moerr.CauseHandshake)
+	//set connect timeout
+	tempCtx, tempCancel := context.WithTimeoutCause(ctx, getPu(mo.service).SV.ConnectTimeout.Duration, moerr.CauseHandshake)
 	defer tempCancel()
 
 	routine := rm.getRoutine(rs)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/20076

## What this PR does / why we need it:

增加超时配置项：

- createTxnOpTimeout New/RestartTxn事务句柄的超时时间。默认值1分钟。

    避免在wait active时死等。

- connectTimeout 用户登录验证超时时间。默认值1分钟。

    避免在验证用户信息时，遇到事务队列满了后，创建事务卡死。
- cn级别的配置。不会相互影响。

用配置项，不用会话变量的原因：会话变量，也要读系统表，然后刷内存变量缓存，也要事务，有鸡生蛋，蛋生鸡的问题。这一点也与泽雄沟通过了。
