### PR TITLE
add a hint in optimizer to skip dedup

### DIFF
--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -159,7 +159,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 	}
 
 	// handle primary/unique key confliction
-	if builder.qry.LoadTag || builder.isRestore {
+	if builder.qry.LoadTag || builder.isRestore || (builder.optimizerHints != nil && builder.optimizerHints.skipDedup == 1) {
 		// load do not handle primary/unique key confliction
 		for i, tableDef := range dmlCtx.tableDefs {
 			idxObjRefs[i] = make([]*plan.ObjectRef, len(tableDef.Indexes))

--- a/pkg/sql/plan/build.go
+++ b/pkg/sql/plan/build.go
@@ -65,6 +65,7 @@ func bindAndOptimizeInsertQuery(ctx CompilerContext, stmt *tree.Insert, isPrepar
 	}()
 
 	builder := NewQueryBuilder(plan.Query_INSERT, ctx, isPrepareStmt, true)
+	builder.parseOptimizeHints()
 	bindCtx := NewBindContext(builder, nil)
 	if IsSnapshotValid(ctx.GetSnapshot()) {
 		bindCtx.snapshot = ctx.GetSnapshot()

--- a/pkg/sql/plan/opt_misc.go
+++ b/pkg/sql/plan/opt_misc.go
@@ -1079,6 +1079,8 @@ func handleOptimizerHints(str string, builder *QueryBuilder) {
 		builder.optimizerHints.disableRightJoin = value
 	case "printShuffle":
 		builder.optimizerHints.printShuffle = value
+	case "skipDedup":
+		builder.optimizerHints.skipDedup = value
 	}
 }
 

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -208,6 +208,7 @@ type OptimizerHints struct {
 	execType                   int
 	disableRightJoin           int
 	printShuffle               int
+	skipDedup                  int
 }
 
 type CTERef struct {

--- a/pkg/sql/plan/utils_test.go
+++ b/pkg/sql/plan/utils_test.go
@@ -95,3 +95,9 @@ func TestInitStageS3Param(t *testing.T) {
 	err = InitStageS3Param(param, s)
 	require.Nil(t, err)
 }
+
+func TestHandleOptimizerHints(t *testing.T) {
+	builder := &QueryBuilder{}
+	handleOptimizerHints("skipDedup=1", builder)
+	require.Equal(t, 1, builder.optimizerHints.skipDedup)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #15768 

## What this PR does / why we need it:
add a hint in optimizer to skip dedup
set session optimizer_hints="skipDedup=1";