### PR TITLE
fix bug: wrong lock type in some case

### DIFF
--- a/pkg/sql/plan/bind_delete.go
+++ b/pkg/sql/plan/bind_delete.go
@@ -440,12 +440,10 @@ func (builder *QueryBuilder) updateLocksOnDemand(nodeID int32) {
 			builder.updateLocksOnDemand(childID)
 		}
 	} else if !node.LockTargets[0].LockTable && node.Stats.Outcnt > float64(lockconfig.MaxLockRowCount) {
-		node.LockTargets[0].LockTable = true
 		logutil.Infof("Row lock upgraded to table lock for SQL : %s", builder.compCtx.GetRootSql())
 		logutil.Infof("the outcnt stats is %f", node.Stats.Outcnt)
-
-		if len(node.LockTargets) > 1 && node.LockTargets[1].IsPartitionTable {
-			node.LockTargets[1].LockTable = true
+		for _, target := range node.LockTargets {
+			target.LockTable = true
 		}
 	}
 }

--- a/pkg/sql/plan/build_util.go
+++ b/pkg/sql/plan/build_util.go
@@ -60,10 +60,8 @@ func reCheckifNeedLockWholeTable(builder *QueryBuilder) {
 			if reCheckIfNeed {
 				logutil.Infof("Row lock upgraded to table lock for SQL : %s", builder.compCtx.GetRootSql())
 				logutil.Infof("the outcnt stats is %f", n.Stats.Outcnt)
-				n.LockTargets[0].LockTable = reCheckIfNeed
-
-				if len(n.LockTargets) > 1 && n.LockTargets[1].IsPartitionTable {
-					n.LockTargets[1].LockTable = true
+				for _, target := range n.LockTargets {
+					target.LockTable = reCheckIfNeed
 				}
 			}
 		}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20066 

## What this PR does / why we need it:
fix bug: wrong lock type in some case。
因为旧的DML一个lock_op只有一个target，新的dml可能会有很多个，当主表是要上表锁的时候，unique key表也应该上表锁，上行锁的话会影响性能