### PR TITLE
Support Crc32(string-type) function.

### DIFF
--- a/pkg/sql/plan/function/function_id.go
+++ b/pkg/sql/plan/function/function_id.go
@@ -103,6 +103,7 @@ const (
 	CORR
 	COS
 	COT
+	CRC32
 	COUNT
 	COUNT_IF
 	COVAR_POP
@@ -565,6 +566,7 @@ var functionIdRegister = map[string]int32{
 	"atan":                           ATAN,
 	"cos":                            COS,
 	"cot":                            COT,
+	"crc32":                          CRC32,
 	"timestamp":                      TIMESTAMP,
 	"database":                       DATABASE,
 	"schema":                         DATABASE,

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -2759,6 +2759,32 @@ var supportedMathBuiltIns = []FuncNew{
 		},
 	},
 
+	// function `crc32`
+	{
+		functionId: CRC32,
+		class:      plan.Function_STRICT,
+		layout:     STANDARD_FUNCTION,
+		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
+			if len(inputs) == 1 && (inputs[0].IsVarlen() || inputs[0].Oid == types.T_any) {
+				return newCheckResultWithSuccess(0)
+			}
+			return newCheckResultWithFailure(failedFunctionParametersWrong)
+		},
+
+		Overloads: []overload{
+			{
+				overloadId: 0,
+				args:       []types.T{types.T_varchar},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_uint32.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return newCrc32ExecContext().builtInCrc32
+				},
+			},
+		},
+	},
+
 	// function `exp`
 	{
 		functionId: EXP,

--- a/test/distributed/cases/function/func_crc32.result
+++ b/test/distributed/cases/function/func_crc32.result
@@ -1,0 +1,16 @@
+SELECT crc32('123');
+crc32(123)
+2286445522
+SELECT crc32(null);
+crc32(null)
+null
+SELECT crc32('123456');
+crc32(123456)
+158520161
+CREATE TABLE crc32test(col1 varchar(100));
+INSERT INTO crc32test VALUES ('123'),(NULL),('123456');
+SELECT crc32(col1) FROM crc32test;
+crc32(col1)
+2286445522
+null
+158520161

--- a/test/distributed/cases/function/func_crc32.sql
+++ b/test/distributed/cases/function/func_crc32.sql
@@ -1,0 +1,6 @@
+SELECT crc32('123');
+SELECT crc32(null);
+SELECT crc32('123456');
+CREATE TABLE crc32test(col1 varchar(100));
+INSERT INTO crc32test VALUES ('123'),(NULL),('123456');
+SELECT crc32(col1) FROM crc32test;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

https://github.com/matrixorigin/matrixone/issues/20121

## What this PR does / why we need it:
支持crc32函数，参数为字符串类型，返回值为uint32。
该函数不支持参数的自动隐式类型转换。