### PR TITLE
fileservice: set global default http client

### DIFF
--- a/pkg/fileservice/http_client.go
+++ b/pkg/fileservice/http_client.go
@@ -36,6 +36,13 @@ var (
 	idleConnTimeout     = 10 * time.Second
 )
 
+func init() {
+	// set global default http client
+	http.DefaultClient = &http.Client{
+		Transport: httpTransport,
+	}
+}
+
 var dnsResolver = dns.NewCachingResolver(
 	nil,
 	dns.MaxCacheEntries(128),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20129

## What this PR does / why we need it:
set global default http client to avoid excessive connections