### PR TITLE
fileservice: set global default http client

### DIFF
--- a/pkg/fileservice/http_client.go
+++ b/pkg/fileservice/http_client.go
@@ -33,7 +33,7 @@ var (
 	maxIdleConns        = 100
 	maxIdleConnsPerHost = 100
 	maxConnsPerHost     = 100
-	idleConnTimeout     = 180 * time.Second
+	idleConnTimeout     = 10 * time.Second
 )
 
 var dnsResolver = dns.NewCachingResolver(
@@ -41,35 +41,38 @@ var dnsResolver = dns.NewCachingResolver(
 	dns.MaxCacheEntries(128),
 )
 
+var httpDialer = &net.Dialer{
+	Timeout:  connectTimeout,
+	Resolver: dnsResolver,
+}
+
+var httpTransport = &http.Transport{
+	DialContext:           httpDialer.DialContext,
+	MaxIdleConns:          maxIdleConns,
+	IdleConnTimeout:       idleConnTimeout,
+	MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+	MaxConnsPerHost:       maxConnsPerHost,
+	TLSHandshakeTimeout:   connectTimeout,
+	ResponseHeaderTimeout: readWriteTimeout,
+	TLSClientConfig: &tls.Config{
+		InsecureSkipVerify: true,
+		RootCAs:            caPool,
+	},
+}
+
+var caPool = func() *x509.CertPool {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		panic(err)
+	}
+	return pool
+}()
+
 func newHTTPClient(args ObjectStorageArguments) *http.Client {
-
-	// dialer
-	dialer := &net.Dialer{
-		Timeout:   connectTimeout,
-		KeepAlive: 5 * time.Second,
-		Resolver:  dnsResolver,
-	}
-
-	// transport
-	transport := &http.Transport{
-		DialContext:           dialer.DialContext,
-		MaxIdleConns:          maxIdleConns,
-		IdleConnTimeout:       idleConnTimeout,
-		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
-		MaxConnsPerHost:       maxConnsPerHost,
-		TLSHandshakeTimeout:   connectTimeout,
-		ResponseHeaderTimeout: readWriteTimeout,
-		//Proxy:                 http.ProxyFromEnvironment,
-		//ForceAttemptHTTP2:     true,
-	}
 
 	// custom certs
 	if len(args.CertFiles) > 0 {
 		// custom certs
-		pool, err := x509.SystemCertPool()
-		if err != nil {
-			panic(err)
-		}
 		for _, path := range args.CertFiles {
 			content, err := os.ReadFile(path)
 			if err != nil {
@@ -82,18 +85,13 @@ func newHTTPClient(args ObjectStorageArguments) *http.Client {
 			logutil.Info("file service: load cert file",
 				zap.Any("path", path),
 			)
-			pool.AppendCertsFromPEM(content)
+			caPool.AppendCertsFromPEM(content)
 		}
-		tlsConfig := &tls.Config{
-			InsecureSkipVerify: true,
-			RootCAs:            pool,
-		}
-		transport.TLSClientConfig = tlsConfig
 	}
 
 	// client
 	client := &http.Client{
-		Transport: transport,
+		Transport: httpTransport,
 	}
 
 	return client

--- a/pkg/fileservice/http_client_test.go
+++ b/pkg/fileservice/http_client_test.go
@@ -1,0 +1,62 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHTTPClient(t *testing.T) {
+
+	curve := elliptic.P384()
+	privateKey, err := ecdsa.GenerateKey(curve, rand.Reader)
+	assert.Nil(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"foo"},
+		},
+		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	assert.Nil(t, err)
+	f, err := os.CreateTemp(t.TempDir(), "*")
+	assert.Nil(t, err)
+	err = pem.Encode(f, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	})
+	assert.Nil(t, err)
+	err = f.Close()
+	assert.Nil(t, err)
+
+	client := newHTTPClient(ObjectStorageArguments{
+		CertFiles: []string{
+			"/file-does-not-exist",
+			f.Name(),
+		},
+	})
+	_ = client
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20129 

## What this PR does / why we need it:
set global HTTP default client to avoid excessive connections