### PR TITLE
fix: skip all system dbs when update pub table list

### DIFF
--- a/pkg/sql/compile/pub_sub.go
+++ b/pkg/sql/compile/pub_sub.go
@@ -17,8 +17,8 @@ package compile
 import (
 	"context"
 	"fmt"
+	"slices"
 
-	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/pubsub"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -28,6 +28,15 @@ import (
 )
 
 const sysAccountId = 0
+
+var sysDatabases = []string{
+	"mo_catalog",
+	"information_schema",
+	"system",
+	"system_metrics",
+	"mysql",
+	"mo_task",
+}
 
 func createSubscription(ctx context.Context, c *Compile, dbName string, subOption *plan.SubscriptionOption) error {
 	accountId, err := defines.GetAccountId(ctx)
@@ -74,8 +83,8 @@ func dropSubscription(ctx context.Context, c *Compile, dbName string) error {
 }
 
 func updatePubTableList(ctx context.Context, c *Compile, dbName, dropTblName string) error {
-	// mo_catalog can't be published, skip
-	if dbName == catalog.MO_CATALOG {
+	// skip system databases
+	if slices.Contains(sysDatabases, dbName) {
 		return nil
 	}
 

--- a/pkg/sql/compile/pub_sub_test.go
+++ b/pkg/sql/compile/pub_sub_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_updatePubTableList(t *testing.T) {
+	err := updatePubTableList(context.Background(), nil, "information_schema", "t1")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20161

## What this PR does / why we need it:
fix: skip all system dbs when update pub table list