### PR TITLE
enable login max-active limit

### DIFF
--- a/pkg/frontend/back_exec.go
+++ b/pkg/frontend/back_exec.go
@@ -564,8 +564,9 @@ var GetComputationWrapperInBack = func(execCtx *ExecCtx, db string, input *UserI
 var NewBackgroundExec = func(
 	reqCtx context.Context,
 	upstream FeSession,
+	opts ...*BackgroundExecOption,
 ) BackgroundExec {
-	return upstream.InitBackExec(nil, "", fakeDataSetFetcher2)
+	return upstream.InitBackExec(nil, "", fakeDataSetFetcher2, opts...)
 }
 
 var NewShareTxnBackgroundExec = func(ctx context.Context, ses FeSession, rawBatch bool) BackgroundExec {
@@ -766,7 +767,7 @@ func (backSes *backSession) initFeSes(
 	return backSes
 }
 
-func (backSes *backSession) InitBackExec(txnOp TxnOperator, db string, callBack outputCallBackFunc) BackgroundExec {
+func (backSes *backSession) InitBackExec(txnOp TxnOperator, db string, callBack outputCallBackFunc, opts ...*BackgroundExecOption) BackgroundExec {
 	if txnOp != nil {
 		if backSes.shareTxnBackExecReused == nil {
 			backSes.shareTxnBackExecReused = &backExec{}
@@ -976,7 +977,7 @@ func (backSes *backSession) GetTenantName() string {
 }
 
 func (backSes *backSession) GetFromRealUser() bool {
-	return false
+	return backSes.fromRealUser
 }
 
 func (backSes *backSession) GetDebugString() string {
@@ -1014,10 +1015,10 @@ func (backSes *backSession) GetSessionSysVar(name string) (interface{}, error) {
 	return nil, nil
 }
 
-func (backSes *backSession) GetBackgroundExec(ctx context.Context) BackgroundExec {
+func (backSes *backSession) GetBackgroundExec(ctx context.Context, opts ...*BackgroundExecOption) BackgroundExec {
 	backSes.EnterFPrint(FPGetBackgroundExecInBackSession)
 	defer backSes.ExitFPrint(FPGetBackgroundExecInBackSession)
-	return NewBackgroundExec(ctx, backSes)
+	return NewBackgroundExec(ctx, backSes, opts...)
 }
 
 func (backSes *backSession) GetStorage() engine.Engine {

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -423,7 +423,7 @@ func (th *TxnHandler) createTxnOpUnsafe(execCtx *ExecCtx) error {
 				tempCtx,
 				execCtx.ses.getLastCommitTS(),
 				opts...)
-			return err2
+			return moerr.AttachCause(tempCtx, err2)
 		})
 	} else if th.txnOp.Txn().Status != txn.TxnStatus_Active {
 		err, hasRecovered = ExecuteFuncWithRecover(func() error {
@@ -432,7 +432,7 @@ func (th *TxnHandler) createTxnOpUnsafe(execCtx *ExecCtx) error {
 				th.txnOp,
 				execCtx.ses.getLastCommitTS(),
 				opts...)
-			return err2
+			return moerr.AttachCause(tempCtx, err2)
 		})
 	} else {
 		return moerr.NewInternalError(execCtx.reqCtx, "NewTxnOperator: txn is already active")

--- a/pkg/frontend/types.go
+++ b/pkg/frontend/types.go
@@ -337,6 +337,10 @@ func execResultArrayHasData(arr []ExecResult) bool {
 	return len(arr) != 0 && arr[0].GetRowCount() != 0
 }
 
+type BackgroundExecOption struct {
+	fromRealUser bool
+}
+
 // BackgroundExec executes the sql in background session without network output.
 type BackgroundExec interface {
 	Close()
@@ -463,7 +467,7 @@ type FeSession interface {
 	GetAccountId() uint32
 	GetTenantInfo() *TenantInfo
 	GetConfig(ctx context.Context, varName, dbName, tblName string) (any, error)
-	GetBackgroundExec(ctx context.Context) BackgroundExec
+	GetBackgroundExec(ctx context.Context, opts ...*BackgroundExecOption) BackgroundExec
 	GetRawBatchBackgroundExec(ctx context.Context) BackgroundExec
 	GetGlobalSysVars() *SystemVariables
 	GetGlobalSysVar(name string) (interface{}, error)
@@ -532,7 +536,7 @@ type FeSession interface {
 	GetStaticTxnInfo() string
 	GetShareTxnBackgroundExec(ctx context.Context, newRawBatch bool) BackgroundExec
 	GetMySQLParser() *mysql.MySQLParser
-	InitBackExec(txnOp TxnOperator, db string, callBack outputCallBackFunc) BackgroundExec
+	InitBackExec(txnOp TxnOperator, db string, callBack outputCallBackFunc, opts ...*BackgroundExecOption) BackgroundExec
 	SessionLogger
 }
 
@@ -678,6 +682,10 @@ type feSessionImpl struct {
 	// Default is false, means that the network connection should be closed.
 	reserveConn bool
 	service     string
+
+	//fromRealUser distinguish the sql that the user inputs from the one
+	//that the internal or background program executes
+	fromRealUser bool
 }
 
 func (ses *feSessionImpl) GetService() string {
@@ -763,6 +771,7 @@ func (ses *feSessionImpl) Reset() {
 		ses.buf = nil
 	}
 	ses.upstream = nil
+	ses.fromRealUser = false
 }
 
 // Clear clean result only


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/20076

## What this PR does / why we need it:

对于max active = 1的测试情况。

原因：用户登录验证时的事务被判定成了非 user txn事务。导致新用户还能登录上，出了一些奇怪的情况。

修改：用户登录验证时的事务改为user txn事务。受max active 的限制。