### PR TITLE
speed up abort all active txn to 2.0

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -1027,3 +1027,7 @@ func (s *service) initProcessCodecService() {
 		),
 	)
 }
+
+func (s *service) GetTxnClient() client.TxnClient {
+	return s._txnClient
+}

--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -83,6 +83,7 @@ type Service interface {
 	GetTimestampWaiter() client.TimestampWaiter
 	GetEngine() engine.Engine
 	GetClock() clock.Clock
+	GetTxnClient() client.TxnClient
 }
 
 type EngineType string

--- a/pkg/sql/compile/compile2.go
+++ b/pkg/sql/compile/compile2.go
@@ -140,12 +140,6 @@ func (c *Compile) Run(_ uint64) (queryResult *util2.RunResult, err error) {
 	c.proc.ResetQueryContext()
 	c.InitPipelineContextToExecuteQuery()
 
-	// record this query to compile service.
-	GetCompileService().recordRunningCompile(c, txnOperator)
-	defer func() {
-		GetCompileService().removeRunningCompile(c, txnOperator)
-	}()
-
 	// check if there is any action to cancel this query.
 	if err = thisQueryStillRunning(c.proc, txnOperator); err != nil {
 		return nil, err

--- a/pkg/sql/compile/compileService.go
+++ b/pkg/sql/compile/compileService.go
@@ -16,9 +16,10 @@ package compile
 
 import (
 	"context"
-	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"sync"
 	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -26,18 +27,6 @@ import (
 	txnClient "github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
-
-// todo: Move it to a CN level structure next day.
-var compileService *ServiceOfCompile
-
-func init() {
-	compileService = InitCompileService()
-	txnClient.SetRunningPipelineManagement(compileService)
-}
-
-func GetCompileService() *ServiceOfCompile {
-	return compileService
-}
 
 // ServiceOfCompile is used to manage the lifecycle of Compile structures,
 // including their creation and deletion.

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -197,12 +197,6 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) error {
 
 		colexec.Get().RecordBuiltPipeline(receiver.clientSession, receiver.messageId, runCompile.proc)
 
-		// running pipeline.
-		GetCompileService().recordRunningCompile(runCompile, runCompile.proc.GetTxnOperator())
-		defer func() {
-			GetCompileService().removeRunningCompile(runCompile, runCompile.proc.GetTxnOperator())
-		}()
-
 		err = s.MergeRun(runCompile)
 		if err == nil {
 			runCompile.GenPhyPlan(runCompile)

--- a/pkg/txn/client/client_test.go
+++ b/pkg/txn/client/client_test.go
@@ -153,41 +153,6 @@ func TestNewTxnWithSnapshotTS(t *testing.T) {
 	assert.Equal(t, txn.TxnStatus_Active, txnMeta.Status)
 }
 
-type fakeRunningPipelinesManager struct{}
-
-func (m *fakeRunningPipelinesManager) PauseService()            {}
-func (m *fakeRunningPipelinesManager) KillAllQueriesWithError() {}
-func (m *fakeRunningPipelinesManager) ResumeService()           {}
-
-func TestTxnClientAbortAllRunningTxn(t *testing.T) {
-	SetRunningPipelineManagement(&fakeRunningPipelinesManager{})
-	rt := runtime.NewRuntime(metadata.ServiceType_CN, "",
-		logutil.GetPanicLogger(),
-		runtime.WithClock(clock.NewHLCClock(func() int64 {
-			return 1
-		}, 0)))
-	runtime.SetupServiceBasedRuntime("", rt)
-
-	c := NewTxnClient("", newTestTxnSender())
-	c.Resume()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	defer cancel()
-	var ops []TxnOperator
-	for i := 0; i < 10; i++ {
-		op, err := c.New(ctx, newTestTimestamp(0))
-		assert.Nil(t, err)
-		ops = append(ops, op)
-	}
-	require.Equal(t, 10, len(c.(*txnClient).mu.activeTxns))
-
-	c.AbortAllRunningTxn()
-	require.Equal(t, 0, len(c.(*txnClient).mu.activeTxns))
-	for _, op := range ops {
-		assert.Equal(t, txn.TxnStatus_Aborted, op.(*txnOperator).mu.txn.Status)
-	}
-}
-
 func TestTxnClientPauseAndResume(t *testing.T) {
 	rt := runtime.NewRuntime(metadata.ServiceType_CN, "",
 		logutil.GetPanicLogger(),

--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -214,6 +214,13 @@ func WithSkipPushClientReady() TxnOption {
 	}
 }
 
+// WithTxnMode set txn mode
+func WithWaitActiveHandle(fn func()) TxnOption {
+	return func(tc *txnOperator) {
+		tc.mu.waitActiveHandle = fn
+	}
+}
+
 type txnOperator struct {
 	sid             string
 	logger          *log.MOLogger
@@ -224,15 +231,16 @@ type txnOperator struct {
 
 	mu struct {
 		sync.RWMutex
-		waitActive   bool
-		closed       bool
-		txn          txn.TxnMeta
-		cachedWrites map[uint64][]txn.TxnRequest
-		lockTables   []lock.LockTable
-		callbacks    map[EventType][]func(TxnEvent)
-		retry        bool
-		lockSeq      uint64
-		waitLocks    map[uint64]Lock
+		waitActive       bool
+		waitActiveHandle func()
+		closed           bool
+		txn              txn.TxnMeta
+		cachedWrites     map[uint64][]txn.TxnRequest
+		lockTables       []lock.LockTable
+		callbacks        map[EventType][]func(TxnEvent)
+		retry            bool
+		lockSeq          uint64
+		waitLocks        map[uint64]Lock
 		//read-only txn operators for supporting snapshot read feature.
 		children []*txnOperator
 		flag     uint32
@@ -336,6 +344,7 @@ func (tc *txnOperator) initReset() {
 
 func (tc *txnOperator) initProtectedFields() {
 	tc.mu.waitActive = false
+	tc.mu.waitActiveHandle = nil
 	tc.mu.closed = false
 	tc.mu.retry = false
 	tc.mu.lockSeq = 0
@@ -404,21 +413,22 @@ func newTxnOperatorWithSnapshot(
 	return tc
 }
 
-func (tc *txnOperator) setWaitActive(v bool) {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-	tc.mu.waitActive = v
-}
-
 func (tc *txnOperator) waitActive(ctx context.Context) error {
 	if tc.reset.waiter == nil {
 		return nil
 	}
 
-	tc.setWaitActive(true)
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	tc.mu.waitActive = true
+	if tc.mu.waitActiveHandle != nil {
+		tc.mu.waitActiveHandle()
+	}
+
 	defer func() {
 		tc.reset.waiter.close()
-		tc.setWaitActive(false)
+		tc.mu.waitActive = false
 	}()
 
 	cost, err := tc.doCostAction(
@@ -427,7 +437,7 @@ func (tc *txnOperator) waitActive(ctx context.Context) error {
 		func() error {
 			return tc.reset.waiter.wait(ctx)
 		},
-		false)
+		true)
 	tc.reset.waitActiveCost = cost
 	v2.TxnWaitActiveDurationHistogram.Observe(cost.Seconds())
 	return err

--- a/pkg/util/executor/options.go
+++ b/pkg/util/executor/options.go
@@ -192,6 +192,11 @@ func (opts Options) WithDisableWaitPaused() Options {
 	return opts
 }
 
+func (opts Options) WithUserTxn() Options {
+	opts.txnOpts = append(opts.txnOpts, client.WithUserTxn())
+	return opts
+}
+
 func (opts Options) ExtraTxnOptions() []client.TxnOption {
 	return opts.txnOpts
 }

--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -1237,6 +1237,12 @@ func (c *PushClient) isNotUnsubscribing(ctx context.Context, dbId, tblId uint64)
 	return true, Subscribing, nil
 }
 
+func (c *PushClient) Disconnect() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.subscriber.logTailClient.Close()
+}
+
 func (s *subscribedTable) setTableSubscribed(dbId, tblId uint64) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue [#4436](https://github.com/matrixorigin/MO-Cloud/issues/4436)

## What this PR does / why we need it:
Speed up abort all active txn when logtail disconnected