### PR TITLE
[bug] logtail consumer: do not panic, just retry to do it again.

### DIFF
--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -874,7 +874,9 @@ func (c *PushClient) connect(ctx context.Context, e *Engine) {
 		c.waitTimestamp()
 
 		if err := c.replayCatalogCache(ctx, e); err != nil {
-			panic(err)
+			c.pause(false)
+			logutil.Errorf("%s replay catalog cache failed, err %v", logTag, err)
+			continue
 		}
 
 		e.setPushClientStatus(true)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20318

## What this PR does / why we need it:
do not panic if replayCatalogCache() returns error, just retry to call it.