### PR TITLE
fix system.SetGoMaxProcs(0) case in 2.0-dev

### DIFF
--- a/pkg/common/system/system.go
+++ b/pkg/common/system/system.go
@@ -119,9 +119,17 @@ func GoMaxProcs() int {
 
 // SetGoMaxProcs
 // co-operate with pkg/cnservice/service.handleGoMaxProcs
-func SetGoMaxProcs(n int) int {
-	goMaxProcs.Store(int32(n))
-	return runtime.GOMAXPROCS(n)
+func SetGoMaxProcs(n int) (ret int) {
+	ret = runtime.GOMAXPROCS(n)
+	if n < 1 {
+		// fix https://github.com/matrixorigin/MO-Cloud/issues/4486
+		goMaxProcs.Store(int32(ret))
+		logutil.Infof("call runtime.GOMAXPROCS(%d): %d, keep: %d", n, ret, ret)
+	} else {
+		goMaxProcs.Store(int32(n))
+		logutil.Infof("call runtime.GOMAXPROCS(%d): %d, keep: %d", n, ret, n)
+	}
+	return ret
 }
 
 func runWithContainer(stopper *stopper.Stopper) {

--- a/pkg/common/system/system_test.go
+++ b/pkg/common/system/system_test.go
@@ -78,3 +78,52 @@ func Benchmark_GoRutinues(b *testing.B) {
 		}
 	})
 }
+
+// TestSetGoMaxProcs
+// ut for https://github.com/matrixorigin/MO-Cloud/issues/4486
+func TestSetGoMaxProcs(t *testing.T) {
+	// init
+	initMaxProcs := runtime.GOMAXPROCS(0)
+	type args struct {
+		n int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantRet int
+		wantGet int
+	}{
+		{
+			name: "normal",
+			args: args{
+				n: 5,
+			},
+			wantRet: initMaxProcs,
+			wantGet: 5,
+		},
+		{
+			name: "zero",
+			args: args{
+				n: 0,
+			},
+			wantRet: 5,
+			wantGet: 5,
+		},
+		{
+			name: "nagetive",
+			args: args{
+				n: -1,
+			},
+			wantRet: 5,
+			wantGet: 5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SetGoMaxProcs(tt.args.n)
+			require.Equal(t, tt.wantRet, got)
+			gotQuery := GoMaxProcs()
+			require.Equal(t, tt.wantGet, gotQuery)
+		})
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4486
cherry-pick: https://github.com/matrixorigin/matrixone/pull/20365

## What this PR does / why we need it:
fix calling system.SetGoMaxProcs(0), should store the return value of `runtime.GOMAXPROCS(n)`