### PR TITLE
fifocache: restore old queue1 size for data cache and metadata cache

### DIFF
--- a/pkg/fileservice/fifocache/data_cache.go
+++ b/pkg/fileservice/fifocache/data_cache.go
@@ -36,7 +36,7 @@ func NewDataCache(
 ) *DataCache {
 	return &DataCache{
 		fifo: New(capacity, shardCacheKey, postSet, postGet, postEvict, func(capacity int64) int64 {
-			return capacity / 5
+			return capacity / 10
 		}),
 	}
 }

--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -136,7 +136,7 @@ func newMetaCache(capacity fscache.CapacityFunc) *fifocache.Cache[mataCacheKey, 
 			capacityBytes.Set(float64(capacity()))
 		},
 		func(capacity int64) int64 {
-			return capacity / 5
+			return capacity / 10
 		},
 	)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20364 

## What this PR does / why we need it:
use old queue1 size. 