### PR TITLE
fix ut panic

### DIFF
--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -524,7 +524,7 @@ func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, er
 			if pu != nil {
 				time.Sleep(time.Duration(pu.SV.KillRountinesInterval) * time.Second)
 			} else {
-				time.Sleep(time.Duration(10) * time.Second)
+				break
 			}
 		}
 	}()

--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -520,7 +520,12 @@ func NewRoutineManager(ctx context.Context, service string) (*RoutineManager, er
 			default:
 			}
 			rm.KillRoutineConnections()
-			time.Sleep(time.Duration(time.Duration(getPu(rm.service).SV.KillRountinesInterval) * time.Second))
+			pu := getPu(rm.service)
+			if pu != nil {
+				time.Sleep(time.Duration(pu.SV.KillRountinesInterval) * time.Second)
+			} else {
+				time.Sleep(time.Duration(10) * time.Second)
+			}
 		}
 	}()
 

--- a/pkg/frontend/routine_manager.go
+++ b/pkg/frontend/routine_manager.go
@@ -408,9 +408,12 @@ func (rm *RoutineManager) cleanKillQueue() {
 	ar := rm.accountRoutine
 	ar.killQueueMu.Lock()
 	defer ar.killQueueMu.Unlock()
-	for toKillAccount, killRecord := range ar.killIdQueue {
-		if time.Since(killRecord.killTime) > time.Duration(getPu(rm.service).SV.CleanKillQueueInterval)*time.Minute {
-			delete(ar.killIdQueue, toKillAccount)
+	pu := getPu(rm.service)
+	if pu != nil {
+		for toKillAccount, killRecord := range ar.killIdQueue {
+			if time.Since(killRecord.killTime) > time.Duration(pu.SV.CleanKillQueueInterval)*time.Minute {
+				delete(ar.killIdQueue, toKillAccount)
+			}
 		}
 	}
 }

--- a/pkg/frontend/routine_manager_test.go
+++ b/pkg/frontend/routine_manager_test.go
@@ -230,8 +230,10 @@ func Test_rm(t *testing.T) {
 	pu.SV.SkipCheckUser = true
 	pu.SV.KillRountinesInterval = 1
 	setPu("", pu)
-	_, err = NewRoutineManager(context.Background(), "")
+	rm, err := NewRoutineManager(context.Background(), "")
 	assert.NoError(t, err)
+	rm.cleanKillQueue()
 	setPu("", nil)
 	time.Sleep(2 * time.Second)
+	rm.cancelCtx()
 }

--- a/pkg/frontend/routine_manager_test.go
+++ b/pkg/frontend/routine_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -218,4 +219,19 @@ func TestRoutineManager_killClients(t *testing.T) {
 			rm.killNetConns()
 		})
 	}
+}
+
+func Test_rm(t *testing.T) {
+	sv, err := getSystemVariables("test/system_vars_config.toml")
+	if err != nil {
+		t.Error(err)
+	}
+	pu := config.NewParameterUnit(sv, nil, nil, nil)
+	pu.SV.SkipCheckUser = true
+	pu.SV.KillRountinesInterval = 1
+	setPu("", pu)
+	_, err = NewRoutineManager(context.Background(), "")
+	assert.NoError(t, err)
+	setPu("", nil)
+	time.Sleep(2 * time.Second)
 }


### PR DESCRIPTION
update

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/20390

## What this PR does / why we need it:

修改panic. 前面的ut中启动的RM,但是UT 退出后。后台线程没退出。