### PR TITLE
Fix cuio calculated result as float64 val 

### DIFF
--- a/pkg/sql/plan/function/func_builtin.go
+++ b/pkg/sql/plan/function/func_builtin.go
@@ -2455,10 +2455,10 @@ func buildInMOCUWithCfg(parameters []*vector.Vector, result vector.FunctionResul
 		case "mem":
 			cu = motrace.CalculateCUMem(int64(stats.GetMemorySize()), durationNS, cfg)
 		case "ioin":
-			cu = motrace.CalculateCUIOIn(int64(stats.GetS3IOInputCount()), cfg) +
+			cu = motrace.CalculateCUIOIn(stats.GetS3IOInputCount(), cfg) +
 				motrace.CalculateCUIODelete(stats.GetS3IODeleteCount(), cfg)
 		case "ioout":
-			cu = motrace.CalculateCUIOOut(int64(stats.GetS3IOOutputCount()), cfg) +
+			cu = motrace.CalculateCUIOOut(stats.GetS3IOOutputCount(), cfg) +
 				motrace.CalculateCUIOList(stats.GetS3IOListCount(), cfg)
 		case "iolist":
 			cu = motrace.CalculateCUIOList(stats.GetS3IOListCount(), cfg)

--- a/pkg/util/trace/impl/motrace/cu.go
+++ b/pkg/util/trace/impl/motrace/cu.go
@@ -135,18 +135,18 @@ func CalculateCUMemDecimal(memByte, durationNS int64, memPrice, cuUnit float64) 
 	return types.Decimal256ToFloat64(val1, cuScale), nil
 }
 
-func CalculateCUIOIn(ioCnt int64, cfg *config.OBCUConfig) float64 {
+func CalculateCUIOIn(ioCnt float64, cfg *config.OBCUConfig) float64 {
 	if cfg == nil {
 		cfg = GetCUConfig()
 	}
-	return float64(ioCnt) * cfg.IoInPrice / cfg.CUUnit
+	return ioCnt * cfg.IoInPrice / cfg.CUUnit
 }
 
-func CalculateCUIOOut(ioCnt int64, cfg *config.OBCUConfig) float64 {
+func CalculateCUIOOut(ioCnt float64, cfg *config.OBCUConfig) float64 {
 	if cfg == nil {
 		cfg = GetCUConfig()
 	}
-	return float64(ioCnt) * cfg.IoOutPrice / cfg.CUUnit
+	return ioCnt * cfg.IoOutPrice / cfg.CUUnit
 }
 
 func CalculateCUIOList(ioCnt float64, cfg *config.OBCUConfig) float64 {

--- a/pkg/util/trace/impl/motrace/cu_bench_test.go
+++ b/pkg/util/trace/impl/motrace/cu_bench_test.go
@@ -15,10 +15,11 @@
 package motrace
 
 import (
-	"github.com/matrixorigin/matrixone/pkg/config"
-	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace/statistic"
 	"testing"
 	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/config"
+	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace/statistic"
 )
 
 // BenchmarkCalculateMem
@@ -229,8 +230,8 @@ func BenchmarkCalculateElem(b *testing.B) {
 		b.Run(bm.name+"/io", func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = CalculateCUIOIn(int64(bm.args.stats.GetS3IOInputCount()), bm.args.cfg)
-				_ = CalculateCUIOOut(int64(bm.args.stats.GetS3IOOutputCount()), bm.args.cfg)
+				_ = CalculateCUIOIn(bm.args.stats.GetS3IOInputCount(), bm.args.cfg)
+				_ = CalculateCUIOOut(bm.args.stats.GetS3IOOutputCount(), bm.args.cfg)
 			}
 		})
 	}

--- a/test/distributed/cases/log/query_cu.result
+++ b/test/distributed/cases/log/query_cu.result
@@ -45,3 +45,12 @@ val
 select CAST(mo_cu('[5,1,2,3,4,5,6,7,8,1,2]', 0, 'iodelete') AS DECIMAL(32,4)) val;
 val
 11.3097
+select CAST(mo_cu('[5,1,2,0.000122,4,5,6,7,8,1,2]', 0, 'ioin') AS DECIMAL(32,4)) val;
+val
+11.3104
+select CAST(mo_cu('[5,1,2,0.000122,4,5,6,7,8,0,0]', 0, 'ioin') AS DECIMAL(32,4)) val;
+val
+0.0007
+select CAST(mo_cu('[5,1,2,0.000244,4,5,6,7,8,0,0]', 0, 'ioin') AS DECIMAL(32,4)) val;
+val
+0.0014

--- a/test/distributed/cases/log/query_cu.sql
+++ b/test/distributed/cases/log/query_cu.sql
@@ -22,5 +22,7 @@ select mo_cu('[4,1,2,3,4,5,6,7,8]', 0, 'iolist') val;
 select CAST(mo_cu('[5,1,2,3,4,5,6,7,8,1,2]', 0, 'iolist') AS DECIMAL(32,4)) val;
 select CAST(mo_cu('[5,1,2,3,4,5,6,7,8,1,2]', 0, 'iodelete') AS DECIMAL(32,4)) val;
 -- issue moc-4510
+-- cu_ioin = 0.000122 * 5.67e-06 / 1.002678e-06 ~= 0.0007
 select CAST(mo_cu('[5,1,2,0.000122,4,5,6,7,8,1,2]', 0, 'ioin') AS DECIMAL(32,4)) val;
-select CAST(mo_cu('[5,1,2,0.000244,4,5,6,7,8,1,2]', 0, 'ioin') AS DECIMAL(32,4)) val;
+select CAST(mo_cu('[5,1,2,0.000122,4,5,6,7,8,0,0]', 0, 'ioin') AS DECIMAL(32,4)) val;
+select CAST(mo_cu('[5,1,2,0.000244,4,5,6,7,8,0,0]', 0, 'ioin') AS DECIMAL(32,4)) val;

--- a/test/distributed/cases/log/query_cu.sql
+++ b/test/distributed/cases/log/query_cu.sql
@@ -21,3 +21,6 @@ select mo_cu('[4,1,2,3,4,5,6,7,8]', 0, 'iolist') val;
 --    10 | delete
 select CAST(mo_cu('[5,1,2,3,4,5,6,7,8,1,2]', 0, 'iolist') AS DECIMAL(32,4)) val;
 select CAST(mo_cu('[5,1,2,3,4,5,6,7,8,1,2]', 0, 'iodelete') AS DECIMAL(32,4)) val;
+-- issue moc-4510
+select CAST(mo_cu('[5,1,2,0.000122,4,5,6,7,8,1,2]', 0, 'ioin') AS DECIMAL(32,4)) val;
+select CAST(mo_cu('[5,1,2,0.000244,4,5,6,7,8,1,2]', 0, 'ioin') AS DECIMAL(32,4)) val;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4510

cherry-pick https://github.com/matrixorigin/matrixone/pull/20420

## What this PR does / why we need it:
fix s3ioinput as float64 value while do cu calculation.