### PR TITLE
quick return if has no tombstone in WorkspaceS3FlushedDeletes

### DIFF
--- a/pkg/vm/engine/tae/blockio/utils.go
+++ b/pkg/vm/engine/tae/blockio/utils.go
@@ -108,18 +108,25 @@ func GetTombstonesByBlockId(
 		skipObjectCnt      int
 		totalBlkCnt        int
 	)
+
 	if tombstoneObjectCnt, skipObjectCnt, totalBlkCnt, err = CheckTombstoneFile(
 		ctx, blockId[:], getTombstoneFileFn, onBlockSelectedFn, fs,
 	); err != nil {
 		return
 	}
 
-	v2.TxnReaderEachBLKLoadedTombstoneHistogram.Observe(float64(loadedBlkCnt))
-	v2.TxnReaderScannedTotalTombstoneHistogram.Observe(float64(tombstoneObjectCnt))
+	if loadedBlkCnt > 0 {
+		v2.TxnReaderEachBLKLoadedTombstoneHistogram.Observe(float64(loadedBlkCnt))
+	}
+
 	if tombstoneObjectCnt > 0 {
+		v2.TxnReaderScannedTotalTombstoneHistogram.Observe(float64(tombstoneObjectCnt))
+	}
+
+	if tombstoneObjectCnt > 0 && skipObjectCnt > 0 {
 		v2.TxnReaderTombstoneZMSelectivityHistogram.Observe(float64(skipObjectCnt) / float64(tombstoneObjectCnt))
 	}
-	if totalBlkCnt > 0 {
+	if totalBlkCnt > 0 && loadedBlkCnt > 0 {
 		v2.TxnReaderTombstoneBLSelectivityHistogram.Observe(float64(loadedBlkCnt) / float64(totalBlkCnt))
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/20443

## What this PR does / why we need it:

quick return if has no tombstone in `WorkspaceS3FlushedDeletes`