### PR TITLE
chore: cu price allow 0

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -910,33 +910,33 @@ func (c *OBCUConfig) SetDefaultValues() {
 	if c.CUUnit <= 0 {
 		c.CUUnit = CUUnitDefault
 	}
-	if c.CpuPrice <= 0 {
+	if c.CpuPrice < 0 {
 		c.CpuPrice = CUCpuPriceDefault
 	}
-	if c.MemPrice <= 0 {
+	if c.MemPrice < 0 {
 		c.MemPrice = CUMemPriceDefault
 	}
-	if c.IoInPrice <= 0 {
+	if c.IoInPrice < 0 {
 		c.IoInPrice = CUIOInPriceDefault
 	}
-	if c.IoOutPrice <= 0 {
+	if c.IoOutPrice < 0 {
 		c.IoOutPrice = CUIOOutPriceDefault
 	}
 	// default as c.IoInPrice
-	if c.IoListPrice <= 0 {
+	if c.IoListPrice < 0 {
 		c.IoListPrice = c.IoInPrice
 	}
 	// default as c.IoInPrice, allow value: 0
 	if c.IoDeletePrice < 0 {
 		c.IoDeletePrice = c.IoInPrice
 	}
-	if c.TrafficPrice0 <= 0 {
+	if c.TrafficPrice0 < 0 {
 		c.TrafficPrice0 = CUTrafficPrice0Default
 	}
-	if c.TrafficPrice1 <= 0 {
+	if c.TrafficPrice1 < 0 {
 		c.TrafficPrice1 = CUTrafficPrice1Default
 	}
-	if c.TrafficPrice2 <= 0 {
+	if c.TrafficPrice2 < 0 {
 		c.TrafficPrice2 = CUTrafficPrice2Default
 	}
 }

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -242,3 +242,85 @@ func TestObservabilityParameters_SetDefaultValues1(t *testing.T) {
 		})
 	}
 }
+
+func TestOBCUConfig_SetDefaultValues(t *testing.T) {
+	type fields struct {
+		CUUnit        float64
+		CpuPrice      float64
+		MemPrice      float64
+		IoInPrice     float64
+		IoOutPrice    float64
+		IoListPrice   float64
+		IoDeletePrice float64
+		TrafficPrice0 float64
+		TrafficPrice1 float64
+		TrafficPrice2 float64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   OBCUConfig
+	}{
+		{
+			name:   "Price_set_0",
+			fields: fields{},
+			want: OBCUConfig{
+				CUUnit:        CUUnitDefault,
+				CpuPrice:      0,
+				MemPrice:      0,
+				IoInPrice:     0,
+				IoOutPrice:    0,
+				IoListPrice:   0,
+				IoDeletePrice: 0,
+				TrafficPrice0: 0,
+				TrafficPrice1: 0,
+				TrafficPrice2: 0,
+			},
+		},
+		{
+			name: "Price_set_negative",
+			fields: fields{
+				CUUnit:        -1,
+				CpuPrice:      -1,
+				MemPrice:      -1,
+				IoInPrice:     -1,
+				IoOutPrice:    -1,
+				IoListPrice:   -1,
+				IoDeletePrice: -1,
+				TrafficPrice0: -1,
+				TrafficPrice1: -1,
+				TrafficPrice2: -1,
+			},
+			want: OBCUConfig{
+				CUUnit:        CUUnitDefault,
+				CpuPrice:      CUCpuPriceDefault,
+				MemPrice:      CUMemPriceDefault,
+				IoInPrice:     CUIOInPriceDefault,
+				IoOutPrice:    CUIOOutPriceDefault,
+				IoListPrice:   CUIOInPriceDefault, // default as ioin price.
+				IoDeletePrice: CUIOInPriceDefault,
+				TrafficPrice0: CUTrafficPrice0Default,
+				TrafficPrice1: CUTrafficPrice0Default,
+				TrafficPrice2: CUTrafficPrice0Default,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &OBCUConfig{
+				CUUnit:        tt.fields.CUUnit,
+				CpuPrice:      tt.fields.CpuPrice,
+				MemPrice:      tt.fields.MemPrice,
+				IoInPrice:     tt.fields.IoInPrice,
+				IoOutPrice:    tt.fields.IoOutPrice,
+				IoListPrice:   tt.fields.IoListPrice,
+				IoDeletePrice: tt.fields.IoDeletePrice,
+				TrafficPrice0: tt.fields.TrafficPrice0,
+				TrafficPrice1: tt.fields.TrafficPrice1,
+				TrafficPrice2: tt.fields.TrafficPrice2,
+			}
+			c.SetDefaultValues()
+			require.Equal(t, tt.want, *c)
+		})
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4524

cherry-pick https://github.com/matrixorigin/matrixone/pull/20481

## What this PR does / why we need it:
fix the configuration `SetDefaultValues` logic, allow the price = 0