### PR TITLE
optimization of the reader Equal filter.

### DIFF
--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -985,6 +985,14 @@ func (ls *LocalDisttaeDataSource) applyPStateInMemDeletes(
 
 	leftRows = offsets
 
+	if len(leftRows) == logtailreplay.IndexScaleOne {
+		if ls.pState.CheckRowIdDeletedInMem(ls.snapshotTS, *types.NewRowid(bid, uint32(offsets[0]))) {
+			return nil
+		}
+
+		return leftRows
+	}
+
 	delIter, fastReturn := ls.getInMemDelIter(bid, len(offsets))
 	if fastReturn {
 		return leftRows

--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -349,6 +349,10 @@ func (ls *LocalDisttaeDataSource) Next(
 			return
 
 		case engine.Persisted:
+			// if satisfies:
+			//	  1. pk equal
+			//    2. already found one row
+			// then skip all the following blocks
 			if ok1, ok2 := ls.memPKFilter.Exact(); ok1 && ok2 {
 				state = engine.End
 				return
@@ -692,6 +696,7 @@ func (ls *LocalDisttaeDataSource) filterInMemCommittedInserts(
 	}
 
 	if outBatch.RowCount()-inputRowCnt == 1 {
+		// found one row in InMemCommitted for the pk equal, record it
 		ls.memPKFilter.RecordExactHit()
 	}
 

--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -943,6 +943,7 @@ func (ls *LocalDisttaeDataSource) applyWorkspaceRawRowIdDeletes(
 
 func (ls *LocalDisttaeDataSource) getInMemDelIter(
 	bid *types.Blockid,
+	offsetCnt int,
 ) (logtailreplay.RowsIter, bool) {
 
 	inMemTombstoneCnt := ls.pState.ApproxInMemTombstones()
@@ -950,7 +951,8 @@ func (ls *LocalDisttaeDataSource) getInMemDelIter(
 		return nil, true
 	}
 
-	if ls.memPKFilter == nil || ls.memPKFilter.SpecFactory == nil {
+	if offsetCnt <= logtailreplay.IndexScaleTiny &&
+		ls.memPKFilter == nil || ls.memPKFilter.SpecFactory == nil {
 		return ls.pState.NewRowsIter(ls.snapshotTS, bid, true), false
 	}
 
@@ -983,7 +985,7 @@ func (ls *LocalDisttaeDataSource) applyPStateInMemDeletes(
 
 	leftRows = offsets
 
-	delIter, fastReturn := ls.getInMemDelIter(bid)
+	delIter, fastReturn := ls.getInMemDelIter(bid, len(offsets))
 	if fastReturn {
 		return leftRows
 	}

--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -951,7 +951,7 @@ func (ls *LocalDisttaeDataSource) getInMemDelIter(
 		return nil, true
 	}
 
-	if offsetCnt <= logtailreplay.IndexScaleTiny &&
+	if offsetCnt <= logtailreplay.IndexScaleTiny ||
 		ls.memPKFilter == nil || ls.memPKFilter.SpecFactory == nil {
 		return ls.pState.NewRowsIter(ls.snapshotTS, bid, true), false
 	}

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -41,6 +41,7 @@ import (
 
 const (
 	IndexScaleZero        = 0
+	IndexScaleTiny        = 10
 	MuchGreaterThanFactor = 100
 )
 

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -41,6 +41,7 @@ import (
 
 const (
 	IndexScaleZero        = 0
+	IndexScaleOne         = 1
 	IndexScaleTiny        = 10
 	MuchGreaterThanFactor = 100
 )
@@ -913,4 +914,24 @@ func (p *PartitionState) IsValid() bool {
 
 func (p *PartitionState) IsEmpty() bool {
 	return p.start == types.MaxTs()
+}
+
+func (p *PartitionState) CheckRowIdDeletedInMem(ts types.TS, rowId types.Rowid) bool {
+	iter := p.rows.Copy().Iter()
+	defer iter.Release()
+
+	if !iter.Seek(RowEntry{
+		Time:    ts,
+		BlockID: rowId.CloneBlockID(),
+		RowID:   rowId,
+	}) {
+		return false
+	}
+
+	item := iter.Item()
+	if !item.Deleted {
+		return false
+	}
+
+	return item.RowID.EQ(&rowId)
 }

--- a/pkg/vm/engine/engine_util/pk_filter_mem.go
+++ b/pkg/vm/engine/engine_util/pk_filter_mem.go
@@ -34,6 +34,10 @@ type MemPKFilter struct {
 	isValid bool
 	TS      types.TS
 
+	exact struct {
+		hit bool
+	}
+
 	filterHint  engine.FilterHint
 	SpecFactory func(f *MemPKFilter) logtailreplay.PrimaryKeyMatchSpec
 }
@@ -209,6 +213,20 @@ func NewMemPKFilter(
 
 func (f *MemPKFilter) InKind() (int, bool) {
 	return len(f.packed), f.op == function.IN || f.op == function.PREFIX_IN
+}
+
+func (f *MemPKFilter) Exact() (bool, bool) {
+	return f.op == function.EQUAL && len(f.packed) == 1, f.exact.hit
+}
+
+func (f *MemPKFilter) RecordExactHit() bool {
+	if ok, _ := f.Exact(); !ok {
+		return false
+	}
+
+	f.exact.hit = true
+
+	return true
 }
 
 func (f *MemPKFilter) Must() bool {

--- a/pkg/vm/engine/engine_util/reader.go
+++ b/pkg/vm/engine/engine_util/reader.go
@@ -528,6 +528,7 @@ func (r *reader) Read(
 	}
 
 	if outBatch.RowCount() == 1 {
+		// found one row in this blk for the pk equal, record it
 		r.withFilterMixin.filterState.memFilter.RecordExactHit()
 	}
 

--- a/pkg/vm/engine/engine_util/reader.go
+++ b/pkg/vm/engine/engine_util/reader.go
@@ -469,7 +469,7 @@ func (r *reader) Read(
 		cols,
 		r.columns.colTypes,
 		r.columns.seqnums,
-		r.filterState.memFilter,
+		&r.filterState.memFilter,
 		mp,
 		outBatch)
 
@@ -525,6 +525,10 @@ func (r *reader) Read(
 	)
 	if err != nil {
 		return false, err
+	}
+
+	if outBatch.RowCount() == 1 {
+		r.withFilterMixin.filterState.memFilter.RecordExactHit()
 	}
 
 	if filter.Valid {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/18603

## What this PR does / why we need it:
1.  if pk Equal is found in Inmem rows, skip all blocks
2. if pk Equal is found in one blk, skip all the following blocks. 
