### PR TITLE
cgo: fix CFLAGS to support older c compiler

### DIFF
--- a/cgo/lib.go
+++ b/cgo/lib.go
@@ -15,7 +15,7 @@
 package cgo
 
 /*
-#cgo CFLAGS: -O3
+#cgo CFLAGS: -O3 -std=c99
 #cgo LDFLAGS: -lm
 */
 import "C"


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20422 

## What this PR does / why we need it:
some older version c compilers' default c standard is not c99 or newer, fix the CFLAGS to make them work.