### PR TITLE
fix txn deadlock during drop account

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -3624,7 +3624,7 @@ func doDropAccount(ctx context.Context, ses *Session, da *dropAccount) (err erro
 			return rtnErr
 		}
 		ses.Infof(ctx, "dropAccount %s sql: %s", da.Name, getAccountIdNamesSql)
-		_, nameInfoMap, rtnErr := getAccounts(ctx, bh)
+		_, nameInfoMap, rtnErr := getAccounts(ctx, bh, true)
 		if rtnErr != nil {
 			return rtnErr
 		}
@@ -7743,7 +7743,7 @@ func createTablesInInformationSchemaOfGeneralTenant(ctx context.Context, bh Back
 // createSubscription insert records into mo_subs of To-All-Publications
 func createSubscription(ctx context.Context, bh BackgroundExec, newTenant *TenantInfo) (err error) {
 	// get all accounts
-	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh)
+	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh, false)
 	if err != nil {
 		return
 	}

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -7126,7 +7126,7 @@ func Test_doDropAccount(t *testing.T) {
 		bh.sql2result["commit;"] = nil
 		bh.sql2result["rollback;"] = nil
 
-		sql := getAccountIdNamesSql
+		sql := getAccountIdNamesSql + " for update"
 		mrs := newMrsForGetAllAccounts([][]interface{}{
 			{uint64(0), "sys", "open", uint64(1), nil},
 			{uint64(1), "acc", "open", uint64(1), nil},
@@ -7187,7 +7187,7 @@ func Test_doDropAccount(t *testing.T) {
 		bh.sql2result["commit;"] = nil
 		bh.sql2result["rollback;"] = nil
 
-		sql := getAccountIdNamesSql
+		sql := getAccountIdNamesSql + " for update"
 		bh.sql2result[sql] = newMrsForGetAllAccounts([][]interface{}{})
 
 		sql, _ = getSqlForDeleteAccountFromMoAccount(context.TODO(), mustUnboxExprStr(stmt.Name))
@@ -7234,7 +7234,7 @@ func Test_doDropAccount(t *testing.T) {
 		bh.sql2result["commit;"] = nil
 		bh.sql2result["rollback;"] = nil
 
-		sql := getAccountIdNamesSql
+		sql := getAccountIdNamesSql + " for update"
 		bh.sql2result[sql] = newMrsForGetAllAccounts([][]interface{}{})
 
 		sql, _ = getSqlForDeleteAccountFromMoAccount(context.TODO(), mustUnboxExprStr(stmt.Name))

--- a/pkg/frontend/publication_subscription.go
+++ b/pkg/frontend/publication_subscription.go
@@ -198,7 +198,7 @@ func createPublication(ctx context.Context, bh BackgroundExec, cp *tree.CreatePu
 		accountNamesStr string
 	)
 
-	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh)
+	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh, false)
 	if err != nil {
 		return
 	}
@@ -342,7 +342,7 @@ func doAlterPublication(ctx context.Context, ses *Session, ap *tree.AlterPublica
 		err = finishTxn(ctx, bh, err)
 	}()
 
-	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh)
+	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh, false)
 	if err != nil {
 		return
 	}
@@ -554,7 +554,7 @@ func doDropPublication(ctx context.Context, ses *Session, dp *tree.DropPublicati
 func dropPublication(ctx context.Context, bh BackgroundExec, ifExists bool, pubName string) (err error) {
 	var sql string
 
-	accIdInfoMap, _, err := getAccounts(ctx, bh)
+	accIdInfoMap, _, err := getAccounts(ctx, bh, false)
 	if err != nil {
 		return
 	}
@@ -625,9 +625,12 @@ func dropPublication(ctx context.Context, bh BackgroundExec, ifExists bool, pubN
 	return
 }
 
-func getAccounts(ctx context.Context, bh BackgroundExec) (idInfoMap map[int32]*pubsub.AccountInfo, nameInfoMap map[string]*pubsub.AccountInfo, err error) {
+func getAccounts(ctx context.Context, bh BackgroundExec, forUpdate bool) (idInfoMap map[int32]*pubsub.AccountInfo, nameInfoMap map[string]*pubsub.AccountInfo, err error) {
 	ctx = defines.AttachAccountId(ctx, catalog.System_Account)
 	sql := getAccountIdNamesSql
+	if forUpdate {
+		sql += " for update"
+	}
 
 	bh.ClearExecResultSet()
 	if err = bh.Exec(ctx, sql); err != nil {
@@ -1037,7 +1040,7 @@ func doShowPublications(ctx context.Context, ses *Session, sp *tree.ShowPublicat
 		return
 	}
 
-	accIdInfoMap, _, err := getAccounts(ctx, bh)
+	accIdInfoMap, _, err := getAccounts(ctx, bh, false)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4563

## What this PR does / why we need it:

原因：并发的drop account 导致的死锁。

修改：在查询mo_account表（sys租户）时，用`select ... for update`。这个避免多个drop account 并发执行的问题。

潜在的问题：锁住mo_account表，会阻塞创建/更新租户、创建/alter/drop/show发布订阅。这些业务也会查mo_account表。