### PR TITLE
clean temporary files when `disttae.test` UTs are complete.

### DIFF
--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -16,7 +16,6 @@ package test
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -370,10 +369,7 @@ func TestChangesHandleForCNWrite(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
-	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(ctx, testutil.TestOptions{TaeEngineOptions: opt}, t)
+	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
 	defer func() {
 		disttaeEngine.Close(ctx)
 		taeEngine.Close(true)
@@ -478,10 +474,7 @@ func TestChangesHandle4(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
-	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(ctx, testutil.TestOptions{TaeEngineOptions: opt}, t)
+	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
 	defer func() {
 		disttaeEngine.Close(ctx)
 		taeEngine.Close(true)
@@ -887,12 +880,7 @@ func TestChangesHandleStaleFiles2(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	dir := testutil.GetDefaultTestPath("test", t)
-	os.RemoveAll(dir)
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, dir)
-	require.NoError(t, err)
-
-	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(ctx, testutil.TestOptions{TaeEngineOptions: opt}, t)
+	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
 	defer func() {
 		disttaeEngine.Close(ctx)
 		taeEngine.Close(true)

--- a/pkg/vm/engine/test/mo_table_stats_test.go
+++ b/pkg/vm/engine/test/mo_table_stats_test.go
@@ -202,13 +202,10 @@ func TestMoTableStatsMoCtl2(t *testing.T) {
 }
 
 func TestHandleGetChangedList(t *testing.T) {
-
-	opt, err := testutil.GetS3SharedFileServiceOption(
-		context.Background(), testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
 	var opts testutil.TestOptions
-	opts.TaeEngineOptions = opt
+
+	opts.TaeEngineOptions = config.WithLongScanAndCKPOpts(nil)
+
 	p := testutil.InitEnginePack(opts, t)
 	defer p.Close()
 
@@ -261,7 +258,7 @@ func TestHandleGetChangedList(t *testing.T) {
 	ts := types.MaxTs().ToTimestamp()
 	req.From[len(tblNames)-1] = &ts
 
-	_, err = p.T.GetRPCHandle().HandleGetChangedTableList(p.Ctx, txn.TxnMeta{}, req, resp)
+	_, err := p.T.GetRPCHandle().HandleGetChangedTableList(p.Ctx, txn.TxnMeta{}, req, resp)
 	require.NoError(t, err)
 
 	require.Equal(t, tblIds[:len(tblIds)-1], resp.TableIds)

--- a/pkg/vm/engine/test/reader_test.go
+++ b/pkg/vm/engine/test/reader_test.go
@@ -85,10 +85,7 @@ func Test_ReaderCanReadRangesBlocksWithoutDeletes(t *testing.T) {
 	require.NoError(t, err)
 	defer rmFault()
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
-	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(ctx, testutil.TestOptions{TaeEngineOptions: opt}, t)
+	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
 	hbMonkeyJob := testutil.MakeTxnHeartbeatMonkeyJob(
 		taeEngine, time.Millisecond*10,
 	)
@@ -201,10 +198,7 @@ func TestReaderCanReadUncommittedInMemInsertAndDeletes(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
-	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(ctx, testutil.TestOptions{TaeEngineOptions: opt}, t)
+	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
 	defer func() {
 		disttaeEngine.Close(ctx)
 		taeEngine.Close(true)
@@ -265,7 +259,7 @@ func TestReaderCanReadUncommittedInMemInsertAndDeletes(t *testing.T) {
 
 func Test_ReaderCanReadCommittedInMemInsertAndDeletes(t *testing.T) {
 	var (
-		//err          error
+		err          error
 		mp           *mpool.MPool
 		accountId    = catalog.System_Account
 		tableName    = "test_reader_table"
@@ -297,12 +291,10 @@ func Test_ReaderCanReadCommittedInMemInsertAndDeletes(t *testing.T) {
 	schema.Name = tableName
 
 	{
-		opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-		require.NoError(t, err)
 
 		disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 			ctx,
-			testutil.TestOptions{TaeEngineOptions: opt},
+			testutil.TestOptions{},
 			t,
 			testutil.WithDisttaeEngineWorkspaceThreshold(mpool.MB*2),
 			testutil.WithDisttaeEngineInsertEntryMaxCount(10000),
@@ -423,7 +415,7 @@ func Test_ReaderCanReadCommittedInMemInsertAndDeletes(t *testing.T) {
 
 func Test_ShardingHandler(t *testing.T) {
 	var (
-		//err          error
+		err error
 		//mp           *mpool.MPool
 		accountId    = catalog.System_Account
 		tableName    = "test_reader_table"
@@ -455,12 +447,10 @@ func Test_ShardingHandler(t *testing.T) {
 	schema.Name = tableName
 
 	{
-		opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-		require.NoError(t, err)
 
 		disttaeEngine, taeEngine, rpcAgent, _ = testutil.CreateEngines(
 			ctx,
-			testutil.TestOptions{TaeEngineOptions: opt},
+			testutil.TestOptions{},
 			t,
 			testutil.WithDisttaeEngineWorkspaceThreshold(mpool.MB*2),
 			testutil.WithDisttaeEngineInsertEntryMaxCount(10000),
@@ -622,7 +612,7 @@ func Test_ShardingHandler(t *testing.T) {
 
 func Test_ShardingRemoteReader(t *testing.T) {
 	var (
-		//err          error
+		err          error
 		mp           *mpool.MPool
 		accountId    = catalog.System_Account
 		tableName    = "test_reader_table"
@@ -654,12 +644,9 @@ func Test_ShardingRemoteReader(t *testing.T) {
 	schema.Name = tableName
 
 	{
-		opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-		require.NoError(t, err)
-
 		disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 			ctx,
-			testutil.TestOptions{TaeEngineOptions: opt},
+			testutil.TestOptions{},
 			t,
 			testutil.WithDisttaeEngineWorkspaceThreshold(mpool.MB*2),
 			testutil.WithDisttaeEngineInsertEntryMaxCount(10000),
@@ -932,7 +919,7 @@ func Test_ShardingRemoteReader(t *testing.T) {
 
 func Test_ShardingTableDelegate(t *testing.T) {
 	var (
-		//err          error
+		err error
 		//mp           *mpool.MPool
 		accountId    = catalog.System_Account
 		tableName    = "test_reader_table"
@@ -958,12 +945,9 @@ func Test_ShardingTableDelegate(t *testing.T) {
 	schema.Name = tableName
 
 	{
-		opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-		require.NoError(t, err)
-
 		disttaeEngine, taeEngine, rpcAgent, _ = testutil.CreateEngines(
 			ctx,
-			testutil.TestOptions{TaeEngineOptions: opt},
+			testutil.TestOptions{},
 			t,
 			testutil.WithDisttaeEngineWorkspaceThreshold(mpool.MB*2),
 			testutil.WithDisttaeEngineInsertEntryMaxCount(10000),
@@ -1103,7 +1087,7 @@ func Test_ShardingTableDelegate(t *testing.T) {
 
 func Test_ShardingLocalReader(t *testing.T) {
 	var (
-		//err          error
+		err          error
 		mp           *mpool.MPool
 		accountId    = catalog.System_Account
 		tableName    = "test_reader_table"
@@ -1129,12 +1113,9 @@ func Test_ShardingLocalReader(t *testing.T) {
 	schema.Name = tableName
 
 	{
-		opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-		require.NoError(t, err)
-
 		disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 			ctx,
-			testutil.TestOptions{TaeEngineOptions: opt},
+			testutil.TestOptions{},
 			t,
 			testutil.WithDisttaeEngineWorkspaceThreshold(mpool.MB*2),
 			testutil.WithDisttaeEngineInsertEntryMaxCount(10000),

--- a/pkg/vm/engine/test/testutil/disttae_engine.go
+++ b/pkg/vm/engine/test/testutil/disttae_engine.go
@@ -20,6 +20,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/frontend"
 	ie "github.com/matrixorigin/matrixone/pkg/util/internalExecutor"
 	"github.com/matrixorigin/matrixone/pkg/util/toml"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -68,6 +69,8 @@ type TestDisttaeEngine struct {
 	mp                  *mpool.MPool
 	workspaceThreshold  uint64
 	insertEntryMaxCount int
+
+	rootDir string
 }
 
 func setServerLevelParams(de *TestDisttaeEngine) {
@@ -430,6 +433,10 @@ func (de *TestDisttaeEngine) Close(ctx context.Context) {
 	close(de.logtailReceiver)
 	de.cancel()
 	de.wg.Wait()
+
+	if err := os.RemoveAll(de.rootDir); err != nil {
+		logutil.Errorf("remove root dir failed (%s): %v", de.rootDir, err)
+	}
 }
 
 func (de *TestDisttaeEngine) GetTable(

--- a/pkg/vm/engine/test/testutil/tae_engine.go
+++ b/pkg/vm/engine/test/testutil/tae_engine.go
@@ -136,11 +136,11 @@ func (ts *TestTxnStorage) GetRPCHandle() *rpc.Handle {
 }
 
 func NewTestTAEEngine(
-	ctx context.Context, moduleName string, t *testing.T,
+	ctx context.Context, taeDir string, t *testing.T,
 	rpcAgent *MockRPCAgent, opts *options.Options) (*TestTxnStorage, error) {
 
 	blockio.Start("")
-	handle := InitTxnHandle(ctx, moduleName, t, opts)
+	handle := InitTxnHandle(ctx, taeDir, opts)
 	logtailServer, err := NewMockLogtailServer(
 		ctx, handle.GetDB(), defaultLogtailConfig(), runtime.DefaultRuntime(), rpcAgent.MockLogtailPRCServerFactory)
 	if err != nil {
@@ -164,9 +164,8 @@ func NewTestTAEEngine(
 	return tc, nil
 }
 
-func InitTxnHandle(ctx context.Context, moduleName string, t *testing.T, opts *options.Options) *rpc.Handle {
-	dir := InitTestEnv(moduleName, t)
-	handle := rpc.NewTAEHandle(ctx, dir, opts)
+func InitTxnHandle(ctx context.Context, taeDir string, opts *options.Options) *rpc.Handle {
+	handle := rpc.NewTAEHandle(ctx, taeDir, opts)
 	handle.GetDB().DiskCleaner.GetCleaner().AddChecker(
 		func(item any) bool {
 			minTS := handle.GetDB().TxnMgr.MinTSForTest()

--- a/pkg/vm/engine/test/testutil/types.go
+++ b/pkg/vm/engine/test/testutil/types.go
@@ -94,7 +94,7 @@ type TestOptions struct {
 	Timeout          time.Duration
 }
 
-func GetS3SharedFileServiceOption(ctx context.Context, dir string) (*options.Options, error) {
+func getS3SharedFileServiceOption(ctx context.Context, dir string) (*options.Options, error) {
 	config := fileservice.Config{
 		Name:    defines.SharedFileServiceName,
 		Backend: "DISK",

--- a/pkg/vm/engine/test/testutil/util.go
+++ b/pkg/vm/engine/test/testutil/util.go
@@ -17,8 +17,10 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 	"testing"
 	"time"
@@ -58,16 +60,6 @@ func MakeDefaultTestPath(module string, t *testing.T) string {
 	return path
 }
 
-func RemoveDefaultTestPath(module string, t *testing.T) {
-	path := GetDefaultTestPath(module, t)
-	os.RemoveAll(path)
-}
-
-func InitTestEnv(module string, t *testing.T) string {
-	RemoveDefaultTestPath(module, t)
-	return MakeDefaultTestPath(module, t)
-}
-
 type TestDisttaeEngineOptions func(*TestDisttaeEngine)
 
 func WithDisttaeEngineMPool(mp *mpool.MPool) TestDisttaeEngineOptions {
@@ -90,7 +82,7 @@ func CreateEngines(
 	ctx context.Context,
 	opts TestOptions,
 	t *testing.T,
-	options ...TestDisttaeEngineOptions,
+	funcOpts ...TestDisttaeEngineOptions,
 ) (
 	disttaeEngine *TestDisttaeEngine,
 	taeEngine *TestTxnStorage,
@@ -106,13 +98,27 @@ func CreateEngines(
 
 	rpcAgent = NewMockLogtailAgent()
 
-	taeEngine, err = NewTestTAEEngine(ctx, "partition_state", t, rpcAgent, opts.TaeEngineOptions)
+	rootDir := GetDefaultTestPath("engine_test", t)
+
+	s3Op, err := getS3SharedFileServiceOption(ctx, rootDir)
+	require.NoError(t, err)
+
+	if opts.TaeEngineOptions == nil {
+		opts.TaeEngineOptions = &options.Options{}
+	}
+
+	opts.TaeEngineOptions.Fs = s3Op.Fs
+
+	taeDir := path.Join(rootDir, "tae")
+
+	taeEngine, err = NewTestTAEEngine(ctx, taeDir, t, rpcAgent, opts.TaeEngineOptions)
 	require.Nil(t, err)
 
-	disttaeEngine, err = NewTestDisttaeEngine(ctx, taeEngine.GetDB().Runtime.Fs.Service, rpcAgent, taeEngine, options...)
+	disttaeEngine, err = NewTestDisttaeEngine(ctx, taeEngine.GetDB().Runtime.Fs.Service, rpcAgent, taeEngine, funcOpts...)
 	require.Nil(t, err)
 
 	mp = disttaeEngine.mp
+	disttaeEngine.rootDir = rootDir
 
 	return
 }

--- a/pkg/vm/engine/test/workspace_test.go
+++ b/pkg/vm/engine/test/workspace_test.go
@@ -74,12 +74,9 @@ func Test_BasicInsertDelete(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
 	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 		ctx,
-		testutil.TestOptions{TaeEngineOptions: opt},
+		testutil.TestOptions{},
 		t,
 	)
 	defer func() {
@@ -164,12 +161,9 @@ func Test_BasicS3InsertDelete(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
 	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 		ctx,
-		testutil.TestOptions{TaeEngineOptions: opt},
+		testutil.TestOptions{},
 		t,
 		testutil.WithDisttaeEngineInsertEntryMaxCount(1),
 		testutil.WithDisttaeEngineWorkspaceThreshold(1),
@@ -302,12 +296,9 @@ func Test_MultiTxnInsertDelete(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
 	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 		ctx,
-		testutil.TestOptions{TaeEngineOptions: opt},
+		testutil.TestOptions{},
 		t,
 	)
 	defer func() {
@@ -460,12 +451,9 @@ func Test_MultiTxnS3InsertDelete(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
 	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 		ctx,
-		testutil.TestOptions{TaeEngineOptions: opt},
+		testutil.TestOptions{},
 		t,
 		testutil.WithDisttaeEngineInsertEntryMaxCount(1),
 		testutil.WithDisttaeEngineWorkspaceThreshold(1),
@@ -617,12 +605,9 @@ func Test_MultiTxnS3Tombstones(t *testing.T) {
 	schema := catalog2.MockSchemaEnhanced(2, primaryKeyIdx, 2)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
 	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 		ctx,
-		testutil.TestOptions{TaeEngineOptions: opt},
+		testutil.TestOptions{},
 		t,
 		testutil.WithDisttaeEngineInsertEntryMaxCount(1),
 		testutil.WithDisttaeEngineWorkspaceThreshold(1),
@@ -793,12 +778,9 @@ func Test_BasicRollbackStatement(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
 	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 		ctx,
-		testutil.TestOptions{TaeEngineOptions: opt},
+		testutil.TestOptions{},
 		t,
 	)
 	defer func() {
@@ -905,12 +887,9 @@ func Test_BasicRollbackStatementS3(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
 	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 		ctx,
-		testutil.TestOptions{TaeEngineOptions: opt},
+		testutil.TestOptions{},
 		t,
 		testutil.WithDisttaeEngineInsertEntryMaxCount(1),
 		testutil.WithDisttaeEngineWorkspaceThreshold(1),
@@ -1057,12 +1036,9 @@ func Test_MultiTxnRollbackStatement(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
 	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 		ctx,
-		testutil.TestOptions{TaeEngineOptions: opt},
+		testutil.TestOptions{},
 		t,
 	)
 	defer func() {
@@ -1230,12 +1206,9 @@ func Test_MultiTxnRollbackStatementS3(t *testing.T) {
 	schema := catalog2.MockSchemaAll(4, primaryKeyIdx)
 	schema.Name = tableName
 
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
 	disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 		ctx,
-		testutil.TestOptions{TaeEngineOptions: opt},
+		testutil.TestOptions{},
 		t,
 		testutil.WithDisttaeEngineInsertEntryMaxCount(1),
 		testutil.WithDisttaeEngineWorkspaceThreshold(1),
@@ -1374,7 +1347,7 @@ func Test_MultiTxnRollbackStatementS3(t *testing.T) {
 
 func Test_DeleteUncommittedBlock(t *testing.T) {
 	var (
-		//err          error
+		err          error
 		mp           *mpool.MPool
 		accountId    = catalog.System_Account
 		tableName    = "test_reader_table"
@@ -1402,12 +1375,10 @@ func Test_DeleteUncommittedBlock(t *testing.T) {
 	schema.Name = tableName
 
 	{
-		opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-		require.NoError(t, err)
 
 		disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 			ctx,
-			testutil.TestOptions{TaeEngineOptions: opt},
+			testutil.TestOptions{},
 			t,
 			testutil.WithDisttaeEngineInsertEntryMaxCount(1),
 			testutil.WithDisttaeEngineWorkspaceThreshold(1),
@@ -1490,7 +1461,7 @@ func Test_DeleteUncommittedBlock(t *testing.T) {
 
 func Test_BigDeleteWriteS3(t *testing.T) {
 	var (
-		//err          error
+		err          error
 		mp           *mpool.MPool
 		accountId    = catalog.System_Account
 		tableName    = "test_reader_table"
@@ -1516,12 +1487,9 @@ func Test_BigDeleteWriteS3(t *testing.T) {
 	schema.Name = tableName
 
 	{
-		opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-		require.NoError(t, err)
-
 		disttaeEngine, taeEngine, rpcAgent, mp = testutil.CreateEngines(
 			ctx,
-			testutil.TestOptions{TaeEngineOptions: opt},
+			testutil.TestOptions{},
 			t,
 			testutil.WithDisttaeEngineInsertEntryMaxCount(1),
 			testutil.WithDisttaeEngineWorkspaceThreshold(1),
@@ -1575,6 +1543,7 @@ func Test_BigDeleteWriteS3(t *testing.T) {
 
 func Test_CNTransferTombstoneObjects(t *testing.T) {
 	var (
+		err          error
 		opts         testutil.TestOptions
 		tableName    = "test1"
 		databaseName = "db1"
@@ -1586,11 +1555,6 @@ func Test_CNTransferTombstoneObjects(t *testing.T) {
 	ctx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(0))
 
 	opts.TaeEngineOptions = config.WithLongScanAndCKPOpts(nil)
-
-	opt, err := testutil.GetS3SharedFileServiceOption(ctx, testutil.GetDefaultTestPath("test", t))
-	require.NoError(t, err)
-
-	opts.TaeEngineOptions.Fs = opt.Fs
 
 	p := testutil.InitEnginePack(opts, t)
 	defer p.Close()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/20603

## What this PR does / why we need it:
clean temporary files when disttae.test UTs are complete.