### PR TITLE
fix init mo_table_stats cron task meta.

### DIFF
--- a/pkg/cnservice/distributed_tae.go
+++ b/pkg/cnservice/distributed_tae.go
@@ -80,8 +80,11 @@ func (s *service) initDistributedTAE(
 
 		disttae.WithCNTransferTxnLifespanThreshold(
 			s.cfg.Engine.CNTransferTxnLifespanThreshold),
-		disttae.WithMoTableStats(s.cfg.Engine.Stats),
+		disttae.WithMoTableStatsConf(s.cfg.Engine.Stats),
 		disttae.WithSQLExecFunc(internalExecutorFactory),
+		disttae.WithMoServerStateChecker(func() bool {
+			return frontend.MoServerIsStarted(s.cfg.UUID)
+		}),
 	)
 	pu.StorageEngine = s.storeEngine
 

--- a/pkg/cnservice/server_task.go
+++ b/pkg/cnservice/server_task.go
@@ -17,7 +17,6 @@ package cnservice
 import (
 	"context"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 	"strings"
 	"time"
 
@@ -39,6 +38,7 @@ import (
 	db_holder "github.com/matrixorigin/matrixone/pkg/util/export/etl/db"
 	ie "github.com/matrixorigin/matrixone/pkg/util/internalExecutor"
 	"github.com/matrixorigin/matrixone/pkg/util/metric/mometric"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 	"go.uber.org/zap"
 )
 

--- a/pkg/cnservice/server_task.go
+++ b/pkg/cnservice/server_task.go
@@ -17,6 +17,7 @@ package cnservice
 import (
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 	"strings"
 	"time"
 
@@ -38,7 +39,6 @@ import (
 	db_holder "github.com/matrixorigin/matrixone/pkg/util/export/etl/db"
 	ie "github.com/matrixorigin/matrixone/pkg/util/internalExecutor"
 	"github.com/matrixorigin/matrixone/pkg/util/metric/mometric"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 	"go.uber.org/zap"
 )
 

--- a/pkg/frontend/server.go
+++ b/pkg/frontend/server.go
@@ -359,6 +359,9 @@ func init() {
 func getServerLevelVars(service string) *ServerLevelVariables {
 	//always there
 	ret, _ := serverVarsMap.Load(service)
+	if ret == nil {
+		return nil
+	}
 	return ret.(*ServerLevelVariables)
 }
 
@@ -416,7 +419,11 @@ func getAicm(service string) *defines.AutoIncrCacheManager {
 }
 
 func MoServerIsStarted(service string) bool {
-	return getServerLevelVars(service).moServerStarted.Load()
+	vars := getServerLevelVars(service)
+	if vars == nil {
+		return false
+	}
+	return vars.moServerStarted.Load()
 }
 
 func setMoServerStarted(service string, b bool) {

--- a/pkg/predefine/predefine.go
+++ b/pkg/predefine/predefine.go
@@ -108,11 +108,12 @@ func GenInitCronTaskSQL(codes ...int32) (string, error) {
 	first := true
 	for _, t := range cronTasks {
 		if len(codes) != 0 && slices.Index(codes, int32(t.Metadata.Executor)) == -1 {
-			// if specified task codes, only process them.
+			// if the task codes specified, only process them.
 			continue
 		}
 
 		if len(codes) == 0 && t.Metadata.Executor == task.TaskCode_MOTableStats {
+			// test code to test if the init mo_table_stats task meta code works.
 			continue
 		}
 

--- a/pkg/predefine/predefine.go
+++ b/pkg/predefine/predefine.go
@@ -17,6 +17,7 @@ package predefine
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -27,7 +28,7 @@ import (
 )
 
 // genInitCronTaskSQL Generate `insert` statement for creating system cron tasks, which works on the `mo_task`.`sys_cron_task` table.
-func GenInitCronTaskSQL() (string, error) {
+func GenInitCronTaskSQL(codes ...int32) (string, error) {
 	cronParser := cron.NewParser(
 		cron.Second |
 			cron.Minute |
@@ -104,12 +105,23 @@ func GenInitCronTaskSQL() (string, error) {
                            update_at
                     ) values `, catalog.MOTaskDB)
 
-	for i, t := range cronTasks {
+	first := true
+	for _, t := range cronTasks {
+		if len(codes) != 0 && slices.Index(codes, int32(t.Metadata.Executor)) == -1 {
+			// if specified task codes, only process them.
+			continue
+		}
+
+		if len(codes) == 0 && t.Metadata.Executor == task.TaskCode_MOTableStats {
+			continue
+		}
+
 		j, err := json.Marshal(t.Metadata.Options)
 		if err != nil {
 			return "", err
 		}
-		if i == 0 {
+		if first {
+			first = false
 			sql += fmt.Sprintf("('%s' ,%d ,'%s' ,'%s' ,'%s' ,%d ,%d ,%d ,%d)",
 				t.Metadata.ID,
 				t.Metadata.Executor,

--- a/pkg/vm/engine/disttae/mo_table_stats.go
+++ b/pkg/vm/engine/disttae/mo_table_stats.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/predefine"
 	"math"
 	"math/rand"
 	"runtime"
@@ -42,6 +41,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/pb/task"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+	"github.com/matrixorigin/matrixone/pkg/predefine"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/ctl"
 	ie "github.com/matrixorigin/matrixone/pkg/util/internalExecutor"
@@ -399,7 +399,6 @@ func initMoTableStatsConfig(
 		}
 
 		go func() {
-			time.Sleep(time.Minute * 1)
 			ctx = turn2SysCtx(context.Background())
 			for {
 				if !eng.config.moServerStateChecker() {

--- a/pkg/vm/engine/disttae/mo_table_stats.go
+++ b/pkg/vm/engine/disttae/mo_table_stats.go
@@ -401,7 +401,7 @@ func initMoTableStatsConfig(
 		go func() {
 			ctx = turn2SysCtx(context.Background())
 			for {
-				if !eng.config.moServerStateChecker() {
+				if eng.config.moServerStateChecker == nil || !eng.config.moServerStateChecker() {
 					time.Sleep(time.Second * 5)
 					continue
 				}

--- a/pkg/vm/engine/disttae/mo_table_stats.go
+++ b/pkg/vm/engine/disttae/mo_table_stats.go
@@ -19,16 +19,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/predefine"
 	"math"
 	"math/rand"
 	"runtime"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/bytejson"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -394,9 +397,72 @@ func initMoTableStatsConfig(
 				launch("beta task", &dynamicCtx.beta)
 			}
 		}
+
+		go func() {
+			time.Sleep(time.Minute * 1)
+			ctx = turn2SysCtx(context.Background())
+			for {
+				if !eng.config.moServerStateChecker() {
+					time.Sleep(time.Second * 5)
+					continue
+				}
+
+				if initCronTask(ctx) {
+					break
+				}
+			}
+		}()
 	})
 
 	return err
+}
+
+func initCronTask(
+	ctx context.Context,
+) bool {
+	// insert mo table stats task meta into sys_cron_task table.
+	var (
+		err error
+		val any
+		sql string
+	)
+
+	insertTask := func() {
+		sql, err = predefine.GenInitCronTaskSQL(int32(task.TaskCode_MOTableStats))
+		if err != nil {
+			logutil.Error(logHeader,
+				zap.String("source", "init cron task"),
+				zap.Error(err))
+		}
+
+		executeSQL(ctx, sql, "init cron task")
+	}
+
+	checkTask := func() bool {
+		sqlRet := executeSQL(ctx,
+			fmt.Sprintf(`select count(*) from %s.%s where task_metadata_id = '%s';`,
+				catalog.MOTaskDB, "sys_cron_task", "mo_table_stats"), "check cron task")
+
+		if sqlRet.Error() != nil || sqlRet.RowCount() != 1 {
+			return false
+		}
+
+		val, err = sqlRet.Value(ctx, 0, 0)
+		if err != nil {
+			return false
+		}
+
+		return val.(int64) == 1
+	}
+
+	if checkTask() {
+		logutil.Info(logHeader, zap.String("source", "init cron task succeed"))
+		return true
+	}
+
+	insertTask()
+
+	return false
 }
 
 type taskState struct {
@@ -410,6 +476,8 @@ var dynamicCtx struct {
 	sync.RWMutex
 
 	once sync.Once
+
+	moServerStateChecker func() bool
 
 	defaultConf MoTableStatsConfig
 	conf        MoTableStatsConfig
@@ -626,14 +694,15 @@ func executeSQL(ctx context.Context, sql string, hint string) ie.InternalExecRes
 }
 
 func intsJoin(items []uint64, delimiter string) string {
-	str := ""
-	for i := range items {
-		str += fmt.Sprintf("%d", items[i])
+	var builder strings.Builder
+	builder.Grow(mpool.MB)
+	for i, item := range items {
+		builder.WriteString(strconv.FormatUint(item, 10))
 		if i < len(items)-1 {
-			str += delimiter
+			builder.WriteString(delimiter)
 		}
 	}
-	return str
+	return builder.String()
 }
 
 func forceUpdateQuery(
@@ -827,6 +896,8 @@ func QueryTableStatsByAccounts(
 		return
 	}
 
+	now := time.Now()
+
 	newCtx := turn2SysCtx(ctx)
 
 	sql := fmt.Sprintf(accumulateIdsByAccSQL,
@@ -864,6 +935,16 @@ func QueryTableStatsByAccounts(
 
 	statsVals, err, ok = QueryTableStats(
 		newCtx, wantedStatsIdxes, accs2, dbs, tbls, forceUpdate, resetUpdateTime, nil)
+
+	logutil.Info(logHeader,
+		zap.String("source", "QueryTableStatsByAccounts"),
+		zap.Int("acc cnt", len(accs)),
+		zap.Int("tbl cnt", len(tbls)),
+		zap.Bool("forceUpdate", forceUpdate),
+		zap.Bool("resetUpdateTime", resetUpdateTime),
+		zap.Duration("takes", time.Since(now)),
+		zap.Bool("ok", ok),
+		zap.Error(err))
 
 	return statsVals, accs2, err, ok
 }

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -173,9 +173,15 @@ func WithCNTransferTxnLifespanThreshold(th time.Duration) EngineOptions {
 	}
 }
 
-func WithMoTableStats(conf MoTableStatsConfig) EngineOptions {
+func WithMoTableStatsConf(conf MoTableStatsConfig) EngineOptions {
 	return func(e *Engine) {
 		e.config.statsConf = conf
+	}
+}
+
+func WithMoServerStateChecker(checker func() bool) EngineOptions {
+	return func(e *Engine) {
+		e.config.moServerStateChecker = checker
 	}
 }
 
@@ -204,8 +210,9 @@ type Engine struct {
 
 		cnTransferTxnLifespanThreshold time.Duration
 
-		ieFactory func() ie.InternalExecutor
-		statsConf MoTableStatsConfig
+		moServerStateChecker func() bool
+		ieFactory            func() ie.InternalExecutor
+		statsConf            MoTableStatsConfig
 	}
 
 	//latest catalog will be loaded from TN when engine is initialized.

--- a/pkg/vm/engine/test/testutil/disttae_engine.go
+++ b/pkg/vm/engine/test/testutil/disttae_engine.go
@@ -135,6 +135,8 @@ func NewTestDisttaeEngine(
 	}
 	engineOpts = append(engineOpts, disttae.WithSQLExecFunc(internalExecutorFactory))
 
+	engineOpts = append(engineOpts, disttae.WithMoServerStateChecker(func() bool { return false }))
+
 	catalog.SetupDefines("")
 	de.Engine = disttae.New(ctx,
 		"",


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4590

## What this PR does / why we need it:
1. A new task meta-record cannot be inserted into the task table when the table already exists.