### PR TITLE
fix drop account

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -3624,7 +3624,7 @@ func doDropAccount(ctx context.Context, ses *Session, da *dropAccount) (err erro
 			return rtnErr
 		}
 		ses.Infof(ctx, "dropAccount %s sql: %s", da.Name, getAccountIdNamesSql)
-		_, nameInfoMap, rtnErr := getAccounts(ctx, bh, true)
+		_, nameInfoMap, rtnErr := getAccounts(ctx, bh, da.Name, true)
 		if rtnErr != nil {
 			return rtnErr
 		}
@@ -7743,7 +7743,7 @@ func createTablesInInformationSchemaOfGeneralTenant(ctx context.Context, bh Back
 // createSubscription insert records into mo_subs of To-All-Publications
 func createSubscription(ctx context.Context, bh BackgroundExec, newTenant *TenantInfo) (err error) {
 	// get all accounts
-	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh, false)
+	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh, "", false)
 	if err != nil {
 		return
 	}

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -7126,7 +7126,7 @@ func Test_doDropAccount(t *testing.T) {
 		bh.sql2result["commit;"] = nil
 		bh.sql2result["rollback;"] = nil
 
-		sql := getAccountIdNamesSql + " for update"
+		sql := getAccountIdNamesSql + ` and account_name = "acc" order by account_id  for update`
 		mrs := newMrsForGetAllAccounts([][]interface{}{
 			{uint64(0), "sys", "open", uint64(1), nil},
 			{uint64(1), "acc", "open", uint64(1), nil},
@@ -7187,7 +7187,7 @@ func Test_doDropAccount(t *testing.T) {
 		bh.sql2result["commit;"] = nil
 		bh.sql2result["rollback;"] = nil
 
-		sql := getAccountIdNamesSql + " for update"
+		sql := getAccountIdNamesSql + ` and account_name = "acc" order by account_id  for update`
 		bh.sql2result[sql] = newMrsForGetAllAccounts([][]interface{}{})
 
 		sql, _ = getSqlForDeleteAccountFromMoAccount(context.TODO(), mustUnboxExprStr(stmt.Name))
@@ -7234,7 +7234,7 @@ func Test_doDropAccount(t *testing.T) {
 		bh.sql2result["commit;"] = nil
 		bh.sql2result["rollback;"] = nil
 
-		sql := getAccountIdNamesSql + " for update"
+		sql := getAccountIdNamesSql + ` and account_name = "acc" order by account_id  for update`
 		bh.sql2result[sql] = newMrsForGetAllAccounts([][]interface{}{})
 
 		sql, _ = getSqlForDeleteAccountFromMoAccount(context.TODO(), mustUnboxExprStr(stmt.Name))

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -7126,7 +7126,7 @@ func Test_doDropAccount(t *testing.T) {
 		bh.sql2result["commit;"] = nil
 		bh.sql2result["rollback;"] = nil
 
-		sql := getAccountIdNamesSql + ` and account_name = "acc" order by account_id  for update`
+		sql := getAccountIdNamesSql + ` order by account_id  for update`
 		mrs := newMrsForGetAllAccounts([][]interface{}{
 			{uint64(0), "sys", "open", uint64(1), nil},
 			{uint64(1), "acc", "open", uint64(1), nil},
@@ -7187,7 +7187,7 @@ func Test_doDropAccount(t *testing.T) {
 		bh.sql2result["commit;"] = nil
 		bh.sql2result["rollback;"] = nil
 
-		sql := getAccountIdNamesSql + ` and account_name = "acc" order by account_id  for update`
+		sql := getAccountIdNamesSql + ` order by account_id  for update`
 		bh.sql2result[sql] = newMrsForGetAllAccounts([][]interface{}{})
 
 		sql, _ = getSqlForDeleteAccountFromMoAccount(context.TODO(), mustUnboxExprStr(stmt.Name))
@@ -7234,7 +7234,7 @@ func Test_doDropAccount(t *testing.T) {
 		bh.sql2result["commit;"] = nil
 		bh.sql2result["rollback;"] = nil
 
-		sql := getAccountIdNamesSql + ` and account_name = "acc" order by account_id  for update`
+		sql := getAccountIdNamesSql + ` order by account_id  for update`
 		bh.sql2result[sql] = newMrsForGetAllAccounts([][]interface{}{})
 
 		sql, _ = getSqlForDeleteAccountFromMoAccount(context.TODO(), mustUnboxExprStr(stmt.Name))

--- a/pkg/frontend/publication_subscription.go
+++ b/pkg/frontend/publication_subscription.go
@@ -198,7 +198,7 @@ func createPublication(ctx context.Context, bh BackgroundExec, cp *tree.CreatePu
 		accountNamesStr string
 	)
 
-	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh, false)
+	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh, "", false)
 	if err != nil {
 		return
 	}
@@ -342,7 +342,7 @@ func doAlterPublication(ctx context.Context, ses *Session, ap *tree.AlterPublica
 		err = finishTxn(ctx, bh, err)
 	}()
 
-	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh, false)
+	accIdInfoMap, accNameInfoMap, err := getAccounts(ctx, bh, "", false)
 	if err != nil {
 		return
 	}
@@ -554,7 +554,7 @@ func doDropPublication(ctx context.Context, ses *Session, dp *tree.DropPublicati
 func dropPublication(ctx context.Context, bh BackgroundExec, ifExists bool, pubName string) (err error) {
 	var sql string
 
-	accIdInfoMap, _, err := getAccounts(ctx, bh, false)
+	accIdInfoMap, _, err := getAccounts(ctx, bh, "", false)
 	if err != nil {
 		return
 	}
@@ -625,9 +625,13 @@ func dropPublication(ctx context.Context, bh BackgroundExec, ifExists bool, pubN
 	return
 }
 
-func getAccounts(ctx context.Context, bh BackgroundExec, forUpdate bool) (idInfoMap map[int32]*pubsub.AccountInfo, nameInfoMap map[string]*pubsub.AccountInfo, err error) {
+func getAccounts(ctx context.Context, bh BackgroundExec, accName string, forUpdate bool) (idInfoMap map[int32]*pubsub.AccountInfo, nameInfoMap map[string]*pubsub.AccountInfo, err error) {
 	ctx = defines.AttachAccountId(ctx, catalog.System_Account)
 	sql := getAccountIdNamesSql
+	if len(accName) != 0 {
+		sql += fmt.Sprintf(` and account_name = "%s"`, accName)
+	}
+	sql += " order by account_id "
 	if forUpdate {
 		sql += " for update"
 	}
@@ -1040,7 +1044,7 @@ func doShowPublications(ctx context.Context, ses *Session, sp *tree.ShowPublicat
 		return
 	}
 
-	accIdInfoMap, _, err := getAccounts(ctx, bh, false)
+	accIdInfoMap, _, err := getAccounts(ctx, bh, "", false)
 	if err != nil {
 		return
 	}

--- a/pkg/frontend/publication_subscription.go
+++ b/pkg/frontend/publication_subscription.go
@@ -628,9 +628,6 @@ func dropPublication(ctx context.Context, bh BackgroundExec, ifExists bool, pubN
 func getAccounts(ctx context.Context, bh BackgroundExec, accName string, forUpdate bool) (idInfoMap map[int32]*pubsub.AccountInfo, nameInfoMap map[string]*pubsub.AccountInfo, err error) {
 	ctx = defines.AttachAccountId(ctx, catalog.System_Account)
 	sql := getAccountIdNamesSql
-	if len(accName) != 0 {
-		sql += fmt.Sprintf(` and account_name = "%s"`, accName)
-	}
 	sql += " order by account_id "
 	if forUpdate {
 		sql += " for update"


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4616

## What this PR does / why we need it:

问题：并发drop account产生的死锁。
原因： 把所有的租户都拿出来。如果数据没顺序，可能会乱序加锁。
修改：加account name 过滤