### PR TITLE
revert maximum value of max_allowed_packet to 1G

### DIFF
--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -1040,7 +1040,7 @@ var gSysVarsDefs = map[string]SystemVariable{
 		Scope:             ScopeBoth,
 		Dynamic:           true,
 		SetVarHintApplies: false,
-		Type:              InitSystemVariableIntType("max_allowed_packet", 1024, 67108864, false),
+		Type:              InitSystemVariableIntType("max_allowed_packet", 1024, 1073741824, false),
 		Default:           int64(67108864),
 	},
 	"version_comment": {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20845

## What this PR does / why we need it:
revert maximum value of max_allowed_packet to 1G