### PR TITLE
make sure the default lock timeout is large enough to reduce sensitivity to 2.0

### DIFF
--- a/pkg/lockservice/cfg.go
+++ b/pkg/lockservice/cfg.go
@@ -27,7 +27,7 @@ var (
 	defaultMaxFixedSliceSize      = 1 << 20 * 10 // 10mb
 	defaultKeepRemoteLockDuration = time.Second
 	defaultKeepBindTimeout        = time.Second * 10
-	defaultRemoteLockTimeout      = time.Minute * 1
+	defaultRemoteLockTimeout      = time.Minute * 10
 )
 
 // Config lock service config


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19750 

## What this PR does / why we need it:
make sure the default lock timeout is large enough to reduce sensitivity to 2.0