### PR TITLE
[bug] logtail: remove "set ready" in init method

### DIFF
--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -516,7 +516,7 @@ func (c *PushClient) subscribeTable(
 		if err != nil {
 			return err
 		}
-		logutil.Debugf("%s send subscribe tbl[db: %d, tbl: %d] request succeed", logTag, tblId.DbId, tblId.TbId)
+		logutil.Infof("%s send subscribe tbl[db: %d, tbl: %d] request succeed", logTag, tblId.DbId, tblId.TbId)
 		return nil
 	}
 }
@@ -1107,6 +1107,10 @@ func (c *PushClient) toSubIfUnsubscribed(ctx context.Context, dbId, tblId uint64
 				return InvalidSubState, err
 			}
 		}
+		v, exist := c.subscribed.m[tblId]
+		if exist && v.SubState == Subscribed {
+			return Subscribed, nil
+		}
 		c.subscribed.m[tblId] = SubTableStatus{
 			DBID:     dbId,
 			SubState: Subscribing,
@@ -1495,7 +1499,6 @@ func (s *logTailSubscriber) init(
 
 	s.sendSubscribe = s.subscribeTable
 	s.sendUnSubscribe = s.unSubscribeTable
-	s.setReady()
 	return nil
 }
 

--- a/pkg/vm/engine/tae/logtail/service/session.go
+++ b/pkg/vm/engine/tae/logtail/service/session.go
@@ -183,19 +183,11 @@ func (s *morpcStream) write(
 	}
 	chunks := Split(buf[:n], s.limit)
 
-	if len(chunks) > 1 {
-		s.logger.Info("send response by segment",
-			zap.Int("chunk-number", len(chunks)),
-			zap.Int("chunk-limit", s.limit),
-			zap.Int("message-size", size),
-		)
-	} else {
-		s.logger.Debug("send response by segment",
-			zap.Int("chunk-number", len(chunks)),
-			zap.Int("chunk-limit", s.limit),
-			zap.Int("message-size", size),
-		)
-	}
+	s.logger.Debug("send response by segment",
+		zap.Int("chunk-number", len(chunks)),
+		zap.Int("chunk-limit", s.limit),
+		zap.Int("message-size", size),
+	)
 
 	for index, chunk := range chunks {
 		seg := s.segments.Acquire()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20898

## What this PR does / why we need it:
remote "set ready" in init method, otherwise, there will be some
subscriptions before system tables are subscribed.