### PR TITLE
fix remote lock EOF and OOM when lock table bind

### DIFF
--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -914,7 +914,7 @@ func (l *lockTableAllocator) getLockTablesLocked(group uint32) map[uint64]pb.Loc
 	if ok {
 		return m
 	}
-	m = make(map[uint64]pb.LockTable, 10240)
+	m = make(map[uint64]pb.LockTable, 128)
 	l.mu.lockTables[group] = m
 	return m
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20747 #20839

## What this PR does / why we need it:

fix remote lock EOF and OOM when lock table bind