### PR TITLE
[improvement] modify the default interval of truncate hakeeper logs.

### DIFF
--- a/pkg/logservice/config.go
+++ b/pkg/logservice/config.go
@@ -48,7 +48,7 @@ const (
 	defaultMaxExportedSnapshot = 20
 	defaultMaxMessageSize      = 1024 * 1024 * 100
 	// The default value for HAKeeper truncate interval.
-	defaultHAKeeperTruncateInterval = 24 * time.Hour
+	defaultHAKeeperTruncateInterval = 2 * time.Hour
 
 	DefaultListenHost     = "0.0.0.0"
 	DefaultServiceHost    = "127.0.0.1"

--- a/pkg/logservice/truncation.go
+++ b/pkg/logservice/truncation.go
@@ -203,12 +203,12 @@ func (l *store) processShardTruncateLog(ctx context.Context, shardID uint64) err
 	// Do NOT process before leader is OK.
 	leaderID, err := l.leaderID(shardID)
 	if err != nil {
-		l.runtime.Logger().Debug("cannot get leader ID, skip truncate",
+		l.runtime.Logger().Warn("cannot get leader ID, skip truncate",
 			zap.Uint64("shard ID", shardID))
 		return nil
 	}
 	if leaderID == 0 {
-		l.runtime.Logger().Debug("no leader yet, skip truncate",
+		l.runtime.Logger().Warn("no leader yet, skip truncate",
 			zap.Uint64("shard ID", shardID))
 		return nil
 	}

--- a/pkg/logservice/truncation_test.go
+++ b/pkg/logservice/truncation_test.go
@@ -19,12 +19,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lni/dragonboat/v4"
 	"github.com/lni/goutils/leaktest"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/hakeeper"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTruncationExportSnapshot(t *testing.T) {
@@ -313,6 +314,14 @@ func TestTruncationImportSnapshot2(t *testing.T) {
 
 	}
 	runServiceTest(t, false, true, fn)
+}
+
+func TestProcessShardTruncateLogError(t *testing.T) {
+	s := store{
+		nh:      &dragonboat.NodeHost{},
+		runtime: runtime.DefaultRuntime(),
+	}
+	assert.NoError(t, s.processShardTruncateLog(context.Background(), 100))
 }
 
 func TestHAKeeperTruncation2(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/4704

## What this PR does / why we need it:
modify the default interval of truncate hakeeper logs.