### PR TITLE
[bug] proxy: migrate session skip error when db is dropped

### DIFF
--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -1837,7 +1837,9 @@ func Migrate(ses *Session, req *query.MigrateConnToRequest) error {
 
 	dbm := newDBMigration(req.DB)
 	if err := dbm.Migrate(ctx, ses); err != nil {
-		return moerr.AttachCause(ctx, err)
+		ses.Warnf(ctx, "the database %s may have been deleted, "+
+			"so continue to mirgrate session, conn ID: %d, err: %v",
+			req.DB, req.ConnID, err)
 	}
 
 	var maxStmtID uint32

--- a/pkg/frontend/session_test.go
+++ b/pkg/frontend/session_test.go
@@ -28,6 +28,7 @@ import (
 
 	catalog2 "github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
@@ -498,11 +499,13 @@ func TestSession_updateTimeZone(t *testing.T) {
 }
 
 func TestSession_Migrate(t *testing.T) {
-	genSession := func(ctrl *gomock.Controller) *Session {
-		sv, err := getSystemVariables("test/system_vars_config.toml")
-		if err != nil {
-			t.Error(err)
-		}
+	sid := "ms1"
+
+	sv, err := getSystemVariables("test/system_vars_config.toml")
+	if err != nil {
+		t.Error(err)
+	}
+	genSession := func(ctrl *gomock.Controller, dbname string, e error) *Session {
 		sv.SkipCheckPrivilege = true
 		sv.SessionTimeout = toml.Duration{Duration: 10 * time.Second}
 		txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
@@ -532,7 +535,7 @@ func TestSession_Migrate(t *testing.T) {
 		db := mock_frontend.NewMockDatabase(ctrl)
 		eng.EXPECT().Hints().Return(hints).AnyTimes()
 		eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-		eng.EXPECT().Database(gomock.Any(), gomock.Any(), gomock.Any()).Return(db, nil).AnyTimes()
+		eng.EXPECT().Database(gomock.Any(), dbname, gomock.Any()).Return(db, e).AnyTimes()
 		rel := mock_frontend.NewMockRelation(ctrl)
 		rel.EXPECT().GetTableDef(gomock.Any()).Return(&plan.TableDef{}).AnyTimes()
 		rel.EXPECT().TableDefs(gomock.Any()).Return(nil, nil).AnyTimes()
@@ -540,23 +543,23 @@ func TestSession_Migrate(t *testing.T) {
 		rel.EXPECT().GetTableID(gomock.Any()).Return(tid).AnyTimes()
 		db.EXPECT().IsSubscription(gomock.Any()).Return(false).AnyTimes()
 		db.EXPECT().Relation(gomock.Any(), gomock.Any(), gomock.Any()).Return(rel, nil).AnyTimes()
-		setPu("", &config.ParameterUnit{
+		setPu(sid, &config.ParameterUnit{
 			SV:            sv,
 			TxnClient:     txnClient,
 			StorageEngine: eng,
 		})
 
 		mockBS := MockBaseService{}
-		rm, _ := NewRoutineManager(context.Background(), "")
+		rm, _ := NewRoutineManager(context.Background(), sid)
 		rm.baseService = &mockBS
-		setRtMgr("", rm)
+		setRtMgr(sid, rm)
 		ctx := defines.AttachAccountId(context.Background(), sysAccountID)
-		ioses, err := NewIOSession(&testConn{}, getPu(""), "")
+		ioses, err := NewIOSession(&testConn{}, getPu(sid), sid)
 		if err != nil {
 			panic(err)
 		}
-		proto := NewMysqlClientProtocol("", 0, ioses, 1024, sv)
-		session := NewSession(ctx, "", proto, nil)
+		proto := NewMysqlClientProtocol(sid, 0, ioses, 1024, sv)
+		session := NewSession(ctx, sid, proto, nil)
 		session.tenant = &TenantInfo{
 			Tenant:   GetDefaultTenant(),
 			TenantID: GetSysTenantId(),
@@ -566,26 +569,51 @@ func TestSession_Migrate(t *testing.T) {
 		session.setRoutineManager(rm)
 		return session
 	}
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
-	bh := &backgroundExecTest{}
-	bh.init()
+	t.Run("ok", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
-	defer bhStub.Reset()
+		bh := &backgroundExecTest{}
+		bh.init()
 
-	s := genSession(ctrl)
-	err := Migrate(s, &query.MigrateConnToRequest{
-		DB: "d1",
-		PrepareStmts: []*query.PrepareStmt{
-			{Name: "p1", SQL: `select ?`},
-			{Name: "p2", SQL: `select ?`},
-		},
+		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
+		defer bhStub.Reset()
+
+		runtime.SetupServiceBasedRuntime(sid, runtime.DefaultRuntime())
+		InitServerLevelVars(sid)
+		SetSessionAlloc(sid, NewSessionAllocator(&config.ParameterUnit{SV: sv}))
+		s := genSession(ctrl, "d1", nil)
+		err := Migrate(s, &query.MigrateConnToRequest{
+			DB: "d1",
+			PrepareStmts: []*query.PrepareStmt{
+				{Name: "p1", SQL: `select ?`},
+				{Name: "p2", SQL: `select ?`},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "d1", s.GetDatabaseName())
+		assert.Equal(t, 2, len(s.prepareStmts))
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, "d1", s.GetDatabaseName())
-	assert.Equal(t, 2, len(s.prepareStmts))
+
+	t.Run("db dropped", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		bh := &backgroundExecTest{}
+		bh.init()
+
+		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
+		defer bhStub.Reset()
+
+		runtime.SetupServiceBasedRuntime(sid, runtime.DefaultRuntime())
+		InitServerLevelVars(sid)
+		SetSessionAlloc(sid, NewSessionAllocator(&config.ParameterUnit{SV: sv}))
+		s := genSession(ctrl, "d2", context.Canceled)
+		err := Migrate(s, &query.MigrateConnToRequest{DB: "d2"})
+		assert.Equal(t, "", s.GetDatabaseName())
+		assert.NoError(t, err)
+	})
 }
 
 func Test_connectionid(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue [migrate session skip error when db is dropped](https://github.com/matrixorigin/MO-Cloud/issues/4724)

## What this PR does / why we need it:
migrate session skip error when db is dropped