### PR TITLE
[Cherry-pick] use full db.table path in insert stmt

### DIFF
--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1293,7 +1293,7 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 
 		// insert into new_table select default_val1, default_val2, ..., * from (select clause);
 		var insertSqlBuilder strings.Builder
-		insertSqlBuilder.WriteString(fmt.Sprintf("insert into `%s` select ", createTable.TableDef.Name))
+		insertSqlBuilder.WriteString(fmt.Sprintf("insert into `%s`.`%s` select ", createTable.Database, createTable.TableDef.Name))
 
 		cols := createTable.TableDef.Cols
 		firstCol := true

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -488,3 +488,36 @@ func TestParseDuration(t *testing.T) {
 		assert.Equal(t, err, c.expectedErr)
 	}
 }
+
+func Test_buildTableDefs(t *testing.T) {
+	stmt := &tree.CreateTable{
+		Temporary:          false,
+		IsClusterTable:     false,
+		IfNotExists:        false,
+		Table:              tree.TableName{},
+		Defs:               nil,
+		Options:            nil,
+		PartitionOption:    nil,
+		ClusterByOption:    nil,
+		Param:              nil,
+		AsSource:           &tree.Select{Select: &tree.SelectClause{From: &tree.From{}}},
+		IsDynamicTable:     false,
+		DTOptions:          nil,
+		IsAsSelect:         true,
+		IsAsLike:           false,
+		LikeTableName:      tree.TableName{},
+		SubscriptionOption: nil,
+	}
+
+	ctx := &MockCompilerContext{}
+
+	createTable := &plan.CreateTable{
+		Database: "db",
+		TableDef: &plan.TableDef{
+			Name: "table",
+		},
+	}
+
+	err := buildTableDefs(stmt, ctx, createTable, nil)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21131

## What this PR does / why we need it:
use full db.table path in insert stmt