### PR TITLE
chore: add account filter-condition to speedup etlmerge check-exist 

### DIFF
--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -316,21 +316,22 @@ func IsRecordExisted(ctx context.Context, record []string, tbl *table.Table, get
 
 	if tbl.Table == "statement_info" {
 		const stmtIDIndex = 0           // Replace with actual index for statement ID if different
+		const accountIndex = 3          // Replace with actual index for account
 		const statusIndex = 15          // Replace with actual index for status
 		const requestAtIndex = 12       // Replace with actual index for request_at
 		if len(record) <= statusIndex { // Use the largest index you will access
 			return false, nil
 		}
-		return isStatementExisted(ctx, dbConn, record[stmtIDIndex], record[statusIndex], record[requestAtIndex])
+		return isStatementExisted(ctx, dbConn, record[stmtIDIndex], record[statusIndex], record[requestAtIndex], record[accountIndex])
 	}
 
 	return false, nil
 }
 
-func isStatementExisted(ctx context.Context, db *sql.DB, stmtId string, status string, request_at string) (bool, error) {
+func isStatementExisted(ctx context.Context, db *sql.DB, stmtId string, status string, request_at, account string) (bool, error) {
 	var exists bool
-	query := "SELECT EXISTS(SELECT 1 FROM `system`.statement_info WHERE statement_id = ? AND status = ? AND request_at = ?)"
-	err := db.QueryRowContext(ctx, query, stmtId, status, request_at).Scan(&exists)
+	query := "SELECT EXISTS(SELECT 1 FROM `system`.statement_info WHERE statement_id = ? AND status = ? AND request_at = ? AND account = ?)"
+	err := db.QueryRowContext(ctx, query, stmtId, status, request_at, account).Scan(&exists)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/util/export/etl/db/db_holder_test.go
+++ b/pkg/util/export/etl/db/db_holder_test.go
@@ -78,13 +78,13 @@ func TestIsRecordExisted(t *testing.T) {
 
 	ctx := context.TODO()
 	// Assuming index 12 is for 'request_at', adding a mock value for it
-	record := []string{"12345", "", "", "", "", "", "", "", "", "", "", "", "2021-10-10 10:00:00", "", "", "active"}
+	record := []string{"12345", "", "", "sys", "", "", "", "", "", "", "", "", "2021-10-10 10:00:00", "", "", "active"}
 	table := &table.Table{Table: "statement_info"}
 
 	// Set up your mock expectations
 	mock.ExpectQuery(regexp.QuoteMeta(
-		"SELECT EXISTS(SELECT 1 FROM `system`.statement_info WHERE statement_id = ? AND status = ? AND request_at = ?)",
-	)).WithArgs(record[0], record[15], record[12]).WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+		"SELECT EXISTS(SELECT 1 FROM `system`.statement_info WHERE statement_id = ? AND status = ? AND request_at = ? AND account = ?)",
+	)).WithArgs(record[0], record[15], record[12], "sys").WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 
 	// Define a function that returns the mocked DB connection
 	getDBConn := func(forceNewConn bool, randomCN bool) (*sql.DB, error) {

--- a/pkg/util/export/merge.go
+++ b/pkg/util/export/merge.go
@@ -377,9 +377,11 @@ func (m *Merge) doMergeFiles(ctx context.Context, files []*FileMeta) error {
 			// Check if the first record already exists in the database
 			existed, err = db_holder.IsRecordExisted(ctx, firstLine, m.table, db_holder.GetOrInitDBConn)
 			if err != nil {
+				v2.TraceETLMergeExistFailedCounter.Inc()
 				m.logger.Error("error checking if the first record exists",
 					logutil.TableField(m.table.GetIdentify()),
 					logutil.PathField(fp.FilePath),
+					logutil.StatementField(firstLine[0]),
 					logutil.ErrorField(err),
 				)
 				return err

--- a/pkg/util/metric/v2/trace.go
+++ b/pkg/util/metric/v2/trace.go
@@ -140,6 +140,7 @@ var (
 	TraceETLMergeSuccessCounter = traceETLMergeCounter.WithLabelValues("success")
 	// TraceETLMergeExistCounter record already exist, against delete failed.
 	TraceETLMergeExistCounter        = traceETLMergeCounter.WithLabelValues("exist")
+	TraceETLMergeExistFailedCounter  = traceETLMergeCounter.WithLabelValues("exist_failed")
 	TraceETLMergeOpenFailedCounter   = traceETLMergeCounter.WithLabelValues("open_failed")
 	TraceETLMergeReadFailedCounter   = traceETLMergeCounter.WithLabelValues("read_failed")
 	TraceETLMergeParseFailedCounter  = traceETLMergeCounter.WithLabelValues("parse_failed")


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/MO-Cloud/issues/4730
parent pr
- https://github.com/matrixorigin/matrixone/pull/21132

## What this PR does / why we need it:
Add `account=?` filter-condition combined with `request_at=?` filter-condition.
-  base on statement_info's cluster-by key is `(account, request_at)`.