### PR TITLE
[bug] stats: fix hang issue when get stats

### DIFF
--- a/pkg/vm/engine/disttae/stats_test.go
+++ b/pkg/vm/engine/disttae/stats_test.go
@@ -52,7 +52,7 @@ func TestGetStats(t *testing.T) {
 	go func() {
 		time.Sleep(time.Millisecond * 20)
 		for _, tid := range tids {
-			gs.notifyLogtailUpdate(tid)
+			gs.notifyLogtailUpdate(tid, true)
 		}
 	}()
 	var wg sync.WaitGroup
@@ -233,7 +233,7 @@ func TestWaitLogtailUpdate(t *testing.T) {
 	tid = 200
 	go func() {
 		time.Sleep(time.Millisecond * 100)
-		gs.notifyLogtailUpdate(tid)
+		gs.notifyLogtailUpdate(tid, true)
 	}()
 	gs.waitLogtailUpdated(tid)
 }
@@ -301,7 +301,7 @@ func TestGlobalStats_ClearTables(t *testing.T) {
 	defer cancel()
 	gs := NewGlobalStats(ctx, nil, nil)
 	for i := 0; i < 10; i++ {
-		gs.notifyLogtailUpdate(uint64(2000 + i))
+		gs.notifyLogtailUpdate(uint64(2000+i), true)
 	}
 	assert.Equal(t, 10, len(gs.logtailUpdate.mu.updated))
 	gs.clearTables()

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1893,13 +1893,12 @@ func (tbl *txnTable) getPartitionState(
 
 func (tbl *txnTable) tryToSubscribe(ctx context.Context) (ps *logtailreplay.PartitionState, err error) {
 	eng := tbl.eng.(*Engine)
+	var createdInTxn bool
 	defer func() {
-		if err == nil {
-			eng.globalStats.notifyLogtailUpdate(tbl.tableId)
-		}
+		eng.globalStats.notifyLogtailUpdate(tbl.tableId, err == nil && !createdInTxn)
 	}()
 
-	createdInTxn, err := tbl.isCreatedInTxn(ctx)
+	createdInTxn, err = tbl.isCreatedInTxn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1907,8 +1906,8 @@ func (tbl *txnTable) tryToSubscribe(ctx context.Context) (ps *logtailreplay.Part
 		return
 	}
 
-	return eng.PushClient().toSubscribeTable(ctx, tbl)
-
+	ps, err = eng.PushClient().toSubscribeTable(ctx, tbl)
+	return ps, err
 }
 
 func (tbl *txnTable) PKPersistedBetween(


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20577 #21174 #21227

## What this PR does / why we need it:
in some case, some tables' subscription request fails and
it will wait for the notification forever. these waiting occupy
all the update stats goroutines which cause the real getting
stats request hang.