### PR TITLE
bug fix: Invalid search string converted to empty pattern to panic

### DIFF
--- a/pkg/fulltext/fulltext.go
+++ b/pkg/fulltext/fulltext.go
@@ -826,6 +826,10 @@ func ParsePatternInNLMode(pattern string) ([]*Pattern, error) {
 		}
 	}
 
+	if len(list) == 0 {
+		return nil, moerr.NewInternalErrorNoCtx("Invalid input search string.  search string onverted to empty pattern")
+	}
+
 	// assign index
 	idx := int32(0)
 	for _, p := range list {

--- a/pkg/fulltext/fulltext_test.go
+++ b/pkg/fulltext/fulltext_test.go
@@ -195,6 +195,23 @@ func TestPatternFail(t *testing.T) {
 	}
 }
 
+func TestPatternNLFail(t *testing.T) {
+
+	tests := []TestCase{
+		{
+			pattern: "+[[[",
+		},
+		{
+			pattern: "+''",
+		},
+	}
+
+	for _, c := range tests {
+		_, err := PatternToString(c.pattern, int64(tree.FULLTEXT_NL))
+		require.NotNil(t, err)
+	}
+}
+
 func TestFullTextNL(t *testing.T) {
 
 	pattern := "apple banana"

--- a/test/distributed/cases/fulltext/fulltext.result
+++ b/test/distributed/cases/fulltext/fulltext.result
@@ -11,6 +11,10 @@ insert into src values (0, 'color is red', 't1'), (1, 'car is yellow', 'crazy ca
 create fulltext index ftidx on src (body, title);
 select * from src where match(body) against('red');
 not supported: MATCH() AGAINST() function cannot be replaced by FULLTEXT INDEX and full table scan with fulltext search is not supported yet.
+select * from src where match(body,title) against('+]]]');
+internal error: Invalid input search string.  search string onverted to empty pattern
+select * from src where match(body,title) against('+I'm');
+SQL parser error: You have an error in your SQL syntax; check the manual that corresponds to your MatrixOne server version for the right syntax to use. syntax error at line 1 column 55 near "m');";
 select match(body) against('red') from src;
 not supported: MATCH() AGAINST() function cannot be replaced by FULLTEXT INDEX and full table scan with fulltext search is not supported yet.
 alter table src add fulltext index ftidx2 (body);

--- a/test/distributed/cases/fulltext/fulltext.sql
+++ b/test/distributed/cases/fulltext/fulltext.sql
@@ -17,6 +17,8 @@ create fulltext index ftidx on src (body, title);
 
 -- check fulltext_match with index error
 select * from src where match(body) against('red');
+select * from src where match(body,title) against('+]]]');
+select * from src where match(body,title) against('+I'm');
 
 select match(body) against('red') from src;
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21217

## What this PR does / why we need it:

 Invalid search string converted to empty pattern to panic

e.g. search string '+[[[' in natural language mode.  After tokenization, it become empty pattern that cause panic.