### PR TITLE
to 2.0: skip to subscribe to the deleted table when calculating the mo table stats.

### DIFF
--- a/pkg/vm/engine/disttae/cache/types.go
+++ b/pkg/vm/engine/disttae/cache/types.go
@@ -141,6 +141,10 @@ type TableItem struct {
 	ClusterByIdx int
 }
 
+func (item *TableItem) IsDeleted() bool {
+	return item.deleted
+}
+
 func (item *TableItem) String() string {
 	return fmt.Sprintln(
 		"item ptr", uintptr(unsafe.Pointer(item)),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/21213

## What this PR does / why we need it:
skip to subscribe to the deleted table when calculating the mo table stats. 

for the deleted tables:
1. should not subscribe
2. even subscribed, should failed

However, in the current implementation, the mo table stats task may subscribe to a deleted table and succeed, which may cause some other bugs. So, it tries to skip to subscribe to a deleted table.
