### PR TITLE
Revert "malloc: default to malloc (#21211)"

### DIFF
--- a/pkg/common/malloc/default.go
+++ b/pkg/common/malloc/default.go
@@ -74,7 +74,7 @@ func newDefault(delta *Config) (allocator Allocator) {
 	}()
 
 	if config.Allocator == nil {
-		config.Allocator = ptrTo("c")
+		config.Allocator = ptrTo("mmap")
 	}
 
 	switch strings.ToLower(*config.Allocator) {


### PR DESCRIPTION
This reverts commit 2f6f3d78a02e726f76e67594fc9973551c5b3bff.

## What type of PR is this?

- [ ] API-change
- [x ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/4753
## What this PR does / why we need it: 

revert 2f6f3d78a02e726f76e67594fc9973551c5b3bff