### PR TITLE
to 2.0: notify global stats when subscribed table.

### DIFF
--- a/pkg/vm/engine/disttae/mo_table_stats.go
+++ b/pkg/vm/engine/disttae/mo_table_stats.go
@@ -2245,10 +2245,11 @@ func subscribeTable(
 		databaseName: tbl.dbName,
 	}
 
+	txnTbl.eng = eng
 	txnTbl.relKind = tbl.relKind
 	txnTbl.primarySeqnum = tbl.pkSequence
 
-	if pState, err = eng.(*Engine).PushClient().toSubscribeTable(ctx, &txnTbl); err != nil {
+	if pState, err = txnTbl.tryToSubscribe(ctx); err != nil {
 		return nil, err
 	}
 

--- a/pkg/vm/engine/disttae/mo_table_stats.go
+++ b/pkg/vm/engine/disttae/mo_table_stats.go
@@ -2245,6 +2245,7 @@ func subscribeTable(
 		databaseName: tbl.dbName,
 	}
 
+	txnTbl.fake = true
 	txnTbl.eng = eng
 	txnTbl.relKind = tbl.relKind
 	txnTbl.primarySeqnum = tbl.pkSequence

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1240,6 +1240,11 @@ func (tbl *txnTable) isCreatedInTxn(ctx context.Context) (bool, error) {
 		return tbl.createdInTxn, nil
 	}
 
+	// test or mo_table_stats
+	if tbl.db.op == nil {
+		return false, nil
+	}
+
 	if tbl.db.op.IsSnapOp() || catalog.IsSystemTable(tbl.tableId) {
 		// if the operation is snapshot read, isCreatedInTxn can not be called by AlterTable
 		// So if the snapshot read want to subcribe logtail tail, let it go ahead.

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1236,13 +1236,13 @@ func (tbl *txnTable) UpdateConstraint(ctx context.Context, c *engine.ConstraintD
 //
 // 2. This check depends on replaying all catalog cache when cn starts.
 func (tbl *txnTable) isCreatedInTxn(ctx context.Context) (bool, error) {
-	if tbl.remoteWorkspace {
-		return tbl.createdInTxn, nil
+	// test or mo_table_stats
+	if tbl.fake {
+		return false, nil
 	}
 
-	// test or mo_table_stats
-	if tbl.db.op == nil {
-		return false, nil
+	if tbl.remoteWorkspace {
+		return tbl.createdInTxn, nil
 	}
 
 	if tbl.db.op.IsSnapOp() || catalog.IsSystemTable(tbl.tableId) {

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -1007,6 +1007,8 @@ type txnTable struct {
 	remoteWorkspace bool
 	createdInTxn    bool
 	eng             engine.Engine
+
+	fake bool
 }
 
 // FIXME: no pointer here


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/21213

## What this PR does / why we need it:
if no notify, global stats will wait forever.