### PR TITLE
fix mo_table_stats task panic and release mpool.

### DIFF
--- a/pkg/vm/engine/disttae/mo_table_stats.go
+++ b/pkg/vm/engine/disttae/mo_table_stats.go
@@ -2419,10 +2419,10 @@ func applyTombstones(
 	//
 	// here, we only collect the deletes that have not paired inserts
 	// according to its LESS function, the deletes come first
-	var lastInsert *logtailreplay.RowEntry
+	var lastInsert logtailreplay.RowEntry
 	err = pState.ScanRows(true, func(entry *logtailreplay.RowEntry) (bool, error) {
 		if !entry.Deleted {
-			lastInsert = entry
+			lastInsert = *entry
 			return true, nil
 		}
 

--- a/pkg/vm/engine/tae/rpc/handle_debug.go
+++ b/pkg/vm/engine/tae/rpc/handle_debug.go
@@ -227,6 +227,10 @@ func (h *Handle) HandleGetChangedTableList(
 	now = types.BuildTS(time.Now().UnixNano(), 0)
 
 	defer func() {
+		if data != nil {
+			data.Close()
+		}
+
 		tt := now.ToTimestamp()
 		resp.Newest = &tt
 	}()
@@ -270,6 +274,11 @@ func (h *Handle) HandleGetChangedTableList(
 	logutil.Info("handle get changed table list", zap.Int("got ckp", len(ckps)))
 
 	for i := 0; i < len(ckps); i++ {
+
+		if data != nil {
+			data.Close()
+		}
+
 		if ckps[i] == nil {
 			continue
 		}
@@ -310,19 +319,7 @@ func (h *Handle) HandleGetChangedTableList(
 				tblIdVec := bats[j].GetVectorByName(logtail.SnapshotAttr_TID)
 				commitVec := bats[j].GetVectorByName(objectio.DefaultCommitTS_Attr)
 				if dbIdVec.Length() <= k || tblIdVec.Length() <= k || commitVec.Length() <= k {
-					logutil.Error("dbId/tblId/commit vector length not match",
-						zap.String("dbId vector", dbIdVec.String()),
-						zap.String("tblId vector", tblIdVec.String()),
-						zap.String("commit vector", commitVec.String()))
-
-					// some wrong, return quickly?
-					//resp.AccIds = req.AccIds
-					//resp.TableIds = req.TableIds
-					//resp.DatabaseIds = req.DatabaseIds
-					//tt := now.ToTimestamp()
-					//resp.Newest = &tt
-
-					return nil, nil
+					continue
 				}
 
 				dbId := dbIdVec.Get(k).(uint64)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/21213

## What this PR does / why we need it:
1. beta task could panic
2. release ckp data