### PR TITLE
bugfix: adjust mo_logger use server side max_allowed_packet config

### DIFF
--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -121,7 +121,7 @@ func GetOrInitDBConn(forceNewConn bool, randomCN bool) (*sql.DB, error) {
 			return err
 		}
 		dsn :=
-			fmt.Sprintf("%s:%s@tcp(%s)/?readTimeout=10s&writeTimeout=15s&timeout=15s&maxAllowedPacket=67108864&disable_txn_trace=1",
+			fmt.Sprintf("%s:%s@tcp(%s)/?readTimeout=10s&writeTimeout=15s&timeout=15s&maxAllowedPacket=0&disable_txn_trace=1",
 				dbUser.UserName,
 				dbUser.Password,
 				dbAddress)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/4786

## What this PR does / why we need it:
mo_logger SHOULD use server side max_allowed_packet config