### PR TITLE
fix: doLock panic

### DIFF
--- a/pkg/sql/compile/lock_meta.go
+++ b/pkg/sql/compile/lock_meta.go
@@ -126,9 +126,8 @@ func (l *LockMeta) doLock(e engine.Engine, proc *process.Process) error {
 	lockDbs := make(map[string]struct{})
 	lockVec := l.lockTableVec
 
-	var bat *batch.Batch
+	bat := batch.NewWithSize(3)
 	if l.lockTableVec == nil {
-		bat = batch.NewWithSize(3)
 		for _, table := range tables {
 			names := strings.SplitN(table, " ", 2)
 			err = vector.AppendFixed(l.lockMetaVecs[0], accountId, false, proc.GetMPool()) //account_id


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/21364

## What this PR does / why we need it:
fix problem that bat is not initialization  causing panic when l.lockTableVec is not nil in dolck function  