### PR TITLE
refactor: compileTableScanDataSource relation reset

### DIFF
--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -113,7 +113,6 @@ func (s *Scope) resetForReuse(c *Compile) (err error) {
 	}
 
 	if s.DataSource != nil && !s.DataSource.isConst {
-		s.DataSource.Rel = nil
 		s.DataSource.R = nil
 	}
 
@@ -129,9 +128,6 @@ func (s *Scope) initDataSource(c *Compile) (err error) {
 		return nil
 	}
 
-	if s.DataSource.Rel != nil {
-		return nil
-	}
 	return c.compileTableScanDataSource(s)
 }
 

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2312,6 +2312,7 @@ func (tbl *txnTable) Reset(op client.TxnOperator) error {
 	tbl.proc.Store(txn.proc)
 	tbl.createdInTxn = false
 	tbl.lastTS = op.SnapshotTS()
+	tbl.resetSnapshot()
 	return nil
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/21237

## What this PR does / why we need it:
compileTableScanDataSource using relation reset interface