### PR TITLE
vector: always check types in *NoTypeCheck functions if race tag is set

### DIFF
--- a/pkg/container/vector/functionTool_test.go
+++ b/pkg/container/vector/functionTool_test.go
@@ -140,7 +140,7 @@ func TestReuseFunctionParameterFixed(t *testing.T) {
 	var err error
 	vec1 := NewVec(types.T_int32.ToType())
 	for i := uint64(0); i < 10; i++ {
-		err = appendOneFixed(vec1, i, false, mp)
+		err = appendOneFixed(vec1, int32(i), false, mp)
 		require.NoError(t, err)
 	}
 	g2 := GenerateFunctionFixedTypeParameter[int32](vec1)
@@ -162,7 +162,7 @@ func TestReuseFunctionParameterFixed(t *testing.T) {
 	ok = ReuseFunctionFixedTypeParameter(vec1, g2)
 	require.Equal(t, true, ok)
 
-	err = appendOneFixed(vec1, 0, false, mp)
+	err = appendOneFixed(vec1, int32(0), false, mp)
 	require.NoError(t, err)
 	ok = ReuseFunctionFixedTypeParameter(vec1, g2)
 	require.Equal(t, false, ok)

--- a/pkg/container/vector/type_check_no_race.go
+++ b/pkg/container/vector/type_check_no_race.go
@@ -1,0 +1,21 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !race
+
+package vector
+
+func checkTypeIfRaceDetectorEnabled[T any](vec *Vector) {
+	// do nothing
+}

--- a/pkg/container/vector/type_check_race.go
+++ b/pkg/container/vector/type_check_race.go
@@ -1,0 +1,21 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build race
+
+package vector
+
+func checkTypeIfRaceDetectorEnabled[T any](vec *Vector) {
+	checkType[T](vec)
+}

--- a/pkg/container/vector/utils.go
+++ b/pkg/container/vector/utils.go
@@ -336,7 +336,8 @@ func typeCompatible[T any](typ types.Type) bool {
 	var t T
 	switch (any)(t).(type) {
 	case types.Varlena:
-		return typ.IsVarlen()
+		return typ.IsVarlen() ||
+			typ.Oid == types.T_Rowid
 	case bool:
 		return typ.IsBoolean()
 	case int8:
@@ -346,7 +347,10 @@ func typeCompatible[T any](typ types.Type) bool {
 	case int32:
 		return typ.Oid == types.T_int32
 	case int64:
-		return typ.Oid == types.T_int64
+		return typ.Oid == types.T_int64 ||
+			typ.Oid == types.T_uint64 ||
+			typ.Oid == types.T_timestamp ||
+			typ.Oid == types.T_decimal64
 	case uint8:
 		return typ.Oid == types.T_uint8
 	case uint16:
@@ -354,7 +358,10 @@ func typeCompatible[T any](typ types.Type) bool {
 	case uint32:
 		return typ.Oid == types.T_uint32
 	case uint64:
-		return typ.Oid == types.T_uint64 || typ.Oid == types.T_bit
+		return typ.Oid == types.T_uint64 ||
+			typ.Oid == types.T_int64 ||
+			typ.Oid == types.T_bit ||
+			typ.Oid == types.T_decimal64
 	case float32:
 		return typ.Oid == types.T_float32
 	case float64:

--- a/pkg/container/vector/vector.go
+++ b/pkg/container/vector/vector.go
@@ -88,18 +88,24 @@ func (t *typedSlice) setFromVector(v *Vector) {
 }
 
 func ToSliceNoTypeCheck[T any](vec *Vector, ret *[]T) {
+	checkTypeIfRaceDetectorEnabled[T](vec)
 	*ret = unsafe.Slice((*T)(vec.col.Ptr), vec.col.Cap)
 }
 
 func ToSliceNoTypeCheck2[T any](vec *Vector) []T {
+	checkTypeIfRaceDetectorEnabled[T](vec)
 	return unsafe.Slice((*T)(vec.col.Ptr), vec.col.Cap)
 }
 
 func ToSlice[T any](vec *Vector, ret *[]T) {
-	if !typeCompatible[T](vec.typ) {
-		panic(fmt.Sprintf("type mismatch: %T %v", []T{}, vec.typ.String()))
-	}
+	checkType[T](vec)
 	*ret = unsafe.Slice((*T)(vec.col.Ptr), vec.col.Cap)
+}
+
+func checkType[T any](vec *Vector) {
+	if !typeCompatible[T](vec.typ) {
+		panic(fmt.Sprintf("type mismatch: casting %v vector to %T", vec.typ.String(), []T{}))
+	}
 }
 
 func (v *Vector) GetSorted() bool {

--- a/pkg/sql/colexec/multi_update/insert_test.go
+++ b/pkg/sql/colexec/multi_update/insert_test.go
@@ -249,7 +249,7 @@ func buildFlushS3InfoBatch(mp *mpool.MPool, hasUniqueKey bool, hasSecondaryKey b
 	totalRowCount := 0
 	for _, bat := range insertBats {
 		totalRowCount += bat.RowCount()
-		_ = vector.AppendFixed(retBat.Vecs[3], bat.RowCount(), false, mp)
+		_ = vector.AppendFixed[uint64](retBat.Vecs[3], uint64(bat.RowCount()), false, mp)
 
 		val, _ := bat.MarshalBinary()
 		_ = vector.AppendBytes(retBat.Vecs[5], val, false, mp)

--- a/pkg/sql/colexec/table_function/fulltext_test.go
+++ b/pkg/sql/colexec/table_function/fulltext_test.go
@@ -332,7 +332,7 @@ func makeBatchFT(proc *process.Process) *batch.Batch {
 	vector.AppendBytes(bat.Vecs[0], []byte("src_table"), false, proc.Mp())
 	vector.AppendBytes(bat.Vecs[1], []byte("idx_table"), false, proc.Mp())
 	vector.AppendBytes(bat.Vecs[2], []byte("pattern"), false, proc.Mp())
-	vector.AppendFixed[int64](bat.Vecs[3], int64(0), false, proc.Mp())
+	vector.AppendFixed[int32](bat.Vecs[3], int32(0), false, proc.Mp())
 
 	bat.SetRowCount(1)
 	return bat

--- a/pkg/sql/colexec/table_function/fulltext_tokenize_test.go
+++ b/pkg/sql/colexec/table_function/fulltext_tokenize_test.go
@@ -297,7 +297,7 @@ func makeBatchJSONFTT(proc *process.Process) *batch.Batch {
 	bat.Vecs[1] = vector.NewVec(types.New(types.T_varchar, 128, 0))
 
 	vector.AppendFixed[int32](bat.Vecs[0], int32(1), false, proc.Mp())
-	vector.AppendBytes(bat.Vecs[0], []byte("{\"a\":\"abcdedfghijklmnopqrstuvwxyz\"}"), false, proc.Mp())
+	vector.AppendBytes(bat.Vecs[1], []byte("{\"a\":\"abcdedfghijklmnopqrstuvwxyz\"}"), false, proc.Mp())
 
 	bat.SetRowCount(1)
 	return bat


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21384 

## What this PR does / why we need it:
to expose type mismatch bug