### PR TITLE
bug fix arm64 build docker failed

### DIFF
--- a/optools/images/Dockerfile
+++ b/optools/images/Dockerfile
@@ -1,16 +1,21 @@
-FROM golang:1.23.0-bookworm AS builder
+FROM ubuntu:22.04 AS builder
 
-# goproxy
-ARG GOPROXY="https://proxy.golang.org,direct"
-RUN go env -w GOPROXY=${GOPROXY}
 
 # Install some utilities used for debugging or by startup script
 RUN apt-get update && apt-get install -y \
+    golang-1.23 \
+    build-essential \
     dnsutils \
     curl \
     git \
     cmake \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH ${PATH}:/usr/lib/go-1.23/bin/
+
+# goproxy
+ARG GOPROXY="https://proxy.golang.org,direct"
+RUN go env -w GOPROXY=${GOPROXY}
 
 RUN mkdir -p /go/src/github.com/matrixorigin/matrixone
 
@@ -29,7 +34,6 @@ RUN make build
 
 FROM ubuntu:22.04
 
-
 COPY --from=builder /go/src/github.com/matrixorigin/matrixone/mo-service /mo-service
 COPY --from=builder /go/src/github.com/matrixorigin/matrixone/etc /etc
 COPY --from=builder /go/src/github.com/matrixorigin/matrixone/thirdparties/install/lib/*.so /usr/local/lib
@@ -46,7 +50,7 @@ RUN apt-get update && apt-get install -y \
 RUN ldconfig
 
 # Debug purpose - run below command to check shared library not found
-# RUN /mo-service -h
+RUN /mo-service -h
 
 WORKDIR /
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21453

## What this PR does / why we need it:

failed to build linux arm64 image with golang-1.23.0-bookworm base image.  Change the base image with ubuntu:22.04 which is the same as the docker image OS.