### PR TITLE
refactor: improve authenticateCanExecuteStatementAndPlan for execute …

### DIFF
--- a/test/distributed/cases/prepare/prepare.result
+++ b/test/distributed/cases/prepare/prepare.result
@@ -691,3 +691,12 @@ col1    col2    col1    col2
 drop table test_prepare_1;
 drop table test_prepare_2;
 drop database db1;
+create account prepare_account_01 ADMIN_NAME admin IDENTIFIED BY '111111';
+create role prepare_role1;
+grant create database on account * to prepare_role1;
+create user prepare_user1 identified by '123456' default role prepare_role1;
+select mo_ctl('cn', 'task', ':retention');
+internal error: do not have privilege to execute the statement
+drop user prepare_user1;
+drop role prepare_role1;
+drop account prepare_account_01;

--- a/test/distributed/cases/prepare/prepare.test
+++ b/test/distributed/cases/prepare/prepare.test
@@ -531,5 +531,26 @@ drop table test_prepare_1;
 drop table test_prepare_2;
 drop database db1;
 
+-- @session
+
+create account prepare_account_01 ADMIN_NAME admin IDENTIFIED BY '111111';
+-- @session:id=1&user=prepare_account_01:admin&password=111111
+create role prepare_role1;
+grant create database on account * to prepare_role1;
+create user prepare_user1 identified by '123456' default role prepare_role1;
+-- @session
+-- @session:id=2&user=prepare_account_01:prepare_user1:prepare_role1&password=123456
+select mo_ctl('cn', 'task', ':retention');
+
+-- @session:id=1&user=prepare_account_01:admin&password=111111
+drop user prepare_user1;
+drop role prepare_role1;
+
+-- @session
+
+drop account prepare_account_01;
+
+
+
 
 


### PR DESCRIPTION
…prepare stmt

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue # https://github.com/matrixorigin/matrixone/issues/21284

## What this PR does / why we need it:
the content of prepare sql don't need to authenticate when execute stmt