### PR TITLE
Split batchs for shuffleV2

### DIFF
--- a/pkg/sql/colexec/shuffleV2/shuffle.go
+++ b/pkg/sql/colexec/shuffleV2/shuffle.go
@@ -84,7 +84,7 @@ func (shuffle *ShuffleV2) Call(proc *process.Process) (vm.CallResult, error) {
 	}
 
 	if shuffle.ctr.ending {
-		_ = shuffle.ctr.shufflePool.getEndingBatch(shuffle.CurrentShuffleIdx, proc, shuffle.IsDebug)
+		shuffle.ctr.shufflePool.waitBatchOrEnd(shuffle.CurrentShuffleIdx, proc)
 		result.Batch = batch.EmptyBatch
 		return result, nil
 	}

--- a/pkg/sql/colexec/shuffleV2/shuffle.go
+++ b/pkg/sql/colexec/shuffleV2/shuffle.go
@@ -59,22 +59,46 @@ func (shuffle *ShuffleV2) Call(proc *process.Process) (vm.CallResult, error) {
 	analyzer := shuffle.OpAnalyzer
 
 	result := vm.NewCallResult()
-SENDLAST:
-	if shuffle.ctr.ending { //send last batch in shuffle pool
-		result.Batch = shuffle.ctr.shufflePool.getEndingBatch(shuffle.ctr.buf, shuffle.CurrentShuffleIdx, proc, shuffle.IsDebug)
-		shuffle.ctr.buf = result.Batch
+
+	if shuffle.ctr.buf != nil {
+		shuffle.ctr.buf.Clean(proc.Mp())
+		shuffle.ctr.buf = nil
+	}
+
+	tmpBat := shuffle.ctr.shufflePool.getFullBatch(shuffle.CurrentShuffleIdx)
+	if tmpBat != nil && tmpBat.RowCount() > 0 {
+		shuffle.ctr.buf = tmpBat
+		result.Batch = shuffle.ctr.buf
 		return result, nil
 	}
 
-	var err error
-	for {
-		tmpBat := shuffle.ctr.shufflePool.getFullBatch(shuffle.ctr.buf, shuffle.CurrentShuffleIdx)
-		if tmpBat != nil && tmpBat.RowCount() > 0 { // find a full batch
+	if shuffle.ctr.shufflePool.allStop() {
+		shuffle.ctr.ending = true
+		tmpBat := shuffle.ctr.shufflePool.getLastBatch(shuffle.CurrentShuffleIdx)
+		if tmpBat != nil {
 			shuffle.ctr.buf = tmpBat
-			break
+			result.Batch = tmpBat
+			return result, nil
 		}
+		return vm.CancelResult, nil
+	}
+
+	if shuffle.ctr.ending {
+		_ = shuffle.ctr.shufflePool.getEndingBatch(shuffle.CurrentShuffleIdx, proc, shuffle.IsDebug)
+		result.Batch = batch.EmptyBatch
+		return result, nil
+	}
+
+	for {
+		tmpBat := shuffle.ctr.shufflePool.getFullBatch(shuffle.CurrentShuffleIdx)
+		if tmpBat != nil { // find a full batch
+			shuffle.ctr.buf = tmpBat
+			result.Batch = shuffle.ctr.buf
+			return result, nil
+		}
+
 		// do input
-		result, err = vm.ChildrenCall(shuffle.GetChildren(0), proc, analyzer)
+		result, err := vm.ChildrenCall(shuffle.GetChildren(0), proc, analyzer)
 		if err != nil {
 			return result, err
 		}
@@ -82,7 +106,8 @@ SENDLAST:
 		if bat == nil {
 			shuffle.ctr.ending = true
 			shuffle.ctr.shufflePool.stopWriting()
-			goto SENDLAST
+			result.Batch = batch.EmptyBatch
+			return result, nil
 		} else if !bat.IsEmpty() {
 			if shuffle.ShuffleType == int32(plan.ShuffleType_Hash) {
 				bat, err = hashShuffle(shuffle, bat, proc)
@@ -99,9 +124,6 @@ SENDLAST:
 			}
 		}
 	}
-	// send the batch
-	result.Batch = shuffle.ctr.buf
-	return result, nil
 }
 
 func (shuffle *ShuffleV2) clearSels() [][]int32 {

--- a/pkg/sql/colexec/shuffleV2/shufflepool.go
+++ b/pkg/sql/colexec/shuffleV2/shufflepool.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -60,7 +59,7 @@ type ShufflePoolV2 struct {
 	holders       int32
 	finished      int32
 	stoppers      int32
-	batches       []*batch.Batch
+	batches       []*batch.CompactBatchs
 	holderLock    sync.Mutex
 	statsLock     sync.Mutex
 	batchLocks    []sync.Mutex
@@ -74,7 +73,10 @@ func NewShufflePool(bucketNum int32, maxHolders int32) *ShufflePoolV2 {
 	sp.holders = 0
 	sp.finished = 0
 	sp.stoppers = 0
-	sp.batches = make([]*batch.Batch, sp.bucketNum)
+	sp.batches = make([]*batch.CompactBatchs, sp.bucketNum)
+	for i := range sp.batches {
+		sp.batches[i] = batch.NewCompactBatchs()
+	}
 	sp.batchLocks = make([]sync.Mutex, bucketNum)
 	sp.endingWaiters = make([]chan bool, bucketNum)
 	sp.batchWaiters = make([]chan bool, bucketNum)
@@ -111,6 +113,12 @@ func (sp *ShufflePoolV2) stopWriting() {
 			sp.endingWaiters[i] <- true
 		}
 	}
+}
+
+func (sp *ShufflePoolV2) allStop() bool {
+	sp.holderLock.Lock()
+	defer sp.holderLock.Unlock()
+	return sp.stoppers == sp.maxHolders
 }
 
 func (sp *ShufflePoolV2) Reset(m *mpool.MPool) {
@@ -153,94 +161,75 @@ func (sp *ShufflePoolV2) DebugPrint() { // only for debug
 }
 
 // shuffle operator is ending, release buf and sending remaining batches
-func (sp *ShufflePoolV2) getEndingBatch(buf *batch.Batch, shuffleIDX int32, proc *process.Process, isDebug bool) *batch.Batch {
+func (sp *ShufflePoolV2) getEndingBatch(shuffleIDX int32, proc *process.Process, isDebug bool) *batch.Batch {
 	if isDebug {
-		return sp.batches[shuffleIDX]
+		return sp.batches[shuffleIDX].PopFront()
 	}
 	for {
-		bat := sp.getFullBatch(buf, shuffleIDX)
-		if bat != nil && bat.RowCount() > 0 {
-			return bat
-		}
 		select {
 		case <-sp.batchWaiters[shuffleIDX]:
-			bat = sp.getFullBatch(buf, shuffleIDX)
-			if bat != nil && bat.RowCount() > 0 {
-				return bat
-			}
+			// bat := sp.getFullBatch(shuffleIDX)
+			// if bat != nil && bat.RowCount() > 0 {
+			// 	return bat
+			// }
+			return nil
 		case <-sp.endingWaiters[shuffleIDX]:
-			if buf != nil {
-				buf.Clean(proc.Mp())
-			}
-			sp.endingWaiters[shuffleIDX] <- true
-			bat = sp.batches[shuffleIDX]
-			sp.batches[shuffleIDX] = nil
+
 			//if bat != nil {
 			//sp.statsLock.Lock()
 			//sp.stats.outputCNT[shuffleIDX] += int64(bat.RowCount())
 			//sp.statsLock.Unlock()
 			//}
-			return bat
+			return nil
 		case <-proc.Ctx.Done():
-			if buf != nil {
-				buf.Clean(proc.Mp())
-			}
 			return nil
 		}
 	}
 }
 
 // if there is full batch  in pool, return it and put buf in the place to continue writing into pool
-func (sp *ShufflePoolV2) getFullBatch(buf *batch.Batch, shuffleIDX int32) *batch.Batch {
+func (sp *ShufflePoolV2) getFullBatch(shuffleIDX int32) *batch.Batch {
 	sp.batchLocks[shuffleIDX].Lock()
 	defer sp.batchLocks[shuffleIDX].Unlock()
-	bat := sp.batches[shuffleIDX]
-	if bat == nil || bat.RowCount() < colexec.DefaultBatchSize { // not full
-		return nil
+	var bat *batch.Batch
+	if sp.batches[shuffleIDX].Length() > 1 {
+		bat = sp.batches[shuffleIDX].PopFront()
 	}
-	//find a full batch, put buf in place
-	if buf != nil {
-		buf.CleanOnlyData()
-		buf.ShuffleIDX = bat.ShuffleIDX
-	}
-	sp.batches[shuffleIDX] = buf
-	//sp.statsLock.Lock()
-	//sp.stats.outputCNT[shuffleIDX] += int64(bat.RowCount())
-	//sp.statsLock.Unlock()
 	return bat
 }
 
-func (sp *ShufflePoolV2) initBatch(srcBatch *batch.Batch, proc *process.Process, shuffleIDX int32) error {
-	bat := sp.batches[shuffleIDX]
-	if bat == nil {
-		var err error
-		bat, err = proc.NewBatchFromSrc(srcBatch, colexec.DefaultBatchSize)
-		if err != nil {
-			return err
-		}
-		bat.ShuffleIDX = shuffleIDX
-		sp.batches[shuffleIDX] = bat
-	}
-	return nil
+func (sp *ShufflePoolV2) getLastBatch(shuffleIDX int32) *batch.Batch {
+	sp.batchLocks[shuffleIDX].Lock()
+	defer sp.batchLocks[shuffleIDX].Unlock()
+
+	bat := sp.batches[shuffleIDX].Pop()
+	return bat
 }
 
 func (sp *ShufflePoolV2) putAllBatchIntoPoolByShuffleIdx(srcBatch *batch.Batch, proc *process.Process, shuffleIDX int32) error {
 	sp.batchLocks[shuffleIDX].Lock()
 	defer sp.batchLocks[shuffleIDX].Unlock()
-	var err error
-	sp.batches[shuffleIDX], err = sp.batches[shuffleIDX].AppendWithCopy(proc.Ctx, proc.Mp(), srcBatch)
+
+	err := sp.batches[shuffleIDX].Extend(proc.Mp(), srcBatch)
 	if err != nil {
 		return err
 	}
+	if sp.batches[shuffleIDX].Length() > 1 && len(sp.batchWaiters[shuffleIDX]) == 0 {
+		sp.batchWaiters[shuffleIDX] <- true
+	}
+	// sp.batches[shuffleIDX], err = sp.batches[shuffleIDX].AppendWithCopy(proc.Ctx, proc.Mp(), srcBatch)
+	// if err != nil {
+	// 	return err
+	// }
 	//sp.statsLock.Lock()
 	//if sp.batches[shuffleIDX].RowCount() > sp.stats.maxBatchCNT {
 	//	sp.stats.maxBatchCNT = sp.batches[shuffleIDX].RowCount()
 	//}
 	//sp.stats.inputCNT[shuffleIDX] += int64(srcBatch.RowCount())
 	//sp.statsLock.Unlock()
-	if sp.batches[shuffleIDX].RowCount() >= colexec.DefaultBatchSize && len(sp.batchWaiters[shuffleIDX]) == 0 {
-		sp.batchWaiters[shuffleIDX] <- true
-	}
+	// if sp.batches[shuffleIDX].RowCount() >= colexec.DefaultBatchSize && len(sp.batchWaiters[shuffleIDX]) == 0 {
+	// 	sp.batchWaiters[shuffleIDX] <- true
+	// }
 	return nil
 }
 
@@ -250,26 +239,36 @@ func (sp *ShufflePoolV2) putBatchIntoShuffledPoolsBySels(srcBatch *batch.Batch, 
 		currentSels := sels[i]
 		if len(currentSels) > 0 {
 			sp.batchLocks[i].Lock()
-			err = sp.initBatch(srcBatch, proc, int32(i))
+			err = sp.batches[i].Union(proc.Mp(), srcBatch, currentSels)
 			if err != nil {
 				sp.batchLocks[i].Unlock()
 				return err
 			}
-			bat := sp.batches[i]
-			for vecIndex := range bat.Vecs {
-				v := bat.Vecs[vecIndex]
-				v.SetSorted(false)
-				err = v.UnionInt32(srcBatch.Vecs[vecIndex], currentSels, proc.Mp())
-				if err != nil {
-					sp.batchLocks[i].Unlock()
-					return err
-				}
-			}
-			bat.AddRowCount(len(currentSels))
-			if bat.RowCount() >= colexec.DefaultBatchSize && len(sp.batchWaiters[i]) == 0 {
+			if sp.batches[i].Length() > 1 && len(sp.batchWaiters[i]) == 0 {
 				sp.batchWaiters[i] <- true
 			}
 			sp.batchLocks[i].Unlock()
+
+			// err = sp.initBatch(srcBatch, proc, int32(i))
+			// if err != nil {
+			// 	sp.batchLocks[i].Unlock()
+			// 	return err
+			// }
+			// bat := sp.batches[i].Get(0)
+			// for vecIndex := range bat.Vecs {
+			// 	v := bat.Vecs[vecIndex]
+			// 	v.SetSorted(false)
+			// 	err = v.UnionInt32(srcBatch.Vecs[vecIndex], currentSels, proc.Mp())
+			// 	if err != nil {
+			// 		sp.batchLocks[i].Unlock()
+			// 		return err
+			// 	}
+			// }
+			// bat.AddRowCount(len(currentSels))
+			// if bat.RowCount() >= colexec.DefaultBatchSize && len(sp.batchWaiters[i]) == 0 {
+			// 	sp.batchWaiters[i] <- true
+			// }
+			// sp.batchLocks[i].Unlock()
 			//sp.statsLock.Lock()
 			//sp.stats.inputCNT[i] += int64(len(currentSels))
 			//if bat.RowCount() > sp.stats.maxBatchCNT {

--- a/pkg/sql/colexec/shuffleV2/types.go
+++ b/pkg/sql/colexec/shuffleV2/types.go
@@ -86,6 +86,7 @@ func (shuffle *ShuffleV2) GetShufflePool() *ShufflePoolV2 {
 func (shuffle *ShuffleV2) Reset(proc *process.Process, pipelineFailed bool, err error) {
 	if shuffle.ctr.buf != nil {
 		shuffle.ctr.buf.Clean(proc.Mp())
+		shuffle.ctr.buf = nil
 	}
 	if shuffle.ctr.shufflePool != nil {
 		shuffle.ctr.shufflePool.Reset(proc.Mp())


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #21414

## What this PR does / why we need it:
Split batchs for shuffleV2

目前会存在当消费较慢，桶又相对集中的情况下。不停append到一个桶里（而桶只是一个batch），从而造成这个batch过大，超过2G的阈值。
这里是把桶的batch从一个batch修改为一个batch数组。避免单个batch过大，顺便重构了下执行逻辑。

从21414的case看，出bug的SQL性能基本一样，跑4-5次看结果还略快了一点。但不一定有普遍意义。