### PR TITLE
fix adding incorrect delete entris to partition state index 2.1

### DIFF
--- a/pkg/objectio/name.go
+++ b/pkg/objectio/name.go
@@ -62,6 +62,10 @@ func (s *ObjectNameShort) Equal(o []byte) bool {
 	return bytes.Equal(s[:], o)
 }
 
+func (s *ObjectNameShort) ShortString() string {
+	return fmt.Sprintf("%v_%d", s.Segmentid().ShortString(), s.Num())
+}
+
 func (o ObjectName) UnsafeString() string {
 	return util.UnsafeBytesToString(o[NameStringOff : NameStringOff+NameStringLen])
 }

--- a/pkg/vm/engine/disttae/logtailreplay/partition.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition.go
@@ -17,6 +17,7 @@ package logtailreplay
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -200,14 +201,15 @@ func (p *Partition) Truncate(ctx context.Context, ids [2]uint64, ts types.TS) er
 
 	state := curState.Copy()
 
+	inst := time.Now()
 	state.truncate(ids, ts)
 
 	if !p.state.CompareAndSwap(curState, state) {
 		panic("concurrent mutation")
 	}
 
-	logutil.Infof("Truncate:table name:%s,tid:%v partition state from %p to %p,startTs:%s",
-		p.TableInfo.Name, p.TableInfo.ID, curState, state, ts.ToString())
+	logutil.Infof("Truncate:table name:%s,tid:%v partition state from %p to %p,startTs:%s, cost:%s",
+		p.TableInfo.Name, p.TableInfo.ID, curState, state, ts.ToString(), time.Since(inst))
 
 	return nil
 }

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state_test.go
@@ -69,12 +69,6 @@ func TestTruncate(t *testing.T) {
 	partition.truncate([2]uint64{0, 0}, types.BuildTS(1, 0))
 	assert.Equal(t, 5, partition.dataObjectTSIndex.Len())
 
-	partition.truncate([2]uint64{0, 0}, types.BuildTS(2, 0))
-	assert.Equal(t, 3, partition.dataObjectTSIndex.Len())
-
-	partition.truncate([2]uint64{0, 0}, types.BuildTS(3, 0))
-	assert.Equal(t, 1, partition.dataObjectTSIndex.Len())
-
 	partition.truncate([2]uint64{0, 0}, types.BuildTS(4, 0))
 	assert.Equal(t, 1, partition.dataObjectTSIndex.Len())
 }
@@ -88,6 +82,13 @@ func addObject(p *PartitionState, create, delete types.TS) {
 		IsDelete:     false,
 	}
 	p.dataObjectTSIndex.Set(objIndex1)
+	id := objectio.NewObjectid()
+	stats := objectio.NewObjectStatsWithObjectID(&id, false, false, false)
+	p.dataObjectsNameIndex.Set(objectio.ObjectEntry{
+		ObjectStats: *stats,
+		CreateTime:  create,
+		DeleteTime:  delete,
+	})
 	if !delete.IsEmpty() {
 		objIndex2 := ObjectIndexByTSEntry{
 			Time:         delete,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/5083

## What this PR does / why we need it:

- remove wrong entries in dataObjectTSIndex