### PR TITLE
fix adding incorrect delete entris to partition state index 2.1

### DIFF
--- a/pkg/objectio/name.go
+++ b/pkg/objectio/name.go
@@ -62,6 +62,10 @@ func (s *ObjectNameShort) Equal(o []byte) bool {
 	return bytes.Equal(s[:], o)
 }
 
+func (s *ObjectNameShort) ShortString() string {
+	return fmt.Sprintf("%v_%d", s.Segmentid().ShortString(), s.Num())
+}
+
 func (o ObjectName) UnsafeString() string {
 	return util.UnsafeBytesToString(o[NameStringOff : NameStringOff+NameStringLen])
 }

--- a/pkg/vm/engine/disttae/logtailreplay/partition.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition.go
@@ -17,6 +17,7 @@ package logtailreplay
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -200,14 +201,15 @@ func (p *Partition) Truncate(ctx context.Context, ids [2]uint64, ts types.TS) er
 
 	state := curState.Copy()
 
+	inst := time.Now()
 	state.truncate(ids, ts)
 
 	if !p.state.CompareAndSwap(curState, state) {
 		panic("concurrent mutation")
 	}
 
-	logutil.Infof("Truncate:table name:%s,tid:%v partition state from %p to %p,startTs:%s",
-		p.TableInfo.Name, p.TableInfo.ID, curState, state, ts.ToString())
+	logutil.Infof("Truncate:table name:%s,tid:%v partition state from %p to %p,startTs:%s, cost:%s",
+		p.TableInfo.Name, p.TableInfo.ID, curState, state, ts.ToString(), time.Since(inst))
 
 	return nil
 }

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state_test.go
@@ -69,12 +69,6 @@ func TestTruncate(t *testing.T) {
 	partition.truncate([2]uint64{0, 0}, types.BuildTS(1, 0))
 	assert.Equal(t, 5, partition.dataObjectTSIndex.Len())
 
-	partition.truncate([2]uint64{0, 0}, types.BuildTS(2, 0))
-	assert.Equal(t, 3, partition.dataObjectTSIndex.Len())
-
-	partition.truncate([2]uint64{0, 0}, types.BuildTS(3, 0))
-	assert.Equal(t, 1, partition.dataObjectTSIndex.Len())
-
 	partition.truncate([2]uint64{0, 0}, types.BuildTS(4, 0))
 	assert.Equal(t, 1, partition.dataObjectTSIndex.Len())
 }
@@ -88,6 +82,14 @@ func addObject(p *PartitionState, create, delete types.TS) {
 		IsDelete:     false,
 	}
 	p.dataObjectTSIndex.Set(objIndex1)
+
+	objId := objectio.NewObjectid()
+	stats := objectio.NewObjectStatsWithObjectID(&objId, false, true, false)
+	p.dataObjectsNameIndex.Set(objectio.ObjectEntry{
+		ObjectStats: *stats,
+		CreateTime:  create,
+		DeleteTime:  delete,
+	})
 	if !delete.IsEmpty() {
 		objIndex2 := ObjectIndexByTSEntry{
 			Time:         delete,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/5083

## What this PR does / why we need it:

- remove wrong entries in dataObjectTSIndex


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed incorrect handling of delete entries in `dataObjectTSIndex`.

- Improved logging with execution time and optimized string building.

- Added a new `ShortString` method for `ObjectNameShort`.

- Enhanced garbage collection logic in `PartitionState`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>name.go</strong><dd><code>Add `ShortString` method to `ObjectNameShort`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/name.go

<li>Added a <code>ShortString</code> method to <code>ObjectNameShort</code>.<br> <li> Improved string representation for object segments.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21562/files#diff-25ec402a08205c219c0aaa243f943678bac20dcd37656fe8cb1d7212a22f22d8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>partition.go</strong><dd><code>Add execution time logging in `Truncate`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/logtailreplay/partition.go

<li>Added execution time logging in <code>Truncate</code>.<br> <li> Enhanced log message with additional details.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21562/files#diff-97e37bd57cb97218ce530996c896f5bb824e4079d6eca11a5bda714068960c54">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>partition_state.go</strong><dd><code>Fix delete entry handling and optimize GC logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/logtailreplay/partition_state.go

<li>Fixed logic for handling delete entries in <code>dataObjectTSIndex</code>.<br> <li> Replaced string concatenation with <code>strings.Builder</code> for efficiency.<br> <li> Improved garbage collection logging for partition state.<br> <li> Removed commented-out code for cleanup.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21562/files#diff-e6df770d1a9df923a1dd64003c965c09737142851e172029adebfbf5030484a7">+11/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>