### PR TITLE
to 2.1: fix the prepare.test BVT case.

### DIFF
--- a/test/distributed/cases/prepare/prepare.result
+++ b/test/distributed/cases/prepare/prepare.result
@@ -692,18 +692,11 @@ drop table test_prepare_1;
 drop table test_prepare_2;
 drop database db1;
 create account prepare_account_01 ADMIN_NAME admin IDENTIFIED BY '111111';
-[unknown result because it is related to issue#21511]
 create role prepare_role1;
-[unknown result because it is related to issue#21511]
 grant create database on account * to prepare_role1;
-[unknown result because it is related to issue#21511]
 create user prepare_user1 identified by '123456' default role prepare_role1;
-[unknown result because it is related to issue#21511]
 select mo_ctl('cn', 'task', ':retention');
-[unknown result because it is related to issue#21511]
+internal error: do not have privilege to execute the statement
 drop user prepare_user1;
-[unknown result because it is related to issue#21511]
 drop role prepare_role1;
-[unknown result because it is related to issue#21511]
 drop account prepare_account_01;
-[unknown result because it is related to issue#21511]

--- a/test/distributed/cases/prepare/prepare.test
+++ b/test/distributed/cases/prepare/prepare.test
@@ -457,12 +457,11 @@ drop database db2;
 drop account if exists prepare_acc01;
 create account prepare_acc01 admin_name = 'test_prepare_account' identified by '111';
 
--- @session:id=2&user=prepare_acc01:test_prepare_account&password=111
+-- @session:id=1&user=prepare_acc01:test_prepare_account&password=111
 create database db1;
 use db1;
 prepare stmt1x from 'select count(*) from system.statement_info limit 0';
 execute stmt1x;
-
 -- @session
 
 drop account prepare_acc01;
@@ -531,26 +530,22 @@ drop table test_prepare_1;
 drop table test_prepare_2;
 drop database db1;
 
--- @bvt:issue#21511
 create account prepare_account_01 ADMIN_NAME admin IDENTIFIED BY '111111';
--- @session:id=1&user=prepare_account_01:admin&password=111111
+-- @session:id=2&user=prepare_account_01:admin&password=111111
 create role prepare_role1;
 grant create database on account * to prepare_role1;
 create user prepare_user1 identified by '123456' default role prepare_role1;
 -- @session
--- @session:id=2&user=prepare_account_01:prepare_user1:prepare_role1&password=123456
+-- @session:id=3&user=prepare_account_01:prepare_user1:prepare_role1&password=123456
 select mo_ctl('cn', 'task', ':retention');
 -- @session
 
--- @session:id=1&user=prepare_account_01:admin&password=111111
+-- @session:id=4&user=prepare_account_01:admin&password=111111
 drop user prepare_user1;
 drop role prepare_role1;
-
 -- @session
 
 drop account prepare_account_01;
--- @bvt:issue
-
 
 
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/21511

## What this PR does / why we need it:
it seems that the connection ID must be unique in different sessions in a single BVT file, or the mo-tester cannot handle the connection correctly.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed session connection ID issues in BVT tests.

- Updated expected results for privilege-related errors.

- Adjusted session IDs and user roles in test cases.

- Removed outdated or redundant comments in test files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prepare.result</strong><dd><code>Update expected results and remove placeholders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/prepare/prepare.result

<li>Updated expected results for privilege-related errors.<br> <li> Removed placeholder comments related to issue #21511.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21569/files#diff-862caf39970e783c64c68f2b43fd86a66a8b06a355733fefb389c7e91f47e47b">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prepare.test</strong><dd><code>Fix session IDs and clean up test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/prepare/prepare.test

<li>Fixed session connection ID inconsistencies.<br> <li> Adjusted session IDs and user roles for clarity.<br> <li> Removed outdated comments and issue references.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21569/files#diff-69f654e48a17e2eb0ca3a2e135a4a5fad30a8fffae37f3a7ed8700432e640d3e">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>