### PR TITLE
fix timeout

### DIFF
--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool.go
@@ -173,10 +173,10 @@ func (c *wrappedClient) Append(
 	}()
 
 	for {
-		ctx, cancel := context.WithTimeoutCause(
+		retryCtx, cancel := context.WithTimeoutCause(
 			ctx, DefaultOneTryTimeout, timeoutCause,
 		)
-		psn, err = c.wrapped.Append(ctx, c.buf)
+		psn, err = c.wrapped.Append(retryCtx, c.buf)
 		cancel()
 		if err == nil {
 			break

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/driver.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/driver.go
@@ -260,14 +260,14 @@ func (d *LogServiceDriver) readFromBackend(
 	defer client.Putback()
 
 	for {
-		ctx, cancel := context.WithTimeoutCause(
+		retryCtx, cancel := context.WithTimeoutCause(
 			ctx,
 			DefaultOneTryTimeout,
 			moerr.CauseReadFromLogService,
 		)
 
 		if records, nextPSN, err = client.wrapped.Read(
-			ctx, firstPSN, uint64(maxSize),
+			retryCtx, firstPSN, uint64(maxSize),
 		); err == nil {
 			cancel()
 			break

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/options.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/options.go
@@ -28,16 +28,15 @@ import (
 const (
 	DefaultMaxClient     = 100
 	DefaultClientBufSize = mpool.MB
-	DefaultMaxTimeout    = time.Second * 30
-	DefaultMaxRetryCount = 10
+	DefaultMaxTimeout    = time.Minute * 3
+	DefaultOneTryTimeout = time.Minute
 )
 
 type Config struct {
 	ClientMaxCount int
 	ClientBufSize  int
 
-	MaxTimeout    time.Duration
-	MaxRetryCount int
+	MaxTimeout time.Duration
 
 	ClientFactory LogServiceClientFactory
 	IsMockBackend bool
@@ -95,12 +94,6 @@ func WithConfigOptMaxTimeout(timeout time.Duration) ConfigOption {
 	}
 }
 
-func WithConfigOptMaxRetryCount(retryCount int) ConfigOption {
-	return func(cfg *Config) {
-		cfg.MaxRetryCount = retryCount
-	}
-}
-
 func WithConfigMockClient(backend MockBackend) ConfigOption {
 	return func(cfg *Config) {
 		cfg.IsMockBackend = true
@@ -131,8 +124,6 @@ func (cfg Config) String() string {
 	w.WriteString(strconv.Itoa(cfg.ClientBufSize))
 	w.WriteString(",MaxTimeout:")
 	w.WriteString(cfg.MaxTimeout.String())
-	w.WriteString(",MaxRetryCount:")
-	w.WriteString(strconv.Itoa(cfg.MaxRetryCount))
 	w.WriteString(",IsMockBackend:")
 	w.WriteString(strconv.FormatBool(cfg.IsMockBackend))
 	w.WriteString("}")
@@ -140,9 +131,6 @@ func (cfg Config) String() string {
 }
 
 func (cfg *Config) fillDefaults() {
-	if cfg.MaxRetryCount <= 0 {
-		cfg.MaxRetryCount = DefaultMaxRetryCount
-	}
 	if cfg.ClientMaxCount <= 0 {
 		cfg.ClientMaxCount = DefaultMaxClient
 	}
@@ -160,9 +148,18 @@ func (cfg *Config) validate() {
 	}
 }
 
-func (cfg Config) RetryInterval() time.Duration {
-	if cfg.MaxRetryCount == 0 {
-		return 0
+// RetryInterval returns exponential backoff interval based on retry count
+// Starting from 100ms, doubles each time up to max 4s
+// retry 0: 100ms
+// retry 1: 200ms
+// retry 2: 400ms
+// retry 3: 800ms
+// retry 4: 1600ms
+// retry 5+: 4000ms
+func (cfg Config) RetryInterval(thisRetry int) time.Duration {
+	interval := time.Millisecond * 100
+	for i := 0; i < thisRetry && interval < time.Second*4; i++ {
+		interval *= 2
 	}
-	return cfg.MaxTimeout / time.Duration(cfg.MaxRetryCount) / 100
+	return interval
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21045 #21573 

## What this PR does / why we need it:

fix connect logservice timeout


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed timeout handling in logservice operations.

- Introduced exponential backoff for retry intervals.

- Replaced fixed retry count with time-based retries.

- Updated default timeout configurations for better performance.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clientpool.go</strong><dd><code>Refactor retry and timeout logic in clientpool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool.go

<li>Replaced fixed retry count with time-based retries.<br> <li> Adjusted timeout logic to use <code>DefaultOneTryTimeout</code>.<br> <li> Added exponential backoff for retry intervals.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21570/files#diff-e3d1fd613cbdade8761171f2eff93cc208ebf1098ac3eb67ec4102c96b307fd5">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>driver.go</strong><dd><code>Refactor retry and timeout logic in driver</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logstore/driver/logservicedriver/driver.go

<li>Replaced fixed retry count with time-based retries.<br> <li> Adjusted timeout logic to use <code>DefaultOneTryTimeout</code>.<br> <li> Added exponential backoff for retry intervals.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21570/files#diff-c809e3292d74849efb85e4e95183b4dcbad5486a6cd1bb0e5695c59936a19618">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>options.go</strong><dd><code>Update configuration and retry interval logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logstore/driver/logservicedriver/options.go

<li>Introduced <code>DefaultOneTryTimeout</code> constant.<br> <li> Removed <code>MaxRetryCount</code> configuration.<br> <li> Implemented exponential backoff for retry intervals.<br> <li> Updated default timeout values for better performance.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21570/files#diff-f29a795c95c6304d11b3c01d832d310813f4f90720c0d74f8ae472689cc2480a">+16/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>truncate.go</strong><dd><code>Refactor retry and timeout logic in truncate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logstore/driver/logservicedriver/truncate.go

<li>Replaced fixed retry count with time-based retries.<br> <li> Adjusted timeout logic to use <code>MaxTimeout</code>.<br> <li> Added exponential backoff for retry intervals.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21570/files#diff-996fd476c61e0bb12d604fb0fccd01759eec8c8108ac006b947b877f5b4c4ddf">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>