### PR TITLE
Fix get snapshot "file not found" error 

### DIFF
--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -7024,6 +7024,13 @@ func TestSnapshotGC(t *testing.T) {
 	err = tbl2.RecurLoop(p)
 	assert.NoError(t, err)
 	assert.True(t, checkPK == db.DiskCleaner.GetCleaner().GetTablePK(checkrel.ID()))
+
+	fault.Enable()
+	defer fault.Disable()
+	fault.AddFaultPoint(ctx, "replay error UT", ":::", "echo", 0, "test error", false)
+	defer fault.RemoveFaultPoint(ctx, "replay error UT")
+	tae.Restart(ctx)
+	assert.Nil(t, tae.DiskCleaner.GetCleaner().GetScannedWindow())
 }
 
 func TestSnapshotMeta(t *testing.T) {
@@ -7355,6 +7362,32 @@ func TestPitrMeta(t *testing.T) {
 	if db.Runtime.Scheduler.GetPenddingLSNCnt() != 0 {
 		return
 	}
+	txn, err = db.StartTxn(nil)
+	require.NoError(t, err)
+	db1, err = txn.GetDatabase("db1")
+	assert.NoError(t, err)
+	rel, err = db1.GetRelationByName(pitrSchema.Name)
+	assert.NoError(t, err)
+	filter = handle.NewEQFilter([]byte("account"))
+	id, offset, err = rel.GetByFilter(context.Background(), filter)
+	assert.NoError(t, err)
+	_, _, err = rel.GetValue(id, offset, 5, false)
+	assert.NoError(t, err)
+	err = rel.RangeDelete(id, offset, offset, handle.DT_Normal)
+	if err != nil {
+		t.Logf("range delete %v, rollbacking", err)
+		_ = txn.Rollback(context.Background())
+		return
+	}
+	assert.NoError(t, err)
+	assert.NoError(t, txn.Commit(context.Background()))
+	testutils.WaitExpect(10000, func() bool {
+		return db.Runtime.Scheduler.GetPenddingLSNCnt() == 0
+	})
+	if db.Runtime.Scheduler.GetPenddingLSNCnt() != 0 {
+		return
+	}
+	db.ForceCheckpoint(ctx, tae.TxnMgr.Now())
 	db.DiskCleaner.GetCleaner().EnableGC()
 	assert.Equal(t, uint64(0), db.Runtime.Scheduler.GetPenddingLSNCnt())
 	initMinMerged := db.DiskCleaner.GetCleaner().GetMinMerged()

--- a/pkg/vm/engine/tae/logtail/snapshot.go
+++ b/pkg/vm/engine/tae/logtail/snapshot.go
@@ -707,18 +707,25 @@ func (sm *SnapshotMeta) Update(
 		ckputil.ObjectType_Tombstone,
 		collector,
 	)
-	for id, info := range sm.pitr.objects {
-		if !info.deleteAt.IsEmpty() {
-			delete(sm.pitr.objects, id)
+
+	trimList := func(
+		objects map[uint64]map[objectio.Segmentid]*objectInfo,
+		objects2 map[objectio.Segmentid]*objectInfo) {
+		for _, objs := range objects {
+			for id, info := range objs {
+				if !info.deleteAt.IsEmpty() {
+					delete(objs, id)
+				}
+			}
 		}
-	}
-	for _, objs := range sm.objects {
-		for id, info := range objs {
+		for id, info := range objects2 {
 			if !info.deleteAt.IsEmpty() {
-				delete(objs, id)
+				delete(objects2, id)
 			}
 		}
 	}
+	trimList(sm.objects, sm.pitr.objects)
+	trimList(sm.tombstones, sm.pitr.tombstones)
 	return
 }
 


### PR DESCRIPTION
### **User description**
Fix get snapshot "file not found" error

Approved by: @XuPeng-SH

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/5081

## What this PR does / why we need it:
Fix get snapshot "file not found" error


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug in the replay mechanism of the checkpoint cleaner to handle errors and reset states properly.

- Enhanced error handling in `DiskCleaner` by using atomic pointers for replay errors.

- Added fault injection points and corresponding test cases for replay error scenarios.

- Refactored snapshot metadata update logic to improve object trimming and cleanup.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>checkpoint.go</strong><dd><code>Enhanced checkpoint replay error handling and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/gc/v3/checkpoint.go

<li>Added error handling to reset mutation states on replay failure.<br> <li> Introduced fault injection for testing replay errors.<br> <li> Improved logging for replay operations.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21581/files#diff-d24973cd30186f29b82d463b1bcfc1c7b13a57164046448a2064207f0bad1824">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>diskcleaner.go</strong><dd><code>Improved DiskCleaner error handling and replay logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/gc/v3/diskcleaner.go

<li>Replaced <code>atomic.Value</code> with <code>atomic.Pointer</code> for replay errors.<br> <li> Updated replay logic to handle errors more robustly.<br> <li> Improved error storage and reset mechanisms.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21581/files#diff-3588223f757a63825e1ca6ed9fe0809bd4a4af1190392e99d819f1998af39402">+9/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db_test.go</strong><dd><code>Added tests for replay error handling and GC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/test/db_test.go

<li>Added fault injection tests for replay error scenarios.<br> <li> Enhanced test coverage for snapshot garbage collection.<br> <li> Verified state reset after replay errors.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21581/files#diff-858060e31b5a9bf1276488170b96f1f70e3d50b9ef08c44bba5d7acf5778d0a3">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapshot.go</strong><dd><code>Refactored snapshot metadata update and cleanup logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/snapshot.go

<li>Refactored object trimming logic for snapshot metadata.<br> <li> Unified cleanup for objects and tombstones.<br> <li> Improved maintainability of snapshot update function.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21581/files#diff-111781ff442a07a8deefe4a9fa1e799b2b5da03309f03c042a9b9b83e33a21be">+14/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>