### PR TITLE
update fatal print with more context

### DIFF
--- a/pkg/vm/engine/disttae/stats.go
+++ b/pkg/vm/engine/disttae/stats.go
@@ -945,7 +945,7 @@ func UpdateStats(ctx context.Context, req *updateStatsRequest, executor Concurre
 		if req.statsInfo.MaxValMap[colName] < req.statsInfo.MinValMap[colName] {
 			logutil.Errorf("error happended in stats!")
 		}
-		logutil.Infof("debug: table %v tablecnt %v  col %v max %v min %v ndv %v overlap %v maxndv %v maxobj %v ndvinmaxobj %v minobj %v ndvinminobj %v",
+		logutil.Debugf("debug: table %v tablecnt %v  col %v max %v min %v ndv %v overlap %v maxndv %v maxobj %v ndvinmaxobj %v minobj %v ndvinminobj %v",
 			baseTableDef.Name, info.TableCnt, colName, req.statsInfo.MaxValMap[colName], req.statsInfo.MinValMap[colName],
 			req.statsInfo.NdvMap[colName], overlap, info.MaxNDVs[i], info.MaxOBJSize, info.NDVinMaxOBJ[i], info.MinOBJSize, info.NDVinMinOBJ[i])
 	}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1012,6 +1012,7 @@ func (tbl *txnTable) collectUnCommittedDataObjs(
 	unCommittedObjects []objectio.ObjectStats,
 	unCommittedObjNames map[objectio.ObjectNameShort]struct{},
 ) {
+	unCommittedObjNames = make(map[objectio.ObjectNameShort]struct{})
 	if tbl.db.op.IsSnapOp() {
 		txnOffset = tbl.getTxn().GetSnapshotWriteOffset()
 	}

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -527,7 +527,7 @@ func (txn *Transaction) PPString() string {
 
 func (txn *Transaction) StartStatement() {
 	if txn.startStatementCalled {
-		logutil.Fatal("BUG: StartStatement called twice")
+		logutil.Fatal("BUG: StartStatement called twice", zap.String("txn", hex.EncodeToString(txn.op.Txn().ID)))
 	}
 	txn.startStatementCalled = true
 	txn.incrStatementCalled = false
@@ -535,7 +535,7 @@ func (txn *Transaction) StartStatement() {
 
 func (txn *Transaction) EndStatement() {
 	if !txn.startStatementCalled {
-		logutil.Fatal("BUG: StartStatement not called")
+		logutil.Fatal("BUG: StartStatement not called", zap.String("txn", hex.EncodeToString(txn.op.Txn().ID)))
 	}
 
 	txn.startStatementCalled = false
@@ -547,10 +547,10 @@ func (txn *Transaction) IncrStatementID(ctx context.Context, commit bool) error 
 	defer txn.op.ExitIncrStmt()
 	if !commit {
 		if !txn.startStatementCalled {
-			logutil.Fatal("BUG: StartStatement not called")
+			logutil.Fatal("BUG: StartStatement not called", zap.String("txn", hex.EncodeToString(txn.op.Txn().ID)))
 		}
 		if txn.incrStatementCalled {
-			logutil.Fatal("BUG: IncrStatementID called twice")
+			logutil.Fatal("BUG: IncrStatementID called twice", zap.String("txn", hex.EncodeToString(txn.op.Txn().ID)))
 		}
 		txn.incrStatementCalled = true
 	}

--- a/pkg/vm/engine/tae/catalog/catalog.go
+++ b/pkg/vm/engine/tae/catalog/catalog.go
@@ -181,7 +181,7 @@ func (catalog *Catalog) GCByTS(ctx context.Context, ts types.TS) {
 		needGC := te.DeleteBefore(ts)
 		if needGC {
 			db := te.db
-			db.RemoveEntry(te)
+			db.RemoveEntry(te, "GC")
 			tblCnt++
 		}
 		return nil

--- a/pkg/vm/engine/tae/catalog/database.go
+++ b/pkg/vm/engine/tae/catalog/database.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
+	"go.uber.org/zap"
 )
 
 type accessInfo struct {
@@ -419,9 +420,12 @@ func (e *DBEntry) RollbackRenameTable(fullname string, tid uint64) {
 	e.removeNameIndexLocked(fullname, tid)
 }
 
-func (e *DBEntry) RemoveEntry(table *TableEntry) (err error) {
-	logutil.Info("[Catalog]", common.OperationField("remove"),
-		common.OperandField(table.String()))
+func (e *DBEntry) RemoveEntry(table *TableEntry, reason string) (err error) {
+	logutil.Info(
+		"Catalog-Trace-RM-TBL",
+		zap.String("table", table.String()),
+		zap.String("reason", reason),
+	)
 	e.Lock()
 	defer e.Unlock()
 	if n, ok := e.entries[table.ID]; !ok {

--- a/pkg/vm/engine/tae/catalog/table.go
+++ b/pkg/vm/engine/tae/catalog/table.go
@@ -663,7 +663,7 @@ func (entry *TableEntry) PrepareRollback() (err error) {
 		return
 	}
 	if isEmpty {
-		err = entry.GetDB().RemoveEntry(entry)
+		err = entry.GetDB().RemoveEntry(entry, "Rollback")
 		if err != nil {
 			return
 		}

--- a/pkg/vm/engine/tae/txn/txnimpl/table.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table.go
@@ -868,7 +868,7 @@ func (tbl *txnTable) Append(ctx context.Context, data *containers.Batch) (err er
 	if tbl.dataTable.tableSpace == nil {
 		tbl.dataTable.tableSpace = newTableSpace(tbl, false)
 	}
-	_, err = tbl.dataTable.tableSpace.Append(data)
+	err = tbl.dataTable.tableSpace.Append(data)
 	return
 }
 func (tbl *txnTable) AddDataFiles(ctx context.Context, stats containers.Vector) (err error) {
@@ -1609,15 +1609,17 @@ func (tbl *txnTable) DeleteByPhyAddrKeys(
 	if tbl.tombstoneTable == nil {
 		tbl.tombstoneTable = newBaseTable(tbl.entry.GetLastestSchema(true), true, tbl)
 	}
-	err = tbl.dedup(tbl.store.ctx, deleteBatch.GetVectorByName(objectio.TombstoneAttr_Rowid_Attr), true)
-	if err != nil {
+	if err = tbl.dedup(
+		tbl.store.ctx,
+		deleteBatch.GetVectorByName(objectio.TombstoneAttr_Rowid_Attr),
+		true,
+	); err != nil {
 		return
 	}
 	if tbl.tombstoneTable.tableSpace == nil {
 		tbl.tombstoneTable.tableSpace = newTableSpace(tbl, true)
 	}
-	_, err = tbl.tombstoneTable.tableSpace.Append(deleteBatch)
-	if err != nil {
+	if err = tbl.tombstoneTable.tableSpace.Append(deleteBatch); err != nil {
 		return
 	}
 	if dt == handle.DT_MergeCompact {

--- a/pkg/vm/engine/tae/txn/txnimpl/table_space.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table_space.go
@@ -17,7 +17,6 @@ package txnimpl
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -292,7 +291,7 @@ func (space *tableSpace) CloseAppends() {
 }
 
 // Append appends batch of data into anode.
-func (space *tableSpace) Append(data *containers.Batch) (dur float64, err error) {
+func (space *tableSpace) Append(data *containers.Batch) (err error) {
 	if space.appendable == nil {
 		space.registerANode()
 	}
@@ -308,7 +307,6 @@ func (space *tableSpace) Append(data *containers.Batch) (dur float64, err error)
 		}
 		dedupType := space.table.store.txn.GetDedupType()
 		if schema.HasPK() && !dedupType.SkipWorkSpace() {
-			now := time.Now()
 			if err = space.index.BatchInsert(
 				data.Attrs[schema.GetSingleSortKeyIdx()],
 				data.Vecs[schema.GetSingleSortKeyIdx()],
@@ -318,7 +316,6 @@ func (space *tableSpace) Append(data *containers.Batch) (dur float64, err error)
 				false); err != nil {
 				break
 			}
-			dur += time.Since(now).Seconds()
 		}
 		offset += appended
 		space.rows += appended

--- a/pkg/vm/engine/tae/txn/txnimpl/table_space.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table_space.go
@@ -170,7 +170,11 @@ func (space *tableSpace) prepareApplyANode(node *anode, startOffset uint32) erro
 				return err
 			}
 			appender = space.tableHandle.SetAppender(objH.Fingerprint())
-			logutil.Info("CreateObject", zap.String("objH", appender.GetID().ObjectString()), zap.String("txn", node.GetTxn().String()))
+			logutil.Info(
+				"Workspace-New-AObject",
+				zap.String("name", appender.GetID().ObjectString()),
+				zap.String("txn", node.GetTxn().String()),
+			)
 			objH.Close()
 		}
 		if !appender.IsSameColumns(space.table.GetLocalSchema(space.isTombstone)) {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #21602 

## What this PR does / why we need it:

update fatal print with more context


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored logging to provide more context and consistency:
  - Replaced `logutil.Infof` with `logutil.Debugf` or `logutil.Info` for better log level usage.
  - Enhanced error and debug logs with additional context using `zap` fields.
  - Updated fatal logs to include transaction IDs for debugging.

- Removed unused or commented-out code to improve codebase maintainability.

- Improved function signatures to include additional parameters for better traceability.

- Enhanced garbage collection and snapshot-related logging for better traceability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>stats.go</strong><dd><code>Updated logging levels and added context to debug logs</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21607/files#diff-d0f8ce84135a062e5992dcb3d1175993ee396beae48de126969255cd9240d02b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>txn_table.go</strong><dd><code>Enhanced logging with error handling and removed unused code</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21607/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+19/-79</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Added transaction ID context to fatal logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21607/files#diff-2d4ca99c63be4d7a3464a5089669767530c849522edfe3030145a5b059775852">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>catalog.go</strong><dd><code>Updated function to include reason parameter in logging</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21607/files#diff-c942af281aef8741f696ca2ae2ccc57aa59dee5520fdfb7a0f4c67a4e70f939c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>database.go</strong><dd><code>Enhanced logging with reason parameter for table removal</code>&nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21607/files#diff-c54ecf2f56733033a88c6ae533ad878909366fd7d5166d12149e23fdec8e5116">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>table.go</strong><dd><code>Updated rollback logging to include reason for removal</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21607/files#diff-e8150a24b9afd22197ca003bbc47e435ee0357a8b96474a0a118a8e8222c7dd7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>snapshot.go</strong><dd><code>Improved snapshot and garbage collection logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21607/files#diff-111781ff442a07a8deefe4a9fa1e799b2b5da03309f03c042a9b9b83e33a21be">+40/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>table_space.go</strong><dd><code>Enhanced logging for object creation in table space</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21607/files#diff-eb2583ca6c5dea86857b6c9ba7eff911e281c04e71c85d0dfa46eec9f80f3178">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>