### PR TITLE
[improvement] frontend: add sql to fatal log

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2689,7 +2689,7 @@ func executeStmtWithWorkspace(ses FeSession,
 	defer ses.ExitFPrint(FPExecStmtWithWorkspaceBeforeStart)
 	//!!!NOTE!!!: statement management
 	//2. start statement on workspace
-	txnOp.GetWorkspace().StartStatement(execCtx.stmt.String())
+	txnOp.GetWorkspace().StartStatement(execCtx.stmt)
 	//3. end statement on workspace
 	// defer Start/End Statement management, called after finishTxnFunc()
 	defer func() {

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2689,7 +2689,7 @@ func executeStmtWithWorkspace(ses FeSession,
 	defer ses.ExitFPrint(FPExecStmtWithWorkspaceBeforeStart)
 	//!!!NOTE!!!: statement management
 	//2. start statement on workspace
-	txnOp.GetWorkspace().StartStatement()
+	txnOp.GetWorkspace().StartStatement(execCtx.stmt.String())
 	//3. end statement on workspace
 	// defer Start/End Statement management, called after finishTxnFunc()
 	defer func() {

--- a/pkg/frontend/test/txn_mock.go
+++ b/pkg/frontend/test/txn_mock.go
@@ -1238,15 +1238,15 @@ func (mr *MockWorkspaceMockRecorder) SetHaveDDL(flag interface{}) *gomock.Call {
 }
 
 // StartStatement mocks base method.
-func (m *MockWorkspace) StartStatement() {
+func (m *MockWorkspace) StartStatement(arg0 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartStatement")
+	m.ctrl.Call(m, "StartStatement", arg0)
 }
 
 // StartStatement indicates an expected call of StartStatement.
-func (mr *MockWorkspaceMockRecorder) StartStatement() *gomock.Call {
+func (mr *MockWorkspaceMockRecorder) StartStatement(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartStatement", reflect.TypeOf((*MockWorkspace)(nil).StartStatement))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartStatement", reflect.TypeOf((*MockWorkspace)(nil).StartStatement), arg0)
 }
 
 // UpdateSnapshotWriteOffset mocks base method.

--- a/pkg/frontend/test/txn_mock.go
+++ b/pkg/frontend/test/txn_mock.go
@@ -13,6 +13,7 @@ import (
 	lock "github.com/matrixorigin/matrixone/pkg/pb/lock"
 	timestamp "github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	txn "github.com/matrixorigin/matrixone/pkg/pb/txn"
+	tree "github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	client "github.com/matrixorigin/matrixone/pkg/txn/client"
 	rpc "github.com/matrixorigin/matrixone/pkg/txn/rpc"
 )
@@ -1238,7 +1239,7 @@ func (mr *MockWorkspaceMockRecorder) SetHaveDDL(flag interface{}) *gomock.Call {
 }
 
 // StartStatement mocks base method.
-func (m *MockWorkspace) StartStatement(arg0 string) {
+func (m *MockWorkspace) StartStatement(arg0 tree.Statement) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "StartStatement", arg0)
 }

--- a/pkg/frontend/txn_test.go
+++ b/pkg/frontend/txn_test.go
@@ -74,9 +74,9 @@ func newTestWorkspace() *testWorkspace {
 	return &testWorkspace{}
 }
 
-func (txn *testWorkspace) StartStatement() {
+func (txn *testWorkspace) StartStatement(sql string) {
 	if txn.start {
-		panic("BUG: StartStatement called twice")
+		panic(fmt.Sprintf("BUG: StartStatement called twice, sql: %s", sql))
 	}
 	txn.start = true
 	txn.incr = false
@@ -177,7 +177,7 @@ func TestWorkspace(t *testing.T) {
 		convey.So(
 			func() {
 				wsp := newTestWorkspace()
-				wsp.StartStatement()
+				wsp.StartStatement("")
 				wsp.EndStatement()
 			},
 			convey.ShouldNotPanic,
@@ -196,8 +196,8 @@ func TestWorkspace(t *testing.T) {
 		convey.So(
 			func() {
 				wsp := newTestWorkspace()
-				wsp.StartStatement()
-				wsp.StartStatement()
+				wsp.StartStatement("")
+				wsp.StartStatement("")
 			},
 			convey.ShouldPanic,
 		)
@@ -217,7 +217,7 @@ func TestWorkspace(t *testing.T) {
 		convey.So(
 			func() {
 				wsp := newTestWorkspace()
-				wsp.StartStatement()
+				wsp.StartStatement("")
 				err := wsp.IncrStatementID(context.TODO(), false)
 				convey.So(err, convey.ShouldBeNil)
 				//incr twice
@@ -231,7 +231,7 @@ func TestWorkspace(t *testing.T) {
 		convey.So(
 			func() {
 				wsp := newTestWorkspace()
-				wsp.StartStatement()
+				wsp.StartStatement("")
 				err := wsp.RollbackLastStatement(context.TODO())
 				convey.So(err, convey.ShouldBeNil)
 			},
@@ -242,7 +242,7 @@ func TestWorkspace(t *testing.T) {
 		convey.So(
 			func() {
 				wsp := newTestWorkspace()
-				wsp.StartStatement()
+				wsp.StartStatement("")
 				err := wsp.IncrStatementID(context.TODO(), false)
 				convey.So(err, convey.ShouldBeNil)
 				err = wsp.RollbackLastStatement(context.TODO())
@@ -484,7 +484,7 @@ func Test_rollbackStatement(t *testing.T) {
 			NeedToBeCommittedInActiveTransaction(&tree.Insert{}), convey.ShouldBeFalse)
 		convey.So(txnOp != nil && !ses.IsDerivedStmt(), convey.ShouldBeTrue)
 		//called incrStatement
-		txnOp.GetWorkspace().StartStatement()
+		txnOp.GetWorkspace().StartStatement("")
 		err = txnOp.GetWorkspace().IncrStatementID(ctx, false)
 		convey.So(err, convey.ShouldBeNil)
 		ec.stmt = &tree.Insert{}
@@ -514,7 +514,7 @@ func Test_rollbackStatement(t *testing.T) {
 			NeedToBeCommittedInActiveTransaction(&tree.Insert{}), convey.ShouldBeFalse)
 		convey.So(txnOp != nil && !ses.IsDerivedStmt(), convey.ShouldBeTrue)
 		//called incrStatement
-		txnOp.GetWorkspace().StartStatement()
+		txnOp.GetWorkspace().StartStatement("")
 		err = txnOp.GetWorkspace().IncrStatementID(ctx, false)
 		convey.So(err, convey.ShouldBeNil)
 		ec.stmt = &tree.Insert{}
@@ -671,7 +671,7 @@ func Test_rollbackStatement5(t *testing.T) {
 			NeedToBeCommittedInActiveTransaction(&tree.Insert{}), convey.ShouldBeFalse)
 		convey.So(txnOp != nil && !ses.IsDerivedStmt(), convey.ShouldBeTrue)
 		//called incrStatement
-		txnOp.GetWorkspace().StartStatement()
+		txnOp.GetWorkspace().StartStatement("")
 		err = txnOp.GetWorkspace().IncrStatementID(ctx, false)
 		convey.So(err, convey.ShouldBeNil)
 		ec.stmt = &tree.Insert{}
@@ -710,7 +710,7 @@ func Test_rollbackStatement6(t *testing.T) {
 			NeedToBeCommittedInActiveTransaction(&tree.Insert{}), convey.ShouldBeFalse)
 		convey.So(txnOp != nil && !ses.IsDerivedStmt(), convey.ShouldBeTrue)
 		//called incrStatement
-		txnOp.GetWorkspace().StartStatement()
+		txnOp.GetWorkspace().StartStatement("")
 		err = txnOp.GetWorkspace().IncrStatementID(ctx, false)
 		convey.So(err, convey.ShouldBeNil)
 		ec.stmt = &tree.Insert{}
@@ -745,7 +745,7 @@ func Test_rollbackStatement6(t *testing.T) {
 			NeedToBeCommittedInActiveTransaction(&tree.Insert{}), convey.ShouldBeFalse)
 		convey.So(txnOp != nil && !ses.IsDerivedStmt(), convey.ShouldBeTrue)
 		//called incrStatement
-		txnOp.GetWorkspace().StartStatement()
+		txnOp.GetWorkspace().StartStatement("")
 		err = txnOp.GetWorkspace().IncrStatementID(ctx, false)
 		convey.So(err, convey.ShouldBeNil)
 		ec.stmt = &tree.Insert{}

--- a/pkg/frontend/txn_test.go
+++ b/pkg/frontend/txn_test.go
@@ -74,8 +74,12 @@ func newTestWorkspace() *testWorkspace {
 	return &testWorkspace{}
 }
 
-func (txn *testWorkspace) StartStatement(sql string) {
+func (txn *testWorkspace) StartStatement(stmt tree.Statement) {
 	if txn.start {
+		var sql string
+		if stmt != nil {
+			sql = stmt.String()
+		}
 		panic(fmt.Sprintf("BUG: StartStatement called twice, sql: %s", sql))
 	}
 	txn.start = true
@@ -177,7 +181,7 @@ func TestWorkspace(t *testing.T) {
 		convey.So(
 			func() {
 				wsp := newTestWorkspace()
-				wsp.StartStatement("")
+				wsp.StartStatement(nil)
 				wsp.EndStatement()
 			},
 			convey.ShouldNotPanic,
@@ -196,8 +200,8 @@ func TestWorkspace(t *testing.T) {
 		convey.So(
 			func() {
 				wsp := newTestWorkspace()
-				wsp.StartStatement("")
-				wsp.StartStatement("")
+				wsp.StartStatement(nil)
+				wsp.StartStatement(nil)
 			},
 			convey.ShouldPanic,
 		)
@@ -217,7 +221,7 @@ func TestWorkspace(t *testing.T) {
 		convey.So(
 			func() {
 				wsp := newTestWorkspace()
-				wsp.StartStatement("")
+				wsp.StartStatement(nil)
 				err := wsp.IncrStatementID(context.TODO(), false)
 				convey.So(err, convey.ShouldBeNil)
 				//incr twice
@@ -231,7 +235,7 @@ func TestWorkspace(t *testing.T) {
 		convey.So(
 			func() {
 				wsp := newTestWorkspace()
-				wsp.StartStatement("")
+				wsp.StartStatement(nil)
 				err := wsp.RollbackLastStatement(context.TODO())
 				convey.So(err, convey.ShouldBeNil)
 			},
@@ -242,7 +246,7 @@ func TestWorkspace(t *testing.T) {
 		convey.So(
 			func() {
 				wsp := newTestWorkspace()
-				wsp.StartStatement("")
+				wsp.StartStatement(nil)
 				err := wsp.IncrStatementID(context.TODO(), false)
 				convey.So(err, convey.ShouldBeNil)
 				err = wsp.RollbackLastStatement(context.TODO())
@@ -484,7 +488,7 @@ func Test_rollbackStatement(t *testing.T) {
 			NeedToBeCommittedInActiveTransaction(&tree.Insert{}), convey.ShouldBeFalse)
 		convey.So(txnOp != nil && !ses.IsDerivedStmt(), convey.ShouldBeTrue)
 		//called incrStatement
-		txnOp.GetWorkspace().StartStatement("")
+		txnOp.GetWorkspace().StartStatement(nil)
 		err = txnOp.GetWorkspace().IncrStatementID(ctx, false)
 		convey.So(err, convey.ShouldBeNil)
 		ec.stmt = &tree.Insert{}
@@ -514,7 +518,7 @@ func Test_rollbackStatement(t *testing.T) {
 			NeedToBeCommittedInActiveTransaction(&tree.Insert{}), convey.ShouldBeFalse)
 		convey.So(txnOp != nil && !ses.IsDerivedStmt(), convey.ShouldBeTrue)
 		//called incrStatement
-		txnOp.GetWorkspace().StartStatement("")
+		txnOp.GetWorkspace().StartStatement(nil)
 		err = txnOp.GetWorkspace().IncrStatementID(ctx, false)
 		convey.So(err, convey.ShouldBeNil)
 		ec.stmt = &tree.Insert{}
@@ -671,7 +675,7 @@ func Test_rollbackStatement5(t *testing.T) {
 			NeedToBeCommittedInActiveTransaction(&tree.Insert{}), convey.ShouldBeFalse)
 		convey.So(txnOp != nil && !ses.IsDerivedStmt(), convey.ShouldBeTrue)
 		//called incrStatement
-		txnOp.GetWorkspace().StartStatement("")
+		txnOp.GetWorkspace().StartStatement(nil)
 		err = txnOp.GetWorkspace().IncrStatementID(ctx, false)
 		convey.So(err, convey.ShouldBeNil)
 		ec.stmt = &tree.Insert{}
@@ -710,7 +714,7 @@ func Test_rollbackStatement6(t *testing.T) {
 			NeedToBeCommittedInActiveTransaction(&tree.Insert{}), convey.ShouldBeFalse)
 		convey.So(txnOp != nil && !ses.IsDerivedStmt(), convey.ShouldBeTrue)
 		//called incrStatement
-		txnOp.GetWorkspace().StartStatement("")
+		txnOp.GetWorkspace().StartStatement(nil)
 		err = txnOp.GetWorkspace().IncrStatementID(ctx, false)
 		convey.So(err, convey.ShouldBeNil)
 		ec.stmt = &tree.Insert{}
@@ -745,7 +749,7 @@ func Test_rollbackStatement6(t *testing.T) {
 			NeedToBeCommittedInActiveTransaction(&tree.Insert{}), convey.ShouldBeFalse)
 		convey.So(txnOp != nil && !ses.IsDerivedStmt(), convey.ShouldBeTrue)
 		//called incrStatement
-		txnOp.GetWorkspace().StartStatement("")
+		txnOp.GetWorkspace().StartStatement(nil)
 		err = txnOp.GetWorkspace().IncrStatementID(ctx, false)
 		convey.So(err, convey.ShouldBeNil)
 		ec.stmt = &tree.Insert{}

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -621,7 +621,7 @@ func TestGetExprValue(t *testing.T) {
 		ws.EXPECT().IncrStatementID(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		ws.EXPECT().IncrSQLCount().AnyTimes()
 		ws.EXPECT().GetSQLCount().AnyTimes()
-		ws.EXPECT().StartStatement("").AnyTimes()
+		ws.EXPECT().StartStatement(nil).AnyTimes()
 		ws.EXPECT().EndStatement().AnyTimes()
 		ws.EXPECT().GetSnapshotWriteOffset().Return(0).AnyTimes()
 		ws.EXPECT().UpdateSnapshotWriteOffset().AnyTimes()
@@ -729,7 +729,7 @@ func TestGetExprValue(t *testing.T) {
 
 		ws := mock_frontend.NewMockWorkspace(ctrl)
 		ws.EXPECT().IncrStatementID(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-		ws.EXPECT().StartStatement("").AnyTimes()
+		ws.EXPECT().StartStatement(nil).AnyTimes()
 		ws.EXPECT().EndStatement().AnyTimes()
 		ws.EXPECT().GetSnapshotWriteOffset().Return(0).AnyTimes()
 		ws.EXPECT().UpdateSnapshotWriteOffset().AnyTimes()

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -621,7 +621,7 @@ func TestGetExprValue(t *testing.T) {
 		ws.EXPECT().IncrStatementID(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		ws.EXPECT().IncrSQLCount().AnyTimes()
 		ws.EXPECT().GetSQLCount().AnyTimes()
-		ws.EXPECT().StartStatement().AnyTimes()
+		ws.EXPECT().StartStatement("").AnyTimes()
 		ws.EXPECT().EndStatement().AnyTimes()
 		ws.EXPECT().GetSnapshotWriteOffset().Return(0).AnyTimes()
 		ws.EXPECT().UpdateSnapshotWriteOffset().AnyTimes()
@@ -729,7 +729,7 @@ func TestGetExprValue(t *testing.T) {
 
 		ws := mock_frontend.NewMockWorkspace(ctrl)
 		ws.EXPECT().IncrStatementID(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-		ws.EXPECT().StartStatement().AnyTimes()
+		ws.EXPECT().StartStatement("").AnyTimes()
 		ws.EXPECT().EndStatement().AnyTimes()
 		ws.EXPECT().GetSnapshotWriteOffset().Return(0).AnyTimes()
 		ws.EXPECT().UpdateSnapshotWriteOffset().AnyTimes()

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -136,10 +136,10 @@ func (w *Ws) Adjust(_ uint64) error {
 	return nil
 }
 
-func (w *Ws) StartStatement()     {}
-func (w *Ws) EndStatement()       {}
-func (w *Ws) IncrSQLCount()       {}
-func (w *Ws) GetSQLCount() uint64 { return 0 }
+func (w *Ws) StartStatement(statement tree.Statement) {}
+func (w *Ws) EndStatement()                           {}
+func (w *Ws) IncrSQLCount()                           {}
+func (w *Ws) GetSQLCount() uint64                     { return 0 }
 
 func (w *Ws) CloneSnapshotWS() client.Workspace {
 	return nil

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -99,7 +99,7 @@ func (s *sqlExecutor) NewTxnOperator(ctx context.Context) client.TxnOperator {
 			return nil
 		}
 	}
-	opts.Txn().GetWorkspace().StartStatement()
+	opts.Txn().GetWorkspace().StartStatement("")
 	opts.Txn().GetWorkspace().IncrStatementID(ctx, false)
 	return opts.Txn()
 }
@@ -282,7 +282,7 @@ func (exec *txnExecutor) Exec(
 	// maybe we should fix it.
 	txnOp := exec.opts.Txn()
 	if txnOp != nil && !exec.opts.DisableIncrStatement() {
-		txnOp.GetWorkspace().StartStatement()
+		txnOp.GetWorkspace().StartStatement(sql)
 		defer func() {
 			txnOp.GetWorkspace().EndStatement()
 		}()

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -99,7 +99,7 @@ func (s *sqlExecutor) NewTxnOperator(ctx context.Context) client.TxnOperator {
 			return nil
 		}
 	}
-	opts.Txn().GetWorkspace().StartStatement("")
+	opts.Txn().GetWorkspace().StartStatement(nil)
 	opts.Txn().GetWorkspace().IncrStatementID(ctx, false)
 	return opts.Txn()
 }
@@ -282,7 +282,7 @@ func (exec *txnExecutor) Exec(
 	// maybe we should fix it.
 	txnOp := exec.opts.Txn()
 	if txnOp != nil && !exec.opts.DisableIncrStatement() {
-		txnOp.GetWorkspace().StartStatement(sql)
+		txnOp.GetWorkspace().StartStatement(nil)
 		defer func() {
 			txnOp.GetWorkspace().EndStatement()
 		}()

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -250,7 +250,7 @@ type Workspace interface {
 	Readonly() bool
 
 	// StartStatement tag a statement is running
-	StartStatement()
+	StartStatement(string)
 	// EndStatement tag end a statement is completed
 	EndStatement()
 

--- a/pkg/txn/client/types.go
+++ b/pkg/txn/client/types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 )
 
@@ -250,7 +251,7 @@ type Workspace interface {
 	Readonly() bool
 
 	// StartStatement tag a statement is running
-	StartStatement(string)
+	StartStatement(tree.Statement)
 	// EndStatement tag end a statement is completed
 	EndStatement()
 

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -525,9 +525,12 @@ func (txn *Transaction) PPString() string {
 		stringifySlice(txn.transfer.timestamps, func(a any) string { t := a.(timestamp.Timestamp); return t.DebugString() }))
 }
 
-func (txn *Transaction) StartStatement() {
+func (txn *Transaction) StartStatement(sql string) {
 	if txn.startStatementCalled {
-		logutil.Fatal("BUG: StartStatement called twice", zap.String("txn", hex.EncodeToString(txn.op.Txn().ID)))
+		logutil.Fatal("BUG: StartStatement called twice",
+			zap.String("txn", hex.EncodeToString(txn.op.Txn().ID)),
+			zap.String("SQL", sql),
+		)
 	}
 	txn.startStatementCalled = true
 	txn.incrStatementCalled = false

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"math"
 	"strconv"
 	"sync"
@@ -525,8 +526,12 @@ func (txn *Transaction) PPString() string {
 		stringifySlice(txn.transfer.timestamps, func(a any) string { t := a.(timestamp.Timestamp); return t.DebugString() }))
 }
 
-func (txn *Transaction) StartStatement(sql string) {
+func (txn *Transaction) StartStatement(stmt tree.Statement) {
 	if txn.startStatementCalled {
+		var sql string
+		if stmt != nil {
+			sql = stmt.String()
+		}
 		logutil.Fatal("BUG: StartStatement called twice",
 			zap.String("txn", hex.EncodeToString(txn.op.Txn().ID)),
 			zap.String("SQL", sql),

--- a/pkg/vm/engine/test/disttae_engine_test.go
+++ b/pkg/vm/engine/test/disttae_engine_test.go
@@ -163,7 +163,7 @@ func TestSystemDB1(t *testing.T) {
 	txnop = p.StartCNTxn()
 	dbs, err = p.D.Engine.Databases(p.Ctx, txnop)
 	require.NoError(t, err)
-	txnop.GetWorkspace().StartStatement("")
+	txnop.GetWorkspace().StartStatement(nil)
 	require.Equal(t, 2+1, len(dbs))
 
 	txn, err := p.T.StartTxn()
@@ -561,7 +561,7 @@ func TestColumnsTransfer(t *testing.T) {
 	require.NoError(t, txnop.Commit(p.Ctx))
 
 	txnop = p.StartCNTxn()
-	txnop.GetWorkspace().StartStatement("")
+	txnop.GetWorkspace().StartStatement(nil)
 	p.DeleteTableInDB(txnop, "db", schema2.Name)
 
 	txn, _ := tae.StartTxn(nil)

--- a/pkg/vm/engine/test/disttae_engine_test.go
+++ b/pkg/vm/engine/test/disttae_engine_test.go
@@ -163,7 +163,7 @@ func TestSystemDB1(t *testing.T) {
 	txnop = p.StartCNTxn()
 	dbs, err = p.D.Engine.Databases(p.Ctx, txnop)
 	require.NoError(t, err)
-	txnop.GetWorkspace().StartStatement()
+	txnop.GetWorkspace().StartStatement("")
 	require.Equal(t, 2+1, len(dbs))
 
 	txn, err := p.T.StartTxn()
@@ -561,7 +561,7 @@ func TestColumnsTransfer(t *testing.T) {
 	require.NoError(t, txnop.Commit(p.Ctx))
 
 	txnop = p.StartCNTxn()
-	txnop.GetWorkspace().StartStatement()
+	txnop.GetWorkspace().StartStatement("")
 	p.DeleteTableInDB(txnop, "db", schema2.Name)
 
 	txn, _ := tae.StartTxn(nil)

--- a/pkg/vm/engine/test/testutil/util.go
+++ b/pkg/vm/engine/test/testutil/util.go
@@ -444,7 +444,7 @@ func WriteToRelation(
 	bat *batch.Batch,
 	isDelete, toEndStatement bool,
 ) (err error) {
-	txn.GetWorkspace().StartStatement("")
+	txn.GetWorkspace().StartStatement(nil)
 	if isDelete {
 		err = relation.Delete(ctx, bat, catalog2.Row_ID)
 	} else {

--- a/pkg/vm/engine/test/testutil/util.go
+++ b/pkg/vm/engine/test/testutil/util.go
@@ -444,7 +444,7 @@ func WriteToRelation(
 	bat *batch.Batch,
 	isDelete, toEndStatement bool,
 ) (err error) {
-	txn.GetWorkspace().StartStatement()
+	txn.GetWorkspace().StartStatement("")
 	if isDelete {
 		err = relation.Delete(ctx, bat, catalog2.Row_ID)
 	} else {

--- a/pkg/vm/engine/test/workspace_test.go
+++ b/pkg/vm/engine/test/workspace_test.go
@@ -809,7 +809,7 @@ func Test_BasicRollbackStatement(t *testing.T) {
 
 		require.NoError(t, testutil.WriteToRelation(ctx, txn, relation, bat1, false, true))
 
-		txn.GetWorkspace().StartStatement()
+		txn.GetWorkspace().StartStatement("")
 		require.NoError(t, relation.Write(ctx, bat2))
 		require.NoError(t, txn.GetWorkspace().RollbackLastStatement(ctx))
 		require.NoError(t, txn.GetWorkspace().IncrStatementID(ctx, false))
@@ -921,7 +921,7 @@ func Test_BasicRollbackStatementS3(t *testing.T) {
 
 		require.NoError(t, testutil.WriteToRelation(ctx, txn, relation, bat1, false, true))
 
-		txn.GetWorkspace().StartStatement()
+		txn.GetWorkspace().StartStatement("")
 		require.NoError(t, relation.Write(ctx, bat2))
 		require.NoError(t, txn.GetWorkspace().RollbackLastStatement(ctx))
 		require.NoError(t, txn.GetWorkspace().IncrStatementID(ctx, false))
@@ -1033,7 +1033,7 @@ func Test_RollbackDeleteAndDrop(t *testing.T) {
 	txnop = p.StartCNTxn()
 	exec := v.(executor.SQLExecutor)
 	execopts := executor.Options{}.WithTxn(txnop).WithDisableIncrStatement()
-	txnop.GetWorkspace().StartStatement()
+	txnop.GetWorkspace().StartStatement("")
 	txnop.GetWorkspace().IncrStatementID(p.Ctx, false)
 	dropTable := func() {
 		_, err := exec.Exec(p.Ctx, "delete from db.test3 where mock_1 = 0", execopts)
@@ -1182,7 +1182,7 @@ func Test_MultiTxnRollbackStatement(t *testing.T) {
 	{
 		require.NoError(t, testutil.WriteToRelation(ctx, txn, relation, bat2, false, true))
 
-		txn.GetWorkspace().StartStatement()
+		txn.GetWorkspace().StartStatement("")
 		require.NoError(t, relation.Write(ctx, bat2))
 		require.NoError(t, txn.GetWorkspace().RollbackLastStatement(ctx))
 		require.NoError(t, txn.GetWorkspace().IncrStatementID(ctx, false))
@@ -1357,7 +1357,7 @@ func Test_MultiTxnRollbackStatementS3(t *testing.T) {
 
 	// txn2 delete 5-15
 	{
-		txn.GetWorkspace().StartStatement()
+		txn.GetWorkspace().StartStatement("")
 		require.NoError(t, relation.Write(ctx, bat2))
 		require.NoError(t, txn.GetWorkspace().RollbackLastStatement(ctx))
 		require.NoError(t, txn.GetWorkspace().IncrStatementID(ctx, false))
@@ -1662,7 +1662,7 @@ func Test_CNTransferTombstoneObjects(t *testing.T) {
 		_, _, cnTxnOp, err = p.D.GetTable(ctx, databaseName, tableName)
 		require.NoError(t, err)
 
-		cnTxnOp.GetWorkspace().StartStatement()
+		cnTxnOp.GetWorkspace().StartStatement("")
 		err = cnTxnOp.GetWorkspace().IncrStatementID(ctx, false)
 		require.NoError(t, err)
 	}

--- a/pkg/vm/engine/test/workspace_test.go
+++ b/pkg/vm/engine/test/workspace_test.go
@@ -809,7 +809,7 @@ func Test_BasicRollbackStatement(t *testing.T) {
 
 		require.NoError(t, testutil.WriteToRelation(ctx, txn, relation, bat1, false, true))
 
-		txn.GetWorkspace().StartStatement("")
+		txn.GetWorkspace().StartStatement(nil)
 		require.NoError(t, relation.Write(ctx, bat2))
 		require.NoError(t, txn.GetWorkspace().RollbackLastStatement(ctx))
 		require.NoError(t, txn.GetWorkspace().IncrStatementID(ctx, false))
@@ -921,7 +921,7 @@ func Test_BasicRollbackStatementS3(t *testing.T) {
 
 		require.NoError(t, testutil.WriteToRelation(ctx, txn, relation, bat1, false, true))
 
-		txn.GetWorkspace().StartStatement("")
+		txn.GetWorkspace().StartStatement(nil)
 		require.NoError(t, relation.Write(ctx, bat2))
 		require.NoError(t, txn.GetWorkspace().RollbackLastStatement(ctx))
 		require.NoError(t, txn.GetWorkspace().IncrStatementID(ctx, false))
@@ -1033,7 +1033,7 @@ func Test_RollbackDeleteAndDrop(t *testing.T) {
 	txnop = p.StartCNTxn()
 	exec := v.(executor.SQLExecutor)
 	execopts := executor.Options{}.WithTxn(txnop).WithDisableIncrStatement()
-	txnop.GetWorkspace().StartStatement("")
+	txnop.GetWorkspace().StartStatement(nil)
 	txnop.GetWorkspace().IncrStatementID(p.Ctx, false)
 	dropTable := func() {
 		_, err := exec.Exec(p.Ctx, "delete from db.test3 where mock_1 = 0", execopts)
@@ -1182,7 +1182,7 @@ func Test_MultiTxnRollbackStatement(t *testing.T) {
 	{
 		require.NoError(t, testutil.WriteToRelation(ctx, txn, relation, bat2, false, true))
 
-		txn.GetWorkspace().StartStatement("")
+		txn.GetWorkspace().StartStatement(nil)
 		require.NoError(t, relation.Write(ctx, bat2))
 		require.NoError(t, txn.GetWorkspace().RollbackLastStatement(ctx))
 		require.NoError(t, txn.GetWorkspace().IncrStatementID(ctx, false))
@@ -1357,7 +1357,7 @@ func Test_MultiTxnRollbackStatementS3(t *testing.T) {
 
 	// txn2 delete 5-15
 	{
-		txn.GetWorkspace().StartStatement("")
+		txn.GetWorkspace().StartStatement(nil)
 		require.NoError(t, relation.Write(ctx, bat2))
 		require.NoError(t, txn.GetWorkspace().RollbackLastStatement(ctx))
 		require.NoError(t, txn.GetWorkspace().IncrStatementID(ctx, false))
@@ -1662,7 +1662,7 @@ func Test_CNTransferTombstoneObjects(t *testing.T) {
 		_, _, cnTxnOp, err = p.D.GetTable(ctx, databaseName, tableName)
 		require.NoError(t, err)
 
-		cnTxnOp.GetWorkspace().StartStatement("")
+		cnTxnOp.GetWorkspace().StartStatement(nil)
 		err = cnTxnOp.GetWorkspace().IncrStatementID(ctx, false)
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21602

## What this PR does / why we need it:
add sql to fatal log


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced `StartStatement` to include SQL string parameter.

- Updated all relevant function calls to pass SQL string.

- Improved error logging with SQL context in `StartStatement`.

- Adjusted and added test cases to validate new functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>mysql_cmd_executor.go</strong><dd><code>Pass SQL string to `StartStatement` in executor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21609/files#diff-af2611d5fc89704398fe09d09644efa41fec8931b395eda292f2f474f1216275">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sql_executor.go</strong><dd><code>Updated SQL executor to pass SQL string to `StartStatement`</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21609/files#diff-8d93841d90b6b267a1c218f24e1f564febdcc4dd780d04909033d706302ca215">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Modified <code>Workspace</code> interface to include SQL string in <code>StartStatement</code></code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21609/files#diff-04dd5377bb096d114087521ac2b2f926bbe80f0459b98e1bb1d5a2774282b08a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Enhanced `StartStatement` with SQL string and improved logging</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21609/files#diff-2d4ca99c63be4d7a3464a5089669767530c849522edfe3030145a5b059775852">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>txn_mock.go</strong><dd><code>Mock `StartStatement` updated to accept SQL string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21609/files#diff-68e826bd15c3f0b74a031fad521dfb4ed97d3d9a22a29d40d0e1372c814dc646">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>txn_test.go</strong><dd><code>Adjusted tests to include SQL string in `StartStatement`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21609/files#diff-a62be3f347c14388335d2c9f5215f4cc4047061478716e92a7ff2008746667af">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>util_test.go</strong><dd><code>Updated mock expectations for `StartStatement` with SQL string</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21609/files#diff-f51b6d5837418f5bbf801345e25b4bfcc4cd436bdec4534ab7a8aa8dc01839e0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>disttae_engine_test.go</strong><dd><code>Updated tests to include SQL string in `StartStatement`</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21609/files#diff-e845a3b940465cd3dc5869ef7cc283787f878ef994419ce12dbe54c16bca74ba">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>util.go</strong><dd><code>Adjusted utility function to pass SQL string to `StartStatement`</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21609/files#diff-7c7bb071a96fe384516cf1bcd2378926568503d930170726a370b789717183e7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workspace_test.go</strong><dd><code>Updated workspace tests to include SQL string in `StartStatement`</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21609/files#diff-80a06ff52f6f94bc5944097668f64328be5d8072db65cbd081c442520fae3458">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>