### PR TITLE
Fix collectObjects for updateTableInfo

### DIFF
--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -7387,7 +7387,6 @@ func TestPitrMeta(t *testing.T) {
 	if db.Runtime.Scheduler.GetPenddingLSNCnt() != 0 {
 		return
 	}
-	db.ForceCheckpoint(ctx, tae.TxnMgr.Now())
 	db.DiskCleaner.GetCleaner().EnableGC()
 	assert.Equal(t, uint64(0), db.Runtime.Scheduler.GetPenddingLSNCnt())
 	initMinMerged := db.DiskCleaner.GetCleaner().GetMinMerged()

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -7213,6 +7213,8 @@ func TestPitrMeta(t *testing.T) {
 	opts := new(options.Options)
 	opts = config.WithQuickScanAndCKPOpts(opts)
 	options.WithDisableGCCheckpoint()(opts)
+	merge.StopMerge.Store(true)
+	defer merge.StopMerge.Store(false)
 	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
 	defer tae.Close()
 	db := tae.DB

--- a/pkg/vm/engine/tae/logtail/snapshot.go
+++ b/pkg/vm/engine/tae/logtail/snapshot.go
@@ -366,10 +366,17 @@ func (sm *SnapshotMeta) updateTableInfo(
 		moTable := (*objects)[tid]
 
 		// dropped object will overwrite the created object, updating the deleteAt
-		moTable[id] = &objectInfo{
-			stats:    stats,
-			createAt: createTS,
-			deleteAt: deleteTS,
+		obj := moTable[id]
+		if obj == nil {
+			moTable[id] = &objectInfo{
+				stats: stats,
+			}
+		}
+		if !createTS.IsEmpty() {
+			moTable[id].createAt = createTS
+		}
+		if !deleteTS.IsEmpty() {
+			moTable[id].deleteAt = deleteTS
 		}
 	}
 	collectObjects(ctx, &objects, nil, data, ckputil.ObjectType_Data, collector)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/21606

## What this PR does / why we need it:
Fix collectObjects for updateTableInfo


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed handling of dropped objects in `updateTableInfo`.

- Ensured proper initialization of `objectInfo` when nil.

- Added checks for non-empty `createTS` and `deleteTS` before assignment.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapshot.go</strong><dd><code>Fix and enhance `updateTableInfo` logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/snapshot.go

<li>Fixed logic for updating <code>objectInfo</code> in <code>updateTableInfo</code>.<br> <li> Added initialization for <code>objectInfo</code> if nil.<br> <li> Added conditional checks for <code>createTS</code> and <code>deleteTS</code>.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21612/files#diff-111781ff442a07a8deefe4a9fa1e799b2b5da03309f03c042a9b9b83e33a21be">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>