### PR TITLE
update checkpoint cluster column

### DIFF
--- a/pkg/vm/engine/ckputil/sinker.go
+++ b/pkg/vm/engine/ckputil/sinker.go
@@ -27,10 +27,12 @@ func EncodeCluser(
 	tableId uint64,
 	objectType int8,
 	obj *objectio.ObjectId,
+	isDeleted bool,
 ) {
 	packer.EncodeUint64(tableId)
 	packer.EncodeInt8(objectType)
 	packer.EncodeObjectid(obj)
+	packer.EncodeBool(isDeleted)
 }
 
 var DataSinkerFactory ioutil.FileSinkerFactory

--- a/pkg/vm/engine/ckputil/sinker_test.go
+++ b/pkg/vm/engine/ckputil/sinker_test.go
@@ -39,7 +39,7 @@ func Test_ClusterKey1(t *testing.T) {
 	tableId := uint64(20)
 	obj := types.NewObjectid()
 
-	EncodeCluser(packer, tableId, ObjectType_Data, &obj)
+	EncodeCluser(packer, tableId, ObjectType_Data, &obj, false)
 
 	buf := packer.Bytes()
 	packer.Reset()
@@ -66,7 +66,7 @@ func Test_ClusterKey2(t *testing.T) {
 	objTemplate := types.NewObjectid()
 	for i := cnt; i >= 1; i-- {
 		obj := objTemplate.Copy(uint16(i))
-		EncodeCluser(packer, 1, ObjectType_Data, &obj)
+		EncodeCluser(packer, 1, ObjectType_Data, &obj, false)
 		clusters = append(clusters, packer.Bytes())
 		packer.Reset()
 	}
@@ -119,7 +119,7 @@ func mockDataBatch(
 				obj2 := obj.Clone()
 				objectio.SetObjectStatsSize(obj2, 0)
 				packer.Reset()
-				EncodeCluser(packer, tableid, ObjectType_Data, objname.ObjectId())
+				EncodeCluser(packer, tableid, ObjectType_Data, objname.ObjectId(), false)
 				// if tableid == uint64(4) {
 				// 	t.Logf("debug %s", obj.String())
 				// }

--- a/pkg/vm/engine/ckputil/sinker_test.go
+++ b/pkg/vm/engine/ckputil/sinker_test.go
@@ -46,7 +46,7 @@ func Test_ClusterKey1(t *testing.T) {
 
 	tuple, _, schemas, err := types.DecodeTuple(buf)
 	require.NoError(t, err)
-	require.Equalf(t, 3, len(schemas), "schemas: %v", schemas)
+	require.Equalf(t, 4, len(schemas), "schemas: %v", schemas)
 	require.Equalf(t, types.T_uint64, schemas[0], "schemas: %v", schemas)
 	require.Equalf(t, types.T_int8, schemas[1], "schemas: %v", schemas)
 	require.Equalf(t, types.T_Objectid, schemas[2], "schemas: %v", schemas)
@@ -78,7 +78,7 @@ func Test_ClusterKey2(t *testing.T) {
 	for _, cluster := range clusters {
 		tuple, _, _, err := types.DecodeTuple(cluster)
 		require.NoError(t, err)
-		require.Equalf(t, 3, len(tuple), "%v", tuple)
+		require.Equalf(t, 4, len(tuple), "%v", tuple)
 		require.Equal(t, uint64(1), tuple[0].(uint64))
 		require.Equal(t, ObjectType_Data, tuple[1].(int8))
 		obj := tuple[2].(types.Objectid)

--- a/pkg/vm/engine/ckputil/types.go
+++ b/pkg/vm/engine/ckputil/types.go
@@ -38,7 +38,7 @@ const (
 	TableObjectsAttr_CreateTS   = "create_ts"
 	TableObjectsAttr_DeleteTS   = "delete_ts"
 
-	// TableObjects should be clustered by `table`+`object_type`+`id`
+	// TableObjects should be clustered by `table`+`object_type`+`id` + `is_deleted`
 	TableObjectsAttr_Cluster = "cluster"
 
 	// TableObjectsAttr_PhysicalAddr = objectio.PhysicalAddr_Attr

--- a/pkg/vm/engine/tae/logtail/backup.go
+++ b/pkg/vm/engine/tae/logtail/backup.go
@@ -408,7 +408,7 @@ func appendValToBatch(
 		return
 	}
 	encoder.Reset()
-	ckputil.EncodeCluser(encoder, tbl, objType, id.ObjectName().ObjectId())
+	ckputil.EncodeCluser(encoder, tbl, objType, id.ObjectName().ObjectId(), delete.IsEmpty())
 	if err = vector.AppendBytes(
 		dst.Vecs[ckputil.TableObjectsAttr_Cluster_Idx], encoder.Bytes(), false, mp,
 	); err != nil {

--- a/pkg/vm/engine/tae/logtail/ckp_reader.go
+++ b/pkg/vm/engine/tae/logtail/ckp_reader.go
@@ -603,9 +603,10 @@ func compatibilityForV12(
 			vector.AppendFixed(ckpData.Vecs[ckputil.TableObjectsAttr_PhysicalAddr_Idx], rowID, false, mp)
 		}
 		tids := vector.MustFixedColNoTypeCheck[uint64](src.Vecs[ObjectInfo_TID_Idx+2].GetDownstreamVector())
+		deletes := vector.MustFixedColNoTypeCheck[types.TS](src.Vecs[ObjectInfo_DeleteAt_Idx+2].GetDownstreamVector())
 		for i := 0; i < src.Length(); i++ {
 			objectStats := objectio.ObjectStats(src.Vecs[ObjectInfo_ObjectStats_Idx+2].GetDownstreamVector().GetBytesAt(i))
-			ckputil.EncodeCluser(encoder, tids[i], dataType, objectStats.ObjectName().ObjectId())
+			ckputil.EncodeCluser(encoder, tids[i], dataType, objectStats.ObjectName().ObjectId(), deletes[i].IsEmpty())
 			vector.AppendBytes(ckpData.Vecs[ckputil.TableObjectsAttr_Cluster_Idx], encoder.Bytes(), false, mp)
 			encoder.Reset()
 		}

--- a/pkg/vm/engine/tae/logtail/ckp_writer.go
+++ b/pkg/vm/engine/tae/logtail/ckp_writer.go
@@ -95,7 +95,7 @@ func (collector *BaseCollector_V2) visitObject(entry *catalog.ObjectEntry) error
 		if node.IsAborted() {
 			continue
 		}
-		isObjectTombstone := node.End.Equal(&entry.CreatedAt)
+		isObjectTombstone := !node.End.Equal(&entry.CreatedAt)
 		if err := collectObjectBatch(
 			collector.data.batch, entry, isObjectTombstone, collector.packer, collector.data.allocator,
 		); err != nil {
@@ -195,7 +195,7 @@ func collectObjectBatch(
 	); err != nil {
 		return
 	}
-	ckputil.EncodeCluser(encoder, srcObjectEntry.GetTable().ID, objType, srcObjectEntry.ID())
+	ckputil.EncodeCluser(encoder, srcObjectEntry.GetTable().ID, objType, srcObjectEntry.ID(), isObjectTombstone)
 	if err = vector.AppendBytes(
 		data.Vecs[ckputil.TableObjectsAttr_Cluster_Idx], encoder.Bytes(), false, mp,
 	); err != nil {
@@ -206,7 +206,7 @@ func collectObjectBatch(
 	); err != nil {
 		return
 	}
-	if isObjectTombstone {
+	if !isObjectTombstone {
 		if err = vector.AppendFixed(
 			data.Vecs[ckputil.TableObjectsAttr_DeleteTS_Idx], types.TS{}, false, mp,
 		); err != nil {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21606 

## What this PR does / why we need it:
update ckp cluster column, add is deleted


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `isDeleted` parameter to `EncodeCluser` function for better cluster encoding.

- Updated test cases to include `isDeleted` parameter in `EncodeCluser` calls.

- Enhanced cluster key logic to include `is_deleted` attribute.

- Adjusted object tombstone handling logic for accuracy.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sinker.go</strong><dd><code>Add `isDeleted` parameter to `EncodeCluser` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/ckputil/sinker.go

<li>Added <code>isDeleted</code> parameter to <code>EncodeCluser</code> function.<br> <li> Updated encoding logic to include <code>isDeleted</code>.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21614/files#diff-b6d975dc6c4f07bc889aecd746b1f5655b3df4279bb133d83dc1952388fff8a4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backup.go</strong><dd><code>Update `EncodeCluser` calls in backup logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/backup.go

<li>Modified <code>EncodeCluser</code> calls to include <code>isDeleted</code> parameter.<br> <li> Integrated <code>delete.IsEmpty()</code> logic for determining <code>isDeleted</code>.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21614/files#diff-e7bff0b56a15ebd4683008a551e30d4fe7bc361b65f1ab42cfbb254b0cd69dde">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ckp_reader.go</strong><dd><code>Enhance checkpoint reader with `isDeleted` logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/ckp_reader.go

<li>Updated <code>EncodeCluser</code> calls to include <code>isDeleted</code> parameter.<br> <li> Added logic to determine <code>isDeleted</code> using <code>deletes[i].IsEmpty()</code>.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21614/files#diff-8decaa0bcfde14b3f32399c96b60fad15f03bf1382c8183150855e389547d81e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sinker_test.go</strong><dd><code>Update test cases for `EncodeCluser` changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/ckputil/sinker_test.go

<li>Updated test cases to include <code>isDeleted</code> parameter.<br> <li> Adjusted test logic for compatibility with new parameter.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21614/files#diff-320e43820ded7de3bd5058188184100084bd4a0cb9604dbedd5b5c4a9d92df33">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Update cluster key comment for `is_deleted`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/ckputil/types.go

- Updated cluster key comment to include `is_deleted`.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21614/files#diff-50bbd13022f8c0aa3a4d294f19dd1a385d3160cc0b56102f43e2b2f2f4d1d926">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ckp_writer.go</strong><dd><code>Refine checkpoint writer for tombstone and `isDeleted`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/ckp_writer.go

<li>Adjusted object tombstone handling logic.<br> <li> Updated <code>EncodeCluser</code> calls to include <code>isDeleted</code> parameter.<br> <li> Refined logic for appending delete timestamps.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21614/files#diff-de36699e87c4add60ee39d25c2ce7ae74ff38052bba1fd2f5aba17a988b56a17">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>