### PR TITLE
escape char in string col

### DIFF
--- a/pkg/cdc/util.go
+++ b/pkg/cdc/util.go
@@ -268,9 +268,11 @@ func convertColIntoSql(
 		types.T_binary,
 		types.T_varbinary,
 		types.T_datalink:
-		value := data.([]byte)
+		value := string(data.([]byte))
+		value = strings.Replace(value, "\\", "\\\\", -1)
+		value = strings.Replace(value, "'", "\\'", -1)
 		sqlBuff = appendByte(sqlBuff, '\'')
-		sqlBuff = appendBytes(sqlBuff, value)
+		sqlBuff = appendBytes(sqlBuff, []byte(value))
 		sqlBuff = appendByte(sqlBuff, '\'')
 	case types.T_array_float32:
 		// NOTE: Don't merge it with T_varchar. You will get raw binary in the SQL output


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/5110

## What this PR does / why we need it:
escape char in string col


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed escape character handling for string columns.

- Replaced backslashes and single quotes in string values.

- Ensured proper SQL string formatting for specific data types.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Handle escape characters in string column processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/util.go

<li>Changed <code>value</code> to be treated as a string instead of a byte slice.<br> <li> Added logic to escape backslashes and single quotes in string values.<br> <li> Updated SQL buffer appending to handle escaped string values.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21618/files#diff-46b260aa5fed62ad704662ba98a550547b13b1950d693dac8d96a865e1e41237">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>