### PR TITLE
Fix cdc with blob|binary|varbinary

### DIFF
--- a/pkg/cdc/util.go
+++ b/pkg/cdc/util.go
@@ -261,12 +261,11 @@ func convertColIntoSql(
 	case types.T_float64:
 		value := data.(float64)
 		sqlBuff = appendFloat64(sqlBuff, value, 64)
+	case types.T_binary, types.T_varbinary, types.T_blob:
+		sqlBuff = appendHex(sqlBuff, data.([]byte))
 	case types.T_char,
 		types.T_varchar,
-		types.T_blob,
 		types.T_text,
-		types.T_binary,
-		types.T_varbinary,
 		types.T_datalink:
 		value := string(data.([]byte))
 		value = strings.Replace(value, "\\", "\\\\", -1)
@@ -353,6 +352,13 @@ func convertColIntoSql(
 	}
 
 	return sqlBuff, nil
+}
+
+func appendHex(dst []byte, src []byte) []byte {
+	dst = append(dst, "x'"...)
+	dst = hex.AppendEncode(dst, src)
+	dst = append(dst, '\'')
+	return dst
 }
 
 func appendByte(buf []byte, d byte) []byte {

--- a/pkg/cdc/util_test.go
+++ b/pkg/cdc/util_test.go
@@ -317,7 +317,7 @@ func Test_convertColIntoSql(t *testing.T) {
 		},
 		{
 			args:    args{ctx: context.Background(), data: []byte("test"), typ: &types.Type{Oid: types.T_blob}, sqlBuff: []byte{}},
-			want:    []byte("'test'"),
+			want:    []byte("x'74657374'"),
 			wantErr: assert.NoError,
 		},
 		{
@@ -327,12 +327,12 @@ func Test_convertColIntoSql(t *testing.T) {
 		},
 		{
 			args:    args{ctx: context.Background(), data: []byte("test"), typ: &types.Type{Oid: types.T_binary}, sqlBuff: []byte{}},
-			want:    []byte("'test'"),
+			want:    []byte("x'74657374'"),
 			wantErr: assert.NoError,
 		},
 		{
 			args:    args{ctx: context.Background(), data: []byte("test"), typ: &types.Type{Oid: types.T_varbinary}, sqlBuff: []byte{}},
-			want:    []byte("'test'"),
+			want:    []byte("x'74657374'"),
 			wantErr: assert.NoError,
 		},
 		{

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -403,8 +403,12 @@ func (exec *txnExecutor) Exec(
 	}
 
 	if !statementOption.DisableLog() {
+		printSql := sql
+		if len(printSql) > 1000 {
+			printSql = printSql[:1000] + "..."
+		}
 		logutil.Info("sql_executor exec",
-			zap.String("sql", sql),
+			zap.String("sql", printSql),
 			zap.String("txn-id", hex.EncodeToString(exec.opts.Txn().Txn().ID)),
 			zap.Duration("duration", time.Since(receiveAt)),
 			zap.Int("BatchSize", len(batches)),


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21623 

## What this PR does / why we need it:

Fix cdc with blob|binary|varbinary


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed handling of `blob`, `binary`, and `varbinary` types in CDC.

- Added `appendHex` function for hexadecimal encoding of binary data.

- Updated tests to validate new behavior for `blob`, `binary`, and `varbinary`.

- Improved SQL logging by truncating long queries for better readability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Add support for binary types and hex encoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/util.go

<li>Added support for <code>blob</code>, <code>binary</code>, and <code>varbinary</code> types.<br> <li> Introduced <code>appendHex</code> function for hexadecimal encoding.<br> <li> Adjusted logic for string replacement in SQL conversion.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21624/files#diff-46b260aa5fed62ad704662ba98a550547b13b1950d693dac8d96a865e1e41237">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>util_test.go</strong><dd><code>Update tests for binary type handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/util_test.go

<li>Updated test cases for <code>blob</code>, <code>binary</code>, and <code>varbinary</code> types.<br> <li> Verified hexadecimal encoding for binary data.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21624/files#diff-682a3d8cc46973e1c1726fa8a8ece492f2a8aba302fb81cee8578934c29caea6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_executor.go</strong><dd><code>Improve SQL logging with query truncation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/sql_executor.go

<li>Truncated long SQL queries in logs for readability.<br> <li> Added logic to limit SQL string length in logging.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21624/files#diff-8d93841d90b6b267a1c218f24e1f564febdcc4dd780d04909033d706302ca215">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>