### PR TITLE
Fix the bug of enum.Formt missing value

### DIFF
--- a/pkg/sql/parsers/tree/types.go
+++ b/pkg/sql/parsers/tree/types.go
@@ -144,6 +144,19 @@ func (node *InternalType) Format(ctx *FmtCtx) {
 
 	switch fs {
 	case "set", "enum":
+		if len(node.EnumValues) > 0 {
+			ctx.WriteByte('(')
+			for i, enum := range node.EnumValues {
+				ctx.WriteByte('"')
+				ctx.WriteString(enum)
+				ctx.WriteByte('"')
+				if i < len(node.EnumValues)-1 {
+					ctx.WriteByte(',')
+				}
+
+			}
+			ctx.WriteByte(')')
+		}
 	case "char":
 		if node.DisplayWith >= 0 {
 			ctx.WriteByte('(')


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/21626

## What this PR does / why we need it:
Fix the bug of enum.Formt missing value


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug where tables with enum column types could not be synced in CDC.

- Added logic to handle formatting of enum values in `InternalType.Format`.

- Ensured proper handling of enum values by iterating and formatting them correctly.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Fix formatting for enum values in `InternalType.Format`</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/parsers/tree/types.go

<li>Added logic to format enum values in <code>InternalType.Format</code>.<br> <li> Ensured enum values are enclosed in quotes and separated by commas.<br> <li> Added conditional handling for non-empty <code>EnumValues</code>.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21628/files#diff-28e10dc889e720c362051882239cf08f87ab0729ee2f3a8bc0a22f8608c73cd0">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>