### PR TITLE
better expr print for debug

### DIFF
--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1977,10 +1977,14 @@ func doFormatExpr(expr *plan.Expr, out *bytes.Buffer, depth int) {
 		out.WriteString(fmt.Sprintf("%sExpr_Vec(len=%d)", prefix, t.Vec.Len))
 	case *plan.Expr_Fold:
 		out.WriteString(fmt.Sprintf("%sExpr_Fold(id=%d)", prefix, t.Fold.Id))
+	case *plan.Expr_List:
+		out.WriteString(fmt.Sprintf("%sExpr_List(len=%d)", prefix, len(t.List.List)))
+		for _, arg := range t.List.List {
+			doFormatExpr(arg, out, depth+1)
+		}
 	default:
 		out.WriteString(fmt.Sprintf("%sExpr_Unknown(%s)", prefix, expr.String()))
 	}
-	out.WriteString(fmt.Sprintf("%sExpr_Selectivity(%v)", prefix, expr.Selectivity))
 }
 
 // databaseIsValid checks whether the database exists or not.

--- a/pkg/vm/engine/ckputil/sinker_test.go
+++ b/pkg/vm/engine/ckputil/sinker_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -192,6 +193,7 @@ func Test_Sinker1(t *testing.T) {
 		mockDataBatch(
 			t, bat, 100, 0, packer, accountId, getDBID, getTBLID, mp,
 		)
+		t.Log(common.MoVectorToString(bat.Vecs[TableObjectsAttr_Cluster_Idx], 10, common.WithIsComposite{}))
 		require.NoError(t, sinker.Write(ctx, bat))
 		rows += 100
 	}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #21045 

## What this PR does / why we need it:

better expr debug


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added support for pretty-printing composite types in debug logs.

- Enhanced `doFormatExpr` to handle `Expr_List` expressions.

- Introduced `WithIsComposite` option for type string formatting.

- Updated test to log composite vector data for debugging.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Support `Expr_List` in `doFormatExpr` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/utils.go

<li>Enhanced <code>doFormatExpr</code> to handle <code>Expr_List</code> expressions.<br> <li> Added recursive formatting for list elements.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21642/files#diff-4086cbd1a662ffb2a7761174da95abee51e3e0cc7e4ab796e2ec6ef82983ab45">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>print.go</strong><dd><code>Add composite type support in type string formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/common/print.go

<li>Introduced <code>WithIsComposite</code> option for type printing.<br> <li> Enhanced <code>TypeStringValue</code> to unpack and format composite types.<br> <li> Added logic for handling composite tuple SQL strings.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21642/files#diff-1399e9e41f45d9ab70bd8cd8c5ced431a9e9d19ab7fc18103c5af8b0889ab0c6">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sinker_test.go</strong><dd><code>Add debug logging for composite vector data in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/ckputil/sinker_test.go

<li>Imported <code>common</code> package for composite type utilities.<br> <li> Added debug log for composite vector data in <code>Test_Sinker1</code>.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21642/files#diff-320e43820ded7de3bd5058188184100084bd4a0cb9604dbedd5b5c4a9d92df33">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>