### PR TITLE
fix bug: prefix_in not sorted in prepare stmt

### DIFF
--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -152,12 +152,17 @@ func (op *implPrefixIn) init(rvec *vector.Vector, mp *mpool.MPool) error {
 		}
 		tmpVec.InplaceSortAndCompact()
 		rvec = tmpVec
-		defer tmpVec.Free(mp)
 	}
+	defer func() {
+		if tmpVec != nil {
+			tmpVec.Free(mp)
+		}
+	}()
 
 	rcol, rarea := vector.MustVarlenaRawData(rvec)
 	for i := 0; i < rvec.Length(); i++ {
-		rval := rcol[i].GetByteSlice(rarea)
+		var rval []byte
+		rval = append(rval, rcol[i].GetByteSlice(rarea)...)
 		tmpVal := op.vals[vlen-1]
 		if vlen == 0 || !bytes.HasPrefix(rval, tmpVal) {
 			op.vals[vlen] = rval

--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -163,8 +163,7 @@ func (op *implPrefixIn) init(rvec *vector.Vector, mp *mpool.MPool) error {
 	for i := 0; i < rvec.Length(); i++ {
 		var rval []byte
 		rval = append(rval, rcol[i].GetByteSlice(rarea)...)
-		tmpVal := op.vals[vlen-1]
-		if vlen == 0 || !bytes.HasPrefix(rval, tmpVal) {
+		if vlen == 0 || !bytes.HasPrefix(rval, op.vals[vlen-1]) {
 			op.vals[vlen] = rval
 			vlen++
 		}

--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"sort"
 
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
@@ -137,10 +138,23 @@ func newImplPrefixIn() *implPrefixIn {
 	return &implPrefixIn{ready: false}
 }
 
-func (op *implPrefixIn) init(rvec *vector.Vector) {
+func (op *implPrefixIn) init(rvec *vector.Vector, mp *mpool.MPool) error {
 	op.ready = true
 	op.vals = make([][]byte, rvec.Length())
 	vlen := 0
+
+	var tmpVec *vector.Vector
+	var err error
+	if !rvec.GetSorted() {
+		tmpVec, err = rvec.Dup(mp)
+		if err != nil {
+			return err
+		}
+		tmpVec.InplaceSortAndCompact()
+		rvec = tmpVec
+		defer tmpVec.Free(mp)
+	}
+
 	rcol, rarea := vector.MustVarlenaRawData(rvec)
 	for i := 0; i < rvec.Length(); i++ {
 		rval := rcol[i].GetByteSlice(rarea)
@@ -150,11 +164,15 @@ func (op *implPrefixIn) init(rvec *vector.Vector) {
 		}
 	}
 	op.vals = op.vals[:vlen]
+	return nil
 }
 
 func (op *implPrefixIn) doPrefixIn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	if !op.ready {
-		op.init(parameters[1])
+		err := op.init(parameters[1], proc.Mp())
+		if err != nil {
+			return err
+		}
 	}
 
 	lvec := parameters[0]

--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -158,7 +158,8 @@ func (op *implPrefixIn) init(rvec *vector.Vector, mp *mpool.MPool) error {
 	rcol, rarea := vector.MustVarlenaRawData(rvec)
 	for i := 0; i < rvec.Length(); i++ {
 		rval := rcol[i].GetByteSlice(rarea)
-		if vlen == 0 || !bytes.HasPrefix(rval, op.vals[vlen-1]) {
+		tmpVal := op.vals[vlen-1]
+		if vlen == 0 || !bytes.HasPrefix(rval, tmpVal) {
 			op.vals[vlen] = rval
 			vlen++
 		}

--- a/test/distributed/cases/prepare/prepare.result
+++ b/test/distributed/cases/prepare/prepare.result
@@ -690,6 +690,19 @@ col1    col2    col1    col2
 1    null    1    null
 drop table test_prepare_1;
 drop table test_prepare_2;
+drop table if exists t1;
+drop table if exists t2;
+create table t1(a int primary key, b int);
+insert into t1 values (1,1),(2,2),(3,3);
+create table t2(a int, t1_a int, primary key(a, t1_a));
+insert into t2 values (10,1),(20,2);
+prepare s1 from select t2.* from t2 join t1 on t2.t1_a = t1.a where t2.a in (?,?);
+set @a=20;
+set @b=10;
+execute s1 using @a, @b;
+a    t1_a
+10    1
+20    2
 drop database db1;
 create account prepare_account_01 ADMIN_NAME admin IDENTIFIED BY '111111';
 create role prepare_role1;

--- a/test/distributed/cases/prepare/prepare.test
+++ b/test/distributed/cases/prepare/prepare.test
@@ -528,6 +528,16 @@ execute st_prepare_2;
 
 drop table test_prepare_1;
 drop table test_prepare_2;
+drop table if exists t1;
+drop table if exists t2;
+create table t1(a int primary key, b int);
+insert into t1 values (1,1),(2,2),(3,3);
+create table t2(a int, t1_a int, primary key(a, t1_a));
+insert into t2 values (10,1),(20,2);
+prepare s1 from select t2.* from t2 join t1 on t2.t1_a = t1.a where t2.a in (?,?);
+set @a=20;
+set @b=10;
+execute s1 using @a, @b;
 drop database db1;
 
 create account prepare_account_01 ADMIN_NAME admin IDENTIFIED BY '111111';
@@ -546,7 +556,6 @@ drop role prepare_role1;
 -- @session
 
 drop account prepare_account_01;
-
 
 
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/21640

## What this PR does / why we need it:
fix bug: prefix_in not sorted in prepare stmt


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed incorrect results in prepared statements by ensuring proper sorting.

- Enhanced `implPrefixIn` to handle unsorted vectors with sorting and compacting.

- Added new test cases to validate prepared statement behavior.

- Improved memory pool usage and error handling in `implPrefixIn`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>func_prefix.go</strong><dd><code>Enhanced `implPrefixIn` to handle unsorted vectors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/function/func_prefix.go

<li>Modified <code>implPrefixIn</code> to sort and compact vectors if unsorted.<br> <li> Added memory pool usage for temporary vector duplication.<br> <li> Enhanced error handling during initialization.<br> <li> Updated <code>init</code> method to return errors when applicable.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21644/files#diff-2b33006c7797dcac350fa83941bc2e8b4fc8d2b42d3ec87fbaf56af3e225ead3">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prepare.result</strong><dd><code>Added test cases for prepared statement behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/prepare/prepare.result

<li>Added new test cases for prepared statements with <code>IN</code> clause.<br> <li> Validated results for sorted and unsorted inputs.<br> <li> Included table creation and data insertion for tests.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21644/files#diff-862caf39970e783c64c68f2b43fd86a66a8b06a355733fefb389c7e91f47e47b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prepare.test</strong><dd><code>Introduced new prepared statement test scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/prepare/prepare.test

<li>Introduced new test scenarios for prepared statements.<br> <li> Verified correctness of query results with dynamic parameters.<br> <li> Added setup and teardown for test tables.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21644/files#diff-69f654e48a17e2eb0ca3a2e135a4a5fad30a8fffae37f3a7ed8700432e640d3e">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>