### PR TITLE
fix bug: dot not upgrade BM25

### DIFF
--- a/pkg/bootstrap/versions/v2_1_0/upgrade.go
+++ b/pkg/bootstrap/versions/v2_1_0/upgrade.go
@@ -70,6 +70,12 @@ func (v *versionHandle) HandleTenantUpgrade(
 			return err
 		}
 
+		err = upgradeForBM25(uint32(tenantID), txn)
+		if err != nil {
+			getLogger(txn.Txn().TxnOptions().CN).Error("tenant upgrade entry execute for BM25 error", zap.Error(err), zap.Int32("tenantId", tenantID), zap.String("version", v.Metadata().Version), zap.String("upgrade for BM25", upgEntry.String()))
+			return err
+		}
+
 		duration := time.Since(start)
 		getLogger(txn.Txn().TxnOptions().CN).Info("tenant upgrade entry complete",
 			zap.String("upgrade entry", upgEntry.String()),

--- a/pkg/bootstrap/versions/v2_1_0/upgrade.go
+++ b/pkg/bootstrap/versions/v2_1_0/upgrade.go
@@ -150,7 +150,7 @@ func upgradeForBM25(accountId uint32, txn executor.TxnExecutor) error {
 			if insertErr != nil {
 				return insertErr
 			}
-			defer insertRes.Close()
+			insertRes.Close()
 
 			getLogger(txn.Txn().TxnOptions().CN).Info("insert doclen for BM25",
 				zap.String("db", dbName),

--- a/pkg/bootstrap/versions/v2_1_0/upgrade.go
+++ b/pkg/bootstrap/versions/v2_1_0/upgrade.go
@@ -70,18 +70,18 @@ func (v *versionHandle) HandleTenantUpgrade(
 			return err
 		}
 
-		err = upgradeForBM25(uint32(tenantID), txn)
-		if err != nil {
-			getLogger(txn.Txn().TxnOptions().CN).Error("tenant upgrade entry execute for BM25 error", zap.Error(err), zap.Int32("tenantId", tenantID), zap.String("version", v.Metadata().Version), zap.String("upgrade for BM25", upgEntry.String()))
-			return err
-		}
-
 		duration := time.Since(start)
 		getLogger(txn.Txn().TxnOptions().CN).Info("tenant upgrade entry complete",
 			zap.String("upgrade entry", upgEntry.String()),
 			zap.Int64("time cost(ms)", duration.Milliseconds()),
 			zap.Int32("tenantId", tenantID),
 			zap.String("toVersion", v.Metadata().Version))
+	}
+
+	err := upgradeForBM25(uint32(tenantID), txn)
+	if err != nil {
+		getLogger(txn.Txn().TxnOptions().CN).Error("tenant upgrade entry execute for BM25 error", zap.Error(err), zap.Int32("tenantId", tenantID), zap.String("version", v.Metadata().Version))
+		return err
 	}
 
 	return nil

--- a/pkg/bootstrap/versions/v2_1_0/upgrade.go
+++ b/pkg/bootstrap/versions/v2_1_0/upgrade.go
@@ -136,7 +136,6 @@ func upgradeForBM25(accountId uint32, txn executor.TxnExecutor) error {
 			if checkErr != nil {
 				return checkErr
 			}
-			defer checkRes.Close()
 			if len(checkRes.Batches) == 0 {
 				continue
 			}
@@ -144,6 +143,7 @@ func upgradeForBM25(accountId uint32, txn executor.TxnExecutor) error {
 			if rowCount > 0 {
 				continue
 			}
+			checkRes.Close()
 
 			insertSQL := fmt.Sprintf("insert into `%s`.`%s` select doc_id, count(*), '%s' from `%s`.`%s` group by doc_id", dbName, idxTable, fulltext.DOC_LEN_WORD, dbName, idxTable)
 			insertRes, insertErr := txn.Exec(insertSQL, executor.StatementOption{}.WithAccountID(accountId))

--- a/pkg/bootstrap/versions/v2_1_0/upgrade.go
+++ b/pkg/bootstrap/versions/v2_1_0/upgrade.go
@@ -140,10 +140,10 @@ func upgradeForBM25(accountId uint32, txn executor.TxnExecutor) error {
 				continue
 			}
 			rowCount := vector.GetFixedAtNoTypeCheck[uint64](checkRes.Batches[0].Vecs[0], 0)
+			checkRes.Close()
 			if rowCount > 0 {
 				continue
 			}
-			checkRes.Close()
 
 			insertSQL := fmt.Sprintf("insert into `%s`.`%s` select doc_id, count(*), '%s' from `%s`.`%s` group by doc_id", dbName, idxTable, fulltext.DOC_LEN_WORD, dbName, idxTable)
 			insertRes, insertErr := txn.Exec(insertSQL, executor.StatementOption{}.WithAccountID(accountId))

--- a/pkg/bootstrap/versions/v2_1_0/upgrade_test.go
+++ b/pkg/bootstrap/versions/v2_1_0/upgrade_test.go
@@ -140,6 +140,9 @@ func Test_HandleTenantUpgrade2(t *testing.T) {
 	txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
 	txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
 	executor2 := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+		if !strings.Contains(strings.ToLower(sql), "table_test") {
+			return executor.Result{}, nil
+		}
 		return executor.Result{}, moerr.NewInvalidInputNoCtx("return error")
 	}, txnOperator)
 

--- a/pkg/bootstrap/versions/v2_1_0/upgrade_test.go
+++ b/pkg/bootstrap/versions/v2_1_0/upgrade_test.go
@@ -153,6 +153,28 @@ func Test_HandleTenantUpgrade2(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func Test_HandleTenantUpgrade3(t *testing.T) {
+	tenantUpgEntries = []versions.UpgradeEntry{}
+
+	v := &versionHandle{
+		metadata: versions.Version{
+			Version: "v2.0.3",
+		},
+	}
+	sid := ""
+	txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+	txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+	executor2 := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+		return executor.Result{}, moerr.NewInvalidInputNoCtx("return error")
+	}, txnOperator)
+
+	err := v.HandleTenantUpgrade(context.Background(),
+		0,
+		executor2,
+	)
+	assert.Error(t, err)
+}
+
 func Test_UpgEntry(t *testing.T) {
 	checkSql := `att_comment AS COLUMN_COMMENT FROM mo_catalog.mo_columns`
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21377 

## What this PR does / why we need it:
fix bub. dot not upgrade BM25


___

### **PR Type**
Bug fix


___

### **Description**
- Added `upgradeForBM25` function call in tenant upgrade process.

- Logged errors for BM25 upgrade failures with relevant details.

- Ensured BM25 upgrade is part of the tenant upgrade workflow.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>upgrade.go</strong><dd><code>Integrate BM25 upgrade into tenant upgrade process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/bootstrap/versions/v2_1_0/upgrade.go

<li>Added <code>upgradeForBM25</code> function call during tenant upgrade.<br> <li> Logged errors for BM25 upgrade failures.<br> <li> Enhanced tenant upgrade process to include BM25 upgrades.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21661/files#diff-971045faa0d53b0db35f87b943df2bbaee02093aa2233959f7a61d23ab11e525">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>