### PR TITLE
add check local timeout txn

### DIFF
--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -2309,9 +2309,7 @@ func TestIssue5176(t *testing.T) {
 		time.Second*1,
 		func(alloc *lockTableAllocator, s []*service) {
 			l := s[0]
-			l.cfg.TxnIterFunc = func(f func([]byte) bool) {
-				return
-			}
+			l.cfg.TxnIterFunc = func(f func([]byte) bool) {}
 
 			ctx, cancel := context.WithTimeout(
 				context.Background(),

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -2230,7 +2230,7 @@ func TestReLockSuccWithReStartCN(t *testing.T) {
 	)
 }
 
-func TestCheckRemoteTxnTimeout(t *testing.T) {
+func TestCheckTxnTimeout(t *testing.T) {
 	runLockServiceTestsWithLevel(
 		t,
 		zapcore.DebugLevel,
@@ -2294,7 +2294,7 @@ func TestCheckRemoteTxnTimeout(t *testing.T) {
 				}
 			}
 
-			l2.checkRemoteTxnTimeout(ctx)
+			l2.checkTxnTimeout(ctx)
 			require.True(t, l2.activeTxnHolder.empty())
 		},
 		nil,

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -2327,6 +2327,34 @@ func TestIssue5176(t *testing.T) {
 	)
 }
 
+func TestIssue5176_2(t *testing.T) {
+	runLockServiceTestsWithLevel(
+		t,
+		zapcore.DebugLevel,
+		[]string{"s1"},
+		time.Second*1,
+		func(alloc *lockTableAllocator, s []*service) {
+			l := s[0]
+			l.cfg.TxnIterFunc = func(f func([]byte) bool) {
+				f([]byte("txn1"))
+			}
+
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				time.Second*10)
+			defer cancel()
+
+			l.activeTxnHolder.getActiveTxn([]byte("txn1"), true, "")
+
+			l.setStatus(pb.Status_ServiceLockWaiting)
+
+			l.checkTxnTimeout(ctx)
+			require.False(t, l.activeTxnHolder.empty())
+		},
+		nil,
+	)
+}
+
 func TestReLockSuccWithKeepBindTimeout(t *testing.T) {
 	runLockServiceTestsWithLevel(
 		t,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/5176

## What this PR does / why we need it:

add check local timeout txn


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Renamed `checkRemoteTxnTimeout` to `checkTxnTimeout` for broader applicability.

- Added `isValidLocalTxn` method to validate local transactions.

- Enhanced timeout handling for local and remote transactions.

- Updated test cases to reflect the new method name and functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_remote.go</strong><dd><code>Enhance transaction timeout handling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/service_remote.go

<li>Renamed <code>checkRemoteTxnTimeout</code> to <code>checkTxnTimeout</code>.<br> <li> Added <code>isValidLocalTxn</code> method for local transaction validation.<br> <li> Improved logic for handling timeout transactions.<br> <li> Integrated <code>isValidLocalTxn</code> into transaction timeout checks.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21703/files#diff-acfba37961bcb7e8b4d814ea0df6e797205c5c5455a350e8093e735ddf32b26f">+43/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_test.go</strong><dd><code>Update tests for transaction timeout handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/service_test.go

<li>Renamed test <code>TestCheckRemoteTxnTimeout</code> to <code>TestCheckTxnTimeout</code>.<br> <li> Updated test logic to align with new timeout handling.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21703/files#diff-e94812797c8b26ff0499bd86698dbc4371dd72642267baa535a7ecc7f8bf3981">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>