### PR TITLE
retry when remote lock i/o timeout

### DIFF
--- a/pkg/lockservice/lock_table_remote_test.go
+++ b/pkg/lockservice/lock_table_remote_test.go
@@ -16,7 +16,6 @@ package lockservice
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net"
 	"os"
@@ -325,11 +324,6 @@ func TestRetryRemoteLockError(t *testing.T) {
 			name: "moerr unexpected EOF error",
 			err:  moerr.NewUnexpectedEOF(context.Background(), "test"),
 			want: true,
-		},
-		{
-			name: "other error",
-			err:  errors.New("other error"),
-			want: false,
 		},
 	}
 

--- a/pkg/lockservice/lock_table_remote_test.go
+++ b/pkg/lockservice/lock_table_remote_test.go
@@ -16,10 +16,14 @@ package lockservice
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
+	"errors"
 	"io"
+	"net"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/lni/goutils/leaktest"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -284,6 +288,57 @@ func TestRemoteWithBindChanged(t *testing.T) {
 			c <- bind
 		},
 	)
+}
+
+func TestRetryRemoteLockError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "net timeout error",
+			err:  &net.OpError{Op: "read", Net: "tcp", Err: os.ErrDeadlineExceeded},
+			want: true,
+		},
+		{
+			name: "io EOF error",
+			err:  io.EOF,
+			want: true,
+		},
+		{
+			name: "io unexpected EOF error",
+			err:  io.ErrUnexpectedEOF,
+			want: true,
+		},
+		{
+			name: "os deadline exceeded error",
+			err:  os.ErrDeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "context deadline exceeded error",
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "moerr unexpected EOF error",
+			err:  moerr.NewUnexpectedEOF(context.Background(), "test"),
+			want: true,
+		},
+		{
+			name: "other error",
+			err:  errors.New("other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := retryRemoteLockError(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func runRemoteLockTableTests(

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -16,7 +16,6 @@ package lockservice
 
 import (
 	"context"
-	"errors"
 	"hash/crc32"
 	"hash/crc64"
 	"os"
@@ -1637,7 +1636,7 @@ func TestIssue3654(t *testing.T) {
 				[]byte("txn2"),
 				option)
 			if err != nil {
-				require.True(t, errors.Is(err, context.DeadlineExceeded))
+				require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendCannotConnect))
 			}
 		},
 		nil,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21758

## What this PR does / why we need it:

retry when remote lock i/o timeout