### PR TITLE
Support changing the product name into OmniFabric

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -70,6 +70,8 @@ var (
 
 	defaultServerVersionPrefix = "8.0.30-MatrixOne-v"
 
+	defaultVersionComment = "MatrixOne"
+
 	//the length of query printed into console. -1, complete string. 0, empty string. >0 , length of characters at the header of the string.
 	defaultLengthOfQueryPrinted = 1024
 
@@ -213,6 +215,8 @@ type FrontendParameters struct {
 	//the root directory of the storage and matrixcube's data. The actual dir is cubeDirPrefix + nodeID
 	ServerVersionPrefix string `toml:"serverVersionPrefix"`
 
+	VersionComment string `toml:"versionComment"`
+
 	//the length of query printed into console. -1, complete string. 0, empty string. >0 , length of characters at the header of the string.
 	LengthOfQueryPrinted int64 `toml:"lengthOfQueryPrinted" user_setting:"advanced"`
 
@@ -354,6 +358,10 @@ func (fp *FrontendParameters) SetDefaultValues() {
 
 	if fp.ServerVersionPrefix == "" {
 		fp.ServerVersionPrefix = defaultServerVersionPrefix
+	}
+
+	if fp.VersionComment == "" {
+		fp.VersionComment = defaultVersionComment
 	}
 
 	if fp.LengthOfQueryPrinted == 0 {

--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -24,8 +24,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fulltext"

--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -17,6 +17,7 @@ package frontend
 import (
 	"context"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/config"
 	"math"
 	bits2 "math/bits"
 	"strconv"
@@ -956,12 +957,20 @@ type GlobalSysVarsMgr struct {
 	accountsGlobalSysVarsMap map[uint32]*SystemVariables
 }
 
+func useTomlConfigOverOtherConfigs(CNServiceConfig *config.FrontendParameters, sysVarsMp map[string]interface{}) {
+	sysVarsMp["version_comment"] = CNServiceConfig.VersionComment
+	sysVarsMp["version"] = CNServiceConfig.ServerVersionPrefix + CNServiceConfig.MoVersion
+}
+
 // Get return sys vars of accountId
 func (m *GlobalSysVarsMgr) Get(accountId uint32, ses *Session, ctx context.Context, bh BackgroundExec) (*SystemVariables, error) {
 	sysVarsMp, err := ses.getGlobalSysVars(ctx, bh)
 	if err != nil {
 		return nil, err
 	}
+
+	CNServiceConfig := getPu(ses.service).SV
+	useTomlConfigOverOtherConfigs(CNServiceConfig, sysVarsMp)
 
 	m.Lock()
 	defer m.Unlock()

--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/config"
 	"math"
 	bits2 "math/bits"
 	"strconv"
@@ -25,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/5253

## What this PR does / why we need it:
- By setting the relevant fields in the TOML file, the product name and the version comment can be changed.


___

### **PR Type**
Enhancement


___

### **Description**
- Added configurable product name and version via TOML file

- Introduced new `versionComment` field in configuration

- Updated system variables to use TOML-configured values

- Ensured default values for new configuration fields


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.go</strong><dd><code>Add product name field and default to configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/config/configuration.go

<li>Added <code>defaultVersionComment</code> constant for product name<br> <li> Introduced <code>VersionComment</code> field to <code>FrontendParameters</code><br> <li> Set default value for <code>VersionComment</code> in <code>SetDefaultValues</code>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21777/files#diff-35ceccc6a9d5bda0966a79f612e9ca3e331cc2e2e53567745876538bd08445f8">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.go</strong><dd><code>Use TOML-configured product name and version in sys vars</code>&nbsp; </dd></summary>
<hr>

pkg/frontend/variables.go

<li>Imported configuration package for access to new fields<br> <li> Added <code>useTomlConfigOverOtherConfigs</code> to set version variables from <br>config<br> <li> Updated global system variables manager to use TOML-configured values


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21777/files#diff-07649adc637b0268b12ec915ec819f66db3a4e4375bfc77291116bfa06c4432f">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>