### PR TITLE
Remove the wrong sql 

### DIFF
--- a/test/distributed/cases/function/func_make_date.result
+++ b/test/distributed/cases/function/func_make_date.result
@@ -22,9 +22,6 @@ message    birthday
 SELECT YEAR(NOW()) - YEAR(MAKEDATE(YEAR(NOW()), 1)) AS years_passed;
 years_passed
 0
-SELECT IF(MAKEDATE(YEAR(NOW()), 366) < NOW(), '闰年', '平年') AS leap_year_status;
-leap_year_status
-闰年
 create database abc;
 use abc;
 CREATE TABLE employees (

--- a/test/distributed/cases/function/func_make_date.sql
+++ b/test/distributed/cases/function/func_make_date.sql
@@ -12,10 +12,6 @@ SELECT '生日快乐！' AS message, MAKEDATE(1990, 100) AS birthday;
 -- @ignore:0
 SELECT YEAR(NOW()) - YEAR(MAKEDATE(YEAR(NOW()), 1)) AS years_passed;
 
--- @bvt:issue#21024
-SELECT IF(MAKEDATE(YEAR(NOW()), 366) < NOW(), '闰年', '平年') AS leap_year_status;
--- @bvt:issue
-
 create database abc;
 use abc;
 CREATE TABLE employees (


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/21024

## What this PR does / why we need it:
- Remove a wrong sql command in bvt test


___

### **PR Type**
Bug fix


___

### **Description**
- Removed an incorrect SQL command from `func_make_date.sql`

- Fixed a test case causing failures in BVT


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>func_make_date.sql</strong><dd><code>Remove problematic SQL and annotations from test file</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/function/func_make_date.sql

<li>Deleted a SQL command and related test annotations causing BVT failure<br> <li> Cleaned up test file by removing unnecessary leap year check


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21783/files#diff-8a7bec57f1120aedfa9c4eb09a4e84a027148ff65b27a45ed0bbf2982fdda35e">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>