### PR TITLE
fifocache: cherry-pick ghost queue changes and optimize

### DIFF
--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -35,14 +35,15 @@ import (
 )
 
 type CacheConfig struct {
-	MemoryCapacity       *toml.ByteSize `toml:"memory-capacity" user_setting:"advanced"`
-	DiskPath             *string        `toml:"disk-path"`
-	DiskCapacity         *toml.ByteSize `toml:"disk-capacity"`
-	DiskMinEvictInterval *toml.Duration `toml:"disk-min-evict-interval"`
-	DiskEvictTarget      *float64       `toml:"disk-evict-target"`
-	RemoteCacheEnabled   bool           `toml:"remote-cache-enabled"`
-	RPC                  morpc.Config   `toml:"rpc"`
-	CheckOverlaps        bool           `toml:"check-overlaps"`
+	MemoryCapacity           *toml.ByteSize `toml:"memory-capacity" user_setting:"advanced"`
+	MemoryGhostQueueCapacity *toml.ByteSize `toml:"memory-ghost-queue-capacity"` // -1 for default, 0 to disable
+	DiskPath                 *string        `toml:"disk-path"`
+	DiskCapacity             *toml.ByteSize `toml:"disk-capacity"`
+	DiskMinEvictInterval     *toml.Duration `toml:"disk-min-evict-interval"`
+	DiskEvictTarget          *float64       `toml:"disk-evict-target"`
+	RemoteCacheEnabled       bool           `toml:"remote-cache-enabled"`
+	RPC                      morpc.Config   `toml:"rpc"`
+	CheckOverlaps            bool           `toml:"check-overlaps"`
 
 	QueryClient      client.QueryClient            `json:"-"`
 	KeyRouterFactory KeyRouterFactory[pb.CacheKey] `json:"-"`

--- a/pkg/fileservice/cache_test.go
+++ b/pkg/fileservice/cache_test.go
@@ -32,7 +32,7 @@ func Test_readCache(t *testing.T) {
 	slowCacheReadThreshold = time.Second
 
 	size := int64(128)
-	m := NewMemCache(fscache.ConstCapacity(size), nil, nil, "")
+	m := NewMemCache(fscache.ConstCapacity(size), nil, nil, "", -1)
 	defer m.Close(ctx)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*3)

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -119,6 +119,7 @@ func NewDiskCache(
 					)
 				}
 			},
+			-1,
 		),
 	}
 	ret.updatingPaths.Cond = sync.NewCond(new(sync.Mutex))

--- a/pkg/fileservice/fifocache/bench_test.go
+++ b/pkg/fileservice/fifocache/bench_test.go
@@ -26,7 +26,7 @@ import (
 func BenchmarkSequentialSet(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, -1)
 	nElements := size * 16
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -37,7 +37,7 @@ func BenchmarkSequentialSet(b *testing.B) {
 func BenchmarkParallelSet(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, -1)
 	nElements := size * 16
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -50,7 +50,7 @@ func BenchmarkParallelSet(b *testing.B) {
 func BenchmarkGet(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, -1)
 	nElements := size * 16
 	for i := 0; i < nElements; i++ {
 		cache.Set(ctx, i, i, int64(1+i%3))
@@ -64,7 +64,7 @@ func BenchmarkGet(b *testing.B) {
 func BenchmarkParallelGet(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, -1)
 	nElements := size * 16
 	for i := 0; i < nElements; i++ {
 		cache.Set(ctx, i, i, int64(1+i%3))
@@ -80,7 +80,7 @@ func BenchmarkParallelGet(b *testing.B) {
 func BenchmarkParallelGetOrSet(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, -1)
 	nElements := size * 16
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -97,7 +97,7 @@ func BenchmarkParallelGetOrSet(b *testing.B) {
 func BenchmarkParallelEvict(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, -1)
 	nElements := size * 16
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/pkg/fileservice/fifocache/data_cache.go
+++ b/pkg/fileservice/fifocache/data_cache.go
@@ -33,9 +33,10 @@ func NewDataCache(
 	postSet func(ctx context.Context, key fscache.CacheKey, value fscache.Data, size int64),
 	postGet func(ctx context.Context, key fscache.CacheKey, value fscache.Data, size int64),
 	postEvict func(ctx context.Context, key fscache.CacheKey, value fscache.Data, size int64),
+	ghostQueueCapacity int,
 ) *DataCache {
 	return &DataCache{
-		fifo: New(capacity, shardCacheKey, postSet, postGet, postEvict),
+		fifo: New(capacity, shardCacheKey, postSet, postGet, postEvict, ghostQueueCapacity),
 	}
 }
 

--- a/pkg/fileservice/fifocache/data_cache_test.go
+++ b/pkg/fileservice/fifocache/data_cache_test.go
@@ -29,6 +29,7 @@ func BenchmarkEnsureNBytesAndSet(b *testing.B) {
 	cache := NewDataCache(
 		fscache.ConstCapacity(1024),
 		nil, nil, nil,
+		-1,
 	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -74,6 +75,7 @@ func BenchmarkDataCacheSet(b *testing.B) {
 	cache := NewDataCache(
 		fscache.ConstCapacity(1024),
 		nil, nil, nil,
+		-1,
 	)
 	b.ResetTimer()
 	for i := range b.N {
@@ -93,6 +95,7 @@ func BenchmarkDataCacheGet(b *testing.B) {
 	cache := NewDataCache(
 		fscache.ConstCapacity(1024),
 		nil, nil, nil,
+		-1,
 	)
 	key := fscache.CacheKey{
 		Path:   "foo",

--- a/pkg/fileservice/fifocache/fifo.go
+++ b/pkg/fileservice/fifocache/fifo.go
@@ -89,7 +89,7 @@ func (c *_CacheItem[K, V]) dec() {
 	}
 }
 
-const DefaultGhostQueueCapacity = 10000
+const defaultGhostQueueCapacity = 10000
 
 func New[K comparable, V any](
 	capacity fscache.CapacityFunc,
@@ -99,6 +99,10 @@ func New[K comparable, V any](
 	postEvict func(ctx context.Context, key K, value V, size int64),
 	ghostQueueCapacity int, // -1 for default, 0 to disable
 ) *Cache[K, V] {
+
+	if ghostQueueCapacity < 0 {
+		ghostQueueCapacity = defaultGhostQueueCapacity
+	}
 
 	ret := &Cache[K, V]{
 		capacity: capacity,
@@ -115,9 +119,6 @@ func New[K comparable, V any](
 		ghostQueueCapacity: ghostQueueCapacity,
 	}
 
-	if ghostQueueCapacity < 0 {
-		ghostQueueCapacity = DefaultGhostQueueCapacity
-	}
 	if ghostQueueCapacity > 0 {
 		ret.ghost = newGhost[K](ghostQueueCapacity)
 	}

--- a/pkg/fileservice/fifocache/fifo_test.go
+++ b/pkg/fileservice/fifocache/fifo_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestCacheSetGet(t *testing.T) {
 	ctx := context.Background()
-	cache := New[int, int](fscache.ConstCapacity(8), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(8), ShardInt[int], nil, nil, nil, -1)
 
 	cache.Set(ctx, 1, 1, 1)
 	n, ok := cache.Get(ctx, 1)
@@ -42,7 +42,7 @@ func TestCacheSetGet(t *testing.T) {
 
 func TestCacheEvict(t *testing.T) {
 	ctx := context.Background()
-	cache := New[int, int](fscache.ConstCapacity(8), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(8), ShardInt[int], nil, nil, nil, -1)
 	for i := 0; i < 64; i++ {
 		cache.Set(ctx, i, i, 1)
 		if cache.used1+cache.used2 > cache.capacity() {
@@ -53,7 +53,7 @@ func TestCacheEvict(t *testing.T) {
 
 func TestCacheEvict2(t *testing.T) {
 	ctx := context.Background()
-	cache := New[int, int](fscache.ConstCapacity(2), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(2), ShardInt[int], nil, nil, nil, -1)
 	cache.Set(ctx, 1, 1, 1)
 	cache.Set(ctx, 2, 2, 1)
 
@@ -94,6 +94,7 @@ func TestCacheEvict3(t *testing.T) {
 		func(_ context.Context, _ int, _ bool, _ int64) {
 			nEvict++
 		},
+		-1,
 	)
 	for i := 0; i < 1024; i++ {
 		cache.Set(ctx, i, true, 1)

--- a/pkg/fileservice/fifocache/ghost.go
+++ b/pkg/fileservice/fifocache/ghost.go
@@ -1,0 +1,54 @@
+package fifocache
+
+import "container/list"
+
+// ghost represents the `ghost` structure in the S3FIFO algorithm.
+// At the time of writing, this implementation is not carefully designed.
+// There can be a better way to implement `ghost`.
+type ghost[K comparable] struct {
+	size  int
+	ll    *list.List
+	items map[K]*list.Element
+}
+
+func newGhost[K comparable](size int) *ghost[K] {
+	return &ghost[K]{
+		size:  size,
+		ll:    list.New(),
+		items: make(map[K]*list.Element),
+	}
+}
+
+func (b *ghost[K]) add(key K) {
+	if _, ok := b.items[key]; ok {
+		return
+	}
+
+	for b.ll.Len() >= b.size {
+		e := b.ll.Back()
+		delete(b.items, e.Value.(K))
+		b.ll.Remove(e)
+	}
+
+	e := b.ll.PushFront(key)
+	b.items[key] = e
+}
+
+func (b *ghost[K]) remove(key K) {
+	if e, ok := b.items[key]; ok {
+		b.ll.Remove(e)
+		delete(b.items, key)
+	}
+}
+
+func (b *ghost[K]) contains(key K) bool {
+	_, ok := b.items[key]
+	return ok
+}
+
+func (b *ghost[K]) clear() {
+	b.ll.Init()
+	for k := range b.items {
+		delete(b.items, k)
+	}
+}

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 	"io"
 	"io/fs"
 	"iter"
@@ -30,6 +29,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 
 	"go.uber.org/zap"
 
@@ -151,11 +152,16 @@ func (l *LocalFS) initCaches(ctx context.Context, config CacheConfig) error {
 	// memory
 	if config.MemoryCapacity != nil &&
 		*config.MemoryCapacity > DisableCacheCapacity { // 1 means disable
+		ghostQueueCapacity := -1 // default
+		if config.MemoryGhostQueueCapacity != nil {
+			ghostQueueCapacity = int(*config.MemoryGhostQueueCapacity)
+		}
 		l.memCache = NewMemCache(
 			fscache.ConstCapacity(int64(*config.MemoryCapacity)),
 			&config.CacheCallbacks,
 			l.perfCounterSets,
 			l.name,
+			ghostQueueCapacity,
 		)
 		logutil.Info("fileservice: memory cache initialized",
 			zap.Any("fs-name", l.name),

--- a/pkg/fileservice/local_fs_test.go
+++ b/pkg/fileservice/local_fs_test.go
@@ -211,12 +211,14 @@ func TestLocalFSWithIOVectorCache(t *testing.T) {
 		fscache.ConstCapacity(1<<20), nil,
 		nil,
 		"",
+		-1,
 	)
 	defer memCache1.Close(ctx)
 	memCache2 := NewMemCache(
 		fscache.ConstCapacity(1<<20), nil,
 		nil,
 		"",
+		-1,
 	)
 	defer memCache2.Close(ctx)
 	caches := []IOVectorCache{memCache1, memCache2}

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -33,6 +33,7 @@ func NewMemCache(
 	callbacks *CacheCallbacks,
 	counterSets []*perfcounter.CounterSet,
 	name string,
+	ghostQueueCapacity int,
 ) *MemCache {
 
 	inuseBytes, capacityBytes := metric.GetFsCacheBytesGauge(name, "mem")
@@ -113,7 +114,7 @@ func NewMemCache(
 		}
 	}
 
-	dataCache := fifocache.NewDataCache(capacityFunc, postSetFn, postGetFn, postEvictFn)
+	dataCache := fifocache.NewDataCache(capacityFunc, postSetFn, postGetFn, postEvictFn, ghostQueueCapacity)
 
 	ret := &MemCache{
 		cache:       dataCache,

--- a/pkg/fileservice/mem_cache_test.go
+++ b/pkg/fileservice/mem_cache_test.go
@@ -45,7 +45,7 @@ func TestMemCacheLeak(t *testing.T) {
 	assert.Nil(t, err)
 
 	size := int64(128)
-	m := NewMemCache(fscache.ConstCapacity(size), nil, nil, "")
+	m := NewMemCache(fscache.ConstCapacity(size), nil, nil, "", -1)
 	defer m.Close(ctx)
 
 	newReadVec := func() *IOVector {
@@ -118,7 +118,7 @@ func TestMemCacheLeak(t *testing.T) {
 // and dataOverlap-checker.
 func TestHighConcurrency(t *testing.T) {
 	ctx := context.Background()
-	m := NewMemCache(fscache.ConstCapacity(2), nil, nil, "")
+	m := NewMemCache(fscache.ConstCapacity(2), nil, nil, "", -1)
 	defer m.Close(ctx)
 
 	n := 10
@@ -165,6 +165,7 @@ func BenchmarkMemoryCacheUpdate(b *testing.B) {
 		nil,
 		nil,
 		"",
+		-1,
 	)
 	defer cache.Flush(ctx)
 
@@ -199,6 +200,7 @@ func BenchmarkMemoryCacheRead(b *testing.B) {
 		nil,
 		nil,
 		"",
+		-1,
 	)
 	defer cache.Flush(ctx)
 
@@ -247,6 +249,7 @@ func TestMemoryCacheGlobalSizeHint(t *testing.T) {
 		nil,
 		nil,
 		"test",
+		-1,
 	)
 	defer cache.Close(ctx)
 

--- a/pkg/fileservice/memory_fs_test.go
+++ b/pkg/fileservice/memory_fs_test.go
@@ -62,6 +62,7 @@ func BenchmarkMemoryFSWithMemoryCache(b *testing.B) {
 		nil,
 		nil,
 		"",
+		-1,
 	)
 	defer cache.Close(ctx)
 
@@ -85,6 +86,7 @@ func BenchmarkMemoryFSWithMemoryCacheLowCapacity(b *testing.B) {
 	cache := NewMemCache(
 		fscache.ConstCapacity(2*1024*1024), nil, nil,
 		"",
+		-1,
 	)
 	defer cache.Close(ctx)
 

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -194,11 +194,16 @@ func (s *S3FS) initCaches(ctx context.Context, config CacheConfig) error {
 	// memory cache
 	if config.MemoryCapacity != nil &&
 		*config.MemoryCapacity > DisableCacheCapacity {
+		ghostQueueCapacity := -1 // default
+		if config.MemoryGhostQueueCapacity != nil {
+			ghostQueueCapacity = int(*config.MemoryGhostQueueCapacity)
+		}
 		s.memCache = NewMemCache(
 			fscache.ConstCapacity(int64(*config.MemoryCapacity)),
 			&config.CacheCallbacks,
 			s.perfCounterSets,
 			s.name,
+			ghostQueueCapacity,
 		)
 		logutil.Info("fileservice: memory cache initialized",
 			zap.Any("fs-name", s.name),

--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -134,7 +134,9 @@ func newMetaCache(capacity fscache.CapacityFunc) *fifocache.Cache[mataCacheKey, 
 		func(_ context.Context, _ mataCacheKey, _ []byte, size int64) { // postEvict
 			inuseBytes.Add(float64(-size))
 			capacityBytes.Set(float64(capacity()))
-		})
+		},
+		-1,
+	)
 }
 
 func EvictCache(ctx context.Context) (target int64) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue issue https://github.com/matrixorigin/matrixone/issues/21654 https://github.com/matrixorigin/matrixone/issues/21589

## What this PR does / why we need it:
Cherry-pick ghost queue changes by Eric.
And optimize the ghost queue with Queue.

benchmark results:
```
goos: linux
goarch: amd64
pkg: github.com/matrixorigin/matrixone/pkg/fileservice/fifocache
cpu: AMD Ryzen 9 7900 12-Core Processor             
                      │ /home/reus/mo/pkg/fileservice/fifocache/b1 │                 b2                  │
                      │                   sec/op                   │    sec/op     vs base               │
SequentialSet-24                                      139.5n ± 11%   232.1n ±  1%  +66.28% (p=0.002 n=6)
ParallelSet-24                                        18.12n ±  2%   23.73n ± 24%  +30.96% (p=0.037 n=6)
Get-24                                                34.67n ±  3%   34.62n ±  1%        ~ (p=0.589 n=6)
ParallelGet-24                                        7.571n ±  6%   7.670n ±  5%        ~ (p=0.589 n=6)
ParallelGetOrSet-24                                   13.76n ±  2%   13.73n ±  7%        ~ (p=0.667 n=6)
ParallelEvict-24                                      160.6n ±  7%   147.0n ±  6%   -8.47% (p=0.002 n=6)
ShardCacheKey-24                                      21.32n ±  3%   21.08n ±  1%        ~ (p=0.180 n=6)
EnsureNBytesAndSet-24                                 16.44n ± 11%   16.43n ±  1%        ~ (p=0.589 n=6)
DataCacheSet-24                                       255.1n ±  4%   377.4n ±  4%  +47.94% (p=0.002 n=6)
DataCacheGet-24                                       36.73n ±  1%   36.57n ±  7%        ~ (p=0.177 n=6)
geomean                                               37.01n         41.20n        +11.34%

                      │ /home/reus/mo/pkg/fileservice/fifocache/b1 │                  b2                  │
                      │                    B/op                    │     B/op      vs base                │
SequentialSet-24                                    32.00 ±   0%     32.00 ±   0%       ~ (p=1.000 n=6) ¹
ParallelSet-24                                      1.000 ±   0%     1.000 ±   0%       ~ (p=1.000 n=6) ¹
Get-24                                              0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=6) ¹
ParallelGet-24                                      0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=6) ¹
ParallelGetOrSet-24                                 0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=6) ¹
ParallelEvict-24                                    1.000 ± 400%     1.000 ± 100%       ~ (p=0.455 n=6)
ShardCacheKey-24                                    0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=6) ¹
EnsureNBytesAndSet-24                               0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=6) ¹
DataCacheSet-24                                     118.0 ±   0%     119.0 ±   0%  +0.85% (p=0.002 n=6)
DataCacheGet-24                                     0.000 ±   0%     0.000 ±   0%       ~ (p=1.000 n=6) ¹
geomean                                                          ²                 +0.08%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                      │ /home/reus/mo/pkg/fileservice/fifocache/b1 │                 b2                  │
                      │                 allocs/op                  │ allocs/op   vs base                 │
SequentialSet-24                                      1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=6) ¹
ParallelSet-24                                        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
Get-24                                                0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ParallelGet-24                                        0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ParallelGetOrSet-24                                   0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ParallelEvict-24                                      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
ShardCacheKey-24                                      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
EnsureNBytesAndSet-24                                 0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
DataCacheSet-24                                       4.000 ± 0%     5.000 ± 0%  +25.00% (p=0.002 n=6)
DataCacheGet-24                                       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=6) ¹
geomean                                                          ²                +2.26%               ²
¹ all samples are equal
² summaries must be >0 to compute geomean

```