### PR TITLE
BUG FIX: [Subtask]: 对象分配优化：fifocache.shardCacheKey

### DIFF
--- a/pkg/fileservice/fifocache/data_cache.go
+++ b/pkg/fileservice/fifocache/data_cache.go
@@ -42,7 +42,7 @@ func NewDataCache(
 var seed = maphash.MakeSeed()
 
 func shardCacheKey(key fscache.CacheKey) uint64 {
-	hasher := new(maphash.Hash)
+	var hasher maphash.Hash
 	hasher.SetSeed(seed)
 	hasher.Write(util.UnsafeToBytes(&key.Offset))
 	hasher.WriteString(key.Path)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21393

## What this PR does / why we need it:

declare the value of hashmap instead of pointer.