### PR TITLE
Revert "[Subtask]: 对象分配优化：fileservice.newEventLogger #21394 (#21805)"

### DIFF
--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -481,8 +481,7 @@ func (s *S3FS) Read(ctx context.Context, vector *IOVector) (err error) {
 		return err
 	}
 
-	// disable EventLogger for release mode and uncomment it for debugging
-	// ctx = WithEventLogger(ctx)
+	ctx = WithEventLogger(ctx)
 	LogEvent(ctx, str_s3fs_read, vector)
 	defer func() {
 		LogEvent(ctx, str_read_return)


### PR DESCRIPTION
This reverts commit 8c6233beb905741329a36840cea4c38f184cf8cc.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21394

## What this PR does / why we need it:

revert the change