### PR TITLE
fileservice: make DiskCacheCallbacks a context.Context to eliminate usages of context.WithValue

### DIFF
--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -40,9 +40,22 @@ func TestDiskCache(t *testing.T) {
 
 	// counter
 	numWritten := 0
+	numEvict := 0
 	ctx = OnDiskCacheWritten(ctx, func(path string, entry IOEntry) {
 		numWritten++
 	})
+	ctx = OnDiskCacheWritten(ctx, nil) // for coverage
+	ctx = OnDiskCacheEvict(ctx, func(path string) {
+		numEvict++
+	})
+	ctx = OnDiskCacheEvict(ctx, nil) // for coverage
+
+	// DiskCacheCallback context
+	_, set := ctx.Deadline()
+	assert.False(t, set)
+	if err := ctx.Err(); err != nil {
+		t.Fatal(err)
+	}
 
 	// new
 	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "")
@@ -158,6 +171,12 @@ func TestDiskCacheWriteAgain(t *testing.T) {
 	ctx := context.Background()
 	var counterSet perfcounter.CounterSet
 	ctx = perfcounter.WithCounterSet(ctx, &counterSet)
+
+	numEvict := 0
+	ctx = OnDiskCacheEvict(ctx, func(path string) {
+		numEvict++
+	})
+	ctx = OnDiskCacheEvict(ctx, nil) // for coverage
 
 	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(4096), nil, false, nil, "")
 	assert.Nil(t, err)


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21810 

## What this PR does / why we need it:
make DiskCacheCallbacks a context.Context to eliminate usages of context.WithValue