### PR TITLE
fifocache: use fibonacci hashing

### DIFF
--- a/pkg/fileservice/fifocache/data_cache.go
+++ b/pkg/fileservice/fifocache/data_cache.go
@@ -16,10 +16,8 @@ package fifocache
 
 import (
 	"context"
-	"hash/maphash"
 	"math"
 
-	"github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
 	"github.com/matrixorigin/matrixone/pkg/pb/query"
 )
@@ -39,14 +37,9 @@ func NewDataCache(
 	}
 }
 
-var seed = maphash.MakeSeed()
-
 func shardCacheKey(key fscache.CacheKey) uint64 {
-	var hasher maphash.Hash
-	hasher.SetSeed(seed)
-	hasher.Write(util.UnsafeToBytes(&key.Offset))
-	hasher.WriteString(key.Path)
-	return hasher.Sum64()
+	// fibonacci hashing
+	return uint64(key.Offset) * uint64(key.Sz) * uint64(11400714819323198485)
 }
 
 var _ fscache.DataCache = new(DataCache)

--- a/pkg/fileservice/fifocache/shard.go
+++ b/pkg/fileservice/fifocache/shard.go
@@ -21,6 +21,8 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
+var seed = maphash.MakeSeed()
+
 func ShardInt[T constraints.Integer](v T) uint64 {
 	return maphash.Bytes(seed, util.UnsafeToBytes(&v))
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21393

## What this PR does / why we need it:
Make hashing much faster.

benchstat:

```
goos: linux
goarch: amd64
pkg: github.com/matrixorigin/matrixone/pkg/fileservice/fifocache
cpu: AMD Ryzen 9 7900 12-Core Processor             
                 │      b1       │                 b2                  │
                 │    sec/op     │    sec/op     vs base               │
ShardCacheKey-24   21.1650n ± 1%   0.1966n ± 6%  -99.07% (p=0.002 n=6)

goos: linux
goarch: amd64
pkg: github.com/matrixorigin/matrixone/pkg/fileservice/fifocache
cpu: AMD Ryzen 9 7900 12-Core Processor             
                │     b1      │                 b2                 │
                │   sec/op    │   sec/op     vs base               │
DataCacheSet-24   260.4n ± 6%   193.7n ± 4%  -25.60% (p=0.002 n=6)
DataCacheGet-24   36.74n ± 1%   18.88n ± 2%  -48.61% (p=0.002 n=6)
geomean           97.82n        60.49n       -38.16%

```