### PR TITLE
s3fifo add ghost fifo for 2.1-dev

### DIFF
--- a/cmd/mo-service/config.go
+++ b/cmd/mo-service/config.go
@@ -301,7 +301,7 @@ func (c *Config) setDefaultValue() error {
 
 func (c *Config) initMetaCache() {
 	if c.MetaCache.MemoryCapacity > 0 {
-		objectio.InitMetaCache(int64(c.MetaCache.MemoryCapacity))
+		objectio.InitMetaCache(int64(c.MetaCache.MemoryCapacity), c.MetaCache.DisableS3Fifo)
 	}
 }
 

--- a/pkg/embed/config.go
+++ b/pkg/embed/config.go
@@ -279,7 +279,7 @@ func (c *ServiceConfig) setDefaultValue() error {
 
 func (c *ServiceConfig) initMetaCache() {
 	if c.MetaCache.MemoryCapacity > 0 {
-		objectio.InitMetaCache(int64(c.MetaCache.MemoryCapacity))
+		objectio.InitMetaCache(int64(c.MetaCache.MemoryCapacity), c.MetaCache.DisableS3Fifo)
 	}
 }
 

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -43,6 +43,7 @@ type CacheConfig struct {
 	RemoteCacheEnabled   bool           `toml:"remote-cache-enabled"`
 	RPC                  morpc.Config   `toml:"rpc"`
 	CheckOverlaps        bool           `toml:"check-overlaps"`
+	DisableS3Fifo        bool           `toml:"disable-s3fifo"`
 
 	QueryClient      client.QueryClient            `json:"-"`
 	KeyRouterFactory KeyRouterFactory[pb.CacheKey] `json:"-"`

--- a/pkg/fileservice/cache_test.go
+++ b/pkg/fileservice/cache_test.go
@@ -32,7 +32,7 @@ func Test_readCache(t *testing.T) {
 	slowCacheReadThreshold = time.Second
 
 	size := int64(128)
-	m := NewMemCache(fscache.ConstCapacity(size), nil, nil, "")
+	m := NewMemCache(fscache.ConstCapacity(size), nil, nil, "", false)
 	defer m.Close(ctx)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*3)

--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -60,6 +60,7 @@ func NewDiskCache(
 	asyncLoad bool,
 	cacheDataAllocator CacheDataAllocator,
 	name string,
+	disable_s3fifo bool,
 ) (ret *DiskCache, err error) {
 
 	err = os.MkdirAll(path, 0755)
@@ -119,6 +120,7 @@ func NewDiskCache(
 					)
 				}
 			},
+			disable_s3fifo,
 		),
 	}
 	ret.updatingPaths.Cond = sync.NewCond(new(sync.Mutex))

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -45,7 +45,7 @@ func TestDiskCache(t *testing.T) {
 	})
 
 	// new
-	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "")
+	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "", false)
 	assert.Nil(t, err)
 	defer cache.Close(ctx)
 
@@ -130,7 +130,7 @@ func TestDiskCache(t *testing.T) {
 	testRead(cache)
 
 	// new cache instance and read
-	cache, err = NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "")
+	cache, err = NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "", false)
 	assert.Nil(t, err)
 	defer cache.Close(ctx)
 
@@ -139,7 +139,7 @@ func TestDiskCache(t *testing.T) {
 	assert.Equal(t, 1, numWritten)
 
 	// new cache instance and update
-	cache, err = NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "")
+	cache, err = NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "", false)
 	assert.Nil(t, err)
 	defer cache.Close(ctx)
 
@@ -159,7 +159,7 @@ func TestDiskCacheWriteAgain(t *testing.T) {
 	var counterSet perfcounter.CounterSet
 	ctx = perfcounter.WithCounterSet(ctx, &counterSet)
 
-	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(4096), nil, false, nil, "")
+	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(4096), nil, false, nil, "", false)
 	assert.Nil(t, err)
 	defer cache.Close(ctx)
 
@@ -224,7 +224,7 @@ func TestDiskCacheWriteAgain(t *testing.T) {
 func TestDiskCacheFileCache(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
-	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "")
+	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "", false)
 	assert.Nil(t, err)
 	defer cache.Close(ctx)
 
@@ -284,7 +284,7 @@ func TestDiskCacheDirSize(t *testing.T) {
 
 	dir := t.TempDir()
 	capacity := 1 << 20
-	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(int64(capacity)), nil, false, nil, "")
+	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(int64(capacity)), nil, false, nil, "", false)
 	assert.Nil(t, err)
 	defer cache.Close(ctx)
 
@@ -347,6 +347,7 @@ func benchmarkDiskCacheWriteThenRead(
 		false,
 		nil,
 		"",
+		false,
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -442,6 +443,7 @@ func benchmarkDiskCacheReadRandomOffsetAtLargeFile(
 		false,
 		nil,
 		"",
+		false,
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -513,6 +515,7 @@ func BenchmarkDiskCacheMultipleIOEntries(b *testing.B) {
 		false,
 		nil,
 		"",
+		false,
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -584,7 +587,7 @@ func TestDiskCacheClearFiles(t *testing.T) {
 	assert.Nil(t, err)
 	numFiles := len(files)
 
-	_, err = NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "")
+	_, err = NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "", false)
 	assert.Nil(t, err)
 
 	files, err = filepath.Glob(filepath.Join(dir, "*"))
@@ -598,7 +601,7 @@ func TestDiskCacheClearFiles(t *testing.T) {
 func TestDiskCacheBadWrite(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
-	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "")
+	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "", false)
 	assert.Nil(t, err)
 
 	written, err := cache.writeFile(
@@ -633,6 +636,7 @@ func TestDiskCacheGlobalSizeHint(t *testing.T) {
 		false,
 		nil,
 		"test",
+		false,
 	)
 	assert.Nil(t, err)
 	defer cache.Close(ctx)
@@ -665,7 +669,7 @@ func TestDiskCacheGlobalSizeHint(t *testing.T) {
 
 func TestDiskCacheSetFromFile(t *testing.T) {
 	ctx := context.Background()
-	cache, err := NewDiskCache(ctx, t.TempDir(), fscache.ConstCapacity(1<<30), nil, false, nil, "")
+	cache, err := NewDiskCache(ctx, t.TempDir(), fscache.ConstCapacity(1<<30), nil, false, nil, "", false)
 	require.Nil(t, err)
 	defer cache.Close(ctx)
 
@@ -690,7 +694,7 @@ func TestDiskCacheSetFromFile(t *testing.T) {
 
 func TestDiskCacheQuotaExceeded(t *testing.T) {
 	ctx := context.Background()
-	cache, err := NewDiskCache(ctx, t.TempDir(), fscache.ConstCapacity(3), nil, false, nil, "")
+	cache, err := NewDiskCache(ctx, t.TempDir(), fscache.ConstCapacity(3), nil, false, nil, "", false)
 	require.Nil(t, err)
 	defer cache.Close(ctx)
 

--- a/pkg/fileservice/fifocache/bench2_test.go
+++ b/pkg/fileservice/fifocache/bench2_test.go
@@ -1,0 +1,130 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fifocache
+
+import (
+	"context"
+	"math/rand/v2"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
+)
+
+const g_cache_size = 51200000 // 512M
+const g_item_size = 128000    // 128K
+const g_io_read_time = 20 * time.Microsecond
+
+func cache_read(ctx context.Context, cache *Cache[int64, int64], key int64) {
+
+	_, ok := cache.Get(ctx, key)
+	if !ok {
+		// cache miss and sleep penalty as IO read
+		time.Sleep(g_io_read_time)
+		cache.Set(ctx, key, int64(0), g_item_size)
+	}
+}
+
+func get_rand(start int64, end int64, r *rand.Rand) int64 {
+	return start + r.Int64N(end-start)
+}
+
+func dataset_read(b *testing.B, ctx context.Context, cache *Cache[int64, int64], startkey int64, endkey int64, r *rand.Rand) {
+
+	ncpu := runtime.NumCPU()
+	var wg sync.WaitGroup
+
+	for i := 0; i < ncpu; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for n := 0; n < b.N; n++ {
+
+				if n%ncpu != i {
+					continue
+				}
+
+				//fmt.Printf("start = %d, end = %d\n", startkey, endkey)
+				for range endkey - startkey {
+
+					key := get_rand(startkey, endkey, r)
+					cache_read(ctx, cache, key)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func data_shift(b *testing.B, time int64) {
+	ctx := context.Background()
+	cache_size := g_cache_size
+	cache := New[int64, int64](fscache.ConstCapacity(int64(cache_size)), ShardInt[int64], nil, nil, nil, false)
+	r := rand.New(rand.NewPCG(1, 2))
+
+	offset := int64(0)
+	start := int64(0)
+	end := int64(g_cache_size) / int64(g_item_size) * time
+	d1 := []int64{start, end}
+	offset += end
+	d2 := []int64{offset + start, offset + end}
+	offset += end
+	d3 := []int64{offset + start, offset + end}
+
+	b.ResetTimer()
+
+	dataset_read(b, ctx, cache, d1[0], d1[1], r)
+	dataset_read(b, ctx, cache, d2[0], d2[1], r)
+	dataset_read(b, ctx, cache, d3[0], d3[1], r)
+}
+
+func data_readNx(b *testing.B, time int64) {
+	ctx := context.Background()
+	cache_size := g_cache_size
+	cache := New[int64, int64](fscache.ConstCapacity(int64(cache_size)), ShardInt[int64], nil, nil, nil, false)
+	start := int64(0)
+	end := int64(g_cache_size) / int64(g_item_size) * time
+	r := rand.New(rand.NewPCG(1, 2))
+
+	b.ResetTimer()
+	dataset_read(b, ctx, cache, start, end, r)
+}
+
+func BenchmarkSimCacheRead1x(b *testing.B) {
+	data_readNx(b, 1)
+}
+
+func BenchmarkSimCacheRead1xShift(b *testing.B) {
+	data_shift(b, 1)
+}
+
+func BenchmarkSimCacheRead2x(b *testing.B) {
+	data_readNx(b, 2)
+}
+
+func BenchmarkSimCacheRead2xShift(b *testing.B) {
+	data_shift(b, 2)
+}
+
+func BenchmarkSimCacheRead4x(b *testing.B) {
+	data_readNx(b, 4)
+}
+
+func BenchmarkSimCacheRead4xShift(b *testing.B) {
+	data_shift(b, 4)
+}

--- a/pkg/fileservice/fifocache/bench_test.go
+++ b/pkg/fileservice/fifocache/bench_test.go
@@ -26,7 +26,7 @@ import (
 func BenchmarkSequentialSet(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, false)
 	nElements := size * 16
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -37,7 +37,7 @@ func BenchmarkSequentialSet(b *testing.B) {
 func BenchmarkParallelSet(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, false)
 	nElements := size * 16
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -50,7 +50,7 @@ func BenchmarkParallelSet(b *testing.B) {
 func BenchmarkGet(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, false)
 	nElements := size * 16
 	for i := 0; i < nElements; i++ {
 		cache.Set(ctx, i, i, int64(1+i%3))
@@ -64,7 +64,7 @@ func BenchmarkGet(b *testing.B) {
 func BenchmarkParallelGet(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, false)
 	nElements := size * 16
 	for i := 0; i < nElements; i++ {
 		cache.Set(ctx, i, i, int64(1+i%3))
@@ -80,7 +80,7 @@ func BenchmarkParallelGet(b *testing.B) {
 func BenchmarkParallelGetOrSet(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, false)
 	nElements := size * 16
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -97,7 +97,7 @@ func BenchmarkParallelGetOrSet(b *testing.B) {
 func BenchmarkParallelEvict(b *testing.B) {
 	ctx := context.Background()
 	size := 65536
-	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(int64(size)), ShardInt[int], nil, nil, nil, false)
 	nElements := size * 16
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {

--- a/pkg/fileservice/fifocache/data_cache_test.go
+++ b/pkg/fileservice/fifocache/data_cache_test.go
@@ -29,6 +29,7 @@ func BenchmarkEnsureNBytesAndSet(b *testing.B) {
 	cache := NewDataCache(
 		fscache.ConstCapacity(1024),
 		nil, nil, nil,
+		false,
 	)
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -63,7 +64,7 @@ func TestShardCacheKeyAllocs(t *testing.T) {
 		Offset: 3,
 		Path:   strings.Repeat("abc", 42),
 	}
-	if n := testing.AllocsPerRun(64, func() {
+	if n := testing.AllocsPerRun(64000, func() {
 		shardCacheKey(key)
 	}); n != 0 {
 		t.Fatalf("should not allocate")
@@ -74,6 +75,7 @@ func BenchmarkDataCacheSet(b *testing.B) {
 	cache := NewDataCache(
 		fscache.ConstCapacity(1024),
 		nil, nil, nil,
+		false,
 	)
 	b.ResetTimer()
 	for i := range b.N {
@@ -93,6 +95,7 @@ func BenchmarkDataCacheGet(b *testing.B) {
 	cache := NewDataCache(
 		fscache.ConstCapacity(1024),
 		nil, nil, nil,
+		false,
 	)
 	key := fscache.CacheKey{
 		Path:   "foo",

--- a/pkg/fileservice/fifocache/fifo_test.go
+++ b/pkg/fileservice/fifocache/fifo_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestCacheSetGet(t *testing.T) {
 	ctx := context.Background()
-	cache := New[int, int](fscache.ConstCapacity(8), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(8), ShardInt[int], nil, nil, nil, false)
 
 	cache.Set(ctx, 1, 1, 1)
 	n, ok := cache.Get(ctx, 1)
@@ -42,18 +42,18 @@ func TestCacheSetGet(t *testing.T) {
 
 func TestCacheEvict(t *testing.T) {
 	ctx := context.Background()
-	cache := New[int, int](fscache.ConstCapacity(8), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(8), ShardInt[int], nil, nil, nil, false)
 	for i := 0; i < 64; i++ {
 		cache.Set(ctx, i, i, 1)
-		if cache.used1+cache.used2 > cache.capacity() {
-			t.Fatalf("capacity %v, used1 %v used2 %v", cache.capacity(), cache.used1, cache.used2)
+		if cache.Used() > cache.capacity() {
+			t.Fatalf("capacity %v, usedSmall %v usedMain %v", cache.capacity(), cache.usedSmall.Load(), cache.usedMain.Load())
 		}
 	}
 }
 
 func TestCacheEvict2(t *testing.T) {
 	ctx := context.Background()
-	cache := New[int, int](fscache.ConstCapacity(2), ShardInt[int], nil, nil, nil)
+	cache := New[int, int](fscache.ConstCapacity(20), ShardInt[int], nil, nil, nil, false)
 	cache.Set(ctx, 1, 1, 1)
 	cache.Set(ctx, 2, 2, 1)
 
@@ -76,8 +76,8 @@ func TestCacheEvict2(t *testing.T) {
 	v, ok = cache.Get(ctx, 4)
 	assert.True(t, ok)
 	assert.Equal(t, 4, v)
-	assert.Equal(t, int64(1), cache.used1)
-	assert.Equal(t, int64(1), cache.used2)
+	assert.Equal(t, int64(4), cache.usedSmall.Load())
+	assert.Equal(t, int64(0), cache.usedMain.Load())
 }
 
 func TestCacheEvict3(t *testing.T) {
@@ -94,12 +94,13 @@ func TestCacheEvict3(t *testing.T) {
 		func(_ context.Context, _ int, _ bool, _ int64) {
 			nEvict++
 		},
+		false,
 	)
 	for i := 0; i < 1024; i++ {
 		cache.Set(ctx, i, true, 1)
 		cache.Get(ctx, i)
 		cache.Get(ctx, i)
-		assert.True(t, cache.used1+cache.used2 <= 1024)
+		assert.True(t, cache.Used() <= 1024)
 	}
 	assert.Equal(t, 0, nEvict)
 	assert.Equal(t, 1024, nSet)
@@ -107,11 +108,123 @@ func TestCacheEvict3(t *testing.T) {
 
 	for i := 0; i < 1024; i++ {
 		cache.Set(ctx, 10000+i, true, 1)
-		assert.True(t, cache.used1+cache.used2 <= 1024)
+		assert.True(t, cache.Used() <= 1024)
 	}
-	assert.Equal(t, int64(102), cache.used1)
-	assert.Equal(t, int64(922), cache.used2)
+	assert.Equal(t, int64(102), cache.usedSmall.Load())
+	assert.Equal(t, int64(922), cache.usedMain.Load())
 	assert.Equal(t, 1024, nEvict)
 	assert.Equal(t, 2048, nSet)
 	assert.Equal(t, 2048, nGet)
+}
+
+func TestCacheOneHitWonder(t *testing.T) {
+	ctx := context.Background()
+	cache := New[int64, int64](fscache.ConstCapacity(1000), ShardInt[int64], nil, nil, nil, false)
+
+	capsmall := int64(1000)
+	for i := range capsmall {
+		cache.Set(ctx, i, i, 1)
+	}
+	assert.Equal(t, int64(0), cache.usedMain.Load())
+	//fmt.Printf("cache main %d, small %d\n", cache.usedMain.Load(), cache.usedSmall.Load())
+}
+
+func TestCacheMoveMain(t *testing.T) {
+	ctx := context.Background()
+	cache := New[int64, int64](fscache.ConstCapacity(100), ShardInt[int64], nil, nil, nil, false)
+
+	// fill small fifo to 90
+	for i := range int64(90) {
+		cache.Set(ctx, 10000+i, 10000+i, 1)
+	}
+
+	results := [][]int64{{0, 100}, {0, 100}, {0, 100}, {0, 100}, {0, 100},
+		{20, 80}, {40, 60}, {60, 40}, {80, 20},
+		{90, 10}, {90, 10}, {90, 10}, {90, 10}, {90, 10}, {90, 10}, {90, 10}, {90, 10}, {90, 10}, {90, 10}, {90, 10}}
+
+	for k := range int64(20) {
+		//fmt.Printf("cache set 10 items\n")
+		capsmall := int64(10)
+		for i := range capsmall {
+			cache.Set(ctx, k*10+i, k*10+i, 1)
+		}
+
+		//fmt.Printf("increment freq 2\n")
+		// increment the freq
+		for j := range 2 {
+			for i := range capsmall {
+				_, ok := cache.Get(ctx, k*10+i)
+				assert.Equal(t, ok, true)
+			}
+			_ = j
+		}
+		//fmt.Printf("Add %d to %d and Try move to main\n", (k+1)*200, (k+1)*200+capsmall)
+		// move to main
+		for i := range capsmall {
+			cache.Set(ctx, (k+1)*200+i, (k+1)*200+i, 1)
+		}
+		//fmt.Printf("cache main %d, small %d\n", cache.usedMain.Load(), cache.usedSmall.Load())
+
+		assert.Equal(t, results[k][0], cache.usedMain.Load())
+		assert.Equal(t, results[k][1], cache.usedSmall.Load())
+	}
+
+	assert.Equal(t, int64(90), cache.usedMain.Load())
+	assert.Equal(t, int64(10), cache.usedSmall.Load())
+	// remove all main 0 - 99
+	//fmt.Printf("remove all main\n")
+}
+
+func TestCacheMoveGhost(t *testing.T) {
+	ctx := context.Background()
+	cache := New[int64, int64](fscache.ConstCapacity(100), ShardInt[int64], nil, nil, nil, false)
+
+	// fill small fifo to 90
+	for i := range int64(90) {
+		cache.Set(ctx, 10000+i, 10000+i, 1)
+	}
+
+	for k := range int64(2) {
+		//fmt.Printf("cache set 10 items\n")
+		capsmall := int64(10)
+		for i := range capsmall {
+			cache.Set(ctx, k*10+i, k*10+i, 1)
+		}
+
+		//fmt.Printf("increment freq 2\n")
+		// increment the freq
+		for j := range 2 {
+			for i := range capsmall {
+				_, ok := cache.Get(ctx, k*10+i)
+				assert.Equal(t, ok, true)
+			}
+			_ = j
+		}
+		//fmt.Printf("Add %d to %d and Try move to main\n", (k+1)*200, (k+1)*200+capsmall)
+		// move to main
+		for i := range capsmall {
+			cache.Set(ctx, (k+1)*200+i, (k+1)*200+i, 1)
+		}
+		//fmt.Printf("cache main %d, small %d\n", cache.usedMain.Load(), cache.usedSmall.Load())
+	}
+
+	for i := 10000; i < 10020; i++ {
+		assert.Equal(t, cache.ghost.contains(int64(i)), true)
+
+	}
+
+	//fmt.Printf("cache main %d, small %d\n", cache.usedMain.Load(), cache.usedSmall.Load())
+	for i := 10000; i < 10020; i++ {
+		cache.Set(ctx, int64(i), int64(i), 1)
+		assert.Equal(t, cache.ghost.contains(int64(i)), false)
+	}
+
+	assert.Equal(t, cache.usedMain.Load(), int64(20))
+	assert.Equal(t, cache.usedSmall.Load(), int64(80))
+	//fmt.Printf("cache main %d, small %d\n", cache.usedMain.Load(), cache.usedSmall.Load())
+	//assert.Equal(t, int64(10), cache.usedMain.Load())
+	//assert.Equal(t, int64(10), cache.usedSmall.Load())
+
+	// remove all main 0 - 99
+	//fmt.Printf("remove all main\n")
 }

--- a/pkg/fileservice/fifocache/ghost.go
+++ b/pkg/fileservice/fifocache/ghost.go
@@ -1,0 +1,90 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fifocache
+
+import (
+	"container/list"
+	"sync"
+)
+
+// ghost implements a thread-safe ghost queue for S3-FIFO
+type ghost[K comparable] struct {
+	mu       sync.RWMutex // Use RWMutex for better read performance
+	capacity int
+	keys     map[K]*list.Element
+	queue    *list.List
+}
+
+func newGhost[K comparable](capacity int) *ghost[K] {
+	return &ghost[K]{
+		capacity: capacity,
+		keys:     make(map[K]*list.Element),
+		queue:    list.New(),
+	}
+}
+
+func (g *ghost[K]) add(key K) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if _, ok := g.keys[key]; ok {
+		// Key already exists, maybe move it to back if needed by specific ghost logic
+		// For simple ghost queue, we might just ignore or update frequency if tracked
+		return
+	}
+
+	// Evict if capacity is reached
+	if g.queue.Len() >= g.capacity {
+		elem := g.queue.Front()
+		if elem != nil {
+			evictedKey := g.queue.Remove(elem).(K)
+			delete(g.keys, evictedKey)
+		}
+	}
+
+	// Add new key
+	elem := g.queue.PushBack(key)
+	g.keys[key] = elem
+}
+
+func (g *ghost[K]) remove(key K) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if elem, ok := g.keys[key]; ok {
+		g.queue.Remove(elem)
+		delete(g.keys, key)
+	}
+}
+
+func (g *ghost[K]) contains(key K) bool {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	_, ok := g.keys[key]
+	return ok
+}
+
+/*
+func (g *ghost[K]) clear() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.queue.Init()
+	for k := range g.keys {
+		delete(g.keys, k)
+	}
+}
+*/

--- a/pkg/fileservice/fifocache/queue.go
+++ b/pkg/fileservice/fifocache/queue.go
@@ -17,9 +17,11 @@ package fifocache
 import "sync"
 
 type Queue[T any] struct {
+	mu       sync.Mutex // Mutex to protect queue operations
 	head     *queuePart[T]
 	tail     *queuePart[T]
 	partPool sync.Pool
+	size     int
 }
 
 type queuePart[T any] struct {
@@ -46,9 +48,9 @@ func NewQueue[T any]() *Queue[T] {
 	return queue
 }
 
+// empty is an internal helper, assumes lock is held
 func (p *Queue[T]) empty() bool {
-	return p.head == p.tail &&
-		p.head.begin == len(p.head.values)
+	return p.head == p.tail && len(p.head.values) == p.head.begin
 }
 
 func (p *queuePart[T]) reset() {
@@ -58,6 +60,9 @@ func (p *queuePart[T]) reset() {
 }
 
 func (p *Queue[T]) enqueue(v T) {
+	p.mu.Lock()         // Acquire lock
+	defer p.mu.Unlock() // Ensure lock is released
+
 	if len(p.head.values) >= maxQueuePartCapacity {
 		// extend
 		newPart := p.partPool.Get().(*queuePart[T])
@@ -66,9 +71,13 @@ func (p *Queue[T]) enqueue(v T) {
 		p.head = newPart
 	}
 	p.head.values = append(p.head.values, v)
+	p.size++
 }
 
 func (p *Queue[T]) dequeue() (ret T, ok bool) {
+	p.mu.Lock()         // Acquire lock
+	defer p.mu.Unlock() // Ensure lock is released
+
 	if p.empty() {
 		return
 	}
@@ -76,17 +85,27 @@ func (p *Queue[T]) dequeue() (ret T, ok bool) {
 	if p.tail.begin >= len(p.tail.values) {
 		// shrink
 		if p.tail.next == nil {
-			panic("impossible")
+			// This should ideally not happen if empty() check passes,
+			// but adding a safeguard.
+			// Consider logging an error here if it does.
+			return
 		}
 		part := p.tail
 		p.tail = p.tail.next
-		p.partPool.Put(part)
+		p.partPool.Put(part) // Return the old part to the pool
 	}
 
 	ret = p.tail.values[p.tail.begin]
 	var zero T
 	p.tail.values[p.tail.begin] = zero
 	p.tail.begin++
+	p.size--
 	ok = true
 	return
+}
+
+func (p *Queue[T]) Len() int {
+	p.mu.Lock()         // Acquire lock
+	defer p.mu.Unlock() // Ensure lock is released
+	return p.size
 }

--- a/pkg/fileservice/fifocache/shardmap.go
+++ b/pkg/fileservice/fifocache/shardmap.go
@@ -1,0 +1,95 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fifocache
+
+import (
+	"sync"
+
+	"golang.org/x/sys/cpu"
+)
+
+const numShards = 256
+
+type ShardMap[K comparable, V any] struct {
+	shards [numShards]struct {
+		sync.RWMutex
+		values map[K]V
+		_      cpu.CacheLinePad
+	}
+	hashfn func(K) uint64
+}
+
+func NewShardMap[K comparable, V any](hashfn func(K) uint64) *ShardMap[K, V] {
+	m := &ShardMap[K, V]{hashfn: hashfn}
+
+	for i := range m.shards {
+		m.shards[i].values = make(map[K]V, 1024)
+	}
+	return m
+}
+
+func (m *ShardMap[K, V]) Set(key K, value V) bool {
+
+	s := &m.shards[m.hashfn(key)%numShards]
+	s.Lock()
+	defer s.Unlock()
+
+	_, ok := s.values[key]
+	if ok {
+		return false
+	}
+
+	s.values[key] = value
+	return true
+}
+
+func (m *ShardMap[K, V]) Get(key K) (V, bool) {
+
+	s := &m.shards[m.hashfn(key)%numShards]
+	s.RLock()
+	defer s.RUnlock()
+	v, ok := s.values[key]
+	return v, ok
+}
+
+func (m *ShardMap[K, V]) Remove(key K) {
+
+	s := &m.shards[m.hashfn(key)%numShards]
+	s.Lock()
+	defer s.Unlock()
+	delete(s.values, key)
+}
+
+func (m *ShardMap[K, V]) CompareAndDelete(key K, fn func(k1, k2 K) bool, postfn func(V)) {
+
+	deleted := make([]V, 0, 64)
+	for i := range m.shards {
+		s := &m.shards[i]
+		func() {
+			s.Lock()
+			defer s.Unlock()
+			for k, v := range s.values {
+				if fn(k, key) {
+					delete(s.values, k)
+					deleted = append(deleted, v)
+				}
+			}
+		}()
+	}
+
+	for _, v := range deleted {
+		postfn(v)
+	}
+}

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 	"io"
 	"io/fs"
 	"iter"
@@ -30,6 +29,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 
 	"go.uber.org/zap"
 
@@ -156,6 +157,7 @@ func (l *LocalFS) initCaches(ctx context.Context, config CacheConfig) error {
 			&config.CacheCallbacks,
 			l.perfCounterSets,
 			l.name,
+			config.DisableS3Fifo,
 		)
 		logutil.Info("fileservice: memory cache initialized",
 			zap.Any("fs-name", l.name),
@@ -177,6 +179,7 @@ func (l *LocalFS) initCaches(ctx context.Context, config CacheConfig) error {
 			true,
 			l,
 			l.name,
+			config.DisableS3Fifo,
 		)
 		if err != nil {
 			return err

--- a/pkg/fileservice/local_fs_test.go
+++ b/pkg/fileservice/local_fs_test.go
@@ -176,12 +176,14 @@ func TestLocalFSWithIOVectorCache(t *testing.T) {
 		fscache.ConstCapacity(1<<20), nil,
 		nil,
 		"",
+		false,
 	)
 	defer memCache1.Close(ctx)
 	memCache2 := NewMemCache(
 		fscache.ConstCapacity(1<<20), nil,
 		nil,
 		"",
+		false,
 	)
 	defer memCache2.Close(ctx)
 	caches := []IOVectorCache{memCache1, memCache2}

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -33,6 +33,7 @@ func NewMemCache(
 	callbacks *CacheCallbacks,
 	counterSets []*perfcounter.CounterSet,
 	name string,
+	disable_s3fifo bool,
 ) *MemCache {
 
 	inuseBytes, capacityBytes := metric.GetFsCacheBytesGauge(name, "mem")
@@ -113,7 +114,7 @@ func NewMemCache(
 		}
 	}
 
-	dataCache := fifocache.NewDataCache(capacityFunc, postSetFn, postGetFn, postEvictFn)
+	dataCache := fifocache.NewDataCache(capacityFunc, postSetFn, postGetFn, postEvictFn, disable_s3fifo)
 
 	ret := &MemCache{
 		cache:       dataCache,

--- a/pkg/fileservice/mem_cache_test.go
+++ b/pkg/fileservice/mem_cache_test.go
@@ -45,7 +45,7 @@ func TestMemCacheLeak(t *testing.T) {
 	assert.Nil(t, err)
 
 	size := int64(128)
-	m := NewMemCache(fscache.ConstCapacity(size), nil, nil, "")
+	m := NewMemCache(fscache.ConstCapacity(size), nil, nil, "", false)
 	defer m.Close(ctx)
 
 	newReadVec := func() *IOVector {
@@ -118,7 +118,7 @@ func TestMemCacheLeak(t *testing.T) {
 // and dataOverlap-checker.
 func TestHighConcurrency(t *testing.T) {
 	ctx := context.Background()
-	m := NewMemCache(fscache.ConstCapacity(2), nil, nil, "")
+	m := NewMemCache(fscache.ConstCapacity(2), nil, nil, "", false)
 	defer m.Close(ctx)
 
 	n := 10
@@ -165,6 +165,7 @@ func BenchmarkMemoryCacheUpdate(b *testing.B) {
 		nil,
 		nil,
 		"",
+		false,
 	)
 	defer cache.Flush(ctx)
 
@@ -199,6 +200,7 @@ func BenchmarkMemoryCacheRead(b *testing.B) {
 		nil,
 		nil,
 		"",
+		false,
 	)
 	defer cache.Flush(ctx)
 
@@ -247,6 +249,7 @@ func TestMemoryCacheGlobalSizeHint(t *testing.T) {
 		nil,
 		nil,
 		"test",
+		false,
 	)
 	defer cache.Close(ctx)
 

--- a/pkg/fileservice/memory_fs_test.go
+++ b/pkg/fileservice/memory_fs_test.go
@@ -62,6 +62,7 @@ func BenchmarkMemoryFSWithMemoryCache(b *testing.B) {
 		nil,
 		nil,
 		"",
+		false,
 	)
 	defer cache.Close(ctx)
 
@@ -85,6 +86,7 @@ func BenchmarkMemoryFSWithMemoryCacheLowCapacity(b *testing.B) {
 	cache := NewMemCache(
 		fscache.ConstCapacity(2*1024*1024), nil, nil,
 		"",
+		false,
 	)
 	defer cache.Close(ctx)
 

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -199,6 +199,7 @@ func (s *S3FS) initCaches(ctx context.Context, config CacheConfig) error {
 			&config.CacheCallbacks,
 			s.perfCounterSets,
 			s.name,
+			config.DisableS3Fifo,
 		)
 		logutil.Info("fileservice: memory cache initialized",
 			zap.Any("fs-name", s.name),
@@ -219,6 +220,7 @@ func (s *S3FS) initCaches(ctx context.Context, config CacheConfig) error {
 			true,
 			s,
 			s.name,
+			config.DisableS3Fifo,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21654 #21589 #15191

## What this PR does / why we need it:

1. add ghost fifo to s3fifo cache as stated in the paper.
2.  clean up shard map to avoid race conditions with items under different locks (shards locks and queue lock).
3. each item has its own mutex to protect postFunc() and its data and improve the concurrency.
4. all queues have their own mutex to improve concurrency.
5. replace VERY SLOW CompareAndSwap() with mutex to protect CacheItem for increment and decrement the frequency.
introduce disable-s3fifo in config.
