### PR TITLE
[Bug]: pub+fulltext index,can not use select * from where match() against()

### DIFF
--- a/pkg/sql/plan/apply_indices_fulltext.go
+++ b/pkg/sql/plan/apply_indices_fulltext.go
@@ -232,11 +232,17 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 	var last_node_id int32
 	var last_ftnode_pkcol *Expr
 
+	srcTblSchema := scanNode.ObjRef.SchemaName
+	if len(scanNode.ObjRef.SubscriptionName) > 0 {
+		srcTblSchema = scanNode.ObjRef.SubscriptionName
+	}
+
 	for i := 0; i < len(ft_filters); i++ {
 		ftidxscan := ft_filters[i]
 		idxdef := indexDefs[i]
-		idxtblname := fmt.Sprintf("`%s`.`%s`", scanNode.ObjRef.SchemaName, idxdef.IndexTableName)
-		srctblname := fmt.Sprintf("`%s`.`%s`", scanNode.ObjRef.SchemaName, scanNode.TableDef.Name)
+
+		idxtblname := fmt.Sprintf("`%s`.`%s`", srcTblSchema, idxdef.IndexTableName)
+		srctblname := fmt.Sprintf("`%s`.`%s`", srcTblSchema, scanNode.TableDef.Name)
 		fn := ftidxscan.GetF()
 		pattern := fn.Args[0].GetLit().GetSval()
 		mode := fn.Args[1].GetLit().GetI64Val()

--- a/pkg/sql/plan/apply_indices_fulltext.go
+++ b/pkg/sql/plan/apply_indices_fulltext.go
@@ -467,6 +467,11 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 	var last_node_id int32
 	var last_ftnode_pkcol *Expr
 
+	srcTblSchema := scanNode.ObjRef.SchemaName
+	if len(scanNode.ObjRef.SubscriptionName) > 0 {
+		srcTblSchema = scanNode.ObjRef.SubscriptionName
+	}
+
 	for i := 0; i < len(ft_filters); i++ {
 		ftidxscan := ft_filters[i]
 		idxdef := indexDefs[i]
@@ -480,8 +485,8 @@ func (builder *QueryBuilder) applyJoinFullTextIndices(nodeID int32, projNode *pl
 				builder.GetContext(), "resolved fulltext index table %q without catalog metadata", idxdef.IndexTableName)
 		}
 
-		idxtblname := sqlquote.QualifiedIdent(idxObjRef.SchemaName, idxObjRef.ObjName)
-		srctblname := sqlquote.QualifiedIdent(scanNode.ObjRef.SchemaName, scanNode.ObjRef.ObjName)
+		idxtblname := sqlquote.QualifiedIdent(srcTblSchema, idxObjRef.ObjName)
+		srctblname := sqlquote.QualifiedIdent(srcTblSchema, scanNode.ObjRef.ObjName)
 		fn := ftidxscan.GetF()
 		params := idxdef.IndexAlgoParams
 		aliasName := fmt.Sprintf("mo_fulltext_alias_%d", i)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20210

## What this PR does / why we need it:

fix the resolve the schema name to subscription name when subscription name is not empty