### PR TITLE
persist merge settings 2.2

### DIFF
--- a/pkg/bootstrap/upgrade.go
+++ b/pkg/bootstrap/upgrade.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions/v2_0_2"
 	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions/v2_0_3"
 	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions/v2_1_0"
+	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions/v2_2_0"
 )
 
 // initUpgrade all versions need create a upgrade handle in pkg/bootstrap/versions
@@ -41,6 +42,7 @@ func (s *service) initUpgrade() {
 	s.handles = append(s.handles, v2_0_2.Handler)
 	s.handles = append(s.handles, v2_0_3.Handler)
 	s.handles = append(s.handles, v2_1_0.Handler)
+	s.handles = append(s.handles, v2_2_0.Handler)
 }
 
 func (s *service) getFinalVersionHandle() VersionHandle {

--- a/pkg/bootstrap/versions/v2_2_0/cluster_upgrade_list.go
+++ b/pkg/bootstrap/versions/v2_2_0/cluster_upgrade_list.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_2_0
+
+import (
+	"fmt"
+
+	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/frontend"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+)
+
+var clusterUpgEntries = []versions.UpgradeEntry{
+	upg_mo_merge_settings_new,
+	upg_mo_merge_settings_init_data,
+}
+
+var upg_mo_merge_settings_new = versions.UpgradeEntry{
+	Schema:    catalog.MO_CATALOG,
+	TableName: catalog.MO_MERGE_SETTINGS,
+	UpgType:   versions.CREATE_NEW_TABLE,
+	UpgSql:    frontend.MoCatalogMergeSettingsDDL,
+	CheckFunc: func(txn executor.TxnExecutor, accountId uint32) (bool, error) {
+		return versions.CheckTableDefinition(txn, accountId, catalog.MO_CATALOG, catalog.MO_MERGE_SETTINGS)
+	},
+}
+
+var upg_mo_merge_settings_init_data = versions.UpgradeEntry{
+	Schema:    catalog.MO_CATALOG,
+	TableName: catalog.MO_MERGE_SETTINGS,
+	UpgType:   versions.CREATE_NEW_TABLE,
+	UpgSql:    frontend.MoCatalogMergeSettingsInitData,
+	CheckFunc: func(txn executor.TxnExecutor, accountId uint32) (bool, error) {
+		sql := fmt.Sprintf("SELECT tid FROM %s.%s limit 1", catalog.MO_CATALOG, catalog.MO_MERGE_SETTINGS)
+		res, err := txn.Exec(sql, executor.StatementOption{}.WithAccountID(accountId))
+		if err != nil {
+			return false, err
+		}
+		defer res.Close()
+		total := 0
+		res.ReadRows(func(rows int, _ []*vector.Vector) bool {
+			total += rows
+			return true
+		})
+		return total > 0, nil
+	},
+}

--- a/pkg/bootstrap/versions/v2_2_0/log.go
+++ b/pkg/bootstrap/versions/v2_2_0/log.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_2_0
+
+import (
+	"github.com/matrixorigin/matrixone/pkg/common/log"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+)
+
+func getLogger(sid string) *log.MOLogger {
+	return runtime.ServiceRuntime(sid).Logger()
+}

--- a/pkg/bootstrap/versions/v2_2_0/tenant_upgrade_list.go
+++ b/pkg/bootstrap/versions/v2_2_0/tenant_upgrade_list.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_2_0
+
+import "github.com/matrixorigin/matrixone/pkg/bootstrap/versions"
+
+var tenantUpgEntries = []versions.UpgradeEntry{}

--- a/pkg/bootstrap/versions/v2_2_0/upgrade.go
+++ b/pkg/bootstrap/versions/v2_2_0/upgrade.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_2_0
+
+import (
+	"context"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+	"go.uber.org/zap"
+)
+
+var (
+	Handler = &versionHandle{
+		metadata: versions.Version{
+			Version:           "2.2.0",
+			MinUpgradeVersion: "2.1.0",
+			UpgradeCluster:    versions.Yes,
+			UpgradeTenant:     versions.Yes,
+			VersionOffset:     uint32(len(clusterUpgEntries) + len(tenantUpgEntries)),
+		},
+	}
+)
+
+type versionHandle struct {
+	metadata versions.Version
+}
+
+func (v *versionHandle) Metadata() versions.Version {
+	return v.metadata
+}
+
+func (v *versionHandle) Prepare(
+	ctx context.Context,
+	txn executor.TxnExecutor,
+	final bool) error {
+	txn.Use(catalog.MO_CATALOG)
+	return nil
+}
+
+func (v *versionHandle) HandleTenantUpgrade(
+	ctx context.Context,
+	tenantID int32,
+	txn executor.TxnExecutor) error {
+
+	// for _, upgEntry := range tenantUpgEntries {
+	// 	start := time.Now()
+
+	// 	err := upgEntry.Upgrade(txn, uint32(tenantID))
+	// 	if err != nil {
+	// 		getLogger(txn.Txn().TxnOptions().CN).Error("tenant upgrade entry execute error", zap.Error(err), zap.Int32("tenantId", tenantID), zap.String("version", v.Metadata().Version), zap.String("upgrade entry", upgEntry.String()))
+	// 		return err
+	// 	}
+
+	// 	duration := time.Since(start)
+	// 	getLogger(txn.Txn().TxnOptions().CN).Info("tenant upgrade entry complete",
+	// 		zap.String("upgrade entry", upgEntry.String()),
+	// 		zap.Int64("time cost(ms)", duration.Milliseconds()),
+	// 		zap.Int32("tenantId", tenantID),
+	// 		zap.String("toVersion", v.Metadata().Version))
+	// }
+
+	return nil
+}
+
+func (v *versionHandle) HandleClusterUpgrade(
+	ctx context.Context,
+	txn executor.TxnExecutor) error {
+	for _, upgEntry := range clusterUpgEntries {
+		start := time.Now()
+
+		err := upgEntry.Upgrade(txn, catalog.System_Account)
+		if err != nil {
+			getLogger(txn.Txn().TxnOptions().CN).Error("cluster upgrade entry execute error", zap.Error(err), zap.String("version", v.Metadata().Version), zap.String("upgrade entry", upgEntry.String()))
+			return err
+		}
+
+		duration := time.Since(start)
+		getLogger(txn.Txn().TxnOptions().CN).Info("cluster upgrade entry complete",
+			zap.String("upgrade entry", upgEntry.String()),
+			zap.Int64("time cost(ms)", duration.Milliseconds()),
+			zap.String("toVersion", v.Metadata().Version))
+	}
+	return nil
+}
+
+func (v *versionHandle) HandleCreateFrameworkDeps(txn executor.TxnExecutor) error {
+	return moerr.NewInternalErrorNoCtxf("Only v1.2.0 can initialize upgrade framework, current version is:%s", Handler.metadata.Version)
+}

--- a/pkg/bootstrap/versions/v2_2_0/upgrade_test.go
+++ b/pkg/bootstrap/versions/v2_2_0/upgrade_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_2_0
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	"github.com/matrixorigin/matrixone/pkg/pb/txn"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
+)
+
+func Test_Upgrade(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			executor := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+				return executor.Result{}, nil
+			}, txnOperator)
+
+			metadata := Handler.Metadata()
+			t.Logf("version metadata:%v", metadata)
+
+			if err := Handler.Prepare(context.Background(), executor, true); err != nil {
+				t.Errorf("Prepare() error = %v", err)
+			}
+
+			if err := Handler.HandleCreateFrameworkDeps(executor); err == nil {
+				t.Errorf("HandleCreateFrameworkDeps() should report err")
+			}
+
+			if err := Handler.HandleClusterUpgrade(context.Background(), executor); err != nil {
+				t.Errorf("HandleClusterUpgrade() error = %v", err)
+			}
+
+			if err := Handler.HandleTenantUpgrade(context.Background(), 0, executor); err != nil {
+				t.Errorf("HandleTenantUpgrade() error = %v", err)
+			}
+		},
+	)
+}
+
+func Test_versionHandle_HandleClusterUpgrade(t *testing.T) {
+	clusterUpgEntries = []versions.UpgradeEntry{}
+
+	v := &versionHandle{
+		metadata: versions.Version{
+			Version: "v2.1.0",
+		},
+	}
+	sid := ""
+	txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+	txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+	executor2 := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+		return executor.Result{}, moerr.NewInvalidInputNoCtx("return error")
+	}, txnOperator)
+
+	err := v.HandleClusterUpgrade(context.Background(),
+		executor2,
+	)
+	assert.Nil(t, err)
+}

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -170,6 +170,8 @@ const (
 	MO_TABLE_STATS = "mo_table_stats_alpha"
 
 	MO_ACCOUNT_LOCK = "__mo_account_lock"
+
+	MO_MERGE_SETTINGS = "mo_merge_settings"
 )
 
 func IsSystemTable(id uint64) bool {

--- a/pkg/frontend/authenticate2.go
+++ b/pkg/frontend/authenticate2.go
@@ -17,6 +17,7 @@ package frontend
 import (
 	"context"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 )
@@ -241,6 +242,21 @@ func hasMoCtrl(p *plan2.Plan) bool {
 							return true
 						}
 					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func isTargetMergeSettings(p *plan2.Plan) bool {
+	if p != nil && p.GetQuery() != nil {
+		q := p.GetQuery()
+		for _, node := range q.Nodes {
+			if node != nil && node.GetTableDef() != nil {
+				d := node.GetTableDef()
+				if d.DbName == catalog.MO_CATALOG && d.Name == catalog.MO_MERGE_SETTINGS {
+					return true
 				}
 			}
 		}

--- a/pkg/frontend/predefined.go
+++ b/pkg/frontend/predefined.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/merge"
 )
 
 var (
@@ -303,6 +304,21 @@ var (
 	MoCatalogMoAccountLockDDL = fmt.Sprintf(`create table mo_catalog.%s(
     			account_name varchar(300) primary key
 				)`, catalog.MO_ACCOUNT_LOCK)
+
+	MoCatalogMergeSettingsDDL = fmt.Sprintf(`create table mo_catalog.%s (
+		account_id int unsigned not null,
+		tid bigint unsigned not null,
+		version int unsigned not null,
+		settings json not null,
+		extra_info text,
+		primary key(account_id, tid)
+	)`, catalog.MO_MERGE_SETTINGS)
+
+	MoCatalogMergeSettingsInitData = fmt.Sprintf(`insert into mo_catalog.%s values (
+		0, 0, %d, '%s', '')`,
+		catalog.MO_MERGE_SETTINGS,
+		merge.MergeSettingsVersion_Curr,
+		merge.DefaultMergeSettings.String())
 )
 
 // `mo_catalog` database system tables

--- a/pkg/pb/api/api.pb.go
+++ b/pkg/pb/api/api.pb.go
@@ -117,6 +117,7 @@ const (
 	AlterKind_UpdatePolicy     AlterKind = 6
 	AlterKind_AddPartition     AlterKind = 7
 	AlterKind_RenameColumn     AlterKind = 8
+	AlterKind_ReplaceDef       AlterKind = 9
 )
 
 var AlterKind_name = map[int32]string{

--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/pb/api"
 	"github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -47,11 +48,17 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 		return convertDBEOB(c.proc.Ctx, err, dbName)
 	}
 
+	accountId, err := defines.GetAccountId(c.proc.Ctx)
+	if err != nil {
+		return err
+	}
+
 	originRel, err := dbSource.Relation(c.proc.Ctx, tblName, nil)
 	if err != nil {
 		return err
 	}
 
+	oldId := originRel.GetTableID(c.proc.Ctx)
 	if c.proc.GetTxnOperator().Txn().IsPessimistic() {
 		var retryErr error
 		// 0. lock origin database metadata in catalog
@@ -187,6 +194,7 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 		return err
 	}
 
+	newId := newRel.GetTableID(c.proc.Ctx)
 	//--------------------------------------------------------------------------------------------------------------
 	// 7. rename temporary replica table into the original table( Table Id remains unchanged)
 	copyTblName := qry.CopyTableDef.Name
@@ -282,6 +290,18 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 				return err
 			}
 		}
+	}
+
+	// update merge settings in mo_catalog.mo_merge_settings
+	err = c.runSqlWithSystemTenant(fmt.Sprintf(updateMoMergeSettings, newId, accountId, oldId))
+	if err != nil {
+		c.proc.Error(c.proc.Ctx, "update mo_catalog.mo_merge_settings for alter table",
+			zap.String("origin tableName", qry.GetTableDef().Name),
+			zap.String("copy table name", qry.CopyTableDef.Name),
+			zap.Uint64("origin table id", oldId),
+			zap.Uint64("copy table id", newId),
+			zap.Error(err))
+		return err
 	}
 	return nil
 }

--- a/pkg/sql/compile/util.go
+++ b/pkg/sql/compile/util.go
@@ -92,6 +92,7 @@ var (
 	updateMoIndexesVisibleFormat                        = `update mo_catalog.mo_indexes set is_visible = %v where table_id = %v and name = '%s';`
 	updateMoIndexesTruncateTableFormat                  = `update mo_catalog.mo_indexes set table_id = %v where table_id = %v`
 	updateMoIndexesAlgoParams                           = `update mo_catalog.mo_indexes set algo_params = '%s' where table_id = %v and name = '%s';`
+	updateMoMergeSettings                               = `update mo_catalog.mo_merge_settings set tid = %v where account_id = %v and tid = %v;`
 )
 
 var (

--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -963,6 +963,7 @@ var (
 		"mo_snapshots":                0,
 		"mo_pitr":                     0,
 		catalog.MO_TABLE_STATS:        0,
+		catalog.MO_MERGE_SETTINGS:     0,
 	}
 )
 

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -77,8 +77,9 @@ func initTaskMetrics() {
 	registry.MustRegister(taskBytesHistogram)
 	registry.MustRegister(taskCountHistogram)
 
-	registry.MustRegister(taskScheduledByCounter)
-	registry.MustRegister(taskGeneratedStuffCounter)
+	registry.MustRegister(taskDNMergeStuffCounter)
+	registry.MustRegister(taskDNMergeDurationHistogram)
+
 	registry.MustRegister(taskSelectivityCounter)
 
 	registry.MustRegister(transferPageHitHistogram)

--- a/pkg/vm/engine/tae/catalog/tableForMerge.go
+++ b/pkg/vm/engine/tae/catalog/tableForMerge.go
@@ -19,6 +19,7 @@ import (
 	"iter"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
@@ -38,6 +39,7 @@ type MergeNotifierOnCatalog interface {
 type CatalogEventSource interface {
 	InitSource() iter.Seq[MergeTable]
 	SetMergeNotifier(MergeNotifierOnCatalog)
+	GetMergeSettingsBatchFn() func() (*batch.Batch, func())
 }
 
 type MergeDataItem interface {

--- a/pkg/vm/engine/tae/db/controller.go
+++ b/pkg/vm/engine/tae/db/controller.go
@@ -690,7 +690,7 @@ func (c *Controller) AssembleDB(ctx context.Context) (err error) {
 
 	db.MergeScheduler = merge.NewMergeScheduler(
 		db.Runtime.Options.CheckpointCfg.ScanInterval,
-		db.Catalog,
+		&merge.TNCatalogEventSource{Catalog: db.Catalog, TxnManager: db.TxnMgr},
 		merge.NewTNMergeExecutor(db.Runtime),
 	)
 	db.MergeScheduler.Start()

--- a/pkg/vm/engine/tae/db/merge/scheduler.go
+++ b/pkg/vm/engine/tae/db/merge/scheduler.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -72,7 +73,7 @@ type MergeScheduler struct {
 	stopped   atomic.Bool
 
 	msgChan chan *MMsg
-	ioChan  chan MMsgVacuumCheck
+	ioChan  chan *MMsg
 
 	pad            *launchPad
 	defaultTrigger *MMsgTaskTrigger
@@ -97,7 +98,7 @@ func NewMergeScheduler(
 
 		stopRecv: make(chan struct{}, 1),
 		msgChan:  make(chan *MMsg, 4096),
-		ioChan:   make(chan MMsgVacuumCheck, 1024),
+		ioChan:   make(chan *MMsg, 256),
 
 		pad:            newLaunchPad(),
 		defaultTrigger: DefaultTrigger.Clone(),
@@ -108,6 +109,14 @@ func NewMergeScheduler(
 	// init priority queue
 	for table := range cata.InitSource() {
 		sched.handleAddTable(table)
+	}
+	if fn := cata.GetMergeSettingsBatchFn(); fn != nil {
+		sched.ioChan <- &MMsg{
+			Kind: MMsgKindConfigBootstrap,
+			Value: MMsgConfigBootstrap{
+				ReadSettingsBatch: fn,
+			},
+		}
 	}
 	cata.SetMergeNotifier(sched)
 
@@ -228,6 +237,9 @@ const (
 	MMsgKindQuery
 	MMsgKindTableChange
 	MMsgKindTrigger
+	MMsgKindConfig
+	MMsgKindVacuumCheck
+	MMsgKindConfigBootstrap
 )
 
 type MMsgSwitch struct {
@@ -248,6 +260,7 @@ type QueryAnswer struct {
 	PendingMergeCnt   int
 	BigDataAcc        int
 	Triggers          string
+	BaseTrigger       string
 
 	NotExists bool
 }
@@ -268,6 +281,15 @@ type MMsgTableChange struct {
 type MMsgVacuumCheck struct {
 	Table catalog.MergeTable
 	opts  *VacuumOpts
+}
+
+type MMsgConfigBootstrap struct {
+	ReadSettingsBatch func() (*batch.Batch, func())
+}
+
+type MMsgConfig struct {
+	ID      uint64
+	Trigger *MMsgTaskTrigger
 }
 
 var DefaultTrigger = &MMsgTaskTrigger{
@@ -512,6 +534,22 @@ func (a *MergeScheduler) SendTrigger(trigger *MMsgTaskTrigger) error {
 	return nil
 }
 
+func (a *MergeScheduler) SendConfig(id uint64, setting *MergeSettings) error {
+	var trigger *MMsgTaskTrigger
+	var err error
+	if setting != nil {
+		trigger, err = setting.ToMMsgTaskTrigger()
+		if err != nil {
+			return err
+		}
+	}
+	a.msgChan <- &MMsg{
+		Kind:  MMsgKindConfig,
+		Value: MMsgConfig{ID: id, Trigger: trigger},
+	}
+	return nil
+}
+
 // region: priority queue
 type todoPQ []*todoItem
 
@@ -561,7 +599,10 @@ type todoSupporter struct {
 	nextDue                time.Duration
 	lastMergeTime          time.Time
 	todo                   *todoItem
-	triggers               []*MMsgTaskTrigger
+	// runtime triggers
+	triggers []*MMsgTaskTrigger
+	// this maybe loaded from config
+	baseTrigger *MMsgTaskTrigger
 }
 
 func (m *todoSupporter) DoneTask() {
@@ -579,6 +620,69 @@ func (m *todoSupporter) NextAfter() time.Time {
 	return time.Now().Add(m.nextDue)
 }
 
+func (a *MergeScheduler) ioVacuumCheck(msg MMsgVacuumCheck) {
+	stats, err := CalculateVacuumStats(context.Background(),
+		msg.Table,
+		msg.opts,
+	)
+	if err != nil {
+		logutil.Warn("MergeExecutorEvent",
+			zap.String("warn", "calculate vacuum stats"),
+			zap.String("table", msg.Table.GetNameDesc()),
+			zap.Error(err),
+		)
+		return
+	}
+
+	compactTasks := GatherCompactTasks(context.Background(), stats)
+	if len(compactTasks) > 0 {
+		a.SendTrigger(
+			NewMMsgTaskTrigger(msg.Table).
+				WithAssignedTasks(compactTasks),
+		)
+	}
+
+	if stats.DelVacuumPercent > 0.5 {
+		oneshotOpts := DefaultTombstoneOpts.Clone().WithOneShot(true)
+		a.SendTrigger(
+			NewMMsgTaskTrigger(msg.Table).
+				WithTombstone(oneshotOpts),
+		)
+	}
+
+	logutil.Info("MergeExecutorEvent",
+		zap.String("event", "vacuum check"),
+		zap.String("table", msg.Table.GetNameDesc()),
+		zap.String("tombstoneVacuum", fmt.Sprintf("%.2g", stats.DelVacuumPercent)),
+		zap.String("dataVacuum", fmt.Sprintf("%.2g", stats.DataVacuumPercent)),
+		zap.Duration("maxAge", stats.MaxCreateAgo.Round(time.Second)),
+		zap.Int("compactThreshold", stats.DataVacuumScoreToCompact),
+		zap.Int("compact", len(compactTasks)),
+	)
+}
+
+func (a *MergeScheduler) ioConfigBootstrap(msg MMsgConfigBootstrap) {
+	bat, release := msg.ReadSettingsBatch()
+	if bat == nil {
+		logutil.Error("MergeExecutorEvent",
+			zap.String("event", "return nil for bootstrap config"),
+		)
+		return
+	}
+	defer release()
+	count := 0
+	DecodeMergeSettingsBatchAnd(bat, func(tid uint64, setting *MergeSettings) {
+		a.SendConfig(tid, setting)
+		count++
+	})
+
+	logutil.Info("MergeExecutorEvent",
+		zap.String("event", "bootstrap config"),
+		zap.Int("batRows", bat.RowCount()),
+		zap.Int("count", count),
+	)
+}
+
 func (a *MergeScheduler) handleIOLoop() {
 	stopCh := *a.stopCh.Load()
 	for {
@@ -586,45 +690,12 @@ func (a *MergeScheduler) handleIOLoop() {
 		case <-stopCh:
 			return
 		case msg := <-a.ioChan:
-
-			stats, err := CalculateVacuumStats(context.Background(),
-				msg.Table,
-				msg.opts,
-			)
-			if err != nil {
-				logutil.Warn("MergeExecutorEvent",
-					zap.String("warn", "calculate vacuum stats"),
-					zap.String("table", msg.Table.GetNameDesc()),
-					zap.Error(err),
-				)
-				continue
+			switch msg.Kind {
+			case MMsgKindVacuumCheck:
+				a.ioVacuumCheck(msg.Value.(MMsgVacuumCheck))
+			case MMsgKindConfigBootstrap:
+				a.ioConfigBootstrap(msg.Value.(MMsgConfigBootstrap))
 			}
-
-			compactTasks := GatherCompactTasks(context.Background(), stats)
-			if len(compactTasks) > 0 {
-				a.SendTrigger(
-					NewMMsgTaskTrigger(msg.Table).
-						WithAssignedTasks(compactTasks),
-				)
-			}
-
-			if stats.DelVacuumPercent > 0.5 {
-				oneshotOpts := DefaultTombstoneOpts.Clone().WithOneShot(true)
-				a.SendTrigger(
-					NewMMsgTaskTrigger(msg.Table).
-						WithTombstone(oneshotOpts),
-				)
-			}
-
-			logutil.Info("MergeExecutorEvent",
-				zap.String("event", "vacuum check"),
-				zap.String("table", msg.Table.GetNameDesc()),
-				zap.String("tombstoneVacuum", fmt.Sprintf("%.2g", stats.DelVacuumPercent)),
-				zap.String("dataVacuum", fmt.Sprintf("%.2g", stats.DataVacuumPercent)),
-				zap.Duration("maxAge", stats.MaxCreateAgo.Round(time.Second)),
-				zap.Int("compactThreshold", stats.DataVacuumScoreToCompact),
-				zap.Int("compact", len(compactTasks)),
-			)
 		}
 	}
 }
@@ -718,6 +789,8 @@ func (a *MergeScheduler) dispatchMsg(msg *MMsg) {
 		a.handleQuery(msg.Value.(MMsgQuery))
 	case MMsgKindTrigger:
 		a.handleTaskTrigger(msg.Value.(*MMsgTaskTrigger))
+	case MMsgKindConfig:
+		a.handleConfig(msg.Value.(MMsgConfig))
 	case MMsgKindTableChange:
 		tableChange := msg.Value.(MMsgTableChange)
 		if tableChange.Create {
@@ -732,9 +805,12 @@ func (a *MergeScheduler) dispatchMsg(msg *MMsg) {
 
 func (a *MergeScheduler) handleTaskTrigger(msg *MMsgTaskTrigger) {
 	if msg.vacuum != nil {
-		a.ioChan <- MMsgVacuumCheck{
-			Table: msg.table,
-			opts:  msg.vacuum,
+		a.ioChan <- &MMsg{
+			Kind: MMsgKindVacuumCheck,
+			Value: MMsgVacuumCheck{
+				Table: msg.table,
+				opts:  msg.vacuum,
+			},
 		}
 	}
 
@@ -751,13 +827,17 @@ func (a *MergeScheduler) handleTaskTrigger(msg *MMsgTaskTrigger) {
 	}
 
 	if !msg.expire.IsZero() {
+		defaultTrigger := a.defaultTrigger
+		if supp.baseTrigger != nil {
+			defaultTrigger = supp.baseTrigger
+		}
 		// this is a policy patch
 		if len(supp.triggers) == 0 {
-			base := a.defaultTrigger.Clone().Merge(msg)
+			base := defaultTrigger.Clone().Merge(msg)
 			supp.triggers = append(supp.triggers, base)
 		} else if supp.triggers[0].expire.IsZero() {
 			// have a disposable trigger to do, put the new trigger in front of it
-			base := a.defaultTrigger.Clone().Merge(msg)
+			base := defaultTrigger.Clone().Merge(msg)
 			supp.triggers = append([]*MMsgTaskTrigger{base}, supp.triggers...)
 		} else {
 			// there is patch already, merge it in place
@@ -826,6 +906,9 @@ func (a *MergeScheduler) handleQuery(msg MMsgQuery) {
 			if len(supp.triggers) > 0 {
 				answer.Triggers = fmt.Sprintf("%v", supp.triggers)
 			}
+			if supp.baseTrigger != nil {
+				answer.BaseTrigger = supp.baseTrigger.String()
+			}
 		} else {
 			answer.NotExists = true
 		}
@@ -843,6 +926,23 @@ func (a *MergeScheduler) handleAddTable(table catalog.MergeTable) {
 		nextDue: a.baseInterval,
 	}
 	heap.Push(&a.pq, todo)
+}
+
+func (a *MergeScheduler) handleConfig(msg MMsgConfig) {
+	supp := a.supps[msg.ID]
+	if supp == nil {
+		return
+	}
+	supp.baseTrigger = msg.Trigger
+	settings := "nil"
+	if msg.Trigger != nil {
+		settings = msg.Trigger.String()
+	}
+	logutil.Info("MergeExecutorEvent",
+		zap.String("event", "set base config"),
+		zap.String("table", supp.todo.table.GetNameDesc()),
+		zap.String("settings", settings),
+	)
 }
 
 func (a *MergeScheduler) handleObjectOps(table catalog.MergeTable) {
@@ -893,6 +993,9 @@ func (a *MergeScheduler) doSched(todo *todoItem) {
 	}
 
 	trigger := a.defaultTrigger
+	if supp.baseTrigger != nil {
+		trigger = supp.baseTrigger
+	}
 	trigger.table = todo.table
 
 	// remove expired triggers
@@ -949,9 +1052,12 @@ func (a *MergeScheduler) doSched(todo *todoItem) {
 
 	// Postprocess tasks: issue new vacuum task or adjust the next due time
 	if supp.bigTaskCnt >= bigDataTaskCntThreshold {
-		a.ioChan <- MMsgVacuumCheck{
-			Table: todo.table,
-			opts:  DefaultVacuumOpts,
+		a.ioChan <- &MMsg{
+			Kind: MMsgKindVacuumCheck,
+			Value: MMsgVacuumCheck{
+				Table: todo.table,
+				opts:  DefaultVacuumOpts,
+			},
 		}
 		supp.bigTaskCnt = supp.bigTaskCnt % bigDataTaskCntThreshold
 	}
@@ -1005,7 +1111,7 @@ func (p *launchPad) Reset() {
 	p.table = nil
 }
 
-var ReleaseDate int64 = 1747559040461945825 //  2025-05-18 17:04:00.461945825 +0800 CST
+var ReleaseDate int64 = 1748412184166943572 //  2025-05-28 14:03:04.166943572 +0800 CST
 
 func (p *launchPad) InitWithTrigger(trigger *MMsgTaskTrigger, lastMergeTime time.Time) {
 	p.table = trigger.table

--- a/pkg/vm/engine/tae/db/merge/settings.go
+++ b/pkg/vm/engine/tae/db/merge/settings.go
@@ -1,0 +1,208 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/docker/go-units"
+	pkgcatalog "github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/tables"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/txn/txnbase"
+	"go.uber.org/zap"
+)
+
+const (
+	MergeSettingsVersion_Curr = 0
+)
+
+var mergeSettingsDecoders = map[uint32]func(bs []byte) (*MergeSettings, error){
+	MergeSettingsVersion_Curr: func(bs []byte) (*MergeSettings, error) {
+		var settings MergeSettings
+		byteJson := types.DecodeJson(bs)
+		normal, err := byteJson.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(normal, &settings); err != nil {
+			return nil, err
+		}
+		if settings.LNMinPointDepthPerCluster == 0 {
+			return nil, moerr.NewInternalErrorNoCtxf("probable corrupted merge settings")
+		}
+		return &settings, nil
+	},
+}
+
+func DecodeMergeSettings(version uint32, bs []byte) (*MergeSettings, error) {
+	decoder, ok := mergeSettingsDecoders[version]
+	if !ok {
+		return nil, moerr.NewInternalErrorNoCtxf("unknown merge settings version: %d", version)
+	}
+	return decoder(bs)
+}
+
+func DecodeMergeSettingsBatchAnd(
+	bat *batch.Batch,
+	fn func(tid uint64, setting *MergeSettings),
+) {
+	// 0 account id
+	// 1 table id
+	// 2 version
+	// 3 settings
+	// 4 extra_info
+	tids := vector.MustFixedColNoTypeCheck[uint64](bat.Vecs[1])
+	versions := vector.MustFixedColNoTypeCheck[uint32](bat.Vecs[2])
+
+	for i, tid := range tids {
+		bs := bat.Vecs[3].GetBytesAt(i)
+		version := versions[i]
+		setting, err := DecodeMergeSettings(version, bs)
+		if err != nil {
+			logutil.Error("MergeExecutorEvent",
+				zap.String("event", "decode settings"),
+				zap.String("table", fmt.Sprintf("%d", tid)),
+				zap.Error(err),
+				zap.String("settings", string(bs)),
+			)
+			continue
+		}
+		fn(tid, setting)
+	}
+}
+
+type MergeSettings struct {
+	VacuumTopK               int    `json:"vacuum-top-k"`
+	VacuumScoreStart         int    `json:"vacuum-score-start"`
+	VacuumScoreEnd           int    `json:"vacuum-score-end"`
+	VacuumScoreDecayDuration string `json:"vacuum-score-decay-duration"`
+
+	L0MaxCountStart         int       `json:"l0-max-count-start"`
+	L0MaxCountEnd           int       `json:"l0-max-count-end"`
+	L0MaxCountDecayDuration string    `json:"l0-max-count-decay-duration"`
+	L0MaxCountDecayControl  []float64 `json:"l0-max-count-decay-control"`
+
+	LNStartLv                 int `json:"ln-start-lv"`
+	LNEndLv                   int `json:"ln-end-lv"`
+	LNMinPointDepthPerCluster int `json:"ln-min-point-depth-per-cluster"`
+
+	TombstoneL1Size  string `json:"tombstone-l1-size"`
+	TombstoneL1Count int    `json:"tombstone-l1-count"`
+	TombstoneL2Count int    `json:"tombstone-l2-count"`
+}
+
+var DefaultMergeSettings = &MergeSettings{
+	VacuumTopK:               DefaultVacuumOpts.HollowTopK,
+	VacuumScoreStart:         DefaultVacuumOpts.StartScore,
+	VacuumScoreEnd:           DefaultVacuumOpts.EndScore,
+	VacuumScoreDecayDuration: DefaultVacuumOpts.Duration.Round(time.Second).String(),
+
+	L0MaxCountStart:         DefaultLayerZeroOpts.Start,
+	L0MaxCountEnd:           DefaultLayerZeroOpts.End,
+	L0MaxCountDecayDuration: DefaultLayerZeroOpts.Duration.Round(time.Second).String(),
+	L0MaxCountDecayControl:  slices.Clone(DefaultLayerZeroOpts.CPoints[:]),
+
+	LNStartLv:                 1,
+	LNEndLv:                   7,
+	LNMinPointDepthPerCluster: DefaultOverlapOpts.MinPointDepthPerCluster,
+
+	TombstoneL1Size:  units.BytesSize(float64(DefaultTombstoneOpts.L1Size)),
+	TombstoneL1Count: DefaultTombstoneOpts.L1Count,
+	TombstoneL2Count: DefaultTombstoneOpts.L2Count,
+}
+
+func (s *MergeSettings) Clone() *MergeSettings {
+	bs, _ := json.Marshal(s)
+	var settings MergeSettings
+	_ = json.Unmarshal(bs, &settings)
+	return &settings
+}
+
+func (s *MergeSettings) String() string {
+	bs, _ := json.Marshal(s)
+	return string(bs)
+}
+
+func (s *MergeSettings) ToMMsgTaskTrigger() (*MMsgTaskTrigger, error) {
+	l0MaxCountDecayDuration, err := time.ParseDuration(s.L0MaxCountDecayDuration)
+	if err != nil {
+		return nil, err
+	}
+	vacuumScoreDecayDuration, err := time.ParseDuration(s.VacuumScoreDecayDuration)
+	if err != nil {
+		return nil, err
+	}
+	tombstoneL1Size, err := units.RAMInBytes(s.TombstoneL1Size)
+	if err != nil {
+		return nil, err
+	}
+	return NewMMsgTaskTrigger(nil).
+		WithL0(NewLayerZeroOpts().WithToleranceDegressionCurve(
+			s.L0MaxCountStart, s.L0MaxCountEnd, l0MaxCountDecayDuration,
+			[4]float64{
+				s.L0MaxCountDecayControl[0],
+				s.L0MaxCountDecayControl[1],
+				s.L0MaxCountDecayControl[2],
+				s.L0MaxCountDecayControl[3],
+			})).
+		WithLn(s.LNStartLv, s.LNEndLv, NewOverlapOptions().
+			WithMinPointDepthPerCluster(s.LNMinPointDepthPerCluster)).
+		WithTombstone(NewTombstoneOpts().
+			WithL1(int(tombstoneL1Size), s.TombstoneL1Count).
+			WithL2Count(s.TombstoneL2Count)).
+		WithVacuumCheck(NewVacuumOpts().
+			WithHollowTopK(s.VacuumTopK).
+			WithStartScore(s.VacuumScoreStart).
+			WithEndScore(s.VacuumScoreEnd).
+			WithDuration(vacuumScoreDecayDuration)), nil
+}
+
+type TNCatalogEventSource struct {
+	*catalog.Catalog
+	*txnbase.TxnManager
+}
+
+func (c *TNCatalogEventSource) GetMergeSettingsBatchFn() func() (*batch.Batch, func()) {
+	db, err := c.GetDatabaseByID(pkgcatalog.MO_CATALOG_ID)
+	if err != nil {
+		return nil
+	}
+	txn := c.OpenOfflineTxn(types.BuildTS(time.Now().UTC().UnixNano(), 0))
+	entry, err := db.GetTableEntryByName(0, pkgcatalog.MO_MERGE_SETTINGS, txn)
+	if err != nil {
+		return nil
+	}
+	return func() (*batch.Batch, func()) {
+		bat := tables.ReadMergeSettingsBatch(context.Background(), entry, txn)
+		if bat == nil {
+			return nil, nil
+		}
+		cnBat := containers.ToCNBatch(bat)
+		return cnBat, func() {
+			bat.Close()
+		}
+	}
+}

--- a/pkg/vm/engine/tae/db/merge/statVacuum.go
+++ b/pkg/vm/engine/tae/db/merge/statVacuum.go
@@ -55,18 +55,18 @@ var (
 
 type TombstoneOpts struct {
 	OneShot bool
-	L1Size  uint32
+	L1Size  int
 	L1Count int
-	L2Size  uint32
+	L2Size  int
 	L2Count int
 }
 
 func (o *TombstoneOpts) String() string {
 	return fmt.Sprintf("TombstoneOpts{OneShot: %t, L1S: %s, L1C: %d, L2S: %s, L2C: %d}",
 		o.OneShot,
-		common.HumanReadableBytes(int(o.L1Size)),
+		common.HumanReadableBytes(o.L1Size),
 		o.L1Count,
-		common.HumanReadableBytes(int(o.L2Size)),
+		common.HumanReadableBytes(o.L2Size),
 		o.L2Count,
 	)
 }
@@ -85,7 +85,7 @@ func NewTombstoneOpts() *TombstoneOpts {
 	return DefaultTombstoneOpts.Clone()
 }
 
-func (o *TombstoneOpts) WithL1(size uint32, count int) *TombstoneOpts {
+func (o *TombstoneOpts) WithL1(size int, count int) *TombstoneOpts {
 	o.L1Size = size
 	o.L1Count = count
 	return o
@@ -121,9 +121,9 @@ func GatherTombstoneTasks(ctx context.Context,
 	small := make([]*objectio.ObjectStats, 0, opts.L1Count)
 	big := make([]*objectio.ObjectStats, 0, opts.L2Count)
 	for stat := range tombstoneStats {
-		if stat.OriginSize() < opts.L1Size {
+		if int(stat.OriginSize()) < opts.L1Size {
 			small = append(small, stat)
-		} else if stat.OriginSize() < opts.L2Size {
+		} else if int(stat.OriginSize()) < opts.L2Size {
 			big = append(big, stat)
 		}
 	}

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -47,6 +47,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/merge"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/rpchandle"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
@@ -335,6 +336,7 @@ func (h *Handle) handleRequests(
 		persistedMemoryInsertRows int
 		inMemoryTombstoneRows     int
 		persistedTombstoneRows    int
+		postFuncs                 []func()
 	)
 
 	if iter = h.newTxnCommitRequestsIter(commitRequests, txnMeta); iter == nil {
@@ -389,7 +391,9 @@ func (h *Handle) handleRequests(
 			}
 
 			var r1, r2, r3, r4 int
-			r1, r2, r3, r4, err = h.HandleWrite(ctx, txn, wr)
+			var postFs []func()
+			r1, r2, r3, r4, postFs, err = h.HandleWrite(ctx, txn, wr)
+			postFuncs = append(postFuncs, postFs...)
 			if err == nil {
 				inMemoryInsertRows += r1
 				persistedMemoryInsertRows += r2
@@ -416,6 +420,21 @@ func (h *Handle) handleRequests(
 			zap.Int("persisted-tombstones", persistedTombstoneRows),
 			zap.String("txn", txn.String()),
 		)
+	}
+	if len(postFuncs) > 0 {
+		if hasDDL {
+			// the target table of merge settings might not put into scheduler yet,
+			// so we need to delay the post func execution
+			time.AfterFunc(5*time.Second, func() {
+				for _, f := range postFuncs {
+					f()
+				}
+			})
+		} else {
+			for _, f := range postFuncs {
+				f()
+			}
+		}
 	}
 	return
 }
@@ -844,6 +863,7 @@ func (h *Handle) HandleWrite(
 	persistedMemoryInsertRows int,
 	inMemoryTombstoneRows int,
 	persistedTombstoneRows int,
+	postFunc []func(),
 	err error,
 ) {
 	defer func() {
@@ -960,6 +980,9 @@ func (h *Handle) HandleWrite(
 		//
 		//}
 		//Appends a batch of data into table.
+		if req.DatabaseId == pkgcatalog.MO_CATALOG_ID && req.TableName == pkgcatalog.MO_MERGE_SETTINGS {
+			postFunc = append(postFunc, parse_merge_settings_set(req.Batch, h.db.MergeScheduler))
+		}
 		err = AppendDataToTable(ctx, tb, req.Batch)
 		return
 	}
@@ -1027,6 +1050,9 @@ func (h *Handle) HandleWrite(
 	}
 	rowIDVec := containers.ToTNVector(req.Batch.GetVector(0), common.WorkspaceAllocator)
 	pkVec := containers.ToTNVector(req.Batch.GetVector(1), common.WorkspaceAllocator)
+	if req.DatabaseId == pkgcatalog.MO_CATALOG_ID && req.TableName == pkgcatalog.MO_MERGE_SETTINGS {
+		postFunc = append(postFunc, parse_merge_settings_unset(pkVec, h.db.MergeScheduler))
+	}
 	inMemoryTombstoneRows += rowIDVec.Length()
 	//defer pkVec.Close()
 	// TODO: debug for #13342, remove me later
@@ -1060,6 +1086,49 @@ func (h *Handle) HandleWrite(
 	//}
 	err = tb.DeleteByPhyAddrKeys(rowIDVec, pkVec, handle.DT_Normal)
 	return
+}
+
+func parse_merge_settings_set(bat *batch.Batch, scheduler *merge.MergeScheduler) func() {
+	settings := make([]*merge.MergeSettings, 0, 1)
+	tids := make([]uint64, 0, 1)
+	merge.DecodeMergeSettingsBatchAnd(bat, func(tid uint64, setting *merge.MergeSettings) {
+		settings = append(settings, setting)
+		tids = append(tids, tid)
+	})
+	return func() {
+		for i, tid := range tids {
+			err := scheduler.SendConfig(tid, settings[i])
+			if err != nil {
+				logutil.Error("MergeExecutorEvent",
+					zap.String("event", "send config"),
+					zap.Uint64("table-id", tid),
+					zap.Error(err),
+					zap.String("settings", settings[i].String()),
+				)
+			}
+		}
+	}
+}
+
+func parse_merge_settings_unset(pkVec containers.Vector, scheduler *merge.MergeScheduler) func() {
+	tids := make([]uint64, 0, 1)
+	for i := 0; i < pkVec.Length(); i++ {
+		bs := pkVec.Get(i).([]byte)
+		tuple, _, _, err := types.DecodeTuple(bs)
+		if err != nil {
+			logutil.Error("MergeExecutorEvent",
+				zap.String("event", "unmarshal settings pk tuple"),
+				zap.Int("idx", i),
+				zap.Error(err),
+			)
+		}
+		tids = append(tids, tuple[1].(uint64))
+	}
+	return func() {
+		for _, tid := range tids {
+			scheduler.SendConfig(tid, nil)
+		}
+	}
 }
 
 func (h *Handle) HandleAlterTable(

--- a/pkg/vm/engine/tae/rpc/inspectMerge.go
+++ b/pkg/vm/engine/tae/rpc/inspectMerge.go
@@ -190,6 +190,9 @@ func (arg *mergeShowArg) Run() error {
 		if len(answer.Triggers) > 0 {
 			out.WriteString(fmt.Sprintf("\n\ttriggers: %s", answer.Triggers))
 		}
+		if len(answer.BaseTrigger) > 0 {
+			out.WriteString(fmt.Sprintf("\n\tbase trigger: %s", answer.BaseTrigger))
+		}
 		// check object distribution
 		// collect all object stats
 		mergeTable := catalog.ToMergeTable(arg.tbl)
@@ -346,7 +349,7 @@ type mergeTriggerArg struct {
 	l0CPoints  []float64
 
 	tombstoneOneShot bool
-	tombstoneL1Size  uint32
+	tombstoneL1Size  int
 	tombstoneL1Count int
 	tombstoneL2Count int
 }
@@ -401,7 +404,7 @@ func (arg *mergeTriggerArg) PrepareCommand() *cobra.Command {
 	cmd.Flags().IntVar(&arg.l0End, "l0-end", merge.DefaultLayerZeroOpts.End, "l0 end count")
 
 	cmd.Flags().BoolVar(&arg.tombstoneOneShot, "tombstone-oneshot", false, "merge all tombstone objects")
-	cmd.Flags().Uint32Var(&arg.tombstoneL1Size, "tombstone-l1-size", merge.DefaultTombstoneOpts.L1Size, "tombstone l1 size")
+	cmd.Flags().IntVar(&arg.tombstoneL1Size, "tombstone-l1-size", merge.DefaultTombstoneOpts.L1Size, "tombstone l1 size")
 	cmd.Flags().IntVar(&arg.tombstoneL1Count, "tombstone-l1-count", merge.DefaultTombstoneOpts.L1Count, "tombstone l1 count")
 	cmd.Flags().IntVar(&arg.tombstoneL2Count, "tombstone-l2-count", merge.DefaultTombstoneOpts.L2Count, "tombstone l2 count")
 

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -444,6 +444,17 @@ func (task *flushTableTailTask) Execute(ctx context.Context) (err error) {
 		zap.Any("extra-info", task))
 	v2.TaskFlushTableTailDurationHistogram.Observe(duration.Seconds())
 
+	if o := task.createdObjHandles; o != nil {
+		v2.TaskDataInputSizeCounter.Add(
+			float64(o.GetMeta().(*catalog.ObjectEntry).OriginSize()),
+		)
+	}
+	if o := task.createdTombstoneHandles; o != nil {
+		v2.TaskTombstoneInputSizeCounter.Add(
+			float64(o.GetMeta().(*catalog.ObjectEntry).OriginSize()),
+		)
+	}
+
 	if time.Since(task.createAt) > SlowFlushTaskOverall {
 		logutil.Info(
 			"[FLUSH-SUMMARY]",

--- a/pkg/vm/engine/tae/tables/table_scan.go
+++ b/pkg/vm/engine/tae/tables/table_scan.go
@@ -20,11 +20,13 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
+	"go.uber.org/zap"
 )
 
 func HybridScanByBlock(
@@ -180,6 +182,40 @@ func ReadSysTableBatch(ctx context.Context, entry *catalog.TableEntry, readTxn t
 			err := HybridScanByBlock(ctx, entry, readTxn, &bat, schema, colIdxes, &blkid, common.CheckpointAllocator)
 			if err != nil || bat == nil || bat.Length() == prevLen {
 				panic(fmt.Sprintf("blkbat is nil, obj %v, blkid %v, err %v", obj.ID().String(), blkOffset, err))
+			}
+		}
+	}
+	if bat != nil {
+		bat.Compact()
+	}
+	return bat
+}
+
+func ReadMergeSettingsBatch(ctx context.Context, entry *catalog.TableEntry, readTxn txnif.AsyncTxn) *containers.Batch {
+	schema := entry.GetLastestSchema(false)
+	it := entry.MakeDataVisibleObjectIt(readTxn)
+	defer it.Release()
+	colIdxes := make([]int, 0, len(schema.ColDefs))
+	for _, col := range schema.ColDefs {
+		if col.IsPhyAddr() {
+			continue
+		}
+		colIdxes = append(colIdxes, col.Idx)
+	}
+	var bat *containers.Batch
+	prevLen := 0
+	for it.Next() {
+		obj := it.Item()
+		for blkOffset := range obj.BlockCnt() {
+			blkid := objectio.NewBlockidWithObjectID(obj.ID(), uint16(blkOffset))
+			err := HybridScanByBlock(ctx, entry, readTxn, &bat, schema, colIdxes, &blkid, common.MergeAllocator)
+			if err != nil || bat == nil || bat.Length() == prevLen {
+				logutil.Error("ReadMergeSettingsBatch",
+					zap.String("event", "read settings empty"),
+					zap.String("obj", obj.ID().String()),
+					zap.Int("blkOffset", blkOffset),
+					zap.Error(err),
+				)
 			}
 		}
 	}

--- a/pkg/vm/engine/tae/tables/txnentries/mergeobjects.go
+++ b/pkg/vm/engine/tae/tables/txnentries/mergeobjects.go
@@ -398,7 +398,11 @@ func (entry *mergeObjectsEntry) collectDelsAndTransfer(
 func (entry *mergeObjectsEntry) PrepareCommit() (err error) {
 	inst := time.Now()
 	defer func() {
-		v2.TaskCommitMergeObjectsDurationHistogram.Observe(time.Since(inst).Seconds())
+		if entry.isTombstone {
+			v2.TaskCommitTombstoneMergeDurationHistogram.Observe(time.Since(inst).Seconds())
+		} else {
+			v2.TaskCommitDataMergeDurationHistogram.Observe(time.Since(inst).Seconds())
+		}
 	}()
 	if len(entry.createdObjs) == 0 || entry.skipTransfer {
 		logutil.Info(

--- a/pkg/vm/engine/tae/txn/txnimpl/table_space.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table_space.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"go.uber.org/zap"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -271,6 +272,11 @@ func (space *tableSpace) prepareApplyObjectStats(stats objectio.ObjectStats) (er
 			&objectio.CreateObjOpt{Stats: &stats, IsTombstone: space.isTombstone})
 		if err != nil {
 			return
+		}
+		if space.isTombstone {
+			v2.TaskTombstoneInputSizeCounter.Add(float64(stats.OriginSize()))
+		} else {
+			v2.TaskDataInputSizeCounter.Add(float64(stats.OriginSize()))
 		}
 	}
 

--- a/test/distributed/cases/disttae/mo_table_stats/mo_table_stats3.result
+++ b/test/distributed/cases/disttae/mo_table_stats/mo_table_stats3.result
@@ -13,6 +13,7 @@ mo_data_key    Tae    Dynamic    1    0    1218    0    0    NULL    0    2024-1
 mo_foreign_keys    Tae    Dynamic    0    0    0    0    0    NULL    0    2024-12-23 17:45:05    NULL    NULL    utf8mb4_bin    NULL            0    moadmin
 mo_indexes    Tae    Dynamic    109    0    5904    0    0    NULL    0    2024-12-23 17:45:05    NULL    NULL    utf8mb4_bin    NULL            0    moadmin
 mo_locks    null    null    null    null    null    null    null    null    null    2024-12-23 17:45:06    null    null    null    null    null    VIEW    0    moadmin
+mo_merge_settings    Tae    Dynamic    0    0    0    0    0    NULL    0    2024-12-23 17:45:06    NULL    NULL    utf8mb4_bin    NULL            0    moadmin
 mo_mysql_compatibility_mode    Tae    Dynamic    4    0    1442    0    0    NULL    0    2024-12-23 17:45:06    NULL    NULL    utf8mb4_bin    NULL            0    moadmin
 mo_pitr    Tae    Dynamic    0    0    0    0    0    NULL    0    2024-12-23 17:45:06    NULL    NULL    utf8mb4_bin    NULL            0    moadmin
 mo_pubs    Tae    Dynamic    0    0    0    0    0    NULL    0    2024-12-23 17:45:06    NULL    NULL    utf8mb4_bin    NULL            0    moadmin

--- a/test/distributed/cases/dml/select/sp_table.result
+++ b/test/distributed/cases/dml/select/sp_table.result
@@ -15,6 +15,7 @@ mo_foreign_keys    r
 mo_increment_columns    
 mo_indexes    r
 mo_locks    v
+mo_merge_settings    r
 mo_mysql_compatibility_mode    r
 mo_pubs    r
 mo_retention    r

--- a/test/distributed/cases/dml/show/database_statistics.result
+++ b/test/distributed/cases/dml/show/database_statistics.result
@@ -9,7 +9,7 @@ Number of tables in mysql
 6
 show table_number from mo_catalog;
 Number of tables in mo_catalog
-36
+37
 show table_number from system;
 Number of tables in system
 6

--- a/test/distributed/cases/dml/show/show.result
+++ b/test/distributed/cases/dml/show/show.result
@@ -235,6 +235,7 @@ mo_database
 mo_foreign_keys
 mo_indexes
 mo_locks
+mo_merge_settings
 mo_mysql_compatibility_mode
 mo_pitr
 mo_pubs
@@ -262,7 +263,7 @@ mo_variables
 mo_version
 show table_number from mo_catalog;
 Number of tables in mo_catalog
-36
+37
 show column_number from mo_database;
 Number of columns in mo_database
 9

--- a/test/distributed/cases/metadata/information_schema.result
+++ b/test/distributed/cases/metadata/information_schema.result
@@ -32,6 +32,7 @@ def    mo_catalog    mo_data_key    BASE TABLE    Tae
 def    mo_catalog    mo_database    BASE TABLE    Tae
 def    mo_catalog    mo_foreign_keys    BASE TABLE    Tae
 def    mo_catalog    mo_indexes    BASE TABLE    Tae
+def    mo_catalog    mo_merge_settings    BASE TABLE    Tae
 def    mo_catalog    mo_mysql_compatibility_mode    BASE TABLE    Tae
 def    mo_catalog    mo_pitr    BASE TABLE    Tae
 def    mo_catalog    mo_pubs    BASE TABLE    Tae

--- a/test/distributed/cases/snapshot/cluster/restore_cluster_table.result
+++ b/test/distributed/cases/snapshot/cluster/restore_cluster_table.result
@@ -416,6 +416,7 @@ mo_database
 mo_foreign_keys
 mo_indexes
 mo_locks
+mo_merge_settings
 mo_mysql_compatibility_mode
 mo_pitr
 mo_pubs
@@ -523,6 +524,7 @@ mo_database
 mo_foreign_keys
 mo_indexes
 mo_locks
+mo_merge_settings
 mo_mysql_compatibility_mode
 mo_pitr
 mo_pubs

--- a/test/distributed/cases/snapshot/cluster_level_snapshot_restore_cluster.result
+++ b/test/distributed/cases/snapshot/cluster_level_snapshot_restore_cluster.result
@@ -451,6 +451,7 @@ mo_database
 mo_foreign_keys
 mo_indexes
 mo_locks
+mo_merge_settings
 mo_mysql_compatibility_mode
 mo_pitr
 mo_pubs
@@ -564,6 +565,7 @@ mo_database
 mo_foreign_keys
 mo_indexes
 mo_locks
+mo_merge_settings
 mo_mysql_compatibility_mode
 mo_pitr
 mo_pubs

--- a/test/distributed/cases/snapshot/snapshotRead.result
+++ b/test/distributed/cases/snapshot/snapshotRead.result
@@ -607,7 +607,7 @@ drop snapshot if exists sp06;
 create snapshot sp06 for account;
 select count(*) from mo_catalog.mo_tables{snapshot = sp06} where reldatabase = 'mo_catalog';
 count(*)
-49
+50
 select * from mo_catalog.mo_database{snapshot = sp06} where datname = 'mo_catalog';
 dat_id    datname    dat_catalog_name    dat_createsql    owner    creator    created_time    account_id    dat_type
 1    mo_catalog    mo_catalog        0    0    2024-12-30 10:46:53    0

--- a/test/distributed/cases/table/system_table_cases.result
+++ b/test/distributed/cases/table/system_table_cases.result
@@ -158,7 +158,7 @@ COUNT(null)
 0
 SELECT COUNT(*) FROM table_constraints;
 COUNT(*)
-109
+112
 USE mo_catalog;
 SHOW CREATE TABLE mo_columns;
 Table    Create Table

--- a/test/distributed/cases/tenant/privilege/create_user_default_role.result
+++ b/test/distributed/cases/tenant/privilege/create_user_default_role.result
@@ -32,6 +32,7 @@ mo_database
 mo_foreign_keys
 mo_indexes
 mo_locks
+mo_merge_settings
 mo_mysql_compatibility_mode
 mo_pitr
 mo_pubs

--- a/test/distributed/cases/tenant/tenant.result
+++ b/test/distributed/cases/tenant/tenant.result
@@ -25,6 +25,7 @@ account_id    relname    relkind
 0    mo_increment_columns    
 0    mo_indexes    r
 0    mo_locks    v
+0    mo_merge_settings    r
 0    mo_mysql_compatibility_mode    r
 0    mo_pitr    r
 0    mo_pubs    r


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/21840

## What this PR does / why we need it:

- Add `mo_merge_settings` to persist merge settings for tables, which is allowed to operate by the sys account.
- Examples:
    -  add new settings for table 293065: `insert into mo_merge_settings  select current_account_id(), 293065, version, json_replace(settings, '$.
"l0-max-count-start"', 20), extra_info from mo_merge_settings where account_id = 0 and tid = 0;`
    - update settings: `update mo_merge_settings set settings = json_replace(settings, '$."l0-max-count-end"', 2) where account_id = 0 and tid = 272519;`
    - restore default settings: `delete from mo_merge_settings where account_id = 0 and tid = 272519;`
- Add metrics about write amplification. During a 2-hour test of TPCC, the average amplification is about 5 under the default settings
<img width="800" alt="image" src="https://github.com/user-attachments/assets/d9c6102c-02b6-4e05-bb74-ece7f37b6731" />

