### PR TITLE
colexec/external: ensure symlink is valid in TestReadDirSymlink

### DIFF
--- a/pkg/sql/colexec/external/external_test.go
+++ b/pkg/sql/colexec/external/external_test.go
@@ -476,6 +476,19 @@ func TestReadDirSymlink(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
+	// sync root dir
+	f, err := os.Open(root)
+	assert.Nil(t, err)
+	err = f.Sync()
+	assert.Nil(t, err)
+	err = f.Close()
+	assert.Nil(t, err)
+
+	// ensure symlink is valid
+	actual, err := filepath.EvalSymlinks(filepath.Join(root, "a", "b", "d"))
+	assert.Nil(t, err)
+	assert.Equal(t, filepath.Join(root, "a", "b", "c"), actual)
+
 	// read a/b/d/foo
 	fooPathInB := filepath.Join(root, "a", "b", "d", "foo")
 	files, _, err := plan2.ReadDir(&tree.ExternParam{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #18855 

## What this PR does / why we need it:
colexec/external: ensure symlink is valid in TestReadDirSymlink