### PR TITLE
to 2.1: fix tombstone object missing after the CN transfer

### DIFF
--- a/pkg/vm/engine/disttae/transfer.go
+++ b/pkg/vm/engine/disttae/transfer.go
@@ -138,6 +138,8 @@ func transferTombstoneObjects(
 				); err != nil {
 					return err
 				}
+
+				tbl.getTxn().StashFlushedTombstones(statsList[i])
 			}
 
 			logs = append(logs,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/21887

## What this PR does / why we need it:
fix tombstone object missing after the CN transfer