### PR TITLE
fix error handling of merge settings 2.2

### DIFF
--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -20,9 +20,6 @@ import (
 	"math"
 	"strings"
 
-	"go.uber.org/zap"
-	"golang.org/x/exp/constraints"
-
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/compress"
@@ -47,6 +44,9 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vectorindex/cache"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
+
+	"go.uber.org/zap"
+	"golang.org/x/exp/constraints"
 )
 
 func (s *Scope) CreateDatabase(c *Compile) error {
@@ -2450,7 +2450,7 @@ func (s *Scope) DropTable(c *Compile) error {
 		return err
 	}
 
-	tblId := qry.GetTableId()
+	tblID := qry.GetTableId()
 	dbSource, err = c.e.Database(c.proc.Ctx, dbName, c.proc.GetTxnOperator())
 	if err != nil {
 		if qry.GetIfExists() {
@@ -2525,7 +2525,7 @@ func (s *Scope) DropTable(c *Compile) error {
 			return err
 		}
 
-		err = s.removeChildTblIdFromParentTable(c, fkRelation, tblId)
+		err = s.removeChildTblIdFromParentTable(c, fkRelation, tblID)
 		if err != nil {
 			return err
 		}
@@ -2540,7 +2540,7 @@ func (s *Scope) DropTable(c *Compile) error {
 		if err != nil {
 			return err
 		}
-		err = s.removeParentTblIdFromChildTable(c, childRelation, tblId)
+		err = s.removeParentTblIdFromChildTable(c, childRelation, tblID)
 		if err != nil {
 			return err
 		}
@@ -2651,7 +2651,10 @@ func (s *Scope) DropTable(c *Compile) error {
 	if dbName == catalog.MO_CATALOG {
 		return nil
 	}
-	deleteRetentionSQL := fmt.Sprintf(deleteMoRetentionWithDatabaseNameAndTableNameFormat, dbName, tblName)
+	deleteRetentionSQL := fmt.Sprintf(
+		deleteMoRetentionWithDatabaseNameAndTableNameFormat,
+		dbName, tblName,
+	)
 	err = c.runSql(deleteRetentionSQL)
 	if moerr.IsMoErrCode(err, moerr.ErrNoSuchTable) {
 		return nil
@@ -2661,19 +2664,20 @@ func (s *Scope) DropTable(c *Compile) error {
 		return err
 	}
 
-	accountId, err := defines.GetAccountId(c.proc.Ctx)
+	accountID, err := defines.GetAccountId(c.proc.Ctx)
 	if err != nil {
 		return err
 	}
 
 	if !needSkipDbs[dbName] {
-		updatePitrSql := fmt.Sprintf("update `%s`.`%s` set `%s` = %d, `%s` = %s where `%s` = %d and `%s` = '%s' and `%s` = '%s' and `%s` = %d and `%s` = %d",
+		updatePitrSql := fmt.Sprintf(
+			"update `%s`.`%s` set `%s` = %d, `%s` = %s where `%s` = %d and `%s` = '%s' and `%s` = '%s' and `%s` = %d and `%s` = %d",
 			catalog.MO_CATALOG, catalog.MO_PITR, catalog.MO_PITR_STATUS, 0, catalog.MO_PITR_CHANGED_TIME, "default",
-			catalog.MO_PITR_ACCOUNT_ID, accountId,
+			catalog.MO_PITR_ACCOUNT_ID, accountID,
 			catalog.MO_PITR_DB_NAME, dbName,
 			catalog.MO_PITR_TABLE_NAME, tblName,
 			catalog.MO_PITR_STATUS, 1,
-			catalog.MO_PITR_OBJECT_ID, tblId,
+			catalog.MO_PITR_OBJECT_ID, tblID,
 		)
 
 		err = c.runSqlWithSystemTenant(updatePitrSql)
@@ -2682,11 +2686,18 @@ func (s *Scope) DropTable(c *Compile) error {
 		}
 	}
 
-	c.runSqlWithSystemTenant(fmt.Sprintf("delete from mo_catalog.mo_merge_settings where account_id = %d and tid = %d", accountId, tblId))
+	sql := fmt.Sprintf(
+		"delete from mo_catalog.mo_merge_settings where account_id = %d and tid = %d",
+		accountID, tblID,
+	)
+	err = c.runSqlWithSystemTenant(sql)
+	if err != nil {
+		return err
+	}
 
 	return partitionservice.GetService(c.proc.GetService()).Delete(
 		c.proc.Ctx,
-		tblId,
+		tblID,
 		c.proc.GetTxnOperator(),
 	)
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/21932

## What this PR does / why we need it:

Return the error to retry


___

### **PR Type**
Bug fix


___

### **Description**
- Fix error handling in `DropTable` to return errors for retries

- Replace ignored error with explicit error check on SQL deletion


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ddl.go</strong><dd><code>Return error on merge settings deletion in DropTable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/ddl.go

<li>Changed <code>DropTable</code> to capture and return errors from <br><code>runSqlWithSystemTenant</code> when deleting from <code>mo_merge_settings</code><br> <li> Ensures that errors trigger retry logic instead of being ignored<br> <li> Added local variable for SQL statement for clarity


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21947/files#diff-819bfdf891fa506cb2b4c89006896d528675fd554c341f38d1a1bf14a496c8aa">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>