### PR TITLE
fix 21952 for 2.2-dev

### DIFF
--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -337,11 +337,7 @@ func MoTableSizeRowsHelper(
 		if dbNull || tblNull {
 			return "", "", false
 		}
-
-		d := functionUtil.QuickBytesToStr(dbBytes)
-		t := functionUtil.QuickBytesToStr(tblBytes)
-
-		return d, t, true
+		return string(dbBytes), string(tblBytes), true
 	}
 
 	defer func() {
@@ -483,8 +479,7 @@ func MoTableRowsOld(ivecs []*vector.Vector, result vector.FunctionResultWrapper,
 			}
 		} else {
 			var rel engine.Relation
-			dbStr := functionUtil.QuickBytesToStr(db)
-			tblStr := functionUtil.QuickBytesToStr(tbl)
+			dbStr, tblStr := string(db), string(tbl)
 
 			if ok, err = specialTableFilterForNonSys(foolCtx, dbStr, tblStr); ok && err == nil {
 				if err = rs.Append(int64(0), false); err != nil {
@@ -582,8 +577,7 @@ func MoTableSizeOld(ivecs []*vector.Vector, result vector.FunctionResultWrapper,
 			}
 		} else {
 			var rel engine.Relation
-			dbStr := functionUtil.QuickBytesToStr(db)
-			tblStr := functionUtil.QuickBytesToStr(tbl)
+			dbStr, tblStr := string(db), string(tbl)
 
 			if ok, err = specialTableFilterForNonSys(foolCtx, dbStr, tblStr); ok && err == nil {
 				if err = rs.Append(int64(0), false); err != nil {
@@ -769,9 +763,7 @@ func moTableColMaxMinImpl(fnName string, parameters []*vector.Vector, result vec
 		if null1 || null2 || null3 {
 			rs.AppendMustNull()
 		} else {
-			dbStr := functionUtil.QuickBytesToStr(db)
-			tableStr := functionUtil.QuickBytesToStr(table)
-			columnStr := functionUtil.QuickBytesToStr(column)
+			dbStr, tableStr, columnStr := string(db), string(table), string(column)
 
 			// Magic code. too confused.
 			if tableStr == "mo_database" || tableStr == "mo_tables" || tableStr == "mo_columns" || tableStr == "sys_async_task" {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21952 #21638 

## What this PR does / why we need it:

fix 21952 for 2.2-dev


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes string conversion for database, table, and column names

- Replaces `QuickBytesToStr` with direct `string()` conversion

- Addresses issue #21952 for correct string handling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>func_mo.go</strong><dd><code>Replace QuickBytesToStr with string() for name conversions</code></dd></summary>
<hr>

pkg/sql/plan/function/func_mo.go

<li>Replaces <code>functionUtil.QuickBytesToStr</code> with direct <code>string()</code> conversion <br>for db, table, and column names<br> <li> Updates multiple helper and main functions to use the new conversion <br>method<br> <li> Ensures proper handling of string values from byte slices<br> <li> Addresses potential bugs in system table filtering and column <br>operations


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21954/files#diff-b553fa8d20dd9d505e58e3272ad74d359a50ce56152e523c8886ef1316b14ed9">+4/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>