### PR TITLE
CI: modify dockerfile (#21935)

### DIFF
--- a/optools/images/Dockerfile
+++ b/optools/images/Dockerfile
@@ -1,15 +1,5 @@
 FROM matrixorigin/golang:1.24-ubuntu22.04 AS builder
 
-
-# Install some utilities used for debugging or by startup script
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    dnsutils \
-    curl \
-    git \
-    cmake \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
 # goproxy
 ARG GOPROXY="https://proxy.golang.org,direct"
 RUN go env -w GOPROXY=${GOPROXY}
@@ -29,26 +19,14 @@ COPY . .
 
 RUN make clean && make build
 
-FROM ubuntu:22.04
-
-# Install some utilities used for debugging or by startup script
-RUN apt-get update && apt-get install -y \
-    dnsutils \
-    curl \
-    git \
-    cmake \
-    libcurl4-openssl-dev libgomp1 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM matrixorigin/ubuntu:22.04
 
 COPY --from=builder /go/src/github.com/matrixorigin/matrixone/mo-service /mo-service
 COPY --from=builder /go/src/github.com/matrixorigin/matrixone/etc /etc
 COPY --from=builder /go/src/github.com/matrixorigin/matrixone/thirdparties/install/lib/*.so /usr/local/lib
 
-
-RUN ldconfig
-
-# Debug purpose - run below command to check shared library not found
-RUN /mo-service -h
+# ldconfig and run mo-service to check if the shared library is found
+RUN ldconfig && /mo-service -h
 
 WORKDIR /
 

--- a/optools/images/README.md
+++ b/optools/images/README.md
@@ -1,0 +1,10 @@
+At present, we have transferred the installation process of the software required during the packaging process and the running process to the packaging of the base image. 
+
+If you want to update some software, please go to the corresponding address to modify it and publish a new base image.
+
+- matrixorigin/golang
+  - Dockerfile: https://github.com/matrixorigin/ci-images/tree/main/golang/ubuntu
+  - Build Workflow: https://github.com/matrixorigin/ci-images/actions/workflows/golang-image.yaml
+- matrixorigin/ubuntu
+  - Dockerfile: https://github.com/matrixorigin/ci-images/tree/main/ubuntu
+  - Build Workflow: https://github.com/matrixorigin/ci-images/actions/workflows/ubuntu-image.yaml

--- a/optools/images/README.md
+++ b/optools/images/README.md
@@ -1,4 +1,6 @@
-At present, we have transferred the installation process of the software required during the packaging process and the running process to the packaging of the base image. 
+At present, we have transferred the installation process of the software required during the packaging process and the running process to the packaging of the base image.
+
+The `matrixorigin/golang` image includes build dependencies (build-essential, git, cmake, etc.), while the `matrixorigin/ubuntu` image contains runtime dependencies (dnsutils, curl, git, cmake, libcurl4-openssl-dev, libgomp1).
 
 If you want to update some software, please go to the corresponding address to modify it and publish a new base image.
 


### PR DESCRIPTION
### **User description**
Sometimes, the network between the runner and the apt software repository is very poor, which will cause packaging failure. We need to package all dependent software into the base image.

Approved by: @XuPeng-SH, @fengttt

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/5495

## What this PR does / why we need it:
Sometimes, the network between the runner and the apt software repository is very poor, which will cause packaging failure. We need to package all dependent software into the base image.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Refactored Dockerfile to use pre-built base images with dependencies
  - Removed in-Dockerfile apt installations for build and runtime
  - Switched to `matrixorigin/golang` and `matrixorigin/ubuntu` base images
  - Combined ldconfig and service check into a single RUN command

- Added README documenting new base image dependency management


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Refactor Dockerfile to use pre-built images and remove apt installs</code></dd></summary>
<hr>

optools/images/Dockerfile

<li>Removed apt-get install steps for build and runtime dependencies<br> <li> Switched to using <code>matrixorigin/golang</code> and <code>matrixorigin/ubuntu</code> images<br> <li> Combined ldconfig and service check into one RUN command<br> <li> Simplified Dockerfile for more reliable builds


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21966/files#diff-ab78a60ede0c02df8bc2df87f932ec9213ed9837b8e2c4921331cc17c1628f3d">+3/-25</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add README for base image dependency management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

optools/images/README.md

<li>Added documentation explaining new base image strategy<br> <li> Provided links to Dockerfiles and build workflows for base images<br> <li> Instructions for updating dependencies via base image rebuilds


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21966/files#diff-f71c0ec26456a827b69998e0f574beb8ebe344c33b89d5462fda0c220b61a927">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>