### PR TITLE
disable runtime filter on fulltext DML temporarily

### DIFF
--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -4430,7 +4430,7 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 		// create sink scan and join with index table JOIN LEFT ON (sink.pkcol = index.docid) and project with (docid, row_id)
 		// see appendDeleteMasterTablePlan
 
-		rfTag := builder.genNewTag()
+		//rfTag := builder.genNewTag()
 		lastNodeId := appendSinkScanNode(builder, bindCtx, delCtx.sourceStep)
 		orgPkColPos, orgPkType := getPkPos(delCtx.tableDef, false)
 
@@ -4458,24 +4458,24 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 			}
 		}
 
-		probeExpr := &plan.Expr{
-			Typ: indexTableDef.Cols[idxDocidPos].Typ,
-			Expr: &plan.Expr_Col{
-				Col: &plan.ColRef{
-					RelPos: 0,
-					ColPos: idxDocidPos,
-					Name:   "doc_id",
-				},
-			},
-		}
+		//probeExpr := &plan.Expr{
+		//	Typ: indexTableDef.Cols[idxDocidPos].Typ,
+		//	Expr: &plan.Expr_Col{
+		//		Col: &plan.ColRef{
+		//			RelPos: 0,
+		//			ColPos: idxDocidPos,
+		//			Name:   "doc_id",
+		//		},
+		//	},
+		//}
 
 		idxScanId := builder.appendNode(&plan.Node{
-			NodeType:               plan.Node_TABLE_SCAN,
-			Stats:                  &plan.Stats{},
-			ObjRef:                 indexObjRef,
-			TableDef:               indexTableDef,
-			ProjectList:            scanNodeProject,
-			RuntimeFilterProbeList: []*plan.RuntimeFilterSpec{MakeRuntimeFilter(rfTag, false, 0, probeExpr)},
+			NodeType:    plan.Node_TABLE_SCAN,
+			Stats:       &plan.Stats{},
+			ObjRef:      indexObjRef,
+			TableDef:    indexTableDef,
+			ProjectList: scanNodeProject,
+			//RuntimeFilterProbeList: []*plan.RuntimeFilterSpec{MakeRuntimeFilter(rfTag, false, 0, probeExpr)},
 		}, bindCtx)
 
 		var leftExpr = &plan.Expr{
@@ -4536,24 +4536,24 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 		},
 		)
 
-		rfBuildExpr := &plan.Expr{
-			Typ: orgPkType,
-			Expr: &plan.Expr_Col{
-				Col: &plan.ColRef{
-					RelPos: 0,
-					ColPos: 0,
-				},
-			},
-		}
+		//rfBuildExpr := &plan.Expr{
+		//	Typ: orgPkType,
+		//	Expr: &plan.Expr_Col{
+		//		Col: &plan.ColRef{
+		//			RelPos: 0,
+		//			ColPos: 0,
+		//		},
+		//	},
+		//}
 
-		sid := builder.compCtx.GetProcess().GetService()
+		//sid := builder.compCtx.GetProcess().GetService()
 		lastNodeId = builder.appendNode(&plan.Node{
-			NodeType:               plan.Node_JOIN,
-			JoinType:               plan.Node_RIGHT,
-			Children:               []int32{idxScanId, lastNodeId},
-			OnList:                 []*Expr{joinCond},
-			ProjectList:            projectList,
-			RuntimeFilterBuildList: []*plan.RuntimeFilterSpec{MakeRuntimeFilter(rfTag, false, GetInFilterCardLimit(sid), rfBuildExpr)},
+			NodeType:    plan.Node_JOIN,
+			JoinType:    plan.Node_RIGHT,
+			Children:    []int32{idxScanId, lastNodeId},
+			OnList:      []*Expr{joinCond},
+			ProjectList: projectList,
+			//RuntimeFilterBuildList: []*plan.RuntimeFilterSpec{MakeRuntimeFilter(rfTag, false, GetInFilterCardLimit(sid), rfBuildExpr)},
 		}, bindCtx)
 
 		deleteIdx := 0

--- a/pkg/sql/plan/opt_misc.go
+++ b/pkg/sql/plan/opt_misc.go
@@ -998,8 +998,6 @@ func (builder *QueryBuilder) forceJoinOnOneCN(nodeID int32, force bool) {
 	node := builder.qry.Nodes[nodeID]
 	if node.NodeType == plan.Node_TABLE_SCAN {
 		node.Stats.ForceOneCN = force
-	} else if node.NodeType == plan.Node_SINK_SCAN {
-		node.Stats.ForceOneCN = true
 	} else if node.NodeType == plan.Node_JOIN {
 		if node.JoinType == plan.Node_DEDUP && !node.Stats.HashmapStats.Shuffle {
 			force = true

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -1861,7 +1861,7 @@ func (builder *QueryBuilder) createQuery() (*Query, error) {
 
 		builder.generateRuntimeFilters(rootID)
 		ReCalcNodeStats(rootID, builder, true, false, false)
-		builder.forceJoinOnOneCN(rootID, i > 0)
+		builder.forceJoinOnOneCN(rootID, false)
 		// after this ,never call ReCalcNodeStats again !!!
 
 		if builder.isForUpdate {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixflow/issues/7204

## What this PR does / why we need it:
to workaround a hung on multi-CN


___

### **PR Type**
Bug fix


___

### **Description**
- Temporarily disable runtime filter for fulltext DML operations

- Comment out runtime filter-related code in `buildDeleteRowsFullTextIndex`

- Adjust join node creation to exclude runtime filter specs

- Update join node forcing logic to avoid unnecessary constraints


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_dml_util.go</strong><dd><code>Disable runtime filter logic in fulltext DML operations</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_dml_util.go

<li>Commented out generation and use of runtime filters in fulltext index <br>DML<br> <li> Removed runtime filter specs from table scan and join nodes<br> <li> Left explanatory comments for disabled code sections


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21976/files#diff-095fb233d51021791cb24454839b013236680bbc6bbc22e0d2f6741ac8fe7dff">+33/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>opt_misc.go</strong><dd><code>Remove forced one-CN for sink scan in join planning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/opt_misc.go

<li>Removed forced one-CN execution for sink scan nodes in join planning<br> <li> Simplified logic for forcing join execution on one CN


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21976/files#diff-2efd240eb857ad87a1ed05754d9d4f908d148b92ace437b07b55e60b9a6b216f">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query_builder.go</strong><dd><code>Adjust join node forcing logic in query builder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/query_builder.go

<li>Changed join node forcing to always use <code>false</code> instead of conditional<br> <li> Ensured join node is not unnecessarily forced to one CN


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21976/files#diff-144e02a38da50867dc021b9254d10a5fd131671cca344c2323337ba2141440f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>