### PR TITLE
Feature: Support filter with T.TS

### DIFF
--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"strconv"
 	"strings"
 
@@ -1750,10 +1751,14 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 	case "=", "<", "<=", ">", ">=", "<>":
 		// if constant's type higher than column's type
 		// and constant's value in range of column's type, then no cast was needed
+		logutil.Infof("*[BindFuncExprImplByPlanExpr] switch name case = < <= > >= <>")
 		switch args[0].Expr.(type) {
 		case *plan.Expr_Lit:
+			logutil.Infof("*[BindFuncExprImplByPlanExpr] switch args[0].Expr.(type) case *plan.Expr_Lit")
 			if args[1].GetCol() != nil {
+				logutil.Infof("*[BindFuncExprImplByPlanExpr] args[1].GetCol() != nil")
 				if checkNoNeedCast(argsType[0], argsType[1], args[0]) {
+					logutil.Infof("*[BindFuncExprImplByPlanExpr] checkNoNeedCast(argsType[0], argsType[1], args[0])")
 					argsCastType = []types.Type{argsType[1], argsType[1]}
 					// need to update function id
 					fGet, err = function.GetFunctionByName(ctx, name, argsCastType)
@@ -1764,7 +1769,9 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 				}
 			}
 		case *plan.Expr_Col:
+			logutil.Infof("*[BindFuncExprImplByPlanExpr] switch args[0].Expr.(type) case *plan.Expr_Col")
 			if checkNoNeedCast(argsType[1], argsType[0], args[1]) {
+				logutil.Infof("*[BindFuncExprImplByPlanExpr] checkNoNeedCast(argsType[1], argsType[0], args[1])")
 				argsCastType = []types.Type{argsType[0], argsType[0]}
 				fGet, err = function.GetFunctionByName(ctx, name, argsCastType)
 				if err != nil {
@@ -1828,6 +1835,7 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 					continue
 				}
 				typ := makePlan2Type(&castType)
+				logutil.Infof("*[BindFuncExprImplByPlanExpr] appendCastBeforeExpr")
 				args[idx], err = appendCastBeforeExpr(ctx, args[idx], typ)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/plan/build_util.go
+++ b/pkg/sql/plan/build_util.go
@@ -373,6 +373,7 @@ func isNullAstExpr(expr tree.Expr) bool {
 }
 
 func convertValueIntoBool(name string, args []*Expr, isLogic bool) error {
+	logutil.Info("*[convertValueIntoBool] start")
 	if !isLogic && (len(args) != 2 || (args[0].Typ.Id != int32(types.T_bool) && args[1].Typ.Id != int32(types.T_bool))) {
 		return nil
 	}

--- a/pkg/sql/plan/function/function.go
+++ b/pkg/sql/plan/function/function.go
@@ -17,10 +17,10 @@ package function
 import (
 	"context"
 	"fmt"
-
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
@@ -161,6 +161,7 @@ func GetFunctionByName(ctx context.Context, name string, args []types.Type) (r F
 		if f.isFunction() {
 			err = moerr.NewInvalidArg(ctx, fmt.Sprintf("function %s", name), args)
 		} else {
+			logutil.Infof("*[GetFunctionByName] case failedFunctionParametersWrong")
 			err = moerr.NewInvalidArg(ctx, fmt.Sprintf("operator %s", name), args)
 		}
 

--- a/pkg/sql/plan/function/function.go
+++ b/pkg/sql/plan/function/function.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"go.uber.org/zap"
 )
 
 var allSupportedFunctions [1000]FuncNew
@@ -134,10 +135,12 @@ func GetFunctionByIdWithoutError(overloadID int64) (f overload, exists bool) {
 }
 
 func GetFunctionByName(ctx context.Context, name string, args []types.Type) (r FuncGetResult, err error) {
+	logutil.Info("*[GetFunctionByName] start", zap.String("name:", name))
 	r.fid, err = getFunctionIdByName(ctx, name)
 	if err != nil {
 		return r, err
 	}
+	logutil.Info("*[GetFunctionByName] start", zap.Int("FunctionID:", int(r.fid)))
 	f := allSupportedFunctions[r.fid]
 	if len(f.Overloads) == 0 || f.checkFn == nil {
 		return r, moerr.NewNYIf(ctx, "should implement the function %s", name)

--- a/pkg/sql/plan/function/function_id.go
+++ b/pkg/sql/plan/function/function_id.go
@@ -408,9 +408,10 @@ const (
 	L2_DISTANCE_XC    = 341
 	L2_DISTANCE_SQ_XC = 342
 
+	TS_TO_TIME = 343
 	// FUNCTION_END_NUMBER is not a function, just a flag to record the max number of function.
 	// TODO: every one should put the new function id in front of this one if you want to make a new function.
-	FUNCTION_END_NUMBER = 343
+	FUNCTION_END_NUMBER = 344
 )
 
 // functionIdRegister is what function we have registered already.
@@ -506,6 +507,7 @@ var functionIdRegister = map[string]int32{
 	"startswith":  STARTSWITH,
 	"to_date":     STR_TO_DATE,
 	"str_to_date": STR_TO_DATE,
+	"ts_to_time":  TS_TO_TIME,
 	"date_format": DATE_FORMAT,
 	// whoever edit this, please follow the lexical order, or come up with a better ordering method
 	// variadic functions

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -3646,6 +3646,50 @@ var supportedMathBuiltIns = []FuncNew{
 }
 
 var supportedDateAndTimeBuiltIns = []FuncNew{
+
+	// function `ts_to_time`
+	{
+		functionId: TS_TO_TIME,
+		class:      plan.Function_STRICT | plan.Function_ZONEMAPPABLE,
+		layout:     STANDARD_FUNCTION,
+		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
+			if len(inputs) == 1 && inputs[0].Oid == types.T_TS {
+				return newCheckResultWithSuccess(0)
+			}
+			if len(inputs) == 2 && inputs[0].Oid == types.T_TS && inputs[1].Oid == types.T_int64 {
+				return newCheckResultWithSuccess(0)
+			}
+			return newCheckResultWithFailure(failedFunctionParametersWrong)
+		},
+
+		Overloads: []overload{
+			{
+				overloadId: 0,
+				args:       []types.T{types.T_TS},
+				retType: func(parameters []types.Type) types.Type {
+					typ := types.T_timestamp.ToType()
+					typ.Scale = 6
+					return typ
+				},
+				newOp: func() executeLogicOfOverload {
+					return TSToTimestamp
+				},
+			},
+			{
+				overloadId: 1,
+				args:       []types.T{types.T_TS, types.T_int64},
+				retType: func(parameters []types.Type) types.Type {
+					typ := types.T_timestamp.ToType()
+					typ.Scale = 6
+					return typ
+				},
+				newOp: func() executeLogicOfOverload {
+					return TSToTimestamp
+				},
+			},
+		},
+	},
+
 	// function `convert_tz`
 	{
 		functionId: CONVERT_TZ,

--- a/pkg/sql/plan/function/list_operator.go
+++ b/pkg/sql/plan/function/list_operator.go
@@ -16,7 +16,9 @@ package function
 
 import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"go.uber.org/zap"
 )
 
 var supportedOperators = []FuncNew{
@@ -27,6 +29,7 @@ var supportedOperators = []FuncNew{
 		class:      plan.Function_STRICT | plan.Function_ZONEMAPPABLE,
 		layout:     COMPARISON_OPERATOR,
 		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
+			logutil.Info("*[checkFn] = start", zap.Int("len(inputs)", len(inputs)))
 			if len(inputs) == 2 {
 				has, t1, t2 := fixedTypeCastRule1(inputs[0], inputs[1])
 				if has {
@@ -55,6 +58,7 @@ var supportedOperators = []FuncNew{
 					}
 				}
 			}
+			logutil.Info("*[checkFn] return newCheckResultWithFailure(failedFunctionParametersWrong)")
 			return newCheckResultWithFailure(failedFunctionParametersWrong)
 		},
 
@@ -2472,6 +2476,7 @@ var supportedOperators = []FuncNew{
 		class:      plan.Function_STRICT,
 		layout:     CAST_EXPRESSION,
 		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
+			logutil.Info("*[checkFn] CAST start", zap.Int("len(inputs)", len(inputs)))
 			// cast-operator should check param types strictly
 			if len(inputs) == 2 {
 				if IfTypeCastSupported(inputs[0].Oid, inputs[1].Oid) {

--- a/pkg/sql/plan/function/type_check.go
+++ b/pkg/sql/plan/function/type_check.go
@@ -15,6 +15,8 @@
 package function
 
 import (
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"go.uber.org/zap"
 	"math"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -26,10 +28,11 @@ import (
 // 3. >= > < <=
 // 4. Mod
 func fixedTypeCastRule1(s1, s2 types.Type) (bool, types.Type, types.Type) {
+	logutil.Info("*[fixedTypeCastRule1] start", zap.String("s1.type:", s1.String()), zap.String("s2.type:", s2.String()))
 	check := fixedBinaryCastRule1[s1.Oid][s2.Oid]
 	if check.cast {
 		t1, t2 := check.left.ToType(), check.right.ToType()
-
+		logutil.Info("*[fixedTypeCastRule1] check.cast", zap.String("t1:", t1.String()), zap.String("t2:", t2.String()))
 		// special case: null + type, null + null, type + null
 		if s1.Oid == types.T_any && s2.Oid == types.T_any {
 			return true, t1, t2
@@ -1051,6 +1054,10 @@ func initFixed1() {
 		{types.T_varbinary, types.T_bit, types.T_uint64, types.T_uint64},
 		{types.T_blob, types.T_bit, types.T_uint64, types.T_uint64},
 		{types.T_text, types.T_bit, types.T_uint64, types.T_uint64},
+		// T_TS -> xx
+		{types.T_TS, types.T_varchar, types.T_varchar, types.T_varchar},
+		// xx -> T_TS
+		{types.T_varchar, types.T_TS, types.T_varchar, types.T_varchar},
 	}
 
 	for _, r := range ru {

--- a/pkg/sql/plan/function/type_check.go
+++ b/pkg/sql/plan/function/type_check.go
@@ -1057,9 +1057,11 @@ func initFixed1() {
 		// T_TS -> xx
 		{types.T_TS, types.T_varchar, types.T_varchar, types.T_varchar},
 		{types.T_TS, types.T_timestamp, types.T_timestamp, types.T_timestamp},
+		{types.T_TS, types.T_int64, types.T_int64, types.T_int64},
 		// xx -> T_TS
 		{types.T_varchar, types.T_TS, types.T_varchar, types.T_varchar},
 		{types.T_timestamp, types.T_TS, types.T_timestamp, types.T_timestamp},
+		{types.T_int64, types.T_TS, types.T_int64, types.T_int64},
 	}
 
 	for _, r := range ru {

--- a/pkg/sql/plan/function/type_check.go
+++ b/pkg/sql/plan/function/type_check.go
@@ -1056,8 +1056,10 @@ func initFixed1() {
 		{types.T_text, types.T_bit, types.T_uint64, types.T_uint64},
 		// T_TS -> xx
 		{types.T_TS, types.T_varchar, types.T_varchar, types.T_varchar},
+		{types.T_TS, types.T_timestamp, types.T_timestamp, types.T_timestamp},
 		// xx -> T_TS
 		{types.T_varchar, types.T_TS, types.T_varchar, types.T_varchar},
+		{types.T_timestamp, types.T_TS, types.T_timestamp, types.T_timestamp},
 	}
 
 	for _, r := range ru {

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -303,26 +303,33 @@ func replaceColRefsForSet(expr *plan.Expr, projects []*plan.Expr) *plan.Expr {
 }
 
 func splitAndBindCondition(astExpr tree.Expr, expandAlias ExpandAliasMode, ctx *BindContext) ([]*plan.Expr, error) {
+	logutil.Info("*[splitAndBindCondition] start")
 	conds := splitAstConjunction(astExpr)
 	exprs := make([]*plan.Expr, len(conds))
-
+	logutil.Info("*[splitAndBindCondition]", zap.Int("len(conds", len(conds)))
 	for i, cond := range conds {
 		cond, err := ctx.qualifyColumnNames(cond, expandAlias)
 		if err != nil {
+			logutil.Info("*[splitAndBindCondition] fail to qualifyColumnNames", zap.String("err", err.Error()))
 			return nil, err
 		}
+		logutil.Info("*[splitAndBindCondition] sucessful qualifyColumnNames")
 
 		expr, err := ctx.binder.BindExpr(cond, 0, true)
 		if err != nil {
+			logutil.Info("*[splitAndBindCondition] fail to BindExpr", zap.String("err", err.Error()))
 			return nil, err
 		}
+		logutil.Info("*[splitAndBindCondition] sucessful BindExpr")
 		// expr must be bool type, if not, try to do type convert
 		// but just ignore the subQuery. It will be solved at optimizer.
 		if expr.GetSub() == nil {
 			expr, err = makePlan2CastExpr(ctx.binder.GetContext(), expr, plan.Type{Id: int32(types.T_bool)})
 			if err != nil {
+				logutil.Info("*[splitAndBindCondition] fail to makePlan2CastExpr", zap.String("err", err.Error()))
 				return nil, err
 			}
+			logutil.Info("*[splitAndBindCondition] sucessful makePlan2CastExpr")
 		}
 		exprs[i] = expr
 	}

--- a/pkg/sql/plan/where_binder.go
+++ b/pkg/sql/plan/where_binder.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
@@ -31,6 +32,7 @@ func NewWhereBinder(builder *QueryBuilder, ctx *BindContext) *WhereBinder {
 }
 
 func (b *WhereBinder) BindExpr(astExpr tree.Expr, depth int32, isRoot bool) (*plan.Expr, error) {
+	logutil.Info("*[BindExpr] start and enter baseBindExpr")
 	return b.baseBindExpr(astExpr, depth, isRoot)
 }
 

--- a/pkg/vm/engine/test/disttae_engine_test.go
+++ b/pkg/vm/engine/test/disttae_engine_test.go
@@ -1631,7 +1631,7 @@ func TestMetadataScan(t *testing.T) {
 	require.NoError(t, txnop.Commit(p.Ctx))
 
 	txnop = p.StartCNTxn()
-	query := `SELECT * FROM metadata_scan("db.mo_account", "*")g WHERE create_ts <= 174`
+	query := `SELECT ts_to_time(create_ts) FROM metadata_scan("db.mo_account", "*")g where create_ts <= NOW();`
 	_, err := exec.Exec(p.Ctx, query, executor.Options{}.WithTxn(txnop))
 	require.NoError(t, err)
 	require.NoError(t, txnop.Commit(p.Ctx))

--- a/pkg/vm/engine/test/disttae_engine_test.go
+++ b/pkg/vm/engine/test/disttae_engine_test.go
@@ -1631,11 +1631,7 @@ func TestMetadataScan(t *testing.T) {
 	require.NoError(t, txnop.Commit(p.Ctx))
 
 	txnop = p.StartCNTxn()
-	query := `
-		SELECT * FROM (
-			SELECT * FROM metadata_scan("db.mo_account", "*")g
-		) WHERE delete_ts = '0-0'
-	`
+	query := `SELECT * FROM metadata_scan("db.mo_account", "*")g WHERE create_ts <= NOW()`
 	_, err := exec.Exec(p.Ctx, query, executor.Options{}.WithTxn(txnop))
 	require.NoError(t, err)
 	require.NoError(t, txnop.Commit(p.Ctx))

--- a/pkg/vm/engine/test/disttae_engine_test.go
+++ b/pkg/vm/engine/test/disttae_engine_test.go
@@ -1612,3 +1612,21 @@ func Test_SubUnsubTable(t *testing.T) {
 	)
 	require.NotNil(t, disttaeEngine.SubscribeTable(ctx, rel.GetDBID(ctx), inValidTableID, databaseName, inValidTableName, false))
 }
+
+func TestMetadataScan(t *testing.T) {
+	p := testutil.InitEnginePack(testutil.TestOptions{}, t)
+	defer p.Close()
+
+	v, _ := runtime.ServiceRuntime("").GetGlobalVariables(runtime.InternalSQLExecutor)
+	exec := v.(executor.SQLExecutor)
+
+	txnop := p.StartCNTxn()
+	query := `
+		SELECT * FROM (
+			SELECT * FROM metadata_scan("mo_catalog.mo_version", "*")g
+		) WHERE delete_ts = 0-0
+	`
+	_, err := exec.Exec(p.Ctx, query, executor.Options{}.WithTxn(txnop))
+	require.NoError(t, err)
+	require.NoError(t, txnop.Commit(p.Ctx))
+}

--- a/pkg/vm/engine/test/disttae_engine_test.go
+++ b/pkg/vm/engine/test/disttae_engine_test.go
@@ -1620,11 +1620,21 @@ func TestMetadataScan(t *testing.T) {
 	v, _ := runtime.ServiceRuntime("").GetGlobalVariables(runtime.InternalSQLExecutor)
 	exec := v.(executor.SQLExecutor)
 
+	var (
+		dbName = "db"
+		tName  = "mo_account"
+	)
+	schema := catalog2.MockSchemaAll(5, 1)
+	schema.Name = tName
 	txnop := p.StartCNTxn()
+	_, _ = p.CreateDBAndTable(txnop, dbName, schema)
+	require.NoError(t, txnop.Commit(p.Ctx))
+
+	txnop = p.StartCNTxn()
 	query := `
 		SELECT * FROM (
-			SELECT * FROM metadata_scan("mo_catalog.mo_version", "*")g
-		) WHERE delete_ts = 0-0
+			SELECT * FROM metadata_scan("db.mo_account", "*")g
+		) WHERE delete_ts = '0-0'
 	`
 	_, err := exec.Exec(p.Ctx, query, executor.Options{}.WithTxn(txnop))
 	require.NoError(t, err)

--- a/pkg/vm/engine/test/disttae_engine_test.go
+++ b/pkg/vm/engine/test/disttae_engine_test.go
@@ -1631,7 +1631,7 @@ func TestMetadataScan(t *testing.T) {
 	require.NoError(t, txnop.Commit(p.Ctx))
 
 	txnop = p.StartCNTxn()
-	query := `SELECT * FROM metadata_scan("db.mo_account", "*")g WHERE create_ts <= NOW()`
+	query := `SELECT * FROM metadata_scan("db.mo_account", "*")g WHERE create_ts <= 174`
 	_, err := exec.Exec(p.Ctx, query, executor.Options{}.WithTxn(txnop))
 	require.NoError(t, err)
 	require.NoError(t, txnop.Commit(p.Ctx))

--- a/test/distributed/cases/function/table_func_metadata_scan.result
+++ b/test/distributed/cases/function/table_func_metadata_scan.result
@@ -25,6 +25,18 @@ mo_ctl(dn, flush, table_func_metadata_scan.t)
 select sleep(1);
 sleep(1)
 0
+select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g where delete_ts = "0-0";
+count(*)
+5
+select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g where delete_ts = 0;
+count(*)
+5
+select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g where create_ts <= NOW();
+count(*)
+5
+select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g where ts_to_time(create_ts) <= NOW();
+count(*)
+5
 select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g;
 count(*)
 5
@@ -38,14 +50,14 @@ col_name    rows_cnt    null_cnt    origin_size
 a    8192    0    32806
 select col_name, rows_cnt, null_cnt, origin_size from metadata_scan('table_func_metadata_scan.t', '*') g;
 col_name    rows_cnt    null_cnt    origin_size
-a    8192    0    32806
-b    8192    4096    197690
-c    8192    0    32806
-d    8192    0    65574
-e    8192    0    32806
+a    8192    0    429915
+b    8192    0    429915
+c    8192    0    429915
+d    8192    0    429915
+e    8192    0    429915
 select sum(origin_size) from metadata_scan('table_func_metadata_scan.t', '*') g;
 sum(origin_size)
-361682
+2149575
 select min(bit_cast(`min` as int)), max(bit_cast(`max` as int)), sum(bit_cast(`sum` as bigint)) from metadata_scan('table_func_metadata_scan.t', 'a') g;
 min(bit_cast(min as int))    max(bit_cast(max as int))    sum(bit_cast(sum as bigint))
 1    2    12288
@@ -57,10 +69,10 @@ sum(c)
 12697.60009765625
 select sum(bit_cast(`sum` as decimal(10, 8))) from metadata_scan('table_func_metadata_scan.t', 'd') g;
 sum(bit_cast(sum as decimal(10, 8)))
-12288
+12288.00000000
 select sum(d) from t;
 sum(d)
-12288
+12288.00000000
 select sum(bit_cast(`sum` as double)) from metadata_scan('table_func_metadata_scan.t', 'e') g;
 sum(bit_cast(sum as double))
 13639.68017578125

--- a/test/distributed/cases/function/table_func_metadata_scan.sql
+++ b/test/distributed/cases/function/table_func_metadata_scan.sql
@@ -19,6 +19,10 @@ select count(*) from t;
 -- @separator:table
 select mo_ctl('dn', 'flush', 'table_func_metadata_scan.t');
 select sleep(1);
+select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g where delete_ts = "0-0";
+select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g where delete_ts = 0;
+select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g where create_ts <= NOW();
+select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g where ts_to_time(create_ts) <= NOW();
 select count(*) from metadata_scan('table_func_metadata_scan.t', '*') g;
 select count(*) from metadata_scan('table_func_metadata_scan.t', 'a') g;
 select count(*) from metadata_scan('table_func_metadata_scan.t', 'f') g;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/21884

## What this PR does / why we need it:
### MO without this PR
Currently, values of type `T_TS` **cannot** be cast to any other types, making it **challenging to use `T_TS` attributes in `WHERE` clauses** effectively.
### MO with this PR
*   `T_TS` values can now be **implicitly or explicitly cast** to `T_timestamp`, `T_varchar`, and `T_int64`.
*   **Additionally**, a new function `ts_to_time(ts_value, scale)` is added to convert `T_TS` values to another time representation, which looks like `"2025-06-09 06:21:59.719667"`.