### PR TITLE
Pick delete hung fix to 2.1 

### DIFF
--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -4431,7 +4431,7 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 		// create sink scan and join with index table JOIN LEFT ON (sink.pkcol = index.docid) and project with (docid, row_id)
 		// see appendDeleteMasterTablePlan
 
-		rfTag := builder.genNewTag()
+		//rfTag := builder.genNewTag()
 		lastNodeId := appendSinkScanNode(builder, bindCtx, delCtx.sourceStep)
 		orgPkColPos, orgPkType := getPkPos(delCtx.tableDef, false)
 
@@ -4459,24 +4459,24 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 			}
 		}
 
-		probeExpr := &plan.Expr{
-			Typ: indexTableDef.Cols[idxDocidPos].Typ,
-			Expr: &plan.Expr_Col{
-				Col: &plan.ColRef{
-					RelPos: 0,
-					ColPos: idxDocidPos,
-					Name:   "doc_id",
-				},
-			},
-		}
+		//probeExpr := &plan.Expr{
+		//	Typ: indexTableDef.Cols[idxDocidPos].Typ,
+		//	Expr: &plan.Expr_Col{
+		//		Col: &plan.ColRef{
+		//			RelPos: 0,
+		//			ColPos: idxDocidPos,
+		//			Name:   "doc_id",
+		//		},
+		//	},
+		//}
 
 		idxScanId := builder.appendNode(&plan.Node{
-			NodeType:               plan.Node_TABLE_SCAN,
-			Stats:                  &plan.Stats{},
-			ObjRef:                 indexObjRef,
-			TableDef:               indexTableDef,
-			ProjectList:            scanNodeProject,
-			RuntimeFilterProbeList: []*plan.RuntimeFilterSpec{MakeRuntimeFilter(rfTag, false, 0, probeExpr)},
+			NodeType:    plan.Node_TABLE_SCAN,
+			Stats:       &plan.Stats{},
+			ObjRef:      indexObjRef,
+			TableDef:    indexTableDef,
+			ProjectList: scanNodeProject,
+			//RuntimeFilterProbeList: []*plan.RuntimeFilterSpec{MakeRuntimeFilter(rfTag, false, 0, probeExpr)},
 		}, bindCtx)
 
 		var leftExpr = &plan.Expr{
@@ -4537,24 +4537,24 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 		},
 		)
 
-		rfBuildExpr := &plan.Expr{
-			Typ: orgPkType,
-			Expr: &plan.Expr_Col{
-				Col: &plan.ColRef{
-					RelPos: 0,
-					ColPos: 0,
-				},
-			},
-		}
+		//rfBuildExpr := &plan.Expr{
+		//	Typ: orgPkType,
+		//	Expr: &plan.Expr_Col{
+		//		Col: &plan.ColRef{
+		//			RelPos: 0,
+		//			ColPos: 0,
+		//		},
+		//	},
+		//}
 
-		sid := builder.compCtx.GetProcess().GetService()
+		//sid := builder.compCtx.GetProcess().GetService()
 		lastNodeId = builder.appendNode(&plan.Node{
-			NodeType:               plan.Node_JOIN,
-			JoinType:               plan.Node_RIGHT,
-			Children:               []int32{idxScanId, lastNodeId},
-			OnList:                 []*Expr{joinCond},
-			ProjectList:            projectList,
-			RuntimeFilterBuildList: []*plan.RuntimeFilterSpec{MakeRuntimeFilter(rfTag, false, GetInFilterCardLimit(sid), rfBuildExpr)},
+			NodeType:    plan.Node_JOIN,
+			JoinType:    plan.Node_RIGHT,
+			Children:    []int32{idxScanId, lastNodeId},
+			OnList:      []*Expr{joinCond},
+			ProjectList: projectList,
+			//RuntimeFilterBuildList: []*plan.RuntimeFilterSpec{MakeRuntimeFilter(rfTag, false, GetInFilterCardLimit(sid), rfBuildExpr)},
 		}, bindCtx)
 
 		deleteIdx := 0


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixflow/issues/7204

## What this PR does / why we need it:

fix https://github.com/matrixorigin/matrixflow/issues/7204


___

### **PR Type**
Bug fix


___

### **Description**
- Temporarily disable runtime filters in fulltext index delete DML.

- Workaround for multi-CN hang issue (#5330).

- Comment out code related to runtime filter generation and usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_dml_util.go</strong><dd><code>Disable runtime filters in fulltext index delete DML</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_dml_util.go

<li>Commented out all code related to runtime filter generation and usage <br>in the fulltext index delete path.<br> <li> Disabled runtime filter probe and build lists in relevant plan nodes.<br> <li> Added comments to clarify temporary nature of the workaround.


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/21998/files#diff-095fb233d51021791cb24454839b013236680bbc6bbc22e0d2f6741ac8fe7dff">+33/-33</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>