### PR TITLE
fix lock hung and remove big log lock

### DIFF
--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -445,7 +445,6 @@ func (l *lockTableAllocator) tryRebindLocked(
 			zap.String("service", binds.serviceID),
 			zap.Int64("old timestamp", oldTimestamp),
 			zap.Int64("new timestamp", newTimestamp))
-		return old
 	}
 	// find a valid table and service bind
 	if old.Valid {

--- a/pkg/lockservice/lock_table_allocator_test.go
+++ b/pkg/lockservice/lock_table_allocator_test.go
@@ -336,9 +336,9 @@ func TestTryRebindLocked(t *testing.T) {
 			}
 			binds := a.registerService(newServiceID)
 			result := a.tryRebindLocked(binds, 0, old, 1)
-			assert.False(t, result.Valid)
-			assert.Equal(t, oldServiceID, result.ServiceID)
-			assert.Equal(t, uint64(1), result.Version)
+			assert.True(t, result.Valid)
+			assert.Equal(t, newServiceID, result.ServiceID)
+			assert.Equal(t, uint64(2), result.Version)
 
 			// Test case 2: Old binding is still valid
 			old = pb.LockTable{

--- a/pkg/lockservice/lock_table_keeper.go
+++ b/pkg/lockservice/lock_table_keeper.go
@@ -225,17 +225,18 @@ func (k *lockTableKeeper) doKeepLockTableBind(ctx context.Context) {
 	}
 
 	n := 0
-	newVersion := k.groupTables.getVersion()
-	if oldVersion == newVersion {
-		k.groupTables.removeWithFilter(func(_ uint64, v lockTable) bool {
-			bind := v.getBind()
-			if bind.ServiceID == k.serviceID {
-				n++
-				return true
-			}
+	k.groupTables.removeWithFilter(func(_ uint64, v lockTable) bool {
+		newVersion := k.groupTables.getVersion()
+		if oldVersion != newVersion {
 			return false
-		})
-	}
+		}
+		bind := v.getBind()
+		if bind.ServiceID == k.serviceID {
+			n++
+			return true
+		}
+		return false
+	})
 
 	if n > 0 {
 		// Keep bind receiving an explicit failure means that all the binds of the local

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -747,6 +747,7 @@ func canRetryLock(table uint64, txn client.TxnOperator, err error) bool {
 	}
 	if moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged) ||
 		moerr.IsMoErrCode(err, moerr.ErrLockTableNotFound) {
+		time.Sleep(defaultWaitTimeOnRetryLock)
 		return true
 	}
 	if moerr.IsMoErrCode(err, moerr.ErrBackendClosed) ||


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22017 #https://github.com/matrixorigin/MO-Cloud/issues/5741

## What this PR does / why we need it:

fix lock hung and remove big log lock


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
• Fix lock hung issue in lock table keeper
• Remove excessive logging for large row sets
• Add retry delay for lock table bind errors
• Improve lock table allocator return logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lock_table_allocator.go</strong><dd><code>Fix return logic in lock table allocator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/lock_table_allocator.go

• Remove unnecessary return statement in <code>tryRebindLocked</code> method<br> • Fix <br>control flow after updating bind with newer service version


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22030/files#diff-6be1ca324d0b56411e41ec19a99ea21442f80563429ee4964aedef60424413a1">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lock_table_keeper.go</strong><dd><code>Fix lock hung in table keeper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/lock_table_keeper.go

• Move version check inside the filter function<br> • Fix potential race <br>condition in <code>doKeepLockTableBind</code><br> • Restructure lock table removal <br>logic


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22030/files#diff-5af69981988fb4d1a3a415cdfa9239b01aa00ae7323ff5a5e36fb9e253fde9c1">+11/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>log.go</strong><dd><code>Limit excessive logging for large row sets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/log.go

• Add <code>maxLogRowCnt</code> constant to limit logged rows to 100<br> • Truncate <br>large row arrays in <code>logLocalLockFailed</code> and <code>logRemoteLockFailed</code><br> • Add <br>row count field to log entries for better debugging


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22030/files#diff-810cd800b6dec0afe01c14f8f4cab0c5753d28d30ea19970d17dfdd81906fa1d">+14/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lock_op.go</strong><dd><code>Add retry delay for lock errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/lockop/lock_op.go

• Add sleep delay for <code>ErrLockTableBindChanged</code> and <code>ErrLockTableNotFound</code> <br>errors<br> • Improve retry behavior in <code>canRetryLock</code> function


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22030/files#diff-72fd177a79db26bc21d48eba216ec1690f1377a9a3430a3da15e293d7690b37a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>