### PR TITLE
optimize cdc table detector

### DIFF
--- a/pkg/cdc/sql_builder.go
+++ b/pkg/cdc/sql_builder.go
@@ -189,7 +189,8 @@ const (
 		" account_id " +
 		"FROM `mo_catalog`.`mo_tables` " +
 		"WHERE " +
-		" relkind = '%s' " +
+		" account_id IN (%s) " +
+		" AND relkind = '%s' " +
 		" AND reldatabase NOT IN (%s)"
 )
 
@@ -294,11 +295,7 @@ var CDCSQLTemplates = [CDCSqlTemplateCount]struct {
 		OutputAttrs: []string{"encrypted_key"},
 	},
 	CDCCollectTableInfoSqlTemplate_Idx: {
-		SQL: fmt.Sprintf(
-			CDCCollectTableInfoSqlTemplate,
-			catalog.SystemOrdinaryRel,
-			AddSingleQuotesJoin(catalog.SystemDatabases),
-		),
+		SQL: CDCCollectTableInfoSqlTemplate,
 		OutputAttrs: []string{
 			"rel_id",
 			"relname",
@@ -589,6 +586,11 @@ func (b cdcSQLBuilder) UpdateWatermarkSQL(
 // ------------------------------------------------------------------------------------------------
 // Table Info SQL
 // ------------------------------------------------------------------------------------------------
-func (b cdcSQLBuilder) CollectTableInfoSQL() string {
-	return CDCSQLTemplates[CDCCollectTableInfoSqlTemplate_Idx].SQL
+func (b cdcSQLBuilder) CollectTableInfoSQL(account_ids string) string {
+	return fmt.Sprintf(
+		CDCSQLTemplates[CDCCollectTableInfoSqlTemplate_Idx].SQL,
+		account_ids,
+		catalog.SystemOrdinaryRel,
+		AddSingleQuotesJoin(catalog.SystemDatabases),
+	)
 }

--- a/pkg/cdc/table_scanner.go
+++ b/pkg/cdc/table_scanner.go
@@ -138,8 +138,13 @@ func (s *TableDetector) scanTable() {
 	defer cancel()
 	var accountIds string
 	s.Lock()
+	var i int
 	for accountId := range s.subscribedAccountIds {
-		accountIds += fmt.Sprintf("%d,", accountId)
+		if i != 0 {
+			accountIds += ","
+		}
+		accountIds += fmt.Sprintf("%d", accountId)
+		i++
 	}
 	s.Unlock()
 

--- a/pkg/cdc/table_scanner.go
+++ b/pkg/cdc/table_scanner.go
@@ -153,8 +153,16 @@ func (s *TableDetector) scanTableLoop(ctx context.Context) {
 func (s *TableDetector) scanTable() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	var accountIds string
+	var (
+		accountIds string
+		mp         = make(map[uint32]TblMap)
+	)
 	s.Lock()
+	if len(s.SubscribedAccountIds) == 0 {
+		s.Mp = mp
+		s.Unlock()
+		return nil
+	}
 	var i int
 	for accountId := range s.SubscribedAccountIds {
 		if i != 0 {
@@ -175,7 +183,6 @@ func (s *TableDetector) scanTable() error {
 	}
 	defer result.Close()
 
-	mp := make(map[uint32]TblMap)
 	result.ReadRows(func(rows int, cols []*vector.Vector) bool {
 		for i := 0; i < rows; i++ {
 			tblId := vector.MustFixedColWithTypeCheck[uint64](cols[0])[i]

--- a/pkg/cdc/table_scanner_test.go
+++ b/pkg/cdc/table_scanner_test.go
@@ -61,7 +61,7 @@ func TestTableScanner(t *testing.T) {
 		Mp:                   make(map[uint32]TblMap),
 		Callbacks:            make(map[string]func(map[uint32]TblMap)),
 		CallBackAccountId:    make(map[string]uint32),
-		SubscribedAccountIds: make(map[uint32]bool),
+		SubscribedAccountIds: make(map[uint32][]string),
 		exec:                 mockSqlExecutor,
 	}
 

--- a/pkg/cdc/table_scanner_test.go
+++ b/pkg/cdc/table_scanner_test.go
@@ -58,8 +58,8 @@ func TestTableScanner(t *testing.T) {
 		Mutex:                sync.Mutex{},
 		Mp:                   make(map[uint32]TblMap),
 		Callbacks:            make(map[string]func(map[uint32]TblMap)),
-		callBackAccountId:    make(map[string]uint32),
-		subscribedAccountIds: make(map[uint32]bool),
+		CallBackAccountId:    make(map[string]uint32),
+		SubscribedAccountIds: make(map[uint32]bool),
 		exec:                 mockSqlExecutor,
 	}
 
@@ -67,21 +67,21 @@ func TestTableScanner(t *testing.T) {
 	assert.Equal(t, 1, len(detector.Callbacks))
 	detector.Register("id2", 2, func(mp map[uint32]TblMap) {})
 	assert.Equal(t, 2, len(detector.Callbacks))
-	assert.Equal(t, 2, len(detector.subscribedAccountIds))
+	assert.Equal(t, 2, len(detector.SubscribedAccountIds))
 
 	detector.Register("id3", 1, func(mp map[uint32]TblMap) {})
 	assert.Equal(t, 3, len(detector.Callbacks))
-	assert.Equal(t, 2, len(detector.subscribedAccountIds))
+	assert.Equal(t, 2, len(detector.SubscribedAccountIds))
 
 	detector.UnRegister("id1")
 	assert.Equal(t, 2, len(detector.Callbacks))
-	assert.Equal(t, 2, len(detector.subscribedAccountIds))
+	assert.Equal(t, 2, len(detector.SubscribedAccountIds))
 
 	detector.UnRegister("id2")
 	assert.Equal(t, 1, len(detector.Callbacks))
-	assert.Equal(t, 1, len(detector.subscribedAccountIds))
+	assert.Equal(t, 1, len(detector.SubscribedAccountIds))
 
 	detector.UnRegister("id3")
 	assert.Equal(t, 0, len(detector.Callbacks))
-	assert.Equal(t, 0, len(detector.subscribedAccountIds))
+	assert.Equal(t, 0, len(detector.SubscribedAccountIds))
 }

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -209,7 +209,7 @@ func (exec *CDCTaskExecutor) Start(rootCtx context.Context) (err error) {
 	go exec.watermarkUpdater.Run(ctx, exec.activeRoutine)
 
 	// register to table scanner
-	cdc.GetTableDetector(cnUUID).Register(taskId, exec.handleNewTables)
+	cdc.GetTableDetector(cnUUID).Register(taskId, accountId, exec.handleNewTables)
 
 	exec.isRunning = true
 	logutil.Infof("cdc task %s start on cn %s success", taskName, cnUUID)

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -1004,7 +1004,7 @@ func TestRegisterCdcExecutor(t *testing.T) {
 			Mp:                   make(map[uint32]cdc.TblMap),
 			Callbacks:            map[string]func(map[uint32]cdc.TblMap){"id": func(mp map[uint32]cdc.TblMap) {}},
 			CallBackAccountId:    map[string]uint32{"id": 0},
-			SubscribedAccountIds: map[uint32]bool{0: true},
+			SubscribedAccountIds: map[uint32][]string{0: {"id"}},
 		}
 	})
 

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -1001,9 +1001,10 @@ func TestRegisterCdcExecutor(t *testing.T) {
 
 	gostub.Stub(&cdc.GetTableDetector, func(cnUUID string) *cdc.TableDetector {
 		return &cdc.TableDetector{
-			Mutex:     sync.Mutex{},
-			Mp:        make(map[uint32]cdc.TblMap),
-			Callbacks: map[string]func(map[uint32]cdc.TblMap){"id": func(mp map[uint32]cdc.TblMap) {}},
+			Mp:                   make(map[uint32]cdc.TblMap),
+			Callbacks:            map[string]func(map[uint32]cdc.TblMap){"id": func(mp map[uint32]cdc.TblMap) {}},
+			CallBackAccountId:    map[string]uint32{"id": 0},
+			SubscribedAccountIds: map[uint32]bool{0: true},
 		}
 	})
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19627 

## What this PR does / why we need it:

Improve the table detector during CDC task execution by pushing down the account_id list


___

### **PR Type**
Enhancement


___

### **Description**
• Optimize CDC table detection by filtering tables by account_id
• Add account tracking to TableDetector for better resource management
• Improve SQL query performance with account_id pushdown
• Update registration methods to include account_id parameter


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_builder.go</strong><dd><code>Add account_id filtering to table collection SQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/sql_builder.go

• Modified SQL template to include account_id IN clause before relkind <br>filter<br> • Updated CollectTableInfoSQL method to accept account_ids <br>parameter<br> • Removed static SQL formatting from template initialization


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22033/files#diff-c3e745c3f21e6e012ee0d8f0bf832c3457401185e8b6ed3449a09234df97e465">+10/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>table_scanner.go</strong><dd><code>Enhance TableDetector with account-aware scanning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/table_scanner.go

• Added account tracking fields to TableDetector struct<br> • Modified <br>Register/UnRegister methods to handle account_id parameter<br> • Updated <br>scanTable to build account_ids list for SQL filtering<br> • Added logging <br>and improved error handling


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22033/files#diff-ff43b62d0f42085266c063c203474532c19fb2aeb3e6d390b187f63f5306af8b">+62/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cdc_exector.go</strong><dd><code>Pass account_id to table detector registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/cdc_exector.go

• Updated Register call to pass accountId parameter


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22033/files#diff-63d732ad294e42566a6feb82dfd2fcab2bb596acb2d4df146b468a5510a30506">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>table_scanner_test.go</strong><dd><code>Update tests for account-aware TableDetector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/table_scanner_test.go

• Updated test to initialize new TableDetector fields<br> • Modified <br>Register calls to include account_id parameter<br> • Added comprehensive <br>test cases for account tracking


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22033/files#diff-42d68181e50c7cc56e83bf3db1137df34178b2945dfcb5556ea00bf8eb68555d">+23/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cdc_test.go</strong><dd><code>Update test mock for new TableDetector fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/cdc_test.go

• Updated mock TableDetector initialization with new fields


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22033/files#diff-8d6e36c031623114ff82f5ef24117fecede45fbcd2f3f13387596e1d1f479988">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>