### PR TITLE
[taskservice] bug: add Created condition when filter tasks

### DIFF
--- a/pkg/taskservice/task_service_cron.go
+++ b/pkg/taskservice/task_service_cron.go
@@ -276,7 +276,7 @@ func (j *cronJob) checkConcurrency() bool {
 	defer cancel()
 
 	queryTask, err := j.s.QueryAsyncTask(ctx,
-		WithTaskStatusCond(task.TaskStatus_Running),
+		WithTaskStatusCond(task.TaskStatus_Running, task.TaskStatus_Created),
 		WithTaskExecutorCond(EQ, j.task.Metadata.Executor))
 	if err != nil ||
 		uint32(len(queryTask)) >= j.task.Metadata.Options.Concurrency {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/5715

## What this PR does / why we need it:
When querying async tasks, we need to add the condition that
status is Created. If there is no CN node that can run the task,
the records in the task table will accumulate a lot, resulting in
a huge amount of error logs.


___

### **PR Type**
Bug fix


___

### **Description**
• Add Created status condition to task filtering in cron job
• Prevent accumulation of unprocessed task records
• Fix memory consumption issues with large data loads


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task_service_cron.go</strong><dd><code>Add Created status to task filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/taskservice/task_service_cron.go

• Modified <code>checkConcurrency()</code> method to include <br><code>task.TaskStatus_Created</code> condition<br> • Added Created status alongside <br>Running status in task query filter<br> • Prevents accumulation of <br>unprocessed task records when no CN nodes available


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22040/files#diff-709e8482a380eead3f6c6c7532a9a9429723103fdc8915c7fb3becbf23e733de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>