### PR TITLE
reduce memory usage and IO in DML plan with vector index

### DIFF
--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -720,8 +720,10 @@ func (s *Scope) handleRuntimeFilters(c *Compile, runtimeInExprList []*plan.Expr)
 		if !ok {
 			panic("missing instruction for runtime filter!")
 		}
-		nonPkFilters = append(nonPkFilters, arg.E)
-		arg.E = colexec.RewriteFilterExprList(plan2.DeepCopyExprList(nonPkFilters))
+		err := arg.SetRuntimeExpr(s.Proc, nonPkFilters)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// reset datasource

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -720,10 +720,8 @@ func (s *Scope) handleRuntimeFilters(c *Compile, runtimeInExprList []*plan.Expr)
 		if !ok {
 			panic("missing instruction for runtime filter!")
 		}
-		err := arg.SetRuntimeExpr(s.Proc, nonPkFilters)
-		if err != nil {
-			return nil, err
-		}
+		nonPkFilters = append(nonPkFilters, arg.E)
+		arg.E = colexec.RewriteFilterExprList(plan2.DeepCopyExprList(nonPkFilters))
 	}
 
 	// reset datasource

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -2416,49 +2416,34 @@ func appendDeleteMasterTablePlan(builder *QueryBuilder, bindCtx *BindContext,
 
 	lastNodeId := baseNodeId
 	projectList := getProjectionByLastNode(builder, lastNodeId)
-	for i := range projectList {
-		col := projectList[i].GetCol()
-		if col != nil && col.RelPos == 0 {
-			col.RelPos = 1
-		}
-	}
 
-	neededCols := make([]*plan.ColDef, 0, 2)
-	scanNodeProject := make([]*Expr, 2)
-	for _, colVal := range masterTableDef.Cols {
+	var rightRowIdPos int32 = -1
+	var rightPkPos int32 = -1
+	scanNodeProject := make([]*Expr, len(masterTableDef.Cols))
+	for colIdx, colVal := range masterTableDef.Cols {
+
 		if colVal.Name == catalog.Row_ID {
-			scanNodeProject[0] = &plan.Expr{
-				Typ: colVal.Typ,
-				Expr: &plan.Expr_Col{
-					Col: &plan.ColRef{
-						ColPos: int32(len(neededCols)),
-						Name:   colVal.Name,
-					},
-				},
-			}
-			neededCols = append(neededCols, colVal)
+			rightRowIdPos = int32(colIdx)
 		} else if colVal.Name == catalog.MasterIndexTableIndexColName {
-			scanNodeProject[1] = &plan.Expr{
-				Typ: colVal.Typ,
-				Expr: &plan.Expr_Col{
-					Col: &plan.ColRef{
-						ColPos: int32(len(neededCols)),
-						Name:   colVal.Name,
-					},
+			rightPkPos = int32(colIdx)
+		}
+
+		scanNodeProject[colIdx] = &plan.Expr{
+			Typ: colVal.Typ,
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{
+					ColPos: int32(colIdx),
+					Name:   colVal.Name,
 				},
-			}
-			neededCols = append(neededCols, colVal)
+			},
 		}
 	}
 
-	newMasterTableDef := DeepCopyTableDef(masterTableDef, false)
-	newMasterTableDef.Cols = neededCols
-
-	masterScanId := builder.appendNode(&plan.Node{
+	rightId := builder.appendNode(&plan.Node{
 		NodeType:    plan.Node_TABLE_SCAN,
 		Stats:       &plan.Stats{},
 		ObjRef:      masterObjRef,
-		TableDef:    newMasterTableDef,
+		TableDef:    masterTableDef,
 		ProjectList: scanNodeProject,
 	}, bindCtx)
 
@@ -2468,45 +2453,45 @@ func appendDeleteMasterTablePlan(builder *QueryBuilder, bindCtx *BindContext,
 	var joinConds *Expr
 	for idx, part := range indexDef.Parts {
 		// serial_full("colPos", col1, pk)
-		var origExpr *Expr
-		origExprArgs := make([]*Expr, 3)
-		origExprArgs[0] = makePlan2StringConstExprWithType(getColSeqFromColDef(tableDef.Cols[posMap[part]]))
-		origExprArgs[1] = &Expr{
+		var leftExpr *Expr
+		leftExprArgs := make([]*Expr, 3)
+		leftExprArgs[0] = makePlan2StringConstExprWithType(getColSeqFromColDef(tableDef.Cols[posMap[part]]))
+		leftExprArgs[1] = &Expr{
 			Typ: typMap[part],
 			Expr: &plan.Expr_Col{
 				Col: &plan.ColRef{
-					RelPos: 1,
+					RelPos: 0,
 					ColPos: int32(posMap[part]),
 					Name:   part,
 				},
 			},
 		}
-		origExprArgs[2] = &Expr{
+		leftExprArgs[2] = &Expr{
 			Typ: originPkType,
 			Expr: &plan.Expr_Col{
 				Col: &plan.ColRef{
-					RelPos: 1,
+					RelPos: 0,
 					ColPos: int32(originPkColumnPos),
 					Name:   tableDef.Pkey.PkeyColName,
 				},
 			},
 		}
-		origExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "serial_full", origExprArgs)
+		leftExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "serial_full", leftExprArgs)
 		if err != nil {
 			return -1, err
 		}
 
-		var masterExpr = &plan.Expr{
-			Typ: scanNodeProject[1].Typ,
+		var rightExpr = &plan.Expr{
+			Typ: masterTableDef.Cols[rightPkPos].Typ,
 			Expr: &plan.Expr_Col{
 				Col: &plan.ColRef{
-					RelPos: 0,
-					ColPos: 1,
+					RelPos: 1,
+					ColPos: rightPkPos,
 					Name:   catalog.MasterIndexTableIndexColName,
 				},
 			},
 		}
-		currCond, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{masterExpr, origExpr})
+		currCond, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{leftExpr, rightExpr})
 		if err != nil {
 			return -1, err
 		}
@@ -2521,34 +2506,35 @@ func appendDeleteMasterTablePlan(builder *QueryBuilder, bindCtx *BindContext,
 	}
 
 	projectList = append(projectList, &plan.Expr{
-		Typ: scanNodeProject[0].Typ,
+		Typ: masterTableDef.Cols[rightRowIdPos].Typ,
 		Expr: &plan.Expr_Col{
 			Col: &plan.ColRef{
-				RelPos: 0,
-				ColPos: 0,
+				RelPos: 1,
+				ColPos: rightRowIdPos,
 				Name:   catalog.Row_ID,
 			},
 		},
 	}, &plan.Expr{
-		Typ: scanNodeProject[1].Typ,
+		Typ: masterTableDef.Cols[rightPkPos].Typ,
 		Expr: &plan.Expr_Col{
 			Col: &plan.ColRef{
-				RelPos: 0,
-				ColPos: 1,
+				RelPos: 1,
+				ColPos: rightPkPos,
 				Name:   catalog.MasterIndexTableIndexColName,
 			},
 		},
 	})
 	lastNodeId = builder.appendNode(&plan.Node{
 		NodeType:    plan.Node_JOIN,
-		JoinType:    plan.Node_RIGHT,
-		Children:    []int32{masterScanId, lastNodeId},
+		JoinType:    plan.Node_LEFT,
+		Children:    []int32{lastNodeId, rightId},
 		OnList:      []*Expr{joinConds},
 		ProjectList: projectList,
 	}, bindCtx)
 
 	return lastNodeId, nil
 }
+
 func appendDeleteIvfTablePlan(builder *QueryBuilder, bindCtx *BindContext,
 	entriesObjRef *ObjectRef, entriesTableDef *TableDef,
 	baseNodeId int32, tableDef *TableDef) (int32, error) {
@@ -4516,29 +4502,47 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 		lastNodeId := appendSinkScanNode(builder, bindCtx, delCtx.sourceStep)
 		orgPkColPos, orgPkType := getPkPos(delCtx.tableDef, false)
 
-		var idxRowIdPos int32 = -1
-		var idxDocidPos int32 = 0  // doc_id
-		var idxFakePkPos int32 = 3 // __mo_fake_pk_col_
-		scanNodeProject := make([]*Expr, len(indexTableDef.Cols))
-		for colIdx, colVal := range indexTableDef.Cols {
-
+		neededCols := make([]*plan.ColDef, 0, 3)
+		scanNodeProject := make([]*Expr, 3)
+		for _, colVal := range indexTableDef.Cols {
 			if colVal.Name == catalog.Row_ID {
-				idxRowIdPos = int32(colIdx)
-			}
-			if colVal.Name == catalog.FakePrimaryKeyColName {
-				idxFakePkPos = int32(colIdx)
-			}
-
-			scanNodeProject[colIdx] = &plan.Expr{
-				Typ: colVal.Typ,
-				Expr: &plan.Expr_Col{
-					Col: &plan.ColRef{
-						ColPos: int32(colIdx),
-						Name:   colVal.Name,
+				scanNodeProject[0] = &plan.Expr{
+					Typ: colVal.Typ,
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{
+							ColPos: int32(len(neededCols)),
+							Name:   colVal.Name,
+						},
 					},
-				},
+				}
+				neededCols = append(neededCols, colVal)
+			} else if colVal.Name == catalog.FullTextIndex_TabCol_Id {
+				scanNodeProject[1] = &plan.Expr{
+					Typ: colVal.Typ,
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{
+							ColPos: int32(len(neededCols)),
+							Name:   colVal.Name,
+						},
+					},
+				}
+				neededCols = append(neededCols, colVal)
+			} else if colVal.Name == catalog.FakePrimaryKeyColName {
+				scanNodeProject[2] = &plan.Expr{
+					Typ: colVal.Typ,
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{
+							ColPos: int32(len(neededCols)),
+							Name:   colVal.Name,
+						},
+					},
+				}
+				neededCols = append(neededCols, colVal)
 			}
 		}
+
+		newIndexTableDef := DeepCopyTableDef(indexTableDef, false)
+		newIndexTableDef.Cols = neededCols
 
 		//probeExpr := &plan.Expr{
 		//	Typ: indexTableDef.Cols[idxDocidPos].Typ,
@@ -4555,7 +4559,7 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 			NodeType:    plan.Node_TABLE_SCAN,
 			Stats:       &plan.Stats{},
 			ObjRef:      indexObjRef,
-			TableDef:    indexTableDef,
+			TableDef:    newIndexTableDef,
 			ProjectList: scanNodeProject,
 			//RuntimeFilterProbeList: []*plan.RuntimeFilterSpec{MakeRuntimeFilter(rfTag, false, 0, probeExpr, true)},
 		}
@@ -4563,11 +4567,11 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 		//idxScanNode.Stats.ForceOneCN = true
 
 		var leftExpr = &plan.Expr{
-			Typ: indexTableDef.Cols[idxDocidPos].Typ,
+			Typ: scanNodeProject[1].Typ,
 			Expr: &plan.Expr_Col{
 				Col: &plan.ColRef{
 					RelPos: 0,
-					ColPos: idxDocidPos,
+					ColPos: 1,
 					Name:   "doc_id",
 				},
 			},
@@ -4591,29 +4595,29 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 
 		projectList := make([]*Expr, 0, 2)
 		projectList = append(projectList, &plan.Expr{
-			Typ: indexTableDef.Cols[idxRowIdPos].Typ,
+			Typ: scanNodeProject[0].Typ,
 			Expr: &plan.Expr_Col{
 				Col: &plan.ColRef{
 					RelPos: 0,
-					ColPos: idxRowIdPos,
+					ColPos: 0,
 					Name:   catalog.Row_ID,
 				},
 			},
 		}, &plan.Expr{
-			Typ: indexTableDef.Cols[idxDocidPos].Typ,
+			Typ: scanNodeProject[1].Typ,
 			Expr: &plan.Expr_Col{
 				Col: &plan.ColRef{
 					RelPos: 0,
-					ColPos: idxDocidPos,
+					ColPos: 1,
 					Name:   "doc_id",
 				},
 			},
 		}, &plan.Expr{
-			Typ: indexTableDef.Cols[idxFakePkPos].Typ,
+			Typ: scanNodeProject[2].Typ,
 			Expr: &plan.Expr_Col{
 				Col: &plan.ColRef{
 					RelPos: 0,
-					ColPos: idxFakePkPos,
+					ColPos: 2,
 					Name:   catalog.FakePrimaryKeyColName,
 				},
 			},
@@ -4642,7 +4646,7 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 
 		deleteIdx := 0
 		retPkPos := deleteIdx + 2
-		retPkTyp := indexTableDef.Cols[idxFakePkPos].Typ
+		retPkTyp := scanNodeProject[2].Typ
 
 		return lastNodeId, deleteIdx, retPkPos, retPkTyp, nil
 	}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/5717

## What this PR does / why we need it:
improve join order and prune projections


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Optimize DML plan memory usage for vector index operations

- Fix join order and column position references in delete operations

- Reduce table scan projections to only needed columns

- Improve runtime filter handling in scope operations


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scope.go</strong><dd><code>Simplify runtime filter expression handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/scope.go

<li>Replace SetRuntimeExpr with direct filter expression manipulation<br> <li> Append non-PK filters to existing expression list<br> <li> Use RewriteFilterExprList for filter optimization


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22043/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_dml_util.go</strong><dd><code>Optimize vector index delete operations and fix joins</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_dml_util.go

<li>Optimize table scans to only select needed columns (row_id, index <br>columns)<br> <li> Fix column position references by updating RelPos from 0 to 1<br> <li> Change join type from LEFT to RIGHT and swap join children order<br> <li> Create minimal table definitions with only required columns<br> <li> Update projection expressions to use correct column positions


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22043/files#diff-095fb233d51021791cb24454839b013236680bbc6bbc22e0d2f6741ac8fe7dff">+120/-78</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>