### PR TITLE
ast string with quote identifier

### DIFF
--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -82,6 +82,31 @@ func TestOriginSQL(t *testing.T) {
 }
 
 var (
+	partitionSQL = struct {
+		input  string
+		output string
+	}{
+		input:  "create table `db_testalterpartitiontablewithaddcolumn_702488000`.`testalterpartitiontablewithaddcolumn_copy_01979b62-2421-7956-81bf-53bb3b5a0090` (`c` int default null comment 'abc', `b` int default null, `d` int default null) partition by hash (c) partitions 2",
+		output: "create table `db_testalterpartitiontablewithaddcolumn_702488000`.`testalterpartitiontablewithaddcolumn_copy_01979b62-2421-7956-81bf-53bb3b5a0090` (`c` int default null comment abc, `b` int default null, `d` int default null) partition by hash (`c`) partitions 2",
+	}
+)
+
+func TestQuoteIdentifer(t *testing.T) {
+	if partitionSQL.output == "" {
+		partitionSQL.output = partitionSQL.input
+	}
+	ast, err := ParseOne(context.TODO(), partitionSQL.input, 1)
+	if err != nil {
+		t.Errorf("Parse(%q) err: %v", partitionSQL.input, err)
+		return
+	}
+	out := tree.StringWithOpts(ast, dialect.MYSQL, tree.WithQuoteIdentifer())
+	if partitionSQL.output != out {
+		t.Errorf("Parsing failed. \nExpected/Got:\n%s\n%s", partitionSQL.output, out)
+	}
+}
+
+var (
 	validSQL = []struct {
 		input  string
 		output string

--- a/pkg/sql/parsers/tree/format.go
+++ b/pkg/sql/parsers/tree/format.go
@@ -29,6 +29,7 @@ type FmtCtx struct {
 	quoteString             bool
 	singleQuoteString       bool
 	escapeSingleQuoteString bool
+	quoteIdentifier         bool
 }
 
 func NewFmtCtx(dialectType dialect.DialectType, opts ...FmtCtxOption) *FmtCtx {
@@ -63,6 +64,12 @@ func WithSingleQuoteString() FmtCtxOption {
 func WithEscapeSingleQuoteString() FmtCtxOption {
 	return FmtCtxOption(func(ctx *FmtCtx) {
 		ctx.escapeSingleQuoteString = true
+	})
+}
+
+func WithQuoteIdentifer() FmtCtxOption {
+	return FmtCtxOption(func(ctx *FmtCtx) {
+		ctx.quoteIdentifier = true
 	})
 }
 

--- a/pkg/sql/parsers/tree/identifier.go
+++ b/pkg/sql/parsers/tree/identifier.go
@@ -107,10 +107,19 @@ func (node *UnresolvedName) ColNameOrigin() string {
 }
 
 func (node *UnresolvedName) Format(ctx *FmtCtx) {
-	for i := node.NumParts - 1; i >= 0; i-- {
-		ctx.WriteString(node.CStrParts[i].Origin())
-		if i > 0 {
-			ctx.WriteByte('.')
+	if ctx.quoteIdentifier {
+		for i := node.NumParts - 1; i >= 0; i-- {
+			ctx.WriteString("`" + node.CStrParts[i].Origin() + "`")
+			if i > 0 {
+				ctx.WriteByte('.')
+			}
+		}
+	} else {
+		for i := node.NumParts - 1; i >= 0; i-- {
+			ctx.WriteString(node.CStrParts[i].Origin())
+			if i > 0 {
+				ctx.WriteByte('.')
+			}
 		}
 	}
 	if node.Star && node.NumParts > 0 {

--- a/pkg/sql/parsers/tree/table_name.go
+++ b/pkg/sql/parsers/tree/table_name.go
@@ -21,15 +21,27 @@ type TableName struct {
 }
 
 func (tn TableName) Format(ctx *FmtCtx) {
-	if tn.ExplicitCatalog {
-		ctx.WriteString(string(tn.CatalogName))
-		ctx.WriteByte('.')
+	if ctx.quoteIdentifier {
+		if tn.ExplicitCatalog {
+			ctx.WriteString("`" + string(tn.CatalogName) + "`")
+			ctx.WriteByte('.')
+		}
+		if tn.ExplicitSchema {
+			ctx.WriteString("`" + string(tn.SchemaName) + "`")
+			ctx.WriteByte('.')
+		}
+		ctx.WriteString("`" + string(tn.ObjectName) + "`")
+	} else {
+		if tn.ExplicitCatalog {
+			ctx.WriteString(string(tn.CatalogName))
+			ctx.WriteByte('.')
+		}
+		if tn.ExplicitSchema {
+			ctx.WriteString(string(tn.SchemaName))
+			ctx.WriteByte('.')
+		}
+		ctx.WriteString(string(tn.ObjectName))
 	}
-	if tn.ExplicitSchema {
-		ctx.WriteString(string(tn.SchemaName))
-		ctx.WriteByte('.')
-	}
-	ctx.WriteString(string(tn.ObjectName))
 	if tn.AtTsExpr != nil {
 		tn.AtTsExpr.Format(ctx)
 	}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16471 

## What this PR does / why we need it:

ast string with quote identifier


___

### **PR Type**
Enhancement


___

### **Description**
- Add quote identifier formatting option for AST string output

- Implement backtick quoting for table names and identifiers

- Add test case for partition table with quoted identifiers


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mysql_sql_test.go</strong><dd><code>Add quote identifier test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/parsers/dialect/mysql/mysql_sql_test.go

<li>Add new test case <code>TestQuoteIdentifer</code> for partition table SQL<br> <li> Test quote identifier functionality with backticks<br> <li> Include expected output with quoted column reference in partition <br>clause


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22046/files#diff-96a7d142d5e6047d7d72e9a45bc7e4a8baeaa0be0ddfece9753e336a09d43ec2">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>format.go</strong><dd><code>Add quote identifier formatting option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/parsers/tree/format.go

<li>Add <code>quoteIdentifier</code> boolean field to <code>FmtCtx</code> struct<br> <li> Implement <code>WithQuoteIdentifer()</code> option function


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22046/files#diff-ef52f02f7ec03dcca38c99a13aba39d542aa17adc75a5902f0a7af05b21f44bf">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>identifier.go</strong><dd><code>Implement identifier quoting in UnresolvedName</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/parsers/tree/identifier.go

<li>Modify <code>UnresolvedName.Format()</code> to support quote identifier option<br> <li> Add backtick wrapping when <code>quoteIdentifier</code> is enabled


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22046/files#diff-4a787fc3ba4793f1d1893e383ee96d82287eebc6852a07ee3157918d1330995a">+13/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>table_name.go</strong><dd><code>Implement identifier quoting in TableName</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/parsers/tree/table_name.go

<li>Update <code>TableName.Format()</code> to support quote identifier option<br> <li> Add backtick wrapping for catalog, schema, and object names


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22046/files#diff-5e859664132ad114b9ac934ad68d8fcbc59597ba26c286ef3216f68d9f3b1cac">+20/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>