### PR TITLE
enable CHAR_LENGTH to accept TEXT

### DIFF
--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -990,6 +990,16 @@ var supportedStringBuiltIns = []FuncNew{
 					return LengthUTF8
 				},
 			},
+			{
+				overloadId: 2,
+				args:       []types.T{types.T_text},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_uint64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return LengthUTF8
+				},
+			},
 		},
 	},
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/5762

## What this PR does / why we need it:
to support strings longer than 65535


___

### **PR Type**
Bug fix


___

### **Description**
- Add TEXT type support to CHAR_LENGTH function

- Enable handling of strings longer than 65535 characters


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>list_builtIn.go</strong><dd><code>Add TEXT overload to CHAR_LENGTH function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/function/list_builtIn.go

<li>Added new overload for CHAR_LENGTH function to accept TEXT type<br> <li> Uses same LengthUTF8 operation and returns uint64 type<br> <li> Enables support for strings longer than 65535 characters


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22051/files#diff-b9b859604bf3c01505320f0a72c9862667f39cdf1323a88d7f8b2991d32098b8">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>