### PR TITLE
[fix] don't use index if it has all PK columns

### DIFF
--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -71,6 +71,42 @@ func (builder *QueryBuilder) canSkipDedup(tableDef *plan.TableDef) bool {
 	return catalog.IsSecondaryIndexTable(tableDef.Name)
 }
 
+func getValidIndexes(tableDef *plan.TableDef) (indexes []*plan.IndexDef, hasIrregularIndex bool) {
+	if tableDef == nil || len(tableDef.Indexes) == 0 {
+		return
+	}
+
+	for _, idxDef := range tableDef.Indexes {
+		if !catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) {
+			hasIrregularIndex = true
+			continue
+		}
+
+		if !idxDef.TableExist {
+			continue
+		}
+
+		colMap := make(map[string]bool)
+		for _, part := range idxDef.Parts {
+			colMap[part] = true
+		}
+
+		notCoverPk := false
+		for _, part := range tableDef.Pkey.Names {
+			if !colMap[part] {
+				notCoverPk = true
+				break
+			}
+		}
+
+		if notCoverPk {
+			indexes = append(indexes, idxDef)
+		}
+	}
+
+	return
+}
+
 func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 	bindCtx *BindContext,
 	dmlCtx *DMLContext,
@@ -85,12 +121,6 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 	if tableDef.TableType != catalog.SystemOrdinaryRel &&
 		tableDef.TableType != catalog.SystemIndexRel {
 		return 0, moerr.NewUnsupportedDML(builder.GetContext(), "insert into vector/text index table")
-	}
-
-	for _, idxDef := range tableDef.Indexes {
-		if !catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) {
-			return 0, moerr.NewUnsupportedDML(builder.GetContext(), "have vector index table")
-		}
 	}
 
 	var (
@@ -153,10 +183,6 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 
 	idxNeedUpdate := make([]bool, len(tableDef.Indexes))
 	for i, idxDef := range tableDef.Indexes {
-		if !idxDef.TableExist {
-			continue
-		}
-
 		for _, part := range idxDef.Parts {
 			if _, ok := updateExprs[catalog.ResolveAlias(part)]; ok {
 				if idxDef.Unique {
@@ -189,8 +215,8 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 		}
 	}
 	// lock unique key table
-	for j, idxDef := range tableDef.Indexes {
-		if !idxDef.TableExist || skipUniqueIdx[j] || !idxDef.Unique {
+	for i, idxDef := range tableDef.Indexes {
+		if !idxDef.Unique || skipUniqueIdx[i] {
 			continue
 		}
 		idxObjRef, idxTableDef := builder.compCtx.ResolveIndexTableByRef(dmlCtx.objRefs[0], idxDef.IndexTableName, bindCtx.snapshot)
@@ -222,10 +248,10 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 	}
 
 	// handle primary/unique key confliction
-	if builder.canSkipDedup(dmlCtx.tableDefs[0]) {
+	if builder.canSkipDedup(tableDef) {
 		// load do not handle primary/unique key confliction
 		for i, idxDef := range tableDef.Indexes {
-			if !idxDef.TableExist || skipUniqueIdx[i] {
+			if skipUniqueIdx[i] {
 				continue
 			}
 
@@ -318,7 +344,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 		}
 
 		for i, idxDef := range tableDef.Indexes {
-			if !idxDef.TableExist || skipUniqueIdx[i] {
+			if skipUniqueIdx[i] {
 				continue
 			}
 
@@ -408,7 +434,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 
 	newProjLen := len(selectNode.ProjectList)
 	for _, idxDef := range tableDef.Indexes {
-		if idxDef.TableExist && !idxDef.Unique {
+		if !idxDef.Unique {
 			newProjLen++
 		}
 	}
@@ -453,7 +479,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 		}
 
 		for i, idxDef := range tableDef.Indexes {
-			if !idxDef.TableExist || idxDef.Unique {
+			if idxDef.Unique {
 				continue
 			}
 
@@ -916,11 +942,17 @@ func (builder *QueryBuilder) appendNodesForInsertStmt(
 		colName2Idx[tableDef.Name+"."+col.Name] = int32(i)
 	}
 
+	validIndexes, hasIrregularIndex := getValidIndexes(tableDef)
+	if hasIrregularIndex {
+		return 0, nil, nil, moerr.NewUnsupportedDML(builder.GetContext(), "have vector index table")
+	}
+	tableDef.Indexes = validIndexes
+
 	skipUniqueIdx := make([]bool, len(tableDef.Indexes))
 	pkName := tableDef.Pkey.PkeyColName
 	pkPos := tableDef.Name2ColIndex[pkName]
 	for i, idxDef := range tableDef.Indexes {
-		if !idxDef.TableExist || !idxDef.Unique {
+		if !idxDef.Unique {
 			continue
 		}
 

--- a/pkg/sql/plan/bind_replace.go
+++ b/pkg/sql/plan/bind_replace.go
@@ -56,12 +56,6 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 		return 0, moerr.NewUnsupportedDML(builder.GetContext(), "insert into vector/text index table")
 	}
 
-	for _, idxDef := range tableDef.Indexes {
-		if !catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) {
-			return 0, moerr.NewUnsupportedDML(builder.GetContext(), "have vector index table")
-		}
-	}
-
 	if pkName == catalog.FakePrimaryKeyColName {
 		return 0, moerr.NewUnsupportedDML(builder.GetContext(), "fake primary key")
 		//return builder.appendDedupAndMultiUpdateNodesForBindInsert(bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx, nil)
@@ -117,10 +111,6 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 		}
 
 		for i, idxDef := range tableDef.Indexes {
-			if !idxDef.TableExist {
-				continue
-			}
-
 			idxObjRefs[i], idxTableDefs[i] = builder.compCtx.ResolveIndexTableByRef(objRef, idxDef.IndexTableName, bindCtx.snapshot)
 
 			if len(idxDef.Parts) == 1 {
@@ -275,7 +265,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 
 	// detect unique key confliction
 	for i, idxDef := range tableDef.Indexes {
-		if !idxDef.TableExist || !idxDef.Unique {
+		if !idxDef.Unique {
 			continue
 		}
 
@@ -362,11 +352,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 	}
 
 	// get old RowID for index tables
-	for i, idxDef := range tableDef.Indexes {
-		if !idxDef.TableExist {
-			continue
-		}
-
+	for i := range tableDef.Indexes {
 		idxTag := builder.genNewTag()
 		builder.addNameByColRef(idxTag, idxTableDefs[i])
 
@@ -505,10 +491,6 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 	}
 
 	for i, idxDef := range tableDef.Indexes {
-		if !idxDef.TableExist {
-			continue
-		}
-
 		insertCols := make([]plan.ColRef, 2)
 		deleteCols := make([]plan.ColRef, 2)
 
@@ -724,14 +706,16 @@ func (builder *QueryBuilder) appendNodesForReplaceStmt(
 		colName2Idx[tableDef.Name+"."+col.Name] = int32(i)
 	}
 
+	validIndexes, hasIrregularIndex := getValidIndexes(tableDef)
+	if hasIrregularIndex {
+		return 0, nil, nil, moerr.NewUnsupportedDML(builder.GetContext(), "have vector index table")
+	}
+	tableDef.Indexes = validIndexes
+
 	skipUniqueIdx := make([]bool, len(tableDef.Indexes))
 	pkName := tableDef.Pkey.PkeyColName
 	pkPos := tableDef.Name2ColIndex[pkName]
 	for i, idxDef := range tableDef.Indexes {
-		if !idxDef.TableExist {
-			continue
-		}
-
 		skipUniqueIdx[i] = true
 		for _, part := range idxDef.Parts {
 			if !columnIsNull[catalog.ResolveAlias(part)] {

--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -56,8 +56,13 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 			})
 		}
 
+		validIndexes, hasIrregularIndex := getValidIndexes(tableDef)
+		if hasIrregularIndex {
+			return 0, moerr.NewUnsupportedDML(builder.GetContext(), "update vector/full-text index")
+		}
+		tableDef.Indexes = validIndexes
+
 		var pkAndUkCols = make(map[string]bool)
-		var vecAndTextIndexCols = make(map[string]bool)
 
 		if tableDef.Name == catalog.MO_PUBS || tableDef.Name == catalog.MO_SUBS {
 			for _, colName := range tableDef.Pkey.Names {
@@ -66,23 +71,13 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 		}
 
 		for _, idxDef := range tableDef.Indexes {
-			if !idxDef.TableExist {
+			if !idxDef.Unique {
 				continue
 			}
 
-			if catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) {
-				if !idxDef.Unique {
-					continue
-				}
-
-				if tableDef.Name == catalog.MO_PUBS || tableDef.Name == catalog.MO_SUBS {
-					for _, colName := range idxDef.Parts {
-						pkAndUkCols[catalog.ResolveAlias(colName)] = true
-					}
-				}
-			} else {
+			if tableDef.Name == catalog.MO_PUBS || tableDef.Name == catalog.MO_SUBS {
 				for _, colName := range idxDef.Parts {
-					vecAndTextIndexCols[catalog.ResolveAlias(colName)] = true
+					pkAndUkCols[catalog.ResolveAlias(colName)] = true
 				}
 			}
 		}
@@ -90,10 +85,6 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 		for colName, updateExpr := range dmlCtx.updateCol2Expr[i] {
 			if pkAndUkCols[colName] {
 				return 0, moerr.NewUnsupportedDML(builder.compCtx.GetContext(), "update pk/uk on pub/sub table")
-			}
-
-			if vecAndTextIndexCols[colName] {
-				return 0, moerr.NewUnsupportedDML(builder.compCtx.GetContext(), "update vector index or full-text index")
 			}
 
 			if !dmlCtx.updatePartCol[i] {
@@ -268,10 +259,6 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 		idxNeedUpdate[i] = make([]bool, len(tableDef.Indexes))
 
 		for j, idxDef := range tableDef.Indexes {
-			if !idxDef.TableExist {
-				continue
-			}
-
 			for _, colName := range idxDef.Parts {
 				if _, ok := newColName2Idx[alias+"."+catalog.ResolveAlias(colName)]; ok {
 					idxNeedUpdate[i][j] = true
@@ -411,7 +398,7 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 			idxScanNodes[i] = make([]*plan.Node, len(tableDef.Indexes))
 
 			for j, idxDef := range tableDef.Indexes {
-				if !idxDef.TableExist || !idxDef.Unique || !idxNeedUpdate[i][j] {
+				if !idxDef.Unique || !idxNeedUpdate[i][j] {
 					continue
 				}
 
@@ -551,10 +538,6 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 		alias := dmlCtx.aliases[i]
 
 		for j, idxDef := range tableDef.Indexes {
-			if !idxDef.TableExist {
-				continue
-			}
-
 			if !pkNeedUpdate[i] && !idxNeedUpdate[i][j] {
 				continue
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/5763

## What this PR does / why we need it:
to fix the bug that if user defines a secondary index on the primary key column, delete doesn't work