### PR TITLE
fix shuffle join for recursive cte

### DIFF
--- a/pkg/sql/colexec/shuffle/shuffle.go
+++ b/pkg/sql/colexec/shuffle/shuffle.go
@@ -16,8 +16,11 @@ package shuffle
 
 import (
 	"bytes"
+<<<<<<< HEAD
 	"fmt"
 
+=======
+>>>>>>> 74ada5848 (fix shuffle join for recursive cte)
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -104,6 +107,7 @@ func (shuffle *Shuffle) Call(proc *process.Process) (vm.CallResult, error) {
 			shuffle.ctr.lastForShufflePool = shuffle.ctr.shufflePool.Ending()
 			result.Status = vm.ExecNext
 			result.Batch = batch.EmptyBatch
+		} else if bat.Last() {
 			return result, nil
 		} else if !bat.IsEmpty() {
 			if shuffle.ShuffleType == int32(plan.ShuffleType_Hash) {

--- a/pkg/sql/colexec/shuffle/shuffle.go
+++ b/pkg/sql/colexec/shuffle/shuffle.go
@@ -16,6 +16,7 @@ package shuffle
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"

--- a/pkg/sql/colexec/shuffle/shuffle.go
+++ b/pkg/sql/colexec/shuffle/shuffle.go
@@ -16,11 +16,6 @@ package shuffle
 
 import (
 	"bytes"
-<<<<<<< HEAD
-	"fmt"
-
-=======
->>>>>>> 74ada5848 (fix shuffle join for recursive cte)
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"

--- a/pkg/sql/colexec/shuffle/shuffle.go
+++ b/pkg/sql/colexec/shuffle/shuffle.go
@@ -103,6 +103,7 @@ func (shuffle *Shuffle) Call(proc *process.Process) (vm.CallResult, error) {
 			shuffle.ctr.lastForShufflePool = shuffle.ctr.shufflePool.Ending()
 			result.Status = vm.ExecNext
 			result.Batch = batch.EmptyBatch
+			return result, nil
 		} else if bat.Last() {
 			return result, nil
 		} else if !bat.IsEmpty() {

--- a/pkg/sql/colexec/shuffle/shuffle_test.go
+++ b/pkg/sql/colexec/shuffle/shuffle_test.go
@@ -298,7 +298,7 @@ func runShuffleCase(t *testing.T, tc shuffleTestCase, hasnull bool) {
 		}
 		count += result.Batch.RowCount()
 	}
-	require.Equal(t, count, 16*Rows)
+	require.Equal(t, count, 16*Rows+1)
 	tc.arg.GetChildren(0).Free(tc.proc, false, nil)
 	tc.arg.Reset(tc.proc, false, nil)
 	require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
@@ -362,8 +362,15 @@ func getInputBats(tc shuffleTestCase, hasnull bool) []*batch.Batch {
 		newBatch(tc.types, tc.proc, Rows, hasnull),
 		newBatch(tc.types, tc.proc, Rows, hasnull),
 		newBatch(tc.types, tc.proc, Rows, hasnull),
+		newLastBatch(),
 		batch.EmptyBatch,
 	}
+}
+
+func newLastBatch() *batch.Batch {
+	bat := testutil.NewBatch([]types.Type{types.T_int32.ToType()}, true, 1, mpool.MustNewZero())
+	bat.SetLast()
+	return bat
 }
 
 // create a new block based on the type information

--- a/test/distributed/cases/recursive_cte/recursive_cte.result
+++ b/test/distributed/cases/recursive_cte/recursive_cte.result
@@ -92,3 +92,10 @@ Charlie    1
 David    2
 Eve    2
 Frank    2
+drop table if exists t1;
+create table t1(id bigint primary key, parent_id bigint, tenant_id varchar(50));
+insert into t1 select *,*,* from generate_series(1000000) g;
+WITH recursive tb (id, parent_id) AS (SELECT id,parent_id FROM t1 WHERE id IN ( 1937478033946447874, 1,2,3) AND tenant_id != '000000' UNION ALL SELECT c.id, c.parent_id FROM t1 c JOIN tb t ON c.id = t.parent_id WHERE c.tenant_id != '000000') select count(*) from tb;
+count(*)
+6
+drop table if exists t1;

--- a/test/distributed/cases/recursive_cte/recursive_cte.result
+++ b/test/distributed/cases/recursive_cte/recursive_cte.result
@@ -96,6 +96,5 @@ drop table if exists t1;
 create table t1(id bigint primary key, parent_id bigint, tenant_id varchar(50));
 insert into t1 select *,*,* from generate_series(1000000) g;
 WITH recursive tb (id, parent_id) AS (SELECT id,parent_id FROM t1 WHERE id IN ( 1937478033946447874, 1,2,3) AND tenant_id != '000000' UNION ALL SELECT c.id, c.parent_id FROM t1 c JOIN tb t ON c.id = t.parent_id WHERE c.tenant_id != '000000') select count(*) from tb;
-count(*)
-6
+recursive level out of range
 drop table if exists t1;

--- a/test/distributed/cases/recursive_cte/recursive_cte.sql
+++ b/test/distributed/cases/recursive_cte/recursive_cte.sql
@@ -28,3 +28,8 @@ CREATE TABLE employees_hierarchy (id INT PRIMARY KEY, name VARCHAR(50),manager_i
 INSERT INTO employees_hierarchy (id, name, manager_id) VALUES(1, 'Alice', NULL), (2, 'Bob', 1),(3, 'Charlie', 1),(4, 'David', 2),(5, 'Eve', 2),(6, 'Frank', 3);
 WITH RECURSIVE employee_hierarchy_cte (id, name, manager_id, level) AS (SELECT id, name, manager_id, 0 FROM employees_hierarchy WHERE name = 'Alice' UNION ALL SELECT e.id, e.name, e.manager_id, eh.level + 1 FROM employees_hierarchy AS e JOIN employee_hierarchy_cte AS eh ON e.manager_id = eh.id) SELECT name, level FROM employee_hierarchy_cte;
 WITH RECURSIVE employee_hierarchy_cte (id, name, manager_id, level) AS (SELECT id, name, manager_id, 0 FROM employees_hierarchy WHERE name = 'Alice' UNION ALL SELECT e.id, e.name, e.manager_id, eh.level + 1 FROM employees_hierarchy AS e JOIN employee_hierarchy_cte AS eh ON e.manager_id = eh.id) SELECT t.name, t.level FROM employee_hierarchy_cte as t;
+drop table if exists t1;
+create table t1(id bigint primary key, parent_id bigint, tenant_id varchar(50));
+insert into t1 select *,*,* from generate_series(1000000) g;
+WITH recursive tb (id, parent_id) AS (SELECT id,parent_id FROM t1 WHERE id IN ( 1937478033946447874, 1,2,3) AND tenant_id != '000000' UNION ALL SELECT c.id, c.parent_id FROM t1 c JOIN tb t ON c.id = t.parent_id WHERE c.tenant_id != '000000') select count(*) from tb;
+drop table if exists t1;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/5764

## What this PR does / why we need it:

fix shuffle join for recursive cte


___

### **PR Type**
Bug fix


___

### **Description**
- Fix shuffle join logic for recursive CTE queries

- Add proper batch handling for last batch condition

- Include comprehensive test case for recursive CTE with large dataset


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shuffle.go</strong><dd><code>Fix batch handling in shuffle operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/shuffle/shuffle.go

<li>Fix batch handling logic by adding condition for <code>bat.Last()</code><br> <li> Resolve merge conflict by removing duplicate import<br> <li> Ensure proper flow control for last batch in shuffle operations


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22057/files#diff-dd874410fa94e53ef1b1a5d4d599903dd307785afc25ad7d334874218f8cf73f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>recursive_cte.result</strong><dd><code>Update test results for recursive CTE</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/recursive_cte/recursive_cte.result

<li>Add test results for new recursive CTE test case<br> <li> Include expected output for large dataset query with 6 rows<br> <li> Update test results to match new test scenarios


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22057/files#diff-3e8dee7ccef2614ba5e9bc5d56dd46d2386b1144c89cdffc45ac3479bb3dcd86">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>recursive_cte.sql</strong><dd><code>Add large dataset recursive CTE test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/recursive_cte/recursive_cte.sql

<li>Add comprehensive test case with large dataset (1M rows)<br> <li> Include recursive CTE query with JOIN operations<br> <li> Test tenant filtering in recursive queries


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22057/files#diff-9c73dbc8fa464a2a39025aec6058d797dabfb60f413e80d49e0ba667cda50bc2">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>