### PR TITLE
Fix version bug of cpt file (#21924)

### DIFF
--- a/pkg/vm/engine/tae/db/gc/v3/merge.go
+++ b/pkg/vm/engine/tae/db/gc/v3/merge.go
@@ -154,7 +154,7 @@ func MergeCheckpoint(
 	bat.GetVectorByName(checkpoint.CheckpointAttr_EndTS).Append(*end, false)
 	bat.GetVectorByName(checkpoint.CheckpointAttr_MetaLocation).Append([]byte(location), false)
 	bat.GetVectorByName(checkpoint.CheckpointAttr_EntryType).Append(false, false)
-	bat.GetVectorByName(checkpoint.CheckpointAttr_Version).Append(ckpEntries[len(ckpEntries)-1].GetVersion(), false)
+	bat.GetVectorByName(checkpoint.CheckpointAttr_Version).Append(logtail.CheckpointCurrentVersion, false)
 	bat.GetVectorByName(checkpoint.CheckpointAttr_AllLocations).Append([]byte(location), false)
 	bat.GetVectorByName(checkpoint.CheckpointAttr_CheckpointLSN).Append(uint64(0), false)
 	bat.GetVectorByName(checkpoint.CheckpointAttr_TruncateLSN).Append(uint64(0), false)


### PR DESCRIPTION
### **User description**
Fix version bug of cpt file

Approved by: @XuPeng-SH

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/5490

## What this PR does / why we need it:
Fix version bug of cpt file


___

### **PR Type**
Bug fix


___

### **Description**
- Fix checkpoint version assignment in merge operation

- Replace dynamic version retrieval with constant current version


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merge.go</strong><dd><code>Fix checkpoint version assignment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/gc/v3/merge.go

<li>Replace <code>ckpEntries[len(ckpEntries)-1].GetVersion()</code> with <br><code>logtail.CheckpointCurrentVersion</code><br> <li> Fix version assignment in checkpoint batch creation during merge


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22058/files#diff-687cc65a41138b0a42fc9a4747b580a21b53ec041527cce4f7394dbcbd4b4828">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>