### PR TITLE
disable pushdown limit for 2.2-dev

### DIFF
--- a/test/distributed/cases/fulltext/fulltext.result
+++ b/test/distributed/cases/fulltext/fulltext.result
@@ -522,7 +522,7 @@ count(*)
 30001
 select count(*) from t1 where match(b) against ('+pushdown +limit' in boolean mode) limit 1;
 count(*)
-1
+30001
 drop table t1;
 drop table if exists articles;
 create table articles (id int auto_increment not null primary key, title varchar, body text);

--- a/test/distributed/cases/fulltext/fulltext_bm25.result
+++ b/test/distributed/cases/fulltext/fulltext_bm25.result
@@ -416,6 +416,13 @@ select * from src2 where match(body, title) against('red');
 id1    id2    body    title
 id0    0    red    t1
 id3    3    blue red    t4
+select *, match(body, title) against('+red' in boolean mode)  from src2 where match(body, title) against('+red' in boolean mode);
+id1    id2    body    title    MATCH (body, title) AGAINST (+red IN BOOLEAN MODE)
+id0    0    red    t1    0.09538849
+id3    3    blue red    t4    0.07879918
+select *, match(body, title) against('+red' in boolean mode)  from src2 where match(body, title) against('+red' in boolean mode) limit 1;
+id1    id2    body    title    MATCH (body, title) AGAINST (+red IN BOOLEAN MODE)
+id0    0    red    t1    0.09538849
 select src2.*, match(body, title) against('blue') from src2;
 id1    id2    body    title    MATCH (body, title) AGAINST (blue)
 id2    2    blue    t3    0.09538849
@@ -522,7 +529,7 @@ count(*)
 30001
 select count(*) from t1 where match(b) against ('+pushdown +limit' in boolean mode) limit 1;
 count(*)
-1
+30001
 drop table t1;
 drop table if exists articles;
 create table articles (id int auto_increment not null primary key, title varchar, body text);

--- a/test/distributed/cases/fulltext/fulltext_bm25.sql
+++ b/test/distributed/cases/fulltext/fulltext_bm25.sql
@@ -319,6 +319,8 @@ create table src2 (id1 varchar, id2 bigint, body char(128), title text, primary 
 insert into src2 values ('id0', 0, 'red', 't1'), ('id1', 1, 'yellow', 't2'), ('id2', 2, 'blue', 't3'), ('id3', 3, 'blue red', 't4');
 
 select * from src2 where match(body, title) against('red');
+select *, match(body, title) against('+red' in boolean mode)  from src2 where match(body, title) against('+red' in boolean mode);
+select *, match(body, title) against('+red' in boolean mode)  from src2 where match(body, title) against('+red' in boolean mode) limit 1;
 select src2.*, match(body, title) against('blue') from src2;
 
 desc src2;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22064

## What this PR does / why we need it:

fullltext index disable pushdown limit so that result is always predictable.

fullltext index disable pushdown limit so that result is always predictable.

https://github.com/matrixorigin/MO-Cloud/issues/5779
