### PR TITLE
bump 2.2 release date

### DIFF
--- a/pkg/vm/engine/tae/db/merge/scheduler.go
+++ b/pkg/vm/engine/tae/db/merge/scheduler.go
@@ -1177,7 +1177,7 @@ func (p *launchPad) Reset() {
 	p.table = nil
 }
 
-var ReleaseDate int64 = 1748412184166943572 //  2025-05-28 14:03:04.166943572 +0800 CST
+var ReleaseDate int64 = 1751439605237702877 //  2025-07-02 15:00:05.237702877 +0800 CST
 
 func (p *launchPad) InitWithTrigger(trigger *MMsgTaskTrigger, lastMergeTime time.Time) {
 	p.table = trigger.table


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/21961

## What this PR does / why we need it:

- Leave more legacy objects alone.


___

### **PR Type**
Other


___

### **Description**
- Update release date from May 28, 2025 to July 2, 2025


___

### **Changes diagram**

```mermaid
flowchart LR
  A["ReleaseDate Variable"] --> B["Updated Timestamp"]
  B --> C["July 2, 2025 15:00:05"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scheduler.go</strong><dd><code>Update release date constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/merge/scheduler.go

<li>Updated <code>ReleaseDate</code> constant from May 28, 2025 to July 2, 2025<br> <li> Changed timestamp value from 1748412184166943572 to <br>1751439605237702877


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22083/files#diff-e39cd8771cc815a9c7daef3e4cb9f6a7a3a91de2ed4eb91942a389452365e113">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>