### PR TITLE
enhance expr format 

### DIFF
--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1959,7 +1959,7 @@ func doFormatExpr(expr *plan.Expr, out *bytes.Buffer, depth int) {
 	prefix := strings.Repeat("\t", depth)
 	switch t := expr.Expr.(type) {
 	case *plan.Expr_Col:
-		out.WriteString(fmt.Sprintf("%sExpr_Col(%s)", prefix, t.Col.Name))
+		out.WriteString(fmt.Sprintf("%sExpr_Col(%s.%d)", prefix, t.Col.Name, t.Col.ColPos))
 	case *plan.Expr_Lit:
 		out.WriteString(fmt.Sprintf("%sExpr_C(%s)", prefix, t.Lit.String()))
 	case *plan.Expr_F:

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1946,33 +1946,14 @@ type FormatOption struct {
 
 	// <=0 means no limit
 	MaxDepth int
-
-	// "json" or "console"
-	// if not set, use "console"
-	Formatter string
 }
 
 func FormatExprs(exprs []*plan.Expr, option FormatOption) string {
-	if option.Formatter == "json" {
-		return FormatExprsInJson(exprs, option)
-	}
-
 	return FormatExprsInConsole(exprs, option)
 }
 
 func FormatExpr(expr *plan.Expr, option FormatOption) string {
-	if option.Formatter == "json" {
-		return FormatExprInJson(expr, option)
-	}
 	return FormatExprInConsole(expr, option)
-}
-
-func FormatExprInJson(expr *plan.Expr, option FormatOption) string {
-	return ""
-}
-
-func FormatExprsInJson(exprs []*plan.Expr, option FormatOption) string {
-	return ""
 }
 
 func FormatExprsInConsole(exprs []*plan.Expr, option FormatOption) string {

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -1993,7 +1993,7 @@ func FormatExprInConsole(expr *plan.Expr, option FormatOption) string {
 func doFormatExprInConsole(expr *plan.Expr, out *bytes.Buffer, depth int, option FormatOption) {
 	out.WriteByte('\n')
 	prefix := strings.Repeat("\t", depth)
-	if depth > option.MaxDepth && option.MaxDepth > 0 {
+	if depth >= option.MaxDepth && option.MaxDepth > 0 {
 		out.WriteString(fmt.Sprintf("%s...", prefix))
 		return
 	}

--- a/pkg/sql/plan/utils.go
+++ b/pkg/sql/plan/utils.go
@@ -46,6 +46,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	"github.com/matrixorigin/matrixone/pkg/stage"
 	"github.com/matrixorigin/matrixone/pkg/stage/stageutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -1939,24 +1940,63 @@ func PkColByTableDef(tblDef *plan.TableDef) *plan.ColDef {
 	return pkCol
 }
 
-func FormatExprs(exprs []*plan.Expr) string {
+type FormatOption struct {
+	ExpandVec       bool
+	ExpandVecMaxLen int
+
+	// <=0 means no limit
+	MaxDepth int
+
+	// "json" or "console"
+	// if not set, use "console"
+	Formatter string
+}
+
+func FormatExprs(exprs []*plan.Expr, option FormatOption) string {
+	if option.Formatter == "json" {
+		return FormatExprsInJson(exprs, option)
+	}
+
+	return FormatExprsInConsole(exprs, option)
+}
+
+func FormatExpr(expr *plan.Expr, option FormatOption) string {
+	if option.Formatter == "json" {
+		return FormatExprInJson(expr, option)
+	}
+	return FormatExprInConsole(expr, option)
+}
+
+func FormatExprInJson(expr *plan.Expr, option FormatOption) string {
+	return ""
+}
+
+func FormatExprsInJson(exprs []*plan.Expr, option FormatOption) string {
+	return ""
+}
+
+func FormatExprsInConsole(exprs []*plan.Expr, option FormatOption) string {
 	var w bytes.Buffer
 	for _, expr := range exprs {
-		w.WriteString(FormatExpr(expr))
+		w.WriteString(FormatExpr(expr, option))
 		w.WriteByte('\n')
 	}
 	return w.String()
 }
 
-func FormatExpr(expr *plan.Expr) string {
+func FormatExprInConsole(expr *plan.Expr, option FormatOption) string {
 	var w bytes.Buffer
-	doFormatExpr(expr, &w, 0)
+	doFormatExprInConsole(expr, &w, 0, option)
 	return w.String()
 }
 
-func doFormatExpr(expr *plan.Expr, out *bytes.Buffer, depth int) {
+func doFormatExprInConsole(expr *plan.Expr, out *bytes.Buffer, depth int, option FormatOption) {
 	out.WriteByte('\n')
 	prefix := strings.Repeat("\t", depth)
+	if depth > option.MaxDepth && option.MaxDepth > 0 {
+		out.WriteString(fmt.Sprintf("%s...", prefix))
+		return
+	}
 	switch t := expr.Expr.(type) {
 	case *plan.Expr_Col:
 		out.WriteString(fmt.Sprintf("%sExpr_Col(%s.%d)", prefix, t.Col.Name, t.Col.ColPos))
@@ -1965,7 +2005,7 @@ func doFormatExpr(expr *plan.Expr, out *bytes.Buffer, depth int) {
 	case *plan.Expr_F:
 		out.WriteString(fmt.Sprintf("%sExpr_F(\n%s\tFunc[\"%s\"](nargs=%d)", prefix, prefix, t.F.Func.ObjName, len(t.F.Args)))
 		for _, arg := range t.F.Args {
-			doFormatExpr(arg, out, depth+1)
+			doFormatExprInConsole(arg, out, depth+1, option)
 		}
 		out.WriteString(fmt.Sprintf("\n%s)", prefix))
 	case *plan.Expr_P:
@@ -1973,13 +2013,30 @@ func doFormatExpr(expr *plan.Expr, out *bytes.Buffer, depth int) {
 	case *plan.Expr_T:
 		out.WriteString(fmt.Sprintf("%sExpr_T(%s)", prefix, t.T.String()))
 	case *plan.Expr_Vec:
-		out.WriteString(fmt.Sprintf("%sExpr_Vec(len=%d)", prefix, t.Vec.Len))
+		if option.ExpandVec {
+			expandVecMaxLen := option.ExpandVecMaxLen
+			if expandVecMaxLen <= 0 {
+				expandVecMaxLen = 1
+			}
+			var (
+				vecStr string
+				vec    vector.Vector
+			)
+			if err := vec.UnmarshalBinary(t.Vec.Data); err != nil {
+				vecStr = fmt.Sprintf("error: %s", err.Error())
+			} else {
+				vecStr = common.MoVectorToString(&vec, expandVecMaxLen)
+			}
+			out.WriteString(fmt.Sprintf("%sExpr_Vec(%s)", prefix, vecStr))
+		} else {
+			out.WriteString(fmt.Sprintf("%sExpr_Vec(len=%d)", prefix, t.Vec.Len))
+		}
 	case *plan.Expr_Fold:
 		out.WriteString(fmt.Sprintf("%sExpr_Fold(id=%d)", prefix, t.Fold.Id))
 	case *plan.Expr_List:
 		out.WriteString(fmt.Sprintf("%sExpr_List(len=%d)", prefix, len(t.List.List)))
 		for _, arg := range t.List.List {
-			doFormatExpr(arg, out, depth+1)
+			doFormatExprInConsole(arg, out, depth+1, option)
 		}
 	default:
 		out.WriteString(fmt.Sprintf("%sExpr_Unknown(%s)", prefix, expr.String()))

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -715,7 +715,13 @@ func (tbl *txnTable) doRanges(ctx context.Context, rangesParam engine.RangesPara
 			logutil.Info(
 				"TXN-FILTER-RANGE-LOG",
 				zap.String("name", tbl.tableDef.Name),
-				zap.String("exprs", plan2.FormatExprs(rangesParam.BlockFilters)),
+				zap.String("exprs", plan2.FormatExprs(
+					rangesParam.BlockFilters, plan2.FormatOption{
+						ExpandVec:       true,
+						ExpandVecMaxLen: 2,
+						MaxDepth:        5,
+					},
+				)),
 				zap.Uint64("tbl-id", tbl.tableId),
 				zap.String("txn", tbl.db.op.Txn().DebugString()),
 				zap.Int("blocks", blocks.Len()),
@@ -839,7 +845,14 @@ func (tbl *txnTable) rangesOnePart(
 		logutil.Info(
 			"SLOW-RANGES:",
 			zap.String("table", tbl.tableDef.Name),
-			zap.String("exprs", plan2.FormatExprs(rangesParam.BlockFilters)),
+			zap.String("exprs", plan2.FormatExprs(
+				rangesParam.BlockFilters,
+				plan2.FormatOption{
+					ExpandVec:       true,
+					ExpandVecMaxLen: 2,
+					MaxDepth:        5,
+				},
+			)),
 		)
 	}
 

--- a/pkg/vm/engine/readutil/expr_filter.go
+++ b/pkg/vm/engine/readutil/expr_filter.go
@@ -428,7 +428,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -462,7 +462,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -501,7 +501,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -540,7 +540,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -574,7 +574,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			isPK, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -608,7 +608,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -641,7 +641,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -675,7 +675,7 @@ func CompileFilterExpr(
 			}
 			vec := vector.NewVec(types.T_any.ToType())
 			_ = vec.UnmarshalBinary(val)
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			isPK, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -712,7 +712,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			fastFilterOp = nil
 			loadOp = loadMetadataOnlyOpFactory(fs)
 			seqNum := colDef.Seqnum
@@ -733,7 +733,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			fastFilterOp = nil
 			loadOp = loadMetadataOnlyOpFactory(fs)
 			seqNum := colDef.Seqnum
@@ -755,7 +755,7 @@ func CompileFilterExpr(
 			}
 			vec := vector.NewVec(types.T_any.ToType())
 			_ = vec.UnmarshalBinary(val)
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			isPK, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -809,7 +809,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
+			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			isPK, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {

--- a/pkg/vm/engine/readutil/expr_filter.go
+++ b/pkg/vm/engine/readutil/expr_filter.go
@@ -428,7 +428,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -462,7 +462,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -501,7 +501,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -540,7 +540,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -574,7 +574,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			isPK, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -608,7 +608,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -641,7 +641,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			_, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -675,7 +675,7 @@ func CompileFilterExpr(
 			}
 			vec := vector.NewVec(types.T_any.ToType())
 			_ = vec.UnmarshalBinary(val)
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			isPK, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -712,7 +712,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			fastFilterOp = nil
 			loadOp = loadMetadataOnlyOpFactory(fs)
 			seqNum := colDef.Seqnum
@@ -733,7 +733,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			fastFilterOp = nil
 			loadOp = loadMetadataOnlyOpFactory(fs)
 			seqNum := colDef.Seqnum
@@ -755,7 +755,7 @@ func CompileFilterExpr(
 			}
 			vec := vector.NewVec(types.T_any.ToType())
 			_ = vec.UnmarshalBinary(val)
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			isPK, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
@@ -809,7 +809,7 @@ func CompileFilterExpr(
 				canCompile = false
 				return
 			}
-			colDef := getColDefByName(colExpr.Col.Name, tableDef)
+			colDef := getColDefByName(colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			isPK, isSorted := isSortedKey(colDef)
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {

--- a/pkg/vm/engine/readutil/expr_util.go
+++ b/pkg/vm/engine/readutil/expr_util.go
@@ -78,7 +78,7 @@ func getColDefByName(expr *plan.Expr, name string, colPos int32, tableDef *plan.
 				zap.String("col-name", name),
 				zap.Int32("col-actual-pos", colPos),
 				zap.Int32("col-expected-pos", pos),
-				zap.String("col-expr", plan2.FormatExpr(expr)),
+				zap.String("col-expr", plan2.FormatExpr(expr, plan2.FormatOption{})),
 			)
 		}
 	})
@@ -121,7 +121,7 @@ func evalValue(
 				"Bad-ColExpr",
 				zap.String("col-name", colName),
 				zap.String("pk-name", pkName),
-				zap.String("col-expr", plan2.FormatExpr(expr)),
+				zap.String("col-expr", plan2.FormatExpr(expr, plan2.FormatOption{})),
 			)
 		}
 	})
@@ -146,7 +146,7 @@ func evalValue(
 				zap.String("col-name", colName),
 				zap.Int32("col-actual-pos", col.Col.ColPos),
 				zap.Int32("col-expected-pos", colPos),
-				zap.String("col-expr", plan2.FormatExpr(expr)),
+				zap.String("col-expr", plan2.FormatExpr(expr, plan2.FormatOption{})),
 			)
 		}
 	})
@@ -222,7 +222,7 @@ func getConstBytesFromExpr(exprs []*plan.Expr) ([][]byte, bool) {
 			vals[idx] = nil
 			vals[idx] = append(vals[idx], fExpr.Fold.Data...)
 		} else {
-			logutil.Warnf("const folded val expr is not a fold expr: %s\n", plan2.FormatExpr(exprs[idx]))
+			logutil.Warnf("const folded val expr is not a fold expr: %s\n", plan2.FormatExpr(exprs[idx], plan2.FormatOption{}))
 			return nil, false
 		}
 	}
@@ -271,7 +271,7 @@ func mustColVecValueFromBinaryFuncExpr(expr *plan.Expr_F) (*plan.Expr_Col, []byt
 			return colExpr, fExpr.Fold.Data, ok
 		}
 
-		logutil.Warnf("const folded val expr is not a vec expr: %s\n", plan2.FormatExpr(valExpr))
+		logutil.Warnf("const folded val expr is not a vec expr: %s\n", plan2.FormatExpr(valExpr, plan2.FormatOption{}))
 		return nil, nil, false
 	}
 

--- a/pkg/vm/engine/readutil/pk_filter_base.go
+++ b/pkg/vm/engine/readutil/pk_filter_base.go
@@ -181,7 +181,7 @@ func ConstructBasePKFilter(
 
 		case ">=":
 			//a >= ?
-			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
 			if !ok {
 				return
 			}
@@ -192,7 +192,7 @@ func ConstructBasePKFilter(
 
 		case "<=":
 			//a <= ?
-			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
 			if !ok {
 				return
 			}
@@ -203,7 +203,7 @@ func ConstructBasePKFilter(
 
 		case ">":
 			//a > ?
-			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
 			if !ok {
 				return
 			}
@@ -214,7 +214,7 @@ func ConstructBasePKFilter(
 
 		case "<":
 			//a < ?
-			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
 			if !ok {
 				return
 			}
@@ -225,7 +225,7 @@ func ConstructBasePKFilter(
 
 		case "=":
 			// a = ?
-			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
 			if !ok {
 				return
 			}
@@ -235,7 +235,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "prefix_eq":
-			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
 			if !ok {
 				return
 			}
@@ -245,7 +245,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "in":
-			ok, oid, vals := evalValue(expr, exprImpl, tblDef, true, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, true, tblDef.Pkey.PkeyColName)
 			if !ok {
 				return
 			}
@@ -261,7 +261,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "prefix_in":
-			ok, oid, vals := evalValue(expr, exprImpl, tblDef, true, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, true, tblDef.Pkey.PkeyColName)
 			if !ok {
 				return
 			}
@@ -277,7 +277,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "between":
-			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
 			if !ok {
 				return
 			}
@@ -288,7 +288,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "prefix_between":
-			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
 			if !ok {
 				return
 			}

--- a/pkg/vm/engine/readutil/pk_filter_base.go
+++ b/pkg/vm/engine/readutil/pk_filter_base.go
@@ -181,7 +181,7 @@ func ConstructBasePKFilter(
 
 		case ">=":
 			//a >= ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -192,7 +192,7 @@ func ConstructBasePKFilter(
 
 		case "<=":
 			//a <= ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -203,7 +203,7 @@ func ConstructBasePKFilter(
 
 		case ">":
 			//a > ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -214,7 +214,7 @@ func ConstructBasePKFilter(
 
 		case "<":
 			//a < ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -225,7 +225,7 @@ func ConstructBasePKFilter(
 
 		case "=":
 			// a = ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -235,7 +235,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "prefix_eq":
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -245,7 +245,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "in":
-			ok, oid, vals := evalValue(exprImpl, tblDef, true, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, true, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -261,7 +261,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "prefix_in":
-			ok, oid, vals := evalValue(exprImpl, tblDef, true, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, true, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -277,7 +277,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "between":
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -288,7 +288,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "prefix_between":
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}

--- a/pkg/vm/engine/readutil/pk_filter_base.go
+++ b/pkg/vm/engine/readutil/pk_filter_base.go
@@ -181,7 +181,7 @@ func ConstructBasePKFilter(
 
 		case ">=":
 			//a >= ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -192,7 +192,7 @@ func ConstructBasePKFilter(
 
 		case "<=":
 			//a <= ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -203,7 +203,7 @@ func ConstructBasePKFilter(
 
 		case ">":
 			//a > ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -214,7 +214,7 @@ func ConstructBasePKFilter(
 
 		case "<":
 			//a < ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -225,7 +225,7 @@ func ConstructBasePKFilter(
 
 		case "=":
 			// a = ?
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -235,7 +235,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "prefix_eq":
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -245,7 +245,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "in":
-			ok, oid, vals := evalValue(exprImpl, tblDef, true, tblDef.Pkey.PkeyColName)
+			ok, oid, vals := evalValue(exprImpl, tblDef, true, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -261,7 +261,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "prefix_in":
-			ok, oid, vals := evalValue(exprImpl, tblDef, true, tblDef.Pkey.PkeyColName)
+			ok, oid, vals := evalValue(exprImpl, tblDef, true, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -277,7 +277,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "between":
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}
@@ -288,7 +288,7 @@ func ConstructBasePKFilter(
 			filter.Oid = oid
 
 		case "prefix_between":
-			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
+			ok, oid, vals := evalValue(exprImpl, tblDef, false, tblDef.Pkey.PkeyColName, int32(tblDef.Pkey.PkeyColId))
 			if !ok {
 				return
 			}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21437 

## What this PR does / why we need it:

If the ColPos and ColName in pushdown's ColExpr do not match, panic. If ColName is empty, preferentially use ColPos


___

### **PR Type**
Bug fix


___

### **Description**
- Fix column position validation in filter expressions

- Add panic checks for mismatched column names and positions

- Update function signatures to include column position parameter

- Handle empty column names by using position fallback


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Filter Expression"] --> B["getColDefByName()"]
  B --> C["Validate ColName vs ColPos"]
  C --> D["Panic if Mismatch"]
  E["evalValue()"] --> F["Handle Empty ColName"]
  F --> G["Use ColPos Fallback"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expr_filter.go</strong><dd><code>Add column position parameter to filter operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/readutil/expr_filter.go

<li>Updated all <code>getColDefByName()</code> calls to include <code>colExpr.Col.ColPos</code> <br>parameter<br> <li> Modified function calls for comparison operators (<=, >=, >, <, =, <br>etc.)<br> <li> Added column position parameter to null/not-null checks<br> <li> Updated prefix and between operations with position validation


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22089/files#diff-bd714b5d8ad55fada8182386a9fb12cb9283b737e66d6c306b1ee52eceba6130">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>expr_util.go</strong><dd><code>Implement column validation and position handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/readutil/expr_util.go

<li>Added <code>fmt</code> import for panic formatting<br> <li> Modified <code>getColDefByName()</code> to accept <code>colPos</code> parameter and validate <br>consistency<br> <li> Added panic check when column name doesn't match expected position<br> <li> Updated <code>evalValue()</code> to handle empty column names and validate <br>positions<br> <li> Added <code>pkColId</code> parameter to <code>evalValue()</code> function signature


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22089/files#diff-aab2d3af9631d1dc36e026ecce4a636eddb25a2368da4358e8b8dc6a77ff8f28">+16/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pk_filter_base.go</strong><dd><code>Add primary key column ID to filter evaluations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/readutil/pk_filter_base.go

<li>Updated all <code>evalValue()</code> calls to include <code>int32(tblDef.Pkey.PkeyColId)</code> <br>parameter<br> <li> Modified comparison operations (>=, <=, >, <, =) with new parameter<br> <li> Updated prefix operations and IN/BETWEEN clauses with column ID <br>validation


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22089/files#diff-860bbc50718b2815d3647b5751be6c494cd4121fd7e49b1feb4b4fe1abe824b3">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>