### PR TITLE
[fix] always assign column name to runtime filter

### DIFF
--- a/pkg/sql/plan/explain/explain_expr.go
+++ b/pkg/sql/plan/explain/explain_expr.go
@@ -40,8 +40,12 @@ func describeMessage(m *plan.MsgHeader, buf *bytes.Buffer) {
 }
 
 func describeColRef(col *plan.ColRef, buf *bytes.Buffer) {
-	if len(col.Name) > 0 && !strings.HasPrefix(col.Name, catalog.PrefixIndexTableName) {
-		buf.WriteString(col.Name)
+	if len(col.Name) > 0 {
+		if strings.HasPrefix(col.Name, catalog.PrefixIndexTableName) {
+			buf.WriteString(strings.Split(col.Name, ".")[1])
+		} else {
+			buf.WriteString(col.Name)
+		}
 	} else {
 		buf.WriteString("#[")
 		buf.WriteString(strconv.Itoa(int(col.RelPos)))

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -351,6 +351,11 @@ func (builder *QueryBuilder) remapAllColRefs(nodeID int32, step int32, colRefCnt
 				if err != nil {
 					return nil, err
 				}
+
+				col := rfSpec.Expr.GetCol()
+				if len(col.Name) == 0 {
+					col.Name = node.TableDef.Cols[col.ColPos].Name
+				}
 			}
 		}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21437

## What this PR does / why we need it:
Filter logic in Reader relies on column name.