### PR TITLE
enable new DML plan for tables with vector columns

### DIFF
--- a/pkg/sql/plan/dml_context.go
+++ b/pkg/sql/plan/dml_context.go
@@ -17,7 +17,6 @@ package plan
 import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
-	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
@@ -230,12 +229,6 @@ func (dmlCtx *DMLContext) ResolveSingleTable(ctx CompilerContext, tbl tree.Table
 
 	if checkFK && (len(tableDef.Fkeys) > 0 || len(tableDef.RefChildTbls) > 0) {
 		return moerr.NewUnsupportedDML(ctx.GetContext(), "foreign key constraint")
-	}
-
-	for _, col := range tableDef.Cols {
-		if types.T(col.Typ.Id).IsArrayRelate() {
-			return moerr.NewUnsupportedDML(ctx.GetContext(), "vector column")
-		}
 	}
 
 	isClusterTable := util.TableIsClusterTable(tableDef.GetTableType())


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22020

## What this PR does / why we need it:
refactored DML has better support for REPLACE INTO SELECT


___

### **PR Type**
Enhancement


___

### **Description**
- Remove vector column restriction from DML operations

- Enable new DML plan for tables with vector columns


___

### **Changes diagram**

```mermaid
flowchart LR
  A["DML Context"] --> B["Table Resolution"]
  B --> C["Vector Column Check"]
  C --> D["Remove Restriction"]
  D --> E["Enable New DML Plan"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dml_context.go</strong><dd><code>Remove vector column DML restriction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/dml_context.go

<li>Remove import of <code>types</code> package<br> <li> Delete vector column validation loop in <code>ResolveSingleTable</code><br> <li> Remove error return for vector column unsupported DML


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22092/files#diff-6e952c10166b807c3a9ef06cde3d549ebbee6e29eb2ffd1aeceb9eab8590fd3e">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>