### PR TITLE
cdc frequency fix + createSql build bug fix

### DIFF
--- a/pkg/cdc/sinker.go
+++ b/pkg/cdc/sinker.go
@@ -103,8 +103,15 @@ var NewSinker = func(
 	if len(createSql) < len(createTableIfNotExists) || !strings.EqualFold(createSql[:len(createTableIfNotExists)], createTableIfNotExists) {
 		createSql = createTableIfNotExists + createSql[len(createTable):]
 	}
-	createSql = strings.ReplaceAll(createSql, dbTblInfo.SourceDbName, dbTblInfo.SinkDbName)
-	createSql = strings.ReplaceAll(createSql, dbTblInfo.SourceTblName, dbTblInfo.SinkTblName)
+	tableStart := len(createTableIfNotExists)
+	tableEnd := strings.Index(createSql, "(")
+	newTablePart := ""
+	if dbTblInfo.SinkDbName != "" {
+		newTablePart = dbTblInfo.SinkDbName + "." + dbTblInfo.SinkTblName
+	} else {
+		newTablePart = dbTblInfo.SinkTblName
+	}
+	createSql = createSql[:tableStart] + " " + newTablePart + createSql[tableEnd:]
 	_ = sink.Send(ctx, ar, []byte(padding+createSql), false)
 
 	return NewMysqlSinker(

--- a/pkg/frontend/cdc_options.go
+++ b/pkg/frontend/cdc_options.go
@@ -205,6 +205,7 @@ func (opts *CDCCreateTaskOptions) ValidateAndFill(
 				opts.ConfigFile = value
 			}
 		case cdc.CDCRequestOptions_Frequency:
+			extraOpts[cdc.CDCTaskExtraOptions_Frequency] = ""
 			if value != "" {
 				if err = opts.handleFrequency(ctx, ses, req, level, value); err != nil {
 					return

--- a/pkg/frontend/cdc_options.go
+++ b/pkg/frontend/cdc_options.go
@@ -209,8 +209,8 @@ func (opts *CDCCreateTaskOptions) ValidateAndFill(
 				if err = opts.handleFrequency(ctx, ses, req, level, value); err != nil {
 					return
 				}
-				extraOpts[cdc.CDCTaskExtraOptions_Frequency] = value
 			}
+			extraOpts[cdc.CDCTaskExtraOptions_Frequency] = value
 		}
 	}
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22086

## What this PR does / why we need it:
exec.additionalConfig[cdc.CDCTaskExtraOptions_Frequency] would not be nil
A bug when building the createSql is also by the way fixed.

___

### **PR Type**
Bug fix


___

### **Description**
- Fix CDC task creation failure when frequency option is empty

- Ensure `extraOpts[cdc.CDCTaskExtraOptions_Frequency]` is always set


___

### **Changes diagram**

```mermaid
flowchart LR
  A["CDC Task Creation"] --> B["Frequency Option Processing"]
  B --> C["Set extraOpts[Frequency]"]
  C --> D["Task Creation Success"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cdc_options.go</strong><dd><code>Fix frequency option assignment logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/cdc_options.go

<li>Move frequency option assignment outside the empty value check<br> <li> Ensure <code>extraOpts[cdc.CDCTaskExtraOptions_Frequency]</code> is always set <br>regardless of value


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22093/files#diff-b0822c012970381e6c2c1e5b825c5cbbe640b0dc77f7b8fad3183dc1e1f2bb2c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>