### PR TITLE
BUG FIX: index generated by for loop didn't pass as go function argument leads to undetermined index

### DIFF
--- a/pkg/fulltext/fixedbytepool.go
+++ b/pkg/fulltext/fixedbytepool.go
@@ -423,13 +423,13 @@ func (pool *FixedBytePool) Spill() error {
 	for i := 0; i < int(nspill); i++ {
 		wg.Add(1)
 
-		go func() {
+		go func(tid int) {
 			defer wg.Done()
-			err := pool.partitions[lru[i].id].Spill()
+			err := pool.partitions[lru[tid].id].Spill()
 			if err != nil {
 				errs = errors.Join(errs, err)
 			}
-		}()
+		}(i)
 	}
 
 	wg.Wait()

--- a/pkg/sql/colexec/productl2/product_l2.go
+++ b/pkg/sql/colexec/productl2/product_l2.go
@@ -255,11 +255,11 @@ func probeRun[T types.RealNumbers](ctr *container, ap *Productl2, proc *process.
 	for n := 0; n < ncpu; n++ {
 
 		wg.Add(1)
-		go func() {
+		go func(tid int) {
 			defer wg.Done()
 			for j := 0; j < probeCount; j++ {
 
-				if j%ncpu != n {
+				if j%ncpu != tid {
 					continue
 				}
 
@@ -306,7 +306,7 @@ func probeRun[T types.RealNumbers](ctr *container, ap *Productl2, proc *process.
 					return
 				}
 			}
-		}()
+		}(n)
 	}
 
 	wg.Wait()

--- a/pkg/vectorindex/hnsw/build_test.go
+++ b/pkg/vectorindex/hnsw/build_test.go
@@ -78,15 +78,15 @@ func TestBuildMulti(t *testing.T) {
 	var wg sync.WaitGroup
 	for j := 0; j < nthread; j++ {
 		wg.Add(1)
-		go func() {
+		go func(tid int) {
 			defer wg.Done()
 
 			for i := 0; i < nitem; i++ {
-				key := j*nitem + i
+				key := tid*nitem + i
 				err := build.Add(int64(key), sample[key])
 				require.Nil(t, err)
 			}
-		}()
+		}(j)
 	}
 	wg.Wait()
 
@@ -133,10 +133,10 @@ func TestBuildMulti(t *testing.T) {
 	var wg2 sync.WaitGroup
 	for j := 0; j < nthread; j++ {
 		wg2.Add(1)
-		go func() {
+		go func(tid int) {
 			defer wg2.Done()
 			for i := 0; i < nitem; i++ {
-				key := int64(j*nitem + i)
+				key := int64(tid*nitem + i)
 				anykeys, distances, err := search.Search(nil, sample[key], vectorindex.RuntimeConfig{Limit: 10})
 				require.Nil(t, err)
 				keys, ok := anykeys.([]int64)
@@ -149,7 +149,7 @@ func TestBuildMulti(t *testing.T) {
 					require.True(t, found)
 				}
 			}
-		}()
+		}(j)
 	}
 
 	wg2.Wait()
@@ -231,15 +231,15 @@ func TestBuildSingleThread(t *testing.T) {
 	var wg sync.WaitGroup
 	for j := 0; j < nthread; j++ {
 		wg.Add(1)
-		go func() {
+		go func(tid int) {
 			defer wg.Done()
 
 			for i := 0; i < nitem; i++ {
-				key := j*nitem + i
+				key := tid*nitem + i
 				err := build.Add(int64(key), sample[key])
 				require.Nil(t, err)
 			}
-		}()
+		}(j)
 	}
 	wg.Wait()
 
@@ -299,10 +299,10 @@ func TestBuildSingleThread(t *testing.T) {
 	var wg2 sync.WaitGroup
 	for j := 0; j < nthread; j++ {
 		wg2.Add(1)
-		go func() {
+		go func(tid int) {
 			defer wg2.Done()
 			for i := 0; i < nitem; i++ {
-				key := int64(j*nitem + i)
+				key := int64(tid*nitem + i)
 				anykeys, distances, err := search.Search(nil, sample[key], vectorindex.RuntimeConfig{Limit: 10})
 				require.Nil(t, err)
 				keys, ok := anykeys.([]int64)
@@ -315,7 +315,7 @@ func TestBuildSingleThread(t *testing.T) {
 					require.True(t, found)
 				}
 			}
-		}()
+		}(j)
 	}
 
 	wg2.Wait()

--- a/pkg/vectorindex/hnsw/search.go
+++ b/pkg/vectorindex/hnsw/search.go
@@ -230,10 +230,10 @@ func (s *HnswSearch) Search(proc *process.Process, anyquery any, rt vectorindex.
 
 	for i := 0; i < nthread; i++ {
 		wg.Add(1)
-		go func() {
+		go func(tid int) {
 			defer wg.Done()
 			for j, idx := range s.Indexes {
-				if j%nthread == i {
+				if j%nthread == tid {
 					keys, distances, err := idx.Search(query, limit)
 					if err != nil {
 						errs = errors.Join(errs, err)
@@ -245,7 +245,7 @@ func (s *HnswSearch) Search(proc *process.Process, anyquery any, rt vectorindex.
 					}
 				}
 			}
-		}()
+		}(i)
 	}
 
 	wg.Wait()

--- a/pkg/vectorindex/ivfflat/kmeans/elkans/clusterer.go
+++ b/pkg/vectorindex/ivfflat/kmeans/elkans/clusterer.go
@@ -272,10 +272,10 @@ func (km *ElkanClusterer[T]) initBounds() error {
 
 	for n := 0; n < ncpu; n++ {
 		wg.Add(1)
-		go func() {
+		go func(tid int) {
 			defer wg.Done()
 			for x := range km.vectorList {
-				if x%ncpu != n {
+				if x%ncpu != tid {
 					continue
 				}
 				minDist := metric.MaxFloat[T]()
@@ -297,7 +297,7 @@ func (km *ElkanClusterer[T]) initBounds() error {
 				km.vectorMetas[x].upper = minDist
 				km.assignments[x] = closestCenter
 			}
-		}()
+		}(n)
 	}
 
 	wg.Wait()
@@ -322,10 +322,10 @@ func (km *ElkanClusterer[T]) computeCentroidDistances() error {
 
 	for n := 0; n < ncpu; n++ {
 		wg.Add(1)
-		go func() {
+		go func(tid int) {
 			defer wg.Done()
 			for i := 0; i < km.clusterCnt; i++ {
-				if i%ncpu != n {
+				if i%ncpu != tid {
 					continue
 				}
 				for j := i + 1; j < km.clusterCnt; j++ {
@@ -340,7 +340,7 @@ func (km *ElkanClusterer[T]) computeCentroidDistances() error {
 
 				}
 			}
-		}()
+		}(n)
 	}
 	wg.Wait()
 
@@ -378,12 +378,12 @@ func (km *ElkanClusterer[T]) assignData() (int, error) {
 	for n := 0; n < ncpu; n++ {
 
 		wg.Add(1)
-		go func() {
+		go func(tid int) {
 			defer wg.Done()
 
 			for currVector := range km.vectorList {
 
-				if currVector%ncpu != n {
+				if currVector%ncpu != tid {
 					continue
 				}
 				// step 2
@@ -451,7 +451,7 @@ func (km *ElkanClusterer[T]) assignData() (int, error) {
 					}
 				}
 			}
-		}()
+		}(n)
 	}
 
 	wg.Wait()

--- a/pkg/vectorindex/ivfflat/kmeans/elkans/initializer.go
+++ b/pkg/vectorindex/ivfflat/kmeans/elkans/initializer.go
@@ -119,12 +119,12 @@ func (kpp *KMeansPlusPlus[T]) InitCentroids(_vectors any, k int) (_centroids any
 		for n := 0; n < ncpu; n++ {
 			wg.Add(1)
 
-			go func() {
+			go func(tid int) {
 				defer wg.Done()
 
 				for vecIdx := range vectors {
 
-					if vecIdx%ncpu != n {
+					if vecIdx%ncpu != tid {
 						continue
 					}
 
@@ -145,7 +145,7 @@ func (kpp *KMeansPlusPlus[T]) InitCentroids(_vectors any, k int) (_centroids any
 					totalDistToExistingCenters += distances[vecIdx]
 					mutex.Unlock()
 				}
-			}()
+			}(n)
 		}
 
 		wg.Wait()

--- a/pkg/vectorindex/ivfflat/search.go
+++ b/pkg/vectorindex/ivfflat/search.go
@@ -148,10 +148,10 @@ func (idx *IvfflatSearchIndex[T]) findCentroids(proc *process.Process, query []T
 	var wg sync.WaitGroup
 	for n := 0; n < nworker; n++ {
 		wg.Add(1)
-		go func() {
+		go func(tid int) {
 			defer wg.Done()
 			for i, c := range idx.Centroids {
-				if i%nworker != n {
+				if i%nworker != tid {
 					continue
 				}
 				dist, err := distfn(query, c.Vec)
@@ -161,7 +161,7 @@ func (idx *IvfflatSearchIndex[T]) findCentroids(proc *process.Process, query []T
 				}
 				heap.Push(&vectorindex.SearchResult{Id: c.Id, Distance: float64(dist)})
 			}
-		}()
+		}(n)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22117

## What this PR does / why we need it:

local index generated by for loop must be passed to go func as argument.