### PR TITLE
cherry pick clean log from main to 2.2

### DIFF
--- a/pkg/frontend/compiler_context.go
+++ b/pkg/frontend/compiler_context.go
@@ -287,20 +287,27 @@ func ShouldSwitchToSysAccount(dbName string, tableName string) bool {
 }
 
 // getRelation returns the context (maybe updated) and the relation
-func (tcc *TxnCompilerContext) getRelation(dbName string, tableName string, sub *plan.SubscriptionMeta, snapshot *plan2.Snapshot) (context.Context, engine.Relation, error) {
+func (tcc *TxnCompilerContext) getRelation(
+	dbName string,
+	tableName string,
+	sub *plan.SubscriptionMeta,
+	snapshot *plan2.Snapshot,
+) (context.Context, engine.Relation, error) {
 	dbName, _, err := tcc.ensureDatabaseIsNotEmpty(dbName, false, snapshot)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	start := time.Now()
+	var (
+		start   = time.Now()
+		ses     = tcc.GetSession()
+		txn     = tcc.GetTxnHandler().GetTxn()
+		tempCtx = tcc.execCtx.reqCtx
+	)
+
 	defer func() {
 		v2.GetRelationDurationHistogram.Observe(time.Since(start).Seconds())
 	}()
-
-	ses := tcc.GetSession()
-	txn := tcc.GetTxnHandler().GetTxn()
-	tempCtx := tcc.execCtx.reqCtx
 
 	if plan2.IsSnapshotValid(snapshot) && snapshot.TS.Less(txn.Txn().SnapshotTS) {
 		txn = txn.CloneSnapshotOp(*snapshot.TS)
@@ -326,44 +333,51 @@ func (tcc *TxnCompilerContext) getRelation(dbName string, tableName string, sub 
 		tempCtx = defines.AttachAccountId(tempCtx, uint32(sysAccountID))
 	}
 
-	start1 := time.Now()
+	start = time.Now()
+
+	var (
+		db    engine.Database
+		table engine.Relation
+	)
 
 	//open database
-	db, err := tcc.GetTxnHandler().GetStorage().Database(tempCtx, dbName, txn)
-	if err != nil {
-		ses.Error(tempCtx,
-			"Failed to get database",
-			zap.String("databaseName", dbName),
-			zap.Error(err))
+	if db, err = tcc.GetTxnHandler().GetStorage().Database(
+		tempCtx, dbName, txn,
+	); err != nil {
+		ses.Error(
+			tempCtx,
+			"fe-get-database-failed",
+			zap.String("db-name", dbName),
+			zap.Error(err),
+		)
 		return nil, nil, err
+	} else {
+		v2.OpenDBDurationHistogram.Observe(time.Since(start).Seconds())
 	}
 
-	v2.OpenDBDurationHistogram.Observe(time.Since(start1).Seconds())
+	start = time.Now()
 
-	// tableNames, err := db.Relations(ctx)
-	// if err != nil {
-	// 	return nil, nil, err
-	// }
-	// logDebugf(ses.GetDebugString(), "dbName %v tableNames %v", dbName, tableNames)
-
-	start2 := time.Now()
-
-	//open table
-	table, err := db.Relation(tempCtx, tableName, nil)
-	if err != nil {
-		tmpTable, e := tcc.getTmpRelation(tempCtx, engine.GetTempTableName(dbName, tableName))
-		if e != nil {
-			ses.Error(tempCtx,
-				"Failed to get table",
-				zap.String("tableName", tableName),
-				zap.Error(err))
+	if table, err = db.Relation(tempCtx, tableName, nil); err != nil {
+		// quick return if the error is not ErrNoSuchTable
+		if !moerr.IsMoErrCode(err, moerr.ErrNoSuchTable) {
 			return nil, nil, err
+		}
+		// for ErrNoSuchTable, try to get from the temp engine
+		eng := tcc.GetTxnHandler().GetStorage()
+		if !eng.HasTempEngine() {
+			// PXU: why not return err???
+			return nil, nil, nil
+		}
+		// get from the temp engine
+		tmpTableName := engine.GetTempTableName(dbName, tableName)
+		if tmpTable, err2 := tcc.getTmpRelation(tempCtx, tmpTableName); err2 != nil {
+			return nil, nil, nil
 		} else {
 			table = tmpTable
 		}
 	}
 
-	v2.OpenTableDurationHistogram.Observe(time.Since(start2).Seconds())
+	v2.OpenTableDurationHistogram.Observe(time.Since(start).Seconds())
 
 	return tempCtx, table, nil
 }

--- a/pkg/frontend/test/engine_mock.go
+++ b/pkg/frontend/test/engine_mock.go
@@ -2055,6 +2055,19 @@ func (mr *MockEngineMockRecorder) LatestLogtailAppliedTime() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestLogtailAppliedTime", reflect.TypeOf((*MockEngine)(nil).LatestLogtailAppliedTime))
 }
 
+// HasTempEngine mocks base method.
+func (m *MockEngine) HasTempEngine() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasTempEngine")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (mr *MockEngineMockRecorder) HasTempEngine() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasTempEngine", reflect.TypeOf((*MockEngine)(nil).HasTempEngine))
+}
+
 // New mocks base method.
 func (m *MockEngine) New(ctx context.Context, op client.TxnOperator) error {
 	m.ctrl.T.Helper()

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -1003,22 +1003,30 @@ func (s *Scope) CreateTable(c *Compile) error {
 	}
 
 	// check in EntireEngine.TempEngine, notice that TempEngine may not init
-	tmpDBSource, err := c.e.Database(c.proc.Ctx, defines.TEMPORARY_DBNAME, c.proc.GetTxnOperator())
-	if err == nil {
-		exists, err := tmpDBSource.RelationExists(c.proc.Ctx, engine.GetTempTableName(dbName, tblName), nil)
-		if err != nil {
-			c.proc.Error(c.proc.Ctx, "check temporary table relation exists failed",
-				zap.String("databaseName", c.db),
-				zap.String("tableName", tblName),
-				zap.Error(err),
-			)
-			return err
-		}
-		if exists {
-			if qry.GetIfNotExists() {
-				return nil
+	if c.e.HasTempEngine() {
+		var tmpDBSource engine.Database
+		if tmpDBSource, err = c.e.Database(
+			c.proc.Ctx,
+			defines.TEMPORARY_DBNAME,
+			c.proc.GetTxnOperator(),
+		); err == nil {
+			exists, err := tmpDBSource.RelationExists(c.proc.Ctx, engine.GetTempTableName(dbName, tblName), nil)
+			if err != nil {
+				c.proc.Error(
+					c.proc.Ctx,
+					"temp-table-exists-check-failed",
+					zap.String("db-name", dbName),
+					zap.String("table-name", tblName),
+					zap.Error(err),
+				)
+				return err
 			}
-			return moerr.NewTableAlreadyExists(c.proc.Ctx, fmt.Sprintf("temporary '%s'", tblName))
+			if exists {
+				if qry.GetIfNotExists() {
+					return nil
+				}
+				return moerr.NewTableAlreadyExists(c.proc.Ctx, fmt.Sprintf("temporary '%s'", tblName))
+			}
 		}
 	}
 
@@ -1559,22 +1567,34 @@ func (s *Scope) CreateView(c *Compile) error {
 	}
 
 	// check in EntireEngine.TempEngine, notice that TempEngine may not init
-	tmpDBSource, err := c.e.Database(c.proc.Ctx, defines.TEMPORARY_DBNAME, c.proc.GetTxnOperator())
-	if err == nil {
-		exists, err = tmpDBSource.RelationExists(c.proc.Ctx, engine.GetTempTableName(dbName, viewName), nil)
-		if err != nil {
-			c.proc.Error(c.proc.Ctx, "check temporary table relation exists failed",
-				zap.String("databaseName", c.db),
-				zap.String("tableName", viewName),
-				zap.Error(err),
+	if c.e.HasTempEngine() {
+		var tmpDBSource engine.Database
+		if tmpDBSource, err = c.e.Database(
+			c.proc.Ctx,
+			defines.TEMPORARY_DBNAME,
+			c.proc.GetTxnOperator(),
+		); err == nil {
+			exists, err := tmpDBSource.RelationExists(
+				c.proc.Ctx,
+				engine.GetTempTableName(dbName, viewName),
+				nil,
 			)
-			return err
-		}
-		if exists {
-			if qry.GetIfNotExists() {
-				return nil
+			if err != nil {
+				c.proc.Error(
+					c.proc.Ctx,
+					"temp-table-exists-check-failed",
+					zap.String("db-name", dbName),
+					zap.String("table-name", viewName),
+					zap.Error(err),
+				)
+				return err
 			}
-			return moerr.NewTableAlreadyExists(c.proc.Ctx, fmt.Sprintf("temporary '%s'", viewName))
+			if exists {
+				if qry.GetIfNotExists() {
+					return nil
+				}
+				return moerr.NewTableAlreadyExists(c.proc.Ctx, fmt.Sprintf("temporary '%s'", viewName))
+			}
 		}
 	}
 

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -213,6 +213,7 @@ func TestScope_CreateTable(t *testing.T) {
 
 		eng := mock_frontend.NewMockEngine(ctrl)
 		mockDbMeta := mock_frontend.NewMockDatabase(ctrl)
+		eng.EXPECT().HasTempEngine().Return(false).AnyTimes()
 		eng.EXPECT().Database(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockDbMeta, nil).AnyTimes()
 
 		mockDbMeta.EXPECT().RelationExists(gomock.Any(), "dept", gomock.Any()).Return(false, moerr.NewInternalErrorNoCtx("test"))
@@ -251,6 +252,7 @@ func TestScope_CreateTable(t *testing.T) {
 		mockDbMeta2.EXPECT().RelationExists(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, moerr.NewInternalErrorNoCtx("test"))
 
 		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().HasTempEngine().Return(true).AnyTimes()
 		eng.EXPECT().Database(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, name string, arg any) (engine.Database, error) {
 			if name == defines.TEMPORARY_DBNAME {
 				return mockDbMeta2, nil
@@ -283,6 +285,7 @@ func TestScope_CreateTable(t *testing.T) {
 		mockDbMeta.EXPECT().Relation(gomock.Any(), catalog.MO_DATABASE, gomock.Any()).Return(relation, nil).AnyTimes()
 
 		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().HasTempEngine().Return(false).AnyTimes()
 		eng.EXPECT().Database(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockDbMeta, nil).AnyTimes()
 
 		planDef2ExecDef := gostub.Stub(&engine.PlanDefsToExeDefs, func(_ *plan.TableDef) ([]engine.TableDef, error) {
@@ -316,6 +319,7 @@ func TestScope_CreateTable(t *testing.T) {
 		mockDbMeta.EXPECT().RelationExists(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil).AnyTimes()
 
 		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().HasTempEngine().Return(false).AnyTimes()
 		eng.EXPECT().Database(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockDbMeta, nil).AnyTimes()
 
 		lockMoDb := gostub.Stub(&lockMoDatabase, func(_ *Compile, _ string, _ lock.LockMode) error {
@@ -355,6 +359,7 @@ func TestScope_CreateTable(t *testing.T) {
 		mockDbMeta.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).Return(moerr.NewInternalErrorNoCtx("test err")).AnyTimes()
 
 		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().HasTempEngine().Return(false).AnyTimes()
 		eng.EXPECT().Database(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockDbMeta, nil).AnyTimes()
 
 		lockMoDb := gostub.Stub(&lockMoDatabase, func(_ *Compile, _ string, _ lock.LockMode) error {
@@ -403,6 +408,7 @@ func TestScope_CreateTable(t *testing.T) {
 		}).AnyTimes()
 
 		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().HasTempEngine().Return(false).AnyTimes()
 		eng.EXPECT().Database(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockDbMeta, nil).AnyTimes()
 
 		planDef2ExecDef := gostub.Stub(&engine.PlanDefsToExeDefs, func(tbl *plan.TableDef) ([]engine.TableDef, error) {

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -619,7 +619,8 @@ func (s *Scope) getRelData(c *Compile, blockExprList []*plan.Expr) error {
 	average := float64(s.DataSource.node.Stats.BlockNum / s.NodeInfo.CNCNT)
 	if commited.DataCnt() < int(average*0.8) ||
 		commited.DataCnt() > int(average*1.2) {
-		logutil.Warnf("workload  table %v maybe not balanced! stats blocks %v, cncnt %v cnidx %v average %v , get %v blocks",
+		logutil.Warnf(
+			"workload table %v maybe not balanced! stats blocks %v, cncnt %v cnidx %v average %v , get %v blocks",
 			s.DataSource.TableDef.Name,
 			s.DataSource.node.Stats.BlockNum,
 			s.NodeInfo.CNCNT,

--- a/pkg/txn/trace/service.go
+++ b/pkg/txn/trace/service.go
@@ -422,7 +422,7 @@ func (s *service) watch(ctx context.Context) {
 			ctx,
 			func(txn executor.TxnExecutor) error {
 				sql := fmt.Sprintf("select name, state from %s.%s", DebugDB, FeaturesTables)
-				res, err := txn.Exec(sql, executor.StatementOption{})
+				res, err := txn.Exec(sql, executor.StatementOption{}.WithDisableLog())
 				if err != nil {
 					return err
 				}

--- a/pkg/util/export/batch_processor.go
+++ b/pkg/util/export/batch_processor.go
@@ -217,18 +217,23 @@ func (b *bufferHolder) Add(item batchpipe.HasName, needAggr bool) {
 }
 
 func (b *bufferHolder) loopAggr() {
-	logger := b.c.logger.With(zap.String("name", b.name)).Named("bufferHolder")
-	interval := time.Second
+	var (
+		lastPrintTime time.Time
+		logger        = b.c.logger.With(zap.String("name", b.name)).Named("bufferHolder")
+		loopInterval  = time.Second
+		printInterval = time.Minute * 10
+		recordCnt     = 0
+	)
 	if b.aggr == nil {
 		logger.Warn("no aggregator available, just quit this loop")
 		return
 	}
 	counter := v2.GetTraceMOLoggerAggrCounter(b.name)
-	logger.Info("start")
+	logutil.Info("handle-aggr-start")
 mainL:
 	for {
 		select {
-		case <-time.After(interval):
+		case <-time.After(loopInterval):
 			// handle aggr
 			end := time.Now().Truncate(b.aggr.GetWindow())
 			results := b.aggr.PopResultsBeforeWindow(end)
@@ -237,19 +242,28 @@ mainL:
 				b.Add(item, false)
 				counter.Inc()
 			}
-			logger.Info("handle aggr", zap.Int("records", len(results)), zap.Time("end", end))
+			recordCnt += len(results)
+			if time.Since(lastPrintTime) > printInterval {
+				logutil.Info(
+					"handle-aggr",
+					zap.Int("records", recordCnt),
+					zap.Time("end", end),
+				)
+				recordCnt = 0
+				lastPrintTime = time.Now()
+			}
 			// END> handle aggr
 
 		case <-b.bgCtx.Done():
 			// trigger by b.bgCancel
-			logger.Info("exiting loopAggr", zap.String("cause", "bgCtx.Done"))
+			logger.Info("handle-aggr-bgctx-done")
 			break mainL
 		case <-b.ctx.Done():
-			logger.Info("exiting loopAggr", zap.String("cause", "ctx.Done"))
+			logutil.Info("handle-aggr-ctx-done")
 			break mainL
 		}
 	}
-	logger.Info("exit loopAggr")
+	logutil.Info("handle-aggr-exit")
 }
 
 var _ generateReq = (*bufferGenerateReq)(nil)
@@ -417,7 +431,7 @@ func NewMOCollector(
 		generatorCntP:  20,
 		exporterCntP:   80,
 		pipeImplHolder: newPipeImplHolder(),
-		statsInterval:  time.Minute,
+		statsInterval:  5 * time.Minute,
 		maxBufferCnt:   int32(runtime.NumCPU()),
 	}
 	c.bufferCond = sync.NewCond(&c.bufferMux)

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -820,3 +820,7 @@ func (e *Engine) PackerPool() *fileservice.Pool[*types.Packer] {
 func (e *Engine) LatestLogtailAppliedTime() timestamp.Timestamp {
 	return e.pClient.LatestLogtailAppliedTime()
 }
+
+func (e *Engine) HasTempEngine() bool {
+	return false
+}

--- a/pkg/vm/engine/entire_engine.go
+++ b/pkg/vm/engine/entire_engine.go
@@ -42,6 +42,10 @@ func (e *EntireEngine) LatestLogtailAppliedTime() timestamp.Timestamp {
 	return e.Engine.LatestLogtailAppliedTime()
 }
 
+func (e *EntireEngine) HasTempEngine() bool {
+	return e.TempEngine != nil
+}
+
 func (e *EntireEngine) Delete(ctx context.Context, databaseName string, op client.TxnOperator) error {
 	return e.Engine.Delete(ctx, databaseName, op)
 }

--- a/pkg/vm/engine/entire_engine_test.go
+++ b/pkg/vm/engine/entire_engine_test.go
@@ -310,6 +310,10 @@ func (e *testEngine) Hints() (h Hints) {
 	return
 }
 
+func (e *testEngine) HasTempEngine() bool {
+	return false
+}
+
 func (e *testEngine) GetNameById(ctx context.Context, op client.TxnOperator, tableId uint64) (dbName string, tblName string, err error) {
 	return "", "", nil
 }

--- a/pkg/vm/engine/memoryengine/binded.go
+++ b/pkg/vm/engine/memoryengine/binded.go
@@ -42,6 +42,10 @@ func (b *BindedEngine) LatestLogtailAppliedTime() timestamp.Timestamp {
 	return b.engine.LatestLogtailAppliedTime()
 }
 
+func (b *BindedEngine) HasTempEngine() bool {
+	return b.engine.HasTempEngine()
+}
+
 func (b *BindedEngine) Commit(ctx context.Context, _ client.TxnOperator) error {
 	return b.engine.Commit(ctx, b.txnOp)
 }

--- a/pkg/vm/engine/memoryengine/engine.go
+++ b/pkg/vm/engine/memoryengine/engine.go
@@ -62,6 +62,10 @@ func (e *Engine) LatestLogtailAppliedTime() timestamp.Timestamp {
 	return timestamp.Timestamp{}
 }
 
+func (e *Engine) HasTempEngine() bool {
+	return false
+}
+
 func (e *Engine) GetService() string {
 	return e.sid
 }

--- a/pkg/vm/engine/tae/db/cronjobs.go
+++ b/pkg/vm/engine/tae/db/cronjobs.go
@@ -130,8 +130,6 @@ func AddCronJob(db *DB, name string, skipMode bool) (err error) {
 			CronJobs_Name_GCTransferTable,
 			db.Opts.CheckpointCfg.TransferInterval,
 			func(context.Context) {
-				db.Runtime.PoolUsageReport()
-				// dbutils.PrintMemStats()
 				db.Runtime.TransferDelsMap.Prune(db.Opts.TransferTableTTL)
 				db.Runtime.TransferTable.RunTTL()
 			},
@@ -211,6 +209,7 @@ func AddCronJob(db *DB, name string, skipMode bool) (err error) {
 			CronJobs_Name_GCLockMerge,
 			options.DefaultLockMergePruneInterval,
 			func(ctx context.Context) {
+				db.Runtime.PoolUsageReport()
 				db.Runtime.LockMergeService.Prune()
 			},
 			1,
@@ -236,19 +235,6 @@ func AddCronJob(db *DB, name string, skipMode bool) (err error) {
 			1,
 		)
 		return
-		// case CronJobs_Name_Scanner:
-		// scanner := NewDBScanner(db, nil)
-		// db.MergeScheduler = merge.NewScheduler(db.Runtime, merge.NewTaskServiceGetter(db.Opts.TaskServiceGetter))
-		// scanner.RegisterOp(db.MergeScheduler)
-		// err = db.CronJobs.AddJob(
-		// 	CronJobs_Name_Scanner,
-		// 	db.Opts.CheckpointCfg.ScanInterval,
-		// 	func(ctx context.Context) {
-		// 		scanner.OnExec()
-		// 	},
-		// 	1,
-		// )
-		// return
 	}
 	err = moerr.NewInternalErrorNoCtxf(
 		"unknown cron job name: %s", name,

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -1138,6 +1138,8 @@ type Engine interface {
 	GetService() string
 
 	LatestLogtailAppliedTime() timestamp.Timestamp
+
+	HasTempEngine() bool
 }
 
 type VectorPool interface {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22101 

## What this PR does / why we need it:

clean log


___

### **PR Type**
Enhancement


___

### **Description**
- Clean up logging and error handling across multiple components

- Add `HasTempEngine()` method to engine interfaces for better temp table handling

- Improve code formatting and variable declarations

- Reduce verbose logging frequency in batch processor


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Engine Interface"] --> B["HasTempEngine() Method"]
  C["Frontend Context"] --> D["Improved Error Handling"]
  E["Batch Processor"] --> F["Reduced Log Frequency"]
  G["DDL Operations"] --> H["Better Temp Table Checks"]
  B --> H
  D --> H
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>compiler_context.go</strong><dd><code>Refactor getRelation method with better error handling</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-2e1e8cbf97f9cd34095a0a6b95d33456cb53dad2c6fec7eb9cd37893b8048b8b">+46/-32</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ddl.go</strong><dd><code>Improve temp table existence checks with HasTempEngine</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-819bfdf891fa506cb2b4c89006896d528675fd554c341f38d1a1bf14a496c8aa">+49/-29</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>service.go</strong><dd><code>Disable logging for trace feature queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-f71ec5387e2f184c24cfd2e0bdac6ea2e076366aeea51e7364bd20f4972f8ca5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batch_processor.go</strong><dd><code>Reduce logging frequency and improve log messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-618ee6d9354fed818b28e1e019e9ca0859723211ff136e7c8fb851cc8cf2b2ea">+23/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>engine.go</strong><dd><code>Implement HasTempEngine method returning false</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-66bacd74568edffe090130ffc5d235b4771a4707612b56145288d4e7119be4a2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>entire_engine.go</strong><dd><code>Implement HasTempEngine method checking TempEngine existence</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-52fe2eafc066efa819aca699822a68d4cd26b2fff42772ed2f57bc860392d658">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>binded.go</strong><dd><code>Delegate HasTempEngine to underlying engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-6a95378afa8e6070e119384b6e0458439e99647292da00cde19513c6ba1d2997">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>engine.go</strong><dd><code>Implement HasTempEngine method returning false</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-1e1db95a11c1cbc1b9773183bf64e4335662115944ae3c3a8a6bcea202c12d58">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cronjobs.go</strong><dd><code>Move pool usage report to GCLockMerge job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-e737a04b4e55fd63cb6ef9faf5c7c51867a71f6a1551b54eb6b5a4538ac64356">+1/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Add HasTempEngine method to Engine interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-63dae27d68e4826370bf8a36cbe79d41cba3c711a7ff2fb8ec91e81babc0a4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>engine_mock.go</strong><dd><code>Add HasTempEngine mock method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-7f25d270cc6d85f3c1655194a9dd2493991b59c88f63be8bf658e28360dd398a">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ddl_test.go</strong><dd><code>Update tests with HasTempEngine expectations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-2d332f4443fbae4cd26a24f5a796e117e0161b9581f3e7811bba9823c0a39415">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>entire_engine_test.go</strong><dd><code>Add HasTempEngine method to test engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-1e6781313efa2d3f2c37c97bcc6e8f3cf63d5af77cf95536e506e548d126be55">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>scope.go</strong><dd><code>Format workload balance warning log message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22122/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>