### PR TITLE
clean log and open debug for commit

### DIFF
--- a/pkg/vm/engine/tae/db/cronjobs.go
+++ b/pkg/vm/engine/tae/db/cronjobs.go
@@ -130,7 +130,6 @@ func AddCronJob(db *DB, name string, skipMode bool) (err error) {
 			CronJobs_Name_GCTransferTable,
 			db.Opts.CheckpointCfg.TransferInterval,
 			func(context.Context) {
-				db.Runtime.PoolUsageReport()
 				// dbutils.PrintMemStats()
 				db.Runtime.TransferDelsMap.Prune(db.Opts.TransferTableTTL)
 				db.Runtime.TransferTable.RunTTL()
@@ -211,6 +210,7 @@ func AddCronJob(db *DB, name string, skipMode bool) (err error) {
 			CronJobs_Name_GCLockMerge,
 			options.DefaultLockMergePruneInterval,
 			func(ctx context.Context) {
+				db.Runtime.PoolUsageReport()
 				db.Runtime.LockMergeService.Prune()
 			},
 			1,
@@ -236,19 +236,6 @@ func AddCronJob(db *DB, name string, skipMode bool) (err error) {
 			1,
 		)
 		return
-		// case CronJobs_Name_Scanner:
-		// scanner := NewDBScanner(db, nil)
-		// db.MergeScheduler = merge.NewScheduler(db.Runtime, merge.NewTaskServiceGetter(db.Opts.TaskServiceGetter))
-		// scanner.RegisterOp(db.MergeScheduler)
-		// err = db.CronJobs.AddJob(
-		// 	CronJobs_Name_Scanner,
-		// 	db.Opts.CheckpointCfg.ScanInterval,
-		// 	func(ctx context.Context) {
-		// 		scanner.OnExec()
-		// 	},
-		// 	1,
-		// )
-		// return
 	}
 	err = moerr.NewInternalErrorNoCtxf(
 		"unknown cron job name: %s", name,

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -31,7 +31,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
-	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -977,24 +976,15 @@ func (h *Handle) HandleWrite(
 				pkDef := schema.GetSingleSortKey()
 				idx := pkDef.Idx
 				isCompositeKey := pkDef.IsCompositeColumn()
-				for i := 0; i < req.Batch.Vecs[0].Length(); i++ {
-					if isCompositeKey {
-						pkbuf := req.Batch.Vecs[idx].GetBytesAt(i)
-						tuple, _ := types.Unpack(pkbuf)
-						logutil.Info(
-							"op1",
-							zap.String("txn", txn.String()),
-							zap.String("pk", common.TypeStringValue(*req.Batch.Vecs[idx].GetType(), pkbuf, false)),
-							zap.Any("detail", tuple.SQLStrings(nil)),
-						)
-					} else {
-						logutil.Info(
-							"op1",
-							zap.String("txn", txn.String()),
-							zap.String("pk", common.MoVectorToString(req.Batch.Vecs[idx], i)),
-						)
-					}
+				var opts []common.TypePrintOpt
+				if isCompositeKey {
+					opts = append(opts, common.WithIsComposite{})
 				}
+				logutil.Info(
+					"op1",
+					zap.String("txn", txn.String()),
+					zap.String("pks", common.MoVectorToString(req.Batch.Vecs[idx], 100, opts...)),
+				)
 			}
 
 		}
@@ -1078,28 +1068,17 @@ func (h *Handle) HandleWrite(
 	if h.IsInterceptTable(tb.Schema(false).(*catalog.Schema).Name) || injected {
 		schema := tb.Schema(false).(*catalog.Schema)
 		if schema.HasPK() {
-			rowids := vector.MustFixedColNoTypeCheck[types.Rowid](rowIDVec.GetDownstreamVector())
 			isCompositeKey := schema.GetSingleSortKey().IsCompositeColumn()
-			for i := 0; i < len(rowids); i++ {
-				if isCompositeKey {
-					pkbuf := req.Batch.Vecs[1].GetBytesAt(i)
-					tuple, _ := types.Unpack(pkbuf)
-					logutil.Info(
-						"op2",
-						zap.String("txn", txn.String()),
-						zap.String("pk", common.TypeStringValue(*req.Batch.Vecs[1].GetType(), pkbuf, false)),
-						zap.String("rowid", rowids[i].String()),
-						zap.Any("detail", tuple.SQLStrings(nil)),
-					)
-				} else {
-					logutil.Info(
-						"op2",
-						zap.String("txn", txn.String()),
-						zap.String("pk", common.MoVectorToString(req.Batch.Vecs[1], i)),
-						zap.String("rowid", rowids[i].String()),
-					)
-				}
+			var opts []common.TypePrintOpt
+			if isCompositeKey {
+				opts = append(opts, common.WithIsComposite{})
 			}
+			logutil.Info(
+				"op2",
+				zap.String("txn", txn.String()),
+				zap.String("pks", common.MoVectorToString(req.Batch.Vecs[1], 100, opts...)),
+				zap.String("rowids", common.MoVectorToString(req.Batch.Vecs[0], 100, opts...)),
+			)
 		}
 	}
 	err = tb.DeleteByPhyAddrKeys(rowIDVec, pkVec, handle.DT_Normal)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #22101 

## What this PR does / why we need it:

clean log and open debug for commit


___

### **PR Type**
Enhancement


___

### **Description**
- Optimize logging frequency in batch processor aggregation loop

- Simplify debug logging for database write operations

- Move pool usage reporting to lock merge cron job

- Remove commented code and unused imports


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Batch Processor"] --> B["Reduced Log Frequency"]
  C["Database Write Operations"] --> D["Simplified Debug Logging"]
  E["Cron Jobs"] --> F["Moved Pool Usage Reporting"]
  G["Code Cleanup"] --> H["Removed Dead Code"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>batch_processor.go</strong><dd><code>Optimize aggregation loop logging frequency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/util/export/batch_processor.go

<li>Introduced periodic logging with 10-minute intervals instead of <br>per-loop logging<br> <li> Added record counting and last print time tracking<br> <li> Replaced structured logger with <code>logutil.Info</code> for consistency<br> <li> Simplified log messages with standardized naming


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22123/files#diff-618ee6d9354fed818b28e1e019e9ca0859723211ff136e7c8fb851cc8cf2b2ea">+22/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cronjobs.go</strong><dd><code>Reorganize cron job responsibilities and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/cronjobs.go

<li>Moved <code>PoolUsageReport()</code> call from GCTransferTable to GCLockMerge cron <br>job<br> <li> Removed large block of commented scanner-related code<br> <li> Cleaned up unused code paths


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22123/files#diff-e737a04b4e55fd63cb6ef9faf5c7c51867a71f6a1551b54eb6b5a4538ac64356">+1/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>handle.go</strong><dd><code>Streamline debug logging for write operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/rpc/handle.go

<li>Simplified debug logging for write operations by batching output<br> <li> Replaced per-row logging with batch logging using <code>MoVectorToString</code><br> <li> Removed unused <code>vector</code> import<br> <li> Consolidated composite key handling logic


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22123/files#diff-98c036f2b292191124a927608e91efd81ad24feebc0b8dd44a2aa1c9cffe6f91">+17/-38</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>