### PR TITLE
workaround txn commit failed but tn handled

### DIFF
--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -1010,6 +1010,13 @@ func (tc *txnOperator) doSend(
 	util.LogTxnSendRequests(tc.logger, requests)
 	result, err := tc.sender.Send(ctx, requests)
 	if err != nil {
+		if commit {
+			// TODO: remove this workaround
+			// set tc.mu.txn.CommitTS = now+10s
+			now, _ := tc.clock.Now()
+			now.PhysicalTime += 10000000000
+			tc.mu.txn.CommitTS = now
+		}
 		util.LogTxnSendRequestsFailed(tc.logger, requests, err)
 		return nil, err
 	}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22115


## What this PR does / why we need it:
workaround txn commit failed but tn handled


___

### **PR Type**
Bug fix


___

### **Description**
- Add workaround for transaction commit failures

- Set CommitTS to current time + 10 seconds on send errors

- Include test coverage for the workaround behavior


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Transaction Commit"] --> B["Send Request"]
  B --> C{"Send Failed?"}
  C -->|Yes| D["Set CommitTS = now + 10s"]
  C -->|No| E["Normal Flow"]
  D --> F["Return Error"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator.go</strong><dd><code>Add commit timestamp workaround for send failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/txn/client/operator.go

<li>Add error handling in <code>doSend</code> method for commit operations<br> <li> Set <code>CommitTS</code> to current time plus 10 seconds when send fails<br> <li> Include TODO comment indicating this is a temporary workaround


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22140/files#diff-43f44107ace02cc2170c3138f30bd1e0ba258be040543c7e43e3a49b89d67c99">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>operator_test.go</strong><dd><code>Add test for commit timestamp workaround</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/txn/client/operator_test.go

<li>Add test function <code>TestCommitSendErrorSetsCommitTSWorkaround</code><br> <li> Verify CommitTS is set to now+10s when commit send fails<br> <li> Use manual test sender to simulate send errors


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22140/files#diff-cc8530d0fbe91edcde0f3189966ae64a0ca01e228e4202df540267af64ba8084">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>