### PR TITLE
fix force gckp

### DIFF
--- a/pkg/vm/engine/tae/db/checkpoint/testutils.go
+++ b/pkg/vm/engine/tae/db/checkpoint/testutils.go
@@ -118,6 +118,8 @@ func (r *runner) ForceGCKP(
 		force:            true,
 		end:              maxEntry.end,
 		histroyRetention: histroyRetention,
+		truncateLSN:      maxEntry.truncateLSN,
+		ckpLSN:           maxEntry.ckpLSN,
 	}
 
 	if err = r.TryTriggerExecuteGCKP(request); err != nil {

--- a/pkg/vm/engine/tae/db/test/replay_test.go
+++ b/pkg/vm/engine/tae/db/test/replay_test.go
@@ -1406,3 +1406,57 @@ func TestReplayDatabaseEntry(t *testing.T) {
 	assert.Equal(t, datypStr, dbEntry.GetDatType())
 	assert.Equal(t, createSqlStr, dbEntry.GetCreateSql())
 }
+
+// LongScanAndCKPOpts
+// add some txns
+// force gckp
+// get ckp-lsn and truncate-lsn
+// replay
+// check ckp-lsn and truncate-lsn
+func Test_ReplayAfterForceGCKP(t *testing.T) {
+	defer testutils.AfterTest(t)()
+	ctx := context.Background()
+
+	opts := config.WithLongScanAndCKPOpts(nil)
+	tae := testutil.NewTestEngine(ctx, ModuleName, t, opts)
+	defer tae.Close()
+
+	{
+		txn, err := tae.StartTxn(nil)
+		assert.NoError(t, err)
+		_, err = testutil.CreateDatabase2(
+			ctx, txn, t.Name(),
+		)
+		assert.NoError(t, err)
+		assert.NoError(t, txn.Commit(context.Background()))
+	}
+
+	err := tae.DB.ForceGlobalCheckpoint(ctx, tae.TxnMgr.Now(), 0)
+	assert.NoError(t, err)
+
+	maxICKP := tae.DB.BGCheckpointRunner.MaxIncrementalCheckpoint()
+	t.Log(maxICKP.String())
+
+	maxGCKP := tae.DB.BGCheckpointRunner.MaxGlobalCheckpoint()
+	t.Log(maxGCKP.String())
+
+	tae.Restart(ctx)
+
+	maxICKP2 := tae.DB.BGCheckpointRunner.MaxIncrementalCheckpoint()
+	t.Log(maxICKP2.String())
+
+	maxGCKP2 := tae.DB.BGCheckpointRunner.MaxGlobalCheckpoint()
+	t.Log(maxGCKP2.String())
+
+	assert.Equal(t, maxICKP.LSN(), maxICKP2.LSN())
+	assert.Equal(t, maxGCKP.LSN(), maxGCKP2.LSN())
+	assert.Equal(t, maxICKP.GetTruncateLsn(), maxICKP2.GetTruncateLsn())
+	assert.Equal(t, maxGCKP.GetTruncateLsn(), maxGCKP2.GetTruncateLsn())
+
+	expectGCKPEnd := maxICKP.GetEnd()
+	expectGCKPEnd = expectGCKPEnd.Next()
+	assert.Equal(t, expectGCKPEnd, maxGCKP2.GetEnd())
+
+	assert.Equal(t, maxICKP.LSN(), maxGCKP2.LSN())
+	assert.Equal(t, maxICKP.GetTruncateLsn(), maxGCKP2.GetTruncateLsn())
+}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22142 

## What this PR does / why we need it:

fix force global checkpoint without lsn and truncate lsn


___

### **PR Type**
Bug fix


___

### **Description**
- Fix force global checkpoint missing LSN fields

- Add test for replay after force GCKP

- Ensure truncateLSN and ckpLSN are properly set


___

### **Changes diagram**

```mermaid
flowchart LR
  A["ForceGCKP"] --> B["Add truncateLSN"]
  A --> C["Add ckpLSN"]
  B --> D["Test replay"]
  C --> D
  D --> E["Verify LSN consistency"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>testutils.go</strong><dd><code>Add missing LSN fields to force GCKP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/checkpoint/testutils.go

<li>Add <code>truncateLSN</code> field to gckpContext request<br> <li> Add <code>ckpLSN</code> field to gckpContext request<br> <li> Set both fields from maxEntry values


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22143/files#diff-38f09e23b6dba4b2baf85b6349c77b35b260a82f9e8aa28e276ab6e4df0aa83d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>replay_test.go</strong><dd><code>Add test for force GCKP replay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/test/replay_test.go

<li>Add new test <code>Test_ReplayAfterForceGCKP</code><br> <li> Test force global checkpoint followed by restart<br> <li> Verify LSN consistency after replay<br> <li> Check truncateLSN and ckpLSN preservation


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22143/files#diff-3fad24b273a8bd0e2f92d7018259508dd7c20ef806f8c15bdb199b5113f6bc4e">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>