### PR TITLE
fix gc mpool leak

### DIFF
--- a/pkg/vm/engine/tae/db/gc/v3/merge.go
+++ b/pkg/vm/engine/tae/db/gc/v3/merge.go
@@ -137,6 +137,7 @@ func MergeCheckpoint(
 	}
 
 	sinker := ckputil.NewDataSinker(pool, fs)
+	defer sinker.Close()
 	if err = sinker.Write(ctx, ckpData); err != nil {
 		return
 	}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22131

## What this PR does / why we need it:
Fix gc mpool leak


___

### **PR Type**
Bug fix


___

### **Description**
- Fix memory pool leak in checkpoint garbage collection

- Add missing `defer sinker.Close()` call to prevent resource leak


___

### **Changes diagram**

```mermaid
flowchart LR
  A["MergeCheckpoint function"] --> B["Create DataSinker"]
  B --> C["Add defer sinker.Close()"]
  C --> D["Prevent memory pool leak"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>merge.go</strong><dd><code>Add missing sinker cleanup in MergeCheckpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/gc/v3/merge.go

<li>Add <code>defer sinker.Close()</code> after creating DataSinker<br> <li> Ensures proper cleanup of memory pool resources<br> <li> Prevents memory leak in checkpoint garbage collection


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22146/files#diff-687cc65a41138b0a42fc9a4747b580a21b53ec041527cce4f7394dbcbd4b4828">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>