### PR TITLE
Revert 22092 changes in 2.2-dev due to oom

### DIFF
--- a/pkg/sql/plan/dml_context.go
+++ b/pkg/sql/plan/dml_context.go
@@ -17,6 +17,7 @@ package plan
 import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
@@ -227,6 +228,12 @@ func (dmlCtx *DMLContext) ResolveSingleTable(ctx CompilerContext, tbl tree.Table
 
 	if checkFK && (len(tableDef.Fkeys) > 0 || len(tableDef.RefChildTbls) > 0) {
 		return moerr.NewUnsupportedDML(ctx.GetContext(), "foreign key constraint")
+	}
+
+	for _, col := range tableDef.Cols {
+		if types.T(col.Typ.Id).IsArrayRelate() {
+			return moerr.NewUnsupportedDML(ctx.GetContext(), "vector column")
+		}
 	}
 
 	isClusterTable := util.TableIsClusterTable(tableDef.GetTableType())


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22151 

## What this PR does / why we need it:

Revert 22092 changes in 2.2-dev due to oom


___

### **PR Type**
Bug fix


___

### **Description**
- Revert changes from PR #22092 causing OOM issues

- Add vector column DML operation restriction

- Import types package for array type checking


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Import types package"] --> B["Check column types"]
  B --> C["Block vector column DML"]
  C --> D["Prevent OOM issues"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dml_context.go</strong><dd><code>Add vector column DML restriction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/dml_context.go

<li>Add import for <code>types</code> package<br> <li> Add validation loop to check column types<br> <li> Return error for vector/array columns in DML operations


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22157/files#diff-6e952c10166b807c3a9ef06cde3d549ebbee6e29eb2ffd1aeceb9eab8590fd3e">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>