### PR TITLE
Bytes with atomic reference counter not guarantee to deallocate memory and memory still accessible even memory was deallocated.

### DIFF
--- a/pkg/fileservice/bytes_test.go
+++ b/pkg/fileservice/bytes_test.go
@@ -28,7 +28,28 @@ func TestBytes(t *testing.T) {
 		bs := &Bytes{
 			bytes:       bytes,
 			deallocator: deallocator,
+			refs:        1,
 		}
 		bs.Release()
 	})
+}
+
+func TestBytesPanic(t *testing.T) {
+	bytes, deallocator, err := ioAllocator().Allocate(42, malloc.NoHints)
+	assert.Nil(t, err)
+	bs := &Bytes{
+		bytes:       bytes,
+		deallocator: deallocator,
+		refs:        1,
+	}
+
+	released := bs.Release()
+	assert.Equal(t, released, true)
+
+	assert.Panics(t, func() { bs.Release() }, "Bytes.Release panic()")
+	assert.Panics(t, func() { bs.Size() }, "Bytes.Size panic()")
+	assert.Panics(t, func() { bs.Bytes() }, "Bytes.Bytes panic()")
+	assert.Panics(t, func() { bs.Slice(0) }, "Bytes.Slice panic()")
+	assert.Panics(t, func() { bs.Retain() }, "Bytes.Retain panic()")
+
 }

--- a/pkg/fileservice/fscache/data.go
+++ b/pkg/fileservice/fscache/data.go
@@ -18,5 +18,5 @@ type Data interface {
 	Bytes() []byte
 	Slice(length int) Data
 	Retain()
-	Release()
+	Release() bool
 }

--- a/pkg/fileservice/io_vector.go
+++ b/pkg/fileservice/io_vector.go
@@ -14,7 +14,9 @@
 
 package fileservice
 
-import "math"
+import (
+	"math"
+)
 
 func (i *IOVector) allDone() bool {
 	for _, entry := range i.Entries {
@@ -28,7 +30,10 @@ func (i *IOVector) allDone() bool {
 func (i *IOVector) Release() {
 	for _, entry := range i.Entries {
 		if entry.CachedData != nil {
-			entry.CachedData.Release()
+			if entry.CachedData.Release() {
+				entry.CachedData = nil
+				entry.fromCache = nil
+			}
 		}
 		if entry.releaseData != nil {
 			entry.releaseData()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22170

## What this PR does / why we need it:

replace atomic reference counter by mutex and fail fast with panic