### PR TITLE
to 2.2: Fix Inconsistent SQL Query Results for the MO System Version. 

### DIFF
--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -961,7 +961,7 @@ type GlobalSysVarsMgr struct {
 
 func useTomlConfigOverOtherConfigs(CNServiceConfig *config.FrontendParameters, sysVarsMp map[string]interface{}) {
 	sysVarsMp["version_comment"] = CNServiceConfig.VersionComment
-	sysVarsMp["version"] = CNServiceConfig.ServerVersionPrefix + CNServiceConfig.MoVersion
+	sysVarsMp["version"] = CNServiceConfig.ServerVersionPrefix + serverVersion.Load().(string)
 }
 
 // Get return sys vars of accountId

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -1578,8 +1578,28 @@ func Sleep[T uint64 | float64](ivecs []*vector.Vector, result vector.FunctionRes
 	return nil
 }
 
-func Version(_ []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
-	versionStr := proc.GetSessionInfo().GetVersion()
+func Version(
+	_ []*vector.Vector,
+	result vector.FunctionResultWrapper,
+	proc *process.Process,
+	length int,
+	selectList *FunctionSelectList,
+) error {
+
+	var (
+		err error
+
+		versionAny interface{}
+		versionStr string
+	)
+
+	if versionAny, err = proc.GetResolveVariableFunc()(
+		"version", true, true,
+	); err != nil {
+		return err
+	}
+
+	versionStr = versionAny.(string)
 
 	return opNoneParamToBytes(result, proc, length, func() []byte {
 		return functionUtil.QuickStrToBytes(versionStr)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/5934

## What this PR does / why we need it:

Fix Inconsistent SQL Query Results for the MO System Version.

Three ways to query the version:

1. New session connection:
`Server version: 8.0.30-MatrixOne-v2.2.1 MatrixOne`

2. Show variables like "%version%":
```
+-------------------------+-------------------------+
| Variable_name           | Value                   |
+-------------------------+-------------------------+
| version                 | 8.0.30-MatrixOne-v2.2.1 |
+-------------------------+-------------------------+
```

3. select version();
```
+-------------------------+
| version()               |
+-------------------------+
| 8.0.30-MatrixOne-v2.2.1 |
+-------------------------+
```

They should all be the system version for the MO, not the metadata version.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix inconsistent SQL query results for MO system version

- Update version retrieval to use `serverVersion.Load()` instead of `CNServiceConfig.MoVersion`

- Modify `Version()` function to resolve version through variable resolver

- Ensure all three version query methods return consistent results


___

### **Changes diagram**

```mermaid
flowchart LR
  A["useTomlConfigOverOtherConfigs"] --> B["serverVersion.Load()"]
  C["Version() function"] --> D["proc.GetResolveVariableFunc()"]
  B --> E["Consistent version output"]
  D --> E
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.go</strong><dd><code>Update version source in system variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/variables.go

<li>Replace <code>CNServiceConfig.MoVersion</code> with <code>serverVersion.Load().(string)</code> <br>in version mapping<br> <li> Ensure system variables use the correct server version


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22177/files#diff-07649adc637b0268b12ec915ec819f66db3a4e4375bfc77291116bfa06c4432f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>func_unary.go</strong><dd><code>Refactor Version function for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/function/func_unary.go

<li>Refactor <code>Version()</code> function to use variable resolver instead of <br>session info<br> <li> Add proper error handling for version retrieval<br> <li> Ensure version consistency across different query methods


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22177/files#diff-c3a42753612b2181b8096b586ceb205b23d4d9f1b884c728ca8705d46c6b7dc4">+22/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>