### PR TITLE
fix rename column: delete table with old metadata

### DIFF
--- a/test/distributed/cases/benchmark/tpch/02_LOAD/11_select_count_snapshot.result
+++ b/test/distributed/cases/benchmark/tpch/02_LOAD/11_select_count_snapshot.result
@@ -8,9 +8,6 @@ drop table if exists orders;
 drop table if exists part;
 drop table if exists partsupp;
 drop table if exists supplier;
-select sleep(10);
-sleep(10)
-0
 select count(*) from customer {snapshot = 'tpch_snapshot'};
 count(*)
 150
@@ -181,9 +178,6 @@ select count(*) from supplier;
 count(*)
 10
 drop database tpch;
-select sleep(10);
-sleep(10)
-0
 select count(*) from tpch.customer {snapshot = 'tpch_snapshot'};
 count(*)
 150

--- a/test/distributed/cases/benchmark/tpch/02_LOAD/11_select_count_snapshot.sql
+++ b/test/distributed/cases/benchmark/tpch/02_LOAD/11_select_count_snapshot.sql
@@ -9,7 +9,6 @@ drop table if exists part;
 drop table if exists partsupp;
 drop table if exists supplier;
 
-select sleep(10);
 -- customer
 select count(*) from customer {snapshot = 'tpch_snapshot'};
 select count(*) from customer {snapshot = 'tpch_snapshot'};
@@ -90,7 +89,6 @@ select count(*) from supplier;
 select count(*) from supplier;
 
 drop database tpch;
-select sleep(10);
 
 select count(*) from tpch.customer {snapshot = 'tpch_snapshot'};
 select count(*) from tpch.customer {snapshot = 'tpch_snapshot'};

--- a/test/distributed/cases/ddl/alter.result
+++ b/test/distributed/cases/ddl/alter.result
@@ -64,13 +64,18 @@ drop table  tm1;
 drop table  ti2;
 drop table  tm2;
 drop table if exists foreign01;
+
 create temporary table foreign01(col1 int primary key,
 col2 varchar(20),
 col3 int,
 col4 bigint);
+
 insert into foreign01 values(1,'shujuku',100,3247984);
+
 insert into foreign01 values(2,'数据库',328932,32324423432);
+
 drop table if exists foreign02;
+
 create temporary table foreign02(col1 int,
 col2 int,
 col3 int primary key,
@@ -81,6 +86,7 @@ no such table test.foreign02
 insert into foreign02 values(2,2,2);
 no such table test.foreign02
 delete from foreign01 where col3 = 100;
+
 show create table foreign02;
 no such table test.foreign02
 alter table foreign02 drop foreign key fk;
@@ -88,20 +94,33 @@ no such table test.foreign02
 show create table foreign02;
 no such table test.foreign02
 drop table foreign01;
+
 drop table foreign02;
 no such table test.foreign02
 drop table if exists ti1;
+
 drop table if exists tm1;
+
 drop table if exists ti2;
+
 drop table if exists tm2;
+
 create temporary table ti1(a INT not null, b INT, c INT);
+
 create temporary table tm1(a INT not null, b INT, c INT);
+
 create temporary table ti2(a INT primary key AUTO_INCREMENT, b INT, c INT);
+
 create temporary table tm2(a INT primary key AUTO_INCREMENT, b INT, c INT);
+
 insert into ti1 values (1,1,1), (2,2,2);
+
 insert into ti2 values (1,1,1), (2,2,2);
+
 insert into tm1 values (1,1,1), (2,2,2);
+
 insert into tm2 values (1,1,1), (2,2,2);
+
 alter table ti1 add constraint fi1 foreign key (b) references ti2(a);
 alter table for temporary table is not yet implemented
 alter table tm1 add constraint fm1 foreign key (b) references tm2(a);
@@ -113,7 +132,9 @@ show create table tm1;
 Table    Create Table
 tm1    CREATE TABLE `tm1` (\n  `a` int NOT NULL,\n  `b` int DEFAULT NULL,\n  `c` int DEFAULT NULL\n)
 delete from ti2 where c = 1;
+
 delete from tm2 where c = 1;
+
 alter table ti1 drop foreign key fi1;
 alter table for temporary table is not yet implemented
 alter table tm1 drop foreign key fm1;
@@ -125,11 +146,17 @@ show create table tm1;
 Table    Create Table
 tm1    CREATE TABLE `tm1` (\n  `a` int NOT NULL,\n  `b` int DEFAULT NULL,\n  `c` int DEFAULT NULL\n)
 delete from ti2 where c = 1;
+
 delete from tm2 where c = 1;
+
 drop table  ti1;
+
 drop table  tm1;
+
 drop table  ti2;
+
 drop table  tm2;
+
 drop table if exists index01;
 create table index01(col1 int,key key1(col1));
 show index from index01;
@@ -556,6 +583,18 @@ id    content
 show create table t5;
 Table    Create Table
 t5    CREATE TABLE `t5` (\n  `id` int NOT NULL,\n  `content` varchar(1000) DEFAULT NULL,\n  PRIMARY KEY (`id`)\n)
+begin;
+alter table t5 rename column content to new_content;
+select mo_ctl('dn', 'flush', 'mo_catalog.mo_columns');
+mo_ctl(dn, flush, mo_catalog.mo_columns)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select sleep(0.51);
+sleep(0.51)
+0
+commit;
+show create table t5;
+Table    Create Table
+t5    CREATE TABLE `t5` (\n  `id` int NOT NULL,\n  `new_content` varchar(1000) DEFAULT NULL,\n  PRIMARY KEY (`id`)\n)
 drop table t1;
 drop table t2;
 drop table t3;

--- a/test/distributed/cases/ddl/alter.sql
+++ b/test/distributed/cases/ddl/alter.sql
@@ -489,6 +489,20 @@ alter table t5 modify column content varchar(1000);
 select * from t5;
 show create table t5;
 
+begin;
+
+alter table t5 rename column content to new_content;
+
+-- @separator:table
+select mo_ctl('dn', 'flush', 'mo_catalog.mo_columns');
+
+select sleep(0.51);
+
+commit;
+
+show create table t5;
+
+
 -- Cleanup
 drop table t1;
 drop table t2;

--- a/test/distributed/cases/view/system_view.result
+++ b/test/distributed/cases/view/system_view.result
@@ -1,6 +1,6 @@
 begin;
-select sleep(10);
-sleep(10)
+select sleep(5);
+sleep(5)
 0
 select count(*) > 0 from mo_sessions() t;
 count(*) > 0

--- a/test/distributed/cases/view/system_view.sql
+++ b/test/distributed/cases/view/system_view.sql
@@ -2,7 +2,7 @@
 
 -- @session:id=1{
 begin;
-select sleep(10);
+select sleep(5);
 -- @session}
 
 select count(*) > 0 from mo_sessions() t;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22015

## What this PR does / why we need it:

- Fix mismatched primary key values between row_ids in `mo_columns` when renaming a column.
- Add BVT test cases


___

### **PR Type**
Bug fix


___

### **Description**
- Fix column rename metadata synchronization issue

- Reorder table definition updates after metadata deletion

- Add BVT test case for rename column operation


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Old Table Metadata"] --> B["Delete Old Metadata"]
  B --> C["Update Table Definitions"]
  C --> D["Create New Metadata"]
  D --> E["Refreshed Table Definition"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Fix table definition refresh timing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/txn_table.go

<li>Add <code>RefeshTableDef</code> method to refresh table definition<br> <li> Reorder table definition updates to occur after metadata deletion<br> <li> Fix timing issue in <code>AlterTable</code> method for rename operations


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22182/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+14/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alter.result</strong><dd><code>Add rename column test results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/ddl/alter.result

<li>Add test case for column rename operation within transaction<br> <li> Include flush and sleep operations for metadata synchronization<br> <li> Verify table structure after rename operation


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22182/files#diff-0b4b68fb93fdb0e58a85c80267c4828bc9086fd75bf735eb497f1818f4c5df01">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>alter.sql</strong><dd><code>Add rename column test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/ddl/alter.sql

<li>Add BVT test case for rename column operation<br> <li> Include transaction boundaries and metadata flush operations<br> <li> Test column rename from <code>content</code> to <code>new_content</code>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22182/files#diff-524187ef0ccfd3b12a36f855a6d23aa4139869311aca10df93f60c155c6bc099">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>