### PR TITLE
colexec/aggexec: add AggFuncExec.Size

### DIFF
--- a/pkg/sql/colexec/aggexec/aggContext.go
+++ b/pkg/sql/colexec/aggexec/aggContext.go
@@ -118,6 +118,23 @@ func (a *AggContext) decodeGroupContexts(encodings [][]byte, resultType types.Ty
 	}
 }
 
+func (a *AggContext) Size() int64 {
+	var size int64
+	if a.hasCommonContext && a.commonContext != nil {
+		size += a.commonContext.Size()
+	}
+	if a.hasGroupContext {
+		for _, g := range a.groupContext {
+			if g != nil {
+				size += g.Size()
+			}
+		}
+		// 16 is the size of an interface.
+		size += int64(cap(a.groupContext)) * 16
+	}
+	return size
+}
+
 // AggCommonExecContext stores the common context for all the groups.
 // like the type scale, timezone and so on.
 type AggCommonExecContext interface {

--- a/pkg/sql/colexec/aggexec/aggMethod.go
+++ b/pkg/sql/colexec/aggexec/aggMethod.go
@@ -124,7 +124,9 @@ type (
 // todo: consider that change them to deliver []byte directly, and agg developer choose how to use the []byte.
 //
 //	because the []byte can be set to one byte vector, and we can use the `mpool` to manage the memory easily.
+
 type AggCanMarshal interface {
 	Marshal() []byte
 	Unmarshal([]byte)
+	Size() int64
 }

--- a/pkg/sql/colexec/aggexec/approx_count.go
+++ b/pkg/sql/colexec/aggexec/approx_count.go
@@ -327,6 +327,20 @@ func (exec *approxCountFixedExec[T]) Free() {
 	exec.groups = nil
 }
 
+func (exec *approxCountFixedExec[T]) Size() int64 {
+	var size int64
+	for _, s := range exec.groups {
+		if s != nil {
+			if data, err := s.MarshalBinary(); err == nil {
+				size += int64(len(data))
+			}
+		}
+	}
+	// 8 is the size of a pointer.
+	size += int64(cap(exec.groups)) * 8
+	return exec.ret.Size() + size
+}
+
 func (exec *approxCountVarExec) GroupGrow(more int) error {
 	oldLen, newLen := len(exec.groups), len(exec.groups)+more
 	if cap(exec.groups) >= newLen {
@@ -464,4 +478,18 @@ func (exec *approxCountVarExec) Flush() ([]*vector.Vector, error) {
 func (exec *approxCountVarExec) Free() {
 	exec.ret.free()
 	exec.groups = nil
+}
+
+func (exec *approxCountVarExec) Size() int64 {
+	var size int64
+	for _, s := range exec.groups {
+		if s != nil {
+			if data, err := s.MarshalBinary(); err == nil {
+				size += int64(len(data))
+			}
+		}
+	}
+	// 8 is the size of a pointer.
+	size += int64(cap(exec.groups)) * 8
+	return exec.ret.Size() + size
 }

--- a/pkg/sql/colexec/aggexec/concat.go
+++ b/pkg/sql/colexec/aggexec/concat.go
@@ -206,6 +206,10 @@ func (exec *groupConcatExec) Free() {
 	exec.ret.free()
 }
 
+func (exec *groupConcatExec) Size() int64 {
+	return exec.ret.Size() + exec.distinctHash.Size() + int64(cap(exec.separator))
+}
+
 var GroupConcatUnsupportedTypes = []types.T{
 	types.T_tuple,
 }

--- a/pkg/sql/colexec/aggexec/count.go
+++ b/pkg/sql/colexec/aggexec/count.go
@@ -256,6 +256,10 @@ func (exec *countColumnExec) Free() {
 	exec.distinctHash.free()
 }
 
+func (exec *countColumnExec) Size() int64 {
+	return exec.ret.Size() + exec.distinctHash.Size()
+}
+
 type countStarExec struct {
 	singleAggInfo
 	singleAggExecExtraInformation
@@ -358,4 +362,8 @@ func (exec *countStarExec) Flush() ([]*vector.Vector, error) {
 
 func (exec *countStarExec) Free() {
 	exec.ret.free()
+}
+
+func (exec *countStarExec) Size() int64 {
+	return exec.ret.Size()
 }

--- a/pkg/sql/colexec/aggexec/distinct.go
+++ b/pkg/sql/colexec/aggexec/distinct.go
@@ -153,3 +153,19 @@ func (d *distinctHash) free() {
 		}
 	}
 }
+
+func (d *distinctHash) Size() int64 {
+	var size int64
+	for _, m := range d.maps {
+		if m != nil {
+			size += m.Size()
+		}
+	}
+	// 8 is the size of a pointer.
+	size += int64(cap(d.maps)) * 8
+	// 16 is the size of an interface.
+	size += int64(cap(d.itrs)) * 16
+	size += int64(cap(d.bs))
+	size += int64(cap(d.bs1))
+	return size
+}

--- a/pkg/sql/colexec/aggexec/fromBytesRetBytes.go
+++ b/pkg/sql/colexec/aggexec/fromBytesRetBytes.go
@@ -549,3 +549,7 @@ func (exec *aggregatorFromBytesToBytes) Free() {
 	exec.ret.free()
 	exec.distinctHash.free()
 }
+
+func (exec *aggregatorFromBytesToBytes) Size() int64 {
+	return exec.ret.Size() + exec.distinctHash.Size() + exec.execContext.Size()
+}

--- a/pkg/sql/colexec/aggexec/fromBytesRetFixed.go
+++ b/pkg/sql/colexec/aggexec/fromBytesRetFixed.go
@@ -647,3 +647,7 @@ func (exec *aggregatorFromBytesToFixed[to]) Free() {
 	exec.ret.free()
 	exec.distinctHash.free()
 }
+
+func (exec *aggregatorFromBytesToFixed[to]) Size() int64 {
+	return exec.ret.Size() + exec.distinctHash.Size() + exec.execContext.Size()
+}

--- a/pkg/sql/colexec/aggexec/fromFixedRetBytes.go
+++ b/pkg/sql/colexec/aggexec/fromFixedRetBytes.go
@@ -666,3 +666,7 @@ func (exec *aggregatorFromFixedToBytes[from]) Free() {
 	exec.ret.free()
 	exec.distinctHash.free()
 }
+
+func (exec *aggregatorFromFixedToBytes[from]) Size() int64 {
+	return exec.ret.Size() + exec.distinctHash.Size() + exec.execContext.Size()
+}

--- a/pkg/sql/colexec/aggexec/fromFixedRetFixed.go
+++ b/pkg/sql/colexec/aggexec/fromFixedRetFixed.go
@@ -721,3 +721,7 @@ func (exec *aggregatorFromFixedToFixed[from, to]) Free() {
 	exec.ret.free()
 	exec.distinctHash.free()
 }
+
+func (exec *aggregatorFromFixedToFixed[from, to]) Size() int64 {
+	return exec.ret.Size() + exec.distinctHash.Size() + exec.execContext.Size()
+}

--- a/pkg/sql/colexec/aggexec/median.go
+++ b/pkg/sql/colexec/aggexec/median.go
@@ -353,6 +353,18 @@ func (exec *medianColumnExecSelf[T, R]) Free() {
 	exec.distinctHash.free()
 }
 
+func (exec *medianColumnExecSelf[T, R]) Size() int64 {
+	var size int64
+	for _, v := range exec.groups {
+		if v != nil {
+			size += v.Size()
+		}
+	}
+	// 8 is the size of a pointer.
+	size += int64(cap(exec.groups)) * 8
+	return exec.ret.Size() + exec.distinctHash.Size() + size
+}
+
 type medianColumnNumericExec[T numeric] struct {
 	medianColumnExecSelf[T, float64]
 }

--- a/pkg/sql/colexec/aggexec/median_test.go
+++ b/pkg/sql/colexec/aggexec/median_test.go
@@ -18,7 +18,9 @@ import (
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMedianMarshal(t *testing.T) {
@@ -28,17 +30,21 @@ func TestMedianMarshal(t *testing.T) {
 	defer vs.Free(m.mp)
 	AppendMultiFixed(vs, 1, false, 262145, m.mp)
 	assert.Equal(t, vs.Length(), 262145)
-	assert.Equal(t, len(vs.vecs), 2)
+	assert.Equal(t, 2, len(vs.vecs))
+	size1 := vs.Size()
+	assert.Greater(t, size1, int64(0))
 
 	vs2 := NewVectors[int64](types.T_int64.ToType())
 	defer vs2.Free(m.mp)
 	AppendMultiFixed(vs2, 1, false, 262145, m.mp)
 	assert.Equal(t, vs2.Length(), 262145)
-	assert.Equal(t, len(vs2.vecs), 2)
+	assert.Equal(t, 2, len(vs2.vecs))
 
 	vs.Union(vs2, m.mp)
 	assert.Equal(t, vs.Length(), 262145*2)
-	assert.Equal(t, len(vs.vecs), 3)
+	assert.Equal(t, 3, len(vs.vecs))
+	size2 := vs.Size()
+	assert.Greater(t, size2, size1)
 
 	b, err := vs.MarshalBinary()
 	assert.NoError(t, err)
@@ -48,4 +54,46 @@ func TestMedianMarshal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, vs.Length(), vs3.Length())
 	assert.Equal(t, vs.vecs[0].Length(), vs3.vecs[0].Length())
+	assert.Greater(t, vs3.Size(), int64(0))
+}
+
+func TestMedianAggSize(t *testing.T) {
+	m := hackAggMemoryManager()
+	defer func() {
+		require.Equal(t, int64(0), m.Mp().CurrNB())
+	}()
+
+	agg, err := newMedianExecutor(m, singleAggInfo{
+		aggID:     aggIdOfMedian,
+		distinct:  false,
+		argType:   types.T_int64.ToType(),
+		retType:   MedianReturnType([]types.Type{types.T_int64.ToType()}),
+		emptyNull: true,
+	})
+	require.NoError(t, err)
+
+	initialSize := agg.Size()
+	require.Greater(t, initialSize, int64(0))
+
+	// grow
+	groupCount := 10
+	err = agg.GroupGrow(groupCount)
+	require.NoError(t, err)
+	grownSize := agg.Size()
+	require.Greater(t, grownSize, initialSize)
+
+	// fill
+	v := vector.NewVec(types.T_int64.ToType())
+	defer v.Free(m.Mp())
+	err = vector.AppendFixedList(v, []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil, m.Mp())
+	require.NoError(t, err)
+
+	for i := 0; i < groupCount; i++ {
+		require.NoError(t, agg.BulkFill(i, []*vector.Vector{v}))
+	}
+	filledSize := agg.Size()
+	require.Greater(t, filledSize, grownSize)
+
+	// free
+	agg.Free()
 }

--- a/pkg/sql/colexec/aggexec/tool.go
+++ b/pkg/sql/colexec/aggexec/tool.go
@@ -228,6 +228,16 @@ func (vs *Vectors[T]) Free(mp *mpool.MPool) {
 	}
 }
 
+func (vs *Vectors[T]) Size() int64 {
+	var size int64
+	for _, vec := range vs.vecs {
+		size += int64(vec.Allocated())
+	}
+	// 8 is the size of a pointer.
+	size += int64(cap(vs.vecs)) * 8
+	return size
+}
+
 func MedianDecimal64[T numeric | types.Decimal64 | types.Decimal128](vs *Vectors[T]) (types.Decimal128, error) {
 	vals := make([]types.Decimal64, 0)
 	for _, vec := range vs.vecs {

--- a/pkg/sql/colexec/aggexec/types.go
+++ b/pkg/sql/colexec/aggexec/types.go
@@ -109,6 +109,8 @@ type AggFuncExec interface {
 	// Flush return the aggregation result.
 	Flush() ([]*vector.Vector, error)
 
+	Size() int64
+
 	// Free clean the resource and reuse the aggregation if possible.
 	Free()
 }
@@ -150,7 +152,8 @@ func (m SimpleAggMemoryManager) Mp() *mpool.MPool {
 func MakeAgg(
 	mg AggMemoryManager,
 	aggID int64, isDistinct bool,
-	param ...types.Type) (AggFuncExec, error) {
+	param ...types.Type,
+) (AggFuncExec, error) {
 	exec, ok, err := makeSpecialAggExec(mg, aggID, isDistinct, param...)
 	if err != nil {
 		return nil, err
@@ -214,7 +217,8 @@ func makeSingleAgg(
 
 func makeSpecialAggExec(
 	mg AggMemoryManager,
-	id int64, isDistinct bool, params ...types.Type) (AggFuncExec, bool, error) {
+	id int64, isDistinct bool, params ...types.Type,
+) (AggFuncExec, bool, error) {
 	if _, ok := specialAgg[id]; ok {
 		switch id {
 		case aggIdOfCountColumn:

--- a/pkg/sql/colexec/aggexec/window.go
+++ b/pkg/sql/colexec/aggexec/window.go
@@ -140,6 +140,17 @@ func (exec *singleWindowExec) Free() {
 	exec.ret.free()
 }
 
+func (exec *singleWindowExec) Size() int64 {
+	var size int64
+	size += exec.ret.Size()
+	for _, group := range exec.groups {
+		size += int64(cap(group)) * int64(types.T_int64.ToType().TypeSize())
+	}
+	// 24 is the size of a slice header.
+	size += int64(cap(exec.groups)) * 24
+	return size
+}
+
 func (exec *singleWindowExec) flushRank() ([]*vector.Vector, error) {
 	values := exec.ret.values
 

--- a/pkg/sql/plan/function/agg/avg.go
+++ b/pkg/sql/plan/function/agg/avg.go
@@ -128,6 +128,10 @@ func generateAggAvgContext(_ types.Type, _ ...types.Type) aggexec.AggGroupExecCo
 	return &c
 }
 
+func (a *aggAvgContext) Size() int64 {
+	return 8 // int64
+}
+
 func aggAvgInitResult(_ types.Type, _ ...types.Type) float64 {
 	return 0
 }
@@ -180,6 +184,10 @@ func (a *aggAvgDecimalCommonCtx) Unmarshal(bs []byte) {
 func generateAggAvgDecimalCommonContext(_ types.Type, parameters ...types.Type) aggexec.AggCommonExecContext {
 	c := aggAvgDecimalCommonCtx(parameters[0].Scale)
 	return &c
+}
+
+func (a *aggAvgDecimalCommonCtx) Size() int64 {
+	return 4 // int32
 }
 
 func aggAvgOfDecimalInitResult(_ types.Type, _ ...types.Type) types.Decimal128 {

--- a/pkg/sql/plan/function/agg/avg_tw_cache.go
+++ b/pkg/sql/plan/function/agg/avg_tw_cache.go
@@ -115,6 +115,10 @@ type AvgTwCacheContext struct {
 	Count int64
 }
 
+func (a *AvgTwCacheContext) Size() int64 {
+	return 16 // float64 + int64
+}
+
 func (a *AvgTwCacheContext) Marshal() []byte {
 	res := make([]byte, 16)
 	s := types.EncodeFloat64(&a.Sum)
@@ -177,6 +181,10 @@ type AvgTwCacheDecimalContext struct {
 	Sum   types.Decimal128
 	Count int64
 	Scale int32
+}
+
+func (a *AvgTwCacheDecimalContext) Size() int64 {
+	return 32
 }
 
 func (a *AvgTwCacheDecimalContext) Marshal() []byte {

--- a/pkg/sql/plan/function/agg/avg_tw_result.go
+++ b/pkg/sql/plan/function/agg/avg_tw_result.go
@@ -49,6 +49,10 @@ type AvgTwResultContext struct {
 	Count int64
 }
 
+func (a *AvgTwResultContext) Size() int64 {
+	return 16 // float64 + int64
+}
+
 func (a *AvgTwResultContext) Marshal() []byte {
 	res := make([]byte, 16)
 	s := types.EncodeFloat64(&a.Sum)
@@ -111,6 +115,10 @@ type AvgTwResultDecimalContext struct {
 	Sum   types.Decimal128
 	Count int64
 	Scale int32
+}
+
+func (a *AvgTwResultDecimalContext) Size() int64 {
+	return 32
 }
 
 func (a *AvgTwResultDecimalContext) Marshal() []byte {

--- a/pkg/sql/plan/function/agg/bitmap.go
+++ b/pkg/sql/plan/function/agg/bitmap.go
@@ -49,6 +49,11 @@ type aggBitmapGroupContext struct {
 func generateBitmapGroupContext(_ types.Type, _ ...types.Type) aggexec.AggGroupExecContext {
 	return &aggBitmapGroupContext{bmp: roaring.New()}
 }
+
+func (a *aggBitmapGroupContext) Size() int64 {
+	return int64(a.bmp.GetSizeInBytes())
+}
+
 func (a *aggBitmapGroupContext) Marshal() []byte {
 	b, _ := a.bmp.ToBytes()
 	return b

--- a/pkg/sql/plan/function/agg/size_test.go
+++ b/pkg/sql/plan/function/agg/size_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggAvgContext_Size(t *testing.T) {
+	ctx := aggAvgContext(0)
+	require.Equal(t, int64(8), ctx.Size())
+}
+
+func TestAggAvgDecimalCommonCtx_Size(t *testing.T) {
+	ctx := aggAvgDecimalCommonCtx(0)
+	require.Equal(t, int64(4), ctx.Size())
+}
+
+func TestAvgTwCacheContext_Size(t *testing.T) {
+	ctx := AvgTwCacheContext{}
+	require.Equal(t, int64(16), ctx.Size())
+}
+
+func TestAvgTwCacheDecimalContext_Size(t *testing.T) {
+	ctx := AvgTwCacheDecimalContext{}
+	require.Equal(t, int64(32), ctx.Size())
+}
+
+func TestAvgTwResultContext_Size(t *testing.T) {
+	ctx := AvgTwResultContext{}
+	require.Equal(t, int64(16), ctx.Size())
+}
+
+func TestAvgTwResultDecimalContext_Size(t *testing.T) {
+	ctx := AvgTwResultDecimalContext{}
+	require.Equal(t, int64(32), ctx.Size())
+}
+
+func TestAggVarPopGroupContext_Size(t *testing.T) {
+	ctx := aggVarPopGroupContext{}
+	require.Equal(t, int64(16), ctx.Size())
+}
+
+func TestAggVarPopOfDecimalGroupContext_Size(t *testing.T) {
+	ctx := aggVarPopOfDecimalGroupContext{}
+	require.Equal(t, int64(32), ctx.Size())
+}
+
+func TestAggVarPopOfDecimalCommonContext_Size(t *testing.T) {
+	ctx := aggVarPopOfDecimalCommonContext{}
+	require.Equal(t, int64(8), ctx.Size())
+}
+
+func TestAggSumDecimal_Size(t *testing.T) {
+	ctx := aggSumDecimal{}
+	require.Equal(t, int64(4), ctx.Size())
+}

--- a/pkg/sql/plan/function/agg/sum.go
+++ b/pkg/sql/plan/function/agg/sum.go
@@ -144,6 +144,10 @@ type aggSumDecimal struct {
 	argScale int32
 }
 
+func (a *aggSumDecimal) Size() int64 {
+	return 4 // int32
+}
+
 func (a *aggSumDecimal) Marshal() []byte     { return types.EncodeInt32(&a.argScale) }
 func (a *aggSumDecimal) Unmarshal(bs []byte) { a.argScale = types.DecodeInt32(bs) }
 func aggSumOfDecimalInitCommonContext(

--- a/pkg/sql/plan/function/agg/var_pop.go
+++ b/pkg/sql/plan/function/agg/var_pop.go
@@ -121,6 +121,11 @@ func generateAggVarPopGroupContext(_ types.Type, _ ...types.Type) aggexec.AggGro
 		count: 0,
 	}
 }
+
+func (a *aggVarPopGroupContext) Size() int64 {
+	return 16 // float64 + int64
+}
+
 func (a *aggVarPopGroupContext) Marshal() []byte {
 	bs := types.EncodeFloat64(&a.sum)
 	bs = append(bs, types.EncodeInt64(&a.count)...)
@@ -202,6 +207,11 @@ func generateAggVarPopOfDecimalGroupContext(_ types.Type, _ ...types.Type) aggex
 		sum:      types.Decimal128{},
 	}
 }
+
+func (a *aggVarPopOfDecimalGroupContext) Size() int64 {
+	return 32
+}
+
 func (a *aggVarPopOfDecimalGroupContext) Marshal() []byte {
 	bs := types.EncodeInt64(&a.count)
 	bs = append(bs, types.EncodeBool(&a.overflow)...)
@@ -225,6 +235,11 @@ func generateAggVarPopOfDecimalCommonContext(ret types.Type, parameters ...types
 		resultScale: ret.Scale,
 	}
 }
+
+func (a *aggVarPopOfDecimalCommonContext) Size() int64 {
+	return 8
+}
+
 func (a *aggVarPopOfDecimalCommonContext) Marshal() []byte {
 	bs := types.EncodeInt32(&a.argScale)
 	bs = append(bs, types.EncodeInt32(&a.resultScale)...)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #3433

## What this PR does / why we need it:
add AggFuncExec.Size to estimate the memory consumption of aggregation states.