### PR TITLE
fifocache: fix potential double-free

### DIFF
--- a/pkg/fileservice/fifocache/data_cache.go
+++ b/pkg/fileservice/fifocache/data_cache.go
@@ -80,6 +80,7 @@ func (d *DataCache) deletePath(ctx context.Context, shardIndex int, path string)
 	for key, item := range shard.values {
 		if key.Path == path {
 			delete(shard.values, key)
+			// key deleted, call postEvict
 			if d.fifo.postEvict != nil {
 				d.fifo.postEvict(ctx, item.key, item.value, item.size)
 			}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22195

## What this PR does / why we need it:
Fix potential double free in the fifocache.

The postEvict callback may be incorrectly called twice in this situation:
1. Item is deleted by calling Delete explicitly;
2. The item is evicted from the queue.

Fixed by checking item existence in the values map before calling postEvict.