### PR TITLE
support strcmp

### DIFF
--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -2142,6 +2142,20 @@ func getSliceFromRight(s string, offset int64) string {
 	return string(substrRune)
 }
 
+func StrCmp(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) (err error) {
+	return opBinaryStrStrToFixedWithErrorCheck[int8](ivecs, result, proc, length, strcmp, nil)
+}
+
+func strcmp(s1, s2 string) (int8, error) {
+	if s1 == s2 {
+		return 0, nil
+	}
+	if s1 < s2 {
+		return -1, nil
+	}
+	return 1, nil
+}
+
 func SubStringWith2Args(ivecs []*vector.Vector, result vector.FunctionResultWrapper, _ *process.Process, length int, selectList *FunctionSelectList) (err error) {
 	rs := vector.MustFunctionResult[types.Varlena](result)
 	vs := vector.GenerateFunctionStrParameter(ivecs[0])

--- a/pkg/sql/plan/function/function_id.go
+++ b/pkg/sql/plan/function/function_id.go
@@ -409,9 +409,10 @@ const (
 	L2_DISTANCE_SQ_XC = 342
 
 	TS_TO_TIME = 343
+	STRCMP     = 344
 	// FUNCTION_END_NUMBER is not a function, just a flag to record the max number of function.
 	// TODO: every one should put the new function id in front of this one if you want to make a new function.
-	FUNCTION_END_NUMBER = 344
+	FUNCTION_END_NUMBER = 345
 )
 
 // functionIdRegister is what function we have registered already.
@@ -523,6 +524,7 @@ var functionIdRegister = map[string]int32{
 	"pi":                PI,
 	"round":             ROUND,
 	"rpad":              RPAD,
+	"strcmp":            STRCMP,
 	"substr":            SUBSTRING,
 	"substring":         SUBSTRING,
 	"mid":               SUBSTRING,

--- a/pkg/sql/plan/function/function_id_test.go
+++ b/pkg/sql/plan/function/function_id_test.go
@@ -392,8 +392,9 @@ var predefinedFunids = map[int]int{
 	L2_DISTANCE_SQ_XC: 342,
 
 	TS_TO_TIME: 343,
+	STRCMP:     344,
 
-	FUNCTION_END_NUMBER: 344,
+	FUNCTION_END_NUMBER: 345,
 }
 
 func Test_funids(t *testing.T) {

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -1724,6 +1724,27 @@ var supportedStringBuiltIns = []FuncNew{
 		},
 	},
 
+	// strcmp
+	{
+		functionId: STRCMP,
+		class:      plan.Function_STRICT,
+		layout:     STANDARD_FUNCTION,
+		checkFn:    fixedTypeMatch,
+
+		Overloads: []overload{
+			{
+				overloadId: 0,
+				args:       []types.T{types.T_varchar, types.T_varchar},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int8.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return StrCmp
+				},
+			},
+		},
+	},
+
 	// function `substring`, `substr`, `mid`
 	{
 		functionId: SUBSTRING,

--- a/test/distributed/cases/function/func_string_strcmp.result
+++ b/test/distributed/cases/function/func_string_strcmp.result
@@ -1,0 +1,21 @@
+select strcmp('a', 'b');
+strcmp(a, b)
+-1
+select strcmp('abc', 'acd');
+strcmp(abc, acd)
+-1
+select strcmp('a', null);
+strcmp(a, null)
+null
+select strcmp('a ', 'a');
+strcmp(a , a)
+1
+select strcmp('a', 'a');
+strcmp(a, a)
+0
+select strcmp(BINARY 'a', BINARY 'A');
+strcmp(BINARY(a), BINARY(A))
+1
+select strcmp(65, 97);
+strcmp(65, 97)
+-1

--- a/test/distributed/cases/function/func_string_strcmp.test
+++ b/test/distributed/cases/function/func_string_strcmp.test
@@ -1,0 +1,7 @@
+select strcmp('a', 'b');
+select strcmp('abc', 'acd');
+select strcmp('a', null);
+select strcmp('a ', 'a');
+select strcmp('a', 'a');
+select strcmp(BINARY 'a', BINARY 'A');
+select strcmp(65, 97);


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/15359

## What this PR does / why we need it:
support `select strcmp(xxx, xxx);`