### PR TITLE
[opt] eliminate memory copy in RIGHT DEDUP join

### DIFF
--- a/pkg/container/batch/batch.go
+++ b/pkg/container/batch/batch.go
@@ -414,7 +414,7 @@ func (bat *Batch) Clean(m *mpool.MPool) {
 
 	for i, vec := range bat.Vecs {
 		if vec != nil {
-			bat.ReplaceVector(vec, nil, i)
+			bat.SetVector(int32(i), nil)
 			vec.Free(m)
 		}
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22151

## What this PR does / why we need it:
memory copy in RIGHT DEDUP join takes more than half of query time in particular test