### PR TITLE
colexec/aggexec: implement marshal/unmarshal for distinctHash; export special agg ids

### DIFF
--- a/pkg/sql/colexec/aggexec/median_test.go
+++ b/pkg/sql/colexec/aggexec/median_test.go
@@ -64,7 +64,7 @@ func TestMedianAggSize(t *testing.T) {
 	}()
 
 	agg, err := newMedianExecutor(m, singleAggInfo{
-		aggID:     aggIdOfMedian,
+		aggID:     AggIdOfMedian,
 		distinct:  false,
 		argType:   types.T_int64.ToType(),
 		retType:   MedianReturnType([]types.Type{types.T_int64.ToType()}),

--- a/pkg/sql/colexec/aggexec/register.go
+++ b/pkg/sql/colexec/aggexec/register.go
@@ -29,43 +29,43 @@ import (
 
 func RegisterCountColumnAgg(id int64) {
 	specialAgg[id] = true
-	aggIdOfCountColumn = id
+	AggIdOfCountColumn = id
 }
 
 func RegisterCountStarAgg(id int64) {
 	specialAgg[id] = true
-	aggIdOfCountStar = id
+	AggIdOfCountStar = id
 }
 
 func RegisterGroupConcatAgg(id int64, sep string) {
 	specialAgg[id] = true
-	aggIdOfGroupConcat = id
+	AggIdOfGroupConcat = id
 	groupConcatSep = sep
 }
 
 func RegisterApproxCountAgg(id int64) {
 	specialAgg[id] = true
-	aggIdOfApproxCount = id
+	AggIdOfApproxCount = id
 }
 
 func RegisterMedian(id int64) {
 	specialAgg[id] = true
-	aggIdOfMedian = id
+	AggIdOfMedian = id
 }
 
 func RegisterRowNumberWin(id int64) {
 	specialAgg[id] = true
-	winIdOfRowNumber = id
+	WinIdOfRowNumber = id
 }
 
 func RegisterRankWin(id int64) {
 	specialAgg[id] = true
-	winIdOfRank = id
+	WinIdOfRank = id
 }
 
 func RegisterDenseRankWin(id int64) {
 	specialAgg[id] = true
-	winIdOfDenseRank = id
+	WinIdOfDenseRank = id
 }
 
 type registeredAggInfo struct {
@@ -89,14 +89,14 @@ var (
 	registeredAggFunctions = make(map[aggKey]aggImplementation)
 
 	// list of special aggregation function IDs.
-	aggIdOfCountColumn = int64(-1)
-	aggIdOfCountStar   = int64(-2)
-	aggIdOfGroupConcat = int64(-3)
-	aggIdOfApproxCount = int64(-4)
-	aggIdOfMedian      = int64(-5)
-	winIdOfRowNumber   = int64(-7)
-	winIdOfRank        = int64(-8)
-	winIdOfDenseRank   = int64(-9)
+	AggIdOfCountColumn = int64(-1)
+	AggIdOfCountStar   = int64(-2)
+	AggIdOfGroupConcat = int64(-3)
+	AggIdOfApproxCount = int64(-4)
+	AggIdOfMedian      = int64(-5)
+	WinIdOfRowNumber   = int64(-7)
+	WinIdOfRank        = int64(-8)
+	WinIdOfDenseRank   = int64(-9)
 	groupConcatSep     = ","
 	getCroupConcatRet  = func(args ...types.Type) types.Type {
 		for _, p := range args {

--- a/pkg/sql/colexec/aggexec/serialize.go
+++ b/pkg/sql/colexec/aggexec/serialize.go
@@ -15,14 +15,10 @@
 package aggexec
 
 import (
-	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 )
 
 func MarshalAggFuncExec(exec AggFuncExec) ([]byte, error) {
-	if exec.IsDistinct() {
-		return nil, moerr.NewInternalErrorNoCtx("marshal distinct agg exec is not supported")
-	}
 	return exec.marshal()
 }
 
@@ -41,7 +37,7 @@ func UnmarshalAggFuncExec(
 		return nil, err
 	}
 
-	if encoded.Info.Id == aggIdOfGroupConcat {
+	if encoded.Info.Id == AggIdOfGroupConcat {
 		if len(encoded.Groups) > 0 && len(encoded.Groups[0]) > 0 {
 			exec.(*groupConcatExec).separator = encoded.Groups[0]
 		}

--- a/pkg/sql/colexec/aggexec/types.go
+++ b/pkg/sql/colexec/aggexec/types.go
@@ -221,18 +221,18 @@ func makeSpecialAggExec(
 ) (AggFuncExec, bool, error) {
 	if _, ok := specialAgg[id]; ok {
 		switch id {
-		case aggIdOfCountColumn:
+		case AggIdOfCountColumn:
 			return makeCount(mg, false, id, isDistinct, params[0]), true, nil
-		case aggIdOfCountStar:
+		case AggIdOfCountStar:
 			return makeCount(mg, true, id, isDistinct, params[0]), true, nil
-		case aggIdOfMedian:
+		case AggIdOfMedian:
 			exec, err := makeMedian(mg, id, isDistinct, params[0])
 			return exec, true, err
-		case aggIdOfGroupConcat:
+		case AggIdOfGroupConcat:
 			return makeGroupConcat(mg, id, isDistinct, params, getCroupConcatRet(params...), groupConcatSep), true, nil
-		case aggIdOfApproxCount:
+		case AggIdOfApproxCount:
 			return makeApproxCount(mg, id, params[0]), true, nil
-		case winIdOfRowNumber, winIdOfRank, winIdOfDenseRank:
+		case WinIdOfRowNumber, WinIdOfRank, WinIdOfDenseRank:
 			exec, err := makeWindowExec(mg, id, isDistinct)
 			return exec, true, err
 		}

--- a/pkg/sql/colexec/aggexec/window.go
+++ b/pkg/sql/colexec/aggexec/window.go
@@ -126,11 +126,11 @@ func (exec *singleWindowExec) SetExtraInformation(partialResult any, groupIndex 
 
 func (exec *singleWindowExec) Flush() ([]*vector.Vector, error) {
 	switch exec.singleAggInfo.aggID {
-	case winIdOfRank:
+	case WinIdOfRank:
 		return exec.flushRank()
-	case winIdOfDenseRank:
+	case WinIdOfDenseRank:
 		return exec.flushDenseRank()
-	case winIdOfRowNumber:
+	case WinIdOfRowNumber:
 		return exec.flushRowNumber()
 	}
 	return nil, moerr.NewInternalErrorNoCtx("invalid window function")


### PR DESCRIPTION

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #3433

## What this PR does / why we need it:
Make aggregate states with distinctHash marshal/unmarshal-able.
Export special agg ids to allow use in tests.