### PR TITLE
trigger ON UPDATE for INSERT ON DUPLICATE UPDATE 2.2-dev

### DIFF
--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -173,6 +173,18 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 			}
 			updateExprs[colDef.Name] = updateExpr
 		}
+
+		for _, col := range tableDef.Cols {
+			if col.OnUpdate != nil && col.OnUpdate.Expr != nil && updateExprs[col.Name] == nil {
+				newDefExpr := DeepCopyExpr(col.OnUpdate.Expr)
+				err = replaceFuncId(builder.GetContext(), newDefExpr)
+				if err != nil {
+					return 0, err
+				}
+
+				updateExprs[col.Name] = newDefExpr
+			}
+		}
 	}
 
 	for _, part := range tableDef.Pkey.Names {

--- a/test/distributed/cases/dml/insert/on_duplicate_key.result
+++ b/test/distributed/cases/dml/insert/on_duplicate_key.result
@@ -224,3 +224,16 @@ execute s1 using @a;
 execute s1 using @a;
 execute s1 using @a;
 execute s1 using @a;
+drop table if exists users;
+create table users (id int primary key auto_increment, counter int, create_at datetime default current_timestamp, update_at datetime default current_timestamp on update current_timestamp);
+insert into users (id, counter) values ('112',1);
+select id, counter, create_at = update_at from users;
+id    counter    create_at = update_at
+112    1    true
+select sleep(1);
+sleep(1)
+0
+insert into users (id, counter) values ('112',2) on duplicate key update counter=counter+values(counter), create_at=current_timestamp();
+select id, counter, create_at = update_at from users;
+id    counter    create_at = update_at
+112    3    true

--- a/test/distributed/cases/dml/insert/on_duplicate_key.sql
+++ b/test/distributed/cases/dml/insert/on_duplicate_key.sql
@@ -151,3 +151,11 @@ execute s1 using @a;
 execute s1 using @a;
 execute s1 using @a;
 execute s1 using @a;
+
+drop table if exists users;
+create table users (id int primary key auto_increment, counter int, create_at datetime default current_timestamp, update_at datetime default current_timestamp on update current_timestamp);
+insert into users (id, counter) values ('112',1);
+select id, counter, create_at = update_at from users;
+select sleep(1);
+insert into users (id, counter) values ('112',2) on duplicate key update counter=counter+values(counter), create_at=current_timestamp();
+select id, counter, create_at = update_at from users;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/6002

## What this PR does / why we need it:
the ON UPDATE clause in column definition should be triggered in INSERT ON DUPLICATE KEY UPDATE stmt as well as in UPDATE.