### PR TITLE
Modify S3 write operations to use off-heap memory batches 2.2

### DIFF
--- a/pkg/container/batch/batch.go
+++ b/pkg/container/batch/batch.go
@@ -471,9 +471,7 @@ func (bat *Batch) String() string {
 	return buf.String()
 }
 
-// Dup used to copy a Batch object, this method will create a new batch
-// and copy all vectors (Vecs) of the current batch to the new batch.
-func (bat *Batch) Dup(mp *mpool.MPool) (*Batch, error) {
+func (bat *Batch) Clone(mp *mpool.MPool, offHeap bool) (*Batch, error) {
 	var err error
 
 	rbat := NewWithSize(len(bat.Vecs))
@@ -482,7 +480,7 @@ func (bat *Batch) Dup(mp *mpool.MPool) (*Batch, error) {
 	for j, vec := range bat.Vecs {
 		typ := *bat.GetVector(int32(j)).GetType()
 		var rvec *vector.Vector
-		if bat.offHeap {
+		if offHeap {
 			rvec = vector.NewOffHeapVecWithType(typ)
 		} else {
 			rvec = vector.NewVec(typ)
@@ -511,6 +509,12 @@ func (bat *Batch) Dup(mp *mpool.MPool) (*Batch, error) {
 	//}
 
 	return rbat, nil
+}
+
+// Dup used to copy a Batch object, this method will create a new batch
+// and copy all vectors (Vecs) of the current batch to the new batch.
+func (bat *Batch) Dup(mp *mpool.MPool) (*Batch, error) {
+	return bat.Clone(mp, bat.offHeap)
 }
 
 func (bat *Batch) Union(bat2 *Batch, sels []int64, m *mpool.MPool) error {

--- a/pkg/container/batch/compact_batchs.go
+++ b/pkg/container/batch/compact_batchs.go
@@ -119,7 +119,7 @@ func (bats *CompactBatchs) Extend(mpool *mpool.MPool, inBatch *Batch) error {
 		return nil
 	}
 
-	copyBat, err = inBatch.Dup(mpool)
+	copyBat, err = inBatch.Clone(mpool, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/objectio/ioutil/sinker.go
+++ b/pkg/objectio/ioutil/sinker.go
@@ -62,6 +62,12 @@ func WithMemorySizeThreshold(size int) SinkerOption {
 	}
 }
 
+func WithOffHeap() SinkerOption {
+	return func(sinker *Sinker) {
+		sinker.config.offHeap = true
+	}
+}
+
 func WithBuffer(buffer *containers.OneSchemaBatchBuffer, isOwner bool) SinkerOption {
 	return func(sinker *Sinker) {
 		sinker.buf.isOwner = isOwner
@@ -319,6 +325,7 @@ type Sinker struct {
 		dedupAll       bool
 		bufferSizeCap  int
 		tailSizeCap    int
+		offHeap        bool
 	}
 	fSinker struct {
 		executor FileSinker
@@ -375,6 +382,7 @@ func (sinker *Sinker) fillDefaults() {
 			sinker.schema.attrs,
 			sinker.schema.attrTypes,
 		)
+		sinker.buf.buffers.SetOffHeap(sinker.config.offHeap)
 	}
 }
 
@@ -561,7 +569,6 @@ func (sinker *Sinker) Write(
 			sinker.putBackBuffer(curr)
 		}
 	}()
-
 	offset := 0
 	left := data.RowCount()
 	for left > 0 {

--- a/pkg/sql/colexec/s3util.go
+++ b/pkg/sql/colexec/s3util.go
@@ -155,7 +155,8 @@ func NewCNS3DataWriter(
 		sortKeyIdx, attrs, attrTypes,
 		factor, mp, fs,
 		ioutil.WithTailSizeCap(0),
-		ioutil.WithMemorySizeThreshold(int(WriteS3Threshold)))
+		ioutil.WithMemorySizeThreshold(int(WriteS3Threshold)),
+		ioutil.WithOffHeap())
 
 	writer.ResetBlockInfoBat()
 

--- a/pkg/vm/engine/tae/containers/utils.go
+++ b/pkg/vm/engine/tae/containers/utils.go
@@ -36,6 +36,7 @@ type IBatchBuffer interface {
 
 type OneSchemaBatchBuffer struct {
 	sync.Mutex
+	offHeap   bool
 	sizeCap   int
 	currSize  int
 	highWater int
@@ -60,6 +61,12 @@ func NewOneSchemaBatchBuffer(
 	}
 }
 
+func (bb *OneSchemaBatchBuffer) SetOffHeap(offHeap bool) {
+	bb.Lock()
+	defer bb.Unlock()
+	bb.offHeap = offHeap
+}
+
 func (bb *OneSchemaBatchBuffer) Len() int {
 	bb.Lock()
 	defer bb.Unlock()
@@ -82,7 +89,7 @@ func (bb *OneSchemaBatchBuffer) FetchWithSchema(attrs []string, types []types.Ty
 		}
 	}
 	if len(bb.buffer) == 0 {
-		return batch.NewWithSchema(false, bb.attrs, bb.typs)
+		return batch.NewWithSchema(bb.offHeap, bb.attrs, bb.typs)
 	}
 	bat := bb.buffer[len(bb.buffer)-1]
 	bb.buffer = bb.buffer[:len(bb.buffer)-1]
@@ -94,7 +101,7 @@ func (bb *OneSchemaBatchBuffer) Fetch() *batch.Batch {
 	bb.Lock()
 	defer bb.Unlock()
 	if len(bb.buffer) == 0 {
-		return batch.NewWithSchema(false, bb.attrs, bb.typs)
+		return batch.NewWithSchema(bb.offHeap, bb.attrs, bb.typs)
 	}
 	bat := bb.buffer[len(bb.buffer)-1]
 	bb.buffer = bb.buffer[:len(bb.buffer)-1]


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:


issue https://github.com/matrixorigin/matrixone/issues/22199

## What this PR does / why we need it:

Intensive write operations create significant GC pressure, making large table copies (10M+ rows, 6 GB data) prone to OOM errors on 16GB machines.

Before
<img width="1727" height="684" alt="Image" src="https://github.com/user-attachments/assets/3f3e4d44-48ac-4cbc-8177-a9301186abf7" />


After
<img width="3444" height="1376" alt="image" src="https://github.com/user-attachments/assets/8e7a174d-459a-4448-b2bf-301d3d6f78a2" />