### PR TITLE
fix right join dedup memory leak

### DIFF
--- a/pkg/sql/colexec/rightdedupjoin/join.go
+++ b/pkg/sql/colexec/rightdedupjoin/join.go
@@ -264,7 +264,6 @@ func (ctr *container) probe(bat *batch.Batch, ap *RightDedupJoin, proc *process.
 
 	for i, rp := range ap.Result {
 		result.Batch.Vecs[i] = bat.Vecs[rp.Pos]
-		bat.Vecs[rp.Pos] = nil
 	}
 
 	return nil


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22226

## What this PR does / why we need it:

fix right join dedup memory leak


___

### **PR Type**
Bug fix


___

### **Description**
- Remove vector nullification to fix memory leak

- Prevent premature cleanup of batch vectors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["probe function"] --> B["create result batch"]
  B --> C["assign vectors to result"]
  C --> D["removed: bat.Vecs[rp.Pos] = nil"]
  D --> E["fixed memory leak"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>join.go</strong><dd><code>Remove vector nullification in probe function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/rightdedupjoin/join.go

<ul><li>Removed line that sets <code>bat.Vecs[rp.Pos] = nil</code><br> <li> Prevents premature vector cleanup in probe function<br> <li> Fixes memory leak in right join deduplication</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22293/files#diff-16e2c9a2d8aa6a2195b50873cd6ca4bc552522d7528f20ac8cb63b6cf81e104b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

