### PR TITLE
Pick 22284 22293 to 3.0-dev

### DIFF
--- a/pkg/objectio/ioutil/sinker.go
+++ b/pkg/objectio/ioutil/sinker.go
@@ -569,6 +569,14 @@ func (sinker *Sinker) getStageFileSinker() FileSinker {
 	return sinker.fSinker.executor
 }
 
+func (sinker *Sinker) GetInMemoryData() []*batch.Batch {
+	return sinker.staged.inMemory
+}
+
+func (sinker *Sinker) GetMPool() *mpool.MPool {
+	return sinker.mp
+}
+
 // Write always copy the data
 func (sinker *Sinker) Write(
 	ctx context.Context,
@@ -673,6 +681,10 @@ func (sinker *Sinker) Sync(ctx context.Context) error {
 	// }
 	// sinker.results = append(sinker.results, newPersied...)
 	//return nil
+}
+
+func (sinker *Sinker) GetInMemoryThreshold() int {
+	return sinker.staged.memorySizeThreshold
 }
 
 func (sinker *Sinker) Close() error {

--- a/pkg/sql/colexec/deletion/types.go
+++ b/pkg/sql/colexec/deletion/types.go
@@ -262,7 +262,7 @@ func (ctr *container) flush(proc *process.Process, analyzer process.Analyzer) (u
 
 			if s3writer == nil {
 				pkType := *bat.Vecs[1].GetType()
-				s3writer = colexec.NewCNS3TombstoneWriter(proc.Mp(), fs, pkType)
+				s3writer = colexec.NewCNS3TombstoneWriter(proc.Mp(), fs, pkType, -1)
 			}
 
 			if err = s3writer.Write(proc.Ctx, bat); err != nil {

--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -55,7 +55,7 @@ func (insert *Insert) Prepare(proc *process.Process) error {
 
 		// If the target is not partition table, you only need to operate the main table
 		s3Writer := colexec.NewCNS3DataWriter(
-			proc.Mp(), fs, insert.InsertCtx.TableDef, insert.isMemoryTable())
+			proc.Mp(), fs, insert.InsertCtx.TableDef, -1, insert.isMemoryTable())
 
 		insert.ctr.s3Writer = s3Writer
 
@@ -251,5 +251,5 @@ func flushTailBatch(
 		return nil
 	}
 
-	return writer.OutputRawData(proc, result.Batch)
+	return writer.OutputInMemoryData(result.Batch)
 }

--- a/pkg/sql/colexec/rightdedupjoin/join.go
+++ b/pkg/sql/colexec/rightdedupjoin/join.go
@@ -264,7 +264,6 @@ func (ctr *container) probe(bat *batch.Batch, ap *RightDedupJoin, proc *process.
 
 	for i, rp := range ap.Result {
 		result.Batch.Vecs[i] = bat.Vecs[rp.Pos]
-		bat.Vecs[rp.Pos] = nil
 	}
 
 	return nil

--- a/pkg/sql/colexec/s3util.go
+++ b/pkg/sql/colexec/s3util.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -39,29 +40,36 @@ import (
 const (
 	// WriteS3Threshold when batches'  size of table reaches this, we will
 	// trigger write s3
-	WriteS3Threshold         uint64 = 128 * mpool.MB
-	FaultInjectedS3Threshold uint64 = 512 * mpool.KB
+	WriteS3Threshold         = 128 * mpool.MB
+	FaultInjectedS3Threshold = 512 * mpool.KB
 )
 
 type CNS3Writer struct {
 	sinker       *ioutil.Sinker
-	written      []objectio.ObjectStats
+	isTombstone  bool
 	blockInfoBat *batch.Batch
-
-	hold                   []*batch.Batch
-	holdFlushUntilSyncCall bool
-
-	isTombstone bool
-	mp          *mpool.MPool
 }
 
 func (w *CNS3Writer) String() string {
 	buf := bytes.NewBuffer(nil)
 	buf.WriteString(fmt.Sprintf("Sinker: %s\n", w.sinker.String()))
+	inMemoryThreshold := w.sinker.GetInMemoryThreshold()
+	flushOnSync := inMemoryThreshold == math.MaxInt
+	var flushOnSyncBatches []*batch.Batch
+	if flushOnSync {
+		flushOnSyncBatches = w.sinker.GetInMemoryData()
+	}
+
+	result, _ := w.sinker.GetResult()
+
 	buf.WriteString(fmt.Sprintf(
-		"Others: {written=%d, isTombstone=%v, holdFlushUntilSyncCall=%v, hold=%v, blockInfoBat=%v}",
-		len(w.written), w.isTombstone, w.holdFlushUntilSyncCall, len(w.hold),
-		common.MoBatchToString(w.blockInfoBat, w.blockInfoBat.RowCount())))
+		"Others: {result_len=%d, isTombstone=%v, flushOnSync=%v, flushOnSyncBatches_len=%d, blockInfoBat=%v}",
+		len(result),
+		w.isTombstone,
+		flushOnSync,
+		len(flushOnSyncBatches),
+		common.MoBatchToString(w.blockInfoBat, w.blockInfoBat.RowCount())),
+	)
 
 	return buf.String()
 }
@@ -70,15 +78,19 @@ func NewCNS3TombstoneWriter(
 	mp *mpool.MPool,
 	fs fileservice.FileService,
 	pkType types.Type,
+	memoryThreshold int,
 	opts ...ioutil.SinkerOption,
 ) *CNS3Writer {
 
 	writer := &CNS3Writer{
-		mp:          mp,
 		isTombstone: true,
 	}
 
-	opts = append(opts, ioutil.WithMemorySizeThreshold(int(WriteS3Threshold)))
+	if memoryThreshold < 0 {
+		memoryThreshold = WriteS3Threshold
+	}
+
+	opts = append(opts, ioutil.WithMemorySizeThreshold(memoryThreshold))
 	opts = append(opts, ioutil.WithTailSizeCap(0))
 
 	writer.sinker = ioutil.NewTombstoneSinker(
@@ -147,40 +159,49 @@ func GetSequmsAttrsSortKeyIdxFromTableDef(
 	return sequms, attrTypes, attrs, sortKeyIdx, isPrimaryKey
 }
 
+// `flushOnSync` true means memoryThreshold is math.MaxInt
+// `memoryThreshold`
+// 1. only effect when `flushOnSync` is false
+// 2. < 0 use default threshold
 func NewCNS3DataWriter(
 	mp *mpool.MPool,
 	fs fileservice.FileService,
 	tableDef *plan.TableDef,
-	holdFlushUntilSyncCall bool,
+	memoryThreshold int,
+	flushOnSync bool,
 	sinkerOpts ...ioutil.SinkerOption,
 ) *CNS3Writer {
 
-	writer := &CNS3Writer{
-		holdFlushUntilSyncCall: holdFlushUntilSyncCall,
-		mp:                     mp,
-	}
+	writer := new(CNS3Writer)
 
 	sequms, attrTypes, attrs, sortKeyIdx, isPrimaryKey := GetSequmsAttrsSortKeyIdxFromTableDef(tableDef)
 
 	factor := ioutil.NewFSinkerImplFactory(sequms, sortKeyIdx, isPrimaryKey, false, tableDef.Version)
+	if memoryThreshold < 0 {
+		memoryThreshold = WriteS3Threshold
+	}
 
-	threshold := WriteS3Threshold
 	if faultInjected, _ := objectio.LogCNFlushSmallObjsInjected(
 		tableDef.DbName, tableDef.Name,
 	); faultInjected {
-		threshold = FaultInjectedS3Threshold
+		memoryThreshold = FaultInjectedS3Threshold
+	}
+	if flushOnSync {
+		// do not flush on sync, so the threshold is the max int
+		memoryThreshold = math.MaxInt
 	}
 
-	opts := []ioutil.SinkerOption{
-		ioutil.WithTailSizeCap(0),
-		ioutil.WithMemorySizeThreshold(int(threshold)),
-		ioutil.WithOffHeap(),
-	}
-	opts = append(opts, sinkerOpts...)
+	sinkerOpts = append(sinkerOpts, ioutil.WithMemorySizeThreshold(memoryThreshold))
+	sinkerOpts = append(sinkerOpts, ioutil.WithTailSizeCap(0))
+	sinkerOpts = append(sinkerOpts, ioutil.WithOffHeap())
 	writer.sinker = ioutil.NewSinker(
-		sortKeyIdx, attrs, attrTypes,
-		factor, mp, fs,
-		opts...,
+		sortKeyIdx,
+		attrs,
+		attrTypes,
+		factor,
+		mp,
+		fs,
+		sinkerOpts...,
 	)
 
 	writer.ResetBlockInfoBat()
@@ -189,65 +210,32 @@ func NewCNS3DataWriter(
 }
 
 func (w *CNS3Writer) Write(ctx context.Context, bat *batch.Batch) error {
-	if w.holdFlushUntilSyncCall {
-		copied, err := bat.Dup(w.mp)
-		if err != nil {
-			return err
-		}
-		w.hold = append(w.hold, copied)
-	} else {
-		return w.sinker.Write(ctx, bat)
-	}
-	return nil
+	return w.sinker.Write(ctx, bat)
 }
 
-func (w *CNS3Writer) Sync(ctx context.Context) ([]objectio.ObjectStats, error) {
-	defer func() {
-		for _, bat := range w.hold {
-			bat.Clean(w.mp)
-		}
-		w.hold = nil
-	}()
-
-	if len(w.hold) != 0 {
-		for _, bat := range w.hold {
-			if err := w.sinker.Write(ctx, bat); err != nil {
-				return nil, err
-			}
-		}
+func (w *CNS3Writer) Sync(ctx context.Context) (stats []objectio.ObjectStats, err error) {
+	if err = w.sinker.Sync(ctx); err != nil {
+		return
 	}
 
-	if err := w.sinker.Sync(ctx); err != nil {
-		return nil, err
-	}
-
-	w.written, _ = w.sinker.GetResult()
-
-	return w.written, nil
+	stats, _ = w.sinker.GetResult()
+	return
 }
 
-func (w *CNS3Writer) Close() error {
+func (w *CNS3Writer) Close() (err error) {
+	var mp *mpool.MPool
 	if w.sinker != nil {
-		if err := w.sinker.Close(); err != nil {
-			return err
+		mp = w.sinker.GetMPool()
+		if err = w.sinker.Close(); err != nil {
+			return
 		}
 		w.sinker = nil
 	}
 
-	if len(w.hold) != 0 {
-		for _, bat := range w.hold {
-			bat.Clean(w.mp)
-		}
-		w.hold = nil
-		w.holdFlushUntilSyncCall = false
-	}
-
 	if w.blockInfoBat != nil {
-		w.blockInfoBat.Clean(w.mp)
+		w.blockInfoBat.Clean(mp)
 		w.blockInfoBat = nil
 	}
-
-	w.written = nil
 
 	return nil
 }
@@ -303,9 +291,21 @@ func ExpandObjectStatsToBatch(
 
 func (w *CNS3Writer) FillBlockInfoBat() (*batch.Batch, error) {
 
-	err := ExpandObjectStatsToBatch(w.mp, w.isTombstone, w.blockInfoBat, true, w.written...)
+	w.ResetBlockInfoBat()
 
-	return w.blockInfoBat, err
+	result, _ := w.sinker.GetResult()
+
+	if err := ExpandObjectStatsToBatch(
+		w.sinker.GetMPool(),
+		w.isTombstone,
+		w.blockInfoBat,
+		true,
+		result...,
+	); err != nil {
+		return nil, err
+	}
+
+	return w.blockInfoBat, nil
 }
 
 func AllocCNS3ResultBat(
@@ -345,9 +345,9 @@ func (w *CNS3Writer) ResetBlockInfoBat() {
 
 	if w.blockInfoBat != nil {
 		w.blockInfoBat.CleanOnlyData()
+	} else {
+		w.blockInfoBat = AllocCNS3ResultBat(w.isTombstone, false)
 	}
-
-	w.blockInfoBat = AllocCNS3ResultBat(w.isTombstone, false)
 }
 
 // reference to pkg/sql/colexec/order/order.go logic
@@ -398,32 +398,22 @@ func SortByKey(
 	return nil
 }
 
-func (w *CNS3Writer) OutputRawData(
-	proc *process.Process,
-	result *batch.Batch,
-) error {
-	defer func() {
-		if len(w.hold) > 0 {
-			for _, bat := range w.hold {
-				bat.Clean(proc.Mp())
-			}
-			w.hold = nil
-		}
-	}()
-
-	for _, bat := range w.hold {
-		if err := vector.AppendFixed(
-			result.Vecs[0], int16(-1), false, proc.Mp()); err != nil {
-			return err
+func (w *CNS3Writer) OutputInMemoryData(result *batch.Batch) (err error) {
+	for _, bat := range w.sinker.GetInMemoryData() {
+		if err = vector.AppendFixed(
+			result.Vecs[0], int16(-1), false, w.sinker.GetMPool(),
+		); err != nil {
+			return
 		}
 
-		bytes, err := bat.MarshalBinary()
-		if err != nil {
-			return err
+		var buf []byte
+		if buf, err = bat.MarshalBinary(); err != nil {
+			return
 		}
 		if err = vector.AppendBytes(
-			result.Vecs[1], bytes, false, proc.Mp()); err != nil {
-			return err
+			result.Vecs[1], buf, false, w.sinker.GetMPool(),
+		); err != nil {
+			return
 		}
 	}
 

--- a/pkg/sql/colexec/s3util_test.go
+++ b/pkg/sql/colexec/s3util_test.go
@@ -87,7 +87,7 @@ func TestSetStatsCNCreated(t *testing.T) {
 	fs, err := fileservice.Get[fileservice.FileService](proc.Base.FileService, defines.SharedFileServiceName)
 	require.NoError(t, err)
 
-	s3writer := NewCNS3TombstoneWriter(proc.Mp(), fs, types.T_int32.ToType())
+	s3writer := NewCNS3TombstoneWriter(proc.Mp(), fs, types.T_int32.ToType(), -1)
 
 	err = s3writer.Write(ctx, bat)
 	require.NoError(t, err)
@@ -485,7 +485,7 @@ func TestS3Writer_SortAndSync(t *testing.T) {
 		fs, err := fileservice.Get[fileservice.FileService](proc.Base.FileService, defines.SharedFileServiceName)
 		require.NoError(t, err)
 
-		s3writer := NewCNS3TombstoneWriter(proc.Mp(), fs, types.T_int32.ToType())
+		s3writer := NewCNS3TombstoneWriter(proc.Mp(), fs, types.T_int32.ToType(), -1)
 
 		s, err := s3writer.Sync(ctx)
 		require.NoError(t, err)
@@ -499,7 +499,7 @@ func TestS3Writer_SortAndSync(t *testing.T) {
 		proc := testutil.NewProc(t)
 		ctx := proc.Ctx
 
-		s3writer := NewCNS3TombstoneWriter(proc.Mp(), proc.GetFileService(), types.T_int32.ToType())
+		s3writer := NewCNS3TombstoneWriter(proc.Mp(), proc.GetFileService(), types.T_int32.ToType(), -1)
 		err = s3writer.Write(ctx, bat)
 		require.NoError(t, err)
 
@@ -517,7 +517,7 @@ func TestS3Writer_SortAndSync(t *testing.T) {
 		fs, err := fileservice.Get[fileservice.FileService](proc.Base.FileService, defines.SharedFileServiceName)
 		require.NoError(t, err)
 
-		s3writer := NewCNS3TombstoneWriter(proc.Mp(), fs, types.T_int32.ToType())
+		s3writer := NewCNS3TombstoneWriter(proc.Mp(), fs, types.T_int32.ToType(), -1)
 
 		err = s3writer.Write(ctx, bat)
 		require.NoError(t, err)
@@ -557,7 +557,7 @@ func TestS3Writer_SortAndSync(t *testing.T) {
 
 		fs, err := fileservice.Get[fileservice.FileService](proc.Base.FileService, defines.SharedFileServiceName)
 		require.NoError(t, err)
-		s3writer := NewCNS3TombstoneWriter(proc.Mp(), fs, types.T_int32.ToType())
+		s3writer := NewCNS3TombstoneWriter(proc.Mp(), fs, types.T_int32.ToType(), -1)
 
 		err = s3writer.Write(ctx, bat2)
 		require.NoError(t, err)

--- a/pkg/vm/engine/disttae/local_disttae_datasource_test.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource_test.go
@@ -113,7 +113,7 @@ func TestLocalDatasource_ApplyWorkspaceFlushedS3Deletes(t *testing.T) {
 	int32Type := types.T_int32.ToType()
 	var tombstoneRowIds []types.Rowid
 	for i := 0; i < 3; i++ {
-		writer := colexec.NewCNS3TombstoneWriter(proc.Mp(), fs, int32Type)
+		writer := colexec.NewCNS3TombstoneWriter(proc.Mp(), fs, int32Type, -1)
 		require.NoError(t, err)
 
 		bat := readutil.NewCNTombstoneBatch(

--- a/pkg/vm/engine/disttae/table_meta_reader.go
+++ b/pkg/vm/engine/disttae/table_meta_reader.go
@@ -227,9 +227,9 @@ func (r *TableMetaReader) collectVisibleInMemRows(
 	writeS3 := func() error {
 		if s3Writer == nil {
 			if isTombstone {
-				s3Writer = colexec.NewCNS3TombstoneWriter(mp, r.fs, colTypes[1])
+				s3Writer = colexec.NewCNS3TombstoneWriter(mp, r.fs, colTypes[1], -1)
 			} else {
-				s3Writer = colexec.NewCNS3DataWriter(mp, r.fs, r.table.tableDef, false)
+				s3Writer = colexec.NewCNS3DataWriter(mp, r.fs, r.table.tableDef, -1, false)
 			}
 		}
 
@@ -391,9 +391,9 @@ func (r *TableMetaReader) collectVisibleObjs(
 
 	if objRelData.DataCnt() > 0 {
 		if isTombstone {
-			s3Writer = colexec.NewCNS3TombstoneWriter(mp, r.fs, colTypes[1])
+			s3Writer = colexec.NewCNS3TombstoneWriter(mp, r.fs, colTypes[1], -1)
 		} else {
-			s3Writer = colexec.NewCNS3DataWriter(mp, r.fs, r.table.tableDef, false)
+			s3Writer = colexec.NewCNS3DataWriter(mp, r.fs, r.table.tableDef, -1, false)
 		}
 
 		source := &LocalDisttaeDataSource{

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -707,7 +707,9 @@ func (txn *Transaction) dumpInsertBatchLocked(
 		}
 
 		tableDef := tbl.GetTableDef(txn.proc.Ctx)
-		s3Writer = colexec.NewCNS3DataWriter(txn.proc.GetMPool(), fs, tableDef, false)
+		s3Writer = colexec.NewCNS3DataWriter(
+			txn.proc.GetMPool(), fs, tableDef, -1, false,
+		)
 
 		for _, bat = range mp[tbKey] {
 			if err = s3Writer.Write(txn.proc.Ctx, bat); err != nil {
@@ -831,7 +833,8 @@ func (txn *Transaction) dumpDeleteBatchLocked(
 
 		pkCol = plan2.PkColByTableDef(tbl.GetTableDef(txn.proc.Ctx))
 		s3Writer = colexec.NewCNS3TombstoneWriter(
-			txn.proc.GetMPool(), fs, plan2.ExprType2Type(&pkCol.Typ))
+			txn.proc.GetMPool(), fs, plan2.ExprType2Type(&pkCol.Typ), -1,
+		)
 
 		for i := 0; i < len(mp[tbKey]); i++ {
 			if err = s3Writer.Write(txn.proc.Ctx, mp[tbKey][i]); err != nil {

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1601,7 +1601,9 @@ func (tbl *txnTable) rewriteObjectByDeletion(
 		return nil, "", err
 	}
 
-	s3Writer := colexec.NewCNS3DataWriter(proc.Mp(), fs, tbl.tableDef, false)
+	s3Writer := colexec.NewCNS3DataWriter(
+		proc.Mp(), fs, tbl.tableDef, -1, false,
+	)
 
 	defer func() { s3Writer.Close() }()
 

--- a/pkg/vm/engine/readutil/datasource_test.go
+++ b/pkg/vm/engine/readutil/datasource_test.go
@@ -69,7 +69,9 @@ func TestRemoteDataSource_ApplyTombstones(t *testing.T) {
 
 	bat.SetRowCount(bat.Vecs[0].Length())
 
-	writer := colexec.NewCNS3TombstoneWriter(proc.Mp(), proc.GetFileService(), types.T_int32.ToType())
+	writer := colexec.NewCNS3TombstoneWriter(
+		proc.Mp(), proc.GetFileService(), types.T_int32.ToType(), -1,
+	)
 
 	err := writer.Write(ctx, bat)
 	require.NoError(t, err)

--- a/pkg/vm/engine/readutil/tombstone_data_test.go
+++ b/pkg/vm/engine/readutil/tombstone_data_test.go
@@ -53,7 +53,9 @@ func TestTombstoneData1(t *testing.T) {
 	var tombstoneRowIds []types.Rowid
 	int32Type := types.T_int32.ToType()
 	for i := 0; i < 3; i++ {
-		writer := colexec.NewCNS3TombstoneWriter(proc.Mp(), fs, int32Type)
+		writer := colexec.NewCNS3TombstoneWriter(
+			proc.Mp(), fs, int32Type, -1,
+		)
 		require.NoError(t, err)
 		bat := NewCNTombstoneBatch(
 			&int32Type,

--- a/pkg/vm/engine/test/reader_test.go
+++ b/pkg/vm/engine/test/reader_test.go
@@ -1387,7 +1387,9 @@ func Test_SimpleReader(t *testing.T) {
 	fs, err := fileservice.Get[fileservice.FileService](proc.GetFileService(), defines.SharedFileServiceName)
 	require.NoError(t, err)
 
-	w := colexec.NewCNS3TombstoneWriter(proc.Mp(), fs, types.T_int32.ToType())
+	w := colexec.NewCNS3TombstoneWriter(
+		proc.Mp(), fs, types.T_int32.ToType(), -1,
+	)
 	defer w.Close()
 
 	err = w.Write(proc.Ctx, bat1)

--- a/pkg/vm/engine/test/workspace_test.go
+++ b/pkg/vm/engine/test/workspace_test.go
@@ -1723,7 +1723,9 @@ func Test_CNTransferTombstoneObjects(t *testing.T) {
 	{
 		proc := rel.GetProcess().(*process.Process)
 
-		w := colexec.NewCNS3TombstoneWriter(proc.Mp(), proc.GetFileService(), types.T_int32.ToType())
+		w := colexec.NewCNS3TombstoneWriter(
+			proc.Mp(), proc.GetFileService(), types.T_int32.ToType(), -1,
+		)
 		require.NoError(t, err)
 
 		err = w.Write(proc.Ctx, tombstoneBat)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22226 #22280

## What this PR does / why we need it:

Pick 22284 22293 to 3.0-dev


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix right join dedup memory leak issue

- Optimize S3 writer with memory threshold configuration

- Refactor S3 writer API to support configurable memory thresholds

- Remove unnecessary batch cloning and improve memory management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Right Join Dedup"] -- "fix memory leak" --> B["Memory Management"]
  C["S3 Writer"] -- "add memory threshold" --> D["Configurable Thresholds"]
  C -- "refactor API" --> E["Simplified Interface"]
  D --> F["Performance Optimization"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>sinker.go</strong><dd><code>Add getter methods for sinker properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-d81c8449c450b4a071c530fcde578022ca1604bf6de96cbc392229337a99b407">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Update S3 tombstone writer constructor call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-417eebdbc9616544122d887970e657db9a20483716361572891533e58c19793b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>insert.go</strong><dd><code>Update S3 data writer constructor calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-ca8e6abaf2f07d17843124356affca004af43c32deba5cb11d429a74a516cc12">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>s3writer_delegate.go</strong><dd><code>Optimize batch cloning and memory management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-8a736ea1683fb464f14f9669fd73982ddc5d531e184fe4fc7eed315155982413">+34/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>s3util.go</strong><dd><code>Refactor S3 writer with configurable memory thresholds</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-df5f720cc405f3e54f67fa856d10f804d605ef16b99747db5a40b2406d8fc1d3">+91/-101</a></td>

</tr>

<tr>
  <td><strong>table_meta_reader.go</strong><dd><code>Update S3 writer constructor calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-879d5d0d22187ecfe6a6034c7e08557ae397d99648c417885f4a5e0b85fc4aaa">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>txn.go</strong><dd><code>Update S3 writer constructor calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-3b3158eacf342a1a2d00fa78724245821aa8bd8f08bb52e7e7acc76ec16e4744">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>txn_table.go</strong><dd><code>Update S3 data writer constructor call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>join.go</strong><dd><code>Fix memory leak by removing vector nullification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-16e2c9a2d8aa6a2195b50873cd6ca4bc552522d7528f20ac8cb63b6cf81e104b">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>s3util_test.go</strong><dd><code>Update test cases for new S3 writer API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-675dbd37325c4ab61cc768a8a7fd4d8509234c33b7f47c02641c6151454976eb">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>local_disttae_datasource_test.go</strong><dd><code>Update S3 tombstone writer constructor call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-3c1eb73e06699e15c27040eec7bc82099561b4e2ec94c5254af96fecc42697b9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>datasource_test.go</strong><dd><code>Update S3 tombstone writer constructor call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-32c4ac99377a9b1cb4bb75b7db738f5be5b7ff6b0d919cd0e28947cb7f50cb03">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tombstone_data_test.go</strong><dd><code>Update S3 tombstone writer constructor call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-9ad38623ef8181a32b3779264ee8f2455e5bbc8e4114e47fb31f00b07f2c3060">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reader_test.go</strong><dd><code>Update S3 tombstone writer constructor call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-090145913fd69f618e323393f46630b1ca56fa14711ddf9ace0d62290026025b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>workspace_test.go</strong><dd><code>Update S3 tombstone writer constructor call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22295/files#diff-80a06ff52f6f94bc5944097668f64328be5d8072db65cbd081c442520fae3458">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

