### PR TITLE
fix 'db not selected' error in alter table

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -1882,26 +1882,6 @@ func handleEmptyStmt(ses FeSession, execCtx *ExecCtx, stmt *tree.EmptyStmt) erro
 	return err
 }
 
-func GetExplainColumns(ctx context.Context, explainColName string) ([]*plan2.ColDef, []interface{}, error) {
-	cols := []*plan2.ColDef{
-		{
-			Typ:        plan2.Type{Id: int32(types.T_varchar)},
-			Name:       strings.ToLower(explainColName),
-			OriginName: explainColName,
-		},
-	}
-	columns := make([]interface{}, len(cols))
-	var err error = nil
-	for i, col := range cols {
-		c, err := colDef2MysqlColumn(ctx, col)
-		if err != nil {
-			return nil, nil, err
-		}
-		columns[i] = c
-	}
-	return cols, columns, err
-}
-
 func getExplainOption(reqCtx context.Context, options []tree.OptionElem) (*explain.ExplainOptions, error) {
 	es := explain.NewExplainDefaultOptions()
 	if options == nil {

--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -87,7 +87,7 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 			if !moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetry) &&
 				!moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetryWithDefChanged) {
 				c.proc.Error(c.proc.Ctx, "lock origin table for alter table",
-					zap.String("databaseName", c.db),
+					zap.String("databaseName", dbName),
 					zap.String("origin tableName", qry.GetTableDef().Name),
 					zap.Error(err))
 				return err
@@ -98,12 +98,20 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 		if qry.TableDef.Indexes != nil {
 			for _, indexdef := range qry.TableDef.Indexes {
 				if indexdef.TableExist {
-					if err = lockIndexTable(c.proc.Ctx, dbSource, c.e, c.proc, indexdef.IndexTableName, true); err != nil {
+					err = lockIndexTable(
+						c.proc.Ctx,
+						dbSource,
+						c.e,
+						c.proc,
+						indexdef.IndexTableName,
+						true,
+					)
+					if err != nil {
 						if !moerr.IsMoErrCode(err, moerr.ErrParseError) &&
 							!moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetry) &&
 							!moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetryWithDefChanged) {
 							c.proc.Error(c.proc.Ctx, "lock index table for alter table",
-								zap.String("databaseName", c.db),
+								zap.String("databaseName", dbName),
 								zap.String("origin tableName", qry.GetTableDef().Name),
 								zap.String("index name", indexdef.IndexName),
 								zap.String("index tableName", indexdef.IndexTableName),
@@ -125,7 +133,7 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 	err = c.runSql(qry.CreateTmpTableSql)
 	if err != nil {
 		c.proc.Error(c.proc.Ctx, "Create copy table for alter table",
-			zap.String("databaseName", c.db),
+			zap.String("databaseName", dbName),
 			zap.String("origin tableName", qry.GetTableDef().Name),
 			zap.String("copy tableName", qry.CopyTableDef.Name),
 			zap.String("CreateTmpTableSql", qry.CreateTmpTableSql),
@@ -140,7 +148,7 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 	err = c.runSqlWithOptions(qry.InsertTmpDataSql, opt)
 	if err != nil {
 		c.proc.Error(c.proc.Ctx, "insert data to copy table for alter table",
-			zap.String("databaseName", c.db),
+			zap.String("databaseName", dbName),
 			zap.String("origin tableName", qry.GetTableDef().Name),
 			zap.String("copy tableName", qry.CopyTableDef.Name),
 			zap.String("InsertTmpDataSql", qry.InsertTmpDataSql),
@@ -149,9 +157,13 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 	}
 
 	// 5. drop original table
-	if err := c.runSqlWithOptions("drop table `"+tblName+"`", executor.StatementOption{}.WithIgnoreForeignKey()); err != nil {
+	dropSql := fmt.Sprintf("drop table `%s`.`%s`", dbName, tblName)
+	if err := c.runSqlWithOptions(
+		dropSql,
+		executor.StatementOption{}.WithIgnoreForeignKey(),
+	); err != nil {
 		c.proc.Error(c.proc.Ctx, "drop original table for alter table",
-			zap.String("databaseName", c.db),
+			zap.String("databaseName", dbName),
 			zap.String("origin tableName", qry.GetTableDef().Name),
 			zap.String("copy tableName", qry.CopyTableDef.Name),
 			zap.Error(err))
@@ -161,11 +173,14 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 	// 5.1 delete all index objects of the table in mo_catalog.mo_indexes
 	if qry.Database != catalog.MO_CATALOG && qry.TableDef.Name != catalog.MO_INDEXES {
 		if qry.GetTableDef().Pkey != nil || len(qry.GetTableDef().Indexes) > 0 {
-			deleteSql := fmt.Sprintf(deleteMoIndexesWithTableIdFormat, qry.GetTableDef().TblId)
+			deleteSql := fmt.Sprintf(
+				deleteMoIndexesWithTableIdFormat,
+				qry.GetTableDef().TblId,
+			)
 			err = c.runSql(deleteSql)
 			if err != nil {
 				c.proc.Error(c.proc.Ctx, "delete all index meta data of origin table in `mo_indexes` for alter table",
-					zap.String("databaseName", c.db),
+					zap.String("databaseName", dbName),
 					zap.String("origin tableName", qry.GetTableDef().Name),
 					zap.String("delete all index sql", deleteSql),
 					zap.Error(err))
@@ -179,7 +194,7 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 	newRel, err := dbSource.Relation(c.proc.Ctx, qry.CopyTableDef.Name, nil)
 	if err != nil {
 		c.proc.Error(c.proc.Ctx, "obtain new relation for copy table for alter table",
-			zap.String("databaseName", c.db),
+			zap.String("databaseName", dbName),
 			zap.String("origin tableName", qry.GetTableDef().Name),
 			zap.String("copy table name", qry.CopyTableDef.Name),
 			zap.Error(err))
@@ -187,16 +202,20 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 	}
 
 	newId := newRel.GetTableID(c.proc.Ctx)
-	//--------------------------------------------------------------------------------------------------------------
-	// 7. rename temporary replica table into the original table( Table Id remains unchanged)
+	//-------------------------------------------------------------------------
+	// 7. rename temporary replica table into the original table(Table Id remains unchanged)
 	copyTblName := qry.CopyTableDef.Name
-	req := api.NewRenameTableReq(newRel.GetDBID(c.proc.Ctx), newRel.GetTableID(c.proc.Ctx), copyTblName, tblName)
-	tmp, err := req.Marshal()
+	req := api.NewRenameTableReq(
+		newRel.GetDBID(c.proc.Ctx),
+		newRel.GetTableID(c.proc.Ctx),
+		copyTblName,
+		tblName,
+	)
+	binaryConstraint, err := req.Marshal()
 	if err != nil {
 		return err
 	}
-	constraint := make([][]byte, 0)
-	constraint = append(constraint, tmp)
+	constraint := [][]byte{binaryConstraint}
 	err = newRel.TableRenameInTxn(c.proc.Ctx, constraint)
 	if err != nil {
 		c.proc.Error(c.proc.Ctx, "Rename copy tableName to origin tableName in for alter table",
@@ -222,15 +241,22 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 						IndexDefs: make(map[string]*plan.IndexDef),
 					}
 				}
-				multiTableIndexes[indexDef.IndexName].IndexDefs[catalog.ToLower(indexDef.IndexAlgoTableType)] = indexDef
+				ty := catalog.ToLower(indexDef.IndexAlgoTableType)
+				multiTableIndexes[indexDef.IndexName].IndexDefs[ty] = indexDef
 			}
 		}
 		for _, multiTableIndex := range multiTableIndexes {
 			switch multiTableIndex.IndexAlgo {
 			case catalog.MoIndexIvfFlatAlgo.ToString():
-				err = s.handleVectorIvfFlatIndex(c, id, extra, dbSource, multiTableIndex.IndexDefs, qry.Database, newTableDef, nil)
+				err = s.handleVectorIvfFlatIndex(
+					c, id, extra, dbSource, multiTableIndex.IndexDefs,
+					qry.Database, newTableDef, nil,
+				)
 			case catalog.MoIndexHnswAlgo.ToString():
-				err = s.handleVectorHnswIndex(c, id, extra, dbSource, multiTableIndex.IndexDefs, qry.Database, newTableDef, nil)
+				err = s.handleVectorHnswIndex(
+					c, id, extra, dbSource, multiTableIndex.IndexDefs,
+					qry.Database, newTableDef, nil,
+				)
 			}
 			if err != nil {
 				c.proc.Error(c.proc.Ctx, "invoke reindex for the new table for alter table",
@@ -264,7 +290,12 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 
 		// update foreign key child table references to the current table
 		for _, tblId := range qry.CopyTableDef.RefChildTbls {
-			if err = updateTableForeignKeyColId(c, qry.ChangeTblColIdMap, tblId, originRel.GetTableID(c.proc.Ctx), newRel.GetTableID(c.proc.Ctx)); err != nil {
+			err = updateTableForeignKeyColId(
+				c, qry.ChangeTblColIdMap, tblId,
+				originRel.GetTableID(c.proc.Ctx),
+				newRel.GetTableID(c.proc.Ctx),
+			)
+			if err != nil {
 				c.proc.Error(c.proc.Ctx, "update foreign key child table references to the current table for alter table",
 					zap.String("origin tableName", qry.GetTableDef().Name),
 					zap.String("copy table name", qry.CopyTableDef.Name),
@@ -276,7 +307,12 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 
 	if len(qry.TableDef.Fkeys) > 0 {
 		for _, fkey := range qry.CopyTableDef.Fkeys {
-			if err = notifyParentTableFkTableIdChange(c, fkey, originRel.GetTableID(c.proc.Ctx)); err != nil {
+			err = notifyParentTableFkTableIdChange(
+				c,
+				fkey,
+				originRel.GetTableID(c.proc.Ctx),
+			)
+			if err != nil {
 				c.proc.Error(c.proc.Ctx, "notify parent table foreign key TableId Change for alter table",
 					zap.String("origin tableName", qry.GetTableDef().Name),
 					zap.String("copy table name", qry.CopyTableDef.Name),
@@ -287,7 +323,8 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 	}
 
 	// update merge settings in mo_catalog.mo_merge_settings
-	err = c.runSqlWithSystemTenant(fmt.Sprintf(updateMoMergeSettings, newId, accountId, oldId))
+	updateSql := fmt.Sprintf(updateMoMergeSettings, newId, accountId, oldId)
+	err = c.runSqlWithSystemTenant(updateSql)
 	if err != nil {
 		c.proc.Error(c.proc.Ctx, "update mo_catalog.mo_merge_settings for alter table",
 			zap.String("origin tableName", qry.GetTableDef().Name),
@@ -418,19 +455,25 @@ func (s *Scope) RenameTable(c *Compile) (err error) {
 }
 
 // updateTableForeignKeyColId update foreign key colid of child table references
-func updateTableForeignKeyColId(c *Compile, changColDefMap map[uint64]*plan.ColDef, childTblId uint64, oldParentTblId uint64, newParentTblId uint64) error {
-	var childRelation engine.Relation
+func updateTableForeignKeyColId(
+	c *Compile,
+	changeColDefMap map[uint64]*plan.ColDef,
+	childTblId uint64,
+	oldParentTblId uint64,
+	newParentTblId uint64,
+) error {
+	var childRel engine.Relation
 	var err error
 	if childTblId == 0 {
 		//fk self refer does not update
 		return nil
 	} else {
-		_, _, childRelation, err = c.e.GetRelationById(c.proc.Ctx, c.proc.GetTxnOperator(), childTblId)
+		_, _, childRel, err = c.e.GetRelationById(c.proc.Ctx, c.proc.GetTxnOperator(), childTblId)
 		if err != nil {
 			return err
 		}
 	}
-	oldCt, err := GetConstraintDef(c.proc.Ctx, childRelation)
+	oldCt, err := GetConstraintDef(c.proc.Ctx, childRel)
 	if err != nil {
 		return err
 	}
@@ -440,7 +483,7 @@ func updateTableForeignKeyColId(c *Compile, changColDefMap map[uint64]*plan.ColD
 				fkey := def.Fkeys[i]
 				if fkey.ForeignTbl == oldParentTblId {
 					for j := 0; j < len(fkey.ForeignCols); j++ {
-						if newColDef, ok2 := changColDefMap[fkey.ForeignCols[j]]; ok2 {
+						if newColDef, ok2 := changeColDefMap[fkey.ForeignCols[j]]; ok2 {
 							fkey.ForeignCols[j] = newColDef.ColId
 						}
 					}
@@ -449,19 +492,19 @@ func updateTableForeignKeyColId(c *Compile, changColDefMap map[uint64]*plan.ColD
 			}
 		}
 	}
-	return childRelation.UpdateConstraint(c.proc.Ctx, oldCt)
+	return childRel.UpdateConstraint(c.proc.Ctx, oldCt)
 }
 
-func updateNewTableColId(c *Compile, copyRel engine.Relation, changColDefMap map[uint64]*plan.ColDef) error {
-	engineDefs, err := copyRel.TableDefs(c.proc.Ctx)
+func updateNewTableColId(c *Compile, copyRel engine.Relation, changeColDefMap map[uint64]*plan.ColDef) error {
+	tableDefs, err := copyRel.TableDefs(c.proc.Ctx)
 	if err != nil {
 		return err
 	}
-	for _, def := range engineDefs {
+	for _, def := range tableDefs {
 		if attr, ok := def.(*engine.AttributeDef); ok {
-			for _, vColDef := range changColDefMap {
-				if vColDef.GetOriginCaseName() == attr.Attr.Name {
-					vColDef.ColId = attr.Attr.ID
+			for _, colDef := range changeColDefMap {
+				if colDef.GetOriginCaseName() == attr.Attr.Name {
+					colDef.ColId = attr.Attr.ID
 					break
 				}
 			}
@@ -495,7 +538,7 @@ func notifyParentTableFkTableIdChange(c *Compile, fkey *plan.ForeignKeyDef, oldT
 	}
 	for _, ct := range oldCt.Cts {
 		if def, ok1 := ct.(*engine.RefChildTableDef); ok1 {
-			def.Tables = plan2.RemoveIf[uint64](def.Tables, func(id uint64) bool {
+			def.Tables = plan2.RemoveIf(def.Tables, func(id uint64) bool {
 				return id == oldTableId
 			})
 		}

--- a/pkg/sql/compile/analyze_module.go
+++ b/pkg/sql/compile/analyze_module.go
@@ -99,7 +99,7 @@ func (anal *AnalyzeModule) release() {
 	//for i := range a.analInfos {
 	//	reuse.Free[process.AnalyzeInfo](a.analInfos[i], nil)
 	//}
-	reuse.Free[AnalyzeModule](anal, nil)
+	reuse.Free(anal, nil)
 }
 
 func (c *Compile) initAnalyzeModule(qry *plan.Query) {
@@ -457,23 +457,10 @@ func (c *Compile) UpdatePreparePhyPlan(runC *Compile) bool {
 }
 
 func (c *Compile) GenPhyPlan(runC *Compile) {
-	var generateReceiverMap func(*Scope, map[*process.WaitRegister]int)
-	generateReceiverMap = func(s *Scope, mp map[*process.WaitRegister]int) {
-		for i := range s.PreScopes {
-			generateReceiverMap(s.PreScopes[i], mp)
-		}
-		if s.Proc == nil {
-			return
-		}
-		for i := range s.Proc.Reg.MergeReceivers {
-			mp[s.Proc.Reg.MergeReceivers[i]] = len(mp)
-		}
-	}
-
-	receiverMap := make(map[*process.WaitRegister]int)
-	ss := runC.scopes
-	for i := range ss {
-		generateReceiverMap(ss[i], receiverMap)
+	recvMap := make(map[*process.WaitRegister]int)
+	scopes := runC.scopes
+	for i := range scopes {
+		genReceiverMap(scopes[i], recvMap)
 	}
 
 	//------------------------------------------------------------------------------------------------------
@@ -481,10 +468,10 @@ func (c *Compile) GenPhyPlan(runC *Compile) {
 	c.anal.phyPlan.RetryTime = runC.anal.retryTimes
 	c.anal.curNodeIdx = runC.anal.curNodeIdx
 
-	if len(runC.scopes) > 0 {
-		for i := range runC.scopes {
-			phyScope := ConvertScopeToPhyScope(runC.scopes[i], receiverMap)
-			c.anal.phyPlan.LocalScope = append(c.anal.phyPlan.LocalScope, phyScope)
+	if len(scopes) > 0 {
+		for i := range scopes {
+			phy := ConvertScopeToPhyScope(scopes[i], recvMap)
+			c.anal.phyPlan.LocalScope = append(c.anal.phyPlan.LocalScope, phy)
 		}
 	}
 
@@ -534,30 +521,41 @@ func getExplainOption(options []tree.OptionElem) *ExplainOption {
 }
 
 // makeExplainPhyPlanBuffer used to explain phyplan statement
-func makeExplainPhyPlanBuffer(ss []*Scope, queryResult *util.RunResult, statsInfo *statistic.StatsInfo, anal *AnalyzeModule, option *ExplainOption) *bytes.Buffer {
-	receiverMap := make(map[*process.WaitRegister]int)
+func makeExplainPhyPlanBuffer(
+	ss []*Scope,
+	queryResult *util.RunResult,
+	statsInfo *statistic.StatsInfo,
+	anal *AnalyzeModule,
+	option *ExplainOption,
+) *bytes.Buffer {
+	recvMap := make(map[*process.WaitRegister]int)
 	for i := range ss {
-		genReceiverMap(ss[i], receiverMap)
+		genReceiverMap(ss[i], recvMap)
 	}
 
-	buffer := bytes.NewBuffer(make([]byte, 0, 300))
-
-	//explainGlobalResources(queryResult, statsInfo, anal, option, buffer)
-	explainResourceOverview(queryResult, statsInfo, anal, option, buffer)
-	explainScopes(ss, 0, receiverMap, option, buffer)
-	return buffer
+	buf := bytes.NewBuffer(make([]byte, 0, 300))
+	explainResourceOverview(queryResult, statsInfo, anal, option, buf)
+	explainScopes(ss, 0, recvMap, option, buf)
+	return buf
 }
 
-func explainResourceOverview(queryResult *util.RunResult, statsInfo *statistic.StatsInfo, anal *AnalyzeModule, option *ExplainOption, buffer *bytes.Buffer) {
+func explainResourceOverview(
+	queryResult *util.RunResult,
+	statsInfo *statistic.StatsInfo,
+	anal *AnalyzeModule,
+	option *ExplainOption,
+	buffer *bytes.Buffer,
+) {
 	if option.Analyze || option.Verbose {
 		gblStats := models.ExtractPhyPlanGlbStats(anal.phyPlan)
 		buffer.WriteString("Overview:\n")
-		buffer.WriteString(fmt.Sprintf("\tMemoryUsage:%dB,  DiskI/O:%dB,  NewWorkI/O:%dB, AffectedRows: %d",
+		fmt.Fprintf(buffer,
+			"\tMemoryUsage:%dB,  DiskI/O:%dB,  NewWorkI/O:%dB, AffectedRows: %d",
 			gblStats.MemorySize,
 			gblStats.DiskIOSize,
 			gblStats.NetWorkSize,
 			queryResult.AffectRows,
-		))
+		)
 
 		if statsInfo != nil {
 			buffer.WriteString("\n")
@@ -565,9 +563,11 @@ func explainResourceOverview(queryResult *util.RunResult, statsInfo *statistic.S
 			list, head, put, get, delete, deleteMul, writtenRows, deletedRows := models.CalcTotalS3Requests(gblStats, statsInfo)
 
 			s3InputEstByRows := objectio.EstimateS3Input(writtenRows)
-			buffer.WriteString(fmt.Sprintf("\tS3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d, S3InputEstByRows((%d+%d)/8192):%.4f \n",
+			fmt.Fprintf(
+				buffer,
+				"\tS3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d, S3InputEstByRows((%d+%d)/8192):%.4f \n",
 				list, head, put, get, delete, deleteMul, writtenRows, deletedRows, s3InputEstByRows,
-			))
+			)
 
 			cpuTimeVal := gblStats.OperatorTimeConsumed +
 				int64(statsInfo.ParseStage.ParseDuration+statsInfo.PlanStage.PlanDuration+statsInfo.CompileStage.CompileDuration) +
@@ -576,8 +576,8 @@ func explainResourceOverview(queryResult *util.RunResult, statsInfo *statistic.S
 				(statsInfo.IOAccessTimeConsumption + statsInfo.S3FSPrefetchFileIOMergerTimeConsumption)
 
 			buffer.WriteString("\tCPU Usage: \n")
-			buffer.WriteString(fmt.Sprintf("\t\t- Total CPU Time: %dns \n", cpuTimeVal))
-			buffer.WriteString(fmt.Sprintf("\t\t- CPU Time Detail: Parse(%d)+BuildPlan(%d)+Compile(%d)+PhyExec(%d)+PrepareRun(%d)-PreRunWaitLock(%d)-PlanStatsIO(%d)-IOAccess(%d)-IOMerge(%d)\n",
+			fmt.Fprintf(buffer, "\t\t- Total CPU Time: %dns \n", cpuTimeVal)
+			fmt.Fprintf(buffer, "\t\t- CPU Time Detail: Parse(%d)+BuildPlan(%d)+Compile(%d)+PhyExec(%d)+PrepareRun(%d)-PreRunWaitLock(%d)-PlanStatsIO(%d)-IOAccess(%d)-IOMerge(%d)\n",
 				statsInfo.ParseStage.ParseDuration,
 				statsInfo.PlanStage.PlanDuration,
 				statsInfo.CompileStage.CompileDuration,
@@ -586,80 +586,80 @@ func explainResourceOverview(queryResult *util.RunResult, statsInfo *statistic.S
 				statsInfo.PrepareRunStage.CompilePreRunOnceWaitLock,
 				statsInfo.PlanStage.BuildPlanStatsIOConsumption,
 				statsInfo.IOAccessTimeConsumption,
-				statsInfo.S3FSPrefetchFileIOMergerTimeConsumption))
-			buffer.WriteString(fmt.Sprintf("\t\t- Permission Authentication Stats Array: %v \n", statsInfo.PermissionAuth))
+				statsInfo.S3FSPrefetchFileIOMergerTimeConsumption)
+			fmt.Fprintf(buffer, "\t\t- Permission Authentication Stats Array: %v \n", statsInfo.PermissionAuth)
 
 			//-------------------------------------------------------------------------------------------------------
 			if option.Analyze {
 				buffer.WriteString("\tQuery Build Plan Stage:\n")
-				buffer.WriteString(fmt.Sprintf("\t\t- CPU Time: %dns \n", int64(statsInfo.PlanStage.PlanDuration)-statsInfo.PlanStage.BuildPlanStatsIOConsumption))
-				buffer.WriteString(fmt.Sprintf("\t\t- S3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d\n",
+				fmt.Fprintf(buffer, "\t\t- CPU Time: %dns \n", int64(statsInfo.PlanStage.PlanDuration)-statsInfo.PlanStage.BuildPlanStatsIOConsumption)
+				fmt.Fprintf(buffer, "\t\t- S3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d\n",
 					statsInfo.PlanStage.BuildPlanS3Request.List,
 					statsInfo.PlanStage.BuildPlanS3Request.Head,
 					statsInfo.PlanStage.BuildPlanS3Request.Put,
 					statsInfo.PlanStage.BuildPlanS3Request.Get,
 					statsInfo.PlanStage.BuildPlanS3Request.Delete,
 					statsInfo.PlanStage.BuildPlanS3Request.DeleteMul,
-				))
-				buffer.WriteString(fmt.Sprintf("\t\t- Build Plan Duration: %dns \n", int64(statsInfo.PlanStage.PlanDuration)))
-				buffer.WriteString(fmt.Sprintf("\t\t- Call Stats Duration: %dns \n", statsInfo.PlanStage.BuildPlanStatsDuration))
-				buffer.WriteString(fmt.Sprintf("\t\t- Call StatsInCache Duration: %dns \n", statsInfo.PlanStage.BuildPlanStatsInCacheDuration))
-				buffer.WriteString(fmt.Sprintf("\t\t- Call Stats IO Consumption: %dns \n", statsInfo.PlanStage.BuildPlanStatsIOConsumption))
-				buffer.WriteString(fmt.Sprintf("\t\t- Call Stats S3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d\n",
+				)
+				fmt.Fprintf(buffer, "\t\t- Build Plan Duration: %dns \n", int64(statsInfo.PlanStage.PlanDuration))
+				fmt.Fprintf(buffer, "\t\t- Call Stats Duration: %dns \n", statsInfo.PlanStage.BuildPlanStatsDuration)
+				fmt.Fprintf(buffer, "\t\t- Call StatsInCache Duration: %dns \n", statsInfo.PlanStage.BuildPlanStatsInCacheDuration)
+				fmt.Fprintf(buffer, "\t\t- Call Stats IO Consumption: %dns \n", statsInfo.PlanStage.BuildPlanStatsIOConsumption)
+				fmt.Fprintf(buffer, "\t\t- Call Stats S3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d\n",
 					statsInfo.PlanStage.BuildPlanStatsS3.List,
 					statsInfo.PlanStage.BuildPlanStatsS3.Head,
 					statsInfo.PlanStage.BuildPlanStatsS3.Put,
 					statsInfo.PlanStage.BuildPlanStatsS3.Get,
 					statsInfo.PlanStage.BuildPlanStatsS3.Delete,
 					statsInfo.PlanStage.BuildPlanStatsS3.DeleteMul,
-				))
+				)
 
 				//-------------------------------------------------------------------------------------------------------
 				buffer.WriteString("\tQuery Compile Stage:\n")
-				buffer.WriteString(fmt.Sprintf("\t\t- CPU Time: %dns \n", statsInfo.CompileStage.CompileDuration))
-				buffer.WriteString(fmt.Sprintf("\t\t- S3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d\n",
+				fmt.Fprintf(buffer, "\t\t- CPU Time: %dns \n", statsInfo.CompileStage.CompileDuration)
+				fmt.Fprintf(buffer, "\t\t- S3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d\n",
 					statsInfo.CompileStage.CompileS3Request.List,
 					statsInfo.CompileStage.CompileS3Request.Head,
 					statsInfo.CompileStage.CompileS3Request.Put,
 					statsInfo.CompileStage.CompileS3Request.Get,
 					statsInfo.CompileStage.CompileS3Request.Delete,
 					statsInfo.CompileStage.CompileS3Request.DeleteMul,
-				))
-				buffer.WriteString(fmt.Sprintf("\t\t- Compile TableScan Duration: %dns \n", statsInfo.CompileStage.CompileTableScanDuration))
+				)
+				fmt.Fprintf(buffer, "\t\t- Compile TableScan Duration: %dns \n", statsInfo.CompileStage.CompileTableScanDuration)
 
 				//-------------------------------------------------------------------------------------------------------
 				buffer.WriteString("\tQuery Prepare Exec Stage:\n")
-				buffer.WriteString(fmt.Sprintf("\t\t- CPU Time: %dns \n", gblStats.ScopePrepareTimeConsumed+statsInfo.PrepareRunStage.CompilePreRunOnceDuration-statsInfo.PrepareRunStage.CompilePreRunOnceWaitLock))
-				buffer.WriteString(fmt.Sprintf("\t\t- CompilePreRunOnce Duration: %dns \n", statsInfo.PrepareRunStage.CompilePreRunOnceDuration))
-				buffer.WriteString(fmt.Sprintf("\t\t- PreRunOnce WaitLock: %dns \n", statsInfo.PrepareRunStage.CompilePreRunOnceWaitLock))
-				buffer.WriteString(fmt.Sprintf("\t\t- ScopePrepareTimeConsumed: %dns \n", gblStats.ScopePrepareTimeConsumed))
-				buffer.WriteString(fmt.Sprintf("\t\t- BuildReader Duration: %dns \n", statsInfo.PrepareRunStage.BuildReaderDuration))
-				buffer.WriteString(fmt.Sprintf("\t\t- S3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d\n",
+				fmt.Fprintf(buffer, "\t\t- CPU Time: %dns \n", gblStats.ScopePrepareTimeConsumed+statsInfo.PrepareRunStage.CompilePreRunOnceDuration-statsInfo.PrepareRunStage.CompilePreRunOnceWaitLock)
+				fmt.Fprintf(buffer, "\t\t- CompilePreRunOnce Duration: %dns \n", statsInfo.PrepareRunStage.CompilePreRunOnceDuration)
+				fmt.Fprintf(buffer, "\t\t- PreRunOnce WaitLock: %dns \n", statsInfo.PrepareRunStage.CompilePreRunOnceWaitLock)
+				fmt.Fprintf(buffer, "\t\t- ScopePrepareTimeConsumed: %dns \n", gblStats.ScopePrepareTimeConsumed)
+				fmt.Fprintf(buffer, "\t\t- BuildReader Duration: %dns \n", statsInfo.PrepareRunStage.BuildReaderDuration)
+				fmt.Fprintf(buffer, "\t\t- S3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d\n",
 					statsInfo.PrepareRunStage.ScopePrepareS3Request.List,
 					statsInfo.PrepareRunStage.ScopePrepareS3Request.Head,
 					statsInfo.PrepareRunStage.ScopePrepareS3Request.Put,
 					statsInfo.PrepareRunStage.ScopePrepareS3Request.Get,
 					statsInfo.PrepareRunStage.ScopePrepareS3Request.Delete,
 					statsInfo.PrepareRunStage.ScopePrepareS3Request.DeleteMul,
-				))
+				)
 
 				//-------------------------------------------------------------------------------------------------------
 				buffer.WriteString("\tQuery Execution Stage:\n")
-				buffer.WriteString(fmt.Sprintf("\t\t- CPU Time: %dns \n", gblStats.OperatorTimeConsumed))
-				buffer.WriteString(fmt.Sprintf("\t\t- S3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d\n",
+				fmt.Fprintf(buffer, "\t\t- CPU Time: %dns \n", gblStats.OperatorTimeConsumed)
+				fmt.Fprintf(buffer, "\t\t- S3List:%d, S3Head:%d, S3Put:%d, S3Get:%d, S3Delete:%d, S3DeleteMul:%d\n",
 					gblStats.S3ListRequest,
 					gblStats.S3HeadRequest,
 					gblStats.S3PutRequest,
 					gblStats.S3GetRequest,
 					gblStats.S3DeleteRequest,
 					gblStats.S3DeleteMultiRequest,
-				))
+				)
 
-				buffer.WriteString(fmt.Sprintf("\t\t- MemoryUsage: %dB,  DiskI/O: %dB,  NewWorkI/O:%dB\n",
+				fmt.Fprintf(buffer, "\t\t- MemoryUsage: %dB,  DiskI/O: %dB,  NewWorkI/O:%dB\n",
 					gblStats.MemorySize,
 					gblStats.DiskIOSize,
 					gblStats.NetWorkSize,
-				))
+				)
 			}
 			//-------------------------------------------------------------------------------------------------------
 			buffer.WriteString("Physical Plan Deployment:")
@@ -686,20 +686,20 @@ func explainSingleScope(scope *Scope, index int, gap int, rmp map[*process.WaitR
 	}
 
 	if option.Verbose || option.Analyze {
-		buffer.WriteString(fmt.Sprintf("Scope %d (Magic: %s, addr:%v, mcpu: %v, Receiver: %s)", index+1, magicShow(scope.Magic), scope.NodeInfo.Addr, scope.NodeInfo.Mcpu, receiverStr))
+		fmt.Fprintf(buffer, "Scope %d (Magic: %s, addr:%v, mcpu: %v, Receiver: %s)", index+1, magicShow(scope.Magic), scope.NodeInfo.Addr, scope.NodeInfo.Mcpu, receiverStr)
 		if scope.ScopeAnalyzer != nil {
-			buffer.WriteString(fmt.Sprintf(" PrepareTimeConsumed: %dns", scope.ScopeAnalyzer.TimeConsumed))
+			fmt.Fprintf(buffer, " PrepareTimeConsumed: %dns", scope.ScopeAnalyzer.TimeConsumed)
 		} else {
 			buffer.WriteString(" PrepareTimeConsumed: 0ns")
 		}
 	} else {
-		buffer.WriteString(fmt.Sprintf("Scope %d (Magic: %s, mcpu: %v, Receiver: %s)", index+1, magicShow(scope.Magic), scope.NodeInfo.Mcpu, receiverStr))
+		fmt.Fprintf(buffer, "Scope %d (Magic: %s, mcpu: %v, Receiver: %s)", index+1, magicShow(scope.Magic), scope.NodeInfo.Mcpu, receiverStr)
 	}
 
 	// Scope DataSource
 	if scope.DataSource != nil {
 		gapNextLine(gap, buffer)
-		buffer.WriteString(fmt.Sprintf("  DataSource: %s", showDataSource(scope.DataSource)))
+		fmt.Fprintf(buffer, "  DataSource: %s", showDataSource(scope.DataSource))
 	}
 
 	if scope.RootOp != nil {
@@ -724,8 +724,7 @@ func explainPipeline(node vm.Operator, prefix string, isRoot bool, isTail bool, 
 		return
 	}
 
-	id := node.OpType()
-	name, ok := debugInstructionNames[id]
+	name, ok := debugInstructionNames[node.OpType()]
 	if !ok {
 		name = "unknown"
 	}
@@ -746,18 +745,18 @@ func explainPipeline(node vm.Operator, prefix string, isRoot bool, isTail bool, 
 	// Write to the current node
 	if isRoot {
 		headPrefix := "  Pipeline: └── "
-		buffer.WriteString(fmt.Sprintf("%s%s%s", headPrefix, name, analyzeStr))
+		fmt.Fprintf(buffer, "%s%s%s", headPrefix, name, analyzeStr)
 		hanldeTailNodeReceiver(node, mp, buffer)
 		buffer.WriteString("\n")
 		// Ensure that child nodes are properly indented
 		prefix += "   "
 	} else {
 		if isTail {
-			buffer.WriteString(fmt.Sprintf("%s└── %s%s", prefix, name, analyzeStr))
+			fmt.Fprintf(buffer, "%s└── %s%s", prefix, name, analyzeStr)
 			hanldeTailNodeReceiver(node, mp, buffer)
 			buffer.WriteString("\n")
 		} else {
-			buffer.WriteString(fmt.Sprintf("%s├── %s%s\n", prefix, name, analyzeStr))
+			fmt.Fprintf(buffer, "%s├── %s%s\n", prefix, name, analyzeStr)
 		}
 	}
 

--- a/pkg/sql/compile/debugTools.go
+++ b/pkg/sql/compile/debugTools.go
@@ -324,19 +324,10 @@ func hanldeTailNodeReceiver(node vm.Operator, mp map[*process.WaitRegister]int, 
 				if i != 0 {
 					remoteChs += ", "
 				}
-				fmt.Fprintf(buffer, "[addr: %s, uuid %s]", reg.NodeAddr, reg.Uuid)
-			}
-			fmt.Fprintf(buffer, " cross-cn receiver info: %s", remoteChs)
-		}
-
-		if len(arg.RemoteRegs) != 0 {
-			remoteChs := ""
-			for i, reg := range arg.RemoteRegs {
-				if i != 0 {
-					remoteChs += ", "
-				}
-				uuidStr := reg.Uuid.String()
-				fmt.Fprintf(buffer, "[addr: %s(%s)]", reg.NodeAddr, uuidStr[len(uuidStr)-6:])
+				remoteChs += fmt.Sprintf(
+					"[addr: %s, uuid: %s]",
+					reg.NodeAddr,
+					reg.Uuid.String())
 			}
 			fmt.Fprintf(buffer, " cross-cn receiver info: %s", remoteChs)
 		}

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -180,7 +180,7 @@ func (s *Scope) Run(c *Compile) (err error) {
 
 				buildStart := time.Now()
 				readers, err := s.buildReaders(c)
-				stats.AddBuidReaderTimeConsumption(time.Since(buildStart))
+				stats.AddBuildReaderTimeConsumption(time.Since(buildStart))
 				if err != nil {
 					return err
 				}
@@ -522,7 +522,7 @@ func buildScanParallelRun(s *Scope, c *Compile) (*Scope, error) {
 	stats := statistic.StatsInfoFromContext(c.proc.GetTopContext())
 	buildStart := time.Now()
 	defer func() {
-		stats.AddBuidReaderTimeConsumption(time.Since(buildStart))
+		stats.AddBuildReaderTimeConsumption(time.Since(buildStart))
 	}()
 	readers, err := s.buildReaders(c)
 	if err != nil {
@@ -534,10 +534,6 @@ func buildScanParallelRun(s *Scope, c *Compile) (*Scope, error) {
 		s.DataSource.R.SetOrderBy(s.DataSource.OrderBy)
 		return s, nil
 	}
-
-	//if len(s.DataSource.OrderBy) > 0 {
-	//	return nil, moerr.NewInternalError(c.proc.Ctx, "ordered scan must run in only one parallel.")
-	//}
 
 	ms, ss := newParallelScope(s)
 	for i := range ss {

--- a/pkg/sql/plan/build_alter_table.go
+++ b/pkg/sql/plan/build_alter_table.go
@@ -550,7 +550,7 @@ func storageAgnosticType(
 }
 
 func storageAgnosticAttrs(
-	ctx context.Context,
+	_ context.Context,
 	nCol *tree.ColumnTableDef,
 	oCol *ColDef,
 ) (ok bool, err error) {

--- a/pkg/util/trace/impl/motrace/statistic/stats_array.go
+++ b/pkg/util/trace/impl/motrace/statistic/stats_array.go
@@ -432,7 +432,7 @@ func (stats *StatsInfo) AddOutputTimeConsumption(d time.Duration) {
 	atomic.AddInt64(&stats.ExecuteStage.OutputDuration, int64(d))
 }
 
-func (stats *StatsInfo) AddBuidReaderTimeConsumption(d time.Duration) {
+func (stats *StatsInfo) AddBuildReaderTimeConsumption(d time.Duration) {
 	if stats == nil {
 		return
 	}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22302

## What this PR does / why we need it:

- Use the database name in the query first and then try the name in the compile struct
- Fix some typos
- Refactor explain phyplan a little bit


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix 'db not selected' error in ALTER TABLE operations

- Refactor EXPLAIN physical plan code consolidation

- Fix typos and improve string formatting consistency

- Remove duplicate code in explain analyze handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ALTER TABLE"] --> B["Database Name Fix"]
  C["EXPLAIN Analyze"] --> D["Code Consolidation"]
  E["String Formatting"] --> F["fmt.Fprintf Usage"]
  B --> G["Fixed Operations"]
  D --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>result_row_stmt.go</strong><dd><code>Consolidate EXPLAIN statement handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/result_row_stmt.go

<ul><li>Consolidate EXPLAIN analyze and physical plan handling into single <br>case<br> <li> Remove duplicate code blocks for explain operations<br> <li> Add conditional logic to determine explain column name type</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22303/files#diff-f4b9fba3825fe81e1de50097face2d704cffacd051f87aefa801d6a96c5aa675">+6/-41</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>analyze_module.go</strong><dd><code>Refactor string formatting and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/analyze_module.go

<ul><li>Replace <code>buffer.WriteString(fmt.Sprintf(...))</code> with <code>fmt.Fprintf(buffer, </code><br><code>...)</code><br> <li> Remove unused function <code>generateReceiverMap</code><br> <li> Fix <code>reuse.Free</code> call syntax<br> <li> Remove commented code</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22303/files#diff-1ae08a385b193ccdc5ad50af00f44b3985fd7a6ecfdc1e1fb782ec57754b7d6b">+42/-56</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>debugTools.go</strong><dd><code>Improve string formatting in debug tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/debugTools.go

<ul><li>Replace <code>buffer.WriteString(fmt.Sprintf(...))</code> with <code>fmt.Fprintf(buffer, </code><br><code>...)</code><br> <li> Simplify <code>addGap</code> function using <code>strings.Repeat</code><br> <li> Improve string formatting consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22303/files#diff-464c5434c51aae8a0b4a3369ee32bedf1f4796824aa7af0bb1a77e0aa23a61e0">+15/-19</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alter.go</strong><dd><code>Fix database name usage in ALTER TABLE</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/alter.go

<ul><li>Replace <code>c.db</code> with <code>dbName</code> in error logging statements<br> <li> Add database name qualification to DROP TABLE statement<br> <li> Fix database context in ALTER TABLE operations</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22303/files#diff-cdaf6d42dbaad7a00150e5cdabe41c49eec265b4a0be8621317ca41fef897ccd">+11/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scope.go</strong><dd><code>Fix typo in reader time consumption method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/scope.go

<ul><li>Fix typo: <code>AddBuidReaderTimeConsumption</code> to <br><code>AddBuildReaderTimeConsumption</code><br> <li> Remove commented code block</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22303/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stats_array.go</strong><dd><code>Fix method name typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/util/trace/impl/motrace/statistic/stats_array.go

<ul><li>Fix method name typo: <code>AddBuidReaderTimeConsumption</code> to <br><code>AddBuildReaderTimeConsumption</code></ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22303/files#diff-ffbafe7bb5fd5225eb5ee9f8bd98a1f6107789298c38734c0925997e6037cdd6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_alter_table.go</strong><dd><code>Remove unused context parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_alter_table.go

- Replace unused `ctx` parameter with underscore `_`


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22303/files#diff-6cab890024a61a633f601ce8b3658cc0a2e5635030e32a54fa2766c75cf8e1dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

