### PR TITLE
fix shuffle join (cp #22282)

### DIFF
--- a/pkg/lockservice/cfg.go
+++ b/pkg/lockservice/cfg.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	defaultLockListenAddress      = "127.0.0.1:6003"
-	defaultMaxLockRowCount        = 1000000
+	defaultMaxLockRowCount        = 200000
 	defaultMaxFixedSliceSize      = 1 << 20 * 10 // 10mb
 	defaultKeepRemoteLockDuration = time.Second
 	defaultKeepBindTimeout        = time.Second * 10

--- a/pkg/sql/colexec/shuffle/shuffle.go
+++ b/pkg/sql/colexec/shuffle/shuffle.go
@@ -17,6 +17,7 @@ package shuffle
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -97,11 +98,12 @@ func (shuffle *Shuffle) Call(proc *process.Process) (vm.CallResult, error) {
 		if err != nil {
 			return result, err
 		}
+
+		result.Status = vm.ExecNext
 		bat := result.Batch
 		if bat == nil {
 			shuffle.ctr.ending = true
 			shuffle.ctr.lastForShufflePool = shuffle.ctr.shufflePool.Ending()
-			result.Status = vm.ExecNext
 			result.Batch = batch.EmptyBatch
 			return result, nil
 		} else if bat.Last() {
@@ -130,6 +132,7 @@ func (shuffle *Shuffle) Call(proc *process.Process) (vm.CallResult, error) {
 	if err = shuffle.handleRuntimeFilter(proc); err != nil {
 		return vm.CancelResult, err
 	}
+
 	// send the batch
 	result.Batch = shuffle.ctr.buf
 	return result, nil

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -2352,6 +2352,8 @@ func (c *Compile) compileJoin(node, left, right *plan.Node, probeScopes, buildSc
 		if len(c.cnList) == 1 {
 			if node.JoinType == plan.Node_DEDUP && node.Stats.HashmapStats.ShuffleType == plan.ShuffleType_Hash {
 				logutil.Infof("not support shuffle v2 for dedup join now")
+			} else if probeScopes[0].NodeInfo.Mcpu != int(left.Stats.Dop) || buildScopes[0].NodeInfo.Mcpu != int(right.Stats.Dop) {
+				logutil.Infof("not support shuffle v2 after merge")
 			} else {
 				return c.compileShuffleJoinV2(node, left, right, probeScopes, buildScopes)
 			}
@@ -2370,6 +2372,7 @@ func (c *Compile) compileShuffleJoinV2(node, left, right *plan.Node, leftscopes,
 	if len(leftscopes) != len(rightscopes) {
 		panic("wrong scopes for shuffle join!")
 	}
+
 	reuse := node.Stats.HashmapStats.ShuffleMethod == plan.ShuffleMethod_Reuse
 	bucketNum := len(c.cnList) * int(node.Stats.Dop)
 	for i := range leftscopes {

--- a/pkg/sql/plan/explain/explain_node.go
+++ b/pkg/sql/plan/explain/explain_node.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	"github.com/matrixorigin/matrixone/pkg/vm/message"
 )
 
@@ -242,23 +243,52 @@ func (ndesc *NodeDescribeImpl) GetActualAnalyzeInfo(ctx context.Context, options
 }
 
 func (ndesc *NodeDescribeImpl) GetTableDef(ctx context.Context, options *ExplainOptions) (string, error) {
-	result := "Table: "
+	buf := bytes.NewBuffer(make([]byte, 0, 300))
+	buf.WriteString("Table: ")
 	if ndesc.Node.NodeType == plan.Node_TABLE_SCAN {
 		tableDef := ndesc.Node.TableDef
-		result += "'" + tableDef.Name + "' ("
+		buf.WriteString("'" + tableDef.Name + "' (")
 		first := true
 		for i, col := range tableDef.Cols {
 			if !first {
-				result += ", "
+				buf.WriteString(", ")
 			}
 			first = false
-			result += strconv.Itoa(i) + ":'" + col.Name + "'"
+			buf.WriteString(strconv.Itoa(i) + ":'" + col.Name + "'")
 		}
-		result += ")"
+		buf.WriteString(")")
+
+		if ndesc.Node.Stats.HashmapStats.Shuffle {
+			shuffleType := ndesc.Node.Stats.HashmapStats.ShuffleType
+			var firstSortColName string
+			if tableDef.ClusterBy != nil {
+				firstSortColName = util.GetClusterByFirstColumn(tableDef.ClusterBy.Name)
+			} else {
+				firstSortColName = tableDef.Pkey.Names[0]
+			}
+
+			if ndesc.Node.Stats.HashmapStats.ShuffleMethod == plan.ShuffleMethod_Reuse {
+				buf.WriteString(" shuffle: REUSE")
+			} else {
+				if shuffleType == plan.ShuffleType_Hash {
+					buf.WriteString(" shuffle: hash(")
+					buf.WriteString(firstSortColName)
+					buf.WriteString(")")
+				} else {
+					buf.WriteString(" shuffle: range(")
+					buf.WriteString(firstSortColName)
+					buf.WriteString(")")
+				}
+
+				if ndesc.Node.Stats.HashmapStats.ShuffleTypeForMultiCN == plan.ShuffleTypeForMultiCN_Hybrid {
+					buf.WriteString(" HYBRID ")
+				}
+			}
+		}
 	} else {
 		panic("implement me")
 	}
-	return result, nil
+	return buf.String(), nil
 }
 
 func (ndesc *NodeDescribeImpl) GetExtraInfo(ctx context.Context, options *ExplainOptions) ([]string, error) {

--- a/test/distributed/cases/ddl/secondary_index_insert.result
+++ b/test/distributed/cases/ddl/secondary_index_insert.result
@@ -95,3 +95,24 @@ delete from t1 where id = "b";
 select * from t1;
 id    name    age
 a    Abby    twenty four
+drop table if exists t1;
+create table t1(id int primary key, val int unique);
+insert into t1 select *, * from generate_series(500000) g;
+select mo_ctl('dn', 'flush', 'secondary_index_insert.t1');
+mo_ctl(dn, flush, secondary_index_insert.t1)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+create table t2 like t1;
+insert into t2 select * from t1;
+select count(*) from t2;
+count(*)
+500000
+delete from t2;
+insert into t2 select * from t1 limit 100000;
+select count(*) from t2;
+count(*)
+100000
+delete from t2;
+insert into t2 select * from t1 limit 300000;
+select count(*) from t2;
+count(*)
+300000

--- a/test/distributed/cases/ddl/secondary_index_insert.sql
+++ b/test/distributed/cases/ddl/secondary_index_insert.sql
@@ -63,3 +63,18 @@ update t1 set name = null where id = "b";
 select * from t1;
 delete from t1 where id = "b";
 select * from t1;
+
+drop table if exists t1;
+create table t1(id int primary key, val int unique);
+insert into t1 select *, * from generate_series(500000) g;
+-- @separator:table
+select mo_ctl('dn', 'flush', 'secondary_index_insert.t1');
+create table t2 like t1;
+insert into t2 select * from t1;
+select count(*) from t2;
+delete from t2;
+insert into t2 select * from t1 limit 100000;
+select count(*) from t2;
+delete from t2;
+insert into t2 select * from t1 limit 300000;
+select count(*) from t2;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22274

## What this PR does / why we need it:
1. use shuffle V1 instead of shuffle V2 if probe/build side has merge operator
2. display shuffle info for table_scan in explain
3. decrease defaultMaxLockRowCount from 1M to 20k


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix shuffle join V2 compatibility with merge operators

- Display shuffle information in table scan explain output

- Reduce default lock row count from 1M to 200K

- Add test coverage for secondary index operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shuffle Join V2"] -- "check merge operators" --> B["Use Shuffle V1"]
  C["Table Scan"] -- "add shuffle info" --> D["Enhanced Explain Output"]
  E["Lock Service"] -- "reduce count" --> F["200K Row Limit"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cfg.go</strong><dd><code>Decrease default lock row count limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/cfg.go

- Reduce `defaultMaxLockRowCount` from 1,000,000 to 200,000


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22305/files#diff-d7a7375d46ce6b2e581483bceac8fe198bb447b4cc708f50f6cb6f9aa375d4e3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>shuffle.go</strong><dd><code>Minor shuffle execution flow adjustments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/shuffle/shuffle.go

<ul><li>Add blank line for code formatting<br> <li> Move <code>result.Status = vm.ExecNext</code> assignment earlier in logic flow</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22305/files#diff-dd874410fa94e53ef1b1a5d4d599903dd307785afc25ad7d334874218f8cf73f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compile.go</strong><dd><code>Fix shuffle V2 compatibility with merge operators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/compile.go

<ul><li>Add condition to check if probe/build sides have merge operators<br> <li> Use shuffle V1 instead of V2 when merge operators are present<br> <li> Add blank line for formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22305/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>shuffle.go</strong><dd><code>Improve dedup join shuffle handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/shuffle.go

<ul><li>Fix dedup join shuffle logic for right joins<br> <li> Add shuffle configuration for right child in range shuffle<br> <li> Improve condition handling for different join scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22305/files#diff-9baa9a638e4d3a9d06042ee71ca8f6893d3e708a9c9e12e9d8f5f62132209827">+22/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>explain_node.go</strong><dd><code>Display shuffle info in table scan explain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/explain/explain_node.go

<ul><li>Add shuffle information display for table scan operations<br> <li> Show shuffle type (hash/range), column names, and method <br>(reuse/hybrid)<br> <li> Import <code>util</code> package for cluster column handling</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22305/files#diff-8f43f1687f258ca1e42e50039e8c7e85db033f7ed0a50f4d6c8b9c7344b40a2d">+36/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>secondary_index_insert.result</strong><dd><code>Add secondary index large dataset test results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/ddl/secondary_index_insert.result

<ul><li>Add test results for large dataset secondary index operations<br> <li> Include results for 500K, 100K, and 300K row insertions</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22305/files#diff-2f3c691d359a67d83f2ba9aed476b0daad9e7fadbc7c9fac66a5687c909e9cb9">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>secondary_index_insert.sql</strong><dd><code>Add secondary index large dataset tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/ddl/secondary_index_insert.sql

<ul><li>Add test cases for secondary index with large datasets<br> <li> Test insertions with 500K rows and various limits<br> <li> Include table flush operations</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22305/files#diff-aa12418711e52662463121b30459693c7b40eeecb7296e0dcedf97f85df134ea">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

