### PR TITLE
container/hashtable: use longer than 16 bytes keys in tests

### DIFF
--- a/pkg/common/malloc/inuse_tracking_allocator_test.go
+++ b/pkg/common/malloc/inuse_tracking_allocator_test.go
@@ -22,7 +22,9 @@ func TestInuseTrackingAllocator(t *testing.T) {
 	testAllocator(t, func() Allocator {
 		return NewInuseTrackingAllocator(
 			newUpstreamAllocatorForTest(),
-			func(inUse uint64) {},
+			func(inUse uint64) error {
+				return nil
+			},
 		)
 	})
 }
@@ -32,7 +34,9 @@ func BenchmarkInuseTrackingAllocator(b *testing.B) {
 		benchmarkAllocator(b, func() Allocator {
 			return NewInuseTrackingAllocator(
 				newUpstreamAllocatorForTest(),
-				func(inUse uint64) {},
+				func(inUse uint64) error {
+					return nil
+				},
 			)
 		}, n)
 	}
@@ -42,7 +46,9 @@ func FuzzInuseTrackingAllocator(f *testing.F) {
 	fuzzAllocator(f, func() Allocator {
 		return NewInuseTrackingAllocator(
 			newUpstreamAllocatorForTest(),
-			func(inUse uint64) {},
+			func(inUse uint64) error {
+				return nil
+			},
 		)
 	})
 }

--- a/pkg/container/hashtable/malloc.go
+++ b/pkg/container/hashtable/malloc.go
@@ -15,12 +15,12 @@
 package hashtable
 
 import (
-	"fmt"
 	"math"
 	"sync"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/malloc"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"go.uber.org/zap"
@@ -51,7 +51,7 @@ func newAllocator() malloc.Allocator {
 			metric.MallocGauge.WithLabelValues("hashmap-inuse-objects"),
 		),
 
-		func(inUse uint64) {
+		func(inUse uint64) error {
 
 			// soft limit
 			if inUse > softLimit && time.Since(softLimitLoggedAt) > softLimitLogMinInterval {
@@ -64,13 +64,14 @@ func newAllocator() malloc.Allocator {
 
 			// hard limit
 			if inUse > hardLimit {
-				panic(fmt.Sprintf(
+				return moerr.NewInternalErrorNoCtxf(
 					"hashmap memory exceed hard limit. hard limit %v, inuse %v",
 					hardLimit,
 					inUse,
-				))
+				)
 			}
 
+			return nil
 		},
 	)
 }

--- a/pkg/container/hashtable/util_test.go
+++ b/pkg/container/hashtable/util_test.go
@@ -24,8 +24,14 @@ type errorAfterNWriter struct {
 var _ io.Writer = new(errorAfterNWriter)
 
 func (e *errorAfterNWriter) Write(p []byte) (n int, err error) {
-	if e.N < 0 {
-		return 0, io.ErrUnexpectedEOF
+	if e.N < len(p) {
+		if e.N < 0 {
+			return 0, io.ErrUnexpectedEOF
+		}
+		n = e.N
+		e.N = -1
+		err = io.ErrShortWrite
+		return
 	}
 	e.N -= len(p)
 	return len(p), nil


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22239

## What this PR does / why we need it:
 container/hashtable: use longer than 16 bytes keys in tests

malloc: call upstream deallocator if error in InuseTrackingAllocator.Allocate

container/hashtable: re-implement WriteTo/UnmarshalFrom with iter and insert


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix allocator error handling in `InuseTrackingAllocator`

- Re-implement hashtable `WriteTo`/`UnmarshalFrom` using iterators

- Improve error handling and memory management

- Update tests for better error coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["InuseTrackingAllocator"] -- "fix error handling" --> B["onChange callback"]
  C["WriteTo/UnmarshalFrom"] -- "re-implement" --> D["iterator-based approach"]
  E["Tests"] -- "improve" --> F["error coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inuse_tracking_allocator.go</strong><dd><code>Fix error handling in allocator callback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/malloc/inuse_tracking_allocator.go

<ul><li>Change <code>onChange</code> callback signature to return error<br> <li> Add error handling in <code>Allocate</code> method with upstream deallocator call<br> <li> Add panic on error in deallocator callback</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22324/files#diff-5c671f1bf8b1cf89046f5a6f1ed019b24969f47dddee91008b31568e88e16da8">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inuse_tracking_allocator_test.go</strong><dd><code>Update tests for new callback signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/malloc/inuse_tracking_allocator_test.go

<ul><li>Update test callbacks to return <code>nil</code> error<br> <li> Modify function signatures in test, benchmark, and fuzz functions</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22324/files#diff-ebc5a7d6211b8cf4dac71b9f85b8671eb64c3994457de7c9e14fc3bd6ca5974b">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hash_test.go</strong><dd><code>Improve error testing for hashtable serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/hash_test.go

<ul><li>Remove unused <code>io</code> import<br> <li> Rewrite <code>TestWriteToError</code> with proper error scenarios<br> <li> Add elements to maps before testing error conditions<br> <li> Improve test coverage for serialization errors</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22324/files#diff-143a72c68553122c52f4ec9f746214d8c31082bf6cf6b1559535d66cab95eb04">+42/-27</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>util_test.go</strong><dd><code>Enhance error writer utility for testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/util_test.go

<ul><li>Improve <code>errorAfterNWriter</code> logic for partial writes<br> <li> Add proper handling for <code>io.ErrShortWrite</code><br> <li> Fix edge cases in error simulation</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22324/files#diff-1c06bbcde63e54e66d122eebe00e539b3da0abae7b2367388aa51975d3a33322">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>int64_hash_map.go</strong><dd><code>Re-implement Int64HashMap serialization with iterators</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/int64_hash_map.go

<ul><li>Simplify <code>WriteTo</code> to only write element count and active cells<br> <li> Use iterator-based approach instead of block traversal<br> <li> Rewrite <code>UnmarshalFrom</code> to use <code>Init</code> and <code>ResizeOnDemand</code><br> <li> Remove complex metadata serialization/deserialization</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22324/files#diff-772d0fd88084fa275aea0e5fd881966931ca7c5f7459220992d5df6eca565564">+25/-61</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>string_hash_map.go</strong><dd><code>Re-implement StringHashMap serialization with iterators</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/string_hash_map.go

<ul><li>Simplify <code>WriteTo</code> to only write element count and active cells<br> <li> Use iterator-based approach for serialization<br> <li> Rewrite <code>UnmarshalFrom</code> to use <code>Init</code> and <code>ResizeOnDemand</code><br> <li> Remove complex metadata handling</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22324/files#diff-1e80a3584223d76a842b76dd5fc96065b2b7d0c0e5bf69d5b439591cf59af273">+32/-68</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>malloc.go</strong><dd><code>Replace panic with error return in allocator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/malloc.go

<ul><li>Change <code>onChange</code> callback to return error instead of panic<br> <li> Replace <code>fmt.Sprintf</code> panic with <code>moerr.NewInternalErrorNoCtxf</code><br> <li> Import <code>moerr</code> package and remove <code>fmt</code></ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22324/files#diff-19946c6236c39e59182736f8ae376be1742733102e27f1335c5e2883c8c5ca33">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

