### PR TITLE
flushing objects in chunks 3.0

### DIFF
--- a/pkg/vm/engine/tae/db/checkpoint/flusher.go
+++ b/pkg/vm/engine/tae/db/checkpoint/flusher.go
@@ -540,30 +540,68 @@ func (flusher *flushImpl) fireFlushTabletail(
 		return nil
 	}
 
-	// freeze all append
-	scopes := make([]common.ID, 0, len(metas))
-	for _, meta := range metas {
-		if !meta.GetObjectData().PrepareCompact() {
-			logutil.Info("[FlushTabletail] data prepareCompact false", zap.String("table", tableDesc), zap.String("obj", meta.ID().String()))
-			return moerr.GetOkExpectedEOB()
-		}
-		scopes = append(scopes, *meta.AsCommonID())
-	}
-	for _, meta := range tombstoneMetas {
-		if !meta.GetObjectData().PrepareCompact() {
-			logutil.Info("[FlushTabletail] tomb prepareCompact false", zap.String("table", tableDesc), zap.String("obj", meta.ID().String()))
-			return moerr.GetOkExpectedEOB()
-		}
-		scopes = append(scopes, *meta.AsCommonID())
+	if len(metas) == 0 && len(tombstoneMetas) > 0 {
+		metas = append(metas, nil) // make it a non-empty chunk
 	}
 
-	factory := jobs.FlushTableTailTaskFactory(metas, tombstoneMetas, flusher.rt)
-	if _, err := flusher.rt.Scheduler.ScheduleMultiScopedTxnTask(nil, tasks.FlushTableTailTask, scopes, factory); err != nil {
-		if err != tasks.ErrScheduleScopeConflict {
-			logutil.Error("[FlushTabletail] Sched Failure", zap.String("table", tableDesc), zap.Error(err))
+	metaChunks := slices.Chunk(metas, 400)
+	firstChunk := true
+
+nextChunk:
+	for chunk := range metaChunks {
+		if len(chunk) == 1 && chunk[0] == nil {
+			chunk = chunk[:0] // remove the placeholder
 		}
-		return moerr.GetOkExpectedEOB()
+		scopes := make([]common.ID, 0, len(chunk))
+		for _, meta := range chunk {
+			if !meta.GetObjectData().PrepareCompact() {
+				logutil.Info("[FlushTabletail] data prepareCompact false",
+					zap.String("table", tableDesc),
+					zap.String("obj", meta.ID().String()),
+				)
+				break nextChunk
+			}
+			scopes = append(scopes, *meta.AsCommonID())
+		}
+		if firstChunk {
+			for _, meta := range tombstoneMetas {
+				if !meta.GetObjectData().PrepareCompact() {
+					logutil.Info("[FlushTabletail] tomb prepareCompact false",
+						zap.String("table", tableDesc),
+						zap.String("obj", meta.ID().String()),
+					)
+					// As we treat tombstone as a monolithic chunk,
+					// skip this fire and wait for the next run if freeze fails.
+					return moerr.GetOkExpectedEOB()
+				}
+				scopes = append(scopes, *meta.AsCommonID())
+			}
+		}
+		var factory tasks.TxnTaskFactory
+		if firstChunk {
+			factory = jobs.FlushTableTailTaskFactory(chunk, tombstoneMetas, flusher.rt)
+			firstChunk = false
+		} else {
+			logutil.Info("[FlushTabletail] fire chunk",
+				zap.String("table", tableDesc),
+				zap.Int("chunk-size", len(chunk)),
+			)
+			factory = jobs.FlushTableTailTaskFactory(chunk, nil, flusher.rt)
+		}
+
+		_, err := flusher.rt.Scheduler.ScheduleMultiScopedTxnTask(
+			nil, tasks.FlushTableTailTask, scopes, factory)
+		if err != nil {
+			if err != tasks.ErrScheduleScopeConflict {
+				logutil.Error("[FlushTabletail] Sched Failure",
+					zap.String("table", tableDesc),
+					zap.Error(err),
+				)
+			}
+			return moerr.GetOkExpectedEOB()
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/MO-Cloud/issues/6068

## What this PR does / why we need it:

- Process appendable objects in controlled chunks to maintain stable memory usage.
- A chunk means 400 appendable data objects


___

### **PR Type**
Enhancement


___

### **Description**
- Process appendable objects in controlled chunks of 400 items

- Maintain stable memory usage during flush operations

- Handle tombstone metadata as monolithic chunk in first iteration

- Add logging for chunk processing progress


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original Objects"] --> B["Split into Chunks (400 items)"]
  B --> C["Process First Chunk + Tombstones"]
  C --> D["Process Remaining Chunks"]
  D --> E["Stable Memory Usage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flusher.go</strong><dd><code>Implement chunked flush processing for memory optimization</code></dd></summary>
<hr>

pkg/vm/engine/tae/db/checkpoint/flusher.go

<ul><li>Replace monolithic object processing with chunked approach (400 items <br>per chunk)<br> <li> Add special handling for tombstone metadata in first chunk only<br> <li> Implement chunk iteration with proper error handling and logging<br> <li> Add placeholder logic for empty metadata with tombstones present</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22331/files#diff-8b77364ba4bb7a1b1cfb6e85ddfabc827686c3c9b86fec4340ee595e12718a99">+57/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

