### PR TITLE
to 3.0: restrict MO_CTL execution of cn merge within explicit transactions

### DIFF
--- a/pkg/sql/plan/function/ctl/ctl.go
+++ b/pkg/sql/plan/function/ctl/ctl.go
@@ -82,6 +82,15 @@ func MoCtl(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *pr
 		return moerr.NewNotSupportedf(proc.Ctx, "command %s not supported", command)
 	}
 
+	switch command {
+	case MergeObjectsMethod:
+		if proc.GetTxnOperator() != nil && proc.GetTxnOperator().TxnOptions().ByBegin {
+			return moerr.NewInternalErrorNoCtxf(
+				"cannot execute %s within an explicit transaction", command,
+			)
+		}
+	}
+
 	res, err := f(proc,
 		service,
 		parameter,

--- a/test/distributed/cases/function/mo_ctl/mo_ctl_merge.result
+++ b/test/distributed/cases/function/mo_ctl/mo_ctl_merge.result
@@ -243,3 +243,7 @@ rows_cnt
 select mo_ctl('dn', 'inspect', 'merge switch on');
 mo_ctl(dn, inspect, merge switch on)
 \nmsg: merge is enabled for table (*)\n\nauto merge is enabled
+begin;
+select mo_ctl('cn', 'mergeobjects', 't:mo_ctl_merge.p_table_01');
+internal error: cannot execute MERGEOBJECTS within an explicit transaction
+commit ;

--- a/test/distributed/cases/function/mo_ctl/mo_ctl_merge.test
+++ b/test/distributed/cases/function/mo_ctl/mo_ctl_merge.test
@@ -147,3 +147,6 @@ select rows_cnt from metadata_scan('mo_ctl_merge.%!%p3%!%p_table_01', 'col1') g;
 -- @bvt:issue
 
 select mo_ctl('dn', 'inspect', 'merge switch on');
+begin;
+select mo_ctl('cn', 'mergeobjects', 't:mo_ctl_merge.p_table_01');
+commit ;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/21941

## What this PR does / why we need it:

mo_ctl advancing the transaction snapshot may result in unexpected behavior,
So we restrict these executions within an explicit transaction.


___

### **PR Type**
Bug fix


___

### **Description**
- Restrict MO_CTL flush/merge/checkpoint execution within explicit transactions

- Add `ByBegin()` method to TxnOperator interface

- Implement transaction state checking for control operations

- Add test cases for transaction restriction validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TxnOperator Interface"] --> B["Add ByBegin() method"]
  B --> C["Implement in all operators"]
  C --> D["MO_CTL function check"]
  D --> E["Block flush/merge/checkpoint in transactions"]
  E --> F["Add test validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>types.go</strong><dd><code>Add ByBegin method to TxnOperator interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-04dd5377bb096d114087521ac2b2f926bbe80f0459b98e1bb1d5a2774282b08a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>operator.go</strong><dd><code>Implement ByBegin method in txnOperator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-43f44107ace02cc2170c3138f30bd1e0ba258be040543c7e43e3a49b89d67c99">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>storage_txn_client.go</strong><dd><code>Implement ByBegin method returning false</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-f3de47afbf03f0313e955d1981e7739483e2583ab25715940cbd860078c45d6a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ctl.go</strong><dd><code>Add transaction check for control operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-10aceaca1f213690f0e86c04765de4b75ae2f958c30296b35fe9c0c8bf26846a">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>txn_mock.go</strong><dd><code>Add ByBegin mock method implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-68e826bd15c3f0b74a031fad521dfb4ed97d3d9a22a29d40d0e1372c814dc646">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service_test.go</strong><dd><code>Add ByBegin panic implementation for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-1545c670565109e9085a67dbb7f5a2282ecc827539c27f35c7e873f086400b12">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>txn_test.go</strong><dd><code>Add ByBegin panic implementation for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-a62be3f347c14388335d2c9f5215f4cc4047061478716e92a7ff2008746667af">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>store_sql_test.go</strong><dd><code>Add ByBegin panic implementation for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-7be9152998e4522d6fdd16ff7a5f3eefee803a694058c564957fd1ddc935017f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>remoterun_test.go</strong><dd><code>Add ByBegin false return for fake operator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-87cb5b928ccaeb113e1cda3c8fe7fe6b65a71d470bf5f32c8da9c8de302456cf">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>entire_engine_test.go</strong><dd><code>Add ByBegin panic implementation for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-1e6781313efa2d3f2c37c97bcc6e8f3cf63d5af77cf95536e506e548d126be55">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>checkpoint.test</strong><dd><code>Add transaction checkpoint restriction test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-8890bfefcbd9016c3e65e37c6ae0dbf0be0ade77af9147b10e7c2260274a9794">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>checkpoint.result</strong><dd><code>Add expected error result for checkpoint test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-c0a115bc80a368d964b56c08b5ba840490c39947f895cfbc133dda2a3eeeef01">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mo_ctl_merge.test</strong><dd><code>Add transaction merge restriction test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-5d0c1f13b214775d4d75d89e3f7ec90f99ddc959cc986c340fd0aac38bef1f68">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mo_ctl_merge.result</strong><dd><code>Add expected error result for merge test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22333/files#diff-3a4c9135f39a9fdd33977fe6936b8ab27d342b60ae8114d042006391ccde1830">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

