### PR TITLE
to 3.0: Fix the appendable tombstone object clone logic.

### DIFF
--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -1049,6 +1049,7 @@ func doRestorePitr(ctx context.Context, ses *Session, stmt *tree.RestorePitr) (s
 			}
 
 			// check account exists or not
+			ctx = context.WithValue(ctx, tree.CloneLevelCtxKey{}, tree.RestoreCloneLevelAccount)
 			rtnErr = restoreAccountUsingClusterSnapshotToNew(
 				ctx,
 				ses,

--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -1299,7 +1299,7 @@ func (ls *LocalDisttaeDataSource) batchApplyTombstoneObjects(
 			location = obj.ObjectStats.BlockLocation(uint16(idx), objectio.BlockMaxRows)
 
 			if _, release, err = ioutil.ReadDeletes(
-				ls.ctx, location, ls.fs, obj.GetCNCreated(), cacheVectors,
+				ls.ctx, location, ls.fs, obj.GetCNCreated(), cacheVectors, nil,
 			); err != nil {
 				return err
 			}

--- a/pkg/vm/engine/disttae/mo_table_stats.go
+++ b/pkg/vm/engine/disttae/mo_table_stats.go
@@ -3137,7 +3137,7 @@ func applyTombstones(
 			func(blk objectio.BlockInfo, blkMeta objectio.BlockObject) bool {
 
 				if _, release, err = ioutil.ReadDeletes(
-					ctx, blk.MetaLoc[:], fs, tombstone.GetCNCreated(), persistedDeletes,
+					ctx, blk.MetaLoc[:], fs, tombstone.GetCNCreated(), persistedDeletes, nil,
 				); err != nil {
 					return false
 				}

--- a/test/distributed/cases/snapshot/clone/clone_appendable_obj.result
+++ b/test/distributed/cases/snapshot/clone/clone_appendable_obj.result
@@ -1,0 +1,50 @@
+drop database if exists test;
+create database test;
+use test;
+create table t1(a int primary key, b int);
+insert into t1 select *,* from generate_series(1, 10)g;
+delete from t1 where a mod 2 = 0;
+drop snapshot if exists sp;
+create snapshot sp for table test t1;
+insert into t1 select *,* from generate_series(11, 20)g;
+delete from t1 where a mod 2 = 0;
+drop snapshot if exists sp2;
+create snapshot sp2 for table test t1;
+delete from t1 where a mod 3 = 0;
+select mo_ctl("dn", "flush", "test.t1");
+mo_ctl(dn, flush, test.t1)
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+create table t2 clone t1 {snapshot = "sp"};
+select * from t2 order by a asc;
+a    b
+1    1
+3    3
+5    5
+7    7
+9    9
+create table t3 clone t1 {snapshot = "sp2"};
+select * from t3 order by a asc;
+a    b
+1    1
+3    3
+5    5
+7    7
+9    9
+11    11
+13    13
+15    15
+17    17
+19    19
+create table t4 clone t1;
+select * from t4 order by a asc;
+a    b
+1    1
+5    5
+7    7
+11    11
+13    13
+17    17
+19    19
+drop database test;
+drop snapshot sp;
+drop snapshot sp2;

--- a/test/distributed/cases/snapshot/clone/clone_appendable_obj.sql
+++ b/test/distributed/cases/snapshot/clone/clone_appendable_obj.sql
@@ -1,0 +1,34 @@
+drop database if exists test;
+create database test;
+use test;
+
+create table t1(a int primary key, b int);
+insert into t1 select *,* from generate_series(1, 10)g;
+delete from t1 where a mod 2 = 0;
+
+drop snapshot if exists sp;
+create snapshot sp for table test t1;
+
+insert into t1 select *,* from generate_series(11, 20)g;
+delete from t1 where a mod 2 = 0;
+
+drop snapshot if exists sp2;
+create snapshot sp2 for table test t1;
+
+delete from t1 where a mod 3 = 0;
+
+-- @ignore:0
+select mo_ctl("dn", "flush", "test.t1");
+
+create table t2 clone t1 {snapshot = "sp"};
+select * from t2 order by a asc;
+
+create table t3 clone t1 {snapshot = "sp2"};
+select * from t3 order by a asc;
+
+create table t4 clone t1;
+select * from t4 order by a asc;
+
+drop database test;
+drop snapshot sp;
+drop snapshot sp2;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22342 https://github.com/matrixorigin/matrixone/issues/22338

## What this PR does / why we need it:

1. Fix the appendable tombstone object clone logic.
2. Fix privilege control when restoring.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix appendable tombstone object clone logic for PITR restoration

- Add primary key column reading support in tombstone operations

- Implement proper snapshot filtering for appendable objects

- Add clone level context for privilege control during restoration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PITR Restore"] --> B["Clone Level Context"]
  C["ReadDeletes Function"] --> D["PK Column Support"]
  E["TableMetaReader"] --> F["Tombstone Filtering"]
  F --> G["Snapshot Validation"]
  B --> H["Privilege Control"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pitr.go</strong><dd><code>Add clone level context for PITR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/pitr.go

- Add clone level context for account restoration privilege control


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22344/files#diff-c8a9f549ed3d2519111f48418df54c80abb5fe22272b05d2cec751c84ec09ab0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>local_disttae_datasource.go</strong><dd><code>Update ReadDeletes function call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/local_disttae_datasource.go

- Update `ReadDeletes` call to pass nil for PK type parameter


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22344/files#diff-6a1e15697fc3cab3d0c3bfb66664b0adfb3017683f87953e93ae1c2213af0f86">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mo_table_stats.go</strong><dd><code>Update ReadDeletes function call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/mo_table_stats.go

- Update `ReadDeletes` call to pass nil for PK type parameter


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22344/files#diff-3fa2c0f28041af8110f1af1461c2094fa7d2534b76af37b6789c993b03364de2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>table_meta_reader.go</strong><dd><code>Refactor tombstone object processing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/table_meta_reader.go

<ul><li>Add imports for ioutil and containers packages<br> <li> Refactor data reading logic into separate functions<br> <li> Implement proper tombstone filtering with snapshot validation<br> <li> Add qualified bitmap for filtering rows by commit timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22344/files#diff-879d5d0d22187ecfe6a6034c7e08557ae397d99648c417885f4a5e0b85fc4aaa">+84/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>funcs.go</strong><dd><code>Enhance ReadDeletes with PK support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/ioutil/funcs.go

<ul><li>Add optional primary key type parameter to <code>ReadDeletes</code> function<br> <li> Update function signature to support PK column reading<br> <li> Add logic to include PK column when type is provided</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22344/files#diff-7281cd8e540805470a83c7f71089de80ef8ade98e1ca841537626af7ffd497d8">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

