### PR TITLE
container/hashtable: use longer than 16 bytes keys in tests

### DIFF
--- a/pkg/common/malloc/inuse_tracking_allocator_test.go
+++ b/pkg/common/malloc/inuse_tracking_allocator_test.go
@@ -22,7 +22,9 @@ func TestInuseTrackingAllocator(t *testing.T) {
 	testAllocator(t, func() Allocator {
 		return NewInuseTrackingAllocator(
 			newUpstreamAllocatorForTest(),
-			func(inUse uint64) {},
+			func(inUse uint64) error {
+				return nil
+			},
 		)
 	})
 }
@@ -32,7 +34,9 @@ func BenchmarkInuseTrackingAllocator(b *testing.B) {
 		benchmarkAllocator(b, func() Allocator {
 			return NewInuseTrackingAllocator(
 				newUpstreamAllocatorForTest(),
-				func(inUse uint64) {},
+				func(inUse uint64) error {
+					return nil
+				},
 			)
 		}, n)
 	}
@@ -42,7 +46,9 @@ func FuzzInuseTrackingAllocator(f *testing.F) {
 	fuzzAllocator(f, func() Allocator {
 		return NewInuseTrackingAllocator(
 			newUpstreamAllocatorForTest(),
-			func(inUse uint64) {},
+			func(inUse uint64) error {
+				return nil
+			},
 		)
 	})
 }

--- a/pkg/container/hashtable/malloc.go
+++ b/pkg/container/hashtable/malloc.go
@@ -15,12 +15,12 @@
 package hashtable
 
 import (
-	"fmt"
 	"math"
 	"sync"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/malloc"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"go.uber.org/zap"
@@ -51,7 +51,7 @@ func newAllocator() malloc.Allocator {
 			metric.MallocGauge.WithLabelValues("hashmap-inuse-objects"),
 		),
 
-		func(inUse uint64) {
+		func(inUse uint64) error {
 
 			// soft limit
 			if inUse > softLimit && time.Since(softLimitLoggedAt) > softLimitLogMinInterval {
@@ -64,13 +64,14 @@ func newAllocator() malloc.Allocator {
 
 			// hard limit
 			if inUse > hardLimit {
-				panic(fmt.Sprintf(
+				return moerr.NewInternalErrorNoCtxf(
 					"hashmap memory exceed hard limit. hard limit %v, inuse %v",
 					hardLimit,
 					inUse,
-				))
+				)
 			}
 
+			return nil
 		},
 	)
 }

--- a/pkg/container/hashtable/util_test.go
+++ b/pkg/container/hashtable/util_test.go
@@ -24,8 +24,14 @@ type errorAfterNWriter struct {
 var _ io.Writer = new(errorAfterNWriter)
 
 func (e *errorAfterNWriter) Write(p []byte) (n int, err error) {
-	if e.N < 0 {
-		return 0, io.ErrUnexpectedEOF
+	if e.N < len(p) {
+		if e.N < 0 {
+			return 0, io.ErrUnexpectedEOF
+		}
+		n = e.N
+		e.N = -1
+		err = io.ErrShortWrite
+		return
 	}
 	e.N -= len(p)
 	return len(p), nil


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22239 

## What this PR does / why we need it:
container/hashtable: use longer than 16 bytes keys in tests

malloc: call upstream deallocator if error in InuseTrackingAllocator.Allocate

container/hashtable: re-implement WriteTo/UnmarshalFrom with iter and insert


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix memory allocator error handling and cleanup

- Refactor hashtable serialization using iterators

- Improve test coverage with longer keys

- Update error handling in tracking allocator


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["InuseTrackingAllocator"] --> B["Error Handling"]
  B --> C["Upstream Deallocator"]
  D["Hashtable WriteTo/UnmarshalFrom"] --> E["Iterator-based Serialization"]
  E --> F["Simplified Format"]
  G["Test Improvements"] --> H["Longer Keys"]
  H --> I["Better Error Testing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inuse_tracking_allocator.go</strong><dd><code>Add error handling to tracking allocator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/malloc/inuse_tracking_allocator.go

<ul><li>Change onChange callback to return error instead of void<br> <li> Add error handling with panic on callback errors<br> <li> Call upstream deallocator on allocation error before panic</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22355/files#diff-5c671f1bf8b1cf89046f5a6f1ed019b24969f47dddee91008b31568e88e16da8">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>inuse_tracking_allocator_test.go</strong><dd><code>Update tests for error-returning callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/malloc/inuse_tracking_allocator_test.go

<ul><li>Update test callbacks to return nil error<br> <li> Maintain compatibility with new error-returning interface</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22355/files#diff-ebc5a7d6211b8cf4dac71b9f85b8671eb64c3994457de7c9e14fc3bd6ca5974b">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hash_test.go</strong><dd><code>Enhance tests with longer keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/hash_test.go

<ul><li>Use longer keys (>16 bytes) in marshal/unmarshal tests<br> <li> Improve error testing with realistic scenarios<br> <li> Replace simple string keys with repeated byte patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22355/files#diff-143a72c68553122c52f4ec9f746214d8c31082bf6cf6b1559535d66cab95eb04">+47/-29</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>util_test.go</strong><dd><code>Enhance error writer test utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/util_test.go

<ul><li>Improve errorAfterNWriter to handle partial writes correctly<br> <li> Add proper error conditions for testing write failures</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22355/files#diff-1c06bbcde63e54e66d122eebe00e539b3da0abae7b2367388aa51975d3a33322">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>int64_hash_map.go</strong><dd><code>Refactor serialization with iterator approach</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/int64_hash_map.go

<ul><li>Reimplement WriteTo using iterator instead of direct cell access<br> <li> Simplify UnmarshalFrom to only store element count initially<br> <li> Use ResizeOnDemand and findEmptyCell for reconstruction</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22355/files#diff-772d0fd88084fa275aea0e5fd881966931ca7c5f7459220992d5df6eca565564">+25/-61</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>string_hash_map.go</strong><dd><code>Refactor serialization with iterator approach</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/string_hash_map.go

<ul><li>Reimplement WriteTo using iterator instead of direct cell access<br> <li> Simplify UnmarshalFrom to only store element count initially<br> <li> Use ResizeOnDemand for proper hashtable reconstruction</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22355/files#diff-1e80a3584223d76a842b76dd5fc96065b2b7d0c0e5bf69d5b439591cf59af273">+32/-68</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>malloc.go</strong><dd><code>Replace panic with error return</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/hashtable/malloc.go

<ul><li>Change memory limit callback to return error instead of panic<br> <li> Replace fmt.Sprintf panic with moerr.NewInternalErrorNoCtxf<br> <li> Import moerr package for proper error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22355/files#diff-19946c6236c39e59182736f8ae376be1742733102e27f1335c5e2883c8c5ca33">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

