### PR TITLE
pick Left/Inner join produces better chunks (#22351) to 3.0-dev

### DIFF
--- a/pkg/sql/colexec/join/join.go
+++ b/pkg/sql/colexec/join/join.go
@@ -46,6 +46,9 @@ func (innerJoin *InnerJoin) Prepare(proc *process.Process) (err error) {
 	} else {
 		innerJoin.OpAnalyzer.Reset()
 	}
+	if len(innerJoin.ctr.joinBats) == 0 {
+		innerJoin.ctr.joinBats = make([]*batch.Batch, 2)
+	}
 	if len(innerJoin.ctr.vecs) == 0 {
 		innerJoin.ctr.vecs = make([]*vector.Vector, len(innerJoin.Conditions[0]))
 		innerJoin.ctr.executor = make([]colexec.ExpressionExecutor, len(innerJoin.Conditions[0]))
@@ -112,12 +115,13 @@ func (innerJoin *InnerJoin) Call(proc *process.Process) (vm.CallResult, error) {
 			}
 
 			startrow := innerJoin.ctr.lastRow
+			// probe will set inbat nil if data is exhauseted
 			if err := ctr.probe(innerJoin, proc, &result); err != nil {
 				return result, err
 			}
-			if innerJoin.ctr.lastRow == 0 {
-				innerJoin.ctr.inbat = nil
-			} else if innerJoin.ctr.lastRow == startrow {
+
+			if innerJoin.ctr.lastRow == startrow && ctr.inbat != nil &&
+				(result.Batch == nil || result.Batch.IsEmpty()) {
 				return result, moerr.NewInternalErrorNoCtx("inner join hanging")
 			}
 
@@ -146,8 +150,7 @@ func (innerJoin *InnerJoin) build(analyzer process.Analyzer, proc *process.Proce
 	return nil
 }
 
-func (ctr *container) probe(ap *InnerJoin, proc *process.Process, result *vm.CallResult) error {
-
+func (ctr *container) setupResultAndCondition(ap *InnerJoin, proc *process.Process) error {
 	mpbat := ctr.mp.GetBatches()
 	if ctr.rbat == nil {
 		ctr.rbat = batch.NewOffHeapWithSize(len(ap.Result))
@@ -172,124 +175,229 @@ func (ctr *container) probe(ap *InnerJoin, proc *process.Process, result *vm.Cal
 	if err := ctr.evalJoinCondition(ap.ctr.inbat, proc); err != nil {
 		return err
 	}
-	if ctr.joinBat1 == nil {
-		ctr.joinBat1, ctr.cfs1 = colexec.NewJoinBatch(ap.ctr.inbat, proc.Mp())
+	if ctr.joinBats[0] == nil {
+		ctr.joinBats[0], ctr.cfs1 = colexec.NewJoinBatch(ap.ctr.inbat, proc.Mp())
 	}
-	if ctr.joinBat2 == nil && ctr.batchRowCount > 0 {
-		ctr.joinBat2, ctr.cfs2 = colexec.NewJoinBatch(mpbat[0], proc.Mp())
+	if ctr.joinBats[1] == nil && ctr.batchRowCount > 0 {
+		ctr.joinBats[1], ctr.cfs2 = colexec.NewJoinBatch(mpbat[0], proc.Mp())
 	}
-
-	count := ap.ctr.inbat.RowCount()
 	if ctr.itr == nil {
 		ctr.itr = ctr.mp.NewIterator()
 	}
-	itr := ctr.itr
+	return nil
+}
+
+func (ctr *container) probe(ap *InnerJoin, proc *process.Process, result *vm.CallResult) error {
+	if err := ctr.setupResultAndCondition(ap, proc); err != nil {
+		return err
+	}
+	mpbat := ctr.mp.GetBatches()
+	inputRowCount := ap.ctr.inbat.RowCount()
 	rowCount := 0
-	for i := ap.ctr.lastRow; i < count; i += hashmap.UnitLimit {
-		if rowCount >= colexec.DefaultBatchSize {
-			ctr.rbat.AddRowCount(rowCount)
-			result.Batch = ctr.rbat
-			ap.ctr.lastRow = i
-			return nil
-		}
-		n := count - i
-		if n > hashmap.UnitLimit {
-			n = hashmap.UnitLimit
-		}
-		vals, zvals := itr.Find(i, n, ctr.vecs)
-		for k := 0; k < n; k++ {
-			if zvals[k] == 0 || vals[k] == 0 {
+
+	for {
+		switch ctr.probeState {
+		case psSelsForOneRow:
+			// Branch 1:handle remaining sels for ctr.lastRow - 1
+			// a non-unique column row is mapped to multiple record in hashmap,
+			// appending at most 8192 rows to result
+			processCount := min(
+				len(ctr.sels),
+				colexec.DefaultBatchSize-rowCount,
+			)
+			sels := ctr.sels[:processCount]
+			// remove processed sels
+			ctr.sels = ctr.sels[processCount:]
+			row := int64(ctr.lastRow - 1)
+			if ap.Cond == nil {
+				// append multi rows by batch
+				for j, rp := range ap.Result {
+					if rp.Rel == 0 {
+						if err := ctr.rbat.Vecs[j].UnionMulti(
+							ap.ctr.inbat.Vecs[rp.Pos],
+							row,
+							processCount, proc.Mp()); err != nil {
+							return err
+						}
+					} else {
+						for _, sel := range sels {
+							idx1 := int64(sel / colexec.DefaultBatchSize)
+							idx2 := int64(sel % colexec.DefaultBatchSize)
+							if err := ctr.rbat.Vecs[j].UnionOne(
+								mpbat[idx1].Vecs[rp.Pos],
+								idx2,
+								proc.Mp(),
+							); err != nil {
+								return err
+							}
+						}
+					}
+				}
+				rowCount += processCount
+			} else {
+				// append one by one
+				for _, sel := range sels {
+					idx1 := int64(sel / colexec.DefaultBatchSize)
+					idx2 := int64(sel % colexec.DefaultBatchSize)
+					ok, err := ctr.evalAndAppendOne(proc, ap, row, idx1, idx2)
+					if err != nil {
+						return err
+					}
+					if ok {
+						rowCount++
+					}
+				}
+			}
+
+			if len(ctr.sels) > 0 {
+				ctr.probeState = psSelsForOneRow
+			} else if ctr.vsidx < len(ctr.vs) {
+				ctr.probeState = psBatchRow
+			} else {
+				ctr.probeState = psNextBatch
+			}
+
+			if rowCount >= colexec.DefaultBatchSize {
+				ctr.rbat.AddRowCount(rowCount)
+				result.Batch = ctr.rbat
+				return nil
+			}
+
+		case psBatchRow:
+			// Branch 2:fetch sels for ctr.lastRow
+			z, v := ctr.zvs[ctr.vsidx], ctr.vs[ctr.vsidx]
+			row := int64(ctr.lastRow)
+			idx := v - 1
+			// skip this row immediately to simplify the thinking paths
+			ctr.lastRow++
+			ctr.vsidx++
+			if z == 0 || v == 0 {
+				if ctr.vsidx >= len(ctr.vs) {
+					ctr.probeState = psNextBatch
+				}
 				continue
 			}
-			idx := vals[k] - 1
-
-			if ap.Cond == nil {
-				if ap.HashOnPK || ctr.mp.HashOnUnique() {
-					for j, rp := range ap.Result {
-						if rp.Rel == 0 {
-							if err := ctr.rbat.Vecs[j].UnionOne(ap.ctr.inbat.Vecs[rp.Pos], int64(i+k), proc.Mp()); err != nil {
-								return err
-							}
-						} else {
-							idx1, idx2 := idx/colexec.DefaultBatchSize, idx%colexec.DefaultBatchSize
-							if err := ctr.rbat.Vecs[j].UnionOne(mpbat[idx1].Vecs[rp.Pos], int64(idx2), proc.Mp()); err != nil {
-								return err
-							}
-						}
-					}
-					rowCount++
-				} else {
-					sels := ctr.mp.GetSels(idx)
-					for j, rp := range ap.Result {
-						if rp.Rel == 0 {
-							if err := ctr.rbat.Vecs[j].UnionMulti(ap.ctr.inbat.Vecs[rp.Pos], int64(i+k), len(sels), proc.Mp()); err != nil {
-								return err
-							}
-						} else {
-							for _, sel := range sels {
-								idx1, idx2 := sel/colexec.DefaultBatchSize, sel%colexec.DefaultBatchSize
-								if err := ctr.rbat.Vecs[j].UnionOne(mpbat[idx1].Vecs[rp.Pos], int64(idx2), proc.Mp()); err != nil {
-									return err
-								}
-							}
-						}
-					}
-					rowCount += len(sels)
-				}
-			} else {
-				if ap.HashOnPK || ctr.mp.HashOnUnique() {
-					if err := ctr.evalApCondForOneSel(ap.ctr.inbat, ctr.rbat, ap, proc, int64(i+k), int64(idx)); err != nil {
+			idx1 := int64(idx / colexec.DefaultBatchSize)
+			idx2 := int64(idx % colexec.DefaultBatchSize)
+			if ap.HashOnPK || ctr.mp.HashOnUnique() {
+				// this is a fast path for unique column,
+				// appending at most 1 row to result
+				if ap.Cond == nil {
+					err := ctr.appendOne(proc, ap, row, idx1, idx2)
+					if err != nil {
 						return err
 					}
 					rowCount++
 				} else {
-					sels := ctr.mp.GetSels(idx)
-					for _, sel := range sels {
-						if err := ctr.evalApCondForOneSel(ap.ctr.inbat, ctr.rbat, ap, proc, int64(i+k), int64(sel)); err != nil {
-							return err
-						}
+					ok, err := ctr.evalAndAppendOne(proc, ap, row, idx1, idx2)
+					if err != nil {
+						return err
 					}
-					rowCount += len(sels)
+					if ok {
+						rowCount++
+					}
 				}
+			} else {
+				ctr.sels = ctr.mp.GetSels(idx)
+			}
+
+			if len(ctr.sels) > 0 {
+				ctr.probeState = psSelsForOneRow
+			} else if ctr.vsidx < len(ctr.vs) {
+				ctr.probeState = psBatchRow
+			} else {
+				ctr.probeState = psNextBatch
+			}
+
+			if rowCount >= colexec.DefaultBatchSize {
+				ctr.rbat.AddRowCount(rowCount)
+				result.Batch = ctr.rbat
+				return nil
+			}
+
+		case psNextBatch:
+			// Branch 3:fetch next batch// Branch 3:fetch next batch
+			if ctr.lastRow < inputRowCount {
+				// preprocess for next batch
+				hashBatch := min(inputRowCount-ctr.lastRow, hashmap.UnitLimit)
+				ctr.vs, ctr.zvs = ctr.itr.Find(ctr.lastRow, hashBatch, ctr.vecs)
+				ctr.vsidx = 0
+				ctr.probeState = psBatchRow
+			} else {
+				// return current result and set the input batch to nil
+				ctr.rbat.AddRowCount(rowCount)
+				result.Batch = ctr.rbat
+				ap.ctr.lastRow = 0
+				ap.ctr.inbat = nil
+				ctr.probeState = psNextBatch
+				return nil
 			}
 		}
 	}
-
-	ctr.rbat.AddRowCount(rowCount)
-	result.Batch = ctr.rbat
-	ap.ctr.lastRow = 0
-	return nil
 }
 
-func (ctr *container) evalApCondForOneSel(bat, rbat *batch.Batch, ap *InnerJoin, proc *process.Process, row, sel int64) error {
-	mpbat := ctr.mp.GetBatches()
-	if err := colexec.SetJoinBatchValues(ctr.joinBat1, bat, row,
-		1, ctr.cfs1); err != nil {
-		return err
-	}
-	idx1, idx2 := sel/colexec.DefaultBatchSize, sel%colexec.DefaultBatchSize
-	if err := colexec.SetJoinBatchValues(ctr.joinBat2, mpbat[idx1], idx2,
-		1, ctr.cfs2); err != nil {
-		return err
-	}
-	vec, err := ctr.expr.Eval(proc, []*batch.Batch{ctr.joinBat1, ctr.joinBat2}, nil)
+func (ctr *container) evalAndAppendOne(
+	proc *process.Process, ap *InnerJoin, row, idx1, idx2 int64,
+) (bool, error) {
+	condPass, err := ctr.evalNonEqCondition(
+		ap.ctr.inbat, row, proc, idx1, idx2,
+	)
 	if err != nil {
-		return err
+		return false, err
+	}
+	if condPass {
+		err := ctr.appendOne(proc, ap, row, idx1, idx2)
+		if err != nil {
+			return false, err
+		}
+	}
+	return condPass, nil
+}
+
+func (ctr *container) evalNonEqCondition(
+	bat *batch.Batch, row int64, proc *process.Process, idx1, idx2 int64,
+) (bool, error) {
+	mpbat := ctr.mp.GetBatches()
+	// TODO: fix the probe row in closure, only change the matched row in hashmap
+	if err := colexec.SetJoinBatchValues(
+		ctr.joinBats[0], bat, row, 1, ctr.cfs1,
+	); err != nil {
+		return false, err
+	}
+	if err := colexec.SetJoinBatchValues(
+		ctr.joinBats[1], mpbat[idx1], idx2, 1, ctr.cfs2,
+	); err != nil {
+		return false, err
+	}
+	vec, err := ctr.expr.Eval(proc, ctr.joinBats, nil)
+	if err != nil {
+		return false, err
 	}
 	if vec.IsConstNull() || vec.GetNulls().Contains(0) {
-		return nil
+		return false, nil
 	}
 	bs := vector.MustFixedColWithTypeCheck[bool](vec)
 	if !bs[0] {
-		return nil
+		return false, nil
 	}
+	return true, nil
+}
+
+func (ctr *container) appendOne(
+	proc *process.Process, ap *InnerJoin, row, idx1, idx2 int64,
+) error {
+	mpbat := ctr.mp.GetBatches()
 	for j, rp := range ap.Result {
 		if rp.Rel == 0 {
-			if err := rbat.Vecs[j].UnionOne(bat.Vecs[rp.Pos], row, proc.Mp()); err != nil {
+			if err := ctr.rbat.Vecs[j].UnionOne(
+				ctr.inbat.Vecs[rp.Pos], row, proc.Mp(),
+			); err != nil {
 				return err
 			}
 		} else {
-			if err := rbat.Vecs[j].UnionOne(mpbat[idx1].Vecs[rp.Pos], idx2, proc.Mp()); err != nil {
+			if err := ctr.rbat.Vecs[j].UnionOne(
+				mpbat[idx1].Vecs[rp.Pos], idx2, proc.Mp(),
+			); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22327

## What this PR does / why we need it:

pick 22351 to 3.0-dev


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor join operations to produce results in chunks of 8192 rows

- Implement state machine for probe method with three states

- Optimize memory usage and prevent OOM in large joins

- Consolidate join batch handling for better performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Input Batch"] --> B["State Machine"]
  B --> C["NextBatch State"]
  B --> D["BatchRow State"] 
  B --> E["SelsForOneRow State"]
  C --> F["Find Hash Results"]
  D --> G["Process Single Row"]
  E --> H["Handle Multiple Matches"]
  F --> D
  G --> I["8192 Row Chunks"]
  H --> I
  I --> J["Output Result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>join.go</strong><dd><code>Implement state machine for inner join probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/join/join.go

<ul><li>Replace simple probe loop with state machine implementation<br> <li> Add chunked result processing with 8192 row limit<br> <li> Consolidate join batch handling from two separate batches to array<br> <li> Refactor condition evaluation and result appending logic</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22356/files#diff-2a43ca762c59d0ece91404da915aa519c35db896df1ec228aab36a10e7dbc1dd">+189/-81</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add state machine types and pagination fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/join/types.go

<ul><li>Add probe state enumeration and pagination fields<br> <li> Replace separate joinBat1/joinBat2 with joinBats array<br> <li> Add state tracking variables for batch processing<br> <li> Update pool creation syntax for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22356/files#diff-67c85cf1b10e35ddf7ac938c17226a987e5548785b126d8c3929a26874fa1d78">+36/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>join.go</strong><dd><code>Implement state machine for left join probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/left/join.go

<ul><li>Implement state machine for left join probe method<br> <li> Add chunked processing with proper null handling for unmatched rows<br> <li> Consolidate join batch management and condition evaluation<br> <li> Refactor match detection logic for better performance</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22356/files#diff-e504c243155528e43dfd3b5e88ce6641dd41fbe3db3d5b6a0ee7d607bca91b3d">+199/-140</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add left join state machine types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/left/types.go

<ul><li>Add probe state enumeration and pagination tracking<br> <li> Replace dual join batches with single array structure<br> <li> Add match tracking flag for non-equality conditions<br> <li> Update memory pool creation syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22356/files#diff-d6e1bd6d4ebd7ee399bf9e27cbd35cd968de3d80b400a23c3885d4cada4b17c4">+33/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

