### PR TITLE
fix cdc table scanner

### DIFF
--- a/pkg/cdc/table_scanner.go
+++ b/pkg/cdc/table_scanner.go
@@ -205,7 +205,7 @@ func (s *TableDetector) scanTableLoop(ctx context.Context) {
 
 			s.mu.Unlock()
 
-			go s.scanAndProcess(ctx)
+			s.scanAndProcess(ctx)
 		case <-retryTicker.C:
 			s.mu.Lock()
 			if s.handling || s.lastMp == nil {
@@ -229,7 +229,7 @@ func (s *TableDetector) scanAndProcess(ctx context.Context) {
 	s.lastMp = s.Mp
 	s.mu.Unlock()
 
-	s.processCallback(ctx, s.lastMp)
+	go s.processCallback(ctx, s.lastMp)
 }
 
 func (s *TableDetector) processCallback(ctx context.Context, tables map[uint32]TblMap) {

--- a/pkg/cdc/table_scanner.go
+++ b/pkg/cdc/table_scanner.go
@@ -185,10 +185,18 @@ func (s *TableDetector) scanTableLoop(ctx context.Context) {
 	logutil.Info("CDC-TableDetector-Scan-Start")
 	defer logutil.Info("CDC-TableDetector-Scan-End")
 
-	ticker := time.NewTicker(15 * time.Second)
+	var tickerDuration, retryTickerDuration time.Duration
+	if msg, injected := objectio.CDCScanTableInjected(); injected || msg == "fast scan" {
+		tickerDuration = 1 * time.Millisecond
+		retryTickerDuration = 1 * time.Millisecond
+	} else {
+		tickerDuration = 15 * time.Second
+		retryTickerDuration = 5 * time.Second
+	}
+	ticker := time.NewTicker(tickerDuration)
 	defer ticker.Stop()
 
-	retryTicker := time.NewTicker(5 * time.Second)
+	retryTicker := time.NewTicker(retryTickerDuration)
 	defer retryTicker.Stop()
 
 	for {

--- a/pkg/cdc/table_scanner_test.go
+++ b/pkg/cdc/table_scanner_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/util/fault"
@@ -163,6 +164,12 @@ func TestScanAndProcess(t *testing.T) {
 
 	fault.Enable()
 	objectio.SimpleInject(objectio.FJ_CDCScanTableErr)
+	rm, _ := objectio.InjectCDCScanTable("fast scan")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go td.scanTableLoop(ctx)
+	time.Sleep(2 * time.Millisecond)
+	defer rm()
 	td.scanAndProcess(context.Background())
 	fault.Disable()
 

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -451,6 +451,7 @@ func (exec *CDCTaskExecutor) handleNewTables(allAccountTbls map[uint32]cdc.TblMa
 				readerInfo := reader.Info()
 				// wait the old reader to stop
 				if info.OnlyDiffinTblId(readerInfo) {
+					logutil.Infof("cdc task wait old reader to stop %s %d->%d", key, readerInfo.SourceTblId, info.SourceTblId)
 					waitChan := make(chan struct{})
 					go func() {
 						defer close(waitChan)

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -451,7 +451,8 @@ func (exec *CDCTaskExecutor) handleNewTables(allAccountTbls map[uint32]cdc.TblMa
 				readerInfo := reader.Info()
 				// wait the old reader to stop
 				if info.OnlyDiffinTblId(readerInfo) {
-					logutil.Infof("cdc task wait old reader to stop %s %d->%d", key, readerInfo.SourceTblId, info.SourceTblId)
+					logutil.Infof("cdc task wait old reader to stop %s %d->%d",
+						key, readerInfo.SourceTblId, info.SourceTblId)
 					waitChan := make(chan struct{})
 					go func() {
 						defer close(waitChan)

--- a/pkg/objectio/injects.go
+++ b/pkg/objectio/injects.go
@@ -54,7 +54,7 @@ const (
 	FJ_CronJobsOpen = "fj/cronjobs/open"
 	FJ_CDCRecordTxn = "fj/cdc/recordtxn"
 
-	FJ_CDCExecutor = "fj/cdc/executor"
+	FJ_CDCExecutor  = "fj/cdc/executor"
 	FJ_CDCScanTable = "fj/cdc/scantable"
 
 	FJ_CDCHandleSlow             = "fj/cdc/handleslow"

--- a/pkg/objectio/injects.go
+++ b/pkg/objectio/injects.go
@@ -55,6 +55,7 @@ const (
 	FJ_CDCRecordTxn = "fj/cdc/recordtxn"
 
 	FJ_CDCExecutor = "fj/cdc/executor"
+	FJ_CDCScanTable = "fj/cdc/scantable"
 
 	FJ_CDCHandleSlow             = "fj/cdc/handleslow"
 	FJ_CDCHandleErr              = "fj/cdc/handleerr"
@@ -350,6 +351,11 @@ func ISCPExecutorInjected() (string, bool) {
 	return sarg, injected
 }
 
+func CDCScanTableInjected() (string, bool) {
+	_, sarg, injected := fault.TriggerFault(FJ_CDCScanTable)
+	return sarg, injected
+}
+
 func InjectWait(key string) (rmFault func(), err error) {
 	if err = fault.AddFaultPoint(
 		context.Background(),
@@ -473,6 +479,24 @@ func InjectCDCExecutor(msg string) (rmFault func() (bool, error), err error) {
 	}
 	rmFault = func() (ok bool, err error) {
 		return fault.RemoveFaultPoint(context.Background(), FJ_CDCExecutor)
+	}
+	return
+}
+
+func InjectCDCScanTable(msg string) (rmFault func() (bool, error), err error) {
+	if err = fault.AddFaultPoint(
+		context.Background(),
+		FJ_CDCScanTable,
+		":::",
+		"echo",
+		0,
+		msg,
+		false,
+	); err != nil {
+		return
+	}
+	rmFault = func() (ok bool, err error) {
+		return fault.RemoveFaultPoint(context.Background(), FJ_CDCScanTable)
 	}
 	return
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/MO-Cloud/issues/6142

## What this PR does / why we need it:
串行做scanTable()，防止s.Mp被覆盖


___

### **PR Type**
Bug fix


___

### **Description**
- Changed CDC table scanning from concurrent to sequential execution

- Prevents race condition where `s.Mp` field gets overwritten

- Moved goroutine execution from scanning to callback processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["scanTableLoop()"] --> B["scanAndProcess()"]
  B --> C["scanTable()"]
  C --> D["processCallback()"]
  B -.-> E["Sequential Execution"]
  D -.-> F["Async Callback"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>table_scanner.go</strong><dd><code>Serialize table scanning to prevent race conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/table_scanner.go

<ul><li>Removed goroutine from <code>scanAndProcess()</code> call to make it synchronous<br> <li> Added goroutine to <code>processCallback()</code> call to make callback processing <br>asynchronous<br> <li> Prevents race condition where <code>s.Mp</code> field could be overwritten during <br>concurrent scans</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22375/files#diff-ff43b62d0f42085266c063c203474532c19fb2aeb3e6d390b187f63f5306af8b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

