### PR TITLE
fix cdc sinker and handle new table

### DIFF
--- a/pkg/cdc/sinker.go
+++ b/pkg/cdc/sinker.go
@@ -855,6 +855,10 @@ var NewMysqlSink = func(
 	return ret, err
 }
 
+func (s *mysqlSink) Reset() {
+	s.tx = nil
+}
+
 func (s *mysqlSink) recordTxnSQL(sqlBuf []byte) {
 	if !s.debugTxnRecorder.doRecord {
 		return
@@ -938,17 +942,11 @@ func (s *mysqlSink) SendBegin(ctx context.Context) (err error) {
 
 func (s *mysqlSink) SendCommit(_ context.Context) error {
 	s.resetRecordedTxn()
-	defer func() {
-		s.tx = nil
-	}()
 	return s.tx.Commit()
 }
 
 func (s *mysqlSink) SendRollback(_ context.Context) error {
 	s.resetRecordedTxn()
-	defer func() {
-		s.tx = nil
-	}()
 	return s.tx.Rollback()
 }
 

--- a/pkg/cdc/types.go
+++ b/pkg/cdc/types.go
@@ -153,6 +153,7 @@ type Sink interface {
 	SendBegin(ctx context.Context) error
 	SendCommit(ctx context.Context) error
 	SendRollback(ctx context.Context) error
+	Reset()
 	Close()
 }
 

--- a/pkg/cdc/util.go
+++ b/pkg/cdc/util.go
@@ -639,6 +639,8 @@ var GetTableDef = func(
 	cnEngine engine.Engine,
 	tblId uint64,
 ) (*plan.TableDef, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
 	_, _, rel, err := cnEngine.GetRelationById(ctx, txnOp, tblId)
 	if err != nil {
 		return nil, err

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -411,8 +411,6 @@ func (exec *CDCTaskExecutor) handleNewTables(allAccountTbls map[uint32]cdc.TblMa
 
 	accountId := uint32(exec.spec.Accounts[0].GetId())
 	ctx := defines.AttachAccountId(context.Background(), accountId)
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
-	defer cancel()
 
 	txnOp, err := cdc.GetTxnOp(ctx, exec.cnEngine, exec.cnTxnClient, "cdc-handleNewTables")
 	if err != nil {

--- a/pkg/vm/engine/test/cdc_sinker_test.go
+++ b/pkg/vm/engine/test/cdc_sinker_test.go
@@ -1,0 +1,100 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/cdc"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	catalog2 "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/test/testutil"
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCDC_Sinker1(t *testing.T) {
+	var mock sqlmock.Sqlmock
+	mockFn := func(_, _, _ string, _ int, _ string) (db *sql.DB, err error) {
+		db, mock, err = sqlmock.New()
+		return
+	}
+	stub := gostub.Stub(&cdc.OpenDbConn, mockFn)
+	defer stub.Reset()
+
+	sink, err := cdc.NewMysqlSink(
+		"root",
+		"123456",
+		"127.0.0.1",
+		3306,
+		3,
+		3*time.Second,
+		cdc.CDCDefaultSendSqlTimeout,
+		false,
+	)
+	require.NoError(t, err)
+	defer sink.Close()
+
+	ctx := context.Background()
+
+	mock.ExpectBegin()
+	err = sink.SendBegin(ctx)
+	require.NoError(t, err)
+	mock.ExpectCommit()
+	err = sink.SendCommit(ctx)
+	require.NoError(t, err)
+	mock.ExpectRollback()
+	err = sink.SendRollback(ctx)
+	require.Error(t, err)
+	sink.Reset()
+}
+
+func TestCDCUtil1(t *testing.T) {
+	catalog.SetupDefines("")
+
+	var (
+		accountId    = catalog.System_Account
+		tableName    = "test1"
+		databaseName = "db1"
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountId)
+
+	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeHandler.Close(true)
+		rpcAgent.Close()
+	}()
+	schema := catalog2.MockSchemaAll(10, 0)
+	schema.Name = tableName
+	ctx, cancel = context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+	_, rel, err := disttaeEngine.CreateDatabaseAndTable(ctx, databaseName, tableName, schema)
+	id := rel.GetTableID(context.Background())
+	require.NoError(t, err)
+
+	txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+	_, err = cdc.GetTableDef(ctx, txn, disttaeEngine.Engine, id)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22386

## What this PR does / why we need it:
fix cdc sinker and handle new table


___

### **PR Type**
Bug fix


___

### **Description**
- Add `Reset()` method to CDC sink interface

- Fix transaction cleanup in MySQL sink operations

- Add timeout handling for table definition retrieval

- Remove redundant timeout context in CDC executor


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CDC Sink Interface"] --> B["Add Reset() method"]
  C["MySQL Sink"] --> D["Fix transaction cleanup"]
  E["Table Definition"] --> F["Add 5-minute timeout"]
  G["CDC Executor"] --> H["Remove redundant timeout"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sinker.go</strong><dd><code>Add Reset method and fix transaction cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/sinker.go

<ul><li>Add <code>Reset()</code> method to clear transaction state<br> <li> Remove defer blocks that set <code>tx = nil</code> in commit/rollback methods<br> <li> Simplify transaction cleanup logic</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22389/files#diff-99322a2c28af9a0a6bcf7030e996605c948a7393e2df0f209a96c3dbcbd3183b">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Add timeout handling for table definition retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/util.go

<ul><li>Add 5-minute timeout context for <code>GetTableDef</code> function<br> <li> Include context cancellation with defer statement</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22389/files#diff-46b260aa5fed62ad704662ba98a550547b13b1950d693dac8d96a865e1e41237">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cdc_exector.go</strong><dd><code>Remove redundant timeout context handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/cdc_exector.go

<ul><li>Remove redundant timeout context creation and cancellation<br> <li> Simplify context handling in <code>handleNewTables</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22389/files#diff-63d732ad294e42566a6feb82dfd2fcab2bb596acb2d4df146b468a5510a30506">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add Reset method to Sink interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/types.go

- Add `Reset()` method to Sink interface definition


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22389/files#diff-a0449bab279af3b2a18abad7a166ddd8f8bb677405e596f9bfca2bb041ae6e17">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

