### PR TITLE
reduce insert batch to prevent create hnsw index from oom

### DIFF
--- a/pkg/vectorindex/hnsw/build.go
+++ b/pkg/vectorindex/hnsw/build.go
@@ -176,7 +176,7 @@ func (idx *HnswBuildIndex) ToSql(cfg vectorindex.IndexTableConfig) ([]string, er
 		chunkid++
 
 		n++
-		if n == 10000 {
+		if n == 2000 {
 			newsql := sql + strings.Join(values, ", ")
 			sqls = append(sqls, newsql)
 			values = values[:0]

--- a/pkg/vectorindex/hnsw/build.go
+++ b/pkg/vectorindex/hnsw/build.go
@@ -133,6 +133,8 @@ func (idx *HnswBuildIndex) SaveToFile() error {
 	return nil
 }
 
+const InsertIndexBatchSize = 2000
+
 // Generate the SQL to update the secondary index tables.
 // 1. store the index file into the index table
 func (idx *HnswBuildIndex) ToSql(cfg vectorindex.IndexTableConfig) ([]string, error) {
@@ -176,7 +178,7 @@ func (idx *HnswBuildIndex) ToSql(cfg vectorindex.IndexTableConfig) ([]string, er
 		chunkid++
 
 		n++
-		if n == 2000 {
+		if n == InsertIndexBatchSize {
 			newsql := sql + strings.Join(values, ", ")
 			sqls = append(sqls, newsql)
 			values = values[:0]


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21506 

## What this PR does / why we need it:

reduce insert batch to prevent create hnsw index from oom


___

### **PR Type**
Bug fix


___

### **Description**
- Reduce HNSW index insert batch size from 10,000 to 2,000

- Prevent out-of-memory errors during index creation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HNSW Index Build"] --> B["Batch Size: 10,000"]
  B --> C["OOM Error"]
  A --> D["Batch Size: 2,000"]
  D --> E["Successful Index Creation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.go</strong><dd><code>Reduce insert batch size for memory optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vectorindex/hnsw/build.go

<ul><li>Changed batch size constant from 10,000 to 2,000 in SQL generation <br>loop<br> <li> Modification prevents memory overflow during HNSW index creation</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22468/files#diff-5664c876948886a68d80d08de8003da96ae8b91a2bd317c8e8deb37187d2dc84">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

