### PR TITLE
Change the right join to inner join in fulltext and ivf deletion plan 3.0

### DIFF
--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -2690,7 +2690,7 @@ func appendDeleteIvfTablePlan(builder *QueryBuilder, bindCtx *BindContext,
 
 	lastNodeId = builder.appendNode(&plan.Node{
 		NodeType:    plan.Node_JOIN,
-		JoinType:    plan.Node_RIGHT,
+		JoinType:    plan.Node_INNER,
 		Children:    []int32{ivfScanId, lastNodeId},
 		OnList:      joinConds,
 		ProjectList: projectList,
@@ -4664,7 +4664,7 @@ func buildDeleteRowsFullTextIndex(ctx CompilerContext, builder *QueryBuilder, bi
 		sid := builder.compCtx.GetProcess().GetService()
 		lastNodeId = builder.appendNode(&plan.Node{
 			NodeType:               plan.Node_JOIN,
-			JoinType:               plan.Node_RIGHT,
+			JoinType:               plan.Node_INNER,
 			Children:               []int32{idxScanId, lastNodeId},
 			OnList:                 []*Expr{joinCond},
 			ProjectList:            projectList,

--- a/test/distributed/cases/fulltext/fulltext.result
+++ b/test/distributed/cases/fulltext/fulltext.result
@@ -559,3 +559,8 @@ CREATE FULLTEXT INDEX idx_english_text ON example_table (english_text);
 id    english_text    chinese_text    json_data
 2    This is a test.    这是一个测试    {"age": 25, "name": "Bob"}
 2    This is a test.    这是一个测试    {"age": 25, "name": "Bob"}
+create table empty_fulltext(a int primary key, b varchar, c varchar, fulltext `ftc` (c) WITH PARSER ngram);
+insert into empty_fulltext select result, 'so long',null from generate_series(1, 300000) g;
+insert into empty_fulltext values (300001, 'this is the end of our story', null);
+delete from empty_fulltext where b like '%story%';
+drop table empty_fulltext;

--- a/test/distributed/cases/fulltext/fulltext.sql
+++ b/test/distributed/cases/fulltext/fulltext.sql
@@ -447,3 +447,15 @@ CREATE TABLE example_table (id INT PRIMARY KEY,english_text TEXT, chinese_text T
 INSERT INTO example_table (id, english_text, chinese_text, json_data) VALUES(1, 'Hello, world!', '你好世界', '{"name": "Alice", "age": 30}'),(2, 'This is a test.', '这是一个测试', '{"name": "Bob", "age": 25}'),(3, 'Full-text search is powerful.', '全文搜索很强大', '{"name": "Charlie", "age": 35}');
 CREATE FULLTEXT INDEX idx_english_text ON example_table (english_text);
 (with t as (SELECT * FROM example_table WHERE MATCH(english_text) AGAINST('+test' IN BOOLEAN MODE)) select * from t) union all (with t as (SELECT * FROM example_table WHERE MATCH(english_text) AGAINST('+test' IN BOOLEAN MODE)) select * from t) ;
+
+create table empty_fulltext(a int primary key, b varchar, c varchar, fulltext `ftc` (c) WITH PARSER ngram);
+insert into empty_fulltext select result, 'so long',null from generate_series(1, 300000) g;
+insert into empty_fulltext values (300001, 'this is the end of our story', null);
+-- big enough to trigger remote delete
+delete from empty_fulltext where b like '%story%';
+drop table empty_fulltext;
+
+
+
+
+


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixflow/issues/6729

## What this PR does / why we need it:

- Inner join will filter out empty rowid, avoiding ExpectedEOB error in TN


___

### **PR Type**
Bug fix


___

### **Description**
- Change RIGHT JOIN to INNER JOIN in fulltext and IVF deletion plans

- Add test case for empty fulltext index deletion scenario

- Fix ExpectedEOB error by filtering out empty rowids


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RIGHT JOIN"] -- "change to" --> B["INNER JOIN"]
  B --> C["Filter empty rowids"]
  C --> D["Fix ExpectedEOB error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_dml_util.go</strong><dd><code>Replace RIGHT JOIN with INNER JOIN in deletion plans</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_dml_util.go

<ul><li>Changed <code>JoinType</code> from <code>plan.Node_RIGHT</code> to <code>plan.Node_INNER</code> in <br><code>appendDeleteIvfTablePlan</code> function<br> <li> Changed <code>JoinType</code> from <code>plan.Node_RIGHT</code> to <code>plan.Node_INNER</code> in <br><code>buildDeleteRowsFullTextIndex</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22478/files#diff-095fb233d51021791cb24454839b013236680bbc6bbc22e0d2f6741ac8fe7dff">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fulltext.sql</strong><dd><code>Add test case for empty fulltext deletion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/fulltext/fulltext.sql

<ul><li>Added test case creating table <code>empty_fulltext</code> with fulltext index<br> <li> Added large data insertion (300,000 rows) with null fulltext column<br> <li> Added deletion operation to trigger remote delete scenario</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22478/files#diff-6b100c429a12e9b9fb9c28f9617e3530df027ea45c4701dc0c20948f4f39b3be">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fulltext.result</strong><dd><code>Update test results for empty fulltext case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/fulltext/fulltext.result

<ul><li>Added expected output for new test case<br> <li> Shows successful execution of empty fulltext table operations</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22478/files#diff-2045017efbb026c4485d17249d8cc8ad338eeaad5280eeb33f33a8dc8a3d4bd8">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

