### PR TITLE
temp to disable off-heap clone in the output operator due to many invalid memory usage

### DIFF
--- a/pkg/cdc/table_scanner.go
+++ b/pkg/cdc/table_scanner.go
@@ -338,10 +338,10 @@ func (s *TableDetector) scanTable() error {
 	result.ReadRows(func(rows int, cols []*vector.Vector) bool {
 		for i := 0; i < rows; i++ {
 			tblId := vector.MustFixedColWithTypeCheck[uint64](cols[0])[i]
-			tblName := cols[1].UnsafeGetStringAt(i)
+			tblName := cols[1].GetStringAt(i)
 			dbId := vector.MustFixedColWithTypeCheck[uint64](cols[2])[i]
-			dbName := cols[3].UnsafeGetStringAt(i)
-			createSql := cols[4].UnsafeGetStringAt(i)
+			dbName := cols[3].GetStringAt(i)
+			createSql := cols[4].GetStringAt(i)
 			accountId := vector.MustFixedColWithTypeCheck[uint32](cols[5])[i]
 
 			// skip table with foreign key

--- a/pkg/sql/colexec/table_function/fulltext.go
+++ b/pkg/sql/colexec/table_function/fulltext.go
@@ -180,19 +180,19 @@ func (u *fulltextState) start(tf *TableFunction, proc *process.Process, nthRow i
 	if v.GetType().Oid != types.T_varchar {
 		return moerr.NewInvalidInput(proc.Ctx, fmt.Sprintf("First argument (source table name) must be string, but got %s", v.GetType().String()))
 	}
-	source_table := v.UnsafeGetStringAt(0)
+	source_table := v.GetStringAt(0)
 
 	v = tf.ctr.argVecs[1]
 	if v.GetType().Oid != types.T_varchar {
 		return moerr.NewInvalidInput(proc.Ctx, fmt.Sprintf("Second argument (index table name) must be string, but got %s", v.GetType().String()))
 	}
-	index_table := v.UnsafeGetStringAt(0)
+	index_table := v.GetStringAt(0)
 
 	v = tf.ctr.argVecs[2]
 	if v.GetType().Oid != types.T_varchar {
 		return moerr.NewInvalidInput(proc.Ctx, fmt.Sprintf("Third argument (pattern) must be string, but got %s", v.GetType().String()))
 	}
-	pattern := v.UnsafeGetStringAt(0)
+	pattern := v.GetStringAt(0)
 
 	v = tf.ctr.argVecs[3]
 	if v.GetType().Oid != types.T_int64 {

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -420,7 +420,7 @@ func (exec *txnExecutor) Exec(
 				// the bat is valid only in current method. So we need copy data.
 				// FIXME: add a custom streaming apply handler to consume readed data. Now
 				// our current internal sql will never read too much data.
-				rows, err := bat.Clone(exec.s.mp, true)
+				rows, err := bat.Clone(exec.s.mp, streaming)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #15191 #22482 

## What this PR does / why we need it:

temp to disable offheap clone in the output operator due to many invalid memory usage


___

### **PR Type**
Bug fix


___

### **Description**
- Disable off-heap clone in output operator

- Fix invalid memory usage issues

- Change clone parameter from hardcoded true to streaming


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["bat.Clone()"] -- "change parameter" --> B["streaming instead of true"]
  B --> C["Fix memory usage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_executor.go</strong><dd><code>Fix clone parameter for memory optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/sql_executor.go

<ul><li>Changed <code>bat.Clone()</code> parameter from hardcoded <code>true</code> to <code>streaming</code> <br>variable<br> <li> Addresses invalid memory usage in output operator</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22480/files#diff-8d93841d90b6b267a1c218f24e1f564febdcc4dd780d04909033d706302ca215">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

