### PR TITLE
Fix iscp bvt crashed

### DIFF
--- a/pkg/vm/engine/tae/logtail/snapshot.go
+++ b/pkg/vm/engine/tae/logtail/snapshot.go
@@ -1155,10 +1155,7 @@ func (sm *SnapshotMeta) GetISCP(
 		tableID := tableIDList[r]
 		watermark := watermarkList.GetBytesAt(r)
 		if !dropAtList.IsNull(uint64(r)) {
-			dropAT := types.StringToTS(util.UnsafeBytesToString(dropAtList.GetBytesAt(r)))
-			if !dropAT.IsEmpty() {
-				return nil
-			}
+			return nil
 		}
 
 		var iscpTS types.TS


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22483

## What this PR does / why we need it:
Fix iscp bvt crashed


___

### **PR Type**
Bug fix


___

### **Description**
- Remove unnecessary timestamp parsing causing crashes

- Simplify null check logic in ISCP processing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ISCP processor"] --> B["Check dropAtList null"]
  B --> C["Return early if not null"]
  C --> D["Continue processing watermark"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapshot.go</strong><dd><code>Simplify ISCP processor null check logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/snapshot.go

<ul><li>Remove timestamp parsing from <code>dropAtList</code> when not null<br> <li> Simplify early return logic in ISCP processor function<br> <li> Eliminate potential crash from empty timestamp handling</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22485/files#diff-111781ff442a07a8deefe4a9fa1e799b2b5da03309f03c042a9b9b83e33a21be">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

