### PR TITLE
Fix iscp data race

### DIFF
--- a/pkg/vm/engine/tae/logtail/snapshot.go
+++ b/pkg/vm/engine/tae/logtail/snapshot.go
@@ -346,6 +346,29 @@ func (st *specialTableInfo) processObjects(
 	return nil
 }
 
+func (st *specialTableInfo) clone() *specialTableInfo {
+	clone := &specialTableInfo{
+		tid:        st.tid,
+		objects:    make(map[objectio.Segmentid]*objectInfo),
+		tombstones: make(map[objectio.Segmentid]*objectInfo),
+	}
+	for id, info := range st.objects {
+		clone.objects[id] = &objectInfo{
+			stats:    info.stats,
+			createAt: info.createAt,
+			deleteAt: info.deleteAt,
+		}
+	}
+	for id, info := range st.tombstones {
+		clone.tombstones[id] = &objectInfo{
+			stats:    info.stats,
+			createAt: info.createAt,
+			deleteAt: info.deleteAt,
+		}
+	}
+	return clone
+}
+
 type SnapshotMeta struct {
 	sync.RWMutex
 
@@ -1035,9 +1058,13 @@ func (sm *SnapshotMeta) GetPITR(
 	mp *mpool.MPool,
 ) (*PitrInfo, error) {
 	idxes := []uint16{ColPitrLevel, ColPitrObjId, ColPitrLength, ColPitrUnit}
-	tombstonesStats := sm.pitr.getTombstonesStats()
+
+	sm.RLock()
+	pitrClone := sm.pitr.clone()
+	sm.RUnlock()
+
 	checkpointTS := types.BuildTS(time.Now().UTC().UnixNano(), 0)
-	ds := NewSnapshotDataSource(ctx, fs, checkpointTS, tombstonesStats)
+	ds := NewSnapshotDataSource(ctx, fs, checkpointTS, pitrClone.getTombstonesStats())
 	pitrInfo := &PitrInfo{
 		cluster:  types.TS{},
 		account:  make(map[uint32]types.TS),
@@ -1128,7 +1155,7 @@ func (sm *SnapshotMeta) GetPITR(
 		return nil
 	}
 
-	err := sm.pitr.processObjects(ctx, fs, idxes, ds, mp, processor)
+	err := pitrClone.processObjects(ctx, fs, idxes, ds, mp, processor)
 	if err != nil {
 		return nil, err
 	}
@@ -1142,9 +1169,13 @@ func (sm *SnapshotMeta) GetISCP(
 	mp *mpool.MPool,
 ) (map[uint64]types.TS, error) {
 	idxes := []uint16{ColIscpTableId, ColIscpWatermark, ColIscpDropAt}
-	tombstonesStats := sm.iscp.getTombstonesStats()
+
+	sm.RLock()
+	iscpClone := sm.iscp.clone()
+	sm.RUnlock()
+
 	checkpointTS := types.BuildTS(time.Now().UTC().UnixNano(), 0)
-	ds := NewSnapshotDataSource(ctx, fs, checkpointTS, tombstonesStats)
+	ds := NewSnapshotDataSource(ctx, fs, checkpointTS, iscpClone.getTombstonesStats())
 	tables := make(map[uint64]types.TS)
 
 	processor := func(bat *batch.Batch, r int) error {
@@ -1179,7 +1210,7 @@ func (sm *SnapshotMeta) GetISCP(
 		return nil
 	}
 
-	err := sm.iscp.processObjects(ctx, fs, idxes, ds, mp, processor)
+	err := iscpClone.processObjects(ctx, fs, idxes, ds, mp, processor)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22486

## What this PR does / why we need it:
Fix iscp data race


___

### **PR Type**
Bug fix


___

### **Description**
- Fix data race in ISCP and PITR operations

- Add clone method for thread-safe access

- Replace direct field access with cloned instances


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SnapshotMeta"] --> B["RLock/RUnlock"]
  B --> C["Clone specialTableInfo"]
  C --> D["Process with cloned data"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snapshot.go</strong><dd><code>Add thread-safe cloning for snapshot operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logtail/snapshot.go

<ul><li>Add <code>clone()</code> method to <code>specialTableInfo</code> struct for deep copying<br> <li> Implement read locks around cloning operations in <code>GetPITR()</code> and <br><code>GetISCP()</code><br> <li> Replace direct field access with cloned instances to prevent data <br>races<br> <li> Use cloned data for processing objects instead of original references</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22487/files#diff-111781ff442a07a8deefe4a9fa1e799b2b5da03309f03c042a9b9b83e33a21be">+37/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

