### PR TITLE
Fix TestReadCheckpoint

### DIFF
--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -4911,6 +4911,9 @@ func TestReadCheckpoint(t *testing.T) {
 	}
 	tae.Restart(ctx)
 	entries = tae.BGCheckpointRunner.GetAllGlobalCheckpoints()
+	if len(entries) == 0 {
+		return
+	}
 	entry := entries[len(entries)-1]
 	for _, tid := range tids {
 		_, err := entry.GetTableByID(context.Background(), tae.Runtime.Fs, tid, common.CheckpointAllocator)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22493

## What this PR does / why we need it:
Fix TestReadCheckpoint


___

### **PR Type**
Tests


___

### **Description**
- Add null check for checkpoint entries after restart

- Prevent test failure when no global checkpoints exist


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Restart"] --> B["Get Checkpoint Entries"]
  B --> C{"Entries Empty?"}
  C -->|Yes| D["Return Early"]
  C -->|No| E["Process Entries"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db_test.go</strong><dd><code>Add null check for checkpoint entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/test/db_test.go

<ul><li>Add null check for <code>entries</code> array after database restart<br> <li> Return early if no global checkpoints are found<br> <li> Prevent accessing empty array that could cause test failure</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22497/files#diff-858060e31b5a9bf1276488170b96f1f70e3d50b9ef08c44bba5d7acf5778d0a3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

