### PR TITLE
update register job

### DIFF
--- a/pkg/cdc/sql_builder.go
+++ b/pkg/cdc/sql_builder.go
@@ -785,6 +785,7 @@ func (b cdcSQLBuilder) ISCPLogInsertSQL(
 	jobID uint64,
 	jobSpec string,
 	jobState int8,
+	watermark types.TS,
 	jobStatus string,
 ) string {
 	return fmt.Sprintf(
@@ -795,7 +796,7 @@ func (b cdcSQLBuilder) ISCPLogInsertSQL(
 		jobID,
 		jobSpec,
 		jobState,
-		types.TS{}.ToString(),
+		watermark.ToString(),
 		jobStatus,
 	)
 }

--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -1525,6 +1525,7 @@ func TestISCPExecutor1(t *testing.T) {
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
+		false,
 	)
 	assert.True(t, ok)
 	assert.NoError(t, err)
@@ -1686,6 +1687,7 @@ func TestISCPExecutor2(t *testing.T) {
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
+		false,
 	)
 	assert.True(t, ok)
 	assert.NoError(t, err)
@@ -1705,6 +1707,7 @@ func TestISCPExecutor2(t *testing.T) {
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
+		false,
 	)
 	assert.False(t, ok)
 	assert.NoError(t, err)
@@ -1761,6 +1764,7 @@ func TestISCPExecutor2(t *testing.T) {
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
+		false,
 	)
 	assert.True(t, ok)
 	assert.NoError(t, err)
@@ -1858,6 +1862,7 @@ func TestISCPExecutor3(t *testing.T) {
 				DBName:    "srcdb",
 				TableName: "src_table",
 			},
+			false,
 		)
 		assert.True(t, ok)
 		assert.NoError(t, err)
@@ -2068,6 +2073,7 @@ func TestISCPExecutor4(t *testing.T) {
 				DBName:    "srcdb",
 				TableName: "src_table",
 			},
+			false,
 		)
 		assert.True(t, ok)
 		assert.NoError(t, err)
@@ -2256,6 +2262,7 @@ func TestISCPExecutor5(t *testing.T) {
 				DBName:    dbName,
 				TableName: tableName,
 			},
+			false,
 		)
 		assert.True(t, ok)
 		assert.NoError(t, err)
@@ -2390,6 +2397,7 @@ func TestISCPExecutor6(t *testing.T) {
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
+		false,
 	)
 	assert.True(t, ok)
 	assert.NoError(t, err)
@@ -2492,6 +2500,7 @@ func TestISCPExecutor7(t *testing.T) {
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
+		false,
 	)
 	assert.True(t, ok)
 	assert.NoError(t, err)
@@ -2595,6 +2604,7 @@ func TestISCPExecutor8(t *testing.T) {
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
+		false,
 	)
 	assert.True(t, ok)
 	assert.NoError(t, err)
@@ -2707,6 +2717,7 @@ func TestUpdateJobSpec(t *testing.T) {
 			DBName:    dbName,
 			TableName: tableName,
 		},
+		false,
 	)
 	assert.True(t, ok)
 	assert.NoError(t, err)
@@ -2884,6 +2895,7 @@ func TestFlushWatermark(t *testing.T) {
 			DBName:    dbName,
 			TableName: tableName,
 		},
+		false,
 	)
 	assert.True(t, ok)
 	assert.NoError(t, err)
@@ -2985,6 +2997,7 @@ func TestGCInMemoryJob(t *testing.T) {
 			DBName:    "srcdb",
 			TableName: "src_table",
 		},
+		false,
 	)
 	assert.True(t, ok)
 	assert.NoError(t, err)
@@ -3111,6 +3124,7 @@ func TestIteration(t *testing.T) {
 				DBName:    "srcdb",
 				TableName: tableName,
 			},
+			false,
 		)
 		assert.True(t, ok)
 		assert.NoError(t, err)
@@ -3235,6 +3249,7 @@ func TestDropJobsByDBName(t *testing.T) {
 				DBName:    "srcdb",
 				TableName: tableName,
 			},
+			false,
 		)
 		assert.True(t, ok)
 		assert.NoError(t, err)
@@ -3491,4 +3506,113 @@ func TestCancelIteration2(t *testing.T) {
 	close(cancelCh)
 	wg.Wait()
 
+}
+
+func TestStartFromNow(t *testing.T) {
+	catalog.SetupDefines("")
+
+	// idAllocator := common.NewIdAllocator(1000)
+
+	var (
+		accountId = catalog.System_Account
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountId)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+
+	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeHandler.Close(true)
+		rpcAgent.Close()
+	}()
+
+	err := mock_mo_indexes(disttaeEngine, ctxWithTimeout)
+	require.NoError(t, err)
+	err = mock_mo_foreign_keys(disttaeEngine, ctxWithTimeout)
+	require.NoError(t, err)
+	err = mock_mo_intra_system_change_propagation_log(disttaeEngine, ctxWithTimeout)
+	require.NoError(t, err)
+	t.Log(taeHandler.GetDB().Catalog.SimplePPString(3))
+
+	// create database and table
+
+	bat := CreateDBAndTableForCNConsumerAndGetAppendData(t, disttaeEngine, ctxWithTimeout, "srcdb", "src_table", 10)
+	bats := bat.Split(10)
+	defer bat.Close()
+
+	// append 1 row
+	_, rel, txn, err := disttaeEngine.GetTable(ctxWithTimeout, "srcdb", "src_table")
+	require.Nil(t, err)
+
+	tableID := rel.GetTableID(ctxWithTimeout)
+
+	err = rel.Write(ctxWithTimeout, containers.ToCNBatch(bats[0]))
+	require.Nil(t, err)
+
+	txn.Commit(ctxWithTimeout)
+
+	// init cdc executor
+	cdcExecutor, err := iscp.NewISCPTaskExecutor(
+		ctxWithTimeout,
+		disttaeEngine.Engine,
+		disttaeEngine.GetTxnClient(),
+		"",
+		&iscp.ISCPExecutorOption{
+			GCInterval:             time.Hour,
+			GCTTL:                  time.Hour,
+			SyncTaskInterval:       time.Millisecond * 100,
+			FlushWatermarkInterval: time.Millisecond * 100,
+			RetryTimes:             1,
+		},
+		common.DebugAllocator,
+	)
+	require.NoError(t, err)
+	cdcExecutor.SetRpcHandleFn(taeHandler.GetRPCHandle().HandleGetChangedTableList)
+
+	cdcExecutor.Start()
+	defer cdcExecutor.Stop()
+
+	fault.Enable()
+	defer fault.Disable()
+
+	rmFn, err := objectio.InjectCDCExecutor("changesNext")
+	require.NoError(t, err)
+	defer rmFn()
+
+	// register cdc job
+	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Engine.LatestLogtailAppliedTime())
+	require.NoError(t, err)
+	ok, err := iscp.RegisterJob(
+		ctx, "", txn, "pitr",
+		&iscp.JobSpec{
+			ConsumerInfo: iscp.ConsumerInfo{
+				ConsumerType: int8(iscp.ConsumerType_CNConsumer),
+			},
+		},
+		&iscp.JobID{
+			JobName:   "hnsw_idx",
+			DBName:    "srcdb",
+			TableName: "src_table",
+		},
+		true,
+	)
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	assert.NoError(t, txn.Commit(ctxWithTimeout))
+
+	now := taeHandler.GetDB().TxnMgr.Now()
+	testutils.WaitExpect(
+		4000,
+		func() bool {
+			ts, ok := cdcExecutor.GetWatermark(accountId, tableID, "hnsw_idx")
+			return ok && ts.GE(&now)
+		},
+	)
+	ts, ok := cdcExecutor.GetWatermark(accountId, tableID, "hnsw_idx")
+	assert.True(t, ok)
+	assert.True(t, ts.GE(&now))
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22502 

## What this PR does / why we need it:
register job support start from now


___

### **PR Type**
Enhancement


___

### **Description**
- Add `startFromNow` parameter to register job functionality

- Enable watermark initialization from current timestamp

- Update SQL builder to accept watermark parameter

- Add comprehensive test coverage for new feature


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RegisterJob"] -- "add startFromNow param" --> B["registerJob"]
  B -- "calculate startTs" --> C["ISCPLogInsertSQL"]
  C -- "use watermark param" --> D["Database Insert"]
  E["Test Cases"] -- "verify functionality" --> F["TestStartFromNow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_builder.go</strong><dd><code>Update SQL builder with watermark parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/sql_builder.go

<ul><li>Add <code>watermark</code> parameter to <code>ISCPLogInsertSQL</code> function<br> <li> Replace hardcoded empty timestamp with dynamic watermark value</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22503/files#diff-c3e745c3f21e6e012ee0d8f0bf832c3457401185e8b6ed3449a09234df97e465">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>watermark_updater.go</strong><dd><code>Implement start-from-now job registration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/iscp/watermark_updater.go

<ul><li>Add <code>startFromNow</code> boolean parameter to <code>RegisterJob</code> and <code>registerJob</code> <br>functions<br> <li> Implement timestamp calculation logic based on transaction snapshot<br> <li> Add logging for start timestamp value</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22503/files#diff-37e544520e14e9e3e9039402971c40416ad73b0ba7ec9840af6abccb0997324c">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>change_handle_test.go</strong><dd><code>Add test coverage for start-from-now feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/test/change_handle_test.go

<ul><li>Update all <code>RegisterJob</code> calls to include <code>false</code> parameter<br> <li> Add new <code>TestStartFromNow</code> test function with comprehensive validation<br> <li> Test watermark initialization from current timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22503/files#diff-d5c3e1d1f51fe4a5dbc7a64b8b0c7977efca72e3f25aebc7b44401886cc35265">+124/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

