### PR TITLE
fix leak of waiter

### DIFF
--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -109,6 +109,10 @@ func (l *localLockTable) doLock(
 			err = l.doAcquireLock(c)
 			if err != nil {
 				logLocalLockFailed(l.logger, c.txn, table, c.rows, c.opts, err)
+				if c.w == nil && old != nil {
+					old.disableNotify()
+					old.close("doLock, doAcquireLock old err", l.logger)
+				}
 				if c.w != nil {
 					c.w.disableNotify()
 					c.w.close("doLock, doAcquireLock err", l.logger)

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -4201,9 +4201,9 @@ func TestLeakWaiterForErr(t *testing.T) {
 			_ = os.Setenv("mo_reuse_enable_checker", "true")
 
 			tableID := uint64(20)
-			row8 := [][]byte{[]byte{8}}
-			row5 := [][]byte{[]byte{5}}
-			row2 := [][]byte{[]byte{2}}
+			row8 := [][]byte{{8}}
+			row5 := [][]byte{{5}}
+			row2 := [][]byte{{2}}
 			rng19 := newTestRows(1, 9)
 
 			txn1 := []byte("rt1")

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -4189,6 +4189,87 @@ func TestIssue2128(t *testing.T) {
 	)
 }
 
+func TestLeakWaiterForErr(t *testing.T) {
+	runLockServiceTests(
+		t,
+		[]string{"s1", "s2"},
+		func(alloc *lockTableAllocator, s []*service) {
+			l1 := s[0]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			_ = os.Setenv("mo_reuse_enable_checker", "true")
+
+			tableID := uint64(20)
+			row8 := [][]byte{[]byte{8}}
+			row5 := [][]byte{[]byte{5}}
+			row2 := [][]byte{[]byte{2}}
+			rng19 := newTestRows(1, 9)
+
+			txn1 := []byte("rt1")
+			txn2 := []byte("rt2")
+			txn3 := []byte("rt3")
+			txn4 := []byte("rt4")
+
+			ll, err := l1.getLockTableWithCreate(0, tableID, nil, pb.Sharding_None)
+			require.NoError(t, err)
+			lt := ll.(*localLockTable)
+			lt.options.afterWait = func(c *lockContext) func() {
+				if c.opts.Granularity == pb.Granularity_Range {
+					time.Sleep(time.Second)
+				}
+				return func() {}
+			}
+			txn := lt.txnHolder.getActiveTxn(txn4, true, "")
+			txn.Lock()
+			txn.beforeLockAdded = func(id []byte, locks [][]byte) error {
+				return ErrTxnNotFound
+			}
+			txn.Unlock()
+
+			_, err = l1.Lock(ctx, tableID, row8, txn1, newTestRowExclusiveOptions())
+			require.NoError(t, err)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, _ = l1.Lock(ctx, tableID, rng19, txn4, newTestRangeExclusiveOptions())
+			}()
+
+			require.NoError(t, WaitWaiters(l1, 0, tableID, row8[0], 1))
+
+			var wt *waiter
+			lt.mu.Lock()
+			lock, _ := lt.mu.store.Get(row8[0])
+			lock.waiters.iter(func(w *waiter) bool {
+				wt = w
+				return false
+			})
+			lt.mu.Unlock()
+
+			require.NoError(t, l1.Unlock(ctx, txn1, timestamp.Timestamp{}))
+
+			_, err = l1.Lock(ctx, tableID, row5, txn2, newTestRowExclusiveOptions())
+			require.NoError(t, err)
+			require.NoError(t, WaitWaiters(l1, 0, tableID, row5[0], 1))
+			require.NoError(t, l1.Unlock(ctx, txn2, timestamp.Timestamp{}))
+
+			_, err = l1.Lock(ctx, tableID, row2, txn3, newTestRowExclusiveOptions())
+			require.NoError(t, err)
+			require.NoError(t, WaitWaiters(l1, 0, tableID, row2[0], 1))
+			require.NoError(t, l1.Unlock(ctx, txn3, timestamp.Timestamp{}))
+
+			wg.Wait()
+			require.NoError(t, l1.Unlock(ctx, txn4, timestamp.Timestamp{}))
+
+			time.Sleep(500 * time.Millisecond)
+			require.NotEqual(t, int32(1), wt.refCount.Load())
+		},
+	)
+
+}
+
 func TestIssue14008(t *testing.T) {
 	runLockServiceTests(
 		t,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #21711 

## What this PR does / why we need it:

fix leak of waiter


___

### **PR Type**
Bug fix


___

### **Description**
- Fix memory leak of waiter objects in lock service

- Add proper cleanup for old waiters when lock acquisition fails

- Add test case to verify waiter leak prevention

- Add test hook for transaction lock addition error simulation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Lock Acquisition"] --> B["Error Occurs"]
  B --> C["Old Waiter Cleanup"]
  C --> D["Prevent Memory Leak"]
  E["Test Hook"] --> F["Error Simulation"]
  F --> G["Leak Detection Test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lock_table_local.go</strong><dd><code>Add waiter cleanup in error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/lock_table_local.go

<ul><li>Add cleanup logic for old waiter when <code>doAcquireLock</code> fails<br> <li> Call <code>disableNotify()</code> and <code>close()</code> on old waiter to prevent leak<br> <li> Fix memory leak in error handling path</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22534/files#diff-58b0bb851b3377534881bd5d6ef248e668d5a5081e2f11f2dbd3e3289c9c2f8d">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_test.go</strong><dd><code>Add waiter leak prevention test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/service_test.go

<ul><li>Add comprehensive test <code>TestLeakWaiterForErr</code> to verify waiter leak fix<br> <li> Test concurrent lock operations with error injection<br> <li> Verify waiter reference count after operations complete<br> <li> Use test hook to simulate transaction errors</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22534/files#diff-e94812797c8b26ff0499bd86698dbc4371dd72642267baa535a7ecc7f8bf3981">+81/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>txn.go</strong><dd><code>Add test hook for lock error simulation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/txn.go

<ul><li>Add <code>beforeLockAdded</code> test hook field to <code>activeTxn</code> struct<br> <li> Implement hook execution in <code>lockAdded</code> method for error simulation<br> <li> Enable test-driven error injection for lock operations</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22534/files#diff-596b09c5fbac1be3d65e494426a0027ae49b654d653bb99d73596604783f18e7">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

