### PR TITLE
update create sql

### DIFF
--- a/pkg/cdc/sinker_test.go
+++ b/pkg/cdc/sinker_test.go
@@ -19,11 +19,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -36,6 +38,35 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/btree"
 )
+
+func mockTableDef() *plan.TableDef {
+	return &plan.TableDef{
+		Cols: []*plan.ColDef{
+			{
+				Name: "pk",
+				Typ:  plan.Type{Id: int32(types.T_uint64)},
+				Default: &plan.Default{
+					NullAbility: false,
+				},
+			},
+		},
+	}
+}
+
+func mockClusterTableDef() *plan.TableDef {
+	return &plan.TableDef{
+		TableType: catalog.SystemClusterRel,
+		Cols: []*plan.ColDef{
+			{
+				Name: "pk",
+				Typ:  plan.Type{Id: int32(types.T_uint64)},
+				Default: &plan.Default{
+					NullAbility: false,
+				},
+			},
+		},
+	}
+}
 
 func TestNewSinker(t *testing.T) {
 	type args struct {
@@ -62,7 +93,7 @@ func TestNewSinker(t *testing.T) {
 				},
 				dbTblInfo:        &DbTableInfo{},
 				watermarkUpdater: nil,
-				tableDef:         nil,
+				tableDef:         mockTableDef(),
 				retryTimes:       0,
 				retryDuration:    0,
 				ar:               NewCdcActiveRoutine(),
@@ -82,7 +113,7 @@ func TestNewSinker(t *testing.T) {
 					SourceCreateSql: "create table t1 (a int, b int, c int)",
 				},
 				watermarkUpdater: nil,
-				tableDef:         nil,
+				tableDef:         mockTableDef(),
 				retryTimes:       0,
 				retryDuration:    0,
 				ar:               NewCdcActiveRoutine(),
@@ -100,13 +131,31 @@ func TestNewSinker(t *testing.T) {
 					IdChanged:       true,
 				},
 				watermarkUpdater: nil,
-				tableDef:         nil,
+				tableDef:         mockTableDef(),
 				retryTimes:       0,
 				retryDuration:    0,
 				ar:               NewCdcActiveRoutine(),
 			},
 			want:    nil,
 			wantErr: assert.NoError,
+		},
+		{
+			args: args{
+				sinkUri: UriInfo{
+					SinkTyp: CDCSinkType_MySQL,
+				},
+				dbTblInfo: &DbTableInfo{
+					SourceCreateSql: "create table t1 (a int, b int, c int)",
+					IdChanged:       true,
+				},
+				watermarkUpdater: nil,
+				tableDef:         mockClusterTableDef(),
+				retryTimes:       0,
+				retryDuration:    0,
+				ar:               NewCdcActiveRoutine(),
+			},
+			want:    nil,
+			wantErr: assert.Error,
 		},
 	}
 

--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -77,16 +77,17 @@ func ConstructCreateTableSQL(
 			continue
 		}
 		//the non-sys account skips the column account_id of the cluster table
-		accountId, err := ctx.GetAccountId()
-		if err != nil {
-			return "", nil, err
-		}
 
-		if util.IsClusterTableAttribute(colNameOrigin) && isClusterTable &&
-			(accountId != catalog.System_Account || IsSnapshotValid(snapshot) || useDbName) {
-			// useDbName reuse in build alter table sql
-			// if use in other place, need to check or add a new parameter
-			continue
+		if util.IsClusterTableAttribute(colNameOrigin) && isClusterTable {
+			accountId, err := ctx.GetAccountId()
+			if err != nil {
+				return "", nil, err
+			}
+			if accountId != catalog.System_Account || IsSnapshotValid(snapshot) || useDbName {
+				// useDbName reuse in build alter table sql
+				// if use in other place, need to check or add a new parameter
+				continue
+			}
 		}
 
 		//-------------------------------------------------------------------------------------------------------------
@@ -533,8 +534,10 @@ func ConstructCreateTableSQL(
 			createStr += fmt.Sprintf(" IGNORE %d LINES", param.Tail.IgnoredLines)
 		}
 	}
-
-	stmt, err := getRewriteSQLStmt(ctx, createStr)
+	var stmt tree.Statement
+	if ctx != nil {
+		stmt, err = getRewriteSQLStmt(ctx, createStr)
+	}
 	return createStr, stmt, err
 }
 


### PR DESCRIPTION
### **User description**
build create sql with table define

Approved by: @ouyuanning, @ck89119, @aunjgr

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22207 

## What this PR does / why we need it:
update create sql


___

### **PR Type**
Bug fix


___

### **Description**
- Replace string manipulation with proper SQL construction for CREATE TABLE

- Add cluster table validation and error handling

- Fix import path from pb/plan to sql/plan

- Add comprehensive test coverage for table creation scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["String Manipulation"] --> B["Table Definition"]
  B --> C["SQL Construction"]
  C --> D["Validation"]
  D --> E["Error Handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sinker.go</strong><dd><code>Replace manual SQL construction with proper table definition</code></dd></summary>
<hr>

pkg/cdc/sinker.go

<ul><li>Replace string manipulation with <code>plan.ConstructCreateTableSQL()</code> <br>function<br> <li> Add cluster table type validation with error handling<br> <li> Update import path from <code>pkg/pb/plan</code> to <code>pkg/sql/plan</code><br> <li> Remove manual SQL string construction logic</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22540/files#diff-99322a2c28af9a0a6bcf7030e996605c948a7393e2df0f209a96c3dbcbd3183b">+15/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_show_util.go</strong><dd><code>Add null context validation for SQL construction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_show_util.go

<ul><li>Add null check for <code>ctx</code> parameter before calling <code>getRewriteSQLStmt()</code><br> <li> Move account ID validation inside cluster table attribute check<br> <li> Prevent null pointer dereference when context is nil</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22540/files#diff-623f0ec8665fe4f1a234d76a4766fe857c8c588a0c943dea032e57bd03b1b43f">+14/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sinker_test.go</strong><dd><code>Add comprehensive test coverage for table creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/sinker_test.go

<ul><li>Add <code>mockTableDef()</code> and <code>mockClusterTableDef()</code> helper functions<br> <li> Update test cases to use mock table definitions<br> <li> Add test case for cluster table error handling<br> <li> Fix import ordering and add missing imports</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22540/files#diff-19616b27e7a808f5a6781eebd2e596cb11f544a2aaac6c3f3bcf12d4f5cca100">+53/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

