### PR TITLE
Align the default field separators for the export table and load data.

### DIFF
--- a/pkg/sql/colexec/external/types.go
+++ b/pkg/sql/colexec/external/types.go
@@ -190,9 +190,9 @@ type ParseLineHandler struct {
 }
 
 func newReaderWithParam(param *ExternalParam) (*csvparser.CSVParser, error) {
-	fieldsTerminatedBy := "\t"
-	fieldsEnclosedBy := "\""
-	fieldsEscapedBy := "\\"
+	fieldsTerminatedBy := tree.DefaultFieldsTerminated
+	fieldsEnclosedBy := tree.DefaultFieldsEnclosedBy
+	fieldsEscapedBy := tree.DefaultFieldsEscapedBy
 
 	linesTerminatedBy := "\n"
 	linesStartingBy := ""

--- a/pkg/sql/parsers/tree/update.go
+++ b/pkg/sql/parsers/tree/update.go
@@ -385,6 +385,12 @@ type Terminated struct {
 	Value string
 }
 
+const (
+	DefaultFieldsTerminated = ","
+	DefaultFieldsEnclosedBy = "\""
+	DefaultFieldsEscapedBy  = "\\"
+)
+
 type Fields struct {
 	Terminated *Terminated
 	Optionally bool

--- a/pkg/sql/plan/bind_load.go
+++ b/pkg/sql/plan/bind_load.go
@@ -156,7 +156,7 @@ func (builder *QueryBuilder) bindExternalScan(
 
 	terminated := tree.DefaultFieldsTerminated
 	enclosedBy := []byte(tree.DefaultFieldsEnclosedBy)
-	escapedBy := []byte(tree.DefaultFieldsEscapedBy)
+	escapedBy := []byte{0}
 	if stmt.Param.Tail.Fields != nil {
 		if stmt.Param.Tail.Fields.EnclosedBy != nil {
 			if stmt.Param.Tail.Fields.EnclosedBy.Value != 0 {

--- a/pkg/sql/plan/bind_load.go
+++ b/pkg/sql/plan/bind_load.go
@@ -154,9 +154,9 @@ func (builder *QueryBuilder) bindExternalScan(
 		tableDef.Createsql = string(json_byte)
 	}
 
-	terminated := ","
-	enclosedBy := []byte("\"")
-	escapedBy := []byte{0}
+	terminated := tree.DefaultFieldsTerminated
+	enclosedBy := []byte(tree.DefaultFieldsEnclosedBy)
+	escapedBy := []byte(tree.DefaultFieldsEscapedBy)
 	if stmt.Param.Tail.Fields != nil {
 		if stmt.Param.Tail.Fields.EnclosedBy != nil {
 			if stmt.Param.Tail.Fields.EnclosedBy.Value != 0 {

--- a/test/distributed/cases/load_data/load_data.result
+++ b/test/distributed/cases/load_data/load_data.result
@@ -1047,3 +1047,20 @@ select count(*) from load_data_0303;
 count(*)
 100
 drop table load_data_0303;
+drop database if exists test;
+create database test;
+use test;
+create table t1(a bigint primary key, b vecf32(3), c varchar(10), d double);
+insert into t1 values(1, "[-1,-1,-1]", "aaaa", 1.213);
+insert into t1 values(2, "[-1, -1, 0]", "bbbb", 11.213);
+insert into t1 values(3, "[1,1,1]", "cccc", 111.213);
+select count(*) from t1;
+count(*)
+3
+select * from t1 into outfile '$resources/into_outfile/load_data/t1.csv';
+truncate table t1;
+load data infile '$resources/into_outfile/load_data/t1.csv' into table t1 ignore 1 lines;
+select count(*) from t1;
+count(*)
+3
+drop database test;

--- a/test/distributed/cases/load_data/load_data.sql
+++ b/test/distributed/cases/load_data/load_data.sql
@@ -607,3 +607,22 @@ delete from load_data_0303;
 LOAD DATA INFILE '$resources/load_data/test_parse_newline.csv' INTO TABLE load_data_0303 FIELDS TERMINATED BY ',';
 select count(*) from load_data_0303;
 drop table load_data_0303;
+
+drop database if exists test;
+create database test;
+use test;
+
+create table t1(a bigint primary key, b vecf32(3), c varchar(10), d double);
+
+insert into t1 values(1, "[-1,-1,-1]", "aaaa", 1.213);
+insert into t1 values(2, "[-1, -1, 0]", "bbbb", 11.213);
+insert into t1 values(3, "[1,1,1]", "cccc", 111.213);
+
+select count(*) from t1;
+
+select * from t1 into outfile '$resources/into_outfile/load_data/t1.csv';
+truncate table t1;
+load data infile '$resources/into_outfile/load_data/t1.csv' into table t1 ignore 1 lines;
+select count(*) from t1;
+
+drop database test;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/22565

## What this PR does / why we need it:

Align the default field separators for the export table and load data.


___

### **PR Type**
Bug fix


___

### **Description**
- Standardized default field separators across export and load operations

- Replaced hardcoded separators with centralized constants

- Added comprehensive test for export-load roundtrip functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded separators"] --> B["Centralized constants"]
  B --> C["External parser"]
  B --> D["Load data binding"]
  C --> E["Consistent behavior"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update.go</strong><dd><code>Define default field separator constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/parsers/tree/update.go

<ul><li>Added three new constants for default field separators<br> <li> <code>DefaultFieldsTerminated</code> set to comma<br> <li> <code>DefaultFieldsEnclosedBy</code> and <code>DefaultFieldsEscapedBy</code> defined</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22570/files#diff-bb9017ae7bc6511944771b0a8c3488df0d88c17dd6eb011d10c8842c6c295304">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Use centralized separator constants in CSV parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/external/types.go

<ul><li>Replaced hardcoded tab separator with comma constant<br> <li> Updated to use centralized default separator constants<br> <li> Changed from <code>\t</code> to <code>tree.DefaultFieldsTerminated</code></ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22570/files#diff-df82d1bd232b927b9c30126bc8cf018e204507d6bab896b3a2375833eac69968">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bind_load.go</strong><dd><code>Apply default constants in load data binding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/bind_load.go

<ul><li>Replaced hardcoded separator values with constants<br> <li> Updated terminated, enclosedBy, and escapedBy assignments<br> <li> Ensures consistency with export operations</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22570/files#diff-6a695581be4b5c00feda49eea331e2e17be4e318ec78bd96cb59351242728e71">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>load_data.sql</strong><dd><code>Add export-load roundtrip test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/load_data/load_data.sql

<ul><li>Added comprehensive roundtrip test case<br> <li> Tests export to CSV and reload functionality<br> <li> Includes vector data types and various column types</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22570/files#diff-159ff6babbf8ace74799ad58c4c9b005f2c0dc2c5276512e1bfd186d19c43424">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>load_data.result</strong><dd><code>Update test results for roundtrip validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/load_data/load_data.result

<ul><li>Added expected results for new test case<br> <li> Shows successful roundtrip with 3 records<br> <li> Validates data integrity after export-load cycle</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22570/files#diff-b72da059e6d9bf7b50b14ab7a73e6ef60c1f408eece4fc911680459b524463f6">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

