### PR TITLE
add some logging and fix a small bug

### DIFF
--- a/pkg/vm/engine/tae/db/db.go
+++ b/pkg/vm/engine/tae/db/db.go
@@ -202,11 +202,11 @@ func (db *DB) ForceCheckpoint(
 func (db *DB) ForceGlobalCheckpoint(
 	ctx context.Context,
 	ts types.TS,
-	histroyRetention time.Duration,
+	historyRetention time.Duration,
 ) (err error) {
 	t0 := time.Now()
 	err = db.BGFlusher.ForceFlush(ctx, ts)
-	forceICKPDuration := time.Since(t0)
+	forceFlushDuration := time.Since(t0)
 	defer func() {
 		logger := logutil.Info
 		if err != nil {
@@ -215,8 +215,8 @@ func (db *DB) ForceGlobalCheckpoint(
 		logger(
 			"DB-Force-ICKP",
 			zap.Duration("total-cost", time.Since(t0)),
-			zap.Duration("force-flush-cost", forceICKPDuration),
-			zap.Duration("histroy-retention", histroyRetention),
+			zap.Duration("force-flush-cost", forceFlushDuration),
+			zap.Duration("histroy-retention", historyRetention),
 			zap.Error(err),
 		)
 	}()
@@ -226,7 +226,7 @@ func (db *DB) ForceGlobalCheckpoint(
 	}
 
 	err = db.BGCheckpointRunner.ForceGCKP(
-		ctx, ts, histroyRetention,
+		ctx, ts, historyRetention,
 	)
 	return err
 }
@@ -284,7 +284,7 @@ func (db *DB) CommitTxn(txn txnif.AsyncTxn) (err error) {
 func (db *DB) GetTxnByID(id []byte) (txn txnif.AsyncTxn, err error) {
 	txn = db.TxnMgr.GetTxnByCtx(id)
 	if txn == nil {
-		err = moerr.NewNotFoundNoCtx()
+		err = moerr.NewTxnNotFoundNoCtx()
 	}
 	return
 }

--- a/pkg/vm/engine/tae/db/replay.go
+++ b/pkg/vm/engine/tae/db/replay.go
@@ -85,6 +85,8 @@ func (ctl *replayCtl) Wait() (err error) {
 func (ctl *replayCtl) Done(err error) {
 	ctl.err = err
 	ctl.doneTime = time.Now()
+	// PXU TODO: why onSuccess is called even if there is an error. since
+	// any error before will be panic.(Fix it later)
 	if ctl.onSuccess != nil {
 		ctl.onSuccess()
 	}
@@ -280,11 +282,11 @@ func (replayer *WalReplayer) MakeReplayHandle(
 		}
 		codec := objectio.GetIOEntryCodec(*head)
 		entry, err := codec.Decode(payload[4:])
-		txnCmd := entry.(*txnbase.TxnCmd)
-		txnCmd.Lsn = lsn
 		if err != nil {
 			panic(err)
 		}
+		txnCmd := entry.(*txnbase.TxnCmd)
+		txnCmd.Lsn = lsn
 		sender <- txnCmd
 		return driver.RE_Nomal
 	}

--- a/pkg/vm/engine/tae/db/scheduler.go
+++ b/pkg/vm/engine/tae/db/scheduler.go
@@ -160,7 +160,6 @@ func (s *taskScheduler) ScheduleScopedFn(ctx *tasks.Context, taskType tasks.Task
 
 func (s *taskScheduler) Schedule(task tasks.Task) (err error) {
 	taskType := task.Type()
-	// if taskType == tasks.DataCompactionTask || taskType == tasks.GCTask {
 	if taskType == tasks.DataCompactionTask || taskType == tasks.FlushTableTailTask {
 		dispatcher := s.Dispatchers[tasks.DataCompactionTask].(*asyncJobDispatcher)
 		return dispatcher.TryDispatch(task)

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -589,6 +589,9 @@ func testCRUD(t *testing.T, tae *db.DB, schema *catalog.Schema) {
 	_, err = db.DropRelationByName(schema.Name)
 	assert.NoError(t, err)
 	assert.NoError(t, txn.Commit(context.Background()))
+
+	_, err = tae.GetTxnByID([]byte("not exist"))
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrTxnNotFound))
 }
 
 func TestCRUD(t *testing.T) {

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -481,6 +481,13 @@ func (task *flushTableTailTask) Execute(ctx context.Context) (err error) {
 func (task *flushTableTailTask) prepareAObjSortedData(
 	ctx context.Context, objIdx int, idxs []int, sortKeyPos int, isTombstone bool,
 ) (bat *containers.Batch, empty bool, err error) {
+	defer func() {
+		if err != nil && bat != nil {
+			bat.Close()
+			bat = nil
+		}
+	}()
+
 	if len(idxs) <= 0 {
 		logutil.Info(
 			"NO-MERGEABLE-COLUMNS",


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22638 

## What this PR does / why we need it:

add some logging and fix a small bug


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved logging in stopReceiver with time-based intervals

- Fixed typo: `histroyRetention` to `historyRetention`

- Corrected error type: `NewNotFoundNoCtx()` to `NewTxnNotFoundNoCtx()`

- Enhanced DB open process with detailed phase logging

- Added error handling in prepareAObjSortedData to prevent resource leaks

- Removed unused variables and debug code


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bug Fixes"] --> B["Typo corrections"]
  A --> C["Error type fix"]
  A --> D["Resource leak prevention"]
  E["Logging Enhancements"] --> F["Time-based log intervals"]
  E --> G["Phase-based DB open logging"]
  H["Code Cleanup"] --> I["Remove unused variables"]
  H --> J["Remove debug code"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>controller.go</strong><dd><code>Improve logging and remove unused variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/controller.go

<ul><li>Improved logging in <code>stopReceiver</code> with time-based intervals instead of <br>modulo-based<br> <li> Changed sleep duration from 1ms to 20ms for better performance<br> <li> Simplified log message formatting<br> <li> Removed unused <code>errMsg</code> variable from <code>AssembleDB</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22639/files#diff-d628bae620ca91ce3a3f310a6245d7064c8b53a86d1ee5d183a273358b023719">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>open.go</strong><dd><code>Add comprehensive phase logging to DB open</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/open.go

<ul><li>Added detailed phase-based logging for DB open process (start, WAL <br>open, catalog open, end)<br> <li> Simplified final log output by removing redundant fields<br> <li> Removed TODO comment and debug code<br> <li> Added error logging during catalog open phase</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22639/files#diff-70f750e6241afa9a68b84ae68293c78c247640ee87b5225c5d3b7265ca531797">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db.go</strong><dd><code>Fix typos and improve variable naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/db.go

<ul><li>Fixed typo: <code>histroyRetention</code> to <code>historyRetention</code> in parameter and <br>usage<br> <li> Renamed variable <code>forceICKPDuration</code> to <code>forceFlushDuration</code> for clarity<br> <li> Updated log field name to match corrected variable name</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22639/files#diff-dc613bd920e611e7549691db0f4ea362f198d8e79f02892e1b48519b924c73cb">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>replay.go</strong><dd><code>Fix error handling order in replay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/replay.go

<ul><li>Moved error check before type assertion to prevent panic on nil<br> <li> Added TODO comment explaining onSuccess behavior with errors</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22639/files#diff-1b624eda15c6fe088d89177b50c04263f846872b22e1c8bcd9a82958b3e5d578">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flushTableTail.go</strong><dd><code>Add resource cleanup on error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/tables/jobs/flushTableTail.go

<ul><li>Added defer block to close batch and prevent resource leaks on error<br> <li> Ensures proper cleanup of containers.Batch when error occurs</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22639/files#diff-0b958d0044e734c5cb32254c0e45c0beaf0e4fdc1f4c846c0bde0fd917da63b0">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Code cleanup</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scheduler.go</strong><dd><code>Remove commented-out code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/scheduler.go

- Removed commented-out code for GCTask condition


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22639/files#diff-5685ec4e51b108a55b7c30b854835395c7b23eeb26a3c51bd9cedd8ce0631da5">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

