### PR TITLE
Snapshot support for databases and tables (#22635)

### DIFF
--- a/pkg/vm/engine/tae/db/gc/v3/checkpoint.go
+++ b/pkg/vm/engine/tae/db/gc/v3/checkpoint.go
@@ -416,7 +416,7 @@ func (c *checkpointCleaner) Replay(inputCtx context.Context) (err error) {
 			)
 			return
 		}
-		var snapshots map[uint32]containers.Vector
+		var snapshots *logtail.SnapshotInfo
 		var pitrs *logtail.PitrInfo
 		pitrs, err = c.GetPITRsLocked(ctx)
 		if err != nil {
@@ -440,8 +440,6 @@ func (c *checkpointCleaner) Replay(inputCtx context.Context) (err error) {
 			)
 			return
 		}
-		accountSnapshots := TransformToTSList(snapshots)
-		logtail.CloseSnapshotList(snapshots)
 		_, sarg, _ := fault.TriggerFault("replay error UT")
 		if sarg != "" {
 			err = moerr.NewInternalErrorNoCtxf("GC-REPLAY-GET-CHECKPOINT-DATA-ERROR %s", sarg)
@@ -464,13 +462,12 @@ func (c *checkpointCleaner) Replay(inputCtx context.Context) (err error) {
 			c.checkpointCli.GetCatalog().GetUsageMemo().(*logtail.TNUsageMemo),
 			ckpBatch,
 			c.mutation.snapshotMeta,
-			accountSnapshots,
+			snapshots,
 			pitrs,
 			0)
 		logutil.Info(
 			"GC-REPLAY-COLLECT-SNAPSHOT-SIZE",
 			zap.String("task", c.TaskNameLocked()),
-			zap.Int("size", len(accountSnapshots)),
 			zap.Duration("duration", time.Since(start)),
 			zap.String("checkpoint", compacted.String()),
 			zap.Int("count", ckpBatch.RowCount()),
@@ -777,7 +774,7 @@ func (c *checkpointCleaner) mergeCheckpointFilesLocked(
 	ctx context.Context,
 	checkpointLowWaterMark *types.TS,
 	memoryBuffer *containers.OneSchemaBatchBuffer,
-	accountSnapshots map[uint32][]types.TS,
+	snapshots *logtail.SnapshotInfo,
 	pitrs *logtail.PitrInfo,
 	gcFileCount int,
 ) (err error) {
@@ -888,7 +885,7 @@ func (c *checkpointCleaner) mergeCheckpointFilesLocked(
 		c.checkpointCli.GetCatalog().GetUsageMemo().(*logtail.TNUsageMemo),
 		newCkpData,
 		c.mutation.snapshotMeta,
-		accountSnapshots,
+		snapshots,
 		pitrs,
 		gcFileCount)
 	if newCkp == nil {
@@ -1069,10 +1066,9 @@ func (c *checkpointCleaner) tryGCAgainstGCKPLocked(
 	memoryBuffer *containers.OneSchemaBatchBuffer,
 ) (err error) {
 	now := time.Now()
-	var snapshots map[uint32]containers.Vector
+	var snapshots *logtail.SnapshotInfo
 	var extraErrMsg string
 	defer func() {
-		logtail.CloseSnapshotList(snapshots)
 		logutil.Info(
 			"GC-TRACE-TRY-GC-AGAINST-GCKP",
 			zap.String("task", c.TaskNameLocked()),
@@ -1092,9 +1088,8 @@ func (c *checkpointCleaner) tryGCAgainstGCKPLocked(
 		extraErrMsg = "GetSnapshot failed"
 		return
 	}
-	accountSnapshots := TransformToTSList(snapshots)
 	filesToGC, err := c.doGCAgainstGlobalCheckpointLocked(
-		ctx, gckp, accountSnapshots, pitrs, memoryBuffer,
+		ctx, gckp, snapshots, pitrs, memoryBuffer,
 	)
 	if err != nil {
 		extraErrMsg = "doGCAgainstGlobalCheckpointLocked failed"
@@ -1132,7 +1127,7 @@ func (c *checkpointCleaner) tryGCAgainstGCKPLocked(
 		waterMark = scanMark
 	}
 	err = c.mergeCheckpointFilesLocked(
-		ctx, &waterMark, memoryBuffer, accountSnapshots, pitrs, len(filesToGC),
+		ctx, &waterMark, memoryBuffer, snapshots, pitrs, len(filesToGC),
 	)
 	if err != nil {
 		extraErrMsg = fmt.Sprintf("mergeCheckpointFilesLocked %v failed", waterMark.ToString())
@@ -1145,7 +1140,7 @@ func (c *checkpointCleaner) tryGCAgainstGCKPLocked(
 func (c *checkpointCleaner) doGCAgainstGlobalCheckpointLocked(
 	ctx context.Context,
 	gckp *checkpoint.CheckpointEntry,
-	accountSnapshots map[uint32][]types.TS,
+	snapshots *logtail.SnapshotInfo,
 	pitrs *logtail.PitrInfo,
 	memoryBuffer *containers.OneSchemaBatchBuffer,
 ) ([]string, error) {
@@ -1189,7 +1184,7 @@ func (c *checkpointCleaner) doGCAgainstGlobalCheckpointLocked(
 	if filesToGC, metafile, err = scannedWindow.ExecuteGlobalCheckpointBasedGC(
 		ctx,
 		gckp,
-		accountSnapshots,
+		snapshots,
 		pitrs,
 		c.mutation.snapshotMeta,
 		iscp,
@@ -1232,7 +1227,7 @@ func (c *checkpointCleaner) doGCAgainstGlobalCheckpointLocked(
 	now = time.Now()
 	// TODO:
 	c.updateGCWaterMark(gckp)
-	c.mutation.snapshotMeta.MergeTableInfo(accountSnapshots, pitrs)
+	c.mutation.snapshotMeta.MergeTableInfo(snapshots, pitrs)
 	mergeDuration = time.Since(now)
 	return filesToGC, nil
 }
@@ -1324,7 +1319,7 @@ func (c *checkpointCleaner) DoCheck(ctx context.Context) error {
 		// TODO
 		return err
 	}
-	var snapshots map[uint32]containers.Vector
+	var snapshots *logtail.SnapshotInfo
 	snapshots, err = c.GetSnapshotsLocked()
 	if err != nil {
 		logutil.Error(
@@ -1334,7 +1329,6 @@ func (c *checkpointCleaner) DoCheck(ctx context.Context) error {
 		)
 		return err
 	}
-	defer logtail.CloseSnapshotList(snapshots)
 	var pitr *logtail.PitrInfo
 	pitr, err = c.GetPITRsLocked(c.ctx)
 	if err != nil {
@@ -1348,8 +1342,6 @@ func (c *checkpointCleaner) DoCheck(ctx context.Context) error {
 
 	mergeWindow := c.GetScannedWindowLocked().Clone()
 	defer mergeWindow.Close()
-
-	accoutSnapshots := TransformToTSList(snapshots)
 	logutil.Info(
 		"GC-TRACE-MERGE-WINDOW",
 		zap.String("task", c.TaskNameLocked()),
@@ -1362,7 +1354,7 @@ func (c *checkpointCleaner) DoCheck(ctx context.Context) error {
 	if _, _, err = mergeWindow.ExecuteGlobalCheckpointBasedGC(
 		c.ctx,
 		gCkp,
-		accoutSnapshots,
+		snapshots,
 		pitr,
 		c.mutation.snapshotMeta,
 		iscp,
@@ -1386,7 +1378,7 @@ func (c *checkpointCleaner) DoCheck(ctx context.Context) error {
 	if _, _, err = debugWindow.ExecuteGlobalCheckpointBasedGC(
 		c.ctx,
 		gCkp,
-		accoutSnapshots,
+		snapshots,
 		pitr,
 		c.mutation.snapshotMeta,
 		iscp,
@@ -1468,7 +1460,7 @@ func (c *checkpointCleaner) DoCheck(ctx context.Context) error {
 	}
 	collectObjectsFromCheckpointData(c.ctx, ckpReader, cptCkpObjects)
 
-	tList, pList := c.mutation.snapshotMeta.AccountToTableSnapshots(accoutSnapshots, pitr)
+	tList, pList := c.mutation.snapshotMeta.AccountToTableSnapshots(snapshots, pitr)
 	for name, tables := range ickpObjects {
 		for _, entry := range tables {
 			if cptCkpObjects[name] != nil {
@@ -1840,12 +1832,13 @@ func (c *checkpointCleaner) mutUpdateSnapshotMetaLocked(
 	)
 }
 
-func (c *checkpointCleaner) GetSnapshots() (map[uint32]containers.Vector, error) {
+func (c *checkpointCleaner) GetSnapshots() (*logtail.SnapshotInfo, error) {
 	c.mutation.Lock()
 	defer c.mutation.Unlock()
 	return c.mutation.snapshotMeta.GetSnapshot(c.ctx, c.sid, c.fs, c.mp)
 }
-func (c *checkpointCleaner) GetSnapshotsLocked() (map[uint32]containers.Vector, error) {
+
+func (c *checkpointCleaner) GetSnapshotsLocked() (*logtail.SnapshotInfo, error) {
 	return c.mutation.snapshotMeta.GetSnapshot(c.ctx, c.sid, c.fs, c.mp)
 }
 func (c *checkpointCleaner) GetTablePK(tid uint64) string {

--- a/pkg/vm/engine/tae/db/gc/v3/mock_cleaner.go
+++ b/pkg/vm/engine/tae/db/gc/v3/mock_cleaner.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/checkpoint"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
 )
@@ -139,7 +138,7 @@ func (c *MockCleaner) GetMPool() *mpool.MPool {
 	return nil
 }
 
-func (c *MockCleaner) GetSnapshots() (map[uint32]containers.Vector, error) {
+func (c *MockCleaner) GetSnapshots() (*logtail.SnapshotInfo, error) {
 	return nil, nil
 }
 

--- a/pkg/vm/engine/tae/db/gc/v3/types.go
+++ b/pkg/vm/engine/tae/db/gc/v3/types.go
@@ -23,7 +23,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/checkpoint"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
 )
@@ -148,7 +147,7 @@ type Cleaner interface {
 	DisableGC()
 	GCEnabled() bool
 	GetMPool() *mpool.MPool
-	GetSnapshots() (map[uint32]containers.Vector, error)
+	GetSnapshots() (*logtail.SnapshotInfo, error)
 	GetDetails(ctx context.Context) (map[uint32]*TableStats, error)
 	Verify(ctx context.Context) string
 	ISCPTables() (map[uint64]types.TS, error)

--- a/pkg/vm/engine/tae/db/gc/v3/util.go
+++ b/pkg/vm/engine/tae/db/gc/v3/util.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
-	"github.com/matrixorigin/matrixone/pkg/container/types"
-	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -70,16 +68,6 @@ func MakeLoadFunc(
 		}
 		return true, nil
 	}, releaseFn
-}
-
-func TransformToTSList(
-	fromKV map[uint32]containers.Vector,
-) map[uint32][]types.TS {
-	newKV := make(map[uint32][]types.TS, len(fromKV))
-	for k, v := range fromKV {
-		newKV[k] = vector.MustFixedColWithTypeCheck[types.TS](v.GetDownstreamVector())
-	}
-	return newKV
 }
 
 func MakeGCWindowBuffer(size int) *containers.OneSchemaBatchBuffer {

--- a/pkg/vm/engine/tae/db/gc/v3/window.go
+++ b/pkg/vm/engine/tae/db/gc/v3/window.go
@@ -120,7 +120,7 @@ func (w *GCWindow) MakeFilesReader(
 func (w *GCWindow) ExecuteGlobalCheckpointBasedGC(
 	ctx context.Context,
 	gCkp *checkpoint.CheckpointEntry,
-	accountSnapshots map[uint32][]types.TS,
+	snapshots *logtail.SnapshotInfo,
 	pitrs *logtail.PitrInfo,
 	snapshotMeta *logtail.SnapshotMeta,
 	iscpTables map[uint64]types.TS,
@@ -142,7 +142,7 @@ func (w *GCWindow) ExecuteGlobalCheckpointBasedGC(
 		gCkp.GetVersion(),
 		sourcer,
 		pitrs,
-		accountSnapshots,
+		snapshots,
 		iscpTables,
 		snapshotMeta,
 		checkpointCli,

--- a/pkg/vm/engine/tae/db/gc/v3/window_test.go
+++ b/pkg/vm/engine/tae/db/gc/v3/window_test.go
@@ -243,11 +243,11 @@ func NewMockSnapshotMeta() *MockSnapshotMeta {
 
 // AccountToTableSnapshots mocks the same method in logtail.SnapshotMeta
 func (m *MockSnapshotMeta) AccountToTableSnapshots(
-	accountSnapshots map[uint32][]types.TS,
+	snapshots *logtail.SnapshotInfo,
 	pitrs *logtail.PitrInfo,
-) (map[uint64][]types.TS, map[uint64][]types.TS) {
+) (map[uint64][]types.TS, map[uint64]*types.TS) {
 	tableSnapshots := make(map[uint64][]types.TS)
-	tablePitrs := make(map[uint64][]types.TS)
+	tablePitrs := make(map[uint64]*types.TS)
 	return tableSnapshots, tablePitrs
 }
 

--- a/pkg/vm/engine/tae/db/test/db_test.go
+++ b/pkg/vm/engine/tae/db/test/db_test.go
@@ -7239,12 +7239,6 @@ func TestSnapshotMeta(t *testing.T) {
 	}
 	//db.DiskCleaner.GetCleaner().DisableGC()
 
-	snapshots := make([]int64, 0)
-	for i := 0; i < 10; i++ {
-		time.Sleep(20 * time.Millisecond)
-		snapshot := time.Now().UTC().Unix()
-		snapshots = append(snapshots, snapshot)
-	}
 	testutils.WaitExpect(10000, func() bool {
 		return testutil.AllCheckpointsFinished(db)
 	})
@@ -7254,6 +7248,12 @@ func TestSnapshotMeta(t *testing.T) {
 	tae.Restart(ctx)
 	db = tae.DB
 	db.DiskCleaner.GetCleaner().DisableGC()
+	snapshots := make([]int64, 0)
+	for i := 0; i < 10; i++ {
+		time.Sleep(20 * time.Millisecond)
+		snapshot := time.Now().UTC().UnixNano()
+		snapshots = append(snapshots, snapshot)
+	}
 	for i, snapshot := range snapshots {
 		attrs := []string{"col0", "col1", "ts", "col3", "col4", "col5", "col6", "id"}
 		vecTypes := []types.Type{types.T_uint64.ToType(),
@@ -7336,11 +7336,7 @@ func TestSnapshotMeta(t *testing.T) {
 	assert.NotNil(t, minMerged)
 	snaps, err := db.DiskCleaner.GetCleaner().GetSnapshots()
 	assert.Nil(t, err)
-	defer logtail.CloseSnapshotList(snaps)
-	assert.Equal(t, 1, len(snaps))
-	for _, snap := range snaps {
-		assert.Equal(t, len(snapshots), snap.Length())
-	}
+	assert.Equal(t, len(snapshots), len(snaps.ToTsList()))
 	err = db.DiskCleaner.GetCleaner().DoCheck(ctx)
 	assert.Nil(t, err)
 	tae.RestartDisableGC(ctx)
@@ -7361,11 +7357,7 @@ func TestSnapshotMeta(t *testing.T) {
 	assert.True(t, end.GE(&minEnd))
 	snaps, err = db.DiskCleaner.GetCleaner().GetSnapshots()
 	assert.Nil(t, err)
-	defer logtail.CloseSnapshotList(snaps)
-	assert.Equal(t, 1, len(snaps))
-	for _, snap := range snaps {
-		assert.Equal(t, len(snapshots), snap.Length())
-	}
+	assert.Equal(t, len(snapshots), len(snaps.ToTsList()))
 	err = db.DiskCleaner.GetCleaner().DoCheck(ctx)
 	assert.Nil(t, err)
 }

--- a/pkg/vm/engine/tae/logtail/snapshot_test.go
+++ b/pkg/vm/engine/tae/logtail/snapshot_test.go
@@ -1,0 +1,418 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logtail
+
+import (
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSnapshotInfo tests the basic functionality of SnapshotInfo
+func TestSnapshotInfo(t *testing.T) {
+	t.Run("NewSnapshotInfo", func(t *testing.T) {
+		info := NewSnapshotInfo()
+		assert.NotNil(t, info)
+		assert.True(t, info.IsEmpty())
+		assert.NotNil(t, info.cluster)
+		assert.NotNil(t, info.account)
+		assert.NotNil(t, info.database)
+		assert.NotNil(t, info.tables)
+	})
+
+	t.Run("AddSnapshots", func(t *testing.T) {
+		info := NewSnapshotInfo()
+		ts1 := types.BuildTS(1000, 0)
+		ts2 := types.BuildTS(2000, 0)
+		ts3 := types.BuildTS(3000, 0)
+
+		// Add cluster snapshots
+		info.cluster = append(info.cluster, ts1, ts2)
+		assert.False(t, info.IsEmpty())
+
+		// Add account snapshots
+		info.account[1] = []types.TS{ts1, ts3}
+		info.account[2] = []types.TS{ts2}
+
+		// Add database snapshots
+		info.database[100] = []types.TS{ts1}
+		info.database[200] = []types.TS{ts2, ts3}
+
+		// Add table snapshots
+		info.tables[1001] = []types.TS{ts1}
+		info.tables[1002] = []types.TS{ts2}
+
+		// Test GetTS (should return first timestamp for PITR compatibility)
+		assert.Equal(t, ts1, info.GetTS(1, 100, 1001)) // cluster level
+		assert.Equal(t, ts1, info.GetTS(1, 0, 0))      // account level
+		assert.Equal(t, ts1, info.GetTS(0, 100, 0))    // database level
+		assert.Equal(t, ts1, info.GetTS(0, 0, 1001))   // table level
+
+		// Test MinTS
+		minTS := info.MinTS()
+		assert.Equal(t, ts1, minTS)
+
+		// Test ToTsList
+		allTS := info.ToTsList()
+		assert.Contains(t, allTS, ts1)
+		assert.Contains(t, allTS, ts2)
+		assert.Contains(t, allTS, ts3)
+	})
+}
+
+// TestAccountToTableSnapshots tests the core logic of snapshot distribution
+func TestAccountToTableSnapshots(t *testing.T) {
+	// Create a mock SnapshotMeta
+	sm := &SnapshotMeta{
+		tableIDIndex: make(map[uint64]*tableInfo),
+	}
+
+	// Setup test data: 2 accounts, 2 databases, 4 tables
+	// Account 1: DB 100 (Table 1001, 1002), DB 200 (Table 2001)
+	// Account 2: DB 300 (Table 3001)
+	sm.tableIDIndex[1001] = &tableInfo{accountID: 1, dbID: 100, tid: 1001}
+	sm.tableIDIndex[1002] = &tableInfo{accountID: 1, dbID: 100, tid: 1002}
+	sm.tableIDIndex[2001] = &tableInfo{accountID: 1, dbID: 200, tid: 2001}
+	sm.tableIDIndex[3001] = &tableInfo{accountID: 2, dbID: 300, tid: 3001}
+
+	t.Run("TableSnapshotAppliedToAllTablesInDatabase", func(t *testing.T) {
+		// Create snapshots with table-level snapshot for table 1001
+		snapshots := NewSnapshotInfo()
+		ts1 := types.BuildTS(1000, 0)
+		ts2 := types.BuildTS(2000, 0)
+
+		// Add table snapshot for table 1001 (in DB 100)
+		snapshots.tables[1001] = []types.TS{ts1}
+		// Add account snapshot for account 1
+		snapshots.account[1] = []types.TS{ts2}
+
+		pitr := NewSnapshotInfo()
+
+		tableSnapshots, tablePitrs := sm.AccountToTableSnapshots(snapshots, pitr)
+
+		// Verify that table 1001 has both its own snapshot and account snapshot
+		require.Contains(t, tableSnapshots, uint64(1001))
+		assert.Contains(t, tableSnapshots[1001], ts1) // table snapshot
+		assert.Contains(t, tableSnapshots[1001], ts2) // account snapshot
+
+		// CRITICAL: Verify that table 1002 (in same DB 100) also gets table 1001's snapshot
+		require.Contains(t, tableSnapshots, uint64(1002))
+		assert.Contains(t, tableSnapshots[1002], ts1) // table snapshot from 1001
+		assert.Contains(t, tableSnapshots[1002], ts2) // account snapshot
+
+		// Verify that table 2001 (in different DB 200) only gets account snapshot
+		require.Contains(t, tableSnapshots, uint64(2001))
+		assert.NotContains(t, tableSnapshots[2001], ts1) // should NOT have table snapshot from 1001
+		assert.Contains(t, tableSnapshots[2001], ts2)    // account snapshot
+
+		// Verify that table 3001 (different account) doesn't get any of these snapshots
+		if snapshots3001, exists := tableSnapshots[3001]; exists {
+			assert.NotContains(t, snapshots3001, ts1) // should NOT have table snapshot from 1001
+			assert.NotContains(t, snapshots3001, ts2) // should NOT have account snapshot from account 1
+		}
+
+		// Verify PITR info is set correctly
+		assert.NotNil(t, tablePitrs[1001])
+		assert.NotNil(t, tablePitrs[1002])
+		assert.NotNil(t, tablePitrs[2001])
+		assert.NotNil(t, tablePitrs[3001])
+	})
+
+	t.Run("MultipleTableSnapshotsInSameDatabase", func(t *testing.T) {
+		// Create snapshots with table-level snapshots for both tables in DB 100
+		snapshots := NewSnapshotInfo()
+		ts1 := types.BuildTS(1000, 0)
+		ts2 := types.BuildTS(2000, 0)
+		ts3 := types.BuildTS(3000, 0)
+
+		// Add table snapshots for both tables in DB 100
+		snapshots.tables[1001] = []types.TS{ts1}
+		snapshots.tables[1002] = []types.TS{ts2}
+		// Add account snapshot
+		snapshots.account[1] = []types.TS{ts3}
+
+		pitr := NewPitrInfo()
+
+		tableSnapshots, _ := sm.AccountToTableSnapshots(snapshots, pitr)
+
+		// Both tables should have all snapshots from their database
+		require.Contains(t, tableSnapshots, uint64(1001))
+		require.Contains(t, tableSnapshots, uint64(1002))
+
+		// Table 1001 should have: its own snapshot + table 1002's snapshot + account snapshot
+		assert.Contains(t, tableSnapshots[1001], ts1) // its own
+		assert.Contains(t, tableSnapshots[1001], ts2) // from table 1002
+		assert.Contains(t, tableSnapshots[1001], ts3) // account
+
+		// Table 1002 should have: its own snapshot + table 1001's snapshot + account snapshot
+		assert.Contains(t, tableSnapshots[1002], ts1) // from table 1001
+		assert.Contains(t, tableSnapshots[1002], ts2) // its own
+		assert.Contains(t, tableSnapshots[1002], ts3) // account
+
+		// Verify snapshots are sorted and deduplicated
+		assert.True(t, len(tableSnapshots[1001]) >= 3)
+		assert.True(t, len(tableSnapshots[1002]) >= 3)
+	})
+
+	t.Run("DatabaseSnapshotTest", func(t *testing.T) {
+		// Test database-level snapshots
+		snapshots := NewSnapshotInfo()
+		ts1 := types.BuildTS(1000, 0)
+		ts2 := types.BuildTS(2000, 0)
+
+		// Add database snapshot for DB 100
+		snapshots.database[100] = []types.TS{ts1}
+		// Add account snapshot
+		snapshots.account[1] = []types.TS{ts2}
+
+		pitr := NewPitrInfo()
+
+		tableSnapshots, _ := sm.AccountToTableSnapshots(snapshots, pitr)
+
+		// Both tables in DB 100 should have database snapshot
+		require.Contains(t, tableSnapshots, uint64(1001))
+		require.Contains(t, tableSnapshots, uint64(1002))
+		assert.Contains(t, tableSnapshots[1001], ts1) // database snapshot
+		assert.Contains(t, tableSnapshots[1001], ts2) // account snapshot
+		assert.Contains(t, tableSnapshots[1002], ts1) // database snapshot
+		assert.Contains(t, tableSnapshots[1002], ts2) // account snapshot
+
+		// Table in DB 200 should only have account snapshot
+		require.Contains(t, tableSnapshots, uint64(2001))
+		assert.NotContains(t, tableSnapshots[2001], ts1) // should NOT have DB 100 snapshot
+		assert.Contains(t, tableSnapshots[2001], ts2)    // account snapshot
+	})
+
+	t.Run("ClusterSnapshotTest", func(t *testing.T) {
+		// Test cluster-level snapshots
+		snapshots := NewSnapshotInfo()
+		ts1 := types.BuildTS(1000, 0)
+
+		// Add cluster snapshot
+		snapshots.cluster = []types.TS{ts1}
+
+		pitr := NewPitrInfo()
+
+		tableSnapshots, _ := sm.AccountToTableSnapshots(snapshots, pitr)
+
+		// All tables should have cluster snapshot
+		for _, tid := range []uint64{1001, 1002, 2001, 3001} {
+			require.Contains(t, tableSnapshots, tid)
+			assert.Contains(t, tableSnapshots[tid], ts1, "Table %d should have cluster snapshot", tid)
+		}
+	})
+
+	t.Run("SnapshotPriorityTest", func(t *testing.T) {
+		// Test that all levels of snapshots are combined correctly
+		snapshots := NewSnapshotInfo()
+		tsCluster := types.BuildTS(1000, 0)
+		tsAccount := types.BuildTS(2000, 0)
+		tsDatabase := types.BuildTS(3000, 0)
+		tsTable := types.BuildTS(4000, 0)
+
+		// Add all levels of snapshots
+		snapshots.cluster = []types.TS{tsCluster}
+		snapshots.account[1] = []types.TS{tsAccount}
+		snapshots.database[100] = []types.TS{tsDatabase}
+		snapshots.tables[1001] = []types.TS{tsTable}
+
+		pitr := NewPitrInfo()
+
+		tableSnapshots, _ := sm.AccountToTableSnapshots(snapshots, pitr)
+
+		// Table 1001 should have all snapshots
+		require.Contains(t, tableSnapshots, uint64(1001))
+		snapshots1001 := tableSnapshots[1001]
+		assert.Contains(t, snapshots1001, tsCluster)
+		assert.Contains(t, snapshots1001, tsAccount)
+		assert.Contains(t, snapshots1001, tsDatabase)
+		assert.Contains(t, snapshots1001, tsTable)
+
+		// Table 1002 (same DB) should have all except direct table snapshot, but should have table 1001's snapshot
+		require.Contains(t, tableSnapshots, uint64(1002))
+		snapshots1002 := tableSnapshots[1002]
+		assert.Contains(t, snapshots1002, tsCluster)
+		assert.Contains(t, snapshots1002, tsAccount)
+		assert.Contains(t, snapshots1002, tsDatabase)
+		assert.Contains(t, snapshots1002, tsTable) // from table 1001 in same DB
+	})
+}
+
+// TestMergeTableInfo tests the MergeTableInfo functionality
+func TestMergeTableInfo(t *testing.T) {
+	// Create a mock SnapshotMeta with some tables
+	sm := &SnapshotMeta{
+		tables:       make(map[uint32]map[uint64]*tableInfo),
+		tableIDIndex: make(map[uint64]*tableInfo),
+		objects:      make(map[uint64]map[objectio.Segmentid]*objectInfo),
+	}
+
+	// Setup test tables
+	deleteTS := types.BuildTS(6000, 0) // deleted timestamp
+	sm.tables[1] = make(map[uint64]*tableInfo)
+	sm.tables[1][1001] = &tableInfo{accountID: 1, dbID: 100, tid: 1001, deleteAt: deleteTS}
+	sm.tables[1][1002] = &tableInfo{accountID: 1, dbID: 100, tid: 1002, deleteAt: deleteTS}
+	sm.tables[1][2001] = &tableInfo{accountID: 1, dbID: 200, tid: 2001, deleteAt: deleteTS}
+
+	sm.tableIDIndex[1001] = sm.tables[1][1001]
+	sm.tableIDIndex[1002] = sm.tables[1][1002]
+	sm.tableIDIndex[2001] = sm.tables[1][2001]
+
+	t.Run("TableSnapshotProtectsAllTablesInDatabase", func(t *testing.T) {
+		// Create snapshots with table snapshot that should protect the table
+		snapshots := NewSnapshotInfo()
+		protectTS := types.BuildTS(5000, 0) // after delete, should protect
+
+		// Add table snapshot for table 1001
+		snapshots.tables[1001] = []types.TS{protectTS}
+
+		pitr := NewPitrInfo()
+
+		// Before merge, all tables exist
+		assert.Contains(t, sm.tables[1], uint64(1001))
+		assert.Contains(t, sm.tables[1], uint64(1002))
+		assert.Contains(t, sm.tables[1], uint64(2001))
+
+		err := sm.MergeTableInfo(snapshots, pitr)
+		require.NoError(t, err)
+
+		// After merge, tables in DB 100 should be protected by table 1001's snapshot
+		assert.Contains(t, sm.tables[1], uint64(1001), "Table 1001 should be protected by its own snapshot")
+		assert.Contains(t, sm.tables[1], uint64(1002), "Table 1002 should be protected by table 1001's snapshot (same DB)")
+
+		// Table in different DB should be deleted (no protection)
+		assert.NotContains(t, sm.tables[1], uint64(2001), "Table 2001 should be deleted (different DB, no protection)")
+	})
+
+	t.Run("NoSnapshotAllowsDeletion", func(t *testing.T) {
+		// Reset tables
+		sm.tables[1] = make(map[uint64]*tableInfo)
+		sm.tables[1][1001] = &tableInfo{accountID: 1, dbID: 100, tid: 1001, deleteAt: deleteTS}
+		sm.tables[1][1002] = &tableInfo{accountID: 1, dbID: 100, tid: 1002, deleteAt: deleteTS}
+
+		// Create empty snapshots and PITR
+		snapshots := NewSnapshotInfo()
+		pitr := NewPitrInfo()
+
+		err := sm.MergeTableInfo(snapshots, pitr)
+		require.NoError(t, err)
+
+		// All deleted tables should be removed
+		assert.NotContains(t, sm.tables[1], uint64(1001))
+		assert.NotContains(t, sm.tables[1], uint64(1002))
+	})
+
+	t.Run("DatabaseSnapshotProtectsAllTablesInDatabase", func(t *testing.T) {
+		// Reset tables
+		sm.tables[1] = make(map[uint64]*tableInfo)
+		sm.tables[1][1001] = &tableInfo{accountID: 1, dbID: 100, tid: 1001, deleteAt: deleteTS}
+		sm.tables[1][1002] = &tableInfo{accountID: 1, dbID: 100, tid: 1002, deleteAt: deleteTS}
+		sm.tables[1][2001] = &tableInfo{accountID: 1, dbID: 200, tid: 2001, deleteAt: deleteTS}
+
+		// Create database snapshot
+		snapshots := NewSnapshotInfo()
+		protectTS := types.BuildTS(5000, 0)
+		snapshots.database[100] = []types.TS{protectTS}
+
+		pitr := NewPitrInfo()
+
+		err := sm.MergeTableInfo(snapshots, pitr)
+		require.NoError(t, err)
+
+		// Tables in DB 100 should be protected
+		assert.Contains(t, sm.tables[1], uint64(1001))
+		assert.Contains(t, sm.tables[1], uint64(1002))
+
+		// Table in different DB should be deleted
+		assert.NotContains(t, sm.tables[1], uint64(2001))
+	})
+}
+
+// TestSnapshotDeduplication tests that snapshots are properly deduplicated
+func TestSnapshotDeduplication(t *testing.T) {
+	sm := &SnapshotMeta{
+		tableIDIndex: make(map[uint64]*tableInfo),
+	}
+
+	// Setup test data
+	sm.tableIDIndex[1001] = &tableInfo{accountID: 1, dbID: 100, tid: 1001}
+	sm.tableIDIndex[1002] = &tableInfo{accountID: 1, dbID: 100, tid: 1002}
+
+	snapshots := NewSnapshotInfo()
+	ts1 := types.BuildTS(1000, 0)
+	ts2 := types.BuildTS(2000, 0)
+
+	// Add duplicate timestamps at different levels
+	snapshots.cluster = []types.TS{ts1, ts2}
+	snapshots.account[1] = []types.TS{ts1, ts2} // duplicates
+	snapshots.database[100] = []types.TS{ts1}   // duplicate
+	snapshots.tables[1001] = []types.TS{ts2}    // duplicate
+
+	pitr := NewPitrInfo()
+
+	tableSnapshots, _ := sm.AccountToTableSnapshots(snapshots, pitr)
+
+	// Verify deduplication - each table should have exactly 2 unique timestamps
+	for _, tid := range []uint64{1001, 1002} {
+		require.Contains(t, tableSnapshots, tid)
+		snapshots := tableSnapshots[tid]
+
+		// Count unique timestamps
+		uniqueTS := make(map[types.TS]bool)
+		for _, ts := range snapshots {
+			uniqueTS[ts] = true
+		}
+
+		assert.Equal(t, 2, len(uniqueTS), "Table %d should have exactly 2 unique timestamps after deduplication", tid)
+		assert.True(t, uniqueTS[ts1], "Table %d should have ts1", tid)
+		assert.True(t, uniqueTS[ts2], "Table %d should have ts2", tid)
+	}
+}
+
+// TestPitrCompatibility tests that PITR functionality still works correctly
+func TestPitrCompatibility(t *testing.T) {
+	t.Run("GetTSReturnsFirstTimestamp", func(t *testing.T) {
+		info := NewSnapshotInfo()
+		ts1 := types.BuildTS(1000, 0)
+		ts2 := types.BuildTS(2000, 0)
+		ts3 := types.BuildTS(3000, 0)
+
+		// Add multiple timestamps in different orders
+		info.cluster = []types.TS{ts3, ts1, ts2} // unsorted
+		info.account[1] = []types.TS{ts2, ts3}
+		info.database[100] = []types.TS{ts3}
+		info.tables[1001] = []types.TS{ts2, ts1}
+
+		// GetTS should return the first (earliest) timestamp for PITR compatibility
+		assert.Equal(t, ts3, info.GetTS(0, 0, 0))    // cluster (first in slice, not necessarily earliest)
+		assert.Equal(t, ts2, info.GetTS(1, 0, 0))    // account
+		assert.Equal(t, ts3, info.GetTS(0, 100, 0))  // database
+		assert.Equal(t, ts2, info.GetTS(0, 0, 1001)) // table
+	})
+
+	t.Run("PitrInfoAlias", func(t *testing.T) {
+		// Test that PitrInfo is correctly aliased to SnapshotInfo
+		var pitr *PitrInfo = NewPitrInfo()
+		assert.NotNil(t, pitr)
+
+		ts := types.BuildTS(1000, 0)
+		pitr.cluster = []types.TS{ts}
+		assert.False(t, pitr.IsEmpty())
+		assert.Equal(t, ts, pitr.GetTS(0, 0, 0))
+	})
+}

--- a/pkg/vm/engine/tae/logtail/storage_usage.go
+++ b/pkg/vm/engine/tae/logtail/storage_usage.go
@@ -784,7 +784,7 @@ func FillUsageBatOfCompacted(
 	usage *TNUsageMemo,
 	data *batch.Batch,
 	meta *SnapshotMeta,
-	accountSnapshots map[uint32][]types.TS,
+	snapshots *SnapshotInfo,
 	pitrs *PitrInfo,
 	_ int,
 ) {
@@ -798,7 +798,7 @@ func FillUsageBatOfCompacted(
 	}()
 	usageData := make(map[[3]uint64]UsageData)
 	tableSnapshots, tablePitrs := meta.AccountToTableSnapshots(
-		accountSnapshots,
+		snapshots,
 		pitrs,
 	)
 	objectsName := make(map[string]struct{})


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22634

## What this PR does / why we need it:
Snapshot support for databases and tables


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored snapshot handling to support database and table-level snapshots
  - Changed from `map[uint32]containers.Vector` to `*logtail.SnapshotInfo` structure
  - Added support for cluster, account, database, and table-level snapshot types

- Unified PITR and Snapshot functionality through shared `SnapshotInfo` structure
  - Made `PitrInfo` an alias for `SnapshotInfo` for backward compatibility
  - Updated all snapshot-related methods to use the new structure

- Enhanced snapshot distribution logic to apply table snapshots across database
  - Table-level snapshots now protect all tables in the same database
  - Implemented proper snapshot hierarchy and deduplication

- Removed manual snapshot cleanup and vector transformation code
  - Eliminated `TransformToTSList()` and `CloseSnapshotList()` functions
  - Simplified snapshot lifecycle management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Structure<br/>map[uint32]containers.Vector"] -->|Refactor| B["SnapshotInfo<br/>cluster/account/database/tables"]
  B -->|Unified| C["PitrInfo<br/>Alias for SnapshotInfo"]
  B -->|Enhanced| D["Snapshot Distribution<br/>Table→Database→Account→Cluster"]
  D -->|Protects| E["Multi-level<br/>Table Protection"]
  F["GetSnapshot()"] -->|Returns| B
  G["AccountToTableSnapshots()"] -->|Uses| B
  H["MergeTableInfo()"] -->|Uses| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>checkpoint.go</strong><dd><code>Updated snapshot parameter types throughout GC logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-d24973cd30186f29b82d463b1bcfc1c7b13a57164046448a2064207f0bad1824">+17/-24</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>exec_v1.go</strong><dd><code>Changed snapshot field from map to SnapshotInfo pointer</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-69c16ce601ed0824dcb61ad1755fe4897ec8cad3c07e5a5e956a257173d58d62">+26/-26</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>mock_cleaner.go</strong><dd><code>Updated mock GetSnapshots return type signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-d1b47d0a85398ccfbf0768d6f760f525955c51521d66dbee83bb1f71a4abb882">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Updated Cleaner interface GetSnapshots method signature</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-7342a4201e330d4feb9826cc93fc9a9a23d5df4442980ab957a643138c7ee3a1">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>util.go</strong><dd><code>Removed TransformToTSList transformation function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-445a2ac62eb349ee2d3515414386346fa669494da493c66ce88e707b3aac6410">+0/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>window.go</strong><dd><code>Updated ExecuteGlobalCheckpointBasedGC snapshot parameter</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-822caab6d8ff49ee3f8fc207ec11ad2c7d0992ef917d007542c6df6dbe4531d6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>storage_usage.go</strong><dd><code>Updated FillUsageBatOfCompacted to use SnapshotInfo parameter</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-f4eff1d34934103a129b5414d2d7118d6d3d345e748e606b501f7bd341d54d0b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>window_test.go</strong><dd><code>Updated mock AccountToTableSnapshots return type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-284e0cfc17e5ac4939f510d7ad0eeb71f79462168a8d56e649d1a9c4eb39edfc">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>db_test.go</strong><dd><code>Updated TestSnapshotMeta to use new SnapshotInfo API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-858060e31b5a9bf1276488170b96f1f70e3d50b9ef08c44bba5d7acf5778d0a3">+8/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>snapshot_test.go</strong><dd><code>Added comprehensive tests for SnapshotInfo functionality</code>&nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-d4582285ce828adb81026dacb2ea863b5b372244f1b9f4684cee54eee736cf32">+418/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>snapshot.go</strong><dd><code>Refactored SnapshotInfo structure with multi-level support</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22641/files#diff-111781ff442a07a8deefe4a9fa1e799b2b5da03309f03c042a9b9b83e33a21be">+409/-144</a></td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

