### PR TITLE
adjust available memory check for merging 3.0

### DIFF
--- a/pkg/vm/engine/tae/db/merge/scheduler.go
+++ b/pkg/vm/engine/tae/db/merge/scheduler.go
@@ -109,7 +109,7 @@ func NewMergeScheduler(
 	sched.rc = rscthrottler.NewMemThrottler(
 		"Merge",
 		3.0/4.0,
-		rscthrottler.WithAllowOutOfLimitAcquire(),
+		rscthrottler.WithLimitIsTheBoss(),
 	)
 
 	sched.stopped.Store(true)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22638

## What this PR does / why we need it:

less available() with respect to `limit`


___

### **PR Type**
Enhancement


___

### **Description**
- Add `limitIsTheBoss` option to control memory throttler behavior

- Modify available memory calculation to prioritize limit over actual memory

- Update merge scheduler to use new `limitIsTheBoss` option

- Change from `WithAllowOutOfLimitAcquire()` to `WithLimitIsTheBoss()`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["memThrottler options"] -->|add| B["limitIsTheBoss flag"]
  B -->|controls| C["Available() calculation"]
  C -->|when true| D["avail = limit - rss - reserved"]
  C -->|when false| E["avail = actualMaxMemory - rss - reserved"]
  F["MergeScheduler"] -->|uses| G["WithLimitIsTheBoss()"]
  G -->|replaces| H["WithAllowOutOfLimitAcquire()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_throttler.go</strong><dd><code>Add limitIsTheBoss option to memory throttler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/rscthrottler/resource_throttler.go

<ul><li>Add new <code>limitIsTheBoss</code> boolean option to <code>memThrottler.options</code> struct<br> <li> Refactor <code>Available()</code> method to check <code>limitIsTheBoss</code> flag and adjust <br>memory calculation accordingly<br> <li> When <code>limitIsTheBoss</code> is true, available memory is calculated as <code>limit - </code><br><code>rss - reserved</code><br> <li> When false, uses original logic comparing <code>actualMaxMemory</code> against <br><code>limit</code><br> <li> Add new <code>WithLimitIsTheBoss()</code> option function to enable the feature</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22651/files#diff-0f4788f9a2505df34b1704cf776fe14b7ec5262d463f29002e3cf470cc95e395">+15/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scheduler.go</strong><dd><code>Update merge scheduler memory throttler configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/merge/scheduler.go

<ul><li>Replace <code>WithAllowOutOfLimitAcquire()</code> with <code>WithLimitIsTheBoss()</code> in <br>merge scheduler initialization<br> <li> Update memory throttler configuration for merge operations to use new <br>limit-priority behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22651/files#diff-e39cd8771cc815a9c7daef3e4cb9f6a7a3a91de2ed4eb91942a389452365e113">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

