### PR TITLE
Fix cdc panic due to UnsafeGetStringAt

### DIFF
--- a/pkg/cdc/table_scanner.go
+++ b/pkg/cdc/table_scanner.go
@@ -426,10 +426,10 @@ func (s *TableDetector) scanTable() error {
 	result.ReadRows(func(rows int, cols []*vector.Vector) bool {
 		for i := 0; i < rows; i++ {
 			tblId := vector.MustFixedColWithTypeCheck[uint64](cols[0])[i]
-			tblName := cols[1].UnsafeGetStringAt(i)
+			tblName := cols[1].GetStringAt(i)
 			dbId := vector.MustFixedColWithTypeCheck[uint64](cols[2])[i]
-			dbName := cols[3].UnsafeGetStringAt(i)
-			createSql := cols[4].UnsafeGetStringAt(i)
+			dbName := cols[3].GetStringAt(i)
+			createSql := cols[4].GetStringAt(i)
 			accountId := vector.MustFixedColWithTypeCheck[uint32](cols[5])[i]
 
 			// skip table with foreign key

--- a/pkg/vm/engine/tae/db/replay.go
+++ b/pkg/vm/engine/tae/db/replay.go
@@ -227,13 +227,15 @@ func (replayer *WalReplayer) Schedule(
 
 	go func() {
 		var err2 error
+		replayStartTime := time.Now()
 		defer func() {
 			logger := logutil.Info
 			if err2 != nil {
 				logger = logutil.Error
 			}
 			logger(
-				"Wal-Replay-Trace-End",
+				"Wal-Replay-Summary",
+				zap.Duration("total-cost", time.Since(replayStartTime)),
 				zap.Duration("apply-cost", replayer.applyDuration),
 				zap.Int("read-count", replayer.readCount),
 				zap.Int("apply-count", replayer.applyCount),


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16235

## What this PR does / why we need it:

Fix cdc panic due to UnsafeGetStringAt


___

### **PR Type**
Bug fix


___

### **Description**
- Replace unsafe string access with safe method calls

- Fix panic in CDC table scanner during row processing

- Change UnsafeGetStringAt to GetStringAt for three columns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TableDetector.scanTable()"] -- "ReadRows callback" --> B["Process row data"]
  B -- "Replace UnsafeGetStringAt" --> C["Use GetStringAt"]
  C -- "Safe string access" --> D["Prevent panic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>table_scanner.go</strong><dd><code>Replace unsafe string access with safe method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cdc/table_scanner.go

<ul><li>Replaced <code>UnsafeGetStringAt</code> with <code>GetStringAt</code> for table name column<br> <li> Replaced <code>UnsafeGetStringAt</code> with <code>GetStringAt</code> for database name column<br> <li> Replaced <code>UnsafeGetStringAt</code> with <code>GetStringAt</code> for create SQL column<br> <li> Improves safety by using bounds-checked string access method</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22652/files#diff-ff43b62d0f42085266c063c203474532c19fb2aeb3e6d390b187f63f5306af8b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

