### PR TITLE
Fix ExportToTableRangesByFilter

### DIFF
--- a/pkg/vm/engine/ckputil/meta.go
+++ b/pkg/vm/engine/ckputil/meta.go
@@ -178,8 +178,11 @@ func ExportToTableRangesByFilter(
 	startRows := vector.MustFixedColNoTypeCheck[types.Rowid](data.Vecs[2])
 	endRows := vector.MustFixedColNoTypeCheck[types.Rowid](data.Vecs[3])
 	for i, rows := start, data.RowCount(); i < rows; i++ {
-		if tableIds[i] != tableId || objectTypes[i] != objectType {
+		if tableIds[i] != tableId {
 			break
+		}
+		if objectTypes[i] != objectType {
+			continue
 		}
 		ranges = append(ranges, TableRange{
 			TableID:     tableId,


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22634

## What this PR does / why we need it:
Fix ExportToTableRangesByFilter


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed logic in `ExportToTableRangesByFilter` to correctly handle object type filtering

- Changed break condition to continue iteration when object type mismatches

- Separates table ID validation from object type validation for proper filtering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Loop through rows"] --> B{"tableIds[i] != tableId?"}
  B -->|Yes| C["Break loop"]
  B -->|No| D{"objectTypes[i] != objectType?"}
  D -->|Yes| E["Continue to next row"]
  D -->|No| F["Append to ranges"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>meta.go</strong><dd><code>Separate table ID and object type validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/ckputil/meta.go

<ul><li>Separated the combined break condition into two distinct checks<br> <li> Table ID mismatch now breaks the loop as before<br> <li> Object type mismatch now continues to next iteration instead of <br>breaking<br> <li> Allows rows with matching table ID but different object type to be <br>skipped while continuing the loop</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22668/files#diff-c32a4ceabd03aebb2d51fffcd3ab64f7b03fe2446a8410ed0c25d3c68aa8825f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

