### PR TITLE
Fix ss leak main

### DIFF
--- a/pkg/cnservice/distributed_tae.go
+++ b/pkg/cnservice/distributed_tae.go
@@ -100,6 +100,9 @@ func (s *service) initDistributedTAE(
 		return err
 	}
 
+	// Start unified GC scheduler
+	go cnEngine.RunGCScheduler(ctx)
+
 	ss, ok := runtime.ServiceRuntime(s.cfg.UUID).GetGlobalVariables(runtime.StatusServer)
 	if ok {
 		statusServer := ss.(*status.Server)

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -106,10 +106,9 @@ func New(
 			},
 		),
 	}
-	e.mu.snapParts = make(map[[2]uint64]*struct {
-		sync.Mutex
-		snaps []*logtailreplay.Partition
-	})
+	// Initialize snapshot manager
+	e.snapshotMgr = NewSnapshotManager()
+	e.snapshotMgr.Init()
 
 	pool, err := ants.NewPool(GCPoolSize)
 	if err != nil {

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -849,3 +849,46 @@ func (e *Engine) LatestLogtailAppliedTime() timestamp.Timestamp {
 func (e *Engine) HasTempEngine() bool {
 	return false
 }
+
+// RunGCScheduler runs all GC tasks in a single goroutine with different intervals
+func (e *Engine) RunGCScheduler(ctx context.Context) {
+	unusedTableTicker := time.NewTicker(unsubscribeProcessTicker)
+	partitionStateTicker := time.NewTicker(gcPartitionStateTicker)
+	snapshotTicker := time.NewTicker(gcSnapshotTicker)
+
+	defer unusedTableTicker.Stop()
+	defer partitionStateTicker.Stop()
+	defer snapshotTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			logutil.Infof("GC scheduler exit.")
+			return
+
+		case <-unusedTableTicker.C:
+			// GC unused tables in PushClient
+			e.pClient.TryGC(ctx)
+
+		case <-partitionStateTicker.C:
+			// GC partition states
+			e.gcPartitionState(ctx)
+
+		case <-snapshotTicker.C:
+			// GC snapshot partitions
+			e.snapshotMgr.MaybeStartGC()
+		}
+	}
+}
+
+// gcPartitionState runs GC for partition states
+func (e *Engine) gcPartitionState(ctx context.Context) {
+	if e.pClient.subscriber == nil {
+		return
+	}
+	if !e.pClient.receivedLogTailTime.ready.Load() {
+		return
+	}
+	logutil.Debugf("Running partition state GC")
+	e.pClient.doGCPartitionState(ctx, e)
+}

--- a/pkg/vm/engine/disttae/tracked_partitions.go
+++ b/pkg/vm/engine/disttae/tracked_partitions.go
@@ -1,0 +1,424 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disttae
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/logtailreplay"
+)
+
+// TrackedPartition wraps a partition with access tracking information
+type TrackedPartition struct {
+	partition  *logtailreplay.Partition
+	lastAccess atomic.Int64 // Unix timestamp in nanoseconds
+	createTime int64        // Unix timestamp in nanoseconds
+}
+
+// TrackedPartitions manages a collection of tracked partitions for a table
+type TrackedPartitions struct {
+	sync.Mutex
+	snaps   []*TrackedPartition
+	dbID    uint64
+	tableID uint64
+	metrics *SnapshotMetrics // pointer to engine's global metrics
+}
+
+// SnapshotManager manages all tracked partitions across all tables
+type SnapshotManager struct {
+	sync.Mutex
+	tables  map[[2]uint64]*TrackedPartitions
+	config  SnapshotGCConfig
+	state   SnapshotGCState
+	metrics SnapshotMetrics
+}
+
+// NewTrackedPartition creates a new TrackedPartition
+func NewTrackedPartition(partition *logtailreplay.Partition) *TrackedPartition {
+	now := time.Now().UnixNano()
+	tp := &TrackedPartition{
+		partition:  partition,
+		createTime: now,
+	}
+	tp.lastAccess.Store(now)
+	return tp
+}
+
+// GetPartition returns the underlying partition and updates access time
+func (tp *TrackedPartition) GetPartition() *logtailreplay.Partition {
+	tp.lastAccess.Store(time.Now().UnixNano())
+	return tp.partition
+}
+
+// GetLastAccessTime returns the last access time
+func (tp *TrackedPartition) GetLastAccessTime() time.Time {
+	return time.Unix(0, tp.lastAccess.Load())
+}
+
+// GetCreateTime returns the creation time
+func (tp *TrackedPartition) GetCreateTime() time.Time {
+	return time.Unix(0, tp.createTime)
+}
+
+// GetAge returns the age since last access
+func (tp *TrackedPartition) GetAge() time.Duration {
+	return time.Since(tp.GetLastAccessTime())
+}
+
+// NewSnapshotManager creates a new SnapshotManager
+func NewSnapshotManager() *SnapshotManager {
+	return &SnapshotManager{
+		tables: make(map[[2]uint64]*TrackedPartitions),
+		config: DefaultSnapshotGCConfig(),
+	}
+}
+
+// Init initializes the snapshot manager with configuration
+func (sm *SnapshotManager) Init() {
+	sm.state.lastGCTime.Store(time.Now().UnixNano())
+}
+
+// NewTrackedPartitions creates a new TrackedPartitions manager
+func NewTrackedPartitions(dbID, tableID uint64, metrics *SnapshotMetrics) *TrackedPartitions {
+	return &TrackedPartitions{
+		snaps:   make([]*TrackedPartition, 0),
+		dbID:    dbID,
+		tableID: tableID,
+		metrics: metrics,
+	}
+}
+
+// Find searches for a partition that can serve the given timestamp
+// Returns the partition state if found, or nil if not found
+// Automatically updates access time and metrics
+func (tp *TrackedPartitions) Find(ts types.TS) *logtailreplay.PartitionState {
+	tp.Lock()
+	defer tp.Unlock()
+
+	for _, trackedSnap := range tp.snaps {
+		partition := trackedSnap.GetPartition() // GetPartition auto-updates access time
+		if partition.Snapshot().CanServe(ts) {
+			// Update metrics
+			if tp.metrics != nil {
+				tp.metrics.SnapshotHits.Add(1)
+			}
+
+			logutil.Debug(
+				"Snapshot-Cache-Hit",
+				zap.Uint64("db-id", tp.dbID),
+				zap.Uint64("table-id", tp.tableID),
+				zap.String("ts", ts.ToString()),
+				zap.Time("last-access", trackedSnap.GetLastAccessTime()),
+			)
+
+			return partition.Snapshot()
+		}
+	}
+
+	// Cache miss
+	if tp.metrics != nil {
+		tp.metrics.SnapshotMisses.Add(1)
+	}
+
+	return nil
+}
+
+// Add adds a new tracked partition, enforcing the maximum count limit with LRU eviction
+// Returns the partition state of the added partition
+func (tp *TrackedPartitions) Add(
+	partition *logtailreplay.Partition,
+	tableName string,
+	ts types.TS,
+	maxCount int,
+) *logtailreplay.PartitionState {
+	tp.Lock()
+	defer tp.Unlock()
+
+	// Wrap partition with tracking information
+	trackedSnap := NewTrackedPartition(partition)
+
+	// Check if we need to evict old snapshots (LRU by count)
+	if len(tp.snaps) >= maxCount {
+		// Sort by last access time (oldest first)
+		sort.Slice(tp.snaps, func(i, j int) bool {
+			return tp.snaps[i].GetLastAccessTime().Before(
+				tp.snaps[j].GetLastAccessTime())
+		})
+
+		// Evict oldest snapshots
+		evictCount := len(tp.snaps) - maxCount + 1
+		for i := 0; i < evictCount; i++ {
+			evicted := tp.snaps[i]
+			logutil.Info(
+				"Snapshot-LRU-Evict",
+				zap.Uint64("db-id", tp.dbID),
+				zap.Uint64("table-id", tp.tableID),
+				zap.String("table-name", tableName),
+				zap.Duration("age", evicted.GetAge()),
+				zap.Time("last-access", evicted.GetLastAccessTime()),
+			)
+		}
+		tp.snaps = tp.snaps[evictCount:]
+
+		if tp.metrics != nil {
+			tp.metrics.LRUEvictions.Add(int64(evictCount))
+		}
+	}
+
+	// Add new snapshot
+	tp.snaps = append(tp.snaps, trackedSnap)
+
+	// Update metrics (SnapshotMisses already updated in Find method)
+	if tp.metrics != nil {
+		tp.metrics.SnapshotCreates.Add(1)
+		tp.metrics.TotalSnapshots.Add(1)
+	}
+
+	logutil.Info(
+		"Snapshot-Created",
+		zap.Uint64("db-id", tp.dbID),
+		zap.Uint64("table-id", tp.tableID),
+		zap.String("table-name", tableName),
+		zap.String("ts", ts.ToString()),
+		zap.Int("total-snaps-for-table", len(tp.snaps)),
+	)
+
+	return partition.Snapshot()
+}
+
+// GC removes partitions that haven't been accessed within maxAge
+// Returns the number of partitions removed
+func (tp *TrackedPartitions) GC(maxAge time.Duration) int {
+	tp.Lock()
+	defer tp.Unlock()
+
+	activeSnaps := make([]*TrackedPartition, 0, len(tp.snaps))
+	gcedCount := 0
+
+	for _, trackedSnap := range tp.snaps {
+		age := trackedSnap.GetAge()
+
+		if age > maxAge {
+			gcedCount++
+			logutil.Info(
+				"Snapshot-GC-Remove",
+				zap.Uint64("db-id", tp.dbID),
+				zap.Uint64("table-id", tp.tableID),
+				zap.Duration("age", age),
+				zap.Time("last-access", trackedSnap.GetLastAccessTime()),
+				zap.Time("create-time", trackedSnap.GetCreateTime()),
+			)
+		} else {
+			activeSnaps = append(activeSnaps, trackedSnap)
+		}
+	}
+
+	tp.snaps = activeSnaps
+
+	if tp.metrics != nil && gcedCount > 0 {
+		tp.metrics.AgeEvictions.Add(int64(gcedCount))
+		tp.metrics.SnapshotsGCed.Add(int64(gcedCount))
+		tp.metrics.TotalSnapshots.Add(-int64(gcedCount))
+	}
+
+	return gcedCount
+}
+
+// Count returns the current number of tracked partitions
+func (tp *TrackedPartitions) Count() int {
+	tp.Lock()
+	defer tp.Unlock()
+	return len(tp.snaps)
+}
+
+// ========== SnapshotManager Methods ==========
+
+// GetOrCreate gets or creates a TrackedPartitions for the given table
+func (sm *SnapshotManager) GetOrCreate(dbID, tableID uint64) *TrackedPartitions {
+	sm.Lock()
+	defer sm.Unlock()
+
+	key := [2]uint64{dbID, tableID}
+	tblSnaps, ok := sm.tables[key]
+	if !ok {
+		tblSnaps = NewTrackedPartitions(dbID, tableID, &sm.metrics)
+		sm.tables[key] = tblSnaps
+	}
+	return tblSnaps
+}
+
+// Find searches for a snapshot that can serve the given timestamp for a table
+func (sm *SnapshotManager) Find(dbID, tableID uint64, ts types.TS) *logtailreplay.PartitionState {
+	tblSnaps := sm.GetOrCreate(dbID, tableID)
+	return tblSnaps.Find(ts)
+}
+
+// Add adds a new partition to the manager for a table
+func (sm *SnapshotManager) Add(
+	dbID, tableID uint64,
+	partition *logtailreplay.Partition,
+	tableName string,
+	ts types.TS,
+) *logtailreplay.PartitionState {
+	tblSnaps := sm.GetOrCreate(dbID, tableID)
+	return tblSnaps.Add(partition, tableName, ts, sm.config.MaxSnapshotsPerTable)
+}
+
+// MaybeStartGC checks if GC should run and starts it if needed
+func (sm *SnapshotManager) MaybeStartGC() {
+	if !sm.config.Enabled {
+		return
+	}
+
+	// Check if enough time has passed since last GC
+	lastGCTime := time.Unix(0, sm.state.lastGCTime.Load())
+	if time.Since(lastGCTime) < sm.config.GCInterval {
+		return
+	}
+
+	// Check if GC is already running
+	if sm.state.gcRunning.Load() {
+		return
+	}
+
+	// Update last GC time and mark as running
+	sm.state.lastGCTime.Store(time.Now().UnixNano())
+	sm.state.gcRunning.Store(true)
+
+	// Run GC asynchronously
+	go func() {
+		defer sm.state.gcRunning.Store(false)
+		sm.RunGC()
+	}()
+}
+
+// RunGC performs garbage collection on all tracked partitions
+func (sm *SnapshotManager) RunGC() {
+	startTime := time.Now()
+	maxAge := sm.config.MaxAge
+
+	totalTables := 0
+	totalSnapsBefore := 0
+	totalSnapsAfter := 0
+	totalGCed := 0
+
+	logutil.Info("Snapshot-GC-Start",
+		zap.Duration("max-age", maxAge),
+		zap.Duration("gc-interval", sm.config.GCInterval),
+		zap.Int("max-snaps-per-table", sm.config.MaxSnapshotsPerTable),
+	)
+
+	// Get snapshot of all table keys to avoid holding global lock
+	sm.Lock()
+	tables := make([][2]uint64, 0, len(sm.tables))
+	for key := range sm.tables {
+		tables = append(tables, key)
+	}
+	sm.Unlock()
+
+	// Process each table
+	for _, tableKey := range tables {
+		sm.Lock()
+		tblSnaps, exists := sm.tables[tableKey]
+		sm.Unlock()
+
+		if !exists {
+			continue
+		}
+
+		beforeCount := tblSnaps.Count()
+		totalSnapsBefore += beforeCount
+		totalTables++
+
+		// GC expired snapshots
+		gcedCount := tblSnaps.GC(maxAge)
+		totalGCed += gcedCount
+
+		totalSnapsAfter += tblSnaps.Count()
+	}
+
+	duration := time.Since(startTime)
+
+	// Update metrics
+	sm.metrics.GCRuns.Add(1)
+	sm.metrics.LastGCDuration.Store(duration.Nanoseconds())
+
+	logutil.Info(
+		"Snapshot-GC-Complete",
+		zap.Int("total-tables", totalTables),
+		zap.Int("snaps-before", totalSnapsBefore),
+		zap.Int("snaps-after", totalSnapsAfter),
+		zap.Int("gced-snaps", totalGCed),
+		zap.Duration("duration", duration),
+		zap.Int64("total-gc-runs", sm.metrics.GCRuns.Load()),
+	)
+}
+
+// GetMetrics returns a pointer to current metrics
+func (sm *SnapshotManager) GetMetrics() *SnapshotMetrics {
+	return &sm.metrics
+}
+
+// GetConfig returns a copy of the configuration
+func (sm *SnapshotManager) GetConfig() SnapshotGCConfig {
+	return sm.config
+}
+
+// SnapshotGCConfig holds configuration for snapshot GC
+type SnapshotGCConfig struct {
+	Enabled              bool          // Whether snapshot GC is enabled
+	GCInterval           time.Duration // Interval between GC runs
+	MaxAge               time.Duration // Max age for inactive snapshots
+	MaxSnapshotsPerTable int           // Max snapshots per table
+	MaxTotalSnapshots    int           // Max total snapshots across all tables
+}
+
+// DefaultSnapshotGCConfig returns the default configuration
+func DefaultSnapshotGCConfig() SnapshotGCConfig {
+	return SnapshotGCConfig{
+		Enabled:              true,
+		GCInterval:           30 * time.Minute,
+		MaxAge:               5 * time.Hour,
+		MaxSnapshotsPerTable: 20,
+		MaxTotalSnapshots:    1000,
+	}
+}
+
+// SnapshotGCState holds the runtime state for snapshot GC
+type SnapshotGCState struct {
+	lastGCTime atomic.Int64 // Unix timestamp in nanoseconds
+	gcRunning  atomic.Bool  // Whether GC is currently running
+}
+
+// SnapshotMetrics holds metrics for snapshot management
+type SnapshotMetrics struct {
+	TotalSnapshots  atomic.Int64 // Current total snapshots
+	TotalTables     atomic.Int64 // Current tables with snapshots
+	GCRuns          atomic.Int64 // Total GC runs
+	SnapshotsGCed   atomic.Int64 // Total snapshots GCed
+	LastGCDuration  atomic.Int64 // Last GC duration in nanoseconds
+	SnapshotHits    atomic.Int64 // Snapshot cache hits (reuse)
+	SnapshotMisses  atomic.Int64 // Snapshot cache misses (create)
+	SnapshotCreates atomic.Int64 // Total snapshots created
+	LRUEvictions    atomic.Int64 // Evictions due to count limit
+	AgeEvictions    atomic.Int64 // Evictions due to age limit
+}

--- a/pkg/vm/engine/disttae/tracked_partitions_test.go
+++ b/pkg/vm/engine/disttae/tracked_partitions_test.go
@@ -1,0 +1,674 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disttae
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/logtailreplay"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMockPartition creates a partition for testing
+// Note: The partition's PartitionState is initialized but doesn't have checkpoint data
+// so CanServe will work based on the internal state's timestamp range
+func newMockPartition(tableID uint64) *logtailreplay.Partition {
+	// Use the real NewPartition to create a properly initialized partition
+	p := logtailreplay.NewPartition("test_service", tableID)
+	return p
+}
+
+// TestTrackedPartition tests the TrackedPartition structure
+func TestTrackedPartition(t *testing.T) {
+	t.Run("NewTrackedPartition", func(t *testing.T) {
+		p := newMockPartition(100)
+		tp := NewTrackedPartition(p)
+
+		assert.NotNil(t, tp)
+		assert.Equal(t, p, tp.partition)
+		assert.True(t, tp.createTime > 0)
+		assert.False(t, tp.GetLastAccessTime().IsZero())
+	})
+
+	t.Run("GetPartition_UpdatesAccessTime", func(t *testing.T) {
+		p := newMockPartition(100)
+		tp := NewTrackedPartition(p)
+
+		// Manually set an old access time
+		oldTime := time.Now().Add(-1 * time.Hour).UnixNano()
+		tp.lastAccess.Store(oldTime)
+
+		// GetPartition should update access time to current time
+		retrieved := tp.GetPartition()
+		assert.Equal(t, p, retrieved)
+
+		newAccessTime := tp.lastAccess.Load()
+		assert.True(t, newAccessTime > oldTime, "Access time should be updated")
+		// Verify it's recent (within last second)
+		assert.True(t, newAccessTime >= time.Now().Add(-1*time.Second).UnixNano(),
+			"Access time should be recent")
+	})
+
+	t.Run("GetAge", func(t *testing.T) {
+		p := newMockPartition(100)
+		tp := NewTrackedPartition(p)
+
+		// Set last access time to 1 hour ago (GetAge measures since last access)
+		oneHourAgo := time.Now().Add(-1 * time.Hour)
+		tp.lastAccess.Store(oneHourAgo.UnixNano())
+
+		// Calculate age (time since last access)
+		age := tp.GetAge()
+
+		// Age should be very close to 1 hour
+		// Allow for small variance due to execution time
+		expectedAge := time.Since(oneHourAgo)
+		diff := age - expectedAge
+		if diff < 0 {
+			diff = -diff
+		}
+		assert.True(t, diff < 100*time.Millisecond,
+			"Age difference too large: expected ~%v, got %v, diff %v",
+			expectedAge, age, diff)
+	})
+
+	t.Run("ConcurrentGetPartition", func(t *testing.T) {
+		p := newMockPartition(100)
+		tp := NewTrackedPartition(p)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				retrieved := tp.GetPartition()
+				assert.Equal(t, p, retrieved)
+			}()
+		}
+		wg.Wait()
+
+		assert.False(t, tp.GetLastAccessTime().IsZero())
+	})
+}
+
+// TestTrackedPartitions tests the TrackedPartitions structure
+func TestTrackedPartitions(t *testing.T) {
+	t.Run("NewTrackedPartitions", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		assert.NotNil(t, tps)
+		assert.Equal(t, uint64(1), tps.dbID)
+		assert.Equal(t, uint64(100), tps.tableID)
+		assert.Equal(t, metrics, tps.metrics)
+		assert.Equal(t, 0, len(tps.snaps))
+	})
+
+	t.Run("Add_SingleSnapshot", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		p := newMockPartition(100)
+		ts := types.BuildTS(150, 0)
+
+		ps := tps.Add(p, "test_table", ts, 10)
+
+		assert.NotNil(t, ps)
+		assert.Equal(t, 1, tps.Count())
+		assert.Equal(t, int64(1), metrics.SnapshotCreates.Load())
+		assert.Equal(t, int64(1), metrics.TotalSnapshots.Load())
+	})
+
+	t.Run("Add_LRU_Eviction", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		// Add 3 snapshots with maxCount=2, with manually set access times
+		p1 := newMockPartition(100)
+		p2 := newMockPartition(101)
+		p3 := newMockPartition(102)
+
+		now := time.Now()
+
+		// Add p1 and set its access time to 2 hours ago (oldest)
+		tps.Lock()
+		tp1 := NewTrackedPartition(p1)
+		tp1.lastAccess.Store(now.Add(-2 * time.Hour).UnixNano())
+		tps.snaps = append(tps.snaps, tp1)
+		metrics.SnapshotCreates.Add(1)
+		metrics.TotalSnapshots.Add(1)
+		tps.Unlock()
+
+		// Add p2 and set its access time to 1 hour ago
+		tps.Lock()
+		tp2 := NewTrackedPartition(p2)
+		tp2.lastAccess.Store(now.Add(-1 * time.Hour).UnixNano())
+		tps.snaps = append(tps.snaps, tp2)
+		metrics.SnapshotCreates.Add(1)
+		metrics.TotalSnapshots.Add(1)
+		tps.Unlock()
+
+		// Now add p3, which should trigger LRU eviction of p1 (oldest)
+		tps.Add(p3, "table", types.BuildTS(350, 0), 2)
+
+		assert.Equal(t, 2, tps.Count(), "Should maintain max count of 2")
+		assert.Equal(t, int64(1), metrics.LRUEvictions.Load(), "Should have 1 LRU eviction")
+		assert.Equal(t, int64(2), metrics.TotalSnapshots.Load(), "Total should be 2 after eviction")
+	})
+
+	t.Run("Find_WithRealPartition", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		// Add a partition
+		p := newMockPartition(100)
+		added := tps.Add(p, "table", types.BuildTS(100, 0), 10)
+		assert.NotNil(t, added)
+
+		// Note: Find relies on PartitionState.CanServe() which checks internal timestamp ranges
+		// The real partition's initial state may or may not serve specific timestamps
+		// depending on its internal state. This is a limitation of using real partitions
+		// without checkpoint data. However, we can verify the structure works.
+
+		// Try to find - it may or may not find depending on partition state
+		result := tps.Find(types.BuildTS(100, 0))
+		// Either found or not found is acceptable here since we're testing structure
+		// The key is that it doesn't panic and metrics are updated
+		if result != nil {
+			assert.Equal(t, int64(1), metrics.SnapshotHits.Load(), "Should record a hit")
+		} else {
+			assert.Equal(t, int64(1), metrics.SnapshotMisses.Load(), "Should record a miss")
+		}
+	})
+
+	t.Run("Find_NotFound", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		// Try to find in empty list
+		ps := tps.Find(types.BuildTS(150, 0))
+		assert.Nil(t, ps)
+		assert.Equal(t, int64(1), metrics.SnapshotMisses.Load())
+	})
+
+	t.Run("GC_RemoveOldSnapshots", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		// Add snapshots with old last access times (GC checks lastAccessTime via GetAge)
+		p1 := newMockPartition(100)
+		p2 := newMockPartition(101)
+
+		now := time.Now()
+
+		// Add p1 with last access time 2 hours ago
+		tps.Lock()
+		tp1 := NewTrackedPartition(p1)
+		tp1.lastAccess.Store(now.Add(-2 * time.Hour).UnixNano())
+		tps.snaps = append(tps.snaps, tp1)
+		metrics.SnapshotCreates.Add(1)
+		metrics.TotalSnapshots.Add(1)
+		tps.Unlock()
+
+		// Add p2 with last access time 2 hours ago
+		tps.Lock()
+		tp2 := NewTrackedPartition(p2)
+		tp2.lastAccess.Store(now.Add(-2 * time.Hour).UnixNano())
+		tps.snaps = append(tps.snaps, tp2)
+		metrics.SnapshotCreates.Add(1)
+		metrics.TotalSnapshots.Add(1)
+		tps.Unlock()
+
+		// GC with maxAge of 1 hour should remove both (they haven't been accessed in 2 hours)
+		gcCount := tps.GC(1 * time.Hour)
+
+		assert.Equal(t, 2, gcCount, "Should have GCed 2 snapshots")
+		assert.Equal(t, 0, tps.Count(), "All snapshots should be GCed")
+		assert.Equal(t, int64(2), metrics.AgeEvictions.Load(), "Should have 2 age evictions")
+		assert.Equal(t, int64(2), metrics.SnapshotsGCed.Load(), "Should have GCed 2 snapshots")
+		assert.Equal(t, int64(0), metrics.TotalSnapshots.Load(), "Total snapshots should be 0")
+	})
+
+	t.Run("GC_KeepRecentSnapshots", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		// Add a snapshot
+		p := newMockPartition(100)
+		tps.Add(p, "table", types.BuildTS(150, 0), 10)
+
+		// GC with maxAge of 1 hour should keep it
+		tps.GC(1 * time.Hour)
+
+		assert.Equal(t, 1, tps.Count(), "Recent snapshot should be kept")
+		assert.Equal(t, int64(0), metrics.AgeEvictions.Load(), "Should have no age evictions")
+	})
+
+	t.Run("ConcurrentAddAndFind", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		var wg sync.WaitGroup
+
+		// Concurrent adds
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				p := newMockPartition(uint64(100 + idx))
+				tps.Add(p, "table", types.BuildTS(int64(100*idx+50), 0), 100)
+			}(i)
+		}
+
+		// Concurrent finds
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				tps.Find(types.BuildTS(int64(100*idx+50), 0))
+			}(i)
+		}
+
+		wg.Wait()
+
+		assert.Equal(t, 10, tps.Count(), "Should have 10 snapshots")
+		assert.Equal(t, int64(10), metrics.SnapshotCreates.Load(), "Should have created exactly 10 snapshots")
+	})
+}
+
+// TestSnapshotManager tests the SnapshotManager structure
+func TestSnapshotManager(t *testing.T) {
+	t.Run("NewSnapshotManager", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+
+		assert.NotNil(t, mgr)
+		assert.NotNil(t, mgr.tables)
+		assert.Equal(t, 20, mgr.config.MaxSnapshotsPerTable)
+		assert.Equal(t, 5*time.Hour, mgr.config.MaxAge)
+	})
+
+	t.Run("Init", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		assert.True(t, mgr.state.lastGCTime.Load() > 0)
+	})
+
+	t.Run("GetOrCreate_NewTable", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		tps := mgr.GetOrCreate(1, 100)
+
+		assert.NotNil(t, tps)
+		assert.Equal(t, uint64(1), tps.dbID)
+		assert.Equal(t, uint64(100), tps.tableID)
+	})
+
+	t.Run("GetOrCreate_ExistingTable", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		tps1 := mgr.GetOrCreate(1, 100)
+		tps2 := mgr.GetOrCreate(1, 100)
+
+		assert.Equal(t, tps1, tps2, "Should return the same instance")
+	})
+
+	t.Run("Add_NewSnapshot", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		p := newMockPartition(100)
+		ps := mgr.Add(1, 100, p, "test_table", types.BuildTS(150, 0))
+
+		assert.NotNil(t, ps)
+		assert.Equal(t, int64(1), mgr.metrics.SnapshotCreates.Load())
+		assert.Equal(t, int64(1), mgr.metrics.TotalSnapshots.Load())
+	})
+
+	t.Run("Find_WithRealPartition", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		// Add a snapshot
+		p := newMockPartition(100)
+		added := mgr.Add(1, 100, p, "test_table", types.BuildTS(150, 0))
+		assert.NotNil(t, added)
+
+		// Try to find it
+		ps := mgr.Find(1, 100, types.BuildTS(150, 0))
+		// Similar to TrackedPartitions test - result depends on partition's internal state
+		// But we verify that Find doesn't panic and returns a valid result (nil or non-nil)
+		if ps != nil {
+			assert.Equal(t, int64(1), mgr.metrics.SnapshotHits.Load(), "Should record a hit")
+		} else {
+			assert.Equal(t, int64(1), mgr.metrics.SnapshotMisses.Load(), "Should record a miss")
+		}
+	})
+
+	t.Run("Find_NonExistentTable", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		ps := mgr.Find(1, 999, types.BuildTS(150, 0))
+		assert.Nil(t, ps)
+	})
+
+	t.Run("MaybeStartGC_FirstTime", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		// Reset last GC time to trigger GC
+		mgr.state.lastGCTime.Store(0)
+
+		mgr.MaybeStartGC()
+
+		// Use require.Eventually to wait for goroutine to complete
+		// This is deterministic - it polls until condition is met or times out
+		require.Eventually(t, func() bool {
+			return mgr.state.lastGCTime.Load() > 0
+		}, 2*time.Second, 10*time.Millisecond, "lastGCTime should be updated after GC")
+	})
+
+	t.Run("MaybeStartGC_TooSoon", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		// Set last GC time to now
+		mgr.state.lastGCTime.Store(time.Now().UnixNano())
+
+		initialTime := mgr.state.lastGCTime.Load()
+		mgr.MaybeStartGC()
+
+		// Should not have changed
+		assert.Equal(t, initialTime, mgr.state.lastGCTime.Load())
+	})
+
+	t.Run("RunGC", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		now := time.Now()
+
+		// Add snapshots with old last access times directly (GC checks lastAccessTime)
+		for i := 0; i < 3; i++ {
+			p := newMockPartition(uint64(100 + i))
+			tps := mgr.GetOrCreate(1, uint64(100+i))
+
+			tps.Lock()
+			tp := NewTrackedPartition(p)
+			tp.lastAccess.Store(now.Add(-2 * time.Hour).UnixNano())
+			tps.snaps = append(tps.snaps, tp)
+			mgr.metrics.SnapshotCreates.Add(1)
+			mgr.metrics.TotalSnapshots.Add(1)
+			tps.Unlock()
+		}
+
+		assert.Equal(t, int64(3), mgr.metrics.TotalSnapshots.Load())
+
+		// Run GC with maxAge of 1 hour should remove all (not accessed in 2 hours)
+		mgr.config.MaxAge = 1 * time.Hour
+		mgr.RunGC()
+
+		assert.Equal(t, int64(0), mgr.metrics.TotalSnapshots.Load(), "All snapshots should be removed")
+		assert.Equal(t, int64(3), mgr.metrics.SnapshotsGCed.Load(), "Should have GCed exactly 3 snapshots")
+	})
+
+	t.Run("GetMetrics", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		metrics := mgr.GetMetrics()
+		assert.NotNil(t, metrics)
+		assert.Equal(t, int64(0), metrics.TotalSnapshots.Load())
+	})
+
+	t.Run("GetConfig", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		config := mgr.GetConfig()
+		assert.NotNil(t, config)
+		assert.Equal(t, 20, config.MaxSnapshotsPerTable)
+	})
+
+	t.Run("ConcurrentOperations", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		var wg sync.WaitGroup
+
+		// Concurrent adds to different tables
+		// Using idx%3 for dbID and idx%5 for tableID
+		// This creates 3*5=15 unique (dbID, tableID) combinations
+		// But we add 20 times, so some tables will get multiple snapshots
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				dbID := uint64(1 + idx%3)      // 3 unique dbIDs: 1, 2, 3
+				tableID := uint64(100 + idx%5) // 5 unique tableIDs: 100-104
+				p := newMockPartition(uint64(100 + idx))
+				mgr.Add(dbID, tableID, p, "test_table", types.BuildTS(int64(100*idx+50), 0))
+			}(i)
+		}
+
+		// Concurrent finds
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				dbID := uint64(1 + idx%3)
+				tableID := uint64(100 + idx%5)
+				mgr.Find(dbID, tableID, types.BuildTS(int64(100*idx+50), 0))
+			}(i)
+		}
+
+		// Concurrent GC calls
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				mgr.MaybeStartGC()
+			}()
+		}
+
+		wg.Wait()
+
+		// We added 20 snapshots across 15 unique tables (3 dbIDs × 5 tableIDs)
+		// Each Add creates a snapshot, so we should have exactly 20 creates
+		assert.Equal(t, int64(20), mgr.metrics.SnapshotCreates.Load(), "Should have created exactly 20 snapshots")
+		// Total snapshots should be 20 (no evictions expected with default config)
+		assert.Equal(t, int64(20), mgr.metrics.TotalSnapshots.Load(), "Should have 20 total snapshots")
+	})
+}
+
+// TestSnapshotMetrics tests the metrics tracking
+func TestSnapshotMetrics(t *testing.T) {
+	t.Run("MetricsInitialization", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+
+		assert.Equal(t, int64(0), metrics.SnapshotHits.Load())
+		assert.Equal(t, int64(0), metrics.SnapshotMisses.Load())
+		assert.Equal(t, int64(0), metrics.SnapshotCreates.Load())
+		assert.Equal(t, int64(0), metrics.TotalSnapshots.Load())
+		assert.Equal(t, int64(0), metrics.LRUEvictions.Load())
+		assert.Equal(t, int64(0), metrics.AgeEvictions.Load())
+		assert.Equal(t, int64(0), metrics.SnapshotsGCed.Load())
+	})
+
+	t.Run("MetricsIncrement", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+
+		metrics.SnapshotHits.Add(1)
+		metrics.SnapshotMisses.Add(1)
+		metrics.SnapshotCreates.Add(1)
+		metrics.TotalSnapshots.Add(1)
+
+		assert.Equal(t, int64(1), metrics.SnapshotHits.Load())
+		assert.Equal(t, int64(1), metrics.SnapshotMisses.Load())
+		assert.Equal(t, int64(1), metrics.SnapshotCreates.Load())
+		assert.Equal(t, int64(1), metrics.TotalSnapshots.Load())
+	})
+
+	t.Run("MetricsConcurrentIncrement", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				metrics.SnapshotHits.Add(1)
+				metrics.SnapshotMisses.Add(1)
+				metrics.SnapshotCreates.Add(1)
+			}()
+		}
+		wg.Wait()
+
+		assert.Equal(t, int64(100), metrics.SnapshotHits.Load())
+		assert.Equal(t, int64(100), metrics.SnapshotMisses.Load())
+		assert.Equal(t, int64(100), metrics.SnapshotCreates.Load())
+	})
+}
+
+// TestSnapshotGCConfig tests the GC configuration
+func TestSnapshotGCConfig(t *testing.T) {
+	t.Run("DefaultConfig", func(t *testing.T) {
+		config := DefaultSnapshotGCConfig()
+
+		assert.Equal(t, true, config.Enabled)
+		assert.Equal(t, 30*time.Minute, config.GCInterval)
+		assert.Equal(t, 5*time.Hour, config.MaxAge)
+		assert.Equal(t, 20, config.MaxSnapshotsPerTable)
+		assert.Equal(t, 1000, config.MaxTotalSnapshots)
+	})
+
+	t.Run("CustomConfig", func(t *testing.T) {
+		config := SnapshotGCConfig{
+			Enabled:              false,
+			GCInterval:           1 * time.Minute,
+			MaxAge:               2 * time.Hour,
+			MaxSnapshotsPerTable: 10,
+			MaxTotalSnapshots:    500,
+		}
+
+		assert.Equal(t, false, config.Enabled)
+		assert.Equal(t, 1*time.Minute, config.GCInterval)
+		assert.Equal(t, 2*time.Hour, config.MaxAge)
+		assert.Equal(t, 10, config.MaxSnapshotsPerTable)
+		assert.Equal(t, 500, config.MaxTotalSnapshots)
+	})
+}
+
+// TestEdgeCases tests various edge cases
+func TestEdgeCases(t *testing.T) {
+	t.Run("Add_WithZeroMaxCount", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		p := newMockPartition(100)
+		ps := tps.Add(p, "table", types.BuildTS(150, 0), 0)
+
+		assert.NotNil(t, ps)
+		assert.Equal(t, 1, tps.Count(), "Should add even with maxCount=0")
+	})
+
+	t.Run("GC_WithZeroAge", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		p := newMockPartition(100)
+		tps.Add(p, "table", types.BuildTS(150, 0), 10)
+
+		// GC with 0 age should remove all
+		tps.GC(0)
+
+		assert.Equal(t, 0, tps.Count())
+	})
+
+	t.Run("EmptyTableGC", func(t *testing.T) {
+		metrics := &SnapshotMetrics{}
+		tps := NewTrackedPartitions(1, 100, metrics)
+
+		// GC on empty table should not panic
+		tps.GC(1 * time.Hour)
+
+		assert.Equal(t, 0, tps.Count())
+	})
+
+	t.Run("ManagerGC_NoTables", func(t *testing.T) {
+		mgr := NewSnapshotManager()
+		mgr.Init()
+
+		// RunGC on empty manager should not panic
+		mgr.RunGC()
+
+		assert.Equal(t, int64(0), mgr.metrics.SnapshotsGCed.Load())
+	})
+}
+
+// Benchmark tests
+func BenchmarkTrackedPartitionGetPartition(b *testing.B) {
+	p := newMockPartition(100)
+	tp := NewTrackedPartition(p)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tp.GetPartition()
+	}
+}
+
+func BenchmarkTrackedPartitionsAdd(b *testing.B) {
+	metrics := &SnapshotMetrics{}
+	tps := NewTrackedPartitions(1, 100, metrics)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := newMockPartition(uint64(100 + i))
+		tps.Add(p, "table", types.BuildTS(int64(100*i+50), 0), 1000)
+	}
+}
+
+func BenchmarkSnapshotManagerAdd(b *testing.B) {
+	mgr := NewSnapshotManager()
+	mgr.Init()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := newMockPartition(uint64(100 + i))
+		mgr.Add(1, uint64(100+i%10), p, "table", types.BuildTS(int64(100*i+50), 0))
+	}
+}
+
+func BenchmarkSnapshotManagerConcurrentAdd(b *testing.B) {
+	mgr := NewSnapshotManager()
+	mgr.Init()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			p := newMockPartition(uint64(100 + i))
+			mgr.Add(1, uint64(100+i%10), p, "table", types.BuildTS(int64(100*i+50), 0))
+			i++
+		}
+	})
+}

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -244,14 +244,9 @@ type Engine struct {
 	catalog atomic.Pointer[cache.CatalogCache]
 	//latest partitions which be protected by e.Lock().
 	partitions map[[2]uint64]*logtailreplay.Partition
-	//snapshot partitions
-	mu struct {
-		sync.Mutex
-		snapParts map[[2]uint64]*struct {
-			sync.Mutex
-			snaps []*logtailreplay.Partition
-		}
-	}
+
+	//snapshot partitions manager
+	snapshotMgr *SnapshotManager
 
 	packerPool *fileservice.Pool[*types.Packer]
 

--- a/pkg/vm/engine/test/testutil/disttae_engine.go
+++ b/pkg/vm/engine/test/testutil/disttae_engine.go
@@ -216,9 +216,15 @@ func NewTestDisttaeEngine(
 	setServerLevelParams(de)
 
 	// InitLoTailPushModel presupposes that the internal sql executor has been initialized.
-	err = de.Engine.InitLogTailPushModel(de.ctx, de.timestampWaiter)
+	if err = de.Engine.InitLogTailPushModel(de.ctx, de.timestampWaiter); err != nil {
+		return de, err
+	}
+
+	// Start unified GC scheduler
+	go de.Engine.RunGCScheduler(de.ctx)
+
 	//err = de.prevSubscribeSysTables(ctx, rpcAgent)
-	return de, err
+	return de, nil
 }
 func (de *TestDisttaeEngine) GetTxnClient() client.TxnClient {
 	return de.txnClient


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22666 

## What this PR does / why we need it:

Fix ss leak main


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implement unified GC scheduler to consolidate multiple goroutines into single scheduler

- Replace manual snapshot partition management with new SnapshotManager for better lifecycle control

- Add LRU eviction and age-based garbage collection for snapshot partitions

- Introduce comprehensive metrics tracking for snapshot cache performance and GC operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Engine Initialization"] -->|"RunGCScheduler"| B["Unified GC Scheduler"]
  B -->|"Ticker: 20min"| C["Unused Table GC"]
  B -->|"Ticker: 20min"| D["Partition State GC"]
  B -->|"Ticker: 20min"| E["Snapshot GC"]
  F["Snapshot Operations"] -->|"Find/Add"| G["SnapshotManager"]
  G -->|"LRU + Age-based"| H["TrackedPartitions"]
  H -->|"Metrics"| I["SnapshotMetrics"]
  E -->|"MaybeStartGC"| G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracked_partitions.go</strong><dd><code>New snapshot manager with LRU and age-based GC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/tracked_partitions.go

<ul><li>New file implementing SnapshotManager for centralized snapshot <br>partition lifecycle management<br> <li> Provides TrackedPartition wrapper with access time tracking for LRU <br>eviction<br> <li> Implements Find/Add operations with automatic metrics collection<br> <li> Includes GC with both age-based and count-based (LRU) eviction <br>strategies<br> <li> Defines SnapshotGCConfig and SnapshotMetrics for configuration and <br>observability</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22669/files#diff-4e95e3725ffca9fb2b7e548cfb060a0772996e19b8101647ec2864c7d97e8995">+426/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>engine.go</strong><dd><code>Integrate unified GC scheduler into engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/engine.go

<ul><li>Replace manual snapParts map with SnapshotManager initialization<br> <li> Add RunGCScheduler method that consolidates three separate GC <br>goroutines into single scheduler<br> <li> Add gcPartitionState helper method for partition state garbage <br>collection<br> <li> Remove individual GC ticker goroutines from InitLogTailPushModel</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22669/files#diff-66bacd74568edffe090130ffc5d235b4771a4707612b56145288d4e7119be4a2">+46/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logtail_consumer.go</strong><dd><code>Remove individual GC goroutines from push client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/logtail_consumer.go

<ul><li>Add gcSnapshotTicker constant for snapshot GC interval<br> <li> Add TryGC method to PushClient for conditional GC execution<br> <li> Remove individual GC ticker goroutines from InitLogTailPushModel<br> <li> Consolidate GC logic into unified scheduler pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22669/files#diff-e17810b9da4ab05c897d8066bbc421520cdaea7c577d50dc64b31ec3aa8d295f">+13/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Replace manual snapshot map with manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/types.go

<ul><li>Replace manual snapParts map structure with SnapshotManager pointer<br> <li> Remove nested sync.Mutex and partition slice from Engine struct<br> <li> Simplify snapshot partition management through manager abstraction</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22669/files#diff-2d4ca99c63be4d7a3464a5089669767530c849522edfe3030145a5b059775852">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>disttae_engine.go</strong><dd><code>Start GC scheduler in test engine initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/test/testutil/disttae_engine.go

<ul><li>Add RunGCScheduler call after InitLogTailPushModel in test engine <br>setup<br> <li> Improve error handling for InitLogTailPushModel initialization<br> <li> Ensure GC scheduler is started in test environment</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22669/files#diff-765d649f17022692f02eb0a5415f39f15cd1c27c804457874e33730cf440e285">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>distributed_tae.go</strong><dd><code>Start unified GC scheduler in service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/cnservice/distributed_tae.go

<ul><li>Add RunGCScheduler call after InitLogTailPushModel in service <br>initialization<br> <li> Start unified GC scheduler as separate goroutine</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22669/files#diff-f6e698740fe49564af6e68322725db22f8ed76b887e6024e95f0e1a48a70b7aa">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tracked_partitions_test.go</strong><dd><code>Complete test coverage for snapshot manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/tracked_partitions_test.go

<ul><li>Comprehensive test suite for TrackedPartition, TrackedPartitions, and <br>SnapshotManager<br> <li> Tests for LRU eviction, age-based GC, concurrent operations, and <br>metrics tracking<br> <li> Includes benchmark tests for performance validation<br> <li> Tests edge cases like zero maxCount and empty table GC</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22669/files#diff-182794cf8684d4390ea81d9de0c040c16ac3352d75d1a53eb7f518dd9b1e21d8">+678/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>db.go</strong><dd><code>Refactor snapshot partition caching to use manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/db.go

<ul><li>Replace manual snapshot partition caching logic with <br>SnapshotManager.Find/Add calls<br> <li> Remove sync.Mutex and nested struct for manual snapshot management<br> <li> Update error logging to use zap structured logging<br> <li> Add snapshot GC trigger via MaybeStartGC after adding new snapshots<br> <li> Remove panic path and add proper error handling for snapshot creation <br>failures</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22669/files#diff-510a93692a080e19d5377a183f951910b64d0f4ce39c0ac7607b6c7f9b64ccaf">+31/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

