### PR TITLE
retry newClient

### DIFF
--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool.go
@@ -121,7 +121,7 @@ type wrappedClient struct {
 	writeToken uint64
 }
 
-func newClient(
+func NewClient(
 	factory LogServiceClientFactory, bufSize int, retryTimes int, retryInterval, retryDuration time.Duration,
 ) *wrappedClient {
 	var (
@@ -255,7 +255,7 @@ func newClientPool(cfg *Config) *clientPool {
 	}
 
 	for i := 0; i < cfg.ClientMaxCount; i++ {
-		pool.clients[i] = newClient(cfg.ClientFactory, cfg.ClientBufSize, DefaultRetryTimes, DefaultRetryInterval, DefaultRetryDuration)
+		pool.clients[i] = NewClient(cfg.ClientFactory, cfg.ClientBufSize, DefaultRetryTimes, DefaultRetryInterval, DefaultRetryDuration)
 	}
 	return pool
 }
@@ -288,7 +288,7 @@ func (c *clientPool) GetOnFly() (*wrappedClient, error) {
 	if c.closed {
 		return nil, ErrClientPoolClosed
 	}
-	client := newClient(c.cfg.ClientFactory, c.cfg.ClientBufSize, DefaultRetryTimes, DefaultRetryInterval, DefaultRetryDuration)
+	client := NewClient(c.cfg.ClientFactory, c.cfg.ClientBufSize, DefaultRetryTimes, DefaultRetryInterval, DefaultRetryDuration)
 	return client, nil
 }
 

--- a/pkg/vm/engine/tae/logstore/store_test.go
+++ b/pkg/vm/engine/tae/logstore/store_test.go
@@ -1,0 +1,71 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lni/vfs"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/logservice"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/util/fault"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logstore/driver/logservicedriver"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func initTest(t *testing.T) (*logservice.Service, *logservice.ClientConfig) {
+	runtime.SetupServiceBasedRuntime("", runtime.DefaultRuntime())
+	fs := vfs.NewStrictMem()
+	service, ccfg, err := logservice.NewTestService(fs)
+	assert.NoError(t, err)
+	return service, &ccfg
+}
+
+func TestNewClientFailed(t *testing.T) {
+
+	service, ccfg := initTest(t)
+	defer service.Close()
+
+	fault.Enable()
+	defer fault.Disable()
+	rmFn, err := objectio.InjectWALReplayFailed("new client")
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+	idx := 0
+	mockFactory := func() (logservice.Client, error) {
+
+		if idx > 10 {
+			rmFn()
+		}
+		idx++
+		var client logservice.Client
+		var err error
+		if msg, injected := objectio.WALReplayFailedExecutorInjected(); injected && msg == "new client" {
+			err = moerr.NewInternalErrorNoCtx("mock error")
+		} else {
+
+			client, err = logservice.NewClient(ctx, "", *ccfg)
+		}
+		return client, err
+	}
+	logservicedriver.NewClient(mockFactory, 100, 100, time.Millisecond*100, time.Minute*5)
+}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22671 

## What this PR does / why we need it:
retry newClient


___

### **PR Type**
Bug fix


___

### **Description**
- Add retry logic to `newClient` function with configurable retry parameters

- Introduce WAL replay failure injection points for testing resilience

- Add test case for client creation failure scenarios with retry mechanism

- Define retry constants: 5-minute duration, 300 attempts, 1-second intervals


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["newClient function"] -->|"add retry loop"| B["Retry with backoff"]
  B -->|"success"| C["Return wrapped client"]
  B -->|"timeout/max retries"| D["Panic on error"]
  E["Fault injection points"] -->|"WALReplayFailed"| F["Test client failures"]
  F -->|"mockFactory"| G["TestNewClientFailed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>injects.go</strong><dd><code>Add WAL replay failure fault injection support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/injects.go

<ul><li>Add new fault injection point constant <code>FJ_WALReplayFailed</code> for WAL <br>replay failures<br> <li> Implement <code>WALReplayFailedExecutorInjected()</code> function to check if fault <br>is triggered<br> <li> Implement <code>InjectWALReplayFailed()</code> function to inject WAL replay <br>failures for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22672/files#diff-05347be6ac14225e17480783b255bb81ede750eaee4a6d4146af7d2005d507f4">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clientpool.go</strong><dd><code>Implement retry logic for log service client creation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool.go

<ul><li>Add three retry constants: <code>DefaultRetryDuration</code> (5 minutes), <br><code>DefaultRetryTimes</code> (300), <code>DefaultRetryInterval</code> (1 second)<br> <li> Implement retry loop in <code>newClient()</code> function with time-based and <br>attempt-based limits<br> <li> Log errors during client creation failures with <code>logutil.Errorf()</code><br> <li> Update all <code>newClient()</code> calls to pass retry parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22672/files#diff-e3d1fd613cbdade8761171f2eff93cc208ebf1098ac3eb67ec4102c96b307fd5">+21/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>driver_test.go</strong><dd><code>Add test for client creation retry mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logstore/driver/logservicedriver/driver_test.go

<ul><li>Add imports for <code>time</code>, <code>moerr</code>, <code>objectio</code>, and <code>fault</code> packages<br> <li> Implement <code>TestNewClientFailed()</code> test case to verify retry behavior on <br>client creation failures<br> <li> Use fault injection to simulate client creation errors and verify <br>retry mechanism works correctly<br> <li> Mock factory function that fails initially then succeeds after <br>threshold is reached</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22672/files#diff-ec129f1387c0400c53a1dca438d211f4e3e50ec073dac24a1d061dd7d89a7f22">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

