### PR TITLE
check parts and skip when column not updated in PreInsertFullTextIndex

### DIFF
--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -181,7 +181,7 @@ func buildInsertPlans(
 	}
 	return buildInsertPlansWithRelatedHiddenTable(stmt, ctx, builder, insertBindCtx, objRef, tableDef,
 		updateColLength, sourceStep, addAffectedRows, isFkRecursionCall, updatePkCol, pkFilterExpr,
-		newPartitionExpr, ifExistAutoPkCol, ifNeedCheckPkDup, indexSourceColTypes, fuzzymessage, insertWithoutUniqueKeyMap, ifInsertFromUniqueColMap)
+		newPartitionExpr, ifExistAutoPkCol, ifNeedCheckPkDup, indexSourceColTypes, fuzzymessage, insertWithoutUniqueKeyMap, ifInsertFromUniqueColMap, nil)
 }
 
 // buildUpdatePlans  build update plan.
@@ -265,7 +265,8 @@ func buildUpdatePlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindC
 	var fuzzymessage *OriginTableMessageForFuzzy
 	return buildInsertPlansWithRelatedHiddenTable(nil, ctx, builder, insertBindCtx, updatePlanCtx.objRef, updatePlanCtx.tableDef,
 		updatePlanCtx.updateColLength, sourceStep, addAffectedRows, updatePlanCtx.isFkRecursionCall, updatePlanCtx.updatePkCol,
-		updatePlanCtx.pkFilterExprs, partitionExpr, ifExistAutoPkCol, ifNeedCheckPkDup, indexSourceColTypes, fuzzymessage, nil, nil)
+		updatePlanCtx.pkFilterExprs, partitionExpr, ifExistAutoPkCol, ifNeedCheckPkDup, indexSourceColTypes, fuzzymessage, nil, nil,
+		updatePlanCtx.updateColPosMap)
 }
 
 func getStepByNodeId(builder *QueryBuilder, nodeId int32) int {
@@ -852,6 +853,7 @@ func buildInsertPlansWithRelatedHiddenTable(
 	updatePkCol bool, pkFilterExprs []*Expr, partitionExpr *Expr, ifExistAutoPkCol bool,
 	checkInsertPkDupForHiddenIndexTable bool, indexSourceColTypes []*plan.Type, fuzzymessage *OriginTableMessageForFuzzy,
 	insertWithoutUniqueKeyMap map[string]bool, ifInsertFromUniqueColMap map[string]bool,
+	updateColPosMap map[string]int,
 ) error {
 	//var lastNodeId int32
 	var err error
@@ -896,6 +898,7 @@ func buildInsertPlansWithRelatedHiddenTable(
 				if err != nil {
 					return err
 				}
+
 			} else if postdml_flag && indexdef.TableExist && catalog.IsFullTextIndexAlgo(indexdef.IndexAlgo) {
 				// TODO: choose either PostInsertFullTextIndex or PreInsertFullTextIndex
 				err = buildPostInsertFullTextIndex(stmt, ctx, builder, bindCtx, objRef, tableDef, updateColLength, sourceStep, ifInsertFromUniqueColMap, indexdef, idx)
@@ -908,7 +911,7 @@ func buildInsertPlansWithRelatedHiddenTable(
 
 		// TODO: choose either PostInsertFullTextIndex or PreInsertFullTextIndex
 		if !postdml_flag && indexdef.TableExist && catalog.IsFullTextIndexAlgo(indexdef.IndexAlgo) {
-			err = buildPreInsertFullTextIndex(stmt, ctx, builder, bindCtx, objRef, tableDef, updateColLength, sourceStep, ifInsertFromUniqueColMap, indexdef, idx)
+			err = buildPreInsertFullTextIndex(stmt, ctx, builder, bindCtx, objRef, tableDef, updateColLength, sourceStep, ifInsertFromUniqueColMap, indexdef, idx, updateColPosMap)
 			if err != nil {
 				return err
 			}
@@ -3578,7 +3581,6 @@ func buildDeleteMultiTableIndexes(ctx CompilerContext, builder *QueryBuilder, bi
 	for _, multiTableIndex := range multiTableIndexes {
 		switch multiTableIndex.IndexAlgo {
 		case catalog.MoIndexIvfFlatAlgo.ToString():
-
 			// Used by pre-insert vector index.
 			var idxRefs = make([]*ObjectRef, 3)
 			var idxTableDefs = make([]*TableDef, 3)
@@ -4292,10 +4294,36 @@ func buildDeleteIndexPlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *
 // For INSERT, create INSERT plan with prePreInsertFullTextIndex()
 // For UPDATE, create DELETE plan with prePreDeleteFullTextIndex() and then create INSERT plan with preInsertFullTextIndex().
 // i.e. delete old rows and then insert new values
-func buildPreInsertFullTextIndex(stmt *tree.Insert, ctx CompilerContext, builder *QueryBuilder, bindCtx *BindContext, objRef *ObjectRef, tableDef *TableDef,
-	updateColLength int, sourceStep int32, ifInsertFromUniqueColMap map[string]bool, indexdef *plan.IndexDef, idx int) error {
+func buildPreInsertFullTextIndex(stmt *tree.Insert, ctx CompilerContext, builder *QueryBuilder, bindCtx *BindContext, objRef *ObjectRef,
+	tableDef *TableDef, updateColLength int, sourceStep int32, ifInsertFromUniqueColMap map[string]bool, indexdef *plan.IndexDef,
+	idx int, updateColPosMap map[string]int) error {
+
+	// Check if secondary key is being updated.
+	isSecondaryKeyUpdated := func() bool {
+		posMap := make(map[string]int)
+		for idx, col := range tableDef.Cols {
+			posMap[col.Name] = idx
+		}
+
+		for _, colName := range indexdef.Parts {
+			resolvedColName := catalog.ResolveAlias(colName)
+			if colIdx, ok := posMap[resolvedColName]; ok {
+				col := tableDef.Cols[colIdx]
+				if _, exists := updateColPosMap[resolvedColName]; exists || col.OnUpdate != nil {
+					return true
+				}
+			}
+		}
+		return false
+	}
 
 	isUpdate := (updateColLength > 0)
+	if isUpdate {
+		if updateColPosMap != nil && !isSecondaryKeyUpdated() {
+			// index parts not updated and skip
+			return nil
+		}
+	}
 
 	lastNodeId := appendSinkScanNode(builder, bindCtx, sourceStep)
 


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22675

## What this PR does / why we need it:

check the index parts column is updated and skip the insert when parts not updated.


___

### **PR Type**
Bug fix


___

### **Description**
- Add `updateColPosMap` parameter to track updated columns in INSERT/UPDATE operations

- Check if full-text index parts are updated before processing in `buildPreInsertFullTextIndex`

- Skip full-text index insertion when indexed columns are not modified during UPDATE

- Propagate column position map through insert plan building functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildInsertPlans"] -->|pass updateColPosMap| B["buildInsertPlansWithRelatedHiddenTable"]
  B -->|pass updateColPosMap| C["buildPreInsertFullTextIndex"]
  C -->|check isSecondaryKeyUpdated| D{"Index parts updated?"}
  D -->|No| E["Skip insertion"]
  D -->|Yes| F["Process insertion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_dml_util.go</strong><dd><code>Add column update tracking for full-text indexes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_dml_util.go

<ul><li>Added <code>updateColPosMap</code> parameter to <br><code>buildInsertPlansWithRelatedHiddenTable</code> function signature<br> <li> Updated function calls to pass <code>updateColPosMap</code> from <code>buildInsertPlans</code> <br>and <code>buildUpdatePlans</code><br> <li> Implemented <code>isSecondaryKeyUpdated()</code> closure in <br><code>buildPreInsertFullTextIndex</code> to check if indexed columns are modified<br> <li> Added early return logic to skip full-text index insertion when <br>indexed columns are not updated during UPDATE operations<br> <li> Minor formatting: removed extra blank line in vector index handling <br>code</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22683/files#diff-095fb233d51021791cb24454839b013236680bbc6bbc22e0d2f6741ac8fe7dff">+34/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

