### PR TITLE
Fix misuse of unsafe get string at

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -1731,13 +1731,13 @@ func doShowCollation(ses *Session, execCtx *ExecCtx, proc *process.Process, sc *
 		v6, area6 := vector.MustVarlenaRawData(bat.Vecs[6])
 		rows = rows[:len(v0)]
 		for i := range v0 {
-			rows[i][0] = v0[i].UnsafeGetString(area0)
-			rows[i][1] = v1[i].UnsafeGetString(area1)
+			rows[i][0] = v0[i].GetString(area0)
+			rows[i][1] = v1[i].GetString(area1)
 			rows[i][2] = v2[i]
-			rows[i][3] = v3[i].UnsafeGetString(area3)
-			rows[i][4] = v4[i].UnsafeGetString(area4)
+			rows[i][3] = v3[i].GetString(area3)
+			rows[i][4] = v4[i].GetString(area4)
 			rows[i][5] = v5[i]
-			rows[i][6] = v6[i].UnsafeGetString(area6)
+			rows[i][6] = v6[i].GetString(area6)
 		}
 	}
 

--- a/pkg/sql/colexec/table_function/fulltext.go
+++ b/pkg/sql/colexec/table_function/fulltext.go
@@ -180,19 +180,19 @@ func (u *fulltextState) start(tf *TableFunction, proc *process.Process, nthRow i
 	if v.GetType().Oid != types.T_varchar {
 		return moerr.NewInvalidInput(proc.Ctx, fmt.Sprintf("First argument (source table name) must be string, but got %s", v.GetType().String()))
 	}
-	source_table := v.UnsafeGetStringAt(0)
+	source_table := v.GetStringAt(0)
 
 	v = tf.ctr.argVecs[1]
 	if v.GetType().Oid != types.T_varchar {
 		return moerr.NewInvalidInput(proc.Ctx, fmt.Sprintf("Second argument (index table name) must be string, but got %s", v.GetType().String()))
 	}
-	index_table := v.UnsafeGetStringAt(0)
+	index_table := v.GetStringAt(0)
 
 	v = tf.ctr.argVecs[2]
 	if v.GetType().Oid != types.T_varchar {
 		return moerr.NewInvalidInput(proc.Ctx, fmt.Sprintf("Third argument (pattern) must be string, but got %s", v.GetType().String()))
 	}
-	pattern := v.UnsafeGetStringAt(0)
+	pattern := v.GetStringAt(0)
 
 	v = tf.ctr.argVecs[3]
 	if v.GetType().Oid != types.T_int64 {

--- a/pkg/txn/trace/service.go
+++ b/pkg/txn/trace/service.go
@@ -429,8 +429,8 @@ func (s *service) watch(ctx context.Context) {
 				defer res.Close()
 				res.ReadRows(func(rows int, cols []*vector.Vector) bool {
 					for i := 0; i < rows; i++ {
-						features = append(features, cols[0].UnsafeGetStringAt(i))
-						states = append(states, cols[1].UnsafeGetStringAt(i))
+						features = append(features, cols[0].GetStringAt(i))
+						states = append(states, cols[1].GetStringAt(i))
 					}
 					return true
 				})

--- a/pkg/txn/trace/service_data_event.go
+++ b/pkg/txn/trace/service_data_event.go
@@ -316,7 +316,7 @@ func (s *service) RefreshTableFilters() error {
 			res.ReadRows(func(rows int, cols []*vector.Vector) bool {
 				for i := 0; i < rows; i++ {
 					id := vector.MustFixedColWithTypeCheck[uint64](cols[0])[i]
-					columns := cols[1].UnsafeGetStringAt(i)
+					columns := cols[1].GetStringAt(i)
 					filters = append(filters, NewKeepTableFilter(id, strings.Split(columns, ",")))
 				}
 				return true

--- a/pkg/txn/trace/service_statement.go
+++ b/pkg/txn/trace/service_statement.go
@@ -148,8 +148,8 @@ func (s *service) RefreshStatementFilters() error {
 
 			res.ReadRows(func(rows int, cols []*vector.Vector) bool {
 				for i := 0; i < rows; i++ {
-					methods = append(methods, cols[0].UnsafeGetStringAt(i))
-					values = append(values, cols[1].UnsafeGetStringAt(i))
+					methods = append(methods, cols[0].GetStringAt(i))
+					values = append(values, cols[1].GetStringAt(i))
 				}
 				return true
 			})


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #16235

## What this PR does / why we need it:

Fix misuse of unsafe get string at


___

### **PR Type**
Bug fix


___

### **Description**
- Replace unsafe string access with safe method calls

- Fix misuse of `UnsafeGetStringAt()` across three service files

- Ensure proper bounds checking and error handling for vector access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UnsafeGetStringAt calls"] -- "replaced with" --> B["GetStringAt calls"]
  B -- "provides" --> C["Safe bounds checking"]
  C -- "prevents" --> D["Potential panics/crashes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service.go</strong><dd><code>Fix unsafe string access in watch method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/txn/trace/service.go

<ul><li>Replace two <code>UnsafeGetStringAt()</code> calls with <code>GetStringAt()</code> in watch <br>method<br> <li> Affects feature name and state retrieval from vector columns<br> <li> Improves safety of row data extraction in database query results</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22685/files#diff-f71ec5387e2f184c24cfd2e0bdac6ea2e076366aeea51e7364bd20f4972f8ca5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service_data_event.go</strong><dd><code>Fix unsafe string access in table filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/txn/trace/service_data_event.go

<ul><li>Replace one <code>UnsafeGetStringAt()</code> call with <code>GetStringAt()</code> in <br>RefreshTableFilters method<br> <li> Affects column filter string retrieval from vector<br> <li> Ensures safe access to table filter configuration data</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22685/files#diff-1b7386cc4dc7c6a101c0086bd584c5880123111006c87123f396f96a800a6af5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service_statement.go</strong><dd><code>Fix unsafe string access in statement filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/txn/trace/service_statement.go

<ul><li>Replace two <code>UnsafeGetStringAt()</code> calls with <code>GetStringAt()</code> in <br>RefreshStatementFilters method<br> <li> Affects method name and value retrieval from vector columns<br> <li> Improves safety of statement filter data extraction</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22685/files#diff-a68457e2d9386e4d13a6b0de8b2b00b353279c55841faafd8822e2733b6b23e8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

