### PR TITLE
fix(plan): Correct decimal literal scale handling in selectivity estimation

### DIFF
--- a/pkg/sql/plan/stats_decimal_test.go
+++ b/pkg/sql/plan/stats_decimal_test.go
@@ -1,0 +1,429 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetDecimalLiteralValue tests the conversion of decimal literals with proper scale handling
+func TestGetDecimalLiteralValue(t *testing.T) {
+	t.Run("decimal64 positive value", func(t *testing.T) {
+		// Test: 5.00 with scale=2
+		// Internal representation: 500
+		// Expected result: 5.0
+		lit := &plan.Literal{
+			Value: &plan.Literal_Decimal64Val{
+				Decimal64Val: &plan.Decimal64{A: 500},
+			},
+		}
+
+		result, ok := getDecimalLiteralValue(lit, 2)
+		require.True(t, ok)
+		require.InDelta(t, 5.0, result, 0.001)
+	})
+
+	t.Run("decimal64 negative value", func(t *testing.T) {
+		// Test: -10.50 with scale=2
+		// Internal representation: -1050
+		// Expected result: -10.5
+		dec, _ := types.Decimal64FromFloat64(-10.5, 10, 2)
+		lit := &plan.Literal{
+			Value: &plan.Literal_Decimal64Val{
+				Decimal64Val: &plan.Decimal64{A: int64(dec)},
+			},
+		}
+
+		result, ok := getDecimalLiteralValue(lit, 2)
+		require.True(t, ok)
+		require.InDelta(t, -10.5, result, 0.001)
+	})
+
+	t.Run("decimal64 scale=0", func(t *testing.T) {
+		// Test: 100 with scale=0
+		// Internal representation: 100
+		// Expected result: 100.0
+		lit := &plan.Literal{
+			Value: &plan.Literal_Decimal64Val{
+				Decimal64Val: &plan.Decimal64{A: 100},
+			},
+		}
+
+		result, ok := getDecimalLiteralValue(lit, 0)
+		require.True(t, ok)
+		require.InDelta(t, 100.0, result, 0.001)
+	})
+
+	t.Run("decimal64 large scale", func(t *testing.T) {
+		// Test: 1.23456 with scale=5
+		// Internal representation: 123456
+		// Expected result: 1.23456
+		lit := &plan.Literal{
+			Value: &plan.Literal_Decimal64Val{
+				Decimal64Val: &plan.Decimal64{A: 123456},
+			},
+		}
+
+		result, ok := getDecimalLiteralValue(lit, 5)
+		require.True(t, ok)
+		require.InDelta(t, 1.23456, result, 0.00001)
+	})
+
+	t.Run("decimal128 positive value", func(t *testing.T) {
+		// Test: 12345.67 with scale=2
+		dec, _ := types.Decimal128FromFloat64(12345.67, 20, 2)
+		lit := &plan.Literal{
+			Value: &plan.Literal_Decimal128Val{
+				Decimal128Val: &plan.Decimal128{
+					A: int64(dec.B0_63),
+					B: int64(dec.B64_127),
+				},
+			},
+		}
+
+		result, ok := getDecimalLiteralValue(lit, 2)
+		require.True(t, ok)
+		require.InDelta(t, 12345.67, result, 0.01)
+	})
+
+	t.Run("non-decimal literal", func(t *testing.T) {
+		// Test: non-decimal literal should return false
+		lit := &plan.Literal{
+			Value: &plan.Literal_I64Val{I64Val: 123},
+		}
+
+		result, ok := getDecimalLiteralValue(lit, 2)
+		require.False(t, ok)
+		require.Equal(t, 0.0, result)
+	})
+}
+
+// TestCalcSelectivityByMinMaxForDecimal tests selectivity calculation for decimal range conditions
+func TestCalcSelectivityByMinMaxForDecimal(t *testing.T) {
+	t.Run("greater than or equal", func(t *testing.T) {
+		// Column: l_quantity range [1.0, 50.0]
+		// Filter: l_quantity >= 5.0
+		// Expected: (50 - 5 + 1) / (50 - 1) = 46/49 ≈ 0.939
+		expr := makeDecimalComparisonExpr(">=", 5.0, 2)
+
+		result := calcSelectivityByMinMaxForDecimal(">=", 1.0, 50.0, expr)
+
+		expected := (50.0 - 5.0 + 1) / (50.0 - 1.0)
+		require.InDelta(t, expected, result, 0.01)
+		require.Greater(t, result, 0.9) // Should be close to 1
+	})
+
+	t.Run("less than or equal", func(t *testing.T) {
+		// Column: l_quantity range [1.0, 50.0]
+		// Filter: l_quantity <= 15.0
+		// Expected: (15 - 1 + 1) / (50 - 1) = 15/49 ≈ 0.306
+		expr := makeDecimalComparisonExpr("<=", 15.0, 2)
+
+		result := calcSelectivityByMinMaxForDecimal("<=", 1.0, 50.0, expr)
+
+		expected := (15.0 - 1.0 + 1) / (50.0 - 1.0)
+		require.InDelta(t, expected, result, 0.01)
+	})
+
+	t.Run("between", func(t *testing.T) {
+		// Column: l_quantity range [1.0, 50.0]
+		// Filter: l_quantity BETWEEN 5.0 AND 15.0
+		// Expected: (15 - 5 + 1) / (50 - 1) = 11/49 ≈ 0.224
+		expr := makeDecimalBetweenExpr(5.0, 15.0, 2)
+
+		result := calcSelectivityByMinMaxForDecimal("between", 1.0, 50.0, expr)
+
+		expected := (15.0 - 5.0 + 1) / (50.0 - 1.0)
+		require.InDelta(t, expected, result, 0.01)
+	})
+
+	t.Run("value out of range - too high", func(t *testing.T) {
+		// Column: l_quantity range [1.0, 50.0]
+		// Filter: l_quantity >= 100.0 (out of range)
+		// Expected: very low selectivity (近似0或0.1)
+		expr := makeDecimalComparisonExpr(">=", 100.0, 2)
+
+		result := calcSelectivityByMinMaxForDecimal(">=", 1.0, 50.0, expr)
+
+		// Should return small value (out of range)
+		require.Less(t, result, 0.001)
+	})
+
+	t.Run("value out of range - too low", func(t *testing.T) {
+		// Column: l_quantity range [1.0, 50.0]
+		// Filter: l_quantity <= 0.5 (out of range)
+		// Expected: very low selectivity
+		expr := makeDecimalComparisonExpr("<=", 0.5, 2)
+
+		result := calcSelectivityByMinMaxForDecimal("<=", 1.0, 50.0, expr)
+
+		// Should return small value (out of range)
+		require.Less(t, result, 0.001)
+	})
+
+	t.Run("negative values", func(t *testing.T) {
+		// Column: c_acctbal range [-999.99, 9999.99]
+		// Filter: c_acctbal >= -500.0
+		// Expected: (9999.99 - (-500) + 1) / (9999.99 - (-999.99)) ≈ 0.954
+		expr := makeDecimalComparisonExpr(">=", -500.0, 2)
+
+		result := calcSelectivityByMinMaxForDecimal(">=", -999.99, 9999.99, expr)
+
+		expected := (9999.99 - (-500.0) + 1) / (9999.99 - (-999.99))
+		require.InDelta(t, expected, result, 0.01)
+	})
+}
+
+// TestDecimalSelectivityRegression tests the specific Q19 scenario that caused performance regression
+func TestDecimalSelectivityRegression(t *testing.T) {
+	t.Run("Q19 l_quantity filter should have reasonable selectivity", func(t *testing.T) {
+		// TPC-H Q19 scenario:
+		// l_quantity range: [1.0, 50.0]
+		// Filter: (l_quantity >= 5 AND l_quantity <= 15) OR
+		//         (l_quantity >= 14 AND l_quantity <= 24) OR
+		//         (l_quantity >= 28 AND l_quantity <= 38)
+
+		// First condition: >= 5 AND <= 15
+		expr1 := makeDecimalComparisonExpr(">=", 5.0, 2)
+		sel1 := calcSelectivityByMinMaxForDecimal(">=", 1.0, 50.0, expr1)
+		require.Greater(t, sel1, 0.5, "l_quantity >= 5 should have >50%% selectivity")
+
+		expr2 := makeDecimalComparisonExpr("<=", 15.0, 2)
+		sel2 := calcSelectivityByMinMaxForDecimal("<=", 1.0, 50.0, expr2)
+		require.Greater(t, sel2, 0.2, "l_quantity <= 15 should have >20%% selectivity")
+
+		// Combined selectivity should be reasonable (not near zero!)
+		// This was the bug: it was calculated as 0.000000
+		combined := andSelectivity(sel1, sel2)
+		require.Greater(t, combined, 0.15, "Combined selectivity should be >15%%")
+		require.Less(t, combined, 0.4, "Combined selectivity should be <40%%")
+	})
+
+	t.Run("l_extendedprice range should not cause extreme selectivity", func(t *testing.T) {
+		// l_extendedprice range: [900.91, 104949.50]
+		// Any reasonable filter should have selectivity > 0.001
+		min := 900.91
+		max := 104949.50
+
+		// Filter: >= 10000
+		expr := makeDecimalComparisonExpr(">=", 10000.0, 2)
+		sel := calcSelectivityByMinMaxForDecimal(">=", min, max, expr)
+
+		require.Greater(t, sel, 0.001)
+		require.Less(t, sel, 1.0)
+	})
+}
+
+// Helper functions to construct test expressions
+
+func makeDecimalComparisonExpr(op string, value float64, scale int32) *plan.Expr {
+	// Convert float to decimal internal representation
+	dec, _ := types.Decimal64FromFloat64(value, 18, scale)
+
+	// Simple expr structure without triggering shuffle logic
+	return &plan.Expr{
+		Expr: &plan.Expr_F{
+			F: &plan.Function{
+				Func: &plan.ObjectRef{ObjName: op},
+				Args: []*plan.Expr{
+					// Column reference - simplified to avoid triggering shuffle
+					{
+						Expr: &plan.Expr_Col{
+							Col: &plan.ColRef{
+								RelPos: 0,
+								ColPos: 0,
+								Name:   "test_col",
+							},
+						},
+						Typ: plan.Type{
+							Id:    int32(types.T_decimal64),
+							Width: 18,
+							Scale: scale,
+						},
+					},
+					// Literal value
+					{
+						Expr: &plan.Expr_Lit{
+							Lit: &plan.Literal{
+								Isnull: false,
+								Value: &plan.Literal_Decimal64Val{
+									Decimal64Val: &plan.Decimal64{A: int64(dec)},
+								},
+							},
+						},
+						Typ: plan.Type{
+							Id:    int32(types.T_decimal64),
+							Width: 18,
+							Scale: scale,
+						},
+					},
+				},
+			},
+		},
+		Typ: plan.Type{Id: int32(types.T_bool)},
+	}
+}
+
+func makeDecimalBetweenExpr(val1, val2 float64, scale int32) *plan.Expr {
+	dec1, _ := types.Decimal64FromFloat64(val1, 18, scale)
+	dec2, _ := types.Decimal64FromFloat64(val2, 18, scale)
+
+	return &plan.Expr{
+		Expr: &plan.Expr_F{
+			F: &plan.Function{
+				Func: &plan.ObjectRef{ObjName: "between"},
+				Args: []*plan.Expr{
+					{
+						Expr: &plan.Expr_Col{
+							Col: &plan.ColRef{Name: "test_col", ColPos: 0},
+						},
+						Typ: plan.Type{Id: int32(types.T_decimal64), Scale: scale},
+					},
+					{
+						Expr: &plan.Expr_Lit{
+							Lit: &plan.Literal{
+								Value: &plan.Literal_Decimal64Val{
+									Decimal64Val: &plan.Decimal64{A: int64(dec1)},
+								},
+							},
+						},
+						Typ: plan.Type{Id: int32(types.T_decimal64), Width: 18, Scale: scale},
+					},
+					{
+						Expr: &plan.Expr_Lit{
+							Lit: &plan.Literal{
+								Value: &plan.Literal_Decimal64Val{
+									Decimal64Val: &plan.Decimal64{A: int64(dec2)},
+								},
+							},
+						},
+						Typ: plan.Type{Id: int32(types.T_decimal64), Width: 18, Scale: scale},
+					},
+				},
+			},
+		},
+		Typ: plan.Type{Id: int32(types.T_bool)},
+	}
+}
+
+// TestDecimalLiteralScaleBugScenario tests the exact bug scenario that caused Q19 performance regression
+func TestDecimalLiteralScaleBugScenario(t *testing.T) {
+	t.Run("bug scenario: l_quantity >= 5.00 with scale=2", func(t *testing.T) {
+		// This is the exact scenario from TPC-H Q19 that caused the bug
+
+		// Column stats: l_quantity ∈ [1.0, 50.0]
+		min := 1.0
+		max := 50.0
+
+		// Filter condition: l_quantity >= 5.00
+		// Literal internal value: 500 (5.00 * 100)
+		// If scale is not applied: val1 = 500.0 → sel = (50-500+1)/49 = negative!
+		// With correct scale: val1 = 5.0 → sel = (50-5+1)/49 = 0.939 ✓
+
+		expr := makeDecimalComparisonExpr(">=", 5.0, 2)
+		result := calcSelectivityByMinMaxForDecimal(">=", min, max, expr)
+
+		// Verify the selectivity is reasonable (NOT near zero!)
+		require.Greater(t, result, 0.5,
+			"BUG: Selectivity for 'l_quantity >= 5' should be >50%%, got %.6f", result)
+		require.Less(t, result, 1.0)
+
+		// More precise check
+		expected := (max - 5.0 + 1) / (max - min)
+		require.InDelta(t, expected, result, 0.01,
+			"Expected selectivity %.4f, got %.4f", expected, result)
+	})
+
+	t.Run("bug scenario: complex OR condition from Q19", func(t *testing.T) {
+		// Q19 has complex OR: (>= 5 AND <= 15) OR (>= 14 AND <= 24) OR (>= 28 AND <= 38)
+		// With the bug, each condition returned ~0, making final selectivity 0
+		// With the fix, should return reasonable selectivity
+
+		min := 1.0
+		max := 50.0
+
+		// Condition 1: >= 5 AND <= 15
+		ge5 := makeDecimalComparisonExpr(">=", 5.0, 2)
+		sel_ge5 := calcSelectivityByMinMaxForDecimal(">=", min, max, ge5)
+
+		le15 := makeDecimalComparisonExpr("<=", 15.0, 2)
+		sel_le15 := calcSelectivityByMinMaxForDecimal("<=", min, max, le15)
+
+		sel1 := andSelectivity(sel_ge5, sel_le15)
+
+		// Each individual selectivity should be reasonable
+		require.Greater(t, sel_ge5, 0.8)
+		require.Greater(t, sel_le15, 0.2)
+		require.Greater(t, sel1, 0.15, "AND selectivity should be >15%%")
+
+		// Similar for other conditions...
+		// The key is that none of them should be near zero!
+	})
+}
+
+// TestDecimal128Selectivity tests decimal128 handling
+func TestDecimal128Selectivity(t *testing.T) {
+	t.Run("decimal128 large values", func(t *testing.T) {
+		// Test with larger decimal128 values
+		dec, _ := types.Decimal128FromFloat64(1000000.50, 38, 2)
+		lit := &plan.Literal{
+			Value: &plan.Literal_Decimal128Val{
+				Decimal128Val: &plan.Decimal128{
+					A: int64(dec.B0_63),
+					B: int64(dec.B64_127),
+				},
+			},
+		}
+
+		result, ok := getDecimalLiteralValue(lit, 2)
+		require.True(t, ok)
+		require.InDelta(t, 1000000.50, result, 0.01)
+	})
+}
+
+// TestDecimalSelectivityEdgeCases tests edge cases and boundary conditions
+func TestDecimalSelectivityEdgeCases(t *testing.T) {
+	t.Run("min equals max", func(t *testing.T) {
+		// When column has only one distinct value
+		expr := makeDecimalComparisonExpr(">=", 5.0, 2)
+		result := calcSelectivityByMinMaxForDecimal(">=", 10.0, 10.0, expr)
+
+		// Should handle gracefully (not panic or return extreme values)
+		require.Greater(t, result, 0.0)
+		require.LessOrEqual(t, result, 1.0)
+	})
+
+	t.Run("exact match on min", func(t *testing.T) {
+		// Filter value exactly equals min
+		expr := makeDecimalComparisonExpr(">=", 1.0, 2)
+		result := calcSelectivityByMinMaxForDecimal(">=", 1.0, 50.0, expr)
+
+		// Should return ~1.0 (all values match)
+		require.Greater(t, result, 0.98)
+	})
+
+	t.Run("exact match on max", func(t *testing.T) {
+		// Filter value exactly equals max
+		expr := makeDecimalComparisonExpr("<=", 50.0, 2)
+		result := calcSelectivityByMinMaxForDecimal("<=", 1.0, 50.0, expr)
+
+		// Should return ~1.0 (all values match)
+		require.Greater(t, result, 0.98)
+	})
+}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22523

## What this PR does / why we need it:

Problem:
- Decimal literals used internal scaled values (e.g., 500) instead of 
  actual values (e.g., 5.0) in selectivity calculation
- Caused TPC-H Q19 performance regression (dop 10→1, 1.5s→12.8s)

Solution:
- Add calcSelectivityByMinMaxForDecimal() for decimal-specific handling
- Add getDecimalLiteralValue() to convert literals using proper scale
- Use zm.GetScale() consistently in UpdateStatsInfo for scale consistency
- Add boundary checks for out-of-range values

Result:
- Q19 performance restored
- Decimal statistics accurate
- Selectivity estimation correct
- Comprehensive unit tests added


___

### **PR Type**
Bug fix


___

### **Description**
- Fix decimal literal scale handling in selectivity estimation for accurate query planning

- Use ZoneMap's scale instead of TableDef's scale for decimal min/max values

- Add decimal-specific selectivity calculation with proper scale conversion

- Add comprehensive unit tests for decimal selectivity edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Decimal Literals<br/>with Internal Scaled Values"] -->|"getDecimalLiteralValue<br/>with proper scale"| B["Correct Float64<br/>Conversion"]
  C["ZoneMap Scale<br/>vs TableDef Scale"] -->|"Use ZoneMap.GetScale"| D["Consistent Scale<br/>Handling"]
  B -->|"calcSelectivityByMinMaxForDecimal"| E["Accurate Selectivity<br/>Estimation"]
  D --> E
  E -->|"Result"| F["Q19 Performance<br/>Restored"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stats.go</strong><dd><code>Implement decimal-specific selectivity calculation with scale handling</code></dd></summary>
<hr>

pkg/sql/plan/stats.go

<ul><li>Use <code>info.ColumnZMs[i].GetScale()</code> instead of <code>coldef.Typ.Scale</code> for both <br>decimal64 and decimal128 types to handle schema changes<br> <li> Add <code>calcSelectivityByMinMaxForDecimal()</code> function for decimal-specific <br>selectivity calculation with proper scale conversion<br> <li> Add <code>getDecimalLiteralValue()</code> helper to extract actual float64 values <br>from decimal literals using their scale<br> <li> Route decimal column comparisons to the new decimal-specific function <br>in <code>estimateNonEqualitySelectivity()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22741/files#diff-3b3d55fa9884dcf8980f90043a05b26a04d0153ae89fcf032cec998752c0cafa">+116/-7</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stats_decimal_test.go</strong><dd><code>Add comprehensive decimal selectivity unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/stats_decimal_test.go

<ul><li>Add <code>TestGetDecimalLiteralValue()</code> to verify decimal literal conversion <br>with various scales and types<br> <li> Add <code>TestCalcSelectivityByMinMaxForDecimal()</code> to test selectivity <br>calculation for comparison operators<br> <li> Add <code>TestDecimalSelectivityRegression()</code> to verify Q19 performance <br>regression is fixed<br> <li> Add <code>TestDecimalLiteralScaleBugScenario()</code> to test the exact bug <br>scenario with scale=2<br> <li> Add <code>TestDecimal128Selectivity()</code> and <code>TestDecimalSelectivityEdgeCases()</code> <br>for edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22741/files#diff-9dc7915c79bf93f708cc6fe2684c97d7d5a560a39188063c079b8eca0f99502e">+429/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

