### PR TITLE
Fix multi cn execution bug

### DIFF
--- a/pkg/queryservice/multi_cn_bug_test.go
+++ b/pkg/queryservice/multi_cn_bug_test.go
@@ -1,0 +1,84 @@
+// Copyright 2021 - 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queryservice
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lni/goutils/leaktest"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
+	pb "github.com/matrixorigin/matrixone/pkg/pb/query"
+	"github.com/matrixorigin/matrixone/pkg/queryservice/client"
+)
+
+// TestRequestMultipleCn_Bug1_NodeConnectionFailed verifies that when one CN node
+// fails to connect, RequestMultipleCn correctly returns an error instead of
+// silently ignoring it.
+//
+// This test ensures the fix for Bug #1 works correctly:
+// - When any CN node fails, the function should return an error
+// - Error should indicate which node failed
+// - Prevents silent data loss in distributed queries
+func TestRequestMultipleCn_Bug1_NodeConnectionFailed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cn := metadata.CNService{ServiceID: "test_multi_cn_bug1"}
+	runTestWithQueryService(t, cn, nil, func(cli client.QueryClient, addr string) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		// Simulate 2 CN nodes
+		node1 := addr                                                                    // First node (will succeed)
+		node2 := fmt.Sprintf("unix:///tmp/nonexistent-%d.sock", time.Now().Nanosecond()) // Second node (does not exist)
+
+		var successCount int
+		genRequest := func() *pb.Request {
+			req := cli.NewRequest(pb.CmdMethod_GetCacheInfo)
+			req.GetCacheInfoRequest = &pb.GetCacheInfoRequest{}
+			return req
+		}
+
+		handleValidResponse := func(nodeAddr string, rsp *pb.Response) {
+			if rsp != nil && rsp.GetCacheInfoResponse != nil {
+				successCount++
+				t.Logf("Received response from: %s", nodeAddr)
+			}
+		}
+
+		// Execute: node1 succeeds, node2 fails to connect
+		err := RequestMultipleCn(ctx, []string{node1, node2}, cli, genRequest, handleValidResponse, nil)
+
+		// Verify correct behavior after fix
+		t.Logf("RequestMultipleCn returned error: %v", err)
+		t.Logf("Success count: %d (node1 succeeded, node2 failed)", successCount)
+
+		// After fix: should return error when node2 fails
+		assert.Error(t, err, "Should return error when node2 connection fails")
+		assert.Contains(t, err.Error(), "nonexistent", "Error message should indicate which node failed")
+		assert.Equal(t, 1, successCount, "Only node1 response should be processed")
+
+		t.Log("")
+		t.Log("✅ Fix verified: Error is correctly returned when CN node fails")
+		t.Log("  - 2 nodes, node2 connection failed")
+		t.Log("  - Function correctly returns error (not nil)")
+		t.Log("  - Error message indicates failed node")
+		t.Log("  - Prevents silent data loss in distributed queries")
+	})
+}

--- a/pkg/queryservice/multi_cn_bug_test.go
+++ b/pkg/queryservice/multi_cn_bug_test.go
@@ -60,7 +60,6 @@ func TestRequestMultipleCn_Bug1_NodeConnectionFailed(t *testing.T) {
 		handleValidResponse := func(nodeAddr string, rsp *pb.Response) {
 			if rsp != nil && rsp.GetCacheInfoResponse != nil {
 				successCount++
-				t.Logf("Received response from: %s", nodeAddr)
 			}
 		}
 
@@ -68,20 +67,9 @@ func TestRequestMultipleCn_Bug1_NodeConnectionFailed(t *testing.T) {
 		err := RequestMultipleCn(ctx, []string{node1, node2}, cli, genRequest, handleValidResponse, nil)
 
 		// Verify correct behavior after fix
-		t.Logf("RequestMultipleCn returned error: %v", err)
-		t.Logf("Success count: %d (node1 succeeded, node2 failed)", successCount)
-
-		// After fix: should return error when node2 fails
 		assert.Error(t, err, "Should return error when node2 connection fails")
 		assert.Contains(t, err.Error(), "nonexistent", "Error message should indicate which node failed")
 		assert.Equal(t, 1, successCount, "Only node1 response should be processed")
-
-		t.Log("")
-		t.Log("✅ Fix verified: Error is correctly returned when CN node fails")
-		t.Log("  - 2 nodes, node2 connection failed")
-		t.Log("  - Function correctly returns error (not nil)")
-		t.Log("  - Error message indicates failed node")
-		t.Log("  - Prevents silent data loss in distributed queries")
 	})
 }
 
@@ -134,19 +122,8 @@ func TestRequestMultipleCn_ContextTimeout(t *testing.T) {
 		err := RequestMultipleCn(ctx, []string{node1, node2}, cli, genRequest, handleValidResponse, nil)
 
 		// Verify context timeout is correctly handled
-		t.Logf("RequestMultipleCn returned error: %v", err)
-		t.Logf("Success count: %d", successCount)
-
-		// Should return context deadline exceeded error
 		assert.Error(t, err, "Should return error when context times out")
 		assert.Contains(t, err.Error(), "context deadline exceeded", "Error should indicate timeout")
-
-		t.Log("")
-		t.Log("✅ Context timeout handling verified:")
-		t.Log("  - Context times out before CN responses")
-		t.Log("  - Function correctly returns timeout error")
-		t.Log("  - Error message clearly indicates deadline exceeded")
-		t.Log("  - Prevents queries from hanging indefinitely")
 	})
 }
 
@@ -190,8 +167,6 @@ func TestRequestMultipleCn_HandlerPanic(t *testing.T) {
 		assert.Equal(t, 1, validCallCount, "handleValidResponse should be called once before panic")
 		assert.Equal(t, 1, invalidCallCount, "handleInvalidResponse should be called for panic")
 		assert.Equal(t, []string{addr}, invalidNodes, "Invalid nodes should contain the failed node")
-
-		t.Log("✅ Handler panic correctly caught, error returned, handleInvalidResponse called")
 	})
 }
 
@@ -243,8 +218,6 @@ func TestRequestMultipleCn_MixedFailures(t *testing.T) {
 		for _, node := range invalidNodes {
 			assert.Contains(t, []string{node2, node3}, node, "Invalid nodes should be real addresses")
 		}
-
-		t.Logf("✅ Mixed failures: %d valid calls, %d invalid calls, error: %v", len(validCallOrder), len(invalidNodes), err)
 	})
 }
 
@@ -279,8 +252,6 @@ func TestRequestMultipleCn_AllNodesFail(t *testing.T) {
 		// Verify error is returned with zero successes
 		assert.Error(t, err, "Should return error when all nodes fail")
 		assert.Equal(t, 0, successCount, "No nodes should succeed")
-
-		t.Log("✅ All nodes failure handled correctly: error returned, no successes")
 	})
 }
 
@@ -315,8 +286,6 @@ func TestRequestMultipleCn_EmptyNodeAddress(t *testing.T) {
 		// Verify empty address is skipped
 		assert.NoError(t, err, "Should succeed when valid nodes succeed")
 		assert.Equal(t, 2, successCount, "Should process 2 valid nodes")
-
-		t.Log("✅ Empty node addresses correctly skipped")
 	})
 }
 
@@ -357,8 +326,6 @@ func TestRequestMultipleCn_ConcurrentSafety(t *testing.T) {
 		// Verify no race conditions (test with -race flag)
 		assert.NoError(t, err)
 		assert.Equal(t, 3, successCount, "All nodes should succeed")
-
-		t.Log("✅ Concurrent processing safe (run with -race to verify)")
 	})
 }
 
@@ -389,9 +356,6 @@ func TestRequestMultipleCn_NoGoroutineLeak(t *testing.T) {
 
 		// Execute: will timeout
 		_ = RequestMultipleCn(ctx, []string{node1, node2}, cli, genRequest, handleValidResponse, nil)
-
-		// leaktest.AfterTest will verify no goroutine leaks
-		t.Log("✅ No goroutine leaks (verified by leaktest)")
 	})
 }
 
@@ -431,8 +395,6 @@ func TestRequestMultipleCn_InvalidResponseCallback(t *testing.T) {
 		assert.Error(t, err, "Should return error")
 		assert.Equal(t, 1, len(invalidNodes), "Should call handleInvalidResponse for failed node")
 		assert.Equal(t, node2, invalidNodes[0], "Invalid node should be the network failed node")
-
-		t.Log("✅ handleInvalidResponse correctly called for network failures")
 	})
 }
 
@@ -484,7 +446,5 @@ func TestRequestMultipleCn_FailedNodesOnlyRealAddresses(t *testing.T) {
 			assert.NotContains(t, failedNode, "timeout", "failedNodes should not contain 'timeout' string")
 			assert.NotContains(t, failedNode, "context", "failedNodes should not contain 'context' string")
 		}
-
-		t.Logf("✅ failedNodes contains only real addresses: %v", capturedFailedNodes)
 	})
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22744 #22727

## What this PR does / why we need it:

Data loss in distributed queries

```go
if res.err != nil && retErr != nil {  // BUG: condition is always false
    retErr = errors.Wrapf(res.err, "failed to get result from %s", res.nodeAddr)
}
```

**Issue**: 
- `retErr` is initialized to `nil`
- Condition `retErr != nil` is always false on first error
- First error is silently ignored
- Function returns `nil` even when nodes fail


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix critical data loss bug in distributed multi-CN queries where first error was silently ignored

- Correct error handling logic: check `retErr == nil` instead of `retErr != nil` before assignment

- Add comprehensive error tracking with success/failure counts and failed node list

- Implement panic recovery for user-provided handlers to prevent crashes

- Add goroutine leak prevention with WaitGroup and proper channel draining

- Add 10 new test cases covering error scenarios, timeouts, panics, and edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RequestMultipleCn<br/>Bug: retErr != nil<br/>always false"] -->|Fix error logic| B["Check retErr == nil<br/>before assignment"]
  B -->|Add tracking| C["Track success/failure<br/>counts and nodes"]
  C -->|Add safety| D["Panic recovery<br/>for handlers"]
  D -->|Prevent leaks| E["WaitGroup +<br/>channel draining"]
  E -->|Verify fix| F["10 new tests<br/>covering all paths"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>query_service.go</strong><dd><code>Fix error handling logic and add goroutine safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/queryservice/query_service.go

<ul><li>Fix critical bug: change condition from <code>res.err != nil && retErr != </code><br><code>nil</code> to <code>res.err == nil</code> check, ensuring first error is captured instead <br>of ignored<br> <li> Add error tracking: track <code>successCount</code>, <code>failedNodes</code> list, and use <br><code>WaitGroup</code> for goroutine management<br> <li> Implement panic recovery: wrap <code>handleValidResponse</code> and <br><code>handleInvalidResponse</code> calls with defer-recover to catch panics and <br>treat as failures<br> <li> Add proper channel draining: continue receiving all responses even <br>after context timeout to prevent goroutine leaks<br> <li> Add error logging: log aggregated error summary with node counts and <br>failed node addresses<br> <li> Improve node validation: count only non-empty node addresses for <br>channel buffer size</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22745/files#diff-5af3b0bbdcf49fa18e3704a758304319f176fd4ae70a547c3a9d89b7001b8347">+147/-22</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multi_cn_bug_test.go</strong><dd><code>Add comprehensive test coverage for multi-CN bug fixes</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/queryservice/multi_cn_bug_test.go

<ul><li>Add <code>TestRequestMultipleCn_Bug1_NodeConnectionFailed</code>: verify error is <br>returned when CN node fails to connect instead of being silently <br>ignored<br> <li> Add <code>TestRequestMultipleCn_ContextTimeout</code>: verify context deadline <br>exceeded error is correctly returned and logged<br> <li> Add <code>TestRequestMultipleCn_HandlerPanic</code>: verify handler panic is caught <br>and treated as failure with <code>handleInvalidResponse</code> called<br> <li> Add <code>TestRequestMultipleCn_MixedFailures</code>: verify correct behavior with <br>multiple failure types (connection fail, handler panic) across <br>different nodes<br> <li> Add <code>TestRequestMultipleCn_AllNodesFail</code>: verify error is returned when <br>all nodes fail<br> <li> Add <code>TestRequestMultipleCn_EmptyNodeAddress</code>: verify empty node <br>addresses are skipped correctly<br> <li> Add <code>TestRequestMultipleCn_ConcurrentSafety</code>: verify no race conditions <br>with concurrent node processing<br> <li> Add <code>TestRequestMultipleCn_NoGoroutineLeak</code>: verify goroutines are <br>properly cleaned up using leaktest<br> <li> Add <code>TestRequestMultipleCn_InvalidResponseCallback</code>: verify <br><code>handleInvalidResponse</code> is called for all failure types<br> <li> Add <code>TestRequestMultipleCn_FailedNodesOnlyRealAddresses</code>: verify failed <br>nodes list contains only real addresses, not synthetic strings</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22745/files#diff-5129e369e8116967e05f8bc8d6a9c0f43ae8186273b783cb6d43c483cf7f2f6b">+490/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

