### PR TITLE
fix bvt

### DIFF
--- a/test/distributed/cases/dml/show/cdc.result
+++ b/test/distributed/cases/dml/show/cdc.result
@@ -4,6 +4,8 @@ use test_cdc;
 create pitr if not exists pitr_db for database test_cdc  range 2 'h';
 create cdc cdc_tpcc 'mysql://test_cdc_var_acc1#admin:111@127.0.0.1:6001' 'matrixone' 'mysql://test_cdc_var_acc1#admin:111@127.0.0.1:6001' 'test_cdc:test_cdc_bak' {'Level'='database'};
 select mo_ctl('cn','syncCommit','');
+mo_ctl(cn, synccommit, )
+{\n  "method": "SyncCommit",\n  "result": [\n    {\n      "method": "SyncCommit",\n      "error": ""\n    }\n  ]\n}\n
 show cdc task cdc_tpcc;
 task_id    task_name    source_uri    sink_uri    state    err_msg    checkpoint    timestamp
 null       cdc_tpcc     null          null        null     null       null          null

--- a/test/distributed/cases/dml/show/cdc.test
+++ b/test/distributed/cases/dml/show/cdc.test
@@ -4,8 +4,10 @@ create database if not exists test_cdc;
 use test_cdc;
 create pitr if not exists pitr_db for database test_cdc  range 2 'h';
 create cdc cdc_tpcc 'mysql://test_cdc_var_acc1#admin:111@127.0.0.1:6001' 'matrixone' 'mysql://test_cdc_var_acc1#admin:111@127.0.0.1:6001' 'test_cdc:test_cdc_bak' {'Level'='database'};
+-- @session
 -- @ignore:0
 select mo_ctl('cn','syncCommit','');
+-- @session:id=2&user=test_cdc_var_acc1:admin&password=111
 -- @ignore:0,1,2,3,4,5,6,7
 show cdc task cdc_tpcc;
 drop cdc task cdc_tpcc;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22729

## What this PR does / why we need it:
fix bvt


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add synchronization commit call before CDC task status check

- Ensure CDC task state is properly committed before verification

- Update test case with ignore directive for mo_ctl output


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CDC Task Creation"] --> B["Sync Commit Call"]
  B --> C["Show CDC Task Status"]
  C --> D["Verify Task State"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cdc.test</strong><dd><code>Add sync commit and ignore directive to CDC test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/dml/show/cdc.test

<ul><li>Added <code>-- @ignore:0</code> directive before the <code>mo_ctl</code> synchronization call<br> <li> Inserted <code>select mo_ctl('cn','syncCommit','');</code> to ensure commit <br>synchronization<br> <li> Ensures CDC task state is properly committed before status <br>verification</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22756/files#diff-cd9891be56450ce2e367dd4e48998ead369bcd4906ce030a4f7975492c213b0b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cdc.result</strong><dd><code>Update CDC test expected results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/dml/show/cdc.result

<ul><li>Added expected output line for <code>select mo_ctl('cn','syncCommit','');</code> <br>command<br> <li> Updates expected test results to match new synchronization call</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22756/files#diff-4a3a02b8a8780d0007a5bb798e522333ba891024434d1003ede19e6383f465ac">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

