### PR TITLE
hash join spill

### DIFF
--- a/pkg/sql/colexec/hashbuild/spill_test.go
+++ b/pkg/sql/colexec/hashbuild/spill_test.go
@@ -1,0 +1,127 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hashbuild
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashBuildSpillBasic(t *testing.T) {
+	defer cleanupSpillFiles(t)
+
+	mp := mpool.MustNewZero()
+	proc := testutil.NewProcessWithMPool(t, "", mp)
+	defer proc.Free()
+
+	// Create a hash build operator with low spill threshold
+	hashBuild := &HashBuild{
+		Spillable:            true,
+		SpillMemoryThreshold: 1024, // Very low threshold to trigger spill
+		NeedHashMap:          true,
+		Conditions: []*plan.Expr{
+			newExpr(0, types.T_int64.ToType()),
+		},
+		JoinMapTag:    1,
+		JoinMapRefCnt: 1,
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{
+				Idx:     0,
+				IsFirst: false,
+				IsLast:  false,
+			},
+		},
+	}
+
+	// Prepare the operator
+	err := hashBuild.Prepare(proc)
+	require.NoError(t, err)
+	defer hashBuild.Free(proc, false, nil)
+
+	// Create a mock source that will generate enough data to trigger spill
+	mockOp := colexec.NewMockOperator()
+
+	// Generate data that will exceed the memory threshold
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = testutil.MakeInt64Vector([]int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, nil)
+	bat.SetRowCount(10)
+
+	// Add more batches to trigger spill
+	for i := 0; i < 100; i++ {
+		mockOp.WithBatchs([]*batch.Batch{bat})
+	}
+
+	hashBuild.SetChildren([]vm.Operator{mockOp})
+
+	// Execute the hash build
+	result, err := vm.Exec(hashBuild, proc)
+	require.NoError(t, err)
+	_ = result
+
+	// Check that spill occurred
+	require.True(t, hashBuild.ctr.spilled, "Hash build should have spilled")
+	require.Equal(t, 8, hashBuild.ctr.partitionCnt, "Should have 8 partitions")
+	require.Greater(t, hashBuild.ctr.memUsed, hashBuild.SpillMemoryThreshold)
+
+	// Check that partition 0 data remains in memory
+	require.NotNil(t, hashBuild.ctr.hashmapBuilder.Batches.Buf)
+	require.Greater(t, len(hashBuild.ctr.hashmapBuilder.Batches.Buf), 0)
+
+	// Check that spill files were created
+	for i := 1; i < 8; i++ {
+		filename := filepath.Join(os.TempDir(), "hashbuild_spill_test_0_0")
+		_, err := os.Stat(filename)
+		require.NoError(t, err, "Spill file should exist for partition %d", i)
+		os.Remove(filename) // Cleanup
+	}
+}
+
+func cleanupSpillFiles(t *testing.T) {
+	// Remove files matching the pattern hashbuild_spill_*
+	matches, err := filepath.Glob(os.TempDir() + "/hashbuild_spill_*")
+	if err != nil {
+		t.Logf("Error globbing spill files: %v", err)
+		return
+	}
+
+	for _, match := range matches {
+		if err := os.Remove(match); err != nil {
+			t.Logf("Error removing spill file %s: %v", match, err)
+		}
+	}
+
+	// Remove files matching the pattern join_probe_spill_*
+	matches, err = filepath.Glob(os.TempDir() + "/join_probe_spill_*")
+	if err != nil {
+		t.Logf("Error globbing probe spill files: %v", err)
+		return
+	}
+
+	for _, match := range matches {
+		if err := os.Remove(match); err != nil {
+			t.Logf("Error removing probe spill file %s: %v", match, err)
+		}
+	}
+}

--- a/pkg/sql/colexec/join/join.go
+++ b/pkg/sql/colexec/join/join.go
@@ -16,11 +16,17 @@ package join
 
 import (
 	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
 	"time"
+	"unsafe"
 
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/hashtable"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/vm"
@@ -83,8 +89,6 @@ func (innerJoin *InnerJoin) Call(proc *process.Process) (vm.CallResult, error) {
 			}
 
 			if ctr.mp == nil && !innerJoin.IsShuffle {
-				// for inner ,right and semi join, if hashmap is empty, we can finish this pipeline
-				// shuffle join can't stop early for this moment
 				ctr.state = End
 			} else {
 				ctr.state = Probe
@@ -97,7 +101,11 @@ func (innerJoin *InnerJoin) Call(proc *process.Process) (vm.CallResult, error) {
 				}
 				bat := input.Batch
 				if bat == nil {
-					ctr.state = End
+					if ctr.spilled {
+						ctr.state = LoopSpilledPartitions
+					} else {
+						ctr.state = End
+					}
 					continue
 				}
 				if bat.Last() {
@@ -115,7 +123,6 @@ func (innerJoin *InnerJoin) Call(proc *process.Process) (vm.CallResult, error) {
 			}
 
 			startrow := innerJoin.ctr.lastRow
-			// probe will set inbat nil if data is exhauseted
 			if err := ctr.probe(innerJoin, proc, &result); err != nil {
 				return result, err
 			}
@@ -126,6 +133,145 @@ func (innerJoin *InnerJoin) Call(proc *process.Process) (vm.CallResult, error) {
 			}
 
 			return result, nil
+
+		case LoopSpilledPartitions:
+			// Start looping from partition 1
+			ctr.currentPartition = 1
+			ctr.state = ProcessSpilledPartition
+
+		case ProcessSpilledPartition:
+			// Load build side partition
+			buildFileName := fmt.Sprintf("hashbuild_spill_%s_%d_%d", proc.QueryId(), ctr.mp.BuildOpID, ctr.currentPartition)
+
+			// Open and read the partition file
+			reader, err := os.Open(buildFileName)
+			if err != nil {
+				if os.IsNotExist(err) {
+					// No more partitions
+					ctr.state = End
+					continue
+				}
+				return result, err
+			}
+			defer reader.Close()
+
+			// Read all batches for this partition
+			var buildBatches []*batch.Batch
+			for {
+				// Read batch size first
+				sizeBuf := make([]byte, 4)
+				_, err := io.ReadFull(reader, sizeBuf)
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return result, err
+				}
+				batchSize := binary.LittleEndian.Uint32(sizeBuf)
+
+				// Read batch data
+				data := make([]byte, batchSize)
+				_, err = io.ReadFull(reader, data)
+				if err != nil {
+					return result, err
+				}
+
+				// Unmarshal batch
+				bat := &batch.Batch{}
+				if err := bat.UnmarshalBinary(data); err != nil {
+					return result, err
+				}
+				buildBatches = append(buildBatches, bat)
+			}
+			reader.Close()
+			os.Remove(buildFileName) // Cleanup build spill file
+
+			// Build hash map for this partition
+			ctr.hashmapBuilder.Batches.Buf = buildBatches
+			ctr.hashmapBuilder.InputBatchRowCount = 0
+			for _, bat := range buildBatches {
+				ctr.hashmapBuilder.InputBatchRowCount += bat.RowCount()
+			}
+
+			// Build the hashmap for this partition
+			needUniqueVec := true
+			if innerJoin.RuntimeFilterSpecs == nil || len(innerJoin.RuntimeFilterSpecs) == 0 || innerJoin.RuntimeFilterSpecs[0].Expr == nil {
+				needUniqueVec = false
+			}
+			err = ctr.hashmapBuilder.BuildHashmap(innerJoin.HashOnPK, true, needUniqueVec, proc)
+			if err != nil {
+				return result, err
+			}
+
+			// Create a new JoinMap for this partition
+			ctr.mp = message.NewJoinMap(ctr.hashmapBuilder.MultiSels, ctr.hashmapBuilder.IntHashMap, ctr.hashmapBuilder.StrHashMap, ctr.hashmapBuilder.DelRows, ctr.hashmapBuilder.Batches.Buf, proc.Mp())
+			ctr.itr = ctr.mp.NewIterator()
+
+			// Load probe side partition
+			probeFileName := fmt.Sprintf("join_probe_spill_%s_%d_%d", proc.QueryId(), innerJoin.GetOperatorID(), ctr.currentPartition)
+
+			probeReader, err := os.Open(probeFileName)
+			if err != nil {
+				if os.IsNotExist(err) {
+					// No probe data for this partition, but build data existed (and processed).
+					// Skip to next partition.
+					// Clean up for this iteration
+					ctr.hashmapBuilder.Free(proc)
+					ctr.mp.Free()
+
+					ctr.currentPartition++
+					if ctr.currentPartition >= ctr.partitionCnt {
+						ctr.state = End
+					}
+					continue
+				}
+				return result, err
+			}
+			defer probeReader.Close()
+
+			// Read probe batch
+			// Note: Probe file might contain multiple batches appended
+			data, err := io.ReadAll(probeReader)
+			if err != nil {
+				return result, err
+			}
+			probeReader.Close()
+			os.Remove(probeFileName) // Cleanup probe spill file
+
+			if len(data) > 0 {
+				probeBat := &batch.Batch{}
+				if err := probeBat.UnmarshalBinary(data); err != nil {
+					return result, err
+				}
+
+				// Probe the hash map with the partition data
+				ctr.inbat = probeBat
+				ctr.lastRow = 0
+				ctr.probeState = psNextBatch
+
+				if err := ctr.probeInMemory(innerJoin, proc, &result); err != nil {
+					return result, err
+				}
+				// If result found, return it. The loop will continue in this state until probeInMemory returns nil batch
+				if result.Batch != nil && !result.Batch.IsEmpty() {
+					return result, nil
+				}
+			}
+
+			// Clean up for this iteration
+			ctr.hashmapBuilder.Free(proc)
+			ctr.mp.Free()
+			if ctr.inbat != nil {
+				ctr.inbat.Clean(proc.Mp())
+				ctr.inbat = nil
+			}
+
+			ctr.currentPartition++
+			if ctr.currentPartition >= ctr.partitionCnt {
+				ctr.state = End
+			}
+			// Continue to next partition immediately if no result from this one
+			continue
 
 		default:
 			result.Batch = nil
@@ -145,8 +291,19 @@ func (innerJoin *InnerJoin) build(analyzer process.Analyzer, proc *process.Proce
 	}
 	if ctr.mp != nil {
 		ctr.maxAllocSize = max(ctr.maxAllocSize, ctr.mp.Size())
+		ctr.spilled = ctr.mp.Spilled
+		ctr.partitionCnt = ctr.mp.PartitionCnt
+		if ctr.spilled {
+			// Prepare the hashmap builder for spilled partitions
+			ctr.hashmapBuilder.IsDedup = false // Dedup logic is already handled by the build side
+			if err := ctr.hashmapBuilder.Prepare(innerJoin.Conditions[1], -1, proc); err != nil {
+				return err
+			}
+		}
 	}
-	ctr.batchRowCount = ctr.mp.GetRowCount()
+	if ctr.mp != nil {
+		ctr.batchRowCount = ctr.mp.GetRowCount()
+	}
 	return nil
 }
 
@@ -191,6 +348,217 @@ func (ctr *container) probe(ap *InnerJoin, proc *process.Process, result *vm.Cal
 	if err := ctr.setupResultAndCondition(ap, proc); err != nil {
 		return err
 	}
+
+	if ctr.spilled {
+		// Partition the incoming probe batch
+		numPartitions := uint64(ctr.partitionCnt)
+		rowCount := ap.ctr.inbat.RowCount()
+		hashes := make([]uint64, rowCount)
+
+		// Calculate hashes for join keys
+		for i, _ := range ap.Conditions[0] {
+			vec, err := ctr.executor[i].Eval(proc, []*batch.Batch{ap.ctr.inbat}, nil)
+			if err != nil {
+				return err
+			}
+
+			// Compute hash values
+			hashCol := make([]uint64, rowCount)
+			if vec.GetType().IsFixedLen() && vec.GetType().TypeSize() == 8 {
+				cols := vector.MustFixedColNoTypeCheck[int64](vec)
+				hashtable.Int64BatchHash(unsafe.Pointer(&cols[0]), &hashCol[0], rowCount)
+			} else {
+				for i := 0; i < rowCount; i++ {
+					bytes := vec.GetBytesAt(i)
+					var states [3]uint64
+					hashtable.BytesBatchGenHashStatesWithSeed(&bytes, &states, 1, 0)
+					hashCol[i] = states[0]
+				}
+			}
+
+			// Combine hash values
+			if i == 0 {
+				copy(hashes, hashCol)
+			} else {
+				for i := range hashes {
+					hashes[i] ^= hashCol[i]
+				}
+			}
+		}
+
+		// Distribute rows to partitions using selection vectors
+		sels := make([][]int64, numPartitions)
+		for i := range sels {
+			sels[i] = make([]int64, 0, rowCount/int(numPartitions)+1)
+		}
+
+		for row := 0; row < rowCount; row++ {
+			partition := hashes[row] % numPartitions
+			sels[partition] = append(sels[partition], int64(row))
+		}
+
+		partitionedBatches := make([][]*batch.Batch, numPartitions)
+		// Create new batches for each partition
+		for i := range sels {
+			if len(sels[i]) > 0 {
+				newBat := batch.NewWithSize(len(ap.ctr.inbat.Vecs))
+				for j, vec := range ap.ctr.inbat.Vecs {
+					newBat.Vecs[j] = vector.NewVec(*vec.GetType())
+				}
+				for col := range ap.ctr.inbat.Vecs {
+					if err := newBat.Vecs[col].Union(ap.ctr.inbat.Vecs[col], sels[i], proc.Mp()); err != nil {
+						return err
+					}
+				}
+				newBat.SetRowCount(len(sels[i]))
+				partitionedBatches[i] = append(partitionedBatches[i], newBat)
+			}
+		}
+
+		// Process partition 0 in memory
+		if len(partitionedBatches[0]) > 0 {
+			// Temporarily replace the input batch with partition 0's batch for probing
+			originalInbat := ap.ctr.inbat
+			ap.ctr.inbat = partitionedBatches[0][0]
+			originalLastRow := ctr.lastRow
+			ctr.lastRow = 0
+
+			// Probe partition 0
+			if err := ctr.probeInMemory(ap, proc, result); err != nil {
+				return err
+			}
+
+			// Restore state
+			ap.ctr.inbat = originalInbat
+			ctr.lastRow = originalLastRow
+			partitionedBatches[0][0].Clean(proc.Mp())
+		}
+
+		// Spill other partitions to disk
+		for i := uint64(1); i < numPartitions; i++ {
+			if len(partitionedBatches[i]) == 0 {
+				continue
+			}
+
+			// Write probe partition to disk
+			partitionFileName := fmt.Sprintf("join_probe_spill_%s_%d_%d", proc.QueryId(), ap.GetOperatorID(), i)
+			writer, err := os.OpenFile(partitionFileName, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
+			if err != nil {
+				return err
+			}
+
+			for _, bat := range partitionedBatches[i] {
+				data, err := bat.MarshalBinary()
+				if err != nil {
+					writer.Close()
+					return err
+				}
+				_, err = writer.Write(data)
+				if err != nil {
+					writer.Close()
+					return err
+				}
+				bat.Clean(proc.Mp())
+			}
+			writer.Close()
+		}
+
+		// Clean up the original input batch
+		ap.ctr.inbat.Clean(proc.Mp())
+		ap.ctr.inbat = nil
+		ctr.lastRow = 0
+		ctr.state = LoopSpilledPartitions
+		return nil
+	}
+
+	return ctr.probeInMemory(ap, proc, result)
+}
+
+func (ctr *container) evalAndAppendOne(
+	proc *process.Process, ap *InnerJoin, row, idx1, idx2 int64,
+) (bool, error) {
+	condPass, err := ctr.evalNonEqCondition(
+		ap.ctr.inbat, row, proc, idx1, idx2,
+	)
+	if err != nil {
+		return false, err
+	}
+	if condPass {
+		err := ctr.appendOne(proc, ap, row, idx1, idx2)
+		if err != nil {
+			return false, err
+		}
+	}
+	return condPass, nil
+}
+
+func (ctr *container) evalNonEqCondition(
+	bat *batch.Batch, row int64, proc *process.Process, idx1, idx2 int64,
+) (bool, error) {
+	mpbat := ctr.mp.GetBatches()
+	// TODO: fix the probe row in closure, only change the matched row in hashmap
+	if err := colexec.SetJoinBatchValues(
+		ctr.joinBats[0], bat, row, 1, ctr.cfs1,
+	); err != nil {
+		return false, err
+	}
+	if err := colexec.SetJoinBatchValues(
+		ctr.joinBats[1], mpbat[idx1], idx2, 1, ctr.cfs2,
+	); err != nil {
+		return false, err
+	}
+	vec, err := ctr.expr.Eval(proc, ctr.joinBats, nil)
+	if err != nil {
+		return false, err
+	}
+	if vec.IsConstNull() || vec.GetNulls().Contains(0) {
+		return false, nil
+	}
+	bs := vector.MustFixedColWithTypeCheck[bool](vec)
+	if !bs[0] {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (ctr *container) appendOne(
+	proc *process.Process, ap *InnerJoin, row, idx1, idx2 int64,
+) error {
+	mpbat := ctr.mp.GetBatches()
+	for j, rp := range ap.Result {
+		if rp.Rel == 0 {
+			if err := ctr.rbat.Vecs[j].UnionOne(
+				ctr.inbat.Vecs[rp.Pos], row, proc.Mp(),
+			); err != nil {
+				return err
+			}
+		} else {
+			if err := ctr.rbat.Vecs[j].UnionOne(
+				mpbat[idx1].Vecs[rp.Pos], idx2, proc.Mp(),
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (ctr *container) evalJoinCondition(bat *batch.Batch, proc *process.Process) error {
+	for i := range ctr.executor {
+		vec, err := ctr.executor[i].Eval(proc, []*batch.Batch{bat}, nil)
+		if err != nil {
+			return err
+		}
+		ctr.vecs[i] = vec
+	}
+	return nil
+}
+
+func (ctr *container) probeInMemory(ap *InnerJoin, proc *process.Process, result *vm.CallResult) error {
+	if err := ctr.setupResultAndCondition(ap, proc); err != nil {
+		return err
+	}
+
 	mpbat := ctr.mp.GetBatches()
 	inputRowCount := ap.ctr.inbat.RowCount()
 	rowCount := 0
@@ -325,6 +693,9 @@ func (ctr *container) probe(ap *InnerJoin, proc *process.Process, result *vm.Cal
 				ctr.probeState = psBatchRow
 			} else {
 				// return current result and set the input batch to nil
+				if inputRowCount > 0 {
+					ap.ctr.inbat.Clean(proc.Mp())
+				}
 				ctr.rbat.AddRowCount(rowCount)
 				result.Batch = ctr.rbat
 				ap.ctr.lastRow = 0
@@ -334,84 +705,4 @@ func (ctr *container) probe(ap *InnerJoin, proc *process.Process, result *vm.Cal
 			}
 		}
 	}
-}
-
-func (ctr *container) evalAndAppendOne(
-	proc *process.Process, ap *InnerJoin, row, idx1, idx2 int64,
-) (bool, error) {
-	condPass, err := ctr.evalNonEqCondition(
-		ap.ctr.inbat, row, proc, idx1, idx2,
-	)
-	if err != nil {
-		return false, err
-	}
-	if condPass {
-		err := ctr.appendOne(proc, ap, row, idx1, idx2)
-		if err != nil {
-			return false, err
-		}
-	}
-	return condPass, nil
-}
-
-func (ctr *container) evalNonEqCondition(
-	bat *batch.Batch, row int64, proc *process.Process, idx1, idx2 int64,
-) (bool, error) {
-	mpbat := ctr.mp.GetBatches()
-	// TODO: fix the probe row in closure, only change the matched row in hashmap
-	if err := colexec.SetJoinBatchValues(
-		ctr.joinBats[0], bat, row, 1, ctr.cfs1,
-	); err != nil {
-		return false, err
-	}
-	if err := colexec.SetJoinBatchValues(
-		ctr.joinBats[1], mpbat[idx1], idx2, 1, ctr.cfs2,
-	); err != nil {
-		return false, err
-	}
-	vec, err := ctr.expr.Eval(proc, ctr.joinBats, nil)
-	if err != nil {
-		return false, err
-	}
-	if vec.IsConstNull() || vec.GetNulls().Contains(0) {
-		return false, nil
-	}
-	bs := vector.MustFixedColWithTypeCheck[bool](vec)
-	if !bs[0] {
-		return false, nil
-	}
-	return true, nil
-}
-
-func (ctr *container) appendOne(
-	proc *process.Process, ap *InnerJoin, row, idx1, idx2 int64,
-) error {
-	mpbat := ctr.mp.GetBatches()
-	for j, rp := range ap.Result {
-		if rp.Rel == 0 {
-			if err := ctr.rbat.Vecs[j].UnionOne(
-				ctr.inbat.Vecs[rp.Pos], row, proc.Mp(),
-			); err != nil {
-				return err
-			}
-		} else {
-			if err := ctr.rbat.Vecs[j].UnionOne(
-				mpbat[idx1].Vecs[rp.Pos], idx2, proc.Mp(),
-			); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (ctr *container) evalJoinCondition(bat *batch.Batch, proc *process.Process) error {
-	for i := range ctr.executor {
-		vec, err := ctr.executor[i].Eval(proc, []*batch.Batch{bat}, nil)
-		if err != nil {
-			return err
-		}
-		ctr.vecs[i] = vec
-	}
-	return nil
 }


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #

## What this PR does / why we need it:


___

### **PR Type**
Enhancement


___

### **Description**
- Add hash join spill support with memory threshold detection

- Introduce new `Spill` state in hash build pipeline

- Track spilled data and partition count through join map

- Add memory usage tracking and spillable configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BuildHashMap State"] -->|"Memory exceeds threshold"| B["Spill State"]
  B -->|"Process spilled data"| C["HandleRuntimeFilter State"]
  A -->|"Memory OK"| C
  C --> D["SendJoinMap"]
  D --> E["SendSucceed"]
  F["JoinMap"] -->|"Spilled flag"| G["InnerJoin Probe"]
  F -->|"PartitionCnt"| G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.go</strong><dd><code>Add spill detection and state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/hashbuild/build.go

<ul><li>Refactored <code>collectBuildBatches</code> into unified <code>build</code> method with spill <br>detection<br> <li> Added memory usage tracking (<code>memUsed</code>) and spillable threshold checking<br> <li> Introduced new <code>Spill</code> state handling for post-spill hash map building<br> <li> Set <code>Spilled</code> and <code>PartitionCnt</code> flags on JoinMap message</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22787/files#diff-0c2753ffdc4ccc951ac44650817da1d8ffe37631363a440b8b55732bb0e2b839">+44/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add spill state and configuration fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/hashbuild/types.go

<ul><li>Added <code>Spill</code> constant to state machine<br> <li> Added spill-related fields to container: <code>spilled</code>, <code>partitionCnt</code>, <br><code>memUsed</code><br> <li> Added spillable configuration to HashBuild: <code>Spillable</code>, <br><code>SpillMemoryThreshold</code><br> <li> Improved code formatting and field alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22787/files#diff-270d27fc945ebbe16cfb88efa16c176856d021853abfe9c6429a8d7ca48d6c5f">+18/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>join.go</strong><dd><code>Capture spill metadata from join map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/join/join.go

<ul><li>Extract spilled and partition count from received JoinMap<br> <li> Add null check before accessing JoinMap properties<br> <li> Add TODO placeholder for handling spilled data in probe phase</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22787/files#diff-2a43ca762c59d0ece91404da915aa519c35db896df1ec228aab36a10e7dbc1dd">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add spill tracking to join container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/join/types.go

<ul><li>Added spill-related fields to container: <code>spilled</code>, <code>partitionCnt</code><br> <li> Reset spill fields in Reset method for clean state</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22787/files#diff-67c85cf1b10e35ddf7ac938c17226a987e5548785b126d8c3929a26874fa1d78">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>joinMapMsg.go</strong><dd><code>Add spill metadata to join map message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/message/joinMapMsg.go

<ul><li>Added <code>Spilled</code> and <code>PartitionCnt</code> fields to JoinMap struct<br> <li> Reset spill fields in FreeMemory method<br> <li> Enhanced DebugString to display spill information</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22787/files#diff-611756ec920adf21c1efea995ec0cd2273cb60abac8efa1f7574597bafde9533">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

