### PR TITLE
Set the maximum number of load retries and retry time

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2398,7 +2398,7 @@ func canExecuteStatementInUncommittedTransaction(
 func readThenWrite(ses FeSession, execCtx *ExecCtx, param *tree.ExternParam, writer *io.PipeWriter, mysqlRrWr MysqlRrWr, skipWrite bool, epoch uint64) (_ bool, _ time.Duration, _ time.Duration, err error) {
 	var readTime, writeTime time.Duration
 	var payload []byte
-	readStart := time.Now()
+	start := time.Now()
 	defer func() {
 		if err != nil {
 			mysqlRrWr.FreeLoadLocal()
@@ -2414,21 +2414,21 @@ func readThenWrite(ses FeSession, execCtx *ExecCtx, param *tree.ExternParam, wri
 		}
 		return skipWrite, readTime, writeTime, err
 	}
-	readTime = time.Since(readStart)
+	readTime = time.Since(start)
 
 	//empty packet means the file is over.
-	length := len(payload)
-	if length == 0 {
+	size := len(payload)
+	if size == 0 {
 		return skipWrite, readTime, writeTime, errorInvalidLength0
 	}
-	ses.CountPayload(length)
+	ses.CountPayload(size)
 
 	// If inner error occurs(unexpected or expected(ctrl-c)), proc.Base.LoadLocalReader will be closed.
 	// Then write will return error, but we need to read the rest of the data and not write it to pipe.
 	// So we need a flag[skipWrite] to tell us whether we need to write the data to pipe.
 	// https://github.com/matrixorigin/matrixone/issues/6665#issuecomment-1422236478
 
-	writeStart := time.Now()
+	start = time.Now()
 	if !skipWrite {
 		_, err = writer.Write(payload)
 		if err != nil {
@@ -2439,7 +2439,7 @@ func readThenWrite(ses FeSession, execCtx *ExecCtx, param *tree.ExternParam, wri
 				zap.Error(err))
 			skipWrite = true
 		}
-		writeTime = time.Since(writeStart)
+		writeTime = time.Since(start)
 
 	}
 	return skipWrite, readTime, writeTime, err
@@ -2463,34 +2463,36 @@ func processLoadLocal(ses FeSession, execCtx *ExecCtx, param *tree.ExternParam, 
 	defer func() {
 		close(quitC)
 	}()
-	mysqlRrWr := ses.GetResponser().MysqlRrWr()
+	mysqlRwer := ses.GetResponser().MysqlRrWr()
 	defer func() {
 		err2 := writer.Close()
 		if err == nil {
 			err = err2
 		}
 		//free load local buffer anyway
-		mysqlRrWr.FreeLoadLocal()
+		mysqlRwer.FreeLoadLocal()
 	}()
 	err = plan2.InitInfileParam(param)
 	if err != nil {
 		return
 	}
-	err = mysqlRrWr.WriteLocalInfileRequest(param.Filepath)
+	err = mysqlRwer.WriteLocalInfileRequest(param.Filepath)
 	if err != nil {
 		return
 	}
 	var skipWrite bool
 	skipWrite = false
 	var readTime, writeTime time.Duration
+	var retError error
 	start := time.Now()
-	epoch, printEvery, minReadTime, maxReadTime, minWriteTime, maxWriteTime := uint64(0), uint64(1024*60), 24*time.Hour, time.Nanosecond, 24*time.Hour, time.Nanosecond
+	epoch, printTime, minReadTime, maxReadTime, minWriteTime, maxWriteTime := uint64(0), uint64(1024*60), 24*time.Hour, time.Nanosecond, 24*time.Hour, time.Nanosecond
 
-	skipWrite, readTime, writeTime, err = readThenWrite(ses, execCtx, param, writer, mysqlRrWr, skipWrite, epoch)
+	skipWrite, readTime, writeTime, err = readThenWrite(ses, execCtx, param, writer, mysqlRwer, skipWrite, epoch)
 	if err != nil {
 		if errors.Is(err, errorInvalidLength0) {
 			return nil
 		}
+		retError = err
 	}
 	if readTime > maxReadTime {
 		maxReadTime = readTime
@@ -2506,13 +2508,34 @@ func processLoadLocal(ses FeSession, execCtx *ExecCtx, param *tree.ExternParam, 
 		minWriteTime = writeTime
 	}
 
+	const maxRetries = 100               // Maximum number of consecutive errors
+	const maxTotalTime = 3 * time.Minute // Maximum total consecutive processing time
+	var consecutiveErrors int
+	consecutiveLoopStartTime := time.Now()
+
 	for {
-		skipWrite, readTime, writeTime, err = readThenWrite(ses, execCtx, param, writer, mysqlRrWr, skipWrite, epoch)
+		skipWrite, readTime, writeTime, err = readThenWrite(ses, execCtx, param, writer, mysqlRwer, skipWrite, epoch)
 		if err != nil {
 			if errors.Is(err, errorInvalidLength0) {
+				if retError != nil {
+					err = retError
+					break
+				}
 				err = nil
 				break
 			}
+			retError = err
+			consecutiveErrors++
+			ses.Errorf(execCtx.reqCtx, "readThenWrite error (attempt %d): %v", consecutiveErrors, err)
+			time.Sleep(10 * time.Millisecond)
+
+			if consecutiveErrors >= maxRetries || time.Since(consecutiveLoopStartTime) > maxTotalTime {
+				return moerr.NewInternalErrorf(execCtx.reqCtx,
+					"load local file failed: consecutive errors (%d), timeout after %v", maxRetries, maxTotalTime)
+			}
+		} else {
+			consecutiveErrors = 0
+			consecutiveLoopStartTime = time.Now()
 		}
 
 		if readTime > maxReadTime {
@@ -2529,7 +2552,7 @@ func processLoadLocal(ses FeSession, execCtx *ExecCtx, param *tree.ExternParam, 
 			minWriteTime = writeTime
 		}
 
-		if epoch%printEvery == 0 {
+		if epoch%printTime == 0 {
 			if execCtx.isIssue3482 {
 				ses.Infof(execCtx.reqCtx, "load local '%s', epoch: %d, skipWrite: %v, minReadTime: %s, maxReadTime: %s, minWriteTime: %s, maxWriteTime: %s,\n", param.Filepath, epoch, skipWrite, minReadTime.String(), maxReadTime.String(), minWriteTime.String(), maxWriteTime.String())
 			}


### PR DESCRIPTION
### **User description**
Set the maximum number of load retries and retry time

Approved by: @daviszhen, @XuPeng-SH

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixflow/issues/6060

## What this PR does / why we need it:
Set the maximum number of load retries and retry time


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implement retry mechanism with maximum limits for load operations
  - Add maximum retry count (100) and timeout (3 minutes) for consecutive errors
  - Track consecutive errors and reset on successful operations
  - Add 10ms delay between retry attempts

- Improve error handling and logging for load failures
  - Log each retry attempt with error details
  - Preserve initial error and return comprehensive error message on failure

- Refactor variable naming for clarity and consistency
  - Rename `readStart`/`writeStart` to `start` for reusability
  - Rename `length` to `size` for better semantics
  - Rename `printEvery` to `printTime` for clarity
  - Rename `mysqlRrWr` to `mysqlRwer` for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["readThenWrite Call"] --> B{"Error Occurred?"}
  B -->|Yes| C["Increment consecutiveErrors"]
  C --> D["Log Retry Attempt"]
  D --> E{"Check Limits"}
  E -->|Exceeded| F["Return Error"]
  E -->|Within Limits| G["Sleep 10ms"]
  G --> A
  B -->|No| H["Reset consecutiveErrors"]
  H --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, enhancement, error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mysql_cmd_executor.go</strong><dd><code>Add retry limits and error handling for load operations</code>&nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/mysql_cmd_executor.go

<ul><li>Implement retry mechanism with configurable limits (100 retries, <br>3-minute timeout) for consecutive load errors<br> <li> Add error tracking with <code>retError</code> variable to preserve initial error <br>and <code>consecutiveErrors</code> counter<br> <li> Add 10ms delay between retry attempts and reset counter on successful <br>operations<br> <li> Improve error logging to track retry attempts with attempt number and <br>error details<br> <li> Refactor variable names: <code>readStart</code>/<code>writeStart</code> to <code>start</code>, <code>length</code> to <br><code>size</code>, <code>printEvery</code> to <code>printTime</code>, <code>mysqlRrWr</code> to <code>mysqlRwer</code></ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22820/files#diff-af2611d5fc89704398fe09d09644efa41fec8931b395eda292f2f474f1216275">+37/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

