### PR TITLE
(fix): left join OR predicate regression 3.0-dev hotfix

### DIFF
--- a/pkg/sql/plan/pushdown.go
+++ b/pkg/sql/plan/pushdown.go
@@ -193,7 +193,7 @@ func (builder *QueryBuilder) pushdownFilters(nodeID int32, filters []*plan.Expr,
 				}
 			}
 
-			if canTurnInner && node.JoinType == plan.Node_LEFT && joinSides[i]&JoinSideRight != 0 && rejectsNull(filter, builder.compCtx.GetProcess()) {
+			if canTurnInner && node.JoinType == plan.Node_LEFT && joinSides[i] == JoinSideRight && rejectsNull(filter, builder.compCtx.GetProcess()) {
 				for _, cond := range node.OnList {
 					filters = append(filters, splitPlanConjunction(applyDistributivity(builder.GetContext(), cond))...)
 				}

--- a/pkg/sql/plan/pushdown_test.go
+++ b/pkg/sql/plan/pushdown_test.go
@@ -1,0 +1,227 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func setupLeftJoinBase(t *testing.T) (*MockCompilerContext, *QueryBuilder, *plan.Expr, *plan.Expr, *plan.Expr) {
+	t.Helper()
+
+	ctx := NewMockCompilerContext(true)
+	builder := NewQueryBuilder(plan.Query_SELECT, ctx, false, false)
+
+	leftTag := builder.genNewTag()
+	rightTag := builder.genNewTag()
+
+	intType := Type{Id: int32(types.T_int64)}
+
+	leftIDCol := &plan.Expr{
+		Typ: intType,
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{
+				RelPos: leftTag,
+				ColPos: 0,
+			},
+		},
+	}
+	rightIDCol := &plan.Expr{
+		Typ: intType,
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{
+				RelPos: rightTag,
+				ColPos: 0,
+			},
+		},
+	}
+	leftSpaceCol := &plan.Expr{
+		Typ: intType,
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{
+				RelPos: leftTag,
+				ColPos: 1,
+			},
+		},
+	}
+
+	onExpr, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "=", []*plan.Expr{
+		DeepCopyExpr(leftIDCol), DeepCopyExpr(rightIDCol),
+	})
+	require.NoError(t, err)
+
+	builder.qry.Nodes = []*plan.Node{
+		{
+			NodeType:    plan.Node_TABLE_SCAN,
+			BindingTags: []int32{leftTag},
+			ProjectList: []*plan.Expr{
+				DeepCopyExpr(leftIDCol),
+				DeepCopyExpr(leftSpaceCol),
+			},
+		},
+		{
+			NodeType:    plan.Node_TABLE_SCAN,
+			BindingTags: []int32{rightTag},
+			ProjectList: []*plan.Expr{
+				DeepCopyExpr(rightIDCol),
+			},
+		},
+		{
+			NodeType: plan.Node_JOIN,
+			JoinType: plan.Node_LEFT,
+			Children: []int32{0, 1},
+			OnList:   []*plan.Expr{onExpr},
+			ProjectList: []*plan.Expr{
+				DeepCopyExpr(leftIDCol),
+				DeepCopyExpr(leftSpaceCol),
+				DeepCopyExpr(rightIDCol),
+			},
+		},
+	}
+
+	return ctx, builder, leftIDCol, rightIDCol, leftSpaceCol
+}
+
+func TestLeftJoinOrFilterKeepsLeftJoin(t *testing.T) {
+	ctx, builder, leftIDCol, rightIDCol, leftSpaceCol := setupLeftJoinBase(t)
+
+	isNotNullExpr, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "isnotnull", []*plan.Expr{
+		DeepCopyExpr(rightIDCol),
+	})
+	require.NoError(t, err)
+
+	constExpr := &plan.Expr{
+		Typ: leftIDCol.Typ,
+		Expr: &plan.Expr_Lit{
+			Lit: &plan.Literal{
+				Value: &plan.Literal_I64Val{I64Val: 11},
+			},
+		},
+	}
+	eqExpr, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "=", []*plan.Expr{
+		DeepCopyExpr(leftSpaceCol),
+		constExpr,
+	})
+	require.NoError(t, err)
+
+	filterExpr, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "or", []*plan.Expr{
+		isNotNullExpr,
+		eqExpr,
+	})
+	require.NoError(t, err)
+
+	nodeID, cantPushdown := builder.pushdownFilters(2, []*plan.Expr{filterExpr}, false)
+	require.Equal(t, plan.Node_LEFT, builder.qry.Nodes[nodeID].JoinType, "left join should not be rewritten to inner join")
+	require.Len(t, cantPushdown, 1)
+
+	require.Equal(t, int32(types.T_bool), filterExpr.Typ.Id)
+}
+
+func TestLeftJoinOrFilterWithConstKeepsLeftJoin(t *testing.T) {
+	ctx, builder, leftIDCol, rightIDCol, leftSpaceCol := setupLeftJoinBase(t)
+
+	rightConst := &plan.Expr{
+		Typ: rightIDCol.Typ,
+		Expr: &plan.Expr_Lit{
+			Lit: &plan.Literal{
+				Value: &plan.Literal_I64Val{I64Val: 5},
+			},
+		},
+	}
+	rightEqConst, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "=", []*plan.Expr{
+		DeepCopyExpr(rightIDCol),
+		rightConst,
+	})
+	require.NoError(t, err)
+
+	leftConst := &plan.Expr{
+		Typ: leftIDCol.Typ,
+		Expr: &plan.Expr_Lit{
+			Lit: &plan.Literal{
+				Value: &plan.Literal_I64Val{I64Val: 11},
+			},
+		},
+	}
+	leftEqConst, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "=", []*plan.Expr{
+		DeepCopyExpr(leftSpaceCol),
+		leftConst,
+	})
+	require.NoError(t, err)
+
+	filterExpr, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "or", []*plan.Expr{
+		rightEqConst,
+		leftEqConst,
+	})
+	require.NoError(t, err)
+
+	nodeID, cantPushdown := builder.pushdownFilters(2, []*plan.Expr{filterExpr}, false)
+	require.Equal(t, plan.Node_LEFT, builder.qry.Nodes[nodeID].JoinType)
+	require.Len(t, cantPushdown, 1)
+}
+
+func TestLeftJoinOrFilterWithAndKeepsLeftJoin(t *testing.T) {
+	ctx, builder, leftIDCol, rightIDCol, leftSpaceCol := setupLeftJoinBase(t)
+
+	isNotNullExpr, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "isnotnull", []*plan.Expr{
+		DeepCopyExpr(rightIDCol),
+	})
+	require.NoError(t, err)
+
+	leftEquals11, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "=", []*plan.Expr{
+		DeepCopyExpr(leftSpaceCol),
+		{
+			Typ: leftIDCol.Typ,
+			Expr: &plan.Expr_Lit{
+				Lit: &plan.Literal{
+					Value: &plan.Literal_I64Val{I64Val: 11},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	orExpr, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "or", []*plan.Expr{
+		isNotNullExpr,
+		leftEquals11,
+	})
+	require.NoError(t, err)
+
+	leftEquals12, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "=", []*plan.Expr{
+		DeepCopyExpr(leftSpaceCol),
+		{
+			Typ: leftIDCol.Typ,
+			Expr: &plan.Expr_Lit{
+				Lit: &plan.Literal{
+					Value: &plan.Literal_I64Val{I64Val: 12},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	filterExpr, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), "and", []*plan.Expr{
+		orExpr,
+		leftEquals12,
+	})
+	require.NoError(t, err)
+
+	nodeID, cantPushdown := builder.pushdownFilters(2, []*plan.Expr{filterExpr}, false)
+	require.Equal(t, plan.Node_LEFT, builder.qry.Nodes[nodeID].JoinType)
+	require.Len(t, cantPushdown, 1)
+}

--- a/test/distributed/cases/optimizer/left_join_or_filter.result
+++ b/test/distributed/cases/optimizer/left_join_or_filter.result
@@ -1,0 +1,85 @@
+drop database if exists bvt_leftjoin_or;
+create database bvt_leftjoin_or;
+use bvt_leftjoin_or;
+drop table if exists orders;
+drop table if exists mapping;
+create table orders(
+id int primary key,
+space_id int,
+status int
+);
+create table mapping(
+id int primary key
+);
+insert into orders values
+(1, 11, 1),
+(2, 12, 1),
+(3, 11, 2),
+(4, 12, 2);
+insert into mapping values
+(2),
+(4);
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where r.id is not null or l.space_id = 11
+order by l.id;
+id    space_id    id
+1    11    null
+2    12    2
+3    11    null
+4    12    4
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where r.id = 2 or l.space_id = 11
+order by l.id;
+id    space_id    id
+1    11    null
+2    12    2
+3    11    null
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where (r.id is not null or l.space_id = 11) and l.status = 1
+order by l.id;
+id    space_id    id
+1    11    null
+2    12    2
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where r.id = 2 or l.space_id = 11 or 1 = 0
+order by l.id;
+id    space_id    id
+1    11    null
+2    12    2
+3    11    null
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where (r.id = 2 and l.status = 1) or l.space_id = 11
+order by l.id;
+id    space_id    id
+1    11    null
+2    12    2
+3    11    null
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where ((r.id is not null and l.status = 2) or l.space_id = 11) and l.id <> 2
+order by l.id;
+id    space_id    id
+1    11    null
+3    11    null
+4    12    4
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where coalesce(r.id, 0) = 4 or l.space_id = 11
+order by l.id;
+id    space_id    id
+1    11    null
+3    11    null
+4    12    4
+drop database bvt_leftjoin_or;

--- a/test/distributed/cases/optimizer/left_join_or_filter.test
+++ b/test/distributed/cases/optimizer/left_join_or_filter.test
@@ -1,0 +1,74 @@
+drop database if exists bvt_leftjoin_or;
+create database bvt_leftjoin_or;
+use bvt_leftjoin_or;
+
+drop table if exists orders;
+drop table if exists mapping;
+create table orders(
+    id int primary key,
+    space_id int,
+    status int
+);
+create table mapping(
+    id int primary key
+);
+
+insert into orders values
+    (1, 11, 1),
+    (2, 12, 1),
+    (3, 11, 2),
+    (4, 12, 2);
+insert into mapping values
+    (2),
+    (4);
+
+-- @bvt:issue
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where r.id is not null or l.space_id = 11
+order by l.id;
+
+-- @bvt:issue
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where r.id = 2 or l.space_id = 11
+order by l.id;
+
+-- @bvt:issue
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where (r.id is not null or l.space_id = 11) and l.status = 1
+order by l.id;
+
+-- @bvt:issue
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where r.id = 2 or l.space_id = 11 or 1 = 0
+order by l.id;
+
+-- @bvt:issue
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where (r.id = 2 and l.status = 1) or l.space_id = 11
+order by l.id;
+
+-- @bvt:issue
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where ((r.id is not null and l.status = 2) or l.space_id = 11) and l.id <> 2
+order by l.id;
+
+-- @bvt:issue
+select l.id, l.space_id, r.id
+from orders l
+left join mapping r on l.id = r.id
+where coalesce(r.id, 0) = 4 or l.space_id = 11
+order by l.id;
+
+drop database bvt_leftjoin_or;


### PR DESCRIPTION
### **User description**
Root cause is the optimizer rewriting LEFT JOIN to INNER JOIN when the WHERE clause OR mixes right-side and left-side references, which drops left rows. The fix keeps the join as LEFT unless the filter is purely right-side null-rejecting.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixflow/issues/5900

## What this PR does / why we need it:

left join OR predicate regression 3.0-dev hotfix


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix LEFT JOIN incorrectly rewritten to INNER JOIN with OR predicates
  - Changed condition from `joinSides[i]&JoinSideRight != 0` to `joinSides[i] == JoinSideRight`
  - Ensures join stays LEFT unless filter is purely right-side null-rejecting

- Add comprehensive unit tests for LEFT JOIN OR filter scenarios

- Add distributed test cases validating correct query results


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WHERE clause with OR<br/>mixing left and right refs"] -->|Previous logic| B["Incorrectly converts<br/>LEFT to INNER JOIN"]
  A -->|Fixed logic| C["Keeps LEFT JOIN<br/>unless purely right-side"]
  B -->|Result| D["❌ Drops left rows"]
  C -->|Result| E["✓ Preserves all left rows"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pushdown.go</strong><dd><code>Fix LEFT JOIN conversion logic for OR predicates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/pushdown.go

<ul><li>Changed join type conversion condition from bitwise AND check to exact <br>equality check<br> <li> Modified line 196: <code>joinSides[i]&JoinSideRight != 0</code> to <code>joinSides[i] == </code><br><code>JoinSideRight</code><br> <li> Prevents LEFT JOIN conversion to INNER JOIN when WHERE clause OR mixes <br>both table references</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22828/files#diff-c56c005810af88df8deafb1160a8d33874d72f941857d9168bf0399547169b10">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pushdown_test.go</strong><dd><code>Add unit tests for LEFT JOIN OR filter fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/pushdown_test.go

<ul><li>Added new test file with helper function <code>setupLeftJoinBase</code> for LEFT <br>JOIN test setup<br> <li> Implemented <code>TestLeftJoinOrFilterKeepsLeftJoin</code> testing OR with <br>right-side null check and left-side condition<br> <li> Implemented <code>TestLeftJoinOrFilterWithConstKeepsLeftJoin</code> testing OR with <br>constants from both sides<br> <li> Implemented <code>TestLeftJoinOrFilterWithAndKeepsLeftJoin</code> testing complex <br>nested AND/OR expressions</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22828/files#diff-7764eaca0adc3dc8188ae9fd05271f00087578aab7a75b0f64012700aad55e1d">+227/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>left_join_or_filter.test</strong><dd><code>Add distributed test cases for LEFT JOIN OR filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/optimizer/left_join_or_filter.test

<ul><li>Added distributed test cases with 7 different LEFT JOIN OR filter <br>scenarios<br> <li> Tests cover: null checks, constant comparisons, nested AND/OR, and <br>COALESCE functions<br> <li> Each test marked with <code>@bvt:issue</code> annotation for validation<br> <li> Includes setup with <code>orders</code> and <code>mapping</code> tables and sample data</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22828/files#diff-ca27e39b391c824f83b156ee23dbfe184779516c68834bcf9ca0403a1c795489">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>left_join_or_filter.result</strong><dd><code>Add expected results for LEFT JOIN OR filter tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/optimizer/left_join_or_filter.result

<ul><li>Added expected results for 7 distributed test cases<br> <li> Validates that LEFT JOIN preserves unmatched left rows with NULL <br>values<br> <li> Confirms correct filtering behavior when OR mixes left and right table <br>conditions</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/22828/files#diff-741fd07c779c0eb41bdc2b676212c8665e5c44a177654be8ab478f3411466202">+85/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

