### PR TITLE
fix: the proxy cannot balance connections when connect too fast

### DIFF
--- a/pkg/proxy/conn_manager_test.go
+++ b/pkg/proxy/conn_manager_test.go
@@ -17,11 +17,11 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"sync"
 	"testing"
 
 	"github.com/lni/goutils/leaktest"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/stretchr/testify/require"
 )
 
@@ -246,4 +246,315 @@ func TestConnManagerLabelInfo(t *testing.T) {
 			"k1": "v1",
 		},
 	}, li)
+}
+
+// TestSelectOneLoadBalancing tests that selectOne distributes connections evenly
+// across multiple CN servers.
+func TestSelectOneLoadBalancing(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cm := newConnManager()
+	require.NotNil(t, cm)
+
+	label := newLabelInfo("t1", map[string]string{"k1": "v1"})
+	cn1 := testMakeCNServer("cn1", "", 0, "hash1", label)
+	cn2 := testMakeCNServer("cn2", "", 0, "hash1", label)
+	cn3 := testMakeCNServer("cn3", "", 0, "hash1", label)
+	cns := []*CNServer{cn1, cn2, cn3}
+
+	// First selection should select cn1 and add a placeholder
+	selected := cm.selectOne("hash1", cns)
+	require.NotNil(t, selected)
+	require.Equal(t, "cn1", selected.uuid)
+	require.Equal(t, 1, cm.getCNTunnels("hash1").count())
+
+	// Second selection should select cn2 (least loaded)
+	selected = cm.selectOne("hash1", cns)
+	require.NotNil(t, selected)
+	require.Equal(t, "cn2", selected.uuid)
+	require.Equal(t, 2, cm.getCNTunnels("hash1").count())
+
+	// Third selection should select cn3 (least loaded)
+	selected = cm.selectOne("hash1", cns)
+	require.NotNil(t, selected)
+	require.Equal(t, "cn3", selected.uuid)
+	require.Equal(t, 3, cm.getCNTunnels("hash1").count())
+
+	// Fourth selection should select cn1 again (all have 1 placeholder)
+	selected = cm.selectOne("hash1", cns)
+	require.NotNil(t, selected)
+	require.Equal(t, "cn1", selected.uuid)
+	require.Equal(t, 4, cm.getCNTunnels("hash1").count())
+}
+
+// TestSelectOneWithPlaceholder tests that placeholders are correctly added
+// and counted in selectOne.
+func TestSelectOneWithPlaceholder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cm := newConnManager()
+	require.NotNil(t, cm)
+
+	label := newLabelInfo("t1", map[string]string{"k1": "v1"})
+	cn1 := testMakeCNServer("cn1", "", 0, "hash1", label)
+	cn2 := testMakeCNServer("cn2", "", 0, "hash1", label)
+	cns := []*CNServer{cn1, cn2}
+
+	// Select cn1, should add a placeholder
+	selected := cm.selectOne("hash1", cns)
+	require.Equal(t, "cn1", selected.uuid)
+	cnTunnels := cm.getCNTunnels("hash1")
+	require.NotNil(t, cnTunnels)
+	require.Equal(t, 1, cnTunnels.count())
+
+	// Check that the placeholder has ctx == nil
+	tunnels := cnTunnels["cn1"]
+	require.NotNil(t, tunnels)
+	require.Equal(t, 1, tunnels.count())
+	for tun := range tunnels {
+		require.Nil(t, tun.ctx, "Placeholder tunnel should have ctx == nil")
+	}
+}
+
+// TestSelectOneConcurrentDistribution tests that concurrent selectOne calls
+// distribute connections evenly across CN servers.
+func TestSelectOneConcurrentDistribution(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cm := newConnManager()
+	require.NotNil(t, cm)
+
+	label := newLabelInfo("t1", map[string]string{"k1": "v1"})
+	cn1 := testMakeCNServer("cn1", "", 0, "hash1", label)
+	cn2 := testMakeCNServer("cn2", "", 0, "hash1", label)
+	cn3 := testMakeCNServer("cn3", "", 0, "hash1", label)
+	cns := []*CNServer{cn1, cn2, cn3}
+
+	// Concurrently select 30 connections
+	numSelections := 30
+	var wg sync.WaitGroup
+	selections := make([]*CNServer, numSelections)
+	var mu sync.Mutex
+
+	for i := 0; i < numSelections; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			selected := cm.selectOne("hash1", cns)
+			mu.Lock()
+			selections[idx] = selected
+			mu.Unlock()
+		}(i)
+	}
+	wg.Wait()
+
+	// Count selections per CN
+	cnCounts := make(map[string]int)
+	for _, selected := range selections {
+		require.NotNil(t, selected)
+		cnCounts[selected.uuid]++
+	}
+
+	// All CNs should be selected at least once
+	require.Equal(t, 3, len(cnCounts))
+	require.GreaterOrEqual(t, cnCounts["cn1"], 1)
+	require.GreaterOrEqual(t, cnCounts["cn2"], 1)
+	require.GreaterOrEqual(t, cnCounts["cn3"], 1)
+
+	// Total count should match number of selections
+	require.Equal(t, numSelections, cm.getCNTunnels("hash1").count())
+
+	// Distribution should be relatively even (each CN should have at least 5 selections)
+	// Note: Due to concurrent execution, exact distribution may vary, but should be reasonable
+	minSelections := numSelections / 6 // At least 1/6 of selections per CN
+	require.GreaterOrEqual(t, cnCounts["cn1"], minSelections)
+	require.GreaterOrEqual(t, cnCounts["cn2"], minSelections)
+	require.GreaterOrEqual(t, cnCounts["cn3"], minSelections)
+}
+
+// TestSelectOneFailed tests that selectOneFailed correctly removes placeholders.
+func TestSelectOneFailed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cm := newConnManager()
+	require.NotNil(t, cm)
+
+	label := newLabelInfo("t1", map[string]string{"k1": "v1"})
+	cn1 := testMakeCNServer("cn1", "", 0, "hash1", label)
+	cn2 := testMakeCNServer("cn2", "", 0, "hash1", label)
+	cns := []*CNServer{cn1, cn2}
+
+	// Select cn1, should add a placeholder
+	selected := cm.selectOne("hash1", cns)
+	require.Equal(t, "cn1", selected.uuid)
+	require.Equal(t, 1, cm.getCNTunnels("hash1").count())
+
+	// Simulate connection failure
+	cm.selectOneFailed("hash1", "cn1")
+	require.Equal(t, 0, cm.getCNTunnels("hash1").count())
+
+	// Select again, should select cn1 again (now it has 0 connections)
+	selected = cm.selectOne("hash1", cns)
+	require.Equal(t, "cn1", selected.uuid)
+	require.Equal(t, 1, cm.getCNTunnels("hash1").count())
+}
+
+// TestSelectOnePlaceholderReplacement tests that connect correctly replaces
+// placeholder with real tunnel.
+func TestSelectOnePlaceholderReplacement(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rt := runtime.DefaultRuntime()
+	cm := newConnManager()
+	require.NotNil(t, cm)
+
+	label := newLabelInfo("t1", map[string]string{"k1": "v1"})
+	cn1 := testMakeCNServer("cn1", "", 0, "hash1", label)
+	cn2 := testMakeCNServer("cn2", "", 0, "hash1", label)
+	cns := []*CNServer{cn1, cn2}
+
+	// Select cn1, should add a placeholder
+	selected := cm.selectOne("hash1", cns)
+	require.Equal(t, "cn1", selected.uuid)
+	cnTunnels := cm.getCNTunnels("hash1")
+	require.Equal(t, 1, cnTunnels.count())
+
+	// Verify placeholder exists (ctx == nil)
+	tunnels := cnTunnels["cn1"]
+	require.NotNil(t, tunnels)
+	require.Equal(t, 1, tunnels.count())
+	var placeholder *tunnel
+	for tun := range tunnels {
+		require.Nil(t, tun.ctx)
+		placeholder = tun
+	}
+
+	// Connect with real tunnel, should replace placeholder
+	realTunnel := newTunnel(context.TODO(), rt.Logger(), nil)
+	cm.connect(cn1, realTunnel)
+	require.Equal(t, 1, cm.getCNTunnels("hash1").count())
+
+	// Verify placeholder is replaced with real tunnel
+	// Note: getCNTunnels returns a reference to the map, so cnTunnels and cnTunnelsAfterConnect
+	// point to the same map. We can use either, but re-fetch for clarity.
+	cnTunnelsAfterConnect := cm.getCNTunnels("hash1")
+	tunnels = cnTunnelsAfterConnect["cn1"]
+	require.Equal(t, 1, tunnels.count())
+	require.True(t, tunnels.exists(realTunnel))
+	require.False(t, tunnels.exists(placeholder))
+	require.NotNil(t, realTunnel.ctx)
+}
+
+// TestSelectOneMultiplePending tests that multiple pending connections
+// to the same CN are correctly counted.
+func TestSelectOneMultiplePending(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cm := newConnManager()
+	require.NotNil(t, cm)
+
+	label := newLabelInfo("t1", map[string]string{"k1": "v1"})
+	cn1 := testMakeCNServer("cn1", "", 0, "hash1", label)
+	cn2 := testMakeCNServer("cn2", "", 0, "hash1", label)
+	cns := []*CNServer{cn1, cn2}
+
+	// Select cn1 multiple times
+	selected1 := cm.selectOne("hash1", cns)
+	require.Equal(t, "cn1", selected1.uuid)
+	require.Equal(t, 1, cm.getCNTunnels("hash1").count())
+
+	selected2 := cm.selectOne("hash1", cns)
+	// cn1 has 1 placeholder (count=1), cn2 has 0 (count=0), so should choose cn2 (least loaded)
+	require.Equal(t, "cn2", selected2.uuid)
+	require.Equal(t, 2, cm.getCNTunnels("hash1").count())
+
+	selected3 := cm.selectOne("hash1", cns)
+	// cn1 has 1 placeholder (count=1), cn2 has 1 placeholder (count=1), so should choose cn1 (first in list)
+	require.Equal(t, "cn1", selected3.uuid)
+	require.Equal(t, 3, cm.getCNTunnels("hash1").count())
+}
+
+// TestSelectOneWithRealConnections tests that selectOne correctly considers
+// both real connections and placeholders when selecting.
+func TestSelectOneWithRealConnections(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rt := runtime.DefaultRuntime()
+	cm := newConnManager()
+	require.NotNil(t, cm)
+
+	label := newLabelInfo("t1", map[string]string{"k1": "v1"})
+	cn1 := testMakeCNServer("cn1", "", 0, "hash1", label)
+	cn2 := testMakeCNServer("cn2", "", 0, "hash1", label)
+	cns := []*CNServer{cn1, cn2}
+
+	// Connect a real tunnel to cn1
+	realTunnel := newTunnel(context.TODO(), rt.Logger(), nil)
+	cm.connect(cn1, realTunnel)
+	require.Equal(t, 1, cm.getCNTunnels("hash1").count())
+
+	// Select should choose cn2 (least loaded)
+	selected := cm.selectOne("hash1", cns)
+	require.Equal(t, "cn2", selected.uuid)
+	require.Equal(t, 2, cm.getCNTunnels("hash1").count())
+
+	// Select again, cn1 has 1 real (count=1), cn2 has 1 placeholder (count=1)
+	// Both have same count, so should choose the first one (cn1)
+	selected = cm.selectOne("hash1", cns)
+	require.Equal(t, "cn1", selected.uuid)
+	require.Equal(t, 3, cm.getCNTunnels("hash1").count()) // cn1 now has 1 real + 1 placeholder
+
+	// Connect real tunnel to cn2, replacing one placeholder
+	realTunnel2 := newTunnel(context.TODO(), rt.Logger(), nil)
+	cm.connect(cn2, realTunnel2)
+	require.Equal(t, 3, cm.getCNTunnels("hash1").count()) // Still 3: 1 real on cn2, 1 real + 1 placeholder on cn1
+
+	// Now cn1 has 1 real + 1 placeholder (count=2), cn2 has 1 real (count=1), so next selection should choose cn2 (least loaded)
+	selected = cm.selectOne("hash1", cns)
+	require.Equal(t, "cn2", selected.uuid)
+	require.Equal(t, 4, cm.getCNTunnels("hash1").count()) // cn2 now has 1 real + 1 placeholder
+}
+
+// TestSelectOneFailedWithMultiplePending tests that selectOneFailed correctly
+// removes one placeholder when there are multiple pending connections.
+func TestSelectOneFailedWithMultiplePending(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cm := newConnManager()
+	require.NotNil(t, cm)
+
+	label := newLabelInfo("t1", map[string]string{"k1": "v1"})
+	cn1 := testMakeCNServer("cn1", "", 0, "hash1", label)
+	cns := []*CNServer{cn1}
+
+	// Select cn1 three times
+	cm.selectOne("hash1", cns)
+	cm.selectOne("hash1", cns)
+	cm.selectOne("hash1", cns)
+	require.Equal(t, 3, cm.getCNTunnels("hash1").count())
+
+	// Fail one connection
+	cm.selectOneFailed("hash1", "cn1")
+	require.Equal(t, 2, cm.getCNTunnels("hash1").count())
+
+	// Fail another connection
+	cm.selectOneFailed("hash1", "cn1")
+	require.Equal(t, 1, cm.getCNTunnels("hash1").count())
+
+	// Fail the last connection
+	cm.selectOneFailed("hash1", "cn1")
+	require.Equal(t, 0, cm.getCNTunnels("hash1").count())
+}
+
+// TestSelectOneEmptyCNServers tests that selectOne handles empty CN server list.
+func TestSelectOneEmptyCNServers(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cm := newConnManager()
+	require.NotNil(t, cm)
+
+	// Select with empty CN list
+	selected := cm.selectOne("hash1", []*CNServer{})
+	require.Nil(t, selected)
+	require.Equal(t, 0, cm.getCNTunnels("hash1").count())
 }

--- a/pkg/proxy/router.go
+++ b/pkg/proxy/router.go
@@ -231,6 +231,8 @@ func (r *router) Connect(
 	// Creates a server connection.
 	sc, err := newServerConn(cn, t, r.rebalancer, r.connectTimeout)
 	if err != nil {
+		// Connection failed, remove the placeholder that was added in selectOne.
+		r.rebalancer.connManager.selectOneFailed(cn.hash, cn.uuid)
 		return nil, nil, err
 	}
 
@@ -246,6 +248,8 @@ func (r *router) Connect(
 	resp, err := sc.HandleHandshake(handshakeResp, r.authTimeout)
 	if err != nil {
 		_ = sc.Close()
+		// Handshake failed, remove the placeholder that was added in selectOne.
+		r.rebalancer.connManager.selectOneFailed(cn.hash, cn.uuid)
 		return nil, nil, err
 	}
 	// After handshake with backend CN server, set the connID of serverConn.

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -86,6 +86,9 @@ func NewServer(ctx context.Context, config Config, opts ...Option) (*Server, err
 	}
 
 	logExporter := newCounterLogExporter(s.counterSet)
+	// Unregister first to handle the case where a previous registration might still exist
+	// (e.g., from a previous test run or failed initialization).
+	stats.Unregister(statsFamilyName)
 	stats.Register(statsFamilyName, stats.WithLogExporter(logExporter))
 
 	s.stopper = stopper.NewStopper("mo-proxy", stopper.WithLogger(s.runtime.Logger().RawLogger()))

--- a/pkg/proxy/server_test.go
+++ b/pkg/proxy/server_test.go
@@ -48,10 +48,12 @@ func TestNewServer(t *testing.T) {
 	hc := &mockHAKeeperClient{}
 	s, err := NewServer(ctx, cfg, WithRuntime(runtime.DefaultRuntime()),
 		WithHAKeeperClient(hc))
-	defer func() {
-		err := s.Close()
-		require.NoError(t, err)
-	}()
 	require.NoError(t, err)
 	require.NotNil(t, s)
+	defer func() {
+		if s != nil {
+			err := s.Close()
+			require.NoError(t, err)
+		}
+	}()
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22854

## What this PR does / why we need it:
proxy may not balance the connections if a batch of connections
come at the same time.
fix: add pre-counter for the connection manager, and when connects
successfully, replace the placeholder.