### PR TITLE
fix: distinct agg should be run in only one node and without any parallel 3.0.4-hotfix

### DIFF
--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -18,7 +18,10 @@ import (
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+	"github.com/stretchr/testify/require"
 )
 
 func makeQueryWithScan(tableType string, rowsize float64, blockNum int32) *plan.Query {
@@ -60,4 +63,202 @@ func TestGetExecType_NonVectorTable_NotForcedByRowsize(t *testing.T) {
 	if got != ExecTypeTP {
 		t.Fatalf("expected ExecTypeTP for non-vector table, got %v", got)
 	}
+}
+
+// TestCalcNodeDOP_DistinctAggregation tests that distinct aggregation nodes
+// are correctly set to Dop=1 and ForceOneCN=true
+func TestCalcNodeDOP_DistinctAggregation(t *testing.T) {
+	// Create a plan with an AGG node containing COUNT(DISTINCT ...)
+	// Use a variable to avoid constant overflow when combining COUNT with Distinct flag
+	countVal := uint64(function.COUNT)
+	distinctVal := uint64(function.Distinct)
+	countWithDistinct := int64(countVal | distinctVal)
+	p := &plan.Plan{
+		Plan: &plan.Plan_Query{
+			Query: &plan.Query{
+				Nodes: []*plan.Node{
+					// Child node (scan)
+					{
+						NodeId:   0,
+						NodeType: plan.Node_TABLE_SCAN,
+						Stats:    DefaultStats(),
+					},
+					// AGG node with COUNT(DISTINCT ...)
+					{
+						NodeId:   1,
+						NodeType: plan.Node_AGG,
+						Children: []int32{0},
+						Stats:    DefaultStats(),
+						AggList: []*plan.Expr{
+							{
+								Expr: &plan.Expr_F{
+									F: &plan.Function{
+										Func: &plan.ObjectRef{
+											// COUNT with Distinct flag: use uint64 to avoid overflow, then convert to int64
+											// Similar to having_binder.go:144, we need to convert to uint64 first
+											Obj:     countWithDistinct,
+											ObjName: "count",
+										},
+										Args: []*plan.Expr{
+											{
+												Typ: plan.Type{Id: int32(types.T_int64)},
+												Expr: &plan.Expr_Col{
+													Col: &plan.ColRef{ColPos: 0},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Steps: []int32{1},
+			},
+		},
+		IsPrepare: false,
+	}
+
+	// Call CalcNodeDOP with multiple CPUs
+	ncpu := int32(8)
+	lencn := 2
+	CalcNodeDOP(p, 1, ncpu, lencn)
+
+	// Verify that the AGG node has Dop=1 and ForceOneCN=true
+	aggNode := p.GetQuery().Nodes[1]
+	require.NotNil(t, aggNode.Stats, "AGG node should have Stats")
+	require.Equal(t, int32(1), aggNode.Stats.Dop, "Distinct aggregation should have Dop=1")
+	require.True(t, aggNode.Stats.ForceOneCN, "Distinct aggregation should have ForceOneCN=true")
+
+	// Verify that child node also has Dop=1 (recursively set)
+	childNode := p.GetQuery().Nodes[0]
+	require.NotNil(t, childNode.Stats, "Child node should have Stats")
+	require.Equal(t, int32(1), childNode.Stats.Dop, "Child node should have Dop=1 (recursively set)")
+}
+
+// TestCalcNodeDOP_NonDistinctAggregation tests that non-distinct aggregation nodes
+// are not affected by the distinct aggregation logic
+func TestCalcNodeDOP_NonDistinctAggregation(t *testing.T) {
+	// Create a plan with an AGG node containing COUNT (without DISTINCT)
+	p := &plan.Plan{
+		Plan: &plan.Plan_Query{
+			Query: &plan.Query{
+				Nodes: []*plan.Node{
+					// Child node (scan)
+					{
+						NodeId:   0,
+						NodeType: plan.Node_TABLE_SCAN,
+						Stats:    DefaultStats(),
+					},
+					// AGG node with COUNT (no DISTINCT)
+					{
+						NodeId:   1,
+						NodeType: plan.Node_AGG,
+						Children: []int32{0},
+						Stats:    DefaultStats(),
+						AggList: []*plan.Expr{
+							{
+								Expr: &plan.Expr_F{
+									F: &plan.Function{
+										Func: &plan.ObjectRef{
+											Obj:     int64(function.COUNT), // COUNT without Distinct flag
+											ObjName: "count",
+										},
+										Args: []*plan.Expr{
+											{
+												Typ: plan.Type{Id: int32(types.T_int64)},
+												Expr: &plan.Expr_Col{
+													Col: &plan.ColRef{ColPos: 0},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Steps: []int32{1},
+			},
+		},
+		IsPrepare: false,
+	}
+
+	// Call CalcNodeDOP with multiple CPUs
+	ncpu := int32(8)
+	lencn := 2
+	CalcNodeDOP(p, 1, ncpu, lencn)
+
+	// Verify that the AGG node does NOT have ForceOneCN=true
+	aggNode := p.GetQuery().Nodes[1]
+	require.NotNil(t, aggNode.Stats, "AGG node should have Stats")
+	require.False(t, aggNode.Stats.ForceOneCN, "Non-distinct aggregation should NOT have ForceOneCN=true")
+	// Dop should be calculated normally (not forced to 1)
+	require.Greater(t, aggNode.Stats.Dop, int32(0), "Non-distinct aggregation should have Dop > 0")
+}
+
+// TestCalcNodeDOP_DistinctAggregationWithNilStats tests that distinct aggregation
+// nodes with nil Stats are handled correctly
+func TestCalcNodeDOP_DistinctAggregationWithNilStats(t *testing.T) {
+	// Create a plan with an AGG node containing COUNT(DISTINCT ...) but no Stats
+	// Use a variable to avoid constant overflow when combining COUNT with Distinct flag
+	countVal := uint64(function.COUNT)
+	distinctVal := uint64(function.Distinct)
+	countWithDistinct := int64(countVal | distinctVal)
+	p := &plan.Plan{
+		Plan: &plan.Plan_Query{
+			Query: &plan.Query{
+				Nodes: []*plan.Node{
+					// Child node (scan)
+					{
+						NodeId:   0,
+						NodeType: plan.Node_TABLE_SCAN,
+						Stats:    DefaultStats(),
+					},
+					// AGG node with COUNT(DISTINCT ...) but nil Stats
+					{
+						NodeId:   1,
+						NodeType: plan.Node_AGG,
+						Children: []int32{0},
+						Stats:    nil, // nil Stats
+						AggList: []*plan.Expr{
+							{
+								Expr: &plan.Expr_F{
+									F: &plan.Function{
+										Func: &plan.ObjectRef{
+											// COUNT with Distinct flag: use uint64 to avoid overflow, then convert to int64
+											// Similar to having_binder.go:144, we need to convert to uint64 first
+											Obj:     countWithDistinct,
+											ObjName: "count",
+										},
+										Args: []*plan.Expr{
+											{
+												Typ: plan.Type{Id: int32(types.T_int64)},
+												Expr: &plan.Expr_Col{
+													Col: &plan.ColRef{ColPos: 0},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Steps: []int32{1},
+			},
+		},
+		IsPrepare: false,
+	}
+
+	// Call CalcNodeDOP
+	ncpu := int32(8)
+	lencn := 2
+	CalcNodeDOP(p, 1, ncpu, lencn)
+
+	// Verify that Stats was created and set correctly
+	aggNode := p.GetQuery().Nodes[1]
+	require.NotNil(t, aggNode.Stats, "Stats should be created for distinct aggregation")
+	require.Equal(t, int32(1), aggNode.Stats.Dop, "Distinct aggregation should have Dop=1")
+	require.True(t, aggNode.Stats.ForceOneCN, "Distinct aggregation should have ForceOneCN=true")
 }

--- a/test/distributed/cases/distinct/distinct.result
+++ b/test/distributed/cases/distinct/distinct.result
@@ -261,3 +261,23 @@ Phone    3    1    1
 TV    1    3    2
 TV    2    2    1
 drop table t13;
+drop table if exists t14;
+drop table if exists t15;
+create table t14 (i bigint, g bigint);
+create table t15 (o bigint, p bigint, v int);
+insert into t14 (select result, (result % 100) + 1 from generate_series(1, 100000, 1) g);
+insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from generate_series(1, 1000000, 1) g;
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i limit 10;
+g    i    COUNT(distinct t15.o)    SUM(t15.v)
+3    2    1    1000
+4    3    1    1000
+5    4    1    1000
+6    5    1    1000
+7    6    1    1000
+8    7    1    1000
+9    8    1    1000
+10    9    1    1000
+11    10    1    1000
+12    11    1    1000
+drop table t14;
+drop table t15;

--- a/test/distributed/cases/distinct/distinct.result
+++ b/test/distributed/cases/distinct/distinct.result
@@ -267,17 +267,17 @@ create table t14 (i bigint, g bigint);
 create table t15 (o bigint, p bigint, v int);
 insert into t14 (select result, (result % 100) + 1 from generate_series(1, 100000, 1) g);
 insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from generate_series(1, 1000000, 1) g;
-SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g limit 10;
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g, t14.i limit 10;
 g    i    COUNT(distinct t15.o)    SUM(t15.v)
-1    700    1    1000
-1    900    1    1000
-1    300    1    1000
-1    600    1    1000
-1    500    1    1000
-1    800    1    1000
-1    200    1    1000
 1    100    1    1000
+1    200    1    1000
+1    300    1    1000
 1    400    1    1000
+1    500    1    1000
+1    600    1    1000
+1    700    1    1000
+1    800    1    1000
+1    900    1    1000
 1    1000    1    1000
 drop table t14;
 drop table t15;

--- a/test/distributed/cases/distinct/distinct.result
+++ b/test/distributed/cases/distinct/distinct.result
@@ -57,8 +57,8 @@ a    b
 1    a
 2    null
 null    b
-null    
-3    
+null
+3
 null    null
 drop table t2;
 drop table if exists t3;
@@ -122,13 +122,13 @@ drop table if exists t7;
 CREATE TABLE t7 (a VARCHAR(400));
 INSERT INTO t7 (a) VALUES ("A"), ("a"), ("a "), ("a   "),
 ("B"), ("b"), ("b "), ("b   ");
-select * from t7;
+select * from t7 order by a;
 a
 A
+B
 a
 a 
 a   
-B
 b
 b 
 b   
@@ -267,17 +267,17 @@ create table t14 (i bigint, g bigint);
 create table t15 (o bigint, p bigint, v int);
 insert into t14 (select result, (result % 100) + 1 from generate_series(1, 100000, 1) g);
 insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from generate_series(1, 1000000, 1) g;
-SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i limit 10;
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g limit 10;
 g    i    COUNT(distinct t15.o)    SUM(t15.v)
-3    2    1    1000
-4    3    1    1000
-5    4    1    1000
-6    5    1    1000
-7    6    1    1000
-8    7    1    1000
-9    8    1    1000
-10    9    1    1000
-11    10    1    1000
-12    11    1    1000
+1    700    1    1000
+1    900    1    1000
+1    300    1    1000
+1    600    1    1000
+1    500    1    1000
+1    800    1    1000
+1    200    1    1000
+1    100    1    1000
+1    400    1    1000
+1    1000    1    1000
 drop table t14;
 drop table t15;

--- a/test/distributed/cases/distinct/distinct.sql
+++ b/test/distributed/cases/distinct/distinct.sql
@@ -220,6 +220,6 @@ insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from ge
 -- Test query with COUNT(DISTINCT) + SUM + GROUP BY multiple columns + JOIN
 -- This is the minimal case that triggers the distinct aggregation parallel execution error
 -- The query should execute successfully without error after the fix
-SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g limit 10;
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g, t14.i limit 10;
 drop table t14;
 drop table t15;

--- a/test/distributed/cases/distinct/distinct.sql
+++ b/test/distributed/cases/distinct/distinct.sql
@@ -202,3 +202,25 @@ INSERT INTO t13 VALUES ( 'Computer', 2,2000, 1200),
 SELECT product, country_id, COUNT(*), COUNT(distinct year) FROM t13 GROUP BY product, country_id order by product;
 
 drop table t13;
+
+
+-- test distinct aggregation with JOIN and GROUP BY multiple columns
+-- This test case verifies that distinct aggregation runs correctly in single CPU mode
+-- without triggering "distinct agg should be run in only one node and without any parallel" error
+drop table if exists t14;
+drop table if exists t15;
+
+create table t14 (i bigint, g bigint);
+create table t15 (o bigint, p bigint, v int);
+
+-- Insert data using generate_series to create sufficient data volume for testing parallel execution
+insert into t14 (select result, (result % 100) + 1 from generate_series(1, 100000, 1) g);
+insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from generate_series(1, 1000000, 1) g;
+
+-- Test query with COUNT(DISTINCT) + SUM + GROUP BY multiple columns + JOIN
+-- This is the minimal case that triggers the distinct aggregation parallel execution error
+-- The query should execute successfully without error after the fix
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i limit 10;
+
+drop table t14;
+drop table t15;

--- a/test/distributed/cases/distinct/distinct.sql
+++ b/test/distributed/cases/distinct/distinct.sql
@@ -96,7 +96,7 @@ CREATE TABLE t7 (a VARCHAR(400));
 INSERT INTO t7 (a) VALUES ("A"), ("a"), ("a "), ("a   "),
                           ("B"), ("b"), ("b "), ("b   ");
 
-select * from t7;
+select * from t7 order by a;
 SELECT COUNT(DISTINCT a) FROM t7;
 
 DROP TABLE t7;
@@ -220,7 +220,6 @@ insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from ge
 -- Test query with COUNT(DISTINCT) + SUM + GROUP BY multiple columns + JOIN
 -- This is the minimal case that triggers the distinct aggregation parallel execution error
 -- The query should execute successfully without error after the fix
-SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i limit 10;
-
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g limit 10;
 drop table t14;
 drop table t15;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixflow/issues/5860 https://github.com/matrixorigin/matrixflow/issues/5859

## What this PR does / why we need it:

Distinct aggregations `(e.g., COUNT(DISTINCT ...), SUM(DISTINCT ...))` cannot correctly merge results when executed in parallel. The query planner (CalcNodeDOP) did not detect distinct aggregations and force single-CPU execution, so the executor attempted parallel execution, triggering the error: "distinct agg should be run in only one node and without any parallel".