### PR TITLE
fix: distinct agg should be run in only one node and without any parallel

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -4314,6 +4314,21 @@ func (c *Compile) generateNodes(n *plan.Node) (engine.Nodes, error) {
 		partialResults, _, _ := checkAggOptimize(n)
 		if partialResults != nil {
 			forceSingle = true
+		} else if n.Stats != nil && n.Stats.ForceOneCN {
+			// ForceOneCN is already set by CalcNodeDOP for distinct aggregation
+			// Use it directly instead of checking again
+			forceSingle = true
+		} else {
+			// Fallback: Check if any aggregation function uses distinct flag
+			// This is defensive programming in case CalcNodeDOP didn't set ForceOneCN
+			for _, agg := range n.AggList {
+				if f, ok := agg.Expr.(*plan.Expr_F); ok {
+					if (uint64(f.F.Func.Obj) & function.Distinct) != 0 {
+						forceSingle = true
+						break
+					}
+				}
+			}
 		}
 	}
 	//if len(n.OrderBy) > 0 {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -35,6 +35,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
@@ -1824,10 +1825,15 @@ func setNodeDOP(p *plan.Plan, rootID int32, dop int32) {
 	if len(node.Children) > 0 {
 		setNodeDOP(p, node.Children[0], dop)
 	}
-	if node.NodeType == plan.Node_JOIN && node.Stats.HashmapStats.Shuffle {
+	if node.NodeType == plan.Node_JOIN &&
+		node.Stats != nil &&
+		node.Stats.HashmapStats != nil &&
+		node.Stats.HashmapStats.Shuffle {
 		setNodeDOP(p, node.Children[1], dop)
 	}
-	node.Stats.Dop = dop
+	if node.Stats != nil {
+		node.Stats.Dop = dop
+	}
 }
 
 func CalcNodeDOP(p *plan.Plan, rootID int32, ncpu int32, lencn int) {
@@ -1836,6 +1842,32 @@ func CalcNodeDOP(p *plan.Plan, rootID int32, ncpu int32, lencn int) {
 	for i := range node.Children {
 		CalcNodeDOP(p, node.Children[i], ncpu, lencn)
 	}
+
+	// Check if node has distinct aggregation, which should run in single CPU
+	hasDistinctAgg := false
+	if node.NodeType == plan.Node_AGG && len(node.AggList) > 0 {
+		for _, agg := range node.AggList {
+			if f, ok := agg.Expr.(*plan.Expr_F); ok {
+				if (uint64(f.F.Func.Obj) & function.Distinct) != 0 {
+					hasDistinctAgg = true
+					break
+				}
+			}
+		}
+	}
+
+	if hasDistinctAgg {
+		// distinct aggregation should run in only one node and without any parallel
+		if node.Stats == nil {
+			// If Stats is nil, create it first
+			// This should be rare for AGG nodes, but we handle it for safety
+			node.Stats = DefaultStats()
+		}
+		setNodeDOP(p, rootID, 1)
+		node.Stats.ForceOneCN = true
+		return
+	}
+
 	if node.Stats.HashmapStats != nil && node.Stats.HashmapStats.Shuffle && node.NodeType != plan.Node_TABLE_SCAN {
 		if node.NodeType == plan.Node_JOIN && node.JoinType == plan.Node_DEDUP {
 			setNodeDOP(p, rootID, ncpu)

--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	index2 "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/stretchr/testify/require"
 )
@@ -306,4 +307,202 @@ func TestUpdateStatsInfo_Decimal_DifferentScales(t *testing.T) {
 			require.InDelta(t, tc.maxFloat, maxVal, 0.01, "Max value mismatch")
 		})
 	}
+}
+
+// TestCalcNodeDOP_DistinctAggregation tests that distinct aggregation nodes
+// are correctly set to Dop=1 and ForceOneCN=true
+func TestCalcNodeDOP_DistinctAggregation(t *testing.T) {
+	// Create a plan with an AGG node containing COUNT(DISTINCT ...)
+	// Use a variable to avoid constant overflow when combining COUNT with Distinct flag
+	countVal := uint64(function.COUNT)
+	distinctVal := uint64(function.Distinct)
+	countWithDistinct := int64(countVal | distinctVal)
+	p := &planpb.Plan{
+		Plan: &planpb.Plan_Query{
+			Query: &planpb.Query{
+				Nodes: []*planpb.Node{
+					// Child node (scan)
+					{
+						NodeId:   0,
+						NodeType: planpb.Node_TABLE_SCAN,
+						Stats:    DefaultStats(),
+					},
+					// AGG node with COUNT(DISTINCT ...)
+					{
+						NodeId:   1,
+						NodeType: planpb.Node_AGG,
+						Children: []int32{0},
+						Stats:    DefaultStats(),
+						AggList: []*planpb.Expr{
+							{
+								Expr: &planpb.Expr_F{
+									F: &planpb.Function{
+										Func: &planpb.ObjectRef{
+											// COUNT with Distinct flag: use uint64 to avoid overflow, then convert to int64
+											// Similar to having_binder.go:144, we need to convert to uint64 first
+											Obj:     countWithDistinct,
+											ObjName: "count",
+										},
+										Args: []*planpb.Expr{
+											{
+												Typ: planpb.Type{Id: int32(types.T_int64)},
+												Expr: &planpb.Expr_Col{
+													Col: &planpb.ColRef{ColPos: 0},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Steps: []int32{1},
+			},
+		},
+		IsPrepare: false,
+	}
+
+	// Call CalcNodeDOP with multiple CPUs
+	ncpu := int32(8)
+	lencn := 2
+	CalcNodeDOP(p, 1, ncpu, lencn)
+
+	// Verify that the AGG node has Dop=1 and ForceOneCN=true
+	aggNode := p.GetQuery().Nodes[1]
+	require.NotNil(t, aggNode.Stats, "AGG node should have Stats")
+	require.Equal(t, int32(1), aggNode.Stats.Dop, "Distinct aggregation should have Dop=1")
+	require.True(t, aggNode.Stats.ForceOneCN, "Distinct aggregation should have ForceOneCN=true")
+
+	// Verify that child node also has Dop=1 (recursively set)
+	childNode := p.GetQuery().Nodes[0]
+	require.NotNil(t, childNode.Stats, "Child node should have Stats")
+	require.Equal(t, int32(1), childNode.Stats.Dop, "Child node should have Dop=1 (recursively set)")
+}
+
+// TestCalcNodeDOP_NonDistinctAggregation tests that non-distinct aggregation nodes
+// are not affected by the distinct aggregation logic
+func TestCalcNodeDOP_NonDistinctAggregation(t *testing.T) {
+	// Create a plan with an AGG node containing COUNT (without DISTINCT)
+	p := &planpb.Plan{
+		Plan: &planpb.Plan_Query{
+			Query: &planpb.Query{
+				Nodes: []*planpb.Node{
+					// Child node (scan)
+					{
+						NodeId:   0,
+						NodeType: planpb.Node_TABLE_SCAN,
+						Stats:    DefaultStats(),
+					},
+					// AGG node with COUNT (no DISTINCT)
+					{
+						NodeId:   1,
+						NodeType: planpb.Node_AGG,
+						Children: []int32{0},
+						Stats:    DefaultStats(),
+						AggList: []*planpb.Expr{
+							{
+								Expr: &planpb.Expr_F{
+									F: &planpb.Function{
+										Func: &planpb.ObjectRef{
+											Obj:     int64(function.COUNT), // COUNT without Distinct flag
+											ObjName: "count",
+										},
+										Args: []*planpb.Expr{
+											{
+												Typ: planpb.Type{Id: int32(types.T_int64)},
+												Expr: &planpb.Expr_Col{
+													Col: &planpb.ColRef{ColPos: 0},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Steps: []int32{1},
+			},
+		},
+		IsPrepare: false,
+	}
+
+	// Call CalcNodeDOP with multiple CPUs
+	ncpu := int32(8)
+	lencn := 2
+	CalcNodeDOP(p, 1, ncpu, lencn)
+
+	// Verify that the AGG node does NOT have ForceOneCN=true
+	aggNode := p.GetQuery().Nodes[1]
+	require.NotNil(t, aggNode.Stats, "AGG node should have Stats")
+	require.False(t, aggNode.Stats.ForceOneCN, "Non-distinct aggregation should NOT have ForceOneCN=true")
+	// Dop should be calculated normally (not forced to 1)
+	require.Greater(t, aggNode.Stats.Dop, int32(0), "Non-distinct aggregation should have Dop > 0")
+}
+
+// TestCalcNodeDOP_DistinctAggregationWithNilStats tests that distinct aggregation
+// nodes with nil Stats are handled correctly
+func TestCalcNodeDOP_DistinctAggregationWithNilStats(t *testing.T) {
+	// Create a plan with an AGG node containing COUNT(DISTINCT ...) but no Stats
+	// Use a variable to avoid constant overflow when combining COUNT with Distinct flag
+	countVal := uint64(function.COUNT)
+	distinctVal := uint64(function.Distinct)
+	countWithDistinct := int64(countVal | distinctVal)
+	p := &planpb.Plan{
+		Plan: &planpb.Plan_Query{
+			Query: &planpb.Query{
+				Nodes: []*planpb.Node{
+					// Child node (scan)
+					{
+						NodeId:   0,
+						NodeType: planpb.Node_TABLE_SCAN,
+						Stats:    DefaultStats(),
+					},
+					// AGG node with COUNT(DISTINCT ...) but nil Stats
+					{
+						NodeId:   1,
+						NodeType: planpb.Node_AGG,
+						Children: []int32{0},
+						Stats:    nil, // nil Stats
+						AggList: []*planpb.Expr{
+							{
+								Expr: &planpb.Expr_F{
+									F: &planpb.Function{
+										Func: &planpb.ObjectRef{
+											// COUNT with Distinct flag: use uint64 to avoid overflow, then convert to int64
+											// Similar to having_binder.go:144, we need to convert to uint64 first
+											Obj:     countWithDistinct,
+											ObjName: "count",
+										},
+										Args: []*planpb.Expr{
+											{
+												Typ: planpb.Type{Id: int32(types.T_int64)},
+												Expr: &planpb.Expr_Col{
+													Col: &planpb.ColRef{ColPos: 0},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Steps: []int32{1},
+			},
+		},
+		IsPrepare: false,
+	}
+
+	// Call CalcNodeDOP
+	ncpu := int32(8)
+	lencn := 2
+	CalcNodeDOP(p, 1, ncpu, lencn)
+
+	// Verify that Stats was created and set correctly
+	aggNode := p.GetQuery().Nodes[1]
+	require.NotNil(t, aggNode.Stats, "Stats should be created for distinct aggregation")
+	require.Equal(t, int32(1), aggNode.Stats.Dop, "Distinct aggregation should have Dop=1")
+	require.True(t, aggNode.Stats.ForceOneCN, "Distinct aggregation should have ForceOneCN=true")
 }

--- a/test/distributed/cases/distinct/distinct.result
+++ b/test/distributed/cases/distinct/distinct.result
@@ -122,13 +122,13 @@ drop table if exists t7;
 CREATE TABLE t7 (a VARCHAR(400));
 INSERT INTO t7 (a) VALUES ("A"), ("a"), ("a "), ("a   "),
 ("B"), ("b"), ("b "), ("b   ");
-select * from t7;
+select * from t7 order by a;
 a
 A
+B
 a
 a 
 a   
-B
 b
 b 
 b   
@@ -267,17 +267,17 @@ create table t14 (i bigint, g bigint);
 create table t15 (o bigint, p bigint, v int);
 insert into t14 (select result, (result % 100) + 1 from generate_series(1, 100000, 1) g);
 insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from generate_series(1, 1000000, 1) g;
-SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i limit 10;
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g limit 10;
 g    i    COUNT(distinct t15.o)    SUM(t15.v)
-3    2    1    1000
-4    3    1    1000
-5    4    1    1000
-6    5    1    1000
-7    6    1    1000
-8    7    1    1000
-9    8    1    1000
-10    9    1    1000
-11    10    1    1000
-12    11    1    1000
+1    700    1    1000
+1    900    1    1000
+1    300    1    1000
+1    600    1    1000
+1    500    1    1000
+1    800    1    1000
+1    200    1    1000
+1    100    1    1000
+1    400    1    1000
+1    1000    1    1000
 drop table t14;
 drop table t15;

--- a/test/distributed/cases/distinct/distinct.result
+++ b/test/distributed/cases/distinct/distinct.result
@@ -261,3 +261,23 @@ Phone    3    1    1
 TV    1    3    2
 TV    2    2    1
 drop table t13;
+drop table if exists t14;
+drop table if exists t15;
+create table t14 (i bigint, g bigint);
+create table t15 (o bigint, p bigint, v int);
+insert into t14 (select result, (result % 100) + 1 from generate_series(1, 100000, 1) g);
+insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from generate_series(1, 1000000, 1) g;
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i limit 10;
+g    i    COUNT(distinct t15.o)    SUM(t15.v)
+3    2    1    1000
+4    3    1    1000
+5    4    1    1000
+6    5    1    1000
+7    6    1    1000
+8    7    1    1000
+9    8    1    1000
+10    9    1    1000
+11    10    1    1000
+12    11    1    1000
+drop table t14;
+drop table t15;

--- a/test/distributed/cases/distinct/distinct.result
+++ b/test/distributed/cases/distinct/distinct.result
@@ -267,17 +267,17 @@ create table t14 (i bigint, g bigint);
 create table t15 (o bigint, p bigint, v int);
 insert into t14 (select result, (result % 100) + 1 from generate_series(1, 100000, 1) g);
 insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from generate_series(1, 1000000, 1) g;
-SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g limit 10;
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g, t14.i limit 10;
 g    i    COUNT(distinct t15.o)    SUM(t15.v)
-1    700    1    1000
-1    900    1    1000
-1    300    1    1000
-1    600    1    1000
-1    500    1    1000
-1    800    1    1000
-1    200    1    1000
 1    100    1    1000
+1    200    1    1000
+1    300    1    1000
 1    400    1    1000
+1    500    1    1000
+1    600    1    1000
+1    700    1    1000
+1    800    1    1000
+1    900    1    1000
 1    1000    1    1000
 drop table t14;
 drop table t15;

--- a/test/distributed/cases/distinct/distinct.sql
+++ b/test/distributed/cases/distinct/distinct.sql
@@ -220,7 +220,7 @@ insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from ge
 -- Test query with COUNT(DISTINCT) + SUM + GROUP BY multiple columns + JOIN
 -- This is the minimal case that triggers the distinct aggregation parallel execution error
 -- The query should execute successfully without error after the fix
-SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g limit 10;
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g, t14.i limit 10;
 
 drop table t14;
 drop table t15;

--- a/test/distributed/cases/distinct/distinct.sql
+++ b/test/distributed/cases/distinct/distinct.sql
@@ -202,3 +202,25 @@ INSERT INTO t13 VALUES ( 'Computer', 2,2000, 1200),
 SELECT product, country_id, COUNT(*), COUNT(distinct year) FROM t13 GROUP BY product, country_id order by product;
 
 drop table t13;
+
+
+-- test distinct aggregation with JOIN and GROUP BY multiple columns
+-- This test case verifies that distinct aggregation runs correctly in single CPU mode
+-- without triggering "distinct agg should be run in only one node and without any parallel" error
+drop table if exists t14;
+drop table if exists t15;
+
+create table t14 (i bigint, g bigint);
+create table t15 (o bigint, p bigint, v int);
+
+-- Insert data using generate_series to create sufficient data volume for testing parallel execution
+insert into t14 (select result, (result % 100) + 1 from generate_series(1, 100000, 1) g);
+insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from generate_series(1, 1000000, 1) g;
+
+-- Test query with COUNT(DISTINCT) + SUM + GROUP BY multiple columns + JOIN
+-- This is the minimal case that triggers the distinct aggregation parallel execution error
+-- The query should execute successfully without error after the fix
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i limit 10;
+
+drop table t14;
+drop table t15;

--- a/test/distributed/cases/distinct/distinct.sql
+++ b/test/distributed/cases/distinct/distinct.sql
@@ -96,7 +96,7 @@ CREATE TABLE t7 (a VARCHAR(400));
 INSERT INTO t7 (a) VALUES ("A"), ("a"), ("a "), ("a   "),
                           ("B"), ("b"), ("b "), ("b   ");
 
-select * from t7;
+select * from t7 order by a;
 SELECT COUNT(DISTINCT a) FROM t7;
 
 DROP TABLE t7;
@@ -220,7 +220,7 @@ insert into t15 select (result % 5000) + 1, ((result % 100000) + 1), 100 from ge
 -- Test query with COUNT(DISTINCT) + SUM + GROUP BY multiple columns + JOIN
 -- This is the minimal case that triggers the distinct aggregation parallel execution error
 -- The query should execute successfully without error after the fix
-SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i limit 10;
+SELECT t14.g, t14.i, COUNT(DISTINCT t15.o), SUM(t15.v) FROM t14 JOIN t15 ON t14.i = t15.p GROUP BY t14.g, t14.i ORDER BY t14.g limit 10;
 
 drop table t14;
 drop table t15;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixflow/issues/5860 https://github.com/matrixorigin/matrixflow/issues/5859

## What this PR does / why we need it:

Distinct aggregations `(e.g., COUNT(DISTINCT ...), SUM(DISTINCT ...))` cannot correctly merge results when executed in parallel. The query planner (CalcNodeDOP) did not detect distinct aggregations and force single-CPU execution, so the executor attempted parallel execution, triggering the error: "distinct agg should be run in only one node and without any parallel".