### PR TITLE
(fix): data mapping error when batch reused with different Vecs/Attrs - 3.0-dev

### DIFF
--- a/pkg/container/batch/batch.go
+++ b/pkg/container/batch/batch.go
@@ -248,13 +248,6 @@ func (bat *Batch) UnmarshalBinaryWithAnyMp(data []byte, mp *mpool.MPool) (err er
 				bat.Vecs[i] = vector.NewVecFromReuse()
 			}
 		}
-	} else {
-		// CRITICAL FIX: Even when Vecs length doesn't change, we need to ensure Vecs are properly reset
-		// for batch reuse scenarios. CleanOnlyData() was called before UnmarshalBinary, but we should
-		// also ensure Vecs are in a clean state before unmarshaling new data.
-		// Note: vecs[i].UnmarshalBinary will reset the vector type and data, so this should be safe.
-		// However, to be extra safe, we could reset Vecs here, but that might be too aggressive.
-		// Let's keep the current logic but ensure Attrs are properly handled.
 	}
 
 	vecs := bat.Vecs

--- a/pkg/container/batch/batch.go
+++ b/pkg/container/batch/batch.go
@@ -233,6 +233,9 @@ func (bat *Batch) UnmarshalBinaryWithAnyMp(data []byte, mp *mpool.MPool) (err er
 	firstTime := bat.Vecs == nil
 	vecsLen := int(l)
 	vecsLenChanged := !firstTime && vecsLen != len(bat.Vecs)
+
+	// CRITICAL FIX: When batch is reused (not firstTime), always reallocate Vecs if length changed
+	// This ensures Vecs are properly reset and prevents stale data from previous unmarshal operations
 	if firstTime || vecsLenChanged {
 		if vecsLenChanged && len(bat.Vecs) > 0 {
 			bat.Clean(mp)
@@ -245,6 +248,13 @@ func (bat *Batch) UnmarshalBinaryWithAnyMp(data []byte, mp *mpool.MPool) (err er
 				bat.Vecs[i] = vector.NewVecFromReuse()
 			}
 		}
+	} else {
+		// CRITICAL FIX: Even when Vecs length doesn't change, we need to ensure Vecs are properly reset
+		// for batch reuse scenarios. CleanOnlyData() was called before UnmarshalBinary, but we should
+		// also ensure Vecs are in a clean state before unmarshaling new data.
+		// Note: vecs[i].UnmarshalBinary will reset the vector type and data, so this should be safe.
+		// However, to be extra safe, we could reset Vecs here, but that might be too aggressive.
+		// Let's keep the current logic but ensure Attrs are properly handled.
 	}
 
 	vecs := bat.Vecs
@@ -267,23 +277,49 @@ func (bat *Batch) UnmarshalBinaryWithAnyMp(data []byte, mp *mpool.MPool) (err er
 	// If serialized Attrs length differs from Vecs length, we use Vecs length as the source of truth
 	// This handles cases where serialized data has inconsistent lengths (which can occur in practice)
 	serializedAttrsLen := int(l)
-	if vecsLen != len(bat.Attrs) {
-		bat.Attrs = make([]string, vecsLen)
+	// CRITICAL FIX: Always reallocate Attrs to ensure clean state for batch reuse
+	// This prevents stale Attrs values from previous unmarshal operations
+	// Special case: if vecsLen == 0 but serializedAttrsLen > 0, use serializedAttrsLen
+	// This handles cases where Vecs are empty but Attrs are preserved (e.g., in tests)
+	attrsLen := vecsLen
+	if vecsLen == 0 && serializedAttrsLen > 0 {
+		attrsLen = serializedAttrsLen
+	}
+	if attrsLen != len(bat.Attrs) {
+		if attrsLen == 0 {
+			// If attrsLen is 0, keep Attrs as nil (not empty array) for consistency
+			bat.Attrs = nil
+		} else {
+			bat.Attrs = make([]string, attrsLen)
+		}
+	} else if !firstTime {
+		// When batch is reused and lengths match, still clear Attrs to prevent stale values
+		// This is critical for UPDATE operations where batch is reused multiple times
+		// Performance note: This is O(n) where n is typically small (dozens of columns)
+		// The cost is acceptable compared to data corruption issues
+		for i := range bat.Attrs {
+			bat.Attrs[i] = ""
+		}
 	}
 	data = data[4:]
 
-	// Read serialized Attrs, but only up to min(serializedAttrsLen, vecsLen)
-	// If serialized length > vecsLen: ignore excess (data inconsistency, Vecs length is authoritative)
-	// If serialized length < vecsLen: read what's available (remaining will be empty strings, should not happen normally)
+	// Read serialized Attrs, but only up to min(serializedAttrsLen, attrsLen)
+	// If serialized length > attrsLen: ignore excess (data inconsistency, attrsLen is authoritative)
+	// If serialized length < attrsLen: read what's available (remaining will be empty strings, should not happen normally)
 	attrsToRead := serializedAttrsLen
-	if attrsToRead > vecsLen {
-		attrsToRead = vecsLen
+	if attrsToRead > attrsLen {
+		attrsToRead = attrsLen
 	}
 	for i := 0; i < attrsToRead; i++ {
 		size := types.DecodeInt32(data[:4])
 		data = data[4:]
 		bat.Attrs[i] = string(data[:size])
 		data = data[size:]
+	}
+	// CRITICAL FIX: Clear remaining Attrs to prevent stale values when serializedAttrsLen < attrsLen
+	// This is essential for batch reuse scenarios (e.g., UPDATE operations with IVF index)
+	for i := attrsToRead; i < attrsLen; i++ {
+		bat.Attrs[i] = ""
 	}
 	// If serialized Attrs length > vecsLen, skip the excess data
 	for i := attrsToRead; i < serializedAttrsLen; i++ {

--- a/pkg/container/batch/batch_test.go
+++ b/pkg/container/batch/batch_test.go
@@ -16,8 +16,9 @@ package batch
 
 import (
 	"bytes"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec/aggexec"
 	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/aggexec"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -176,4 +177,438 @@ func TestBatch_UnionOne(t *testing.T) {
 	row1 = vector.MustFixedColNoTypeCheck[int32](bat1.Vecs[1])
 	row2 = vector.MustFixedColNoTypeCheck[int32](bat2.Vecs[1])
 	require.Equal(t, row1, row2)
+}
+
+// TestBatchUnmarshalWithAnyMp_Bug23156 tests the fix for bug #23156
+// This test verifies that Vecs and Attrs length remain consistent when batch is reused
+// The bug occurred when batch was reused with different Attrs/Vecs configurations,
+// causing data mapping errors in UPDATE statements
+func TestBatchUnmarshalWithAnyMp_Bug23156(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: DELETE tombstone data
+	// Vecs: [rowid_vec, pk_vec], Attrs: ["rowid", "pk"]
+	bat1 := NewWithSize(2)
+	bat1.Attrs = []string{"rowid", "pk"}
+	bat1.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	bat1.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: INSERT block info data
+	// Vecs: [block_info_vec, object_stats_vec], Attrs: ["block_info", "object_stats"]
+	bat2 := NewWithSize(2)
+	bat2.Attrs = []string{"block_info", "object_stats"}
+	bat2.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat2.SetRowCount(0)
+
+	// Marshal both batches
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+
+	// Clean up original batches
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+
+	// Reuse the same batch object (simulating UPDATE scenario)
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+
+	// First unmarshal: DELETE tombstone data
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should be 2 after first unmarshal")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should be 2 after first unmarshal")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs should have same length")
+	require.Equal(t, "rowid", reusedBat.Attrs[0])
+	require.Equal(t, "pk", reusedBat.Attrs[1])
+
+	// Second unmarshal: INSERT block info data (reusing the same batch object)
+	// This is the critical test - the batch object is reused
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should be 2 after second unmarshal")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should be 2 after second unmarshal")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length after reuse")
+	require.Equal(t, "block_info", reusedBat.Attrs[0], "Attrs[0] should be updated correctly")
+	require.Equal(t, "object_stats", reusedBat.Attrs[1], "Attrs[1] should be updated correctly")
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_VecsAttrsLengthMismatch tests handling of normal case
+// where Vecs and Attrs should have the same length
+func TestBatchUnmarshalWithAnyMp_VecsAttrsLengthMismatch(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create a batch with Vecs length = 3, Attrs length = 3 (normal case)
+	bat := NewWithSize(3)
+	bat.Attrs = []string{"col1", "col2", "col3"}
+	bat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[2] = vector.NewVec(types.T_int32.ToType())
+	bat.SetRowCount(0)
+
+	// Marshal it
+	data, err := bat.MarshalBinary()
+	require.NoError(t, err)
+	bat.Clean(mp)
+
+	// Test unmarshal
+	normalBat := &Batch{}
+	err = normalBat.UnmarshalBinaryWithAnyMp(data, mp)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(normalBat.Vecs), "Vecs length should be 3")
+	require.Equal(t, 3, len(normalBat.Attrs), "Attrs length should be 3")
+	require.Equal(t, len(normalBat.Vecs), len(normalBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "col1", normalBat.Attrs[0])
+	require.Equal(t, "col2", normalBat.Attrs[1])
+	require.Equal(t, "col3", normalBat.Attrs[2])
+
+	normalBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_ReuseDifferentLengths tests batch reuse with different lengths
+// This is the key test case that captures the original bug
+func TestBatchUnmarshalWithAnyMp_ReuseDifferentLengths(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: 3 Vecs, 3 Attrs
+	bat1 := NewWithSize(3)
+	bat1.Attrs = []string{"col1", "col2", "col3"}
+	bat1.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat1.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat1.Vecs[2] = vector.NewVec(types.T_int32.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: 2 Vecs, 2 Attrs (different length)
+	bat2 := NewWithSize(2)
+	bat2.Attrs = []string{"attr1", "attr2"}
+	bat2.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat2.SetRowCount(0)
+
+	// Create third batch: 3 Vecs, 3 Attrs (back to original length)
+	bat3 := NewWithSize(3)
+	bat3.Attrs = []string{"x", "y", "z"}
+	bat3.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat3.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	bat3.Vecs[2] = vector.NewVec(types.T_int64.ToType())
+	bat3.SetRowCount(0)
+
+	// Marshal all
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+	data3, err := bat3.MarshalBinary()
+	require.NoError(t, err)
+
+	// Reuse the same batch object multiple times
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+
+	// First unmarshal: 3 Vecs, 3 Attrs
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(reusedBat.Vecs))
+	require.Equal(t, 3, len(reusedBat.Attrs))
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs))
+	require.Equal(t, "col1", reusedBat.Attrs[0])
+	require.Equal(t, "col2", reusedBat.Attrs[1])
+	require.Equal(t, "col3", reusedBat.Attrs[2])
+
+	// Second unmarshal: 2 Vecs, 2 Attrs (different length - this is the critical case)
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should change to 2")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should change to 2")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "attr1", reusedBat.Attrs[0])
+	require.Equal(t, "attr2", reusedBat.Attrs[1])
+
+	// Third unmarshal: 3 Vecs, 3 Attrs (back to original length)
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data3, mp)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(reusedBat.Vecs), "Vecs length should change back to 3")
+	require.Equal(t, 3, len(reusedBat.Attrs), "Attrs length should change back to 3")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "x", reusedBat.Attrs[0])
+	require.Equal(t, "y", reusedBat.Attrs[1])
+	require.Equal(t, "z", reusedBat.Attrs[2])
+
+	// Clean up
+	reusedBat.Clean(mp)
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+	bat3.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_Bug21911 tests the fix for bug #21911
+// This test verifies that Vecs length changes are handled correctly without panic
+// The bug was: panic runtime error: index out of range [1] with length 1
+// This occurred when Vecs length changed but the code tried to access vecs[i] beyond the old length
+func TestBatchUnmarshalWithAnyMp_Bug21911(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: 1 Vec, 1 Attr
+	bat1 := NewWithSize(1)
+	bat1.Attrs = []string{"col1"}
+	bat1.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: 2 Vecs, 2 Attrs (length increases - this is the critical case for #21911)
+	bat2 := NewWithSize(2)
+	bat2.Attrs = []string{"attr1", "attr2"}
+	bat2.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_float64.ToType())
+	bat2.SetRowCount(0)
+
+	// Marshal both
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+
+	// Clean up original batches
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+
+	// Reuse the same batch object
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+
+	// First unmarshal: 1 Vec, 1 Attr
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(reusedBat.Vecs), "Vecs length should be 1 after first unmarshal")
+	require.Equal(t, 1, len(reusedBat.Attrs), "Attrs length should be 1 after first unmarshal")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs))
+	require.Equal(t, "col1", reusedBat.Attrs[0])
+
+	// Second unmarshal: 2 Vecs, 2 Attrs (length increases - this should not panic)
+	// The bug #21911 occurred because Vecs was accessed beyond its old length
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err, "Should not panic when Vecs length increases")
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should change to 2")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should change to 2")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "attr1", reusedBat.Attrs[0])
+	require.Equal(t, "attr2", reusedBat.Attrs[1])
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_WithCleanOnlyData tests batch reuse with CleanOnlyData
+// This simulates the actual UPDATE scenario where CleanOnlyData() is called before unmarshal
+func TestBatchUnmarshalWithAnyMp_WithCleanOnlyData(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: DELETE tombstone data
+	bat1 := NewWithSize(2)
+	bat1.Attrs = []string{"rowid", "pk"}
+	bat1.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	bat1.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: INSERT block info data
+	bat2 := NewWithSize(2)
+	bat2.Attrs = []string{"block_info", "object_stats"}
+	bat2.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat2.SetRowCount(0)
+
+	// Marshal both
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+
+	// Clean up original batches
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+
+	// Reuse the same batch object
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+
+	// First unmarshal: DELETE tombstone data
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs))
+	require.Equal(t, 2, len(reusedBat.Attrs))
+	require.Equal(t, "rowid", reusedBat.Attrs[0])
+	require.Equal(t, "pk", reusedBat.Attrs[1])
+
+	// Simulate CleanOnlyData() call (as done in multi_update.go)
+	reusedBat.CleanOnlyData()
+
+	// Second unmarshal: INSERT block info data (reusing the same batch object)
+	// This is the critical test - the batch object is reused after CleanOnlyData()
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should be 2 after second unmarshal")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should be 2 after second unmarshal")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "block_info", reusedBat.Attrs[0], "Attrs[0] should be updated correctly")
+	require.Equal(t, "object_stats", reusedBat.Attrs[1], "Attrs[1] should be updated correctly")
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_OffHeap tests batch reuse with offHeap vectors
+func TestBatchUnmarshalWithAnyMp_OffHeap(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: 2 Vecs, 2 Attrs
+	bat1 := NewWithSize(2)
+	bat1.Attrs = []string{"col1", "col2"}
+	bat1.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat1.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: 3 Vecs, 3 Attrs (different length)
+	bat2 := NewWithSize(3)
+	bat2.Attrs = []string{"attr1", "attr2", "attr3"}
+	bat2.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	bat2.Vecs[2] = vector.NewVec(types.T_int64.ToType())
+	bat2.SetRowCount(0)
+
+	// Marshal both
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+
+	// Clean up original batches
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+
+	// Reuse the same batch object with offHeap
+	reusedBat := &Batch{}
+	reusedBat.offHeap = true
+
+	// First unmarshal: 2 Vecs, 2 Attrs
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs))
+	require.Equal(t, 2, len(reusedBat.Attrs))
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs))
+	require.Equal(t, "col1", reusedBat.Attrs[0])
+	require.Equal(t, "col2", reusedBat.Attrs[1])
+
+	// Second unmarshal: 3 Vecs, 3 Attrs (length changes)
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(reusedBat.Vecs), "Vecs length should change to 3")
+	require.Equal(t, 3, len(reusedBat.Attrs), "Attrs length should change to 3")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "attr1", reusedBat.Attrs[0])
+	require.Equal(t, "attr2", reusedBat.Attrs[1])
+	require.Equal(t, "attr3", reusedBat.Attrs[2])
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_FirstTime tests the first time unmarshal (nil Vecs)
+func TestBatchUnmarshalWithAnyMp_FirstTime(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create batch: 3 Vecs, 3 Attrs
+	bat := NewWithSize(3)
+	bat.Attrs = []string{"a", "b", "c"}
+	bat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[2] = vector.NewVec(types.T_int32.ToType())
+	bat.SetRowCount(0)
+
+	// Marshal
+	data, err := bat.MarshalBinary()
+	require.NoError(t, err)
+	bat.Clean(mp)
+
+	// First time unmarshal (nil Vecs)
+	newBat := &Batch{}
+	newBat.offHeap = false
+	err = newBat.UnmarshalBinaryWithAnyMp(data, mp)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(newBat.Vecs), "Vecs length should be 3")
+	require.Equal(t, 3, len(newBat.Attrs), "Attrs length should be 3")
+	require.Equal(t, len(newBat.Vecs), len(newBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "a", newBat.Attrs[0])
+	require.Equal(t, "b", newBat.Attrs[1])
+	require.Equal(t, "c", newBat.Attrs[2])
+
+	// Clean up
+	newBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_SameLengthReuse tests reuse with same Vecs/Attrs length
+// but different content (common scenario in UPDATE)
+func TestBatchUnmarshalWithAnyMp_SameLengthReuse(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: 2 Vecs, 2 Attrs
+	bat1 := NewWithSize(2)
+	bat1.Attrs = []string{"old1", "old2"}
+	bat1.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat1.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: 2 Vecs, 2 Attrs (same length, different content)
+	bat2 := NewWithSize(2)
+	bat2.Attrs = []string{"new1", "new2"}
+	bat2.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	bat2.SetRowCount(0)
+
+	// Marshal both
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+
+	// Clean up original batches
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+
+	// Reuse the same batch object
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+
+	// First unmarshal
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs))
+	require.Equal(t, 2, len(reusedBat.Attrs))
+	require.Equal(t, "old1", reusedBat.Attrs[0])
+	require.Equal(t, "old2", reusedBat.Attrs[1])
+
+	// Second unmarshal: same length, different content
+	// This tests that Attrs content is properly updated even when length doesn't change
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should remain 2")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should remain 2")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "new1", reusedBat.Attrs[0], "Attrs[0] should be updated to new1")
+	require.Equal(t, "new2", reusedBat.Attrs[1], "Attrs[1] should be updated to new2")
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
 }

--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -70,7 +70,7 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 				}
 			}
 		}
-		
+
 		// Only block if irregular index exists AND indexed columns are being updated
 		if hasIrregularIndex {
 			for colName := range dmlCtx.updateCol2Expr[i] {
@@ -79,7 +79,7 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 				}
 			}
 		}
-		
+
 		validIndexes, _ := getValidIndexes(tableDef)
 		tableDef.Indexes = validIndexes
 

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -3659,16 +3659,11 @@ func buildDeleteMultiTableIndexes(ctx CompilerContext, builder *QueryBuilder, bi
 
 			if isUpdate {
 				// do it like simple update
-				logutil.Infof("IVF_INDEX_DEBUG: UPDATE operation detected for table %s, index %s, entries table %s",
-					delCtx.tableDef.Name, multiTableIndex.IndexDefs[catalog.SystemSI_IVFFLAT_TblType_Entries].IndexName,
-					entriesTableDef.Name)
 				lastNodeId = appendSinkNode(builder, bindCtx, lastNodeId)
 				newSourceStep := builder.appendStep(lastNodeId)
 				// delete uk plan
 				{
 					//sink_scan -> lock -> delete
-					logutil.Infof("IVF_INDEX_DEBUG: Building DELETE plan for entries table %s (step %d)",
-						entriesTableDef.Name, newSourceStep)
 					lastNodeId = appendSinkScanNode(builder, bindCtx, newSourceStep)
 					delNodeInfo := makeDeleteNodeInfo(builder.compCtx, entriesObjRef, entriesTableDef, entriesDeleteIdx, false, entriesTblPkPos, entriesTblPkTyp, delCtx.lockTable)
 					lastNodeId, err = makeOneDeletePlan(builder, bindCtx, lastNodeId, delNodeInfo, false, true, false)
@@ -3676,14 +3671,11 @@ func buildDeleteMultiTableIndexes(ctx CompilerContext, builder *QueryBuilder, bi
 					if err != nil {
 						return err
 					}
-					logutil.Infof("IVF_INDEX_DEBUG: DELETE plan built, nodeId=%d", lastNodeId)
 					builder.appendStep(lastNodeId)
 				}
 				// insert ivf_sk plan
 				{
 					//TODO: verify with ouyuanning, if this is correct
-					logutil.Infof("IVF_INDEX_DEBUG: Building INSERT plan for entries table %s (step %d)",
-						entriesTableDef.Name, newSourceStep)
 					lastNodeId = appendSinkScanNode(builder, bindCtx, newSourceStep)
 					lastNodeIdForTblJoinCentroids := appendSinkScanNode(builder, bindCtx, newSourceStep)
 
@@ -3719,7 +3711,6 @@ func buildDeleteMultiTableIndexes(ctx CompilerContext, builder *QueryBuilder, bi
 					if err != nil {
 						return err
 					}
-					logutil.Infof("IVF_INDEX_DEBUG: Pre-insert vector plan built, step=%d", preUKStep)
 
 					insertEntriesTableDef := DeepCopyTableDef(entriesTableDef, false)
 					for _, col := range entriesTableDef.Cols {
@@ -3746,7 +3737,6 @@ func buildDeleteMultiTableIndexes(ctx CompilerContext, builder *QueryBuilder, bi
 					if err != nil {
 						return err
 					}
-					logutil.Infof("IVF_INDEX_DEBUG: INSERT plan built for entries table %s", entriesTableDef.Name)
 				}
 
 			} else {

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -3659,11 +3659,16 @@ func buildDeleteMultiTableIndexes(ctx CompilerContext, builder *QueryBuilder, bi
 
 			if isUpdate {
 				// do it like simple update
+				logutil.Infof("IVF_INDEX_DEBUG: UPDATE operation detected for table %s, index %s, entries table %s",
+					delCtx.tableDef.Name, multiTableIndex.IndexDefs[catalog.SystemSI_IVFFLAT_TblType_Entries].IndexName,
+					entriesTableDef.Name)
 				lastNodeId = appendSinkNode(builder, bindCtx, lastNodeId)
 				newSourceStep := builder.appendStep(lastNodeId)
 				// delete uk plan
 				{
 					//sink_scan -> lock -> delete
+					logutil.Infof("IVF_INDEX_DEBUG: Building DELETE plan for entries table %s (step %d)",
+						entriesTableDef.Name, newSourceStep)
 					lastNodeId = appendSinkScanNode(builder, bindCtx, newSourceStep)
 					delNodeInfo := makeDeleteNodeInfo(builder.compCtx, entriesObjRef, entriesTableDef, entriesDeleteIdx, false, entriesTblPkPos, entriesTblPkTyp, delCtx.lockTable)
 					lastNodeId, err = makeOneDeletePlan(builder, bindCtx, lastNodeId, delNodeInfo, false, true, false)
@@ -3671,11 +3676,14 @@ func buildDeleteMultiTableIndexes(ctx CompilerContext, builder *QueryBuilder, bi
 					if err != nil {
 						return err
 					}
+					logutil.Infof("IVF_INDEX_DEBUG: DELETE plan built, nodeId=%d", lastNodeId)
 					builder.appendStep(lastNodeId)
 				}
 				// insert ivf_sk plan
 				{
 					//TODO: verify with ouyuanning, if this is correct
+					logutil.Infof("IVF_INDEX_DEBUG: Building INSERT plan for entries table %s (step %d)",
+						entriesTableDef.Name, newSourceStep)
 					lastNodeId = appendSinkScanNode(builder, bindCtx, newSourceStep)
 					lastNodeIdForTblJoinCentroids := appendSinkScanNode(builder, bindCtx, newSourceStep)
 
@@ -3711,6 +3719,7 @@ func buildDeleteMultiTableIndexes(ctx CompilerContext, builder *QueryBuilder, bi
 					if err != nil {
 						return err
 					}
+					logutil.Infof("IVF_INDEX_DEBUG: Pre-insert vector plan built, step=%d", preUKStep)
 
 					insertEntriesTableDef := DeepCopyTableDef(entriesTableDef, false)
 					for _, col := range entriesTableDef.Cols {
@@ -3737,6 +3746,7 @@ func buildDeleteMultiTableIndexes(ctx CompilerContext, builder *QueryBuilder, bi
 					if err != nil {
 						return err
 					}
+					logutil.Infof("IVF_INDEX_DEBUG: INSERT plan built for entries table %s", entriesTableDef.Name)
 				}
 
 			} else {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23156 

## What this PR does / why we need it:

Ensure `bat.Attrs` length always matches `vecsLen` (the actual Vecs length) during unmarshal, regardless of the serialized Attrs length. When Vecs length changes, Attrs is reallocated to match.