### PR TITLE
fix: replace into rows affected

### DIFF
--- a/pkg/sql/colexec/multi_update/multi_update_partition_test.go
+++ b/pkg/sql/colexec/multi_update/multi_update_partition_test.go
@@ -40,3 +40,193 @@ func TestNewPartitionMultiUpdateFrom(t *testing.T) {
 	require.Equal(t, ps.raw.Engine, op.(*PartitionMultiUpdate).raw.Engine)
 	require.Equal(t, ps.tableID, op.(*PartitionMultiUpdate).tableID)
 }
+
+func TestAddInsertAffectRows(t *testing.T) {
+	tests := []struct {
+		name       string
+		action     actionType
+		tableType  UpdateTableType
+		rowCount   uint64
+		expectRows uint64
+	}{
+		{
+			name:       "actionInsert with main table",
+			action:     actionInsert,
+			tableType:  UpdateMainTable,
+			rowCount:   5,
+			expectRows: 5,
+		},
+		{
+			name:       "actionUpdate with main table (REPLACE INTO)",
+			action:     actionUpdate,
+			tableType:  UpdateMainTable,
+			rowCount:   3,
+			expectRows: 3,
+		},
+		{
+			name:       "actionInsert with unique index table (should not count)",
+			action:     actionInsert,
+			tableType:  UpdateUniqueIndexTable,
+			rowCount:   5,
+			expectRows: 0,
+		},
+		{
+			name:       "actionUpdate with unique index table (should not count)",
+			action:     actionUpdate,
+			tableType:  UpdateUniqueIndexTable,
+			rowCount:   3,
+			expectRows: 0,
+		},
+		{
+			name:       "actionDelete with main table (should not count)",
+			action:     actionDelete,
+			tableType:  UpdateMainTable,
+			rowCount:   2,
+			expectRows: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			update := &MultiUpdate{
+				ctr: container{
+					action:       tt.action,
+					affectedRows: 0,
+				},
+			}
+			update.addAffectedRowsFunc = update.doAddAffectedRows
+
+			update.addInsertAffectRows(tt.tableType, tt.rowCount)
+
+			require.Equal(t, tt.expectRows, update.ctr.affectedRows, "affected rows should match expected value")
+		})
+	}
+}
+
+func TestAddDeleteAffectRows(t *testing.T) {
+	tests := []struct {
+		name       string
+		action     actionType
+		tableType  UpdateTableType
+		rowCount   uint64
+		expectRows uint64
+	}{
+		{
+			name:       "actionDelete with main table",
+			action:     actionDelete,
+			tableType:  UpdateMainTable,
+			rowCount:   5,
+			expectRows: 5,
+		},
+		{
+			name:       "actionUpdate with main table (should not count for REPLACE INTO)",
+			action:     actionUpdate,
+			tableType:  UpdateMainTable,
+			rowCount:   3,
+			expectRows: 0,
+		},
+		{
+			name:       "actionDelete with unique index table (should not count)",
+			action:     actionDelete,
+			tableType:  UpdateUniqueIndexTable,
+			rowCount:   5,
+			expectRows: 0,
+		},
+		{
+			name:       "actionUpdate with unique index table (should not count)",
+			action:     actionUpdate,
+			tableType:  UpdateUniqueIndexTable,
+			rowCount:   3,
+			expectRows: 0,
+		},
+		{
+			name:       "actionInsert with main table (should not count)",
+			action:     actionInsert,
+			tableType:  UpdateMainTable,
+			rowCount:   2,
+			expectRows: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			update := &MultiUpdate{
+				ctr: container{
+					action:       tt.action,
+					affectedRows: 0,
+				},
+			}
+			update.addAffectedRowsFunc = update.doAddAffectedRows
+
+			update.addDeleteAffectRows(tt.tableType, tt.rowCount)
+
+			require.Equal(t, tt.expectRows, update.ctr.affectedRows, "affected rows should match expected value")
+		})
+	}
+}
+
+func TestReplaceIntoAffectedRows(t *testing.T) {
+	// Test REPLACE INTO scenario: should only count INSERT rows, not DELETE rows
+	update := &MultiUpdate{
+		ctr: container{
+			action:       actionUpdate, // REPLACE INTO uses actionUpdate
+			affectedRows: 0,
+		},
+	}
+	update.addAffectedRowsFunc = update.doAddAffectedRows
+
+	// Simulate REPLACE INTO: DELETE 2 rows, INSERT 2 rows
+	// Should only count INSERT rows (2), not DELETE rows
+	update.addDeleteAffectRows(UpdateMainTable, 2) // Should not count
+	require.Equal(t, uint64(0), update.ctr.affectedRows, "DELETE rows should not be counted for REPLACE INTO")
+
+	update.addInsertAffectRows(UpdateMainTable, 2) // Should count
+	require.Equal(t, uint64(2), update.ctr.affectedRows, "INSERT rows should be counted for REPLACE INTO")
+}
+
+func TestUpdateAffectedRows(t *testing.T) {
+	// Test UPDATE scenario: should only count INSERT rows (updated rows), not DELETE rows
+	update := &MultiUpdate{
+		ctr: container{
+			action:       actionUpdate, // UPDATE uses actionUpdate
+			affectedRows: 0,
+		},
+	}
+	update.addAffectedRowsFunc = update.doAddAffectedRows
+
+	// Simulate UPDATE: DELETE 3 rows, INSERT 3 rows
+	// Should only count INSERT rows (3), not DELETE rows
+	update.addDeleteAffectRows(UpdateMainTable, 3) // Should not count
+	require.Equal(t, uint64(0), update.ctr.affectedRows, "DELETE rows should not be counted for UPDATE")
+
+	update.addInsertAffectRows(UpdateMainTable, 3) // Should count
+	require.Equal(t, uint64(3), update.ctr.affectedRows, "INSERT rows should be counted for UPDATE")
+}
+
+func TestInsertAffectedRows(t *testing.T) {
+	// Test INSERT scenario: should count INSERT rows
+	update := &MultiUpdate{
+		ctr: container{
+			action:       actionInsert,
+			affectedRows: 0,
+		},
+	}
+	update.addAffectedRowsFunc = update.doAddAffectedRows
+
+	update.addInsertAffectRows(UpdateMainTable, 5)
+	require.Equal(t, uint64(5), update.ctr.affectedRows, "INSERT rows should be counted")
+}
+
+func TestDeleteAffectedRows(t *testing.T) {
+	// Test DELETE scenario: should count DELETE rows
+	update := &MultiUpdate{
+		ctr: container{
+			action:       actionDelete,
+			affectedRows: 0,
+		},
+	}
+	update.addAffectedRowsFunc = update.doAddAffectedRows
+
+	update.addDeleteAffectRows(UpdateMainTable, 4)
+	require.Equal(t, uint64(4), update.ctr.affectedRows, "DELETE rows should be counted")
+}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23185 

## What this PR does / why we need it:

replace into rows affected


___

### **PR Type**
Bug fix


___

### **Description**
- Fix REPLACE INTO affected rows counting to only include INSERT rows

- Remove DELETE row counting from REPLACE INTO operations

- Add conditional logic to count INSERT rows for actionUpdate case

- Add comprehensive test coverage for affected rows counting scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["REPLACE INTO Operation"] -->|actionUpdate| B["addDeleteAffectRows"]
  A -->|actionUpdate| C["addInsertAffectRows"]
  B -->|tableType=MainTable| D["Skip counting DELETE"]
  C -->|tableType=MainTable| E["Count INSERT rows"]
  D --> F["affectedRows = INSERT only"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multi_update.go</strong><dd><code>Remove DELETE row counting from REPLACE INTO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/multi_update/multi_update.go

<ul><li>Removed <code>addDeleteAffectRows</code> call for REPLACE INTO DELETE operations<br> <li> Added conditional check to only count INSERT rows for main table<br> <li> Added comments explaining REPLACE INTO affected rows behavior<br> <li> Changed to use <code>addAffectedRowsFunc</code> directly for INSERT operations</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23186/files#diff-cebba3878577b2e066b0021f4d7d59734308e9cff0e02ffc219524b4baf2a617">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Update affected rows logic for REPLACE INTO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/multi_update/types.go

<ul><li>Updated <code>addInsertAffectRows</code> to count INSERT rows for both actionInsert <br>and actionUpdate cases<br> <li> Updated <code>addDeleteAffectRows</code> to skip counting for actionUpdate (REPLACE <br>INTO scenario)<br> <li> Added detailed comments explaining REPLACE INTO vs regular UPDATE <br>behavior<br> <li> Clarified that REPLACE INTO should only return INSERT row count</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23186/files#diff-c0ad521127deda6531dc053b05f577d6b0fd573a1f655f21e422085b257d7c5a">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multi_update_partition_test.go</strong><dd><code>Add comprehensive affected rows counting tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/multi_update/multi_update_partition_test.go

<ul><li>Added <code>TestAddInsertAffectRows</code> with 5 test cases covering different <br>action and table type combinations<br> <li> Added <code>TestAddDeleteAffectRows</code> with 5 test cases for DELETE row <br>counting scenarios<br> <li> Added <code>TestReplaceIntoAffectedRows</code> to verify REPLACE INTO only counts <br>INSERT rows<br> <li> Added <code>TestUpdateAffectedRows</code>, <code>TestInsertAffectedRows</code>, and <br><code>TestDeleteAffectedRows</code> for operation-specific scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23186/files#diff-d6c5cb1536664b04715c7cc8870e8b5a05b6df63994ece256c02ac9fea054864">+190/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

