### PR TITLE
fix: panic when JOIN condition type conversion fails

### DIFF
--- a/test/distributed/cases/join/join.result
+++ b/test/distributed/cases/join/join.result
@@ -198,7 +198,7 @@ drop table if exists t2;
 create table t2 (a int);
 insert into t2 values(1);
 select * from (t1 join t2 on t1.a = t2.a);
-a    a   
+a    a
 1    1
 drop table if exists tt;
 drop table if exists tt2;
@@ -290,3 +290,13 @@ a    b    a    b
 42    3    42    1
 drop table x1;
 drop table x2;
+drop table if exists t1;
+drop table if exists t2;
+CREATE TABLE t1 (id INT);
+CREATE TABLE t2 (name VARCHAR(100));
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES ('abc'), ('123');
+SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.name;
+invalid argument cast to int, bad value abc
+drop table if exists t1;
+drop table if exists t2;

--- a/test/distributed/cases/join/join.test
+++ b/test/distributed/cases/join/join.test
@@ -201,3 +201,16 @@ select count(*) from x2 inner join x1 on x1.a = x2.a;
 select * from x2 inner join x1 on x1.a = x2.a order by x1.a limit 10;
 drop table x1;
 drop table x2;
+
+-- @case
+-- @desc:鲁棒性测试 - LEFT JOIN with type mismatch (INT = VARCHAR) should return error instead of panic
+-- @label:bvt
+drop table if exists t1;
+drop table if exists t2;
+CREATE TABLE t1 (id INT);
+CREATE TABLE t2 (name VARCHAR(100));
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES ('abc'), ('123');
+SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.name;
+drop table if exists t1;
+drop table if exists t2;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixflow/issues/5772

## What this PR does / why we need it:

When a JOIN operation encounters a type mismatch (e.g., INT = VARCHAR), the type conversion fails during evalJoinCondition(), leaving HashmapBuilder.vecs in a partially initialized state. When Reset() is called during cleanup, it attempts to free nil pointers, causing a panic.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add nil pointer checks in `Reset()` and `Free()` methods to prevent panics

- Introduce `cleanupPartiallyCreatedVecs()` helper to handle partial initialization failures

- Call cleanup on errors in `evalJoinCondition()` to prevent memory leaks

- Add comprehensive regression tests for nil pointer handling in Reset/Free

- Add BVT test case for LEFT JOIN with type mismatch error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["evalJoinCondition<br/>encounters error"] -->|calls| B["cleanupPartiallyCreatedVecs"]
  B -->|frees partial vecs| C["hb.vecs = nil"]
  C -->|prevents nil deref| D["Reset/Free safe"]
  E["Reset/Free methods"] -->|check nil| F["vecs[i] != nil"]
  F -->|check nil| G["vecs[i][j] != nil"]
  G -->|safe free| H["No panic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hashmap_util.go</strong><dd><code>Add nil pointer safety checks and cleanup helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/hashmap_util/hashmap_util.go

<ul><li>Add nil pointer checks in <code>Reset()</code> method for <code>hb.vecs</code> and <br><code>hb.UniqueJoinKeys</code> arrays<br> <li> Add nil pointer checks in <code>Free()</code> method for <code>hb.UniqueJoinKeys</code> array<br> <li> Introduce new <code>cleanupPartiallyCreatedVecs()</code> helper function to safely <br>free partially initialized vectors<br> <li> Call <code>cleanupPartiallyCreatedVecs()</code> in <code>evalJoinCondition()</code> when errors <br>occur during vector evaluation or duplication</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23191/files#diff-4e472814399bbb0cac40fbad6d42daabca4111e950bebe1a2f5c4dbf8560bd74">+32/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hashmap_util_test.go</strong><dd><code>Add comprehensive nil pointer regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/hashmap_util/hashmap_util_test.go

<ul><li>Add import for <code>vector</code> package<br> <li> Add <code>TestResetWithNilPointers()</code> regression test for nil pointer <br>handling in Reset with needDupVec=true<br> <li> Add <code>TestResetWithMixedNilAndValidPointers()</code> test for mixed nil and <br>valid vectors in Reset<br> <li> Add <code>TestFreeWithNilPointers()</code> regression test for nil pointer handling <br>in Free<br> <li> Add <code>TestFreeWithMixedNilAndValidPointers()</code> test for mixed nil and <br>valid vectors in Free</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23191/files#diff-dc62011f0bc0fcb2eb8d9fe366c82ba5265a34cb8efc810e5a21b450763e1320">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>join.test</strong><dd><code>Add BVT test for LEFT JOIN type mismatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/join/join.test

<ul><li>Add BVT test case for LEFT JOIN with type mismatch (INT = VARCHAR)<br> <li> Test that type conversion error is returned instead of causing panic<br> <li> Include table creation, data insertion, and error validation</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23191/files#diff-c786ef775fdeba111970aafa87ec9dc5c1086e298fc7cd6f3ae01896a2586b8b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>join.result</strong><dd><code>Update test results with type mismatch error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/join/join.result

<ul><li>Update expected output for existing JOIN test (whitespace formatting)<br> <li> Add expected error output for LEFT JOIN with type mismatch test case<br> <li> Include test cleanup statements for new test case</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23191/files#diff-b989d5ea2130cdea874fcd458a930f745012401c8d4456f58ab1a51601e2106d">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

