### PR TITLE
fix: panic when JOIN condition type conversion fails (main)

### DIFF
--- a/test/distributed/cases/join/join.result
+++ b/test/distributed/cases/join/join.result
@@ -198,7 +198,7 @@ drop table if exists t2;
 create table t2 (a int);
 insert into t2 values(1);
 select * from (t1 join t2 on t1.a = t2.a);
-a    a   
+a    a
 1    1
 drop table if exists tt;
 drop table if exists tt2;
@@ -290,3 +290,13 @@ a    b    a    b
 42    3    42    1
 drop table x1;
 drop table x2;
+drop table if exists t1;
+drop table if exists t2;
+CREATE TABLE t1 (id INT);
+CREATE TABLE t2 (name VARCHAR(100));
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES ('abc'), ('123');
+SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.name;
+invalid argument cast to int, bad value abc
+drop table if exists t1;
+drop table if exists t2;

--- a/test/distributed/cases/join/join.test
+++ b/test/distributed/cases/join/join.test
@@ -201,3 +201,16 @@ select count(*) from x2 inner join x1 on x1.a = x2.a;
 select * from x2 inner join x1 on x1.a = x2.a order by x1.a limit 10;
 drop table x1;
 drop table x2;
+
+-- @case
+-- @desc:鲁棒性测试 - LEFT JOIN with type mismatch (INT = VARCHAR) should return error instead of panic
+-- @label:bvt
+drop table if exists t1;
+drop table if exists t2;
+CREATE TABLE t1 (id INT);
+CREATE TABLE t2 (name VARCHAR(100));
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES ('abc'), ('123');
+SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.name;
+drop table if exists t1;
+drop table if exists t2;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixflow/issues/5772

## What this PR does / why we need it:

When a JOIN operation encounters a type mismatch (e.g., INT = VARCHAR), the type conversion fails during evalJoinCondition(), leaving HashmapBuilder.vecs in a partially initialized state. When Reset() is called during cleanup, it attempts to free nil pointers, causing a panic.


___

### **PR Type**
Bug fix


___

### **Description**
- Add nil pointer checks in `HashmapBuilder.Reset()` and `Free()` to prevent panics

- Introduce `cleanupPartiallyCreatedVecs()` method to handle cleanup on JOIN condition evaluation errors

- Add comprehensive unit tests for nil pointer handling in reset and free operations

- Fix test deadlock in `TestRequestMultipleCn_NoGoroutineLeak` with context cancellation checks

- Add regression test case for LEFT JOIN with type mismatch (INT = VARCHAR)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JOIN Condition<br/>Evaluation Error"] -->|"Partial vecs<br/>initialization"| B["cleanupPartiallyCreatedVecs()"]
  B -->|"Free created<br/>vectors"| C["Reset/Free<br/>Methods"]
  C -->|"Nil pointer<br/>checks"| D["Safe cleanup<br/>without panic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hashmap_util.go</strong><dd><code>Add nil pointer safety checks and cleanup method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/hashmap_util/hashmap_util.go

<ul><li>Add nil pointer checks in <code>Reset()</code> method for <code>hb.vecs</code> and <br><code>hb.UniqueJoinKeys</code> arrays<br> <li> Add nil pointer checks in <code>Free()</code> method for <code>hb.UniqueJoinKeys</code> array<br> <li> Introduce new <code>cleanupPartiallyCreatedVecs()</code> helper method to safely <br>free partially initialized vectors<br> <li> Call <code>cleanupPartiallyCreatedVecs()</code> in <code>evalJoinCondition()</code> when errors <br>occur during vector evaluation or duplication</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23192/files#diff-4e472814399bbb0cac40fbad6d42daabca4111e950bebe1a2f5c4dbf8560bd74">+32/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>multi_cn_bug_test.go</strong><dd><code>Fix test deadlock with context cancellation checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/queryservice/multi_cn_bug_test.go

<ul><li>Replace blocking channel read with select statement to check context <br>cancellation<br> <li> Add timeout protection in main test loop to prevent indefinite waiting<br> <li> Improve cleanup logic with channel close to unblock waiting handler <br>goroutines<br> <li> Add comments explaining deadlock prevention mechanisms</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23192/files#diff-5129e369e8116967e05f8bc8d6a9c0f43ae8186273b783cb6d43c483cf7f2f6b">+18/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hashmap_util_test.go</strong><dd><code>Add comprehensive nil pointer regression tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/hashmap_util/hashmap_util_test.go

<ul><li>Add import for <code>vector</code> package<br> <li> Add <code>TestResetWithNilPointers()</code> test for nil pointer handling in Reset <br>with needDupVec flag<br> <li> Add <code>TestResetWithMixedNilAndValidPointers()</code> test for mixed nil and <br>valid vector scenarios<br> <li> Add <code>TestFreeWithNilPointers()</code> test for nil pointer handling in Free <br>method<br> <li> Add <code>TestFreeWithMixedNilAndValidPointers()</code> test for Free with mixed <br>nil and valid vectors</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23192/files#diff-dc62011f0bc0fcb2eb8d9fe366c82ba5265a34cb8efc810e5a21b450763e1320">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>join.test</strong><dd><code>Add LEFT JOIN type mismatch regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/join/join.test

<ul><li>Add regression test case for LEFT JOIN with type mismatch between INT <br>and VARCHAR columns<br> <li> Test verifies error is returned instead of panic when join condition <br>type conversion fails<br> <li> Include table creation, data insertion, and cleanup statements</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23192/files#diff-c786ef775fdeba111970aafa87ec9dc5c1086e298fc7cd6f3ae01896a2586b8b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>join.result</strong><dd><code>Update expected test results for type mismatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/join/join.result

<ul><li>Update expected test results for LEFT JOIN type mismatch case<br> <li> Add error message output: "invalid argument cast to int, bad value <br>abc"<br> <li> Fix whitespace formatting in previous test result</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23192/files#diff-b989d5ea2130cdea874fcd458a930f745012401c8d4456f58ab1a51601e2106d">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

