### PR TITLE
fix: delete statement reporting incorrect affected rows in S3 write mode

### DIFF
--- a/pkg/sql/colexec/multi_update/multi_update.go
+++ b/pkg/sql/colexec/multi_update/multi_update.go
@@ -321,6 +321,9 @@ func (update *MultiUpdate) updateFlushS3Info(proc *process.Process, analyzer pro
 			if err != nil {
 				return input, err
 			}
+			if tableType == UpdateMainTable {
+				update.addDeleteAffectRows(tableType, rowCounts[i])
+			}
 			analyzer.AddDeletedRows(int64(batBufs[actionDelete].RowCount()))
 			analyzer.AddS3RequestCount(crs)
 			analyzer.AddFileServiceCacheInfo(crs)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23196 

## What this PR does / why we need it:

In `UpdateFlushS3Info` mode, the DELETE operation was not calling `addDeleteAffectRows()` to count the affected rows, unlike the `UpdateWriteTable` mode which correctly counts them.


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing affected rows count for DELETE operations in S3 write mode

- Ensures DELETE statements report correct row counts consistently

- Matches behavior of UpdateWriteTable mode for accurate row tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DELETE Operation"] --> B["UpdateFlushS3Info Mode"]
  B --> C["addDeleteAffectRows Called"]
  C --> D["Correct Row Count Reported"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multi_update.go</strong><dd><code>Add affected rows counting for DELETE in S3 mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/multi_update/multi_update.go

<ul><li>Added conditional check for <code>UpdateMainTable</code> type after DELETE <br>operation<br> <li> Calls <code>addDeleteAffectRows()</code> to properly count affected rows in S3 <br>write mode<br> <li> Ensures consistency with UpdateWriteTable mode row counting behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23199/files#diff-cebba3878577b2e066b0021f4d7d59734308e9cff0e02ffc219524b4baf2a617">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

