### PR TITLE
fix: CI TestRequestMultipleCn_XXX and TestNewClientPoolRetriesThenSucceeds

### DIFF
--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool_test.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool_test.go
@@ -33,8 +33,8 @@ func TestNewClientPoolRetriesThenSucceeds(t *testing.T) {
 		ClientBufSize:       128,
 		MaxTimeout:          time.Second,
 		ClientRetryTimes:    2,
-		ClientRetryInterval: time.Nanosecond,
-		ClientRetryDuration: time.Millisecond,
+		ClientRetryInterval: time.Millisecond,       // 1ms between retries
+		ClientRetryDuration: 100 * time.Millisecond, // 100ms budget (enough for any CI)
 		ClientFactory: func() (logservice.Client, error) {
 			if attempts.Add(1) == 1 {
 				return nil, moerr.NewInternalErrorNoCtx("logservice client creation failed")


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #22799

## What this PR does / why we need it:

CI TestRequestMultipleCn_XXX and TestNewClientPoolRetriesThenSucceeds


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add timeout protection to prevent test hangs in multi-CN tests

- Simplify context timeout test by removing complex event synchronization

- Improve retry logic in NewClient with clearer timing and error handling

- Increase retry interval and duration in test config for CI stability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Execution"] -->|Add 10s timeout protection| B["Prevent Test Hangs"]
  C["Context Timeout Test"] -->|Simplify event sync| D["More Reliable Test"]
  E["NewClient Retry Logic"] -->|Improve timing checks| F["Better Error Handling"]
  G["Test Configuration"] -->|Increase intervals| H["CI Stability"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>multi_cn_bug_test.go</strong><dd><code>Add timeout protection and simplify deadline exceeded test</code></dd></summary>
<hr>

pkg/queryservice/multi_cn_bug_test.go

<ul><li>Add 10-second timeout protection to multiple test cases to prevent <br>hangs<br> <li> Replace direct channel waits with select statements including timeout <br>fallbacks<br> <li> Simplify TestRequestMultipleCn_ResponseErrorWithDeadlineExceeded by <br>removing complex event synchronization<br> <li> Relax error assertions to accept multiple timeout-related error types <br>for CI compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23201/files#diff-5129e369e8116967e05f8bc8d6a9c0f43ae8186273b783cb6d43c483cf7f2f6b">+76/-108</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clientpool.go</strong><dd><code>Improve NewClient retry logic with better timing control</code>&nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool.go

<ul><li>Refactor retry loop to use clearer attempt counter and early return on <br>success<br> <li> Add explicit time limit check before sleeping between retries<br> <li> Improve error logging to show attempt number and total attempts<br> <li> Ensure all retries are attempted before checking duration limit</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23201/files#diff-e3d1fd613cbdade8761171f2eff93cc208ebf1098ac3eb67ec4102c96b307fd5">+22/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clientpool_test.go</strong><dd><code>Increase retry timing for CI environment stability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool_test.go

<ul><li>Increase ClientRetryInterval from nanosecond to millisecond for CI <br>reliability<br> <li> Increase ClientRetryDuration from millisecond to 100 milliseconds<br> <li> Add comments explaining retry timing configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23201/files#diff-e72c25d74bc285db98a3a5f72d20a10458bdcf649721fc5ecbdb07050ad97237">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

