### PR TITLE
Fixed the "is not found" bug in ISCP scenarios.

### DIFF
--- a/pkg/vm/engine/tae/db/gc/v3/exec_v1.go
+++ b/pkg/vm/engine/tae/db/gc/v3/exec_v1.go
@@ -398,25 +398,25 @@ func MakeSnapshotAndPitrFineFilter(
 
 			if transObjects[name] != nil {
 				tables := transObjects[name]
-				if entry := tables[tableID]; entry != nil {
+				if objectEntry := tables[tableID]; objectEntry != nil {
 					// Check if the table still exists using the combined map
 					ok := tableExistenceMap[tableID]
 					// The table has not been dropped, and the dropTS is empty, so it cannot be deleted.
-					if entry.dropTS.IsEmpty() && ok {
+					if objectEntry.dropTS.IsEmpty() && ok {
 						continue
 					}
 
 					if !logtail.ObjectIsSnapshotRefers(
-						entry.stats, pitr, &entry.createTS, &entry.dropTS, sp,
+						objectEntry.stats, pitr, &objectEntry.createTS, &objectEntry.dropTS, sp,
 					) {
 						if iscpTables == nil {
 							bm.Add(uint64(i))
 							continue
 						}
-						if iscpTS, ok := iscpTables[entry.table]; ok {
-							if entry.stats.GetCNCreated() || entry.stats.GetAppendable() {
-								if (!entry.dropTS.IsEmpty() && entry.dropTS.GT(&iscpTS)) ||
-									entry.createTS.GT(&iscpTS) {
+						if iscpTS, ok := iscpTables[objectEntry.table]; ok {
+							if objectEntry.stats.GetCNCreated() || objectEntry.stats.GetAppendable() {
+								if (!objectEntry.dropTS.IsEmpty() && objectEntry.dropTS.GT(&iscpTS)) ||
+									objectEntry.createTS.GT(&iscpTS) {
 									continue
 								}
 							}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/22296

## What this PR does / why we need it:
Fixed the "is not found" bug in ISCP scenarios.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect timestamp comparison logic in ISCP garbage collection

- Changed `LT` (less than) to `GT` (greater than) for drop/delete timestamp checks

- Corrects filtering of tables in snapshot and PITR fine filter operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Timestamp Comparison Logic"] -->|Bug: LT operator| B["Incorrect Filtering"]
  A -->|Fix: GT operator| C["Correct Filtering"]
  C --> D["Proper ISCP Table Handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exec_v1.go</strong><dd><code>Correct timestamp comparison operators in ISCP filtering</code>&nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/gc/v3/exec_v1.go

<ul><li>Fixed timestamp comparison operator from <code>LT</code> to <code>GT</code> in two locations <br>(lines 419 and 448)<br> <li> Corrects the logic for filtering tables based on drop/delete timestamp <br>against ISCP timestamp<br> <li> Affects both entry-based and direct table ID-based filtering paths<br> <li> Ensures tables are properly excluded when their drop/delete timestamp <br>is greater than ISCP timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23204/files#diff-69c16ce601ed0824dcb61ad1755fe4897ec8cad3c07e5a5e956a257173d58d62">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

