### PR TITLE
fix: pick some fixes to 3.0.4 hotfix

### DIFF
--- a/pkg/container/batch/batch_test.go
+++ b/pkg/container/batch/batch_test.go
@@ -16,8 +16,9 @@ package batch
 
 import (
 	"bytes"
-	"github.com/matrixorigin/matrixone/pkg/sql/colexec/aggexec"
 	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/aggexec"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -176,4 +177,595 @@ func TestBatch_UnionOne(t *testing.T) {
 	row1 = vector.MustFixedColNoTypeCheck[int32](bat1.Vecs[1])
 	row2 = vector.MustFixedColNoTypeCheck[int32](bat2.Vecs[1])
 	require.Equal(t, row1, row2)
+}
+
+// TestBatchUnmarshalWithAnyMp_Bug23156 tests the fix for bug #23156
+// This test verifies that Vecs and Attrs length remain consistent when batch is reused
+// The bug occurred when batch was reused with different Attrs/Vecs configurations,
+// causing data mapping errors in UPDATE statements
+func TestBatchUnmarshalWithAnyMp_Bug23156(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: DELETE tombstone data
+	// Vecs: [rowid_vec, pk_vec], Attrs: ["rowid", "pk"]
+	bat1 := NewWithSize(2)
+	bat1.Attrs = []string{"rowid", "pk"}
+	bat1.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	bat1.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: INSERT block info data
+	// Vecs: [block_info_vec, object_stats_vec], Attrs: ["block_info", "object_stats"]
+	bat2 := NewWithSize(2)
+	bat2.Attrs = []string{"block_info", "object_stats"}
+	bat2.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat2.SetRowCount(0)
+
+	// Marshal both batches
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+
+	// Clean up original batches
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+
+	// Reuse the same batch object (simulating UPDATE scenario)
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+
+	// First unmarshal: DELETE tombstone data
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should be 2 after first unmarshal")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should be 2 after first unmarshal")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs should have same length")
+	require.Equal(t, "rowid", reusedBat.Attrs[0])
+	require.Equal(t, "pk", reusedBat.Attrs[1])
+
+	// Second unmarshal: INSERT block info data (reusing the same batch object)
+	// This is the critical test - the batch object is reused
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should be 2 after second unmarshal")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should be 2 after second unmarshal")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length after reuse")
+	require.Equal(t, "block_info", reusedBat.Attrs[0], "Attrs[0] should be updated correctly")
+	require.Equal(t, "object_stats", reusedBat.Attrs[1], "Attrs[1] should be updated correctly")
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_VecsAttrsLengthMismatch tests handling of normal case
+// where Vecs and Attrs should have the same length
+func TestBatchUnmarshalWithAnyMp_VecsAttrsLengthMismatch(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create a batch with Vecs length = 3, Attrs length = 3 (normal case)
+	bat := NewWithSize(3)
+	bat.Attrs = []string{"col1", "col2", "col3"}
+	bat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[2] = vector.NewVec(types.T_int32.ToType())
+	bat.SetRowCount(0)
+
+	// Marshal it
+	data, err := bat.MarshalBinary()
+	require.NoError(t, err)
+	bat.Clean(mp)
+
+	// Test unmarshal
+	normalBat := &Batch{}
+	err = normalBat.UnmarshalBinaryWithAnyMp(data, mp)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(normalBat.Vecs), "Vecs length should be 3")
+	require.Equal(t, 3, len(normalBat.Attrs), "Attrs length should be 3")
+	require.Equal(t, len(normalBat.Vecs), len(normalBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "col1", normalBat.Attrs[0])
+	require.Equal(t, "col2", normalBat.Attrs[1])
+	require.Equal(t, "col3", normalBat.Attrs[2])
+
+	normalBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_ReuseDifferentLengths tests batch reuse with different lengths
+// This is the key test case that captures the original bug
+func TestBatchUnmarshalWithAnyMp_ReuseDifferentLengths(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: 3 Vecs, 3 Attrs
+	bat1 := NewWithSize(3)
+	bat1.Attrs = []string{"col1", "col2", "col3"}
+	bat1.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat1.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat1.Vecs[2] = vector.NewVec(types.T_int32.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: 2 Vecs, 2 Attrs (different length)
+	bat2 := NewWithSize(2)
+	bat2.Attrs = []string{"attr1", "attr2"}
+	bat2.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat2.SetRowCount(0)
+
+	// Create third batch: 3 Vecs, 3 Attrs (back to original length)
+	bat3 := NewWithSize(3)
+	bat3.Attrs = []string{"x", "y", "z"}
+	bat3.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat3.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	bat3.Vecs[2] = vector.NewVec(types.T_int64.ToType())
+	bat3.SetRowCount(0)
+
+	// Marshal all
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+	data3, err := bat3.MarshalBinary()
+	require.NoError(t, err)
+
+	// Reuse the same batch object multiple times
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+
+	// First unmarshal: 3 Vecs, 3 Attrs
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(reusedBat.Vecs))
+	require.Equal(t, 3, len(reusedBat.Attrs))
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs))
+	require.Equal(t, "col1", reusedBat.Attrs[0])
+	require.Equal(t, "col2", reusedBat.Attrs[1])
+	require.Equal(t, "col3", reusedBat.Attrs[2])
+
+	// Second unmarshal: 2 Vecs, 2 Attrs (different length - this is the critical case)
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should change to 2")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should change to 2")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "attr1", reusedBat.Attrs[0])
+	require.Equal(t, "attr2", reusedBat.Attrs[1])
+
+	// Third unmarshal: 3 Vecs, 3 Attrs (back to original length)
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data3, mp)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(reusedBat.Vecs), "Vecs length should change back to 3")
+	require.Equal(t, 3, len(reusedBat.Attrs), "Attrs length should change back to 3")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "x", reusedBat.Attrs[0])
+	require.Equal(t, "y", reusedBat.Attrs[1])
+	require.Equal(t, "z", reusedBat.Attrs[2])
+
+	// Clean up
+	reusedBat.Clean(mp)
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+	bat3.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_Bug21911 tests the fix for bug #21911
+// This test verifies that Vecs length changes are handled correctly without panic
+// The bug was: panic runtime error: index out of range [1] with length 1
+// This occurred when Vecs length changed but the code tried to access vecs[i] beyond the old length
+func TestBatchUnmarshalWithAnyMp_Bug21911(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: 1 Vec, 1 Attr
+	bat1 := NewWithSize(1)
+	bat1.Attrs = []string{"col1"}
+	bat1.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: 2 Vecs, 2 Attrs (length increases - this is the critical case for #21911)
+	bat2 := NewWithSize(2)
+	bat2.Attrs = []string{"attr1", "attr2"}
+	bat2.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_float64.ToType())
+	bat2.SetRowCount(0)
+
+	// Marshal both
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+
+	// Clean up original batches
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+
+	// Reuse the same batch object
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+
+	// First unmarshal: 1 Vec, 1 Attr
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(reusedBat.Vecs), "Vecs length should be 1 after first unmarshal")
+	require.Equal(t, 1, len(reusedBat.Attrs), "Attrs length should be 1 after first unmarshal")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs))
+	require.Equal(t, "col1", reusedBat.Attrs[0])
+
+	// Second unmarshal: 2 Vecs, 2 Attrs (length increases - this should not panic)
+	// The bug #21911 occurred because Vecs was accessed beyond its old length
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err, "Should not panic when Vecs length increases")
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should change to 2")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should change to 2")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "attr1", reusedBat.Attrs[0])
+	require.Equal(t, "attr2", reusedBat.Attrs[1])
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_WithCleanOnlyData tests batch reuse with CleanOnlyData
+// This simulates the actual UPDATE scenario where CleanOnlyData() is called before unmarshal
+func TestBatchUnmarshalWithAnyMp_WithCleanOnlyData(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: DELETE tombstone data
+	bat1 := NewWithSize(2)
+	bat1.Attrs = []string{"rowid", "pk"}
+	bat1.Vecs[0] = vector.NewVec(types.T_Rowid.ToType())
+	bat1.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: INSERT block info data
+	bat2 := NewWithSize(2)
+	bat2.Attrs = []string{"block_info", "object_stats"}
+	bat2.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat2.SetRowCount(0)
+
+	// Marshal both
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+
+	// Clean up original batches
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+
+	// Reuse the same batch object
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+
+	// First unmarshal: DELETE tombstone data
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs))
+	require.Equal(t, 2, len(reusedBat.Attrs))
+	require.Equal(t, "rowid", reusedBat.Attrs[0])
+	require.Equal(t, "pk", reusedBat.Attrs[1])
+
+	// Simulate CleanOnlyData() call (as done in multi_update.go)
+	reusedBat.CleanOnlyData()
+
+	// Second unmarshal: INSERT block info data (reusing the same batch object)
+	// This is the critical test - the batch object is reused after CleanOnlyData()
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should be 2 after second unmarshal")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should be 2 after second unmarshal")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "block_info", reusedBat.Attrs[0], "Attrs[0] should be updated correctly")
+	require.Equal(t, "object_stats", reusedBat.Attrs[1], "Attrs[1] should be updated correctly")
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_OffHeap tests batch reuse with offHeap vectors
+func TestBatchUnmarshalWithAnyMp_OffHeap(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: 2 Vecs, 2 Attrs
+	bat1 := NewWithSize(2)
+	bat1.Attrs = []string{"col1", "col2"}
+	bat1.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat1.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: 3 Vecs, 3 Attrs (different length)
+	bat2 := NewWithSize(3)
+	bat2.Attrs = []string{"attr1", "attr2", "attr3"}
+	bat2.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	bat2.Vecs[2] = vector.NewVec(types.T_int64.ToType())
+	bat2.SetRowCount(0)
+
+	// Marshal both
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+
+	// Clean up original batches
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+
+	// Reuse the same batch object with offHeap
+	reusedBat := &Batch{}
+	reusedBat.offHeap = true
+
+	// First unmarshal: 2 Vecs, 2 Attrs
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs))
+	require.Equal(t, 2, len(reusedBat.Attrs))
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs))
+	require.Equal(t, "col1", reusedBat.Attrs[0])
+	require.Equal(t, "col2", reusedBat.Attrs[1])
+
+	// Second unmarshal: 3 Vecs, 3 Attrs (length changes)
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(reusedBat.Vecs), "Vecs length should change to 3")
+	require.Equal(t, 3, len(reusedBat.Attrs), "Attrs length should change to 3")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "attr1", reusedBat.Attrs[0])
+	require.Equal(t, "attr2", reusedBat.Attrs[1])
+	require.Equal(t, "attr3", reusedBat.Attrs[2])
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_FirstTime tests the first time unmarshal (nil Vecs)
+func TestBatchUnmarshalWithAnyMp_FirstTime(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create batch: 3 Vecs, 3 Attrs
+	bat := NewWithSize(3)
+	bat.Attrs = []string{"a", "b", "c"}
+	bat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[2] = vector.NewVec(types.T_int32.ToType())
+	bat.SetRowCount(0)
+
+	// Marshal
+	data, err := bat.MarshalBinary()
+	require.NoError(t, err)
+	bat.Clean(mp)
+
+	// First time unmarshal (nil Vecs)
+	newBat := &Batch{}
+	newBat.offHeap = false
+	err = newBat.UnmarshalBinaryWithAnyMp(data, mp)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(newBat.Vecs), "Vecs length should be 3")
+	require.Equal(t, 3, len(newBat.Attrs), "Attrs length should be 3")
+	require.Equal(t, len(newBat.Vecs), len(newBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "a", newBat.Attrs[0])
+	require.Equal(t, "b", newBat.Attrs[1])
+	require.Equal(t, "c", newBat.Attrs[2])
+
+	// Clean up
+	newBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_SameLengthReuse tests reuse with same Vecs/Attrs length
+// but different content (common scenario in UPDATE)
+func TestBatchUnmarshalWithAnyMp_SameLengthReuse(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create first batch: 2 Vecs, 2 Attrs
+	bat1 := NewWithSize(2)
+	bat1.Attrs = []string{"old1", "old2"}
+	bat1.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat1.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat1.SetRowCount(0)
+
+	// Create second batch: 2 Vecs, 2 Attrs (same length, different content)
+	bat2 := NewWithSize(2)
+	bat2.Attrs = []string{"new1", "new2"}
+	bat2.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat2.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	bat2.SetRowCount(0)
+
+	// Marshal both
+	data1, err := bat1.MarshalBinary()
+	require.NoError(t, err)
+	data2, err := bat2.MarshalBinary()
+	require.NoError(t, err)
+
+	// Clean up original batches
+	bat1.Clean(mp)
+	bat2.Clean(mp)
+
+	// Reuse the same batch object
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+
+	// First unmarshal
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data1, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs))
+	require.Equal(t, 2, len(reusedBat.Attrs))
+	require.Equal(t, "old1", reusedBat.Attrs[0])
+	require.Equal(t, "old2", reusedBat.Attrs[1])
+
+	// Second unmarshal: same length, different content
+	// This tests that Attrs content is properly updated even when length doesn't change
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data2, mp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(reusedBat.Vecs), "Vecs length should remain 2")
+	require.Equal(t, 2, len(reusedBat.Attrs), "Attrs length should remain 2")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "new1", reusedBat.Attrs[0], "Attrs[0] should be updated to new1")
+	require.Equal(t, "new2", reusedBat.Attrs[1], "Attrs[1] should be updated to new2")
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_SerializedLengthMismatch tests handling of inconsistent serialized data
+// where serialized Vecs length != serialized Attrs length (can occur in practice)
+// The fix ensures Attrs length always matches Vecs length, using Vecs length as authoritative
+func TestBatchUnmarshalWithAnyMp_SerializedLengthMismatch(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create a normal batch: 2 Vecs, 2 Attrs
+	bat := NewWithSize(2)
+	bat.Attrs = []string{"col1", "col2"}
+	bat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat.SetRowCount(2)
+	vector.AppendFixed(bat.Vecs[0], int32(1), false, mp)
+	vector.AppendFixed(bat.Vecs[0], int32(2), false, mp)
+	vector.AppendFixed(bat.Vecs[1], int32(10), false, mp)
+	vector.AppendFixed(bat.Vecs[1], int32(20), false, mp)
+
+	// Marshal it
+	data, err := bat.MarshalBinary()
+	require.NoError(t, err)
+
+	// Manually modify the serialized data to create inconsistency:
+	// Change Attrs length from 2 to 3 in the serialized data
+	// Format: | rowCount(8) | VecsLen(4) | Vecs... | AttrsLen(4) | Attrs... | ...
+	offset := 8 + 4 // skip rowCount and VecsLen
+	// Skip Vecs data to find AttrsLen position
+	for i := 0; i < 2; i++ {
+		vecSize := types.DecodeInt32(data[offset:])
+		offset += 4 + int(vecSize)
+	}
+	// Now offset points to AttrsLen
+	// Change it from 2 to 3 and add an extra attr entry
+	three := int32(3)
+	attrsLenBytes := types.EncodeInt32(&three)
+	newData := make([]byte, 0, len(data)+13)
+	newData = append(newData, data[:offset]...)
+	newData = append(newData, attrsLenBytes...)
+	// Keep existing two attrs, then add third
+	offset += 4
+	// Copy existing two attrs
+	attrsDataOffset := offset
+	for i := 0; i < 2; i++ {
+		attrSize := types.DecodeInt32(data[attrsDataOffset:])
+		newData = append(newData, data[attrsDataOffset:attrsDataOffset+4+int(attrSize)]...)
+		attrsDataOffset += 4 + int(attrSize)
+	}
+	// Add third attr
+	extraAttrSize := int32(5) // "extra" is 5 bytes
+	newData = append(newData, types.EncodeInt32(&extraAttrSize)...)
+	newData = append(newData, []byte("extra")...)
+	// Copy rest of data
+	newData = append(newData, data[attrsDataOffset:]...)
+	data = newData
+
+	// Clean up original batch
+	bat.Clean(mp)
+
+	// Unmarshal the inconsistent data
+	// Vecs length = 2 (from serialized data), but serialized Attrs length = 3
+	// The fix should ensure Attrs length matches Vecs length (2), ignoring the extra Attr
+	testBat := &Batch{}
+	testBat.offHeap = false
+	err = testBat.UnmarshalBinaryWithAnyMp(data, mp)
+	require.NoError(t, err)
+
+	// Attrs length should match Vecs length (2), not serialized Attrs length (3)
+	require.Equal(t, 2, len(testBat.Vecs), "Vecs length should be 2")
+	require.Equal(t, 2, len(testBat.Attrs), "Attrs length should match Vecs length (2), ignoring serialized length (3)")
+	require.Equal(t, len(testBat.Vecs), len(testBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "col1", testBat.Attrs[0], "First attr should be correct")
+	require.Equal(t, "col2", testBat.Attrs[1], "Second attr should be correct")
+
+	// Clean up
+	testBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+// TestBatchUnmarshalWithAnyMp_SerializedAttrsLenLessThanVecsLen tests the case where
+// serialized Attrs length < Vecs length (data inconsistency)
+// This ensures remaining Attrs are cleared to prevent stale values
+func TestBatchUnmarshalWithAnyMp_SerializedAttrsLenLessThanVecsLen(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	// Create a batch: 3 Vecs, 3 Attrs
+	bat := NewWithSize(3)
+	bat.Attrs = []string{"col1", "col2", "col3"}
+	bat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[2] = vector.NewVec(types.T_int32.ToType())
+	bat.SetRowCount(0)
+
+	// Marshal it
+	data, err := bat.MarshalBinary()
+	require.NoError(t, err)
+
+	// Manually modify the serialized data to create inconsistency:
+	// Change Attrs length from 3 to 2 in the serialized data
+	// Format: | rowCount(8) | VecsLen(4) | Vecs... | AttrsLen(4) | Attrs... | ...
+	offset := 8 + 4 // skip rowCount and VecsLen
+	// Skip Vecs data to find AttrsLen position
+	for i := 0; i < 3; i++ {
+		vecSize := types.DecodeInt32(data[offset:])
+		offset += 4 + int(vecSize)
+	}
+	// Now offset points to AttrsLen
+	// Change it from 3 to 2
+	two := int32(2)
+	attrsLenBytes := types.EncodeInt32(&two)
+	newData := make([]byte, 0, len(data))
+	newData = append(newData, data[:offset]...)
+	newData = append(newData, attrsLenBytes...)
+	// Copy only first two attrs
+	offset += 4
+	attrsDataOffset := offset
+	for i := 0; i < 2; i++ {
+		attrSize := types.DecodeInt32(data[attrsDataOffset:])
+		newData = append(newData, data[attrsDataOffset:attrsDataOffset+4+int(attrSize)]...)
+		attrsDataOffset += 4 + int(attrSize)
+	}
+	// Skip the third attr (size + content) and copy rest of data
+	thirdAttrSize := types.DecodeInt32(data[attrsDataOffset:])
+	attrsDataOffset += 4 + int(thirdAttrSize) // Skip third attr completely
+	newData = append(newData, data[attrsDataOffset:]...)
+	data = newData
+
+	// Clean up original batch
+	bat.Clean(mp)
+
+	// Reuse a batch object (simulating UPDATE scenario)
+	reusedBat := &Batch{}
+	reusedBat.offHeap = false
+	// First unmarshal with 3 Vecs, 3 Attrs to simulate stale Attrs
+	reusedBat.Attrs = []string{"old1", "old2", "old3"} // Simulate stale Attrs
+	reusedBat.Vecs = make([]*vector.Vector, 3)
+	for i := range reusedBat.Vecs {
+		reusedBat.Vecs[i] = vector.NewVecFromReuse()
+	}
+
+	// Unmarshal the inconsistent data
+	// Vecs length = 3 (from serialized data), but serialized Attrs length = 2
+	// The fix should ensure Attrs length matches Vecs length (3), clearing the third Attr
+	err = reusedBat.UnmarshalBinaryWithAnyMp(data, mp)
+	require.NoError(t, err)
+
+	// Attrs length should match Vecs length (3), not serialized Attrs length (2)
+	require.Equal(t, 3, len(reusedBat.Vecs), "Vecs length should be 3")
+	require.Equal(t, 3, len(reusedBat.Attrs), "Attrs length should match Vecs length (3)")
+	require.Equal(t, len(reusedBat.Vecs), len(reusedBat.Attrs), "Vecs and Attrs must have same length")
+	require.Equal(t, "col1", reusedBat.Attrs[0], "First attr should be correct")
+	require.Equal(t, "col2", reusedBat.Attrs[1], "Second attr should be correct")
+	require.Equal(t, "", reusedBat.Attrs[2], "Third attr should be cleared (empty string) to prevent stale value")
+
+	// Clean up
+	reusedBat.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
 }

--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -56,10 +56,31 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 			})
 		}
 
-		validIndexes, hasIrregularIndex := getValidIndexes(tableDef)
-		if hasIrregularIndex {
-			return 0, moerr.NewUnsupportedDML(builder.GetContext(), "update vector/full-text index")
+		// Check if any irregular index (vector/full-text) columns are being updated
+		// Only block UPDATE if the indexed columns are being updated
+		hasIrregularIndex := false
+		irregularIndexCols := make(map[string]bool)
+		for _, idxDef := range tableDef.Indexes {
+			if !catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) {
+				hasIrregularIndex = true
+				// Collect all columns in this irregular index
+				for _, part := range idxDef.Parts {
+					resolvedColName := catalog.ResolveAlias(part)
+					irregularIndexCols[resolvedColName] = true
+				}
+			}
 		}
+
+		// Only block if irregular index exists AND indexed columns are being updated
+		if hasIrregularIndex {
+			for colName := range dmlCtx.updateCol2Expr[i] {
+				if irregularIndexCols[colName] {
+					return 0, moerr.NewUnsupportedDML(builder.GetContext(), "update vector/full-text index")
+				}
+			}
+		}
+
+		validIndexes, _ := getValidIndexes(tableDef)
 		tableDef.Indexes = validIndexes
 
 		var pkAndUkCols = make(map[string]bool)

--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
@@ -193,7 +194,105 @@ func (ls *LocalDisttaeDataSource) getBlockZMs() {
 	orderByCol, _ := ls.OrderBy[0].Expr.Expr.(*plan.Expr_Col)
 
 	def := ls.table.tableDef
-	orderByColIDX := int(def.Cols[int(orderByCol.Col.ColPos)].Seqnum)
+
+	// Find the column by name instead of using ColPos directly.
+	// In JOIN scenarios, ColPos points to the projection list position,
+	// not the table column position. We need to find the column by name.
+	var orderByColIDX int = -1
+	orderByColName := strings.ToLower(orderByCol.Col.Name)
+
+	// Extract column name from qualified name format (e.g., "db.table.column" -> "column")
+	// Use LastIndex to handle cases where column name itself might contain dots
+	if idx := strings.LastIndex(orderByColName, "."); idx >= 0 {
+		orderByColName = orderByColName[idx+1:]
+	}
+
+	// Validate RelPos: In JOIN scenarios, RelPos indicates which table the column belongs to.
+	// For LocalDisttaeDataSource, we typically only handle one table (RelPos=0 or -1).
+	// If RelPos > 0, it might indicate the column is from a joined table, which we can't handle here.
+	// However, in practice, ORDER BY columns from joined tables might still be processed,
+	// so we'll proceed but log a warning if RelPos seems inconsistent.
+	relPos := orderByCol.Col.RelPos
+	if relPos > 0 {
+		// This might be a column from a joined table, but we'll still try to find it
+		// in the current table definition as the column might have been projected.
+		logutil.Debug("getBlockZMs: ORDER BY column has RelPos > 0, might be from joined table",
+			zap.String("column", orderByCol.Col.Name),
+			zap.Int32("RelPos", relPos))
+	}
+
+	// First try to use Name2ColIndex if available (O(1) lookup)
+	// Note: Name2ColIndex keys should be lowercase according to proto definition
+	if def.Name2ColIndex != nil {
+		if colIdx, ok := def.Name2ColIndex[orderByColName]; ok {
+			if int(colIdx) < len(def.Cols) {
+				// Verify the found column's type matches the ORDER BY expression type
+				foundCol := def.Cols[colIdx]
+				if foundCol.Typ.Id == ls.OrderBy[0].Expr.Typ.Id {
+					orderByColIDX = int(foundCol.Seqnum)
+				} else {
+					logutil.Warn("getBlockZMs: type mismatch in Name2ColIndex lookup",
+						zap.String("column", orderByColName),
+						zap.Int32("foundType", foundCol.Typ.Id),
+						zap.Int32("expectedType", ls.OrderBy[0].Expr.Typ.Id))
+				}
+			}
+		}
+	}
+
+	// If Name2ColIndex is not available or lookup failed, search by name
+	if orderByColIDX == -1 {
+		for _, col := range def.Cols {
+			if strings.ToLower(col.Name) == orderByColName {
+				// Verify type match before using this column
+				if col.Typ.Id == ls.OrderBy[0].Expr.Typ.Id {
+					orderByColIDX = int(col.Seqnum)
+					break
+				} else {
+					logutil.Debug("getBlockZMs: found column by name but type mismatch, continuing search",
+						zap.String("column", orderByColName),
+						zap.Int32("foundType", col.Typ.Id),
+						zap.Int32("expectedType", ls.OrderBy[0].Expr.Typ.Id))
+				}
+			}
+		}
+	}
+
+	// Fallback to ColPos only if:
+	// 1. Name lookup completely failed
+	// 2. RelPos is 0 or -1 (indicating it's from the current table, not a joined table)
+	// 3. ColPos is within valid bounds
+	// This fallback is risky in JOIN scenarios, so we add extra validation
+	if orderByColIDX == -1 {
+		if relPos <= 0 && int(orderByCol.Col.ColPos) < len(def.Cols) {
+			fallbackCol := def.Cols[int(orderByCol.Col.ColPos)]
+			// Verify type match before using fallback
+			if fallbackCol.Typ.Id == ls.OrderBy[0].Expr.Typ.Id {
+				orderByColIDX = int(fallbackCol.Seqnum)
+				logutil.Debug("getBlockZMs: using ColPos fallback",
+					zap.String("column", orderByCol.Col.Name),
+					zap.Int32("ColPos", orderByCol.Col.ColPos),
+					zap.String("foundColumn", fallbackCol.Name))
+			} else {
+				logutil.Warn("getBlockZMs: ColPos fallback type mismatch",
+					zap.String("column", orderByCol.Col.Name),
+					zap.Int32("ColPos", orderByCol.Col.ColPos),
+					zap.Int32("foundType", fallbackCol.Typ.Id),
+					zap.Int32("expectedType", ls.OrderBy[0].Expr.Typ.Id))
+			}
+		}
+	}
+
+	// If we still haven't found the column, panic with detailed error information
+	if orderByColIDX == -1 {
+		var availableCols []string
+		for _, col := range def.Cols {
+			availableCols = append(availableCols, fmt.Sprintf("%s(type=%d)", col.Name, col.Typ.Id))
+		}
+		panic(fmt.Sprintf(
+			"getBlockZMs: cannot find column for ORDER BY: name=%s, ColPos=%d, RelPos=%d, expectedType=%d, tableColsCount=%d, availableCols=%v",
+			orderByCol.Col.Name, orderByCol.Col.ColPos, relPos, ls.OrderBy[0].Expr.Typ.Id, len(def.Cols), availableCols))
+	}
 
 	sliceLen := ls.rangeSlice.Len()
 	ls.blockZMS = make([]index.ZM, sliceLen)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixflow/issues/5824

## What this PR does / why we need it:

fix: pick some fixes to 3.0.4 hotfix


___

### **PR Type**
Bug fix


___

### **Description**
- Fix batch data mapping errors when reused with different Vecs/Attrs lengths

- Ensure Attrs length always matches Vecs length during unmarshal operations

- Fix ORDER BY panic in JOIN queries by using column name lookup instead of ColPos

- Refine UPDATE statement validation to only block when irregular index columns are updated


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Batch Reuse"] --> B["UnmarshalBinaryWithAnyMp"]
  B --> C["Detect Length Changes"]
  C --> D["Reallocate Vecs/Attrs"]
  D --> E["Consistent State"]
  F["JOIN Query"] --> G["getBlockZMs"]
  G --> H["Column Name Lookup"]
  H --> I["Avoid ColPos Mismatch"]
  I --> J["Correct Column Found"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>batch.go</strong><dd><code>Fix batch data mapping errors on reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/batch/batch.go

<ul><li>Refactored Vecs/Attrs length handling to detect and handle changes <br>during batch reuse<br> <li> Added logic to reallocate Vecs when length changes, preventing stale <br>data<br> <li> Ensured Attrs length always matches Vecs length, using Vecs as <br>authoritative source<br> <li> Added clearing of stale Attrs values when batch is reused with same <br>length<br> <li> Added handling for serialized data inconsistencies where Attrs length <br>differs from Vecs length</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23205/files#diff-d3a2533fc9b5975159f2b11fc8bd0192557e46333581c8f3dea68ebb1867f335">+58/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>local_disttae_datasource.go</strong><dd><code>Fix ORDER BY column lookup in JOIN queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/local_disttae_datasource.go

<ul><li>Replaced direct ColPos usage with column name lookup to handle JOIN <br>scenarios correctly<br> <li> Added Name2ColIndex lookup for O(1) column resolution<br> <li> Added fallback to linear search when Name2ColIndex unavailable<br> <li> Added type validation to ensure found column matches expected type<br> <li> Added detailed error messages with available columns when column <br>lookup fails<br> <li> Added handling for qualified column names (e.g., "table.column")</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23205/files#diff-6a1e15697fc3cab3d0c3bfb66664b0adfb3017683f87953e93ae1c2213af0f86">+100/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>batch_test.go</strong><dd><code>Add comprehensive batch unmarshal reuse tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/container/batch/batch_test.go

<ul><li>Added comprehensive test suite for batch unmarshal with reuse <br>scenarios<br> <li> Added test for bug #23156 covering batch reuse with different <br>Vecs/Attrs configurations<br> <li> Added tests for normal cases, length mismatches, and serialized data <br>inconsistencies<br> <li> Added tests for offHeap vectors and CleanOnlyData scenarios<br> <li> Added tests for edge cases like empty Vecs and stale Attrs clearing</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23205/files#diff-02855920675ecd1c93966652df69956ad3cedac0591fab3551dc0d0d86acacfa">+593/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>local_disttae_datasource_test.go</strong><dd><code>Add tests for ORDER BY column lookup fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/local_disttae_datasource_test.go

<ul><li>Added test for column lookup logic with qualified names and wrong <br>ColPos<br> <li> Added comprehensive test for getBlockZMs with multiple columns and <br>JOIN scenarios<br> <li> Added test for column name extraction from qualified names with <br>multiple dots<br> <li> Added test cases for Name2ColIndex lookup, fallback to ColPos, and <br>error scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23205/files#diff-3c1eb73e06699e15c27040eec7bc82099561b4e2ec94c5254af96fecc42697b9">+252/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bind_update.go</strong><dd><code>Refine UPDATE validation for irregular indexes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/bind_update.go

<ul><li>Changed UPDATE validation to only block when irregular index columns <br>are being updated<br> <li> Collect irregular index columns and check if they are in the update <br>set<br> <li> Allow UPDATE statements that don't modify indexed columns even if <br>irregular indexes exist<br> <li> Improved error handling to be more granular and less restrictive</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23205/files#diff-b8b162088c8190404e922ae9e3ab6505d2ff9197b570677c7e8f5f78cdea6f11">+23/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

