### PR TITLE
to 3.0: fix non sys account cannot find the branch meta table.

### DIFF
--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -678,7 +678,7 @@ func diffMergeAgency(
 	}
 
 	if dagInfo, err = decideLCABranchTSFromBranchDAG(
-		ctx, ses, tblStuff.tarRel, tblStuff.baseRel,
+		ctx, ses, bh, tblStuff.tarRel, tblStuff.baseRel,
 	); err != nil {
 		return
 	}
@@ -4250,6 +4250,7 @@ func getTablesCreationCommitTS(
 func decideLCABranchTSFromBranchDAG(
 	ctx context.Context,
 	ses *Session,
+	bh BackgroundExec,
 	tarRel engine.Relation,
 	baseRel engine.Relation,
 ) (
@@ -4279,7 +4280,7 @@ func decideLCABranchTSFromBranchDAG(
 		}
 	}()
 
-	if dag, err = constructBranchDAG(ctx, ses); err != nil {
+	if dag, err = constructBranchDAG(ctx, ses, bh); err != nil {
 		return
 	}
 
@@ -4323,6 +4324,7 @@ func decideLCABranchTSFromBranchDAG(
 func constructBranchDAG(
 	ctx context.Context,
 	ses *Session,
+	bh BackgroundExec,
 ) (dag *databranchutils.DataBranchDAG, err error) {
 
 	var (
@@ -4341,9 +4343,10 @@ func constructBranchDAG(
 		sqlRet.Close()
 	}()
 
-	if sqlRet, err = sqlexec.RunSql(
-		sqlexec.NewSqlProcess(ses.proc),
+	if sqlRet, err = runSql(
+		sysCtx, ses, bh,
 		fmt.Sprintf(scanBranchMetadataSql, catalog.MO_CATALOG, catalog.MO_BRANCH_METADATA),
+		nil, nil,
 	); err != nil {
 		return
 	}

--- a/test/distributed/cases/snapshot/branch/diff/diff_6.result
+++ b/test/distributed/cases/snapshot/branch/diff/diff_6.result
@@ -1,0 +1,136 @@
+drop account if exists acc1;
+create account acc1 admin_name "root1" identified by "111";
+drop database if exists test_null_diff;
+create database test_null_diff;
+use test_null_diff;
+create table customer_lifecycle (
+customer_id int,
+region varchar(12),
+loyalty_level tinyint,
+credit_limit decimal(12,2),
+credit_score int,
+preferred_channel varchar(12),
+risk_note varchar(40),
+last_contact timestamp,
+is_active tinyint,
+birthdate date,
+primary key(customer_id)
+);
+insert into customer_lifecycle values
+(1001, 'east', 3, 8000.00, 720, 'app', 'stable usage', '2024-03-01 09:20:00', 1, '1990-02-10'),
+(1002, 'north', null, null, null, null, 'missing bureau', null, 1, '1984-05-05'),
+(1003, 'west', 2, 4500.00, 655, 'web', null, '2024-03-02 15:11:00', 0, null),
+(1004, null, 1, 3200.50, 610, 'branch', 'watchlist', null, 1, '1992-09-01');
+create snapshot sp_customer_base for table test_null_diff customer_lifecycle;
+data branch create table customer_branch_alpha from customer_lifecycle{snapshot='sp_customer_base'};
+data branch create table customer_branch_beta from customer_lifecycle{snapshot='sp_customer_base'};
+update customer_branch_alpha
+set credit_score = null,
+risk_note = null,
+last_contact = null
+where customer_id = 1001;
+update customer_branch_alpha
+set loyalty_level = 4,
+credit_limit = null,
+preferred_channel = 'sms',
+is_active = 0
+where customer_id = 1003;
+delete from customer_branch_alpha
+where customer_id = 1004;
+insert into customer_branch_alpha values
+(1005, 'south', null, null, 580, null, 'manual review', '2024-03-04 08:00:00', 1, null);
+create snapshot sp_customer_alpha for table test_null_diff customer_branch_alpha;
+update customer_branch_beta
+set credit_limit = credit_limit + 500,
+preferred_channel = null,
+last_contact = '2024-03-03 12:00:00'
+where customer_id = 1001;
+update customer_branch_beta
+set risk_note = 'reactivated',
+credit_score = 670
+where customer_id = 1003;
+insert into customer_branch_beta values
+(1006, 'central', 1, 2500.00, null, 'ivr', null, null, 1, '1995-10-12');
+drop snapshot if exists sp_customer_beta;
+create snapshot sp_customer_beta for table test_null_diff customer_branch_beta;
+data branch diff customer_branch_alpha{snapshot='sp_customer_alpha'} against customer_branch_beta{snapshot='sp_customer_beta'};
+diff customer_branch_alpha against customer_branch_beta    flag    customer_id    region    loyalty_level    credit_limit    credit_score    preferred_channel    risk_note    last_contact    is_active    birthdate
+customer_branch_alpha    UPDATE    1001    east    3    8000.00    null    app    null    null    1    1990-02-10
+customer_branch_beta    UPDATE    1001    east    3    8500.00    720    null    stable usage    2024-03-03 12:00:00    1    1990-02-10
+customer_branch_alpha    UPDATE    1003    west    4    null    655    sms    null    2024-03-02 15:11:00    0    null
+customer_branch_beta    UPDATE    1003    west    2    4500.00    670    web    reactivated    2024-03-02 15:11:00    0    null
+customer_branch_alpha    DELETE    1004    null    1    3200.50    610    branch    watchlist    null    1    1992-09-01
+customer_branch_alpha    INSERT    1005    south    null    null    580    null    manual review    2024-03-04 08:00:00    1    null
+customer_branch_beta    INSERT    1006    central    1    2500.00    null    ivr    null    null    1    1995-10-12
+drop snapshot sp_customer_alpha;
+drop snapshot sp_customer_beta;
+drop snapshot sp_customer_base;
+drop table customer_branch_alpha;
+drop table customer_branch_beta;
+drop table customer_lifecycle;
+create table instrument_positions (
+account_id bigint,
+instrument_code char(5),
+bucket varchar(6),
+exposure double,
+delta decimal(10,4),
+margin_rate float,
+notes varchar(40),
+settle_date date,
+settle_time timestamp,
+primary key (account_id, instrument_code, bucket)
+);
+insert into instrument_positions values
+(5001, 'FX001', 'spot', 120000.25, 0.4321, 0.12, 'hedged', '2024-03-01', '2024-03-01 16:00:00'),
+(5001, 'FX002', 'swap', null, null, 0.05, null, null, null),
+(5002, 'EQ100', 'beta', 8500.00, -0.1250, null, 'partial', '2024-03-02', null),
+(5003, 'CB200', 'spot', 62000.00, 0.0050, 0.01, 'new issue', '2024-03-03', '2024-03-03 09:45:00');
+drop snapshot if exists sp_position_base;
+create snapshot sp_position_base for table test_null_diff instrument_positions;
+data branch create table position_branch_live from instrument_positions{snapshot='sp_position_base'};
+data branch create table position_branch_model from instrument_positions{snapshot='sp_position_base'};
+update position_branch_live
+set exposure = null,
+margin_rate = null,
+notes = 'awaiting quote'
+where account_id = 5001 and instrument_code = 'FX001' and bucket = 'spot';
+update position_branch_live
+set delta = null,
+notes = null
+where account_id = 5002 and instrument_code = 'EQ100' and bucket = 'beta';
+delete from position_branch_live
+where account_id = 5003 and instrument_code = 'CB200' and bucket = 'spot';
+insert into position_branch_live values
+(5004, 'IR300', 'swap', null, 0.2500, null, 'pilot', '2024-03-05', null);
+drop snapshot if exists sp_position_live;
+create snapshot sp_position_live for table test_null_diff position_branch_live;
+update position_branch_model
+set exposure = 125000.75,
+margin_rate = 0.15,
+notes = null
+where account_id = 5001 and instrument_code = 'FX001' and bucket = 'spot';
+update position_branch_model
+set settle_date = '2024-03-04',
+settle_time = '2024-03-04 10:00:00'
+where account_id = 5002 and instrument_code = 'EQ100' and bucket = 'beta';
+insert into position_branch_model values
+(5005, 'EQ200', 'spot', 41000.00, null, 0.08, 'hedge-ext', null, null);
+drop snapshot if exists sp_position_model;
+create snapshot sp_position_model for table test_null_diff position_branch_model;
+data branch diff position_branch_live{snapshot='sp_position_live'} against position_branch_model{snapshot='sp_position_model'};
+diff position_branch_live against position_branch_model    flag    account_id    instrument_code    bucket    exposure    delta    margin_rate    notes    settle_date    settle_time
+position_branch_live    UPDATE    5001    FX001    spot    null    0.4321    null    awaiting quote    2024-03-01    2024-03-01 16:00:00
+position_branch_model    UPDATE    5001    FX001    spot    125000.75    0.4321    0.15    null    2024-03-01    2024-03-01 16:00:00
+position_branch_live    UPDATE    5002    EQ100    beta    8500.0    null    null    null    2024-03-02    null
+position_branch_model    UPDATE    5002    EQ100    beta    8500.0    -0.1250    null    partial    2024-03-04    2024-03-04 10:00:00
+position_branch_live    DELETE    5003    CB200    spot    62000.0    0.0050    0.01    new issue    2024-03-03    2024-03-03 09:45:00
+position_branch_live    INSERT    5004    IR300    swap    null    0.2500    null    pilot    2024-03-05    null
+position_branch_model    INSERT    5005    EQ200    spot    41000.0    null    0.08    hedge-ext    null    null
+drop snapshot sp_position_live;
+drop snapshot sp_position_model;
+drop snapshot sp_position_base;
+drop table position_branch_live;
+drop table position_branch_model;
+drop table instrument_positions;
+drop database test_null_diff;
+drop account acc1;

--- a/test/distributed/cases/snapshot/branch/diff/diff_6.sql
+++ b/test/distributed/cases/snapshot/branch/diff/diff_6.sql
@@ -1,0 +1,157 @@
+drop account if exists acc1;
+create account acc1 admin_name "root1" identified by "111";
+
+-- @session:id=1&user=acc1:root1&password=111
+drop database if exists test_null_diff;
+create database test_null_diff;
+use test_null_diff;
+
+-- case 1: diff branches that keep toggling NULL across wide column types
+create table customer_lifecycle (
+    customer_id int,
+    region varchar(12),
+    loyalty_level tinyint,
+    credit_limit decimal(12,2),
+    credit_score int,
+    preferred_channel varchar(12),
+    risk_note varchar(40),
+    last_contact timestamp,
+    is_active tinyint,
+    birthdate date,
+    primary key(customer_id)
+);
+
+insert into customer_lifecycle values
+(1001, 'east', 3, 8000.00, 720, 'app', 'stable usage', '2024-03-01 09:20:00', 1, '1990-02-10'),
+(1002, 'north', null, null, null, null, 'missing bureau', null, 1, '1984-05-05'),
+(1003, 'west', 2, 4500.00, 655, 'web', null, '2024-03-02 15:11:00', 0, null),
+(1004, null, 1, 3200.50, 610, 'branch', 'watchlist', null, 1, '1992-09-01');
+
+create snapshot sp_customer_base for table test_null_diff customer_lifecycle;
+
+data branch create table customer_branch_alpha from customer_lifecycle{snapshot='sp_customer_base'};
+data branch create table customer_branch_beta from customer_lifecycle{snapshot='sp_customer_base'};
+
+update customer_branch_alpha
+   set credit_score = null,
+       risk_note = null,
+       last_contact = null
+ where customer_id = 1001;
+
+update customer_branch_alpha
+   set loyalty_level = 4,
+       credit_limit = null,
+       preferred_channel = 'sms',
+       is_active = 0
+ where customer_id = 1003;
+
+delete from customer_branch_alpha
+ where customer_id = 1004;
+
+insert into customer_branch_alpha values
+(1005, 'south', null, null, 580, null, 'manual review', '2024-03-04 08:00:00', 1, null);
+
+create snapshot sp_customer_alpha for table test_null_diff customer_branch_alpha;
+
+update customer_branch_beta
+   set credit_limit = credit_limit + 500,
+       preferred_channel = null,
+       last_contact = '2024-03-03 12:00:00'
+ where customer_id = 1001;
+
+update customer_branch_beta
+   set risk_note = 'reactivated',
+       credit_score = 670
+ where customer_id = 1003;
+
+insert into customer_branch_beta values
+(1006, 'central', 1, 2500.00, null, 'ivr', null, null, 1, '1995-10-12');
+
+drop snapshot if exists sp_customer_beta;
+create snapshot sp_customer_beta for table test_null_diff customer_branch_beta;
+
+data branch diff customer_branch_alpha{snapshot='sp_customer_alpha'} against customer_branch_beta{snapshot='sp_customer_beta'};
+
+drop snapshot sp_customer_alpha;
+drop snapshot sp_customer_beta;
+drop snapshot sp_customer_base;
+drop table customer_branch_alpha;
+drop table customer_branch_beta;
+drop table customer_lifecycle;
+
+-- case 2: diff on composite key inventory where NULL flips collide with numeric/temporal types
+create table instrument_positions (
+    account_id bigint,
+    instrument_code char(5),
+    bucket varchar(6),
+    exposure double,
+    delta decimal(10,4),
+    margin_rate float,
+    notes varchar(40),
+    settle_date date,
+    settle_time timestamp,
+    primary key (account_id, instrument_code, bucket)
+);
+
+insert into instrument_positions values
+(5001, 'FX001', 'spot', 120000.25, 0.4321, 0.12, 'hedged', '2024-03-01', '2024-03-01 16:00:00'),
+(5001, 'FX002', 'swap', null, null, 0.05, null, null, null),
+(5002, 'EQ100', 'beta', 8500.00, -0.1250, null, 'partial', '2024-03-02', null),
+(5003, 'CB200', 'spot', 62000.00, 0.0050, 0.01, 'new issue', '2024-03-03', '2024-03-03 09:45:00');
+
+drop snapshot if exists sp_position_base;
+create snapshot sp_position_base for table test_null_diff instrument_positions;
+
+data branch create table position_branch_live from instrument_positions{snapshot='sp_position_base'};
+data branch create table position_branch_model from instrument_positions{snapshot='sp_position_base'};
+
+update position_branch_live
+   set exposure = null,
+       margin_rate = null,
+       notes = 'awaiting quote'
+ where account_id = 5001 and instrument_code = 'FX001' and bucket = 'spot';
+
+update position_branch_live
+   set delta = null,
+       notes = null
+ where account_id = 5002 and instrument_code = 'EQ100' and bucket = 'beta';
+
+delete from position_branch_live
+ where account_id = 5003 and instrument_code = 'CB200' and bucket = 'spot';
+
+insert into position_branch_live values
+(5004, 'IR300', 'swap', null, 0.2500, null, 'pilot', '2024-03-05', null);
+
+drop snapshot if exists sp_position_live;
+create snapshot sp_position_live for table test_null_diff position_branch_live;
+
+update position_branch_model
+   set exposure = 125000.75,
+       margin_rate = 0.15,
+       notes = null
+ where account_id = 5001 and instrument_code = 'FX001' and bucket = 'spot';
+
+update position_branch_model
+   set settle_date = '2024-03-04',
+       settle_time = '2024-03-04 10:00:00'
+ where account_id = 5002 and instrument_code = 'EQ100' and bucket = 'beta';
+
+insert into position_branch_model values
+(5005, 'EQ200', 'spot', 41000.00, null, 0.08, 'hedge-ext', null, null);
+
+drop snapshot if exists sp_position_model;
+create snapshot sp_position_model for table test_null_diff position_branch_model;
+
+data branch diff position_branch_live{snapshot='sp_position_live'} against position_branch_model{snapshot='sp_position_model'};
+
+drop snapshot sp_position_live;
+drop snapshot sp_position_model;
+drop snapshot sp_position_base;
+drop table position_branch_live;
+drop table position_branch_model;
+drop table instrument_positions;
+
+drop database test_null_diff;
+
+-- @session
+drop account acc1;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/21979

## What this PR does / why we need it:
fix non sys account cannot find the branch meta table.


___

### **PR Type**
Bug fix


___

### **Description**
- Pass `BackgroundExec` to branch metadata functions for non-sys account access

- Fix `constructBranchDAG` to use `runSql` with system context for metadata queries

- Add `bh` parameter to `decideLCABranchTSFromBranchDAG` function signature

- Add comprehensive test cases for branch diff with NULL value handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["diffMergeAgency"] -->|pass bh| B["decideLCABranchTSFromBranchDAG"]
  B -->|pass bh| C["constructBranchDAG"]
  C -->|use runSql with sysCtx| D["Query branch metadata"]
  D -->|system account context| E["Access MO_BRANCH_METADATA"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_branch.go</strong><dd><code>Add BackgroundExec parameter for metadata access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/data_branch.go

<ul><li>Add <code>bh BackgroundExec</code> parameter to <code>decideLCABranchTSFromBranchDAG</code> <br>function<br> <li> Add <code>bh BackgroundExec</code> parameter to <code>constructBranchDAG</code> function<br> <li> Replace <code>sqlexec.RunSql</code> with <code>runSql</code> call using system context for <br>metadata queries<br> <li> Pass <code>bh</code> parameter through call chain from <code>diffMergeAgency</code> to <br><code>constructBranchDAG</code></ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23220/files#diff-632e0d2d46c8bdef4144b4d6f532cf8df78cc583e4903672ae6675d8c09783b4">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>diff_6.sql</strong><dd><code>Add branch diff NULL value test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/snapshot/branch/diff/diff_6.sql

<ul><li>Create test account <code>acc1</code> with non-sys credentials<br> <li> Test branch diff operations with NULL value toggling across multiple <br>column types<br> <li> Test case 1: Customer lifecycle table with wide column types and NULL <br>transitions<br> <li> Test case 2: Instrument positions table with composite primary key and <br>NULL handling</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23220/files#diff-207fec78bb17c4546cfc894cb37a6b5e1eb2d5e76a0c92839482807f4441d3e7">+157/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>diff_6.result</strong><dd><code>Add expected results for branch diff tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/snapshot/branch/diff/diff_6.result

<ul><li>Expected output for branch diff operations on customer lifecycle table<br> <li> Expected output for branch diff operations on instrument positions <br>table<br> <li> Verify correct diff results with UPDATE, DELETE, and INSERT operations<br> <li> Validate NULL value handling in diff output across different data <br>types</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23220/files#diff-58aa5c493fd2886badf44bfc688a8d8ffd8d3fd32a45c01526cba3d5f04ad5f9">+136/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

