### PR TITLE
refactor: remove or optmize some logging 3.0 - PART 1

### DIFF
--- a/pkg/bootstrap/versions/upgrade_strategy.go
+++ b/pkg/bootstrap/versions/upgrade_strategy.go
@@ -250,7 +250,7 @@ func CheckTableColumn(txn executor.TxnExecutor,
             AND att_database = '%s' and att_relname = '%s' and attname = '%s';`, schema, tableName, columnName)
 	}
 
-	res, err := txn.Exec(sql, executor.StatementOption{}.WithAccountID(accountId))
+	res, err := txn.Exec(sql, executor.StatementOption{}.WithAccountID(accountId).WithDisableLog())
 	if err != nil {
 		return colInfo, err
 	}
@@ -292,7 +292,7 @@ var CheckViewDefinition = func(txn executor.TxnExecutor, accountId uint32, schem
 		sql = fmt.Sprintf("SELECT tbl.rel_createsql AS `VIEW_DEFINITION` FROM mo_catalog.mo_tables tbl LEFT JOIN mo_catalog.mo_user usr ON tbl.creator = usr.user_id WHERE tbl.relkind = 'v' AND account_id = 0 AND tbl.reldatabase = '%s'  AND  tbl.relname = '%s'", schema, viewName)
 	}
 
-	res, err := txn.Exec(sql, executor.StatementOption{}.WithAccountID(accountId))
+	res, err := txn.Exec(sql, executor.StatementOption{}.WithAccountID(accountId).WithDisableLog())
 	if err != nil {
 		return false, "", err
 	}
@@ -330,7 +330,7 @@ var CheckTableDefinition = func(txn executor.TxnExecutor, accountId uint32, sche
                                   AND account_id = 0 AND reldatabase = '%s' AND relname = '%s'`, schema, tableName)
 	}
 
-	res, err := txn.Exec(sql, executor.StatementOption{}.WithAccountID(accountId))
+	res, err := txn.Exec(sql, executor.StatementOption{}.WithAccountID(accountId).WithDisableLog())
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -998,15 +998,26 @@ func SaveProfile(profilePath string, profileType string, etlFS fileservice.FileS
 	}
 	err := profile.ProfileRuntime(profileType, gzWriter, debug)
 	if err != nil {
-		logutil.Errorf("get profile of %s failed. err:%v", profilePath, err)
+		logutil.Error(
+			"profile.save.runtime.failed",
+			zap.String("path", profilePath),
+			zap.Error(err),
+		)
 		return
 	}
 	err = gzWriter.Close()
 	if err != nil {
-		logutil.Errorf("close gzip write of %s failed. err:%v", profilePath, err)
+		logutil.Error(
+			"profile.writer.close.failed",
+			zap.String("path", profilePath),
+			zap.Error(err),
+		)
 		return
 	}
-	logutil.Info("get profile done. save profiles ", zap.String("path", profilePath))
+	logutil.Info(
+		"profile.save.get.ok",
+		zap.String("path", profilePath),
+	)
 	writeVec := fileservice.IOVector{
 		FilePath: profilePath,
 		Entries: []fileservice.IOEntry{
@@ -1022,7 +1033,11 @@ func SaveProfile(profilePath string, profileType string, etlFS fileservice.FileS
 	err = etlFS.Write(ctx, writeVec)
 	if err != nil {
 		err = moerr.AttachCause(ctx, err)
-		logutil.Errorf("save profile %s failed. err:%v", profilePath, err)
+		logutil.Error(
+			"profile.save.failed",
+			zap.String("path", profilePath),
+			zap.Error(err),
+		)
 		return
 	}
 }

--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -912,7 +912,9 @@ func NewConstraintViolation(ctx context.Context, msg string) *Error {
 
 func NewUnsupportedDML(ctx context.Context, msg string, args ...any) *Error {
 	xmsg := fmt.Sprintf(msg, args...)
-	return newError(ctx, ErrUnsupportedDML, xmsg)
+	// Use ContextWithNoReport to prevent logging, but still carry runtime info in error message
+	noReportCtx := errutil.ContextWithNoReport(ctx, true)
+	return newError(noReportCtx, ErrUnsupportedDML, xmsg)
 }
 
 func NewEmptyVector(ctx context.Context) *Error {

--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -918,7 +918,8 @@ func NewConstraintViolation(ctx context.Context, msg string) *Error {
 
 func NewUnsupportedDML(ctx context.Context, format string, args ...any) *Error {
 	msg := fmt.Sprintf(format, args...)
-	return newError(ctx, ErrUnsupportedDML, msg)
+	noReportCtx := errutil.ContextWithNoReport(ctx, true)
+	return newError(noReportCtx, ErrUnsupportedDML, msg)
 }
 
 func NewEmptyVector(ctx context.Context) *Error {

--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -808,7 +808,8 @@ func NewBadS3Config(ctx context.Context, msg string) *Error {
 }
 
 func NewInternalErrorf(ctx context.Context, format string, args ...any) *Error {
-	return NewInternalError(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrInternal, msg)
 }
 
 func NewInternalError(ctx context.Context, msg string) *Error {
@@ -828,7 +829,8 @@ func NewNYI(ctx context.Context, msg string) *Error {
 }
 
 func NewNotSupportedf(ctx context.Context, format string, args ...any) *Error {
-	return NewNotSupported(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrNotSupported, msg)
 }
 
 func NewNotSupported(ctx context.Context, msg string) *Error {
@@ -848,7 +850,8 @@ func NewDivByZero(ctx context.Context) *Error {
 }
 
 func NewOutOfRangef(ctx context.Context, typ string, format string, args ...any) *Error {
-	return NewOutOfRange(ctx, typ, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrOutOfRange, typ, msg)
 }
 
 func NewOutOfRange(ctx context.Context, typ string, msg string) *Error {
@@ -856,15 +859,13 @@ func NewOutOfRange(ctx context.Context, typ string, msg string) *Error {
 }
 
 func NewDataTruncatedf(ctx context.Context, typ string, format string, args ...any) *Error {
-	return NewDataTruncated(ctx, typ, fmt.Sprintf(format, args...))
-}
-
-func NewDataTruncated(ctx context.Context, typ string, msg string) *Error {
+	msg := fmt.Sprintf(format, args...)
 	return newError(ctx, ErrDataTruncated, typ, msg)
 }
 
 func NewInvalidArg(ctx context.Context, arg string, val any) *Error {
-	return newError(ctx, ErrInvalidArg, arg, fmt.Sprintf("%v", val))
+	msg := fmt.Sprintf("%v", val)
+	return newError(ctx, ErrInvalidArg, arg, msg)
 }
 
 func NewTruncatedValueForField(ctx context.Context, t, v, c string, idx int) *Error {
@@ -872,7 +873,8 @@ func NewTruncatedValueForField(ctx context.Context, t, v, c string, idx int) *Er
 }
 
 func NewBadConfigf(ctx context.Context, format string, args ...any) *Error {
-	return NewBadConfig(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrBadConfig, msg)
 }
 
 func NewBadConfig(ctx context.Context, msg string) *Error {
@@ -880,7 +882,8 @@ func NewBadConfig(ctx context.Context, msg string) *Error {
 }
 
 func NewInvalidInputf(ctx context.Context, format string, args ...any) *Error {
-	return NewInvalidInput(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrInvalidInput, msg)
 }
 
 func NewInvalidInput(ctx context.Context, msg string) *Error {
@@ -888,7 +891,8 @@ func NewInvalidInput(ctx context.Context, msg string) *Error {
 }
 
 func NewSyntaxErrorf(ctx context.Context, format string, args ...any) *Error {
-	return NewSyntaxError(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrSyntaxError, msg)
 }
 
 func NewSyntaxError(ctx context.Context, msg string) *Error {
@@ -896,25 +900,25 @@ func NewSyntaxError(ctx context.Context, msg string) *Error {
 }
 
 func NewParseErrorf(ctx context.Context, format string, args ...any) *Error {
-	return NewParseError(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrParseError, msg)
 }
 func NewParseError(ctx context.Context, msg string) *Error {
 	return newError(ctx, ErrParseError, msg)
 }
 
 func NewConstraintViolationf(ctx context.Context, format string, args ...any) *Error {
-	return NewConstraintViolation(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrConstraintViolation, msg)
 }
 
 func NewConstraintViolation(ctx context.Context, msg string) *Error {
 	return newError(ctx, ErrConstraintViolation, msg)
 }
 
-func NewUnsupportedDML(ctx context.Context, msg string, args ...any) *Error {
-	xmsg := fmt.Sprintf(msg, args...)
-	// Use ContextWithNoReport to prevent logging, but still carry runtime info in error message
-	noReportCtx := errutil.ContextWithNoReport(ctx, true)
-	return newError(noReportCtx, ErrUnsupportedDML, xmsg)
+func NewUnsupportedDML(ctx context.Context, format string, args ...any) *Error {
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrUnsupportedDML, msg)
 }
 
 func NewEmptyVector(ctx context.Context) *Error {
@@ -966,7 +970,8 @@ func NewInvalidPath(ctx context.Context, f string) *Error {
 }
 
 func NewInvalidStatef(ctx context.Context, format string, args ...any) *Error {
-	return NewInvalidState(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrInvalidState, msg)
 }
 
 func NewInvalidState(ctx context.Context, msg string) *Error {
@@ -1066,7 +1071,8 @@ func NewTxnClosed(ctx context.Context, txnID []byte) *Error {
 }
 
 func NewTxnWriteConflictf(ctx context.Context, format string, args ...any) *Error {
-	return NewTxnWriteConflict(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrTxnWriteConflict, msg)
 }
 
 func NewTxnWriteConflict(ctx context.Context, msg string) *Error {
@@ -1082,7 +1088,8 @@ func NewUnresolvedConflict(ctx context.Context) *Error {
 }
 
 func NewTxnErrorf(ctx context.Context, format string, args ...any) *Error {
-	return NewTxnError(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrTxnError, msg)
 }
 
 func NewTxnError(ctx context.Context, msg string) *Error {
@@ -1090,7 +1097,8 @@ func NewTxnError(ctx context.Context, msg string) *Error {
 }
 
 func NewTAEErrorf(ctx context.Context, format string, args ...any) *Error {
-	return NewTAEError(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrTAEError, msg)
 }
 
 func NewTAEError(ctx context.Context, msg string) *Error {
@@ -1106,7 +1114,8 @@ func NewShardNotReported(ctx context.Context, uuid string, id uint64) *Error {
 }
 
 func NewDragonboatTimeoutf(ctx context.Context, format string, args ...any) *Error {
-	return NewDragonboatTimeout(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrDragonboatTimeout, msg)
 }
 
 func NewDragonboatTimeout(ctx context.Context, msg string) *Error {
@@ -1114,7 +1123,8 @@ func NewDragonboatTimeout(ctx context.Context, msg string) *Error {
 }
 
 func NewDragonboatTimeoutTooSmallf(ctx context.Context, format string, args ...any) *Error {
-	return NewDragonboatTimeoutTooSmall(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrDragonboatTimeoutTooSmall, msg)
 }
 
 func NewDragonboatTimeoutTooSmall(ctx context.Context, msg string) *Error {
@@ -1122,7 +1132,8 @@ func NewDragonboatTimeoutTooSmall(ctx context.Context, msg string) *Error {
 }
 
 func NewDragonboatInvalidDeadlinef(ctx context.Context, format string, args ...any) *Error {
-	return NewDragonboatInvalidDeadline(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrDragonboatInvalidDeadline, msg)
 }
 
 func NewDragonboatInvalidDeadline(ctx context.Context, msg string) *Error {
@@ -1130,7 +1141,8 @@ func NewDragonboatInvalidDeadline(ctx context.Context, msg string) *Error {
 }
 
 func NewDragonboatRejectedf(ctx context.Context, format string, args ...any) *Error {
-	return NewDragonboatRejected(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrDragonboatRejected, msg)
 }
 
 func NewDragonboatRejected(ctx context.Context, msg string, args ...any) *Error {
@@ -1138,7 +1150,8 @@ func NewDragonboatRejected(ctx context.Context, msg string, args ...any) *Error 
 }
 
 func NewDragonboatInvalidPayloadSizef(ctx context.Context, format string, args ...any) *Error {
-	return NewDragonboatInvalidPayloadSize(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrDragonboatInvalidPayloadSize, msg)
 }
 
 func NewDragonboatInvalidPayloadSize(ctx context.Context, msg string) *Error {
@@ -1146,7 +1159,8 @@ func NewDragonboatInvalidPayloadSize(ctx context.Context, msg string) *Error {
 }
 
 func NewDragonboatShardNotReadyf(ctx context.Context, format string, args ...any) *Error {
-	return NewDragonboatShardNotReady(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrDragonboatShardNotReady, msg)
 }
 
 func NewDragonboatShardNotReady(ctx context.Context, msg string) *Error {
@@ -1154,21 +1168,24 @@ func NewDragonboatShardNotReady(ctx context.Context, msg string) *Error {
 }
 
 func NewDragonboatSystemClosedf(ctx context.Context, format string, args ...any) *Error {
-	return NewDragonboatSystemClosed(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrDragonboatSystemClosed, msg)
 }
 func NewDragonboatSystemClosed(ctx context.Context, msg string) *Error {
 	return newError(ctx, ErrDragonboatSystemClosed, msg)
 }
 
 func NewDragonboatInvalidRangef(ctx context.Context, format string, args ...any) *Error {
-	return NewDragonboatInvalidRange(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrDragonboatInvalidRange, msg)
 }
 func NewDragonboatInvalidRange(ctx context.Context, msg string) *Error {
 	return newError(ctx, ErrDragonboatInvalidRange, msg)
 }
 
 func NewDragonboatShardNotFoundf(ctx context.Context, format string, args ...any) *Error {
-	return NewDragonboatShardNotFound(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrDragonboatShardNotFound, msg)
 }
 
 func NewDragonboatShardNotFound(ctx context.Context, msg string) *Error {
@@ -1176,7 +1193,8 @@ func NewDragonboatShardNotFound(ctx context.Context, msg string) *Error {
 }
 
 func NewDragonboatOtherSystemErrorf(ctx context.Context, format string, args ...any) *Error {
-	return NewDragonboatOtherSystemError(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrDragonboatOtherSystemError, msg)
 }
 
 func NewDragonboatOtherSystemError(ctx context.Context, msg string) *Error {
@@ -1212,7 +1230,8 @@ func NewTAEWrite(ctx context.Context) *Error {
 }
 
 func NewTAECommitf(ctx context.Context, format string, args ...any) *Error {
-	return NewTAECommit(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrTAECommit, msg)
 }
 
 func NewTAECommit(ctx context.Context, msg string) *Error {
@@ -1220,7 +1239,8 @@ func NewTAECommit(ctx context.Context, msg string) *Error {
 }
 
 func NewTAERollbackf(ctx context.Context, format string, args ...any) *Error {
-	return NewTAERollback(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrTAERollback, msg)
 }
 
 func NewTAERollback(ctx context.Context, msg string) *Error {
@@ -1228,7 +1248,8 @@ func NewTAERollback(ctx context.Context, msg string) *Error {
 }
 
 func NewTAEPreparef(ctx context.Context, format string, args ...any) *Error {
-	return NewTAEPrepare(ctx, fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	return newError(ctx, ErrTAEPrepare, msg)
 }
 
 func NewTAEPrepare(ctx context.Context, msg string) *Error {

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -17,6 +17,8 @@ package moerr
 import (
 	"encoding/hex"
 	"fmt"
+
+	"github.com/matrixorigin/matrixone/pkg/util/errutil"
 )
 
 func NewInfoNoCtx(msg string) *Error {
@@ -314,8 +316,12 @@ func NewTAENeedRetryNoCtx() *Error {
 	return newError(Context(), ErrTAENeedRetry)
 }
 
-func NewTxnStaleNoCtx(msg string) *Error {
-	return newError(Context(), ErrTxnStale, msg)
+func NewTxnStaleNoCtxf(
+	format string, args ...any,
+) *Error {
+	msg := fmt.Sprintf(format, args...)
+	ctx := errutil.ContextWithNoReport(Context(), true)
+	return newError(ctx, ErrTxnStale, msg)
 }
 
 func NewRetryForCNRollingRestart() *Error {

--- a/pkg/common/moerr/error_test.go
+++ b/pkg/common/moerr/error_test.go
@@ -160,3 +160,63 @@ func TestIsSameMoErr(t *testing.T) {
 	b = GetOkExpectedEOB()
 	require.True(t, IsSameMoErr(a, b))
 }
+
+func Test_ForCoverage(t *testing.T) {
+	ctx := context.Background()
+	err := NewDataTruncatedf(ctx, "test", "test")
+	require.True(t, IsMoErrCode(err, ErrDataTruncated))
+
+	err = NewConstraintViolationf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrConstraintViolation))
+
+	err = NewTxnWriteConflictf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrTxnWriteConflict))
+
+	err = NewTxnErrorf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrTxnError))
+
+	err = NewTAEErrorf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrTAEError))
+
+	err = NewDragonboatTimeoutf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrDragonboatTimeout))
+
+	err = NewDragonboatTimeoutTooSmallf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrDragonboatTimeoutTooSmall))
+
+	err = NewDragonboatInvalidDeadlinef(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrDragonboatInvalidDeadline))
+
+	err = NewDragonboatRejectedf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrDragonboatRejected))
+
+	err = NewDragonboatInvalidPayloadSizef(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrDragonboatInvalidPayloadSize))
+
+	err = NewDragonboatShardNotReadyf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrDragonboatShardNotReady))
+
+	err = NewDragonboatSystemClosedf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrDragonboatSystemClosed))
+
+	err = NewDragonboatInvalidRangef(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrDragonboatInvalidRange))
+
+	err = NewDragonboatShardNotFoundf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrDragonboatShardNotFound))
+
+	err = NewDragonboatOtherSystemErrorf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrDragonboatOtherSystemError))
+
+	err = NewTAECommitf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrTAECommit))
+
+	err = NewTAERollbackf(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrTAERollback))
+
+	err = NewTAEPreparef(ctx, "test")
+	require.True(t, IsMoErrCode(err, ErrTAEPrepare))
+
+	err = NewTxnStaleNoCtxf("test")
+	require.True(t, IsMoErrCode(err, ErrTxnStale))
+}

--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -416,8 +416,6 @@ func getAccountsStorageUsage(
 				}
 				ret[k][0] = v
 			}
-			logutil.Info("show accounts",
-				zap.Int("get size from mts (acc cnt)", len(sizes)))
 		}
 	}()
 

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -484,14 +484,27 @@ func (s statementStatus) String() string {
 }
 
 // logStatementStatus prints the status of the statement into the log.
-func logStatementStatus(ctx context.Context, ses FeSession, stmt tree.Statement, status statementStatus, err error) {
+func logStatementStatus(
+	ctx context.Context,
+	ses FeSession,
+	_ tree.Statement,
+	status statementStatus,
+	err error,
+) {
 	logStatementStringStatus(ctx, ses, "", status, err)
 }
 
 // logStatementStringStatus
-// if stmtStr == "", get the query statement from FeSession or motrace.StatementInfo (which migrate from logStatementStatus).
+// if stmtStr == "", get the query statement from FeSession or motrace.StatementInfo
+// (which migrate from logStatementStatus).
 // This op is aim to avoid string copy in 'status == success' case.
-func logStatementStringStatus(ctx context.Context, ses FeSession, stmtStr string, status statementStatus, err error) {
+func logStatementStringStatus(
+	ctx context.Context,
+	ses FeSession,
+	stmtStr string,
+	status statementStatus,
+	err error,
+) {
 	var outBytes, outPacket int64
 	var getFormatedSqlStr = func() string {
 		var str = stmtStr

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -4858,7 +4858,7 @@ func detectFkSelfRefer(c *Compile, detectSqls []string) error {
 
 // runDetectSql runs the fk detecting sql
 func runDetectSql(c *Compile, sql string) error {
-	res, err := c.runSqlWithResult(sql, NoAccountId)
+	res, err := c.runSqlWithResultAndOptions(sql, NoAccountId, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		c.proc.Errorf(c.proc.Ctx, "The sql that caused the fk self refer check failed is %s, and generated background sql is %s", c.sql, sql)
 		return err
@@ -4879,7 +4879,7 @@ func runDetectSql(c *Compile, sql string) error {
 
 // runDetectFkReferToDBSql runs the fk detecting sql
 func runDetectFkReferToDBSql(c *Compile, sql string) error {
-	res, err := c.runSqlWithResult(sql, NoAccountId)
+	res, err := c.runSqlWithResultAndOptions(sql, NoAccountId, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		c.proc.Errorf(c.proc.Ctx, "The sql that caused the fk self refer check failed is %s, and generated background sql is %s", c.sql, sql)
 		return err

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -438,11 +438,13 @@ func (s *Scope) AlterTableInplace(c *Compile) error {
 						if !moerr.IsMoErrCode(err, moerr.ErrParseError) &&
 							!moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetry) &&
 							!moerr.IsMoErrCode(err, moerr.ErrTxnNeedRetryWithDefChanged) {
-							c.proc.Error(c.proc.Ctx, "lock index table for alter table",
-								zap.String("databaseName", c.db),
-								zap.String("origin tableName", qry.GetTableDef().Name),
-								zap.String("index name", indexdef.IndexName),
-								zap.String("index tableName", indexdef.IndexTableName),
+							c.proc.Error(
+								c.proc.Ctx,
+								"alter.table.lock.index.table",
+								zap.String("db", c.db),
+								zap.String("main-table", qry.GetTableDef().Name),
+								zap.String("index-name", indexdef.IndexName),
+								zap.String("index-table-name", indexdef.IndexTableName),
 								zap.Error(err))
 							return err
 						}

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -43,6 +43,7 @@ import (
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/matrixorigin/matrixone/pkg/vectorindex/cache"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -729,8 +730,9 @@ func (s *Scope) AlterTableInplace(c *Compile) error {
 
 						// 3.b Update mo_catalog.mo_indexes
 						updateSql := fmt.Sprintf(updateMoIndexesAlgoParams, newAlgoParams, oTableDef.TblId, alterIndex.IndexName)
-						err = c.runSql(updateSql)
-						if err != nil {
+						if err = c.runSqlWithOptions(
+							updateSql, executor.StatementOption{}.WithDisableLog(),
+						); err != nil {
 							return err
 						}
 

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -205,7 +205,7 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	// 4.update mo_pitr table
 	if !needSkipDbs[dbName] {
 		now := c.proc.GetTxnOperator().SnapshotTS().ToStdTime().UTC().UnixNano()
-		updatePitrSql := fmt.Sprintf("update `%s`.`%s` set `%s` = %d, `%s` = %d where `%s` = %d and `%s` = '%s' and `%s` = %d and `%s` = %s",
+		updatePitrSql := fmt.Sprintf("UPDATE `%s`.`%s` SET `%s` = %d, `%s` = %d WHERE `%s` = %d AND `%s` = '%s' AND `%s` = %d AND `%s` = %s",
 			catalog.MO_CATALOG, catalog.MO_PITR,
 			catalog.MO_PITR_STATUS, 0,
 			catalog.MO_PITR_CHANGED_TIME, now,
@@ -1377,7 +1377,7 @@ func (s *Scope) CreateTable(c *Compile) error {
 		var initSQL string
 		switch def.TableType {
 		case catalog.SystemSI_IVFFLAT_TblType_Metadata:
-			initSQL = fmt.Sprintf("insert into `%s`.`%s` (`%s`, `%s`) VALUES('version', '0');",
+			initSQL = fmt.Sprintf("INSERT INTO `%s`.`%s` (`%s`, `%s`) VALUES('version', '0');",
 				qry.Database,
 				def.Name,
 				catalog.SystemSI_IVFFLAT_TblCol_Metadata_key,
@@ -1385,7 +1385,7 @@ func (s *Scope) CreateTable(c *Compile) error {
 			)
 
 		case catalog.SystemSI_IVFFLAT_TblType_Centroids:
-			initSQL = fmt.Sprintf("insert into `%s`.`%s` (`%s`, `%s`, `%s`) VALUES(0,1,NULL);",
+			initSQL = fmt.Sprintf("INSERT INTO `%s`.`%s` (`%s`, `%s`, `%s`) VALUES(0,1,NULL);",
 				qry.Database,
 				def.Name,
 				catalog.SystemSI_IVFFLAT_TblCol_Centroids_version,
@@ -1561,7 +1561,7 @@ func (s *Scope) CreateView(c *Compile) error {
 		}
 
 		if qry.GetReplace() {
-			err = c.runSql(fmt.Sprintf("drop view if exists %s", viewName))
+			err = c.runSql(fmt.Sprintf("DROP VIEW IF EXISTS %s", viewName))
 			if err != nil {
 				getLogger(s.Proc.GetService()).Error("drop existing view failed",
 					zap.String("databaseName", c.db),
@@ -2781,7 +2781,7 @@ func (s *Scope) DropTable(c *Compile) error {
 	if !needSkipDbs[dbName] {
 		now := c.proc.GetTxnOperator().SnapshotTS().ToStdTime().UTC().UnixNano()
 		updatePitrSql := fmt.Sprintf(
-			"update `%s`.`%s` set `%s` = %d, `%s` = %d where `%s` = %d and `%s` = '%s' and `%s` = '%s' and `%s` = %d and `%s` = %d",
+			"UPDATE `%s`.`%s` SET `%s` = %d, `%s` = %d WHERE `%s` = %d AND `%s` = '%s' AND `%s` = '%s' AND `%s` = %d AND `%s` = %d",
 			catalog.MO_CATALOG, catalog.MO_PITR,
 			catalog.MO_PITR_STATUS, 0,
 			catalog.MO_PITR_CHANGED_TIME, now,
@@ -2801,12 +2801,12 @@ func (s *Scope) DropTable(c *Compile) error {
 
 	sqls := []string{
 		fmt.Sprintf(
-			"delete from mo_catalog.mo_merge_settings where account_id = %d and tid = %d",
+			"DELETE FROM mo_catalog.mo_merge_settings WHERE account_id = %d AND tid = %d",
 			accountID, tblID,
 		),
 
 		fmt.Sprintf(
-			"update mo_catalog.mo_branch_metadata set table_deleted = true where table_id = %d",
+			"UPDATE mo_catalog.mo_branch_metadata SET table_deleted = true WHERE table_id = %d",
 			tblID,
 		),
 	}
@@ -2933,7 +2933,7 @@ func (s *Scope) AlterSequence(c *Compile) error {
 	if rel, err := dbSource.Relation(c.proc.Ctx, tblName, nil); err == nil {
 		// sequence table exists
 		// get pre sequence table row values
-		_values, err := c.proc.GetSessionInfo().SqlHelper.ExecSql(fmt.Sprintf("select * from `%s`.`%s`", dbName, tblName))
+		_values, err := c.proc.GetSessionInfo().SqlHelper.ExecSql(fmt.Sprintf("SELECT * FROM `%s`.`%s`", dbName, tblName))
 		if err != nil {
 			return err
 		}
@@ -2946,7 +2946,7 @@ func (s *Scope) AlterSequence(c *Compile) error {
 
 		curval = c.proc.GetSessionInfo().SeqCurValues[rel.GetTableID(c.proc.Ctx)]
 		// dorp the pre sequence
-		err = c.runSql(fmt.Sprintf("drop sequence %s", tblName))
+		err = c.runSql(fmt.Sprintf("DROP SEQUENCE %s", tblName))
 		if err != nil {
 			return err
 		}
@@ -3846,7 +3846,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
 
 	// check pitr if exists（pitr_name + create_account）
 	checkExistSql := getSqlForCheckPitrExists(pitrName, accountId)
-	existRes, err := c.runSqlWithResult(checkExistSql, int32(accountId))
+	existRes, err := c.runSqlWithResultAndOptions(checkExistSql, int32(accountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -3861,7 +3861,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
 
 	// Check if pitr dup
 	checkSql := getSqlForCheckPitrDup(createPitr)
-	res, err := c.runSqlWithResult(checkSql, int32(accountId))
+	res, err := c.runSqlWithResultAndOptions(checkSql, int32(accountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -3878,7 +3878,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
 
 	now := c.proc.GetTxnOperator().SnapshotTS().ToStdTime().UTC().UnixNano()
 	// Build create pitr sql
-	sql := fmt.Sprintf(`insert into mo_catalog.mo_pitr(
+	sql := fmt.Sprintf(`INSERT INTO mo_catalog.mo_pitr(
                                pitr_id,
                                pitr_name,
                                create_account,
@@ -3892,7 +3892,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
                                obj_id,
                                pitr_length,
                                pitr_unit,
-                               pitr_status_changed_time) values ('%s', '%s', %d, %d, %d, '%s', %d, '%s', '%s', '%s', %d, %d, '%s', %d)`,
+                               pitr_status_changed_time) VALUES ('%s', '%s', %d, %d, %d, '%s', %d, '%s', '%s', '%s', %d, %d, '%s', %d)`,
 		newUUid,
 		pitrName,
 		createPitr.GetCurrentAccountId(),
@@ -3910,7 +3910,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
 	)
 
 	// Execute create pitr sql
-	err = c.runSql(sql)
+	err = c.runSqlWithOptions(sql, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -3920,8 +3920,8 @@ func (s *Scope) CreatePitr(c *Compile) error {
 	const sysAccountId = 0
 
 	// Query for sys_mo_catalog_pitr
-	sysPitrSql := "select pitr_length, pitr_unit from mo_catalog.mo_pitr where pitr_name = '" + sysMoCatalogPitr + "'"
-	sysRes, err := c.runSqlWithResult(sysPitrSql, sysAccountId)
+	sysPitrSql := "SELECT pitr_length, pitr_unit FROM mo_catalog.mo_pitr WHERE pitr_name = '" + sysMoCatalogPitr + "'"
+	sysRes, err := c.runSqlWithResultAndOptions(sysPitrSql, sysAccountId, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -3938,8 +3938,8 @@ func (s *Scope) CreatePitr(c *Compile) error {
 	}
 
 	if needUpdateSysPitr {
-		updateSql := fmt.Sprintf("update mo_catalog.mo_pitr set pitr_length = %d, pitr_unit = '%s' where pitr_name = '%s'", createPitr.GetPitrValue(), createPitr.GetPitrUnit(), sysMoCatalogPitr)
-		err = c.runSqlWithAccountId(updateSql, sysAccountId)
+		updateSql := fmt.Sprintf("UPDATE mo_catalog.mo_pitr SET pitr_length = %d, pitr_unit = '%s' WHERE pitr_name = '%s'", createPitr.GetPitrValue(), createPitr.GetPitrUnit(), sysMoCatalogPitr)
+		err = c.runSqlWithAccountIdAndOptions(updateSql, sysAccountId, executor.StatementOption{}.WithDisableLog())
 		if err != nil {
 			return err
 		}
@@ -3958,7 +3958,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
 		if err != nil {
 			return err
 		}
-		insertSql := fmt.Sprintf(`insert into mo_catalog.mo_pitr(
+		insertSql := fmt.Sprintf(`INSERT INTO mo_catalog.mo_pitr(
 			pitr_id,
 			pitr_name,
 			create_account,
@@ -3973,7 +3973,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
 			pitr_length,
 			pitr_unit,
             pitr_status_changed_time
-        ) values ('%s', '%s', %d, %d, %d, '%s', %d, '%s', '%s', '%s', '%s', %d, '%s', %d)`,
+        ) VALUES ('%s', '%s', %d, %d, %d, '%s', %d, '%s', '%s', '%s', '%s', %d, '%s', %d)`,
 
 			sysPitrUuid,
 			sysMoCatalogPitr,
@@ -3990,7 +3990,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
 			createPitr.GetPitrUnit(),
 			now,
 		)
-		err = c.runSqlWithAccountId(insertSql, sysAccountId)
+		err = c.runSqlWithAccountIdAndOptions(insertSql, sysAccountId, executor.StatementOption{}.WithDisableLog())
 		if err != nil {
 			return err
 		}
@@ -4039,8 +4039,8 @@ func (s *Scope) DropPitr(c *Compile) error {
 	}
 
 	// 1. Check if PITR exists
-	checkSql := fmt.Sprintf("select pitr_id from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = %d", pitrName, accountId)
-	res, err := c.runSqlWithResult(checkSql, int32(accountId))
+	checkSql := fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", pitrName, accountId)
+	res, err := c.runSqlWithResultAndOptions(checkSql, int32(accountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -4053,23 +4053,23 @@ func (s *Scope) DropPitr(c *Compile) error {
 	}
 
 	// 2. Delete PITR record
-	deleteSql := fmt.Sprintf("delete from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = %d", pitrName, accountId)
-	err = c.runSqlWithAccountId(deleteSql, int32(accountId))
+	deleteSql := fmt.Sprintf("DELETE FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", pitrName, accountId)
+	err = c.runSqlWithAccountIdAndOptions(deleteSql, int32(accountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
 
 	// 3. Check if there are other PITR records besides sys_mo_catalog_pitr
-	checkOtherSql := fmt.Sprintf("select pitr_id from mo_catalog.mo_pitr where pitr_name != '%s'", sysMoCatalogPitr)
-	otherRes, err := c.runSqlWithResult(checkOtherSql, sysAccountId)
+	checkOtherSql := fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name != '%s'", sysMoCatalogPitr)
+	otherRes, err := c.runSqlWithResultAndOptions(checkOtherSql, sysAccountId, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
 	defer otherRes.Close()
 	if len(otherRes.Batches) == 0 || otherRes.Batches[0].RowCount() == 0 {
 		// 4. No other PITR records, delete sys_mo_catalog_pitr
-		deleteSysSql := fmt.Sprintf("delete from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = %d", sysMoCatalogPitr, sysAccountId)
-		err = c.runSqlWithAccountId(deleteSysSql, sysAccountId)
+		deleteSysSql := fmt.Sprintf("DELETE FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", sysMoCatalogPitr, sysAccountId)
+		err = c.runSqlWithAccountIdAndOptions(deleteSysSql, sysAccountId, executor.StatementOption{}.WithDisableLog())
 		if err != nil {
 			return err
 		}
@@ -4095,7 +4095,7 @@ func pitrDupError(c *Compile, createPitr *plan.CreatePitr) error {
 func getSqlForCheckPitrDup(
 	createPitr *plan.CreatePitr,
 ) string {
-	sql := "select pitr_id from mo_catalog.mo_pitr where create_account = %d"
+	sql := "SELECT pitr_id FROM mo_catalog.mo_pitr WHERE create_account = %d"
 	switch tree.PitrLevel(createPitr.GetLevel()) {
 	case tree.PITRLEVELCLUSTER:
 		return getSqlForCheckDupPitrFormat(createPitr.CurrentAccountId, math.MaxUint64)
@@ -4114,7 +4114,7 @@ func getSqlForCheckPitrDup(
 }
 
 func getSqlForCheckDupPitrFormat(accountId uint32, objId uint64) string {
-	return fmt.Sprintf(`select pitr_id from mo_catalog.mo_pitr where create_account = %d and obj_id = %d;`, accountId, objId)
+	return fmt.Sprintf(`SELECT pitr_id FROM mo_catalog.mo_pitr WHERE create_account = %d AND obj_id = %d;`, accountId, objId)
 }
 
 func getPitrObjectId(createPitr *plan.CreatePitr) uint64 {
@@ -4182,5 +4182,5 @@ func CheckSysMoCatalogPitrResult(ctx context.Context, vecs []*vector.Vector, new
 }
 
 func getSqlForCheckPitrExists(pitrName string, accountId uint32) string {
-	return fmt.Sprintf("select pitr_id from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = %d order by pitr_id", pitrName, accountId)
+	return fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d ORDER BY pitr_id", pitrName, accountId)
 }

--- a/pkg/sql/compile/ddl_index_algo.go
+++ b/pkg/sql/compile/ddl_index_algo.go
@@ -113,7 +113,7 @@ func (s *Scope) handleMasterIndexTable(
 
 	insertSQLs := genInsertIndexTableSqlForMasterIndex(originalTableDef, indexDef, qryDatabase)
 	for _, insertSQL := range insertSQLs {
-		err = c.runSql(insertSQL)
+		err = c.runSqlWithOptions(insertSQL, executor.StatementOption{}.WithDisableLog())
 		if err != nil {
 			return err
 		}
@@ -143,7 +143,7 @@ func (s *Scope) handleFullTextIndexTable(
 
 	insertSQLs := genInsertIndexTableSqlForFullTextIndex(originalTableDef, indexDef, qryDatabase)
 	for _, insertSQL := range insertSQLs {
-		err = c.runSql(insertSQL)
+		err = c.runSqlWithOptions(insertSQL, executor.StatementOption{}.WithDisableLog())
 		if err != nil {
 			return err
 		}
@@ -197,7 +197,8 @@ func (s *Scope) handleIvfIndexMetaTable(c *Compile, indexDef *plan.IndexDef, qry
 		catalog.SystemSI_IVFFLAT_TblCol_Metadata_val,
 	)
 
-	err := c.runSql(insertSQL)
+	// Disable SQL logging for vector index metadata table operations
+	err := c.runSqlWithOptions(insertSQL, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -248,7 +249,8 @@ func (s *Scope) handleIvfIndexCentroidsTable(c *Compile, indexDef *plan.IndexDef
 			metadataTableName,
 			catalog.SystemSI_IVFFLAT_TblCol_Metadata_key,
 		)
-		err := c.runSql(initSQL)
+		// Disable SQL logging for vector index centroids table initialization
+		err := c.runSqlWithOptions(initSQL, executor.StatementOption{}.WithDisableLog())
 		if err != nil {
 			return err
 		}
@@ -294,7 +296,8 @@ func (s *Scope) handleIvfIndexCentroidsTable(c *Compile, indexDef *plan.IndexDef
 		return err
 	}
 
-	err = c.runSql(sql)
+	// Disable SQL logging for vector index centroids clustering
+	err = c.runSqlWithOptions(sql, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -389,7 +392,8 @@ func (s *Scope) handleIvfIndexEntriesTable(c *Compile, indexDef *plan.IndexDef, 
 		return err
 	}
 
-	err = c.runSql(centroidsCrossL2JoinTbl)
+	// Disable SQL logging for vector index entries table mapping
+	err = c.runSqlWithOptions(centroidsCrossL2JoinTbl, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -403,9 +407,8 @@ func (s *Scope) handleIvfIndexEntriesTable(c *Compile, indexDef *plan.IndexDef, 
 }
 
 func (s *Scope) logTimestamp(c *Compile, qryDatabase, metadataTableName, metrics string) error {
-	return c.runSql(fmt.Sprintf("INSERT INTO `%s`.`%s` (%s, %s) "+
-		" VALUES ('%s', NOW()) "+
-		" ON DUPLICATE KEY UPDATE %s = NOW();",
+	// Disable SQL logging for vector index timestamp logging
+	return c.runSqlWithOptions(fmt.Sprintf("INSERT INTO `%s`.`%s` (%s, %s) "+" VALUES ('%s', NOW()) "+" ON DUPLICATE KEY UPDATE %s = NOW();",
 		qryDatabase,
 		metadataTableName,
 		catalog.SystemSI_IVFFLAT_TblCol_Metadata_key,
@@ -414,7 +417,7 @@ func (s *Scope) logTimestamp(c *Compile, qryDatabase, metadataTableName, metrics
 		metrics,
 
 		catalog.SystemSI_IVFFLAT_TblCol_Metadata_val,
-	))
+	), executor.StatementOption{}.WithDisableLog())
 }
 
 func (s *Scope) isExperimentalEnabled(c *Compile, flag string) (bool, error) {
@@ -479,12 +482,13 @@ func (s *Scope) handleIvfIndexDeleteOldEntries(c *Compile,
 		return err
 	}
 
-	err = c.runSql(pruneCentroidsTbl)
+	// Disable SQL logging for vector index old entries pruning
+	err = c.runSqlWithOptions(pruneCentroidsTbl, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
 
-	err = c.runSql(pruneEntriesTbl)
+	err = c.runSqlWithOptions(pruneEntriesTbl, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -543,7 +547,8 @@ func (s *Scope) handleVectorHnswIndex(
 		}
 
 		for _, sql := range sqls {
-			err = c.runSql(sql)
+			// Disable SQL logging for vector index SQL execution
+			err = c.runSqlWithOptions(sql, executor.StatementOption{}.WithDisableLog())
 			if err != nil {
 				return err
 			}
@@ -557,7 +562,8 @@ func (s *Scope) handleVectorHnswIndex(
 	}
 
 	for _, sql := range sqls {
-		err = c.runSql(sql)
+		// Disable SQL logging for vector index SQL execution
+		err = c.runSqlWithOptions(sql, executor.StatementOption{}.WithDisableLog())
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/compile/fuzzyCheck.go
+++ b/pkg/sql/compile/fuzzyCheck.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/util/executor"
 )
 
 /*
@@ -317,7 +318,7 @@ func (f *fuzzyCheck) backgroundSQLCheck(c *Compile) error {
 		duplicateCheckSql = fmt.Sprintf(fuzzyNonCompoundCheck, f.attr, f.db, f.tbl, f.attr, f.condition, f.attr)
 	}
 
-	res, err := c.runSqlWithResult(duplicateCheckSql, NoAccountId)
+	res, err := c.runSqlWithResultAndOptions(duplicateCheckSql, NoAccountId, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		c.debugLogFor19288(err, duplicateCheckSql)
 		c.proc.Errorf(c.proc.Ctx, "The sql that caused the fuzzy check background SQL failed is %s, and generated background sql is %s", c.sql, duplicateCheckSql)

--- a/pkg/sql/compile/pub_sub.go
+++ b/pkg/sql/compile/pub_sub.go
@@ -46,9 +46,9 @@ func createSubscription(ctx context.Context, c *Compile, dbName string, subOptio
 
 	// check existence
 	sql := fmt.Sprintf(`
-		SELECT COUNT(1)
+		SELECT count(1)
 		FROM mo_catalog.mo_subs
-		WHERE pub_account_name = '%s' AND pub_name = '%s' AND sub_account_id = %d AND sub_name IS NOT NULL
+		WHERE pub_account_name = '%s' AND pub_name = '%s' AND sub_account_id = %d AND sub_name is not null
 	`, subOption.From, subOption.Publication, accountId)
 	rs, err := c.runSqlWithResultAndOptions(
 		sql,
@@ -71,7 +71,7 @@ func createSubscription(ctx context.Context, c *Compile, dbName string, subOptio
 
 	sql = fmt.Sprintf(`
 		UPDATE mo_catalog.mo_subs
-		SET sub_name='%s', sub_time=NOW()
+		SET sub_name='%s', sub_time=now()
 		WHERE pub_account_name = '%s' AND pub_name = '%s' AND sub_account_id = %d
 	`, dbName, subOption.From, subOption.Publication, accountId)
 	return c.runSqlWithAccountIdAndOptions(
@@ -90,7 +90,7 @@ func dropSubscription(ctx context.Context, c *Compile, dbName string) error {
 	// update SubStatusNormal records
 	sql := fmt.Sprintf(`
 		UPDATE mo_catalog.mo_subs
-		SET sub_name=NULL, sub_time=NULL
+		SET sub_name=null, sub_time=null
 		WHERE sub_account_id = %d AND sub_name = '%s' AND status = %d
 	`, accountId, dbName, pubsub.SubStatusNormal)
 	if err = c.runSqlWithAccountIdAndOptions(

--- a/pkg/sql/compile/pub_sub.go
+++ b/pkg/sql/compile/pub_sub.go
@@ -46,9 +46,9 @@ func createSubscription(ctx context.Context, c *Compile, dbName string, subOptio
 
 	// check existence
 	sql := fmt.Sprintf(`
-		SELECT count(1)
+		SELECT COUNT(1)
 		FROM mo_catalog.mo_subs
-		WHERE pub_account_name = '%s' AND pub_name = '%s' AND sub_account_id = %d AND sub_name is not null
+		WHERE pub_account_name = '%s' AND pub_name = '%s' AND sub_account_id = %d AND sub_name IS NOT NULL
 	`, subOption.From, subOption.Publication, accountId)
 	rs, err := c.runSqlWithResultAndOptions(
 		sql,
@@ -71,7 +71,7 @@ func createSubscription(ctx context.Context, c *Compile, dbName string, subOptio
 
 	sql = fmt.Sprintf(`
 		UPDATE mo_catalog.mo_subs
-		SET sub_name='%s', sub_time=now()
+		SET sub_name='%s', sub_time=NOW()
 		WHERE pub_account_name = '%s' AND pub_name = '%s' AND sub_account_id = %d
 	`, dbName, subOption.From, subOption.Publication, accountId)
 	return c.runSqlWithAccountIdAndOptions(
@@ -90,7 +90,7 @@ func dropSubscription(ctx context.Context, c *Compile, dbName string) error {
 	// update SubStatusNormal records
 	sql := fmt.Sprintf(`
 		UPDATE mo_catalog.mo_subs
-		SET sub_name=null, sub_time=null
+		SET sub_name=NULL, sub_time=NULL
 		WHERE sub_account_id = %d AND sub_name = '%s' AND status = %d
 	`, accountId, dbName, pubsub.SubStatusNormal)
 	if err = c.runSqlWithAccountIdAndOptions(

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -906,7 +906,7 @@ func (s *Scope) replace(c *Compile) error {
 
 	delAffectedRows := uint64(0)
 	if deleteCond != "" {
-		result, err := c.runSqlWithResult(fmt.Sprintf("delete from `%s`.`%s` where %s", dbName, tblName, deleteCond), NoAccountId)
+		result, err := c.runSqlWithResult(fmt.Sprintf("DELETE FROM `%s`.`%s` WHERE %s", dbName, tblName, deleteCond), NoAccountId)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/compile/util.go
+++ b/pkg/sql/compile/util.go
@@ -70,31 +70,31 @@ var (
 )
 var (
 	// see the comment in fuzzyCheck func genCondition for the reason why has to be two SQLs
-	fuzzyNonCompoundCheck = "select %s from `%s`.`%s` where %s in (%s) group by %s having count(*) > 1 limit 1;"
-	fuzzyCompoundCheck    = "select serial(%s) from `%s`.`%s` where %s group by serial(%s) having count(*) > 1 limit 1;"
+	fuzzyNonCompoundCheck = "SELECT %s FROM `%s`.`%s` WHERE %s IN (%s) GROUP BY %s HAVING COUNT(*) > 1 LIMIT 1;"
+	fuzzyCompoundCheck    = "SELECT serial(%s) FROM `%s`.`%s` WHERE %s GROUP BY serial(%s) HAVING COUNT(*) > 1 LIMIT 1;"
 )
 
 var (
-	insertIntoSingleIndexTableWithPKeyFormat    = "insert into  `%s`.`%s` select (%s), %s from `%s`.`%s` where (%s) is not null;"
-	insertIntoUniqueIndexTableWithPKeyFormat    = "insert into  `%s`.`%s` select serial(%s), %s from `%s`.`%s` where serial(%s) is not null;"
-	insertIntoSecondaryIndexTableWithPKeyFormat = "insert into  `%s`.`%s` select serial_full(%s), %s from `%s`.`%s`;"
-	insertIntoSingleIndexTableWithoutPKeyFormat = "insert into  `%s`.`%s` select (%s) from `%s`.`%s` where (%s) is not null;"
-	insertIntoIndexTableWithoutPKeyFormat       = "insert into  `%s`.`%s` select serial(%s) from `%s`.`%s` where serial(%s) is not null;"
-	insertIntoMasterIndexTableFormat            = "insert into  `%s`.`%s` select serial_full('%s', %s, %s), %s from `%s`.`%s`;"
+	insertIntoSingleIndexTableWithPKeyFormat    = "INSERT INTO  `%s`.`%s` SELECT (%s), %s FROM `%s`.`%s` WHERE (%s) IS NOT NULL;"
+	insertIntoUniqueIndexTableWithPKeyFormat    = "INSERT INTO  `%s`.`%s` SELECT serial(%s), %s FROM `%s`.`%s` WHERE serial(%s) IS NOT NULL;"
+	insertIntoSecondaryIndexTableWithPKeyFormat = "INSERT INTO  `%s`.`%s` SELECT serial_full(%s), %s FROM `%s`.`%s`;"
+	insertIntoSingleIndexTableWithoutPKeyFormat = "INSERT INTO  `%s`.`%s` SELECT (%s) FROM `%s`.`%s` WHERE (%s) IS NOT NULL;"
+	insertIntoIndexTableWithoutPKeyFormat       = "INSERT INTO  `%s`.`%s` SELECT serial(%s) FROM `%s`.`%s` WHERE serial(%s) IS NOT NULL;"
+	insertIntoMasterIndexTableFormat            = "INSERT INTO  `%s`.`%s` SELECT serial_full('%s', %s, %s), %s FROM `%s`.`%s`;"
 )
 
 var (
-	deleteMoIndexesWithDatabaseIdFormat          = `delete from mo_catalog.mo_indexes where database_id = %v;`
-	deleteMoIndexesWithTableIdFormat             = `delete from mo_catalog.mo_indexes where table_id = %v;`
-	deleteMoIndexesWithTableIdAndIndexNameFormat = `delete from mo_catalog.mo_indexes where table_id = %v and name = '%s';`
-	updateMoIndexesVisibleFormat                 = `update mo_catalog.mo_indexes set is_visible = %v where table_id = %v and name = '%s';`
-	updateMoIndexesTruncateTableFormat           = `update mo_catalog.mo_indexes set table_id = %v where table_id = %v`
-	updateMoIndexesAlgoParams                    = `update mo_catalog.mo_indexes set algo_params = '%s' where table_id = %v and name = '%s';`
-	updateMoMergeSettings                        = `update mo_catalog.mo_merge_settings set tid = %v where account_id = %v and tid = %v;`
+	deleteMoIndexesWithDatabaseIdFormat          = `DELETE FROM mo_catalog.mo_indexes WHERE database_id = %v;`
+	deleteMoIndexesWithTableIdFormat             = `DELETE FROM mo_catalog.mo_indexes WHERE table_id = %v;`
+	deleteMoIndexesWithTableIdAndIndexNameFormat = `DELETE FROM mo_catalog.mo_indexes WHERE table_id = %v AND name = '%s';`
+	updateMoIndexesVisibleFormat                 = `UPDATE mo_catalog.mo_indexes SET is_visible = %v WHERE table_id = %v AND name = '%s';`
+	updateMoIndexesTruncateTableFormat           = `UPDATE mo_catalog.mo_indexes SET table_id = %v WHERE table_id = %v`
+	updateMoIndexesAlgoParams                    = `UPDATE mo_catalog.mo_indexes SET algo_params = '%s' WHERE table_id = %v AND name = '%s';`
+	updateMoMergeSettings                        = `UPDATE mo_catalog.mo_merge_settings SET tid = %v WHERE account_id = %v AND tid = %v;`
 )
 
 var (
-	dropTableBeforeDropDatabase = "drop table if exists `%v`.`%v`;"
+	dropTableBeforeDropDatabase = "DROP TABLE IF EXISTS `%v`.`%v`;"
 )
 
 var (
@@ -102,7 +102,7 @@ var (
 )
 
 var (
-	insertIntoHnswIndexTableFormat = "SELECT f.* from `%s`.`%s` AS %s CROSS APPLY hnsw_create('%s', '%s', %s, %s) AS f;"
+	insertIntoHnswIndexTableFormat = "SELECT f.* FROM `%s`.`%s` AS %s CROSS APPLY hnsw_create('%s', '%s', %s, %s) AS f;"
 )
 
 // genInsertIndexTableSql: Generate an insert statement for inserting data into the index table

--- a/pkg/sql/compile/util.go
+++ b/pkg/sql/compile/util.go
@@ -70,31 +70,31 @@ var (
 )
 var (
 	// see the comment in fuzzyCheck func genCondition for the reason why has to be two SQLs
-	fuzzyNonCompoundCheck = "SELECT %s FROM `%s`.`%s` WHERE %s IN (%s) GROUP BY %s HAVING COUNT(*) > 1 LIMIT 1;"
-	fuzzyCompoundCheck    = "SELECT serial(%s) FROM `%s`.`%s` WHERE %s GROUP BY serial(%s) HAVING COUNT(*) > 1 LIMIT 1;"
+	fuzzyNonCompoundCheck = "select %s from `%s`.`%s` where %s in (%s) group by %s having count(*) > 1 limit 1;"
+	fuzzyCompoundCheck    = "select serial(%s) from `%s`.`%s` where %s group by serial(%s) having count(*) > 1 limit 1;"
 )
 
 var (
-	insertIntoSingleIndexTableWithPKeyFormat    = "INSERT INTO  `%s`.`%s` SELECT (%s), %s FROM `%s`.`%s` WHERE (%s) IS NOT NULL;"
-	insertIntoUniqueIndexTableWithPKeyFormat    = "INSERT INTO  `%s`.`%s` SELECT serial(%s), %s FROM `%s`.`%s` WHERE serial(%s) IS NOT NULL;"
-	insertIntoSecondaryIndexTableWithPKeyFormat = "INSERT INTO  `%s`.`%s` SELECT serial_full(%s), %s FROM `%s`.`%s`;"
-	insertIntoSingleIndexTableWithoutPKeyFormat = "INSERT INTO  `%s`.`%s` SELECT (%s) FROM `%s`.`%s` WHERE (%s) IS NOT NULL;"
-	insertIntoIndexTableWithoutPKeyFormat       = "INSERT INTO  `%s`.`%s` SELECT serial(%s) FROM `%s`.`%s` WHERE serial(%s) IS NOT NULL;"
-	insertIntoMasterIndexTableFormat            = "INSERT INTO  `%s`.`%s` SELECT serial_full('%s', %s, %s), %s FROM `%s`.`%s`;"
+	insertIntoSingleIndexTableWithPKeyFormat    = "insert into  `%s`.`%s` select (%s), %s from `%s`.`%s` where (%s) is not null;"
+	insertIntoUniqueIndexTableWithPKeyFormat    = "insert into  `%s`.`%s` select serial(%s), %s from `%s`.`%s` where serial(%s) is not null;"
+	insertIntoSecondaryIndexTableWithPKeyFormat = "insert into  `%s`.`%s` select serial_full(%s), %s from `%s`.`%s`;"
+	insertIntoSingleIndexTableWithoutPKeyFormat = "insert into  `%s`.`%s` select (%s) from `%s`.`%s` where (%s) is not null;"
+	insertIntoIndexTableWithoutPKeyFormat       = "insert into  `%s`.`%s` select serial(%s) from `%s`.`%s` where serial(%s) is not null;"
+	insertIntoMasterIndexTableFormat            = "insert into  `%s`.`%s` select serial_full('%s', %s, %s), %s from `%s`.`%s`;"
 )
 
 var (
-	deleteMoIndexesWithDatabaseIdFormat          = `DELETE FROM mo_catalog.mo_indexes WHERE database_id = %v;`
-	deleteMoIndexesWithTableIdFormat             = `DELETE FROM mo_catalog.mo_indexes WHERE table_id = %v;`
-	deleteMoIndexesWithTableIdAndIndexNameFormat = `DELETE FROM mo_catalog.mo_indexes WHERE table_id = %v AND name = '%s';`
-	updateMoIndexesVisibleFormat                 = `UPDATE mo_catalog.mo_indexes SET is_visible = %v WHERE table_id = %v AND name = '%s';`
-	updateMoIndexesTruncateTableFormat           = `UPDATE mo_catalog.mo_indexes SET table_id = %v WHERE table_id = %v`
-	updateMoIndexesAlgoParams                    = `UPDATE mo_catalog.mo_indexes SET algo_params = '%s' WHERE table_id = %v AND name = '%s';`
-	updateMoMergeSettings                        = `UPDATE mo_catalog.mo_merge_settings SET tid = %v WHERE account_id = %v AND tid = %v;`
+	deleteMoIndexesWithDatabaseIdFormat          = `delete from mo_catalog.mo_indexes where database_id = %v;`
+	deleteMoIndexesWithTableIdFormat             = `delete from mo_catalog.mo_indexes where table_id = %v;`
+	deleteMoIndexesWithTableIdAndIndexNameFormat = `delete from mo_catalog.mo_indexes where table_id = %v and name = '%s';`
+	updateMoIndexesVisibleFormat                 = `update mo_catalog.mo_indexes set is_visible = %v where table_id = %v and name = '%s';`
+	updateMoIndexesTruncateTableFormat           = `update mo_catalog.mo_indexes set table_id = %v where table_id = %v`
+	updateMoIndexesAlgoParams                    = `update mo_catalog.mo_indexes set algo_params = '%s' where table_id = %v and name = '%s';`
+	updateMoMergeSettings                        = `update mo_catalog.mo_merge_settings set tid = %v where account_id = %v and tid = %v;`
 )
 
 var (
-	dropTableBeforeDropDatabase = "DROP TABLE IF EXISTS `%v`.`%v`;"
+	dropTableBeforeDropDatabase = "drop table if exists `%v`.`%v`;"
 )
 
 var (
@@ -102,7 +102,7 @@ var (
 )
 
 var (
-	insertIntoHnswIndexTableFormat = "SELECT f.* FROM `%s`.`%s` AS %s CROSS APPLY hnsw_create('%s', '%s', %s, %s) AS f;"
+	insertIntoHnswIndexTableFormat = "SELECT f.* from `%s`.`%s` AS %s CROSS APPLY hnsw_create('%s', '%s', %s, %s) AS f;"
 )
 
 // genInsertIndexTableSql: Generate an insert statement for inserting data into the index table

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1271,14 +1271,15 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 			createTable.TableDef.Cols = append(createTable.TableDef.Cols, col)
 		}
 
-		// insert into new_table select default_val1, default_val2, ..., * from (select clause);
+		// INSERT INTO new_table SELECT default_val1, default_val2, ..., * FROM (SELECT clause);
 		var insertSqlBuilder strings.Builder
-		insertSqlBuilder.WriteString(fmt.Sprintf("insert into `%s`.`%s` select ", createTable.Database, createTable.TableDef.Name))
+		insertSqlBuilder.WriteString(fmt.Sprintf("INSERT INTO `%s`.`%s` SELECT ",
+			createTable.Database, createTable.TableDef.Name))
 
 		cols := createTable.TableDef.Cols
 		firstCol := true
 		for i := range cols {
-			// insert default values if col[i] only in create clause
+			// INSERT default values if col[i] only in create clause
 			if !slices.ContainsFunc(asSelectCols, func(c *ColDef) bool { return c.Name == cols[i].Name }) {
 				if !firstCol {
 					insertSqlBuilder.WriteString(", ")
@@ -1290,13 +1291,13 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 		if !firstCol {
 			insertSqlBuilder.WriteString(", ")
 		}
-		// add all cols from select clause
+		// add all cols from SELECT clause
 		insertSqlBuilder.WriteString("*")
 
-		// from
+		// FROM
 		fmtCtx := tree.NewFmtCtx(dialect.MYSQL, tree.WithQuoteString(true))
 		stmt.AsSource.Format(fmtCtx)
-		insertSqlBuilder.WriteString(fmt.Sprintf(" from (%s)", fmtCtx.String()))
+		insertSqlBuilder.WriteString(fmt.Sprintf(" FROM (%s)", fmtCtx.String()))
 
 		createTable.CreateAsSelectSql = insertSqlBuilder.String()
 	}

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -3271,7 +3271,7 @@ func (fk FkReferDef) String() string {
 // that refer to the table
 func GetSqlForFkReferredTo(db, table string) string {
 	return fmt.Sprintf(
-		"select "+
+		"SELECT "+
 			"db_name, "+
 			"table_name, "+
 			"constraint_name, "+
@@ -3279,13 +3279,13 @@ func GetSqlForFkReferredTo(db, table string) string {
 			"refer_column_name, "+
 			"on_delete, "+
 			"on_update "+
-			"from "+
+			"FROM "+
 			"`mo_catalog`.`mo_foreign_keys` "+
-			"where "+
-			"refer_db_name = '%s' and refer_table_name = '%s' "+
-			" and "+
-			"(db_name != '%s' or db_name = '%s' and table_name != '%s') "+
-			"order by db_name, table_name, constraint_name;",
+			"WHERE "+
+			"refer_db_name = '%s' AND refer_table_name = '%s' "+
+			"AND "+
+			"(db_name != '%s' OR db_name = '%s' AND table_name != '%s') "+
+			"ORDER BY db_name, table_name, constraint_name;",
 		db, table, db, db, table)
 }
 
@@ -3408,9 +3408,9 @@ func getSqlForAddFk(db, table string, data *FkData) string {
 // on the table
 func getSqlForDeleteTable(db, tbl string) string {
 	sb := strings.Builder{}
-	sb.WriteString("DELETE FROM `mo_catalog`.`mo_foreign_keys` WHERE ")
-	sb.WriteString(fmt.Sprintf(
-		"db_name = '%s' AND table_name = '%s'", db, tbl))
+	sb.WriteString("DELETE FROM `mo_catalog`.`mo_foreign_keys` ")
+	sb.WriteString(fmt.Sprintf("WHERE db_name = '%s' AND table_name = '%s'",
+		db, tbl))
 	return sb.String()
 }
 
@@ -3418,9 +3418,8 @@ func getSqlForDeleteTable(db, tbl string) string {
 // on the table
 func getSqlForDeleteConstraint(db, tbl, constraint string) string {
 	sb := strings.Builder{}
-	sb.WriteString("DELETE FROM `mo_catalog`.`mo_foreign_keys` WHERE ")
-	sb.WriteString(fmt.Sprintf(
-		"constraint_name = '%s' AND db_name = '%s' AND table_name = '%s'",
+	sb.WriteString("DELETE FROM `mo_catalog`.`mo_foreign_keys` ")
+	sb.WriteString(fmt.Sprintf("WHERE constraint_name = '%s' AND db_name = '%s' AND table_name = '%s'",
 		constraint, db, tbl))
 	return sb.String()
 }
@@ -3429,8 +3428,8 @@ func getSqlForDeleteConstraint(db, tbl, constraint string) string {
 // on the database
 func getSqlForDeleteDB(db string) string {
 	sb := strings.Builder{}
-	sb.WriteString("DELETE FROM `mo_catalog`.`mo_foreign_keys` WHERE ")
-	sb.WriteString(fmt.Sprintf("db_name = '%s'", db))
+	sb.WriteString("DELETE FROM `mo_catalog`.`mo_foreign_keys` ")
+	sb.WriteString(fmt.Sprintf("WHERE db_name = '%s'", db))
 	return sb.String()
 }
 
@@ -3439,13 +3438,15 @@ func getSqlForRenameTable(db, oldName, newName string) (ret []string) {
 	sb := strings.Builder{}
 	sb.WriteString("UPDATE `mo_catalog`.`mo_foreign_keys` ")
 	sb.WriteString(fmt.Sprintf("SET table_name = '%s' ", newName))
-	sb.WriteString(fmt.Sprintf("WHERE db_name = '%s' AND table_name = '%s' ; ", db, oldName))
+	sb.WriteString(fmt.Sprintf("WHERE db_name = '%s' AND table_name = '%s' ; ",
+		db, oldName))
 	ret = append(ret, sb.String())
 
 	sb.Reset()
 	sb.WriteString("UPDATE `mo_catalog`.`mo_foreign_keys` ")
 	sb.WriteString(fmt.Sprintf("SET refer_table_name = '%s' ", newName))
-	sb.WriteString(fmt.Sprintf("WHERE refer_db_name = '%s' AND refer_table_name = '%s' ; ", db, oldName))
+	sb.WriteString(fmt.Sprintf("WHERE refer_db_name = '%s' AND refer_table_name = '%s' ; ",
+		db, oldName))
 	ret = append(ret, sb.String())
 	return
 }
@@ -3453,16 +3454,16 @@ func getSqlForRenameTable(db, oldName, newName string) (ret []string) {
 // getSqlForRenameColumn returns the sqls that rename the column of all fk relationships in mo_foreign_keys
 func getSqlForRenameColumn(db, table, oldName, newName string) (ret []string) {
 	sb := strings.Builder{}
-	sb.WriteString("update `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("set column_name = '%s' ", newName))
-	sb.WriteString(fmt.Sprintf("where db_name = '%s' and table_name = '%s' and column_name = '%s' ; ",
+	sb.WriteString("UPDATE `mo_catalog`.`mo_foreign_keys` ")
+	sb.WriteString(fmt.Sprintf("SET column_name = '%s' ", newName))
+	sb.WriteString(fmt.Sprintf("WHERE db_name = '%s' AND table_name = '%s' AND column_name = '%s' ; ",
 		db, table, oldName))
 	ret = append(ret, sb.String())
 
 	sb.Reset()
-	sb.WriteString("update `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("set refer_column_name = '%s' ", newName))
-	sb.WriteString(fmt.Sprintf("where refer_db_name = '%s' and refer_table_name = '%s' and refer_column_name = '%s' ; ",
+	sb.WriteString("UPDATE `mo_catalog`.`mo_foreign_keys` ")
+	sb.WriteString(fmt.Sprintf("SET refer_column_name = '%s' ", newName))
+	sb.WriteString(fmt.Sprintf("WHERE refer_db_name = '%s' AND refer_table_name = '%s' AND refer_column_name = '%s' ; ",
 		db, table, oldName))
 	ret = append(ret, sb.String())
 	return
@@ -3473,7 +3474,8 @@ func getSqlForRenameColumn(db, table, oldName, newName string) (ret []string) {
 func getSqlForCheckHasDBRefersTo(db string) string {
 	sb := strings.Builder{}
 	sb.WriteString("SELECT COUNT(*) > 0 FROM `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("WHERE refer_db_name = '%s' AND db_name != '%s';", db, db))
+	sb.WriteString(fmt.Sprintf("WHERE refer_db_name = '%s' AND db_name != '%s'",
+		db, db))
 	return sb.String()
 }
 

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -3365,8 +3365,8 @@ func getSqlForAddFk(db, table string, data *FkData) string {
 	row := make([]string, 16)
 	rows := 0
 	sb := strings.Builder{}
-	sb.WriteString("insert into `mo_catalog`.`mo_foreign_keys`  ")
-	sb.WriteString(" values ")
+	sb.WriteString("INSERT INTO `mo_catalog`.`mo_foreign_keys` ")
+	sb.WriteString("VALUES ")
 	for childIdx, childCol := range data.Cols.Cols {
 		row[0] = data.Def.Name
 		row[1] = "0"
@@ -3408,9 +3408,9 @@ func getSqlForAddFk(db, table string, data *FkData) string {
 // on the table
 func getSqlForDeleteTable(db, tbl string) string {
 	sb := strings.Builder{}
-	sb.WriteString("delete from `mo_catalog`.`mo_foreign_keys` where ")
+	sb.WriteString("DELETE FROM `mo_catalog`.`mo_foreign_keys` WHERE ")
 	sb.WriteString(fmt.Sprintf(
-		"db_name = '%s' and table_name = '%s'", db, tbl))
+		"db_name = '%s' AND table_name = '%s'", db, tbl))
 	return sb.String()
 }
 
@@ -3418,9 +3418,9 @@ func getSqlForDeleteTable(db, tbl string) string {
 // on the table
 func getSqlForDeleteConstraint(db, tbl, constraint string) string {
 	sb := strings.Builder{}
-	sb.WriteString("delete from `mo_catalog`.`mo_foreign_keys` where ")
+	sb.WriteString("DELETE FROM `mo_catalog`.`mo_foreign_keys` WHERE ")
 	sb.WriteString(fmt.Sprintf(
-		"constraint_name = '%s' and db_name = '%s' and table_name = '%s'",
+		"constraint_name = '%s' AND db_name = '%s' AND table_name = '%s'",
 		constraint, db, tbl))
 	return sb.String()
 }
@@ -3429,7 +3429,7 @@ func getSqlForDeleteConstraint(db, tbl, constraint string) string {
 // on the database
 func getSqlForDeleteDB(db string) string {
 	sb := strings.Builder{}
-	sb.WriteString("delete from `mo_catalog`.`mo_foreign_keys` where ")
+	sb.WriteString("DELETE FROM `mo_catalog`.`mo_foreign_keys` WHERE ")
 	sb.WriteString(fmt.Sprintf("db_name = '%s'", db))
 	return sb.String()
 }
@@ -3437,15 +3437,15 @@ func getSqlForDeleteDB(db string) string {
 // getSqlForRenameTable returns the sqls that rename the table of all fk relationships in mo_foreign_keys
 func getSqlForRenameTable(db, oldName, newName string) (ret []string) {
 	sb := strings.Builder{}
-	sb.WriteString("update `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("set table_name = '%s' ", newName))
-	sb.WriteString(fmt.Sprintf("where db_name = '%s' and table_name = '%s' ; ", db, oldName))
+	sb.WriteString("UPDATE `mo_catalog`.`mo_foreign_keys` ")
+	sb.WriteString(fmt.Sprintf("SET table_name = '%s' ", newName))
+	sb.WriteString(fmt.Sprintf("WHERE db_name = '%s' AND table_name = '%s' ; ", db, oldName))
 	ret = append(ret, sb.String())
 
 	sb.Reset()
-	sb.WriteString("update `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("set refer_table_name = '%s' ", newName))
-	sb.WriteString(fmt.Sprintf("where refer_db_name = '%s' and refer_table_name = '%s' ; ", db, oldName))
+	sb.WriteString("UPDATE `mo_catalog`.`mo_foreign_keys` ")
+	sb.WriteString(fmt.Sprintf("SET refer_table_name = '%s' ", newName))
+	sb.WriteString(fmt.Sprintf("WHERE refer_db_name = '%s' AND refer_table_name = '%s' ; ", db, oldName))
 	ret = append(ret, sb.String())
 	return
 }
@@ -3472,8 +3472,8 @@ func getSqlForRenameColumn(db, table, oldName, newName string) (ret []string) {
 // that refer to it.
 func getSqlForCheckHasDBRefersTo(db string) string {
 	sb := strings.Builder{}
-	sb.WriteString("select count(*) > 0 from `mo_catalog`.`mo_foreign_keys` ")
-	sb.WriteString(fmt.Sprintf("where refer_db_name = '%s' and db_name != '%s';", db, db))
+	sb.WriteString("SELECT COUNT(*) > 0 FROM `mo_catalog`.`mo_foreign_keys` ")
+	sb.WriteString(fmt.Sprintf("WHERE refer_db_name = '%s' AND db_name != '%s';", db, db))
 	return sb.String()
 }
 

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -3226,7 +3226,8 @@ func runSql(ctx CompilerContext, sql string) (executor.Result, error) {
 		WithTxn(proc.GetTxnOperator()).
 		WithDatabase(proc.GetSessionInfo().Database).
 		WithTimeZone(proc.GetSessionInfo().TimeZone).
-		WithAccountID(accountId)
+		WithAccountID(accountId).
+		WithStatementOption(executor.StatementOption{}.WithDisableLog())
 	return exec.Exec(topContext, sql, opts)
 }
 

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -74,7 +74,7 @@ func buildShowCreateDatabase(stmt *tree.ShowCreateDatabase,
 		return returnByRewriteSQL(ctx, sql, plan.DataDefinition_SHOW_CREATEDATABASE)
 	}
 
-	sqlStr := "SELECT \"%s\" AS `Database`, \"%s` AS `Create Database`"
+	sqlStr := "SELECT \"%s\" AS `Database`, \"%s\" AS `Create Database`"
 	createSql := fmt.Sprintf("CREATE DATABASE `%s`", name)
 	sqlStr = fmt.Sprintf(sqlStr, name, createSql)
 
@@ -1079,10 +1079,10 @@ func buildShowCreatePublications(stmt *tree.ShowCreatePublications, ctx Compiler
 func returnByRewriteSQL(ctx CompilerContext, sql string,
 	ddlType plan.DataDefinition_DdlType) (*Plan, error) {
 	newStmt, err := getRewriteSQLStmt(ctx, sql)
-	defer newStmt.Free()
 	if err != nil {
 		return nil, err
 	}
+	defer newStmt.Free()
 	return getReturnDdlBySelectStmt(ctx, newStmt, ddlType)
 }
 

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -74,7 +74,7 @@ func buildShowCreateDatabase(stmt *tree.ShowCreateDatabase,
 		return returnByRewriteSQL(ctx, sql, plan.DataDefinition_SHOW_CREATEDATABASE)
 	}
 
-	sqlStr := "select \"%s\" as `Database`, \"%s\" as `Create Database`"
+	sqlStr := "SELECT \"%s\" AS `Database`, \"%s` AS `Create Database`"
 	createSql := fmt.Sprintf("CREATE DATABASE `%s`", name)
 	sqlStr = fmt.Sprintf(sqlStr, name, createSql)
 
@@ -148,7 +148,7 @@ func buildShowCreateTable(stmt *tree.ShowCreateTable, ctx CompilerContext) (*Pla
 		}
 		buf.WriteRune(ch)
 	}
-	sql := "select \"%s\" as `Table`, \"%s\" as `Create Table`"
+	sql := "SELECT \"%s\" AS `Table`, \"%s\" AS `Create Table`"
 	sql = fmt.Sprintf(sql, tblName, buf.String())
 
 	return returnByRewriteSQL(ctx, sql, plan.DataDefinition_SHOW_CREATETABLE)
@@ -231,7 +231,7 @@ func buildShowDatabases(stmt *tree.ShowDatabases, ctx CompilerContext) (*Plan, e
 
 	// Any account should show database MO_CATALOG_DB_NAME
 	accountClause := fmt.Sprintf("account_id = %v or (account_id = 0 and datname = '%s')", accountId, MO_CATALOG_DB_NAME)
-	sql = fmt.Sprintf("SELECT datname `Database` FROM %s.mo_database %s where (%s) ORDER BY %s", MO_CATALOG_DB_NAME, snapshotSpec, accountClause, catalog.SystemDBAttr_Name)
+	sql = fmt.Sprintf("SELECT datname `Database` FROM %s.mo_database %s WHERE (%s) ORDER BY %s", MO_CATALOG_DB_NAME, snapshotSpec, accountClause, catalog.SystemDBAttr_Name)
 
 	if stmt.Where != nil {
 		return returnByWhereAndBaseSQL(ctx, sql, stmt.Where, ddlType)
@@ -256,7 +256,7 @@ func buildShowSequences(stmt *tree.ShowSequences, ctx CompilerContext) (*Plan, e
 
 	ddlType := plan.DataDefinition_SHOW_SEQUENCES
 
-	sql := fmt.Sprintf("select %s.mo_tables.relname as `Names`, mo_show_visible_bin(%s.mo_columns.atttyp, 2) as 'Data Type' from %s.mo_tables left join %s.mo_columns on %s.mo_tables.rel_id = %s.mo_columns.att_relname_id where %s.mo_tables.relkind = '%s' and %s.mo_tables.reldatabase = '%s' and %s.mo_columns.attname = '%s'", MO_CATALOG_DB_NAME,
+	sql := fmt.Sprintf("SELECT %s.mo_tables.relname AS `Names`, mo_show_visible_bin(%s.mo_columns.atttyp, 2) AS 'Data Type' FROM %s.mo_tables LEFT JOIN %s.mo_columns ON %s.mo_tables.rel_id = %s.mo_columns.att_relname_id WHERE %s.mo_tables.relkind = '%s' AND %s.mo_tables.reldatabase = '%s' AND %s.mo_columns.attname = '%s'", MO_CATALOG_DB_NAME,
 		MO_CATALOG_DB_NAME, MO_CATALOG_DB_NAME, MO_CATALOG_DB_NAME, MO_CATALOG_DB_NAME, MO_CATALOG_DB_NAME, MO_CATALOG_DB_NAME, catalog.SystemSequenceRel, MO_CATALOG_DB_NAME, dbName, MO_CATALOG_DB_NAME, Sequence_cols_name[0])
 
 	if stmt.Where != nil {
@@ -1071,7 +1071,7 @@ func buildShowCreatePublications(stmt *tree.ShowCreatePublications, ctx Compiler
 	if err != nil {
 		return nil, err
 	}
-	sql := fmt.Sprintf("select pub_name as Publication, 'CREATE PUBLICATION ' || pub_name || ' DATABASE ' || database_name || case table_list when '*' then '' else ' TABLE ' || table_list end || ' ACCOUNT ' || account_list as 'Create Publication' from mo_catalog.mo_pubs where account_id = %d and pub_name='%s';", accountId, stmt.Name)
+	sql := fmt.Sprintf("SELECT pub_name AS Publication, 'CREATE PUBLICATION ' || pub_name || ' DATABASE ' || database_name || CASE table_list WHEN '*' THEN '' ELSE ' TABLE ' || table_list END || ' ACCOUNT ' || account_list AS 'Create Publication' FROM mo_catalog.mo_pubs WHERE account_id = %d AND pub_name='%s';", accountId, stmt.Name)
 	ctx.SetContext(defines.AttachAccountId(ctx.GetContext(), catalog.System_Account))
 	return returnByRewriteSQL(ctx, sql, ddlType)
 }

--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -92,7 +92,7 @@ func doFaultPoint(
 		ret = true
 	}
 
-	logutil.Info("FaultPoint",
+	logutil.Debug("FaultPoint",
 		zap.String("sql", sql),
 		zap.String("sqlRet", string(sqlRet[0][0].([]byte))))
 

--- a/pkg/sql/plan/function/func_builtin.go
+++ b/pkg/sql/plan/function/func_builtin.go
@@ -623,7 +623,7 @@ func builtInPurgeLog(parameters []*vector.Vector, result vector.FunctionResultWr
 	exec := v.(executor.SQLExecutor)
 
 	deleteTable := func(tbl *table.Table, dateStr string) error {
-		sql := fmt.Sprintf("delete from `%s`.`%s` where `%s` < %q",
+		sql := fmt.Sprintf("DELETE FROM `%s`.`%s` WHERE `%s` < %q",
 			tbl.Database, tbl.Table, tbl.TimestampColumn.Name, dateStr)
 		opts := executor.Options{}.WithDatabase(tbl.Database).
 			WithTxn(proc.GetTxnOperator()).
@@ -644,7 +644,7 @@ func builtInPurgeLog(parameters []*vector.Vector, result vector.FunctionResultWr
 		opts := executor.Options{}.WithDatabase(tbl.Database).
 			WithTimeZone(proc.GetSessionInfo().TimeZone)
 		// fixme: hours should > 24 * time.Hour
-		runPruneSql := fmt.Sprintf(`select mo_ctl('dn', 'inspect', 'objprune -t %s.%s -d %s -f')`, tbl.Database, tbl.Table, hours)
+		runPruneSql := fmt.Sprintf(`SELECT mo_ctl('dn', 'inspect', 'objprune -t %s.%s -d %s -f')`, tbl.Database, tbl.Table, hours)
 		res, err := exec.Exec(proc.Ctx, runPruneSql, opts)
 		if err != nil {
 			return "", err

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -1526,7 +1526,7 @@ func DisableFaultInjection(
 		fault.Disable()
 		finalVal = true
 	} else {
-		sql := "select fault_inject('all.','disable_fault_injection','');"
+		sql := "SELECT fault_inject('all.','disable_fault_injection','');"
 
 		if finalVal, err = doFaultPoint(proc, sql); err != nil {
 			return err
@@ -1556,7 +1556,7 @@ func EnableFaultInjection(
 		fault.Enable()
 		finalVal = true
 	} else {
-		sql := "select fault_inject('all.','enable_fault_injection','');"
+		sql := "SELECT fault_inject('all.','enable_fault_injection','');"
 
 		if finalVal, err = doFaultPoint(proc, sql); err != nil {
 			return err

--- a/pkg/sql/plan/tools/matcher.go
+++ b/pkg/sql/plan/tools/matcher.go
@@ -390,7 +390,7 @@ func (matcher *JoinMatcher) String() string {
 }
 
 func parseSql(sql string) tree.Expr {
-	exSql := "select " + sql
+	exSql := "SELECT " + sql
 	one, err := parsers.ParseOne(context.Background(), dialect.MYSQL, exSql, 1)
 	if err != nil {
 		panic(err)

--- a/pkg/util/export/batch_processor.go
+++ b/pkg/util/export/batch_processor.go
@@ -229,7 +229,7 @@ func (b *bufferHolder) loopAggr() {
 		return
 	}
 	counter := v2.GetTraceMOLoggerAggrCounter(b.name)
-	logutil.Info("handle-aggr-start")
+	logutil.Info("logger.aggr.start")
 mainL:
 	for {
 		select {
@@ -245,9 +245,8 @@ mainL:
 			recordCnt += len(results)
 			if time.Since(lastPrintTime) > printInterval {
 				logutil.Info(
-					"handle-aggr",
-					zap.Int("records", recordCnt),
-					zap.Time("end", end),
+					"logger.aggr.handle.count",
+					zap.Int("count", recordCnt),
 				)
 				recordCnt = 0
 				lastPrintTime = time.Now()
@@ -256,14 +255,14 @@ mainL:
 
 		case <-b.bgCtx.Done():
 			// trigger by b.bgCancel
-			logger.Info("handle-aggr-bgctx-done")
+			logger.Info("logger.aggr.bgctx.done")
 			break mainL
 		case <-b.ctx.Done():
-			logutil.Info("handle-aggr-ctx-done")
+			logutil.Info("logger.aggr.ctx.done")
 			break mainL
 		}
 	}
-	logutil.Info("handle-aggr-exit")
+	logutil.Info("logger.aggr.exit")
 }
 
 var _ generateReq = (*bufferGenerateReq)(nil)

--- a/pkg/util/metric/config.go
+++ b/pkg/util/metric/config.go
@@ -28,7 +28,7 @@ var (
 	// full buffer approximately cost (56[Sample struct] + 8[pointer]) x 4096 = 256K
 	configRawHistBufLimit     int32 = EnvOrDefaultInt[int32]("MO_METRIC_RAWHIST_BUF_LIMIT", 4096)
 	configGatherInterval      int64 = EnvOrDefaultInt[int64]("MO_METRIC_GATHER_INTERVAL", 15000) // 15s
-	configStatsGatherInterval int64 = EnvOrDefaultInt[int64]("MO_STATS_GATHER_INTERVAL", 15000)  // 15s
+	configStatsGatherInterval int64 = EnvOrDefaultInt[int64]("MO_STATS_GATHER_INTERVAL", 150000) // 15s
 	configExportToProm        int32 = EnvOrDefaultBool("MO_METRIC_EXPORT_TO_PROM", 1)
 	configForceReinit         int32 = EnvOrDefaultBool("MO_METRIC_DROP_AND_INIT", 0) // TODO: find a better way to init metrics and remove this one
 )

--- a/pkg/util/metric/mometric/cron_task.go
+++ b/pkg/util/metric/mometric/cron_task.go
@@ -445,9 +445,13 @@ func checkNewAccountSize(ctx context.Context, logger *log.MOLogger, sqlExecutor 
 			// done query.
 
 			// update new accounts metric
-			logger.Info("new account storage_usage", zap.String("account", account), zap.Float64("sizeMB", sizeMB),
-				zap.Float64("snapshot", snapshotSizeMB),
-				zap.String("created_time", createdTime))
+			logger.Info(
+				"storage_usage.new_account",
+				zap.String("name", account),
+				zap.Float64("size-mb", sizeMB),
+				zap.Float64("snapshot-mb", snapshotSizeMB),
+				zap.String("created-time", createdTime),
+			)
 
 			metric.StorageUsage(account).Set(sizeMB)
 			metric.SnapshotUsage(account).Set(snapshotSizeMB)

--- a/pkg/util/metric/mometric/stats_log_writer.go
+++ b/pkg/util/metric/mometric/stats_log_writer.go
@@ -16,14 +16,11 @@ package mometric
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/log"
-	"github.com/matrixorigin/matrixone/pkg/objectio"
-	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/util/metric/stats"
 )
 
@@ -91,38 +88,4 @@ func (e *StatsLogWriter) gatherAndWrite(ctx context.Context) {
 			e.logger.Info(statsFName, statsFamily...)
 		}
 	}
-
-	// logging block read statistics info here
-	v := ctx.Value(ServiceTypeKey).(string)
-	if v == metadata.ServiceType_name[int32(metadata.ServiceType_CN)] || v == LaunchMode {
-		e.writeBlkReadStats()
-	}
-}
-
-func (e *StatsLogWriter) writeBlkReadStats() {
-	blkHit, blkTotal := objectio.BlkReadStats.BlkCacheHitStats.ExportW()
-	blkHitRate := float32(1)
-	if blkTotal != 0 {
-		blkHitRate = float32(blkHit) / float32(blkTotal)
-	}
-
-	entryHit, entryTotal := objectio.BlkReadStats.EntryCacheHitStats.ExportW()
-	entryHitRate := float32(1)
-	if entryTotal != 0 {
-		entryHitRate = float32(entryHit) / float32(entryTotal)
-	}
-
-	readerNum, blkNum := objectio.BlkReadStats.BlksByReaderStats.ExportW()
-	blksInEachReader := float32(1)
-	if readerNum != 0 {
-		blksInEachReader = float32(blkNum) / float32(readerNum)
-	}
-
-	e.logger.Info(fmt.Sprintf("duration: %d, "+
-		"blk hit rate: %d/%d=%.4f, entry hit rate: %d/%d=%.4f, (average) blks in each reader: %d/%d=%.4f",
-		e.gatherInterval,
-		blkHit, blkTotal, blkHitRate,
-		entryHit, entryTotal, entryHitRate,
-		blkNum, readerNum, blksInEachReader))
-
 }

--- a/pkg/util/metric/mometric/stats_log_writer_test.go
+++ b/pkg/util/metric/mometric/stats_log_writer_test.go
@@ -16,8 +16,6 @@ package mometric
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -25,7 +23,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
-	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/util/metric/stats"
 	"github.com/stretchr/testify/assert"
@@ -160,43 +157,4 @@ func waitUtil(timeout, checkInterval time.Duration, check func() bool) error {
 			time.Sleep(checkInterval)
 		}
 	}
-}
-
-func TestWriteBlkReadStats(t *testing.T) {
-	h1, t1 := rand.Int(), rand.Int()+1
-	objectio.BlkReadStats.BlksByReaderStats.Record(h1, t1)
-
-	h2, t2 := rand.Int(), rand.Int()+1
-	objectio.BlkReadStats.EntryCacheHitStats.Record(h2, t2)
-
-	h3, t3 := rand.Int(), rand.Int()+1
-	objectio.BlkReadStats.BlkCacheHitStats.Record(h3, t3)
-
-	s := new(StatsLogWriter)
-	type threadSafeWrittenLog struct {
-		content []zapcore.Entry
-		// This is because, BusyLoop and StatsLogger read (ie len) and write (content) to the same field.
-		sync.Mutex
-	}
-
-	writtenLogs := threadSafeWrittenLog{}
-	runtime.SetupServiceBasedRuntime("", runtime.NewRuntime(metadata.ServiceType_CN, "test", logutil.GetGlobalLogger()))
-	s.logger = runtime.ServiceRuntime("").Logger().WithOptions(zap.Hooks(func(entry zapcore.Entry) error {
-		writtenLogs.Lock()
-		defer writtenLogs.Unlock()
-		writtenLogs.content = append(writtenLogs.content, entry)
-		return nil
-	}))
-	s.writeBlkReadStats()
-
-	expected := fmt.Sprintf("duration: %d, "+
-		"blk hit rate: %d/%d=%.4f, entry hit rate: %d/%d=%.4f, (average) blks in each reader: %d/%d=%.4f",
-		s.gatherInterval,
-		h3, t3, float32(h3)/float32(t3),
-		h2, t2, float32(h2)/float32(t2),
-		t1, h1, float32(t1)/float32(h1),
-	)
-
-	require.Equal(t, writtenLogs.content[0].Level, zapcore.InfoLevel)
-	require.Equal(t, writtenLogs.content[0].Message, expected)
 }

--- a/pkg/vectorindex/sqlexec/sqlexec.go
+++ b/pkg/vectorindex/sqlexec/sqlexec.go
@@ -141,7 +141,8 @@ func RunSql(sqlproc *SqlProcess, sql string) (executor.Result, error) {
 			WithDatabase(proc.GetSessionInfo().Database).
 			WithTimeZone(proc.GetSessionInfo().TimeZone).
 			WithAccountID(accountId).
-			WithResolveVariableFunc(proc.GetResolveVariableFunc())
+			WithResolveVariableFunc(proc.GetResolveVariableFunc()).
+			WithStatementOption(executor.StatementOption{}.WithDisableLog())
 		return exec.Exec(topContext, sql, opts)
 	} else {
 
@@ -160,7 +161,8 @@ func RunSql(sqlproc *SqlProcess, sql string) (executor.Result, error) {
 			WithDisableIncrStatement().
 			WithTxn(sqlctx.Txn()).
 			WithAccountID(accountId).
-			WithResolveVariableFunc(sqlctx.GetResolveVariableFunc())
+			WithResolveVariableFunc(sqlctx.GetResolveVariableFunc()).
+			WithStatementOption(executor.StatementOption{}.WithDisableLog())
 		return exec.Exec(sqlctx.Ctx, sql, opts)
 
 	}
@@ -194,6 +196,7 @@ func RunStreamingSql(
 		WithDatabase(proc.GetSessionInfo().Database).
 		WithTimeZone(proc.GetSessionInfo().TimeZone).
 		WithAccountID(accountId).
-		WithStreaming(stream_chan, error_chan)
+		WithStreaming(stream_chan, error_chan).
+		WithStatementOption(executor.StatementOption{}.WithDisableLog())
 	return exec.Exec(ctx, sql, opts)
 }

--- a/pkg/vm/engine/disttae/cache/catalog.go
+++ b/pkg/vm/engine/disttae/cache/catalog.go
@@ -18,7 +18,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -62,9 +61,11 @@ func (cc *CatalogCache) UpdateDuration(start types.TS, end types.TS) {
 	defer cc.mu.Unlock()
 	cc.mu.start = start
 	cc.mu.end = end
-	logutil.Info("FIND_TABLE CACHE update serve range",
+	logutil.Info(
+		"catalog.cache.update.start.end",
 		zap.String("start", cc.mu.start.ToString()),
-		zap.String("end", cc.mu.end.ToString()))
+		zap.String("end", cc.mu.end.ToString()),
+	)
 }
 
 func (cc *CatalogCache) UpdateStart(ts types.TS) {
@@ -72,9 +73,11 @@ func (cc *CatalogCache) UpdateStart(ts types.TS) {
 	defer cc.mu.Unlock()
 	if cc.mu.start != types.MaxTs() && ts.GT(&cc.mu.start) {
 		cc.mu.start = ts
-		logutil.Info("FIND_TABLE CACHE update serve range (by start)",
+		logutil.Info(
+			"catalog.cache.update.start",
 			zap.String("start", cc.mu.start.ToString()),
-			zap.String("end", cc.mu.end.ToString()))
+			zap.String("end", cc.mu.end.ToString()),
+		)
 	}
 }
 
@@ -113,7 +116,6 @@ func (cc *CatalogCache) GC(ts timestamp.Timestamp) GCReport {
 
 	*/
 
-	inst := time.Now()
 	r := GCReport{}
 	{ // table cache gc
 		var prevName string
@@ -195,8 +197,6 @@ func (cc *CatalogCache) GC(ts timestamp.Timestamp) GCReport {
 		}
 	}
 	cc.UpdateStart(types.TimestampToTS(ts))
-	duration := time.Since(inst)
-	logutil.Info("FIND_TABLE CACHE gc", zap.Any("report", r), zap.Duration("cost", duration))
 	return r
 }
 

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -44,7 +44,6 @@ import (
 	client2 "github.com/matrixorigin/matrixone/pkg/queryservice/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
-	"github.com/matrixorigin/matrixone/pkg/util/stack"
 	"github.com/matrixorigin/matrixone/pkg/version"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/cache"
@@ -297,13 +296,18 @@ func (e *Engine) Create(ctx context.Context, name string, op client.TxnOperator)
 func (e *Engine) loadDatabaseFromStorage(
 	ctx context.Context,
 	accountID uint32,
-	name string, op client.TxnOperator) (*cache.DatabaseItem, error) {
+	name string,
+	op client.TxnOperator,
+) (*cache.DatabaseItem, error) {
 	sql := fmt.Sprintf(catalog.MoDatabaseAllQueryFormat, accountID, name)
 	now := time.Now()
 	defer func() {
 		if time.Since(now) > time.Second {
-			logutil.Info("FIND_TABLE slow loadDatabaseFromStorage",
-				zap.String("sql", sql), zap.Duration("cost", time.Since(now)))
+			logutil.Info(
+				"engine.database.load.from.storage.slow",
+				zap.String("sql", sql),
+				zap.Duration("cost", time.Since(now)),
+			)
 		}
 	}()
 	res, err := execReadSql(ctx, op, sql, true)
@@ -312,10 +316,14 @@ func (e *Engine) loadDatabaseFromStorage(
 	}
 	defer res.Close()
 	logerror := func() {
-		logutil.Error("FIND_TABLE bad loadDatabaseFromStorage", zap.String("batch", stringifySlice(res.Batches, func(a any) string {
-			bat := a.(*batch.Batch)
-			return common.MoBatchToString(bat, 10)
-		})), zap.String("sql", sql))
+		logutil.Error(
+			"engine.database.load.from.storage.bad",
+			zap.String("sql", sql),
+			zap.String("batch", stringifySlice(res.Batches, func(a any) string {
+				bat := a.(*batch.Batch)
+				return common.MoBatchToString(bat, 10)
+			})),
+		)
 	}
 
 	if len(res.Batches) != 1 { // not found
@@ -391,7 +399,12 @@ func (e *Engine) Database(
 
 	if ok := catalog.GetDatabase(item); !ok {
 		if !catalog.CanServe(types.TimestampToTS(op.SnapshotTS())) {
-			logutil.Info("FIND_TABLE loadDatabaseFromStorage", zap.String("name", name), zap.String("cacheTs", catalog.GetStartTS().ToString()), zap.String("txn", op.Txn().DebugString()))
+			logutil.Info(
+				"engine.database.load.from.storage",
+				zap.String("name", name),
+				zap.String("cache-start", catalog.GetStartTS().ToString()),
+				zap.String("txn", op.Txn().DebugString()),
+			)
 			// read batch from storage
 			if item, err = e.loadDatabaseFromStorage(ctx, accountId, name, op); err != nil {
 				return nil, err
@@ -441,7 +454,12 @@ func (e *Engine) GetNameById(ctx context.Context, op client.TxnOperator, tableId
 	return
 }
 
-func loadNameByIdFromStorage(ctx context.Context, op client.TxnOperator, accountId uint32, tableId uint64) (dbName string, tblName string, err error) {
+func loadNameByIdFromStorage(
+	ctx context.Context,
+	op client.TxnOperator,
+	accountId uint32,
+	tableId uint64,
+) (dbName string, tblName string, err error) {
 	sql := fmt.Sprintf(catalog.MoTablesQueryNameById, accountId, tableId)
 	tblanmes, dbnames := []string{}, []string{}
 	result, err := execReadSql(ctx, op, sql, true)
@@ -455,9 +473,14 @@ func loadNameByIdFromStorage(ctx context.Context, op client.TxnOperator, account
 		}
 	}
 	if len(tblanmes) != 1 {
-		logutil.Warn("FIND_TABLE GetRelationById sql failed",
-			zap.Uint64("tableId", tableId), zap.Uint32("accountId", accountId),
-			zap.Strings("tblanmes", tblanmes), zap.Strings("dbnames", dbnames), zap.String("txn", op.Txn().DebugString()))
+		logutil.Warn(
+			"engine.relation.load.from.storage.bad",
+			zap.Uint64("table-id", tableId),
+			zap.Uint32("account-id", accountId),
+			zap.Strings("table-names", tblanmes),
+			zap.Strings("db-names", dbnames),
+			zap.String("txn", op.Txn().DebugString()),
+		)
 	} else {
 		tblName = tblanmes[0]
 		dbName = dbnames[0]
@@ -501,9 +524,14 @@ func (e *Engine) GetRelationById(ctx context.Context, op client.TxnOperator, tab
 			dbName = cacheItem.DatabaseName
 		} else if !cache.CanServe(types.TimestampToTS(op.SnapshotTS())) {
 			// not found in cache, try storage
-			logutil.Info("FIND_TABLE loadNameByIdFromStorage", zap.String("txn", op.Txn().DebugString()), zap.Uint64("tableId", tableId))
-			dbName, tableName, err = loadNameByIdFromStorage(ctx, op, accountId, tableId)
-			if err != nil {
+			logutil.Info(
+				"engine.relation.load.from.storage",
+				zap.String("txn", op.Txn().DebugString()),
+				zap.Uint64("table-id", tableId),
+			)
+			if dbName, tableName, err = loadNameByIdFromStorage(
+				ctx, op, accountId, tableId,
+			); err != nil {
 				return "", "", nil, err
 			}
 		}
@@ -511,9 +539,11 @@ func (e *Engine) GetRelationById(ctx context.Context, op client.TxnOperator, tab
 
 	if tableName == "" {
 		accountId, _ := defines.GetAccountId(ctx)
-		logutil.Error("FIND_TABLE GetRelationById failed",
-			zap.Uint64("tableId", tableId), zap.Uint32("accountId", accountId), zap.String("workspace", txn.PPString()))
-		return "", "", nil, moerr.NewInternalErrorf(ctx, "can not find table by id %d: accountId: %v ", tableId, accountId)
+		return "", "", nil, moerr.NewInternalErrorf(
+			ctx,
+			"can not find table by id %d: accountId: %d",
+			tableId, accountId,
+		)
 	}
 
 	txnDb, err := e.Database(ctx, dbName, op)
@@ -534,15 +564,6 @@ func (e *Engine) AllocateIDByKey(ctx context.Context, key string) (uint64, error
 }
 
 func (e *Engine) Delete(ctx context.Context, name string, op client.TxnOperator) (err error) {
-	defer func() {
-		if err != nil {
-			if strings.Contains(name, "sysbench_db") {
-				logutil.Errorf("delete database %s failed: %v", name, err)
-				logutil.Errorf("stack: %s", stack.Callers(3))
-				logutil.Errorf("txnmeta %v", op.Txn().DebugString())
-			}
-		}
-	}()
 	if op.IsSnapOp() {
 		return moerr.NewInternalErrorNoCtx("delete database in snapshot txn")
 	}
@@ -576,20 +597,24 @@ func (e *Engine) Delete(ctx context.Context, name string, op client.TxnOperator)
 	if err != nil {
 		return err
 	}
-	res, err := execReadSql(ctx, op, fmt.Sprintf(catalog.MoDatabaseRowidQueryFormat, accountId, name), true)
+	res, err := execReadSql(
+		ctx, op, fmt.Sprintf(catalog.MoDatabaseRowidQueryFormat, accountId, name), true,
+	)
 	if err != nil {
 		return err
 	}
 	if len(res.Batches) != 1 || res.Batches[0].Vecs[0].Length() != 1 {
-		logutil.Error("FIND_TABLE deleteDatabaseError",
+		logutil.Error(
+			"engine.delete.relation.bad",
+			zap.Uint64("db-id", databaseId),
+			zap.Uint32("account-id", accountId),
+			zap.String("name", name),
+			zap.String("workspace", op.GetWorkspace().PPString()),
 			zap.String("bat", stringifySlice(res.Batches, func(a any) string {
 				bat := a.(*batch.Batch)
 				return common.MoBatchToString(bat, 10)
 			})),
-			zap.Uint32("accountId", accountId),
-			zap.String("name", name),
-			zap.Uint64("did", databaseId),
-			zap.String("workspace", op.GetWorkspace().PPString()))
+		)
 		panic("delete table failed: query failed")
 	}
 	rowId := vector.GetFixedAtNoTypeCheck[types.Rowid](res.Batches[0].Vecs[0], 0)
@@ -862,7 +887,7 @@ func (e *Engine) RunGCScheduler(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			logutil.Infof("GC scheduler exit.")
+			logutil.Info("engine.gc.scheduler.stopped")
 			return
 
 		case <-unusedTableTicker.C:
@@ -888,6 +913,5 @@ func (e *Engine) gcPartitionState(ctx context.Context) {
 	if !e.pClient.receivedLogTailTime.ready.Load() {
 		return
 	}
-	logutil.Debugf("Running partition state GC")
 	e.pClient.doGCPartitionState(ctx, e)
 }

--- a/pkg/vm/engine/disttae/logtailreplay/blocks_iter.go
+++ b/pkg/vm/engine/disttae/logtailreplay/blocks_iter.go
@@ -16,10 +16,9 @@ package logtailreplay
 
 import (
 	"bytes"
-	"fmt"
+
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
-	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/tidwall/btree"
 )
@@ -125,10 +124,10 @@ func (p *PartitionState) NewObjectsIter(
 	visitTombstone bool,
 ) (objectio.ObjectIter, error) {
 	if !p.IsEmpty() && snapshot.LT(&p.start) {
-		logutil.Infof("NewObjectsIter: tid:%v, ps:%p, snapshot ts:%s, minTS:%s",
-			p.tid, p, snapshot.ToString(), p.start.ToString())
-		msg := fmt.Sprintf("(%s<%s)", snapshot.ToString(), p.start.ToString())
-		return nil, moerr.NewTxnStaleNoCtx(msg)
+		return nil, moerr.NewTxnStaleNoCtxf(
+			"(%s<%s)",
+			snapshot.ToString(), p.start.ToString(),
+		)
 	}
 
 	if visitTombstone {

--- a/pkg/vm/engine/disttae/logtailreplay/blocks_iter_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/blocks_iter_test.go
@@ -237,3 +237,10 @@ func TestPartitionState_CollectObjectsBetweenInProgress(t *testing.T) {
 		}
 	}
 }
+
+func TestPartitionState_NewBlocksIter(t *testing.T) {
+	pState := NewPartitionState("", false, 0x3fff, false)
+	pState.start = types.BuildTS(100, 0)
+	_, err := pState.NewObjectsIter(types.BuildTS(99, 0), false, true)
+	require.Error(t, err)
+}

--- a/pkg/vm/engine/disttae/logtailreplay/partition.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition.go
@@ -234,7 +234,7 @@ func (p *Partition) Truncate(ctx context.Context, ids [2]uint64, ts types.TS) er
 	}
 
 	logutil.Info(
-		"PS-Truncate",
+		"partition.state.truncate",
 		zap.String("name", p.TableInfo.Name),
 		zap.Uint64("id", p.TableInfo.ID),
 		zap.String("prev-state", fmt.Sprintf("%p", curState)),

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -937,7 +937,7 @@ func NewPartitionState(
 		prefetch:                  prefetch,
 	}
 	logutil.Info(
-		"PS-CREATED",
+		"partition.state.created",
 		zap.Uint64("table-id", tid),
 		zap.String("service", service),
 		zap.String("addr", fmt.Sprintf("%p", ps)),
@@ -969,7 +969,7 @@ func (p *PartitionState) truncateTombstoneObjects(
 
 	if gcLog.Len() > 0 {
 		logutil.Info(
-			"PS-GC-TombstoneIndex",
+			"partition.state.gc.tombstone.index",
 			zap.String("db.tbl", fmt.Sprintf("%d.%d", dbId, tblId)),
 			zap.String("ts", ts.ToString()),
 			zap.String("files", gcLog.String()))
@@ -1030,7 +1030,7 @@ func (p *PartitionState) truncate(ids [2]uint64, ts types.TS) (updated bool) {
 	}
 	if gced {
 		logutil.Info(
-			"PS-GC-DataObject",
+			"partition.state.gc.data.object",
 			zap.String("ts", ts.ToString()),
 			zap.String("db.tbl", fmt.Sprintf("%d.%d", ids[0], ids[1])),
 			zap.String("files", objectsToDelete),
@@ -1068,7 +1068,7 @@ func (p *PartitionState) truncate(ids [2]uint64, ts types.TS) (updated bool) {
 	objsToDelete := objectsToDeleteBuilder.String()
 	if objGced {
 		logutil.Info(
-			"PS-GC-NameIndex",
+			"partition.state.gc.name.index",
 			zap.String("ts", ts.ToString()),
 			zap.String("db.tbl", fmt.Sprintf("%d.%d", ids[0], ids[1])),
 			zap.String("files", objsToDelete),

--- a/pkg/vm/engine/disttae/mo_table_stats.go
+++ b/pkg/vm/engine/disttae/mo_table_stats.go
@@ -270,7 +270,7 @@ const (
 	defaultGamaCycleDur      = time.Minute
 	defaultGetTableListLimit = options.DefaultBlockMaxRows
 
-	logHeader = "MO-TABLE-STATS-TASK"
+	logHeader = "mo.table.stats.task"
 )
 
 const (
@@ -332,8 +332,9 @@ func initMoTableStatsConfig(
 		defer func() {
 			eng.dynamicCtx.defaultConf = eng.dynamicCtx.conf
 			if err != nil {
-				logutil.Error(logHeader,
-					zap.String("source", "init mo table stats config"),
+				logutil.Error(
+					logHeader,
+					zap.String("action", "init.config"),
 					zap.Error(err))
 			}
 		}()
@@ -416,8 +417,9 @@ func initMoTableStatsConfig(
 				runtime.NumCPU(),
 				ants.WithNonblocking(false),
 				ants.WithPanicHandler(func(e interface{}) {
-					logutil.Error(logHeader,
-						zap.String("source", "gama task panic"),
+					logutil.Error(
+						logHeader,
+						zap.String("action", "beta.panic.handler"),
 						zap.Any("error", e))
 				})); err != nil {
 				return
@@ -427,8 +429,9 @@ func initMoTableStatsConfig(
 				runtime.NumCPU(),
 				ants.WithNonblocking(false),
 				ants.WithPanicHandler(func(e interface{}) {
-					logutil.Error(logHeader,
-						zap.String("source", "gama task panic"),
+					logutil.Error(
+						logHeader,
+						zap.String("action", "gama.panic.handler"),
 						zap.Any("error", e))
 				})); err != nil {
 				return
@@ -443,9 +446,11 @@ func initMoTableStatsConfig(
 			task.launchTimes++
 			task.running = true
 
-			logutil.Info(logHeader,
-				zap.String("source", fmt.Sprintf("launch %s", hint)),
-				zap.Int("times", task.launchTimes))
+			logutil.Info(
+				logHeader,
+				zap.String("action", fmt.Sprintf("launch.%s", hint)),
+				zap.Int("times", task.launchTimes),
+			)
 
 			go func() {
 				defer func() {
@@ -482,9 +487,10 @@ func initMoTableStatsConfig(
 			)
 
 			defer func() {
-				logutil.Info(logHeader,
-					zap.String("source", "wait the mo service started"),
-					zap.Duration("duration", moServerStarted.Sub(start)),
+				logutil.Info(
+					logHeader,
+					zap.String("action", "wait.mo.service.started"),
+					zap.Duration("takes", moServerStarted.Sub(start)),
 				)
 			}()
 
@@ -538,9 +544,11 @@ func (d *dynamicCtx) initCronTask(
 	insertTask := func() {
 		sql, err = predefine.GenInitCronTaskSQL(int32(task.TaskCode_MOTableStats))
 		if err != nil {
-			logutil.Error(logHeader,
-				zap.String("source", "init cron task"),
-				zap.Error(err))
+			logutil.Error(
+				logHeader,
+				zap.String("action", "init.cron.task"),
+				zap.Error(err),
+			)
 		}
 
 		d.executeSQL(ctx, sql, "init cron task")
@@ -564,7 +572,10 @@ func (d *dynamicCtx) initCronTask(
 	}
 
 	if checkTask() {
-		logutil.Info(logHeader, zap.String("source", "init cron task succeed"))
+		logutil.Info(
+			logHeader,
+			zap.String("action", "init.cron.task.succeed"),
+		)
 		return true
 	}
 
@@ -820,9 +831,11 @@ func (d *dynamicCtx) checkMoveOnTask() bool {
 
 	disable := d.conf.DisableStatsTask
 
-	logutil.Info(logHeader,
-		zap.String("source", "check move on"),
-		zap.Bool("disable", disable))
+	logutil.Info(
+		logHeader,
+		zap.String("action", "check.move.on"),
+		zap.Bool("state", disable),
+	)
 
 	return disable
 }
@@ -867,9 +880,11 @@ func (d *dynamicCtx) setMoveOnTask(newVal bool) string {
 	d.conf.DisableStatsTask = !newVal
 
 	ret := fmt.Sprintf("move on: %v to %v", oldState, newVal)
-	logutil.Info(logHeader,
-		zap.String("source", "set move on"),
-		zap.String("state", ret))
+	logutil.Info(
+		logHeader,
+		zap.String("action", "set.move.on"),
+		zap.String("state", ret),
+	)
 
 	return ret
 }
@@ -883,9 +898,11 @@ func (d *dynamicCtx) setUseOldImpl(newVal bool) string {
 	d.conf.StatsUsingOldImpl = newVal
 
 	ret := fmt.Sprintf("use old impl: %v to %v", oldState, newVal)
-	logutil.Info(logHeader,
-		zap.String("source", "set use old impl"),
-		zap.String("state", ret))
+	logutil.Info(
+		logHeader,
+		zap.String("action", "set.use.old.impl"),
+		zap.String("state", ret),
+	)
 
 	return ret
 }
@@ -899,9 +916,11 @@ func (d *dynamicCtx) setForceUpdate(newVal bool) string {
 	d.conf.ForceUpdate = newVal
 
 	ret := fmt.Sprintf("force update: %v to %v", oldState, newVal)
-	logutil.Info(logHeader,
-		zap.String("source", "set force update"),
-		zap.String("state", ret))
+	logutil.Info(
+		logHeader,
+		zap.String("action", "set.force.update"),
+		zap.String("state", ret),
+	)
 
 	return ret
 }
@@ -1266,12 +1285,13 @@ func (d *dynamicCtx) QueryTableStatsByAccounts(
 		ctx, sql, "query table stats by account",
 		wantedStatsIdxes, forceUpdate, resetUpdateTime)
 
-	logutil.Info(logHeader,
-		zap.String("source", "QueryTableStatsByAccounts"),
-		zap.Int("acc cnt", len(accs)),
-		zap.Int("tbl cnt", len(tbls)),
-		zap.Bool("forceUpdate", forceUpdate),
-		zap.Bool("resetUpdateTime", resetUpdateTime),
+	logutil.Info(
+		logHeader,
+		zap.String("action", "query.table.stats.by.accounts"),
+		zap.Int("account-count", len(accs)),
+		zap.Int("table-count", len(tbls)),
+		zap.Bool("force-update", forceUpdate),
+		zap.Bool("reset-update-time", resetUpdateTime),
 		zap.Duration("takes", time.Since(now)),
 		zap.Bool("ok", ok),
 		zap.Error(err))
@@ -1302,15 +1322,17 @@ func (d *dynamicCtx) QueryTableStatsByDatabase(
 	statsVals, _, retDb, tbls, ok, err = d.queryTableStatsByXXX(
 		ctx, sql, "query table stats by database", wantedStatsIdxes, forceUpdate, resetUpdateTime)
 
-	logutil.Info(logHeader,
-		zap.String("source", "QueryTableStatsByDatabase"),
-		zap.Int("db cnt", len(dbIds)),
-		zap.Int("tbl cnt", len(tbls)),
-		zap.Bool("forceUpdate", forceUpdate),
-		zap.Bool("resetUpdateTime", resetUpdateTime),
+	logutil.Info(
+		logHeader,
+		zap.String("action", "query.table.stats.by.database"),
+		zap.Int("database-count", len(dbIds)),
+		zap.Int("table-count", len(tbls)),
+		zap.Bool("force-update", forceUpdate),
+		zap.Bool("reset-update-time", resetUpdateTime),
 		zap.Duration("takes", time.Since(now)),
 		zap.Bool("ok", ok),
-		zap.Error(err))
+		zap.Error(err),
+	)
 
 	return statsVals, retDb, ok, err
 }
@@ -1336,14 +1358,16 @@ func (d *dynamicCtx) QueryTableStatsByTable(
 	statsVals, _, _, retTbls, ok, err = d.queryTableStatsByXXX(
 		ctx, sql, "query table stats by table", wantedStatsIdxes, forceUpdate, resetUpdateTime)
 
-	logutil.Info(logHeader,
-		zap.String("source", "QueryTableStatsByTable"),
-		zap.Int("tbl cnt", len(tblIds)),
-		zap.Bool("forceUpdate", forceUpdate),
-		zap.Bool("resetUpdateTime", resetUpdateTime),
+	logutil.Info(
+		logHeader,
+		zap.String("action", "query.table.stats.by.table"),
+		zap.Int("table-count", len(tblIds)),
+		zap.Bool("force-update", forceUpdate),
+		zap.Bool("reset-update-time", resetUpdateTime),
 		zap.Duration("takes", time.Since(now)),
 		zap.Bool("ok", ok),
-		zap.Error(err))
+		zap.Error(err),
+	)
 
 	return statsVals, retTbls, ok, err
 }
@@ -1748,11 +1772,13 @@ func (d *dynamicCtx) callAlphaWithRetry(
 
 	defer func() {
 		if round > 1 || round >= retryTimes || timeout {
-			logutil.Warn(logHeader,
-				zap.String("source", caller),
-				zap.Int("alpha tried", round),
-				zap.Int("specified retry times", retryTimes),
-				zap.Bool("final round timeout", timeout))
+			logutil.Warn(
+				logHeader,
+				zap.String("action", caller),
+				zap.Int("round", round),
+				zap.Int("retry-times", retryTimes),
+				zap.Bool("timeout", timeout),
+			)
 		}
 	}()
 
@@ -1806,16 +1832,18 @@ func (d *dynamicCtx) alphaTask(
 	defer func() {
 		dur := time.Since(now)
 
-		logutil.Info(logHeader,
-			zap.String("source", "alpha task"),
+		logutil.Info(
+			logHeader,
+			zap.String("action", "alpha.task"),
 			zap.Int("processed", processed),
 			zap.Int("requested", requestCnt),
-			zap.Int("batch count", batCnt),
+			zap.Int("batch-count", batCnt),
 			zap.Duration("takes", dur),
-			zap.Duration("wait err", waitErrDur),
+			zap.Duration("wait-err", waitErrDur),
 			zap.String("caller", caller),
-			zap.Bool("isBetaRunning", d.isBetaRun()),
-			zap.String("timeout tbl", timeoutBuf.String()))
+			zap.Bool("is-beta-running", d.isBetaRun()),
+			zap.String("timeout-tbl", timeoutBuf.String()),
+		)
 
 		v2.AlphaTaskDurationHistogram.Observe(dur.Seconds())
 		v2.AlphaTaskCountingHistogram.Observe(float64(processed))
@@ -1901,13 +1929,14 @@ func (d *dynamicCtx) alphaTask(
 
 				if d.beta.forbidden || (waitErrDur > 0 && waitErrDur%(time.Second*30) == 0) {
 
-					logutil.Warn(logHeader,
-						zap.String("source", "alpha task"),
-						zap.String("event", "waited err another 30s"),
+					logutil.Warn(
+						logHeader,
+						zap.String("action", "alpha.task.wait.err.another.30s"),
 						zap.String("caller", caller),
-						zap.Int("total", processed),
+						zap.Int("processed", processed),
 						zap.Int("left", errWaitToReceive),
-						zap.Bool("is beta running", betaRunning))
+						zap.Bool("is-beta-running", betaRunning),
+					)
 				}
 
 				continue
@@ -1926,10 +1955,12 @@ func (d *dynamicCtx) alphaTask(
 					var pState *logtailreplay.PartitionState
 					if !tbls[i].onlyUpdateTS {
 						if pState, err2 = subscribeTable(ctx, service, d.de, tbls[i]); err2 != nil {
-							logutil.Info(logHeader,
-								zap.String("source", "alpha task"),
-								zap.String("subscribe failed", err2.Error()),
-								zap.String("tbl", tbls[i].String()))
+							logutil.Info(
+								logHeader,
+								zap.String("action", "alpha.task.subscribe.failed"),
+								zap.Error(err2),
+								zap.String("tbl", tbls[i].String()),
+							)
 
 							tbls[i].Done(err2)
 							return
@@ -1974,9 +2005,11 @@ func (d *dynamicCtx) betaTask(
 ) {
 	var err error
 	defer func() {
-		logutil.Info(logHeader,
-			zap.String("source", "beta task exit"),
-			zap.Error(err))
+		logutil.Info(
+			logHeader,
+			zap.String("action", "beta.task.exit"),
+			zap.Error(err),
+		)
 	}()
 
 	if d.beta.forbidden {
@@ -2090,10 +2123,12 @@ func (d *dynamicCtx) gamaInsertNewTables(
 	)
 
 	defer func() {
-		logutil.Error(logHeader,
-			zap.String("source", "gama insert new table"),
-			zap.Int("cnt", len(values)),
-			zap.Error(err))
+		logutil.Error(
+			logHeader,
+			zap.String("action", "gama.insert.new.table"),
+			zap.Int("count", len(values)),
+			zap.Error(err),
+		)
 	}()
 
 	if sqlRet.RowCount() == 0 {
@@ -2228,12 +2263,14 @@ func (d *dynamicCtx) gamaUpdateForgotten(
 	)
 
 	defer func() {
-		logutil.Info(logHeader,
-			zap.String("source", "gama task"),
-			zap.Int("null stats cnt", nullStatsCnt),
-			zap.Int("miss update check cnt", missUpdateCheckCnt),
+		logutil.Info(
+			logHeader,
+			zap.String("action", "gama.task"),
+			zap.Int("null-count", nullStatsCnt),
+			zap.Int("miss-count", missUpdateCheckCnt),
 			zap.Duration("takes", time.Since(now)),
-			zap.Error(err))
+			zap.Error(err),
+		)
 	}()
 
 	idsToPairs := func(accIds, dbIds, tblIds []uint64, to types.TS) []tablePair {
@@ -2340,9 +2377,11 @@ func (d *dynamicCtx) gamaUpdateForgotten(
 		} else {
 			// if there has no table > minimal checked table id, means that
 			// all tables have checked in this round.
-			logutil.Info(logHeader,
-				zap.String("source", "reset minimal checked table id"),
-				zap.Uint64("last checked table id", minimalChecked))
+			logutil.Info(
+				logHeader,
+				zap.String("action", "reset.minimal.checked.table.id"),
+				zap.Uint64("table-id", minimalChecked),
+			)
 
 			minimalChecked = 0
 		}
@@ -2472,15 +2511,17 @@ func (d *dynamicCtx) gamaCleanDeletes(
 	)
 
 	defer func() {
-		logutil.Info(logHeader,
-			zap.String("source", "gama clean deletes"),
+		logutil.Info(
+			logHeader,
+			zap.String("action", "gama.clean.deletes"),
 			zap.Duration("takes", time.Since(now)),
-			zap.Any("clean account err", err1),
-			zap.Any("clean database err", err2),
-			zap.Any("clean table err", err3),
-			zap.Any("clean accounts cnt", len(delAcc)),
-			zap.Any("clean database cnt", len(delDB)),
-			zap.Any("clean table cnt", len(delTable)))
+			zap.Any("clean-account-err", err1),
+			zap.Any("clean-database-err", err2),
+			zap.Any("clean-table-err", err3),
+			zap.Any("clean-accounts-cnt", len(delAcc)),
+			zap.Any("clean-database-cnt", len(delDB)),
+			zap.Any("clean-table-cnt", len(delTable)),
+		)
 	}()
 
 	delAcc, err1 = cleanAccounts()
@@ -2516,9 +2557,11 @@ func (d *dynamicCtx) gamaTask(
 	for {
 		select {
 		case <-ctx.Done():
-			logutil.Info(logHeader,
-				zap.String("source", "gama task exit"),
-				zap.Error(ctx.Err()))
+			logutil.Info(
+				logHeader,
+				zap.String("action", "gama.task.exit"),
+				zap.Error(ctx.Err()),
+			)
 			return
 
 		case <-tickerA.C:
@@ -2700,11 +2743,12 @@ func (d *dynamicCtx) updateSpecialStatsStart(
 		start := stats[specialStart].(string)
 		old := oldStart.ToTimestamp().ToStdTime().Format("2006-01-02 15:04:05.000000")
 		if old != start {
-			logutil.Info(logHeader,
-				zap.String("source", "update special stats start"),
-				zap.String("given up update", "the start changed already"),
-				zap.String("current", start),
-				zap.String("last read", old))
+			logutil.Info(
+				logHeader,
+				zap.String("action", "update.special.stats.start"),
+				zap.String("start", start),
+				zap.String("last", old),
+			)
 
 			return false, nil
 		}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2015,15 +2015,14 @@ func (tbl *txnTable) BuildShardingReaders(
 func (tbl *txnTable) getPartitionState(
 	ctx context.Context,
 ) (ps *logtailreplay.PartitionState, err error) {
-
-	defer func() {
-		if tbl.tableId == catalog.MO_COLUMNS_ID {
-			logutil.Info("open partition state for mo_columns",
-				zap.String("txn", tbl.db.op.Txn().DebugString()),
-				zap.String("desc", ps.Desc(true)),
-				zap.String("pointer", fmt.Sprintf("%p", ps)))
-		}
-	}()
+	// defer func() {
+	// 	if tbl.tableId == catalog.MO_COLUMNS_ID {
+	// 		logutil.Info("open partition state for mo_columns",
+	// 			zap.String("txn", tbl.db.op.Txn().DebugString()),
+	// 			zap.String("desc", ps.Desc(true)),
+	// 			zap.String("pointer", fmt.Sprintf("%p", ps)))
+	// 	}
+	// }()
 
 	var (
 		eng          = tbl.eng.(*Engine)

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2108,10 +2108,10 @@ func (tbl *txnTable) getPartitionState(
 	start, end = types.MaxTs(), types.MinTs()
 	if ps != nil {
 		start, end = ps.GetDuration()
-		msg = "Txn-Table-GetSSPS-Succeed"
+		msg = "table.get.snapshot.state.succeed"
 	} else {
 		logger = logutil.Error
-		msg = "Txn-Table-GetSSPS-Failed"
+		msg = "table.get.snapshot.state.failed"
 	}
 
 	logger(

--- a/pkg/vm/engine/disttae/txn_table_test.go
+++ b/pkg/vm/engine/disttae/txn_table_test.go
@@ -135,8 +135,7 @@ func TestTxnTable_Reset(t *testing.T) {
 		rt.SetGlobalVariables(runtime.ClusterService, mc)
 		st := shardservice.NewShardStorage("", rt.Clock(), nil, nil, nil, nil)
 		sv := shardservice.NewService(shardservice.Config{
-			ServiceID:     "s1",
-			ListenAddress: "127.0.0.1:0", // 使用随机端口避免冲突
+			ServiceID: "s1",
 		}, st)
 		tbl, err := MockTableDelegate(orig, sv)
 		assert.NoError(t, err)

--- a/pkg/vm/engine/disttae/txn_table_test.go
+++ b/pkg/vm/engine/disttae/txn_table_test.go
@@ -135,7 +135,8 @@ func TestTxnTable_Reset(t *testing.T) {
 		rt.SetGlobalVariables(runtime.ClusterService, mc)
 		st := shardservice.NewShardStorage("", rt.Clock(), nil, nil, nil, nil)
 		sv := shardservice.NewService(shardservice.Config{
-			ServiceID: "s1",
+			ServiceID:     "s1",
+			ListenAddress: "127.0.0.1:0", // 使用随机端口避免冲突
 		}, st)
 		tbl, err := MockTableDelegate(orig, sv)
 		assert.NoError(t, err)

--- a/pkg/vm/engine/disttae/util.go
+++ b/pkg/vm/engine/disttae/util.go
@@ -655,7 +655,12 @@ func stringifyMap(req any, f func(any, any) string) string {
 	return buf.String()
 }
 
-func execReadSql(ctx context.Context, op client.TxnOperator, sql string, disableLog bool) (executor.Result, error) {
+func execReadSql(
+	ctx context.Context,
+	op client.TxnOperator,
+	sql string,
+	disableLog bool,
+) (executor.Result, error) {
 	// copy from compile.go runSqlWithResult
 	service := op.GetWorkspace().(*Transaction).proc.GetService()
 	v, ok := moruntime.ServiceRuntime(service).GetGlobalVariables(moruntime.InternalSQLExecutor)

--- a/pkg/vm/engine/tae/txn/txnimpl/table_space.go
+++ b/pkg/vm/engine/tae/txn/txnimpl/table_space.go
@@ -169,12 +169,12 @@ func (space *tableSpace) prepareApplyANode(node *anode, startOffset uint32) erro
 	for appended < node.Rows() {
 		appender, err := space.tableHandle.GetAppender()
 		if moerr.IsMoErrCode(err, moerr.ErrAppendableObjectNotFound) {
-			objH, err := space.table.CreateObject(space.isTombstone)
-			if err != nil {
-				return err
+			objH, err2 := space.table.CreateObject(space.isTombstone)
+			if err2 != nil {
+				return err2
 			}
 			appender = space.tableHandle.SetAppender(objH.Fingerprint())
-			logutil.Info("CreateObject", zap.String("objH", appender.GetID().ObjectString()), zap.String("txn", node.GetTxn().String()))
+			// logutil.Info("CreateObject", zap.String("objH", appender.GetID().ObjectString()), zap.String("txn", node.GetTxn().String()))
 			objH.Close()
 		}
 		if !appender.IsSameColumns(space.table.GetLocalSchema(space.isTombstone)) {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #23222 

## What this PR does / why we need it:

remove or optmize some logging 3.0 - PART 1


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Optimize logging by removing verbose logs and standardizing log messages
  - Remove redundant "save profiles start/end" logs in debug.go
  - Remove low-value logs from catalog cache GC and database operations
  - Standardize log message format to use dot-separated keys (e.g., "save.profiles.loop.started")

- Refactor error handling functions to directly call newError instead of intermediate wrappers
  - Consolidate *f (formatted) error functions to avoid unnecessary function call chains
  - Remove NewDataTruncated function and inline its logic

- Fix CPU profile generation to handle already-in-use profiling gracefully
  - Add check for -cpu-profile flag to skip duplicate CPU profiling
  - Handle "cpu profiling already in use" error silently

- Remove unused code and imports
  - Delete writeBlkReadStats method and related block read statistics logging
  - Remove unused imports (fmt, time, objectio, metadata) from stats_log_writer files
  - Remove debug logging from txnTable.getPartitionState

- Improve error messages and logging consistency across engine operations
  - Update log field names to use hyphens (e.g., "table-id" instead of "tableId")
  - Consolidate error logging with structured zap fields


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Logging Optimization"] --> B["Remove Verbose Logs"]
  A --> C["Standardize Log Format"]
  D["Error Handling Refactor"] --> E["Consolidate Error Functions"]
  D --> F["Remove Intermediate Wrappers"]
  G["Code Cleanup"] --> H["Remove Unused Code"]
  G --> I["Remove Unused Imports"]
  J["Bug Fix"] --> K["CPU Profile Handling"]
  K --> L["Skip Duplicate Profiling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>debug.go</strong><dd><code>Optimize profile logging and fix CPU profiling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-1932ee5d4c3eaee815950d1afbbc966661ef6afa8373377a3d783fca2201eb70">+16/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>server.go</strong><dd><code>Standardize profile save error logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-3a5012a0926d6830df057d5994c8cc87d91d484802c6b8a60a6d417110c09854">+19/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error.go</strong><dd><code>Refactor error functions to reduce call chains</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-159394a393381d0a11103e3a62077b39ecb1da72ea72e3d2995b2458517736bf">+56/-33</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>error_no_ctx.go</strong><dd><code>Add formatted error function for transaction stale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-ca37f540e6e78236250aa1377226580d516bf5f0bc80d8d74d837f5b3519b9e0">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>show_account.go</strong><dd><code>Remove low-value logging from account storage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-dc65a2ea81d3ac3e276c1e0cac8d638f0b24db39ccc389d0d81af21f51f7e84d">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ddl.go</strong><dd><code>Standardize alter table error logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-819bfdf891fa506cb2b4c89006896d528675fd554c341f38d1a1bf14a496c8aa">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>batch_processor.go</strong><dd><code>Standardize aggregator logging messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-618ee6d9354fed818b28e1e019e9ca0859723211ff136e7c8fb851cc8cf2b2ea">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cron_task.go</strong><dd><code>Standardize new account storage usage logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-8c0b5691752db05d0c7e640b60f896c46b1840e2cdb7e308f5533424be73e6e4">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stats_log_writer.go</strong><dd><code>Remove block read statistics logging code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-d6d8d82e7ae0b3a36294471b4e4daed14050cacb864669f455ccd4eb4a39fb5f">+0/-37</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>catalog.go</strong><dd><code>Remove timing logs from catalog cache GC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-b806d5f61fd598f45655f4ba9b484d7ca2a62a892566dc1ec65a9857fb69b018">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>engine.go</strong><dd><code>Optimize engine logging and remove debug logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-66bacd74568edffe090130ffc5d235b4771a4707612b56145288d4e7119be4a2">+60/-36</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>logtail_consumer.go</strong><dd><code>Standardize logtail consumer logging messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-e17810b9da4ab05c897d8066bbc421520cdaea7c577d50dc64b31ec3aa8d295f">+94/-57</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>blocks_iter.go</strong><dd><code>Use formatted error function for transaction stale</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-2a65096be82448984c3028029297fa50357275c6dafbb8747f64a0a340629d40">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mo_table_stats.go</strong><dd><code>Standardize table stats task logging format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-3fa2c0f28041af8110f1af1461c2094fa7d2534b76af37b6789c993b03364de2">+143/-99</a></td>

</tr>

<tr>
  <td><strong>txn_table.go</strong><dd><code>Comment out debug logging for mo_columns partition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>util.go</strong><dd><code>Improve function signature formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-005617216374ac58bf3cf72b81841d5cb6a17495d1d7b36ff387e294a0d6e043">+16/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>util.go</strong><dd><code>Improve function signature formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-6808a91f32ea7065cd63ff5887ac4600b5b6744b6cd2bb12859a0e4a5fb0efd2">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>stats_log_writer_test.go</strong><dd><code>Remove block read statistics test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23228/files#diff-4ebc5c6fc544c4894f9f52b831009d6aa33e5ee72191a574a53e09e27aed9b4e">+0/-42</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

