### PR TITLE
refactor: quick cap on SQL print max length

### DIFF
--- a/pkg/cdc/table_scanner.go
+++ b/pkg/cdc/table_scanner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
@@ -561,7 +562,7 @@ func (s *TableDetector) cleanupOrphanWatermarks(ctx context.Context) {
 		fields := []zap.Field{
 			zap.Uint64("deleted-rows", res.AffectedRows),
 			zap.Duration("duration", duration),
-			zap.String("sql", sql),
+			zap.String("sql", commonutil.Abbreviate(sql, 500)),
 		}
 		if duration > s.cleanupWarn {
 			logutil.Warn(

--- a/pkg/cdc/util.go
+++ b/pkg/cdc/util.go
@@ -135,7 +135,7 @@ func extractRowFromVector(ctx context.Context, vec *vector.Vector, i int, row []
 
 	switch vec.GetType().Oid { //get col
 	case types.T_json:
-		row[i] = types.DecodeJson(copyBytes(vec.GetBytesAt(rowIndex)))
+		row[i] = types.DecodeJson(vec.CloneBytesAt(rowIndex))
 	case types.T_bool:
 		row[i] = vector.GetFixedAtWithTypeCheck[bool](vec, rowIndex)
 	case types.T_bit:
@@ -161,7 +161,7 @@ func extractRowFromVector(ctx context.Context, vec *vector.Vector, i int, row []
 	case types.T_float64:
 		row[i] = vector.GetFixedAtWithTypeCheck[float64](vec, rowIndex)
 	case types.T_char, types.T_varchar, types.T_blob, types.T_text, types.T_binary, types.T_varbinary, types.T_datalink:
-		row[i] = copyBytes(vec.GetBytesAt(rowIndex))
+		row[i] = vec.CloneBytesAt(rowIndex)
 	case types.T_array_float32:
 		// NOTE: Don't merge it with T_varchar. You will get raw binary in the SQL output
 		//+------------------------------+
@@ -209,16 +209,6 @@ func extractRowFromVector(ctx context.Context, vec *vector.Vector, i int, row []
 		return moerr.NewInternalErrorf(ctx, "extractRowFromVector : unsupported type %d", vec.GetType().Oid)
 	}
 	return nil
-}
-
-func copyBytes(src []byte) []byte {
-	if len(src) > 0 {
-		dst := make([]byte, len(src))
-		copy(dst, src)
-		return dst
-	} else {
-		return []byte{}
-	}
 }
 
 func convertColIntoSql(

--- a/pkg/cdc/util_test.go
+++ b/pkg/cdc/util_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/bytejson"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -438,7 +439,7 @@ func Test_copyBytes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, copyBytes(tt.args.src), "copyBytes(%v)", tt.args.src)
+			assert.Equalf(t, tt.want, commonutil.CloneBytes(tt.args.src), "copyBytes(%v)", tt.args.src)
 		})
 	}
 }

--- a/pkg/cnservice/server_query.go
+++ b/pkg/cnservice/server_query.go
@@ -22,6 +22,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/system"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
@@ -345,15 +346,9 @@ func copyWaitTxn(src pblock.WaitTxn) *pblock.WaitTxn {
 	return dst
 }
 
-func copyBytes(src []byte) []byte {
-	dst := make([]byte, len(src))
-	copy(dst, src)
-	return dst
-}
-
 func copyTxnMeta(src txn.TxnMeta) *txn.TxnMeta {
 	dst := &txn.TxnMeta{
-		ID:         copyBytes(src.GetID()),
+		ID:         commonutil.CloneBytes(src.GetID()),
 		Status:     src.GetStatus(),
 		SnapshotTS: src.GetSnapshotTS(),
 		PreparedTS: src.GetPreparedTS(),

--- a/pkg/cnservice/server_query.go
+++ b/pkg/cnservice/server_query.go
@@ -22,7 +22,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/system"
-	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
+	commonUtil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
@@ -348,14 +348,15 @@ func copyWaitTxn(src pblock.WaitTxn) *pblock.WaitTxn {
 
 func copyTxnMeta(src txn.TxnMeta) *txn.TxnMeta {
 	dst := &txn.TxnMeta{
-		ID:         commonutil.CloneBytes(src.GetID()),
+		ID:         commonUtil.CloneBytes(src.GetID()),
 		Status:     src.GetStatus(),
 		SnapshotTS: src.GetSnapshotTS(),
-		PreparedTS: src.GetPreparedTS(),
-		CommitTS:   src.GetCommitTS(),
+		PreparedTS: commonUtil.CloneBytes(src.GetPreparedTS()),
+		CommitTS:   commonUtil.CloneBytes(src.GetCommitTS()),
 		Mode:       src.GetMode(),
 		Isolation:  src.GetIsolation(),
 	}
+	return commonUtil.CloneBytes(src.GetID())
 	return dst
 }
 

--- a/pkg/cnservice/server_query.go
+++ b/pkg/cnservice/server_query.go
@@ -351,12 +351,11 @@ func copyTxnMeta(src txn.TxnMeta) *txn.TxnMeta {
 		ID:         commonUtil.CloneBytes(src.GetID()),
 		Status:     src.GetStatus(),
 		SnapshotTS: src.GetSnapshotTS(),
-		PreparedTS: commonUtil.CloneBytes(src.GetPreparedTS()),
-		CommitTS:   commonUtil.CloneBytes(src.GetCommitTS()),
+		PreparedTS: src.GetPreparedTS(),
+		CommitTS:   src.GetCommitTS(),
 		Mode:       src.GetMode(),
 		Isolation:  src.GetIsolation(),
 	}
-	return commonUtil.CloneBytes(src.GetID())
 	return dst
 }
 

--- a/pkg/common/util/bytes.go
+++ b/pkg/common/util/bytes.go
@@ -32,10 +32,10 @@ func CloneBytesIf(src []byte, clone bool) []byte {
 
 // new copy of the slice
 func CloneBytes(src []byte) []byte {
-	var ret []byte
 	if len(src) > 0 {
-		ret = make([]byte, len(src))
+		ret := make([]byte, len(src))
 		copy(ret, src)
+		return ret
 	}
-	return ret
+	return make([]byte, 0)
 }

--- a/pkg/common/util/bytes.go
+++ b/pkg/common/util/bytes.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+// CloneBytesIf conditionally copies a byte slice.
+// If clone is true, it returns a new copy of the slice.
+// If clone is false, it returns the original slice without copying.
+// If the source slice is empty, it returns an empty slice.
+func CloneBytesIf(src []byte, clone bool) []byte {
+	if clone {
+		if len(src) > 0 {
+			dst := make([]byte, len(src))
+			copy(dst, src)
+			return dst
+		}
+		return []byte{}
+	}
+	return src
+}
+
+// new copy of the slice
+func CloneBytes(src []byte) []byte {
+	var ret []byte
+	if len(src) > 0 {
+		ret = make([]byte, len(src))
+		copy(ret, src)
+	}
+	return ret
+}

--- a/pkg/common/util/bytes_test.go
+++ b/pkg/common/util/bytes_test.go
@@ -1,0 +1,88 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopyBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		src      []byte
+		needCopy bool
+		want     []byte
+		wantSame bool // whether the returned slice is the same as src (when needCopy=false)
+	}{
+		{
+			name:     "empty slice, needCopy=true",
+			src:      []byte{},
+			needCopy: true,
+			want:     []byte{},
+			wantSame: false,
+		},
+		{
+			name:     "empty slice, needCopy=false",
+			src:      []byte{},
+			needCopy: false,
+			want:     []byte{},
+			wantSame: true,
+		},
+		{
+			name:     "non-empty slice, needCopy=true",
+			src:      []byte{'a', 'b', 'c'},
+			needCopy: true,
+			want:     []byte{'a', 'b', 'c'},
+			wantSame: false,
+		},
+		{
+			name:     "non-empty slice, needCopy=false",
+			src:      []byte{'a', 'b', 'c'},
+			needCopy: false,
+			want:     []byte{'a', 'b', 'c'},
+			wantSame: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CloneBytesIf(tt.src, tt.needCopy)
+			assert.Equal(t, tt.want, got, "CopyBytes(%v, %v)", tt.src, tt.needCopy)
+
+			// Check if the returned slice is the same as src when needCopy=false
+			if tt.needCopy {
+				// When needCopy=true, the slice should be a copy
+				if len(tt.src) > 0 {
+					assert.NotSame(t, &tt.src[0], &got[0], "CopyBytes should return a new slice when needCopy=true")
+				}
+			} else {
+				// When needCopy=false, the slice should be the same
+				if len(tt.src) > 0 {
+					assert.Same(t, &tt.src[0], &got[0], "CopyBytes should return the same slice when needCopy=false")
+				}
+			}
+
+			// Verify that modifying the original doesn't affect the copy when needCopy=true
+			if tt.needCopy && len(tt.src) > 0 {
+				original := make([]byte, len(tt.src))
+				copy(original, tt.src)
+				tt.src[0] = 'x'
+				assert.Equal(t, original, got, "CopyBytes should return an independent copy when needCopy=true")
+			}
+		})
+	}
+}

--- a/pkg/common/util/string.go
+++ b/pkg/common/util/string.go
@@ -1,0 +1,38 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+// Abbreviate truncates a string from the beginning to the specified length.
+// Parameters:
+//   - str: the input string
+//   - length: the maximum length to truncate to
+//     -1: return the complete string
+//     0: return empty string
+//     >0: return the first 'length' characters, appending "..." if truncated
+func Abbreviate(str string, length int) string {
+	if length == 0 || length < -1 {
+		return ""
+	}
+
+	if length == -1 {
+		return str
+	}
+
+	l := min(len(str), length)
+	if l != len(str) {
+		return str[:l] + "..."
+	}
+	return str[:l]
+}

--- a/pkg/common/util/string_test.go
+++ b/pkg/common/util/string_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestSubStringFromBegin(t *testing.T) {
+	convey.Convey("SubStringFromBegin", t, func() {
+		// Test normal truncation
+		convey.So(Abbreviate("abcdef", 3), convey.ShouldEqual, "abc...")
+
+		// Test string shorter than length
+		convey.So(Abbreviate("abc", 5), convey.ShouldEqual, "abc")
+
+		// Test exact length match
+		convey.So(Abbreviate("abc", 3), convey.ShouldEqual, "abc")
+
+		// Test empty string
+		convey.So(Abbreviate("", 5), convey.ShouldEqual, "")
+
+		// Test length 0
+		convey.So(Abbreviate("abcdef", 0), convey.ShouldEqual, "")
+
+		// Test length -1 (return complete string)
+		convey.So(Abbreviate("abcdef", -1), convey.ShouldEqual, "abcdef")
+
+		// Test length < -1
+		convey.So(Abbreviate("abcdef", -2), convey.ShouldEqual, "")
+
+		// Test long string
+		longStr := "a" + string(make([]byte, 2000))
+		result := Abbreviate(longStr, 1024)
+		convey.So(len(result), convey.ShouldEqual, 1027) // 1024 + "..."
+		convey.So(result[:1024], convey.ShouldEqual, longStr[:1024])
+		convey.So(result[1024:], convey.ShouldEqual, "...")
+	})
+}

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -38,6 +38,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/bytejson"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -4395,8 +4396,8 @@ func compareSingleValInVector(
 	// Use raw values to avoid format conversions in extractRowFromVector.
 	switch vec1.GetType().Oid {
 	case types.T_json:
-		val1 := types.DecodeJson(copyBytes(vec1.GetBytesAt(rowIdx1), false))
-		val2 := types.DecodeJson(copyBytes(vec2.GetBytesAt(rowIdx2), false))
+		val1 := types.DecodeJson(commonutil.CloneBytesIf(vec1.GetBytesAt(rowIdx1), false))
+		val2 := types.DecodeJson(commonutil.CloneBytesIf(vec2.GetBytesAt(rowIdx2), false))
 		return types.CompareValue(val1, val2), nil
 	case types.T_bool:
 		val1 := vector.GetFixedAtNoTypeCheck[bool](vec1, rowIdx1)
@@ -4447,8 +4448,8 @@ func compareSingleValInVector(
 		val2 := vector.GetFixedAtNoTypeCheck[float64](vec2, rowIdx2)
 		return types.CompareValue(val1, val2), nil
 	case types.T_char, types.T_varchar, types.T_blob, types.T_text, types.T_binary, types.T_varbinary, types.T_datalink:
-		val1 := copyBytes(vec1.GetBytesAt(rowIdx1), false)
-		val2 := copyBytes(vec2.GetBytesAt(rowIdx2), false)
+		val1 := commonutil.CloneBytesIf(vec1.GetBytesAt(rowIdx1), false)
+		val2 := commonutil.CloneBytesIf(vec2.GetBytesAt(rowIdx2), false)
 		return types.CompareValue(val1, val2), nil
 	case types.T_array_float32:
 		val1 := vector.GetArrayAt[float32](vec1, rowIdx1)

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -38,7 +38,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
-	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/bytejson"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -4396,9 +4395,9 @@ func compareSingleValInVector(
 	// Use raw values to avoid format conversions in extractRowFromVector.
 	switch vec1.GetType().Oid {
 	case types.T_json:
-		val1 := types.DecodeJson(commonutil.CloneBytesIf(vec1.GetBytesAt(rowIdx1), false))
-		val2 := types.DecodeJson(commonutil.CloneBytesIf(vec2.GetBytesAt(rowIdx2), false))
-		return types.CompareValue(val1, val2), nil
+		val1 := types.DecodeJson(vec1.GetBytesAt(rowIdx1))
+		val2 := types.DecodeJson(vec2.GetBytesAt(rowIdx2))
+		return bytejson.CompareByteJson(val1, val2), nil
 	case types.T_bool:
 		val1 := vector.GetFixedAtNoTypeCheck[bool](vec1, rowIdx1)
 		val2 := vector.GetFixedAtNoTypeCheck[bool](vec2, rowIdx2)
@@ -4448,9 +4447,10 @@ func compareSingleValInVector(
 		val2 := vector.GetFixedAtNoTypeCheck[float64](vec2, rowIdx2)
 		return types.CompareValue(val1, val2), nil
 	case types.T_char, types.T_varchar, types.T_blob, types.T_text, types.T_binary, types.T_varbinary, types.T_datalink:
-		val1 := commonutil.CloneBytesIf(vec1.GetBytesAt(rowIdx1), false)
-		val2 := commonutil.CloneBytesIf(vec2.GetBytesAt(rowIdx2), false)
-		return types.CompareValue(val1, val2), nil
+		return bytes.Compare(
+			vec1.GetBytesAt(rowIdx1),
+			vec2.GetBytesAt(rowIdx2),
+		), nil
 	case types.T_array_float32:
 		val1 := vector.GetArrayAt[float32](vec1, rowIdx1)
 		val2 := vector.GetArrayAt[float32](vec2, rowIdx2)

--- a/pkg/frontend/mysql_buffer.go
+++ b/pkg/frontend/mysql_buffer.go
@@ -582,7 +582,7 @@ func (c *Conn) Append(elems ...byte) (err error) {
 	for cutIndex < len(elems) {
 		// if bufferLength > 16MB, split packet
 		remainPacketSpace := int(MaxPayloadSize) - c.packetLength
-		writeLength := Min(remainPacketSpace, len(elems[cutIndex:]))
+		writeLength := min(remainPacketSpace, len(elems[cutIndex:]))
 		err = AppendPart(c, elems[cutIndex:cutIndex+writeLength])
 		if err != nil {
 			return err

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -42,7 +42,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/pubsub"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
-	"github.com/matrixorigin/matrixone/pkg/common/util"
 	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -3308,7 +3307,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 	case COM_QUIT:
 		return resp, moerr.GetMysqlClientQuit()
 	case COM_QUERY:
-		var query = util.UnsafeBytesToString(req.GetData().([]byte))
+		var query = commonutil.UnsafeBytesToString(req.GetData().([]byte))
 		ses.addSqlCount(1)
 		ses.Debug(execCtx.reqCtx, "query trace", logutil.QueryField(commonutil.Abbreviate(query, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))))
 		input := &UserInput{sql: query}
@@ -3322,7 +3321,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 		}
 		return resp, nil
 	case COM_INIT_DB:
-		var dbname = util.UnsafeBytesToString(req.GetData().([]byte))
+		var dbname = commonutil.UnsafeBytesToString(req.GetData().([]byte))
 		ses.addSqlCount(1)
 		query := "use `" + dbname + "`"
 		err = doComQuery(ses, execCtx, &UserInput{sql: query})
@@ -3332,7 +3331,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 
 		return resp, nil
 	case COM_FIELD_LIST:
-		var payload = util.UnsafeBytesToString(req.GetData().([]byte))
+		var payload = commonutil.UnsafeBytesToString(req.GetData().([]byte))
 		ses.addSqlCount(1)
 		query := makeCmdFieldListSql(payload)
 		err = doComQuery(ses, execCtx, &UserInput{sql: query})
@@ -3348,7 +3347,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 
 	case COM_STMT_PREPARE:
 		ses.SetCmd(COM_STMT_PREPARE)
-		sql = util.UnsafeBytesToString(req.GetData().([]byte))
+		sql = commonutil.UnsafeBytesToString(req.GetData().([]byte))
 		ses.addSqlCount(1)
 
 		// rewrite to "Prepare stmt_name from 'xxx'"
@@ -3600,11 +3599,11 @@ func convertMysqlTextTypeToBlobType(col *MysqlColumn) {
 // build plan json when marhal plan error
 func buildErrorJsonPlan(buffer *bytes.Buffer, uuid uuid.UUID, errcode uint16, msg string) []byte {
 	var bytes [36]byte
-	util.EncodeUUIDHex(bytes[:], uuid[:])
+	commonutil.EncodeUUIDHex(bytes[:], uuid[:])
 	explainData := models.ExplainData{
 		Code:    errcode,
 		Message: msg,
-		Uuid:    util.UnsafeBytesToString(bytes[:]),
+		Uuid:    commonutil.UnsafeBytesToString(bytes[:]),
 	}
 	encoder := json.NewEncoder(buffer)
 	encoder.SetEscapeHTML(false)

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -43,6 +43,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/pubsub"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -155,7 +156,7 @@ var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Proc
 			bb.WriteString(envStmt)
 			bb.WriteString(" // ")
 			bb.WriteString(execSql)
-			text = SubStringFromBegin(bb.String(), int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))
+			text = commonutil.Abbreviate(bb.String(), int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))
 		} else {
 			// ignore envStmt == ""
 			// case: exec `set @t = 2;` will trigger an internal query with the same session.
@@ -163,11 +164,11 @@ var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Proc
 			//	+ fmtCtx := tree.NewFmtCtx(dialect.MYSQL, tree.WithQuoteString(true))
 			//	+ cw.GetAst().Format(fmtCtx)
 			//  + envStmt = fmtCtx.String()
-			text = SubStringFromBegin(envStmt, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))
+			text = commonutil.Abbreviate(envStmt, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))
 		}
 	} else {
 		stmID, _ = uuid.NewV7()
-		text = SubStringFromBegin(envStmt, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))
+		text = commonutil.Abbreviate(envStmt, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))
 	}
 	ses.SetStmtId(stmID)
 	ses.SetStmtType(getStatementType(statement).GetStatementType())
@@ -3309,7 +3310,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 	case COM_QUERY:
 		var query = util.UnsafeBytesToString(req.GetData().([]byte))
 		ses.addSqlCount(1)
-		ses.Debug(execCtx.reqCtx, "query trace", logutil.QueryField(SubStringFromBegin(query, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))))
+		ses.Debug(execCtx.reqCtx, "query trace", logutil.QueryField(commonutil.Abbreviate(query, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))))
 		input := &UserInput{sql: query}
 		err = doComQuery(ses, execCtx, input)
 		if err != nil {

--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -2220,7 +2220,7 @@ func Test_beginPacket(t *testing.T) {
 			var data []byte = nil
 			var sequenceId byte = 0
 			for i := 0; i < n; i += curLen {
-				curLen = Min(int(MaxPayloadSize), n-i)
+				curLen = min(int(MaxPayloadSize), n-i)
 				binary.LittleEndian.PutUint32(header[:], uint32(curLen))
 				header[3] = sequenceId
 				sequenceId++

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -38,7 +38,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
-	"github.com/matrixorigin/matrixone/pkg/common/util"
 	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	mo_config "github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
@@ -1396,7 +1395,7 @@ func Copy[T any](src []T) []T {
 
 func hashString(s string) string {
 	hash := sha256.New()
-	hash.Write(util.UnsafeStringToBytes(s))
+	hash.Write(commonutil.UnsafeStringToBytes(s))
 	hashBytes := hash.Sum(nil)
 	return hex.EncodeToString(hashBytes)
 }

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -106,49 +106,6 @@ func GetRoutineId() uint64 {
 	return uint64(id)
 }
 
-type Timeout struct {
-	//last record of the time
-	lastTime atomic.Value //time.Time
-
-	//period
-	timeGap time.Duration
-
-	//auto update
-	autoUpdate bool
-}
-
-func NewTimeout(tg time.Duration, autoUpdateWhenChecked bool) *Timeout {
-	ret := &Timeout{
-		timeGap:    tg,
-		autoUpdate: autoUpdateWhenChecked,
-	}
-	ret.lastTime.Store(time.Now())
-	return ret
-}
-
-func (t *Timeout) UpdateTime(tn time.Time) {
-	t.lastTime.Store(tn)
-}
-
-/*
-----------+---------+------------------+--------
-
-	lastTime     Now         lastTime + timeGap
-
-return true  :  is timeout. the lastTime has been updated.
-return false :  is not timeout. the lastTime has not been updated.
-*/
-func (t *Timeout) isTimeout() bool {
-	if time.Since(t.lastTime.Load().(time.Time)) <= t.timeGap {
-		return false
-	}
-
-	if t.autoUpdate {
-		t.lastTime.Store(time.Now())
-	}
-	return true
-}
-
 /*
 path exists in the system
 return:

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -39,6 +39,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	mo_config "github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
@@ -82,14 +83,6 @@ func (cf *CloseFlag) IsClosed() bool {
 
 func (cf *CloseFlag) IsOpened() bool {
 	return atomic.LoadUint32(&cf.closed) == 0
-}
-
-func Min(a int, b int) int {
-	if a < b {
-		return a
-	} else {
-		return b
-	}
 }
 
 func Max(a int, b int) int {
@@ -154,28 +147,6 @@ func (t *Timeout) isTimeout() bool {
 		t.lastTime.Store(time.Now())
 	}
 	return true
-}
-
-/*
-length:
--1, complete string.
-0, empty string
->0 , length of characters at the header of the string.
-*/
-func SubStringFromBegin(str string, length int) string {
-	if length == 0 || length < -1 {
-		return ""
-	}
-
-	if length == -1 {
-		return str
-	}
-
-	l := Min(len(str), length)
-	if l != len(str) {
-		return str[:l] + "..."
-	}
-	return str[:l]
 }
 
 /*
@@ -516,7 +487,7 @@ func logStatementStringStatus(
 				str = stm.CopyStatementInfo()
 			}
 		}
-		str = SubStringFromBegin(str, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))
+		str = commonutil.Abbreviate(str, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))
 		return str
 	}
 	switch resper := ses.GetResponser().(type) {

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -557,19 +557,6 @@ func makeServerVersion(pu *mo_config.ParameterUnit, version string) string {
 	return pu.SV.ServerVersionPrefix + version
 }
 
-func copyBytes(src []byte, needCopy bool) []byte {
-	if needCopy {
-		if len(src) > 0 {
-			dst := make([]byte, len(src))
-			copy(dst, src)
-			return dst
-		} else {
-			return []byte{}
-		}
-	}
-	return src
-}
-
 // getUserProfile returns the account, user, role of the account
 func getUserProfile(account *TenantInfo) (string, string, string) {
 	var (

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -97,14 +97,6 @@ func Test_routineid(t *testing.T) {
 	})
 }
 
-func Test_timeout(t *testing.T) {
-	cvey.Convey("timeout", t, func() {
-		to := NewTimeout(5*time.Second, true)
-		to.UpdateTime(time.Now())
-		cvey.So(to.isTimeout(), cvey.ShouldBeFalse)
-	})
-}
-
 func Test_substringFromBegin(t *testing.T) {
 	cvey.Convey("ssfb", t, func() {
 		cvey.So(commonutil.Abbreviate("abcdef", 3), cvey.ShouldEqual, "abc...")

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -82,12 +83,7 @@ func Test_PathExists(t *testing.T) {
 	}
 }
 
-func Test_MinMax(t *testing.T) {
-	cvey.Convey("min", t, func() {
-		cvey.So(Min(10, 9), cvey.ShouldEqual, 9)
-		cvey.So(Min(9, 10), cvey.ShouldEqual, 9)
-	})
-
+func Test_Max(t *testing.T) {
 	cvey.Convey("max", t, func() {
 		cvey.So(Max(10, 9), cvey.ShouldEqual, 10)
 		cvey.So(Max(9, 10), cvey.ShouldEqual, 10)
@@ -111,7 +107,7 @@ func Test_timeout(t *testing.T) {
 
 func Test_substringFromBegin(t *testing.T) {
 	cvey.Convey("ssfb", t, func() {
-		cvey.So(SubStringFromBegin("abcdef", 3), cvey.ShouldEqual, "abc...")
+		cvey.So(commonutil.Abbreviate("abcdef", 3), cvey.ShouldEqual, "abc...")
 	})
 }
 

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/common/system"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -520,7 +521,7 @@ func (c *Compile) runOnce() (err error) {
 					if e := recover(); e != nil {
 						err := moerr.ConvertPanicError(c.proc.Ctx, e)
 						c.proc.Error(c.proc.Ctx, "panic in run",
-							zap.String("sql", c.sql),
+							zap.String("sql", commonutil.Abbreviate(c.sql, 500)),
 							zap.String("error", err.Error()))
 						errC <- err
 					}

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -2814,7 +2815,7 @@ func (s *Scope) DropTable(c *Compile) error {
 	for _, ss := range sqls {
 		if err = c.runSqlWithSystemTenant(ss); err != nil {
 			logutil.Error("run extra sql failed when drop table",
-				zap.String("sql", ss),
+				zap.String("sql", commonutil.Abbreviate(ss, 500)),
 				zap.Error(err),
 			)
 			return err

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
@@ -146,7 +147,7 @@ func (s *Scope) Run(c *Compile) (err error) {
 		if e := recover(); e != nil {
 			err = moerr.ConvertPanicError(s.Proc.Ctx, e)
 			c.proc.Error(c.proc.Ctx, "panic in scope run",
-				zap.String("sql", c.sql),
+				zap.String("sql", commonutil.Abbreviate(c.sql, 500)),
 				zap.String("error", err.Error()))
 		}
 		if p != nil {
@@ -446,7 +447,7 @@ func (s *Scope) ParallelRun(c *Compile) (err error) {
 		if e := recover(); e != nil {
 			err = moerr.ConvertPanicError(s.Proc.Ctx, e)
 			c.proc.Error(c.proc.Ctx, "panic in scope run",
-				zap.String("sql", c.sql),
+				zap.String("sql", commonutil.Abbreviate(c.sql, 500)),
 				zap.String("error", err.Error()))
 		}
 

--- a/pkg/sql/compile/sql_executor.go
+++ b/pkg/sql/compile/sql_executor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
@@ -158,7 +159,7 @@ func (s *sqlExecutor) ExecTxn(
 	if err != nil {
 		logutil.Error("internal sql executor error",
 			zap.Error(err),
-			zap.String("sql", opts.SQL()),
+			zap.String("sql", commonutil.Abbreviate(opts.SQL(), 500)),
 			zap.String("txn", exec.Txn().Txn().DebugString()),
 		)
 		return exec.rollback(err)
@@ -507,12 +508,8 @@ func (exec *txnExecutor) Exec(
 	}
 
 	if !statementOption.DisableLog() {
-		printSql := sql
-		if len(printSql) > 1000 {
-			printSql = printSql[:1000] + "..."
-		}
 		logutil.Info("sql_executor exec",
-			zap.String("sql", printSql),
+			zap.String("sql", commonutil.Abbreviate(sql, 500)),
 			zap.String("txn-id", hex.EncodeToString(exec.opts.Txn().Txn().ID)),
 			zap.Duration("duration", time.Since(receiveAt)),
 			zap.Int("BatchSize", len(batches)),

--- a/pkg/sql/plan/function/func_mo.go
+++ b/pkg/sql/plan/function/func_mo.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/pubsub"
+	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/container/bytejson"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -229,7 +230,7 @@ func isSubscribedTable(
 					zap.String("db name", dbName),
 					zap.String("tbl name", tblName),
 					zap.String("subscription", sub.String()),
-					zap.String("sql", sql),
+					zap.String("sql", commonutil.Abbreviate(sql, 500)),
 				)
 			}
 		}()

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1853,7 +1853,7 @@ func extractPStateFromRelData(
 		logutil.Warn("RELDATA-WITH-EMPTY-PSTATE",
 			zap.String("db", tbl.db.databaseName),
 			zap.String("table", tbl.tableName),
-			zap.String("sql", sql),
+			zap.String("sql", commonUtil.Abbreviate(sql, 500)),
 			zap.String("relDataType", fmt.Sprintf("%T", relData)),
 			zap.String("relDataContent", relData.String()),
 			zap.String("stack", string(debug.Stack())))


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #23222 

## What this PR does / why we need it:

quick cap on SQL print max length


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Centralize byte and string utility functions into common package
  - Create `CloneBytes`, `CloneBytesIf`, and `Abbreviate` utilities
  - Remove duplicate implementations across codebase

- Limit SQL logging output to 500 characters maximum
  - Prevent excessive log sizes from long SQL statements
  - Apply abbreviation consistently across logging calls

- Optimize byte operations and comparisons
  - Replace manual byte copying with vector's `CloneBytesAt` method
  - Use `bytes.Compare` for direct byte slice comparison

- Remove unused utility functions and code
  - Delete `Timeout` struct and related methods
  - Remove redundant `Min` function (use built-in `min`)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Duplicate byte/string utilities<br/>across multiple files"] -->|Consolidate| B["pkg/common/util<br/>bytes.go & string.go"]
  C["Long SQL statements<br/>in logs"] -->|Apply Abbreviate| D["Truncated output<br/>max 500 chars"]
  E["Manual byte copying<br/>copyBytes functions"] -->|Replace with| F["Vector.CloneBytesAt<br/>& CloneBytes"]
  B -->|Import & use| G["Updated files:<br/>cdc, frontend, sql"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>17 files</summary><table>
<tr>
  <td><strong>bytes.go</strong><dd><code>New byte cloning utility functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-0cd1ad6aa08bd7e47f08ca6841fdedaea22fac08d8b84ccaf263f7a39fdb932c">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>string.go</strong><dd><code>New string abbreviation utility function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-1ede190a8918c9653055ee53088626775f70eb9c62c574288aa5b82199f6bc3b">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>table_scanner.go</strong><dd><code>Limit SQL logging to 500 characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-ff43b62d0f42085266c063c203474532c19fb2aeb3e6d390b187f63f5306af8b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>util.go</strong><dd><code>Replace copyBytes with vector.CloneBytesAt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-46b260aa5fed62ad704662ba98a550547b13b1950d693dac8d96a865e1e41237">+2/-12</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>data_branch.go</strong><dd><code>Optimize byte comparison and remove copyBytes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-632e0d2d46c8bdef4144b4d6f532cf8df78cc583e4903672ae6675d8c09783b4">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mysql_buffer.go</strong><dd><code>Replace Min function with built-in min</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-57df9142267c7468f8fc339e9071fe9750d24b5a6ab2efbca5d0a2765ff5ca59">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mysql_cmd_executor.go</strong><dd><code>Replace SubStringFromBegin with Abbreviate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-af2611d5fc89704398fe09d09644efa41fec8931b395eda292f2f474f1216275">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mysql_protocol_test.go</strong><dd><code>Replace Min function with built-in min</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-e6b33be301283d85ec5e07d87fa0d6d826a68d7810019b613d315659f329ebac">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>output.go</strong><dd><code>Replace copyBytes with CloneBytesIf utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-df1b62301c885e4cd4075140bdd989df1c9660b561033f8b56a56b605f5e7d18">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>util.go</strong><dd><code>Remove duplicate utilities and use common package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-005617216374ac58bf3cf72b81841d5cb6a17495d1d7b36ff387e294a0d6e043">+2/-87</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>compile.go</strong><dd><code>Limit SQL logging to 500 characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>compile2.go</strong><dd><code>Limit SQL logging to 500 characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-1c117d6b04a95023864b6b925099524a28e4ce3e4c8b6d93f4ab32d62cd4974e">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ddl.go</strong><dd><code>Limit SQL logging to 500 characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-819bfdf891fa506cb2b4c89006896d528675fd554c341f38d1a1bf14a496c8aa">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>scope.go</strong><dd><code>Limit SQL logging to 500 characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sql_executor.go</strong><dd><code>Limit SQL logging to 500 characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-8d93841d90b6b267a1c218f24e1f564febdcc4dd780d04909033d706302ca215">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>func_mo.go</strong><dd><code>Limit SQL logging to 500 characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-b553fa8d20dd9d505e58e3272ad74d359a50ce56152e523c8886ef1316b14ed9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>txn_table.go</strong><dd><code>Limit SQL logging to 500 characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>bytes_test.go</strong><dd><code>Tests for byte cloning utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-e0ee223e0dd8dbd06e10644be0d576d23f205e905a06cc3af94ce49585985a3b">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>string_test.go</strong><dd><code>Tests for string abbreviation function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-266b890c079978ce53248b043bfdeef28ac0e94d97dc24715d420637326f295a">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>util_test.go</strong><dd><code>Update test to use commonutil.CloneBytes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-682a3d8cc46973e1c1726fa8a8ece492f2a8aba302fb81cee8578934c29caea6">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>util_test.go</strong><dd><code>Update tests for removed and moved utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-f51b6d5837418f5bbf801345e25b4bfcc4cd436bdec4534ab7a8aa8dc01839e0">+3/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>server_query.go</strong><dd><code>Replace copyBytes with commonutil.CloneBytes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23229/files#diff-9155e9743825e69f57408c43feab229fd722006804cef7dffbf57a78d507d7c1">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

