### PR TITLE
to hotfix: fix clone indexes when alter table.

### DIFF
--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -158,6 +158,7 @@ func buildInsertPlans(
 	ifNeedCheckPkDup := !builder.qry.LoadTag
 	var indexSourceColTypes []*plan.Type
 	var fuzzymessage *OriginTableMessageForFuzzy
+	var skipIndexesCoyp map[string]bool
 
 	if v := builder.compCtx.GetContext().Value(defines.AlterCopyOpt{}); v != nil {
 		dedupOpt := v.(*plan.AlterCopyOpt)
@@ -178,10 +179,13 @@ func buildInsertPlans(
 				}
 			}
 		}
+		skipIndexesCoyp = dedupOpt.SkipIndexesCopy
 	}
 	return buildInsertPlansWithRelatedHiddenTable(stmt, ctx, builder, insertBindCtx, objRef, tableDef,
 		updateColLength, sourceStep, addAffectedRows, isFkRecursionCall, updatePkCol, pkFilterExpr,
-		newPartitionExpr, ifExistAutoPkCol, ifNeedCheckPkDup, indexSourceColTypes, fuzzymessage, insertWithoutUniqueKeyMap, ifInsertFromUniqueColMap, nil)
+		newPartitionExpr, ifExistAutoPkCol, ifNeedCheckPkDup, indexSourceColTypes, fuzzymessage,
+		insertWithoutUniqueKeyMap, ifInsertFromUniqueColMap, nil, skipIndexesCoyp,
+	)
 }
 
 // buildUpdatePlans  build update plan.
@@ -266,7 +270,7 @@ func buildUpdatePlans(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindC
 	return buildInsertPlansWithRelatedHiddenTable(nil, ctx, builder, insertBindCtx, updatePlanCtx.objRef, updatePlanCtx.tableDef,
 		updatePlanCtx.updateColLength, sourceStep, addAffectedRows, updatePlanCtx.isFkRecursionCall, updatePlanCtx.updatePkCol,
 		updatePlanCtx.pkFilterExprs, partitionExpr, ifExistAutoPkCol, ifNeedCheckPkDup, indexSourceColTypes, fuzzymessage, nil, nil,
-		updatePlanCtx.updateColPosMap)
+		updatePlanCtx.updateColPosMap, nil)
 }
 
 func getStepByNodeId(builder *QueryBuilder, nodeId int32) int {
@@ -853,7 +857,7 @@ func buildInsertPlansWithRelatedHiddenTable(
 	updatePkCol bool, pkFilterExprs []*Expr, partitionExpr *Expr, ifExistAutoPkCol bool,
 	checkInsertPkDupForHiddenIndexTable bool, indexSourceColTypes []*plan.Type, fuzzymessage *OriginTableMessageForFuzzy,
 	insertWithoutUniqueKeyMap map[string]bool, ifInsertFromUniqueColMap map[string]bool,
-	updateColPosMap map[string]int,
+	updateColPosMap map[string]int, skipIndexesCopy map[string]bool,
 ) error {
 	//var lastNodeId int32
 	var err error
@@ -867,6 +871,11 @@ func buildInsertPlansWithRelatedHiddenTable(
 	for idx, indexdef := range tableDef.Indexes {
 		if updateColLength == 0 {
 			if indexdef.GetUnique() && (insertWithoutUniqueKeyMap != nil && insertWithoutUniqueKeyMap[indexdef.IndexName]) {
+				continue
+			}
+
+			// we will clone this index data to new index table, skip insert.
+			if skipIndexesCopy != nil && skipIndexesCopy[indexdef.IndexName] {
 				continue
 			}
 

--- a/test/distributed/cases/snapshot/clone/clone_in_alter_table_2.result
+++ b/test/distributed/cases/snapshot/clone/clone_in_alter_table_2.result
@@ -1,0 +1,149 @@
+SET experimental_fulltext_index = 1;
+SET experimental_ivf_index = 1;
+SET experimental_hnsw_index = 1;
+drop database if exists db;
+create database db;
+use db;
+DROP TABLE IF EXISTS stress_alter_table;
+CREATE TABLE `stress_alter_table` (
+`md5_id` int NOT NULL,
+`b` varchar(65535) DEFAULT NULL,
+`delete_flag` int DEFAULT NULL,
+PRIMARY KEY (`md5_id`),
+FULLTEXT `fb`(`b`) WITH PARSER ngram,
+KEY `delete_flag_idx` (`delete_flag`)
+);
+INSERT INTO stress_alter_table VALUES (1, 'this is a one', 0);
+DELETE FROM `stress_alter_table` WHERE delete_flag = 0;
+INSERT INTO `stress_alter_table` (`md5_id`,`b`,`delete_flag`) VALUES (1,'this is a one',0);
+ALTER TABLE `stress_alter_table` MODIFY COLUMN delete_flag INT DEFAULT 0;
+select mo_ctl('dn','checkpoint','');
+mo_ctl(dn, checkpoint, )
+{\n  "method": "Checkpoint",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+SELECT COUNT(*) FROM `stress_alter_table`;
+COUNT(*)
+1
+UPDATE `stress_alter_table` SET delete_flag = 1 WHERE md5_id = '1';
+SELECT COUNT(*) FROM `stress_alter_table`;
+COUNT(*)
+1
+drop table stress_alter_table;
+create table t1 (id bigint primary key, delete_flag int, a int, body varchar(10), title text, FULLTEXT (title, body), key(delete_flag));
+insert into t1 values(1,1,1, "body", "title");
+ALTER TABLE t1 MODIFY COLUMN a int DEFAULT NULL;
+SET @inner_sql = (
+SELECT GROUP_CONCAT(
+DISTINCT CONCAT(
+'SELECT ''', mi.index_table_name,
+''' AS index_table_name, COUNT(*) AS cnt FROM `',
+mi.index_table_name, '`'
+) SEPARATOR ' UNION ALL '
+)
+FROM mo_catalog.mo_indexes mi
+JOIN mo_catalog.mo_tables mt ON mi.table_id = mt.rel_id
+WHERE mt.relname = 't1'
+AND mt.reldatabase = 'db'
+AND mi.type IN ('MULTIPLE', 'UNIQUE')
+AND mi.index_table_name IS NOT NULL
+AND mi.index_table_name != ''
+AND mi.column_name <> 'question'
+AND mi.column_name <> 'keyword'
+);
+SET @sql = CONCAT(
+'SELECT * FROM (',
+@inner_sql,
+') AS t ORDER BY cnt DESC'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+index_table_name    cnt
+__mo_index_secondary_019b0be5-956f-77a1-b31b-b1db0d19540e    3
+__mo_index_secondary_019b0be5-956f-77a8-923c-2ce77693d21a    1
+DEALLOCATE PREPARE stmt;
+drop table t1;
+create table t2 (id int primary key, a int, b int, c int, key(a), key(b));
+insert into t2 values(1,1,1,1);
+ALTER TABLE t2 MODIFY COLUMN c int DEFAULT NULL;
+SET @inner_sql = (
+SELECT GROUP_CONCAT(
+DISTINCT CONCAT(
+'SELECT ''', mi.index_table_name,
+''' AS index_table_name, COUNT(*) AS cnt FROM `',
+mi.index_table_name, '`'
+) SEPARATOR ' UNION ALL '
+)
+FROM mo_catalog.mo_indexes mi
+JOIN mo_catalog.mo_tables mt ON mi.table_id = mt.rel_id
+WHERE mt.relname = 't2'
+AND mt.reldatabase = 'db'
+AND mi.type IN ('MULTIPLE', 'UNIQUE')
+AND mi.index_table_name IS NOT NULL
+AND mi.index_table_name != ''
+AND mi.column_name <> 'question'
+AND mi.column_name <> 'keyword'
+);
+SET @sql = CONCAT(
+'SELECT * FROM (',
+@inner_sql,
+') AS t ORDER BY cnt DESC'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+index_table_name    cnt
+__mo_index_secondary_019b0be5-95ad-764d-b6f8-03e4c66741c5    1
+__mo_index_secondary_019b0be5-95ad-7645-8b2b-2cac0abec44d    1
+DEALLOCATE PREPARE stmt;
+drop table t2;
+create table t3 (
+id bigint primary key,
+delete_flag int,
+a vecf32(3),
+b vecf32(3),
+body varchar(10),
+title text,
+FULLTEXT (title, body),
+key(delete_flag),
+key ivf using ivfflat (a),
+key idx using hnsw(b) op_type 'vector_l2_ops'
+);
+insert into t3 values(1,1, '[0.1,0.2,0.3]','[0.1,0.2,0.3]', "body", "title");
+ALTER TABLE t3 MODIFY COLUMN delete_flag int DEFAULT NULL;
+SET @inner_sql = (
+SELECT GROUP_CONCAT(
+DISTINCT CONCAT(
+'SELECT ''', mi.index_table_name,
+''' AS index_table_name, COUNT(*) AS cnt FROM `',
+mi.index_table_name, '`'
+) SEPARATOR ' UNION ALL '
+)
+FROM mo_catalog.mo_indexes mi
+JOIN mo_catalog.mo_tables mt ON mi.table_id = mt.rel_id
+WHERE mt.relname = 't3'
+AND mt.reldatabase = 'db'
+AND mi.type IN ('MULTIPLE', 'UNIQUE')
+AND mi.index_table_name IS NOT NULL
+AND mi.index_table_name != ''
+AND mi.column_name <> 'question'
+AND mi.column_name <> 'keyword'
+);
+SET @sql = CONCAT(
+'SELECT * FROM (',
+@inner_sql,
+') AS t ORDER BY cnt DESC'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+index_table_name    cnt
+__mo_index_secondary_019b0be5-95fd-7791-afd3-507749cef99c    7
+__mo_index_secondary_019b0be5-95fd-7776-9a98-70ab95462275    3
+__mo_index_secondary_019b0be5-95fd-77bc-a462-f9ff422590ec    1
+__mo_index_secondary_019b0be5-95fd-77b4-9add-05fb884cd701    1
+__mo_index_secondary_019b0be5-95fd-77ac-89bd-7e681c4689d8    1
+__mo_index_secondary_019b0be5-95fd-77a5-bc19-7b0dd32ae669    1
+__mo_index_secondary_019b0be5-95fd-7789-927c-8fbad1739d08    1
+DEALLOCATE PREPARE stmt;
+drop table t3;
+SET experimental_fulltext_index = 0;
+SET experimental_ivf_index = 0;
+SET experimental_hnsw_index = 0;
+drop database db;

--- a/test/distributed/cases/snapshot/clone/clone_in_alter_table_2.sql
+++ b/test/distributed/cases/snapshot/clone/clone_in_alter_table_2.sql
@@ -1,0 +1,163 @@
+SET experimental_fulltext_index = 1;
+SET experimental_ivf_index = 1;
+SET experimental_hnsw_index = 1;
+
+drop database if exists db;
+create database db;
+use db;
+
+-- case 1: primary table duplicate
+DROP TABLE IF EXISTS stress_alter_table;
+CREATE TABLE `stress_alter_table` (
+    `md5_id` int NOT NULL,
+    `b` varchar(65535) DEFAULT NULL,
+    `delete_flag` int DEFAULT NULL,
+    PRIMARY KEY (`md5_id`),
+    FULLTEXT `fb`(`b`) WITH PARSER ngram,
+    KEY `delete_flag_idx` (`delete_flag`)
+);
+
+INSERT INTO stress_alter_table VALUES (1, 'this is a one', 0);
+
+DELETE FROM `stress_alter_table` WHERE delete_flag = 0;
+INSERT INTO `stress_alter_table` (`md5_id`,`b`,`delete_flag`) VALUES (1,'this is a one',0);
+ALTER TABLE `stress_alter_table` MODIFY COLUMN delete_flag INT DEFAULT 0;
+-- @ignore:0
+select mo_ctl('dn','checkpoint','');
+SELECT COUNT(*) FROM `stress_alter_table`;
+UPDATE `stress_alter_table` SET delete_flag = 1 WHERE md5_id = '1';
+SELECT COUNT(*) FROM `stress_alter_table`;
+
+drop table stress_alter_table;
+
+-- case 2
+create table t1 (id bigint primary key, delete_flag int, a int, body varchar(10), title text, FULLTEXT (title, body), key(delete_flag));
+insert into t1 values(1,1,1, "body", "title");
+ALTER TABLE t1 MODIFY COLUMN a int DEFAULT NULL;
+
+SET @inner_sql = (
+    SELECT GROUP_CONCAT(
+                   DISTINCT CONCAT(
+                    'SELECT ''', mi.index_table_name,
+                    ''' AS index_table_name, COUNT(*) AS cnt FROM `',
+                    mi.index_table_name, '`'
+                            ) SEPARATOR ' UNION ALL '
+           )
+    FROM mo_catalog.mo_indexes mi
+             JOIN mo_catalog.mo_tables mt ON mi.table_id = mt.rel_id
+    WHERE mt.relname = 't1'
+      AND mt.reldatabase = 'db'
+      AND mi.type IN ('MULTIPLE', 'UNIQUE')
+      AND mi.index_table_name IS NOT NULL
+      AND mi.index_table_name != ''
+      AND mi.column_name <> 'question'
+      AND mi.column_name <> 'keyword'
+);
+
+SET @sql = CONCAT(
+        'SELECT * FROM (',
+        @inner_sql,
+        ') AS t ORDER BY cnt DESC'
+           );
+
+PREPARE stmt FROM @sql;
+-- @ignore:0
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+
+drop table t1;
+
+-- case 3
+
+create table t2 (id int primary key, a int, b int, c int, key(a), key(b));
+insert into t2 values(1,1,1,1);
+ALTER TABLE t2 MODIFY COLUMN c int DEFAULT NULL;
+
+SET @inner_sql = (
+    SELECT GROUP_CONCAT(
+                   DISTINCT CONCAT(
+                    'SELECT ''', mi.index_table_name,
+                    ''' AS index_table_name, COUNT(*) AS cnt FROM `',
+                    mi.index_table_name, '`'
+                            ) SEPARATOR ' UNION ALL '
+           )
+    FROM mo_catalog.mo_indexes mi
+             JOIN mo_catalog.mo_tables mt ON mi.table_id = mt.rel_id
+    WHERE mt.relname = 't2'
+      AND mt.reldatabase = 'db'
+      AND mi.type IN ('MULTIPLE', 'UNIQUE')
+      AND mi.index_table_name IS NOT NULL
+      AND mi.index_table_name != ''
+      AND mi.column_name <> 'question'
+      AND mi.column_name <> 'keyword'
+);
+
+SET @sql = CONCAT(
+        'SELECT * FROM (',
+        @inner_sql,
+        ') AS t ORDER BY cnt DESC'
+           );
+
+PREPARE stmt FROM @sql;
+-- @ignore:0
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+drop table t2;
+
+-- case 3
+
+create table t3 (
+    id bigint primary key,
+    delete_flag int,
+    a vecf32(3),
+    b vecf32(3),
+    body varchar(10),
+    title text,
+    FULLTEXT (title, body),
+    key(delete_flag),
+    key ivf using ivfflat (a),
+    key idx using hnsw(b) op_type 'vector_l2_ops'
+);
+
+insert into t3 values(1,1, '[0.1,0.2,0.3]','[0.1,0.2,0.3]', "body", "title");
+ALTER TABLE t3 MODIFY COLUMN delete_flag int DEFAULT NULL;
+
+SET @inner_sql = (
+    SELECT GROUP_CONCAT(
+                   DISTINCT CONCAT(
+                    'SELECT ''', mi.index_table_name,
+                    ''' AS index_table_name, COUNT(*) AS cnt FROM `',
+                    mi.index_table_name, '`'
+                            ) SEPARATOR ' UNION ALL '
+           )
+    FROM mo_catalog.mo_indexes mi
+             JOIN mo_catalog.mo_tables mt ON mi.table_id = mt.rel_id
+    WHERE mt.relname = 't3'
+      AND mt.reldatabase = 'db'
+      AND mi.type IN ('MULTIPLE', 'UNIQUE')
+      AND mi.index_table_name IS NOT NULL
+      AND mi.index_table_name != ''
+      AND mi.column_name <> 'question'
+      AND mi.column_name <> 'keyword'
+);
+
+SET @sql = CONCAT(
+        'SELECT * FROM (',
+        @inner_sql,
+        ') AS t ORDER BY cnt DESC'
+           );
+
+PREPARE stmt FROM @sql;
+-- @ignore:0
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+drop table t3;
+
+SET experimental_fulltext_index = 0;
+SET experimental_ivf_index = 0;
+SET experimental_hnsw_index = 0;
+
+drop database db;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/23258

## What this PR does / why we need it:
Fixing the ALTER TABLE with a full-text index will cause index data duplication.


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent index data duplication during ALTER TABLE operations

- Skip inserting into indexes marked for cloning in copy operations

- Add `skipIndexesCopy` parameter to track indexes being cloned

- Add comprehensive test cases for ALTER TABLE with various index types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ALTER TABLE Operation"] --> B["Check skipIndexesCopy Map"]
  B --> C["Skip Insert for Cloned Indexes"]
  C --> D["Prevent Data Duplication"]
  E["AlterCopyOpt"] --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build_dml_util.go</strong><dd><code>Add index cloning skip logic to prevent duplication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_dml_util.go

<ul><li>Added <code>skipIndexesCoyp</code> variable to track indexes being cloned during <br>ALTER TABLE<br> <li> Extract <code>SkipIndexesCopy</code> from <code>AlterCopyOpt</code> context when available<br> <li> Added logic to skip insert operations for indexes marked in <br><code>skipIndexesCopy</code> map<br> <li> Updated function signature of <code>buildInsertPlansWithRelatedHiddenTable</code> <br>to accept <code>skipIndexesCopy</code> parameter<br> <li> Updated all callers to pass the new <code>skipIndexesCopy</code> parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23260/files#diff-095fb233d51021791cb24454839b013236680bbc6bbc22e0d2f6741ac8fe7dff">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clone_in_alter_table_2.sql</strong><dd><code>Add test cases for ALTER TABLE index cloning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/snapshot/clone/clone_in_alter_table_2.sql

<ul><li>New test file with comprehensive test cases for ALTER TABLE with <br>various index types<br> <li> Test case 1: FULLTEXT index with primary table and secondary key<br> <li> Test case 2: FULLTEXT index with multiple secondary keys<br> <li> Test case 3: Complex scenario with FULLTEXT, IVFFLAT, and HNSW vector <br>indexes<br> <li> Validates index table row counts to ensure no data duplication occurs</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23260/files#diff-9c0c4513a70440bc95029f784a8b0cdc2fd63e654594507b43bfb36ce04cdac1">+163/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>clone_in_alter_table_2.result</strong><dd><code>Add expected test results for ALTER TABLE</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/snapshot/clone/clone_in_alter_table_2.result

<ul><li>Expected output results for the new test cases<br> <li> Validates correct row counts in index tables after ALTER TABLE <br>operations<br> <li> Confirms no data duplication in FULLTEXT, secondary, IVFFLAT, and HNSW <br>indexes</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23260/files#diff-1c31cb9ccba87c68106869dbc154f5ac8f1a11056ad6a428071bc12c69fee79d">+149/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

