### PR TITLE
metric: improve metrics

### DIFF
--- a/pkg/cdc/reader_v2_txn_manager.go
+++ b/pkg/cdc/reader_v2_txn_manager.go
@@ -99,6 +99,21 @@ func (tm *TransactionManager) BeginTransaction(ctx context.Context, fromTs, toTs
 		}
 	}
 
+	// If tracker exists and is already rolled back
+	if tm.tracker != nil && tm.tracker.IsCompleted() {
+		existingFromTs := tm.tracker.GetFromTs()
+		existingToTs := tm.tracker.GetToTs()
+		if existingFromTs.Equal(&fromTs) && existingToTs.Equal(&toTs) {
+			// Same data range, already rolled back - this should not happen in normal flow
+			// as processTailDone should check IsCompleted() before calling BeginTransaction
+			// But if it does happen, clear tracker to allow retry
+			tm.tracker = nil
+		} else {
+			// Different data range - clear old tracker
+			tm.tracker = nil
+		}
+	}
+
 	// Create new tracker
 	tm.tracker = NewTransactionTracker(fromTs, toTs)
 
@@ -293,11 +308,19 @@ func (tm *TransactionManager) RollbackTransaction(ctx context.Context) error {
 		// Mark as rolled back even if it failed
 		// to avoid infinite retry loops
 		tm.tracker.MarkRollback()
+		// Keep tracker to ensure EnsureCleanup is idempotent
+		// BeginTransaction will clear it when starting a new transaction
 		return err
 	}
 
 	// Mark tracker as rolled back
 	tm.tracker.MarkRollback()
+
+	// Keep tracker instead of setting to nil
+	// Reason: This ensures EnsureCleanup is idempotent - if called again,
+	// it will see hasRolledBack == true and won't trigger another rollback.
+	// BeginTransaction will clear the tracker when starting a new transaction
+	// (either for retry of same data or new data range).
 
 	logutil.Debug(
 		"cdc.txn_manager.rollback_success",
@@ -444,11 +467,19 @@ func (tm *TransactionManager) rollbackLocked(ctx context.Context) error {
 		// Mark as rolled back even if it failed
 		// to avoid infinite retry loops
 		tm.tracker.MarkRollback()
+		// Keep tracker to ensure EnsureCleanup is idempotent
+		// BeginTransaction will clear it when starting a new transaction
 		return err
 	}
 
 	// Mark tracker as rolled back
 	tm.tracker.MarkRollback()
+
+	// Keep tracker instead of setting to nil
+	// Reason: This ensures EnsureCleanup is idempotent - if called again,
+	// it will see hasRolledBack == true and won't trigger another rollback.
+	// BeginTransaction will clear the tracker when starting a new transaction
+	// (either for retry of same data or new data range).
 
 	logutil.Debug(
 		"cdc.txn_manager.rollback_success",

--- a/pkg/cdc/reader_v2_txn_manager.go
+++ b/pkg/cdc/reader_v2_txn_manager.go
@@ -227,6 +227,11 @@ func (tm *TransactionManager) CommitTransaction(ctx context.Context) error {
 		zap.String("to-ts", toTs.ToString()),
 	)
 
+	// Step 4: Clean up tracker to allow next transaction to begin
+	// This is critical: without cleanup, processTailDone will see tracker.hasBegin == true
+	// and won't call BeginTransaction again
+	tm.tracker = nil
+
 	return nil
 }
 

--- a/pkg/cdc/reader_v2_txn_manager_test.go
+++ b/pkg/cdc/reader_v2_txn_manager_test.go
@@ -358,9 +358,8 @@ func TestTransactionManager_CommitTransaction(t *testing.T) {
 	assert.True(t, sinker.commitCalled)
 	assert.True(t, sinker.dummyCalled)
 	assert.True(t, updater.updateCalled)
-	assert.True(t, tm.tracker.hasCommitted)
-	assert.True(t, tm.tracker.IsWatermarkUpdated())
-	assert.False(t, tm.tracker.NeedsRollback())
+	// Note: tracker is set to nil after successful commit, so we can't check its state
+	// The commit success is verified by checking external effects (sinker, watermark)
 
 	// Verify watermark was updated
 	wm, err := updater.GetFromCache(ctx, tm.watermarkKey)

--- a/pkg/cdc/sinker_v2_handlers_insert_delete_test.go
+++ b/pkg/cdc/sinker_v2_handlers_insert_delete_test.go
@@ -1,0 +1,749 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper to create a standard table definition with id and name columns
+func createStandardTableDef() *plan.TableDef {
+	return &plan.TableDef{
+		Name: "test",
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			{Name: "name", Typ: plan.Type{Id: int32(types.T_varchar)}},
+		},
+		Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+		Name2ColIndex: map[string]int32{"id": 0, "name": 1},
+	}
+}
+
+// Helper to create a table definition with only id column
+func createSimpleTableDef() *plan.TableDef {
+	return &plan.TableDef{
+		Name: "test",
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+		},
+		Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+		Name2ColIndex: map[string]int32{"id": 0},
+	}
+}
+
+// Helper function to create a test batch with PK, name, and TS columns
+// Batch structure: [id, name, ts] - matches tableDef (id, name) + ts for AtomicBatch
+// Note: BuildInsertSQL expects columns matching tableDef.Cols (excluding internal columns)
+// BuildInsertSQL will extract first len(b.insertColTypes) columns, which is [id, name]
+// AtomicBatch.Append uses tsColIdx=2, pkColIdx=0
+func createTestBatchForAtomicBatch(t *testing.T, mp *mpool.MPool, ts types.TS, ids []int32) *batch.Batch {
+	t.Helper()
+	bat := batch.NewWithSize(3)
+	idVec := vector.NewVec(types.T_int32.ToType())
+	nameVec := vector.NewVec(types.T_varchar.ToType())
+	tsVec := vector.NewVec(types.T_TS.ToType())
+
+	for _, id := range ids {
+		require.NoError(t, vector.AppendFixed(idVec, id, false, mp))
+		name := []byte("test")
+		require.NoError(t, vector.AppendBytes(nameVec, name, false, mp))
+		require.NoError(t, vector.AppendFixed(tsVec, ts, false, mp))
+	}
+
+	bat.Vecs[0] = idVec   // PK column (index 0) - matches tableDef.Cols[0]
+	bat.Vecs[1] = nameVec // name column (index 1) - matches tableDef.Cols[1]
+	bat.Vecs[2] = tsVec   // TS column (index 2) - used by AtomicBatch.Append
+	bat.SetRowCount(len(ids))
+	return bat
+}
+
+// Helper function to create an AtomicBatch with test data
+func createAtomicBatchWithData(t *testing.T, mp *mpool.MPool, ts types.TS, ids []int32) *AtomicBatch {
+	t.Helper()
+	atmBatch := NewAtomicBatch(mp)
+	packer := types.NewPacker()
+	defer packer.Close()
+
+	bat := createTestBatchForAtomicBatch(t, mp, ts, ids)
+	// Append to atomic batch: tsColIdx=2, pkColIdx=0
+	atmBatch.Append(packer, bat, 2, 0)
+	return atmBatch
+}
+
+// Helper to create a sinker with mock executor and builder
+// Returns sinker, db, and mock for test setup
+func createSinkerForInsertDeleteTest(t *testing.T) (*mysqlSinker2, *sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	executor := &Executor{
+		conn:          db,
+		retryTimes:    0, // No retry for deterministic tests
+		retryDuration: 1 * time.Second,
+	}
+
+	tableDef := &plan.TableDef{
+		Name: "test",
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			{Name: "name", Typ: plan.Type{Id: int32(types.T_varchar)}},
+		},
+		Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+		Name2ColIndex: map[string]int32{"id": 0, "name": 1},
+	}
+
+	builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+	require.NoError(t, err)
+
+	sinker := NewMysqlSinker2(
+		executor,
+		1,
+		"task-1",
+		&DbTableInfo{SourceDbName: "src", SourceTblName: "test", SinkDbName: "test_db", SinkTblName: "test"},
+		nil,
+		builder,
+		NewCdcActiveRoutine(),
+	)
+
+	return sinker, db, mock
+}
+
+// Helper to create a sinker with custom table definition
+func createSinkerWithTableDef(t *testing.T, tableDef *plan.TableDef, maxSQLSize int) (*mysqlSinker2, *sql.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	executor := &Executor{
+		conn:          db,
+		retryTimes:    0, // No retry for deterministic tests
+		retryDuration: 1 * time.Second,
+	}
+
+	builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, uint64(maxSQLSize), false)
+	require.NoError(t, err)
+
+	sinker := NewMysqlSinker2(
+		executor,
+		1,
+		"task-1",
+		&DbTableInfo{SourceDbName: "src", SourceTblName: "test", SinkDbName: "test_db", SinkTblName: "test"},
+		nil,
+		builder,
+		NewCdcActiveRoutine(),
+	)
+
+	return sinker, db, mock
+}
+
+// TestHandleInsertDeleteBatch_Comprehensive tests handleInsertDeleteBatch with all possible scenarios
+func TestHandleInsertDeleteBatch_Comprehensive(t *testing.T) {
+	ctx := context.Background()
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	require.NoError(t, err)
+	defer mpool.DeleteMPool(mp)
+
+	t.Run("Success_InsertOnly", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		// Create AtomicBatch with insert data
+		// Note: Batch structure must match tableDef: [id, name, ts]
+		// BuildInsertSQL will extract [id, name] (first len(b.insertColTypes) columns)
+		insertBatch := NewAtomicBatch(mp)
+		packer := types.NewPacker()
+		defer packer.Close()
+
+		// Create batch matching tableDef structure: [id, name, ts]
+		bat := batch.NewWithSize(3)
+		idVec := vector.NewVec(types.T_int32.ToType())
+		nameVec := vector.NewVec(types.T_varchar.ToType())
+		tsVec := vector.NewVec(types.T_TS.ToType())
+
+		// Add 2 rows
+		for i := 1; i <= 2; i++ {
+			require.NoError(t, vector.AppendFixed(idVec, int32(i), false, mp))
+			require.NoError(t, vector.AppendBytes(nameVec, []byte("test"), false, mp))
+			require.NoError(t, vector.AppendFixed(tsVec, types.BuildTS(100, 0), false, mp))
+		}
+
+		bat.Vecs[0] = idVec
+		bat.Vecs[1] = nameVec
+		bat.Vecs[2] = tsVec
+		bat.SetRowCount(2)
+
+		// Append to atomic batch: tsColIdx=2, pkColIdx=0
+		insertBatch.Append(packer, bat, 2, 0)
+
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, nil, fromTs, toTs)
+
+		// Expect SQL execution (BuildInsertSQL generates SQL for each batch in AtomicBatch)
+		// Since AtomicBatch contains one batch with 2 rows, expect one SQL execution
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(2, 2))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+		// Verify batch was closed
+		assert.Nil(t, insertBatch.Rows)
+	})
+
+	t.Run("Success_DeleteOnly", func(t *testing.T) {
+		tableDef := createSimpleTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		// Create AtomicBatch with delete data
+		deleteBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1, 2})
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(nil, deleteBatch, fromTs, toTs)
+
+		// Expect DELETE SQL execution
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(0, 2))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+		// Verify batch was closed
+		assert.Nil(t, deleteBatch.Rows)
+	})
+
+	t.Run("Success_InsertAndDelete", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		// Create both insert and delete batches
+		insertBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1, 2})
+		deleteBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{3, 4})
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, deleteBatch, fromTs, toTs)
+
+		// Expect INSERT SQL first, then DELETE SQL
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(2, 2))
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(0, 2))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+		// Verify batches were closed
+		assert.Nil(t, insertBatch.Rows)
+		assert.Nil(t, deleteBatch.Rows)
+	})
+
+	t.Run("Success_EmptyInsertBatch", func(t *testing.T) {
+		tableDef := createSimpleTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		// Create empty AtomicBatch
+		insertBatch := NewAtomicBatch(mp)
+		deleteBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1})
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, deleteBatch, fromTs, toTs)
+
+		// Only DELETE SQL should be executed (insert batch is empty)
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Success_EmptyDeleteBatch", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		// Create empty delete batch
+		insertBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1})
+		deleteBatch := NewAtomicBatch(mp)
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, deleteBatch, fromTs, toTs)
+
+		// Only INSERT SQL should be executed (delete batch is empty, so no DELETE SQL)
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Success_BothEmpty", func(t *testing.T) {
+		sinker, db, mock := createSinkerForInsertDeleteTest(t)
+		defer db.Close()
+
+		// Both batches empty
+		insertBatch := NewAtomicBatch(mp)
+		deleteBatch := NewAtomicBatch(mp)
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, deleteBatch, fromTs, toTs)
+
+		// No SQL should be executed
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Success_MultipleBatchesInInsert", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		// Create AtomicBatch with multiple source batches
+		insertBatch := NewAtomicBatch(mp)
+		packer := types.NewPacker()
+		defer packer.Close()
+
+		// Add first batch
+		bat1 := createTestBatchForAtomicBatch(t, mp, types.BuildTS(100, 0), []int32{1})
+		insertBatch.Append(packer, bat1, 2, 0) // tsColIdx=2, pkColIdx=0
+
+		// Add second batch
+		bat2 := createTestBatchForAtomicBatch(t, mp, types.BuildTS(100, 0), []int32{2})
+		insertBatch.Append(packer, bat2, 2, 0) // tsColIdx=2, pkColIdx=0
+
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, nil, fromTs, toTs)
+
+		// Expect SQL for each batch
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	// Note: SkipNilBatch test removed because:
+	// 1. AtomicBatch.Close() will panic if Batches contains nil (it calls oneBat.Clean())
+	// 2. In real scenarios, Batches should never contain nil (Append doesn't add nil)
+	// 3. The nil check in handleInsertDeleteBatch (if srcBatch == nil) is tested indirectly
+	//    through other test cases that verify the loop correctly skips empty batches
+
+	t.Run("Success_SkipEmptyBatch", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		// Create AtomicBatch with empty batch
+		insertBatch := NewAtomicBatch(mp)
+		packer := types.NewPacker()
+		defer packer.Close()
+
+		// Add valid batch
+		bat1 := createTestBatchForAtomicBatch(t, mp, types.BuildTS(100, 0), []int32{1})
+		insertBatch.Append(packer, bat1, 2, 0) // tsColIdx=2, pkColIdx=0
+
+		// Add empty batch (must have same structure: [id, name, ts])
+		emptyBat := batch.NewWithSize(3)
+		emptyBat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+		emptyBat.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+		emptyBat.Vecs[2] = vector.NewVec(types.T_TS.ToType())
+		emptyBat.SetRowCount(0)
+		insertBatch.Append(packer, emptyBat, 2, 0) // tsColIdx=2, pkColIdx=0
+
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, nil, fromTs, toTs)
+
+		// Only one SQL should be executed (empty batch is skipped)
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	// Note: BuildInsertSQL failure is hard to test with valid data structure
+	// The builder is robust and handles most edge cases internally.
+	// We focus on ExecSQL failures which are more common in real scenarios.
+
+	t.Run("Error_ExecInsertSQLFailure", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		insertBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1})
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, nil, fromTs, toTs)
+
+		// ExecSQL fails (with retryTimes=0, no retry, so only one expectation needed)
+		execErr := moerr.NewInternalErrorNoCtx("exec failed")
+		mock.ExpectExec("fakeSql").WillReturnError(execErr)
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exec failed")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Error_ExecDeleteSQLFailure", func(t *testing.T) {
+		tableDef := createSimpleTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		deleteBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1})
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(nil, deleteBatch, fromTs, toTs)
+
+		// ExecSQL fails
+		execErr := moerr.NewInternalErrorNoCtx("delete exec failed")
+		mock.ExpectExec("fakeSql").WillReturnError(execErr)
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "delete exec failed")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Success_WithProgressTracker", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		// Attach progress tracker
+		progressTracker := NewProgressTracker(1, "task-1", "src", "test")
+		sinker.AttachProgressTracker(progressTracker)
+
+		insertBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1, 2})
+		deleteBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{3})
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, deleteBatch, fromTs, toTs)
+
+		// Expect SQL executions
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(2, 2))
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+		// Verify metrics were recorded (via progressTracker)
+	})
+
+	t.Run("Success_WithDuplicates", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		// Create AtomicBatch with duplicates
+		insertBatch := NewAtomicBatch(mp)
+		packer := types.NewPacker()
+		defer packer.Close()
+
+		// Add same batch twice (will create duplicates)
+		bat1 := createTestBatchForAtomicBatch(t, mp, types.BuildTS(100, 0), []int32{1})
+		insertBatch.Append(packer, bat1, 2, 0)                                          // tsColIdx=2, pkColIdx=0
+		bat2 := createTestBatchForAtomicBatch(t, mp, types.BuildTS(100, 0), []int32{1}) // Same PK
+		insertBatch.Append(packer, bat2, 2, 0)                                          // tsColIdx=2, pkColIdx=0
+
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, nil, fromTs, toTs)
+
+		// Expect SQL execution (duplicates are deduplicated, so only one row)
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Check duplicate tracking before Close() (Close() resets duplicateRows to 0)
+		duplicateCount := insertBatch.DuplicateRows()
+		assert.Greater(t, duplicateCount, 0, "should have duplicates")
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+		// Note: After Close(), duplicateRows is reset to 0, so we checked before
+	})
+
+	t.Run("Success_SlowSQL_Warning", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		insertBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1})
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, nil, fromTs, toTs)
+
+		// Mock SQL execution
+		// Note: sqlmock doesn't support delaying execution, so we can't test the slow warning
+		// But we can verify the code path exists and executes successfully
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Success_MultipleSQLStatements", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		// Use small maxSQLSize to force multiple SQL statements
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 100) // Very small limit
+		defer db.Close()
+
+		// Create batch with multiple rows
+		insertBatch := NewAtomicBatch(mp)
+		packer := types.NewPacker()
+		defer packer.Close()
+
+		bat := createTestBatchForAtomicBatch(t, mp, types.BuildTS(100, 0), []int32{1, 2, 3, 4, 5})
+		insertBatch.Append(packer, bat, 2, 0) // tsColIdx=2, pkColIdx=0
+
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, nil, fromTs, toTs)
+
+		// Expect multiple SQL executions (due to size limit)
+		// With 5 rows and small maxSQLSize (200 bytes), should generate multiple SQLs
+		// Each row generates ~30-40 bytes, so 5 rows might fit in 1-2 SQLs depending on overhead
+		// Use flexible expectations - allow up to 5 SQLs (sqlmock will match as many as needed)
+		for i := 0; i < 5; i++ {
+			mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+		}
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		// Should succeed even with multiple SQL statements
+		assert.NoError(t, err)
+		// Note: sqlmock will match only the SQLs that were actually executed
+		// If fewer SQLs were generated, the remaining expectations will be unmatched
+		// We can't easily verify exact count, but we verify it doesn't error
+	})
+
+	// Note: BuildDeleteSQL failure is hard to test with valid data structure
+	// The builder is robust and handles most edge cases internally.
+	// We focus on ExecSQL failures which are more common in real scenarios.
+
+	t.Run("Success_InsertThenDeleteOrder", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		insertBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1})
+		deleteBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{2})
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, deleteBatch, fromTs, toTs)
+
+		// Verify order: INSERT first, then DELETE
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		// Verify expectations were met in order (INSERT before DELETE)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+// TestHandleInsertDeleteBatch_EdgeCases tests edge cases and boundary conditions
+func TestHandleInsertDeleteBatch_EdgeCases(t *testing.T) {
+	ctx := context.Background()
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	require.NoError(t, err)
+	defer mpool.DeleteMPool(mp)
+
+	t.Run("NilInsertBatch", func(t *testing.T) {
+		tableDef := createSimpleTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		deleteBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1})
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(nil, deleteBatch, fromTs, toTs)
+
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(0, 1))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("NilDeleteBatch", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		insertBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), []int32{1})
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, nil, fromTs, toTs)
+
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("BothNilBatches", func(t *testing.T) {
+		sinker, db, mock := createSinkerForInsertDeleteTest(t)
+		defer db.Close()
+
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(nil, nil, fromTs, toTs)
+
+		// No SQL should be executed
+		err := sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("LargeBatch", func(t *testing.T) {
+		tableDef := createStandardTableDef()
+		sinker, db, mock := createSinkerWithTableDef(t, tableDef, 1024*1024)
+		defer db.Close()
+
+		// Create batch with many rows
+		ids := make([]int32, 100)
+		for i := range ids {
+			ids[i] = int32(i + 1)
+		}
+		insertBatch := createAtomicBatchWithData(t, mp, types.BuildTS(100, 0), ids)
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, nil, fromTs, toTs)
+
+		// Expect SQL execution (may be split into multiple SQLs due to size limits)
+		// Allow up to 5 SQLs to be flexible
+		for i := 0; i < 5; i++ {
+			mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(100, 100))
+		}
+
+		err = sinker.handleInsertDeleteBatch(ctx, cmd)
+
+		assert.NoError(t, err)
+		// Note: May have multiple SQLs due to size limits, but should not error
+	})
+}
+
+// BenchmarkHandleInsertDeleteBatch benchmarks handleInsertDeleteBatch performance
+func BenchmarkHandleInsertDeleteBatch(b *testing.B) {
+	ctx := context.Background()
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	if err != nil {
+		b.Fatalf("Failed to create mpool: %v", err)
+	}
+	defer mpool.DeleteMPool(mp)
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		b.Fatalf("Failed to create mock: %v", err)
+	}
+	defer db.Close()
+
+	executor := &Executor{
+		conn:          db,
+		retryTimes:    0,
+		retryDuration: 1 * time.Second,
+	}
+
+	tableDef := &plan.TableDef{
+		Name: "test",
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			{Name: "name", Typ: plan.Type{Id: int32(types.T_varchar)}},
+		},
+		Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+		Name2ColIndex: map[string]int32{"id": 0, "name": 1},
+	}
+
+	builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+	if err != nil {
+		b.Fatalf("Failed to create builder: %v", err)
+	}
+
+	sinker := NewMysqlSinker2(
+		executor,
+		1,
+		"task-1",
+		&DbTableInfo{SourceDbName: "src", SourceTblName: "test", SinkDbName: "test_db", SinkTblName: "test"},
+		nil,
+		builder,
+		NewCdcActiveRoutine(),
+	)
+
+	fromTs := types.BuildTS(100, 0)
+	toTs := types.BuildTS(200, 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Create batch for each iteration
+		insertBatch := NewAtomicBatch(mp)
+		packer := types.NewPacker()
+		bat := batch.NewWithSize(3)
+		idVec := vector.NewVec(types.T_int32.ToType())
+		nameVec := vector.NewVec(types.T_varchar.ToType())
+		tsVec := vector.NewVec(types.T_TS.ToType())
+		vector.AppendFixed(idVec, int32(1), false, mp)
+		vector.AppendBytes(nameVec, []byte("test"), false, mp)
+		vector.AppendFixed(tsVec, types.BuildTS(100, 0), false, mp)
+		bat.Vecs[0] = idVec
+		bat.Vecs[1] = nameVec
+		bat.Vecs[2] = tsVec
+		bat.SetRowCount(1)
+		insertBatch.Append(packer, bat, 2, 0)
+		packer.Close()
+
+		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
+		cmd := NewInsertDeleteBatchCommand(insertBatch, nil, fromTs, toTs)
+		_ = sinker.handleInsertDeleteBatch(ctx, cmd)
+	}
+}

--- a/pkg/cdc/sinker_v2_handlers_test.go
+++ b/pkg/cdc/sinker_v2_handlers_test.go
@@ -1,0 +1,1104 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleBegin_Comprehensive tests handleBegin with all possible scenarios
+func TestHandleBegin_Comprehensive(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success_FromIdle", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Verify initial state
+		require.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+
+		// Begin transaction
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+
+		// Verify success
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Idempotent_AlreadyActive", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// First BEGIN
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+
+		// Second BEGIN (idempotent - should succeed without calling BeginTx again)
+		// Note: Executor.BeginTx will return error "transaction already active"
+		// but handleBegin treats this as idempotent and returns success
+		err = sinker.handleBegin(ctx)
+
+		// Should succeed (idempotent behavior)
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("ResetFromCommitted_ThenBegin", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin and commit first transaction
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+
+		mock.ExpectCommit()
+		err = sinker.handleCommit(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+
+		// Now BEGIN from COMMITTED state (should reset to IDLE and begin)
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("ResetFromRolledBack_ThenBegin", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin and rollback first transaction
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+
+		mock.ExpectRollback()
+		err = sinker.handleRollback(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+
+		// Now BEGIN from ROLLED_BACK state (should reset to IDLE and begin)
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("BeginTxFailure", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// BeginTx fails
+		beginErr := moerr.NewInternalErrorNoCtx("connection lost")
+		mock.ExpectBegin().WillReturnError(beginErr)
+		err = sinker.handleBegin(ctx)
+
+		// Should return error, state remains IDLE
+		assert.Error(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+// TestHandleCommit_Comprehensive tests handleCommit with all possible scenarios
+func TestHandleCommit_Comprehensive(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success_FromActive", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin transaction first
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+
+		// Commit transaction
+		mock.ExpectCommit()
+		err = sinker.handleCommit(ctx)
+
+		// Verify success and state transition: ACTIVE -> COMMITTED -> IDLE
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Idempotent_FromIdle", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Commit from IDLE state (idempotent)
+		err = sinker.handleCommit(ctx)
+
+		// Should succeed (idempotent), state remains IDLE
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		// No database calls expected (idempotent)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Idempotent_FromCommitted", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin and commit first transaction
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+
+		mock.ExpectCommit()
+		err = sinker.handleCommit(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+
+		// Commit again from IDLE (idempotent)
+		err = sinker.handleCommit(ctx)
+
+		// Should succeed (idempotent), state remains IDLE
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Idempotent_FromRolledBack", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin and rollback first transaction
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+
+		mock.ExpectRollback()
+		err = sinker.handleRollback(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+
+		// Commit from IDLE (idempotent)
+		err = sinker.handleCommit(ctx)
+
+		// Should succeed (idempotent), state remains IDLE
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("CommitTxFailure", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin transaction first
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+
+		// CommitTx fails
+		commitErr := moerr.NewInternalErrorNoCtx("commit failed")
+		mock.ExpectCommit().WillReturnError(commitErr)
+		err = sinker.handleCommit(ctx)
+
+		// Should return error, state transitions: ACTIVE -> ROLLED_BACK
+		// Note: On commit failure, state is set to ROLLED_BACK but NOT to IDLE
+		// This is different from successful commit which goes ACTIVE -> COMMITTED -> IDLE
+		assert.Error(t, err)
+		assert.Equal(t, v2TxnStateRolledBack, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("StateTransition_ActiveToCommittedToIdle", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+
+		// Commit - verify intermediate COMMITTED state (if we could check it)
+		// Note: The state transitions ACTIVE -> COMMITTED -> IDLE happen atomically
+		mock.ExpectCommit()
+		err = sinker.handleCommit(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+// TestHandleRollback_Comprehensive tests handleRollback with all possible scenarios
+func TestHandleRollback_Comprehensive(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success_FromActive", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin transaction first
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+
+		// Rollback transaction
+		mock.ExpectRollback()
+		err = sinker.handleRollback(ctx)
+
+		// Verify success and state transition: ACTIVE -> ROLLED_BACK -> IDLE
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Idempotent_FromIdle", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Rollback from IDLE state (idempotent)
+		err = sinker.handleRollback(ctx)
+
+		// Should succeed (idempotent), state remains IDLE
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		// No database calls expected (idempotent)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Idempotent_FromCommitted", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin and commit first transaction
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+
+		mock.ExpectCommit()
+		err = sinker.handleCommit(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+
+		// Rollback from IDLE (idempotent)
+		err = sinker.handleRollback(ctx)
+
+		// Should succeed (idempotent), state remains IDLE
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("Idempotent_FromRolledBack", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin and rollback first transaction
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+
+		mock.ExpectRollback()
+		err = sinker.handleRollback(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+
+		// Rollback again from IDLE (idempotent)
+		err = sinker.handleRollback(ctx)
+
+		// Should succeed (idempotent), state remains IDLE
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("RollbackTxFailure", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin transaction first
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		require.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+
+		// RollbackTx fails
+		rollbackErr := moerr.NewInternalErrorNoCtx("rollback failed")
+		mock.ExpectRollback().WillReturnError(rollbackErr)
+		err = sinker.handleRollback(ctx)
+
+		// Should return error, state transitions: ACTIVE -> ROLLED_BACK -> IDLE
+		assert.Error(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("StateTransition_ActiveToRolledBackToIdle", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Begin
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+
+		// Rollback - verify intermediate ROLLED_BACK state (if we could check it)
+		// Note: The state transitions ACTIVE -> ROLLED_BACK -> IDLE happen atomically
+		mock.ExpectRollback()
+		err = sinker.handleRollback(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+// TestTransactionLifecycle_RealWorldScenarios tests realistic transaction lifecycle patterns
+func TestTransactionLifecycle_RealWorldScenarios(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("NormalTransactionFlow", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Normal flow: BEGIN -> COMMIT
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+
+		mock.ExpectCommit()
+		err = sinker.handleCommit(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("ErrorRecoveryFlow", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Error recovery flow: BEGIN -> COMMIT fails -> ROLLBACK -> BEGIN (retry)
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+
+		// Commit fails
+		mock.ExpectCommit().WillReturnError(moerr.NewInternalErrorNoCtx("commit failed"))
+		err = sinker.handleCommit(ctx)
+		assert.Error(t, err)
+		// On commit failure, state is set to ROLLED_BACK (not IDLE)
+		assert.Equal(t, v2TxnStateRolledBack, sinker.GetTxnState())
+
+		// Rollback from ROLLED_BACK state (idempotent - returns immediately without DB call)
+		err = sinker.handleRollback(ctx)
+		assert.NoError(t, err)
+		// Rollback from non-ACTIVE state is idempotent, state remains ROLLED_BACK
+		assert.Equal(t, v2TxnStateRolledBack, sinker.GetTxnState())
+
+		// Retry: Begin again (handleBegin will reset ROLLED_BACK to IDLE, then begin)
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, v2TxnStateActive, sinker.GetTxnState())
+
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("MultipleTransactions", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// First transaction
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		mock.ExpectCommit()
+		err = sinker.handleCommit(ctx)
+		require.NoError(t, err)
+
+		// Second transaction
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		mock.ExpectRollback()
+		err = sinker.handleRollback(ctx)
+		require.NoError(t, err)
+
+		// Third transaction
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+		mock.ExpectCommit()
+		err = sinker.handleCommit(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("IdempotentOperations", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		executor := &Executor{conn: db}
+		tableDef := &plan.TableDef{
+			Name: "test",
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+			Name2ColIndex: map[string]int32{"id": 0},
+		}
+		builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+		require.NoError(t, err)
+
+		sinker := NewMysqlSinker2(
+			executor,
+			1,
+			"task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil,
+			builder,
+			NewCdcActiveRoutine(),
+		)
+
+		// Multiple idempotent commits (no active transaction)
+		err = sinker.handleCommit(ctx)
+		assert.NoError(t, err)
+		err = sinker.handleCommit(ctx)
+		assert.NoError(t, err)
+		err = sinker.handleCommit(ctx)
+		assert.NoError(t, err)
+
+		// Multiple idempotent rollbacks (no active transaction)
+		err = sinker.handleRollback(ctx)
+		assert.NoError(t, err)
+		err = sinker.handleRollback(ctx)
+		assert.NoError(t, err)
+
+		// Begin
+		mock.ExpectBegin()
+		err = sinker.handleBegin(ctx)
+		require.NoError(t, err)
+
+		// Multiple idempotent begins (already active)
+		err = sinker.handleBegin(ctx)
+		assert.NoError(t, err)
+		err = sinker.handleBegin(ctx)
+		assert.NoError(t, err)
+
+		// Commit
+		mock.ExpectCommit()
+		err = sinker.handleCommit(ctx)
+		require.NoError(t, err)
+
+		// Multiple idempotent commits again
+		err = sinker.handleCommit(ctx)
+		assert.NoError(t, err)
+		err = sinker.handleCommit(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, v2TxnStateIdle, sinker.GetTxnState())
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+// BenchmarkHandleBegin benchmarks handleBegin performance
+func BenchmarkHandleBegin(b *testing.B) {
+	ctx := context.Background()
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	executor := &Executor{conn: db}
+	tableDef := &plan.TableDef{
+		Name: "test",
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+		},
+		Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+		Name2ColIndex: map[string]int32{"id": 0},
+	}
+	builder, _ := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+	sinker := NewMysqlSinker2(
+		executor,
+		1,
+		"task-1",
+		&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+		nil,
+		builder,
+		NewCdcActiveRoutine(),
+	)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mock.ExpectBegin()
+		mock.ExpectCommit()
+		_ = sinker.handleBegin(ctx)
+		_ = sinker.handleCommit(ctx)
+	}
+}
+
+// BenchmarkHandleCommit benchmarks handleCommit performance
+func BenchmarkHandleCommit(b *testing.B) {
+	ctx := context.Background()
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	executor := &Executor{conn: db}
+	tableDef := &plan.TableDef{
+		Name: "test",
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+		},
+		Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+		Name2ColIndex: map[string]int32{"id": 0},
+	}
+	builder, _ := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+	sinker := NewMysqlSinker2(
+		executor,
+		1,
+		"task-1",
+		&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+		nil,
+		builder,
+		NewCdcActiveRoutine(),
+	)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mock.ExpectBegin()
+		mock.ExpectCommit()
+		_ = sinker.handleBegin(ctx)
+		_ = sinker.handleCommit(ctx)
+	}
+}
+
+// BenchmarkHandleRollback benchmarks handleRollback performance
+func BenchmarkHandleRollback(b *testing.B) {
+	ctx := context.Background()
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+
+	executor := &Executor{conn: db}
+	tableDef := &plan.TableDef{
+		Name: "test",
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+		},
+		Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+		Name2ColIndex: map[string]int32{"id": 0},
+	}
+	builder, _ := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+	sinker := NewMysqlSinker2(
+		executor,
+		1,
+		"task-1",
+		&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+		nil,
+		builder,
+		NewCdcActiveRoutine(),
+	)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mock.ExpectBegin()
+		mock.ExpectRollback()
+		_ = sinker.handleBegin(ctx)
+		_ = sinker.handleRollback(ctx)
+	}
+}

--- a/pkg/cdc/table_change_stream.go
+++ b/pkg/cdc/table_change_stream.go
@@ -578,6 +578,13 @@ func (s *TableChangeStream) cleanup(ctx context.Context) {
 	)
 	defer s.wg.Done()
 	defer func() {
+		// Decrement table stream state gauge on cleanup
+		if s.progressTracker != nil {
+			state, _ := s.progressTracker.GetState()
+			if state != "" {
+				v2.CdcTableStreamTotalGauge.WithLabelValues(state).Dec()
+			}
+		}
 		logutil.Debug(
 			"cdc.table_stream.cleanup_done",
 			zap.String("table", s.tableInfo.String()),

--- a/pkg/cdc/table_change_stream_test.go
+++ b/pkg/cdc/table_change_stream_test.go
@@ -1549,7 +1549,7 @@ func TestTableChangeStream_RollbackFailure(t *testing.T) {
 	var runErr error
 	select {
 	case runErr = <-errCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("table change stream run did not complete")
 	}
 
@@ -1660,11 +1660,18 @@ func TestTableChangeStream_FullPipeline_RandomDelaysAndErrors(t *testing.T) {
 	errCh, done := h.RunStreamAsync(ar)
 
 	// Wait for stale read recovery (multiple collect calls)
+	// Use longer timeout for slow CI environments, but keep frequent checks
+	// Stale read recovery may involve retry backoff: base=5ms, max=20ms, factor=2.0, maxRetries=3
+	// Worst case delay per retry cycle: ~35ms, plus processing time
 	require.Eventually(t, func() bool {
 		return collectCalls.Load() >= 2
-	}, 2*time.Second, 10*time.Millisecond, "should see stale read recovery")
+	}, 10*time.Second, 10*time.Millisecond, "should see stale read recovery")
 
 	// Wait for commit attempt (which will fail)
+	// Use longer timeout for slow CI environments, but keep frequent checks
+	// Calculate worst-case retry delay: base=5ms, max=20ms, factor=2.0, maxRetries=3
+	// Worst case: 5ms + 10ms + 20ms = 35ms per retry cycle, plus processing time
+	// Use 10s timeout to handle multiple retry cycles and slow CI environments
 	require.Eventually(t, func() bool {
 		ops := h.Sinker().opsSnapshot()
 		for _, op := range ops {
@@ -1673,15 +1680,23 @@ func TestTableChangeStream_FullPipeline_RandomDelaysAndErrors(t *testing.T) {
 			}
 		}
 		return false
-	}, 2*time.Second, 10*time.Millisecond, "should see commit attempt")
+	}, 10*time.Second, 10*time.Millisecond, "should see commit attempt")
 
-	// Clear commit error and inject rollback failure, then clear it
+	// Keep commit error and inject rollback failure (rollback happens during cleanup after commit failure)
+	// To eliminate race condition: set rollback error immediately after confirming commit attempt,
+	// then add a small synchronization delay to ensure the error is set in sinker before cleanup rollback happens.
+	// This reduces the race window to near zero.
 	rollbackErr := moerr.NewInternalError(h.Context(), "rollback failure")
-	h.Sinker().setCommitError(nil)
 	h.Sinker().setRollbackError(rollbackErr)
 	rollbackFailInjected.Store(true)
+	// Small synchronization delay to ensure rollback error is set before cleanup rollback happens
+	// This eliminates the race condition where rollback might occur before error is set.
+	// 50ms is sufficient for error injection to propagate, even in slow environments.
+	time.Sleep(50 * time.Millisecond)
 
-	// Wait for rollback attempt (which will fail)
+	// Wait for rollback attempt (which will fail during cleanup after commit failure)
+	// Use longer timeout for slow CI environments, but keep frequent checks
+	// Rollback happens during EnsureCleanup after commit failure, which may have retry delays
 	require.Eventually(t, func() bool {
 		ops := h.Sinker().opsSnapshot()
 		for _, op := range ops {
@@ -1690,25 +1705,50 @@ func TestTableChangeStream_FullPipeline_RandomDelaysAndErrors(t *testing.T) {
 			}
 		}
 		return false
-	}, 2*time.Second, 10*time.Millisecond, "should see rollback attempt")
+	}, 10*time.Second, 10*time.Millisecond, "should see rollback attempt")
+
+	// Verify that rollback failure marks stream as non-retryable (system state may be inconsistent)
+	// This is the core behavior: rollback failure indicates system state may be inconsistent,
+	// so the stream should not be retryable even if the original error (commit failure) is retryable
+	// Use longer timeout for slow CI environments to ensure state propagation, but keep frequent checks
+	// State propagation may take time due to retry backoff and processing delays
+	// To make the check more stable and reduce flakiness, we verify the state is stable by checking
+	// multiple consecutive times. This ensures the state has settled after recovery path + backoff + scheduling.
+	// The state must remain non-retryable for 3 consecutive checks (30ms total) to be considered stable.
+	var stableCount int
+	const requiredStableChecks = 3 // Require 3 consecutive checks to ensure state is stable
+	require.Eventually(t, func() bool {
+		isNonRetryable := !h.Stream().GetRetryable()
+		if isNonRetryable {
+			stableCount++
+			if stableCount >= requiredStableChecks {
+				return true
+			}
+		} else {
+			// State changed or not yet stable, reset counter
+			stableCount = 0
+		}
+		return false
+	}, 10*time.Second, 10*time.Millisecond, "stream should be non-retryable after rollback failure (with stable state check)")
 
 	// Clear rollback error so stream can remain retryable after rollback failure is verified
+	// Note: The test verifies that rollback failure marks stream as non-retryable.
+	// After clearing the rollback error, the next round will succeed (rollback will succeed),
+	// and cleanupRollbackErr will not be set, so the stream will become retryable again.
+	// However, this depends on other factors (e.g., no other errors), so we don't assert it here.
+	// The core behavior (rollback failure -> non-retryable) is already verified above.
 	h.Sinker().setRollbackError(nil)
-
-	// Verify that we've seen the expected error scenarios
-	// The stream should be retryable and have attempted rollback
-	require.Eventually(t, func() bool {
-		return h.Stream().GetRetryable()
-	}, 500*time.Millisecond, 10*time.Millisecond, "stream should be retryable after stale read and commit failure")
 
 	// Cancel to exit
 	h.Cancel()
 	done()
 
 	var runErr error
+	// Use longer timeout for resource cleanup in slow CI environments
+	// Cleanup may involve rollback operations and state synchronization
 	select {
 	case runErr = <-errCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("stream did not exit after cancellation")
 	}
 	// The stream may return either the commit failure error or context.Canceled
@@ -1750,7 +1790,11 @@ func TestTableChangeStream_FullPipeline_RandomDelaysAndErrors(t *testing.T) {
 	require.GreaterOrEqual(t, beginCount, 1, "should have at least one begin")
 
 	// Verify consistency: retryable flag and sinker reset
-	require.True(t, h.Stream().GetRetryable(), "stream should be retryable after stale read recovery")
+	// Note: After rollback failure, stream is marked as non-retryable (system state may be inconsistent).
+	// If rollback error was cleared and next round succeeded, stream should be retryable again.
+	// However, other factors (e.g., watermark mismatch) may also affect retryability.
+	// The core behavior (rollback failure -> non-retryable) is verified earlier in the test.
+	// Here we just verify that the stream has processed the scenarios (stale read, commit failure, rollback failure).
 	require.GreaterOrEqual(t, h.Sinker().ResetCountSnapshot(), 1, "sinker should reset at least once for stale read")
 
 	// Verify all error injections occurred

--- a/pkg/cdc/types.go
+++ b/pkg/cdc/types.go
@@ -357,6 +357,9 @@ func (row AtomicBatchRow) Less(other AtomicBatchRow) bool {
 }
 
 func (bat *AtomicBatch) RowCount() int {
+	if bat == nil || bat.Rows == nil {
+		return 0
+	}
 	unique := bat.Rows.Len()
 	if bat.duplicateRows > 0 && !bat.duplicateLogged {
 		logutil.Warn("cdc.atomic_batch.dedup",

--- a/pkg/cdc/types.go
+++ b/pkg/cdc/types.go
@@ -357,8 +357,11 @@ func (row AtomicBatchRow) Less(other AtomicBatchRow) bool {
 }
 
 func (bat *AtomicBatch) RowCount() int {
-	if bat == nil || bat.Rows == nil {
+	if bat == nil {
 		return 0
+	}
+	if bat.Rows == nil {
+		panic("RowCount() called on closed AtomicBatch (Fail Fast)")
 	}
 	unique := bat.Rows.Len()
 	if bat.duplicateRows > 0 && !bat.duplicateLogged {

--- a/pkg/cdc/watermark_updater.go
+++ b/pkg/cdc/watermark_updater.go
@@ -934,6 +934,13 @@ func (u *CDCWatermarkUpdater) UpdateWatermarkErrMsg(
 		delete(u.errorMetadataCache, *key)
 		u.Unlock()
 
+		// Clear metric when error is cleared
+		tableLabel := key.String()
+		errorTypes := []string{"network", "commit", "table_relation", "sinker", "max_retry_exceeded", "unknown"}
+		for _, et := range errorTypes {
+			v2.CdcTableNonRetryableErrorGauge.WithLabelValues(tableLabel, et).Set(0)
+		}
+
 		job := NewUpdateWMErrMsgJob(ctx, key, "")
 		if _, err = u.queue.Enqueue(job); err != nil {
 			if errors.Is(err, sm.ErrClose) {
@@ -1019,6 +1026,21 @@ func (u *CDCWatermarkUpdater) UpdateWatermarkErrMsg(
 		newMetadata.IsRetryable = false
 		newMetadata.Message = fmt.Sprintf("max retry exceeded (%d): %s",
 			newMetadata.RetryCount, newMetadata.Message)
+	}
+
+	// 6.5. Update metric if non-retryable error
+	if !newMetadata.IsRetryable {
+		tableLabel := key.String()
+		errorType := extractErrorType(newMetadata.Message)
+		v2.CdcTableNonRetryableErrorGauge.WithLabelValues(tableLabel, errorType).Set(1)
+	} else {
+		// Clear metric for retryable errors (they may become non-retryable later)
+		// Reset all possible error_type labels for this table
+		tableLabel := key.String()
+		errorTypes := []string{"network", "commit", "table_relation", "sinker", "max_retry_exceeded", "unknown"}
+		for _, et := range errorTypes {
+			v2.CdcTableNonRetryableErrorGauge.WithLabelValues(tableLabel, et).Set(0)
+		}
 	}
 
 	// 7. Update memory cache (like UpdateWatermarkOnly - no SQL)
@@ -1378,6 +1400,9 @@ func (u *CDCWatermarkUpdater) wrapCronJob(job func(ctx context.Context)) func(ct
 				zap.Int("committed-watermarks", committedCount),
 				zap.Float64("skip-ratio", float64(u.stats.skipTimes.Load())/float64(u.stats.runTimes.Load())),
 			)
+
+			// Scan all tables with errors and update non-retryable error metrics
+			u.scanAndUpdateNonRetryableErrorMetrics(ctx)
 		}
 		u.stats.runTimes.Add(1)
 		job(ctx)
@@ -1390,6 +1415,131 @@ func (u *CDCWatermarkUpdater) scheduleJob(job *UpdaterJob) (err error) {
 		return
 	}
 	return
+}
+
+// extractErrorType extracts error type from error message for metric labels
+// This is a simplified version that extracts common error patterns
+func extractErrorType(errMsg string) string {
+	if errMsg == "" {
+		return "none"
+	}
+
+	// Network/system errors
+	if strings.Contains(errMsg, "connection") ||
+		strings.Contains(errMsg, "timeout") ||
+		strings.Contains(errMsg, "network") ||
+		strings.Contains(errMsg, "unavailable") ||
+		strings.Contains(errMsg, "rpc") ||
+		strings.Contains(errMsg, "backend") {
+		return "network"
+	}
+
+	// Commit errors
+	if strings.Contains(errMsg, "commit") {
+		return "commit"
+	}
+
+	// Table relation errors
+	if strings.Contains(errMsg, "relation") ||
+		strings.Contains(errMsg, "truncated") ||
+		strings.Contains(errMsg, "table not found") ||
+		strings.Contains(errMsg, "table") {
+		return "table_relation"
+	}
+
+	// Sinker errors
+	if strings.Contains(errMsg, "sinker") {
+		return "sinker"
+	}
+
+	// Max retry exceeded
+	if strings.Contains(errMsg, "max retry exceeded") {
+		return "max_retry_exceeded"
+	}
+
+	// Default category
+	return "unknown"
+}
+
+// scanAndUpdateNonRetryableErrorMetrics scans all tables with errors from database
+// and updates non-retryable error metrics
+func (u *CDCWatermarkUpdater) scanAndUpdateNonRetryableErrorMetrics(ctx context.Context) {
+	// Query all watermarks with err_msg != ''
+	// Use System_Account context for querying
+	queryCtx := defines.AttachAccountId(ctx, catalog.System_Account)
+	projection := "account_id, task_id, db_name, table_name, err_msg"
+	whereClause := "err_msg != ''"
+	sql := CDCSQLBuilder.GetWatermarkWhereSQL(projection, whereClause)
+
+	res := u.ie.Query(queryCtx, sql, ie.SessionOverrideOptions{})
+	if res.Error() != nil {
+		logutil.Warn(
+			"cdc.watermark.scan_errors_failed",
+			zap.Error(res.Error()),
+		)
+		return
+	}
+
+	// Track all tables we've seen to reset metrics for tables that no longer have errors
+	seenTables := make(map[string]bool)
+	nonRetryableCount := 0
+
+	// Process each row
+	for i := uint64(0); i < res.RowCount(); i++ {
+		accountId, err := res.GetUint64(queryCtx, i, 0)
+		if err != nil {
+			logutil.Warn(
+				"cdc.watermark.scan_errors_get_account_id_failed",
+				zap.Error(err),
+				zap.Uint64("row", i),
+			)
+			continue
+		}
+		taskId, _ := res.GetString(queryCtx, i, 1)
+		dbName, _ := res.GetString(queryCtx, i, 2)
+		tableName, _ := res.GetString(queryCtx, i, 3)
+		errMsg, _ := res.GetString(queryCtx, i, 4)
+
+		if errMsg == "" {
+			continue
+		}
+
+		// Build table label: account_id.task_id.db_name.table_name (format matches WatermarkKey.String())
+		tableLabel := fmt.Sprintf("%d.%s.%s.%s", accountId, taskId, dbName, tableName)
+		seenTables[tableLabel] = true
+
+		// Parse error metadata
+		metadata := ParseErrorMetadata(errMsg)
+		if metadata == nil {
+			continue
+		}
+
+		// Check if non-retryable (ShouldRetry returns false)
+		if !ShouldRetry(metadata) {
+			// Extract error type from message
+			errorType := extractErrorType(metadata.Message)
+			// Set metric to 1 (has non-retryable error)
+			v2.CdcTableNonRetryableErrorGauge.WithLabelValues(tableLabel, errorType).Set(1)
+			nonRetryableCount++
+		} else {
+			// Retryable error or no error - set to 0
+			// We need to reset all possible error_type labels for this table
+			// Since we don't know which error_type was previously set, we'll reset common ones
+			errorTypes := []string{"network", "commit", "table_relation", "sinker", "max_retry_exceeded", "unknown"}
+			for _, et := range errorTypes {
+				v2.CdcTableNonRetryableErrorGauge.WithLabelValues(tableLabel, et).Set(0)
+			}
+		}
+	}
+
+	// Update total count
+	v2.CdcTableNonRetryableErrorTotalGauge.Set(float64(nonRetryableCount))
+
+	logutil.Debug(
+		"cdc.watermark.scan_errors_complete",
+		zap.Int("total-tables-with-errors", int(res.RowCount())),
+		zap.Int("non-retryable-count", nonRetryableCount),
+	)
 }
 
 // cronRun is the periodic job that moves watermarks from cacheUncommitted to database.

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -29,7 +29,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	commonutil "github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/defines"
-	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	pbpipeline "github.com/matrixorigin/matrixone/pkg/pb/pipeline"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -621,18 +620,20 @@ func (s *Scope) getRelData(c *Compile, blockExprList []*plan.Expr) error {
 		return err
 	}
 
-	average := float64(s.DataSource.node.Stats.BlockNum / s.NodeInfo.CNCNT)
-	if commited.DataCnt() < int(average*0.8) ||
-		commited.DataCnt() > int(average*1.2) {
-		logutil.Warnf(
-			"workload table %v maybe not balanced! stats blocks %v, cncnt %v cnidx %v average %v , get %v blocks",
-			s.DataSource.TableDef.Name,
-			s.DataSource.node.Stats.BlockNum,
-			s.NodeInfo.CNCNT,
-			s.NodeInfo.CNIDX,
-			average,
-			commited.DataCnt())
-	}
+	// TODO: the below warning is not useful, we should replace it with a more useful warning.
+	//       temporarily disable it.
+	// average := float64(s.DataSource.node.Stats.BlockNum / s.NodeInfo.CNCNT)
+	// if commited.DataCnt() < int(average*0.8) ||
+	// 	commited.DataCnt() > int(average*1.2) {
+	// 	logutil.Warnf(
+	// 		"workload table %v maybe not balanced! stats blocks %v, cncnt %v cnidx %v average %v , get %v blocks",
+	// 		s.DataSource.TableDef.Name,
+	// 		s.DataSource.node.Stats.BlockNum,
+	// 		s.NodeInfo.CNCNT,
+	// 		s.NodeInfo.CNIDX,
+	// 		average,
+	// 		commited.DataCnt())
+	// }
 
 	//collect uncommited data if it's local cn
 	if !s.IsRemote {

--- a/pkg/util/metric/v2/cdc_metrics.go
+++ b/pkg/util/metric/v2/cdc_metrics.go
@@ -335,6 +335,26 @@ var (
 			Name:      "table_snapshot_no_progress_total",
 			Help:      "Number of times a table round observed snapshot timestamp not advancing",
 		}, []string{"table"})
+
+	// CdcTableNonRetryableErrorGauge tracks tables with non-retryable errors
+	// Value: 1 = has non-retryable error, 0 = no error or error cleared
+	// Labels: table (account_id.task_id.db_name.table_name), error_type (extracted from error message)
+	CdcTableNonRetryableErrorGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "mo",
+			Subsystem: "cdc",
+			Name:      "table_non_retryable_error",
+			Help:      "Tables with non-retryable errors (1=has error, 0=no error)",
+		}, []string{"table", "error_type"})
+
+	// CdcTableNonRetryableErrorTotalGauge tracks total count of tables with non-retryable errors
+	CdcTableNonRetryableErrorTotalGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "mo",
+			Subsystem: "cdc",
+			Name:      "table_non_retryable_error_total",
+			Help:      "Total number of tables with non-retryable errors",
+		})
 )
 
 // CDC Initial Sync Metrics
@@ -473,6 +493,8 @@ func initCDCMetrics() {
 	registry.MustRegister(CdcTableStuckGauge)
 	registry.MustRegister(CdcTableLastActivityTimestamp)
 	registry.MustRegister(CdcTableNoProgressCounter)
+	registry.MustRegister(CdcTableNonRetryableErrorGauge)
+	registry.MustRegister(CdcTableNonRetryableErrorTotalGauge)
 
 	// Initial sync metrics
 	registry.MustRegister(CdcInitialSyncStatusGauge)

--- a/pkg/util/metric/v2/cdc_metrics.go
+++ b/pkg/util/metric/v2/cdc_metrics.go
@@ -149,13 +149,16 @@ var (
 
 // CDC Watermark Metrics
 var (
-	// CdcWatermarkUpdateCounter tracks watermark updates
+	// CdcWatermarkUpdateCounter tracks watermark updates to memory cache
+	// This counts calls to UpdateWatermarkOnly(), which buffers watermarks in memory.
+	// Watermarks are persisted to database in batches every 3 seconds (not per call).
+	// Note: This is NOT the database commit count - use CdcWatermarkCommitBatchCounter for that.
 	CdcWatermarkUpdateCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "mo",
 			Subsystem: "cdc",
 			Name:      "watermark_update_total",
-			Help:      "Total number of watermark updates",
+			Help:      "Total number of watermark updates to memory cache (buffered, not yet persisted to database)",
 		}, []string{"table", "update_type"}) // update_type: commit, heartbeat
 
 	// CdcWatermarkLagSeconds tracks watermark lag (current time - watermark time)
@@ -168,33 +171,54 @@ var (
 		}, []string{"table"})
 
 	// CdcWatermarkLagRatio tracks the ratio of actual lag to expected lag
-	// Value < 2: normal, 2-5: warning, > 5: critical
+	// Baseline: 3 seconds (realistic for batch processing delays and network latency)
+	// Value < 2: normal (lag < 6s), 2-5: warning (lag 6-15s), > 5: critical (lag > 15s)
 	// This metric is frequency-agnostic and suitable for unified alerting
 	CdcWatermarkLagRatio = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "mo",
 			Subsystem: "cdc",
 			Name:      "watermark_lag_ratio",
-			Help:      "Ratio of actual watermark lag to expected lag (based on task frequency)",
+			Help:      "Ratio of actual watermark lag to expected lag (baseline: 3s, normal < 2, warning 2-5, critical > 5)",
 		}, []string{"table"})
 
+	// CdcWatermarkCommitBatchCounter tracks actual database commit batches
+	// This counts successful batch commits to the database (one batch per execBatchUpdateWM() call).
+	// Each batch may contain multiple watermark keys. Batches occur every ~3 seconds via cronJob.
+	CdcWatermarkCommitBatchCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "cdc",
+			Name:      "watermark_commit_batch_total",
+			Help:      "Total number of batch commits to database (each batch may contain multiple watermark keys)",
+		})
+
 	// CdcWatermarkCommitDuration tracks watermark commit duration
+	// This measures the time to execute the batch UPDATE SQL statement that persists
+	// watermarks from cacheCommitting to the database (mo_cdc_watermark table).
+	// This is the actual database transaction duration.
 	CdcWatermarkCommitDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "mo",
 			Subsystem: "cdc",
 			Name:      "watermark_commit_duration_seconds",
-			Help:      "Duration of watermark commit to database",
+			Help:      "Duration of batch UPDATE SQL execution to persist watermarks to database (database transaction duration)",
 			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 15), // 0.1ms to 1.6s
 		})
 
 	// CdcWatermarkCacheGauge tracks watermark cache sizes
+	// Three-tier cache architecture:
+	// - uncommitted: Watermarks buffered in memory by UpdateWatermarkOnly(), not yet persisted
+	// - committing: Watermarks being persisted to database (transitional state during batch commit)
+	// - committed: Watermarks successfully persisted to database (synced with mo_cdc_watermark table)
+	// Note: Each watermark key (account_id.task_id.db_name.table_name) appears once per tier.
+	// Normally uncommitted > 0 while watermarks are buffered, and committed contains all persisted keys.
 	CdcWatermarkCacheGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "mo",
 			Subsystem: "cdc",
 			Name:      "watermark_cache_size",
-			Help:      "Number of watermarks in each cache tier",
+			Help:      "Number of watermarks in each cache tier (uncommitted: buffered in memory, committing: being persisted, committed: persisted to database)",
 		}, []string{"tier"}) // tier: uncommitted, committing, committed
 
 	// CdcWatermarkCommitErrorCounter tracks commit failures by reason
@@ -428,6 +452,7 @@ func initCDCMetrics() {
 
 	// Watermark metrics
 	registry.MustRegister(CdcWatermarkUpdateCounter)
+	registry.MustRegister(CdcWatermarkCommitBatchCounter)
 	registry.MustRegister(CdcWatermarkLagSeconds)
 	registry.MustRegister(CdcWatermarkLagRatio)
 	registry.MustRegister(CdcWatermarkCommitDuration)

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_frontend.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_frontend.go
@@ -36,8 +36,7 @@ func (c *DashboardCreator) initFrontendDashboard() error {
 			c.initFrontendCreateAccount(),
 			c.initFrontendPubSubDuration(),
 			c.initFrontendSQLLength(),
-			c.initFrontendCdc(),
-			c.initFrontendCdcDuration(),
+			// Note: CDC metrics moved to CDC dashboard
 		)...)
 	if err != nil {
 		return err
@@ -215,77 +214,4 @@ func (c *DashboardCreator) initFrontendSQLLength() dashboard.Option {
 	)
 }
 
-func (c *DashboardCreator) initFrontendCdc() dashboard.Option {
-	return dashboard.Row(
-		"Cdc Overview",
-
-		c.withMultiGraph(
-			"Record Count",
-			3,
-			[]string{
-				`sum(rate(` + c.getMetricWithFilter("mo_frontend_cdc_record_count", `type="read"`) + `[$interval]))`,
-				`sum(rate(` + c.getMetricWithFilter("mo_frontend_cdc_record_count", `type="sink"`) + `[$interval]))`,
-			},
-			[]string{
-				"read",
-				"sink",
-			}),
-
-		c.withMultiGraph(
-			"Error Count",
-			3,
-			[]string{
-				`sum(rate(` + c.getMetricWithFilter("mo_frontend_cdc_error_count", `type="mysql-conn"`) + `[$interval]))`,
-				`sum(rate(` + c.getMetricWithFilter("mo_frontend_cdc_error_count", `type="mysql-sink"`) + `[$interval]))`,
-			},
-			[]string{
-				"mysql-conn",
-				"mysql-sink",
-			}),
-
-		c.withMultiGraph(
-			"Processing Record Count",
-			3,
-			[]string{
-				`sum(` + c.getMetricWithFilter("mo_frontend_cdc_processing_record_count", `type="total"`) + `)`,
-			},
-			[]string{
-				"total",
-			}),
-
-		c.withMultiGraph(
-			"Memory",
-			3,
-			[]string{
-				`sum(` + c.getMetricWithFilter("mo_frontend_cdc_memory", `type="hold-changes"`) + `)`,
-				`sum(` + c.getMetricWithFilter("mo_frontend_cdc_memory", `type="mpool-inuse"`) + `)`,
-			},
-			[]string{
-				"hold-changes",
-				"mpool-inuse",
-			}),
-	)
-}
-
-func (c *DashboardCreator) initFrontendCdcDuration() dashboard.Option {
-	return dashboard.Row(
-		"Cdc Duration",
-		c.getMultiHistogram(
-			[]string{
-				c.getMetricWithFilter(`mo_frontend_cdc_duration_bucket`, `type="read"`),
-				c.getMetricWithFilter(`mo_frontend_cdc_duration_bucket`, `type="append"`),
-				c.getMetricWithFilter(`mo_frontend_cdc_duration_bucket`, `type="sink"`),
-				c.getMetricWithFilter(`mo_frontend_cdc_duration_bucket`, `type="send-sql"`),
-			},
-			[]string{
-				"read",
-				"append",
-				"sink",
-				"send-sql",
-			},
-			[]float64{0.50, 0.8, 0.90, 0.99},
-			[]float32{3, 3, 3, 3},
-			axis.Unit("s"),
-			axis.Min(0))...,
-	)
-}
+// Note: CDC metrics have been moved to CDC dashboard (initCDCDashboard)

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/K-Phoen/grabana/axis"
 	"github.com/K-Phoen/grabana/dashboard"
-	"github.com/K-Phoen/grabana/row"
 	"github.com/K-Phoen/grabana/timeseries"
 	tsaxis "github.com/K-Phoen/grabana/timeseries/axis"
 )
@@ -38,7 +37,6 @@ func (c *DashboardCreator) initTaskDashboard() error {
 			c.initTaskMergeRow(),
 			c.initTaskMergeTransferPageRow(),
 			c.initTaskCheckpointRow(),
-			c.initTaskSelectivityRow(),
 			c.initTaskStorageUsageRow(),
 			c.initMoTableStatsTaskDurationRow(),
 			c.initMoTableStatsTaskCountingRow(),
@@ -284,42 +282,6 @@ func (c *DashboardCreator) initTaskStorageUsageRow() dashboard.Option {
 		rows...,
 	)
 
-}
-
-func (c *DashboardCreator) initTaskSelectivityRow() dashboard.Option {
-
-	hitRateFunc := func(title, metricType, selectedLabel string) row.Option {
-		return c.getTimeSeries(
-			title,
-			[]string{
-				fmt.Sprintf(
-					"sum(%s) by (%s) / on(%s) sum(%s) by (%s)",
-					c.getMetricWithFilter(`mo_task_selectivity`, `type="`+selectedLabel+`"`), c.by, c.by,
-					c.getMetricWithFilter(`mo_task_selectivity`, `type="`+metricType+`_total"`), c.by),
-			},
-			[]string{fmt.Sprintf("selectivity-{{ %s }}", c.by)},
-			timeseries.Span(4),
-		)
-	}
-	counterRateFunc := func(title, metricType string) row.Option {
-		return c.getTimeSeries(
-			title,
-			[]string{
-				fmt.Sprintf(
-					"sum(rate(%s[$interval])) by (%s)",
-					c.getMetricWithFilter(`mo_task_selectivity`, `type="`+metricType+`_total"`), c.by),
-			},
-			[]string{fmt.Sprintf("req-{{ %s }}", c.by)},
-			timeseries.Span(4),
-		)
-	}
-	return dashboard.Row(
-		"Read Selectivity",
-		hitRateFunc("Read filter rate", "readfilter", "readfilter_hit"),
-		hitRateFunc("Column update filter rate", "column", "column_hit"),
-		counterRateFunc("Read filter request", "readfilter"),
-		counterRateFunc("Column update request", "column"),
-	)
 }
 
 func (c *DashboardCreator) initMoTableStatsTaskDurationRow() dashboard.Option {

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
@@ -288,16 +288,16 @@ func (c *DashboardCreator) initTaskStorageUsageRow() dashboard.Option {
 
 func (c *DashboardCreator) initTaskSelectivityRow() dashboard.Option {
 
-	hitRateFunc := func(title, metricType string) row.Option {
+	hitRateFunc := func(title, metricType, selectedLabel string) row.Option {
 		return c.getTimeSeries(
 			title,
 			[]string{
 				fmt.Sprintf(
 					"sum(%s) by (%s) / on(%s) sum(%s) by (%s)",
-					c.getMetricWithFilter(`mo_task_selectivity`, `type="`+metricType+`_hit"`), c.by, c.by,
+					c.getMetricWithFilter(`mo_task_selectivity`, `type="`+selectedLabel+`"`), c.by, c.by,
 					c.getMetricWithFilter(`mo_task_selectivity`, `type="`+metricType+`_total"`), c.by),
 			},
-			[]string{fmt.Sprintf("filterout-{{ %s }}", c.by)},
+			[]string{fmt.Sprintf("selectivity-{{ %s }}", c.by)},
 			timeseries.Span(4),
 		)
 	}
@@ -315,11 +315,9 @@ func (c *DashboardCreator) initTaskSelectivityRow() dashboard.Option {
 	}
 	return dashboard.Row(
 		"Read Selectivity",
-		hitRateFunc("Read filter rate", "readfilter"),
-		hitRateFunc("Block range filter rate", "block"),
-		hitRateFunc("Column update filter rate", "column"),
+		hitRateFunc("Read filter rate", "readfilter", "readfilter_hit"),
+		hitRateFunc("Column update filter rate", "column", "column_hit"),
 		counterRateFunc("Read filter request", "readfilter"),
-		counterRateFunc("Block range request", "block"),
 		counterRateFunc("Column update request", "column"),
 	)
 }

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
@@ -328,14 +328,6 @@ func (c *DashboardCreator) initTaskSelectivityRow() dashboard.Option {
 		counterRateFunc("Read filter request", "readfilter"),
 		counterRateFunc("Block range request", "block"),
 		counterRateFunc("Column update request", "column"),
-		c.getPercentHist(
-			"Iterate deletes rows count per block",
-			c.getMetricWithFilter(`mo_task_hist_total_bucket`, `type="load_mem_deletes_per_block"`),
-			[]float64{0.5, 0.7, 0.8, 0.9},
-			timeseries.Axis(tsaxis.Unit("")),
-			timeseries.Span(4),
-			SpanNulls(true),
-		),
 	)
 }
 

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_task.go
@@ -86,13 +86,6 @@ func (c *DashboardCreator) initTaskMergeTransferPageRow() dashboard.Option {
 			timeseries.Span(3),
 		),
 		c.getPercentHist(
-			"Transfer duration since born",
-			c.getMetricWithFilter(`mo_task_transfer_duration_bucket`, `type="page_since_born_duration"`),
-			[]float64{0.50, 0.8, 0.90, 0.99},
-			SpanNulls(true),
-			timeseries.Span(3),
-		),
-		c.getPercentHist(
 			"Transfer memory latency",
 			c.getMetricWithFilter(`mo_task_transfer_short_duration_bucket`, `type="mem_latency"`),
 			[]float64{0.50, 0.8, 0.90, 0.99},

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -78,8 +78,6 @@ func initTaskMetrics() {
 	registry.MustRegister(taskDNMergeStuffCounter)
 	registry.MustRegister(taskDNMergeDurationHistogram)
 
-	registry.MustRegister(taskSelectivityCounter)
-
 	registry.MustRegister(transferPageHitHistogram)
 	registry.MustRegister(TransferPageRowHistogram)
 	registry.MustRegister(TaskMergeTransferPageLengthGauge)
@@ -167,6 +165,8 @@ func initTxnMetrics() {
 	registry.MustRegister(txnTransferDurationHistogram)
 	registry.MustRegister(TransferTombstonesCountHistogram)
 	registry.MustRegister(TxnExtraWorkspaceQuotaGauge)
+	registry.MustRegister(txnSelectivityCounter)
+	registry.MustRegister(txnColumnReadHistogram)
 }
 
 func initRPCMetrics() {

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -74,8 +74,6 @@ func initMemMetrics() {
 func initTaskMetrics() {
 	registry.MustRegister(taskShortDurationHistogram)
 	registry.MustRegister(taskLongDurationHistogram)
-	registry.MustRegister(taskBytesHistogram)
-	registry.MustRegister(taskCountHistogram)
 
 	registry.MustRegister(taskDNMergeStuffCounter)
 	registry.MustRegister(taskDNMergeDurationHistogram)
@@ -124,7 +122,6 @@ func initLogtailMetrics() {
 	registry.MustRegister(logTailApplyDurationHistogram)
 	registry.MustRegister(logtailUpdatePartitionDurationHistogram)
 	registry.MustRegister(LogTailAppendDurationHistogram)
-	registry.MustRegister(logTailSendDurationHistogram)
 	registry.MustRegister(LogTailLoadCheckpointDurationHistogram)
 
 	registry.MustRegister(LogTailPushCollectionDurationHistogram)

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -165,7 +165,7 @@ func initTxnMetrics() {
 	registry.MustRegister(txnTransferDurationHistogram)
 	registry.MustRegister(TransferTombstonesCountHistogram)
 	registry.MustRegister(TxnExtraWorkspaceQuotaGauge)
-	registry.MustRegister(txnSelectivityCounter)
+	registry.MustRegister(txnSelectivityHistogram)
 	registry.MustRegister(txnColumnReadHistogram)
 }
 

--- a/pkg/util/metric/v2/task.go
+++ b/pkg/util/metric/v2/task.go
@@ -51,24 +51,6 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(1, 2.0, 13),
 		}, []string{"type"})
 
-	taskBytesHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "mo",
-			Subsystem: "task",
-			Name:      "hist_bytes",
-			Help:      "Bucketed histogram of task result bytes.",
-			Buckets:   prometheus.ExponentialBuckets(1, 2.0, 30),
-		}, []string{"type"})
-
-	taskCountHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "mo",
-			Subsystem: "task",
-			Name:      "hist_total",
-			Help:      "Bucketed histogram of task result count.",
-			Buckets:   prometheus.ExponentialBuckets(1, 2.0, 30),
-		}, []string{"type"})
-
 	TaskCkpEntryPendingDurationHistogram = taskLongDurationHistogram.WithLabelValues("ckp_entry_pending")
 )
 

--- a/pkg/util/metric/v2/task.go
+++ b/pkg/util/metric/v2/task.go
@@ -83,22 +83,6 @@ var (
 	TaskTombstoneMergeDurationHistogram       = taskDNMergeDurationHistogram.WithLabelValues("merge", "tombstone")
 )
 
-// selectivity metrics
-var (
-	taskSelectivityCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "mo",
-			Subsystem: "task",
-			Name:      "selectivity",
-			Help:      "Selectivity counter for read filter, block etc.",
-		}, []string{"type"})
-
-	TaskSelReadFilterTotal = taskSelectivityCounter.WithLabelValues("readfilter_total")
-	TaskSelReadFilterHit   = taskSelectivityCounter.WithLabelValues("readfilter_hit")
-	TaskSelColumnTotal     = taskSelectivityCounter.WithLabelValues("column_total")
-	TaskSelColumnHit       = taskSelectivityCounter.WithLabelValues("column_hit")
-)
-
 var (
 	TaskMergeTransferPageLengthGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{

--- a/pkg/util/metric/v2/task.go
+++ b/pkg/util/metric/v2/task.go
@@ -145,11 +145,10 @@ var (
 		Buckets:   getDurationBuckets(),
 	}, []string{"type"})
 
-	TransferDiskLatencyHistogram           = transferDurationHistogram.WithLabelValues("disk_latency")
-	TransferPageSinceBornDurationHistogram = transferDurationHistogram.WithLabelValues("page_since_born_duration")
-	TransferTableRunTTLDurationHistogram   = transferDurationHistogram.WithLabelValues("table_run_ttl_duration")
-	TransferPageFlushLatencyHistogram      = transferDurationHistogram.WithLabelValues("page_flush_latency")
-	TransferPageMergeLatencyHistogram      = transferDurationHistogram.WithLabelValues("page_merge_latency")
+	TransferDiskLatencyHistogram         = transferDurationHistogram.WithLabelValues("disk_latency")
+	TransferTableRunTTLDurationHistogram = transferDurationHistogram.WithLabelValues("table_run_ttl_duration")
+	TransferPageFlushLatencyHistogram    = transferDurationHistogram.WithLabelValues("page_flush_latency")
+	TransferPageMergeLatencyHistogram    = transferDurationHistogram.WithLabelValues("page_merge_latency")
 
 	transferShortDurationHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "mo",

--- a/pkg/util/metric/v2/task.go
+++ b/pkg/util/metric/v2/task.go
@@ -95,8 +95,6 @@ var (
 
 	TaskSelReadFilterTotal = taskSelectivityCounter.WithLabelValues("readfilter_total")
 	TaskSelReadFilterHit   = taskSelectivityCounter.WithLabelValues("readfilter_hit")
-	TaskSelBlockTotal      = taskSelectivityCounter.WithLabelValues("block_total")
-	TaskSelBlockHit        = taskSelectivityCounter.WithLabelValues("block_hit")
 	TaskSelColumnTotal     = taskSelectivityCounter.WithLabelValues("column_total")
 	TaskSelColumnHit       = taskSelectivityCounter.WithLabelValues("column_hit")
 )

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -418,3 +418,37 @@ var (
 			Help:      "Extra workspace quota for txn.",
 		})
 )
+
+// selectivity metrics for read filter and column
+var (
+	txnSelectivityCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "txn",
+			Name:      "selectivity",
+			Help:      "Selectivity counter for read filter and column.",
+		}, []string{"type"})
+
+	// Read filter metrics: track filter effectiveness
+	// Total: total number of filter operations
+	// Filtered: number of filters that filtered out all data (len(sels) == 0)
+	TxnSelReadFilterTotal    = txnSelectivityCounter.WithLabelValues("readfilter_total")
+	TxnSelReadFilterFiltered = txnSelectivityCounter.WithLabelValues("readfilter_filtered")
+)
+
+// Column read histogram metrics: track per-read column counts
+var (
+	txnColumnReadHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "mo",
+			Subsystem: "txn",
+			Name:      "column_read_count",
+			Help:      "Bucketed histogram of column read count per read operation.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2.0, 15),
+		}, []string{"type"})
+
+	// Column read count: number of columns actually read per operation
+	TxnColumnReadCountHistogram = txnColumnReadHistogram.WithLabelValues("read")
+	// Column total count: total number of columns in table per operation
+	TxnColumnTotalCountHistogram = txnColumnReadHistogram.WithLabelValues("total")
+)

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -421,19 +421,20 @@ var (
 
 // selectivity metrics for read filter and column
 var (
-	txnSelectivityCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	txnSelectivityHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Namespace: "mo",
 			Subsystem: "txn",
 			Name:      "selectivity",
-			Help:      "Selectivity counter for read filter and column.",
+			Help:      "Bucketed histogram of selectivity for read filter and column.",
+			Buckets:   prometheus.ExponentialBuckets(1, 2.0, 15),
 		}, []string{"type"})
 
 	// Read filter metrics: track filter effectiveness
-	// Total: total number of filter operations
-	// Filtered: number of filters that filtered out all data (len(sels) == 0)
-	TxnSelReadFilterTotal    = txnSelectivityCounter.WithLabelValues("readfilter_total")
-	TxnSelReadFilterFiltered = txnSelectivityCounter.WithLabelValues("readfilter_filtered")
+	// Total: total number of filter operations per read (observe 1.0 for each operation)
+	// Filtered: number of operations where all rows were filtered out (observe 1.0 when len(sels) == 0)
+	TxnSelReadFilterTotal    = txnSelectivityHistogram.WithLabelValues("readfilter_total")
+	TxnSelReadFilterFiltered = txnSelectivityHistogram.WithLabelValues("readfilter_filtered")
 )
 
 // Column read histogram metrics: track per-read column counts

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -723,11 +723,11 @@ func (tbl *txnTable) doRanges(ctx context.Context, rangesParam engine.RangesPara
 			slowStep = uint64(1)
 		}
 		tbl.enableLogFilterExpr.Store(false)
-		if traceFilterExprInterval.Add(step) >= 2000000 {
+		if traceFilterExprInterval.Add(step) >= 10000000 {
 			traceFilterExprInterval.Store(0)
 			tbl.enableLogFilterExpr.Store(true)
 		}
-		if traceFilterExprInterval2.Add(slowStep) >= 100 {
+		if traceFilterExprInterval2.Add(slowStep) >= 500 {
 			traceFilterExprInterval2.Store(0)
 			tbl.enableLogFilterExpr.Store(true)
 		}
@@ -741,7 +741,7 @@ func (tbl *txnTable) doRanges(ctx context.Context, rangesParam engine.RangesPara
 			tbl.enableLogFilterExpr.Load() ||
 			cost > 5*time.Second {
 			logutil.Info(
-				"TXN-FILTER-RANGE-LOG",
+				"txn.table.ranges.log",
 				zap.String("name", tbl.tableDef.Name),
 				zap.String("exprs", plan2.FormatExprs(
 					rangesParam.BlockFilters, plan2.FormatOption{

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1006,8 +1006,6 @@ func (tbl *txnTable) rangesOnePart(
 	}
 
 	bhit, btotal := outBlocks.Len()-1, int(s3BlkCnt)
-	v2.TaskSelBlockTotal.Add(float64(btotal))
-	v2.TaskSelBlockHit.Add(float64(btotal - bhit))
 	if btotal > 0 {
 		v2.TxnRangesSlowPathLoadObjCntHistogram.Observe(float64(loadObjCnt))
 		v2.TxnRangesSlowPathSelectedBlockCntHistogram.Observe(float64(bhit))

--- a/pkg/vm/engine/readutil/reader.go
+++ b/pkg/vm/engine/readutil/reader.go
@@ -98,9 +98,10 @@ func (mixin *withFilterMixin) tryUpdateColumns(cols []string) {
 
 	// record the column selectivity
 	chit, ctotal := len(cols), len(mixin.tableDef.Cols)
-	v2.TaskSelColumnTotal.Add(float64(ctotal))
+	// record per-read column counts for histogram metrics
 	if ctotal >= chit {
-		v2.TaskSelColumnHit.Add(float64(ctotal - chit))
+		v2.TxnColumnReadCountHistogram.Observe(float64(chit))
+		v2.TxnColumnTotalCountHistogram.Observe(float64(ctotal))
 	}
 
 	mixin.columns.seqnums = make([]uint16, len(cols))

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -251,12 +251,10 @@ func BlockDataRead(
 		); err != nil {
 			return err
 		}
-		v2.TxnSelReadFilterTotal.Inc()
-		if len(sels) == 0 {
-			v2.TxnSelReadFilterFiltered.Inc()
-		}
+		v2.TxnSelReadFilterTotal.Observe(1.0)
 
 		if len(sels) == 0 {
+			v2.TxnSelReadFilterFiltered.Observe(1.0)
 			return nil
 		}
 	}

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -251,9 +251,9 @@ func BlockDataRead(
 		); err != nil {
 			return err
 		}
-		v2.TaskSelReadFilterTotal.Inc()
+		v2.TxnSelReadFilterTotal.Inc()
 		if len(sels) == 0 {
-			v2.TaskSelReadFilterHit.Inc()
+			v2.TxnSelReadFilterFiltered.Inc()
 		}
 
 		if len(sels) == 0 {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23246 

## What this PR does / why we need it:

1. Improve cdc related metrics


___

### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive CDC metrics for observability and monitoring
  - Table stream state tracking with gauge metrics
  - Round execution metrics (duration, status counters)
  - End-to-end latency and watermark lag ratio tracking
  - Batch size distribution and rows/bytes processed counters

- Improve watermark tracking with three-tier cache architecture
  - Distinguish between memory updates and database commits
  - Add watermark commit batch counter and duration metrics
  - Track non-retryable errors with error type classification

- Enhance sinker transaction handling with idempotent operations
  - Add transaction state metrics (begin, commit, rollback)
  - Improve error handling and logging for transaction operations
  - Record insert/delete operation metrics in sinker

- Refactor Grafana dashboard with new CDC Overview row
  - Consolidate key metrics (throughput, latency, errors)
  - Add threshold-based alerting with color coding
  - Separate CDC metrics from Frontend dashboard

- Improve logging consistency across codebase
  - Standardize log message format to snake_case
  - Add log throttling for high-frequency messages
  - Reduce noise from verbose debug logs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CDC Progress Tracker"] -->|"state changes, rounds"| B["Metrics Collection"]
  C["Watermark Updater"] -->|"cache tiers, commits"| B
  D["MySQL Sinker"] -->|"transactions, operations"| B
  E["Table Stream"] -->|"state tracking"| B
  B -->|"Prometheus metrics"| F["Grafana Dashboard"]
  F -->|"Overview, Watermark, Processing"| G["Monitoring & Alerting"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>observability.go</strong><dd><code>Add table stream state and round metrics tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-40a4f83e75b852e82bbcd65f40ec15bd1cab69a7a33fd04e71f75953703079fd">+50/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sinker_v2.go</strong><dd><code>Add transaction metrics and improve error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-cd05d3ef88ae4714625a85a9e912bcfe8af5a798e9241984b6f0c483258683fc">+95/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>table_change_stream.go</strong><dd><code>Decrement table stream gauge on cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-cbff9e9c74e505ad0a56d6eb223441ef9608b6f55907fe6e8ff67a53849feed5">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>watermark_updater.go</strong><dd><code>Add watermark commit metrics and non-retryable error tracking</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-6ddc0418bfe4e98fcdce4dd6641f68d842776bb617096b2572b4f0adcb65ebd6">+174/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>scope.go</strong><dd><code>Disable unbalanced workload warning log</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+14/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cdc_metrics.go</strong><dd><code>Add new CDC metrics for comprehensive monitoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-cc734775f51adb05df3bc0cfddf695d6a864f2abab9716031dce77f060dc7e34">+53/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>grafana_dashboard_cdc.go</strong><dd><code>Redesign CDC dashboard with overview and thresholds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-7d7d0af4d278fc7f6a3816735f6731a8d7466dca46be9d137fb7e190e4331b7f">+252/-17</a></td>

</tr>

<tr>
  <td><strong>grafana_dashboard_frontend.go</strong><dd><code>Remove CDC metrics from frontend dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-fce8bbcf22021b940542ec6708984b50549cc5c9ccb9ce070123a78b0c169ba3">+2/-76</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>txn_table.go</strong><dd><code>Adjust filter expression logging thresholds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flusher.go</strong><dd><code>Standardize logging and add log throttling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-8b77364ba4bb7a1b1cfb6e85ddfabc827686c3c9b86fec4340ee595e12718a99">+73/-16</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>reader_v2_data_processor.go</strong><dd><code>Fix transaction state check and capture row counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-a6fd87d3b1285d584c8a08d72401a67d6efd5952d50746bcd3c0074dbaa77d6e">+14/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reader_v2_txn_manager.go</strong><dd><code>Clean up tracker after transaction commit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-b13493b9fa1170c06966ae92554198b85ded83632878dae9c60c8170f927cc4a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Add nil check for atomic batch row count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23276/files#diff-a0449bab279af3b2a18abad7a166ddd8f8bb677405e596f9bfca2bb041ae6e17">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

