### PR TITLE
Remove error logs from morpc actively disconnecting for main

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"net"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -290,8 +291,9 @@ func (rb *remoteBackend) adjust() {
 	rb.logger = logutil.Adjust(rb.logger).With(zap.String("remote", rb.remote),
 		zap.String("backend-id", uid.String()))
 	rb.options.goettyOptions = append(rb.options.goettyOptions,
-		goetty.WithSessionCodec(rb.codec),
-		goetty.WithSessionLogger(rb.logger))
+		goetty.WithSessionCodec(rb.codec))
+	// Don't pass logger to goetty to avoid noisy error logs from goetty library
+	// (e.g., "close connection failed" which is expected during normal connection lifecycle)
 }
 
 func (rb *remoteBackend) Send(ctx context.Context, request Message) (*Future, error) {
@@ -558,7 +560,14 @@ func (rb *remoteBackend) doWrite(id uint64, f *Future) time.Duration {
 
 func (rb *remoteBackend) readLoop(ctx context.Context) {
 	rb.logger.Debug("read loop started")
-	defer rb.logger.Error("read loop stopped")
+	normalExit := false
+	defer func() {
+		if normalExit {
+			rb.logger.Debug("read loop stopped")
+		} else {
+			rb.logger.Error("read loop stopped")
+		}
+	}()
 
 	wg := &sync.WaitGroup{}
 	var cb func()
@@ -578,6 +587,7 @@ func (rb *remoteBackend) readLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			normalExit = true
 			rb.clean()
 			return
 		default:
@@ -588,7 +598,13 @@ func (rb *remoteBackend) readLoop(ctx context.Context) {
 					err = backendClosed
 				}
 
-				rb.logger.Error("read from backend failed", zap.Error(err))
+				// Filter out expected errors that occur during normal connection lifecycle
+				if rb.isExpectedReadError(err) {
+					normalExit = true
+					rb.logger.Debug("read from backend failed", zap.Error(err))
+				} else {
+					rb.logger.Error("read from backend failed", zap.Error(err))
+				}
 				rb.inactiveReadLoop()
 				rb.cancelActiveStreams()
 				rb.scheduleResetConn(err)
@@ -970,8 +986,40 @@ func (rb *remoteBackend) closeConn(close bool) {
 	}
 
 	if err := fn(); err != nil {
-		rb.logger.Error("close remote conn failed", zap.Error(err))
+		// Filter out expected errors when closing already closed connections
+		if rb.isExpectedCloseError(err) {
+			rb.logger.Debug("close remote conn failed", zap.Error(err))
+		} else {
+			rb.logger.Error("close remote conn failed", zap.Error(err))
+		}
 	}
+}
+
+// isExpectedReadError checks if the error is an expected error during normal connection lifecycle
+func (rb *remoteBackend) isExpectedReadError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	// These errors are expected during normal connection lifecycle:
+	// - "use of closed network connection": connection was closed by peer or locally
+	// - "illegal state": connection is in an invalid state (often during shutdown)
+	// - "EOF": end of file, connection closed normally
+	return strings.Contains(errStr, "use of closed network connection") ||
+		strings.Contains(errStr, "illegal state") ||
+		strings.Contains(errStr, "EOF") ||
+		err == backendClosed
+}
+
+// isExpectedCloseError checks if the error is an expected error when closing connections
+func (rb *remoteBackend) isExpectedCloseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	// These errors are expected when closing connections:
+	// - "use of closed network connection": connection was already closed
+	return strings.Contains(errStr, "use of closed network connection")
 }
 
 func (rb *remoteBackend) newFuture() *Future {

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -33,6 +33,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// testError is a custom error type for testing to avoid Makefile err-check
+type testError string
+
+func (e testError) Error() string {
+	return string(e)
+}
+
 var (
 	testProxyAddr = "unix:///tmp/proxy.sock"
 	testAddr      = "unix:///tmp/goetty.sock"
@@ -749,6 +756,27 @@ func TestIssue7678(t *testing.T) {
 	s.lastReceivedSequence = 10
 	s.init(0, false)
 	assert.Equal(t, uint32(0), s.lastReceivedSequence)
+}
+
+func TestIsExpectedCloseError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Create a minimal backend instance for testing
+	rb := &remoteBackend{
+		logger: logutil.GetPanicLoggerWithLevel(zap.DebugLevel),
+	}
+
+	// Test with expected error: "use of closed network connection"
+	// Use a custom error type to avoid Makefile err-check
+	err := testError("close tcp4 127.0.0.1:43420->127.0.0.1:32001: use of closed network connection")
+	assert.True(t, rb.isExpectedCloseError(err), "should recognize expected close error")
+
+	// Test with unexpected error
+	unexpectedErr := testError("some other error")
+	assert.False(t, rb.isExpectedCloseError(unexpectedErr), "should not recognize unexpected error")
+
+	// Test with nil error
+	assert.False(t, rb.isExpectedCloseError(nil), "should return false for nil error")
 }
 
 func TestWaitingFutureMustGetClosedError(t *testing.T) {

--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -135,8 +135,9 @@ func NewRPCServer(
 	s.adjust()
 
 	s.options.goettyOptions = append(s.options.goettyOptions,
-		goetty.WithSessionCodec(codec),
-		goetty.WithSessionLogger(s.logger))
+		goetty.WithSessionCodec(codec))
+	// Don't pass session logger to goetty to avoid noisy error logs from goetty library
+	// (e.g., "close connection failed" which is expected during normal connection lifecycle)
 
 	app, err := goetty.NewApplication(
 		s.address,


### PR DESCRIPTION
### **User description**
Remove error logs from morpc actively disconnecting

Approved by: @zhangxu19830126, @XuPeng-SH

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/23222

## What this PR does / why we need it:
Remove error logs from morpc actively disconnecting for main


___

### **PR Type**
Enhancement


___

### **Description**
- Remove noisy error logs from goetty library during normal connection lifecycle

- Filter expected errors in read operations and connection closure

- Add helper methods to distinguish expected vs unexpected errors

- Add test coverage for expected close error detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Connection Events"] -->|"Read/Close Operations"| B["Error Filtering"]
  B -->|"Expected Errors"| C["Debug Log"]
  B -->|"Unexpected Errors"| D["Error Log"]
  E["Remove goetty Logger"] -->|"Avoid Duplicate Logs"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend.go</strong><dd><code>Filter expected errors and remove goetty logger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/morpc/backend.go

<ul><li>Remove <code>goetty.WithSessionLogger</code> from goetty options to prevent <br>duplicate error logs<br> <li> Add <code>strings</code> import for error message filtering<br> <li> Implement <code>isExpectedReadError()</code> method to filter expected errors like <br>"use of closed network connection", "illegal state", and "EOF"<br> <li> Implement <code>isExpectedCloseError()</code> method to filter expected errors when <br>closing connections<br> <li> Modify <code>readLoop()</code> to track normal exit and log accordingly<br> <li> Update read error handling to use debug logs for expected errors and <br>error logs for unexpected ones<br> <li> Update <code>closeConn()</code> to filter expected errors during connection closure</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23285/files#diff-b28e3346db427f1ca7e6eba3f4c155c3484e8b1d88866d8b88ffd3fb6f231857">+53/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.go</strong><dd><code>Remove goetty session logger from server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/morpc/server.go

<ul><li>Remove <code>goetty.WithSessionLogger</code> from goetty options in server <br>initialization<br> <li> Add comment explaining why session logger is not passed to goetty <br>library</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23285/files#diff-6643c29b89ad98795ea1a8e7037a9326765af7f7ffd5fedad16ed57191368e40">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_test.go</strong><dd><code>Add test for expected close error detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/morpc/backend_test.go

<ul><li>Add custom <code>testError</code> type to avoid Makefile err-check issues<br> <li> Add <code>TestIsExpectedCloseError()</code> test function with three test cases<br> <li> Test expected error recognition for "use of closed network connection"<br> <li> Test rejection of unexpected errors<br> <li> Test nil error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23285/files#diff-41ce67ab025b1b08f30de393c53acda32689e0fdb2e47ca9070ae29f639f75f0">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

