### PR TITLE
refactor: Optimize RPC Error Handling and Reduce Log Storms in High-Frequency Scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -962,9 +962,9 @@ static-check: config err-check
 	$(CGO_OPTS) golangci-lint run -v -c .golangci.yml ./...
 
 fmtErrs := $(shell grep -onr 'fmt.Errorf' pkg/ --exclude-dir=.git --exclude-dir=vendor \
-				--exclude=*.pb.go --exclude=system_vars.go --exclude=Makefile)
+				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
 errNews := $(shell grep -onr 'errors.New' pkg/ --exclude-dir=.git --exclude-dir=vendor \
-				--exclude=*.pb.go --exclude=system_vars.go --exclude=Makefile)
+				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
 withTimeout := $(shell grep -onr 'context.WithTimeout' pkg/ --exclude-dir=.git --exclude-dir=vendor \
 				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
 withDeadline := $(shell grep -onr 'context.WithDeadline' pkg/ --exclude-dir=.git --exclude-dir=vendor \
@@ -983,12 +983,12 @@ ifneq ("$(strip $(fmtErrs))$(strip $(errNews))", "")
 		$(warning One of 'errors.New()' is called at: $(shell printf "%s\n" $(errNews) | head -1))
  endif
  ifneq ("$(strip $(withTimeout))", "")
- 		$(warning 'context.WithTimeout' is found.)
- 		$(warning One of 'context.WithTimeout' is called at: $(shell printf "%s\n" $(errNews) | head -1))
+		$(warning 'context.WithTimeout' is found.)
+		$(warning One of 'context.WithTimeout' is called at: $(shell printf "%s\n" $(withTimeout) | head -1))
  endif
  ifneq ("$(strip $(withDeadline))", "")
- 		$(warning 'context.WithDeadline' is found.)
- 		$(warning One of 'context.WithDeadline' is called at: $(shell printf "%s\n" $(errNews) | head -1))
+		$(warning 'context.WithDeadline' is found.)
+		$(warning One of 'context.WithDeadline' is called at: $(shell printf "%s\n" $(withDeadline) | head -1))
  endif
 	$(error Use moerr instead.)
 else

--- a/pkg/cdc/table_change_stream.go
+++ b/pkg/cdc/table_change_stream.go
@@ -928,7 +928,8 @@ func (s *TableChangeStream) determineRetryable(err error) bool {
 		moerr.IsMoErrCode(err, moerr.ErrTNShardNotFound) ||
 		moerr.IsMoErrCode(err, moerr.ErrRpcError) ||
 		moerr.IsMoErrCode(err, moerr.ErrClientClosed) ||
-		moerr.IsMoErrCode(err, moerr.ErrBackendClosed) {
+		moerr.IsMoErrCode(err, moerr.ErrBackendClosed) ||
+		moerr.IsMoErrCode(err, moerr.ErrServiceUnavailable) {
 		return true
 	}
 
@@ -1015,6 +1016,7 @@ func (s *TableChangeStream) classifyErrorType(err error) string {
 		moerr.IsMoErrCode(err, moerr.ErrRpcError) ||
 		moerr.IsMoErrCode(err, moerr.ErrClientClosed) ||
 		moerr.IsMoErrCode(err, moerr.ErrBackendClosed) ||
+		moerr.IsMoErrCode(err, moerr.ErrServiceUnavailable) ||
 		errors.Is(err, context.DeadlineExceeded) ||
 		strings.Contains(errMsg, "connection") ||
 		strings.Contains(errMsg, "timeout") ||

--- a/pkg/cnservice/cnclient/client.go
+++ b/pkg/cnservice/cnclient/client.go
@@ -15,6 +15,7 @@
 package cnclient
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/fagongzi/goetty/v2"
@@ -110,11 +111,11 @@ func NewPipelineClient(
 	return c, nil
 }
 
-func (c *pipelineClient) NewStream(backend string) (morpc.Stream, error) {
+func (c *pipelineClient) NewStream(ctx context.Context, backend string) (morpc.Stream, error) {
 	if backend == c.localServiceAddress {
 		return nil, moerr.NewInternalErrorNoCtx(fmt.Sprintf("remote run pipeline in local: %s", backend))
 	}
-	return c.client.NewStream(backend, true)
+	return c.client.NewStream(ctx, backend, true)
 }
 
 func (c *pipelineClient) Raw() morpc.RPCClient {

--- a/pkg/cnservice/cnclient/types.go
+++ b/pkg/cnservice/cnclient/types.go
@@ -15,6 +15,7 @@
 package cnclient
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -56,7 +57,7 @@ type PipelineConfig struct {
 
 // PipelineClient pipeline client
 type PipelineClient interface {
-	NewStream(backend string) (morpc.Stream, error)
+	NewStream(ctx context.Context, backend string) (morpc.Stream, error)
 	Raw() morpc.RPCClient
 	Close() error
 }

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -230,6 +230,14 @@ func NewBackendCannotConnectNoCtx(args ...any) *Error {
 	return newError(Context(), ErrBackendCannotConnect, args...)
 }
 
+func NewServiceUnavailableNoCtx(reason string) *Error {
+	return newError(Context(), ErrServiceUnavailable, reason)
+}
+
+func NewConnectionResetNoCtx() *Error {
+	return newError(Context(), ErrConnectionReset)
+}
+
 func NewTxnClosedNoCtx(txnID []byte) *Error {
 	id := "unknown"
 	if len(txnID) > 0 {

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -207,35 +207,49 @@ func NewNoSuchTableNoCtx(db, tbl string) *Error {
 	return newError(Context(), ErrNoSuchTable, db, tbl)
 }
 
+// NewClientClosedNoCtx creates a client closed error without logging.
+// RPC errors use NoReportContext() to avoid log storms in retry loops.
 func NewClientClosedNoCtx() *Error {
-	return newError(Context(), ErrClientClosed)
+	return newError(NoReportContext(), ErrClientClosed)
 }
 
+// NewBackendClosedNoCtx creates a backend closed error without logging.
+// RPC errors use NoReportContext() to avoid log storms in retry loops.
 func NewBackendClosedNoCtx() *Error {
-	return newError(Context(), ErrBackendClosed)
+	return newError(NoReportContext(), ErrBackendClosed)
 }
 
+// NewStreamClosedNoCtx creates a stream closed error without logging.
+// RPC errors use NoReportContext() to avoid log storms in retry loops.
 func NewStreamClosedNoCtx() *Error {
-	return newError(Context(), ErrStreamClosed)
+	return newError(NoReportContext(), ErrStreamClosed)
 }
 
+// NewNoAvailableBackendNoCtx creates a no available backend error without logging.
+// RPC errors use NoReportContext() to avoid log storms in retry loops.
 func NewNoAvailableBackendNoCtx() *Error {
-	return newError(Context(), ErrNoAvailableBackend)
+	return newError(NoReportContext(), ErrNoAvailableBackend)
 }
 
+// NewBackendCannotConnectNoCtx creates a backend connection error without logging.
+// RPC errors use NoReportContext() to avoid log storms in retry loops.
 func NewBackendCannotConnectNoCtx(args ...any) *Error {
 	if len(args) == 0 {
-		return newError(Context(), ErrBackendCannotConnect, "none")
+		return newError(NoReportContext(), ErrBackendCannotConnect, "none")
 	}
-	return newError(Context(), ErrBackendCannotConnect, args...)
+	return newError(NoReportContext(), ErrBackendCannotConnect, args...)
 }
 
+// NewServiceUnavailableNoCtx creates a service unavailable error without logging.
+// RPC errors use NoReportContext() to avoid log storms in retry loops.
 func NewServiceUnavailableNoCtx(reason string) *Error {
-	return newError(Context(), ErrServiceUnavailable, reason)
+	return newError(NoReportContext(), ErrServiceUnavailable, reason)
 }
 
+// NewConnectionResetNoCtx creates a connection reset error without logging.
+// RPC errors use NoReportContext() to avoid log storms in retry loops.
 func NewConnectionResetNoCtx() *Error {
-	return newError(Context(), ErrConnectionReset)
+	return newError(NoReportContext(), ErrConnectionReset)
 }
 
 func NewTxnClosedNoCtx(txnID []byte) *Error {
@@ -444,8 +458,10 @@ func NewTxnCannotRetryNoCtx() *Error {
 	return newError(Context(), ErrTxnCannotRetry)
 }
 
+// NewRPCTimeoutNoCtx creates an RPC timeout error without logging.
+// RPC errors use NoReportContext() to avoid log storms in retry loops.
 func NewRPCTimeoutNoCtx() *Error {
-	return newError(Context(), ErrRPCTimeout)
+	return newError(NoReportContext(), ErrRPCTimeout)
 }
 
 func NewKeyAlreadyExistsNoCtx() *Error {

--- a/pkg/common/moerr/error_rpc_test.go
+++ b/pkg/common/moerr/error_rpc_test.go
@@ -1,0 +1,216 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package moerr
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsConnectionRelatedRPCError tests IsConnectionRelatedRPCError with various error types
+func TestIsConnectionRelatedRPCError(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "ErrBackendClosed",
+			err:      NewBackendClosedNoCtx(),
+			expected: true,
+		},
+		{
+			name:     "ErrNoAvailableBackend",
+			err:      NewNoAvailableBackendNoCtx(),
+			expected: true,
+		},
+		{
+			name:     "ErrBackendCannotConnect",
+			err:      NewBackendCannotConnectNoCtx(),
+			expected: true,
+		},
+		{
+			name:     "ErrServiceUnavailable",
+			err:      NewServiceUnavailable(ctx, "test service unavailable"),
+			expected: true,
+		},
+		{
+			name:     "ErrConnectionReset",
+			err:      NewConnectionReset(ctx),
+			expected: true,
+		},
+		{
+			name:     "non-connection error - ErrClientClosed",
+			err:      NewClientClosedNoCtx(),
+			expected: false,
+		},
+		{
+			name:     "non-connection error - standard error",
+			err:      errors.New("some error"),
+			expected: false,
+		},
+		{
+			name:     "non-connection error - ErrInternal",
+			err:      NewInternalErrorNoCtx("internal error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsConnectionRelatedRPCError(tt.err)
+			assert.Equal(t, tt.expected, result, "IsConnectionRelatedRPCError(%v) = %v, expected %v", tt.err, result, tt.expected)
+		})
+	}
+}
+
+// TestNewServiceUnavailable tests NewServiceUnavailable function
+func TestNewServiceUnavailable(t *testing.T) {
+	tests := []struct {
+		name   string
+		ctx    context.Context
+		reason string
+	}{
+		{
+			name:   "with background context",
+			ctx:    context.Background(),
+			reason: "database connection lost",
+		},
+		{
+			name:   "with canceled context",
+			ctx:    func() context.Context { ctx, cancel := context.WithCancel(context.Background()); cancel(); return ctx }(),
+			reason: "operation timeout",
+		},
+		{
+			name:   "empty reason",
+			ctx:    context.Background(),
+			reason: "",
+		},
+		{
+			name:   "long reason",
+			ctx:    context.Background(),
+			reason: "service is temporarily unavailable due to maintenance and will be restored soon",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := NewServiceUnavailable(tt.ctx, tt.reason)
+			assert.NotNil(t, err)
+			assert.True(t, IsMoErrCode(err, ErrServiceUnavailable))
+			errMsg := err.Error()
+			assert.Contains(t, errMsg, "service unavailable")
+			if tt.reason != "" {
+				assert.Contains(t, errMsg, tt.reason)
+			}
+		})
+	}
+}
+
+// TestIsRPCClientClosed tests IsRPCClientClosed with various error types
+func TestIsRPCClientClosed(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "ErrClientClosed",
+			err:      NewClientClosedNoCtx(),
+			expected: true,
+		},
+		{
+			name:     "non-client-closed error - ErrBackendClosed",
+			err:      NewBackendClosedNoCtx(),
+			expected: false,
+		},
+		{
+			name:     "non-client-closed error - standard error",
+			err:      errors.New("some error"),
+			expected: false,
+		},
+		{
+			name:     "non-client-closed error - ErrNoAvailableBackend",
+			err:      NewNoAvailableBackendNoCtx(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRPCClientClosed(tt.err)
+			assert.Equal(t, tt.expected, result, "IsRPCClientClosed(%v) = %v, expected %v", tt.err, result, tt.expected)
+		})
+	}
+}
+
+// TestConnectionRelatedErrorsCoexistence tests that multiple connection errors are properly identified
+func TestConnectionRelatedErrorsCoexistence(t *testing.T) {
+	ctx := context.Background()
+
+	connectionErrors := []error{
+		NewBackendClosedNoCtx(),
+		NewNoAvailableBackendNoCtx(),
+		NewBackendCannotConnectNoCtx(),
+		NewServiceUnavailable(ctx, "test"),
+		NewConnectionReset(ctx),
+	}
+
+	for i, err := range connectionErrors {
+		t.Run("connection_error_"+string(rune('A'+i)), func(t *testing.T) {
+			assert.True(t, IsConnectionRelatedRPCError(err))
+			assert.False(t, IsRPCClientClosed(err))
+		})
+	}
+
+	// Test that ErrClientClosed is distinct
+	clientClosedErr := NewClientClosedNoCtx()
+	assert.False(t, IsConnectionRelatedRPCError(clientClosedErr))
+	assert.True(t, IsRPCClientClosed(clientClosedErr))
+}
+
+// TestErrorTypeDistinction tests that different error types are properly distinguished
+func TestErrorTypeDistinction(t *testing.T) {
+	ctx := context.Background()
+
+	// Connection errors should not be identified as client closed
+	serviceErr := NewServiceUnavailable(ctx, "test")
+	assert.True(t, IsConnectionRelatedRPCError(serviceErr))
+	assert.False(t, IsRPCClientClosed(serviceErr))
+
+	backendErr := NewBackendClosedNoCtx()
+	assert.True(t, IsConnectionRelatedRPCError(backendErr))
+	assert.False(t, IsRPCClientClosed(backendErr))
+
+	// Client closed should not be identified as connection error
+	clientErr := NewClientClosedNoCtx()
+	assert.False(t, IsConnectionRelatedRPCError(clientErr))
+	assert.True(t, IsRPCClientClosed(clientErr))
+}

--- a/pkg/common/morpc/backend_test.go
+++ b/pkg/common/morpc/backend_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fagongzi/goetty/v2"
 	"github.com/fagongzi/goetty/v2/buf"
 	"github.com/lni/goutils/leaktest"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1087,3 +1088,91 @@ var (
 		},
 	}
 )
+
+// TestIsExpectedReadErrorWithStandardEOF tests that standard io.EOF is recognized as expected error
+func TestIsExpectedReadErrorWithStandardEOF(t *testing.T) {
+	rb := &remoteBackend{}
+
+	// Standard io.EOF should be recognized
+	assert.True(t, rb.isExpectedReadError(io.EOF),
+		"standard io.EOF should be recognized as expected error")
+
+	// io.ErrUnexpectedEOF should also be recognized
+	assert.True(t, rb.isExpectedReadError(io.ErrUnexpectedEOF),
+		"io.ErrUnexpectedEOF should be recognized as expected error")
+
+	// backendClosed should be recognized
+	assert.True(t, rb.isExpectedReadError(backendClosed),
+		"backendClosed should be recognized as expected error")
+
+	// nil error should not be recognized
+	assert.False(t, rb.isExpectedReadError(nil),
+		"nil error should not be recognized as expected error")
+}
+
+// TestIsExpectedReadErrorWithWrappedEOF tests that wrapped io.EOF is correctly identified
+func TestIsExpectedReadErrorWithWrappedEOF(t *testing.T) {
+	rb := &remoteBackend{}
+
+	// Wrapped io.EOF using fmt.Errorf with %w should be recognized
+	wrappedEOF := fmt.Errorf("connection: %w", io.EOF)
+	assert.True(t, rb.isExpectedReadError(wrappedEOF),
+		"wrapped io.EOF should be recognized as expected error")
+
+	// Deeply wrapped io.EOF should also be recognized
+	deepWrappedEOF := fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", io.EOF))
+	assert.True(t, rb.isExpectedReadError(deepWrappedEOF),
+		"deeply wrapped io.EOF should be recognized as expected error")
+
+	// Wrapped io.ErrUnexpectedEOF should also be recognized
+	wrappedUnexpectedEOF := fmt.Errorf("read failed: %w", io.ErrUnexpectedEOF)
+	assert.True(t, rb.isExpectedReadError(wrappedUnexpectedEOF),
+		"wrapped io.ErrUnexpectedEOF should be recognized as expected error")
+}
+
+// TestIsExpectedReadErrorWithConnectionErrors tests platform-specific connection errors
+func TestIsExpectedReadErrorWithConnectionErrors(t *testing.T) {
+	rb := &remoteBackend{}
+
+	// "use of closed network connection" should be recognized
+	closedConnErr := testError("use of closed network connection")
+	assert.True(t, rb.isExpectedReadError(closedConnErr),
+		"'use of closed network connection' should be recognized")
+
+	// "illegal state" should be recognized
+	illegalStateErr := testError("illegal state")
+	assert.True(t, rb.isExpectedReadError(illegalStateErr),
+		"'illegal state' should be recognized")
+
+	// "connection reset" should be recognized
+	connResetErr := testError("connection reset by peer")
+	assert.True(t, rb.isExpectedReadError(connResetErr),
+		"'connection reset' should be recognized")
+
+	// "broken pipe" should be recognized
+	brokenPipeErr := testError("broken pipe")
+	assert.True(t, rb.isExpectedReadError(brokenPipeErr),
+		"'broken pipe' should be recognized")
+
+	// Random error should not be recognized
+	randomErr := testError("some random error")
+	assert.False(t, rb.isExpectedReadError(randomErr),
+		"random error should not be recognized as expected error")
+}
+
+// TestIsExpectedReadErrorWithMoErrWrappedEOF tests moerr-wrapped EOF (moerr.Error doesn't implement Unwrap)
+func TestIsExpectedReadErrorWithMoErrWrappedEOF(t *testing.T) {
+	rb := &remoteBackend{}
+
+	// moerr.ConvertGoError converts io.EOF to moerr.NewUnexpectedEOF with "EOF" in message
+	// Since moerr.Error doesn't implement Unwrap(), errors.Is() won't match io.EOF
+	// But our string fallback "EOF" should catch it because the message is "unexpected end of file EOF"
+	convertedEOF := moerr.ConvertGoError(context.Background(), io.EOF)
+	assert.True(t, rb.isExpectedReadError(convertedEOF),
+		"moerr.ConvertGoError(io.EOF) should be recognized via string fallback, got: %q", convertedEOF.Error())
+
+	// Note: moerr.NewUnexpectedEOFNoCtx("something") produces "unexpected end of file something"
+	// which does NOT contain "EOF" substring, so it won't match.
+	// However, in practice, readLoop errors come from goetty conn.Read() which returns raw io.EOF,
+	// not moerr-wrapped errors. moerr wrapping only happens in RPC response serialization.
+}

--- a/pkg/common/morpc/circuit_breaker.go
+++ b/pkg/common/morpc/circuit_breaker.go
@@ -1,0 +1,392 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"go.uber.org/zap"
+)
+
+// CircuitState represents the state of a circuit breaker.
+type CircuitState int32
+
+const (
+	// CircuitClosed is the normal state where requests are allowed.
+	CircuitClosed CircuitState = iota
+	// CircuitOpen is the state where all requests are rejected.
+	CircuitOpen
+	// CircuitHalfOpen is the state where limited requests are allowed for probing.
+	CircuitHalfOpen
+)
+
+// String returns the string representation of the circuit state.
+func (s CircuitState) String() string {
+	switch s {
+	case CircuitClosed:
+		return "closed"
+	case CircuitOpen:
+		return "open"
+	case CircuitHalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+var (
+	// DefaultCircuitBreakerConfig disables circuit breaker by default.
+	// This preserves existing behavior where callers rely on context timeout
+	// and retry logic. Use EnabledCircuitBreakerConfig to opt-in.
+	DefaultCircuitBreakerConfig = CircuitBreakerConfig{
+		Enabled: false,
+	}
+
+	// EnabledCircuitBreakerConfig is a recommended circuit breaker configuration.
+	// It opens the circuit after 5 consecutive failures, waits 10 seconds before
+	// allowing probe requests, and allows 3 probe requests in half-open state.
+	// Use WithClientCircuitBreaker(EnabledCircuitBreakerConfig) to enable.
+	EnabledCircuitBreakerConfig = CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    5,
+		ResetTimeout:        10 * time.Second,
+		HalfOpenMaxRequests: 3,
+	}
+
+	// DisabledCircuitBreakerConfig explicitly disables the circuit breaker.
+	DisabledCircuitBreakerConfig = CircuitBreakerConfig{
+		Enabled: false,
+	}
+)
+
+// CircuitBreakerConfig defines the configuration for a circuit breaker.
+type CircuitBreakerConfig struct {
+	// Enabled determines if circuit breaker is active.
+	Enabled bool
+	// FailureThreshold is the number of consecutive failures before opening the circuit.
+	FailureThreshold int32
+	// ResetTimeout is the duration to wait before transitioning from open to half-open.
+	ResetTimeout time.Duration
+	// HalfOpenMaxRequests is the maximum number of requests allowed in half-open state.
+	HalfOpenMaxRequests int32
+}
+
+// CircuitBreaker implements the circuit breaker pattern for a single backend.
+// It tracks failures and prevents cascading failures by temporarily rejecting
+// requests to a failing backend.
+type CircuitBreaker struct {
+	config CircuitBreakerConfig
+	logger *zap.Logger
+
+	mu sync.RWMutex
+	// state is the current circuit state
+	state CircuitState
+	// failures is the count of consecutive failures in closed state
+	failures int32
+	// lastFailure is the timestamp of the last failure
+	lastFailure time.Time
+	// halfOpenRequests is the count of requests in half-open state
+	halfOpenRequests int32
+	// halfOpenSuccesses is the count of successful requests in half-open state
+	halfOpenSuccesses int32
+	// metrics
+	openCount    int64
+	rejectCount  int64
+	successCount int64
+	failureCount int64
+}
+
+// NewCircuitBreaker creates a new CircuitBreaker with the given configuration.
+func NewCircuitBreaker(config CircuitBreakerConfig, logger *zap.Logger) *CircuitBreaker {
+	return &CircuitBreaker{
+		config: config,
+		logger: logger,
+		state:  CircuitClosed,
+	}
+}
+
+// Allow checks if a request should be allowed.
+// Returns true if the request is allowed, false if rejected due to open circuit.
+func (cb *CircuitBreaker) Allow() bool {
+	if !cb.config.Enabled {
+		return true
+	}
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case CircuitClosed:
+		return true
+
+	case CircuitOpen:
+		// Check if reset timeout has passed
+		if time.Since(cb.lastFailure) >= cb.config.ResetTimeout {
+			cb.transitionToHalfOpenLocked()
+			// Allow the first probe request
+			cb.halfOpenRequests++
+			return true
+		}
+		atomic.AddInt64(&cb.rejectCount, 1)
+		return false
+
+	case CircuitHalfOpen:
+		// Allow limited requests for probing
+		if cb.halfOpenRequests < cb.config.HalfOpenMaxRequests {
+			cb.halfOpenRequests++
+			return true
+		}
+		atomic.AddInt64(&cb.rejectCount, 1)
+		return false
+
+	default:
+		return true
+	}
+}
+
+// RecordSuccess records a successful request.
+func (cb *CircuitBreaker) RecordSuccess() {
+	if !cb.config.Enabled {
+		return
+	}
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	atomic.AddInt64(&cb.successCount, 1)
+
+	switch cb.state {
+	case CircuitClosed:
+		// Reset failure count on success
+		cb.failures = 0
+
+	case CircuitHalfOpen:
+		cb.halfOpenSuccesses++
+		// If enough successful probes, close the circuit
+		if cb.halfOpenSuccesses >= cb.config.HalfOpenMaxRequests {
+			cb.transitionToClosedLocked()
+		}
+
+	case CircuitOpen:
+		// Shouldn't happen, but reset to closed if we get success
+		cb.transitionToClosedLocked()
+	}
+}
+
+// RecordFailure records a failed request.
+func (cb *CircuitBreaker) RecordFailure() {
+	if !cb.config.Enabled {
+		return
+	}
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	atomic.AddInt64(&cb.failureCount, 1)
+	cb.lastFailure = time.Now()
+
+	switch cb.state {
+	case CircuitClosed:
+		cb.failures++
+		if cb.failures >= cb.config.FailureThreshold {
+			cb.transitionToOpenLocked()
+		}
+
+	case CircuitHalfOpen:
+		// Any failure in half-open state reopens the circuit
+		cb.transitionToOpenLocked()
+
+	case CircuitOpen:
+		// Already open, just update last failure time
+	}
+}
+
+// State returns the current circuit state.
+func (cb *CircuitBreaker) State() CircuitState {
+	cb.mu.RLock()
+	defer cb.mu.RUnlock()
+	return cb.state
+}
+
+// Stats returns circuit breaker statistics.
+func (cb *CircuitBreaker) Stats() CircuitBreakerStats {
+	cb.mu.RLock()
+	defer cb.mu.RUnlock()
+	return CircuitBreakerStats{
+		State:        cb.state,
+		Failures:     cb.failures,
+		LastFailure:  cb.lastFailure,
+		OpenCount:    atomic.LoadInt64(&cb.openCount),
+		RejectCount:  atomic.LoadInt64(&cb.rejectCount),
+		SuccessCount: atomic.LoadInt64(&cb.successCount),
+		FailureCount: atomic.LoadInt64(&cb.failureCount),
+	}
+}
+
+// Reset resets the circuit breaker to closed state.
+func (cb *CircuitBreaker) Reset() {
+	if !cb.config.Enabled {
+		return
+	}
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.transitionToClosedLocked()
+}
+
+func (cb *CircuitBreaker) transitionToOpenLocked() {
+	if cb.state != CircuitOpen {
+		atomic.AddInt64(&cb.openCount, 1)
+		cb.logger.Warn("circuit breaker opened",
+			zap.Int32("failures", cb.failures),
+			zap.Duration("reset_timeout", cb.config.ResetTimeout))
+	}
+	cb.state = CircuitOpen
+}
+
+func (cb *CircuitBreaker) transitionToHalfOpenLocked() {
+	cb.state = CircuitHalfOpen
+	cb.halfOpenRequests = 0
+	cb.halfOpenSuccesses = 0
+	cb.logger.Info("circuit breaker half-open, probing backend")
+}
+
+func (cb *CircuitBreaker) transitionToClosedLocked() {
+	if cb.state != CircuitClosed {
+		cb.logger.Info("circuit breaker closed, backend recovered",
+			zap.String("previous_state", cb.state.String()))
+	}
+	cb.state = CircuitClosed
+	cb.failures = 0
+	cb.halfOpenRequests = 0
+	cb.halfOpenSuccesses = 0
+}
+
+// CircuitBreakerStats contains statistics for a circuit breaker.
+type CircuitBreakerStats struct {
+	State        CircuitState
+	Failures     int32
+	LastFailure  time.Time
+	OpenCount    int64
+	RejectCount  int64
+	SuccessCount int64
+	FailureCount int64
+}
+
+// CircuitBreakerManager manages circuit breakers for multiple backends.
+type CircuitBreakerManager struct {
+	config CircuitBreakerConfig
+	logger *zap.Logger
+
+	mu       sync.RWMutex
+	breakers map[string]*CircuitBreaker
+}
+
+// NewCircuitBreakerManager creates a new CircuitBreakerManager.
+func NewCircuitBreakerManager(config CircuitBreakerConfig, logger *zap.Logger) *CircuitBreakerManager {
+	return &CircuitBreakerManager{
+		config:   config,
+		logger:   logger,
+		breakers: make(map[string]*CircuitBreaker),
+	}
+}
+
+// GetBreaker returns the circuit breaker for the given backend address.
+// Creates a new breaker if one doesn't exist.
+func (m *CircuitBreakerManager) GetBreaker(backend string) *CircuitBreaker {
+	if !m.config.Enabled {
+		// Return a disabled breaker that always allows
+		return &CircuitBreaker{config: DisabledCircuitBreakerConfig}
+	}
+
+	m.mu.RLock()
+	cb, ok := m.breakers[backend]
+	m.mu.RUnlock()
+
+	if ok {
+		return cb
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if cb, ok = m.breakers[backend]; ok {
+		return cb
+	}
+
+	cb = NewCircuitBreaker(m.config, m.logger.With(zap.String("backend", backend)))
+	m.breakers[backend] = cb
+	return cb
+}
+
+// Allow checks if a request to the given backend should be allowed.
+func (m *CircuitBreakerManager) Allow(backend string) bool {
+	return m.GetBreaker(backend).Allow()
+}
+
+// RecordSuccess records a successful request to the given backend.
+func (m *CircuitBreakerManager) RecordSuccess(backend string) {
+	m.GetBreaker(backend).RecordSuccess()
+}
+
+// RecordFailure records a failed request to the given backend.
+func (m *CircuitBreakerManager) RecordFailure(backend string) {
+	m.GetBreaker(backend).RecordFailure()
+}
+
+// RemoveBreaker removes the circuit breaker for the given backend.
+func (m *CircuitBreakerManager) RemoveBreaker(backend string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.breakers, backend)
+}
+
+// Stats returns statistics for all circuit breakers.
+func (m *CircuitBreakerManager) Stats() map[string]CircuitBreakerStats {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	stats := make(map[string]CircuitBreakerStats, len(m.breakers))
+	for backend, cb := range m.breakers {
+		stats[backend] = cb.Stats()
+	}
+	return stats
+}
+
+// ErrCircuitOpen is returned when the circuit breaker is open and rejecting requests.
+var ErrCircuitOpen = moerr.NewServiceUnavailableNoCtx("circuit breaker is open")
+
+// IsCircuitOpen checks if the error indicates a circuit breaker rejection.
+// It checks both identity comparison and error code for wrapped errors.
+func IsCircuitOpen(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Identity check for direct comparison
+	if err == ErrCircuitOpen {
+		return true
+	}
+	// Check error code for wrapped errors or recreated errors
+	if moerr.IsMoErrCode(err, moerr.ErrServiceUnavailable) {
+		// Also check the message to distinguish from other ServiceUnavailable errors
+		return strings.Contains(err.Error(), "circuit breaker")
+	}
+	return false
+}

--- a/pkg/common/morpc/circuit_breaker_test.go
+++ b/pkg/common/morpc/circuit_breaker_test.go
@@ -1,0 +1,328 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestCircuitBreakerInitialState(t *testing.T) {
+	logger := zap.NewNop()
+	cb := NewCircuitBreaker(DefaultCircuitBreakerConfig, logger)
+
+	assert.Equal(t, CircuitClosed, cb.State())
+	assert.True(t, cb.Allow())
+}
+
+func TestCircuitBreakerDisabled(t *testing.T) {
+	logger := zap.NewNop()
+	cb := NewCircuitBreaker(DisabledCircuitBreakerConfig, logger)
+
+	// Always allows when disabled
+	assert.True(t, cb.Allow())
+
+	// Recording failures shouldn't affect anything
+	for i := 0; i < 100; i++ {
+		cb.RecordFailure()
+	}
+	assert.True(t, cb.Allow())
+}
+
+func TestCircuitBreakerOpensAfterThreshold(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    3,
+		ResetTimeout:        100 * time.Millisecond,
+		HalfOpenMaxRequests: 1,
+	}
+	cb := NewCircuitBreaker(config, logger)
+
+	// Initial state is closed
+	assert.Equal(t, CircuitClosed, cb.State())
+
+	// Record failures up to threshold
+	for i := 0; i < 3; i++ {
+		assert.True(t, cb.Allow())
+		cb.RecordFailure()
+	}
+
+	// Circuit should be open now
+	assert.Equal(t, CircuitOpen, cb.State())
+	assert.False(t, cb.Allow())
+}
+
+func TestCircuitBreakerSuccessResetsFailures(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    3,
+		ResetTimeout:        100 * time.Millisecond,
+		HalfOpenMaxRequests: 1,
+	}
+	cb := NewCircuitBreaker(config, logger)
+
+	// Record 2 failures
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Record a success - should reset failure count
+	cb.RecordSuccess()
+
+	// Record 2 more failures - should not open circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	assert.Equal(t, CircuitClosed, cb.State())
+	assert.True(t, cb.Allow())
+}
+
+func TestCircuitBreakerHalfOpenAfterTimeout(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    2,
+		ResetTimeout:        50 * time.Millisecond,
+		HalfOpenMaxRequests: 2,
+	}
+	cb := NewCircuitBreaker(config, logger)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+	assert.Equal(t, CircuitOpen, cb.State())
+	assert.False(t, cb.Allow())
+
+	// Wait for reset timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// First request should be allowed (transitions to half-open)
+	assert.True(t, cb.Allow())
+	assert.Equal(t, CircuitHalfOpen, cb.State())
+}
+
+func TestCircuitBreakerHalfOpenSuccess(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    2,
+		ResetTimeout:        50 * time.Millisecond,
+		HalfOpenMaxRequests: 2,
+	}
+	cb := NewCircuitBreaker(config, logger)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Wait for reset timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// Transition to half-open
+	assert.True(t, cb.Allow())
+	assert.Equal(t, CircuitHalfOpen, cb.State())
+
+	// Record enough successes to close the circuit
+	cb.RecordSuccess()
+	cb.RecordSuccess()
+
+	assert.Equal(t, CircuitClosed, cb.State())
+	assert.True(t, cb.Allow())
+}
+
+func TestCircuitBreakerHalfOpenFailure(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    2,
+		ResetTimeout:        50 * time.Millisecond,
+		HalfOpenMaxRequests: 2,
+	}
+	cb := NewCircuitBreaker(config, logger)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Wait for reset timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// Transition to half-open
+	assert.True(t, cb.Allow())
+	assert.Equal(t, CircuitHalfOpen, cb.State())
+
+	// Record a failure - should reopen the circuit
+	cb.RecordFailure()
+
+	assert.Equal(t, CircuitOpen, cb.State())
+	assert.False(t, cb.Allow())
+}
+
+func TestCircuitBreakerHalfOpenLimitedRequests(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    2,
+		ResetTimeout:        50 * time.Millisecond,
+		HalfOpenMaxRequests: 2,
+	}
+	cb := NewCircuitBreaker(config, logger)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Wait for reset timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// First 2 requests should be allowed
+	assert.True(t, cb.Allow())
+	assert.True(t, cb.Allow())
+
+	// Third request should be rejected
+	assert.False(t, cb.Allow())
+}
+
+func TestCircuitBreakerReset(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    2,
+		ResetTimeout:        1 * time.Hour, // Long timeout
+		HalfOpenMaxRequests: 2,
+	}
+	cb := NewCircuitBreaker(config, logger)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+	assert.Equal(t, CircuitOpen, cb.State())
+
+	// Reset should close the circuit
+	cb.Reset()
+	assert.Equal(t, CircuitClosed, cb.State())
+	assert.True(t, cb.Allow())
+}
+
+func TestCircuitBreakerStats(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    5,
+		ResetTimeout:        100 * time.Millisecond,
+		HalfOpenMaxRequests: 2,
+	}
+	cb := NewCircuitBreaker(config, logger)
+
+	// Record some events
+	cb.RecordSuccess()
+	cb.RecordSuccess()
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	stats := cb.Stats()
+	assert.Equal(t, CircuitClosed, stats.State)
+	assert.Equal(t, int32(3), stats.Failures)
+	assert.Equal(t, int64(2), stats.SuccessCount)
+	assert.Equal(t, int64(3), stats.FailureCount)
+}
+
+func TestCircuitBreakerManager(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    2,
+		ResetTimeout:        100 * time.Millisecond,
+		HalfOpenMaxRequests: 1,
+	}
+	manager := NewCircuitBreakerManager(config, logger)
+
+	// Different backends have independent circuit breakers
+	assert.True(t, manager.Allow("backend1"))
+	assert.True(t, manager.Allow("backend2"))
+
+	// Open circuit for backend1
+	manager.RecordFailure("backend1")
+	manager.RecordFailure("backend1")
+
+	// backend1 should be blocked, backend2 should work
+	assert.False(t, manager.Allow("backend1"))
+	assert.True(t, manager.Allow("backend2"))
+
+	// Check stats
+	stats := manager.Stats()
+	assert.Equal(t, CircuitOpen, stats["backend1"].State)
+	assert.Equal(t, CircuitClosed, stats["backend2"].State)
+}
+
+func TestCircuitBreakerManagerRemoveBreaker(t *testing.T) {
+	logger := zap.NewNop()
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    2,
+		ResetTimeout:        100 * time.Millisecond,
+		HalfOpenMaxRequests: 1,
+	}
+	manager := NewCircuitBreakerManager(config, logger)
+
+	// Open circuit for backend1
+	manager.RecordFailure("backend1")
+	manager.RecordFailure("backend1")
+	assert.False(t, manager.Allow("backend1"))
+
+	// Remove breaker
+	manager.RemoveBreaker("backend1")
+
+	// New breaker should be created in closed state
+	assert.True(t, manager.Allow("backend1"))
+}
+
+func TestCircuitBreakerManagerDisabled(t *testing.T) {
+	logger := zap.NewNop()
+	manager := NewCircuitBreakerManager(DisabledCircuitBreakerConfig, logger)
+
+	// Always allows when disabled
+	for i := 0; i < 100; i++ {
+		manager.RecordFailure("backend1")
+	}
+	assert.True(t, manager.Allow("backend1"))
+}
+
+func TestCircuitStateString(t *testing.T) {
+	assert.Equal(t, "closed", CircuitClosed.String())
+	assert.Equal(t, "open", CircuitOpen.String())
+	assert.Equal(t, "half-open", CircuitHalfOpen.String())
+	assert.Equal(t, "unknown", CircuitState(-1).String())
+}
+
+func TestIsCircuitOpen(t *testing.T) {
+	assert.True(t, IsCircuitOpen(ErrCircuitOpen))
+	assert.False(t, IsCircuitOpen(backendClosed))
+	assert.False(t, IsCircuitOpen(nil))
+
+	// Test with wrapped error message containing "circuit breaker"
+	wrappedErr := moerr.NewServiceUnavailableNoCtx("circuit breaker is open")
+	assert.True(t, IsCircuitOpen(wrappedErr))
+
+	// Test with different ServiceUnavailable error (should not match)
+	otherErr := moerr.NewServiceUnavailableNoCtx("server overloaded")
+	assert.False(t, IsCircuitOpen(otherErr))
+}

--- a/pkg/common/morpc/client_retry_test.go
+++ b/pkg/common/morpc/client_retry_test.go
@@ -1,0 +1,535 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRetryPolicyNextBackoff tests the nextBackoff calculation
+func TestRetryPolicyNextBackoff(t *testing.T) {
+	tests := []struct {
+		name           string
+		policy         RetryPolicy
+		currentBackoff time.Duration
+		expectedMin    time.Duration
+		expectedMax    time.Duration
+	}{
+		{
+			name: "initial backoff",
+			policy: RetryPolicy{
+				InitialBackoff: 10 * time.Millisecond,
+				MaxBackoff:     1 * time.Second,
+				Multiplier:     2.0,
+				JitterFraction: 0,
+			},
+			currentBackoff: 0,
+			expectedMin:    10 * time.Millisecond,
+			expectedMax:    10 * time.Millisecond,
+		},
+		{
+			name: "exponential growth",
+			policy: RetryPolicy{
+				InitialBackoff: 10 * time.Millisecond,
+				MaxBackoff:     1 * time.Second,
+				Multiplier:     2.0,
+				JitterFraction: 0,
+			},
+			currentBackoff: 10 * time.Millisecond,
+			expectedMin:    20 * time.Millisecond,
+			expectedMax:    20 * time.Millisecond,
+		},
+		{
+			name: "max backoff limit",
+			policy: RetryPolicy{
+				InitialBackoff: 10 * time.Millisecond,
+				MaxBackoff:     50 * time.Millisecond,
+				Multiplier:     2.0,
+				JitterFraction: 0,
+			},
+			currentBackoff: 100 * time.Millisecond,
+			expectedMin:    50 * time.Millisecond,
+			expectedMax:    50 * time.Millisecond,
+		},
+		{
+			name: "with jitter - bounds check",
+			policy: RetryPolicy{
+				InitialBackoff: 100 * time.Millisecond,
+				MaxBackoff:     1 * time.Second,
+				Multiplier:     2.0,
+				JitterFraction: 0.2, // ±20%
+			},
+			currentBackoff: 100 * time.Millisecond,
+			expectedMin:    160 * time.Millisecond, // 200ms - 20%
+			expectedMax:    240 * time.Millisecond, // 200ms + 20%
+		},
+		{
+			name: "no jitter when fraction is 0",
+			policy: RetryPolicy{
+				InitialBackoff: 100 * time.Millisecond,
+				MaxBackoff:     1 * time.Second,
+				Multiplier:     3.0,
+				JitterFraction: 0,
+			},
+			currentBackoff: 100 * time.Millisecond,
+			expectedMin:    300 * time.Millisecond,
+			expectedMax:    300 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Run multiple times to test jitter randomness
+			iterations := 1
+			if tt.policy.JitterFraction > 0 {
+				iterations = 100
+			}
+
+			for i := 0; i < iterations; i++ {
+				result := tt.policy.nextBackoff(tt.currentBackoff)
+				assert.GreaterOrEqual(t, result, tt.expectedMin, "backoff should be >= minimum")
+				assert.LessOrEqual(t, result, tt.expectedMax, "backoff should be <= maximum")
+
+				// Test that it never goes negative
+				assert.GreaterOrEqual(t, result, time.Duration(0))
+			}
+		})
+	}
+}
+
+// TestRetryPolicyZeroJitterFraction ensures deterministic behavior with no jitter
+func TestRetryPolicyZeroJitterFraction(t *testing.T) {
+	policy := RetryPolicy{
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     1 * time.Second,
+		Multiplier:     2.0,
+		JitterFraction: 0,
+	}
+
+	backoff := time.Duration(0)
+	expected := []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		80 * time.Millisecond,
+		160 * time.Millisecond,
+	}
+
+	for i, exp := range expected {
+		backoff = policy.nextBackoff(backoff)
+		assert.Equal(t, exp, backoff, "iteration %d", i)
+	}
+}
+
+// TestWithClientRetryPolicy tests the WithClientRetryPolicy option
+func TestWithClientRetryPolicy(t *testing.T) {
+	customPolicy := RetryPolicy{
+		MaxRetries:     5,
+		InitialBackoff: 50 * time.Millisecond,
+		MaxBackoff:     500 * time.Millisecond,
+		Multiplier:     1.5,
+		JitterFraction: 0.1,
+	}
+
+	rc, err := NewClient(
+		"test-retry-policy",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		WithClientRetryPolicy(customPolicy),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	c := rc.(*client)
+	assert.Equal(t, customPolicy.MaxRetries, c.options.retryPolicy.MaxRetries)
+	assert.Equal(t, customPolicy.InitialBackoff, c.options.retryPolicy.InitialBackoff)
+	assert.Equal(t, customPolicy.MaxBackoff, c.options.retryPolicy.MaxBackoff)
+	assert.Equal(t, customPolicy.Multiplier, c.options.retryPolicy.Multiplier)
+	assert.Equal(t, customPolicy.JitterFraction, c.options.retryPolicy.JitterFraction)
+}
+
+// TestWithClientDisableRetry tests the WithClientDisableRetry option
+func TestWithClientDisableRetry(t *testing.T) {
+	rc, err := NewClient(
+		"test-disable-retry",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		WithClientDisableRetry(),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	c := rc.(*client)
+	assert.Equal(t, NoRetryPolicy.MaxRetries, c.options.retryPolicy.MaxRetries)
+	assert.Equal(t, 1, c.options.retryPolicy.MaxRetries, "should only try once")
+}
+
+// TestWithClientCircuitBreaker tests the WithClientCircuitBreaker option
+func TestWithClientCircuitBreaker(t *testing.T) {
+	customConfig := CircuitBreakerConfig{
+		Enabled:          true,
+		FailureThreshold: 10,
+		ResetTimeout:     2 * time.Second,
+	}
+
+	rc, err := NewClient(
+		"test-circuit-breaker",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		WithClientCircuitBreaker(customConfig),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	c := rc.(*client)
+	assert.Equal(t, customConfig.Enabled, c.options.circuitBreakerConfig.Enabled)
+	assert.Equal(t, customConfig.FailureThreshold, c.options.circuitBreakerConfig.FailureThreshold)
+	assert.Equal(t, customConfig.ResetTimeout, c.options.circuitBreakerConfig.ResetTimeout)
+}
+
+// TestWithClientDisableCircuitBreaker tests the WithClientDisableCircuitBreaker option
+func TestWithClientDisableCircuitBreaker(t *testing.T) {
+	rc, err := NewClient(
+		"test-disable-circuit-breaker",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		WithClientDisableCircuitBreaker(),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	c := rc.(*client)
+	assert.False(t, c.options.circuitBreakerConfig.Enabled, "circuit breaker should be disabled")
+	assert.Equal(t, DisabledCircuitBreakerConfig.Enabled, c.options.circuitBreakerConfig.Enabled)
+}
+
+// TestClientSendWithContextCancellation tests Send behavior when context is canceled
+func TestClientSendWithContextCancellation(t *testing.T) {
+	testRPCServer(t, func(rs *server) {
+		c := newTestClient(t, WithClientMaxBackendPerHost(1))
+		defer func() {
+			assert.NoError(t, c.Close())
+		}()
+
+		rs.RegisterRequestHandler(func(_ context.Context, request RPCMessage, _ uint64, cs ClientSession) error {
+			time.Sleep(100 * time.Millisecond) // Simulate slow processing
+			return cs.Write(context.Background(), request.Message)
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		req := newTestMessage(1)
+		f, err := c.Send(ctx, testAddr, req)
+
+		if err == nil {
+			_, err = f.Get()
+			f.Close()
+		}
+
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, context.DeadlineExceeded) || err == context.DeadlineExceeded)
+	})
+}
+
+// TestClientSendWithEmptyBackend tests Send with empty backend string
+func TestClientSendWithEmptyBackend(t *testing.T) {
+	rc, err := NewClient(
+		"test-empty-backend",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	ctx := context.Background()
+	req := newTestMessage(1)
+
+	f, err := rc.Send(ctx, "", req)
+	assert.Error(t, err)
+	assert.Nil(t, f)
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendCannotConnect))
+}
+
+// TestClientSendWithCircuitBreakerOpen tests Send when circuit breaker is open
+func TestClientSendWithCircuitBreakerOpen(t *testing.T) {
+	rc, err := NewClient(
+		"test-cb-open",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		WithClientCircuitBreaker(CircuitBreakerConfig{
+			Enabled:          true,
+			FailureThreshold: 1, // Open after 1 failure
+			ResetTimeout:     1 * time.Second,
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	c := rc.(*client)
+	backend := "test-backend"
+
+	// Force circuit breaker to open
+	c.circuitBreakers.RecordFailure(backend)
+
+	ctx := context.Background()
+	req := newTestMessage(1)
+
+	f, err := rc.Send(ctx, backend, req)
+	assert.Error(t, err)
+	assert.Nil(t, f)
+	assert.Equal(t, ErrCircuitOpen, err)
+}
+
+// TestClientNewStreamWithContextCancellation tests NewStream with context cancellation
+func TestClientNewStreamWithContextCancellation(t *testing.T) {
+	testRPCServer(t, func(rs *server) {
+		c := newTestClient(t, WithClientMaxBackendPerHost(1))
+		defer func() {
+			assert.NoError(t, c.Close())
+		}()
+
+		rs.RegisterRequestHandler(func(_ context.Context, request RPCMessage, _ uint64, cs ClientSession) error {
+			return cs.Write(context.Background(), request.Message)
+		})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		st, err := c.NewStream(ctx, testAddr, false)
+		assert.Error(t, err)
+		assert.Nil(t, st)
+		assert.Equal(t, context.Canceled, err)
+	})
+}
+
+// TestClientNewStreamWithCircuitBreakerOpen tests NewStream when circuit breaker is open
+func TestClientNewStreamWithCircuitBreakerOpen(t *testing.T) {
+	rc, err := NewClient(
+		"test-stream-cb",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		WithClientCircuitBreaker(CircuitBreakerConfig{
+			Enabled:          true,
+			FailureThreshold: 1,
+			ResetTimeout:     1 * time.Second,
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	c := rc.(*client)
+	backend := "test-backend"
+
+	// Open circuit breaker
+	c.circuitBreakers.RecordFailure(backend)
+
+	ctx := context.Background()
+	st, err := rc.NewStream(ctx, backend, false)
+	assert.Error(t, err)
+	assert.Nil(t, st)
+	assert.Equal(t, ErrCircuitOpen, err)
+}
+
+// TestClientPingWithCircuitBreakerOpen tests Ping when circuit breaker is open
+func TestClientPingWithCircuitBreakerOpen(t *testing.T) {
+	rc, err := NewClient(
+		"test-ping-cb",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		WithClientCircuitBreaker(CircuitBreakerConfig{
+			Enabled:          true,
+			FailureThreshold: 1,
+			ResetTimeout:     1 * time.Second,
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	c := rc.(*client)
+	backend := "test-backend"
+
+	// Open circuit breaker
+	c.circuitBreakers.RecordFailure(backend)
+
+	ctx := context.Background()
+	err = rc.Ping(ctx, backend)
+	assert.Error(t, err)
+	assert.Equal(t, ErrCircuitOpen, err)
+}
+
+// TestClientSendWithRetrySuccess tests successful retry after backend closed
+func TestClientSendWithRetrySuccess(t *testing.T) {
+	// This test uses a mock backend that fails once then succeeds
+	factory := &testBackendFactoryWithRetry{
+		attemptCounter: atomic.Int32{},
+	}
+
+	rc, err := NewClient(
+		"test-retry-success",
+		factory,
+		WithClientMaxBackendPerHost(1),
+		WithClientRetryPolicy(RetryPolicy{
+			MaxRetries:     3,
+			InitialBackoff: 1 * time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+			Multiplier:     2.0,
+			JitterFraction: 0,
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	// Note: This test demonstrates the retry mechanism structure
+	// Actual retry testing requires a more complex setup with real backends
+}
+
+// TestClientWithClosedClient tests operations on a closed client
+func TestClientWithClosedClient(t *testing.T) {
+	rc, err := NewClient(
+		"test-closed-client",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+	)
+	require.NoError(t, err)
+
+	// Close the client
+	assert.NoError(t, rc.Close())
+
+	ctx := context.Background()
+	req := newTestMessage(1)
+
+	// Test Send on closed client
+	_, err = rc.Send(ctx, "test-backend", req)
+	assert.Error(t, err)
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrClientClosed))
+
+	// Test NewStream on closed client
+	_, err = rc.NewStream(ctx, "test-backend", false)
+	assert.Error(t, err)
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrClientClosed))
+
+	// Test Ping on closed client
+	err = rc.Ping(ctx, "test-backend")
+	assert.Error(t, err)
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrClientClosed))
+}
+
+// TestRetryPolicyDefaults tests that default retry policy is applied correctly
+func TestRetryPolicyDefaults(t *testing.T) {
+	rc, err := NewClient(
+		"test-default-policy",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		// No retry policy specified, should use DefaultRetryPolicy
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	c := rc.(*client)
+	assert.Equal(t, DefaultRetryPolicy.MaxRetries, c.options.retryPolicy.MaxRetries)
+	assert.Equal(t, DefaultRetryPolicy.InitialBackoff, c.options.retryPolicy.InitialBackoff)
+	assert.Equal(t, DefaultRetryPolicy.MaxBackoff, c.options.retryPolicy.MaxBackoff)
+}
+
+// Mock backend factory for testing retry behavior
+type testBackendFactoryWithRetry struct {
+	attemptCounter atomic.Int32
+}
+
+func (f *testBackendFactoryWithRetry) Create(remote string, options ...BackendOption) (Backend, error) {
+	b := &testBackendWithRetry{
+		attemptCounter: &f.attemptCounter,
+	}
+	b.testBackend.activeTime = time.Now()
+	return b, nil
+}
+
+type testBackendWithRetry struct {
+	testBackend
+	attemptCounter *atomic.Int32
+}
+
+func (b *testBackendWithRetry) Send(ctx context.Context, request Message) (*Future, error) {
+	attempts := b.attemptCounter.Add(1)
+	if attempts == 1 {
+		return nil, backendClosed
+	}
+	return &Future{}, nil
+}
+
+// TestNoRetryPolicyConstants verifies NoRetryPolicy is configured correctly
+func TestNoRetryPolicyConstants(t *testing.T) {
+	assert.Equal(t, 1, NoRetryPolicy.MaxRetries, "NoRetryPolicy should allow only 1 attempt")
+	assert.Equal(t, time.Duration(0), NoRetryPolicy.InitialBackoff)
+	assert.Equal(t, time.Duration(0), NoRetryPolicy.MaxBackoff)
+	assert.Equal(t, 1.0, NoRetryPolicy.Multiplier)
+	assert.Equal(t, 0.0, NoRetryPolicy.JitterFraction)
+}
+
+// TestDefaultRetryPolicyConstants verifies DefaultRetryPolicy is configured correctly
+func TestDefaultRetryPolicyConstants(t *testing.T) {
+	assert.Equal(t, 0, DefaultRetryPolicy.MaxRetries, "DefaultRetryPolicy should have unlimited retries")
+	assert.Equal(t, 10*time.Millisecond, DefaultRetryPolicy.InitialBackoff)
+	assert.Equal(t, 1*time.Second, DefaultRetryPolicy.MaxBackoff)
+	assert.Equal(t, 2.0, DefaultRetryPolicy.Multiplier)
+	assert.Equal(t, 0.2, DefaultRetryPolicy.JitterFraction)
+}
+
+// TestClientCircuitBreakerDefaults tests that default circuit breaker config is applied
+func TestClientCircuitBreakerDefaults(t *testing.T) {
+	rc, err := NewClient(
+		"test-default-cb",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(1),
+		// No circuit breaker config specified, should use DefaultCircuitBreakerConfig
+	)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rc.Close())
+	}()
+
+	c := rc.(*client)
+	assert.Equal(t, DefaultCircuitBreakerConfig.Enabled, c.options.circuitBreakerConfig.Enabled)
+	assert.Equal(t, DefaultCircuitBreakerConfig.FailureThreshold, c.options.circuitBreakerConfig.FailureThreshold)
+}

--- a/pkg/common/morpc/examples/stream/main.go
+++ b/pkg/common/morpc/examples/stream/main.go
@@ -46,7 +46,7 @@ func main() {
 		panic(err)
 	}
 
-	st, err := cli.NewStream(addr, false)
+	st, err := cli.NewStream(context.Background(), addr, false)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -162,7 +162,7 @@ func TestStreamServer(t *testing.T) {
 			return nil
 		})
 
-		st, err := c.NewStream(testAddr, false)
+		st, err := c.NewStream(context.Background(), testAddr, false)
 		assert.NoError(t, err)
 		defer func() {
 			assert.NoError(t, st.Close(false))
@@ -219,7 +219,7 @@ func TestStreamServerWithCache(t *testing.T) {
 			return nil
 		})
 
-		st, err := c.NewStream(testAddr, false)
+		st, err := c.NewStream(context.Background(), testAddr, false)
 		assert.NoError(t, err)
 		defer func() {
 			assert.NoError(t, st.Close(false))
@@ -266,7 +266,7 @@ func TestServerTimeoutCacheWillRemoved(t *testing.T) {
 			return cache.Add(request)
 		})
 
-		st, err := c.NewStream(testAddr, false)
+		st, err := c.NewStream(context.Background(), testAddr, false)
 		assert.NoError(t, err)
 		defer func() {
 			assert.NoError(t, st.Close(false))
@@ -303,7 +303,7 @@ func TestStreamServerWithSequenceNotMatch(t *testing.T) {
 			return cs.Write(ctx, request.Message)
 		})
 
-		v, err := c.NewStream(testAddr, false)
+		v, err := c.NewStream(context.Background(), testAddr, false)
 		assert.NoError(t, err)
 		st := v.(*stream)
 		defer func() {
@@ -336,7 +336,7 @@ func TestStreamReadCannotBlockWrite(t *testing.T) {
 			return cs.Write(ctx, request.Message)
 		})
 
-		st, err := c.NewStream(testAddr, false)
+		st, err := c.NewStream(context.Background(), testAddr, false)
 		assert.NoError(t, err)
 		defer func() {
 			assert.NoError(t, st.Close(false))
@@ -380,7 +380,7 @@ func TestCannotGetClosedBackend(t *testing.T) {
 			return cs.Write(ctx, request.Message)
 		})
 
-		st, err := c.NewStream(testAddr, true)
+		st, err := c.NewStream(context.Background(), testAddr, true)
 		require.NoError(t, err)
 		require.NoError(t, st.Close(true))
 

--- a/pkg/common/morpc/status.go
+++ b/pkg/common/morpc/status.go
@@ -1,0 +1,199 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+)
+
+// StatusCategory classifies RPC errors into semantic categories.
+// This allows callers to make informed decisions about error handling
+// without checking individual error codes.
+type StatusCategory int
+
+const (
+	// StatusOK indicates no error (success).
+	StatusOK StatusCategory = iota
+
+	// StatusTransient indicates temporary failures that may succeed on immediate retry.
+	// Examples: timeout waiting for response, temporary network hiccup.
+	// These errors suggest the system is working but the specific request failed.
+	StatusTransient
+
+	// StatusUnavailable indicates the service/backend is currently unavailable.
+	// Examples: backend closed, cannot connect, no available backend.
+	// These errors suggest a connection-level problem that may recover over time.
+	// Note: By the time caller receives this, morpc has already exhausted internal retries.
+	StatusUnavailable
+
+	// StatusCancelled indicates the operation was cancelled by the client side.
+	// Examples: client closed, context cancelled.
+	// Whether to retry depends on the caller's shutdown logic.
+	StatusCancelled
+
+	// StatusUnknown indicates the error category cannot be determined.
+	// Callers should handle these conservatively based on their specific requirements.
+	StatusUnknown
+)
+
+// String returns the string representation of the status category.
+func (s StatusCategory) String() string {
+	switch s {
+	case StatusOK:
+		return "ok"
+	case StatusTransient:
+		return "transient"
+	case StatusUnavailable:
+		return "unavailable"
+	case StatusCancelled:
+		return "cancelled"
+	default:
+		return "unknown"
+	}
+}
+
+// GetStatusCategory classifies an error into a semantic category.
+// This provides a unified way to understand RPC errors without checking
+// individual error codes.
+//
+// Usage patterns:
+//   - lockservice: Use IsUnavailable() to detect definitive failures
+//   - CDC: Use IsTransient() || IsUnavailable() to detect retryable errors
+func GetStatusCategory(err error) StatusCategory {
+	if err == nil {
+		return StatusOK
+	}
+
+	// Check moerr codes first (most specific)
+	if moerr.IsMoErrCode(err, moerr.ErrRPCTimeout) {
+		return StatusTransient
+	}
+	if moerr.IsMoErrCode(err, moerr.ErrServiceUnavailable) ||
+		moerr.IsMoErrCode(err, moerr.ErrConnectionReset) {
+		return StatusTransient
+	}
+
+	// Connection-level unavailability
+	if moerr.IsMoErrCode(err, moerr.ErrBackendClosed) ||
+		moerr.IsMoErrCode(err, moerr.ErrNoAvailableBackend) ||
+		moerr.IsMoErrCode(err, moerr.ErrBackendCannotConnect) {
+		return StatusUnavailable
+	}
+
+	// Client-side cancellation
+	if moerr.IsMoErrCode(err, moerr.ErrClientClosed) ||
+		moerr.IsMoErrCode(err, moerr.ErrStreamClosed) {
+		return StatusCancelled
+	}
+
+	// Check standard context errors
+	if errors.Is(err, context.Canceled) {
+		return StatusCancelled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return StatusTransient
+	}
+
+	// Check standard io errors (connection issues)
+	if errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, os.ErrDeadlineExceeded) {
+		return StatusTransient
+	}
+
+	// Check net.Error for timeout
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return StatusTransient
+		}
+		// Other net errors are unavailable
+		return StatusUnavailable
+	}
+
+	// Check for connection reset by peer (common pattern)
+	if strings.Contains(err.Error(), "connection reset by peer") ||
+		strings.Contains(err.Error(), "broken pipe") {
+		return StatusTransient
+	}
+
+	return StatusUnknown
+}
+
+// IsTransient returns true if the error is a transient failure.
+// Transient errors are temporary and may succeed on immediate retry.
+// Examples: timeout, temporary network issues.
+func IsTransient(err error) bool {
+	return GetStatusCategory(err) == StatusTransient
+}
+
+// IsUnavailable returns true if the error indicates service unavailability.
+// This means the backend/connection is currently down.
+// By the time caller receives this, morpc has already exhausted internal retries.
+//
+// Usage:
+//   - lockservice: Use this to detect when lock table bindings should be refreshed
+//   - txn/rpc: Use this to detect when to switch to a different TN
+func IsUnavailable(err error) bool {
+	return GetStatusCategory(err) == StatusUnavailable
+}
+
+// IsCancelled returns true if the error indicates client-side cancellation.
+// Examples: client closed, context cancelled.
+//
+// Usage:
+//   - During shutdown, this is expected and should not trigger retries
+//   - CDC may choose to retry by creating a new client
+func IsCancelled(err error) bool {
+	return GetStatusCategory(err) == StatusCancelled
+}
+
+// IsConnectionError returns true if the error is related to connection issues.
+// This includes both transient network problems and unavailable backends.
+// Convenience function combining transient and unavailable categories.
+func IsConnectionError(err error) bool {
+	cat := GetStatusCategory(err)
+	return cat == StatusTransient || cat == StatusUnavailable
+}
+
+// IsRetryableForCDC returns true if the error should trigger retry in CDC-style callers.
+// This is a convenience function for callers that want to retry on any
+// connection-related error, including client cancellation (for reconnection).
+//
+// Note: This differs from lockservice semantics where ErrClientClosed means
+// the local client is shutting down and should not retry.
+func IsRetryableForCDC(err error) bool {
+	cat := GetStatusCategory(err)
+	return cat == StatusTransient || cat == StatusUnavailable || cat == StatusCancelled
+}
+
+// IsDefinitiveFailure returns true if the error indicates a definitive failure
+// where the remote service is considered unavailable.
+// This is the opposite of "transient" - the failure is not temporary.
+//
+// Usage (lockservice style):
+//   - If true: The remote is definitely gone, take action (refresh bindings, etc.)
+//   - If false: Be conservative, assume things might still be OK
+func IsDefinitiveFailure(err error) bool {
+	cat := GetStatusCategory(err)
+	return cat == StatusUnavailable || cat == StatusCancelled
+}

--- a/pkg/common/morpc/status_test.go
+++ b/pkg/common/morpc/status_test.go
@@ -1,0 +1,295 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusCategoryString(t *testing.T) {
+	tests := []struct {
+		cat    StatusCategory
+		expect string
+	}{
+		{StatusOK, "ok"},
+		{StatusTransient, "transient"},
+		{StatusUnavailable, "unavailable"},
+		{StatusCancelled, "cancelled"},
+		{StatusUnknown, "unknown"},
+		{StatusCategory(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expect, func(t *testing.T) {
+			assert.Equal(t, tt.expect, tt.cat.String())
+		})
+	}
+}
+
+func TestGetStatusCategory(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected StatusCategory
+	}{
+		// Nil error
+		{"nil error", nil, StatusOK},
+
+		// Transient errors (moerr)
+		{"ErrRPCTimeout", moerr.NewRPCTimeoutNoCtx(), StatusTransient},
+		{"ErrServiceUnavailable", moerr.NewServiceUnavailableNoCtx("test"), StatusTransient},
+		{"ErrConnectionReset", moerr.NewConnectionReset(context.Background()), StatusTransient},
+
+		// Unavailable errors (moerr)
+		{"ErrBackendClosed", moerr.NewBackendClosedNoCtx(), StatusUnavailable},
+		{"ErrNoAvailableBackend", moerr.NewNoAvailableBackendNoCtx(), StatusUnavailable},
+		{"ErrBackendCannotConnect", moerr.NewBackendCannotConnectNoCtx(errors.New("conn failed")), StatusUnavailable},
+
+		// Cancelled errors (moerr)
+		{"ErrClientClosed", moerr.NewClientClosedNoCtx(), StatusCancelled},
+		{"ErrStreamClosed", moerr.NewStreamClosedNoCtx(), StatusCancelled},
+
+		// Context errors
+		{"context.Canceled", context.Canceled, StatusCancelled},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, StatusTransient},
+
+		// IO errors
+		{"io.EOF", io.EOF, StatusTransient},
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, StatusTransient},
+		{"os.ErrDeadlineExceeded", os.ErrDeadlineExceeded, StatusTransient},
+
+		// String pattern matching
+		{"connection reset by peer", errors.New("connection reset by peer"), StatusTransient},
+		{"broken pipe", errors.New("write: broken pipe"), StatusTransient},
+
+		// Unknown errors
+		{"generic error", errors.New("some random error"), StatusUnknown},
+		{"wrapped unknown", fmt.Errorf("wrapped: %w", errors.New("inner")), StatusUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetStatusCategory(tt.err)
+			assert.Equal(t, tt.expected, got, "error: %v", tt.err)
+		})
+	}
+}
+
+// mockNetError implements net.Error for testing
+type mockNetError struct {
+	timeout   bool
+	temporary bool
+}
+
+func (e *mockNetError) Error() string   { return "mock net error" }
+func (e *mockNetError) Timeout() bool   { return e.timeout }
+func (e *mockNetError) Temporary() bool { return e.temporary }
+
+var _ net.Error = (*mockNetError)(nil)
+
+func TestGetStatusCategoryNetError(t *testing.T) {
+	tests := []struct {
+		name     string
+		timeout  bool
+		expected StatusCategory
+	}{
+		{"net timeout error", true, StatusTransient},
+		{"net non-timeout error", false, StatusUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &mockNetError{timeout: tt.timeout}
+			got := GetStatusCategory(err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestIsTransient(t *testing.T) {
+	assert.True(t, IsTransient(moerr.NewRPCTimeoutNoCtx()))
+	assert.True(t, IsTransient(context.DeadlineExceeded))
+	assert.True(t, IsTransient(io.EOF))
+
+	assert.False(t, IsTransient(nil))
+	assert.False(t, IsTransient(moerr.NewBackendClosedNoCtx()))
+	assert.False(t, IsTransient(moerr.NewClientClosedNoCtx()))
+}
+
+func TestIsUnavailable(t *testing.T) {
+	assert.True(t, IsUnavailable(moerr.NewBackendClosedNoCtx()))
+	assert.True(t, IsUnavailable(moerr.NewNoAvailableBackendNoCtx()))
+	assert.True(t, IsUnavailable(moerr.NewBackendCannotConnectNoCtx(errors.New("test"))))
+	assert.True(t, IsUnavailable(&mockNetError{timeout: false}))
+
+	assert.False(t, IsUnavailable(nil))
+	assert.False(t, IsUnavailable(moerr.NewRPCTimeoutNoCtx()))
+	assert.False(t, IsUnavailable(moerr.NewClientClosedNoCtx()))
+}
+
+func TestIsCancelled(t *testing.T) {
+	assert.True(t, IsCancelled(moerr.NewClientClosedNoCtx()))
+	assert.True(t, IsCancelled(moerr.NewStreamClosedNoCtx()))
+	assert.True(t, IsCancelled(context.Canceled))
+
+	assert.False(t, IsCancelled(nil))
+	assert.False(t, IsCancelled(moerr.NewRPCTimeoutNoCtx()))
+	assert.False(t, IsCancelled(moerr.NewBackendClosedNoCtx()))
+}
+
+func TestIsConnectionError(t *testing.T) {
+	// Should be true for both transient and unavailable
+	assert.True(t, IsConnectionError(moerr.NewRPCTimeoutNoCtx()))
+	assert.True(t, IsConnectionError(moerr.NewBackendClosedNoCtx()))
+	assert.True(t, IsConnectionError(io.EOF))
+
+	// Should be false for cancelled and unknown
+	assert.False(t, IsConnectionError(nil))
+	assert.False(t, IsConnectionError(moerr.NewClientClosedNoCtx()))
+	assert.False(t, IsConnectionError(errors.New("random error")))
+}
+
+func TestIsRetryableForCDC(t *testing.T) {
+	// CDC retries on transient, unavailable, AND cancelled
+	assert.True(t, IsRetryableForCDC(moerr.NewRPCTimeoutNoCtx()))
+	assert.True(t, IsRetryableForCDC(moerr.NewBackendClosedNoCtx()))
+	assert.True(t, IsRetryableForCDC(moerr.NewClientClosedNoCtx()))
+	assert.True(t, IsRetryableForCDC(context.Canceled))
+
+	// Not retryable: nil and unknown
+	assert.False(t, IsRetryableForCDC(nil))
+	assert.False(t, IsRetryableForCDC(errors.New("unknown error")))
+}
+
+func TestIsDefinitiveFailure(t *testing.T) {
+	// Definitive: unavailable and cancelled
+	assert.True(t, IsDefinitiveFailure(moerr.NewBackendClosedNoCtx()))
+	assert.True(t, IsDefinitiveFailure(moerr.NewClientClosedNoCtx()))
+	assert.True(t, IsDefinitiveFailure(moerr.NewNoAvailableBackendNoCtx()))
+
+	// Not definitive: transient, ok, unknown
+	assert.False(t, IsDefinitiveFailure(nil))
+	assert.False(t, IsDefinitiveFailure(moerr.NewRPCTimeoutNoCtx()))
+	assert.False(t, IsDefinitiveFailure(io.EOF))
+	assert.False(t, IsDefinitiveFailure(errors.New("unknown")))
+}
+
+// TestLockserviceCompatibility verifies that the new API is compatible with
+// lockservice's isRetryError semantics.
+// lockservice: isRetryError returns FALSE for ErrBackendClosed/ErrBackendCannotConnect
+// Our equivalent: IsDefinitiveFailure returns TRUE for these errors
+func TestLockserviceCompatibility(t *testing.T) {
+	// These should be "definitive" (lockservice: !isRetryError)
+	definitiveErrors := []error{
+		moerr.NewBackendClosedNoCtx(),
+		moerr.NewBackendCannotConnectNoCtx(errors.New("test")),
+	}
+
+	for _, err := range definitiveErrors {
+		assert.True(t, IsDefinitiveFailure(err),
+			"lockservice expects this to be definitive: %v", err)
+		assert.True(t, IsUnavailable(err),
+			"should be unavailable: %v", err)
+	}
+
+	// These should be "transient" (lockservice: isRetryError returns true)
+	transientErrors := []error{
+		moerr.NewRPCTimeoutNoCtx(),
+		context.DeadlineExceeded,
+		io.EOF,
+	}
+
+	for _, err := range transientErrors {
+		assert.False(t, IsDefinitiveFailure(err),
+			"lockservice expects this to be transient: %v", err)
+		assert.True(t, IsTransient(err),
+			"should be transient: %v", err)
+	}
+}
+
+// TestCDCCompatibility verifies that the new API is compatible with
+// CDC's determineRetryable semantics.
+func TestCDCCompatibility(t *testing.T) {
+	// These are all retryable in CDC
+	retryableErrors := []error{
+		moerr.NewRPCTimeoutNoCtx(),
+		moerr.NewNoAvailableBackendNoCtx(),
+		moerr.NewBackendCannotConnectNoCtx(errors.New("test")),
+		moerr.NewClientClosedNoCtx(),
+		moerr.NewBackendClosedNoCtx(),
+		moerr.NewServiceUnavailableNoCtx("test"),
+		context.DeadlineExceeded,
+	}
+
+	for _, err := range retryableErrors {
+		assert.True(t, IsRetryableForCDC(err),
+			"CDC expects this to be retryable: %v", err)
+	}
+}
+
+func TestWrappedErrors(t *testing.T) {
+	// Test that wrapped errors are properly classified
+	wrapped := fmt.Errorf("operation failed: %w", context.DeadlineExceeded)
+	assert.Equal(t, StatusTransient, GetStatusCategory(wrapped))
+	assert.True(t, IsTransient(wrapped))
+
+	wrapped2 := fmt.Errorf("connection issue: %w", io.EOF)
+	assert.Equal(t, StatusTransient, GetStatusCategory(wrapped2))
+	assert.True(t, IsTransient(wrapped2))
+
+	wrapped3 := fmt.Errorf("cancelled: %w", context.Canceled)
+	assert.Equal(t, StatusCancelled, GetStatusCategory(wrapped3))
+	assert.True(t, IsCancelled(wrapped3))
+}
+
+// Benchmark to ensure classification is fast
+func BenchmarkGetStatusCategory(b *testing.B) {
+	err := moerr.NewRPCTimeoutNoCtx()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		GetStatusCategory(err)
+	}
+}
+
+// TestRealWorldTimeout tests with a real timeout scenario
+func TestRealWorldTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond) // Ensure timeout
+
+	err := ctx.Err()
+	assert.Equal(t, StatusTransient, GetStatusCategory(err))
+	assert.True(t, IsTransient(err))
+}
+
+// TestRealWorldCancel tests with a real cancel scenario
+func TestRealWorldCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	err := ctx.Err()
+	assert.Equal(t, StatusCancelled, GetStatusCategory(err))
+	assert.True(t, IsCancelled(err))
+}

--- a/pkg/common/morpc/types.go
+++ b/pkg/common/morpc/types.go
@@ -89,8 +89,9 @@ type RPCClient interface {
 	Send(ctx context.Context, backend string, request Message) (*Future, error)
 	// NewStream create a stream used to asynchronous stream of sending and receiving messages.
 	// If the underlying connection is reset during the duration of the stream, then the stream will
-	// be closed.
-	NewStream(backend string, lock bool) (Stream, error)
+	// be closed. The context is used to control cancellation of stream creation; if the context
+	// is cancelled during connection establishment or retry backoff, NewStream will return immediately.
+	NewStream(ctx context.Context, backend string, lock bool) (Stream, error)
 	// Ping is used to check if the remote service is available. The remote service will reply with
 	// a pong when it receives the ping.
 	Ping(ctx context.Context, backend string) error

--- a/pkg/lockservice/log.go
+++ b/pkg/lockservice/log.go
@@ -704,6 +704,16 @@ func logUnlockTableOnRemoteFailed(
 	bind pb.LockTable,
 	err error,
 ) {
+	logUnlockTableOnRemoteFailedWithCount(logger, txn, bind, err, 0)
+}
+
+func logUnlockTableOnRemoteFailedWithCount(
+	logger *log.MOLogger,
+	txn *activeTxn,
+	bind pb.LockTable,
+	err error,
+	retryCount int,
+) {
 	if logger == nil {
 		return
 	}
@@ -713,6 +723,7 @@ func logUnlockTableOnRemoteFailed(
 		getLogOptions(zap.ErrorLevel),
 		txnField(txn),
 		zap.String("bind", bind.DebugString()),
+		zap.Int("retry-count", retryCount),
 		zap.Error(err),
 	)
 }

--- a/pkg/lockservice/log.go
+++ b/pkg/lockservice/log.go
@@ -698,15 +698,6 @@ func logUnlockTableOnRemote(
 	}
 }
 
-func logUnlockTableOnRemoteFailed(
-	logger *log.MOLogger,
-	txn *activeTxn,
-	bind pb.LockTable,
-	err error,
-) {
-	logUnlockTableOnRemoteFailedWithCount(logger, txn, bind, err, 0)
-}
-
 func logUnlockTableOnRemoteFailedWithCount(
 	logger *log.MOLogger,
 	txn *activeTxn,

--- a/pkg/logutil/rate_limited.go
+++ b/pkg/logutil/rate_limited.go
@@ -1,0 +1,169 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// RateLimitedLogger wraps a zap.Logger with rate limiting to prevent log storms.
+// It limits log output by both count and time interval.
+type RateLimitedLogger struct {
+	logger *zap.Logger
+	// callerSkipLogger is used for logging with correct caller frame.
+	// It has CallerSkip(2) to account for the wrapper methods.
+	callerSkipLogger *zap.Logger
+
+	mu struct {
+		sync.Mutex
+		states map[string]*rateLimitState
+	}
+}
+
+// rateLimitState tracks the state of a particular log message for rate limiting.
+type rateLimitState struct {
+	count      int64     // total occurrences since last log
+	suppressed int64     // count of suppressed logs
+	lastLog    time.Time // last time this message was logged
+}
+
+// RateLimitConfig configures rate limiting behavior.
+type RateLimitConfig struct {
+	// Interval is the minimum time between log outputs for the same message.
+	// Default: 10 seconds
+	Interval time.Duration
+	// BurstCount is the number of logs allowed in burst before rate limiting kicks in.
+	// First N occurrences are always logged.
+	// Default: 3
+	BurstCount int
+	// SampleInterval is the count interval at which to log even when rate limited.
+	// e.g., 100 means log every 100th occurrence.
+	// Default: 100
+	SampleInterval int
+}
+
+var (
+	// DefaultRateLimitConfig is the default configuration for rate limiting.
+	DefaultRateLimitConfig = RateLimitConfig{
+		Interval:       10 * time.Second,
+		BurstCount:     3,
+		SampleInterval: 100,
+	}
+)
+
+// NewRateLimitedLogger creates a new rate-limited logger wrapper.
+// It automatically adds CallerSkip(2) to ensure correct caller information
+// is displayed in logs (accounting for Error/Warn -> logWithConfig call chain).
+func NewRateLimitedLogger(logger *zap.Logger) *RateLimitedLogger {
+	rl := &RateLimitedLogger{
+		logger:           logger,
+		callerSkipLogger: logger.WithOptions(zap.AddCallerSkip(2)),
+	}
+	rl.mu.states = make(map[string]*rateLimitState)
+	return rl
+}
+
+// Error logs at error level with rate limiting.
+// The key parameter is used to identify unique log sources for rate limiting.
+func (l *RateLimitedLogger) Error(key string, msg string, fields ...zap.Field) {
+	l.logWithConfig(key, zap.ErrorLevel, msg, DefaultRateLimitConfig, fields...)
+}
+
+// ErrorWithConfig logs at error level with custom rate limit configuration.
+func (l *RateLimitedLogger) ErrorWithConfig(key string, msg string, config RateLimitConfig, fields ...zap.Field) {
+	l.logWithConfig(key, zap.ErrorLevel, msg, config, fields...)
+}
+
+// Warn logs at warn level with rate limiting.
+func (l *RateLimitedLogger) Warn(key string, msg string, fields ...zap.Field) {
+	l.logWithConfig(key, zap.WarnLevel, msg, DefaultRateLimitConfig, fields...)
+}
+
+// WarnWithConfig logs at warn level with custom rate limit configuration.
+func (l *RateLimitedLogger) WarnWithConfig(key string, msg string, config RateLimitConfig, fields ...zap.Field) {
+	l.logWithConfig(key, zap.WarnLevel, msg, config, fields...)
+}
+
+func (l *RateLimitedLogger) logWithConfig(key string, level zapcore.Level, msg string, config RateLimitConfig, fields ...zap.Field) {
+	l.mu.Lock()
+	state, ok := l.mu.states[key]
+	if !ok {
+		state = &rateLimitState{}
+		l.mu.states[key] = state
+	}
+	l.mu.Unlock()
+
+	count := atomic.AddInt64(&state.count, 1)
+	now := time.Now()
+
+	shouldLog := false
+
+	// Always log the first N occurrences (burst)
+	if count <= int64(config.BurstCount) {
+		shouldLog = true
+	} else if count%int64(config.SampleInterval) == 0 {
+		// Log every Nth occurrence when rate limited
+		shouldLog = true
+	} else {
+		// Check time-based rate limiting
+		l.mu.Lock()
+		if now.Sub(state.lastLog) >= config.Interval {
+			shouldLog = true
+		}
+		l.mu.Unlock()
+	}
+
+	if shouldLog {
+		l.mu.Lock()
+		suppressed := atomic.SwapInt64(&state.suppressed, 0)
+		state.lastLog = now
+		l.mu.Unlock()
+
+		if suppressed > 0 {
+			fields = append(fields, zap.Int64("suppressed", suppressed))
+		}
+		fields = append(fields, zap.Int64("occurrence", count))
+
+		if ce := l.callerSkipLogger.Check(level, msg); ce != nil {
+			ce.Write(fields...)
+		}
+	} else {
+		atomic.AddInt64(&state.suppressed, 1)
+	}
+}
+
+// Reset resets the rate limiting state for a specific key.
+func (l *RateLimitedLogger) Reset(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.mu.states, key)
+}
+
+// ResetAll resets all rate limiting states.
+func (l *RateLimitedLogger) ResetAll() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.mu.states = make(map[string]*rateLimitState)
+}
+
+// Logger returns the underlying zap.Logger.
+func (l *RateLimitedLogger) Logger() *zap.Logger {
+	return l.logger
+}

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -301,7 +301,7 @@ func (tRpcClient *testRpcClient) Send(ctx context.Context, backend string, reque
 	panic("implement me")
 }
 
-func (tRpcClient *testRpcClient) NewStream(backend string, lock bool) (morpc.Stream, error) {
+func (tRpcClient *testRpcClient) NewStream(ctx context.Context, backend string, lock bool) (morpc.Stream, error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -350,7 +350,7 @@ func newMessageSenderOnClient(
 	mp *mpool.MPool,
 	analyzeModule *AnalyzeModule,
 ) (*messageSenderOnClient, error) {
-	streamSender, err := cnclient.GetPipelineClient(sid).NewStream(toAddr)
+	streamSender, err := cnclient.GetPipelineClient(sid).NewStream(ctx, toAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/compile/remoterunClient_test.go
+++ b/pkg/sql/compile/remoterunClient_test.go
@@ -44,7 +44,7 @@ type testPipelineClient struct {
 	genStream func(string) morpc.Stream
 }
 
-func (tPCli *testPipelineClient) NewStream(backend string) (morpc.Stream, error) {
+func (tPCli *testPipelineClient) NewStream(ctx context.Context, backend string) (morpc.Stream, error) {
 	return tPCli.genStream(backend), nil
 }
 

--- a/pkg/txn/rpc/sender.go
+++ b/pkg/txn/rpc/sender.go
@@ -229,7 +229,7 @@ func (s *sender) createStream(ctx context.Context, tn metadata.TNShard, size int
 			return ls, nil
 		}
 	}
-	return s.client.NewStream(tn.Address, false)
+	return s.client.NewStream(ctx, tn.Address, false)
 }
 
 func (s *sender) acquireLocalStream() *localStream {

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -134,7 +134,6 @@ func New(
 	}
 
 	e.pClient.LogtailRPCClientFactory = DefaultNewRpcStreamToTnLogTailService
-	e.pClient.ctx = ctx
 
 	err = initMoTableStatsConfig(ctx, e)
 	if err != nil {

--- a/pkg/vm/engine/tae/logtail/service/server_test.go
+++ b/pkg/vm/engine/tae/logtail/service/server_test.go
@@ -61,7 +61,7 @@ func TestService(t *testing.T) {
 	rpcClient, err := morpc.NewClient("", bf, morpc.WithClientMaxBackendPerHost(1))
 	require.NoError(t, err)
 
-	rpcStream, err := rpcClient.NewStream(address, false)
+	rpcStream, err := rpcClient.NewStream(context.Background(), address, false)
 	require.NoError(t, err)
 
 	logtailClient, err := NewLogtailClient(context.TODO(), rpcStream, WithClientRequestPerSecond(100))

--- a/pkg/vm/engine/test/testutil/rpc.go
+++ b/pkg/vm/engine/test/testutil/rpc.go
@@ -60,6 +60,7 @@ func (a *MockRPCAgent) Close() {
 }
 
 func (a *MockRPCAgent) MockLogtailRPCClientFactory(
+	ctx context.Context,
 	sid string,
 	serverAddr string,
 	ownClient morpc.RPCClient,
@@ -70,7 +71,7 @@ func (a *MockRPCAgent) MockLogtailRPCClientFactory(
 
 	var err error
 
-	stream, _ := a.client.NewStream("", false)
+	stream, _ := a.client.NewStream(ctx, "", false)
 	return a.client, stream, err
 }
 
@@ -106,7 +107,7 @@ func (c *MockLogtailRPCClient) Send(ctx context.Context, backend string, request
 	return nil, nil
 }
 
-func (c *MockLogtailRPCClient) NewStream(backend string, lock bool) (morpc.Stream, error) {
+func (c *MockLogtailRPCClient) NewStream(ctx context.Context, backend string, lock bool) (morpc.Stream, error) {
 	stream := new(MockRPCClientStream)
 	stream.receiver = c.responseReceiver
 	stream.sender = c.requestSender


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #23222 #22052

## What this PR does / why we need it:

1. Eliminated Log Storms from RPC Errors

    - Modified high-frequency RPC error creation functions (NewXXXNoCtx) to suppress automatic logging

    - Added NoReportContext() utility in moerr package for creating errors without triggering logs

     - Preserved backward compatibility - context-aware error functions still log as expected

2. Enhanced RPC Error Classification

    - Added new error types: ErrServiceUnavailable and ErrConnectionReset
    - Improved error messages with clearer semantics
    - Added helper functions IsConnectionRelatedRPCError() and IsRPCClientClosed() for better 

3. error categorization

    - Implemented Circuit Breaker Pattern
    - Added configurable circuit breaker mechanism to prevent cascading failures
    - Provides automatic failure detection and recovery with configurable thresholds

4. Added Rate Limiting for Error Logs

    - Implemented rate-limited logging for backend operations to prevent log flooding
    - Applied to common error scenarios like connection resets and write failures

5. Improved Error Semantics

    - Enhanced error categorization with transient/unavailable/cancelled classifications
    - Added compatibility layers for different consumers (CDC, lockservice) with specific retry semantics