### PR TITLE
fix: Autocommit Status Sync Issue - 3.0-dev

### DIFF
--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -1571,11 +1571,12 @@ func (ses *Session) getCNLabels() map[string]string {
 func (ses *Session) SetNewResponse(category int, affectedRows uint64, cmd int, d interface{}, isLastStmt bool) *Response {
 	// If the stmt has next stmt, should add SERVER_MORE_RESULTS_EXISTS to the server status.
 	var resp *Response
+	serverStatus := ses.GetTxnHandler().GetServerStatus()
 	if !isLastStmt {
 		resp = NewResponse(category, affectedRows, 0, 0,
-			ses.GetTxnHandler().GetServerStatus()|SERVER_MORE_RESULTS_EXISTS, cmd, d)
+			serverStatus|SERVER_MORE_RESULTS_EXISTS, cmd, d)
 	} else {
-		resp = NewResponse(category, affectedRows, 0, 0, ses.GetTxnHandler().GetServerStatus(), cmd, d)
+		resp = NewResponse(category, affectedRows, 0, 0, serverStatus, cmd, d)
 	}
 	return resp
 }

--- a/pkg/frontend/txn.go
+++ b/pkg/frontend/txn.go
@@ -237,10 +237,14 @@ func (th *TxnHandler) GetTxnCtx() context.Context {
 }
 
 // invalidateTxnUnsafe releases the txnOp and clears the server status bit SERVER_STATUS_IN_TRANS
+// It preserves autocommit-related flags (SERVER_STATUS_AUTOCOMMIT, OPTION_AUTOCOMMIT, OPTION_NOT_AUTOCOMMIT)
+// since they are session-level settings that should persist across transactions.
 func (th *TxnHandler) invalidateTxnUnsafe() {
 	th.txnOp = nil
-	resetBits(&th.serverStatus, defaultServerStatus)
-	resetBits(&th.optionBits, defaultOptionBits)
+	// Preserve SERVER_STATUS_AUTOCOMMIT flag, only clear SERVER_STATUS_IN_TRANS
+	clearBits(&th.serverStatus, uint32(SERVER_STATUS_IN_TRANS))
+	// Preserve autocommit option bits (OPTION_AUTOCOMMIT or OPTION_NOT_AUTOCOMMIT), only clear OPTION_BEGIN
+	clearBits(&th.optionBits, OPTION_BEGIN)
 }
 
 func (th *TxnHandler) InActiveTxn() bool {

--- a/pkg/frontend/txn_test.go
+++ b/pkg/frontend/txn_test.go
@@ -974,3 +974,402 @@ func (txnop *testTxnOp) ExitRollbackStmt() {
 func (txnop *testTxnOp) SetFootPrints(id int, enter bool) {
 
 }
+
+// TestAutocommitStatusSync tests that autocommit status is correctly preserved
+// after transaction commit/rollback. This is the fix for the issue where
+// SET autocommit=0 changes were being overwritten by invalidateTxnUnsafe.
+func TestAutocommitStatusSync(t *testing.T) {
+	convey.Convey("autocommit status sync after SET autocommit=0", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
+		txnClient := mock_frontend.NewMockTxnClient(ctrl)
+		txnClient.EXPECT().New(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, commitTS timestamp.Timestamp, options ...TxnOption) (client.TxnOperator, error) {
+				return newTestTxnOp(), nil
+			}).AnyTimes()
+		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		eng.EXPECT().Hints().Return(engine.Hints{
+			CommitOrRollbackTimeout: time.Second,
+		}).AnyTimes()
+
+		ses := newTestSession(t, ctrl)
+		getPu("").TxnClient = txnClient
+		ses.txnHandler.storage = eng
+
+		ec := newTestExecCtx(ctx, ctrl)
+		ec.ses = ses
+
+		// Case 1: SET autocommit=0 should preserve status after commit
+		// This is the main bug case - autocommit status was being reset to ON
+		convey.Convey("SET autocommit=0 preserves status after commit", func() {
+			// Start with autocommit=true (default)
+			ec.txnOpt = FeTxnOption{autoCommit: true}
+			err := ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify initial state: autocommit is ON
+			serverStatus := ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, SERVER_STATUS_AUTOCOMMIT)
+
+			// Execute SET autocommit=0 (on -> off)
+			err = ses.GetTxnHandler().SetAutocommit(ec, true, false)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify: autocommit should be OFF in serverStatus
+			serverStatus = ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+			convey.So(ses.GetTxnHandler().OptionBitsIsSet(OPTION_NOT_AUTOCOMMIT), convey.ShouldBeTrue)
+			convey.So(ses.GetTxnHandler().OptionBitsIsSet(OPTION_AUTOCOMMIT), convey.ShouldBeFalse)
+
+			// The fix ensures that after SetAutocommit commits the txn,
+			// invalidateTxnUnsafe preserves the autocommit=OFF status
+			// Before the fix: serverStatus would be reset to 0x0002 (AUTOCOMMIT=ON)
+			// After the fix: serverStatus should remain 0x0000 (AUTOCOMMIT=OFF)
+			serverStatus = ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+		})
+	})
+
+	convey.Convey("autocommit status sync after SET autocommit=1", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
+		txnClient := mock_frontend.NewMockTxnClient(ctrl)
+		txnClient.EXPECT().New(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, commitTS timestamp.Timestamp, options ...TxnOption) (client.TxnOperator, error) {
+				return newTestTxnOp(), nil
+			}).AnyTimes()
+		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		eng.EXPECT().Hints().Return(engine.Hints{
+			CommitOrRollbackTimeout: time.Second,
+		}).AnyTimes()
+
+		ses := newTestSession(t, ctrl)
+		getPu("").TxnClient = txnClient
+		ses.txnHandler.storage = eng
+
+		ec := newTestExecCtx(ctx, ctrl)
+		ec.ses = ses
+
+		// Case 2: SET autocommit=1 (off -> on) should work correctly
+		convey.Convey("SET autocommit=1 from OFF state", func() {
+			// Start with autocommit=false
+			ec.txnOpt = FeTxnOption{autoCommit: false}
+			err := ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify: autocommit is OFF
+			serverStatus := ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+
+			// Execute SET autocommit=1 (off -> on)
+			err = ses.GetTxnHandler().SetAutocommit(ec, false, true)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify: autocommit should be ON
+			serverStatus = ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, SERVER_STATUS_AUTOCOMMIT)
+			convey.So(ses.GetTxnHandler().OptionBitsIsSet(OPTION_NOT_AUTOCOMMIT), convey.ShouldBeFalse)
+		})
+	})
+
+	convey.Convey("autocommit status multiple transitions", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
+		txnClient := mock_frontend.NewMockTxnClient(ctrl)
+		txnClient.EXPECT().New(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, commitTS timestamp.Timestamp, options ...TxnOption) (client.TxnOperator, error) {
+				return newTestTxnOp(), nil
+			}).AnyTimes()
+		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		eng.EXPECT().Hints().Return(engine.Hints{
+			CommitOrRollbackTimeout: time.Second,
+		}).AnyTimes()
+
+		ses := newTestSession(t, ctrl)
+		getPu("").TxnClient = txnClient
+		ses.txnHandler.storage = eng
+
+		ec := newTestExecCtx(ctx, ctrl)
+		ec.ses = ses
+
+		// Case 3: Multiple transitions ON -> OFF -> ON
+		convey.Convey("ON -> OFF -> ON transitions", func() {
+			// Start with autocommit=true
+			ec.txnOpt = FeTxnOption{autoCommit: true}
+			err := ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify initial: autocommit ON
+			serverStatus := ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, SERVER_STATUS_AUTOCOMMIT)
+
+			// Transition 1: ON -> OFF
+			err = ses.GetTxnHandler().SetAutocommit(ec, true, false)
+			convey.So(err, convey.ShouldBeNil)
+			serverStatus = ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+
+			// Create a new transaction with autocommit=false
+			ec.txnOpt = FeTxnOption{autoCommit: false}
+			err = ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify: still OFF after new txn creation
+			serverStatus = ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+
+			// Transition 2: OFF -> ON
+			err = ses.GetTxnHandler().SetAutocommit(ec, false, true)
+			convey.So(err, convey.ShouldBeNil)
+			serverStatus = ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, SERVER_STATUS_AUTOCOMMIT)
+		})
+	})
+}
+
+// TestInvalidateTxnUnsafePreservesAutocommit tests that invalidateTxnUnsafe
+// correctly preserves autocommit-related flags while clearing transaction flags.
+func TestInvalidateTxnUnsafePreservesAutocommit(t *testing.T) {
+	convey.Convey("invalidateTxnUnsafe preserves autocommit flags", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
+		txnClient := mock_frontend.NewMockTxnClient(ctrl)
+		txnClient.EXPECT().New(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, commitTS timestamp.Timestamp, options ...TxnOption) (client.TxnOperator, error) {
+				return newTestTxnOp(), nil
+			}).AnyTimes()
+		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		eng.EXPECT().Hints().Return(engine.Hints{
+			CommitOrRollbackTimeout: time.Second,
+		}).AnyTimes()
+
+		ses := newTestSession(t, ctrl)
+		getPu("").TxnClient = txnClient
+		ses.txnHandler.storage = eng
+
+		ec := newTestExecCtx(ctx, ctrl)
+		ec.ses = ses
+
+		// Test case: After commit, SERVER_STATUS_IN_TRANS should be cleared
+		// but SERVER_STATUS_AUTOCOMMIT should be preserved based on session setting
+		convey.Convey("commit clears IN_TRANS but preserves AUTOCOMMIT=OFF", func() {
+			// Create txn with autocommit=false
+			ec.txnOpt = FeTxnOption{autoCommit: false}
+			err := ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify: IN_TRANS is set, AUTOCOMMIT is not set
+			serverStatus := ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_IN_TRANS, convey.ShouldEqual, SERVER_STATUS_IN_TRANS)
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+
+			// Commit the transaction using byCommit flag (simulates COMMIT statement)
+			ec.txnOpt.byCommit = true
+			err = ses.GetTxnHandler().Commit(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// After commit: IN_TRANS should be cleared, AUTOCOMMIT should still be OFF
+			serverStatus = ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_IN_TRANS, convey.ShouldEqual, uint16(0))
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+		})
+
+		convey.Convey("commit clears IN_TRANS but preserves AUTOCOMMIT=ON", func() {
+			// Create txn with autocommit=true (single-statement mode)
+			ec.txnOpt = FeTxnOption{autoCommit: true}
+			err := ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify: IN_TRANS is set, AUTOCOMMIT is set
+			serverStatus := ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_IN_TRANS, convey.ShouldEqual, SERVER_STATUS_IN_TRANS)
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, SERVER_STATUS_AUTOCOMMIT)
+
+			// Commit the transaction (in single-statement mode, any statement commits)
+			ec.stmt = &tree.Select{}
+			err = ses.GetTxnHandler().Commit(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// After commit: IN_TRANS should be cleared, AUTOCOMMIT should still be ON
+			serverStatus = ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_IN_TRANS, convey.ShouldEqual, uint16(0))
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, SERVER_STATUS_AUTOCOMMIT)
+		})
+
+		convey.Convey("rollback clears IN_TRANS but preserves AUTOCOMMIT=OFF", func() {
+			// Create txn with autocommit=false
+			ec.txnOpt = FeTxnOption{autoCommit: false}
+			err := ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify: IN_TRANS is set, AUTOCOMMIT is not set
+			serverStatus := ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_IN_TRANS, convey.ShouldEqual, SERVER_STATUS_IN_TRANS)
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+
+			// Rollback the transaction using byRollback flag (simulates ROLLBACK statement)
+			ec.txnOpt.byRollback = true
+			err = ses.GetTxnHandler().Rollback(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// After rollback: IN_TRANS should be cleared, AUTOCOMMIT should still be OFF
+			serverStatus = ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_IN_TRANS, convey.ShouldEqual, uint16(0))
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+		})
+	})
+}
+
+// TestOptionBitsPreservedAfterInvalidate tests that OPTION_AUTOCOMMIT and
+// OPTION_NOT_AUTOCOMMIT are preserved after transaction invalidation,
+// while OPTION_BEGIN is correctly cleared.
+func TestOptionBitsPreservedAfterInvalidate(t *testing.T) {
+	convey.Convey("option bits preserved after invalidate", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
+		txnClient := mock_frontend.NewMockTxnClient(ctrl)
+		txnClient.EXPECT().New(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, commitTS timestamp.Timestamp, options ...TxnOption) (client.TxnOperator, error) {
+				return newTestTxnOp(), nil
+			}).AnyTimes()
+		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		eng.EXPECT().Hints().Return(engine.Hints{
+			CommitOrRollbackTimeout: time.Second,
+		}).AnyTimes()
+
+		ses := newTestSession(t, ctrl)
+		getPu("").TxnClient = txnClient
+		ses.txnHandler.storage = eng
+
+		ec := newTestExecCtx(ctx, ctrl)
+		ec.ses = ses
+
+		convey.Convey("OPTION_BEGIN is cleared but OPTION_NOT_AUTOCOMMIT preserved after commit", func() {
+			// Create txn with BEGIN and autocommit=false
+			ec.txnOpt = FeTxnOption{autoCommit: false, byBegin: true}
+			err := ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify: OPTION_BEGIN and OPTION_NOT_AUTOCOMMIT are set
+			convey.So(ses.GetTxnHandler().OptionBitsIsSet(OPTION_BEGIN), convey.ShouldBeTrue)
+			convey.So(ses.GetTxnHandler().OptionBitsIsSet(OPTION_NOT_AUTOCOMMIT), convey.ShouldBeTrue)
+
+			// Commit by COMMIT statement
+			ec.txnOpt.byCommit = true
+			err = ses.GetTxnHandler().Commit(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// After commit: OPTION_BEGIN should be cleared, OPTION_NOT_AUTOCOMMIT should be preserved
+			convey.So(ses.GetTxnHandler().OptionBitsIsSet(OPTION_BEGIN), convey.ShouldBeFalse)
+			convey.So(ses.GetTxnHandler().OptionBitsIsSet(OPTION_NOT_AUTOCOMMIT), convey.ShouldBeTrue)
+		})
+
+		convey.Convey("OPTION_AUTOCOMMIT preserved after commit with autocommit=true", func() {
+			// Create txn with BEGIN and autocommit=true
+			ec.txnOpt = FeTxnOption{autoCommit: true, byBegin: true}
+			err := ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify: OPTION_BEGIN is set, OPTION_AUTOCOMMIT should be default
+			convey.So(ses.GetTxnHandler().OptionBitsIsSet(OPTION_BEGIN), convey.ShouldBeTrue)
+
+			// Commit by COMMIT statement
+			ec.txnOpt.byCommit = true
+			err = ses.GetTxnHandler().Commit(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// After commit: OPTION_BEGIN should be cleared
+			convey.So(ses.GetTxnHandler().OptionBitsIsSet(OPTION_BEGIN), convey.ShouldBeFalse)
+		})
+	})
+}
+
+// TestSetAutocommitStatusInResponse verifies that the server status returned
+// to the client correctly reflects the autocommit state after SET autocommit.
+// This tests the end-to-end scenario described in the bug report.
+func TestSetAutocommitStatusInResponse(t *testing.T) {
+	convey.Convey("server status in response reflects autocommit state", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := defines.AttachAccountId(context.TODO(), sysAccountID)
+		txnClient := mock_frontend.NewMockTxnClient(ctrl)
+		txnClient.EXPECT().New(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, commitTS timestamp.Timestamp, options ...TxnOption) (client.TxnOperator, error) {
+				return newTestTxnOp(), nil
+			}).AnyTimes()
+		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		eng.EXPECT().Hints().Return(engine.Hints{
+			CommitOrRollbackTimeout: time.Second,
+		}).AnyTimes()
+
+		ses := newTestSession(t, ctrl)
+		getPu("").TxnClient = txnClient
+		ses.txnHandler.storage = eng
+
+		ec := newTestExecCtx(ctx, ctrl)
+		ec.ses = ses
+
+		// Simulate the bug scenario:
+		// 1. Connection starts with autocommit=true
+		// 2. Execute SET autocommit=0
+		// 3. The server status returned should have AUTOCOMMIT=false
+		convey.Convey("SET autocommit=0 returns correct server status", func() {
+			// Start with autocommit=true
+			ec.txnOpt = FeTxnOption{autoCommit: true}
+			err := ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Execute SET autocommit=0
+			err = ses.GetTxnHandler().SetAutocommit(ec, true, false)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Get the server status (this is what would be sent to the client)
+			serverStatus := ses.GetTxnHandler().GetServerStatus()
+
+			// Bug scenario: Before fix, serverStatus would have AUTOCOMMIT bit set (0x0002)
+			// After fix, serverStatus should NOT have AUTOCOMMIT bit set
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+
+			// Note: We don't check IN_TRANS here because after SetAutocommit commits the
+			// current transaction, a new one may be started depending on the session state
+		})
+
+		convey.Convey("SET autocommit=1 returns correct server status", func() {
+			// Start with autocommit=false
+			ec.txnOpt = FeTxnOption{autoCommit: false}
+			err := ses.GetTxnHandler().Create(ec)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Verify autocommit is OFF
+			serverStatus := ses.GetTxnHandler().GetServerStatus()
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, uint16(0))
+
+			// Execute SET autocommit=1
+			err = ses.GetTxnHandler().SetAutocommit(ec, false, true)
+			convey.So(err, convey.ShouldBeNil)
+
+			// Get the server status
+			serverStatus = ses.GetTxnHandler().GetServerStatus()
+
+			// serverStatus should have AUTOCOMMIT bit set
+			convey.So(serverStatus&SERVER_STATUS_AUTOCOMMIT, convey.ShouldEqual, SERVER_STATUS_AUTOCOMMIT)
+		})
+	})
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23328 

## What this PR does / why we need it:

#### Changes
1. **Core Fix**: Modified `invalidateTxnUnsafe` in `pkg/frontend/txn.go` to preserve autocommit-related flags while only clearing transaction-specific flags
2. **Comprehensive Tests**: Added 4 new test functions with 11 test cases covering various autocommit scenarios
3. **Documentation**: Added detailed analysis of the issue and fix