### PR TITLE
 support variable enable_vector_prefilter_by_default

### DIFF
--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -3570,12 +3570,12 @@ var gSysVarsDefs = map[string]SystemVariable{
 		Type:              InitSystemVariableIntType("ivf_threads_search", 0, 1024, false),
 		Default:           int64(0),
 	},
-	"pre_filter_for_vector_test": {
-		Name:              "pre_filter_for_vector_test",
+	"enable_vector_prefilter_by_default": {
+		Name:              "enable_vector_prefilter_by_default",
 		Scope:             ScopeSession,
 		Dynamic:           true,
 		SetVarHintApplies: false,
-		Type:              InitSystemVariableBoolType("pre_filter_for_vector_test"),
+		Type:              InitSystemVariableBoolType("enable_vector_prefilter_by_default"),
 		Default:           int8(0),
 	},
 	"probe_limit": {

--- a/pkg/sql/plan/apply_indices_ivfflat.go
+++ b/pkg/sql/plan/apply_indices_ivfflat.go
@@ -51,10 +51,12 @@ func (builder *QueryBuilder) prepareIvfIndexContext(vecCtx *vectorSortContext, m
 		return nil, nil
 	}
 
-	var preFilterForVectorTest bool
-	if val, err := builder.compCtx.ResolveVariable("pre_filter_for_vector_test", true, false); err == nil && val != nil {
+	// Check if vector pre-filter pushdown should be enabled by default
+	// This session variable changes the default vector search behavior
+	var enableVectorPrefilterByDefault bool
+	if val, err := builder.compCtx.ResolveVariable("enable_vector_prefilter_by_default", true, false); err == nil && val != nil {
 		if v, ok := val.(int8); ok && v == 1 {
-			preFilterForVectorTest = true
+			enableVectorPrefilterByDefault = true
 		}
 	}
 
@@ -128,7 +130,7 @@ func (builder *QueryBuilder) prepareIvfIndexContext(vecCtx *vectorSortContext, m
 		params:          idxDef.IndexAlgoParams,
 		nThread:         nThread.(int64),
 		nProbe:          nProbe,
-		pushdownEnabled: (vecCtx.rankOption != nil && vecCtx.rankOption.Mode == "pre") || (vecCtx.rankOption == nil && preFilterForVectorTest),
+		pushdownEnabled: (vecCtx.rankOption != nil && vecCtx.rankOption.Mode == "pre") || (vecCtx.rankOption == nil && enableVectorPrefilterByDefault),
 	}, nil
 }
 

--- a/test/distributed/cases/vector/vector_ivf_session_var.result
+++ b/test/distributed/cases/vector/vector_ivf_session_var.result
@@ -8,7 +8,7 @@ INSERT INTO mini_vector_data (id, text, vec) VALUES ('id3','vector search test',
 select id, text, vec from mini_vector_data order by l2_distance(vec, '[0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1]') limit 1;
 id    text    vec
 id2    greeting message    [0.44, 0.09, -0.31, 0.62, 0.18, -0.55, 0.21, 0.33]
-set pre_filter_for_vector_test = 1;
+set enable_vector_prefilter_by_default = 1;
 select id, text, vec from mini_vector_data order by l2_distance(vec, '[0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1]') limit 1;
 id    text    vec
 id2    greeting message    [0.44, 0.09, -0.31, 0.62, 0.18, -0.55, 0.21, 0.33]
@@ -21,5 +21,5 @@ id2    greeting message    [0.44, 0.09, -0.31, 0.62, 0.18, -0.55, 0.21, 0.33]
 select id, text, vec from mini_vector_data order by l2_distance(vec, '[0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1]') limit 1 by rank with option 'mode=pre';
 id    text    vec
 id2    greeting message    [0.44, 0.09, -0.31, 0.62, 0.18, -0.55, 0.21, 0.33]
-set pre_filter_for_vector_test = 0;
+set enable_vector_prefilter_by_default = 0;
 drop database vec_session_var_db;

--- a/test/distributed/cases/vector/vector_ivf_session_var.sql
+++ b/test/distributed/cases/vector/vector_ivf_session_var.sql
@@ -10,7 +10,7 @@ INSERT INTO mini_vector_data (id, text, vec) VALUES ('id3','vector search test',
 select id, text, vec from mini_vector_data order by l2_distance(vec, '[0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1]') limit 1;
 
 -- Set session variable
-set pre_filter_for_vector_test = 1;
+set enable_vector_prefilter_by_default = 1;
 
 -- Test 1: Should trigger pushdown path (variable logic)
 select id, text, vec from mini_vector_data order by l2_distance(vec, '[0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1]') limit 1;
@@ -24,6 +24,6 @@ select id, text, vec from mini_vector_data order by l2_distance(vec, '[0.1,0.1,0
 -- Test 4: mode=pre should explicitly enable pushdown (consistent with variable)
 select id, text, vec from mini_vector_data order by l2_distance(vec, '[0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1]') limit 1 by rank with option 'mode=pre';
 
-set pre_filter_for_vector_test = 0;
+set enable_vector_prefilter_by_default = 0;
 
 drop database vec_session_var_db;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23345 

## What this PR does / why we need it:

 support variable pre_filter_for_vector_test