### PR TITLE
to 3.0: Fix null mask mutation during shrink in multi_update

### DIFF
--- a/pkg/sql/colexec/multi_update/clone_selected_vecs_test.go
+++ b/pkg/sql/colexec/multi_update/clone_selected_vecs_test.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multi_update
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneSelectedVecsFromCompactBatches_NullMask(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	defer mpool.DeleteMPool(mp)
+
+	bat := batch.NewWithSize(2)
+	bat.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	defer bat.Clean(mp)
+
+	for i := 0; i < 4; i++ {
+		isNull := i == 1 || i == 3
+		require.NoError(t, vector.AppendFixed(bat.Vecs[0], int64(i), isNull, mp))
+		require.NoError(t, vector.AppendFixed(bat.Vecs[1], int64(100+i), false, mp))
+	}
+	bat.SetRowCount(4)
+
+	sourceBats := batch.NewCompactBatchs(10)
+	require.NoError(t, sourceBats.Push(mp, bat))
+
+	cloned, err := cloneSelectedVecsFromCompactBatches(
+		sourceBats,
+		[]int{0, 1},
+		[]string{"a", "b"},
+		0,
+		mp,
+	)
+	require.NoError(t, err)
+	require.Len(t, cloned, 1)
+	defer func() {
+		for _, cb := range cloned {
+			if cb != nil {
+				cb.Clean(mp)
+			}
+		}
+	}()
+
+	got := cloned[0]
+	require.Equal(t, 2, got.RowCount())
+	require.Equal(t, got.RowCount(), got.Vecs[0].Length())
+	require.Equal(t, got.RowCount(), got.Vecs[1].Length())
+
+	col0 := vector.MustFixedColWithTypeCheck[int64](got.Vecs[0])
+	col1 := vector.MustFixedColWithTypeCheck[int64](got.Vecs[1])
+	require.Equal(t, []int64{0, 2}, col0)
+	require.Equal(t, []int64{100, 102}, col1)
+}

--- a/pkg/sql/colexec/multi_update/s3writer_delegate.go
+++ b/pkg/sql/colexec/multi_update/s3writer_delegate.go
@@ -875,7 +875,8 @@ func cloneSelectedVecsFromCompactBatches(
 		}
 
 		if selectColsCheckNullColIdx > -1 && tmpBat.Vecs[selectColsCheckNullColIdx].HasNull() {
-			sortKeyNulls := tmpBat.Vecs[selectColsCheckNullColIdx].GetNulls().GetBitmap()
+			// Clone bitmap to avoid in-place mutation during shrink.
+			sortKeyNulls := tmpBat.Vecs[selectColsCheckNullColIdx].GetNulls().GetBitmap().Clone()
 			tmpBat.ShrinkByMask(sortKeyNulls, true, 0)
 		}
 		if tmpBat.RowCount() == 0 {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/23385

## What this PR does / why we need it:

 - Clone the sort-key null bitmap before shrinking to avoid in-place mask mutation that breaks row filtering.
  - Add a regression test that reproduces the incorrect row count/value alignment when nulls exist.
  - Improves correctness for index table batch shrinking.

  Testing

 go test ./pkg/sql/colexec/multi_update -run TestCloneSelectedVecsFromCompactBatches_NullMask