### PR TITLE
Revert "Fix hashagg spill memory accounting (#23398)"

### DIFF
--- a/pkg/sql/colexec/group/exec2.go
+++ b/pkg/sql/colexec/group/exec2.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -42,7 +43,7 @@ const (
 
 func (group *Group) Prepare(proc *process.Process) (err error) {
 	group.ctr.state = vm.Build
-	group.ctr.mp = proc.Mp()
+	group.ctr.mp = mpool.MustNewNoFixed("group_mpool")
 
 	// debug,
 	// group.ctr.mp.EnableDetailRecording()

--- a/pkg/sql/colexec/group/mergeGroup.go
+++ b/pkg/sql/colexec/group/mergeGroup.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/aggexec"
@@ -28,7 +29,7 @@ import (
 
 func (mergeGroup *MergeGroup) Prepare(proc *process.Process) error {
 	mergeGroup.ctr.state = vm.Build
-	mergeGroup.ctr.mp = proc.Mp()
+	mergeGroup.ctr.mp = mpool.MustNewNoFixed("merge_group_mpool")
 
 	if mergeGroup.OpAnalyzer != nil {
 		mergeGroup.OpAnalyzer.Reset()

--- a/pkg/sql/colexec/group/types2.go
+++ b/pkg/sql/colexec/group/types2.go
@@ -194,6 +194,7 @@ func (ctr *container) free(proc *process.Process) {
 	ctr.freeAggList(proc)
 	ctr.freeSpillBkts(proc)
 
+	mpool.DeleteMPool(ctr.mp)
 	ctr.mp = nil
 }
 
@@ -206,9 +207,9 @@ func (ctr *container) reset(proc *process.Process) {
 
 	ctr.resetForSpill(proc)
 	ctr.freeSpillBkts(proc)
-	if ctr.mp == nil {
-		ctr.mp = proc.Mp()
-	}
+
+	mpool.DeleteMPool(ctr.mp)
+	ctr.mp = mpool.MustNewNoFixed("group_mpool")
 }
 
 func (ctr *container) resetForSpill(proc *process.Process) {


### PR DESCRIPTION
This reverts commit 7587b3bdf38c23ef2cc6eaea6244ceebadbf26f4.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/23296

## What this PR does / why we need it:
revert #23398, #23293 already has the fix.