### PR TITLE
fix(mpool): Fix cross-pool free memory leak and optimize with sharded locks

### DIFF
--- a/pkg/common/mpool/mpool_test.go
+++ b/pkg/common/mpool/mpool_test.go
@@ -198,7 +198,6 @@ func TestMPoolNoLock(t *testing.T) {
 	require.Equal(t, int64(0), mp2.CurrNB())
 }
 
-
 // TestCrossPoolFreeOffHeap tests that cross-pool free correctly deallocates offHeap memory.
 // This catches the bug where cross-pool free only recorded stats but didn't actually free memory.
 func TestCrossPoolFreeOffHeap(t *testing.T) {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23421

## What this PR does / why we need it:

Fixes memory leak introduced in #23293

### Bugs Fixed:
1. **Cross-pool free memory leak**: offHeap memory was not being deallocated when freed from a different pool
2. **Incorrect deallocateAllPtrs size calculation**: was using `allocSz + kMemHdrSz` but new design doesn't allocate headers
3. **Stats inconsistency**: cross-pool free didn't properly update original pool stats

### Performance Optimizations:
- **Sharded locks**: Replace single global lock (`globalPtrsMu`) with 128 sharded locks (`globalPtrShards`) to reduce lock contention
- **Better hash distribution**: Use FNV-like hash mixing for even shard distribution

### Key Changes:
- Restore delegation to original pool for cross-pool free to ensure correct stats tracking
- Handle edge case where original pool is deleted before cross-pool free
- Fix `deallocateAllPtrs` to only deallocate offHeap memory with correct size
- Replace `globalPtrs + globalPtrsMu` with `globalPtrShards[128]` for better concurrency


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix cross-pool free memory leak by delegating to original pool

- Replace global lock with 128 sharded locks for better concurrency

- Fix deallocateAllPtrs to only deallocate offHeap memory correctly

- Add comprehensive tests for cross-pool free and concurrent operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cross-pool Free Request"] --> B{"Original Pool Exists?"}
  B -->|Yes| C["Delegate to Original Pool"]
  B -->|No| D["Free Memory Directly"]
  C --> E["Update Stats Correctly"]
  D --> E
  F["Global Ptr Map"] --> G["128 Sharded Locks"]
  G --> H["Reduced Lock Contention"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mpool.go</strong><dd><code>Implement sharded locks and fix cross-pool free delegation</code></dd></summary>
<hr>

pkg/common/mpool/mpool.go

<ul><li>Fixed <code>deallocateAllPtrs</code> to only deallocate offHeap memory with correct <br>size (removed kMemHdrSz)<br> <li> Replaced single global lock (<code>globalPtrsMu</code>) with 128 sharded locks <br>(<code>globalPtrShards</code>) using FNV-like hash mixing<br> <li> Refactored <code>freePtr</code> to delegate cross-pool free to original pool via <br>new <code>freePtrInternal</code> method<br> <li> Added edge case handling when original pool is deleted before <br>cross-pool free<br> <li> Initialize sharded pointer maps in <code>init()</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23423/files#diff-464ac4ea6ea162c1e0867b367c850faf4525f2518a4099319f0e944457cae7c1">+57/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mpool_test.go</strong><dd><code>Add comprehensive tests for memory management fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/common/mpool/mpool_test.go

<ul><li>Added <code>TestCrossPoolFreeOffHeap</code> to verify offHeap memory deallocation <br>on cross-pool free<br> <li> Added <code>TestCrossPoolFreeOnHeap</code> to verify on-heap cross-pool free <br>behavior<br> <li> Added <code>TestDoubleFree</code> to verify double free detection and panic<br> <li> Added <code>TestConcurrentAllocFree</code> to test concurrent allocation/free with <br>sharded locks<br> <li> Added <code>TestConcurrentCrossPoolFree</code> to test concurrent cross-pool <br>operations<br> <li> Added <code>TestAllocZeroSize</code>, <code>TestFreeNil</code>, and <code>TestShardDistribution</code> for <br>edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23423/files#diff-01e2ed668061952031bd9d6a3ca32adcff3aad73e7abf9e7519d7e6992dad197">+177/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

