### PR TITLE
enhancement(go-runtime): trace object zero-allocation and HashMap caching to reduce GC pressure

### DIFF
--- a/pkg/common/log/logger.go
+++ b/pkg/common/log/logger.go
@@ -59,11 +59,18 @@ func (l *MOLogger) Named(name string) *MOLogger {
 }
 
 func (l *MOLogger) WithContext(ctx context.Context) *MOLogger {
-	if ctx == nil || ctx == context.TODO() || ctx == context.Background() {
-		panic("nil, context.TODO() and context.Background() are not supported")
+	if ctx == nil {
+		panic("nil context is not supported")
 	}
-	if sc := trace.SpanFromContext(ctx).SpanContext(); trace.IsEnable() && sc.IsEmpty() {
-		panic("context with empty SpanContext are not supported")
+	// When tracing is enabled, context.TODO() and context.Background() are not allowed
+	// because they don't have trace information. When tracing is disabled, they are allowed.
+	if trace.IsEnable() {
+		if ctx == context.TODO() || ctx == context.Background() {
+			panic("context.TODO() and context.Background() are not supported when tracing is enabled")
+		}
+		if sc := trace.SpanFromContext(ctx).SpanContext(); sc.IsEmpty() {
+			panic("context with empty SpanContext are not supported when tracing is enabled")
+		}
 	}
 	return newMOLogger(l.logger, ctx)
 }
@@ -202,9 +209,15 @@ func wrapWithContext(logger *zap.Logger, ctx context.Context) *MOLogger {
 	if logger == nil {
 		panic("zap logger is nil")
 	}
-	if ctx != nil &&
-		(ctx == context.TODO() || ctx == context.Background()) {
-		panic("TODO and Background are not supported")
+	// When tracing is enabled, context.TODO() and context.Background() are not allowed
+	// because they don't have trace information. When tracing is disabled, they are allowed.
+	if ctx != nil && trace.IsEnable() {
+		if ctx == context.TODO() || ctx == context.Background() {
+			panic("TODO and Background are not supported when tracing is enabled")
+		}
+		if sc := trace.SpanFromContext(ctx).SpanContext(); sc.IsEmpty() {
+			panic("context with empty SpanContext are not supported when tracing is enabled")
+		}
 	}
 
 	return newMOLogger(
@@ -225,11 +238,15 @@ func (opts LogOptions) WithContext(ctx context.Context) LogOptions {
 	if ctx == nil {
 		panic("context is nil")
 	}
-	if ctx == context.TODO() || ctx == context.Background() {
-		panic("TODO and Background contexts are not supported")
-	}
-	if sc := trace.SpanFromContext(ctx).SpanContext(); trace.IsEnable() && sc.IsEmpty() {
-		panic("context with empty SpanContext are not supported")
+	// When tracing is enabled, context.TODO() and context.Background() are not allowed
+	// because they don't have trace information. When tracing is disabled, they are allowed.
+	if trace.IsEnable() {
+		if ctx == context.TODO() || ctx == context.Background() {
+			panic("TODO and Background contexts are not supported when tracing is enabled")
+		}
+		if sc := trace.SpanFromContext(ctx).SpanContext(); sc.IsEmpty() {
+			panic("context with empty SpanContext are not supported when tracing is enabled")
+		}
 	}
 
 	opts.ctx = ctx

--- a/pkg/common/log/logger_test.go
+++ b/pkg/common/log/logger_test.go
@@ -1,0 +1,170 @@
+// Copyright 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/util/trace"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// mockEnabledTracer is a tracer that reports IsEnable() = true
+type mockEnabledTracer struct {
+	trace.NoopTracer
+}
+
+func (m mockEnabledTracer) IsEnable(opts ...trace.SpanStartOption) bool {
+	return true
+}
+
+func TestMOLogger_WithContext(t *testing.T) {
+	logger := wrap(zap.NewNop())
+
+	t.Run("nil context should panic", func(t *testing.T) {
+		assert.Panics(t, func() {
+			logger.WithContext(nil)
+		})
+	})
+
+	t.Run("trace disabled - TODO and Background allowed", func(t *testing.T) {
+		// NoopTracer is the default, IsEnable() returns false
+		trace.SetDefaultTracer(trace.NoopTracer{})
+
+		assert.NotPanics(t, func() {
+			logger.WithContext(context.TODO())
+		})
+		assert.NotPanics(t, func() {
+			logger.WithContext(context.Background())
+		})
+	})
+
+	t.Run("trace enabled - TODO and Background should panic", func(t *testing.T) {
+		trace.SetDefaultTracer(mockEnabledTracer{})
+		defer trace.SetDefaultTracer(trace.NoopTracer{})
+
+		assert.Panics(t, func() {
+			logger.WithContext(context.TODO())
+		})
+		assert.Panics(t, func() {
+			logger.WithContext(context.Background())
+		})
+	})
+
+	t.Run("trace enabled - empty SpanContext should panic", func(t *testing.T) {
+		trace.SetDefaultTracer(mockEnabledTracer{})
+		defer trace.SetDefaultTracer(trace.NoopTracer{})
+
+		// A custom context without span info
+		ctx := context.WithValue(context.Background(), "key", "value")
+		assert.Panics(t, func() {
+			logger.WithContext(ctx)
+		})
+	})
+}
+
+func TestWrapWithContext(t *testing.T) {
+	zapLogger := zap.NewNop()
+
+	t.Run("nil logger should panic", func(t *testing.T) {
+		assert.Panics(t, func() {
+			wrapWithContext(nil, context.Background())
+		})
+	})
+
+	t.Run("nil context allowed", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			wrapWithContext(zapLogger, nil)
+		})
+	})
+
+	t.Run("trace disabled - TODO and Background allowed", func(t *testing.T) {
+		trace.SetDefaultTracer(trace.NoopTracer{})
+
+		assert.NotPanics(t, func() {
+			wrapWithContext(zapLogger, context.TODO())
+		})
+		assert.NotPanics(t, func() {
+			wrapWithContext(zapLogger, context.Background())
+		})
+	})
+
+	t.Run("trace enabled - TODO and Background should panic", func(t *testing.T) {
+		trace.SetDefaultTracer(mockEnabledTracer{})
+		defer trace.SetDefaultTracer(trace.NoopTracer{})
+
+		assert.Panics(t, func() {
+			wrapWithContext(zapLogger, context.TODO())
+		})
+		assert.Panics(t, func() {
+			wrapWithContext(zapLogger, context.Background())
+		})
+	})
+
+	t.Run("trace enabled - empty SpanContext should panic", func(t *testing.T) {
+		trace.SetDefaultTracer(mockEnabledTracer{})
+		defer trace.SetDefaultTracer(trace.NoopTracer{})
+
+		ctx := context.WithValue(context.Background(), "key", "value")
+		assert.Panics(t, func() {
+			wrapWithContext(zapLogger, ctx)
+		})
+	})
+}
+
+func TestLogOptions_WithContext(t *testing.T) {
+	opts := DefaultLogOptions()
+
+	t.Run("nil context should panic", func(t *testing.T) {
+		assert.Panics(t, func() {
+			opts.WithContext(nil)
+		})
+	})
+
+	t.Run("trace disabled - TODO and Background allowed", func(t *testing.T) {
+		trace.SetDefaultTracer(trace.NoopTracer{})
+
+		assert.NotPanics(t, func() {
+			opts.WithContext(context.TODO())
+		})
+		assert.NotPanics(t, func() {
+			opts.WithContext(context.Background())
+		})
+	})
+
+	t.Run("trace enabled - TODO and Background should panic", func(t *testing.T) {
+		trace.SetDefaultTracer(mockEnabledTracer{})
+		defer trace.SetDefaultTracer(trace.NoopTracer{})
+
+		assert.Panics(t, func() {
+			opts.WithContext(context.TODO())
+		})
+		assert.Panics(t, func() {
+			opts.WithContext(context.Background())
+		})
+	})
+
+	t.Run("trace enabled - empty SpanContext should panic", func(t *testing.T) {
+		trace.SetDefaultTracer(mockEnabledTracer{})
+		defer trace.SetDefaultTracer(trace.NoopTracer{})
+
+		ctx := context.WithValue(context.Background(), "key", "value")
+		assert.Panics(t, func() {
+			opts.WithContext(ctx)
+		})
+	})
+}

--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -69,7 +69,12 @@ func init() {
 			return &HashBuild{}
 		},
 		func(a *HashBuild) {
+			// Preserve cached iterators across pool resets to avoid reallocating
+			// short-lived iterator buffers. Detach owners so old hashmaps can be GC'd.
+			intItr, strItr := a.ctr.hashmapBuilder.ExtractCachedIteratorsForReuse()
+
 			*a = HashBuild{}
+			a.ctr.hashmapBuilder.RestoreCachedIterators(intItr, strItr)
 		},
 		reuse.DefaultOptions[HashBuild]().
 			WithEnableChecker(),

--- a/pkg/sql/colexec/hashmap_util/hashmap_util_test.go
+++ b/pkg/sql/colexec/hashmap_util/hashmap_util_test.go
@@ -15,15 +15,21 @@
 package hashmap_util
 
 import (
+	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
-
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,6 +94,369 @@ func TestHashMapAllocAndFree(t *testing.T) {
 	err = hb.IntHashMap.PreAlloc(100000000)
 	require.NoError(t, err)
 	hb.IntHashMap.Free()
+}
+
+func TestIteratorReuseAcrossBuilds(t *testing.T) {
+	var hb HashmapBuilder
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+
+	b := testutil.NewBatch([]types.Type{types.T_int32.ToType()}, true, 16, proc.Mp())
+	defer b.Clean(proc.Mp())
+
+	hb.InputBatchRowCount = b.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(b, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedIntIterator)
+	itr1 := hb.cachedIntIterator
+
+	// Reset should detach owner but keep iterator for reuse.
+	hb.Reset(proc, true)
+	require.NotNil(t, hb.cachedIntIterator)
+	require.Same(t, itr1, hb.cachedIntIterator)
+
+	// Next build should reuse the same iterator instance.
+	hb.InputBatchRowCount = b.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(b, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.Same(t, itr1, hb.cachedIntIterator)
+}
+
+func TestStrIteratorCapacityPrune(t *testing.T) {
+	var hb HashmapBuilder
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_varchar.ToType())}, -1, proc))
+
+	// Build with an oversized string to inflate iterator buffers beyond threshold.
+	vec := vector.NewVec(types.T_varchar.ToType())
+	large := strings.Repeat("x", hashmap.MaxStrIteratorCapacity+4096)
+	require.NoError(t, vector.AppendBytes(vec, []byte(large), false, proc.Mp()))
+	bat := batch.New([]string{"col"})
+	bat.SetVector(0, vec)
+	bat.SetRowCount(1)
+	hb.InputBatchRowCount = bat.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(bat, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedStrIterator)
+	require.Greater(t, hashmap.StrIteratorCapacity(hb.cachedStrIterator), hashmap.MaxStrIteratorCapacity)
+
+	hb.detachAndPruneCachedIterators()
+	require.Nil(t, hb.cachedStrIterator)
+}
+
+func TestStrIteratorBelowThresholdIsKept(t *testing.T) {
+	var hb HashmapBuilder
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_varchar.ToType())}, -1, proc))
+
+	// Build with small strings so iterator capacity stays below threshold.
+	vec := vector.NewVec(types.T_varchar.ToType())
+	for i := 0; i < 4; i++ {
+		require.NoError(t, vector.AppendBytes(vec, []byte("small"), false, proc.Mp()))
+	}
+	bat := batch.New([]string{"col"})
+	bat.SetVector(0, vec)
+	bat.SetRowCount(vec.Length())
+	hb.InputBatchRowCount = bat.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(bat, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedStrIterator)
+	require.Less(t, hashmap.StrIteratorCapacity(hb.cachedStrIterator), hashmap.MaxStrIteratorCapacity)
+
+	hb.detachAndPruneCachedIterators()
+	require.NotNil(t, hb.cachedStrIterator, "iterator below threshold should be kept")
+}
+
+func TestResetWithHashTableSentKeepsCache(t *testing.T) {
+	var hb HashmapBuilder
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+
+	// Build once to populate cachedIntIterator.
+	b := testutil.NewBatch([]types.Type{types.T_int32.ToType()}, true, 8, proc.Mp())
+	defer b.Clean(proc.Mp())
+	hb.InputBatchRowCount = b.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(b, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedIntIterator)
+
+	// hashTableHasNotSent=false should skip FreeHashMapAndBatches and keep cached iterator.
+	hb.Reset(proc, false)
+	require.NotNil(t, hb.cachedIntIterator)
+}
+
+func TestAlternateIntStrBuildsReuseIndependently(t *testing.T) {
+	var hb HashmapBuilder
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+
+	// First int build
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+	bInt := testutil.NewBatch([]types.Type{types.T_int32.ToType()}, true, 4, proc.Mp())
+	defer bInt.Clean(proc.Mp())
+	hb.InputBatchRowCount = bInt.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(bInt, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedIntIterator)
+	require.Nil(t, hb.cachedStrIterator)
+
+	hb.Reset(proc, true)
+	// Simulate a new plan with different key types.
+	hb.executors = nil
+
+	// Then str build
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_varchar.ToType())}, -1, proc))
+	vec := vector.NewVec(types.T_varchar.ToType())
+	require.NoError(t, vector.AppendBytes(vec, []byte("a"), false, proc.Mp()))
+	bat := batch.New([]string{"col"})
+	bat.SetVector(0, vec)
+	bat.SetRowCount(1)
+	hb.InputBatchRowCount = bat.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(bat, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedStrIterator)
+
+	hb.Reset(proc, true)
+	// Simulate switching back to int keys in a new plan.
+	hb.executors = nil
+
+	// Build int again and ensure int cache still exists (reuse if retained).
+	prevIntItr := hb.cachedIntIterator
+	// Use a fresh int batch to avoid zero-row short-circuit.
+	bInt2 := testutil.NewBatch([]types.Type{types.T_int32.ToType()}, true, 4, proc.Mp())
+	defer bInt2.Clean(proc.Mp())
+	hb.InputBatchRowCount = bInt2.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(bInt2, proc))
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedIntIterator)
+	if prevIntItr != nil {
+		require.Same(t, prevIntItr, hb.cachedIntIterator)
+	}
+}
+
+func TestBuildHashmapWithZeroInputKeepsCachesUntouched(t *testing.T) {
+	var hb HashmapBuilder
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+
+	// No rows added.
+	hb.InputBatchRowCount = 0
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+
+	require.Nil(t, hb.cachedIntIterator)
+	require.Nil(t, hb.cachedStrIterator)
+}
+
+func TestBuildHashmapErrorDoesNotLeakIterators(t *testing.T) {
+	var hb HashmapBuilder
+	mp := mpool.MustNewZero()
+	proc := testutil.NewProcessWithMPool(t, "", mp)
+
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+
+	// Inject a failing executor to trigger an error during evalJoinCondition.
+	hb.executors = []colexec.ExpressionExecutor{failingExecutor{}}
+	hb.InputBatchRowCount = 1
+	hb.Batches.Buf = []*batch.Batch{batch.NewWithSize(1)}
+	hb.Batches.Buf[0].Vecs[0] = testutil.MakeInt32Vector([]int32{1}, nil, proc.Mp())
+	require.Error(t, hb.BuildHashmap(false, false, false, proc))
+	require.Nil(t, hb.cachedIntIterator)
+	require.Nil(t, hb.cachedStrIterator)
+
+	// After failure, a normal path should still succeed and populate cache.
+	hb.executors = nil
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+	hb.InputBatchRowCount = 1
+	hb.Batches.Reset()
+	hb.Batches.Buf = nil
+	intVec := testutil.MakeInt32Vector([]int32{1}, nil, proc.Mp())
+	intBat := batch.New([]string{"col"})
+	intBat.SetVector(0, intVec)
+	intBat.SetRowCount(1)
+	require.NoError(t, hb.Batches.CopyIntoBatches(intBat, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedIntIterator)
+}
+
+func TestFreeThenBuildRepopulatesCache(t *testing.T) {
+	var hb HashmapBuilder
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+
+	// First build to populate cache.
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+	intVec := testutil.MakeInt32Vector([]int32{1, 2}, nil, proc.Mp())
+	intBat := batch.New([]string{"col"})
+	intBat.SetVector(0, intVec)
+	intBat.SetRowCount(2)
+	hb.InputBatchRowCount = intBat.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(intBat, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedIntIterator)
+
+	// Free should clear cache.
+	hb.Free(proc)
+	require.Nil(t, hb.cachedIntIterator)
+	require.Nil(t, hb.cachedStrIterator)
+
+	// Build again after Free should succeed and repopulate cache.
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+	hb.InputBatchRowCount = intBat.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(intBat, proc))
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedIntIterator)
+}
+
+// failingExecutor always returns an error; used to simulate BuildHashmap failure paths.
+type failingExecutor struct{}
+
+func (f failingExecutor) Eval(*process.Process, []*batch.Batch, []bool) (*vector.Vector, error) {
+	return nil, moerr.NewInternalErrorNoCtx("exec failed")
+}
+func (f failingExecutor) EvalWithoutResultReusing(*process.Process, []*batch.Batch, []bool) (*vector.Vector, error) {
+	return nil, moerr.NewInternalErrorNoCtx("exec failed")
+}
+func (f failingExecutor) IsColumnExpr() bool { return false }
+func (f failingExecutor) TypeName() string   { return "failingExecutor" }
+func (f failingExecutor) Free()              {}
+func (f failingExecutor) ResetForNextQuery() {}
+
+// Benchmarks: cached vs new iterator paths for int/str.
+func BenchmarkBuildHashmapCachedInt(b *testing.B) {
+	proc := testutil.NewProcessWithMPool(b, "", mpool.MustNewZero())
+	hb := &HashmapBuilder{}
+	require.NoError(b, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+	data := makeIntBatch(b, 1024, proc)
+	defer data.Clean(proc.Mp())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hb.InputBatchRowCount = data.RowCount()
+		require.NoError(b, hb.Batches.CopyIntoBatches(data, proc))
+		require.NoError(b, hb.BuildHashmap(false, false, false, proc))
+		hb.Reset(proc, true)
+	}
+}
+
+func BenchmarkBuildHashmapCachedStr(b *testing.B) {
+	proc := testutil.NewProcessWithMPool(b, "", mpool.MustNewZero())
+	hb := &HashmapBuilder{}
+	require.NoError(b, hb.Prepare([]*plan.Expr{newExpr(0, types.T_varchar.ToType())}, -1, proc))
+	data := makeStrBatch(b, 1024, proc)
+	defer data.Clean(proc.Mp())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hb.InputBatchRowCount = data.RowCount()
+		require.NoError(b, hb.Batches.CopyIntoBatches(data, proc))
+		require.NoError(b, hb.BuildHashmap(false, false, false, proc))
+		hb.Reset(proc, true)
+	}
+}
+
+func makeIntBatch(tb testing.TB, n int, proc *process.Process) *batch.Batch {
+	ints := make([]int32, n)
+	for i := 0; i < n; i++ {
+		ints[i] = int32(i)
+	}
+	vec := testutil.MakeInt32Vector(ints, nil, proc.Mp())
+	bat := batch.New([]string{"col"})
+	bat.SetVector(0, vec)
+	bat.SetRowCount(n)
+	return bat
+}
+
+func makeStrBatch(tb testing.TB, n int, proc *process.Process) *batch.Batch {
+	vec := vector.NewVec(types.T_varchar.ToType())
+	for i := 0; i < n; i++ {
+		require.NoError(tb, vector.AppendBytes(vec, []byte("v"+strconv.Itoa(i)), false, proc.Mp()))
+	}
+	bat := batch.New([]string{"col"})
+	bat.SetVector(0, vec)
+	bat.SetRowCount(n)
+	return bat
+}
+
+// Cold path benchmarks: recreate builder each iteration (no cached iterator reuse).
+func BenchmarkBuildHashmapColdInt(b *testing.B) {
+	proc := testutil.NewProcessWithMPool(b, "", mpool.MustNewZero())
+	data := makeIntBatch(b, 1024, proc)
+	defer data.Clean(proc.Mp())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hb := &HashmapBuilder{}
+		require.NoError(b, hb.Prepare([]*plan.Expr{newExpr(0, types.T_int32.ToType())}, -1, proc))
+		hb.InputBatchRowCount = data.RowCount()
+		require.NoError(b, hb.Batches.CopyIntoBatches(data, proc))
+		require.NoError(b, hb.BuildHashmap(false, false, false, proc))
+		hb.Free(proc)
+	}
+}
+
+func BenchmarkBuildHashmapColdStr(b *testing.B) {
+	proc := testutil.NewProcessWithMPool(b, "", mpool.MustNewZero())
+	data := makeStrBatch(b, 1024, proc)
+	defer data.Clean(proc.Mp())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		hb := &HashmapBuilder{}
+		require.NoError(b, hb.Prepare([]*plan.Expr{newExpr(0, types.T_varchar.ToType())}, -1, proc))
+		hb.InputBatchRowCount = data.RowCount()
+		require.NoError(b, hb.Batches.CopyIntoBatches(data, proc))
+		require.NoError(b, hb.BuildHashmap(false, false, false, proc))
+		hb.Free(proc)
+	}
+}
+
+func TestExtractRestoreCachedIterators(t *testing.T) {
+	var hb HashmapBuilder
+	mp := mpool.MustNewZero()
+
+	intMap, err := hashmap.NewIntHashMap(false, mp)
+	require.NoError(t, err)
+	strMap, err := hashmap.NewStrHashMap(false, mp)
+	require.NoError(t, err)
+
+	hb.cachedIntIterator = intMap.NewIterator()
+	hb.cachedStrIterator = strMap.NewIterator()
+
+	intItr, strItr := hb.ExtractCachedIteratorsForReuse()
+	require.Nil(t, hb.cachedIntIterator)
+	require.Nil(t, hb.cachedStrIterator)
+
+	// Owners should be cleared after extraction.
+	rvInt := reflect.ValueOf(intItr).Elem()
+	require.True(t, rvInt.FieldByName("mp").IsNil())
+	rvStr := reflect.ValueOf(strItr).Elem()
+	require.True(t, rvStr.FieldByName("mp").IsNil())
+
+	hb.RestoreCachedIterators(intItr, strItr)
+	require.Same(t, intItr, hb.cachedIntIterator)
+	require.Same(t, strItr, hb.cachedStrIterator)
+}
+
+func TestStrIteratorLargeStringTriggersPrune(t *testing.T) {
+	var hb HashmapBuilder
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	require.NoError(t, hb.Prepare([]*plan.Expr{newExpr(0, types.T_varchar.ToType())}, -1, proc))
+
+	// Build a batch with one very large string to bloat iterator buffers.
+	vec := vector.NewVec(types.T_varchar.ToType())
+	large := strings.Repeat("x", hashmap.MaxStrIteratorCapacity+2048)
+	require.NoError(t, vector.AppendBytes(vec, []byte(large), false, proc.Mp()))
+	bat := batch.New([]string{"col"})
+	bat.SetVector(0, vec)
+	bat.SetRowCount(1)
+
+	hb.InputBatchRowCount = bat.RowCount()
+	require.NoError(t, hb.Batches.CopyIntoBatches(bat, proc))
+
+	require.NoError(t, hb.BuildHashmap(false, false, false, proc))
+	require.NotNil(t, hb.cachedStrIterator)
+	require.Greater(t, hashmap.StrIteratorCapacity(hb.cachedStrIterator), hashmap.MaxStrIteratorCapacity)
+
+	hb.Reset(proc, true)
+	require.Nil(t, hb.cachedStrIterator, "iterator with oversized buffers should be dropped")
 }
 
 // TestResetWithNilPointers tests that Reset() handles nil pointers gracefully

--- a/pkg/sql/colexec/hashmap_util/hashmap_util_test.go
+++ b/pkg/sql/colexec/hashmap_util/hashmap_util_test.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"unsafe"
 
 	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -357,7 +356,7 @@ func TestCachedStrIteratorOwnerClearedBeforeReuse(t *testing.T) {
 	rv := reflect.ValueOf(hb.cachedStrIterator).Elem()
 	mpField := rv.FieldByName("mp")
 	require.False(t, mpField.IsNil())
-	require.NotEqual(t, uintptr(unsafe.Pointer(staleMap)), uintptr(mpField.UnsafePointer()))
+	require.NotEqual(t, reflect.ValueOf(staleMap).Pointer(), mpField.Pointer())
 }
 
 func TestSwitchKeyTypeCreatesCorrectIterator(t *testing.T) {
@@ -419,7 +418,7 @@ func TestCachedIteratorOwnerClearedBeforeReuse(t *testing.T) {
 	rv := reflect.ValueOf(hb.cachedIntIterator).Elem()
 	mpField := rv.FieldByName("mp")
 	require.False(t, mpField.IsNil())
-	require.NotEqual(t, uintptr(unsafe.Pointer(staleMap)), uintptr(mpField.UnsafePointer()))
+	require.NotEqual(t, reflect.ValueOf(staleMap).Pointer(), mpField.Pointer())
 }
 
 func TestFreeThenBuildRepopulatesCache(t *testing.T) {

--- a/pkg/util/trace/config.go
+++ b/pkg/util/trace/config.go
@@ -388,6 +388,14 @@ func (f spanOptionFunc) ApplySpanStart(cfg *SpanConfig) {
 	f(cfg)
 }
 
+// KindOption is a zero-allocation SpanStartOption that wraps a SpanKind.
+// It allows IsEnable to extract the Kind directly via type assertion without allocating a SpanConfig.
+type KindOption SpanKind
+
+func (k KindOption) ApplySpanStart(cfg *SpanConfig) {
+	cfg.Kind = SpanKind(k)
+}
+
 func WithNewRoot(newRoot bool) SpanStartOption {
 	return spanOptionFunc(func(cfg *SpanConfig) {
 		cfg.NewRoot = newRoot
@@ -395,9 +403,7 @@ func WithNewRoot(newRoot bool) SpanStartOption {
 }
 
 func WithKind(kind SpanKind) SpanStartOption {
-	return spanOptionFunc(func(cfg *SpanConfig) {
-		cfg.Kind = kind
-	})
+	return KindOption(kind)
 }
 
 // WithLongTimeThreshold set timeout threshold. Span.End will check the Span duration value.


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #12518 

## What this PR does / why we need it:

### Trace Object Zero-Allocation Optimization
  • Optimize NoopTracer.Start and Debug to return ctx, NoopSpan{} directly without any allocation
  • Optimize MOTracer.IsEnable to use type assertion on KindOption instead of allocating SpanConfig
  • Optimize MOTracer.Start to check provider enable state first and parse opts only once
  • Add KindOption type that implements SpanStartOption for zero-allocation Kind extraction
  • Impact: Eliminates ~4GB allocation from trace objects (3.86GB from NoopTracer + ~144 bytes/call from IsEnable)

### HashMap Iterator Caching
  • Add IteratorClearOwner() API to detach iterators from hashmap owners for safe caching
  • Add StrIteratorCapacity() to check string iterator buffer capacity (64KB threshold)
  • Cache int/str iterators in HashmapBuilder and reuse them across BuildHashmap calls
  • Preserve cached iterators during object pool reset in hashbuild/types.go
  • Impact: Reduces iterator allocation from 14.87GB (9.67%) to ~26.56MB (0.05%), a 99.8% reduction

### uniqueSels Buffer Reuse
  • Cache uniqueSels buffer in HashmapBuilder to avoid repeated allocation
  • Reuse uniqueSels slice across BuildHashmap calls using hb.uniqueSels[:0] pattern
  • Impact: Eliminates repeated allocation of newSels buffer (previously 6.19GB, 2.42% of total allocation)


___

### **PR Type**
Enhancement


___

### **Description**
- Optimize NoopTracer to return ctx and NoopSpan{} directly without allocation

- Add KindOption type for zero-allocation Kind extraction in trace options

- Cache int/str iterators in HashmapBuilder and reuse across BuildHashmap calls

- Cache uniqueSels buffer in HashmapBuilder to avoid repeated allocation

- Add iterator capacity checking and pruning for oversized string iterators


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NoopTracer.Start/Debug"] -->|"Zero-allocation return"| B["ctx + NoopSpan{}"]
  C["KindOption Type"] -->|"Type assertion"| D["MOTracer.IsEnable"]
  D -->|"No SpanConfig alloc"| E["Fast path check"]
  F["HashmapBuilder"] -->|"Cache iterators"| G["IntIterator + StrIterator"]
  G -->|"Reuse across builds"| H["BuildHashmap calls"]
  I["StrIterator"] -->|"Capacity check"| J["Prune if > 64KB"]
  K["uniqueSels buffer"] -->|"Cache + reuse"| L["BuildHashmap iterations"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>iterator.go</strong><dd><code>Add iterator owner management and capacity checking APIs</code>&nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23429/files#diff-076226b852dd6f825853e3be6c80a57937515ac61a2fe8e3105e5d9b71763f56">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>types.go</strong><dd><code>Preserve cached iterators across object pool resets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23429/files#diff-270d27fc945ebbe16cfb88efa16c176856d021853abfe9c6429a8d7ca48d6c5f">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hashmap_util.go</strong><dd><code>Implement iterator and uniqueSels buffer caching and reuse</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23429/files#diff-4e472814399bbb0cac40fbad6d42daabca4111e950bebe1a2f5c4dbf8560bd74">+68/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.go</strong><dd><code>Add KindOption type for zero-allocation span kind extraction</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23429/files#diff-6f588d44f64116845b77af5ded375b705033f4c9e7502693e6cecff8b110d231">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mo_trace.go</strong><dd><code>Optimize IsEnable and Start using zero-allocation type assertion</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23429/files#diff-4430cecd2a4e7734d6ce2a2321d296afde107cf8f05859321ca2175283bef69d">+28/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>noop_trace.go</strong><dd><code>Simplify NoopTracer to return ctx and NoopSpan without allocation</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23429/files#diff-3b05d54057e1281ac80f67d4196094edd89a8f66cb36dd8c40d87ad774139722">+13/-21</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>hashmap_util_test.go</strong><dd><code>Add comprehensive tests for iterator caching and buffer reuse</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23429/files#diff-dc62011f0bc0fcb2eb8d9fe366c82ba5265a34cb8efc810e5a21b450763e1320">+513/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>config_test.go</strong><dd><code>Add tests for KindOption implementation and zero-allocation behavior</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23429/files#diff-1d93d9c6ea95e9a15feee3ffb09b669419efc83a5d432d377687e17cac07ea50">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mo_trace_test.go</strong><dd><code>Add tests and benchmarks for zero-allocation IsEnable path</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23429/files#diff-e1f4dec1d053f37ed10baae09d769a4d40881592afb41f7e888f7c50b516cc4a">+159/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>noop_trace_test.go</strong><dd><code>Update tests and add benchmarks for zero-allocation NoopTracer</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23429/files#diff-8faedefa88ec85241a4976f5d218d181a07a2373683ac407cfa9a8a695d224bd">+36/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

