### PR TITLE
fix: morpc client lock contention causing long blocking during CN node terminated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1015,9 +1015,9 @@ fmtErrs := $(shell grep -onr 'fmt.Errorf' pkg/ --exclude-dir=.git --exclude-dir=
 				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
 errNews := $(shell grep -onr 'errors.New' pkg/ --exclude-dir=.git --exclude-dir=vendor \
 				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
-withTimeout := $(shell grep -onr 'context.WithTimeout' pkg/ --exclude-dir=.git --exclude-dir=vendor \
+withTimeout := $(shell grep -onr 'context\.WithTimeout[^C]' pkg/ --exclude-dir=.git --exclude-dir=vendor \
 				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
-withDeadline := $(shell grep -onr 'context.WithDeadline' pkg/ --exclude-dir=.git --exclude-dir=vendor \
+withDeadline := $(shell grep -onr 'context\.WithDeadline[^C]' pkg/ --exclude-dir=.git --exclude-dir=vendor \
 				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
 
 

--- a/pkg/common/morpc/circuit_breaker_test.go
+++ b/pkg/common/morpc/circuit_breaker_test.go
@@ -253,7 +253,7 @@ func TestCircuitBreakerManager(t *testing.T) {
 		ResetTimeout:        100 * time.Millisecond,
 		HalfOpenMaxRequests: 1,
 	}
-	manager := NewCircuitBreakerManager(config, logger)
+	manager := NewCircuitBreakerManager("test-client", config, logger)
 
 	// Different backends have independent circuit breakers
 	assert.True(t, manager.Allow("backend1"))
@@ -281,7 +281,7 @@ func TestCircuitBreakerManagerRemoveBreaker(t *testing.T) {
 		ResetTimeout:        100 * time.Millisecond,
 		HalfOpenMaxRequests: 1,
 	}
-	manager := NewCircuitBreakerManager(config, logger)
+	manager := NewCircuitBreakerManager("test-client", config, logger)
 
 	// Open circuit for backend1
 	manager.RecordFailure("backend1")
@@ -297,7 +297,7 @@ func TestCircuitBreakerManagerRemoveBreaker(t *testing.T) {
 
 func TestCircuitBreakerManagerDisabled(t *testing.T) {
 	logger := zap.NewNop()
-	manager := NewCircuitBreakerManager(DisabledCircuitBreakerConfig, logger)
+	manager := NewCircuitBreakerManager("test-client", DisabledCircuitBreakerConfig, logger)
 
 	// Always allows when disabled
 	for i := 0; i < 100; i++ {

--- a/pkg/common/morpc/client.go
+++ b/pkg/common/morpc/client.go
@@ -851,28 +851,6 @@ func (c *client) closeIdleBackends() int {
 	return len(idleBackends)
 }
 
-func (c *client) createBackend(backend string, lock bool) (Backend, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	b, err := c.getBackendLocked(backend, lock)
-	if err != nil {
-		return nil, err
-	}
-	if b != nil {
-		return b, nil
-	}
-
-	b, err = c.createBackendLocked(backend)
-	if err != nil {
-		return nil, err
-	}
-	if lock {
-		b.Lock()
-	}
-	return b, nil
-}
-
 func (c *client) createBackendLocked(backend string) (Backend, error) {
 	if !c.canCreateLocked(backend) {
 		return nil, moerr.NewNoAvailableBackendNoCtx()

--- a/pkg/common/morpc/client.go
+++ b/pkg/common/morpc/client.go
@@ -694,19 +694,19 @@ func (c *client) getBackend(backend string, lock bool) (Backend, error) {
 		c.mu.Unlock()
 		return b, nil
 	}
-	
+
 	// No backend available in pool
 	// Check if we can create more backends
 	canCreate := c.canCreateLocked(backend)
-	c.mu.Unlock()  // Release lock before any potentially blocking operation
-	
+	c.mu.Unlock() // Release lock before any potentially blocking operation
+
 	if canCreate {
 		// Trigger async backend creation via global GC manager
 		// This avoids holding the lock during network I/O
 		// The backend will be available for subsequent requests
 		globalClientGC.triggerCreate(c, backend)
 	}
-	
+
 	// Return error to trigger retry in caller
 	// The retry mechanism in Send() will handle this gracefully
 	return nil, moerr.NewNoAvailableBackendNoCtx()

--- a/pkg/common/morpc/client.go
+++ b/pkg/common/morpc/client.go
@@ -174,6 +174,16 @@ func applyJitter(duration time.Duration) time.Duration {
 func WithClientEnableAutoCreateBackend() ClientOption {
 	return func(c *client) {
 		c.options.enableAutoCreate = true
+		c.options.enableAutoCreateSet = true
+	}
+}
+
+// WithClientDisableAutoCreateBackend disable client from automatically creating backends.
+// By default, auto-create is enabled. Use this option to disable it.
+func WithClientDisableAutoCreateBackend() ClientOption {
+	return func(c *client) {
+		c.options.enableAutoCreate = false
+		c.options.enableAutoCreateSet = true
 	}
 }
 
@@ -217,6 +227,7 @@ type client struct {
 		initBackends         []string
 		initBackendCounts    []int
 		enableAutoCreate     bool
+		enableAutoCreateSet  bool // true if user explicitly set enableAutoCreate
 		retryPolicy          RetryPolicy
 		circuitBreakerConfig CircuitBreakerConfig
 	}
@@ -277,6 +288,10 @@ func (c *client) adjust() {
 		// Only apply default if user didn't explicitly set it
 		// If user set it to 0, it means "no idle time limit" per documentation
 		c.options.maxIdleDuration = applyJitter(defaultMaxIdleDuration)
+	}
+	// Default enableAutoCreate to true for backward compatibility
+	if !c.options.enableAutoCreateSet {
+		c.options.enableAutoCreate = true
 	}
 	// Set default retry policy if not configured
 	if c.options.retryPolicy.MaxRetries == 0 && c.options.retryPolicy.InitialBackoff == 0 {

--- a/pkg/common/morpc/client_autocreate_test.go
+++ b/pkg/common/morpc/client_autocreate_test.go
@@ -23,17 +23,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestAutoCreateDisabled verifies that when auto-create is disabled,
+// TestAutoCreateDisabled verifies that when auto-create is explicitly disabled,
 // no backends are created and proper error is returned
 func TestAutoCreateDisabled(t *testing.T) {
-	// Create client with auto-create disabled (default)
-	rpcClient, err := NewClient("test", &testBackendFactory{})
+	// Create client with auto-create explicitly disabled
+	rpcClient, err := NewClient("test", &testBackendFactory{}, WithClientDisableAutoCreateBackend())
 	require.NoError(t, err)
 	defer rpcClient.Close()
 
 	c := rpcClient.(*client)
 
-	// Verify auto-create is disabled by default
+	// Verify auto-create is disabled
 	assert.False(t, c.options.enableAutoCreate)
 
 	// getBackend should return ErrNoAvailableBackend without creating anything
@@ -46,6 +46,19 @@ func TestAutoCreateDisabled(t *testing.T) {
 	backends := c.mu.backends["test-addr"]
 	c.mu.Unlock()
 	assert.Empty(t, backends)
+}
+
+// TestAutoCreateEnabledByDefault verifies that auto-create is enabled by default
+func TestAutoCreateEnabledByDefault(t *testing.T) {
+	// Create client without any auto-create option
+	rpcClient, err := NewClient("test", &testBackendFactory{})
+	require.NoError(t, err)
+	defer rpcClient.Close()
+
+	c := rpcClient.(*client)
+
+	// Verify auto-create is enabled by default
+	assert.True(t, c.options.enableAutoCreate)
 }
 
 // TestAutoCreateEnabled verifies that when auto-create is enabled,

--- a/pkg/common/morpc/client_autocreate_test.go
+++ b/pkg/common/morpc/client_autocreate_test.go
@@ -1,0 +1,193 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAutoCreateDisabled verifies that when auto-create is disabled,
+// no backends are created and proper error is returned
+func TestAutoCreateDisabled(t *testing.T) {
+	// Create client with auto-create disabled (default)
+	rpcClient, err := NewClient("test", &testBackendFactory{})
+	require.NoError(t, err)
+	defer rpcClient.Close()
+
+	c := rpcClient.(*client)
+
+	// Verify auto-create is disabled by default
+	assert.False(t, c.options.enableAutoCreate)
+
+	// getBackend should return ErrNoAvailableBackend without creating anything
+	_, err = c.getBackend("test-addr", false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no available backend")
+
+	// Verify no backend was created
+	c.mu.Lock()
+	backends := c.mu.backends["test-addr"]
+	c.mu.Unlock()
+	assert.Empty(t, backends)
+}
+
+// TestAutoCreateEnabled verifies that when auto-create is enabled,
+// backends are created asynchronously
+func TestAutoCreateEnabled(t *testing.T) {
+	// Create client with auto-create enabled
+	rpcClient, err := NewClient("test", &testBackendFactory{}, WithClientEnableAutoCreateBackend())
+	require.NoError(t, err)
+	defer rpcClient.Close()
+
+	c := rpcClient.(*client)
+
+	// Verify auto-create is enabled
+	assert.True(t, c.options.enableAutoCreate)
+
+	// First call should trigger async creation
+	_, err = c.getBackend("test-addr", false)
+	assert.Error(t, err) // No backend available yet
+	assert.Contains(t, err.Error(), "no available backend")
+
+	// Wait for async creation
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	for {
+		b, err := c.getBackend("test-addr", false)
+		if err == nil && b != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal("Backend creation timed out")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Verify backend was created
+	c.mu.Lock()
+	backends := c.mu.backends["test-addr"]
+	ops := c.mu.ops["test-addr"]
+	c.mu.Unlock()
+	assert.Len(t, backends, 1)
+	assert.NotNil(t, ops) // ops should be initialized
+}
+
+// TestCreateQueueFullFallback verifies fallback behavior when create queue is full
+func TestCreateQueueFullFallback(t *testing.T) {
+	// Create client with small queue size and auto-create enabled
+	rpcClient, err := NewClient("test", &testBackendFactory{},
+		WithClientEnableAutoCreateBackend(),
+		WithClientCreateTaskChanSize(1))
+	require.NoError(t, err)
+	defer rpcClient.Close()
+
+	c := rpcClient.(*client)
+
+	// Fill the queue by triggering creation for multiple backends
+	// This should fill the queue and trigger fallback for subsequent calls
+	_, err1 := c.getBackend("addr1", false)
+	_, err2 := c.getBackend("addr2", false)
+
+	// Both should return "no available backend" but trigger different paths
+	assert.Error(t, err1)
+	assert.Error(t, err2)
+
+	// Wait a bit for async creation
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify at least one backend was created (either async or sync fallback)
+	c.mu.Lock()
+	totalBackends := len(c.mu.backends["addr1"]) + len(c.mu.backends["addr2"])
+	ops1 := c.mu.ops["addr1"]
+	ops2 := c.mu.ops["addr2"]
+	c.mu.Unlock()
+
+	assert.Greater(t, totalBackends, 0, "At least one backend should be created")
+	// ops should be initialized for any created backend
+	if len(c.mu.backends["addr1"]) > 0 {
+		assert.NotNil(t, ops1, "ops should be initialized for addr1")
+	}
+	if len(c.mu.backends["addr2"]) > 0 {
+		assert.NotNil(t, ops2, "ops should be initialized for addr2")
+	}
+}
+
+// TestSyncFallbackRespectsLimits verifies that sync fallback respects pool limits
+func TestSyncFallbackRespectsLimits(t *testing.T) {
+	// Create client with max 1 backend per host
+	rpcClient, err := NewClient("test", &testBackendFactory{},
+		WithClientEnableAutoCreateBackend(),
+		WithClientMaxBackendPerHost(1))
+	require.NoError(t, err)
+	defer rpcClient.Close()
+
+	c := rpcClient.(*client)
+
+	// Pre-create a backend to reach the limit
+	c.mu.Lock()
+	backend := &testBackend{id: 1}
+	c.mu.backends["test-addr"] = []Backend{backend}
+	c.mu.ops["test-addr"] = &op{}
+	c.mu.Unlock()
+
+	// Now try to create another - should fail due to limits
+	b, err := c.createBackendWithBookkeeping("test-addr", false)
+	assert.Error(t, err)
+	assert.Nil(t, b)
+	assert.Contains(t, err.Error(), "no available backend")
+
+	// Verify no additional backend was created
+	c.mu.Lock()
+	backends := c.mu.backends["test-addr"]
+	c.mu.Unlock()
+	assert.Len(t, backends, 1) // Still only the original backend
+}
+
+// TestCircuitBreakerFastPath verifies circuit breaker check before lock
+func TestCircuitBreakerFastPath(t *testing.T) {
+	// Create client with circuit breaker
+	config := CircuitBreakerConfig{
+		Enabled:          true,
+		FailureThreshold: 1,
+		ResetTimeout:     time.Second,
+	}
+	rpcClient, err := NewClient("test", &testBackendFactory{},
+		WithClientCircuitBreaker(config))
+	require.NoError(t, err)
+	defer rpcClient.Close()
+
+	c := rpcClient.(*client)
+
+	// Trigger circuit breaker to open
+	c.circuitBreakers.RecordFailure("test-addr")
+
+	// getBackend should return ErrCircuitOpen immediately
+	_, err = c.getBackend("test-addr", false)
+	assert.Error(t, err)
+	assert.Equal(t, ErrCircuitOpen, err)
+
+	// Verify no backend creation was attempted
+	c.mu.Lock()
+	backends := c.mu.backends["test-addr"]
+	c.mu.Unlock()
+	assert.Empty(t, backends)
+}

--- a/pkg/common/morpc/client_gc_test.go
+++ b/pkg/common/morpc/client_gc_test.go
@@ -145,7 +145,7 @@ func TestGlobalClientGC_GCIdleLoop(t *testing.T) {
 func TestGlobalClientGC_GCInactiveLoop(t *testing.T) {
 	mgr := newClientGCManager()
 
-	c, err := NewClient("test-client", newTestBackendFactory())
+	c, err := NewClient("test-client", newTestBackendFactory(), WithClientEnableAutoCreateBackend())
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -344,7 +344,7 @@ func TestGlobalClientGC_GCIdleRespectsMaxIdleDuration(t *testing.T) {
 	mgr := newClientGCManager()
 
 	// Create client without maxIdleDuration (should not GC)
-	c1, err := NewClient("test-client-1", newTestBackendFactory())
+	c1, err := NewClient("test-client-1", newTestBackendFactory(), WithClientEnableAutoCreateBackend())
 	require.NoError(t, err)
 	defer c1.Close()
 
@@ -359,7 +359,8 @@ func TestGlobalClientGC_GCIdleRespectsMaxIdleDuration(t *testing.T) {
 	// Create client with maxIdleDuration
 	c2, err := NewClient("test-client-2",
 		newTestBackendFactory(),
-		WithClientMaxBackendMaxIdleDuration(time.Millisecond*100))
+		WithClientMaxBackendMaxIdleDuration(time.Millisecond*100),
+		WithClientEnableAutoCreateBackend())
 	require.NoError(t, err)
 	defer c2.Close()
 

--- a/pkg/common/morpc/client_gc_test.go
+++ b/pkg/common/morpc/client_gc_test.go
@@ -648,10 +648,11 @@ func TestGlobalClientGC_TryCreateReturnsCorrectValue(t *testing.T) {
 	ok := cli1.tryCreate("b1")
 	assert.True(t, ok, "tryCreate should return true when successful")
 
-	// Create a client without auto-create
+	// Create a client with auto-create explicitly disabled
 	c2, err := NewClient("test-client-2",
 		newTestBackendFactory(),
-		WithClientMaxBackendPerHost(2))
+		WithClientMaxBackendPerHost(2),
+		WithClientDisableAutoCreateBackend())
 	require.NoError(t, err)
 	defer c2.Close()
 

--- a/pkg/common/morpc/client_lock_contention_test.go
+++ b/pkg/common/morpc/client_lock_contention_test.go
@@ -1,0 +1,516 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetBackendWithSlowConnection tests that getBackend doesn't block
+// when backend creation is slow (simulating network delay or crashed node)
+func TestGetBackendWithSlowConnection(t *testing.T) {
+	// Create a factory that simulates slow connection
+	slowFactory := &testBackendFactoryWithDelay{
+		delay: 100 * time.Millisecond,
+	}
+	
+	rc, err := NewClient(
+		"test-client",
+		slowFactory,
+		WithClientMaxBackendPerHost(2),
+		WithClientEnableAutoCreateBackend(),
+	)
+	require.NoError(t, err)
+	defer rc.Close()
+	
+	c := rc.(*client)
+	
+	// First call should trigger async creation and return error quickly
+	start := time.Now()
+	b, err := c.getBackend("slow-backend", false)
+	elapsed := time.Since(start)
+	
+	// Should return error immediately without blocking
+	assert.Error(t, err)
+	assert.Nil(t, b)
+	assert.Less(t, elapsed, 50*time.Millisecond, "getBackend should not block")
+	
+	// Wait for async creation to complete
+	time.Sleep(150 * time.Millisecond)
+	
+	// Second call should succeed with the created backend
+	b, err = c.getBackend("slow-backend", false)
+	assert.NoError(t, err)
+	assert.NotNil(t, b)
+}
+
+// TestGetBackendConcurrentWithSlowConnection tests that multiple concurrent
+// getBackend calls don't serialize when connection is slow
+func TestGetBackendConcurrentWithSlowConnection(t *testing.T) {
+	slowFactory := &testBackendFactoryWithDelay{
+		delay: 100 * time.Millisecond,
+	}
+	
+	rc, err := NewClient(
+		"test-client",
+		slowFactory,
+		WithClientMaxBackendPerHost(5),
+		WithClientEnableAutoCreateBackend(),
+	)
+	require.NoError(t, err)
+	defer rc.Close()
+	
+	c := rc.(*client)
+	
+	// Launch 10 concurrent getBackend calls
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	start := time.Now()
+	
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			b, err := c.getBackend("slow-backend", false)
+			if b != nil {
+				b.Close()
+			}
+			// Don't check error - some may succeed, some may fail
+			_ = err
+		}()
+	}
+	
+	wg.Wait()
+	elapsed := time.Since(start)
+	
+	// All goroutines should complete quickly without serializing
+	// If they serialized, it would take 10 * 100ms = 1000ms
+	// With async creation, should complete in ~100-200ms
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"Concurrent calls should not serialize (elapsed: %v)", elapsed)
+}
+
+// TestGetBackendWithCircuitBreaker tests that circuit breaker prevents
+// repeated attempts to bad backends
+func TestGetBackendWithCircuitBreaker(t *testing.T) {
+	factory := &testBackendFactoryWithDelay{
+		delay:      10 * time.Millisecond,
+		shouldFail: true,
+	}
+	
+	rc, err := NewClient(
+		"test-client",
+		factory,
+		WithClientMaxBackendPerHost(2),
+		WithClientEnableAutoCreateBackend(),
+	)
+	require.NoError(t, err)
+	defer rc.Close()
+	
+	c := rc.(*client)
+	
+	// Trigger circuit breaker by recording failures
+	for i := 0; i < 10; i++ {
+		c.circuitBreakers.RecordFailure("bad-backend")
+	}
+	
+	// getBackend should fail fast
+	start := time.Now()
+	b, err := c.getBackend("bad-backend", false)
+	elapsed := time.Since(start)
+	
+	assert.Error(t, err)
+	assert.Nil(t, b)
+	// Should fail fast (either circuit breaker or no backend available)
+	assert.Less(t, elapsed, 20*time.Millisecond,
+		"Should fail fast with circuit breaker or no backend")
+}
+
+// TestGetBackendWithClientClosed tests that getBackend handles
+// client closure gracefully
+func TestGetBackendWithClientClosed(t *testing.T) {
+	rc, err := NewClient(
+		"test-client",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(2),
+	)
+	require.NoError(t, err)
+	
+	c := rc.(*client)
+	
+	// Close client
+	err = c.Close()
+	require.NoError(t, err)
+	
+	// getBackend should return error immediately
+	b, err := c.getBackend("any-backend", false)
+	assert.Error(t, err)
+	assert.Nil(t, b)
+}
+
+// TestGetBackendAsyncCreationEventualSuccess tests that async creation
+// eventually succeeds and subsequent calls work
+func TestGetBackendAsyncCreationEventualSuccess(t *testing.T) {
+	factory := &testBackendFactoryWithDelay{
+		delay: 50 * time.Millisecond,
+	}
+	
+	rc, err := NewClient(
+		"test-client",
+		factory,
+		WithClientMaxBackendPerHost(3),
+		WithClientEnableAutoCreateBackend(),
+	)
+	require.NoError(t, err)
+	defer rc.Close()
+	
+	c := rc.(*client)
+	
+	// First call triggers async creation
+	b, err := c.getBackend("test-backend", false)
+	assert.Error(t, err)
+	assert.Nil(t, b)
+	
+	// Poll until backend is created (with timeout)
+	var createdBackend Backend
+	for i := 0; i < 20; i++ {
+		time.Sleep(10 * time.Millisecond)
+		b, err := c.getBackend("test-backend", false)
+		if err == nil && b != nil {
+			createdBackend = b
+			break
+		}
+	}
+	
+	require.NotNil(t, createdBackend, "Backend should be created within 200ms")
+	
+	// Subsequent calls should succeed immediately
+	for i := 0; i < 5; i++ {
+		b, err := c.getBackend("test-backend", false)
+		assert.NoError(t, err)
+		assert.NotNil(t, b)
+	}
+}
+
+// TestGetBackendRespectMaxBackends tests that async creation respects
+// maxBackendsPerHost limit
+// testBackendFactoryForCrash simulates a crashed node that always fails to connect
+type testBackendFactoryForCrash struct {
+	sync.RWMutex
+}
+
+func (bf *testBackendFactoryForCrash) Create(backend string, opts ...BackendOption) (Backend, error) {
+	// Simulate network timeout when connecting to crashed node
+	time.Sleep(100 * time.Millisecond)
+	return nil, moerr.NewInternalErrorNoCtx("connection refused: node crashed")
+}
+
+// TestCrashedNodeRecovery tests the core problem scenario:
+// Multiple goroutines requesting a crashed CN node should not serialize
+// and should recover quickly via circuit breaker
+func TestCrashedNodeRecovery(t *testing.T) {
+	// Create a factory that always fails (simulating crashed node)
+	crashedFactory := &testBackendFactoryForCrash{}
+	
+	rc, err := NewClient(
+		"test-client",
+		crashedFactory,
+		WithClientMaxBackendPerHost(5),
+		WithClientEnableAutoCreateBackend(),
+	)
+	require.NoError(t, err)
+	defer rc.Close()
+	
+	c := rc.(*client)
+	
+	// Simulate 27 goroutines (like in production) requesting crashed node
+	const numGoroutines = 27
+	var wg sync.WaitGroup
+	var totalBlockTime atomic.Int64
+	var successCount atomic.Int32
+	var noBackendCount atomic.Int32
+	
+	start := time.Now()
+	
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			
+			goroutineStart := time.Now()
+			
+			// Try to get backend (should fail quickly)
+			b, err := c.getBackend("crashed-node", false)
+			
+			elapsed := time.Since(goroutineStart)
+			totalBlockTime.Add(int64(elapsed))
+			
+			if err == nil {
+				successCount.Add(1)
+				if b != nil {
+					b.Close()
+				}
+			} else if moerr.IsMoErrCode(err, moerr.ErrNoAvailableBackend) {
+				noBackendCount.Add(1)
+			}
+		}(i)
+	}
+	
+	wg.Wait()
+	totalElapsed := time.Since(start)
+	
+	// Verify: Total time should be much less than serial execution (27 * 100ms = 2.7s)
+	// With async creation, should complete in < 1 second
+	assert.Less(t, totalElapsed, 1500*time.Millisecond,
+		"Total time should be < 1.5s (not serialized)")
+	
+	// Verify: Average blocking time per goroutine should be small
+	avgBlockTime := time.Duration(totalBlockTime.Load() / int64(numGoroutines))
+	assert.Less(t, avgBlockTime, 500*time.Millisecond,
+		"Average blocking time should be < 500ms per goroutine")
+	
+	// Verify: Most goroutines should see ErrNoAvailableBackend (async creation)
+	// This proves they didn't block waiting for backend creation
+	assert.Greater(t, int(noBackendCount.Load()), numGoroutines/2,
+		"Most requests should return immediately with ErrNoAvailableBackend")
+	
+	// Verify: No successful connections (node is crashed)
+	assert.Equal(t, int32(0), successCount.Load(),
+		"Should have no successful connections to crashed node")
+	
+	t.Logf("Recovery test completed:")
+	t.Logf("  Total time: %v (vs 2.7s if serialized)", totalElapsed)
+	t.Logf("  Avg block time: %v per goroutine", avgBlockTime)
+	t.Logf("  NoBackend count: %d/%d (proves async behavior)", noBackendCount.Load(), numGoroutines)
+}
+
+// testBackendFactoryForRetry creates backends after a delay
+type testBackendFactoryForRetry struct {
+	sync.RWMutex
+	creationCount atomic.Int32
+	delay         time.Duration
+}
+
+func (bf *testBackendFactoryForRetry) Create(backend string, opts ...BackendOption) (Backend, error) {
+	bf.creationCount.Add(1)
+	
+	// Simulate backend creation delay
+	time.Sleep(bf.delay)
+	
+	// Create a simple test backend
+	return &testBackend{
+		id:         int(bf.creationCount.Load()),
+		activeTime: time.Now(),
+	}, nil
+}
+
+// TestSendRetryMechanism tests that Send() correctly retries on ErrNoAvailableBackend
+func TestSendRetryMechanism(t *testing.T) {
+	// Factory that succeeds after a delay (simulating async creation)
+	delayedFactory := &testBackendFactoryForRetry{
+		delay: 200 * time.Millisecond,
+	}
+	
+	rc, err := NewClient(
+		"test-client",
+		delayedFactory,
+		WithClientMaxBackendPerHost(2),
+		WithClientEnableAutoCreateBackend(),
+	)
+	require.NoError(t, err)
+	defer rc.Close()
+	
+	c := rc.(*client)
+	
+	// First Send should trigger async creation and retry
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	
+	req := &testMessage{id: 1}
+	future, err := c.Send(ctx, "backend-1", req)
+	
+	elapsed := time.Since(start)
+	
+	// Should succeed after retry
+	require.NoError(t, err, "Send should succeed after retry")
+	require.NotNil(t, future, "Future should not be nil")
+	
+	// Should take at least one retry cycle (200ms creation + backoff)
+	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond,
+		"Should wait for async creation")
+	
+	// Should not take too long (max 2-3 retries)
+	assert.Less(t, elapsed, 2*time.Second,
+		"Should succeed within reasonable time")
+	
+	// Verify backend was created exactly once (not multiple times)
+	assert.Equal(t, int32(1), delayedFactory.creationCount.Load(),
+		"Backend should be created exactly once")
+	
+	// Second Send should use existing backend (no retry)
+	start = time.Now()
+	req2 := &testMessage{id: 2}
+	future2, err := c.Send(ctx, "backend-1", req2)
+	elapsed2 := time.Since(start)
+	
+	require.NoError(t, err)
+	require.NotNil(t, future2)
+	
+	// Should be very fast (no creation, no retry)
+	assert.Less(t, elapsed2, 50*time.Millisecond,
+		"Second Send should be fast (backend already exists)")
+	
+	// Verify no additional backend creation
+	assert.Equal(t, int32(1), delayedFactory.creationCount.Load(),
+		"Should still have only one backend")
+	
+	t.Logf("First Send: %v (with retry)", elapsed)
+	t.Logf("Second Send: %v (no retry)", elapsed2)
+	t.Logf("Backend created: %d times", delayedFactory.creationCount.Load())
+}
+
+func TestGetBackendRespectMaxBackends(t *testing.T) {
+	factory := &testBackendFactoryWithDelay{
+		delay: 20 * time.Millisecond,
+	}
+	
+	const maxBackends = 2
+	rc, err := NewClient(
+		"test-client",
+		factory,
+		WithClientMaxBackendPerHost(maxBackends),
+		WithClientEnableAutoCreateBackend(),
+	)
+	require.NoError(t, err)
+	defer rc.Close()
+	
+	c := rc.(*client)
+	
+	// Trigger multiple async creations
+	for i := 0; i < 10; i++ {
+		c.getBackend("test-backend", false)
+	}
+	
+	// Wait for creations to complete
+	time.Sleep(100 * time.Millisecond)
+	
+	// Check that we don't exceed max backends
+	c.mu.Lock()
+	backendCount := len(c.mu.backends["test-backend"])
+	c.mu.Unlock()
+	
+	assert.LessOrEqual(t, backendCount, maxBackends,
+		"Should not exceed maxBackendsPerHost")
+}
+
+// Helper types for testing
+
+type testBackendFactoryWithDelay struct {
+	delay      time.Duration
+	shouldFail bool
+	createCount atomic.Int32
+}
+
+func (f *testBackendFactoryWithDelay) Create(address string, opts ...BackendOption) (Backend, error) {
+	f.createCount.Add(1)
+	
+	if f.shouldFail {
+		return nil, moerr.NewBackendCannotConnectNoCtx()
+	}
+	
+	// Simulate slow connection
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	
+	return &testBackend{
+		id:         int(f.createCount.Load()),
+		activeTime: time.Now(),
+	}, nil
+}
+
+// Benchmark to verify no performance regression
+
+func BenchmarkGetBackendWithAvailableBackend(b *testing.B) {
+	rc, err := NewClient(
+		"bench-client",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(10),
+	)
+	require.NoError(b, err)
+	defer rc.Close()
+	
+	c := rc.(*client)
+	
+	// Pre-create backends
+	for i := 0; i < 5; i++ {
+		c.mu.Lock()
+		backend := &testBackend{id: i, activeTime: time.Now()}
+		c.mu.backends["bench-backend"] = append(c.mu.backends["bench-backend"], backend)
+		c.mu.Unlock()
+	}
+	c.mu.Lock()
+	c.mu.ops["bench-backend"] = &op{}
+	c.mu.Unlock()
+	
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			backend, err := c.getBackend("bench-backend", false)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if backend == nil {
+				b.Fatal("expected backend")
+			}
+		}
+	})
+}
+
+func BenchmarkGetBackendWithCircuitBreaker(b *testing.B) {
+	rc, err := NewClient(
+		"bench-client",
+		newTestBackendFactory(),
+		WithClientMaxBackendPerHost(10),
+	)
+	require.NoError(b, err)
+	defer rc.Close()
+	
+	c := rc.(*client)
+	
+	// Trip circuit breaker
+	for i := 0; i < 10; i++ {
+		c.circuitBreakers.RecordFailure("bad-backend")
+	}
+	
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := c.getBackend("bad-backend", false)
+			if err != ErrCircuitOpen {
+				b.Fatalf("expected ErrCircuitOpen, got %v", err)
+			}
+		}
+	})
+}

--- a/pkg/common/morpc/client_state_test.go
+++ b/pkg/common/morpc/client_state_test.go
@@ -1,0 +1,368 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package morpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestErrBackendUnavailable tests the ErrBackendUnavailable error
+func TestErrBackendUnavailable(t *testing.T) {
+	// Test error is NoCtx (no logging)
+	assert.NotNil(t, ErrBackendUnavailable)
+	assert.True(t, moerr.IsMoErrCode(ErrBackendUnavailable, moerr.ErrBackendClosed))
+
+	// Test status classification
+	assert.Equal(t, StatusUnavailable, GetStatusCategory(ErrBackendUnavailable))
+	assert.True(t, IsUnavailable(ErrBackendUnavailable))
+	assert.False(t, IsTransient(ErrBackendUnavailable))
+}
+
+// TestErrBackendCreateTimeout tests the ErrBackendCreateTimeout error
+func TestErrBackendCreateTimeout(t *testing.T) {
+	// Test error is NoCtx (no logging)
+	assert.NotNil(t, ErrBackendCreateTimeout)
+	assert.True(t, moerr.IsMoErrCode(ErrBackendCreateTimeout, moerr.ErrBackendClosed))
+
+	// Test status classification
+	assert.Equal(t, StatusUnavailable, GetStatusCategory(ErrBackendCreateTimeout))
+	assert.True(t, IsUnavailable(ErrBackendCreateTimeout))
+	assert.False(t, IsTransient(ErrBackendCreateTimeout))
+}
+
+// TestErrCircuitHalfOpen tests the ErrCircuitHalfOpen error
+func TestErrCircuitHalfOpen(t *testing.T) {
+	// Test error is NoCtx (no logging)
+	assert.NotNil(t, ErrCircuitHalfOpen)
+	assert.True(t, moerr.IsMoErrCode(ErrCircuitHalfOpen, moerr.ErrServiceUnavailable))
+
+	// Test status classification - Half-Open is transient (allows probe)
+	assert.Equal(t, StatusTransient, GetStatusCategory(ErrCircuitHalfOpen))
+	assert.True(t, IsTransient(ErrCircuitHalfOpen))
+	assert.False(t, IsUnavailable(ErrCircuitHalfOpen))
+}
+
+// TestErrClientClosing tests the ErrClientClosing error
+func TestErrClientClosing(t *testing.T) {
+	// Test error is NoCtx (no logging)
+	assert.NotNil(t, ErrClientClosing)
+	assert.True(t, moerr.IsMoErrCode(ErrClientClosing, moerr.ErrClientClosed))
+
+	// Test status classification
+	assert.Equal(t, StatusCancelled, GetStatusCategory(ErrClientClosing))
+	assert.True(t, IsCancelled(ErrClientClosing))
+	assert.False(t, IsTransient(ErrClientClosing))
+}
+
+// TestCircuitBreakerGetError tests CircuitBreakerManager.GetError()
+func TestCircuitBreakerGetError(t *testing.T) {
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    3,
+		ResetTimeout:        100 * time.Millisecond,
+		HalfOpenMaxRequests: 2,
+	}
+
+	logger := logutil.GetGlobalLogger().Named("test")
+	manager := NewCircuitBreakerManager("test-client", config, logger)
+	backend := "test-backend"
+
+	// Test 1: Closed state returns nil
+	err := manager.GetError(backend)
+	assert.Nil(t, err)
+
+	// Test 2: Trigger failures to open circuit
+	for i := 0; i < 3; i++ {
+		manager.Allow(backend)
+		manager.RecordFailure(backend)
+	}
+
+	// Circuit should be open
+	err = manager.GetError(backend)
+	assert.Equal(t, ErrCircuitOpen, err)
+
+	// Test 3: Wait for reset timeout to transition to half-open
+	time.Sleep(150 * time.Millisecond)
+
+	// Allow one request to trigger transition to half-open
+	allowed := manager.Allow(backend)
+	assert.True(t, allowed)
+
+	// Circuit should be half-open
+	err = manager.GetError(backend)
+	assert.Equal(t, ErrCircuitHalfOpen, err)
+
+	// Test 4: Successful probes close the circuit
+	manager.RecordSuccess(backend)
+	manager.Allow(backend)
+	manager.RecordSuccess(backend)
+
+	// Circuit should be closed
+	err = manager.GetError(backend)
+	assert.Nil(t, err)
+}
+
+// TestCircuitBreakerGetErrorDisabled tests GetError with disabled circuit breaker
+func TestCircuitBreakerGetErrorDisabled(t *testing.T) {
+	config := DisabledCircuitBreakerConfig
+	logger := logutil.GetGlobalLogger().Named("test")
+	manager := NewCircuitBreakerManager("test-client", config, logger)
+
+	// Disabled circuit breaker always returns nil
+	err := manager.GetError("any-backend")
+	assert.Nil(t, err)
+}
+
+// TestClientClosingState tests client closing state behavior
+func TestClientClosingState(t *testing.T) {
+	bf := NewGoettyBasedBackendFactory(newTestCodec())
+	c, err := NewClient("test", bf, WithClientEnableAutoCreateBackend())
+	require.NoError(t, err)
+
+	// Test: Close sets closing state
+	closeDone := make(chan struct{})
+	go func() {
+		c.Close()
+		close(closeDone)
+	}()
+
+	// Wait for close to complete
+	select {
+	case <-closeDone:
+		// Success - close completed
+	case <-time.After(time.Second):
+		t.Fatal("Close() blocked for too long")
+	}
+
+	// After close, client should be in closed state
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err = c.Send(ctx, "test-backend", &testMessage{id: 1})
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrClientClosed) || errors.Is(err, ErrClientClosing))
+}
+
+// TestBackendUnavailableVsCreateTimeout tests distinction between unavailable and timeout
+func TestBackendUnavailableVsCreateTimeout(t *testing.T) {
+	// Use GoettyBasedBackendFactory with invalid address
+	bf := NewGoettyBasedBackendFactory(newTestCodec())
+
+	c, err := NewClient("test", bf,
+		WithClientEnableAutoCreateBackend(),
+		WithClientAutoCreateWaitTimeout(100*time.Millisecond))
+	require.NoError(t, err)
+	defer c.Close()
+
+	// Use invalid backend address
+	backend := "127.0.0.1:1" // Port 1 should be refused
+
+	// Request should timeout after 100ms
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err = c.Send(ctx, backend, &testMessage{id: 1})
+
+	// Should get error
+	assert.Error(t, err)
+}
+
+// testFailingBackendFactory always fails to create backends
+type testFailingBackendFactory struct{}
+
+func (f *testFailingBackendFactory) Create(address string, opts ...BackendOption) (Backend, error) {
+	return nil, errors.New("connection refused")
+}
+
+// TestAutoCreateWaitTimeoutDeterministic tests bounded wait timeout deterministically
+func TestAutoCreateWaitTimeoutDeterministic(t *testing.T) {
+	bf := &testFailingBackendFactory{}
+
+	c, err := NewClient("test", bf,
+		WithClientEnableAutoCreateBackend(),
+		WithClientAutoCreateWaitTimeout(50*time.Millisecond))
+	require.NoError(t, err)
+	defer c.Close()
+
+	backend := "127.0.0.1:9999"
+
+	// Request should timeout after ~50ms
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err = c.Send(ctx, backend, &testMessage{id: 1})
+	elapsed := time.Since(start)
+
+	// Should fail
+	assert.Error(t, err)
+
+	// Should complete within reasonable time (50ms timeout + overhead)
+	// Allow up to 150ms for test stability
+	assert.Less(t, elapsed, 150*time.Millisecond,
+		"should timeout quickly, took %v", elapsed)
+}
+
+// TestCircuitBreakerStateTransitions tests all state transitions
+func TestCircuitBreakerStateTransitions(t *testing.T) {
+	config := CircuitBreakerConfig{
+		Enabled:             true,
+		FailureThreshold:    2,
+		ResetTimeout:        50 * time.Millisecond,
+		HalfOpenMaxRequests: 2,
+	}
+
+	logger := logutil.GetGlobalLogger().Named("test")
+	manager := NewCircuitBreakerManager("test-client", config, logger)
+	backend := "test-backend"
+
+	// State 1: Closed (initial)
+	assert.Nil(t, manager.GetError(backend))
+	assert.True(t, manager.Allow(backend))
+
+	// State 2: Closed -> Open (after failures)
+	manager.RecordFailure(backend)
+	manager.RecordFailure(backend)
+	assert.Equal(t, ErrCircuitOpen, manager.GetError(backend))
+	assert.False(t, manager.Allow(backend))
+
+	// State 3: Open -> Half-Open (after timeout)
+	time.Sleep(60 * time.Millisecond)
+	assert.True(t, manager.Allow(backend)) // First probe allowed
+	assert.Equal(t, ErrCircuitHalfOpen, manager.GetError(backend))
+
+	// State 4: Half-Open -> Open (on failure)
+	manager.RecordFailure(backend)
+	assert.Equal(t, ErrCircuitOpen, manager.GetError(backend))
+
+	// State 5: Open -> Half-Open -> Closed (on success)
+	time.Sleep(60 * time.Millisecond)
+	assert.True(t, manager.Allow(backend))
+	manager.RecordSuccess(backend)
+	assert.True(t, manager.Allow(backend))
+	manager.RecordSuccess(backend)
+	assert.Nil(t, manager.GetError(backend))
+}
+
+// TestClientClosingDoesNotBlockClose tests that closing state doesn't deadlock
+func TestClientClosingDoesNotBlockClose(t *testing.T) {
+	bf := NewGoettyBasedBackendFactory(newTestCodec())
+	c, err := NewClient("test", bf, WithClientEnableAutoCreateBackend())
+	require.NoError(t, err)
+
+	// Close should complete quickly
+	done := make(chan struct{})
+	go func() {
+		c.Close()
+		close(done)
+	}()
+
+	// Wait for close to complete
+	select {
+	case <-done:
+		// Success
+	case <-time.After(time.Second):
+		t.Fatal("Close() blocked for too long")
+	}
+}
+
+// TestHandleAutoCreateWaitDeterministic tests handleAutoCreateWait behavior
+func TestHandleAutoCreateWaitDeterministic(t *testing.T) {
+	bf := &testFailingBackendFactory{}
+
+	c, err := NewClient("test", bf,
+		WithClientEnableAutoCreateBackend(),
+		WithClientAutoCreateWaitTimeout(30*time.Millisecond))
+	require.NoError(t, err)
+	defer c.Close()
+
+	client := c.(*client)
+
+	// Test 1: Timeout exceeded
+	creationStart := time.Now().Add(-50 * time.Millisecond)
+	shouldContinue, err := client.handleAutoCreateWait(
+		context.Background(),
+		"test-backend",
+		&creationStart,
+		1)
+
+	assert.False(t, shouldContinue)
+	assert.Equal(t, ErrBackendCreateTimeout, err)
+
+	// Test 2: Context cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	creationStart2 := time.Now()
+	shouldContinue, err = client.handleAutoCreateWait(
+		ctx,
+		"test-backend",
+		&creationStart2,
+		1)
+
+	assert.False(t, shouldContinue)
+	assert.Equal(t, context.Canceled, err)
+
+	// Test 3: Should continue (within timeout)
+	creationStart3 := time.Now()
+	shouldContinue, err = client.handleAutoCreateWait(
+		context.Background(),
+		"test-backend",
+		&creationStart3,
+		1)
+
+	assert.True(t, shouldContinue)
+	assert.Nil(t, err)
+}
+
+// TestErrorDistinction tests that all errors are distinguishable
+func TestErrorDistinction(t *testing.T) {
+	errors := []error{
+		ErrBackendCreating,
+		ErrBackendUnavailable,
+		ErrBackendCreateTimeout,
+		ErrCircuitOpen,
+		ErrCircuitHalfOpen,
+		ErrClientClosing,
+		moerr.NewClientClosedNoCtx(),
+		moerr.NewNoAvailableBackendNoCtx(),
+	}
+
+	// Test that each error has correct status
+	expectedStatus := []StatusCategory{
+		StatusTransient,   // ErrBackendCreating
+		StatusUnavailable, // ErrBackendUnavailable
+		StatusUnavailable, // ErrBackendCreateTimeout
+		StatusUnavailable, // ErrCircuitOpen
+		StatusTransient,   // ErrCircuitHalfOpen
+		StatusCancelled,   // ErrClientClosing
+		StatusCancelled,   // ErrClientClosed
+		StatusUnavailable, // ErrNoAvailableBackend
+	}
+
+	for i, err := range errors {
+		status := GetStatusCategory(err)
+		assert.Equal(t, expectedStatus[i], status,
+			"error %d (%v) has wrong status: expected %v, got %v",
+			i, err, expectedStatus[i], status)
+	}
+}

--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -265,7 +265,7 @@ func TestCloseIdleBackends(t *testing.T) {
 	b.(*testBackend).busy = true
 
 	// Second backend - trigger async creation
-	_, err = c.getBackend("b1", false)
+	_, _ = c.getBackend("b1", false)
 	// Wait for async creation
 	for i := 0; i < 20; i++ {
 		c.mu.Lock()

--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -382,7 +382,7 @@ func TestGetBackendsWithAllInactiveAndWillCreateNew(t *testing.T) {
 	assert.NotNil(t, b)
 
 	b.(*testBackend).activeTime = time.Time{}
-	
+
 	// Backend is now inactive, next call triggers async recreation
 	b, err = c.getBackend("b1", false)
 	// May return error initially

--- a/pkg/common/morpc/client_test.go
+++ b/pkg/common/morpc/client_test.go
@@ -209,6 +209,7 @@ func TestMaybeCreateLockedWithFullBackends(t *testing.T) {
 func TestGetBackendAutoCreateDisabled(t *testing.T) {
 	rc, err := NewClient("",
 		newTestBackendFactory(),
+		WithClientDisableAutoCreateBackend(),
 		WithClientMaxBackendPerHost(1))
 	assert.NoError(t, err)
 	c := rc.(*client)
@@ -218,6 +219,9 @@ func TestGetBackendAutoCreateDisabled(t *testing.T) {
 
 	b, err := c.getBackend("b1", false)
 	assert.Nil(t, b)
+	if err != nil {
+		t.Logf("Error: %v, Type: %T", err, err)
+	}
 	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrNoAvailableBackend))
 
 	c.mu.Lock()
@@ -258,7 +262,7 @@ func TestCreateBackendWithBookkeeping(t *testing.T) {
 	// Second creation should respect maxBackendsPerHost and fail.
 	b2, err := c.createBackendWithBookkeeping("b1", false)
 	assert.Nil(t, b2)
-	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrNoAvailableBackend))
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendClosed))
 }
 
 func TestInitBackendsAndMaxBackendsPerHostNotMatch(t *testing.T) {

--- a/pkg/common/morpc/method_based_test.go
+++ b/pkg/common/morpc/method_based_test.go
@@ -136,7 +136,9 @@ func runRPCTests(
 			}()
 			require.NoError(t, s.Start())
 
-			cfg := Config{}
+			cfg := Config{
+				ClientOptions: []ClientOption{WithClientEnableAutoCreateBackend()},
+			}
 			c, err := cfg.NewClient(
 				sid,
 				"ctl-service",

--- a/pkg/common/morpc/metrics.go
+++ b/pkg/common/morpc/metrics.go
@@ -38,6 +38,8 @@ type metrics struct {
 	writeDurationHistogram        prometheus.Observer
 	connectDurationHistogram      prometheus.Observer
 	doneDurationHistogram         prometheus.Observer
+	autoCreateTimeoutCounter      prometheus.Counter // tracks auto-create wait timeouts
+	backendUnavailableCounter     prometheus.Counter // tracks backend unavailable (pool has backends but all down)
 }
 
 func newMetrics(name string) *metrics {
@@ -60,6 +62,8 @@ func newMetrics(name string) *metrics {
 		writeLatencyDurationHistogram: v2.NewRPCBackendWriteLatencyDurationHistogramByName(name),
 		inputBytesCounter:             v2.NewRPCInputCounter(),
 		outputBytesCounter:            v2.NewRPCOutputCounter(),
+		autoCreateTimeoutCounter:      v2.NewRPCBackendAutoCreateTimeoutCounterByName(name),
+		backendUnavailableCounter:     v2.NewRPCBackendUnavailableCounterByName(name),
 	}
 }
 

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -457,10 +457,13 @@ func testRPCServer(t assert.TestingT, testFunc func(*server), options ...ServerO
 
 func newTestClient(t assert.TestingT, options ...ClientOption) RPCClient {
 	bf := NewGoettyBasedBackendFactory(newTestCodec())
+	// Add auto-create by default for tests
+	defaultOptions := []ClientOption{WithClientEnableAutoCreateBackend()}
+	defaultOptions = append(defaultOptions, options...)
 	c, err := NewClient(
 		"",
 		bf,
-		options...)
+		defaultOptions...)
 	assert.NoError(t, err)
 	return c
 }

--- a/pkg/common/morpc/status.go
+++ b/pkg/common/morpc/status.go
@@ -93,8 +93,14 @@ func GetStatusCategory(err error) StatusCategory {
 	}
 
 	// Backend is being created asynchronously - treat as transient wait
-	if errors.Is(err, ErrBackendCreating) {
+	if err == ErrBackendCreating || errors.Is(err, ErrBackendCreating) {
 		return StatusTransient
+	}
+
+	// Backend unavailable or create timeout - treat as unavailable (permanent for this request)
+	if err == ErrBackendUnavailable || errors.Is(err, ErrBackendUnavailable) ||
+		err == ErrBackendCreateTimeout || errors.Is(err, ErrBackendCreateTimeout) {
+		return StatusUnavailable
 	}
 
 	// Connection-level unavailability

--- a/pkg/common/morpc/status.go
+++ b/pkg/common/morpc/status.go
@@ -83,15 +83,7 @@ func GetStatusCategory(err error) StatusCategory {
 		return StatusOK
 	}
 
-	// Check moerr codes first (most specific)
-	if moerr.IsMoErrCode(err, moerr.ErrRPCTimeout) {
-		return StatusTransient
-	}
-	if moerr.IsMoErrCode(err, moerr.ErrServiceUnavailable) ||
-		moerr.IsMoErrCode(err, moerr.ErrConnectionReset) {
-		return StatusTransient
-	}
-
+	// Check specific error variables first (before moerr codes)
 	// Backend is being created asynchronously - treat as transient wait
 	if err == ErrBackendCreating || errors.Is(err, ErrBackendCreating) {
 		return StatusTransient
@@ -101,6 +93,28 @@ func GetStatusCategory(err error) StatusCategory {
 	if err == ErrBackendUnavailable || errors.Is(err, ErrBackendUnavailable) ||
 		err == ErrBackendCreateTimeout || errors.Is(err, ErrBackendCreateTimeout) {
 		return StatusUnavailable
+	}
+
+	// Circuit breaker errors
+	if err == ErrCircuitOpen || errors.Is(err, ErrCircuitOpen) {
+		return StatusUnavailable
+	}
+	if err == ErrCircuitHalfOpen || errors.Is(err, ErrCircuitHalfOpen) {
+		return StatusTransient // Half-open allows probe requests
+	}
+
+	// Client closing/closed
+	if err == ErrClientClosing || errors.Is(err, ErrClientClosing) {
+		return StatusCancelled
+	}
+
+	// Check moerr codes (after specific error variables)
+	if moerr.IsMoErrCode(err, moerr.ErrRPCTimeout) {
+		return StatusTransient
+	}
+	if moerr.IsMoErrCode(err, moerr.ErrServiceUnavailable) ||
+		moerr.IsMoErrCode(err, moerr.ErrConnectionReset) {
+		return StatusTransient
 	}
 
 	// Connection-level unavailability

--- a/pkg/common/morpc/status.go
+++ b/pkg/common/morpc/status.go
@@ -92,6 +92,11 @@ func GetStatusCategory(err error) StatusCategory {
 		return StatusTransient
 	}
 
+	// Backend is being created asynchronously - treat as transient wait
+	if errors.Is(err, ErrBackendCreating) {
+		return StatusTransient
+	}
+
 	// Connection-level unavailability
 	if moerr.IsMoErrCode(err, moerr.ErrBackendClosed) ||
 		moerr.IsMoErrCode(err, moerr.ErrNoAvailableBackend) ||

--- a/pkg/common/morpc/status_test.go
+++ b/pkg/common/morpc/status_test.go
@@ -59,6 +59,7 @@ func TestGetStatusCategory(t *testing.T) {
 		{"ErrRPCTimeout", moerr.NewRPCTimeoutNoCtx(), StatusTransient},
 		{"ErrServiceUnavailable", moerr.NewServiceUnavailableNoCtx("test"), StatusTransient},
 		{"ErrConnectionReset", moerr.NewConnectionReset(context.Background()), StatusTransient},
+		{"ErrBackendCreating", ErrBackendCreating, StatusTransient},
 
 		// Unavailable errors (moerr)
 		{"ErrBackendClosed", moerr.NewBackendClosedNoCtx(), StatusUnavailable},

--- a/pkg/lockservice/lock_table_allocator.go
+++ b/pkg/lockservice/lock_table_allocator.go
@@ -992,8 +992,10 @@ func validateService(
 	client Client,
 	logger *log.MOLogger,
 ) (bool, error) {
-	if timeout < defaultRPCTimeout {
-		timeout = defaultRPCTimeout
+	// Enforce minimum timeout to avoid immediate failures from misconfiguration
+	const minTimeout = 100 * time.Millisecond
+	if timeout < minTimeout {
+		timeout = minTimeout
 	}
 	ctx, cancel := context.WithTimeoutCause(context.Background(), timeout, moerr.CauseValidateService)
 	defer cancel()

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -197,7 +197,7 @@ func TestRPCSendErrBackendCannotConnect(t *testing.T) {
 					writeResponse(getLogger(""), cancel, resp, nil, cs)
 				})
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 			defer cancel()
 			err := s.Close()
 			require.NoError(t, err)
@@ -205,7 +205,11 @@ func TestRPCSendErrBackendCannotConnect(t *testing.T) {
 				&lock.Request{
 					LockTable: lock.LockTable{ServiceID: "s1"},
 					Method:    lock.Method_Lock})
-			require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendCannotConnect))
+			if err != nil {
+				t.Logf("Error: %v, Type: %T", err, err)
+			}
+			// After auto-create wait timeout (500ms), should return ErrBackendClosed
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendClosed))
 		},
 	)
 }

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -2038,14 +2038,14 @@ func TestIssue3288(t *testing.T) {
 
 			l1.Close()
 
-			// should lock failed
+			// should lock failed - after auto-create wait timeout, returns ErrBackendClosed
 			_, err = l2.Lock(
 				ctx,
 				0,
 				[][]byte{{1}},
 				[]byte("txn2"),
 				option)
-			require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendCannotConnect))
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendClosed))
 
 			time.Sleep(time.Second * 3)
 

--- a/pkg/logservice/client.go
+++ b/pkg/logservice/client.go
@@ -517,7 +517,7 @@ func connectToLogService(
 			c.respPool,
 			c.cfg.MaxMessageSize,
 			cfg.EnableCompress,
-			0,
+			time.Second*10,
 			cfg.Tag,
 		)
 		if err != nil {

--- a/pkg/logservice/shardinfo.go
+++ b/pkg/logservice/shardinfo.go
@@ -56,7 +56,7 @@ func GetShardInfo(
 		respPool,
 		defaultMaxMessageSize,
 		false,
-		0,
+		time.Second*10,
 		"GetShardInfo",
 	)
 	if err != nil {

--- a/pkg/txn/rpc/sender.go
+++ b/pkg/txn/rpc/sender.go
@@ -88,7 +88,8 @@ func NewSender(
 	}
 
 	s.cfg.BackendOptions = append(s.cfg.BackendOptions,
-		morpc.WithBackendStreamBufferSize(10000))
+		morpc.WithBackendStreamBufferSize(10000),
+		morpc.WithBackendReadTimeout(time.Second*30))
 	client, err := s.cfg.NewClient(
 		s.rt.ServiceUUID(),
 		"txn-client",

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -193,6 +193,8 @@ func initRPCMetrics() {
 	registry.MustRegister(rpcGCCreateProcessedCounter)
 	registry.MustRegister(rpcBackendAutoCreateTimeoutCounter)
 	registry.MustRegister(rpcBackendUnavailableCounter)
+	registry.MustRegister(rpcCircuitBreakerStateGauge)
+	registry.MustRegister(rpcCircuitBreakerTripsCounter)
 
 	registry.MustRegister(rpcBackendPoolSizeGauge)
 	registry.MustRegister(rpcSendingQueueSizeGauge)

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -191,6 +191,8 @@ func initRPCMetrics() {
 	registry.MustRegister(rpcGCIdleBackendsCleanedCounter)
 	registry.MustRegister(rpcGCInactiveProcessedCounter)
 	registry.MustRegister(rpcGCCreateProcessedCounter)
+	registry.MustRegister(rpcBackendAutoCreateTimeoutCounter)
+	registry.MustRegister(rpcBackendUnavailableCounter)
 
 	registry.MustRegister(rpcBackendPoolSizeGauge)
 	registry.MustRegister(rpcSendingQueueSizeGauge)

--- a/pkg/util/metric/v2/morpc.go
+++ b/pkg/util/metric/v2/morpc.go
@@ -98,6 +98,22 @@ var (
 			Name:      "gc_create_processed_total",
 			Help:      "Total number of backend creation requests processed.",
 		})
+
+	rpcBackendAutoCreateTimeoutCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "rpc",
+			Name:      "backend_auto_create_timeout_total",
+			Help:      "Total number of auto-create backend wait timeouts.",
+		}, []string{"name"})
+
+	rpcBackendUnavailableCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "rpc",
+			Name:      "backend_unavailable_total",
+			Help:      "Total number of backend unavailable errors (pool has backends but all down).",
+		}, []string{"name"})
 )
 
 var (
@@ -310,6 +326,14 @@ func GetRPCGCIdleBackendsCleanedCounter() prometheus.Counter {
 
 func GetRPCGCInactiveProcessedCounter() prometheus.Counter {
 	return rpcGCInactiveProcessedCounter
+}
+
+func NewRPCBackendAutoCreateTimeoutCounterByName(name string) prometheus.Counter {
+	return rpcBackendAutoCreateTimeoutCounter.WithLabelValues(name)
+}
+
+func NewRPCBackendUnavailableCounterByName(name string) prometheus.Counter {
+	return rpcBackendUnavailableCounter.WithLabelValues(name)
 }
 
 func GetRPCGCCreateProcessedCounter() prometheus.Counter {

--- a/pkg/util/metric/v2/morpc.go
+++ b/pkg/util/metric/v2/morpc.go
@@ -114,6 +114,22 @@ var (
 			Name:      "backend_unavailable_total",
 			Help:      "Total number of backend unavailable errors (pool has backends but all down).",
 		}, []string{"name"})
+
+	rpcCircuitBreakerStateGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "mo",
+			Subsystem: "rpc",
+			Name:      "circuit_breaker_state",
+			Help:      "Circuit breaker state (0=closed, 1=half-open, 2=open).",
+		}, []string{"name", "backend"})
+
+	rpcCircuitBreakerTripsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "rpc",
+			Name:      "circuit_breaker_trips_total",
+			Help:      "Total number of circuit breaker trips (closed -> open).",
+		}, []string{"name", "backend"})
 )
 
 var (
@@ -334,6 +350,14 @@ func NewRPCBackendAutoCreateTimeoutCounterByName(name string) prometheus.Counter
 
 func NewRPCBackendUnavailableCounterByName(name string) prometheus.Counter {
 	return rpcBackendUnavailableCounter.WithLabelValues(name)
+}
+
+func NewRPCCircuitBreakerStateGauge(name, backend string) prometheus.Gauge {
+	return rpcCircuitBreakerStateGauge.WithLabelValues(name, backend)
+}
+
+func NewRPCCircuitBreakerTripsCounter(name, backend string) prometheus.Counter {
+	return rpcCircuitBreakerTripsCounter.WithLabelValues(name, backend)
 }
 
 func GetRPCGCCreateProcessedCounter() prometheus.Counter {

--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -81,7 +81,7 @@ const (
 	consumerBufferLength   = 8192
 	consumerWarningPercent = 0.9
 
-	defaultRPCReadTimeout = time.Minute * 2
+	defaultRPCReadTimeout = time.Second * 30
 
 	logTag = "[logtail-consumer]"
 )


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23434 

## What this PR does / why we need it:

### Lock Contention During Backend Creation
- Problem: Synchronous backend creation in getBackend() caused 27 goroutines to serialize for 135 seconds when CN nodes crashed, reducing CPU utilization to 30%.
- Solution: Implemented asynchronous backend creation using the existing global client GC mechanism, eliminating lock-held network I/O.
- Impact: Recovery time improved from 135 seconds to 200ms (675x improvement).

### Pool Saturation Immediate Failure
- Problem: When the backend pool was full but all connections were busy/inactive, getBackend() returned ErrBackendUnavailable, causing immediate failure instead of waiting for connections to become available.
- Solution: Changed error type to ErrBackendCreating to trigger proper retry logic, allowing requests to wait for free connections under high load.
- Impact: Improved system availability by preventing request drops during temporary saturation.

### Circuit Breaker Not Triggering on Permanent Failures
- Problem: When backend creation repeatedly failed (e.g., permanently crashed nodes), the circuit breaker never opened because failures during async creation waits weren't recorded.
- Solution: Added circuit breaker failure recording when auto-create timeouts or retry limits are exceeded.
- Impact: Permanent failures now trigger circuit breaker protection, enabling fast failure and preventing wasteful retries.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implement asynchronous backend creation to eliminate lock contention during CN node failures

- Add bounded wait timeout for auto-create with circuit breaker integration for fast failure detection

- Distinguish transient creation states from permanent unavailability via new error types

- Enhance error classification and observability with metrics for backend health and circuit breaker state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getBackend Request"] --> B{"Circuit Breaker<br/>Check"}
  B -->|Open| C["Return ErrCircuitOpen<br/>Fast Fail"]
  B -->|Closed/HalfOpen| D["Check Pool<br/>& Limits"]
  D -->|Backend Available| E["Return Backend<br/>Success"]
  D -->|Pool Empty| F{"Auto-Create<br/>Enabled?"}
  D -->|Pool Busy| G["Return ErrBackendCreating<br/>Trigger Wait"]
  F -->|Yes| H["Queue Async Creation<br/>Return ErrBackendCreating"]
  F -->|No| I["Return ErrNoAvailableBackend<br/>Fail Fast"]
  H --> J["Caller Retries<br/>with Bounded Wait"]
  J -->|Timeout| K["Record Failure<br/>Return ErrBackendCreateTimeout"]
  J -->|Success| E
  K --> L["Circuit Breaker<br/>May Open"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>client.go</strong><dd><code>Implement async backend creation and bounded wait logic</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-c691cadb921c60ec52fdd2c4fbc6a23e36900aa31740bac6d70a778b57e02497">+446/-43</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>client_state_test.go</strong><dd><code>Add comprehensive tests for error states and transitions</code>&nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-c4f72bfe96d3915f639be056a75aa4b88e83608276d8d3da27a5092ea9722a0e">+506/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>client_lock_contention_test.go</strong><dd><code>Add tests for concurrent access and crash recovery scenarios</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-3de367e12253aa54dcb520a10053176993e433fd5a33daa046c0465fdc310dec">+517/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>client_test.go</strong><dd><code>Update existing tests for async creation behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-e7f585213c8ab155c5ea04096cee88493972eb04dca8f654771db427616a4f79">+136/-16</a></td>

</tr>

<tr>
  <td><strong>client_gc_test.go</strong><dd><code>Add helper for async creation and update test expectations</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-7fe744bce67840c53433c16449e8c217f110e67d912bf6ba887505f65b4949f1">+40/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>client_autocreate_test.go</strong><dd><code>Add tests for auto-create enable/disable behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-e21d4dcbf709ffcee86e71b9e3f20723809e6e5f627ff5f02928bb408d5fa0d4">+210/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>circuit_breaker_test.go</strong><dd><code>Update tests to pass client name parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-fd357396c964772aa6a03e928601d01e40e95ba231f418a9f1ea8d6546e7c86d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>status_test.go</strong><dd><code>Add test for ErrBackendCreating status classification</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-fd97dc9dc8e2a2b3a5a9874b8f68de312124e9b53ee191e9640c2b354119ed0f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rpc_test.go</strong><dd><code>Update test expectations for auto-create timeout behavior</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-42ee96474cacf3ad69ffd4ee7f476f9deae83856b7c50dc05d784fee568ef124">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service_test.go</strong><dd><code>Update test to expect ErrBackendClosed after timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-e94812797c8b26ff0499bd86698dbc4371dd72642267baa535a7ecc7f8bf3981">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>query_service_test.go</strong><dd><code>Add circuit breaker configuration to test client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-f22c38be7cc8de1dd5bfa57136ea5d86e49ffe4d2b2fa8ca75ab4416cfbcd7a6">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>multi_cn_bug_test.go</strong><dd><code>Add backend warmup and adjust timeouts for async creation</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-5129e369e8116967e05f8bc8d6a9c0f43ae8186273b783cb6d43c483cf7f2f6b">+41/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server_test.go</strong><dd><code>Enable auto-create by default in test client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-2d74ef3edad3e64314a80a49ca387581932a8d099a777b13d77de7f95c5fbaac">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>method_based_test.go</strong><dd><code>Enable auto-create in test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-03440f9eaa7cfb22849d0c2dd15a1a7d616087e949464c6f246b2b6c503e4648">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>circuit_breaker.go</strong><dd><code>Add GetError method and metrics reporting for state changes</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-08491766aa1dde7d9c5ba478c220be2fa36aa658e5cfce5a404566326939a723">+69/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metrics.go</strong><dd><code>Add metrics for auto-create timeout and backend unavailable</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-bc08c3398d65e07127bd76395a35652fc206aff26933326f1237b158d19d1ea8">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>status.go</strong><dd><code>Add status classification for new error types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-1fa786f7dde97b228c4243742f2df33f8cdd082a37a1f75280f706311ceb2261">+26/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>morpc.go</strong><dd><code>Add prometheus metrics for backend health and circuit breaker</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-d55d3aca2598ceb56e2a938719643e1b1d71af46bf9fbb6789b64260f4325177">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>grafana_dashboard_rpc.go</strong><dd><code>Add dashboard rows for backend health and circuit breaker metrics</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-e114792b1bd421b5d49d18ef97a6e06e6fae9997adc4abf4de88af8243fe58a1">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metrics.go</strong><dd><code>Register new RPC metrics in prometheus registry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-97ea305cc79979fa7db0a8fd618613cdda1c9bda32e6aa91847d8a754de671f3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>table_change_stream.go</strong><dd><code>Use unified error classification for retry logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-cbff9e9c74e505ad0a56d6eb223441ef9608b6f55907fe6e8ff67a53849feed5">+7/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lock_op.go</strong><dd><code>Use unified error classification for lock retry logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-72fd177a79db26bc21d48eba216ec1690f1377a9a3430a3da15e293d7690b37a">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rpc.go</strong><dd><code>Set bounded wait timeout for fast failure detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-ae1529f0f236a2a7ccf01b2fc2279cce63acf06136c196637a633d5d645c6b45">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sender.go</strong><dd><code>Add read timeout configuration for backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-3ed46fecb17182e944f66dae546e5d7f21271248eb3ae9ca77f0bcd334067973">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>client.go</strong><dd><code>Set explicit read timeout instead of zero</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-b4070a75e731b13921353515e2d26d1ebd7a02bf1044f863add9b44141ad4d1d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>shardinfo.go</strong><dd><code>Set explicit read timeout instead of zero</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-3da0b27e0429b4117051288752adec2df2434088fae3638871e044c8818f3e58">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>logtail_consumer.go</strong><dd><code>Reduce default RPC read timeout from 2 minutes to 30 seconds</code></dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-e17810b9da4ab05c897d8066bbc421520cdaea7c577d50dc64b31ec3aa8d295f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>lock_table_allocator.go</strong><dd><code>Enforce minimum timeout to prevent misconfiguration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-6be1ca324d0b56411e41ec19a99ea21442f80563429ee4964aedef60424413a1">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Makefile</strong><dd><code>Fix regex patterns for context timeout/deadline checks</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23435/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

