### PR TITLE
fix `loadSpilledData` memory leak

### DIFF
--- a/pkg/sql/colexec/group/helper.go
+++ b/pkg/sql/colexec/group/helper.go
@@ -334,6 +334,9 @@ func (ctr *container) loadSpilledData(proc *process.Process, opAnalyzer process.
 	// we reset ctr state, and create a new group by batch.
 	ctr.resetForSpill()
 	gbBatch := ctr.createNewGroupByBatch(nil, aggBatchSize)
+	defer func() {
+		gbBatch.Clean(ctr.mp)
+	}()
 	totalCnt := int64(0)
 
 	bufferedFile := bufio.NewReaderSize(bkt.file, 1024*1024)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/23407

## What this PR does / why we need it:
fix `loadSpillData` memory leak


___

### **PR Type**
Bug fix


___

### **Description**
- Add defer cleanup for gbBatch to prevent memory leak

- Ensures batch resources are properly freed after loadSpilledData completes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["loadSpilledData function"] -- "creates" --> B["gbBatch object"]
  B -- "defer cleanup added" --> C["gbBatch.Clean called"]
  C -- "prevents" --> D["memory leak"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helper.go</strong><dd><code>Add defer cleanup for gbBatch resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/group/helper.go

<ul><li>Added defer statement to ensure gbBatch cleanup on function exit<br> <li> Calls gbBatch.Clean with memory pool to release resources<br> <li> Prevents memory leak in loadSpilledData function</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23436/files#diff-c9d9cd6b008accd27ff56bb6a7b0860d64723c9b6c33f7ebf45f21dd61c8b235">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

