### PR TITLE
modify year from 2025 to 2026(v3.0.4-hotfix)

### DIFF
--- a/test/distributed/cases/function/func_datetime_utc_timestamp.result
+++ b/test/distributed/cases/function/func_datetime_utc_timestamp.result
@@ -34,7 +34,7 @@ insert into t1 select 1,1,1,utc_timestamp();
 insert into t1 select 2,0,0,null;
 select a,b,c,year(d) from t1;
 a    b    c    year(d)
-1    1    1    2025
+1    1    1    2026
 2    0    0    null
 DROP TABLE t1;
 CREATE TABLE t1 (a TIMESTAMP);
@@ -43,8 +43,8 @@ INSERT INTO t1 select (utc_timestamp());
 INSERT INTO t1 select (utc_timestamp());
 SELECT year(a) FROM t1 WHERE a > '2008-01-01';
 year(a)
-2025
-2025
-2025
+2026
+2026
+2026
 DROP TABLE t1;
 SET TIME_ZONE = "SYSTEM";


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:
modify year from 2025 to 2026

issue #https://github.com/matrixorigin/matrixone/issues/23442

## What this PR does / why we need it:
modify year from 2025 to 2026


___

### **PR Type**
Tests


___

### **Description**
- Update test result expectations from 2025 to 2026

- Modify UTC timestamp function test outputs

- Align test cases with current year expectations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Result File"] -- "Update year values" --> B["2025 → 2026"]
  B -- "UTC timestamp tests" --> C["Updated Expectations"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>func_datetime_utc_timestamp.result</strong><dd><code>Update UTC timestamp test year expectations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/function/func_datetime_utc_timestamp.result

<ul><li>Updated year extraction results from 2025 to 2026 in UTC timestamp <br>test cases<br> <li> Modified 4 test result lines: 1 single year value and 3 repeated year <br>values<br> <li> Maintains test structure and logic while updating expected output <br>values</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23443/files#diff-e2ce94c306d9d720f29e8bffbac5e3bb0b08fdf39c1db61dca881197d9dfeee0">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

