### PR TITLE
Fixed a bug related to inconsistent caching in the auto-increment service

### DIFF
--- a/pkg/incrservice/store_sql.go
+++ b/pkg/incrservice/store_sql.go
@@ -226,6 +226,19 @@ func (s *sqlStore) Allocate(
 
 	from, to := getNextRange(current, next, int(step))
 	commitTs := txnOp.GetOverview().Meta.CommitTS
+	// Fix: When the transaction has not committed yet (e.g., during CREATE TABLE),
+	// CommitTS is zero. Use SnapshotTS as a fallback to avoid setting lastAllocateAt to zero,
+	// which would cause PrimaryKeysMayBeUpserted to scan an excessively large time range.
+	if commitTs.IsEmpty() {
+		snapshotTs := txnOp.SnapshotTS()
+		getLogger(s.ls.GetConfig().ServiceID).Debug("auto-increment allocate: CommitTS is empty, using SnapshotTS as fallback",
+			zap.Uint64("table-id", tableID),
+			zap.String("col-name", colName),
+			zap.Uint64("from", from),
+			zap.Uint64("to", to),
+			zap.String("snapshot-ts", snapshotTs.DebugString()))
+		commitTs = snapshotTs
+	}
 	return from, to, commitTs, nil
 }
 

--- a/pkg/incrservice/store_sql_test.go
+++ b/pkg/incrservice/store_sql_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
@@ -109,8 +110,9 @@ func (tls *testLockService) GetServiceID() string {
 }
 
 func (tls *testLockService) GetConfig() lockservice.Config {
-	//TODO implement me
-	panic("implement me")
+	return lockservice.Config{
+		ServiceID: "test-lock-service",
+	}
 }
 
 func (tls *testLockService) Lock(ctx context.Context, tableID uint64, rows [][]byte, txnID []byte, options lock.LockOptions) (lock.Result, error) {
@@ -160,10 +162,19 @@ func (tls *testLockService) CloseRemoteLockTable(group uint32, tableID, version 
 var _ client.TxnOperator = new(testTxnOperator)
 
 type testTxnOperator struct {
+	// commitTS is used to simulate transaction commit timestamp
+	// If empty, Allocate should fallback to use SnapshotTS
+	commitTS timestamp.Timestamp
+	// snapshotTS is used to simulate transaction snapshot timestamp
+	snapshotTS timestamp.Timestamp
 }
 
 func (tTxnOp *testTxnOperator) GetOverview() client.TxnOverview {
-	return client.TxnOverview{}
+	return client.TxnOverview{
+		Meta: txn.TxnMeta{
+			CommitTS: tTxnOp.commitTS,
+		},
+	}
 }
 
 func (tTxnOp *testTxnOperator) CloneSnapshotOp(snapshot timestamp.Timestamp) client.TxnOperator {
@@ -201,8 +212,7 @@ func (tTxnOp *testTxnOperator) UpdateSnapshot(ctx context.Context, ts timestamp.
 }
 
 func (tTxnOp *testTxnOperator) SnapshotTS() timestamp.Timestamp {
-	//TODO implement me
-	panic("implement me")
+	return tTxnOp.snapshotTS
 }
 
 func (tTxnOp *testTxnOperator) CreateTS() timestamp.Timestamp {
@@ -336,49 +346,173 @@ func (tTxnOp *testTxnOperator) SetFootPrints(id int, enter bool) {
 }
 
 func Test_Allocate(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	sid := "test-lock-service" // Must match testLockService.GetConfig().ServiceID
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			ctx := context.TODO()
+			ctx = defines.AttachAccountId(ctx, 12)
 
-	ctx := context.TODO()
-	ctx = defines.AttachAccountId(ctx, 12)
+			txnOp := &testTxnOperator{}
 
-	txnOp := &testTxnOperator{}
+			var updateCnt atomic.Int32
 
-	var updateCnt atomic.Int32
+			sqlExecutor := executor.NewMemExecutor2(
+				func(sql string) (executor.Result, error) {
+					if strings.HasPrefix(sql, "select offset, step from mo_increment_columns where table_id") {
+						typs := []types.Type{
+							types.New(types.T_uint64, 64, 0),
+							types.New(types.T_uint64, 64, 0),
+						}
 
-	sqlExecutor := executor.NewMemExecutor2(
-		func(sql string) (executor.Result, error) {
-			if strings.HasPrefix(sql, "select offset, step from mo_increment_columns where table_id") {
-				typs := []types.Type{
-					types.New(types.T_uint64, 64, 0),
-					types.New(types.T_uint64, 64, 0),
-				}
+						memRes := executor.NewMemResult(
+							typs,
+							mpool.MustNewZero())
+						memRes.NewBatch()
+						executor.AppendFixedRows(memRes, 0, []uint64{1})
+						executor.AppendFixedRows(memRes, 1, []uint64{1})
+						return memRes.GetResult(), nil
+					} else if strings.HasPrefix(sql, "update mo_increment_columns set offset =") {
+						if updateCnt.Load() > 0 {
+							return executor.Result{AffectedRows: 1}, nil
+						}
+						updateCnt.Add(1)
+					}
 
-				memRes := executor.NewMemResult(
-					typs,
-					mpool.MustNewZero())
-				memRes.NewBatch()
-				executor.AppendFixedRows(memRes, 0, []uint64{1})
-				executor.AppendFixedRows(memRes, 1, []uint64{1})
-				return memRes.GetResult(), nil
-			} else if strings.HasPrefix(sql, "update mo_increment_columns set offset =") {
-				if updateCnt.Load() > 0 {
-					return executor.Result{AffectedRows: 1}, nil
-				}
-				updateCnt.Add(1)
+					return executor.Result{}, nil
+				},
+				txnOp,
+			)
+
+			s := &sqlStore{
+				exec: sqlExecutor,
+				ls:   &testLockService{},
 			}
 
-			return executor.Result{}, nil
+			_, _, _, err := s.Allocate(ctx, 10, "a", 1, nil)
+			require.NoError(t, err)
 		},
-		txnOp,
 	)
+}
 
-	s := &sqlStore{
-		exec: sqlExecutor,
-		ls:   &testLockService{},
-	}
+// TestAllocateWithEmptyCommitTS verifies that when CommitTS is empty (e.g., during CREATE TABLE),
+// the Allocate function falls back to using SnapshotTS for lastAllocateAt.
+// This fix prevents PrimaryKeysMayBeUpserted from scanning an excessively large time range.
+func TestAllocateWithEmptyCommitTS(t *testing.T) {
+	sid := "test-lock-service" // Must match testLockService.GetConfig().ServiceID
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			ctx := context.TODO()
+			ctx = defines.AttachAccountId(ctx, 12)
 
-	_, _, _, err := s.Allocate(ctx, 10, "a", 1, nil)
-	require.NoError(t, err)
-	//require.Equal(t, 2, len(executedSQLs))
+			// Create txnOp with empty CommitTS but valid SnapshotTS
+			snapshotTS := timestamp.Timestamp{PhysicalTime: 1000, LogicalTime: 1}
+			txnOp := &testTxnOperator{
+				commitTS:   timestamp.Timestamp{}, // Empty CommitTS
+				snapshotTS: snapshotTS,
+			}
+
+			var updateCnt atomic.Int32
+
+			sqlExecutor := executor.NewMemExecutor2(
+				func(sql string) (executor.Result, error) {
+					if strings.HasPrefix(sql, "select offset, step from mo_increment_columns where table_id") {
+						typs := []types.Type{
+							types.New(types.T_uint64, 64, 0),
+							types.New(types.T_uint64, 64, 0),
+						}
+
+						memRes := executor.NewMemResult(
+							typs,
+							mpool.MustNewZero())
+						memRes.NewBatch()
+						executor.AppendFixedRows(memRes, 0, []uint64{1})
+						executor.AppendFixedRows(memRes, 1, []uint64{1})
+						return memRes.GetResult(), nil
+					} else if strings.HasPrefix(sql, "update mo_increment_columns set offset =") {
+						if updateCnt.Load() > 0 {
+							return executor.Result{AffectedRows: 1}, nil
+						}
+						updateCnt.Add(1)
+					}
+
+					return executor.Result{}, nil
+				},
+				txnOp,
+			)
+
+			s := &sqlStore{
+				exec: sqlExecutor,
+				ls:   &testLockService{},
+			}
+
+			_, _, allocateTS, err := s.Allocate(ctx, 10, "a", 1, txnOp)
+			require.NoError(t, err)
+
+			// Verify that when CommitTS is empty, SnapshotTS is used as fallback
+			require.Equal(t, snapshotTS, allocateTS, "When CommitTS is empty, should fallback to SnapshotTS")
+		},
+	)
+}
+
+// TestAllocateWithValidCommitTS verifies that when CommitTS is valid,
+// the Allocate function uses CommitTS directly (not SnapshotTS).
+func TestAllocateWithValidCommitTS(t *testing.T) {
+	sid := "test-lock-service" // Must match testLockService.GetConfig().ServiceID
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			ctx := context.TODO()
+			ctx = defines.AttachAccountId(ctx, 12)
+
+			// Create txnOp with valid CommitTS
+			commitTS := timestamp.Timestamp{PhysicalTime: 2000, LogicalTime: 2}
+			snapshotTS := timestamp.Timestamp{PhysicalTime: 1000, LogicalTime: 1}
+			txnOp := &testTxnOperator{
+				commitTS:   commitTS,
+				snapshotTS: snapshotTS,
+			}
+
+			var updateCnt atomic.Int32
+
+			sqlExecutor := executor.NewMemExecutor2(
+				func(sql string) (executor.Result, error) {
+					if strings.HasPrefix(sql, "select offset, step from mo_increment_columns where table_id") {
+						typs := []types.Type{
+							types.New(types.T_uint64, 64, 0),
+							types.New(types.T_uint64, 64, 0),
+						}
+
+						memRes := executor.NewMemResult(
+							typs,
+							mpool.MustNewZero())
+						memRes.NewBatch()
+						executor.AppendFixedRows(memRes, 0, []uint64{1})
+						executor.AppendFixedRows(memRes, 1, []uint64{1})
+						return memRes.GetResult(), nil
+					} else if strings.HasPrefix(sql, "update mo_increment_columns set offset =") {
+						if updateCnt.Load() > 0 {
+							return executor.Result{AffectedRows: 1}, nil
+						}
+						updateCnt.Add(1)
+					}
+
+					return executor.Result{}, nil
+				},
+				txnOp,
+			)
+
+			s := &sqlStore{
+				exec: sqlExecutor,
+				ls:   &testLockService{},
+			}
+
+			_, _, allocateTS, err := s.Allocate(ctx, 10, "a", 1, txnOp)
+			require.NoError(t, err)
+
+			// Verify that when CommitTS is valid, it is used directly
+			require.Equal(t, commitTS, allocateTS, "When CommitTS is valid, should use CommitTS directly")
+		},
+	)
 }

--- a/pkg/sql/colexec/preinsert/preinsert.go
+++ b/pkg/sql/colexec/preinsert/preinsert.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
@@ -262,6 +263,20 @@ func genAutoIncrCol(bat *batch.Batch, proc *proc, preInsert *PreInsert) error {
 	currentTxn := proc.Base.TxnOperator
 
 	needReCheck := checkIfNeedReGenAutoIncrCol(bat, preInsert)
+
+	// FIX: Capture lastAllocateAt BEFORE InsertValues to avoid false negative bug
+	// If InsertValues triggers a new allocation, lastAllocateAt will be updated,
+	// which would cause PrimaryKeysMayBeUpserted to check a narrower time range
+	// and miss manual inserts that happened between the old and new allocation.
+	lastAllocateTSMap := make(map[string]timestamp.Timestamp)
+	for col := range needReCheck {
+		ts, err := proc.GetIncrService().GetLastAllocateTS(proc.Ctx, tableID, col)
+		if err != nil {
+			return err
+		}
+		lastAllocateTSMap[col] = ts
+	}
+
 	lastInsertValue, err := proc.GetIncrService().InsertValues(
 		proc.Ctx,
 		tableID,
@@ -294,16 +309,18 @@ func genAutoIncrCol(bat *batch.Batch, proc *proc, preInsert *PreInsert) error {
 			return err
 		}
 
+		// Use the captured lastAllocateAt timestamps (before InsertValues)
 		for col, idx := range needReCheck {
-			from, err := proc.GetIncrService().GetLastAllocateTS(proc.Ctx, tableID, col)
-			if err != nil {
-				return err
-			}
-			fromTs := types.TimestampToTS(from)
+			fromTs := types.TimestampToTS(lastAllocateTSMap[col])
 			toTs := types.TimestampToTS(proc.Base.TxnOperator.SnapshotTS())
+			// INFO level for debugging multi-CN auto-increment conflict check
+			logutil.Infof("auto-increment PK conflict check: tableID=%d, col=%s, fromTS=%s, toTS=%s",
+				tableID, col, fromTs.ToString(), toTs.ToString())
 			if mayChanged, err := rel.PrimaryKeysMayBeUpserted(proc.Ctx, fromTs, toTs, bat, preInsert.ColOffset+int32(idx)); err == nil {
+				logutil.Infof("auto-increment PK conflict check result: tableID=%d, col=%s, mayChanged=%v",
+					tableID, col, mayChanged)
 				if mayChanged {
-					logutil.Debugf("user may have manually specified the value to be inserted into the auto pk col before this transaction.")
+					logutil.Infof("auto-increment PK conflict detected, need retry: tableID=%d, col=%s", tableID, col)
 					return moerr.NewTxnNeedRetry(proc.Ctx)
 				}
 			} else {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/23364

## What this PR does / why we need it:
Fixed a bug related to inconsistent caching in the auto-increment service


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed inconsistent caching in auto-increment service by always updating `lastAllocateAt` to latest allocation timestamp

- Added fallback to `SnapshotTS` when `CommitTS` is empty during transaction allocation

- Captured `lastAllocateAt` before `InsertValues` to prevent false negatives in `PrimaryKeysMayBeUpserted` checks

- Added comprehensive test coverage for timestamp handling in allocation scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Allocation Request"] --> B["Check CommitTS"]
  B -->|Empty| C["Use SnapshotTS Fallback"]
  B -->|Valid| D["Use CommitTS"]
  C --> E["Update lastAllocateAt"]
  D --> E
  E --> F["Capture Timestamp Before InsertValues"]
  F --> G["PrimaryKeysMayBeUpserted Check"]
  G --> H["Correct Time Range Scan"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>column_cache.go</strong><dd><code>Simplify lastAllocateAt update logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/incrservice/column_cache.go

<ul><li>Simplified <code>lastAllocateAt</code> update logic to always use the latest <br>allocation timestamp<br> <li> Removed nested conditional checks and consolidated into single <br>condition<br> <li> Added detailed comments explaining multi-CN serialization and <br>timestamp ordering<br> <li> Commented out debug logging with enhanced fields for future debugging</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23489/files#diff-fcf6d693b06dbd358de6692d4728cce3a103d2c0de430140dfca1ef9dc59165e">+17/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>store_sql.go</strong><dd><code>Add CommitTS empty fallback to SnapshotTS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/incrservice/store_sql.go

<ul><li>Added fallback logic to use <code>SnapshotTS</code> when <code>CommitTS</code> is empty<br> <li> Prevents setting <code>lastAllocateAt</code> to zero which would cause excessive <br>time range scans<br> <li> Added debug logging to track when fallback is triggered<br> <li> Handles edge case during CREATE TABLE operations</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23489/files#diff-4323955c900a2e9d749c8e92201d99047d0ce505640bcdf180a7e736b3b912b1">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>preinsert.go</strong><dd><code>Capture lastAllocateAt before InsertValues call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/preinsert/preinsert.go

<ul><li>Captured <code>lastAllocateAt</code> timestamps BEFORE calling <code>InsertValues</code> to <br>prevent false negatives<br> <li> Stores captured timestamps in <code>lastAllocateTSMap</code> for use in <br><code>PrimaryKeysMayBeUpserted</code> checks<br> <li> Changed logging level from Debug to Info for auto-increment conflict <br>checks<br> <li> Added detailed logging of time range and conflict detection results<br> <li> Imported <code>timestamp</code> package</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23489/files#diff-1514ff4b2e07067345a5617851eea311f3d2005466d037e0d24104c559ef899e">+23/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>column_cache_test.go</strong><dd><code>Add tests for lastAllocateAt timestamp updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/incrservice/column_cache_test.go

<ul><li>Added <code>TestLastAllocateAtUpdate</code> to verify timestamp updates with <br>multiple allocations<br> <li> Added <code>TestLastAllocateAtEmptyInitial</code> to verify initialization from <br>empty state<br> <li> Tests cover scenarios with increasing, decreasing, and empty <br>timestamps<br> <li> Imported <code>timestamp</code> package for test timestamp creation</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23489/files#diff-3702d46bc03b506e1fa6f9c13f34a17a36d56a4b5111bc1a7a7352b71d034052">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>store_sql_test.go</strong><dd><code>Add tests for CommitTS fallback logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/incrservice/store_sql_test.go

<ul><li>Refactored <code>Test_Allocate</code> to use <code>runtime.RunTest</code> for proper <br>initialization<br> <li> Implemented <code>testTxnOperator</code> fields for <code>commitTS</code> and <code>snapshotTS</code> <br>simulation<br> <li> Added <code>TestAllocateWithEmptyCommitTS</code> to verify fallback behavior<br> <li> Added <code>TestAllocateWithValidCommitTS</code> to verify CommitTS is used when <br>available<br> <li> Fixed <code>testLockService.GetConfig()</code> to return proper configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23489/files#diff-7be9152998e4522d6fdd16ff7a5f3eefee803a694058c564957fd1ddc935017f">+176/-42</a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>table_cache.go</strong><dd><code>Add debug logging for empty timestamps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/incrservice/table_cache.go

<ul><li>Added debug logging in <code>getLastAllocateTS</code> to warn when timestamp is <br>empty<br> <li> Helps identify performance issues from large time range scans<br> <li> Imported <code>zap</code> logging package</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23489/files#diff-32e890372ec56995136716af74b222975fc5fc54f9858dbba26ea705569ffe26">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

