### PR TITLE
enhancement(perf): Optimize UUID generation performance by eliminating global lock contention

### DIFF
--- a/pkg/frontend/back_exec.go
+++ b/pkg/frontend/back_exec.go
@@ -38,6 +38,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/util"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace"
 	"github.com/matrixorigin/matrixone/pkg/util/trace/impl/motrace/statistic"
@@ -810,7 +811,8 @@ func newBackSession(ses FeSession, txnOp TxnOperator, db string, callBack output
 	txnHandler := InitTxnHandler(ses.GetService(), getPu(service).StorageEngine, ses.GetTxnHandler().GetConnCtx(), txnOp)
 	backSes := &backSession{}
 	backSes.initFeSes(ses, txnHandler, db, callBack)
-	backSes.uuid, _ = uuid.NewV7()
+	u, _ := util.FastUuid()
+	backSes.uuid = uuid.UUID(u)
 	return backSes
 }
 

--- a/pkg/frontend/computation_wrapper.go
+++ b/pkg/frontend/computation_wrapper.go
@@ -70,7 +70,8 @@ func InitTxnComputationWrapper(
 	stmt tree.Statement,
 	proc *process.Process,
 ) *TxnComputationWrapper {
-	uuid, _ := uuid.NewV7()
+	u, _ := util2.FastUuid()
+	uuid := uuid.UUID(u)
 	return &TxnComputationWrapper{
 		stmt: stmt,
 		proc: proc,

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -65,6 +65,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/explain"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	txnTrace "github.com/matrixorigin/matrixone/pkg/txn/trace"
+	"github.com/matrixorigin/matrixone/pkg/util"
 	"github.com/matrixorigin/matrixone/pkg/util/fault"
 	"github.com/matrixorigin/matrixone/pkg/util/metric"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
@@ -167,7 +168,8 @@ var RecordStatement = func(ctx context.Context, ses *Session, proc *process.Proc
 			text = commonutil.Abbreviate(envStmt, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))
 		}
 	} else {
-		stmID, _ = uuid.NewV7()
+		u, _ := util.FastUuid()
+		stmID = uuid.UUID(u)
 		text = commonutil.Abbreviate(envStmt, int(getPu(ses.GetService()).SV.LengthOfQueryPrinted))
 	}
 	ses.SetStmtId(stmID)

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -44,6 +44,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/util"
 	db_holder "github.com/matrixorigin/matrixone/pkg/util/export/etl/db"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/trace"
@@ -618,7 +619,8 @@ func NewSession(
 
 	ses.buf = buffer.New()
 	ses.sqlHelper = &SqlHelper{ses: ses}
-	ses.uuid, _ = uuid.NewV7()
+	u, _ := util.FastUuid()
+	ses.uuid = uuid.UUID(u)
 	pu := getPu(service)
 	if ses.pool == nil {
 		// If no mp, we create one for session.  Use GuestMmuLimitation as cap.

--- a/pkg/util/uuid.go
+++ b/pkg/util/uuid.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"crypto/rand"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+)
+
+// FastUuid generates UUID v7 with high performance and no global lock.
+//
+// Performance:
+//   - Single-threaded: ~60 ns/op (1.7x faster than google/uuid)
+//   - Concurrent: ~17 ns/op (10.9x faster than google/uuid)
+//   - Zero memory allocation
+//
+// Guarantees:
+//   - Uniqueness: crypto/rand provides 74 bits of randomness
+//   - Time monotonicity: time increases → UUID increases
+//   - No global lock: fully concurrent
+//
+// Trade-offs:
+//   - No strict monotonicity within the same millisecond
+//   - Random order for UUIDs generated in the same millisecond
+//
+// This is suitable for MatrixOne's point query scenario where:
+//   - UUIDs are used for identification, not strict ordering
+//   - High concurrency performance is critical
+//   - Time-based ordering is sufficient
+func FastUuid() (types.Uuid, error) {
+	var uuid [16]byte
+
+	// Fill random bytes (10 bytes) for uniqueness
+	// This is the key to guarantee uniqueness
+	if _, err := rand.Read(uuid[6:]); err != nil {
+		return types.Uuid{}, err
+	}
+
+	// Fill timestamp (6 bytes)
+	nano := time.Now().UnixNano()
+	milli := nano / 1000000
+
+	uuid[0] = byte(milli >> 40)
+	uuid[1] = byte(milli >> 32)
+	uuid[2] = byte(milli >> 24)
+	uuid[3] = byte(milli >> 16)
+	uuid[4] = byte(milli >> 8)
+	uuid[5] = byte(milli)
+
+	// Set version (7) and variant (RFC 4122)
+	uuid[6] = (uuid[6] & 0x0f) | 0x70 // version 7
+	uuid[8] = (uuid[8] & 0x3f) | 0x80 // variant
+
+	return types.Uuid(uuid), nil
+}

--- a/pkg/util/uuid_test.go
+++ b/pkg/util/uuid_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFastUuid_Uniqueness tests that generated UUIDs are unique
+func TestFastUuid_Uniqueness(t *testing.T) {
+	const count = 100000
+	seen := make(map[[16]byte]bool, count)
+
+	for i := 0; i < count; i++ {
+		u, err := FastUuid()
+		require.NoError(t, err)
+
+		// Check uniqueness
+		require.False(t, seen[u], "UUID collision detected: %v", u)
+		seen[u] = true
+	}
+}
+
+// TestFastUuid_TimeMonotonicity tests time-based monotonicity
+func TestFastUuid_TimeMonotonicity(t *testing.T) {
+	// Test that UUIDs from different milliseconds are ordered by time
+	u1, err := FastUuid()
+	require.NoError(t, err)
+
+	// Wait for time to advance
+	time.Sleep(2 * time.Millisecond)
+
+	u2, err := FastUuid()
+	require.NoError(t, err)
+
+	// u2 should be greater than u1 (time has advanced)
+	require.True(t, u2.Gt(u1), "UUID should increase with time")
+
+	// Test multiple iterations
+	for i := 0; i < 100; i++ {
+		prev, err := FastUuid()
+		require.NoError(t, err)
+
+		time.Sleep(time.Millisecond)
+
+		current, err := FastUuid()
+		require.NoError(t, err)
+
+		require.True(t, current.Gt(prev), "UUID should increase when time advances")
+	}
+}
+
+// TestFastUuid_Concurrent tests concurrent UUID generation
+func TestFastUuid_Concurrent(t *testing.T) {
+	const goroutines = 100
+	const perGoroutine = 1000
+
+	var wg sync.WaitGroup
+	results := make([][][16]byte, goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			uuids := make([][16]byte, perGoroutine)
+			for i := 0; i < perGoroutine; i++ {
+				u, err := FastUuid()
+				require.NoError(t, err)
+				uuids[i] = u
+			}
+			results[idx] = uuids
+		}(g)
+	}
+
+	wg.Wait()
+
+	// Check uniqueness across all goroutines
+	seen := make(map[[16]byte]bool, goroutines*perGoroutine)
+	for _, uuids := range results {
+		for _, u := range uuids {
+			require.False(t, seen[u], "UUID collision in concurrent test")
+			seen[u] = true
+		}
+	}
+}
+
+// TestFastUuid_Format tests UUID v7 format compliance
+func TestFastUuid_Format(t *testing.T) {
+	u, err := FastUuid()
+	require.NoError(t, err)
+
+	// Check version (should be 7)
+	version := (u[6] >> 4) & 0x0f
+	require.Equal(t, byte(7), version, "UUID version should be 7")
+
+	// Check variant (should be RFC 4122)
+	variant := (u[8] >> 6) & 0x03
+	require.Equal(t, byte(2), variant, "UUID variant should be RFC 4122 (10b)")
+}
+
+// BenchmarkGoogleUUID benchmarks google/uuid.NewV7()
+func BenchmarkGoogleUUID(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = uuid.NewV7()
+	}
+}
+
+// BenchmarkFastUuid benchmarks our implementation
+func BenchmarkFastUuid(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = FastUuid()
+	}
+}
+
+// BenchmarkGoogleUUID_Parallel benchmarks google/uuid in parallel
+func BenchmarkGoogleUUID_Parallel(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = uuid.NewV7()
+		}
+	})
+}
+
+// BenchmarkFastUuid_Parallel benchmarks our implementation in parallel
+func BenchmarkFastUuid_Parallel(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = FastUuid()
+		}
+	})
+}
+
+// TestFastUuid_Compatibility tests compatibility with google/uuid
+func TestFastUuid_Compatibility(t *testing.T) {
+	// Generate UUID using FastUuid
+	fastUuid, err := FastUuid()
+	require.NoError(t, err)
+
+	// Convert to google/uuid.UUID
+	googleUuid := uuid.UUID(fastUuid)
+
+	// Test 1: String format should be valid
+	str := googleUuid.String()
+	require.Len(t, str, 36, "UUID string should be 36 characters")
+	require.Contains(t, str, "-", "UUID string should contain hyphens")
+
+	// Test 2: Parse back should work
+	parsed, err := uuid.Parse(str)
+	require.NoError(t, err)
+	require.Equal(t, googleUuid, parsed, "Parsed UUID should match original")
+
+	// Test 3: Version should be 7
+	require.Equal(t, uuid.Version(7), googleUuid.Version(), "UUID version should be 7")
+
+	// Test 4: Variant should be RFC 4122
+	require.Equal(t, uuid.RFC4122, googleUuid.Variant(), "UUID variant should be RFC 4122")
+
+	// Test 5: Can be used in google/uuid functions
+	require.NotEqual(t, uuid.Nil, googleUuid, "UUID should not be nil")
+	require.True(t, googleUuid != uuid.Nil, "UUID should not equal Nil")
+}
+
+// TestFastUuid_InteroperabilityWithGoogleUuid tests that FastUuid and google/uuid can be mixed
+func TestFastUuid_InteroperabilityWithGoogleUuid(t *testing.T) {
+	// Generate UUIDs from both implementations
+	fastUuid1, err := FastUuid()
+	require.NoError(t, err)
+
+	googleUuid1, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	fastUuid2, err := FastUuid()
+	require.NoError(t, err)
+
+	// Convert to same type for comparison
+	fast1 := uuid.UUID(fastUuid1)
+	google1 := googleUuid1
+	fast2 := uuid.UUID(fastUuid2)
+
+	// All should be unique
+	require.NotEqual(t, fast1, google1)
+	require.NotEqual(t, fast1, fast2)
+	require.NotEqual(t, google1, fast2)
+
+	// All should be valid UUID v7
+	require.Equal(t, uuid.Version(7), fast1.Version())
+	require.Equal(t, uuid.Version(7), google1.Version())
+	require.Equal(t, uuid.Version(7), fast2.Version())
+
+	// All should have RFC 4122 variant
+	require.Equal(t, uuid.RFC4122, fast1.Variant())
+	require.Equal(t, uuid.RFC4122, google1.Variant())
+	require.Equal(t, uuid.RFC4122, fast2.Variant())
+}
+
+// TestFastUuid_DatabaseCompatibility tests that FastUuid can be stored/retrieved like google/uuid
+func TestFastUuid_DatabaseCompatibility(t *testing.T) {
+	fastUuid, err := FastUuid()
+	require.NoError(t, err)
+
+	// Test binary format (16 bytes)
+	require.Len(t, fastUuid, 16, "UUID should be 16 bytes")
+
+	// Test string format
+	googleUuid := uuid.UUID(fastUuid)
+	str := googleUuid.String()
+
+	// Parse back from string
+	parsed, err := uuid.Parse(str)
+	require.NoError(t, err)
+	require.Equal(t, fastUuid[:], parsed[:], "Binary representation should match")
+
+	// Test MarshalText/UnmarshalText (used by JSON)
+	text, err := googleUuid.MarshalText()
+	require.NoError(t, err)
+
+	var unmarshaled uuid.UUID
+	err = unmarshaled.UnmarshalText(text)
+	require.NoError(t, err)
+	require.Equal(t, googleUuid, unmarshaled, "Marshaled UUID should unmarshal correctly")
+}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20386

## What this PR does / why we need it:

### Problem
The current UUID v7 implementation using google/uuid.NewV7() has a global lock (timeMu)
that causes severe mutex contention in high-concurrency scenarios:
- Mutex contention: 10,667s (2.96 hours) during point query benchmark
- CPU overhead: 3.05-3.18% (3rd largest hotspot)
- Concurrent performance degradation: 83% slower (101.4ns → 185.5ns per operation)

### Solution
Implemented a lock-free FastUuid() function that:
- Eliminates global lock by using goroutine-independent generation
- Uses time.Now().UnixNano() for 48-bit timestamp (millisecond precision)
- Uses crypto/rand for 74-bit random space (2^74 collision resistance)
- Maintains RFC 9562 UUID v7 format compatibility

### Performance Impact
- Single-threaded: 1.7x faster (101.4ns → 60.5ns)
- Concurrent: 10.9x faster (185.5ns → 17.0ns)
- Mutex contention: -60.9% (10,667s → 4,171s)

### Compatibility
- 100% format compatible with google/uuid
- Same 16-byte binary format and 36-character string format
- Can be used interchangeably with existing UUID code
- No database schema changes required

### Trade-offs
- No strict monotonicity within same millisecond (acceptable: 2^37 UUIDs needed for 50% collision)
- Time-based monotonicity preserved (time increases → UUID increases)


___

### **PR Type**
Enhancement


___

### **Description**
- Implement lock-free FastUuid() function for high-performance UUID v7 generation

- Replace google/uuid.NewV7() calls with FastUuid() across frontend modules

- Achieve 10.9x concurrent performance improvement and 60.9% mutex contention reduction

- Maintain RFC 9562 UUID v7 format compatibility with existing code


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["google/uuid.NewV7<br/>Global Lock Contention"] -->|Replace| B["FastUuid<br/>Lock-Free Implementation"]
  B -->|Used in| C["back_exec.go<br/>mysql_cmd_executor.go<br/>session.go"]
  B -->|Maintains| D["RFC 9562 v7 Format<br/>100% Compatible"]
  B -->|Achieves| E["10.9x Faster<br/>Concurrent Performance"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uuid.go</strong><dd><code>Lock-free UUID v7 generation implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/util/uuid.go

<ul><li>New lock-free FastUuid() function using time.Now().UnixNano() for <br>48-bit timestamp<br> <li> Uses crypto/rand for 74-bit random space to ensure uniqueness<br> <li> Sets UUID v7 version and RFC 4122 variant bits<br> <li> Comprehensive documentation with performance guarantees and trade-offs</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23498/files#diff-8c6087037f2e19a5a40e94e62724ebefb2b434408889ef64f51f5ba2fc8bc735">+69/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>back_exec.go</strong><dd><code>Replace UUID generation with FastUuid in back_exec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/back_exec.go

<ul><li>Add import for util package<br> <li> Replace uuid.NewV7() with util.FastUuid() in newBackSession function<br> <li> Convert returned types.Uuid to uuid.UUID for compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23498/files#diff-6c8c7605ddaba02dbfd483c021e3901f66c8205e467634fde29e0dbdbb79396a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mysql_cmd_executor.go</strong><dd><code>Replace UUID generation with FastUuid in mysql_cmd_executor</code></dd></summary>
<hr>

pkg/frontend/mysql_cmd_executor.go

<ul><li>Add import for util package<br> <li> Replace uuid.NewV7() with util.FastUuid() in RecordStatement function<br> <li> Convert returned types.Uuid to uuid.UUID for compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23498/files#diff-af2611d5fc89704398fe09d09644efa41fec8931b395eda292f2f474f1216275">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>session.go</strong><dd><code>Replace UUID generation with FastUuid in session</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/session.go

<ul><li>Add import for util package<br> <li> Replace uuid.NewV7() with util.FastUuid() in NewSession function<br> <li> Convert returned types.Uuid to uuid.UUID for compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23498/files#diff-88f0aa40a4ccdc2de0ba0760f6e37fd2627e2ae337489de5ac58dcc9075bd7f8">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uuid_test.go</strong><dd><code>Comprehensive UUID generation tests and benchmarks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/util/uuid_test.go

<ul><li>Comprehensive test suite with 240 lines covering uniqueness, time <br>monotonicity, and concurrent generation<br> <li> Benchmarks comparing FastUuid vs google/uuid in single-threaded and <br>parallel scenarios<br> <li> Format compliance tests for UUID v7 version and RFC 4122 variant<br> <li> Compatibility and interoperability tests with google/uuid library<br> <li> Database compatibility tests for binary and string formats</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23498/files#diff-95dec0f26ccba89ee48b60290637dee2613558c654742467d82c3315a6404acc">+240/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

