### PR TITLE
enhancement(perf): optimize PushClient.isSubscribed mutex contention with RWMutex and atomic timestamp

### DIFF
--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -1035,7 +1035,7 @@ func (c *PushClient) doGCUnusedTable(ctx context.Context) {
 	}
 
 	// Phase 2: write phase, re-check and mark
-	var jobs []unsubJob
+	jobs := make([]unsubJob, 0, len(toClean))
 	c.subscribed.rw.Lock()
 	for _, job := range toClean {
 		ent, ok := c.subscribed.m[job.tId]

--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -221,11 +221,15 @@ func (c *PushClient) LatestLogtailAppliedTime() timestamp.Timestamp {
 }
 
 func (c *PushClient) GetState() State {
-	c.subscribed.mutex.Lock()
-	defer c.subscribed.mutex.Unlock()
+	c.subscribed.rw.RLock()
+	defer c.subscribed.rw.RUnlock()
 	subTables := make(map[uint64]SubTableStatus, len(c.subscribed.m))
-	for k, v := range c.subscribed.m {
-		subTables[k] = v
+	for k, ent := range c.subscribed.m {
+		subTables[k] = SubTableStatus{
+			DBID:       ent.dbID,
+			SubState:   ent.state,
+			LatestTime: time.Unix(0, ent.lastTs.Load()),
+		}
 	}
 	return State{
 		LatestTS:  c.receivedLogTailTime.getTimestamp(),
@@ -235,11 +239,12 @@ func (c *PushClient) GetState() State {
 
 // Only used for ut
 func (c *PushClient) SetSubscribeState(dbId, tblId uint64, state SubscribeState) {
-	c.subscribed.m[tblId] = SubTableStatus{
-		DBID:       dbId,
-		SubState:   state,
-		LatestTime: time.Now(),
+	ent := &subEntry{
+		dbID:  dbId,
+		state: state,
 	}
+	ent.lastTs.Store(time.Now().UnixNano())
+	c.subscribed.m[tblId] = ent
 }
 
 func (c *PushClient) IsSubscriberReady() bool {
@@ -247,8 +252,8 @@ func (c *PushClient) IsSubscriberReady() bool {
 }
 
 func (c *PushClient) IsSubscribed(tblId uint64) bool {
-	c.subscribed.mutex.Lock()
-	defer c.subscribed.mutex.Unlock()
+	c.subscribed.rw.RLock()
+	defer c.subscribed.rw.RUnlock()
 	if _, ok := c.subscribed.m[tblId]; ok {
 		return true
 	}
@@ -306,13 +311,13 @@ func (c *PushClient) init(
 	c.receivedLogTailTime.ready.Store(false)
 	c.dca = delayedCacheApply{}
 	c.subscriber.setNotReady()
-	c.subscribed.mutex.Lock()
+	c.subscribed.rw.Lock()
 	defer func() {
-		c.subscribed.mutex.Unlock()
+		c.subscribed.rw.Unlock()
 	}()
 
 	c.receivedLogTailTime.initLogTailTimestamp(timestampWaiter)
-	c.subscribed.m = make(map[uint64]SubTableStatus)
+	c.subscribed.m = make(map[uint64]*subEntry)
 
 	if !c.initialized {
 		c.connector = newConnector(c, e)
@@ -981,21 +986,17 @@ func (c *PushClient) UnsubscribeTable(ctx context.Context, accId, dbID, tbID uin
 	if ifShouldNotDistribute(dbID, tbID) {
 		return moerr.NewInternalErrorf(ctx, "%s cannot unsubscribe table %d-%d as table ID is not allowed", logTag, dbID, tbID)
 	}
-	c.subscribed.mutex.Lock()
-	defer c.subscribed.mutex.Unlock()
+	c.subscribed.rw.Lock()
+	defer c.subscribed.rw.Unlock()
 	k := tbID
-	status, ok := c.subscribed.m[k]
-	if !ok || status.SubState != Subscribed {
+	ent, ok := c.subscribed.m[k]
+	if !ok || ent.state != Subscribed {
 		logutil.Infof("%s table %d-%d is not subscribed yet", logTag, dbID, tbID)
 		return nil
 	}
 
-	dbID = status.DBID
-	c.subscribed.m[k] = SubTableStatus{
-		DBID:       dbID,
-		SubState:   Unsubscribing,
-		LatestTime: status.LatestTime,
-	}
+	dbID = ent.dbID
+	ent.state = Unsubscribing
 
 	if err := c.subscriber.sendUnSubscribe(ctx, api.TableID{DbId: dbID, TbId: tbID}); err != nil {
 		logutil.Errorf("%s cannot unsubscribe table %d-%d, err: %v", logTag, dbID, tbID, err)
@@ -1006,41 +1007,82 @@ func (c *PushClient) UnsubscribeTable(ctx context.Context, accId, dbID, tbID uin
 }
 
 func (c *PushClient) doGCUnusedTable(ctx context.Context) {
-	shouldClean := time.Now().Add(-unsubscribeTimer)
+	cutoff := time.Now().Add(-unsubscribeTimer).UnixNano()
 
-	// lock the subscribed map.
-	c.subscribed.mutex.Lock()
-	defer c.subscribed.mutex.Unlock()
-	var err error
-	for k, v := range c.subscribed.m {
-		if ifShouldNotDistribute(v.DBID, k) {
+	// Phase 1: read phase, collect candidates
+	type unsubJob struct {
+		dbID uint64
+		tId  uint64
+	}
+	var toClean []unsubJob
+
+	c.subscribed.rw.RLock()
+	for k, ent := range c.subscribed.m {
+		if ifShouldNotDistribute(ent.dbID, k) {
 			// never unsubscribe the mo_databases, mo_tables, mo_columns.
 			continue
 		}
-		if !v.LatestTime.After(shouldClean) {
-			if v.SubState != Subscribed {
-				continue
-			}
-			c.subscribed.m[k] = SubTableStatus{
-				SubState:   Unsubscribing,
-				LatestTime: v.LatestTime,
-			}
-			if err = c.subscriber.sendUnSubscribe(
-				ctx,
-				api.TableID{DbId: v.DBID, TbId: k}); err == nil {
-				logutil.Infof("%s send unsubscribe tbl[db: %d, tbl: %d] request succeed",
-					logTag,
-					v.DBID,
-					k)
-				continue
-			}
+		if ent.state == Subscribed && ent.lastTs.Load() <= cutoff {
+			toClean = append(toClean, unsubJob{dbID: ent.dbID, tId: k})
+		}
+	}
+	c.subscribed.rw.RUnlock()
+
+	if len(toClean) == 0 {
+		return
+	}
+
+	// Phase 2: write phase, re-check and mark
+	var jobs []unsubJob
+	c.subscribed.rw.Lock()
+	for _, job := range toClean {
+		ent, ok := c.subscribed.m[job.tId]
+		if !ok || ent.state != Subscribed {
+			continue // state changed
+		}
+		// Re-check timestamp: table may have been accessed between Phase 1 and Phase 2
+		if ent.lastTs.Load() > cutoff {
+			continue // recently accessed, skip
+		}
+		ent.state = Unsubscribing
+		jobs = append(jobs, job)
+	}
+	c.subscribed.rw.Unlock()
+
+	// Phase 3: send RPCs without holding the lock
+	// On failure, revert state to Subscribed so GC can retry next round
+	var failedJobs []unsubJob
+	for _, job := range jobs {
+		if err := c.subscriber.sendUnSubscribe(
+			ctx,
+			api.TableID{DbId: job.dbID, TbId: job.tId}); err == nil {
+			logutil.Infof("%s send unsubscribe tbl[db: %d, tbl: %d] request succeed",
+				logTag,
+				job.dbID,
+				job.tId)
+		} else {
 			logutil.Errorf("%s send unsubsribe tbl[dbId: %d, tblId: %d] request failed, err : %s",
 				logTag,
-				v.DBID,
-				k,
+				job.dbID,
+				job.tId,
 				err.Error())
-			break
+			failedJobs = append(failedJobs, job)
 		}
+	}
+
+	// Phase 4: revert failed jobs to Subscribed state for retry
+	if len(failedJobs) > 0 {
+		c.subscribed.rw.Lock()
+		for _, job := range failedJobs {
+			if ent, ok := c.subscribed.m[job.tId]; ok && ent.state == Unsubscribing {
+				ent.state = Subscribed
+				logutil.Infof("%s reverted tbl[db: %d, tbl: %d] to Subscribed for retry",
+					logTag,
+					job.dbID,
+					job.tId)
+			}
+		}
+		c.subscribed.rw.Unlock()
 	}
 }
 
@@ -1136,13 +1178,21 @@ func (c *PushClient) TryGC(ctx context.Context) {
 // subscribedTable used to record table subscribed status.
 // only if m[table T] = true, T has been subscribed.
 type subscribedTable struct {
-	eng   *Engine
-	mutex sync.Mutex
+	eng *Engine
+	rw  sync.RWMutex
 
-	// value is table's latest use time.
-	m map[uint64]SubTableStatus
+	// value is table's subscription entry with atomic timestamp.
+	m map[uint64]*subEntry
 }
 
+// subEntry holds subscription state with atomic timestamp for lock-free updates.
+type subEntry struct {
+	dbID   uint64
+	state  SubscribeState
+	lastTs atomic.Int64 // UnixNano, for GC to check if table is still in use
+}
+
+// SubTableStatus is used for external API compatibility (e.g., GetState).
 type SubTableStatus struct {
 	DBID       uint64
 	SubState   SubscribeState
@@ -1155,34 +1205,56 @@ func (c *PushClient) isSubscribed(
 ) (*logtailreplay.PartitionState, bool, SubscribeState) {
 
 	s := &c.subscribed
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
 
-	v, exist := s.m[tId]
-	if exist && v.SubState == Subscribed {
-		//update latest time
-		s.m[tId] = SubTableStatus{
-			DBID:       dbId,
-			SubState:   Subscribed,
-			LatestTime: time.Now(),
-		}
-		return c.eng.GetOrCreateLatestPart(ctx, accId, dbId, tId).Snapshot(), true, Subscribed
-	}
+	// First check: verify state under RLock
+	s.rw.RLock()
+	ent, exist := s.m[tId]
 	if !exist {
+		s.rw.RUnlock()
 		return nil, false, Unsubscribed
 	}
-	return nil, false, v.SubState
+	if ent.state != Subscribed {
+		st := ent.state
+		s.rw.RUnlock()
+		return nil, false, st
+	}
+	s.rw.RUnlock()
+
+	// Get partition outside subscribed lock (Engine has its own lock)
+	ps := c.eng.GetOrCreateLatestPart(ctx, accId, dbId, tId).Snapshot()
+
+	// Re-check: state may have changed while we were getting partition
+	s.rw.RLock()
+	ent, exist = s.m[tId]
+	if !exist {
+		s.rw.RUnlock()
+		return nil, false, Unsubscribed
+	}
+	st := ent.state
+	if st == Subscribed {
+		// Update timestamp (with sampling)
+		now := time.Now().UnixNano()
+		if now-ent.lastTs.Load() > int64(time.Minute) {
+			ent.lastTs.Store(now)
+		}
+	}
+	s.rw.RUnlock()
+
+	if st != Subscribed {
+		return nil, false, st
+	}
+	return ps, true, Subscribed
 }
 
 func (c *PushClient) toSubIfUnsubscribed(ctx context.Context, dbId, tblId uint64) (SubscribeState, error) {
-	c.subscribed.mutex.Lock()
-	defer c.subscribed.mutex.Unlock()
+	c.subscribed.rw.Lock()
+	defer c.subscribed.rw.Unlock()
 	_, ok := c.subscribed.m[tblId]
 	if !ok {
 		if !c.subscriber.ready() {
 			if err := func() error {
-				c.subscribed.mutex.Unlock()
-				defer c.subscribed.mutex.Lock()
+				c.subscribed.rw.Unlock()
+				defer c.subscribed.rw.Lock()
 				if err := c.subscriber.waitReady(ctx); err != nil {
 					return err
 				}
@@ -1191,13 +1263,13 @@ func (c *PushClient) toSubIfUnsubscribed(ctx context.Context, dbId, tblId uint64
 				return InvalidSubState, err
 			}
 		}
-		v, exist := c.subscribed.m[tblId]
-		if exist && v.SubState == Subscribed {
+		ent, exist := c.subscribed.m[tblId]
+		if exist && ent.state == Subscribed {
 			return Subscribed, nil
 		}
-		c.subscribed.m[tblId] = SubTableStatus{
-			DBID:     dbId,
-			SubState: Subscribing,
+		c.subscribed.m[tblId] = &subEntry{
+			dbID:  dbId,
+			state: Subscribing,
 		}
 
 		if err := c.subscribeTable(ctx, api.TableID{DbId: dbId, TbId: tblId}); err != nil {
@@ -1206,23 +1278,20 @@ func (c *PushClient) toSubIfUnsubscribed(ctx context.Context, dbId, tblId uint64
 			return Unsubscribed, err
 		}
 	}
-	return c.subscribed.m[tblId].SubState, nil
+	return c.subscribed.m[tblId].state, nil
 
 }
 
 func (s *subscribedTable) isSubscribed(dbId, tblId uint64) bool {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	v, exist := s.m[tblId]
-	if exist && v.SubState == Subscribed {
-		//update latest time
-		s.m[tblId] = SubTableStatus{
-			DBID:       dbId,
-			SubState:   Subscribed,
-			LatestTime: time.Now(),
-		}
+	s.rw.RLock()
+	ent, exist := s.m[tblId]
+	if exist && ent.state == Subscribed {
+		// Update timestamp atomically
+		ent.lastTs.Store(time.Now().UnixNano())
+		s.rw.RUnlock()
 		return true
 	}
+	s.rw.RUnlock()
 	return false
 }
 
@@ -1236,20 +1305,17 @@ func (c *PushClient) loadAndConsumeLatestCkp(
 	dbName string,
 ) (SubscribeState, error) {
 
-	c.subscribed.mutex.Lock()
-	defer c.subscribed.mutex.Unlock()
-	v, exist := c.subscribed.m[tableID]
-	if exist && (v.SubState == SubRspReceived || v.SubState == Subscribed) {
+	c.subscribed.rw.Lock()
+	defer c.subscribed.rw.Unlock()
+	ent, exist := c.subscribed.m[tableID]
+	if exist && (ent.state == SubRspReceived || ent.state == Subscribed) {
 		_, err := c.eng.LazyLoadLatestCkp(ctx, accId, tableID, tableName, dbID, dbName)
 		if err != nil {
 			return InvalidSubState, err
 		}
-		//update latest time
-		c.subscribed.m[tableID] = SubTableStatus{
-			DBID:       dbID,
-			SubState:   Subscribed,
-			LatestTime: time.Now(),
-		}
+		//update state and timestamp
+		ent.state = Subscribed
+		ent.lastTs.Store(time.Now().UnixNano())
 		return Subscribed, nil
 	}
 	//if unsubscribed, need to subscribe table.
@@ -1257,9 +1323,9 @@ func (c *PushClient) loadAndConsumeLatestCkp(
 		if !c.subscriber.ready() {
 			return Unsubscribed, moerr.NewInternalError(ctx, "log tail subscriber is not ready")
 		}
-		c.subscribed.m[tableID] = SubTableStatus{
-			DBID:     dbID,
-			SubState: Subscribing,
+		c.subscribed.m[tableID] = &subEntry{
+			dbID:  dbID,
+			state: Subscribing,
 		}
 		if err := c.subscribeTable(ctx, api.TableID{DbId: dbID, TbId: tableID}); err != nil {
 			//restore the table status.
@@ -1268,7 +1334,7 @@ func (c *PushClient) loadAndConsumeLatestCkp(
 		}
 		return Subscribing, nil
 	}
-	return v.SubState, nil
+	return ent.state, nil
 }
 
 func (c *PushClient) waitUntilSubscribingChanged(ctx context.Context, dbId, tblId uint64) (SubscribeState, error) {
@@ -1322,23 +1388,23 @@ func (c *PushClient) waitUntilUnsubscribingChanged(ctx context.Context, dbId, tb
 }
 
 func (c *PushClient) isNotSubscribing(ctx context.Context, dbId, tblId uint64) (bool, SubscribeState, error) {
-	c.subscribed.mutex.Lock()
-	defer c.subscribed.mutex.Unlock()
-	v, exist := c.subscribed.m[tblId]
+	c.subscribed.rw.Lock()
+	defer c.subscribed.rw.Unlock()
+	ent, exist := c.subscribed.m[tblId]
 	if exist {
-		if v.SubState == Subscribing {
-			return false, v.SubState, nil
+		if ent.state == Subscribing {
+			return false, ent.state, nil
 		}
-		return true, v.SubState, nil
+		return true, ent.state, nil
 	}
 	//table is unsubscribed
 	if !c.subscriber.ready() {
 		// let wait the subscriber ready.
 		return false, Unsubscribed, nil //moerr.NewInternalError(ctx, "log tail subscriber is not ready")
 	}
-	c.subscribed.m[tblId] = SubTableStatus{
-		DBID:     dbId,
-		SubState: Subscribing,
+	c.subscribed.m[tblId] = &subEntry{
+		dbID:  dbId,
+		state: Subscribing,
 	}
 	if err := c.subscribeTable(ctx, api.TableID{DbId: dbId, TbId: tblId}); err != nil {
 		//restore the table status.
@@ -1350,23 +1416,23 @@ func (c *PushClient) isNotSubscribing(ctx context.Context, dbId, tblId uint64) (
 
 // isUnsubscribed check if the table is unsubscribed, if yes, set the table status to subscribing and do subscribe.
 func (c *PushClient) isNotUnsubscribing(ctx context.Context, dbId, tblId uint64) (bool, SubscribeState, error) {
-	c.subscribed.mutex.Lock()
-	defer c.subscribed.mutex.Unlock()
-	v, exist := c.subscribed.m[tblId]
+	c.subscribed.rw.Lock()
+	defer c.subscribed.rw.Unlock()
+	ent, exist := c.subscribed.m[tblId]
 	if exist {
-		if v.SubState == Unsubscribing {
-			return false, v.SubState, nil
+		if ent.state == Unsubscribing {
+			return false, ent.state, nil
 		} else {
-			return true, v.SubState, nil
+			return true, ent.state, nil
 		}
 	}
 	//table is unsubscribed
 	if !c.subscriber.ready() {
 		return false, Unsubscribed, nil //moerr.NewInternalError(ctx, "log tail subscriber is not ready")
 	}
-	c.subscribed.m[tblId] = SubTableStatus{
-		DBID:     dbId,
-		SubState: Subscribing,
+	c.subscribed.m[tblId] = &subEntry{
+		dbID:  dbId,
+		state: Subscribing,
 	}
 	if err := c.subscribeTable(ctx, api.TableID{DbId: dbId, TbId: tblId}); err != nil {
 		//restore the table status.
@@ -1383,13 +1449,14 @@ func (c *PushClient) Disconnect() error {
 }
 
 func (s *subscribedTable) setTableSubNotExist(dbId, tblId uint64) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	s.m[tblId] = SubTableStatus{
-		DBID:       dbId,
-		SubState:   SubRspTableNotExist,
-		LatestTime: time.Now(),
+	s.rw.Lock()
+	defer s.rw.Unlock()
+	ent := &subEntry{
+		dbID:  dbId,
+		state: SubRspTableNotExist,
 	}
+	ent.lastTs.Store(time.Now().UnixNano())
+	s.m[tblId] = ent
 	logutil.Error(
 		"logtail.consumer.set.table.sub.not.exist",
 		zap.Uint64("db-id", dbId),
@@ -1398,19 +1465,20 @@ func (s *subscribedTable) setTableSubNotExist(dbId, tblId uint64) {
 }
 
 func (s *subscribedTable) clearTable(dbId, tblId uint64) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	s.rw.Lock()
+	defer s.rw.Unlock()
 	delete(s.m, tblId)
 }
 
 func (s *subscribedTable) setTableSubscribed(dbId, tblId uint64) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	s.m[tblId] = SubTableStatus{
-		DBID:       dbId,
-		SubState:   Subscribed,
-		LatestTime: time.Now(),
+	s.rw.Lock()
+	defer s.rw.Unlock()
+	ent := &subEntry{
+		dbID:  dbId,
+		state: Subscribed,
 	}
+	ent.lastTs.Store(time.Now().UnixNano())
+	s.m[tblId] = ent
 	logutil.Info(
 		"logtail.consumer.set.table.subscribed",
 		zap.Uint64("db-id", dbId),
@@ -1419,13 +1487,14 @@ func (s *subscribedTable) setTableSubscribed(dbId, tblId uint64) {
 }
 
 func (s *subscribedTable) setTableSubRspReceived(dbId, tblId uint64) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-	s.m[tblId] = SubTableStatus{
-		DBID:       dbId,
-		SubState:   SubRspReceived,
-		LatestTime: time.Now(),
+	s.rw.Lock()
+	defer s.rw.Unlock()
+	ent := &subEntry{
+		dbID:  dbId,
+		state: SubRspReceived,
 	}
+	ent.lastTs.Store(time.Now().UnixNano())
+	s.m[tblId] = ent
 	logutil.Info(
 		"logtail.consumer.set.table.sub.rsp.received",
 		zap.String("service", s.eng.service),
@@ -1436,8 +1505,8 @@ func (s *subscribedTable) setTableSubRspReceived(dbId, tblId uint64) {
 }
 
 func (s *subscribedTable) setTableUnsubscribe(dbId, tblId uint64) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+	s.rw.Lock()
+	defer s.rw.Unlock()
 	s.eng.cleanMemoryTableWithTable(dbId, tblId)
 	delete(s.m, tblId)
 	logutil.Info(

--- a/pkg/vm/engine/disttae/logtail_consumer_test.go
+++ b/pkg/vm/engine/disttae/logtail_consumer_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -241,7 +242,7 @@ func TestPushClient_LatestLogtailAppliedTime(t *testing.T) {
 
 func TestPushClient_GetState(t *testing.T) {
 	var c PushClient
-	c.subscribed.m = make(map[uint64]SubTableStatus)
+	c.subscribed.m = make(map[uint64]*subEntry)
 	tw := client.NewTimestampWaiter(runtime.GetLogger(""))
 	c.receivedLogTailTime.initLogTailTimestamp(tw)
 	ts := timestamp.Timestamp{
@@ -266,7 +267,7 @@ func TestPushClient_GetState(t *testing.T) {
 func TestSubscribedTable(t *testing.T) {
 	var subscribeRecord subscribedTable
 
-	subscribeRecord.m = make(map[uint64]SubTableStatus)
+	subscribeRecord.m = make(map[uint64]*subEntry)
 	subscribeRecord.eng = &Engine{
 		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
 		globalStats: &GlobalStats{},
@@ -513,7 +514,7 @@ func TestPushClient_DoGCUnusedTable(t *testing.T) {
 		c.subscriber = &logTailSubscriber{}
 		c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
 		c.subscriber.setReady()
-		c.subscribed.m = make(map[uint64]SubTableStatus)
+		c.subscribed.m = make(map[uint64]*subEntry)
 	}
 
 	t.Run("unsubscribe - should not unsub", func(t *testing.T) {
@@ -521,23 +522,23 @@ func TestPushClient_DoGCUnusedTable(t *testing.T) {
 		defer cancel()
 		var c PushClient
 		initFn(ctx, &c)
-		c.subscribed.m[2] = SubTableStatus{
-			DBID: catalog.MO_CATALOG_ID,
-		}
+		ent := &subEntry{dbID: catalog.MO_CATALOG_ID, state: Subscribed}
+		ent.lastTs.Store(time.Now().Add(-time.Hour * 2).UnixNano())
+		c.subscribed.m[2] = ent
 		c.doGCUnusedTable(ctx)
 		assert.Equal(t, 1, len(c.subscribed.m))
 		_, ok := c.subscribed.m[2]
 		assert.True(t, ok)
 	})
 
-	t.Run("unsubscribe - not safe", func(t *testing.T) {
+	t.Run("unsubscribe - not subscribed state", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		var c PushClient
 		initFn(ctx, &c)
-		c.subscribed.m[200] = SubTableStatus{
-			DBID: 1000,
-		}
+		ent := &subEntry{dbID: 1000, state: Subscribing}
+		ent.lastTs.Store(time.Now().Add(-time.Hour * 2).UnixNano())
+		c.subscribed.m[200] = ent
 		c.doGCUnusedTable(ctx)
 		assert.Equal(t, 1, len(c.subscribed.m))
 		_, ok := c.subscribed.m[200]
@@ -550,16 +551,14 @@ func TestPushClient_DoGCUnusedTable(t *testing.T) {
 		var c PushClient
 		initFn(ctx, &c)
 		var tid uint64 = 200
-		c.subscribed.m[tid] = SubTableStatus{
-			DBID:       1000,
-			SubState:   Subscribed,
-			LatestTime: time.Now().Add(-time.Hour * 2),
-		}
+		ent := &subEntry{dbID: 1000, state: Subscribed}
+		ent.lastTs.Store(time.Now().Add(-time.Hour * 2).UnixNano())
+		c.subscribed.m[tid] = ent
 		ch := make(chan struct{})
 		c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
 			go func() {
-				c.subscribed.mutex.Lock()
-				defer c.subscribed.mutex.Unlock()
+				c.subscribed.rw.Lock()
+				defer c.subscribed.rw.Unlock()
 				delete(c.subscribed.m, id.TbId)
 				ch <- struct{}{}
 			}()
@@ -576,11 +575,9 @@ func TestPushClient_DoGCUnusedTable(t *testing.T) {
 		var c PushClient
 		initFn(ctx, &c)
 		var tid uint64 = 200
-		c.subscribed.m[tid] = SubTableStatus{
-			DBID:       1000,
-			SubState:   Subscribed,
-			LatestTime: time.Now().Add(-time.Hour * 2),
-		}
+		ent := &subEntry{dbID: 1000, state: Subscribed}
+		ent.lastTs.Store(time.Now().Add(-time.Hour * 2).UnixNano())
+		c.subscribed.m[tid] = ent
 		ch := make(chan struct{})
 		c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
 			go func() {
@@ -734,7 +731,7 @@ func TestPushClient_LoadAndConsumeLatestCkp(t *testing.T) {
 		serviceID:       sid,
 		timestampWaiter: tw,
 		subscriber:      &logTailSubscriber{},
-		subscribed:      subscribedTable{m: make(map[uint64]SubTableStatus)},
+		subscribed:      subscribedTable{m: make(map[uint64]*subEntry)},
 	}
 	c.receivedLogTailTime.initLogTailTimestamp(tw)
 
@@ -1017,4 +1014,1676 @@ func TestCommandActions(t *testing.T) {
 		assert.Equal(t, receiveAt, cmd.receiveAt)
 	})
 
+}
+
+// =============================================================================
+// Tests for subscribedTable with RWMutex and atomic timestamp (Solution E)
+// =============================================================================
+
+// TestSubEntry_AtomicTimestamp tests atomic timestamp operations
+func TestSubEntry_AtomicTimestamp(t *testing.T) {
+	t.Run("basic atomic operations", func(t *testing.T) {
+		ent := &subEntry{
+			dbID:  100,
+			state: Subscribed,
+		}
+		now := time.Now().UnixNano()
+		ent.lastTs.Store(now)
+
+		assert.Equal(t, now, ent.lastTs.Load())
+		assert.Equal(t, uint64(100), ent.dbID)
+		assert.Equal(t, Subscribed, ent.state)
+	})
+
+	t.Run("concurrent atomic updates", func(t *testing.T) {
+		ent := &subEntry{
+			dbID:  100,
+			state: Subscribed,
+		}
+		ent.lastTs.Store(time.Now().UnixNano())
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					ent.lastTs.Store(time.Now().UnixNano())
+					_ = ent.lastTs.Load()
+				}
+			}()
+		}
+		wg.Wait()
+		// No race condition should occur
+	})
+}
+
+// TestSubscribedTable_RWMutex tests RWMutex behavior
+func TestSubscribedTable_RWMutex(t *testing.T) {
+	t.Run("concurrent reads", func(t *testing.T) {
+		s := &subscribedTable{
+			m: make(map[uint64]*subEntry),
+		}
+		// Add some entries
+		for i := uint64(0); i < 100; i++ {
+			ent := &subEntry{dbID: i, state: Subscribed}
+			ent.lastTs.Store(time.Now().UnixNano())
+			s.m[i] = ent
+		}
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 1000; j++ {
+					s.rw.RLock()
+					for _, ent := range s.m {
+						_ = ent.state
+						_ = ent.lastTs.Load()
+					}
+					s.rw.RUnlock()
+				}
+			}()
+		}
+		wg.Wait()
+	})
+
+	t.Run("read-write contention", func(t *testing.T) {
+		s := &subscribedTable{
+			m: make(map[uint64]*subEntry),
+		}
+		ent := &subEntry{dbID: 1, state: Subscribed}
+		ent.lastTs.Store(time.Now().UnixNano())
+		s.m[1] = ent
+
+		var wg sync.WaitGroup
+		stop := make(chan struct{})
+
+		// Readers
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						s.rw.RLock()
+						if e, ok := s.m[1]; ok {
+							_ = e.state
+							e.lastTs.Store(time.Now().UnixNano())
+						}
+						s.rw.RUnlock()
+					}
+				}
+			}()
+		}
+
+		// Writer
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				s.rw.Lock()
+				s.m[1].state = Subscribed
+				s.rw.Unlock()
+				time.Sleep(time.Microsecond)
+			}
+		}()
+
+		time.Sleep(50 * time.Millisecond)
+		close(stop)
+		wg.Wait()
+	})
+}
+
+// TestIsSubscribed_Concurrent tests concurrent isSubscribed calls
+func TestIsSubscribed_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+
+	// Setup subscribed table
+	ent := &subEntry{dbID: 1, state: Subscribed}
+	ent.lastTs.Store(time.Now().UnixNano())
+	c.subscribed.m[100] = ent
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_, ok, state := c.isSubscribed(ctx, 0, 1, 100)
+				assert.True(t, ok)
+				assert.Equal(t, Subscribed, state)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestIsSubscribed_TimestampSampling tests that timestamp is only updated when > 1 minute old
+func TestIsSubscribed_TimestampSampling(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+
+	t.Run("recent timestamp not updated", func(t *testing.T) {
+		now := time.Now().UnixNano()
+		ent := &subEntry{dbID: 1, state: Subscribed}
+		ent.lastTs.Store(now)
+		c.subscribed.m[100] = ent
+
+		c.isSubscribed(ctx, 0, 1, 100)
+
+		// Timestamp should not change (within 1 minute)
+		assert.Equal(t, now, ent.lastTs.Load())
+	})
+
+	t.Run("old timestamp updated", func(t *testing.T) {
+		oldTime := time.Now().Add(-2 * time.Minute).UnixNano()
+		ent := &subEntry{dbID: 1, state: Subscribed}
+		ent.lastTs.Store(oldTime)
+		c.subscribed.m[101] = ent
+
+		c.isSubscribed(ctx, 0, 1, 101)
+
+		// Timestamp should be updated
+		assert.True(t, ent.lastTs.Load() > oldTime)
+	})
+}
+
+// TestDoGCUnusedTable_ConcurrentAccess tests GC with concurrent reads
+func TestDoGCUnusedTable_ConcurrentAccess(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	// Track unsubscribe calls
+	var unsubCalls sync.Map
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		unsubCalls.Store(id.TbId, true)
+		return nil
+	}
+
+	// Add old entries that should be GC'd
+	for i := uint64(200); i < 210; i++ {
+		ent := &subEntry{dbID: 1000, state: Subscribed}
+		ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+		c.subscribed.m[i] = ent
+	}
+
+	// Add recent entries that should NOT be GC'd
+	for i := uint64(300); i < 310; i++ {
+		ent := &subEntry{dbID: 1000, state: Subscribed}
+		ent.lastTs.Store(time.Now().UnixNano())
+		c.subscribed.m[i] = ent
+	}
+
+	var wg sync.WaitGroup
+
+	// Concurrent readers
+	stop := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					c.subscribed.rw.RLock()
+					for _, ent := range c.subscribed.m {
+						_ = ent.state
+						_ = ent.lastTs.Load()
+					}
+					c.subscribed.rw.RUnlock()
+				}
+			}
+		}()
+	}
+
+	// Run GC
+	c.doGCUnusedTable(ctx)
+
+	close(stop)
+	wg.Wait()
+
+	// Verify old entries were marked for unsubscribe
+	for i := uint64(200); i < 210; i++ {
+		_, called := unsubCalls.Load(i)
+		assert.True(t, called, "table %d should be unsubscribed", i)
+	}
+
+	// Verify recent entries were NOT unsubscribed
+	for i := uint64(300); i < 310; i++ {
+		_, called := unsubCalls.Load(i)
+		assert.False(t, called, "table %d should NOT be unsubscribed", i)
+	}
+}
+
+// TestDoGCUnusedTable_RaceWithIsSubscribed tests GC race with isSubscribed updating timestamp
+func TestDoGCUnusedTable_RaceWithIsSubscribed(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	var unsubCalled atomic.Bool
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		unsubCalled.Store(true)
+		return nil
+	}
+
+	// Add entry with old timestamp
+	ent := &subEntry{dbID: 1000, state: Subscribed}
+	ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+	c.subscribed.m[500] = ent
+
+	var wg sync.WaitGroup
+
+	// Simulate isSubscribed updating timestamp between GC Phase 1 and Phase 2
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Wait a bit for GC Phase 1 to complete
+		time.Sleep(time.Microsecond * 100)
+		// Update timestamp (simulating isSubscribed call)
+		ent.lastTs.Store(time.Now().UnixNano())
+	}()
+
+	// Run GC
+	c.doGCUnusedTable(ctx)
+
+	wg.Wait()
+
+	// The table should NOT be unsubscribed because timestamp was updated
+	// (Phase 2 re-checks timestamp)
+	// Note: This is a race, so we can't guarantee the order, but the code should be safe
+}
+
+// TestSubscribedTable_StateTransitions tests state machine transitions
+func TestSubscribedTable_StateTransitions(t *testing.T) {
+	s := &subscribedTable{
+		m:   make(map[uint64]*subEntry),
+		eng: &Engine{partitions: make(map[[2]uint64]*logtailreplay.Partition), globalStats: &GlobalStats{}},
+	}
+
+	t.Run("subscribe flow", func(t *testing.T) {
+		// Unsubscribed -> Subscribing -> SubRspReceived -> Subscribed
+		s.m[1] = &subEntry{dbID: 100, state: Subscribing}
+
+		s.setTableSubRspReceived(100, 1)
+		assert.Equal(t, SubRspReceived, s.m[1].state)
+
+		s.setTableSubscribed(100, 1)
+		assert.Equal(t, Subscribed, s.m[1].state)
+	})
+
+	t.Run("unsubscribe flow", func(t *testing.T) {
+		ent := &subEntry{dbID: 100, state: Subscribed}
+		ent.lastTs.Store(time.Now().UnixNano())
+		s.m[2] = ent
+
+		// Mark as unsubscribing
+		s.rw.Lock()
+		s.m[2].state = Unsubscribing
+		s.rw.Unlock()
+
+		assert.Equal(t, Unsubscribing, s.m[2].state)
+
+		// Complete unsubscribe
+		s.setTableUnsubscribe(100, 2)
+		_, exists := s.m[2]
+		assert.False(t, exists)
+	})
+
+	t.Run("table not exist", func(t *testing.T) {
+		s.setTableSubNotExist(100, 3)
+		assert.Equal(t, SubRspTableNotExist, s.m[3].state)
+	})
+}
+
+// TestGetState_Concurrent tests concurrent GetState calls
+func TestGetState_Concurrent(t *testing.T) {
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	tw := client.NewTimestampWaiter(runtime.GetLogger(""))
+	c.receivedLogTailTime.initLogTailTimestamp(tw)
+
+	// Add entries
+	for i := uint64(0); i < 100; i++ {
+		ent := &subEntry{dbID: i, state: Subscribed}
+		ent.lastTs.Store(time.Now().UnixNano())
+		c.subscribed.m[i] = ent
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				state := c.GetState()
+				assert.Equal(t, 100, len(state.SubTables))
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestIsSubscribed_NotFound tests isSubscribed with non-existent table
+func TestIsSubscribed_NotFound(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+
+	_, ok, state := c.isSubscribed(ctx, 0, 1, 999)
+	assert.False(t, ok)
+	assert.Equal(t, Unsubscribed, state)
+}
+
+// TestIsSubscribed_DifferentStates tests isSubscribed with different states
+func TestIsSubscribed_DifferentStates(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+
+	states := []SubscribeState{Subscribing, SubRspReceived, Unsubscribing, SubRspTableNotExist}
+	for i, s := range states {
+		ent := &subEntry{dbID: 1, state: s}
+		ent.lastTs.Store(time.Now().UnixNano())
+		c.subscribed.m[uint64(i)] = ent
+	}
+
+	for i, expectedState := range states {
+		_, ok, state := c.isSubscribed(ctx, 0, 1, uint64(i))
+		assert.False(t, ok)
+		assert.Equal(t, expectedState, state)
+	}
+}
+
+// TestConcurrentSubscribeUnsubscribe tests concurrent subscribe and unsubscribe operations
+func TestConcurrentSubscribeUnsubscribe(t *testing.T) {
+	s := &subscribedTable{
+		m:   make(map[uint64]*subEntry),
+		eng: &Engine{partitions: make(map[[2]uint64]*logtailreplay.Partition), globalStats: &GlobalStats{}},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		tblId := uint64(i)
+
+		// Subscribe
+		go func() {
+			defer wg.Done()
+			s.setTableSubscribed(100, tblId)
+		}()
+
+		// Unsubscribe (may or may not find the entry)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Microsecond * 10)
+			s.setTableUnsubscribe(100, tblId)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestDoGCUnusedTable_ProtectedTables tests that system tables are not GC'd
+func TestDoGCUnusedTable_ProtectedTables(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	var unsubCalled atomic.Bool
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		unsubCalled.Store(true)
+		return nil
+	}
+
+	// Add system table (should be protected)
+	ent := &subEntry{dbID: catalog.MO_CATALOG_ID, state: Subscribed}
+	ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+	c.subscribed.m[catalog.MO_DATABASE_ID] = ent
+
+	c.doGCUnusedTable(ctx)
+
+	assert.False(t, unsubCalled.Load(), "system table should not be unsubscribed")
+}
+
+// TestDoGCUnusedTable_NonSubscribedState tests that non-Subscribed entries are skipped
+func TestDoGCUnusedTable_NonSubscribedState(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	var unsubCalled atomic.Bool
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		unsubCalled.Store(true)
+		return nil
+	}
+
+	// Add entry with Subscribing state (should be skipped)
+	ent := &subEntry{dbID: 1000, state: Subscribing}
+	ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+	c.subscribed.m[600] = ent
+
+	c.doGCUnusedTable(ctx)
+
+	assert.False(t, unsubCalled.Load(), "non-Subscribed entry should not be unsubscribed")
+}
+
+
+// =============================================================================
+// Additional tests for edge cases and complex concurrent scenarios
+// =============================================================================
+
+// TestGC_ConcurrentWithSubscribe tests GC running while new subscriptions are being added
+func TestGC_ConcurrentWithSubscribe(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	var gcCount atomic.Int32
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		gcCount.Add(1)
+		return nil
+	}
+
+	// Add old entries
+	for i := uint64(100); i < 150; i++ {
+		ent := &subEntry{dbID: 1000, state: Subscribed}
+		ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+		c.subscribed.m[i] = ent
+	}
+
+	var wg sync.WaitGroup
+
+	// GC goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			c.doGCUnusedTable(ctx)
+			time.Sleep(time.Microsecond * 100)
+		}
+	}()
+
+	// Subscribe goroutine - adding new entries
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := uint64(200); i < 300; i++ {
+			c.subscribed.setTableSubscribed(2000, i)
+			time.Sleep(time.Microsecond * 10)
+		}
+	}()
+
+	wg.Wait()
+
+	// New subscriptions should not be affected by GC
+	c.subscribed.rw.RLock()
+	newCount := 0
+	for id := range c.subscribed.m {
+		if id >= 200 && id < 300 {
+			newCount++
+		}
+	}
+	c.subscribed.rw.RUnlock()
+	assert.Equal(t, 100, newCount, "all new subscriptions should exist")
+}
+
+// TestGC_ConcurrentWithUnsubscribe tests GC running while unsubscriptions are happening
+func TestGC_ConcurrentWithUnsubscribe(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		return nil
+	}
+
+	// Add entries
+	for i := uint64(100); i < 200; i++ {
+		ent := &subEntry{dbID: 1000, state: Subscribed}
+		ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+		c.subscribed.m[i] = ent
+	}
+
+	var wg sync.WaitGroup
+
+	// GC goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 5; i++ {
+			c.doGCUnusedTable(ctx)
+			time.Sleep(time.Microsecond * 50)
+		}
+	}()
+
+	// Manual unsubscribe goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := uint64(100); i < 150; i++ {
+			c.subscribed.setTableUnsubscribe(1000, i)
+			time.Sleep(time.Microsecond * 10)
+		}
+	}()
+
+	wg.Wait()
+	// No panic or race condition should occur
+}
+
+// TestTripleConcurrent_Subscribe_Unsubscribe_Read tests three-way concurrent operations
+func TestTripleConcurrent_Subscribe_Unsubscribe_Read(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+	c.subscribed.eng = c.eng
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Reader goroutines
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					for j := uint64(0); j < 100; j++ {
+						c.isSubscribed(ctx, 0, 1000, j)
+					}
+				}
+			}
+		}()
+	}
+
+	// Subscribe goroutines
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					for j := uint64(0); j < 50; j++ {
+						c.subscribed.setTableSubscribed(1000, j+uint64(offset*50))
+					}
+				}
+			}
+		}(i)
+	}
+
+	// Unsubscribe goroutines
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					for j := uint64(0); j < 30; j++ {
+						c.subscribed.setTableUnsubscribe(1000, j+uint64(offset*30))
+					}
+				}
+			}
+		}(i)
+	}
+
+	// Run for a short time
+	time.Sleep(100 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+	// No panic or race condition should occur
+}
+
+// TestGC_TimestampUpdateBetweenPhases tests the race between GC phases and isSubscribed
+func TestGC_TimestampUpdateBetweenPhases(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	var gcCalled atomic.Int32
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		gcCalled.Add(1)
+		return nil
+	}
+
+	// Add entry with old timestamp
+	ent := &subEntry{dbID: 1000, state: Subscribed}
+	ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+	c.subscribed.m[999] = ent
+
+	// First GC - should try to unsubscribe (timestamp is old)
+	c.doGCUnusedTable(ctx)
+	firstGCCalls := gcCalled.Load()
+	assert.Equal(t, int32(1), firstGCCalls, "first GC should call sendUnSubscribe")
+
+	// Now update timestamp to simulate active access
+	ent.lastTs.Store(time.Now().UnixNano())
+	// Reset state to Subscribed (simulating the entry was re-subscribed or GC was reverted)
+	ent.state = Subscribed
+
+	// Second GC - should NOT try to unsubscribe (timestamp is recent)
+	c.doGCUnusedTable(ctx)
+	secondGCCalls := gcCalled.Load()
+	assert.Equal(t, firstGCCalls, secondGCCalls, "second GC should not call sendUnSubscribe for recently accessed table")
+}
+
+// TestEmptyMap_Operations tests operations on empty map
+func TestEmptyMap_Operations(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		return nil
+	}
+
+	// GC on empty map
+	c.doGCUnusedTable(ctx)
+
+	// isSubscribed on empty map
+	_, ok, state := c.isSubscribed(ctx, 0, 1, 999)
+	assert.False(t, ok)
+	assert.Equal(t, Unsubscribed, state)
+
+	// GetState on empty map
+	st := c.GetState()
+	assert.Equal(t, 0, len(st.SubTables))
+
+	// IsSubscribed on empty map
+	assert.False(t, c.IsSubscribed(999))
+}
+
+// TestHighConcurrency_StressTest tests under high concurrency load
+func TestHighConcurrency_StressTest(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+	const operations = 1000
+
+	// Mixed operations
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < operations; j++ {
+				tblId := uint64((id*operations + j) % 500)
+				switch j % 5 {
+				case 0:
+					c.subscribed.setTableSubscribed(1000, tblId)
+				case 1:
+					c.isSubscribed(ctx, 0, 1000, tblId)
+				case 2:
+					c.IsSubscribed(tblId)
+				case 3:
+					c.GetState()
+				case 4:
+					c.subscribed.setTableUnsubscribe(1000, tblId)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// No panic or race condition should occur
+}
+
+// TestGC_FailedUnsubscribe tests GC behavior when unsubscribe fails
+func TestGC_FailedUnsubscribe(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	var failCount atomic.Int32
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		failCount.Add(1)
+		return moerr.NewInternalErrorNoCtx("network error")
+	}
+
+	// Add old entries
+	for i := uint64(100); i < 110; i++ {
+		ent := &subEntry{dbID: 1000, state: Subscribed}
+		ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+		c.subscribed.m[i] = ent
+	}
+
+	c.doGCUnusedTable(ctx)
+
+	// All entries should have been attempted
+	assert.Equal(t, int32(10), failCount.Load())
+
+	// Entries should be reverted to Subscribed (for retry) since all failed
+	c.subscribed.rw.RLock()
+	for i := uint64(100); i < 110; i++ {
+		assert.Equal(t, Subscribed, c.subscribed.m[i].state)
+	}
+	c.subscribed.rw.RUnlock()
+}
+
+// TestStateTransition_InvalidTransitions tests handling of invalid state transitions
+func TestStateTransition_InvalidTransitions(t *testing.T) {
+	s := &subscribedTable{
+		m:   make(map[uint64]*subEntry),
+		eng: &Engine{partitions: make(map[[2]uint64]*logtailreplay.Partition), globalStats: &GlobalStats{}},
+	}
+
+	// Set to Subscribing
+	s.m[1] = &subEntry{dbID: 100, state: Subscribing}
+
+	// Try to unsubscribe while Subscribing (should still work - just deletes)
+	s.setTableUnsubscribe(100, 1)
+	_, exists := s.m[1]
+	assert.False(t, exists)
+
+	// Set to Unsubscribing
+	ent := &subEntry{dbID: 100, state: Unsubscribing}
+	ent.lastTs.Store(time.Now().UnixNano())
+	s.m[2] = ent
+
+	// isSubscribed should return false for Unsubscribing state
+	ok := s.isSubscribed(100, 2)
+	assert.False(t, ok)
+}
+
+// TestConcurrent_GC_Subscribe_Unsubscribe_Read tests all four operations concurrently
+func TestConcurrent_GC_Subscribe_Unsubscribe_Read(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		return nil
+	}
+
+	// Pre-populate with some old entries for GC
+	for i := uint64(0); i < 50; i++ {
+		ent := &subEntry{dbID: 1000, state: Subscribed}
+		ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+		c.subscribed.m[i] = ent
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// GC goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				c.doGCUnusedTable(ctx)
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+
+	// Subscribe goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for i := uint64(100); i < 200; i++ {
+					c.subscribed.setTableSubscribed(2000, i)
+				}
+			}
+		}
+	}()
+
+	// Unsubscribe goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for i := uint64(100); i < 150; i++ {
+					c.subscribed.setTableUnsubscribe(2000, i)
+				}
+			}
+		}
+	}()
+
+	// Read goroutines
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					for j := uint64(0); j < 200; j++ {
+						c.isSubscribed(ctx, 0, 1000, j)
+						c.IsSubscribed(j)
+					}
+				}
+			}
+		}()
+	}
+
+	// GetState goroutine
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = c.GetState()
+			}
+		}
+	}()
+
+	// Run for a short time
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+	// No panic or race condition should occur
+}
+
+// TestIsSubscribed_PartitionCreation tests that partition is created correctly
+func TestIsSubscribed_PartitionCreation(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+
+	// Add subscribed entry
+	ent := &subEntry{dbID: 1, state: Subscribed}
+	ent.lastTs.Store(time.Now().UnixNano())
+	c.subscribed.m[100] = ent
+
+	// Call isSubscribed
+	ps, ok, state := c.isSubscribed(ctx, 0, 1, 100)
+	assert.True(t, ok)
+	assert.Equal(t, Subscribed, state)
+	assert.NotNil(t, ps)
+
+	// Verify partition was created
+	c.eng.Lock()
+	_, exists := c.eng.partitions[[2]uint64{1, 100}]
+	c.eng.Unlock()
+	assert.True(t, exists)
+}
+
+
+// =============================================================================
+// Tests for complex write operations that require Lock (not RLock)
+// These are the reasons why original implementation used Mutex instead of RWMutex
+// =============================================================================
+
+// TestToSubIfUnsubscribed_Concurrent tests concurrent toSubIfUnsubscribed calls
+// This operation does read-then-write, requiring exclusive lock
+func TestToSubIfUnsubscribed_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+	// Mock sendSubscribe to avoid nil pointer
+	c.subscriber.sendSubscribe = func(ctx context.Context, id api.TableID) error {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	var successCount atomic.Int32
+
+	// Multiple goroutines trying to subscribe the same table
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			state, err := c.toSubIfUnsubscribed(ctx, 1000, 100)
+			if err == nil && (state == Subscribing || state == Subscribed) {
+				successCount.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// All should succeed (either got Subscribing or found already Subscribed)
+	assert.Equal(t, int32(10), successCount.Load())
+
+	// Table should exist in map
+	c.subscribed.rw.RLock()
+	_, exists := c.subscribed.m[100]
+	c.subscribed.rw.RUnlock()
+	assert.True(t, exists)
+}
+
+// TestIsNotSubscribing_Concurrent tests concurrent isNotSubscribing calls
+func TestIsNotSubscribing_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	// Pre-set table to Subscribing state
+	c.subscribed.m[100] = &subEntry{dbID: 1000, state: Subscribing}
+
+	var wg sync.WaitGroup
+	var subscribingCount atomic.Int32
+
+	// Multiple goroutines checking if table is subscribing
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ok, state, _ := c.isNotSubscribing(ctx, 1000, 100)
+			if !ok && state == Subscribing {
+				subscribingCount.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// All should see Subscribing state
+	assert.Equal(t, int32(20), subscribingCount.Load())
+}
+
+// TestIsNotUnsubscribing_Concurrent tests concurrent isNotUnsubscribing calls
+func TestIsNotUnsubscribing_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	// Pre-set table to Unsubscribing state
+	ent := &subEntry{dbID: 1000, state: Unsubscribing}
+	ent.lastTs.Store(time.Now().UnixNano())
+	c.subscribed.m[100] = ent
+
+	var wg sync.WaitGroup
+	var unsubscribingCount atomic.Int32
+
+	// Multiple goroutines checking if table is unsubscribing
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ok, state, _ := c.isNotUnsubscribing(ctx, 1000, 100)
+			if !ok && state == Unsubscribing {
+				unsubscribingCount.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// All should see Unsubscribing state
+	assert.Equal(t, int32(20), unsubscribingCount.Load())
+}
+
+// TestLoadAndConsumeLatestCkp_Concurrent tests concurrent loadAndConsumeLatestCkp calls
+func TestLoadAndConsumeLatestCkp_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	// Pre-set table to SubRspReceived state
+	ent := &subEntry{dbID: 1000, state: SubRspReceived}
+	ent.lastTs.Store(time.Now().UnixNano())
+	c.subscribed.m[100] = ent
+
+	var wg sync.WaitGroup
+	var successCount atomic.Int32
+
+	// Multiple goroutines trying to consume checkpoint
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			state, err := c.loadAndConsumeLatestCkp(ctx, 0, 100, "test", 1000, "db")
+			if err == nil && state == Subscribed {
+				successCount.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// All should succeed
+	assert.Equal(t, int32(10), successCount.Load())
+
+	// State should be Subscribed
+	c.subscribed.rw.RLock()
+	assert.Equal(t, Subscribed, c.subscribed.m[100].state)
+	c.subscribed.rw.RUnlock()
+}
+
+// TestConcurrent_ReadWrite_SameTable tests concurrent read and write on same table
+// This is the core reason why we need careful locking
+func TestConcurrent_ReadWrite_SameTable(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		return nil
+	}
+
+	// Pre-set table
+	ent := &subEntry{dbID: 1000, state: Subscribed}
+	ent.lastTs.Store(time.Now().UnixNano())
+	c.subscribed.m[100] = ent
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Reader: isSubscribed (RLock)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				c.isSubscribed(ctx, 0, 1000, 100)
+			}
+		}
+	}()
+
+	// Reader: IsSubscribed (RLock)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				c.IsSubscribed(100)
+			}
+		}
+	}()
+
+	// Writer: state changes (Lock)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				// Simulate state transitions
+				c.subscribed.rw.Lock()
+				if ent, ok := c.subscribed.m[100]; ok {
+					if ent.state == Subscribed {
+						ent.state = Unsubscribing
+					} else {
+						ent.state = Subscribed
+					}
+				}
+				c.subscribed.rw.Unlock()
+				time.Sleep(time.Microsecond * 100)
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+	// No race condition should occur
+}
+
+// TestLockUnlockRelock_Pattern tests the unlock-then-relock pattern in toSubIfUnsubscribed
+// This is a tricky pattern that was one reason for using Mutex
+func TestLockUnlockRelock_Pattern(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	// NOT setting ready - this will trigger the unlock-relock pattern
+	c.subscriber.sendSubscribe = func(ctx context.Context, id api.TableID) error {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+
+	// Multiple goroutines hitting the unlock-relock path
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			// This will try to wait for subscriber ready, triggering unlock-relock
+			c.toSubIfUnsubscribed(ctx, 1000, uint64(id))
+		}(i)
+	}
+
+	// Another goroutine doing reads
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				c.subscribed.rw.RLock()
+				_ = len(c.subscribed.m)
+				c.subscribed.rw.RUnlock()
+			}
+		}
+	}()
+
+	// Set subscriber ready after a short delay
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		c.subscriber.setReady()
+	}()
+
+	wg.Wait()
+	// No deadlock should occur
+}
+
+// TestAllWriteOperations_Concurrent tests all write operations running concurrently
+func TestAllWriteOperations_Concurrent(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// setTableSubscribed
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for i := uint64(0); i < 50; i++ {
+					c.subscribed.setTableSubscribed(1000, i)
+				}
+			}
+		}
+	}()
+
+	// setTableSubRspReceived
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for i := uint64(50); i < 100; i++ {
+					c.subscribed.setTableSubRspReceived(1000, i)
+				}
+			}
+		}
+	}()
+
+	// setTableUnsubscribe
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for i := uint64(0); i < 30; i++ {
+					c.subscribed.setTableUnsubscribe(1000, i)
+				}
+			}
+		}
+	}()
+
+	// clearTable
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for i := uint64(30); i < 50; i++ {
+					c.subscribed.clearTable(1000, i)
+				}
+			}
+		}
+	}()
+
+	// isSubscribed (read)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for i := uint64(0); i < 100; i++ {
+					c.isSubscribed(ctx, 0, 1000, i)
+				}
+			}
+		}
+	}()
+
+	// GetState (read)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = c.GetState()
+			}
+		}
+	}()
+
+	// doGCUnusedTable
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				c.doGCUnusedTable(ctx)
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+	// No race condition or deadlock should occur
+}
+
+
+// TestIsSubscribed_ShortCriticalSection tests that isSubscribed maintains atomicity
+func TestIsSubscribed_Atomicity(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+	c.subscribed.eng = c.eng
+
+	// Add subscribed entry
+	ent := &subEntry{dbID: 1, state: Subscribed}
+	ent.lastTs.Store(time.Now().UnixNano())
+	c.subscribed.m[100] = ent
+
+	var wg sync.WaitGroup
+
+	// Reader: call isSubscribed
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ps, ok, state := c.isSubscribed(ctx, 0, 1, 100)
+		// Should get valid result
+		assert.True(t, ok)
+		assert.Equal(t, Subscribed, state)
+		assert.NotNil(t, ps)
+	}()
+
+	wg.Wait()
+}
+
+// TestGC_FailureRetry tests that GC reverts state on failure for retry
+func TestGC_FailureRetry(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	var callCount atomic.Int32
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		callCount.Add(1)
+		return moerr.NewInternalErrorNoCtx("network error")
+	}
+
+	// Add old entry
+	ent := &subEntry{dbID: 1000, state: Subscribed}
+	ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+	c.subscribed.m[100] = ent
+
+	// First GC round - should fail and revert state
+	c.doGCUnusedTable(ctx)
+	assert.Equal(t, int32(1), callCount.Load())
+
+	// State should be reverted to Subscribed
+	c.subscribed.rw.RLock()
+	assert.Equal(t, Subscribed, c.subscribed.m[100].state)
+	c.subscribed.rw.RUnlock()
+
+	// Second GC round - should retry
+	c.doGCUnusedTable(ctx)
+	assert.Equal(t, int32(2), callCount.Load())
+
+	// State should still be Subscribed (failed again)
+	c.subscribed.rw.RLock()
+	assert.Equal(t, Subscribed, c.subscribed.m[100].state)
+	c.subscribed.rw.RUnlock()
+}
+
+// TestGC_PartialFailure tests GC with some successes and some failures
+func TestGC_PartialFailure(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: NewGlobalStats(ctx, nil, nil),
+	}
+	c.subscribed.eng = c.eng
+	c.subscriber = &logTailSubscriber{}
+	c.subscriber.mu.cond = sync.NewCond(&c.subscriber.mu)
+	c.subscriber.setReady()
+
+	// Fail for odd table IDs, succeed for even
+	c.subscriber.sendUnSubscribe = func(ctx context.Context, id api.TableID) error {
+		if id.TbId%2 == 1 {
+			return moerr.NewInternalErrorNoCtx("network error")
+		}
+		return nil
+	}
+
+	// Add old entries
+	for i := uint64(100); i < 110; i++ {
+		ent := &subEntry{dbID: 1000, state: Subscribed}
+		ent.lastTs.Store(time.Now().Add(-2 * time.Hour).UnixNano())
+		c.subscribed.m[i] = ent
+	}
+
+	c.doGCUnusedTable(ctx)
+
+	// Check states
+	c.subscribed.rw.RLock()
+	for i := uint64(100); i < 110; i++ {
+		ent := c.subscribed.m[i]
+		if i%2 == 0 {
+			// Even: success, should be Unsubscribing (waiting for response)
+			assert.Equal(t, Unsubscribing, ent.state, "table %d should be Unsubscribing", i)
+		} else {
+			// Odd: failed, should be reverted to Subscribed
+			assert.Equal(t, Subscribed, ent.state, "table %d should be Subscribed (reverted)", i)
+		}
+	}
+	c.subscribed.rw.RUnlock()
+}
+
+// TestIsSubscribed_StateChangeAfterCheck tests the TOCTOU scenario where
+// state changes between RUnlock and GetOrCreateLatestPart call.
+// This is acceptable behavior - the returned partition is still valid.
+func TestIsSubscribed_StateChangeAfterCheck(t *testing.T) {
+	ctx := context.Background()
+	var c PushClient
+	c.subscribed.m = make(map[uint64]*subEntry)
+	c.eng = &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{},
+	}
+
+	ent := &subEntry{dbID: 1, state: Subscribed}
+	ent.lastTs.Store(time.Now().UnixNano())
+	c.subscribed.m[100] = ent
+
+	// Concurrent: one goroutine reads, another changes state
+	var wg sync.WaitGroup
+	results := make(chan bool, 1000)
+
+	// Reader goroutines
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				ps, ok, state := c.isSubscribed(ctx, 0, 1, 100)
+				// Either we see Subscribed with valid partition, or we see other state
+				if ok {
+					assert.NotNil(t, ps)
+					results <- true
+				} else {
+					assert.Contains(t, []SubscribeState{Unsubscribed, Subscribing, Unsubscribing}, state)
+					results <- false
+				}
+			}
+		}()
+	}
+
+	// State changer goroutine - rapidly toggle state
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 100; j++ {
+			c.subscribed.rw.Lock()
+			if c.subscribed.m[100].state == Subscribed {
+				c.subscribed.m[100].state = Unsubscribing
+			} else {
+				c.subscribed.m[100].state = Subscribed
+			}
+			c.subscribed.rw.Unlock()
+			time.Sleep(time.Microsecond)
+		}
+	}()
+
+	wg.Wait()
+	close(results)
+
+	// Count results - we should see a mix of true/false
+	trueCount, falseCount := 0, 0
+	for r := range results {
+		if r {
+			trueCount++
+		} else {
+			falseCount++
+		}
+	}
+	t.Logf("Results: ok=%d, not_ok=%d", trueCount, falseCount)
+	// Both should be non-zero in a proper concurrent test
+	assert.True(t, trueCount > 0, "should have some successful reads")
 }

--- a/pkg/vm/engine/disttae/logtail_consumer_test.go
+++ b/pkg/vm/engine/disttae/logtail_consumer_test.go
@@ -1522,7 +1522,6 @@ func TestDoGCUnusedTable_NonSubscribedState(t *testing.T) {
 	assert.False(t, unsubCalled.Load(), "non-Subscribed entry should not be unsubscribed")
 }
 
-
 // =============================================================================
 // Additional tests for edge cases and complex concurrent scenarios
 // =============================================================================
@@ -2041,7 +2040,6 @@ func TestIsSubscribed_PartitionCreation(t *testing.T) {
 	assert.True(t, exists)
 }
 
-
 // =============================================================================
 // Tests for complex write operations that require Lock (not RLock)
 // These are the reasons why original implementation used Mutex instead of RWMutex
@@ -2492,7 +2490,6 @@ func TestAllWriteOperations_Concurrent(t *testing.T) {
 	wg.Wait()
 	// No race condition or deadlock should occur
 }
-
 
 // TestIsSubscribed_ShortCriticalSection tests that isSubscribed maintains atomicity
 func TestIsSubscribed_Atomicity(t *testing.T) {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20386 

## What this PR does / why we need it:

### Summary
Reduce mutex contention in PushClient.isSubscribed by 77-85% through RWMutex and lock-free timestamp updates.

### Changes
- Replace sync.Mutex with sync.RWMutex for subscribedTable
- Use atomic.Int64 for timestamp with 1-minute sampling (avoid write on every read)
- Change map[uint64]SubTableStatus to map[uint64]*subEntry (eliminate map rewrites)
- Add state re-check after GetOrCreateLatestPart (ensure atomicity)
- Implement GC failure recovery (Phase 4 reverts failed unsubscribe to Subscribed)

### Performance
- isSubscribed mutex delay: 276.24s (6.8%) → 25.91s (1.79%) on CN1
- isSubscribed mutex delay: 64.52s (4.22%) on CN2
- Reduction: ~85% on CN1, ~77% on CN2

### Testing
- 13 new concurrency tests covering edge cases (state changes, GC failures, concurrent operations)
- All tests pass with -race flag


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `sync.Mutex` with `sync.RWMutex` for `subscribedTable` to reduce contention

- Implement atomic timestamp (`atomic.Int64`) with 1-minute sampling to avoid write-on-read

- Change map storage from `SubTableStatus` values to `*subEntry` pointers for efficient state updates

- Refactor `doGCUnusedTable` into 4-phase design with failure recovery and re-check logic

- Add 13 comprehensive concurrency tests covering edge cases, state transitions, and GC scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sync.Mutex<br/>subscribedTable"] -->|Replace| B["sync.RWMutex<br/>subscribedTable"]
  C["SubTableStatus<br/>values in map"] -->|Change to| D["*subEntry<br/>pointers in map"]
  E["time.Time<br/>LatestTime field"] -->|Replace with| F["atomic.Int64<br/>lastTs field"]
  G["GC: Single phase<br/>with lock held"] -->|Refactor to| H["GC: 4-phase design<br/>Phase1:RLock<br/>Phase2:Lock<br/>Phase3:Unlock<br/>Phase4:Lock"]
  B -->|Enables| I["Concurrent reads<br/>with RLock"]
  F -->|Enables| J["Lock-free timestamp<br/>updates"]
  H -->|Enables| K["Failure recovery<br/>and re-check"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logtail_consumer.go</strong><dd><code>Refactor subscribedTable locking and timestamp management</code></dd></summary>
<hr>

pkg/vm/engine/disttae/logtail_consumer.go

<ul><li>Replace <code>sync.Mutex</code> with <code>sync.RWMutex</code> in <code>subscribedTable</code> struct<br> <li> Change map type from <code>map[uint64]SubTableStatus</code> to <code>map[uint64]*subEntry</code> <br>for pointer-based storage<br> <li> Introduce new <code>subEntry</code> struct with atomic <code>lastTs</code> field for lock-free <br>timestamp updates<br> <li> Refactor <code>isSubscribed()</code> to use RLock for reads and implement 1-minute <br>timestamp sampling<br> <li> Refactor <code>doGCUnusedTable()</code> into 4-phase design: Phase 1 (RLock read), <br>Phase 2 (Lock re-check), Phase 3 (Unlock RPC), Phase 4 (Lock failure <br>recovery)<br> <li> Update all methods to use RLock/Lock appropriately: <code>GetState()</code>, <br><code>IsSubscribed()</code>, <code>UnsubscribeTable()</code>, <code>toSubIfUnsubscribed()</code>, <br><code>loadAndConsumeLatestCkp()</code>, <code>isNotSubscribing()</code>, <code>isNotUnsubscribing()</code>, <br><code>setTableSubscribed()</code>, <code>setTableSubRspReceived()</code>, <code>setTableUnsubscribe()</code>, <br><code>setTableSubNotExist()</code>, <code>clearTable()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23511/files#diff-e17810b9da4ab05c897d8066bbc421520cdaea7c577d50dc64b31ec3aa8d295f">+212/-143</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logtail_consumer_test.go</strong><dd><code>Add 13 comprehensive concurrency tests for RWMutex optimization</code></dd></summary>
<hr>

pkg/vm/engine/disttae/logtail_consumer_test.go

<ul><li>Add import for <code>sync/atomic</code> package<br> <li> Update test setup to use <code>map[uint64]*subEntry</code> instead of <br><code>map[uint64]SubTableStatus</code><br> <li> Add 13 new comprehensive concurrency tests covering: atomic timestamp <br>operations, RWMutex behavior, concurrent isSubscribed calls, timestamp <br>sampling, GC with concurrent access, state transitions, GetState <br>concurrency, and complex multi-goroutine scenarios<br> <li> Add tests for edge cases: empty map operations, high concurrency <br>stress test, GC failure handling, partial failures, state change <br>races, and all write operations running concurrently<br> <li> Add tests for unlock-relock pattern in <code>toSubIfUnsubscribed()</code> and <br>atomicity guarantees</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23511/files#diff-b7d865ce7c4fc1a611e36d748d2379dccbe47754bac0379c908480b4bf34e6c6">+1689/-23</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

