### PR TITLE
enhancement(perf): Reduce mutex contention with sharded activeTxns map

### DIFF
--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -157,6 +157,18 @@ const (
 	normal status = status(1)
 )
 
+const (
+	// activeTxnShards is the number of shards for activeTxns map.
+	// Using sharded locks to reduce contention on high-concurrency workloads.
+	activeTxnShards = 16
+)
+
+// activeTxnShard is a shard of active transactions with its own lock.
+type activeTxnShard struct {
+	sync.RWMutex
+	txns map[string]*txnOperator
+}
+
 type txnClient struct {
 	sid                        string
 	stopper                    *stopper.Stopper
@@ -190,7 +202,13 @@ type txnClient struct {
 		latestCommitTS atomic.Pointer[timestamp.Timestamp]
 		// just for bvt testing
 		forceSyncCommitTimes atomic.Uint64
+		// activeTxnCount is the total count of active transactions across all shards.
+		activeTxnCount atomic.Int64
 	}
+
+	// activeTxns is sharded to reduce lock contention.
+	// Use getActiveTxnShard() to get the shard for a given txnID.
+	activeTxns [activeTxnShards]activeTxnShard
 
 	mu struct {
 		sync.RWMutex
@@ -201,8 +219,6 @@ type txnClient struct {
 		state status
 		// user active txns
 		users int
-		// all active txns
-		activeTxns map[string]*txnOperator
 		// FIFO queue for ready to active txn
 		waitActiveTxns            []*txnOperator
 		waitMarkAllActiveAbortedC chan struct{}
@@ -211,20 +227,105 @@ type txnClient struct {
 	abortC chan time.Time
 }
 
-func (client *txnClient) GetState() TxnState {
-	client.mu.Lock()
-	defer client.mu.Unlock()
-	at := make([]string, 0, len(client.mu.activeTxns))
-	for k := range client.mu.activeTxns {
-		at = append(at, hex.EncodeToString([]byte(k)))
+// getActiveTxnShard returns the shard for a given txnID.
+func (client *txnClient) getActiveTxnShard(txnID string) *activeTxnShard {
+	// Use FNV-1a hash for better distribution
+	h := uint32(2166136261)
+	for i := 0; i < len(txnID); i++ {
+		h ^= uint32(txnID[i])
+		h *= 16777619
 	}
+	return &client.activeTxns[h%activeTxnShards]
+}
+
+// addActiveTxn adds a transaction to the sharded map.
+func (client *txnClient) addActiveTxn(op *txnOperator) {
+	key := string(op.reset.txnID)
+	shard := client.getActiveTxnShard(key)
+	shard.Lock()
+	shard.txns[key] = op
+	shard.Unlock()
+	client.atomic.activeTxnCount.Add(1)
+	client.addToLeakCheck(op)
+}
+
+// removeActiveTxn removes a transaction from the sharded map.
+// Returns the removed operator and whether it existed.
+func (client *txnClient) removeActiveTxn(txnID string) (*txnOperator, bool) {
+	shard := client.getActiveTxnShard(txnID)
+	shard.Lock()
+	op, ok := shard.txns[txnID]
+	if ok {
+		delete(shard.txns, txnID)
+	}
+	shard.Unlock()
+	if ok {
+		client.atomic.activeTxnCount.Add(-1)
+		client.removeFromLeakCheck([]byte(txnID))
+	}
+	return op, ok
+}
+
+// getActiveTxn gets a transaction from the sharded map.
+func (client *txnClient) getActiveTxn(txnID string) (*txnOperator, bool) {
+	shard := client.getActiveTxnShard(txnID)
+	shard.RLock()
+	op, ok := shard.txns[txnID]
+	shard.RUnlock()
+	return op, ok
+}
+
+// forEachActiveTxn iterates over all active transactions.
+// The callback is called with each shard's lock held (read lock).
+func (client *txnClient) forEachActiveTxn(fn func(op *txnOperator) bool) {
+	for i := range client.activeTxns {
+		shard := &client.activeTxns[i]
+		shard.RLock()
+		for _, op := range shard.txns {
+			if !fn(op) {
+				shard.RUnlock()
+				return
+			}
+		}
+		shard.RUnlock()
+	}
+}
+
+// collectActiveTxns collects all active transactions into a slice.
+func (client *txnClient) collectActiveTxns() []*txnOperator {
+	count := client.atomic.activeTxnCount.Load()
+	ops := make([]*txnOperator, 0, count)
+	for i := range client.activeTxns {
+		shard := &client.activeTxns[i]
+		shard.RLock()
+		for _, op := range shard.txns {
+			ops = append(ops, op)
+		}
+		shard.RUnlock()
+	}
+	return ops
+}
+
+func (client *txnClient) GetState() TxnState {
+	// Collect active txn IDs from sharded map
+	at := make([]string, 0, client.atomic.activeTxnCount.Load())
+	client.forEachActiveTxn(func(op *txnOperator) bool {
+		at = append(at, hex.EncodeToString(op.reset.txnID))
+		return true
+	})
+
+	client.mu.RLock()
 	wt := make([]string, 0, len(client.mu.waitActiveTxns))
 	for _, v := range client.mu.waitActiveTxns {
 		wt = append(wt, hex.EncodeToString(v.reset.txnID))
 	}
+	state := client.mu.state
+	users := client.mu.users
+	client.mu.RUnlock()
+
 	return TxnState{
-		State:          int(client.mu.state),
-		Users:          client.mu.users,
+		State:          int(state),
+		Users:          users,
 		ActiveTxns:     at,
 		WaitActiveTxns: wt,
 		LatestTS:       client.timestampWaiter.LatestTS(),
@@ -247,7 +348,10 @@ func NewTxnClient(
 	c.stopper = stopper.NewStopper("txn-client", stopper.WithLogger(c.logger.RawLogger()))
 	c.mu.state = paused
 	c.mu.cond = sync.NewCond(&c.mu)
-	c.mu.activeTxns = make(map[string]*txnOperator, 100000)
+	// Initialize sharded activeTxns
+	for i := range c.activeTxns {
+		c.activeTxns[i].txns = make(map[string]*txnOperator, 100000/activeTxnShards)
+	}
 	for _, opt := range options {
 		opt(c)
 	}
@@ -385,12 +489,7 @@ func (client *txnClient) Close() error {
 }
 
 func (client *txnClient) MinTimestamp() timestamp.Timestamp {
-	client.mu.RLock()
-	ops := make([]*txnOperator, 0, len(client.mu.activeTxns))
-	for _, op := range client.mu.activeTxns {
-		ops = append(ops, op)
-	}
-	client.mu.RUnlock()
+	ops := client.collectActiveTxns()
 
 	min := timestamp.Timestamp{}
 	for _, op := range ops {
@@ -502,28 +601,23 @@ func (client *txnClient) GetSyncLatestCommitTSTimes() uint64 {
 
 func (client *txnClient) openTxn(op *txnOperator) error {
 	client.mu.Lock()
-	defer func() {
-		v2.TxnActiveQueueSizeGauge.Set(float64(len(client.mu.activeTxns)))
-		v2.TxnWaitActiveQueueSizeGauge.Set(float64(len(client.mu.waitActiveTxns)))
-		client.mu.Unlock()
-	}()
 
 	client.waitMarkAllActiveAbortedLocked()
 
 	if !op.opts.skipWaitPushClient {
 		for client.mu.state == paused {
 			if client.normalStateNoWait {
+				client.mu.Unlock()
 				return moerr.NewInternalErrorNoCtx("cn service is not ready, retry later")
 			}
 
 			if op.opts.options.WaitPausedDisabled() {
+				client.mu.Unlock()
 				return moerr.NewInvalidStateNoCtx("txn client is in pause state")
 			}
 
 			client.logger.Warn("txn client is in pause state, wait for it to be ready",
 				zap.String("txn ID", hex.EncodeToString(op.reset.txnID)))
-			// Wait until the txn client's state changed to normal, and it will probably take
-			// no more than 5 seconds in theory.
 			client.mu.cond.Wait()
 			client.logger.Warn("txn client is in ready state",
 				zap.String("txn ID", hex.EncodeToString(op.reset.txnID)))
@@ -532,55 +626,84 @@ func (client *txnClient) openTxn(op *txnOperator) error {
 
 	if !op.opts.options.UserTxn() ||
 		client.mu.users < client.maxActiveTxn {
-		client.addActiveTxnLocked(op)
+		if op.opts.options.UserTxn() {
+			client.mu.users++
+		}
+		waitQueueSize := len(client.mu.waitActiveTxns)
+		client.mu.Unlock()
+		// Add to sharded map outside mu lock
+		client.addActiveTxn(op)
+		// Update metrics after actual operation
+		v2.TxnActiveQueueSizeGauge.Set(float64(client.atomic.activeTxnCount.Load()))
+		v2.TxnWaitActiveQueueSizeGauge.Set(float64(waitQueueSize))
 		return nil
 	}
+
 	op.reset.waiter = newWaiter(timestamp.Timestamp{})
 	op.reset.waiter.ref()
 	client.mu.waitActiveTxns = append(client.mu.waitActiveTxns, op)
+	activeCount := client.atomic.activeTxnCount.Load()
+	waitQueueSize := len(client.mu.waitActiveTxns)
+	client.mu.Unlock()
+	v2.TxnActiveQueueSizeGauge.Set(float64(activeCount))
+	v2.TxnWaitActiveQueueSizeGauge.Set(float64(waitQueueSize))
 	return nil
 }
 
 func (client *txnClient) closeTxn(ctx context.Context, txnOp TxnOperator, event TxnEvent, value any) (err error) {
 	txn := event.Txn
+	key := string(txn.ID)
+
+	// Remove from sharded map first
+	op, ok := client.removeActiveTxn(key)
 
 	client.mu.Lock()
-	defer func() {
-		v2.TxnActiveQueueSizeGauge.Set(float64(len(client.mu.activeTxns)))
-		v2.TxnWaitActiveQueueSizeGauge.Set(float64(len(client.mu.waitActiveTxns)))
-		client.mu.Unlock()
-	}()
 
 	if moerr.IsMoErrCode(event.Err, moerr.ErrCannotCommitOnInvalidCN) {
 		client.markAllActiveTxnAborted()
 	}
 
-	key := string(txn.ID)
-	op, ok := client.mu.activeTxns[key]
 	if ok {
 		v2.TxnLifeCycleDurationHistogram.Observe(time.Since(op.reset.createAt).Seconds())
 
-		delete(client.mu.activeTxns, key)
-		client.removeFromLeakCheck(txn.ID)
 		if !op.opts.options.UserTxn() {
+			v2.TxnActiveQueueSizeGauge.Set(float64(client.atomic.activeTxnCount.Load()))
+			v2.TxnWaitActiveQueueSizeGauge.Set(float64(len(client.mu.waitActiveTxns)))
+			client.mu.Unlock()
 			return
 		}
 		client.mu.users--
 		if client.mu.users < 0 {
 			panic("BUG: user txns < 0")
 		}
+
+		// Collect waiting ops to activate
+		var toActivate []*txnOperator
 		if len(client.mu.waitActiveTxns) > 0 {
 			newCanAdded := client.maxActiveTxn - client.mu.users
 			for i := 0; i < newCanAdded; i++ {
-				op := client.fetchWaitActiveOpLocked()
-				if op == nil {
-					return
+				waitOp := client.fetchWaitActiveOpLocked()
+				if waitOp == nil {
+					break
 				}
-				client.addActiveTxnLocked(op)
-				op.notifyActive()
+				client.mu.users++
+				toActivate = append(toActivate, waitOp)
 			}
 		}
-	} else if ok = client.removeFromWaitActiveLocked(txn.ID); ok {
+
+		v2.TxnActiveQueueSizeGauge.Set(float64(client.atomic.activeTxnCount.Load() + int64(len(toActivate))))
+		v2.TxnWaitActiveQueueSizeGauge.Set(float64(len(client.mu.waitActiveTxns)))
+		client.mu.Unlock()
+
+		// Add to sharded map and notify outside mu lock
+		for _, waitOp := range toActivate {
+			client.addActiveTxn(waitOp)
+			waitOp.notifyActive()
+		}
+		return
+	}
+
+	if ok = client.removeFromWaitActiveLocked(txn.ID); ok {
 		client.removeFromLeakCheck(txn.ID)
 	} else {
 		client.logger.Warn("txn closed",
@@ -588,15 +711,19 @@ func (client *txnClient) closeTxn(ctx context.Context, txnOp TxnOperator, event 
 			zap.String("stack", string(debug.Stack())))
 	}
 
+	v2.TxnActiveQueueSizeGauge.Set(float64(client.atomic.activeTxnCount.Load()))
+	v2.TxnWaitActiveQueueSizeGauge.Set(float64(len(client.mu.waitActiveTxns)))
+	client.mu.Unlock()
 	return
 }
 
+// addActiveTxnLocked is kept for compatibility but should not be used directly.
+// Use addActiveTxn instead.
 func (client *txnClient) addActiveTxnLocked(op *txnOperator) {
 	if op.opts.options.UserTxn() {
 		client.mu.users++
 	}
-	client.mu.activeTxns[string(op.reset.txnID)] = op
-	client.addToLeakCheck(op)
+	client.addActiveTxn(op)
 }
 
 func (client *txnClient) fetchWaitActiveOpLocked() *txnOperator {
@@ -658,14 +785,14 @@ func (client *txnClient) IterTxns(fn func(TxnOverview) bool) {
 }
 
 func (client *txnClient) getAllTxnOperators() []*txnOperator {
-	client.mu.RLock()
-	defer client.mu.RUnlock()
+	// Collect from sharded map
+	ops := client.collectActiveTxns()
 
-	ops := make([]*txnOperator, 0, len(client.mu.activeTxns)+len(client.mu.waitActiveTxns))
-	for _, op := range client.mu.activeTxns {
-		ops = append(ops, op)
-	}
+	// Also include waiting txns
+	client.mu.RLock()
 	ops = append(ops, client.mu.waitActiveTxns...)
+	client.mu.RUnlock()
+
 	return ops
 }
 
@@ -712,13 +839,16 @@ func (client *txnClient) handleMarkActiveTxnAborted(
 			fn := func() {
 				client.mu.Lock()
 				client.mu.waitMarkAllActiveAbortedC = make(chan struct{})
-				ops := make([]*txnOperator, 0, len(client.mu.activeTxns))
-				for _, op := range client.mu.activeTxns {
+				client.mu.Unlock()
+
+				// Collect ops from sharded map
+				ops := make([]*txnOperator, 0)
+				client.forEachActiveTxn(func(op *txnOperator) bool {
 					if op.reset.createAt.Before(from) {
 						ops = append(ops, op)
 					}
-				}
-				client.mu.Unlock()
+					return true
+				})
 
 				for _, op := range ops {
 					op.addFlag(AbortedFlag)

--- a/pkg/txn/client/client.go
+++ b/pkg/txn/client/client.go
@@ -742,15 +742,6 @@ func (client *txnClient) closeTxn(ctx context.Context, txnOp TxnOperator, event 
 	return
 }
 
-// addActiveTxnLocked is kept for compatibility but should not be used directly.
-// Use addActiveTxn instead.
-func (client *txnClient) addActiveTxnLocked(op *txnOperator) {
-	if op.opts.options.UserTxn() {
-		client.mu.users++
-	}
-	client.addActiveTxn(op)
-}
-
 func (client *txnClient) fetchWaitActiveOpLocked() *txnOperator {
 	if len(client.mu.waitActiveTxns) == 0 {
 		return nil


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20386 

## What this PR does / why we need it:

1. **Sharded activeTxns map** - Replace global `mu.activeTxns` with 16-shard structure to reduce lock contention on high-concurrency workloads
   - Each shard has independent RWMutex
   - FNV-1a hash for txnID distribution
   - Atomic counter for total active transaction count

2. **Helper methods** - Implement sharded map operations:
   - `getActiveTxnShard()` - Get shard for txnID
   - `addActiveTxn()` - Add transaction outside mu lock
   - `removeActiveTxn()` - Remove transaction with leak check
   - `getActiveTxn()` - Read-only lookup
   - `forEachActiveTxn()` - Iterate all shards
   - `collectActiveTxns()` - Collect into slice

3. **Optimized openTxn/closeTxn** - Move sharded map operations outside global mu lock:
   - `openTxn`: Add to sharded map after mu.Unlock()
   - `closeTxn`: Remove from sharded map before abort-all check to ensure transaction is marked

4. **Metrics consistency** - Update gauge metrics on all code paths:
   - Add gauge updates in early return paths (normalStateNoWait, WaitPausedDisabled)
   - Ensure monitoring reflects actual state

5. **Safety improvements**:
   - Move sharded initialization to `adjust()` to support zero-value clients
   - Add consistency note to `GetState()` about non-atomic snapshot
   - Fix abort-all check ordering in `closeTxn


___

### **PR Type**
Enhancement


___

### **Description**
- Replace global `mu.activeTxns` map with 16-shard structure to reduce lock contention

- Implement sharded map helper methods for add/remove/get/iterate operations

- Move sharded map operations outside global mu lock in openTxn/closeTxn

- Update gauge metrics on all code paths including early returns

- Add sharded map initialization to adjust() for zero-value client support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Global mu.activeTxns<br/>Single Lock"] -->|Refactor| B["16-Shard activeTxns<br/>Independent RWMutex"]
  B -->|Reduces| C["Lock Contention<br/>on High Concurrency"]
  D["openTxn/closeTxn<br/>Operations"] -->|Move Outside| E["Global mu Lock"]
  E -->|Improves| F["Throughput &<br/>Latency"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.go</strong><dd><code>Implement sharded activeTxns map with lock-free operations</code></dd></summary>
<hr>

pkg/txn/client/client.go

<ul><li>Added <code>activeTxnShards</code> constant (16) and <code>activeTxnShard</code> struct with <br>RWMutex and txn map<br> <li> Replaced global <code>mu.activeTxns</code> map with sharded <code>activeTxns</code> array and <br>atomic <code>activeTxnCount</code><br> <li> Implemented helper methods: <code>getActiveTxnShard()</code>, <code>addActiveTxn()</code>, <br><code>removeActiveTxn()</code>, <code>getActiveTxn()</code>, <code>forEachActiveTxn()</code>, <br><code>collectActiveTxns()</code><br> <li> Refactored <code>openTxn()</code> to add transactions to sharded map outside mu <br>lock with metrics updates on all paths<br> <li> Refactored <code>closeTxn()</code> to remove transactions from sharded map and <br>activate waiting txns outside mu lock<br> <li> Updated <code>GetState()</code>, <code>MinTimestamp()</code>, <code>getAllTxnOperators()</code>, and <br><code>handleMarkActiveTxnAborted()</code> to use sharded map helpers<br> <li> Modified <code>NewTxnClient()</code> and <code>adjust()</code> to initialize sharded maps</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23518/files#diff-f4f177db5c0c25f4d24f1aced66ebcc38f7b0589ea867e55022a096211ff1565">+207/-52</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client_test.go</strong><dd><code>Add tests for sharded map and concurrent operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/txn/client/client_test.go

<ul><li>Fixed duplicate assertion in <code>TestAdjustClient()</code> and added verification <br>of sharded map initialization<br> <li> Added <code>TestZeroValueClientShardedMaps()</code> to verify sharded map <br>operations on zero-value client<br> <li> Added <code>TestConcurrentOpenCloseTxn()</code> with 50 goroutines and 100 <br>iterations to test concurrent txn operations<br> <li> Added <code>TestCloseTxnWithAbortAllCheck()</code> to verify abort-all check <br>ordering in closeTxn<br> <li> Updated <code>TestOpenTxnWithWaitPausedDisabled()</code> and <code>TestWaitAbortMarked()</code> <br>to initialize sharded maps</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23518/files#diff-0febaf951158ba36a4b14339d9e186130d4f69785f780a8060fd457a80e06de1">+95/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

