### PR TITLE
to 3.0: fix export table data

### DIFF
--- a/pkg/frontend/export.go
+++ b/pkg/frontend/export.go
@@ -298,10 +298,6 @@ var writeDataToCSVFile = func(ep *ExportConfig, output []byte) error {
 	return nil
 }
 
-func formatJsonString(str string) string {
-        return strings.ReplaceAll(str, "\"", "\"\"")
-}
-
 func escapeJSONControlChars(s string) string {
 	var builder strings.Builder
 	builder.Grow(len(s))
@@ -384,9 +380,9 @@ func constructByte(ctx context.Context, obj FeSession, bat *batch.Batch, index i
 			}
 			switch vec.GetType().Oid { //get col
 			case types.T_json:
-                                val := types.DecodeJson(vec.GetBytesAt(i))
-                                value := addEscapeToString([]byte(val.String()), closeby)
-                                formatOutputString(ep, value, symbol[j], closeby, true, buffer)
+				val := types.DecodeJson(vec.GetBytesAt(i))
+				value := addEscapeToString([]byte(val.String()), closeby)
+				formatOutputString(ep, value, symbol[j], closeby, true, buffer)
 			case types.T_bool:
 				val := vector.GetFixedAtNoTypeCheck[bool](vec, i)
 				if val {
@@ -536,11 +532,11 @@ func constructByte(ctx context.Context, obj FeSession, bat *batch.Batch, index i
 }
 
 func addEscapeToString(s []byte, escape byte) []byte {
-        s = bytes.ReplaceAll(s, []byte("\\"[:1]), []byte("\\\\"[:2]))
-        if escape != 0 && escape != "\\"[0] {
-                s = bytes.ReplaceAll(s, []byte{escape}, []byte{escape, escape})
-        }
-        return s
+	s = bytes.ReplaceAll(s, []byte("\\"[:1]), []byte("\\\\"[:2]))
+	if escape != 0 && escape != "\\"[0] {
+		s = bytes.ReplaceAll(s, []byte{escape}, []byte{escape, escape})
+	}
+	return s
 }
 
 func exportDataFromResultSetToCSVFile(oq *ExportConfig) error {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/23530

## What this PR does / why we need it:

before:
origin_table -> export to csv -> load to copy_table.
bit_xor(origin_table) != bit_xor(copy_table)
