### PR TITLE
BUG: default MARCH set to haswell for x86_64

### DIFF
--- a/cgo/Makefile
+++ b/cgo/Makefile
@@ -1,11 +1,16 @@
 DEBUG_OPT :=
+UNAME_M := $(shell uname -m)
 
 # Yeah, fast math.  We want it to be fast, for all xcall, 
 # IEEE compliance should not be an issue.
 OPT_LV := -O3 -ffast-math
-CFLAGS=-std=c99 -g ${OPT_LV} -Wall -Werror -march=haswell
+CFLAGS=-std=c99 -g ${OPT_LV} -Wall -Werror
 OBJS=mo.o arith.o compare.o logic.o xcall.o
 CUDA_OBJS=
+
+ifeq ($(UNAME_M), x86_64)
+	CFLAGS += -march=haswell
+endif
 
 ifeq ($(MO_CL_CUDA),1)
 	CC = /usr/local/cuda/bin/nvcc 

--- a/cgo/test/Makefile
+++ b/cgo/test/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-I.. -g -Wall -Werror -lm -march=haswell
+CFLAGS=-I.. -g -Wall -Werror -lm
 
 test_add.exe: test_add.c ../libmo.a
 	$(CC) $(CFLAGS) -o test_add.exe test_add.c -L.. -lmo


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23305

## What this PR does / why we need it:

1. default MARCH to haswell for x86_64
