### PR TITLE
fix: Fix AUTO_INCREMENT handling for zero values

### DIFF
--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -1069,6 +1069,14 @@ var gSysVarsDefs = map[string]SystemVariable{
 		Type:              InitSystemVariableStringType("version_comment"),
 		Default:           "MatrixOne",
 	},
+	"server_id": {
+		Name:              "server_id",
+		Scope:             ScopeGlobal,
+		Dynamic:           false,
+		SetVarHintApplies: false,
+		Type:              InitSystemVariableIntType("server_id", 0, math.MaxInt64, false),
+		Default:           int64(0),
+	},
 	"tx_isolation": {
 		Name:              "tx_isolation",
 		Scope:             ScopeBoth,

--- a/test/distributed/cases/system_variable/system_variables.result
+++ b/test/distributed/cases/system_variable/system_variables.result
@@ -6,6 +6,12 @@ set max_allowed_packet = default;
 set wait_timeout = default;
 set tx_isolation = default;
 set tx_isolation = default;
+show variables like 'server_id';
+Variable_name    Value
+server_id    0
+select @@server_id;
+@@server_id
+0
 show variables like 'auto%';
 Variable_name    Value
 auto_generate_certs    on

--- a/test/distributed/cases/system_variable/system_variables.sql
+++ b/test/distributed/cases/system_variable/system_variables.sql
@@ -11,6 +11,8 @@ set max_allowed_packet = default;
 set wait_timeout = default;
 set tx_isolation = default;
 set tx_isolation = default;
+show variables like 'server_id';
+select @@server_id;
 
 
 -- auto_increment_increment


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [✅ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #14490

## What this PR does / why we need it:
This PR fixes MatrixOne’s AUTO_INCREMENT handling to match MySQL: when sql_mode does not include NO_AUTO_VALUE_ON_ZERO, inserting 0 into an AUTO_INCREMENT column is treated as NULL and allocates a new id. This prevents false duplicate-key errors seen in HyBench and aligns behavior with MySQL.