### PR TITLE
(improvement): startcount optimization with tombstones

### DIFF
--- a/pkg/frontend/test/engine_mock.go
+++ b/pkg/frontend/test/engine_mock.go
@@ -1144,6 +1144,21 @@ func (mr *MockRelationMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockRelation)(nil).Delete), arg0, arg1, arg2)
 }
 
+// EstimateCommittedTombstoneCount mocks base method.
+func (m *MockRelation) EstimateCommittedTombstoneCount(ctx context.Context) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EstimateCommittedTombstoneCount", ctx)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EstimateCommittedTombstoneCount indicates an expected call of EstimateCommittedTombstoneCount.
+func (mr *MockRelationMockRecorder) EstimateCommittedTombstoneCount(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateCommittedTombstoneCount", reflect.TypeOf((*MockRelation)(nil).EstimateCommittedTombstoneCount), ctx)
+}
+
 // GetColumMetadataScanInfo mocks base method.
 func (m *MockRelation) GetColumMetadataScanInfo(ctx context.Context, name string, visitTombstone bool) ([]*plan.MetadataScanInfo, error) {
 	m.ctrl.T.Helper()
@@ -1405,6 +1420,21 @@ func (m *MockRelation) Size(ctx context.Context, columnName string) (uint64, err
 func (mr *MockRelationMockRecorder) Size(ctx, columnName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockRelation)(nil).Size), ctx, columnName)
+}
+
+// StarCount mocks base method.
+func (m *MockRelation) StarCount(ctx context.Context) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StarCount", ctx)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StarCount indicates an expected call of StarCount.
+func (mr *MockRelationMockRecorder) StarCount(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StarCount", reflect.TypeOf((*MockRelation)(nil).StarCount), ctx)
 }
 
 // Stats mocks base method.
@@ -1784,21 +1814,6 @@ func (m *MockDatabase) Relations(arg0 context.Context) ([]string, error) {
 func (mr *MockDatabaseMockRecorder) Relations(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Relations", reflect.TypeOf((*MockDatabase)(nil).Relations), arg0)
-}
-
-// Truncate mocks base method.
-func (m *MockDatabase) Truncate(arg0 context.Context, arg1 string) (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Truncate", arg0, arg1)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Truncate indicates an expected call of Truncate.
-func (mr *MockDatabaseMockRecorder) Truncate(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Truncate", reflect.TypeOf((*MockDatabase)(nil).Truncate), arg0, arg1)
 }
 
 // MockLogtailEngine is a mock of LogtailEngine interface.

--- a/pkg/frontend/test/txn_mock.go
+++ b/pkg/frontend/test/txn_mock.go
@@ -613,7 +613,6 @@ func (mr *MockTxnOperatorMockRecorder) ExitRunSqlWithToken(token interface{}) *g
 }
 
 // Get mocks base method.
-
 func (m *MockTxnOperator) Get(key string) (any, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", key)

--- a/pkg/objectio/injects.go
+++ b/pkg/objectio/injects.go
@@ -65,8 +65,8 @@ const (
 	FJ_CDCAddExecErr             = "fj/cdc/addexecerr"
 	FJ_CDCAddExecConsumeTruncate = "fj/cdc/addexecconsumetruncate"
 
-	FJ_CNFlushSmallObjs     = "fj/cn/flush_small_objs"
-	FJ_CNSubscribeTableFail = "fj/cn/subscribe_table_fail"
+	FJ_CNFlushSmallObjs      = "fj/cn/flush_small_objs"
+	FJ_CNSubscribeTableFail  = "fj/cn/subscribe_table_fail"
 	FJ_CNWorkspaceForceFlush = "fj/cn/workspace_force_flush"
 
 	FJ_CNCLONEFailed    = "fj/cn/clone_fails"

--- a/pkg/objectio/injects.go
+++ b/pkg/objectio/injects.go
@@ -67,6 +67,7 @@ const (
 
 	FJ_CNFlushSmallObjs     = "fj/cn/flush_small_objs"
 	FJ_CNSubscribeTableFail = "fj/cn/subscribe_table_fail"
+	FJ_CNWorkspaceForceFlush = "fj/cn/workspace_force_flush"
 
 	FJ_CNCLONEFailed    = "fj/cn/clone_fails"
 	FJ_CNNeedRetryError = "fj/cn/need_retry_error"
@@ -191,6 +192,11 @@ func LogCNFlushSmallObjsInjected(args ...string) (bool, int) {
 
 	ok, level := checkLoggingArgs(int(iarg), sarg, args...)
 	return ok, level
+}
+
+func CNWorkspaceForceFlushInjected() bool {
+	_, _, injected := fault.TriggerFault(FJ_CNWorkspaceForceFlush)
+	return injected
 }
 
 func LogCNNeedRetryErrorInjected(args ...string) (bool, int) {

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -2093,11 +2093,6 @@ func (c *Compile) compileTableScanDataSource(s *Scope) error {
 		s.DataSource.Rel = rel
 	} else {
 		s.DataSource.Rel.Reset(txnOp)
-		// Reuse: clear StarCount cache so this run re-executes StarCount with new snapshot.
-		s.StarCountOnly = false
-		if mg := findMergeGroup(s.RootOp); mg != nil {
-			mg.PartialResults = nil
-		}
 		tblDef = s.DataSource.Rel.GetTableDef(ctx)
 	}
 

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -4195,7 +4195,9 @@ func checkAggOptimize(node *plan.Node) ([]any, []types.T, map[int]int) {
 			col, ok := args.Expr.(*plan.Expr_Col)
 			if !ok {
 				if _, ok := args.Expr.(*plan.Expr_Lit); ok {
+					// COUNT(lit) e.g. count(1) from count(*): set ObjName+Obj so runtime uses countStarExec
 					agg.F.Func.ObjName = "starcount"
+					agg.F.Func.Obj = function.EncodeOverloadID(int32(function.STARCOUNT), 0)
 					return partialResults, partialResultTypes, columnMap
 				}
 				return nil, nil, nil
@@ -4211,7 +4213,7 @@ func checkAggOptimize(node *plan.Node) ([]any, []types.T, map[int]int) {
 				if node.TableDef.Cols[colPos].Typ.NotNullable {
 					// Rewrite COUNT(not_null_col) to STARCOUNT so runtime uses countStarExec
 					agg.F.Func.ObjName = "starcount"
-					agg.F.Func.Obj = function.EncodeOverloadID(function.STARCOUNT, 0)
+					agg.F.Func.Obj = function.EncodeOverloadID(int32(function.STARCOUNT), 0)
 				} else {
 					columnMap[colPos] = int(node.TableDef.Cols[colPos].Seqnum)
 				}

--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/group"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
@@ -178,6 +179,8 @@ type Scope struct {
 	// StarCountOnly: when true, aggOptimize took the single-starcount fast path.
 	// buildReaders should return EmptyReaders and no data should flow.
 	StarCountOnly bool
+	// StarCountMergeGroup: set when StarCountOnly is true; resetForReuse clears its PartialResults.
+	StarCountMergeGroup *group.MergeGroup
 
 	Plan *plan.Plan
 	// DataSource stores information about data source.

--- a/pkg/sql/compile/types.go
+++ b/pkg/sql/compile/types.go
@@ -175,6 +175,9 @@ type Scope struct {
 	IsTbFunc bool
 
 	HasPartialResults bool
+	// StarCountOnly: when true, aggOptimize took the single-starcount fast path.
+	// buildReaders should return EmptyReaders and no data should flow.
+	StarCountOnly bool
 
 	Plan *plan.Plan
 	// DataSource stores information about data source.

--- a/pkg/sql/plan/build_util_test.go
+++ b/pkg/sql/plan/build_util_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
@@ -58,4 +59,38 @@ func Test_replaceFuncId(t *testing.T) {
 	case1Expr, err := getDefaultExpr(context.Background(), case1ColDef)
 	assert.NoError(t, err)
 	assert.NotNil(t, case1Expr)
+}
+
+// TestRewriteCountNotNullColToStarcount ensures plan-level rewrite sets both ObjName and Obj
+// so runtime uses countStarExec; regression test for count(not_null_col) performance fix.
+func TestRewriteCountNotNullColToStarcount(t *testing.T) {
+	wantObj := function.EncodeOverloadID(int32(function.STARCOUNT), 0)
+
+	node := &plan.Node{
+		AggList: []*plan.Expr{
+			{
+				Expr: &plan.Expr_F{
+					F: &plan.Function{
+						Func: &plan.ObjectRef{ObjName: "count"},
+						Args: []*plan.Expr{
+							{Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 0}}},
+						},
+					},
+				},
+			},
+		},
+	}
+	tableDef := &plan.TableDef{
+		Cols: []*plan.ColDef{
+			{Name: "a", Typ: plan.Type{NotNullable: true}},
+		},
+	}
+
+	RewriteCountNotNullColToStarcount(node, tableDef)
+
+	agg := node.AggList[0].GetF()
+	require.NotNil(t, agg)
+	require.NotNil(t, agg.Func)
+	assert.Equal(t, "starcount", agg.Func.ObjName, "ObjName must be starcount so compile treats as single starcount")
+	assert.Equal(t, wantObj, agg.Func.Obj, "Obj must be CountStar overload so runtime uses countStarExec")
 }

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -3959,6 +3959,13 @@ func (builder *QueryBuilder) appendAggNode(
 		SpillMem:     builder.aggSpillMem,
 	}, ctx)
 
+	// Plan-level rewrite: count(not_null_col) -> starcount (ObjName + Obj) so compile uses countStarExec.
+	if aggNode := builder.qry.Nodes[nodeID]; len(aggNode.Children) > 0 {
+		if childNode := builder.qry.Nodes[aggNode.Children[0]]; childNode.NodeType == plan.Node_TABLE_SCAN && childNode.TableDef != nil {
+			RewriteCountNotNullColToStarcount(aggNode, childNode.TableDef)
+		}
+	}
+
 	if len(boundHavingList) > 0 {
 		var newFilterList []*plan.Expr
 		var expr *plan.Expr

--- a/pkg/sql/plan/tools/check.go
+++ b/pkg/sql/plan/tools/check.go
@@ -80,7 +80,10 @@ func (checker *ExprChecker) checkFuncExpr(astExpr *tree.FuncExpr, expr *plan2.Ex
 	if len(astExpr.Exprs) != len(fun.GetArgs()) {
 		return false, nil
 	}
-	if fun.GetFunc().ObjName != astExpr.FuncName.Compare() {
+	planName := fun.GetFunc().ObjName
+	astName := astExpr.FuncName.Compare()
+	// Plan rewrites COUNT(not_null_col) to starcount; accept pattern "count" when plan has "starcount".
+	if planName != astName && !(planName == "starcount" && astName == "count") {
 		return false, nil
 	}
 	for i, arg := range astExpr.Exprs {

--- a/pkg/sql/plan/tools/matcher.go
+++ b/pkg/sql/plan/tools/matcher.go
@@ -241,7 +241,12 @@ func (matcher *OutputMatcher) DeepMatch(ctx context.Context, node *plan.Node, al
 		for _, projExpr := range node.ProjectList {
 			name := projExpr.GetCol().Name
 			if strings.Contains(name, "(") {
-				found = strings.HasPrefix(strings.ToLower(name), ref)
+				lower := strings.ToLower(name)
+				found = strings.HasPrefix(lower, ref)
+				// Plan rewrites COUNT(not_null_col) to starcount; PROJECT output name may still be "count(...)".
+				if !found && ref == "starcount" && strings.HasPrefix(lower, "count(") {
+					found = true
+				}
 			} else {
 				names := strings.Split(name, ".")
 				if len(names) != 2 {

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -179,6 +179,13 @@ func initTxnMetrics() {
 	registry.MustRegister(txnSelectivityHistogram)
 	registry.MustRegister(txnColumnReadHistogram)
 	registry.MustRegister(txnReadSizeHistogram)
+
+	registry.MustRegister(starcountPathCounter)
+	registry.MustRegister(StarcountDurationHistogram)
+	registry.MustRegister(StarcountResultRowsHistogram)
+	registry.MustRegister(StarcountEstimateTombstoneRowsHistogram)
+	registry.MustRegister(StarcountEstimateTombstoneObjectsHistogram)
+	registry.MustRegister(StarcountEstimateOverActualRatioHistogram)
 }
 
 func initRPCMetrics() {

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -1410,7 +1410,7 @@ func (p *PartitionState) CollectTombstoneStats(
 	return p.countTombstoneStatsWithMap(ctx, snapshot, fs, visibleObjects, stats)
 }
 
-// isDataObjectVisible checks if a data object is visible at the given snapshot.
+// IsDataObjectVisible checks if a data object is visible at the given snapshot.
 //
 // Background:
 // - CN can delete rows on both appendable and non-appendable data objects
@@ -1420,7 +1420,7 @@ func (p *PartitionState) CollectTombstoneStats(
 // This function checks:
 // 1. Non-appendable objects in dataObjectsNameIndex (O(log n) lookup)
 // 2. Appendable objects in rows btree (O(n) scan, but cached by caller)
-func (p *PartitionState) isDataObjectVisible(objId *types.Objectid, snapshot types.TS) bool {
+func (p *PartitionState) IsDataObjectVisible(objId *types.Objectid, snapshot types.TS) bool {
 	// Build a dummy ObjectEntry with the target objectid for lookup
 	var stats objectio.ObjectStats
 	objectio.SetObjectStatsObjectName(&stats, objectio.BuildObjectNameWithObjectID(objId))
@@ -1530,7 +1530,7 @@ func (p *PartitionState) countTombstoneStatsLinear(
 				if !lastObjIdSet || !objId.EQ(&lastObjId) {
 					lastObjId = *objId
 					lastObjIdSet = true
-					lastVisible = p.isDataObjectVisible(objId, snapshot)
+					lastVisible = p.IsDataObjectVisible(objId, snapshot)
 				}
 
 				if lastVisible {
@@ -1626,7 +1626,7 @@ func (p *PartitionState) countTombstoneStatsWithMap(
 					if !lastObjIdSet || !objId.EQ(&lastObjId) {
 						lastObjId = *objId
 						lastObjIdSet = true
-						lastVisible = p.isDataObjectVisible(objId, snapshot)
+						lastVisible = p.IsDataObjectVisible(objId, snapshot)
 					}
 
 					if lastVisible {
@@ -1673,7 +1673,7 @@ func (p *PartitionState) countTombstoneStatsWithMap(
 		if !lastObjIdSet || !objId.EQ(&lastObjId) {
 			lastObjId = *objId
 			lastObjIdSet = true
-			lastVisible = p.isDataObjectVisible(objId, snapshot)
+			lastVisible = p.IsDataObjectVisible(objId, snapshot)
 		}
 
 		if lastVisible {
@@ -1757,7 +1757,7 @@ func (it *tombstoneBlockIterator) next() bool {
 			}
 
 			objId := it.inMemEntry.RowID.BorrowObjectID()
-			if !it.p.isDataObjectVisible(objId, it.snapshot) {
+			if !it.p.IsDataObjectVisible(objId, it.snapshot) {
 				continue
 			}
 
@@ -1774,7 +1774,7 @@ func (it *tombstoneBlockIterator) next() bool {
 			}
 
 			objId := it.rowIds[it.rowIdx].BorrowObjectID()
-			if !it.p.isDataObjectVisible(objId, it.snapshot) {
+			if !it.p.IsDataObjectVisible(objId, it.snapshot) {
 				it.rowIdx++
 				continue
 			}

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -630,7 +630,7 @@ func (txn *Transaction) dumpInsertBatchLocked(
 	sort.Slice(keys, func(i, j int) bool {
 		return tbSize[keys[i]] < tbSize[keys[j]]
 	})
-	
+
 	// Skip the skipTable logic if force flush is enabled
 	if !forceFlush {
 		sum := 0

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -481,15 +481,18 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 	var size uint64
 	var pkCount int
 
+	// Check fault injection first - if enabled, force flush
+	forceFlush := objectio.CNWorkspaceForceFlushInjected()
+
 	//offset < 0 indicates commit.
 	if offset < 0 {
-		if txn.approximateInMemInsertSize < txn.commitWorkspaceThreshold &&
+		if !forceFlush && txn.approximateInMemInsertSize < txn.commitWorkspaceThreshold &&
 			txn.approximateInMemInsertCnt < txn.engine.config.insertEntryMaxCount &&
 			txn.approximateInMemDeleteCnt < txn.engine.config.insertEntryMaxCount {
 			return nil
 		}
 	} else {
-		if txn.approximateInMemInsertSize < txn.writeWorkspaceThreshold {
+		if !forceFlush && txn.approximateInMemInsertSize < txn.writeWorkspaceThreshold {
 			return nil
 		}
 	}
@@ -499,7 +502,7 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 		offset = 0
 	}
 
-	if !dumpAll {
+	if !dumpAll && !forceFlush {
 		for i := offset; i < len(txn.writes); i++ {
 			if txn.writes[i].isCatalog() {
 				continue
@@ -600,6 +603,9 @@ func (txn *Transaction) dumpInsertBatchLocked(
 	pkCount *int,
 ) error {
 
+	// Check if force flush is enabled
+	forceFlush := objectio.CNWorkspaceForceFlushInjected()
+
 	tbSize := make(map[uint64]int)
 	tbCount := make(map[uint64]int)
 	skipTable := make(map[uint64]bool)
@@ -624,16 +630,20 @@ func (txn *Transaction) dumpInsertBatchLocked(
 	sort.Slice(keys, func(i, j int) bool {
 		return tbSize[keys[i]] < tbSize[keys[j]]
 	})
-	sum := 0
-	for _, k := range keys {
-		if tbCount[k] >= txn.engine.config.insertEntryMaxCount {
-			continue
+	
+	// Skip the skipTable logic if force flush is enabled
+	if !forceFlush {
+		sum := 0
+		for _, k := range keys {
+			if tbCount[k] >= txn.engine.config.insertEntryMaxCount {
+				continue
+			}
+			if uint64(sum+tbSize[k]) >= txn.commitWorkspaceThreshold {
+				break
+			}
+			sum += tbSize[k]
+			skipTable[k] = true
 		}
-		if uint64(sum+tbSize[k]) >= txn.commitWorkspaceThreshold {
-			break
-		}
-		sum += tbSize[k]
-		skipTable[k] = true
 	}
 
 	lastWriteIndex := offset

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -641,6 +641,23 @@ func (tbl *txnTable) Ranges(ctx context.Context, rangesParam engine.RangesParam)
 	return tbl.doRanges(ctx, rangesParam)
 }
 
+func (tbl *txnTable) StarCount(ctx context.Context) (uint64, error) {
+	part, err := tbl.getPartitionState(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	snapshot := tbl.db.op.SnapshotTS()
+	fs, err := fileservice.Get[fileservice.FileService](
+		tbl.getTxn().proc.Base.FileService,
+		defines.SharedFileServiceName)
+	if err != nil {
+		return 0, err
+	}
+
+	return part.CountRows(ctx, types.TimestampToTS(snapshot), fs)
+}
+
 func (tbl *txnTable) getObjList(ctx context.Context, rangesParam engine.RangesParam) (data engine.RelData, err error) {
 	needUncommited := rangesParam.Policy&engine.Policy_CollectUncommittedData != 0
 

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -662,7 +662,7 @@ func (tbl *txnTable) StarCount(ctx context.Context) (uint64, error) {
 
 	// Check if there are uncommitted tombstones
 	hasUncommittedTombstones := false
-	txnOffset := 0
+	txnOffset := len(tbl.getTxn().writes)
 	if tbl.db.op.IsSnapOp() {
 		txnOffset = tbl.getTxn().GetSnapshotWriteOffset()
 	}

--- a/pkg/vm/engine/disttae/txn_table_combined.go
+++ b/pkg/vm/engine/disttae/txn_table_combined.go
@@ -243,6 +243,23 @@ func (t *combinedTxnTable) CollectTombstones(
 	return tombstone, nil
 }
 
+func (t *combinedTxnTable) StarCount(ctx context.Context) (uint64, error) {
+	tables, err := t.tablesFunc()
+	if err != nil {
+		return 0, err
+	}
+
+	var total uint64
+	for _, rel := range tables {
+		count, err := rel.StarCount(ctx)
+		if err != nil {
+			return 0, err
+		}
+		total += count
+	}
+	return total, nil
+}
+
 func (t *combinedTxnTable) CollectChanges(
 	ctx context.Context,
 	from, to types.TS,

--- a/pkg/vm/engine/disttae/txn_table_combined.go
+++ b/pkg/vm/engine/disttae/txn_table_combined.go
@@ -260,6 +260,23 @@ func (t *combinedTxnTable) StarCount(ctx context.Context) (uint64, error) {
 	return total, nil
 }
 
+func (t *combinedTxnTable) EstimateCommittedTombstoneCount(ctx context.Context) (int, error) {
+	tables, err := t.tablesFunc()
+	if err != nil {
+		return 0, err
+	}
+
+	var total int
+	for _, rel := range tables {
+		count, err := rel.EstimateCommittedTombstoneCount(ctx)
+		if err != nil {
+			return 0, err
+		}
+		total += count
+	}
+	return total, nil
+}
+
 func (t *combinedTxnTable) CollectChanges(
 	ctx context.Context,
 	from, to types.TS,

--- a/pkg/vm/engine/disttae/txn_table_combined_test.go
+++ b/pkg/vm/engine/disttae/txn_table_combined_test.go
@@ -778,6 +778,184 @@ func TestCombinedTxnTable_Size(t *testing.T) {
 	})
 }
 
+func TestCombinedTxnTable_StarCount(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success with multiple tables", func(t *testing.T) {
+		mockRel1 := &mockRelation{
+			starCountFunc: func(ctx context.Context) (uint64, error) {
+				return 100, nil
+			},
+		}
+		mockRel2 := &mockRelation{
+			starCountFunc: func(ctx context.Context) (uint64, error) {
+				return 200, nil
+			},
+		}
+
+		table := &combinedTxnTable{
+			tablesFunc: func() ([]engine.Relation, error) {
+				return []engine.Relation{mockRel1, mockRel2}, nil
+			},
+		}
+
+		count, err := table.StarCount(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(300), count)
+	})
+
+	t.Run("Error from tablesFunc", func(t *testing.T) {
+		table := &combinedTxnTable{
+			tablesFunc: func() ([]engine.Relation, error) {
+				return nil, assert.AnError
+			},
+		}
+
+		count, err := table.StarCount(ctx)
+		assert.Error(t, err)
+		assert.Equal(t, uint64(0), count)
+		assert.Equal(t, assert.AnError, err)
+	})
+
+	t.Run("Error from individual table", func(t *testing.T) {
+		mockRel := &mockRelation{
+			starCountFunc: func(ctx context.Context) (uint64, error) {
+				return 0, assert.AnError
+			},
+		}
+
+		table := &combinedTxnTable{
+			tablesFunc: func() ([]engine.Relation, error) {
+				return []engine.Relation{mockRel}, nil
+			},
+		}
+
+		count, err := table.StarCount(ctx)
+		assert.Error(t, err)
+		assert.Equal(t, uint64(0), count)
+		assert.Equal(t, assert.AnError, err)
+	})
+
+	t.Run("Empty tables list", func(t *testing.T) {
+		table := &combinedTxnTable{
+			tablesFunc: func() ([]engine.Relation, error) {
+				return []engine.Relation{}, nil
+			},
+		}
+
+		count, err := table.StarCount(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0), count)
+	})
+
+	t.Run("Single table", func(t *testing.T) {
+		mockRel := &mockRelation{
+			starCountFunc: func(ctx context.Context) (uint64, error) {
+				return 42, nil
+			},
+		}
+
+		table := &combinedTxnTable{
+			tablesFunc: func() ([]engine.Relation, error) {
+				return []engine.Relation{mockRel}, nil
+			},
+		}
+
+		count, err := table.StarCount(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(42), count)
+	})
+}
+
+func TestCombinedTxnTable_EstimateCommittedTombstoneCount(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Success with multiple tables", func(t *testing.T) {
+		mockRel1 := &mockRelation{
+			estimateCommittedTombstoneCountFunc: func(ctx context.Context) (int, error) {
+				return 10, nil
+			},
+		}
+		mockRel2 := &mockRelation{
+			estimateCommittedTombstoneCountFunc: func(ctx context.Context) (int, error) {
+				return 20, nil
+			},
+		}
+
+		table := &combinedTxnTable{
+			tablesFunc: func() ([]engine.Relation, error) {
+				return []engine.Relation{mockRel1, mockRel2}, nil
+			},
+		}
+
+		count, err := table.EstimateCommittedTombstoneCount(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, 30, count)
+	})
+
+	t.Run("Error from tablesFunc", func(t *testing.T) {
+		table := &combinedTxnTable{
+			tablesFunc: func() ([]engine.Relation, error) {
+				return nil, assert.AnError
+			},
+		}
+
+		count, err := table.EstimateCommittedTombstoneCount(ctx)
+		assert.Error(t, err)
+		assert.Equal(t, 0, count)
+		assert.Equal(t, assert.AnError, err)
+	})
+
+	t.Run("Error from individual table", func(t *testing.T) {
+		mockRel := &mockRelation{
+			estimateCommittedTombstoneCountFunc: func(ctx context.Context) (int, error) {
+				return 0, assert.AnError
+			},
+		}
+
+		table := &combinedTxnTable{
+			tablesFunc: func() ([]engine.Relation, error) {
+				return []engine.Relation{mockRel}, nil
+			},
+		}
+
+		count, err := table.EstimateCommittedTombstoneCount(ctx)
+		assert.Error(t, err)
+		assert.Equal(t, 0, count)
+		assert.Equal(t, assert.AnError, err)
+	})
+
+	t.Run("Empty tables list", func(t *testing.T) {
+		table := &combinedTxnTable{
+			tablesFunc: func() ([]engine.Relation, error) {
+				return []engine.Relation{}, nil
+			},
+		}
+
+		count, err := table.EstimateCommittedTombstoneCount(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("Single table", func(t *testing.T) {
+		mockRel := &mockRelation{
+			estimateCommittedTombstoneCountFunc: func(ctx context.Context) (int, error) {
+				return 5, nil
+			},
+		}
+
+		table := &combinedTxnTable{
+			tablesFunc: func() ([]engine.Relation, error) {
+				return []engine.Relation{mockRel}, nil
+			},
+		}
+
+		count, err := table.EstimateCommittedTombstoneCount(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, 5, count)
+	})
+}
+
 func TestCombinedTxnTable_Rows(t *testing.T) {
 	// Test case 1: Success case with multiple tables
 	t.Run("Success with multiple tables", func(t *testing.T) {
@@ -1141,14 +1319,16 @@ func (m *mockReader) SetIndexParam(param *plan.IndexReaderParam) {}
 func (m *mockReader) SetFilterZM(objectio.ZoneMap) {}
 
 type mockRelation struct {
-	rangesFunc                      func(ctx context.Context, param engine.RangesParam) (engine.RelData, error)
-	getColumMetadataScanInfoFunc    func(ctx context.Context, name string, visitTombstone bool) ([]*plan.MetadataScanInfo, error)
-	getNonAppendableObjectStatsFunc func(ctx context.Context) ([]objectio.ObjectStats, error)
-	approxObjectsNumFunc            func(ctx context.Context) int
-	collectTombstonesFunc           func(ctx context.Context, txnOffset int, policy engine.TombstoneCollectPolicy) (engine.Tombstoner, error)
-	sizeFunc                        func(ctx context.Context, columnName string) (uint64, error)
-	rowsFunc                        func(ctx context.Context) (uint64, error)
-	buildReadersFunc                func(ctx context.Context, proc any, expr *plan.Expr, relData engine.RelData, num int, txnOffset int, orderBy bool, policy engine.TombstoneApplyPolicy, filterHint engine.FilterHint) ([]engine.Reader, error)
+	rangesFunc                          func(ctx context.Context, param engine.RangesParam) (engine.RelData, error)
+	getColumMetadataScanInfoFunc        func(ctx context.Context, name string, visitTombstone bool) ([]*plan.MetadataScanInfo, error)
+	getNonAppendableObjectStatsFunc     func(ctx context.Context) ([]objectio.ObjectStats, error)
+	approxObjectsNumFunc                func(ctx context.Context) int
+	collectTombstonesFunc               func(ctx context.Context, txnOffset int, policy engine.TombstoneCollectPolicy) (engine.Tombstoner, error)
+	sizeFunc                            func(ctx context.Context, columnName string) (uint64, error)
+	rowsFunc                            func(ctx context.Context) (uint64, error)
+	starCountFunc                       func(ctx context.Context) (uint64, error)
+	estimateCommittedTombstoneCountFunc func(ctx context.Context) (int, error)
+	buildReadersFunc                    func(ctx context.Context, proc any, expr *plan.Expr, relData engine.RelData, num int, txnOffset int, orderBy bool, policy engine.TombstoneApplyPolicy, filterHint engine.FilterHint) ([]engine.Reader, error)
 }
 
 func (m *mockRelation) Ranges(ctx context.Context, param engine.RangesParam) (engine.RelData, error) {
@@ -1193,10 +1373,16 @@ func (m *mockRelation) CollectTombstones(ctx context.Context, txnOffset int, pol
 }
 
 func (m *mockRelation) StarCount(ctx context.Context) (uint64, error) {
+	if m.starCountFunc != nil {
+		return m.starCountFunc(ctx)
+	}
 	return 0, nil
 }
 
 func (m *mockRelation) EstimateCommittedTombstoneCount(ctx context.Context) (int, error) {
+	if m.estimateCommittedTombstoneCountFunc != nil {
+		return m.estimateCommittedTombstoneCountFunc(ctx)
+	}
 	return 0, nil
 }
 

--- a/pkg/vm/engine/disttae/txn_table_combined_test.go
+++ b/pkg/vm/engine/disttae/txn_table_combined_test.go
@@ -1192,6 +1192,10 @@ func (m *mockRelation) CollectTombstones(ctx context.Context, txnOffset int, pol
 	return nil, nil
 }
 
+func (m *mockRelation) StarCount(ctx context.Context) (uint64, error) {
+	return 0, nil
+}
+
 func (m *mockRelation) CollectChanges(ctx context.Context, from, to types.TS, _ bool, mp *mpool.MPool) (engine.ChangesHandle, error) {
 	return nil, nil
 }

--- a/pkg/vm/engine/disttae/txn_table_combined_test.go
+++ b/pkg/vm/engine/disttae/txn_table_combined_test.go
@@ -1196,6 +1196,10 @@ func (m *mockRelation) StarCount(ctx context.Context) (uint64, error) {
 	return 0, nil
 }
 
+func (m *mockRelation) EstimateCommittedTombstoneCount(ctx context.Context) (int, error) {
+	return 0, nil
+}
+
 func (m *mockRelation) CollectChanges(ctx context.Context, from, to types.TS, _ bool, mp *mpool.MPool) (engine.ChangesHandle, error) {
 	return nil, nil
 }

--- a/pkg/vm/engine/disttae/txn_table_delegate.go
+++ b/pkg/vm/engine/disttae/txn_table_delegate.go
@@ -351,6 +351,22 @@ func (tbl *txnTableDelegate) StarCount(ctx context.Context) (uint64, error) {
 	return tbl.parent.StarCount(ctx)
 }
 
+func (tbl *txnTableDelegate) EstimateCommittedTombstoneCount(ctx context.Context) (int, error) {
+	if tbl.combined.is {
+		return tbl.combined.tbl.EstimateCommittedTombstoneCount(ctx)
+	}
+
+	is, err := tbl.isLocal()
+	if err != nil {
+		return 0, err
+	}
+	if is {
+		return tbl.origin.EstimateCommittedTombstoneCount(ctx)
+	}
+
+	return tbl.parent.EstimateCommittedTombstoneCount(ctx)
+}
+
 func (tbl *txnTableDelegate) CollectTombstones(
 	ctx context.Context,
 	txnOffset int,

--- a/pkg/vm/engine/disttae/txn_table_delegate.go
+++ b/pkg/vm/engine/disttae/txn_table_delegate.go
@@ -335,6 +335,22 @@ func (tbl *txnTableDelegate) Ranges(ctx context.Context, rangesParam engine.Rang
 	return ret, nil
 }
 
+func (tbl *txnTableDelegate) StarCount(ctx context.Context) (uint64, error) {
+	if tbl.combined.is {
+		return tbl.combined.tbl.StarCount(ctx)
+	}
+
+	is, err := tbl.isLocal()
+	if err != nil {
+		return 0, err
+	}
+	if is {
+		return tbl.origin.StarCount(ctx)
+	}
+
+	return tbl.parent.StarCount(ctx)
+}
+
 func (tbl *txnTableDelegate) CollectTombstones(
 	ctx context.Context,
 	txnOffset int,

--- a/pkg/vm/engine/memoryengine/table_reader.go
+++ b/pkg/vm/engine/memoryengine/table_reader.go
@@ -277,6 +277,10 @@ func (t *Table) StarCount(ctx context.Context) (uint64, error) {
 	return t.Rows(ctx)
 }
 
+func (t *Table) EstimateCommittedTombstoneCount(ctx context.Context) (int, error) {
+	return 0, nil // memory engine has no persisted tombstones
+}
+
 // for memory engine.
 type MemRelationData struct {
 	Shards ShardIdSlice

--- a/pkg/vm/engine/memoryengine/table_reader.go
+++ b/pkg/vm/engine/memoryengine/table_reader.go
@@ -273,6 +273,10 @@ func (t *Table) CollectTombstones(
 	panic("implement me")
 }
 
+func (t *Table) StarCount(ctx context.Context) (uint64, error) {
+	return t.Rows(ctx)
+}
+
 // for memory engine.
 type MemRelationData struct {
 	Shards ShardIdSlice

--- a/pkg/vm/engine/test/testutil/disttae_engine.go
+++ b/pkg/vm/engine/test/testutil/disttae_engine.go
@@ -385,8 +385,8 @@ func (de *TestDisttaeEngine) SubscribeTable(
 	dbName, tblName string,
 	setSubscribed bool,
 ) (err error) {
-	ticker := time.NewTicker(time.Second)
-	timeout := 5
+	ticker := time.NewTicker(time.Millisecond * 5)
+	timeout := 1000
 
 	for range ticker.C {
 		if timeout <= 0 {

--- a/pkg/vm/engine/test/txn_table_starcount_test.go
+++ b/pkg/vm/engine/test/txn_table_starcount_test.go
@@ -252,3 +252,87 @@ func TestStarCountReadonly(t *testing.T) {
 	err = txn.Commit(ctx)
 	require.NoError(t, err)
 }
+
+
+// TestStarCountWithPersistedInserts tests StarCount with persisted uncommitted inserts
+func TestStarCountWithPersistedInserts(t *testing.T) {
+	catalog.SetupDefines("")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+
+	// Create engine with very small workspace threshold to trigger persist
+	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(
+		ctx,
+		testutil.TestOptions{
+			DisttaeOptions: []testutil.TestDisttaeEngineOptions{
+				testutil.WithDisttaeEngineWriteWorkspaceThreshold(1024), // 1KB threshold
+			},
+		},
+		t,
+	)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeHandler.Close(true)
+		rpcAgent.Close()
+	}()
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	// Setup: Create database and table with 100 rows
+	txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+
+	err = disttaeEngine.Engine.Create(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	db, err := disttaeEngine.Engine.Database(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	schema := catalog2.MockSchemaAll(3, -1) // No PK
+	schema.Name = "test_table"
+	defs, err := testutil.EngineTableDefBySchema(schema)
+	require.NoError(t, err)
+
+	err = db.Create(ctx, "test_table", defs)
+	require.NoError(t, err)
+
+	rel, err := db.Relation(ctx, "test_table", nil)
+	require.NoError(t, err)
+
+	bat := catalog2.MockBatch(schema, 100)
+	err = rel.Write(ctx, containers.ToCNBatch(bat))
+	require.NoError(t, err)
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	// Test: Add uncommitted inserts that will be persisted
+	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+
+	db, err = disttaeEngine.Engine.Database(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	rel, err = db.Relation(ctx, "test_table", nil)
+	require.NoError(t, err)
+
+	// Insert enough data to trigger persist (> 1KB)
+	// Each row is ~100 bytes, so 20 rows should be enough
+	for i := 0; i < 5; i++ {
+		bat = catalog2.MockBatch(schema, 20)
+		err = rel.Write(ctx, containers.ToCNBatch(bat))
+		require.NoError(t, err)
+	}
+
+	// Count should include both committed and persisted uncommitted inserts
+	count, err := rel.StarCount(ctx)
+	require.NoError(t, err)
+	t.Logf("StarCount returned: %d, expected: 200 (100 committed + 100 persisted uncommitted)", count)
+	require.Equal(t, uint64(200), count, "Should count 100 committed + 100 persisted uncommitted")
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+}

--- a/pkg/vm/engine/test/txn_table_starcount_test.go
+++ b/pkg/vm/engine/test/txn_table_starcount_test.go
@@ -1,0 +1,254 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	catalog2 "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/test/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStarCountBasic(t *testing.T) {
+	catalog.SetupDefines("")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+
+	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeHandler.Close(true)
+		rpcAgent.Close()
+	}()
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	// Create database
+	txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+
+	err = disttaeEngine.Engine.Create(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	db, err := disttaeEngine.Engine.Database(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	// Create table
+	schema := catalog2.MockSchemaAll(3, 0)
+	schema.Name = "test_table"
+	defs, err := testutil.EngineTableDefBySchema(schema)
+	require.NoError(t, err)
+
+	err = db.Create(ctx, "test_table", defs)
+	require.NoError(t, err)
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	// Test 1: Empty table
+	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+
+	db, err = disttaeEngine.Engine.Database(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	rel, err := db.Relation(ctx, "test_table", nil)
+	require.NoError(t, err)
+
+	count, err := rel.StarCount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), count, "Empty table should have 0 rows")
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	// Test 2: Insert and count
+	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+
+	db, err = disttaeEngine.Engine.Database(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	rel, err = db.Relation(ctx, "test_table", nil)
+	require.NoError(t, err)
+
+	// Insert 100 rows
+	bat := catalog2.MockBatch(schema, 100)
+	err = rel.Write(ctx, containers.ToCNBatch(bat))
+	require.NoError(t, err)
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	// Test 2: Count after commit
+	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+
+	db, err = disttaeEngine.Engine.Database(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	rel, err = db.Relation(ctx, "test_table", nil)
+	require.NoError(t, err)
+
+	count, err = rel.StarCount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), count, "Should count committed rows")
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+}
+
+func TestStarCountWithUncommittedInserts(t *testing.T) {
+	catalog.SetupDefines("")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+
+	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeHandler.Close(true)
+		rpcAgent.Close()
+	}()
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	// Setup: Create database and table with 100 rows
+	txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+
+	err = disttaeEngine.Engine.Create(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	db, err := disttaeEngine.Engine.Database(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	schema := catalog2.MockSchemaAll(3, -1) // -1 means no primary key
+	schema.Name = "test_table"
+	defs, err := testutil.EngineTableDefBySchema(schema)
+	require.NoError(t, err)
+
+	err = db.Create(ctx, "test_table", defs)
+	require.NoError(t, err)
+
+	rel, err := db.Relation(ctx, "test_table", nil)
+	require.NoError(t, err)
+
+	bat := catalog2.MockBatch(schema, 100)
+	err = rel.Write(ctx, containers.ToCNBatch(bat))
+	require.NoError(t, err)
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	// Test: Add uncommitted inserts
+	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+
+	db, err = disttaeEngine.Engine.Database(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	rel, err = db.Relation(ctx, "test_table", nil)
+	require.NoError(t, err)
+
+	// Insert 50 more rows (uncommitted) - no PK so no conflict
+	bat = catalog2.MockBatch(schema, 50)
+	err = rel.Write(ctx, containers.ToCNBatch(bat))
+	require.NoError(t, err)
+
+	// Count should include uncommitted inserts
+	count, err := rel.StarCount(ctx)
+	require.NoError(t, err)
+	t.Logf("StarCount returned: %d, expected: 150 (100 committed + 50 uncommitted)", count)
+	require.Equal(t, uint64(150), count, "Should count 100 committed + 50 uncommitted")
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+}
+
+func TestStarCountReadonly(t *testing.T) {
+	catalog.SetupDefines("")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, catalog.System_Account)
+
+	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeHandler.Close(true)
+		rpcAgent.Close()
+	}()
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	// Setup: Create database and table with 100 rows
+	txn, err := disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+
+	err = disttaeEngine.Engine.Create(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	db, err := disttaeEngine.Engine.Database(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	schema := catalog2.MockSchemaAll(3, 0)
+	schema.Name = "test_table"
+	defs, err := testutil.EngineTableDefBySchema(schema)
+	require.NoError(t, err)
+
+	err = db.Create(ctx, "test_table", defs)
+	require.NoError(t, err)
+
+	rel, err := db.Relation(ctx, "test_table", nil)
+	require.NoError(t, err)
+
+	bat := catalog2.MockBatch(schema, 100)
+	err = rel.Write(ctx, containers.ToCNBatch(bat))
+	require.NoError(t, err)
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+
+	// Test: Readonly transaction (use snapshot)
+	txn, err = disttaeEngine.NewTxnOperator(ctx, disttaeEngine.Now())
+	require.NoError(t, err)
+
+	db, err = disttaeEngine.Engine.Database(ctx, "testdb", txn)
+	require.NoError(t, err)
+
+	rel, err = db.Relation(ctx, "test_table", nil)
+	require.NoError(t, err)
+
+	// Readonly transaction should only see committed rows
+	count, err := rel.StarCount(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), count, "Readonly should only count committed rows")
+
+	err = txn.Commit(ctx)
+	require.NoError(t, err)
+}

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -1002,6 +1002,11 @@ type Relation interface {
 
 	CollectTombstones(ctx context.Context, txnOffset int, policy TombstoneCollectPolicy) (Tombstoner, error)
 
+	// StarCount returns the total number of visible rows at the current transaction snapshot.
+	// Optimized for COUNT(*) queries by using metadata (total rows - deleted rows)
+	// instead of scanning data blocks.
+	StarCount(ctx context.Context) (uint64, error)
+
 	CollectChanges(ctx context.Context, from, to types.TS, skipDeletes bool, mp *mpool.MPool) (ChangesHandle, error)
 
 	TableDefs(context.Context) ([]TableDef, error)

--- a/pkg/vm/engine/types.go
+++ b/pkg/vm/engine/types.go
@@ -1007,6 +1007,12 @@ type Relation interface {
 	// instead of scanning data blocks.
 	StarCount(ctx context.Context) (uint64, error)
 
+	// EstimateCommittedTombstoneCount returns an estimated count of committed tombstone rows.
+	// This is very lightweight (only reads metadata, no S3 I/O) and can be used to decide
+	// whether to use StarCount optimization.
+	// Returns an upper bound estimate (includes duplicates and invisible data object references).
+	EstimateCommittedTombstoneCount(ctx context.Context) (int, error)
+
 	CollectChanges(ctx context.Context, from, to types.TS, skipDeletes bool, mp *mpool.MPool) (ChangesHandle, error)
 
 	TableDefs(context.Context) ([]TableDef, error)

--- a/test/distributed/cases/dml/delete/delete.result
+++ b/test/distributed/cases/dml/delete/delete.result
@@ -125,6 +125,9 @@ create table t1(a int primary key);
 delete from t1;
 select * from t1;
 ➤ a[4,32,0]
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+0
 drop table if exists t1;
 create table t1 (a char(20));
 insert into t1 values ('heelo'), ('sub'), ('none'), (null);
@@ -543,5 +546,8 @@ select * from repro_delete_error;
 ➤ a[4,32,0]  𝄀
 2  𝄀
 3
+select count(*) from repro_delete_error;
+➤ count(*)[-5,64,0]  𝄀
+2
 drop database if exists db1;
 drop database if exists db2;

--- a/test/distributed/cases/dml/delete/delete.result
+++ b/test/distributed/cases/dml/delete/delete.result
@@ -12,10 +12,10 @@ create table t2 (b int);
 insert into t2 values(1),(2),(3);
 delete from db1.t2, db2.t1 using db1.t2 join db2.t1 on db1.t2.b = db2.t1.a where 2 > 1;
 select * from db1.t2;
-b
+➤ b[4,32,0]  𝄀
 3
 select * from db2.t1;
-a
+➤ a[4,32,0]  𝄀
 4
 drop table if exists t1;
 drop table if exists t2;
@@ -33,12 +33,12 @@ create table t2 (b char(20));
 insert into t2 values('a'),('b'),('d');
 delete from db1.t1, db2.t2 using db1.t1 join db2.t2 on db1.t1.a = db2.t2.b where db1.t1.a = 'a';
 select * from db1.t1;
-a
-b
+➤ a[1,20,0]  𝄀
+b  𝄀
 c
 select * from db2.t2;
-b
-b
+➤ b[1,20,0]  𝄀
+b  𝄀
 d
 drop table if exists t1;
 drop table if exists t2;
@@ -54,8 +54,8 @@ create table t2 (b int);
 insert into t2 values(1), (2), (3);
 with t11 as ( select * from t1) delete t2 from t11 join t2 on t11.a = t2.b where t2.b = 3;
 select * from t2;
-b
-1
+➤ b[4,32,0]  𝄀
+1  𝄀
 2
 drop table if exists t1;
 drop table if exists t2;
@@ -65,16 +65,16 @@ create table t2 (b int);
 insert into t2 values(1), (2), (5);
 delete t1 from t1 join t2 where t1.a = 2;
 select * from t1;
-a
-1
+➤ a[4,32,0]  𝄀
+1  𝄀
 4
 drop table if exists t1;
 create table t1 (a int);
 insert into t1 values(1), (2), (3);
 delete from t1 as a1 where a1.a = 1;
 select * from t1;
-a
-2
+➤ a[4,32,0]  𝄀
+2  𝄀
 3
 drop table if exists t1;
 drop table if exists t2;
@@ -84,7 +84,7 @@ create table t2 (b int);
 insert into t2 values(1), (2), (5);
 DELETE a1, a2 FROM t1 AS a1 INNER JOIN t2 AS a2 WHERE a1.a = a2.b;
 select * from t1;
-a
+➤ a[4,32,0]  𝄀
 4
 drop table if exists t1;
 create table t1 (a int, b float, c varchar);
@@ -92,45 +92,45 @@ insert into t1 values(1, 1.5, 'a');
 insert into t1 values(1, 1.5, 'b');
 delete from t1 where (a, b) in ((1, 1.5));
 select * from t1;
-a    b    c
+➤ a[4,32,0]  ¦  b[7,24,0]  ¦  c[12,-1,0]
 insert into t1 values(2, 2.5, 'a');
 insert into t1 values(2, 2.5, 'b');
 delete from t1 where (a, b) in ((2.0, 2.5), (2.1, 2.5));
 select * from t1;
-a    b    c
+➤ a[4,32,0]  ¦  b[7,24,0]  ¦  c[12,-1,0]
 drop table if exists t1;
 create table t1 (a char(20));
 insert into t1 values (null), (null), ('hello');
 delete from t1 where a is null;
 select * from t1;
-a
+➤ a[1,20,0]  𝄀
 hello
 drop table if exists t1;
 create table t1 (a int, b int);
 insert into t1 values (1, 2), (3, 4), (5, 6);
 delete from t1 where a > 1;
 select * from t1;
-a    b
-1    2
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2
 drop table if exists t2;
 create table t2 (a int primary key, b int);
 insert into t2 values (1, 2), (3, 4), (5, 6);
 delete from t2 where a > 1 order by a limit 1;
 select * from t2;
-a    b
-1    2
-5    6
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2  𝄀
+5  ¦  6
 drop table if exists t1;
 create table t1(a int primary key);
 delete from t1;
 select * from t1;
-a
+➤ a[4,32,0]
 drop table if exists t1;
 create table t1 (a char(20));
 insert into t1 values ('heelo'), ('sub'), ('none'), (null);
 delete from t1 where a is not null;
 select * from t1;
-a
+➤ a[1,20,0]  𝄀
 null
 drop table if exists t1;
 drop table if exists t2;
@@ -140,41 +140,41 @@ create table t2 (b int primary key);
 insert into t2 values(1), (2), (3);
 delete t1, t2 from t1 join t2 on t1.a = t2.b where t1.a = 1;
 select * from t2;
-b
-2
+➤ b[4,32,0]  𝄀
+2  𝄀
 3
 drop table if exists t1;
 create table t1(a int auto_increment, b bigint auto_increment);
 insert into t1 values(null, 2), (3, null), (null, null);
 select * from t1;
-a    b
-1    2
-3    3
-4    4
+➤ a[4,32,0]  ¦  b[-5,64,0]  𝄀
+1  ¦  2  𝄀
+3  ¦  3  𝄀
+4  ¦  4
 insert into t1 values(100, 2), (null, null), (null, null);
 select * from t1;
-a    b
-1    2
-3    3
-4    4
-100    2
-101    5
-102    6
+➤ a[4,32,0]  ¦  b[-5,64,0]  𝄀
+1  ¦  2  𝄀
+3  ¦  3  𝄀
+4  ¦  4  𝄀
+100  ¦  2  𝄀
+101  ¦  5  𝄀
+102  ¦  6
 delete from t1 where a >= 100;
 select * from t1;
-a    b
-1    2
-3    3
-4    4
+➤ a[4,32,0]  ¦  b[-5,64,0]  𝄀
+1  ¦  2  𝄀
+3  ¦  3  𝄀
+4  ¦  4
 insert into t1 values(null, null), (null, null), (null, null);
 select * from t1;
-a    b
-1    2
-3    3
-4    4
-103    7
-104    8
-105    9
+➤ a[4,32,0]  ¦  b[-5,64,0]  𝄀
+1  ¦  2  𝄀
+3  ¦  3  𝄀
+4  ¦  4  𝄀
+103  ¦  7  𝄀
+104  ¦  8  𝄀
+105  ¦  9
 drop table if exists t1;
 create table t1(a int, b int, primary key(a, b));
 insert into t1 values(1, 2);
@@ -182,60 +182,60 @@ insert into t1 values(1, 3);
 insert into t1 values(2, 2);
 insert into t1 values(2, 3);
 select * from t1;
-a    b
-1    2
-1    3
-2    2
-2    3
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2  𝄀
+1  ¦  3  𝄀
+2  ¦  2  𝄀
+2  ¦  3
 delete from t1 where a = 1;
 select * from t1;
-a    b
-2    2
-2    3
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+2  ¦  2  𝄀
+2  ¦  3
 drop table if exists t1;
-
+[unknown result because it is related to issue#5790]
 create table t1(a int, b int, unique key(a));
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(1, 1);
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(2, 2);
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(3, 3);
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(4, 4);
-
+[unknown result because it is related to issue#5790]
 select * from t1;
-
+[unknown result because it is related to issue#5790]
 delete from t1 where a = 1;
-
+[unknown result because it is related to issue#5790]
 select * from t1;
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(1, 2);
-
+[unknown result because it is related to issue#5790]
 drop table if exists t1;
-
+[unknown result because it is related to issue#5790]
 create table t1(a int, b int, unique key(a, b));
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(1, 2);
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(1, 3);
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(2, 2);
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(2, 3);
-
+[unknown result because it is related to issue#5790]
 select * from t1;
-
+[unknown result because it is related to issue#5790]
 delete from t1 where a = 1;
-
+[unknown result because it is related to issue#5790]
 select * from t1;
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(1, 2);
-
+[unknown result because it is related to issue#5790]
 insert into t1 values(1, null);
-
+[unknown result because it is related to issue#5790]
 delete from t1 where a = 1;
-
+[unknown result because it is related to issue#5790]
 drop database if exists db1;
 use `delete`;
 create table temp(a int);
@@ -251,29 +251,29 @@ insert into t select * from t;
 insert into t select * from t;
 insert into t select * from t;
 insert into t select * from t;
-
+[unknown result because it is related to issue#9447]
 begin;
-
+[unknown result because it is related to issue#9447]
 insert into t select * from t;
-
+[unknown result because it is related to issue#9447]
 delete from t where a = 1;
-
+[unknown result because it is related to issue#9447]
 select count(*) from t;
-
+[unknown result because it is related to issue#9447]
 rollback;
-
+[unknown result because it is related to issue#9447]
 begin;
-
+[unknown result because it is related to issue#9447]
 insert into t select * from t;
-
+[unknown result because it is related to issue#9447]
 delete from t where a = 1;
-
+[unknown result because it is related to issue#9447]
 select count(*) from t;
-
+[unknown result because it is related to issue#9447]
 commit;
-
+[unknown result because it is related to issue#9447]
 select count(*) from t;
-
+[unknown result because it is related to issue#9447]
 drop table if exists temp;
 drop table if exists t;
 create table temp(a int);
@@ -281,44 +281,79 @@ insert into temp select * from generate_series(1,8192) g;
 create table t(a int);
 insert into t select * from temp;
 insert into t select * from t;
-begin;
-insert into t select * from t;
-delete from t where a > 1;
 select count(*) from t;
-count(*)
-4
-rollback;
-select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 16384
 begin;
 insert into t select * from t;
+select count(*) from t;
+➤ count(*)[-5,64,0]  𝄀
+32768
 delete from t where a > 1;
+select count(*) from t;
+➤ count(*)[-5,64,0]  𝄀
+4
+rollback;
+select count(*) from t;
+➤ count(*)[-5,64,0]  𝄀
+16384
+begin;
+insert into t select * from t;
+select count(*) from t;
+➤ count(*)[-5,64,0]  𝄀
+32768
+delete from t where a > 1;
+select count(*) from t;
+➤ count(*)[-5,64,0]  𝄀
+4
 delete from t where a = 1;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 0
 commit;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 0
 drop table if exists t2;
 create table t2 (a int, b int unique key, c int, d int, primary key(c,d));
 insert into t2 values (1,2,1,2);
 delete from t2 where b in (c in (select 1) and d in (select 1));
 select * from t2;
-a    b    c    d
-1    2    1    2
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  ¦  d[4,32,0]  𝄀
+1  ¦  2  ¦  1  ¦  2
 drop table if exists t7;
 create table t7(a int primary key, b int unique key, c varchar(20) unique key);
 insert into t7 select result, result, "a"||result from generate_series(1,20000) g;
 select count(*) from t7;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 20000
+delete from t7 where a <= 2000;
+select count(*) from t7;
+➤ count(*)[-5,64,0]  𝄀
+18000
+delete from t7 where a <= 10000;
+select count(*) from t7;
+➤ count(*)[-5,64,0]  𝄀
+10000
+delete from t7 where a <= 18000;
+select count(*) from t7;
+➤ count(*)[-5,64,0]  𝄀
+2000
 delete from t7;
 select count(*) from t7;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 0
+explain analyze select count(*) from t7;
+-- @regex("(?s)Table Scan.*Aggregate Functions: starcount\(1\)", true)
+➤ tp query plan[12,-1,0]  𝄀
+Project  𝄀
+  Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=8 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=8 bytes (min=8 bytes, max=8 bytes)  𝄀
+  ->  Aggregate  𝄀
+        Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=0 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on delete.t7  𝄀
+              Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=0 inputRows=0 outputRows=0 (min=0, max=0) InputSize=0 bytes OutputSize=0 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
+              Aggregate Functions: starcount(1)
 drop database if exists `delete`;
 drop database if exists db1;
 drop database if exists db2;
@@ -334,10 +369,10 @@ create table t2 (b int);
 insert into t2 values(1),(2),(3);
 delete from db1.t2, db2.t1 using db1.t2 join db2.t1 on db1.t2.b = db2.t1.a;
 select * from db1.t2;
-b
+➤ b[4,32,0]  𝄀
 3
 select * from db2.t1;
-a
+➤ a[4,32,0]  𝄀
 4
 drop table if exists t3;
 create table t3 (a int primary key, b int unique key, c int, key(c));
@@ -347,18 +382,18 @@ insert into t3 (a, b, c) values (3, 300, 3000);
 insert into t3 (a, b, c) values (4, 400, 4000);
 delete from t3 where a > 3;
 select * from t3;
-a    b    c
-1    100    1000
-2    200    2000
-3    300    3000
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+1  ¦  100  ¦  1000  𝄀
+2  ¦  200  ¦  2000  𝄀
+3  ¦  300  ¦  3000
 delete from t3 limit 1;
 select * from t3;
-a    b    c
-2    200    2000
-3    300    3000
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+2  ¦  200  ¦  2000  𝄀
+3  ¦  300  ¦  3000
 delete from t3;
 select * from t3;
-a    b    c
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]
 drop table if exists t4;
 create table t4 (a int, b int, c int);
 insert into t4 (a, b, c) values (1, 100, 1000);
@@ -367,18 +402,18 @@ insert into t4 (a, b, c) values (3, 300, 3000);
 insert into t4 (a, b, c) values (4, 400, 4000);
 delete from t4 where a > 3;
 select * from t4;
-a    b    c
-1    100    1000
-2    200    2000
-3    300    3000
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+1  ¦  100  ¦  1000  𝄀
+2  ¦  200  ¦  2000  𝄀
+3  ¦  300  ¦  3000
 delete from t4 limit 1;
 select * from t4;
-a    b    c
-2    200    2000
-3    300    3000
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+2  ¦  200  ¦  2000  𝄀
+3  ¦  300  ¦  3000
 delete from t4;
 select * from t4;
-a    b    c
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]
 create table t5 (id int primary key, c int);
 create table t6 (id int primary key, t5_id int, foreign KEY (t5_id) references t5(id) on delete cascade);
 insert into t5 (id, c) values (1, 100);
@@ -391,18 +426,18 @@ insert into t6 (id, t5_id) values (6, 3);
 insert into t6 (id, t5_id) values (7, 4);
 delete from t5 where id > 3;
 select * from t6;
-id    t5_id
-4    1
-5    2
-6    3
+➤ id[4,32,0]  ¦  t5_id[4,32,0]  𝄀
+4  ¦  1  𝄀
+5  ¦  2  𝄀
+6  ¦  3
 delete from t5 limit 1;
 select * from t6;
-id    t5_id
-5    2
-6    3
+➤ id[4,32,0]  ¦  t5_id[4,32,0]  𝄀
+5  ¦  2  𝄀
+6  ¦  3
 delete from t5;
 select * from t6;
-id    t5_id
+➤ id[4,32,0]  ¦  t5_id[4,32,0]
 drop table if exists t6;
 drop table if exists t5;
 create table t5 (id int primary key, c int);
@@ -417,46 +452,46 @@ insert into t6 (id, t5_id) values (6, 3);
 insert into t6 (id, t5_id) values (7, 4);
 delete from t5 where id > 3;
 select * from t6;
-id    t5_id
-4    1
-5    2
-6    3
-7    null
+➤ id[4,32,0]  ¦  t5_id[4,32,0]  𝄀
+4  ¦  1  𝄀
+5  ¦  2  𝄀
+6  ¦  3  𝄀
+7  ¦  null
 delete from t5 limit 1;
 select * from t6;
-id    t5_id
-5    2
-6    3
-7    null
-4    null
+➤ id[4,32,0]  ¦  t5_id[4,32,0]  𝄀
+5  ¦  2  𝄀
+6  ¦  3  𝄀
+7  ¦  null  𝄀
+4  ¦  null
 delete from t5;
 select * from t6;
-id    t5_id
-7    null
-4    null
-5    null
-6    null
+➤ id[4,32,0]  ¦  t5_id[4,32,0]  𝄀
+7  ¦  null  𝄀
+4  ¦  null  𝄀
+5  ¦  null  𝄀
+6  ¦  null
 drop table if exists t1;
 create table t1(c1 int primary key, c2 int, c3 int, key(c2));
 insert into t1 select *,*,* from generate_series(1,100000)g;
 select count(*) from t1;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 100000
 delete from t1 where c3>50000;
 select count(*) from t1;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 50000
 update t1 set c1=c1+100000, c2=c2+100000 where c3<40000;
 delete from t1 where c1>100000;
 select count(*) from t1;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 10001
 DROP TABLE IF EXISTS `t3`;
 CREATE TABLE t3 ( id INT PRIMARY KEY,col1 INT,key idx_col1 (col1));
 INSERT INTO t3 (SELECT *,1 FROM generate_series(0,8192,1)g);
 DELETE FROM t3 WHERE col1=1;
 SELECT COUNT(*) FROM t3 WHERE col1=1;
-COUNT(*)
+➤ COUNT(*)[-5,64,0]  𝄀
 0
 drop table if exists t1;
 drop table if exists t2;
@@ -482,15 +517,15 @@ insert into t7 select * from t7;
 insert into t7 select * from t7;
 insert into t7 select * from t7;
 select count(*) from t7;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 49152
 delete from t7 where i=1;
 select count(*) from t7 where i=1;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 0
 delete from t7 where i=2;
 select count(*) from t7 where i=2;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 0
 drop table if exists t7;
 use db1;
@@ -500,13 +535,13 @@ begin;
 insert into repro_delete_error values (1),(2),(3);
 delete from repro_delete_error where a=1;
 select * from repro_delete_error;
-a
-2
+➤ a[4,32,0]  𝄀
+2  𝄀
 3
 commit;
 select * from repro_delete_error;
-a
-2
+➤ a[4,32,0]  𝄀
+2  𝄀
 3
 drop database if exists db1;
 drop database if exists db2;

--- a/test/distributed/cases/dml/delete/delete.test
+++ b/test/distributed/cases/dml/delete/delete.test
@@ -207,18 +207,26 @@ insert into temp select * from generate_series(1,8192) g;
 create table t(a int);
 insert into t select * from temp;
 insert into t select * from t;
+select count(*) from t;
+
 begin;
 insert into t select * from t;
+select count(*) from t;
 delete from t where a > 1;
 select count(*) from t;
 rollback;
+
 select count(*) from t;
+
 begin;
 insert into t select * from t;
+select count(*) from t;
 delete from t where a > 1;
+select count(*) from t;
 delete from t where a = 1;
 select count(*) from t;
 commit;
+
 select count(*) from t;
 
 drop table if exists t2;
@@ -231,8 +239,20 @@ drop table if exists t7;
 create table t7(a int primary key, b int unique key, c varchar(20) unique key);
 insert into t7 select result, result, "a"||result from generate_series(1,20000) g;
 select count(*) from t7;
+
+delete from t7 where a <= 2000;
+select count(*) from t7;
+
+delete from t7 where a <= 10000;
+select count(*) from t7;
+
+delete from t7 where a <= 18000;
+select count(*) from t7;
+
 delete from t7;
 select count(*) from t7;
+-- @regex("(?s)Table Scan.*Aggregate Functions: starcount\(1\)",true)
+explain analyze select count(*) from t7;
 
 drop database if exists `delete`;
 

--- a/test/distributed/cases/dml/delete/delete.test
+++ b/test/distributed/cases/dml/delete/delete.test
@@ -103,6 +103,7 @@ drop table if exists t1;
 create table t1(a int primary key);
 delete from t1;
 select * from t1;
+select count(*) from t1;
 
 drop table if exists t1;
 create table t1 (a char(20));
@@ -385,5 +386,6 @@ delete from repro_delete_error where a=1;
 select * from repro_delete_error;
 commit;
 select * from repro_delete_error;
+select count(*) from repro_delete_error;
 drop database if exists db1;
 drop database if exists db2;

--- a/test/distributed/cases/dml/update/update.result
+++ b/test/distributed/cases/dml/update/update.result
@@ -9,15 +9,15 @@ create table t2 (b int);
 insert into t2 values(1), (2), (3);
 update t1, t2 set a = 1, b =2;
 select * from t1;
-a
-1
-1
+➤ a[4,32,0]  𝄀
+1  𝄀
+1  𝄀
 1
 update t1, t2 set a = null, b =null;
 select * from t2;
-b
-null
-null
+➤ b[4,32,0]  𝄀
+null  𝄀
+null  𝄀
 null
 drop table if exists t1;
 drop table if exists t2;
@@ -28,9 +28,9 @@ create table t2 (b int);
 insert into t2 values(1), (2), (3);
 update t2 as t222, (select b from t2) as t22 set t222.b = 555 where t222.b = 3;
 select  * from t2;
-b
-1
-2
+➤ b[4,32,0]  𝄀
+1  𝄀
+2  𝄀
 555
 drop table if exists t1;
 drop table if exists t2;
@@ -40,16 +40,16 @@ create table t2 (a int, b int, c int);
 insert into t2 values(1, 2, 3), (4, 5, 6), (7, 8, 9);
 update t1 join t2 on t1.a = t2.a set t1.b = 222, t1.c = 333, t2.b = 222, t2.c = 333;
 select * from t1;
-a	b	c
-1	222	333
-4	222	333
-7	222	333
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+1  ¦  222  ¦  333  𝄀
+4  ¦  222  ¦  333  𝄀
+7  ¦  222  ¦  333
 with t11 as (select * from (select * from t1) as t22) update t11 join t2 on t11.a = t2.a set t2.b = 666;
 select * from t2;
-a	b	c
-1	666	333
-4	666	333
-7	666	333
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+1  ¦  666  ¦  333  𝄀
+4  ¦  666  ¦  333  𝄀
+7  ¦  666  ¦  333
 drop table if exists t1;
 drop table if exists t2;
 create table t1 (a int primary key, b int, c int);
@@ -58,132 +58,141 @@ create table t2 (a int, b int, c int);
 insert into t2 values(1, 2, 3), (4, 5, 6), (7, 8, 9);
 update t1 join t2 on t1.a = t2.a set t1.a = 111 where t1.b = 2;
 select * from t1;
-a	b	c
-4	5	6
-7	8	9
-111	2	3
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+4  ¦  5  ¦  6  𝄀
+7  ¦  8  ¦  9  𝄀
+111  ¦  2  ¦  3
 drop table if exists t1;
 create table t1 (a int, b int);
 insert into t1 values (1, 2), (3, 4), (5, 6);
 update t1 set a = 1 where a > 1;
 select * from t1;
-a	b
-1	2
-1	4
-1	6
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2  𝄀
+1  ¦  4  𝄀
+1  ¦  6
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+3
 drop table if exists t2;
 create table t2 (a int primary key, b int);
 insert into t2 values (1, 2), (3, 4);
 select * from t2;
-a	b
-1	2
-3	4
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2  𝄀
+3  ¦  4
 update t2 set a = 2 where a > 1;
 select * from t2;
-a	b
-1	2
-2	4
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2  𝄀
+2  ¦  4
 update t2 set a = b, b = a +1 where a > 1;
 select * from t2;
-a	b
-1	2
-4	3
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2  𝄀
+4  ¦  3
+select count(*) from t2;
+➤ count(*)[-5,64,0]  𝄀
+2
 drop table if exists t3;
 create table t3 (a char(20));
 insert into t3 values("hello"), ("world");
 select * from t3;
-a
-hello
+➤ a[1,20,0]  𝄀
+hello  𝄀
 world
 update t3 set a = "modify";
 select * from t3;
-a
+➤ a[1,20,0]  𝄀
+modify  𝄀
 modify
-modify
+select count(*) from t3;
+➤ count(*)[-5,64,0]  𝄀
+2
 drop table if exists t5;
 create table t5(a date);
 insert into t5 values ('20070210'), ('1997-02-10'), ('0001-04-28'), ('20041112'), ('0123-04-03');
 select * from t5;
-a
-2007-02-10
-1997-02-10
-0001-04-28
-2004-11-12
+➤ a[91,64,0]  𝄀
+2007-02-10  𝄀
+1997-02-10  𝄀
+0001-04-28  𝄀
+2004-11-12  𝄀
 0123-04-03
 update t5 set a = '20070212' where a = '20070210';
 select * from t5;
-a
-1997-02-10
-0001-04-28
-2004-11-12
-0123-04-03
+➤ a[91,64,0]  𝄀
+1997-02-10  𝄀
+0001-04-28  𝄀
+2004-11-12  𝄀
+0123-04-03  𝄀
 2007-02-12
 drop table if exists t7;
 create table t7 (a int, b int, c int);
 insert into t7 values (1, 2, 11), (3, 4, 11), (5, 6, 11);
 select * from t7;
-a	b	c
-1	2	11
-3	4	11
-5	6	11
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+1  ¦  2  ¦  11  𝄀
+3  ¦  4  ¦  11  𝄀
+5  ¦  6  ¦  11
 update t7 set a = b,  b = a + 1 where a > 1;
 select * from t7;
-a	b	c
-1	2	11
-4	4	11
-6	6	11
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+1  ¦  2  ¦  11  𝄀
+4  ¦  4  ¦  11  𝄀
+6  ¦  6  ¦  11
 drop table if exists t8;
 create table t8 (a int);
 insert into t8 values(1), (2), (3),  (4),  (5);
 select * from t8;
-a
-1
-2
-3
-4
+➤ a[4,32,0]  𝄀
+1  𝄀
+2  𝄀
+3  𝄀
+4  𝄀
 5
 update t8 set a = 111 where a > 2 order by a limit 2;
 select * from t8;
-a
-1
-2
-5
-111
+➤ a[4,32,0]  𝄀
+1  𝄀
+2  𝄀
+5  𝄀
+111  𝄀
 111
 drop table if exists t9;
 CREATE TABLE t9 (a bigint(3), b bigint(5) primary key);
 insert INTO t9 VALUES (1,1),(1,2);
 update t9 set a=2 where a=1 limit 1;
 select * from t9;
-a	b
-1	2
-2	1
+➤ a[-5,64,0]  ¦  b[-5,64,0]  𝄀
+1  ¦  2  𝄀
+2  ¦  1
 drop table if exists t10;
 create table t10 (a int primary key, b int);
 insert into t10 values(1, 2),  (3, 4),  (5, 6);
 update t10 set b = null, a = a +1 where a > 1;
 select * from t10;
-a	b
-1	2
-4	null
-6	null
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2  𝄀
+4  ¦  null  𝄀
+6  ¦  null
 drop table if exists t11;
 create table t11 (a int, b int);
 insert into t11 values(1, null),  (3, 4),  (5, null);
 update t11 set a = b+1;
 select * from t11;
-a	b
-null	null
-5	4
-null	null
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+null  ¦  null  𝄀
+5  ¦  4  𝄀
+null  ¦  null
 drop table if exists t1;
 create table t1 (a int default 222);
 insert into t1 values(1), (2), (3);
 update t1 set a = default;
 select * from t1;
-a
-222
-222
+➤ a[4,32,0]  𝄀
+222  𝄀
+222  𝄀
 222
 drop table if exists t1;
 drop table if exists t2;
@@ -193,43 +202,49 @@ create table t2 (a int, b int default 111* 3);
 insert into t2 values (1, 1), (2, 2);
 update t1 join t2 on t1.a = t2.a set t1.b = default, t2.a = default;
 select * from t1;
-a	b
-1	289
-2	289
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  289  𝄀
+2  ¦  289
 select * from t2;
-a	b
-null	1
-null	2
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+null  ¦  1  𝄀
+null  ¦  2
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+2
+select count(*) from t2;
+➤ count(*)[-5,64,0]  𝄀
+2
 drop table if exists t1;
 create table t1(a int auto_increment, b int auto_increment);
 insert into t1 values(null, null), (null, null);
 select * from t1;
-a    b
-1    1
-2    2
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1  𝄀
+2  ¦  2
 insert into t1 values(100, 200), (null, null);
 select * from t1;
-a    b
-1    1
-2    2
-100    200
-101    201
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1  𝄀
+2  ¦  2  𝄀
+100  ¦  200  𝄀
+101  ¦  201
 update t1 set a=null;
 constraint violation: Column 'a' cannot be null
 select * from t1;
-a    b
-1    1
-2    2
-100    200
-101    201
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1  𝄀
+2  ¦  2  𝄀
+100  ¦  200  𝄀
+101  ¦  201
 update t1 set b=null;
 constraint violation: Column 'b' cannot be null
 select * from t1;
-a    b
-1    1
-2    2
-100    200
-101    201
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1  𝄀
+2  ¦  2  𝄀
+100  ¦  200  𝄀
+101  ¦  201
 drop table if exists t1;
 create table t1(
 id int,
@@ -238,15 +253,15 @@ b datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 insert into t1(id) values(1);
 select a is null from t1;
-a is null
+➤ a is null[-7,1,0]  𝄀
 1
 update t1 set id = 2 where id = 1;
 select a is not null from t1;
-a is not null
+➤ a is not null[-7,1,0]  𝄀
 1
 update t1  set id = 3,  a = '20121212' where id = 2;
 select id from t1 where a = '20121212';
-id
+➤ id[4,32,0]  𝄀
 3
 drop table if exists t1;
 create table t1(a int, b int, primary key(a));
@@ -267,46 +282,51 @@ insert into t1 values(2, 3);
 update t1 set a = 2 where a = 1;
 Duplicate entry ('\(\d\,\d\)'|'\d\w\d{5}\w\d{4}') for key '(\(a,b\)|__mo_cpkey_col)'
 drop table if exists t1;
+[unknown result because it is related to issue#5790]
 create table t1(a int, b varchar(20), unique key(a));
+[unknown result because it is related to issue#5790]
 insert into t1 values(1, '1');
+[unknown result because it is related to issue#5790]
 insert into t1 values(2, '2');
+[unknown result because it is related to issue#5790]
 insert into t1 values(3, '3');
+[unknown result because it is related to issue#5790]
 insert into t1 values(4, '4');
+[unknown result because it is related to issue#5790]
 select * from t1;
-a    b
-1    1
-2    2
-3    3
-4    4
+[unknown result because it is related to issue#5790]
 update t1 set a = 2 where a = 1;
-tae data: duplicate
+[unknown result because it is related to issue#5790]
 drop table if exists t1;
+[unknown result because it is related to issue#5790]
 create table t1(a int, b varchar(20), unique key(a, b));
+[unknown result because it is related to issue#5790]
 insert into t1 values(1, '2');
+[unknown result because it is related to issue#5790]
 insert into t1 values(1, '3');
+[unknown result because it is related to issue#5790]
 insert into t1 values(2, '2');
+[unknown result because it is related to issue#5790]
 insert into t1 values(2, '3');
+[unknown result because it is related to issue#5790]
 select * from t1;
-a    b
-1    2
-1    3
-2    2
-2    3
+[unknown result because it is related to issue#5790]
 update t1 set a = 2 where a = 1;
-tae data: duplicate
+[unknown result because it is related to issue#5790]
 update t1 set a = null where a = 1;
+[unknown result because it is related to issue#5790]
 drop table if exists t1;
 create table t1(a int, b int, c datetime on update CURRENT_TIMESTAMP);
 insert into t1(a) values(1);
 update t1 set a = 2 where a = 1;
 select c is not null from t1;
-c is not null
+➤ c is not null[-7,1,0]  𝄀
 1
 drop table if exists t1;
 create table t1 (a int primary key, b int);
 insert into t1 values (1,100);
 select b from t1 where a = 1 for update;
-b
+➤ b[4,32,0]  𝄀
 100
 drop database if exists db1;
 create database db1;
@@ -316,14 +336,17 @@ create database db2;
 use db2;
 insert into db1.t1 values (1,1);
 select * from db1.t1;
-a    b
-1    1
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1
 update db1.t1 set b = 2 where a = 1;
 select * from db1.t1;
-a    b
-1    2
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2
 delete from db1.t1;
 select * from db1.t1;
-a    b
+➤ a[4,32,0]  ¦  b[4,32,0]
+select count(*) from db1.t1;
+➤ count(*)[-5,64,0]  𝄀
+0
 drop database if exists db1;
 drop database if exists db2;

--- a/test/distributed/cases/dml/update/update.test
+++ b/test/distributed/cases/dml/update/update.test
@@ -47,6 +47,7 @@ create table t1 (a int, b int);
 insert into t1 values (1, 2), (3, 4), (5, 6);
 update t1 set a = 1 where a > 1;
 select * from t1;
+select count(*) from t1;
 
 drop table if exists t2;
 create table t2 (a int primary key, b int);
@@ -56,6 +57,7 @@ update t2 set a = 2 where a > 1;
 select * from t2;
 update t2 set a = b, b = a +1 where a > 1;
 select * from t2;
+select count(*) from t2;
 
 drop table if exists t3;
 create table t3 (a char(20));
@@ -63,6 +65,7 @@ insert into t3 values("hello"), ("world");
 select * from t3;
 update t3 set a = "modify";
 select * from t3;
+select count(*) from t3;
 
 drop table if exists t5;
 create table t5(a date);
@@ -118,6 +121,8 @@ insert into t2 values (1, 1), (2, 2);
 update t1 join t2 on t1.a = t2.a set t1.b = default, t2.a = default;
 select * from t1;
 select * from t2;
+select count(*) from t1;
+select count(*) from t2;
 
 drop table if exists t1;
 create table t1(a int auto_increment, b int auto_increment);
@@ -205,5 +210,6 @@ update db1.t1 set b = 2 where a = 1;
 select * from db1.t1;
 delete from db1.t1;
 select * from db1.t1;
+select count(*) from db1.t1;
 drop database if exists db1;
 drop database if exists db2;

--- a/test/distributed/cases/function/func_aggr_count.result
+++ b/test/distributed/cases/function/func_aggr_count.result
@@ -50,10 +50,24 @@ create table t1(a int);
 select count(*) from t1;
 ➤ count(*)[-5,64,0]  𝄀
 0
+explain analyze select count(*) from t1;
+-- @regex("(?s)Table Scan.*Aggregate Functions: starcount\(1\)", true)
+➤ tp query plan[12,-1,0]  𝄀
+Project  𝄀
+  Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=8 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=8 bytes (min=8 bytes, max=8 bytes)  𝄀
+  ->  Aggregate  𝄀
+        Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=0 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on func_aggr_count.t1  𝄀
+              Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=0 inputRows=0 outputRows=0 (min=0, max=0) InputSize=0 bytes OutputSize=0 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
+              Aggregate Functions: starcount(1)
 insert into t1 values(null),(null),(null),(null);
 select count(*) from t1;
 ➤ count(*)[-5,64,0]  𝄀
 4
+select count(a) from t1;
+➤ count(a)[-5,64,0]  𝄀
+0
 drop table t1;
 CREATE TABLE t1 (
 bug_id bigint(9) NOT NULL,
@@ -138,10 +152,10 @@ explain analyze select count(*) from t1;
 Project  𝄀
   Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=8 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=8 bytes (min=8 bytes, max=8 bytes)  𝄀
   ->  Aggregate  𝄀
-        Analyze: timeConsumed=0ms waitTime=0ms inputRows=4 outputRows=1 (min=1, max=1) InputSize=6 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
+        Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=0 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
         Aggregate Functions: starcount(1)  𝄀
         ->  Table Scan on func_aggr_count.t1  𝄀
-              Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=1 inputRows=3 outputRows=3 (min=3, max=3) InputSize=6 bytes OutputSize=6 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=12 bytes (min=12 bytes, max=12 bytes)  𝄀
+              Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=0 inputRows=0 outputRows=0 (min=0, max=0) InputSize=0 bytes OutputSize=0 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
               Aggregate Functions: starcount(1)
 explain analyze select count(a) from t1;
 -- @regex("(?s)Table Scan.*Aggregate Functions: starcount\(t1\.a\)", true)
@@ -149,10 +163,10 @@ explain analyze select count(a) from t1;
 Project  𝄀
   Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=8 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=8 bytes (min=8 bytes, max=8 bytes)  𝄀
   ->  Aggregate  𝄀
-        Analyze: timeConsumed=0ms waitTime=0ms inputRows=4 outputRows=1 (min=1, max=1) InputSize=6 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
+        Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=0 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
         Aggregate Functions: count(t1.a)  𝄀
         ->  Table Scan on func_aggr_count.t1  𝄀
-              Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=1 inputRows=3 outputRows=3 (min=3, max=3) InputSize=6 bytes OutputSize=6 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=12 bytes (min=12 bytes, max=12 bytes)  𝄀
+              Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=0 inputRows=0 outputRows=0 (min=0, max=0) InputSize=0 bytes OutputSize=0 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
               Aggregate Functions: starcount(t1.a)
 explain analyze select count(a) from t1 where a = 1;
 -- @regex("(?s)Table Scan.*Filter Cond", true)
@@ -228,10 +242,10 @@ explain analyze select count(*) from t1;
 Project  𝄀
   Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=8 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=8 bytes (min=8 bytes, max=8 bytes)  𝄀
   ->  Aggregate  𝄀
-        Analyze: timeConsumed=0ms waitTime=0ms inputRows=6 outputRows=1 (min=1, max=1) InputSize=20 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
+        Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=0 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
         Aggregate Functions: starcount(1)  𝄀
         ->  Table Scan on func_aggr_count.t1  𝄀
-              Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=1 inputRows=5 outputRows=5 (min=5, max=5) InputSize=20 bytes OutputSize=20 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=40 bytes (min=40 bytes, max=40 bytes)  𝄀
+              Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=0 inputRows=0 outputRows=0 (min=0, max=0) InputSize=0 bytes OutputSize=0 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
               Aggregate Functions: starcount(1)
 drop table t1;
 CREATE TABLE t1 (a INT, b INT);
@@ -465,7 +479,7 @@ SELECT COUNT(*) FROM t1;
 ➤ COUNT(*)[-5,64,0]  𝄀
 100000
 explain analyze SELECT COUNT(*) FROM t1;
--- @regex("(?s)Table Scan.*Aggregate Functions: starcount\(\*\)", true)
+-- @regex("(?s)Table Scan.*Aggregate Functions: starcount\(1\)", true)
 ➤ tp query plan[12,-1,0]  𝄀
 Project  𝄀
   Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=8 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=8 bytes (min=8 bytes, max=8 bytes)  𝄀

--- a/test/distributed/cases/function/func_aggr_count.test
+++ b/test/distributed/cases/function/func_aggr_count.test
@@ -35,8 +35,12 @@ drop table t1;
 #EXTREME VALUE
 create table t1(a int);
 select count(*) from t1;
+-- @regex("(?s)Table Scan.*Aggregate Functions: starcount\(1\)",true)
+explain analyze select count(*) from t1;
+
 insert into t1 values(null),(null),(null),(null);
 select count(*) from t1;
+select count(a) from t1;
 drop table t1;
 
 

--- a/test/distributed/cases/optimizer/blockfilter.result
+++ b/test/distributed/cases/optimizer/blockfilter.result
@@ -6,196 +6,218 @@ drop table if exists t2;
 create table t1(c2 int, c1 int, c3 int) cluster by (c1,c2);
 create table t2(c1 int, c2 int, c3 int, primary key(c1,c2));
 insert into t1 select result%100,result%10000, result from generate_series(100000) g;
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+100000
 insert into t2 select result%100,*,* from generate_series(1000000) g;
+select count(*) from t2;
+➤ count(*)[-5,64,0]  𝄀
+1000000
 select mo_ctl('dn', 'flush', 'd1.t1');
-mo_ctl(dn, flush, d1.t1)
-{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+➤ mo_ctl(dn, flush, d1.t1)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
 select mo_ctl('dn', 'flush', 'd1.t2');
-mo_ctl(dn, flush, d1.t2)
-{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+➤ mo_ctl(dn, flush, d1.t2)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
 select Sleep(1);
-Sleep(1)
+➤ Sleep(1)[-6,8,0]  𝄀
 0
 explain select count(*) from t1 where c1 = 1;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t1
-              Filter Cond: prefix_eq(t1.__mo_cbkey_002c1002c2)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t1  𝄀
+              Filter Cond: prefix_eq(t1.__mo_cbkey_002c1002c2)  𝄀
               Block Filter Cond: prefix_eq(t1.__mo_cbkey_002c1002c2)
 select count(*) from t1 where c1 = 1;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 10
 explain select count(*) from t1 where c1 > 10;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t1
-              Filter Cond: (t1.c1 > 10)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t1  𝄀
+              Filter Cond: (t1.c1 > 10)  𝄀
               Block Filter Cond: (t1.c1 > 10)
 select count(*) from t1 where c1 > 10;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 99890
 explain select count(*) from t1 where c1 in (1,2,3);
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t1
-              Filter Cond: prefix_in(t1.__mo_cbkey_002c1002c2)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t1  𝄀
+              Filter Cond: prefix_in(t1.__mo_cbkey_002c1002c2)  𝄀
               Block Filter Cond: prefix_in(t1.__mo_cbkey_002c1002c2)
 select count(*) from t1 where c1 in (1,2,3);
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 30
 explain select count(*) from t1 where c1 between 1 and 5;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t1
-              Filter Cond: prefix_between(t1.__mo_cbkey_002c1002c2)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t1  𝄀
+              Filter Cond: prefix_between(t1.__mo_cbkey_002c1002c2)  𝄀
               Block Filter Cond: prefix_between(t1.__mo_cbkey_002c1002c2)
 select count(*) from t1 where c1 between 1 and 5;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 50
 explain select count(*) from t1 where c1 = 2 and c2 = 10;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t1
-              Filter Cond: (t1.__mo_cbkey_002c1002c2 = )
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t1  𝄀
+              Filter Cond: (t1.__mo_cbkey_002c1002c2 = )  𝄀
               Block Filter Cond: (t1.__mo_cbkey_002c1002c2 = )
 select count(*) from t1 where c1 = 2 and c2 = 10;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 0
 explain select count(*) from t1 where c1 = 5 and c2 > 10;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t1
-              Filter Cond: prefix_eq(t1.__mo_cbkey_002c1002c2), (t1.c2 > 10)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t1  𝄀
+              Filter Cond: prefix_eq(t1.__mo_cbkey_002c1002c2), (t1.c2 > 10)  𝄀
               Block Filter Cond: prefix_eq(t1.__mo_cbkey_002c1002c2), (t1.c2 > 10)
 select count(*) from t1 where c1 = 5 and c2 > 10;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 0
 explain select count(*) from t1 where c1 = 3 and c2 in (1,2,3);
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t1
-              Filter Cond: t1.__mo_cbkey_002c1002c2 in ()
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t1  𝄀
+              Filter Cond: t1.__mo_cbkey_002c1002c2 in ()  𝄀
               Block Filter Cond: t1.__mo_cbkey_002c1002c2 in ()
 select count(*) from t1 where c1 = 3 and c2 in (1,2,3);
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 10
 explain select count(*) from t1 where c1=4 and c2 between 1 and 5;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t1
-              Filter Cond: t1.__mo_cbkey_002c1002c2 BETWEEN '::' AND '::'
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t1  𝄀
+              Filter Cond: t1.__mo_cbkey_002c1002c2 BETWEEN '::' AND '::'  𝄀
               Block Filter Cond: t1.__mo_cbkey_002c1002c2 BETWEEN '::' AND '::'
 select count(*) from t1 where c1=4 and c2 between 1 and 5;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 10
 explain select count(*) from t2 where c1 = 1;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t2
-              Filter Cond: prefix_eq(t2.__mo_cpkey_col)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t2  𝄀
+              Filter Cond: prefix_eq(t2.__mo_cpkey_col)  𝄀
               Block Filter Cond: prefix_eq(t2.__mo_cpkey_col)
 select count(*) from t2 where c1 = 1;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 10000
 explain select count(*) from t2 where c1 > 10;
-AP QUERY PLAN ON ONE CN(4 core)
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t2
-              Filter Cond: (t2.c1 > 10)
+➤ AP QUERY PLAN ON ONE CN(24 core)[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t2  𝄀
+              Filter Cond: (t2.c1 > 10)  𝄀
               Block Filter Cond: (t2.c1 > 10)
 select count(*) from t2 where c1 > 10;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 890000
 explain select count(*) from t2 where c1 in (1,2,3);
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t2
-              Filter Cond: prefix_in(t2.__mo_cpkey_col)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t2  𝄀
+              Filter Cond: prefix_in(t2.__mo_cpkey_col)  𝄀
               Block Filter Cond: prefix_in(t2.__mo_cpkey_col)
 select count(*) from t2 where c1 in (1,2,3);
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 30000
 explain select count(*) from t2 where c1 between 1 and 5;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t2
-              Filter Cond: prefix_between(t2.__mo_cpkey_col)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t2  𝄀
+              Filter Cond: prefix_between(t2.__mo_cpkey_col)  𝄀
               Block Filter Cond: prefix_between(t2.__mo_cpkey_col)
 select count(*) from t2 where c1 between 1 and 5;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 50000
 explain select count(*) from t2 where c1 = 2 and c2 = 10;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t2
-              Filter Cond: (t2.__mo_cpkey_col = )
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t2  𝄀
+              Filter Cond: (t2.__mo_cpkey_col = )  𝄀
               Block Filter Cond: (t2.__mo_cpkey_col = )
 select count(*) from t2 where c1 = 2 and c2 = 10;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 0
 explain select count(*) from t2 where c1 = 5 and c2 > 10;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t2
-              Filter Cond: prefix_eq(t2.__mo_cpkey_col), (t2.c2 > 10)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t2  𝄀
+              Filter Cond: prefix_eq(t2.__mo_cpkey_col), (t2.c2 > 10)  𝄀
               Block Filter Cond: prefix_eq(t2.__mo_cpkey_col), (t2.c2 > 10)
 select count(*) from t2 where c1 = 5 and c2 > 10;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 9999
 explain select count(*) from t2 where c1 = 3 and c2 in (1,2,3);
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t2
-              Filter Cond: t2.__mo_cpkey_col in ()
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t2  𝄀
+              Filter Cond: t2.__mo_cpkey_col in ()  𝄀
               Block Filter Cond: t2.__mo_cpkey_col in ()
 select count(*) from t2 where c1 = 3 and c2 in (1,2,3);
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 1
 explain select count(*) from t2 where c1=4 and c2 between 1 and 5;
-TP QUERY PLAN
-Project
-  ->  Aggregate
-        Aggregate Functions: starcount(1)
-        ->  Table Scan on d1.t2
-              Filter Cond: t2.__mo_cpkey_col BETWEEN '::' AND '::'
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t2  𝄀
+              Filter Cond: t2.__mo_cpkey_col BETWEEN '::' AND '::'  𝄀
               Block Filter Cond: t2.__mo_cpkey_col BETWEEN '::' AND '::'
 select count(*) from t2 where c1=4 and c2 between 1 and 5;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 1
 drop table if exists t1;
 create table t1 (a varchar(100) primary key, b int);
 insert into t1 select result, 2 from generate_series('2021-01-01 00:00:00','2022-01-01 00:00:00', '1 minute') g;
 select count(*) as ttl from t1 where a between "2021-02-02 20:00:00" and "2021-02-03 00:00:00";
-ttl
+➤ ttl[-5,64,0]  𝄀
 241
 drop database if exists d1;

--- a/test/distributed/cases/optimizer/blockfilter.test
+++ b/test/distributed/cases/optimizer/blockfilter.test
@@ -6,7 +6,11 @@ drop table if exists t2;
 create table t1(c2 int, c1 int, c3 int) cluster by (c1,c2);
 create table t2(c1 int, c2 int, c3 int, primary key(c1,c2));
 insert into t1 select result%100,result%10000, result from generate_series(100000) g;
+select count(*) from t1;
+
 insert into t2 select result%100,*,* from generate_series(1000000) g;
+select count(*) from t2;
+
 -- @separator:table
 select mo_ctl('dn', 'flush', 'd1.t1');
 -- @separator:table

--- a/test/distributed/cases/optimizer/group.result
+++ b/test/distributed/cases/optimizer/group.result
@@ -4,164 +4,176 @@ use d1;
 drop table if exists t1;
 create table t1(c1 bigint primary key, c2 varchar(64) not null);
 insert into t1 select result, result%10 from generate_series(1,100000)g;
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+100000
 select sum(c1),c2 from t1 group by c2 order by c2;
-sum(c1)    c2
-500050000    0
-499960000    1
-499970000    2
-499980000    3
-499990000    4
-500000000    5
-500010000    6
-500020000    7
-500030000    8
-500040000    9
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  𝄀
+500050000  ¦  0  𝄀
+499960000  ¦  1  𝄀
+499970000  ¦  2  𝄀
+499980000  ¦  3  𝄀
+499990000  ¦  4  𝄀
+500000000  ¦  5  𝄀
+500010000  ¦  6  𝄀
+500020000  ¦  7  𝄀
+500030000  ¦  8  𝄀
+500040000  ¦  9
 delete from t1 where c2=1;
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+90000
 insert into t1 select result, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' from generate_series(100001,200000)g;
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+190000
 insert into t1 select result, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' from generate_series(200001,300000)g;
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+290000
 select sum(c1),c2 from t1 group by c2 order by c2;
-sum(c1)    c2
-500050000    0
-499970000    2
-499980000    3
-499990000    4
-500000000    5
-500010000    6
-500020000    7
-500030000    8
-500040000    9
-15000050000    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-25000050000    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  𝄀
+500050000  ¦  0  𝄀
+499970000  ¦  2  𝄀
+499980000  ¦  3  𝄀
+499990000  ¦  4  𝄀
+500000000  ¦  5  𝄀
+500010000  ¦  6  𝄀
+500020000  ¦  7  𝄀
+500030000  ¦  8  𝄀
+500040000  ¦  9  𝄀
+15000050000  ¦  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  𝄀
+25000050000  ¦  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 drop table if exists t1;
 create table t1(c1 bigint, c2 varchar(64)) cluster by c1;
 insert into t1 select result, result%5 from generate_series(1,100000)g;
 select sum(c1),c2 from t1 group by c2 order by c2;
-sum(c1)    c2
-1000050000    0
-999970000    1
-999990000    2
-1000010000    3
-1000030000    4
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  𝄀
+1000050000  ¦  0  𝄀
+999970000  ¦  1  𝄀
+999990000  ¦  2  𝄀
+1000010000  ¦  3  𝄀
+1000030000  ¦  4
 insert into t1 select result, null from generate_series(1,100000)g;
 select sum(c1),c2 from t1 group by c2 order by c2;
-sum(c1)    c2
-5000050000    null
-1000050000    0
-999970000    1
-999990000    2
-1000010000    3
-1000030000    4
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  𝄀
+5000050000  ¦  null  𝄀
+1000050000  ¦  0  𝄀
+999970000  ¦  1  𝄀
+999990000  ¦  2  𝄀
+1000010000  ¦  3  𝄀
+1000030000  ¦  4
 delete from t1 where c2=1;
 select sum(c1),c2 from t1 group by c2 order by c2;
-sum(c1)    c2
-5000050000    null
-1000050000    0
-999990000    2
-1000010000    3
-1000030000    4
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  𝄀
+5000050000  ¦  null  𝄀
+1000050000  ¦  0  𝄀
+999990000  ¦  2  𝄀
+1000010000  ¦  3  𝄀
+1000030000  ¦  4
 insert into t1 select result, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' from generate_series(100001,200000)g;
 insert into t1 select result, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' from generate_series(200001,300000)g;
 select sum(c1),c2 from t1 group by c2 order by c2;
-sum(c1)    c2
-5000050000    null
-1000050000    0
-999990000    2
-1000010000    3
-1000030000    4
-15000050000    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-25000050000    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  𝄀
+5000050000  ¦  null  𝄀
+1000050000  ¦  0  𝄀
+999990000  ¦  2  𝄀
+1000010000  ¦  3  𝄀
+1000030000  ¦  4  𝄀
+15000050000  ¦  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  𝄀
+25000050000  ¦  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 drop table if exists t1;
 create table t1(c1 bigint primary key, c2 varchar(64) not null, c3 varchar(64) not null);
 insert into t1 select result, result%3, result %4 from generate_series(1,100000)g;
 select sum(c1),c2,c3 from t1 group by c2,c3 order by c2,c3;
-sum(c1)    c2    c3
-416683332    0    0
-416658333    0    1
-416633334    0    2
-416708334    0    3
-416716668    1    0
-416691666    1    1
-416666666    1    2
-416641667    1    3
-416650000    2    0
-416625001    2    1
-416700000    2    2
-416674999    2    3
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  ¦  c3[12,-1,0]  𝄀
+416683332  ¦  0  ¦  0  𝄀
+416658333  ¦  0  ¦  1  𝄀
+416633334  ¦  0  ¦  2  𝄀
+416708334  ¦  0  ¦  3  𝄀
+416716668  ¦  1  ¦  0  𝄀
+416691666  ¦  1  ¦  1  𝄀
+416666666  ¦  1  ¦  2  𝄀
+416641667  ¦  1  ¦  3  𝄀
+416650000  ¦  2  ¦  0  𝄀
+416625001  ¦  2  ¦  1  𝄀
+416700000  ¦  2  ¦  2  𝄀
+416674999  ¦  2  ¦  3
 delete from t1 where c2=1;
 insert into t1 select result, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','a' from generate_series(100001,200000)g;
 insert into t1 select result, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','b' from generate_series(200001,300000)g;
 select sum(c1),c2,c3 from t1 group by c2,c3 order by c2,c3;
-sum(c1)    c2    c3
-416683332    0    0
-416658333    0    1
-416633334    0    2
-416708334    0    3
-416650000    2    0
-416625001    2    1
-416700000    2    2
-416674999    2    3
-15000050000    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa    a
-25000050000    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb    b
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  ¦  c3[12,-1,0]  𝄀
+416683332  ¦  0  ¦  0  𝄀
+416658333  ¦  0  ¦  1  𝄀
+416633334  ¦  0  ¦  2  𝄀
+416708334  ¦  0  ¦  3  𝄀
+416650000  ¦  2  ¦  0  𝄀
+416625001  ¦  2  ¦  1  𝄀
+416700000  ¦  2  ¦  2  𝄀
+416674999  ¦  2  ¦  3  𝄀
+15000050000  ¦  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  ¦  a  𝄀
+25000050000  ¦  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  ¦  b
 drop table if exists t1;
 create table t1(c1 bigint, c2 varchar(64), c3 varchar(64)) cluster by c1;
 insert into t1 select result, result%4, result%3 from generate_series(1,100000)g;
 select sum(c1),c2,c3 from t1 group by c2,c3 order by c2,c3;
-sum(c1)    c2    c3
-416683332    0    0
-416716668    0    1
-416650000    0    2
-416658333    1    0
-416691666    1    1
-416625001    1    2
-416633334    2    0
-416666666    2    1
-416700000    2    2
-416708334    3    0
-416641667    3    1
-416674999    3    2
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  ¦  c3[12,-1,0]  𝄀
+416683332  ¦  0  ¦  0  𝄀
+416716668  ¦  0  ¦  1  𝄀
+416650000  ¦  0  ¦  2  𝄀
+416658333  ¦  1  ¦  0  𝄀
+416691666  ¦  1  ¦  1  𝄀
+416625001  ¦  1  ¦  2  𝄀
+416633334  ¦  2  ¦  0  𝄀
+416666666  ¦  2  ¦  1  𝄀
+416700000  ¦  2  ¦  2  𝄀
+416708334  ¦  3  ¦  0  𝄀
+416641667  ¦  3  ¦  1  𝄀
+416674999  ¦  3  ¦  2
 insert into t1 select result, null, null from generate_series(1,100000)g;
 select sum(c1),c2,c3 from t1 group by c2,c3 order by c2,c3;
-sum(c1)    c2    c3
-5000050000    null    null
-416683332    0    0
-416716668    0    1
-416650000    0    2
-416658333    1    0
-416691666    1    1
-416625001    1    2
-416633334    2    0
-416666666    2    1
-416700000    2    2
-416708334    3    0
-416641667    3    1
-416674999    3    2
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  ¦  c3[12,-1,0]  𝄀
+5000050000  ¦  null  ¦  null  𝄀
+416683332  ¦  0  ¦  0  𝄀
+416716668  ¦  0  ¦  1  𝄀
+416650000  ¦  0  ¦  2  𝄀
+416658333  ¦  1  ¦  0  𝄀
+416691666  ¦  1  ¦  1  𝄀
+416625001  ¦  1  ¦  2  𝄀
+416633334  ¦  2  ¦  0  𝄀
+416666666  ¦  2  ¦  1  𝄀
+416700000  ¦  2  ¦  2  𝄀
+416708334  ¦  3  ¦  0  𝄀
+416641667  ¦  3  ¦  1  𝄀
+416674999  ¦  3  ¦  2
 delete from t1 where c2=1;
 select sum(c1),c2,c3 from t1 group by c2,c3 order by c2,c3;
-sum(c1)    c2    c3
-5000050000    null    null
-416683332    0    0
-416716668    0    1
-416650000    0    2
-416633334    2    0
-416666666    2    1
-416700000    2    2
-416708334    3    0
-416641667    3    1
-416674999    3    2
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  ¦  c3[12,-1,0]  𝄀
+5000050000  ¦  null  ¦  null  𝄀
+416683332  ¦  0  ¦  0  𝄀
+416716668  ¦  0  ¦  1  𝄀
+416650000  ¦  0  ¦  2  𝄀
+416633334  ¦  2  ¦  0  𝄀
+416666666  ¦  2  ¦  1  𝄀
+416700000  ¦  2  ¦  2  𝄀
+416708334  ¦  3  ¦  0  𝄀
+416641667  ¦  3  ¦  1  𝄀
+416674999  ¦  3  ¦  2
 insert into t1 select result, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','a' from generate_series(100001,200000)g;
 insert into t1 select result, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb','b' from generate_series(200001,300000)g;
 select sum(c1),c2,c3 from t1 group by c2,c3 order by c2,c3;
-sum(c1)    c2    c3
-5000050000    null    null
-416683332    0    0
-416716668    0    1
-416650000    0    2
-416633334    2    0
-416666666    2    1
-416700000    2    2
-416708334    3    0
-416641667    3    1
-416674999    3    2
-15000050000    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa    a
-25000050000    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb    b
+➤ sum(c1)[-5,64,0]  ¦  c2[12,-1,0]  ¦  c3[12,-1,0]  𝄀
+5000050000  ¦  null  ¦  null  𝄀
+416683332  ¦  0  ¦  0  𝄀
+416716668  ¦  0  ¦  1  𝄀
+416650000  ¦  0  ¦  2  𝄀
+416633334  ¦  2  ¦  0  𝄀
+416666666  ¦  2  ¦  1  𝄀
+416700000  ¦  2  ¦  2  𝄀
+416708334  ¦  3  ¦  0  𝄀
+416641667  ¦  3  ¦  1  𝄀
+416674999  ¦  3  ¦  2  𝄀
+15000050000  ¦  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  ¦  a  𝄀
+25000050000  ¦  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  ¦  b
 drop database if exists d1;

--- a/test/distributed/cases/optimizer/group.test
+++ b/test/distributed/cases/optimizer/group.test
@@ -4,10 +4,18 @@ use d1;
 drop table if exists t1;
 create table t1(c1 bigint primary key, c2 varchar(64) not null);
 insert into t1 select result, result%10 from generate_series(1,100000)g;
+select count(*) from t1;
+
 select sum(c1),c2 from t1 group by c2 order by c2;
 delete from t1 where c2=1;
+select count(*) from t1;
+
 insert into t1 select result, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' from generate_series(100001,200000)g;
+select count(*) from t1;
+
 insert into t1 select result, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' from generate_series(200001,300000)g;
+select count(*) from t1;
+
 select sum(c1),c2 from t1 group by c2 order by c2;
 drop table if exists t1;
 create table t1(c1 bigint, c2 varchar(64)) cluster by c1;

--- a/test/distributed/cases/optimizer/index.result
+++ b/test/distributed/cases/optimizer/index.result
@@ -10,171 +10,187 @@ create table t2(c0 int, c1 int , c2 int, c3 int, primary key(c0,c1),key(c2), uni
 insert into t2 select *,*,*,* from generate_series(1,100000) g;
 insert into t2 select *,*,1111,* from generate_series(100001,150000) g;
 select mo_ctl('dn', 'flush', 'd1.t1');
-mo_ctl(dn, flush, d1.t1)
-{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+➤ mo_ctl(dn, flush, d1.t1)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
 select mo_ctl('dn', 'flush', 'd1.t2');
-mo_ctl(dn, flush, d1.t2)
-{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+➤ mo_ctl(dn, flush, d1.t2)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
 select Sleep(1);
-Sleep(1)
+➤ Sleep(1)[-6,8,0]  𝄀
 0
 explain select * from t1,t2 where t1.c1=t2.c0 and t1.c3=11;
-TP QUERY PLAN
-Project
-  ->  Join
-        Join Type: INNER   hashOnPK
-        Join Cond: (t2.c0 = t1.c1)
-        Runtime Filter Build: serial(#[-1,0])
-        ->  Table Scan on d1.t2
-              Runtime Filter Probe: t2.__mo_cpkey_col Match Prefix
-        ->  Join
-              Join Type: INDEX
-              Join Cond: (t1.c1 = __mo_index_pri_col)
-              Runtime Filter Build: #[-1,0]
-              ->  Table Scan on d1.t1 [ForceOneCN]
-                    Filter Cond: (t1.c3 = 11)
-                    Block Filter Cond: (t1.c3 = 11)
-                    Runtime Filter Probe: t1.c1
-              ->  Index Table Scan on t1.id1 [ForceOneCN]
-                    Filter Cond: (__mo_index_idx_col = 11)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Join  𝄀
+        Join Type: INNER   hashOnPK  𝄀
+        Join Cond: (t2.c0 = t1.c1)  𝄀
+        Runtime Filter Build: serial(#[-1,0])  𝄀
+        ->  Table Scan on d1.t2  𝄀
+              Runtime Filter Probe: t2.__mo_cpkey_col Match Prefix  𝄀
+        ->  Join  𝄀
+              Join Type: INDEX  𝄀
+              Join Cond: (t1.c1 = __mo_index_pri_col)  𝄀
+              Runtime Filter Build: #[-1,0]  𝄀
+              ->  Table Scan on d1.t1 [ForceOneCN]  𝄀
+                    Filter Cond: (t1.c3 = 11)  𝄀
+                    Block Filter Cond: (t1.c3 = 11)  𝄀
+                    Runtime Filter Probe: t1.c1  𝄀
+              ->  Index Table Scan on t1.id1 [ForceOneCN]  𝄀
+                    Filter Cond: (__mo_index_idx_col = 11)  𝄀
                     Block Filter Cond: (__mo_index_idx_col = 11)
 select * from t1,t2 where t1.c1=t2.c0 and t1.c3=11;
-c1    c2    c3    c0    c1    c2    c3
-11    11    11    11    11    11    11
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  ¦  c0[4,32,0]  ¦  c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+11  ¦  11  ¦  11  ¦  11  ¦  11  ¦  11  ¦  11
 select * from t1 where c2=1;
-c1    c2    c3
-1    1    1
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1  ¦  1  ¦  1
 select count(c3) from t1 where c2=1111;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 50001
 select * from t1 where c3=1234;
-c1    c2    c3
-1234    1234    1234
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1234  ¦  1234  ¦  1234
 select * from t1 where c3=5678;
-c1    c2    c3
-5678    5678    5678
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+5678  ¦  5678  ¦  5678
 select * from t1 where c2 between 1 and 3;
-c1    c2    c3
-1    1    1
-2    2    2
-3    3    3
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1  ¦  1  ¦  1  𝄀
+2  ¦  2  ¦  2  𝄀
+3  ¦  3  ¦  3
 select * from t1 where c3 between 2 and 10;
-c1    c2    c3
-2    2    2
-3    3    3
-4    4    4
-5    5    5
-6    6    6
-7    7    7
-8    8    8
-9    9    9
-10    10    10
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+2  ¦  2  ¦  2  𝄀
+3  ¦  3  ¦  3  𝄀
+4  ¦  4  ¦  4  𝄀
+5  ¦  5  ¦  5  𝄀
+6  ¦  6  ¦  6  𝄀
+7  ¦  7  ¦  7  𝄀
+8  ¦  8  ¦  8  𝄀
+9  ¦  9  ¦  9  𝄀
+10  ¦  10  ¦  10
 select count(c3) from t1 where c2 between 1000 and 1100;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 101
 select count(c3) from t1 where c2 between 1000 and 1200;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 50201
 select count(c3) from t1 where c2 between 1000 and 2000;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 51001
 select count(c3) from t1 where c2 between 1000 and 3000;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 52001
 select count(c3) from t1 where c3 between 1000 and 1100;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 101
 select count(c3) from t1 where c2 between 1000 and 2000;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 51001
 select * from t1 where c2 in (1);
-c1    c2    c3
-1    1    1
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1  ¦  1  ¦  1
 select * from t1 where c2 in (1,1000,2000);
-c1    c2    c3
-1    1    1
-1000    1000    1000
-2000    2000    2000
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1  ¦  1  ¦  1  𝄀
+1000  ¦  1000  ¦  1000  𝄀
+2000  ¦  2000  ¦  2000
 select count(c3) from t1 where c2 in (1,1000,1111,2000);
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 50004
 select * from t2 where c2=1;
-c0    c1    c2    c3
-1    1    1    1
+➤ c0[4,32,0]  ¦  c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1  ¦  1  ¦  1  ¦  1
 select count(c3) from t2 where c2=1111;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 50001
 select * from t2 where c3=1234;
-c0    c1    c2    c3
-1234    1234    1234    1234
+➤ c0[4,32,0]  ¦  c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1234  ¦  1234  ¦  1234  ¦  1234
 select * from t2 where c3=5678;
-c0    c1    c2    c3
-5678    5678    5678    5678
+➤ c0[4,32,0]  ¦  c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+5678  ¦  5678  ¦  5678  ¦  5678
 select * from t2 where c2 between 1 and 3;
-c0    c1    c2    c3
-1    1    1    1
-2    2    2    2
-3    3    3    3
+➤ c0[4,32,0]  ¦  c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1  ¦  1  ¦  1  ¦  1  𝄀
+2  ¦  2  ¦  2  ¦  2  𝄀
+3  ¦  3  ¦  3  ¦  3
 select * from t2 where c3 between 2 and 10;
-c0    c1    c2    c3
-2    2    2    2
-3    3    3    3
-4    4    4    4
-5    5    5    5
-6    6    6    6
-7    7    7    7
-8    8    8    8
-9    9    9    9
-10    10    10    10
+➤ c0[4,32,0]  ¦  c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+2  ¦  2  ¦  2  ¦  2  𝄀
+3  ¦  3  ¦  3  ¦  3  𝄀
+4  ¦  4  ¦  4  ¦  4  𝄀
+5  ¦  5  ¦  5  ¦  5  𝄀
+6  ¦  6  ¦  6  ¦  6  𝄀
+7  ¦  7  ¦  7  ¦  7  𝄀
+8  ¦  8  ¦  8  ¦  8  𝄀
+9  ¦  9  ¦  9  ¦  9  𝄀
+10  ¦  10  ¦  10  ¦  10
 select count(c3) from t2 where c2 between 1000 and 1100;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 101
 select count(c3) from t2 where c2 between 1000 and 1200;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 50201
 select count(c3) from t2 where c2 between 1000 and 2000;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 51001
 select count(c3) from t2 where c2 between 1000 and 3000;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 52001
 select count(c3) from t2 where c3 between 1000 and 1100;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 101
 select count(c3) from t2 where c2 between 1000 and 2000;
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 51001
 select * from t2 where c2 in (1);
-c0    c1    c2    c3
-1    1    1    1
+➤ c0[4,32,0]  ¦  c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1  ¦  1  ¦  1  ¦  1
 select * from t2 where c2 in (1,1000,2000);
-c0    c1    c2    c3
-1    1    1    1
-1000    1000    1000    1000
-2000    2000    2000    2000
+➤ c0[4,32,0]  ¦  c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1  ¦  1  ¦  1  ¦  1  𝄀
+1000  ¦  1000  ¦  1000  ¦  1000  𝄀
+2000  ¦  2000  ¦  2000  ¦  2000
 select count(c3) from t2 where c2 in (1,1000,1111,2000);
-count(c3)
+➤ count(c3)[-5,64,0]  𝄀
 50004
 select c3,c2 from t1 where c2=1111 order by c3 limit 10;
-c3    c2
-1111    1111
-100001    1111
-100002    1111
-100003    1111
-100004    1111
-100005    1111
-100006    1111
-100007    1111
-100008    1111
-100009    1111
+➤ c3[4,32,0]  ¦  c2[4,32,0]  𝄀
+1111  ¦  1111  𝄀
+100001  ¦  1111  𝄀
+100002  ¦  1111  𝄀
+100003  ¦  1111  𝄀
+100004  ¦  1111  𝄀
+100005  ¦  1111  𝄀
+100006  ¦  1111  𝄀
+100007  ¦  1111  𝄀
+100008  ¦  1111  𝄀
+100009  ¦  1111
 select * from t1 where c2=-1;
-c1    c2    c3
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]
 insert into t1 values(-1,-1,-1);
 select * from t1 where c2=-1;
-c1    c2    c3
--1    -1    -1
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+-1  ¦  -1  ¦  -1
 select * from t1 where c2=-2;
-c1    c2    c3
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]
 drop table if exists t1;
 create table t1(a varchar(30), b varchar(30), c varchar(30));
 create index idx1 using master on t1(a,b,c);
@@ -182,43 +198,59 @@ insert into t1 values("Congress","Lane", "1");
 insert into t1 values("Juniper","Way", "2");
 insert into t1 values("Nightingale","Lane", "3");
 select * from t1 where a in ("Congress","Nightingale") and b="Lane" and c in("1","2","3");
-a    b    c
-Congress    Lane    1
-Nightingale    Lane    3
+➤ a[12,-1,0]  ¦  b[12,-1,0]  ¦  c[12,-1,0]  𝄀
+Congress  ¦  Lane  ¦  1  𝄀
+Nightingale  ¦  Lane  ¦  3
 drop table if exists t1;
 create table t1(a int primary key, b int unique key);
 insert into t1 select result, result from generate_series(1,10000)g;
 select mo_ctl('dn','flush','d1.t1');
-mo_ctl(dn, flush, d1.t1)
-{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+➤ mo_ctl(dn, flush, d1.t1)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
 select * from t1 where b in (1,2) for update;
-a    b
-1    1
-2    2
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1  𝄀
+2  ¦  2
 create view v1 as select (case when a in (1,2,3) then 'y' else 'n' end) as a from t1;
 select count(a) from v1;
-count(a)
+➤ count(a)[-5,64,0]  𝄀
 10000
 drop table t1;
 create table t1(a int unsigned, b int, c varchar, primary key(a, c));
 select a from t1 where a = current_account_id() or (a = 0 and c in ('mo_catalog'));
-a
+➤ a[4,32,0]
 drop table if exists t1;
 create table t1(c1 int , c2 int, c3 int, key(c2), unique key id1(c3)) cluster by c1;
 insert into t1 select *,*,* from generate_series(1,100000)g;
 select mo_ctl('dn','flush','d1.t1');
-mo_ctl(dn, flush, d1.t1)
-{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+➤ mo_ctl(dn, flush, d1.t1)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
 select * from t1 where c2=1;
-c1    c2    c3
-1    1    1
+➤ c1[4,32,0]  ¦  c2[4,32,0]  ¦  c3[4,32,0]  𝄀
+1  ¦  1  ¦  1
 explain select * from t1 where c3<2000;
-TP QUERY PLAN
-Project
-  ->  Table Scan on d1.t1
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Table Scan on d1.t1  𝄀
         Filter Cond: (t1.c3 < 2000)
 select count(*) from t1 where c3<2000;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 1999
 drop table if exists t1;
 drop database if exists d1;
@@ -227,8 +259,28 @@ use d1;
 create table t1(c1 int primary key, c2 int, c3 int, key(c2), unique key id1(c3));
 insert into t1 select *,*,* from generate_series(1,100000) g;
 insert into t1 select *,1111,* from generate_series(100001,150000) g;
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+150000
 update t1 set c1=c1+1000000, c2=1,c3=c3-1000000 where c2=1;
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+150001
 delete from t1;
+select count(*) from t1;
+➤ count(*)[-5,64,0]  𝄀
+0
+explain analyze select count(*) from t1;
+-- @regex("(?s)Table Scan.*Aggregate Functions: starcount\(1\)", true)
+➤ tp query plan[12,-1,0]  𝄀
+Project  𝄀
+  Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=8 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=8 bytes (min=8 bytes, max=8 bytes)  𝄀
+  ->  Aggregate  𝄀
+        Analyze: timeConsumed=0ms waitTime=0ms inputRows=1 outputRows=1 (min=1, max=1) InputSize=0 bytes OutputSize=8 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Table Scan on d1.t1  𝄀
+              Analyze: timeConsumed=0ms waitTime=0ms inputBlocks=0 inputRows=0 outputRows=0 (min=0, max=0) InputSize=0 bytes OutputSize=0 bytes ReadSize=0 bytes|0 bytes|0 bytes MemorySize=0 bytes (min=0 bytes, max=0 bytes)  𝄀
+              Aggregate Functions: starcount(1)
 drop table t1;
 drop database d1;
 drop database if exists d1;
@@ -253,20 +305,20 @@ drop table t1;
 create table t1 (a timestamp, b varchar(10), key(b));
 insert into t1 select "2024-01-01 10:10:10", "a"||result from generate_series(1,200000)g;
 select * from t1 where a >= "2020-01-01 10:10:10" and a <= "2034-01-01 10:10:10" and b in ("a1");
-a    b
-2024-01-01 10:10:10    a1
+➤ a[93,64,0]  ¦  b[12,-1,0]  𝄀
+2024-01-01 10:10:10  ¦  a1
 drop table if exists t14;
 CREATE TABLE t14 (`pseudo` char(35) NOT NULL default '',`pseudo1` char(35) NOT NULL default '',
 `same` tinyint(1) unsigned NOT NULL default '1',PRIMARY KEY  (`pseudo1`),KEY `pseudo` (`pseudo`));
 INSERT INTO t14 (pseudo,pseudo1,same) VALUES ('joce', 'testtt', 1),('joce', 'tsestset', 1),('dekad', 'joce', 1);
 explain SELECT pseudo1 FROM t14 WHERE pseudo='joce';
-TP QUERY PLAN
-Project
-  ->  Index Table Scan on t14.pseudo
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Index Table Scan on t14.pseudo  𝄀
         Filter Cond: prefix_eq(__mo_index_idx_col)
 SELECT pseudo1 FROM t14 WHERE pseudo='joce';
-pseudo1
-testtt
+➤ pseudo1[1,35,0]  𝄀
+testtt  𝄀
 tsestset
 drop table t1;
 create table t1(a bigint, b bigint default null, c int, primary key(a), key(b));
@@ -275,15 +327,15 @@ delete from t1 where b = 1;
 drop table t1;
 create table t1(c1 int, c2 int, c3 int, key(c1));
 explain select * from t1 where c1=1;
-TP QUERY PLAN
-Project
-  ->  Join
-        Join Type: INDEX
-        Join Cond: (t1.__mo_fake_pk_col = __mo_index_pri_col)
-        Runtime Filter Build: #[-1,0]
-        ->  Table Scan on d1.t1 [ForceOneCN]
-              Filter Cond: (t1.c1 = 1)
-              Runtime Filter Probe: t1.__mo_fake_pk_col
-        ->  Index Table Scan on t1.c1 [ForceOneCN]
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Join  𝄀
+        Join Type: INDEX  𝄀
+        Join Cond: (t1.__mo_fake_pk_col = __mo_index_pri_col)  𝄀
+        Runtime Filter Build: #[-1,0]  𝄀
+        ->  Table Scan on d1.t1 [ForceOneCN]  𝄀
+              Filter Cond: (t1.c1 = 1)  𝄀
+              Runtime Filter Probe: t1.__mo_fake_pk_col  𝄀
+        ->  Index Table Scan on t1.c1 [ForceOneCN]  𝄀
               Filter Cond: prefix_eq(__mo_index_idx_col)
 drop database d1;

--- a/test/distributed/cases/optimizer/index.test
+++ b/test/distributed/cases/optimizer/index.test
@@ -87,8 +87,16 @@ use d1;
 create table t1(c1 int primary key, c2 int, c3 int, key(c2), unique key id1(c3));
 insert into t1 select *,*,* from generate_series(1,100000) g;
 insert into t1 select *,1111,* from generate_series(100001,150000) g;
+select count(*) from t1;
+
 update t1 set c1=c1+1000000, c2=1,c3=c3-1000000 where c2=1;
+select count(*) from t1;
+
 delete from t1;
+select count(*) from t1;
+-- @regex("(?s)Table Scan.*Aggregate Functions: starcount\(1\)",true)
+explain analyze select count(*) from t1;
+
 drop table t1;
 drop database d1;
 drop database if exists d1;

--- a/test/distributed/cases/pessimistic_transaction/insert.result
+++ b/test/distributed/cases/pessimistic_transaction/insert.result
@@ -5,25 +5,25 @@ insert into names(id, name, age) values(2,"Bob", 25);
 insert into names(id, name, age) values(3,"Carol", 23);
 insert into names(id, name, age) values(4,"Dora", 29);
 select id,name,age from names;
-id    name    age
-1    Abby    24
-2    Bob    25
-3    Carol    23
-4    Dora    29
+➤ id[4,32,0]  ¦  name[12,-1,0]  ¦  age[4,32,0]  𝄀
+1  ¦  Abby  ¦  24  𝄀
+2  ¦  Bob  ¦  25  𝄀
+3  ¦  Carol  ¦  23  𝄀
+4  ¦  Dora  ¦  29
 drop table if exists weights;
 create table weights(a int unique);
 insert into weights values(1);
 select * from weights;
-a
+➤ a[4,32,0]  𝄀
 1
 drop table if exists test;
 create table test(id int primary key, name varchar(10), age int);
 insert into test values(1, 'Abby', 20);
 insert into test values(2, 'Bob', 21);
 select id,name,age from test;
-id    name    age
-1    Abby    20
-2    Bob    21
+➤ id[4,32,0]  ¦  name[12,-1,0]  ¦  age[4,32,0]  𝄀
+1  ¦  Abby  ¦  20  𝄀
+2  ¦  Bob  ¦  21
 drop table if exists pet;
 create table pet(name char(10),owner char(10), species char(10), gender char(1), weight float,age int);
 insert into pet values ('Sunsweet01','Dsant01','otter','f',30.11,2),
@@ -31,53 +31,53 @@ insert into pet values ('Sunsweet01','Dsant01','otter','f',30.11,2),
 insert into pet(name, owner, species, gender, weight, age) values ('Sunsweet03','Dsant01','otter','f',30.11,2),
 ('Sunsweet04','Dsant02','otter','m',30.11,3);
 select * from pet;
-name    owner    species    gender    weight    age
-Sunsweet01    Dsant01    otter    f    30.11    2
-Sunsweet02    Dsant02    otter    m    30.11    3
-Sunsweet03    Dsant01    otter    f    30.11    2
-Sunsweet04    Dsant02    otter    m    30.11    3
+➤ name[1,10,0]  ¦  owner[1,10,0]  ¦  species[1,10,0]  ¦  gender[1,1,0]  ¦  weight[7,24,0]  ¦  age[4,32,0]  𝄀
+Sunsweet01  ¦  Dsant01  ¦  otter  ¦  f  ¦  30.11  ¦  2  𝄀
+Sunsweet02  ¦  Dsant02  ¦  otter  ¦  m  ¦  30.11  ¦  3  𝄀
+Sunsweet03  ¦  Dsant01  ¦  otter  ¦  f  ¦  30.11  ¦  2  𝄀
+Sunsweet04  ¦  Dsant02  ¦  otter  ¦  m  ¦  30.11  ¦  3
 drop table if exists t1;
 create table t1 (a bigint unsigned not null, primary key(a));
 insert into t1 values (18446744073709551615), (0xFFFFFFFFFFFFFFFE), (18446744073709551613), (18446744073709551612);
 select * from t1;
-a
-18446744073709551615
-18446744073709551614
-18446744073709551613
+➤ a[-5,64,0]  𝄀
+18446744073709551615  𝄀
+18446744073709551614  𝄀
+18446744073709551613  𝄀
 18446744073709551612
 drop table if exists t1;
 create table t1(a int, b int);
 insert into t1 values(), ();
 select * from t1;
-a    b
-null    null
-null    null
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+null  ¦  null  𝄀
+null  ¦  null
 drop table if exists t1;
 create table t1(a int default (1+12), b int);
 insert into t1(b) values(1), (1);
 select * from t1;
-a    b
-13    1
-13    1
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+13  ¦  1  𝄀
+13  ¦  1
 drop table if exists t1;
 create table t1(a int primary key default (1+12));
 insert into t1 values();
 select * from t1;
-a
+➤ a[4,32,0]  𝄀
 13
 drop table if exists t1;
 create table t1(a int, b int);
 insert into t1(a) values(1), (2);
 select * from t1;
-a    b
-1    null
-2    null
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  null  𝄀
+2  ¦  null
 drop table if exists t1;
 create table t1 (a int);
 insert into t1 values (1+2), (2*2);
 select * from t1;
-a
-3
+➤ a[4,32,0]  𝄀
+3  𝄀
 4
 drop table if exists t1;
 create table t1 (a datetime default now());
@@ -87,59 +87,59 @@ drop table if exists t1;
 create table t1 (a int);
 insert into t1 values(1+2*3), (666/2);
 select * from t1;
-a
-7
+➤ a[4,32,0]  𝄀
+7  𝄀
 333
 drop table if exists t;
 CREATE TABLE t (i1 INT, d1 DOUBLE, e2 DECIMAL(5,2));
 INSERT INTO t VALUES ( 6, 6.0, 10.0/3), ( null, 9.0, 10.0/3), ( 1, null, 10.0/3), ( 2, 2.0, null );
 select * from t;
-i1    d1    e2
-6    6.0    3.33
-null    9.0    3.33
-1    null    3.33
-2    2.0    null
+➤ i1[4,32,0]  ¦  d1[8,54,0]  ¦  e2[3,5,2]  𝄀
+6  ¦  6.0  ¦  3.33  𝄀
+null  ¦  9.0  ¦  3.33  𝄀
+1  ¦  null  ¦  3.33  𝄀
+2  ¦  2.0  ¦  null
 drop table if exists t1;
 create table t1 (a date);
 insert into t1 values(DATE("2017-06-15 09:34:21")),(DATE("2019-06-25 10:12:21")),(DATE("2019-06-25 18:20:49"));
 select * from t1;
-a
-2017-06-15
-2019-06-25
+➤ a[91,64,0]  𝄀
+2017-06-15  𝄀
+2019-06-25  𝄀
 2019-06-25
 drop table if exists t1;
 create table t1 (a date default DATE("2017-06-15 09:34:21"));
 insert into t1 (a) values (default), (default), (default);
 select * from t1;
-a
-2017-06-15
-2017-06-15
+➤ a[91,64,0]  𝄀
+2017-06-15  𝄀
+2017-06-15  𝄀
 2017-06-15
 drop table if exists t1;
 create table t1(a int auto_increment, b int);
 insert into t1 values(null, 2), (3, null), (null, null);
 select * from t1;
-a    b
-1    2
-3    null
-4    null
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2  𝄀
+3  ¦  null  𝄀
+4  ¦  null
 drop table if exists t1;
 create table t1(a int auto_increment, b bigint auto_increment);
 insert into t1 values(null, 2), (3, null), (null, null);
 select * from t1;
-a    b
-1    2
-3    3
-4    4
+➤ a[4,32,0]  ¦  b[-5,64,0]  𝄀
+1  ¦  2  𝄀
+3  ¦  3  𝄀
+4  ¦  4
 insert into t1 values(100, 2), (null, null), (null, null);
 select * from t1;
-a    b
-1    2
-3    3
-4    4
-100    2
-101    5
-102    6
+➤ a[4,32,0]  ¦  b[-5,64,0]  𝄀
+1  ¦  2  𝄀
+3  ¦  3  𝄀
+4  ¦  4  𝄀
+100  ¦  2  𝄀
+101  ¦  5  𝄀
+102  ¦  6
 drop table if exists t1;
 create table t1(a int, b int, primary key(a));
 insert into t1 values(null, 1);
@@ -155,11 +155,11 @@ insert into t1 values(1, '3');
 insert into t1 values(2, '2');
 insert into t1 values(2, '3');
 select * from t1;
-a    b
-1    2
-1    3
-2    2
-2    3
+➤ a[4,32,0]  ¦  b[12,-1,0]  𝄀
+1  ¦  2  𝄀
+1  ¦  3  𝄀
+2  ¦  2  𝄀
+2  ¦  3
 insert into t1 values(2, '3');
 Duplicate entry '(2,3)' for key '(a,b)'
 drop table if exists t1;
@@ -222,26 +222,58 @@ insert into flush_logtail values(3, 3);
 insert into flush_logtail values(4, 4);
 insert into flush_logtail values(5, 5);
 select mo_ctl('dn', 'AddFaultPoint', 'enable_fault_injection');
-mo_ctl(dn, AddFaultPoint, enable_fault_injection)
-{\n  "method": "AddFaultPoint",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+➤ mo_ctl(dn, AddFaultPoint, enable_fault_injection)[12,-1,0]  𝄀
+{
+  "method": "AddFaultPoint",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
 select mo_ctl('dn', 'AddFaultPoint', 'flush_table_error.:::.echo.0.flush_table_fault');
-mo_ctl(dn, AddFaultPoint, flush_table_error.:::.echo.0.flush_table_fault)
-{\n  "method": "AddFaultPoint",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+➤ mo_ctl(dn, AddFaultPoint, flush_table_error.:::.echo.0.flush_table_fault)[12,-1,0]  𝄀
+{
+  "method": "AddFaultPoint",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
 select mo_ctl('dn', 'flush', 'insert.flush_logtail');
 internal error: flush_table_fault
 select * from flush_logtail;
-a    b
-1    1
-2    2
-3    3
-4    4
-5    5
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1  𝄀
+2  ¦  2  𝄀
+3  ¦  3  𝄀
+4  ¦  4  𝄀
+5  ¦  5
 select mo_ctl('dn', 'AddFaultPoint', 'disable_fault_injection');
-mo_ctl(dn, AddFaultPoint, disable_fault_injection)
-{\n  "method": "AddFaultPoint",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+➤ mo_ctl(dn, AddFaultPoint, disable_fault_injection)[12,-1,0]  𝄀
+{
+  "method": "AddFaultPoint",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
 select mo_ctl('dn', 'flush', 'insert.flush_logtail');
-mo_ctl(dn, flush, insert.flush_logtail)
-{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+➤ mo_ctl(dn, flush, insert.flush_logtail)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
 drop table if exists t1;
 create table t1 (a varchar(50));
 insert into t1 values("这是一个字节数超过五十的字符串，但是utf8没有超过");
@@ -254,126 +286,135 @@ create table t(a int);
 insert into t values(1);
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 2
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 4
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 8
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 16
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 32
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 64
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 128
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 256
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 512
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 1024
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 2048
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 4096
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 8192
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 16384
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 32768
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 65536
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 131072
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 262144
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 524288
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 1048576
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 2097152
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 4194304
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 8388608
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 16777216
 begin;
 insert into t select * from t;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 33554432
 commit;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 33554432
 drop table t;
 create table t(a int primary key);
 insert into t select * from generate_series(1,200000) g;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
 200000
 insert into t select * from t;
-Duplicate entry ('[0-9]{6}'|'[0-9]{5}'|'[0-9]{4}'|'[0-9]{3}'|'[0-9]{2}'|'[0-9]{1}') for key 'a'
-begin;
-insert into t select * from t;
-Duplicate entry ('[0-9]{6}'|'[0-9]{5}'|'[0-9]{4}'|'[0-9]{3}'|'[0-9]{2}'|'[0-9]{1}') for key 'a'
+Duplicate entry '1' for key 'a'
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
+200000
+begin;
+select count(*) from t;
+➤ count(*)[-5,64,0]  𝄀
+200000
+insert into t select * from t;
+Duplicate entry '1' for key 'a'
+select count(*) from t;
+➤ count(*)[-5,64,0]  𝄀
 200000
 commit;
 select count(*) from t;
-count(*)
+➤ count(*)[-5,64,0]  𝄀
+200000
+select count(*) from t;
+➤ count(*)[-5,64,0]  𝄀
 200000
 insert into t select null;
 constraint violation: Column 'a' cannot be null
@@ -512,7 +553,7 @@ insert into t4 (col2, col3, col1) values(2, 3, 1);
 insert into t4 (col3, col1) values (8, 6);
 Duplicate entry '(6,8)' for key '(col1,col3)'
 select * from t4;
-col1    col2    col3
-6    6    8
-1    2    3
+➤ col1[4,32,0]  ¦  col2[3,39,0]  ¦  col3[5,16,0]  𝄀
+6  ¦  6  ¦  8  𝄀
+1  ¦  2  ¦  3
 drop table t4;

--- a/test/distributed/cases/pessimistic_transaction/insert.result
+++ b/test/distributed/cases/pessimistic_transaction/insert.result
@@ -396,7 +396,7 @@ select count(*) from t;
 ➤ count(*)[-5,64,0]  𝄀
 200000
 insert into t select * from t;
-Duplicate entry '1' for key 'a'
+Duplicate entry ('[0-9]{6}'|'[0-9]{5}'|'[0-9]{4}'|'[0-9]{3}'|'[0-9]{2}'|'[0-9]{1}') for key 'a'
 select count(*) from t;
 ➤ count(*)[-5,64,0]  𝄀
 200000
@@ -405,7 +405,7 @@ select count(*) from t;
 ➤ count(*)[-5,64,0]  𝄀
 200000
 insert into t select * from t;
-Duplicate entry '1' for key 'a'
+Duplicate entry ('[0-9]{6}'|'[0-9]{5}'|'[0-9]{4}'|'[0-9]{3}'|'[0-9]{2}'|'[0-9]{1}') for key 'a'
 select count(*) from t;
 ➤ count(*)[-5,64,0]  𝄀
 200000

--- a/test/distributed/cases/pessimistic_transaction/insert.test
+++ b/test/distributed/cases/pessimistic_transaction/insert.test
@@ -234,15 +234,21 @@ drop table t;
 create table t(a int primary key);
 insert into t select * from generate_series(1,200000) g;
 select count(*) from t;
+
 # abort,duplicate key
 -- @pattern
 insert into t select * from t;
+select count(*) from t;
+
 # transaction test
 begin;
+select count(*) from t;
 -- @pattern
 insert into t select * from t;
 select count(*) from t;
 commit;
+
+select count(*) from t;
 select count(*) from t;
 # not-null test
 insert into t select null;


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #19303 

## What this PR does / why we need it:

### StarCount optimization for `SELECT COUNT(*)`
  • Main change: For a single SELECT COUNT(*) (or equivalent count(not_null_col)) with no filter/groupby, use a lightweight
    EstimateCommittedTombstoneCount to decide path: if estimate &gt; 5M tombstone rows, use the per-block path; otherwise use the
    metadata-only StarCount() fast path to avoid expensive CollectTombstoneStats on large tombstone sets.
  • Engine API: Add StarCount(ctx) and EstimateCommittedTombstoneCount(ctx) on Relation; implement in disttae, memoryengine, and
    partition_state.
  • Supporting: Plan/compile rewrite so count(not_null_col) and COUNT(lit) use starcount and countStarExec; fix StarCount undercount
     when a batch has multiple persisted-insert ObjectStats; StarCount metrics and Grafana row; export IsDataObjectVisible.


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- **StarCount optimization for SELECT COUNT(*)**: Implements lightweight metadata-only path for `SELECT COUNT(*)` queries by estimating tombstone count; uses fast `StarCount()` path when tombstones < 5M rows, otherwise falls back to per-block scanning

- **Engine API additions**: Added `StarCount(ctx)` and `EstimateCommittedTombstoneCount(ctx)` methods to Relation interface with implementations in disttae, memory engine, and partition_state

- **Plan/compile rewrites**: Added plan-level and compile-phase rewrites to convert `count(not_null_col)` and `COUNT(lit)` to starcount operations with proper overload IDs for runtime optimization

- **Tombstone visibility improvements**: Exported `IsDataObjectVisible()` method and added helpers for counting visible tombstones with proper visibility checks

- **Bug fixes**: Fixed StarCount undercount when a batch has multiple persisted-insert ObjectStats; fixed missing PrimaryKeyDef in schema constraints; set correct overload IDs for starcount rewrites

- **Fault injection support**: Added `CNWorkspaceForceFlushInjected()` for testing workspace flush behavior

- **Comprehensive test coverage**: Added 2015-line test suite for StarCount functionality covering empty tables, committed/uncommitted data, persisted inserts, and tombstone scenarios; updated distributed test cases with count assertions and starcount verification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SELECT COUNT(*)"] --> B["isSingleStarCountNoFilterNoGroupBy"]
  B --> C["EstimateCommittedTombstoneCount"]
  C --> D{Tombstones < 5M?}
  D -->|Yes| E["StarCount Fast Path<br/>Metadata Only"]
  D -->|No| F["Per-Block Scan Path<br/>CollectTombstoneStats"]
  E --> G["countStarExec<br/>Runtime"]
  F --> G
  H["count(not_null_col)<br/>COUNT(lit)"] --> I["Plan Rewrite<br/>RewriteCountNotNullColToStarcount"]
  I --> J["Compile Rewrite<br/>checkAggOptimize"]
  J --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>19 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>txn_table_starcount_test.go</strong><dd><code>Comprehensive StarCount test suite with tombstone scenarios</code></dd></summary>
<hr>

pkg/vm/engine/test/txn_table_starcount_test.go

<ul><li>Added comprehensive test suite (2015 lines) for <code>StarCount</code> <br>functionality covering basic operations, uncommitted inserts/deletes, <br>persisted data, and tombstone handling<br> <li> Tests cover scenarios: empty tables, committed/uncommitted data, <br>in-memory vs persisted inserts, mixed operations, and tombstone <br>transfers after merge<br> <li> Includes regression test for bug where multiple ObjectStats in one <br>batch were not fully counted<br> <li> Tests verify formula: <code>StarCount = CommittedRows + UncommittedInserts - </code><br><code>UncommittedTombstones</code></ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-32aef934d7b87201872891b6a6e9510e3fe669380f2ffd64aedd1cd2b1187cbf">+2015/-0</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agg_optimize_test.go</strong><dd><code>Test COUNT rewrite to starcount with overload ID</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/agg_optimize_test.go

<ul><li>Added test case for <code>COUNT(lit)</code> rewrite to starcount with proper <code>Obj</code> <br>field validation<br> <li> Updated existing test to verify both <code>ObjName</code> and <code>Obj</code> (overload ID) are <br>set correctly for starcount<br> <li> Added assertion to ensure <code>Obj</code> is set to <code>CountStar</code> overload so runtime <br>uses <code>countStarExec</code></ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-dc2b638432f3a2d50679bcd25c1f4d9d79435c4ee79d98b8a3c98772364cdfe4">+34/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>engine_mock.go</strong><dd><code>Add mock methods for StarCount API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/frontend/test/engine_mock.go

<ul><li>Added mock methods for <code>StarCount(ctx)</code> and <br><code>EstimateCommittedTombstoneCount(ctx)</code> on <code>MockRelation</code><br> <li> Includes both method implementations and recorder methods for test <br>setup</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-7f25d270cc6d85f3c1655194a9dd2493991b59c88f63be8bf658e28360dd398a">+30/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_util_test.go</strong><dd><code>Test plan-level count rewrite to starcount</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_util_test.go

<ul><li>Added regression test <code>TestRewriteCountNotNullColToStarcount()</code> to <br>verify plan-level rewrite sets both <code>ObjName</code> and <code>Obj</code><br> <li> Ensures <code>count(not_null_col)</code> rewrite produces correct overload ID for <br>runtime execution</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-7d3593ef70ac299713841f55c8fbaaa83851f632688ea768649d2042696e29d0">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>txn_table_combined_test.go</strong><dd><code>Add mock implementations for StarCount methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/txn_table_combined_test.go

<ul><li>Added stub implementations of <code>StarCount()</code> and <br><code>EstimateCommittedTombstoneCount()</code> to mockRelation<br> <li> Both methods return zero/nil for testing purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-383cfd22c3abce4ae1d2bb41f31a0ff865c20c507166fd71c54d3008572f16b1">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.result</strong><dd><code>Update index optimizer test results with starcount cases</code>&nbsp; </dd></summary>
<hr>

test/distributed/cases/optimizer/index.result

<ul><li>Updated test output formatting with improved readability (JSON <br>pretty-printing)<br> <li> Added visual separators and metadata annotations to query results<br> <li> Added new test cases for <code>count(*)</code> with starcount optimization <br>verification</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-6681b2ca0c84cb5b3e7aea5301e29ce2183b97e196320f689b79d6d4c4ed2f7d">+195/-143</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>delete.result</strong><dd><code>Add count verification and starcount explain tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/dml/delete/delete.result

<ul><li>Updated output formatting with visual separators and metadata<br> <li> Added new <code>count(*)</code> assertions after delete operations<br> <li> Added <code>explain analyze</code> test cases verifying starcount aggregate <br>function usage</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-2695cc4b5a2c02b0ce2a5f568b726e492741732b364bb24e4d5dde44bde2f43b">+190/-149</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>insert.result</strong><dd><code>Update insert test results with count assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/pessimistic_transaction/insert.result

<ul><li>Updated result formatting with visual separators and type metadata<br> <li> Added <code>count(*)</code> assertions throughout insert test cases<br> <li> Improved readability of multi-row results with consistent formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-121ac549253adc85eeffd8a06f6152d72ce6a4f122d0c27e1b6baaa53515a248">+152/-111</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>group.result</strong><dd><code>Add count assertions to group optimizer tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/optimizer/group.result

<ul><li>Added <code>count(*)</code> assertions after data modifications in group tests<br> <li> Updated output formatting with visual separators and metadata<br> <li> Verifies row counts after insert/delete operations</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-8efc8d8f8c3d153d3128a647ef2b879a969ce7d69f53606233afe3d7ca9f6ace">+137/-125</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>func_aggr_count.result</strong><dd><code>Add starcount optimization verification to count tests</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/function/func_aggr_count.result

<ul><li>Added <code>explain analyze</code> test cases for starcount optimization <br>verification<br> <li> Updated test output showing starcount aggregate function in execution <br>plans<br> <li> Modified expected inputRows from actual data rows to 1 (metadata-only <br>path)</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-7e8b4af45d2f088f2308022f5c113fd40a9faab3df350d602090ced890a9de31">+21/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>delete.test</strong><dd><code>Add count verification tests for delete operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/dml/delete/delete.test

<ul><li>Added <code>select count(*)</code> statements after delete operations for <br>verification<br> <li> Added <code>explain analyze</code> test with regex pattern to verify starcount <br>usage<br> <li> Improved test coverage for count operations after data modifications</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-e59fbf4657499ef05814802b335f9b5c00109a6e91b5f06b9c6ac5e73888dc76">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update.test</strong><dd><code>Add count assertions to update test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/dml/update/update.test

<ul><li>Added <code>select count(*)</code> assertions after update operations<br> <li> Verifies row counts remain correct after various update scenarios<br> <li> Improves test coverage for count operations</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-cfd493f8984f55c187fc734e1814a4f4dd7cf475cf22aba5265eb45986070649">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>group.test</strong><dd><code>Add count verification to group optimizer tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/optimizer/group.test

<ul><li>Added <code>select count(*)</code> statements after insert/delete operations<br> <li> Verifies row counts at various stages of group aggregation tests<br> <li> Improves test data validation</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-d796083b0e7245d222b556ddffca3f97c32998e7a9e1d67812ab09c26f7cac54">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>func_aggr_count.test</strong><dd><code>Add starcount explain and null count tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/function/func_aggr_count.test

<ul><li>Added <code>explain analyze</code> test for empty table count with starcount <br>verification<br> <li> Added <code>select count(a)</code> test for null column counting<br> <li> Improved test coverage for count optimization scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-3ee60a7ee3cfa10f7d89d540976e6e481f8fcc9a43f477c4bcb80859f317fa1a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.test</strong><dd><code>Add count and starcount tests to index optimizer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/optimizer/index.test

<ul><li>Added <code>select count(*)</code> statements after update/delete operations<br> <li> Added <code>explain analyze</code> test with regex pattern for starcount <br>verification<br> <li> Improves test coverage for count operations in index scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-4c4fbe175b643249cf2a81dd48014391c2121a73be00e8bb13b90dd2b097aa96">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>blockfilter.test</strong><dd><code>Add count assertions to blockfilter tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/optimizer/blockfilter.test

<ul><li>Added <code>select count(*)</code> assertions after large insert operations<br> <li> Verifies row counts for block filter test tables<br> <li> Improves test data validation</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-16b881f91f35a90bce38c2f1599b7e73a301ec512a9afd6eea26737a4f206ac0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>insert.test</strong><dd><code>Add count assertions to pessimistic transaction tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/distributed/cases/pessimistic_transaction/insert.test

<ul><li>Added <code>select count(*)</code> statements throughout transaction test cases<br> <li> Verifies row counts at various transaction stages<br> <li> Improves test coverage for count operations in pessimistic <br>transactions</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-4da44c58b3aba883dcc0728503b3ec792b285da66f7f5779ac9494f860097f00">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>update.result</strong><dd><code>Test result formatting updates and count(*) verification additions</code></dd></summary>
<hr>

test/distributed/cases/dml/update/update.result

<ul><li>Updated test result output formatting to include column type metadata <br>(e.g., <code>[4,32,0]</code>) and visual separators (<code>𝄀</code>, <code>¦</code>) for better readability<br> <li> Added new <code>select count(*)</code> test cases after update operations to verify <br>row counts<br> <li> Marked several test cases with <code>[unknown result because it is related </code><br><code>to issue#5790]</code> to indicate known issues<br> <li> Reformatted query plan output to use multi-line display with proper <br>indentation</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-f60d06bda3a1e69f5d4d5be0d5274107babfd26c7af58fd83c657819c6ba6b8d">+149/-126</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>blockfilter.result</strong><dd><code>Test output formatting enhancements and count(*) query additions</code></dd></summary>
<hr>

test/distributed/cases/optimizer/blockfilter.result

<ul><li>Added <code>select count(*)</code> statements after table insertions to verify row <br>counts (100000 and 1000000 rows)<br> <li> Updated output formatting for <code>mo_ctl()</code> function results to display <br>JSON in multi-line format instead of escaped single-line<br> <li> Reformatted <code>EXPLAIN</code> query plan outputs with visual separators and <br>proper line breaks for improved readability<br> <li> Updated result column headers to include type metadata (e.g., <br><code>count(*)[-5,64,0]</code>, <code>TP QUERY PLAN[12,0,0]</code>)<br> <li> Changed query plan header from <code>AP QUERY PLAN ON ONE CN(4 core)</code> to <code>AP </code><br><code>QUERY PLAN ON ONE CN(24 core)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-893bde4a45c92a8b3218dcf358aec85e095ce03fd9b1507a494dd96ec223821d">+141/-119</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>txn_table.go</strong><dd><code>Add StarCount optimization for SELECT COUNT(*) queries</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/txn_table.go

<ul><li>Implemented <code>StarCount(ctx)</code> method that returns row count for <code>SELECT </code><br><code>COUNT(*)</code> queries using lightweight metadata-only path when tombstone <br>count is low<br> <li> Implemented <code>EstimateCommittedTombstoneCount(ctx)</code> to decide whether to <br>use fast StarCount path or per-block scan<br> <li> Added <code>countUncommittedPersistedTombstones()</code> and <br><code>countSingleTombstoneObject()</code> helpers to count visible tombstones with <br>visibility checks<br> <li> Modified <code>BuildReaders()</code> to return <code>EmptyReader</code> when no blocks need <br>scanning (StarCount-only optimization)</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-ec8d7fbb6765aa12484ff5529b88835dc1da369005256b065fb3db4972f2d32f">+255/-2</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>partition_state.go</strong><dd><code>Export visibility check and add tombstone estimation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/logtailreplay/partition_state.go

<ul><li>Added <code>EstimateCommittedTombstoneCount(snapshot)</code> to provide lightweight <br>upper-bound estimate of tombstone rows from metadata only<br> <li> Exported <code>IsDataObjectVisible()</code> method (renamed from private <br><code>isDataObjectVisible</code>) for use in tombstone visibility checks<br> <li> Updated all internal callers to use the new public method name</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-e6df770d1a9df923a1dd64003c965c09737142851e172029adebfbf5030484a7">+34/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scope.go</strong><dd><code>Add StarCount fast path in query compilation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/scope.go

<ul><li>Added <code>isSingleStarCountNoFilterNoGroupBy()</code> helper to detect single <br>starcount aggregation without filters or groupby<br> <li> Implemented fast path in <code>aggOptimize()</code> that calls <code>rel.StarCount()</code> <br>directly when tombstone estimate is below threshold (5M rows)<br> <li> Added <code>StarCountOnly</code> flag to <code>Scope</code> to signal that only <code>StarCount()</code> was <br>called, no block scanning needed<br> <li> Modified <code>buildReaders()</code> to return <code>EmptyReader</code> instances when <br><code>StarCountOnly</code> flag is set</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-1a84d311b058e390f8c70e84f5e0c59dbd42736a85d022e2a283d926d43f5bd6">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>txn.go</strong><dd><code>Add fault injection for workspace force flush</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/txn.go

<ul><li>Added fault injection support via <code>CNWorkspaceForceFlushInjected()</code> to <br>force workspace flush for testing<br> <li> Modified <code>dumpBatchLocked()</code> to check for force flush flag before <br>applying size/count thresholds<br> <li> Modified <code>dumpInsertBatchLocked()</code> to skip table filtering logic when <br>force flush is enabled</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-3b3158eacf342a1a2d00fa78724245821aa8bd8f08bb52e7e7acc76ec16e4744">+22/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>injects.go</strong><dd><code>Add workspace force flush fault injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/objectio/injects.go

<ul><li>Added new fault injection constant <code>FJ_CNWorkspaceForceFlush</code> for <br>testing workspace flush behavior<br> <li> Added <code>CNWorkspaceForceFlushInjected()</code> function to check if force flush <br>fault is active</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-05347be6ac14225e17480783b255bb81ede750eaee4a6d4146af7d2005d507f4">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_util.go</strong><dd><code>Add plan-level count to starcount rewrite utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_util.go

<ul><li>Added <code>RewriteCountNotNullColToStarcount()</code> utility function to rewrite <br><code>count(not_null_col)</code> to starcount at plan level<br> <li> Sets both <code>ObjName</code> to "starcount" and <code>Obj</code> to <code>CountStar</code> overload ID for <br>runtime optimization<br> <li> Includes validation for column position bounds and NOT NULL constraint</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-ef8222c968de6353c556fdaf8b21d01514ebf4f9bcf13f6a2964c4f3d012084e">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>table_reader.go</strong><dd><code>Implement StarCount API for memory engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/memoryengine/table_reader.go

<ul><li>Implemented <code>StarCount(ctx)</code> method returning total row count via <br><code>Rows(ctx)</code><br> <li> Implemented <code>EstimateCommittedTombstoneCount(ctx)</code> returning 0 (memory <br>engine has no persisted tombstones)</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-5a902f9bea41cc82853f90473220464db8347857f8c0d73f8163dd06c2a1afb0">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>txn_table_combined.go</strong><dd><code>Add StarCount and EstimateCommittedTombstoneCount methods</code></dd></summary>
<hr>

pkg/vm/engine/disttae/txn_table_combined.go

<ul><li>Added <code>StarCount()</code> method to aggregate row counts from multiple <br>relations<br> <li> Added <code>EstimateCommittedTombstoneCount()</code> method to estimate tombstone <br>rows across relations<br> <li> Both methods iterate through tables and sum results for distributed <br>transaction tables</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-ae3ccd9a3d1a0093249a680f3986a55abf27f7f6d58b10804971b89d145a37a1">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>txn_table_delegate.go</strong><dd><code>Implement StarCount delegation in transaction table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/txn_table_delegate.go

<ul><li>Implemented <code>StarCount()</code> method with delegation logic for combined, <br>local, and parent tables<br> <li> Implemented <code>EstimateCommittedTombstoneCount()</code> method with same <br>delegation pattern<br> <li> Methods route calls to appropriate table implementation based on table <br>type</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-5619e07fab32462581a863b585d99b8037c50d152a35c466d938a35e8ef63b9d">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add Relation interface methods for COUNT optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/types.go

<ul><li>Added <code>StarCount()</code> interface method for optimized COUNT(*) using <br>metadata instead of scanning<br> <li> Added <code>EstimateCommittedTombstoneCount()</code> interface method for <br>lightweight tombstone estimation<br> <li> Both methods documented with usage patterns and performance <br>characteristics</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-63dae27d68e4826370bf8a36cbe79d41cba3c711a7ff2fb8ec91e81babc0a4ed">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>query_builder.go</strong><dd><code>Add plan rewrite for count aggregation optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/query_builder.go

<ul><li>Added plan-level rewrite to convert <code>count(not_null_col)</code> to starcount <br>operations<br> <li> Rewrite applied when building aggregation nodes with table scan <br>children<br> <li> Enables compile phase to use optimized countStarExec execution</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-144e02a38da50867dc021b9254d10a5fd131671cca344c2323337ba2141440f1">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>disttae_engine.go</strong><dd><code>Optimize test engine subscription polling timing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/test/testutil/disttae_engine.go

<ul><li>Changed ticker interval from 1 second to 5 milliseconds for faster <br>polling<br> <li> Increased timeout from 5 to 1000 iterations to maintain same total <br>wait time<br> <li> Improves test responsiveness in SubscribeTable method</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-765d649f17022692f02eb0a5415f39f15cd1c27c804457874e33730cf440e285">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.go</strong><dd><code>Add StarCountOnly flag to compilation scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/types.go

<ul><li>Added <code>StarCountOnly</code> boolean field to Scope struct<br> <li> Field indicates when aggregation optimization took the <br>single-starcount fast path<br> <li> Signals buildReaders to return EmptyReaders with no data flow</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-a4dcef274017300a3251138d7116e56db5c8749ac87367179081cd6caabb3a60">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>compile.go</strong><dd><code>Set overload ID for starcount rewrite in checkAggOptimize</code></dd></summary>
<hr>

pkg/sql/compile/compile.go

<ul><li>Updated <code>checkAggOptimize()</code> to set both <code>ObjName</code> and <code>Obj</code> (overload ID) <br>when rewriting <code>COUNT(not_null_col)</code> and <code>COUNT(lit)</code> to starcount<br> <li> Added null checks for <code>node.TableDef</code> and column position bounds <br>validation<br> <li> Ensures runtime uses <code>countStarExec</code> instead of <code>countColumnExec</code> for <br>optimized count operations</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+14/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Fix missing PrimaryKeyDef in schema constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/test/testutil/util.go

<ul><li>Added logic to detect missing PrimaryKeyDef in ConstraintDef when <br>schema has primary key<br> <li> Automatically creates and appends PrimaryKeyDef for fake primary keys <br>(pkIdx == -1)<br> <li> Ensures schema consistency when using MockSchemaAll</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-7c7bb071a96fe384516cf1bcd2378926568503d930170726a370b789717183e7">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>txn_mock.go</strong></td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23636/files#diff-68e826bd15c3f0b74a031fad521dfb4ed97d3d9a22a29d40d0e1372c814dc646">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

