### PR TITLE
fix cn oom in create index

### DIFF
--- a/pkg/sql/colexec/hashmap_util/hashmap_util.go
+++ b/pkg/sql/colexec/hashmap_util/hashmap_util.go
@@ -277,14 +277,19 @@ func (hb *HashmapBuilder) BuildHashmap(hashOnPK bool, needAllocateSels bool, nee
 	}
 
 	if hashOnPK || hb.IsDedup {
-		// if hash on primary key, prealloc hashmap size to the count of batch
+		// Prealloc improves performance, but for dedup with huge inputs it can OOM.
+		// Cap the initial prealloc so the hashmap can still grow incrementally.
+		preAllocCount := uint64(hb.InputBatchRowCount)
+		if hb.IsDedup && preAllocCount > uint64(hashmap.HashMapSizeThreshHold) {
+			preAllocCount = uint64(hashmap.HashMapSizeThreshHold)
+		}
 		if hb.keyWidth <= 8 {
-			err = hb.IntHashMap.PreAlloc(uint64(hb.InputBatchRowCount))
+			err = hb.IntHashMap.PreAlloc(preAllocCount)
 			if err != nil {
 				return err
 			}
 		} else {
-			err = hb.StrHashMap.PreAlloc(uint64(hb.InputBatchRowCount))
+			err = hb.StrHashMap.PreAlloc(preAllocCount)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20236

## What this PR does / why we need it:
Problem: BuildHashmap preallocates to InputBatchRowCount when IsDedup is true. For very large unique index builds this can trigger excessive upfront memory allocation and OOM/panic.
Fix: cap the initial prealloc size for dedup to hashmap.HashMapSizeThreshHold, allowing the hashmap to grow incrementally instead of allocating the full size upfront.
Impact: reduces peak memory usage for create unique index on large datasets; no semantic change to dedup behavior.
Tests: go test ./pkg/sql/colexec/hashmap_util


___

### **PR Type**
Bug fix


___

### **Description**
- Cap dedup hashmap preallocation to prevent OOM on large unique index builds

- Allow hashmap to grow incrementally instead of allocating full size upfront

- Reduces peak memory usage for create unique index operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BuildHashmap called<br/>with IsDedup=true"] -->|"Large InputBatchRowCount"| B["Check preAllocCount<br/>vs HashMapSizeThreshHold"]
  B -->|"preAllocCount > threshold"| C["Cap to HashMapSizeThreshHold"]
  B -->|"preAllocCount <= threshold"| D["Use InputBatchRowCount"]
  C --> E["PreAlloc hashmap<br/>with capped size"]
  D --> E
  E -->|"Hashmap grows<br/>incrementally"| F["Reduced peak memory usage"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hashmap_util.go</strong><dd><code>Cap dedup hashmap preallocation to threshold</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/hashmap_util/hashmap_util.go

<ul><li>Added logic to cap initial preallocation size for dedup operations to <br><code>hashmap.HashMapSizeThreshHold</code><br> <li> Introduced <code>preAllocCount</code> variable to conditionally limit the <br>allocation size based on <code>IsDedup</code> flag<br> <li> Updated both <code>IntHashMap.PreAlloc()</code> and <code>StrHashMap.PreAlloc()</code> calls to <br>use the capped value<br> <li> Improved comment to explain the OOM prevention strategy</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23641/files#diff-4e472814399bbb0cac40fbad6d42daabca4111e950bebe1a2f5c4dbf8560bd74">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

