### PR TITLE
fix flush timeout log output

### DIFF
--- a/pkg/vm/engine/tae/db/checkpoint/flusher.go
+++ b/pkg/vm/engine/tae/db/checkpoint/flusher.go
@@ -826,8 +826,9 @@ func (flusher *flushImpl) FlushTable(
 		// debug logging for mo_columns
 		if tableID == 3 {
 			debugCounter++
-			if debugCounter%10 == 0 {
-				flusher.debugPrintTableObjects(dbID, tableID, ts)
+			did, tid := tableTree.DbID, tableTree.ID
+			if debugCounter%15 == 0 {
+				flusher.debugPrintTableObjects(did, tid, ts)
 			}
 		}
 
@@ -883,6 +884,12 @@ func (flusher *flushImpl) debugPrintTableObjects(dbID, tableID uint64, ts types.
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("debug.flush.mo_columns ts=%s\n", ts.ToString()))
 
+	ready, notFlushed := table.IsTableTailFlushed(types.TS{}, ts)
+	buf.WriteString(fmt.Sprintf("ready=%v\n", ready))
+	if notFlushed != nil {
+		buf.WriteString(fmt.Sprintf("not flushed: %s\n", notFlushed.StringWithLevel(common.PPL2)))
+	}
+
 	// print data objects
 	buf.WriteString("=== Data Objects ===\n")
 	dataIt := table.MakeDataObjectIt()
@@ -894,8 +901,9 @@ func (flusher *flushImpl) debugPrintTableObjects(dbID, tableID uint64, ts types.
 		if next := obj.GetNextVersion(); next != nil {
 			nextCommitted = next.IsCommitted()
 		}
+		buf.WriteString("  " + obj.StringWithLevel(common.PPL2) + "\n")
 		buf.WriteString(fmt.Sprintf(
-			"  obj=%s appendable=%v isCEntry=%v isDEntry=%v createdAt=%s deletedAt=%s hasDCounterpart=%v nextCommitted=%v\n",
+			"    obj=%s appendable=%v isCEntry=%v isDEntry=%v createdAt=%s deletedAt=%s hasDCounterpart=%v nextCommitted=%v\n",
 			obj.ID().ShortStringEx(),
 			obj.IsAppendable(),
 			obj.IsCEntry(),
@@ -918,8 +926,9 @@ func (flusher *flushImpl) debugPrintTableObjects(dbID, tableID uint64, ts types.
 		if next := obj.GetNextVersion(); next != nil {
 			nextCommitted = next.IsCommitted()
 		}
+		buf.WriteString("  " + obj.StringWithLevel(common.PPL2) + "\n")
 		buf.WriteString(fmt.Sprintf(
-			"  obj=%s appendable=%v isCEntry=%v isDEntry=%v createdAt=%s deletedAt=%s hasDCounterpart=%v nextCommitted=%v\n",
+			"    obj=%s appendable=%v isCEntry=%v isDEntry=%v createdAt=%s deletedAt=%s hasDCounterpart=%v nextCommitted=%v\n",
 			obj.ID().ShortStringEx(),
 			obj.IsAppendable(),
 			obj.IsCEntry(),


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23631 

## What this PR does / why we need it:

fix db not found error and add more detailed info


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix database ID retrieval by using tableTree properties instead of parameters

- Enhance debug logging with table flush status and detailed object information

- Adjust debug counter frequency from 10 to 15 for reduced log output

- Add comprehensive object state details to flush debug output


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Debug Flush Logic"] -->|Extract dbID/tableID| B["From tableTree"]
  A -->|Check flush status| C["IsTableTailFlushed"]
  C -->|Log ready state| D["Enhanced Debug Output"]
  A -->|Add object details| E["StringWithLevel PPL2"]
  E -->|Include in output| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flusher.go</strong><dd><code>Improve flush debug logging with state details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/tae/db/checkpoint/flusher.go

<ul><li>Fixed database and table ID retrieval by using <code>tableTree.DbID</code> and <br><code>tableTree.ID</code> instead of function parameters<br> <li> Added table flush status check using <code>IsTableTailFlushed()</code> with ready <br>and notFlushed information<br> <li> Enhanced debug output with detailed object state using <br><code>StringWithLevel(common.PPL2)</code> for both data and tombstone objects<br> <li> Adjusted debug counter frequency from 10 to 15 for less frequent <br>logging<br> <li> Improved formatting with additional indentation for nested object <br>details</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23647/files#diff-8b77364ba4bb7a1b1cfb6e85ddfabc827686c3c9b86fec4340ee595e12718a99">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

