### PR TITLE
disable wrong parallel decompression for LOAD DATA

### DIFF
--- a/pkg/sql/colexec/external/external.go
+++ b/pkg/sql/colexec/external/external.go
@@ -383,6 +383,13 @@ func readFile(param *ExternalParam, proc *process.Process) (io.ReadCloser, error
 }
 
 func ReadFileOffset(param *tree.ExternParam, mcpu int, fileSize int64, visibleCols []*plan.ColDef) ([]int64, error) {
+	if GetCompressType(param, param.Filepath) != tree.NOCOMPRESS {
+		ctx := param.Ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		return nil, moerr.NewInvalidInputf(ctx, "parallel read is not supported for compressed file %s", param.Filepath)
+	}
 	arr := make([]int64, 0)
 
 	fs, readPath, err := plan2.GetForETLWithType(param, param.Filepath)

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -1635,7 +1635,11 @@ func (c *Compile) compileExternScanParallelWrite(n *plan.Node, param *tree.Exter
 	scope := c.constructScopeForExternal("", false)
 	currentFirstFlag := c.anal.isFirst
 	extern := constructExternal(n, param, c.proc.Ctx, fileList, fileSize, fileOffsetTmp, strictSqlMode)
-	extern.Es.ParallelLoad = true
+	parallelLoad := true
+	if len(fileList) > 0 && external.GetCompressType(param, fileList[0]) != tree.NOCOMPRESS {
+		parallelLoad = false
+	}
+	extern.Es.ParallelLoad = parallelLoad
 	extern.SetAnalyzeControl(c.anal.curNodeIdx, currentFirstFlag)
 	scope.setRootOperator(extern)
 	c.anal.isFirst = false

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -373,7 +373,7 @@ func TestCompileExternScanParallelReadWrite(t *testing.T) {
 		TableDef:   &plan.TableDef{},
 		ExternScan: &plan.ExternScan{},
 	}
-	filePath := fmt.Sprintf("%s/../../../test/distributed/resources/load_data/parallel_1.txt.gz", GetFilePath())
+	filePath := fmt.Sprintf("%s/../../../test/distributed/resources/load_data/parallel_1.txt", GetFilePath())
 	filePath = path.Clean("/" + filePath)
 	fileSize := []int64{int64(colexec.WriteS3Threshold) * 2}
 	_, err := testCompile.compileExternScanParallelReadWrite(n, param, []string{filePath}, fileSize, true)
@@ -384,6 +384,12 @@ func TestCompileExternScanParallelReadWrite(t *testing.T) {
 	fileSize = []int64{int64(colexec.WriteS3Threshold) * 3}
 	_, err = testCompile.compileExternScanParallelReadWrite(n, param, []string{filePath}, fileSize, false)
 	require.NoError(t, err)
+
+	// Compressed files should not be split for parallel read.
+	gzPath := fmt.Sprintf("%s/../../../test/distributed/resources/load_data/parallel_1.txt.gz", GetFilePath())
+	gzPath = path.Clean("/" + gzPath)
+	_, err = testCompile.compileExternScanParallelReadWrite(n, param, []string{gzPath}, fileSize, false)
+	require.Error(t, err)
 }
 
 func generateScopeWithRootOperator(proc *process.Process, operatorList []vm.OpType) *Scope {

--- a/pkg/sql/plan/build_load.go
+++ b/pkg/sql/plan/build_load.go
@@ -328,7 +328,7 @@ func buildLoad(stmt *tree.Load, ctx CompilerContext, isPrepareStmt bool) (*Plan,
 		builder.qry.LoadWriteS3 = false
 	}
 
-	if stmt.Param.Parallel && (!noCompress || stmt.Local) {
+	if stmt.Param.Parallel && noCompress {
 		projectNode.ProjectList = makeCastExpr(stmt, fileName, originTableDef, projectNode)
 	}
 	lastNodeId = builder.appendNode(projectNode, bindCtx)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23618

## What this PR does / why we need it:
Summary

Parallel LOAD DATA on compressed files is unsafe because the current implementation splits input by byte offsets and then tries to locate line boundaries on a compressed stream. This can cut rows in the middle, cause column misalignment, and finally write corrupted values (e.g., invalid DATE/DECIMAL). The issue manifests later as panics during query output (e.g., Date.ToBytes out-of-range).

Root Cause

ReadFileOffset computes offsets using Offset = previous + batchSize and then getTailSize on the compressed reader, which is not a valid line-boundary strategy for compressed streams. This leads to row corruption.

Fix (medium-cost path)

Keep parallel write, but disable parallel splitting for compressed files.
For compressed data, load is handled by a single reader (proper decompression + parsing), and the insert stage still runs in parallel.
Avoid the “string vector + cast projection” path for compressed files to prevent misalignment.
Tests

Added a unit test that asserts ReadFileOffset rejects compressed input.
This locks the unsafe behavior and prevents regression.
Note: If we later refactor to truly support parallel splitting for compressed files (e.g., with a splittable format), this test must be updated or removed.
Behavior After Fix

Compressed LOAD DATA no longer panics.
Parallelism is preserved on the write side; read-side splitting is disabled for compressed inputs.


___

### **PR Type**
Bug fix


___

### **Description**
- Disable parallel read splitting for compressed files in LOAD DATA

- Add validation in ReadFileOffset to reject compressed input

- Preserve write-side parallelism while disabling unsafe read-side splitting

- Add unit test to prevent regression of unsafe compressed file handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LOAD DATA Request"] --> B{"File Compressed?"}
  B -->|Yes| C["Single Reader<br/>Proper Decompression"]
  B -->|No| D["Parallel Read<br/>Split by Offsets"]
  C --> E["Parallel Write<br/>Insert Stage"]
  D --> E
  E --> F["Output Data"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>external.go</strong><dd><code>Add compression validation to ReadFileOffset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/external/external.go

<ul><li>Add compression type check in ReadFileOffset function<br> <li> Return error if parallel read requested for compressed files<br> <li> Prevent unsafe byte-offset splitting on compressed streams</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23648/files#diff-81231a121d9293d51f08e00a14fd08a5d7f50631fc9cea82a67940ab0f2f78b3">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>compile.go</strong><dd><code>Disable parallel load for compressed files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/compile.go

<ul><li>Check compression type before enabling ParallelLoad<br> <li> Set ParallelLoad to false for compressed files<br> <li> Preserve parallel write capability for non-compressed files</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23648/files#diff-1f95b23a5c61734c0686b47c14583f114fe66c015310f43992c517fa62c76f3d">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build_load.go</strong><dd><code>Restrict parallel load to uncompressed files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/plan/build_load.go

<ul><li>Simplify parallel load condition to check only noCompress flag<br> <li> Remove stmt.Local condition from parallel load decision<br> <li> Prevent cast projection path for compressed files</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23648/files#diff-f4d97d7b39aceecc7483340bc220e0f473127b8251fcf147361c90fd6c0f1b8c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>external_test.go</strong><dd><code>Add test for compressed file rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/colexec/external/external_test.go

<ul><li>Add new test TestReadFileOffsetCompressedUnsafe<br> <li> Create zlib-compressed test file with sample data<br> <li> Verify ReadFileOffset rejects compressed input with error<br> <li> Import compress/zlib and fileservice packages</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23648/files#diff-1931092c89cc568dcac54bbb07b777e088946b160fab45a92cab58a427cc6c86">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scope_test.go</strong><dd><code>Update tests for compression handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/sql/compile/scope_test.go

<ul><li>Change test file from compressed .gz to uncompressed .txt<br> <li> Add new test case for compressed file handling<br> <li> Verify that compressed files return error in parallel read scenario</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23648/files#diff-7cdb7cbcb109b8a29bef3b6b3a0eb615fc3e464cedbea8ea8bb0e7e2553f0839">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

