### PR TITLE
optimize partition state gc time

### DIFF
--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -1121,7 +1121,7 @@ func (c *PushClient) doGCPartitionState(ctx context.Context, e *Engine) {
 		parts[ids] = part
 	}
 	e.Unlock()
-	ts := types.BuildTS(time.Now().UTC().UnixNano()-gcPartitionStateTimer.Nanoseconds()*5, 0)
+	ts := types.BuildTS(time.Now().UTC().UnixNano()-gcPartitionStateTimer.Nanoseconds()*1, 0)
 	collector := logtailreplay.NewTruncateCollector()
 	for ids, part := range parts {
 		part.Truncate(ctx, ids, ts, collector)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23645 

## What this PR does / why we need it:

Optimize partition state gc time from 5hrs to 1 hrs


___

### **PR Type**
Enhancement


___

### **Description**
- Reduce partition state garbage collection time from 5 hours to 1 hour

- Adjust timestamp calculation multiplier in `doGCPartitionState` method

- Improves performance of partition state cleanup operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GC Timestamp Calculation"] -- "Change multiplier from 5 to 1" --> B["Faster Partition State Cleanup"]
  B -- "5 hours → 1 hour" --> C["Improved Performance"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logtail_consumer.go</strong><dd><code>Optimize GC timestamp calculation multiplier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/vm/engine/disttae/logtail_consumer.go

<ul><li>Modified <code>doGCPartitionState</code> method to adjust garbage collection <br>timestamp calculation<br> <li> Changed multiplier from 5 to 1 in the timestamp offset calculation<br> <li> Reduces the time window for partition state retention, enabling faster <br>cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23651/files#diff-e17810b9da4ab05c897d8066bbc421520cdaea7c577d50dc64b31ec3aa8d295f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

