### PR TITLE
(fix): TestIssue3288 and TestWaitReadyBeforeRefresh

### DIFF
--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -2038,25 +2038,28 @@ func TestIssue3288(t *testing.T) {
 
 			l1.Close()
 
-			// should lock failed - after auto-create wait timeout, returns ErrBackendClosed
-			_, err = l2.Lock(
-				ctx,
-				0,
-				[][]byte{{1}},
-				[]byte("txn2"),
-				option)
-			require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendClosed))
-
-			time.Sleep(time.Second * 3)
-
-			// should lock succ
-			_, err = l2.Lock(
-				ctx,
-				0,
-				[][]byte{{1}},
-				[]byte("txn2"),
-				option)
-			require.NoError(t, err)
+			// Real scenario: after s1 (l1) dies, s2 (l2) acquires the lock. Caller retries on
+			// ErrBackendClosed or ErrLockTableBindChanged per API contract until success.
+			//
+			// No infinite wait: (1) success -> break; (2) retryable error -> continue; (3) any other
+			// error -> require.NoError fails and test stops; (4) ctx has 10s timeout, so even if we
+			// only ever get retryable errors, Lock() will eventually return context.DeadlineExceeded
+			// and (3) triggers. So the loop always terminates.
+			//
+			// No flakiness: no sleep; outcome is determined only by retry-until-success. CI stable
+			// unless the environment is so slow that allocator cannot move bind within 10s.
+			var result pb.Result
+			for {
+				result, err = l2.Lock(ctx, 0, [][]byte{{1}}, []byte("txn2"), option)
+				if err == nil {
+					break
+				}
+				if moerr.IsMoErrCode(err, moerr.ErrBackendClosed) || moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged) {
+					continue
+				}
+				require.NoError(t, err, "lock must succeed or return retryable error (ErrBackendClosed/ErrLockTableBindChanged)")
+			}
+			_ = result
 
 		},
 		nil,
@@ -2226,13 +2229,24 @@ func TestReLockSuccWithBindChanged(t *testing.T) {
 			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged))
 
 			// should lock succ
-			_, err = l2.Lock(
-				ctx,
-				0,
-				[][]byte{{1}},
-				[]byte("txn2"),
-				option)
-			require.NoError(t, err)
+			for {
+				select {
+				case <-ctx.Done():
+					require.Fail(t, "timeout")
+				default:
+				}
+				_, err = l2.Lock(
+					ctx,
+					0,
+					[][]byte{{1}},
+					[]byte("txn2"),
+					option)
+				if moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged) {
+					continue
+				}
+				require.NoError(t, err)
+				break
+			}
 		},
 		nil,
 	)


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23545 

## What this PR does / why we need it:

1. **TestIssue3288** (pkg/lockservice): Removed dependency on fixed sleep delays and added retry logic for `ErrBackendClosed` and `ErrLockTableBindChanged` errors, aligning with the lockservice API contract that requires callers to retry on these errors.

2. **TestWaitReadyBeforeRefresh** (pkg/clusterservice): Fixed a synchronization bug in `cluster.go` where `close(readyC)` was executed before `ready.Store(true)`, causing a race condition where `waitReady()` could return while `ready` was still false. Reordered operations to ensure proper happens-before guarantees.

## Root Causes

### TestIssue3288
- Flakiness caused by timing race between allocator's bind invalidation (1s interval) and lock table cache
- Test did not retry on `ErrLockTableBindChanged`, which is a valid retryable error per API contract
- Fixed by implementing retry loop for retryable errors instead of relying on fixed sleep

### TestWaitReadyBeforeRefresh
- Implementation bug: `readyOnce.Do` executed `close(readyC)` before `ready.Store(true)`
- Under high load, the goroutine receiving from `readyC` could observe `ready` as false due to cache visibility delay
- Fixed by reordering: `ready.Store(true)` first, then `close(readyC)`, establishing proper synchronization


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed race condition in cluster.go where ready flag was stored after channel close

- Reordered operations to ensure proper synchronization happens-before guarantees

- Replaced fixed sleep delays with retry logic for retryable lock service errors

- Updated tests to handle ErrBackendClosed and ErrLockTableBindChanged as expected


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Race Condition<br/>in cluster.go"] -->|"Reorder operations"| B["ready.Store first<br/>then close channel"]
  C["Fixed Sleep Delays<br/>in lock tests"] -->|"Add retry logic"| D["Retry on retryable<br/>errors"]
  B -->|"Result"| E["Proper synchronization<br/>guarantees"]
  D -->|"Result"| F["Stable CI tests<br/>without flakiness"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cluster.go</strong><dd><code>Fix synchronization order in cluster ready initialization</code></dd></summary>
<hr>

pkg/clusterservice/cluster.go

<ul><li>Reordered <code>ready.Store(true)</code> to execute before <code>close(readyC)</code> in two <br>locations<br> <li> Updated correctness comment to reflect new happens-before guarantee<br> <li> Ensures atomic flag is set before channel is closed for proper <br>synchronization</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23667/files#diff-7b5573810b07a4665c06c877f6404188b0479f535784e4e2baed3d438948e020">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_test.go</strong><dd><code>Replace sleep delays with retry logic in lock tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/service_test.go

<ul><li>Replaced fixed 3-second sleep with retry loop in TestIssue3288<br> <li> Added retry logic for <code>ErrBackendClosed</code> and <code>ErrLockTableBindChanged</code> <br>errors<br> <li> Added context timeout check and retry loop in <br>TestReLockSuccWithBindChanged<br> <li> Removed dependency on timing assumptions, aligning with lockservice <br>API contract</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23667/files#diff-e94812797c8b26ff0499bd86698dbc4371dd72642267baa535a7ecc7f8bf3981">+40/-26</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

