### PR TITLE
(fix): TestAbortRemoteDeadlockTxn hang and waiter ordering race condition

### DIFF
--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -523,11 +523,13 @@ func (l *localLockTable) handleLockConflictLocked(
 	})
 
 	conflictWith.addWaiter(l.logger, c.w)
+	// Set waiter to blocking before adding to events.mu.blockedWaiters so
+	// waiter_events.check() won't remove it (check removes only non-blocking).
+	c.txn.setBlocked(c.w, l.logger)
 	l.events.add(c)
 
 	// find conflict, and wait prev txn completed, and a new
 	// waiter added, we need to active deadlock check.
-	c.txn.setBlocked(c.w, l.logger)
 	logLocalLockWaitOn(l.logger, c.txn, l.bind.Table, c.w, key, conflictWith)
 
 	if c.opts.Granularity != pb.Granularity_Range {


### PR DESCRIPTION
### **User description**
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23665

## What this PR does / why we need it:

**Root cause**: Waiter was added to `events.mu.blockedWaiters` (status=ready) before being set to blocking state via `setBlocked()`. This created a race window where `waiter_events.check()` could remove the waiter as "non-blocking" before `setBlocked()` completed.

**Fix**: Reorder operations to call `setBlocked()` before `events.add()`:
- Ensures waiter is in blocking state before entering `blockedWaiters`
- Prevents `check()` from incorrectly removing valid waiters
- Eliminates the race condition


___

### **PR Type**
Bug fix


___

### **Description**
- Fix race condition in waiter blocking state initialization

- Reorder `setBlocked()` call before `events.add()` to prevent premature waiter removal

- Improve test reliability with timeout-based polling and assertion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["addWaiter<br/>to waiters list"] --> B["setBlocked<br/>mark as blocking"]
  B --> C["events.add<br/>add to blockedWaiters"]
  C --> D["waiter_events.check<br/>won't remove blocking waiter"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lock_table_local.go</strong><dd><code>Reorder waiter blocking state initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/lock_table_local.go

<ul><li>Move <code>setBlocked()</code> call before <code>events.add()</code> to establish blocking state <br>first<br> <li> Add explanatory comment about race condition prevention<br> <li> Ensures waiter is marked as blocking before entering <code>blockedWaiters</code> <br>queue</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23668/files#diff-58b0bb851b3377534881bd5d6ef248e668d5a5081e2f11f2dbd3e3289c9c2f8d">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>service_test.go</strong><dd><code>Add timeout and assertion to waiter queue test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pkg/lockservice/service_test.go

<ul><li>Replace infinite loop with timeout-based polling (5 second deadline)<br> <li> Add small sleep interval (5ms) to prevent busy-waiting<br> <li> Add explicit assertion to verify exactly one blocked waiter exists<br> <li> Improve test robustness and prevent hangs</ul>


</details>


  </td>
  <td><a href="https://github.com/matrixorigin/matrixone/pull/23668/files#diff-e94812797c8b26ff0499bd86698dbc4371dd72642267baa535a7ecc7f8bf3981">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

