### PR TITLE
fix: StarCount with snapshot can return 0 by counting rows in persisted appendable objects

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -1024,11 +1024,13 @@ func NewLogServiceNotReady(ctx context.Context) *Error {
 }
 
 func NewBadDB(ctx context.Context, name string) *Error {
-	return newError(ctx, ErrBadDB, name)
+	noReportCtx := errutil.ContextWithNoReport(ctx, true)
+	return newError(noReportCtx, ErrBadDB, name)
 }
 
 func NewNoDB(ctx context.Context) *Error {
-	return newError(ctx, ErrNoDB)
+	noReportCtx := errutil.ContextWithNoReport(ctx, true)
+	return newError(noReportCtx, ErrNoDB)
 }
 
 func NewNoWorkingStore(ctx context.Context) *Error {
@@ -1060,11 +1062,13 @@ func NewNotLeaseHolder(ctx context.Context, holderId uint64) *Error {
 }
 
 func NewNoSuchTable(ctx context.Context, db, tbl string) *Error {
-	return newError(ctx, ErrNoSuchTable, db, tbl)
+	noReportCtx := errutil.ContextWithNoReport(ctx, true)
+	return newError(noReportCtx, ErrNoSuchTable, db, tbl)
 }
 
 func NewNoSuchSequence(ctx context.Context, db, tbl string) *Error {
-	return newError(ctx, ErrNoSuchSequence, db, tbl)
+	noReportCtx := errutil.ContextWithNoReport(ctx, true)
+	return newError(noReportCtx, ErrNoSuchSequence, db, tbl)
 }
 
 func NewBadView(ctx context.Context, db, v string) *Error {

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -180,11 +180,11 @@ func NewInvalidServiceIndexNoCtx(idx int) *Error {
 }
 
 func NewBadDBNoCtx(name string) *Error {
-	return newError(Context(), ErrBadDB, name)
+	return newError(NoReportContext(), ErrBadDB, name)
 }
 
 func NewNoDBNoCtx() *Error {
-	return newError(Context(), ErrNoDB)
+	return newError(NoReportContext(), ErrNoDB)
 }
 
 func NewNoWorkingStoreNoCtx() *Error {
@@ -204,7 +204,7 @@ func NewWrongServiceNoCtx(exp, got string) *Error {
 }
 
 func NewNoSuchTableNoCtx(db, tbl string) *Error {
-	return newError(Context(), ErrNoSuchTable, db, tbl)
+	return newError(NoReportContext(), ErrNoSuchTable, db, tbl)
 }
 
 // NewClientClosedNoCtx creates a client closed error without logging.

--- a/pkg/util/errutil/errors.go
+++ b/pkg/util/errutil/errors.go
@@ -62,6 +62,9 @@ type noReportKeyType int
 const noReportKey noReportKeyType = iota
 
 func ContextWithNoReport(parent context.Context, no bool) context.Context {
+	if parent == nil {
+		parent = context.Background()
+	}
 	return context.WithValue(parent, noReportKey, no)
 }
 

--- a/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
+++ b/pkg/util/metric/v2/dashboard/grafana_dashboard_txn.go
@@ -271,7 +271,21 @@ func (c *DashboardCreator) initTxnStarcountRow() dashboard.Option {
 		6,
 		axis.Min(1))
 
-	options := []row.Option{pathRate, durationHistogram, resultRowsHistogram, ratioHistogram}
+	// Appendable data object scan (S3 I/O when counting rows by commit_ts)
+	appendableScanDurationHistogram := c.getHistogram(
+		"StarCount Appendable Scan Duration (appendable 块扫描 S3 耗时)",
+		c.getMetricWithFilter(`mo_txn_starcount_appendable_scan_duration_seconds_bucket`, ``),
+		[]float64{0.50, 0.8, 0.90, 0.99},
+		6,
+		axis.Unit("s"), axis.Min(0))
+	appendableObjectsScannedHistogram := c.getHistogram(
+		"StarCount Appendable Objects Scanned (每次调用扫描的 appendable 对象数)",
+		c.getMetricWithFilter(`mo_txn_starcount_appendable_objects_scanned_bucket`, ``),
+		[]float64{0.50, 0.8, 0.90, 0.99},
+		6,
+		axis.Min(0))
+
+	options := []row.Option{pathRate, durationHistogram, resultRowsHistogram, ratioHistogram, appendableScanDurationHistogram, appendableObjectsScannedHistogram}
 	options = append(options, estimateHistograms...)
 
 	return dashboard.Row(

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -186,6 +186,8 @@ func initTxnMetrics() {
 	registry.MustRegister(StarcountEstimateTombstoneRowsHistogram)
 	registry.MustRegister(StarcountEstimateTombstoneObjectsHistogram)
 	registry.MustRegister(StarcountEstimateOverActualRatioHistogram)
+	registry.MustRegister(StarcountAppendableScanDurationSecondsHistogram)
+	registry.MustRegister(StarcountAppendableObjectsScannedHistogram)
 }
 
 func initRPCMetrics() {

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -597,4 +597,22 @@ var (
 			Help:      "Ratio of estimated tombstone rows over actual (dedup) tombstone rows. High ratio (e.g. 100x) means estimate is loose.",
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 14), // 1, 2, 4, ..., 8192
 		})
+
+	// Appendable data object scan (S3 I/O) when counting visible rows by commit_ts
+	StarcountAppendableScanDurationSecondsHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "mo",
+			Subsystem: "txn",
+			Name:      "starcount_appendable_scan_duration_seconds",
+			Help:      "Duration of scanning appendable data objects (S3 I/O) to count rows by commit_ts. Use for monitoring StarCount appendable path cost.",
+			Buckets:   getDurationBuckets(),
+		})
+	StarcountAppendableObjectsScannedHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "mo",
+			Subsystem: "txn",
+			Name:      "starcount_appendable_objects_scanned",
+			Help:      "Number of appendable data objects scanned (S3 I/O) per CollectDataStats call. Use for monitoring appendable scan volume.",
+			Buckets:   prometheus.ExponentialBuckets(1, 5, 10), // 1 to ~2e6
+		})
 )

--- a/pkg/vm/engine/disttae/mo_table_stats.go
+++ b/pkg/vm/engine/disttae/mo_table_stats.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/bytejson"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
@@ -2545,8 +2546,10 @@ func (d *dynamicCtx) statsCalculateOp(
 
 	born := time.Now()
 
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
 	// Use the new CalculateTableStats function in partition state
-	stats, err := pState.CalculateTableStats(ctx, snapshot, fs)
+	stats, err := pState.CalculateTableStats(ctx, snapshot, fs, mp)
 	if err != nil {
 		return sl, err
 	}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -657,7 +657,7 @@ func (tbl *txnTable) StarCount(ctx context.Context) (uint64, error) {
 
 	// Fast path: readonly transaction has no uncommitted data
 	if tbl.getTxn().ReadOnly() {
-		return part.CountRows(ctx, types.TimestampToTS(snapshot), fs)
+		return part.CountRows(ctx, types.TimestampToTS(snapshot), fs, tbl.getTxn().proc.Mp())
 	}
 
 	// Determine the range of workspace entries to scan.
@@ -684,7 +684,7 @@ func (tbl *txnTable) StarCount(ctx context.Context) (uint64, error) {
 
 	// Get committed row count from PartitionState.
 	// This already accounts for committed inserts minus committed tombstones.
-	committedRows, err := part.CountRows(ctx, types.TimestampToTS(snapshot), fs)
+	committedRows, err := part.CountRows(ctx, types.TimestampToTS(snapshot), fs, tbl.getTxn().proc.Mp())
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23671 

## What this PR does / why we need it:

  ### Problem
  `SELECT count(*) FROM t { snapshot = '...' }` could return 0 instead of the real row count when some rows lived only in persisted appendable data (already
  flushed from in-memory state). CollectDataStats only used metadata for non-appendable objects and the in-memory rows btree, so it skipped those persisted
  appendable rows.
  ### Solution
  - Extend CollectDataStats to take ctx and fs, and for each visible appendable data object scan its blocks, read the commit_ts column, and count rows with
  commit_ts <= snapshot (same visibility rule as elsewhere).
  - Add countVisibleRowsInAppendableObject to perform this block scan and return an error on I/O failure.
  - Make CollectDataStats and its callers (CountRows, CalculateTableStats) propagate errors and accept an mpool argument instead of allocating one per object.