### PR TITLE
morpc: fix backend logger memory, 10s GC for closed backends, and pipeline stream metric

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/fagongzi/goetty/v2"
-	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/moprobe"
 	"github.com/matrixorigin/matrixone/pkg/common/stopper"
@@ -148,6 +147,8 @@ type remoteBackend struct {
 	remote          string
 	metrics         *metrics
 	logger          *zap.Logger
+	logID           uint64 // stable id for log fields, set in adjust(); avoids per-backend zap Logger clone
+	logFieldsCache  []zap.Field // cached for logFields(), set once in adjust() to avoid alloc per log call
 	rateLimitLogger *logutil.RateLimitedLogger
 	codec           Codec
 	conn            goetty.IOSession
@@ -252,7 +253,7 @@ func NewRemoteBackend(
 	rb.conn = goetty.NewIOSession(rb.options.goettyOptions...)
 
 	if err := rb.resetConn(); err != nil {
-		rb.logger.Error("connect to remote failed")
+		rb.logger.Error("connect to remote failed", rb.logFields()...)
 		return nil, err
 	}
 	rb.activeReadLoop(false)
@@ -290,14 +291,24 @@ func (rb *remoteBackend) adjust() {
 		}
 	}
 
-	uid, _ := uuid.NewV7()
-	rb.logger = logutil.Adjust(rb.logger).With(zap.String("remote", rb.remote),
-		zap.String("backend-id", uid.String()))
+	// Use shared logger and add remote/logID at log sites to avoid cloning the zap core
+	// chain per backend. Each Logger.With() can trigger zapcore.newCounters (Sampler);
+	// under sysbench this path reached ~102GB with newCounters alone ~83.4GB. See
+	// docs/worklog_morpc_backend_logger_memory.md.
+	rb.logger = logutil.Adjust(rb.logger)
+	rb.logID = rb.nextID()
+	rb.logFieldsCache = []zap.Field{zap.String("remote", rb.remote), zap.Uint64("backend-id", rb.logID)}
 	rb.rateLimitLogger = logutil.NewRateLimitedLogger(rb.logger)
 	rb.options.goettyOptions = append(rb.options.goettyOptions,
 		goetty.WithSessionCodec(rb.codec))
 	// Don't pass logger to goetty to avoid noisy error logs from goetty library
 	// (e.g., "close connection failed" which is expected during normal connection lifecycle)
+}
+
+// logFields returns zap fields for this backend; use at log sites instead of a per-backend Logger.With().
+// Returns cached slice (set once in adjust()) to avoid allocating per log call.
+func (rb *remoteBackend) logFields() []zap.Field {
+	return rb.logFieldsCache
 }
 
 func (rb *remoteBackend) Send(ctx context.Context, request Message) (*Future, error) {
@@ -462,14 +473,14 @@ func (rb *remoteBackend) changeToStopping() {
 }
 
 func (rb *remoteBackend) writeLoop(ctx context.Context) {
-	rb.logger.Debug("write loop started")
+	rb.logger.Debug("write loop started", rb.logFields()...)
 	defer func() {
 		rb.pingTimer.Stop()
 		rb.closeConn(false)
 		rb.readStopper.Stop()
 		rb.closeConn(true)
 		close(rb.waitWriteC)
-		rb.logger.Debug("write loop stopped")
+		rb.logger.Debug("write loop stopped", rb.logFields()...)
 	}()
 
 	defer func() {
@@ -481,7 +492,7 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 	defer func() {
 		if err := recover(); err != nil {
 			rb.logger.Fatal("write loop failed",
-				zap.Any("err", err))
+				append(rb.logFields(), zap.Any("err", err))...)
 		}
 	}()
 
@@ -553,8 +564,7 @@ func (rb *remoteBackend) writeLoop(ctx context.Context) {
 						id := f.getSendMessageID()
 						rb.rateLimitLogger.Error("write-flush",
 							"write request failed",
-							zap.Uint64("request-id", id),
-							zap.Error(err))
+							append(rb.logFields(), zap.Uint64("request-id", id), zap.Error(err))...)
 						f.messageSent(err)
 					}
 				} else {
@@ -597,13 +607,13 @@ func (rb *remoteBackend) doWrite(id uint64, f *Future) time.Duration {
 		conn.SetWriteDeadline(time.Now().Add(v))
 	}
 	if ce := rb.logger.Check(zap.DebugLevel, "write request"); ce != nil {
-		ce.Write(zap.Uint64("request-id", id),
-			zap.String("request", f.send.Message.DebugString()))
+		ce.Write(append(rb.logFields(), zap.Uint64("request-id", id),
+			zap.String("request", f.send.Message.DebugString()))...)
 	}
 	if err := rb.conn.Write(f.send, goetty.WriteOptions{}); err != nil {
 		rb.rateLimitLogger.Error("write-conn",
 			"write request failed",
-			zap.Uint64("request-id", id), zap.Error(err))
+			append(rb.logFields(), zap.Uint64("request-id", id), zap.Error(err))...)
 		f.messageSent(err)
 		return 0
 	}
@@ -611,13 +621,13 @@ func (rb *remoteBackend) doWrite(id uint64, f *Future) time.Duration {
 }
 
 func (rb *remoteBackend) readLoop(ctx context.Context) {
-	rb.logger.Debug("read loop started")
+	rb.logger.Debug("read loop started", rb.logFields()...)
 	normalExit := false
 	defer func() {
 		if normalExit {
-			rb.logger.Debug("read loop stopped")
+			rb.logger.Debug("read loop stopped", rb.logFields()...)
 		} else {
-			rb.logger.Error("read loop stopped")
+			rb.logger.Error("read loop stopped", rb.logFields()...)
 		}
 	}()
 
@@ -631,7 +641,7 @@ func (rb *remoteBackend) readLoop(ctx context.Context) {
 	defer func() {
 		if err := recover(); err != nil {
 			rb.logger.Fatal("read loop failed",
-				zap.Any("err", err))
+				append(rb.logFields(), zap.Any("err", err))...)
 		}
 	}()
 
@@ -658,7 +668,7 @@ func (rb *remoteBackend) readLoop(ctx context.Context) {
 				} else {
 					rb.rateLimitLogger.Error("read-loop",
 						"read from backend failed",
-						zap.Error(err))
+						append(rb.logFields(), zap.Error(err))...)
 				}
 				rb.inactiveReadLoop()
 				rb.cancelActiveStreams()
@@ -796,7 +806,7 @@ func (rb *remoteBackend) handleResetConn() error {
 	if err := rb.resetConn(); err != nil {
 		rb.rateLimitLogger.Error("reset-conn",
 			"fail to reset backend connection",
-			zap.Error(err))
+			append(rb.logFields(), zap.Error(err))...)
 		rb.inactive()
 		return err
 	}
@@ -873,8 +883,8 @@ func (rb *remoteBackend) requestDone(
 		if response != nil {
 			debugStr = response.DebugString()
 		}
-		ce.Write(zap.Uint64("request-id", id),
-			zap.String("response", debugStr))
+		ce.Write(append(rb.logFields(), zap.Uint64("request-id", id),
+			zap.String("response", debugStr))...)
 	}
 
 	rb.mu.Lock()
@@ -954,12 +964,12 @@ func (rb *remoteBackend) resetConn() error {
 		default:
 		}
 
-		rb.logger.Debug("start connect to remote")
+		rb.logger.Debug("start connect to remote", rb.logFields()...)
 		rb.closeConn(false)
 		rb.metrics.connectCounter.Inc()
 		err := rb.conn.Connect(rb.remote, rb.options.connectTimeout)
 		if err == nil {
-			rb.logger.Debug("connect to remote succeed")
+			rb.logger.Debug("connect to remote succeed", rb.logFields()...)
 			rb.activeReadLoop(false)
 			return nil
 		}
@@ -973,8 +983,7 @@ func (rb *remoteBackend) resetConn() error {
 		}
 		rb.rateLimitLogger.Error("connect-retry",
 			"init remote connection failed, retry later",
-			zap.Bool("can-retry", canRetry),
-			zap.Error(err))
+			append(rb.logFields(), zap.Bool("can-retry", canRetry), zap.Error(err))...)
 
 		if !canRetry {
 			return moerr.NewBackendCannotConnectNoCtx(err)
@@ -1024,7 +1033,7 @@ func (rb *remoteBackend) activeReadLoop(locked bool) {
 	}
 
 	if err := rb.readStopper.RunTask(rb.readLoop); err != nil {
-		rb.logger.Error("active read loop failed", zap.Error(err))
+		rb.logger.Error("active read loop failed", append(rb.logFields(), zap.Error(err))...)
 		return
 	}
 	rb.stateMu.readLoopActive = true
@@ -1051,7 +1060,7 @@ func (rb *remoteBackend) scheduleResetConn(err error) {
 
 	select {
 	case rb.resetConnC <- err:
-		rb.logger.Debug("schedule reset remote connection")
+		rb.logger.Debug("schedule reset remote connection", rb.logFields()...)
 	default:
 	}
 }
@@ -1064,10 +1073,11 @@ func (rb *remoteBackend) closeConn(close bool) {
 
 	if err := fn(); err != nil {
 		// Filter out expected errors when closing already closed connections
+		fields := append(rb.logFields(), zap.Error(err))
 		if rb.isExpectedCloseError(err) {
-			rb.logger.Debug("close remote conn failed", zap.Error(err))
+			rb.logger.Debug("close remote conn failed", fields...)
 		} else {
-			rb.logger.Error("close remote conn failed", zap.Error(err))
+			rb.logger.Error("close remote conn failed", fields...)
 		}
 	}
 }
@@ -1243,7 +1253,7 @@ func (s *stream) Send(ctx context.Context, request Message) error {
 	s.mu.RLock()
 	if s.mu.closed {
 		s.mu.RUnlock()
-		s.rb.logger.Warn("stream is closed on send", zap.Uint64("stream-id", s.id))
+		s.rb.logger.Warn("stream is closed on send", append(s.rb.logFields(), zap.Uint64("stream-id", s.id))...)
 		return moerr.NewStreamClosedNoCtx()
 	}
 
@@ -1281,7 +1291,7 @@ func (s *stream) Receive() (chan Message, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.mu.closed {
-		s.rb.logger.Warn("stream is closed on receive", zap.Uint64("stream-id", s.id))
+		s.rb.logger.Warn("stream is closed on receive", append(s.rb.logFields(), zap.Uint64("stream-id", s.id))...)
 		return nil, moerr.NewStreamClosedNoCtx()
 	}
 	return s.c, nil
@@ -1289,7 +1299,7 @@ func (s *stream) Receive() (chan Message, error) {
 
 func (s *stream) Close(closeConn bool) error {
 	if closeConn {
-		s.rb.logger.Info("stream call closed on client", zap.Uint64("stream-id", s.id))
+		s.rb.logger.Info("stream call closed on client", append(s.rb.logFields(), zap.Uint64("stream-id", s.id))...)
 		s.rb.Close()
 	}
 	s.mu.Lock()
@@ -1332,8 +1342,8 @@ func (s *stream) done(
 	}
 	if response != nil &&
 		message.streamSequence != s.lastReceivedSequence+1 {
-		s.rb.logger.Warn("sequence out of order", zap.Uint32("new", message.streamSequence),
-			zap.Uint32("last", s.lastReceivedSequence))
+		s.rb.logger.Warn("sequence out of order", append(s.rb.logFields(),
+			zap.Uint32("new", message.streamSequence), zap.Uint32("last", s.lastReceivedSequence))...)
 		response = nil
 	}
 

--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -147,7 +147,7 @@ type remoteBackend struct {
 	remote          string
 	metrics         *metrics
 	logger          *zap.Logger
-	logID           uint64 // stable id for log fields, set in adjust(); avoids per-backend zap Logger clone
+	logID           uint64      // stable id for log fields, set in adjust(); avoids per-backend zap Logger clone
 	logFieldsCache  []zap.Field // cached for logFields(), set once in adjust() to avoid alloc per log call
 	rateLimitLogger *logutil.RateLimitedLogger
 	codec           Codec

--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -405,7 +405,7 @@ func (rb *remoteBackend) doSend(f *Future) error {
 }
 
 func (rb *remoteBackend) Close() {
-	rb.metrics.closeCounter.Inc()
+	// closeCounter is incremented once per backend in doClose() to avoid double-counting when Close() is called multiple times.
 	rb.cancelOnce.Do(func() {
 		rb.cancel()
 	})
@@ -819,6 +819,9 @@ func (rb *remoteBackend) doClose() {
 		rb.closeConn(false)
 		// TODO: re create when reconnect
 		rb.conn = nil
+		if rb.metrics != nil {
+			rb.metrics.closeCounter.Inc()
+		}
 	})
 }
 

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -272,7 +272,8 @@ func TestServerTimeoutCacheWillRemoved(t *testing.T) {
 			assert.NoError(t, st.Close(false))
 		}()
 
-		assert.NoError(t, st.Send(ctx, newTestMessage(1)))
+		// Stream.Send requires request.GetID() == stream.ID(); stream id is assigned by backend at NewStream().
+		assert.NoError(t, st.Send(ctx, newTestMessage(st.ID())))
 		<-cc
 		v, ok := rs.sessions.Load(uint64(1))
 		if ok {

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -373,7 +373,7 @@ func newMessageSenderOnClient(
 		sender.receiveCh, err = sender.streamSender.Receive()
 	}
 
-	v2.PipelineMessageSenderCounter.Inc()
+	v2.PipelineMessageSenderGauge.Inc()
 	return sender, moerr.AttachCause(ctx, err)
 }
 
@@ -555,5 +555,5 @@ func (sender *messageSenderOnClient) close() {
 	}
 	_ = sender.streamSender.Close(true)
 
-	v2.PipelineMessageSenderCounter.Desc()
+	v2.PipelineMessageSenderGauge.Dec()
 }

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/cnservice/cnclient"
@@ -341,6 +342,10 @@ type messageSenderOnClient struct {
 	safeToClose bool
 	// alreadyClose should be true once we get a stream closed signal.
 	alreadyClose bool
+
+	// gaugeDecOnce ensures PipelineMessageSenderGauge.Dec() is called at most once when close() runs
+	// (including when close() returns early because alreadyClose is true, so the gauge still decrements).
+	gaugeDecOnce sync.Once
 }
 
 func newMessageSenderOnClient(
@@ -373,7 +378,11 @@ func newMessageSenderOnClient(
 		sender.receiveCh, err = sender.streamSender.Receive()
 	}
 
-	v2.PipelineMessageSenderGauge.Inc()
+	// Only Inc() when we return a valid sender that the caller will eventually close();
+	// when Receive() fails, remoteRun returns nil and never calls close(), so we must not Inc() to avoid gauge leak.
+	if err == nil {
+		v2.PipelineMessageSenderGauge.Inc()
+	}
 	return sender, moerr.AttachCause(ctx, err)
 }
 
@@ -545,6 +554,10 @@ func (sender *messageSenderOnClient) dealRemoteAnalysis(p models.PhyPlan) {
 }
 
 func (sender *messageSenderOnClient) close() {
+	// Ensure Gauge is decremented exactly once when this sender is torn down, including when
+	// alreadyClose is true (stream already closed by remote); otherwise we'd leak the gauge.
+	defer sender.gaugeDecOnce.Do(func() { v2.PipelineMessageSenderGauge.Dec() })
+
 	sender.waitingTheStopResponse()
 
 	if sender.ctxCancel != nil {
@@ -554,6 +567,4 @@ func (sender *messageSenderOnClient) close() {
 		return
 	}
 	_ = sender.streamSender.Close(true)
-
-	v2.PipelineMessageSenderGauge.Dec()
 }

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -250,7 +250,7 @@ func initFrontendMetrics() {
 
 func initPipelineMetrics() {
 	registry.MustRegister(PipelineServerDurationHistogram)
-	registry.MustRegister(pipelineStreamCounter)
+	registry.MustRegister(pipelineStreamGauge)
 }
 
 func initLogServiceMetrics() {

--- a/pkg/util/metric/v2/pipeline.go
+++ b/pkg/util/metric/v2/pipeline.go
@@ -26,12 +26,14 @@ var (
 			Buckets:   getDurationBuckets(),
 		})
 
-	pipelineStreamCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	// Gauge (not Counter): "living" senders must Inc() on create and Dec() on close.
+	// Counter only ever increases; calling .Desc() does not decrement (Desc is metric metadata).
+	pipelineStreamGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Namespace: "mo",
 			Subsystem: "pipeline",
 			Name:      "stream_connection",
-			Help:      "Total number of stream connections to send messages to other CN.",
+			Help:      "Current number of stream connections to send messages to other CN (living senders).",
 		}, []string{"type"})
-	PipelineMessageSenderCounter = pipelineStreamCounter.WithLabelValues("living")
+	PipelineMessageSenderGauge = pipelineStreamGauge.WithLabelValues("living")
 )


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23680 

## What this PR does / why we need it:

  **1. Backend logger memory (backend.go)**
  - Stop using Logger.With() per backend to avoid cloning the zap core chain and newCounters growth (e.g. ~83GB under sysbench).
  - Use a shared logger and add logID + logFieldsCache in adjust(); all log sites use rb.logFields() or append(rb.logFields(), ...).
  - Add backend tests and adjust server_test as needed.
  
  **2. 10s GC for closed backends (client.go, client_gc.go)**
  - Explicitly closed (inactive) backends (LastActiveTime == zero) are now removed from the pool within ~10s instead of waiting for the 1-minute idle timeout.

  - Add client.doRemoveInactiveAll() and, in the existing GC idle goroutine, a 10s ticker that runs doGCInactivePeriodic() for all registered clients (no
  extra goroutine).
  - Cleanup is per-remote; only inactive backends are removed.
  
  **3. Pipeline stream metric (remoterunClient, metrics, pipeline)**
  - Replace pipeline stream Counter with a Gauge: living senders Inc() on create and Dec() on close. Counter never decreased and Desc() does not decrement, so
   the metric now reflects current number of stream connections.