### PR TITLE
fix: fix pipeline client leak

### DIFF
--- a/pkg/common/morpc/backend.go
+++ b/pkg/common/morpc/backend.go
@@ -681,7 +681,10 @@ func (rb *remoteBackend) readLoop(ctx context.Context) {
 			}
 			rb.metrics.receiveCounter.Inc()
 
-			rb.active()
+			// Only update lastActiveTime for user traffic; heartbeat (internal) should not prevent idle timeout.
+			if rpcm, ok := msg.(interface{ InternalMessage() bool }); ok && !rpcm.InternalMessage() {
+				rb.active()
+			}
 
 			if rb.options.hasPayloadResponse {
 				wg.Add(1)

--- a/pkg/common/morpc/client.go
+++ b/pkg/common/morpc/client.go
@@ -942,7 +942,10 @@ func (c *client) getBackendLocked(backend string, lock bool) (Backend, error) {
 		if lock && b != nil {
 			b.Lock()
 		}
-		c.maybeCreateLocked(backend)
+		// Only try to create when no available backend was found; avoid unbounded growth when backends are locked.
+		if b == nil {
+			c.maybeCreateLocked(backend)
+		}
 		return b, nil
 	}
 	return nil, nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23680 

## What this PR does / why we need it:

  ### Summary
  - **readLoop**: Call `active()` only for non-internal messages. Heartbeat (ping/pong) no longer updates `LastActiveTime`, so idle
  GC can close backends that only receive heartbeats and avoid connection leaks.
  - **getBackendLocked**: Call `maybeCreateLocked` only when no available backend was found (`b == nil`), preventing unbounded
  backend growth when backends are locked/busy.