### PR TITLE
OBCollector spin up too many go routines.

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -162,11 +162,11 @@ var (
 	defaultOBBufferSize int64 = 10485760
 
 	// defaultOBCollectorCntPercent
-	defaultOBCollectorCntPercent = 1000
+	defaultOBCollectorCntPercent = 10
 	// defaultOBGeneratorCntPercent
-	defaultOBGeneratorCntPercent = 1000
+	defaultOBGeneratorCntPercent = 20
 	// defaultOBExporterCntPercent
-	defaultOBExporterCntPercent = 1000
+	defaultOBExporterCntPercent = 80
 
 	// defaultPrintDebugInterval default: 30 minutes
 	defaultPrintDebugInterval = 30

--- a/pkg/util/export/batch_processor.go
+++ b/pkg/util/export/batch_processor.go
@@ -442,8 +442,6 @@ func NewMOCollector(
 	return c
 }
 
-const maxPercentValue = 1000
-
 // calculateDefaultWorker
 // totalNum = int( #cpu * 0.1 + 0.5 )
 // default collectorCntP : generatorCntP : exporterCntP = 10 : 20 : 80.
@@ -482,17 +480,6 @@ func (c *MOCollector) calculateDefaultWorker(numCpu int) {
 	}
 	if c.exporterCnt > numCpu {
 		c.exporterCnt = numCpu
-	}
-
-	// last check: disable calculation
-	if c.collectorCnt >= maxPercentValue {
-		c.collectorCnt = numCpu
-	}
-	if c.generatorCntP >= maxPercentValue {
-		c.generatorCnt = numCpu
-	}
-	if c.exporterCnt >= maxPercentValue {
-		c.generatorCnt = numCpu
 	}
 }
 

--- a/pkg/util/export/batch_processor.go
+++ b/pkg/util/export/batch_processor.go
@@ -457,10 +457,16 @@ func NewMOCollector(
 func (c *MOCollector) calculateDefaultWorker(numCpu int) {
 	var totalNum = math.Ceil(float64(numCpu) * 0.1)
 	unit := float64(totalNum) / (100.0)
-	// set default value if non-set
-	c.collectorCnt = int(math.Round(unit * float64(c.collectorCntP)))
-	c.generatorCnt = int(math.Round(unit * float64(c.generatorCntP)))
-	c.exporterCnt = int(math.Round(unit * float64(c.exporterCntP)))
+	// set default value if non-set; explicit cnt (set via WithCollectorCnt/etc.) wins.
+	if c.collectorCnt <= 0 {
+		c.collectorCnt = int(math.Round(unit * float64(c.collectorCntP)))
+	}
+	if c.generatorCnt <= 0 {
+		c.generatorCnt = int(math.Round(unit * float64(c.generatorCntP)))
+	}
+	if c.exporterCnt <= 0 {
+		c.exporterCnt = int(math.Round(unit * float64(c.exporterCntP)))
+	}
 	if c.collectorCnt <= 0 {
 		c.collectorCnt = 1
 	}
@@ -491,6 +497,19 @@ func WithGeneratorCntP(p int) MOCollectorOption {
 }
 func WithExporterCntP(p int) MOCollectorOption {
 	return MOCollectorOption(func(c *MOCollector) { c.exporterCntP = p })
+}
+
+// WithCollectorCnt sets the collector worker count directly, bypassing the
+// percent-based calculation. Mainly useful for tests that need deterministic
+// worker counts independent of runtime.NumCPU().
+func WithCollectorCnt(n int) MOCollectorOption {
+	return MOCollectorOption(func(c *MOCollector) { c.collectorCnt = n })
+}
+func WithGeneratorCnt(n int) MOCollectorOption {
+	return MOCollectorOption(func(c *MOCollector) { c.generatorCnt = n })
+}
+func WithExporterCnt(n int) MOCollectorOption {
+	return MOCollectorOption(func(c *MOCollector) { c.exporterCnt = n })
 }
 
 func WithOBCollectorConfig(cfg *config.OBCollectorConfig) MOCollectorOption {

--- a/pkg/util/export/batch_processor_test.go
+++ b/pkg/util/export/batch_processor_test.go
@@ -370,9 +370,9 @@ func Test_newBufferHolder_AddAfterStop(t *testing.T) {
 func getDummyOBCollectorConfig() *config.OBCollectorConfig {
 	cfg := &config.OBCollectorConfig{}
 	cfg.SetDefaultValues()
-	cfg.ExporterCntPercent = maxPercentValue
-	cfg.GeneratorCntPercent = maxPercentValue
-	cfg.CollectorCntPercent = maxPercentValue
+	cfg.ExporterCntPercent = 100
+	cfg.GeneratorCntPercent = 100
+	cfg.CollectorCntPercent = 100
 	return cfg
 }
 

--- a/pkg/util/export/batch_processor_test.go
+++ b/pkg/util/export/batch_processor_test.go
@@ -261,7 +261,13 @@ func TestNewMOCollector_BufferCnt(t *testing.T) {
 	cfg := getDummyOBCollectorConfig()
 	cfg.ShowStatsInterval.Duration = 5 * time.Second
 	cfg.BufferCnt = 2
-	collector := NewMOCollector(ctx, "", WithOBCollectorConfig(cfg))
+	// The test stalls two batches inside GetBatch concurrently, so it needs at
+	// least 2 generator workers regardless of host CPU count. Pin them
+	// explicitly to keep the test deterministic on small CI runners.
+	collector := NewMOCollector(ctx, "",
+		WithOBCollectorConfig(cfg),
+		WithGeneratorCnt(2),
+	)
 	collector.Register(newDummy(0), &dummyPipeImpl{ch: ch, duration: time.Hour})
 	collector.Start()
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23747 

## What this PR does / why we need it:

Computation of OBCollector number of threads is just wrong.