### PR TITLE
to 3.0: fix: force CTAS follow-up insert to run on one CN

### DIFF
--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -1497,6 +1497,9 @@ func (s *Scope) CreateTable(c *Compile) error {
 	}
 
 	if createAsSelectSql := qry.GetCreateAsSelectSql(); createAsSelectSql != "" {
+		// Mark current txn as DDL before compiling CTAS follow-up INSERT ... SELECT,
+		// so internal SQL stays on one CN and can see uncommitted table metadata.
+		c.setHaveDDL(true)
 		res, err := func() (executor.Result, error) {
 			oldCtx := c.proc.Ctx
 			// Force privilege checking for CTAS follow-up INSERT ... SELECT.
@@ -1761,6 +1764,9 @@ func (s *Scope) CreateTempTable(c *Compile) error {
 	}
 
 	if createAsSelectSql := qry.GetCreateAsSelectSql(); createAsSelectSql != "" {
+		// Mark current txn as DDL before compiling CTAS follow-up INSERT ... SELECT,
+		// so internal SQL stays on one CN and can see uncommitted table metadata.
+		c.setHaveDDL(true)
 		res, err := func() (executor.Result, error) {
 			oldCtx := c.proc.Ctx
 			// Force privilege checking for CTAS follow-up INSERT ... SELECT.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/23744

## What this PR does / why we need it:

For CTAS, table creation and data population now happen in the same transaction.
  the newly created target table (including hidden auto-increment/fake-pk metadata), causing pre-insert auto-increment
  lookup to fail as no such table.

  ## Fix

  Before executing the CTAS follow-up internal SQL (createAsSelectSql), mark the current transaction as having DDL:

  - pkg/sql/compile/ddl.go (normal CTAS path)
  - pkg/sql/compile/ddl.go (temp table CTAS path)

  This makes the internal SQL compile path choose one-CN execution, so the follow-up insert runs on the coordinator CN
  and can access uncommitted metadata in the same transaction.

  ## Why This Is Safe

  - Scope is limited to CTAS internal follow-up SQL only.
  - No user-visible SQL semantics are changed.
  - This is a correctness-first mitigation; only CTAS internal insert distribution is constrained.

  ## Impact

  - Fixes CTAS failures in multi-CN for same-transaction create+insert scenarios.
  - Potentially reduces parallelism for CTAS follow-up insert (expected and acceptable for correctness).