### PR TITLE
BUG: check valid haswell before substitute

### DIFF
--- a/thirdparties/Makefile
+++ b/thirdparties/Makefile
@@ -75,7 +75,9 @@ install/include/usearch.h:
 	cp -r $(FP16_DIR)/* $(USEARCH_DIR)/fp16
 	cp -r $(SIMSIMD_DIR)/* $(USEARCH_DIR)/simsimd
 	cp -r $(STRINGZILLA_DIR)/* $(USEARCH_DIR)/stringzilla
-	sed -i -e "s/march=native/march=haswell/g" $(USEARCH_DIR)/CMakeLists.txt
+	@if $(CC) -march=haswell -E - < /dev/null > /dev/null 2>&1; then \
+		sed -i -e "s/march=native/march=haswell/g" $(USEARCH_DIR)/CMakeLists.txt; \
+	fi
 	(cd $(USEARCH_DIR) && cmake -B build $(USEARCH_CMAKE_FLAG) && cmake --build build --config Release)
 ifeq ($(UNAME_S),darwin)
 	cp $(USEARCH_DIR)/build/*.dylib install/lib


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23305

## What this PR does / why we need it:

valid haswell is valid before substitute.