### PR TITLE
config: increase defaultCreateTxnOpTimeout to 2min and add S3FS read/write internal phase metrics

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -200,7 +200,7 @@ var (
 
 	CNPrimaryCheck atomic.Bool
 
-	defaultCreateTxnOpTimeout = time.Minute
+	defaultCreateTxnOpTimeout = 2 * time.Minute
 
 	defaultConnectTimeout = time.Minute
 )

--- a/pkg/util/metric/v2/fileservice.go
+++ b/pkg/util/metric/v2/fileservice.go
@@ -129,6 +129,16 @@ var (
 	FSReadDurationIOReadAll         = fsReadWriteDuration.WithLabelValues("io-read-all")
 
 	FSWriteDurationWrite = fsReadWriteDuration.WithLabelValues("write")
+
+	// S3FS Read internal phase metrics
+	FSReadDurationTotal    = fsReadWriteDuration.WithLabelValues("s3fs-read-total")
+	FSReadDurationIOMerger = fsReadWriteDuration.WithLabelValues("s3fs-read-io-merger")
+	FSReadDurationS3Read   = fsReadWriteDuration.WithLabelValues("s3fs-read-s3")
+
+	// S3FS Write internal phase metrics
+	FSWriteDurationExists       = fsReadWriteDuration.WithLabelValues("s3fs-write-exists")
+	FSWriteDurationStorage      = fsReadWriteDuration.WithLabelValues("s3fs-write-storage")
+	FSWriteDurationDiskCacheSet = fsReadWriteDuration.WithLabelValues("s3fs-write-disk-cache-setfile")
 )
 
 var (


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/23088

## What this PR does / why we need it:
- Change defaultCreateTxnOpTimeout from 1min to 2min to avoid timeout under high concurrency (1000 connections with MaxActive=56 causes long txn queue)
- Add fine-grained metrics for S3FS Read: total, io-merger wait, s3-read, disk-cache-setfile
- Add fine-grained metrics for S3FS Write: total, exists check, storage write, disk-cache-setfile
