### PR TITLE
fix pr23674

### DIFF
--- a/pkg/frontend/authenticate.go
+++ b/pkg/frontend/authenticate.go
@@ -8878,8 +8878,10 @@ func InitFunction(ses *Session, execCtx *ExecCtx, tenant *TenantInfo, cf *tree.C
 		if err != nil {
 			return err
 		}
-		body = strconv.Quote(string(byt))
-		body = body[1 : len(body)-1]
+		// Keep raw JSON here; SQL-level escaping is applied below.
+		// Using strconv.Quote here would preserve backslashes before JSON quotes
+		// in storage and break json.Unmarshal when invoking python UDFs.
+		body = string(byt)
 	}
 	body = escapeSQLStringForDoubleQuotes(body)
 

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -17,11 +17,13 @@ package frontend
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -47,6 +49,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/queryservice"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
+	mysqlparser "github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/stage"
@@ -143,6 +147,36 @@ func TestEscapeSQLStringForDoubleQuotes(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestEscapeSQLStringForDoubleQuotes_PythonUdfBodyRoundTrip(t *testing.T) {
+	payload := map[string]any{
+		"handler": "pdf_to_markdown",
+		"import":  false,
+		"body":    "def f():\n    return \"ok\"\n",
+	}
+	rawBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+	raw := string(rawBytes)
+
+	scanStringLiteral := func(s string) string {
+		scanner := mysqlparser.NewScanner(dialect.MYSQL, `"`+escapeSQLStringForDoubleQuotes(s)+`"`)
+		typ, val := scanner.Scan()
+		require.Equal(t, mysqlparser.STRING, typ)
+		return val
+	}
+
+	// Regression check: quoting JSON before SQL escaping leaves `\"` in storage,
+	// then python_udf json.Unmarshal fails with "invalid character '\\' ...".
+	bad := strconv.Quote(raw)
+	bad = bad[1 : len(bad)-1]
+	badStored := scanStringLiteral(bad)
+	var decoded map[string]any
+	require.Error(t, json.Unmarshal([]byte(badStored), &decoded))
+
+	goodStored := scanStringLiteral(raw)
+	require.Equal(t, raw, goodStored)
+	require.NoError(t, json.Unmarshal([]byte(goodStored), &decoded))
 }
 
 func TestPrivilegeType_Scope(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #20051

## What this PR does / why we need it:
Fix Python UDF body escaping and local Python UDF service wiring
Background
Creating a Python UDF with a $$...$$ body could fail at runtime with:

invalid character '\\' looking for beginning of object key string

This happened when calling the UDF, even though creation succeeded.

Root Cause
Double-escaping in UDF metadata storage

Python UDF body JSON was first strconv.Quote-escaped, then SQL-escaped again before writing to mo_catalog.mo_user_defined_function.body.
Stored value became {\"handler\":...} instead of valid JSON {"handler":...}.
At execution time, json.Unmarshal in Python UDF path failed.
Runtime service wiring (local launch)

Local launch config did not start Python UDF service or wire CN to Python UDF client, causing missing python udf service.
On macOS, python may be unavailable while python3 exists.
Changes
pkg/frontend/authenticate.go

For non-SQL UDFs, store raw json.Marshal(...) result directly (remove strconv.Quote step).
Keep SQL literal safety via escapeSQLStringForDoubleQuotes(...).
pkg/frontend/authenticate_test.go

Added regression test to verify:
old quoted path fails JSON round-trip,
new path round-trips and unmarshals correctly.
UDF parser behavior / tests

Keep dollar-quoted string backslash preservation behavior and update related parser expectation.
Local launch config

Add Python UDF service in launch config.
Add CN Python UDF client address.
Set Python executable to /usr/bin/python3 for local environment compatibility.
Validation
go test ./pkg/frontend -run TestEscapeSQLStringForDoubleQuotes -count=1
go test ./pkg/sql/parsers/dialect/mysql -run TestValid -count=1
Reproduced SQL flow:
no longer hits invalid character '\\' ... during UDF invocation,
body_hex now starts with 7B22... ({"...) instead of 7B5C22... ({\"...),
UDF invocation proceeds to runtime-level errors (e.g., missing imports/path), confirming serialization issue is fixed.