### PR TITLE
feat: add BIT_COUNT() function (MySQL compatible) (#23798)

### DIFF
--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -32,6 +32,7 @@ import (
 	"hash/crc32"
 	"io"
 	"math"
+	"math/bits"
 	"net"
 	"runtime"
 	"strconv"
@@ -508,6 +509,13 @@ func BinFloat[T constraints.Float](ivecs []*vector.Vector, result vector.Functio
 func BitLengthFunc(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	return opUnaryStrToFixed[int64](ivecs, result, proc, length, func(v string) int64 {
 		return int64(len(v) * 8)
+	}, selectList)
+}
+
+// BitCountFunc implements MySQL BIT_COUNT(N): returns the number of bits set in the argument (treated as unsigned).
+func BitCountFunc[T constraints.Unsigned | constraints.Signed](ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	return opUnaryFixedToFixed[T, int64](ivecs, result, proc, length, func(v T) int64 {
+		return int64(bits.OnesCount64(uint64(v)))
 	}, selectList)
 }
 

--- a/pkg/sql/plan/function/func_unary_test.go
+++ b/pkg/sql/plan/function/func_unary_test.go
@@ -1072,6 +1072,70 @@ func TestBitLengthFunc(t *testing.T) {
 	}
 }
 
+func initBitCountFuncTestCase() []tcTemp {
+	return []tcTemp{
+		{
+			info: "test BitCountFunc int64: MySQL BIT_COUNT(8), BIT_COUNT(24), BIT_COUNT(28), BIT_COUNT(255)",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_int64.ToType(),
+					[]int64{8, 24, 28, 255},
+					[]bool{false, false, false, false}),
+			},
+			expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+				[]int64{1, 2, 3, 8},
+				[]bool{false, false, false, false}),
+		},
+		{
+			info: "test BitCountFunc uint64",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_uint64.ToType(),
+					[]uint64{0, 1, 255, 256},
+					[]bool{false, false, false, false}),
+			},
+			expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+				[]int64{0, 1, 8, 1},
+				[]bool{false, false, false, false}),
+		},
+		{
+			info: "test BitCountFunc with null",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_int64.ToType(),
+					[]int64{8},
+					[]bool{true}),
+			},
+			expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+				[]int64{},
+				[]bool{true}),
+		},
+	}
+}
+
+func TestBitCountFunc(t *testing.T) {
+	testCases := initBitCountFuncTestCase()
+	proc := testutil.NewProcess(t)
+	for _, tc := range testCases {
+		fcTC := NewFunctionTestCase(proc,
+			tc.inputs, tc.expect, BitCountFunc[int64])
+		s, info := fcTC.Run()
+		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
+	}
+	// Test uint64 overload
+	t.Run("uint64", func(t *testing.T) {
+		fcTC := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(types.T_uint64.ToType(),
+					[]uint64{0, 1, 255},
+					[]bool{false, false, false}),
+			},
+			NewFunctionTestResult(types.T_int64.ToType(), false,
+				[]int64{0, 1, 8},
+				[]bool{false, false, false}),
+			BitCountFunc[uint64])
+		s, info := fcTC.Run()
+		require.True(t, s, fmt.Sprintf("BitCountFunc[uint64]: %s", info))
+	})
+}
+
 func initCurrentDateTestCase() []tcTemp {
 	return []tcTemp{
 		{

--- a/pkg/sql/plan/function/function_id.go
+++ b/pkg/sql/plan/function/function_id.go
@@ -585,9 +585,12 @@ const (
 	IN_RANGE        = 404
 	PREFIX_IN_RANGE = 405
 
+	// function `bit_count` (MySQL compatible: returns number of bits set in argument)
+	BIT_COUNT = 406
+
 	// FUNCTION_END_NUMBER is not a function, just a flag to record the max number of function.
 	// TODO: every one should put the new function id in front of this one if you want to make a new function.
-	FUNCTION_END_NUMBER = 406
+	FUNCTION_END_NUMBER = 407
 )
 
 // functionIdRegister is what function we have registered already.
@@ -759,6 +762,7 @@ var functionIdRegister = map[string]int32{
 	"is_ipv4_mapped":                 IS_IPV4_MAPPED,
 	"asin":                           ASIN,
 	"assert":                         ASSERT,
+	"bit_count":                      BIT_COUNT,
 	"bit_length":                     BIT_LENGTH,
 	"date":                           DATE,
 	"time":                           TIME,

--- a/pkg/sql/plan/function/function_id_test.go
+++ b/pkg/sql/plan/function/function_id_test.go
@@ -459,7 +459,8 @@ var predefinedFunids = map[int]int{
 	MO_FEATURE_LIMIT_UPSERT:    403,
 	IN_RANGE:                   404,
 	PREFIX_IN_RANGE:            405,
-	FUNCTION_END_NUMBER:        406,
+	BIT_COUNT:                  406,
+	FUNCTION_END_NUMBER:        407,
 }
 
 func Test_funids(t *testing.T) {

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -236,6 +236,97 @@ var supportedStringBuiltIns = []FuncNew{
 		},
 	},
 
+	// function `bit_count` (MySQL compatible: returns number of bits set in argument)
+	{
+		functionId: BIT_COUNT,
+		class:      plan.Function_STRICT,
+		layout:     STANDARD_FUNCTION,
+		checkFn:    fixedTypeMatch,
+
+		Overloads: []overload{
+			{
+				overloadId: 0,
+				args:       []types.T{types.T_uint8},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return BitCountFunc[uint8]
+				},
+			},
+			{
+				overloadId: 1,
+				args:       []types.T{types.T_uint16},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return BitCountFunc[uint16]
+				},
+			},
+			{
+				overloadId: 2,
+				args:       []types.T{types.T_uint32},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return BitCountFunc[uint32]
+				},
+			},
+			{
+				overloadId: 3,
+				args:       []types.T{types.T_uint64},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return BitCountFunc[uint64]
+				},
+			},
+			{
+				overloadId: 4,
+				args:       []types.T{types.T_int8},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return BitCountFunc[int8]
+				},
+			},
+			{
+				overloadId: 5,
+				args:       []types.T{types.T_int16},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return BitCountFunc[int16]
+				},
+			},
+			{
+				overloadId: 6,
+				args:       []types.T{types.T_int32},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return BitCountFunc[int32]
+				},
+			},
+			{
+				overloadId: 7,
+				args:       []types.T{types.T_int64},
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return BitCountFunc[int64]
+				},
+			},
+		},
+	},
+
 	// function `concat`
 	{
 		functionId: CONCAT,

--- a/test/distributed/cases/operator/bit_operator.result
+++ b/test/distributed/cases/operator/bit_operator.result
@@ -1,3 +1,6 @@
+SELECT BIT_COUNT(8), BIT_COUNT(24), BIT_COUNT(28), BIT_COUNT(255);
+bit_count(8)    bit_count(24)    bit_count(28)    bit_count(255)
+1    2    3    8
 SELECT 1 ^ 1, 9 &4& 2, 1 ^ 0;
 1 ^ 1    9 & 4 & 2    1 ^ 0
 0    0    1

--- a/test/distributed/cases/operator/bit_operator.sql
+++ b/test/distributed/cases/operator/bit_operator.sql
@@ -4,6 +4,8 @@
 -- @desc:test bit operators such as &, |, ^, ~, <<, >>
 -- @label:bvt
 
+-- BIT_COUNT(N): MySQL compatible, returns number of bits set in argument
+SELECT BIT_COUNT(8), BIT_COUNT(24), BIT_COUNT(28), BIT_COUNT(255);
 SELECT 1 ^ 1, 9 &4& 2, 1 ^ 0;
 SELECT 29 & 15;
 SELECT ~0, 64 << 2, '40' << 2;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Closes #23798

## What this PR does / why we need it:

Adds BIT_COUNT(N) — returns the number of set bits in N (MySQL compatible). Supports int8/16/32/64 and uint8/16/32/64. Implements in func_unary.go, registers in list_builtIn.go; adds unit tests and BVT in operator/bit_operator.