### PR TITLE
to 3.0: fix: handle stale read on immediate branch merge after GC

### DIFF
--- a/pkg/cdc/table_change_stream.go
+++ b/pkg/cdc/table_change_stream.go
@@ -762,7 +762,7 @@ func (s *TableChangeStream) processOneRound(ctx context.Context, ar *ActiveRouti
 	s.stateMu.Unlock()
 
 	// Handle StaleRead error
-	if moerr.IsMoErrCode(err, moerr.ErrStaleRead) {
+	if moerr.IsMoErrCode(err, moerr.ErrStaleRead) || moerr.IsMoErrCode(err, moerr.ErrFileNotFound) {
 		recoveryErr := s.handleStaleRead(ctx, txnOp)
 		// If recovery succeeded (nil), mark as retryable and continue
 		if recoveryErr == nil {
@@ -937,8 +937,8 @@ func (s *TableChangeStream) determineRetryable(err error) bool {
 		return true
 	}
 
-	// StaleRead errors are retryable if recovery is possible
-	if moerr.IsMoErrCode(err, moerr.ErrStaleRead) {
+	// StaleRead/FileNotFound errors are retryable if recovery is possible
+	if moerr.IsMoErrCode(err, moerr.ErrStaleRead) || moerr.IsMoErrCode(err, moerr.ErrFileNotFound) {
 		// If startTs is set and noFull is false, StaleRead is fatal (handled in handleStaleRead)
 		// If handleStaleRead returns nil, recovery succeeded (retryable)
 		// If handleStaleRead returns error, recovery failed (non-retryable)
@@ -1035,8 +1035,8 @@ func (s *TableChangeStream) classifyErrorType(err error) string {
 		return "commit"
 	}
 
-	// StaleRead errors - fast retry (usually resolves quickly)
-	if moerr.IsMoErrCode(err, moerr.ErrStaleRead) {
+	// StaleRead/FileNotFound errors - fast retry (usually resolves quickly)
+	if moerr.IsMoErrCode(err, moerr.ErrStaleRead) || moerr.IsMoErrCode(err, moerr.ErrFileNotFound) {
 		return "stale_read"
 	}
 

--- a/pkg/vm/engine/disttae/change_handle.go
+++ b/pkg/vm/engine/disttae/change_handle.go
@@ -41,6 +41,10 @@ import (
 
 const DefaultLoadParallism = 20
 
+// NewPartitionStateChangesHandler is the function used to create a ChangeHandler
+// from the partition state. It is a variable so tests can stub it.
+var NewPartitionStateChangesHandler = logtailreplay.NewChangesHandler
+
 func (tbl *txnTable) CollectChanges(
 	ctx context.Context,
 	from, to types.TS,
@@ -133,6 +137,7 @@ func (h *PartitionChangesHandle) getNextChangeHandle(ctx context.Context) (end b
 		nextFrom = h.currentPSTo.Next()
 	}
 	stateStart := state.GetStart()
+
 	if stateStart.LE(&nextFrom) {
 		h.currentPSTo = h.toTs
 		h.currentPSFrom = nextFrom
@@ -150,7 +155,7 @@ func (h *PartitionChangesHandle) getNextChangeHandle(ctx context.Context) (end b
 			)
 		}
 		h.handleIdx++
-		h.currentChangeHandle, err = logtailreplay.NewChangesHandler(
+		h.currentChangeHandle, err = NewPartitionStateChangesHandler(
 			ctx,
 			state,
 			h.currentPSFrom,
@@ -162,9 +167,26 @@ func (h *PartitionChangesHandle) getNextChangeHandle(ctx context.Context) (end b
 			h.fs,
 		)
 		if err != nil {
+			// If the partition state references GC-ed object files,
+			// fall through to the snapshot read path which reads from
+			// checkpoint files instead of the deleted object files.
+			// Only FileNotFound is recoverable; a real ErrStaleRead means
+			// the partition state's logical range doesn't cover the request.
+			if moerr.IsMoErrCode(err, moerr.ErrFileNotFound) {
+				logutil.Warn("ChangesHandle-Split partition state file missing, falling back to snapshot read",
+					zap.String("table", fmt.Sprintf("%d", h.tbl.tableId)),
+					zap.String("nextFrom", nextFrom.ToString()),
+					zap.String("stateStart", stateStart.ToString()),
+					zap.Error(err),
+				)
+				_ = h.closeCurrentChangeHandle()
+				err = nil
+			} else {
+				return
+			}
+		} else {
 			return
 		}
-		return
 	}
 
 	logutil.Info("ChangesHandle-Split request snapshot read",
@@ -177,6 +199,7 @@ func (h *PartitionChangesHandle) getNextChangeHandle(ctx context.Context) (end b
 		return
 	}
 	resp, ok := response.(*cmd_util.SnapshotReadResp)
+
 	var checkpointEntries []*checkpoint.CheckpointEntry
 	minTS := types.MaxTs()
 	maxTS := types.TS{}
@@ -200,7 +223,16 @@ func (h *PartitionChangesHandle) getNextChangeHandle(ctx context.Context) (end b
 		}
 	}
 	if nextFrom.LT(&minTS) || nextFrom.GT(&maxTS) {
-		logutil.Infof("ChangesHandle-Split nextFrom is not in the checkpoint entry range: %s-%s", minTS.ToString(), maxTS.ToString())
+		logutil.Info("ChangesHandle-Split stale read",
+			zap.String("table", fmt.Sprintf("%d", h.tbl.tableId)),
+			zap.String("nextFrom", nextFrom.ToString()),
+			zap.String("stateStart", stateStart.ToString()),
+			zap.String("minTS", minTS.ToString()),
+			zap.String("maxTS", maxTS.ToString()),
+			zap.Int("checkpointEntries", len(checkpointEntries)),
+			zap.Bool("nextFrom<minTS", nextFrom.LT(&minTS)),
+			zap.Bool("nextFrom>maxTS", nextFrom.GT(&maxTS)),
+		)
 		return false, moerr.NewErrStaleReadNoCtx(minTS.ToString(), nextFrom.ToString())
 	}
 	h.currentPSFrom = nextFrom
@@ -239,10 +271,16 @@ func (h *PartitionChangesHandle) getNextChangeHandle(ctx context.Context) (end b
 	return false, nil
 }
 func (h *PartitionChangesHandle) Close() error {
+	if h == nil {
+		return nil
+	}
 	return h.closeCurrentChangeHandle()
 }
 
 func (h *PartitionChangesHandle) closeCurrentChangeHandle() (err error) {
+	if h == nil {
+		return nil
+	}
 	h.closeMu.Lock()
 	defer h.closeMu.Unlock()
 	if h.currentChangeHandle != nil {

--- a/pkg/vm/engine/disttae/change_handle_test.go
+++ b/pkg/vm/engine/disttae/change_handle_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disttae
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionChangesHandleCloseWithTypedNil(t *testing.T) {
+	var handle engine.ChangesHandle = (*PartitionChangesHandle)(nil)
+	require.NoError(t, handle.Close())
+}

--- a/pkg/vm/engine/disttae/logtailreplay/change_handle.go
+++ b/pkg/vm/engine/disttae/logtailreplay/change_handle.go
@@ -250,7 +250,6 @@ func (h *CNObjectHandle) prefetch(ctx context.Context) (err error) {
 			if moerr.IsMoErrCode(err, moerr.ErrFileNotFound) {
 				logutil.Info("ChangesHandle-FileNotFound",
 					zap.String("err", err.Error()))
-				return moerr.NewErrStaleReadNoCtx(types.TS{}.ToString(), h.base.changesHandle.start.ToString())
 			}
 			h.base.changesHandle.readDuration += time.Since(t0)
 			return
@@ -384,7 +383,6 @@ func (h *AObjectHandle) prefetch(ctx context.Context) (err error) {
 			if moerr.IsMoErrCode(err, moerr.ErrFileNotFound) {
 				logutil.Info("ChangesHandle-FileNotFound",
 					zap.String("err", err.Error()))
-				return moerr.NewErrStaleReadNoCtx(types.TS{}.ToString(), h.p.changesHandle.start.ToString())
 			}
 			h.p.changesHandle.readDuration += time.Since(t0)
 			return
@@ -878,6 +876,13 @@ func getObjectsFromCheckpointEntries(
 	return
 }
 
+// NewChangesHandler creates a ChangeHandler that reads changes from the partition state.
+//
+// Error contract:
+//   - Returns ErrStaleRead if state.start > start (logical range not covered).
+//   - Returns ErrFileNotFound if a referenced object file has been physically
+//     deleted by GC. Callers should treat this as recoverable and fall back
+//     to the snapshot read path (reading from checkpoint files).
 func NewChangesHandler(
 	ctx context.Context,
 	state *PartitionState,
@@ -904,6 +909,12 @@ func NewChangesHandler(
 		mp:            mp,
 		scheduler:     tasks.NewParallelJobScheduler(LoadParallism),
 	}
+	defer func() {
+		if err != nil {
+			changeHandle.scheduler.Stop()
+			changeHandle = nil
+		}
+	}()
 	changeHandle.tombstoneHandle, err = NewBaseHandler(state, changeHandle, start, end, mp, true, fs, ctx)
 	if err != nil {
 		return
@@ -921,10 +932,17 @@ func NewChangesHandler(
 		return
 	}
 	err = changeHandle.tombstoneHandle.init(ctx, changeHandle.quick, mp)
+	if err != nil {
+		changeHandle.dataHandle.Close()
+		changeHandle.tombstoneHandle.Close()
+	}
 	return
 }
 
 func (p *ChangeHandler) Close() error {
+	if p == nil {
+		return nil
+	}
 	p.dataHandle.Close()
 	p.tombstoneHandle.Close()
 	p.scheduler.Stop()

--- a/pkg/vm/engine/tae/rpc/handle_debug.go
+++ b/pkg/vm/engine/tae/rpc/handle_debug.go
@@ -100,6 +100,12 @@ func (h *Handle) HandleSnapshotRead(
 	if maxCheckpoint != nil {
 		maxEnd = maxCheckpoint.GetEnd()
 	}
+	if maxEnd.IsEmpty() {
+		maxGlobal := h.db.BGCheckpointRunner.MaxGlobalCheckpoint()
+		if maxGlobal != nil {
+			maxEnd = maxGlobal.GetEnd()
+		}
+	}
 	snapshot := types.TimestampToTS(*req.Snapshot)
 	if snapshot.GT(&maxEnd) {
 		resp.Succeed = false

--- a/pkg/vm/engine/test/change_handle_test.go
+++ b/pkg/vm/engine/test/change_handle_test.go
@@ -1061,7 +1061,7 @@ func TestChangesHandleStaleFiles2(t *testing.T) {
 			assert.NoError(t, err)
 		}
 		data, tombstone, _, err := handle.Next(ctx, mp)
-		assert.True(t, moerr.IsMoErrCode(err, moerr.ErrStaleRead))
+		assert.True(t, moerr.IsMoErrCode(err, moerr.ErrFileNotFound))
 		assert.Nil(t, tombstone)
 		assert.Nil(t, data)
 	}
@@ -1956,6 +1956,216 @@ func TestPartitionChangesHandleGCKPBoundaryStaleRead(t *testing.T) {
 			if data == nil && tombstone == nil {
 				break
 			}
+		}
+	}
+}
+
+func TestFileNotFoundFallbackToSnapshotRead(t *testing.T) {
+	// When PartitionState references GC-ed object files, NewChangesHandler
+	// returns ErrFileNotFound. getNextChangeHandle should fall back to the
+	// snapshot read path and succeed.
+
+	catalog.SetupDefines("")
+
+	var (
+		accountId    = catalog.System_Account
+		tableName    = "test_fnf_fallback"
+		databaseName = "db_fnf_fallback"
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountId)
+
+	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeHandler.Close(true)
+		rpcAgent.Close()
+	}()
+
+	schema := catalog2.MockSchemaAll(20, 0)
+	schema.Name = tableName
+	bat := catalog2.MockBatch(schema, 3)
+	defer bat.Close()
+	bats := bat.Split(3)
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+
+	_, _, err := disttaeEngine.CreateDatabaseAndTable(ctx, databaseName, tableName, schema)
+	require.NoError(t, err)
+
+	txn, rel := testutil2.GetRelation(t, accountId, taeHandler.GetDB(), databaseName, tableName)
+	require.Nil(t, rel.Append(ctx, bats[0]))
+	require.Nil(t, txn.Commit(ctx))
+	t1 := txn.GetCommitTS()
+
+	txn, rel = testutil2.GetRelation(t, accountId, taeHandler.GetDB(), databaseName, tableName)
+	id := rel.GetMeta().(*catalog2.TableEntry).AsCommonID()
+	require.Nil(t, txn.Commit(ctx))
+
+	now := taeHandler.GetDB().TxnMgr.Now()
+	taeHandler.GetDB().ForceCheckpoint(ctx, now)
+	now = taeHandler.GetDB().TxnMgr.Now()
+	taeHandler.GetDB().ForceCheckpoint(ctx, now)
+
+	txn, rel = testutil2.GetRelation(t, accountId, taeHandler.GetDB(), databaseName, tableName)
+	require.Nil(t, rel.Append(ctx, bats[1]))
+	require.Nil(t, txn.Commit(ctx))
+
+	now = taeHandler.GetDB().TxnMgr.Now()
+	taeHandler.GetDB().ForceCheckpoint(ctx, now)
+
+	txn, rel = testutil2.GetRelation(t, accountId, taeHandler.GetDB(), databaseName, tableName)
+	require.Nil(t, rel.Append(ctx, bats[2]))
+	require.Nil(t, txn.Commit(ctx))
+
+	err = disttaeEngine.SubscribeTable(ctx, id.DbID, id.TableID, databaseName, tableName, false)
+	require.Nil(t, err)
+
+	mp := common.DebugAllocator
+
+	// Inject FileNotFound to simulate GC-ed object files while PartitionState
+	// still references them. The partition state path will fail, and the code
+	// should fall back to snapshot read.
+	chStub := gostub.Stub(
+		&disttae.NewPartitionStateChangesHandler,
+		func(
+			ctx context.Context,
+			state *logtailreplay.PartitionState,
+			start, end types.TS,
+			skipDeletes bool,
+			maxRow uint32,
+			primarySeqnum int,
+			mp *mpool.MPool,
+			fs fileservice.FileService,
+		) (*logtailreplay.ChangeHandler, error) {
+			return nil, moerr.NewFileNotFoundNoCtx("simulated-gc-deleted-object")
+		},
+	)
+	defer chStub.Reset()
+
+	ssStub := gostub.Stub(
+		&disttae.RequestSnapshotRead,
+		disttae.GetSnapshotReadFnWithHandler(
+			taeHandler.GetRPCHandle().HandleSnapshotRead,
+		),
+	)
+	defer ssStub.Reset()
+
+	{
+		_, rel, _, err := disttaeEngine.GetTable(ctx, databaseName, tableName)
+		require.Nil(t, err)
+
+		readToTS := taeHandler.GetDB().TxnMgr.Now()
+		handle, err := rel.CollectChanges(ctx, t1.Prev(), readToTS, false, mp)
+		// Should succeed via snapshot read fallback, not return ErrFileNotFound
+		assert.NoError(t, err, "expected fallback to snapshot read to succeed")
+		if handle != nil {
+			handle.Close()
+		}
+	}
+}
+
+func TestRealStaleReadStillReturnsError(t *testing.T) {
+	// A real ErrStaleRead (state.start > start, logical range not covered)
+	// must NOT be swallowed — it should propagate to the caller as error 22101.
+
+	catalog.SetupDefines("")
+
+	var (
+		accountId    = catalog.System_Account
+		tableName    = "test_real_stale"
+		databaseName = "db_real_stale"
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, accountId)
+
+	disttaeEngine, taeHandler, rpcAgent, _ := testutil.CreateEngines(ctx, testutil.TestOptions{}, t)
+	defer func() {
+		disttaeEngine.Close(ctx)
+		taeHandler.Close(true)
+		rpcAgent.Close()
+	}()
+
+	schema := catalog2.MockSchemaAll(20, 0)
+	schema.Name = tableName
+	bat := catalog2.MockBatch(schema, 3)
+	defer bat.Close()
+	bats := bat.Split(3)
+
+	ctx, cancel = context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
+
+	_, _, err := disttaeEngine.CreateDatabaseAndTable(ctx, databaseName, tableName, schema)
+	require.NoError(t, err)
+
+	txn, rel := testutil2.GetRelation(t, accountId, taeHandler.GetDB(), databaseName, tableName)
+	require.Nil(t, rel.Append(ctx, bats[0]))
+	require.Nil(t, txn.Commit(ctx))
+	t1 := txn.GetCommitTS()
+
+	txn, rel = testutil2.GetRelation(t, accountId, taeHandler.GetDB(), databaseName, tableName)
+	id := rel.GetMeta().(*catalog2.TableEntry).AsCommonID()
+	require.Nil(t, txn.Commit(ctx))
+
+	now := taeHandler.GetDB().TxnMgr.Now()
+	taeHandler.GetDB().ForceCheckpoint(ctx, now)
+	now = taeHandler.GetDB().TxnMgr.Now()
+	taeHandler.GetDB().ForceCheckpoint(ctx, now)
+
+	txn, rel = testutil2.GetRelation(t, accountId, taeHandler.GetDB(), databaseName, tableName)
+	require.Nil(t, rel.Append(ctx, bats[1]))
+	require.Nil(t, txn.Commit(ctx))
+	t2 := txn.GetCommitTS()
+
+	err = disttaeEngine.SubscribeTable(ctx, id.DbID, id.TableID, databaseName, tableName, false)
+	require.Nil(t, err)
+
+	mp := common.DebugAllocator
+
+	// Force GC so that state.start > t1, making the partition state unable
+	// to serve the requested range. This is a real stale read.
+	disttaeEngine.Engine.ForceGC(ctx, t2.Next())
+
+	// Stub snapshot read to also fail (return entries that don't cover t1)
+	ssStub := gostub.Stub(
+		&disttae.RequestSnapshotRead,
+		disttae.GetSnapshotReadFnWithHandler(
+			func(ctx context.Context, meta pbtxn.TxnMeta, req *cmd_util.SnapshotReadReq, resp *cmd_util.SnapshotReadResp) (func(), error) {
+				t2ts := t2.ToTimestamp()
+				t2NextTs := t2.Next().ToTimestamp()
+				resp.Succeed = true
+				resp.Entries = []*cmd_util.CheckpointEntryResp{
+					{
+						Start:     &t2ts,
+						End:       &t2NextTs,
+						Location1: []byte("fake"),
+						Location2: []byte("fake"),
+						EntryType: 0,
+						Version:   1,
+					},
+				}
+				return func() {}, nil
+			},
+		),
+	)
+	defer ssStub.Reset()
+
+	{
+		_, rel, _, err := disttaeEngine.GetTable(ctx, databaseName, tableName)
+		require.Nil(t, err)
+
+		readToTS := taeHandler.GetDB().TxnMgr.Now()
+		handle, err := rel.CollectChanges(ctx, t1.Prev(), readToTS, false, mp)
+		// Real stale read: must return ErrStaleRead, not silently succeed
+		assert.True(t, moerr.IsMoErrCode(err, moerr.ErrStaleRead),
+			"expected ErrStaleRead (22101), got: %v", err)
+		if handle != nil {
+			handle.Close()
 		}
 	}
 }


### PR DESCRIPTION


## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/23820

## What this PR does / why we need it:

When gc deletes object files while CN's PartitionState still references them, NewChangesHandler hits ErrFileNotFound during prefetch.

Changes:
- logtailreplay: preserve ErrFileNotFound instead of converting to ErrStaleRead, so callers can distinguish recoverable (GC-ed files) from non-recoverable (logical range gap) errors
- disttae: getNextChangeHandle catches ErrFileNotFound and falls back to snapshot read path; real ErrStaleRead still propagates
- disttae: nil receiver guard on PartitionChangesHandle.Close()
- handle_debug: HandleSnapshotRead falls back to MaxGlobalCheckpoint when all incremental checkpoints have been GC-ed
- tests: FileNotFound fallback, real stale read propagation, nil Close