### PR TITLE
colexec/hashbuild: replace JoinSels [][][]int32 with flat GroupSels layout

### DIFF
--- a/pkg/sql/colexec/hashbuild/build.go
+++ b/pkg/sql/colexec/hashbuild/build.go
@@ -93,12 +93,12 @@ func (hashBuild *HashBuild) Call(proc *process.Process) (vm.CallResult, error) {
 			if ctr.hashmapBuilder.InputBatchRowCount > 0 {
 				if spillMode {
 					// In spill mode: send empty JoinMap with spill info, no batches
-					jm = message.NewJoinMap(message.JoinSels{}, nil, nil, nil, nil, proc.Mp())
+					jm = message.NewJoinMap(message.GroupSels{}, nil, nil, nil, nil, proc.Mp())
 					jm.Spilled = true
 					jm.SpillBuckets = ctr.spilledBuckets
 				} else {
 					// Normal mode: send hashmap and batches
-					jm = message.NewJoinMap(ctr.hashmapBuilder.MultiSels, ctr.hashmapBuilder.IntHashMap, ctr.hashmapBuilder.StrHashMap, ctr.hashmapBuilder.DelRows, ctr.hashmapBuilder.Batches.Buf, proc.Mp())
+					jm = message.NewJoinMap(ctr.hashmapBuilder.Sels, ctr.hashmapBuilder.IntHashMap, ctr.hashmapBuilder.StrHashMap, ctr.hashmapBuilder.DelRows, ctr.hashmapBuilder.Batches.Buf, proc.Mp())
 					jm.SetPushedRuntimeFilterIn(ctr.runtimeFilterIn)
 				}
 				jm.SetRowCount(int64(ctr.hashmapBuilder.InputBatchRowCount))

--- a/pkg/sql/colexec/hashbuild/hashmap.go
+++ b/pkg/sql/colexec/hashbuild/hashmap.go
@@ -37,7 +37,7 @@ type HashmapBuilder struct {
 	vecs               [][]*vector.Vector
 	IntHashMap         *hashmap.IntHashMap
 	StrHashMap         *hashmap.StrHashMap
-	MultiSels          message.JoinSels
+	Sels               message.GroupSels
 	keyWidth           int // keyWidth is the width of hash columns, it determines which hash map to use.
 	Batches            colexec.Batches
 	executors          []colexec.ExpressionExecutor
@@ -71,7 +71,7 @@ func (hb *HashmapBuilder) GetJoinMap() *message.JoinMap {
 	if hb.InputBatchRowCount == 0 {
 		return nil
 	}
-	return message.NewJoinMap(hb.MultiSels, hb.IntHashMap, hb.StrHashMap, hb.DelRows, hb.Batches.Buf, nil)
+	return message.NewJoinMap(hb.Sels, hb.IntHashMap, hb.StrHashMap, hb.DelRows, hb.Batches.Buf, nil)
 }
 
 func (hb *HashmapBuilder) GetGroupCount() uint64 {
@@ -146,7 +146,6 @@ func (hb *HashmapBuilder) Reset(proc *process.Process, hashTableHasNotSent bool)
 		}
 	}
 	hb.UniqueJoinKeys = nil
-	hb.MultiSels.Free()
 	for i := range hb.executors {
 		if hb.executors[i] != nil {
 			hb.executors[i].ResetForNextQuery()
@@ -162,7 +161,6 @@ func (hb *HashmapBuilder) Free(proc *process.Process) {
 	hb.Batches.Reset()
 	hb.IntHashMap = nil
 	hb.StrHashMap = nil
-	hb.MultiSels.Free()
 	hb.FreeExecutors()
 	hb.vecs = nil
 	for i := range hb.UniqueJoinKeys {
@@ -316,7 +314,9 @@ func (hb *HashmapBuilder) BuildHashmap(hashOnPK bool, needAllocateSels bool, nee
 	}
 
 	if needAllocateSels {
-		hb.MultiSels.InitSel(hb.InputBatchRowCount)
+		if err := hb.Sels.Init(hb.InputBatchRowCount, proc.Mp()); err != nil {
+			return err
+		}
 	}
 
 	if hb.IsDedup && hb.OnDuplicateAction == plan.Node_IGNORE {
@@ -372,7 +372,7 @@ func (hb *HashmapBuilder) BuildHashmap(hashOnPK bool, needAllocateSels bool, nee
 		}
 		for k, v := range vals[:n] {
 			if hb.IsDedup && hb.OnDuplicateAction == plan.Node_UPDATE {
-				hb.MultiSels.InsertSel(int32(v), int32(i+k))
+				hb.Sels.Insert(int32(v), int32(i+k))
 				continue
 			}
 
@@ -413,7 +413,7 @@ func (hb *HashmapBuilder) BuildHashmap(hashOnPK bool, needAllocateSels bool, nee
 					cardinality = v
 				}
 			} else if !hashOnPK && needAllocateSels {
-				hb.MultiSels.InsertSel(int32(v-1), int32(i+k))
+				hb.Sels.Insert(int32(v-1), int32(i+k))
 			}
 		}
 
@@ -493,19 +493,7 @@ func (hb *HashmapBuilder) BuildHashmap(hashOnPK bool, needAllocateSels bool, nee
 		hb.InputBatchRowCount = hb.Batches.RowCount()
 	}
 
-	// if groupcount == inputrowcount, it means building hashmap on unique rows
-	// we can free sels now
-	if hb.keyWidth <= 8 {
-		if hb.InputBatchRowCount == int(hb.IntHashMap.GroupCount()) {
-			hb.MultiSels.Free()
-		}
-	} else {
-		if hb.InputBatchRowCount == int(hb.StrHashMap.GroupCount()) {
-			hb.MultiSels.Free()
-		}
-	}
-
-	return nil
+	return hb.Sels.Finalize(int(hb.GetGroupCount()), hb.InputBatchRowCount, proc.Mp())
 }
 
 // ExtractCachedIteratorsForReuse detaches and returns cached iterators so they

--- a/pkg/sql/colexec/hashjoin/spill.go
+++ b/pkg/sql/colexec/hashjoin/spill.go
@@ -412,7 +412,7 @@ func (hashJoin *HashJoin) rebuildHashmapForBucket(proc *process.Process, bucketN
 		return nil, err
 	}
 
-	jm := message.NewJoinMap(builder.MultiSels, builder.IntHashMap, builder.StrHashMap, nil, builder.Batches.Buf, proc.Mp())
+	jm := message.NewJoinMap(builder.Sels, builder.IntHashMap, builder.StrHashMap, nil, builder.Batches.Buf, proc.Mp())
 	jm.SetRowCount(int64(builder.InputBatchRowCount))
 	jm.IncRef(1)
 

--- a/pkg/sql/colexec/rightdedupjoin/join.go
+++ b/pkg/sql/colexec/rightdedupjoin/join.go
@@ -161,7 +161,7 @@ func (rightDedupJoin *RightDedupJoin) build(analyzer process.Analyzer, proc *pro
 			}
 		}
 
-		ctr.mp = message.NewJoinMap(message.JoinSels{}, intHashMap, strHashMap, nil, nil, proc.Mp())
+		ctr.mp = message.NewJoinMap(message.GroupSels{}, intHashMap, strHashMap, nil, nil, proc.Mp())
 		ctr.mp.IncRef(1)
 	} else {
 		ctr.groupCount = ctr.mp.GetGroupCount()

--- a/pkg/vm/message/group_sels_test.go
+++ b/pkg/vm/message/group_sels_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package message
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/stretchr/testify/require"
+)
+
+func testMp() *mpool.MPool {
+	return mpool.MustNewZero()
+}
+
+func TestGroupSels_NilBeforeInit(t *testing.T) {
+	var js GroupSels
+	require.NoError(t, js.Finalize(3, 3, testMp()))
+	require.Nil(t, js.offsets)
+	require.Nil(t, js.Get(0))
+}
+
+func TestGroupSels_AllUnique(t *testing.T) {
+	mp := testMp()
+	var js GroupSels
+	require.NoError(t, js.Init(3, mp))
+	js.Insert(0, 0)
+	js.Insert(1, 1)
+	js.Insert(2, 2)
+	require.NoError(t, js.Finalize(3, 3, mp))
+	require.Nil(t, js.offsets)
+	require.Nil(t, js.Get(0))
+}
+
+func TestGroupSels_Normal0Based(t *testing.T) {
+	mp := testMp()
+	var js GroupSels
+	require.NoError(t, js.Init(4, mp))
+	js.Insert(0, 10)
+	js.Insert(1, 11)
+	js.Insert(0, 12)
+	js.Insert(1, 13)
+	require.NoError(t, js.Finalize(2, 4, mp))
+	require.NotNil(t, js.offsets)
+	require.ElementsMatch(t, []int32{10, 12}, js.Get(0))
+	require.ElementsMatch(t, []int32{11, 13}, js.Get(1))
+	require.Empty(t, js.Get(2))
+	js.Free(mp)
+}
+
+func TestGroupSels_Dedup1Based(t *testing.T) {
+	mp := testMp()
+	var js GroupSels
+	require.NoError(t, js.Init(3, mp))
+	js.Insert(1, 0)
+	js.Insert(2, 1)
+	js.Insert(1, 2)
+	require.NoError(t, js.Finalize(2, 3, mp))
+	require.NotNil(t, js.offsets)
+	require.ElementsMatch(t, []int32{0, 2}, js.Get(1))
+	require.ElementsMatch(t, []int32{1}, js.Get(2))
+	require.Empty(t, js.Get(0))
+	js.Free(mp)
+}
+
+func TestGroupSels_Free(t *testing.T) {
+	mp := testMp()
+	var js GroupSels
+	require.NoError(t, js.Init(2, mp))
+	js.Insert(0, 5)
+	js.Free(mp)
+	require.NoError(t, js.Finalize(1, 1, mp))
+	require.Nil(t, js.offsets)
+}
+
+func TestGroupSels_AllNulls(t *testing.T) {
+	// all rows are null — Init called but Insert never called
+	mp := testMp()
+	var js GroupSels
+	require.NoError(t, js.Init(3, mp))
+	// no Insert calls
+	require.NoError(t, js.Finalize(0, 3, mp))
+	require.Nil(t, js.offsets)
+}
+
+func TestGroupSels_NullsSkipped(t *testing.T) {
+	// 4 input rows but only 3 inserted (1 null) — groupCount==n but inputRowCount!=groupCount
+	// must NOT trigger all-unique path
+	mp := testMp()
+	var js GroupSels
+	require.NoError(t, js.Init(4, mp))
+	js.Insert(0, 0) // row 0 → group 0
+	js.Insert(1, 1) // row 1 → group 1
+	// row 2 is null, skipped
+	js.Insert(2, 3) // row 3 → group 2
+	require.NoError(t, js.Finalize(3, 4, mp))
+	require.NotNil(t, js.offsets) // must NOT be nil
+	require.ElementsMatch(t, []int32{0}, js.Get(0))
+	require.ElementsMatch(t, []int32{1}, js.Get(1))
+	require.ElementsMatch(t, []int32{3}, js.Get(2))
+	js.Free(mp)
+}

--- a/pkg/vm/message/joinMapMsg.go
+++ b/pkg/vm/message/joinMapMsg.go
@@ -28,39 +28,98 @@ import (
 
 var _ Message = new(JoinMapMsg)
 
-const selsDivideLength = 256
-const selsPreAlloc = 4
+type GroupSels struct {
+	// vals holds all row IDs in group order after Finalize.
+	// offsets[k] .. offsets[k+1] is the range in vals for group k.
+	vals    []int32
+	offsets []int32
 
-type JoinSels struct {
-	sels [][][]int32
+	// tmp holds (groupID, rowID) pairs during the build phase, before Finalize.
+	tmp []int32
 }
 
-func (js *JoinSels) InitSel(len int) {
-	js.sels = make([][][]int32, 0, len/selsDivideLength+1)
+func freeSlice[T any](mp *mpool.MPool, s []T) {
+	mpool.FreeSlice(mp, s[:cap(s)])
 }
 
-func (js *JoinSels) Free() {
-	js.sels = nil
-}
-
-func (js *JoinSels) InsertSel(k, v int32) {
-	i := k / selsDivideLength
-	j := k % selsDivideLength
-	if len(js.sels) <= int(i) {
-		s := make([][]int32, selsDivideLength)
-		js.sels = append(js.sels, s)
-		var internalArray [selsDivideLength * selsPreAlloc]int32
-		for p := 0; p < selsDivideLength; p++ {
-			js.sels[i][p] = internalArray[p*selsPreAlloc : p*selsPreAlloc : (p+1)*selsPreAlloc]
-		}
+func (sels *GroupSels) Init(n int, mp *mpool.MPool) error {
+	var err error
+	sels.tmp, err = mpool.MakeSlice[int32](n*2, mp, false)
+	if err != nil {
+		return err
 	}
-	js.sels[i][j] = append(js.sels[i][j], v)
+	sels.tmp = sels.tmp[:0]
+	return nil
 }
 
-func (js *JoinSels) GetSels(k int32) []int32 {
-	i := k / selsDivideLength
-	j := k % selsDivideLength
-	return js.sels[i][j]
+func (sels *GroupSels) Free(mp *mpool.MPool) {
+	if mp != nil {
+		freeSlice(mp, sels.vals)
+		freeSlice(mp, sels.offsets)
+		freeSlice(mp, sels.tmp)
+	}
+	sels.vals = nil
+	sels.offsets = nil
+	sels.tmp = nil
+}
+
+func (sels *GroupSels) Insert(k, v int32) {
+	sels.tmp = append(sels.tmp, k, v)
+}
+
+func (sels *GroupSels) Finalize(groupCount int, inputRowCount int, mp *mpool.MPool) error {
+	if sels.tmp == nil {
+		return nil
+	}
+	n := len(sels.tmp) / 2
+	// if every input row got its own group (no nulls, no duplicates), no sels needed
+	if n == 0 || groupCount == inputRowCount {
+		sels.vals = nil
+		sels.offsets = nil
+		freeSlice(mp, sels.tmp)
+		sels.tmp = nil
+		return nil
+	}
+	// groupCount+2: +1 for sentinel, +1 for 1-based callers (dedup UPDATE uses keys 1..groupCount)
+	var err error
+	sels.offsets, err = mpool.MakeSlice[int32](groupCount+2, mp, false)
+	if err != nil {
+		return err
+	}
+
+	// count occurrences per group
+	for i := 0; i < len(sels.tmp); i += 2 {
+		k := sels.tmp[i]
+		sels.offsets[k+1]++
+	}
+	// prefix sum
+	for i := int32(1); i < int32(len(sels.offsets)); i++ {
+		sels.offsets[i] += sels.offsets[i-1]
+	}
+	// scatter vals using offsets as write cursors, then recover
+	sels.vals, err = mpool.MakeSlice[int32](n, mp, false)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < len(sels.tmp); i += 2 {
+		k := sels.tmp[i]
+		v := sels.tmp[i+1]
+		sels.vals[sels.offsets[k]] = v
+		sels.offsets[k]++
+	}
+	// recover offsets: shift right by one
+	copy(sels.offsets[1:], sels.offsets[:len(sels.offsets)-1])
+	sels.offsets[0] = 0
+	freeSlice(mp, sels.tmp)
+	sels.tmp = nil
+	return nil
+}
+
+func (sels *GroupSels) Get(k int32) []int32 {
+	if sels.offsets == nil || int(k+1) >= len(sels.offsets) {
+		return nil
+	}
+	return sels.vals[sels.offsets[k]:sels.offsets[k+1]]
 }
 
 // JoinMap is used for join
@@ -72,7 +131,7 @@ type JoinMap struct {
 	mpool            *mpool.MPool
 	shm              *hashmap.StrHashMap
 	ihm              *hashmap.IntHashMap
-	multiSels        JoinSels
+	sels             GroupSels
 	delRows          *bitmap.Bitmap
 	batches          []*batch.Batch
 
@@ -82,13 +141,13 @@ type JoinMap struct {
 	SpillRowCnts []int64  // rows per bucket
 }
 
-func NewJoinMap(sels JoinSels, ihm *hashmap.IntHashMap, shm *hashmap.StrHashMap, delRows *bitmap.Bitmap, batches []*batch.Batch, m *mpool.MPool) *JoinMap {
+func NewJoinMap(sels GroupSels, ihm *hashmap.IntHashMap, shm *hashmap.StrHashMap, delRows *bitmap.Bitmap, batches []*batch.Batch, m *mpool.MPool) *JoinMap {
 	return &JoinMap{
 		valid:        true,
 		mpool:        m,
 		shm:          shm,
 		ihm:          ihm,
-		multiSels:    sels,
+		sels:         sels,
 		delRows:      delRows,
 		batches:      batches,
 		Spilled:      false,
@@ -138,11 +197,11 @@ func (jm *JoinMap) PushedRuntimeFilterIn() bool {
 }
 
 func (jm *JoinMap) HashOnUnique() bool {
-	return jm.multiSels.sels == nil
+	return jm.sels.offsets == nil
 }
 
 func (jm *JoinMap) GetSels(k uint64) []int32 {
-	return jm.multiSels.GetSels(int32(k))
+	return jm.sels.Get(int32(k))
 }
 
 //func (jm *JoinMap) GetIgnoreRows() *bitmap.Bitmap {
@@ -191,7 +250,7 @@ func (jm *JoinMap) IsDeleted(row uint64) bool {
 }
 
 func (jm *JoinMap) FreeMemory() {
-	jm.multiSels.Free()
+	jm.sels.Free(jm.mpool)
 	if jm.ihm != nil {
 		jm.ihm.Free()
 		jm.ihm = nil


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #23846

## What this PR does / why we need it:
Replace the nested [][][]int32 sels structure with a flat radix-sort style layout: a single vals []int32 of all row IDs ordered by group, plus an offsets []int32 where offsets[k]..offsets[k+1] gives the range for group k.

This eliminates the massive number of small allocations from the old design. All three slices (tmp, vals, offsets) are mpool-allocated. Finalize() does a counting sort in-place, reusing offsets as write cursors and recovering it with a single copy-shift. Ownership transfers from HashmapBuilder to JoinMap via NewJoinMap; HashmapBuilder no longer frees GroupSels itself.