### PR TITLE
fix: make suspend/resume of protectedScans defer-safe

### DIFF
--- a/.kiro/settings/mcp.json
+++ b/.kiro/settings/mcp.json
@@ -1,0 +1,25 @@
+{
+  "mcpServers": {
+    "memoria": {
+      "_version": "0.2.1",
+      "args": [
+        "mcp",
+        "--db-url",
+        "mysql://root:111@localhost:6001/memoria_dev",
+        "--user",
+        "default"
+      ],
+      "command": "/home/xupeng/github/Memoria/memoria/target/release/memoria",
+      "env": {
+        "EMBEDDING_API_KEY": "sk-etpoezborerprqydjtzcppfikkanqfcfezgcttttujnvyfkd",
+        "EMBEDDING_BASE_URL": "https://api.siliconflow.cn/v1",
+        "EMBEDDING_DIM": "1024",
+        "EMBEDDING_MODEL": "BAAI/bge-m3",
+        "EMBEDDING_PROVIDER": "openai",
+        "MEMORIA_GOVERNANCE_ENABLED": "",
+        "MEMORIA_GOVERNANCE_PLUGIN_BINDING": "default",
+        "_README": "EMBEDDING_*: required for semantic search. Use 'openai' provider with any OpenAI-compatible API (SiliconFlow, Ollama, etc). MEMORIA_GOVERNANCE_PLUGIN_BINDING selects the shared repository binding resolved at startup."
+      }
+    }
+  }
+}

--- a/.kiro/steering/goal-driven-evolution.md
+++ b/.kiro/steering/goal-driven-evolution.md
@@ -1,0 +1,142 @@
+---
+inclusion: always
+---
+
+<!-- memoria-version: 0.2.1-->
+
+# Goal-Driven Evolution + Plan Integration
+
+Track goals, plans, progress, lessons, and user feedback across conversations. Integrates with plan panels (Kiro Shift+Tab, Cursor Composer, Claude multi-step).
+
+## Before Starting Any Multi-Step Task
+
+Query memory first:
+
+```
+memory_search(query="GOAL [topic]")                    # existing related goals
+memory_search(query="LESSON [topic]")                  # past learnings
+memory_search(query="CORRECTION ANTIPATTERN [topic]") # what NOT to do
+```
+
+If an active goal exists, continue it instead of creating a new one.
+
+## Register Goal
+
+For multi-session work (skip for trivial single-session tasks < 3 steps):
+
+```
+memory_search(query="GOAL [keywords]")
+memory_store(
+  content="🎯 GOAL: [description]\nSuccess Criteria: [measurable]\nStatus: ACTIVE\nCreated: [date]",
+  memory_type="procedural"
+)
+```
+
+## Plan & Execute
+
+Store the plan, then track each step:
+
+```
+memory_store(content="📋 PLAN for GOAL [name]\nSteps:\n1. [step] — ⏳\nRisks: [risks]\nIteration: #1", memory_type="procedural")
+
+# After each step — use working type (will be cleaned up later)
+memory_store(content="✅ STEP [N/total] for GOAL [name] (#X)\nAction: [done]\nResult: [outcome]\nInsight: [learned]", memory_type="working")
+memory_store(content="❌ STEP [N/total] for GOAL [name] (#X)\nAction: [tried]\nError: [wrong]\nRoot Cause: [why]\nNext: [adjust]", memory_type="working")
+```
+
+Only store non-obvious insights. Don't store "ran tests, passed".
+
+For high-risk iterations, isolate on a branch:
+```
+memory_branch(name="goal_[name]_iter_[N]")
+memory_checkout(name="goal_[name]_iter_[N]")
+# work on branch... then validate and merge (see Iteration Review)
+```
+
+## Capture User Feedback (immediately)
+
+User corrections are highest-value — always store as `procedural`:
+
+```
+# User corrects direction
+memory_store(content="🔧 CORRECTION for GOAL [name]: [old approach] → [corrected approach]. Reason: [why]", memory_type="procedural")
+
+# User confirms something works well
+memory_store(content="👍 FEEDBACK for GOAL [name]: [what worked]. Reuse: [when to apply again]", memory_type="procedural")
+
+# User is frustrated — record what NOT to do
+memory_store(content="⚠️ ANTIPATTERN for GOAL [name]: [what went wrong]. Rule: NEVER [this] again.", memory_type="procedural")
+
+# User changes direction entirely
+memory_correct(query="GOAL: [name]", new_content="🎯 GOAL: [name]\n...\nPivot: [old] → [new]. Reason: [why]", reason="User changed direction")
+```
+
+## Iteration Review
+
+When an iteration completes or is blocked:
+
+```
+memory_search(query="STEP for GOAL [name] Iteration #X")
+
+memory_store(
+  content="🔄 RETRO for GOAL [name] Iteration #X\nCompleted: [M/N]\nWorked: [...]\nFailed: [...]\nKey insight: [...]\nNext: [improvements]",
+  memory_type="procedural"
+)
+
+# If the insight is reusable beyond this goal, extract it now
+memory_store(content="💡 LESSON from [goal] iter #X: [cross-goal reusable insight]", memory_type="procedural")
+
+memory_correct(query="GOAL: [name]", new_content="🎯 GOAL: [name]\nStatus: ITERATION #X COMPLETE — [progress %]\nNext: [plan]", reason="iteration complete")
+```
+
+If on a branch:
+```
+memory_diff(source="goal_[name]_iter_[N]")
+memory_checkout(name="main")
+memory_merge(source="goal_[name]_iter_[N]", strategy="replace")
+memory_branch_delete(name="goal_[name]_iter_[N]")
+```
+
+Starting the next iteration? Reference the previous RETRO's improvements:
+```
+memory_search(query="RETRO for GOAL [name]")
+# Incorporate "Next: [improvements]" into the new plan
+```
+
+## New Conversation Bootstrap
+
+```
+memory_search(query="GOAL ACTIVE")
+memory_search(query="RETRO for GOAL [name]")
+memory_search(query="CORRECTION ANTIPATTERN [name]")
+```
+
+Summarize to user: active goals, last progress, and any corrections to respect.
+
+## Goal Completion & Cleanup
+
+```
+memory_correct(query="GOAL: [name]", new_content="🎯 GOAL: [name] — ✅ ACHIEVED\nIterations: [N]\nFinal approach: [what worked]", reason="Goal achieved")
+
+# Extract reusable lessons (permanent — survives cleanup)
+memory_store(content="💡 LESSON from [goal]: [reusable insight for future work]", memory_type="procedural")
+
+# Clean up step logs (working type, already archived in RETROs)
+memory_purge(topic="STEP for GOAL [name]", reason="Goal achieved, archived in RETRO")
+```
+
+## When Goal is Abandoned
+
+```
+memory_store(content="⚠️ ANTIPATTERN: [what didn't work]. Reason: [why abandoned]", memory_type="procedural")
+memory_correct(query="GOAL: [name]", new_content="🎯 GOAL: [name] — ❌ ABANDONED\nReason: [why]", reason="abandoned")
+```
+
+## Rules
+
+- **Search before acting**: always check past failures, corrections, and antipatterns before proposing a plan
+- **User corrections override all**: if user corrected something, that correction has highest priority forever
+- **Be specific**: "pytest fixtures don't work with async DB, use factory pattern" > "tests failed"
+- **Don't create goals for quick fixes** (< 3 tasks, single session)
+- **Emoji prefixes**: 🎯 goal, 📋 plan, ✅❌ steps, 🔄 retro, 💡 lesson, 🔧 correction, 👍 feedback, ⚠️ antipattern
+- **Type discipline**: GOAL/PLAN/RETRO/LESSON/CORRECTION → `procedural`; STEP logs → `working`

--- a/.kiro/steering/memory-branching-patterns.md
+++ b/.kiro/steering/memory-branching-patterns.md
@@ -1,0 +1,112 @@
+---
+inclusion: auto
+name: memory-branching
+description: Git-like branching for memory - isolated experiments, tech evaluation, A/B comparison. Use when exploring alternatives or risky changes.
+---
+
+<!-- memoria-version: 0.2.1-->
+
+# Memory Branching Patterns
+
+Use Memoria's Git-like branching to isolate experiments, evaluate alternatives, and protect stable memory state.
+
+## Pattern 1: Tech Evaluation
+
+Compare alternatives without polluting main memory.
+
+```
+memory_branch(name="eval_[technology]")
+memory_checkout(name="eval_[technology]")
+
+# Store findings on branch
+memory_store(content="[technology] evaluation: [findings]", memory_type="semantic")
+
+# When done — preview and decide
+memory_diff(source="eval_[technology]")
+
+# Accept: merge back
+memory_checkout(name="main")
+memory_merge(source="eval_[technology]", strategy="replace")
+memory_branch_delete(name="eval_[technology]")
+
+# Reject: just delete
+memory_checkout(name="main")
+memory_branch_delete(name="eval_[technology]")
+```
+
+## Pattern 2: Pre-Refactor Safety Net
+
+Snapshot + branch before risky memory changes.
+
+```
+memory_snapshot(name="pre_[task]", description="before [task]")
+memory_branch(name="refactor_[task]")
+memory_checkout(name="refactor_[task]")
+
+# Do risky work on branch...
+
+# If it goes wrong:
+memory_checkout(name="main")
+memory_branch_delete(name="refactor_[task]")
+# main is untouched
+
+# If it succeeds:
+memory_diff(source="refactor_[task]")
+memory_checkout(name="main")
+memory_merge(source="refactor_[task]")  # default strategy: branch wins on conflicts
+memory_branch_delete(name="refactor_[task]")
+```
+
+## Pattern 3: A/B Memory Comparison
+
+Two branches for competing approaches, diff both before deciding.
+
+```
+memory_branch(name="approach_a")
+memory_branch(name="approach_b")
+
+# Work on A
+memory_checkout(name="approach_a")
+memory_store(content="Approach A: [details]", memory_type="semantic")
+
+# Work on B
+memory_checkout(name="approach_b")
+memory_store(content="Approach B: [details]", memory_type="semantic")
+
+# Compare
+memory_diff(source="approach_a")
+memory_diff(source="approach_b")
+
+# Merge winner, delete both
+memory_checkout(name="main")
+memory_merge(source="approach_a")  # default strategy: branch wins on conflicts
+memory_branch_delete(name="approach_a")
+memory_branch_delete(name="approach_b")
+```
+
+## When to Branch
+
+- ✅ Evaluating a technology, framework, or architecture change
+- ✅ About to bulk-correct or purge many memories
+- ✅ User says "let's try something different" or "what if we..."
+- ✅ Exploring a hypothesis that might be wrong
+- ❌ Simple fact storage — just use main
+- ❌ Quick corrections — use `memory_correct` directly
+
+## Naming Convention
+
+- `eval_[thing]` — technology/approach evaluation
+- `refactor_[task]` — risky memory restructuring
+- `goal_[name]_iter_[N]` — goal iteration (see goal-driven-evolution)
+- `experiment_[topic]` — open-ended exploration
+
+## Cleanup
+
+Always delete branches after merge or abandonment. Check with `memory_branches()` periodically. Stale branches waste cognitive overhead when listed.
+
+## Merge Strategies
+
+- `replace` (default, also called `accept`): branch wins on conflicts — if the same memory exists on both main and branch, the branch version replaces main's
+- `append`: skip-on-conflict — only adds new memories from branch, never overwrites existing main memories
+
+Use `replace` when the branch contains validated corrections. Use `append` when the branch only adds new information and you want to preserve main's existing state.

--- a/.kiro/steering/memory-hygiene.md
+++ b/.kiro/steering/memory-hygiene.md
@@ -1,0 +1,70 @@
+---
+inclusion: auto
+name: memory-hygiene
+description: Memory health management - governance triggers, contradiction resolution, snapshot cleanup. Use when memory seems noisy or contradictory.
+---
+
+<!-- memoria-version: 0.2.1-->
+
+# Memory Hygiene & Self-Governance
+
+Proactive memory health management — don't wait for the user to ask.
+
+## Proactive Governance Triggers
+
+Run `memory_governance` (1h cooldown) when you notice ANY of these:
+- Retrieval returns clearly outdated or contradictory results
+- You stored 10+ memories in this session without any cleanup
+- User mentions memory feels "noisy" or "wrong"
+
+After governance, check the response for:
+- `snapshot_health.auto_ratio > 50%` → suggest `memory_snapshot_delete(prefix="auto:")`
+- Quarantined memories → inform user what was quarantined and why
+
+## Contradiction Resolution
+
+When you detect two memories that contradict each other:
+
+1. `memory_search` to find both memories and their IDs
+2. Determine which is newer/more accurate based on timestamps and context
+3. `memory_correct` the older one with the accurate information, OR
+4. `memory_purge` the wrong one if it's completely invalid
+5. Never leave both — contradictions poison retrieval
+
+Run `memory_consolidate` (30min cooldown) when:
+- You found a contradiction manually
+- User reports "memory says X but it should be Y" more than once in a session
+- After a large batch of corrections
+
+## Snapshot Hygiene
+
+Snapshots accumulate from auto-saves and safety snapshots. Clean periodically:
+
+```
+memory_snapshots(limit=20)  # check current state
+```
+
+If too many:
+- `memory_snapshot_delete(prefix="pre_")` — purge safety snapshots from purge/correct
+- `memory_snapshot_delete(prefix="auto:")` — purge auto-generated snapshots
+- `memory_snapshot_delete(older_than="<3 months ago>")` — age-based cleanup
+
+Keep named snapshots the user created explicitly.
+
+## Entity Graph Maintenance
+
+Entity extraction is automatic — every `memory_store` triggers regex-based extraction, with LLM extraction as a fallback when configured. No manual intervention needed.
+
+## Reflection Cadence
+
+`memory_reflect` (2h cooldown) synthesizes high-level insights. Suggest it when:
+- User asks "what patterns do you see" or "summarize what you know"
+- `memory_search` returns a high volume of results and no reflection has been done recently
+- Starting a new project phase — reflect on the previous phase first
+
+## Memory Volume Monitoring
+
+Watch for these signals during retrieval:
+- **Too many results all relevant** → memories are too granular, suggest consolidation
+- **Results mostly irrelevant** → memories may be too broad, or index needs rebuild
+- **Same fact appears multiple times** → deduplication needed, use `memory_correct` to merge

--- a/.kiro/steering/memory.md
+++ b/.kiro/steering/memory.md
@@ -1,0 +1,168 @@
+---
+inclusion: always
+---
+
+<!-- memoria-version: 0.2.1-->
+
+# Memory Integration (Memoria Lite)
+
+You have persistent memory via MCP tools. Memory survives across conversations.
+
+## 🔴 MANDATORY: Every conversation start
+
+Call `memory_retrieve` with a **semantic query** derived from the user's message BEFORE responding.
+
+**Query rules:**
+- ✅ Extract key concepts → "benchmark optimization", "graph retrieval bug"
+- ❌ Don't use meta-queries → "all memories", "everything", "list all"
+
+**After retrieval:**
+- Results → use as reference, verify against current context
+- "No relevant memories" → normal for new users, proceed
+- ⚠️ warnings → inform user, offer `memory_governance`
+
+## 🔴 MANDATORY: Every conversation turn
+After responding, decide if anything is worth remembering:
+- User stated a preference, fact, or decision → `memory_store`
+- User corrected a previously stored fact → `memory_correct` (not `memory_store` + `memory_purge`)
+- You learned something new about the project/workflow → `memory_store`
+- Do NOT store: greetings, trivial questions, things already in memory.
+
+**Deduplication is automatic.** The system detects semantically similar memories and supersedes old ones. You do not need to check for duplicates before storing.
+
+If `memory_store` or `memory_correct` response contains ⚠️, tell the user — it means the embedding service is down and retrieval will degrade to keyword-only search.
+
+## 🟡 When NOT to store (noise reduction)
+Do NOT call `memory_store` for:
+- **Transient debug context**: temporary print statements, one-off test values, ephemeral error messages
+- **Vague or low-confidence observations**: "might be using X", "probably prefers Y" — wait for confirmation
+- **Conversation-specific context** that won't matter next session: "currently looking at line 42", "just ran the test"
+- **Information already in memory**: if `memory_retrieve` already returned it, don't store again
+- **Trivial or obvious facts**: "user is writing code", "user asked a question"
+
+## 🟡 Working memory lifecycle — CRITICAL for long debug sessions
+`working` memories are session-scoped temporary context. They **persist and will be retrieved in future sessions** unless explicitly cleaned up.
+
+**When to purge working memories:**
+- Task or debug session is complete → `memory_purge(topic="<task keyword>", reason="task complete")`
+- You stored a working memory that turned out to be wrong → `memory_purge(memory_id="...", reason="incorrect conclusion")`
+- User says "start fresh", "forget what we tried", "let's try a different approach"
+- Only purge completed tasks — leave active task working memories for next session
+
+**Promote or purge as you go:**
+- Hypothesis confirmed → `memory_store` the conclusion as `semantic`, then `memory_purge` the working memory
+- Hypothesis disproven → `memory_purge` the working memory immediately
+- Don't wait until session end to promote — do it as soon as you know
+
+**When a working memory contradicts current findings:**
+- Do NOT keep both. Purge the stale one immediately: `memory_purge(memory_id="...", reason="superseded by new finding")`
+- Then store the correct conclusion as `semantic` (not `working`) if it's a durable fact
+
+**Anti-pattern to avoid:** Storing "current bug is X" as working memory, then later finding out it's Y, but keeping both. The stale "bug is X" memory will keep surfacing and misleading future retrieval.
+
+## 🟡 Correction workflow (prefer correct over store+purge)
+When the user contradicts a previously stored fact:
+1. **Always use `memory_correct`** — not `memory_store` + `memory_purge`. This preserves the audit trail.
+2. **Prefer query-based correction**: `memory_correct(query="formatting tool", new_content="Uses ruff for formatting", reason="switched from black")` — no need to look up memory_id first.
+3. **Only use `memory_purge`** when the user explicitly asks to forget something entirely, not when updating a fact.
+
+## 🟡 Deduplication before storing
+Before storing a new memory, consider:
+- Did `memory_retrieve` at conversation start already return a similar fact? → skip or `memory_correct` instead
+- Is this a refinement of something already stored? → use `memory_correct` with the original as query
+- When in doubt, `memory_search` with the key phrase first — if a match exists, correct it rather than creating a duplicate
+
+## Tool reference
+
+### Write tools
+| Tool | When to use | Key params |
+|------|-------------|------------|
+| `memory_store` | User shares a fact, preference, or decision | `content`, `memory_type` (default: semantic), `session_id` (optional) |
+| `memory_correct` | User says a stored memory is wrong | `memory_id` or `query` (one required), `new_content`, `reason` |
+| `memory_purge` | User asks to forget something | `memory_id` (single or comma-separated batch, e.g. `"id1,id2"`) or `topic` (bulk keyword match), `reason` |
+
+`memory_purge` automatically creates a safety snapshot before deleting. The response includes the snapshot name — tell the user they can `memory_rollback` to undo. If the response contains a ⚠️ warning about snapshot quota, relay it and suggest `memory_snapshot_delete(prefix="pre_")`.
+
+### Read tools
+| Tool | When to use | Key params |
+|------|-------------|------------|
+| `memory_retrieve` | Conversation start, or when context is needed | `query`, `top_k` (default 5), `session_id` (optional), `explain` (false = no debug, true = show timing) |
+| `memory_search` | User asks "what do you know about X" or you need to browse | `query`, `top_k` (default 10), `explain` (false = no debug, true = show timing) |
+| `memory_profile` | User asks "what do you know about me" | — |
+| `memory_feedback` | After using a retrieved memory, record if it was helpful | `memory_id`, `signal` (useful/irrelevant/outdated/wrong), `context` (optional) |
+
+**`memory_feedback`**: Call this after retrieval when you can assess whether a memory was helpful. Signals:
+- `useful` — memory helped answer the question or complete the task
+- `irrelevant` — memory was retrieved but not relevant to the query
+- `outdated` — memory contains stale information (consider `memory_correct` instead if you know the new value)
+- `wrong` — memory contains incorrect information (consider `memory_correct` instead if you know the correct value)
+
+**When to call feedback vs other tools**:
+- Memory helped → `memory_feedback(signal="useful")`
+- Memory irrelevant but correct → `memory_feedback(signal="irrelevant")`
+- Memory outdated and you know new value → `memory_correct` (not feedback)
+- Memory outdated but you don't know new value → `memory_feedback(signal="outdated")`
+- Memory wrong and you know correct value → `memory_correct` (not feedback)
+- Memory should be deleted → `memory_purge` (not feedback)
+
+**Example flow**:
+```
+# 1. Retrieve memories
+memories = memory_retrieve(query="database config")
+
+# 2. Use memories to answer user's question
+# ... (memory about "Uses PostgreSQL" helped answer)
+
+# 3. Record feedback for the helpful memory
+memory_feedback(memory_id="abc123", signal="useful", context="answered DB question")
+```
+
+**Impact**: Feedback accumulates over time. With default settings, a memory with 3 `useful` signals ranks ~30% higher in future retrievals. Don't call for every memory — only when you have clear signal.
+
+**`memory_retrieve` vs `memory_search`**: In MCP mode, both use the same retrieval pipeline (graph → hybrid vector+fulltext → fulltext fallback). The differences are:
+- `memory_retrieve` accepts `session_id` for session-scoped boosting; `memory_search` does not
+- `memory_retrieve` defaults to `top_k=5` (focused); `memory_search` defaults to `top_k=10` (broader)
+- Use `memory_retrieve` when you have a `session_id` or want focused results; use `memory_search` for broader exploration
+
+**Debug parameter:** `explain=true` shows execution timing and retrieval path. **ONLY use when user explicitly asks** to debug performance or investigate why certain memories were/weren't retrieved. **DO NOT use proactively** — it adds overhead and clutters output.
+
+**When to use explain:**
+- ✅ User says: "why is this slow", "show me the retrieval path", "debug this query"
+- ❌ Normal retrieval — never add explain unless user asks
+
+### Memory types
+| Type | Use for | Examples |
+|------|---------|---------|
+| `semantic` | Project facts, technical decisions (default) | "Uses MatrixOne as primary DB", "API follows REST conventions" |
+| `profile` | User/agent identity and preferences | "Prefers concise answers", "Works on mo-dev-agent project" |
+| `procedural` | How-to knowledge, workflows | "Deploy with: make dev-start", "Run tests with pytest -n auto" |
+| `working` | Temporary context for current task | "Currently debugging embedding issue" |
+| `tool_result` | Tool execution results worth caching | "Last CI run: 126 passed, 0 failed" |
+| `episodic` | Session summaries (topic/action/outcome) | "Session Summary: Database optimization\n\nActions: Added indexes\n\nOutcome: 93% faster" |
+
+### Snapshots (save/restore/cleanup)
+Use before risky changes. `memory_snapshot(name)` saves state, `memory_rollback(name)` restores it, `memory_snapshots(limit, offset)` lists with pagination, `memory_snapshot_delete(names|prefix|older_than)` cleans up.
+
+When `memory_governance` reports snapshot_health with high auto_ratio (>50%), suggest cleanup:
+- `memory_snapshot_delete(prefix="auto:")` — remove auto-generated snapshots
+- `memory_snapshot_delete(prefix="pre_")` — remove safety snapshots from purge/correct
+- `memory_snapshot_delete(older_than="2026-01-01")` — remove snapshots before a date
+
+### Branches (isolated experiments)
+Git-like workflow for memory. `memory_branch(name)` creates, `memory_checkout(name)` switches, `memory_diff(source)` previews changes, `memory_merge(source)` merges back, `memory_branch_delete(name)` cleans up. `memory_branches()` lists all.
+
+### Entity graph
+Entity extraction is automatic — every `memory_store` triggers regex-based extraction, with LLM extraction as a fallback when configured. No manual intervention needed.
+
+### Maintenance (proactive triggers in [memory-hygiene](memory-hygiene.md), manual triggers below)
+| Tool | Trigger phrase | Cooldown |
+|------|---------------|----------|
+| `memory_governance` | "clean up memories", "check memory health", or proactively per [memory-hygiene](memory-hygiene.md) | 1 hour |
+| `memory_consolidate` | "check for contradictions", "fix conflicts" | 30 min |
+| `memory_reflect` | "find patterns", "summarize what you know" | 2 hours |
+| `memory_snapshot_delete` | When governance reports high snapshot auto_ratio, or user asks to clean snapshots | — |
+
+`memory_reflect` supports `mode` parameter:
+- `auto` (default): uses Memoria's internal LLM if configured, otherwise returns candidates for YOU to process
+- `candidates`: always returns raw data for YOU to synthesize, then store results via `memory_store`
+- `internal`: always uses Memoria's internal LLM (fails if not configured)

--- a/.kiro/steering/session-lifecycle.md
+++ b/.kiro/steering/session-lifecycle.md
@@ -1,0 +1,80 @@
+---
+inclusion: auto
+name: session-lifecycle
+description: Detailed session lifecycle management - bootstrap, mid-session re-retrieval, wrap-up cleanup. Use when starting conversations or managing session state.
+---
+
+<!-- memoria-version: 0.2.1-->
+
+# Session Lifecycle Management
+
+Systematic memory management across conversation phases: bootstrap, mid-session, and wrap-up.
+
+## Phase 1: Conversation Start (Bootstrap)
+
+Before your first response, run a multi-query bootstrap to load full context:
+
+1. **Primary query** — derive from user's message: `memory_retrieve(query="<semantic extraction>")`
+2. **Active goals** — `memory_search(query="GOAL ACTIVE")` (if user's message references ongoing work, a previous task, or doesn't start a clearly new topic)
+3. **User profile** — `memory_profile()` (if user asks about preferences or you need style context)
+
+Combine retrieved context into a mental model. Flag anything that looks stale (e.g., "Currently debugging X" from days ago).
+
+**session_id**: If the user's tool provides a session ID, pass it to `memory_retrieve` and `memory_store` throughout the conversation. This enables episodic memory and per-session retrieval boosting.
+
+## Phase 2: Mid-Session (Active Work)
+
+### Re-retrieval triggers
+
+Call `memory_retrieve` again mid-conversation when:
+- User shifts to a completely different topic
+- You need context about something not covered in the initial bootstrap
+- User references a past decision or preference you don't have loaded
+
+### Store cadence
+
+- Don't batch-store at the end. Store facts as they emerge — this gives each memory accurate timestamps.
+- One fact per `memory_store` call. Don't combine unrelated facts into one memory.
+
+Working memory discipline (when to store as `working`, when to promote/purge) is defined in [memory.md](memory.md) — follow those rules here.
+
+## Phase 3: Conversation End (Wrap-Up)
+
+When the conversation is winding down (user says thanks, goodbye, or stops engaging):
+
+### 1. Clean up working memories
+
+```
+memory_purge(topic="<task keyword>", reason="session complete")
+```
+
+Only purge working memories for tasks that are actually done. Leave active task working memories for next session.
+
+### 2. Promote durable findings
+
+Any working memory that turned out to be a lasting fact should already be stored as `semantic`. Double-check: did you learn something important this session that's still only in `working`? Promote it.
+
+### 3. Generate episodic summary (if session was substantive)
+
+If the session involved meaningful work (not just a quick question), and `session_id` is available:
+
+- The agent itself can synthesize a summary and store it:
+```
+memory_store(
+  content="Session Summary: [topic]\n\nActions: [what was done]\n\nOutcome: [result/status]",
+  memory_type="episodic",
+  session_id="<session_id>"
+)
+```
+
+### 4. Update goal status
+
+If you were working on a tracked goal, update its status via `memory_correct`.
+
+## Anti-Patterns
+
+- ❌ Storing 10+ memories at conversation end in a burst — timestamps all identical, retrieval ranking suffers
+- ❌ Leaving stale working memories from completed tasks — they pollute future retrieval
+- ❌ Never re-retrieving mid-conversation — you miss context when topics shift
+- ❌ Skipping session summary for long productive sessions — loses the high-level narrative
+- ❌ Storing the same fact as both `working` and `semantic` — pick one

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -204,6 +204,31 @@ func (builder *QueryBuilder) isScanProtected(scanID int32) bool {
 	return builder.protectedScans[scanID] > 0
 }
 
+func (builder *QueryBuilder) suspendScanProtection(scanID int32) func() {
+	if builder == nil || builder.protectedScans == nil {
+		return func() {}
+	}
+
+	originalCount, wasProtected := builder.protectedScans[scanID]
+	if wasProtected {
+		delete(builder.protectedScans, scanID)
+	}
+
+	return func() {
+		if wasProtected {
+			builder.protectedScans[scanID] = originalCount
+		} else {
+			delete(builder.protectedScans, scanID)
+		}
+	}
+}
+
+func (builder *QueryBuilder) withSuspendedScanProtection(scanID int32, callback func()) {
+	restore := builder.suspendScanProtection(scanID)
+	defer restore()
+	callback()
+}
+
 func containsInt32(list []int32, target int32) bool {
 	for _, v := range list {
 		if v == target {

--- a/pkg/sql/plan/apply_indices_ivfflat.go
+++ b/pkg/sql/plan/apply_indices_ivfflat.go
@@ -275,7 +275,33 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 		}
 
 		if builder.canApplyRegularIndex(secondScanNode) {
-			optimizedSecondScanID := builder.applyIndicesForFilters(secondScanNodeID, secondScanNode, colRefCnt, idxColMap)
+			// Remove filters that reference the vector column (e.g., "embedding IS NOT NULL")
+			// from secondScanNode. This node only needs to produce a PK list for the
+			// BloomFilter pushdown to ivf_search. The vector column filter is redundant here
+			// because: (1) rows without embeddings won't have entries in the IVF index anyway,
+			// and (2) the outer scanNode still retains the full FilterList as a safety net.
+			// Removing these filters enables index-only scan when the remaining filter columns
+			// + PK are all covered by the index.
+			partPos := ivfCtx.partPos
+			var cleanedFilters []*plan.Expr
+			for _, expr := range secondScanNode.FilterList {
+				if refsColumn(expr, newTag, partPos) {
+					continue
+				}
+				cleanedFilters = append(cleanedFilters, expr)
+			}
+			secondScanNode.FilterList = cleanedFilters
+
+			// Build a minimal colRefCnt that only references PK + filter columns.
+			// The original colRefCnt includes all columns from the query (e.g., embedding),
+			// which prevents tryIndexOnlyScan. With the vector column filter removed,
+			// the remaining columns are likely all covered by the index.
+			secondColRefCnt := make(map[[2]int32]int)
+			secondColRefCnt[[2]int32{newTag, ivfCtx.pkPos}] = 1
+			for _, expr := range secondScanNode.FilterList {
+				extractColRefs(expr, newTag, secondColRefCnt)
+			}
+			optimizedSecondScanID := builder.applyIndicesForFilters(secondScanNodeID, secondScanNode, secondColRefCnt, idxColMap)
 			secondScanNodeID = optimizedSecondScanID
 			secondScanNode = builder.qry.Nodes[secondScanNodeID]
 		}
@@ -368,6 +394,18 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 		probeSpec.UseBloomFilter = true
 		tableFuncNode.RuntimeFilterProbeList = []*plan.RuntimeFilterSpec{probeSpec}
 
+		// Apply regular index optimization to the original scanNode (left side of outer join).
+		// The scanNode was protected from index optimization during the recursive applyIndices pass
+		// to preserve it for vector index transformation. Now that the IVF plan is built, we must
+		// temporarily unprotect it so applyIndicesForFilters can apply regular indices
+		// (e.g., idx_user_active) to avoid full table scan on the row-fetch join.
+		outerScanNodeID := scanNode.NodeId
+		if builder.canApplyRegularIndex(scanNode) {
+			builder.withSuspendedScanProtection(scanNode.NodeId, func() {
+				outerScanNodeID = builder.applyIndicesForFilters(scanNode.NodeId, scanNode, colRefCnt, idxColMap)
+			})
+		}
+
 		// outer join: original table JOIN (inner ivf join)
 		outerOn, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{
 			{
@@ -392,7 +430,7 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 
 		outerJoinNodeID := builder.appendNode(&plan.Node{
 			NodeType: plan.Node_JOIN,
-			Children: []int32{scanNode.NodeId, innerJoinNodeID},
+			Children: []int32{outerScanNodeID, innerJoinNodeID},
 			JoinType: plan.Node_INNER,
 			OnList:   []*Expr{outerOn},
 			// Don't set Limit/Offset on JOIN - they should be applied after SORT
@@ -661,4 +699,54 @@ func colRefsWithin(expr *plan.Expr, colCnt int) bool {
 	default:
 		return true
 	}
+}
+
+// extractColRefs walks an expression tree and records column references
+// that match the given tag into the colRefCnt map.
+func extractColRefs(expr *plan.Expr, tag int32, colRefCnt map[[2]int32]int) {
+	if expr == nil {
+		return
+	}
+	switch impl := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		if impl.Col.RelPos == tag {
+			colRefCnt[[2]int32{tag, impl.Col.ColPos}]++
+		}
+	case *plan.Expr_F:
+		for _, arg := range impl.F.Args {
+			extractColRefs(arg, tag, colRefCnt)
+		}
+	case *plan.Expr_Sub:
+		return
+	case *plan.Expr_List:
+		for _, sub := range impl.List.List {
+			extractColRefs(sub, tag, colRefCnt)
+		}
+	}
+}
+
+// refsColumn checks if an expression references a specific column (identified by tag and colPos).
+func refsColumn(expr *plan.Expr, tag int32, colPos int32) bool {
+	if expr == nil {
+		return false
+	}
+	switch impl := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		return impl.Col.RelPos == tag && impl.Col.ColPos == colPos
+	case *plan.Expr_F:
+		for _, arg := range impl.F.Args {
+			if refsColumn(arg, tag, colPos) {
+				return true
+			}
+		}
+	case *plan.Expr_Sub:
+		return false
+	case *plan.Expr_List:
+		for _, sub := range impl.List.List {
+			if refsColumn(sub, tag, colPos) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/sql/plan/apply_indices_ivfflat_optimize_test.go
+++ b/pkg/sql/plan/apply_indices_ivfflat_optimize_test.go
@@ -186,3 +186,176 @@ func TestApplyIndicesForSortUsingIvfflat_PushdownOptimization(t *testing.T) {
 		assert.Equal(t, plan.Node_JOIN, innerJoinNode.NodeType, "With filter, right child should be nested JOIN")
 	})
 }
+
+func TestApplyIndicesForSortUsingIvfflat_OuterScanRegularIndexPreservesProtection(t *testing.T) {
+	baseMockCtx := NewMockCompilerContext(false)
+	mockCtx := &customMockCompilerContext{
+		MockCompilerContext: baseMockCtx,
+		resolveVarFunc: func(varName string, isSystem, isGlobal bool) (interface{}, error) {
+			switch varName {
+			case "enable_vector_prefilter_by_default":
+				return int8(1), nil
+			case "ivf_threads_search":
+				return int64(4), nil
+			case "probe_limit":
+				return int64(10), nil
+			}
+			return baseMockCtx.ResolveVariable(varName, isSystem, isGlobal)
+		},
+	}
+
+	const (
+		tableName  = "t_idx"
+		indexTable = "__mo_index_status"
+		schemaName = "db"
+	)
+
+	tableDef := &plan.TableDef{
+		Name: tableName,
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "status", Typ: plan.Type{Id: int32(types.T_int32)}},
+			{Name: "v", Typ: plan.Type{Id: int32(types.T_array_float32)}},
+		},
+		Pkey: &plan.PrimaryKeyDef{
+			PkeyColName: "id",
+			Names:       []string{"id"},
+		},
+		Name2ColIndex: map[string]int32{
+			"id":     0,
+			"status": 1,
+			"v":      2,
+		},
+		Indexes: []*plan.IndexDef{
+			{
+				IndexName:      "idx_status",
+				IndexAlgo:      "btree",
+				IndexTableName: indexTable,
+				Unique:         true,
+				TableExist:     true,
+				Parts:          []string{"status"},
+			},
+		},
+	}
+
+	idxTableDef := &plan.TableDef{
+		Name: indexTable,
+		Cols: []*plan.ColDef{
+			{Name: "__mo_index_idx_col", Typ: plan.Type{Id: int32(types.T_int32)}},
+			{Name: "__mo_index_pk_col", Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+		Name2ColIndex: map[string]int32{
+			"__mo_index_idx_col": 0,
+			"__mo_index_pk_col":  1,
+		},
+	}
+	mockCtx.tables[indexTable] = idxTableDef
+	mockCtx.objects[indexTable] = &plan.ObjectRef{SchemaName: schemaName, ObjName: indexTable}
+
+	idxAlgoParams := `{"op_type": "` + metric.DistFuncOpTypes["l2_distance"] + `"}`
+	multiTableIndex := &MultiTableIndex{
+		IndexAlgo: catalog.MoIndexIvfFlatAlgo.ToString(),
+		IndexDefs: map[string]*plan.IndexDef{
+			catalog.SystemSI_IVFFLAT_TblType_Metadata: {
+				IndexTableName:  "meta",
+				IndexAlgoParams: idxAlgoParams,
+			},
+			catalog.SystemSI_IVFFLAT_TblType_Centroids: {
+				IndexTableName:  "centroids",
+				Parts:           []string{"v"},
+				IndexAlgoParams: idxAlgoParams,
+			},
+			catalog.SystemSI_IVFFLAT_TblType_Entries: {
+				IndexTableName: "entries",
+			},
+		},
+	}
+
+	builder := NewQueryBuilder(plan.Query_SELECT, mockCtx, false, true)
+	ctx := NewBindContext(builder, nil)
+
+	scanNode := &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		TableDef:    tableDef,
+		ObjRef:      &plan.ObjectRef{SchemaName: schemaName, ObjName: tableName},
+		BindingTags: []int32{builder.genNewBindTag()},
+		FilterList: []*plan.Expr{
+			{
+				Expr: &plan.Expr_F{
+					F: &plan.Function{
+						Func: &plan.ObjectRef{ObjName: "="},
+						Args: []*plan.Expr{
+							{
+								Typ:  plan.Type{Id: int32(types.T_int32)},
+								Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 1, Name: "status"}},
+							},
+							{
+								Typ:  plan.Type{Id: int32(types.T_int32)},
+								Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_I32Val{I32Val: 1}}},
+							},
+						},
+					},
+				},
+				Selectivity: 0.01,
+			},
+		},
+		Stats: &plan.Stats{
+			TableCnt:    1000,
+			Selectivity: 0.01,
+			Outcnt:      10,
+			Cost:        1000,
+		},
+	}
+	scanNode.FilterList[0].GetF().Args[0].GetCol().RelPos = scanNode.BindingTags[0]
+	scanNodeID := builder.appendNode(scanNode, ctx)
+
+	for int(scanNodeID) >= len(builder.ctxByNode) {
+		builder.ctxByNode = append(builder.ctxByNode, ctx)
+	}
+	// Preallocate enough BindContexts for all plan nodes appended by the IVF rewrite
+	// path in this test (function scan, nested joins, projects, sort, and index join).
+	for i := 0; i < 40; i++ {
+		builder.ctxByNode = append(builder.ctxByNode, ctx)
+	}
+
+	float32Typ := plan.Type{Id: int32(types.T_array_float32)}
+	distFnExpr := &plan.Function{
+		Func: &ObjectRef{ObjName: "l2_distance"},
+		Args: []*plan.Expr{
+			{Typ: float32Typ, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: scanNode.BindingTags[0], ColPos: 2}}},
+			{Typ: float32Typ, Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_VecVal{VecVal: "[1,1,1]"}}}},
+		},
+	}
+
+	vecCtx := &vectorSortContext{
+		scanNode:   scanNode,
+		sortNode:   &plan.Node{NodeType: plan.Node_SORT},
+		projNode:   &plan.Node{NodeType: plan.Node_PROJECT, Children: []int32{scanNodeID}},
+		distFnExpr: distFnExpr,
+		limit:      &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 10}}}},
+		rankOption: &plan.RankOption{Mode: "pre"},
+	}
+
+	colRefCnt := map[[2]int32]int{
+		{scanNode.BindingTags[0], 0}: 1,
+		{scanNode.BindingTags[0], 1}: 1,
+		{scanNode.BindingTags[0], 2}: 1,
+	}
+	idxColMap := make(map[[2]int32]*plan.Expr)
+
+	builder.protectedScans[scanNode.NodeId] = 2
+
+	_, err := builder.applyIndicesForSortUsingIvfflat(scanNodeID, vecCtx, multiTableIndex, colRefCnt, idxColMap)
+	require.NoError(t, err)
+
+	sortNode := builder.qry.Nodes[vecCtx.projNode.Children[0]]
+	outerJoinNode := builder.qry.Nodes[sortNode.Children[0]]
+	outerLeft := builder.qry.Nodes[outerJoinNode.Children[0]]
+
+	require.Equal(t, plan.Node_SORT, sortNode.NodeType)
+	require.Equal(t, plan.Node_JOIN, outerJoinNode.NodeType)
+	assert.Equal(t, plan.Node_JOIN, outerLeft.NodeType)
+	assert.Equal(t, plan.Node_INDEX, outerLeft.JoinType)
+	assert.Equal(t, 2, builder.protectedScans[scanNode.NodeId])
+	assert.NotEmpty(t, scanNode.RuntimeFilterProbeList)
+}

--- a/pkg/sql/plan/apply_indices_ivfflat_test.go
+++ b/pkg/sql/plan/apply_indices_ivfflat_test.go
@@ -1128,6 +1128,49 @@ func TestCanApplyRegularIndex_Success(t *testing.T) {
 	assert.True(t, result)
 }
 
+func TestExtractColRefs_SubqueryNoop(t *testing.T) {
+	colRefCnt := make(map[[2]int32]int)
+	expr := &plan.Expr{
+		Expr: &plan.Expr_Sub{
+			Sub: &plan.SubqueryRef{
+				NodeId: 1,
+				Child: &plan.Expr{
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{
+							RelPos: 10,
+							ColPos: 3,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	extractColRefs(expr, 10, colRefCnt)
+
+	assert.Empty(t, colRefCnt)
+}
+
+func TestRefsColumn_SubqueryReturnsFalse(t *testing.T) {
+	expr := &plan.Expr{
+		Expr: &plan.Expr_Sub{
+			Sub: &plan.SubqueryRef{
+				NodeId: 1,
+				Child: &plan.Expr{
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{
+							RelPos: 10,
+							ColPos: 3,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.False(t, refsColumn(expr, 10, 3))
+}
+
 // ============================================================================
 // Tests for colRefsWithin
 // ============================================================================

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -19,7 +19,59 @@ import (
 	"testing"
 
 	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestSuspendScanProtection_RestoresExactCount(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	const scanID int32 = 42
+
+	builder.protectedScans[scanID] = 3
+	restore := builder.suspendScanProtection(scanID)
+
+	assert.False(t, builder.isScanProtected(scanID))
+
+	restore()
+
+	assert.Equal(t, 3, builder.protectedScans[scanID])
+}
+
+func TestSuspendScanProtection_NoExistingProtection(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	const scanID int32 = 24
+
+	restore := builder.suspendScanProtection(scanID)
+	assert.False(t, builder.isScanProtected(scanID))
+
+	restore()
+
+	_, exists := builder.protectedScans[scanID]
+	assert.False(t, exists)
+}
+
+func TestWithSuspendedScanProtection_RestoresAfterPanic(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	const scanID int32 = 64
+
+	builder.protectedScans[scanID] = 2
+
+	recovered := false
+	func() {
+		defer func() {
+			if recover() != nil {
+				recovered = true
+			}
+		}()
+
+		builder.withSuspendedScanProtection(scanID, func() {
+			assert.False(t, builder.isScanProtected(scanID))
+			panic("boom")
+		})
+	}()
+
+	assert.True(t, recovered)
+	assert.Equal(t, 2, builder.protectedScans[scanID])
+}
 
 func TestCalculatePostFilterOverFetchFactor(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23918 

## What this PR does / why we need it:

  Body Summary Fix a bug in ivfflat optimization where ad-hoc temporary unprotect of builder.protectedScans used delete/++ and could
  corrupt counts if the original count > 1. Replace ad-hoc logic with a defer-safe helper and add panic-safe wrapper. Add unit &
  integration tests to cover normal and panic restore paths.

  Changes

   - Add suspendScanProtection(scanID) -> restore() helper and withSuspendedScanProtection wrapper (pkg/sql/plan/apply_indices.go)
   - Replace delete/++ sites in ivfflat path with the helper (pkg/sql/plan/apply_indices_ivfflat.go)
   - Minor robustness: add Expr_Sub branch in refsColumn/extractColRefs to avoid future mis-detection
   - Tests: add suspend/restore and ivfflat integration tests (pkg/sql/plan/*_test.go)