### PR TITLE
fix: make suspend/resume of protectedScans defer-safe main

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -241,6 +241,31 @@ func (builder *QueryBuilder) isScanProtected(scanID int32) bool {
 	return builder.protectedScans[scanID] > 0
 }
 
+func (builder *QueryBuilder) suspendScanProtection(scanID int32) func() {
+	if builder == nil || builder.protectedScans == nil {
+		return func() {}
+	}
+
+	originalCount, wasProtected := builder.protectedScans[scanID]
+	if wasProtected {
+		delete(builder.protectedScans, scanID)
+	}
+
+	return func() {
+		if wasProtected {
+			builder.protectedScans[scanID] = originalCount
+		} else {
+			delete(builder.protectedScans, scanID)
+		}
+	}
+}
+
+func (builder *QueryBuilder) withSuspendedScanProtection(scanID int32, callback func()) {
+	restore := builder.suspendScanProtection(scanID)
+	defer restore()
+	callback()
+}
+
 func containsInt32(list []int32, target int32) bool {
 	for _, v := range list {
 		if v == target {

--- a/pkg/sql/plan/apply_indices_ivfflat.go
+++ b/pkg/sql/plan/apply_indices_ivfflat.go
@@ -606,7 +606,6 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 			}
 			optimizedSecondScanID := builder.applyIndicesForFilters(secondScanNodeID, secondScanNode, secondColRefCnt, idxColMap)
 			secondScanNodeID = optimizedSecondScanID
-			secondScanNode = builder.qry.Nodes[secondScanNodeID]
 		}
 
 		// Otherwise BloomFilter will only see the truncated primary key set, causing data loss.

--- a/pkg/sql/plan/apply_indices_ivfflat.go
+++ b/pkg/sql/plan/apply_indices_ivfflat.go
@@ -710,17 +710,21 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 			})
 		}
 
-		// outer join: original table JOIN (inner ivf join)
+		outerPkExpr := builder.buildPkExprFromNode(outerScanNodeID, ivfCtx.pkType, scanNode.TableDef.Pkey.PkeyColName)
+		if outerPkExpr == nil && outerScanNodeID != scanNode.NodeId {
+			// If a future regular-index rewrite produces an unsupported subtree shape,
+			// fall back to the original scan instead of wiring stale bindings into the IVF join.
+			logutil.Debugf("IVF outer PK fallback: optimized node %d -> original scan %d", outerScanNodeID, scanNode.NodeId)
+			outerScanNodeID = scanNode.NodeId
+			outerPkExpr = builder.buildPkExprFromNode(outerScanNodeID, ivfCtx.pkType, scanNode.TableDef.Pkey.PkeyColName)
+		}
+		if outerPkExpr == nil {
+			return nodeID, nil
+		}
+
+		// outer join: optimized outer subtree JOIN (inner ivf join)
 		outerOn, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{
-			{
-				Typ: ivfCtx.pkType,
-				Expr: &plan.Expr_Col{
-					Col: &plan.ColRef{
-						RelPos: scanNode.BindingTags[0],
-						ColPos: ivfCtx.pkPos, // tbl.pk
-					},
-				},
-			},
+			DeepCopyExpr(outerPkExpr),
 			{
 				Typ: ivfCtx.pkType,
 				Expr: &plan.Expr_Col{
@@ -748,18 +752,13 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 		//   2) UpperLimit is set to avoid all filters being degraded to PASS due to 0.
 		rfTag2 := builder.genNewMsgTag()
 
-		// probe: primary key column from original table (scanNode left child)
-		probeExpr2 := &plan.Expr{
-			Typ: ivfCtx.pkType,
-			Expr: &plan.Expr_Col{
-				Col: &plan.ColRef{
-					RelPos: scanNode.BindingTags[0],
-					ColPos: ivfCtx.pkPos,
-				},
-			},
+		outerHasProbeRuntimeFilter := false
+		outerProbeNodeID := builder.findScanNodeByTag(outerScanNodeID, outerPkExpr.GetCol().RelPos)
+		if outerProbeNodeID >= 0 {
+			probeSpec2 := MakeRuntimeFilter(rfTag2, false, 0, DeepCopyExpr(outerPkExpr), false)
+			builder.qry.Nodes[outerProbeNodeID].RuntimeFilterProbeList = append(builder.qry.Nodes[outerProbeNodeID].RuntimeFilterProbeList, probeSpec2)
+			outerHasProbeRuntimeFilter = true
 		}
-		probeSpec2 := MakeRuntimeFilter(rfTag2, false, 0, DeepCopyExpr(probeExpr2), false)
-		scanNode.RuntimeFilterProbeList = append(scanNode.RuntimeFilterProbeList, probeSpec2)
 
 		// build: placeholder column, HashBuild will generate IN-list based on build side join key's UniqueJoinKeys[0]
 		buildExpr2 := &plan.Expr{
@@ -777,8 +776,10 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 		const unlimitedInFilterCard = int32(1<<31 - 1)
 		buildSpec2 := MakeRuntimeFilter(rfTag2, false, unlimitedInFilterCard, buildExpr2, false)
 
-		outerJoinNode := builder.qry.Nodes[outerJoinNodeID]
-		outerJoinNode.RuntimeFilterBuildList = append(outerJoinNode.RuntimeFilterBuildList, buildSpec2)
+		if outerHasProbeRuntimeFilter {
+			outerJoinNode := builder.qry.Nodes[outerJoinNodeID]
+			outerJoinNode.RuntimeFilterBuildList = append(outerJoinNode.RuntimeFilterBuildList, buildSpec2)
+		}
 
 		// Outer join doesn't add extra project, let global column pruning optimizer handle it
 		joinRootID = outerJoinNodeID
@@ -878,7 +879,18 @@ func (builder *QueryBuilder) buildPkExprFromNode(nodeID int32, pkType plan.Type,
 		}
 		colIdx, ok := node.TableDef.Name2ColIndex[pkName]
 		if !ok {
-			colIdx = node.TableDef.Name2ColIndex[node.TableDef.Pkey.PkeyColName]
+			if node.IndexScanInfo.IsIndexScan {
+				colIdx, ok = node.TableDef.Name2ColIndex[catalog.IndexTablePrimaryColName]
+				if !ok {
+					logutil.Debugf("IVF buildPkExprFromNode: index primary column %q missing in table %q for node %d", catalog.IndexTablePrimaryColName, node.TableDef.Name, nodeID)
+					return nil
+				}
+			} else {
+				if node.TableDef.Pkey == nil {
+					return nil
+				}
+				colIdx = node.TableDef.Name2ColIndex[node.TableDef.Pkey.PkeyColName]
+			}
 		}
 		return &plan.Expr{
 			Typ: pkType,
@@ -898,9 +910,9 @@ func (builder *QueryBuilder) buildPkExprFromNode(nodeID int32, pkType plan.Type,
 				}
 			}
 		}
-		if len(node.Children) > 0 {
-			return builder.buildPkExprFromNode(node.Children[0], pkType, pkName)
-		}
+		// If PROJECT doesn't expose PK, don't recurse to child: using child's binding tag here
+		// would produce stale ColRef(RelPos) for joins/runtime filters above this PROJECT.
+		return nil
 	case plan.Node_JOIN:
 		if len(node.Children) > 0 {
 			return builder.buildPkExprFromNode(node.Children[0], pkType, pkName)
@@ -911,6 +923,30 @@ func (builder *QueryBuilder) buildPkExprFromNode(nodeID int32, pkType plan.Type,
 		}
 	}
 	return nil
+}
+
+func (builder *QueryBuilder) findScanNodeByTag(nodeID, tag int32) int32 {
+	return builder.findScanNodeByTagWithVisited(nodeID, tag, make(map[int32]struct{}))
+}
+
+func (builder *QueryBuilder) findScanNodeByTagWithVisited(nodeID, tag int32, visited map[int32]struct{}) int32 {
+	if builder == nil || nodeID < 0 {
+		return -1
+	}
+	if _, seen := visited[nodeID]; seen {
+		return -1
+	}
+	visited[nodeID] = struct{}{}
+	node := builder.qry.Nodes[nodeID]
+	if node.NodeType == plan.Node_TABLE_SCAN && len(node.BindingTags) > 0 && node.BindingTags[0] == tag {
+		return nodeID
+	}
+	for _, childID := range node.Children {
+		if found := builder.findScanNodeByTagWithVisited(childID, tag, visited); found >= 0 {
+			return found
+		}
+	}
+	return -1
 }
 
 func (builder *QueryBuilder) getColName(col *plan.ColRef) string {

--- a/pkg/sql/plan/apply_indices_ivfflat.go
+++ b/pkg/sql/plan/apply_indices_ivfflat.go
@@ -586,7 +586,27 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 		}
 
 		if builder.canApplyRegularIndex(secondScanNode) {
-			optimizedSecondScanID := builder.applyIndicesForFilters(secondScanNodeID, secondScanNode, colRefCnt, idxColMap)
+			// Remove filters that reference the vector column (e.g. "embedding IS NOT NULL").
+			// The copied second scan only needs to produce PKs for the inner BloomFilter join;
+			// the original outer scan still keeps the full filter list as the safety net.
+			partPos := ivfCtx.partPos
+			var cleanedFilters []*plan.Expr
+			for _, expr := range secondScanNode.FilterList {
+				if refsColumn(expr, newTag, partPos) {
+					continue
+				}
+				cleanedFilters = append(cleanedFilters, expr)
+			}
+			secondScanNode.FilterList = cleanedFilters
+
+			// Build a minimal colRefCnt for the copied scan so index-only planning is still
+			// possible after removing vector-column-only filters.
+			secondColRefCnt := make(map[[2]int32]int)
+			secondColRefCnt[[2]int32{newTag, ivfCtx.pkPos}] = 1
+			for _, expr := range secondScanNode.FilterList {
+				extractColRefs(expr, newTag, secondColRefCnt)
+			}
+			optimizedSecondScanID := builder.applyIndicesForFilters(secondScanNodeID, secondScanNode, secondColRefCnt, idxColMap)
 			secondScanNodeID = optimizedSecondScanID
 			secondScanNode = builder.qry.Nodes[secondScanNodeID]
 		}
@@ -679,6 +699,17 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 		probeSpec.UseBloomFilter = true
 		tableFuncNode.RuntimeFilterProbeList = []*plan.RuntimeFilterSpec{probeSpec}
 
+		// The original scan was guarded during the recursive planner pass so the vector rewrite
+		// could see the raw table scan shape. Once the IVF subtree is constructed, we can
+		// temporarily suspend that protection and apply regular secondary-index optimization
+		// to the row-fetch side of the outer join.
+		outerScanNodeID := scanNode.NodeId
+		if builder.canApplyRegularIndex(scanNode) {
+			builder.withSuspendedScanProtection(scanNode.NodeId, func() {
+				outerScanNodeID = builder.applyIndicesForFilters(scanNode.NodeId, scanNode, colRefCnt, idxColMap)
+			})
+		}
+
 		// outer join: original table JOIN (inner ivf join)
 		outerOn, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*Expr{
 			{
@@ -703,7 +734,7 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 
 		outerJoinNodeID := builder.appendNode(&plan.Node{
 			NodeType: plan.Node_JOIN,
-			Children: []int32{scanNode.NodeId, innerJoinNodeID},
+			Children: []int32{outerScanNodeID, innerJoinNodeID},
 			JoinType: plan.Node_INNER,
 			OnList:   []*Expr{outerOn},
 			// Don't set Limit/Offset on JOIN - they should be applied after SORT
@@ -973,4 +1004,51 @@ func colRefsWithin(expr *plan.Expr, colCnt int) bool {
 	default:
 		return true
 	}
+}
+
+func extractColRefs(expr *plan.Expr, tag int32, colRefCnt map[[2]int32]int) {
+	if expr == nil {
+		return
+	}
+	switch impl := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		if impl.Col.RelPos == tag {
+			colRefCnt[[2]int32{tag, impl.Col.ColPos}]++
+		}
+	case *plan.Expr_F:
+		for _, arg := range impl.F.Args {
+			extractColRefs(arg, tag, colRefCnt)
+		}
+	case *plan.Expr_Sub:
+		return
+	case *plan.Expr_List:
+		for _, sub := range impl.List.List {
+			extractColRefs(sub, tag, colRefCnt)
+		}
+	}
+}
+
+func refsColumn(expr *plan.Expr, tag int32, colPos int32) bool {
+	if expr == nil {
+		return false
+	}
+	switch impl := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		return impl.Col.RelPos == tag && impl.Col.ColPos == colPos
+	case *plan.Expr_F:
+		for _, arg := range impl.F.Args {
+			if refsColumn(arg, tag, colPos) {
+				return true
+			}
+		}
+	case *plan.Expr_Sub:
+		return false
+	case *plan.Expr_List:
+		for _, sub := range impl.List.List {
+			if refsColumn(sub, tag, colPos) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/sql/plan/apply_indices_ivfflat.go
+++ b/pkg/sql/plan/apply_indices_ivfflat.go
@@ -564,8 +564,6 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 		// secondScanNode: copy original scanNode for JOIN(ivf, table)
 		secondScanNodeID := builder.copyNode(ctx, scanNode.NodeId)
 		secondScanNode := builder.qry.Nodes[secondScanNodeID]
-		baseSecondScan := secondScanNode
-
 		oldTag := secondScanNode.BindingTags[0]
 		builder.rebindScanNode(secondScanNode)
 		newTag := secondScanNode.BindingTags[0]
@@ -612,23 +610,15 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 		}
 
 		// Otherwise BloomFilter will only see the truncated primary key set, causing data loss.
-		secondScanNode.Limit = nil
-		secondScanNode.Offset = nil
+		clearLimitOffsetInSubtree(builder.qry, secondScanNodeID)
 
 		// Add a PROJECT node above secondScanNode to output only the primary key column
 		secondProjectTag := builder.genNewBindTag()
 		secondPkExpr := builder.buildPkExprFromNode(secondScanNodeID, ivfCtx.pkType, scanNode.TableDef.Pkey.PkeyColName)
 		if secondPkExpr == nil {
-			secondPkExpr = &plan.Expr{
-				Typ: ivfCtx.pkType,
-				Expr: &plan.Expr_Col{
-					Col: &plan.ColRef{
-						RelPos: baseSecondScan.BindingTags[0],
-						ColPos: ivfCtx.pkPos,
-						Name:   scanNode.TableDef.Cols[ivfCtx.pkPos].Name,
-					},
-				},
-			}
+			// If an optimized second-scan subtree can't provide a stable PK expression,
+			// skip IVF rewrite to avoid wiring stale bindings into join/runtime-filter paths.
+			return nodeID, nil
 		}
 		secondProjectNodeID := builder.appendNode(&plan.Node{
 			NodeType:    plan.Node_PROJECT,
@@ -1014,6 +1004,18 @@ func (builder *QueryBuilder) canApplyRegularIndex(node *plan.Node) bool {
 		}
 	}
 	return len(node.FilterList) > 0
+}
+
+func clearLimitOffsetInSubtree(qry *plan.Query, nodeID int32) {
+	if qry == nil || nodeID < 0 {
+		return
+	}
+	node := qry.Nodes[nodeID]
+	node.Limit = nil
+	node.Offset = nil
+	for _, childID := range node.Children {
+		clearLimitOffsetInSubtree(qry, childID)
+	}
 }
 
 func colRefsWithin(expr *plan.Expr, colCnt int) bool {

--- a/pkg/sql/plan/apply_indices_ivfflat_optimize_test.go
+++ b/pkg/sql/plan/apply_indices_ivfflat_optimize_test.go
@@ -359,3 +359,182 @@ func TestApplyIndicesForSortUsingIvfflat_OuterScanRegularIndexPreservesProtectio
 	assert.Equal(t, 2, builder.protectedScans[scanNode.NodeId])
 	assert.NotEmpty(t, scanNode.RuntimeFilterProbeList)
 }
+
+func TestApplyIndicesForSortUsingIvfflat_OuterScanIndexOnlyUsesOptimizedPk(t *testing.T) {
+	baseMockCtx := NewMockCompilerContext(false)
+	mockCtx := &customMockCompilerContext{
+		MockCompilerContext: baseMockCtx,
+		resolveVarFunc: func(varName string, isSystem, isGlobal bool) (interface{}, error) {
+			switch varName {
+			case "enable_vector_prefilter_by_default":
+				return int8(1), nil
+			case "ivf_threads_search":
+				return int64(4), nil
+			case "probe_limit":
+				return int64(10), nil
+			}
+			return baseMockCtx.ResolveVariable(varName, isSystem, isGlobal)
+		},
+	}
+
+	const (
+		tableName  = "t_outer_file_idx"
+		indexTable = "__mo_index_outer_file_id"
+		schemaName = "db"
+	)
+
+	tableDef := &plan.TableDef{
+		Name: tableName,
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "file_id", Typ: plan.Type{Id: int32(types.T_varchar)}},
+			{Name: "v", Typ: plan.Type{Id: int32(types.T_array_float32)}},
+		},
+		Pkey: &plan.PrimaryKeyDef{
+			PkeyColName: "id",
+			Names:       []string{"id"},
+		},
+		Name2ColIndex: map[string]int32{
+			"id":      0,
+			"file_id": 1,
+			"v":       2,
+		},
+		Indexes: []*plan.IndexDef{
+			{
+				IndexName:      "idx_file_id",
+				IndexAlgo:      "btree",
+				IndexTableName: indexTable,
+				TableExist:     true,
+				Parts:          []string{"file_id", "id"},
+			},
+		},
+	}
+
+	idxTableDef := &plan.TableDef{
+		Name: indexTable,
+		Cols: []*plan.ColDef{
+			{Name: catalog.IndexTableIndexColName, Typ: plan.Type{Id: int32(types.T_varchar)}},
+			{Name: catalog.IndexTablePrimaryColName, Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+		Name2ColIndex: map[string]int32{
+			catalog.IndexTableIndexColName:   0,
+			catalog.IndexTablePrimaryColName: 1,
+		},
+	}
+	mockCtx.tables[indexTable] = idxTableDef
+	mockCtx.objects[indexTable] = &plan.ObjectRef{SchemaName: schemaName, ObjName: indexTable}
+
+	idxAlgoParams := `{"op_type": "` + metric.DistFuncOpTypes["l2_distance"] + `"}`
+	multiTableIndex := &MultiTableIndex{
+		IndexAlgo: catalog.MoIndexIvfFlatAlgo.ToString(),
+		IndexDefs: map[string]*plan.IndexDef{
+			catalog.SystemSI_IVFFLAT_TblType_Metadata: {
+				IndexTableName:  "meta",
+				IndexAlgoParams: idxAlgoParams,
+			},
+			catalog.SystemSI_IVFFLAT_TblType_Centroids: {
+				IndexTableName:  "centroids",
+				Parts:           []string{"v"},
+				IndexAlgoParams: idxAlgoParams,
+			},
+			catalog.SystemSI_IVFFLAT_TblType_Entries: {
+				IndexTableName: "entries",
+			},
+		},
+	}
+
+	builder := NewQueryBuilder(plan.Query_SELECT, mockCtx, false, true)
+	ctx := NewBindContext(builder, nil)
+
+	scanNode := &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		TableDef:    tableDef,
+		ObjRef:      &plan.ObjectRef{SchemaName: schemaName, ObjName: tableName},
+		BindingTags: []int32{builder.genNewBindTag()},
+		FilterList: []*plan.Expr{
+			{
+				Expr: &plan.Expr_F{
+					F: &plan.Function{
+						Func: &plan.ObjectRef{ObjName: "="},
+						Args: []*plan.Expr{
+							{
+								Typ:  plan.Type{Id: int32(types.T_varchar)},
+								Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 1, Name: "file_id"}},
+							},
+							{
+								Typ:  plan.Type{Id: int32(types.T_varchar)},
+								Expr: makePlan2StringConstExprWithType("file01").Expr,
+							},
+						},
+					},
+				},
+				Selectivity: 0.2,
+			},
+		},
+		Stats: &plan.Stats{
+			TableCnt:    1000,
+			Selectivity: 0.2,
+			Outcnt:      200,
+			Cost:        1000,
+		},
+	}
+	scanNode.FilterList[0].GetF().Args[0].GetCol().RelPos = scanNode.BindingTags[0]
+	scanNodeID := builder.appendNode(scanNode, ctx)
+
+	for int(scanNodeID) >= len(builder.ctxByNode) {
+		builder.ctxByNode = append(builder.ctxByNode, ctx)
+	}
+	for i := 0; i < 40; i++ {
+		builder.ctxByNode = append(builder.ctxByNode, ctx)
+	}
+
+	float32Typ := plan.Type{Id: int32(types.T_array_float32)}
+	distFnExpr := &plan.Function{
+		Func: &ObjectRef{ObjName: "l2_distance"},
+		Args: []*plan.Expr{
+			{Typ: float32Typ, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: scanNode.BindingTags[0], ColPos: 2}}},
+			{Typ: float32Typ, Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_VecVal{VecVal: "[1,1,1]"}}}},
+		},
+	}
+
+	vecCtx := &vectorSortContext{
+		scanNode:   scanNode,
+		sortNode:   &plan.Node{NodeType: plan.Node_SORT},
+		projNode:   &plan.Node{NodeType: plan.Node_PROJECT, Children: []int32{scanNodeID}},
+		distFnExpr: distFnExpr,
+		limit:      &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 10}}}},
+		rankOption: &plan.RankOption{Mode: "pre"},
+	}
+
+	colRefCnt := map[[2]int32]int{
+		{scanNode.BindingTags[0], 0}: 1,
+		{scanNode.BindingTags[0], 1}: 1,
+	}
+	idxColMap := make(map[[2]int32]*plan.Expr)
+
+	builder.protectedScans[scanNode.NodeId] = 1
+
+	_, err := builder.applyIndicesForSortUsingIvfflat(scanNodeID, vecCtx, multiTableIndex, colRefCnt, idxColMap)
+	require.NoError(t, err)
+
+	sortNode := builder.qry.Nodes[vecCtx.projNode.Children[0]]
+	outerJoinNode := builder.qry.Nodes[sortNode.Children[0]]
+	outerLeft := builder.qry.Nodes[outerJoinNode.Children[0]]
+
+	require.Equal(t, plan.Node_TABLE_SCAN, outerLeft.NodeType)
+	assert.True(t, outerLeft.IndexScanInfo.IsIndexScan)
+
+	joinLeftPk := outerJoinNode.OnList[0].GetF().Args[0].GetCol()
+	require.NotNil(t, joinLeftPk)
+	assert.Equal(t, outerLeft.BindingTags[0], joinLeftPk.RelPos)
+	assert.Equal(t, int32(1), joinLeftPk.ColPos)
+
+	require.NotEmpty(t, outerLeft.RuntimeFilterProbeList)
+	outerProbe := outerLeft.RuntimeFilterProbeList[0].Expr.GetCol()
+	require.NotNil(t, outerProbe)
+	assert.Equal(t, outerLeft.BindingTags[0], outerProbe.RelPos)
+	assert.Equal(t, int32(1), outerProbe.ColPos)
+
+	assert.Empty(t, scanNode.RuntimeFilterProbeList)
+	assert.Equal(t, 1, builder.protectedScans[scanNode.NodeId])
+}

--- a/pkg/sql/plan/apply_indices_ivfflat_optimize_test.go
+++ b/pkg/sql/plan/apply_indices_ivfflat_optimize_test.go
@@ -186,3 +186,176 @@ func TestApplyIndicesForSortUsingIvfflat_PushdownOptimization(t *testing.T) {
 		assert.Equal(t, plan.Node_JOIN, innerJoinNode.NodeType, "With filter, right child should be nested JOIN")
 	})
 }
+
+func TestApplyIndicesForSortUsingIvfflat_OuterScanRegularIndexPreservesProtection(t *testing.T) {
+	baseMockCtx := NewMockCompilerContext(false)
+	mockCtx := &customMockCompilerContext{
+		MockCompilerContext: baseMockCtx,
+		resolveVarFunc: func(varName string, isSystem, isGlobal bool) (interface{}, error) {
+			switch varName {
+			case "enable_vector_prefilter_by_default":
+				return int8(1), nil
+			case "ivf_threads_search":
+				return int64(4), nil
+			case "probe_limit":
+				return int64(10), nil
+			}
+			return baseMockCtx.ResolveVariable(varName, isSystem, isGlobal)
+		},
+	}
+
+	const (
+		tableName  = "t_idx"
+		indexTable = "__mo_index_status"
+		schemaName = "db"
+	)
+
+	tableDef := &plan.TableDef{
+		Name: tableName,
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int64)}},
+			{Name: "status", Typ: plan.Type{Id: int32(types.T_int32)}},
+			{Name: "v", Typ: plan.Type{Id: int32(types.T_array_float32)}},
+		},
+		Pkey: &plan.PrimaryKeyDef{
+			PkeyColName: "id",
+			Names:       []string{"id"},
+		},
+		Name2ColIndex: map[string]int32{
+			"id":     0,
+			"status": 1,
+			"v":      2,
+		},
+		Indexes: []*plan.IndexDef{
+			{
+				IndexName:      "idx_status",
+				IndexAlgo:      "btree",
+				IndexTableName: indexTable,
+				Unique:         true,
+				TableExist:     true,
+				Parts:          []string{"status"},
+			},
+		},
+	}
+
+	idxTableDef := &plan.TableDef{
+		Name: indexTable,
+		Cols: []*plan.ColDef{
+			{Name: "__mo_index_idx_col", Typ: plan.Type{Id: int32(types.T_int32)}},
+			{Name: "__mo_index_pk_col", Typ: plan.Type{Id: int32(types.T_int64)}},
+		},
+		Name2ColIndex: map[string]int32{
+			"__mo_index_idx_col": 0,
+			"__mo_index_pk_col":  1,
+		},
+	}
+	mockCtx.tables[indexTable] = idxTableDef
+	mockCtx.objects[indexTable] = &plan.ObjectRef{SchemaName: schemaName, ObjName: indexTable}
+
+	idxAlgoParams := `{"op_type": "` + metric.DistFuncOpTypes["l2_distance"] + `"}`
+	multiTableIndex := &MultiTableIndex{
+		IndexAlgo: catalog.MoIndexIvfFlatAlgo.ToString(),
+		IndexDefs: map[string]*plan.IndexDef{
+			catalog.SystemSI_IVFFLAT_TblType_Metadata: {
+				IndexTableName:  "meta",
+				IndexAlgoParams: idxAlgoParams,
+			},
+			catalog.SystemSI_IVFFLAT_TblType_Centroids: {
+				IndexTableName:  "centroids",
+				Parts:           []string{"v"},
+				IndexAlgoParams: idxAlgoParams,
+			},
+			catalog.SystemSI_IVFFLAT_TblType_Entries: {
+				IndexTableName: "entries",
+			},
+		},
+	}
+
+	builder := NewQueryBuilder(plan.Query_SELECT, mockCtx, false, true)
+	ctx := NewBindContext(builder, nil)
+
+	scanNode := &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		TableDef:    tableDef,
+		ObjRef:      &plan.ObjectRef{SchemaName: schemaName, ObjName: tableName},
+		BindingTags: []int32{builder.genNewBindTag()},
+		FilterList: []*plan.Expr{
+			{
+				Expr: &plan.Expr_F{
+					F: &plan.Function{
+						Func: &plan.ObjectRef{ObjName: "="},
+						Args: []*plan.Expr{
+							{
+								Typ:  plan.Type{Id: int32(types.T_int32)},
+								Expr: &plan.Expr_Col{Col: &plan.ColRef{ColPos: 1, Name: "status"}},
+							},
+							{
+								Typ:  plan.Type{Id: int32(types.T_int32)},
+								Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_I32Val{I32Val: 1}}},
+							},
+						},
+					},
+				},
+				Selectivity: 0.01,
+			},
+		},
+		Stats: &plan.Stats{
+			TableCnt:    1000,
+			Selectivity: 0.01,
+			Outcnt:      10,
+			Cost:        1000,
+		},
+	}
+	scanNode.FilterList[0].GetF().Args[0].GetCol().RelPos = scanNode.BindingTags[0]
+	scanNodeID := builder.appendNode(scanNode, ctx)
+
+	for int(scanNodeID) >= len(builder.ctxByNode) {
+		builder.ctxByNode = append(builder.ctxByNode, ctx)
+	}
+	// Preallocate enough BindContexts for all plan nodes appended by the IVF rewrite
+	// path in this test (function scan, nested joins, projects, sort, and index join).
+	for i := 0; i < 40; i++ {
+		builder.ctxByNode = append(builder.ctxByNode, ctx)
+	}
+
+	float32Typ := plan.Type{Id: int32(types.T_array_float32)}
+	distFnExpr := &plan.Function{
+		Func: &ObjectRef{ObjName: "l2_distance"},
+		Args: []*plan.Expr{
+			{Typ: float32Typ, Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: scanNode.BindingTags[0], ColPos: 2}}},
+			{Typ: float32Typ, Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_VecVal{VecVal: "[1,1,1]"}}}},
+		},
+	}
+
+	vecCtx := &vectorSortContext{
+		scanNode:   scanNode,
+		sortNode:   &plan.Node{NodeType: plan.Node_SORT},
+		projNode:   &plan.Node{NodeType: plan.Node_PROJECT, Children: []int32{scanNodeID}},
+		distFnExpr: distFnExpr,
+		limit:      &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 10}}}},
+		rankOption: &plan.RankOption{Mode: "pre"},
+	}
+
+	colRefCnt := map[[2]int32]int{
+		{scanNode.BindingTags[0], 0}: 1,
+		{scanNode.BindingTags[0], 1}: 1,
+		{scanNode.BindingTags[0], 2}: 1,
+	}
+	idxColMap := make(map[[2]int32]*plan.Expr)
+
+	builder.protectedScans[scanNode.NodeId] = 2
+
+	_, err := builder.applyIndicesForSortUsingIvfflat(scanNodeID, vecCtx, multiTableIndex, colRefCnt, idxColMap)
+	require.NoError(t, err)
+
+	sortNode := builder.qry.Nodes[vecCtx.projNode.Children[0]]
+	outerJoinNode := builder.qry.Nodes[sortNode.Children[0]]
+	outerLeft := builder.qry.Nodes[outerJoinNode.Children[0]]
+
+	require.Equal(t, plan.Node_SORT, sortNode.NodeType)
+	require.Equal(t, plan.Node_JOIN, outerJoinNode.NodeType)
+	assert.Equal(t, plan.Node_JOIN, outerLeft.NodeType)
+	assert.Equal(t, plan.Node_INDEX, outerLeft.JoinType)
+	assert.Equal(t, 2, builder.protectedScans[scanNode.NodeId])
+	assert.NotEmpty(t, scanNode.RuntimeFilterProbeList)
+}

--- a/pkg/sql/plan/apply_indices_ivfflat_test.go
+++ b/pkg/sql/plan/apply_indices_ivfflat_test.go
@@ -1177,6 +1177,36 @@ func TestBuildPkExprFromNode_TableScan_Success(t *testing.T) {
 	assert.Equal(t, "id", col.Name)
 }
 
+func TestBuildPkExprFromNode_IndexTableScan_UsesIndexPrimaryColumn(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, NewMockCompilerContext(true), false, true)
+
+	scanNode := &plan.Node{
+		NodeType: plan.Node_TABLE_SCAN,
+		TableDef: &plan.TableDef{
+			Name2ColIndex: map[string]int32{
+				catalog.IndexTableIndexColName:   0,
+				catalog.IndexTablePrimaryColName: 1,
+			},
+		},
+		BindingTags: []int32{101},
+		IndexScanInfo: plan.IndexScanInfo{
+			IsIndexScan: true,
+		},
+	}
+
+	builder.qry.Nodes = append(builder.qry.Nodes, scanNode)
+
+	pkType := plan.Type{Id: int32(types.T_int64)}
+	result := builder.buildPkExprFromNode(0, pkType, "id")
+
+	require.NotNil(t, result)
+	col := result.GetCol()
+	require.NotNil(t, col)
+	assert.Equal(t, int32(101), col.RelPos)
+	assert.Equal(t, int32(1), col.ColPos)
+	assert.Equal(t, "id", col.Name)
+}
+
 // TestBuildPkExprFromNode_TableScan_NilTableDef tests TABLE_SCAN with nil TableDef
 func TestBuildPkExprFromNode_TableScan_NilTableDef(t *testing.T) {
 	builder := NewQueryBuilder(plan.Query_SELECT, NewMockCompilerContext(true), false, true)
@@ -1261,7 +1291,7 @@ func TestBuildPkExprFromNode_Project_Recursive(t *testing.T) {
 	builder.qry.Nodes = append(builder.qry.Nodes, scanNode, projNode)
 
 	result := builder.buildPkExprFromNode(1, plan.Type{Id: int32(types.T_int64)}, "id")
-	require.NotNil(t, result)
+	assert.Nil(t, result)
 }
 
 // TestBuildPkExprFromNode_Join_Recursive tests JOIN node
@@ -1286,6 +1316,78 @@ func TestBuildPkExprFromNode_Join_Recursive(t *testing.T) {
 
 	result := builder.buildPkExprFromNode(1, plan.Type{Id: int32(types.T_int64)}, "id")
 	require.NotNil(t, result)
+}
+
+func TestBuildPkExprFromNode_Project_ExposesPk_Success(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, NewMockCompilerContext(true), false, true)
+	builder.nameByColRef = make(map[[2]int32]string)
+	builder.nameByColRef[[2]int32{200, 1}] = "id"
+
+	projNode := &plan.Node{
+		NodeType: plan.Node_PROJECT,
+		ProjectList: []*plan.Expr{
+			{
+				Typ: plan.Type{Id: int32(types.T_int64)},
+				Expr: &plan.Expr_Col{
+					Col: &plan.ColRef{
+						RelPos: 200,
+						ColPos: 1,
+						Name:   "id",
+					},
+				},
+			},
+		},
+		Children: []int32{0},
+	}
+	builder.qry.Nodes = append(builder.qry.Nodes, &plan.Node{}, projNode)
+
+	result := builder.buildPkExprFromNode(1, plan.Type{Id: int32(types.T_int64)}, "id")
+	require.NotNil(t, result)
+	col := result.GetCol()
+	require.NotNil(t, col)
+	assert.Equal(t, int32(200), col.RelPos)
+	assert.Equal(t, int32(1), col.ColPos)
+}
+
+// ============================================================================
+// Tests for findScanNodeByTag
+// ============================================================================
+
+func TestFindScanNodeByTag_FindsMatchingScan(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, NewMockCompilerContext(true), false, true)
+
+	scanNode := &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		BindingTags: []int32{321},
+	}
+	projNode := &plan.Node{
+		NodeType: plan.Node_PROJECT,
+		Children: []int32{0},
+	}
+
+	builder.qry.Nodes = append(builder.qry.Nodes, scanNode, projNode)
+
+	result := builder.findScanNodeByTag(1, 321)
+	assert.Equal(t, int32(0), result)
+}
+
+func TestFindScanNodeByTag_CycleDoesNotLoop(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, NewMockCompilerContext(true), false, true)
+
+	// Create a malformed graph cycle: node0 -> node1 -> node0.
+	node0 := &plan.Node{
+		NodeType: plan.Node_PROJECT,
+		Children: []int32{1},
+	}
+	node1 := &plan.Node{
+		NodeType: plan.Node_JOIN,
+		Children: []int32{0},
+	}
+
+	builder.qry.Nodes = append(builder.qry.Nodes, node0, node1)
+
+	result := builder.findScanNodeByTag(0, 999)
+	assert.Equal(t, int32(-1), result)
 }
 
 // ============================================================================

--- a/pkg/sql/plan/apply_indices_ivfflat_test.go
+++ b/pkg/sql/plan/apply_indices_ivfflat_test.go
@@ -1717,6 +1717,37 @@ func TestCanApplyRegularIndex_Success(t *testing.T) {
 	assert.True(t, result)
 }
 
+func TestClearLimitOffsetInSubtree_ClearsAllNodes(t *testing.T) {
+	qry := &plan.Query{}
+	scan := &plan.Node{
+		NodeType: plan.Node_TABLE_SCAN,
+		Limit:    &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 1}}}},
+		Offset:   &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 2}}}},
+	}
+	join := &plan.Node{
+		NodeType: plan.Node_JOIN,
+		Children: []int32{0},
+		Limit:    &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 3}}}},
+		Offset:   &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 4}}}},
+	}
+	proj := &plan.Node{
+		NodeType: plan.Node_PROJECT,
+		Children: []int32{1},
+		Limit:    &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 5}}}},
+		Offset:   &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_U64Val{U64Val: 6}}}},
+	}
+	qry.Nodes = append(qry.Nodes, scan, join, proj)
+
+	clearLimitOffsetInSubtree(qry, 2)
+
+	assert.Nil(t, qry.Nodes[0].Limit)
+	assert.Nil(t, qry.Nodes[0].Offset)
+	assert.Nil(t, qry.Nodes[1].Limit)
+	assert.Nil(t, qry.Nodes[1].Offset)
+	assert.Nil(t, qry.Nodes[2].Limit)
+	assert.Nil(t, qry.Nodes[2].Offset)
+}
+
 // ============================================================================
 // Tests for colRefsWithin
 // ============================================================================

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -18,8 +18,60 @@ import (
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSuspendScanProtection_RestoresExactCount(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, NewMockCompilerContext(true), false, true)
+	const scanID int32 = 42
+
+	builder.protectedScans[scanID] = 3
+	restore := builder.suspendScanProtection(scanID)
+
+	assert.False(t, builder.isScanProtected(scanID))
+
+	restore()
+
+	assert.Equal(t, 3, builder.protectedScans[scanID])
+}
+
+func TestSuspendScanProtection_NoExistingProtection(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, NewMockCompilerContext(true), false, true)
+	const scanID int32 = 24
+
+	restore := builder.suspendScanProtection(scanID)
+	assert.False(t, builder.isScanProtected(scanID))
+
+	restore()
+
+	_, exists := builder.protectedScans[scanID]
+	assert.False(t, exists)
+}
+
+func TestWithSuspendedScanProtection_RestoresAfterPanic(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, NewMockCompilerContext(true), false, true)
+	const scanID int32 = 64
+
+	builder.protectedScans[scanID] = 2
+
+	recovered := false
+	func() {
+		defer func() {
+			if recover() != nil {
+				recovered = true
+			}
+		}()
+
+		builder.withSuspendedScanProtection(scanID, func() {
+			assert.False(t, builder.isScanProtected(scanID))
+			panic("boom")
+		})
+	}()
+
+	assert.True(t, recovered)
+	assert.Equal(t, 2, builder.protectedScans[scanID])
+}
 
 func TestCalculatePostFilterOverFetchFactor(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23918 

## What this PR does / why we need it:

  Body Summary Fix a bug in ivfflat optimization where ad-hoc temporary unprotect of builder.protectedScans used delete/++ and could
  corrupt counts if the original count > 1. Replace ad-hoc logic with a defer-safe helper and add panic-safe wrapper. Add unit &
  integration tests to cover normal and panic restore paths.

  Changes

   - Add suspendScanProtection(scanID) -> restore() helper and withSuspendedScanProtection wrapper (pkg/sql/plan/apply_indices.go)
   - Replace delete/++ sites in ivfflat path with the helper (pkg/sql/plan/apply_indices_ivfflat.go)
   - Minor robustness: add Expr_Sub branch in refsColumn/extractColRefs to avoid future mis-detection
   - Tests: add suspend/restore and ivfflat integration tests (pkg/sql/plan/*_test.go)