### PR TITLE
[3.0-dev] fix lag/lead/value window functions losing partition info

### DIFF
--- a/pkg/sql/colexec/window/window.go
+++ b/pkg/sql/colexec/window/window.go
@@ -593,8 +593,6 @@ func (ctr *container) processOrder(idx int, ap *Window, bat *batch.Batch, proc *
 		}
 	}
 
-	ctr.ps = nil
-
 	return false, nil
 }
 

--- a/test/distributed/cases/window/value_window_functions.result
+++ b/test/distributed/cases/window/value_window_functions.result
@@ -2,123 +2,222 @@ drop table if exists test_value_window;
 create table test_value_window (id int, year_col int, revenue decimal(10, 2), category varchar(20));
 insert into test_value_window values (1, 2020, 1000.00, 'A'), (2, 2021, 1500.00, 'A'), (3, 2022, 1800.00, 'A'), (4, 2023, 2000.00, 'A'), (5, 2020, 500.00, 'B'), (6, 2021, 600.00, 'B'), (7, 2022, 750.00, 'B');
 select id, year_col, revenue, LAG(revenue) over (order by year_col) as prev_revenue from test_value_window where category = 'A';
-id	year_col	revenue	prev_revenue
-1	2020	1000.00	null
-2	2021	1500.00	1000.00
-3	2022	1800.00	1500.00
-4	2023	2000.00	1800.00
+id    year_col    revenue    prev_revenue
+1    2020    1000.00    null
+2    2021    1500.00    1000.00
+3    2022    1800.00    1500.00
+4    2023    2000.00    1800.00
 select id, year_col, revenue, LEAD(revenue) over (order by year_col) as next_revenue from test_value_window where category = 'A';
-id	year_col	revenue	next_revenue
-1	2020	1000.00	1500.00
-2	2021	1500.00	1800.00
-3	2022	1800.00	2000.00
-4	2023	2000.00	null
+id    year_col    revenue    next_revenue
+1    2020    1000.00    1500.00
+2    2021    1500.00    1800.00
+3    2022    1800.00    2000.00
+4    2023    2000.00    null
 select id, year_col, revenue, FIRST_VALUE(revenue) over (order by year_col) as first_revenue from test_value_window where category = 'A';
-id	year_col	revenue	first_revenue
-1	2020	1000.00	1000.00
-2	2021	1500.00	1000.00
-3	2022	1800.00	1000.00
-4	2023	2000.00	1000.00
+id    year_col    revenue    first_revenue
+1    2020    1000.00    1000.00
+2    2021    1500.00    1000.00
+3    2022    1800.00    1000.00
+4    2023    2000.00    1000.00
 select id, year_col, revenue, LAST_VALUE(revenue) over (order by year_col rows between unbounded preceding and unbounded following) as last_revenue from test_value_window where category = 'A';
-id	year_col	revenue	last_revenue
-1	2020	1000.00	2000.00
-2	2021	1500.00	2000.00
-3	2022	1800.00	2000.00
-4	2023	2000.00	2000.00
+id    year_col    revenue    last_revenue
+1    2020    1000.00    2000.00
+2    2021    1500.00    2000.00
+3    2022    1800.00    2000.00
+4    2023    2000.00    2000.00
 select id, year_col, revenue, NTH_VALUE(revenue, 1) over (order by year_col) as first_revenue from test_value_window where category = 'A';
-id	year_col	revenue	first_revenue
-1	2020	1000.00	1000.00
-2	2021	1500.00	1000.00
-3	2022	1800.00	1000.00
-4	2023	2000.00	1000.00
+id    year_col    revenue    first_revenue
+1    2020    1000.00    1000.00
+2    2021    1500.00    1000.00
+3    2022    1800.00    1000.00
+4    2023    2000.00    1000.00
 select id, year_col, revenue, category, LAG(revenue) over (partition by category order by year_col) as prev_revenue from test_value_window order by category, year_col;
-id	year_col	revenue	category	prev_revenue
-1	2020	1000.00	A	null
-2	2021	1500.00	A	1000.00
-3	2022	1800.00	A	1500.00
-4	2023	2000.00	A	1800.00
-5	2020	500.00	B	null
-6	2021	600.00	B	500.00
-7	2022	750.00	B	600.00
+id    year_col    revenue    category    prev_revenue
+1    2020    1000.00    A    null
+2    2021    1500.00    A    1000.00
+3    2022    1800.00    A    1500.00
+4    2023    2000.00    A    1800.00
+5    2020    500.00    B    null
+6    2021    600.00    B    500.00
+7    2022    750.00    B    600.00
 select id, category, LAG(category) over (order by id) as prev_category from test_value_window where category = 'A';
-id	category	prev_category
-1	A	null
-2	A	A
-3	A	A
-4	A	A
+id    category    prev_category
+1    A    null
+2    A    A
+3    A    A
+4    A    A
 select id, category, LEAD(category) over (order by id) as next_category from test_value_window where category = 'A';
-id	category	next_category
-1	A	A
-2	A	A
-3	A	A
-4	A	null
+id    category    next_category
+1    A    A
+2    A    A
+3    A    A
+4    A    null
 select id, category, FIRST_VALUE(category) over (order by id) as first_category from test_value_window where category = 'A';
-id	category	first_category
-1	A	A
-2	A	A
-3	A	A
-4	A	A
+id    category    first_category
+1    A    A
+2    A    A
+3    A    A
+4    A    A
 select id, category, LAST_VALUE(category) over (order by id rows between unbounded preceding and unbounded following) as last_category from test_value_window where category = 'A';
-id	category	last_category
-1	A	A
-2	A	A
-3	A	A
-4	A	A
+id    category    last_category
+1    A    A
+2    A    A
+3    A    A
+4    A    A
 drop table if exists test_null_window;
 create table test_null_window (id int, val int);
 insert into test_null_window values (1, 100), (2, null), (3, 300), (4, null);
 select id, val, LAG(val) over (order by id) as prev_val from test_null_window;
-id	val	prev_val
-1	100	null
-2	null	100
-3	300	null
-4	null	300
+id    val    prev_val
+1    100    null
+2    null    100
+3    300    null
+4    null    300
 select id, val, LEAD(val) over (order by id) as next_val from test_null_window;
-id	val	next_val
-1	100	null
-2	null	300
-3	300	null
-4	null	null
+id    val    next_val
+1    100    null
+2    null    300
+3    300    null
+4    null    null
 select id, val, FIRST_VALUE(val) over (order by id) as first_val from test_null_window;
-id	val	first_val
-1	100	100
-2	null	100
-3	300	100
-4	null	100
+id    val    first_val
+1    100    100
+2    null    100
+3    300    100
+4    null    100
 drop table if exists test_null_window;
 drop table if exists test_int_types;
 create table test_int_types (id int, val_i8 tinyint, val_i16 smallint, val_i32 int, val_i64 bigint);
 insert into test_int_types values (1, 10, 100, 1000, 10000), (2, 20, 200, 2000, 20000), (3, 30, 300, 3000, 30000);
 select id, LAG(val_i8) over (order by id) as prev_i8 from test_int_types;
-id	prev_i8
-1	null
-2	10
-3	20
+id    prev_i8
+1    null
+2    10
+3    20
 select id, LAG(val_i64) over (order by id) as prev_i64 from test_int_types;
-id	prev_i64
-1	null
-2	10000
-3	20000
+id    prev_i64
+1    null
+2    10000
+3    20000
 select id, LEAD(val_i32) over (order by id) as next_i32 from test_int_types;
-id	next_i32
-1	2000
-2	3000
-3	null
+id    next_i32
+1    2000
+2    3000
+3    null
 drop table if exists test_int_types;
 drop table if exists test_float_types;
 create table test_float_types (id int, val_f32 float, val_f64 double);
 insert into test_float_types values (1, 1.1, 1.11), (2, 2.2, 2.22), (3, 3.3, 3.33);
 select id, LAG(val_f32) over (order by id) as prev_f32 from test_float_types;
-id	prev_f32
-1	null
-2	1.1
-3	2.2
+id    prev_f32
+1    null
+2    1.1
+3    2.2
 select id, LEAD(val_f64) over (order by id) as next_f64 from test_float_types;
-id	next_f64
-1	2.22
-2	3.33
-3	null
+id    next_f64
+1    2.22
+2    3.33
+3    null
 drop table if exists test_float_types;
+drop table if exists t_lag_test;
+create table t_lag_test (id int primary key, val int);
+insert into t_lag_test values (1,10),(2,20),(3,30),(4,40),(5,50),(6,60),(7,70),(8,80);
+select id, val, lag(val, 1) over (order by id) as lag1 from t_lag_test order by id;
+id    val    lag1
+1    10    null
+2    20    10
+3    30    20
+4    40    30
+5    50    40
+6    60    50
+7    70    60
+8    80    70
+select id, val, lag(val, 3) over (order by id) as lag3 from t_lag_test order by id;
+id    val    lag3
+1    10    null
+2    20    null
+3    30    null
+4    40    10
+5    50    20
+6    60    30
+7    70    40
+8    80    50
+select id, val, lag(val, 5) over (order by id) as lag5 from t_lag_test order by id;
+id    val    lag5
+1    10    null
+2    20    null
+3    30    null
+4    40    null
+5    50    null
+6    60    10
+7    70    20
+8    80    30
+select id, val, lag(val, 1, -1) over (order by id) as lag1_def from t_lag_test order by id;
+id    val    lag1_def
+1    10    -1
+2    20    10
+3    30    20
+4    40    30
+5    50    40
+6    60    50
+7    70    60
+8    80    70
+select id, val, lead(val, 3) over (order by id) as lead3 from t_lag_test order by id;
+id    val    lead3
+1    10    40
+2    20    50
+3    30    60
+4    40    70
+5    50    80
+6    60    null
+7    70    null
+8    80    null
+select id, val, lead(val, 1, -1) over (order by id) as lead1_def from t_lag_test order by id;
+id    val    lead1_def
+1    10    20
+2    20    30
+3    30    40
+4    40    50
+5    50    60
+6    60    70
+7    70    80
+8    80    -1
+drop table if exists t_lag_test;
+drop table if exists t_lag_part;
+create table t_lag_part (id int primary key, grp char(1), val int);
+insert into t_lag_part values (1,'A',10),(2,'A',20),(3,'A',30),(4,'A',40),
+(5,'B',50),(6,'B',60),(7,'B',70),(8,'B',80);
+select id, grp, val, lag(val, 2) over (partition by grp order by id) as lag2 from t_lag_part order by grp, id;
+id    grp    val    lag2
+1    A    10    null
+2    A    20    null
+3    A    30    10
+4    A    40    20
+5    B    50    null
+6    B    60    null
+7    B    70    50
+8    B    80    60
+select id, grp, val, lead(val, 2) over (partition by grp order by id) as lead2 from t_lag_part order by grp, id;
+id    grp    val    lead2
+1    A    10    30
+2    A    20    40
+3    A    30    null
+4    A    40    null
+5    B    50    70
+6    B    60    80
+7    B    70    null
+8    B    80    null
+select id, grp, val, lag(val, 1, -1) over (partition by grp order by id) as lag1_def from t_lag_part order by grp, id;
+id    grp    val    lag1_def
+1    A    10    -1
+2    A    20    10
+3    A    30    20
+4    A    40    30
+5    B    50    -1
+6    B    60    50
+7    B    70    60
+8    B    80    70
+drop table if exists t_lag_part;
 drop role if exists lag;
 drop role if exists lead;
 drop table if exists test_value_window;

--- a/test/distributed/cases/window/value_window_functions.sql
+++ b/test/distributed/cases/window/value_window_functions.sql
@@ -52,6 +52,29 @@ select id, LAG(val_f32) over (order by id) as prev_f32 from test_float_types;
 select id, LEAD(val_f64) over (order by id) as next_f64 from test_float_types;
 drop table if exists test_float_types;
 
+-- Test lag/lead with offset and partition
+drop table if exists t_lag_test;
+create table t_lag_test (id int primary key, val int);
+insert into t_lag_test values (1,10),(2,20),(3,30),(4,40),(5,50),(6,60),(7,70),(8,80);
+
+select id, val, lag(val, 1) over (order by id) as lag1 from t_lag_test order by id;
+select id, val, lag(val, 3) over (order by id) as lag3 from t_lag_test order by id;
+select id, val, lag(val, 5) over (order by id) as lag5 from t_lag_test order by id;
+select id, val, lag(val, 1, -1) over (order by id) as lag1_def from t_lag_test order by id;
+select id, val, lead(val, 3) over (order by id) as lead3 from t_lag_test order by id;
+select id, val, lead(val, 1, -1) over (order by id) as lead1_def from t_lag_test order by id;
+drop table if exists t_lag_test;
+
+drop table if exists t_lag_part;
+create table t_lag_part (id int primary key, grp char(1), val int);
+insert into t_lag_part values (1,'A',10),(2,'A',20),(3,'A',30),(4,'A',40),
+                              (5,'B',50),(6,'B',60),(7,'B',70),(8,'B',80);
+
+select id, grp, val, lag(val, 2) over (partition by grp order by id) as lag2 from t_lag_part order by grp, id;
+select id, grp, val, lead(val, 2) over (partition by grp order by id) as lead2 from t_lag_part order by grp, id;
+select id, grp, val, lag(val, 1, -1) over (partition by grp order by id) as lag1_def from t_lag_part order by grp, id;
+drop table if exists t_lag_part;
+
 -- Test keywords as role names
 drop role if exists lag;
 drop role if exists lead;


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix

## Which issue(s) does this PR fix?

Fixes #23969

## What this PR does

Cherry-pick of #23971 to 3.0-dev.

`processOrder` was clearing `ctr.ps` (partition boundaries) at the end of the method. When `processValueFunc` (which handles lag/lead/first_value/last_value/nth_value) was called afterwards, `ctr.ps` was already `nil`, so all rows were treated as a single partition.

The fix removes the erroneous `ctr.ps = nil` at the end of `processOrder`. The cleanup of `ctr.ps` is already handled in `processFunc` after the value function results are computed.
