### PR TITLE
fix: reset lockop lock count on reuse

### DIFF
--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -1107,6 +1107,7 @@ func (lockOp *LockOp) Reset(proc *process.Process, pipelineFailed bool, err erro
 	lockOp.resetParker()
 	lockOp.ctr.retryError = nil
 	lockOp.ctr.defChanged = false
+	lockOp.ctr.lockCount = 0
 }
 
 // Free free mem

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -572,6 +572,19 @@ func TestLockWithHasNewVersionInLockedTS(t *testing.T) {
 	stopper.Stop()
 }
 
+func TestLockOpResetClearsLockCount(t *testing.T) {
+	arg := NewArgumentByEngine(nil)
+	arg.ctr.lockCount = 7
+	arg.ctr.defChanged = true
+	arg.ctr.retryError = moerr.NewTxnNeedRetryNoCtx()
+
+	arg.Reset(nil, false, nil)
+
+	require.Equal(t, int64(0), arg.ctr.lockCount)
+	require.False(t, arg.ctr.defChanged)
+	require.Nil(t, arg.ctr.retryError)
+}
+
 func runLockNonBlockingOpTest(
 	t *testing.T,
 	tables []uint64,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23927 

## What this PR does / why we need it:

dirty lockcount