### PR TITLE
fix: harden prepared binary reset cleanup

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -1355,7 +1355,12 @@ func doDeallocate(ses *Session, execCtx *ExecCtx, st *tree.Deallocate) error {
 	return nil
 }
 
-func doReset(_ context.Context, _ *Session, _ *tree.Reset) error {
+func doReset(ctx context.Context, ses *Session, st *tree.Reset) error {
+	prepareStmt, err := ses.GetPrepareStmt(ctx, string(st.Name))
+	if err != nil {
+		return err
+	}
+	prepareStmt.resetBinaryParamState()
 	return nil
 }
 
@@ -3527,6 +3532,9 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 		var prepareStmt *PrepareStmt
 		sql, prepareStmt, err = parseStmtExecute(execCtx.reqCtx, ses, req.GetData().([]byte))
 		if err != nil {
+			if prepareStmt != nil {
+				prepareStmt.resetBinaryParamState()
+			}
 			return NewGeneralErrorResponse(COM_STMT_EXECUTE, ses.GetTxnHandler().GetServerStatus(), err), nil
 		}
 		execCtx.prepareColDef = prepareStmt.ColDefData
@@ -3534,12 +3542,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 		if err != nil {
 			resp = NewGeneralErrorResponse(COM_STMT_EXECUTE, ses.GetTxnHandler().GetServerStatus(), err)
 		}
-		if prepareStmt.params != nil {
-			prepareStmt.params.GetNulls().Reset()
-			for k := range prepareStmt.getFromSendLongData {
-				delete(prepareStmt.getFromSendLongData, k)
-			}
-		}
+		prepareStmt.resetBinaryParamState()
 		return resp, nil
 
 	case COM_STMT_SEND_LONG_DATA:
@@ -3558,7 +3561,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 		stmtName := getPrepareStmtName(stmtID)
 		preStmt, err = ses.GetPrepareStmt(execCtx.reqCtx, stmtName)
 		if err != nil {
-			resp = NewGeneralErrorResponse(COM_STMT_CLOSE, ses.GetTxnHandler().GetServerStatus(), err)
+			return NewGeneralErrorResponse(COM_STMT_CLOSE, ses.GetTxnHandler().GetServerStatus(), err), nil
 		}
 		prefix := ""
 		if preStmt.IsCloudNonuser {
@@ -3580,7 +3583,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 		var preStmt *PrepareStmt
 		preStmt, err = ses.GetPrepareStmt(execCtx.reqCtx, stmtName)
 		if err != nil {
-			resp = NewGeneralErrorResponse(COM_STMT_CLOSE, ses.GetTxnHandler().GetServerStatus(), err)
+			return NewGeneralErrorResponse(COM_STMT_RESET, ses.GetTxnHandler().GetServerStatus(), err), nil
 		}
 		prefix := ""
 		if preStmt.IsCloudNonuser {
@@ -3638,7 +3641,7 @@ func parseStmtExecute(reqCtx context.Context, ses *Session, data []byte) (string
 	ses.Debug(reqCtx, "query trace", logutil.QueryField(sql))
 	err = ses.GetResponser().MysqlRrWr().ParseExecuteData(reqCtx, ses.GetProc(), preStmt, data, pos)
 	if err != nil {
-		return "", nil, err
+		return "", preStmt, err
 	}
 	return sql, preStmt, nil
 }

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -921,6 +921,110 @@ func Test_HandleDeallocate(t *testing.T) {
 	})
 }
 
+func Test_doResetClearsPreparedBinaryState(t *testing.T) {
+	ctx := context.TODO()
+	ses := &Session{
+		prepareStmts: make(map[string]*PrepareStmt),
+	}
+	proc := testutil.NewProc(t)
+	params := vector.NewVec(types.T_text.ToType())
+	require.NoError(t, vector.AppendBytes(params, []byte("long-data"), false, proc.Mp()))
+	params.GetNulls().Set(0)
+
+	stmtName := "stmt1"
+	prepareStmt := &PrepareStmt{
+		Name:                stmtName,
+		proc:                proc,
+		params:              params,
+		getFromSendLongData: map[int]struct{}{0: {}},
+	}
+	defer prepareStmt.Close()
+	ses.prepareStmts[stmtName] = prepareStmt
+
+	require.NoError(t, doReset(ctx, ses, tree.NewReset(tree.Identifier(stmtName))))
+	require.False(t, prepareStmt.params.GetNulls().Any())
+	require.Empty(t, prepareStmt.getFromSendLongData)
+}
+
+func Test_ExecRequestPrepareCommandMissingStmt(t *testing.T) {
+	ctx := context.TODO()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range []struct {
+		name string
+		cmd  CommandType
+	}{
+		{name: "close", cmd: COM_STMT_CLOSE},
+		{name: "reset", cmd: COM_STMT_RESET},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ses := newTestSession(t, ctrl)
+			ec := newTestExecCtx(ctx, ctrl)
+			stmtID := uint32(123)
+			data := make([]byte, 4)
+			binary.LittleEndian.PutUint32(data, stmtID)
+
+			resp, err := ExecRequest(ses, ec, &Request{cmd: tc.cmd, data: data})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, ErrorResponse, resp.category)
+			require.Equal(t, int(tc.cmd), resp.cmd)
+			require.Error(t, resp.GetData().(error))
+		})
+	}
+}
+
+func Test_ExecRequestStmtExecuteErrorClearsPreparedBinaryState(t *testing.T) {
+	ctx := context.TODO()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ses := newTestSession(t, ctrl)
+	ec := newTestExecCtx(ctx, ctrl)
+	stmtID := uint32(321)
+	stmtName := getPrepareStmtName(stmtID)
+	st := tree.NewPrepareString(tree.Identifier(stmtName), "select ?, ?")
+	stmts, err := mysql.Parse(ctx, st.Sql, 1)
+	require.NoError(t, err)
+	compCtx := plan.NewEmptyCompilerContext()
+	preparePlan, err := buildPlan(ctx, nil, compCtx, st)
+	require.NoError(t, err)
+
+	proc := ses.GetProc()
+	params := vector.NewVec(types.T_text.ToType())
+	require.NoError(t, vector.AppendBytes(params, []byte("leftover"), false, proc.Mp()))
+	require.NoError(t, vector.AppendBytes(params, []byte("leftover"), false, proc.Mp()))
+	params.GetNulls().Set(1)
+
+	prepareStmt := &PrepareStmt{
+		Name:                stmtName,
+		PreparePlan:         preparePlan,
+		PrepareStmt:         stmts[0],
+		proc:                proc,
+		params:              params,
+		getFromSendLongData: map[int]struct{}{0: {}},
+	}
+	defer prepareStmt.Close()
+	require.NoError(t, ses.SetPrepareStmt(ctx, stmtName, prepareStmt))
+
+	data := make([]byte, 0, 10)
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, stmtID)
+	data = append(data, buf...)
+	data = append(data, 0)          // flag
+	data = append(data, 0, 0, 0, 0) // iteration-count
+	data = append(data, 0)          // null bitmap
+	data = append(data, 0)          // use existing ParamTypes, which are empty
+
+	resp, err := ExecRequest(ses, ec, &Request{cmd: COM_STMT_EXECUTE, data: data})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, ErrorResponse, resp.category)
+	require.False(t, prepareStmt.params.GetNulls().Any())
+	require.Empty(t, prepareStmt.getFromSendLongData)
+}
+
 func Test_CMD_FIELD_LIST(t *testing.T) {
 	ctx := defines.AttachAccountId(context.TODO(), catalog.System_Account)
 	convey.Convey("cmd field list", t, func() {

--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -767,6 +767,7 @@ func (mp *MysqlProtocolImpl) SendPrepareResponse(ctx context.Context, stmt *Prep
 
 func (mp *MysqlProtocolImpl) ParseSendLongData(ctx context.Context, proc *process.Process, stmt *PrepareStmt, data []byte, pos int) error {
 	var err error
+	stmt.proc = proc
 	dcPrepare, ok := stmt.PreparePlan.GetDcl().Control.(*planPb.DataControl_Prepare)
 	if !ok {
 		return moerr.NewInternalError(ctx, "can not get Prepare plan in prepareStmt")
@@ -803,6 +804,7 @@ func (mp *MysqlProtocolImpl) ParseSendLongData(ctx context.Context, proc *proces
 
 func (mp *MysqlProtocolImpl) ParseExecuteData(ctx context.Context, proc *process.Process, stmt *PrepareStmt, data []byte, pos int) error {
 	var err error
+	stmt.proc = proc
 	dcPrepare, ok := stmt.PreparePlan.GetDcl().Control.(*planPb.DataControl_Prepare)
 	if !ok {
 		return moerr.NewInternalError(ctx, "can not get Prepare plan in prepareStmt")

--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -2376,6 +2376,7 @@ func FuzzParseExecuteData(f *testing.F) {
 	pu := config.NewParameterUnit(sv, nil, nil, nil)
 	pu.SV.SkipCheckUser = true
 	pu.SV.KillRountinesInterval = 0
+	setSessionAlloc("", NewLeakCheckAllocator())
 	setPu("", pu)
 	ioses, err := NewIOSession(&testConn{}, pu, "")
 	if err != nil {
@@ -2431,6 +2432,42 @@ func FuzzParseExecuteData(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		proto.ParseExecuteData(ctx, proc, prepareStmt, data, 0)
+	})
+}
+
+func TestPrepareStmtCloseAfterBinaryParamParsing(t *testing.T) {
+	ctx := context.TODO()
+	sv, err := getSystemVariables("test/system_vars_config.toml")
+	require.NoError(t, err)
+
+	pu := config.NewParameterUnit(sv, nil, nil, nil)
+	pu.SV.SkipCheckUser = true
+	pu.SV.KillRountinesInterval = 0
+	setSessionAlloc("", NewLeakCheckAllocator())
+	setPu("", pu)
+	ioses, err := NewIOSession(&testConn{}, pu, "")
+	require.NoError(t, err)
+	proto := NewMysqlClientProtocol("", 0, ioses, 1024, sv)
+	proc := testutil.NewProcess(t)
+	st := tree.NewPrepareString(tree.Identifier(getPrepareStmtName(1)), "select ?")
+	stmts, err := mysql.Parse(ctx, st.Sql, 1)
+	require.NoError(t, err)
+	compCtx := plan.NewEmptyCompilerContext()
+	preparePlan, err := buildPlan(ctx, nil, compCtx, st)
+	require.NoError(t, err)
+
+	prepareStmt := &PrepareStmt{
+		Name:                preparePlan.GetDcl().GetPrepare().GetName(),
+		PreparePlan:         preparePlan,
+		PrepareStmt:         stmts[0],
+		getFromSendLongData: make(map[int]struct{}),
+	}
+
+	testData := []byte{0, 0, 0, 0, 0, 0, 1, uint8(defines.MYSQL_TYPE_TINY), 0, 10}
+	require.NoError(t, proto.ParseExecuteData(ctx, proc, prepareStmt, testData, 0))
+	require.Same(t, proc, prepareStmt.proc)
+	require.NotPanics(t, func() {
+		prepareStmt.Close()
 	})
 }
 

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -1149,6 +1149,9 @@ func (ses *Session) SetPrepareStmt(ctx context.Context, name string, prepareStmt
 		stmt.Close()
 	}
 
+	if prepareStmt != nil && prepareStmt.proc == nil {
+		prepareStmt.proc = ses.proc
+	}
 	ses.prepareStmts[name] = prepareStmt
 
 	return nil

--- a/pkg/frontend/types.go
+++ b/pkg/frontend/types.go
@@ -416,6 +416,18 @@ func (prepareStmt *PrepareStmt) Close() {
 	}
 }
 
+func (prepareStmt *PrepareStmt) resetBinaryParamState() {
+	if prepareStmt == nil {
+		return
+	}
+	if prepareStmt.params != nil {
+		prepareStmt.params.GetNulls().Reset()
+	}
+	for k := range prepareStmt.getFromSendLongData {
+		delete(prepareStmt.getFromSendLongData, k)
+	}
+}
+
 type Allocator interface {
 	// Alloc allocate a []byte with len(data) >= size, and the returned []byte cannot
 	// be expanded in use.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23977

## What this PR does / why we need it:
This PR hardens prepared-statement binary protocol cleanup on `main`.

It fixes three closely related problems in the frontend prepare path:
1. `PrepareStmt.Close()` now keeps a valid process context for freeing binary parameter vectors after binary parsing.
2. `COM_STMT_RESET` / `reset prepare` now clears accumulated binary prepared-statement state instead of acting like a no-op.
3. `COM_STMT_CLOSE`, `COM_STMT_RESET`, and malformed `COM_STMT_EXECUTE` error paths now cleanly return and clean up instead of dereferencing nil state or leaving dirty binary state behind.

Focused validation:
- `go test ./pkg/frontend -run 'Test_doResetClearsPreparedBinaryState|Test_ExecRequestPrepareCommandMissingStmt|Test_ExecRequestStmtExecuteErrorClearsPreparedBinaryState|TestPrepareStmtCloseAfterBinaryParamParsing|TestMysqlProtocolImpl_Close|Test_parseStmtSendLongData'`
