### PR TITLE
fix: harden prepare long data parsing

### DIFF
--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -798,8 +798,17 @@ func (mp *MysqlProtocolImpl) ParseSendLongData(ctx context.Context, proc *proces
 	if !ok {
 		return moerr.NewInvalidInput(ctx, "mysql protocol error, malformed packet")
 	}
+	if stmt.getFromSendLongData == nil {
+		stmt.getFromSendLongData = make(map[int]struct{})
+	}
+	if _, ok := stmt.getFromSendLongData[int(paramIdx)]; ok {
+		val = append(append([]byte(nil), stmt.params.GetBytesAt(int(paramIdx))...), val...)
+	}
+	if err = util.SetAnyToStringVector(proc, val, stmt.params, int(paramIdx)); err != nil {
+		return err
+	}
 	stmt.getFromSendLongData[int(paramIdx)] = struct{}{}
-	return util.SetAnyToStringVector(proc, val, stmt.params, int(paramIdx))
+	return nil
 }
 
 func (mp *MysqlProtocolImpl) ParseExecuteData(ctx context.Context, proc *process.Process, stmt *PrepareStmt, data []byte, pos int) error {
@@ -844,8 +853,12 @@ func (mp *MysqlProtocolImpl) ParseExecuteData(ctx context.Context, proc *process
 		}
 
 		// new param bound flag
-		if data[pos] == 1 {
-			pos++
+		var newParamBoundFlag uint8
+		newParamBoundFlag, pos, ok = mp.io.ReadUint8(data, pos)
+		if !ok {
+			return moerr.NewInvalidInput(ctx, "mysql protocol error, malformed packet")
+		}
+		if newParamBoundFlag == 1 {
 
 			// Just the first StmtExecute packet contain parameters type,
 			// we need save it for further use.
@@ -854,8 +867,6 @@ func (mp *MysqlProtocolImpl) ParseExecuteData(ctx context.Context, proc *process
 			if !ok {
 				return moerr.NewInvalidInput(ctx, "mysql protocol error, malformed packet")
 			}
-		} else {
-			pos++
 		}
 
 		// get paramters and set value to session variables

--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -2551,6 +2551,18 @@ func TestParseSendLongDataAppendsRepeatedChunks(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestParseSendLongDataInitializesTrackingMap(t *testing.T) {
+	ctx := context.TODO()
+	proto, proc, prepareStmt := newBinaryPrepareProtocolTestCase(t, "select ?")
+	prepareStmt.getFromSendLongData = nil
+
+	chunk := append(make([]byte, 2), []byte("hello")...)
+	require.NoError(t, proto.ParseSendLongData(ctx, proc, prepareStmt, chunk, 0))
+	require.Equal(t, "hello", prepareStmt.params.GetStringAt(0))
+	_, ok := prepareStmt.getFromSendLongData[0]
+	require.True(t, ok)
+}
+
 /* FIXME The prepare process has undergone some modifications,
   	so the unit tests for prepare need to be refactored, and the subsequent pr I will resubmit a reasonable ut
 func TestParseExecuteData(t *testing.T) {

--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -2524,6 +2524,33 @@ func TestPrepareStmtClearBinaryParamStateReleasesParamArea(t *testing.T) {
 	require.Equal(t, firstAreaLen, len(prepareStmt.params.GetArea()))
 }
 
+func TestParseExecuteDataRejectsTruncatedNewParamBoundFlag(t *testing.T) {
+	ctx := context.TODO()
+	proto, proc, prepareStmt := newBinaryPrepareProtocolTestCase(t, "select ?")
+
+	testData := []byte{0, 0, 0, 0, 0, 0}
+
+	var err error
+	require.NotPanics(t, func() {
+		err = proto.ParseExecuteData(ctx, proc, prepareStmt, testData, 0)
+	})
+	require.Error(t, err)
+}
+
+func TestParseSendLongDataAppendsRepeatedChunks(t *testing.T) {
+	ctx := context.TODO()
+	proto, proc, prepareStmt := newBinaryPrepareProtocolTestCase(t, "select ?")
+
+	firstChunk := append(make([]byte, 2), []byte("hello ")...)
+	secondChunk := append(make([]byte, 2), []byte("world")...)
+
+	require.NoError(t, proto.ParseSendLongData(ctx, proc, prepareStmt, firstChunk, 0))
+	require.NoError(t, proto.ParseSendLongData(ctx, proc, prepareStmt, secondChunk, 0))
+	require.Equal(t, "hello world", prepareStmt.params.GetStringAt(0))
+	_, ok := prepareStmt.getFromSendLongData[0]
+	require.True(t, ok)
+}
+
 /* FIXME The prepare process has undergone some modifications,
   	so the unit tests for prepare need to be refactored, and the subsequent pr I will resubmit a reasonable ut
 func TestParseExecuteData(t *testing.T) {

--- a/pkg/sql/colexec/deletion/deletion_partition.go
+++ b/pkg/sql/colexec/deletion/deletion_partition.go
@@ -109,12 +109,10 @@ func (op *PartitionDelete) Call(
 		panic("Prune result is empty")
 	}
 
-	ref := op.raw.DeleteCtx.Ref
+	// Use a local copy of the ObjRef to avoid mutating the shared plan
+	// object that may be read concurrently by other operators.
+	localRef := *op.raw.DeleteCtx.Ref
 	eng := op.raw.DeleteCtx.Engine
-	oldName := ref.ObjName
-	defer func() {
-		ref.ObjName = oldName
-	}()
 
 	var rel engine.Relation
 	res.Iter(
@@ -122,12 +120,12 @@ func (op *PartitionDelete) Call(
 			partition partition.Partition,
 			bat *batch.Batch,
 		) bool {
-			ref.ObjName = partition.PartitionTableName
+			localRef.ObjName = partition.PartitionTableName
 			rel, err = colexec.GetRelAndPartitionRelsByObjRef(
 				proc.Ctx,
 				proc,
 				eng,
-				ref,
+				&localRef,
 			)
 			if err != nil {
 				return false

--- a/pkg/sql/colexec/deletion/deletion_partition_test.go
+++ b/pkg/sql/colexec/deletion/deletion_partition_test.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deletion
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/partition"
+	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPartitionDeleteCallDoesNotMutateSharedObjectRef(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proc, eng := prepareDeletionTest(t, ctrl, false)
+
+	raw := &Deletion{
+		DeleteCtx: &DeleteCtx{
+			Ref: &plan.ObjectRef{
+				SchemaName: "testDb",
+				ObjName:    "testTable",
+			},
+			Engine:        eng,
+			PrimaryKeyIdx: 1,
+		},
+	}
+	require.NoError(t, raw.Prepare(proc))
+
+	op := &PartitionDelete{
+		raw: raw,
+		meta: partition.PartitionMetadata{
+			Partitions: []partition.Partition{
+				{
+					PartitionID:        1,
+					PartitionTableName: "partition_table",
+					ExprWithRowID: &pbplan.Expr{
+						Typ: pbplan.Type{Id: int32(types.T_bool)},
+						Expr: &pbplan.Expr_Lit{
+							Lit: &pbplan.Literal{Value: &pbplan.Literal_Bval{Bval: true}},
+						},
+					},
+				},
+			},
+		},
+	}
+	bat := batch.NewWithSize(2)
+	bat.SetAttributes([]string{"row_id", "pk"})
+	bat.Vecs[0] = testutil.MakeRowIdVector([]types.Rowid{types.BuildTestRowid(1, 1)}, nil, proc.Mp())
+	bat.Vecs[1] = testutil.MakeInt64Vector([]int64{1}, nil, proc.Mp())
+	bat.SetRowCount(1)
+	op.AppendChild(
+		colexec.NewMockOperator().WithBatchs([]*batch.Batch{
+			bat,
+		}),
+	)
+
+	_, err := op.Call(proc)
+	require.NoError(t, err)
+	require.Equal(t, "testTable", raw.DeleteCtx.Ref.ObjName)
+
+	raw.Free(proc, false, nil)
+	proc.Free()
+}

--- a/pkg/sql/colexec/insert/insert_partition.go
+++ b/pkg/sql/colexec/insert/insert_partition.go
@@ -106,12 +106,10 @@ func (op *PartitionInsert) Call(
 		panic("Prune result is empty")
 	}
 
-	ref := op.raw.InsertCtx.Ref
+	// Use a local copy of the ObjRef to avoid mutating the shared plan
+	// object that may be read concurrently by other operators.
+	localRef := *op.raw.InsertCtx.Ref
 	eng := op.raw.InsertCtx.Engine
-	oldName := ref.ObjName
-	defer func() {
-		ref.ObjName = oldName
-	}()
 
 	var rel engine.Relation
 	res.Iter(
@@ -119,12 +117,12 @@ func (op *PartitionInsert) Call(
 			partition partition.Partition,
 			bat *batch.Batch,
 		) bool {
-			ref.ObjName = partition.PartitionTableName
+			localRef.ObjName = partition.PartitionTableName
 			rel, err = colexec.GetRelAndPartitionRelsByObjRef(
 				proc.Ctx,
 				proc,
 				eng,
-				ref,
+				&localRef,
 			)
 			if err != nil {
 				return false

--- a/pkg/sql/colexec/insert/insert_partition_test.go
+++ b/pkg/sql/colexec/insert/insert_partition_test.go
@@ -16,8 +16,20 @@ package insert
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	"github.com/matrixorigin/matrixone/pkg/pb/partition"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,4 +49,87 @@ func TestNewPartitionInsertFrom(t *testing.T) {
 	require.Equal(t, ps.raw.InsertCtx, op.(*PartitionInsert).raw.InsertCtx)
 	require.Equal(t, ps.raw.ToWriteS3, op.(*PartitionInsert).raw.ToWriteS3)
 	require.Equal(t, ps.tableID, op.(*PartitionInsert).tableID)
+}
+
+func TestPartitionInsertCallDoesNotMutateSharedObjectRef(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.TODO()
+	txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOperator.EXPECT().Commit(gomock.Any()).Return(nil).AnyTimes()
+	txnOperator.EXPECT().Rollback(ctx).Return(nil).AnyTimes()
+
+	txnClient := mock_frontend.NewMockTxnClient(ctrl)
+	txnClient.EXPECT().New(gomock.Any(), gomock.Any()).Return(txnOperator, nil).AnyTimes()
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	database := mock_frontend.NewMockDatabase(ctrl)
+	relation := mock_frontend.NewMockRelation(ctrl)
+	var relationNames []string
+
+	eng.EXPECT().Hints().Return(engine.Hints{}).AnyTimes()
+	eng.EXPECT().Database(gomock.Any(), "testDb", gomock.Any()).Return(database, nil).AnyTimes()
+	database.EXPECT().Relation(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, name string, _ any) (engine.Relation, error) {
+			relationNames = append(relationNames, name)
+			return relation, nil
+		},
+	).AnyTimes()
+	relation.EXPECT().Write(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	relation.EXPECT().Reset(gomock.Any()).Return(nil).AnyTimes()
+
+	proc := testutil.NewProc(t)
+	proc.Base.TxnClient = txnClient
+	proc.Base.TxnOperator = txnOperator
+	proc.Ctx = ctx
+
+	raw := &Insert{
+		InsertCtx: &InsertCtx{
+			Ref: &plan.ObjectRef{
+				SchemaName: "testDb",
+				ObjName:    "testTable",
+			},
+			Engine: eng,
+			Attrs:  []string{"a"},
+		},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{Idx: 0},
+		},
+		ctr: container{state: vm.Build},
+	}
+	require.NoError(t, raw.Prepare(proc))
+
+	bat := batch.NewWithSize(1)
+	bat.Attrs = []string{"a"}
+	bat.Vecs[0] = testutil.MakeInt64Vector([]int64{1}, nil, proc.Mp())
+	bat.SetRowCount(1)
+
+	op := &PartitionInsert{
+		raw: raw,
+		meta: partition.PartitionMetadata{
+			Partitions: []partition.Partition{
+				{
+					PartitionID:        1,
+					PartitionTableName: "partition_table",
+					Expr: &pbplan.Expr{
+						Typ: pbplan.Type{Id: int32(types.T_bool)},
+						Expr: &pbplan.Expr_Lit{
+							Lit: &pbplan.Literal{Value: &pbplan.Literal_Bval{Bval: true}},
+						},
+					},
+				},
+			},
+		},
+	}
+	op.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat}))
+
+	_, err := op.Call(proc)
+	require.NoError(t, err)
+	require.Equal(t, "testTable", raw.InsertCtx.Ref.ObjName)
+	require.Contains(t, relationNames, "testTable")
+	require.Contains(t, relationNames, "partition_table")
+
+	raw.Free(proc, false, nil)
+	proc.Free()
 }

--- a/pkg/sql/colexec/multi_update/multi_update_partition.go
+++ b/pkg/sql/colexec/multi_update/multi_update_partition.go
@@ -183,6 +183,9 @@ func (op *PartitionMultiUpdate) writeTable(
 			}
 
 			// mapping all main table and index table to partition's.
+			// Clone each context to avoid mutating shared plan objects
+			// that may be read concurrently by other operators.
+			cloned := make([]*MultiUpdateCtx, len(op.raw.MultiUpdateCtx))
 			for i, c := range op.raw.MultiUpdateCtx {
 				r := rel
 				if features.IsIndexTable(op.rawTableFlags[i]) {
@@ -197,9 +200,11 @@ func (op *PartitionMultiUpdate) writeTable(
 					}
 				}
 
-				c.ObjRef.ObjName = r.GetTableName()
-				c.TableDef = r.GetTableDef(proc.Ctx)
+				cloned[i] = c.clone()
+				cloned[i].ObjRef.ObjName = r.GetTableName()
+				cloned[i].TableDef = r.GetTableDef(proc.Ctx)
 			}
+			op.raw.MultiUpdateCtx = cloned
 			op.raw.resetMultiUpdateCtxs()
 			if err = op.raw.resetMultiSources(proc); err != nil {
 				return false
@@ -423,7 +428,7 @@ func (ctx *MultiUpdateCtx) clone() *MultiUpdateCtx {
 	v := &MultiUpdateCtx{
 		InsertCols:    ctx.InsertCols,
 		DeleteCols:    ctx.DeleteCols,
-		PartitionCols: ctx.DeleteCols,
+		PartitionCols: ctx.PartitionCols,
 	}
 	objRef := *ctx.ObjRef
 	def := *ctx.TableDef

--- a/pkg/sql/colexec/multi_update/multi_update_partition_test.go
+++ b/pkg/sql/colexec/multi_update/multi_update_partition_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/stretchr/testify/require"
 )
 
@@ -229,4 +230,31 @@ func TestDeleteAffectedRows(t *testing.T) {
 
 	update.addDeleteAffectRows(UpdateMainTable, 4)
 	require.Equal(t, uint64(4), update.ctr.affectedRows, "DELETE rows should be counted")
+}
+
+func TestMultiUpdateCtxClone(t *testing.T) {
+	ctx := &MultiUpdateCtx{
+		InsertCols:    []int{1, 2, 3},
+		DeleteCols:    []int{4, 5},
+		PartitionCols: []int{6, 7, 8},
+		ObjRef:        &plan.ObjectRef{SchemaName: "test", ObjName: "t1"},
+		TableDef:      &plan.TableDef{Name: "t1"},
+	}
+
+	cloned := ctx.clone()
+
+	// Verify values are copied
+	require.Equal(t, ctx.InsertCols, cloned.InsertCols)
+	require.Equal(t, ctx.DeleteCols, cloned.DeleteCols)
+	require.Equal(t, ctx.PartitionCols, cloned.PartitionCols)
+	require.Equal(t, ctx.ObjRef.SchemaName, cloned.ObjRef.SchemaName)
+	require.Equal(t, ctx.TableDef.Name, cloned.TableDef.Name)
+
+	// Verify they are different objects (not shallow copy)
+	require.NotSame(t, ctx.ObjRef, cloned.ObjRef)
+	require.NotSame(t, ctx.TableDef, cloned.TableDef)
+
+	// Modify cloned and verify original is unchanged
+	cloned.ObjRef.ObjName = "modified"
+	require.Equal(t, "t1", ctx.ObjRef.ObjName)
 }

--- a/pkg/sql/colexec/preinsert/preinsert.go
+++ b/pkg/sql/colexec/preinsert/preinsert.go
@@ -70,6 +70,7 @@ func (preInsert *PreInsert) Prepare(proc *process.Process) (err error) {
 		}
 	}
 	if preInsert.HasAutoCol {
+		preInsert.ctr.tblId = preInsert.TableDef.TblId
 		if err = preInsert.refreshAutoIncrementTableID(proc); err != nil {
 			return
 		}
@@ -96,7 +97,7 @@ func (preInsert *PreInsert) refreshAutoIncrementTableID(proc *proc) error {
 	if err != nil {
 		return err
 	}
-	preInsert.TableDef.TblId = rel.GetTableID(proc.Ctx)
+	preInsert.ctr.tblId = rel.GetTableID(proc.Ctx)
 	return nil
 }
 
@@ -370,7 +371,7 @@ func genAutoIncrCol(bat *batch.Batch, proc *proc, preInsert *PreInsert) error {
 	retriedWithFreshTableID := false
 
 retryInsertValues:
-	tableID := preInsert.TableDef.TblId
+	tableID := preInsert.ctr.tblId
 	needReCheck := checkIfNeedReGenAutoIncrCol(bat, preInsert)
 
 	// FIX: Capture lastAllocateAt BEFORE InsertValues to avoid false negative bug
@@ -407,7 +408,7 @@ retryInsertValues:
 					}
 					return refreshErr
 				}
-				if preInsert.TableDef.TblId != tableID {
+				if preInsert.ctr.tblId != tableID {
 					goto retryInsertValues
 				}
 			}

--- a/pkg/sql/colexec/preinsert/preinsert_test.go
+++ b/pkg/sql/colexec/preinsert/preinsert_test.go
@@ -400,7 +400,7 @@ func TestPreInsertPrepareRefreshesAutoIncrementTableID(t *testing.T) {
 
 	err := argument.Prepare(proc)
 	require.NoError(t, err)
-	require.Equal(t, uint64(200), argument.TableDef.TblId)
+	require.Equal(t, uint64(200), argument.ctr.tblId)
 }
 
 func TestPreInsertPrepareSkipsTemporaryTableRefresh(t *testing.T) {
@@ -445,7 +445,7 @@ func TestPreInsertPrepareSkipsTemporaryTableRefresh(t *testing.T) {
 
 	err := argument.Prepare(proc)
 	require.NoError(t, err)
-	require.Equal(t, uint64(100), argument.TableDef.TblId)
+	require.Equal(t, uint64(100), argument.ctr.tblId)
 }
 
 func TestGenAutoIncrColRefreshesStaleTableID(t *testing.T) {
@@ -499,6 +499,7 @@ func TestGenAutoIncrColRefreshesStaleTableID(t *testing.T) {
 		Attrs:             []string{catalog.FakePrimaryKeyColName},
 		EstimatedRowCount: 1,
 	}
+	preInsert.ctr.tblId = preInsert.TableDef.TblId
 
 	bat := batch.NewWithSize(1)
 	bat.Vecs[0] = testutil.MakeInt64Vector([]int64{0}, nil, proc.Mp())
@@ -506,7 +507,7 @@ func TestGenAutoIncrColRefreshesStaleTableID(t *testing.T) {
 
 	err := genAutoIncrCol(bat, proc, preInsert)
 	require.NoError(t, err)
-	require.Equal(t, uint64(200), preInsert.TableDef.TblId)
+	require.Equal(t, uint64(200), preInsert.ctr.tblId)
 }
 
 func TestGenAutoIncrColReturnsRetryWhenDefinitionStillChanged(t *testing.T) {
@@ -556,6 +557,7 @@ func TestGenAutoIncrColReturnsRetryWhenDefinitionStillChanged(t *testing.T) {
 		Attrs:             []string{catalog.FakePrimaryKeyColName},
 		EstimatedRowCount: 1,
 	}
+	preInsert.ctr.tblId = preInsert.TableDef.TblId
 
 	bat := batch.NewWithSize(1)
 	bat.Vecs[0] = testutil.MakeInt64Vector([]int64{0}, nil, proc.Mp())
@@ -604,6 +606,7 @@ func TestGenAutoIncrColKeepsTemporaryTableBehavior(t *testing.T) {
 		Attrs:             []string{catalog.FakePrimaryKeyColName},
 		EstimatedRowCount: 1,
 	}
+	preInsert.ctr.tblId = preInsert.TableDef.TblId
 
 	bat := batch.NewWithSize(1)
 	bat.Vecs[0] = testutil.MakeInt64Vector([]int64{0}, nil, proc.Mp())

--- a/pkg/sql/colexec/preinsert/types.go
+++ b/pkg/sql/colexec/preinsert/types.go
@@ -32,6 +32,10 @@ type container struct {
 	canFreeVecIdx     map[int]bool //auto incr & expand constant vecotr.need free
 	clusterByExecutor colexec.ExpressionExecutor
 	compPkExecutor    colexec.ExpressionExecutor
+	// tblId is a local copy of TableDef.TblId, refreshed by
+	// refreshAutoIncrementTableID.  Storing it here avoids mutating the
+	// shared *plan.TableDef that other operators may read concurrently.
+	tblId uint64
 }
 type PreInsert struct {
 	ctr container


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23979

## What this PR does / why we need it:

This PR fixes three categories of issues:

### 1. Harden prepared-statement binary protocol edges
- Repeated COM_STMT_SEND_LONG_DATA chunks for the same parameter now **append** instead of overwriting, matching MySQL protocol semantics.
- Truncated COM_STMT_EXECUTE packets now return a malformed-packet error instead of risking a panic while reading the new parameter bound flag.

### 2. Fix data race on shared TableDef.TblId (detected by -race in TestDeleteAndSelect)
- PreInsert.refreshAutoIncrementTableID() wrote directly to the shared *plan.TableDef.TblId during Prepare().
- MultiUpdate.Prepare() read the same TblId concurrently in a different ants worker pool goroutine.
- **Fix**: Store the refreshed TblId in a local container field (ctr.tblId) instead of mutating the shared plan object.

### 3. Harden partition operators against shared plan object mutations
- PartitionInsert and PartitionDelete temporarily mutated the shared ObjRef.ObjName during partition iteration (save/restore via defer) -- replaced with stack-local copies.
- PartitionMultiUpdate.writeTable() directly mutated shared MultiUpdateCtx entries -- now uses clone() to match the writeS3 code path.
- Also fixed a pre-existing copy-paste bug in MultiUpdateCtx.clone() where PartitionCols was incorrectly copying DeleteCols.