### PR TITLE
fix: support json prepared params

### DIFF
--- a/pkg/frontend/mysql_protocol.go
+++ b/pkg/frontend/mysql_protocol.go
@@ -976,7 +976,7 @@ func (mp *MysqlProtocolImpl) ParseExecuteData(ctx context.Context, proc *process
 				pos = newPos
 				err = util.SetAnyToStringVector(proc, val, stmt.params, i)
 
-			case defines.MYSQL_TYPE_BLOB, defines.MYSQL_TYPE_TINY_BLOB, defines.MYSQL_TYPE_MEDIUM_BLOB, defines.MYSQL_TYPE_LONG_BLOB, defines.MYSQL_TYPE_TEXT:
+			case defines.MYSQL_TYPE_BLOB, defines.MYSQL_TYPE_TINY_BLOB, defines.MYSQL_TYPE_MEDIUM_BLOB, defines.MYSQL_TYPE_LONG_BLOB, defines.MYSQL_TYPE_TEXT, defines.MYSQL_TYPE_JSON:
 				val, newPos, ok := mp.readStringLenEnc(data, pos)
 				if !ok {
 					return moerr.NewInvalidInput(ctx, "mysql protocol error, malformed packet")

--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -2484,9 +2484,13 @@ func TestParseExecuteDataWithJSONParam(t *testing.T) {
 	ctx := context.TODO()
 	proto, proc, prepareStmt := newBinaryPrepareProtocolTestCase(t, "select ?")
 
-	jsonPayload := []byte(`{"k":"v"}`)
-	testData := []byte{0, 0, 0, 0, 0, 0, 1, uint8(defines.MYSQL_TYPE_JSON), 0, byte(len(jsonPayload))}
-	testData = append(testData, jsonPayload...)
+	jsonPayload := append([]byte(`{"k":"`), bytes.Repeat([]byte{'v'}, 300)...)
+	jsonPayload = append(jsonPayload, []byte(`"}`)...)
+
+	testData := make([]byte, 8+2+9+len(jsonPayload))
+	copy(testData, []byte{0, 0, 0, 0, 0, 0, 1, uint8(defines.MYSQL_TYPE_JSON), 0})
+	pos := proto.writeStringLenEnc(testData, 9, string(jsonPayload))
+	testData = testData[:pos]
 
 	require.NoError(t, proto.ParseExecuteData(ctx, proc, prepareStmt, testData, 0))
 	require.Equal(t, string(jsonPayload), prepareStmt.params.GetStringAt(0))

--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -2435,7 +2435,8 @@ func FuzzParseExecuteData(f *testing.F) {
 	})
 }
 
-func TestPrepareStmtCloseAfterBinaryParamParsing(t *testing.T) {
+func newBinaryPrepareProtocolTestCase(t *testing.T, sql string) (*MysqlProtocolImpl, *process.Process, *PrepareStmt) {
+	t.Helper()
 	ctx := context.TODO()
 	sv, err := getSystemVariables("test/system_vars_config.toml")
 	require.NoError(t, err)
@@ -2445,11 +2446,14 @@ func TestPrepareStmtCloseAfterBinaryParamParsing(t *testing.T) {
 	pu.SV.KillRountinesInterval = 0
 	setSessionAlloc("", NewLeakCheckAllocator())
 	setPu("", pu)
+
 	ioses, err := NewIOSession(&testConn{}, pu, "")
 	require.NoError(t, err)
+
 	proto := NewMysqlClientProtocol("", 0, ioses, 1024, sv)
 	proc := testutil.NewProcess(t)
-	st := tree.NewPrepareString(tree.Identifier(getPrepareStmtName(1)), "select ?")
+
+	st := tree.NewPrepareString(tree.Identifier(getPrepareStmtName(1)), sql)
 	stmts, err := mysql.Parse(ctx, st.Sql, 1)
 	require.NoError(t, err)
 	compCtx := plan.NewEmptyCompilerContext()
@@ -2462,13 +2466,30 @@ func TestPrepareStmtCloseAfterBinaryParamParsing(t *testing.T) {
 		PrepareStmt:         stmts[0],
 		getFromSendLongData: make(map[int]struct{}),
 	}
+	return proto, proc, prepareStmt
+}
 
+func TestPrepareStmtCloseAfterBinaryParamParsing(t *testing.T) {
+	ctx := context.TODO()
+	proto, proc, prepareStmt := newBinaryPrepareProtocolTestCase(t, "select ?")
 	testData := []byte{0, 0, 0, 0, 0, 0, 1, uint8(defines.MYSQL_TYPE_TINY), 0, 10}
 	require.NoError(t, proto.ParseExecuteData(ctx, proc, prepareStmt, testData, 0))
 	require.Same(t, proc, prepareStmt.proc)
 	require.NotPanics(t, func() {
 		prepareStmt.Close()
 	})
+}
+
+func TestParseExecuteDataWithJSONParam(t *testing.T) {
+	ctx := context.TODO()
+	proto, proc, prepareStmt := newBinaryPrepareProtocolTestCase(t, "select ?")
+
+	jsonPayload := []byte(`{"k":"v"}`)
+	testData := []byte{0, 0, 0, 0, 0, 0, 1, uint8(defines.MYSQL_TYPE_JSON), 0, byte(len(jsonPayload))}
+	testData = append(testData, jsonPayload...)
+
+	require.NoError(t, proto.ParseExecuteData(ctx, proc, prepareStmt, testData, 0))
+	require.Equal(t, string(jsonPayload), prepareStmt.params.GetStringAt(0))
 }
 
 /* FIXME The prepare process has undergone some modifications,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23981

## What this PR does / why we need it:
This PR fixes a missing `MYSQL_TYPE_JSON` branch in the prepared-statement binary execute parser on `main`.

Without this change, `COM_STMT_EXECUTE` falls through to `unsupport parameter type` when a client sends a JSON-typed parameter through the binary protocol.

Focused validation:
- `go test ./pkg/frontend -run 'TestParseExecuteDataWithJSONParam'`
- `go test ./pkg/frontend -run 'TestParseExecuteDataWithJSONParam|Test_StripPassword'`
