### PR TITLE
fix: clear prepared binary param state

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -3533,7 +3533,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 		sql, prepareStmt, err = parseStmtExecute(execCtx.reqCtx, ses, req.GetData().([]byte))
 		if err != nil {
 			if prepareStmt != nil {
-				prepareStmt.resetBinaryParamState()
+				prepareStmt.clearBinaryParamState(ses.GetProc())
 			}
 			return NewGeneralErrorResponse(COM_STMT_EXECUTE, ses.GetTxnHandler().GetServerStatus(), err), nil
 		}
@@ -3542,7 +3542,7 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 		if err != nil {
 			resp = NewGeneralErrorResponse(COM_STMT_EXECUTE, ses.GetTxnHandler().GetServerStatus(), err)
 		}
-		prepareStmt.resetBinaryParamState()
+		prepareStmt.clearBinaryParamState(ses.GetProc())
 		return resp, nil
 
 	case COM_STMT_SEND_LONG_DATA:

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -1021,7 +1021,7 @@ func Test_ExecRequestStmtExecuteErrorClearsPreparedBinaryState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, ErrorResponse, resp.category)
-	require.False(t, prepareStmt.params.GetNulls().Any())
+	require.Nil(t, prepareStmt.params)
 	require.Empty(t, prepareStmt.getFromSendLongData)
 }
 

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -1826,6 +1826,49 @@ func Test_unsupportedCommand(t *testing.T) {
 	assert.Equal(t, "internal error: unsupported command. 0x0", respErr.Error())
 }
 
+func Test_ExecRequestStmtExecuteErrorClearsPreparedParamState(t *testing.T) {
+	ctx := context.TODO()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ses := newTestSession(t, ctrl)
+	execCtx := &ExecCtx{
+		ses:    ses,
+		reqCtx: ctx,
+	}
+
+	st := tree.NewPrepareString(tree.Identifier(getPrepareStmtName(1)), "select ?")
+	stmts, err := mysql.Parse(ctx, st.Sql, 1)
+	require.NoError(t, err)
+
+	compCtx := plan.NewEmptyCompilerContext()
+	preparePlan, err := buildPlan(ctx, nil, compCtx, st)
+	require.NoError(t, err)
+
+	prepareStmt := &PrepareStmt{
+		Name:                preparePlan.GetDcl().GetPrepare().GetName(),
+		PreparePlan:         preparePlan,
+		PrepareStmt:         stmts[0],
+		getFromSendLongData: make(map[int]struct{}),
+	}
+	require.NoError(t, ses.SetPrepareStmt(ctx, prepareStmt.Name, prepareStmt))
+
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint32(payload, 1)
+	payload = append(payload, 0)          // flag
+	payload = append(payload, 0, 0, 0, 0) // iteration-count
+	payload = append(payload, 0)          // null bitmap
+	payload = append(payload, 1)          // new param bound flag
+	payload = append(payload, uint8(defines.MYSQL_TYPE_VAR_STRING), 0)
+	payload = append(payload, 5, 'a', 'b') // truncated lenenc string
+
+	resp, err := ExecRequest(ses, execCtx, &Request{cmd: COM_STMT_EXECUTE, data: payload})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Nil(t, prepareStmt.params)
+	require.Empty(t, prepareStmt.getFromSendLongData)
+}
+
 func Test_panic(t *testing.T) {
 	fault.EnableDomain(fault.DomainFrontend)
 	defer fault.DisableDomain(fault.DomainFrontend)

--- a/pkg/frontend/mysql_protocol_test.go
+++ b/pkg/frontend/mysql_protocol_test.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -2494,6 +2495,33 @@ func TestParseExecuteDataWithJSONParam(t *testing.T) {
 
 	require.NoError(t, proto.ParseExecuteData(ctx, proc, prepareStmt, testData, 0))
 	require.Equal(t, string(jsonPayload), prepareStmt.params.GetStringAt(0))
+}
+
+func buildStringExecutePacket(proto *MysqlProtocolImpl, tp defines.MysqlType, payload string) []byte {
+	data := make([]byte, 8+2+9+len(payload))
+	copy(data, []byte{0, 0, 0, 0, 0, 0, 1, byte(tp), 0})
+	pos := proto.writeStringLenEnc(data, 9, payload)
+	return data[:pos]
+}
+
+func TestPrepareStmtClearBinaryParamStateReleasesParamArea(t *testing.T) {
+	ctx := context.TODO()
+	proto, proc, prepareStmt := newBinaryPrepareProtocolTestCase(t, "select ?")
+
+	firstPayload := strings.Repeat("a", 300)
+	secondPayload := strings.Repeat("b", 300)
+
+	require.NoError(t, proto.ParseExecuteData(ctx, proc, prepareStmt, buildStringExecutePacket(proto, defines.MYSQL_TYPE_VAR_STRING, firstPayload), 0))
+	firstAreaLen := len(prepareStmt.params.GetArea())
+	require.Greater(t, firstAreaLen, 0)
+
+	prepareStmt.clearBinaryParamState(proc)
+	require.Nil(t, prepareStmt.params)
+	require.Empty(t, prepareStmt.getFromSendLongData)
+
+	require.NoError(t, proto.ParseExecuteData(ctx, proc, prepareStmt, buildStringExecutePacket(proto, defines.MYSQL_TYPE_VAR_STRING, secondPayload), 0))
+	require.Equal(t, secondPayload, prepareStmt.params.GetStringAt(0))
+	require.Equal(t, firstAreaLen, len(prepareStmt.params.GetArea()))
 }
 
 /* FIXME The prepare process has undergone some modifications,

--- a/pkg/frontend/types.go
+++ b/pkg/frontend/types.go
@@ -428,6 +428,19 @@ func (prepareStmt *PrepareStmt) resetBinaryParamState() {
 	}
 }
 
+func (prepareStmt *PrepareStmt) clearBinaryParamState(proc *process.Process) {
+	if prepareStmt == nil {
+		return
+	}
+	if prepareStmt.params != nil && proc != nil {
+		prepareStmt.params.Free(proc.Mp())
+		prepareStmt.params = nil
+	}
+	for k := range prepareStmt.getFromSendLongData {
+		delete(prepareStmt.getFromSendLongData, k)
+	}
+}
+
 type Allocator interface {
 	// Alloc allocate a []byte with len(data) >= size, and the returned []byte cannot
 	// be expanded in use.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23983

## What this PR does / why we need it:
This PR reclaims prepared-statement binary parameter state after `COM_STMT_EXECUTE` and on malformed execute cleanup.

It fixes two closely related problems on `main`:
1. repeated binary executes with varlen parameters reused the same params vector and kept appending to its area, growing session memory until statement close;
2. malformed `COM_STMT_EXECUTE` packets could leave a partially populated params vector attached to the prepared statement because the parse-error path dropped the statement pointer before cleanup.

Focused validation:
- `go test ./pkg/frontend -run 'TestPrepareStmtClearBinaryParamStateReleasesParamArea|Test_ExecRequestStmtExecuteErrorClearsPreparedParamState'`
- `go test ./pkg/frontend -run 'TestPrepareStmtClearBinaryParamStateReleasesParamArea|Test_ExecRequestStmtExecuteErrorClearsPreparedParamState|Test_parseStmtSendLongData'`
