### PR TITLE
fix: multi-CN operator serialization/deserialization bugs in remoterun

### DIFF
--- a/pkg/sql/compile/remoterun.go
+++ b/pkg/sql/compile/remoterun.go
@@ -457,6 +457,7 @@ func convertToPipelineInstruction(op vm.Operator, proc *process.Process, ctx *sc
 			UniqueCols:         t.UniqueCols,
 			OnDuplicateIdx:     t.OnDuplicateIdx,
 			OnDuplicateExpr:    t.OnDuplicateExpr,
+			IsIgnore:           t.IsIgnore,
 		}
 	case *fuzzyfilter.FuzzyFilter:
 		in.FuzzyFilter = &pipeline.FuzzyFilter{
@@ -836,6 +837,7 @@ func convertToVmOperator(opr *pipeline.Instruction, ctx *scopeContext, eng engin
 			Ref:             t.Ref,
 			AddAffectedRows: t.AddAffectedRows,
 			PrimaryKeyIdx:   int(t.PrimaryKeyIdx),
+			Engine:          eng,
 		}
 		op = arg
 	case vm.Insert:
@@ -847,6 +849,7 @@ func convertToVmOperator(opr *pipeline.Instruction, ctx *scopeContext, eng engin
 			AddAffectedRows: t.AddAffectedRows,
 			Attrs:           t.Attrs,
 			TableDef:        t.TableDef,
+			Engine:          eng,
 		}
 		op = arg
 	case vm.PreInsert:
@@ -903,6 +906,7 @@ func convertToVmOperator(opr *pipeline.Instruction, ctx *scopeContext, eng engin
 		arg.N = float64(t.N)
 		arg.PkName = t.PkName
 		arg.PkTyp = t.PkTyp
+		arg.BuildIdx = int(t.BuildIdx)
 		arg.IfInsertFromUnique = t.IfInsertFromUnique
 		op = arg
 	case vm.Shuffle:
@@ -1210,6 +1214,7 @@ func convertToVmOperator(opr *pipeline.Instruction, ctx *scopeContext, eng engin
 		arg.SetAffectedRows(t.AffectedRows)
 		arg.Action = multi_update.UpdateAction(t.Action)
 		arg.IsRemote = true //only remote CN use this function to rebuild MultiUpdate
+		arg.Engine = eng
 
 		arg.MultiUpdateCtx = make([]*multi_update.MultiUpdateCtx, len(t.UpdateCtxList))
 		for i, muCtx := range t.UpdateCtxList {
@@ -1227,6 +1232,11 @@ func convertToVmOperator(opr *pipeline.Instruction, ctx *scopeContext, eng engin
 			arg.MultiUpdateCtx[i].DeleteCols = make([]int, len(muCtx.DeleteCols))
 			for j, pos := range muCtx.DeleteCols {
 				arg.MultiUpdateCtx[i].DeleteCols[j] = int(pos.ColPos)
+			}
+
+			arg.MultiUpdateCtx[i].PartitionCols = make([]int, len(muCtx.PartitionCols))
+			for j, pos := range muCtx.PartitionCols {
+				arg.MultiUpdateCtx[i].PartitionCols[j] = int(pos.ColPos)
 			}
 		}
 

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/dispatch"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/external"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/filter"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/fuzzyfilter"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/group"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashbuild"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashjoin"
@@ -57,6 +58,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/mergerecursive"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/mergetop"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/minus"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/multi_update"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/offset"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/onduplicatekey"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/order"
@@ -288,6 +290,141 @@ func Test_convertToVmInstruction(t *testing.T) {
 		_, err := convertToVmOperator(instruction, ctx, nil)
 		require.Nil(t, err)
 	}
+}
+
+func Test_DMLOperatorSerializationRoundtrip(t *testing.T) {
+	ctx := &scopeContext{
+		id:     1,
+		root:   &scopeContext{},
+		parent: &scopeContext{},
+	}
+	proc := &process.Process{}
+	proc.Base = &process.BaseProcess{}
+
+	t.Run("OnDuplicateKey_IsIgnore", func(t *testing.T) {
+		op := &onduplicatekey.OnDuplicatekey{
+			IsIgnore:       true,
+			InsertColCount: 3,
+		}
+		_, pipeInstr, err := convertToPipelineInstruction(op, proc, ctx, 1)
+		require.NoError(t, err)
+		require.True(t, pipeInstr.OnDuplicateKey.IsIgnore)
+
+		restored, err := convertToVmOperator(pipeInstr, ctx, nil)
+		require.NoError(t, err)
+		restoredOp := restored.(*onduplicatekey.OnDuplicatekey)
+		require.True(t, restoredOp.IsIgnore)
+		require.Equal(t, int32(3), restoredOp.InsertColCount)
+	})
+
+	t.Run("FuzzyFilter_BuildIdx", func(t *testing.T) {
+		op := &fuzzyfilter.FuzzyFilter{
+			N:        42.5,
+			PkName:   "pk",
+			BuildIdx: 7,
+		}
+		_, pipeInstr, err := convertToPipelineInstruction(op, proc, ctx, 1)
+		require.NoError(t, err)
+		require.Equal(t, int32(7), pipeInstr.FuzzyFilter.BuildIdx)
+
+		restored, err := convertToVmOperator(pipeInstr, ctx, nil)
+		require.NoError(t, err)
+		restoredOp := restored.(*fuzzyfilter.FuzzyFilter)
+		require.Equal(t, 7, restoredOp.BuildIdx)
+		require.Equal(t, "pk", restoredOp.PkName)
+	})
+
+	t.Run("MultiUpdate_PartitionCols", func(t *testing.T) {
+		op := &multi_update.MultiUpdate{
+			MultiUpdateCtx: []*multi_update.MultiUpdateCtx{
+				{
+					ObjRef:        &plan.ObjectRef{ObjName: "t1"},
+					TableDef:      &plan.TableDef{Name: "t1"},
+					InsertCols:    []int{0, 1, 2},
+					DeleteCols:    []int{3, 4},
+					PartitionCols: []int{5, 6},
+				},
+			},
+			Action: multi_update.UpdateWriteTable,
+		}
+		_, pipeInstr, err := convertToPipelineInstruction(op, proc, ctx, 1)
+		require.NoError(t, err)
+		require.Len(t, pipeInstr.MultiUpdate.UpdateCtxList[0].PartitionCols, 2)
+
+		restored, err := convertToVmOperator(pipeInstr, ctx, nil)
+		require.NoError(t, err)
+		restoredOp := restored.(*multi_update.MultiUpdate)
+		require.Equal(t, []int{5, 6}, restoredOp.MultiUpdateCtx[0].PartitionCols)
+		require.Equal(t, []int{0, 1, 2}, restoredOp.MultiUpdateCtx[0].InsertCols)
+		require.Equal(t, []int{3, 4}, restoredOp.MultiUpdateCtx[0].DeleteCols)
+		require.True(t, restoredOp.IsRemote)
+	})
+
+	t.Run("Deletion_Engine", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		op := &deletion.Deletion{
+			DeleteCtx: &deletion.DeleteCtx{
+				RowIdIdx:      2,
+				PrimaryKeyIdx: 0,
+				Ref:           &plan.ObjectRef{ObjName: "t1"},
+			},
+		}
+		_, pipeInstr, err := convertToPipelineInstruction(op, proc, ctx, 1)
+		require.NoError(t, err)
+
+		mockEng := mock_frontend.NewMockEngine(ctrl)
+		restored, err := convertToVmOperator(pipeInstr, ctx, mockEng)
+		require.NoError(t, err)
+		restoredOp := restored.(*deletion.Deletion)
+		require.Equal(t, mockEng, restoredOp.DeleteCtx.Engine)
+		require.Equal(t, 2, restoredOp.DeleteCtx.RowIdIdx)
+	})
+
+	t.Run("Insert_Engine", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		op := &insert.Insert{
+			InsertCtx: &insert.InsertCtx{
+				Ref:      &plan.ObjectRef{ObjName: "t1"},
+				TableDef: &plan.TableDef{Name: "t1"},
+				Attrs:    []string{"a", "b"},
+			},
+		}
+		_, pipeInstr, err := convertToPipelineInstruction(op, proc, ctx, 1)
+		require.NoError(t, err)
+
+		mockEng := mock_frontend.NewMockEngine(ctrl)
+		restored, err := convertToVmOperator(pipeInstr, ctx, mockEng)
+		require.NoError(t, err)
+		restoredOp := restored.(*insert.Insert)
+		require.Equal(t, mockEng, restoredOp.InsertCtx.Engine)
+		require.Equal(t, []string{"a", "b"}, restoredOp.InsertCtx.Attrs)
+	})
+
+	t.Run("MultiUpdate_Engine", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		op := &multi_update.MultiUpdate{
+			MultiUpdateCtx: []*multi_update.MultiUpdateCtx{
+				{
+					ObjRef:   &plan.ObjectRef{ObjName: "t1"},
+					TableDef: &plan.TableDef{Name: "t1"},
+				},
+			},
+		}
+		_, pipeInstr, err := convertToPipelineInstruction(op, proc, ctx, 1)
+		require.NoError(t, err)
+
+		mockEng := mock_frontend.NewMockEngine(ctrl)
+		restored, err := convertToVmOperator(pipeInstr, ctx, mockEng)
+		require.NoError(t, err)
+		restoredOp := restored.(*multi_update.MultiUpdate)
+		require.Equal(t, mockEng, restoredOp.Engine)
+	})
 }
 
 func Test_convertToProcessLimitation(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix

## Which issue does this PR fix?

Fixes #23988

## What this PR does / why we need it:

Fix 5 bugs where operator fields were lost during serialization or deserialization for remote CN execution in `pkg/sql/compile/remoterun.go`:

1. **Deletion: Engine not set** — `DeleteCtx.Engine` not populated from `eng` parameter during deserialization → nil-pointer panic on remote CN
2. **Insert: Engine not set** — `InsertCtx.Engine` not populated from `eng` → nil-pointer panic on remote CN
3. **MultiUpdate: Engine + PartitionCols missing** — `Engine` not set from `eng`; `PartitionCols` serialized but never deserialized → nil panic + wrong partition routing
4. **FuzzyFilter: BuildIdx not restored** — Serialized to proto but not read back → defaults to 0, wrong index selection
5. **OnDuplicateKey: IsIgnore not serialized** — Proto field exists, deser reads it, but serialization never writes it → IGNORE silently becomes UPDATE

### Changes

- `remoterun.go`: 10 lines added across 5 fix sites
- `remoterun_test.go`: Added `Test_DMLOperatorSerializationRoundtrip` with 6 subtests verifying all fixed fields survive serialization roundtrip (OnDuplicateKey.IsIgnore, FuzzyFilter.BuildIdx, MultiUpdate.PartitionCols, Deletion.Engine, Insert.Engine, MultiUpdate.Engine)

### Testing

```
go test -v -run Test_DMLOperatorSerializationRoundtrip ./pkg/sql/compile/
--- PASS: Test_DMLOperatorSerializationRoundtrip (0.00s)
    --- PASS: .../OnDuplicateKey_IsIgnore (0.00s)
    --- PASS: .../FuzzyFilter_BuildIdx (0.00s)
    --- PASS: .../MultiUpdate_PartitionCols (0.00s)
    --- PASS: .../Deletion_Engine (0.00s)
    --- PASS: .../Insert_Engine (0.00s)
    --- PASS: .../MultiUpdate_Engine (0.00s)
```
