### PR TITLE
fix: add missing PartitionMultiUpdate case in dupOperator

### DIFF
--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -439,6 +439,11 @@ func dupOperator(sourceOp vm.Operator, index int, maxParallel int) vm.Operator {
 		op := deletion.NewPartitionDeleteFrom(t)
 		op.SetInfo(&info)
 		return op
+	case vm.PartitionMultiUpdate:
+		t := sourceOp.(*multi_update.PartitionMultiUpdate)
+		op := multi_update.NewPartitionMultiUpdateFrom(t)
+		op.SetInfo(&info)
+		return op
 	case vm.PreInsert:
 		t := sourceOp.(*preinsert.PreInsert)
 		op := preinsert.NewArgument()

--- a/pkg/sql/compile/operator_test.go
+++ b/pkg/sql/compile/operator_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/deletion"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/insert"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/multi_update"
 )
 
 func TestDupOperator(t *testing.T) {
@@ -34,6 +35,15 @@ func TestDupOperator(t *testing.T) {
 	dupOperator(
 		deletion.NewPartitionDelete(
 			&deletion.Deletion{},
+			1,
+		),
+		0,
+		0,
+	)
+
+	dupOperator(
+		multi_update.NewPartitionMultiUpdate(
+			multi_update.NewArgument(),
 			1,
 		),
 		0,


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix

## Which issue does this PR fix?

Fixes #23990

## What this PR does / why we need it:

Add missing `vm.PartitionMultiUpdate` case in `dupOperator()` (`pkg/sql/compile/operator.go`).

`dupOperator()` is called when creating parallel scopes to duplicate operators for concurrent pipeline execution. Both `PartitionInsert` and `PartitionDelete` are handled, but `PartitionMultiUpdate` was missed. Without this fix, if a `PartitionMultiUpdate` operator appears in a parallel scope, `dupOperator` panics.

### Changes

- `operator.go`: 5 lines — add `case vm.PartitionMultiUpdate` using existing `NewPartitionMultiUpdateFrom()`
- `operator_test.go`: 10 lines — add PartitionMultiUpdate coverage to `TestDupOperator`

### Testing

```
go test -v -run TestDupOperator ./pkg/sql/compile/
--- PASS: TestDupOperator (0.00s)
```
