### PR TITLE
fix: defer res.Close() inside for loop leaks PruneResult in writeS3

### DIFF
--- a/pkg/sql/colexec/multi_update/multi_update_partition.go
+++ b/pkg/sql/colexec/multi_update/multi_update_partition.go
@@ -251,8 +251,8 @@ func (op *PartitionMultiUpdate) writeS3(
 		if err != nil {
 			return vm.CallResult{}, err
 		}
-		defer res.Close()
 		if res.Empty() {
+			res.Close()
 			panic("Prune result is empty")
 		}
 
@@ -307,6 +307,7 @@ func (op *PartitionMultiUpdate) writeS3(
 				return err == nil
 			},
 		)
+		res.Close()
 		if err != nil {
 			return vm.CallResult{}, err
 		}

--- a/pkg/sql/colexec/multi_update/multi_update_partition.go
+++ b/pkg/sql/colexec/multi_update/multi_update_partition.go
@@ -252,7 +252,6 @@ func (op *PartitionMultiUpdate) writeS3(
 			return vm.CallResult{}, err
 		}
 		if res.Empty() {
-			res.Close()
 			panic("Prune result is empty")
 		}
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix

## Which issue does this PR fix?

Fixes #23992

## What this PR does / why we need it:

Replace `defer res.Close()` with explicit `res.Close()` in `PartitionMultiUpdate.writeS3()`.

The `defer` was inside a `for` loop, so `Close()` only ran at function exit instead of at each loop iteration end. This causes all `PruneResult` objects to accumulate until the function returns.

Currently latent since `PruneResult.Close()` is a no-op, but will become a real resource leak when `Close()` gets a proper implementation.

### Changes

- `multi_update_partition.go`: 2 lines changed — remove `defer res.Close()`, add explicit `res.Close()` after `Iter()` and before panic path
