### PR TITLE
fix: batch small DML operator bugs found during audit

### DIFF
--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -941,17 +941,18 @@ func (lockOp *LockOp) CopyToPipelineTarget() []*pipeline.LockTarget {
 	targets := make([]*pipeline.LockTarget, len(lockOp.targets))
 	for i, target := range lockOp.targets {
 		targets[i] = &pipeline.LockTarget{
-			TableId:            target.tableID,
-			PrimaryColIdxInBat: target.primaryColumnIndexInBatch,
-			PrimaryColTyp:      plan.MakePlan2Type(&target.primaryColumnType),
-			RefreshTsIdxInBat:  target.refreshTimestampIndexInBatch,
-			FilterColIdxInBat:  target.filterColIndexInBatch,
-			LockTable:          target.lockTable,
-			ChangeDef:          target.changeDef,
-			Mode:               target.mode,
-			LockRows:           plan.DeepCopyExpr(target.lockRows),
-			LockTableAtTheEnd:  target.lockTableAtTheEnd,
-			ObjRef:             plan.DeepCopyObjectRef(target.objRef),
+			TableId:               target.tableID,
+			PrimaryColIdxInBat:    target.primaryColumnIndexInBatch,
+			PrimaryColTyp:         plan.MakePlan2Type(&target.primaryColumnType),
+			RefreshTsIdxInBat:     target.refreshTimestampIndexInBatch,
+			FilterColIdxInBat:     target.filterColIndexInBatch,
+			LockTable:             target.lockTable,
+			ChangeDef:             target.changeDef,
+			Mode:                  target.mode,
+			LockRows:              plan.DeepCopyExpr(target.lockRows),
+			LockTableAtTheEnd:     target.lockTableAtTheEnd,
+			ObjRef:                plan.DeepCopyObjectRef(target.objRef),
+			PartitionColIdxInBat:  target.partitionColumnIndexInBatch,
 		}
 	}
 	return targets
@@ -1213,9 +1214,6 @@ func lockTalbeIfLockCountIsZero(
 			if err != nil {
 				return err
 			}
-			defer func() {
-				free()
-			}()
 
 			bat := batch.NewWithSize(int(target.primaryColumnIndexInBatch) + 1)
 			bat.Vecs[target.primaryColumnIndexInBatch] = vec
@@ -1223,8 +1221,9 @@ func lockTalbeIfLockCountIsZero(
 
 			anal := lockOp.OpAnalyzer
 			anal.Start()
-			defer anal.Stop()
 			err = performLock(bat, proc, lockOp, anal, idx)
+			anal.Stop()
+			free()
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -941,18 +941,18 @@ func (lockOp *LockOp) CopyToPipelineTarget() []*pipeline.LockTarget {
 	targets := make([]*pipeline.LockTarget, len(lockOp.targets))
 	for i, target := range lockOp.targets {
 		targets[i] = &pipeline.LockTarget{
-			TableId:               target.tableID,
-			PrimaryColIdxInBat:    target.primaryColumnIndexInBatch,
-			PrimaryColTyp:         plan.MakePlan2Type(&target.primaryColumnType),
-			RefreshTsIdxInBat:     target.refreshTimestampIndexInBatch,
-			FilterColIdxInBat:     target.filterColIndexInBatch,
-			LockTable:             target.lockTable,
-			ChangeDef:             target.changeDef,
-			Mode:                  target.mode,
-			LockRows:              plan.DeepCopyExpr(target.lockRows),
-			LockTableAtTheEnd:     target.lockTableAtTheEnd,
-			ObjRef:                plan.DeepCopyObjectRef(target.objRef),
-			PartitionColIdxInBat:  target.partitionColumnIndexInBatch,
+			TableId:              target.tableID,
+			PrimaryColIdxInBat:   target.primaryColumnIndexInBatch,
+			PrimaryColTyp:        plan.MakePlan2Type(&target.primaryColumnType),
+			RefreshTsIdxInBat:    target.refreshTimestampIndexInBatch,
+			FilterColIdxInBat:    target.filterColIndexInBatch,
+			LockTable:            target.lockTable,
+			ChangeDef:            target.changeDef,
+			Mode:                 target.mode,
+			LockRows:             plan.DeepCopyExpr(target.lockRows),
+			LockTableAtTheEnd:    target.lockTableAtTheEnd,
+			ObjRef:               plan.DeepCopyObjectRef(target.objRef),
+			PartitionColIdxInBat: target.partitionColumnIndexInBatch,
 		}
 	}
 	return targets

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -691,3 +691,16 @@ func resetChildren(arg *LockOp, bat *batch.Batch) {
 	arg.Children = nil
 	arg.AppendChild(op)
 }
+
+func TestCopyToPipelineTargetIncludesPartitionColIdx(t *testing.T) {
+	pkType := types.New(types.T_int32, 0, 0)
+	arg := NewArgumentByEngine(nil)
+	defer arg.Release()
+
+	// Add lock target with partition column index
+	arg.AddLockTarget(1, nil, 0, pkType, 2, -1, nil, false)
+
+	targets := arg.CopyToPipelineTarget()
+	require.Len(t, targets, 1)
+	require.Equal(t, int32(2), targets[0].PartitionColIdxInBat)
+}

--- a/pkg/sql/colexec/multi_update/s3writer_delegate.go
+++ b/pkg/sql/colexec/multi_update/s3writer_delegate.go
@@ -653,6 +653,9 @@ func (writer *s3WriterDelegate) flushTailAndWriteToOutput(proc *process.Process,
 		for _, blockData := range block {
 			name := objectio.PhysicalAddr_Attr
 			err = writer.addBatchToOutput(mp, actionDelete, i, uint64(blockData.bat.RowCount()), name, blockData.bat)
+			if err != nil {
+				return
+			}
 		}
 	}
 

--- a/pkg/sql/colexec/onduplicatekey/on_duplicate_key.go
+++ b/pkg/sql/colexec/onduplicatekey/on_duplicate_key.go
@@ -149,6 +149,7 @@ func resetInsertBatchForOnduplicateKey(proc *process.Process, originBatch *batch
 		if oldConflictIdx > -1 {
 
 			if insertArg.IsIgnore {
+				newBatch.Clean(proc.GetMPool())
 				continue
 			}
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix

## Which issue does this PR fix?

Fixes #23994

## What this PR does / why we need it:

This PR batches 4 small but confirmed DML operator fixes found during a systematic audit:

1. **LockOp remote serialization**
   - Serialize `PartitionColIdxInBat` in `CopyToPipelineTarget()`.
   - Remote deserialization already expects this field, so omitting it could mis-handle partitioned-table locks on remote CN.

2. **OnDuplicateKey IGNORE cleanup**
   - Clean `newBatch` before `continue` on the `IsIgnore` conflict path.
   - Prevents a leak when `INSERT IGNORE` repeatedly hits duplicate conflicts.

3. **LockOp per-iteration cleanup**
   - Remove defer-in-loop cleanup in `lockTalbeIfLockCountIsZero()`.
   - Make analyzer/vector cleanup happen per iteration instead of accumulating until function return.

4. **S3WriterDelegate error propagation**
   - Check and return the error from `addBatchToOutput()` inside the `deleteBlockMap` loop.
   - Prevents silent loss of delete-block output failures.

## Testing

```bash
go build ./pkg/sql/colexec/lockop/ ./pkg/sql/colexec/onduplicatekey/ ./pkg/sql/colexec/multi_update/
go test -count=1 -timeout 120s ./pkg/sql/colexec/lockop/... ./pkg/sql/colexec/onduplicatekey/... ./pkg/sql/colexec/multi_update/...
```

All passed locally.
