### PR TITLE
fix: DML audit batch - preinsert tmpVec leak and Deletion CanTruncate serialization

### DIFF
--- a/pkg/sql/colexec/preinsert/preinsert.go
+++ b/pkg/sql/colexec/preinsert/preinsert.go
@@ -144,6 +144,7 @@ func (preInsert *PreInsert) constructColBuf(proc *proc, bat *batch.Batch, first 
 				typ := bat.Vecs[idx].GetType()
 				tmpVec := vector.NewVec(*typ)
 				if err = vector.GetUnionAllFunction(*typ, proc.Mp())(tmpVec, bat.Vecs[idx]); err != nil {
+					tmpVec.Free(proc.Mp())
 					return err
 				}
 				preInsert.ctr.buf.Vecs[idx] = tmpVec

--- a/pkg/sql/compile/remoterun.go
+++ b/pkg/sql/compile/remoterun.go
@@ -445,6 +445,7 @@ func convertToPipelineInstruction(op vm.Operator, proc *process.Process, ctx *sc
 			NBucket:      t.Nbucket,
 			// deleteCtx
 			RowIdIdx:        int32(t.DeleteCtx.RowIdIdx),
+			CanTruncate:     t.DeleteCtx.CanTruncate,
 			AddAffectedRows: t.DeleteCtx.AddAffectedRows,
 			Ref:             t.DeleteCtx.Ref,
 			PrimaryKeyIdx:   int32(t.DeleteCtx.PrimaryKeyIdx),

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -705,3 +705,52 @@ func Test_checkPipelineStandaloneExecutableAtRemote(t *testing.T) {
 		require.False(t, checkPipelineStandaloneExecutableAtRemote(s0))
 	}
 }
+
+// TestDeletionCanTruncateSerializationRoundtrip verifies that CanTruncate is
+// properly serialized and deserialized when Deletion operators are sent to remote CN.
+func TestDeletionCanTruncateSerializationRoundtrip(t *testing.T) {
+	// Create a Deletion operator with CanTruncate=true
+	arg := deletion.NewArgument()
+	arg.DeleteCtx = &deletion.DeleteCtx{
+		CanTruncate:     true,
+		RowIdIdx:        1,
+		PrimaryKeyIdx:   0,
+		AddAffectedRows: true,
+		Ref:             &plan.ObjectRef{SchemaName: "test", ObjName: "t1"},
+	}
+
+	// Create minimal context for serialization
+	ctx := &scopeContext{
+		id:       0,
+		plan:     &plan.Plan{},
+		scope:    &Scope{},
+		root:     &scopeContext{},
+		parent:   nil,
+		children: nil,
+		pipe:     nil,
+		regs:     make(map[*process.WaitRegister]int32),
+	}
+	ctx.root = ctx
+
+	// Serialize to pipeline instruction
+	_, in, err := convertToPipelineInstruction(arg, nil, ctx, 0)
+	require.NoError(t, err)
+	require.NotNil(t, in.Delete)
+	require.True(t, in.Delete.CanTruncate, "CanTruncate should be serialized")
+
+	// Deserialize back to operator
+	opr := &pipeline.Instruction{
+		Op:     int32(vm.Deletion),
+		Delete: in.Delete,
+	}
+	op, err := convertToVmOperator(opr, ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+
+	restored := op.(*deletion.Deletion)
+	require.NotNil(t, restored.DeleteCtx)
+	require.True(t, restored.DeleteCtx.CanTruncate, "CanTruncate should be deserialized")
+	require.Equal(t, 1, restored.DeleteCtx.RowIdIdx)
+	require.Equal(t, 0, restored.DeleteCtx.PrimaryKeyIdx)
+	require.True(t, restored.DeleteCtx.AddAffectedRows)
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes two bugs discovered during systematic DML/multi-CN code audit:

### Fix 1: preinsert.go tmpVec memory leak on error path
- In `constructColBuf()`, when `GetUnionAllFunction` fails, `tmpVec` was never freed
- Added `tmpVec.Free(proc.Mp())` before returning error

### Fix 2: Deletion.CanTruncate serialization gap
- `CanTruncate` field exists in pipeline proto and is deserialized correctly
- But serialization in `convertToPipelineInstruction` was missing the field
- This caused DELETE truncation optimization to be lost on remote CN execution

## Which issue(s) this PR fixes:

Fixes #23996

## Type of changes:

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Documentation

## Additional context:

Added regression test `TestDeletionCanTruncateSerializationRoundtrip` to verify the serialization fix.