### PR TITLE
fix: DML audit batch 3 - clone bugs and serialization gap

### DIFF
--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -957,6 +957,33 @@ func (lockOp *LockOp) CopyToPipelineTarget() []*pipeline.LockTarget {
 	return targets
 }
 
+// CopyTargetsFrom creates a deep copy of targets from another LockOp.
+// This is used by dupOperator to avoid sharing targets slice during parallel execution.
+func (lockOp *LockOp) CopyTargetsFrom(src *LockOp) {
+	if len(src.targets) == 0 {
+		lockOp.targets = nil
+		return
+	}
+	lockOp.targets = make([]lockTarget, len(src.targets))
+	for i, t := range src.targets {
+		lockOp.targets[i] = lockTarget{
+			tableID:                      t.tableID,
+			objRef:                       plan.DeepCopyObjectRef(t.objRef),
+			primaryColumnIndexInBatch:    t.primaryColumnIndexInBatch,
+			refreshTimestampIndexInBatch: t.refreshTimestampIndexInBatch,
+			primaryColumnType:            t.primaryColumnType,
+			partitionColumnIndexInBatch:  t.partitionColumnIndexInBatch,
+			filter:                       t.filter, // function pointer, safe to copy
+			filterColIndexInBatch:        t.filterColIndexInBatch,
+			lockTable:                    t.lockTable,
+			changeDef:                    t.changeDef,
+			mode:                         t.mode,
+			lockRows:                     plan.DeepCopyExpr(t.lockRows),
+			lockTableAtTheEnd:            t.lockTableAtTheEnd,
+		}
+	}
+}
+
 // AddLockTarget add lock target, LockMode_Exclusive will used
 func (lockOp *LockOp) AddLockTarget(
 	tableID uint64,

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 	"github.com/matrixorigin/matrixone/pkg/vm"
@@ -690,4 +691,65 @@ func resetChildren(arg *LockOp, bat *batch.Batch) {
 	op := colexec.NewMockOperator().WithBatchs([]*batch.Batch{bat})
 	arg.Children = nil
 	arg.AppendChild(op)
+}
+
+// TestCopyTargetsFrom verifies that CopyTargetsFrom creates independent deep copies
+// of targets, preventing race conditions in parallel execution.
+func TestCopyTargetsFrom(t *testing.T) {
+	src := NewArgument()
+	defer src.Release()
+
+	// Add targets to source
+	src.AddLockTarget(
+		100,                        // tableID
+		&plan.ObjectRef{SchemaName: "test", ObjName: "t1"},
+		0,                          // primaryColumnIndexInBatch
+		types.T_int64.ToType(),     // primaryColumnType
+		-1,                         // partitionColIndexInBatch
+		1,                          // refreshTimestampIndexInBatch
+		nil,                        // lockRows
+		false,                      // lockTableAtTheEnd
+	)
+	src.AddLockTarget(
+		200,
+		&plan.ObjectRef{SchemaName: "test", ObjName: "t2"},
+		2,
+		types.T_varchar.ToType(),
+		-1,
+		3,
+		nil, // simplified - no lockRows expr
+		true,
+	)
+
+	// Copy targets to destination
+	dst := NewArgument()
+	defer dst.Release()
+	dst.CopyTargetsFrom(src)
+
+	// Verify copy is independent
+	require.Equal(t, len(src.targets), len(dst.targets), "targets length should match")
+
+	// Modify source and verify destination is unchanged
+	src.targets[0].tableID = 999
+	src.targets[0].objRef.ObjName = "modified"
+	require.Equal(t, uint64(100), dst.targets[0].tableID, "dst tableID should be unchanged")
+	require.Equal(t, "t1", dst.targets[0].objRef.ObjName, "dst objRef should be unchanged")
+
+	// Verify all fields were copied correctly
+	require.Equal(t, uint64(200), dst.targets[1].tableID)
+	require.Equal(t, "t2", dst.targets[1].objRef.ObjName)
+	require.True(t, dst.targets[1].lockTableAtTheEnd)
+}
+
+// TestCopyTargetsFromEmpty verifies CopyTargetsFrom handles empty targets correctly.
+func TestCopyTargetsFromEmpty(t *testing.T) {
+	src := NewArgument()
+	defer src.Release()
+
+	dst := NewArgument()
+	defer dst.Release()
+
+	// Copy empty targets
+	dst.CopyTargetsFrom(src)
+	require.Nil(t, dst.targets)
 }

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -701,14 +701,14 @@ func TestCopyTargetsFrom(t *testing.T) {
 
 	// Add targets to source
 	src.AddLockTarget(
-		100,                        // tableID
+		100, // tableID
 		&plan.ObjectRef{SchemaName: "test", ObjName: "t1"},
-		0,                          // primaryColumnIndexInBatch
-		types.T_int64.ToType(),     // primaryColumnType
-		-1,                         // partitionColIndexInBatch
-		1,                          // refreshTimestampIndexInBatch
-		nil,                        // lockRows
-		false,                      // lockTableAtTheEnd
+		0,                      // primaryColumnIndexInBatch
+		types.T_int64.ToType(), // primaryColumnType
+		-1,                     // partitionColIndexInBatch
+		1,                      // refreshTimestampIndexInBatch
+		nil,                    // lockRows
+		false,                  // lockTableAtTheEnd
 	)
 	src.AddLockTarget(
 		200,

--- a/pkg/sql/colexec/multi_update/multi_update_partition.go
+++ b/pkg/sql/colexec/multi_update/multi_update_partition.go
@@ -423,7 +423,7 @@ func (ctx *MultiUpdateCtx) clone() *MultiUpdateCtx {
 	v := &MultiUpdateCtx{
 		InsertCols:    ctx.InsertCols,
 		DeleteCols:    ctx.DeleteCols,
-		PartitionCols: ctx.DeleteCols,
+		PartitionCols: ctx.PartitionCols,
 	}
 	objRef := *ctx.ObjRef
 	def := *ctx.TableDef

--- a/pkg/sql/colexec/multi_update/multi_update_partition_test.go
+++ b/pkg/sql/colexec/multi_update/multi_update_partition_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/stretchr/testify/require"
 )
 
@@ -229,4 +230,32 @@ func TestDeleteAffectedRows(t *testing.T) {
 
 	update.addDeleteAffectRows(UpdateMainTable, 4)
 	require.Equal(t, uint64(4), update.ctr.affectedRows, "DELETE rows should be counted")
+}
+
+// TestMultiUpdateCtxClonePartitionCols verifies that clone() correctly copies
+// PartitionCols (regression test for copy-paste bug that assigned DeleteCols).
+func TestMultiUpdateCtxClonePartitionCols(t *testing.T) {
+	original := &MultiUpdateCtx{
+		InsertCols:    []int{1, 2, 3},
+		DeleteCols:    []int{4, 5},
+		PartitionCols: []int{6, 7, 8, 9},
+		ObjRef:        &plan.ObjectRef{SchemaName: "test", ObjName: "t1"},
+		TableDef:      &plan.TableDef{Name: "t1"},
+	}
+
+	cloned := original.clone()
+
+	// Verify PartitionCols is correctly cloned (not DeleteCols)
+	require.Equal(t, original.PartitionCols, cloned.PartitionCols,
+		"PartitionCols should match original, not DeleteCols")
+	require.NotEqual(t, original.DeleteCols, cloned.PartitionCols,
+		"PartitionCols should not be DeleteCols")
+
+	// Verify other fields
+	require.Equal(t, original.InsertCols, cloned.InsertCols)
+	require.Equal(t, original.DeleteCols, cloned.DeleteCols)
+
+	// Verify ObjRef and TableDef are deep copied
+	cloned.ObjRef.ObjName = "modified"
+	require.Equal(t, "t1", original.ObjRef.ObjName, "original ObjRef should be unchanged")
 }

--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -467,7 +467,7 @@ func dupOperator(sourceOp vm.Operator, index int, maxParallel int) vm.Operator {
 	case vm.LockOp:
 		t := sourceOp.(*lockop.LockOp)
 		op := lockop.NewArgument()
-		*op = *t
+		op.CopyTargetsFrom(t)
 		op.SetChildren(nil) // make sure res.arg.children is nil
 		op.SetInfo(&info)
 		return op

--- a/pkg/sql/compile/remoterun.go
+++ b/pkg/sql/compile/remoterun.go
@@ -457,6 +457,7 @@ func convertToPipelineInstruction(op vm.Operator, proc *process.Process, ctx *sc
 			UniqueCols:         t.UniqueCols,
 			OnDuplicateIdx:     t.OnDuplicateIdx,
 			OnDuplicateExpr:    t.OnDuplicateExpr,
+			IsIgnore:           t.IsIgnore,
 		}
 	case *fuzzyfilter.FuzzyFilter:
 		in.FuzzyFilter = &pipeline.FuzzyFilter{

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -705,3 +705,46 @@ func Test_checkPipelineStandaloneExecutableAtRemote(t *testing.T) {
 		require.False(t, checkPipelineStandaloneExecutableAtRemote(s0))
 	}
 }
+
+// TestOnDuplicateKeyIsIgnoreSerializationRoundtrip verifies that IsIgnore is
+// properly serialized and deserialized when OnDuplicateKey operators are sent to remote CN.
+func TestOnDuplicateKeyIsIgnoreSerializationRoundtrip(t *testing.T) {
+	// Create an OnDuplicateKey operator with IsIgnore=true
+	arg := onduplicatekey.NewArgument()
+	arg.Attrs = []string{"col1", "col2"}
+	arg.InsertColCount = 2
+	arg.IsIgnore = true
+
+	// Create minimal context for serialization
+	ctx := &scopeContext{
+		id:       0,
+		plan:     &plan.Plan{},
+		scope:    &Scope{},
+		root:     &scopeContext{},
+		parent:   nil,
+		children: nil,
+		pipe:     nil,
+		regs:     make(map[*process.WaitRegister]int32),
+	}
+	ctx.root = ctx
+
+	// Serialize to pipeline instruction
+	_, in, err := convertToPipelineInstruction(arg, nil, ctx, 0)
+	require.NoError(t, err)
+	require.NotNil(t, in.OnDuplicateKey)
+	require.True(t, in.OnDuplicateKey.IsIgnore, "IsIgnore should be serialized")
+
+	// Deserialize back to operator
+	opr := &pipeline.Instruction{
+		Op:             int32(vm.OnDuplicateKey),
+		OnDuplicateKey: in.OnDuplicateKey,
+	}
+	op, err := convertToVmOperator(opr, ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+
+	restored := op.(*onduplicatekey.OnDuplicatekey)
+	require.True(t, restored.IsIgnore, "IsIgnore should be deserialized")
+	require.Equal(t, []string{"col1", "col2"}, restored.Attrs)
+	require.Equal(t, int32(2), restored.InsertColCount)
+}


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes three bugs discovered during systematic DML/multi-CN code audit:

### Fix 1: MultiUpdateCtx.clone() copy-paste bug
- `PartitionCols` was incorrectly assigned `ctx.DeleteCols` instead of `ctx.PartitionCols`
- This caused wrong partition columns in cloned contexts during partition DML

### Fix 2: LockOp shallow copy in dupOperator
- Using `*op = *t` caused targets slice to be shared between duplicated operators
- Added `CopyTargetsFrom()` method for proper deep copy of targets
- Prevents race conditions during parallel LockOp execution

### Fix 3: OnDuplicateKey.IsIgnore not serialized
- `IsIgnore` field was deserialized but never serialized
- This broke `INSERT IGNORE ... ON DUPLICATE KEY UPDATE` on remote CN

## Which issue(s) this PR fixes:

Fixes #23998

## Type of changes:

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Documentation

## Additional context:

Added regression tests for all three fixes:
- `TestMultiUpdateCtxClonePartitionCols`
- `TestCopyTargetsFrom` and `TestCopyTargetsFromEmpty`
- `TestOnDuplicateKeyIsIgnoreSerializationRoundtrip`