### PR TITLE
fix: DML audit batch 4 - preinsert executor leak and LoopJoin MarkPos

### DIFF
--- a/pkg/sql/colexec/preinsert/preinsert.go
+++ b/pkg/sql/colexec/preinsert/preinsert.go
@@ -66,6 +66,11 @@ func (preInsert *PreInsert) Prepare(proc *process.Process) (err error) {
 	if preInsert.ClusterByExpr != nil && preInsert.ctr.clusterByExecutor == nil {
 		preInsert.ctr.clusterByExecutor, err = colexec.NewExpressionExecutor(proc, preInsert.ClusterByExpr)
 		if err != nil {
+			// Clean up compPkExecutor if ClusterByExpr initialization fails
+			if preInsert.ctr.compPkExecutor != nil {
+				preInsert.ctr.compPkExecutor.Free()
+				preInsert.ctr.compPkExecutor = nil
+			}
 			return
 		}
 	}

--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -206,6 +206,7 @@ func dupOperator(sourceOp vm.Operator, index int, maxParallel int) vm.Operator {
 		op.NonEqCond = t.NonEqCond
 		op.JoinMapTag = t.JoinMapTag
 		op.JoinType = t.JoinType
+		op.MarkPos = t.MarkPos
 		op.SetInfo(&info)
 		return op
 


### PR DESCRIPTION
## What this PR does / why we need it:

Fixes two bugs discovered during systematic DML/multi-CN code audit:

### Fix 1: PreInsert.Prepare() ExpressionExecutor leak
- When ClusterByExpr initialization fails, compPkExecutor was never freed
- Added cleanup logic to free compPkExecutor on ClusterByExpr error

### Fix 2: LoopJoin.MarkPos not copied in dupOperator  
- MarkPos field was missing from LoopJoin operator duplication
- This is a completeness fix for forward compatibility (field currently unused)

## Which issue(s) this PR fixes:

Fixes #24000

## Type of changes:

- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds functionality)
- [ ] Documentation

## Additional context:

Both fixes are minimal and low-risk. The preinsert fix adds proper cleanup on error path. The LoopJoin fix adds a missing field copy.