### PR TITLE
fix: dupOperator missing MergeTop/MergeOrder cases and memory leaks

### DIFF
--- a/pkg/sql/colexec/group/helper.go
+++ b/pkg/sql/colexec/group/helper.go
@@ -680,10 +680,18 @@ func (ctr *container) makeAggList(aggExprs []aggexec.AggFuncExecExpression) ([]a
 		}
 		aggList[i], err = aggexec.MakeAgg(ctr.mp, agExpr.GetAggID(), agExpr.IsDistinct(), typs...)
 		if err != nil {
+			// Clean up previously created aggregators
+			for k := 0; k < i; k++ {
+				aggList[k].Free()
+			}
 			return nil, err
 		}
 		if config := agExpr.GetExtraConfig(); config != nil {
 			if err := aggList[i].SetExtraInformation(config, 0); err != nil {
+				// Clean up all created aggregators including current one
+				for k := 0; k <= i; k++ {
+					aggList[k].Free()
+				}
 				return nil, err
 			}
 		}
@@ -695,6 +703,10 @@ func (ctr *container) makeAggList(aggExprs []aggexec.AggFuncExecExpression) ([]a
 		aggexec.SyncAggregatorsToChunkSize(aggList, 1)
 		for _, ag := range aggList {
 			if err := ag.GroupGrow(1); err != nil {
+				// Clean up all aggregators on GroupGrow failure
+				for _, a := range aggList {
+					a.Free()
+				}
 				return nil, err
 			}
 		}

--- a/pkg/sql/colexec/order/order.go
+++ b/pkg/sql/colexec/order/order.go
@@ -172,11 +172,6 @@ func (order *Order) Call(proc *process.Process) (vm.CallResult, error) {
 		ctr.rbat = nil
 	}
 
-	if ctr.rbat != nil {
-		ctr.rbat.Clean(proc.GetMPool())
-		ctr.rbat = nil
-	}
-
 	if ctr.state == vm.Build {
 		for {
 			input, err := vm.ChildrenCall(order.GetChildren(0), proc, analyzer)

--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -276,6 +276,19 @@ func dupOperator(sourceOp vm.Operator, index int, maxParallel int) vm.Operator {
 		op.Fs = t.Fs
 		op.SetInfo(&info)
 		return op
+	case vm.MergeTop:
+		t := sourceOp.(*mergetop.MergeTop)
+		op := mergetop.NewArgument()
+		op.Limit = t.Limit
+		op.Fs = t.Fs
+		op.SetInfo(&info)
+		return op
+	case vm.MergeOrder:
+		t := sourceOp.(*mergeorder.MergeOrder)
+		op := mergeorder.NewArgument()
+		op.OrderBySpecs = t.OrderBySpecs
+		op.SetInfo(&info)
+		return op
 	case vm.Intersect:
 		op := intersect.NewArgument()
 		op.SetInfo(&info)
@@ -408,6 +421,7 @@ func dupOperator(sourceOp vm.Operator, index int, maxParallel int) vm.Operator {
 		op := dispatch.NewArgument()
 		op.IsSink = sourceArg.IsSink
 		op.RecSink = sourceArg.RecSink
+		op.RecCTE = sourceArg.RecCTE
 		op.ShuffleType = sourceArg.ShuffleType
 		op.ShuffleRegIdxLocal = sourceArg.ShuffleRegIdxLocal
 		op.ShuffleRegIdxRemote = sourceArg.ShuffleRegIdxRemote


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug fix

## Which issue(s) does this PR fix or relate to?
N/A - discovered during code audit

## What does this PR change or fix?
This PR fixes four bugs discovered during systematic DML and multi-CN code audit:

### 1. Missing MergeTop and MergeOrder in dupOperator (HIGH priority)
**File:** `pkg/sql/compile/operator.go`

`dupOperator()` is called to create independent copies of operators for parallel execution. Missing cases for MergeTop and MergeOrder operators means parallel queries using these operators will hit the default panic case:
```go
default:
    panic("unexpected operator type for duplication")
```

**Fix:** Add proper duplication cases for both operators.

### 2. Missing RecCTE field copy in Dispatch operator (HIGH priority)
**File:** `pkg/sql/compile/operator.go`

The Dispatch operator has a `RecCTE` boolean field that wasn't being copied during operator duplication. This breaks recursive CTE queries in parallel execution scenarios.

**Fix:** Add `op.RecCTE = sourceArg.RecCTE` to the Dispatch case.

### 3. Duplicate batch cleanup code in Order operator (MEDIUM priority)
**File:** `pkg/sql/colexec/order/order.go`

The Order operator's `Call()` method had duplicate code:
```go
if ctr.rbat != nil {
    ctr.rbat.Clean(proc.GetMPool())
    ctr.rbat = nil
}
// Same block repeated immediately after
if ctr.rbat != nil {
    ctr.rbat.Clean(proc.GetMPool())
    ctr.rbat = nil
}
```

**Fix:** Remove the duplicate block.

### 4. Memory leak in makeAggList on error paths (MEDIUM priority)
**File:** `pkg/sql/colexec/group/helper.go`

`makeAggList()` creates aggregator objects but doesn't clean them up when errors occur mid-creation. This leads to memory leaks when:
- `MakeAgg()` fails for aggregator N (aggregators 0..N-1 leak)
- `SetExtraInformation()` fails (aggregators 0..N leak)
- `GroupGrow()` fails in H0 mode (all aggregators leak)

**Fix:** Add proper cleanup loops before each error return.

## Testing
- [x] Existing tests pass
- [x] `go build ./pkg/sql/...` compiles successfully