### PR TITLE
fix(dml): batch bug fixes for parallel execution and memory leaks

### DIFF
--- a/pkg/sql/colexec/group/group_test.go
+++ b/pkg/sql/colexec/group/group_test.go
@@ -153,3 +153,48 @@ func TestGroupResetAndReuse(t *testing.T) {
 	proc.Free()
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
+
+func TestFreeAggListPartial(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+
+	// Create a few mock aggregators
+	aggList := make([]aggexec.AggFuncExec, 3)
+	for i := 0; i < 3; i++ {
+		agg, err := aggexec.MakeAgg(proc.Mp(), aggexec.AggIdOfCountStar, false, types.T_int64.ToType())
+		require.NoError(t, err)
+		aggList[i] = agg
+	}
+
+	// Free first 2 aggregators
+	freeAggListPartial(aggList, 2)
+
+	// Free all remaining
+	freeAggListPartial(aggList, 3)
+}
+
+func TestFreeAggList(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+
+	aggList := make([]aggexec.AggFuncExec, 2)
+	for i := 0; i < 2; i++ {
+		agg, err := aggexec.MakeAgg(proc.Mp(), aggexec.AggIdOfCountStar, false, types.T_int64.ToType())
+		require.NoError(t, err)
+		aggList[i] = agg
+	}
+
+	freeAggList(aggList)
+}
+
+func TestFreeAggListPartialWithNilEntries(t *testing.T) {
+	// Test with nil entries - should not panic
+	aggList := make([]aggexec.AggFuncExec, 3)
+	aggList[0] = nil
+	aggList[1] = nil
+	aggList[2] = nil
+
+	// Should not panic
+	freeAggListPartial(aggList, 3)
+	freeAggList(aggList)
+}

--- a/pkg/sql/colexec/group/group_test.go
+++ b/pkg/sql/colexec/group/group_test.go
@@ -158,7 +158,6 @@ func TestFreeAggListPartial(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	defer proc.Free()
 
-	// Create a few mock aggregators
 	aggList := make([]aggexec.AggFuncExec, 3)
 	for i := 0; i < 3; i++ {
 		agg, err := aggexec.MakeAgg(proc.Mp(), aggexec.AggIdOfCountStar, false, types.T_int64.ToType())
@@ -166,10 +165,7 @@ func TestFreeAggListPartial(t *testing.T) {
 		aggList[i] = agg
 	}
 
-	// Free first 2 aggregators
 	freeAggListPartial(aggList, 2)
-
-	// Free all remaining
 	freeAggListPartial(aggList, 3)
 }
 
@@ -188,13 +184,20 @@ func TestFreeAggList(t *testing.T) {
 }
 
 func TestFreeAggListPartialWithNilEntries(t *testing.T) {
-	// Test with nil entries - should not panic
 	aggList := make([]aggexec.AggFuncExec, 3)
-	aggList[0] = nil
-	aggList[1] = nil
-	aggList[2] = nil
 
-	// Should not panic
 	freeAggListPartial(aggList, 3)
 	freeAggList(aggList)
+}
+
+func TestMakeAggListFreesPartialOnCreationError(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+
+	ctr := &container{mp: proc.Mp()}
+	_, err := ctr.makeAggList([]aggexec.AggFuncExecExpression{
+		countStarAgg(),
+		aggexec.MakeAggFunctionExpression(-1, false, []*plan.Expr{colExpr(0, types.T_int32)}, nil),
+	})
+	require.Error(t, err)
 }

--- a/pkg/sql/colexec/group/helper.go
+++ b/pkg/sql/colexec/group/helper.go
@@ -680,10 +680,12 @@ func (ctr *container) makeAggList(aggExprs []aggexec.AggFuncExecExpression) ([]a
 		}
 		aggList[i], err = aggexec.MakeAgg(ctr.mp, agExpr.GetAggID(), agExpr.IsDistinct(), typs...)
 		if err != nil {
+			freeAggListPartial(aggList, i)
 			return nil, err
 		}
 		if config := agExpr.GetExtraConfig(); config != nil {
 			if err := aggList[i].SetExtraInformation(config, 0); err != nil {
+				freeAggListPartial(aggList, i+1)
 				return nil, err
 			}
 		}
@@ -695,11 +697,26 @@ func (ctr *container) makeAggList(aggExprs []aggexec.AggFuncExecExpression) ([]a
 		aggexec.SyncAggregatorsToChunkSize(aggList, 1)
 		for _, ag := range aggList {
 			if err := ag.GroupGrow(1); err != nil {
+				freeAggList(aggList)
 				return nil, err
 			}
 		}
 	}
 	return aggList, nil
+}
+
+// freeAggListPartial frees the first n aggregators in the list.
+func freeAggListPartial(aggList []aggexec.AggFuncExec, n int) {
+	for i := 0; i < n && i < len(aggList); i++ {
+		if aggList[i] != nil {
+			aggList[i].Free()
+		}
+	}
+}
+
+// freeAggList frees all aggregators in the list.
+func freeAggList(aggList []aggexec.AggFuncExec) {
+	freeAggListPartial(aggList, len(aggList))
 }
 
 func (ctr *container) sanityCheck() {

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -941,17 +941,18 @@ func (lockOp *LockOp) CopyToPipelineTarget() []*pipeline.LockTarget {
 	targets := make([]*pipeline.LockTarget, len(lockOp.targets))
 	for i, target := range lockOp.targets {
 		targets[i] = &pipeline.LockTarget{
-			TableId:            target.tableID,
-			PrimaryColIdxInBat: target.primaryColumnIndexInBatch,
-			PrimaryColTyp:      plan.MakePlan2Type(&target.primaryColumnType),
-			RefreshTsIdxInBat:  target.refreshTimestampIndexInBatch,
-			FilterColIdxInBat:  target.filterColIndexInBatch,
-			LockTable:          target.lockTable,
-			ChangeDef:          target.changeDef,
-			Mode:               target.mode,
-			LockRows:           plan.DeepCopyExpr(target.lockRows),
-			LockTableAtTheEnd:  target.lockTableAtTheEnd,
-			ObjRef:             plan.DeepCopyObjectRef(target.objRef),
+			TableId:              target.tableID,
+			PrimaryColIdxInBat:   target.primaryColumnIndexInBatch,
+			PrimaryColTyp:        plan.MakePlan2Type(&target.primaryColumnType),
+			RefreshTsIdxInBat:    target.refreshTimestampIndexInBatch,
+			FilterColIdxInBat:    target.filterColIndexInBatch,
+			LockTable:            target.lockTable,
+			ChangeDef:            target.changeDef,
+			Mode:                 target.mode,
+			LockRows:             plan.DeepCopyExpr(target.lockRows),
+			LockTableAtTheEnd:    target.lockTableAtTheEnd,
+			ObjRef:               plan.DeepCopyObjectRef(target.objRef),
+			PartitionColIdxInBat: target.partitionColumnIndexInBatch,
 		}
 	}
 	return targets
@@ -1209,22 +1210,7 @@ func lockTalbeIfLockCountIsZero(
 	for idx := 0; idx < len(lockOp.targets); idx++ {
 		target := lockOp.targets[idx]
 		if target.lockRows != nil {
-			vec, free, err := colexec.GetReadonlyResultFromNoColumnExpression(proc, target.lockRows)
-			if err != nil {
-				return err
-			}
-			defer func() {
-				free()
-			}()
-
-			bat := batch.NewWithSize(int(target.primaryColumnIndexInBatch) + 1)
-			bat.Vecs[target.primaryColumnIndexInBatch] = vec
-			bat.SetRowCount(vec.Length())
-
-			anal := lockOp.OpAnalyzer
-			anal.Start()
-			defer anal.Stop()
-			err = performLock(bat, proc, lockOp, anal, idx)
+			err := lockTargetWithRows(proc, lockOp, idx, target)
 			if err != nil {
 				return err
 			}
@@ -1241,4 +1227,26 @@ func lockTalbeIfLockCountIsZero(
 	ctr.lockCount = 1
 
 	return nil
+}
+
+func lockTargetWithRows(
+	proc *process.Process,
+	lockOp *LockOp,
+	idx int,
+	target lockTarget,
+) error {
+	vec, free, err := colexec.GetReadonlyResultFromNoColumnExpression(proc, target.lockRows)
+	if err != nil {
+		return err
+	}
+	defer free()
+
+	bat := batch.NewWithSize(int(target.primaryColumnIndexInBatch) + 1)
+	bat.Vecs[target.primaryColumnIndexInBatch] = vec
+	bat.SetRowCount(vec.Length())
+
+	anal := lockOp.OpAnalyzer
+	anal.Start()
+	defer anal.Stop()
+	return performLock(bat, proc, lockOp, anal, idx)
 }

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/lock"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 	"github.com/matrixorigin/matrixone/pkg/vm"
@@ -697,10 +698,25 @@ func TestCopyToPipelineTargetIncludesPartitionColIdx(t *testing.T) {
 	arg := NewArgumentByEngine(nil)
 	defer arg.Release()
 
-	// Add lock target with partition column index
 	arg.AddLockTarget(1, nil, 0, pkType, 2, -1, nil, false)
 
 	targets := arg.CopyToPipelineTarget()
 	require.Len(t, targets, 1)
 	require.Equal(t, int32(2), targets[0].PartitionColIdxInBat)
+}
+
+func TestLockTableIfLockCountIsZeroWithLockRows(t *testing.T) {
+	runLockOpTest(t, func(proc *process.Process) {
+		pkType := types.New(types.T_int32, 0, 0)
+		arg := NewArgumentByEngine(nil)
+		arg.OperatorBase.OperatorInfo = vm.OperatorInfo{Idx: 0}
+		arg.AddLockTarget(1, nil, 0, pkType, -1, -1, plan2.MakePlan2Int32ConstExprWithType(42), false)
+
+		require.NoError(t, arg.Prepare(proc))
+		arg.ctr.hasNewVersionInRange = testFunc
+
+		require.NoError(t, lockTalbeIfLockCountIsZero(proc, arg))
+
+		arg.Free(proc, false, nil)
+	})
 }

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -691,3 +691,16 @@ func resetChildren(arg *LockOp, bat *batch.Batch) {
 	arg.Children = nil
 	arg.AppendChild(op)
 }
+
+func TestCopyToPipelineTargetIncludesPartitionColIdx(t *testing.T) {
+	pkType := types.New(types.T_int32, 0, 0)
+	arg := NewArgumentByEngine(nil)
+	defer arg.Release()
+
+	// Add lock target with partition column index
+	arg.AddLockTarget(1, nil, 0, pkType, 2, -1, nil, false)
+
+	targets := arg.CopyToPipelineTarget()
+	require.Len(t, targets, 1)
+	require.Equal(t, int32(2), targets[0].PartitionColIdxInBat)
+}

--- a/pkg/sql/colexec/multi_update/s3writer_delegate.go
+++ b/pkg/sql/colexec/multi_update/s3writer_delegate.go
@@ -653,6 +653,9 @@ func (writer *s3WriterDelegate) flushTailAndWriteToOutput(proc *process.Process,
 		for _, blockData := range block {
 			name := objectio.PhysicalAddr_Attr
 			err = writer.addBatchToOutput(mp, actionDelete, i, uint64(blockData.bat.RowCount()), name, blockData.bat)
+			if err != nil {
+				return
+			}
 		}
 	}
 

--- a/pkg/sql/colexec/onduplicatekey/on_duplicate_key.go
+++ b/pkg/sql/colexec/onduplicatekey/on_duplicate_key.go
@@ -149,6 +149,7 @@ func resetInsertBatchForOnduplicateKey(proc *process.Process, originBatch *batch
 		if oldConflictIdx > -1 {
 
 			if insertArg.IsIgnore {
+				newBatch.Clean(proc.GetMPool())
 				continue
 			}
 

--- a/pkg/sql/colexec/onduplicatekey/on_duplicate_key_test.go
+++ b/pkg/sql/colexec/onduplicatekey/on_duplicate_key_test.go
@@ -84,6 +84,24 @@ func TestOnDuplicateKey(t *testing.T) {
 	}
 }
 
+func TestOnDuplicateKeyIgnoreCleansConflictBatch(t *testing.T) {
+	tc := newTestCase(t)
+	tc.arg.IsIgnore = true
+	tc.rowCount = 1
+
+	resetChildren(tc.arg, tc.proc.Mp())
+	err := tc.arg.Prepare(tc.proc)
+	require.NoError(t, err)
+
+	ret, execErr := vm.Exec(tc.arg, tc.proc)
+	require.NoError(t, execErr)
+	require.Equal(t, tc.rowCount, ret.Batch.RowCount())
+
+	tc.arg.Free(tc.proc, false, nil)
+	tc.proc.Free()
+	require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
+}
+
 func resetChildren(arg *OnDuplicatekey, m *mpool.MPool) {
 	bat := batch.New([]string{"a", "b", "a", "b", catalog.Row_ID})
 	vecs := make([]*vector.Vector, 5)

--- a/pkg/sql/colexec/order/order.go
+++ b/pkg/sql/colexec/order/order.go
@@ -172,11 +172,6 @@ func (order *Order) Call(proc *process.Process) (vm.CallResult, error) {
 		ctr.rbat = nil
 	}
 
-	if ctr.rbat != nil {
-		ctr.rbat.Clean(proc.GetMPool())
-		ctr.rbat = nil
-	}
-
 	if ctr.state == vm.Build {
 		for {
 			input, err := vm.ChildrenCall(order.GetChildren(0), proc, analyzer)

--- a/pkg/sql/colexec/preinsert/preinsert.go
+++ b/pkg/sql/colexec/preinsert/preinsert.go
@@ -144,6 +144,7 @@ func (preInsert *PreInsert) constructColBuf(proc *proc, bat *batch.Batch, first 
 				typ := bat.Vecs[idx].GetType()
 				tmpVec := vector.NewVec(*typ)
 				if err = vector.GetUnionAllFunction(*typ, proc.Mp())(tmpVec, bat.Vecs[idx]); err != nil {
+					tmpVec.Free(proc.Mp())
 					return err
 				}
 				preInsert.ctr.buf.Vecs[idx] = tmpVec

--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -206,6 +206,7 @@ func dupOperator(sourceOp vm.Operator, index int, maxParallel int) vm.Operator {
 		op.NonEqCond = t.NonEqCond
 		op.JoinMapTag = t.JoinMapTag
 		op.JoinType = t.JoinType
+		op.MarkPos = t.MarkPos
 		op.SetInfo(&info)
 		return op
 
@@ -274,6 +275,19 @@ func dupOperator(sourceOp vm.Operator, index int, maxParallel int) vm.Operator {
 			op.TopValueTag = t.TopValueTag + int32(index)<<16
 		}
 		op.Fs = t.Fs
+		op.SetInfo(&info)
+		return op
+	case vm.MergeTop:
+		t := sourceOp.(*mergetop.MergeTop)
+		op := mergetop.NewArgument()
+		op.Limit = t.Limit
+		op.Fs = t.Fs
+		op.SetInfo(&info)
+		return op
+	case vm.MergeOrder:
+		t := sourceOp.(*mergeorder.MergeOrder)
+		op := mergeorder.NewArgument()
+		op.OrderBySpecs = t.OrderBySpecs
 		op.SetInfo(&info)
 		return op
 	case vm.Intersect:
@@ -408,6 +422,7 @@ func dupOperator(sourceOp vm.Operator, index int, maxParallel int) vm.Operator {
 		op := dispatch.NewArgument()
 		op.IsSink = sourceArg.IsSink
 		op.RecSink = sourceArg.RecSink
+		op.RecCTE = sourceArg.RecCTE
 		op.ShuffleType = sourceArg.ShuffleType
 		op.ShuffleRegIdxLocal = sourceArg.ShuffleRegIdxLocal
 		op.ShuffleRegIdxRemote = sourceArg.ShuffleRegIdxRemote
@@ -437,6 +452,11 @@ func dupOperator(sourceOp vm.Operator, index int, maxParallel int) vm.Operator {
 	case vm.PartitionDelete:
 		t := sourceOp.(*deletion.PartitionDelete)
 		op := deletion.NewPartitionDeleteFrom(t)
+		op.SetInfo(&info)
+		return op
+	case vm.PartitionMultiUpdate:
+		t := sourceOp.(*multi_update.PartitionMultiUpdate)
+		op := multi_update.NewPartitionMultiUpdateFrom(t)
 		op.SetInfo(&info)
 		return op
 	case vm.PreInsert:

--- a/pkg/sql/compile/operator_test.go
+++ b/pkg/sql/compile/operator_test.go
@@ -17,8 +17,15 @@ package compile
 import (
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/deletion"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/dispatch"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/insert"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/loopjoin"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/mergeorder"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/mergetop"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/multi_update"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 )
 
 func TestDupOperator(t *testing.T) {
@@ -39,4 +46,68 @@ func TestDupOperator(t *testing.T) {
 		0,
 		0,
 	)
+}
+
+func TestDupOperatorMergeTop(t *testing.T) {
+	op := mergetop.NewArgument()
+	op.Limit = plan2.MakePlan2Int64ConstExprWithType(10)
+	op.Fs = []*plan.OrderBySpec{{Flag: plan.OrderBySpec_DESC}}
+	result := dupOperator(op, 0, 1)
+	if result == nil {
+		t.Fatal("dupOperator returned nil for MergeTop")
+	}
+	dupOp := result.(*mergetop.MergeTop)
+	if dupOp.Limit != op.Limit {
+		t.Errorf("Limit mismatch")
+	}
+}
+
+func TestDupOperatorMergeOrder(t *testing.T) {
+	op := mergeorder.NewArgument()
+	op.OrderBySpecs = []*plan.OrderBySpec{{Flag: plan.OrderBySpec_ASC}}
+	result := dupOperator(op, 0, 1)
+	if result == nil {
+		t.Fatal("dupOperator returned nil for MergeOrder")
+	}
+	dupOp := result.(*mergeorder.MergeOrder)
+	if len(dupOp.OrderBySpecs) != len(op.OrderBySpecs) {
+		t.Errorf("OrderBySpecs length mismatch: got %d, want %d", len(dupOp.OrderBySpecs), len(op.OrderBySpecs))
+	}
+}
+
+func TestDupOperatorPartitionMultiUpdate(t *testing.T) {
+	innerOp := multi_update.NewArgument()
+	op := multi_update.NewPartitionMultiUpdate(innerOp, 1)
+	result := dupOperator(op, 0, 1)
+	if result == nil {
+		t.Fatal("dupOperator returned nil for PartitionMultiUpdate")
+	}
+}
+
+func TestDupOperatorDispatchRecCTE(t *testing.T) {
+	op := dispatch.NewArgument()
+	op.RecCTE = true
+	op.RecSink = true
+	op.IsSink = true
+	result := dupOperator(op, 0, 1)
+	if result == nil {
+		t.Fatal("dupOperator returned nil for Dispatch")
+	}
+	dupOp := result.(*dispatch.Dispatch)
+	if dupOp.RecCTE != op.RecCTE {
+		t.Errorf("RecCTE mismatch: got %v, want %v", dupOp.RecCTE, op.RecCTE)
+	}
+}
+
+func TestDupOperatorLoopJoinMarkPos(t *testing.T) {
+	op := loopjoin.NewArgument()
+	op.MarkPos = 3
+	result := dupOperator(op, 0, 1)
+	if result == nil {
+		t.Fatal("dupOperator returned nil for LoopJoin")
+	}
+	dupOp := result.(*loopjoin.LoopJoin)
+	if dupOp.MarkPos != op.MarkPos {
+		t.Errorf("MarkPos mismatch: got %d, want %d", dupOp.MarkPos, op.MarkPos)
+	}
 }

--- a/pkg/sql/compile/remoterun.go
+++ b/pkg/sql/compile/remoterun.go
@@ -445,6 +445,7 @@ func convertToPipelineInstruction(op vm.Operator, proc *process.Process, ctx *sc
 			NBucket:      t.Nbucket,
 			// deleteCtx
 			RowIdIdx:        int32(t.DeleteCtx.RowIdIdx),
+			CanTruncate:     t.DeleteCtx.CanTruncate,
 			AddAffectedRows: t.DeleteCtx.AddAffectedRows,
 			Ref:             t.DeleteCtx.Ref,
 			PrimaryKeyIdx:   int32(t.DeleteCtx.PrimaryKeyIdx),

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -290,6 +290,38 @@ func Test_convertToVmInstruction(t *testing.T) {
 	}
 }
 
+func Test_DMLOperatorSerializationRoundtrip(t *testing.T) {
+	ctx := &scopeContext{
+		id:     1,
+		root:   &scopeContext{},
+		parent: &scopeContext{},
+	}
+	proc := &process.Process{}
+	proc.Base = &process.BaseProcess{}
+
+	t.Run("Deletion_CanTruncate", func(t *testing.T) {
+		op := &deletion.Deletion{
+			DeleteCtx: &deletion.DeleteCtx{
+				CanTruncate:     true,
+				RowIdIdx:        1,
+				PrimaryKeyIdx:   0,
+				AddAffectedRows: true,
+				Ref:             &plan.ObjectRef{ObjName: "t1"},
+			},
+		}
+		_, pipeInstr, err := convertToPipelineInstruction(op, proc, ctx, 1)
+		require.NoError(t, err)
+		require.True(t, pipeInstr.Delete.CanTruncate)
+
+		restored, err := convertToVmOperator(pipeInstr, ctx, nil)
+		require.NoError(t, err)
+		restoredOp := restored.(*deletion.Deletion)
+		require.True(t, restoredOp.DeleteCtx.CanTruncate)
+		require.Equal(t, 1, restoredOp.DeleteCtx.RowIdIdx)
+		require.Equal(t, 0, restoredOp.DeleteCtx.PrimaryKeyIdx)
+		require.True(t, restoredOp.DeleteCtx.AddAffectedRows)
+	})
+}
 func Test_convertToProcessLimitation(t *testing.T) {
 	lim := pipeline.ProcessLimitation{
 		Size: 100,

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -705,3 +705,52 @@ func Test_checkPipelineStandaloneExecutableAtRemote(t *testing.T) {
 		require.False(t, checkPipelineStandaloneExecutableAtRemote(s0))
 	}
 }
+
+// TestDeletionCanTruncateSerializationRoundtrip verifies that CanTruncate is
+// properly serialized and deserialized when Deletion operators are sent to remote CN.
+func TestDeletionCanTruncateSerializationRoundtrip(t *testing.T) {
+	// Create a Deletion operator with CanTruncate=true
+	arg := deletion.NewArgument()
+	arg.DeleteCtx = &deletion.DeleteCtx{
+		CanTruncate:     true,
+		RowIdIdx:        1,
+		PrimaryKeyIdx:   0,
+		AddAffectedRows: true,
+		Ref:             &plan.ObjectRef{SchemaName: "test", ObjName: "t1"},
+	}
+
+	// Create minimal context for serialization
+	ctx := &scopeContext{
+		id:       0,
+		plan:     &plan.Plan{},
+		scope:    &Scope{},
+		root:     nil,
+		parent:   nil,
+		children: nil,
+		pipe:     nil,
+		regs:     make(map[*process.WaitRegister]int32),
+	}
+	ctx.root = ctx
+
+	// Serialize to pipeline instruction
+	_, in, err := convertToPipelineInstruction(arg, nil, ctx, 0)
+	require.NoError(t, err)
+	require.NotNil(t, in.Delete)
+	require.True(t, in.Delete.CanTruncate, "CanTruncate should be serialized")
+
+	// Deserialize back to operator
+	opr := &pipeline.Instruction{
+		Op:     int32(vm.Deletion),
+		Delete: in.Delete,
+	}
+	op, err := convertToVmOperator(opr, ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, op)
+
+	restored := op.(*deletion.Deletion)
+	require.NotNil(t, restored.DeleteCtx)
+	require.True(t, restored.DeleteCtx.CanTruncate, "CanTruncate should be deserialized")
+	require.Equal(t, 1, restored.DeleteCtx.RowIdIdx)
+	require.Equal(t, 0, restored.DeleteCtx.PrimaryKeyIdx)
+	require.True(t, restored.DeleteCtx.AddAffectedRows)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24000 

## What this PR does / why we need it:

This PR fixes several bugs found during the DML and multi-CN execution-path audit, and adds focused regression tests to keep the related coverage above the required threshold.

It includes the following fixes:

- add missing `dupOperator()` cases and field copies for `MergeTop`, `MergeOrder`, `PartitionMultiUpdate`, `Dispatch.RecCTE`, and `LoopJoin.MarkPos`
- preserve `Deletion.DeleteCtx.CanTruncate` during remote pipeline serialization
- include `PartitionColIdxInBat` in `LockOp.CopyToPipelineTarget()`
- avoid leaking partially-created aggregators in `group.makeAggList()` error paths
- clean `newBatch` on `ON DUPLICATE KEY IGNORE` conflict-skip path
- return early when `s3WriterDelegate.addBatchToOutput()` fails in the delete-block loop
- remove the duplicate `ctr.rbat` cleanup block in `order.Call()`
- add/adjust targeted unit tests for the changed logic above

These changes are needed to prevent parallel execution panics, preserve DML semantics in distributed execution, fix memory-leak / cleanup issues, and make the PR coverage meet the requested 75%+ level.
