### PR TITLE
fix: harden batched DML/DDL and remote-run correctness paths

### DIFF
--- a/pkg/partitionprune/prune_test.go
+++ b/pkg/partitionprune/prune_test.go
@@ -335,6 +335,25 @@ func TestPrune(t *testing.T) {
 		_, err := Prune(proc, bat, metadata, -1)
 		require.Error(t, err)
 	})
+
+	t.Run("all rows miss partitions returns invalid input before empty result", func(t *testing.T) {
+		metadata := partition.PartitionMetadata{
+			Partitions: []partition.Partition{
+				{
+					Expr: &plan.Expr{
+						Typ: plan.Type{Id: int32(types.T_bool)},
+						Expr: &plan.Expr_Lit{
+							Lit: &plan.Literal{Value: &plan.Literal_Bval{Bval: false}},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := Prune(proc, bat, metadata, -1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Table has no partition for value from column_list")
+	})
 }
 
 func batchCount(result partitionservice.PruneResult) int {

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -2001,21 +2001,13 @@ func (s *Scope) CreateIndex(c *Compile) error {
 	}
 
 	for _, p := range metadata.Partitions {
-		q := *qry
-		q.Table = p.PartitionTableName
-		r, err := dbSource.Relation(c.proc.Ctx, q.Table, nil)
+		r, err := dbSource.Relation(c.proc.Ctx, p.PartitionTableName, nil)
 		if err != nil {
 			return err
 		}
-		q.TableDef = r.CopyTableDef(c.proc.Ctx)
-		for _, def := range q.Index.IndexTables {
-			def.Name = fmt.Sprintf("%s_%s", def.Name, p.Name)
-		}
-		for _, def := range q.Index.TableDef.Indexes {
-			def.IndexTableName = fmt.Sprintf("%s_%s", def.IndexTableName, p.Name)
-		}
+		q := cloneCreateIndexForPartition(qry, p.PartitionTableName, p.Name, r.CopyTableDef(c.proc.Ctx))
 
-		err = s.doCreateIndex(c, &q, dbSource, r)
+		err = s.doCreateIndex(c, q, dbSource, r)
 		if err != nil {
 			return err
 		}
@@ -2680,24 +2672,56 @@ func (s *Scope) TruncateTable(c *Compile) error {
 		if err != nil {
 			return err
 		}
-		for _, ct := range oldCt.Cts {
-			if def, ok := ct.(*engine.RefChildTableDef); ok {
-				for idx, refTable := range def.Tables {
-					if refTable == oldID {
-						def.Tables[idx] = newID
-						break
-					}
-				}
-				break
+		if updateRefChildTableConstraintIDs(oldCt, oldID, newID) {
+			err = fkRelation.UpdateConstraint(c.proc.Ctx, oldCt)
+			if err != nil {
+				return err
 			}
-		}
-		err = fkRelation.UpdateConstraint(c.proc.Ctx, oldCt)
-		if err != nil {
-			return err
 		}
 	}
 
 	return nil
+}
+
+func cloneCreateIndexForPartition(
+	qry *plan.CreateIndex,
+	partitionTableName string,
+	partitionName string,
+	tableDef *plan.TableDef,
+) *plan.CreateIndex {
+	dd := &plan.DataDefinition{
+		DdlType: plan.DataDefinition_CREATE_INDEX,
+		Definition: &plan.DataDefinition_CreateIndex{
+			CreateIndex: qry,
+		},
+	}
+	cloned := plan2.DeepCopyDataDefinition(dd).Definition.(*plan.DataDefinition_CreateIndex).CreateIndex
+	cloned.Table = partitionTableName
+	cloned.TableDef = tableDef
+	for _, def := range cloned.Index.IndexTables {
+		def.Name = fmt.Sprintf("%s_%s", def.Name, partitionName)
+	}
+	for _, def := range cloned.Index.TableDef.Indexes {
+		def.IndexTableName = fmt.Sprintf("%s_%s", def.IndexTableName, partitionName)
+	}
+	return cloned
+}
+
+func updateRefChildTableConstraintIDs(ct *engine.ConstraintDef, oldID, newID uint64) bool {
+	updated := false
+	for _, c := range ct.Cts {
+		def, ok := c.(*engine.RefChildTableDef)
+		if !ok {
+			continue
+		}
+		for idx, refTable := range def.Tables {
+			if refTable == oldID {
+				def.Tables[idx] = newID
+				updated = true
+			}
+		}
+	}
+	return updated
 }
 
 func (s *Scope) DropSequence(c *Compile) error {

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/buffer"
@@ -46,6 +47,62 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
+
+func TestCloneCreateIndexForPartitionDeepCopiesIndexMetadata(t *testing.T) {
+	qry := &plan2.CreateIndex{
+		Table: "source_table",
+		Index: &plan2.CreateTable{
+			TableDef: &plan2.TableDef{
+				Name: "idx_meta",
+				Indexes: []*plan2.IndexDef{
+					{IndexTableName: "idx_table"},
+				},
+			},
+			IndexTables: []*plan2.TableDef{
+				{Name: "idx_table"},
+			},
+		},
+	}
+	partitionTableDef := &plan2.TableDef{Name: "partition_table"}
+
+	cloned := cloneCreateIndexForPartition(qry, "partition_table", "p1", partitionTableDef)
+
+	require.Equal(t, "partition_table", cloned.Table)
+	require.Same(t, partitionTableDef, cloned.TableDef)
+	require.Equal(t, "idx_table_p1", cloned.Index.IndexTables[0].Name)
+	require.Equal(t, "idx_table_p1", cloned.Index.TableDef.Indexes[0].IndexTableName)
+	require.Equal(t, "source_table", qry.Table)
+	require.Equal(t, "idx_table", qry.Index.IndexTables[0].Name)
+	require.Equal(t, "idx_table", qry.Index.TableDef.Indexes[0].IndexTableName)
+}
+
+func TestUpdateRefChildTableConstraintIDsUpdatesAllMatches(t *testing.T) {
+	ct := &engine.ConstraintDef{
+		Cts: []engine.Constraint{
+			&engine.RefChildTableDef{Tables: []uint64{10, 20, 10}},
+			&engine.RefChildTableDef{Tables: []uint64{30, 10}},
+		},
+	}
+
+	updated := updateRefChildTableConstraintIDs(ct, 10, 99)
+
+	require.True(t, updated)
+	require.Equal(t, []uint64{99, 20, 99}, ct.Cts[0].(*engine.RefChildTableDef).Tables)
+	require.Equal(t, []uint64{30, 99}, ct.Cts[1].(*engine.RefChildTableDef).Tables)
+}
+
+func TestUpdateRefChildTableConstraintIDsReturnsFalseWithoutMatch(t *testing.T) {
+	ct := &engine.ConstraintDef{
+		Cts: []engine.Constraint{
+			&engine.RefChildTableDef{Tables: []uint64{10, 20}},
+		},
+	}
+
+	updated := updateRefChildTableConstraintIDs(ct, 99, 77)
+
+	require.False(t, updated)
+	require.Equal(t, []uint64{10, 20}, ct.Cts[0].(*engine.RefChildTableDef).Tables)
+}
 
 func Test_lockIndexTable(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/sql/compile/operator_test.go
+++ b/pkg/sql/compile/operator_test.go
@@ -25,7 +25,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/mergeorder"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/mergetop"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/multi_update"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/shuffle"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/shuffleV2"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDupOperator(t *testing.T) {
@@ -110,4 +113,28 @@ func TestDupOperatorLoopJoinMarkPos(t *testing.T) {
 	if dupOp.MarkPos != op.MarkPos {
 		t.Errorf("MarkPos mismatch: got %d, want %d", dupOp.MarkPos, op.MarkPos)
 	}
+}
+
+func TestDupOperatorShuffleSharesPoolAcrossWorkers(t *testing.T) {
+	op := shuffle.NewArgument()
+	op.BucketNum = 4
+
+	dup1 := dupOperator(op, 0, 2).(*shuffle.Shuffle)
+	dup2 := dupOperator(op, 1, 2).(*shuffle.Shuffle)
+
+	require.NotNil(t, op.GetShufflePool())
+	require.Same(t, op.GetShufflePool(), dup1.GetShufflePool())
+	require.Same(t, op.GetShufflePool(), dup2.GetShufflePool())
+}
+
+func TestDupOperatorShuffleV2SharesPoolAcrossWorkers(t *testing.T) {
+	op := shuffleV2.NewArgument()
+	op.BucketNum = 4
+
+	dup1 := dupOperator(op, 0, 2).(*shuffleV2.ShuffleV2)
+	dup2 := dupOperator(op, 1, 2).(*shuffleV2.ShuffleV2)
+
+	require.NotNil(t, op.GetShufflePool())
+	require.Same(t, op.GetShufflePool(), dup1.GetShufflePool())
+	require.Same(t, op.GetShufflePool(), dup2.GetShufflePool())
 }

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -173,31 +173,10 @@ func checkPipelineStandaloneExecutableAtRemote(s *Scope) bool {
 }
 
 func prepareRemoteRunSendingData(sqlStr string, s *Scope) (scopeData []byte, withoutOutput bool, processData []byte, err error) {
-	// if simpleRun is true, it indicates that this pipeline will not produce any output.
-	withoutOutput = true
-
-	// if the last operator is a sender operator, we need to keep it in local for sending batch to its receivers correctly.
-	if lastOpType := s.RootOp.OpType(); lastOpType == vm.Connector || lastOpType == vm.Dispatch {
-		withoutOutput = false
-
-		originRoot := s.RootOp
-		if originRoot.GetOperatorBase().NumChildren() == 0 {
-			s.RootOp = nil
-		} else {
-			s.RootOp = originRoot.GetOperatorBase().GetChildren(0)
-		}
-
-		// todo: the following code to set children to nil must be a bug.
-		// 		but I kept it here because there will be an operator release twice bug once I remove this code.
-		//		I cannot find it why, maybe two scopes hold the same operator list pointer.
-		originRoot.GetOperatorBase().SetChildren(nil)
-		defer func() {
-			s.doSetRootOperator(originRoot)
-		}()
-	}
+	encodedScope, withoutOutput := getScopeForRemoteRunEncoding(s)
 
 	// Encode the ScopeList which need to be sent.
-	if scopeData, err = encodeScope(s); err != nil {
+	if scopeData, err = encodeScope(encodedScope); err != nil {
 		return nil, false, nil, err
 	}
 
@@ -283,20 +262,16 @@ func receiveMessageFromCnServerIfDispatch(s *Scope, sender *messageSenderOnClien
 	if err = fakeValueScanOperator.Prepare(s.Proc); err != nil {
 		return err
 	}
-
-	oldChildren := arg.Children
-	arg.Children = nil
-	arg.AppendChild(fakeValueScanOperator)
+	dispatchRunner := buildRemoteDispatchReceiverRoot(arg, fakeValueScanOperator)
 	defer func() {
-		arg.Children = oldChildren
 		fakeValueScanOperator.Batchs = nil
 		fakeValueScanOperator.Release()
 	}()
 
-	if err = s.RootOp.Prepare(s.Proc); err != nil {
+	if err = dispatchRunner.Prepare(s.Proc); err != nil {
 		return err
 	}
-	dispatchAnalyze := s.RootOp.GetOperatorBase().OpAnalyzer
+	dispatchAnalyze := dispatchRunner.GetOperatorBase().OpAnalyzer
 
 	mp := s.Proc.Mp()
 	for {
@@ -308,12 +283,47 @@ func receiveMessageFromCnServerIfDispatch(s *Scope, sender *messageSenderOnClien
 		dispatchAnalyze.Network(bat)
 		fakeValueScanOperator.Batchs = append(fakeValueScanOperator.Batchs, bat)
 
-		result, errCall := vm.Exec(s.RootOp, s.Proc)
+		result, errCall := vm.Exec(dispatchRunner, s.Proc)
 		bat.Clean(mp)
 		if errCall != nil || result.Status == vm.ExecStop {
 			return errCall
 		}
 	}
+}
+
+func getScopeForRemoteRunEncoding(s *Scope) (*Scope, bool) {
+	withoutOutput := true
+	if s.RootOp == nil {
+		return s, withoutOutput
+	}
+
+	if lastOpType := s.RootOp.OpType(); lastOpType == vm.Connector || lastOpType == vm.Dispatch {
+		withoutOutput = false
+		copied := *s
+		if s.RootOp.GetOperatorBase().NumChildren() == 0 {
+			copied.RootOp = nil
+		} else {
+			copied.RootOp = s.RootOp.GetOperatorBase().GetChildren(0)
+		}
+		return &copied, withoutOutput
+	}
+	return s, withoutOutput
+}
+
+func buildRemoteDispatchReceiverRoot(arg *dispatch.Dispatch, child vm.Operator) *dispatch.Dispatch {
+	copied := dispatch.NewArgument()
+	copied.IsSink = arg.IsSink
+	copied.RecSink = arg.RecSink
+	copied.RecCTE = arg.RecCTE
+	copied.ShuffleType = arg.ShuffleType
+	copied.FuncId = arg.FuncId
+	copied.LocalRegs = arg.LocalRegs
+	copied.RemoteRegs = arg.RemoteRegs
+	copied.ShuffleRegIdxLocal = arg.ShuffleRegIdxLocal
+	copied.ShuffleRegIdxRemote = arg.ShuffleRegIdxRemote
+	copied.OperatorBase.OperatorInfo = arg.OperatorBase.OperatorInfo
+	copied.AppendChild(child)
+	return copied
 }
 
 // messageSenderOnClient support a series of methods

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -633,6 +633,8 @@ func Test_prepareRemoteRunSendingData(t *testing.T) {
 	_, withoutOut, _, err := prepareRemoteRunSendingData("", s1)
 	require.NoError(t, err)
 	require.False(t, withoutOut)
+	require.NotNil(t, s1.RootOp)
+	require.Equal(t, vm.Connector, s1.RootOp.OpType())
 
 	// if this is a pipeline with operator list "scan -> connector / dispatch".
 	// this should return withoutOut == false.
@@ -641,9 +643,12 @@ func Test_prepareRemoteRunSendingData(t *testing.T) {
 		RootOp: dispatch.NewArgument(),
 	}
 	s2.RootOp.AppendChild(value_scan.NewArgument())
+	originChild := s2.RootOp.GetOperatorBase().GetChildren(0)
 	_, withoutOut, _, err = prepareRemoteRunSendingData("", s2)
 	require.NoError(t, err)
 	require.False(t, withoutOut)
+	require.Equal(t, 1, s2.RootOp.GetOperatorBase().NumChildren())
+	require.Same(t, originChild, s2.RootOp.GetOperatorBase().GetChildren(0))
 
 	// if this is a pipeline no need to sent back message, like "scan -> scan".
 	// this should return withoutOut == true.
@@ -655,6 +660,37 @@ func Test_prepareRemoteRunSendingData(t *testing.T) {
 	_, withoutOut, _, err = prepareRemoteRunSendingData("", s3)
 	require.NoError(t, err)
 	require.True(t, withoutOut)
+}
+
+func TestGetScopeForRemoteRunEncodingDoesNotMutateOriginalScope(t *testing.T) {
+	root := dispatch.NewArgument()
+	child := value_scan.NewArgument()
+	root.AppendChild(child)
+	s := &Scope{RootOp: root}
+
+	encoded, withoutOutput := getScopeForRemoteRunEncoding(s)
+
+	require.False(t, withoutOutput)
+	require.Same(t, root, s.RootOp)
+	require.Equal(t, 1, s.RootOp.GetOperatorBase().NumChildren())
+	require.Same(t, child, s.RootOp.GetOperatorBase().GetChildren(0))
+	require.NotSame(t, s, encoded)
+	require.Same(t, child, encoded.RootOp)
+}
+
+func TestBuildRemoteDispatchReceiverRootDoesNotMutateOriginalChildren(t *testing.T) {
+	origin := dispatch.NewArgument()
+	originChild := value_scan.NewArgument()
+	fakeChild := value_scan.NewArgument()
+	origin.AppendChild(originChild)
+
+	cloned := buildRemoteDispatchReceiverRoot(origin, fakeChild)
+
+	require.NotSame(t, origin, cloned)
+	require.Equal(t, 1, origin.GetOperatorBase().NumChildren())
+	require.Same(t, originChild, origin.GetOperatorBase().GetChildren(0))
+	require.Equal(t, 1, cloned.GetOperatorBase().NumChildren())
+	require.Same(t, fakeChild, cloned.GetOperatorBase().GetChildren(0))
 }
 
 func Test_MessageSenderSendPipeline(t *testing.T) {

--- a/pkg/sql/plan/build_dml_util_test.go
+++ b/pkg/sql/plan/build_dml_util_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/common/buffer"
@@ -123,4 +124,53 @@ func TestBuildWithInsert(t *testing.T) {
 			require.Greater(t, len(ins.With.CTEs), 0, "WITH clause should have at least one CTE")
 		})
 	}
+}
+
+func TestBuildInsertOnDuplicateUpdatePlansReleasesDmlPlanCtxOnError(t *testing.T) {
+	oldGet := buildInsertGetDmlPlanCtx
+	oldPut := buildInsertPutDmlPlanCtx
+	oldBuild := buildInsertUpdatePlans
+	defer func() {
+		buildInsertGetDmlPlanCtx = oldGet
+		buildInsertPutDmlPlanCtx = oldPut
+		buildInsertUpdatePlans = oldBuild
+	}()
+
+	wantErr := moerr.NewInternalErrorNoCtx("build update plans failed")
+	ctxHolder := &dmlPlanCtx{}
+	putCalled := false
+
+	buildInsertGetDmlPlanCtx = func() *dmlPlanCtx {
+		return ctxHolder
+	}
+	buildInsertPutDmlPlanCtx = func(ctx *dmlPlanCtx) {
+		putCalled = true
+		require.Same(t, ctxHolder, ctx)
+	}
+	buildInsertUpdatePlans = func(ctx CompilerContext, builder *QueryBuilder, bindCtx *BindContext, updatePlanCtx *dmlPlanCtx, addAffectedRows bool) error {
+		require.Same(t, ctxHolder, updatePlanCtx)
+		require.Equal(t, int32(7), updatePlanCtx.sourceStep)
+		require.Equal(t, 3, updatePlanCtx.updateColLength)
+		require.Equal(t, 2, updatePlanCtx.rowIdPos)
+		require.Equal(t, []int{4, 5}, updatePlanCtx.insertColPos)
+		require.Equal(t, map[string]int{"a": 1}, updatePlanCtx.updateColPosMap)
+		require.True(t, updatePlanCtx.updatePkCol)
+		require.True(t, addAffectedRows)
+		return wantErr
+	}
+
+	err := buildInsertOnDuplicateUpdatePlans(
+		nil,
+		nil,
+		&ObjectRef{ObjName: "t"},
+		&TableDef{Name: "t"},
+		7,
+		3,
+		2,
+		[]int{4, 5},
+		map[string]int{"a": 1},
+		true,
+	)
+	require.ErrorIs(t, err, wantErr)
+	require.True(t, putCalled)
 }

--- a/pkg/sql/plan/build_insert.go
+++ b/pkg/sql/plan/build_insert.go
@@ -297,24 +297,21 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 		sourceStep = builder.appendStep(lastNodeId)
 
 		// append plans like update
-		updateBindCtx := NewBindContext(builder, nil)
-		upPlanCtx := getDmlPlanCtx()
-		upPlanCtx.objRef = objRef
-		upPlanCtx.tableDef = tableDef
-		upPlanCtx.beginIdx = 0
-		upPlanCtx.sourceStep = sourceStep
-		upPlanCtx.isMulti = false
-		upPlanCtx.updateColLength = updateColLength
-		upPlanCtx.rowIdPos = rowIdPos
-		upPlanCtx.insertColPos = insertColPos
-		upPlanCtx.updateColPosMap = updateColPosMap
-		upPlanCtx.updatePkCol = updatePkCol
-
-		err = buildUpdatePlans(ctx, builder, updateBindCtx, upPlanCtx, true)
+		err = buildInsertOnDuplicateUpdatePlans(
+			ctx,
+			builder,
+			objRef,
+			tableDef,
+			sourceStep,
+			updateColLength,
+			rowIdPos,
+			insertColPos,
+			updateColPosMap,
+			updatePkCol,
+		)
 		if err != nil {
 			return nil, err
 		}
-		putDmlPlanCtx(upPlanCtx)
 
 		query.StmtType = plan.Query_UPDATE
 	} else {
@@ -339,6 +336,40 @@ func buildInsert(stmt *tree.Insert, ctx CompilerContext, isReplace bool, isPrepa
 			Query: query,
 		},
 	}, err
+}
+
+var buildInsertGetDmlPlanCtx = getDmlPlanCtx
+var buildInsertPutDmlPlanCtx = putDmlPlanCtx
+var buildInsertUpdatePlans = buildUpdatePlans
+
+func buildInsertOnDuplicateUpdatePlans(
+	ctx CompilerContext,
+	builder *QueryBuilder,
+	objRef *ObjectRef,
+	tableDef *TableDef,
+	sourceStep int32,
+	updateColLength int,
+	rowIdPos int,
+	insertColPos []int,
+	updateColPosMap map[string]int,
+	updatePkCol bool,
+) error {
+	updateBindCtx := NewBindContext(builder, nil)
+	upPlanCtx := buildInsertGetDmlPlanCtx()
+	defer buildInsertPutDmlPlanCtx(upPlanCtx)
+
+	upPlanCtx.objRef = objRef
+	upPlanCtx.tableDef = tableDef
+	upPlanCtx.beginIdx = 0
+	upPlanCtx.sourceStep = sourceStep
+	upPlanCtx.isMulti = false
+	upPlanCtx.updateColLength = updateColLength
+	upPlanCtx.rowIdPos = rowIdPos
+	upPlanCtx.insertColPos = insertColPos
+	upPlanCtx.updateColPosMap = updateColPosMap
+	upPlanCtx.updatePkCol = updatePkCol
+
+	return buildInsertUpdatePlans(ctx, builder, updateBindCtx, upPlanCtx, true)
 }
 
 // ------------------- pk filter relatived -------------------

--- a/pkg/sql/plan/deepcopy.go
+++ b/pkg/sql/plan/deepcopy.go
@@ -742,13 +742,17 @@ func DeepCopyDataDefinition(old *plan.DataDefinition) *plan.DataDefinition {
 			CreateIndex: &plan.CreateIndex{
 				Database: df.CreateIndex.Database,
 				Table:    df.CreateIndex.Table,
+				TableDef: DeepCopyTableDef(df.CreateIndex.TableDef, true),
 				Index: &plan.CreateTable{
 					IfNotExists: df.CreateIndex.Index.IfNotExists,
 					Temporary:   df.CreateIndex.Index.Temporary,
 					Database:    df.CreateIndex.Index.Database,
+					Replace:     df.CreateIndex.Index.Replace,
 					TableDef:    DeepCopyTableDef(df.CreateIndex.Index.TableDef, true),
+					IndexTables: DeepCopyTableDefList(df.CreateIndex.Index.GetIndexTables()),
 				},
 				OriginTablePrimaryKey: df.CreateIndex.OriginTablePrimaryKey,
+				TableExist:            df.CreateIndex.TableExist,
 			},
 		}
 


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix
- [x] Tests

## Which issue(s) this PR fixes:

Fixes #24004

## What this PR does / why we need it:

This PR lands the first batched fix set from #24004 and focuses on the items with a concrete, code-backed repro/fix path.

It makes `INSERT ... ON DUPLICATE KEY UPDATE` planning always release `dmlPlanCtx` even when `buildUpdatePlans` fails, so the pooled context is not leaked on the error path.

It hardens DDL metadata handling in two places: partitioned `CREATE INDEX` now deep-copies per-partition index metadata before renaming index tables, and `TRUNCATE TABLE` now rewrites all matching `RefChildTableDef` references instead of stopping after the first hit.

It also removes two in-place mutation windows from remote-run handling: `prepareRemoteRunSendingData` now encodes a copied scope rather than mutating `Scope.RootOp`, and the dispatch receive path now runs a fresh dispatch runner instead of swapping the original dispatch children in place.

Regression tests were added for all of the above paths. Items that were re-triaged as design-intent or still needing a stronger repro (such as shared shuffle pool and the partition-prune panic guard) were intentionally kept out of this PR.