### PR TITLE
fix: stabilize table-scoped DDL errors after concurrent db drop

### DIFF
--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -46,6 +46,13 @@ func convertDBEOB(ctx context.Context, e error, name string) error {
 	return e
 }
 
+func convertDBEOBToNoSuchTable(ctx context.Context, e error, dbName, tblName string) error {
+	if moerr.IsMoErrCode(e, moerr.OkExpectedEOB) {
+		return moerr.NewNoSuchTable(ctx, dbName, tblName)
+	}
+	return e
+}
+
 func (s *Scope) AlterTableCopy(c *Compile) error {
 	qry := s.Plan.GetDdl().GetAlterTable()
 	dbName := qry.Database
@@ -56,7 +63,7 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 	tblName := qry.GetTableDef().GetName()
 	dbSource, err := c.e.Database(c.proc.Ctx, dbName, c.proc.GetTxnOperator())
 	if err != nil {
-		return convertDBEOB(c.proc.Ctx, err, dbName)
+		return convertDBEOBToNoSuchTable(c.proc.Ctx, err, dbName, tblName)
 	}
 
 	accountId, err := defines.GetAccountId(c.proc.Ctx)

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -1962,10 +1962,10 @@ func (s *Scope) CreateIndex(c *Compile) error {
 		if qry.GetDatabase() != "" {
 			dbName = qry.GetDatabase()
 		}
-		if err := lockMoDatabase(c, dbName, lock.LockMode_Shared); err != nil {
-			return convertDBEOB(c.proc.Ctx, err, dbName)
-		}
 		tblName := qry.GetTableDef().GetName()
+		if err := lockMoDatabase(c, dbName, lock.LockMode_Shared); err != nil {
+			return convertDBEOBToNoSuchTable(c.proc.Ctx, err, dbName, tblName)
+		}
 		if err := lockMoTable(c, dbName, tblName, lock.LockMode_Exclusive); err != nil {
 			return err
 		}
@@ -1973,7 +1973,7 @@ func (s *Scope) CreateIndex(c *Compile) error {
 
 	dbSource, err := c.e.Database(c.proc.Ctx, qry.Database, c.proc.GetTxnOperator())
 	if err != nil {
-		return convertDBEOB(c.proc.Ctx, err, qry.Database)
+		return convertDBEOBToNoSuchTable(c.proc.Ctx, err, qry.Database, qry.Table)
 	}
 
 	r, err := dbSource.Relation(c.proc.Ctx, qry.Table, nil)
@@ -2298,7 +2298,7 @@ func (s *Scope) DropIndex(c *Compile) error {
 	}
 	d, err := c.e.Database(c.proc.Ctx, qry.Database, c.proc.GetTxnOperator())
 	if err != nil {
-		return convertDBEOB(c.proc.Ctx, err, qry.Database)
+		return convertDBEOBToNoSuchTable(c.proc.Ctx, err, qry.Database, qry.Table)
 	}
 	r, err := d.Relation(c.proc.Ctx, qry.Table, nil)
 	if err != nil {
@@ -2806,7 +2806,7 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 		if qry.GetIfExists() {
 			return nil
 		}
-		return convertDBEOB(c.proc.Ctx, err, dbName)
+		return convertDBEOBToNoSuchTable(c.proc.Ctx, err, dbName, tblName)
 	}
 
 	if rel, err = dbSource.Relation(c.proc.Ctx, tblName, nil); err != nil {

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -420,7 +420,7 @@ func (s *Scope) AlterTableInplace(c *Compile) error {
 	isTemp := qry.GetTableDef().GetIsTemporary()
 	dbSource, err := c.e.Database(c.proc.Ctx, dbName, c.proc.GetTxnOperator())
 	if err != nil {
-		return convertDBEOB(c.proc.Ctx, err, dbName)
+		return convertDBEOBToNoSuchTable(c.proc.Ctx, err, dbName, tblName)
 	}
 	databaseId := dbSource.GetDatabaseId(c.proc.Ctx)
 

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/buffer"
@@ -47,6 +48,17 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
+func TestConvertDBEOBToNoSuchTable(t *testing.T) {
+	err := convertDBEOBToNoSuchTable(context.Background(), moerr.GetOkExpectedEOB(), "db1", "t2")
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable))
+	require.Contains(t, err.Error(), "no such table db1.t2")
+}
+
+func TestConvertDBEOBToNoSuchTablePassThrough(t *testing.T) {
+	want := moerr.NewBadDB(context.Background(), "db1")
+	got := convertDBEOBToNoSuchTable(context.Background(), want, "db1", "t2")
+	require.Same(t, want, got)
+}
 func Test_lockIndexTable(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -59,6 +59,125 @@ func TestConvertDBEOBToNoSuchTablePassThrough(t *testing.T) {
 	got := convertDBEOBToNoSuchTable(context.Background(), want, "db1", "t2")
 	require.Same(t, want, got)
 }
+
+func TestTableScopedDDLDatabaseEOBMapsToNoSuchTable(t *testing.T) {
+	newCompileWithStubEngine := func(t *testing.T, eng *stubEngine, sql string) *Compile {
+		t.Helper()
+		proc := testutil.NewProcess(t)
+		proc.Base.SessionInfo.Buf = buffer.New()
+		proc.Ctx = defines.AttachAccountId(context.Background(), sysAccountId)
+		return NewCompile("test", "db1", sql, "", "", eng, proc, nil, false, nil, time.Now())
+	}
+
+	t.Run("AlterTableInplace", func(t *testing.T) {
+		eng := newStubEngine()
+		eng.dbErr = moerr.GetOkExpectedEOB()
+		s := &Scope{Plan: &plan2.Plan{Plan: &plan2.Plan_Ddl{Ddl: &plan2.DataDefinition{
+			Definition: &plan2.DataDefinition_AlterTable{
+				AlterTable: &plan2.AlterTable{
+					Database: "db1",
+					TableDef: &plan2.TableDef{Name: "t2"},
+				},
+			},
+		}}}}
+
+		err := s.AlterTableInplace(newCompileWithStubEngine(t, eng, "alter table t2 add b int"))
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable))
+	})
+
+	t.Run("AlterTableCopy", func(t *testing.T) {
+		eng := newStubEngine()
+		eng.dbErr = moerr.GetOkExpectedEOB()
+		s := &Scope{Plan: &plan2.Plan{Plan: &plan2.Plan_Ddl{Ddl: &plan2.DataDefinition{
+			Definition: &plan2.DataDefinition_AlterTable{
+				AlterTable: &plan2.AlterTable{
+					Database: "db1",
+					TableDef: &plan2.TableDef{Name: "t2"},
+				},
+			},
+		}}}}
+
+		err := s.AlterTableCopy(newCompileWithStubEngine(t, eng, "alter table t2 add b int"))
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable))
+	})
+
+	t.Run("CreateIndexDatabaseLookup", func(t *testing.T) {
+		eng := newStubEngine()
+		eng.dbErr = moerr.GetOkExpectedEOB()
+		s := &Scope{Plan: &plan2.Plan{Plan: &plan2.Plan_Ddl{Ddl: &plan2.DataDefinition{
+			Definition: &plan2.DataDefinition_CreateIndex{
+				CreateIndex: &plan2.CreateIndex{
+					Database: "db1",
+					Table:    "t2",
+					TableDef: &plan2.TableDef{Name: "t2"},
+				},
+			},
+		}}}}
+
+		lockMoDb := gostub.Stub(&lockMoDatabase, func(_ *Compile, _ string, _ lock.LockMode) error { return nil })
+		defer lockMoDb.Reset()
+		lockMoTbl := gostub.Stub(&lockMoTable, func(_ *Compile, _ string, _ string, _ lock.LockMode) error { return nil })
+		defer lockMoTbl.Reset()
+
+		err := s.CreateIndex(newCompileWithStubEngine(t, eng, "create index t2_idx on t2(a)"))
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable))
+	})
+
+	t.Run("CreateIndexLockDatabase", func(t *testing.T) {
+		eng := newStubEngine()
+		s := &Scope{Plan: &plan2.Plan{Plan: &plan2.Plan_Ddl{Ddl: &plan2.DataDefinition{
+			Definition: &plan2.DataDefinition_CreateIndex{
+				CreateIndex: &plan2.CreateIndex{
+					Database: "db1",
+					Table:    "t2",
+					TableDef: &plan2.TableDef{Name: "t2"},
+				},
+			},
+		}}}}
+
+		lockMoDb := gostub.Stub(&lockMoDatabase, func(_ *Compile, _ string, _ lock.LockMode) error {
+			return moerr.GetOkExpectedEOB()
+		})
+		defer lockMoDb.Reset()
+
+		err := s.CreateIndex(newCompileWithStubEngine(t, eng, "create index t2_idx on t2(a)"))
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable))
+	})
+
+	t.Run("DropIndex", func(t *testing.T) {
+		eng := newStubEngine()
+		eng.dbErr = moerr.GetOkExpectedEOB()
+		s := &Scope{Plan: &plan2.Plan{Plan: &plan2.Plan_Ddl{Ddl: &plan2.DataDefinition{
+			Definition: &plan2.DataDefinition_DropIndex{
+				DropIndex: &plan2.DropIndex{
+					Database:  "db1",
+					Table:     "t2",
+					IndexName: "t2_idx",
+				},
+			},
+		}}}}
+
+		lockMoDb := gostub.Stub(&lockMoDatabase, func(_ *Compile, _ string, _ lock.LockMode) error { return nil })
+		defer lockMoDb.Reset()
+
+		err := s.DropIndex(newCompileWithStubEngine(t, eng, "drop index t2_idx on t2"))
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable))
+	})
+
+	t.Run("DropTableSingle", func(t *testing.T) {
+		eng := newStubEngine()
+		eng.dbErr = moerr.GetOkExpectedEOB()
+		c := newCompileWithStubEngine(t, eng, "drop table t2")
+		s := &Scope{}
+		lockMoDb := gostub.Stub(&lockMoDatabase, func(_ *Compile, _ string, _ lock.LockMode) error { return nil })
+		defer lockMoDb.Reset()
+		err := s.dropTableSingle(c, &plan2.DropTable{
+			Database: "db1",
+			Table:    "t2",
+		})
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable))
+	})
+}
 func Test_lockIndexTable(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/sql/compile/stub_engine_test.go
+++ b/pkg/sql/compile/stub_engine_test.go
@@ -26,7 +26,8 @@ import (
 
 type stubEngine struct {
 	engine.Engine
-	dbs map[string]*stubDatabase
+	dbs   map[string]*stubDatabase
+	dbErr error
 }
 
 func newStubEngine() *stubEngine {
@@ -40,6 +41,9 @@ func newStubEngine() *stubEngine {
 }
 
 func (e *stubEngine) Database(ctx context.Context, name string, op client.TxnOperator) (engine.Database, error) {
+	if e.dbErr != nil {
+		return nil, e.dbErr
+	}
 	if db, ok := e.dbs[name]; ok {
 		return db, nil
 	}


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix
- [x] Tests

## Which issue(s) this PR fixes:

Fixes #24007

## What this PR does / why we need it:

This fixes a sporadic main-branch failure in `test/distributed/cases/pessimistic_transaction/ddl_atomicity.sql`.

When a concurrent `DROP DATABASE` causes table-scoped DDL to see `OkExpectedEOB` while resolving the target database, different compile paths were mapping the same race to different SQL errors. Some returned `Unknown database db1`, while others reached the later table lookup and returned `no such table db1.t2`, which made the result timing-dependent.

This PR introduces a table-scoped conversion helper and applies it to all relevant table-scoped DDL entry points involved in that script: `ALTER TABLE` (both inplace/copy resolution points that hit `Engine.Database()`), `CREATE INDEX`, `DROP INDEX`, and `DROP TABLE`. As a result, these operations now consistently surface `ErrNoSuchTable` for the referenced table after the database disappears.

A focused unit test was added to lock the conversion behavior in.