### PR TITLE
fix: harden remote pipeline error propagation

### DIFF
--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -18,8 +18,10 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
@@ -281,6 +283,114 @@ func Test_sendToAnyRemoteFunc_NetworkError(t *testing.T) {
 	t.Log("Network error path: lines 319-322 in sendfunc.go")
 	t.Log("Behavior: err != nil causes immediate return without retry")
 	t.Log("Covered by integration tests with real network stack")
+}
+
+func TestSendToAnyFunc_PropagatesLocalError(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bat := batch.New(nil)
+	bat.SetRowCount(1)
+	want := moerr.NewInternalErrorNoCtx("local send failed")
+
+	stub := gostub.Stub(&sendToAnyLocal, func(*batch.Batch, *Dispatch, *process.Process) (bool, error) {
+		return false, want
+	})
+	defer stub.Reset()
+
+	d := &Dispatch{
+		ctr: &container{
+			aliveRegCnt:  1,
+			localRegsCnt: 1,
+		},
+	}
+
+	end, err := sendToAnyFunc(bat, d, proc)
+	require.False(t, end)
+	require.ErrorIs(t, err, want)
+}
+
+func TestSendToAnyFunc_PropagatesRemoteError(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bat := batch.New(nil)
+	bat.SetRowCount(1)
+	want := moerr.NewInternalErrorNoCtx("remote send failed")
+
+	stub := gostub.Stub(&sendToAnyRemote, func(*batch.Batch, *Dispatch, *process.Process) (bool, error) {
+		return false, want
+	})
+	defer stub.Reset()
+
+	d := &Dispatch{
+		ctr: &container{
+			aliveRegCnt:  1,
+			localRegsCnt: 0,
+		},
+	}
+
+	end, err := sendToAnyFunc(bat, d, proc)
+	require.False(t, end)
+	require.ErrorIs(t, err, want)
+}
+
+func TestSendToAnyFunc_FallbackFromLocalToRemote(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bat := batch.New(nil)
+	bat.SetRowCount(1)
+
+	localStub := gostub.Stub(&sendToAnyLocal, func(*batch.Batch, *Dispatch, *process.Process) (bool, error) {
+		return true, nil
+	})
+	defer localStub.Reset()
+
+	remoteCalled := false
+	remoteStub := gostub.Stub(&sendToAnyRemote, func(*batch.Batch, *Dispatch, *process.Process) (bool, error) {
+		remoteCalled = true
+		return false, nil
+	})
+	defer remoteStub.Reset()
+
+	d := &Dispatch{
+		ctr: &container{
+			aliveRegCnt:  2,
+			localRegsCnt: 1,
+		},
+	}
+
+	end, err := sendToAnyFunc(bat, d, proc)
+	require.False(t, end)
+	require.NoError(t, err)
+	require.True(t, remoteCalled)
+}
+
+func TestSendToAnyFunc_FallbackRemoteErrorIsPropagated(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	bat := batch.New(nil)
+	bat.SetRowCount(1)
+	want := moerr.NewInternalErrorNoCtx("fallback remote failed")
+	localCalled := false
+
+	remoteStub := gostub.Stub(&sendToAnyRemote, func(*batch.Batch, *Dispatch, *process.Process) (bool, error) {
+		return true, nil
+	})
+	defer remoteStub.Reset()
+
+	localStub := gostub.Stub(&sendToAnyLocal, func(*batch.Batch, *Dispatch, *process.Process) (bool, error) {
+		localCalled = true
+		return false, want
+	})
+	defer localStub.Reset()
+
+	d := &Dispatch{
+		ctr: &container{
+			aliveRegCnt:  2,
+			localRegsCnt: 1,
+			sendCnt:      1,
+		},
+	}
+
+	end, err := sendToAnyFunc(bat, d, proc)
+	require.False(t, end)
+	require.ErrorIs(t, err, want)
+	require.True(t, localCalled)
 }
 
 // TestShuffleScenario_TargetReceiverFailed tests shuffle with specific target receiver failed

--- a/pkg/sql/colexec/dispatch/sendfunc.go
+++ b/pkg/sql/colexec/dispatch/sendfunc.go
@@ -44,6 +44,11 @@ const (
 	FailureModeTolerant
 )
 
+var (
+	sendToAnyLocal  = sendToAnyLocalFunc
+	sendToAnyRemote = sendToAnyRemoteFunc
+)
+
 func (ctr *container) removeIdxReceiver(idx int) {
 	ctr.remoteReceivers = append(ctr.remoteReceivers[:idx], ctr.remoteReceivers[idx+1:]...)
 	ctr.remoteRegsCnt--
@@ -343,22 +348,22 @@ func sendToAnyRemoteFunc(bat *batch.Batch, ap *Dispatch, proc *process.Process) 
 func sendToAnyFunc(bat *batch.Batch, ap *Dispatch, proc *process.Process) (bool, error) {
 	toLocal := (ap.ctr.sendCnt % ap.ctr.aliveRegCnt) < ap.ctr.localRegsCnt
 	if toLocal {
-		allclosed, err := sendToAnyLocalFunc(bat, ap, proc)
+		allclosed, err := sendToAnyLocal(bat, ap, proc)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 		if allclosed { // all local reg closed, change sendFunc to send remote only
 			ap.ctr.sendFunc = sendToAnyRemoteFunc
-			return ap.ctr.sendFunc(bat, ap, proc)
+			return sendToAnyRemote(bat, ap, proc)
 		}
 	} else {
-		allclosed, err := sendToAnyRemoteFunc(bat, ap, proc)
+		allclosed, err := sendToAnyRemote(bat, ap, proc)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 		if allclosed { // all remote reg closed, change sendFunc to send local only
 			ap.ctr.sendFunc = sendToAnyLocalFunc
-			return ap.ctr.sendFunc(bat, ap, proc)
+			return sendToAnyLocal(bat, ap, proc)
 		}
 	}
 	return false, nil

--- a/pkg/sql/colexec/dispatch/types.go
+++ b/pkg/sql/colexec/dispatch/types.go
@@ -136,6 +136,14 @@ func (dispatch *Dispatch) Release() {
 	}
 }
 
+func (dispatch *Dispatch) AdoptCleanupState(from *Dispatch) {
+	if dispatch == nil || from == nil {
+		return
+	}
+	dispatch.ctr = from.ctr
+	from.ctr = nil
+}
+
 func (dispatch *Dispatch) Reset(proc *process.Process, pipelineFailed bool, err error) {
 	if dispatch.ctr != nil {
 		if dispatch.ctr.isRemote {

--- a/pkg/sql/colexec/server.go
+++ b/pkg/sql/colexec/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
@@ -46,6 +47,7 @@ func NewServer(client logservice.CNHAKeeperClient) *Server {
 		cnSegmentMap:  CnSegmentMap{mp: make(map[string]int32, 1024)},
 		receivedRunningPipeline: RunningPipelineMapForRemoteNode{
 			fromRpcClientToRelatedPipeline: make(map[rpcClientItem]runningPipelineInfo, 1024),
+			sessionCleanupWaiters:          make(map[morpc.ClientSession]struct{}, 128),
 		},
 	}
 	Set(s)

--- a/pkg/sql/colexec/types.go
+++ b/pkg/sql/colexec/types.go
@@ -65,6 +65,7 @@ type RunningPipelineMapForRemoteNode struct {
 	sync.Mutex
 
 	fromRpcClientToRelatedPipeline map[rpcClientItem]runningPipelineInfo
+	sessionCleanupWaiters          map[morpc.ClientSession]struct{}
 }
 
 type rpcClientItem struct {

--- a/pkg/sql/colexec/types2.go
+++ b/pkg/sql/colexec/types2.go
@@ -85,6 +85,7 @@ func (srv *Server) RecordBuiltPipeline(
 
 	// check if sender has sent a stop running message.
 	if v, ok := srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key]; ok && v.alreadyDone {
+		cancel()
 		return
 	}
 
@@ -121,7 +122,13 @@ func (srv *Server) CancelPipelineSending(
 				zap.Uint64("streamID", streamID))
 			v.cancelPipeline()
 		}
+		return
 	}
+
+	srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key] = runningPipelineInfo{
+		alreadyDone: true,
+	}
+	srv.ensureSessionCleanupLocked(session)
 }
 
 func (srv *Server) RemoveRelatedPipeline(session morpc.ClientSession, streamID uint64) {
@@ -133,4 +140,37 @@ func (srv *Server) RemoveRelatedPipeline(session morpc.ClientSession, streamID u
 
 func generateRecordKey(session morpc.ClientSession, streamID uint64) rpcClientItem {
 	return rpcClientItem{tcp: session, id: streamID}
+}
+
+func (srv *Server) ensureSessionCleanupLocked(session morpc.ClientSession) {
+	if session == nil || session.SessionCtx() == nil || session.SessionCtx().Done() == nil {
+		return
+	}
+	if _, ok := srv.receivedRunningPipeline.sessionCleanupWaiters[session]; ok {
+		return
+	}
+	srv.receivedRunningPipeline.sessionCleanupWaiters[session] = struct{}{}
+
+	done := session.SessionCtx().Done()
+	go func() {
+		<-done
+		srv.cleanupPipelinesForSession(session)
+	}()
+}
+
+func (srv *Server) cleanupPipelinesForSession(session morpc.ClientSession) {
+	srv.receivedRunningPipeline.Lock()
+	var infos []runningPipelineInfo
+	delete(srv.receivedRunningPipeline.sessionCleanupWaiters, session)
+	for key := range srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline {
+		if key.tcp == session {
+			infos = append(infos, srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key])
+			delete(srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline, key)
+		}
+	}
+	srv.receivedRunningPipeline.Unlock()
+
+	for i := range infos {
+		infos[i].cancelPipeline()
+	}
 }

--- a/pkg/sql/colexec/types2_test.go
+++ b/pkg/sql/colexec/types2_test.go
@@ -17,6 +17,7 @@ package colexec
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,7 @@ import (
 // mockClientSession is a simple mock implementation of morpc.ClientSession for testing
 type mockClientSession struct {
 	remoteAddr string
+	ctx        context.Context
 }
 
 func (m *mockClientSession) RemoteAddress() string {
@@ -35,6 +37,9 @@ func (m *mockClientSession) RemoteAddress() string {
 }
 
 func (m *mockClientSession) SessionCtx() context.Context {
+	if m.ctx != nil {
+		return m.ctx
+	}
 	return context.Background()
 }
 
@@ -287,6 +292,7 @@ func TestRecordBuiltPipeline(t *testing.T) {
 
 	require.True(t, exists2, "Record should still exist")
 	require.True(t, record2.alreadyDone, "Record should still be marked as done")
+	require.NotNil(t, proc2.GetQueryContextError(), "Process should be canceled when a tombstone already exists")
 }
 
 // TestCancelPipelineSending tests CancelPipelineSending function
@@ -330,6 +336,20 @@ func TestCancelPipelineSending(t *testing.T) {
 	srv.CancelPipelineSending(session, streamID2)
 
 	require.False(t, dispatchReceiver.ReceiverDone, "Dispatch receiver should not be canceled")
+
+	// Test 3: Cancel before record exists should create a tombstone for later registration.
+	streamID3 := uint64(10)
+	srv.CancelPipelineSending(session, streamID3)
+
+	key3 := generateRecordKey(session, streamID3)
+	srv.receivedRunningPipeline.Lock()
+	record3, exists3 := srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key3]
+	srv.receivedRunningPipeline.Unlock()
+
+	require.True(t, exists3, "Cancel before registration should leave a tombstone")
+	require.True(t, record3.alreadyDone, "Tombstone should mark the pipeline already done")
+	require.Nil(t, record3.receiver, "Tombstone should not carry a dispatch receiver")
+	require.Nil(t, record3.queryCancel, "Tombstone should not carry a cancel func yet")
 }
 
 // TestRemoveRelatedPipeline tests RemoveRelatedPipeline function
@@ -370,4 +390,100 @@ func TestRemoveRelatedPipeline(t *testing.T) {
 
 	// Test removing non-existent pipeline (should not panic)
 	srv.RemoveRelatedPipeline(session, streamID+1)
+}
+
+func TestCancelPipelineSending_TombstoneAllowsDispatchRegistration(t *testing.T) {
+	srv := NewServer(nil)
+	require.NotNil(t, srv)
+
+	session := &mockClientSession{remoteAddr: "test-addr"}
+	streamID := uint64(11)
+
+	srv.CancelPipelineSending(session, streamID)
+
+	receiverUid := uuid.Must(uuid.NewV7())
+	dispatchReceiver := &process.WrapCs{
+		ReceiverDone: false,
+		MsgId:        streamID,
+		Uid:          receiverUid,
+		Cs:           session,
+		Err:          make(chan error, 1),
+	}
+
+	srv.RecordDispatchPipeline(session, streamID, dispatchReceiver)
+
+	key := generateRecordKey(session, streamID)
+	srv.receivedRunningPipeline.Lock()
+	record, exists := srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key]
+	srv.receivedRunningPipeline.Unlock()
+
+	require.True(t, exists, "Dispatch registration should replace the stale tombstone")
+	require.False(t, record.alreadyDone, "Dispatch registration should clear the tombstone state")
+	require.True(t, record.isDispatch, "Dispatch receiver should register normally after stale tombstone cleanup")
+	require.Equal(t, receiverUid, record.receiver.Uid, "Dispatch receiver should be recorded")
+	require.False(t, dispatchReceiver.ReceiverDone, "Dispatch receiver should not be spuriously canceled")
+}
+
+func TestCancelPipelineSending_TombstoneCleansOnSessionClose(t *testing.T) {
+	srv := NewServer(nil)
+	require.NotNil(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	session := &mockClientSession{remoteAddr: "test-addr", ctx: ctx}
+	streamID := uint64(12)
+	streamID2 := uint64(13)
+
+	srv.CancelPipelineSending(session, streamID)
+	srv.CancelPipelineSending(session, streamID2)
+
+	key := generateRecordKey(session, streamID)
+	key2 := generateRecordKey(session, streamID2)
+	srv.receivedRunningPipeline.Lock()
+	_, exists := srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key]
+	_, exists2 := srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key2]
+	waiterCount := len(srv.receivedRunningPipeline.sessionCleanupWaiters)
+	srv.receivedRunningPipeline.Unlock()
+	require.True(t, exists, "Cancel before registration should create a tombstone")
+	require.True(t, exists2, "Second stop on the same session should also create a tombstone")
+	require.Equal(t, 1, waiterCount, "A session should register only one cleanup waiter")
+
+	cancel()
+
+	require.Eventually(t, func() bool {
+		srv.receivedRunningPipeline.Lock()
+		defer srv.receivedRunningPipeline.Unlock()
+		_, exists := srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key]
+		_, exists2 := srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key2]
+		return !exists && !exists2 && len(srv.receivedRunningPipeline.sessionCleanupWaiters) == 0
+	}, time.Second, 10*time.Millisecond, "Session close should clean all tombstones for the session")
+}
+
+func TestCleanupPipelinesForSession_CancelsRegisteredPipelines(t *testing.T) {
+	srv := NewServer(nil)
+	require.NotNil(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session := &mockClientSession{remoteAddr: "test-addr", ctx: ctx}
+	streamID := uint64(14)
+
+	proc := &process.Process{}
+	proc.Base = &process.BaseProcess{}
+	queryCtx, queryCancel := context.WithCancel(context.Background())
+	defer queryCancel()
+	proc.Base.GetContextBase().BuildQueryCtx(queryCtx)
+
+	srv.RecordBuiltPipeline(session, streamID, proc)
+	srv.cleanupPipelinesForSession(session)
+
+	key := generateRecordKey(session, streamID)
+	srv.receivedRunningPipeline.Lock()
+	_, exists := srv.receivedRunningPipeline.fromRpcClientToRelatedPipeline[key]
+	waiterCount := len(srv.receivedRunningPipeline.sessionCleanupWaiters)
+	srv.receivedRunningPipeline.Unlock()
+
+	require.False(t, exists, "Session cleanup should remove registered pipeline records")
+	require.Equal(t, 0, waiterCount, "Session cleanup should remove the waiter registration")
+	require.NotNil(t, proc.GetQueryContextError(), "Session cleanup should cancel registered non-dispatch pipelines")
 }

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -550,26 +550,6 @@ func forwardRemoteBatchWithContext(
 	}
 }
 
-func forwardTerminalSignalWithContext(
-	sender *messageSenderOnClient,
-	nextChannel chan process.PipelineSignal,
-	err error,
-	mp *mpool.MPool,
-) bool {
-	signal := process.NewPipelineSignalToDirectly(nil, err, mp)
-	if sender == nil || sender.ctx == nil {
-		nextChannel <- signal
-		return true
-	}
-
-	select {
-	case nextChannel <- signal:
-		return true
-	case <-sender.ctx.Done():
-		return false
-	}
-}
-
 // no matter how we stop the remote-run, we should get the final remote cost here.
 func (sender *messageSenderOnClient) waitingTheStopResponse() {
 	if sender.alreadyClose || sender.safeToClose {

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -267,6 +267,9 @@ func receiveMessageFromCnServerIfDispatch(s *Scope, sender *messageSenderOnClien
 	}
 	dispatchRunner := buildRemoteDispatchReceiverRoot(arg, fakeValueScanOperator)
 	defer func() {
+		arg.AdoptCleanupState(dispatchRunner)
+		dispatchRunner.Release()
+		fakeValueScanOperator.Free(s.Proc, err != nil, err)
 		fakeValueScanOperator.Batchs = nil
 		fakeValueScanOperator.Release()
 	}()

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -249,7 +249,9 @@ func receiveMessageFromCnServerIfConnector(s *Scope, sender *messageSenderOnClie
 		}
 		connectorAnalyze.Network(bat)
 
-		nextChannel <- process.NewPipelineSignalToDirectly(bat, nil, mp)
+		if err = forwardRemoteBatchWithContext(sender, nextChannel, bat, mp); err != nil {
+			return err
+		}
 	}
 }
 
@@ -525,6 +527,47 @@ func (sender *messageSenderOnClient) contextDoneError() error {
 		return moerr.NewRPCTimeout(sender.ctx)
 	}
 	return moerr.NewQueryInterrupted(sender.ctx)
+}
+
+func forwardRemoteBatchWithContext(
+	sender *messageSenderOnClient,
+	nextChannel chan process.PipelineSignal,
+	bat *batch.Batch,
+	mp *mpool.MPool,
+) error {
+	signal := process.NewPipelineSignalToDirectly(bat, nil, mp)
+	if sender == nil || sender.ctx == nil {
+		nextChannel <- signal
+		return nil
+	}
+
+	select {
+	case nextChannel <- signal:
+		return nil
+	case <-sender.ctx.Done():
+		bat.Clean(mp)
+		return sender.contextDoneError()
+	}
+}
+
+func forwardTerminalSignalWithContext(
+	sender *messageSenderOnClient,
+	nextChannel chan process.PipelineSignal,
+	err error,
+	mp *mpool.MPool,
+) bool {
+	signal := process.NewPipelineSignalToDirectly(nil, err, mp)
+	if sender == nil || sender.ctx == nil {
+		nextChannel <- signal
+		return true
+	}
+
+	select {
+	case nextChannel <- signal:
+		return true
+	case <-sender.ctx.Done():
+		return false
+	}
 }
 
 // no matter how we stop the remote-run, we should get the final remote cost here.

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -17,6 +17,7 @@ package compile
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -331,8 +332,9 @@ func buildRemoteDispatchReceiverRoot(arg *dispatch.Dispatch, child vm.Operator) 
 type messageSenderOnClient struct {
 	// sender's context
 	// and cancel function (it exists if this context was recreated by us).
-	ctx       context.Context
-	ctxCancel context.CancelFunc
+	ctx                context.Context
+	ctxCancel          context.CancelFunc
+	useInternalTimeout bool
 
 	mp *mpool.MPool
 
@@ -380,6 +382,7 @@ func newMessageSenderOnClient(
 
 	if _, ok := ctx.Deadline(); !ok {
 		sender.ctx, sender.ctxCancel = context.WithTimeoutCause(ctx, MaxRpcTime, moerr.CauseNewMessageSenderOnClient)
+		sender.useInternalTimeout = true
 	} else {
 		sender.ctx = ctx
 	}
@@ -463,6 +466,9 @@ func (sender *messageSenderOnClient) receiveBatch() (bat *batch.Batch, over bool
 			return nil, false, err
 		}
 		if val == nil {
+			if ctxErr := sender.contextDoneError(); ctxErr != nil {
+				return nil, false, ctxErr
+			}
 			return nil, true, nil
 		}
 
@@ -505,6 +511,20 @@ func (sender *messageSenderOnClient) receiveBatch() (bat *batch.Batch, over bool
 		   		} */
 		return bat, false, err
 	}
+}
+
+func (sender *messageSenderOnClient) contextDoneError() error {
+	if sender.ctx == nil {
+		return nil
+	}
+	err := sender.ctx.Err()
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) && sender.useInternalTimeout {
+		return moerr.NewRPCTimeout(sender.ctx)
+	}
+	return moerr.NewQueryInterrupted(sender.ctx)
 }
 
 // no matter how we stop the remote-run, we should get the final remote cost here.

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -880,31 +880,6 @@ func TestReceiveMsgAndForward_ReturnsOnBlockedReceiverCancel(t *testing.T) {
 	}
 }
 
-func TestForwardTerminalSignalWithContext_SkipsBlockedSendAfterCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	forwardCh := make(chan process.PipelineSignal, 1)
-	forwardCh <- process.NewPipelineSignalToDirectly(nil, nil, nil)
-
-	sender := &messageSenderOnClient{ctx: ctx}
-	done := make(chan bool, 1)
-	go func() {
-		done <- forwardTerminalSignalWithContext(sender, forwardCh, moerr.NewInternalErrorNoCtx("test"), nil)
-	}()
-
-	cancel()
-
-	select {
-	case ok := <-done:
-		require.False(t, ok)
-		require.Equal(t, 1, len(forwardCh))
-	case <-time.After(time.Second):
-		<-forwardCh
-		require.Fail(t, "forwardTerminalSignalWithContext did not unblock after cancellation")
-	}
-}
-
 func Test_checkPipelineStandaloneExecutableAtRemote(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	proc.Base.TxnOperator = fakeTxnOperator{}

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -16,6 +16,7 @@ package compile
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
@@ -877,6 +878,69 @@ func TestReceiveMsgAndForward_ReturnsOnBlockedReceiverCancel(t *testing.T) {
 	case <-time.After(time.Second):
 		<-forwardCh
 		require.Fail(t, "receiveMsgAndForward did not unblock after cancellation")
+	}
+}
+
+func TestReceiveMessageFromCnServerIfDispatch_PreservesCleanupOnOriginalRoot(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	reg := &process.WaitRegister{Ch2: make(chan process.PipelineSignal, 2)}
+	d := dispatch.NewArgument()
+	d.LocalRegs = []*process.WaitRegister{reg}
+	d.FuncId = dispatch.SendToAllLocalFunc
+	s := &Scope{Proc: proc, RootOp: d}
+
+	sender := &messageSenderOnClient{
+		ctx:       context.Background(),
+		mp:        proc.Mp(),
+		receiveCh: make(chan morpc.Message, 2),
+	}
+	dataBat := batch.NewWithSize(0)
+	dataBat.SetRowCount(1)
+	sender.receiveCh <- makeRemoteBatchMessage(t, dataBat)
+	sender.receiveCh <- &pipeline.Message{Sid: pipeline.Status_MessageEnd}
+
+	err := receiveMessageFromCnServerIfDispatch(s, sender)
+	require.NoError(t, err)
+
+	ctrField := reflect.ValueOf(d).Elem().FieldByName("ctr")
+	require.False(t, ctrField.IsNil(), "receiveMessageFromCnServerIfDispatch should keep cleanup state on the original root")
+
+	select {
+	case signal := <-reg.Ch2:
+		bat, actionErr := signal.Action()
+		require.NoError(t, actionErr)
+		require.NotNil(t, bat)
+		require.Equal(t, 1, bat.RowCount())
+	case <-time.After(time.Second):
+		require.Fail(t, "dispatch runner did not send the data batch signal")
+	}
+
+	done := make(chan struct{}, 1)
+	go func() {
+		d.Reset(proc, false, nil)
+		done <- struct{}{}
+	}()
+
+	select {
+	case signal := <-reg.Ch2:
+		bat, actionErr := signal.Action()
+		require.NoError(t, actionErr)
+		require.Nil(t, bat)
+	case <-time.After(time.Second):
+		require.Fail(t, "original root cleanup did not send a terminal signal")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.Fail(t, "original root cleanup did not finish after terminal signal consumption")
+	}
+
+	select {
+	case <-reg.Ch2:
+		require.Fail(t, "original root cleanup should not emit duplicate terminal signals")
+	default:
 	}
 }
 

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -80,6 +80,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func makeRemoteBatchMessage(t *testing.T, bat *batch.Batch) morpc.Message {
+	t.Helper()
+	data, err := bat.MarshalBinary()
+	require.NoError(t, err)
+	return &pipeline.Message{
+		Sid:  pipeline.Status_Last,
+		Data: data,
+	}
+}
+
 func Test_EncodeProcessInfo(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
@@ -799,6 +809,99 @@ func Test_ReceiveMessageFromCnServer(t *testing.T) {
 		sender.receiveCh = ch
 
 		require.NotNil(t, receiveMessageFromCnServer(s4, false, &sender))
+	}
+}
+
+func TestReceiveMessageFromCnServerIfConnector_ReturnsOnBlockedReceiverCancel(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	proc.BuildPipelineContext(context.Background())
+
+	s := &Scope{
+		Proc:   proc,
+		RootOp: connector.NewArgument(),
+	}
+	s.RootOp.(*connector.Connector).Reg = &process.WaitRegister{
+		Ch2: make(chan process.PipelineSignal, 1),
+	}
+	s.RootOp.(*connector.Connector).Reg.Ch2 <- process.NewPipelineSignalToDirectly(nil, nil, proc.Mp())
+
+	sender := &messageSenderOnClient{
+		ctx:       proc.Ctx,
+		mp:        proc.Mp(),
+		receiveCh: make(chan morpc.Message, 1),
+	}
+	sender.receiveCh <- makeRemoteBatchMessage(t, batch.NewWithSize(0))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- receiveMessageFromCnServerIfConnector(s, sender)
+	}()
+
+	proc.Cancel(nil)
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted))
+	case <-time.After(time.Second):
+		<-s.RootOp.(*connector.Connector).Reg.Ch2
+		require.Fail(t, "receiveMessageFromCnServerIfConnector did not unblock after cancellation")
+	}
+}
+
+func TestReceiveMsgAndForward_ReturnsOnBlockedReceiverCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	forwardCh := make(chan process.PipelineSignal, 1)
+	forwardCh <- process.NewPipelineSignalToDirectly(nil, nil, nil)
+
+	sender := &messageSenderOnClient{
+		ctx:       ctx,
+		mp:        mpool.MustNewZero(),
+		receiveCh: make(chan morpc.Message, 1),
+	}
+	sender.receiveCh <- makeRemoteBatchMessage(t, batch.NewWithSize(0))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- receiveMsgAndForward(sender, forwardCh)
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted))
+	case <-time.After(time.Second):
+		<-forwardCh
+		require.Fail(t, "receiveMsgAndForward did not unblock after cancellation")
+	}
+}
+
+func TestForwardTerminalSignalWithContext_SkipsBlockedSendAfterCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	forwardCh := make(chan process.PipelineSignal, 1)
+	forwardCh <- process.NewPipelineSignalToDirectly(nil, nil, nil)
+
+	sender := &messageSenderOnClient{ctx: ctx}
+	done := make(chan bool, 1)
+	go func() {
+		done <- forwardTerminalSignalWithContext(sender, forwardCh, moerr.NewInternalErrorNoCtx("test"), nil)
+	}()
+
+	cancel()
+
+	select {
+	case ok := <-done:
+		require.False(t, ok)
+		require.Equal(t, 1, len(forwardCh))
+	case <-time.After(time.Second):
+		<-forwardCh
+		require.Fail(t, "forwardTerminalSignalWithContext did not unblock after cancellation")
 	}
 }
 

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -817,7 +817,7 @@ func (s *Scope) sendNotifyMessage(wg *sync.WaitGroup, resultChan chan notifyMess
 	// if context has done, it means the user or other part of the pipeline stops this query.
 	closeWithError := func(err error, reg *process.WaitRegister, sender *messageSenderOnClient) {
 		err = suppressRemoteRunCancelError(s.Proc.Ctx, err)
-		forwardTerminalSignalWithContext(sender, reg.Ch2, err, s.Proc.Mp())
+		reg.Ch2 <- process.NewPipelineSignalToDirectly(nil, err, s.Proc.Mp())
 		resultChan <- notifyMessageResult{err: err, sender: sender}
 		wg.Done()
 	}

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -428,12 +428,10 @@ func (s *Scope) RemoteRun(c *Compile) error {
 	sender, err := s.remoteRun(c)
 
 	runErr := err
-	if s.Proc.Ctx.Err() != nil {
-		runErr = nil
-	}
+	runErr = suppressRemoteRunCancelError(s.Proc.Ctx, runErr)
 	// this clean-up action shouldn't be called before context check.
 	// because the clean-up action will cancel the context, and error will be suppressed.
-	p.CleanRootOperator(s.Proc, err != nil, c.isPrepare, err)
+	p.CleanRootOperator(s.Proc, err != nil, c.isPrepare, runErr)
 
 	// sender should be closed after cleanup (tell the children-pipeline that query was done).
 	if sender != nil {
@@ -818,14 +816,9 @@ func (r *notifyMessageResult) clean(proc *process.Process) {
 func (s *Scope) sendNotifyMessage(wg *sync.WaitGroup, resultChan chan notifyMessageResult) {
 	// if context has done, it means the user or other part of the pipeline stops this query.
 	closeWithError := func(err error, reg *process.WaitRegister, sender *messageSenderOnClient) {
+		err = suppressRemoteRunCancelError(s.Proc.Ctx, err)
 		reg.Ch2 <- process.NewPipelineSignalToDirectly(nil, err, s.Proc.Mp())
-
-		select {
-		case <-s.Proc.Ctx.Done():
-			resultChan <- notifyMessageResult{err: nil, sender: sender}
-		default:
-			resultChan <- notifyMessageResult{err: err, sender: sender}
-		}
+		resultChan <- notifyMessageResult{err: err, sender: sender}
 		wg.Done()
 	}
 
@@ -879,6 +872,16 @@ func (s *Scope) sendNotifyMessage(wg *sync.WaitGroup, resultChan chan notifyMess
 			closeWithError(errSubmit, s.Proc.Reg.MergeReceivers[receiverIdx], nil)
 		}
 	}
+}
+
+func suppressRemoteRunCancelError(procCtx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if procCtx != nil && procCtx.Err() != nil && moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted) {
+		return nil
+	}
+	return err
 }
 
 func receiveMsgAndForward(sender *messageSenderOnClient, forwardCh chan process.PipelineSignal) error {

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -817,7 +817,7 @@ func (s *Scope) sendNotifyMessage(wg *sync.WaitGroup, resultChan chan notifyMess
 	// if context has done, it means the user or other part of the pipeline stops this query.
 	closeWithError := func(err error, reg *process.WaitRegister, sender *messageSenderOnClient) {
 		err = suppressRemoteRunCancelError(s.Proc.Ctx, err)
-		reg.Ch2 <- process.NewPipelineSignalToDirectly(nil, err, s.Proc.Mp())
+		forwardTerminalSignalWithContext(sender, reg.Ch2, err, s.Proc.Mp())
 		resultChan <- notifyMessageResult{err: err, sender: sender}
 		wg.Done()
 	}
@@ -891,7 +891,9 @@ func receiveMsgAndForward(sender *messageSenderOnClient, forwardCh chan process.
 			return err
 		}
 
-		forwardCh <- process.NewPipelineSignalToDirectly(bat, nil, sender.mp)
+		if err = forwardRemoteBatchWithContext(sender, forwardCh, bat, sender.mp); err != nil {
+			return err
+		}
 	}
 }
 

--- a/pkg/sql/compile/scope_test.go
+++ b/pkg/sql/compile/scope_test.go
@@ -249,6 +249,79 @@ func TestMessageSenderOnClientReceive(t *testing.T) {
 	}
 }
 
+func TestMessageSenderOnClientReceiveBatchContextDone(t *testing.T) {
+	t.Run("cancel returns query interrupted", func(t *testing.T) {
+		sender := new(messageSenderOnClient)
+		sender.receiveCh = make(chan morpc.Message, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+		sender.ctx = ctx
+		sender.ctxCancel = cancel
+		cancel()
+
+		bat, over, err := sender.receiveBatch()
+		require.Nil(t, bat)
+		require.False(t, over)
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted))
+	})
+
+	t.Run("upstream deadline returns query interrupted", func(t *testing.T) {
+		sender := new(messageSenderOnClient)
+		sender.receiveCh = make(chan morpc.Message, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		sender.ctx = ctx
+		sender.ctxCancel = cancel
+		defer cancel()
+
+		<-ctx.Done()
+
+		bat, over, err := sender.receiveBatch()
+		require.Nil(t, bat)
+		require.False(t, over)
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted))
+	})
+
+	t.Run("internal deadline returns rpc timeout", func(t *testing.T) {
+		sender := new(messageSenderOnClient)
+		sender.receiveCh = make(chan morpc.Message, 1)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		sender.ctx = ctx
+		sender.ctxCancel = cancel
+		sender.useInternalTimeout = true
+		defer cancel()
+
+		<-ctx.Done()
+
+		bat, over, err := sender.receiveBatch()
+		require.Nil(t, bat)
+		require.False(t, over)
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrRPCTimeout))
+	})
+
+	t.Run("cancel during merge loop returns query interrupted", func(t *testing.T) {
+		sender := new(messageSenderOnClient)
+		sender.receiveCh = make(chan morpc.Message, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+		sender.ctx = ctx
+		sender.ctxCancel = cancel
+		defer cancel()
+
+		sender.receiveCh <- &pipeline.Message{Sid: pipeline.Status_WaitingNext, Data: []byte("partial")}
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+		}()
+
+		bat, over, err := sender.receiveBatch()
+		require.Nil(t, bat)
+		require.False(t, over)
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted))
+	})
+}
+
 func TestNewParallelScope(t *testing.T) {
 	// function `newParallelScope` will dispatch one scope's work into n scopes.
 	testCompile := NewMockCompile(t)
@@ -513,6 +586,29 @@ func TestNotifyMessageClean(t *testing.T) {
 
 	n2.clean(proc)
 	require.Equal(t, 2, ff.number)
+}
+
+func TestSuppressRemoteRunCancelError(t *testing.T) {
+	t.Run("suppress query interrupted after proc cancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.NoError(t, suppressRemoteRunCancelError(ctx, moerr.NewQueryInterrupted(ctx)))
+	})
+
+	t.Run("keep rpc timeout after proc cancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := suppressRemoteRunCancelError(ctx, moerr.NewRPCTimeout(ctx))
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrRPCTimeout))
+	})
+
+	t.Run("keep query interrupted while proc still active", func(t *testing.T) {
+		ctx := context.Background()
+		err := suppressRemoteRunCancelError(ctx, moerr.NewQueryInterrupted(ctx))
+		require.Error(t, err)
+		require.True(t, moerr.IsMoErrCode(err, moerr.ErrQueryInterrupted))
+	})
 }
 
 func TestScopeHoldAnyCannotRemoteOperator(t *testing.T) {

--- a/pkg/tests/ddl/ddl_test.go
+++ b/pkg/tests/ddl/ddl_test.go
@@ -396,7 +396,8 @@ func TestCDCCases(t *testing.T) {
 
 			// Drop all and validate empty
 			mustExec(db, "drop cdc all internal")
-			require.Equal(t, rows("", "select * from mo_catalog.mo_cdc_task"), 0)
+			waitForTaskCount(0)
+			require.Equal(t, 0, rows("", "select * from mo_catalog.mo_cdc_task"))
 
 			// cleanup PITR
 			mustExec(db, "drop pitr pitr_db internal")


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24011

## What this PR does / why we need it:

This PR hardens several adjacent remote-pipeline runtime failure paths on top of the original `sendToAny` fix.

It includes four behavior-preserving fixes:

1. `pkg/sql/colexec/dispatch/sendfunc.go`: `sendToAnyFunc()` now propagates real local/remote send failures instead of swallowing them as success-shaped `nil` errors.
2. `pkg/sql/compile/remoterunClient.go` and `pkg/sql/compile/scope.go`: remote-run receive paths no longer treat context cancellation as clean EOF, while cleanup/notify paths still suppress only parent-query cancellation so it does not hide the real root cause.
3. `pkg/sql/compile/remoterunClient.go` and `pkg/sql/compile/scope.go`: connector / notify-forward data paths no longer block forever on full local receiver channels after downstream stops consuming.
4. `pkg/sql/colexec/types2.go`: `StopSending` once again preserves pre-registration cancellation by recording an `alreadyDone` tombstone, canceling late non-dispatch registrations immediately, and cleaning session-scoped tombstones without regressing dispatch receiver behavior.

Together these changes make remote execution fail more honestly and unwind more safely: real send failures surface immediately, cancellation is no longer misreported as EOF/success, blocked batch forwarding exits on cancellation/timeout, and early `StopSending` messages no longer get lost before the target pipeline record exists.

## Testing

- `go test ./pkg/sql/colexec/dispatch -count=1`
- `go test ./pkg/sql/colexec -run 'TestCancelPipelineSending|TestRecordBuiltPipeline|TestCancelPipelineSending_TombstoneAllowsDispatchRegistration|TestCancelPipelineSending_TombstoneCleansOnSessionClose|TestCleanupPipelinesForSession_CancelsRegisteredPipelines|TestRecordDispatchPipeline|TestRemoveRelatedPipeline' -count=1`
- `go test ./pkg/sql/compile -count=1`

## Notes

The latest follow-up came from re-checking current `origin/main` and proving that `runningPipelineInfo.alreadyDone` had become dead production logic: `RecordBuiltPipeline` / `RecordDispatchPipeline` still branched on tombstones, but production code no longer created them. Multi-agent review was used to keep the repair narrow and to avoid follow-on regressions such as dispatch mis-cancellation, expiring tombstones too early, stop-handler blocking, leaking per-stream cleanup goroutines, or orphaning active remote pipelines on session close.
