### PR TITLE
fix: preserve dispatch receiver cleanup state

### DIFF
--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -53,6 +53,33 @@ func TestPrepareRemote(t *testing.T) {
 	require.Equal(t, d.ctr.remoteInfo, c)
 }
 
+func TestDispatchAdoptCleanupState_TransfersOwnership(t *testing.T) {
+	original := &container{sendCnt: 1}
+	target := &Dispatch{ctr: &container{sendCnt: 99}}
+	source := &Dispatch{ctr: original}
+
+	target.AdoptCleanupState(source)
+
+	require.Same(t, original, target.ctr)
+	require.Nil(t, source.ctr)
+}
+
+func TestDispatchAdoptCleanupState_NilSafe(t *testing.T) {
+	source := &Dispatch{ctr: &container{sendCnt: 1}}
+
+	var nilDispatch *Dispatch
+	require.NotPanics(t, func() {
+		nilDispatch.AdoptCleanupState(source)
+	})
+	require.NotNil(t, source.ctr)
+
+	target := &Dispatch{}
+	require.NotPanics(t, func() {
+		target.AdoptCleanupState(nil)
+	})
+	require.Nil(t, target.ctr)
+}
+
 // TestReceiverDone_OldBehavior tests the old behavior (kept for backward compatibility verification)
 func TestReceiverDone_OldBehavior(t *testing.T) {
 	proc := testutil.NewProcess(t)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24013

## What this PR does / why we need it:

This PR fixes a cleanup-ownership bug in the dispatch local-return path.

`receiveMessageFromCnServerIfDispatch()` prepares a temporary dispatch runner so remote batches can be forwarded into local wait registers. That temporary runner owns the prepared cleanup state, including the `pSpool`, but `Scope.RemoteRun()` later cleans only the original root dispatch.

Before this patch, the original root never adopted the temporary runner's cleanup state, so `Dispatch.Reset()` skipped the spool close path and the prepared spool state could be leaked.

The fix stays narrow:

- add `Dispatch.AdoptCleanupState(...)` to transfer prepared cleanup ownership,
- adopt that state onto the original root only after the receive loop finishes,
- keep terminal cleanup in the existing root `Reset()` path,
- add a regression test that verifies cleanup ownership and exactly one terminal signal.

## Validation

- `go test ./pkg/sql/compile -run 'Test_ReceiveMessageFromCnServer|TestReceiveMessageFromCnServerIfDispatch_PreservesCleanupOnOriginalRoot|TestBuildRemoteDispatchReceiverRoot' -count=1`
- `go test ./pkg/sql/compile -count=1`
