### PR TITLE
fix: NULL bitmap corruption in InplaceSort and roaring filter

### DIFF
--- a/pkg/sql/colexec/fuzzyfilter/filter.go
+++ b/pkg/sql/colexec/fuzzyfilter/filter.go
@@ -315,6 +315,9 @@ func (fuzzyFilter *FuzzyFilter) handleRuntimeFilter(proc *process.Process) error
 	//	bloomFilterCardLimit = v.(int64)
 	//}
 
+	// InplaceSort reorders data but NOT the null bitmap.
+	// Reset bitmap before sort to avoid corruption.
+	ctr.pass2RuntimeFilter.GetNulls().Reset()
 	ctr.pass2RuntimeFilter.InplaceSort()
 	data, err := ctr.pass2RuntimeFilter.MarshalBinary()
 	if err != nil {

--- a/pkg/sql/colexec/fuzzyfilter/filter.go
+++ b/pkg/sql/colexec/fuzzyfilter/filter.go
@@ -102,7 +102,7 @@ func (fuzzyFilter *FuzzyFilter) Prepare(proc *process.Process) (err error) {
 		useRoaring := IfCanUseRoaringFilter(types.T(fuzzyFilter.PkTyp.Id))
 
 		if useRoaring {
-			ctr.roaringFilter = newroaringFilter(types.T(fuzzyFilter.PkTyp.Id))
+			ctr.roaringFilter = newRoaringFilter(types.T(fuzzyFilter.PkTyp.Id))
 		} else {
 			//@see https://hur.st/bloomfilter/
 			var probability float64

--- a/pkg/sql/colexec/fuzzyfilter/roaring_filter.go
+++ b/pkg/sql/colexec/fuzzyfilter/roaring_filter.go
@@ -76,14 +76,23 @@ func newroaringFilter(t types.T) *roaringFilter {
 
 func addFunc[T canUseRoaring](f *roaringFilter, v *vector.Vector) {
 	ss := vector.MustFixedColNoTypeCheck[T](v)
-	for _, s := range ss {
+	nsp := v.GetNulls()
+	for i, s := range ss {
+		// SQL standard: NULL != NULL, skip NULLs from duplicate check
+		if nsp.Contains(uint64(i)) {
+			continue
+		}
 		f.b.Add(uint32(s))
 	}
 }
 
 func testFunc[T canUseRoaring](f *roaringFilter, v *vector.Vector) (int, any) {
 	ss := vector.MustFixedColNoTypeCheck[T](v)
+	nsp := v.GetNulls()
 	for i, s := range ss {
+		if nsp.Contains(uint64(i)) {
+			continue
+		}
 		if f.b.Contains(uint32(s)) {
 			return i, s
 		}
@@ -93,7 +102,11 @@ func testFunc[T canUseRoaring](f *roaringFilter, v *vector.Vector) (int, any) {
 
 func testAndAddFunc[T canUseRoaring](f *roaringFilter, v *vector.Vector) (int, any) {
 	ss := vector.MustFixedColWithTypeCheck[T](v)
+	nsp := v.GetNulls()
 	for i, s := range ss {
+		if nsp.Contains(uint64(i)) {
+			continue
+		}
 		if !f.b.CheckedAdd(uint32(s)) {
 			return i, s
 		}

--- a/pkg/sql/colexec/fuzzyfilter/roaring_filter.go
+++ b/pkg/sql/colexec/fuzzyfilter/roaring_filter.go
@@ -33,44 +33,38 @@ type roaringFilter struct {
 	testAndAddFunc func(f *roaringFilter, v *vector.Vector) (int, any)
 }
 
-func newroaringFilter(t types.T) *roaringFilter {
-	var add func(f *roaringFilter, v *vector.Vector)
-	var test func(f *roaringFilter, v *vector.Vector) (int, any)
-	var testAndAdd func(f *roaringFilter, v *vector.Vector) (int, any)
+func newRoaringFilter(t types.T) *roaringFilter {
+	f := &roaringFilter{b: roaring.New()}
 
 	switch t {
 	case types.T_int8:
-		add = addFunc[int8]
-		test = testFunc[int8]
-		testAndAdd = testAndAddFunc[int8]
+		f.addFunc = addFunc[int8]
+		f.testFunc = testFunc[int8]
+		f.testAndAddFunc = testAndAddFunc[int8]
 	case types.T_int16:
-		add = addFunc[int16]
-		test = testFunc[int16]
-		testAndAdd = testAndAddFunc[int16]
+		f.addFunc = addFunc[int16]
+		f.testFunc = testFunc[int16]
+		f.testAndAddFunc = testAndAddFunc[int16]
 	case types.T_int32:
-		add = addFunc[int32]
-		test = testFunc[int32]
-		testAndAdd = testAndAddFunc[int32]
+		f.addFunc = addFunc[int32]
+		f.testFunc = testFunc[int32]
+		f.testAndAddFunc = testAndAddFunc[int32]
 	case types.T_uint8:
-		add = addFunc[uint8]
-		test = testFunc[uint8]
-		testAndAdd = testAndAddFunc[uint8]
+		f.addFunc = addFunc[uint8]
+		f.testFunc = testFunc[uint8]
+		f.testAndAddFunc = testAndAddFunc[uint8]
 	case types.T_uint16:
-		add = addFunc[uint16]
-		test = testFunc[uint16]
-		testAndAdd = testAndAddFunc[uint16]
+		f.addFunc = addFunc[uint16]
+		f.testFunc = testFunc[uint16]
+		f.testAndAddFunc = testAndAddFunc[uint16]
 	case types.T_uint32:
-		add = addFunc[uint32]
-		test = testFunc[uint32]
-		testAndAdd = testAndAddFunc[uint32]
+		f.addFunc = addFunc[uint32]
+		f.testFunc = testFunc[uint32]
+		f.testAndAddFunc = testAndAddFunc[uint32]
+	default:
+		panic("unsupported type for roaring filter: " + t.String())
 	}
 
-	f := &roaringFilter{
-		addFunc:        add,
-		testFunc:       test,
-		testAndAddFunc: testAndAdd,
-		b:              roaring.New(),
-	}
 	return f
 }
 
@@ -101,7 +95,7 @@ func testFunc[T canUseRoaring](f *roaringFilter, v *vector.Vector) (int, any) {
 }
 
 func testAndAddFunc[T canUseRoaring](f *roaringFilter, v *vector.Vector) (int, any) {
-	ss := vector.MustFixedColWithTypeCheck[T](v)
+	ss := vector.MustFixedColNoTypeCheck[T](v)
 	nsp := v.GetNulls()
 	for i, s := range ss {
 		if nsp.Contains(uint64(i)) {

--- a/pkg/sql/colexec/fuzzyfilter/roaring_filter_test.go
+++ b/pkg/sql/colexec/fuzzyfilter/roaring_filter_test.go
@@ -80,7 +80,7 @@ func TestRoaringAddFuncSkipsNulls(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := newroaringFilter(tt.typ)
+			f := newRoaringFilter(tt.typ)
 			vec := makeVec(t, mp, tt.typ.ToType(), tt.vals, tt.isNull)
 			defer vec.Free(mp)
 			f.addFunc(f, vec)
@@ -94,7 +94,7 @@ func TestRoaringTestFuncSkipsNulls(t *testing.T) {
 	require.NoError(t, err)
 
 	// Build a filter containing value 5.
-	f := newroaringFilter(types.T_int32)
+	f := newRoaringFilter(types.T_int32)
 	{
 		buildVec := makeVec(t, mp, types.T_int32.ToType(), []int32{5}, []bool{false})
 		defer buildVec.Free(mp)
@@ -205,7 +205,7 @@ func TestRoaringTestAndAddFuncSkipsNulls(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := newroaringFilter(types.T_int32)
+			f := newRoaringFilter(types.T_int32)
 			vec := makeVec(t, mp, types.T_int32.ToType(), tt.vals, tt.isNull)
 			defer vec.Free(mp)
 			idx, val := f.testAndAddFunc(f, vec)
@@ -221,7 +221,7 @@ func TestRoaringMultipleTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("int8", func(t *testing.T) {
-		f := newroaringFilter(types.T_int8)
+		f := newRoaringFilter(types.T_int8)
 		vec := vector.NewVec(types.T_int8.ToType())
 		require.NoError(t, vector.AppendFixedList(vec, []int8{1, 0, 3}, []bool{false, true, false}, mp))
 		defer vec.Free(mp)
@@ -230,7 +230,7 @@ func TestRoaringMultipleTypes(t *testing.T) {
 	})
 
 	t.Run("int16", func(t *testing.T) {
-		f := newroaringFilter(types.T_int16)
+		f := newRoaringFilter(types.T_int16)
 		vec := vector.NewVec(types.T_int16.ToType())
 		require.NoError(t, vector.AppendFixedList(vec, []int16{100, 0, 200}, []bool{false, true, false}, mp))
 		defer vec.Free(mp)
@@ -239,7 +239,7 @@ func TestRoaringMultipleTypes(t *testing.T) {
 	})
 
 	t.Run("uint8", func(t *testing.T) {
-		f := newroaringFilter(types.T_uint8)
+		f := newRoaringFilter(types.T_uint8)
 		vec := vector.NewVec(types.T_uint8.ToType())
 		require.NoError(t, vector.AppendFixedList(vec, []uint8{10, 0, 20}, []bool{false, true, false}, mp))
 		defer vec.Free(mp)
@@ -248,7 +248,7 @@ func TestRoaringMultipleTypes(t *testing.T) {
 	})
 
 	t.Run("uint16", func(t *testing.T) {
-		f := newroaringFilter(types.T_uint16)
+		f := newRoaringFilter(types.T_uint16)
 		vec := vector.NewVec(types.T_uint16.ToType())
 		require.NoError(t, vector.AppendFixedList(vec, []uint16{1000, 0, 2000}, []bool{false, true, false}, mp))
 		defer vec.Free(mp)
@@ -257,7 +257,7 @@ func TestRoaringMultipleTypes(t *testing.T) {
 	})
 
 	t.Run("uint32", func(t *testing.T) {
-		f := newroaringFilter(types.T_uint32)
+		f := newRoaringFilter(types.T_uint32)
 		vec := vector.NewVec(types.T_uint32.ToType())
 		require.NoError(t, vector.AppendFixedList(vec, []uint32{50000, 0, 60000}, []bool{false, true, false}, mp))
 		defer vec.Free(mp)
@@ -270,7 +270,7 @@ func TestRoaringTestAndAddMultipleBatches(t *testing.T) {
 	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
 	require.NoError(t, err)
 
-	f := newroaringFilter(types.T_int32)
+	f := newRoaringFilter(types.T_int32)
 
 	// Batch 1: values 1, NULL, 3
 	v1 := makeVec(t, mp, types.T_int32.ToType(), []int32{1, 0, 3}, []bool{false, true, false})
@@ -337,7 +337,7 @@ func TestNewRoaringFilterAllTypes(t *testing.T) {
 		types.T_int8, types.T_int16, types.T_int32,
 		types.T_uint8, types.T_uint16, types.T_uint32,
 	} {
-		f := newroaringFilter(typ)
+		f := newRoaringFilter(typ)
 		require.NotNil(t, f)
 		require.NotNil(t, f.b)
 		require.NotNil(t, f.addFunc)

--- a/pkg/sql/colexec/fuzzyfilter/roaring_filter_test.go
+++ b/pkg/sql/colexec/fuzzyfilter/roaring_filter_test.go
@@ -1,0 +1,347 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package fuzzyfilter
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/stretchr/testify/require"
+)
+
+// makeVec creates a vector with explicit NULLs for testing.
+func makeVec[T canUseRoaring](t *testing.T, mp *mpool.MPool, typ types.Type, vals []T, isNull []bool) *vector.Vector {
+	t.Helper()
+	vec := vector.NewVec(typ)
+	require.NoError(t, vector.AppendFixedList(vec, vals, isNull, mp))
+	return vec
+}
+
+func TestRoaringAddFuncSkipsNulls(t *testing.T) {
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		typ       types.T
+		vals      []int32
+		isNull    []bool
+		wantCount uint64
+	}{
+		{
+			name:      "no nulls",
+			typ:       types.T_int32,
+			vals:      []int32{1, 2, 3},
+			isNull:    []bool{false, false, false},
+			wantCount: 3,
+		},
+		{
+			name:      "all nulls",
+			typ:       types.T_int32,
+			vals:      []int32{0, 0, 0},
+			isNull:    []bool{true, true, true},
+			wantCount: 0,
+		},
+		{
+			name:      "mixed nulls and values",
+			typ:       types.T_int32,
+			vals:      []int32{10, 0, 20, 0, 30},
+			isNull:    []bool{false, true, false, true, false},
+			wantCount: 3,
+		},
+		{
+			name:      "null at zero value - zero should not be added",
+			typ:       types.T_int32,
+			vals:      []int32{0},
+			isNull:    []bool{true},
+			wantCount: 0,
+		},
+		{
+			name:      "real zero vs null zero",
+			typ:       types.T_int32,
+			vals:      []int32{0, 0},
+			isNull:    []bool{false, true},
+			wantCount: 1, // only real zero
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newroaringFilter(tt.typ)
+			vec := makeVec(t, mp, tt.typ.ToType(), tt.vals, tt.isNull)
+			defer vec.Free(mp)
+			f.addFunc(f, vec)
+			require.Equal(t, tt.wantCount, f.b.GetCardinality(), "unexpected bitmap cardinality")
+		})
+	}
+}
+
+func TestRoaringTestFuncSkipsNulls(t *testing.T) {
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	require.NoError(t, err)
+
+	// Build a filter containing value 5.
+	f := newroaringFilter(types.T_int32)
+	{
+		buildVec := makeVec(t, mp, types.T_int32.ToType(), []int32{5}, []bool{false})
+		defer buildVec.Free(mp)
+		f.addFunc(f, buildVec)
+	}
+
+	tests := []struct {
+		name    string
+		vals    []int32
+		isNull  []bool
+		wantIdx int
+		wantVal any
+	}{
+		{
+			name:    "probe with matching value",
+			vals:    []int32{5},
+			isNull:  []bool{false},
+			wantIdx: 0,
+			wantVal: int32(5),
+		},
+		{
+			name:    "probe with null only - no match",
+			vals:    []int32{5},
+			isNull:  []bool{true},
+			wantIdx: -1,
+			wantVal: nil,
+		},
+		{
+			name:    "null before match - match still found",
+			vals:    []int32{0, 5},
+			isNull:  []bool{true, false},
+			wantIdx: 1,
+			wantVal: int32(5),
+		},
+		{
+			name:    "null with zero-value that matches bitmap entry",
+			vals:    []int32{5},
+			isNull:  []bool{true},
+			wantIdx: -1,
+			wantVal: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			probeVec := makeVec(t, mp, types.T_int32.ToType(), tt.vals, tt.isNull)
+			defer probeVec.Free(mp)
+			idx, val := f.testFunc(f, probeVec)
+			require.Equal(t, tt.wantIdx, idx, "unexpected index")
+			require.Equal(t, tt.wantVal, val, "unexpected value")
+		})
+	}
+}
+
+func TestRoaringTestAndAddFuncSkipsNulls(t *testing.T) {
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		vals         []int32
+		isNull       []bool
+		wantIdx      int
+		wantVal      any
+		wantBitCount uint64
+	}{
+		{
+			name:         "no duplicates, no nulls",
+			vals:         []int32{1, 2, 3},
+			isNull:       []bool{false, false, false},
+			wantIdx:      -1,
+			wantVal:      nil,
+			wantBitCount: 3,
+		},
+		{
+			name:         "duplicate detected",
+			vals:         []int32{1, 2, 1},
+			isNull:       []bool{false, false, false},
+			wantIdx:      2,
+			wantVal:      int32(1),
+			wantBitCount: 2, // 1 and 2 added before dup detected
+		},
+		{
+			name:         "multiple nulls - no false duplicate",
+			vals:         []int32{0, 0, 0},
+			isNull:       []bool{true, true, true},
+			wantIdx:      -1,
+			wantVal:      nil,
+			wantBitCount: 0,
+		},
+		{
+			name:         "nulls interleaved - only real values checked",
+			vals:         []int32{10, 0, 20, 0, 30},
+			isNull:       []bool{false, true, false, true, false},
+			wantIdx:      -1,
+			wantVal:      nil,
+			wantBitCount: 3,
+		},
+		{
+			name:         "null then duplicate real value",
+			vals:         []int32{0, 42, 42},
+			isNull:       []bool{true, false, false},
+			wantIdx:      2,
+			wantVal:      int32(42),
+			wantBitCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newroaringFilter(types.T_int32)
+			vec := makeVec(t, mp, types.T_int32.ToType(), tt.vals, tt.isNull)
+			defer vec.Free(mp)
+			idx, val := f.testAndAddFunc(f, vec)
+			require.Equal(t, tt.wantIdx, idx, "unexpected index")
+			require.Equal(t, tt.wantVal, val, "unexpected value")
+			require.Equal(t, tt.wantBitCount, f.b.GetCardinality(), "unexpected bitmap cardinality")
+		})
+	}
+}
+
+func TestRoaringMultipleTypes(t *testing.T) {
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	require.NoError(t, err)
+
+	t.Run("int8", func(t *testing.T) {
+		f := newroaringFilter(types.T_int8)
+		vec := vector.NewVec(types.T_int8.ToType())
+		require.NoError(t, vector.AppendFixedList(vec, []int8{1, 0, 3}, []bool{false, true, false}, mp))
+		defer vec.Free(mp)
+		f.addFunc(f, vec)
+		require.Equal(t, uint64(2), f.b.GetCardinality())
+	})
+
+	t.Run("int16", func(t *testing.T) {
+		f := newroaringFilter(types.T_int16)
+		vec := vector.NewVec(types.T_int16.ToType())
+		require.NoError(t, vector.AppendFixedList(vec, []int16{100, 0, 200}, []bool{false, true, false}, mp))
+		defer vec.Free(mp)
+		f.addFunc(f, vec)
+		require.Equal(t, uint64(2), f.b.GetCardinality())
+	})
+
+	t.Run("uint8", func(t *testing.T) {
+		f := newroaringFilter(types.T_uint8)
+		vec := vector.NewVec(types.T_uint8.ToType())
+		require.NoError(t, vector.AppendFixedList(vec, []uint8{10, 0, 20}, []bool{false, true, false}, mp))
+		defer vec.Free(mp)
+		f.addFunc(f, vec)
+		require.Equal(t, uint64(2), f.b.GetCardinality())
+	})
+
+	t.Run("uint16", func(t *testing.T) {
+		f := newroaringFilter(types.T_uint16)
+		vec := vector.NewVec(types.T_uint16.ToType())
+		require.NoError(t, vector.AppendFixedList(vec, []uint16{1000, 0, 2000}, []bool{false, true, false}, mp))
+		defer vec.Free(mp)
+		f.addFunc(f, vec)
+		require.Equal(t, uint64(2), f.b.GetCardinality())
+	})
+
+	t.Run("uint32", func(t *testing.T) {
+		f := newroaringFilter(types.T_uint32)
+		vec := vector.NewVec(types.T_uint32.ToType())
+		require.NoError(t, vector.AppendFixedList(vec, []uint32{50000, 0, 60000}, []bool{false, true, false}, mp))
+		defer vec.Free(mp)
+		f.addFunc(f, vec)
+		require.Equal(t, uint64(2), f.b.GetCardinality())
+	})
+}
+
+func TestRoaringTestAndAddMultipleBatches(t *testing.T) {
+	mp, err := mpool.NewMPool("test", 0, mpool.NoFixed)
+	require.NoError(t, err)
+
+	f := newroaringFilter(types.T_int32)
+
+	// Batch 1: values 1, NULL, 3
+	v1 := makeVec(t, mp, types.T_int32.ToType(), []int32{1, 0, 3}, []bool{false, true, false})
+	defer v1.Free(mp)
+	idx, _ := f.testAndAddFunc(f, v1)
+	require.Equal(t, -1, idx, "batch 1 should have no duplicates")
+
+	// Batch 2: values NULL, 2, NULL — no duplicate (NULLs skipped)
+	v2 := makeVec(t, mp, types.T_int32.ToType(), []int32{0, 2, 0}, []bool{true, false, true})
+	defer v2.Free(mp)
+	idx, _ = f.testAndAddFunc(f, v2)
+	require.Equal(t, -1, idx, "batch 2 NULLs should not trigger duplicate")
+
+	// Batch 3: values 1 — duplicate of batch 1
+	v3 := makeVec(t, mp, types.T_int32.ToType(), []int32{1}, []bool{false})
+	defer v3.Free(mp)
+	idx, val := f.testAndAddFunc(f, v3)
+	require.Equal(t, 0, idx, "batch 3 should detect duplicate")
+	require.Equal(t, int32(1), val)
+}
+
+func TestValueToString(t *testing.T) {
+	tests := []struct {
+		name string
+		val  any
+		want string
+	}{
+		{"int8", int8(42), "42"},
+		{"int16", int16(-100), "-100"},
+		{"int32", int32(999), "999"},
+		{"uint8", uint8(255), "255"},
+		{"uint16", uint16(65535), "65535"},
+		{"uint32", uint32(4294967295), "4294967295"},
+		{"nil", nil, ""},
+		{"string", "hello", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, valueToString(tt.val))
+		})
+	}
+}
+
+func TestIfCanUseRoaringFilter(t *testing.T) {
+	roaringTypes := []types.T{
+		types.T_int8, types.T_int16, types.T_int32,
+		types.T_uint8, types.T_uint16, types.T_uint32,
+	}
+	for _, typ := range roaringTypes {
+		require.True(t, IfCanUseRoaringFilter(typ), "expected true for %v", typ)
+	}
+
+	nonRoaringTypes := []types.T{
+		types.T_int64, types.T_uint64, types.T_float32, types.T_float64,
+		types.T_varchar, types.T_date, types.T_datetime,
+	}
+	for _, typ := range nonRoaringTypes {
+		require.False(t, IfCanUseRoaringFilter(typ), "expected false for %v", typ)
+	}
+}
+
+func TestNewRoaringFilterAllTypes(t *testing.T) {
+	for _, typ := range []types.T{
+		types.T_int8, types.T_int16, types.T_int32,
+		types.T_uint8, types.T_uint16, types.T_uint32,
+	} {
+		f := newroaringFilter(typ)
+		require.NotNil(t, f)
+		require.NotNil(t, f.b)
+		require.NotNil(t, f.addFunc)
+		require.NotNil(t, f.testFunc)
+		require.NotNil(t, f.testAndAddFunc)
+	}
+}

--- a/pkg/sql/colexec/hashbuild/build.go
+++ b/pkg/sql/colexec/hashbuild/build.go
@@ -372,10 +372,14 @@ func (hashBuild *HashBuild) handleRuntimeFilter(proc *process.Process) error {
 			if erg != nil {
 				return erg
 			}
+			// InplaceSort reorders data but NOT the null bitmap.
+			// NULLs are irrelevant for IN-filter: clear bitmap before sort.
+			vec.GetNulls().Reset()
 			vec.InplaceSort()
 			data, err = vec.MarshalBinary()
 			free()
 		} else {
+			ctr.hashmapBuilder.UniqueJoinKeys[0].GetNulls().Reset()
 			ctr.hashmapBuilder.UniqueJoinKeys[0].InplaceSort()
 			data, err = ctr.hashmapBuilder.UniqueJoinKeys[0].MarshalBinary()
 		}

--- a/pkg/sql/colexec/hashbuild/build_test.go
+++ b/pkg/sql/colexec/hashbuild/build_test.go
@@ -411,6 +411,117 @@ func TestHashBuildHashOnPK(t *testing.T) {
 	tc.proc.Free()
 }
 
+// TestHashBuildRuntimeFilterWithNulls verifies that NULLs in the build side
+// don't corrupt the runtime filter. Before the fix, InplaceSort reordered
+// data but NOT the null bitmap, corrupting the serialized filter.
+func TestHashBuildRuntimeFilterWithNulls(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	proc.SetMessageBoard(message.NewMessageBoard())
+	proc.Reg.MergeReceivers = make([]*process.WaitRegister, 1)
+	proc.Reg.MergeReceivers[0] = &process.WaitRegister{
+		Ch2: make(chan process.PipelineSignal, 10),
+	}
+
+	arg := &HashBuild{
+		JoinMapTag:    1,
+		JoinMapRefCnt: 1,
+		Conditions: []*plan.Expr{
+			newExpr(0, types.T_int32.ToType()),
+		},
+		NeedHashMap: true,
+		RuntimeFilterSpec: &plan.RuntimeFilterSpec{
+			Tag:        1,
+			UpperLimit: 10000,
+			Expr:       newExpr(0, types.T_int32.ToType()),
+		},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{
+				Idx:     0,
+				IsFirst: false,
+				IsLast:  false,
+			},
+		},
+	}
+
+	err := arg.Prepare(proc)
+	require.NoError(t, err)
+
+	// Create a batch with NULLs at every even index.
+	bat := testutil.NewBatchWithNulls(
+		[]types.Type{types.T_int32.ToType()}, false, 10, proc.Mp(),
+	)
+	proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(bat, nil, proc.Mp())
+	proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(batch.EmptyBatch, nil, proc.Mp())
+	proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(nil, nil, proc.Mp())
+
+	marg := &merge.Merge{}
+	err = marg.Prepare(proc)
+	require.NoError(t, err)
+	arg.SetChildren([]vm.Operator{marg})
+
+	ok, err := vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.Equal(t, vm.ExecStop, ok.Status)
+
+	arg.Free(proc, false, nil)
+	proc.Free()
+}
+
+// TestHashBuildRuntimeFilterWithNullsHashOnPK tests the hashOnPK path
+// where UniqueJoinKeys include NULLs from UnionBatch.
+func TestHashBuildRuntimeFilterWithNullsHashOnPK(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	proc.SetMessageBoard(message.NewMessageBoard())
+	proc.Reg.MergeReceivers = make([]*process.WaitRegister, 1)
+	proc.Reg.MergeReceivers[0] = &process.WaitRegister{
+		Ch2: make(chan process.PipelineSignal, 10),
+	}
+
+	arg := &HashBuild{
+		JoinMapTag:    1,
+		JoinMapRefCnt: 1,
+		HashOnPK:      true,
+		Conditions: []*plan.Expr{
+			newExpr(0, types.T_int32.ToType()),
+		},
+		NeedHashMap: true,
+		RuntimeFilterSpec: &plan.RuntimeFilterSpec{
+			Tag:        1,
+			UpperLimit: 10000,
+			Expr:       newExpr(0, types.T_int32.ToType()),
+		},
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{
+				Idx:     0,
+				IsFirst: false,
+				IsLast:  false,
+			},
+		},
+	}
+
+	err := arg.Prepare(proc)
+	require.NoError(t, err)
+
+	bat := testutil.NewBatchWithNulls(
+		[]types.Type{types.T_int32.ToType()}, false, 10, proc.Mp(),
+	)
+	proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(bat, nil, proc.Mp())
+	proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(batch.EmptyBatch, nil, proc.Mp())
+	proc.Reg.MergeReceivers[0].Ch2 <- process.NewPipelineSignalToDirectly(nil, nil, proc.Mp())
+
+	marg := &merge.Merge{}
+	err = marg.Prepare(proc)
+	require.NoError(t, err)
+	arg.SetChildren([]vm.Operator{marg})
+
+	ok, err := vm.Exec(arg, proc)
+	require.NoError(t, err)
+	require.Equal(t, vm.ExecStop, ok.Status)
+
+	arg.Free(proc, false, nil)
+	proc.Free()
+}
+
 func TestHashBuildIsShuffle(t *testing.T) {
 	tc := newTestCase(t, []bool{false}, []types.Type{types.T_int32.ToType()}, []*plan.Expr{newExpr(0, types.T_int32.ToType())})
 	tc.arg.IsShuffle = true

--- a/pkg/sql/colexec/indexbuild/build.go
+++ b/pkg/sql/colexec/indexbuild/build.go
@@ -133,6 +133,9 @@ func (ctr *container) handleRuntimeFilter(ap *IndexBuild, proc *process.Process)
 			panic("there must be only 1 vector in index build batch")
 		}
 		vec := ctr.buf.Vecs[0]
+		// InplaceSort reorders data but NOT the null bitmap.
+		// NULLs are irrelevant for IN-filter: clear bitmap before sort.
+		vec.GetNulls().Reset()
 		vec.InplaceSort()
 		data, err := vec.MarshalBinary()
 		if err != nil {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24055 — hashbuild InplaceSort NULL bitmap corruption in runtime filter
Fixes #24056 — FuzzyFilter roaring_filter NULL handling for UNIQUE INDEX

## What this PR does / why we need it:

Fixes three related NULL-handling bugs discovered during the investigation of PR #24054:

### 1. hashbuild runtime filter InplaceSort (build.go)

`handleRuntimeFilter()` calls `InplaceSort()` on `UniqueJoinKeys` vectors before serializing them as runtime IN-filters. However, `InplaceSort()` reorders the data array but **never updates the null bitmap** (`nsp`). After sorting, null positions in the bitmap no longer correspond to actual null values, producing corrupted serialized filter data.

**Fix**: Call `GetNulls().Reset()` before `InplaceSort()`. NULLs are irrelevant for IN-filter matching (probe side should never match NULLs), so clearing the bitmap is the correct and cheapest fix.

### 2. fuzzyfilter roaring bitmap NULL handling (roaring_filter.go)

`addFunc`, `testFunc`, and `testAndAddFunc` iterate all vector values without checking the null bitmap. NULL values (which appear as zero in the raw data) get added to the roaring bitmap as if they were real values.

**Fix**: Add `nsp.Contains(uint64(i))` check to skip NULL rows in all three functions. Per SQL standard, NULL != NULL.

### 3. fuzzyfilter pass2RuntimeFilter InplaceSort (filter.go)

Defensive fix: Reset null bitmap before `InplaceSort()` on `pass2RuntimeFilter`, same pattern as fix #1.

### 4. indexbuild InplaceSort (indexbuild/build.go)

Same InplaceSort null bitmap corruption pattern as hashbuild. `indexBuild.handleRuntimeFilter()` sorts vectors without resetting the null bitmap.

## Test coverage

### roaring_filter_test.go (new, 30 sub-tests)
- `TestRoaringAddFuncSkipsNulls` / `TestRoaringTestFuncSkipsNulls` / `TestRoaringTestAndAddFuncSkipsNulls`
- `TestRoaringMultipleTypes` / `TestRoaringTestAndAddMultipleBatches`
- `TestValueToString` / `TestIfCanUseRoaringFilter` / `TestNewRoaringFilterAllTypes`

### build_test.go (2 new tests)
- `TestHashBuildRuntimeFilterWithNulls` / `TestHashBuildRuntimeFilterWithNullsHashOnPK`

| Function | Coverage |
|----------|----------|
| addFunc | 100% |
| testFunc | 100% |
| testAndAddFunc | 100% |
| handleRuntimeFilter | 52.7% (fix lines covered) |
