### PR TITLE
fix: 4 CN memory leak/growth issues (#24058 #24059 #24060 #24061)

### DIFF
--- a/pkg/sql/colexec/aggexec/aggState.go
+++ b/pkg/sql/colexec/aggexec/aggState.go
@@ -129,6 +129,8 @@ func (ag *aggState) init(mp *mpool.MPool, l, c int32, info *aggInfo, setNulls bo
 		}
 
 		if ag.argbuf, err = mp.Alloc(bufsz, true); err != nil {
+			mpool.FreeSlice(mp, ag.argCnt)
+			ag.argCnt = nil
 			return err
 		}
 		arena := arenaskl.NewArena(ag.argbuf)

--- a/pkg/sql/colexec/aggexec/aggexec_test.go
+++ b/pkg/sql/colexec/aggexec/aggexec_test.go
@@ -72,3 +72,57 @@ func TestVectorsUnmarshalFromReader(t *testing.T) {
 	exec.Free()
 	exec2.Free()
 }
+
+func TestAggStateInitSaveArgCleanup(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer func() {
+		require.Equal(t, int64(0), mp.CurrNB())
+	}()
+
+	t.Run("normal_init_and_free", func(t *testing.T) {
+		ag := &aggState{}
+		info := &aggInfo{saveArg: true}
+		err := ag.init(mp, 0, 100, info, false)
+		require.NoError(t, err)
+		require.NotNil(t, ag.argCnt)
+		require.NotNil(t, ag.argbuf)
+		require.NotNil(t, ag.argSkl)
+		ag.free(mp)
+		require.Nil(t, ag.argCnt)
+		require.Nil(t, ag.argSkl)
+	})
+
+	t.Run("error_path_argCnt_cleanup", func(t *testing.T) {
+		// Create a limited mpool and pre-fill it so MakeSlice succeeds
+		// but the subsequent Alloc(16KB) fails — exercising the real fix path.
+		limitedMp, err := mpool.NewMPool("limited", 1024*1024, mpool.NoFixed)
+		require.NoError(t, err)
+
+		// Pre-fill to leave only ~4KB free (16KB Alloc will fail)
+		filler, err := limitedMp.Alloc(1024*1024-4*1024, true)
+		require.NoError(t, err)
+
+		ag := &aggState{}
+		info := &aggInfo{saveArg: true}
+		err = ag.init(limitedMp, 0, 100, info, false)
+		require.Error(t, err, "Alloc should fail due to mpool capacity")
+		require.Nil(t, ag.argCnt, "argCnt must be freed on Alloc failure")
+
+		limitedMp.Free(filler)
+		mpool.DeleteMPool(limitedMp)
+	})
+
+	t.Run("non_savearg_path", func(t *testing.T) {
+		ag := &aggState{}
+		info := &aggInfo{
+			saveArg:    false,
+			stateTypes: []types.Type{types.T_int64.ToType()},
+			emptyNull:  true,
+		}
+		err := ag.init(mp, 0, 100, info, true)
+		require.NoError(t, err)
+		require.Nil(t, ag.argCnt)
+		require.NotNil(t, ag.vecs)
+		ag.free(mp)
+	})
+}

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -1392,6 +1392,13 @@ func GetExprZoneMap(
 			default:
 				ivecs := make([]*vector.Vector, len(args))
 				if isAllConst(args) { // constant fold
+					defer func() {
+						for _, v := range ivecs {
+							if v != nil {
+								v.Free(proc.Mp())
+							}
+						}
+					}()
 					for i, arg := range args {
 						if vecs[arg.AuxId] != nil {
 							vecs[arg.AuxId].Free(proc.Mp())

--- a/pkg/sql/colexec/evalExpression_test.go
+++ b/pkg/sql/colexec/evalExpression_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
 )
@@ -575,4 +576,53 @@ func TestTimestampLiteral_ScaleValidation(t *testing.T) {
 		require.Contains(t, err.Error(), "TIMESTAMP")
 		require.Contains(t, err.Error(), "Maximum is 6")
 	})
+}
+
+func TestGetExprZoneMapConstantFold(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	// Build abs(-42): a function in the "default" case with all-constant args.
+	// This exercises the constant-fold path and the defer cleanup for ivecs.
+	argExpr := &plan.Expr{
+		Expr: &plan.Expr_Lit{Lit: &plan.Literal{
+			Isnull: false,
+			Value:  &plan.Literal_I64Val{I64Val: -42},
+		}},
+		Typ:   plan.Type{Id: int32(types.T_int64), NotNullable: true},
+		AuxId: 0,
+	}
+
+	// Resolve the "abs" function for int64
+	fGet, err := function.GetFunctionByName(ctx, "abs", []types.Type{types.T_int64.ToType()})
+	require.NoError(t, err)
+	funcID := fGet.GetEncodedOverloadID()
+	retType := fGet.GetReturnType()
+
+	funcExpr := &plan.Expr{
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{
+				Obj:     funcID,
+				ObjName: "abs",
+			},
+			Args: []*plan.Expr{argExpr},
+		}},
+		Typ:   plan.Type{Id: int32(retType.Oid), Width: retType.Width, Scale: retType.Scale},
+		AuxId: 1,
+	}
+
+	// Allocate ZM and vec arrays (size = max AuxId + 1)
+	zms := make([]index.ZM, 2)
+	vecs := make([]*vector.Vector, 2)
+
+	zm := GetExprZoneMap(ctx, proc, funcExpr, nil, nil, zms, vecs)
+	require.True(t, zm.IsInited(), "result zone map should be initialized")
+
+	// Clean up any vecs allocated during evaluation
+	for _, v := range vecs {
+		if v != nil {
+			v.Free(proc.Mp())
+		}
+	}
+	proc.Free()
 }

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -883,15 +883,16 @@ func (e *Engine) setPushClientStatus(ready bool) {
 
 func (e *Engine) cleanMemoryTableWithTable(dbId, tblId uint64) {
 	e.Lock()
-	defer e.Unlock()
 	// XXX it's probably not a good way to do that.
 	// after we set it to empty, actually this part of memory was not immediately released.
 	// maybe a very old transaction still using that.
 	delete(e.partitions, [2]uint64{dbId, tblId})
+	e.Unlock()
 
-	//  When removing the PartitionState, you need to remove the tid in globalStats,
-	// When re-subscribing, globalStats will wait for the PartitionState to be consumed before updating the object state.
-	//e.globalStats.RemoveTid(tblId)
+	// Remove the tid from globalStats AFTER releasing Engine lock to avoid
+	// deadlock: cleanMemoryTableWithTable holds Engine.mu→GlobalStats.mu,
+	// while GlobalStats.Get holds GlobalStats.mu→Engine.mu (via GetOrCreateLatestPart).
+	e.globalStats.RemoveTid(tblId)
 	logutil.Debugf("clean memory table of tbl[dbId: %d, tblId: %d]", dbId, tblId)
 }
 

--- a/pkg/vm/engine/disttae/stats.go
+++ b/pkg/vm/engine/disttae/stats.go
@@ -318,6 +318,23 @@ func (gs *GlobalStats) keyExists(key pb.StatsInfoKey) bool {
 	return ok
 }
 
+// RemoveTid removes all statsInfoMap entries for the given table ID.
+// Called from cleanMemoryTableWithTable (1+ hour after unsubscribe/drop)
+// to prevent unbounded map growth. Safe because no queries target a
+// table that has been unsubscribed for over an hour.
+func (gs *GlobalStats) RemoveTid(tableID uint64) {
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+	for key := range gs.mu.statsInfoMap {
+		if key.TableID == tableID {
+			delete(gs.mu.statsInfoMap, key)
+		}
+	}
+	if gs.mu.cond != nil {
+		gs.mu.cond.Broadcast()
+	}
+}
+
 func (gs *GlobalStats) PrefetchTableMeta(ctx context.Context, key pb.StatsInfoKey) bool {
 	wrapkey := pb.StatsInfoKeyWithContext{
 		Ctx: ctx,

--- a/pkg/vm/engine/disttae/stats_test.go
+++ b/pkg/vm/engine/disttae/stats_test.go
@@ -1640,3 +1640,135 @@ func TestGlobalStats_ShouldEnqueue(t *testing.T) {
 		gs.updatingMu.Unlock()
 	})
 }
+
+func TestCleanMemoryTableWithTable(t *testing.T) {
+	t.Run("removes_partition_and_stats", func(t *testing.T) {
+		runTest(t, func(ctx context.Context, e *Engine) {
+			dbId, tblId := uint64(100), uint64(1001)
+
+			// Insert a fake partition (nil is valid; delete works on nil values)
+			e.Lock()
+			e.partitions[[2]uint64{dbId, tblId}] = nil
+			e.Unlock()
+
+			// Insert a stats entry for the same table
+			k := statsinfo.StatsInfoKey{DatabaseID: dbId, TableID: tblId, TableName: "t"}
+			e.globalStats.mu.Lock()
+			e.globalStats.mu.statsInfoMap[k] = plan2.NewStatsInfo()
+			e.globalStats.mu.Unlock()
+
+			// Call cleanMemoryTableWithTable
+			e.cleanMemoryTableWithTable(dbId, tblId)
+
+			// Verify partition removed
+			e.Lock()
+			_, partOk := e.partitions[[2]uint64{dbId, tblId}]
+			e.Unlock()
+			assert.False(t, partOk, "partition should be removed")
+
+			// Verify stats entry removed via RemoveTid
+			e.globalStats.mu.Lock()
+			_, statsOk := e.globalStats.mu.statsInfoMap[k]
+			e.globalStats.mu.Unlock()
+			assert.False(t, statsOk, "stats entry should be removed")
+		})
+	})
+
+	t.Run("no_panic_on_missing_partition", func(t *testing.T) {
+		runTest(t, func(ctx context.Context, e *Engine) {
+			// Calling with non-existent partition should not panic
+			e.cleanMemoryTableWithTable(999, 888)
+		})
+	})
+}
+
+func TestRemoveTid(t *testing.T) {
+	t.Run("remove_existing_entries", func(t *testing.T) {
+		runTest(t, func(ctx context.Context, e *Engine) {
+			gs := e.globalStats
+
+			// Insert entries for two tables
+			k1 := statsinfo.StatsInfoKey{DatabaseID: 100, TableID: 1001, TableName: "t1"}
+			k2 := statsinfo.StatsInfoKey{DatabaseID: 100, TableID: 1001, TableName: "t1_alt"}
+			k3 := statsinfo.StatsInfoKey{DatabaseID: 200, TableID: 2001, TableName: "t2"}
+
+			gs.mu.Lock()
+			gs.mu.statsInfoMap[k1] = plan2.NewStatsInfo()
+			gs.mu.statsInfoMap[k2] = nil // simulate failed update
+			gs.mu.statsInfoMap[k3] = plan2.NewStatsInfo()
+			gs.mu.Unlock()
+
+			// Remove table 1001 entries
+			gs.RemoveTid(1001)
+
+			gs.mu.Lock()
+			defer gs.mu.Unlock()
+			_, ok1 := gs.mu.statsInfoMap[k1]
+			_, ok2 := gs.mu.statsInfoMap[k2]
+			_, ok3 := gs.mu.statsInfoMap[k3]
+			assert.False(t, ok1, "k1 should be removed")
+			assert.False(t, ok2, "k2 should be removed")
+			assert.True(t, ok3, "k3 should not be removed")
+		})
+	})
+
+	t.Run("remove_nonexistent_table", func(t *testing.T) {
+		runTest(t, func(ctx context.Context, e *Engine) {
+			gs := e.globalStats
+
+			k := statsinfo.StatsInfoKey{DatabaseID: 100, TableID: 1001}
+			gs.mu.Lock()
+			gs.mu.statsInfoMap[k] = plan2.NewStatsInfo()
+			gs.mu.Unlock()
+
+			// Remove a non-existent table — should not panic
+			gs.RemoveTid(9999)
+
+			gs.mu.Lock()
+			defer gs.mu.Unlock()
+			_, ok := gs.mu.statsInfoMap[k]
+			assert.True(t, ok, "existing entry should remain")
+		})
+	})
+
+	t.Run("remove_wakes_waiting_goroutines", func(t *testing.T) {
+		runTest(t, func(ctx context.Context, e *Engine) {
+			gs := e.globalStats
+
+			// Set up: goroutine will cond.Wait() on a key, RemoveTid should broadcast
+			targetKey := statsinfo.StatsInfoKey{TableID: 42, DatabaseID: 1}
+
+			woken := make(chan bool, 1)
+			gs.mu.Lock()
+			go func() {
+				gs.mu.Lock()
+				defer gs.mu.Unlock()
+				// Block on cond.Wait() like production GlobalStats.Get does
+				for {
+					if _, ok := gs.mu.statsInfoMap[targetKey]; ok {
+						break
+					}
+					// cond.Wait releases the lock and waits for Broadcast
+					gs.mu.cond.Wait()
+					// After Broadcast, check if our condition changed
+					break
+				}
+				woken <- true
+			}()
+			gs.mu.Unlock()
+
+			// Small sleep to let goroutine enter cond.Wait()
+			time.Sleep(50 * time.Millisecond)
+
+			// RemoveTid broadcasts to cond, which should wake the waiting goroutine
+			gs.RemoveTid(999)
+
+			select {
+			case <-woken:
+				// ok — goroutine was woken by Broadcast
+			case <-time.After(2 * time.Second):
+				t.Fatal("RemoveTid did not wake goroutine blocked on cond.Wait()")
+			}
+		})
+	})
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24058 #24059 #24060 #24061

## What this PR does / why we need it:

Fixes 4 CN memory leak/growth issues:

1. **aggState.go**: Free `argCnt` on `Alloc()` failure path — prevents mpool leak when arena allocation fails after `MakeSlice` succeeds (#24061)
2. **evalExpression.go**: Defer cleanup for constant-fold `ivecs` in `GetExprZoneMap` — prevents vector leak in constant folding (#24060)
3. **engine.go**: Move `RemoveTid` call outside Engine lock to prevent deadlock between `Engine.mu` and `GlobalStats.mu`, and uncomment the previously disabled `RemoveTid` call (#24058)
4. **stats.go**: Add `RemoveTid()` method — cleans up `statsInfoMap` entries when tables are unsubscribed, preventing unbounded map growth (#24059)

### Tests added:
- `aggexec_test.go`: 3 sub-tests — normal init/free, real Alloc failure path (limited mpool), non-savearg path
- `stats_test.go`: 3 sub-tests — remove existing entries, nonexistent table, broadcast wakeup
- `stats_test.go`: 2 sub-tests — TestCleanMemoryTableWithTable (partition+stats removal, missing partition)
- `evalExpression_test.go`: TestGetExprZoneMapConstantFold — exercises the constant-fold defer cleanup via `abs(-42)`

### Not included (reverted):
- **scope.go** `ctx.Done()` check in `mergeRunSelectLoop` was reverted: caused ISCP executor test failures because pre-scope goroutines already handle context cancellation internally. Issue #24058 remains open for the goroutine leak concern.