### PR TITLE
fix: skip checkTableIsMaster during FK table restoration to prevent flaky restore failures

### DIFF
--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -1430,13 +1430,16 @@ func restoreToDatabaseOrTableWithPitr(
 			return
 		}
 
+		// Skip master check for TABLE/DATABASE level restore:
+		// 1. User explicitly specifies which table(s) to restore
+		// 2. If the table is referenced by other tables restored earlier, master check would incorrectly block
 		if err = reCreateTableWithPitr(ctx,
 			sid,
 			bh,
 			pitrName,
 			ts,
 			tblInfo,
-			false); err != nil {
+			true); err != nil {
 			return
 		}
 	}
@@ -1834,7 +1837,8 @@ func restoreSystemDatabaseWithPitr(
 			return
 		}
 
-		if err = reCreateTableWithPitr(ctx, sid, bh, pitrName, ts, tblInfo, false); err != nil {
+		// Skip master check for system tables - they are restored as part of the system database
+		if err = reCreateTableWithPitr(ctx, sid, bh, pitrName, ts, tblInfo, true); err != nil {
 			return
 		}
 	}

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -1435,7 +1435,8 @@ func restoreToDatabaseOrTableWithPitr(
 			bh,
 			pitrName,
 			ts,
-			tblInfo); err != nil {
+			tblInfo,
+			false); err != nil {
 			return
 		}
 	}
@@ -1456,15 +1457,21 @@ func reCreateTableWithPitr(
 	bh BackgroundExec,
 	pitrName string,
 	ts int64,
-	tblInfo *tableInfo) (err error) {
+	tblInfo *tableInfo,
+	skipMasterCheck bool) (err error) {
 	getLogger(sid).Info(fmt.Sprintf("[%s] start to restore table: '%v' at timestamp %d", pitrName, tblInfo.tblName, ts))
 
-	var isMasterTable bool
-	isMasterTable, err = checkTableIsMaster(ctx, sid, bh, pitrName, tblInfo.dbName, tblInfo.tblName)
-	if isMasterTable {
-		// skip restore the table which is master table
-		getLogger(sid).Info(fmt.Sprintf("[%s] skip restore master table: %v.%v", pitrName, tblInfo.dbName, tblInfo.tblName))
-		return
+	if !skipMasterCheck {
+		var isMasterTable bool
+		isMasterTable, err = checkTableIsMaster(ctx, sid, bh, pitrName, tblInfo.dbName, tblInfo.tblName)
+		if err != nil {
+			return
+		}
+		if isMasterTable {
+			// skip restore the table which is master table
+			getLogger(sid).Info(fmt.Sprintf("[%s] skip restore master table: %v.%v", pitrName, tblInfo.dbName, tblInfo.tblName))
+			return
+		}
 	}
 
 	if err = bh.Exec(ctx, fmt.Sprintf("use `%s`", tblInfo.dbName)); err != nil {
@@ -1696,7 +1703,7 @@ func restoreTablesWithFkByPitr(
 		// e.g. t1.pk <- t2.fk, we only want to restore t2, fkTableMap[t1.key] is nil, ignore t1
 		if tblInfo := fkTableMap[key]; tblInfo != nil {
 			getLogger(sid).Info(fmt.Sprintf("[%s] start to restore table with fk: %v, restore timestamp: %d", pitrName, tblInfo.tblName, ts))
-			if err = reCreateTableWithPitr(ctx, sid, bh, pitrName, ts, tblInfo); err != nil {
+			if err = reCreateTableWithPitr(ctx, sid, bh, pitrName, ts, tblInfo, true); err != nil {
 				return
 			}
 		}
@@ -1827,7 +1834,7 @@ func restoreSystemDatabaseWithPitr(
 			return
 		}
 
-		if err = reCreateTableWithPitr(ctx, sid, bh, pitrName, ts, tblInfo); err != nil {
+		if err = reCreateTableWithPitr(ctx, sid, bh, pitrName, ts, tblInfo, false); err != nil {
 			return
 		}
 	}

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -1498,11 +1498,17 @@ func reCreateTableWithPitr(
 		}
 	}
 
+	// Use a context with IgnoreForeignKey=true for clone operations.
+	// This skips FK validation during restore, as FK tables are already restored
+	// in topological order by restoreTablesWithFkByPitr(). Without this, Resolve() can
+	// fail with ExpectedEOB when the database was drop+recreated in the same transaction.
+	cloneCtx := context.WithValue(ctx, defines.IgnoreForeignKey{}, true)
+
 	// insert data
 	insertIntoSql := fmt.Sprintf(restoreTableDataByTsFmt, tblInfo.dbName, tblInfo.tblName, tblInfo.dbName, tblInfo.tblName, ts)
 	beginTime := time.Now()
 	getLogger(sid).Info(fmt.Sprintf("[%s] start to insert select table: '%v', insert sql: %s", pitrName, tblInfo.tblName, insertIntoSql))
-	if err = bh.Exec(ctx, insertIntoSql); err != nil {
+	if err = bh.Exec(cloneCtx, insertIntoSql); err != nil {
 		return
 	}
 	getLogger(sid).Info(fmt.Sprintf("[%s] insert select table: %v, cost: %v", pitrName, tblInfo.tblName, time.Since(beginTime)))

--- a/pkg/frontend/pitr_test.go
+++ b/pkg/frontend/pitr_test.go
@@ -17,7 +17,7 @@ package frontend
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +25,7 @@ import (
 	"github.com/prashantv/gostub"
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -3444,4 +3445,248 @@ func Test_getPitrLengthAndUnit(t *testing.T) {
 
 	_, _, _, err = getPitrLengthAndUnit(ctx, bh, "table", "", "", "tbl")
 	assert.Error(t, err)
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests for reCreateTableWithPitr skipMasterCheck and restoreTablesWithFkByPitr
+// ──────────────────────────────────────────────────────────────────────────────
+
+func Test_reCreateTableWithPitr_SkipMasterCheck(t *testing.T) {
+	convey.Convey("reCreateTableWithPitr with skipMasterCheck=true should always restore table", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// Register a result for checkTableIsMaster that would return true.
+		// With skipMasterCheck=true, this should be ignored.
+		masterCheckSql := fmt.Sprintf(checkTableIsMasterFormat, "testdb", "parent_tbl")
+		bh.sql2result[masterCheckSql] = newMrsForCheckMaster([][]interface{}{{"testdb", "child_tbl"}})
+
+		tblInfo := &tableInfo{
+			dbName:  "testdb",
+			tblName: "parent_tbl",
+		}
+
+		err := reCreateTableWithPitr(ctx, "", bh, "pitr01", 100, tblInfo, true)
+		convey.So(err, convey.ShouldBeNil)
+
+		// Verify that the master check SQL was NOT executed
+		convey.So(bh.hasExecuted(masterCheckSql), convey.ShouldBeFalse)
+
+		// Verify that use/drop/clone SQLs WERE executed
+		convey.So(bh.hasExecuted("use `testdb`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `parent_tbl`"), convey.ShouldBeTrue)
+
+		// The clone SQL should have been executed
+		cloneExecuted := false
+		for _, sql := range bh.executedSqls {
+			if strings.Contains(sql, "clone") && strings.Contains(sql, "parent_tbl") {
+				cloneExecuted = true
+				break
+			}
+		}
+		convey.So(cloneExecuted, convey.ShouldBeTrue)
+	})
+}
+
+func Test_reCreateTableWithPitr_MasterTableSkipped(t *testing.T) {
+	convey.Convey("reCreateTableWithPitr with skipMasterCheck=false should skip master tables", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// Register a result that makes checkTableIsMaster return true
+		masterCheckSql := fmt.Sprintf(checkTableIsMasterFormat, "testdb", "parent_tbl")
+		bh.sql2result[masterCheckSql] = newMrsForCheckMaster([][]interface{}{{"testdb", "child_tbl"}})
+
+		tblInfo := &tableInfo{
+			dbName:  "testdb",
+			tblName: "parent_tbl",
+		}
+
+		err := reCreateTableWithPitr(ctx, "", bh, "pitr01", 100, tblInfo, false)
+		convey.So(err, convey.ShouldBeNil)
+
+		// Verify master check WAS executed
+		convey.So(bh.hasExecuted(masterCheckSql), convey.ShouldBeTrue)
+
+		// Verify that use/drop/clone were NOT executed (table was skipped)
+		convey.So(bh.hasExecuted("use `testdb`"), convey.ShouldBeFalse)
+		convey.So(bh.hasExecuted("drop table if exists `parent_tbl`"), convey.ShouldBeFalse)
+	})
+}
+
+func Test_reCreateTableWithPitr_NonMasterProceeds(t *testing.T) {
+	convey.Convey("reCreateTableWithPitr with skipMasterCheck=false should proceed for non-master tables", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// Register an empty result → checkTableIsMaster returns false
+		masterCheckSql := fmt.Sprintf(checkTableIsMasterFormat, "testdb", "leaf_tbl")
+		bh.sql2result[masterCheckSql] = newMrsForCheckMaster([][]interface{}{})
+
+		tblInfo := &tableInfo{
+			dbName:  "testdb",
+			tblName: "leaf_tbl",
+		}
+
+		err := reCreateTableWithPitr(ctx, "", bh, "pitr01", 100, tblInfo, false)
+		convey.So(err, convey.ShouldBeNil)
+
+		// Master check was executed
+		convey.So(bh.hasExecuted(masterCheckSql), convey.ShouldBeTrue)
+
+		// And the restore proceeded
+		convey.So(bh.hasExecuted("use `testdb`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `leaf_tbl`"), convey.ShouldBeTrue)
+	})
+}
+
+func Test_reCreateTableWithPitr_MasterCheckError(t *testing.T) {
+	convey.Convey("reCreateTableWithPitr propagates checkTableIsMaster errors", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// Do NOT register a result for the master check SQL.
+		// getResultSet will fail when it encounters nil.
+		tblInfo := &tableInfo{
+			dbName:  "testdb",
+			tblName: "some_tbl",
+		}
+
+		err := reCreateTableWithPitr(ctx, "", bh, "pitr01", 100, tblInfo, false)
+		convey.So(err, convey.ShouldNotBeNil)
+		convey.So(err.Error(), convey.ShouldContainSubstring, "not the type of result set")
+
+		// The restore should NOT have proceeded
+		convey.So(bh.hasExecuted("use `testdb`"), convey.ShouldBeFalse)
+	})
+}
+
+func Test_restoreTablesWithFkByPitr_AlwaysRestoresParentTables(t *testing.T) {
+	convey.Convey("restoreTablesWithFkByPitr should always restore parent tables (skipMasterCheck=true)", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// Setup: pri01 is a parent table that checkTableIsMaster would report as master.
+		// In the old code, this would cause pri01 to be skipped, breaking child FK validation.
+		masterCheckPri := fmt.Sprintf(checkTableIsMasterFormat, "acc_test02", "pri01")
+		bh.sql2result[masterCheckPri] = newMrsForCheckMaster([][]interface{}{{"acc_test02", "aff01"}})
+
+		masterCheckAff := fmt.Sprintf(checkTableIsMasterFormat, "acc_test02", "aff01")
+		bh.sql2result[masterCheckAff] = newMrsForCheckMaster([][]interface{}{})
+
+		// Topo-sorted: parent first, then child
+		sortedFkTbls := []string{
+			genKey("acc_test02", "pri01"),
+			genKey("acc_test02", "aff01"),
+		}
+
+		fkTableMap := map[string]*tableInfo{
+			genKey("acc_test02", "pri01"): {dbName: "acc_test02", tblName: "pri01"},
+			genKey("acc_test02", "aff01"): {dbName: "acc_test02", tblName: "aff01"},
+		}
+
+		err := restoreTablesWithFkByPitr(ctx, "", bh, "pitr01", 100, sortedFkTbls, fkTableMap)
+		convey.So(err, convey.ShouldBeNil)
+
+		// Both tables should have been restored
+		convey.So(bh.hasExecuted("use `acc_test02`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `pri01`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `aff01`"), convey.ShouldBeTrue)
+
+		// Master check should NOT have been executed (skipMasterCheck=true inside restoreTablesWithFkByPitr)
+		convey.So(bh.hasExecuted(masterCheckPri), convey.ShouldBeFalse)
+		convey.So(bh.hasExecuted(masterCheckAff), convey.ShouldBeFalse)
+	})
+}
+
+func Test_restoreTablesWithFkByPitr_SkipsNilEntries(t *testing.T) {
+	convey.Convey("restoreTablesWithFkByPitr skips tables not in fkTableMap", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// t1.pk <- t2.fk, but we only restore t2. t1 is nil in fkTableMap.
+		sortedFkTbls := []string{
+			genKey("db1", "t1"),
+			genKey("db1", "t2"),
+		}
+
+		fkTableMap := map[string]*tableInfo{
+			genKey("db1", "t2"): {dbName: "db1", tblName: "t2"},
+			// t1 not in map → should be skipped
+		}
+
+		err := restoreTablesWithFkByPitr(ctx, "", bh, "pitr01", 100, sortedFkTbls, fkTableMap)
+		convey.So(err, convey.ShouldBeNil)
+
+		// t2 should be restored, t1 should not
+		convey.So(bh.hasExecuted("drop table if exists `t2`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `t1`"), convey.ShouldBeFalse)
+	})
+}
+
+func Test_restoreTablesWithFkByPitr_EmptyList(t *testing.T) {
+	convey.Convey("restoreTablesWithFkByPitr with empty list succeeds", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		err := restoreTablesWithFkByPitr(ctx, "", bh, "pitr01", 100, nil, nil)
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(len(bh.executedSqls), convey.ShouldEqual, 0)
+	})
+}
+
+func Test_restoreTablesWithFkByPitr_MultipleParentChain(t *testing.T) {
+	convey.Convey("restoreTablesWithFkByPitr handles multi-level FK chain", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// grandparent -> parent -> child: all should be restored without master check
+		sortedFkTbls := []string{
+			genKey("db1", "grandparent"),
+			genKey("db1", "parent"),
+			genKey("db1", "child"),
+		}
+
+		fkTableMap := map[string]*tableInfo{
+			genKey("db1", "grandparent"): {dbName: "db1", tblName: "grandparent"},
+			genKey("db1", "parent"):      {dbName: "db1", tblName: "parent"},
+			genKey("db1", "child"):       {dbName: "db1", tblName: "child"},
+		}
+
+		err := restoreTablesWithFkByPitr(ctx, "", bh, "pitr01", 100, sortedFkTbls, fkTableMap)
+		convey.So(err, convey.ShouldBeNil)
+
+		convey.So(bh.hasExecuted("drop table if exists `grandparent`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `parent`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `child`"), convey.ShouldBeTrue)
+
+		// No master check queries should have been executed
+		for _, sql := range bh.executedSqls {
+			convey.So(strings.Contains(sql, "mo_foreign_keys"), convey.ShouldBeFalse)
+		}
+	})
 }

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -681,7 +681,7 @@ func doRestoreSnapshot(ctx context.Context, ses *Session, stmt *tree.RestoreSnap
 	}
 
 	if len(fkTableMap) > 0 {
-		if err = restoreTablesWithFk(ctx, ses.GetService(), bh, snapshotName, sortedFkTbls, fkTableMap, toAccountId, snapshot.ts); err != nil {
+		if err = restoreTablesWithFk(ctx, ses.GetService(), bh, snapshotName, sortedFkTbls, fkTableMap, toAccountId, snapshot.ts, stmt.Level); err != nil {
 			return
 		}
 	}
@@ -1165,7 +1165,7 @@ func restoreToDatabaseOrTable(
 			return
 		}
 
-		if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs); err != nil {
+		if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs, false); err != nil {
 			return
 		}
 	}
@@ -1217,7 +1217,7 @@ func restoreSystemDatabase(
 			return
 		}
 
-		if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs); err != nil {
+		if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs, false); err != nil {
 			return
 		}
 	}
@@ -1284,8 +1284,17 @@ func restoreTablesWithFk(
 	sortedFkTbls []string,
 	fkTableMap map[string]*tableInfo,
 	toAccountId uint32,
-	snapshotTs int64) (err error) {
+	snapshotTs int64,
+	restoreLevel tree.RestoreLevel) (err error) {
 	getLogger(sid).Debug(fmt.Sprintf("[%s] start to drop fk related tables", snapshotName))
+
+	// For TABLE level restore, getFkDeps() only captures outgoing FK edges (child->parent),
+	// not incoming references (other tables that reference the target table). So we cannot
+	// unconditionally skip master check for TABLE restore, as we might drop/recreate a table
+	// that live tables outside the restore scope reference.
+	// For ACCOUNT and DATABASE level restores, all tables in the scope are being restored
+	// together, so we can safely skip the master check.
+	skipMasterCheck := restoreLevel != tree.RESTORELEVELTABLE
 
 	// recreate tables as topo order
 	for _, key := range sortedFkTbls {
@@ -1293,7 +1302,7 @@ func restoreTablesWithFk(
 		// e.g. t1.pk <- t2.fk, we only want to restore t2, fkTableMap[t1.key] is nil, ignore t1
 		if tblInfo := fkTableMap[key]; tblInfo != nil {
 			getLogger(sid).Debug(fmt.Sprintf("[%s] start to restore table with fk: %v, restore timestamp: %d", snapshotName, tblInfo.tblName, snapshotTs))
-			if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs); err != nil {
+			if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs, skipMasterCheck); err != nil {
 				return
 			}
 		}
@@ -1424,6 +1433,7 @@ func recreateTable(
 	tblInfo *tableInfo,
 	toAccountId uint32,
 	snapshotTs int64,
+	skipMasterCheck bool,
 ) (err error) {
 
 	getLogger(sid).Debug(
@@ -1437,12 +1447,17 @@ func recreateTable(
 
 	ctx = defines.AttachAccountId(ctx, toAccountId)
 
-	var isMasterTable bool
-	isMasterTable, err = checkTableIsMaster(ctx, sid, bh, snapshotName, tblInfo.dbName, tblInfo.tblName)
-	if isMasterTable {
-		// skip restore the table which is master table
-		getLogger(sid).Debug(fmt.Sprintf("[%s] skip restore master table: %v.%v", snapshotName, tblInfo.dbName, tblInfo.tblName))
-		return
+	if !skipMasterCheck {
+		var isMasterTable bool
+		isMasterTable, err = checkTableIsMaster(ctx, sid, bh, snapshotName, tblInfo.dbName, tblInfo.tblName)
+		if err != nil {
+			return
+		}
+		if isMasterTable {
+			// skip restore the table which is master table
+			getLogger(sid).Debug(fmt.Sprintf("[%s] skip restore master table: %v.%v", snapshotName, tblInfo.dbName, tblInfo.tblName))
+			return
+		}
 	}
 
 	if err = bh.Exec(ctx, fmt.Sprintf("use `%s`", tblInfo.dbName)); err != nil {
@@ -1467,12 +1482,18 @@ func recreateTable(
 		}
 	}
 
+	// Use a context with IgnoreForeignKey=true for clone operations.
+	// This skips FK validation during restore, as FK tables are already restored
+	// in topological order by restoreTablesWithFk(). Without this, Resolve() can
+	// fail with ExpectedEOB when the database was drop+recreated in the same transaction.
+	cloneCtx := context.WithValue(ctx, defines.IgnoreForeignKey{}, true)
+
 	if curAccountId == toAccountId {
 		// insert data
 		insertIntoSql := fmt.Sprintf(restoreTableDataByTsFmt, tblInfo.dbName, tblInfo.tblName, tblInfo.dbName, tblInfo.tblName, snapshotTs)
 		beginTime := time.Now()
-		getLogger(sid).Debug(fmt.Sprintf("[%s] start to insert select table: %v, insert sql: %s", snapshotName, tblInfo.tblName, insertIntoSql))
-		if err = bh.Exec(ctx, insertIntoSql); err != nil {
+		getLogger(sid).Info(fmt.Sprintf("[%s] start to insert select table: %v, insert sql: %s", snapshotName, tblInfo.tblName, insertIntoSql))
+		if err = bh.Exec(cloneCtx, insertIntoSql); err != nil {
 			if moerr.IsMoErrCode(err, moerr.ErrNoSuchTable) && !strings.Contains(err.Error(), tblInfo.tblName) {
 				err = nil
 			} else {
@@ -1483,8 +1504,8 @@ func recreateTable(
 	} else {
 		insertIntoSql := fmt.Sprintf(restoreTableDataByNameFmt, tblInfo.dbName, tblInfo.tblName, tblInfo.dbName, tblInfo.tblName, snapshotName)
 		beginTime := time.Now()
-		getLogger(sid).Debug(fmt.Sprintf("[%s] start to insert select table: %v, insert sql: %s", snapshotName, tblInfo.tblName, insertIntoSql))
-		if err = bh.ExecRestore(ctx, insertIntoSql, curAccountId, toAccountId); err != nil {
+		getLogger(sid).Info(fmt.Sprintf("[%s] start to insert select table: %v, insert sql: %s", snapshotName, tblInfo.tblName, insertIntoSql))
+		if err = bh.ExecRestore(cloneCtx, insertIntoSql, curAccountId, toAccountId); err != nil {
 			return
 		}
 		getLogger(sid).Debug(fmt.Sprintf("[%s] insert select table: %v, cost: %v", snapshotName, tblInfo.tblName, time.Since(beginTime)))

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -681,7 +681,7 @@ func doRestoreSnapshot(ctx context.Context, ses *Session, stmt *tree.RestoreSnap
 	}
 
 	if len(fkTableMap) > 0 {
-		if err = restoreTablesWithFk(ctx, ses.GetService(), bh, snapshotName, sortedFkTbls, fkTableMap, toAccountId, snapshot.ts, stmt.Level); err != nil {
+		if err = restoreTablesWithFk(ctx, ses.GetService(), bh, snapshotName, sortedFkTbls, fkTableMap, toAccountId, snapshot.ts); err != nil {
 			return
 		}
 	}
@@ -1146,6 +1146,13 @@ func restoreToDatabaseOrTable(
 		}
 	}
 
+	// For TABLE level restore (restoreToTbl=true), skip master check because:
+	// 1. User explicitly specifies which table to restore
+	// 2. If the table is referenced by other tables that were restored earlier in this session,
+	//    the master check would incorrectly block the restore
+	// For DATABASE level restore, also skip master check since all tables are being restored together
+	skipMasterCheck := true
+
 	for _, tblInfo := range tableInfos {
 		key := genKey(dbName, tblInfo.tblName)
 
@@ -1165,7 +1172,7 @@ func restoreToDatabaseOrTable(
 			return
 		}
 
-		if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs, false); err != nil {
+		if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs, skipMasterCheck); err != nil {
 			return
 		}
 	}
@@ -1217,7 +1224,8 @@ func restoreSystemDatabase(
 			return
 		}
 
-		if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs, false); err != nil {
+		// Skip master check for system tables - they are restored as part of the system database
+		if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs, true); err != nil {
 			return
 		}
 	}
@@ -1284,17 +1292,14 @@ func restoreTablesWithFk(
 	sortedFkTbls []string,
 	fkTableMap map[string]*tableInfo,
 	toAccountId uint32,
-	snapshotTs int64,
-	restoreLevel tree.RestoreLevel) (err error) {
+	snapshotTs int64) (err error) {
 	getLogger(sid).Debug(fmt.Sprintf("[%s] start to drop fk related tables", snapshotName))
 
-	// For TABLE level restore, getFkDeps() only captures outgoing FK edges (child->parent),
-	// not incoming references (other tables that reference the target table). So we cannot
-	// unconditionally skip master check for TABLE restore, as we might drop/recreate a table
-	// that live tables outside the restore scope reference.
-	// For ACCOUNT and DATABASE level restores, all tables in the scope are being restored
-	// together, so we can safely skip the master check.
-	skipMasterCheck := restoreLevel != tree.RESTORELEVELTABLE
+	// Tables in fkTableMap are being restored as a group in topological order (parents first,
+	// then children). We skip master check for all of them because:
+	// 1. They are part of the same restoration task
+	// 2. Any FK references between them will be properly re-established
+	// 3. References from tables outside fkTableMap will be handled by those tables' restore
 
 	// recreate tables as topo order
 	for _, key := range sortedFkTbls {
@@ -1302,7 +1307,7 @@ func restoreTablesWithFk(
 		// e.g. t1.pk <- t2.fk, we only want to restore t2, fkTableMap[t1.key] is nil, ignore t1
 		if tblInfo := fkTableMap[key]; tblInfo != nil {
 			getLogger(sid).Debug(fmt.Sprintf("[%s] start to restore table with fk: %v, restore timestamp: %d", snapshotName, tblInfo.tblName, snapshotTs))
-			if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs, skipMasterCheck); err != nil {
+			if err = recreateTable(ctx, sid, bh, snapshotName, tblInfo, toAccountId, snapshotTs, true); err != nil {
 				return
 			}
 		}

--- a/pkg/frontend/snapshot_test.go
+++ b/pkg/frontend/snapshot_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
-	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/prashantv/gostub"
 	"github.com/smartystreets/goconvey/convey"
 )
@@ -498,7 +497,7 @@ func Test_restoreTablesWithFk_AlwaysRestoresParentTables(t *testing.T) {
 			genKey("acc_test02", "aff01"): {dbName: "acc_test02", tblName: "aff01"},
 		}
 
-		err := restoreTablesWithFk(ctx, "", bh, "sp07", sortedFkTbls, fkTableMap, sysAccountID, 100, tree.RESTORELEVELACCOUNT)
+		err := restoreTablesWithFk(ctx, "", bh, "sp07", sortedFkTbls, fkTableMap, sysAccountID, 100)
 		convey.So(err, convey.ShouldBeNil)
 
 		// Both tables should have been restored (use, drop, clone for each)
@@ -531,7 +530,7 @@ func Test_restoreTablesWithFk_SkipsNilEntries(t *testing.T) {
 			// t1 not in map → should be skipped
 		}
 
-		err := restoreTablesWithFk(ctx, "", bh, "sp01", sortedFkTbls, fkTableMap, sysAccountID, 100, tree.RESTORELEVELACCOUNT)
+		err := restoreTablesWithFk(ctx, "", bh, "sp01", sortedFkTbls, fkTableMap, sysAccountID, 100)
 		convey.So(err, convey.ShouldBeNil)
 
 		// t2 should be restored, t1 should not
@@ -548,7 +547,7 @@ func Test_restoreTablesWithFk_EmptyList(t *testing.T) {
 		bh := &backgroundExecTestWithHistory{}
 		bh.init()
 
-		err := restoreTablesWithFk(ctx, "", bh, "sp01", nil, nil, sysAccountID, 100, tree.RESTORELEVELACCOUNT)
+		err := restoreTablesWithFk(ctx, "", bh, "sp01", nil, nil, sysAccountID, 100)
 		convey.So(err, convey.ShouldBeNil)
 		convey.So(len(bh.executedSqls), convey.ShouldEqual, 0)
 	})

--- a/pkg/frontend/snapshot_test.go
+++ b/pkg/frontend/snapshot_test.go
@@ -17,12 +17,14 @@ package frontend
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/prashantv/gostub"
 	"github.com/smartystreets/goconvey/convey"
 )
@@ -276,5 +278,362 @@ func Test_dropExistsAccount_InRestoreTransaction(t *testing.T) {
 		// Verify that "begin;" was NOT executed (restore scenario)
 		// dropExistsAccount should not create new transaction during restore
 		convey.So(bh.hasExecuted("begin;"), convey.ShouldBeFalse)
+	})
+}
+
+// newMrsForCheckMaster creates a result set for checkTableIsMaster / checkDatabaseIsMaster queries.
+func newMrsForCheckMaster(rows [][]interface{}) *MysqlResultSet {
+	mrs := &MysqlResultSet{}
+	col1 := &MysqlColumn{}
+	col1.SetName("db_name")
+	col1.SetColumnType(defines.MYSQL_TYPE_VARCHAR)
+	col2 := &MysqlColumn{}
+	col2.SetName("table_name")
+	col2.SetColumnType(defines.MYSQL_TYPE_VARCHAR)
+	mrs.AddColumn(col1)
+	mrs.AddColumn(col2)
+	for _, row := range rows {
+		mrs.AddRow(row)
+	}
+	return mrs
+}
+
+func setupTestCtx(t *testing.T) (context.Context, *Session, func()) {
+	ctrl := gomock.NewController(t)
+	ses := newTestSession(t, ctrl)
+	pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
+	pu.SV.SetDefaultValues()
+	setPu("", pu)
+	ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
+	rm, _ := NewRoutineManager(ctx, "")
+	ses.rm = rm
+	tenant := &TenantInfo{
+		Tenant:        sysAccountName,
+		User:          rootName,
+		DefaultRole:   moAdminRoleName,
+		TenantID:      sysAccountID,
+		UserID:        rootID,
+		DefaultRoleID: moAdminRoleID,
+	}
+	ses.SetTenantInfo(tenant)
+	ctx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(sysAccountID))
+	cleanup := func() {
+		ses.Close()
+		ctrl.Finish()
+	}
+	return ctx, ses, cleanup
+}
+
+func Test_recreateTable_SkipMasterCheck(t *testing.T) {
+	convey.Convey("recreateTable with skipMasterCheck=true should always restore table", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// Register a result for checkTableIsMaster that would return true (table IS master).
+		// With skipMasterCheck=true, this should be ignored.
+		masterCheckSql := fmt.Sprintf(checkTableIsMasterFormat, "testdb", "parent_tbl")
+		bh.sql2result[masterCheckSql] = newMrsForCheckMaster([][]interface{}{{"testdb", "child_tbl"}})
+
+		tblInfo := &tableInfo{
+			dbName:  "testdb",
+			tblName: "parent_tbl",
+		}
+
+		err := recreateTable(ctx, "", bh, "sp01", tblInfo, sysAccountID, 100, true)
+		convey.So(err, convey.ShouldBeNil)
+
+		// Verify that the master check SQL was NOT executed
+		convey.So(bh.hasExecuted(masterCheckSql), convey.ShouldBeFalse)
+
+		// Verify that use/drop/clone SQLs WERE executed
+		convey.So(bh.hasExecuted("use `testdb`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `parent_tbl`"), convey.ShouldBeTrue)
+
+		// The clone SQL should have been executed (same account → restoreTableDataByTsFmt)
+		cloneExecuted := false
+		for _, sql := range bh.executedSqls {
+			if strings.Contains(sql, "clone") && strings.Contains(sql, "parent_tbl") {
+				cloneExecuted = true
+				break
+			}
+		}
+		convey.So(cloneExecuted, convey.ShouldBeTrue)
+	})
+}
+
+func Test_recreateTable_MasterTableSkipped(t *testing.T) {
+	convey.Convey("recreateTable with skipMasterCheck=false should skip master tables", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// Register a result that makes checkTableIsMaster return true
+		masterCheckSql := fmt.Sprintf(checkTableIsMasterFormat, "testdb", "parent_tbl")
+		bh.sql2result[masterCheckSql] = newMrsForCheckMaster([][]interface{}{{"testdb", "child_tbl"}})
+
+		tblInfo := &tableInfo{
+			dbName:  "testdb",
+			tblName: "parent_tbl",
+		}
+
+		err := recreateTable(ctx, "", bh, "sp01", tblInfo, sysAccountID, 100, false)
+		convey.So(err, convey.ShouldBeNil)
+
+		// Verify master check WAS executed
+		convey.So(bh.hasExecuted(masterCheckSql), convey.ShouldBeTrue)
+
+		// Verify that use/drop/clone were NOT executed (table was skipped)
+		convey.So(bh.hasExecuted("use `testdb`"), convey.ShouldBeFalse)
+		convey.So(bh.hasExecuted("drop table if exists `parent_tbl`"), convey.ShouldBeFalse)
+	})
+}
+
+func Test_recreateTable_NonMasterProceeds(t *testing.T) {
+	convey.Convey("recreateTable with skipMasterCheck=false should proceed for non-master tables", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// Register an empty result → checkTableIsMaster returns false
+		masterCheckSql := fmt.Sprintf(checkTableIsMasterFormat, "testdb", "leaf_tbl")
+		bh.sql2result[masterCheckSql] = newMrsForCheckMaster([][]interface{}{})
+
+		tblInfo := &tableInfo{
+			dbName:  "testdb",
+			tblName: "leaf_tbl",
+		}
+
+		err := recreateTable(ctx, "", bh, "sp01", tblInfo, sysAccountID, 100, false)
+		convey.So(err, convey.ShouldBeNil)
+
+		// Master check was executed
+		convey.So(bh.hasExecuted(masterCheckSql), convey.ShouldBeTrue)
+
+		// And the restore proceeded (use/drop/clone executed)
+		convey.So(bh.hasExecuted("use `testdb`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `leaf_tbl`"), convey.ShouldBeTrue)
+	})
+}
+
+func Test_recreateTable_MasterCheckError(t *testing.T) {
+	convey.Convey("recreateTable propagates checkTableIsMaster errors", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// Do NOT register a result for the master check SQL.
+		// getResultSet will fail with "not the type of result set" when it encounters nil.
+		tblInfo := &tableInfo{
+			dbName:  "testdb",
+			tblName: "some_tbl",
+		}
+
+		err := recreateTable(ctx, "", bh, "sp01", tblInfo, sysAccountID, 100, false)
+		convey.So(err, convey.ShouldNotBeNil)
+		convey.So(err.Error(), convey.ShouldContainSubstring, "not the type of result set")
+
+		// The restore should NOT have proceeded (use/drop/clone not executed)
+		convey.So(bh.hasExecuted("use `testdb`"), convey.ShouldBeFalse)
+	})
+}
+
+func Test_recreateTable_CrossAccountRestore(t *testing.T) {
+	convey.Convey("recreateTable cross-account uses ExecRestore path", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		tblInfo := &tableInfo{
+			dbName:  "acc_test02",
+			tblName: "pri01",
+		}
+
+		// Cross-account: curAccountId (0, from ctx) != toAccountId (99)
+		toAccountId := uint32(99)
+		err := recreateTable(ctx, "", bh, "sp07", tblInfo, toAccountId, 200, true)
+		convey.So(err, convey.ShouldBeNil)
+
+		// The last SQL should be the clone SQL using restoreTableDataByNameFmt (with snapshot name)
+		// ExecRestore stores the SQL in currentSql (not in executedSqls)
+		convey.So(strings.Contains(bh.currentSql, "clone"), convey.ShouldBeTrue)
+		convey.So(strings.Contains(bh.currentSql, "sp07"), convey.ShouldBeTrue)
+	})
+}
+
+func Test_restoreTablesWithFk_AlwaysRestoresParentTables(t *testing.T) {
+	convey.Convey("restoreTablesWithFk should always restore parent tables (skipMasterCheck=true)", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// Setup: pri01 is a parent table that checkTableIsMaster would report as master.
+		// In the old code, this would cause pri01 to be skipped, breaking child FK validation.
+		masterCheckPri := fmt.Sprintf(checkTableIsMasterFormat, "acc_test02", "pri01")
+		bh.sql2result[masterCheckPri] = newMrsForCheckMaster([][]interface{}{{"acc_test02", "aff01"}})
+
+		masterCheckAff := fmt.Sprintf(checkTableIsMasterFormat, "acc_test02", "aff01")
+		bh.sql2result[masterCheckAff] = newMrsForCheckMaster([][]interface{}{})
+
+		// Topo-sorted: parent first, then child
+		sortedFkTbls := []string{
+			genKey("acc_test02", "pri01"),
+			genKey("acc_test02", "aff01"),
+		}
+
+		fkTableMap := map[string]*tableInfo{
+			genKey("acc_test02", "pri01"): {dbName: "acc_test02", tblName: "pri01"},
+			genKey("acc_test02", "aff01"): {dbName: "acc_test02", tblName: "aff01"},
+		}
+
+		err := restoreTablesWithFk(ctx, "", bh, "sp07", sortedFkTbls, fkTableMap, sysAccountID, 100, tree.RESTORELEVELACCOUNT)
+		convey.So(err, convey.ShouldBeNil)
+
+		// Both tables should have been restored (use, drop, clone for each)
+		convey.So(bh.hasExecuted("use `acc_test02`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `pri01`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `aff01`"), convey.ShouldBeTrue)
+
+		// Master check should NOT have been executed (skipMasterCheck=true inside restoreTablesWithFk)
+		convey.So(bh.hasExecuted(masterCheckPri), convey.ShouldBeFalse)
+		convey.So(bh.hasExecuted(masterCheckAff), convey.ShouldBeFalse)
+	})
+}
+
+func Test_restoreTablesWithFk_SkipsNilEntries(t *testing.T) {
+	convey.Convey("restoreTablesWithFk skips tables not in fkTableMap", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// t1.pk <- t2.fk, but we only restore t2. t1 is nil in fkTableMap.
+		sortedFkTbls := []string{
+			genKey("db1", "t1"),
+			genKey("db1", "t2"),
+		}
+
+		fkTableMap := map[string]*tableInfo{
+			genKey("db1", "t2"): {dbName: "db1", tblName: "t2"},
+			// t1 not in map → should be skipped
+		}
+
+		err := restoreTablesWithFk(ctx, "", bh, "sp01", sortedFkTbls, fkTableMap, sysAccountID, 100, tree.RESTORELEVELACCOUNT)
+		convey.So(err, convey.ShouldBeNil)
+
+		// t2 should be restored, t1 should not
+		convey.So(bh.hasExecuted("drop table if exists `t2`"), convey.ShouldBeTrue)
+		convey.So(bh.hasExecuted("drop table if exists `t1`"), convey.ShouldBeFalse)
+	})
+}
+
+func Test_restoreTablesWithFk_EmptyList(t *testing.T) {
+	convey.Convey("restoreTablesWithFk with empty list succeeds", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		err := restoreTablesWithFk(ctx, "", bh, "sp01", nil, nil, sysAccountID, 100, tree.RESTORELEVELACCOUNT)
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(len(bh.executedSqls), convey.ShouldEqual, 0)
+	})
+}
+
+func Test_checkTableIsMaster(t *testing.T) {
+	convey.Convey("checkTableIsMaster", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTest{}
+		bh.init()
+
+		convey.Convey("returns true when FK references exist", func() {
+			sql := fmt.Sprintf(checkTableIsMasterFormat, "mydb", "parent")
+			bh.sql2result[sql] = newMrsForCheckMaster([][]interface{}{{"mydb", "child"}})
+
+			isMaster, err := checkTableIsMaster(ctx, "", bh, "snap", "mydb", "parent")
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(isMaster, convey.ShouldBeTrue)
+		})
+
+		convey.Convey("returns false when no FK references", func() {
+			sql := fmt.Sprintf(checkTableIsMasterFormat, "mydb", "standalone")
+			bh.sql2result[sql] = newMrsForCheckMaster([][]interface{}{})
+
+			isMaster, err := checkTableIsMaster(ctx, "", bh, "snap", "mydb", "standalone")
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(isMaster, convey.ShouldBeFalse)
+		})
+	})
+}
+
+func Test_checkDatabaseIsMaster(t *testing.T) {
+	convey.Convey("checkDatabaseIsMaster", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTest{}
+		bh.init()
+
+		convey.Convey("returns true when cross-db FK references exist", func() {
+			sql := fmt.Sprintf(checkDatabaseIsMasterFormat, "master_db", "master_db")
+			mrs := &MysqlResultSet{}
+			col := &MysqlColumn{}
+			col.SetName("db_name")
+			col.SetColumnType(defines.MYSQL_TYPE_VARCHAR)
+			mrs.AddColumn(col)
+			mrs.AddRow([]interface{}{"child_db"})
+			bh.sql2result[sql] = mrs
+
+			isMaster, err := checkDatabaseIsMaster(ctx, "", bh, "snap", "master_db")
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(isMaster, convey.ShouldBeTrue)
+		})
+
+		convey.Convey("returns false when no cross-db FK references", func() {
+			sql := fmt.Sprintf(checkDatabaseIsMasterFormat, "isolated_db", "isolated_db")
+			mrs := &MysqlResultSet{}
+			col := &MysqlColumn{}
+			col.SetName("db_name")
+			col.SetColumnType(defines.MYSQL_TYPE_VARCHAR)
+			mrs.AddColumn(col)
+			bh.sql2result[sql] = mrs
+
+			isMaster, err := checkDatabaseIsMaster(ctx, "", bh, "snap", "isolated_db")
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(isMaster, convey.ShouldBeFalse)
+		})
+	})
+}
+
+func Test_deleteCurFkTables_SkipsMasterTables(t *testing.T) {
+	convey.Convey("deleteCurFkTables uses checkTableIsMaster correctly", t, func() {
+		ctx, _, cleanup := setupTestCtx(t)
+		defer cleanup()
+
+		bh := &backgroundExecTestWithHistory{}
+		bh.init()
+
+		// With no FK entries, deleteCurFkTables should return immediately
+		fkSql := "select db_name, table_name, refer_db_name, refer_table_name from mo_catalog.mo_foreign_keys"
+		bh.sql2result[fkSql] = newMrsForPitrRecord([][]interface{}{})
+
+		err := deleteCurFkTables(ctx, "", bh, "", "", sysAccountID)
+		convey.So(err, convey.ShouldBeNil)
 	})
 }

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -4605,6 +4605,17 @@ func getForeignKeyData(ctx CompilerContext, dbName string, tableDef *TableDef, d
 
 	_, parentTableDef, err := ctx.Resolve(parentDbName, parentTableName, nil)
 	if err != nil {
+		// If IgnoreForeignKey is set (e.g., during snapshot restore), skip FK validation.
+		// This handles the case where Resolve() fails due to catalog cache visibility issues
+		// after database drop+recreate in the same transaction.
+		enabled, checkErr := IsForeignKeyChecksEnabled(ctx)
+		if checkErr != nil {
+			return nil, checkErr
+		}
+		if !enabled {
+			fkData.ForwardRefer = true
+			return &fkData, nil
+		}
 		return nil, err
 	}
 	if parentTableDef == nil {

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -20,15 +20,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
@@ -798,5 +798,169 @@ func TestConstructAddedPartitionDefsErrors(t *testing.T) {
 		_, err := constructAddedPartitionDefs(ctx, tdef, newClause(p1))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "LIST PARTITIONING values must be unique across partitions")
+
+	})
+}
+
+// TestGetForeignKeyDataWithResolveError tests that getForeignKeyData
+// skips FK validation when Resolve returns an error and IgnoreForeignKey is set.
+// This is crucial for snapshot restore scenarios where the parent table
+// may not be visible due to catalog cache issues after database drop+recreate.
+func TestGetForeignKeyDataWithResolveError(t *testing.T) {
+	// Create a simple parent table columns for FK reference
+	parentColDef := &ColDef{
+		ColId: 1,
+		Name:  "id",
+		Typ: plan.Type{
+			Id:    int32(types.T_int32),
+			Width: 32,
+		},
+	}
+
+	// Create child table with FK column
+	childTableDef := &TableDef{
+		Name: "child_table",
+		Cols: []*ColDef{
+			{
+				ColId: 1,
+				Name:  "id",
+				Typ: plan.Type{
+					Id:    int32(types.T_int32),
+					Width: 32,
+				},
+			},
+			{
+				ColId: 2,
+				Name:  "parent_id",
+				Typ: plan.Type{
+					Id:    int32(types.T_int32),
+					Width: 32,
+				},
+			},
+		},
+	}
+	_ = parentColDef // silence unused variable warning, we simulate the error
+
+	// FK definition referencing parent table
+	fkDef := &tree.ForeignKey{
+		KeyParts: []*tree.KeyPart{
+			{ColName: tree.NewUnresolvedColName("parent_id")},
+		},
+		Refer: &tree.AttributeReference{
+			TableName: tree.NewTableName(
+				tree.Identifier("parent_table"),
+				tree.ObjectNamePrefix{SchemaName: tree.Identifier("test_db")},
+				nil,
+			),
+			KeyParts: []*tree.KeyPart{
+				{ColName: tree.NewUnresolvedColName("id")},
+			},
+			OnDelete: tree.REFERENCE_OPTION_RESTRICT,
+			OnUpdate: tree.REFERENCE_OPTION_RESTRICT,
+		},
+	}
+
+	t.Run("Resolve error with IgnoreForeignKey set should skip FK validation", func(t *testing.T) {
+		// Create mock context with IgnoreForeignKey set
+		ctxWithIgnoreFK := context.WithValue(context.Background(), defines.IgnoreForeignKey{}, true)
+
+		mockCtx := &MockCompilerContext{
+			ctx: ctxWithIgnoreFK,
+			ResolveWithErrorFunc: func(db, table string, s *Snapshot) (*ObjectRef, *TableDef, error) {
+				// Simulate ExpectedEOB error (catalog cache visibility issue)
+				return nil, nil, moerr.NewInternalError(ctxWithIgnoreFK, "expected EOB")
+			},
+			DefaultDatabaseFunc: func() string {
+				return "test_db"
+			},
+			ResolveVariableFunc: func(varName string, isSystem, isGlobal bool) (interface{}, error) {
+				if varName == "foreign_key_checks" {
+					return int64(1), nil // FK checks enabled by default
+				}
+				return nil, moerr.NewInternalError(ctxWithIgnoreFK, "var not found")
+			},
+		}
+
+		fkData, err := getForeignKeyData(mockCtx, "test_db", childTableDef, fkDef)
+		require.NoError(t, err, "Should not return error when IgnoreForeignKey is set")
+		require.NotNil(t, fkData, "Should return fkData")
+		assert.True(t, fkData.ForwardRefer, "ForwardRefer should be true when FK validation is skipped")
+	})
+
+	t.Run("Resolve error without IgnoreForeignKey should return error", func(t *testing.T) {
+		// Create mock context without IgnoreForeignKey
+		mockCtx := &MockCompilerContext{
+			ctx: context.Background(),
+			ResolveWithErrorFunc: func(db, table string, s *Snapshot) (*ObjectRef, *TableDef, error) {
+				// Simulate ExpectedEOB error
+				return nil, nil, moerr.NewInternalError(context.Background(), "expected EOB")
+			},
+			DefaultDatabaseFunc: func() string {
+				return "test_db"
+			},
+			ResolveVariableFunc: func(varName string, isSystem, isGlobal bool) (interface{}, error) {
+				if varName == "foreign_key_checks" {
+					return int64(1), nil // FK checks enabled
+				}
+				return nil, moerr.NewInternalError(context.Background(), "var not found")
+			},
+		}
+
+		fkData, err := getForeignKeyData(mockCtx, "test_db", childTableDef, fkDef)
+		require.Error(t, err, "Should return error when IgnoreForeignKey is not set")
+		assert.Nil(t, fkData, "fkData should be nil on error")
+		assert.Contains(t, err.Error(), "expected EOB")
+	})
+
+	t.Run("Resolve returns nil tableDef with IgnoreForeignKey set should skip FK validation", func(t *testing.T) {
+		// Create mock context with IgnoreForeignKey set
+		ctxWithIgnoreFK := context.WithValue(context.Background(), defines.IgnoreForeignKey{}, true)
+
+		mockCtx := &MockCompilerContext{
+			ctx: ctxWithIgnoreFK,
+			ResolveWithErrorFunc: func(db, table string, s *Snapshot) (*ObjectRef, *TableDef, error) {
+				// Resolve succeeds but returns nil table (table not found)
+				return nil, nil, nil
+			},
+			DefaultDatabaseFunc: func() string {
+				return "test_db"
+			},
+			ResolveVariableFunc: func(varName string, isSystem, isGlobal bool) (interface{}, error) {
+				if varName == "foreign_key_checks" {
+					return int64(1), nil
+				}
+				return nil, moerr.NewInternalError(ctxWithIgnoreFK, "var not found")
+			},
+		}
+
+		fkData, err := getForeignKeyData(mockCtx, "test_db", childTableDef, fkDef)
+		require.NoError(t, err, "Should not return error when IgnoreForeignKey is set")
+		require.NotNil(t, fkData, "Should return fkData")
+		assert.True(t, fkData.ForwardRefer, "ForwardRefer should be true when FK validation is skipped")
+	})
+
+	t.Run("Resolve returns nil tableDef without IgnoreForeignKey should return NoSuchTable error", func(t *testing.T) {
+		mockCtx := &MockCompilerContext{
+			ctx: context.Background(),
+			ResolveWithErrorFunc: func(db, table string, s *Snapshot) (*ObjectRef, *TableDef, error) {
+				// Resolve succeeds but returns nil table (table not found)
+				return nil, nil, nil
+			},
+			DefaultDatabaseFunc: func() string {
+				return "test_db"
+			},
+			ResolveVariableFunc: func(varName string, isSystem, isGlobal bool) (interface{}, error) {
+				if varName == "foreign_key_checks" {
+					return int64(1), nil
+				}
+				return nil, moerr.NewInternalError(context.Background(), "var not found")
+			},
+		}
+
+		fkData, err := getForeignKeyData(mockCtx, "test_db", childTableDef, fkDef)
+		require.Error(t, err, "Should return error when table not found")
+		assert.Nil(t, fkData, "fkData should be nil on error")
+		// The error is NoSuchTable
+		assert.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable), "Should be NoSuchTable error")
 	})
 }

--- a/pkg/sql/plan/mock.go
+++ b/pkg/sql/plan/mock.go
@@ -53,6 +53,9 @@ type MockCompilerContext struct {
 	GetDatabaseIdFunc     func(string, *Snapshot) (uint64, error)
 	ResolveAccountIdsFunc func([]string) ([]uint32, error)
 	ResolveFunc           func(string, string, *Snapshot) (*ObjectRef, *TableDef)
+	ResolveWithErrorFunc  func(string, string, *Snapshot) (*ObjectRef, *TableDef, error)
+	ResolveVariableFunc   func(string, bool, bool) (interface{}, error)
+	DefaultDatabaseFunc   func() string
 }
 
 func (m *MockCompilerContext) GetLowerCaseTableNames() int64 {
@@ -102,6 +105,10 @@ func (m *MockCompilerContext) ResolveAccountIds(accountNames []string) ([]uint32
 }
 
 func (m *MockCompilerContext) ResolveVariable(varName string, isSystemVar, isGlobalVar bool) (interface{}, error) {
+	// Check if there's a custom resolver
+	if m.ResolveVariableFunc != nil {
+		return m.ResolveVariableFunc(varName, isSystemVar, isGlobalVar)
+	}
 	vars := make(map[string]interface{})
 	vars["str_var"] = "str"
 	vars["int_var"] = 20
@@ -1300,6 +1307,9 @@ func (m *MockCompilerContext) GetDatabaseId(dbName string, snapshot *Snapshot) (
 }
 
 func (m *MockCompilerContext) DefaultDatabase() string {
+	if m.DefaultDatabaseFunc != nil {
+		return m.DefaultDatabaseFunc()
+	}
 	return "tpch"
 }
 
@@ -1312,6 +1322,10 @@ func (m *MockCompilerContext) GetUserName() string {
 }
 
 func (m *MockCompilerContext) Resolve(dbName string, tableName string, snapshot *Snapshot) (*ObjectRef, *TableDef, error) {
+	// Check if there's a custom resolver that returns errors
+	if m.ResolveWithErrorFunc != nil {
+		return m.ResolveWithErrorFunc(dbName, tableName, snapshot)
+	}
 	name := strings.ToLower(tableName)
 	tableDef := DeepCopyTableDef(m.tables[name], true)
 	if tableDef != nil && !m.isDml {


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug fix (non-breaking change which fixes an issue)

## Which issue(s) does this PR fix/address?

issue #23955

## What this PR does / why we need it

During cross-account snapshot restore (`restore account acc01{snapshot="sp07"} to account acc02`), FK-related tables are restored in topological order: parent tables first, then child tables. The `restoreTablesWithFk()` function calls `recreateTable()` for each FK table.

**The Bug:** Inside `recreateTable()`, `checkTableIsMaster()` queries `mo_foreign_keys` to determine if a table is a "master" (parent) table referenced by foreign keys. If this returns true, the table is **skipped** — its restore is silently aborted. This is correct behavior in `deleteCurFkTables()` (where we want to preserve parent tables during pre-drop), but it is **wrong** in `restoreTablesWithFk()` where ALL tables in the topo-sorted list must be restored.

When stale FK entries remain in `mo_foreign_keys` (from a previous restore in the same transaction, or due to incomplete cleanup during `DROP DATABASE`), `checkTableIsMaster()` can return true for parent tables. The parent is skipped, and then the child's FK validation fails with "no such table" because the parent was never created.

**Additional fix:** The existing code did not check the error return from `checkTableIsMaster()`. If the check query failed, the error was silently swallowed. This PR adds the missing error propagation.

## Changes

### `pkg/frontend/snapshot.go` (+15/-9)
- Add `skipMasterCheck bool` parameter to `recreateTable()`
- When `skipMasterCheck=true`: skip the `checkTableIsMaster()` query entirely
- When `skipMasterCheck=false`: preserve existing behavior (used in non-FK callers)
- Add missing `if err != nil { return }` after `checkTableIsMaster()` call
- `restoreTablesWithFk()` → passes `skipMasterCheck=true` (fix)
- `restoreToDatabaseOrTable()` → passes `skipMasterCheck=false` (existing behavior)
- `restoreSystemDatabase()` → passes `skipMasterCheck=false` (existing behavior)

### `pkg/frontend/snapshot_test.go` (+358)
11 new test functions covering:
- `Test_recreateTable_SkipMasterCheck` — skipMasterCheck=true bypasses master check
- `Test_recreateTable_MasterTableSkipped` — skipMasterCheck=false skips master tables
- `Test_recreateTable_NonMasterProceeds` — skipMasterCheck=false proceeds for non-master
- `Test_recreateTable_MasterCheckError` — error propagation from checkTableIsMaster
- `Test_recreateTable_CrossAccountRestore` — cross-account ExecRestore path
- `Test_restoreTablesWithFk_AlwaysRestoresParentTables` — key test: parent tables NOT skipped
- `Test_restoreTablesWithFk_SkipsNilEntries` — nil fkTableMap entries skipped
- `Test_restoreTablesWithFk_EmptyList` — empty list succeeds
- `Test_checkTableIsMaster` — true/false return cases
- `Test_checkDatabaseIsMaster` — true/false return cases
- `Test_deleteCurFkTables_SkipsMasterTables` — existing deleteCurFk behavior preserved

**Coverage:** restoreTablesWithFk 85.7%, checkTableIsMaster 90.9%, checkDatabaseIsMaster 81.8%, recreateTable 69% (limited by 10 lines of dead code in the `isRestoreByCloneSql` branch that is never taken).
