### PR TITLE
frontend: optimize SHOW ACCOUNTS account-info SQL (#24092)

### DIFF
--- a/pkg/frontend/show_account.go
+++ b/pkg/frontend/show_account.go
@@ -54,18 +54,25 @@ const (
 		"	md.account_id = %d;"
 
 	getAccountInfoFormatV2 = "" +
-		"WITH db_tbl_counts AS (" +
+		"WITH db_counts AS (" +
+		"	SELECT" +
+		"		CAST(md.account_id AS BIGINT) AS account_id," +
+		"		COUNT(DISTINCT md.dat_id) AS db_count" +
+		"	FROM" +
+		"		mo_catalog.mo_database AS md" +
+		"		%s" + // optional exact account filter for database counts
+		"	GROUP BY" +
+		"		md.account_id" +
+		")," +
+		"tbl_counts AS (" +
 		"	SELECT" +
 		"		CAST(mt.account_id AS BIGINT) AS account_id," +
-		"		COUNT(DISTINCT md.dat_id) AS db_count," +
 		"		COUNT(DISTINCT mt.rel_id) AS tbl_count" +
 		"	FROM" +
 		"		mo_catalog.mo_tables AS mt" +
-		"	JOIN" +
-		"		mo_catalog.mo_database AS md" +
-		"	ON " +
-		"		mt.account_id = md.account_id AND" +
+		"	WHERE" +
 		"		mt.relkind IN ('v','e','r','cluster') " +
+		"		%s" + // optional exact account filter for table counts
 		"	GROUP BY" +
 		"		mt.account_id" +
 		")," +
@@ -77,18 +84,22 @@ const (
 		"		ma.created_time," +
 		"		ma.status," +
 		"		ma.suspended_time," +
-		"		db_tbl_counts.db_count," +
-		"		db_tbl_counts.tbl_count," +
+		"		db_counts.db_count," +
+		"		tbl_counts.tbl_count," +
 		"		CAST(0 AS DOUBLE) AS size," +
 		"		CAST(0 AS DOUBLE) AS snapshot_size," +
 		"		ma.comments" +
 		"		%s" + // possible placeholder for object count
 		"	FROM" +
-		"		db_tbl_counts" +
-		"	JOIN" +
 		"		mo_catalog.mo_account AS ma " +
+		"	JOIN" +
+		"		db_counts " +
 		"	ON " +
-		"		db_tbl_counts.account_id = ma.account_id " +
+		"		ma.account_id = db_counts.account_id " +
+		"	JOIN" +
+		"		tbl_counts " +
+		"	ON " +
+		"		ma.account_id = tbl_counts.account_id " +
 		"		%s" + // where clause
 		")" +
 		"SELECT * FROM final_result;"
@@ -116,34 +127,50 @@ var cnUsageCache = logtail.NewStorageUsageCache(
 	logtail.WithLazyThreshold(5))
 
 func getSqlForAccountInfo(like *tree.ComparisonExpr, accId int64, needObjectCount bool) string {
-	var likePattern = ""
-	var where = ""
-	var and = ""
-	var account = ""
-	if like != nil {
-		likePattern = fmt.Sprintf("ma.account_name like '%s'", strings.TrimSpace(like.Right.String()))
-	}
-
-	if accId != -1 {
-		account = fmt.Sprintf("ma.account_id = %s", strconv.FormatInt(accId, 10))
-	}
-
-	if len(likePattern) != 0 && len(account) != 0 {
-		and = "and"
-	}
-
-	if len(likePattern) != 0 || len(account) != 0 {
-		where = "where"
-	}
-
-	clause := fmt.Sprintf("%s %s %s %s", where, likePattern, and, account)
+	clause := buildAccountInfoClause(like, accId)
+	dbCountFilter, tblCountFilter := buildAccountInfoCountFilters(accId)
 
 	var objectCountExpr = ""
 	if needObjectCount {
 		objectCountExpr = ", CAST(0 AS BIGINT) AS object_count"
 	}
 
-	return fmt.Sprintf(getAccountInfoFormatV2, objectCountExpr, clause)
+	return fmt.Sprintf(getAccountInfoFormatV2, dbCountFilter, tblCountFilter, objectCountExpr, clause)
+}
+
+func buildAccountInfoClause(like *tree.ComparisonExpr, accId int64) string {
+	predicates := make([]string, 0, 2)
+	if like != nil {
+		pattern := strings.TrimSpace(like.Right.String())
+		predicates = append(predicates, "ma.account_name like "+quoteSQLStringLiteral(pattern))
+	}
+
+	if accId != -1 {
+		predicates = append(predicates, fmt.Sprintf("ma.account_id = %s", strconv.FormatInt(accId, 10)))
+	}
+
+	if len(predicates) > 0 {
+		return "where " + strings.Join(predicates, " and ")
+	}
+
+	return ""
+}
+
+func buildAccountInfoCountFilters(accId int64) (dbCountFilter, tblCountFilter string) {
+	if accId != -1 {
+		accountFilter := strconv.FormatInt(accId, 10)
+		dbCountFilter = fmt.Sprintf("WHERE md.account_id = %s", accountFilter)
+		tblCountFilter = fmt.Sprintf("AND mt.account_id = %s", accountFilter)
+	}
+	return
+}
+
+func quoteSQLStringLiteral(s string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`'`, `''`,
+	)
+	return "'" + replacer.Replace(s) + "'"
 }
 
 func requestStorageUsage(ctx context.Context, ses *Session, accIds [][]int64) (resp any, tried bool, err error) {

--- a/pkg/frontend/show_account_test.go
+++ b/pkg/frontend/show_account_test.go
@@ -17,6 +17,7 @@ package frontend
 import (
 	"context"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,28 +35,120 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func normalizeSQL(sql string) string {
+	return strings.Join(strings.Fields(sql), " ")
+}
+
 func Test_getSqlForAccountInfo(t *testing.T) {
 	type arg struct {
-		s    string
-		want string
+		name            string
+		s               string
+		accID           int64
+		needObjectCount bool
+		wantContains    []string
+		wantNotContains []string
 	}
 	args := []arg{
 		{
-			s:    "show accounts;",
-			want: "WITH db_tbl_counts AS (\tSELECT\t\tCAST(mt.account_id AS BIGINT) AS account_id,\t\tCOUNT(DISTINCT md.dat_id) AS db_count,\t\tCOUNT(DISTINCT mt.rel_id) AS tbl_count\tFROM\t\tmo_catalog.mo_tables AS mt\tJOIN\t\tmo_catalog.mo_database AS md\tON \t\tmt.account_id = md.account_id AND\t\tmt.relkind IN ('v','e','r','cluster') \tGROUP BY\t\tmt.account_id),final_result AS (\tSELECT\t\tCAST(ma.account_id AS BIGINT) AS account_id,\t\tma.account_name,\t\tma.admin_name,\t\tma.created_time,\t\tma.status,\t\tma.suspended_time,\t\tdb_tbl_counts.db_count,\t\tdb_tbl_counts.tbl_count,\t\tCAST(0 AS DOUBLE) AS size,\t\tCAST(0 AS DOUBLE) AS snapshot_size,\t\tma.comments\t\t\tFROM\t\tdb_tbl_counts\tJOIN\t\tmo_catalog.mo_account AS ma \tON \t\tdb_tbl_counts.account_id = ma.account_id \t\t   )SELECT * FROM final_result;",
+			name:  "all accounts",
+			s:     "show accounts;",
+			accID: -1,
+			wantContains: []string{
+				"WITH db_counts AS (",
+				"COUNT(DISTINCT md.dat_id) AS db_count",
+				"tbl_counts AS (",
+				"COUNT(DISTINCT mt.rel_id) AS tbl_count",
+				"JOIN db_counts ON ma.account_id = db_counts.account_id",
+				"JOIN tbl_counts ON ma.account_id = tbl_counts.account_id",
+			},
+			wantNotContains: []string{
+				"mo_catalog.mo_tables AS mt JOIN mo_catalog.mo_database AS md",
+				"db_tbl_counts",
+				"LEFT JOIN",
+			},
 		},
 		{
-			s:    "show accounts like '%abc';",
-			want: "WITH db_tbl_counts AS (\tSELECT\t\tCAST(mt.account_id AS BIGINT) AS account_id,\t\tCOUNT(DISTINCT md.dat_id) AS db_count,\t\tCOUNT(DISTINCT mt.rel_id) AS tbl_count\tFROM\t\tmo_catalog.mo_tables AS mt\tJOIN\t\tmo_catalog.mo_database AS md\tON \t\tmt.account_id = md.account_id AND\t\tmt.relkind IN ('v','e','r','cluster') \tGROUP BY\t\tmt.account_id),final_result AS (\tSELECT\t\tCAST(ma.account_id AS BIGINT) AS account_id,\t\tma.account_name,\t\tma.admin_name,\t\tma.created_time,\t\tma.status,\t\tma.suspended_time,\t\tdb_tbl_counts.db_count,\t\tdb_tbl_counts.tbl_count,\t\tCAST(0 AS DOUBLE) AS size,\t\tCAST(0 AS DOUBLE) AS snapshot_size,\t\tma.comments\t\t\tFROM\t\tdb_tbl_counts\tJOIN\t\tmo_catalog.mo_account AS ma \tON \t\tdb_tbl_counts.account_id = ma.account_id \t\twhere ma.account_name like '%abc'  )SELECT * FROM final_result;",
+			name:  "like filter",
+			s:     "show accounts like '%abc';",
+			accID: -1,
+			wantContains: []string{
+				"where ma.account_name like '%abc'",
+			},
+		},
+		{
+			name:  "like filter with quote",
+			s:     "show accounts like 'ab''cd';",
+			accID: -1,
+			wantContains: []string{
+				"where ma.account_name like 'ab''cd'",
+			},
+		},
+		{
+			name:  "like filter with backslash",
+			s:     "show accounts like 'ab\\_cd';",
+			accID: -1,
+			wantContains: []string{
+				"where ma.account_name like 'ab\\\\_cd'",
+			},
+		},
+		{
+			name:  "exact account filter",
+			s:     "show accounts;",
+			accID: 100,
+			wantContains: []string{
+				"WHERE md.account_id = 100",
+				"AND mt.account_id = 100",
+				"where ma.account_id = 100",
+			},
+		},
+		{
+			name:  "like and exact account filter",
+			s:     "show accounts like '%abc';",
+			accID: 100,
+			wantContains: []string{
+				"where ma.account_name like '%abc' and ma.account_id = 100",
+				"WHERE md.account_id = 100",
+				"AND mt.account_id = 100",
+			},
+		},
+		{
+			name:            "object count",
+			s:               "show accounts;",
+			accID:           -1,
+			needObjectCount: true,
+			wantContains: []string{
+				"CAST(0 AS BIGINT) AS object_count",
+			},
+		},
+		{
+			name:            "object count with exact account filter",
+			s:               "show accounts;",
+			accID:           100,
+			needObjectCount: true,
+			wantContains: []string{
+				"CAST(0 AS BIGINT) AS object_count",
+				"WHERE md.account_id = 100",
+				"AND mt.account_id = 100",
+				"where ma.account_id = 100",
+			},
 		},
 	}
 
 	for _, a := range args {
-		one, err := parsers.ParseOne(context.Background(), dialect.MYSQL, a.s, 1)
-		assert.NoError(t, err)
-		sa1 := one.(*tree.ShowAccounts)
-		r1 := getSqlForAccountInfo(sa1.Like, -1, false)
-		assert.Equal(t, a.want, r1)
+		t.Run(a.name, func(t *testing.T) {
+			one, err := parsers.ParseOne(context.Background(), dialect.MYSQL, a.s, 1)
+			require.NoError(t, err)
+			sa1 := one.(*tree.ShowAccounts)
+			got := normalizeSQL(getSqlForAccountInfo(sa1.Like, a.accID, a.needObjectCount))
+			for _, fragment := range a.wantContains {
+				assert.Contains(t, got, normalizeSQL(fragment))
+			}
+			for _, fragment := range a.wantNotContains {
+				assert.NotContains(t, got, normalizeSQL(fragment))
+			}
+			_, err = parsers.ParseOne(context.Background(), dialect.MYSQL, got, 1)
+			require.NoError(t, err)
+		})
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/24091

## What this PR does / why we need it:
Address #24091 by rewriting `getSqlForAccountInfo()` so `SHOW ACCOUNTS` computes database and table counts with separate aggregates instead of joining `mo_catalog.mo_tables` and `mo_catalog.mo_database` on `account_id` before `COUNT(DISTINCT ...)`. This removes the `mo_tables x mo_database` amplification that dominated the `getAccountInfo()` CPU flamegraph, pushes exact `account_id` filters into the aggregate CTEs for single-account requests, and keeps the rest of the `SHOW ACCOUNTS` behavior unchanged. As a low-risk follow-up, this PR also hardens reconstruction of the internal `LIKE` predicate by escaping single quotes and backslashes, and adds combined SQL-generation plus parser round-trip coverage.