### PR TITLE
frontend: fix data race in materializeSubqueryUnified goroutine

### DIFF
--- a/pkg/frontend/data_branch_pick.go
+++ b/pkg/frontend/data_branch_pick.go
@@ -841,6 +841,7 @@ func materializeSubqueryUnified(
 	errChan := make(chan error, 1)
 	subqueryCtx := compile.AttachInternalExecutorSession(ctx, ses)
 	subqueryCtx = compile.AttachInternalExecutorPrivilegeCheck(subqueryCtx)
+	subqueryCtx, cancelSubquery := context.WithCancel(subqueryCtx)
 
 	// Launch the streaming SQL in a goroutine.
 	done := make(chan struct{})
@@ -860,6 +861,14 @@ func materializeSubqueryUnified(
 	// callers can safely close bh without a data race on the
 	// underlying session.
 	defer func() {
+		cancelSubquery()
+		// Drain errChan to unblock the executor's double-send on
+		// context cancellation (sql_executor.go sends to err_chan
+		// in the callback AND after c.Run, with buffer=1).
+		go func() {
+			for range errChan {
+			}
+		}()
 		for res := range streamChan {
 			res.Close()
 		}

--- a/pkg/frontend/data_branch_pick.go
+++ b/pkg/frontend/data_branch_pick.go
@@ -843,7 +843,9 @@ func materializeSubqueryUnified(
 	subqueryCtx = compile.AttachInternalExecutorPrivilegeCheck(subqueryCtx)
 
 	// Launch the streaming SQL in a goroutine.
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		defer close(streamChan)
 		defer close(errChan)
 		if _, err2 := runSql(subqueryCtx, ses, bh, orderSQL, streamChan, errChan); err2 != nil {
@@ -852,6 +854,16 @@ func materializeSubqueryUnified(
 			default:
 			}
 		}
+	}()
+
+	// Ensure the goroutine finishes before we return so that
+	// callers can safely close bh without a data race on the
+	// underlying session.
+	defer func() {
+		for res := range streamChan {
+			res.Close()
+		}
+		<-done
 	}()
 
 	mp := ses.proc.Mp()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24118

## What this PR does / why we need it:
The streaming goroutine launched in materializeSubqueryUnified accesses the back executor (bh) via runSql. On early-return paths (ctx.Done or error), the function returned without waiting for the goroutine to finish. The caller chain then closed bh via deferred cleanup, racing with the goroutine's read of feSessionImpl fields.

Add a done channel and a defer that drains streamChan and waits for the goroutine to complete before returning, ensuring bh is not closed while still in use.