### PR TITLE
3.0: fix: clone hidden views from subscriptions

### DIFF
--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -7589,8 +7589,10 @@ func newBh(ctrl *gomock.Controller, sql2result map[string]ExecResult) Background
 }
 
 type backgroundExecTest struct {
-	currentSql string
-	sql2result map[string]ExecResult
+	currentSql   string
+	sql2result   map[string]ExecResult
+	sql2err      map[string]error
+	executedSQLs []string
 }
 
 func (bt *backgroundExecTest) ExecStmt(ctx context.Context, statement tree.Statement) error {
@@ -7610,6 +7612,7 @@ func (bt *backgroundExecTest) ClearExecResultBatches() {
 
 func (bt *backgroundExecTest) init() {
 	bt.sql2result = make(map[string]ExecResult)
+	bt.sql2err = make(map[string]error)
 }
 
 func (bt *backgroundExecTest) Close() {
@@ -7625,12 +7628,14 @@ func (bt *backgroundExecTest) GetExecStatsArray() statistic.StatsArray {
 
 func (bt *backgroundExecTest) Exec(ctx context.Context, s string) error {
 	bt.currentSql = s
-	return nil
+	bt.executedSQLs = append(bt.executedSQLs, s)
+	return bt.sql2err[s]
 }
 
 func (bt *backgroundExecTest) ExecRestore(ctx context.Context, s string, from uint32, to uint32) error {
 	bt.currentSql = s
-	return nil
+	bt.executedSQLs = append(bt.executedSQLs, s)
+	return bt.sql2err[s]
 }
 
 func (bt *backgroundExecTest) GetExecResultSet() []interface{} {

--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -508,37 +508,80 @@ func handleCloneDatabase(
 
 	// clone view table
 	if len(viewMap) != 0 {
+		viewSnapshot := prepareCloneViewSnapshot(snapshot, snapshotTS)
 		fromAccount := opAccountId
-		if snapshot != nil && snapshot.Tenant != nil {
-			fromAccount = snapshot.Tenant.TenantID
+		if viewSnapshot != nil && viewSnapshot.Tenant != nil {
+			fromAccount = viewSnapshot.Tenant.TenantID
 		}
 
 		if sortedViews, err = sortedViewInfos(
-			reqCtx, ses, bh, "", snapshot, viewMap, fromAccount, toAccountId,
+			reqCtx, ses, bh, "", viewSnapshot, viewMap, fromAccount, toAccountId,
 		); err != nil {
 			return
 		}
 
-		for i := range sortedViews {
-			sortedViews[i] = strings.ReplaceAll(
-				sortedViews[i], stmt.SrcDatabase.String(), stmt.DstDatabase.String())
-		}
+		newViewMap, sortedViews := rewriteCloneViewInfos(
+			viewMap, sortedViews, srcDBName, stmt.DstDatabase.String(),
+		)
 
-		newViewMap := make(map[string]*tableInfo)
-		for key, info := range viewMap {
-			key = strings.ReplaceAll(key, stmt.SrcDatabase.String(), stmt.DstDatabase.String())
-			info.createSql = strings.ReplaceAll(info.createSql, stmt.SrcDatabase.String(), stmt.DstDatabase.String())
-			info.dbName = stmt.DstDatabase.String()
-
-			newViewMap[key] = info
-		}
-
-		if err = restoreViews(reqCtx, ses, bh, "", newViewMap, toAccountId, sortedViews); err != nil {
+		if err = restoreViews(reqCtx, ses, bh, "", newViewMap, toAccountId, sortedViews, true); err != nil {
 			return
 		}
 	}
 
 	return
+}
+
+func prepareCloneViewSnapshot(snapshot *plan.Snapshot, snapshotTS int64) *plan.Snapshot {
+	if plan.IsSnapshotValid(snapshot) || snapshotTS == 0 {
+		return snapshot
+	}
+	if snapshot == nil {
+		return &plan.Snapshot{
+			TS: &timestamp.Timestamp{PhysicalTime: snapshotTS},
+		}
+	}
+
+	cloned := *snapshot
+	cloned.TS = &timestamp.Timestamp{PhysicalTime: snapshotTS}
+	return &cloned
+}
+
+func rewriteCloneViewInfos(
+	viewMap map[string]*tableInfo,
+	sortedViews []string,
+	srcDBName string,
+	dstDBName string,
+) (map[string]*tableInfo, []string) {
+	rewrittenViews := make([]string, 0, len(sortedViews))
+	for _, key := range sortedViews {
+		dbName, tblName := splitKey(key)
+		if tblName == "" {
+			rewrittenViews = append(rewrittenViews, strings.ReplaceAll(key, srcDBName, dstDBName))
+			continue
+		}
+		if dbName == srcDBName {
+			key = genKey(dstDBName, tblName)
+		}
+		rewrittenViews = append(rewrittenViews, key)
+	}
+
+	rewrittenViewMap := make(map[string]*tableInfo, len(viewMap))
+	for key, info := range viewMap {
+		dbName, tblName := splitKey(key)
+		if tblName == "" {
+			key = strings.ReplaceAll(key, srcDBName, dstDBName)
+		} else if dbName == srcDBName {
+			key = genKey(dstDBName, tblName)
+		}
+
+		clonedInfo := *info
+		clonedInfo.dbName = dstDBName
+		clonedInfo.createSql = strings.ReplaceAll(info.createSql, srcDBName, dstDBName)
+		rewrittenViewMap[key] = &clonedInfo
+	}
+
+	return rewrittenViewMap, rewrittenViews
 }
 
 func tryToIncreaseTxnPhysicalTS(

--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -520,11 +520,11 @@ func handleCloneDatabase(
 			return
 		}
 
-		newViewMap, sortedViews := rewriteCloneViewInfos(
+		rewrittenViewMap, rewrittenViews := rewriteCloneViewInfos(
 			viewMap, sortedViews, srcDBName, stmt.DstDatabase.String(),
 		)
 
-		if err = restoreViews(reqCtx, ses, bh, "", newViewMap, toAccountId, sortedViews, true); err != nil {
+		if err = restoreViews(reqCtx, ses, bh, "", rewrittenViewMap, toAccountId, rewrittenViews, true); err != nil {
 			return
 		}
 	}

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -40,9 +40,18 @@ func Test_prepareCloneViewSnapshot(t *testing.T) {
 		Tenant: &plan.SnapshotTenant{TenantID: 2002},
 	}
 	require.Same(t, valid, prepareCloneViewSnapshot(valid, 42))
+
+	fromNil := prepareCloneViewSnapshot(nil, 24)
+	require.NotNil(t, fromNil)
+	require.NotNil(t, fromNil.TS)
+	require.Equal(t, int64(24), fromNil.TS.PhysicalTime)
+	require.Nil(t, fromNil.Tenant)
+
+	require.Nil(t, prepareCloneViewSnapshot(nil, 0))
 }
 
 func Test_rewriteCloneViewInfos(t *testing.T) {
+	fallbackKey := "pub_db#"
 	viewMap := map[string]*tableInfo{
 		genKey("pub_db", "v1"): {
 			dbName:    "pub_db",
@@ -50,15 +59,23 @@ func Test_rewriteCloneViewInfos(t *testing.T) {
 			typ:       view,
 			createSql: "create view `pub_db`.`v1` as select * from `pub_db`.`t1`",
 		},
+		fallbackKey: {
+			dbName:    "pub_db",
+			tblName:   "legacy_v",
+			typ:       view,
+			createSql: "create view `pub_db`.`legacy_v` as select 1",
+		},
 	}
 	sortedViews := []string{
 		genKey("other_db", "dep_v"),
+		fallbackKey,
 		genKey("pub_db", "v1"),
 	}
 
 	rewrittenViewMap, rewrittenViews := rewriteCloneViewInfos(viewMap, sortedViews, "pub_db", "clone_db")
 	require.Equal(t, []string{
 		genKey("other_db", "dep_v"),
+		"clone_db#",
 		genKey("clone_db", "v1"),
 	}, rewrittenViews)
 
@@ -67,6 +84,13 @@ func Test_rewriteCloneViewInfos(t *testing.T) {
 	require.Equal(t, "clone_db", info.dbName)
 	require.Equal(t, "create view `clone_db`.`v1` as select * from `clone_db`.`t1`", info.createSql)
 
+	fallbackInfo, ok := rewrittenViewMap["clone_db#"]
+	require.True(t, ok)
+	require.Equal(t, "clone_db", fallbackInfo.dbName)
+	require.Equal(t, "create view `clone_db`.`legacy_v` as select 1", fallbackInfo.createSql)
+
 	require.Equal(t, "pub_db", viewMap[genKey("pub_db", "v1")].dbName)
 	require.Equal(t, "create view `pub_db`.`v1` as select * from `pub_db`.`t1`", viewMap[genKey("pub_db", "v1")].createSql)
+	require.Equal(t, "pub_db", viewMap[fallbackKey].dbName)
+	require.Equal(t, "create view `pub_db`.`legacy_v` as select 1", viewMap[fallbackKey].createSql)
 }

--- a/pkg/frontend/clone_test.go
+++ b/pkg/frontend/clone_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
+)
+
+func Test_prepareCloneViewSnapshot(t *testing.T) {
+	original := &plan.Snapshot{
+		Tenant: &plan.SnapshotTenant{TenantID: 1001},
+	}
+
+	rewritten := prepareCloneViewSnapshot(original, 42)
+	require.NotNil(t, rewritten)
+	require.NotNil(t, rewritten.TS)
+	require.Equal(t, int64(42), rewritten.TS.PhysicalTime)
+	require.Equal(t, uint32(1001), rewritten.Tenant.TenantID)
+	require.Nil(t, original.TS)
+
+	valid := &plan.Snapshot{
+		TS:     &timestamp.Timestamp{PhysicalTime: 99},
+		Tenant: &plan.SnapshotTenant{TenantID: 2002},
+	}
+	require.Same(t, valid, prepareCloneViewSnapshot(valid, 42))
+}
+
+func Test_rewriteCloneViewInfos(t *testing.T) {
+	viewMap := map[string]*tableInfo{
+		genKey("pub_db", "v1"): {
+			dbName:    "pub_db",
+			tblName:   "v1",
+			typ:       view,
+			createSql: "create view `pub_db`.`v1` as select * from `pub_db`.`t1`",
+		},
+	}
+	sortedViews := []string{
+		genKey("other_db", "dep_v"),
+		genKey("pub_db", "v1"),
+	}
+
+	rewrittenViewMap, rewrittenViews := rewriteCloneViewInfos(viewMap, sortedViews, "pub_db", "clone_db")
+	require.Equal(t, []string{
+		genKey("other_db", "dep_v"),
+		genKey("clone_db", "v1"),
+	}, rewrittenViews)
+
+	info, ok := rewrittenViewMap[genKey("clone_db", "v1")]
+	require.True(t, ok)
+	require.Equal(t, "clone_db", info.dbName)
+	require.Equal(t, "create view `clone_db`.`v1` as select * from `clone_db`.`t1`", info.createSql)
+
+	require.Equal(t, "pub_db", viewMap[genKey("pub_db", "v1")].dbName)
+	require.Equal(t, "create view `pub_db`.`v1` as select * from `pub_db`.`t1`", viewMap[genKey("pub_db", "v1")].createSql)
+}

--- a/pkg/frontend/pitr_test.go
+++ b/pkg/frontend/pitr_test.go
@@ -3027,7 +3027,6 @@ func Test_restoreViewsSkipMissingDependency(t *testing.T) {
 
 		missingSQL := "create view skip_v as select * from missing_t"
 		okSQL := "create view ok_v as select 1"
-		bh.sql2err[missingSQL] = moerr.NewNoSuchTable(ctx, "db01", "missing_t")
 
 		viewMap := map[string]*tableInfo{
 			genKey("db01", "skip_v"): {
@@ -3045,15 +3044,80 @@ func Test_restoreViewsSkipMissingDependency(t *testing.T) {
 		}
 		sortedViews := []string{genKey("db01", "skip_v"), genKey("db01", "ok_v")}
 
-		err := restoreViews(ctx, ses, bh, "sp01", viewMap, 0, sortedViews, true)
-		require.NoError(t, err)
-		require.Contains(t, bh.executedSQLs, okSQL)
+		testCases := []struct {
+			name       string
+			missingErr error
+		}{
+			{
+				name:       "no such table",
+				missingErr: moerr.NewNoSuchTable(ctx, "db01", "missing_t"),
+			},
+			{
+				name:       "parse missing table",
+				missingErr: moerr.NewParseErrorf(ctx, "table %q does not exist", "missing_t"),
+			},
+		}
 
-		bh.executedSQLs = nil
-		err = restoreViews(ctx, ses, bh, "sp01", viewMap, 0, sortedViews, false)
-		require.Error(t, err)
-		require.NotContains(t, bh.executedSQLs, okSQL)
+		for _, tc := range testCases {
+			bh.sql2err = map[string]error{missingSQL: tc.missingErr}
+			bh.executedSQLs = nil
+
+			err := restoreViews(ctx, ses, bh, "sp01", viewMap, 0, sortedViews, true)
+			require.NoError(t, err, tc.name)
+			require.Contains(t, bh.executedSQLs, okSQL, tc.name)
+
+			bh.executedSQLs = nil
+			err = restoreViews(ctx, ses, bh, "sp01", viewMap, 0, sortedViews, false)
+			require.Error(t, err, tc.name)
+			require.NotContains(t, bh.executedSQLs, okSQL, tc.name)
+		}
 	})
+}
+
+func Test_canSkipRestoreViewError(t *testing.T) {
+	ctx := context.Background()
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "no such table",
+			err:  moerr.NewNoSuchTable(ctx, "db01", "missing_t"),
+			want: true,
+		},
+		{
+			name: "bad database",
+			err:  moerr.NewBadDB(ctx, "missing_db"),
+			want: true,
+		},
+		{
+			name: "parse missing table",
+			err:  moerr.NewParseErrorf(ctx, "table %q does not exist", "missing_t"),
+			want: true,
+		},
+		{
+			name: "parse missing column",
+			err:  moerr.NewParseErrorf(ctx, "column %q does not exist", "missing_c"),
+			want: false,
+		},
+		{
+			name: "other error",
+			err:  moerr.NewInternalError(ctx, "boom"),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, canSkipRestoreViewError(tc.err))
+		})
+	}
 }
 
 func Test_restoreViewsWithPitr(t *testing.T) {

--- a/pkg/frontend/pitr_test.go
+++ b/pkg/frontend/pitr_test.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -25,7 +24,9 @@ import (
 	"github.com/prashantv/gostub"
 	"github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
@@ -2969,7 +2970,7 @@ func Test_restoreViews(t *testing.T) {
 			ctx, ses, bh, "sp01", nil, viewMap, 0, 0)
 		require.NoError(t, err)
 
-		err = restoreViews(ctx, ses, bh, "sp01", viewMap, 0, sortedViews)
+		err = restoreViews(ctx, ses, bh, "sp01", viewMap, 0, sortedViews, false)
 		assert.NoError(t, err)
 
 		viewMap = map[string]*tableInfo{
@@ -2987,6 +2988,71 @@ func Test_restoreViews(t *testing.T) {
 		//
 		//err = restoreViews(ctx, ses, bh, "sp01", viewMap, 0, sortedViews)
 		//assert.Error(t, err)
+	})
+}
+
+func Test_restoreViewsSkipMissingDependency(t *testing.T) {
+	convey.Convey("restoreViews skips missing dependency for clone", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ses := newTestSession(t, ctrl)
+		defer ses.Close()
+
+		bh := &backgroundExecTest{}
+		bh.init()
+
+		bhStub := gostub.StubFunc(&NewBackgroundExec, bh)
+		defer bhStub.Reset()
+
+		pu := config.NewParameterUnit(&config.FrontendParameters{}, nil, nil, nil)
+		pu.SV.SetDefaultValues()
+		pu.SV.KillRountinesInterval = 0
+		setPu("", pu)
+		ctx := context.WithValue(context.TODO(), config.ParameterUnitKey, pu)
+		rm, _ := NewRoutineManager(ctx, "")
+		ses.rm = rm
+
+		tenant := &TenantInfo{
+			Tenant:        sysAccountName,
+			User:          rootName,
+			DefaultRole:   moAdminRoleName,
+			TenantID:      sysAccountID,
+			UserID:        rootID,
+			DefaultRoleID: moAdminRoleID,
+		}
+		ses.SetTenantInfo(tenant)
+
+		ctx = context.WithValue(ctx, defines.TenantIDKey{}, uint32(sysAccountID))
+
+		missingSQL := "create view skip_v as select * from missing_t"
+		okSQL := "create view ok_v as select 1"
+		bh.sql2err[missingSQL] = moerr.NewNoSuchTable(ctx, "db01", "missing_t")
+
+		viewMap := map[string]*tableInfo{
+			genKey("db01", "skip_v"): {
+				dbName:    "db01",
+				tblName:   "skip_v",
+				typ:       "VIEW",
+				createSql: missingSQL,
+			},
+			genKey("db01", "ok_v"): {
+				dbName:    "db01",
+				tblName:   "ok_v",
+				typ:       "VIEW",
+				createSql: okSQL,
+			},
+		}
+		sortedViews := []string{genKey("db01", "skip_v"), genKey("db01", "ok_v")}
+
+		err := restoreViews(ctx, ses, bh, "sp01", viewMap, 0, sortedViews, true)
+		require.NoError(t, err)
+		require.Contains(t, bh.executedSQLs, okSQL)
+
+		bh.executedSQLs = nil
+		err = restoreViews(ctx, ses, bh, "sp01", viewMap, 0, sortedViews, false)
+		require.Error(t, err)
+		require.NotContains(t, bh.executedSQLs, okSQL)
 	})
 }
 

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -1346,7 +1346,13 @@ func canSkipRestoreViewError(err error) bool {
 	}
 
 	errMsg := strings.ToLower(err.Error())
-	return strings.Contains(errMsg, "no such table") || strings.Contains(errMsg, "unknown database")
+	if strings.Contains(errMsg, "no such table") || strings.Contains(errMsg, "unknown database") {
+		return true
+	}
+
+	return moerr.IsMoErrCode(err, moerr.ErrParseError) &&
+		strings.Contains(errMsg, "does not exist") &&
+		(strings.Contains(errMsg, "table ") || strings.Contains(errMsg, "database "))
 }
 
 func sortedViewInfos(

--- a/pkg/frontend/snapshot.go
+++ b/pkg/frontend/snapshot.go
@@ -682,7 +682,7 @@ func doRestoreSnapshot(ctx context.Context, ses *Session, stmt *tree.RestoreSnap
 		}
 
 		if err = restoreViews(
-			ctx, ses, bh, snapshotName, viewMap, toAccountId, sortedView,
+			ctx, ses, bh, snapshotName, viewMap, toAccountId, sortedView, false,
 		); err != nil {
 			return
 		}
@@ -1295,6 +1295,7 @@ func restoreViews(
 	viewMap map[string]*tableInfo,
 	toAccountId uint32,
 	sortedViews []string,
+	skipIfDependencyMissing bool,
 ) (err error) {
 
 	getLogger(ses.GetService()).Info("start to restore views")
@@ -1321,6 +1322,12 @@ func restoreViews(
 				snapshotName, tblInfo.tblName, tblInfo.createSql))
 
 			if err = bh.Exec(toCtx, tblInfo.createSql); err != nil {
+				if skipIfDependencyMissing && canSkipRestoreViewError(err) {
+					getLogger(ses.GetService()).Info(fmt.Sprintf(
+						"[%s] skip restore view %v because dependency is missing: %v",
+						snapshotName, tblInfo.tblName, err))
+					continue
+				}
 				return err
 			}
 			getLogger(ses.GetService()).Info(fmt.Sprintf("[%s] restore view: %v success", snapshotName, tblInfo.tblName))
@@ -1328,6 +1335,18 @@ func restoreViews(
 	}
 
 	return nil
+}
+
+func canSkipRestoreViewError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if moerr.IsMoErrCode(err, moerr.ErrNoSuchTable) || moerr.IsMoErrCode(err, moerr.ErrBadDB) {
+		return true
+	}
+
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "no such table") || strings.Contains(errMsg, "unknown database")
 }
 
 func sortedViewInfos(

--- a/test/distributed/cases/git4data/clone/clone_subscription.result
+++ b/test/distributed/cases/git4data/clone/clone_subscription.result
@@ -111,3 +111,60 @@ drop database if exists sub_fk_chain;
 drop publication pub_fk_chain;
 drop account acc_chain;
 drop database sys_fk_chain;
+drop database if exists view_src;
+drop publication if exists pub_view_src;
+drop account if exists acc_view;
+create database view_src;
+create table view_src.t1(a int primary key);
+insert into view_src.t1 values(1),(2);
+create view view_src.v1 as select * from view_src.t1;
+create account acc_view admin_name "rootv" identified by "111";
+create publication pub_view_src database view_src account acc_view;
+create database sub_view_src from sys publication pub_view_src;
+show full tables from sub_view_src;
+Tables_in_sub_view_src    Table_type
+t1    BASE TABLE
+create database clone_view_src clone sub_view_src;
+show full tables from clone_view_src;
+Tables_in_clone_view_src    Table_type
+t1    BASE TABLE
+v1    VIEW
+select * from clone_view_src.v1;
+a
+1
+2
+drop database if exists clone_view_src;
+drop database if exists sub_view_src;
+drop publication pub_view_src;
+drop account acc_view;
+drop database view_src;
+drop database if exists base_dep;
+drop database if exists view_skip_src;
+drop publication if exists pub_view_skip;
+drop account if exists acc_skip;
+create database base_dep;
+create table base_dep.ref_t(a int primary key);
+insert into base_dep.ref_t values(10),(20);
+create database view_skip_src;
+create table view_skip_src.marker(id int primary key);
+insert into view_skip_src.marker values(1);
+create view view_skip_src.v_skip as select a from base_dep.ref_t;
+create account acc_skip admin_name "roots" identified by "111";
+create publication pub_view_skip database view_skip_src account acc_skip;
+create database sub_view_skip from sys publication pub_view_skip;
+show full tables from sub_view_skip;
+Tables_in_sub_view_skip    Table_type
+marker    BASE TABLE
+create database clone_view_skip clone sub_view_skip;
+show full tables from clone_view_skip;
+Tables_in_clone_view_skip    Table_type
+marker    BASE TABLE
+select * from clone_view_skip.marker;
+id
+1
+drop database if exists clone_view_skip;
+drop database if exists sub_view_skip;
+drop publication pub_view_skip;
+drop account acc_skip;
+drop database view_skip_src;
+drop database base_dep;

--- a/test/distributed/cases/git4data/clone/clone_subscription.sql
+++ b/test/distributed/cases/git4data/clone/clone_subscription.sql
@@ -126,3 +126,67 @@ drop database if exists sub_fk_chain;
 drop publication pub_fk_chain;
 drop account acc_chain;
 drop database sys_fk_chain;
+
+-- case 5: cross account clone db should restore hidden published views.
+drop database if exists view_src;
+drop publication if exists pub_view_src;
+drop account if exists acc_view;
+
+create database view_src;
+create table view_src.t1(a int primary key);
+insert into view_src.t1 values(1),(2);
+create view view_src.v1 as select * from view_src.t1;
+
+create account acc_view admin_name "rootv" identified by "111";
+create publication pub_view_src database view_src account acc_view;
+
+-- @session:id=6&user=acc_view:rootv&password=111
+create database sub_view_src from sys publication pub_view_src;
+show full tables from sub_view_src;
+
+create database clone_view_src clone sub_view_src;
+show full tables from clone_view_src;
+select * from clone_view_src.v1;
+
+drop database if exists clone_view_src;
+drop database if exists sub_view_src;
+-- @session
+
+drop publication pub_view_src;
+drop account acc_view;
+drop database view_src;
+
+-- case 6: cross account clone db should skip view whose dependency is outside clone target.
+drop database if exists base_dep;
+drop database if exists view_skip_src;
+drop publication if exists pub_view_skip;
+drop account if exists acc_skip;
+
+create database base_dep;
+create table base_dep.ref_t(a int primary key);
+insert into base_dep.ref_t values(10),(20);
+
+create database view_skip_src;
+create table view_skip_src.marker(id int primary key);
+insert into view_skip_src.marker values(1);
+create view view_skip_src.v_skip as select a from base_dep.ref_t;
+
+create account acc_skip admin_name "roots" identified by "111";
+create publication pub_view_skip database view_skip_src account acc_skip;
+
+-- @session:id=7&user=acc_skip:roots&password=111
+create database sub_view_skip from sys publication pub_view_skip;
+show full tables from sub_view_skip;
+
+create database clone_view_skip clone sub_view_skip;
+show full tables from clone_view_skip;
+select * from clone_view_skip.marker;
+
+drop database if exists clone_view_skip;
+drop database if exists sub_view_skip;
+-- @session
+
+drop publication pub_view_skip;
+drop account acc_skip;
+drop database view_skip_src;
+drop database base_dep;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23287

## What this PR does / why we need it:

- backport #24121 to 3.0-dev
- use the publisher DB name and a valid snapshot when cloning views from a subscription DB
- skip restoring a cloned view only when its dependencies are missing in the target clone
- add frontend coverage and a distributed clone_subscription regression for hidden and skipped views

## Validation

- CGO_CFLAGS="-I$(pwd)/thirdparties/install/include" CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -Wl,-rpath,$(pwd)/thirdparties/install/lib" go test ./pkg/frontend -run "Test_prepareCloneViewSnapshot|Test_rewriteCloneViewInfos|Test_restoreViews|Test_restoreViewsSkipMissingDependency|Test_restoreViewsWithPitr" -count=1
- ../mo-tester/run.sh -n -g -p /Users/ghs-mo/MOWorkSpace/matrixone-1st/test/distributed/cases/git4data/clone/clone_subscription.sql
- local single-node repro for hidden-view clone and missing-dependency skip cases on git_version() = 15c9b3b298