### PR TITLE
3.0: cdc: fix memory leaks in sinker pipeline

### DIFF
--- a/pkg/cdc/reader_v2_data_processor.go
+++ b/pkg/cdc/reader_v2_data_processor.go
@@ -202,6 +202,7 @@ func (dp *DataProcessor) processSnapshot(ctx context.Context, data *ChangeData) 
 		checkpointBat: data.InsertBatch,
 		fromTs:        dp.fromTs,
 		toTs:          dp.toTs,
+		mp:            dp.mp,
 	})
 
 	// Note: We don't clean data.InsertBatch here because Sink() takes ownership

--- a/pkg/cdc/sinker_v2.go
+++ b/pkg/cdc/sinker_v2.go
@@ -342,6 +342,8 @@ func (s *mysqlSinker2) processCommand(ctx context.Context, cmd *Command) {
 			zap.String("table", s.dbTblInfo.String()),
 			zap.String("command", cmd.String()),
 			zap.Error(err))
+		// Clean up batch data in skipped commands to prevent memory leaks
+		cmd.Close()
 		return
 	}
 
@@ -544,6 +546,9 @@ func (s *mysqlSinker2) recordSQLFailure(sqlType string, duration time.Duration) 
 
 // handleInsertBatch handles INSERT batch command (snapshot data)
 func (s *mysqlSinker2) handleInsertBatch(ctx context.Context, cmd *Command) error {
+	// Ensure snapshot batch is cleaned up after processing
+	defer cmd.Close()
+
 	// start := time.Now()
 	rows := 0
 	if cmd.InsertBatch != nil {
@@ -608,6 +613,9 @@ func (s *mysqlSinker2) handleInsertBatch(ctx context.Context, cmd *Command) erro
 
 // handleInsertDeleteBatch handles INSERT/DELETE batch command (tail data)
 func (s *mysqlSinker2) handleInsertDeleteBatch(ctx context.Context, cmd *Command) error {
+	// Ensure atomic batches are cleaned up on all paths (including error returns)
+	defer cmd.Close()
+
 	start := time.Now()
 	insertRows := 0
 	deleteRows := 0
@@ -771,14 +779,6 @@ func (s *mysqlSinker2) handleInsertDeleteBatch(ctx context.Context, cmd *Command
 		logutil.Debug("cdc.mysql_sinker2.insert_delete_batch_complete", completeFields...)
 	}
 
-	// Clean up atomic batches after processing
-	if cmd.InsertAtmBatch != nil {
-		cmd.InsertAtmBatch.Close()
-	}
-	if cmd.DeleteAtmBatch != nil {
-		cmd.DeleteAtmBatch.Close()
-	}
-
 	return nil
 }
 
@@ -800,6 +800,10 @@ func (s *mysqlSinker2) handleFlush(ctx context.Context, cmd *Command) error {
 // This method is called by the producer (reader) to sink data.
 // It validates watermark and queues appropriate commands for the consumer goroutine.
 func (s *mysqlSinker2) Sink(ctx context.Context, data *DecoderOutput) {
+	// Ensure batch data is freed if we return before transferring ownership to a Command.
+	// Once ownership transfers, we nil out data's batch fields to prevent double-free.
+	defer data.Close()
+
 	// Check if sinker is closed
 	s.closeMutex.RLock()
 	if s.closed {
@@ -844,12 +848,17 @@ func (s *mysqlSinker2) Sink(ctx context.Context, data *DecoderOutput) {
 		return
 	}
 
-	// Queue data command
+	// Queue data command — transfer ownership of batch data to the Command.
+	// Nil out data's fields so the deferred data.Close() won't double-free.
 	var cmd *Command
 	if data.outputTyp == OutputTypeSnapshot {
-		cmd = NewInsertBatchCommand(data.checkpointBat, data.fromTs, data.toTs)
+		cmd = NewInsertBatchCommand(data.checkpointBat, data.mp, data.fromTs, data.toTs)
+		data.checkpointBat = nil
+		data.mp = nil
 	} else if data.outputTyp == OutputTypeTail {
 		cmd = NewInsertDeleteBatchCommand(data.insertAtmBatch, data.deleteAtmBatch, data.fromTs, data.toTs)
+		data.insertAtmBatch = nil
+		data.deleteAtmBatch = nil
 	} else {
 		logutil.Error("cdc.mysql_sinker2.unknown_output_type",
 			zap.String("table", s.dbTblInfo.String()),
@@ -865,6 +874,8 @@ func (s *mysqlSinker2) sendCommand(cmd *Command) {
 	s.closeMutex.RLock()
 	if s.closed {
 		s.closeMutex.RUnlock()
+		// Clean up batch data in dropped commands
+		cmd.Close()
 		return
 	}
 	cmdCh := s.cmdCh
@@ -877,6 +888,8 @@ func (s *mysqlSinker2) sendCommand(cmd *Command) {
 	select {
 	case cmdCh <- cmd:
 	case <-closeCh:
+		// Clean up batch data in dropped commands
+		cmd.Close()
 		return
 	}
 }

--- a/pkg/cdc/sinker_v2_command.go
+++ b/pkg/cdc/sinker_v2_command.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 )
@@ -76,6 +77,10 @@ type Command struct {
 	InsertAtmBatch *AtomicBatch
 	DeleteAtmBatch *AtomicBatch
 
+	// Mp is the mpool used to allocate InsertBatch (snapshot).
+	// Needed for proper cleanup via batch.Clean(mp).
+	Mp *mpool.MPool
+
 	// Metadata for the command
 	Meta CommandMetadata
 }
@@ -112,10 +117,11 @@ func NewRollbackCommand() *Command {
 }
 
 // NewInsertBatchCommand creates a command to insert a batch of rows
-func NewInsertBatchCommand(bat *batch.Batch, fromTs, toTs types.TS) *Command {
+func NewInsertBatchCommand(bat *batch.Batch, mp *mpool.MPool, fromTs, toTs types.TS) *Command {
 	return &Command{
 		Type:        CmdInsertBatch,
 		InsertBatch: bat,
+		Mp:          mp,
 		Meta: CommandMetadata{
 			FromTs: fromTs,
 			ToTs:   toTs,
@@ -221,5 +227,28 @@ func (c *Command) Validate() error {
 
 	default:
 		return moerr.NewInternalErrorNoCtx(fmt.Sprintf("unknown command type: %v", c.Type))
+	}
+}
+
+// Close releases batch resources held by the command.
+// Must be called after the command is processed (or skipped) to avoid memory leaks.
+func (c *Command) Close() {
+	if c == nil {
+		return
+	}
+	if c.InsertBatch != nil {
+		if c.Mp != nil {
+			c.InsertBatch.Clean(c.Mp)
+		}
+		c.InsertBatch = nil
+		c.Mp = nil
+	}
+	if c.InsertAtmBatch != nil {
+		c.InsertAtmBatch.Close()
+		c.InsertAtmBatch = nil
+	}
+	if c.DeleteAtmBatch != nil {
+		c.DeleteAtmBatch.Close()
+		c.DeleteAtmBatch = nil
 	}
 }

--- a/pkg/cdc/sinker_v2_command_test.go
+++ b/pkg/cdc/sinker_v2_command_test.go
@@ -81,7 +81,7 @@ func TestNewInsertBatchCommand(t *testing.T) {
 	fromTs := types.BuildTS(100, 0)
 	toTs := types.BuildTS(200, 0)
 
-	cmd := NewInsertBatchCommand(bat, fromTs, toTs)
+	cmd := NewInsertBatchCommand(bat, nil, fromTs, toTs)
 
 	require.NotNil(t, cmd)
 	assert.Equal(t, CmdInsertBatch, cmd.Type)
@@ -175,7 +175,7 @@ func TestCommand_String(t *testing.T) {
 
 		fromTs := types.BuildTS(100, 0)
 		toTs := types.BuildTS(200, 0)
-		cmd := NewInsertBatchCommand(bat, fromTs, toTs)
+		cmd := NewInsertBatchCommand(bat, nil, fromTs, toTs)
 
 		str := cmd.String()
 		assert.Contains(t, str, "INSERT_BATCH")
@@ -314,5 +314,43 @@ func TestCommand_Validate(t *testing.T) {
 		err := cmd.Validate()
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unknown command type")
+	})
+}
+
+func TestCommand_Close(t *testing.T) {
+	t.Run("NilCommand", func(t *testing.T) {
+		var cmd *Command
+		assert.NotPanics(t, func() { cmd.Close() })
+	})
+
+	t.Run("InsertBatchWithMp", func(t *testing.T) {
+		bat := &batch.Batch{
+			Vecs: []*vector.Vector{vector.NewVec(types.T_int32.ToType())},
+		}
+		bat.SetRowCount(1)
+		cmd := NewInsertBatchCommand(bat, nil, types.BuildTS(1, 0), types.BuildTS(2, 0))
+		cmd.Close()
+		assert.Nil(t, cmd.InsertBatch)
+		assert.Nil(t, cmd.Mp)
+	})
+
+	t.Run("InsertDeleteBatch", func(t *testing.T) {
+		insertBatch := NewAtomicBatch(nil)
+		deleteBatch := NewAtomicBatch(nil)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, deleteBatch, types.BuildTS(1, 0), types.BuildTS(2, 0))
+		cmd.Close()
+		assert.Nil(t, cmd.InsertAtmBatch)
+		assert.Nil(t, cmd.DeleteAtmBatch)
+	})
+
+	t.Run("Idempotent", func(t *testing.T) {
+		cmd := NewInsertDeleteBatchCommand(NewAtomicBatch(nil), nil, types.BuildTS(1, 0), types.BuildTS(2, 0))
+		cmd.Close()
+		assert.NotPanics(t, func() { cmd.Close() })
+	})
+
+	t.Run("EmptyCommand", func(t *testing.T) {
+		cmd := NewBeginCommand()
+		assert.NotPanics(t, func() { cmd.Close() })
 	})
 }

--- a/pkg/cdc/sinker_v2_executor.go
+++ b/pkg/cdc/sinker_v2_executor.go
@@ -571,9 +571,18 @@ func (e *Executor) ensureConnection(ctx context.Context) error {
 	return nil
 }
 
+// Maximum number of SQL statements to record per transaction for debugging.
+// Prevents unbounded memory growth when recording is enabled on high-volume tables.
+const maxDebugTxnSQLEntries = 1000
+
 // recordTxnSQL records SQL for debugging
 func (e *Executor) recordTxnSQL(sqlBuf []byte) {
 	if !e.debugTxnRecorder.doRecord {
+		return
+	}
+
+	// Cap the number of recorded SQL statements to prevent unbounded memory growth
+	if len(e.debugTxnRecorder.txnSQL) >= maxDebugTxnSQLEntries {
 		return
 	}
 

--- a/pkg/cdc/sinker_v2_executor_test.go
+++ b/pkg/cdc/sinker_v2_executor_test.go
@@ -683,3 +683,31 @@ func TestExecutor_TransactionCleanupOnError(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestExecutor_RecordTxnSQL_Cap(t *testing.T) {
+	executor := &Executor{}
+	executor.debugTxnRecorder.doRecord = true
+
+	// Fill up to the cap
+	for i := 0; i < maxDebugTxnSQLEntries; i++ {
+		sqlBuf := make([]byte, v2SQLBufReserved+10)
+		copy(sqlBuf[v2SQLBufReserved:], []byte("SELECT 1;"))
+		executor.recordTxnSQL(sqlBuf)
+	}
+	assert.Equal(t, maxDebugTxnSQLEntries, len(executor.debugTxnRecorder.txnSQL))
+
+	// One more should be dropped
+	sqlBuf := make([]byte, v2SQLBufReserved+20)
+	copy(sqlBuf[v2SQLBufReserved:], []byte("SELECT overflow;"))
+	executor.recordTxnSQL(sqlBuf)
+	assert.Equal(t, maxDebugTxnSQLEntries, len(executor.debugTxnRecorder.txnSQL))
+
+	t.Run("RecordDisabled", func(t *testing.T) {
+		e := &Executor{}
+		e.debugTxnRecorder.doRecord = false
+		sqlBuf := make([]byte, v2SQLBufReserved+10)
+		copy(sqlBuf[v2SQLBufReserved:], []byte("SELECT 1;"))
+		e.recordTxnSQL(sqlBuf)
+		assert.Equal(t, 0, len(e.debugTxnRecorder.txnSQL))
+	})
+}

--- a/pkg/cdc/sinker_v2_test.go
+++ b/pkg/cdc/sinker_v2_test.go
@@ -281,6 +281,28 @@ func TestMysqlSinker2_CommandProcessing(t *testing.T) {
 		// Clear error for next test
 		sinker.ClearError()
 	})
+
+	t.Run("SkipBatchCommandWhenErrorExists_CleansUp", func(t *testing.T) {
+		// Set error so processCommand skips
+		sinker.SetError(moerr.NewInternalErrorNoCtx("test error"))
+
+		// Create an InsertBatch command with real batch data
+		bat := &batch.Batch{
+			Vecs: []*vector.Vector{vector.NewVec(types.T_int32.ToType())},
+		}
+		bat.SetRowCount(1)
+		fromTs := types.BuildTS(100, 0)
+		toTs := types.BuildTS(200, 0)
+		cmd := NewInsertBatchCommand(bat, nil, fromTs, toTs)
+
+		// processCommand should skip AND call cmd.Close() to clean up batch
+		sinker.processCommand(ctx, cmd)
+
+		// Batch should have been cleaned (nil'd by Close)
+		assert.Nil(t, cmd.InsertBatch)
+
+		sinker.ClearError()
+	})
 }
 
 func TestMysqlSinker2_Reset(t *testing.T) {
@@ -557,7 +579,7 @@ func TestMysqlSinker2_HandleInsertBatch(t *testing.T) {
 
 		fromTs := types.BuildTS(100, 0)
 		toTs := types.BuildTS(200, 0)
-		cmd := NewInsertBatchCommand(bat, fromTs, toTs)
+		cmd := NewInsertBatchCommand(bat, mp, fromTs, toTs)
 
 		// Expect SQL execution
 		mock.ExpectExec("fakeSql").WillReturnResult(sqlmock.NewResult(1, 1))
@@ -614,7 +636,7 @@ func TestMysqlSinker2_HandleInsertBatch(t *testing.T) {
 
 		fromTs := types.BuildTS(100, 0)
 		toTs := types.BuildTS(200, 0)
-		cmd := NewInsertBatchCommand(bat, fromTs, toTs)
+		cmd := NewInsertBatchCommand(bat, mp, fromTs, toTs)
 
 		// Expect SQL execution to fail
 		mock.ExpectExec("fakeSql").WillReturnError(sqlmock.ErrCancelled)
@@ -626,8 +648,233 @@ func TestMysqlSinker2_HandleInsertBatch(t *testing.T) {
 	})
 }
 
-// Skipping complex async workflow tests for now
-// Will be tested through integration tests with reader
+func TestMysqlSinker2_SendCommandCleanupOnClose(t *testing.T) {
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	executor := &Executor{conn: db}
+
+	tableDef := &plan.TableDef{
+		Name: "test",
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+		},
+		Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+		Name2ColIndex: map[string]int32{"id": 0},
+	}
+
+	builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+	require.NoError(t, err)
+
+	t.Run("SendCommandAfterClose_CleansBatch", func(t *testing.T) {
+		sinker := NewMysqlSinker2(
+			executor, 1, "task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil, builder, NewCdcActiveRoutine(),
+		)
+		// Close sinker first
+		sinker.Close()
+
+		// Create a batch command
+		bat := &batch.Batch{
+			Vecs: []*vector.Vector{vector.NewVec(types.T_int32.ToType())},
+		}
+		bat.SetRowCount(1)
+		cmd := NewInsertBatchCommand(bat, nil, types.BuildTS(1, 0), types.BuildTS(2, 0))
+
+		// sendCommand should detect closed and call cmd.Close()
+		sinker.sendCommand(cmd)
+		assert.Nil(t, cmd.InsertBatch, "batch should be cleaned on closed sinker")
+	})
+
+	t.Run("SendCommandWhileCloseCh_CleansBatch", func(t *testing.T) {
+		sinker := NewMysqlSinker2(
+			executor, 1, "task-2",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil, builder, NewCdcActiveRoutine(),
+		)
+
+		// Create a batch command
+		insertBatch := NewAtomicBatch(nil)
+		deleteBatch := NewAtomicBatch(nil)
+		cmd := NewInsertDeleteBatchCommand(insertBatch, deleteBatch, types.BuildTS(1, 0), types.BuildTS(2, 0))
+
+		// cmdCh is unbuffered — sendCommand will block on it.
+		// Close sinker in another goroutine to unblock via closeCh.
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sinker.sendCommand(cmd)
+		}()
+
+		time.Sleep(10 * time.Millisecond)
+		sinker.Close()
+		wg.Wait()
+
+		// Batch should be cleaned via closeCh path
+		assert.Nil(t, cmd.InsertAtmBatch, "insert batch should be cleaned on closeCh")
+		assert.Nil(t, cmd.DeleteAtmBatch, "delete batch should be cleaned on closeCh")
+	})
+}
+
+func TestMysqlSinker2_SinkEarlyReturnCleansData(t *testing.T) {
+	mp, err := mpool.NewMPool("test_sink_cleanup", 0, mpool.NoFixed)
+	require.NoError(t, err)
+	defer mpool.DeleteMPool(mp)
+
+	db, _, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	executor := &Executor{conn: db}
+
+	tableDef := &plan.TableDef{
+		Name: "test",
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_int32)}},
+		},
+		Pkey:          &plan.PrimaryKeyDef{Names: []string{"id"}},
+		Name2ColIndex: map[string]int32{"id": 0},
+	}
+
+	builder, err := NewCDCStatementBuilder("test_db", "test", tableDef, 1024*1024, false)
+	require.NoError(t, err)
+
+	t.Run("SinkOnClosedSinker_CleansSnapshotData", func(t *testing.T) {
+		sinker := NewMysqlSinker2(
+			executor, 1, "task-1",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil, builder, NewCdcActiveRoutine(),
+		)
+		sinker.Close()
+
+		data := &DecoderOutput{
+			outputTyp:     OutputTypeSnapshot,
+			checkpointBat: &batch.Batch{Vecs: make([]*vector.Vector, 0)},
+			mp:            mp,
+			fromTs:        types.BuildTS(1, 0),
+			toTs:          types.BuildTS(2, 0),
+		}
+
+		ctx := context.Background()
+		sinker.Sink(ctx, data)
+
+		// data.Close() should have cleaned up via defer
+		assert.Nil(t, data.checkpointBat)
+		assert.Nil(t, data.mp)
+	})
+
+	t.Run("SinkOnClosedSinker_CleansTailData", func(t *testing.T) {
+		sinker := NewMysqlSinker2(
+			executor, 1, "task-2",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			nil, builder, NewCdcActiveRoutine(),
+		)
+		sinker.Close()
+
+		data := &DecoderOutput{
+			outputTyp:      OutputTypeTail,
+			insertAtmBatch: NewAtomicBatch(nil),
+			deleteAtmBatch: NewAtomicBatch(nil),
+			fromTs:         types.BuildTS(1, 0),
+			toTs:           types.BuildTS(2, 0),
+		}
+
+		ctx := context.Background()
+		sinker.Sink(ctx, data)
+
+		assert.Nil(t, data.insertAtmBatch)
+		assert.Nil(t, data.deleteAtmBatch)
+	})
+
+	t.Run("SinkWithSuccessfulOwnershipTransfer_NilsOutDataFields", func(t *testing.T) {
+		// Create a watermark updater with a cached watermark
+		wu := &CDCWatermarkUpdater{
+			cacheUncommitted:    make(map[WatermarkKey]types.TS),
+			cacheCommitting:     make(map[WatermarkKey]types.TS),
+			cacheCommitted:      make(map[WatermarkKey]types.TS),
+			errorMetadataCache:  make(map[WatermarkKey]*ErrorMetadata),
+			commitFailureCount:  make(map[WatermarkKey]uint32),
+			commitCircuitOpen:   make(map[WatermarkKey]time.Time),
+			previousErrorLabels: make(map[string]bool),
+		}
+		key := WatermarkKey{AccountId: 1, TaskId: "task-3", DBName: "src", TableName: "test"}
+		wu.cacheCommitted[key] = types.BuildTS(0, 0) // Set a zero watermark
+
+		sinker := NewMysqlSinker2(
+			executor, 1, "task-3",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			wu, builder, NewCdcActiveRoutine(),
+		)
+
+		data := &DecoderOutput{
+			outputTyp:      OutputTypeTail,
+			insertAtmBatch: NewAtomicBatch(nil),
+			deleteAtmBatch: NewAtomicBatch(nil),
+			fromTs:         types.BuildTS(1, 0),
+			toTs:           types.BuildTS(2, 0),
+		}
+
+		// Start a goroutine to drain the command channel
+		go func() {
+			cmd := <-sinker.cmdCh
+			cmd.Close()
+		}()
+
+		ctx := context.Background()
+		sinker.Sink(ctx, data)
+
+		// After ownership transfer, data fields should be nil'd
+		assert.Nil(t, data.insertAtmBatch)
+		assert.Nil(t, data.deleteAtmBatch)
+
+		sinker.Close()
+	})
+
+	t.Run("SinkSnapshotOwnershipTransfer_NilsOutDataFields", func(t *testing.T) {
+		wu := &CDCWatermarkUpdater{
+			cacheUncommitted:    make(map[WatermarkKey]types.TS),
+			cacheCommitting:     make(map[WatermarkKey]types.TS),
+			cacheCommitted:      make(map[WatermarkKey]types.TS),
+			errorMetadataCache:  make(map[WatermarkKey]*ErrorMetadata),
+			commitFailureCount:  make(map[WatermarkKey]uint32),
+			commitCircuitOpen:   make(map[WatermarkKey]time.Time),
+			previousErrorLabels: make(map[string]bool),
+		}
+		key := WatermarkKey{AccountId: 1, TaskId: "task-snap", DBName: "src", TableName: "test"}
+		wu.cacheCommitted[key] = types.BuildTS(0, 0)
+
+		sinker := NewMysqlSinker2(
+			executor, 1, "task-snap",
+			&DbTableInfo{SourceDbName: "src", SourceTblName: "test"},
+			wu, builder, NewCdcActiveRoutine(),
+		)
+
+		data := &DecoderOutput{
+			outputTyp:     OutputTypeSnapshot,
+			checkpointBat: &batch.Batch{Vecs: make([]*vector.Vector, 0)},
+			mp:            mp,
+			fromTs:        types.BuildTS(1, 0),
+			toTs:          types.BuildTS(2, 0),
+		}
+
+		go func() {
+			cmd := <-sinker.cmdCh
+			cmd.Close()
+		}()
+
+		ctx := context.Background()
+		sinker.Sink(ctx, data)
+
+		// After snapshot ownership transfer, data fields should be nil'd
+		assert.Nil(t, data.checkpointBat)
+		assert.Nil(t, data.mp)
+
+		sinker.Close()
+	})
+}
 
 // TestCreateMysqlSinker2 verifies CreateMysqlSinker2 handles various scenarios
 func TestCreateMysqlSinker2(t *testing.T) {

--- a/pkg/cdc/types.go
+++ b/pkg/cdc/types.go
@@ -250,6 +250,30 @@ type DecoderOutput struct {
 	checkpointBat  *batch.Batch
 	insertAtmBatch *AtomicBatch
 	deleteAtmBatch *AtomicBatch
+	mp             *mpool.MPool // mpool for snapshot batch cleanup
+}
+
+// Close releases batch resources held by the DecoderOutput.
+// Called when ownership was NOT transferred to a Command (early-return paths in Sink).
+func (d *DecoderOutput) Close() {
+	if d == nil {
+		return
+	}
+	if d.checkpointBat != nil {
+		if d.mp != nil {
+			d.checkpointBat.Clean(d.mp)
+		}
+		d.checkpointBat = nil
+		d.mp = nil
+	}
+	if d.insertAtmBatch != nil {
+		d.insertAtmBatch.Close()
+		d.insertAtmBatch = nil
+	}
+	if d.deleteAtmBatch != nil {
+		d.deleteAtmBatch.Close()
+		d.deleteAtmBatch = nil
+	}
 }
 
 type RowType int

--- a/pkg/cdc/types_test.go
+++ b/pkg/cdc/types_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 )
 
@@ -708,6 +709,65 @@ func TestUriInfo_String(t *testing.T) {
 			assert.Equalf(t, tt.want, info.String(), "String()")
 		})
 	}
+}
+
+func TestDecoderOutput_Close(t *testing.T) {
+	mp, err := mpool.NewMPool("test_decoder_output_close", 0, mpool.NoFixed)
+	assert.NoError(t, err)
+	defer mpool.DeleteMPool(mp)
+
+	t.Run("NilReceiver", func(t *testing.T) {
+		var d *DecoderOutput
+		assert.NotPanics(t, func() { d.Close() })
+	})
+
+	t.Run("EmptyOutput", func(t *testing.T) {
+		d := &DecoderOutput{}
+		assert.NotPanics(t, func() { d.Close() })
+	})
+
+	t.Run("WithCheckpointBat", func(t *testing.T) {
+		bat := batch.NewWithSize(1)
+		bat.Vecs[0] = testutil.NewInt32Vector(3, types.T_int32.ToType(), mp, false, []int32{1, 2, 3})
+		bat.SetRowCount(3)
+		d := &DecoderOutput{
+			checkpointBat: bat,
+			mp:            mp,
+		}
+		d.Close()
+		assert.Nil(t, d.checkpointBat)
+		assert.Nil(t, d.mp)
+	})
+
+	t.Run("WithCheckpointBatNoMp", func(t *testing.T) {
+		bat := &batch.Batch{Vecs: make([]*vector.Vector, 0)}
+		d := &DecoderOutput{
+			checkpointBat: bat,
+			mp:            nil,
+		}
+		d.Close()
+		assert.Nil(t, d.checkpointBat)
+	})
+
+	t.Run("WithAtomicBatches", func(t *testing.T) {
+		insertBatch := NewAtomicBatch(mp)
+		deleteBatch := NewAtomicBatch(mp)
+		d := &DecoderOutput{
+			insertAtmBatch: insertBatch,
+			deleteAtmBatch: deleteBatch,
+		}
+		d.Close()
+		assert.Nil(t, d.insertAtmBatch)
+		assert.Nil(t, d.deleteAtmBatch)
+	})
+
+	t.Run("Idempotent", func(t *testing.T) {
+		d := &DecoderOutput{
+			insertAtmBatch: NewAtomicBatch(mp),
+		}
+		d.Close()
+		assert.NotPanics(t, func() { d.Close() })
+	})
 }
 
 func TestActiveRoutine_ClosePause(t *testing.T) {

--- a/pkg/cdc/watermark_updater.go
+++ b/pkg/cdc/watermark_updater.go
@@ -346,6 +346,7 @@ func NewCDCWatermarkUpdater(
 		getOrAddCommittedBuffer: make([]*UpdaterJob, 0, 100),
 		addCommittedBuffer:      make([]*UpdaterJob, 0, 100),
 		committingBuffer:        make([]*UpdaterJob, 0, 100),
+		committingErrMsgBuffer:  make([]*UpdaterJob, 0, 100),
 		readKeysBuffer:          make(map[WatermarkKey]WatermarkResult, 100),
 	}
 	for _, opt := range opts {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24127

Cherry-pick of #24126 to 3.0-dev

## What this PR does / why we need it:

Fix multiple CDC memory management issues that can lead to OOM, particularly when processing large tables (e.g., TPC-H lineitem).

**Root cause analysis**: CDC sinker pipeline has several code paths where batch data (mpool-allocated memory) is not properly freed:
- When commands are skipped due to error state, batch data leaks
- When `handleInsertDeleteBatch` returns early on SQL error, cleanup code is unreachable
- Snapshot batches (`handleInsertBatch`) are never freed after processing
- When commands are dropped due to sinker shutdown, batch data leaks
- `debugTxnRecorder.txnSQL` grows unboundedly when recording is enabled

## What are the changes?

### Memory leak fixes (sinker_v2.go, sinker_v2_command.go)

1. **`Command.Close()`**: New centralized cleanup method that properly frees `InsertBatch` (via mpool), `InsertAtmBatch`, and `DeleteAtmBatch`.

2. **`handleInsertDeleteBatch`**: Move AtomicBatch cleanup to `defer cmd.Close()` so it runs on all code paths, including early error returns from SQL execution.

3. **`handleInsertBatch`**: Add `defer cmd.Close()` to free snapshot batch memory via mpool after processing. Previously these batches were never freed.

4. **`processCommand`**: Call `cmd.Close()` when commands are skipped due to pre-existing error state.

5. **`sendCommand`**: Call `cmd.Close()` when commands are dropped because the sinker is closed or shutting down.

### Other memory improvements

6. **`debugTxnRecorder`** (sinker_v2_executor.go): Cap `txnSQL` slice at 1000 entries to prevent unbounded growth.

7. **`committingErrMsgBuffer`** (watermark_updater.go): Pre-allocate with capacity 100 like all other buffers.

### Supporting changes

- Add `Mp *mpool.MPool` field to `Command` struct for proper snapshot batch cleanup
- Add `mp` field to `DecoderOutput` to propagate mpool from DataProcessor to sinker
- Update `NewInsertBatchCommand` signature to accept mpool
- Update tests accordingly
