### PR TITLE
fix: handle missing child table in DropTable FK cleanup

### DIFF
--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -2926,7 +2926,7 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 			// a table refer to it?
 			// the FOREIGN_KEY_CHECKS disabled !!!
 			// so this inexistence is expected, no need to return an error.
-			if strings.Contains(err.Error(), "can not find table by id") {
+			if isMissingTableForFkCleanup(err) {
 				logutil.Warn(
 					"cannot find the referred table when drop table",
 					zap.String("table", fmt.Sprintf("%s-%s", dbName, tblName)),
@@ -2954,6 +2954,16 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 		}
 		_, _, childRelation, err := c.e.GetRelationById(c.proc.Ctx, c.proc.GetTxnOperator(), childTblId)
 		if err != nil {
+			if isMissingTableForFkCleanup(err) {
+				logutil.Warn(
+					"cannot find child table when drop table fk cleanup",
+					zap.String("table", fmt.Sprintf("%s-%s", dbName, tblName)),
+					zap.Int("child table id", int(childTblId)),
+					zap.String("txn info", c.proc.GetTxnOperator().Txn().DebugString()),
+					zap.Error(err),
+				)
+				continue
+			}
 			return err
 		}
 		err = s.removeParentTblIdFromChildTable(c, childRelation, tblID)

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -1266,3 +1266,53 @@ func TestIsMissingTableForFkCleanup(t *testing.T) {
 	require.False(t, isMissingTableForFkCleanup(
 		moerr.NewBadDB(ctx, "db1")))
 }
+
+func TestDropTableSingleSkipsMissingFkTables(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proc := testutil.NewProcess(t)
+	proc.Base.SessionInfo.Buf = buffer.New()
+	ctx := defines.AttachAccountId(context.Background(), sysAccountId)
+	proc.Ctx = ctx
+	proc.ReplaceTopCtx(ctx)
+
+	txnMeta := txn.TxnMeta{}
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().Txn().Return(txnMeta).AnyTimes()
+	txnOp.EXPECT().GetWorkspace().Return(&Ws{}).AnyTimes()
+	proc.Base.TxnOperator = txnOp
+
+	mockRel := mock_frontend.NewMockRelation(ctrl)
+	mockRel.EXPECT().GetTableID(gomock.Any()).Return(uint64(1)).AnyTimes()
+	mockRel.EXPECT().GetTableDef(gomock.Any()).Return(&plan2.TableDef{}).AnyTimes()
+
+	mockDb := mock_frontend.NewMockDatabase(ctrl)
+	mockDb.EXPECT().Relation(gomock.Any(), "test_tbl", gomock.Any()).Return(mockRel, nil).AnyTimes()
+	mockDb.EXPECT().Delete(gomock.Any(), "test_tbl").Return(nil).AnyTimes()
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	eng.EXPECT().Database(gomock.Any(), catalog.MO_CATALOG, gomock.Any()).Return(mockDb, nil).AnyTimes()
+	// FK parent table not found → covers line 2929 (isMissingTableForFkCleanup in ForeignTbl loop)
+	eng.EXPECT().GetRelationById(gomock.Any(), gomock.Any(), uint64(42)).
+		Return("", "", nil, moerr.NewNoSuchTable(ctx, "db", "parent_tbl")).
+		Times(1)
+	// FK child table not found → covers lines 2957, 2965 (isMissingTableForFkCleanup in FkChildTblsReferToMe loop)
+	eng.EXPECT().GetRelationById(gomock.Any(), gomock.Any(), uint64(43)).
+		Return("", "", nil, moerr.NewInternalErrorf(ctx, "can not find table by id %d", 43)).
+		Times(1)
+
+	c := NewCompile("test", "test", "drop table test_tbl", "", "", eng, proc, nil, false, nil, time.Now())
+	c.disableLock = true
+	s := &Scope{}
+	err := s.dropTableSingle(c, &plan2.DropTable{
+		Database:             catalog.MO_CATALOG,
+		Table:                "test_tbl",
+		TableId:              1,
+		IsView:               true,
+		TableDef:             &plan2.TableDef{},
+		ForeignTbl:           []uint64{42},
+		FkChildTblsReferToMe: []uint64{43},
+	})
+	require.NoError(t, err)
+}

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -1246,3 +1246,23 @@ func TestRemoveFkeysRelationshipsSkipsDeletedParentTableIds(t *testing.T) {
 	s := &Scope{}
 	require.NoError(t, s.removeFkeysRelationships(c, "acc_test02"))
 }
+
+func TestIsMissingTableForFkCleanup(t *testing.T) {
+	ctx := context.Background()
+
+	// ErrNoSuchTable should match
+	require.True(t, isMissingTableForFkCleanup(
+		moerr.NewNoSuchTable(ctx, "db1", "t1")))
+
+	// ErrInternal with "can not find table by id" should match
+	require.True(t, isMissingTableForFkCleanup(
+		moerr.NewInternalError(ctx, "can not find table by id : accountId: 0")))
+
+	// ErrInternal without the specific message should not match
+	require.False(t, isMissingTableForFkCleanup(
+		moerr.NewInternalError(ctx, "some other internal error")))
+
+	// A different error type should not match
+	require.False(t, isMissingTableForFkCleanup(
+		moerr.NewBadDB(ctx, "db1")))
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24133

## What this PR does / why we need it:

When a table has stale `RefChildTbls` entries pointing to non-existent child tables (due to previous operations like CDC, snapshot restore, or prior bugs), the `FkChildTblsReferToMe` cleanup loop in `dropTableSingle` fails with:

```
internal error: can not find table by id <N>: accountId: <M>
```

This blocks `DROP TABLE` and `DROP ACCOUNT` operations.

Related issue: #24008 / PR #24009 (fixed the same error in `removeFkeysRelationships` for DropDatabase path, but missed the DropTable path).

## What is changed?

**`pkg/sql/compile/ddl.go`** (`dropTableSingle`):

1. **`FkChildTblsReferToMe` loop (line 2957)** — Added `isMissingTableForFkCleanup` error tolerance when looking up child tables. If a child table no longer exists, log a warning and continue instead of returning a fatal error. This is the same pattern already applied by PR #24009 to `removeFkeysRelationships`.

2. **`ForeignTbl` loop (line 2929)** — Upgraded the existing error check from raw `strings.Contains(err.Error(), "can not find table by id")` to the more robust `isMissingTableForFkCleanup()` helper (which also catches `ErrNoSuchTable`).
