### PR TITLE
fix: preserve CHECK constraints in SHOW CREATE TABLE

### DIFF
--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -43,6 +43,18 @@ func ConstructCreateTableSQL(
 	var err error
 	var createStr string
 
+	// CHECK constraints are preserved in rel_createsql, but the resolved table
+	// metadata does not currently reconstruct them back into tableDef.Checks.
+	// Prefer the stored DDL for SHOW CREATE TABLE so named CHECK constraints are
+	// not silently dropped from the output.
+	if !useDbName && shouldUseStoredCreateSQL(tableDef) {
+		if ctx == nil {
+			return tableDef.Createsql, nil, nil
+		}
+		stmt, err := getRewriteSQLStmt(ctx, tableDef.Createsql)
+		return tableDef.Createsql, stmt, err
+	}
+
 	tblName := tableDef.Name
 	schemaName := tableDef.DbName
 	dbTblName := fmt.Sprintf("`%s`", formatStr(tblName))
@@ -581,6 +593,15 @@ func ConstructCreateTableSQL(
 		stmt, err = getRewriteSQLStmt(ctx, createStr)
 	}
 	return createStr, stmt, err
+}
+
+func shouldUseStoredCreateSQL(tableDef *plan.TableDef) bool {
+	if tableDef == nil || tableDef.Createsql == "" || tableDef.TableType == catalog.SystemExternalRel {
+		return false
+	}
+
+	createSQLUpper := strings.ToUpper(tableDef.Createsql)
+	return strings.Contains(createSQLUpper, " CHECK (") || strings.Contains(createSQLUpper, " CONSTRAINT ")
 }
 
 // FormatColType Get the formatted description of the column type.

--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -42,18 +42,7 @@ func ConstructCreateTableSQL(
 
 	var err error
 	var createStr string
-
-	// CHECK constraints are preserved in rel_createsql, but the resolved table
-	// metadata does not currently reconstruct them back into tableDef.Checks.
-	// Prefer the stored DDL for SHOW CREATE TABLE so named CHECK constraints are
-	// not silently dropped from the output.
-	if !useDbName && shouldUseStoredCreateSQL(tableDef) {
-		if ctx == nil {
-			return tableDef.Createsql, nil, nil
-		}
-		stmt, err := getRewriteSQLStmt(ctx, tableDef.Createsql)
-		return tableDef.Createsql, stmt, err
-	}
+	checkDefs := extractTopLevelCheckDefs(tableDef)
 
 	tblName := tableDef.Name
 	schemaName := tableDef.DbName
@@ -430,6 +419,10 @@ func ConstructCreateTableSQL(
 			formatStr(fk.Name), strings.Join(colOriginNames, "`,`"), fkRefDbTblName, strings.Join(fkColOriginNames, "`,`"), strings.ReplaceAll(fk.OnDelete.String(), "_", " "), strings.ReplaceAll(fk.OnUpdate.String(), "_", " "))
 	}
 
+	for _, checkDef := range checkDefs {
+		createStr += ",\n  " + checkDef
+	}
+
 	if rowCount != 0 {
 		createStr += "\n"
 	}
@@ -595,13 +588,217 @@ func ConstructCreateTableSQL(
 	return createStr, stmt, err
 }
 
-func shouldUseStoredCreateSQL(tableDef *plan.TableDef) bool {
+func extractTopLevelCheckDefs(tableDef *plan.TableDef) []string {
 	if tableDef == nil || tableDef.Createsql == "" || tableDef.TableType == catalog.SystemExternalRel {
+		return nil
+	}
+
+	defsSection, ok := extractCreateTableDefsSection(tableDef.Createsql)
+	if !ok {
+		return nil
+	}
+
+	segments := splitTopLevelDefs(defsSection)
+	checks := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		segment = strings.TrimSpace(segment)
+		if isTopLevelCheckDef(segment) {
+			checks = append(checks, segment)
+		}
+	}
+	return checks
+}
+
+func extractCreateTableDefsSection(createSQL string) (string, bool) {
+	start := findTopLevelByte(createSQL, '(')
+	if start == -1 {
+		return "", false
+	}
+
+	end := findMatchingParen(createSQL, start)
+	if end == -1 || end <= start {
+		return "", false
+	}
+	return createSQL[start+1 : end], true
+}
+
+func splitTopLevelDefs(defs string) []string {
+	parts := make([]string, 0, 8)
+	start := 0
+	depth := 0
+	for i := 0; i < len(defs); i++ {
+		switch defs[i] {
+		case '\'', '"', '`':
+			i = skipQuoted(defs, i)
+		case '#':
+			i = skipLineComment(defs, i)
+		case '-':
+			if i+1 < len(defs) && defs[i+1] == '-' {
+				i = skipLineComment(defs, i+1)
+			}
+		case '/':
+			if i+1 < len(defs) && defs[i+1] == '*' {
+				i = skipBlockComment(defs, i)
+			}
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, defs[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, defs[start:])
+	return parts
+}
+
+func isTopLevelCheckDef(def string) bool {
+	if def == "" {
 		return false
 	}
 
-	createSQLUpper := strings.ToUpper(tableDef.Createsql)
-	return strings.Contains(createSQLUpper, " CHECK (") || strings.Contains(createSQLUpper, " CONSTRAINT ")
+	trimmed := strings.TrimSpace(def)
+	upper := strings.ToUpper(trimmed)
+	if strings.HasPrefix(upper, "CHECK") {
+		return true
+	}
+	if !strings.HasPrefix(upper, "CONSTRAINT") {
+		return false
+	}
+	return containsKeywordOutsideQuotes(trimmed, "CHECK")
+}
+
+func containsKeywordOutsideQuotes(s string, keyword string) bool {
+	upper := strings.ToUpper(s)
+	for i := 0; i < len(upper); i++ {
+		switch upper[i] {
+		case '\'', '"', '`':
+			i = skipQuoted(upper, i)
+		case '#':
+			i = skipLineComment(upper, i)
+		case '-':
+			if i+1 < len(upper) && upper[i+1] == '-' {
+				i = skipLineComment(upper, i+1)
+			}
+		case '/':
+			if i+1 < len(upper) && upper[i+1] == '*' {
+				i = skipBlockComment(upper, i)
+			}
+		default:
+			if hasKeywordAt(upper, keyword, i) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasKeywordAt(s string, keyword string, pos int) bool {
+	end := pos + len(keyword)
+	if end > len(s) || s[pos:end] != keyword {
+		return false
+	}
+	prevIsIdent := pos > 0 && isIdentChar(s[pos-1])
+	nextIsIdent := end < len(s) && isIdentChar(s[end])
+	return !prevIsIdent && !nextIsIdent
+}
+
+func isIdentChar(ch byte) bool {
+	return ch == '_' || ch >= '0' && ch <= '9' || ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
+}
+
+func findTopLevelByte(s string, target byte) int {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\'', '"', '`':
+			i = skipQuoted(s, i)
+		case '#':
+			i = skipLineComment(s, i)
+		case '-':
+			if i+1 < len(s) && s[i+1] == '-' {
+				i = skipLineComment(s, i+1)
+			}
+		case '/':
+			if i+1 < len(s) && s[i+1] == '*' {
+				i = skipBlockComment(s, i)
+			}
+		default:
+			if s[i] == target {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func findMatchingParen(s string, start int) int {
+	depth := 0
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '\'', '"', '`':
+			i = skipQuoted(s, i)
+		case '#':
+			i = skipLineComment(s, i)
+		case '-':
+			if i+1 < len(s) && s[i+1] == '-' {
+				i = skipLineComment(s, i+1)
+			}
+		case '/':
+			if i+1 < len(s) && s[i+1] == '*' {
+				i = skipBlockComment(s, i)
+			}
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func skipQuoted(s string, start int) int {
+	quote := s[start]
+	for i := start + 1; i < len(s); i++ {
+		if s[i] == '\\' && quote != '`' {
+			i++
+			continue
+		}
+		if s[i] != quote {
+			continue
+		}
+		if i+1 < len(s) && s[i+1] == quote && quote != '`' {
+			i++
+			continue
+		}
+		return i
+	}
+	return len(s) - 1
+}
+
+func skipLineComment(s string, start int) int {
+	for i := start + 1; i < len(s); i++ {
+		if s[i] == '\n' {
+			return i
+		}
+	}
+	return len(s) - 1
+}
+
+func skipBlockComment(s string, start int) int {
+	for i := start + 2; i < len(s); i++ {
+		if s[i-1] == '*' && s[i] == '/' {
+			return i
+		}
+	}
+	return len(s) - 1
 }
 
 // FormatColType Get the formatted description of the column type.

--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -592,6 +592,9 @@ func extractTopLevelCheckDefs(tableDef *plan.TableDef) []string {
 	if tableDef == nil || tableDef.Createsql == "" || tableDef.TableType == catalog.SystemExternalRel {
 		return nil
 	}
+	if !containsKeywordOutsideQuotes(tableDef.Createsql, "CHECK") {
+		return nil
+	}
 
 	defsSection, ok := extractCreateTableDefsSection(tableDef.Createsql)
 	if !ok {

--- a/pkg/sql/plan/build_show_util_test.go
+++ b/pkg/sql/plan/build_show_util_test.go
@@ -15,6 +15,7 @@
 package plan
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -166,8 +167,32 @@ func Test_ShowCreateTableUsesStoredDDLForChecks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("construct show create failed: %+v", err)
 	}
-	if showSQL != sql {
-		t.Fatalf("expected stored create sql to be reused\nexpected: %s\nactual: %s", sql, showSQL)
+	if !strings.Contains(showSQL, "CONSTRAINT chk_age CHECK (c_age IS NULL OR (c_age >= 0 AND c_age <= 200))") {
+		t.Fatalf("expected chk_age check constraint in show create output: %s", showSQL)
+	}
+	if !strings.Contains(showSQL, "CONSTRAINT chk_score CHECK (c_score IS NULL OR (c_score >= 0 AND c_score <= 100))") {
+		t.Fatalf("expected chk_score check constraint in show create output: %s", showSQL)
+	}
+	if !strings.Contains(showSQL, "PRIMARY KEY (`id`)") {
+		t.Fatalf("expected canonical primary key output to be preserved: %s", showSQL)
+	}
+}
+
+func Test_extractTopLevelCheckDefs(t *testing.T) {
+	tableDef := &plan.TableDef{
+		TableType: catalog.SystemOrdinaryRel,
+		Createsql: "CREATE TABLE t1 (id int, note varchar(20) comment 'constraint check', CONSTRAINT chk_id CHECK(id > 0), CHECK(score>0), CONSTRAINT fk1 FOREIGN KEY (id) REFERENCES t2(id)) ENGINE=InnoDB",
+	}
+
+	checks := extractTopLevelCheckDefs(tableDef)
+	if len(checks) != 2 {
+		t.Fatalf("expected 2 top-level check defs, got %d: %#v", len(checks), checks)
+	}
+	if checks[0] != "CONSTRAINT chk_id CHECK(id > 0)" {
+		t.Fatalf("unexpected first check def: %s", checks[0])
+	}
+	if checks[1] != "CHECK(score>0)" {
+		t.Fatalf("unexpected second check def: %s", checks[1])
 	}
 }
 

--- a/pkg/sql/plan/build_show_util_test.go
+++ b/pkg/sql/plan/build_show_util_test.go
@@ -145,6 +145,32 @@ func Test_buildTestShowCreateTable(t *testing.T) {
 	}
 }
 
+func Test_ShowCreateTableUsesStoredDDLForChecks(t *testing.T) {
+	const sql = `CREATE TABLE t_numeric_types (
+		id BIGINT NOT NULL AUTO_INCREMENT,
+		c_age INT NULL,
+		c_score DECIMAL(5,2) NULL,
+		PRIMARY KEY (id),
+		CONSTRAINT chk_age CHECK (c_age IS NULL OR (c_age >= 0 AND c_age <= 200)),
+		CONSTRAINT chk_score CHECK (c_score IS NULL OR (c_score >= 0 AND c_score <= 100))
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`
+
+	mock := NewMockOptimizer(false)
+	tableDef, err := buildTestCreateTableStmt(mock, sql)
+	if err != nil {
+		t.Fatalf("build create table failed: %+v", err)
+	}
+	tableDef.Createsql = sql
+
+	showSQL, _, err := ConstructCreateTableSQL(&mock.ctxt, tableDef, nil, false, nil)
+	if err != nil {
+		t.Fatalf("construct show create failed: %+v", err)
+	}
+	if showSQL != sql {
+		t.Fatalf("expected stored create sql to be reused\nexpected: %s\nactual: %s", sql, showSQL)
+	}
+}
+
 func Test_SingleShowCreateTable(t *testing.T) {
 	tests := []struct {
 		name string

--- a/test/distributed/cases/dml/show/show_create_table.result
+++ b/test/distributed/cases/dml/show/show_create_table.result
@@ -214,5 +214,5 @@ extable1    CREATE EXTERNAL TABLE `extable1` (\n  `n1` int DEFAULT NULL\n) INFIL
 CREATE TABLE t_check (id BIGINT NOT NULL AUTO_INCREMENT, c_age INT NULL, c_score DECIMAL(5,2) NULL, PRIMARY KEY (id), CONSTRAINT chk_age CHECK (c_age IS NULL OR (c_age >= 0 AND c_age <= 200)), CONSTRAINT chk_score CHECK (c_score IS NULL OR (c_score >= 0 AND c_score <= 100))) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 show create table t_check;
 Table    Create Table
-t_check    CREATE TABLE t_check (id BIGINT NOT NULL AUTO_INCREMENT, c_age INT NULL, c_score DECIMAL(5,2) NULL, PRIMARY KEY (id), CONSTRAINT chk_age CHECK (c_age IS NULL OR (c_age >= 0 AND c_age <= 200)), CONSTRAINT chk_score CHECK (c_score IS NULL OR (c_score >= 0 AND c_score <= 100))) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+t_check    CREATE TABLE `t_check` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `c_age` int DEFAULT NULL,\n  `c_score` decimal(5,2) DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  CONSTRAINT chk_age CHECK (c_age IS NULL OR (c_age >= 0 AND c_age <= 200)),\n  CONSTRAINT chk_score CHECK (c_score IS NULL OR (c_score >= 0 AND c_score <= 100))\n)
 drop database if exists db1;

--- a/test/distributed/cases/dml/show/show_create_table.result
+++ b/test/distributed/cases/dml/show/show_create_table.result
@@ -211,4 +211,8 @@ n1    INT(32)    YES        null
 show create table extable1;
 Table    Create Table
 extable1    CREATE EXTERNAL TABLE `extable1` (\n  `n1` int DEFAULT NULL\n) INFILE{'FILEPATH'='','COMPRESSION'='','FORMAT'='csv','JSONDATA'=''}
+CREATE TABLE t_check (id BIGINT NOT NULL AUTO_INCREMENT, c_age INT NULL, c_score DECIMAL(5,2) NULL, PRIMARY KEY (id), CONSTRAINT chk_age CHECK (c_age IS NULL OR (c_age >= 0 AND c_age <= 200)), CONSTRAINT chk_score CHECK (c_score IS NULL OR (c_score >= 0 AND c_score <= 100))) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+show create table t_check;
+Table    Create Table
+t_check    CREATE TABLE t_check (id BIGINT NOT NULL AUTO_INCREMENT, c_age INT NULL, c_score DECIMAL(5,2) NULL, PRIMARY KEY (id), CONSTRAINT chk_age CHECK (c_age IS NULL OR (c_age >= 0 AND c_age <= 200)), CONSTRAINT chk_score CHECK (c_score IS NULL OR (c_score >= 0 AND c_score <= 100))) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 drop database if exists db1;

--- a/test/distributed/cases/dml/show/show_create_table.sql
+++ b/test/distributed/cases/dml/show/show_create_table.sql
@@ -132,4 +132,8 @@ create external table extable1(n1 int)infile{"filepath"='$resources/external_tab
 desc extable1;
 show create table extable1;
 -----------------------------------------------------------------------------------------------------
+CREATE TABLE t_check (id BIGINT NOT NULL AUTO_INCREMENT, c_age INT NULL, c_score DECIMAL(5,2) NULL, PRIMARY KEY (id), CONSTRAINT chk_age CHECK (c_age IS NULL OR (c_age >= 0 AND c_age <= 200)), CONSTRAINT chk_score CHECK (c_score IS NULL OR (c_score >= 0 AND c_score <= 100))) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+show create table t_check;
+-----------------------------------------------------------------------------------------------------
 drop database if exists db1;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24130

## What this PR does / why we need it:

Fix `SHOW CREATE TABLE` dropping named `CHECK` constraints from the output.

`CHECK` constraints are preserved in `mo_catalog.mo_tables.rel_createsql`, but the resolved runtime table metadata does not reconstruct them back into `tableDef.Checks`. The existing `SHOW CREATE TABLE` path rebuilds DDL from `tableDef`, so named `CHECK` constraints disappear even though they were part of the original create statement.

This PR keeps the fix scoped to the issue itself by reusing the stored `rel_createsql` for `SHOW CREATE TABLE` when the table definition contains `CHECK` constraints. It also adds a planner unit test and a distributed regression case to verify the output keeps the `CHECK` clauses.

## Validation

- `sshpass -p '111111' ssh -o StrictHostKeyChecking=no mo@10.222.1.55 'cd /home/mo/code/moukeyu/matrixone && CGO_CFLAGS="-I/home/mo/code/moukeyu/matrixone/thirdparties/install/include" CGO_LDFLAGS="-L/home/mo/code/moukeyu/matrixone/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib -fopenmp" go test ./pkg/sql/plan -run "Test_buildTestShowCreateTable|Test_SingleShowCreateTable|Test_ShowCreateTableUsesStoredDDLForChecks"'`
- `cd /Users/moukeyu/mo-tester && ./run.sh -p /Users/moukeyu/matrixone/test/distributed/cases/dml/show/show_create_table.sql -g`
- `report/report.txt`: `[SUMMARY] COST : 4s, TOTAL :64, SUCCESS : 64, FAILED :0, IGNORED :0, ABNORAML :0, SUCCESS RATE : 100%`