### PR TITLE
frontend: rename GPU offload to sidecar, add GPU execution wrapping

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -367,11 +367,12 @@ type FrontendParameters struct {
 	// including mysql protocol handshake, checking user, loading session variables
 	ConnectTimeout toml.Duration `toml:"connectTimeout" user_setting:"advanced"`
 
-	// GPU sidecar URL for offloading queries to DuckDB via /*+ GPU */ hint.
-	// When set, this becomes the default for the gpu_sidecar_url session variable.
-	// Can be overridden per-session with SET gpu_sidecar_url = '...' or
-	// globally for new sessions with SET GLOBAL gpu_sidecar_url = '...'.
-	GPUSidecarURL string `toml:"gpuSidecarUrl" user_setting:"advanced"`
+	// SidecarURL is the DuckDB sidecar HTTP endpoint for offloading queries
+	// via /*+ SIDECAR */ or /*+ SIDECAR GPU */ hints.
+	// When set, this becomes the default for the sidecar_url session variable.
+	// Can be overridden per-session with SET sidecar_url = '...' or
+	// globally for new sessions with SET GLOBAL sidecar_url = '...'.
+	SidecarURL string `toml:"sidecarUrl" user_setting:"advanced"`
 }
 
 func (fp *FrontendParameters) SetDefaultValues() {

--- a/pkg/frontend/gpu_offload.go
+++ b/pkg/frontend/gpu_offload.go
@@ -35,11 +35,14 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
 
-const gpuHintPrefix = "/*+ GPU */"
+const (
+	sidecarHintPrefix    = "/*+ SIDECAR */"
+	sidecarGPUHintPrefix = "/*+ SIDECAR GPU */"
+)
 
-// errGPUNotConfigured is a sentinel indicating GPU offload should fall back
-// to normal MO execution (sidecar URL not set).
-var errGPUNotConfigured = moerr.NewInternalErrorNoCtx("gpu offload not configured")
+// errSidecarNotConfigured is a sentinel indicating sidecar offload should
+// fall back to normal MO execution (sidecar URL not set).
+var errSidecarNotConfigured = moerr.NewInternalErrorNoCtx("sidecar offload not configured")
 
 // Precompiled regexes for fixMOSyntaxForDuckDB (avoid recompiling per query).
 var (
@@ -77,18 +80,30 @@ func getManifestBaseURL() string {
 	return "http://" + host
 }
 
-// isGPUOffloadQuery checks whether the SQL string starts with the /*+ GPU */ hint.
-func isGPUOffloadQuery(sql string) bool {
-	trimmed := strings.TrimSpace(sql)
-	return strings.HasPrefix(strings.ToUpper(trimmed), gpuHintPrefix)
-}
-
-// stripGPUHint removes the /*+ GPU */ hint prefix from the SQL string.
-func stripGPUHint(sql string) string {
+// isSidecarQuery checks whether the SQL string starts with a /*+ SIDECAR */
+// or /*+ SIDECAR GPU */ hint. Returns (isSidecar, useGPU).
+func isSidecarQuery(sql string) (bool, bool) {
 	trimmed := strings.TrimSpace(sql)
 	upper := strings.ToUpper(trimmed)
-	if strings.HasPrefix(upper, gpuHintPrefix) {
-		return strings.TrimSpace(trimmed[len(gpuHintPrefix):])
+	if strings.HasPrefix(upper, sidecarGPUHintPrefix) {
+		return true, true
+	}
+	if strings.HasPrefix(upper, sidecarHintPrefix) {
+		return true, false
+	}
+	return false, false
+}
+
+// stripSidecarHint removes the /*+ SIDECAR GPU */ or /*+ SIDECAR */ hint
+// prefix from the SQL string. The longer GPU variant is checked first.
+func stripSidecarHint(sql string) string {
+	trimmed := strings.TrimSpace(sql)
+	upper := strings.ToUpper(trimmed)
+	if strings.HasPrefix(upper, sidecarGPUHintPrefix) {
+		return strings.TrimSpace(trimmed[len(sidecarGPUHintPrefix):])
+	}
+	if strings.HasPrefix(upper, sidecarHintPrefix) {
+		return strings.TrimSpace(trimmed[len(sidecarHintPrefix):])
 	}
 	return sql
 }
@@ -114,32 +129,33 @@ type gpuStatistics struct {
 	ByteRead int     `json:"bytes_read"`
 }
 
-// handleGPUOffload intercepts a /*+ GPU */ query:
+// handleSidecarOffload intercepts a /*+ SIDECAR */ or /*+ SIDECAR GPU */ query:
 //  1. Strips the hint.
 //  2. Generates manifests for referenced tables via the debug HTTP endpoint.
 //  3. Rewrites FROM clauses to use tae_scan(manifest_url).
-//  4. Sends the rewritten SQL to the DuckDB sidecar.
-//  5. Translates the response into a MySQL result set.
-func handleGPUOffload(ses *Session, execCtx *ExecCtx, sql string) error {
+//  4. Optionally wraps in gpu_execution('...') for Sirius GPU mode.
+//  5. Sends the rewritten SQL to the DuckDB sidecar.
+//  6. Translates the response into a MySQL result set.
+func handleSidecarOffload(ses *Session, execCtx *ExecCtx, sql string, useGPU bool) error {
 	ctx := execCtx.reqCtx
-	stripped := stripGPUHint(sql)
+	stripped := stripSidecarHint(sql)
 
-	sidecarURLVal, err := ses.GetSessionSysVar("gpu_sidecar_url")
+	sidecarURLVal, err := ses.GetSessionSysVar("sidecar_url")
 	var sidecarURL string
 	if err == nil && sidecarURLVal != nil {
 		sidecarURL = sidecarURLVal.(string)
 	}
 	if sidecarURL == "" {
-		// Fall back to TOML config value (frontend.gpuSidecarUrl).
-		sidecarURL = getPu(ses.GetService()).SV.GPUSidecarURL
+		// Fall back to TOML config value (frontend.sidecarUrl).
+		sidecarURL = getPu(ses.GetService()).SV.SidecarURL
 	}
 	if sidecarURL == "" {
-		return errGPUNotConfigured
+		return errSidecarNotConfigured
 	}
 
 	manifestURL := getManifestBaseURL()
 	if manifestURL == "" {
-		return errGPUNotConfigured
+		return errSidecarNotConfigured
 	}
 
 	t0 := time.Now()
@@ -149,7 +165,11 @@ func handleGPUOffload(ses *Session, execCtx *ExecCtx, sql string) error {
 	}
 	t1 := time.Now()
 
-	logutil.Debugf("GPU offload: rewritten SQL: %s", rewritten)
+	if useGPU {
+		rewritten = wrapForGPUExecution(rewritten)
+	}
+
+	logutil.Debugf("Sidecar offload: rewritten SQL (gpu=%v): %s", useGPU, rewritten)
 
 	result, err := sendToSidecar(ctx, sidecarURL, rewritten)
 	if err != nil {
@@ -167,8 +187,8 @@ func handleGPUOffload(ses *Session, execCtx *ExecCtx, sql string) error {
 	err = trySaveQueryResult(ctx, ses, mrs)
 	t4 := time.Now()
 
-	logutil.Infof("GPU offload timing: rewrite=%v sidecar=%v buildResult=%v saveResult=%v total=%v rows=%d",
-		t1.Sub(t0), t2.Sub(t1), t3.Sub(t2), t4.Sub(t3), t4.Sub(t0), result.Rows)
+	logutil.Infof("Sidecar offload timing: gpu=%v rewrite=%v sidecar=%v buildResult=%v saveResult=%v total=%v rows=%d",
+		useGPU, t1.Sub(t0), t2.Sub(t1), t3.Sub(t2), t4.Sub(t3), t4.Sub(t0), result.Rows)
 
 	return err
 }
@@ -183,6 +203,15 @@ type taeScanRef struct {
 func (t *taeScanRef) Format(ctx *tree.FmtCtx) {
 	escaped := strings.ReplaceAll(t.url, "'", "''")
 	ctx.WriteString(fmt.Sprintf("tae_scan('%s')", escaped))
+}
+
+// wrapForGPUExecution wraps a SQL string in a gpu_execution('...') table
+// function call so the DuckDB sidecar routes execution through the Sirius
+// GPU engine. Single quotes in the inner SQL are doubled per SQL standard
+// string literal escaping — DuckDB unescapes them when parsing the argument.
+func wrapForGPUExecution(sql string) string {
+	escaped := strings.ReplaceAll(sql, "'", "''")
+	return fmt.Sprintf("SELECT * FROM gpu_execution('%s')", escaped)
 }
 
 // rewriteTablesForGPU parses the SQL into an AST, walks the tree to find

--- a/pkg/frontend/gpu_offload_test.go
+++ b/pkg/frontend/gpu_offload_test.go
@@ -32,19 +32,58 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
 
-func TestIsGPUOffloadQuery(t *testing.T) {
-	assert.True(t, isGPUOffloadQuery("/*+ GPU */ SELECT * FROM t"))
-	assert.True(t, isGPUOffloadQuery("  /*+ GPU */ SELECT * FROM t"))
-	assert.True(t, isGPUOffloadQuery("/*+ gpu */ SELECT * FROM t"))
-	assert.False(t, isGPUOffloadQuery("SELECT * FROM t"))
-	assert.False(t, isGPUOffloadQuery("/*+ HASH_JOIN */ SELECT * FROM t"))
-	assert.False(t, isGPUOffloadQuery(""))
+func TestIsSidecarQuery(t *testing.T) {
+	// /*+ SIDECAR */ — CPU mode
+	isSidecar, useGPU := isSidecarQuery("/*+ SIDECAR */ SELECT * FROM t")
+	assert.True(t, isSidecar)
+	assert.False(t, useGPU)
+
+	isSidecar, useGPU = isSidecarQuery("  /*+ SIDECAR */ SELECT * FROM t")
+	assert.True(t, isSidecar)
+	assert.False(t, useGPU)
+
+	isSidecar, useGPU = isSidecarQuery("/*+ sidecar */ SELECT * FROM t")
+	assert.True(t, isSidecar)
+	assert.False(t, useGPU)
+
+	// /*+ SIDECAR GPU */ — GPU mode
+	isSidecar, useGPU = isSidecarQuery("/*+ SIDECAR GPU */ SELECT * FROM t")
+	assert.True(t, isSidecar)
+	assert.True(t, useGPU)
+
+	isSidecar, useGPU = isSidecarQuery("  /*+ sidecar gpu */ SELECT * FROM t")
+	assert.True(t, isSidecar)
+	assert.True(t, useGPU)
+
+	// Non-sidecar queries
+	isSidecar, _ = isSidecarQuery("SELECT * FROM t")
+	assert.False(t, isSidecar)
+
+	isSidecar, _ = isSidecarQuery("/*+ HASH_JOIN */ SELECT * FROM t")
+	assert.False(t, isSidecar)
+
+	isSidecar, _ = isSidecarQuery("")
+	assert.False(t, isSidecar)
 }
 
-func TestStripGPUHint(t *testing.T) {
-	assert.Equal(t, "SELECT * FROM t", stripGPUHint("/*+ GPU */ SELECT * FROM t"))
-	assert.Equal(t, "SELECT * FROM t", stripGPUHint("  /*+ GPU */ SELECT * FROM t"))
-	assert.Equal(t, "SELECT * FROM t", stripGPUHint("SELECT * FROM t"))
+func TestStripSidecarHint(t *testing.T) {
+	assert.Equal(t, "SELECT * FROM t", stripSidecarHint("/*+ SIDECAR */ SELECT * FROM t"))
+	assert.Equal(t, "SELECT * FROM t", stripSidecarHint("  /*+ SIDECAR */ SELECT * FROM t"))
+	assert.Equal(t, "SELECT * FROM t", stripSidecarHint("/*+ SIDECAR GPU */ SELECT * FROM t"))
+	assert.Equal(t, "SELECT * FROM t", stripSidecarHint("  /*+ sidecar gpu */ SELECT * FROM t"))
+	assert.Equal(t, "SELECT * FROM t", stripSidecarHint("SELECT * FROM t"))
+}
+
+func TestWrapForGPUExecution(t *testing.T) {
+	// Simple query
+	assert.Equal(t,
+		"SELECT * FROM gpu_execution('SELECT 1')",
+		wrapForGPUExecution("SELECT 1"))
+
+	// Query with single quotes — they should be doubled
+	assert.Equal(t,
+		"SELECT * FROM gpu_execution('SELECT * FROM tae_scan(''http://localhost:8888/debug/tae/manifest?table=db.t'')')",
+		wrapForGPUExecution("SELECT * FROM tae_scan('http://localhost:8888/debug/tae/manifest?table=db.t')"))
 }
 
 func TestGetManifestBaseURL(t *testing.T) {
@@ -592,9 +631,9 @@ func TestSendToSidecar_InvalidJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to parse sidecar response")
 }
 
-func TestExecRequest_GPUOffloadNotConfigured(t *testing.T) {
-	// When gpu_sidecar_url is not set and debugHTTPAddr is empty,
-	// handleGPUOffload returns errGPUNotConfigured → ExecRequest strips
+func TestExecRequest_SidecarNotConfigured(t *testing.T) {
+	// When sidecar_url is not set and debugHTTPAddr is empty,
+	// handleSidecarOffload returns errSidecarNotConfigured → ExecRequest strips
 	// the hint and falls through to normal COM_QUERY processing.
 	saved := debugHTTPAddr
 	defer func() { debugHTTPAddr = saved }()
@@ -608,14 +647,18 @@ func TestExecRequest_GPUOffloadNotConfigured(t *testing.T) {
 
 	execCtx := &ExecCtx{reqCtx: context.Background(), ses: ses}
 
-	// handleGPUOffload should return errGPUNotConfigured
-	err := handleGPUOffload(ses, execCtx, "/*+ GPU */ SELECT 1")
-	assert.Equal(t, errGPUNotConfigured, err)
+	// handleSidecarOffload should return errSidecarNotConfigured (CPU mode)
+	err := handleSidecarOffload(ses, execCtx, "/*+ SIDECAR */ SELECT 1", false)
+	assert.Equal(t, errSidecarNotConfigured, err)
+
+	// Same for GPU mode
+	err = handleSidecarOffload(ses, execCtx, "/*+ SIDECAR GPU */ SELECT 1", true)
+	assert.Equal(t, errSidecarNotConfigured, err)
 }
 
-func TestExecRequest_GPUOffloadSidecarError(t *testing.T) {
-	// When sidecar URL is set but returns an error, handleGPUOffload
-	// returns a real error (not errGPUNotConfigured).
+func TestExecRequest_SidecarError(t *testing.T) {
+	// When sidecar URL is set but returns an error, handleSidecarOffload
+	// returns a real error (not errSidecarNotConfigured).
 	saved := debugHTTPAddr
 	defer func() { debugHTTPAddr = saved }()
 	debugHTTPAddr = ":8888"
@@ -633,19 +676,19 @@ func TestExecRequest_GPUOffloadSidecarError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := ses.SetSessionSysVar(context.Background(), "gpu_sidecar_url", srv.URL)
+	err := ses.SetSessionSysVar(context.Background(), "sidecar_url", srv.URL)
 	require.NoError(t, err)
 
 	ses.SetDatabaseName("testdb")
 	execCtx := &ExecCtx{reqCtx: context.Background(), ses: ses}
 
-	err = handleGPUOffload(ses, execCtx, "/*+ GPU */ SELECT 1 AS x FROM testdb.t1")
+	err = handleSidecarOffload(ses, execCtx, "/*+ SIDECAR */ SELECT 1 AS x FROM testdb.t1", false)
 	assert.Error(t, err)
-	assert.NotEqual(t, errGPUNotConfigured, err)
+	assert.NotEqual(t, errSidecarNotConfigured, err)
 	assert.Contains(t, err.Error(), "sidecar error (500)")
 }
 
-func TestExecRequest_GPUOffloadSuccess(t *testing.T) {
+func TestExecRequest_SidecarSuccess(t *testing.T) {
 	// Full end-to-end: sidecar URL set + mock sidecar → result set built.
 	saved := debugHTTPAddr
 	defer func() { debugHTTPAddr = saved }()
@@ -664,13 +707,14 @@ func TestExecRequest_GPUOffloadSuccess(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := ses.SetSessionSysVar(context.Background(), "gpu_sidecar_url", srv.URL)
+	err := ses.SetSessionSysVar(context.Background(), "sidecar_url", srv.URL)
 	require.NoError(t, err)
 
 	ses.SetDatabaseName("testdb")
 	execCtx := &ExecCtx{reqCtx: context.Background(), ses: ses}
 
-	err = handleGPUOffload(ses, execCtx, "/*+ GPU */ SELECT 42 AS x FROM testdb.t1")
+	// CPU mode
+	err = handleSidecarOffload(ses, execCtx, "/*+ SIDECAR */ SELECT 42 AS x FROM testdb.t1", false)
 	assert.NoError(t, err)
 
 	// Verify result set was built correctly

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -3462,22 +3462,23 @@ func ExecRequest(ses *Session, execCtx *ExecCtx, req *Request) (resp *Response, 
 		return resp, moerr.GetMysqlClientQuit()
 	case COM_QUERY:
 		var query = commonutil.UnsafeBytesToString(req.GetData().([]byte))
-		// GPU offload: intercept /*+ GPU */ hint before normal processing.
-		// If sidecar is not configured, silently fall through to normal MO execution.
-		if isGPUOffloadQuery(query) {
+		// Sidecar offload: intercept /*+ SIDECAR */ or /*+ SIDECAR GPU */ hint
+		// before normal processing. If sidecar is not configured, silently
+		// fall through to normal MO execution.
+		if isSidecar, useGPU := isSidecarQuery(query); isSidecar {
 			ses.addSqlCount(1)
-			err = handleGPUOffload(ses, execCtx, query)
+			err = handleSidecarOffload(ses, execCtx, query, useGPU)
 			if err == nil {
 				mer := NewMysqlExecutionResult(0, 0, 0, 0, ses.GetMysqlResultSet())
 				resp = ses.SetNewResponse(ResultResponse, 0, int(COM_QUERY), mer, true)
 				return resp, nil
 			}
-			if err != errGPUNotConfigured {
+			if err != errSidecarNotConfigured {
 				resp = NewGeneralErrorResponse(COM_QUERY, ses.GetTxnHandler().GetServerStatus(), err)
 				return resp, nil
 			}
-			// errGPUNotConfigured: strip hint and fall through to normal execution
-			query = stripGPUHint(query)
+			// errSidecarNotConfigured: strip hint and fall through to normal execution
+			query = stripSidecarHint(query)
 		} else {
 			ses.addSqlCount(1)
 		}

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -1809,7 +1809,7 @@ func Benchmark_RecordStatement_IsTrue(b *testing.B) {
 	})
 }
 
-func Test_ExecRequest_GPUOffloadSuccess(t *testing.T) {
+func Test_ExecRequest_SidecarSuccess(t *testing.T) {
 	ctx := context.TODO()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1827,14 +1827,14 @@ func Test_ExecRequest_GPUOffloadSuccess(t *testing.T) {
 
 	ses := newTestSession(t, ctrl)
 	ses.txnHandler = &TxnHandler{}
-	err := ses.SetSessionSysVar(ctx, "gpu_sidecar_url", srv.URL)
+	err := ses.SetSessionSysVar(ctx, "sidecar_url", srv.URL)
 	require.NoError(t, err)
 	ses.SetDatabaseName("testdb")
 
 	ec := newTestExecCtx(ctx, ctrl)
 	req := &Request{
 		cmd:  COM_QUERY,
-		data: []byte("/*+ GPU */ SELECT 42 AS x FROM testdb.t1"),
+		data: []byte("/*+ SIDECAR */ SELECT 42 AS x FROM testdb.t1"),
 	}
 
 	resp, err := ExecRequest(ses, ec, req)
@@ -1843,7 +1843,7 @@ func Test_ExecRequest_GPUOffloadSuccess(t *testing.T) {
 	assert.Equal(t, ResultResponse, resp.category)
 }
 
-func Test_ExecRequest_GPUOffloadSidecarError(t *testing.T) {
+func Test_ExecRequest_SidecarError(t *testing.T) {
 	ctx := context.TODO()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1861,14 +1861,14 @@ func Test_ExecRequest_GPUOffloadSidecarError(t *testing.T) {
 
 	ses := newTestSession(t, ctrl)
 	ses.txnHandler = &TxnHandler{}
-	err := ses.SetSessionSysVar(ctx, "gpu_sidecar_url", srv.URL)
+	err := ses.SetSessionSysVar(ctx, "sidecar_url", srv.URL)
 	require.NoError(t, err)
 	ses.SetDatabaseName("testdb")
 
 	ec := newTestExecCtx(ctx, ctrl)
 	req := &Request{
 		cmd:  COM_QUERY,
-		data: []byte("/*+ GPU */ SELECT 1 FROM testdb.t1"),
+		data: []byte("/*+ SIDECAR */ SELECT 1 FROM testdb.t1"),
 	}
 
 	resp, err := ExecRequest(ses, ec, req)
@@ -1878,8 +1878,8 @@ func Test_ExecRequest_GPUOffloadSidecarError(t *testing.T) {
 	assert.Equal(t, ErrorResponse, resp.category)
 }
 
-func Test_ExecRequest_GPUOffloadFallthrough(t *testing.T) {
-	// GPU hint present but sidecar not configured → strips hint, falls through.
+func Test_ExecRequest_SidecarFallthrough(t *testing.T) {
+	// SIDECAR hint present but sidecar not configured → strips hint, falls through.
 	// doComQuery will fail (no engine), but we verify the fallthrough happened.
 	ctx := context.TODO()
 	ctrl := gomock.NewController(t)
@@ -1887,7 +1887,7 @@ func Test_ExecRequest_GPUOffloadFallthrough(t *testing.T) {
 
 	saved := debugHTTPAddr
 	defer func() { debugHTTPAddr = saved }()
-	debugHTTPAddr = "" // no manifest URL → errGPUNotConfigured
+	debugHTTPAddr = "" // no manifest URL → errSidecarNotConfigured
 
 	ses := newTestSession(t, ctrl)
 	ses.txnHandler = &TxnHandler{}
@@ -1895,7 +1895,7 @@ func Test_ExecRequest_GPUOffloadFallthrough(t *testing.T) {
 	ec := newTestExecCtx(ctx, ctrl)
 	req := &Request{
 		cmd:  COM_QUERY,
-		data: []byte("/*+ GPU */ SELECT 1"),
+		data: []byte("/*+ SIDECAR */ SELECT 1"),
 	}
 
 	// ExecRequest won't return an error even though doComQuery panics/fails;

--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -3895,12 +3895,12 @@ var gSysVarsDefs = map[string]SystemVariable{
 		Type:              InitSystemVariableIntType("max_dop", 0, math.MaxInt32, false),
 		Default:           int64(0),
 	},
-	"gpu_sidecar_url": {
-		Name:              "gpu_sidecar_url",
+	"sidecar_url": {
+		Name:              "sidecar_url",
 		Scope:             ScopeBoth,
 		Dynamic:           true,
 		SetVarHintApplies: false,
-		Type:              InitSystemVariableStringType("gpu_sidecar_url"),
+		Type:              InitSystemVariableStringType("sidecar_url"),
 		Default:           "",
 	},
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24067

## What this PR does / why we need it:
Rename /*+ GPU */ hint to /*+ SIDECAR */ (CPU) and /*+ SIDECAR GPU */ (GPU). When GPU mode is active, wrap rewritten SQL in gpu_execution() for Sirius.

- isSidecarQuery returns (isSidecar, useGPU) tuple
- stripSidecarHint handles both hint variants
- handleSidecarOffload takes useGPU bool parameter
- wrapForGPUExecution wraps SQL with proper quote doubling
- Rename gpu_sidecar_url session var to sidecar_url
- Rename GPUSidecarURL config to SidecarURL
- Update all tests for new API