### PR TITLE
fix: break disttae lock inversion causing IVF hang

### DIFF
--- a/pkg/vm/engine/disttae/stats.go
+++ b/pkg/vm/engine/disttae/stats.go
@@ -344,18 +344,18 @@ func (gs *GlobalStats) PrefetchTableMeta(ctx context.Context, key pb.StatsInfoKe
 }
 
 func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) *pb.StatsInfo {
-	gs.mu.Lock()
-	defer gs.mu.Unlock()
-
 	wrapkey := pb.StatsInfoKeyWithContext{
 		Ctx: ctx,
 		Key: key,
 	}
 
+	gs.mu.Lock()
 	info, ok := gs.mu.statsInfoMap[key]
 	if ok && info != nil {
+		gs.mu.Unlock()
 		return info
 	}
+	gs.mu.Unlock()
 
 	// after checking first potential patched cache
 	// we check the approx to avoid taking a place in statInfo map
@@ -371,6 +371,7 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 		return nil
 	}
 
+	var remoteInfo *pb.StatsInfo
 	if _, ok = ctx.Value(perfcounter.CalcTableStatsKey{}).(bool); ok {
 		stats := statistic.StatsInfoFromContext(ctx)
 		start := time.Now()
@@ -389,13 +390,24 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 				logutil.Errorf("failed to send request to %s, err: %v, resp: %v", "", err, resp)
 			} else if resp.GetStatsInfoResponse != nil {
 				defer client.Release(resp)
-
-				info := resp.GetStatsInfoResponse.StatsInfo
-				// If we get stats info from remote node, update local stats info.
-				gs.mu.statsInfoMap[key] = info
-				return info
+				remoteInfo = resp.GetStatsInfoResponse.StatsInfo
 			}
 		}
+	}
+
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+
+	// Recheck local cache after lock reacquired, another goroutine may have updated it.
+	info, ok = gs.mu.statsInfoMap[key]
+	if ok && info != nil {
+		return info
+	}
+
+	if remoteInfo != nil {
+		// If we get stats info from remote node, update local stats info.
+		gs.mu.statsInfoMap[key] = remoteInfo
+		return remoteInfo
 	}
 
 	ok = false

--- a/pkg/vm/engine/disttae/stats.go
+++ b/pkg/vm/engine/disttae/stats.go
@@ -260,6 +260,9 @@ type GlobalStats struct {
 
 	// beforeCacheRemoteInfo is for test only.
 	beforeCacheRemoteInfo func(pb.StatsInfoKey)
+
+	// beforeSubscribeTable is for test only.
+	beforeSubscribeTable func(pb.StatsInfoKey)
 }
 
 func NewGlobalStats(
@@ -386,6 +389,9 @@ func (gs *GlobalStats) cacheRemoteInfoIfSubscribed(
 	}
 
 	gs.mu.statsInfoMap[key] = remoteInfo
+	if gs.mu.cond != nil {
+		gs.mu.cond.Broadcast()
+	}
 	return remoteInfo
 }
 
@@ -405,6 +411,9 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 
 	// after checking first potential patched cache
 	// we check the approx to avoid taking a place in statInfo map
+	if gs.beforeSubscribeTable != nil {
+		gs.beforeSubscribeTable(key)
+	}
 	ps, err := gs.engine.pClient.toSubscribeTable(
 		ctx,
 		uint64(key.AccId),

--- a/pkg/vm/engine/disttae/stats.go
+++ b/pkg/vm/engine/disttae/stats.go
@@ -257,6 +257,9 @@ type GlobalStats struct {
 
 	// approxObjectNumUpdater is for test only currently.
 	approxObjectNumUpdater func() int64
+
+	// beforeCacheRemoteInfo is for test only.
+	beforeCacheRemoteInfo func(pb.StatsInfoKey)
 }
 
 func NewGlobalStats(
@@ -343,6 +346,49 @@ func (gs *GlobalStats) PrefetchTableMeta(ctx context.Context, key pb.StatsInfoKe
 	return gs.enqueueStatsUpdate(wrapkey, false)
 }
 
+func (gs *GlobalStats) subscribedEntry(key pb.StatsInfoKey) *subEntry {
+	gs.engine.pClient.subscribed.rw.RLock()
+	defer gs.engine.pClient.subscribed.rw.RUnlock()
+
+	ent, ok := gs.engine.pClient.subscribed.m[key.TableID]
+	if !ok || ent == nil {
+		return nil
+	}
+	if ent.dbID != key.DatabaseID || ent.state != Subscribed {
+		return nil
+	}
+	return ent
+}
+
+func (gs *GlobalStats) cacheRemoteInfoIfSubscribed(
+	key pb.StatsInfoKey,
+	subscribedEnt *subEntry,
+	remoteInfo *pb.StatsInfo,
+) *pb.StatsInfo {
+	if subscribedEnt == nil || remoteInfo == nil {
+		return nil
+	}
+
+	gs.engine.pClient.subscribed.rw.RLock()
+	defer gs.engine.pClient.subscribed.rw.RUnlock()
+
+	currentEnt, ok := gs.engine.pClient.subscribed.m[key.TableID]
+	if !ok || currentEnt != subscribedEnt || currentEnt.dbID != key.DatabaseID || currentEnt.state != Subscribed {
+		return nil
+	}
+
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+
+	info, ok := gs.mu.statsInfoMap[key]
+	if ok && info != nil {
+		return info
+	}
+
+	gs.mu.statsInfoMap[key] = remoteInfo
+	return remoteInfo
+}
+
 func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) *pb.StatsInfo {
 	wrapkey := pb.StatsInfoKeyWithContext{
 		Ctx: ctx,
@@ -371,6 +417,7 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 		return nil
 	}
 
+	subscribedEnt := gs.subscribedEntry(key)
 	var remoteInfo *pb.StatsInfo
 	if _, ok = ctx.Value(perfcounter.CalcTableStatsKey{}).(bool); ok {
 		stats := statistic.StatsInfoFromContext(ctx)
@@ -395,6 +442,15 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 		}
 	}
 
+	if remoteInfo != nil {
+		if gs.beforeCacheRemoteInfo != nil {
+			gs.beforeCacheRemoteInfo(key)
+		}
+		if info = gs.cacheRemoteInfoIfSubscribed(key, subscribedEnt, remoteInfo); info != nil {
+			return info
+		}
+	}
+
 	gs.mu.Lock()
 	defer gs.mu.Unlock()
 
@@ -402,12 +458,6 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 	info, ok = gs.mu.statsInfoMap[key]
 	if ok && info != nil {
 		return info
-	}
-
-	if remoteInfo != nil {
-		// If we get stats info from remote node, update local stats info.
-		gs.mu.statsInfoMap[key] = remoteInfo
-		return remoteInfo
 	}
 
 	ok = false

--- a/pkg/vm/engine/disttae/stats_test.go
+++ b/pkg/vm/engine/disttae/stats_test.go
@@ -1841,6 +1841,16 @@ func TestGlobalStatsGetDoesNotHoldMuWhileSubscribing(t *testing.T) {
 			DbName:     "d",
 		}
 
+		reachSubscribe := make(chan struct{})
+		oldSubscribeHook := gs.beforeSubscribeTable
+		var subscribeOnce sync.Once
+		gs.beforeSubscribeTable = func(statsinfo.StatsInfoKey) {
+			subscribeOnce.Do(func() { close(reachSubscribe) })
+		}
+		defer func() {
+			gs.beforeSubscribeTable = oldSubscribeHook
+		}()
+
 		getCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 
@@ -1850,8 +1860,14 @@ func TestGlobalStatsGetDoesNotHoldMuWhileSubscribing(t *testing.T) {
 			_ = gs.Get(getCtx, key, false)
 		}()
 
-		// Give Get enough time to reach toSubscribeTable and block on subscribed.rw.
-		time.Sleep(20 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			select {
+			case <-reachSubscribe:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, 10*time.Millisecond, "GlobalStats.Get did not reach subscribe path")
 
 		muAcquired := make(chan struct{})
 		go func() {
@@ -1860,12 +1876,19 @@ func TestGlobalStatsGetDoesNotHoldMuWhileSubscribing(t *testing.T) {
 			close(muAcquired)
 		}()
 
-		select {
-		case <-muAcquired:
-			// expected: Get should not hold gs.mu while waiting subscribe lock.
-		case <-time.After(200 * time.Millisecond):
-			t.Fatal("GlobalStats.Get holds gs.mu while waiting on subscribe lock")
-		}
+		require.Eventually(t, func() bool {
+			select {
+			case <-getDone:
+				return false
+			default:
+			}
+			select {
+			case <-muAcquired:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, 10*time.Millisecond, "GlobalStats.Get holds gs.mu while waiting on subscribe lock")
 
 		locked = false
 		e.pClient.subscribed.rw.Unlock()
@@ -1875,6 +1898,75 @@ func TestGlobalStatsGetDoesNotHoldMuWhileSubscribing(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("GlobalStats.Get did not return after subscribe lock released")
 		}
+	})
+}
+
+func TestCacheRemoteInfoIfSubscribedBroadcastsWaiters(t *testing.T) {
+	runTest(t, func(ctx context.Context, e *Engine) {
+		gs := e.globalStats
+		const dbID uint64 = 100
+		const tblID uint64 = 10001
+
+		e.pClient.eng = e
+		e.pClient.subscribed.eng = e
+
+		ent := &subEntry{dbID: dbID, state: Subscribed}
+		ent.lastTs.Store(time.Now().UnixNano())
+
+		if e.pClient.subscribed.m == nil {
+			e.pClient.subscribed.m = make(map[uint64]*subEntry)
+		}
+		e.pClient.subscribed.m[tblID] = ent
+
+		key := statsinfo.StatsInfoKey{
+			AccId:      0,
+			DatabaseID: dbID,
+			TableID:    tblID,
+			TableName:  "t",
+			DbName:     "d",
+		}
+
+		remoteInfo := plan2.NewStatsInfo()
+		remoteInfo.TableCnt = 42
+
+		waitEntered := make(chan struct{})
+		waitDone := make(chan struct{})
+		var waitOnce sync.Once
+
+		go func() {
+			gs.mu.Lock()
+			defer gs.mu.Unlock()
+			for {
+				if _, ok := gs.mu.statsInfoMap[key]; ok {
+					break
+				}
+				waitOnce.Do(func() { close(waitEntered) })
+				gs.mu.cond.Wait()
+			}
+			close(waitDone)
+		}()
+
+		require.Eventually(t, func() bool {
+			select {
+			case <-waitEntered:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, 10*time.Millisecond, "waiter did not enter cond.Wait")
+
+		info := gs.cacheRemoteInfoIfSubscribed(key, ent, remoteInfo)
+		require.NotNil(t, info)
+		require.Equal(t, remoteInfo, info)
+
+		require.Eventually(t, func() bool {
+			select {
+			case <-waitDone:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, 10*time.Millisecond, "waiter was not awakened by remote cache broadcast")
 	})
 }
 

--- a/pkg/vm/engine/disttae/stats_test.go
+++ b/pkg/vm/engine/disttae/stats_test.go
@@ -1772,3 +1772,73 @@ func TestRemoveTid(t *testing.T) {
 		})
 	})
 }
+
+func TestGlobalStatsGetDoesNotHoldMuWhileSubscribing(t *testing.T) {
+	runTest(t, func(ctx context.Context, e *Engine) {
+		gs := e.globalStats
+		const dbID uint64 = 100
+		const tblID uint64 = 10001
+
+		e.pClient.eng = e
+		e.pClient.subscribed.eng = e
+
+		ent := &subEntry{dbID: dbID, state: Subscribed}
+		ent.lastTs.Store(time.Now().UnixNano())
+
+		locked := true
+		e.pClient.subscribed.rw.Lock()
+		defer func() {
+			if locked {
+				e.pClient.subscribed.rw.Unlock()
+			}
+		}()
+
+		if e.pClient.subscribed.m == nil {
+			e.pClient.subscribed.m = make(map[uint64]*subEntry)
+		}
+		e.pClient.subscribed.m[tblID] = ent
+
+		key := statsinfo.StatsInfoKey{
+			AccId:      0,
+			DatabaseID: dbID,
+			TableID:    tblID,
+			TableName:  "t",
+			DbName:     "d",
+		}
+
+		getCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		getDone := make(chan struct{})
+		go func() {
+			defer close(getDone)
+			_ = gs.Get(getCtx, key, false)
+		}()
+
+		// Give Get enough time to reach toSubscribeTable and block on subscribed.rw.
+		time.Sleep(20 * time.Millisecond)
+
+		muAcquired := make(chan struct{})
+		go func() {
+			gs.mu.Lock()
+			gs.mu.Unlock()
+			close(muAcquired)
+		}()
+
+		select {
+		case <-muAcquired:
+			// expected: Get should not hold gs.mu while waiting subscribe lock.
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("GlobalStats.Get holds gs.mu while waiting on subscribe lock")
+		}
+
+		locked = false
+		e.pClient.subscribed.rw.Unlock()
+
+		select {
+		case <-getDone:
+		case <-time.After(time.Second):
+			t.Fatal("GlobalStats.Get did not return after subscribe lock released")
+		}
+	})
+}

--- a/pkg/vm/engine/disttae/stats_test.go
+++ b/pkg/vm/engine/disttae/stats_test.go
@@ -35,11 +35,46 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/lockservice"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/pb/gossip"
+	querypb "github.com/matrixorigin/matrixone/pkg/pb/query"
 	"github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/cache"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae/logtailreplay"
 )
+
+type mockStatsKeyRouter struct {
+	target string
+}
+
+func (r *mockStatsKeyRouter) Target(statsinfo.StatsInfoKey) string { return r.target }
+func (r *mockStatsKeyRouter) AddItem(gossip.CommonItem)            {}
+
+type mockStatsQueryClient struct {
+	response    *querypb.Response
+	sendStarted chan struct{}
+	allowReturn chan struct{}
+}
+
+func (m *mockStatsQueryClient) ServiceID() string {
+	return "mock-stats-query-client"
+}
+
+func (m *mockStatsQueryClient) SendMessage(context.Context, string, *querypb.Request) (*querypb.Response, error) {
+	close(m.sendStarted)
+	<-m.allowReturn
+	return m.response, nil
+}
+
+func (m *mockStatsQueryClient) NewRequest(method querypb.CmdMethod) *querypb.Request {
+	return &querypb.Request{CmdMethod: method}
+}
+
+func (m *mockStatsQueryClient) Release(*querypb.Response) {}
+
+func (m *mockStatsQueryClient) Close() error {
+	return nil
+}
 
 func runTest(
 	t *testing.T,
@@ -1840,5 +1875,110 @@ func TestGlobalStatsGetDoesNotHoldMuWhileSubscribing(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("GlobalStats.Get did not return after subscribe lock released")
 		}
+	})
+}
+
+func TestGlobalStatsGetDoesNotCacheRemoteInfoAfterUnsubscribe(t *testing.T) {
+	runTest(t, func(ctx context.Context, e *Engine) {
+		gs := e.globalStats
+		const dbID uint64 = 100
+		const tblID uint64 = 10001
+
+		e.pClient.eng = e
+		e.pClient.subscribed.eng = e
+
+		ent := &subEntry{dbID: dbID, state: Subscribed}
+		ent.lastTs.Store(time.Now().UnixNano())
+
+		if e.pClient.subscribed.m == nil {
+			e.pClient.subscribed.m = make(map[uint64]*subEntry)
+		}
+		e.pClient.subscribed.m[tblID] = ent
+
+		key := statsinfo.StatsInfoKey{
+			AccId:      0,
+			DatabaseID: dbID,
+			TableID:    tblID,
+			TableName:  "t",
+			DbName:     "d",
+		}
+
+		part := e.GetOrCreateLatestPart(ctx, 0, dbID, tblID)
+		state, done := part.MutateState()
+		oid := types.NewObjectid()
+		stats := objectio.NewObjectStatsWithObjectID(&oid, false, false, false)
+		require.NoError(t, objectio.SetObjectStatsBlkCnt(stats, 1))
+		require.NoError(t, objectio.SetObjectStatsRowCnt(stats, 1))
+		require.NoError(t, objectio.SetObjectStatsSize(stats, 1))
+		require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+			ObjectStats: *stats,
+			CreateTime:  types.BuildTS(time.Now().UnixNano(), 0),
+		}, false))
+		done()
+
+		remoteInfo := plan2.NewStatsInfo()
+		remoteInfo.TableCnt = 42
+
+		qc := &mockStatsQueryClient{
+			response: &querypb.Response{
+				GetStatsInfoResponse: &querypb.GetStatsInfoResponse{StatsInfo: remoteInfo},
+			},
+			sendStarted: make(chan struct{}),
+			allowReturn: make(chan struct{}),
+		}
+		oldQC := e.qc
+		oldRouter := gs.KeyRouter
+		oldHook := gs.beforeCacheRemoteInfo
+		e.qc = qc
+		gs.KeyRouter = &mockStatsKeyRouter{target: "cn1"}
+		defer func() {
+			e.qc = oldQC
+			gs.KeyRouter = oldRouter
+			gs.beforeCacheRemoteInfo = oldHook
+		}()
+
+		beforeCacheReached := make(chan struct{})
+		allowCache := make(chan struct{})
+		gs.beforeCacheRemoteInfo = func(statsinfo.StatsInfoKey) {
+			close(beforeCacheReached)
+			<-allowCache
+		}
+
+		getCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		resultCh := make(chan *statsinfo.StatsInfo, 1)
+		go func() {
+			resultCh <- gs.Get(getCtx, key, false)
+		}()
+
+		select {
+		case <-qc.sendStarted:
+		case <-time.After(time.Second):
+			t.Fatal("GlobalStats.Get did not request remote stats")
+		}
+
+		close(qc.allowReturn)
+
+		select {
+		case <-beforeCacheReached:
+		case <-time.After(time.Second):
+			t.Fatal("GlobalStats.Get did not reach remote cache write point")
+		}
+
+		e.pClient.subscribed.setTableUnsubscribe(dbID, tblID)
+		close(allowCache)
+
+		select {
+		case info := <-resultCh:
+			require.Nil(t, info)
+		case <-time.After(time.Second):
+			t.Fatal("GlobalStats.Get did not return after unsubscribe")
+		}
+
+		gs.mu.Lock()
+		_, ok := gs.mu.statsInfoMap[key]
+		gs.mu.Unlock()
+		assert.False(t, ok)
 	})
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24094

## What this PR does / why we need it:

This PR fixes a lock-order inversion in disttae that can cause ANN/IVF workload hang-like behavior under concurrency.

Root cause from goroutine dumps:
- setTableUnsubscribe path holds subscribed.rw and waits for GlobalStats.mu.
- GlobalStats.Get held GlobalStats.mu and called toSubscribeTable -> isSubscribed, waiting for subscribed.rw.
- This creates circular wait and fan-out blocking.

Changes:
- Refactor GlobalStats.Get to avoid holding GlobalStats.mu while calling toSubscribeTable and remote stats fetch.
- Reacquire lock and recheck local cache before writing remote stats.
- Add regression test TestGlobalStatsGetDoesNotHoldMuWhileSubscribing to ensure Get does not hold GlobalStats.mu while waiting on subscribe lock.

Verification:
- go test ./pkg/vm/engine/disttae -run 'Test(GlobalStatsGetDoesNotHoldMuWhileSubscribing|RemoveTid|CleanMemoryTableWithTable)$' -count=1
