### PR TITLE
to 3.0: fix: avoid duplicate rows in data branch diff replay

### DIFF
--- a/pkg/vm/engine/disttae/logtailreplay/change_handle.go
+++ b/pkg/vm/engine/disttae/logtailreplay/change_handle.go
@@ -1143,7 +1143,11 @@ func (p *baseHandle) resolveVisibleObjectsByDeleteChain(
 			continue
 		}
 		visited[name] = struct{}{}
-		if !current.GetAppendable() && !current.DeleteTime.IsEmpty() && current.DeleteTime.LE(&end) {
+		// For snapshot-state range replay, we only need terminal objects that are
+		// still visible at range end. If an object has already been deleted at or
+		// before end, keep following its delete-time chain instead of reading this
+		// transient intermediate object.
+		if !current.DeleteTime.IsEmpty() && current.DeleteTime.LE(&end) {
 			next, successorTS, exact := lookupDeleteChainSuccessor(current.DeleteTime, tnByCreateTS, tnCreateTSKeys)
 			if len(next) == 0 {
 				logutil.Warn(

--- a/pkg/vm/engine/disttae/logtailreplay/change_handle_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/change_handle_test.go
@@ -612,6 +612,41 @@ func TestBaseHandleResolveVisibleObjectsByDeleteChain(t *testing.T) {
 	require.Equal(t, []*objectio.ObjectEntry{successor, orphan}, resolved)
 }
 
+func TestBaseHandleResolveVisibleObjectsByDeleteChain_AppendableDeletedBeforeEnd(t *testing.T) {
+	ctx := context.Background()
+	fs, err := fileservice.NewMemoryFS("mem", fileservice.DisabledCacheConfig, nil)
+	require.NoError(t, err)
+
+	deleted := makeNamedObjectEntry(t, 1, true, false, types.BuildTS(5, 0), types.BuildTS(10, 0))
+	successor := makeNamedObjectEntry(t, 2, false, false, types.BuildTS(10, 0), types.TS{})
+
+	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
+		FilePath: successor.ObjectName().String(),
+		Entries: []fileservice.IOEntry{
+			{Data: []byte("ok"), Size: 2},
+		},
+	}))
+
+	base := &baseHandle{
+		changesHandle: &ChangeHandler{fs: fs},
+	}
+
+	resolved, err := base.resolveVisibleObjectsByDeleteChain(
+		ctx,
+		types.BuildTS(1, 0),
+		types.BuildTS(30, 0),
+		[]*objectio.ObjectEntry{deleted},
+		map[types.TS][]*objectio.ObjectEntry{
+			successor.CreateTime: {successor},
+		},
+		[]types.TS{successor.CreateTime},
+		false,
+		"data",
+	)
+	require.NoError(t, err)
+	require.Equal(t, []*objectio.ObjectEntry{successor}, resolved)
+}
+
 func TestNewChangesHandlerWithPartitionStateRange_EmptyState(t *testing.T) {
 	mp := mpool.MustNewZero()
 	defer mpool.DeleteMPool(mp)

--- a/pkg/vm/engine/disttae/logtailreplay/change_handle_test.go
+++ b/pkg/vm/engine/disttae/logtailreplay/change_handle_test.go
@@ -620,12 +620,14 @@ func TestBaseHandleResolveVisibleObjectsByDeleteChain_AppendableDeletedBeforeEnd
 	deleted := makeNamedObjectEntry(t, 1, true, false, types.BuildTS(5, 0), types.BuildTS(10, 0))
 	successor := makeNamedObjectEntry(t, 2, false, false, types.BuildTS(10, 0), types.TS{})
 
-	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
-		FilePath: successor.ObjectName().String(),
-		Entries: []fileservice.IOEntry{
-			{Data: []byte("ok"), Size: 2},
-		},
-	}))
+	for _, obj := range []*objectio.ObjectEntry{deleted, successor} {
+		require.NoError(t, fs.Write(ctx, fileservice.IOVector{
+			FilePath: obj.ObjectName().String(),
+			Entries: []fileservice.IOEntry{
+				{Data: []byte("ok"), Size: 2},
+			},
+		}))
+	}
 
 	base := &baseHandle{
 		changesHandle: &ChangeHandler{fs: fs},


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23751

## What this PR does / why we need it:

This is the 3.0-dev port of the main-branch fix for duplicated DATA BRANCH DIFF replay rows.

Range replay could keep both an appendable predecessor and its TN successor when the predecessor had already been deleted at or before the replay end timestamp. After GC and restart, CollectChanges then replayed the same logical row from both objects, which surfaced as duplicated INSERT output such as a repeated 5,5 row.

This change makes delete-chain resolution treat any object deleted at or before the range end as a transient intermediate, regardless of appendable state, and follow its successor so the final replay set contains only the terminal object visible at the end timestamp.

A 3.0-dev regression test is added for the appendable-predecessor case to lock the behavior down.