### PR TITLE
proxy: avoid cleanup storms on normal disconnect

### DIFF
--- a/pkg/proxy/client_conn.go
+++ b/pkg/proxy/client_conn.go
@@ -323,6 +323,9 @@ func (c *clientConn) HandleEvent(ctx context.Context, e IEvent, resp chan<- []by
 	case *setVarEvent:
 		return c.handleSetVar(ev)
 	case *quitEvent:
+		if c.tun != nil {
+			c.tun.markExpectedCacheQuit()
+		}
 		// Notify/finish the event immediately.
 		ev.notify()
 		// Then handle the quit event async.

--- a/pkg/proxy/client_conn_test.go
+++ b/pkg/proxy/client_conn_test.go
@@ -208,7 +208,8 @@ func (r *killTestRouter) Connect(c *CNServer, handshakeResp *frontend.Packet, t 
 }
 
 type killCurrentServerConn struct {
-	cn *CNServer
+	cn      *CNServer
+	closeFn func() error
 }
 
 func (s *killCurrentServerConn) ConnID() uint32 { return s.cn.connID }
@@ -226,7 +227,12 @@ func (s *killCurrentServerConn) SetConnResponse(_ []byte) {}
 func (s *killCurrentServerConn) GetConnResponse() []byte  { return nil }
 func (s *killCurrentServerConn) CreateTime() time.Time    { return time.Now() }
 func (s *killCurrentServerConn) Quit() error              { return nil }
-func (s *killCurrentServerConn) Close() error             { return nil }
+func (s *killCurrentServerConn) Close() error {
+	if s.closeFn != nil {
+		return s.closeFn()
+	}
+	return nil
+}
 
 type killExecServerConn struct {
 	stmt internalStmt

--- a/pkg/proxy/client_conn_test.go
+++ b/pkg/proxy/client_conn_test.go
@@ -187,6 +187,21 @@ func (c *mockClientConn) KillCurrentBackendConn(sc ServerConn) error {
 }
 func (c *mockClientConn) Close() error { return nil }
 
+type mockConnCache struct {
+	pushFn func(cacheKey, ServerConn) bool
+}
+
+func (m *mockConnCache) Push(key cacheKey, sc ServerConn) bool {
+	if m.pushFn != nil {
+		return m.pushFn(key, sc)
+	}
+	return true
+}
+
+func (m *mockConnCache) Pop(cacheKey, uint32, []byte, []byte) ServerConn { return nil }
+func (m *mockConnCache) Count() int                                      { return 0 }
+func (m *mockConnCache) Close() error                                    { return nil }
+
 type killTestRouter struct {
 	connectFn func(*CNServer, *frontend.Packet, *tunnel) (ServerConn, []byte, error)
 }
@@ -315,6 +330,31 @@ func TestClientConn_KillCurrentBackendConn(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cmdQuery, execSC.stmt.cmdType)
 	require.Equal(t, "kill connection 42", execSC.stmt.s)
+}
+
+func TestClientConn_HandleQuitEventMarksExpectedCacheQuit(t *testing.T) {
+	tun := &tunnel{}
+	tun.mu.scp = &pipe{}
+	tun.mu.scp.mu.cond = sync.NewCond(&tun.mu.scp.mu)
+
+	c := &clientConn{
+		tun: tun,
+		sc:  &killCurrentServerConn{cn: &CNServer{connID: 11, uuid: "cn1"}},
+		connCache: &mockConnCache{
+			pushFn: func(key cacheKey, sc ServerConn) bool {
+				return true
+			},
+		},
+	}
+
+	e := makeQuitEvent().(*quitEvent)
+	errC := make(chan error, 1)
+	go func() {
+		errC <- c.HandleEvent(context.Background(), e, nil)
+	}()
+	e.wait()
+	require.NoError(t, <-errC)
+	require.True(t, tun.hasExpectedCacheQuit())
 }
 
 func copyCNServer(dst, src *CNServer) {

--- a/pkg/proxy/error.go
+++ b/pkg/proxy/error.go
@@ -60,6 +60,10 @@ func (e *errWithCode) Error() string {
 	return fmt.Sprintf("%s: %v", e.code, e.cause)
 }
 
+func (e *errWithCode) Unwrap() error {
+	return e.cause
+}
+
 func withCode(err error, code errorCode) error {
 	if err == nil {
 		return nil

--- a/pkg/proxy/error_test.go
+++ b/pkg/proxy/error_test.go
@@ -15,6 +15,8 @@
 package proxy
 
 import (
+	"errors"
+	"net"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -51,4 +53,10 @@ func TestRetryableError(t *testing.T) {
 
 	e = newConnectErr(moerr.NewInternalErrorNoCtx("e"))
 	require.Equal(t, e.Error(), "internal error: e")
+}
+
+func TestErrWithCodeUnwrap(t *testing.T) {
+	err := withCode(net.ErrClosed, codeClientDisconnect)
+	require.True(t, errors.Is(err, net.ErrClosed))
+	require.True(t, isConnEndErr(err))
 }

--- a/pkg/proxy/error_test.go
+++ b/pkg/proxy/error_test.go
@@ -17,6 +17,7 @@ package proxy
 import (
 	"errors"
 	"net"
+	"syscall"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -58,5 +59,9 @@ func TestRetryableError(t *testing.T) {
 func TestErrWithCodeUnwrap(t *testing.T) {
 	err := withCode(net.ErrClosed, codeClientDisconnect)
 	require.True(t, errors.Is(err, net.ErrClosed))
+	require.True(t, isConnEndErr(err))
+
+	err = withCode(syscall.ECONNRESET, codeClientDisconnect)
+	require.True(t, errors.Is(err, syscall.ECONNRESET))
 	require.True(t, isConnEndErr(err))
 }

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -301,6 +301,9 @@ func (h *handler) cleanupBackendOnClientDisconnect(err error, cc ClientConn, t *
 	// For normal EOF / closed-connection exits, close the current backend
 	// session directly instead of creating an extra proxy->CN KILL connection.
 	if isEOFErr(err) || isConnEndErr(err) {
+		if t != nil && t.hasExpectedCacheQuit() {
+			return
+		}
 		if currentSC != nil {
 			if err := currentSC.Close(); err != nil {
 				h.logger.Warn("failed to close backend connection after client disconnect",

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -291,7 +291,10 @@ func (h *handler) handleTunnelErr(err error, cc ClientConn, t *tunnel, sessionID
 }
 
 func (h *handler) cleanupBackendOnClientDisconnect(err error, cc ClientConn, t *tunnel) {
-	if cc == nil || getErrorCode(err) != codeClientDisconnect {
+	// Normal EOF / closed-conn client exits already tear down the backend session
+	// through the tunnel close path. Only issue an explicit KILL for wrapped client
+	// disconnects that would otherwise leave a blocked backend session behind.
+	if cc == nil || getErrorCode(err) != codeClientDisconnect || isEOFErr(err) || isConnEndErr(err) {
 		return
 	}
 	var currentSC ServerConn

--- a/pkg/proxy/handler.go
+++ b/pkg/proxy/handler.go
@@ -291,15 +291,25 @@ func (h *handler) handleTunnelErr(err error, cc ClientConn, t *tunnel, sessionID
 }
 
 func (h *handler) cleanupBackendOnClientDisconnect(err error, cc ClientConn, t *tunnel) {
-	// Normal EOF / closed-conn client exits already tear down the backend session
-	// through the tunnel close path. Only issue an explicit KILL for wrapped client
-	// disconnects that would otherwise leave a blocked backend session behind.
-	if cc == nil || getErrorCode(err) != codeClientDisconnect || isEOFErr(err) || isConnEndErr(err) {
+	if cc == nil || getErrorCode(err) != codeClientDisconnect {
 		return
 	}
 	var currentSC ServerConn
 	if t != nil {
 		currentSC = t.getServerConn()
+	}
+	// For normal EOF / closed-connection exits, close the current backend
+	// session directly instead of creating an extra proxy->CN KILL connection.
+	if isEOFErr(err) || isConnEndErr(err) {
+		if currentSC != nil {
+			if err := currentSC.Close(); err != nil {
+				h.logger.Warn("failed to close backend connection after client disconnect",
+					zap.Uint32("Conn ID", cc.ConnID()),
+					zap.Error(err),
+				)
+			}
+		}
+		return
 	}
 	if err := cc.KillCurrentBackendConn(currentSC); err != nil {
 		h.logger.Warn("failed to kill backend connection after client disconnect",

--- a/pkg/proxy/handler_test.go
+++ b/pkg/proxy/handler_test.go
@@ -26,7 +26,9 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"net"
 	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -412,6 +414,89 @@ func TestHandler_handleTunnelErrClosesBackendForEOFClientDisconnect(t *testing.T
 	require.NoError(t, ret)
 	require.Equal(t, 0, killCalled)
 	require.Equal(t, 1, closeCalled)
+	require.Equal(t, int64(0), h.counterSet.clientDisconnect.Load())
+}
+
+func TestHandler_handleTunnelErrClosesBackendForWrappedConnEndClientDisconnect(t *testing.T) {
+	rt := runtime.DefaultRuntime()
+	runtime.SetupServiceBasedRuntime("", rt)
+	h := &handler{
+		logger:     rt.Logger(),
+		counterSet: newCounterSet(),
+	}
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "net.ErrClosed",
+			err:  withCode(net.ErrClosed, codeClientDisconnect),
+		},
+		{
+			name: "syscall.ECONNRESET",
+			err:  withCode(syscall.ECONNRESET, codeClientDisconnect),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			killCalled := 0
+			closeCalled := 0
+			tun := &tunnel{}
+			tun.mu.sc = &killCurrentServerConn{
+				cn: &CNServer{connID: 11, uuid: "cn-new"},
+				closeFn: func() error {
+					closeCalled++
+					return nil
+				},
+			}
+			cc := &mockClientConn{
+				killFn: func(sc ServerConn) error {
+					killCalled++
+					return nil
+				},
+			}
+
+			ret := h.handleTunnelErr(tc.err, cc, tun, 733923, 100)
+			require.NoError(t, ret)
+			require.Equal(t, 0, killCalled)
+			require.Equal(t, 1, closeCalled)
+			require.Equal(t, int64(0), h.counterSet.clientDisconnect.Load())
+		})
+	}
+}
+
+func TestHandler_handleTunnelErrSkipsBackendCleanupForExpectedCacheQuit(t *testing.T) {
+	rt := runtime.DefaultRuntime()
+	runtime.SetupServiceBasedRuntime("", rt)
+	h := &handler{
+		logger:     rt.Logger(),
+		counterSet: newCounterSet(),
+	}
+
+	killCalled := 0
+	closeCalled := 0
+	tun := &tunnel{}
+	tun.markExpectedCacheQuit()
+	tun.mu.sc = &killCurrentServerConn{
+		cn: &CNServer{connID: 11, uuid: "cn-new"},
+		closeFn: func() error {
+			closeCalled++
+			return nil
+		},
+	}
+	cc := &mockClientConn{
+		killFn: func(sc ServerConn) error {
+			killCalled++
+			return nil
+		},
+	}
+
+	ret := h.handleTunnelErr(withCode(io.EOF, codeClientDisconnect), cc, tun, 733923, 100)
+	require.NoError(t, ret)
+	require.Equal(t, 0, killCalled)
+	require.Equal(t, 0, closeCalled)
 	require.Equal(t, int64(0), h.counterSet.clientDisconnect.Load())
 }
 

--- a/pkg/proxy/handler_test.go
+++ b/pkg/proxy/handler_test.go
@@ -336,10 +336,13 @@ func TestHandler_cleanupBackendOnClientDisconnect(t *testing.T) {
 	}
 
 	h.cleanupBackendOnClientDisconnect(withCode(io.EOF, codeClientDisconnect), cc, tun)
-	require.Equal(t, 1, called)
+	require.Equal(t, 0, called)
 
 	h.cleanupBackendOnClientDisconnect(withCode(io.EOF, codeServerDisconnect), cc, tun)
 	h.cleanupBackendOnClientDisconnect(io.EOF, cc, tun)
+	require.Equal(t, 0, called)
+
+	h.cleanupBackendOnClientDisconnect(withCode(moerr.NewInternalErrorNoCtx("send message error: connection reset by peer"), codeClientDisconnect), cc, tun)
 	require.Equal(t, 1, called)
 }
 
@@ -368,6 +371,30 @@ func TestHandler_handleTunnelErrCleansUpWrappedClientDisconnect(t *testing.T) {
 	require.Same(t, err, ret)
 	require.Equal(t, 1, called)
 	require.Equal(t, int64(1), h.counterSet.clientDisconnect.Load())
+}
+
+func TestHandler_handleTunnelErrSkipsCleanupForEOFClientDisconnect(t *testing.T) {
+	rt := runtime.DefaultRuntime()
+	runtime.SetupServiceBasedRuntime("", rt)
+	h := &handler{
+		logger:     rt.Logger(),
+		counterSet: newCounterSet(),
+	}
+
+	called := 0
+	tun := &tunnel{}
+	tun.mu.sc = &killCurrentServerConn{cn: &CNServer{connID: 11, uuid: "cn-new"}}
+	cc := &mockClientConn{
+		killFn: func(sc ServerConn) error {
+			called++
+			return nil
+		},
+	}
+
+	ret := h.handleTunnelErr(withCode(io.EOF, codeClientDisconnect), cc, tun, 733923, 100)
+	require.NoError(t, ret)
+	require.Equal(t, 0, called)
+	require.Equal(t, int64(0), h.counterSet.clientDisconnect.Load())
 }
 
 func TestHandler_HandleWithSSL(t *testing.T) {

--- a/pkg/proxy/handler_test.go
+++ b/pkg/proxy/handler_test.go
@@ -323,27 +323,37 @@ func TestHandler_cleanupBackendOnClientDisconnect(t *testing.T) {
 	runtime.SetupServiceBasedRuntime("", rt)
 	h := &handler{logger: rt.Logger()}
 
-	called := 0
-	expectedSC := &killCurrentServerConn{cn: &CNServer{connID: 11, uuid: "cn-new"}}
+	killCalled := 0
+	closeCalled := 0
+	expectedSC := &killCurrentServerConn{
+		cn: &CNServer{connID: 11, uuid: "cn-new"},
+		closeFn: func() error {
+			closeCalled++
+			return nil
+		},
+	}
 	tun := &tunnel{}
 	tun.mu.sc = expectedSC
 	cc := &mockClientConn{
 		killFn: func(sc ServerConn) error {
 			require.Same(t, expectedSC, sc)
-			called++
+			killCalled++
 			return nil
 		},
 	}
 
 	h.cleanupBackendOnClientDisconnect(withCode(io.EOF, codeClientDisconnect), cc, tun)
-	require.Equal(t, 0, called)
+	require.Equal(t, 0, killCalled)
+	require.Equal(t, 1, closeCalled)
 
 	h.cleanupBackendOnClientDisconnect(withCode(io.EOF, codeServerDisconnect), cc, tun)
 	h.cleanupBackendOnClientDisconnect(io.EOF, cc, tun)
-	require.Equal(t, 0, called)
+	require.Equal(t, 0, killCalled)
+	require.Equal(t, 1, closeCalled)
 
 	h.cleanupBackendOnClientDisconnect(withCode(moerr.NewInternalErrorNoCtx("send message error: connection reset by peer"), codeClientDisconnect), cc, tun)
-	require.Equal(t, 1, called)
+	require.Equal(t, 1, killCalled)
+	require.Equal(t, 1, closeCalled)
 }
 
 func TestHandler_handleTunnelErrCleansUpWrappedClientDisconnect(t *testing.T) {
@@ -373,7 +383,7 @@ func TestHandler_handleTunnelErrCleansUpWrappedClientDisconnect(t *testing.T) {
 	require.Equal(t, int64(1), h.counterSet.clientDisconnect.Load())
 }
 
-func TestHandler_handleTunnelErrSkipsCleanupForEOFClientDisconnect(t *testing.T) {
+func TestHandler_handleTunnelErrClosesBackendForEOFClientDisconnect(t *testing.T) {
 	rt := runtime.DefaultRuntime()
 	runtime.SetupServiceBasedRuntime("", rt)
 	h := &handler{
@@ -381,19 +391,27 @@ func TestHandler_handleTunnelErrSkipsCleanupForEOFClientDisconnect(t *testing.T)
 		counterSet: newCounterSet(),
 	}
 
-	called := 0
+	killCalled := 0
+	closeCalled := 0
 	tun := &tunnel{}
-	tun.mu.sc = &killCurrentServerConn{cn: &CNServer{connID: 11, uuid: "cn-new"}}
+	tun.mu.sc = &killCurrentServerConn{
+		cn: &CNServer{connID: 11, uuid: "cn-new"},
+		closeFn: func() error {
+			closeCalled++
+			return nil
+		},
+	}
 	cc := &mockClientConn{
 		killFn: func(sc ServerConn) error {
-			called++
+			killCalled++
 			return nil
 		},
 	}
 
 	ret := h.handleTunnelErr(withCode(io.EOF, codeClientDisconnect), cc, tun, 733923, 100)
 	require.NoError(t, ret)
-	require.Equal(t, 0, called)
+	require.Equal(t, 0, killCalled)
+	require.Equal(t, 1, closeCalled)
 	require.Equal(t, int64(0), h.counterSet.clientDisconnect.Load())
 }
 

--- a/pkg/proxy/handler_test.go
+++ b/pkg/proxy/handler_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509/pkix"
 	"database/sql"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -436,6 +437,26 @@ func TestHandler_handleTunnelErrClosesBackendForWrappedConnEndClientDisconnect(t
 		{
 			name: "syscall.ECONNRESET",
 			err:  withCode(syscall.ECONNRESET, codeClientDisconnect),
+		},
+		{
+			name: "joined send net.ErrClosed",
+			err: withCode(
+				errors.Join(
+					moerr.NewInternalErrorNoCtxf("send message error: %v", net.ErrClosed),
+					net.ErrClosed,
+				),
+				codeClientDisconnect,
+			),
+		},
+		{
+			name: "joined send syscall.ECONNRESET",
+			err: withCode(
+				errors.Join(
+					moerr.NewInternalErrorNoCtxf("send message error: %v", syscall.ECONNRESET),
+					syscall.ECONNRESET,
+				),
+				codeClientDisconnect,
+			),
 		},
 	}
 

--- a/pkg/proxy/tunnel.go
+++ b/pkg/proxy/tunnel.go
@@ -262,6 +262,32 @@ func (t *tunnel) hasExpectedCacheQuit() bool {
 	return t != nil && t.expectedCacheQuit.Load()
 }
 
+func wrapPipeSendError(name string, err error) error {
+	wrapped := errors.Join(
+		moerr.NewInternalErrorNoCtxf("send message error: %v", err),
+		err,
+	)
+	if name == pipeServerToClient && isConnEndErr(err) {
+		return withCode(wrapped, codeClientDisconnect)
+	}
+	return wrapped
+}
+
+func (t *tunnel) reportPipeError(err error, defaultCode errorCode) {
+	code := getErrorCode(err)
+	if code == codeNone {
+		code = defaultCode
+		err = withCode(err, code)
+	}
+	switch code {
+	case codeClientDisconnect:
+		v2.ProxyClientDisconnectCounter.Inc()
+	case codeServerDisconnect:
+		v2.ProxyServerDisconnectCounter.Inc()
+	}
+	t.setError(err)
+}
+
 // setError tries to set the tunnel error if there is no error.
 func (t *tunnel) setError(err error) {
 	select {
@@ -276,14 +302,12 @@ func (t *tunnel) kickoff() error {
 	csp, scp := t.getPipes()
 	go func() {
 		if err := csp.kickoff(t.ctx, scp); err != nil {
-			v2.ProxyClientDisconnectCounter.Inc()
-			t.setError(withCode(err, codeClientDisconnect))
+			t.reportPipeError(err, codeClientDisconnect)
 		}
 	}()
 	go func() {
 		if err := scp.kickoff(t.ctx, csp); err != nil {
-			v2.ProxyServerDisconnectCounter.Inc()
-			t.setError(withCode(err, codeServerDisconnect))
+			t.reportPipeError(err, codeServerDisconnect)
 		}
 	}()
 	if err := csp.waitReady(t.ctx); err != nil {
@@ -742,10 +766,7 @@ func (p *pipe) kickoff(ctx context.Context, peer *pipe) (e error) {
 		p.wg.Wait()
 
 		if err = p.src.sendTo(p.dst); err != nil {
-			return errors.Join(
-				moerr.NewInternalErrorNoCtxf("send message error: %v", err),
-				err,
-			)
+			return wrapPipeSendError(p.name, err)
 		}
 	}
 	return ctx.Err()

--- a/pkg/proxy/tunnel.go
+++ b/pkg/proxy/tunnel.go
@@ -742,7 +742,10 @@ func (p *pipe) kickoff(ctx context.Context, peer *pipe) (e error) {
 		p.wg.Wait()
 
 		if err = p.src.sendTo(p.dst); err != nil {
-			return moerr.NewInternalErrorNoCtxf("send message error: %v", err)
+			return errors.Join(
+				moerr.NewInternalErrorNoCtxf("send message error: %v", err),
+				err,
+			)
 		}
 	}
 	return ctx.Err()

--- a/pkg/proxy/tunnel.go
+++ b/pkg/proxy/tunnel.go
@@ -123,6 +123,10 @@ type tunnel struct {
 	// more proactive.
 	// It only works if RebalancePolicy is "active".
 	transferIntent atomic.Bool
+	// expectedCacheQuit indicates this tunnel already intercepted a client QUIT
+	// for connection caching, so the follow-up client EOF should not tear down
+	// the backend session that is being cached.
+	expectedCacheQuit atomic.Bool
 
 	mu struct {
 		sync.Mutex
@@ -246,6 +250,16 @@ func (t *tunnel) getServerConn() ServerConn {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.mu.sc
+}
+
+func (t *tunnel) markExpectedCacheQuit() {
+	if t != nil {
+		t.expectedCacheQuit.Store(true)
+	}
+}
+
+func (t *tunnel) hasExpectedCacheQuit() bool {
+	return t != nil && t.expectedCacheQuit.Load()
 }
 
 // setError tries to set the tunnel error if there is no error.

--- a/pkg/proxy/tunnel_test.go
+++ b/pkg/proxy/tunnel_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -187,6 +188,17 @@ func TestTunnelClientToServer(t *testing.T) {
 		t.Fatalf("require no error, but got %v", err)
 	default:
 	}
+}
+
+func TestWrapPipeSendError(t *testing.T) {
+	err := wrapPipeSendError(pipeServerToClient, net.ErrClosed)
+	require.Equal(t, codeClientDisconnect, getErrorCode(err))
+	require.True(t, errors.Is(err, net.ErrClosed))
+	require.True(t, isConnEndErr(err))
+
+	err = wrapPipeSendError(pipeClientToServer, net.ErrClosed)
+	require.Equal(t, codeNone, getErrorCode(err))
+	require.True(t, errors.Is(err, net.ErrClosed))
 }
 
 func TestTunnelServerClient(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24151

## What this PR does / why we need it:

This is a 3.0-dev follow-up to #24152.

The earlier fix added explicit backend cleanup for client-disconnect paths so blocked backend sessions would not survive after the client side disappeared. That logic was correct for wrapped client-disconnect errors, but it was too broad for normal EOF / closed-connection exits.

Under phase-boundary sysbench workloads, many client connections can close at once when one test step ends and the next one starts immediately. The old cleanup path opened an extra temporary proxy-to-CN control connection for every client disconnect, even when the disconnect was a normal EOF. That amplified connection pressure and could turn a normal step transition into a handshake storm:

- proxy dial timeouts to CN (`failed to connect to cn server`)
- CN extra-info / salt read timeouts (`cannot get salt, maybe not use proxy`)
- benchmark-side `reading initial communication packet` failures

This PR narrows the cleanup behavior:
- keep explicit backend cleanup for wrapped non-EOF client disconnects
- on normal EOF / closed-connection exits, close the current backend session directly instead of opening an extra temporary control connection
- when conn-cache has already intercepted an expected client `QUIT`, skip that EOF-close path so the cached backend stays reusable
- preserve the underlying write-side disconnect cause when proxy result forwarding fails, so wrapped send errors still hit the direct-close path
- make `errWithCode` unwrap its cause so wrapped closed-connection errors are classified correctly

That preserves the original holder-cleanup fix while avoiding connection storms during high-concurrency benchmark phase transitions, without breaking normal cached QUIT reuse.

## Validation

- `go test ./pkg/proxy -run 'TestClientConn_HandleQuitEventMarksExpectedCacheQuit|TestHandler_handleTunnelErrSkipsBackendCleanupForExpectedCacheQuit|TestErrWithCodeUnwrap|TestHandler_handleTunnelErrClosesBackendForWrappedConnEndClientDisconnect|TestHandler_handleTunnelErrClosesBackendForEOFClientDisconnect|TestHandler_handleTunnelErrCleansUpWrappedClientDisconnect|TestHandler_cleanupBackendOnClientDisconnect|TestClientConn_KillCurrentBackendConn' -count=1`
- `go test ./pkg/proxy -count=1`
