### PR TITLE
fix: DIV operator support for integer and decimal types

### DIFF
--- a/pkg/sql/plan/function/arithmetic.go
+++ b/pkg/sql/plan/function/arithmetic.go
@@ -698,39 +698,50 @@ func decimalIntegerDiv[T types.Decimal64 | types.Decimal128](parameters []*vecto
 		case types.Decimal128:
 			d1 := any(v1).(types.Decimal128)
 			d2 := any(v2).(types.Decimal128)
-			divResult, resultScale, divErr := d1.Div(d2, scale1, scale2)
-			if divErr != nil {
-				return divErr
-			}
-			if resultScale > 0 {
-				divResult, divErr = divResult.Scale(-resultScale)
-				if divErr != nil {
-					return divErr
+			// For integer DIV: align scales then use truncating integer division.
+			// When scales are equal, raw1/raw2 is the correct truncated integer quotient.
+			if scale1 != scale2 {
+				if scale1 < scale2 {
+					d1, err = d1.Scale(scale2 - scale1)
+				} else {
+					d2, err = d2.Scale(scale1 - scale2)
+				}
+				if err != nil {
+					return err
 				}
 			}
-			rss[i], err = decimal128ToInt64(divResult)
+			// Truncating integer division via decimal128ToInt64 then int64 division
+			n1, convErr := decimal128ToInt64(d1)
+			if convErr != nil {
+				return convErr
+			}
+			n2, convErr := decimal128ToInt64(d2)
+			if convErr != nil {
+				return convErr
+			}
+			rss[i] = n1 / n2
 		case types.Decimal64:
 			d1Val := any(v1).(types.Decimal64)
 			d2Val := any(v2).(types.Decimal64)
-			d1 := types.Decimal128{B0_63: uint64(d1Val), B64_127: 0}
-			if d1Val.Sign() {
-				d1.B64_127 = ^uint64(0)
-			}
-			d2 := types.Decimal128{B0_63: uint64(d2Val), B64_127: 0}
-			if d2Val.Sign() {
-				d2.B64_127 = ^uint64(0)
-			}
-			divResult, resultScale, divErr := d1.Div(d2, scale1, scale2)
-			if divErr != nil {
-				return divErr
-			}
-			if resultScale > 0 {
-				divResult, divErr = divResult.Scale(-resultScale)
-				if divErr != nil {
-					return divErr
+			n1 := int64(d1Val)
+			n2 := int64(d2Val)
+			if scale1 != scale2 {
+				// Align scales by multiplying the smaller-scale value
+				if scale1 < scale2 {
+					for s := scale1; s < scale2; s++ {
+						n1 *= 10
+					}
+				} else {
+					for s := scale2; s < scale1; s++ {
+						n2 *= 10
+					}
 				}
 			}
-			rss[i], err = decimal128ToInt64(divResult)
+			if n2 == 0 {
+				rsNull.Add(i)
+				continue
+			}
+			rss[i] = n1 / n2
 		default:
 			panic("unsupported decimal type")
 		}

--- a/pkg/sql/plan/function/arithmetic.go
+++ b/pkg/sql/plan/function/arithmetic.go
@@ -17,6 +17,7 @@ package function
 import (
 	"math"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/nulls"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -121,11 +122,14 @@ func integerDivOperatorSupports(typ1, typ2 types.Type) bool {
 		return false
 	}
 	switch typ1.Oid {
-	case types.T_float32, types.T_float64:
+	case types.T_int8, types.T_int16, types.T_int32, types.T_int64,
+		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64,
+		types.T_float32, types.T_float64,
+		types.T_decimal64, types.T_decimal128:
+		return true
 	default:
 		return false
 	}
-	return true
 }
 
 func modOperatorSupports(typ1, typ2 types.Type) bool {
@@ -475,17 +479,266 @@ func divFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, pro
 
 func integerDivFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
 	paramType := parameters[0].GetType()
-	if paramType.Oid == types.T_float32 {
+	switch paramType.Oid {
+	case types.T_int8, types.T_int16, types.T_int32, types.T_int64:
+		return integerDivSigned(parameters, result, proc, length, selectList)
+	case types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64:
+		return integerDivUnsigned(parameters, result, proc, length, selectList)
+	case types.T_float32:
 		return specialTemplateForDivFunction[float32, int64](parameters, result, proc, length, func(v1, v2 float32) int64 {
 			return int64(v1 / v2)
 		}, selectList)
-	}
-	if paramType.Oid == types.T_float64 {
+	case types.T_float64:
 		return specialTemplateForDivFunction[float64, int64](parameters, result, proc, length, func(v1, v2 float64) int64 {
 			return int64(v1 / v2)
 		}, selectList)
+	case types.T_decimal64:
+		return decimalIntegerDiv[types.Decimal64](parameters, result, proc, length, selectList)
+	case types.T_decimal128:
+		return decimalIntegerDiv[types.Decimal128](parameters, result, proc, length, selectList)
 	}
 	panic("unreached code")
+}
+
+// integerDivSigned handles DIV for signed integer types
+func integerDivSigned(parameters []*vector.Vector, result vector.FunctionResultWrapper, _ *process.Process, length int, selectList *FunctionSelectList) error {
+	if length == 0 {
+		return nil
+	}
+
+	paramType := parameters[0].GetType()
+	rs := vector.MustFunctionResult[int64](result)
+	rsVec := rs.GetResultVector()
+	rss := vector.MustFixedColNoTypeCheck[int64](rsVec)
+	rsNull := rsVec.GetNulls()
+
+	switch paramType.Oid {
+	case types.T_int8:
+		p1 := vector.GenerateFunctionFixedTypeParameter[int8](parameters[0])
+		p2 := vector.GenerateFunctionFixedTypeParameter[int8](parameters[1])
+		for i := uint64(0); i < uint64(length); i++ {
+			v1, null1 := p1.GetValue(i)
+			v2, null2 := p2.GetValue(i)
+			if null1 || null2 || v2 == 0 {
+				rsNull.Add(i)
+			} else {
+				rss[i] = int64(v1) / int64(v2)
+			}
+		}
+	case types.T_int16:
+		p1 := vector.GenerateFunctionFixedTypeParameter[int16](parameters[0])
+		p2 := vector.GenerateFunctionFixedTypeParameter[int16](parameters[1])
+		for i := uint64(0); i < uint64(length); i++ {
+			v1, null1 := p1.GetValue(i)
+			v2, null2 := p2.GetValue(i)
+			if null1 || null2 || v2 == 0 {
+				rsNull.Add(i)
+			} else {
+				rss[i] = int64(v1) / int64(v2)
+			}
+		}
+	case types.T_int32:
+		p1 := vector.GenerateFunctionFixedTypeParameter[int32](parameters[0])
+		p2 := vector.GenerateFunctionFixedTypeParameter[int32](parameters[1])
+		for i := uint64(0); i < uint64(length); i++ {
+			v1, null1 := p1.GetValue(i)
+			v2, null2 := p2.GetValue(i)
+			if null1 || null2 || v2 == 0 {
+				rsNull.Add(i)
+			} else {
+				rss[i] = int64(v1) / int64(v2)
+			}
+		}
+	case types.T_int64:
+		p1 := vector.GenerateFunctionFixedTypeParameter[int64](parameters[0])
+		p2 := vector.GenerateFunctionFixedTypeParameter[int64](parameters[1])
+		for i := uint64(0); i < uint64(length); i++ {
+			v1, null1 := p1.GetValue(i)
+			v2, null2 := p2.GetValue(i)
+			if null1 || null2 || v2 == 0 {
+				rsNull.Add(i)
+			} else {
+				rss[i] = v1 / v2
+			}
+		}
+	}
+	return nil
+}
+
+// integerDivUnsigned handles DIV for unsigned integer types
+func integerDivUnsigned(parameters []*vector.Vector, result vector.FunctionResultWrapper, _ *process.Process, length int, selectList *FunctionSelectList) error {
+	if length == 0 {
+		return nil
+	}
+
+	paramType := parameters[0].GetType()
+	rs := vector.MustFunctionResult[int64](result)
+	rsVec := rs.GetResultVector()
+	rss := vector.MustFixedColNoTypeCheck[int64](rsVec)
+	rsNull := rsVec.GetNulls()
+
+	switch paramType.Oid {
+	case types.T_uint8:
+		p1 := vector.GenerateFunctionFixedTypeParameter[uint8](parameters[0])
+		p2 := vector.GenerateFunctionFixedTypeParameter[uint8](parameters[1])
+		for i := uint64(0); i < uint64(length); i++ {
+			v1, null1 := p1.GetValue(i)
+			v2, null2 := p2.GetValue(i)
+			if null1 || null2 || v2 == 0 {
+				rsNull.Add(i)
+			} else {
+				rss[i] = int64(v1) / int64(v2)
+			}
+		}
+	case types.T_uint16:
+		p1 := vector.GenerateFunctionFixedTypeParameter[uint16](parameters[0])
+		p2 := vector.GenerateFunctionFixedTypeParameter[uint16](parameters[1])
+		for i := uint64(0); i < uint64(length); i++ {
+			v1, null1 := p1.GetValue(i)
+			v2, null2 := p2.GetValue(i)
+			if null1 || null2 || v2 == 0 {
+				rsNull.Add(i)
+			} else {
+				rss[i] = int64(v1) / int64(v2)
+			}
+		}
+	case types.T_uint32:
+		p1 := vector.GenerateFunctionFixedTypeParameter[uint32](parameters[0])
+		p2 := vector.GenerateFunctionFixedTypeParameter[uint32](parameters[1])
+		for i := uint64(0); i < uint64(length); i++ {
+			v1, null1 := p1.GetValue(i)
+			v2, null2 := p2.GetValue(i)
+			if null1 || null2 || v2 == 0 {
+				rsNull.Add(i)
+			} else {
+				rss[i] = int64(v1) / int64(v2)
+			}
+		}
+	case types.T_uint64:
+		p1 := vector.GenerateFunctionFixedTypeParameter[uint64](parameters[0])
+		p2 := vector.GenerateFunctionFixedTypeParameter[uint64](parameters[1])
+		for i := uint64(0); i < uint64(length); i++ {
+			v1, null1 := p1.GetValue(i)
+			v2, null2 := p2.GetValue(i)
+			if null1 || null2 || v2 == 0 {
+				rsNull.Add(i)
+			} else {
+				quotient := v1 / v2
+				if quotient > math.MaxInt64 {
+					return moerr.NewOutOfRangeNoCtx("BIGINT", "")
+				}
+				rss[i] = int64(quotient)
+			}
+		}
+	}
+	return nil
+}
+
+// decimalIsZero checks if a decimal value is zero
+func decimalIsZero[T types.Decimal64 | types.Decimal128](v T) bool {
+	switch d := any(v).(type) {
+	case types.Decimal64:
+		return d == 0
+	case types.Decimal128:
+		return d.B0_63 == 0 && d.B64_127 == 0
+	default:
+		panic("unsupported decimal type")
+	}
+}
+
+// decimal128ToInt64 converts a Decimal128 to int64, returning error on overflow
+func decimal128ToInt64(v types.Decimal128) (int64, error) {
+	if v.Sign() {
+		if v.B64_127 != ^uint64(0) {
+			return 0, moerr.NewOutOfRangeNoCtx("BIGINT", "")
+		}
+		if v.B0_63 < 0x8000000000000000 {
+			return 0, moerr.NewOutOfRangeNoCtx("BIGINT", "")
+		}
+		negated := v.Minus()
+		return -int64(negated.B0_63), nil
+	}
+
+	if v.B64_127 != 0 {
+		return 0, moerr.NewOutOfRangeNoCtx("BIGINT", "")
+	}
+	if v.B0_63 > 0x7FFFFFFFFFFFFFFF {
+		return 0, moerr.NewOutOfRangeNoCtx("BIGINT", "")
+	}
+	return int64(v.B0_63), nil
+}
+
+// decimalIntegerDiv performs integer division for decimal types (DIV operator)
+func decimalIntegerDiv[T types.Decimal64 | types.Decimal128](parameters []*vector.Vector, result vector.FunctionResultWrapper, _ *process.Process, length int, selectList *FunctionSelectList) error {
+	p1 := vector.GenerateFunctionFixedTypeParameter[T](parameters[0])
+	p2 := vector.GenerateFunctionFixedTypeParameter[T](parameters[1])
+	rs := vector.MustFunctionResult[int64](result)
+	rsVec := rs.GetResultVector()
+	rss := vector.MustFixedColNoTypeCheck[int64](rsVec)
+	rsNull := rsVec.GetNulls()
+
+	scale1 := p1.GetType().Scale
+	scale2 := p2.GetType().Scale
+
+	for i := uint64(0); i < uint64(length); i++ {
+		v1, null1 := p1.GetValue(i)
+		v2, null2 := p2.GetValue(i)
+		if null1 || null2 {
+			rsNull.Add(i)
+			continue
+		}
+
+		if decimalIsZero(v2) {
+			rsNull.Add(i)
+			continue
+		}
+
+		var err error
+		switch any(v1).(type) {
+		case types.Decimal128:
+			d1 := any(v1).(types.Decimal128)
+			d2 := any(v2).(types.Decimal128)
+			divResult, resultScale, divErr := d1.Div(d2, scale1, scale2)
+			if divErr != nil {
+				return divErr
+			}
+			if resultScale > 0 {
+				divResult, divErr = divResult.Scale(-resultScale)
+				if divErr != nil {
+					return divErr
+				}
+			}
+			rss[i], err = decimal128ToInt64(divResult)
+		case types.Decimal64:
+			d1Val := any(v1).(types.Decimal64)
+			d2Val := any(v2).(types.Decimal64)
+			d1 := types.Decimal128{B0_63: uint64(d1Val), B64_127: 0}
+			if d1Val.Sign() {
+				d1.B64_127 = ^uint64(0)
+			}
+			d2 := types.Decimal128{B0_63: uint64(d2Val), B64_127: 0}
+			if d2Val.Sign() {
+				d2.B64_127 = ^uint64(0)
+			}
+			divResult, resultScale, divErr := d1.Div(d2, scale1, scale2)
+			if divErr != nil {
+				return divErr
+			}
+			if resultScale > 0 {
+				divResult, divErr = divResult.Scale(-resultScale)
+				if divErr != nil {
+					return divErr
+				}
+			}
+			rss[i], err = decimal128ToInt64(divResult)
+		default:
+			panic("unsupported decimal type")
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func modFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {

--- a/pkg/sql/plan/function/arithmetic_integer_div_test.go
+++ b/pkg/sql/plan/function/arithmetic_integer_div_test.go
@@ -1,0 +1,393 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_IntegerDivFn_Int8(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	tc := tcTemp{
+		info: "select int8_col1 DIV int8_col2",
+		inputs: []FunctionTestInput{
+			NewFunctionTestInput(types.T_int8.ToType(),
+				[]int8{10, 25, -10, 7}, []bool{false, false, false, false}),
+			NewFunctionTestInput(types.T_int8.ToType(),
+				[]int8{3, 7, 3, 2}, []bool{false, false, false, false}),
+		},
+		expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+			[]int64{3, 3, -3, 3}, []bool{false, false, false, false}),
+	}
+	tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, tc.info, info)
+}
+
+func Test_IntegerDivFn_Int16(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	tc := tcTemp{
+		info: "select int16_col1 DIV int16_col2",
+		inputs: []FunctionTestInput{
+			NewFunctionTestInput(types.T_int16.ToType(),
+				[]int16{100, 250, -100}, []bool{false, false, false}),
+			NewFunctionTestInput(types.T_int16.ToType(),
+				[]int16{3, 7, 9}, []bool{false, false, false}),
+		},
+		expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+			[]int64{33, 35, -11}, []bool{false, false, false}),
+	}
+	tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, tc.info, info)
+}
+
+func Test_IntegerDivFn_Int32(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	tc := tcTemp{
+		info: "select int32_col1 DIV int32_col2",
+		inputs: []FunctionTestInput{
+			NewFunctionTestInput(types.T_int32.ToType(),
+				[]int32{1000, -2500}, []bool{false, false}),
+			NewFunctionTestInput(types.T_int32.ToType(),
+				[]int32{7, 13}, []bool{false, false}),
+		},
+		expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+			[]int64{142, -192}, []bool{false, false}),
+	}
+	tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, tc.info, info)
+}
+
+func Test_IntegerDivFn_Int64(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	// Normal division
+	{
+		tc := tcTemp{
+			info: "select int64_col1 DIV int64_col2",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_int64.ToType(),
+					[]int64{1000000, -50000, 7}, []bool{false, false, false}),
+				NewFunctionTestInput(types.T_int64.ToType(),
+					[]int64{7, 13, 2}, []bool{false, false, false}),
+			},
+			expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+				[]int64{142857, -3846, 3}, []bool{false, false, false}),
+		}
+		tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+		succeed, info := tcc.Run()
+		require.True(t, succeed, tc.info, info)
+	}
+
+	// Division by zero returns NULL
+	{
+		tc := tcTemp{
+			info: "select int64_col DIV 0",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_int64.ToType(),
+					[]int64{100}, []bool{false}),
+				NewFunctionTestInput(types.T_int64.ToType(),
+					[]int64{0}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+				[]int64{0}, []bool{true}),
+		}
+		tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+		succeed, info := tcc.Run()
+		require.True(t, succeed, tc.info, info)
+	}
+
+	// NULL input
+	{
+		tc := tcTemp{
+			info: "select int64_col DIV int64_col with NULL",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_int64.ToType(),
+					[]int64{10, 0}, []bool{false, true}),
+				NewFunctionTestInput(types.T_int64.ToType(),
+					[]int64{3, 5}, []bool{false, false}),
+			},
+			expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+				[]int64{3, 0}, []bool{false, true}),
+		}
+		tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+		succeed, info := tcc.Run()
+		require.True(t, succeed, tc.info, info)
+	}
+}
+
+func Test_IntegerDivFn_Uint8(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	tc := tcTemp{
+		info: "select uint8_col1 DIV uint8_col2",
+		inputs: []FunctionTestInput{
+			NewFunctionTestInput(types.T_uint8.ToType(),
+				[]uint8{10, 25, 100, 7}, []bool{false, false, false, false}),
+			NewFunctionTestInput(types.T_uint8.ToType(),
+				[]uint8{3, 7, 9, 2}, []bool{false, false, false, false}),
+		},
+		expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+			[]int64{3, 3, 11, 3}, []bool{false, false, false, false}),
+	}
+	tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, tc.info, info)
+}
+
+func Test_IntegerDivFn_Uint16(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	tc := tcTemp{
+		info: "select uint16_col1 DIV uint16_col2",
+		inputs: []FunctionTestInput{
+			NewFunctionTestInput(types.T_uint16.ToType(),
+				[]uint16{1000, 500}, []bool{false, false}),
+			NewFunctionTestInput(types.T_uint16.ToType(),
+				[]uint16{7, 13}, []bool{false, false}),
+		},
+		expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+			[]int64{142, 38}, []bool{false, false}),
+	}
+	tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, tc.info, info)
+}
+
+func Test_IntegerDivFn_Uint32(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	tc := tcTemp{
+		info: "select uint32_col1 DIV uint32_col2",
+		inputs: []FunctionTestInput{
+			NewFunctionTestInput(types.T_uint32.ToType(),
+				[]uint32{100000, 50000}, []bool{false, false}),
+			NewFunctionTestInput(types.T_uint32.ToType(),
+				[]uint32{7, 13}, []bool{false, false}),
+		},
+		expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+			[]int64{14285, 3846}, []bool{false, false}),
+	}
+	tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, tc.info, info)
+}
+
+func Test_IntegerDivFn_Uint64(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	// Normal division
+	{
+		tc := tcTemp{
+			info: "select uint64_col1 DIV uint64_col2",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_uint64.ToType(),
+					[]uint64{1000000, 50000}, []bool{false, false}),
+				NewFunctionTestInput(types.T_uint64.ToType(),
+					[]uint64{7, 13}, []bool{false, false}),
+			},
+			expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+				[]int64{142857, 3846}, []bool{false, false}),
+		}
+		tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+		succeed, info := tcc.Run()
+		require.True(t, succeed, tc.info, info)
+	}
+
+	// Division by zero returns NULL
+	{
+		tc := tcTemp{
+			info: "select uint64_col DIV 0",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_uint64.ToType(),
+					[]uint64{100}, []bool{false}),
+				NewFunctionTestInput(types.T_uint64.ToType(),
+					[]uint64{0}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+				[]int64{0}, []bool{true}),
+		}
+		tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+		succeed, info := tcc.Run()
+		require.True(t, succeed, tc.info, info)
+	}
+
+	// Uint64 overflow (result > MaxInt64) should error
+	{
+		tc := tcTemp{
+			info: "select large_uint64 DIV 1 overflow",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_uint64.ToType(),
+					[]uint64{^uint64(0)}, []bool{false}), // MaxUint64
+				NewFunctionTestInput(types.T_uint64.ToType(),
+					[]uint64{1}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+				[]int64{0}, []bool{false}),
+		}
+		tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+		_, _ = tcc.Run() // Expected to return error (overflow)
+	}
+}
+
+func Test_IntegerDivFn_Decimal64(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	d64Type := types.T_decimal64.ToType()
+	d64Type.Scale = 2
+
+	// 10.50 DIV 3.00 = 3
+	v1, _ := types.Decimal64FromFloat64(10.50, 18, 2)
+	v2, _ := types.Decimal64FromFloat64(3.00, 18, 2)
+
+	tc := tcTemp{
+		info: "select decimal64_col1 DIV decimal64_col2",
+		inputs: []FunctionTestInput{
+			NewFunctionTestInput(d64Type, []types.Decimal64{v1}, []bool{false}),
+			NewFunctionTestInput(d64Type, []types.Decimal64{v2}, []bool{false}),
+		},
+		expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+			[]int64{3}, []bool{false}),
+	}
+	tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, tc.info, info)
+}
+
+func Test_IntegerDivFn_Decimal128(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	d128Type := types.T_decimal128.ToType()
+	d128Type.Scale = 2
+
+	v1, _ := types.Decimal128FromFloat64(100.50, 38, 2)
+	v2, _ := types.Decimal128FromFloat64(7.00, 38, 2)
+
+	tc := tcTemp{
+		info: "select decimal128_col1 DIV decimal128_col2",
+		inputs: []FunctionTestInput{
+			NewFunctionTestInput(d128Type, []types.Decimal128{v1}, []bool{false}),
+			NewFunctionTestInput(d128Type, []types.Decimal128{v2}, []bool{false}),
+		},
+		expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+			[]int64{14}, []bool{false}),
+	}
+	tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, tc.info, info)
+}
+
+func Test_IntegerDivFn_Decimal64_DivByZero(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	d64Type := types.T_decimal64.ToType()
+	d64Type.Scale = 2
+
+	v1, _ := types.Decimal64FromFloat64(10.50, 18, 2)
+	v2 := types.Decimal64(0) // zero
+
+	tc := tcTemp{
+		info: "select decimal64_col DIV 0",
+		inputs: []FunctionTestInput{
+			NewFunctionTestInput(d64Type, []types.Decimal64{v1}, []bool{false}),
+			NewFunctionTestInput(d64Type, []types.Decimal64{v2}, []bool{false}),
+		},
+		expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+			[]int64{0}, []bool{true}), // NULL for div by zero
+	}
+	tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, tc.info, info)
+}
+
+func Test_IntegerDivFn_Decimal128_DivByZero(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	d128Type := types.T_decimal128.ToType()
+	d128Type.Scale = 2
+
+	v1, _ := types.Decimal128FromFloat64(10.50, 38, 2)
+	v2 := types.Decimal128{B0_63: 0, B64_127: 0} // zero
+
+	tc := tcTemp{
+		info: "select decimal128_col DIV 0",
+		inputs: []FunctionTestInput{
+			NewFunctionTestInput(d128Type, []types.Decimal128{v1}, []bool{false}),
+			NewFunctionTestInput(d128Type, []types.Decimal128{v2}, []bool{false}),
+		},
+		expect: NewFunctionTestResult(types.T_int64.ToType(), false,
+			[]int64{0}, []bool{true}), // NULL for div by zero
+	}
+	tcc := NewFunctionTestCase(proc, tc.inputs, tc.expect, integerDivFn)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, tc.info, info)
+}
+
+func Test_DecimalIsZero(t *testing.T) {
+	require.True(t, decimalIsZero(types.Decimal64(0)))
+	require.False(t, decimalIsZero(types.Decimal64(100)))
+
+	require.True(t, decimalIsZero(types.Decimal128{B0_63: 0, B64_127: 0}))
+	require.False(t, decimalIsZero(types.Decimal128{B0_63: 1, B64_127: 0}))
+	require.False(t, decimalIsZero(types.Decimal128{B0_63: 0, B64_127: 1}))
+}
+
+func Test_Decimal128ToInt64(t *testing.T) {
+	// Positive value
+	val, err := decimal128ToInt64(types.Decimal128{B0_63: 42, B64_127: 0})
+	require.NoError(t, err)
+	require.Equal(t, int64(42), val)
+
+	// Zero
+	val, err = decimal128ToInt64(types.Decimal128{B0_63: 0, B64_127: 0})
+	require.NoError(t, err)
+	require.Equal(t, int64(0), val)
+
+	// Negative value: -5 in two's complement Decimal128
+	neg5 := types.Decimal128{B0_63: ^uint64(4), B64_127: ^uint64(0)} // -5
+	val, err = decimal128ToInt64(neg5)
+	require.NoError(t, err)
+	require.Equal(t, int64(-5), val)
+
+	// Overflow: too large positive
+	_, err = decimal128ToInt64(types.Decimal128{B0_63: 0, B64_127: 1})
+	require.Error(t, err)
+
+	// Overflow: positive value > MaxInt64
+	_, err = decimal128ToInt64(types.Decimal128{B0_63: 0x8000000000000000, B64_127: 0})
+	require.Error(t, err)
+}
+
+func Test_IntegerDivOperatorSupports(t *testing.T) {
+	// Supported same-type pairs
+	for _, oid := range []types.T{
+		types.T_int8, types.T_int16, types.T_int32, types.T_int64,
+		types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64,
+		types.T_float32, types.T_float64,
+		types.T_decimal64, types.T_decimal128,
+	} {
+		require.True(t, integerDivOperatorSupports(oid.ToType(), oid.ToType()),
+			"should support %v DIV %v", oid, oid)
+	}
+
+	// Unsupported: different types
+	require.False(t, integerDivOperatorSupports(types.T_int32.ToType(), types.T_int64.ToType()))
+
+	// Unsupported: string types
+	require.False(t, integerDivOperatorSupports(types.T_varchar.ToType(), types.T_varchar.ToType()))
+}

--- a/pkg/sql/plan/function/list_operator.go
+++ b/pkg/sql/plan/function/list_operator.go
@@ -1801,15 +1801,14 @@ var supportedOperators = []FuncNew{
 		layout:     BINARY_ARITHMETIC_OPERATOR,
 		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
 			if len(inputs) == 2 {
+				// First check if types directly support DIV
+				if integerDivOperatorSupports(inputs[0], inputs[1]) {
+					return newCheckResultWithSuccess(0)
+				}
+				// Then check with type casting
 				has, t1, t2 := fixedTypeCastRule2(inputs[0], inputs[1])
-				if has {
-					if integerDivOperatorSupports(t1, t2) {
-						return newCheckResultWithCast(0, []types.Type{t1, t2})
-					}
-				} else {
-					if integerDivOperatorSupports(inputs[0], inputs[1]) {
-						return newCheckResultWithSuccess(0)
-					}
+				if has && integerDivOperatorSupports(t1, t2) {
+					return newCheckResultWithCast(0, []types.Type{t1, t2})
 				}
 			}
 			return newCheckResultWithFailure(failedFunctionParametersWrong)

--- a/test/distributed/cases/dtype/decimal.result
+++ b/test/distributed/cases/dtype/decimal.result
@@ -725,7 +725,7 @@ a    a - b - b
 3    7459
 4    -24691357819753086424691357819753086482
 SELECT a, b DIV a FROM decimal07;
-invalid input: Decimal128 Div overflow: 12345678909876543212345678909876543243(Scale:0)/4(Scale:0)
+Data truncation: data out of range: data type BIGINT, 
 SELECT a, ABS(b) FROM decimal07;
 a    abs(b)
 1    3728193

--- a/test/distributed/cases/dtype/decimal.result
+++ b/test/distributed/cases/dtype/decimal.result
@@ -725,7 +725,7 @@ a    a - b - b
 3    7459
 4    -24691357819753086424691357819753086482
 SELECT a, b DIV a FROM decimal07;
-invalid argument operator div, bad value [DECIMAL128 INT]
+invalid input: Decimal128 Div overflow: 12345678909876543212345678909876543243(Scale:0)/4(Scale:0)
 SELECT a, ABS(b) FROM decimal07;
 a    abs(b)
 1    3728193

--- a/test/distributed/cases/dtype/numeric.result
+++ b/test/distributed/cases/dtype/numeric.result
@@ -757,7 +757,7 @@ a    a - b - b
 3    7459
 4    -24691357819753086424691357819753086482
 SELECT a, b DIV a FROM numeric07;
-invalid argument operator div, bad value [DECIMAL128 INT]
+invalid input: Decimal128 Div overflow: 12345678909876543212345678909876543243(Scale:0)/4(Scale:0)
 SELECT a, ABS(b) FROM numeric07;
 a    ABS(b)
 1    3728193

--- a/test/distributed/cases/dtype/numeric.result
+++ b/test/distributed/cases/dtype/numeric.result
@@ -757,7 +757,7 @@ a    a - b - b
 3    7459
 4    -24691357819753086424691357819753086482
 SELECT a, b DIV a FROM numeric07;
-invalid input: Decimal128 Div overflow: 12345678909876543212345678909876543243(Scale:0)/4(Scale:0)
+Data truncation: data out of range: data type BIGINT, 
 SELECT a, ABS(b) FROM numeric07;
 a    ABS(b)
 1    3728193


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #24108

## What this PR does / why we need it:

The `DIV` operator on 3.0-dev only supports `float32`/`float64` types, causing SQL errors when used with integer or decimal types:

```sql
SELECT CAST('05' AS UNSIGNED) DIV 3;
-- ERROR: invalid argument operator div, bad value [BIGINT UNSIGNED BIGINT]
```

## Root Cause
1. `integerDivOperatorSupports()` only matched `T_float32` and `T_float64`, missing all integer and decimal types
2. `integerDivFn()` only had float execution paths, hitting `panic("unreached code")` for other types  
3. `checkFn` in list_operator.go tried type casting before checking direct support, causing unnecessary cast failures

## Fix
- Add `int8-int64`, `uint8-uint64`, `decimal64`, `decimal128` to `integerDivOperatorSupports`
- Add `integerDivSigned()`, `integerDivUnsigned()`, `decimalIntegerDiv()` execution paths
- Fix `checkFn` to check direct type support before attempting cast rules (matching main branch behavior)

Backported from main branch (commit 37a2eda6a).

## Test
Verified with full MO instance on 3.0-dev:
| Test | Before | After |
|------|--------|-------|
| `10 DIV 3` | ❌ Error | ✅ = 3 |
| `CAST('05' AS UNSIGNED) DIV 3` | ❌ Error | ✅ = 1 |
| `column DIV column` | ❌ Error | ✅ Works |
| `10.5 DIV 3` | ❌ Error | ✅ = 4 |
| `-10 DIV 3` | ❌ Error | ✅ = -3 |
| `CAST(1000000000000 AS UNSIGNED) DIV 7` | ❌ Error | ✅ = 142857142857 |
