### PR TITLE
fix(disttae): clamp stale workspace write offset

### DIFF
--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -699,6 +699,9 @@ func (txn *Transaction) dumpBatchLocked(ctx context.Context, offset int) error {
 		}
 		size = 0
 	}
+	if offset < txn.adjustWriteOffset {
+		txn.adjustWriteOffset = offset
+	}
 	txn.hasS3Op.Store(true)
 
 	var (
@@ -2240,6 +2243,7 @@ func (txn *Transaction) UpdateSnapshotWriteOffset() {
 	txn.Lock()
 	defer txn.Unlock()
 	txn.snapshotWriteOffset = len(txn.writes)
+	txn.adjustWriteOffset = txn.snapshotWriteOffset
 }
 
 // ApproximateInMemInsertSize returns the approximate total size of in-memory

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -384,26 +384,52 @@ func TestTransactionCheckDupUsesWriteEntryPKMetadata(t *testing.T) {
 	})
 }
 
-func TestAdjustUpdateOrderLockedFallsBackToStatementStart(t *testing.T) {
-	txn := &Transaction{
-		statementID: 1,
-		offsets:     []int{1},
-		writes: []Entry{
-			{typ: INSERT, tableId: 99},
-			{typ: INSERT, tableId: 1},
-			{typ: DELETE, tableId: 1},
-		},
-	}
+func TestAdjustUpdateOrderLockedUsesAdjustedWriteOffset(t *testing.T) {
+	t.Run("in range stale offset", func(t *testing.T) {
+		txn := &Transaction{
+			statementID:       1,
+			adjustWriteOffset: 1,
+			writes: []Entry{
+				{typ: INSERT, tableId: 99},
+				{typ: INSERT, tableId: 1},
+				{typ: DELETE, tableId: 1},
+				{typ: INSERT, tableId: 2, fileName: "flushed"},
+			},
+		}
 
-	require.NotPanics(t, func() {
-		require.NoError(t, txn.adjustUpdateOrderLocked(4))
+		require.NotPanics(t, func() {
+			require.NoError(t, txn.adjustUpdateOrderLocked(2))
+		})
+
+		require.Len(t, txn.writes, 4)
+		require.Equal(t, INSERT, txn.writes[0].typ)
+		require.Equal(t, uint64(99), txn.writes[0].tableId)
+		require.Equal(t, DELETE, txn.writes[1].typ)
+		require.Equal(t, INSERT, txn.writes[2].typ)
+		require.Equal(t, INSERT, txn.writes[3].typ)
 	})
 
-	require.Len(t, txn.writes, 3)
-	require.Equal(t, INSERT, txn.writes[0].typ)
-	require.Equal(t, uint64(99), txn.writes[0].tableId)
-	require.Equal(t, DELETE, txn.writes[1].typ)
-	require.Equal(t, INSERT, txn.writes[2].typ)
+	t.Run("out of range stale offset", func(t *testing.T) {
+		txn := &Transaction{
+			statementID:       1,
+			adjustWriteOffset: 1,
+			writes: []Entry{
+				{typ: INSERT, tableId: 99},
+				{typ: INSERT, tableId: 1},
+				{typ: DELETE, tableId: 1},
+			},
+		}
+
+		require.NotPanics(t, func() {
+			require.NoError(t, txn.adjustUpdateOrderLocked(4))
+		})
+
+		require.Len(t, txn.writes, 3)
+		require.Equal(t, INSERT, txn.writes[0].typ)
+		require.Equal(t, uint64(99), txn.writes[0].tableId)
+		require.Equal(t, DELETE, txn.writes[1].typ)
+		require.Equal(t, INSERT, txn.writes[2].typ)
+	})
 }
 
 func TestTransactionGetTableNilGuards(t *testing.T) {

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -384,22 +384,26 @@ func TestTransactionCheckDupUsesWriteEntryPKMetadata(t *testing.T) {
 	})
 }
 
-func TestAdjustUpdateOrderLockedClampsStaleWriteOffset(t *testing.T) {
+func TestAdjustUpdateOrderLockedFallsBackToStatementStart(t *testing.T) {
 	txn := &Transaction{
 		statementID: 1,
+		offsets:     []int{1},
 		writes: []Entry{
-			{typ: DELETE, tableId: 1},
+			{typ: INSERT, tableId: 99},
 			{typ: INSERT, tableId: 1},
+			{typ: DELETE, tableId: 1},
 		},
 	}
 
 	require.NotPanics(t, func() {
-		require.NoError(t, txn.adjustUpdateOrderLocked(3))
+		require.NoError(t, txn.adjustUpdateOrderLocked(4))
 	})
 
-	require.Len(t, txn.writes, 2)
-	require.Equal(t, DELETE, txn.writes[0].typ)
-	require.Equal(t, INSERT, txn.writes[1].typ)
+	require.Len(t, txn.writes, 3)
+	require.Equal(t, INSERT, txn.writes[0].typ)
+	require.Equal(t, uint64(99), txn.writes[0].tableId)
+	require.Equal(t, DELETE, txn.writes[1].typ)
+	require.Equal(t, INSERT, txn.writes[2].typ)
 }
 
 func TestTransactionGetTableNilGuards(t *testing.T) {

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -384,6 +384,24 @@ func TestTransactionCheckDupUsesWriteEntryPKMetadata(t *testing.T) {
 	})
 }
 
+func TestAdjustUpdateOrderLockedClampsStaleWriteOffset(t *testing.T) {
+	txn := &Transaction{
+		statementID: 1,
+		writes: []Entry{
+			{typ: DELETE, tableId: 1},
+			{typ: INSERT, tableId: 1},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		require.NoError(t, txn.adjustUpdateOrderLocked(3))
+	})
+
+	require.Len(t, txn.writes, 2)
+	require.Equal(t, DELETE, txn.writes[0].typ)
+	require.Equal(t, INSERT, txn.writes[1].typ)
+}
+
 func TestTransactionGetTableNilGuards(t *testing.T) {
 	txn := &Transaction{}
 

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -762,7 +762,14 @@ func (txn *Transaction) adjustUpdateOrderLocked(writeOffset uint64) error {
 
 	if txn.statementID > 0 {
 		if writeOffset > uint64(len(txn.writes)) {
-			writeOffset = uint64(len(txn.writes))
+			stmtStart := 0
+			if len(txn.offsets) >= txn.statementID {
+				stmtStart = txn.offsets[txn.statementID-1]
+			}
+			if stmtStart > len(txn.writes) {
+				stmtStart = len(txn.writes)
+			}
+			writeOffset = uint64(stmtStart)
 		}
 		slices.SortStableFunc(txn.writes[writeOffset:], func(a, b Entry) int {
 			// expected in descending order

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -376,6 +376,9 @@ type Transaction struct {
 	approximateInMemDeleteCnt int
 	// the last snapshot write offset
 	snapshotWriteOffset int
+	// the earliest write offset that Adjust must still consider for the current SQL
+	// after in-place workspace compaction shifts surviving writes to the left.
+	adjustWriteOffset int
 
 	tnStores []DNStore
 	proc     *process.Process
@@ -761,15 +764,11 @@ func (txn *Transaction) traceWorkspaceLocked(commit bool) {
 func (txn *Transaction) adjustUpdateOrderLocked(writeOffset uint64) error {
 
 	if txn.statementID > 0 {
+		if txn.adjustWriteOffset < int(writeOffset) {
+			writeOffset = uint64(txn.adjustWriteOffset)
+		}
 		if writeOffset > uint64(len(txn.writes)) {
-			stmtStart := 0
-			if len(txn.offsets) >= txn.statementID {
-				stmtStart = txn.offsets[txn.statementID-1]
-			}
-			if stmtStart > len(txn.writes) {
-				stmtStart = len(txn.writes)
-			}
-			writeOffset = uint64(stmtStart)
+			writeOffset = uint64(len(txn.writes))
 		}
 		slices.SortStableFunc(txn.writes[writeOffset:], func(a, b Entry) int {
 			// expected in descending order

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -761,6 +761,9 @@ func (txn *Transaction) traceWorkspaceLocked(commit bool) {
 func (txn *Transaction) adjustUpdateOrderLocked(writeOffset uint64) error {
 
 	if txn.statementID > 0 {
+		if writeOffset > uint64(len(txn.writes)) {
+			writeOffset = uint64(len(txn.writes))
+		}
 		slices.SortStableFunc(txn.writes[writeOffset:], func(a, b Entry) int {
 			// expected in descending order
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #24164

## What this PR does / why we need it:

This fixes the stale workspace offset panic in `disttae.Transaction.adjustUpdateOrderLocked`.

`Compile.Run` captures a `writeOffset` before statement execution and calls `Workspace.Adjust(writeOffset)` on the way out. During execution, `dumpBatchLocked` can compact `txn.writes` in place. On force-dump paths it may rescan from an earlier offset inside the same statement, which can both shrink `txn.writes` and shift surviving writes to indexes before the captured offset. The old code then sliced `txn.writes[writeOffset:]` directly and could panic with `slice bounds out of range [17:15]`.

A pure bounds clamp is still not safe, because current-statement writes can move left while the final slice length stays valid. In that case `Adjust` would skip surviving writes that still need the DELETE-before-INSERT reorder.

This PR tracks the earliest workspace offset that the current SQL still needs to adjust after in-place compaction. `UpdateSnapshotWriteOffset` initializes that boundary for the SQL, `dumpBatchLocked` lowers it whenever compaction starts earlier, and `adjustUpdateOrderLocked` uses the lowered boundary before sorting. That preserves the original adjust semantics for normal executions, avoids the panic, and still covers surviving writes after force-dump compaction.

Also included:
- regression tests for both in-range and out-of-range stale offsets

## Validation

- `GOFLAGS='-mod=mod' go test ./pkg/vm/engine/disttae -run 'TestAdjustUpdateOrderLockedUsesAdjustedWriteOffset|TestTransactionCheckDupUsesWriteEntryPKMetadata' -count=1`
- `GOFLAGS='-mod=mod' go test ./pkg/vm/engine/disttae -count=1`
- `GOFLAGS='-mod=mod' go test ./pkg/vm/engine/test -run 'Test_WorkspaceForceDumpWithStatementBoundary|Test_WorkspaceForceDumpNoIncrStatement' -count=1`