### PR TITLE
fix(cnservice): delay task runner until startup completes

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -268,7 +268,13 @@ func (s *service) Start() error {
 		return err
 	}
 
-	return s.server.Start()
+	if err = s.server.Start(); err != nil {
+		return err
+	}
+
+	s.task.runnerReady.Store(true)
+	s.startTaskRunner()
+	return nil
 }
 
 func (s *service) Close() error {

--- a/pkg/cnservice/server_task.go
+++ b/pkg/cnservice/server_task.go
@@ -186,13 +186,21 @@ func (s *service) startTaskRunner() {
 	s.task.Lock()
 	defer s.task.Unlock()
 
+	if !s.task.runnerReady.Load() {
+		return
+	}
+
 	if s.task.runner != nil {
+		return
+	}
+
+	if s.task.holder == nil {
 		return
 	}
 
 	ts, ok := s.task.holder.Get()
 	if !ok {
-		panic("task service must created")
+		return
 	}
 
 	s.task.runner = taskservice.NewTaskRunner(s.cfg.UUID,

--- a/pkg/cnservice/server_task_test.go
+++ b/pkg/cnservice/server_task_test.go
@@ -139,6 +139,7 @@ var _ taskservice.TaskServiceHolder = new(testHolder)
 
 type testHolder struct {
 	ts taskservice.TaskService
+	ok bool
 }
 
 func (holder *testHolder) Close() error {
@@ -147,7 +148,7 @@ func (holder *testHolder) Close() error {
 }
 
 func (holder *testHolder) Get() (taskservice.TaskService, bool) {
-	return holder.ts, true
+	return holder.ts, holder.ok
 }
 
 func (holder *testHolder) Create(command pb.CreateTaskService) error {
@@ -301,7 +302,29 @@ func Test_registerExecutorsLocked(t *testing.T) {
 
 	sv.task.holder = &testHolder{
 		ts: ts,
+		ok: true,
 	}
 
 	sv.registerExecutorsLocked()
+}
+
+func Test_startTaskRunnerRequiresReadyAndHolder(t *testing.T) {
+	conf := &Config{}
+	sv := &service{cfg: conf}
+
+	sv.startTaskRunner()
+	assert.Nil(t, sv.task.runner)
+
+	sv.task.holder = &testHolder{ts: &testTS{}}
+	sv.startTaskRunner()
+	assert.Nil(t, sv.task.runner)
+
+	sv.task.runnerReady.Store(true)
+	sv.task.holder = &testHolder{ok: false}
+	sv.startTaskRunner()
+	assert.Nil(t, sv.task.runner)
+
+	sv.task.holder = nil
+	sv.startTaskRunner()
+	assert.Nil(t, sv.task.runner)
 }

--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -669,6 +669,7 @@ type service struct {
 		sync.RWMutex
 		holder         taskservice.TaskServiceHolder
 		runner         taskservice.TaskRunner
+		runnerReady    atomic.Bool
 		storageFactory taskservice.TaskStorageFactory
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #24175

## What this PR does / why we need it:

This fixes a CDC startup panic on `3.0-dev` caused by starting the CN task runner before the frontend / internal-executor dependencies are ready.

`NewService()` starts the HAKeeper heartbeat before CN startup is fully complete. If HAKeeper delivers `CreateTaskService` during that window, `createTaskService()` can create the task service and immediately start the task runner. A claimed CDC daemon task calls `frontend.NewInternalExecutor(...).Query(...)` very early in `retrieveCdcTask()`, but the frontend server-level runtime dependencies are only fully initialized later in CN startup. That leaves `getPu(service)` uninitialized and can panic the CN with a nil pointer dereference.

This PR keeps early task-service creation intact, but defers task-runner startup until CN startup has completed. It also makes `startTaskRunner()` tolerant of the intermediate state where the holder exists but the task service has not been created yet. That preserves the normal late-start path while removing the startup race that crashes CDC tasks.

Also included:
- a regression test that pins the task-runner readiness gate

## Validation

- `GOFLAGS='-mod=mod' go test ./pkg/cnservice -run 'Test_canClaimDaemonTask|Test_registerExecutorsLocked|Test_startTaskRunnerRequiresReadyAndHolder' -count=1`
- `GOFLAGS='-mod=mod' go test ./pkg/cnservice -count=1`