### PR TITLE
fix(cnservice): delay task runner until startup completes

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -258,7 +258,13 @@ func (s *service) Start() error {
 		return err
 	}
 
-	return s.server.Start()
+	if err := s.server.Start(); err != nil {
+		return err
+	}
+
+	s.task.runnerReady.Store(true)
+	s.startTaskRunner()
+	return nil
 }
 
 func (s *service) Close() error {

--- a/pkg/cnservice/server_task.go
+++ b/pkg/cnservice/server_task.go
@@ -168,13 +168,21 @@ func (s *service) startTaskRunner() {
 	s.task.Lock()
 	defer s.task.Unlock()
 
+	if !s.task.runnerReady.Load() {
+		return
+	}
+
 	if s.task.runner != nil {
+		return
+	}
+
+	if s.task.holder == nil {
 		return
 	}
 
 	ts, ok := s.task.holder.Get()
 	if !ok {
-		panic("task service must created")
+		return
 	}
 
 	s.task.runner = taskservice.NewTaskRunner(s.cfg.UUID,

--- a/pkg/cnservice/server_task_start_test.go
+++ b/pkg/cnservice/server_task_start_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cnservice
+
+import (
+	"testing"
+
+	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
+	"github.com/matrixorigin/matrixone/pkg/taskservice"
+	"github.com/stretchr/testify/assert"
+)
+
+type testTaskHolder struct {
+	ok bool
+}
+
+func (holder *testTaskHolder) Close() error {
+	return nil
+}
+
+func (holder *testTaskHolder) Get() (taskservice.TaskService, bool) {
+	return nil, holder.ok
+}
+
+func (holder *testTaskHolder) Create(command pb.CreateTaskService) error {
+	return nil
+}
+
+func Test_startTaskRunnerRequiresReadyAndHolder(t *testing.T) {
+	conf := &Config{}
+	sv := &service{cfg: conf}
+
+	sv.startTaskRunner()
+	assert.Nil(t, sv.task.runner)
+
+	sv.task.holder = &testTaskHolder{ok: true}
+	sv.startTaskRunner()
+	assert.Nil(t, sv.task.runner)
+
+	sv.task.runnerReady.Store(true)
+	sv.task.holder = &testTaskHolder{ok: false}
+	sv.startTaskRunner()
+	assert.Nil(t, sv.task.runner)
+
+	sv.task.holder = nil
+	sv.startTaskRunner()
+	assert.Nil(t, sv.task.runner)
+}

--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -638,6 +638,7 @@ type service struct {
 		sync.RWMutex
 		holder         taskservice.TaskServiceHolder
 		runner         taskservice.TaskRunner
+		runnerReady    atomic.Bool
 		storageFactory taskservice.TaskStorageFactory
 	}
 

--- a/pkg/common/malloc/default.go
+++ b/pkg/common/malloc/default.go
@@ -38,9 +38,11 @@ func NewDefault(config *Config) (allocator Allocator) {
 		if config.EnableMetrics {
 			allocator = NewMetricsAllocator(allocator, &metrics)
 		}
+		println("Using C allocatorrrrr")
 		return allocator
 
 	case "old":
+		println("Using old allocatorallocatorallocator")
 		return NewShardedAllocator(
 			runtime.GOMAXPROCS(0),
 			func() Allocator {

--- a/pkg/common/malloc/default.go
+++ b/pkg/common/malloc/default.go
@@ -56,6 +56,7 @@ func NewDefault(config *Config) (allocator Allocator) {
 		)
 
 	default:
+		println("Using NewShardedAllocator allocatorallocatorallocator")
 		return NewShardedAllocator(
 			runtime.GOMAXPROCS(0),
 			func() Allocator {

--- a/pkg/objectio/constructors.go
+++ b/pkg/objectio/constructors.go
@@ -43,7 +43,7 @@ func constructorFactory(size int64, algo uint8) CacheConstructor {
 			copy(cacheData.Bytes(), data)
 			return cacheData, nil
 		}
-
+		start := time.Now()
 		now := time.Now()
 		var allocDuration time.Duration
 		var decompressDuration time.Duration
@@ -60,8 +60,9 @@ func constructorFactory(size int64, algo uint8) CacheConstructor {
 		now = time.Now()
 		decompressed = decompressed.Slice(len(bs))
 		SliceDuration = time.Since(now)
-		if len(data) > 10*1024*1024 {
-			logutil.Infof("decompress data size: %d, allocDuration: %v, decompressDuration: %v, SliceDuration: %v", len(data), allocDuration, decompressDuration, SliceDuration)
+		end := time.Since(start)
+		if end > 500*time.Millisecond {
+			logutil.Infof("decompress data size: %d, allocDuration: %v, decompressDuration: %v, SliceDuration: %v, cost: %v", len(data), allocDuration, decompressDuration, SliceDuration, end)
 		}
 		return decompressed, nil
 	}

--- a/pkg/objectio/constructors.go
+++ b/pkg/objectio/constructors.go
@@ -60,7 +60,7 @@ func constructorFactory(size int64, algo uint8) CacheConstructor {
 		now = time.Now()
 		decompressed = decompressed.Slice(len(bs))
 		SliceDuration = time.Since(now)
-		if len(data) > 5*1024*1024 {
+		if len(data) > 10*1024*1024 {
 			logutil.Infof("decompress data size: %d, allocDuration: %v, decompressDuration: %v, SliceDuration: %v", len(data), allocDuration, decompressDuration, SliceDuration)
 		}
 		return decompressed, nil

--- a/pkg/objectio/constructors.go
+++ b/pkg/objectio/constructors.go
@@ -62,7 +62,7 @@ func constructorFactory(size int64, algo uint8) CacheConstructor {
 		SliceDuration = time.Since(now)
 		end := time.Since(start)
 		if end > 500*time.Millisecond {
-			logutil.Infof("decompress data size: %d, allocDuration: %v, decompressDuration: %v, SliceDuration: %v, cost: %v", len(data), allocDuration, decompressDuration, SliceDuration, end)
+			logutil.Infof("decompress data size: %d, size: %d, allocDuration: %v, decompressDuration: %v, SliceDuration: %v, cost: %v", len(data), size, allocDuration, decompressDuration, SliceDuration, end)
 		}
 		return decompressed, nil
 	}

--- a/pkg/vm/engine/tae/blockio/funcs.go
+++ b/pkg/vm/engine/tae/blockio/funcs.go
@@ -147,7 +147,7 @@ func LoadTombstoneColumns(
 	location objectio.Location,
 	m *mpool.MPool,
 ) (bat *batch.Batch, release func(), err error) {
-	return LoadColumnsData(ctx, objectio.SchemaTombstone, cols, typs, fs, location, m, fileservice.Policy(0))
+	return LoadColumnsData(ctx, objectio.SchemaTombstone, cols, typs, fs, location, m, fileservice.SkipAllCache)
 }
 
 // LoadColumns2 load columns data from file service for TN

--- a/pkg/vm/engine/tae/iface/data/object.go
+++ b/pkg/vm/engine/tae/iface/data/object.go
@@ -152,7 +152,7 @@ type Object interface {
 		start, end types.TS,
 		withAborted bool,
 		mp *mpool.MPool,
-	) (bat *containers.Batch, err error)
+	) (bat *containers.Batch, p int, err error)
 	// GetAppendNodeByRow(row uint32) (an txnif.AppendNode)
 	// GetDeleteNodeByRow(row uint32) (an txnif.DeleteNode)
 	GetFs() *objectio.ObjectFS

--- a/pkg/vm/engine/tae/iface/data/object.go
+++ b/pkg/vm/engine/tae/iface/data/object.go
@@ -144,7 +144,7 @@ type Object interface {
 	UpgradeAllDeleteChain()
 	CollectAppendInRange(start, end types.TS, withAborted bool, mp *mpool.MPool) (*containers.BatchWithVersion, error)
 	CollectDeleteInRange(ctx context.Context, start, end types.TS, withAborted bool, mp *mpool.MPool) (*containers.Batch, *bitmap.Bitmap, error)
-	CollectDeleteInRangeByBlock(ctx context.Context, blkID uint16, start, end types.TS, withAborted bool, mp *mpool.MPool) (*containers.Batch, error)
+	CollectDeleteInRangeByBlock(ctx context.Context, blkID uint16, start, end types.TS, withAborted bool, mp *mpool.MPool) (*containers.Batch, int, int, error)
 	PersistedCollectDeleteInRange(
 		ctx context.Context,
 		b *containers.Batch,

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -528,7 +528,7 @@ func (blk *baseObject) foreachPersistedDeletes(
 			if commitTS.GreaterEq(&start) && commitTS.LessEq(&end) {
 				if i > y {
 					if rowIdVecss[y].Equal(rowIdVecss[i]) && commitTsVecss[y].Equal(&commitTsVecss[i]) {
-						logutil.Warnf("foreachPersistedDeletes error : %v, %v", rowIdVecss[i].String(), commitTsVecss[i].ToString())
+						logutil.Warnf("foreachPersistedDeletes error : %v, %v, i: %d", rowIdVecss[i].String(), commitTsVecss[i].ToString(), i)
 					}
 					y++
 				}

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -936,8 +936,8 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 	if start.IsEmpty() {
 		logutil.Infof("CollectDeleteInRangeByBlock is %v-%v-%v", start.ToString(), end.ToString(), currentEnd.ToString())
 	}
-	if deletes != nil {
-		inMeory := deletes.CloneWindowWithPool(0, deletes.Length(), blk.rt.VectorPool.Transient)
+	if deletes != nil && deletes.Length() > 0 {
+		inMeory := deletes.CloneWindow(0, deletes.Length())
 		defer inMeory.Close()
 		_, err = mergesort.SortBlockColumns(inMeory.Vecs, 0, blk.rt.VectorPool.Transient)
 		if err != nil {

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -936,7 +936,6 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 			rowIDvec := vector.MustFixedCol[types.Rowid](deletes.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
 			commitsVec := vector.MustFixedCol[types.TS](deletes.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
 			logutil.Debugf("inMemoryCollectDeleteInRange is %v-%v", rowIDvec[i].String(), commitsVec[i].ToString())
-
 		}
 	}
 	deletes, err = blk.PersistedCollectDeleteInRange(

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -527,9 +527,6 @@ func (blk *baseObject) foreachPersistedDeletes(
 			}
 			commitTS := vector.GetFixedAt[types.TS](commitTsVec, i)
 			if commitTS.GreaterEq(&start) && commitTS.LessEq(&end) {
-				if rowIdVecss[i].Segment().ToString() != blk.meta.ID.Segment().ToString() {
-					logutil.Warnf("blk.meta.ID.String()222 %v error : %v, %v, i: %d", blk.meta.ID.String(), rowIdVecss[i].String(), commitTsVecss[i].ToString(), i)
-				}
 				if i > y {
 					if rowIdVecss[y].Equal(rowIdVecss[i]) && commitTsVecss[y].Equal(&commitTsVecss[i]) {
 						logutil.Warnf("foreachPersistedDeletes error : %v, %v, i: %d", rowIdVecss[i].String(), commitTsVecss[i].ToString(), i)
@@ -953,9 +950,6 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 		for z := 0; z < inMeory.Length(); z++ {
 			if start.IsEmpty() && minTS.Greater(&commitTsVecss[z]) {
 				logutil.Infof("inm is %v-%v-%v", rowIdVecss[z].String(), commitTsVecss[z].ToString(), z, end.ToString(), minTS.ToString())
-			}
-			if blk.meta.ID.Segment().ToString() != rowIdVecss[z].Segment().ToString() {
-				logutil.Warnf("blk.meta.ID.String() %v error : %v, %v, i: %d", blk.meta.ID.String(), rowIdVecss[z].String(), commitTsVecss[z].ToString(), z)
 			}
 			if z > y {
 				if rowIdVecss[y].Equal(rowIdVecss[z]) && commitTsVecss[y].Equal(&commitTsVecss[z]) {

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -527,6 +527,9 @@ func (blk *baseObject) foreachPersistedDeletes(
 			}
 			commitTS := vector.GetFixedAt[types.TS](commitTsVec, i)
 			if commitTS.GreaterEq(&start) && commitTS.LessEq(&end) {
+				if rowIdVecss[i].String() != blk.meta.ID.String() {
+					logutil.Warnf("blk.meta.ID.String()222 %v error : %v, %v, i: %d", blk.meta.ID.String(), rowIDVec[i].String(), commitsVec[i].ToString(), i)
+				}
 				if i > y {
 					if rowIdVecss[y].Equal(rowIdVecss[i]) && commitTsVecss[y].Equal(&commitTsVecss[i]) {
 						logutil.Warnf("foreachPersistedDeletes error : %v, %v, i: %d", rowIdVecss[i].String(), commitTsVecss[i].ToString(), i)
@@ -1045,9 +1048,6 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 				for i := 0; i < delBat.Length(); i++ {
 					rowIDVec := vector.MustFixedCol[types.Rowid](delBat.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
 					commitsVec := vector.MustFixedCol[types.TS](delBat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
-					if rowIDVec[i].String() != blk.meta.ID.String() {
-						logutil.Warnf("blk.meta.ID.String()222 %v error : %v, %v, i: %d", blk.meta.ID.String(), rowIDVec[i].String(), commitsVec[i].ToString(), i)
-					}
 					logutil.Debugf("PersistedCollectDeleteInRange is %v-%v", rowIDVec[i].String(), commitsVec[i].ToString())
 
 				}

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -516,7 +516,7 @@ func (blk *baseObject) foreachPersistedDeletes(
 		commitTsVecss := vector.MustFixedCol[types.TS](commitTsVec)
 
 		rstart, rend := blockio.FindIntervalForBlock(rowIdVecss, objectio.NewBlockidWithObjectID(&blk.meta.ID, blkID))
-		y := 1
+		y := 0
 		for i := rstart; i < rend; i++ {
 			if skipAbort {
 				abort := vector.GetFixedAt[bool](abortVec, i)
@@ -526,10 +526,11 @@ func (blk *baseObject) foreachPersistedDeletes(
 			}
 			commitTS := vector.GetFixedAt[types.TS](commitTsVec, i)
 			if commitTS.GreaterEq(&start) && commitTS.LessEq(&end) {
-				if y == i {
-					if rowIdVecss[0].Equal(rowIdVecss[i]) && commitTsVecss[0].Equal(&commitTsVecss[i]) {
-						logutil.Warnf("foreachPersistedDeletes error : %v, %v", rowIdVecss[0].String(), commitTsVecss[i].ToString())
+				if i > y {
+					if rowIdVecss[y].Equal(rowIdVecss[i]) && commitTsVecss[y].Equal(&commitTsVecss[i]) {
+						logutil.Warnf("foreachPersistedDeletes error : %v, %v", rowIdVecss[i].String(), commitTsVecss[i].ToString())
 					}
+					y++
 				}
 				loopOp(i, rowIdVec)
 			}

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -930,11 +930,12 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 	if !minTS.IsEmpty() && currentEnd.Greater(&minTS) {
 		currentEnd = minTS.Prev()
 	}
+	logutil.Infof("CollectDeleteInRangeByBlock is %v-%v-%v", start.ToString(), end.ToString(), currentEnd.ToString())
 	if deletes != nil {
 		for i := 0; i < deletes.Length(); i++ {
 			rowIDvec := vector.MustFixedCol[types.Rowid](deletes.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
 			commitsVec := vector.MustFixedCol[types.TS](deletes.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
-			logutil.Infof("inMemoryCollectDeleteInRange is %v-%v", rowIDvec[i].String(), commitsVec[i].ToString())
+			logutil.Debugf("inMemoryCollectDeleteInRange is %v-%v", rowIDvec[i].String(), commitsVec[i].ToString())
 
 		}
 	}
@@ -1022,7 +1023,7 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 					rowIDVec := vector.MustFixedCol[types.Rowid](delBat.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
 					commitsVec := vector.MustFixedCol[types.TS](delBat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
 
-					logutil.Infof("PersistedCollectDeleteInRange is %v-%v", rowIDVec[i].String(), commitsVec[i].ToString())
+					logutil.Debugf("PersistedCollectDeleteInRange is %v-%v", rowIDVec[i].String(), commitsVec[i].ToString())
 
 				}
 

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -930,7 +930,7 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 	if !minTS.IsEmpty() && currentEnd.Greater(&minTS) {
 		currentEnd = minTS.Prev()
 	}
-	logutil.Infof("CollectDeleteInRangeByBlock is %v-%v-%v", start.ToString(), end.ToString(), currentEnd.ToString())
+	logutil.Debugf("CollectDeleteInRangeByBlock is %v-%v-%v", start.ToString(), end.ToString(), currentEnd.ToString())
 	if deletes != nil {
 		for i := 0; i < deletes.Length(); i++ {
 			rowIDvec := vector.MustFixedCol[types.Rowid](deletes.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -1065,15 +1065,6 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 					)
 				}
 			}
-			if delBat != nil {
-				for i := 0; i < delBat.Length(); i++ {
-					rowIDVec := vector.MustFixedCol[types.Rowid](delBat.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
-					commitsVec := vector.MustFixedCol[types.TS](delBat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
-					logutil.Debugf("PersistedCollectDeleteInRange is %v-%v", rowIDVec[i].String(), commitsVec[i].ToString())
-
-				}
-
-			}
 			for _, name := range bat.Attrs {
 				retVec := bat.GetVectorByName(name)
 				srcVec := delBat.GetVectorByName(name)

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -992,11 +992,8 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 	withAborted bool,
 	mp *mpool.MPool,
 ) (bat *containers.Batch, err error) {
-	ob := 0
-	rb := 0
 	if b != nil {
 		bat = b
-		ob = b.Length()
 	}
 	t := types.T_int32.ToType()
 	sels := blk.rt.VectorPool.Transient.GetVector(&t)
@@ -1034,7 +1031,6 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 					logutil.Debugf("PersistedCollectDeleteInRange is %v-%v", rowIDVec[i].String(), commitsVec[i].ToString())
 
 				}
-				rb = delBat.Length()
 
 			}
 			for _, name := range bat.Attrs {

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -982,7 +982,8 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 		return nil, 0, 0, err
 	}
 	persistedCollectDeleteInRangeDuration = time.Since(now1)
-	if time.Since(now) > time.Second*5 {
+	end1 := time.Since(now)
+	if end1 > time.Second*5 {
 		logutil.Warnf("CollectDeleteInRangeByBlock is %v-%v-%v, id %v, inMemoryCollectDeleteInRangeDuration %v, persistedCollectDeleteInRangeDuration %v",
 			start.ToString(), end.ToString(), currentEnd.ToString(), inMemoryCollectDeleteInRangeDuration, persistedCollectDeleteInRangeDuration, blk.meta.ID.String())
 	}

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -951,6 +951,9 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 			if start.IsEmpty() && minTS.Greater(&commitTsVecss[z]) {
 				logutil.Infof("inm is %v-%v-%v", rowIdVecss[z].String(), commitTsVecss[z].ToString(), z, end.ToString(), minTS.ToString())
 			}
+			if blk.meta.ID.String() != rowIdVecss[z].String() {
+				logutil.Warnf("blk.meta.ID.String() %v error : %v, %v, i: %d", blk.meta.ID.String(), rowIdVecss[z].String(), commitTsVecss[z].ToString(), z)
+			}
 			if z > y {
 				if rowIdVecss[y].Equal(rowIdVecss[z]) && commitTsVecss[y].Equal(&commitTsVecss[z]) {
 					logutil.Warnf("CollectDeleteInRangeByBlock error : %v, %v, i: %d", rowIdVecss[z].String(), commitTsVecss[z].ToString(), z)
@@ -1042,7 +1045,9 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 				for i := 0; i < delBat.Length(); i++ {
 					rowIDVec := vector.MustFixedCol[types.Rowid](delBat.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
 					commitsVec := vector.MustFixedCol[types.TS](delBat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
-
+					if rowIDVec[i].String() != blk.meta.ID.String() {
+						logutil.Warnf("blk.meta.ID.String()222 %v error : %v, %v, i: %d", blk.meta.ID.String(), rowIDVec[i].String(), commitsVec[i].ToString(), i)
+					}
 					logutil.Debugf("PersistedCollectDeleteInRange is %v-%v", rowIDVec[i].String(), commitsVec[i].ToString())
 
 				}

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -527,7 +527,7 @@ func (blk *baseObject) foreachPersistedDeletes(
 			}
 			commitTS := vector.GetFixedAt[types.TS](commitTsVec, i)
 			if commitTS.GreaterEq(&start) && commitTS.LessEq(&end) {
-				if rowIdVecss[i].String() != blk.meta.ID.String() {
+				if rowIdVecss[i].Segment().ToString() != blk.meta.ID.Segment().ToString() {
 					logutil.Warnf("blk.meta.ID.String()222 %v error : %v, %v, i: %d", blk.meta.ID.String(), rowIdVecss[i].String(), commitTsVecss[i].ToString(), i)
 				}
 				if i > y {
@@ -954,7 +954,7 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 			if start.IsEmpty() && minTS.Greater(&commitTsVecss[z]) {
 				logutil.Infof("inm is %v-%v-%v", rowIdVecss[z].String(), commitTsVecss[z].ToString(), z, end.ToString(), minTS.ToString())
 			}
-			if blk.meta.ID.String() != rowIdVecss[z].String() {
+			if blk.meta.ID.Segment().ToString() != rowIdVecss[z].Segment().ToString() {
 				logutil.Warnf("blk.meta.ID.String() %v error : %v, %v, i: %d", blk.meta.ID.String(), rowIdVecss[z].String(), commitTsVecss[z].ToString(), z)
 			}
 			if z > y {

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -1041,13 +1041,15 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 					retVec.GetAllocator(),
 				)
 			}
-			rowIDVec := vector.MustFixedCol[types.Rowid](delBat.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
-			commitsVec := vector.MustFixedCol[types.TS](delBat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
+			rowIDVec := vector.MustFixedCol[types.Rowid](bat.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
+			commitsVec := vector.MustFixedCol[types.TS](bat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
 			y := 0
+			dup := 0
 			for i := 0; i < bat.Length(); i++ {
-				if i > y && i < bat.Length() {
+				if i > y {
 					if rowIDVec[y].Equal(rowIDVec[i]) && commitsVec[y].Equal(&commitsVec[i]) {
-						logutil.Warnf("foreachPersistedDeletesCommittedInRange error : %v, %v, i: %d, ob %d, rb %d", rowIDVec[i].String(), commitsVec[i].ToString(), i, ob, rb)
+						dup++
+						logutil.Warnf("foreachPersistedDeletesCommittedInRange error : %v, %v, i: %d, ob %d, rb %d, dup %d", rowIDVec[i].String(), commitsVec[i].ToString(), i, ob, rb, dup)
 					}
 					y++
 				}

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -959,7 +959,7 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 			}
 		}
 	}
-	deletes, err = blk.PersistedCollectDeleteInRange(
+	deletes, p, err = blk.PersistedCollectDeleteInRange(
 		ctx,
 		deletes,
 		blkID,
@@ -968,9 +968,6 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 		withAborted,
 		mp,
 	)
-	if deletes != nil {
-		p = deletes.Length() - in
-	}
 	if err != nil {
 		if deletes != nil {
 			deletes.Close()
@@ -1009,7 +1006,7 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 	start, end types.TS,
 	withAborted bool,
 	mp *mpool.MPool,
-) (bat *containers.Batch, err error) {
+) (bat *containers.Batch, p int, err error) {
 	if b != nil {
 		bat = b
 	}
@@ -1049,6 +1046,7 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 					logutil.Debugf("PersistedCollectDeleteInRange is %v-%v", rowIDVec[i].String(), commitsVec[i].ToString())
 
 				}
+				p += delBat.Length()
 
 			}
 			for _, name := range bat.Attrs {
@@ -1064,7 +1062,7 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 		},
 		mp,
 	)
-	return bat, nil
+	return bat, p, nil
 }
 
 func (blk *baseObject) OnReplayDelete(blkID uint16, node txnif.DeleteNode) (err error) {

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -512,8 +512,11 @@ func (blk *baseObject) foreachPersistedDeletes(
 		abortVec := deletes.Vecs[3].GetDownstreamVector()
 		commitTsVec := deletes.Vecs[1].GetDownstreamVector()
 		rowIdVec := deletes.Vecs[0].GetDownstreamVector()
+		rowIdVecss := vector.MustFixedCol[types.Rowid](rowIdVec)
+		commitTsVecss := vector.MustFixedCol[types.TS](commitTsVec)
 
-		rstart, rend := blockio.FindIntervalForBlock(vector.MustFixedCol[types.Rowid](rowIdVec), objectio.NewBlockidWithObjectID(&blk.meta.ID, blkID))
+		rstart, rend := blockio.FindIntervalForBlock(rowIdVecss, objectio.NewBlockidWithObjectID(&blk.meta.ID, blkID))
+		y := 1
 		for i := rstart; i < rend; i++ {
 			if skipAbort {
 				abort := vector.GetFixedAt[bool](abortVec, i)
@@ -523,6 +526,11 @@ func (blk *baseObject) foreachPersistedDeletes(
 			}
 			commitTS := vector.GetFixedAt[types.TS](commitTsVec, i)
 			if commitTS.GreaterEq(&start) && commitTS.LessEq(&end) {
+				if y == i {
+					if rowIdVecss[0].Equal(rowIdVecss[i]) && commitTsVecss[0].Equal(&commitTsVecss[i]) {
+						logutil.Warnf("foreachPersistedDeletes error : %v, %v", rowIdVecss[0].String(), commitTsVecss[i].ToString())
+					}
+				}
 				loopOp(i, rowIdVec)
 			}
 		}

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -528,7 +528,7 @@ func (blk *baseObject) foreachPersistedDeletes(
 			commitTS := vector.GetFixedAt[types.TS](commitTsVec, i)
 			if commitTS.GreaterEq(&start) && commitTS.LessEq(&end) {
 				if rowIdVecss[i].String() != blk.meta.ID.String() {
-					logutil.Warnf("blk.meta.ID.String()222 %v error : %v, %v, i: %d", blk.meta.ID.String(), rowIDVec[i].String(), commitsVec[i].ToString(), i)
+					logutil.Warnf("blk.meta.ID.String()222 %v error : %v, %v, i: %d", blk.meta.ID.String(), rowIdVecss[i].String(), commitTsVecss[i].ToString(), i)
 				}
 				if i > y {
 					if rowIdVecss[y].Equal(rowIdVecss[i]) && commitTsVecss[y].Equal(&commitTsVecss[i]) {

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -937,6 +937,7 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 		logutil.Infof("CollectDeleteInRangeByBlock is %v-%v-%v", start.ToString(), end.ToString(), currentEnd.ToString())
 	}
 	if deletes != nil && deletes.Length() > 0 {
+		in = deletes.Length()
 		inMeory := deletes.CloneWindow(0, deletes.Length())
 		defer inMeory.Close()
 		_, err = mergesort.SortBlockColumns(inMeory.Vecs, 0, blk.rt.VectorPool.Transient)

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -1047,7 +1047,7 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 			for i := 0; i < bat.Length(); i++ {
 				if i > y {
 					if rowIDVec[y].Equal(rowIDVec[i]) && commitsVec[y].Equal(&commitsVec[i]) {
-						logutil.Warnf("foreachPersistedDeletes error : %v, %v, i: %d, ob %d, rb %d", rowIDVec[i].String(), commitsVec[i].ToString(), i, ob, rb)
+						logutil.Warnf("foreachPersistedDeletesCommittedInRange error : %v, %v, i: %d, ob %d, rb %d", rowIDVec[i].String(), commitsVec[i].ToString(), i, ob, rb)
 					}
 					y++
 				}

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -1045,7 +1045,7 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 			commitsVec := vector.MustFixedCol[types.TS](delBat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
 			y := 0
 			for i := 0; i < bat.Length(); i++ {
-				if i > y {
+				if i > y && i < bat.Length() {
 					if rowIDVec[y].Equal(rowIDVec[i]) && commitsVec[y].Equal(&commitsVec[i]) {
 						logutil.Warnf("foreachPersistedDeletesCommittedInRange error : %v, %v, i: %d, ob %d, rb %d", rowIDVec[i].String(), commitsVec[i].ToString(), i, ob, rb)
 					}

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -883,7 +883,7 @@ func (blk *baseObject) CollectDeleteInRange(
 	emtpyDelBlkIdx = &bitmap.Bitmap{}
 	emtpyDelBlkIdx.InitWithSize(int64(blk.meta.BlockCnt()))
 	for blkID := uint16(0); blkID < uint16(blk.meta.BlockCnt()); blkID++ {
-		deletes, err := blk.CollectDeleteInRangeByBlock(ctx, blkID, start, end, withAborted, mp)
+		deletes, _, _, err := blk.CollectDeleteInRangeByBlock(ctx, blkID, start, end, withAborted, mp)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1046,20 +1046,6 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 					vector.MustFixedCol[int32](sels.GetDownstreamVector()),
 					retVec.GetAllocator(),
 				)
-			}
-			rowIDVec := vector.MustFixedCol[types.Rowid](bat.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
-			commitsVec := vector.MustFixedCol[types.TS](bat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
-			y := 0
-			dup := 0
-			for i := 0; i < bat.Length(); i++ {
-				if i > y {
-					if rowIDVec[y].Equal(rowIDVec[i]) && commitsVec[y].Equal(&commitsVec[i]) {
-						dup++
-						logutil.Warnf("foreachPersistedDeletesCommittedInRange error : %v, %v, i: %d, ob %d, rb %d, dup %d", rowIDVec[i].String(), commitsVec[i].ToString(), i, ob, rb, dup)
-					}
-					y++
-				}
-
 			}
 		},
 		mp,

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -559,9 +559,9 @@ func (blk *baseObject) foreachPersistedDeletes(
 		postOp(deletes)
 		postOpDuration = time.Since(d3)
 	}
-	if time.Since(now) > 10*time.Second {
-		logutil.Infof("foreachPersistedDeletes cost : %v, loadFnDuration: %v, FindIntervalForBlockDuration: %v, loopOpDuration: %v, postOpDuration: %v",
-			time.Since(now), loadFnDuration, FindIntervalForBlockDuration, loopOpDuration, postOpDuration)
+	if time.Since(now) > 3*time.Second {
+		logutil.Infof("foreachPersistedDeletes cost : %v, loadFnDuration: %v, FindIntervalForBlockDuration: %v, loopOpDuration: %v, postOpDuration: %v, id : %v",
+			time.Since(now), loadFnDuration, FindIntervalForBlockDuration, loopOpDuration, postOpDuration, blk.meta.ID.String())
 	}
 	return
 }

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -1046,7 +1046,6 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 					logutil.Debugf("PersistedCollectDeleteInRange is %v-%v", rowIDVec[i].String(), commitsVec[i].ToString())
 
 				}
-				p += delBat.Length()
 
 			}
 			for _, name := range bat.Attrs {
@@ -1062,6 +1061,15 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 		},
 		mp,
 	)
+	p += selsVec.Length()
+	test := make(map[uint32]struct{})
+	selsV := vector.MustFixedCol[int32](selsVec)
+	for i := 0; i < selsVec.Length(); i++ {
+		test[uint32(selsV[i])] = struct{}{}
+	}
+	if len(test) != selsVec.Length() {
+		logutil.Warnf("selsVecselsVec dup error : %d - %d, %d ", len(test), selsVec.Length(), blkID)
+	}
 	return bat, p, nil
 }
 

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -930,6 +930,14 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 	if !minTS.IsEmpty() && currentEnd.Greater(&minTS) {
 		currentEnd = minTS.Prev()
 	}
+	if deletes != nil {
+		for i := 0; i < deletes.Length(); i++ {
+			rowIDvec := vector.MustFixedCol[types.Rowid](deletes.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
+			commitsVec := vector.MustFixedCol[types.TS](deletes.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
+			logutil.Infof("inMemoryCollectDeleteInRange is %v-%v", rowIDvec[i].String(), commitsVec[i].ToString())
+
+		}
+	}
 	deletes, err = blk.PersistedCollectDeleteInRange(
 		ctx,
 		deletes,
@@ -1008,6 +1016,16 @@ func (blk *baseObject) PersistedCollectDeleteInRange(
 						blk.rt.VectorPool.Transient.GetVector(delBat.Vecs[i].GetType()),
 					)
 				}
+			}
+			if delBat != nil {
+				for i := 0; i < delBat.Length(); i++ {
+					rowIDVec := vector.MustFixedCol[types.Rowid](delBat.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
+					commitsVec := vector.MustFixedCol[types.TS](delBat.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
+
+					logutil.Infof("PersistedCollectDeleteInRange is %v-%v", rowIDVec[i].String(), commitsVec[i].ToString())
+
+				}
+
 			}
 			for _, name := range bat.Attrs {
 				retVec := bat.GetVectorByName(name)

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -432,6 +432,10 @@ func (blk *baseObject) foreachPersistedDeletesCommittedInRange(
 			return
 		}
 
+		if location.Rows() > 5000000 {
+			logutil.Infof("foreachPersistedDeletesCommittedInRange: location.Rows() > 5000000, location: %v", location.String())
+		}
+
 		// quick check for early return.
 		persistedByCN, err = blockio.IsPersistedByCN(ctx, location, blk.rt.Fs.Service)
 		if err != nil {

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -948,6 +948,9 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 		rowIdVecss := vector.MustFixedCol[types.Rowid](inMeory.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
 		commitTsVecss := vector.MustFixedCol[types.TS](inMeory.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
 		for z := 0; z < inMeory.Length(); z++ {
+			if start.IsEmpty() && minTS.Greater(&commitTsVecss[z]) {
+				logutil.Infof("inm is %v-%v-%v", rowIdVecss[z].String(), commitTsVecss[z].ToString(), z, end.ToString(), minTS.ToString())
+			}
 			if z > y {
 				if rowIdVecss[y].Equal(rowIdVecss[z]) && commitTsVecss[y].Equal(&commitTsVecss[z]) {
 					logutil.Warnf("CollectDeleteInRangeByBlock error : %v, %v, i: %d", rowIdVecss[z].String(), commitTsVecss[z].ToString(), z)

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -933,7 +933,9 @@ func (blk *baseObject) CollectDeleteInRangeByBlock(
 	if !minTS.IsEmpty() && currentEnd.Greater(&minTS) {
 		currentEnd = minTS.Prev()
 	}
-	logutil.Debugf("CollectDeleteInRangeByBlock is %v-%v-%v", start.ToString(), end.ToString(), currentEnd.ToString())
+	if start.IsEmpty() {
+		logutil.Infof("CollectDeleteInRangeByBlock is %v-%v-%v", start.ToString(), end.ToString(), currentEnd.ToString())
+	}
 	if deletes != nil {
 		inMeory := deletes.CloneWindowWithPool(0, deletes.Length(), blk.rt.VectorPool.Transient)
 		defer inMeory.Close()

--- a/pkg/vm/engine/tae/tables/base.go
+++ b/pkg/vm/engine/tae/tables/base.go
@@ -17,7 +17,6 @@ package tables
 import (
 	"context"
 	"fmt"
-	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/mergesort"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -703,8 +703,8 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 			commitTsVecss := vector.MustFixedCol[types.TS](deletes.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
 			for z := 0; z < deletes.Length(); z++ {
 				if z > y {
-					if rowIdVecss[y].Equal(rowIdVecss[i]) && commitTsVecss[y].Equal(&commitTsVecss[i]) {
-						logutil.Warnf("flushAllDeletesFromDelSrc error : %v, %v, i: %d", rowIdVecss[i].String(), commitTsVecss[i].ToString(), z)
+					if rowIdVecss[y].Equal(rowIdVecss[z]) && commitTsVecss[y].Equal(&commitTsVecss[z]) {
+						logutil.Warnf("flushAllDeletesFromDelSrc error : %v, %v, i: %d", rowIdVecss[z].String(), commitTsVecss[z].ToString(), z)
 					}
 					y++
 				}

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -716,10 +716,12 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 		y := 0
 		rowIdVecss := vector.MustFixedCol[types.Rowid](bufferBatch.GetVectorByName(catalog.PhyAddrColumnName).GetDownstreamVector())
 		commitTsVecss := vector.MustFixedCol[types.TS](bufferBatch.GetVectorByName(catalog.AttrCommitTs).GetDownstreamVector())
+		dup := 0
 		for z := 0; z < bufferBatch.Length(); z++ {
 			if z > y {
 				if rowIdVecss[y].Equal(rowIdVecss[z]) && commitTsVecss[y].Equal(&commitTsVecss[z]) {
-					logutil.Warnf("flushAllDeletesFromDelSrc error : %v, %v, i: %d", rowIdVecss[z].String(), commitTsVecss[z].ToString(), z)
+					dup++
+					logutil.Warnf("flushAllDeletesFromDelSrc error : %v, %v, i: %d", rowIdVecss[z].String(), commitTsVecss[z].ToString(), z, dup)
 				}
 				y++
 			}

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -734,7 +734,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 			}
 		}
 		if dup > 0 {
-			logutil.Infof("collect delete intents, allD: %d, allIn: %d, allP: %d, dup: %d", allD, allIn, allP, dup)
+			logutil.Infof("collect delete intents, allD: %d, allIn: %d, allP: %d, dup: %d, ts %v", allD, allIn, allP, dup, task.txn.GetStartTS().ToString())
 		}
 		subtask = NewFlushDeletesTask(tasks.WaitableCtx, task.rt.Fs, bufferBatch)
 		if err = task.rt.Scheduler.Schedule(subtask); err != nil {

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -709,9 +709,10 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 	}()
 	var HasDeleteIntentsPreparedInByBlockDuration time.Duration
 	var CollectDeleteInRangeByBlockDuration time.Duration
+	var CollectDeleteInRangeByBlockcount int
 	var SortBlockColumnsDuration time.Duration
 	var FlushDeletesTaskDuration time.Duration
-
+	CollectDeleteInRangeByBlockcount = 0
 	emtpyDelObjIdx = make([]*bitmap.Bitmap, len(task.delSrcMetas))
 	var (
 		enableDeltaStat = true
@@ -766,6 +767,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 				return
 			}
 			CollectDeleteInRangeByBlockDuration += time.Since(d2)
+			CollectDeleteInRangeByBlockcount++
 			if deletes == nil || deletes.Length() == 0 {
 				emptyDelObjs.Add(uint64(j))
 				continue
@@ -827,8 +829,8 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 		FlushDeletesTaskDuration += time.Since(d4)
 	}
 	if time.Since(now) > 1*time.Minute {
-		logutil.Infof("HasDeleteIntentsPreparedInByBlockDuration: %v, CollectDeleteInRangeByBlockDuration: %v, SortBlockColumnsDuration: %v, FlushDeletesTaskDuration: %v cost: %v",
-			HasDeleteIntentsPreparedInByBlockDuration, CollectDeleteInRangeByBlockDuration, SortBlockColumnsDuration, FlushDeletesTaskDuration, time.Since(now))
+		logutil.Infof("HasDeleteIntentsPreparedInByBlockDuration: %v, CollectDeleteInRangeByBlockDuration: %v, CollectDeleteInRangeByBlockcount: %d, SortBlockColumnsDuration: %v, FlushDeletesTaskDuration: %v cost: %v",
+			HasDeleteIntentsPreparedInByBlockDuration, CollectDeleteInRangeByBlockDuration, CollectDeleteInRangeByBlockcount, SortBlockColumnsDuration, FlushDeletesTaskDuration, time.Since(now))
 	}
 	return
 }

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -826,7 +826,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 		}
 		FlushDeletesTaskDuration += time.Since(d4)
 	}
-	if time.Since(now) > 5*time.Minute {
+	if time.Since(now) > 1*time.Minute {
 		logutil.Infof("HasDeleteIntentsPreparedInByBlockDuration: %v, CollectDeleteInRangeByBlockDuration: %v, SortBlockColumnsDuration: %v, FlushDeletesTaskDuration: %v cost: %v",
 			HasDeleteIntentsPreparedInByBlockDuration, CollectDeleteInRangeByBlockDuration, SortBlockColumnsDuration, FlushDeletesTaskDuration, time.Since(now))
 	}

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -680,6 +680,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 	emtpyDelObjIdx = make([]*bitmap.Bitmap, len(task.delSrcMetas))
 	allIn := 0
 	allP := 0
+	allD := 0
 	for i, obj := range task.delSrcMetas {
 		objData := obj.GetObjectData()
 		var deletes *containers.Batch
@@ -703,6 +704,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 			}
 			allIn += in
 			allP += p
+			allD += deletes.Length()
 			if bufferBatch == nil {
 				bufferBatch = makeDeletesTempBatch(deletes, task.rt.VectorPool.Transient)
 			}
@@ -732,7 +734,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 			}
 		}
 		if dup > 0 {
-			logutil.Infof("collect delete intents, allIn: %d, allP: %d, dup: %d", allIn, allP, dup)
+			logutil.Infof("collect delete intents, allD: %d, allIn: %d, allP: %d, dup: %d", allD, allIn, allP, dup)
 		}
 		subtask = NewFlushDeletesTask(tasks.WaitableCtx, task.rt.Fs, bufferBatch)
 		if err = task.rt.Scheduler.Schedule(subtask); err != nil {

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -828,7 +828,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 		}
 		FlushDeletesTaskDuration += time.Since(d4)
 	}
-	if time.Since(now) > 1*time.Minute {
+	if time.Since(now) > 40*time.Second {
 		logutil.Infof("HasDeleteIntentsPreparedInByBlockDuration: %v, CollectDeleteInRangeByBlockDuration: %v, CollectDeleteInRangeByBlockcount: %d, SortBlockColumnsDuration: %v, FlushDeletesTaskDuration: %v cost: %v, task.delSrcMetas len %d",
 			HasDeleteIntentsPreparedInByBlockDuration, CollectDeleteInRangeByBlockDuration, CollectDeleteInRangeByBlockcount, SortBlockColumnsDuration, FlushDeletesTaskDuration, time.Since(now), len(task.delSrcMetas))
 	}

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -717,6 +717,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 				bufferBatch = makeDeletesTempBatch(deletes, task.rt.VectorPool.Transient)
 			}
 			task.nObjDeletesCnt += deletes.Length()
+
 			// deletes is closed by Extend
 			bufferBatch.Extend(deletes)
 		}

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -704,7 +704,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 			for z := 0; z < deletes.Length(); z++ {
 				if z > y {
 					if rowIdVecss[y].Equal(rowIdVecss[i]) && commitTsVecss[y].Equal(&commitTsVecss[i]) {
-						logutil.Warnf("flushAllDeletesFromDelSrc error : %v, %v, i: %d", rowIdVecss[i].String(), commitTsVecss[i].ToString(), i)
+						logutil.Warnf("flushAllDeletesFromDelSrc error : %v, %v, i: %d", rowIdVecss[i].String(), commitTsVecss[i].ToString(), z)
 					}
 					y++
 				}

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -829,8 +829,8 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 		FlushDeletesTaskDuration += time.Since(d4)
 	}
 	if time.Since(now) > 1*time.Minute {
-		logutil.Infof("HasDeleteIntentsPreparedInByBlockDuration: %v, CollectDeleteInRangeByBlockDuration: %v, CollectDeleteInRangeByBlockcount: %d, SortBlockColumnsDuration: %v, FlushDeletesTaskDuration: %v cost: %v",
-			HasDeleteIntentsPreparedInByBlockDuration, CollectDeleteInRangeByBlockDuration, CollectDeleteInRangeByBlockcount, SortBlockColumnsDuration, FlushDeletesTaskDuration, time.Since(now))
+		logutil.Infof("HasDeleteIntentsPreparedInByBlockDuration: %v, CollectDeleteInRangeByBlockDuration: %v, CollectDeleteInRangeByBlockcount: %d, SortBlockColumnsDuration: %v, FlushDeletesTaskDuration: %v cost: %v, task.delSrcMetas len %d",
+			HasDeleteIntentsPreparedInByBlockDuration, CollectDeleteInRangeByBlockDuration, CollectDeleteInRangeByBlockcount, SortBlockColumnsDuration, FlushDeletesTaskDuration, time.Since(now), len(task.delSrcMetas))
 	}
 	return
 }

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -385,7 +385,7 @@ func (task *flushTableTailTask) Execute(ctx context.Context) (err error) {
 		common.DurationField(duration1),
 		common.OperandField(task))
 
-	v2.TaskFlushTableTailDurationHistogram.Observe(duration.Seconds())
+	v2.TaskFlushTableTailDurationHistogram.Observe(duration1.Seconds())
 
 	sleep, name, exist := fault.TriggerFault("slow_flush")
 	if exist && name == task.schema.Name {

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -734,7 +734,7 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 			}
 		}
 		if dup > 0 {
-			logutil.Infof("collect delete intents, allD: %d, allIn: %d, allP: %d, dup: %d, ts %v", allD, allIn, allP, dup, task.txn.GetStartTS().ToString())
+			logutil.Infof("collect delete intents, allD: %d, allIn: %d, allP: %d, bufferBatch: %d, dup: %d, ts %v", allD, allIn, allP, bufferBatch.Length(), dup, task.txn.GetStartTS().ToString())
 		}
 		subtask = NewFlushDeletesTask(tasks.WaitableCtx, task.rt.Fs, bufferBatch)
 		if err = task.rt.Scheduler.Schedule(subtask); err != nil {

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -154,6 +154,7 @@ func NewFlushTableTailTask(
 	}
 	task.schema = rel.Schema().(*catalog.Schema)
 
+	objSeen := make(map[*catalog.ObjectEntry]struct{})
 	for _, obj := range objs {
 		task.scopes = append(task.scopes, *obj.AsCommonID())
 		var hdl handle.Object
@@ -161,6 +162,10 @@ func NewFlushTableTailTask(
 		if err != nil {
 			return
 		}
+		if _, ok := objSeen[obj]; ok {
+			continue
+		}
+		objSeen[obj] = struct{}{}
 		if hdl.IsAppendable() && !obj.HasDropCommitted() {
 			task.aObjMetas = append(task.aObjMetas, obj)
 			task.aObjHandles = append(task.aObjHandles, hdl)
@@ -192,6 +197,10 @@ func NewFlushTableTailTask(
 		if err != nil {
 			return
 		}
+		if _, ok := objSeen[obj]; ok {
+			continue
+		}
+		objSeen[obj] = struct{}{}
 		task.delSrcMetas = append(task.delSrcMetas, obj)
 		task.delSrcHandles = append(task.delSrcHandles, hdl)
 	}

--- a/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
+++ b/pkg/vm/engine/tae/tables/jobs/flushTableTail.go
@@ -37,6 +37,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/containers"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/db/dbutils"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/data"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/handle"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/iface/txnif"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/mergesort"
@@ -687,16 +688,37 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 		}
 	}()
 	emtpyDelObjIdx = make([]*bitmap.Bitmap, len(task.delSrcMetas))
+	var (
+		enableDeltaStat = task.schema.Name == "bmsql_stock"
+		tbl             *catalog.TableEntry
+		tombstone       data.Tombstone
+		locMap          = make(map[string]int)
+		now             time.Time
+	)
+
+	if enableDeltaStat {
+		tbl = task.rel.GetMeta().(*catalog.TableEntry)
+		now = time.Now()
+	}
 	for i, obj := range task.delSrcMetas {
 		objData := obj.GetObjectData()
 		var deletes *containers.Batch
 		emptyDelObjs := &bitmap.Bitmap{}
 		emptyDelObjs.InitWithSize(int64(obj.BlockCnt()))
+		if enableDeltaStat {
+			tombstone = tbl.TryGetTombstone(obj.ID)
+		}
 		for j := 0; j < obj.BlockCnt(); j++ {
 			found, _ := objData.HasDeleteIntentsPreparedInByBlock(uint16(j), types.TS{}, task.txn.GetStartTS())
 			if !found {
 				emptyDelObjs.Add(uint64(j))
 				continue
+			}
+			if enableDeltaStat && tombstone != nil {
+				loc := tombstone.GetLatestDeltaloc(uint16(j))
+				if loc != nil {
+					locMap[loc.String()]++
+				}
 			}
 			if deletes, err = objData.CollectDeleteInRangeByBlock(
 				ctx, uint16(j), types.TS{}, task.txn.GetStartTS(), true, common.MergeAllocator,
@@ -715,6 +737,11 @@ func (task *flushTableTailTask) flushAllDeletesFromDelSrc(ctx context.Context) (
 			bufferBatch.Extend(deletes)
 		}
 		emtpyDelObjIdx[i] = emptyDelObjs
+	}
+	if enableDeltaStat {
+		cost := time.Since(now)
+		logutil.Infof("[FlushTabletail] task %d collect tombstone for %s cost %v, location distribution(%v):%v",
+			task.ID(), task.schema.Name, cost, len(locMap), locMap)
 	}
 	if bufferBatch != nil {
 		// make sure every batch in deltaloc object is sorted by rowid

--- a/pkg/vm/engine/tae/tables/updates/mvcc.go
+++ b/pkg/vm/engine/tae/tables/updates/mvcc.go
@@ -916,8 +916,15 @@ func (n *MVCCHandle) CollectDeleteLocked(
 							nulls.Add(aborts, uint64(row))
 						}
 					}
+					prv := -1
 					for it.HasNext() {
 						row := it.Next()
+						if prv >= 0 {
+							if int(row) == prv {
+								logutil.Infof("row %d is deleted more than once, id is %v, committs %v", row, id.String(), node.GetEnd().ToString())
+							}
+						}
+						prv = int(row)
 						rowIDVec.Append(*objectio.NewRowid(id, row), false)
 						commitTSVec.Append(node.GetEnd(), false)
 						// for deleteNode V1，rowid2PK is nil after restart

--- a/pkg/vm/engine/tae/tables/updates/mvcc.go
+++ b/pkg/vm/engine/tae/tables/updates/mvcc.go
@@ -910,9 +910,9 @@ func (n *MVCCHandle) CollectDeleteLocked(
 				if in {
 					it := node.mask.Iterator()
 					if node.IsAborted() {
-						it2 := node.mask.Iterator()
-						for it2.HasNext() {
-							row := it2.Next()
+						it := node.mask.Iterator()
+						for it.HasNext() {
+							row := it.Next()
 							nulls.Add(aborts, uint64(row))
 						}
 					}

--- a/pkg/vm/engine/tae/tables/updates/mvcc.go
+++ b/pkg/vm/engine/tae/tables/updates/mvcc.go
@@ -1025,7 +1025,7 @@ func (n *MVCCHandle) CollectDeleteInRangeAfterDeltalocation(
 	// there's another delta location committed.
 	// It includes more deletes than former delta location.
 	if persisted.Greater(&start) {
-		deletes, err = n.meta.GetObjectData().PersistedCollectDeleteInRange(
+		deletes, _, err = n.meta.GetObjectData().PersistedCollectDeleteInRange(
 			ctx,
 			deletes,
 			n.blkID,

--- a/pkg/vm/engine/tae/tables/updates/mvcc.go
+++ b/pkg/vm/engine/tae/tables/updates/mvcc.go
@@ -940,7 +940,7 @@ func (n *MVCCHandle) CollectDeleteLocked(
 							minTS = node.GetEnd()
 						} else {
 							end := node.GetEnd()
-							if minTS.Greater(&end) {
+							if minTS.Less(&end) {
 								minTS = node.GetEnd()
 							}
 						}

--- a/pkg/vm/engine/tae/tables/updates/mvcc.go
+++ b/pkg/vm/engine/tae/tables/updates/mvcc.go
@@ -910,9 +910,9 @@ func (n *MVCCHandle) CollectDeleteLocked(
 				if in {
 					it := node.mask.Iterator()
 					if node.IsAborted() {
-						it := node.mask.Iterator()
-						for it.HasNext() {
-							row := it.Next()
+						it2 := node.mask.Iterator()
+						for it2.HasNext() {
+							row := it2.Next()
 							nulls.Add(aborts, uint64(row))
 						}
 					}
@@ -940,7 +940,7 @@ func (n *MVCCHandle) CollectDeleteLocked(
 							minTS = node.GetEnd()
 						} else {
 							end := node.GetEnd()
-							if minTS.Less(&end) {
+							if minTS.Greater(&end) {
 								minTS = node.GetEnd()
 							}
 						}

--- a/pkg/vm/engine/tae/tables/updates/mvcc.go
+++ b/pkg/vm/engine/tae/tables/updates/mvcc.go
@@ -546,9 +546,10 @@ func (n *ObjectMVCCHandle) GetObject() any {
 }
 func (n *ObjectMVCCHandle) GetLatestDeltaloc(blkOffset uint16) objectio.Location {
 	mvcc := n.TryGetDeleteChain(blkOffset)
-	if mvcc == nil {
+	if mvcc == nil || mvcc.deltaloc == nil || mvcc.deltaloc.GetLatestNodeLocked() == nil {
 		return nil
 	}
+
 	return mvcc.deltaloc.GetLatestNodeLocked().BaseNode.DeltaLoc
 }
 func (n *ObjectMVCCHandle) GetLatestMVCCNode(blkOffset uint16) *catalog.MVCCNode[*catalog.MetadataMVCCNode] {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #24175

## What this PR does / why we need it:

This ports the CDC startup panic fix to `main`.

The same CN startup ordering race exists on `main`: HAKeeper heartbeat can create the task service and start the task runner before CN frontend startup has completed. A claimed CDC daemon task uses frontend internal executor very early in `retrieveCdcTask()`, but frontend server-level dependencies are not guaranteed to be initialized yet. That can dereference an uninitialized `Pu` and crash the CN during startup.

This PR keeps early task-service creation intact, but defers task-runner startup until CN startup has completed. It also makes `startTaskRunner()` tolerate the intermediate state where the holder exists but the task service has not been created yet.

Also included:
- a regression test that pins the task-runner readiness gate on `main`

## Validation

- `GOFLAGS='-mod=mod' go test ./pkg/cnservice -run 'Test_InitServer|Test_startTaskRunnerRequiresReadyAndHolder' -count=1`
- `GOFLAGS='-mod=mod' go test ./pkg/cnservice -count=1`