### PR TITLE
fix(malloc): harden pprof output for Pyroscope malloc profiles

### DIFF
--- a/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
+++ b/optools/mo_checkin_regression/mo_checkin_regression_tke.yaml
@@ -93,6 +93,10 @@ spec:
       logtail-collect-interval = "2ms"
       logtail-response-send-timeout = "10s"
       max-logtail-fetch-failure = 5
+      [malloc]
+      enable-metrics = true
+      full-stack-fraction = 10
+      mpool-profiling = true
       [observability]
       metricUpdateStorageUsageInterval = "15m"
       enableStmtMerge = true
@@ -189,6 +193,10 @@ spec:
       buffer-size = 100000
       flush-bytes = "64M"
       force-flush-duration = "60s"
+      [malloc]
+      enable-metrics = true
+      full-stack-fraction = 10
+      mpool-profiling = true
     replicas: 2
     nodeSelector:
       tke.matrixorigin.io/mo-checkin-regression: "true"

--- a/pkg/common/malloc/heap_profiler_pprof_test.go
+++ b/pkg/common/malloc/heap_profiler_pprof_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/pprof/profile"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeapProfilerWriteParsesAsPprof(t *testing.T) {
+	profiler := NewProfiler[HeapSampleValues]("malloc_test")
+
+	s := profiler.Sample(0, 1)
+	s.Objects.Allocated.Add(2)
+	s.Bytes.Allocated.Add(64)
+	s.Objects.Inuse.Add(1)
+	s.Bytes.Inuse.Add(32)
+
+	var buf bytes.Buffer
+	require.NoError(t, profiler.Write(&buf))
+
+	p, err := profile.Parse(&buf)
+	require.NoError(t, err)
+
+	require.NotNil(t, p.PeriodType)
+	require.Equal(t, "space", p.PeriodType.Type)
+	require.Equal(t, "bytes", p.PeriodType.Unit)
+	require.Equal(t, int64(512*1024), p.Period)
+	require.NotZero(t, p.TimeNanos)
+
+	require.Equal(t, "inuse_space", p.DefaultSampleType)
+	require.Len(t, p.SampleType, 4)
+	require.Equal(t, "alloc_objects", p.SampleType[0].Type)
+	require.Equal(t, "alloc_space", p.SampleType[1].Type)
+	require.Equal(t, "inuse_objects", p.SampleType[2].Type)
+	require.Equal(t, "inuse_space", p.SampleType[3].Type)
+
+	require.Len(t, p.Mapping, 1)
+	require.True(t, p.Mapping[0].HasFunctions)
+
+	for _, s := range p.Sample {
+		require.Len(t, s.Value, len(p.SampleType), "sample value length must match SampleType count")
+	}
+}

--- a/pkg/common/malloc/heap_profiler_pprof_test.go
+++ b/pkg/common/malloc/heap_profiler_pprof_test.go
@@ -36,6 +36,7 @@ func TestHeapProfilerWriteParsesAsPprof(t *testing.T) {
 
 	p, err := profile.Parse(&buf)
 	require.NoError(t, err)
+	require.NoError(t, p.CheckValid())
 
 	require.NotNil(t, p.PeriodType)
 	require.Equal(t, "space", p.PeriodType.Type)
@@ -52,6 +53,10 @@ func TestHeapProfilerWriteParsesAsPprof(t *testing.T) {
 
 	require.Len(t, p.Mapping, 1)
 	require.True(t, p.Mapping[0].HasFunctions)
+	for _, loc := range p.Location {
+		require.NotNil(t, loc.Mapping)
+		require.Equal(t, p.Mapping[0].ID, loc.Mapping.ID)
+	}
 
 	for _, s := range p.Sample {
 		require.Len(t, s.Value, len(p.SampleType), "sample value length must match SampleType count")

--- a/pkg/common/malloc/profile_allocator.go
+++ b/pkg/common/malloc/profile_allocator.go
@@ -42,25 +42,25 @@ func (h *HeapSampleValues) Init() {
 }
 
 func (h *HeapSampleValues) DefaultSampleType() string {
-	return "inuse_bytes"
+	return "inuse_space"
 }
 
 func (h *HeapSampleValues) SampleTypes() []*profile.ValueType {
 	return []*profile.ValueType{
 		{
-			Type: "allocated_objects",
-			Unit: "object",
+			Type: "alloc_objects",
+			Unit: "count",
 		},
 		{
-			Type: "allocated_bytes",
+			Type: "alloc_space",
 			Unit: "bytes",
 		},
 		{
 			Type: "inuse_objects",
-			Unit: "object",
+			Unit: "count",
 		},
 		{
-			Type: "inuse_bytes",
+			Type: "inuse_space",
 			Unit: "bytes",
 		},
 	}

--- a/pkg/common/malloc/profiler.go
+++ b/pkg/common/malloc/profiler.go
@@ -296,6 +296,7 @@ func (p *Profiler[T, P]) Write(w io.Writer) error {
 			HasFunctions: true,
 		}},
 	}
+	defaultMapping := prof.Mapping[0]
 
 	prof.Sample = append(prof.Sample, &profile.Sample{
 		Location: p.stackOmittedSample.Locations,
@@ -314,7 +315,7 @@ func (p *Profiler[T, P]) Write(w io.Writer) error {
 
 	p.locations.Range(func(k, v any) bool {
 		location := v.(*profile.Location)
-		prof.Location = append(prof.Location, copyLocation(location))
+		prof.Location = append(prof.Location, copyLocation(location, defaultMapping))
 		return true
 	})
 
@@ -332,8 +333,9 @@ func copyFunction(fn *profile.Function) *profile.Function {
 	return &ret
 }
 
-func copyLocation(location *profile.Location) *profile.Location {
+func copyLocation(location *profile.Location, mapping *profile.Mapping) *profile.Location {
 	ret := *location
 	ret.Line = slices.Clone(location.Line)
+	ret.Mapping = mapping
 	return &ret
 }

--- a/pkg/common/malloc/profiler.go
+++ b/pkg/common/malloc/profiler.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/pprof/profile"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
@@ -283,9 +284,16 @@ func (p *Profiler[T, P]) Write(w io.Writer) error {
 	prof := &profile.Profile{
 		SampleType:        ptr.SampleTypes(),
 		DefaultSampleType: ptr.DefaultSampleType(),
+		PeriodType: &profile.ValueType{
+			Type: "space",
+			Unit: "bytes",
+		},
+		Period:    512 * 1024,
+		TimeNanos: time.Now().UnixNano(),
 		Mapping: []*profile.Mapping{{
-			ID:   1,
-			File: p.name,
+			ID:           1,
+			File:         p.name,
+			HasFunctions: true,
 		}},
 	}
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/24222

## What this PR does / why we need it:

This PR hardens MatrixOne's custom `/debug/malloc` pprof output for Pyroscope ingestion.

Changes:
- rename malloc profile sample types to Go heap-style names:
  - `alloc_objects`
  - `alloc_space`
  - `inuse_objects`
  - `inuse_space`
- populate pprof metadata in `Profiler.Write`:
  - `PeriodType`
  - `Period`
  - `TimeNanos`
  - `Mapping.HasFunctions`
- explicitly bind every emitted `profile.Location` to the default `profile.Mapping`
- strengthen malloc pprof tests with:
  - `profile.Parse(...)`
  - `p.CheckValid()`
  - non-nil `Location.Mapping` assertions
- update regression TKE template to include `[malloc]` config for `tp` / `dn`

We previously observed that `/debug/malloc` was parseable by `go tool pprof`, and Pyroscope could discover `malloc` profile types, but agent/backend ingest could still fail with `nil pointer dereference`. The remaining MatrixOne-side compatibility gap appeared to be `Location.Mapping == nil` in the emitted profile.

Validation:
- malloc pprof round-trip/validity test added and strengthened
- isolated TKE validation using the forked build from this change
- `malloc` profile types visible in Pyroscope API
- CN/DN series queryable
- stacktrace/flamegraph data queryable
- previous nil-pointer ingest failure did not reproduce in short-window validation

Longer soak / overhead validation is handled separately in `mo-auto-test`.

