### PR TITLE
fix: narrow pessimistic insert table lock window

### DIFF
--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -203,6 +203,9 @@ func performLock(
 		if proc.GetTxnOperator().LockSkipped(target.tableID, target.mode) {
 			return nil
 		}
+		if target.lockTable && proc.GetTxnOperator().HasLockTable(target.tableID) {
+			continue
+		}
 		lockOp.logger.Debug("lock",
 			zap.Uint64("table", target.tableID),
 			zap.Bool("filter", target.filter != nil),

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -203,9 +203,6 @@ func performLock(
 		if proc.GetTxnOperator().LockSkipped(target.tableID, target.mode) {
 			return nil
 		}
-		if target.lockTable && proc.GetTxnOperator().HasLockTable(target.tableID) {
-			continue
-		}
 		lockOp.logger.Debug("lock",
 			zap.Uint64("table", target.tableID),
 			zap.Bool("filter", target.filter != nil),

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	txnpb "github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
-	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 	"github.com/matrixorigin/matrixone/pkg/vm"
@@ -63,34 +62,6 @@ var testFunc = func(
 var (
 	sid = ""
 )
-
-func TestPerformLockSkipsRepeatedTableLock(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	proc := testutil.NewProcess(t)
-	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
-	proc.Base.TxnOperator = txnOp
-
-	txnOp.EXPECT().LockSkipped(uint64(1), lock.LockMode_Exclusive).Return(false)
-	txnOp.EXPECT().HasLockTable(uint64(1)).Return(true)
-
-	arg := NewArgumentByEngine(nil)
-	arg.AddLockTarget(1, nil, 0, types.T_int32.ToType(), -1, -1, nil, false)
-	arg.LockTable(1, false)
-
-	bat := batch.NewWithSize(1)
-	vec := vector.NewVec(types.T_int32.ToType())
-	require.NoError(t, vector.AppendFixed(vec, int32(1), false, proc.Mp()))
-	bat.Vecs[0] = vec
-	bat.SetRowCount(1)
-	defer func() {
-		bat.Clean(proc.Mp())
-		arg.Free(proc, false, nil)
-	}()
-
-	require.NoError(t, performLock(bat, proc, arg, nil, -1))
-}
 
 func TestLockWithRetryReturnsBackendErrorWhenDeadlineExceededStopsBoundedRetry(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	txnpb "github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 	"github.com/matrixorigin/matrixone/pkg/vm"
@@ -62,6 +63,34 @@ var testFunc = func(
 var (
 	sid = ""
 )
+
+func TestPerformLockSkipsRepeatedTableLock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proc := testutil.NewProcess(t)
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	proc.Base.TxnOperator = txnOp
+
+	txnOp.EXPECT().LockSkipped(uint64(1), lock.LockMode_Exclusive).Return(false)
+	txnOp.EXPECT().HasLockTable(uint64(1)).Return(true)
+
+	arg := NewArgumentByEngine(nil)
+	arg.AddLockTarget(1, nil, 0, types.T_int32.ToType(), -1, -1, nil, false)
+	arg.LockTable(1, false)
+
+	bat := batch.NewWithSize(1)
+	vec := vector.NewVec(types.T_int32.ToType())
+	require.NoError(t, vector.AppendFixed(vec, int32(1), false, proc.Mp()))
+	bat.Vecs[0] = vec
+	bat.SetRowCount(1)
+	defer func() {
+		bat.Clean(proc.Mp())
+		arg.Free(proc, false, nil)
+	}()
+
+	require.NoError(t, performLock(bat, proc, arg, nil, -1))
+}
 
 func TestLockWithRetryReturnsBackendErrorWhenDeadlineExceededStopsBoundedRetry(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -534,6 +534,31 @@ func TestCallLockOpWithNoConflict(t *testing.T) {
 	)
 }
 
+func TestCallLockOpLocksTableAtEOFWhenNoRowsProduced(t *testing.T) {
+	tableID := uint64(10)
+	runLockOpTest(
+		t,
+		func(proc *process.Process) {
+			pkType := types.New(types.T_int32, 0, 0)
+			arg := NewArgumentByEngine(nil)
+			arg.OperatorBase.OperatorInfo = vm.OperatorInfo{
+				Idx:     0,
+				IsFirst: false,
+				IsLast:  false,
+			}
+			arg.AddLockTarget(tableID, nil, 0, pkType, -1, -1, nil, true)
+			arg.LockTable(tableID, false)
+			resetChildren(arg, nil)
+			defer arg.Free(proc, false, nil)
+
+			require.NoError(t, arg.Prepare(proc))
+			_, err := vm.Exec(arg, proc)
+			require.NoError(t, err)
+			require.True(t, proc.GetTxnOperator().HasLockTable(tableID))
+		},
+	)
+}
+
 func TestCallLockOpWithConflict(t *testing.T) {
 	tableID := uint64(10)
 	runLockNonBlockingOpTest(

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -770,8 +770,8 @@ func (c *Compile) shouldPrePipelineLockTable(target *plan.LockTarget) bool {
 	if qry == nil {
 		return true
 	}
-	// For INSERT ... SELECT, pre-run table locking stretches the lock hold window
-	// across the source scan. Keep the same table-lock semantics, but let LockOp
+	// For INSERT statements, pre-run table locking can stretch the target-table
+	// lock hold window. Keep the same table-lock semantics, but let LockOp
 	// acquire it when the first batch reaches the target pipeline.
 	return qry.StmtType != plan.Query_INSERT
 }

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -763,6 +763,7 @@ func (c *Compile) lockTable() error {
 }
 
 func (c *Compile) shouldPrePipelineLockTable(target *plan.LockTarget) bool {
+	target.LockTableAtTheEnd = false
 	if !target.LockTable {
 		return false
 	}
@@ -771,9 +772,14 @@ func (c *Compile) shouldPrePipelineLockTable(target *plan.LockTarget) bool {
 		return true
 	}
 	// For INSERT statements, pre-run table locking can stretch the target-table
-	// lock hold window. Keep the same table-lock semantics, but let LockOp
-	// acquire it when the first batch reaches the target pipeline.
-	return qry.StmtType != plan.Query_INSERT
+	// lock hold window. Keep the same table-lock semantics by letting LockOp
+	// acquire it when the first batch reaches the target pipeline and by
+	// falling back to EOF-time table locking if the child produces no rows.
+	if qry.StmtType == plan.Query_INSERT {
+		target.LockTableAtTheEnd = true
+		return false
+	}
+	return true
 }
 
 // func (c *Compile) compileAttachedScope(attachedPlan *plan.Plan) ([]*Scope, error) {

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -762,6 +762,20 @@ func (c *Compile) lockTable() error {
 	return nil
 }
 
+func (c *Compile) shouldPrePipelineLockTable(target *plan.LockTarget) bool {
+	if !target.LockTable {
+		return false
+	}
+	qry := c.pn.GetQuery()
+	if qry == nil {
+		return true
+	}
+	// For INSERT ... SELECT, pre-run table locking stretches the lock hold window
+	// across the source scan. Keep the same table-lock semantics, but let LockOp
+	// acquire it when the first batch reaches the target pipeline.
+	return qry.StmtType != plan.Query_INSERT
+}
+
 // func (c *Compile) compileAttachedScope(attachedPlan *plan.Plan) ([]*Scope, error) {
 // 	query := attachedPlan.Plan.(*plan.Plan_Query)
 // 	attachedScope, err := c.compileQuery(ctx, query.Query)
@@ -3629,7 +3643,7 @@ func (c *Compile) compileDelete(n *plan.Node, ss []*Scope) ([]*Scope, error) {
 func (c *Compile) compileLock(n *plan.Node, ss []*Scope) ([]*Scope, error) {
 	lockRows := make([]*plan.LockTarget, 0, len(n.LockTargets))
 	for _, tbl := range n.LockTargets {
-		if tbl.LockTable {
+		if c.shouldPrePipelineLockTable(tbl) {
 			c.lockTables[tbl.TableId] = tbl
 		} else {
 			if _, ok := c.lockTables[tbl.TableId]; !ok {

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -145,6 +145,31 @@ func TestNewCompileResetsStmtSnapshotTS(t *testing.T) {
 	require.True(t, c.proc.GetStmtSnapshotTS().IsEmpty())
 }
 
+func TestShouldPrePipelineLockTable(t *testing.T) {
+	c := NewMockCompile(t)
+	target := &plan.LockTarget{LockTable: true}
+
+	c.pn = &plan.Plan{
+		Plan: &plan.Plan_Query{
+			Query: &plan.Query{StmtType: plan.Query_INSERT},
+		},
+	}
+	require.False(t, c.shouldPrePipelineLockTable(target))
+
+	c.pn = &plan.Plan{
+		Plan: &plan.Plan_Query{
+			Query: &plan.Query{StmtType: plan.Query_UPDATE},
+		},
+	}
+	require.True(t, c.shouldPrePipelineLockTable(target))
+
+	c.pn = &plan.Plan{}
+	require.True(t, c.shouldPrePipelineLockTable(target))
+
+	target.LockTable = false
+	require.False(t, c.shouldPrePipelineLockTable(target))
+}
+
 func makeJoinColExpr(relPos, colPos int32, typ types.Type) *plan.Expr {
 	return &plan.Expr{
 		Typ: plan.Type{

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -155,19 +155,26 @@ func TestShouldPrePipelineLockTable(t *testing.T) {
 		},
 	}
 	require.False(t, c.shouldPrePipelineLockTable(target))
+	require.True(t, target.LockTableAtTheEnd)
 
+	target = &plan.LockTarget{LockTable: true}
 	c.pn = &plan.Plan{
 		Plan: &plan.Plan_Query{
 			Query: &plan.Query{StmtType: plan.Query_UPDATE},
 		},
 	}
 	require.True(t, c.shouldPrePipelineLockTable(target))
+	require.False(t, target.LockTableAtTheEnd)
 
+	target = &plan.LockTarget{LockTable: true}
 	c.pn = &plan.Plan{}
 	require.True(t, c.shouldPrePipelineLockTable(target))
+	require.False(t, target.LockTableAtTheEnd)
 
+	target = &plan.LockTarget{LockTable: false, LockTableAtTheEnd: true}
 	target.LockTable = false
 	require.False(t, c.shouldPrePipelineLockTable(target))
+	require.False(t, target.LockTableAtTheEnd)
 }
 
 func makeJoinColExpr(relPos, colPos int32, typ types.Type) *plan.Expr {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24200

## What this PR does / why we need it:

This PR narrows the lock hold window for pessimistic `INSERT ... SELECT ...` statements that were escalated to table locks. Before this change, `Compile.prePipelineInitializer()` acquired the target table lock before the source side of the pipeline started running, which let large source scans hold the target table lock for too long and block later writers.

The change keeps table-lock semantics intact but skips pre-pipeline table locking for `Query_INSERT`, allowing the existing `LockOp` in the execution pipeline to acquire the table lock closer to the actual write path. A focused compile test is added to lock the intended timing behavior.
