### PR TITLE
fix: avoid remote lock stale bind hangs

### DIFF
--- a/pkg/common/morpc/cfg.go
+++ b/pkg/common/morpc/cfg.go
@@ -161,6 +161,7 @@ func (c Config) NewServer(
 	}
 	opts = append(opts,
 		WithServerLogger(getLogger(sid).RawLogger().Named(name)),
+		WithServerMessageReleaseFunc(responseReleaseFunc),
 		WithServerGoettyOptions(goetty.WithSessionReleaseMsgFunc(func(v interface{}) {
 			m := v.(RPCMessage)
 			if !m.InternalMessage() {

--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -376,7 +376,16 @@ func (s *server) startWriteLoop(cs *clientSession) error {
 						f.Close()
 					}
 				}
-				for _, f := range responses {
+				failUnwritten := func(values []*Future, err error) {
+					for _, f := range values {
+						cs.releaseMessage(f.send)
+						f.messageSent(err)
+						if f.oneWay {
+							f.Close()
+						}
+					}
+				}
+				for idx, f := range responses {
 					s.metrics.writeLatencyDurationHistogram.Observe(start.Sub(f.send.createAt).Seconds())
 					if f.oneWay {
 						needClose = append(needClose, f)
@@ -422,6 +431,10 @@ func (s *server) startWriteLoop(cs *clientSession) error {
 							cs.releaseMessage(f.send)
 						}
 						f.messageSent(err)
+						for _, writtenFuture := range written {
+							writtenFuture.messageSent(err)
+						}
+						failUnwritten(responses[idx+1:], err)
 						closeNeedClose()
 						return
 					}

--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -623,6 +623,9 @@ func (cs *clientSession) cleanSend() {
 			}
 			cs.releaseMessage(f.send)
 			f.messageSent(backendClosed)
+			if f.oneWay {
+				f.Close()
+			}
 		default:
 			return
 		}

--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -413,7 +413,9 @@ func (s *server) startWriteLoop(cs *clientSession) error {
 						s.logger.Error("write response failed",
 							zap.Uint64("request-id", f.send.Message.GetID()),
 							zap.Error(err))
-						cs.releaseMessage(f.send)
+						if err == goetty.ErrIllegalState {
+							cs.releaseMessage(f.send)
+						}
 						f.messageSent(err)
 						return
 					}
@@ -619,6 +621,7 @@ func (cs *clientSession) cleanSend() {
 			if !ok {
 				return
 			}
+			cs.releaseMessage(f.send)
 			f.messageSent(backendClosed)
 		default:
 			return

--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -670,7 +670,15 @@ func (cs *clientSession) send(msg RPCMessage) (*Future, error) {
 	if !f.oneWay {
 		f.ref()
 	}
-	cs.c <- f
+	select {
+	case cs.c <- f:
+	case <-msg.Ctx.Done():
+		f.Close()
+		if !f.oneWay {
+			f.unRef()
+		}
+		return nil, msg.Ctx.Err()
+	}
 	cs.metrics.sendingQueueSizeGauge.Set(float64(len(cs.c)))
 	return f, nil
 }

--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -58,6 +58,14 @@ func WithServerGoettyOptions(options ...goetty.Option) ServerOption {
 	}
 }
 
+// WithServerMessageReleaseFunc sets the release callback used for responses
+// dropped before goetty takes ownership of them.
+func WithServerMessageReleaseFunc(release func(Message)) ServerOption {
+	return func(s *server) {
+		s.options.releaseMessageFunc = release
+	}
+}
+
 // WithServerBatchSendSize set the maximum number of messages to be sent together
 // at each batch. Default is 8.
 func WithServerBatchSendSize(size int) ServerOption {
@@ -107,6 +115,7 @@ type server struct {
 		bufferSize               int
 		batchSendSize            int
 		filter                   func(Message) bool
+		releaseMessageFunc       func(Message)
 		disableAutoCancelContext bool
 	}
 	pool struct {
@@ -369,17 +378,20 @@ func (s *server) startWriteLoop(cs *clientSession) error {
 					}
 
 					if !s.options.filter(f.send.Message) {
+						cs.releaseMessage(f.send)
 						f.messageSent(messageSkipped)
 						continue
 					}
 
 					if f.send.Timeout() {
+						cs.releaseMessage(f.send)
 						f.messageSent(f.send.Ctx.Err())
 						continue
 					}
 
 					v, err := f.send.GetTimeoutFromContext()
 					if err != nil {
+						cs.releaseMessage(f.send)
 						f.messageSent(err)
 						continue
 					}
@@ -401,6 +413,7 @@ func (s *server) startWriteLoop(cs *clientSession) error {
 						s.logger.Error("write response failed",
 							zap.Uint64("request-id", f.send.Message.GetID()),
 							zap.Error(err))
+						cs.releaseMessage(f.send)
 						f.messageSent(err)
 						return
 					}
@@ -463,7 +476,7 @@ func (s *server) getSession(rs goetty.IOSession) (*clientSession, error) {
 		return v.(*clientSession), nil
 	}
 
-	cs := newClientSession(s.metrics, rs, s.codec, s.newFuture)
+	cs := newClientSession(s.metrics, rs, s.codec, s.newFuture, s.options.releaseMessageFunc)
 	v, loaded := s.sessions.LoadOrStore(rs.ID(), cs)
 	if loaded {
 		close(cs.c)
@@ -531,6 +544,7 @@ type clientSession struct {
 	sentStreamSequences   sync.Map
 	cancel                context.CancelFunc
 	ctx                   context.Context
+	releaseMessageFunc    func(Message)
 	checkTimeoutCacheOnce sync.Once
 	closedC               chan struct{}
 	disconnectedC         chan struct{}
@@ -545,7 +559,8 @@ func newClientSession(
 	metrics *serverMetrics,
 	conn goetty.IOSession,
 	codec Codec,
-	newFutureFunc func() *Future) *clientSession {
+	newFutureFunc func() *Future,
+	releaseMessageFunc func(Message)) *clientSession {
 	ctx, cancel := context.WithCancel(context.Background())
 	cs := &clientSession{
 		metrics:                 metrics,
@@ -558,6 +573,7 @@ func newClientSession(
 		ctx:                     ctx,
 		cancel:                  cancel,
 		newFutureFunc:           newFutureFunc,
+		releaseMessageFunc:      releaseMessageFunc,
 	}
 	cs.mu.caches = make(map[uint64]cacheWithContext)
 	return cs
@@ -647,6 +663,7 @@ func (cs *clientSession) send(msg RPCMessage) (*Future, error) {
 
 	response := msg.Message
 	if err := cs.codec.Valid(response); err != nil {
+		cs.releaseMessage(msg)
 		return nil, err
 	}
 
@@ -654,6 +671,7 @@ func (cs *clientSession) send(msg RPCMessage) (*Future, error) {
 	defer cs.mu.RUnlock()
 
 	if cs.mu.closed {
+		cs.releaseMessage(msg)
 		return nil, moerr.NewClientClosedNoCtx()
 	}
 
@@ -673,6 +691,7 @@ func (cs *clientSession) send(msg RPCMessage) (*Future, error) {
 	select {
 	case cs.c <- f:
 	case <-msg.Ctx.Done():
+		cs.releaseMessage(msg)
 		f.Close()
 		if !f.oneWay {
 			f.unRef()
@@ -681,6 +700,13 @@ func (cs *clientSession) send(msg RPCMessage) (*Future, error) {
 	}
 	cs.metrics.sendingQueueSizeGauge.Set(float64(len(cs.c)))
 	return f, nil
+}
+
+func (cs *clientSession) releaseMessage(msg RPCMessage) {
+	if cs.releaseMessageFunc == nil || msg.InternalMessage() {
+		return
+	}
+	cs.releaseMessageFunc(msg.Message)
 }
 
 func (cs *clientSession) startCheckCacheTimeout() {

--- a/pkg/common/morpc/server.go
+++ b/pkg/common/morpc/server.go
@@ -371,6 +371,11 @@ func (s *server) startWriteLoop(cs *clientSession) error {
 
 				written := responses[:0]
 				timeout := time.Duration(0)
+				closeNeedClose := func() {
+					for _, f := range needClose {
+						f.Close()
+					}
+				}
 				for _, f := range responses {
 					s.metrics.writeLatencyDurationHistogram.Observe(start.Sub(f.send.createAt).Seconds())
 					if f.oneWay {
@@ -417,6 +422,7 @@ func (s *server) startWriteLoop(cs *clientSession) error {
 							cs.releaseMessage(f.send)
 						}
 						f.messageSent(err)
+						closeNeedClose()
 						return
 					}
 					written = append(written, f)
@@ -443,6 +449,7 @@ func (s *server) startWriteLoop(cs *clientSession) error {
 						ce.Write(fields...)
 					}
 					if err != nil {
+						closeNeedClose()
 						return
 					}
 				}
@@ -450,9 +457,7 @@ func (s *server) startWriteLoop(cs *clientSession) error {
 				for _, f := range written {
 					f.messageSent(nil)
 				}
-				for _, f := range needClose {
-					f.Close()
-				}
+				closeNeedClose()
 
 				s.metrics.writeDurationHistogram.Observe(time.Since(start).Seconds())
 			}

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -139,6 +139,32 @@ func TestHandleServerWriteWithClosedClientSession(t *testing.T) {
 	})
 }
 
+func TestClientSessionWriteReturnsWhenSendQueueFullAndContextExpires(t *testing.T) {
+	cs := newClientSession(
+		newServerMetrics("test"),
+		nil,
+		newTestCodec(),
+		func() *Future { return newFuture(nil) },
+	)
+	cs.c = make(chan *Future, 1)
+	cs.c <- newFuture(nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cs.Write(ctx, newTestMessage(1))
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("write blocked after context deadline")
+	}
+}
+
 func TestStreamServer(t *testing.T) {
 	testRPCServer(t, func(rs *server) {
 		ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -168,6 +168,28 @@ func TestClientSessionWriteReturnsWhenSendQueueFullAndContextExpires(t *testing.
 	}
 }
 
+func TestClientSessionCleanSendReleasesQueuedMessages(t *testing.T) {
+	released := 0
+	cs := newClientSession(
+		newServerMetrics("test"),
+		nil,
+		newTestCodec(),
+		func() *Future { return newFuture(nil) },
+		func(Message) { released++ },
+	)
+
+	f := newFuture(nil)
+	f.init(RPCMessage{
+		Ctx:     context.Background(),
+		Message: newTestMessage(1),
+		oneWay:  true,
+	})
+	cs.c <- f
+
+	cs.cleanSend()
+	require.Equal(t, 1, released)
+}
+
 func TestStreamServer(t *testing.T) {
 	testRPCServer(t, func(rs *server) {
 		ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -197,7 +198,7 @@ func TestClientSessionCleanSendReleasesQueuedMessages(t *testing.T) {
 
 func TestStartWriteLoopClosesOneWayFuturesOnWriteFailures(t *testing.T) {
 	run := func(t *testing.T, conn *testIOSession) {
-		futureReleased := 0
+		var futureReleased atomic.Int32
 		s := &server{
 			name:     "test",
 			metrics:  newServerMetrics("test"),
@@ -216,7 +217,7 @@ func TestStartWriteLoopClosesOneWayFuturesOnWriteFailures(t *testing.T) {
 			nil,
 		)
 
-		f := newFuture(func(*Future) { futureReleased++ })
+		f := newFuture(func(*Future) { futureReleased.Add(1) })
 		f.init(RPCMessage{
 			Ctx:     context.Background(),
 			Message: newTestMessage(1),
@@ -226,7 +227,7 @@ func TestStartWriteLoopClosesOneWayFuturesOnWriteFailures(t *testing.T) {
 
 		require.NoError(t, s.startWriteLoop(cs))
 		require.Eventually(t, func() bool {
-			return futureReleased == 1
+			return futureReleased.Load() == 1
 		}, time.Second, time.Millisecond*10)
 		s.stopper.Stop()
 	}

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -240,6 +240,58 @@ func TestStartWriteLoopClosesOneWayFuturesOnWriteFailures(t *testing.T) {
 	})
 }
 
+func TestStartWriteLoopCompletesBatchOnWriteFailure(t *testing.T) {
+	var released atomic.Int32
+	s := &server{
+		name:     "test",
+		metrics:  newServerMetrics("test"),
+		logger:   logutil.GetPanicLoggerWithLevel(zap.FatalLevel),
+		stopper:  stopper.NewStopper("test"),
+		sessions: &sync.Map{},
+	}
+	s.adjust()
+	s.options.batchSendSize = 3
+	defer s.stopper.Stop()
+
+	cs := newClientSession(
+		s.metrics,
+		newTestIOSessionWithWriteErrorAt(2, goetty.ErrIllegalState, nil),
+		newTestCodec(),
+		func() *Future { return newFuture(nil) },
+		func(Message) { released.Add(1) },
+	)
+
+	newSyncFuture := func(id uint64) *Future {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		t.Cleanup(cancel)
+		f := newFuture(nil)
+		f.init(RPCMessage{
+			Ctx:     ctx,
+			Message: newTestMessage(id),
+		})
+		f.ref()
+		t.Cleanup(f.Close)
+		return f
+	}
+	f1 := newSyncFuture(1)
+	f2 := newSyncFuture(2)
+	f3 := newSyncFuture(3)
+	cs.c <- f1
+	cs.c <- f2
+	cs.c <- f3
+
+	require.NoError(t, s.startWriteLoop(cs))
+	for _, f := range []*Future{f1, f2, f3} {
+		select {
+		case err := <-f.writtenC:
+			require.ErrorIs(t, err, goetty.ErrIllegalState)
+		case <-time.After(time.Second):
+			t.Fatalf("future %d was not completed after batch write failure", f.getSendMessageID())
+		}
+	}
+	require.Equal(t, int32(2), released.Load())
+}
+
 func TestStreamServer(t *testing.T) {
 	testRPCServer(t, func(rs *server) {
 		ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
@@ -283,16 +335,27 @@ func TestStreamServer(t *testing.T) {
 }
 
 type testIOSession struct {
-	out      *buf.ByteBuf
-	writeErr error
-	flushErr error
+	out        *buf.ByteBuf
+	writeErr   error
+	writeErrAt int32
+	writeCount atomic.Int32
+	flushErr   error
 }
 
 func newTestIOSession(writeErr, flushErr error) *testIOSession {
+	writeErrAt := int32(0)
+	if writeErr != nil {
+		writeErrAt = 1
+	}
+	return newTestIOSessionWithWriteErrorAt(writeErrAt, writeErr, flushErr)
+}
+
+func newTestIOSessionWithWriteErrorAt(writeErrAt int32, writeErr, flushErr error) *testIOSession {
 	return &testIOSession{
-		out:      buf.NewByteBuf(1),
-		writeErr: writeErr,
-		flushErr: flushErr,
+		out:        buf.NewByteBuf(1),
+		writeErr:   writeErr,
+		writeErrAt: writeErrAt,
+		flushErr:   flushErr,
 	}
 }
 
@@ -303,12 +366,17 @@ func (s *testIOSession) Disconnect() error                    { return nil }
 func (s *testIOSession) Close() error                         { s.out.Close(); return nil }
 func (s *testIOSession) Ref()                                 {}
 func (s *testIOSession) Read(goetty.ReadOptions) (any, error) { return nil, io.EOF }
-func (s *testIOSession) Write(any, goetty.WriteOptions) error { return s.writeErr }
-func (s *testIOSession) Flush(time.Duration) error            { return s.flushErr }
-func (s *testIOSession) RemoteAddress() string                { return "" }
-func (s *testIOSession) RawConn() net.Conn                    { return nil }
-func (s *testIOSession) UseConn(net.Conn)                     {}
-func (s *testIOSession) OutBuf() *buf.ByteBuf                 { return s.out }
+func (s *testIOSession) Write(any, goetty.WriteOptions) error {
+	if s.writeErr != nil && s.writeCount.Add(1) == s.writeErrAt {
+		return s.writeErr
+	}
+	return nil
+}
+func (s *testIOSession) Flush(time.Duration) error { return s.flushErr }
+func (s *testIOSession) RemoteAddress() string     { return "" }
+func (s *testIOSession) RawConn() net.Conn         { return nil }
+func (s *testIOSession) UseConn(net.Conn)          {}
+func (s *testIOSession) OutBuf() *buf.ByteBuf      { return s.out }
 
 func TestStreamServerWithCache(t *testing.T) {
 	testRPCServer(t, func(rs *server) {

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -17,12 +17,15 @@ package morpc
 import (
 	"context"
 	"io"
+	"net"
 	"os"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/fagongzi/goetty/v2"
+	"github.com/fagongzi/goetty/v2/buf"
+	"github.com/matrixorigin/matrixone/pkg/common/stopper"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -192,6 +195,50 @@ func TestClientSessionCleanSendReleasesQueuedMessages(t *testing.T) {
 	require.Equal(t, 1, futureReleased)
 }
 
+func TestStartWriteLoopClosesOneWayFuturesOnWriteFailures(t *testing.T) {
+	run := func(t *testing.T, conn *testIOSession) {
+		futureReleased := 0
+		s := &server{
+			name:     "test",
+			metrics:  newServerMetrics("test"),
+			logger:   logutil.GetPanicLoggerWithLevel(zap.FatalLevel),
+			stopper:  stopper.NewStopper("test"),
+			sessions: &sync.Map{},
+		}
+		s.adjust()
+		s.options.batchSendSize = 1
+
+		cs := newClientSession(
+			s.metrics,
+			conn,
+			newTestCodec(),
+			func() *Future { return newFuture(nil) },
+			nil,
+		)
+
+		f := newFuture(func(*Future) { futureReleased++ })
+		f.init(RPCMessage{
+			Ctx:     context.Background(),
+			Message: newTestMessage(1),
+			oneWay:  true,
+		})
+		cs.c <- f
+
+		require.NoError(t, s.startWriteLoop(cs))
+		require.Eventually(t, func() bool {
+			return futureReleased == 1
+		}, time.Second, time.Millisecond*10)
+		s.stopper.Stop()
+	}
+
+	t.Run("write error", func(t *testing.T) {
+		run(t, newTestIOSession(goetty.ErrIllegalState, nil))
+	})
+	t.Run("flush error", func(t *testing.T) {
+		run(t, newTestIOSession(nil, io.ErrClosedPipe))
+	})
+}
+
 func TestStreamServer(t *testing.T) {
 	testRPCServer(t, func(rs *server) {
 		ctx, cancel := context.WithTimeout(context.TODO(), time.Second*10)
@@ -233,6 +280,34 @@ func TestStreamServer(t *testing.T) {
 		wg.Wait()
 	})
 }
+
+type testIOSession struct {
+	out      *buf.ByteBuf
+	writeErr error
+	flushErr error
+}
+
+func newTestIOSession(writeErr, flushErr error) *testIOSession {
+	return &testIOSession{
+		out:      buf.NewByteBuf(1),
+		writeErr: writeErr,
+		flushErr: flushErr,
+	}
+}
+
+func (s *testIOSession) ID() uint64                           { return 1 }
+func (s *testIOSession) Connect(string, time.Duration) error  { return nil }
+func (s *testIOSession) Connected() bool                      { return true }
+func (s *testIOSession) Disconnect() error                    { return nil }
+func (s *testIOSession) Close() error                         { s.out.Close(); return nil }
+func (s *testIOSession) Ref()                                 {}
+func (s *testIOSession) Read(goetty.ReadOptions) (any, error) { return nil, io.EOF }
+func (s *testIOSession) Write(any, goetty.WriteOptions) error { return s.writeErr }
+func (s *testIOSession) Flush(time.Duration) error            { return s.flushErr }
+func (s *testIOSession) RemoteAddress() string                { return "" }
+func (s *testIOSession) RawConn() net.Conn                    { return nil }
+func (s *testIOSession) UseConn(net.Conn)                     {}
+func (s *testIOSession) OutBuf() *buf.ByteBuf                 { return s.out }
 
 func TestStreamServerWithCache(t *testing.T) {
 	testRPCServer(t, func(rs *server) {

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -140,11 +140,13 @@ func TestHandleServerWriteWithClosedClientSession(t *testing.T) {
 }
 
 func TestClientSessionWriteReturnsWhenSendQueueFullAndContextExpires(t *testing.T) {
+	released := 0
 	cs := newClientSession(
 		newServerMetrics("test"),
 		nil,
 		newTestCodec(),
 		func() *Future { return newFuture(nil) },
+		func(Message) { released++ },
 	)
 	cs.c = make(chan *Future, 1)
 	cs.c <- newFuture(nil)
@@ -160,6 +162,7 @@ func TestClientSessionWriteReturnsWhenSendQueueFullAndContextExpires(t *testing.
 	select {
 	case err := <-done:
 		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Equal(t, 1, released)
 	case <-time.After(time.Second):
 		t.Fatal("write blocked after context deadline")
 	}

--- a/pkg/common/morpc/server_test.go
+++ b/pkg/common/morpc/server_test.go
@@ -170,6 +170,7 @@ func TestClientSessionWriteReturnsWhenSendQueueFullAndContextExpires(t *testing.
 
 func TestClientSessionCleanSendReleasesQueuedMessages(t *testing.T) {
 	released := 0
+	futureReleased := 0
 	cs := newClientSession(
 		newServerMetrics("test"),
 		nil,
@@ -178,7 +179,7 @@ func TestClientSessionCleanSendReleasesQueuedMessages(t *testing.T) {
 		func(Message) { released++ },
 	)
 
-	f := newFuture(nil)
+	f := newFuture(func(*Future) { futureReleased++ })
 	f.init(RPCMessage{
 		Ctx:     context.Background(),
 		Message: newTestMessage(1),
@@ -188,6 +189,7 @@ func TestClientSessionCleanSendReleasesQueuedMessages(t *testing.T) {
 
 	cs.cleanSend()
 	require.Equal(t, 1, released)
+	require.Equal(t, 1, futureReleased)
 }
 
 func TestStreamServer(t *testing.T) {

--- a/pkg/lockservice/lock_table_keeper.go
+++ b/pkg/lockservice/lock_table_keeper.go
@@ -94,7 +94,6 @@ func (k *lockTableKeeper) keepRemoteLock(ctx context.Context) {
 	timer := time.NewTimer(k.keepRemoteLockInterval)
 	defer timer.Stop()
 
-	services := make(map[string]pb.LockTable)
 	var futures []*morpc.Future
 	var binds []pb.LockTable
 	for {
@@ -105,7 +104,6 @@ func (k *lockTableKeeper) keepRemoteLock(ctx context.Context) {
 			futures, binds = k.doKeepRemoteLock(
 				ctx,
 				futures,
-				services,
 				binds)
 			timer.Reset(k.keepRemoteLockInterval)
 		}
@@ -115,28 +113,24 @@ func (k *lockTableKeeper) keepRemoteLock(ctx context.Context) {
 func (k *lockTableKeeper) doKeepRemoteLock(
 	ctx context.Context,
 	futures []*morpc.Future,
-	services map[string]pb.LockTable,
 	binds []pb.LockTable) ([]*morpc.Future, []pb.LockTable) {
-	for k := range services {
-		delete(services, k)
-	}
 	binds = binds[:0]
 	futures = futures[:0]
 
 	k.groupTables.iter(func(_ uint64, v lockTable) bool {
 		bind := v.getBind()
 		if bind.ServiceID != k.serviceID {
-			services[bind.ServiceID] = bind
+			binds = append(binds, bind)
 		}
 		return true
 	})
-	if len(services) == 0 {
+	if len(binds) == 0 {
 		return futures[:0], binds[:0]
 	}
 
 	ctx, cancel := context.WithTimeoutCause(ctx, defaultRPCTimeout, moerr.CauseDoKeepRemoteLock)
 	defer cancel()
-	for _, bind := range services {
+	for _, bind := range binds {
 		req := acquireRequest()
 		defer releaseRequest(req)
 

--- a/pkg/lockservice/lock_table_keeper.go
+++ b/pkg/lockservice/lock_table_keeper.go
@@ -114,23 +114,24 @@ func (k *lockTableKeeper) doKeepRemoteLock(
 	ctx context.Context,
 	futures []*morpc.Future,
 	binds []pb.LockTable) ([]*morpc.Future, []pb.LockTable) {
+	allBinds := binds[:0]
 	binds = binds[:0]
 	futures = futures[:0]
 
 	k.groupTables.iter(func(_ uint64, v lockTable) bool {
 		bind := v.getBind()
 		if bind.ServiceID != k.serviceID {
-			binds = append(binds, bind)
+			allBinds = append(allBinds, bind)
 		}
 		return true
 	})
-	if len(binds) == 0 {
+	if len(allBinds) == 0 {
 		return futures[:0], binds[:0]
 	}
 
 	ctx, cancel := context.WithTimeoutCause(ctx, defaultRPCTimeout, moerr.CauseDoKeepRemoteLock)
 	defer cancel()
-	for _, bind := range binds {
+	for _, bind := range allBinds {
 		req := acquireRequest()
 		defer releaseRequest(req)
 

--- a/pkg/lockservice/lock_table_keeper_test.go
+++ b/pkg/lockservice/lock_table_keeper_test.go
@@ -107,7 +107,7 @@ func TestKeepBindFailedWillRemoveAllLocalLockTable(t *testing.T) {
 	runRPCTests(
 		t,
 		func(c Client, s Server) {
-			events := newWaiterEvents(1, nil, nil, nil, getLogger(""))
+			events := newWaiterEvents(1, nil, nil, time.Second, nil, getLogger(""))
 			defer events.close()
 
 			s.RegisterMethodHandler(

--- a/pkg/lockservice/orphan_txn_test.go
+++ b/pkg/lockservice/orphan_txn_test.go
@@ -210,6 +210,7 @@ func TestUnlockOrphanTxnWithServiceRestart(t *testing.T) {
 
 func TestUnlockOrphanTxnWhenBindHeartbeatMissing(t *testing.T) {
 	remoteLockTimeout := time.Millisecond * 200
+	activeTxns := [][]byte{[]byte("anchor"), []byte("holder"), []byte("waiter")}
 	runLockServiceTestsWithAdjustConfig(
 		t,
 		[]string{"s1", "s2"},
@@ -256,6 +257,13 @@ func TestUnlockOrphanTxnWhenBindHeartbeatMissing(t *testing.T) {
 		func(c *Config) {
 			c.RemoteLockTimeout.Duration = remoteLockTimeout
 			c.KeepRemoteLockDuration.Duration = time.Millisecond * 50
+			c.TxnIterFunc = func(f func([]byte) bool) {
+				for _, txn := range activeTxns {
+					if !f(txn) {
+						return
+					}
+				}
+			}
 		},
 	)
 }
@@ -307,6 +315,72 @@ func TestKeepRemoteLockRefreshesAllRemoteBinds(t *testing.T) {
 		func(c *Config) {
 			c.RemoteLockTimeout.Duration = remoteLockTimeout
 			c.KeepRemoteLockDuration.Duration = time.Millisecond * 50
+		},
+	)
+}
+
+func TestCannotUnlockStaleBindTxnWithCommittingInAllocator(t *testing.T) {
+	remoteLockTimeout := time.Millisecond * 200
+	activeTxns := [][]byte{[]byte("anchor"), []byte("holder"), []byte("waiter")}
+	runLockServiceTestsWithAdjustConfig(
+		t,
+		[]string{"s1", "s2"},
+		time.Second*10,
+		func(alloc *lockTableAllocator, s []*service) {
+			l1 := s[0]
+			l2 := s[1]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			anchorTxn := []byte("anchor")
+			holderTxn := []byte("holder")
+			waiterTxn := []byte("waiter")
+			table1 := uint64(1)
+			row1 := []byte{1}
+			row2 := []byte{2}
+
+			mustAddTestLock(t, ctx, l1, table1, anchorTxn, [][]byte{row2}, pb.Granularity_Row)
+			mustAddTestLock(t, ctx, l2, table1, holderTxn, [][]byte{row1}, pb.Granularity_Row)
+			alloc.getCtl(l2.GetServiceID()).add(string(holderTxn), committingState)
+
+			l2.tableGroups.removeWithFilter(func(id uint64, _ lockTable) bool {
+				return id == table1
+			})
+
+			doneC := make(chan struct{})
+			go func() {
+				defer close(doneC)
+				mustAddTestLock(t, ctx, l1, table1, waiterTxn, [][]byte{row1}, pb.Granularity_Row)
+			}()
+
+			select {
+			case <-doneC:
+				require.FailNow(t, "waiter txn was unlocked while holder txn was still committing")
+			case <-time.After(remoteLockTimeout * 3):
+			}
+
+			require.NotNil(t, l1.activeTxnHolder.getActiveTxn(holderTxn, false, ""))
+			require.NoError(t, l1.Unlock(ctx, holderTxn, timestamp.Timestamp{}))
+
+			select {
+			case <-doneC:
+			case <-ctx.Done():
+				require.FailNow(t, "waiter txn did not resume after holder unlock")
+			}
+
+			require.NoError(t, l1.Unlock(ctx, waiterTxn, timestamp.Timestamp{}))
+			require.NoError(t, l1.Unlock(ctx, anchorTxn, timestamp.Timestamp{}))
+		},
+		func(c *Config) {
+			c.RemoteLockTimeout.Duration = remoteLockTimeout
+			c.KeepRemoteLockDuration.Duration = time.Millisecond * 50
+			c.TxnIterFunc = func(f func([]byte) bool) {
+				for _, txn := range activeTxns {
+					if !f(txn) {
+						return
+					}
+				}
+			}
 		},
 	)
 }
@@ -770,4 +844,40 @@ func TestValidTxnWithInvalidRemoteTxnAndNotifyFoundCommitting(t *testing.T) {
 		},
 	).(*mapBasedTxnHolder)
 	require.True(t, hold.isValidRemoteTxn(pb.WaitTxn{TxnID: []byte{1}, CreatedOn: "s0"}))
+}
+
+func TestCanUnlockRemoteTxnWithNotifyOK(t *testing.T) {
+	hold := newMapBasedTxnHandler(
+		"s1",
+		getLogger(""),
+		newFixedSlicePool(16),
+		func(sid string) (bool, error) { return false, nil },
+		func(ot []pb.OrphanTxn) ([][]byte, error) { return nil, nil },
+		func(txn pb.WaitTxn) (bool, error) { return true, nil },
+	).(*mapBasedTxnHolder)
+	require.True(t, hold.canUnlockRemoteTxn(pb.WaitTxn{TxnID: []byte{1}, CreatedOn: "s0"}))
+}
+
+func TestCanUnlockRemoteTxnWithNotifyFailed(t *testing.T) {
+	hold := newMapBasedTxnHandler(
+		"s1",
+		getLogger(""),
+		newFixedSlicePool(16),
+		func(sid string) (bool, error) { return false, nil },
+		func(ot []pb.OrphanTxn) ([][]byte, error) { return nil, ErrLockConflict },
+		func(txn pb.WaitTxn) (bool, error) { return true, nil },
+	).(*mapBasedTxnHolder)
+	require.False(t, hold.canUnlockRemoteTxn(pb.WaitTxn{TxnID: []byte{1}, CreatedOn: "s0"}))
+}
+
+func TestCanUnlockRemoteTxnWithNotifyFoundCommitting(t *testing.T) {
+	hold := newMapBasedTxnHandler(
+		"s1",
+		getLogger(""),
+		newFixedSlicePool(16),
+		func(sid string) (bool, error) { return false, nil },
+		func(ot []pb.OrphanTxn) ([][]byte, error) { return [][]byte{{1}}, nil },
+		func(txn pb.WaitTxn) (bool, error) { return true, nil },
+	).(*mapBasedTxnHolder)
+	require.False(t, hold.canUnlockRemoteTxn(pb.WaitTxn{TxnID: []byte{1}, CreatedOn: "s0"}))
 }

--- a/pkg/lockservice/orphan_txn_test.go
+++ b/pkg/lockservice/orphan_txn_test.go
@@ -208,6 +208,109 @@ func TestUnlockOrphanTxnWithServiceRestart(t *testing.T) {
 	)
 }
 
+func TestUnlockOrphanTxnWhenBindHeartbeatMissing(t *testing.T) {
+	remoteLockTimeout := time.Millisecond * 200
+	runLockServiceTestsWithAdjustConfig(
+		t,
+		[]string{"s1", "s2"},
+		time.Second*10,
+		func(alloc *lockTableAllocator, s []*service) {
+			l1 := s[0]
+			l2 := s[1]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			anchorTxn := []byte("anchor")
+			holderTxn := []byte("holder")
+			waiterTxn := []byte("waiter")
+			table1 := uint64(1)
+			row1 := []byte{1}
+			row2 := []byte{2}
+
+			mustAddTestLock(t, ctx, l1, table1, anchorTxn, [][]byte{row2}, pb.Granularity_Row)
+			mustAddTestLock(t, ctx, l2, table1, holderTxn, [][]byte{row1}, pb.Granularity_Row)
+			require.NotNil(t, l1.activeTxnHolder.getActiveTxn(holderTxn, false, ""))
+
+			l2.tableGroups.removeWithFilter(func(id uint64, _ lockTable) bool {
+				return id == table1
+			})
+
+			doneC := make(chan struct{})
+			go func() {
+				defer close(doneC)
+				mustAddTestLock(t, ctx, l1, table1, waiterTxn, [][]byte{row1}, pb.Granularity_Row)
+			}()
+
+			select {
+			case <-doneC:
+			case <-ctx.Done():
+				require.FailNow(t, "waiter txn still blocked after bind heartbeat timeout")
+			}
+
+			require.Eventually(t, func() bool {
+				return l1.activeTxnHolder.getActiveTxn(holderTxn, false, "") == nil
+			}, time.Second*3, time.Millisecond*50)
+			require.NoError(t, l1.Unlock(ctx, waiterTxn, timestamp.Timestamp{}))
+			require.NoError(t, l1.Unlock(ctx, anchorTxn, timestamp.Timestamp{}))
+		},
+		func(c *Config) {
+			c.RemoteLockTimeout.Duration = remoteLockTimeout
+			c.KeepRemoteLockDuration.Duration = time.Millisecond * 50
+		},
+	)
+}
+
+func TestKeepRemoteLockRefreshesAllRemoteBinds(t *testing.T) {
+	remoteLockTimeout := time.Millisecond * 200
+	runLockServiceTestsWithAdjustConfig(
+		t,
+		[]string{"s1", "s2"},
+		time.Second*10,
+		func(alloc *lockTableAllocator, s []*service) {
+			l1 := s[0]
+			l2 := s[1]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			anchor1 := []byte("anchor1")
+			anchor2 := []byte("anchor2")
+			holder1 := []byte("holder1")
+			holder2 := []byte("holder2")
+			row1 := []byte{1}
+			row2 := []byte{2}
+			table1 := uint64(1)
+			table2 := uint64(2)
+
+			mustAddTestLock(t, ctx, l1, table1, anchor1, [][]byte{row2}, pb.Granularity_Row)
+			mustAddTestLock(t, ctx, l1, table2, anchor2, [][]byte{row2}, pb.Granularity_Row)
+			mustAddTestLock(t, ctx, l2, table1, holder1, [][]byte{row1}, pb.Granularity_Row)
+			mustAddTestLock(t, ctx, l2, table2, holder2, [][]byte{row1}, pb.Granularity_Row)
+
+			bind1 := l1.tableGroups.get(0, table1).getBind()
+			bind2 := l1.tableGroups.get(0, table2).getBind()
+
+			require.Eventually(t, func() bool {
+				return l1.activeTxnHolder.hasRemoteLockBind(l2.serviceID, bind1, remoteLockTimeout) &&
+					l1.activeTxnHolder.hasRemoteLockBind(l2.serviceID, bind2, remoteLockTimeout)
+			}, time.Second*3, time.Millisecond*50)
+
+			time.Sleep(remoteLockTimeout * 2)
+
+			require.True(t, l1.activeTxnHolder.hasRemoteLockBind(l2.serviceID, bind1, remoteLockTimeout))
+			require.True(t, l1.activeTxnHolder.hasRemoteLockBind(l2.serviceID, bind2, remoteLockTimeout))
+
+			require.NoError(t, l2.Unlock(ctx, holder1, timestamp.Timestamp{}))
+			require.NoError(t, l2.Unlock(ctx, holder2, timestamp.Timestamp{}))
+			require.NoError(t, l1.Unlock(ctx, anchor1, timestamp.Timestamp{}))
+			require.NoError(t, l1.Unlock(ctx, anchor2, timestamp.Timestamp{}))
+		},
+		func(c *Config) {
+			c.RemoteLockTimeout.Duration = remoteLockTimeout
+			c.KeepRemoteLockDuration.Duration = time.Millisecond * 50
+		},
+	)
+}
+
 func TestGetTimeoutRemoveTxn(t *testing.T) {
 	hold := newMapBasedTxnHandler(
 		"s1",

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -34,6 +34,7 @@ import (
 
 var (
 	defaultRPCTimeout          = time.Second * 10
+	defaultRPCWriteTimeout     = time.Second * 3
 	defaultHandleWorkers       = 12
 	defaultHandleGetTxnWorkers = 4
 )
@@ -450,6 +451,43 @@ func writeResponse(
 			zap.Error(err),
 			zap.String("response", detail))
 	}
+}
+
+func writeResponseWithDeadline(
+	logger *log.MOLogger,
+	cancel context.CancelFunc,
+	resp *pb.Response,
+	err error,
+	cs morpc.ClientSession,
+	timeout time.Duration,
+) error {
+	if cancel != nil {
+		defer cancel()
+	}
+
+	if err != nil {
+		resp.WrapError(err)
+	}
+	detail := ""
+	if logger.Enabled(zap.DebugLevel) {
+		detail = resp.DebugString()
+		logger.Debug("handle request completed",
+			zap.String("response", detail))
+	}
+
+	writeCtx, writeCancel := context.WithTimeout(context.Background(), timeout)
+	defer writeCancel()
+	if sessionCtx := cs.SessionCtx(); sessionCtx != nil {
+		stop := context.AfterFunc(sessionCtx, writeCancel)
+		defer stop()
+	}
+	if err := cs.Write(writeCtx, resp); err != nil {
+		logger.Error("write response failed",
+			zap.Error(err),
+			zap.String("response", detail))
+		return err
+	}
+	return nil
 }
 
 func (s *server) setupRemoteHandles(

--- a/pkg/lockservice/rpc.go
+++ b/pkg/lockservice/rpc.go
@@ -432,25 +432,7 @@ func writeResponse(
 	err error,
 	cs morpc.ClientSession,
 ) {
-	if cancel != nil {
-		defer cancel()
-	}
-
-	if err != nil {
-		resp.WrapError(err)
-	}
-	detail := ""
-	if logger.Enabled(zap.DebugLevel) {
-		detail = resp.DebugString()
-		logger.Debug("handle request completed",
-			zap.String("response", detail))
-	}
-	// after write, response will be released by rpc
-	if err := cs.AsyncWrite(resp); err != nil {
-		logger.Error("write response failed",
-			zap.Error(err),
-			zap.String("response", detail))
-	}
+	_ = writeResponseWithDeadline(logger, cancel, resp, err, cs, defaultRPCWriteTimeout)
 }
 
 func writeResponseWithDeadline(

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -79,6 +79,18 @@ func TestWriteResponseWithDeadlineUsesSyncWrite(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestWriteResponseUsesSyncWrite(t *testing.T) {
+	resp := acquireResponse()
+	defer releaseResponse(resp)
+
+	cs := &testClientSession{ctx: context.Background()}
+	writeResponse(getLogger(""), nil, resp, nil, cs)
+	require.True(t, cs.writeCalled)
+	require.False(t, cs.asyncCalled)
+	_, ok := cs.writeCtx.Deadline()
+	require.True(t, ok)
+}
+
 func TestRPCSend(t *testing.T) {
 	runRPCTests(
 		t,

--- a/pkg/lockservice/rpc_test.go
+++ b/pkg/lockservice/rpc_test.go
@@ -33,6 +33,52 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testClientSession struct {
+	ctx         context.Context
+	writeCtx    context.Context
+	writeErr    error
+	writeCalled bool
+	asyncCalled bool
+}
+
+func (s *testClientSession) Close() error { return nil }
+
+func (s *testClientSession) SessionCtx() context.Context { return s.ctx }
+
+func (s *testClientSession) Write(ctx context.Context, response morpc.Message) error {
+	s.writeCtx = ctx
+	s.writeCalled = true
+	return s.writeErr
+}
+
+func (s *testClientSession) AsyncWrite(response morpc.Message) error {
+	s.asyncCalled = true
+	return nil
+}
+
+func (s *testClientSession) CreateCache(ctx context.Context, cacheID uint64) (morpc.MessageCache, error) {
+	return nil, nil
+}
+
+func (s *testClientSession) DeleteCache(cacheID uint64) {}
+
+func (s *testClientSession) GetCache(cacheID uint64) (morpc.MessageCache, error) { return nil, nil }
+
+func (s *testClientSession) RemoteAddress() string { return "" }
+
+func TestWriteResponseWithDeadlineUsesSyncWrite(t *testing.T) {
+	resp := acquireResponse()
+	defer releaseResponse(resp)
+
+	cs := &testClientSession{ctx: context.Background()}
+	err := writeResponseWithDeadline(getLogger(""), nil, resp, nil, cs, time.Second)
+	require.NoError(t, err)
+	require.True(t, cs.writeCalled)
+	require.False(t, cs.asyncCalled)
+	_, ok := cs.writeCtx.Deadline()
+	require.True(t, ok)
+}
+
 func TestRPCSend(t *testing.T) {
 	runRPCTests(
 		t,

--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -114,7 +114,7 @@ func NewLockService(
 	s.clock = runtime.ServiceRuntime(cfg.ServiceID).Clock()
 
 	s.initRemote()
-	s.events = newWaiterEvents(eventsWorkers, s.deadlockDetector, s.activeTxnHolder, s.Unlock, s.logger)
+	s.events = newWaiterEvents(eventsWorkers, s.deadlockDetector, s.activeTxnHolder, s.cfg.RemoteLockTimeout.Duration, s.Unlock, s.logger)
 	s.events.start()
 	for i := 0; i < fetchWhoWaitingListTaskCount; i++ {
 		_ = s.stopper.RunTask(s.handleFetchWhoWaitingMe)
@@ -652,6 +652,8 @@ type activeTxnHolder interface {
 	hasActiveTxn(txnID []byte) bool
 	deleteActiveTxn(txnID []byte) *activeTxn
 	keepRemoteActiveTxn(remoteService string)
+	keepRemoteLockBindActive(remoteService string, bind pb.LockTable)
+	hasRemoteLockBind(remoteService string, bind pb.LockTable, maxKeepInterval time.Duration) bool
 	getTimeoutRemoveTxn(
 		timeoutServices map[string]struct{},
 		timeoutTxns [][]byte,
@@ -670,6 +672,8 @@ type mapBasedTxnHolder struct {
 		sync.RWMutex
 		// remoteServices known remote service
 		remoteServices map[string]*list.Element[remote]
+		// remoteLockBinds records the last heartbeat seen for a specific remote service + bind.
+		remoteLockBinds map[string]time.Time
 		// head(oldest) -> tail (newest)
 		dequeue           list.Deque[remote]
 		activeTxns        map[string]*activeTxn
@@ -695,6 +699,7 @@ func newMapBasedTxnHandler(
 	h.mu.activeTxns = make(map[string]*activeTxn, 1024)
 	h.mu.activeTxnServices = make(map[string]string)
 	h.mu.remoteServices = make(map[string]*list.Element[remote])
+	h.mu.remoteLockBinds = make(map[string]time.Time)
 	h.mu.dequeue = list.New[remote]()
 	return h
 }
@@ -795,6 +800,28 @@ func (h *mapBasedTxnHolder) keepRemoteActiveTxn(remoteService string) {
 	}
 }
 
+func (h *mapBasedTxnHolder) keepRemoteLockBindActive(remoteService string, bind pb.LockTable) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.mu.remoteLockBinds[getRemoteLockBindKey(remoteService, bind)] = time.Now()
+}
+
+func (h *mapBasedTxnHolder) hasRemoteLockBind(remoteService string, bind pb.LockTable, maxKeepInterval time.Duration) bool {
+	if remoteService == h.serviceID {
+		return true
+	}
+	h.mu.RLock()
+	lastSeen, ok := h.mu.remoteLockBinds[getRemoteLockBindKey(remoteService, bind)]
+	h.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	if maxKeepInterval <= 0 {
+		return true
+	}
+	return time.Since(lastSeen) < maxKeepInterval
+}
+
 func (h *mapBasedTxnHolder) getTimeoutRemoveTxn(
 	timeoutServices map[string]struct{},
 	needRemoved [][]byte,
@@ -806,6 +833,11 @@ func (h *mapBasedTxnHolder) getTimeoutRemoveTxn(
 	}
 	h.mu.Lock()
 	now := time.Now()
+	for key, lastSeen := range h.mu.remoteLockBinds {
+		if now.Sub(lastSeen) >= maxKeepInterval {
+			delete(h.mu.remoteLockBinds, key)
+		}
+	}
 	h.mu.dequeue.Iter(0, func(r remote) bool {
 		v := now.Sub(r.time)
 		if v < maxKeepInterval {
@@ -951,6 +983,10 @@ func getUUIDFromServiceIdentifier(id string) string {
 		return id
 	}
 	return id[19:]
+}
+
+func getRemoteLockBindKey(remoteService string, bind pb.LockTable) string {
+	return remoteService + "/" + bind.DebugString()
 }
 
 func ShardingByRow(row []byte) uint64 {

--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -656,6 +656,7 @@ type activeTxnHolder interface {
 	keepRemoteActiveTxn(remoteService string)
 	keepRemoteLockBindActive(remoteService string, bind pb.LockTable)
 	hasRemoteLockBind(remoteService string, bind pb.LockTable, maxKeepInterval time.Duration) bool
+	canUnlockRemoteTxn(pb.WaitTxn) bool
 	getTimeoutRemoveTxn(
 		timeoutServices map[string]struct{},
 		timeoutTxns [][]byte,
@@ -935,7 +936,13 @@ func (h *mapBasedTxnHolder) isValidRemoteTxn(txn pb.WaitTxn) bool {
 	if isRetryError(err) {
 		return true
 	}
+	return !h.canUnlockRemoteTxn(txn)
+}
 
+func (h *mapBasedTxnHolder) canUnlockRemoteTxn(txn pb.WaitTxn) bool {
+	if txn.CreatedOn == h.serviceID {
+		return false
+	}
 	cannotCommit := []pb.OrphanTxn{
 		{
 			Service: txn.CreatedOn,
@@ -945,11 +952,11 @@ func (h *mapBasedTxnHolder) isValidRemoteTxn(txn pb.WaitTxn) bool {
 
 	committing, err := h.notify(cannotCommit)
 	if err != nil {
-		// any error, we cannot make txn as a invalid txn
-		return true
+		// any error, we cannot determine that the txn is safe to unlock.
+		return false
 	}
-	// the target txn is committing, valid
-	return len(committing) != 0
+	// the target txn is safe to unlock only when TN confirms it is not committing.
+	return len(committing) == 0
 }
 
 func (h *mapBasedTxnHolder) close() {

--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"fmt"
 	"hash/crc64"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -986,7 +988,22 @@ func getUUIDFromServiceIdentifier(id string) string {
 }
 
 func getRemoteLockBindKey(remoteService string, bind pb.LockTable) string {
-	return remoteService + "/" + bind.DebugString()
+	var b strings.Builder
+	b.Grow(len(remoteService) + len(bind.ServiceID) + 64)
+	b.WriteString(remoteService)
+	b.WriteByte('/')
+	b.WriteString(strconv.FormatUint(uint64(bind.Group), 10))
+	b.WriteByte('/')
+	b.WriteString(strconv.FormatUint(bind.Table, 10))
+	b.WriteByte('/')
+	b.WriteString(strconv.FormatUint(bind.OriginTable, 10))
+	b.WriteByte('/')
+	b.WriteString(strconv.FormatUint(uint64(bind.Sharding), 10))
+	b.WriteByte('/')
+	b.WriteString(bind.ServiceID)
+	b.WriteByte('/')
+	b.WriteString(strconv.FormatUint(bind.Version, 10))
+	return b.String()
 }
 
 func ShardingByRow(row []byte) uint64 {

--- a/pkg/lockservice/service_forward_test.go
+++ b/pkg/lockservice/service_forward_test.go
@@ -51,8 +51,10 @@ func TestForwardLock(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.NotNil(t, l2.activeTxnHolder.getActiveTxn(txn1, false, ""))
-			require.NotNil(t, l2.activeTxnHolder.getActiveTxn(txn1, false, ""))
+			txn := l2.activeTxnHolder.getActiveTxn(txn1, false, "")
+			require.NotNil(t, txn)
+			require.Equal(t, l1.serviceID, txn.remoteService)
+			require.True(t, l2.activeTxnHolder.hasRemoteLockBind(l1.serviceID, l2.tableGroups.get(0, tableID).getBind(), time.Second))
 		},
 	)
 }

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -258,7 +258,9 @@ func (s *service) handleForwardLock(
 		return
 	}
 
-	txn := s.activeTxnHolder.getActiveTxn(req.Lock.TxnID, true, "")
+	s.activeTxnHolder.keepRemoteActiveTxn(req.Lock.ServiceID)
+	s.activeTxnHolder.keepRemoteLockBindActive(req.Lock.ServiceID, req.LockTable)
+	txn := s.activeTxnHolder.getActiveTxn(req.Lock.TxnID, true, req.Lock.ServiceID)
 	txn.Lock()
 	if !bytes.Equal(txn.txnID, req.Lock.TxnID) {
 		txn.Unlock()

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -184,7 +184,7 @@ func (s *service) handleRemoteLock(
 	resp *pb.Response,
 	cs morpc.ClientSession) {
 	if !s.canLockOnServiceStatus(req.Lock.TxnID, req.Lock.Options, req.LockTable.Table, req.Lock.Rows) {
-		writeResponse(s.logger, cancel, resp, moerr.NewRetryForCNRollingRestart(), cs)
+		_ = writeResponseWithDeadline(s.logger, cancel, resp, moerr.NewRetryForCNRollingRestart(), cs, defaultRPCWriteTimeout)
 		return
 	}
 
@@ -193,29 +193,31 @@ func (s *service) handleRemoteLock(
 		l == nil {
 		// means that the lockservice sending the lock request holds a stale
 		// lock table binding.
-		writeResponse(s.logger, cancel, resp, err, cs)
+		_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout)
 		return
 	}
+	s.activeTxnHolder.keepRemoteActiveTxn(req.Lock.ServiceID)
+	s.activeTxnHolder.keepRemoteLockBindActive(req.Lock.ServiceID, req.LockTable)
 
 	txn := s.activeTxnHolder.getActiveTxn(req.Lock.TxnID, true, req.Lock.ServiceID)
 	txn.Lock()
 	defer txn.Unlock()
 	if !bytes.Equal(txn.txnID, req.Lock.TxnID) {
-		writeResponse(s.logger, cancel, resp, ErrTxnNotFound, cs)
+		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrTxnNotFound, cs, defaultRPCWriteTimeout)
 		return
 	}
 	if txn.deadlockFound {
-		writeResponse(s.logger, cancel, resp, ErrDeadLockDetected, cs)
+		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrDeadLockDetected, cs, defaultRPCWriteTimeout)
 		return
 	}
 
-	var e error
+	var lockErr error
 	// it needs to inc table bind ref when set restart cn
 	h := txn.getHoldLocksLocked(l.getBind().Group)
 	_, hasBind := h.tableBinds[l.getBind().Table]
 	defer func() {
 		if s.isStatus(pb.Status_ServiceLockEnable) ||
-			e != nil ||
+			lockErr != nil ||
 			hasBind {
 			return
 		}
@@ -228,9 +230,9 @@ func (s *service) handleRemoteLock(
 		req.Lock.Rows,
 		LockOptions{LockOptions: req.Lock.Options, async: true},
 		func(result pb.Result, err error) {
-			e = err
+			lockErr = err
 			resp.Lock.Result = result
-			writeResponse(s.logger, cancel, resp, err, cs)
+			_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout)
 		})
 }
 
@@ -241,7 +243,7 @@ func (s *service) handleForwardLock(
 	resp *pb.Response,
 	cs morpc.ClientSession) {
 	if !s.canLockOnServiceStatus(req.Lock.TxnID, req.Lock.Options, req.LockTable.Table, req.Lock.Rows) {
-		writeResponse(s.logger, cancel, resp, moerr.NewRetryForCNRollingRestart(), cs)
+		_ = writeResponseWithDeadline(s.logger, cancel, resp, moerr.NewRetryForCNRollingRestart(), cs, defaultRPCWriteTimeout)
 		return
 	}
 
@@ -252,7 +254,7 @@ func (s *service) handleForwardLock(
 		l == nil {
 		// means that the lockservice sending the lock request holds a stale
 		// lock table binding.
-		writeResponse(s.logger, cancel, resp, err, cs)
+		_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout)
 		return
 	}
 
@@ -260,22 +262,22 @@ func (s *service) handleForwardLock(
 	txn.Lock()
 	if !bytes.Equal(txn.txnID, req.Lock.TxnID) {
 		txn.Unlock()
-		writeResponse(s.logger, cancel, resp, ErrTxnNotFound, cs)
+		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrTxnNotFound, cs, defaultRPCWriteTimeout)
 		return
 	}
 	if txn.deadlockFound {
 		txn.Unlock()
-		writeResponse(s.logger, cancel, resp, ErrDeadLockDetected, cs)
+		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrDeadLockDetected, cs, defaultRPCWriteTimeout)
 		return
 	}
 
-	var e error
+	var lockErr error
 	// it needs to inc table bind ref when set restart cn
 	h := txn.getHoldLocksLocked(l.getBind().Group)
 	_, hasBind := h.tableBinds[l.getBind().Table]
 	defer func() {
 		if s.isStatus(pb.Status_ServiceLockEnable) ||
-			e != nil ||
+			lockErr != nil ||
 			hasBind {
 			return
 		}
@@ -289,9 +291,9 @@ func (s *service) handleForwardLock(
 		LockOptions{LockOptions: req.Lock.Options, async: true},
 		func(result pb.Result, err error) {
 			txn.Unlock()
-			e = err
+			lockErr = err
 			resp.Lock.Result = result
-			writeResponse(s.logger, cancel, resp, err, cs)
+			_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout)
 		})
 }
 
@@ -402,6 +404,7 @@ func (s *service) handleKeepRemoteLock(
 	}
 
 	s.activeTxnHolder.keepRemoteActiveTxn(req.KeepRemoteLock.ServiceID)
+	s.activeTxnHolder.keepRemoteLockBindActive(req.KeepRemoteLock.ServiceID, req.LockTable)
 	writeResponse(s.logger, cancel, resp, nil, cs)
 }
 

--- a/pkg/lockservice/txn_test.go
+++ b/pkg/lockservice/txn_test.go
@@ -68,7 +68,7 @@ func TestLockAddedThatShouldFail(t *testing.T) {
 
 func TestClose(t *testing.T) {
 	reuse.RunReuseTests(func() {
-		events := newWaiterEvents(1, nil, nil, nil, getLogger(""))
+		events := newWaiterEvents(1, nil, nil, time.Second, nil, getLogger(""))
 		defer events.close()
 
 		id := []byte("t1")

--- a/pkg/lockservice/waiter_events.go
+++ b/pkg/lockservice/waiter_events.go
@@ -283,6 +283,12 @@ func (mw *waiterEvents) checkOrphan(v checkOrphan) {
 
 	for _, h := range holders {
 		if !mw.txnHolder.hasRemoteLockBind(h.CreatedOn, v.lt.bind, mw.remoteLockTimeout) {
+			if !mw.txnHolder.canUnlockRemoteTxn(h) {
+				mw.logger.Warn("found stale remote lock without bind heartbeat, but txn may still commit",
+					zap.String("bind", v.lt.bind.DebugString()),
+					bytesArrayField("txns", [][]byte{h.TxnID}))
+				continue
+			}
 			mw.logger.Warn("found stale remote lock without bind heartbeat",
 				zap.String("bind", v.lt.bind.DebugString()),
 				bytesArrayField("txns", [][]byte{h.TxnID}))

--- a/pkg/lockservice/waiter_events.go
+++ b/pkg/lockservice/waiter_events.go
@@ -109,14 +109,15 @@ func (e event) notified() {
 // waiterEvents is used to handle all notified waiters. And use a pool to retry the lock op,
 // to avoid too many goroutine blocked.
 type waiterEvents struct {
-	logger       *log.MOLogger
-	workers      int
-	detector     *detector
-	eventC       chan *lockContext
-	checkOrphanC chan checkOrphan
-	txnHolder    activeTxnHolder
-	unlock       func(ctx context.Context, txnID []byte, commitTS timestamp.Timestamp, mutations ...pb.ExtraMutation) error
-	stopper      *stopper.Stopper
+	logger            *log.MOLogger
+	workers           int
+	detector          *detector
+	eventC            chan *lockContext
+	checkOrphanC      chan checkOrphan
+	txnHolder         activeTxnHolder
+	remoteLockTimeout time.Duration
+	unlock            func(ctx context.Context, txnID []byte, commitTS timestamp.Timestamp, mutations ...pb.ExtraMutation) error
+	stopper           *stopper.Stopper
 
 	mu struct {
 		sync.RWMutex
@@ -128,18 +129,20 @@ func newWaiterEvents(
 	workers int,
 	detector *detector,
 	txnHolder activeTxnHolder,
+	remoteLockTimeout time.Duration,
 	unlock func(ctx context.Context, txnID []byte, commitTS timestamp.Timestamp, mutations ...pb.ExtraMutation) error,
 	logger *log.MOLogger,
 ) *waiterEvents {
 	return &waiterEvents{
-		logger:       logger,
-		workers:      workers,
-		detector:     detector,
-		txnHolder:    txnHolder,
-		unlock:       unlock,
-		eventC:       make(chan *lockContext, 10000),
-		checkOrphanC: make(chan checkOrphan, 64),
-		stopper:      stopper.NewStopper("waiter-events", stopper.WithLogger(logger.RawLogger())),
+		logger:            logger,
+		workers:           workers,
+		detector:          detector,
+		txnHolder:         txnHolder,
+		remoteLockTimeout: remoteLockTimeout,
+		unlock:            unlock,
+		eventC:            make(chan *lockContext, 10000),
+		checkOrphanC:      make(chan checkOrphan, 64),
+		stopper:           stopper.NewStopper("waiter-events", stopper.WithLogger(logger.RawLogger())),
 	}
 }
 
@@ -279,6 +282,13 @@ func (mw *waiterEvents) checkOrphan(v checkOrphan) {
 	}
 
 	for _, h := range holders {
+		if !mw.txnHolder.hasRemoteLockBind(h.CreatedOn, v.lt.bind, mw.remoteLockTimeout) {
+			mw.logger.Warn("found stale remote lock without bind heartbeat",
+				zap.String("bind", v.lt.bind.DebugString()),
+				bytesArrayField("txns", [][]byte{h.TxnID}))
+			_ = mw.unlock(context.Background(), h.TxnID, timestamp.Timestamp{})
+			continue
+		}
 		// When you have determined that a remote transaction is an orphaned transaction, you
 		// can release the lock that the remote transaction has placed on the current cn.
 		if !mw.txnHolder.isValidRemoteTxn(h) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24205

## What this PR does / why we need it:

- switch remote lock / forward lock result responses to bounded synchronous writes so the requester does not stay hung in `morpc.Future.Get()` after the owner has already taken the lock
- separate lock outcome from response write failure so bind ref retention still follows the real lock result
- track remote keepalive at bind granularity during orphan detection
- send `KeepRemoteLock` heartbeats per bind so multiple remote tables on the same peer are all refreshed
- add regression coverage for bounded response writes, stale bind cleanup, and multi-bind keepalive refresh
