### PR TITLE
fix(malloc): harden pprof output for Pyroscope on 3.0-dev

### DIFF
--- a/pkg/common/malloc/heap_profiler_pprof_test.go
+++ b/pkg/common/malloc/heap_profiler_pprof_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package malloc
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/pprof/profile"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeapProfilerWriteParsesAsPprof(t *testing.T) {
+	profiler := NewProfiler[HeapSampleValues]()
+
+	s := profiler.Sample(0, 1)
+	s.Objects.Allocated.Add(2)
+	s.Bytes.Allocated.Add(64)
+	s.Objects.Inuse.Add(1)
+	s.Bytes.Inuse.Add(32)
+
+	var buf bytes.Buffer
+	require.NoError(t, profiler.Write(&buf))
+
+	p, err := profile.Parse(&buf)
+	require.NoError(t, err)
+	require.NoError(t, p.CheckValid())
+
+	require.NotNil(t, p.PeriodType)
+	require.Equal(t, "space", p.PeriodType.Type)
+	require.Equal(t, "bytes", p.PeriodType.Unit)
+	require.Equal(t, int64(512*1024), p.Period)
+	require.NotZero(t, p.TimeNanos)
+
+	require.Equal(t, "inuse_space", p.DefaultSampleType)
+	require.Len(t, p.SampleType, 4)
+	require.Equal(t, "alloc_objects", p.SampleType[0].Type)
+	require.Equal(t, "alloc_space", p.SampleType[1].Type)
+	require.Equal(t, "inuse_objects", p.SampleType[2].Type)
+	require.Equal(t, "inuse_space", p.SampleType[3].Type)
+
+	require.Len(t, p.Mapping, 1)
+	require.True(t, p.Mapping[0].HasFunctions)
+	for _, loc := range p.Location {
+		require.NotNil(t, loc.Mapping)
+		require.Equal(t, p.Mapping[0].ID, loc.Mapping.ID)
+	}
+
+	for _, s := range p.Sample {
+		require.Len(t, s.Value, len(p.SampleType), "sample value length must match SampleType count")
+	}
+}

--- a/pkg/common/malloc/profile_allocator.go
+++ b/pkg/common/malloc/profile_allocator.go
@@ -42,25 +42,25 @@ func (h *HeapSampleValues) Init() {
 }
 
 func (h *HeapSampleValues) DefaultSampleType() string {
-	return "inuse_bytes"
+	return "inuse_space"
 }
 
 func (h *HeapSampleValues) SampleTypes() []*profile.ValueType {
 	return []*profile.ValueType{
 		{
-			Type: "allocated_objects",
-			Unit: "object",
+			Type: "alloc_objects",
+			Unit: "count",
 		},
 		{
-			Type: "allocated_bytes",
+			Type: "alloc_space",
 			Unit: "bytes",
 		},
 		{
 			Type: "inuse_objects",
-			Unit: "object",
+			Unit: "count",
 		},
 		{
-			Type: "inuse_bytes",
+			Type: "inuse_space",
 			Unit: "bytes",
 		},
 	}

--- a/pkg/common/malloc/profiler.go
+++ b/pkg/common/malloc/profiler.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/pprof/profile"
 	"github.com/matrixorigin/matrixone/pkg/common/util"
@@ -280,7 +281,19 @@ func (p *Profiler[T, P]) Write(w io.Writer) error {
 	prof := &profile.Profile{
 		SampleType:        ptr.SampleTypes(),
 		DefaultSampleType: ptr.DefaultSampleType(),
+		PeriodType: &profile.ValueType{
+			Type: "space",
+			Unit: "bytes",
+		},
+		Period:    512 * 1024,
+		TimeNanos: time.Now().UnixNano(),
+		Mapping: []*profile.Mapping{{
+			ID:           1,
+			File:         "malloc",
+			HasFunctions: true,
+		}},
 	}
+	defaultMapping := prof.Mapping[0]
 
 	prof.Sample = append(prof.Sample, &profile.Sample{
 		Location: p.stackOmittedSample.Locations,
@@ -299,7 +312,7 @@ func (p *Profiler[T, P]) Write(w io.Writer) error {
 
 	p.locations.Range(func(k, v any) bool {
 		location := v.(*profile.Location)
-		prof.Location = append(prof.Location, copyLocation(location))
+		prof.Location = append(prof.Location, copyLocation(location, defaultMapping))
 		return true
 	})
 
@@ -317,8 +330,9 @@ func copyFunction(fn *profile.Function) *profile.Function {
 	return &ret
 }
 
-func copyLocation(location *profile.Location) *profile.Location {
+func copyLocation(location *profile.Location, mapping *profile.Mapping) *profile.Location {
 	ret := *location
 	ret.Line = slices.Clone(location.Line)
+	ret.Mapping = mapping
 	return &ret
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24222

## What this PR does / why we need it:

Backport malloc pprof compatibility hardening to `3.0-dev` for Pyroscope ingestion.

Changes:
- rename malloc profile sample types to Go heap-style names:
  - `alloc_objects`
  - `alloc_space`
  - `inuse_objects`
  - `inuse_space`
- populate pprof metadata in `Profiler.Write`:
  - `PeriodType`
  - `Period`
  - `TimeNanos`
  - `Mapping.HasFunctions`
- explicitly bind every emitted `profile.Location` to the default `profile.Mapping`
- add a malloc pprof round-trip test with:
  - `profile.Parse(...)`
  - `p.CheckValid()`
  - non-nil `Location.Mapping` assertions

3.0-dev-specific notes:
- keep the existing `NewProfiler()` API on `3.0-dev`
- use a fixed mapping file name `malloc` instead of `p.name`
- do not update `optools/mo_checkin_regression/mo_checkin_regression_tke.yaml`; this PR is scoped to code-side compatibility only

Validation:
- `go test ./pkg/common/malloc/... -short`
