### PR TITLE
fix: restore load data pre-lock path

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -749,15 +749,24 @@ func (c *Compile) appendMetaTables(objRes *plan.ObjectRef) {
 }
 
 func (c *Compile) lockTable() error {
-	for _, tbl := range c.lockTables {
+	tableIDs := make([]uint64, 0, len(c.lockTables))
+	for tableID := range c.lockTables {
+		tableIDs = append(tableIDs, tableID)
+	}
+	sort.Slice(tableIDs, func(i, j int) bool {
+		return tableIDs[i] < tableIDs[j]
+	})
+	for _, tableID := range tableIDs {
+		tbl := c.lockTables[tableID]
 		typ := plan2.MakeTypeByPlan2Type(tbl.PrimaryColTyp)
-		return lockop.LockTable(
+		if err := lockop.LockTable(
 			c.e,
 			c.proc,
 			tbl.TableId,
 			typ,
-			false)
-
+			false); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -776,6 +785,11 @@ func (c *Compile) shouldPrePipelineLockTable(target *plan.LockTarget) bool {
 	// acquire it when the first batch reaches the target pipeline and by
 	// falling back to EOF-time table locking if the child produces no rows.
 	if qry.StmtType == plan.Query_INSERT {
+		// LOAD DATA always plans a table-locking LockOp. Keeping the pre-pipeline
+		// lock avoids retrying the same whole-table lock on every non-empty batch.
+		if qry.LoadTag {
+			return true
+		}
 		target.LockTableAtTheEnd = true
 		return false
 	}

--- a/pkg/sql/compile/compile_test.go
+++ b/pkg/sql/compile/compile_test.go
@@ -26,15 +26,20 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/common/system"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/lockservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
+	"github.com/matrixorigin/matrixone/pkg/txn/rpc"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/matrixorigin/matrixone/pkg/cnservice/cnclient"
 	"github.com/matrixorigin/matrixone/pkg/common/buffer"
@@ -160,6 +165,15 @@ func TestShouldPrePipelineLockTable(t *testing.T) {
 	target = &plan.LockTarget{LockTable: true}
 	c.pn = &plan.Plan{
 		Plan: &plan.Plan_Query{
+			Query: &plan.Query{StmtType: plan.Query_INSERT, LoadTag: true},
+		},
+	}
+	require.True(t, c.shouldPrePipelineLockTable(target))
+	require.False(t, target.LockTableAtTheEnd)
+
+	target = &plan.LockTarget{LockTable: true}
+	c.pn = &plan.Plan{
+		Plan: &plan.Plan_Query{
 			Query: &plan.Query{StmtType: plan.Query_UPDATE},
 		},
 	}
@@ -177,6 +191,61 @@ func TestShouldPrePipelineLockTable(t *testing.T) {
 	require.False(t, target.LockTableAtTheEnd)
 }
 
+func TestLockTableLocksAllPrePipelineTargets(t *testing.T) {
+	runtime.RunTest(
+		"",
+		func(rt runtime.Runtime) {
+			runtime.SetupServiceBasedRuntime("s1", rt)
+			lockservice.RunLockServicesForTest(
+				zap.DebugLevel,
+				[]string{"s1"},
+				time.Second,
+				func(_ lockservice.LockTableAllocator, services []lockservice.LockService) {
+					rt.SetGlobalVariables(runtime.LockService, services[0])
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+					defer cancel()
+
+					sender, err := rpc.NewSender(rpc.Config{}, rt)
+					require.NoError(t, err)
+
+					txnClient := client.NewTxnClient("", sender, client.WithLockService(services[0]))
+					txnClient.Resume()
+					defer func() {
+						require.NoError(t, txnClient.Close())
+					}()
+
+					txnOp, err := txnClient.New(ctx, timestamp.Timestamp{})
+					require.NoError(t, err)
+
+					proc := process.NewTopProcess(
+						ctx,
+						mpool.MustNewZero(),
+						txnClient,
+						txnOp,
+						nil,
+						services[0],
+						nil,
+						nil,
+						nil,
+						nil)
+					c := &Compile{
+						proc: proc,
+						lockTables: map[uint64]*plan.LockTarget{
+							10: {TableId: 10, PrimaryColTyp: plan.Type{Id: int32(types.T_int32)}},
+							11: {TableId: 11, PrimaryColTyp: plan.Type{Id: int32(types.T_int32)}},
+						},
+					}
+
+					require.NoError(t, c.lockTable())
+					require.True(t, txnOp.HasLockTable(10))
+					require.True(t, txnOp.HasLockTable(11))
+				},
+				nil,
+			)
+		},
+	)
+}
 func makeJoinColExpr(relPos, colPos int32, typ types.Type) *plan.Expr {
 	return &plan.Expr{
 		Typ: plan.Type{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24213

## What this PR does / why we need it:

PR #24201 moved Query_INSERT table locking off the pre-pipeline path. LOAD DATA is also planned as Query_INSERT and always carries a table-locking LockOp, so TPCH 1T load started taking that path too and the nightly load phase regressed noticeably after b79773d551.

This patch keeps the #24201 behavior for regular INSERT statements, but restores the pre-pipeline table lock for LOAD DATA only. That keeps the fix scope narrow and avoids changing unrelated INSERT paths again.

A compile test was added to lock the routing behavior between regular INSERT and LOAD DATA.
