### PR TITLE
fix: prune commit-ts filtering in block reads

### DIFF
--- a/pkg/objectio/ioutil/loadfuncs.go
+++ b/pkg/objectio/ioutil/loadfuncs.go
@@ -38,13 +38,30 @@ func LoadColumnsData(
 	m *mpool.MPool,
 	policy fileservice.Policy,
 ) (dataMeta objectio.ObjectDataMeta, release func(), err error) {
-	name := location.Name().UnsafeString()
 	var meta objectio.ObjectMeta
-	var vectors fileservice.IOVector
 	if meta, err = objectio.FastLoadObjectMeta(ctx, &location, false, fs); err != nil {
 		return
 	}
 	dataMeta = meta.MustGetMeta(objectio.SchemaData)
+	release, err = LoadColumnsWithMeta(ctx, columns, typs, fs, location, dataMeta, cacheVectors, m, policy)
+	return
+}
+
+// LoadColumnsWithMeta loads block columns using object metadata the caller has
+// already fetched.
+func LoadColumnsWithMeta(
+	ctx context.Context,
+	columns []uint16,
+	typs []types.Type,
+	fs fileservice.FileService,
+	location objectio.Location,
+	dataMeta objectio.ObjectDataMeta,
+	cacheVectors containers.Vectors, // cacheVectors.Allocated() must be 0
+	m *mpool.MPool,
+	policy fileservice.Policy,
+) (release func(), err error) {
+	name := location.Name().UnsafeString()
+	var vectors fileservice.IOVector
 	if vectors, err = objectio.ReadOneBlock(
 		ctx,
 		&dataMeta,
@@ -64,7 +81,7 @@ func LoadColumnsData(
 	}
 	for i := range columns {
 		if err = objectio.MustVectorTo(&cacheVectors[i], vectors.Entries[i].CachedData.Bytes()); err != nil {
-			logutil.Errorf("LoadColumnsData %s error: %v", location.String(), err.Error())
+			logutil.Errorf("LoadColumnsWithMeta %s error: %v", location.String(), err.Error())
 			release()
 			release = nil
 			return

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -802,6 +802,87 @@ func buildRowidColumn(
 	return
 }
 
+type commitTSFilterAction uint8
+
+const (
+	commitTSFilterNone commitTSFilterAction = iota
+	commitTSFilterAllRows
+	commitTSFilterByRow
+)
+
+func hiddenCommitTSColumn(blkMeta objectio.BlockObject) (objectio.ColumnMeta, bool) {
+	metaColCnt := blkMeta.GetMetaColumnCount()
+	if metaColCnt == 0 {
+		return nil, false
+	}
+	// CommitTS is a trailing special column; a visible user TS column must not
+	// be treated as row visibility metadata.
+	if int(metaColCnt) <= int(blkMeta.GetMaxSeqnum())+1 {
+		return nil, false
+	}
+	commitTSCol := blkMeta.ColumnMeta(metaColCnt - 1)
+	if commitTSCol.DataType() != uint8(types.T_TS) {
+		return nil, false
+	}
+	return commitTSCol, true
+}
+
+func planCommitTSFilter(blkMeta objectio.BlockObject, snapshotTS types.TS) commitTSFilterAction {
+	commitTSCol, ok := hiddenCommitTSColumn(blkMeta)
+	if !ok {
+		return commitTSFilterNone
+	}
+
+	zm := commitTSCol.ZoneMap()
+	if !zm.IsInited() || zm.GetType() != types.T_TS {
+		return commitTSFilterByRow
+	}
+	minTS := types.DecodeFixed[types.TS](zm.GetMinBuf())
+	maxTS := types.DecodeFixed[types.TS](zm.GetMaxBuf())
+	if !maxTS.GT(&snapshotTS) {
+		return commitTSFilterNone
+	}
+	if minTS.GT(&snapshotTS) {
+		return commitTSFilterAllRows
+	}
+	return commitTSFilterByRow
+}
+
+func buildFullDeleteMask(rowCount uint32) objectio.Bitmap {
+	if rowCount == 0 {
+		return objectio.NullBitmap
+	}
+	deletes := objectio.GetNoReuseBitmap()
+	deletes.Bitmap().AddRange(0, uint64(rowCount))
+	return deletes
+}
+
+func buildCommitTSDeleteMask(commits []types.TS, snapshotTS types.TS) objectio.Bitmap {
+	var deletes objectio.Bitmap
+	for i := range commits {
+		if !commits[i].GT(&snapshotTS) {
+			continue
+		}
+		if !deletes.IsValid() {
+			deletes = objectio.GetNoReuseBitmap()
+		}
+		deletes.Add(uint64(i))
+	}
+	return deletes
+}
+
+func loadObjectDataMeta(
+	ctx context.Context,
+	location objectio.Location,
+	fs fileservice.FileService,
+) (objectio.ObjectDataMeta, error) {
+	meta, err := objectio.FastLoadObjectMeta(ctx, &location, false, fs)
+	if err != nil {
+		return nil, err
+	}
+	return meta.MustGetMeta(objectio.SchemaData), nil
+}
+
 // This func load columns from storage of specified column indexes
 // No memory copy, the loaded data is directly stored in the cacheVectors
 // if `phyAddrColumnPos` >= 0, it means one of the columns is the physical address column,
@@ -835,24 +916,12 @@ func readBlockData(
 
 	idxes, typs := excludePhyAddrColumn(colIndexes, colTypes, phyAddrColumnPos)
 
-	blockHasCommitTS := func() (bool, error) {
-		if info.IsAppendable() {
-			return true, nil
-		}
-
-		location := info.MetaLocation()
-		meta, err2 := objectio.FastLoadObjectMeta(ctx, &location, false, fs)
-		if err2 != nil {
-			return false, err2
-		}
-		dataMeta := meta.MustGetMeta(objectio.SchemaData)
-		blkMeta := dataMeta.GetBlockMeta(uint32(info.MetaLocation().ID()))
-		metaColCnt := blkMeta.GetMetaColumnCount()
-		if metaColCnt == 0 {
-			return false, nil
-		}
-		return blkMeta.ColumnMeta(metaColCnt-1).DataType() == uint8(types.T_TS), nil
+	location := info.MetaLocation()
+	dataMeta, err := loadObjectDataMeta(ctx, location, fs)
+	if err != nil {
+		return
 	}
+	commitTSAction := planCommitTSFilter(dataMeta.GetBlockMeta(uint32(location.ID())), ts)
 
 	readColumns := func(
 		cols []uint16,
@@ -865,8 +934,8 @@ func readBlockData(
 			return
 		}
 
-		release2, err2 = ioutil.LoadColumns(
-			ctx, cols, typs2, fs, info.MetaLocation(), cacheVectors2, m, policy,
+		release2, err2 = ioutil.LoadColumnsWithMeta(
+			ctx, cols, typs2, fs, location, dataMeta, cacheVectors2, m, policy,
 		)
 		if err2 != nil {
 			return
@@ -886,25 +955,38 @@ func readBlockData(
 		if err2 != nil {
 			return
 		}
+		if dataRelease == nil {
+			dataRelease = func() {}
+		}
 
-		hasCommitTS, err2 := blockHasCommitTS()
-		if err2 != nil {
+		switch commitTSAction {
+		case commitTSFilterNone:
+			release = dataRelease
+			return
+		case commitTSFilterAllRows:
+			release = dataRelease
+			deletes = buildFullDeleteMask(info.MetaLocation().Rows())
+			return
+		case commitTSFilterByRow:
+		default:
 			if dataRelease != nil {
 				dataRelease()
 			}
-			return
-		}
-		if !hasCommitTS {
-			release = dataRelease
-			deletes = objectio.GetReusableBitmap()
+			err2 = moerr.NewInternalErrorNoCtxf("unknown commit ts filter action %d", commitTSAction)
 			return
 		}
 
 		commitTSVectors := containers.NewVectors(1)
-		releaseCommitTS, err2 := readColumns(
+		releaseCommitTS, err2 := ioutil.LoadColumnsWithMeta(
+			ctx,
 			[]uint16{objectio.SEQNUM_COMMITTS},
 			[]types.Type{types.T_TS.ToType()},
+			fs,
+			location,
+			dataMeta,
 			commitTSVectors,
+			m,
+			policy,
 		)
 		if err2 != nil {
 			if dataRelease != nil {
@@ -912,25 +994,14 @@ func readBlockData(
 			}
 			return
 		}
-
-		release = func() {
-			if releaseCommitTS != nil {
-				releaseCommitTS()
-			}
-			if dataRelease != nil {
-				dataRelease()
-			}
+		if releaseCommitTS != nil {
+			defer releaseCommitTS()
 		}
-
-		deletes = objectio.GetReusableBitmap()
+		release = dataRelease
 
 		t0 := time.Now()
 		commits := vector.MustFixedColWithTypeCheck[types.TS](&commitTSVectors[0])
-		for i := 0; i < len(commits); i++ {
-			if commits[i].GT(&ts) {
-				deletes.Add(uint64(i))
-			}
-		}
+		deletes = buildCommitTSDeleteMask(commits, ts)
 		logutil.Debugf(
 			"blockread %s scan filter cost %v: base %s filter out %v\n ",
 			info.BlockID.String(),

--- a/pkg/vm/engine/tae/blockio/read_test.go
+++ b/pkg/vm/engine/tae/blockio/read_test.go
@@ -428,6 +428,132 @@ func TestReadBlockDataFiltersNonAppendableByCommitTS(t *testing.T) {
 	require.Equal(t, []int32{11, 22, 33}, vals)
 }
 
+func TestReadBlockDataSkipsCommitTSFilterWhenSnapshotCoversBlock(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	writer := ioutil.ConstructWriter(
+		0,
+		[]uint16{0, objectio.SEQNUM_COMMITTS},
+		-1,
+		false,
+		false,
+		fs,
+	)
+
+	input := batch.NewWithSize(2)
+	input.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_TS.ToType())
+	for _, row := range []struct {
+		val int32
+		ts  types.TS
+	}{
+		{val: 11, ts: types.BuildTS(10, 0)},
+		{val: 22, ts: types.BuildTS(11, 0)},
+		{val: 33, ts: types.BuildTS(12, 0)},
+	} {
+		require.NoError(t, vector.AppendFixed(input.Vecs[0], row.val, false, mp))
+		require.NoError(t, vector.AppendFixed(input.Vecs[1], row.ts, false, mp))
+	}
+	input.SetRowCount(3)
+
+	_, err := writer.WriteBatch(input)
+	require.NoError(t, err)
+	blocks, _, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+
+	info := blocks[0].GenerateBlockInfo(writer.GetName(), false)
+	require.False(t, info.IsAppendable())
+
+	cacheVectors := containers.NewVectors(1)
+	deleteMask, release, err := readBlockData(
+		ctx,
+		[]uint16{0},
+		[]types.Type{types.T_int32.ToType()},
+		-1,
+		&info,
+		nil,
+		types.BuildTS(20, 0),
+		0,
+		cacheVectors,
+		mp,
+		fs,
+	)
+	require.NoError(t, err)
+	defer deleteMask.Release()
+	defer release()
+
+	require.False(t, deleteMask.IsValid())
+	vals := vector.MustFixedColWithTypeCheck[int32](&cacheVectors[0])
+	require.Equal(t, []int32{11, 22, 33}, vals)
+}
+
+func TestReadBlockDataDoesNotTreatVisibleTSColumnAsCommitTS(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	writer := ioutil.ConstructWriter(
+		0,
+		[]uint16{0, 1},
+		-1,
+		false,
+		false,
+		fs,
+	)
+
+	input := batch.NewWithSize(2)
+	input.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	input.Vecs[1] = vector.NewVec(types.T_TS.ToType())
+	for _, row := range []struct {
+		val int32
+		ts  types.TS
+	}{
+		{val: 11, ts: types.BuildTS(20, 0)},
+		{val: 22, ts: types.BuildTS(10, 0)},
+		{val: 33, ts: types.BuildTS(30, 0)},
+	} {
+		require.NoError(t, vector.AppendFixed(input.Vecs[0], row.val, false, mp))
+		require.NoError(t, vector.AppendFixed(input.Vecs[1], row.ts, false, mp))
+	}
+	input.SetRowCount(3)
+
+	_, err := writer.WriteBatch(input)
+	require.NoError(t, err)
+	blocks, _, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+
+	info := blocks[0].GenerateBlockInfo(writer.GetName(), false)
+	require.False(t, info.IsAppendable())
+
+	cacheVectors := containers.NewVectors(1)
+	deleteMask, release, err := readBlockData(
+		ctx,
+		[]uint16{0},
+		[]types.Type{types.T_int32.ToType()},
+		-1,
+		&info,
+		nil,
+		types.BuildTS(15, 0),
+		0,
+		cacheVectors,
+		mp,
+		fs,
+	)
+	require.NoError(t, err)
+	defer deleteMask.Release()
+	defer release()
+
+	require.False(t, deleteMask.IsValid())
+	vals := vector.MustFixedColWithTypeCheck[int32](&cacheVectors[0])
+	require.Equal(t, []int32{11, 22, 33}, vals)
+}
+
 func TestReadBlockDataNonAppendableWithoutCommitTS(t *testing.T) {
 	ctx := context.Background()
 	fs := testutil.NewSharedFS()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23751

## What this PR does / why we need it:

- avoid reading and scanning the hidden commit-ts column on every normal block read when block-level commit-ts zonemap proves the whole block is visible to the snapshot
- keep row-level commit-ts filtering for snapshot/data-branch fallback reads when the commit-ts range overlaps the requested snapshot
- avoid treating a user-visible trailing `TS` column as hidden commit-ts metadata
- reuse already loaded object metadata while loading block columns so the read path does not fetch the same metadata twice
- add blockio coverage for row-level filtering, zonemap fast path, and visible TS-column behavior

Validation:

- `gofmt` applied
- `git diff --check` passed
- `go test ./pkg/vm/engine/tae/blockio ./pkg/objectio/ioutil` could not complete in this local environment because CGO headers `usearch.h` and `xxhash.h` are missing before package tests run
