### PR TITLE
fix(function): optimize serial_extract for 3.0 (#24241)

### DIFF
--- a/etc/launch-multi-cn/tn.toml
+++ b/etc/launch-multi-cn/tn.toml
@@ -43,7 +43,7 @@ log-backend = "logservice"
 flush-interval = "60s"
 min-count = 100
 scan-interval = "5s"
-incremental-interval = "180s"
+incremental-interval = "60s"
 global-min-count = 60
 
 [tn.LogtailServer]

--- a/etc/launch-multi-cn/tn.toml
+++ b/etc/launch-multi-cn/tn.toml
@@ -43,7 +43,7 @@ log-backend = "logservice"
 flush-interval = "60s"
 min-count = 100
 scan-interval = "5s"
-incremental-interval = "60s"
+incremental-interval = "180s"
 global-min-count = 60
 
 [tn.LogtailServer]

--- a/pkg/container/types/tuple.go
+++ b/pkg/container/types/tuple.go
@@ -761,7 +761,7 @@ func UnpackNthElement(b []byte, n int) (any, T, error) {
 		i += off
 	}
 
-	return nil, 0, moerr.NewInternalErrorNoCtxf("index %d out of range", n)
+	return nil, 0, moerr.NewInternalErrorNoCtx("index out of range")
 }
 
 func StringifyTuple(b []byte, types []plan.Type) ([]string, error) {

--- a/pkg/container/types/tuple.go
+++ b/pkg/container/types/tuple.go
@@ -625,6 +625,145 @@ func UnpackWithSchema(b []byte) (Tuple, []T, error) {
 	return t, schema, err
 }
 
+// UnpackNthElement decodes only up to the nth element (0-based) and returns
+// just that element plus its type. This avoids deserializing the entire tuple
+// when only one element is needed, which is critical for performance in
+// GROUP BY serial_extract(__mo_index_idx_col, 0, VARCHAR) queries.
+func UnpackNthElement(b []byte, n int) (any, T, error) {
+	checkBytes := func(pos, need int) error {
+		if pos+need > len(b) {
+			return moerr.NewInternalErrorNoCtxf("insufficient bytes: need %d at position %d, but only %d bytes available", need, pos, len(b)-pos)
+		}
+		return nil
+	}
+
+	decodeWithOffset := func(i int, decodeFn func(byte, []byte) (any, int), code byte) (any, int, error) {
+		if err := checkBytes(i, 2); err != nil {
+			return nil, 0, err
+		}
+		el, off := decodeFn(code, b[i+1:])
+		return el, off + 1, nil
+	}
+
+	idx := 0
+	i := 0
+	for i < len(b) {
+		var el any
+		var off int
+		var err error
+		var schema T
+
+		switch b[i] {
+		case nilCode:
+			schema, el, off = T_any, nil, 1
+		case int8Code:
+			schema = T_int8
+			el, off, err = decodeWithOffset(i, decodeInt, int8Code)
+		case int16Code:
+			schema = T_int16
+			el, off, err = decodeWithOffset(i, decodeInt, int16Code)
+		case int32Code:
+			schema = T_int32
+			el, off, err = decodeWithOffset(i, decodeInt, int32Code)
+		case int64Code:
+			schema = T_int64
+			el, off, err = decodeWithOffset(i, decodeInt, int64Code)
+		case uint8Code:
+			schema = T_uint8
+			el, off, err = decodeWithOffset(i, decodeUint, uint8Code)
+		case uint16Code:
+			schema = T_uint16
+			el, off, err = decodeWithOffset(i, decodeUint, uint16Code)
+		case uint32Code:
+			schema = T_uint32
+			el, off, err = decodeWithOffset(i, decodeUint, uint32Code)
+		case uint64Code:
+			schema = T_uint64
+			el, off, err = decodeWithOffset(i, decodeUint, uint64Code)
+		case trueCode:
+			schema, el, off = T_bool, true, 1
+		case falseCode:
+			schema, el, off = T_bool, false, 1
+		case float32Code:
+			if err = checkBytes(i, 5); err != nil {
+				return nil, 0, err
+			}
+			schema = T_float32
+			el, off = decodeFloat32(b[i:])
+		case float64Code:
+			if err = checkBytes(i, 9); err != nil {
+				return nil, 0, err
+			}
+			schema = T_float64
+			el, off = decodeFloat64(b[i:])
+		case dateCode:
+			schema = T_date
+			el, off, err = decodeWithOffset(i, decodeInt, dateCode)
+		case datetimeCode:
+			schema = T_datetime
+			el, off, err = decodeWithOffset(i, decodeInt, datetimeCode)
+		case timestampCode:
+			schema = T_timestamp
+			el, off, err = decodeWithOffset(i, decodeInt, timestampCode)
+		case timeCode:
+			schema = T_time
+			el, off, err = decodeWithOffset(i, decodeInt, timeCode)
+		case decimal64Code:
+			if err = checkBytes(i, 9); err != nil {
+				return nil, 0, err
+			}
+			schema = T_decimal64
+			el, off = decodeDecimal64(b[i+1:])
+		case decimal128Code:
+			if err = checkBytes(i, 17); err != nil {
+				return nil, 0, err
+			}
+			schema = T_decimal128
+			el, off = decodeDecimal128(b[i+1:])
+		case stringTypeCode:
+			if err = checkBytes(i, 2); err != nil {
+				return nil, 0, err
+			}
+			schema = T_varchar
+			el, off = decodeBytes(b[i+1:])
+			off += 1
+		case bitCode:
+			schema = T_bit
+			el, off, err = decodeWithOffset(i, decodeUint, uint64Code)
+		case enumCode:
+			schema = T_enum
+			el, off, err = decodeWithOffset(i, decodeUint, uint16Code)
+		case uuidCode:
+			if err = checkBytes(i, 17); err != nil {
+				return nil, 0, err
+			}
+			schema = T_uuid
+			el, off = decodeUuid(b[i:])
+		case objectIdCode:
+			if err = checkBytes(i, 19); err != nil {
+				return nil, 0, err
+			}
+			schema = T_Objectid
+			el, off = decodeObjectid(b[i:])
+		default:
+			return nil, 0, moerr.NewInternalErrorNoCtxf("unable to decode tuple element with unknown typecode %02x", b[i])
+		}
+
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if idx == n {
+			return el, schema, nil
+		}
+
+		idx++
+		i += off
+	}
+
+	return nil, 0, moerr.NewInternalErrorNoCtxf("index %d out of range", n)
+}
+
 func StringifyTuple(b []byte, types []plan.Type) ([]string, error) {
 	items := make([]string, len(types))
 

--- a/pkg/container/types/tuple_test.go
+++ b/pkg/container/types/tuple_test.go
@@ -1083,3 +1083,73 @@ func TestDecodeTupleWithSchema(t *testing.T) {
 		})
 	}
 }
+
+func TestUnpackNthElement(t *testing.T) {
+	uuid, _ := BuildUuid()
+	tuple := Tuple{
+		[]byte("hello"),
+		int32(42),
+		true,
+		float64(3.14),
+		[]byte("world"),
+		uuid,
+	}
+
+	packer := NewPacker()
+	encodeBufToPacker(tuple, packer)
+	encoded := packer.GetBuf()
+
+	// Verify against full unpack
+	fullTuple, fullSchema, err := UnpackWithSchema(encoded)
+	require.NoError(t, err)
+
+	for i := 0; i < len(fullTuple); i++ {
+		el, schema, err := UnpackNthElement(encoded, i)
+		require.NoError(t, err, "UnpackNthElement(%d) should not error", i)
+		require.Equal(t, fullSchema[i], schema, "schema mismatch at index %d", i)
+		require.Equal(t, fullTuple[i], el, "value mismatch at index %d", i)
+	}
+
+	// Out of range
+	_, _, err = UnpackNthElement(encoded, len(fullTuple))
+	require.Error(t, err)
+
+	// Single element tuple
+	packer2 := NewPacker()
+	encodeBufToPacker(Tuple{[]byte("single")}, packer2)
+	el, schema, err := UnpackNthElement(packer2.GetBuf(), 0)
+	require.NoError(t, err)
+	require.Equal(t, T_varchar, schema)
+	require.Equal(t, []byte("single"), el)
+
+	// Multi-type tuple
+	packer3 := NewPacker()
+	encodeBufToPacker(Tuple{int32(7), int64(99)}, packer3)
+	el, schema, err = UnpackNthElement(packer3.GetBuf(), 0)
+	require.NoError(t, err)
+	require.Equal(t, T_int32, schema)
+	require.Equal(t, int32(7), el)
+
+	el2, schema2, err := UnpackNthElement(packer3.GetBuf(), 1)
+	require.NoError(t, err)
+	require.Equal(t, T_int64, schema2)
+	require.Equal(t, int64(99), el2)
+
+	// Decimal128 followed by string (regression: decodeDecimal128 offset was double-counted)
+	packer4 := NewPacker()
+	packer4.EncodeDecimal128(Decimal128{1, 0})
+	packer4.EncodeStringType([]byte("after_dec128"))
+	el3, schema3, err := UnpackNthElement(packer4.GetBuf(), 1)
+	require.NoError(t, err)
+	require.Equal(t, T_varchar, schema3)
+	require.Equal(t, []byte("after_dec128"), el3)
+
+	// Decimal64 followed by string
+	packer5 := NewPacker()
+	packer5.EncodeDecimal64(Decimal64(42))
+	packer5.EncodeStringType([]byte("after_decimal"))
+	el4, schema4, err := UnpackNthElement(packer5.GetBuf(), 1)
+	require.NoError(t, err)
+	require.Equal(t, T_varchar, schema4)
+	require.Equal(t, []byte("after_decimal"), el4)
+}

--- a/pkg/sql/plan/function/func_builtin.go
+++ b/pkg/sql/plan/function/func_builtin.go
@@ -1901,10 +1901,58 @@ func builtInSerialExtract(parameters []*vector.Vector, result vector.FunctionRes
 
 }
 
+// getConstInt64 checks if the parameter is a constant int64 value and returns it.
+func getConstInt64(p vector.FunctionParameterWrapper[int64]) (int64, bool) {
+	sv := p.GetSourceVector()
+	if sv.IsConst() && !sv.IsConstNull() {
+		v, _ := p.GetValue(0)
+		return v, true
+	}
+	return 0, false
+}
+
 func serialExtractExceptStrings[T types.Number | bool | types.Date | types.Datetime | types.Time | types.Timestamp](
 	p1 vector.FunctionParameterWrapper[types.Varlena],
 	p2 vector.FunctionParameterWrapper[int64],
 	result *vector.FunctionResult[T], proc *process.Process, length int, selectList *FunctionSelectList) error {
+
+	// Fast path: when p2 is constant, use UnpackNthElement to avoid full tuple deserialization
+	if p2.WithAnyNullValue() {
+		// fall through to slow path
+	} else if constIdx, isConst := getConstInt64(p2); isConst {
+		for i := uint64(0); i < uint64(length); i++ {
+			v1, null := p1.GetStrValue(i)
+			if null {
+				var nilVal T
+				if err := result.Append(nilVal, true); err != nil {
+					return err
+				}
+				continue
+			}
+
+			el, schema, err := types.UnpackNthElement(v1, int(constIdx))
+			if err != nil {
+				return err
+			}
+
+			if schema == types.T_any {
+				var nilVal T
+				if err = result.Append(nilVal, true); err != nil {
+					return err
+				}
+				continue
+			}
+
+			if value, ok := el.(T); ok {
+				if err := result.Append(value, false); err != nil {
+					return err
+				}
+			} else {
+				return moerr.NewInternalError(proc.Ctx, "provided type did not match the expected type")
+			}
+		}
+		return nil
+	}
 
 	for i := uint64(0); i < uint64(length); i++ {
 		v1, null := p1.GetStrValue(i)
@@ -1949,6 +1997,43 @@ func serialExtractExceptStrings[T types.Number | bool | types.Date | types.Datet
 func serialExtractForString(p1 vector.FunctionParameterWrapper[types.Varlena],
 	p2 vector.FunctionParameterWrapper[int64],
 	result *vector.FunctionResult[types.Varlena], proc *process.Process, length int, selectList *FunctionSelectList) error {
+
+	// Fast path: when p2 is constant, use UnpackNthElement to avoid full tuple deserialization
+	if p2.WithAnyNullValue() {
+		// fall through to slow path
+	} else if constIdx, isConst := getConstInt64(p2); isConst {
+		for i := uint64(0); i < uint64(length); i++ {
+			v1, null := p1.GetStrValue(i)
+			if null {
+				if err := result.AppendBytes(nil, true); err != nil {
+					return err
+				}
+				continue
+			}
+
+			el, schema, err := types.UnpackNthElement(v1, int(constIdx))
+			if err != nil {
+				return err
+			}
+
+			if schema == types.T_any {
+				if err = result.AppendBytes(nil, true); err != nil {
+					return err
+				}
+				continue
+			}
+
+			if value, ok := el.([]byte); ok {
+				if err := result.AppendBytes(value, false); err != nil {
+					return err
+				}
+			} else {
+				return moerr.NewInternalError(proc.Ctx, "provided type did not match the expected type")
+			}
+		}
+		return nil
+	}
+
 	for i := uint64(0); i < uint64(length); i++ {
 		v1, null := p1.GetStrValue(i)
 		v2, null2 := p2.GetValue(i)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #24241

## What this PR does / why we need it:
- Cherry-pick of #24246 to 3.0-dev branch
- Add `UnpackNthElement` to deserialize only the Nth element from a serialized tuple, avoiding full deserialization
- Add fast path in `serial_extract` for constant index parameter (the common case in DISTINCT queries on secondary index)
- **7.9x speedup** on DISTINCT queries over composite secondary index (14.9s → 1.9s aggregate phase on 5M rows)

## Adaptation for 3.0
- Removed `yearCode` case (not present in 3.0)
- Adapted nil test case (3.0 Packer has no `EncodeNull`)

## Test plan
- [x] Unit test `TestUnpackNthElement` passes
- [x] Local verification: 10M row table with 6-column composite index, DISTINCT aggregate 1209ms (vs ~15s without fix)
- [x] Builds successfully on 3.0-dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)