### PR TITLE
3.0: fix: protect data branch history with internal pitr

### DIFF
--- a/pkg/bootstrap/versions/v3_0_0/cluster_upgrade_list.go
+++ b/pkg/bootstrap/versions/v3_0_0/cluster_upgrade_list.go
@@ -25,7 +25,6 @@ import (
 
 var clusterUpgEntries = []versions.UpgradeEntry{
 	upg_mo_pitr,
-	upg_mo_pitr_add_kind,
 	upg_drop_mo_stored_procedure,
 	upg_create_mo_stored_procedure,
 	upg_create_mo_branch_metadata,
@@ -54,23 +53,6 @@ var upg_mo_pitr = versions.UpgradeEntry{
 			return true, nil
 		}
 		return false, nil
-	},
-}
-
-var upg_mo_pitr_add_kind = versions.UpgradeEntry{
-	Schema:    catalog.MO_CATALOG,
-	TableName: catalog.MO_PITR,
-	UpgType:   versions.ADD_COLUMN,
-	UpgSql: fmt.Sprintf(
-		"ALTER TABLE %s.%s ADD COLUMN kind varchar(32) not null default 'user' AFTER pitr_status_changed_time",
-		catalog.MO_CATALOG, catalog.MO_PITR,
-	),
-	CheckFunc: func(txn executor.TxnExecutor, accountId uint32) (bool, error) {
-		colInfo, err := versions.CheckTableColumn(txn, accountId, catalog.MO_CATALOG, catalog.MO_PITR, "kind")
-		if err != nil {
-			return false, err
-		}
-		return colInfo.IsExits, nil
 	},
 }
 

--- a/pkg/bootstrap/versions/v3_0_0/cluster_upgrade_list.go
+++ b/pkg/bootstrap/versions/v3_0_0/cluster_upgrade_list.go
@@ -25,6 +25,7 @@ import (
 
 var clusterUpgEntries = []versions.UpgradeEntry{
 	upg_mo_pitr,
+	upg_mo_pitr_add_kind,
 	upg_drop_mo_stored_procedure,
 	upg_create_mo_stored_procedure,
 	upg_create_mo_branch_metadata,
@@ -53,6 +54,23 @@ var upg_mo_pitr = versions.UpgradeEntry{
 			return true, nil
 		}
 		return false, nil
+	},
+}
+
+var upg_mo_pitr_add_kind = versions.UpgradeEntry{
+	Schema:    catalog.MO_CATALOG,
+	TableName: catalog.MO_PITR,
+	UpgType:   versions.ADD_COLUMN,
+	UpgSql: fmt.Sprintf(
+		"ALTER TABLE %s.%s ADD COLUMN kind varchar(32) not null default 'user' AFTER pitr_status_changed_time",
+		catalog.MO_CATALOG, catalog.MO_PITR,
+	),
+	CheckFunc: func(txn executor.TxnExecutor, accountId uint32) (bool, error) {
+		colInfo, err := versions.CheckTableColumn(txn, accountId, catalog.MO_CATALOG, catalog.MO_PITR, "kind")
+		if err != nil {
+			return false, err
+		}
+		return colInfo.IsExits, nil
 	},
 }
 

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -12372,7 +12372,7 @@ func TestCheckTimeStampValid(t *testing.T) {
 
 func Test_getSqlForCheckDupPitrFormat(t *testing.T) {
 	sql := getSqlForCheckDupPitrFormat(123, 456)
-	assert.Equal(t, "select pitr_id from mo_catalog.mo_pitr where create_account = 123 and obj_id = 456 and kind = 'user';", sql)
+	assert.Equal(t, "select pitr_id from mo_catalog.mo_pitr where create_account = 123 and obj_id = 456 and pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';", sql)
 }
 
 func Test_checkPitrDup(t *testing.T) {

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -12372,7 +12372,7 @@ func TestCheckTimeStampValid(t *testing.T) {
 
 func Test_getSqlForCheckDupPitrFormat(t *testing.T) {
 	sql := getSqlForCheckDupPitrFormat(123, 456)
-	assert.Equal(t, "select pitr_id from mo_catalog.mo_pitr where create_account = 123 and obj_id = 456 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';", sql)
+	assert.Equal(t, "select pitr_id from mo_catalog.mo_pitr where create_account = 123 and obj_id = 456 and kind = 'user';", sql)
 }
 
 func Test_checkPitrDup(t *testing.T) {

--- a/pkg/frontend/authenticate_test.go
+++ b/pkg/frontend/authenticate_test.go
@@ -12372,7 +12372,7 @@ func TestCheckTimeStampValid(t *testing.T) {
 
 func Test_getSqlForCheckDupPitrFormat(t *testing.T) {
 	sql := getSqlForCheckDupPitrFormat(123, 456)
-	assert.Equal(t, "select pitr_id from mo_catalog.mo_pitr where create_account = 123 and obj_id = 456;", sql)
+	assert.Equal(t, "select pitr_id from mo_catalog.mo_pitr where create_account = 123 and obj_id = 456 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';", sql)
 }
 
 func Test_checkPitrDup(t *testing.T) {

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -417,6 +417,10 @@ func dataBranchPitrName(level string, objectID string) string {
 	return fmt.Sprintf("%s_%s_%s", dataBranchPitrNamePrefix, level, objectID)
 }
 
+func quoteSQLIdentifier(s string) string {
+	return "`" + strings.ReplaceAll(s, "`", "``") + "`"
+}
+
 func dataBranchCloneTxn(ctx context.Context, bh BackgroundExec) (TxnOperator, error) {
 	be, ok := bh.(*backExec)
 	if !ok || be.backSes == nil || be.backSes.GetTxnHandler() == nil {
@@ -1270,8 +1274,12 @@ func dataBranchDeleteTable(
 
 	if sqlRet, err = runSql(
 		execCtx.reqCtx, ses, bh, fmt.Sprintf(
-			"select rel_id, reldatabase_id from %s.%s where account_id = %d and reldatabase = '%s' and relname = '%s'",
-			catalog.MO_CATALOG, catalog.MO_TABLES, accId, dbName, tblName,
+			"select rel_id, reldatabase_id from %s.%s where account_id = %d and reldatabase = %s and relname = %s",
+			catalog.MO_CATALOG,
+			catalog.MO_TABLES,
+			accId,
+			quoteSQLStringLiteral(string(dbName)),
+			quoteSQLStringLiteral(string(tblName)),
 		), nil, nil,
 	); err != nil {
 		return
@@ -1294,7 +1302,11 @@ func dataBranchDeleteTable(
 			dropRet.Close()
 		}()
 
-		dropSQL := fmt.Sprintf("drop table if exists `%s`.`%s`", dbName, tblName)
+		dropSQL := fmt.Sprintf(
+			"drop table if exists %s.%s",
+			quoteSQLIdentifier(string(dbName)),
+			quoteSQLIdentifier(string(tblName)),
+		)
 		if dropRet, err = runSql(execCtx.reqCtx, ses, bh, dropSQL, nil, nil); err != nil {
 			return
 		}
@@ -1353,8 +1365,11 @@ func dataBranchDeleteDatabase(
 
 	if sqlRet, err = runSql(
 		execCtx.reqCtx, ses, bh, fmt.Sprintf(
-			"select dat_id from %s.%s where account_id = %d and datname = '%s'",
-			catalog.MO_CATALOG, catalog.MO_DATABASE, accId, dbName,
+			"select dat_id from %s.%s where account_id = %d and datname = %s",
+			catalog.MO_CATALOG,
+			catalog.MO_DATABASE,
+			accId,
+			quoteSQLStringLiteral(string(dbName)),
 		), nil, nil,
 	); err != nil {
 		return
@@ -1372,8 +1387,11 @@ func dataBranchDeleteDatabase(
 
 	if sqlRet, err = runSql(
 		execCtx.reqCtx, ses, bh, fmt.Sprintf(
-			"select rel_id from %s.%s where account_id = %d and reldatabase = '%s'",
-			catalog.MO_CATALOG, catalog.MO_TABLES, accId, dbName,
+			"select rel_id from %s.%s where account_id = %d and reldatabase = %s",
+			catalog.MO_CATALOG,
+			catalog.MO_TABLES,
+			accId,
+			quoteSQLStringLiteral(string(dbName)),
 		), nil, nil,
 	); err != nil {
 		return
@@ -1394,7 +1412,7 @@ func dataBranchDeleteDatabase(
 			dropRet.Close()
 		}()
 
-		dropSQL := fmt.Sprintf("drop database if exists `%s`", dbName)
+		dropSQL := fmt.Sprintf("drop database if exists %s", quoteSQLIdentifier(string(dbName)))
 		if dropRet, err = runSql(execCtx.reqCtx, ses, bh, dropSQL, nil, nil); err != nil {
 			return
 		}

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -26,6 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -48,6 +49,31 @@ import (
 	"github.com/panjf2000/ants/v2"
 	"go.uber.org/zap"
 )
+
+const (
+	dataBranchPitrNamePrefix = "__mo_data_branch_pitr"
+	dataBranchPitrLength     = 1
+	dataBranchPitrUnit       = "y"
+	dataBranchPitrKind       = "internal"
+)
+
+type dataBranchPitrRecord struct {
+	pitrName     string
+	level        string
+	accountID    uint64
+	accountName  string
+	databaseName string
+	tableName    string
+	objectID     uint64
+}
+
+type dataBranchExistingPitrRecord struct {
+	exists     bool
+	kind       string
+	active     bool
+	pitrLength uint64
+	pitrUnit   string
+}
 
 func newBranchHashmapAllocator(limitRate float64) *branchHashmapAllocator {
 	throttler := rscthrottler.NewMemThrottler(
@@ -338,6 +364,10 @@ func dataBranchCreateTable(
 		return
 	}
 
+	if err = createDataBranchTablePitr(execCtx.reqCtx, ses, bh, receipt); err != nil {
+		return
+	}
+
 	return nil
 }
 
@@ -376,7 +406,821 @@ func dataBranchCreateDatabase(
 		}
 	}
 
+	if err = createDataBranchDatabasePitr(execCtx.reqCtx, ses, bh, &stmt.CloneDatabase, receipts); err != nil {
+		return
+	}
+
 	return nil
+}
+
+func dataBranchPitrName(level string, objectID string) string {
+	return fmt.Sprintf("%s_%s_%s", dataBranchPitrNamePrefix, level, objectID)
+}
+
+func dataBranchCloneTxn(ctx context.Context, bh BackgroundExec) (TxnOperator, error) {
+	be, ok := bh.(*backExec)
+	if !ok || be.backSes == nil || be.backSes.GetTxnHandler() == nil {
+		return nil, moerr.NewInternalError(ctx, "data branch pitr requires background transaction")
+	}
+	return be.backSes.GetTxnHandler().GetTxn(), nil
+}
+
+func createDataBranchTablePitr(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	receipt cloneReceipt,
+) error {
+	if receipt.dstDb == "" || receipt.dstTbl == "" {
+		return moerr.NewInternalError(ctx, "data branch table pitr requires target table")
+	}
+
+	cloneTxnOp, err := dataBranchCloneTxn(ctx, bh)
+	if err != nil {
+		return err
+	}
+	if err = createDataBranchTablePitrForTarget(
+		ctx, ses, bh, cloneTxnOp, receipt.toAccount, receipt.dstDb, receipt.dstTbl, "target",
+	); err != nil {
+		return err
+	}
+	if receipt.srcDb == "" || receipt.srcTbl == "" {
+		return nil
+	}
+	return createDataBranchTablePitrForTarget(
+		ctx, ses, bh, cloneTxnOp, receipt.srcAccount, receipt.srcDb, receipt.srcTbl, "source",
+	)
+}
+
+func createDataBranchDatabasePitr(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	stmt *tree.CloneDatabase,
+	receipts []cloneReceipt,
+) error {
+	if stmt == nil {
+		return moerr.NewInternalError(ctx, "data branch database pitr requires clone database statement")
+	}
+
+	var (
+		toAccountID  uint32
+		srcAccountID uint32
+		err          error
+	)
+	if len(receipts) > 0 {
+		toAccountID = receipts[0].toAccount
+		srcAccountID = receipts[0].srcAccount
+	} else {
+		var snapshot *plan2.Snapshot
+		srcAccountID, toAccountID, snapshot, err = getOpAndToAccountId(
+			ctx, ses, bh, stmt.ToAccountOpt, stmt.AtTsExpr,
+		)
+		if err != nil {
+			return err
+		}
+		if snapshot != nil && snapshot.Tenant != nil {
+			srcAccountID = snapshot.Tenant.TenantID
+		}
+	}
+
+	dstDb := stmt.DstDatabase.String()
+	if dstDb == "" {
+		return moerr.NewInternalError(ctx, "data branch database pitr requires target database")
+	}
+	cloneTxnOp, err := dataBranchCloneTxn(ctx, bh)
+	if err != nil {
+		return err
+	}
+	if err = createDataBranchDatabasePitrForTarget(
+		ctx, ses, bh, cloneTxnOp, toAccountID, dstDb, "target",
+	); err != nil {
+		return err
+	}
+
+	srcDb := stmt.SrcDatabase.String()
+	if len(receipts) > 0 && receipts[0].srcDb != "" {
+		srcDb = receipts[0].srcDb
+	}
+	if srcDb == "" {
+		return nil
+	}
+	return createDataBranchDatabasePitrForTarget(
+		ctx, ses, bh, cloneTxnOp, srcAccountID, srcDb, "source",
+	)
+}
+
+func createDataBranchTablePitrForTarget(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	cloneTxnOp TxnOperator,
+	accountID uint32,
+	dbName string,
+	tableName string,
+	role string,
+) error {
+	tableID, err := dataBranchTableID(ctx, ses, cloneTxnOp, accountID, dbName, tableName)
+	if err != nil {
+		return err
+	}
+	pitrName := dataBranchPitrName("table", strconv.FormatUint(tableID, 10))
+	accountName, err := dataBranchPitrAccountName(ctx, ses, bh, accountID)
+	if err != nil {
+		return err
+	}
+	logutil.Info(
+		"DataBranch-CreatePITR-Table",
+		zap.String("role", role),
+		zap.String("pitr-name", pitrName),
+		zap.Uint64("table-id", tableID),
+		zap.Uint32("account-id", accountID),
+		zap.String("database", dbName),
+		zap.String("table", tableName),
+	)
+	return createDataBranchPitrRecord(ctx, ses, bh, cloneTxnOp, dataBranchPitrRecord{
+		pitrName:     pitrName,
+		level:        tree.PITRLEVELTABLE.String(),
+		accountID:    uint64(accountID),
+		accountName:  accountName,
+		databaseName: dbName,
+		tableName:    tableName,
+		objectID:     tableID,
+	})
+}
+
+func createDataBranchDatabasePitrForTarget(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	cloneTxnOp TxnOperator,
+	accountID uint32,
+	dbName string,
+	role string,
+) error {
+	databaseID, err := dataBranchDatabaseID(ctx, ses, cloneTxnOp, accountID, dbName)
+	if err != nil {
+		return err
+	}
+	pitrName := dataBranchPitrName("database", strconv.FormatUint(databaseID, 10))
+	accountName, err := dataBranchPitrAccountName(ctx, ses, bh, accountID)
+	if err != nil {
+		return err
+	}
+	logutil.Info(
+		"DataBranch-CreatePITR-Database",
+		zap.String("role", role),
+		zap.String("pitr-name", pitrName),
+		zap.Uint64("database-id", databaseID),
+		zap.Uint32("account-id", accountID),
+		zap.String("database", dbName),
+	)
+	return createDataBranchPitrRecord(ctx, ses, bh, cloneTxnOp, dataBranchPitrRecord{
+		pitrName:     pitrName,
+		level:        tree.PITRLEVELDATABASE.String(),
+		accountID:    uint64(accountID),
+		accountName:  accountName,
+		databaseName: dbName,
+		objectID:     databaseID,
+	})
+}
+
+func dataBranchDatabaseID(
+	ctx context.Context,
+	ses *Session,
+	cloneTxnOp TxnOperator,
+	accountID uint32,
+	dbName string,
+) (uint64, error) {
+	dbCtx := defines.AttachAccountId(ctx, accountID)
+	db, err := ses.proc.GetSessionInfo().StorageEngine.Database(dbCtx, dbName, cloneTxnOp)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(db.GetDatabaseId(dbCtx), 10, 64)
+}
+
+func dataBranchTableID(
+	ctx context.Context,
+	ses *Session,
+	cloneTxnOp TxnOperator,
+	accountID uint32,
+	dbName string,
+	tableName string,
+) (uint64, error) {
+	dbCtx := defines.AttachAccountId(ctx, accountID)
+	db, err := ses.proc.GetSessionInfo().StorageEngine.Database(dbCtx, dbName, cloneTxnOp)
+	if err != nil {
+		return 0, err
+	}
+	rel, err := db.Relation(dbCtx, tableName, nil)
+	if err != nil {
+		return 0, err
+	}
+	return rel.GetTableDef(dbCtx).TblId, nil
+}
+
+func dataBranchPitrAccountName(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	accountID uint32,
+) (string, error) {
+	if accountID == sysAccountID {
+		return sysAccountName, nil
+	}
+	if tenantInfo := ses.GetTenantInfo(); tenantInfo != nil && accountID == tenantInfo.GetTenantID() {
+		return tenantInfo.GetTenant(), nil
+	}
+
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	sql := fmt.Sprintf(
+		"select account_name from mo_catalog.mo_account where account_id = %d",
+		accountID,
+	)
+	bh.ClearExecResultSet()
+	if err := bh.Exec(sysCtx, sql); err != nil {
+		return "", err
+	}
+	erArray, err := getResultSet(sysCtx, bh)
+	if err != nil {
+		return "", err
+	}
+	if !execResultArrayHasData(erArray) {
+		return "", moerr.NewInternalErrorf(ctx, "account %d does not exist", accountID)
+	}
+	return erArray[0].GetString(sysCtx, 0, 0)
+}
+
+func createDataBranchPitrRecord(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	cloneTxnOp TxnOperator,
+	record dataBranchPitrRecord,
+) error {
+	now := cloneTxnOp.SnapshotTS().ToStdTime().UTC().UnixNano()
+	existing, err := getDataBranchPitrRecord(ctx, bh, record.pitrName, record.accountID)
+	if err != nil {
+		return err
+	}
+	if existing.exists {
+		if err = ensureDataBranchPitrRecord(ctx, bh, now, record, existing); err != nil {
+			return err
+		}
+		return ensureDataBranchMoCatalogPitr(
+			ctx, ses, bh, cloneTxnOp, now,
+		)
+	}
+
+	pitrID, err := uuid.NewV7()
+	if err != nil {
+		return err
+	}
+	sql, err := getSqlForCreateDataBranchPitrRecord(ctx, pitrID.String(), now, record)
+	if err != nil {
+		return err
+	}
+
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	if err = bh.Exec(sysCtx, sql); err != nil {
+		// Concurrent branch creation can win the primary key race. Re-read the
+		// record and normalize it if it is the expected internal PITR.
+		existing, readErr := getDataBranchPitrRecord(ctx, bh, record.pitrName, record.accountID)
+		if readErr == nil && existing.exists && existing.kind == dataBranchPitrKind {
+			if ensureErr := ensureDataBranchPitrRecord(ctx, bh, now, record, existing); ensureErr != nil {
+				return ensureErr
+			}
+			return ensureDataBranchMoCatalogPitr(ctx, ses, bh, cloneTxnOp, now)
+		}
+		return err
+	}
+	return ensureDataBranchMoCatalogPitr(ctx, ses, bh, cloneTxnOp, now)
+}
+
+func getDataBranchPitrRecord(
+	ctx context.Context,
+	bh BackgroundExec,
+	pitrName string,
+	accountID uint64,
+) (dataBranchExistingPitrRecord, error) {
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	sql := fmt.Sprintf(
+		"select kind, pitr_status, pitr_length, pitr_unit from mo_catalog.mo_pitr where pitr_name = %s and create_account = %d",
+		quoteSQLStringLiteral(pitrName),
+		accountID,
+	)
+	bh.ClearExecResultSet()
+	if err := bh.Exec(sysCtx, sql); err != nil {
+		return dataBranchExistingPitrRecord{}, err
+	}
+	erArray, err := getResultSet(sysCtx, bh)
+	if err != nil {
+		return dataBranchExistingPitrRecord{}, err
+	}
+	if !execResultArrayHasData(erArray) {
+		return dataBranchExistingPitrRecord{}, nil
+	}
+	kind, err := erArray[0].GetString(sysCtx, 0, 0)
+	if err != nil {
+		return dataBranchExistingPitrRecord{}, err
+	}
+	status, err := erArray[0].GetUint64(sysCtx, 0, 1)
+	if err != nil {
+		return dataBranchExistingPitrRecord{}, err
+	}
+	pitrLength, err := erArray[0].GetUint64(sysCtx, 0, 2)
+	if err != nil {
+		return dataBranchExistingPitrRecord{}, err
+	}
+	pitrUnit, err := erArray[0].GetString(sysCtx, 0, 3)
+	if err != nil {
+		return dataBranchExistingPitrRecord{}, err
+	}
+	return dataBranchExistingPitrRecord{
+		exists:     true,
+		kind:       kind,
+		active:     status == 1,
+		pitrLength: pitrLength,
+		pitrUnit:   pitrUnit,
+	}, nil
+}
+
+func ensureDataBranchPitrRecord(
+	ctx context.Context,
+	bh BackgroundExec,
+	now int64,
+	record dataBranchPitrRecord,
+	existing dataBranchExistingPitrRecord,
+) error {
+	setParts := []string{
+		fmt.Sprintf("modified_time = %d", now),
+		fmt.Sprintf("level = %s", quoteSQLStringLiteral(record.level)),
+		fmt.Sprintf("account_id = %d", record.accountID),
+		fmt.Sprintf("account_name = %s", quoteSQLStringLiteral(record.accountName)),
+		fmt.Sprintf("database_name = %s", quoteSQLStringLiteral(record.databaseName)),
+		fmt.Sprintf("table_name = %s", quoteSQLStringLiteral(record.tableName)),
+		fmt.Sprintf("obj_id = %d", record.objectID),
+		"pitr_status = 1",
+		fmt.Sprintf("kind = %s", quoteSQLStringLiteral(dataBranchPitrKind)),
+	}
+	if !existing.active {
+		setParts = append(setParts, fmt.Sprintf("pitr_status_changed_time = %d", now))
+	}
+	needDurationUpdate, err := dataBranchPitrDurationNeedsUpdate(existing.pitrLength, existing.pitrUnit)
+	if err != nil {
+		return err
+	}
+	if needDurationUpdate {
+		setParts = append(setParts,
+			fmt.Sprintf("pitr_length = %d", dataBranchPitrLength),
+			fmt.Sprintf("pitr_unit = %s", quoteSQLStringLiteral(dataBranchPitrUnit)),
+		)
+	}
+
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	sql := fmt.Sprintf(
+		"update mo_catalog.mo_pitr set %s where pitr_name = %s and create_account = %d",
+		strings.Join(setParts, ", "),
+		quoteSQLStringLiteral(record.pitrName),
+		record.accountID,
+	)
+	return bh.Exec(sysCtx, sql)
+}
+
+func dataBranchPitrDurationNeedsUpdate(oldLength uint64, oldUnit string) (bool, error) {
+	oldMinTs, err := addTimeSpan(time.Time{}, int(oldLength), oldUnit)
+	if err != nil {
+		return false, err
+	}
+	newMinTs, err := addTimeSpan(time.Time{}, dataBranchPitrLength, dataBranchPitrUnit)
+	if err != nil {
+		return false, err
+	}
+	return newMinTs.Before(oldMinTs), nil
+}
+
+func getSqlForCreateDataBranchPitrRecord(
+	ctx context.Context,
+	pitrID string,
+	now int64,
+	record dataBranchPitrRecord,
+) (string, error) {
+	if err := inputNameIsInvalid(ctx, record.pitrName); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`insert into mo_catalog.mo_pitr(
+		pitr_id,
+		pitr_name,
+		create_account,
+		create_time,
+		modified_time,
+		level,
+		account_id,
+		account_name,
+		database_name,
+		table_name,
+		obj_id,
+		pitr_length,
+		pitr_unit,
+		pitr_status_changed_time,
+		kind) values (%s, %s, %d, %d, %d, %s, %d, %s, %s, %s, %d, %d, %s, %d, %s);`,
+		quoteSQLStringLiteral(pitrID),
+		quoteSQLStringLiteral(record.pitrName),
+		record.accountID,
+		now,
+		now,
+		quoteSQLStringLiteral(record.level),
+		record.accountID,
+		quoteSQLStringLiteral(record.accountName),
+		quoteSQLStringLiteral(record.databaseName),
+		quoteSQLStringLiteral(record.tableName),
+		record.objectID,
+		dataBranchPitrLength,
+		quoteSQLStringLiteral(dataBranchPitrUnit),
+		now,
+		quoteSQLStringLiteral(dataBranchPitrKind),
+	), nil
+}
+
+func ensureDataBranchMoCatalogPitr(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	cloneTxnOp TxnOperator,
+	now int64,
+) error {
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	sql := fmt.Sprintf(
+		"select pitr_length, pitr_unit from mo_catalog.mo_pitr where pitr_name = %s",
+		quoteSQLStringLiteral(SYSMOCATALOGPITR),
+	)
+	bh.ClearExecResultSet()
+	if err := bh.Exec(sysCtx, sql); err != nil {
+		return err
+	}
+	erArray, err := getResultSet(sysCtx, bh)
+	if err != nil {
+		return err
+	}
+
+	if execResultArrayHasData(erArray) {
+		sysPitrLength, err := erArray[0].GetUint64(sysCtx, 0, 0)
+		if err != nil {
+			return err
+		}
+		sysPitrUnit, err := erArray[0].GetString(sysCtx, 0, 1)
+		if err != nil {
+			return err
+		}
+		oldMinTs, err := addTimeSpan(time.Time{}, int(sysPitrLength), sysPitrUnit)
+		if err != nil {
+			return err
+		}
+		newMinTs, err := addTimeSpan(time.Time{}, dataBranchPitrLength, dataBranchPitrUnit)
+		if err != nil {
+			return err
+		}
+		setParts := []string{
+			fmt.Sprintf("modified_time = %d", now),
+			"pitr_status = 1",
+			fmt.Sprintf("kind = %s", quoteSQLStringLiteral(dataBranchPitrKind)),
+		}
+		if !newMinTs.Before(oldMinTs) {
+			sql = fmt.Sprintf(
+				"update mo_catalog.mo_pitr set %s where pitr_name = %s and create_account = %d",
+				strings.Join(setParts, ", "),
+				quoteSQLStringLiteral(SYSMOCATALOGPITR),
+				sysAccountID,
+			)
+			return bh.Exec(sysCtx, sql)
+		}
+		setParts = append(setParts,
+			fmt.Sprintf("pitr_length = %d", dataBranchPitrLength),
+			fmt.Sprintf("pitr_unit = %s", quoteSQLStringLiteral(dataBranchPitrUnit)),
+		)
+		sql = fmt.Sprintf(
+			"update mo_catalog.mo_pitr set %s where pitr_name = %s and create_account = %d",
+			strings.Join(setParts, ", "),
+			quoteSQLStringLiteral(SYSMOCATALOGPITR),
+			sysAccountID,
+		)
+		return bh.Exec(sysCtx, sql)
+	}
+
+	moCatalogDB, err := ses.proc.GetSessionInfo().StorageEngine.Database(
+		sysCtx, catalog.MO_CATALOG, cloneTxnOp,
+	)
+	if err != nil {
+		return err
+	}
+	moCatalogID, err := strconv.ParseUint(moCatalogDB.GetDatabaseId(sysCtx), 10, 64)
+	if err != nil {
+		return err
+	}
+	pitrID, err := uuid.NewV7()
+	if err != nil {
+		return err
+	}
+	sql, err = getSqlForCreateDataBranchPitrRecord(ctx, pitrID.String(), now, dataBranchPitrRecord{
+		pitrName:     SYSMOCATALOGPITR,
+		level:        tree.PITRLEVELDATABASE.String(),
+		accountID:    sysAccountID,
+		accountName:  sysAccountName,
+		databaseName: catalog.MO_CATALOG,
+		objectID:     moCatalogID,
+	})
+	if err != nil {
+		return err
+	}
+	return bh.Exec(sysCtx, sql)
+}
+
+func deleteDataBranchInternalPitrRecord(
+	ctx context.Context,
+	bh BackgroundExec,
+	accountID uint64,
+	pitrName string,
+) error {
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	sql := fmt.Sprintf(
+		"delete from mo_catalog.mo_pitr where pitr_name = %s and create_account = %d and (kind = %s or pitr_name like %s)",
+		quoteSQLStringLiteral(pitrName),
+		accountID,
+		quoteSQLStringLiteral(dataBranchPitrKind),
+		quoteSQLStringLiteral(dataBranchPitrName("", "")+"%"),
+	)
+	if err := bh.Exec(sysCtx, sql); err != nil {
+		return err
+	}
+	return cleanupDataBranchMoCatalogPitrIfUnused(ctx, bh)
+}
+
+func cleanupDataBranchMoCatalogPitrIfUnused(ctx context.Context, bh BackgroundExec) error {
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	sql := fmt.Sprintf(
+		"select pitr_id from mo_catalog.mo_pitr where pitr_name != %s limit 1",
+		quoteSQLStringLiteral(SYSMOCATALOGPITR),
+	)
+	bh.ClearExecResultSet()
+	if err := bh.Exec(sysCtx, sql); err != nil {
+		return err
+	}
+	erArray, err := getResultSet(sysCtx, bh)
+	if err != nil {
+		return err
+	}
+	if execResultArrayHasData(erArray) {
+		return nil
+	}
+	sql = fmt.Sprintf(
+		"delete from mo_catalog.mo_pitr where pitr_name = %s and create_account = %d and kind = %s",
+		quoteSQLStringLiteral(SYSMOCATALOGPITR),
+		sysAccountID,
+		quoteSQLStringLiteral(dataBranchPitrKind),
+	)
+	return bh.Exec(sysCtx, sql)
+}
+
+func cleanupDataBranchTablePitrIfUnused(
+	ctx context.Context,
+	bh BackgroundExec,
+	accountID uint64,
+	tableID uint64,
+) error {
+	hasRef, err := dataBranchTablesHaveActiveReference(ctx, bh, []uint64{tableID})
+	if err != nil {
+		return err
+	}
+	if hasRef {
+		return nil
+	}
+	return deleteDataBranchInternalPitrRecord(
+		ctx,
+		bh,
+		accountID,
+		dataBranchPitrName("table", strconv.FormatUint(tableID, 10)),
+	)
+}
+
+func cleanupAllDataBranchTablePitrsIfUnused(ctx context.Context, bh BackgroundExec) error {
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	sql := fmt.Sprintf(
+		"select create_account, obj_id from mo_catalog.mo_pitr where (kind = %s or pitr_name like %s) and level = %s and pitr_name like %s",
+		quoteSQLStringLiteral(dataBranchPitrKind),
+		quoteSQLStringLiteral(dataBranchPitrName("", "")+"%"),
+		quoteSQLStringLiteral(tree.PITRLEVELTABLE.String()),
+		quoteSQLStringLiteral(dataBranchPitrName("table", "")+"%"),
+	)
+	bh.ClearExecResultSet()
+	if err := bh.Exec(sysCtx, sql); err != nil {
+		return err
+	}
+	erArray, err := getResultSet(sysCtx, bh)
+	if err != nil {
+		return err
+	}
+	if !execResultArrayHasData(erArray) {
+		return nil
+	}
+
+	type tablePitr struct {
+		accountID uint64
+		tableID   uint64
+	}
+	pitrs := make([]tablePitr, 0, erArray[0].GetRowCount())
+	for i := uint64(0); i < erArray[0].GetRowCount(); i++ {
+		accountID, err := erArray[0].GetUint64(sysCtx, i, 0)
+		if err != nil {
+			return err
+		}
+		tableID, err := erArray[0].GetUint64(sysCtx, i, 1)
+		if err != nil {
+			return err
+		}
+		pitrs = append(pitrs, tablePitr{accountID: accountID, tableID: tableID})
+	}
+
+	for _, pitr := range pitrs {
+		if err = cleanupDataBranchTablePitrIfUnused(ctx, bh, pitr.accountID, pitr.tableID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cleanupAllDataBranchDatabasePitrsIfUnused(ctx context.Context, bh BackgroundExec) error {
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	sql := fmt.Sprintf(
+		"select create_account, obj_id, database_name, create_time from mo_catalog.mo_pitr where (kind = %s or pitr_name like %s) and level = %s and pitr_name like %s",
+		quoteSQLStringLiteral(dataBranchPitrKind),
+		quoteSQLStringLiteral(dataBranchPitrName("", "")+"%"),
+		quoteSQLStringLiteral(tree.PITRLEVELDATABASE.String()),
+		quoteSQLStringLiteral(dataBranchPitrName("database", "")+"%"),
+	)
+	bh.ClearExecResultSet()
+	if err := bh.Exec(sysCtx, sql); err != nil {
+		return err
+	}
+	erArray, err := getResultSet(sysCtx, bh)
+	if err != nil {
+		return err
+	}
+	if !execResultArrayHasData(erArray) {
+		return nil
+	}
+
+	type dbPitr struct {
+		accountID  uint64
+		databaseID uint64
+		database   string
+		createTime int64
+	}
+	pitrs := make([]dbPitr, 0, erArray[0].GetRowCount())
+	for i := uint64(0); i < erArray[0].GetRowCount(); i++ {
+		accountID, err := erArray[0].GetUint64(sysCtx, i, 0)
+		if err != nil {
+			return err
+		}
+		databaseID, err := erArray[0].GetUint64(sysCtx, i, 1)
+		if err != nil {
+			return err
+		}
+		database, err := erArray[0].GetString(sysCtx, i, 2)
+		if err != nil {
+			return err
+		}
+		createTime, err := erArray[0].GetInt64(sysCtx, i, 3)
+		if err != nil {
+			return err
+		}
+		pitrs = append(pitrs, dbPitr{
+			accountID:  accountID,
+			databaseID: databaseID,
+			database:   database,
+			createTime: createTime,
+		})
+	}
+
+	for _, pitr := range pitrs {
+		tableIDs, err := dataBranchDatabaseTableIDsAt(ctx, bh, pitr.accountID, pitr.database, pitr.createTime)
+		if err != nil {
+			return err
+		}
+		if err = cleanupDataBranchDatabasePitrIfUnused(
+			ctx, bh, pitr.accountID, pitr.databaseID, tableIDs,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cleanupDataBranchDatabasePitrIfUnused(
+	ctx context.Context,
+	bh BackgroundExec,
+	accountID uint64,
+	databaseID uint64,
+	tableIDs []uint64,
+) error {
+	if len(tableIDs) > 0 {
+		hasRef, err := dataBranchTablesHaveActiveReference(ctx, bh, tableIDs)
+		if err != nil {
+			return err
+		}
+		if hasRef {
+			return nil
+		}
+	}
+	return deleteDataBranchInternalPitrRecord(
+		ctx,
+		bh,
+		accountID,
+		dataBranchPitrName("database", strconv.FormatUint(databaseID, 10)),
+	)
+}
+
+func dataBranchDatabaseTableIDsAt(
+	ctx context.Context,
+	bh BackgroundExec,
+	accountID uint64,
+	databaseName string,
+	ts int64,
+) ([]uint64, error) {
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	sql := fmt.Sprintf(
+		"select rel_id from mo_catalog.mo_tables {MO_TS = %d} where account_id = %d and reldatabase = %s",
+		ts,
+		accountID,
+		quoteSQLStringLiteral(databaseName),
+	)
+	bh.ClearExecResultSet()
+	if err := bh.Exec(sysCtx, sql); err != nil {
+		return nil, err
+	}
+	erArray, err := getResultSet(sysCtx, bh)
+	if err != nil {
+		return nil, err
+	}
+	if !execResultArrayHasData(erArray) {
+		return nil, nil
+	}
+	tableIDs := make([]uint64, 0, erArray[0].GetRowCount())
+	for i := uint64(0); i < erArray[0].GetRowCount(); i++ {
+		tableID, err := erArray[0].GetUint64(sysCtx, i, 0)
+		if err != nil {
+			return nil, err
+		}
+		tableIDs = append(tableIDs, tableID)
+	}
+	return tableIDs, nil
+}
+
+func dataBranchTablesHaveActiveReference(
+	ctx context.Context,
+	bh BackgroundExec,
+	tableIDs []uint64,
+) (bool, error) {
+	if len(tableIDs) == 0 {
+		return false, nil
+	}
+	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	const batchSize = 512
+	for start := 0; start < len(tableIDs); start += batchSize {
+		end := start + batchSize
+		if end > len(tableIDs) {
+			end = len(tableIDs)
+		}
+		idList := dataBranchUintListSQL(tableIDs[start:end])
+		sql := fmt.Sprintf(
+			"select table_id from mo_catalog.mo_branch_metadata where table_deleted = false and (table_id in (%s) or p_table_id in (%s)) limit 1",
+			idList,
+			idList,
+		)
+		bh.ClearExecResultSet()
+		if err := bh.Exec(sysCtx, sql); err != nil {
+			return false, err
+		}
+		erArray, err := getResultSet(sysCtx, bh)
+		if err != nil {
+			return false, err
+		}
+		if execResultArrayHasData(erArray) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func dataBranchUintListSQL(ids []uint64) string {
+	var sqlBuilder strings.Builder
+	for i, id := range ids {
+		if i > 0 {
+			sqlBuilder.WriteByte(',')
+		}
+		sqlBuilder.WriteString(strconv.FormatUint(id, 10))
+	}
+	return sqlBuilder.String()
 }
 
 func markBranchTablesDeleted(
@@ -500,6 +1344,16 @@ func dataBranchDeleteTable(
 		return
 	}
 
+	if err = cleanupDataBranchTablePitrIfUnused(execCtx.reqCtx, bh, uint64(accId), tblID); err != nil {
+		return
+	}
+	if err = cleanupAllDataBranchTablePitrsIfUnused(execCtx.reqCtx, bh); err != nil {
+		return
+	}
+	if err = cleanupAllDataBranchDatabasePitrsIfUnused(execCtx.reqCtx, bh); err != nil {
+		return
+	}
+
 	return nil
 }
 
@@ -527,12 +1381,33 @@ func dataBranchDeleteDatabase(
 		dbName   = stmt.DatabaseName
 		accId    uint32
 		sqlRet   executor.Result
+		dbID     uint64
+		dbFound  bool
 		tableIDs []uint64
 	)
 
 	if accId, err = defines.GetAccountId(execCtx.reqCtx); err != nil {
 		return
 	}
+
+	if sqlRet, err = runSql(
+		execCtx.reqCtx, ses, bh, fmt.Sprintf(
+			"select dat_id from %s.%s where account_id = %d and datname = '%s'",
+			catalog.MO_CATALOG, catalog.MO_DATABASE, accId, dbName,
+		), nil, nil,
+	); err != nil {
+		return
+	}
+
+	sqlRet.ReadRows(func(rows int, cols []*vector.Vector) bool {
+		if rows == 0 {
+			return false
+		}
+		dbID = vector.GetFixedAtWithTypeCheck[uint64](cols[0], 0)
+		dbFound = true
+		return false
+	})
+	sqlRet.Close()
 
 	if sqlRet, err = runSql(
 		execCtx.reqCtx, ses, bh, fmt.Sprintf(
@@ -565,6 +1440,23 @@ func dataBranchDeleteDatabase(
 	}
 
 	if err = markBranchTablesDeleted(execCtx.reqCtx, ses, bh, accId, tableIDs); err != nil {
+		return
+	}
+
+	for _, tableID := range tableIDs {
+		if err = cleanupDataBranchTablePitrIfUnused(execCtx.reqCtx, bh, uint64(accId), tableID); err != nil {
+			return
+		}
+	}
+	if err = cleanupAllDataBranchTablePitrsIfUnused(execCtx.reqCtx, bh); err != nil {
+		return
+	}
+	if dbFound {
+		if err = cleanupDataBranchDatabasePitrIfUnused(execCtx.reqCtx, bh, uint64(accId), dbID, tableIDs); err != nil {
+			return
+		}
+	}
+	if err = cleanupAllDataBranchDatabasePitrsIfUnused(execCtx.reqCtx, bh); err != nil {
 		return
 	}
 

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -944,11 +944,9 @@ func deleteDataBranchInternalPitrRecord(
 ) error {
 	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
 	sql := fmt.Sprintf(
-		"delete from mo_catalog.mo_pitr where pitr_name = %s and create_account = %d and (kind = %s or pitr_name like %s)",
+		"delete from mo_catalog.mo_pitr where pitr_name = %s and create_account = %d",
 		quoteSQLStringLiteral(pitrName),
 		accountID,
-		quoteSQLStringLiteral(dataBranchPitrKind),
-		quoteSQLStringLiteral(dataBranchPitrName("", "")+"%"),
 	)
 	if err := bh.Exec(sysCtx, sql); err != nil {
 		return err
@@ -1003,117 +1001,81 @@ func cleanupDataBranchTablePitrIfUnused(
 	)
 }
 
-func cleanupAllDataBranchTablePitrsIfUnused(ctx context.Context, bh BackgroundExec) error {
-	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
-	sql := fmt.Sprintf(
-		"select create_account, obj_id from mo_catalog.mo_pitr where (kind = %s or pitr_name like %s) and level = %s and pitr_name like %s",
-		quoteSQLStringLiteral(dataBranchPitrKind),
-		quoteSQLStringLiteral(dataBranchPitrName("", "")+"%"),
-		quoteSQLStringLiteral(tree.PITRLEVELTABLE.String()),
-		quoteSQLStringLiteral(dataBranchPitrName("table", "")+"%"),
-	)
-	bh.ClearExecResultSet()
-	if err := bh.Exec(sysCtx, sql); err != nil {
-		return err
-	}
-	erArray, err := getResultSet(sysCtx, bh)
-	if err != nil {
-		return err
-	}
-	if !execResultArrayHasData(erArray) {
-		return nil
-	}
-
-	type tablePitr struct {
-		accountID uint64
-		tableID   uint64
-	}
-	pitrs := make([]tablePitr, 0, erArray[0].GetRowCount())
-	for i := uint64(0); i < erArray[0].GetRowCount(); i++ {
-		accountID, err := erArray[0].GetUint64(sysCtx, i, 0)
-		if err != nil {
-			return err
-		}
-		tableID, err := erArray[0].GetUint64(sysCtx, i, 1)
-		if err != nil {
-			return err
-		}
-		pitrs = append(pitrs, tablePitr{accountID: accountID, tableID: tableID})
-	}
-
-	for _, pitr := range pitrs {
-		if err = cleanupDataBranchTablePitrIfUnused(ctx, bh, pitr.accountID, pitr.tableID); err != nil {
-			return err
-		}
-	}
-	return nil
+type dataBranchDatabasePitrForCleanup struct {
+	accountID  uint64
+	databaseID uint64
+	database   string
+	createTime int64
 }
 
-func cleanupAllDataBranchDatabasePitrsIfUnused(ctx context.Context, bh BackgroundExec) error {
+func getDataBranchDatabasePitrForCleanup(
+	ctx context.Context,
+	bh BackgroundExec,
+	accountID uint64,
+	databaseID uint64,
+) (dataBranchDatabasePitrForCleanup, bool, error) {
+	if databaseID == 0 {
+		return dataBranchDatabasePitrForCleanup{}, false, nil
+	}
 	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
+	pitrName := dataBranchPitrName("database", strconv.FormatUint(databaseID, 10))
 	sql := fmt.Sprintf(
-		"select create_account, obj_id, database_name, create_time from mo_catalog.mo_pitr where (kind = %s or pitr_name like %s) and level = %s and pitr_name like %s",
-		quoteSQLStringLiteral(dataBranchPitrKind),
-		quoteSQLStringLiteral(dataBranchPitrName("", "")+"%"),
+		"select create_account, obj_id, database_name, create_time from mo_catalog.mo_pitr where create_account = %d and pitr_name = %s and level = %s limit 1",
+		accountID,
+		quoteSQLStringLiteral(pitrName),
 		quoteSQLStringLiteral(tree.PITRLEVELDATABASE.String()),
-		quoteSQLStringLiteral(dataBranchPitrName("database", "")+"%"),
 	)
 	bh.ClearExecResultSet()
 	if err := bh.Exec(sysCtx, sql); err != nil {
-		return err
+		return dataBranchDatabasePitrForCleanup{}, false, err
 	}
 	erArray, err := getResultSet(sysCtx, bh)
 	if err != nil {
-		return err
+		return dataBranchDatabasePitrForCleanup{}, false, err
 	}
 	if !execResultArrayHasData(erArray) {
-		return nil
+		return dataBranchDatabasePitrForCleanup{}, false, nil
 	}
 
-	type dbPitr struct {
-		accountID  uint64
-		databaseID uint64
-		database   string
-		createTime int64
+	pitrAccountID, err := erArray[0].GetUint64(sysCtx, 0, 0)
+	if err != nil {
+		return dataBranchDatabasePitrForCleanup{}, false, err
 	}
-	pitrs := make([]dbPitr, 0, erArray[0].GetRowCount())
-	for i := uint64(0); i < erArray[0].GetRowCount(); i++ {
-		accountID, err := erArray[0].GetUint64(sysCtx, i, 0)
-		if err != nil {
-			return err
-		}
-		databaseID, err := erArray[0].GetUint64(sysCtx, i, 1)
-		if err != nil {
-			return err
-		}
-		database, err := erArray[0].GetString(sysCtx, i, 2)
-		if err != nil {
-			return err
-		}
-		createTime, err := erArray[0].GetInt64(sysCtx, i, 3)
-		if err != nil {
-			return err
-		}
-		pitrs = append(pitrs, dbPitr{
-			accountID:  accountID,
-			databaseID: databaseID,
-			database:   database,
-			createTime: createTime,
-		})
+	pitrDatabaseID, err := erArray[0].GetUint64(sysCtx, 0, 1)
+	if err != nil {
+		return dataBranchDatabasePitrForCleanup{}, false, err
 	}
+	database, err := erArray[0].GetString(sysCtx, 0, 2)
+	if err != nil {
+		return dataBranchDatabasePitrForCleanup{}, false, err
+	}
+	createTime, err := erArray[0].GetInt64(sysCtx, 0, 3)
+	if err != nil {
+		return dataBranchDatabasePitrForCleanup{}, false, err
+	}
+	return dataBranchDatabasePitrForCleanup{
+		accountID:  pitrAccountID,
+		databaseID: pitrDatabaseID,
+		database:   database,
+		createTime: createTime,
+	}, true, nil
+}
 
-	for _, pitr := range pitrs {
-		tableIDs, err := dataBranchDatabaseTableIDsAt(ctx, bh, pitr.accountID, pitr.database, pitr.createTime)
-		if err != nil {
-			return err
-		}
-		if err = cleanupDataBranchDatabasePitrIfUnused(
-			ctx, bh, pitr.accountID, pitr.databaseID, tableIDs,
-		); err != nil {
-			return err
-		}
+func cleanupDataBranchDatabasePitrByIDIfUnused(
+	ctx context.Context,
+	bh BackgroundExec,
+	accountID uint64,
+	databaseID uint64,
+) error {
+	pitr, found, err := getDataBranchDatabasePitrForCleanup(ctx, bh, accountID, databaseID)
+	if err != nil || !found {
+		return err
 	}
-	return nil
+	tableIDs, err := dataBranchDatabaseTableIDsAt(ctx, bh, pitr.accountID, pitr.database, pitr.createTime)
+	if err != nil {
+		return err
+	}
+	return cleanupDataBranchDatabasePitrIfUnused(ctx, bh, pitr.accountID, pitr.databaseID, tableIDs)
 }
 
 func cleanupDataBranchDatabasePitrIfUnused(
@@ -1294,6 +1256,7 @@ func dataBranchDeleteTable(
 		accId   uint32
 		sqlRet  executor.Result
 		tblID   uint64
+		dbID    uint64
 		found   bool
 	)
 
@@ -1307,7 +1270,7 @@ func dataBranchDeleteTable(
 
 	if sqlRet, err = runSql(
 		execCtx.reqCtx, ses, bh, fmt.Sprintf(
-			"select rel_id from %s.%s where account_id = %d and reldatabase = '%s' and relname = '%s'",
+			"select rel_id, reldatabase_id from %s.%s where account_id = %d and reldatabase = '%s' and relname = '%s'",
 			catalog.MO_CATALOG, catalog.MO_TABLES, accId, dbName, tblName,
 		), nil, nil,
 	); err != nil {
@@ -1319,6 +1282,7 @@ func dataBranchDeleteTable(
 			return false
 		}
 		tblID = vector.GetFixedAtWithTypeCheck[uint64](cols[0], 0)
+		dbID = vector.GetFixedAtWithTypeCheck[uint64](cols[1], 0)
 		found = true
 		return false
 	})
@@ -1347,10 +1311,7 @@ func dataBranchDeleteTable(
 	if err = cleanupDataBranchTablePitrIfUnused(execCtx.reqCtx, bh, uint64(accId), tblID); err != nil {
 		return
 	}
-	if err = cleanupAllDataBranchTablePitrsIfUnused(execCtx.reqCtx, bh); err != nil {
-		return
-	}
-	if err = cleanupAllDataBranchDatabasePitrsIfUnused(execCtx.reqCtx, bh); err != nil {
+	if err = cleanupDataBranchDatabasePitrByIDIfUnused(execCtx.reqCtx, bh, uint64(accId), dbID); err != nil {
 		return
 	}
 
@@ -1448,16 +1409,10 @@ func dataBranchDeleteDatabase(
 			return
 		}
 	}
-	if err = cleanupAllDataBranchTablePitrsIfUnused(execCtx.reqCtx, bh); err != nil {
-		return
-	}
 	if dbFound {
-		if err = cleanupDataBranchDatabasePitrIfUnused(execCtx.reqCtx, bh, uint64(accId), dbID, tableIDs); err != nil {
+		if err = cleanupDataBranchDatabasePitrByIDIfUnused(execCtx.reqCtx, bh, uint64(accId), dbID); err != nil {
 			return
 		}
-	}
-	if err = cleanupAllDataBranchDatabasePitrsIfUnused(execCtx.reqCtx, bh); err != nil {
-		return
 	}
 
 	return nil

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -51,10 +51,10 @@ import (
 )
 
 const (
-	dataBranchPitrNamePrefix = "__mo_data_branch_pitr"
-	dataBranchPitrLength     = 1
-	dataBranchPitrUnit       = "y"
-	dataBranchPitrKind       = "internal"
+	dataBranchPitrNamePrefix        = "__mo_data_branch_pitr"
+	dataBranchInternalPitrSQLPrefix = dataBranchPitrNamePrefix + "_"
+	dataBranchPitrLength            = 1
+	dataBranchPitrUnit              = "y"
 )
 
 type dataBranchPitrRecord struct {
@@ -69,7 +69,6 @@ type dataBranchPitrRecord struct {
 
 type dataBranchExistingPitrRecord struct {
 	exists     bool
-	kind       string
 	active     bool
 	pitrLength uint64
 	pitrUnit   string
@@ -691,7 +690,7 @@ func createDataBranchPitrRecord(
 		// Concurrent branch creation can win the primary key race. Re-read the
 		// record and normalize it if it is the expected internal PITR.
 		existing, readErr := getDataBranchPitrRecord(ctx, bh, record.pitrName, record.accountID)
-		if readErr == nil && existing.exists && existing.kind == dataBranchPitrKind {
+		if readErr == nil && existing.exists {
 			if ensureErr := ensureDataBranchPitrRecord(ctx, bh, now, record, existing); ensureErr != nil {
 				return ensureErr
 			}
@@ -710,7 +709,7 @@ func getDataBranchPitrRecord(
 ) (dataBranchExistingPitrRecord, error) {
 	sysCtx := defines.AttachAccountId(ctx, sysAccountID)
 	sql := fmt.Sprintf(
-		"select kind, pitr_status, pitr_length, pitr_unit from mo_catalog.mo_pitr where pitr_name = %s and create_account = %d",
+		"select pitr_status, pitr_length, pitr_unit from mo_catalog.mo_pitr where pitr_name = %s and create_account = %d",
 		quoteSQLStringLiteral(pitrName),
 		accountID,
 	)
@@ -725,25 +724,20 @@ func getDataBranchPitrRecord(
 	if !execResultArrayHasData(erArray) {
 		return dataBranchExistingPitrRecord{}, nil
 	}
-	kind, err := erArray[0].GetString(sysCtx, 0, 0)
+	status, err := erArray[0].GetUint64(sysCtx, 0, 0)
 	if err != nil {
 		return dataBranchExistingPitrRecord{}, err
 	}
-	status, err := erArray[0].GetUint64(sysCtx, 0, 1)
+	pitrLength, err := erArray[0].GetUint64(sysCtx, 0, 1)
 	if err != nil {
 		return dataBranchExistingPitrRecord{}, err
 	}
-	pitrLength, err := erArray[0].GetUint64(sysCtx, 0, 2)
-	if err != nil {
-		return dataBranchExistingPitrRecord{}, err
-	}
-	pitrUnit, err := erArray[0].GetString(sysCtx, 0, 3)
+	pitrUnit, err := erArray[0].GetString(sysCtx, 0, 2)
 	if err != nil {
 		return dataBranchExistingPitrRecord{}, err
 	}
 	return dataBranchExistingPitrRecord{
 		exists:     true,
-		kind:       kind,
 		active:     status == 1,
 		pitrLength: pitrLength,
 		pitrUnit:   pitrUnit,
@@ -766,7 +760,6 @@ func ensureDataBranchPitrRecord(
 		fmt.Sprintf("table_name = %s", quoteSQLStringLiteral(record.tableName)),
 		fmt.Sprintf("obj_id = %d", record.objectID),
 		"pitr_status = 1",
-		fmt.Sprintf("kind = %s", quoteSQLStringLiteral(dataBranchPitrKind)),
 	}
 	if !existing.active {
 		setParts = append(setParts, fmt.Sprintf("pitr_status_changed_time = %d", now))
@@ -827,8 +820,7 @@ func getSqlForCreateDataBranchPitrRecord(
 		obj_id,
 		pitr_length,
 		pitr_unit,
-		pitr_status_changed_time,
-		kind) values (%s, %s, %d, %d, %d, %s, %d, %s, %s, %s, %d, %d, %s, %d, %s);`,
+		pitr_status_changed_time) values (%s, %s, %d, %d, %d, %s, %d, %s, %s, %s, %d, %d, %s, %d);`,
 		quoteSQLStringLiteral(pitrID),
 		quoteSQLStringLiteral(record.pitrName),
 		record.accountID,
@@ -843,7 +835,6 @@ func getSqlForCreateDataBranchPitrRecord(
 		dataBranchPitrLength,
 		quoteSQLStringLiteral(dataBranchPitrUnit),
 		now,
-		quoteSQLStringLiteral(dataBranchPitrKind),
 	), nil
 }
 
@@ -888,7 +879,6 @@ func ensureDataBranchMoCatalogPitr(
 		setParts := []string{
 			fmt.Sprintf("modified_time = %d", now),
 			"pitr_status = 1",
-			fmt.Sprintf("kind = %s", quoteSQLStringLiteral(dataBranchPitrKind)),
 		}
 		if !newMinTs.Before(oldMinTs) {
 			sql = fmt.Sprintf(
@@ -976,10 +966,9 @@ func cleanupDataBranchMoCatalogPitrIfUnused(ctx context.Context, bh BackgroundEx
 		return nil
 	}
 	sql = fmt.Sprintf(
-		"delete from mo_catalog.mo_pitr where pitr_name = %s and create_account = %d and kind = %s",
+		"delete from mo_catalog.mo_pitr where pitr_name = %s and create_account = %d",
 		quoteSQLStringLiteral(SYSMOCATALOGPITR),
 		sysAccountID,
-		quoteSQLStringLiteral(dataBranchPitrKind),
 	)
 	return bh.Exec(sysCtx, sql)
 }

--- a/pkg/frontend/data_branch_helpers_test.go
+++ b/pkg/frontend/data_branch_helpers_test.go
@@ -17,16 +17,20 @@ package frontend
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/stretchr/testify/require"
 )
 
@@ -86,6 +90,536 @@ func TestContainsDataBranchTempTableName(t *testing.T) {
 func TestQuoteSQLIdentifier(t *testing.T) {
 	require.Equal(t, "`plain`", quoteSQLIdentifier("plain"))
 	require.Equal(t, "`a``b`", quoteSQLIdentifier("a`b"))
+}
+
+func TestDataBranchPitrEntryValidation(t *testing.T) {
+	ctx := context.Background()
+	bh := &backgroundExecTest{}
+	bh.init()
+
+	err := createDataBranchTablePitr(ctx, nil, bh, cloneReceipt{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires target table")
+
+	err = createDataBranchTablePitr(ctx, nil, bh, cloneReceipt{
+		dstDb:     "db",
+		dstTbl:    "tbl",
+		toAccount: 7,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires background transaction")
+
+	err = createDataBranchDatabasePitr(ctx, nil, bh, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires clone database statement")
+
+	err = createDataBranchDatabasePitr(ctx, nil, bh, &tree.CloneDatabase{}, []cloneReceipt{{toAccount: 7}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires target database")
+
+	err = createDataBranchDatabasePitr(ctx, nil, bh, &tree.CloneDatabase{
+		DstDatabase: tree.Identifier("dst"),
+	}, []cloneReceipt{{toAccount: 7}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires background transaction")
+}
+
+func TestDataBranchPitrAccountName(t *testing.T) {
+	ctx := context.Background()
+	ses := newValidateSession(t)
+	ses.SetTenantInfo(&TenantInfo{
+		Tenant:   "tenant_42",
+		TenantID: 42,
+	})
+
+	bh := &backgroundExecTest{}
+	bh.init()
+
+	name, err := dataBranchPitrAccountName(ctx, ses, bh, sysAccountID)
+	require.NoError(t, err)
+	require.Equal(t, sysAccountName, name)
+
+	name, err = dataBranchPitrAccountName(ctx, ses, bh, 42)
+	require.NoError(t, err)
+	require.Equal(t, "tenant_42", name)
+
+	lookupSQL := "select account_name from mo_catalog.mo_account where account_id = 99"
+	bh.sql2result[lookupSQL] = dataBranchTestResultSet(
+		[]defines.MysqlType{defines.MYSQL_TYPE_VARCHAR},
+		[][]interface{}{{"tenant_99"}},
+	)
+	name, err = dataBranchPitrAccountName(ctx, ses, bh, 99)
+	require.NoError(t, err)
+	require.Equal(t, "tenant_99", name)
+
+	bh.sql2result[lookupSQL] = dataBranchTestResultSet(
+		[]defines.MysqlType{defines.MYSQL_TYPE_VARCHAR},
+		nil,
+	)
+	_, err = dataBranchPitrAccountName(ctx, ses, bh, 99)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "account 99 does not exist")
+}
+
+func TestDataBranchPitrRecordSQLPaths(t *testing.T) {
+	ctx := context.Background()
+	bh := &backgroundExecTest{}
+	bh.init()
+
+	record := dataBranchPitrRecord{
+		pitrName:     dataBranchPitrName("table", "77"),
+		level:        "table",
+		accountID:    7,
+		accountName:  "acc_7",
+		databaseName: "db`x",
+		tableName:    "tbl'x",
+		objectID:     77,
+	}
+
+	selectSQL := dataBranchPitrRecordSelectSQL(record.pitrName, record.accountID)
+	bh.sql2result[selectSQL] = dataBranchExistingPitrResult(0, 1, "h")
+
+	existing, err := getDataBranchPitrRecord(ctx, bh, record.pitrName, record.accountID)
+	require.NoError(t, err)
+	require.True(t, existing.exists)
+	require.False(t, existing.active)
+	require.Equal(t, uint64(1), existing.pitrLength)
+	require.Equal(t, "h", existing.pitrUnit)
+
+	err = ensureDataBranchPitrRecord(ctx, bh, 123, record, existing)
+	require.NoError(t, err)
+	requireExecutedSQLContains(t, bh.executedSQLs, "pitr_status_changed_time = 123")
+	requireExecutedSQLContains(t, bh.executedSQLs, "pitr_length = 1")
+	requireExecutedSQLContains(t, bh.executedSQLs, "pitr_unit = 'y'")
+	requireExecutedSQLContains(t, bh.executedSQLs, "database_name = 'db`x'")
+	requireExecutedSQLContains(t, bh.executedSQLs, "table_name = 'tbl''x'")
+
+	sql, err := getSqlForCreateDataBranchPitrRecord(ctx, "pitr-id", 456, record)
+	require.NoError(t, err)
+	require.Contains(t, sql, "pitr_status_changed_time) values")
+	require.Contains(t, sql, "'__mo_data_branch_pitr_table_77'")
+	require.Contains(t, sql, "'tbl''x'")
+}
+
+func TestCreateDataBranchPitrRecordRefreshesExistingRecords(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().SnapshotTS().Return(types.BuildTS(100, 0).ToTimestamp()).AnyTimes()
+
+	bh := &backgroundExecTest{}
+	bh.init()
+
+	record := dataBranchPitrRecord{
+		pitrName:     dataBranchPitrName("table", "88"),
+		level:        "table",
+		accountID:    8,
+		accountName:  "acc_8",
+		databaseName: "db",
+		tableName:    "tbl",
+		objectID:     88,
+	}
+
+	bh.sql2result[dataBranchPitrRecordSelectSQL(record.pitrName, record.accountID)] =
+		dataBranchExistingPitrResult(0, 1, "h")
+
+	sysSelectSQL := fmt.Sprintf(
+		"select pitr_length, pitr_unit from mo_catalog.mo_pitr where pitr_name = %s",
+		quoteSQLStringLiteral(SYSMOCATALOGPITR),
+	)
+	bh.sql2result[sysSelectSQL] = dataBranchTestResultSet(
+		[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG, defines.MYSQL_TYPE_VARCHAR},
+		[][]interface{}{{uint64(2), "y"}},
+	)
+
+	err := createDataBranchPitrRecord(ctx, nil, bh, txnOp, record)
+	require.NoError(t, err)
+	requireExecutedSQLContains(t, bh.executedSQLs, "update mo_catalog.mo_pitr set modified_time =")
+	requireExecutedSQLContains(t, bh.executedSQLs, "pitr_status_changed_time =")
+	requireExecutedSQLContains(t, bh.executedSQLs, "where pitr_name = '__mo_data_branch_pitr_table_88' and create_account = 8")
+	requireExecutedSQLContains(t, bh.executedSQLs, "where pitr_name = 'sys_mo_catalog_pitr' and create_account = 0")
+}
+
+func TestCreateDataBranchPitrRecordCreatesMissingRecord(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().SnapshotTS().Return(types.BuildTS(200, 0).ToTimestamp()).AnyTimes()
+
+	bh := &backgroundExecTest{}
+	bh.init()
+
+	record := dataBranchPitrRecord{
+		pitrName:     dataBranchPitrName("table", "99"),
+		level:        "table",
+		accountID:    9,
+		accountName:  "acc_9",
+		databaseName: "db",
+		tableName:    "tbl",
+		objectID:     99,
+	}
+
+	bh.sql2result[dataBranchPitrRecordSelectSQL(record.pitrName, record.accountID)] =
+		dataBranchPitrRecordResult(nil)
+
+	sysSelectSQL := fmt.Sprintf(
+		"select pitr_length, pitr_unit from mo_catalog.mo_pitr where pitr_name = %s",
+		quoteSQLStringLiteral(SYSMOCATALOGPITR),
+	)
+	bh.sql2result[sysSelectSQL] = dataBranchTestResultSet(
+		[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG, defines.MYSQL_TYPE_VARCHAR},
+		[][]interface{}{{uint64(2), "y"}},
+	)
+
+	err := createDataBranchPitrRecord(ctx, nil, bh, txnOp, record)
+	require.NoError(t, err)
+	requireExecutedSQLContains(t, bh.executedSQLs, "insert into mo_catalog.mo_pitr")
+	requireExecutedSQLContains(t, bh.executedSQLs, "'__mo_data_branch_pitr_table_99'")
+	requireExecutedSQLContains(t, bh.executedSQLs, "where pitr_name = 'sys_mo_catalog_pitr' and create_account = 0")
+}
+
+func TestEnsureDataBranchMoCatalogPitrUpdatesDurationWhenNeeded(t *testing.T) {
+	ctx := context.Background()
+	selectSQL := fmt.Sprintf(
+		"select pitr_length, pitr_unit from mo_catalog.mo_pitr where pitr_name = %s",
+		quoteSQLStringLiteral(SYSMOCATALOGPITR),
+	)
+
+	t.Run("extends short existing pitr", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[selectSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG, defines.MYSQL_TYPE_VARCHAR},
+			[][]interface{}{{uint64(1), "h"}},
+		)
+
+		err := ensureDataBranchMoCatalogPitr(ctx, nil, bh, nil, 123)
+		require.NoError(t, err)
+		requireExecutedSQLContains(t, bh.executedSQLs, "pitr_length = 1")
+		requireExecutedSQLContains(t, bh.executedSQLs, "pitr_unit = 'y'")
+	})
+
+	t.Run("keeps longer existing pitr duration", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[selectSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG, defines.MYSQL_TYPE_VARCHAR},
+			[][]interface{}{{uint64(2), "y"}},
+		)
+
+		err := ensureDataBranchMoCatalogPitr(ctx, nil, bh, nil, 456)
+		require.NoError(t, err)
+		lastSQL := bh.executedSQLs[len(bh.executedSQLs)-1]
+		require.Contains(t, lastSQL, "modified_time = 456")
+		require.NotContains(t, lastSQL, "pitr_length")
+		require.NotContains(t, lastSQL, "pitr_unit")
+	})
+
+	t.Run("creates missing sys mo catalog pitr", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[selectSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG, defines.MYSQL_TYPE_VARCHAR},
+			nil,
+		)
+
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+		eng := mock_frontend.NewMockEngine(ctrl)
+		db := mock_frontend.NewMockDatabase(ctrl)
+		db.EXPECT().GetDatabaseId(gomock.Any()).Return("123").Times(1)
+		eng.EXPECT().Database(gomock.Any(), catalog.MO_CATALOG, txnOp).Return(db, nil).Times(1)
+
+		ses := newValidateSession(t)
+		ses.proc.Base.SessionInfo.StorageEngine = eng
+
+		err := ensureDataBranchMoCatalogPitr(ctx, ses, bh, txnOp, 789)
+		require.NoError(t, err)
+		requireExecutedSQLContains(t, bh.executedSQLs, "insert into mo_catalog.mo_pitr")
+		requireExecutedSQLContains(t, bh.executedSQLs, "'sys_mo_catalog_pitr'")
+		requireExecutedSQLContains(t, bh.executedSQLs, "'mo_catalog'")
+	})
+}
+
+func TestDataBranchPitrCleanupHelpers(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("cleanup sys pitr when it is the last internal pitr", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		selectSQL := fmt.Sprintf(
+			"select pitr_id from mo_catalog.mo_pitr where pitr_name != %s limit 1",
+			quoteSQLStringLiteral(SYSMOCATALOGPITR),
+		)
+		bh.sql2result[selectSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_UUID},
+			nil,
+		)
+
+		err := cleanupDataBranchMoCatalogPitrIfUnused(ctx, bh)
+		require.NoError(t, err)
+		requireExecutedSQLContains(t, bh.executedSQLs, "delete from mo_catalog.mo_pitr where pitr_name = 'sys_mo_catalog_pitr'")
+	})
+
+	t.Run("read database pitr for cleanup", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		selectSQL := fmt.Sprintf(
+			"select create_account, obj_id, database_name, create_time from mo_catalog.mo_pitr where create_account = %d and pitr_name = %s and level = %s limit 1",
+			uint64(7),
+			quoteSQLStringLiteral(dataBranchPitrName("database", "55")),
+			quoteSQLStringLiteral("database"),
+		)
+		bh.sql2result[selectSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{
+				defines.MYSQL_TYPE_LONGLONG,
+				defines.MYSQL_TYPE_LONGLONG,
+				defines.MYSQL_TYPE_VARCHAR,
+				defines.MYSQL_TYPE_LONGLONG,
+			},
+			[][]interface{}{{uint64(7), uint64(55), "db1", int64(999)}},
+		)
+
+		pitr, found, err := getDataBranchDatabasePitrForCleanup(ctx, bh, 7, 55)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, uint64(7), pitr.accountID)
+		require.Equal(t, uint64(55), pitr.databaseID)
+		require.Equal(t, "db1", pitr.database)
+		require.Equal(t, int64(999), pitr.createTime)
+	})
+
+	t.Run("read table ids at database pitr timestamp", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		selectSQL := fmt.Sprintf(
+			"select rel_id from mo_catalog.mo_tables {MO_TS = %d} where account_id = %d and reldatabase = %s",
+			int64(999),
+			uint64(7),
+			quoteSQLStringLiteral("db1"),
+		)
+		bh.sql2result[selectSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG},
+			[][]interface{}{{uint64(101)}, {uint64(102)}},
+		)
+
+		tableIDs, err := dataBranchDatabaseTableIDsAt(ctx, bh, 7, "db1", 999)
+		require.NoError(t, err)
+		require.Equal(t, []uint64{101, 102}, tableIDs)
+	})
+
+	t.Run("delete table pitr when no branch references remain", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		refSQL := "select table_id from mo_catalog.mo_branch_metadata where table_deleted = false and (table_id in (88) or p_table_id in (88)) limit 1"
+		bh.sql2result[refSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG},
+			nil,
+		)
+		sysPitrRefSQL := fmt.Sprintf(
+			"select pitr_id from mo_catalog.mo_pitr where pitr_name != %s limit 1",
+			quoteSQLStringLiteral(SYSMOCATALOGPITR),
+		)
+		bh.sql2result[sysPitrRefSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_UUID},
+			[][]interface{}{{"pitr-id"}},
+		)
+
+		err := cleanupDataBranchTablePitrIfUnused(ctx, bh, 7, 88)
+		require.NoError(t, err)
+		requireExecutedSQLContains(t, bh.executedSQLs, "delete from mo_catalog.mo_pitr where pitr_name = '__mo_data_branch_pitr_table_88' and create_account = 7")
+	})
+
+	t.Run("keep table pitr when active branch still references it", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		refSQL := "select table_id from mo_catalog.mo_branch_metadata where table_deleted = false and (table_id in (88) or p_table_id in (88)) limit 1"
+		bh.sql2result[refSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG},
+			[][]interface{}{{uint64(88)}},
+		)
+
+		err := cleanupDataBranchTablePitrIfUnused(ctx, bh, 7, 88)
+		require.NoError(t, err)
+		for _, sql := range bh.executedSQLs {
+			require.NotContains(t, sql, "delete from mo_catalog.mo_pitr")
+		}
+	})
+
+	t.Run("delete database pitr when no table reference remains", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		refSQL := "select table_id from mo_catalog.mo_branch_metadata where table_deleted = false and (table_id in (101,102) or p_table_id in (101,102)) limit 1"
+		bh.sql2result[refSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG},
+			nil,
+		)
+		sysPitrRefSQL := fmt.Sprintf(
+			"select pitr_id from mo_catalog.mo_pitr where pitr_name != %s limit 1",
+			quoteSQLStringLiteral(SYSMOCATALOGPITR),
+		)
+		bh.sql2result[sysPitrRefSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_UUID},
+			[][]interface{}{{"pitr-id"}},
+		)
+
+		err := cleanupDataBranchDatabasePitrIfUnused(ctx, bh, 7, 55, []uint64{101, 102})
+		require.NoError(t, err)
+		requireExecutedSQLContains(t, bh.executedSQLs, "delete from mo_catalog.mo_pitr where pitr_name = '__mo_data_branch_pitr_database_55' and create_account = 7")
+	})
+
+	t.Run("keep database pitr when active branch still references a table", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		refSQL := "select table_id from mo_catalog.mo_branch_metadata where table_deleted = false and (table_id in (101) or p_table_id in (101)) limit 1"
+		bh.sql2result[refSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG},
+			[][]interface{}{{uint64(101)}},
+		)
+
+		err := cleanupDataBranchDatabasePitrIfUnused(ctx, bh, 7, 55, []uint64{101})
+		require.NoError(t, err)
+		for _, sql := range bh.executedSQLs {
+			require.NotContains(t, sql, "delete from mo_catalog.mo_pitr")
+		}
+	})
+
+	t.Run("delete database pitr by id after resolving tables at branch timestamp", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		pitrSQL := fmt.Sprintf(
+			"select create_account, obj_id, database_name, create_time from mo_catalog.mo_pitr where create_account = %d and pitr_name = %s and level = %s limit 1",
+			uint64(7),
+			quoteSQLStringLiteral(dataBranchPitrName("database", "66")),
+			quoteSQLStringLiteral("database"),
+		)
+		bh.sql2result[pitrSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{
+				defines.MYSQL_TYPE_LONGLONG,
+				defines.MYSQL_TYPE_LONGLONG,
+				defines.MYSQL_TYPE_VARCHAR,
+				defines.MYSQL_TYPE_LONGLONG,
+			},
+			[][]interface{}{{uint64(7), uint64(66), "db2", int64(1001)}},
+		)
+		tablesSQL := fmt.Sprintf(
+			"select rel_id from mo_catalog.mo_tables {MO_TS = %d} where account_id = %d and reldatabase = %s",
+			int64(1001),
+			uint64(7),
+			quoteSQLStringLiteral("db2"),
+		)
+		bh.sql2result[tablesSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG},
+			[][]interface{}{{uint64(201)}},
+		)
+		refSQL := "select table_id from mo_catalog.mo_branch_metadata where table_deleted = false and (table_id in (201) or p_table_id in (201)) limit 1"
+		bh.sql2result[refSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG},
+			nil,
+		)
+		sysPitrRefSQL := fmt.Sprintf(
+			"select pitr_id from mo_catalog.mo_pitr where pitr_name != %s limit 1",
+			quoteSQLStringLiteral(SYSMOCATALOGPITR),
+		)
+		bh.sql2result[sysPitrRefSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_UUID},
+			[][]interface{}{{"pitr-id"}},
+		)
+
+		err := cleanupDataBranchDatabasePitrByIDIfUnused(ctx, bh, 7, 66)
+		require.NoError(t, err)
+		requireExecutedSQLContains(t, bh.executedSQLs, "delete from mo_catalog.mo_pitr where pitr_name = '__mo_data_branch_pitr_database_66' and create_account = 7")
+	})
+}
+
+func TestDataBranchPitrErrorPaths(t *testing.T) {
+	ctx := context.Background()
+	wantErr := moerr.NewInternalErrorNoCtx("pitr helper failed")
+
+	t.Run("get pitr record propagates exec error", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		selectSQL := dataBranchPitrRecordSelectSQL(dataBranchPitrName("table", "88"), 7)
+		bh.sql2err[selectSQL] = wantErr
+
+		_, err := getDataBranchPitrRecord(ctx, bh, dataBranchPitrName("table", "88"), 7)
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("ensure pitr record rejects invalid existing duration", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+
+		err := ensureDataBranchPitrRecord(ctx, bh, 123, dataBranchPitrRecord{
+			pitrName:  dataBranchPitrName("table", "88"),
+			level:     "table",
+			accountID: 7,
+			objectID:  88,
+		}, dataBranchExistingPitrRecord{
+			exists:     true,
+			active:     true,
+			pitrLength: 1,
+			pitrUnit:   "bad",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("ensure sys pitr propagates select error", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		selectSQL := fmt.Sprintf(
+			"select pitr_length, pitr_unit from mo_catalog.mo_pitr where pitr_name = %s",
+			quoteSQLStringLiteral(SYSMOCATALOGPITR),
+		)
+		bh.sql2err[selectSQL] = wantErr
+
+		err := ensureDataBranchMoCatalogPitr(ctx, nil, bh, nil, 123)
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("cleanup sys pitr propagates select error", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		selectSQL := fmt.Sprintf(
+			"select pitr_id from mo_catalog.mo_pitr where pitr_name != %s limit 1",
+			quoteSQLStringLiteral(SYSMOCATALOGPITR),
+		)
+		bh.sql2err[selectSQL] = wantErr
+
+		err := cleanupDataBranchMoCatalogPitrIfUnused(ctx, bh)
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("database pitr lookup skips zero database id", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+
+		_, found, err := getDataBranchDatabasePitrForCleanup(ctx, bh, 7, 0)
+		require.NoError(t, err)
+		require.False(t, found)
+		require.Empty(t, bh.executedSQLs)
+	})
+
+	t.Run("database pitr lookup propagates select error", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		selectSQL := fmt.Sprintf(
+			"select create_account, obj_id, database_name, create_time from mo_catalog.mo_pitr where create_account = %d and pitr_name = %s and level = %s limit 1",
+			uint64(7),
+			quoteSQLStringLiteral(dataBranchPitrName("database", "55")),
+			quoteSQLStringLiteral("database"),
+		)
+		bh.sql2err[selectSQL] = wantErr
+
+		_, _, err := getDataBranchDatabasePitrForCleanup(ctx, bh, 7, 55)
+		require.ErrorIs(t, err, wantErr)
+	})
 }
 
 func TestRunSQL_BackgroundExecPaths(t *testing.T) {
@@ -294,4 +828,51 @@ func buildRunSQLResultSet() *MysqlResultSet {
 
 func vectorValueAsInt64(bat *batch.Batch, colIdx int, rowIdx int) int64 {
 	return vector.MustFixedColWithTypeCheck[int64](bat.Vecs[colIdx])[rowIdx]
+}
+
+func dataBranchPitrRecordSelectSQL(pitrName string, accountID uint64) string {
+	return fmt.Sprintf(
+		"select pitr_status, pitr_length, pitr_unit from mo_catalog.mo_pitr where pitr_name = %s and create_account = %d",
+		quoteSQLStringLiteral(pitrName),
+		accountID,
+	)
+}
+
+func dataBranchExistingPitrResult(status uint64, pitrLength uint64, pitrUnit string) *MysqlResultSet {
+	return dataBranchPitrRecordResult([][]interface{}{{status, pitrLength, pitrUnit}})
+}
+
+func dataBranchPitrRecordResult(rows [][]interface{}) *MysqlResultSet {
+	return dataBranchTestResultSet(
+		[]defines.MysqlType{
+			defines.MYSQL_TYPE_LONGLONG,
+			defines.MYSQL_TYPE_LONGLONG,
+			defines.MYSQL_TYPE_VARCHAR,
+		},
+		rows,
+	)
+}
+
+func dataBranchTestResultSet(colTypes []defines.MysqlType, rows [][]interface{}) *MysqlResultSet {
+	mrs := &MysqlResultSet{}
+	for i, colType := range colTypes {
+		col := &MysqlColumn{}
+		col.SetName(fmt.Sprintf("c%d", i))
+		col.SetColumnType(colType)
+		mrs.AddColumn(col)
+	}
+	for _, row := range rows {
+		mrs.AddRow(row)
+	}
+	return mrs
+}
+
+func requireExecutedSQLContains(t *testing.T, sqls []string, substr string) {
+	t.Helper()
+	for _, sql := range sqls {
+		if strings.Contains(sql, substr) {
+			return
+		}
+	}
+	require.Failf(t, "expected executed SQL to contain substring", "substring: %s\nsqls:\n%s", substr, strings.Join(sqls, "\n"))
 }

--- a/pkg/frontend/data_branch_helpers_test.go
+++ b/pkg/frontend/data_branch_helpers_test.go
@@ -83,6 +83,11 @@ func TestContainsDataBranchTempTableName(t *testing.T) {
 	require.False(t, containsDataBranchTempTableName("select '__mo_diff_del_merge_1'"))
 }
 
+func TestQuoteSQLIdentifier(t *testing.T) {
+	require.Equal(t, "`plain`", quoteSQLIdentifier("plain"))
+	require.Equal(t, "`a``b`", quoteSQLIdentifier("a`b"))
+}
+
 func TestRunSQL_BackgroundExecPaths(t *testing.T) {
 	ses := newValidateSession(t)
 

--- a/pkg/frontend/data_branch_helpers_test.go
+++ b/pkg/frontend/data_branch_helpers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/stretchr/testify/require"
 )
@@ -159,6 +160,89 @@ func TestDataBranchPitrAccountName(t *testing.T) {
 	_, err = dataBranchPitrAccountName(ctx, ses, bh, 99)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "account 99 does not exist")
+
+	wantErr := moerr.NewInternalErrorNoCtx("account lookup failed")
+	bh.sql2err[lookupSQL] = wantErr
+	_, err = dataBranchPitrAccountName(ctx, ses, bh, 99)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestDataBranchPitrIDLookups(t *testing.T) {
+	ctx := context.Background()
+	wantErr := moerr.NewInternalErrorNoCtx("lookup failed")
+
+	t.Run("database id propagates engine error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().Database(gomock.Any(), "db", txnOp).Return(nil, wantErr).Times(1)
+
+		ses := newValidateSession(t)
+		ses.proc.Base.SessionInfo.StorageEngine = eng
+
+		_, err := dataBranchDatabaseID(ctx, ses, txnOp, 7, "db")
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("database id rejects malformed catalog id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+		db := mock_frontend.NewMockDatabase(ctrl)
+		db.EXPECT().GetDatabaseId(gomock.Any()).Return("bad-id").Times(1)
+
+		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().Database(gomock.Any(), "db", txnOp).Return(db, nil).Times(1)
+
+		ses := newValidateSession(t)
+		ses.proc.Base.SessionInfo.StorageEngine = eng
+
+		_, err := dataBranchDatabaseID(ctx, ses, txnOp, 7, "db")
+		require.Error(t, err)
+	})
+
+	t.Run("table id propagates relation error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+		db := mock_frontend.NewMockDatabase(ctrl)
+		db.EXPECT().Relation(gomock.Any(), "tbl", nil).Return(nil, wantErr).Times(1)
+
+		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().Database(gomock.Any(), "db", txnOp).Return(db, nil).Times(1)
+
+		ses := newValidateSession(t)
+		ses.proc.Base.SessionInfo.StorageEngine = eng
+
+		_, err := dataBranchTableID(ctx, ses, txnOp, 7, "db", "tbl")
+		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("table id reads table definition", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+		rel := mock_frontend.NewMockRelation(ctrl)
+		rel.EXPECT().GetTableDef(gomock.Any()).Return(&plan.TableDef{TblId: 99}).Times(1)
+
+		db := mock_frontend.NewMockDatabase(ctrl)
+		db.EXPECT().Relation(gomock.Any(), "tbl", nil).Return(rel, nil).Times(1)
+
+		eng := mock_frontend.NewMockEngine(ctrl)
+		eng.EXPECT().Database(gomock.Any(), "db", txnOp).Return(db, nil).Times(1)
+
+		ses := newValidateSession(t)
+		ses.proc.Base.SessionInfo.StorageEngine = eng
+
+		tableID, err := dataBranchTableID(ctx, ses, txnOp, 7, "db", "tbl")
+		require.NoError(t, err)
+		require.Equal(t, uint64(99), tableID)
+	})
 }
 
 func TestDataBranchPitrRecordSQLPaths(t *testing.T) {
@@ -199,6 +283,10 @@ func TestDataBranchPitrRecordSQLPaths(t *testing.T) {
 	require.Contains(t, sql, "pitr_status_changed_time) values")
 	require.Contains(t, sql, "'__mo_data_branch_pitr_table_77'")
 	require.Contains(t, sql, "'tbl''x'")
+
+	record.pitrName = "bad'name"
+	_, err = getSqlForCreateDataBranchPitrRecord(ctx, "pitr-id", 456, record)
+	require.Error(t, err)
 }
 
 func TestCreateDataBranchPitrRecordRefreshesExistingRecords(t *testing.T) {
@@ -240,6 +328,33 @@ func TestCreateDataBranchPitrRecordRefreshesExistingRecords(t *testing.T) {
 	requireExecutedSQLContains(t, bh.executedSQLs, "pitr_status_changed_time =")
 	requireExecutedSQLContains(t, bh.executedSQLs, "where pitr_name = '__mo_data_branch_pitr_table_88' and create_account = 8")
 	requireExecutedSQLContains(t, bh.executedSQLs, "where pitr_name = 'sys_mo_catalog_pitr' and create_account = 0")
+}
+
+func TestCreateDataBranchPitrRecordPropagatesExistingRecordError(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().SnapshotTS().Return(types.BuildTS(100, 0).ToTimestamp()).AnyTimes()
+
+	bh := &backgroundExecTest{}
+	bh.init()
+
+	record := dataBranchPitrRecord{
+		pitrName:     dataBranchPitrName("table", "88"),
+		level:        "table",
+		accountID:    8,
+		accountName:  "acc_8",
+		databaseName: "db",
+		tableName:    "tbl",
+		objectID:     88,
+	}
+	bh.sql2result[dataBranchPitrRecordSelectSQL(record.pitrName, record.accountID)] =
+		dataBranchExistingPitrResult(1, 1, "bad-unit")
+
+	err := createDataBranchPitrRecord(ctx, nil, bh, txnOp, record)
+	require.Error(t, err)
 }
 
 func TestCreateDataBranchPitrRecordCreatesMissingRecord(t *testing.T) {
@@ -344,6 +459,29 @@ func TestEnsureDataBranchMoCatalogPitrUpdatesDurationWhenNeeded(t *testing.T) {
 		requireExecutedSQLContains(t, bh.executedSQLs, "insert into mo_catalog.mo_pitr")
 		requireExecutedSQLContains(t, bh.executedSQLs, "'sys_mo_catalog_pitr'")
 		requireExecutedSQLContains(t, bh.executedSQLs, "'mo_catalog'")
+	})
+
+	t.Run("propagates database lookup error when creating missing sys pitr", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		bh := &backgroundExecTest{}
+		bh.init()
+		bh.sql2result[selectSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG, defines.MYSQL_TYPE_VARCHAR},
+			nil,
+		)
+
+		txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+		eng := mock_frontend.NewMockEngine(ctrl)
+		wantErr := moerr.NewInternalErrorNoCtx("mo catalog lookup failed")
+		eng.EXPECT().Database(gomock.Any(), catalog.MO_CATALOG, txnOp).Return(nil, wantErr).Times(1)
+
+		ses := newValidateSession(t)
+		ses.proc.Base.SessionInfo.StorageEngine = eng
+
+		err := ensureDataBranchMoCatalogPitr(ctx, ses, bh, txnOp, 789)
+		require.ErrorIs(t, err, wantErr)
 	})
 }
 
@@ -474,6 +612,23 @@ func TestDataBranchPitrCleanupHelpers(t *testing.T) {
 		requireExecutedSQLContains(t, bh.executedSQLs, "delete from mo_catalog.mo_pitr where pitr_name = '__mo_data_branch_pitr_database_55' and create_account = 7")
 	})
 
+	t.Run("delete database pitr without table ids", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		sysPitrRefSQL := fmt.Sprintf(
+			"select pitr_id from mo_catalog.mo_pitr where pitr_name != %s limit 1",
+			quoteSQLStringLiteral(SYSMOCATALOGPITR),
+		)
+		bh.sql2result[sysPitrRefSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_UUID},
+			[][]interface{}{{"pitr-id"}},
+		)
+
+		err := cleanupDataBranchDatabasePitrIfUnused(ctx, bh, 7, 56, nil)
+		require.NoError(t, err)
+		requireExecutedSQLContains(t, bh.executedSQLs, "delete from mo_catalog.mo_pitr where pitr_name = '__mo_data_branch_pitr_database_56' and create_account = 7")
+	})
+
 	t.Run("keep database pitr when active branch still references a table", func(t *testing.T) {
 		bh := &backgroundExecTest{}
 		bh.init()
@@ -535,6 +690,40 @@ func TestDataBranchPitrCleanupHelpers(t *testing.T) {
 		err := cleanupDataBranchDatabasePitrByIDIfUnused(ctx, bh, 7, 66)
 		require.NoError(t, err)
 		requireExecutedSQLContains(t, bh.executedSQLs, "delete from mo_catalog.mo_pitr where pitr_name = '__mo_data_branch_pitr_database_66' and create_account = 7")
+	})
+
+	t.Run("active reference lookup batches large table id sets", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		tableIDs := make([]uint64, 513)
+		for i := range tableIDs {
+			tableIDs[i] = uint64(i + 1)
+		}
+		firstBatch := dataBranchUintListSQL(tableIDs[:512])
+		secondBatch := dataBranchUintListSQL(tableIDs[512:])
+		firstSQL := fmt.Sprintf(
+			"select table_id from mo_catalog.mo_branch_metadata where table_deleted = false and (table_id in (%s) or p_table_id in (%s)) limit 1",
+			firstBatch,
+			firstBatch,
+		)
+		secondSQL := fmt.Sprintf(
+			"select table_id from mo_catalog.mo_branch_metadata where table_deleted = false and (table_id in (%s) or p_table_id in (%s)) limit 1",
+			secondBatch,
+			secondBatch,
+		)
+		bh.sql2result[firstSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG},
+			nil,
+		)
+		bh.sql2result[secondSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{defines.MYSQL_TYPE_LONGLONG},
+			[][]interface{}{{uint64(513)}},
+		)
+
+		hasRef, err := dataBranchTablesHaveActiveReference(ctx, bh, tableIDs)
+		require.NoError(t, err)
+		require.True(t, hasRef)
+		require.Len(t, bh.executedSQLs, 2)
 	})
 }
 
@@ -619,6 +808,30 @@ func TestDataBranchPitrErrorPaths(t *testing.T) {
 
 		_, _, err := getDataBranchDatabasePitrForCleanup(ctx, bh, 7, 55)
 		require.ErrorIs(t, err, wantErr)
+	})
+
+	t.Run("database pitr lookup returns not found for empty result", func(t *testing.T) {
+		bh := &backgroundExecTest{}
+		bh.init()
+		selectSQL := fmt.Sprintf(
+			"select create_account, obj_id, database_name, create_time from mo_catalog.mo_pitr where create_account = %d and pitr_name = %s and level = %s limit 1",
+			uint64(7),
+			quoteSQLStringLiteral(dataBranchPitrName("database", "55")),
+			quoteSQLStringLiteral("database"),
+		)
+		bh.sql2result[selectSQL] = dataBranchTestResultSet(
+			[]defines.MysqlType{
+				defines.MYSQL_TYPE_LONGLONG,
+				defines.MYSQL_TYPE_LONGLONG,
+				defines.MYSQL_TYPE_VARCHAR,
+				defines.MYSQL_TYPE_LONGLONG,
+			},
+			nil,
+		)
+
+		_, found, err := getDataBranchDatabasePitrForCleanup(ctx, bh, 7, 55)
+		require.NoError(t, err)
+		require.False(t, found)
 	})
 }
 

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -54,15 +54,15 @@ var (
 		pitr_unit,
         pitr_status_changed_time) values ('%s', '%s', %d, %d, %d, '%s', %d, '%s', '%s', '%s', %d, %d, '%s', %d);`
 
-	checkPitrFormat = `select pitr_id from mo_catalog.mo_pitr where pitr_name = "%s" and create_account = %d order by pitr_id;`
+	checkPitrFormat = `select pitr_id from mo_catalog.mo_pitr where pitr_name = "%s" and create_account = %d and kind = 'user' order by pitr_id;`
 
-	dropPitrFormat = `delete from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = %d order by pitr_id;`
+	dropPitrFormat = `delete from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = %d and kind = 'user' order by pitr_id;`
 
-	alterPitrFormat = `update mo_catalog.mo_pitr set modified_time = %d, pitr_length = %d, pitr_unit = '%s' where pitr_name = '%s' and create_account = %d;`
+	alterPitrFormat = `update mo_catalog.mo_pitr set modified_time = %d, pitr_length = %d, pitr_unit = '%s' where pitr_name = '%s' and create_account = %d and kind = 'user';`
 
 	getPitrFormat = `select * from mo_catalog.mo_pitr`
 
-	checkDupPitrFormat = `select pitr_id from mo_catalog.mo_pitr where create_account = %d and obj_id = %d;`
+	checkDupPitrFormat = `select pitr_id from mo_catalog.mo_pitr where create_account = %d and obj_id = %d and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';`
 
 	getSqlForCheckDatabaseFmt = `select dat_id from mo_catalog.mo_database {MO_TS = %d} where datname = '%s';`
 
@@ -73,9 +73,9 @@ var (
 	getPubInfoWithPitrFormat = `select pub_name, database_name, database_id, table_list, account_list, created_time, update_time, owner, creator, comment from mo_catalog.mo_pubs {MO_TS = %d} where account_id = %d and database_name = '%s';`
 
 	// update mo_pitr object id
-	updateMoPitrAccountObjectIdFmt = `update mo_catalog.mo_pitr set pitr_status = 0, pitr_status_changed_time = %d where account_name = '%s' and pitr_status = 1 and obj_id = %d;`
+	updateMoPitrAccountObjectIdFmt = `update mo_catalog.mo_pitr set pitr_status = 0, pitr_status_changed_time = %d where account_name = '%s' and pitr_status = 1 and obj_id = %d and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';`
 
-	getLengthAndUnitFmt = `select pitr_length, pitr_unit from mo_catalog.mo_pitr where account_id = %d and level = '%s'`
+	getLengthAndUnitFmt = `select pitr_length, pitr_unit from mo_catalog.mo_pitr where account_id = %d and level = '%s' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%'`
 )
 
 type pitrRecord struct {
@@ -97,6 +97,12 @@ type pitrRecord struct {
 const (
 	SYSMOCATALOGPITR = "sys_mo_catalog_pitr"
 )
+
+func isReservedPitrName(pitrName string) bool {
+	return pitrName == SYSMOCATALOGPITR ||
+		pitrName == dataBranchPitrNamePrefix ||
+		strings.HasPrefix(pitrName, dataBranchPitrNamePrefix+"_")
+}
 
 func getSqlForCreatePitr(
 	ctx context.Context,
@@ -232,14 +238,14 @@ func getSqlForCheckPitrDup(createAccount string, createAccountId uint64, stmt *t
 		return getSqlForCheckDupPitrFormat(createAccountId, math.MaxUint64)
 	case tree.PITRLEVELACCOUNT:
 		if len(stmt.AccountName) > 0 {
-			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", stmt.AccountName)
+			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';", stmt.AccountName)
 		} else {
-			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", createAccount)
+			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';", createAccount)
 		}
 	case tree.PITRLEVELDATABASE:
-		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and level = 'database' and pitr_status = 1;", stmt.DatabaseName)
+		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and level = 'database' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';", stmt.DatabaseName)
 	case tree.PITRLEVELTABLE:
-		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and table_name = '%s' and level = 'table' and pitr_status = 1;", stmt.DatabaseName, stmt.TableName)
+		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and table_name = '%s' and level = 'table' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';", stmt.DatabaseName, stmt.TableName)
 	}
 	return sql
 }
@@ -338,7 +344,7 @@ func doCreatePitr(ctx context.Context, ses *Session, stmt *tree.CreatePitr) erro
 
 	// 6.check pitr exists or not
 	pitrName = string(stmt.Name)
-	if pitrName == SYSMOCATALOGPITR {
+	if isReservedPitrName(pitrName) {
 		return moerr.NewInternalError(ctx, "pitr name is reserved")
 	}
 
@@ -785,6 +791,9 @@ func doDropPitr(ctx context.Context, ses *Session, stmt *tree.DropPitr) (err err
 
 	// check pitr exists or not
 	tenantInfo := ses.GetTenantInfo()
+	if isReservedPitrName(string(stmt.Name)) {
+		return moerr.NewInternalError(ctx, "pitr name is reserved")
+	}
 	pitrExist, err = checkPitrExistOrNot(ctx, bh, string(stmt.Name), uint64(tenantInfo.GetTenantID()))
 	if err != nil {
 		return err
@@ -875,6 +884,9 @@ func doAlterPitr(ctx context.Context, ses *Session, stmt *tree.AlterPitr) (err e
 
 	// check pitr exists or not
 	tenantInfo := ses.GetTenantInfo()
+	if isReservedPitrName(string(stmt.Name)) {
+		return moerr.NewInternalError(ctx, "pitr name is reserved")
+	}
 	pitrExist, err = checkPitrExistOrNot(ctx, bh, string(stmt.Name), uint64(tenantInfo.GetTenantID()))
 	if err != nil {
 		return err
@@ -935,6 +947,9 @@ func doRestorePitr(ctx context.Context, ses *Session, stmt *tree.RestorePitr) (s
 
 	// get pitr name
 	pitrName := string(stmt.Name)
+	if isReservedPitrName(pitrName) {
+		return stats, moerr.NewInternalError(ctx, "pitr name is reserved")
+	}
 	accountName := string(stmt.AccountName)
 	dbName := string(stmt.DatabaseName)
 	tblName := string(stmt.TableName)
@@ -1910,7 +1925,7 @@ func getPitrByName(ctx context.Context, bh BackgroundExec, pitrName string, acco
 		return nil, err
 	}
 
-	sql := fmt.Sprintf("%s where pitr_name = '%s' and create_account = %d", getPitrFormat, pitrName, accountId)
+	sql := fmt.Sprintf("%s where pitr_name = '%s' and create_account = %d and kind = 'user'", getPitrFormat, pitrName, accountId)
 	if records, err := getPitrRecords(newCtx, bh, sql); err != nil {
 		return nil, err
 	} else if len(records) != 1 {

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -781,18 +781,22 @@ func doDropPitr(ctx context.Context, ses *Session, stmt *tree.DropPitr) (err err
 		return err
 	}
 
+	// check pitr exists or not
+	tenantInfo := ses.GetTenantInfo()
+	if isReservedPitrName(string(stmt.Name)) {
+		// Reserved PITRs are maintained internally; IF EXISTS keeps cleanup SQL idempotent.
+		if stmt.IfExists {
+			return nil
+		}
+		return moerr.NewInternalError(ctx, "pitr name is reserved")
+	}
+
 	err = bh.Exec(ctx, "begin;")
 	defer func() {
 		err = finishTxn(ctx, bh, err)
 	}()
 	if err != nil {
 		return err
-	}
-
-	// check pitr exists or not
-	tenantInfo := ses.GetTenantInfo()
-	if isReservedPitrName(string(stmt.Name)) {
-		return moerr.NewInternalError(ctx, "pitr name is reserved")
 	}
 	pitrExist, err = checkPitrExistOrNot(ctx, bh, string(stmt.Name), uint64(tenantInfo.GetTenantID()))
 	if err != nil {

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -62,7 +62,7 @@ var (
 
 	getPitrFormat = `select * from mo_catalog.mo_pitr`
 
-	checkDupPitrFormat = `select pitr_id from mo_catalog.mo_pitr where create_account = %d and obj_id = %d and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';`
+	checkDupPitrFormat = `select pitr_id from mo_catalog.mo_pitr where create_account = %d and obj_id = %d and kind = 'user';`
 
 	getSqlForCheckDatabaseFmt = `select dat_id from mo_catalog.mo_database {MO_TS = %d} where datname = '%s';`
 
@@ -73,9 +73,9 @@ var (
 	getPubInfoWithPitrFormat = `select pub_name, database_name, database_id, table_list, account_list, created_time, update_time, owner, creator, comment from mo_catalog.mo_pubs {MO_TS = %d} where account_id = %d and database_name = '%s';`
 
 	// update mo_pitr object id
-	updateMoPitrAccountObjectIdFmt = `update mo_catalog.mo_pitr set pitr_status = 0, pitr_status_changed_time = %d where account_name = '%s' and pitr_status = 1 and obj_id = %d and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';`
+	updateMoPitrAccountObjectIdFmt = `update mo_catalog.mo_pitr set pitr_status = 0, pitr_status_changed_time = %d where account_name = '%s' and pitr_status = 1 and obj_id = %d and kind = 'user';`
 
-	getLengthAndUnitFmt = `select pitr_length, pitr_unit from mo_catalog.mo_pitr where account_id = %d and level = '%s' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%'`
+	getLengthAndUnitFmt = `select pitr_length, pitr_unit from mo_catalog.mo_pitr where account_id = %d and level = '%s' and pitr_status = 1 and kind = 'user'`
 )
 
 type pitrRecord struct {
@@ -238,14 +238,14 @@ func getSqlForCheckPitrDup(createAccount string, createAccountId uint64, stmt *t
 		return getSqlForCheckDupPitrFormat(createAccountId, math.MaxUint64)
 	case tree.PITRLEVELACCOUNT:
 		if len(stmt.AccountName) > 0 {
-			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';", stmt.AccountName)
+			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user';", stmt.AccountName)
 		} else {
-			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';", createAccount)
+			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user';", createAccount)
 		}
 	case tree.PITRLEVELDATABASE:
-		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and level = 'database' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';", stmt.DatabaseName)
+		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and level = 'database' and pitr_status = 1 and kind = 'user';", stmt.DatabaseName)
 	case tree.PITRLEVELTABLE:
-		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and table_name = '%s' and level = 'table' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';", stmt.DatabaseName, stmt.TableName)
+		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and table_name = '%s' and level = 'table' and pitr_status = 1 and kind = 'user';", stmt.DatabaseName, stmt.TableName)
 	}
 	return sql
 }

--- a/pkg/frontend/pitr.go
+++ b/pkg/frontend/pitr.go
@@ -38,6 +38,13 @@ import (
 )
 
 var (
+	userPitrNameCondition = fmt.Sprintf(
+		"pitr_name != '%s' and left(pitr_name, %d) != '%s'",
+		SYSMOCATALOGPITR,
+		len(dataBranchInternalPitrSQLPrefix),
+		dataBranchInternalPitrSQLPrefix,
+	)
+
 	insertIntoMoPitr = `insert into mo_catalog.mo_pitr(
 		pitr_id,
 		pitr_name,
@@ -54,15 +61,15 @@ var (
 		pitr_unit,
         pitr_status_changed_time) values ('%s', '%s', %d, %d, %d, '%s', %d, '%s', '%s', '%s', %d, %d, '%s', %d);`
 
-	checkPitrFormat = `select pitr_id from mo_catalog.mo_pitr where pitr_name = "%s" and create_account = %d and kind = 'user' order by pitr_id;`
+	checkPitrFormat = `select pitr_id from mo_catalog.mo_pitr where pitr_name = "%s" and create_account = %d order by pitr_id;`
 
-	dropPitrFormat = `delete from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = %d and kind = 'user' order by pitr_id;`
+	dropPitrFormat = `delete from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = %d order by pitr_id;`
 
-	alterPitrFormat = `update mo_catalog.mo_pitr set modified_time = %d, pitr_length = %d, pitr_unit = '%s' where pitr_name = '%s' and create_account = %d and kind = 'user';`
+	alterPitrFormat = `update mo_catalog.mo_pitr set modified_time = %d, pitr_length = %d, pitr_unit = '%s' where pitr_name = '%s' and create_account = %d;`
 
 	getPitrFormat = `select * from mo_catalog.mo_pitr`
 
-	checkDupPitrFormat = `select pitr_id from mo_catalog.mo_pitr where create_account = %d and obj_id = %d and kind = 'user';`
+	checkDupPitrFormat = `select pitr_id from mo_catalog.mo_pitr where create_account = %d and obj_id = %d and ` + userPitrNameCondition + `;`
 
 	getSqlForCheckDatabaseFmt = `select dat_id from mo_catalog.mo_database {MO_TS = %d} where datname = '%s';`
 
@@ -73,9 +80,9 @@ var (
 	getPubInfoWithPitrFormat = `select pub_name, database_name, database_id, table_list, account_list, created_time, update_time, owner, creator, comment from mo_catalog.mo_pubs {MO_TS = %d} where account_id = %d and database_name = '%s';`
 
 	// update mo_pitr object id
-	updateMoPitrAccountObjectIdFmt = `update mo_catalog.mo_pitr set pitr_status = 0, pitr_status_changed_time = %d where account_name = '%s' and pitr_status = 1 and obj_id = %d and kind = 'user';`
+	updateMoPitrAccountObjectIdFmt = `update mo_catalog.mo_pitr set pitr_status = 0, pitr_status_changed_time = %d where account_name = '%s' and pitr_status = 1 and obj_id = %d and ` + userPitrNameCondition + `;`
 
-	getLengthAndUnitFmt = `select pitr_length, pitr_unit from mo_catalog.mo_pitr where account_id = %d and level = '%s' and pitr_status = 1 and kind = 'user'`
+	getLengthAndUnitFmt = `select pitr_length, pitr_unit from mo_catalog.mo_pitr where account_id = %d and level = '%s' and pitr_status = 1 and ` + userPitrNameCondition
 )
 
 type pitrRecord struct {
@@ -232,20 +239,24 @@ func checkPitrDup(ctx context.Context, bh BackgroundExec, createAccount string, 
 // if level is table, check whether has a pitr which account_name db_name and tbl_name is the same
 // @return sql
 func getSqlForCheckPitrDup(createAccount string, createAccountId uint64, stmt *tree.CreatePitr) string {
-	sql := "select pitr_id from mo_catalog.mo_pitr where create_account = %d"
+	sql := fmt.Sprintf(
+		"select pitr_id from mo_catalog.mo_pitr where create_account = %d and %s",
+		createAccountId,
+		userPitrNameCondition,
+	)
 	switch stmt.Level {
 	case tree.PITRLEVELCLUSTER:
 		return getSqlForCheckDupPitrFormat(createAccountId, math.MaxUint64)
 	case tree.PITRLEVELACCOUNT:
 		if len(stmt.AccountName) > 0 {
-			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user';", stmt.AccountName)
+			return sql + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", stmt.AccountName)
 		} else {
-			return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user';", createAccount)
+			return sql + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", createAccount)
 		}
 	case tree.PITRLEVELDATABASE:
-		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and level = 'database' and pitr_status = 1 and kind = 'user';", stmt.DatabaseName)
+		return sql + fmt.Sprintf(" and database_name = '%s' and level = 'database' and pitr_status = 1;", stmt.DatabaseName)
 	case tree.PITRLEVELTABLE:
-		return fmt.Sprintf(sql, createAccountId) + fmt.Sprintf(" and database_name = '%s' and table_name = '%s' and level = 'table' and pitr_status = 1 and kind = 'user';", stmt.DatabaseName, stmt.TableName)
+		return sql + fmt.Sprintf(" and database_name = '%s' and table_name = '%s' and level = 'table' and pitr_status = 1;", stmt.DatabaseName, stmt.TableName)
 	}
 	return sql
 }
@@ -1929,7 +1940,7 @@ func getPitrByName(ctx context.Context, bh BackgroundExec, pitrName string, acco
 		return nil, err
 	}
 
-	sql := fmt.Sprintf("%s where pitr_name = '%s' and create_account = %d and kind = 'user'", getPitrFormat, pitrName, accountId)
+	sql := fmt.Sprintf("%s where pitr_name = '%s' and create_account = %d", getPitrFormat, pitrName, accountId)
 	if records, err := getPitrRecords(newCtx, bh, sql); err != nil {
 		return nil, err
 	} else if len(records) != 1 {

--- a/pkg/frontend/pitr_test.go
+++ b/pkg/frontend/pitr_test.go
@@ -289,7 +289,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -369,7 +369,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -451,7 +451,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -534,7 +534,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -618,7 +618,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -716,7 +716,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -813,7 +813,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -911,7 +911,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1007,7 +1007,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1088,7 +1088,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1172,7 +1172,7 @@ func Test_doRestorePitrValid(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1253,7 +1253,7 @@ func Test_doRestorePitrValid(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1296,7 +1296,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 			stmt: &tree.CreatePitr{
 				Level: tree.PITRLEVELCLUSTER,
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and obj_id = 18446744073709551615;",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and obj_id = 18446744073709551615 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
 		},
 		{
 			createAccount:   "sys",
@@ -1304,7 +1304,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 			stmt: &tree.CreatePitr{
 				Level: tree.PITRLEVELACCOUNT,
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and account_name = 'sys' and level = 'account' and pitr_status = 1;",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and account_name = 'sys' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
 		},
 		{
 			createAccount:   "testAccount",
@@ -1312,7 +1312,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 			stmt: &tree.CreatePitr{
 				Level: tree.PITRLEVELACCOUNT,
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and account_name = 'testAccount' and level = 'account' and pitr_status = 1;",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and account_name = 'testAccount' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
 		},
 		{
 			createAccount:   "sys",
@@ -1321,7 +1321,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				Level:       tree.PITRLEVELACCOUNT,
 				AccountName: "testAccountName",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and account_name = 'testAccountName' and level = 'account' and pitr_status = 1;",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and account_name = 'testAccountName' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
 		},
 		{
 			createAccount:   "sys",
@@ -1330,7 +1330,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				Level:        tree.PITRLEVELDATABASE,
 				DatabaseName: "testDb",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and database_name = 'testDb' and level = 'database' and pitr_status = 1;",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and database_name = 'testDb' and level = 'database' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
 		},
 		{
 			createAccount:   "testAccount",
@@ -1339,7 +1339,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				Level:        tree.PITRLEVELDATABASE,
 				DatabaseName: "testDb",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and database_name = 'testDb' and level = 'database' and pitr_status = 1;",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and database_name = 'testDb' and level = 'database' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
 		},
 		{
 			createAccount:   "sys",
@@ -1349,7 +1349,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				DatabaseName: "testDb",
 				TableName:    "testTable",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1;",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
 		},
 		{
 			createAccount:   "testAccount",
@@ -1359,7 +1359,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				DatabaseName: "testDb",
 				TableName:    "testTable",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1;",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
 		},
 	}
 
@@ -1427,7 +1427,7 @@ func Test_doRestorePitr_Account(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1553,7 +1553,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1672,7 +1672,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_To_new(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1793,7 +1793,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_To_new(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1913,7 +1913,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_Using_cluster(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -2035,7 +2035,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_Using_cluster(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -2155,7 +2155,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_To_new_Using_cluster(t *testi
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -2281,7 +2281,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_To_new_Using_cluster(t *testi
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -2403,7 +2403,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_To_new_Using_cluster(t *testi
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -2543,7 +2543,7 @@ func Test_doCreatePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{})
 		bh.sql2result[sql] = mrs
 
-		sql = fmt.Sprintf("select pitr_id from mo_catalog.mo_pitr where create_account = %d", sysAccountID) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", sysAccountName)
+		sql = fmt.Sprintf("select pitr_id from mo_catalog.mo_pitr where create_account = %d", sysAccountID) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';", sysAccountName)
 		mrs = newMrsForPitrRecord([][]interface{}{})
 		bh.sql2result[sql] = mrs
 
@@ -3241,7 +3241,7 @@ func Test_RestoreOtherAccount(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -3330,7 +3330,7 @@ func Test_RestoreOtherAccount(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -3420,7 +3420,7 @@ func Test_RestoreOtherAccount(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -3510,7 +3510,7 @@ func Test_RestoreOtherAccount(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -3574,4 +3574,13 @@ func Test_getPitrLengthAndUnit(t *testing.T) {
 
 	_, _, _, err = getPitrLengthAndUnit(ctx, bh, "table", "", "", "tbl")
 	assert.Error(t, err)
+}
+
+func Test_isReservedPitrName(t *testing.T) {
+	assert.True(t, isReservedPitrName(SYSMOCATALOGPITR))
+	assert.True(t, isReservedPitrName("__mo_data_branch_pitr"))
+	assert.True(t, isReservedPitrName("__mo_data_branch_pitr_table_123"))
+	assert.True(t, isReservedPitrName("__mo_data_branch_pitr_database_456"))
+	assert.False(t, isReservedPitrName("__mo_data_branch_pitrx_table_123"))
+	assert.False(t, isReservedPitrName("user_pitr"))
 }

--- a/pkg/frontend/pitr_test.go
+++ b/pkg/frontend/pitr_test.go
@@ -1296,7 +1296,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 			stmt: &tree.CreatePitr{
 				Level: tree.PITRLEVELCLUSTER,
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and obj_id = 18446744073709551615 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and obj_id = 18446744073709551615 and kind = 'user';",
 		},
 		{
 			createAccount:   "sys",
@@ -1304,7 +1304,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 			stmt: &tree.CreatePitr{
 				Level: tree.PITRLEVELACCOUNT,
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and account_name = 'sys' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and account_name = 'sys' and level = 'account' and pitr_status = 1 and kind = 'user';",
 		},
 		{
 			createAccount:   "testAccount",
@@ -1312,7 +1312,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 			stmt: &tree.CreatePitr{
 				Level: tree.PITRLEVELACCOUNT,
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and account_name = 'testAccount' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and account_name = 'testAccount' and level = 'account' and pitr_status = 1 and kind = 'user';",
 		},
 		{
 			createAccount:   "sys",
@@ -1321,7 +1321,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				Level:       tree.PITRLEVELACCOUNT,
 				AccountName: "testAccountName",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and account_name = 'testAccountName' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and account_name = 'testAccountName' and level = 'account' and pitr_status = 1 and kind = 'user';",
 		},
 		{
 			createAccount:   "sys",
@@ -1330,7 +1330,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				Level:        tree.PITRLEVELDATABASE,
 				DatabaseName: "testDb",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and database_name = 'testDb' and level = 'database' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and database_name = 'testDb' and level = 'database' and pitr_status = 1 and kind = 'user';",
 		},
 		{
 			createAccount:   "testAccount",
@@ -1339,7 +1339,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				Level:        tree.PITRLEVELDATABASE,
 				DatabaseName: "testDb",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and database_name = 'testDb' and level = 'database' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and database_name = 'testDb' and level = 'database' and pitr_status = 1 and kind = 'user';",
 		},
 		{
 			createAccount:   "sys",
@@ -1349,7 +1349,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				DatabaseName: "testDb",
 				TableName:    "testTable",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1 and kind = 'user';",
 		},
 		{
 			createAccount:   "testAccount",
@@ -1359,7 +1359,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				DatabaseName: "testDb",
 				TableName:    "testTable",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1 and kind = 'user';",
 		},
 	}
 
@@ -2543,7 +2543,7 @@ func Test_doCreatePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{})
 		bh.sql2result[sql] = mrs
 
-		sql = fmt.Sprintf("select pitr_id from mo_catalog.mo_pitr where create_account = %d", sysAccountID) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user' and pitr_name not like '__mo_data_branch_pitr_%%';", sysAccountName)
+		sql = fmt.Sprintf("select pitr_id from mo_catalog.mo_pitr where create_account = %d", sysAccountID) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user';", sysAccountName)
 		mrs = newMrsForPitrRecord([][]interface{}{})
 		bh.sql2result[sql] = mrs
 

--- a/pkg/frontend/pitr_test.go
+++ b/pkg/frontend/pitr_test.go
@@ -289,7 +289,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -369,7 +369,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -451,7 +451,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -534,7 +534,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -618,7 +618,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -716,7 +716,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -813,7 +813,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -911,7 +911,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1007,7 +1007,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1088,7 +1088,7 @@ func Test_doRestorePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1172,7 +1172,7 @@ func Test_doRestorePitrValid(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1253,7 +1253,7 @@ func Test_doRestorePitrValid(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1296,7 +1296,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 			stmt: &tree.CreatePitr{
 				Level: tree.PITRLEVELCLUSTER,
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and obj_id = 18446744073709551615 and kind = 'user';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and obj_id = 18446744073709551615 and pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';",
 		},
 		{
 			createAccount:   "sys",
@@ -1304,7 +1304,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 			stmt: &tree.CreatePitr{
 				Level: tree.PITRLEVELACCOUNT,
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and account_name = 'sys' and level = 'account' and pitr_status = 1 and kind = 'user';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_' and account_name = 'sys' and level = 'account' and pitr_status = 1;",
 		},
 		{
 			createAccount:   "testAccount",
@@ -1312,7 +1312,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 			stmt: &tree.CreatePitr{
 				Level: tree.PITRLEVELACCOUNT,
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and account_name = 'testAccount' and level = 'account' and pitr_status = 1 and kind = 'user';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_' and account_name = 'testAccount' and level = 'account' and pitr_status = 1;",
 		},
 		{
 			createAccount:   "sys",
@@ -1321,7 +1321,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				Level:       tree.PITRLEVELACCOUNT,
 				AccountName: "testAccountName",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and account_name = 'testAccountName' and level = 'account' and pitr_status = 1 and kind = 'user';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_' and account_name = 'testAccountName' and level = 'account' and pitr_status = 1;",
 		},
 		{
 			createAccount:   "sys",
@@ -1330,7 +1330,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				Level:        tree.PITRLEVELDATABASE,
 				DatabaseName: "testDb",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and database_name = 'testDb' and level = 'database' and pitr_status = 1 and kind = 'user';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_' and database_name = 'testDb' and level = 'database' and pitr_status = 1;",
 		},
 		{
 			createAccount:   "testAccount",
@@ -1339,7 +1339,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				Level:        tree.PITRLEVELDATABASE,
 				DatabaseName: "testDb",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and database_name = 'testDb' and level = 'database' and pitr_status = 1 and kind = 'user';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_' and database_name = 'testDb' and level = 'database' and pitr_status = 1;",
 		},
 		{
 			createAccount:   "sys",
@@ -1349,7 +1349,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				DatabaseName: "testDb",
 				TableName:    "testTable",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1 and kind = 'user';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 0 and pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_' and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1;",
 		},
 		{
 			createAccount:   "testAccount",
@@ -1359,7 +1359,7 @@ func TestGetSqlForCheckPitrDup(t *testing.T) {
 				DatabaseName: "testDb",
 				TableName:    "testTable",
 			},
-			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1 and kind = 'user';",
+			expected: "select pitr_id from mo_catalog.mo_pitr where create_account = 1 and pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_' and database_name = 'testDb' and table_name = 'testTable' and level = 'table' and pitr_status = 1;",
 		},
 	}
 
@@ -1427,7 +1427,7 @@ func Test_doRestorePitr_Account(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1553,7 +1553,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1672,7 +1672,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_To_new(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1793,7 +1793,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_To_new(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -1913,7 +1913,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_Using_cluster(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -2035,7 +2035,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_Using_cluster(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -2155,7 +2155,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_To_new_Using_cluster(t *testi
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -2281,7 +2281,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_To_new_Using_cluster(t *testi
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -2403,7 +2403,7 @@ func Test_doRestorePitr_Account_Sys_Restore_Normal_To_new_Using_cluster(t *testi
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -2543,7 +2543,7 @@ func Test_doCreatePitr(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{})
 		bh.sql2result[sql] = mrs
 
-		sql = fmt.Sprintf("select pitr_id from mo_catalog.mo_pitr where create_account = %d", sysAccountID) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1 and kind = 'user';", sysAccountName)
+		sql = fmt.Sprintf("select pitr_id from mo_catalog.mo_pitr where create_account = %d and pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_'", sysAccountID) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", sysAccountName)
 		mrs = newMrsForPitrRecord([][]interface{}{})
 		bh.sql2result[sql] = mrs
 
@@ -3241,7 +3241,7 @@ func Test_RestoreOtherAccount(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -3330,7 +3330,7 @@ func Test_RestoreOtherAccount(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -3420,7 +3420,7 @@ func Test_RestoreOtherAccount(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",
@@ -3510,7 +3510,7 @@ func Test_RestoreOtherAccount(t *testing.T) {
 		mrs := newMrsForPitrRecord([][]interface{}{{"018ee4cd-5991-7caa-b75d-f9290144bd9f"}})
 		bh.sql2result[sql] = mrs
 
-		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0 and kind = 'user'"
+		sql = "select * from mo_catalog.mo_pitr where pitr_name = 'pitr01' and create_account = 0"
 		mrs = newMrsForPitrRecord([][]interface{}{{
 			"018ee4cd-5991-7caa-b75d-f9290144bd9f",
 			"pitr01",

--- a/pkg/frontend/predefined.go
+++ b/pkg/frontend/predefined.go
@@ -154,6 +154,7 @@ var (
 			pitr_unit varchar(10),
 			pitr_status tinyint unsigned default 1 comment '1: active, 0: inactive',
 			pitr_status_changed_time bigint not null,
+			kind varchar(32) not null default 'user',
 			primary key(pitr_name, create_account)
 			)`, catalog.MO_CATALOG, catalog.MO_PITR)
 

--- a/pkg/frontend/predefined.go
+++ b/pkg/frontend/predefined.go
@@ -154,7 +154,6 @@ var (
 			pitr_unit varchar(10),
 			pitr_status tinyint unsigned default 1 comment '1: active, 0: inactive',
 			pitr_status_changed_time bigint not null,
-			kind varchar(32) not null default 'user',
 			primary key(pitr_name, create_account)
 			)`, catalog.MO_CATALOG, catalog.MO_PITR)
 

--- a/pkg/frontend/show_recovery_window.go
+++ b/pkg/frontend/show_recovery_window.go
@@ -198,7 +198,7 @@ func constructRecoveryWindow(
 			"	modified_time, pitr_length, pitr_unit, pitr_status, pitr_status_changed_time "+
 			"from "+
 			"`%s`.`%s` "+
-			"	where %s AND pitr_name != '%s'",
+			"	where %s AND pitr_name != '%s' AND kind = 'user' AND pitr_name not like '__mo_data_branch_pitr_%%'",
 		catalog.MO_CATALOG, catalog.MO_PITR, snapPitrSearchCond, SYSMOCATALOGPITR,
 	)
 

--- a/pkg/frontend/show_recovery_window.go
+++ b/pkg/frontend/show_recovery_window.go
@@ -198,7 +198,7 @@ func constructRecoveryWindow(
 			"	modified_time, pitr_length, pitr_unit, pitr_status, pitr_status_changed_time "+
 			"from "+
 			"`%s`.`%s` "+
-			"	where %s AND pitr_name != '%s' AND kind = 'user' AND pitr_name not like '__mo_data_branch_pitr_%%'",
+			"	where %s AND pitr_name != '%s' AND kind = 'user'",
 		catalog.MO_CATALOG, catalog.MO_PITR, snapPitrSearchCond, SYSMOCATALOGPITR,
 	)
 

--- a/pkg/frontend/show_recovery_window.go
+++ b/pkg/frontend/show_recovery_window.go
@@ -198,8 +198,8 @@ func constructRecoveryWindow(
 			"	modified_time, pitr_length, pitr_unit, pitr_status, pitr_status_changed_time "+
 			"from "+
 			"`%s`.`%s` "+
-			"	where %s AND pitr_name != '%s' AND kind = 'user'",
-		catalog.MO_CATALOG, catalog.MO_PITR, snapPitrSearchCond, SYSMOCATALOGPITR,
+			"	where %s AND %s",
+		catalog.MO_CATALOG, catalog.MO_PITR, snapPitrSearchCond, userPitrNameCondition,
 	)
 
 	var (

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -2950,7 +2950,6 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 		return err
 	}
 
-	tblID := qry.GetTableId()
 	dbSource, err = c.e.Database(c.proc.Ctx, dbName, c.proc.GetTxnOperator())
 	if err != nil {
 		if qry.GetIfExists() {
@@ -2977,6 +2976,7 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 		}
 		isTemp = true
 	}
+	tblID := rel.GetTableID(c.proc.Ctx)
 
 	if !isTemp && !isView && !isSource && c.proc.GetTxnOperator().Txn().IsPessimistic() {
 		var err error

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -185,6 +186,10 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	if err != nil {
 		return err
 	}
+	databaseID, err := strconv.ParseUint(database.GetDatabaseId(c.proc.Ctx), 10, 64)
+	if err != nil {
+		return err
+	}
 	relations, err := database.Relations(c.proc.Ctx)
 	if err != nil {
 		return err
@@ -212,11 +217,13 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	}
 
 	ignoreTables := make(map[string]struct{})
+	relationIDs := make(map[string]uint64, len(relations))
 	for _, r := range relations {
 		t, err := database.Relation(c.proc.Ctx, r, nil)
 		if err != nil {
 			return err
 		}
+		relationIDs[r] = t.GetTableID(c.proc.Ctx)
 		defs, err := t.TableDefs(c.proc.Ctx)
 		if err != nil {
 			return err
@@ -257,6 +264,12 @@ func (s *Scope) DropDatabase(c *Compile) error {
 			deleteTables = append(deleteTables, r)
 		}
 	}
+	tableIDs := make([]uint64, 0, len(deleteTables))
+	for _, t := range deleteTables {
+		if id, ok := relationIDs[t]; ok {
+			tableIDs = append(tableIDs, id)
+		}
+	}
 
 	for _, t := range deleteTables {
 		dropSql := fmt.Sprintf(dropTableBeforeDropDatabase, dbName, t)
@@ -294,7 +307,7 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	// 4.update mo_pitr table
 	if !needSkipDbs[dbName] {
 		now := c.proc.GetTxnOperator().SnapshotTS().ToStdTime().UTC().UnixNano()
-		updatePitrSql := fmt.Sprintf("UPDATE `%s`.`%s` SET `%s` = %d, `%s` = %d WHERE `%s` = %d AND `%s` = '%s' AND `%s` = %d AND `%s` = %s",
+		updatePitrSql := fmt.Sprintf("UPDATE `%s`.`%s` SET `%s` = %d, `%s` = %d WHERE `%s` = %d AND `%s` = '%s' AND `%s` = %d AND `%s` = %s AND `kind` = 'user'",
 			catalog.MO_CATALOG, catalog.MO_PITR,
 			catalog.MO_PITR_STATUS, 0,
 			catalog.MO_PITR_CHANGED_TIME, now,
@@ -309,6 +322,14 @@ func (s *Scope) DropDatabase(c *Compile) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if err = c.cleanupDataBranchPitrsForDroppedDatabase(
+		uint64(accountId),
+		databaseID,
+		tableIDs,
+	); err != nil {
+		return err
 	}
 	return err
 }
@@ -1619,6 +1640,211 @@ func (c *Compile) runSqlWithSystemTenant(sql string) error {
 		c.proc.Ctx = oldCtx
 	}()
 	return c.runSql(sql)
+}
+
+const (
+	dataBranchInternalPitrNamePrefix     = "__mo_data_branch_pitr"
+	dataBranchInternalTablePitrPrefix    = dataBranchInternalPitrNamePrefix + "_table_"
+	dataBranchInternalDatabasePitrPrefix = dataBranchInternalPitrNamePrefix + "_database_"
+	dataBranchInternalPitrKind           = "internal"
+	dataBranchSysMoCatalogPitrName       = "sys_mo_catalog_pitr"
+)
+
+func isReservedPitrName(pitrName string) bool {
+	return pitrName == dataBranchSysMoCatalogPitrName ||
+		pitrName == dataBranchInternalPitrNamePrefix ||
+		strings.HasPrefix(pitrName, dataBranchInternalPitrNamePrefix+"_")
+}
+
+type dataBranchDatabasePitrForCleanup struct {
+	accountID  uint64
+	databaseID uint64
+	database   string
+	createTime int64
+}
+
+func (c *Compile) cleanupDataBranchPitrsForDroppedTable(accountID uint64, databaseID uint64, tableID uint64) error {
+	if err := c.cleanupDataBranchTablePitrAfterDDL(accountID, tableID); err != nil {
+		return err
+	}
+	if err := c.cleanupDataBranchDatabasePitrByIDAfterDDL(accountID, databaseID); err != nil {
+		return err
+	}
+	return c.cleanupDataBranchMoCatalogPitrAfterDDL()
+}
+
+func (c *Compile) cleanupDataBranchPitrsForDroppedDatabase(accountID uint64, databaseID uint64, tableIDs []uint64) error {
+	for _, tableID := range tableIDs {
+		if err := c.cleanupDataBranchTablePitrAfterDDL(accountID, tableID); err != nil {
+			return err
+		}
+	}
+	if err := c.cleanupDataBranchDatabasePitrByIDAfterDDL(accountID, databaseID); err != nil {
+		return err
+	}
+	return c.cleanupDataBranchMoCatalogPitrAfterDDL()
+}
+
+func (c *Compile) cleanupDataBranchTablePitrAfterDDL(accountID uint64, tableID uint64) error {
+	pitrName := dataBranchInternalTablePitrPrefix + strconv.FormatUint(tableID, 10)
+	sql := fmt.Sprintf(
+		"delete from mo_catalog.mo_pitr where create_account = %d and pitr_name = %s and not exists (select 1 from mo_catalog.mo_branch_metadata where table_deleted = false and (table_id = %d or p_table_id = %d))",
+		accountID,
+		quoteCompileSQLStringLiteral(pitrName),
+		tableID,
+		tableID,
+	)
+	return c.runSqlWithSystemTenant(sql)
+}
+
+func (c *Compile) cleanupDataBranchDatabasePitrByIDAfterDDL(accountID uint64, databaseID uint64) error {
+	pitr, found, err := c.getDataBranchDatabasePitrForCleanup(accountID, databaseID)
+	if err != nil || !found {
+		return err
+	}
+	tableIDs, err := c.dataBranchDatabaseTableIDsAt(pitr.accountID, pitr.database, pitr.createTime)
+	if err != nil {
+		return err
+	}
+	return c.cleanupDataBranchDatabasePitrAfterDDL(pitr.accountID, pitr.databaseID, tableIDs)
+}
+
+func (c *Compile) getDataBranchDatabasePitrForCleanup(accountID uint64, databaseID uint64) (dataBranchDatabasePitrForCleanup, bool, error) {
+	if databaseID == 0 {
+		return dataBranchDatabasePitrForCleanup{}, false, nil
+	}
+	pitrName := dataBranchInternalDatabasePitrPrefix + strconv.FormatUint(databaseID, 10)
+	sql := fmt.Sprintf(
+		"select create_account, obj_id, database_name, create_time from mo_catalog.mo_pitr where create_account = %d and pitr_name = %s and level = '%s' limit 1",
+		accountID,
+		quoteCompileSQLStringLiteral(pitrName),
+		tree.PITRLEVELDATABASE.String(),
+	)
+	rs, err := c.runSqlWithResultAndOptions(sql, int32(catalog.System_Account), executor.StatementOption{}.WithDisableLog())
+	if err != nil {
+		return dataBranchDatabasePitrForCleanup{}, false, err
+	}
+	defer rs.Close()
+
+	var (
+		pitr  dataBranchDatabasePitrForCleanup
+		found bool
+	)
+	rs.ReadRows(func(rows int, cols []*vector.Vector) bool {
+		if rows == 0 {
+			return false
+		}
+		pitr = dataBranchDatabasePitrForCleanup{
+			accountID:  vector.GetFixedAtWithTypeCheck[uint64](cols[0], 0),
+			databaseID: vector.GetFixedAtWithTypeCheck[uint64](cols[1], 0),
+			database:   cols[2].GetStringAt(0),
+			createTime: vector.GetFixedAtWithTypeCheck[int64](cols[3], 0),
+		}
+		found = true
+		return false
+	})
+	return pitr, found, nil
+}
+
+func (c *Compile) cleanupDataBranchDatabasePitrAfterDDL(accountID uint64, databaseID uint64, tableIDs []uint64) error {
+	if len(tableIDs) > 0 {
+		hasRef, err := c.dataBranchTablesHaveActiveReference(tableIDs)
+		if err != nil {
+			return err
+		}
+		if hasRef {
+			return nil
+		}
+	}
+	pitrName := dataBranchInternalDatabasePitrPrefix + strconv.FormatUint(databaseID, 10)
+	sql := fmt.Sprintf(
+		"delete from mo_catalog.mo_pitr where create_account = %d and pitr_name = %s",
+		accountID,
+		quoteCompileSQLStringLiteral(pitrName),
+	)
+	return c.runSqlWithSystemTenant(sql)
+}
+
+func (c *Compile) dataBranchDatabaseTableIDsAt(accountID uint64, databaseName string, ts int64) ([]uint64, error) {
+	sql := fmt.Sprintf(
+		"select rel_id from mo_catalog.mo_tables {MO_TS = %d} where account_id = %d and reldatabase = %s",
+		ts,
+		accountID,
+		quoteCompileSQLStringLiteral(databaseName),
+	)
+	rs, err := c.runSqlWithResultAndOptions(sql, int32(catalog.System_Account), executor.StatementOption{}.WithDisableLog())
+	if err != nil {
+		return nil, err
+	}
+	defer rs.Close()
+
+	tableIDs := make([]uint64, 0)
+	rs.ReadRows(func(rows int, cols []*vector.Vector) bool {
+		if rows == 0 {
+			return true
+		}
+		tableIDs = append(tableIDs, executor.GetFixedRows[uint64](cols[0])...)
+		return true
+	})
+	return tableIDs, nil
+}
+
+func (c *Compile) dataBranchTablesHaveActiveReference(tableIDs []uint64) (bool, error) {
+	if len(tableIDs) == 0 {
+		return false, nil
+	}
+	const batchSize = 512
+	for start := 0; start < len(tableIDs); start += batchSize {
+		end := start + batchSize
+		if end > len(tableIDs) {
+			end = len(tableIDs)
+		}
+		idList := dataBranchUintListSQL(tableIDs[start:end])
+		sql := fmt.Sprintf(
+			"select table_id from mo_catalog.mo_branch_metadata where table_deleted = false and (table_id in (%s) or p_table_id in (%s)) limit 1",
+			idList,
+			idList,
+		)
+		rs, err := c.runSqlWithResultAndOptions(sql, int32(catalog.System_Account), executor.StatementOption{}.WithDisableLog())
+		if err != nil {
+			return false, err
+		}
+		hasRef := false
+		rs.ReadRows(func(rows int, cols []*vector.Vector) bool {
+			hasRef = rows > 0
+			return false
+		})
+		rs.Close()
+		if hasRef {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (c *Compile) cleanupDataBranchMoCatalogPitrAfterDDL() error {
+	sql := fmt.Sprintf(
+		"delete from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = 0 and kind = '%s' and not exists (select 1 from mo_catalog.mo_pitr where pitr_name != '%s')",
+		dataBranchSysMoCatalogPitrName,
+		dataBranchInternalPitrKind,
+		dataBranchSysMoCatalogPitrName,
+	)
+	return c.runSqlWithSystemTenant(sql)
+}
+
+func dataBranchUintListSQL(ids []uint64) string {
+	var sqlBuilder strings.Builder
+	for i, id := range ids {
+		if i > 0 {
+			sqlBuilder.WriteByte(',')
+		}
+		sqlBuilder.WriteString(strconv.FormatUint(id, 10))
+	}
+	return sqlBuilder.String()
+}
+
+func quoteCompileSQLStringLiteral(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
 func (s *Scope) CreateView(c *Compile) error {
@@ -2958,11 +3184,15 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 	if err != nil {
 		return err
 	}
+	databaseID, err := strconv.ParseUint(dbSource.GetDatabaseId(c.proc.Ctx), 10, 64)
+	if err != nil {
+		return err
+	}
 
 	if !needSkipDbs[dbName] {
 		now := c.proc.GetTxnOperator().SnapshotTS().ToStdTime().UTC().UnixNano()
 		updatePitrSql := fmt.Sprintf(
-			"UPDATE `%s`.`%s` SET `%s` = %d, `%s` = %d WHERE `%s` = %d AND `%s` = '%s' AND `%s` = '%s' AND `%s` = %d AND `%s` = %d",
+			"UPDATE `%s`.`%s` SET `%s` = %d, `%s` = %d WHERE `%s` = %d AND `%s` = '%s' AND `%s` = '%s' AND `%s` = %d AND `%s` = %d AND `kind` = 'user'",
 			catalog.MO_CATALOG, catalog.MO_PITR,
 			catalog.MO_PITR_STATUS, 0,
 			catalog.MO_PITR_CHANGED_TIME, now,
@@ -3000,6 +3230,10 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 			)
 			return err
 		}
+	}
+
+	if err = c.cleanupDataBranchPitrsForDroppedTable(uint64(accountID), databaseID, tblID); err != nil {
+		return err
 	}
 
 	return partitionservice.GetService(c.proc.GetService()).Delete(
@@ -4018,6 +4252,9 @@ func (s *Scope) CreatePitr(c *Compile) error {
 	createPitr := s.Plan.GetDdl().GetCreatePitr()
 	pitrName := createPitr.GetName()
 	pitrLevel := tree.PitrLevel(createPitr.GetLevel())
+	if isReservedPitrName(pitrName) {
+		return moerr.NewInternalError(c.proc.Ctx, "pitr name is reserved")
+	}
 
 	// Get current account info
 	accountId, err := defines.GetAccountId(c.proc.Ctx)
@@ -4027,7 +4264,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
 
 	// check pitr if exists（pitr_name + create_account）
 	checkExistSql := getSqlForCheckPitrExists(pitrName, accountId)
-	existRes, err := c.runSqlWithResultAndOptions(checkExistSql, int32(accountId), executor.StatementOption{}.WithDisableLog())
+	existRes, err := c.runSqlWithResultAndOptions(checkExistSql, int32(sysAccountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -4042,7 +4279,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
 
 	// Check if pitr dup
 	checkSql := getSqlForCheckPitrDup(createPitr)
-	res, err := c.runSqlWithResultAndOptions(checkSql, int32(accountId), executor.StatementOption{}.WithDisableLog())
+	res, err := c.runSqlWithResultAndOptions(checkSql, int32(sysAccountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -4091,7 +4328,7 @@ func (s *Scope) CreatePitr(c *Compile) error {
 	)
 
 	// Execute create pitr sql
-	err = c.runSqlWithOptions(sql, executor.StatementOption{}.WithDisableLog())
+	err = c.runSqlWithAccountIdAndOptions(sql, int32(sysAccountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -4210,7 +4447,14 @@ func (s *Scope) DropPitr(c *Compile) error {
 	if pitrName == "" {
 		return moerr.NewInternalErrorf(c.proc.Ctx, "pitr name is empty")
 	}
-	const sysMoCatalogPitr = "sys_mo_catalog_pitr"
+	if isReservedPitrName(pitrName) {
+		// Reserved PITRs are maintained internally; IF EXISTS keeps cleanup SQL idempotent.
+		if dropPitr.GetIfExists() {
+			return nil
+		}
+		return moerr.NewInternalError(c.proc.Ctx, "pitr name is reserved")
+	}
+	const sysMoCatalogPitr = dataBranchSysMoCatalogPitrName
 	const sysAccountId = 0
 
 	// Get current account
@@ -4220,8 +4464,9 @@ func (s *Scope) DropPitr(c *Compile) error {
 	}
 
 	// 1. Check if PITR exists
-	checkSql := fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", pitrName, accountId)
-	res, err := c.runSqlWithResultAndOptions(checkSql, int32(accountId), executor.StatementOption{}.WithDisableLog())
+	pitrNameLiteral := quoteCompileSQLStringLiteral(pitrName)
+	checkSql := fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = %s AND create_account = %d AND kind = 'user'", pitrNameLiteral, accountId)
+	res, err := c.runSqlWithResultAndOptions(checkSql, int32(sysAccountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -4234,8 +4479,8 @@ func (s *Scope) DropPitr(c *Compile) error {
 	}
 
 	// 2. Delete PITR record
-	deleteSql := fmt.Sprintf("DELETE FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", pitrName, accountId)
-	err = c.runSqlWithAccountIdAndOptions(deleteSql, int32(accountId), executor.StatementOption{}.WithDisableLog())
+	deleteSql := fmt.Sprintf("DELETE FROM mo_catalog.mo_pitr WHERE pitr_name = %s AND create_account = %d AND kind = 'user'", pitrNameLiteral, accountId)
+	err = c.runSqlWithAccountIdAndOptions(deleteSql, int32(sysAccountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
 	}
@@ -4276,7 +4521,7 @@ func pitrDupError(c *Compile, createPitr *plan.CreatePitr) error {
 func getSqlForCheckPitrDup(
 	createPitr *plan.CreatePitr,
 ) string {
-	sql := "SELECT pitr_id FROM mo_catalog.mo_pitr WHERE create_account = %d"
+	sql := "SELECT pitr_id FROM mo_catalog.mo_pitr WHERE create_account = %d AND kind = 'user'"
 	switch tree.PitrLevel(createPitr.GetLevel()) {
 	case tree.PITRLEVELCLUSTER:
 		return getSqlForCheckDupPitrFormat(createPitr.CurrentAccountId, math.MaxUint64)
@@ -4295,7 +4540,7 @@ func getSqlForCheckPitrDup(
 }
 
 func getSqlForCheckDupPitrFormat(accountId uint32, objId uint64) string {
-	return fmt.Sprintf(`SELECT pitr_id FROM mo_catalog.mo_pitr WHERE create_account = %d AND obj_id = %d;`, accountId, objId)
+	return fmt.Sprintf(`SELECT pitr_id FROM mo_catalog.mo_pitr WHERE create_account = %d AND obj_id = %d AND kind = 'user';`, accountId, objId)
 }
 
 func getPitrObjectId(createPitr *plan.CreatePitr) uint64 {
@@ -4363,5 +4608,5 @@ func CheckSysMoCatalogPitrResult(ctx context.Context, vecs []*vector.Vector, new
 }
 
 func getSqlForCheckPitrExists(pitrName string, accountId uint32) string {
-	return fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d ORDER BY pitr_id", pitrName, accountId)
+	return fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = %s AND create_account = %d AND kind = 'user' ORDER BY pitr_id", quoteCompileSQLStringLiteral(pitrName), accountId)
 }

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -217,11 +217,13 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	}
 
 	ignoreTables := make(map[string]struct{})
+	relationIDs := make(map[string]uint64, len(relations))
 	for _, r := range relations {
 		t, err := database.Relation(c.proc.Ctx, r, nil)
 		if err != nil {
 			return err
 		}
+		relationIDs[r] = t.GetTableID(c.proc.Ctx)
 		defs, err := t.TableDefs(c.proc.Ctx)
 		if err != nil {
 			return err
@@ -260,6 +262,12 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	for _, r := range relations {
 		if _, isIndexTable := ignoreTables[r]; !isIndexTable {
 			deleteTables = append(deleteTables, r)
+		}
+	}
+	tableIDs := make([]uint64, 0, len(deleteTables))
+	for _, t := range deleteTables {
+		if id, ok := relationIDs[t]; ok {
+			tableIDs = append(tableIDs, id)
 		}
 	}
 
@@ -319,6 +327,7 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	if err = c.cleanupDataBranchPitrsForDroppedDatabase(
 		uint64(accountId),
 		databaseID,
+		tableIDs,
 	); err != nil {
 		return err
 	}
@@ -1664,7 +1673,12 @@ func (c *Compile) cleanupDataBranchPitrsForDroppedTable(accountID uint64, databa
 	return c.cleanupDataBranchMoCatalogPitrAfterDDL()
 }
 
-func (c *Compile) cleanupDataBranchPitrsForDroppedDatabase(accountID uint64, databaseID uint64) error {
+func (c *Compile) cleanupDataBranchPitrsForDroppedDatabase(accountID uint64, databaseID uint64, tableIDs []uint64) error {
+	for _, tableID := range tableIDs {
+		if err := c.cleanupDataBranchTablePitrAfterDDL(accountID, tableID); err != nil {
+			return err
+		}
+	}
 	if err := c.cleanupDataBranchDatabasePitrByIDAfterDDL(accountID, databaseID); err != nil {
 		return err
 	}

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -4466,7 +4466,6 @@ func (s *Scope) DropPitr(c *Compile) error {
 		}
 		return moerr.NewInternalError(c.proc.Ctx, "pitr name is reserved")
 	}
-	const sysMoCatalogPitr = dataBranchSysMoCatalogPitrName
 	const sysAccountId = 0
 
 	// Get current account

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -307,7 +307,7 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	// 4.update mo_pitr table
 	if !needSkipDbs[dbName] {
 		now := c.proc.GetTxnOperator().SnapshotTS().ToStdTime().UTC().UnixNano()
-		updatePitrSql := fmt.Sprintf("UPDATE `%s`.`%s` SET `%s` = %d, `%s` = %d WHERE `%s` = %d AND `%s` = '%s' AND `%s` = %d AND `%s` = %s AND `kind` = 'user'",
+		updatePitrSql := fmt.Sprintf("UPDATE `%s`.`%s` SET `%s` = %d, `%s` = %d WHERE `%s` = %d AND `%s` = '%s' AND `%s` = %d AND `%s` = %s AND %s",
 			catalog.MO_CATALOG, catalog.MO_PITR,
 			catalog.MO_PITR_STATUS, 0,
 			catalog.MO_PITR_CHANGED_TIME, now,
@@ -316,6 +316,7 @@ func (s *Scope) DropDatabase(c *Compile) error {
 			catalog.MO_PITR_DB_NAME, dbName,
 			catalog.MO_PITR_STATUS, 1,
 			catalog.MO_PITR_OBJECT_ID, database.GetDatabaseId(c.proc.Ctx),
+			dataBranchUserPitrNameConditionSQL("`pitr_name`"),
 		)
 
 		err = c.runSqlWithSystemTenant(updatePitrSql)
@@ -1646,7 +1647,7 @@ const (
 	dataBranchInternalPitrNamePrefix     = "__mo_data_branch_pitr"
 	dataBranchInternalTablePitrPrefix    = dataBranchInternalPitrNamePrefix + "_table_"
 	dataBranchInternalDatabasePitrPrefix = dataBranchInternalPitrNamePrefix + "_database_"
-	dataBranchInternalPitrKind           = "internal"
+	dataBranchInternalPitrSQLPrefix      = dataBranchInternalPitrNamePrefix + "_"
 	dataBranchSysMoCatalogPitrName       = "sys_mo_catalog_pitr"
 )
 
@@ -1654,6 +1655,17 @@ func isReservedPitrName(pitrName string) bool {
 	return pitrName == dataBranchSysMoCatalogPitrName ||
 		pitrName == dataBranchInternalPitrNamePrefix ||
 		strings.HasPrefix(pitrName, dataBranchInternalPitrNamePrefix+"_")
+}
+
+func dataBranchUserPitrNameConditionSQL(column string) string {
+	return fmt.Sprintf(
+		"%s != '%s' AND left(%s, %d) != '%s'",
+		column,
+		dataBranchSysMoCatalogPitrName,
+		column,
+		len(dataBranchInternalPitrSQLPrefix),
+		dataBranchInternalPitrSQLPrefix,
+	)
 }
 
 type dataBranchDatabasePitrForCleanup struct {
@@ -1824,9 +1836,8 @@ func (c *Compile) dataBranchTablesHaveActiveReference(tableIDs []uint64) (bool, 
 
 func (c *Compile) cleanupDataBranchMoCatalogPitrAfterDDL() error {
 	sql := fmt.Sprintf(
-		"delete from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = 0 and kind = '%s' and not exists (select 1 from mo_catalog.mo_pitr where pitr_name != '%s')",
+		"delete from mo_catalog.mo_pitr where pitr_name = '%s' and create_account = 0 and not exists (select 1 from mo_catalog.mo_pitr where pitr_name != '%s')",
 		dataBranchSysMoCatalogPitrName,
-		dataBranchInternalPitrKind,
 		dataBranchSysMoCatalogPitrName,
 	)
 	return c.runSqlWithSystemTenant(sql)
@@ -3192,7 +3203,7 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 	if !needSkipDbs[dbName] {
 		now := c.proc.GetTxnOperator().SnapshotTS().ToStdTime().UTC().UnixNano()
 		updatePitrSql := fmt.Sprintf(
-			"UPDATE `%s`.`%s` SET `%s` = %d, `%s` = %d WHERE `%s` = %d AND `%s` = '%s' AND `%s` = '%s' AND `%s` = %d AND `%s` = %d AND `kind` = 'user'",
+			"UPDATE `%s`.`%s` SET `%s` = %d, `%s` = %d WHERE `%s` = %d AND `%s` = '%s' AND `%s` = '%s' AND `%s` = %d AND `%s` = %d AND %s",
 			catalog.MO_CATALOG, catalog.MO_PITR,
 			catalog.MO_PITR_STATUS, 0,
 			catalog.MO_PITR_CHANGED_TIME, now,
@@ -3202,6 +3213,7 @@ func (s *Scope) dropTableSingle(c *Compile, qry *plan.DropTable) error {
 			catalog.MO_PITR_TABLE_NAME, tblName,
 			catalog.MO_PITR_STATUS, 1,
 			catalog.MO_PITR_OBJECT_ID, tblID,
+			dataBranchUserPitrNameConditionSQL("`pitr_name`"),
 		)
 
 		err = c.runSqlWithSystemTenant(updatePitrSql)
@@ -4465,7 +4477,7 @@ func (s *Scope) DropPitr(c *Compile) error {
 
 	// 1. Check if PITR exists
 	pitrNameLiteral := quoteCompileSQLStringLiteral(pitrName)
-	checkSql := fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = %s AND create_account = %d AND kind = 'user'", pitrNameLiteral, accountId)
+	checkSql := fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = %s AND create_account = %d", pitrNameLiteral, accountId)
 	res, err := c.runSqlWithResultAndOptions(checkSql, int32(sysAccountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
@@ -4479,7 +4491,7 @@ func (s *Scope) DropPitr(c *Compile) error {
 	}
 
 	// 2. Delete PITR record
-	deleteSql := fmt.Sprintf("DELETE FROM mo_catalog.mo_pitr WHERE pitr_name = %s AND create_account = %d AND kind = 'user'", pitrNameLiteral, accountId)
+	deleteSql := fmt.Sprintf("DELETE FROM mo_catalog.mo_pitr WHERE pitr_name = %s AND create_account = %d", pitrNameLiteral, accountId)
 	err = c.runSqlWithAccountIdAndOptions(deleteSql, int32(sysAccountId), executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
@@ -4521,26 +4533,35 @@ func pitrDupError(c *Compile, createPitr *plan.CreatePitr) error {
 func getSqlForCheckPitrDup(
 	createPitr *plan.CreatePitr,
 ) string {
-	sql := "SELECT pitr_id FROM mo_catalog.mo_pitr WHERE create_account = %d AND kind = 'user'"
+	sql := fmt.Sprintf(
+		"SELECT pitr_id FROM mo_catalog.mo_pitr WHERE create_account = %d AND %s",
+		createPitr.CurrentAccountId,
+		dataBranchUserPitrNameConditionSQL("pitr_name"),
+	)
 	switch tree.PitrLevel(createPitr.GetLevel()) {
 	case tree.PITRLEVELCLUSTER:
 		return getSqlForCheckDupPitrFormat(createPitr.CurrentAccountId, math.MaxUint64)
 	case tree.PITRLEVELACCOUNT:
 		if createPitr.OriginAccountName {
-			return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", createPitr.AccountName)
+			return sql + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", createPitr.AccountName)
 		} else {
-			return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", createPitr.CurrentAccount)
+			return sql + fmt.Sprintf(" and account_name = '%s' and level = 'account' and pitr_status = 1;", createPitr.CurrentAccount)
 		}
 	case tree.PITRLEVELDATABASE:
-		return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" and database_name = '%s' and level = 'database' and pitr_status = 1;", createPitr.DatabaseName)
+		return sql + fmt.Sprintf(" and database_name = '%s' and level = 'database' and pitr_status = 1;", createPitr.DatabaseName)
 	case tree.PITRLEVELTABLE:
-		return fmt.Sprintf(sql, createPitr.CurrentAccountId) + fmt.Sprintf(" and database_name = '%s' and table_name = '%s' and level = 'table' and pitr_status = 1;", createPitr.DatabaseName, createPitr.TableName)
+		return sql + fmt.Sprintf(" and database_name = '%s' and table_name = '%s' and level = 'table' and pitr_status = 1;", createPitr.DatabaseName, createPitr.TableName)
 	}
 	return sql
 }
 
 func getSqlForCheckDupPitrFormat(accountId uint32, objId uint64) string {
-	return fmt.Sprintf(`SELECT pitr_id FROM mo_catalog.mo_pitr WHERE create_account = %d AND obj_id = %d AND kind = 'user';`, accountId, objId)
+	return fmt.Sprintf(
+		`SELECT pitr_id FROM mo_catalog.mo_pitr WHERE create_account = %d AND obj_id = %d AND %s;`,
+		accountId,
+		objId,
+		dataBranchUserPitrNameConditionSQL("pitr_name"),
+	)
 }
 
 func getPitrObjectId(createPitr *plan.CreatePitr) uint64 {
@@ -4608,5 +4629,5 @@ func CheckSysMoCatalogPitrResult(ctx context.Context, vecs []*vector.Vector, new
 }
 
 func getSqlForCheckPitrExists(pitrName string, accountId uint32) string {
-	return fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = %s AND create_account = %d AND kind = 'user' ORDER BY pitr_id", quoteCompileSQLStringLiteral(pitrName), accountId)
+	return fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name = %s AND create_account = %d ORDER BY pitr_id", quoteCompileSQLStringLiteral(pitrName), accountId)
 }

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -217,13 +217,11 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	}
 
 	ignoreTables := make(map[string]struct{})
-	relationIDs := make(map[string]uint64, len(relations))
 	for _, r := range relations {
 		t, err := database.Relation(c.proc.Ctx, r, nil)
 		if err != nil {
 			return err
 		}
-		relationIDs[r] = t.GetTableID(c.proc.Ctx)
 		defs, err := t.TableDefs(c.proc.Ctx)
 		if err != nil {
 			return err
@@ -262,12 +260,6 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	for _, r := range relations {
 		if _, isIndexTable := ignoreTables[r]; !isIndexTable {
 			deleteTables = append(deleteTables, r)
-		}
-	}
-	tableIDs := make([]uint64, 0, len(deleteTables))
-	for _, t := range deleteTables {
-		if id, ok := relationIDs[t]; ok {
-			tableIDs = append(tableIDs, id)
 		}
 	}
 
@@ -327,7 +319,6 @@ func (s *Scope) DropDatabase(c *Compile) error {
 	if err = c.cleanupDataBranchPitrsForDroppedDatabase(
 		uint64(accountId),
 		databaseID,
-		tableIDs,
 	); err != nil {
 		return err
 	}
@@ -1673,12 +1664,7 @@ func (c *Compile) cleanupDataBranchPitrsForDroppedTable(accountID uint64, databa
 	return c.cleanupDataBranchMoCatalogPitrAfterDDL()
 }
 
-func (c *Compile) cleanupDataBranchPitrsForDroppedDatabase(accountID uint64, databaseID uint64, tableIDs []uint64) error {
-	for _, tableID := range tableIDs {
-		if err := c.cleanupDataBranchTablePitrAfterDDL(accountID, tableID); err != nil {
-			return err
-		}
-	}
+func (c *Compile) cleanupDataBranchPitrsForDroppedDatabase(accountID uint64, databaseID uint64) error {
 	if err := c.cleanupDataBranchDatabasePitrByIDAfterDDL(accountID, databaseID); err != nil {
 		return err
 	}

--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -4486,7 +4486,7 @@ func (s *Scope) DropPitr(c *Compile) error {
 	}
 
 	// 3. Check if there are other PITR records besides sys_mo_catalog_pitr
-	checkOtherSql := fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name != '%s'", sysMoCatalogPitr)
+	checkOtherSql := fmt.Sprintf("SELECT pitr_id FROM mo_catalog.mo_pitr WHERE pitr_name != '%s'", dataBranchSysMoCatalogPitrName)
 	otherRes, err := c.runSqlWithResultAndOptions(checkOtherSql, sysAccountId, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		return err
@@ -4494,7 +4494,7 @@ func (s *Scope) DropPitr(c *Compile) error {
 	defer otherRes.Close()
 	if len(otherRes.Batches) == 0 || otherRes.Batches[0].RowCount() == 0 {
 		// 4. No other PITR records, delete sys_mo_catalog_pitr
-		deleteSysSql := fmt.Sprintf("DELETE FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", sysMoCatalogPitr, sysAccountId)
+		deleteSysSql := fmt.Sprintf("DELETE FROM mo_catalog.mo_pitr WHERE pitr_name = '%s' AND create_account = %d", dataBranchSysMoCatalogPitrName, sysAccountId)
 		err = c.runSqlWithAccountIdAndOptions(deleteSysSql, sysAccountId, executor.StatementOption{}.WithDisableLog())
 		if err != nil {
 			return err

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -884,6 +884,12 @@ func TestDropPitrReservedName(t *testing.T) {
 	}
 }
 
+func TestGetSqlForCheckPitrExistsQuotesName(t *testing.T) {
+	sql := getSqlForCheckPitrExists("a'b", 7)
+	assert.Contains(t, sql, "pitr_name = 'a''b'")
+	assert.Contains(t, sql, "create_account = 7")
+}
+
 func TestIsExperimentalEnabled(t *testing.T) {
 	s := newScope(TableClone)
 

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -853,6 +853,37 @@ func TestPitrDupError(t *testing.T) {
 	}
 }
 
+func TestDropPitrReservedName(t *testing.T) {
+	newDropPitrScope := func(name string, ifExists bool) *Scope {
+		return &Scope{Plan: &plan2.Plan{Plan: &plan2.Plan_Ddl{Ddl: &plan2.DataDefinition{
+			Definition: &plan2.DataDefinition_DropPitr{
+				DropPitr: &plan2.DropPitr{
+					Name:     name,
+					IfExists: ifExists,
+				},
+			},
+		}}}}
+	}
+
+	compile := &Compile{proc: testutil.NewProc(t)}
+	for _, name := range []string{
+		dataBranchSysMoCatalogPitrName,
+		dataBranchInternalPitrNamePrefix,
+		dataBranchInternalPitrNamePrefix + "_table_123",
+	} {
+		t.Run(name+"/without_if_exists", func(t *testing.T) {
+			err := newDropPitrScope(name, false).DropPitr(compile)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "pitr name is reserved")
+		})
+
+		t.Run(name+"/with_if_exists", func(t *testing.T) {
+			err := newDropPitrScope(name, true).DropPitr(compile)
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestIsExperimentalEnabled(t *testing.T) {
 	s := newScope(TableClone)
 

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -717,6 +717,7 @@ func TestScope_DropDatabase_ToleratesDanglingHiddenIndexMetadata(t *testing.T) {
 
 	mockDbMeta := mock_frontend.NewMockDatabase(ctrl)
 	mockDbMeta.EXPECT().IsSubscription(gomock.Any()).Return(false).AnyTimes()
+	mockDbMeta.EXPECT().GetDatabaseId(gomock.Any()).Return("1").AnyTimes()
 	mockDbMeta.EXPECT().Relations(gomock.Any()).Return([]string{"__idx_meta"}, nil).AnyTimes()
 	mockDbMeta.EXPECT().Relation(gomock.Any(), "__idx_meta", gomock.Any()).Return(relation, nil).AnyTimes()
 

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -4856,9 +4856,7 @@ func buildCreatePitr(stmt *tree.CreatePitr, ctx CompilerContext) (*Plan, error) 
 	}
 
 	// check pitr exists or not
-	if string(stmt.Name) == SYSMOCATALOGPITR ||
-		string(stmt.Name) == DATA_BRANCH_PITR_NAME_PREFIX ||
-		strings.HasPrefix(string(stmt.Name), DATA_BRANCH_PITR_NAME_PREFIX+"_") {
+	if isReservedPitrName(string(stmt.Name)) {
 		return nil, moerr.NewInternalError(ctx.GetContext(), "pitr name is reserved")
 	}
 
@@ -4932,9 +4930,7 @@ func buildCreatePitr(stmt *tree.CreatePitr, ctx CompilerContext) (*Plan, error) 
 func buildDropPitr(stmt *tree.DropPitr, ctx CompilerContext) (*Plan, error) {
 	ddlType := plan.DataDefinition_DROP_PITR
 	// Remove privilege check, no account ID validation
-	if string(stmt.Name) == SYSMOCATALOGPITR ||
-		string(stmt.Name) == DATA_BRANCH_PITR_NAME_PREFIX ||
-		strings.HasPrefix(string(stmt.Name), DATA_BRANCH_PITR_NAME_PREFIX+"_") {
+	if isReservedPitrName(string(stmt.Name)) && !stmt.IfExists {
 		return nil, moerr.NewInternalError(ctx.GetContext(), "pitr name is reserved")
 	}
 
@@ -4954,4 +4950,10 @@ func buildDropPitr(stmt *tree.DropPitr, ctx CompilerContext) (*Plan, error) {
 			},
 		},
 	}, nil
+}
+
+func isReservedPitrName(pitrName string) bool {
+	return pitrName == SYSMOCATALOGPITR ||
+		pitrName == DATA_BRANCH_PITR_NAME_PREFIX ||
+		strings.HasPrefix(pitrName, DATA_BRANCH_PITR_NAME_PREFIX+"_")
 }

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -4856,7 +4856,9 @@ func buildCreatePitr(stmt *tree.CreatePitr, ctx CompilerContext) (*Plan, error) 
 	}
 
 	// check pitr exists or not
-	if string(stmt.Name) == SYSMOCATALOGPITR {
+	if string(stmt.Name) == SYSMOCATALOGPITR ||
+		string(stmt.Name) == DATA_BRANCH_PITR_NAME_PREFIX ||
+		strings.HasPrefix(string(stmt.Name), DATA_BRANCH_PITR_NAME_PREFIX+"_") {
 		return nil, moerr.NewInternalError(ctx.GetContext(), "pitr name is reserved")
 	}
 
@@ -4930,6 +4932,11 @@ func buildCreatePitr(stmt *tree.CreatePitr, ctx CompilerContext) (*Plan, error) 
 func buildDropPitr(stmt *tree.DropPitr, ctx CompilerContext) (*Plan, error) {
 	ddlType := plan.DataDefinition_DROP_PITR
 	// Remove privilege check, no account ID validation
+	if string(stmt.Name) == SYSMOCATALOGPITR ||
+		string(stmt.Name) == DATA_BRANCH_PITR_NAME_PREFIX ||
+		strings.HasPrefix(string(stmt.Name), DATA_BRANCH_PITR_NAME_PREFIX+"_") {
+		return nil, moerr.NewInternalError(ctx.GetContext(), "pitr name is reserved")
+	}
 
 	// Build drop pitr plan
 	dropPitr := &plan.DropPitr{

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -814,6 +814,19 @@ func TestBuildCreatePitr(t *testing.T) {
 		assert.Contains(t, err.Error(), "pitr name is reserved")
 	})
 
+	t.Run("reserved data branch pitr name", func(t *testing.T) {
+		ctx := &MockCompilerContext{}
+		ctx.GetAccountNameFunc = func() string { return "sys" }
+		ctx.GetAccountIdFunc = func() (uint32, error) { return 1, nil }
+		stmt := baseStmt()
+		for _, name := range []string{"__mo_data_branch_pitr", "__mo_data_branch_pitr_table_123"} {
+			stmt.Name = tree.Identifier(name)
+			_, err := buildCreatePitr(stmt, ctx)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "pitr name is reserved")
+		}
+	})
+
 	t.Run("database level pitr, database not exist", func(t *testing.T) {
 		ctx := &MockCompilerContext{}
 		ctx.GetAccountNameFunc = func() string { return "sys" }

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -732,35 +732,8 @@ func TestBuildCreatePitr(t *testing.T) {
 			Level:       tree.PITRLEVELCLUSTER,
 			PitrValue:   1,
 			PitrUnit:    "h",
+		}
 	}
-}
-
-func TestBuildDropPitrReservedName(t *testing.T) {
-	ctx := &MockCompilerContext{}
-	for _, name := range []string{
-		SYSMOCATALOGPITR,
-		DATA_BRANCH_PITR_NAME_PREFIX,
-		DATA_BRANCH_PITR_NAME_PREFIX + "_table_123",
-	} {
-		t.Run(name+"/without_if_exists", func(t *testing.T) {
-			stmt := &tree.DropPitr{Name: tree.Identifier(name)}
-			_, err := buildDropPitr(stmt, ctx)
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "pitr name is reserved")
-		})
-
-		t.Run(name+"/with_if_exists", func(t *testing.T) {
-			stmt := &tree.DropPitr{Name: tree.Identifier(name), IfExists: true}
-			built, err := buildDropPitr(stmt, ctx)
-			assert.NoError(t, err)
-			require.NotNil(t, built)
-			dropPitr := built.GetDdl().GetDropPitr()
-			require.NotNil(t, dropPitr)
-			assert.True(t, dropPitr.GetIfExists())
-			assert.Equal(t, name, dropPitr.GetName())
-		})
-	}
-}
 
 	t.Run("sys account can create cluster level pitr", func(t *testing.T) {
 		ctx := &MockCompilerContext{}
@@ -910,4 +883,31 @@ func TestBuildDropPitrReservedName(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, plan)
 	})
+}
+
+func TestBuildDropPitrReservedName(t *testing.T) {
+	ctx := &MockCompilerContext{}
+	for _, name := range []string{
+		SYSMOCATALOGPITR,
+		DATA_BRANCH_PITR_NAME_PREFIX,
+		DATA_BRANCH_PITR_NAME_PREFIX + "_table_123",
+	} {
+		t.Run(name+"/without_if_exists", func(t *testing.T) {
+			stmt := &tree.DropPitr{Name: tree.Identifier(name)}
+			_, err := buildDropPitr(stmt, ctx)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "pitr name is reserved")
+		})
+
+		t.Run(name+"/with_if_exists", func(t *testing.T) {
+			stmt := &tree.DropPitr{Name: tree.Identifier(name), IfExists: true}
+			built, err := buildDropPitr(stmt, ctx)
+			assert.NoError(t, err)
+			require.NotNil(t, built)
+			dropPitr := built.GetDdl().GetDropPitr()
+			require.NotNil(t, dropPitr)
+			assert.True(t, dropPitr.GetIfExists())
+			assert.Equal(t, name, dropPitr.GetName())
+		})
+	}
 }

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -732,8 +732,35 @@ func TestBuildCreatePitr(t *testing.T) {
 			Level:       tree.PITRLEVELCLUSTER,
 			PitrValue:   1,
 			PitrUnit:    "h",
-		}
 	}
+}
+
+func TestBuildDropPitrReservedName(t *testing.T) {
+	ctx := &MockCompilerContext{}
+	for _, name := range []string{
+		SYSMOCATALOGPITR,
+		DATA_BRANCH_PITR_NAME_PREFIX,
+		DATA_BRANCH_PITR_NAME_PREFIX + "_table_123",
+	} {
+		t.Run(name+"/without_if_exists", func(t *testing.T) {
+			stmt := &tree.DropPitr{Name: tree.Identifier(name)}
+			_, err := buildDropPitr(stmt, ctx)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "pitr name is reserved")
+		})
+
+		t.Run(name+"/with_if_exists", func(t *testing.T) {
+			stmt := &tree.DropPitr{Name: tree.Identifier(name), IfExists: true}
+			built, err := buildDropPitr(stmt, ctx)
+			assert.NoError(t, err)
+			require.NotNil(t, built)
+			dropPitr := built.GetDdl().GetDropPitr()
+			require.NotNil(t, dropPitr)
+			assert.True(t, dropPitr.GetIfExists())
+			assert.Equal(t, name, dropPitr.GetName())
+		})
+	}
+}
 
 	t.Run("sys account can create cluster level pitr", func(t *testing.T) {
 		ctx := &MockCompilerContext{}

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -37,6 +37,7 @@ const MO_CATALOG_DB_NAME = "mo_catalog"
 const MO_DEFUALT_HOSTNAME = "localhost"
 const INFORMATION_SCHEMA = "information_schema"
 const SYSMOCATALOGPITR = "sys_mo_catalog_pitr"
+const DATA_BRANCH_PITR_NAME_PREFIX = "__mo_data_branch_pitr"
 
 func buildShowCreateDatabase(stmt *tree.ShowCreateDatabase,
 	ctx CompilerContext) (*Plan, error) {
@@ -1128,10 +1129,10 @@ func buildShowPitr(stmt *tree.ShowPitr, ctx CompilerContext) (*Plan, error) {
 			"		pitr_length as `PITR_LENGTH`, "+
 			"		pitr_unit  as `PITR_UNIT` FROM %s.mo_pitr "+
 			"where "+
-			"	create_account = %d and pitr_name != '%s' "+
+			"	create_account = %d and pitr_name != '%s' and kind = 'user' and pitr_name not like '%s%%' "+
 			"ORDER BY "+
 			"	create_time DESC",
-		MO_CATALOG_DB_NAME, curAccountId, SYSMOCATALOGPITR)
+		MO_CATALOG_DB_NAME, curAccountId, SYSMOCATALOGPITR, DATA_BRANCH_PITR_NAME_PREFIX+"_")
 
 	newCtx := ctx.GetContext()
 	if curAccountId != catalog.System_Account {

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -1129,10 +1129,10 @@ func buildShowPitr(stmt *tree.ShowPitr, ctx CompilerContext) (*Plan, error) {
 			"		pitr_length as `PITR_LENGTH`, "+
 			"		pitr_unit  as `PITR_UNIT` FROM %s.mo_pitr "+
 			"where "+
-			"	create_account = %d and pitr_name != '%s' and kind = 'user' "+
+			"	create_account = %d and pitr_name != '%s' and left(pitr_name, %d) != '%s' "+
 			"ORDER BY "+
 			"	create_time DESC",
-		MO_CATALOG_DB_NAME, curAccountId, SYSMOCATALOGPITR)
+		MO_CATALOG_DB_NAME, curAccountId, SYSMOCATALOGPITR, len(DATA_BRANCH_PITR_NAME_PREFIX)+1, DATA_BRANCH_PITR_NAME_PREFIX+"_")
 
 	newCtx := ctx.GetContext()
 	if curAccountId != catalog.System_Account {

--- a/pkg/sql/plan/build_show.go
+++ b/pkg/sql/plan/build_show.go
@@ -1129,10 +1129,10 @@ func buildShowPitr(stmt *tree.ShowPitr, ctx CompilerContext) (*Plan, error) {
 			"		pitr_length as `PITR_LENGTH`, "+
 			"		pitr_unit  as `PITR_UNIT` FROM %s.mo_pitr "+
 			"where "+
-			"	create_account = %d and pitr_name != '%s' and kind = 'user' and pitr_name not like '%s%%' "+
+			"	create_account = %d and pitr_name != '%s' and kind = 'user' "+
 			"ORDER BY "+
 			"	create_time DESC",
-		MO_CATALOG_DB_NAME, curAccountId, SYSMOCATALOGPITR, DATA_BRANCH_PITR_NAME_PREFIX+"_")
+		MO_CATALOG_DB_NAME, curAccountId, SYSMOCATALOGPITR)
 
 	newCtx := ctx.GetContext()
 	if curAccountId != catalog.System_Account {

--- a/pkg/vm/engine/disttae/snapshot_scan.go
+++ b/pkg/vm/engine/disttae/snapshot_scan.go
@@ -137,7 +137,7 @@ func ScanSnapshotWithCurrentRanges(
 		zap.Int("disk-block-cnt", diskBlockCnt),
 	)
 
-	tombstones, err := tbl.CollectTombstones(ctx, 0, engine.Policy_CollectAllTombstones)
+	tombstones, err := tbl.collectTombstonesAtSnapshot(ctx, 0, engine.Policy_CollectCommittedTombstones, snapshotTS)
 	if err != nil {
 		return err
 	}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -542,6 +542,20 @@ func (tbl *txnTable) CollectTombstones(
 	txnOffset int,
 	policy engine.TombstoneCollectPolicy,
 ) (engine.Tombstoner, error) {
+	return tbl.collectTombstonesAtSnapshot(
+		ctx,
+		txnOffset,
+		policy,
+		types.TimestampToTS(tbl.db.op.SnapshotTS()),
+	)
+}
+
+func (tbl *txnTable) collectTombstonesAtSnapshot(
+	ctx context.Context,
+	txnOffset int,
+	policy engine.TombstoneCollectPolicy,
+	snapshot types.TS,
+) (engine.Tombstoner, error) {
 	tombstone := readutil.NewEmptyTombstoneData()
 
 	//collect uncommitted tombstones
@@ -601,8 +615,7 @@ func (tbl *txnTable) CollectTombstones(
 			return nil, err
 		}
 		{
-			ts := tbl.db.op.SnapshotTS()
-			iter := state.NewRowsIter(types.TimestampToTS(ts), nil, true)
+			iter := state.NewRowsIter(snapshot, nil, true)
 			for iter.Next() {
 				entry := iter.Entry()
 				//bid, o := entry.RowID.Decode()
@@ -613,7 +626,6 @@ func (tbl *txnTable) CollectTombstones(
 
 		//tombstone.SortInMemory()
 		//collect committed persisted tombstones from partition state.
-		snapshot := types.TimestampToTS(tbl.db.op.Txn().SnapshotTS)
 		err = state.CollectTombstoneObjects(snapshot,
 			func(stats *objectio.ObjectStats) {
 				tombstone.AppendFiles(*stats)

--- a/test/distributed/cases/git4data/branch/diff/diff_9.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_9.result
@@ -166,8 +166,10 @@ data branch merge t2 into t1;
 data branch diff t2 against t1;
 diff t2 against t1	flag	a	b
 update t1 set b = b + 1 where a = 4;
+update t1 set b = 2 where a = 1;
 data branch diff t2 against t1;
 diff t2 against t1	flag	a	b
+t1	UPDATE	1	2
 t2	INSERT	4	4
 t1	INSERT	4	5
 select mo_ctl('dn', 'flush', 'test_gc_diff.t2');
@@ -193,6 +195,7 @@ select mo_ctl('dn', 'diskcleaner', 'force_gc');
 {\n  "method": "DiskCleaner",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
 data branch diff t2 against t1;
 diff t2 against t1	flag	a	b
+t1	UPDATE	1	2
 t2	INSERT	4	4
 t1	INSERT	4	5
 drop table t1;

--- a/test/distributed/cases/git4data/branch/diff/diff_9.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_9.result
@@ -154,4 +154,47 @@ data branch diff c3_tar against c3_src output count;
 178
 drop table c3_src;
 drop table c3_tar;
+create table t1(a int, b int, primary key(a));
+insert into t1 values(1, 1), (2, 2), (3, 3);
+data branch create table t2 from t1;
+insert into t2 values(4, 4), (5, 5);
+data branch diff t2 against t1;
+diff t2 against t1	flag	a	b
+t2	INSERT	4	4
+t2	INSERT	5	5
+data branch merge t2 into t1;
+data branch diff t2 against t1;
+diff t2 against t1	flag	a	b
+update t1 set b = b + 1 where a = 4;
+data branch diff t2 against t1;
+diff t2 against t1	flag	a	b
+t2	INSERT	4	4
+t1	INSERT	4	5
+select mo_ctl('dn', 'flush', 'test_gc_diff.t2');
+➤ mo_ctl(dn, flush, test_gc_diff.t2)[12,-1,0]  𝄀
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select mo_ctl('dn', 'flush', 'test_gc_diff.t1');
+➤ mo_ctl(dn, flush, test_gc_diff.t1)[12,-1,0]  𝄀
+{\n  "method": "Flush",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select mo_ctl('dn', 'globalcheckpoint', '');
+➤ mo_ctl(dn, globalcheckpoint, )[12,-1,0]  𝄀
+{\n  "method": "GlobalCheckpoint",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select mo_ctl('dn', 'globalcheckpoint', '');
+➤ mo_ctl(dn, globalcheckpoint, )[12,-1,0]  𝄀
+{\n  "method": "GlobalCheckpoint",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select mo_ctl('dn', 'diskcleaner', 'force_gc');
+➤ mo_ctl(dn, diskcleaner, force_gc)[12,-1,0]  𝄀
+{\n  "method": "DiskCleaner",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select mo_ctl('dn', 'globalcheckpoint', '');
+➤ mo_ctl(dn, globalcheckpoint, )[12,-1,0]  𝄀
+{\n  "method": "GlobalCheckpoint",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+select mo_ctl('dn', 'diskcleaner', 'force_gc');
+➤ mo_ctl(dn, diskcleaner, force_gc)[12,-1,0]  𝄀
+{\n  "method": "DiskCleaner",\n  "result": [\n    {\n      "returnStr": "OK"\n    }\n  ]\n}\n
+data branch diff t2 against t1;
+diff t2 against t1	flag	a	b
+t2	INSERT	4	4
+t1	INSERT	4	5
+drop table t1;
+drop table t2;
 drop database test_gc_diff;

--- a/test/distributed/cases/git4data/branch/diff/diff_9.sql
+++ b/test/distributed/cases/git4data/branch/diff/diff_9.sql
@@ -132,4 +132,37 @@ data branch diff c3_tar against c3_src output count;
 drop table c3_src;
 drop table c3_tar;
 
+-- Case 4: merged branch inserts must remain INSERT after GC even if base updates same PK
+create table t1(a int, b int, primary key(a));
+insert into t1 values(1, 1), (2, 2), (3, 3);
+data branch create table t2 from t1;
+insert into t2 values(4, 4), (5, 5);
+
+data branch diff t2 against t1;
+data branch merge t2 into t1;
+data branch diff t2 against t1;
+
+update t1 set b = b + 1 where a = 4;
+data branch diff t2 against t1;
+
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'test_gc_diff.t2');
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'test_gc_diff.t1');
+-- @ignore:0
+select mo_ctl('dn', 'globalcheckpoint', '');
+-- @ignore:0
+select mo_ctl('dn', 'globalcheckpoint', '');
+-- @ignore:0
+select mo_ctl('dn', 'diskcleaner', 'force_gc');
+-- @ignore:0
+select mo_ctl('dn', 'globalcheckpoint', '');
+-- @ignore:0
+select mo_ctl('dn', 'diskcleaner', 'force_gc');
+
+data branch diff t2 against t1;
+
+drop table t1;
+drop table t2;
+
 drop database test_gc_diff;

--- a/test/distributed/cases/git4data/branch/diff/diff_9.sql
+++ b/test/distributed/cases/git4data/branch/diff/diff_9.sql
@@ -143,6 +143,7 @@ data branch merge t2 into t1;
 data branch diff t2 against t1;
 
 update t1 set b = b + 1 where a = 4;
+update t1 set b = 2 where a = 1;
 data branch diff t2 against t1;
 
 -- @ignore:0

--- a/test/distributed/cases/pitr/pitr.result
+++ b/test/distributed/cases/pitr/pitr.result
@@ -5,58 +5,58 @@ create pitr pitr01 for cluster range 1 'h';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 pitr01    2024-12-25 17:22:15    2024-12-25 17:22:15    cluster    *    *    *    1    h
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bc8a-7c50-82c7-9702538eaf9d    pitr01    0    2024-12-25 09:22:15    2024-12-25 09:22:15    cluster    0                18446744073709551615    1    h
 alter pitr pitr01 range 10 'd';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 pitr01    2024-12-25 17:22:15    2024-12-25 17:22:15    cluster    *    *    *    10    d
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bc8a-7c50-82c7-9702538eaf9d    pitr01    0    2024-12-25 09:22:15    2024-12-25 09:22:15    cluster    0                18446744073709551615    10    d
 drop pitr pitr01;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 drop pitr if exists p02;
 create pitr p02 for account acc01 range 1 'd';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 p02    2024-12-25 17:22:15    2024-12-25 17:22:15    account    acc01    *    *    1    d
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bcb6-7246-9d91-875413dfc702    p02    0    2024-12-25 09:22:15    2024-12-25 09:22:15    account    30010    acc01            30010    1    d
 alter pitr p02 range 100 'd';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 p02    2024-12-25 17:22:15    2024-12-25 17:22:15    account    acc01    *    *    100    d
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bcb6-7246-9d91-875413dfc702    p02    0    2024-12-25 09:22:15    2024-12-25 09:22:15    account    30010    acc01            30010    100    d
 drop pitr p02;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 drop pitr if exists `select`;
 create pitr `select` for account range 10 'd';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 select    2024-12-25 17:22:15    2024-12-25 17:22:15    account    acc01    *    *    10    d
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bce9-705d-bca9-7a795f93de07    select    30010    2024-12-25 09:22:15    2024-12-25 09:22:15    account    30010    acc01            30010    10    d
 alter pitr `select` range 30 'd';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 select    2024-12-25 17:22:15    2024-12-25 17:22:15    account    acc01    *    *    30    d
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bce9-705d-bca9-7a795f93de07    select    30010    2024-12-25 09:22:15    2024-12-25 09:22:15    account    30010    acc01            30010    30    d
 drop pitr `select`;
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 drop database if exists test01;
 create database test01;
@@ -65,20 +65,20 @@ create pitr account for database test01 range 1 'mo';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 account    2024-12-25 17:22:15    2024-12-25 17:22:15    database    sys    test01    *    1    mo
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bd11-76d6-ae30-218792e1f7e9    account    0    2024-12-25 09:22:15    2024-12-25 09:22:15    database    0    sys    test01        317750    1    mo
 alter pitr account range 4 'mo';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 account    2024-12-25 17:22:15    2024-12-25 17:22:15    database    sys    test01    *    4    mo
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bd11-76d6-ae30-218792e1f7e9    account    0    2024-12-25 09:22:15    2024-12-25 09:22:15    database    0    sys    test01        317750    4    mo
 drop pitr account;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 use test01;
 create table t1 (col1 int, col2 decimal);
@@ -97,14 +97,14 @@ truncate t1;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 $%^#    2024-12-25 17:22:15    2024-12-25 17:22:15    table    sys    test01    t1    1    y
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bd3c-70fa-ae01-a0699c57a124    $%^#    0    2024-12-25 09:22:15    2024-12-25 09:22:15    table    0    sys    test01    t1    317751    1    y
 alter pitr `$%^#` range 2 'mo';
 drop pitr `$%^#`;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 drop table t1;
 drop database test01;
@@ -131,7 +131,7 @@ sum(a)
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 p03    2024-12-25 17:22:16    2024-12-25 17:22:16    table    sys    test    s3t    2    h
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-bf0c-7b65-a849-dc6e020fa8d6    p03    0    2024-12-25 09:22:16    2024-12-25 09:22:16    table    0    sys    test    s3t    317754    2    h
 drop pitr p03;
@@ -237,7 +237,7 @@ show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 pitr01    2024-12-25 17:22:16    2024-12-25 17:22:16    account    acc01    *    *    11    mo
 p12    2024-12-25 17:22:16    2024-12-25 17:22:16    account    sys    *    *    1    d
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fd1f-c063-7c38-a759-278113df2442    pitr01    0    2024-12-25 09:22:16    2024-12-25 09:22:16    account    30010    acc01            30010    11    mo
 0193fd1f-c0f9-7343-9a0c-a8aefb514339    p11    30010    2024-12-25 09:22:16    2024-12-25 09:22:16    account    30010    acc01            30010    1    d

--- a/test/distributed/cases/pitr/pitr.sql
+++ b/test/distributed/cases/pitr/pitr.sql
@@ -7,17 +7,17 @@ create pitr pitr01 for cluster range 1 'h';
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 alter pitr pitr01 range 10 'd';
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop pitr pitr01;
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 
 
 -- sys creates pitr for account, show pitr
@@ -26,17 +26,17 @@ create pitr p02 for account acc01 range 1 'd';
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 alter pitr p02 range 100 'd';
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop pitr p02;
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 
 
 -- nonsys creates pitr for current account
@@ -47,19 +47,19 @@ create pitr `select` for account range 10 'd';
 show pitr;
 -- @session
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @session:id=1&user=acc01:test_account&password=111
 alter pitr `select` range 30 'd';
 -- @ignore:1,2
 show pitr;
 -- @session
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @session:id=1&user=acc01:test_account&password=111
 drop pitr `select`;
 -- @session
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 
 
 drop database if exists test01;
@@ -69,17 +69,17 @@ create pitr account for database test01 range 1 'mo';
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 alter pitr account range 4 'mo';
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop pitr account;
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 
 
 use test01;
@@ -94,13 +94,13 @@ truncate t1;
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 alter pitr `$%^#` range 2 'mo';
 drop pitr `$%^#`;
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop table t1;
 drop database test01;
 -- @session
@@ -122,7 +122,7 @@ select sum(a) from s3t;
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop pitr p03;
 drop database test;
 
@@ -246,7 +246,7 @@ create pitr p12 for account range 1 'd';
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 alter pitr p11 range 11 'mo';
 drop pitr p10;
 -- @session:id=1&user=acc01:test_account&password=111

--- a/test/distributed/cases/pitr/pitr_basic.result
+++ b/test/distributed/cases/pitr/pitr_basic.result
@@ -156,21 +156,21 @@ pitr19    2024-12-25 16:34:55    2024-12-25 16:34:55    database    acc01    db0
 pitr21    2024-12-25 16:34:55    2024-12-25 16:34:55    table    acc01    db01    table01    1    h
 drop pitr if exists pitr19;
 drop pitr if exists pitr21;
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-63d4-77d7-96f1-d95052aab623    pitr05    0    2024-12-25 08:34:55    2024-12-25 08:34:55    cluster    0                18446744073709551615    1    h
 0193fcf4-63f2-7be2-8ddd-e8282428a82d    pitr10    0    2024-12-25 08:34:55    2024-12-25 08:34:55    database    0    sys    db01        316946    1    h
 0193fcf4-6418-7631-82ab-1712a55199b3    pitr12    0    2024-12-25 08:34:55    2024-12-25 08:34:55    table    0    sys    db01    table01    316947    1    h
 0193fcf4-64fe-7781-b9ff-0682df39be3f    pitr14    0    2024-12-25 08:34:55    2024-12-25 08:34:55    account    30001    acc01            30001    1    h
 drop account if exists acc01;
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-63d4-77d7-96f1-d95052aab623    pitr05    0    2024-12-25 08:34:55    2024-12-25 08:34:55    cluster    0                18446744073709551615    1    h
 0193fcf4-63f2-7be2-8ddd-e8282428a82d    pitr10    0    2024-12-25 08:34:55    2024-12-25 08:34:55    database    0    sys    db01        316946    1    h
 0193fcf4-6418-7631-82ab-1712a55199b3    pitr12    0    2024-12-25 08:34:55    2024-12-25 08:34:55    table    0    sys    db01    table01    316947    1    h
 0193fcf4-64fe-7781-b9ff-0682df39be3f    pitr14    0    2024-12-25 08:34:55    2024-12-25 08:34:55    account    30001    acc01            30001    1    h
 drop database if exists db01;
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-63d4-77d7-96f1-d95052aab623    pitr05    0    2024-12-25 08:34:55    2024-12-25 08:34:55    cluster    0                18446744073709551615    1    h
 0193fcf4-63f2-7be2-8ddd-e8282428a82d    pitr10    0    2024-12-25 08:34:55    2024-12-25 08:34:55    database    0    sys    db01        316946    1    h
@@ -186,7 +186,7 @@ drop pitr if exists pitr12;
 drop pitr if exists pitr14;
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 drop account if exists acc02;
 create account acc02 admin_name = 'test_account' identified by '111';
@@ -201,11 +201,11 @@ alter pitr pitr01 range 1 'd';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 pitr01    2024-12-25 16:34:56    2024-12-25 16:34:57    account    acc02    *    *    1    d
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-67e2-71ad-9b82-dc69bd36f851    pitr01    30002    2024-12-25 08:34:56    2024-12-25 08:34:57    account    30002    acc02            30002    1    d
 drop account if exists acc02;
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 drop pitr if exists pitr01;
 create pitr pitr01 for account range 1 'h';
@@ -335,7 +335,7 @@ internal error: pitr name is reserved
 drop pitr if exists sys_mo_catalog_pitr;
 drop pitr if exists pitr01;
 create pitr pitr01 for account range 1 'h';
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-7237-7363-8427-cb7957be626c    pitr01    0    2024-12-25 08:34:58    2024-12-25 08:34:58    account    0    sys            0    1    h
 show pitr;
@@ -344,7 +344,7 @@ pitr01    2024-12-25 16:34:58    2024-12-25 16:34:58    account    sys    *    *
 drop pitr if exists pitr01;
 drop pitr if exists pitr02;
 create pitr pitr02 for account range 1 'd';
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-7247-7436-ae78-07192b79ba46    pitr02    0    2024-12-25 08:34:58    2024-12-25 08:34:58    account    0    sys            0    1    d
 show pitr;
@@ -357,7 +357,7 @@ create pitr pitr01 for account range 1 'mo';
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 pitr01    2024-12-25 16:34:59    2024-12-25 16:34:59    account    acc01    *    *    1    mo
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-7352-7251-a537-78f5f2939857    pitr01    30005    2024-12-25 08:34:59    2024-12-25 08:34:59    account    30005    acc01            30005    1    mo
 drop account if exists acc01;
@@ -365,13 +365,13 @@ drop database if exists db01;
 create database db01;
 drop pitr if exists pitr10;
 create pitr pitr10 for database db01 range 1 'y';
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-747e-72ab-8b45-48aa5dce3e23    pitr10    0    2024-12-25 08:34:59    2024-12-25 08:34:59    database    0    sys    db01        317339    1    y
 show pitr;
 PITR_NAME    CREATED_TIME    MODIFIED_TIME    PITR_LEVEL    ACCOUNT_NAME    DATABASE_NAME    TABLE_NAME    PITR_LENGTH    PITR_UNIT
 pitr10    2024-12-25 16:34:59    2024-12-25 16:34:59    database    sys    db01    *    1    y
 drop pitr if exists pitr10;
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 drop database if exists db01;

--- a/test/distributed/cases/pitr/pitr_basic.sql
+++ b/test/distributed/cases/pitr/pitr_basic.sql
@@ -135,13 +135,13 @@ drop pitr if exists pitr21;
 
 
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop account if exists acc01;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop database if exists db01;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @ignore:1,2
 drop pitr if exists pitr01;
 drop pitr if exists pitr02;
@@ -154,7 +154,7 @@ drop pitr if exists pitr14;
 -- @ignore:1,2
 show pitr;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 
 drop account if exists acc02;
 create account acc02 admin_name = 'test_account' identified by '111';
@@ -168,10 +168,10 @@ alter pitr pitr01 range 1 'd';
 show pitr;
 -- @session
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop account if exists acc02;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 
 
 drop pitr if exists pitr01;
@@ -304,14 +304,14 @@ drop pitr if exists sys_mo_catalog_pitr;
 drop pitr if exists pitr01;
 create pitr pitr01 for account range 1 'h';
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @ignore:1,2
 show pitr;
 drop pitr if exists pitr01;
 drop pitr if exists pitr02;
 create pitr pitr02 for account range 1 'd';
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @ignore:1,2
 show pitr;
 drop pitr if exists pitr02;
@@ -323,17 +323,17 @@ create pitr pitr01 for account range 1 'mo';
 show pitr;
 -- @session
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop account if exists acc01;
 drop database if exists db01;
 create database db01;
 drop pitr if exists pitr10;
 create pitr pitr10 for database db01 range 1 'y';
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @ignore:1,2
 show pitr;
 drop pitr if exists pitr10;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop database if exists db01;

--- a/test/distributed/cases/pitr/pitr_inherit.result
+++ b/test/distributed/cases/pitr/pitr_inherit.result
@@ -2,7 +2,7 @@ drop account if exists acc01;
 create account acc01 admin_name = 'test_account' identified by '111';
 drop pitr if exists pitr01;
 create pitr pitr01 for account acc01 range 1 'h';
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-cf9e-768b-a904-24dec1580cbc    pitr01    0    2024-12-25 08:35:22    2024-12-25 08:35:22    account    30006    acc01            30006    1    h
 select account_id, account_name from mo_catalog.mo_account where account_name = 'acc01';
@@ -10,7 +10,7 @@ account_id    account_name
 30006    acc01
 drop account if exists acc01;
 create account acc01 admin_name = 'test_account' identified by '111';
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-cf9e-768b-a904-24dec1580cbc    pitr01    0    2024-12-25 08:35:22    2024-12-25 08:35:23    account    30006    acc01            30007    1    h
 select account_id, account_name from mo_catalog.mo_account where account_name = 'acc01';
@@ -22,12 +22,12 @@ drop database if exists abc1;
 create database abc1;
 drop pitr if exists pitr02;
 create pitr pitr02 for database abc1 range 1 'h';
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-d313-7c06-b4fe-b8c6b3658588    pitr02    0    2024-12-25 08:35:23    2024-12-25 08:35:23    database    0    sys    abc1        317495    1    h
 drop database abc1;
 create database abc1;
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-d313-7c06-b4fe-b8c6b3658588    pitr02    0    2024-12-25 08:35:23    2024-12-25 08:35:23    database    0    sys    abc1        317496    1    h
 drop database abc1;
@@ -38,12 +38,12 @@ use abc1;
 create table test1(a timestamp);
 drop pitr if exists pitr03;
 create pitr pitr03 for table abc1 test1 range 1 'h';
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-d34f-79c4-890b-4f0c460964c5    pitr03    0    2024-12-25 08:35:23    2024-12-25 08:35:23    table    0    sys    abc1    test1    317498    1    h
 drop table test1;
 create table test1(a timestamp);
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-d34f-79c4-890b-4f0c460964c5    pitr03    0    2024-12-25 08:35:23    2024-12-25 08:35:23    table    0    sys    abc1    test1    317499    1    h
 drop database abc1;
@@ -54,12 +54,12 @@ drop database if exists abc1;
 create database abc1;
 drop pitr if exists pitr02;
 create pitr pitr02 for database abc1 range 1 'h';
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-d447-7403-89f0-138b4bd88a5b    pitr02    30008    2024-12-25 08:35:23    2024-12-25 08:35:23    database    30008    acc01    abc1        317577    1    h
 drop database abc1;
 create database abc1;
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-d447-7403-89f0-138b4bd88a5b    pitr02    30008    2024-12-25 08:35:23    2024-12-25 08:35:23    database    30008    acc01    abc1        317578    1    h
 drop database abc1;
@@ -69,13 +69,13 @@ use abc1;
 create table test1(a timestamp);
 drop pitr if exists pitr03;
 create pitr pitr03 for table abc1 test1 range 1 'h';
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-d447-7403-89f0-138b4bd88a5b    pitr02    30008    2024-12-25 08:35:23    2024-12-25 08:35:23    database    30008    acc01    abc1        317579    1    h
 0193fcf4-d4d0-7e9a-b664-04edf8469ab2    pitr03    30008    2024-12-25 08:35:23    2024-12-25 08:35:23    table    30008    acc01    abc1    test1    317580    1    h
 drop table test1;
 create table test1(a timestamp);
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 pitr_id    pitr_name    create_account    create_time    modified_time    level    account_id    account_name    database_name    table_name    obj_id    pitr_length    pitr_unit
 0193fcf4-d447-7403-89f0-138b4bd88a5b    pitr02    30008    2024-12-25 08:35:23    2024-12-25 08:35:23    database    30008    acc01    abc1        317579    1    h
 0193fcf4-d4d0-7e9a-b664-04edf8469ab2    pitr03    30008    2024-12-25 08:35:23    2024-12-25 08:35:23    table    30008    acc01    abc1    test1    317581    1    h

--- a/test/distributed/cases/pitr/pitr_inherit.sql
+++ b/test/distributed/cases/pitr/pitr_inherit.sql
@@ -4,13 +4,13 @@ create account acc01 admin_name = 'test_account' identified by '111';
 drop pitr if exists pitr01;
 create pitr pitr01 for account acc01 range 1 'h';
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @ignore:0,1
 select account_id, account_name from mo_catalog.mo_account where account_name = 'acc01';
 drop account if exists acc01;
 create account acc01 admin_name = 'test_account' identified by '111';
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @ignore:0,1
 select account_id, account_name from mo_catalog.mo_account where account_name = 'acc01';
 drop account if exists acc01;
@@ -22,11 +22,11 @@ create database abc1;
 drop pitr if exists pitr02;
 create pitr pitr02 for database abc1 range 1 'h';
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop database abc1;
 create database abc1;
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop database abc1;
 drop pitr if exists pitr02;
 
@@ -38,11 +38,11 @@ create table test1(a timestamp);
 drop pitr if exists pitr03;
 create pitr pitr03 for table abc1 test1 range 1 'h';
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop table test1;
 create table test1(a timestamp);
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 drop database abc1;
 drop pitr if exists pitr03;
 
@@ -56,13 +56,13 @@ drop pitr if exists pitr02;
 create pitr pitr02 for database abc1 range 1 'h';
 -- @session
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @session:id=1&user=acc01:test_account&password=111
 drop database abc1;
 create database abc1;
 -- @session
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @session:id=1&user=acc01:test_account&password=111
 drop database abc1;
 -- @session
@@ -77,13 +77,13 @@ drop pitr if exists pitr03;
 create pitr pitr03 for table abc1 test1 range 1 'h';
 -- @session
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @session:id=1&user=acc01:test_account&password=111
 drop table test1;
 create table test1(a timestamp);
 -- @session
 -- @ignore:0,2,3,4,6,7,10
-select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr';
+select `pitr_id`, `pitr_name`, `create_account`, `create_time`, `modified_time`, `level`, `account_id`, `account_name`, `database_name`, `table_name`, `obj_id`, `pitr_length`, `pitr_unit` from mo_catalog.mo_pitr Where pitr_name != 'sys_mo_catalog_pitr' and left(pitr_name, 22) != '__mo_data_branch_pitr_';
 -- @session:id=1&user=acc01:test_account&password=111
 drop database abc1;
 -- @session


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issues https://github.com/matrixorigin/matrixone/issues/23751

## What this PR does / why we need it:

Backport/adapt the data branch PITR protection from #24256 to `3.0-dev`.

Data branch diff may need to read the LCA snapshot after source table objects are compacted or GC'd. Without pinning the branch point, later object merge/GC can remove the required historical state and cause update rows to be classified as inserts. This PR creates internal 1-year PITRs for data-branch source tables/databases so the branch point remains readable without relying on fallback reconstruction.

Main changes:

- create reserved internal PITRs for data-branch source tables/databases
- create/refresh the supporting `sys_mo_catalog_pitr` only when internal/user PITRs still need it
- reuse the same internal PITR when the same table/database is branched multiple times
- clean internal PITRs when the source table/database is dropped or no active branch metadata still references it
- scope data-branch PITR cleanup to related metadata instead of scanning all branch metadata
- quote generated cleanup SQL names
- hide internal PITRs from user PITR operations by reserved names and prefixes
- migrate the GC data-branch diff BVT coverage, including base-row update after branch merge

3.0-dev adaptation:

- no `mo_catalog.mo_pitr` schema change
- no cluster upgrade entry for PITR kind/type columns
- do not backport unrelated main-branch CCPR/CDC/partition code that only appeared as cherry-pick context

Validation:

- `git diff --check`
- `go test ./pkg/frontend -run 'Pitr|PITR' -count=1`
- `go test ./pkg/sql/plan -run 'TestBuildDropPitrReservedName|TestBuildCreatePitr|TestBuildDropPitr|TestBuildShow' -count=1`
- `go test ./pkg/sql/compile -run 'TestDropPitrReservedName|TestGetSqlForCheckPitrExistsQuotesName|TestDropDatabase|TestDropTableSingle' -count=1`
- `go test ./pkg/bootstrap/versions/v3_0_0 -count=1`
- `mo-tester -i git4data/branch/diff/diff_9`: 76/76 passed
