### PR TITLE
fix: throttle CN S3 writes under memory pressure

### DIFF
--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -99,10 +99,18 @@ func (m *memThrottler) pinnedRate() float64 {
 }
 
 func (m *memThrottler) Refresh() {
+	m.refresh(false)
+}
+
+func (m *memThrottler) ForceRefresh() {
+	m.refresh(true)
+}
+
+func (m *memThrottler) refresh(force bool) {
 	last := m.lastRefresh.Load()
 	now := time.Now().UnixNano()
 
-	if time.Duration(now-last) <= refreshMaxInterval {
+	if !force && time.Duration(now-last) <= refreshMaxInterval {
 		return
 	}
 
@@ -344,7 +352,6 @@ func AcquirePolicyForCNFlushS3(
 	throttler *memThrottler,
 	ask int64,
 ) (int64, bool) {
-
 	rate := throttler.pinnedRate()
 
 	if rate >= 0.80 {
@@ -358,10 +365,37 @@ func AcquirePolicyForCNFlushS3(
 		if ask >= mpool.MB*10 {
 			return 0, false
 		}
-		return defaultAcquirePolicy(throttler, ask)
+		return acquireWithinRSSLimit(throttler, ask)
 	}
 
-	return defaultAcquirePolicy(throttler, ask)
+	return acquireWithinRSSLimit(throttler, ask)
+}
+
+func acquireWithinRSSLimit(throttler *memThrottler, ask int64) (int64, bool) {
+	for {
+		avail := throttler.Available()
+		if !throttler.options.allowOutOfMemoryAcquire && avail < ask {
+			return avail, false
+		}
+
+		currReserved := throttler.reserved.Load()
+		if currReserved < 0 {
+			currReserved = 0
+		}
+
+		total := int64(throttler.actualTotalMemory.Load())
+		if total > 0 && throttler.limitRate > 0 {
+			used := throttler.rss.Load() + currReserved + ask
+			if float64(used) > float64(total)*throttler.limitRate {
+				return 0, false
+			}
+		}
+
+		newReserved := currReserved + ask
+		if throttler.reserved.CompareAndSwap(currReserved, newReserved) {
+			return avail - ask, true
+		}
+	}
 }
 
 func AcquirePolicyForDataBranch(

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -169,3 +169,54 @@ func TestAcquirePolicyForDataBranch(t *testing.T) {
 		require.Equal(t, int64(10), throttler.reserved.Load())
 	})
 }
+
+func TestAcquirePolicyForCNFlushS3(t *testing.T) {
+	t.Run("deny when rss already crosses limit", func(t *testing.T) {
+		throttler := &memThrottler{limitRate: 0.90}
+		throttler.actualTotalMemory.Store(100)
+		throttler.limit.Store(90)
+		throttler.rss.Store(91)
+
+		left, ok := AcquirePolicyForCNFlushS3(throttler, 1)
+		require.False(t, ok)
+		require.Equal(t, int64(0), left)
+		require.Equal(t, int64(0), throttler.reserved.Load())
+	})
+
+	t.Run("deny when projected rss crosses limit", func(t *testing.T) {
+		throttler := &memThrottler{limitRate: 0.90}
+		throttler.actualTotalMemory.Store(100)
+		throttler.limit.Store(90)
+		throttler.rss.Store(85)
+
+		left, ok := AcquirePolicyForCNFlushS3(throttler, 6)
+		require.False(t, ok)
+		require.Equal(t, int64(0), left)
+		require.Equal(t, int64(0), throttler.reserved.Load())
+	})
+
+	t.Run("deny when projected rss plus reserved crosses limit", func(t *testing.T) {
+		throttler := &memThrottler{limitRate: 0.90}
+		throttler.actualTotalMemory.Store(100)
+		throttler.limit.Store(90)
+		throttler.rss.Store(80)
+		throttler.reserved.Store(9)
+
+		left, ok := AcquirePolicyForCNFlushS3(throttler, 2)
+		require.False(t, ok)
+		require.Equal(t, int64(0), left)
+		require.Equal(t, int64(9), throttler.reserved.Load())
+	})
+
+	t.Run("allow under rss limit and reserve memory", func(t *testing.T) {
+		throttler := &memThrottler{limitRate: 0.90}
+		throttler.actualTotalMemory.Store(100)
+		throttler.limit.Store(90)
+		throttler.rss.Store(80)
+
+		left, ok := AcquirePolicyForCNFlushS3(throttler, 10)
+		require.True(t, ok)
+		require.Equal(t, int64(10), left)
+		require.Equal(t, int64(10), throttler.reserved.Load())
+	})
+}

--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -121,13 +121,18 @@ func (insert *Insert) Call(proc *process.Process) (vm.CallResult, error) {
 	return insert.insert_table(proc, analyzer)
 }
 
-func (insert *Insert) insert_s3(proc *process.Process, analyzer process.Analyzer) (vm.CallResult, error) {
+func (insert *Insert) insert_s3(proc *process.Process, analyzer process.Analyzer) (result vm.CallResult, err error) {
 	start := time.Now()
 	defer func() {
 		v2.TxnStatementInsertS3DurationHistogram.Observe(time.Since(start).Seconds())
 	}()
+	defer func() {
+		if err != nil {
+			insert.releaseS3MemGrant()
+		}
+	}()
 
-	result := vm.NewCallResult()
+	result = vm.NewCallResult()
 	result.Batch = insert.ctr.buf
 
 	if insert.ctr.state == vm.Build {
@@ -259,11 +264,16 @@ func forcedRefresh(throttler interface{ Refresh() }) {
 	throttler.Refresh()
 }
 
-func (insert *Insert) flushS3WriterOnMemoryPressure(proc *process.Process, analyzer process.Analyzer) error {
+func (insert *Insert) flushS3WriterOnMemoryPressure(proc *process.Process, analyzer process.Analyzer) (err error) {
 	if insert.isMemoryTable() || insert.ctr.s3Writer == nil {
 		insert.releaseS3MemGrant()
 		return nil
 	}
+	defer func() {
+		if err != nil {
+			insert.releaseS3MemGrant()
+		}
+	}()
 
 	crs := analyzer.GetOpCounterSet()
 	newCtx := perfcounter.AttachS3RequestKey(proc.Ctx, crs)

--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -19,6 +19,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/rscthrottler"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
@@ -64,6 +67,11 @@ func (insert *Insert) Prepare(proc *process.Process) error {
 			sinkerOpts...)
 
 		insert.ctr.s3Writer = s3Writer
+		insert.ctr.s3MemGranted = 0
+		insert.ctr.s3MemThrottler = nil
+		if throttler, ok := runtime.ServiceRuntime(proc.GetService()).GetGlobalVariables(runtime.CNMemoryThrottler); ok {
+			insert.ctr.s3MemThrottler = throttler.(rscthrottler.RSCThrottler)
+		}
 
 		if insert.ctr.buf == nil {
 			insert.initBufForS3()
@@ -116,6 +124,9 @@ func (insert *Insert) insert_s3(proc *process.Process, analyzer process.Analyzer
 		v2.TxnStatementInsertS3DurationHistogram.Observe(time.Since(start).Seconds())
 	}()
 
+	result := vm.NewCallResult()
+	result.Batch = insert.ctr.buf
+
 	if insert.ctr.state == vm.Build {
 		for {
 			input, err := vm.ChildrenCall(insert.GetChildren(0), proc, analyzer)
@@ -138,6 +149,10 @@ func (insert *Insert) insert_s3(proc *process.Process, analyzer process.Analyzer
 
 			// write to s3.
 			input.Batch.Attrs = append(input.Batch.Attrs[:0], insert.InsertCtx.Attrs...)
+			if err = insert.acquireS3WriteMemory(proc, analyzer, input.Batch.Size()); err != nil {
+				insert.ctr.state = vm.End
+				return vm.CancelResult, err
+			}
 			err = insert.ctr.s3Writer.Write(proc.Ctx, input.Batch)
 			if err != nil {
 				insert.ctr.state = vm.End
@@ -146,8 +161,6 @@ func (insert *Insert) insert_s3(proc *process.Process, analyzer process.Analyzer
 		}
 	}
 
-	result := vm.NewCallResult()
-	result.Batch = insert.ctr.buf
 	if insert.ctr.state == vm.Eval {
 		writer := insert.ctr.s3Writer
 		// handle the last Batch that batchSize less than DefaultBlockMaxRows
@@ -159,6 +172,7 @@ func (insert *Insert) insert_s3(proc *process.Process, analyzer process.Analyzer
 			insert.ctr.state = vm.End
 			return result, err
 		}
+		insert.releaseS3MemGrant()
 		insert.ctr.state = vm.End
 		return result, nil
 	}
@@ -168,6 +182,75 @@ func (insert *Insert) insert_s3(proc *process.Process, analyzer process.Analyzer
 	}
 
 	panic("bug")
+}
+
+type forceRefreshThrottler interface {
+	ForceRefresh()
+}
+
+func (insert *Insert) acquireS3WriteMemory(proc *process.Process, analyzer process.Analyzer, size int) error {
+	if insert.isMemoryTable() || insert.ctr.s3MemThrottler == nil || size <= 0 {
+		return nil
+	}
+
+	ask := int64(size)
+	forcedRefresh(insert.ctr.s3MemThrottler)
+	if _, ok := insert.ctr.s3MemThrottler.Acquire(ask); ok {
+		insert.ctr.s3MemGranted += ask
+		return nil
+	}
+
+	if err := insert.flushS3WriterOnMemoryPressure(proc, analyzer); err != nil {
+		return err
+	}
+
+	forcedRefresh(insert.ctr.s3MemThrottler)
+	if _, ok := insert.ctr.s3MemThrottler.Acquire(ask); ok {
+		insert.ctr.s3MemGranted += ask
+		return nil
+	}
+
+	return moerr.NewInternalErrorf(proc.Ctx,
+		"CN S3 write memory is exhausted, available %d bytes, ask %d bytes",
+		insert.ctr.s3MemThrottler.Available(), ask)
+}
+
+func forcedRefresh(throttler interface{ Refresh() }) {
+	if refresher, ok := throttler.(forceRefreshThrottler); ok {
+		refresher.ForceRefresh()
+		return
+	}
+	throttler.Refresh()
+}
+
+func (insert *Insert) flushS3WriterOnMemoryPressure(proc *process.Process, analyzer process.Analyzer) error {
+	if insert.isMemoryTable() || insert.ctr.s3Writer == nil {
+		insert.releaseS3MemGrant()
+		return nil
+	}
+
+	crs := analyzer.GetOpCounterSet()
+	newCtx := perfcounter.AttachS3RequestKey(proc.Ctx, crs)
+
+	blockInfoBat, err := insert.ctr.s3Writer.SyncAndFillBlockInfoBat(newCtx)
+	if err != nil {
+		return err
+	}
+
+	analyzer.AddS3RequestCount(crs)
+	analyzer.AddFileServiceCacheInfo(crs)
+	analyzer.AddDiskIO(crs)
+
+	if blockInfoBat != nil && blockInfoBat.RowCount() > 0 {
+		insert.ctr.buf, err = insert.ctr.buf.Append(proc.Ctx, proc.GetMPool(), blockInfoBat)
+		if err != nil {
+			return err
+		}
+		insert.ctr.s3Writer.ResetBlockInfoBat()
+	}
+
+	insert.releaseS3MemGrant()
+	return nil
 }
 
 func (insert *Insert) insert_table(proc *process.Process, analyzer process.Analyzer) (vm.CallResult, error) {

--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -59,7 +59,9 @@ func (insert *Insert) Prepare(proc *process.Process) error {
 
 		// If the target is not partition table, you only need to operate the main table
 		var sinkerOpts []ioutil.SinkerOption
+		pipelineFlush := false
 		if v, ok := proc.Ctx.Value(ioutil.PipelineFlushKey).(bool); ok && v {
+			pipelineFlush = true
 			sinkerOpts = append(sinkerOpts, ioutil.WithPipelineFlush())
 		}
 		s3Writer := colexec.NewCNS3DataWriter(
@@ -68,6 +70,7 @@ func (insert *Insert) Prepare(proc *process.Process) error {
 
 		insert.ctr.s3Writer = s3Writer
 		insert.ctr.s3MemGranted = 0
+		insert.ctr.s3MemNoThresholdCap = pipelineFlush
 		insert.ctr.s3MemThrottler = nil
 		if throttler, ok := runtime.ServiceRuntime(proc.GetService()).GetGlobalVariables(runtime.CNMemoryThrottler); ok {
 			insert.ctr.s3MemThrottler = throttler.(rscthrottler.RSCThrottler)
@@ -193,10 +196,17 @@ func (insert *Insert) acquireS3WriteMemory(proc *process.Process, analyzer proce
 		return nil
 	}
 
-	ask := int64(size)
+	ask := insert.s3WriteMemoryReservation(size) - insert.ctr.s3MemGranted
+	if ask <= 0 {
+		return nil
+	}
+
+	if insert.tryAcquireS3WriteMemory(ask) {
+		return nil
+	}
+
 	forcedRefresh(insert.ctr.s3MemThrottler)
-	if _, ok := insert.ctr.s3MemThrottler.Acquire(ask); ok {
-		insert.ctr.s3MemGranted += ask
+	if insert.tryAcquireS3WriteMemory(ask) {
 		return nil
 	}
 
@@ -204,15 +214,41 @@ func (insert *Insert) acquireS3WriteMemory(proc *process.Process, analyzer proce
 		return err
 	}
 
-	forcedRefresh(insert.ctr.s3MemThrottler)
-	if _, ok := insert.ctr.s3MemThrottler.Acquire(ask); ok {
-		insert.ctr.s3MemGranted += ask
+	ask = insert.s3WriteMemoryReservation(size) - insert.ctr.s3MemGranted
+	if ask <= 0 || insert.tryAcquireS3WriteMemory(ask) {
 		return nil
 	}
 
+	forcedRefresh(insert.ctr.s3MemThrottler)
+	if insert.tryAcquireS3WriteMemory(ask) {
+		return nil
+	}
 	return moerr.NewInternalErrorf(proc.Ctx,
 		"CN S3 write memory is exhausted, available %d bytes, ask %d bytes",
 		insert.ctr.s3MemThrottler.Available(), ask)
+}
+
+func (insert *Insert) s3WriteMemoryReservation(size int) int64 {
+	reservation := insert.ctr.s3MemGranted + int64(size)
+	if insert.ctr.s3MemNoThresholdCap {
+		return reservation
+	}
+	if insert.ctr.s3Writer != nil {
+		if threshold := int64(insert.ctr.s3Writer.MemorySizeThreshold()); threshold > 0 && reservation > threshold {
+			reservation = threshold
+		}
+	} else if threshold := int64(colexec.WriteS3Threshold); reservation > threshold {
+		reservation = int64(colexec.WriteS3Threshold)
+	}
+	return reservation
+}
+
+func (insert *Insert) tryAcquireS3WriteMemory(ask int64) bool {
+	if _, ok := insert.ctr.s3MemThrottler.Acquire(ask); ok {
+		insert.ctr.s3MemGranted += ask
+		return true
+	}
+	return false
 }
 
 func forcedRefresh(throttler interface{ Refresh() }) {

--- a/pkg/sql/colexec/insert/insert_test.go
+++ b/pkg/sql/colexec/insert/insert_test.go
@@ -21,10 +21,12 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
@@ -202,6 +204,14 @@ func (t *testS3MemThrottler) Available() int64 {
 	return 0
 }
 
+type testRefreshOnlyThrottler struct {
+	refreshed int
+}
+
+func (t *testRefreshOnlyThrottler) Refresh() {
+	t.refreshed++
+}
+
 func TestInsertAcquireS3WriteMemory(t *testing.T) {
 	proc := testutil.NewProc(t)
 	defer proc.Free()
@@ -291,4 +301,118 @@ func TestInsertAcquireS3WriteMemoryDoesNotCapPipelineFlush(t *testing.T) {
 	require.Equal(t, []int64{int64(size)}, throttler.acquired)
 	require.Equal(t, int64(size), insert.ctr.s3MemGranted)
 	require.Equal(t, 0, throttler.forceRefresh)
+}
+
+func TestInsertAcquireS3WriteMemoryReturnsExhaustedError(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	throttler := &testS3MemThrottler{grants: []bool{false, false, false, false}}
+	insert := &Insert{
+		InsertCtx: &InsertCtx{},
+		ctr: container{
+			s3MemThrottler: throttler,
+		},
+	}
+
+	err := insert.acquireS3WriteMemory(proc, process.NewAnalyzer(0, false, false, "insert"), 1024)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CN S3 write memory is exhausted")
+	require.Equal(t, []int64{1024, 1024, 1024, 1024}, throttler.acquired)
+	require.Equal(t, 2, throttler.forceRefresh)
+}
+
+func TestForcedRefreshFallsBackToRefresh(t *testing.T) {
+	throttler := &testRefreshOnlyThrottler{}
+	forcedRefresh(throttler)
+	require.Equal(t, 1, throttler.refreshed)
+}
+
+func TestInsertPrepareToWriteS3WithPipelineFlush(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	proc.Ctx = context.WithValue(proc.Ctx, ioutil.PipelineFlushKey, true)
+	throttler := &testS3MemThrottler{}
+	runtime.ServiceRuntime(proc.GetService()).SetGlobalVariables(runtime.CNMemoryThrottler, throttler)
+
+	insert := &Insert{
+		ToWriteS3: true,
+		InsertCtx: &InsertCtx{
+			TableDef: testInsertS3TableDef(),
+		},
+	}
+
+	err := insert.Prepare(proc)
+	require.NoError(t, err)
+	require.True(t, insert.ctr.s3MemNoThresholdCap)
+	require.Same(t, throttler, insert.ctr.s3MemThrottler)
+	require.NotNil(t, insert.ctr.s3Writer)
+	require.NotNil(t, insert.ctr.buf)
+	require.Equal(t, colexec.WriteS3Threshold, insert.ctr.s3Writer.MemorySizeThreshold())
+}
+
+func TestInsertFlushS3WriterOnMemoryPressureAppendsBlockInfo(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	fs, err := colexec.GetSharedFSFromProc(proc)
+	require.NoError(t, err)
+
+	throttler := &testS3MemThrottler{}
+	insert := &Insert{
+		InsertCtx: &InsertCtx{
+			TableDef: testInsertS3TableDef(),
+		},
+		ctr: container{
+			s3Writer:       colexec.NewCNS3DataWriter(proc.Mp(), fs, testInsertS3TableDef(), 1, false),
+			s3MemGranted:   1024,
+			s3MemThrottler: throttler,
+		},
+	}
+	insert.initBufForS3()
+	defer insert.ctr.s3Writer.Close()
+
+	bat := &batch.Batch{
+		Attrs: []string{"a", "b"},
+		Vecs: []*vector.Vector{
+			testutil.MakeInt64Vector([]int64{1}, nil, proc.Mp()),
+			testutil.MakeVarcharVector([]string{"x"}, nil, proc.Mp()),
+		},
+	}
+	bat.SetRowCount(1)
+	defer bat.Clean(proc.Mp())
+
+	err = insert.ctr.s3Writer.Write(proc.Ctx, bat)
+	require.NoError(t, err)
+
+	err = insert.flushS3WriterOnMemoryPressure(proc, process.NewAnalyzer(0, false, false, "insert"))
+	require.NoError(t, err)
+	require.Equal(t, int64(0), insert.ctr.s3MemGranted)
+	require.Equal(t, int64(1024), throttler.released)
+	require.NotNil(t, insert.ctr.buf)
+	require.Greater(t, insert.ctr.buf.RowCount(), 0)
+}
+
+func testInsertS3TableDef() *plan.TableDef {
+	tableDef := &plan.TableDef{
+		Name: "t1",
+		Cols: []*plan.ColDef{
+			{ColId: 0, Name: "a", Seqnum: 0, Typ: plan.Type{Id: int32(types.T_int64)}, NotNull: true, Primary: true, Default: &plan.Default{NullAbility: false}},
+			{ColId: 1, Name: "b", Seqnum: 1, Typ: plan.Type{Id: int32(types.T_varchar), Width: 8192}, NotNull: true},
+			{ColId: 2, Name: catalog.Row_ID, Seqnum: 2, Typ: plan.Type{Id: int32(types.T_Rowid)}},
+		},
+		Pkey: &plan.PrimaryKeyDef{
+			Cols:        []uint64{0},
+			PkeyColId:   0,
+			PkeyColName: "a",
+			Names:       []string{"a"},
+		},
+		Name2ColIndex: map[string]int32{
+			"a":            0,
+			"b":            1,
+			catalog.Row_ID: 2,
+		},
+	}
+	return tableDef
 }

--- a/pkg/sql/colexec/insert/insert_test.go
+++ b/pkg/sql/colexec/insert/insert_test.go
@@ -206,7 +206,7 @@ func TestInsertAcquireS3WriteMemory(t *testing.T) {
 	proc := testutil.NewProc(t)
 	defer proc.Free()
 
-	throttler := &testS3MemThrottler{grants: []bool{true}}
+	throttler := &testS3MemThrottler{grants: []bool{true, true}}
 	insert := &Insert{
 		InsertCtx: &InsertCtx{},
 		ctr: container{
@@ -218,14 +218,20 @@ func TestInsertAcquireS3WriteMemory(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []int64{1024}, throttler.acquired)
 	require.Equal(t, int64(1024), insert.ctr.s3MemGranted)
-	require.Equal(t, 1, throttler.forceRefresh)
+	require.Equal(t, 0, throttler.forceRefresh)
+
+	err = insert.acquireS3WriteMemory(proc, process.NewAnalyzer(0, false, false, "insert"), 1024)
+	require.NoError(t, err)
+	require.Equal(t, []int64{1024, 1024}, throttler.acquired)
+	require.Equal(t, int64(2048), insert.ctr.s3MemGranted)
+	require.Equal(t, 0, throttler.forceRefresh)
 }
 
 func TestInsertAcquireS3WriteMemoryFlushesBeforeRetry(t *testing.T) {
 	proc := testutil.NewProc(t)
 	defer proc.Free()
 
-	throttler := &testS3MemThrottler{grants: []bool{false, true}}
+	throttler := &testS3MemThrottler{grants: []bool{false, false, true}}
 	insert := &Insert{
 		InsertCtx: &InsertCtx{},
 		ctr: container{
@@ -234,10 +240,55 @@ func TestInsertAcquireS3WriteMemoryFlushesBeforeRetry(t *testing.T) {
 		},
 	}
 
-	err := insert.acquireS3WriteMemory(proc, process.NewAnalyzer(0, false, false, "insert"), 1024)
+	err := insert.acquireS3WriteMemory(proc, process.NewAnalyzer(0, false, false, "insert"), 4096)
 	require.NoError(t, err)
-	require.Equal(t, []int64{1024, 1024}, throttler.acquired)
+	require.Equal(t, []int64{4096, 4096, 4096}, throttler.acquired)
 	require.Equal(t, int64(2048), throttler.released)
-	require.Equal(t, int64(1024), insert.ctr.s3MemGranted)
-	require.Equal(t, 2, throttler.forceRefresh)
+	require.Equal(t, int64(4096), insert.ctr.s3MemGranted)
+	require.Equal(t, 1, throttler.forceRefresh)
+}
+
+func TestInsertAcquireS3WriteMemoryCapsReservationToS3Threshold(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	throttler := &testS3MemThrottler{grants: []bool{true}}
+	insert := &Insert{
+		InsertCtx: &InsertCtx{},
+		ctr: container{
+			s3MemThrottler: throttler,
+		},
+	}
+
+	size := colexec.WriteS3Threshold * 4
+	err := insert.acquireS3WriteMemory(proc, process.NewAnalyzer(0, false, false, "insert"), size)
+	require.NoError(t, err)
+	require.Equal(t, []int64{int64(colexec.WriteS3Threshold)}, throttler.acquired)
+	require.Equal(t, int64(colexec.WriteS3Threshold), insert.ctr.s3MemGranted)
+	require.Equal(t, 0, throttler.forceRefresh)
+
+	err = insert.acquireS3WriteMemory(proc, process.NewAnalyzer(0, false, false, "insert"), size)
+	require.NoError(t, err)
+	require.Equal(t, []int64{int64(colexec.WriteS3Threshold)}, throttler.acquired)
+}
+
+func TestInsertAcquireS3WriteMemoryDoesNotCapPipelineFlush(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	throttler := &testS3MemThrottler{grants: []bool{true}}
+	insert := &Insert{
+		InsertCtx: &InsertCtx{},
+		ctr: container{
+			s3MemThrottler:      throttler,
+			s3MemNoThresholdCap: true,
+		},
+	}
+
+	size := colexec.WriteS3Threshold * 4
+	err := insert.acquireS3WriteMemory(proc, process.NewAnalyzer(0, false, false, "insert"), size)
+	require.NoError(t, err)
+	require.Equal(t, []int64{int64(size)}, throttler.acquired)
+	require.Equal(t, int64(size), insert.ctr.s3MemGranted)
+	require.Equal(t, 0, throttler.forceRefresh)
 }

--- a/pkg/sql/colexec/insert/insert_test.go
+++ b/pkg/sql/colexec/insert/insert_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/memoryengine"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
 )
 
@@ -165,4 +166,78 @@ func TestInsert_initBufForS3(t *testing.T) {
 			require.Equal(t, types.T_binary, insert.ctr.buf.Vecs[2].GetType().Oid)
 		})
 	}
+}
+
+type testS3MemThrottler struct {
+	grants       []bool
+	acquired     []int64
+	released     int64
+	forceRefresh int
+}
+
+func (t *testS3MemThrottler) Refresh() {}
+
+func (t *testS3MemThrottler) ForceRefresh() {
+	t.forceRefresh++
+}
+
+func (t *testS3MemThrottler) PrintUsage() {}
+
+func (t *testS3MemThrottler) Acquire(size int64) (int64, bool) {
+	t.acquired = append(t.acquired, size)
+	if len(t.grants) == 0 {
+		return 0, false
+	}
+	grant := t.grants[0]
+	t.grants = t.grants[1:]
+	return 0, grant
+}
+
+func (t *testS3MemThrottler) Release(size int64) int64 {
+	t.released += size
+	return 0
+}
+
+func (t *testS3MemThrottler) Available() int64 {
+	return 0
+}
+
+func TestInsertAcquireS3WriteMemory(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	throttler := &testS3MemThrottler{grants: []bool{true}}
+	insert := &Insert{
+		InsertCtx: &InsertCtx{},
+		ctr: container{
+			s3MemThrottler: throttler,
+		},
+	}
+
+	err := insert.acquireS3WriteMemory(proc, process.NewAnalyzer(0, false, false, "insert"), 1024)
+	require.NoError(t, err)
+	require.Equal(t, []int64{1024}, throttler.acquired)
+	require.Equal(t, int64(1024), insert.ctr.s3MemGranted)
+	require.Equal(t, 1, throttler.forceRefresh)
+}
+
+func TestInsertAcquireS3WriteMemoryFlushesBeforeRetry(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	throttler := &testS3MemThrottler{grants: []bool{false, true}}
+	insert := &Insert{
+		InsertCtx: &InsertCtx{},
+		ctr: container{
+			s3MemGranted:   2048,
+			s3MemThrottler: throttler,
+		},
+	}
+
+	err := insert.acquireS3WriteMemory(proc, process.NewAnalyzer(0, false, false, "insert"), 1024)
+	require.NoError(t, err)
+	require.Equal(t, []int64{1024, 1024}, throttler.acquired)
+	require.Equal(t, int64(2048), throttler.released)
+	require.Equal(t, int64(1024), insert.ctr.s3MemGranted)
+	require.Equal(t, 2, throttler.forceRefresh)
 }

--- a/pkg/sql/colexec/insert/types.go
+++ b/pkg/sql/colexec/insert/types.go
@@ -16,6 +16,7 @@ package insert
 
 import (
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
+	"github.com/matrixorigin/matrixone/pkg/common/rscthrottler"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
@@ -38,6 +39,8 @@ type container struct {
 	partitionS3Writers []*colexec.CNS3Writer // The array is aligned with the partition number array
 	buf                *batch.Batch
 	affectedRows       uint64
+	s3MemGranted       int64
+	s3MemThrottler     rscthrottler.RSCThrottler
 
 	source engine.Relation
 }
@@ -98,6 +101,7 @@ func (insert *Insert) Reset(proc *process.Process, pipelineFailed bool, err erro
 		insert.ctr.s3Writer.Close()
 		insert.ctr.s3Writer = nil
 	}
+	insert.releaseS3MemGrant()
 	if insert.ctr.partitionS3Writers != nil {
 		for _, writer := range insert.ctr.partitionS3Writers {
 			writer.Close()
@@ -118,6 +122,7 @@ func (insert *Insert) Free(proc *process.Process, pipelineFailed bool, err error
 		insert.ctr.s3Writer.Close()
 		insert.ctr.s3Writer = nil
 	}
+	insert.releaseS3MemGrant()
 
 	// Free the partition table S3writer object resources
 	if insert.ctr.partitionS3Writers != nil {
@@ -132,6 +137,13 @@ func (insert *Insert) Free(proc *process.Process, pipelineFailed bool, err error
 		insert.ctr.buf = nil
 	}
 	insert.ctr.source = nil
+}
+
+func (insert *Insert) releaseS3MemGrant() {
+	if insert.ctr.s3MemThrottler != nil && insert.ctr.s3MemGranted > 0 {
+		insert.ctr.s3MemThrottler.Release(insert.ctr.s3MemGranted)
+		insert.ctr.s3MemGranted = 0
+	}
 }
 
 func (insert *Insert) ExecProjection(proc *process.Process, input *batch.Batch) (*batch.Batch, error) {

--- a/pkg/sql/colexec/insert/types.go
+++ b/pkg/sql/colexec/insert/types.go
@@ -34,13 +34,14 @@ var _ vm.Operator = new(Insert)
 // )
 
 type container struct {
-	state              vm.CtrState
-	s3Writer           *colexec.CNS3Writer
-	partitionS3Writers []*colexec.CNS3Writer // The array is aligned with the partition number array
-	buf                *batch.Batch
-	affectedRows       uint64
-	s3MemGranted       int64
-	s3MemThrottler     rscthrottler.RSCThrottler
+	state               vm.CtrState
+	s3Writer            *colexec.CNS3Writer
+	partitionS3Writers  []*colexec.CNS3Writer // The array is aligned with the partition number array
+	buf                 *batch.Batch
+	affectedRows        uint64
+	s3MemGranted        int64
+	s3MemThrottler      rscthrottler.RSCThrottler
+	s3MemNoThresholdCap bool
 
 	source engine.Relation
 }

--- a/pkg/sql/colexec/s3util.go
+++ b/pkg/sql/colexec/s3util.go
@@ -226,6 +226,30 @@ func (w *CNS3Writer) Sync(ctx context.Context) (stats []objectio.ObjectStats, er
 	return
 }
 
+func (w *CNS3Writer) SyncAndFillBlockInfoBat(ctx context.Context) (*batch.Batch, error) {
+	stats, _, err := w.sinker.SyncAndTakeResults(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	w.ResetBlockInfoBat()
+	if len(stats) == 0 {
+		return w.blockInfoBat, nil
+	}
+
+	if err = ExpandObjectStatsToBatch(
+		w.sinker.GetMPool(),
+		w.isTombstone,
+		w.blockInfoBat,
+		true,
+		stats...,
+	); err != nil {
+		return nil, err
+	}
+
+	return w.blockInfoBat, nil
+}
+
 func (w *CNS3Writer) Close() (err error) {
 	var mp *mpool.MPool
 	if w.sinker != nil {

--- a/pkg/sql/colexec/s3util.go
+++ b/pkg/sql/colexec/s3util.go
@@ -45,9 +45,10 @@ const (
 )
 
 type CNS3Writer struct {
-	sinker       *ioutil.Sinker
-	isTombstone  bool
-	blockInfoBat *batch.Batch
+	sinker              *ioutil.Sinker
+	isTombstone         bool
+	blockInfoBat        *batch.Batch
+	memorySizeThreshold int
 }
 
 func (w *CNS3Writer) String() string {
@@ -190,6 +191,7 @@ func NewCNS3DataWriter(
 		// do not flush on sync, so the threshold is the max int
 		memoryThreshold = math.MaxInt
 	}
+	writer.memorySizeThreshold = memoryThreshold
 
 	sinkerOpts = append(sinkerOpts, ioutil.WithMemorySizeThreshold(memoryThreshold))
 	sinkerOpts = append(sinkerOpts, ioutil.WithTailSizeCap(0))
@@ -211,6 +213,10 @@ func NewCNS3DataWriter(
 
 func (w *CNS3Writer) Write(ctx context.Context, bat *batch.Batch) error {
 	return w.sinker.Write(ctx, bat)
+}
+
+func (w *CNS3Writer) MemorySizeThreshold() int {
+	return w.memorySizeThreshold
 }
 
 func (w *CNS3Writer) WriteOwned(ctx context.Context, bat *batch.Batch) (bool, error) {

--- a/pkg/sql/colexec/s3util_threshold_test.go
+++ b/pkg/sql/colexec/s3util_threshold_test.go
@@ -1,0 +1,98 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package colexec
+
+import (
+	"math"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCNS3DataWriterMemoryThresholdAndSyncAndFillBlockInfoBat(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	fs, err := fileservice.Get[fileservice.FileService](proc.Base.FileService, defines.SharedFileServiceName)
+	require.NoError(t, err)
+
+	tableDef := testCNS3WriterTableDef()
+
+	t.Run("custom threshold", func(t *testing.T) {
+		writer := NewCNS3DataWriter(proc.Mp(), fs, tableDef, 1, false)
+		defer writer.Close()
+
+		require.Equal(t, 1, writer.MemorySizeThreshold())
+
+		bat := &batch.Batch{
+			Attrs: []string{"a", "b"},
+			Vecs: []*vector.Vector{
+				testutil.MakeInt64Vector([]int64{1}, nil, proc.Mp()),
+				testutil.MakeVarcharVector([]string{"x"}, nil, proc.Mp()),
+			},
+		}
+		bat.SetRowCount(1)
+		defer bat.Clean(proc.Mp())
+
+		err = writer.Write(proc.Ctx, bat)
+		require.NoError(t, err)
+
+		blockInfoBat, err := writer.SyncAndFillBlockInfoBat(proc.Ctx)
+		require.NoError(t, err)
+		require.NotNil(t, blockInfoBat)
+		require.Greater(t, blockInfoBat.RowCount(), 0)
+
+		blockInfoBat, err = writer.SyncAndFillBlockInfoBat(proc.Ctx)
+		require.NoError(t, err)
+		require.NotNil(t, blockInfoBat)
+		require.Equal(t, 0, blockInfoBat.RowCount())
+	})
+
+	t.Run("flush on sync", func(t *testing.T) {
+		writer := NewCNS3DataWriter(proc.Mp(), fs, tableDef, -1, true)
+		defer writer.Close()
+		require.Equal(t, math.MaxInt, writer.MemorySizeThreshold())
+	})
+}
+
+func testCNS3WriterTableDef() *plan.TableDef {
+	return &plan.TableDef{
+		Name: "t1",
+		Cols: []*plan.ColDef{
+			{ColId: 0, Name: "a", Seqnum: 0, Typ: plan.Type{Id: int32(types.T_int64)}, NotNull: true, Primary: true, Default: &plan.Default{NullAbility: false}},
+			{ColId: 1, Name: "b", Seqnum: 1, Typ: plan.Type{Id: int32(types.T_varchar), Width: 8192}, NotNull: true},
+			{ColId: 2, Name: catalog.Row_ID, Seqnum: 2, Typ: plan.Type{Id: int32(types.T_Rowid)}},
+		},
+		Pkey: &plan.PrimaryKeyDef{
+			Cols:        []uint64{0},
+			PkeyColId:   0,
+			PkeyColName: "a",
+			Names:       []string{"a"},
+		},
+		Name2ColIndex: map[string]int32{
+			"a":            0,
+			"b":            1,
+			catalog.Row_ID: 2,
+		},
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24267

## What this PR does / why we need it:

This PR reduces CN OOM risk for large `LOAD DATA` / `INSERT SELECT` workloads that write through the CN S3 path.

The observed OOM case loaded a large CSV with `PARALLEL 'TRUE'` and immediately copied the data into another wide table containing `vecf32(1024)`, `text`, and `json` columns. The CN RSS crossed the CNFlushS3 soft budget and approached the cgroup limit while `pinned` memory remained low, which means the normal `insert.ToWriteS3` path was not applying enough backpressure before feeding batches into `CNS3DataWriter`.

Changes:

- Add RSS-aware hard-limit checks to `AcquirePolicyForCNFlushS3`, including already reserved memory.
- Add a forced refresh path so S3 insert memory checks can use current RSS instead of waiting for the normal refresh interval.
- Make `insert.ToWriteS3` reserve memory against `CNMemoryThrottler` before writing each batch.
- When the CN S3 memory budget is exhausted, flush the current S3 writer state, append the generated block-info rows to the insert result, release the reservation, and retry once.
- Expose a `CNS3Writer.SyncAndFillBlockInfoBat` helper to support safe partial flushes without changing final insert result semantics.

## Testing

- `go test ./pkg/common/rscthrottler ./pkg/sql/colexec/insert ./pkg/sql/colexec ./pkg/objectio/ioutil -count=1`
