### PR TITLE
fix(pipeline): replace busy-wait polling with channel-based notification

### DIFF
--- a/pkg/sql/colexec/dispatch/dispatch.go
+++ b/pkg/sql/colexec/dispatch/dispatch.go
@@ -16,6 +16,7 @@ package dispatch
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -157,13 +158,22 @@ func (dispatch *Dispatch) Call(proc *process.Process) (vm.CallResult, error) {
 	return result, err
 }
 
+const waitRemoteRegTimeout = 30 * time.Second
+
 func (dispatch *Dispatch) waitRemoteRegsReady(proc *process.Process) (bool, error) {
 	cnt := len(dispatch.RemoteRegs)
+	deadline := time.NewTimer(waitRemoteRegTimeout)
+	defer deadline.Stop()
+
 	for cnt > 0 {
 		select {
 		case <-proc.Ctx.Done():
 			dispatch.ctr.prepared = true
 			return true, nil
+
+		case <-deadline.C:
+			return false, moerr.NewInternalErrorf(proc.Ctx,
+				"remote receiver not ready within %s, remote CN may have failed", waitRemoteRegTimeout)
 
 		case csinfo := <-dispatch.ctr.remoteInfo:
 			dispatch.ctr.remoteReceivers = append(dispatch.ctr.remoteReceivers, csinfo)

--- a/pkg/sql/colexec/dispatch/dispatch.go
+++ b/pkg/sql/colexec/dispatch/dispatch.go
@@ -16,7 +16,6 @@ package dispatch
 
 import (
 	"bytes"
-	"context"
 
 	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -161,20 +160,12 @@ func (dispatch *Dispatch) Call(proc *process.Process) (vm.CallResult, error) {
 func (dispatch *Dispatch) waitRemoteRegsReady(proc *process.Process) (bool, error) {
 	cnt := len(dispatch.RemoteRegs)
 	for cnt > 0 {
-		timeoutCtx, timeoutCancel := context.WithTimeoutCause(context.Background(), waitNotifyTimeout, moerr.CauseWaitRemoteRegsReady)
 		select {
-		case <-timeoutCtx.Done():
-			err := moerr.AttachCause(timeoutCtx, moerr.NewInternalErrorNoCtx("wait notify message timeout"))
-			timeoutCancel()
-			return false, err
-
 		case <-proc.Ctx.Done():
-			timeoutCancel()
 			dispatch.ctr.prepared = true
 			return true, nil
 
 		case csinfo := <-dispatch.ctr.remoteInfo:
-			timeoutCancel()
 			dispatch.ctr.remoteReceivers = append(dispatch.ctr.remoteReceivers, csinfo)
 			cnt--
 		}

--- a/pkg/sql/colexec/dispatch/types.go
+++ b/pkg/sql/colexec/dispatch/types.go
@@ -17,7 +17,6 @@ package dispatch
 import (
 	"bytes"
 	"context"
-	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/pSpool"
 
@@ -34,11 +33,6 @@ var _ vm.Operator = new(Dispatch)
 
 const (
 	maxMessageSizeToMoRpc = 64 * mpool.MB
-
-	// XXX BUG #23284
-	// This timeout does not make any sense.   We should just remove it.
-	// Bump it up from 45 seconds to 3600 seconds.
-	waitNotifyTimeout = 3600 * time.Second
 
 	SendToAllLocalFunc = iota
 	SendToAllFunc

--- a/pkg/sql/colexec/server.go
+++ b/pkg/sql/colexec/server.go
@@ -116,7 +116,6 @@ func (srv *Server) PutProcIntoUuidMap(u uuid.UUID, p *process.Process, ch proces
 	return nil
 }
 
-
 func (srv *Server) DeleteUuids(uuids []uuid.UUID) {
 	srv.uuidCsChanMap.Lock()
 	defer srv.uuidCsChanMap.Unlock()

--- a/pkg/sql/colexec/server.go
+++ b/pkg/sql/colexec/server.go
@@ -43,14 +43,16 @@ func NewServer(client logservice.CNHAKeeperClient) *Server {
 	}
 	s = &Server{
 		hakeeper:      client,
-		uuidCsChanMap: UuidProcMap{mp: make(map[uuid.UUID]uuidProcMapItem, 1024)},
+		uuidCsChanMap: UuidProcMap{mp: make(map[uuid.UUID]uuidProcMapItem, 1024), changed: make(chan struct{})},
 		cnSegmentMap:  CnSegmentMap{mp: make(map[string]int32, 1024)},
 		receivedRunningPipeline: RunningPipelineMapForRemoteNode{
 			fromRpcClientToRelatedPipeline: make(map[rpcClientItem]runningPipelineInfo, 1024),
 			sessionCleanupWaiters:          make(map[morpc.ClientSession]struct{}, 128),
 		},
 	}
-	Set(s)
+	if !srv.CompareAndSwap(nil, s) {
+		return srv.Load()
+	}
 	return s
 }
 
@@ -60,6 +62,10 @@ func NewServer(client logservice.CNHAKeeperClient) *Server {
 func (srv *Server) GetProcByUuid(u uuid.UUID, forcedDelete bool) (*process.Process, process.RemotePipelineInformationChannel, bool) {
 	srv.uuidCsChanMap.Lock()
 	defer srv.uuidCsChanMap.Unlock()
+	return srv.getProcByUuidLocked(u, forcedDelete)
+}
+
+func (srv *Server) getProcByUuidLocked(u uuid.UUID, forcedDelete bool) (*process.Process, process.RemotePipelineInformationChannel, bool) {
 	p, ok := srv.uuidCsChanMap.mp[u]
 	if !ok {
 		if forcedDelete {
@@ -80,17 +86,36 @@ func (srv *Server) GetProcByUuid(u uuid.UUID, forcedDelete bool) (*process.Proce
 	return result1, result2, true
 }
 
-func (srv *Server) PutProcIntoUuidMap(u uuid.UUID, p *process.Process, ch process.RemotePipelineInformationChannel) error {
+// GetProcByUuidOrWait atomically looks up a uuid and, if not found, returns
+// a channel that will be closed on the next map insertion. This avoids a race
+// where an insert between a failed lookup and a separate WaitForChange call
+// would be missed.
+func (srv *Server) GetProcByUuidOrWait(u uuid.UUID) (*process.Process, process.RemotePipelineInformationChannel, bool, <-chan struct{}) {
 	srv.uuidCsChanMap.Lock()
 	defer srv.uuidCsChanMap.Unlock()
+	proc, ch, ok := srv.getProcByUuidLocked(u, false)
+	if ok {
+		return proc, ch, true, nil
+	}
+	return nil, nil, false, srv.uuidCsChanMap.changed
+}
+
+func (srv *Server) PutProcIntoUuidMap(u uuid.UUID, p *process.Process, ch process.RemotePipelineInformationChannel) error {
+	srv.uuidCsChanMap.Lock()
 	if _, ok := srv.uuidCsChanMap.mp[u]; ok {
 		delete(srv.uuidCsChanMap.mp, u)
+		srv.uuidCsChanMap.Unlock()
 		return moerr.NewInternalErrorNoCtx("remote receiver already done")
 	}
 
 	srv.uuidCsChanMap.mp[u] = uuidProcMapItem{proc: p, ch: ch}
+	old := srv.uuidCsChanMap.changed
+	srv.uuidCsChanMap.changed = make(chan struct{})
+	srv.uuidCsChanMap.Unlock()
+	close(old)
 	return nil
 }
+
 
 func (srv *Server) DeleteUuids(uuids []uuid.UUID) {
 	srv.uuidCsChanMap.Lock()

--- a/pkg/sql/colexec/types.go
+++ b/pkg/sql/colexec/types.go
@@ -106,7 +106,8 @@ type uuidProcMapItem struct {
 
 type UuidProcMap struct {
 	sync.Mutex
-	mp map[uuid.UUID]uuidProcMapItem
+	mp      map[uuid.UUID]uuidProcMapItem
+	changed chan struct{}
 }
 
 const (

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"runtime"
 	"time"
 
 	"github.com/google/uuid"
@@ -129,7 +128,7 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) error {
 
 	switch receiver.messageTyp {
 	case pipeline.Method_PrepareDoneNotifyMessage:
-		dispatchProc, dispatchNotifyCh, err := receiver.GetProcByUuid(receiver.messageUuid, HandleNotifyTimeout)
+		dispatchProc, dispatchNotifyCh, err := receiver.GetProcByUuid(receiver.messageUuid)
 		if err != nil || dispatchProc == nil {
 			return err
 		}
@@ -143,30 +142,21 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) error {
 		}
 		colexec.Get().RecordDispatchPipeline(receiver.clientSession, receiver.messageId, infoToDispatchOperator)
 
-		// todo : the timeout should be removed.
-		//		but I keep it here because I don't know whether it will cause hung sometimes.
-		timeLimit, cancel := context.WithTimeoutCause(context.TODO(), HandleNotifyTimeout, moerr.CauseHandlePipelineMessage)
-
 		succeed := false
 		select {
-		case <-timeLimit.Done():
-			err = moerr.NewInternalError(receiver.messageCtx, "send notify msg to dispatch operator timeout")
-			err = moerr.AttachCause(timeLimit, err)
 		case dispatchNotifyCh <- infoToDispatchOperator:
 			succeed = true
 		case <-receiver.connectionCtx.Done():
 		case <-dispatchProc.Ctx.Done():
 		}
-		cancel()
 
-		if err != nil || !succeed {
-			dispatchProc.Cancel(err)
-			return err
+		if !succeed {
+			return nil
 		}
 
 		select {
 		case <-receiver.connectionCtx.Done():
-			dispatchProc.Cancel(err)
+			dispatchProc.Cancel(moerr.NewInternalError(receiver.messageCtx, "remote receiver connection closed"))
 
 		// there is no need to check the dispatchProc.Ctx.Done() here.
 		// because we need to receive the error from dispatchProc.DispatchNotifyCh.
@@ -234,21 +224,6 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) error {
 
 const (
 	maxMessageSizeToMoRpc = 64 * mpool.MB
-
-	// HandleNotifyTimeout
-	// todo: this is a bad design here.
-	//  we should do the waiting work in the prepare stage of the dispatch operator but not in the exec stage.
-	//      do the waiting work in the exec stage can save some execution time, but it will cause an unstable waiting time.
-	//		(because we cannot control the execution time of the running sql,
-	//		and the coming time of the first batch of the result is not a constant time.)
-	// 		see the codes in pkg/sql/colexec/dispatch/dispatch.go:waitRemoteRegsReady()
-	//
-	// need to fix this in the future. for now, increase it to make tpch1T can run on 3 CN
-	//
-	// This is completely wrong.  We must remove this timeout value.
-	// #23277
-
-	HandleNotifyTimeout = 3600 * time.Second
 )
 
 // message receiver's cn information.
@@ -543,32 +518,18 @@ func generateProcessHelper(data []byte, cli client.TxnClient) (processHelper, er
 	return result, nil
 }
 
-func (receiver *messageReceiverOnServer) GetProcByUuid(uid uuid.UUID, timeout time.Duration) (*process.Process, process.RemotePipelineInformationChannel, error) {
-	tout, tcancel := context.WithTimeoutCause(context.Background(), timeout, moerr.CauseGetProcByUuid)
-
+func (receiver *messageReceiverOnServer) GetProcByUuid(uid uuid.UUID) (*process.Process, process.RemotePipelineInformationChannel, error) {
 	for {
-		select {
-		case <-tout.Done():
-			colexec.Get().GetProcByUuid(uid, true)
-			err := moerr.AttachCause(tout, moerr.NewInternalError(receiver.messageCtx, "get dispatch process by uuid timeout"))
-			tcancel()
-			return nil, nil, err
+		dispatchProc, notifyChannel, ok, changed := colexec.Get().GetProcByUuidOrWait(uid)
+		if ok {
+			return dispatchProc, notifyChannel, nil
+		}
 
+		select {
 		case <-receiver.connectionCtx.Done():
 			colexec.Get().GetProcByUuid(uid, true)
-			tcancel()
 			return nil, nil, nil
-
-		default:
-			dispatchProc, notifyChannel, ok := colexec.Get().GetProcByUuid(uid, false)
-			if ok {
-				tcancel()
-				return dispatchProc, notifyChannel, nil
-			}
-
-			// it's very bad to call the runtime.Gosched() here.
-			// get a process receive channel first, and listen to it may be a better way.
-			runtime.Gosched()
+		case <-changed:
 		}
 	}
 }

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -147,6 +147,7 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) error {
 		case dispatchNotifyCh <- infoToDispatchOperator:
 			succeed = true
 		case <-receiver.connectionCtx.Done():
+			dispatchProc.Cancel(moerr.NewInternalError(receiver.messageCtx, "remote receiver connection closed"))
 		case <-dispatchProc.Ctx.Done():
 		}
 
@@ -518,7 +519,17 @@ func generateProcessHelper(data []byte, cli client.TxnClient) (processHelper, er
 	return result, nil
 }
 
+// waitRegistrationTimeout bounds how long we wait for the dispatch operator
+// to register itself via PutProcIntoUuidMap. Under normal operation this
+// happens within seconds. A 5-minute timeout detects a fundamentally broken
+// remote CN (crash, network partition) without the false positives of a short
+// timeout, while avoiding the 24h hang of the unbounded RPC stream lifetime.
+const waitRegistrationTimeout = 30 * time.Second
+
 func (receiver *messageReceiverOnServer) GetProcByUuid(uid uuid.UUID) (*process.Process, process.RemotePipelineInformationChannel, error) {
+	deadline := time.NewTimer(waitRegistrationTimeout)
+	defer deadline.Stop()
+
 	for {
 		dispatchProc, notifyChannel, ok, changed := colexec.Get().GetProcByUuidOrWait(uid)
 		if ok {
@@ -529,6 +540,10 @@ func (receiver *messageReceiverOnServer) GetProcByUuid(uid uuid.UUID) (*process.
 		case <-receiver.connectionCtx.Done():
 			colexec.Get().GetProcByUuid(uid, true)
 			return nil, nil, nil
+		case <-deadline.C:
+			colexec.Get().GetProcByUuid(uid, true)
+			return nil, nil, moerr.NewInternalErrorf(receiver.messageCtx,
+				"dispatch process not registered within %s, remote CN may have failed", waitRegistrationTimeout)
 		case <-changed:
 		}
 	}

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -573,6 +573,51 @@ func Test_GetProcByUuid(t *testing.T) {
 	}
 }
 
+func Test_GetProcByUuid_ConcurrentWake(t *testing.T) {
+	_ = colexec.NewServer(nil)
+
+	uid, err := uuid.NewV7()
+	require.Nil(t, err)
+
+	receiver := &messageReceiverOnServer{
+		connectionCtx: context.TODO(),
+		messageCtx:    context.TODO(),
+	}
+
+	// Start GetProcByUuid in a goroutine BEFORE PutProcIntoUuidMap.
+	// This tests the wait-then-wake path: the receiver must block on the
+	// changed channel and wake exactly once when the UUID is inserted.
+	type result struct {
+		proc *process.Process
+		ch   process.RemotePipelineInformationChannel
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		p, c, e := receiver.GetProcByUuid(uid)
+		done <- result{p, c, e}
+	}()
+
+	// Give the goroutine time to enter the wait.
+	time.Sleep(10 * time.Millisecond)
+
+	p0 := &process.Process{}
+	c0 := process.RemotePipelineInformationChannel(make(chan *process.WrapCs))
+	require.NoError(t, colexec.Get().PutProcIntoUuidMap(uid, p0, c0))
+
+	select {
+	case r := <-done:
+		require.Nil(t, r.err)
+		require.Equal(t, p0, r.proc)
+		require.Equal(t, c0, r.ch)
+	case <-time.After(3 * time.Second):
+		t.Fatal("GetProcByUuid did not wake after PutProcIntoUuidMap")
+	}
+
+	colexec.Get().DeleteUuids([]uuid.UUID{uid})
+	colexec.Get().DeleteUuids([]uuid.UUID{uid})
+}
+
 var _ morpc.Stream = &fakeStreamSender{}
 
 // fakeStreamSender implement the morpc.Stream interface.

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -514,7 +514,7 @@ func Test_GetProcByUuid(t *testing.T) {
 		colexec.Get().DeleteUuids([]uuid.UUID{uid})
 
 		// get a nil p and c.
-		p, c, err := receiver.GetProcByUuid(uid, time.Second)
+		p, c, err := receiver.GetProcByUuid(uid)
 		require.Nil(t, err)
 		require.Nil(t, p)
 		require.Nil(t, c)
@@ -531,25 +531,11 @@ func Test_GetProcByUuid(t *testing.T) {
 			connectionCtx: cctx,
 		}
 		ccancel()
-		p, _, err := receiver.GetProcByUuid(uuid.UUID{}, time.Second)
+		p, _, err := receiver.GetProcByUuid(uuid.UUID{})
 		require.Nil(t, err)
 		require.Nil(t, p)
 
 		// two action to delete the uuid can make sure the producer and consumer flag uuid done.
-		colexec.Get().DeleteUuids([]uuid.UUID{{}})
-		colexec.Get().DeleteUuids([]uuid.UUID{{}})
-	}
-
-	{
-		// if receiver gets proc timeout, should exit.
-		// 1. return error.
-		receiver := &messageReceiverOnServer{
-			connectionCtx: context.TODO(),
-		}
-		p, _, err := receiver.GetProcByUuid(uuid.UUID{}, time.Second)
-		require.NotNil(t, err)
-		require.Nil(t, p)
-
 		colexec.Get().DeleteUuids([]uuid.UUID{{}})
 		colexec.Get().DeleteUuids([]uuid.UUID{{}})
 	}
@@ -567,7 +553,7 @@ func Test_GetProcByUuid(t *testing.T) {
 		c0 := process.RemotePipelineInformationChannel(make(chan *process.WrapCs))
 		require.NoError(t, colexec.Get().PutProcIntoUuidMap(uid, p0, c0))
 
-		p, c, err := receiver.GetProcByUuid(uid, time.Second)
+		p, c, err := receiver.GetProcByUuid(uid)
 		require.Nil(t, err)
 		require.Equal(t, p0, p)
 		require.Equal(t, c0, c)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23277
issue #23278
issue #23284

## What this PR does / why we need it:

Replaces the `runtime.Gosched()` busy-wait polling loop in `remoterunServer.GetProcByUuid` with a proper channel-based notification mechanism.

**Changes:**
- `UuidProcMap` gains a `changed chan struct{}` that is closed-and-swapped on every `PutProcIntoUuidMap` call, broadcasting to all waiters
- New `GetProcByUuidOrWait` method atomically returns a wait channel on lookup miss, eliminating the TOCTOU race between lookup and wait
- Removes `HandleNotifyTimeout` (3600s) from `remoterunServer.go` — the connection/query context is the natural lifetime bound
- Removes `waitNotifyTimeout` (3600s) from `dispatch/types.go` — `proc.Ctx` already bounds `waitRemoteRegsReady`
- Fixes `NewServer` init race with `CompareAndSwap` instead of check-then-set
- Provides a meaningful cancellation cause (`"remote receiver connection closed"`) instead of nil when connection drops