### PR TITLE
fix(join): deduplicate MARK JOIN probe rows

### DIFF
--- a/pkg/sql/colexec/loopjoin/join.go
+++ b/pkg/sql/colexec/loopjoin/join.go
@@ -197,6 +197,78 @@ func (ctr *container) probe(ap *LoopJoin, proc *process.Process, result *vm.Call
 
 	rowCountIncrease := 0
 	for i := ctr.probeIdx; i < count; i++ {
+		if ap.JoinType == plan.Node_MARK && ctr.expr != nil {
+			if rowCountIncrease >= colexec.DefaultBatchSize {
+				result.Batch = ctr.resBat
+				ctr.resBat.SetRowCount(rowCountIncrease)
+				ctr.probeIdx = i
+				ctr.batIdx = 0
+				return nil
+			}
+
+			hasTrue := false
+			hasNull := false
+			for idx := 0; idx < len(mpbat); idx++ {
+				bat := mpbat[idx]
+				if err := colexec.SetJoinBatchValues(ctr.joinBat, inbat, int64(i),
+					bat.RowCount(), ctr.cfs); err != nil {
+					return err
+				}
+
+				vec, err := ctr.expr.Eval(proc, []*batch.Batch{ctr.joinBat, bat}, nil)
+				if err != nil {
+					return err
+				}
+
+				rs := vector.GenerateFunctionFixedTypeParameter[bool](vec)
+				if vec.IsConst() {
+					v, null := rs.GetValue(0)
+					if null {
+						hasNull = true
+					} else if v {
+						hasTrue = true
+						break
+					}
+				} else {
+					for j := uint64(0); j < uint64(vec.Length()); j++ {
+						val, null := rs.GetValue(j)
+						if null {
+							hasNull = true
+						} else if val {
+							hasTrue = true
+							break
+						}
+					}
+					if hasTrue {
+						break
+					}
+				}
+			}
+
+			var err error
+			for k, rp := range ap.ResultCols {
+				if rp.Rel == 0 {
+					if err = ctr.resBat.Vecs[k].UnionOne(inbat.Vecs[rp.Pos], int64(i), proc.Mp()); err != nil {
+						return err
+					}
+				} else {
+					if hasTrue {
+						err = vector.AppendFixed(ctr.resBat.Vecs[k], true, false, proc.Mp())
+					} else if hasNull {
+						err = vector.AppendFixed(ctr.resBat.Vecs[k], false, true, proc.Mp())
+					} else {
+						err = vector.AppendFixed(ctr.resBat.Vecs[k], false, false, proc.Mp())
+					}
+					if err != nil {
+						return err
+					}
+				}
+			}
+			rowCountIncrease++
+			ctr.batIdx = 0
+			continue
+		}
+
 		matched := false
 		if ctr.batIdx != 0 {
 			matched = true
@@ -224,82 +296,39 @@ func (ctr *container) probe(ap *LoopJoin, proc *process.Process, result *vm.Call
 				}
 
 				rs := vector.GenerateFunctionFixedTypeParameter[bool](vec)
-				if ap.JoinType != plan.Node_MARK {
-					l := uint64(bat.RowCount())
-					for j := uint64(0); j < l; j++ {
-						b, null := rs.GetValue(j)
-						if !null && b {
-							if ap.JoinType == plan.Node_SINGLE && matched {
-								return moerr.NewInternalError(proc.Ctx, "scalar subquery returns more than 1 row")
-							}
+				l := uint64(bat.RowCount())
+				for j := uint64(0); j < l; j++ {
+					b, null := rs.GetValue(j)
+					if !null && b {
+						if ap.JoinType == plan.Node_SINGLE && matched {
+							return moerr.NewInternalError(proc.Ctx, "scalar subquery returns more than 1 row")
+						}
 
-							matched = true
+						matched = true
 
-							if ap.JoinType == plan.Node_ANTI {
-								continue
-							}
+						if ap.JoinType == plan.Node_ANTI {
+							continue
+						}
 
-							if ap.JoinType == plan.Node_OUTER {
-								ctr.rightRowsMatched.Add(ctr.rightBatchOffset[idx] + j)
-							}
+						if ap.JoinType == plan.Node_OUTER {
+							ctr.rightRowsMatched.Add(ctr.rightBatchOffset[idx] + j)
+						}
 
-							for k, rp := range ap.ResultCols {
-								if rp.Rel == 0 {
-									if err = ctr.resBat.Vecs[k].UnionOne(inbat.Vecs[rp.Pos], int64(i), proc.Mp()); err != nil {
-										return err
-									}
-								} else {
-									if err = ctr.resBat.Vecs[k].UnionOne(bat.Vecs[rp.Pos], int64(j), proc.Mp()); err != nil {
-										return err
-									}
+						for k, rp := range ap.ResultCols {
+							if rp.Rel == 0 {
+								if err = ctr.resBat.Vecs[k].UnionOne(inbat.Vecs[rp.Pos], int64(i), proc.Mp()); err != nil {
+									return err
+								}
+							} else {
+								if err = ctr.resBat.Vecs[k].UnionOne(bat.Vecs[rp.Pos], int64(j), proc.Mp()); err != nil {
+									return err
 								}
 							}
-							rowCountIncrease++
-
-							if ap.JoinType == plan.Node_SEMI {
-								break
-							}
 						}
-					}
-				} else {
-					hasTrue := false
-					hasNull := false
+						rowCountIncrease++
 
-					if vec.IsConst() {
-						v, null := rs.GetValue(0)
-						if null {
-							hasNull = true
-						} else {
-							hasTrue = v
-						}
-					} else {
-						for j := uint64(0); j < uint64(vec.Length()); j++ {
-							val, null := rs.GetValue(j)
-							if null {
-								hasNull = true
-							} else if val {
-								hasTrue = true
-							}
-						}
-					}
-
-					for j := range ap.ResultCols {
-						if ap.ResultCols[j].Rel == 0 {
-							if err = ctr.resBat.Vecs[j].UnionOne(inbat.Vecs[ap.ResultCols[j].Pos], int64(i), proc.Mp()); err != nil {
-								return err
-							}
-						} else {
-							if hasTrue {
-								err = vector.AppendFixed(ctr.resBat.Vecs[j], true, false, proc.Mp())
-							} else if hasNull {
-								err = vector.AppendFixed(ctr.resBat.Vecs[j], false, true, proc.Mp())
-							} else {
-								err = vector.AppendFixed(ctr.resBat.Vecs[j], false, false, proc.Mp())
-							}
-							if err != nil {
-								return err
-							}
-							rowCountIncrease++
+						if ap.JoinType == plan.Node_SEMI {
+							break
 						}
 					}
 				}

--- a/pkg/sql/colexec/loopjoin/join_test.go
+++ b/pkg/sql/colexec/loopjoin/join_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashbuild"
@@ -126,6 +127,192 @@ func TestJoin(t *testing.T) {
 		tc.proc.Free()
 		require.Equal(t, int64(0), tc.proc.Mp().CurrNB())
 	}
+}
+
+func TestMarkJoinEmitsOneRowPerProbeRowAcrossBuildBatches(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	proc.SetMessageBoard(message.NewMessageBoard())
+
+	int32Type := types.T_int32.ToType()
+	fr, err := function.GetFunctionByName(context.Background(), "=", []types.Type{int32Type, int32Type})
+	require.NoError(t, err)
+	fid := fr.GetEncodedOverloadID()
+	cond := &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_bool)},
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Args: []*plan.Expr{
+				{
+					Typ: plan.Type{Id: int32(types.T_int32)},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: 0,
+						ColPos: 0,
+					}},
+				},
+				{
+					Typ: plan.Type{Id: int32(types.T_int32)},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: 1,
+						ColPos: 0,
+					}},
+				},
+			},
+			Func: &plan.ObjectRef{Obj: fid, ObjName: "="},
+		}},
+	}
+
+	tag++
+	join := &LoopJoin{
+		NonEqCond:  cond,
+		ResultCols: []colexec.ResultPos{colexec.NewResultPos(0, 0), colexec.NewResultPos(-1, 0)},
+		LeftTypes:  []types.Type{int32Type},
+		RightTypes: []types.Type{int32Type},
+		JoinType:   plan.Node_MARK,
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{
+				Idx: 1,
+			},
+		},
+		JoinMapTag: tag,
+	}
+	join.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{
+		makeInt32LoopJoinBatch(proc.Mp(), []int32{1, 4}),
+	}))
+
+	build := &hashbuild.HashBuild{
+		NeedBatches:   true,
+		JoinMapTag:    tag,
+		JoinMapRefCnt: 1,
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{
+				Idx: 0,
+			},
+		},
+	}
+	build.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{
+		makeInt32LoopJoinBatch(proc.Mp(), []int32{1}),
+		makeInt32LoopJoinBatch(proc.Mp(), []int32{1}),
+	}))
+
+	require.NoError(t, join.Prepare(proc))
+	require.NoError(t, build.Prepare(proc))
+
+	res, err := vm.Exec(build, proc)
+	require.NoError(t, err)
+	require.Nil(t, res.Batch)
+
+	res, err = vm.Exec(join, proc)
+	require.NoError(t, err)
+	require.NotNil(t, res.Batch)
+	require.Equal(t, 2, res.Batch.RowCount())
+	require.Equal(t, []int32{1, 4}, vector.MustFixedColNoTypeCheck[int32](res.Batch.Vecs[0])[:2])
+	require.Equal(t, []bool{true, false}, vector.MustFixedColNoTypeCheck[bool](res.Batch.Vecs[1])[:2])
+	require.False(t, res.Batch.Vecs[1].GetNulls().Contains(0))
+	require.False(t, res.Batch.Vecs[1].GetNulls().Contains(1))
+
+	join.Free(proc, false, nil)
+	build.Free(proc, false, nil)
+	proc.Free()
+}
+
+func TestMarkJoinResumesAfterDefaultBatchSize(t *testing.T) {
+	proc := testutil.NewProcessWithMPool(t, "", mpool.MustNewZero())
+	proc.SetMessageBoard(message.NewMessageBoard())
+
+	int32Type := types.T_int32.ToType()
+	fr, err := function.GetFunctionByName(context.Background(), "=", []types.Type{int32Type, int32Type})
+	require.NoError(t, err)
+	fid := fr.GetEncodedOverloadID()
+	cond := &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_bool)},
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Args: []*plan.Expr{
+				{
+					Typ: plan.Type{Id: int32(types.T_int32)},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: 0,
+						ColPos: 0,
+					}},
+				},
+				{
+					Typ: plan.Type{Id: int32(types.T_int32)},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: 1,
+						ColPos: 0,
+					}},
+				},
+			},
+			Func: &plan.ObjectRef{Obj: fid, ObjName: "="},
+		}},
+	}
+
+	tag++
+	join := &LoopJoin{
+		NonEqCond:  cond,
+		ResultCols: []colexec.ResultPos{colexec.NewResultPos(0, 0), colexec.NewResultPos(-1, 0)},
+		LeftTypes:  []types.Type{int32Type},
+		RightTypes: []types.Type{int32Type},
+		JoinType:   plan.Node_MARK,
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{
+				Idx: 1,
+			},
+		},
+		JoinMapTag: tag,
+	}
+	leftVals := make([]int32, colexec.DefaultBatchSize+1)
+	for i := range leftVals {
+		leftVals[i] = int32(i)
+	}
+	join.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{
+		makeInt32LoopJoinBatch(proc.Mp(), leftVals),
+	}))
+
+	build := &hashbuild.HashBuild{
+		NeedBatches:   true,
+		JoinMapTag:    tag,
+		JoinMapRefCnt: 1,
+		OperatorBase: vm.OperatorBase{
+			OperatorInfo: vm.OperatorInfo{
+				Idx: 0,
+			},
+		},
+	}
+	build.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{
+		makeInt32LoopJoinBatch(proc.Mp(), []int32{-1}),
+	}))
+
+	require.NoError(t, join.Prepare(proc))
+	require.NoError(t, build.Prepare(proc))
+
+	res, err := vm.Exec(build, proc)
+	require.NoError(t, err)
+	require.Nil(t, res.Batch)
+
+	res, err = vm.Exec(join, proc)
+	require.NoError(t, err)
+	require.NotNil(t, res.Batch)
+	require.Equal(t, colexec.DefaultBatchSize, res.Batch.RowCount())
+	require.Equal(t, int32(0), vector.MustFixedColNoTypeCheck[int32](res.Batch.Vecs[0])[0])
+	require.Equal(t, int32(colexec.DefaultBatchSize-1), vector.MustFixedColNoTypeCheck[int32](res.Batch.Vecs[0])[colexec.DefaultBatchSize-1])
+
+	res, err = vm.Exec(join, proc)
+	require.NoError(t, err)
+	require.NotNil(t, res.Batch)
+	require.Equal(t, 1, res.Batch.RowCount())
+	require.Equal(t, int32(colexec.DefaultBatchSize), vector.MustFixedColNoTypeCheck[int32](res.Batch.Vecs[0])[0])
+	require.Equal(t, []bool{false}, vector.MustFixedColNoTypeCheck[bool](res.Batch.Vecs[1])[:1])
+	require.False(t, res.Batch.Vecs[1].GetNulls().Contains(0))
+
+	join.Free(proc, false, nil)
+	build.Free(proc, false, nil)
+	proc.Free()
+}
+
+func makeInt32LoopJoinBatch(mp *mpool.MPool, vals []int32) *batch.Batch {
+	bat := batch.New([]string{"id"})
+	bat.Vecs[0] = testutil.MakeInt32Vector(vals, nil, mp)
+	bat.SetRowCount(len(vals))
+	return bat
 }
 
 /*

--- a/test/distributed/cases/benchmark/tpcds/02_issue_24219.result
+++ b/test/distributed/cases/benchmark/tpcds/02_issue_24219.result
@@ -1,0 +1,51 @@
+drop table if exists issue_24219_customer;
+drop table if exists issue_24219_web_sales;
+drop table if exists issue_24219_catalog_sales;
+create table issue_24219_customer (
+c_customer_sk int
+);
+create table issue_24219_web_sales (
+ws_bill_customer_sk int
+);
+create table issue_24219_catalog_sales (
+cs_ship_customer_sk int,
+cs_sold_item_sk int
+);
+insert into issue_24219_customer values (1);
+insert into issue_24219_catalog_sales
+select
+1,
+result
+from generate_series(1, 9000, 1) g;
+select c_customer_sk
+from issue_24219_customer c
+where exists (
+select 1
+from issue_24219_web_sales ws
+where c.c_customer_sk = ws.ws_bill_customer_sk
+)
+or exists (
+select 1
+from issue_24219_catalog_sales cs
+where c.c_customer_sk = cs.cs_ship_customer_sk
+)
+order by c_customer_sk;
+➤ c_customer_sk[4,32,0]  𝄀
+1
+select count(*) as exists_or_count
+from issue_24219_customer c
+where exists (
+select 1
+from issue_24219_web_sales ws
+where c.c_customer_sk = ws.ws_bill_customer_sk
+)
+or exists (
+select 1
+from issue_24219_catalog_sales cs
+where c.c_customer_sk = cs.cs_ship_customer_sk
+);
+➤ exists_or_count[-5,64,0]  𝄀
+1
+drop table if exists issue_24219_customer;
+drop table if exists issue_24219_web_sales;
+drop table if exists issue_24219_catalog_sales;

--- a/test/distributed/cases/benchmark/tpcds/02_issue_24219.sql
+++ b/test/distributed/cases/benchmark/tpcds/02_issue_24219.sql
@@ -1,0 +1,59 @@
+-- Regression test for issue #24219.
+-- The catalog-side EXISTS input intentionally has more than one execution
+-- batch, but the outer customer row must still be emitted only once.
+
+drop table if exists issue_24219_customer;
+drop table if exists issue_24219_web_sales;
+drop table if exists issue_24219_catalog_sales;
+
+create table issue_24219_customer (
+  c_customer_sk int
+);
+
+create table issue_24219_web_sales (
+  ws_bill_customer_sk int
+);
+
+create table issue_24219_catalog_sales (
+  cs_ship_customer_sk int,
+  cs_sold_item_sk int
+);
+
+insert into issue_24219_customer values (1);
+
+insert into issue_24219_catalog_sales
+select
+  1,
+  result
+from generate_series(1, 9000, 1) g;
+
+select c_customer_sk
+from issue_24219_customer c
+where exists (
+        select 1
+        from issue_24219_web_sales ws
+        where c.c_customer_sk = ws.ws_bill_customer_sk
+      )
+   or exists (
+        select 1
+        from issue_24219_catalog_sales cs
+        where c.c_customer_sk = cs.cs_ship_customer_sk
+      )
+order by c_customer_sk;
+
+select count(*) as exists_or_count
+from issue_24219_customer c
+where exists (
+        select 1
+        from issue_24219_web_sales ws
+        where c.c_customer_sk = ws.ws_bill_customer_sk
+      )
+   or exists (
+        select 1
+        from issue_24219_catalog_sales cs
+        where c.c_customer_sk = cs.cs_ship_customer_sk
+      );
+
+drop table if exists issue_24219_customer;
+drop table if exists issue_24219_web_sales;
+drop table if exists issue_24219_catalog_sales;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24219

## What this PR does / why we need it:

Correlated `EXISTS` subqueries are flattened into MARK JOINs. The loop join executor evaluated each build batch independently and emitted the same probe row once per build batch, so `EXISTS(A) OR EXISTS(B)` could inflate outer rows instead of acting as a boolean predicate.

This PR aggregates MARK JOIN condition results across all build batches before emitting the probe row. Each probe row now produces a single mark value (`true`, `NULL`, or `false`), preserving EXISTS/semi-join semantics. It also adds:
- unit tests covering duplicate matches split across build batches and MARK JOIN resume after the default output batch size
- a small BVT regression case with one outer row and 9000 inner rows, just enough to cross the 8192-row execution batch boundary

Validation:
- `CGO_CFLAGS="-I${ROOT}/thirdparties/install/include" CGO_LDFLAGS="-L${ROOT}/thirdparties/install/lib -Wl,-rpath,${ROOT}/thirdparties/install/lib" go test ./pkg/sql/colexec/loopjoin -coverprofile=/tmp/loopjoin_cover.out`
- `make build`
- `cd /Users/ghs-mo/MOWorkSpace/mo-tester && ./run.sh -p /Users/ghs-mo/MOWorkSpace/matrixone-3rd/test/distributed/cases/ -m genrs -i issue_24219`
- `cd /Users/ghs-mo/MOWorkSpace/mo-tester && ./run.sh -p /Users/ghs-mo/MOWorkSpace/matrixone-3rd/test/distributed/cases/ -i issue_24219`
- local TPC-DS repro with `../tpcds`: `web_exists_count=0`, `catalog_exists_count=1`, `or_exists_count=1` after the fix
- TPC-DS query10 matches the PG golden result modulo CHAR padding whitespace
