### PR TITLE
test(tpcds): remove stale BVT issue tag

### DIFF
--- a/test/distributed/cases/benchmark/tpcds/01_issue_24208.sql
+++ b/test/distributed/cases/benchmark/tpcds/01_issue_24208.sql
@@ -1,4 +1,3 @@
--- @bvt:issue#24208
 -- Reproduces the q34 root cause on the AP merge-group path.
 -- The first partial batch contains only non-null customer keys, while a
 -- later batch contains the NULL group that used to be dropped.


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

N/A. Follow-up to #24223, refs #24208.

## What this PR does / why we need it:

PR #24223 fixed issue #24208 and added `test/distributed/cases/benchmark/tpcds/01_issue_24208.sql` as a focused regression case. The file still had a leading `-- @bvt:issue#24208` tag. In mo-tester, that tag starts an issue skip block when `-g` is used, and this file does not contain the matching `-- @bvt:issue` end tag.

This PR removes the stale issue skip tag so the regression SQL is not ignored in issue-skip mode.

Validation:
- `rg -n "@bvt:issue#24208" test/distributed/cases/benchmark/tpcds/01_issue_24208.sql || true`
- `git diff --check -- test/distributed/cases/benchmark/tpcds/01_issue_24208.sql`
