### PR TITLE
fix(index): propagate decimal scale in zonemap Between

### DIFF
--- a/pkg/vm/engine/readutil/expr_filter.go
+++ b/pkg/vm/engine/readutil/expr_filter.go
@@ -635,7 +635,7 @@ func CompileFilterExpr(
 			}
 			// TODO: define seekOp
 			// ok
-		case "between":
+		case "in_range", "between":
 			colExpr, vals, ok := mustColConstValueFromBinaryFuncExpr(exprImpl)
 			if !ok {
 				canCompile = false

--- a/pkg/vm/engine/readutil/pk_filter_base.go
+++ b/pkg/vm/engine/readutil/pk_filter_base.go
@@ -303,6 +303,29 @@ func ConstructBasePKFilter(
 			}
 			filter.Oid = oid
 
+		case "in_range":
+			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
+			if !ok || len(vals) < 3 {
+				return
+			}
+			filter.Valid = true
+			flag := types.DecodeInt64(vals[2])
+			switch flag {
+			case 0:
+				filter.Op = function.BETWEEN
+			case 1:
+				filter.Op = RangeLeftOpen
+			case 2:
+				filter.Op = RangeRightOpen
+			case 3:
+				filter.Op = RangeBothOpen
+			default:
+				return
+			}
+			filter.LB = vals[0]
+			filter.UB = vals[1]
+			filter.Oid = oid
+
 		case "between":
 			ok, oid, vals := evalValue(expr, exprImpl, tblDef, false, tblDef.Pkey.PkeyColName)
 			if !ok {

--- a/pkg/vm/engine/tae/index/zm.go
+++ b/pkg/vm/engine/tae/index/zm.go
@@ -692,6 +692,7 @@ func (zm ZM) PrefixBetween(lb, ub []byte) bool {
 
 func (zm ZM) Between(lb, ub []byte) bool {
 	oth := BuildZM(zm.GetType(), lb)
+	oth.SetScale(zm.GetScale())
 	if zm.IsString() {
 		oth.updateMinString(lb)
 		oth.updateMaxString(ub)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24282

## What this PR does / why we need it:

`ZM.Between(lb, ub []byte)` calls `BuildZM(zm.GetType(), lb)` to construct a temporary zonemap representing the query range, but never copies the scale from the source zonemap. When the type is `DECIMAL(p,s)`, the subsequent `Intersect()` call uses `CompareDecimal64WithScale` which multiplies one operand by `10^scale` — but since the temp zonemap has scale=0, the comparison produces wrong results and prunes blocks that actually contain matching rows.

Fix: add `oth.SetScale(zm.GetScale())` after `BuildZM()`.

Also wires `in_range` function into `CompileFilterExpr` (zonemap pruning) and `ConstructBasePKFilter` (PK row filtering) so it benefits from the same block/object elimination as `BETWEEN`.

**Verified:**
- Unit tests pass (`go test ./pkg/vm/engine/tae/index/`)
- `DECIMAL(10,2) PK BETWEEN` on 20K-row table returns correct 5001 rows (was 0 before fix)
- `in_range_operator.sql` BVT: 368/368 pass (was failing on DECIMAL cases)
- All `in_range` flag variants (closed-closed, left-open, right-open, both-open) return correct counts