### PR TITLE
fix(objectio): release partial read cache data on error

### DIFF
--- a/pkg/fileservice/io_vector.go
+++ b/pkg/fileservice/io_vector.go
@@ -47,6 +47,8 @@ func (i *IOVector) ReleaseReadResultOnError() {
 			entry.releaseData()
 			entry.releaseData = nil
 		}
+		entry.done = false
+		entry.fromCache = nil
 	}
 }
 

--- a/pkg/fileservice/io_vector.go
+++ b/pkg/fileservice/io_vector.go
@@ -36,6 +36,20 @@ func (i *IOVector) Release() {
 	}
 }
 
+func (i *IOVector) ReleaseReadResultOnError() {
+	for idx := range i.Entries {
+		entry := &i.Entries[idx]
+		if entry.CachedData != nil {
+			entry.CachedData.Release()
+			entry.CachedData = nil
+		}
+		if entry.done && entry.releaseData != nil {
+			entry.releaseData()
+			entry.releaseData = nil
+		}
+	}
+}
+
 func (i *IOVector) readRange() (min *int64, max *int64, readFull bool) {
 	readFull = i.Policy.CacheFullFile() &&
 		!i.Policy.Any(SkipDiskCache)

--- a/pkg/fileservice/io_vector_test.go
+++ b/pkg/fileservice/io_vector_test.go
@@ -58,13 +58,15 @@ func TestIOVectorReleaseReadResultOnErrorSkipsUndoneReleaseData(t *testing.T) {
 				releaseData: func() {
 					doneReleaseData.Add(1)
 				},
-				done: true,
+				done:      true,
+				fromCache: &MemCache{},
 			},
 			{
 				CachedData: &releaseCountingData{releases: &cacheReleases},
 				releaseData: func() {
 					undoneReleaseData.Add(1)
 				},
+				fromCache: &MemCache{},
 			},
 		},
 	}
@@ -76,6 +78,10 @@ func TestIOVectorReleaseReadResultOnErrorSkipsUndoneReleaseData(t *testing.T) {
 	require.Equal(t, int32(0), undoneReleaseData.Load())
 	require.Nil(t, vector.Entries[0].CachedData)
 	require.Nil(t, vector.Entries[0].releaseData)
+	require.False(t, vector.Entries[0].done)
+	require.Nil(t, vector.Entries[0].fromCache)
 	require.Nil(t, vector.Entries[1].CachedData)
 	require.NotNil(t, vector.Entries[1].releaseData)
+	require.False(t, vector.Entries[1].done)
+	require.Nil(t, vector.Entries[1].fromCache)
 }

--- a/pkg/fileservice/io_vector_test.go
+++ b/pkg/fileservice/io_vector_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileservice
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
+)
+
+type releaseCountingData struct {
+	releases *atomic.Int32
+}
+
+func (r *releaseCountingData) Size() int64 {
+	return 0
+}
+
+func (r *releaseCountingData) Bytes() []byte {
+	return nil
+}
+
+func (r *releaseCountingData) Slice(int) fscache.Data {
+	return r
+}
+
+func (r *releaseCountingData) Retain() {
+}
+
+func (r *releaseCountingData) Release() {
+	r.releases.Add(1)
+}
+
+func TestIOVectorReleaseReadResultOnErrorSkipsUndoneReleaseData(t *testing.T) {
+	var cacheReleases atomic.Int32
+	var doneReleaseData atomic.Int32
+	var undoneReleaseData atomic.Int32
+
+	vector := IOVector{
+		Entries: []IOEntry{
+			{
+				CachedData: &releaseCountingData{releases: &cacheReleases},
+				releaseData: func() {
+					doneReleaseData.Add(1)
+				},
+				done: true,
+			},
+			{
+				CachedData: &releaseCountingData{releases: &cacheReleases},
+				releaseData: func() {
+					undoneReleaseData.Add(1)
+				},
+			},
+		},
+	}
+
+	vector.ReleaseReadResultOnError()
+
+	require.Equal(t, int32(2), cacheReleases.Load())
+	require.Equal(t, int32(1), doneReleaseData.Load())
+	require.Equal(t, int32(0), undoneReleaseData.Load())
+	require.Nil(t, vector.Entries[0].CachedData)
+	require.Nil(t, vector.Entries[0].releaseData)
+	require.Nil(t, vector.Entries[1].CachedData)
+	require.NotNil(t, vector.Entries[1].releaseData)
+}

--- a/pkg/objectio/constructors.go
+++ b/pkg/objectio/constructors.go
@@ -52,6 +52,7 @@ func constructorFactory(size int64, algo uint8) CacheConstructor {
 		decompressedData := allocator.AllocateCacheDataWithHint(ctx, int(size), malloc.NoClear)
 		bs, err := compress.Decompress(data, decompressedData.Bytes(), compress.Lz4)
 		if err != nil {
+			decompressedData.Release()
 			return
 		}
 		decompressedData = decompressedData.Slice(len(bs))

--- a/pkg/objectio/funcs.go
+++ b/pkg/objectio/funcs.go
@@ -56,6 +56,7 @@ func ReadExtent(
 		ToCacheData: factory(int64(extent.OriginSize()), extent.Alg()),
 	}
 	if err = fs.Read(ctx, ioVec); err != nil {
+		ReleaseIOVector(ioVec)
 		return
 	}
 	if ioVec.Entries[0].CachedData == nil {
@@ -204,6 +205,11 @@ func ReadOneBlockWithMeta(
 		})
 	}
 	if len(ioVec.Entries) > 0 {
+		defer func() {
+			if err != nil {
+				ioVec.Release()
+			}
+		}()
 		err = fs.Read(ctx, &ioVec)
 		if err != nil {
 			return
@@ -288,6 +294,10 @@ func ReadAllBlocksWithMeta(
 	}
 
 	err = fs.Read(ctx, &ioVec)
+	if err != nil {
+		ioVec.Release()
+		return
+	}
 	//TODO when to call ioVec.Release?
 	return
 }
@@ -320,6 +330,7 @@ func ReadOneBlockAllColumns(
 
 	err = fs.Read(ctx, ioVec)
 	if err != nil {
+		ioVec.Release()
 		return nil, err
 	}
 	defer ioVec.Release()

--- a/pkg/objectio/funcs.go
+++ b/pkg/objectio/funcs.go
@@ -147,6 +147,14 @@ func ReadOneBlockWithMeta(
 		Entries:  make([]fileservice.IOEntry, 0, len(seqnums)),
 		Policy:   policy,
 	}
+	var generatedIOVec fileservice.IOVector
+	defer func() {
+		if err != nil {
+			ioVec.ReleaseReadResultOnError()
+			generatedIOVec.ReleaseReadResultOnError()
+			ioVec = fileservice.IOVector{}
+		}
+	}()
 
 	var filledEntries []fileservice.IOEntry
 	putFillHolder := func(i int, seqnum uint16) {
@@ -205,11 +213,6 @@ func ReadOneBlockWithMeta(
 		})
 	}
 	if len(ioVec.Entries) > 0 {
-		defer func() {
-			if err != nil {
-				ioVec.ReleaseReadResultOnError()
-			}
-		}()
 		err = fs.Read(ctx, &ioVec)
 		if err != nil {
 			return
@@ -251,6 +254,9 @@ func ReadOneBlockWithMeta(
 				}
 				cacheData := fileservice.DefaultCacheDataAllocator().CopyToCacheData(ctx, buf.Bytes())
 				filledEntries[i].CachedData = cacheData
+				generatedIOVec.Entries = append(generatedIOVec.Entries, fileservice.IOEntry{
+					CachedData: cacheData,
+				})
 			}
 		}
 		ioVec.Entries = filledEntries
@@ -296,6 +302,7 @@ func ReadAllBlocksWithMeta(
 	err = fs.Read(ctx, &ioVec)
 	if err != nil {
 		ioVec.ReleaseReadResultOnError()
+		ioVec = fileservice.IOVector{}
 		return
 	}
 	//TODO when to call ioVec.Release?

--- a/pkg/objectio/funcs.go
+++ b/pkg/objectio/funcs.go
@@ -56,7 +56,7 @@ func ReadExtent(
 		ToCacheData: factory(int64(extent.OriginSize()), extent.Alg()),
 	}
 	if err = fs.Read(ctx, ioVec); err != nil {
-		ReleaseIOVector(ioVec)
+		ioVec.ReleaseReadResultOnError()
 		return
 	}
 	if ioVec.Entries[0].CachedData == nil {
@@ -207,7 +207,7 @@ func ReadOneBlockWithMeta(
 	if len(ioVec.Entries) > 0 {
 		defer func() {
 			if err != nil {
-				ioVec.Release()
+				ioVec.ReleaseReadResultOnError()
 			}
 		}()
 		err = fs.Read(ctx, &ioVec)
@@ -295,7 +295,7 @@ func ReadAllBlocksWithMeta(
 
 	err = fs.Read(ctx, &ioVec)
 	if err != nil {
-		ioVec.Release()
+		ioVec.ReleaseReadResultOnError()
 		return
 	}
 	//TODO when to call ioVec.Release?
@@ -330,7 +330,7 @@ func ReadOneBlockAllColumns(
 
 	err = fs.Read(ctx, ioVec)
 	if err != nil {
-		ioVec.Release()
+		ioVec.ReleaseReadResultOnError()
 		return nil, err
 	}
 	defer ioVec.Release()

--- a/pkg/objectio/funcs_test.go
+++ b/pkg/objectio/funcs_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectio
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
+)
+
+type releaseTrackingData struct {
+	releases *atomic.Int32
+}
+
+func (r *releaseTrackingData) Size() int64 {
+	return 0
+}
+
+func (r *releaseTrackingData) Bytes() []byte {
+	return nil
+}
+
+func (r *releaseTrackingData) Slice(int) fscache.Data {
+	return r
+}
+
+func (r *releaseTrackingData) Retain() {
+}
+
+func (r *releaseTrackingData) Release() {
+	r.releases.Add(1)
+}
+
+type partialReadErrorFS struct {
+	fileservice.FileService
+	data fscache.Data
+	err  error
+}
+
+func (p *partialReadErrorFS) Name() string {
+	return "partial-read-error"
+}
+
+func (p *partialReadErrorFS) Read(_ context.Context, vector *fileservice.IOVector) error {
+	if len(vector.Entries) > 0 {
+		vector.Entries[0].CachedData = p.data
+	}
+	return p.err
+}
+
+func (p *partialReadErrorFS) ReadCache(context.Context, *fileservice.IOVector) error {
+	return nil
+}
+
+func TestReadOneBlockWithMetaReleasesPartialReadOnError(t *testing.T) {
+	var releases atomic.Int32
+	readErr := errors.New("read canceled after partial cache fill")
+	fs := &partialReadErrorFS{
+		data: &releaseTrackingData{releases: &releases},
+		err:  readErr,
+	}
+
+	meta := BuildMetaData(1, 1)
+	col := meta.GetBlockMeta(0).ColumnMeta(0)
+	col.setDataType(uint8(types.T_int8))
+	col.setLocation(NewExtent(1, 0, 1, 1))
+
+	_, err := ReadOneBlockWithMeta(
+		context.Background(),
+		&meta,
+		"test-object",
+		0,
+		[]uint16{0},
+		[]types.Type{types.T_int8.ToType()},
+		mpool.MustNewZero(),
+		fs,
+		constructorFactory,
+		fileservice.Policy(0),
+	)
+	require.ErrorIs(t, err, readErr)
+	require.Equal(t, int32(1), releases.Load())
+}
+
+func TestReadExtentReleasesPartialReadOnError(t *testing.T) {
+	var releases atomic.Int32
+	readErr := errors.New("read canceled after partial extent fill")
+	fs := &partialReadErrorFS{
+		data: &releaseTrackingData{releases: &releases},
+		err:  readErr,
+	}
+	extent := NewExtent(1, 0, 1, 1)
+
+	_, err := ReadExtent(
+		context.Background(),
+		"test-object",
+		&extent,
+		fileservice.Policy(0),
+		fs,
+		constructorFactory,
+	)
+	require.ErrorIs(t, err, readErr)
+	require.Equal(t, int32(1), releases.Load())
+}
+
+func TestReadOneBlockAllColumnsReleasesPartialReadOnError(t *testing.T) {
+	var releases atomic.Int32
+	readErr := errors.New("read canceled after partial all-columns fill")
+	fs := &partialReadErrorFS{
+		data: &releaseTrackingData{releases: &releases},
+		err:  readErr,
+	}
+
+	meta := BuildMetaData(1, 1)
+	col := meta.GetBlockMeta(0).ColumnMeta(0)
+	col.setDataType(uint8(types.T_int8))
+	col.setLocation(NewExtent(1, 0, 1, 1))
+
+	_, err := ReadOneBlockAllColumns(
+		context.Background(),
+		&meta,
+		"test-object",
+		0,
+		[]uint16{0},
+		fileservice.Policy(0),
+		fs,
+	)
+	require.ErrorIs(t, err, readErr)
+	require.Equal(t, int32(1), releases.Load())
+}

--- a/pkg/objectio/funcs_test.go
+++ b/pkg/objectio/funcs_test.go
@@ -105,7 +105,7 @@ func TestReadOneBlockWithMetaReleasesPartialReadOnError(t *testing.T) {
 	col.setDataType(uint8(types.T_int8))
 	col.setLocation(NewExtent(1, 0, 1, 1))
 
-	_, err := ReadOneBlockWithMeta(
+	ioVec, err := ReadOneBlockWithMeta(
 		context.Background(),
 		&meta,
 		"test-object",
@@ -119,6 +119,7 @@ func TestReadOneBlockWithMetaReleasesPartialReadOnError(t *testing.T) {
 	)
 	require.ErrorIs(t, err, readErr)
 	require.Equal(t, int32(1), releases.Load())
+	require.Empty(t, ioVec.Entries)
 }
 
 func TestReadAllBlocksWithMetaReleasesPartialReadOnError(t *testing.T) {
@@ -134,7 +135,7 @@ func TestReadAllBlocksWithMetaReleasesPartialReadOnError(t *testing.T) {
 	col.setDataType(uint8(types.T_int8))
 	col.setLocation(NewExtent(1, 0, 1, 1))
 
-	_, err := ReadAllBlocksWithMeta(
+	ioVec, err := ReadAllBlocksWithMeta(
 		context.Background(),
 		&meta,
 		"test-object",
@@ -146,6 +147,7 @@ func TestReadAllBlocksWithMetaReleasesPartialReadOnError(t *testing.T) {
 	)
 	require.ErrorIs(t, err, readErr)
 	require.Equal(t, int32(1), releases.Load())
+	require.Empty(t, ioVec.Entries)
 }
 
 func TestReadExtentReleasesPartialReadOnError(t *testing.T) {

--- a/pkg/objectio/funcs_test.go
+++ b/pkg/objectio/funcs_test.go
@@ -17,13 +17,13 @@ package objectio
 import (
 	"bytes"
 	"context"
-	"errors"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/common/malloc"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/compress"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -94,7 +94,7 @@ func (t *trackingCacheDataAllocator) CopyToCacheData(context.Context, []byte) fs
 
 func TestReadOneBlockWithMetaReleasesPartialReadOnError(t *testing.T) {
 	var releases atomic.Int32
-	readErr := errors.New("read canceled after partial cache fill")
+	readErr := moerr.NewInternalErrorNoCtx("read canceled after partial cache fill")
 	fs := &partialReadErrorFS{
 		data: &releaseTrackingData{releases: &releases},
 		err:  readErr,
@@ -123,7 +123,7 @@ func TestReadOneBlockWithMetaReleasesPartialReadOnError(t *testing.T) {
 
 func TestReadAllBlocksWithMetaReleasesPartialReadOnError(t *testing.T) {
 	var releases atomic.Int32
-	readErr := errors.New("read canceled after partial all-blocks fill")
+	readErr := moerr.NewInternalErrorNoCtx("read canceled after partial all-blocks fill")
 	fs := &partialReadErrorFS{
 		data: &releaseTrackingData{releases: &releases},
 		err:  readErr,
@@ -150,7 +150,7 @@ func TestReadAllBlocksWithMetaReleasesPartialReadOnError(t *testing.T) {
 
 func TestReadExtentReleasesPartialReadOnError(t *testing.T) {
 	var releases atomic.Int32
-	readErr := errors.New("read canceled after partial extent fill")
+	readErr := moerr.NewInternalErrorNoCtx("read canceled after partial extent fill")
 	fs := &partialReadErrorFS{
 		data: &releaseTrackingData{releases: &releases},
 		err:  readErr,
@@ -191,7 +191,7 @@ func TestConstructorFactoryReleasesDecompressionDataOnError(t *testing.T) {
 
 func TestReadOneBlockAllColumnsReleasesPartialReadOnError(t *testing.T) {
 	var releases atomic.Int32
-	readErr := errors.New("read canceled after partial all-columns fill")
+	readErr := moerr.NewInternalErrorNoCtx("read canceled after partial all-columns fill")
 	fs := &partialReadErrorFS{
 		data: &releaseTrackingData{releases: &releases},
 		err:  readErr,

--- a/pkg/objectio/funcs_test.go
+++ b/pkg/objectio/funcs_test.go
@@ -15,6 +15,7 @@
 package objectio
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"sync/atomic"
@@ -22,7 +23,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/matrixorigin/matrixone/pkg/common/malloc"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/compress"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
@@ -30,14 +33,15 @@ import (
 
 type releaseTrackingData struct {
 	releases *atomic.Int32
+	bytes    []byte
 }
 
 func (r *releaseTrackingData) Size() int64 {
-	return 0
+	return int64(len(r.bytes))
 }
 
 func (r *releaseTrackingData) Bytes() []byte {
-	return nil
+	return r.bytes
 }
 
 func (r *releaseTrackingData) Slice(int) fscache.Data {
@@ -72,6 +76,22 @@ func (p *partialReadErrorFS) ReadCache(context.Context, *fileservice.IOVector) e
 	return nil
 }
 
+type trackingCacheDataAllocator struct {
+	data fscache.Data
+}
+
+func (t *trackingCacheDataAllocator) AllocateCacheData(context.Context, int) fscache.Data {
+	return t.data
+}
+
+func (t *trackingCacheDataAllocator) AllocateCacheDataWithHint(context.Context, int, malloc.Hints) fscache.Data {
+	return t.data
+}
+
+func (t *trackingCacheDataAllocator) CopyToCacheData(context.Context, []byte) fscache.Data {
+	return t.data
+}
+
 func TestReadOneBlockWithMetaReleasesPartialReadOnError(t *testing.T) {
 	var releases atomic.Int32
 	readErr := errors.New("read canceled after partial cache fill")
@@ -101,6 +121,33 @@ func TestReadOneBlockWithMetaReleasesPartialReadOnError(t *testing.T) {
 	require.Equal(t, int32(1), releases.Load())
 }
 
+func TestReadAllBlocksWithMetaReleasesPartialReadOnError(t *testing.T) {
+	var releases atomic.Int32
+	readErr := errors.New("read canceled after partial all-blocks fill")
+	fs := &partialReadErrorFS{
+		data: &releaseTrackingData{releases: &releases},
+		err:  readErr,
+	}
+
+	meta := BuildMetaData(1, 1)
+	col := meta.GetBlockMeta(0).ColumnMeta(0)
+	col.setDataType(uint8(types.T_int8))
+	col.setLocation(NewExtent(1, 0, 1, 1))
+
+	_, err := ReadAllBlocksWithMeta(
+		context.Background(),
+		&meta,
+		"test-object",
+		[]uint16{0},
+		fileservice.Policy(0),
+		mpool.MustNewZero(),
+		fs,
+		constructorFactory,
+	)
+	require.ErrorIs(t, err, readErr)
+	require.Equal(t, int32(1), releases.Load())
+}
+
 func TestReadExtentReleasesPartialReadOnError(t *testing.T) {
 	var releases atomic.Int32
 	readErr := errors.New("read canceled after partial extent fill")
@@ -119,6 +166,26 @@ func TestReadExtentReleasesPartialReadOnError(t *testing.T) {
 		constructorFactory,
 	)
 	require.ErrorIs(t, err, readErr)
+	require.Equal(t, int32(1), releases.Load())
+}
+
+func TestConstructorFactoryReleasesDecompressionDataOnError(t *testing.T) {
+	var releases atomic.Int32
+	allocator := &trackingCacheDataAllocator{
+		data: &releaseTrackingData{
+			releases: &releases,
+			bytes:    make([]byte, 16),
+		},
+	}
+
+	cacheData, err := constructorFactory(16, compress.Lz4)(
+		context.Background(),
+		bytes.NewReader([]byte("not-lz4")),
+		[]byte("not-lz4"),
+		allocator,
+	)
+	require.Error(t, err)
+	require.Nil(t, cacheData)
 	require.Equal(t, int32(1), releases.Load())
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24310

## What this PR does / why we need it:

Brings the same partial-read cleanup fix to `main`.

`main` still had the same ObjectIO/FileService ownership bug as `3.0-dev`: when a `FileService.Read` partially filled `IOEntry.CachedData` and then returned an error, ObjectIO helpers could return without releasing those partially-filled read results. In cancellation-heavy read paths such as parallel table scans with `LIMIT`, this can surface later as a checked malloc `missing free` panic.

This PR:

- adds `IOVector.ReleaseReadResultOnError()` so error cleanup releases cached data and raw read buffers only for entries whose reads completed,
- uses that cleanup in `ReadOneBlockWithMeta`, `ReadExtent`, `ReadAllBlocksWithMeta`, and `ReadOneBlockAllColumns`,
- releases allocated decompression cache data if LZ4 decompression fails before ownership is returned,
- cleans up schema-evolution generated placeholder cache data on error and returns inert `IOVector` values after cleanup,
- adds unit coverage for the partial-read, decompression-error, and no-double-free paths.

## Validation

```bash
PROJECTROOT=/Users/shenjiangwei/Work/code/view/matrixone
export CGO_CFLAGS="-I$PROJECTROOT/cgo -I$PROJECTROOT/thirdparties/install/include"
export CGO_LDFLAGS="-Wl,-w,-rpath,$PROJECTROOT/thirdparties/install/lib -L$PROJECTROOT/thirdparties/install/lib -L$PROJECTROOT/cgo -lmo"
go test -mod=mod ./pkg/fileservice -run TestIOVectorReleaseReadResultOnErrorSkipsUndoneReleaseData -count=1
go test -mod=mod ./pkg/objectio -count=1
```
