### PR TITLE
fix(logtail): reduce consumer backlog pressure

### DIFF
--- a/pkg/txn/client/timestamp_waiter.go
+++ b/pkg/txn/client/timestamp_waiter.go
@@ -81,7 +81,9 @@ func (tw *timestampWaiter) GetTimestamp(ctx context.Context, ts timestamp.Timest
 
 func (tw *timestampWaiter) NotifyLatestCommitTS(ts timestamp.Timestamp) {
 	util.LogTxnPushedTimestampUpdated(tw.logger, ts)
-	tw.storeNotified(ts)
+	if !tw.storeNotified(ts) {
+		return
+	}
 	select {
 	case tw.notifiedC <- struct{}{}:
 	default:
@@ -154,15 +156,15 @@ func (tw *timestampWaiter) handleEvent(ctx context.Context) {
 	}
 }
 
-func (tw *timestampWaiter) storeNotified(ts timestamp.Timestamp) {
+func (tw *timestampWaiter) storeNotified(ts timestamp.Timestamp) bool {
 	for {
 		latest := tw.notified.Load()
 		if latest != nil && latest.GreaterEq(ts) {
-			return
+			return false
 		}
 		v := ts
 		if tw.notified.CompareAndSwap(latest, &v) {
-			return
+			return true
 		}
 	}
 }

--- a/pkg/txn/client/timestamp_waiter.go
+++ b/pkg/txn/client/timestamp_waiter.go
@@ -33,8 +33,9 @@ const (
 type timestampWaiter struct {
 	logger    *log.MOLogger
 	stopper   stopper.Stopper
-	notifiedC chan timestamp.Timestamp
+	notifiedC chan struct{}
 	latestTS  atomic.Pointer[timestamp.Timestamp]
+	notified  atomic.Pointer[timestamp.Timestamp]
 	mu        struct {
 		sync.Mutex
 		waiters      []*waiter
@@ -50,7 +51,7 @@ func NewTimestampWaiter(
 		logger: logger,
 		stopper: *stopper.NewStopper("timestamp-waiter",
 			stopper.WithLogger(logger.RawLogger())),
-		notifiedC: make(chan timestamp.Timestamp, maxNotifiedCount),
+		notifiedC: make(chan struct{}, maxNotifiedCount),
 	}
 	if err := tw.stopper.RunTask(tw.handleEvent); err != nil {
 		panic(err)
@@ -80,7 +81,11 @@ func (tw *timestampWaiter) GetTimestamp(ctx context.Context, ts timestamp.Timest
 
 func (tw *timestampWaiter) NotifyLatestCommitTS(ts timestamp.Timestamp) {
 	util.LogTxnPushedTimestampUpdated(tw.logger, ts)
-	tw.notifiedC <- ts
+	tw.storeNotified(ts)
+	select {
+	case tw.notifiedC <- struct{}{}:
+	default:
+	}
 }
 
 func (tw *timestampWaiter) Close() {
@@ -138,8 +143,8 @@ func (tw *timestampWaiter) handleEvent(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case ts := <-tw.notifiedC:
-			ts = tw.fetchLatestTS(ts)
+		case <-tw.notifiedC:
+			ts := tw.fetchLatestTS()
 			if latest.Less(ts) {
 				latest = ts
 				tw.latestTS.Store(&ts)
@@ -149,15 +154,43 @@ func (tw *timestampWaiter) handleEvent(ctx context.Context) {
 	}
 }
 
-func (tw *timestampWaiter) fetchLatestTS(ts timestamp.Timestamp) timestamp.Timestamp {
+func (tw *timestampWaiter) storeNotified(ts timestamp.Timestamp) {
 	for {
+		latest := tw.notified.Load()
+		if latest != nil && latest.GreaterEq(ts) {
+			return
+		}
+		v := ts
+		if tw.notified.CompareAndSwap(latest, &v) {
+			return
+		}
+	}
+}
+
+func (tw *timestampWaiter) fetchLatestTS() timestamp.Timestamp {
+	ts := tw.takeNotified()
+	for i := 0; i < maxNotifiedCount; i++ {
 		select {
-		case v := <-tw.notifiedC:
-			if v.Greater(ts) {
+		case <-tw.notifiedC:
+			v := tw.takeNotified()
+			if ts.Less(v) {
 				ts = v
 			}
 		default:
 			return ts
+		}
+	}
+	return ts
+}
+
+func (tw *timestampWaiter) takeNotified() timestamp.Timestamp {
+	for {
+		latest := tw.notified.Load()
+		if latest == nil {
+			return timestamp.Timestamp{}
+		}
+		if tw.notified.CompareAndSwap(latest, nil) {
+			return *latest
 		}
 	}
 }

--- a/pkg/txn/client/timestamp_waiter_test.go
+++ b/pkg/txn/client/timestamp_waiter_test.go
@@ -124,6 +124,43 @@ func TestNotifyWaiters(t *testing.T) {
 	assert.Equal(t, 0, len(tw.mu.waiters))
 }
 
+func TestNotifyLatestCommitTSNonBlockingWhenChannelFull(t *testing.T) {
+	tw := &timestampWaiter{
+		logger:    util.GetLogger(""),
+		notifiedC: make(chan struct{}, 1),
+	}
+	tw.notifiedC <- struct{}{}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tw.NotifyLatestCommitTS(newTestTimestamp(10))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("NotifyLatestCommitTS blocked when notification channel was full")
+	}
+
+	latest := tw.notified.Load()
+	require.NotNil(t, latest)
+	assert.Equal(t, newTestTimestamp(10), *latest)
+}
+
+func TestFetchLatestTSDoesNotDrainUnboundedSignals(t *testing.T) {
+	tw := &timestampWaiter{
+		notifiedC: make(chan struct{}, maxNotifiedCount*2),
+	}
+	for i := 0; i < maxNotifiedCount*2; i++ {
+		tw.notifiedC <- struct{}{}
+	}
+	tw.storeNotified(newTestTimestamp(10))
+
+	assert.Equal(t, newTestTimestamp(10), tw.fetchLatestTS())
+	assert.NotZero(t, len(tw.notifiedC))
+}
+
 func BenchmarkGetTimestampWithWaitNotify(b *testing.B) {
 	runTimestampWaiterTests(
 		b,

--- a/pkg/txn/client/timestamp_waiter_test.go
+++ b/pkg/txn/client/timestamp_waiter_test.go
@@ -148,6 +148,20 @@ func TestNotifyLatestCommitTSNonBlockingWhenChannelFull(t *testing.T) {
 	assert.Equal(t, newTestTimestamp(10), *latest)
 }
 
+func TestNotifyLatestCommitTSSkipsRedundantWakeup(t *testing.T) {
+	tw := &timestampWaiter{
+		logger:    util.GetLogger(""),
+		notifiedC: make(chan struct{}, maxNotifiedCount),
+	}
+	tw.NotifyLatestCommitTS(newTestTimestamp(10))
+	tw.NotifyLatestCommitTS(newTestTimestamp(9))
+
+	assert.Equal(t, 1, len(tw.notifiedC))
+	latest := tw.notified.Load()
+	require.NotNil(t, latest)
+	assert.Equal(t, newTestTimestamp(10), *latest)
+}
+
 func TestFetchLatestTSDoesNotDrainUnboundedSignals(t *testing.T) {
 	tw := &timestampWaiter{
 		notifiedC: make(chan struct{}, maxNotifiedCount*2),

--- a/pkg/vm/engine/disttae/logtail_consumer.go
+++ b/pkg/vm/engine/disttae/logtail_consumer.go
@@ -1835,18 +1835,41 @@ func dispatchUpdateResponse(
 		}
 	}
 
+	var (
+		lastLogtailIndex [consumerNumber]int
+		hasLogtail       [consumerNumber]bool
+	)
+	for i := range lastLogtailIndex {
+		lastLogtailIndex[i] = -1
+	}
 	for index := 0; index < len(list); index++ {
 		table := list[index].Table
 		if ifShouldNotDistribute(table.DbId, table.TbId) {
 			continue
 		}
 		recIndex := table.TbId % consumerNumber
-		recRoutines[recIndex].sendTableLogTail(list[index], receiveAt)
+		lastLogtailIndex[recIndex] = index
+	}
+	for index := 0; index < len(list); index++ {
+		table := list[index].Table
+		if ifShouldNotDistribute(table.DbId, table.TbId) {
+			continue
+		}
+		recIndex := table.TbId % consumerNumber
+		hasLogtail[recIndex] = true
+		recRoutines[recIndex].sendTableLogTailWithTimestamp(
+			list[index],
+			*response.To,
+			lastLogtailIndex[recIndex] == index,
+			receiveAt,
+		)
 	}
 	// should update all the timestamp.
 	e.pClient.receivedLogTailTime.updateTimestamp(consumerNumber, *response.To, receiveAt)
 	for i := range recRoutines {
-		recRoutines[i].updateTimeFromT(*response.To, receiveAt)
+		if !hasLogtail[i] {
+			recRoutines[i].updateTimeFromT(*response.To, receiveAt)
+		}
 	}
 
 	n := 0
@@ -1909,6 +1932,14 @@ func (rc *routineController) sendSubscribeResponse(
 }
 
 func (rc *routineController) sendTableLogTail(r logtail.TableLogtail, receiveAt time.Time) {
+	rc.sendTableLogTailWithTimestamp(r, timestamp.Timestamp{}, false, receiveAt)
+}
+
+func (rc *routineController) sendTableLogTailWithTimestamp(
+	r logtail.TableLogtail,
+	applied timestamp.Timestamp,
+	notifyApplied bool,
+	receiveAt time.Time) {
 	if l := len(rc.signalChan); l > rc.warningBufferLen {
 		rc.warningBufferLen = l
 		logutil.Info(
@@ -1920,6 +1951,8 @@ func (rc *routineController) sendTableLogTail(r logtail.TableLogtail, receiveAt 
 
 	log := rc.cmdLogPool.Get().(*cmdToConsumeLog)
 	log.log = r
+	log.applied = applied
+	log.notifyApplied = notifyApplied
 	log.receiveAt = receiveAt
 	rc.signalChan <- log
 }
@@ -2022,8 +2055,10 @@ type cmdToConsumeSub struct {
 	receiveAt time.Time
 }
 type cmdToConsumeLog struct {
-	log       logtail.TableLogtail
-	receiveAt time.Time
+	log           logtail.TableLogtail
+	applied       timestamp.Timestamp
+	notifyApplied bool
+	receiveAt     time.Time
 }
 type cmdToUpdateTime struct {
 	time      timestamp.Timestamp
@@ -2046,10 +2081,19 @@ func (cmd *cmdToConsumeSub) action(ctx context.Context, e *Engine, ctrl *routine
 }
 
 func (cmd *cmdToConsumeLog) action(ctx context.Context, e *Engine, ctrl *routineController) error {
-	defer ctrl.cmdLogPool.Put(cmd)
+	defer func() {
+		cmd.log = logtail.TableLogtail{}
+		cmd.applied = timestamp.Timestamp{}
+		cmd.notifyApplied = false
+		cmd.receiveAt = time.Time{}
+		ctrl.cmdLogPool.Put(cmd)
+	}()
 	response := cmd.log
 	if err := e.consumeUpdateLogTail(ctx, response, true, cmd.receiveAt); err != nil {
 		return err
+	}
+	if cmd.notifyApplied {
+		e.pClient.receivedLogTailTime.updateTimestamp(ctrl.routineId, cmd.applied, cmd.receiveAt)
 	}
 	return nil
 }

--- a/pkg/vm/engine/disttae/logtail_consumer_test.go
+++ b/pkg/vm/engine/disttae/logtail_consumer_test.go
@@ -970,23 +970,7 @@ func TestDispatchUpdateResponseCoalescesTimestampCommands(t *testing.T) {
 	e := &Engine{}
 	e.pClient.receivedLogTailTime.initLogTailTimestamp(tw)
 
-	recRoutines := make([]*routineController, consumerNumber)
-	for i := range recRoutines {
-		recRoutines[i] = &routineController{
-			routineId:  i,
-			signalChan: make(chan routineControlCmd, 8),
-			cmdLogPool: sync.Pool{
-				New: func() any {
-					return &cmdToConsumeLog{}
-				},
-			},
-			cmdTimePool: sync.Pool{
-				New: func() any {
-					return &cmdToUpdateTime{}
-				},
-			},
-		}
-	}
+	recRoutines := newTestRoutineControllers(8)
 
 	to := timestamp.Timestamp{PhysicalTime: 100, LogicalTime: 1}
 	response := &logtail.UpdateResponse{
@@ -1017,6 +1001,65 @@ func TestDispatchUpdateResponseCoalescesTimestampCommands(t *testing.T) {
 	require.Equal(t, 1, len(recRoutines[3].signalChan))
 	_, ok = (<-recRoutines[3].signalChan).(*cmdToUpdateTime)
 	assert.True(t, ok)
+}
+
+func TestDispatchUpdateResponseAdvancesTimestampAfterLastLogtail(t *testing.T) {
+	ctx := context.Background()
+	tw := client.NewTimestampWaiter(runtime.GetLogger(""))
+	defer tw.Close()
+
+	e := &Engine{
+		partitions:  make(map[[2]uint64]*logtailreplay.Partition),
+		globalStats: &GlobalStats{tailC: make(chan *logtail.TableLogtail, 8)},
+		skipConsume: true,
+	}
+	e.pClient.receivedLogTailTime.initLogTailTimestamp(tw)
+
+	recRoutines := newTestRoutineControllers(8)
+	to := timestamp.Timestamp{PhysicalTime: 200, LogicalTime: 1}
+	response := &logtail.UpdateResponse{
+		To: &to,
+		LogtailList: []logtail.TableLogtail{
+			{Table: &api.TableID{DbId: 10, TbId: 101, DbName: "db", TbName: "t1"}},
+			{Table: &api.TableID{DbId: 10, TbId: 105, DbName: "db", TbName: "t2"}},
+		},
+	}
+	require.NoError(t, dispatchUpdateResponse(ctx, e, response, recRoutines, time.Now()))
+
+	cmd := (<-recRoutines[1].signalChan).(*cmdToConsumeLog)
+	require.False(t, cmd.notifyApplied)
+	require.NoError(t, cmd.action(ctx, e, recRoutines[1]))
+	assert.Equal(t, timestamp.Timestamp{}, e.pClient.receivedLogTailTime.tList[1].Load().(timestamp.Timestamp))
+
+	cmd = (<-recRoutines[1].signalChan).(*cmdToConsumeLog)
+	require.True(t, cmd.notifyApplied)
+	require.NoError(t, cmd.action(ctx, e, recRoutines[1]))
+	assert.Equal(t, to, e.pClient.receivedLogTailTime.tList[1].Load().(timestamp.Timestamp))
+
+	timeCmd := (<-recRoutines[0].signalChan).(*cmdToUpdateTime)
+	require.NoError(t, timeCmd.action(ctx, e, recRoutines[0]))
+	assert.Equal(t, to, e.pClient.receivedLogTailTime.tList[0].Load().(timestamp.Timestamp))
+}
+
+func newTestRoutineControllers(buffer int) []*routineController {
+	recRoutines := make([]*routineController, consumerNumber)
+	for i := range recRoutines {
+		recRoutines[i] = &routineController{
+			routineId:  i,
+			signalChan: make(chan routineControlCmd, buffer),
+			cmdLogPool: sync.Pool{
+				New: func() any {
+					return &cmdToConsumeLog{}
+				},
+			},
+			cmdTimePool: sync.Pool{
+				New: func() any {
+					return &cmdToUpdateTime{}
+				},
+			},
+		}
+	}
+	return recRoutines
 }
 
 // TestCommandActions verifies that command actions can be created and their basic functionality works

--- a/pkg/vm/engine/disttae/logtail_consumer_test.go
+++ b/pkg/vm/engine/disttae/logtail_consumer_test.go
@@ -962,6 +962,63 @@ func TestRoutineController_CommandPools(t *testing.T) {
 	})
 }
 
+func TestDispatchUpdateResponseCoalescesTimestampCommands(t *testing.T) {
+	ctx := context.Background()
+	tw := client.NewTimestampWaiter(runtime.GetLogger(""))
+	defer tw.Close()
+
+	e := &Engine{}
+	e.pClient.receivedLogTailTime.initLogTailTimestamp(tw)
+
+	recRoutines := make([]*routineController, consumerNumber)
+	for i := range recRoutines {
+		recRoutines[i] = &routineController{
+			routineId:  i,
+			signalChan: make(chan routineControlCmd, 8),
+			cmdLogPool: sync.Pool{
+				New: func() any {
+					return &cmdToConsumeLog{}
+				},
+			},
+			cmdTimePool: sync.Pool{
+				New: func() any {
+					return &cmdToUpdateTime{}
+				},
+			},
+		}
+	}
+
+	to := timestamp.Timestamp{PhysicalTime: 100, LogicalTime: 1}
+	response := &logtail.UpdateResponse{
+		To: &to,
+		LogtailList: []logtail.TableLogtail{
+			{Table: &api.TableID{DbId: 10, TbId: 101}},
+			{Table: &api.TableID{DbId: 10, TbId: 105}},
+			{Table: &api.TableID{DbId: 10, TbId: 102}},
+		},
+	}
+	require.NoError(t, dispatchUpdateResponse(ctx, e, response, recRoutines, time.Now()))
+
+	require.Equal(t, 2, len(recRoutines[1].signalChan))
+	cmd := (<-recRoutines[1].signalChan).(*cmdToConsumeLog)
+	assert.False(t, cmd.notifyApplied)
+	cmd = (<-recRoutines[1].signalChan).(*cmdToConsumeLog)
+	assert.True(t, cmd.notifyApplied)
+	assert.Equal(t, to, cmd.applied)
+
+	require.Equal(t, 1, len(recRoutines[2].signalChan))
+	cmd = (<-recRoutines[2].signalChan).(*cmdToConsumeLog)
+	assert.True(t, cmd.notifyApplied)
+	assert.Equal(t, to, cmd.applied)
+
+	require.Equal(t, 1, len(recRoutines[0].signalChan))
+	_, ok := (<-recRoutines[0].signalChan).(*cmdToUpdateTime)
+	assert.True(t, ok)
+	require.Equal(t, 1, len(recRoutines[3].signalChan))
+	_, ok = (<-recRoutines[3].signalChan).(*cmdToUpdateTime)
+	assert.True(t, ok)
+}
+
 // TestCommandActions verifies that command actions can be created and their basic functionality works
 func TestCommandActions(t *testing.T) {
 	t.Run("cmdToConsumeSub creation and basic properties", func(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24322

## What this PR does / why we need it:

Fixes the CN logtail consumer backlog risk found in nightly sysbench write-heavy regressions.

The bad run had `logtail.consumer.slow.*` in the `update_pk_1000` window, with `signal-chan-len` around 7373~7738 on one CN consumer routine. The good control run using the same MO image did not have these slow logs in the same case window. No sysbench reconnect/retry storm, workspace quota shortage, or UPDATE table-lock upgrade was found.

This PR reduces internal backpressure without changing table assignment or increasing consumer routine count:

- coalesces update-response timestamp commands for routines that already have table logtail commands,
- advances the routine applied timestamp only after that routine consumes the last table logtail for the response,
- keeps timestamp-only commands for routines that do not receive table logtails, preserving global min applied timestamp semantics,
- makes timestamp waiter commit-ts notifications non-blocking and coalesced to the latest timestamp,
- adds tests for non-blocking timestamp notifications, bounded notification draining, and logtail timestamp advancement ordering.

## Validation

```bash
PROJECTROOT="/Users/shenjiangwei/Work/code/view/matrixone"
export CGO_CFLAGS="-I$PROJECTROOT/cgo -I$PROJECTROOT/thirdparties/install/include"
export CGO_LDFLAGS="-Wl,-w,-rpath,$PROJECTROOT/thirdparties/install/lib -L$PROJECTROOT/thirdparties/install/lib -L$PROJECTROOT/cgo -lmo"
go test -mod=mod ./pkg/txn/client ./pkg/vm/engine/disttae -count=1
go test -mod=mod -race ./pkg/txn/client -run 'Test(GetTimestampWithNotified|NotifyLatestCommitTSNonBlockingWhenChannelFull|FetchLatestTSDoesNotDrainUnboundedSignals)' -count=1
go test -mod=mod ./pkg/vm/engine/disttae -run 'TestDispatchUpdateResponse(CoalescesTimestampCommands|AdvancesTimestampAfterLastLogtail)|TestPushClient_LatestLogtailAppliedTime' -count=10
```
