### PR TITLE
fix: optimize regular index order-by limit

### DIFF
--- a/pkg/objectio/types.go
+++ b/pkg/objectio/types.go
@@ -84,11 +84,13 @@ func (h *Float64Heap) Pop() any {
 }
 
 type IndexReaderTopOp struct {
-	Typ        types.T
-	MetricType metric.MetricType
-	ColPos     int32
-	NumVec     []byte
-	Limit      uint64
+	Typ          types.T
+	MetricType   metric.MetricType
+	ColPos       int32
+	NumVec       []byte
+	Limit        uint64
+	OrderedLimit bool
+	Desc         bool
 
 	LowerBoundType plan.BoundType
 	UpperBoundType plan.BoundType

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -739,7 +739,9 @@ func (builder *QueryBuilder) applyRegularIndexTopSort(ctx *regularIndexTopSortCo
 		Expr: scanHiddenKeyExpr,
 		Flag: ctx.sortNode.OrderBy[0].Flag,
 	})
-	applyRegularIndexOrderedLimitParam(ctx.scanNode, ctx.scanNode.OrderBy[len(ctx.scanNode.OrderBy)-1], ctx.sortNode.Limit)
+	if ctx.sortNode.Offset == nil && ctx.sortNode.RankOption == nil {
+		applyRegularIndexOrderedLimitParam(ctx.scanNode, ctx.scanNode.OrderBy[len(ctx.scanNode.OrderBy)-1], ctx.sortNode.Limit)
+	}
 
 	if !hasTopValueMessage(ctx.sortNode) {
 		msgHeader := plan.MsgHeader{

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -739,6 +739,7 @@ func (builder *QueryBuilder) applyRegularIndexTopSort(ctx *regularIndexTopSortCo
 		Expr: scanHiddenKeyExpr,
 		Flag: ctx.sortNode.OrderBy[0].Flag,
 	})
+	applyRegularIndexOrderedLimitParam(ctx.scanNode, ctx.scanNode.OrderBy[len(ctx.scanNode.OrderBy)-1], ctx.sortNode.Limit)
 
 	if !hasTopValueMessage(ctx.sortNode) {
 		msgHeader := plan.MsgHeader{
@@ -747,6 +748,19 @@ func (builder *QueryBuilder) applyRegularIndexTopSort(ctx *regularIndexTopSortCo
 		}
 		ctx.sortNode.SendMsgList = append([]plan.MsgHeader{msgHeader}, ctx.sortNode.SendMsgList...)
 		ctx.scanNode.RecvMsgList = append(ctx.scanNode.RecvMsgList, msgHeader)
+	}
+}
+
+func applyRegularIndexOrderedLimitParam(scanNode *plan.Node, orderBy *plan.OrderBySpec, limit *plan.Expr) {
+	if scanNode == nil || orderBy == nil || limit == nil {
+		return
+	}
+	if limitLit := limit.GetLit(); limitLit == nil || limitLit.GetU64Val() == 0 {
+		return
+	}
+	scanNode.IndexReaderParam = &plan.IndexReaderParam{
+		OrderBy: []*plan.OrderBySpec{DeepCopyOrderBySpec(orderBy)},
+		Limit:   DeepCopyExpr(limit),
 	}
 }
 

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -731,6 +731,51 @@ func TestHandleMessageFromTopToScanSkipsOrderedLimitForOffsetOrRank(t *testing.T
 	}
 }
 
+func TestApplyIndicesForProjectSkipsOrderedLimitForOffsetOrRank(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(*planpb.Node)
+	}{
+		{
+			name: "offset",
+			setup: func(sortNode *planpb.Node) {
+				sortNode.Offset = &planpb.Expr{
+					Typ: planpb.Type{Id: int32(types.T_uint64)},
+					Expr: &planpb.Expr_Lit{
+						Lit: &planpb.Literal{Value: &planpb.Literal_U64Val{U64Val: 3}},
+					},
+				}
+			},
+		},
+		{
+			name: "rank",
+			setup: func(sortNode *planpb.Node) {
+				sortNode.RankOption = &planpb.RankOption{}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			builder, rootNodeID := makeTestRegularIndexProjectBuilder(
+				t,
+				2,
+				GetColExpr(planpb.Type{Id: int32(types.T_int64)}, 100, 1),
+				planpb.OrderBySpec_DESC,
+			)
+			sortNode := builder.qry.Nodes[2]
+			tc.setup(sortNode)
+
+			_, err := builder.applyIndicesForProject(rootNodeID, builder.qry.Nodes[rootNodeID], map[[2]int32]int{}, map[[2]int32]*planpb.Expr{})
+			require.NoError(t, err)
+
+			scanNode := builder.qry.Nodes[0]
+			assert.Empty(t, sortNode.SendMsgList)
+			assert.Empty(t, scanNode.RecvMsgList)
+			assert.Empty(t, scanNode.OrderBy)
+			assert.Nil(t, scanNode.IndexReaderParam)
+		})
+	}
+}
+
 // Benchmark the function to ensure it's fast
 func BenchmarkCalculatePostFilterOverFetchFactor(b *testing.B) {
 	limits := []uint64{1, 5, 10, 20, 50, 100, 200, 500, 1000, 10000}

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -542,6 +542,15 @@ func TestApplyIndicesForProjectPushesTopValueThroughRegularIndexPKOrder(t *testi
 	assert.Equal(t, int32(0), scanOrderCol.ColPos)
 	assert.Equal(t, catalog.IndexTableIndexColName, scanOrderCol.Name)
 	assert.Equal(t, planpb.OrderBySpec_DESC, scanNode.OrderBy[0].Flag)
+	require.NotNil(t, scanNode.IndexReaderParam)
+	require.Len(t, scanNode.IndexReaderParam.OrderBy, 1)
+	assert.Equal(t, uint64(20), scanNode.IndexReaderParam.Limit.GetLit().GetU64Val())
+	indexParamCol := scanNode.IndexReaderParam.OrderBy[0].Expr.GetCol()
+	require.NotNil(t, indexParamCol)
+	assert.Equal(t, int32(100), indexParamCol.RelPos)
+	assert.Equal(t, int32(0), indexParamCol.ColPos)
+	assert.Equal(t, catalog.IndexTableIndexColName, indexParamCol.Name)
+	assert.Equal(t, planpb.OrderBySpec_DESC, scanNode.IndexReaderParam.OrderBy[0].Flag)
 
 	sortOrderCol := sortNode.OrderBy[0].Expr.GetCol()
 	require.NotNil(t, sortOrderCol)
@@ -575,6 +584,11 @@ func TestApplyIndicesForProjectPushesTopValueThroughRegularIndexPKOrderAsc(t *te
 	assert.Equal(t, planpb.OrderBySpec_OrderByFlag(0), sortNode.OrderBy[0].Flag)
 	assert.Equal(t, planpb.OrderBySpec_OrderByFlag(0), scanNode.OrderBy[0].Flag)
 	assert.Equal(t, catalog.IndexTableIndexColName, scanNode.OrderBy[0].Expr.GetCol().Name)
+	require.NotNil(t, scanNode.IndexReaderParam)
+	require.Len(t, scanNode.IndexReaderParam.OrderBy, 1)
+	assert.Equal(t, uint64(20), scanNode.IndexReaderParam.Limit.GetLit().GetU64Val())
+	assert.Equal(t, planpb.OrderBySpec_OrderByFlag(0), scanNode.IndexReaderParam.OrderBy[0].Flag)
+	assert.Equal(t, catalog.IndexTableIndexColName, scanNode.IndexReaderParam.OrderBy[0].Expr.GetCol().Name)
 }
 
 func TestHandleMessageFromTopToScanRewritesRegularIndexPKOrderToHiddenKey(t *testing.T) {
@@ -588,6 +602,9 @@ func TestHandleMessageFromTopToScanRewritesRegularIndexPKOrderToHiddenKey(t *tes
 	require.Len(t, sortNode.SendMsgList, 1)
 	require.Len(t, scanNode.RecvMsgList, 1)
 	require.Len(t, scanNode.OrderBy, 1)
+	require.NotNil(t, scanNode.IndexReaderParam)
+	require.Len(t, scanNode.IndexReaderParam.OrderBy, 1)
+	assert.Equal(t, uint64(20), scanNode.IndexReaderParam.Limit.GetLit().GetU64Val())
 
 	sortOrderCol := sortNode.OrderBy[0].Expr.GetCol()
 	require.NotNil(t, sortOrderCol)
@@ -600,6 +617,11 @@ func TestHandleMessageFromTopToScanRewritesRegularIndexPKOrderToHiddenKey(t *tes
 	assert.Equal(t, int32(100), scanOrderCol.RelPos)
 	assert.Equal(t, int32(0), scanOrderCol.ColPos)
 	assert.Equal(t, catalog.IndexTableIndexColName, scanOrderCol.Name)
+	indexParamCol := scanNode.IndexReaderParam.OrderBy[0].Expr.GetCol()
+	require.NotNil(t, indexParamCol)
+	assert.Equal(t, int32(100), indexParamCol.RelPos)
+	assert.Equal(t, int32(0), indexParamCol.ColPos)
+	assert.Equal(t, catalog.IndexTableIndexColName, indexParamCol.Name)
 }
 
 func TestHandleMessageFromTopToScanKeepsPKOrderWhenPrefixIncomplete(t *testing.T) {
@@ -613,6 +635,7 @@ func TestHandleMessageFromTopToScanKeepsPKOrderWhenPrefixIncomplete(t *testing.T
 	require.Len(t, sortNode.SendMsgList, 1)
 	require.Len(t, scanNode.RecvMsgList, 1)
 	require.Len(t, scanNode.OrderBy, 1)
+	assert.Nil(t, scanNode.IndexReaderParam)
 
 	sortOrderCol := sortNode.OrderBy[0].Expr.GetCol()
 	require.NotNil(t, sortOrderCol)
@@ -643,6 +666,7 @@ func TestApplyIndicesForProjectSkipsRegularIndexPKOrderWithoutFullPrefixEquality
 	assert.Empty(t, sortNode.SendMsgList)
 	assert.Empty(t, scanNode.RecvMsgList)
 	assert.Empty(t, scanNode.OrderBy)
+	assert.Nil(t, scanNode.IndexReaderParam)
 	require.Len(t, sortProjectNode.ProjectList, 1)
 }
 
@@ -664,7 +688,47 @@ func TestApplyIndicesForProjectSkipsRegularIndexPKOrderForNonPKSortColumn(t *tes
 	assert.Empty(t, sortNode.SendMsgList)
 	assert.Empty(t, scanNode.RecvMsgList)
 	assert.Empty(t, scanNode.OrderBy)
+	assert.Nil(t, scanNode.IndexReaderParam)
 	require.Len(t, sortProjectNode.ProjectList, 1)
+}
+
+func TestHandleMessageFromTopToScanSkipsOrderedLimitForOffsetOrRank(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(*planpb.Node)
+	}{
+		{
+			name: "offset",
+			setup: func(sortNode *planpb.Node) {
+				sortNode.Offset = &planpb.Expr{
+					Typ: planpb.Type{Id: int32(types.T_uint64)},
+					Expr: &planpb.Expr_Lit{
+						Lit: &planpb.Literal{Value: &planpb.Literal_U64Val{U64Val: 3}},
+					},
+				}
+			},
+		},
+		{
+			name: "rank",
+			setup: func(sortNode *planpb.Node) {
+				sortNode.RankOption = &planpb.RankOption{}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			builder, rootNodeID := makeTestRegularIndexMessageBuilder(t, 2, 1, planpb.OrderBySpec_DESC)
+			sortNode := builder.qry.Nodes[1]
+			tc.setup(sortNode)
+
+			builder.handleMessageFromTopToScan(rootNodeID)
+
+			scanNode := builder.qry.Nodes[0]
+			require.Len(t, sortNode.SendMsgList, 1)
+			require.Len(t, scanNode.RecvMsgList, 1)
+			require.Len(t, scanNode.OrderBy, 1)
+			assert.Nil(t, scanNode.IndexReaderParam)
+		})
+	}
 }
 
 // Benchmark the function to ensure it's fast

--- a/pkg/sql/plan/message.go
+++ b/pkg/sql/plan/message.go
@@ -76,6 +76,7 @@ func (builder *QueryBuilder) handleMessageFromTopToScan(nodeID int32) {
 		return
 	}
 	scanOrderBy := DeepCopyOrderBySpec(node.OrderBy[0])
+	enableOrderedLimit := false
 	if canUseRegularIndexHiddenSortKey(scanNode, orderByCol) {
 		orderByName := orderByCol.Name
 		hiddenKeyExpr := GetColExpr(scanNode.TableDef.Cols[0].Typ, scanNode.BindingTags[0], 0)
@@ -89,6 +90,7 @@ func (builder *QueryBuilder) handleMessageFromTopToScan(nodeID int32) {
 			Expr: scanHiddenKeyExpr,
 			Flag: node.OrderBy[0].Flag,
 		}
+		enableOrderedLimit = node.Offset == nil && node.RankOption == nil
 	}
 	if orderByCol.RelPos != scanNode.BindingTags[0] {
 		return
@@ -99,6 +101,9 @@ func (builder *QueryBuilder) handleMessageFromTopToScan(nodeID int32) {
 	node.SendMsgList = append(node.SendMsgList, msgHeader)
 	scanNode.RecvMsgList = append(scanNode.RecvMsgList, msgHeader)
 	scanNode.OrderBy = append(scanNode.OrderBy, scanOrderBy)
+	if enableOrderedLimit {
+		applyRegularIndexOrderedLimitParam(scanNode, scanOrderBy, node.Limit)
+	}
 }
 
 func (builder *QueryBuilder) handleHashMapMessages(nodeID int32) {

--- a/pkg/vm/engine/readutil/reader.go
+++ b/pkg/vm/engine/readutil/reader.go
@@ -474,7 +474,25 @@ func (r *reader) SetOrderBy(orderby []*plan.OrderBySpec) {
 }
 
 func (r *reader) SetIndexParam(param *plan.IndexReaderParam) {
-	if param == nil {
+	if param == nil || len(param.OrderBy) == 0 || param.Limit == nil {
+		return
+	}
+	if r.orderByLimit == nil {
+		r.orderByLimit = &objectio.IndexReaderTopOp{}
+	}
+
+	if col := param.OrderBy[0].Expr.GetCol(); col != nil {
+		r.orderByLimit.Typ = types.T(param.OrderBy[0].Expr.Typ.Id)
+		r.orderByLimit.ColPos = col.ColPos
+		r.orderByLimit.Limit = param.Limit.GetLit().GetU64Val()
+		r.orderByLimit.OrderedLimit = true
+		r.orderByLimit.Desc = param.OrderBy[0].Flag&plan.OrderBySpec_DESC != 0
+		r.orderByLimit.NumVec = nil
+		r.orderByLimit.DistHeap = nil
+		r.orderByLimit.LowerBoundType = 0
+		r.orderByLimit.UpperBoundType = 0
+		r.orderByLimit.LowerBound = 0
+		r.orderByLimit.UpperBound = 0
 		return
 	}
 
@@ -498,15 +516,13 @@ func (r *reader) SetIndexParam(param *plan.IndexReaderParam) {
 		panic("unsupported order function")
 	}
 
-	if r.orderByLimit == nil {
-		r.orderByLimit = &objectio.IndexReaderTopOp{}
-	}
-
 	r.orderByLimit.Typ = types.T(orderFunc.Args[0].Typ.Id)
 	r.orderByLimit.MetricType = metricType
 	r.orderByLimit.ColPos = col.ColPos
 	r.orderByLimit.NumVec = []byte(numVec)
 	r.orderByLimit.Limit = param.Limit.GetLit().GetU64Val()
+	r.orderByLimit.OrderedLimit = false
+	r.orderByLimit.Desc = param.OrderBy[0].Flag&plan.OrderBySpec_DESC != 0
 
 	if param.DistRange != nil {
 		r.orderByLimit.LowerBoundType = param.DistRange.LowerBoundType
@@ -620,7 +636,7 @@ func (r *reader) Read(
 	// Read(), so detach it before source.Next() to avoid seqNums out-of-range panic in
 	// InMem paths. We keep one float64 distVec for reuse to avoid repeated allocations.
 	var detachedDistVec *vector.Vector
-	if r.orderByLimit != nil && len(outBatch.Vecs) > len(cols) {
+	if r.orderByLimit != nil && !r.orderByLimit.OrderedLimit && len(outBatch.Vecs) > len(cols) {
 		if candidate := outBatch.Vecs[len(cols)]; candidate != nil &&
 			candidate.GetType().Oid == types.T_float64 {
 			candidate.CleanOnlyData()
@@ -663,7 +679,7 @@ func (r *reader) Read(
 		return true, nil
 	}
 	if state == engine.InMem {
-		if r.orderByLimit != nil {
+		if r.orderByLimit != nil && !r.orderByLimit.OrderedLimit {
 			sels, dists, err := blockio.HandleOrderByLimitOnIVFFlatIndex(ctx, nil, outBatch.Vecs[r.orderByLimit.ColPos], r.orderByLimit)
 			if err != nil {
 				return false, err
@@ -712,7 +728,7 @@ func (r *reader) Read(
 	if len(r.cacheVectors) == 0 {
 		r.cacheVectors = containers.NewVectors(len(r.columns.seqnums) + 1)
 	}
-	if r.orderByLimit != nil && detachedDistVec != nil {
+	if r.orderByLimit != nil && !r.orderByLimit.OrderedLimit && detachedDistVec != nil {
 		// Re-attach the detached distVec so BlockDataRead can take its fast reuse branch.
 		outBatch.Vecs = append(outBatch.Vecs, detachedDistVec)
 		detachedDistVec = nil

--- a/pkg/vm/engine/readutil/reader_test.go
+++ b/pkg/vm/engine/readutil/reader_test.go
@@ -69,3 +69,30 @@ func TestReaderSetIndexParamDoesNotPreallocateDistHeap(t *testing.T) {
 	require.Zero(t, len(r.orderByLimit.DistHeap))
 	require.Zero(t, cap(r.orderByLimit.DistHeap))
 }
+
+func TestReaderSetIndexParamSupportsOrderedLimit(t *testing.T) {
+	r := &reader{}
+	param := &plan.IndexReaderParam{
+		OrderBy: []*plan.OrderBySpec{
+			{
+				Expr: &plan.Expr{
+					Typ: plan.Type{Id: int32(types.T_int64)},
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{ColPos: 1},
+					},
+				},
+				Flag: plan.OrderBySpec_DESC,
+			},
+		},
+		Limit: plan2.MakePlan2Uint64ConstExprWithType(8),
+	}
+
+	r.SetIndexParam(param)
+
+	require.NotNil(t, r.orderByLimit)
+	require.True(t, r.orderByLimit.OrderedLimit)
+	require.True(t, r.orderByLimit.Desc)
+	require.Equal(t, int32(1), r.orderByLimit.ColPos)
+	require.Equal(t, uint64(8), r.orderByLimit.Limit)
+	require.Nil(t, r.orderByLimit.NumVec)
+}

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -562,7 +562,7 @@ func fillOutputBatchBySelectedRows(
 		if outputColPos == phyAddrColumnPos {
 			continue
 		}
-		if orderByLimit != nil && loadedColumnPos == int(orderByLimit.ColPos) {
+		if orderByLimit != nil && !orderByLimit.OrderedLimit && loadedColumnPos == int(orderByLimit.ColPos) {
 			loadedColumnPos++
 			continue
 		}
@@ -579,7 +579,7 @@ func fillOutputBatchBySelectedRows(
 		loadedColumnPos++
 	}
 
-	if orderByLimit != nil {
+	if orderByLimit != nil && !orderByLimit.OrderedLimit {
 		if len(outputBat.Vecs) == len(columns) {
 			distVec := vector.NewVec(types.T_float64.ToType())
 			if err = vector.AppendFixedList(distVec, dists, nil, mp); err != nil {
@@ -643,7 +643,7 @@ func BlockDataReadInner(
 		var dists []float64
 
 		if orderByLimit != nil {
-			selectRows, dists, err = handleOrderByLimitOnSelectRows(ctx, selectRows, orderByLimit, phyAddrColumnPos, cacheVectors)
+			selectRows, dists, err = handleOrderByLimitOnSelectRows(ctx, selectRows, orderByLimit, info, phyAddrColumnPos, cacheVectors)
 			if err != nil {
 				return err
 			}
@@ -691,10 +691,8 @@ func BlockDataReadInner(
 	// No pre-filter rows, but vector TopN pushdown is requested:
 	// apply TopN on live rows (exclude tombstones first), then materialize selected rows.
 	if orderByLimit != nil {
-		topInputRows := buildTopInputRows(int(info.MetaLocation().Rows()), deleteMask)
-
 		var dists []float64
-		selectRows, dists, err = handleOrderByLimitOnSelectRows(ctx, topInputRows, orderByLimit, phyAddrColumnPos, cacheVectors)
+		selectRows, dists, err = handleOrderByLimitOnLiveRows(ctx, orderByLimit, info, phyAddrColumnPos, deleteMask, cacheVectors)
 		if err != nil {
 			return err
 		}
@@ -1021,9 +1019,21 @@ func handleOrderByLimitOnSelectRows(
 	ctx context.Context,
 	selectRows []int64,
 	orderByLimit *objectio.IndexReaderTopOp,
+	info *objectio.BlockInfo,
 	phyAddrColumnPos int,
 	cacheVectors containers.Vectors,
 ) ([]int64, []float64, error) {
+	if orderByLimit.OrderedLimit {
+		if info == nil || !info.IsSorted() || uint64(len(selectRows)) <= orderByLimit.Limit {
+			return selectRows, nil, nil
+		}
+		limit := int(orderByLimit.Limit)
+		if orderByLimit.Desc {
+			return selectRows[len(selectRows)-limit:], nil, nil
+		}
+		return selectRows[:limit], nil, nil
+	}
+
 	vecColPos := orderByLimit.ColPos
 	if phyAddrColumnPos >= 0 && vecColPos > int32(phyAddrColumnPos) {
 		vecColPos--
@@ -1031,4 +1041,111 @@ func handleOrderByLimitOnSelectRows(
 	vecCol := &cacheVectors[vecColPos]
 
 	return HandleOrderByLimitOnIVFFlatIndex(ctx, selectRows, vecCol, orderByLimit)
+}
+
+func handleOrderByLimitOnLiveRows(
+	ctx context.Context,
+	orderByLimit *objectio.IndexReaderTopOp,
+	info *objectio.BlockInfo,
+	phyAddrColumnPos int,
+	deleteMask objectio.Bitmap,
+	cacheVectors containers.Vectors,
+) ([]int64, []float64, error) {
+	vecColPos := orderByLimit.ColPos
+	if phyAddrColumnPos >= 0 && vecColPos > int32(phyAddrColumnPos) {
+		vecColPos--
+	}
+	if orderByLimit.OrderedLimit {
+		rowCount := 0
+		if int(vecColPos) < len(cacheVectors) {
+			rowCount = cacheVectors[vecColPos].Length()
+		} else if info != nil {
+			rowCount = int(info.MetaLocation().Rows())
+		}
+		return buildOrderedLiveRows(rowCount, deleteMask, orderByLimit, info != nil && info.IsSorted()), nil, nil
+	}
+
+	vecCol := &cacheVectors[vecColPos]
+	selectRows := buildLiveRows(vecCol.Length(), deleteMask)
+	return HandleOrderByLimitOnIVFFlatIndex(ctx, selectRows, vecCol, orderByLimit)
+}
+
+func buildLiveRows(rowCount int, deleteMask objectio.Bitmap) []int64 {
+	if rowCount <= 0 || deleteMask.IsEmpty() {
+		return nil
+	}
+	capHint := rowCount - deleteMask.Count()
+	if capHint < 0 {
+		capHint = 0
+	}
+	rows := make([]int64, 0, capHint)
+	for i := 0; i < rowCount; i++ {
+		if !deleteMask.Contains(uint64(i)) {
+			rows = append(rows, int64(i))
+		}
+	}
+	return rows
+}
+
+func buildOrderedLiveRows(
+	rowCount int,
+	deleteMask objectio.Bitmap,
+	orderByLimit *objectio.IndexReaderTopOp,
+	isSorted bool,
+) []int64 {
+	if rowCount <= 0 {
+		return nil
+	}
+	if !isSorted {
+		if deleteMask.IsEmpty() {
+			return buildContiguousRows(0, rowCount)
+		}
+		return buildLiveRows(rowCount, deleteMask)
+	}
+	limit := rowCount
+	if orderByLimit.Limit > 0 && orderByLimit.Limit < uint64(rowCount) {
+		limit = int(orderByLimit.Limit)
+	}
+	if orderByLimit.Desc {
+		return buildOrderedLiveRowsDesc(rowCount, deleteMask, limit)
+	}
+	return buildOrderedLiveRowsAsc(rowCount, deleteMask, limit)
+}
+
+func buildOrderedLiveRowsAsc(rowCount int, deleteMask objectio.Bitmap, limit int) []int64 {
+	if deleteMask.IsEmpty() {
+		return buildContiguousRows(0, limit)
+	}
+	rows := make([]int64, 0, limit)
+	for i := 0; i < rowCount && len(rows) < limit; i++ {
+		if !deleteMask.Contains(uint64(i)) {
+			rows = append(rows, int64(i))
+		}
+	}
+	return rows
+}
+
+func buildOrderedLiveRowsDesc(rowCount int, deleteMask objectio.Bitmap, limit int) []int64 {
+	if deleteMask.IsEmpty() {
+		return buildContiguousRows(rowCount-limit, rowCount)
+	}
+	rows := make([]int64, 0, limit)
+	for i := rowCount - 1; i >= 0 && len(rows) < limit; i-- {
+		if !deleteMask.Contains(uint64(i)) {
+			rows = append(rows, int64(i))
+		}
+	}
+	slices.Reverse(rows)
+	return rows
+}
+
+func buildContiguousRows(start, end int) []int64 {
+	if end <= start {
+		return nil
+	}
+	rows := make([]int64, end-start)
+	for i := range rows {
+		rows[i] = int64(start + i)
+	}
+	return rows
 }

--- a/pkg/vm/engine/tae/blockio/read.go
+++ b/pkg/vm/engine/tae/blockio/read.go
@@ -688,6 +688,13 @@ func BlockDataReadInner(
 		deletedRows = deleteMask.ToI64Array(&arr)
 	}
 
+	if shouldFallbackOrderedLimitToFullBlockRead(orderByLimit, info) {
+		// Ordered-limit pushdown can only prune sorted blocks. Fall back to the
+		// normal UnionBatch+Shrink path on unsorted blocks to avoid building
+		// full row-index slices that do not eliminate any rows.
+		orderByLimit = nil
+	}
+
 	// No pre-filter rows, but vector TopN pushdown is requested:
 	// apply TopN on live rows (exclude tombstones first), then materialize selected rows.
 	if orderByLimit != nil {
@@ -742,9 +749,9 @@ func BlockDataReadInner(
 }
 
 // buildTopInputRows constructs a slice of live row indices by excluding rows
-// present in the deleteMask. Returns nil if deleteMask is empty.
+// present in the deleteMask. Returns nil when there is nothing to filter.
 func buildTopInputRows(length int, deleteMask objectio.Bitmap) []int64 {
-	if deleteMask.IsEmpty() {
+	if length <= 0 || deleteMask.IsEmpty() {
 		return nil
 	}
 	capHint := length - deleteMask.Count()
@@ -1066,25 +1073,15 @@ func handleOrderByLimitOnLiveRows(
 	}
 
 	vecCol := &cacheVectors[vecColPos]
-	selectRows := buildLiveRows(vecCol.Length(), deleteMask)
+	selectRows := buildTopInputRows(vecCol.Length(), deleteMask)
 	return HandleOrderByLimitOnIVFFlatIndex(ctx, selectRows, vecCol, orderByLimit)
 }
 
-func buildLiveRows(rowCount int, deleteMask objectio.Bitmap) []int64 {
-	if rowCount <= 0 || deleteMask.IsEmpty() {
-		return nil
-	}
-	capHint := rowCount - deleteMask.Count()
-	if capHint < 0 {
-		capHint = 0
-	}
-	rows := make([]int64, 0, capHint)
-	for i := 0; i < rowCount; i++ {
-		if !deleteMask.Contains(uint64(i)) {
-			rows = append(rows, int64(i))
-		}
-	}
-	return rows
+func shouldFallbackOrderedLimitToFullBlockRead(
+	orderByLimit *objectio.IndexReaderTopOp,
+	info *objectio.BlockInfo,
+) bool {
+	return orderByLimit != nil && orderByLimit.OrderedLimit && (info == nil || !info.IsSorted())
 }
 
 func buildOrderedLiveRows(
@@ -1100,7 +1097,7 @@ func buildOrderedLiveRows(
 		if deleteMask.IsEmpty() {
 			return buildContiguousRows(0, rowCount)
 		}
-		return buildLiveRows(rowCount, deleteMask)
+		return buildTopInputRows(rowCount, deleteMask)
 	}
 	limit := rowCount
 	if orderByLimit.Limit > 0 && orderByLimit.Limit < uint64(rowCount) {

--- a/pkg/vm/engine/tae/blockio/read_test.go
+++ b/pkg/vm/engine/tae/blockio/read_test.go
@@ -222,7 +222,7 @@ func TestHandleOrderByLimitOnSelectRows(t *testing.T) {
 		DistHeap:   make(objectio.Float64Heap, 0, 2),
 	}
 
-	resSels, resDists, err := handleOrderByLimitOnSelectRows(ctx, selectRows, orderByLimit, -1, cacheVectors)
+	resSels, resDists, err := handleOrderByLimitOnSelectRows(ctx, selectRows, orderByLimit, nil, -1, cacheVectors)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(resSels))
 	require.Equal(t, 2, len(resDists))
@@ -676,7 +676,82 @@ func TestHandleOrderByLimitOnSelectRowsRejectsOverflowLimit(t *testing.T) {
 		MetricType: metric.Metric_L2Distance,
 	}
 
-	_, _, err := handleOrderByLimitOnSelectRows(context.Background(), []int64{0}, orderByLimit, -1, cacheVectors)
+	_, _, err := handleOrderByLimitOnSelectRows(context.Background(), []int64{0}, orderByLimit, nil, -1, cacheVectors)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "overflows int")
+}
+
+func TestHandleOrderByLimitOnSelectRowsForOrderedLimit(t *testing.T) {
+	ctx := context.Background()
+	selectRows := []int64{2, 4, 6, 8}
+	info := &objectio.BlockInfo{ObjectFlags: objectio.ObjectFlag_Sorted}
+
+	descLimit := &objectio.IndexReaderTopOp{Limit: 2, OrderedLimit: true, Desc: true}
+	descRows, descDists, err := handleOrderByLimitOnSelectRows(ctx, selectRows, descLimit, info, -1, nil)
+	require.NoError(t, err)
+	require.Nil(t, descDists)
+	require.Equal(t, []int64{6, 8}, descRows)
+
+	ascLimit := &objectio.IndexReaderTopOp{Limit: 2, OrderedLimit: true}
+	ascRows, ascDists, err := handleOrderByLimitOnSelectRows(ctx, selectRows, ascLimit, info, -1, nil)
+	require.NoError(t, err)
+	require.Nil(t, ascDists)
+	require.Equal(t, []int64{2, 4}, ascRows)
+}
+
+func TestHandleOrderByLimitOnLiveRowsForOrderedLimit(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer mpool.DeleteMPool(mp)
+
+	vec0 := vector.NewVec(types.T_int32.ToType())
+	for i := 0; i < 6; i++ {
+		vector.AppendFixed(vec0, int32(i), false, mp)
+	}
+	cacheVectors := make(containers.Vectors, 1)
+	cacheVectors[0] = *vec0
+
+	descLimit := &objectio.IndexReaderTopOp{
+		Typ:          types.T_int32,
+		ColPos:       0,
+		Limit:        2,
+		OrderedLimit: true,
+		Desc:         true,
+	}
+	info := &objectio.BlockInfo{ObjectFlags: objectio.ObjectFlag_Sorted}
+
+	rows, dists, err := handleOrderByLimitOnLiveRows(context.Background(), descLimit, info, -1, objectio.Bitmap{}, cacheVectors)
+	require.NoError(t, err)
+	require.Nil(t, dists)
+	require.Equal(t, []int64{4, 5}, rows)
+
+	ascLimit := &objectio.IndexReaderTopOp{
+		Typ:          types.T_int32,
+		ColPos:       0,
+		Limit:        2,
+		OrderedLimit: true,
+	}
+	rows, dists, err = handleOrderByLimitOnLiveRows(context.Background(), ascLimit, info, -1, objectio.Bitmap{}, cacheVectors)
+	require.NoError(t, err)
+	require.Nil(t, dists)
+	require.Equal(t, []int64{0, 1}, rows)
+
+	deleteMask := objectio.GetReusableBitmap()
+	defer deleteMask.Release()
+	deleteMask.Add(4)
+	rows, dists, err = handleOrderByLimitOnLiveRows(context.Background(), descLimit, info, -1, deleteMask, cacheVectors)
+	require.NoError(t, err)
+	require.Nil(t, dists)
+	require.Equal(t, []int64{3, 5}, rows)
+
+	deleteMask.Add(0)
+	rows, dists, err = handleOrderByLimitOnLiveRows(context.Background(), ascLimit, info, -1, deleteMask, cacheVectors)
+	require.NoError(t, err)
+	require.Nil(t, dists)
+	require.Equal(t, []int64{1, 2}, rows)
+
+	unsortedInfo := &objectio.BlockInfo{}
+	rows, dists, err = handleOrderByLimitOnLiveRows(context.Background(), ascLimit, unsortedInfo, -1, deleteMask, cacheVectors)
+	require.NoError(t, err)
+	require.Nil(t, dists)
+	require.Equal(t, []int64{1, 2, 3, 5}, rows)
 }

--- a/pkg/vm/engine/tae/blockio/read_test.go
+++ b/pkg/vm/engine/tae/blockio/read_test.go
@@ -356,9 +356,31 @@ func TestBuildTopInputRows(t *testing.T) {
 		defer mask.Release()
 		mask.Add(0)
 		rows := buildTopInputRows(0, mask)
-		require.NotNil(t, rows)
-		require.Equal(t, 0, len(rows))
+		require.Nil(t, rows)
 	})
+}
+
+func TestShouldFallbackOrderedLimitToFullBlockRead(t *testing.T) {
+	sortedInfo := &objectio.BlockInfo{ObjectFlags: objectio.ObjectFlag_Sorted}
+	unsortedInfo := &objectio.BlockInfo{}
+
+	require.False(t, shouldFallbackOrderedLimitToFullBlockRead(nil, sortedInfo))
+	require.False(t, shouldFallbackOrderedLimitToFullBlockRead(
+		&objectio.IndexReaderTopOp{Limit: 2},
+		unsortedInfo,
+	))
+	require.False(t, shouldFallbackOrderedLimitToFullBlockRead(
+		&objectio.IndexReaderTopOp{Limit: 2, OrderedLimit: true},
+		sortedInfo,
+	))
+	require.True(t, shouldFallbackOrderedLimitToFullBlockRead(
+		&objectio.IndexReaderTopOp{Limit: 2, OrderedLimit: true},
+		unsortedInfo,
+	))
+	require.True(t, shouldFallbackOrderedLimitToFullBlockRead(
+		&objectio.IndexReaderTopOp{Limit: 2, OrderedLimit: true},
+		nil,
+	))
 }
 
 func TestReadBlockDataFiltersNonAppendableByCommitTS(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23965

## What this PR does / why we need it:

Brings the useful regular-index `ORDER BY ... LIMIT` optimization from #23966 to `main`, adapted to `main`'s existing `IndexReaderParam` / `IndexReaderTopOp` path.

`main` already had the planner-side hidden-key rewrite and top-value message wiring for non-unique regular secondary indexes, but it still lacked the ordered-limit pushdown on the storage read path. As a result, the query shape was recognized, yet the reader/blockio path still treated top pushdown as IVF/vector-only and missed the sorted-block row pruning that makes the optimization useful.

This PR:

- populates `scanNode.IndexReaderParam` for safe regular-index hidden-key ordered-limit cases,
- extends `objectio.IndexReaderTopOp` with ordered-limit metadata,
- teaches `readutil.reader.SetIndexParam` to distinguish scalar ordered-limit from IVF distance top-N,
- teaches `blockio/read.go` to prune sorted block rows for ordered-limit while keeping the existing IVF path intact,
- adds planner, readutil, and blockio coverage for the `main`-specific implementation.

## Validation

```bash
PROJECTROOT="/Users/shenjiangwei/Work/code/view/matrixone"
export CGO_CFLAGS="-I$PROJECTROOT/cgo -I$PROJECTROOT/thirdparties/install/include"
export CGO_LDFLAGS="-Wl,-w,-rpath,$PROJECTROOT/thirdparties/install/lib -L$PROJECTROOT/thirdparties/install/lib -L$PROJECTROOT/cgo -lmo"
go test -mod=mod ./pkg/sql/plan ./pkg/vm/engine/readutil ./pkg/vm/engine/tae/blockio ./pkg/objectio -count=1
```
