### PR TITLE
fix(lockservice): enforce lock wait timeout

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -247,6 +247,8 @@ const (
 	ErrLockNeedUpgrade uint16 = 20707
 	// ErrCannotCommitOnInvalidCN cannot commit transaction on invalid CN
 	ErrCannotCommitOnInvalidCN uint16 = 20708
+	// ErrLockWaitTimeout lock wait exceeds lock_wait_timeout
+	ErrLockWaitTimeout uint16 = 20709
 
 	// Group 8: partition
 	ErrPartitionFunctionIsNotAllowed       uint16 = 20801
@@ -485,6 +487,7 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	ErrLockConflict:            {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "lock options conflict, wait policy is fast fail"},
 	ErrLockNeedUpgrade:         {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "row level lock is too large that need upgrade to table level lock"},
 	ErrCannotCommitOnInvalidCN: {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "cannot commit a orphan transaction on invalid cn"},
+	ErrLockWaitTimeout:         {ER_LOCK_WAIT_TIMEOUT, []string{MySQLDefaultSqlState}, "Lock wait timeout exceeded; try restarting transaction"},
 
 	// Group 8: partition
 	ErrPartitionFunctionIsNotAllowed:       {ER_PARTITION_FUNCTION_IS_NOT_ALLOWED, []string{MySQLDefaultSqlState}, "This partition function is not allowed"},
@@ -1364,6 +1367,10 @@ func NewLockTableNotFound(ctx context.Context) *Error {
 
 func NewLockConflict(ctx context.Context) *Error {
 	return newError(ctx, ErrLockConflict)
+}
+
+func NewLockWaitTimeout(ctx context.Context) *Error {
+	return newError(ctx, ErrLockWaitTimeout)
 }
 
 func NewPartitionFunctionIsNotAllowed(ctx context.Context) *Error {

--- a/pkg/common/moerr/error_no_ctx.go
+++ b/pkg/common/moerr/error_no_ctx.go
@@ -408,6 +408,10 @@ func NewLockConflictNoCtx() *Error {
 	return newError(Context(), ErrLockConflict)
 }
 
+func NewLockWaitTimeoutNoCtx() *Error {
+	return newError(Context(), ErrLockWaitTimeout)
+}
+
 func NewLockNeedUpgradeNoCtx() *Error {
 	return newError(Context(), ErrLockNeedUpgrade)
 }

--- a/pkg/frontend/util.go
+++ b/pkg/frontend/util.go
@@ -1032,6 +1032,7 @@ var errCodeRollbackWholeTxn = map[uint16]bool{
 	moerr.ErrLockTableNotFound:        false,
 	moerr.ErrDeadlockCheckBusy:        false,
 	moerr.ErrLockConflict:             false,
+	moerr.ErrLockWaitTimeout:          false,
 	moerr.ErrTxnUnknown:               false,
 	moerr.ErrBackendClosed:            false,
 	moerr.ErrNoAvailableBackend:       false,
@@ -1073,6 +1074,8 @@ func getRandomErrorRollbackWholeTxn() error {
 		return moerr.NewDeadlockCheckBusyNoCtx()
 	case moerr.ErrLockConflict:
 		return moerr.NewLockConflictNoCtx()
+	case moerr.ErrLockWaitTimeout:
+		return moerr.NewLockWaitTimeoutNoCtx()
 	case moerr.ErrTxnUnknown:
 		return moerr.NewTxnUnknown(context.Background(), "test")
 	case moerr.ErrBackendClosed:

--- a/pkg/frontend/util_test.go
+++ b/pkg/frontend/util_test.go
@@ -1070,6 +1070,7 @@ func Test_isErrorRollbackWholeTxn(t *testing.T) {
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewLockTableNotFoundNoCtx()))
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewDeadlockCheckBusyNoCtx()))
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewLockConflictNoCtx()))
+	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewLockWaitTimeoutNoCtx()))
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewTxnUnknown(context.Background(), "test")))
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewBackendClosedNoCtx()))
 	assert.Equal(t, true, isErrorRollbackWholeTxn(moerr.NewNoAvailableBackendNoCtx()))

--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -2154,7 +2154,7 @@ var gSysVarsDefs = map[string]SystemVariable{
 		Dynamic:           true,
 		SetVarHintApplies: true,
 		Type:              InitSystemVariableIntType("lock_wait_timeout", 1, 31536000, false),
-		Default:           int64(31536000),
+		Default:           int64(50),
 	},
 	"locked_in_memory": {
 		Name:              "locked_in_memory",

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -18,7 +18,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,6 +52,7 @@ var (
 	retryError                 = moerr.NewTxnNeedRetryNoCtx()
 	retryWithDefChangedError   = moerr.NewTxnNeedRetryWithDefChangedNoCtx()
 	defaultWaitTimeOnRetryLock = time.Second
+	defaultLockWaitTimeout     = 50 * time.Second
 	// Keep backend/CN-restart retries bounded so abnormal txns fail instead of
 	// holding CN resources for hours while the outer statement context is still alive.
 	defaultMaxWaitTimeOnRetryBackendLock = 30 * time.Second
@@ -545,8 +548,15 @@ func doLock(
 		table = lockservice.ShardingByRow(rows[0])
 	}
 
+	lockWaitTimeout, err := getLockWaitTimeout(proc)
+	if err != nil {
+		return false, false, timestamp.Timestamp{}, err
+	}
+	lockCtx, cancel := contextWithLockWaitTimeout(ctx, lockWaitTimeout)
+	defer cancel()
+
 	result, err := lockWithRetry(
-		ctx,
+		lockCtx,
 		lockService,
 		table,
 		rows,
@@ -559,6 +569,7 @@ func doLock(
 		pkType,
 	)
 	if err != nil {
+		err = convertLockWaitTimeoutError(ctx, lockCtx, err)
 		return false, false, timestamp.Timestamp{}, err
 	}
 
@@ -763,6 +774,86 @@ func doLock(
 
 type lockRetryState struct {
 	backendRetryDeadline time.Time
+}
+
+func getLockWaitTimeout(proc *process.Process) (time.Duration, error) {
+	if proc == nil || proc.GetResolveVariableFunc() == nil {
+		return defaultLockWaitTimeout, nil
+	}
+	value, err := proc.GetResolveVariableFunc()("lock_wait_timeout", true, false)
+	if err != nil {
+		return 0, err
+	}
+	return lockWaitTimeoutFromValue(value)
+}
+
+func lockWaitTimeoutFromValue(value any) (time.Duration, error) {
+	var seconds int64
+	switch v := value.(type) {
+	case nil:
+		return defaultLockWaitTimeout, nil
+	case int:
+		seconds = int64(v)
+	case int8:
+		seconds = int64(v)
+	case int16:
+		seconds = int64(v)
+	case int32:
+		seconds = int64(v)
+	case int64:
+		seconds = v
+	case uint:
+		seconds = int64(v)
+	case uint8:
+		seconds = int64(v)
+	case uint16:
+		seconds = int64(v)
+	case uint32:
+		seconds = int64(v)
+	case uint64:
+		if v > uint64(1<<63-1) {
+			return 0, moerr.NewInvalidInputNoCtx("lock_wait_timeout is too large")
+		}
+		seconds = int64(v)
+	case string:
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		seconds = n
+	default:
+		return 0, moerr.NewInvalidInputNoCtxf("unsupported lock_wait_timeout type %T", value)
+	}
+	if seconds <= 0 {
+		return 0, moerr.NewInvalidInputNoCtx("lock_wait_timeout must be positive")
+	}
+	if seconds > int64(1<<63-1)/int64(time.Second) {
+		return 0, moerr.NewInvalidInputNoCtx("lock_wait_timeout is too large")
+	}
+	return time.Duration(seconds) * time.Second, nil
+}
+
+func contextWithLockWaitTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= timeout {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+func convertLockWaitTimeoutError(ctx, lockCtx context.Context, err error) error {
+	if err == nil ||
+		ctx.Err() != nil ||
+		lockCtx.Err() != context.DeadlineExceeded {
+		return err
+	}
+	if !errors.Is(err, context.DeadlineExceeded) &&
+		!isBoundedRetryLockError(err) {
+		return err
+	}
+	return moerr.NewLockWaitTimeout(ctx)
 }
 
 func lockWithRetry(

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -97,6 +97,55 @@ func TestLockWithRetryReturnsBackendErrorWhenDeadlineExceededStopsBoundedRetry(t
 	require.Less(t, time.Since(start), 200*time.Millisecond)
 }
 
+func TestLockWaitTimeoutFromValue(t *testing.T) {
+	timeout, err := lockWaitTimeoutFromValue(int64(2))
+	require.NoError(t, err)
+	require.Equal(t, 2*time.Second, timeout)
+
+	timeout, err = lockWaitTimeoutFromValue("3")
+	require.NoError(t, err)
+	require.Equal(t, 3*time.Second, timeout)
+
+	timeout, err = lockWaitTimeoutFromValue(nil)
+	require.NoError(t, err)
+	require.Equal(t, defaultLockWaitTimeout, timeout)
+
+	_, err = lockWaitTimeoutFromValue(int64(0))
+	require.Error(t, err)
+}
+
+func TestConvertLockWaitTimeoutError(t *testing.T) {
+	ctx := context.Background()
+	lockCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	defer cancel()
+
+	err := convertLockWaitTimeoutError(ctx, lockCtx, context.DeadlineExceeded)
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockWaitTimeout))
+
+	err = convertLockWaitTimeoutError(ctx, lockCtx, moerr.NewBackendCannotConnectNoCtx("context deadline exceeded"))
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockWaitTimeout))
+
+	stmtCtx, stmtCancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer stmtCancel()
+	err = convertLockWaitTimeoutError(stmtCtx, stmtCtx, context.DeadlineExceeded)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	activeLockCtx, activeLockCancel := context.WithTimeout(context.Background(), time.Hour)
+	defer activeLockCancel()
+	err = convertLockWaitTimeoutError(ctx, activeLockCtx, moerr.NewBackendCannotConnectNoCtx("backend down"))
+	require.True(t, moerr.IsMoErrCode(err, moerr.ErrBackendCannotConnect))
+}
+
+func TestContextWithLockWaitTimeoutKeepsShorterExistingDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	lockCtx, lockCancel := contextWithLockWaitTimeout(ctx, time.Hour)
+	defer lockCancel()
+
+	require.True(t, lockCtx == ctx)
+}
+
 func TestLockWithRetryReturnsBackendErrorWhenCanceledContextStopsBoundedRetry(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24333

## What this PR does / why we need it:

Fixes a stability failure mode where a multi-statement pessimistic transaction can keep locks acquired by earlier statements while a later statement waits on another row lock indefinitely.

The root cause is that the lock wait path only observes holder notifications or the outer statement context. Although `lock_wait_timeout` existed, it was not applied to SQL lock acquisition, and its default was effectively unbounded for stability scenarios (`31536000` seconds). In issue #24333 this allowed one blocked statement to keep earlier locks for nearly 20 hours, causing waiter buildup and eventually saturating CN active txn capacity.

This PR:

- applies `lock_wait_timeout` to pessimistic lock acquisition in `lockop`, without changing the lockservice protobuf/RPC API,
- preserves any shorter existing statement/client deadline instead of extending or masking it,
- converts only the lock-wait-owned deadline into a dedicated `ErrLockWaitTimeout` using MySQL error 1205 text,
- treats `ErrLockWaitTimeout` as a whole-transaction rollback error so explicit multi-statement transactions release locks acquired by previous statements,
- changes the default `lock_wait_timeout` to 50 seconds, matching MySQL's default and preventing effectively infinite waits,
- adds unit coverage for timeout parsing, lock-wait timeout error conversion, shorter caller deadline preservation, and frontend whole-txn rollback classification.

## Validation

```bash
PROJECTROOT=/Users/shenjiangwei/Work/code/view/matrixone
export CGO_CFLAGS="-I$PROJECTROOT/cgo -I$PROJECTROOT/thirdparties/install/include"
export CGO_LDFLAGS="-Wl,-w,-rpath,$PROJECTROOT/thirdparties/install/lib -L$PROJECTROOT/thirdparties/install/lib -L$PROJECTROOT/cgo -lmo"
GOFLAGS=-mod=mod go test ./pkg/sql/colexec/lockop ./pkg/frontend ./pkg/common/moerr -run 'TestLock|TestConvertLockWaitTimeoutError|TestContextWithLockWaitTimeoutKeepsShorterExistingDeadline|TestLockWaitTimeoutFromValue|Test_isErrorRollbackWholeTxn|TestErrors' -count=1
GOFLAGS=-mod=mod go test ./pkg/sql/colexec/lockop ./pkg/frontend ./pkg/common/moerr -count=1
GOFLAGS=-mod=mod go test ./pkg/lockservice -count=1
```
