### PR TITLE
fix: enforce geometry subtype validation at INSERT/UPDATE bind time

### DIFF
--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -192,6 +192,12 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 					return 0, err
 				}
 
+				if isGeometryPlanType(&col.Typ) {
+					newDefExpr, err = funcCastForGeometryType(builder.GetContext(), newDefExpr, col.Typ)
+					if err != nil {
+						return 0, err
+					}
+				}
 				updateExprs[col.Name] = newDefExpr
 			}
 		}
@@ -1243,6 +1249,13 @@ func (builder *QueryBuilder) appendNodesForInsertStmt(
 				return 0, nil, nil, err
 			}
 
+			if isGeometryPlanType(&col.Typ) {
+				defExpr, err = funcCastForGeometryType(builder.GetContext(), defExpr, col.Typ)
+				if err != nil {
+					return 0, nil, nil, err
+				}
+			}
+
 			if !col.Typ.AutoIncr {
 				if lit := defExpr.GetLit(); lit != nil {
 					if lit.Isnull {
@@ -1391,6 +1404,12 @@ func (builder *QueryBuilder) buildValueScan(
 					defExpr, err = getDefaultExpr(builder.GetContext(), col)
 					if err != nil {
 						return 0, err
+					}
+					if isGeometryPlanType(&col.Typ) {
+						defExpr, err = funcCastForGeometryType(builder.GetContext(), defExpr, col.Typ)
+						if err != nil {
+							return 0, err
+						}
 					}
 				} else {
 					defExpr, err = binder.BindExpr(r[i], 0, true)

--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -170,9 +170,16 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 				}
 			}
 
-			updateExpr, err = forceCastExpr(builder.GetContext(), updateExpr, colDef.Typ)
-			if err != nil {
-				return 0, err
+			if isGeometryPlanType(&colDef.Typ) {
+				updateExpr, err = funcCastForGeometryType(builder.GetContext(), updateExpr, colDef.Typ)
+				if err != nil {
+					return 0, err
+				}
+			} else {
+				updateExpr, err = forceCastExpr(builder.GetContext(), updateExpr, colDef.Typ)
+				if err != nil {
+					return 0, err
+				}
 			}
 			updateExprs[colDef.Name] = updateExpr
 		}

--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -1129,6 +1129,11 @@ func (builder *QueryBuilder) initInsertReplaceStmt(bindCtx *BindContext, astRows
 			if err != nil {
 				return 0, nil, nil, err
 			}
+		} else if isGeometryPlanType(&tableDef.Cols[colIdx].Typ) {
+			projExpr, err = funcCastForGeometryType(builder.GetContext(), projExpr, tableDef.Cols[colIdx].Typ)
+			if err != nil {
+				return 0, nil, nil, err
+			}
 		} else {
 			projExpr, err = forceCastExpr(builder.GetContext(), projExpr, tableDef.Cols[colIdx].Typ)
 			if err != nil {
@@ -1387,6 +1392,11 @@ func (builder *QueryBuilder) buildValueScan(
 					}
 					if col.Typ.Id == int32(types.T_enum) {
 						defExpr, err = funcCastForEnumType(builder.GetContext(), defExpr, col.Typ)
+						if err != nil {
+							return 0, err
+						}
+					} else if isGeometryPlanType(&col.Typ) {
+						defExpr, err = funcCastForGeometryType(builder.GetContext(), defExpr, col.Typ)
 						if err != nil {
 							return 0, err
 						}

--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -213,6 +213,11 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 					if err != nil {
 						return 0, err
 					}
+				} else if col != nil && isGeometryPlanType(&col.Typ) {
+					selectNode.ProjectList[colPos], err = funcCastForGeometryType(builder.GetContext(), updateExpr, col.Typ)
+					if err != nil {
+						return 0, err
+					}
 				} else {
 					selectNode.ProjectList[colPos], err = forceCastExpr(builder.GetContext(), updateExpr, col.Typ)
 					if err != nil {
@@ -233,6 +238,11 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 
 				if col.Typ.Id == int32(types.T_enum) {
 					selectNode.ProjectList[originPos], err = funcCastForEnumType(builder.GetContext(), selectNode.ProjectList[originPos], col.Typ)
+					if err != nil {
+						return 0, err
+					}
+				} else if isGeometryPlanType(&col.Typ) {
+					selectNode.ProjectList[originPos], err = funcCastForGeometryType(builder.GetContext(), selectNode.ProjectList[originPos], col.Typ)
 					if err != nil {
 						return 0, err
 					}

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -529,6 +529,11 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 			if err != nil {
 				return false, nil, nil, err
 			}
+		} else if isGeometryPlanType(&tableDef.Cols[colIdx].Typ) {
+			projExpr, err = funcCastForGeometryType(builder.GetContext(), projExpr, tableDef.Cols[colIdx].Typ)
+			if err != nil {
+				return false, nil, nil, err
+			}
 		} else {
 			projExpr, err = forceCastExpr(builder.GetContext(), projExpr, tableDef.Cols[colIdx].Typ)
 			if err != nil {
@@ -1206,6 +1211,11 @@ func buildValueScan(
 					}
 					if col.Typ.Id == int32(types.T_enum) {
 						defExpr, err = funcCastForEnumType(builder.GetContext(), defExpr, col.Typ)
+						if err != nil {
+							return err
+						}
+					} else if isGeometryPlanType(&col.Typ) {
+						defExpr, err = funcCastForGeometryType(builder.GetContext(), defExpr, col.Typ)
 						if err != nil {
 							return err
 						}

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -608,6 +608,13 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 				return false, nil, nil, err
 			}
 
+			if isGeometryPlanType(&col.Typ) {
+				defExpr, err = funcCastForGeometryType(builder.GetContext(), defExpr, col.Typ)
+				if err != nil {
+					return false, nil, nil, err
+				}
+			}
+
 			if col.Typ.AutoIncr {
 				if _, ok := pkCols[col.Name]; ok {
 					existAutoPkCol = true
@@ -1179,6 +1186,12 @@ func buildValueScan(
 			if err != nil {
 				return err
 			}
+			if isGeometryPlanType(&col.Typ) {
+				defExpr, err = funcCastForGeometryType(builder.GetContext(), defExpr, col.Typ)
+				if err != nil {
+					return err
+				}
+			}
 			defExpr, err = forceCastExpr2(builder.GetContext(), defExpr, colTyp, targetTyp)
 			if err != nil {
 				return err
@@ -1210,6 +1223,12 @@ func buildValueScan(
 					defExpr, err = getDefaultExpr(builder.GetContext(), col)
 					if err != nil {
 						return err
+					}
+					if isGeometryPlanType(&col.Typ) {
+						defExpr, err = funcCastForGeometryType(builder.GetContext(), defExpr, col.Typ)
+						if err != nil {
+							return err
+						}
 					}
 				} else {
 					defExpr, err = binder.BindExpr(r[i], 0, true)

--- a/pkg/sql/plan/build_constraint_util.go
+++ b/pkg/sql/plan/build_constraint_util.go
@@ -714,9 +714,16 @@ func initInsertStmt(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Inse
 							return false, nil, nil, err
 						}
 					}
-					defExpr, err = forceCastExpr(builder.GetContext(), defExpr, col.Typ)
-					if err != nil {
-						return false, nil, nil, err
+					if isGeometryPlanType(&col.Typ) {
+						defExpr, err = funcCastForGeometryType(builder.GetContext(), defExpr, col.Typ)
+						if err != nil {
+							return false, nil, nil, err
+						}
+					} else {
+						defExpr, err = forceCastExpr(builder.GetContext(), defExpr, col.Typ)
+						if err != nil {
+							return false, nil, nil, err
+						}
 					}
 					updateExprs[col.Name] = defExpr
 				}

--- a/pkg/sql/plan/build_update.go
+++ b/pkg/sql/plan/build_update.go
@@ -135,6 +135,11 @@ func rewriteUpdateQueryLastNode(builder *QueryBuilder, planCtxs []*dmlPlanCtx, l
 					if err != nil {
 						return err
 					}
+				} else if col != nil && isGeometryPlanType(&col.Typ) {
+					lastNode.ProjectList[pos], err = funcCastForGeometryType(builder.GetContext(), posExpr, col.Typ)
+					if err != nil {
+						return err
+					}
 				} else {
 					lastNode.ProjectList[pos], err = forceCastExpr(builder.GetContext(), posExpr, col.Typ)
 					if err != nil {
@@ -155,6 +160,11 @@ func rewriteUpdateQueryLastNode(builder *QueryBuilder, planCtxs []*dmlPlanCtx, l
 
 				if col != nil && col.Typ.Id == int32(types.T_enum) {
 					lastNode.ProjectList[pos], err = funcCastForEnumType(builder.GetContext(), lastNode.ProjectList[pos], col.Typ)
+					if err != nil {
+						return err
+					}
+				} else if col != nil && isGeometryPlanType(&col.Typ) {
+					lastNode.ProjectList[pos], err = funcCastForGeometryType(builder.GetContext(), lastNode.ProjectList[pos], col.Typ)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/plan/function/func_geometry.go
+++ b/pkg/sql/plan/function/func_geometry.go
@@ -1,0 +1,714 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/functionUtil"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+func CastGeometryToSubtype(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	return opBinaryBytesBytesToBytesWithErrorCheck(ivecs, result, proc, length, func(targetSubtype, payload []byte) ([]byte, error) {
+		columnMetadata := strings.TrimSpace(functionUtil.QuickBytesToStr(targetSubtype))
+		columnSubtype := ""
+		columnSRID := uint32(0)
+		columnSRIDDefined := false
+		if columnMetadata != "" {
+			parts := strings.Split(columnMetadata, ";")
+			head := strings.TrimSpace(parts[0])
+			if head != "" && !strings.HasPrefix(strings.ToUpper(head), "SRID=") {
+				columnSubtype = strings.ToUpper(head)
+			}
+			start := 0
+			if columnSubtype != "" {
+				start = 1
+			}
+			for _, part := range parts[start:] {
+				part = strings.TrimSpace(part)
+				if len(part) < len("SRID=") || !strings.EqualFold(part[:5], "SRID=") {
+					continue
+				}
+				parsed, err := strconv.ParseUint(strings.TrimSpace(part[5:]), 10, 32)
+				if err == nil {
+					columnSRID = uint32(parsed)
+					columnSRIDDefined = true
+					break
+				}
+			}
+		}
+
+		wkt, valueSubtype, valueSRID, valueSRIDDefined, err := validateGeometryPayload(payload, maxPointsInGeometryLimit(proc))
+		if err != nil {
+			return nil, err
+		}
+		if columnSubtype != "" && columnSubtype != "GEOMETRY" && valueSubtype != "GEOMETRY" && valueSubtype != columnSubtype {
+			return nil, moerr.NewInvalidInputNoCtxf("cannot store %s in %s column", valueSubtype, columnSubtype)
+		}
+
+		if !columnSRIDDefined {
+			return payload, nil
+		}
+		if !valueSRIDDefined {
+			valueSRID = 0
+		}
+		if valueSRID != columnSRID {
+			columnLabel := columnSubtype
+			if columnLabel == "" {
+				columnLabel = "GEOMETRY"
+			}
+			return nil, moerr.NewInvalidInputNoCtxf(
+				"The SRID of the geometry does not match the SRID of the column '%s'. The SRID of the geometry is %d, but the SRID of the column is %d. Consider changing the SRID of the geometry or the SRID property of the column.",
+				columnLabel,
+				valueSRID,
+				columnSRID,
+			)
+		}
+		if valueSRIDDefined {
+			return payload, nil
+		}
+		return encodeGeometryPayload(wkt, columnSRID, true), nil
+	}, selectList)
+}
+
+func encodeGeometryPayload(wkt string, srid uint32, sridDefined bool) []byte {
+	wkt = strings.TrimSpace(wkt)
+	if !sridDefined {
+		return functionUtil.QuickStrToBytes(wkt)
+	}
+	return functionUtil.QuickStrToBytes(fmt.Sprintf("SRID=%d;%s", srid, wkt))
+}
+
+func decodeGeometryPayload(payload []byte) (wkt string, srid uint32, sridDefined bool, err error) {
+	s := strings.TrimSpace(functionUtil.QuickBytesToStr(payload))
+	if len(s) == 0 {
+		return "", 0, false, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	upper := strings.ToUpper(s)
+	if !strings.HasPrefix(upper, "SRID=") {
+		return s, 0, false, nil
+	}
+
+	sepIdx := strings.IndexByte(s, ';')
+	if sepIdx <= len("SRID=") || sepIdx == len(s)-1 {
+		return "", 0, false, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	value := strings.TrimSpace(s[len("SRID="):sepIdx])
+	parsed, parseErr := strconv.ParseUint(value, 10, 32)
+	if parseErr != nil {
+		return "", 0, false, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	wkt = strings.TrimSpace(s[sepIdx+1:])
+	if wkt == "" {
+		return "", 0, false, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	return wkt, uint32(parsed), true, nil
+}
+
+func geometryTypeNameFromText(wkt string) (string, error) {
+	s := strings.TrimSpace(wkt)
+	if len(s) == 0 {
+		return "", moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	upper := strings.ToUpper(s)
+	if strings.HasSuffix(upper, " EMPTY") {
+		typeName := strings.TrimSpace(strings.TrimSuffix(upper, " EMPTY"))
+		switch typeName {
+		case "POINT", "LINESTRING", "POLYGON", "MULTIPOINT", "MULTILINESTRING", "MULTIPOLYGON", "GEOMETRYCOLLECTION":
+			return typeName, nil
+		default:
+			return "", moerr.NewInvalidInputNoCtx("invalid geometry type")
+		}
+	}
+	openIdx := strings.IndexByte(s, '(')
+	if openIdx <= 0 {
+		return "", moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	typeName := strings.TrimSpace(upper[:openIdx])
+	switch typeName {
+	case "POINT", "LINESTRING", "POLYGON", "MULTIPOINT", "MULTILINESTRING", "MULTIPOLYGON", "GEOMETRYCOLLECTION":
+		return typeName, nil
+	case "GEOMETRY":
+		return typeName, nil
+	default:
+		return "", moerr.NewInvalidInputNoCtx("invalid geometry type")
+	}
+}
+
+const defaultMaxPointsInGeometry = int64(65536)
+
+func validateGeometryPayload(payload []byte, maxPoints int64) (wkt string, typeName string, srid uint32, sridDefined bool, err error) {
+	wkt, srid, sridDefined, err = decodeGeometryPayload(payload)
+	if err != nil {
+		return "", "", 0, false, err
+	}
+	typeName, err = geometryTypeNameFromText(wkt)
+	if err != nil {
+		return "", "", 0, false, err
+	}
+	if err = validateGeometryTextForStorage(wkt, maxPoints); err != nil {
+		return "", "", 0, false, err
+	}
+	return wkt, typeName, srid, sridDefined, nil
+}
+
+func maxPointsInGeometryLimit(proc *process.Process) int64 {
+	if proc != nil && proc.GetResolveVariableFunc() != nil {
+		if v, err := proc.GetResolveVariableFunc()("max_points_in_geometry", true, false); err == nil && v != nil {
+			switch val := v.(type) {
+			case int64:
+				return val
+			case int32:
+				return int64(val)
+			case uint64:
+				return int64(val)
+			case uint32:
+				return int64(val)
+			case int:
+				return int64(val)
+			case uint:
+				return int64(val)
+			}
+		}
+	}
+	return defaultMaxPointsInGeometry
+}
+
+func validateGeometryTextForStorage(wkt string, maxPoints int64) error {
+	if err := validateGeometryTextStructure(wkt); err != nil {
+		return err
+	}
+	if err := validateFiniteCoordinatesInGeometryText(wkt); err != nil {
+		return err
+	}
+	if maxPoints <= 0 {
+		return nil
+	}
+	pointCount, err := geometryPointCountFromText(wkt)
+	if err != nil {
+		return err
+	}
+	if pointCount > maxPoints {
+		return moerr.NewInvalidInputNoCtxf("geometry has %d points, which exceeds max_points_in_geometry=%d", pointCount, maxPoints)
+	}
+	return nil
+}
+
+func validateGeometryTextStructure(wkt string) error {
+	return validateGeometryTextStructureWithDepth(wkt, 0)
+}
+
+func validateGeometryTextStructureWithDepth(wkt string, depth int) error {
+	s := strings.TrimSpace(wkt)
+	typeName, err := geometryTypeNameFromText(s)
+	if err != nil {
+		return err
+	}
+
+	if strings.EqualFold(strings.TrimSpace(s), typeName+" EMPTY") {
+		return nil
+	}
+
+	openIdx := strings.IndexByte(s, '(')
+	if openIdx <= 0 || s[len(s)-1] != ')' {
+		return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	if strings.TrimSpace(strings.ToUpper(s[:openIdx])) != typeName {
+		return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+
+	content := strings.TrimSpace(s[openIdx+1 : len(s)-1])
+	switch typeName {
+	case "POINT":
+		return validatePointGeometryTextContent(content)
+	case "LINESTRING":
+		return validateLineStringGeometryTextContent(content)
+	case "POLYGON":
+		return validatePolygonGeometryTextContent(content)
+	case "MULTIPOINT":
+		return validateMultiPointGeometryTextContent(content, depth)
+	case "MULTILINESTRING":
+		return validateMultiLineStringGeometryTextContent(content)
+	case "MULTIPOLYGON":
+		return validateMultiPolygonGeometryTextContent(content)
+	case "GEOMETRYCOLLECTION":
+		return validateGeometryCollectionTextContent(content, depth)
+	case "GEOMETRY":
+		return validateGenericGeometryTextContent(content, depth)
+	default:
+		return moerr.NewInvalidInputNoCtx("invalid geometry type")
+	}
+}
+
+func validatePointGeometryTextContent(content string) error {
+	if content == "" {
+		return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	_, _, err := parseCoordinatePairWithError(content, "invalid geometry payload")
+	return err
+}
+
+func validateLineStringGeometryTextContent(content string) error {
+	points, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return err
+	}
+	if len(points) < 2 {
+		return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	for _, point := range points {
+		if _, _, err := parseCoordinatePairWithError(point, "invalid geometry payload"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePolygonGeometryTextContent(content string) error {
+	rings, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return err
+	}
+	for _, ring := range rings {
+		ring = strings.TrimSpace(ring)
+		if len(ring) < 2 || ring[0] != '(' || ring[len(ring)-1] != ')' {
+			return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+		}
+		if err := validatePolygonRingTextContent(ring[1 : len(ring)-1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePolygonRingTextContent(content string) error {
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return err
+	}
+	if len(items) < 3 {
+		return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+
+	points := make([]geometryPoint2D, 0, len(items))
+	for _, item := range items {
+		x, y, err := parseCoordinatePairWithError(item, "invalid geometry payload")
+		if err != nil {
+			return err
+		}
+		points = append(points, geometryPoint2D{x: x, y: y})
+	}
+
+	if len(points) > 1 && sameGeometryPoint(points[0], points[len(points)-1]) {
+		points = points[:len(points)-1]
+	}
+	if len(points) < 3 {
+		return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	return nil
+}
+
+func validateMultiPointGeometryTextContent(content string, depth int) error {
+	if content == "" {
+		return nil
+	}
+
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+		}
+		if itemType, err := geometryTypeNameFromText(item); err == nil {
+			if itemType != "POINT" {
+				return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+			}
+			if err := validateGeometryTextStructureWithDepth(item, depth+1); err != nil {
+				return err
+			}
+			continue
+		}
+		if strings.HasPrefix(item, "(") {
+			if len(item) < 2 || item[len(item)-1] != ')' {
+				return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+			}
+			if err := validatePointGeometryTextContent(strings.TrimSpace(item[1 : len(item)-1])); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := validatePointGeometryTextContent(item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateMultiLineStringGeometryTextContent(content string) error {
+	if content == "" {
+		return nil
+	}
+
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if len(item) < 2 || item[0] != '(' || item[len(item)-1] != ')' {
+			return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+		}
+		if err := validateLineStringGeometryTextContent(strings.TrimSpace(item[1 : len(item)-1])); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateMultiPolygonGeometryTextContent(content string) error {
+	if content == "" {
+		return nil
+	}
+
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if len(item) < 2 || item[0] != '(' || item[len(item)-1] != ')' {
+			return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+		}
+		if err := validatePolygonGeometryTextContent(strings.TrimSpace(item[1 : len(item)-1])); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+const maxGeometryCollectionNestingDepth = 64
+
+func validateGeometryCollectionTextContent(content string, depth int) error {
+	if depth >= maxGeometryCollectionNestingDepth {
+		return moerr.NewInvalidInputNoCtxf("geometry collection nesting depth exceeds %d", maxGeometryCollectionNestingDepth)
+	}
+	if content == "" {
+		return nil
+	}
+
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		if err := validateGeometryTextStructureWithDepth(item, depth+1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateGenericGeometryTextContent(content string, depth int) error {
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return err
+	}
+	if len(items) != 1 {
+		return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	return validateGeometryTextStructureWithDepth(items[0], depth+1)
+}
+
+func validateFiniteCoordinatesInGeometryText(wkt string) error {
+	tokens := strings.FieldsFunc(wkt, func(r rune) bool {
+		switch r {
+		case '(', ')', ',', ' ', '\t', '\n', '\r':
+			return true
+		default:
+			return false
+		}
+	})
+	for _, token := range tokens {
+		if token == "" {
+			continue
+		}
+		value, err := strconv.ParseFloat(token, 64)
+		if !math.IsNaN(value) && !math.IsInf(value, 0) {
+			continue
+		}
+		if err == nil || math.IsNaN(value) || math.IsInf(value, 0) {
+			return moerr.NewInvalidInputNoCtx("invalid geometry payload")
+		}
+	}
+	return nil
+}
+
+func geometryPointCountFromText(wkt string) (int64, error) {
+	return geometryPointCountFromTextWithDepth(wkt, 0)
+}
+
+func geometryPointCountFromTextWithDepth(wkt string, depth int) (int64, error) {
+	s := strings.TrimSpace(wkt)
+	typeName, err := geometryTypeNameFromText(s)
+	if err != nil {
+		return 0, err
+	}
+	if strings.EqualFold(strings.TrimSpace(s), typeName+" EMPTY") {
+		return 0, nil
+	}
+
+	openIdx := strings.IndexByte(s, '(')
+	if openIdx <= 0 || s[len(s)-1] != ')' {
+		return 0, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	if strings.TrimSpace(strings.ToUpper(s[:openIdx])) != typeName {
+		return 0, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+
+	content := strings.TrimSpace(s[openIdx+1 : len(s)-1])
+	switch typeName {
+	case "POINT":
+		if content == "" {
+			return 0, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+		}
+		return 1, nil
+	case "LINESTRING":
+		return coordinateListPointCount(content)
+	case "POLYGON":
+		return polygonPointCountFromTextContent(content)
+	case "MULTIPOINT":
+		return multiPointCountFromTextContent(content, depth)
+	case "MULTILINESTRING":
+		return multiLineStringPointCountFromTextContent(content)
+	case "MULTIPOLYGON":
+		return multiPolygonPointCountFromTextContent(content)
+	case "GEOMETRYCOLLECTION":
+		return geometryCollectionPointCountFromTextContent(content, depth)
+	case "GEOMETRY":
+		return genericGeometryPointCountFromTextContent(content, depth)
+	default:
+		return 0, moerr.NewInvalidInputNoCtx("invalid geometry type")
+	}
+}
+
+func coordinateListPointCount(content string) (int64, error) {
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(items)), nil
+}
+
+func polygonPointCountFromTextContent(content string) (int64, error) {
+	rings, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return 0, err
+	}
+	total := int64(0)
+	for _, ring := range rings {
+		ring = strings.TrimSpace(ring)
+		if len(ring) < 2 || ring[0] != '(' || ring[len(ring)-1] != ')' {
+			return 0, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+		}
+		count, err := coordinateListPointCount(strings.TrimSpace(ring[1 : len(ring)-1]))
+		if err != nil {
+			return 0, err
+		}
+		total += count
+	}
+	return total, nil
+}
+
+func multiPointCountFromTextContent(content string, depth int) (int64, error) {
+	if content == "" {
+		return 0, nil
+	}
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return 0, err
+	}
+	total := int64(0)
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if itemType, err := geometryTypeNameFromText(item); err == nil {
+			if itemType != "POINT" {
+				return 0, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+			}
+			count, err := geometryPointCountFromTextWithDepth(item, depth+1)
+			if err != nil {
+				return 0, err
+			}
+			total += count
+			continue
+		}
+		total++
+	}
+	return total, nil
+}
+
+func multiLineStringPointCountFromTextContent(content string) (int64, error) {
+	if content == "" {
+		return 0, nil
+	}
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return 0, err
+	}
+	total := int64(0)
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if len(item) < 2 || item[0] != '(' || item[len(item)-1] != ')' {
+			return 0, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+		}
+		count, err := coordinateListPointCount(strings.TrimSpace(item[1 : len(item)-1]))
+		if err != nil {
+			return 0, err
+		}
+		total += count
+	}
+	return total, nil
+}
+
+func multiPolygonPointCountFromTextContent(content string) (int64, error) {
+	if content == "" {
+		return 0, nil
+	}
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return 0, err
+	}
+	total := int64(0)
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if len(item) < 2 || item[0] != '(' || item[len(item)-1] != ')' {
+			return 0, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+		}
+		count, err := polygonPointCountFromTextContent(strings.TrimSpace(item[1 : len(item)-1]))
+		if err != nil {
+			return 0, err
+		}
+		total += count
+	}
+	return total, nil
+}
+
+func geometryCollectionPointCountFromTextContent(content string, depth int) (int64, error) {
+	if content == "" {
+		return 0, nil
+	}
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return 0, err
+	}
+	total := int64(0)
+	for _, item := range items {
+		count, err := geometryPointCountFromTextWithDepth(item, depth+1)
+		if err != nil {
+			return 0, err
+		}
+		total += count
+	}
+	return total, nil
+}
+
+func genericGeometryPointCountFromTextContent(content string, depth int) (int64, error) {
+	items, err := splitTopLevelGeometryItemsStrict(content, "invalid geometry payload")
+	if err != nil {
+		return 0, err
+	}
+	if len(items) != 1 {
+		return 0, moerr.NewInvalidInputNoCtx("invalid geometry payload")
+	}
+	return geometryPointCountFromTextWithDepth(items[0], depth+1)
+}
+
+func splitTopLevelGeometryItemsStrict(content string, errMsg string) ([]string, error) {
+	items := make([]string, 0)
+	depth := 0
+	start := 0
+	for i, r := range content {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return nil, moerr.NewInvalidInputNoCtx(errMsg)
+			}
+		case ',':
+			if depth == 0 {
+				item := strings.TrimSpace(content[start:i])
+				if item == "" {
+					return nil, moerr.NewInvalidInputNoCtx(errMsg)
+				}
+				items = append(items, item)
+				start = i + 1
+			}
+		}
+	}
+	if depth != 0 {
+		return nil, moerr.NewInvalidInputNoCtx(errMsg)
+	}
+	last := strings.TrimSpace(content[start:])
+	if last == "" {
+		return nil, moerr.NewInvalidInputNoCtx(errMsg)
+	}
+	items = append(items, last)
+	return items, nil
+}
+
+func parseFiniteCoordinate(token string, errMsg string) (float64, error) {
+	value, err := strconv.ParseFloat(token, 64)
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, moerr.NewInvalidInputNoCtx(errMsg)
+	}
+	return value, nil
+}
+
+func parseCoordinatePairWithError(point string, errMsg string) (float64, float64, error) {
+	coords := strings.Fields(strings.TrimSpace(point))
+	if len(coords) != 2 {
+		return 0, 0, moerr.NewInvalidInputNoCtx(errMsg)
+	}
+
+	x, err := parseFiniteCoordinate(coords[0], errMsg)
+	if err != nil {
+		return 0, 0, moerr.NewInvalidInputNoCtx(errMsg)
+	}
+	y, err := parseFiniteCoordinate(coords[1], errMsg)
+	if err != nil {
+		return 0, 0, moerr.NewInvalidInputNoCtx(errMsg)
+	}
+	return x, y, nil
+}
+
+type geometryPoint2D struct {
+	x float64
+	y float64
+}
+
+func sameGeometryPoint(a, b geometryPoint2D) bool {
+	const epsilon = 1e-9
+	return math.Abs(a.x-b.x) <= epsilon && math.Abs(a.y-b.y) <= epsilon
+}

--- a/pkg/sql/plan/function/func_geometry.go
+++ b/pkg/sql/plan/function/func_geometry.go
@@ -60,7 +60,7 @@ func CastGeometryToSubtype(ivecs []*vector.Vector, result vector.FunctionResultW
 		if err != nil {
 			return nil, err
 		}
-		if columnSubtype != "" && columnSubtype != "GEOMETRY" && valueSubtype != "GEOMETRY" && valueSubtype != columnSubtype {
+		if columnSubtype != "" && columnSubtype != "GEOMETRY" && valueSubtype != columnSubtype {
 			return nil, moerr.NewInvalidInputNoCtxf("cannot store %s in %s column", valueSubtype, columnSubtype)
 		}
 

--- a/pkg/sql/plan/function/func_geometry_test.go
+++ b/pkg/sql/plan/function/func_geometry_test.go
@@ -130,3 +130,15 @@ func TestCastGeometryToSubtypeRejectNonFinite(t *testing.T) {
 	succeed, info := tcc.Run()
 	require.True(t, succeed, info)
 }
+
+func TestCastGeometryToSubtypeRejectGeometryWrapper(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	inputs := []FunctionTestInput{
+		NewFunctionTestInput(types.T_varchar.ToType(), []string{"POINT"}, nil),
+		NewFunctionTestInput(types.T_geometry.ToType(), []string{"GEOMETRY(LINESTRING(0 0, 1 1))"}, nil),
+	}
+	expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+	tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, info)
+}

--- a/pkg/sql/plan/function/func_geometry_test.go
+++ b/pkg/sql/plan/function/func_geometry_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCastGeometryToSubtype(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	cases := []struct {
+		name      string
+		subtype   string
+		payload   string
+		wantErr   bool
+		wantValue string
+	}{
+		{
+			name:      "POINT matches POINT column",
+			subtype:   "POINT",
+			payload:   "POINT(1 2)",
+			wantErr:   false,
+			wantValue: "POINT(1 2)",
+		},
+		{
+			name:      "LINESTRING matches LINESTRING column",
+			subtype:   "LINESTRING",
+			payload:   "LINESTRING(0 0, 1 1)",
+			wantErr:   false,
+			wantValue: "LINESTRING(0 0, 1 1)",
+		},
+		{
+			name:    "LINESTRING rejected in POINT column",
+			subtype: "POINT",
+			payload: "LINESTRING(0 0, 1 1)",
+			wantErr: true,
+		},
+		{
+			name:    "POINT rejected in POLYGON column",
+			subtype: "POLYGON",
+			payload: "POINT(1 2)",
+			wantErr: true,
+		},
+		{
+			name:      "any subtype allowed in GEOMETRY column",
+			subtype:   "GEOMETRY",
+			payload:   "LINESTRING(0 0, 1 1)",
+			wantErr:   false,
+			wantValue: "LINESTRING(0 0, 1 1)",
+		},
+		{
+			name:      "any subtype allowed when column has no subtype constraint",
+			subtype:   "",
+			payload:   "POLYGON((0 0, 1 0, 1 1, 0 0))",
+			wantErr:   false,
+			wantValue: "POLYGON((0 0, 1 0, 1 1, 0 0))",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{tc.subtype}, nil),
+				NewFunctionTestInput(types.T_geometry.ToType(), []string{tc.payload}, nil),
+			}
+			if tc.wantErr {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			} else {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), false, []string{tc.wantValue}, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			}
+		})
+	}
+}
+
+func TestCastGeometryToSubtypeRejectSRIDMismatch(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	inputs := []FunctionTestInput{
+		NewFunctionTestInput(types.T_varchar.ToType(), []string{"POINT;SRID=4326"}, nil),
+		NewFunctionTestInput(types.T_geometry.ToType(), []string{"SRID=0;POINT(1 2)"}, nil),
+	}
+	expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+	tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, info)
+}
+
+func TestCastGeometryToSubtypeRejectMalformedStructure(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	inputs := []FunctionTestInput{
+		NewFunctionTestInput(types.T_varchar.ToType(), []string{"POINT"}, nil),
+		NewFunctionTestInput(types.T_geometry.ToType(), []string{"POINT("}, nil),
+	}
+	expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+	tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, info)
+}
+
+func TestCastGeometryToSubtypeRejectNonFinite(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	inputs := []FunctionTestInput{
+		NewFunctionTestInput(types.T_varchar.ToType(), []string{"POINT"}, nil),
+		NewFunctionTestInput(types.T_geometry.ToType(), []string{"POINT(Inf 0)"}, nil),
+	}
+	expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+	tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, info)
+}

--- a/pkg/sql/plan/function/func_geometry_test.go
+++ b/pkg/sql/plan/function/func_geometry_test.go
@@ -47,6 +47,41 @@ func TestCastGeometryToSubtype(t *testing.T) {
 			wantValue: "LINESTRING(0 0, 1 1)",
 		},
 		{
+			name:      "POLYGON matches POLYGON column",
+			subtype:   "POLYGON",
+			payload:   "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+			wantErr:   false,
+			wantValue: "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))",
+		},
+		{
+			name:      "MULTIPOINT matches MULTIPOINT column",
+			subtype:   "MULTIPOINT",
+			payload:   "MULTIPOINT((0 0), (1 1))",
+			wantErr:   false,
+			wantValue: "MULTIPOINT((0 0), (1 1))",
+		},
+		{
+			name:      "MULTILINESTRING matches MULTILINESTRING column",
+			subtype:   "MULTILINESTRING",
+			payload:   "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+			wantErr:   false,
+			wantValue: "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+		},
+		{
+			name:      "MULTIPOLYGON matches MULTIPOLYGON column",
+			subtype:   "MULTIPOLYGON",
+			payload:   "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 0)))",
+			wantErr:   false,
+			wantValue: "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 0)))",
+		},
+		{
+			name:      "GEOMETRYCOLLECTION matches GEOMETRYCOLLECTION column",
+			subtype:   "GEOMETRYCOLLECTION",
+			payload:   "GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(0 0, 1 1))",
+			wantErr:   false,
+			wantValue: "GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(0 0, 1 1))",
+		},
+		{
 			name:    "LINESTRING rejected in POINT column",
 			subtype: "POINT",
 			payload: "LINESTRING(0 0, 1 1)",
@@ -72,6 +107,20 @@ func TestCastGeometryToSubtype(t *testing.T) {
 			wantErr:   false,
 			wantValue: "POLYGON((0 0, 1 0, 1 1, 0 0))",
 		},
+		{
+			name:      "POINT EMPTY accepted in POINT column",
+			subtype:   "POINT",
+			payload:   "POINT EMPTY",
+			wantErr:   false,
+			wantValue: "POINT EMPTY",
+		},
+		{
+			name:      "GEOMETRYCOLLECTION EMPTY accepted",
+			subtype:   "GEOMETRYCOLLECTION",
+			payload:   "GEOMETRYCOLLECTION EMPTY",
+			wantErr:   false,
+			wantValue: "GEOMETRYCOLLECTION EMPTY",
+		},
 	}
 
 	for _, tc := range cases {
@@ -95,49 +144,112 @@ func TestCastGeometryToSubtype(t *testing.T) {
 	}
 }
 
-func TestCastGeometryToSubtypeRejectSRIDMismatch(t *testing.T) {
+func TestCastGeometryToSubtypeSRID(t *testing.T) {
 	proc := testutil.NewProcess(t)
-	inputs := []FunctionTestInput{
-		NewFunctionTestInput(types.T_varchar.ToType(), []string{"POINT;SRID=4326"}, nil),
-		NewFunctionTestInput(types.T_geometry.ToType(), []string{"SRID=0;POINT(1 2)"}, nil),
+
+	cases := []struct {
+		name      string
+		subtype   string
+		payload   string
+		wantErr   bool
+		wantValue string
+	}{
+		{
+			name:    "SRID mismatch rejected",
+			subtype: "POINT;SRID=4326",
+			payload: "SRID=0;POINT(1 2)",
+			wantErr: true,
+		},
+		{
+			name:      "SRID matches",
+			subtype:   "POINT;SRID=4326",
+			payload:   "SRID=4326;POINT(1 2)",
+			wantErr:   false,
+			wantValue: "SRID=4326;POINT(1 2)",
+		},
+		{
+			name:    "no SRID in value rejected when column requires SRID",
+			subtype: "POINT;SRID=4326",
+			payload: "POINT(1 2)",
+			wantErr: true,
+		},
+		{
+			name:    "value has SRID but column expects different",
+			subtype: ";SRID=4326",
+			payload: "SRID=3857;POINT(1 2)",
+			wantErr: true,
+		},
+		{
+			name:      "no column SRID allows any value SRID",
+			subtype:   "POINT",
+			payload:   "SRID=4326;POINT(1 2)",
+			wantErr:   false,
+			wantValue: "SRID=4326;POINT(1 2)",
+		},
 	}
-	expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
-	tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
-	succeed, info := tcc.Run()
-	require.True(t, succeed, info)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{tc.subtype}, nil),
+				NewFunctionTestInput(types.T_geometry.ToType(), []string{tc.payload}, nil),
+			}
+			if tc.wantErr {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			} else {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), false, []string{tc.wantValue}, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			}
+		})
+	}
 }
 
-func TestCastGeometryToSubtypeRejectMalformedStructure(t *testing.T) {
+func TestCastGeometryToSubtypeRejectMalformed(t *testing.T) {
 	proc := testutil.NewProcess(t)
-	inputs := []FunctionTestInput{
-		NewFunctionTestInput(types.T_varchar.ToType(), []string{"POINT"}, nil),
-		NewFunctionTestInput(types.T_geometry.ToType(), []string{"POINT("}, nil),
+
+	cases := []struct {
+		name    string
+		subtype string
+		payload string
+	}{
+		{name: "unclosed paren", subtype: "POINT", payload: "POINT("},
+		{name: "empty payload", subtype: "POINT", payload: ""},
+		{name: "invalid type name", subtype: "POINT", payload: "FOOBAR(1 2)"},
+		{name: "non-finite Inf", subtype: "POINT", payload: "POINT(Inf 0)"},
+		{name: "non-finite NaN", subtype: "POINT", payload: "POINT(NaN 0)"},
+		{name: "linestring too few points", subtype: "LINESTRING", payload: "LINESTRING(0 0)"},
+		{name: "polygon ring too few points", subtype: "POLYGON", payload: "POLYGON((0 0, 1 0))"},
+		{name: "malformed SRID prefix", subtype: "POINT", payload: "SRID=;POINT(1 2)"},
+		{name: "GEOMETRY wrapper rejected in POINT column", subtype: "POINT", payload: "GEOMETRY(LINESTRING(0 0, 1 1))"},
+		{name: "three coords in point", subtype: "POINT", payload: "POINT(1 2 3)"},
 	}
-	expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
-	tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
-	succeed, info := tcc.Run()
-	require.True(t, succeed, info)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{tc.subtype}, nil),
+				NewFunctionTestInput(types.T_geometry.ToType(), []string{tc.payload}, nil),
+			}
+			expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+			tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+			succeed, info := tcc.Run()
+			require.True(t, succeed, info)
+		})
+	}
 }
 
-func TestCastGeometryToSubtypeRejectNonFinite(t *testing.T) {
+func TestCastGeometryToSubtypeNull(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	inputs := []FunctionTestInput{
-		NewFunctionTestInput(types.T_varchar.ToType(), []string{"POINT"}, nil),
-		NewFunctionTestInput(types.T_geometry.ToType(), []string{"POINT(Inf 0)"}, nil),
+		NewFunctionTestInput(types.T_varchar.ToType(), []string{"POINT"}, []bool{false}),
+		NewFunctionTestInput(types.T_geometry.ToType(), []string{""}, []bool{true}),
 	}
-	expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
-	tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
-	succeed, info := tcc.Run()
-	require.True(t, succeed, info)
-}
-
-func TestCastGeometryToSubtypeRejectGeometryWrapper(t *testing.T) {
-	proc := testutil.NewProcess(t)
-	inputs := []FunctionTestInput{
-		NewFunctionTestInput(types.T_varchar.ToType(), []string{"POINT"}, nil),
-		NewFunctionTestInput(types.T_geometry.ToType(), []string{"GEOMETRY(LINESTRING(0 0, 1 1))"}, nil),
-	}
-	expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+	expect := NewFunctionTestResult(types.T_geometry.ToType(), false, []string{""}, []bool{true})
 	tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
 	succeed, info := tcc.Run()
 	require.True(t, succeed, info)

--- a/pkg/sql/plan/function/func_geometry_test.go
+++ b/pkg/sql/plan/function/func_geometry_test.go
@@ -254,3 +254,506 @@ func TestCastGeometryToSubtypeNull(t *testing.T) {
 	succeed, info := tcc.Run()
 	require.True(t, succeed, info)
 }
+
+func TestCastGeometryToSubtypeSRIDAssign(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	// value SRID=0, column SRID=0 => should pass and assign SRID
+	inputs := []FunctionTestInput{
+		NewFunctionTestInput(types.T_varchar.ToType(), []string{"POINT;SRID=0"}, nil),
+		NewFunctionTestInput(types.T_geometry.ToType(), []string{"POINT(1 2)"}, nil),
+	}
+	expect := NewFunctionTestResult(types.T_geometry.ToType(), false, []string{"SRID=0;POINT(1 2)"}, nil)
+	tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, info)
+}
+
+func TestCastGeometryToSubtypeMultiPointValidation(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	cases := []struct {
+		name    string
+		subtype string
+		payload string
+		wantErr bool
+		want    string
+	}{
+		{
+			name:    "multipoint with bare coords",
+			subtype: "MULTIPOINT",
+			payload: "MULTIPOINT(0 0, 1 1, 2 2)",
+			wantErr: false,
+			want:    "MULTIPOINT(0 0, 1 1, 2 2)",
+		},
+		{
+			name:    "multipoint empty content",
+			subtype: "MULTIPOINT",
+			payload: "MULTIPOINT EMPTY",
+			wantErr: false,
+			want:    "MULTIPOINT EMPTY",
+		},
+		{
+			name:    "multipoint with nested POINT keyword",
+			subtype: "MULTIPOINT",
+			payload: "MULTIPOINT(POINT(0 0), POINT(1 1))",
+			wantErr: false,
+			want:    "MULTIPOINT(POINT(0 0), POINT(1 1))",
+		},
+		{
+			name:    "multipoint with parenthesized coords",
+			subtype: "MULTIPOINT",
+			payload: "MULTIPOINT((0 0), (1 1))",
+			wantErr: false,
+			want:    "MULTIPOINT((0 0), (1 1))",
+		},
+		{
+			name:    "multipoint with invalid nested type",
+			subtype: "MULTIPOINT",
+			payload: "MULTIPOINT(LINESTRING(0 0, 1 1))",
+			wantErr: true,
+		},
+		{
+			name:    "multipoint with malformed parens",
+			subtype: "MULTIPOINT",
+			payload: "MULTIPOINT((0 0)",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{tc.subtype}, nil),
+				NewFunctionTestInput(types.T_geometry.ToType(), []string{tc.payload}, nil),
+			}
+			if tc.wantErr {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			} else {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), false, []string{tc.want}, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			}
+		})
+	}
+}
+
+func TestCastGeometryToSubtypeMultiLineStringValidation(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	cases := []struct {
+		name    string
+		payload string
+		wantErr bool
+		want    string
+	}{
+		{
+			name:    "valid multilinestring",
+			payload: "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+			wantErr: false,
+			want:    "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+		},
+		{
+			name:    "multilinestring empty",
+			payload: "MULTILINESTRING EMPTY",
+			wantErr: false,
+			want:    "MULTILINESTRING EMPTY",
+		},
+		{
+			name:    "multilinestring missing inner parens",
+			payload: "MULTILINESTRING(0 0, 1 1)",
+			wantErr: true,
+		},
+		{
+			name:    "multilinestring inner too few points",
+			payload: "MULTILINESTRING((0 0))",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"MULTILINESTRING"}, nil),
+				NewFunctionTestInput(types.T_geometry.ToType(), []string{tc.payload}, nil),
+			}
+			if tc.wantErr {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			} else {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), false, []string{tc.want}, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			}
+		})
+	}
+}
+
+func TestCastGeometryToSubtypeMultiPolygonValidation(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	cases := []struct {
+		name    string
+		payload string
+		wantErr bool
+		want    string
+	}{
+		{
+			name:    "valid multipolygon",
+			payload: "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 0)), ((2 2, 3 2, 3 3, 2 2)))",
+			wantErr: false,
+			want:    "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 0)), ((2 2, 3 2, 3 3, 2 2)))",
+		},
+		{
+			name:    "multipolygon empty",
+			payload: "MULTIPOLYGON EMPTY",
+			wantErr: false,
+			want:    "MULTIPOLYGON EMPTY",
+		},
+		{
+			name:    "multipolygon missing inner parens",
+			payload: "MULTIPOLYGON((0 0, 1 0, 1 1, 0 0))",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"MULTIPOLYGON"}, nil),
+				NewFunctionTestInput(types.T_geometry.ToType(), []string{tc.payload}, nil),
+			}
+			if tc.wantErr {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			} else {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), false, []string{tc.want}, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			}
+		})
+	}
+}
+
+func TestCastGeometryToSubtypeGeometryCollectionValidation(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	cases := []struct {
+		name    string
+		payload string
+		wantErr bool
+		want    string
+	}{
+		{
+			name:    "nested collection",
+			payload: "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(0 0)))",
+			wantErr: false,
+			want:    "GEOMETRYCOLLECTION(GEOMETRYCOLLECTION(POINT(0 0)))",
+		},
+		{
+			name:    "collection with multiple types",
+			payload: "GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(0 0, 1 1), POLYGON((0 0, 1 0, 1 1, 0 0)))",
+			wantErr: false,
+			want:    "GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(0 0, 1 1), POLYGON((0 0, 1 0, 1 1, 0 0)))",
+		},
+		{
+			name:    "empty collection",
+			payload: "GEOMETRYCOLLECTION EMPTY",
+			wantErr: false,
+			want:    "GEOMETRYCOLLECTION EMPTY",
+		},
+		{
+			name:    "collection with invalid member",
+			payload: "GEOMETRYCOLLECTION(FOOBAR(1 2))",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputs := []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"GEOMETRYCOLLECTION"}, nil),
+				NewFunctionTestInput(types.T_geometry.ToType(), []string{tc.payload}, nil),
+			}
+			if tc.wantErr {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), true, nil, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			} else {
+				expect := NewFunctionTestResult(types.T_geometry.ToType(), false, []string{tc.want}, nil)
+				tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+				succeed, info := tcc.Run()
+				require.True(t, succeed, info)
+			}
+		})
+	}
+}
+
+func TestCastGeometryToSubtypePointLimit(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	// Build a linestring with many points to test the point count validation.
+	// defaultMaxPointsInGeometry is 65536; we use a much smaller one via a
+	// long linestring that exceeds what a reasonable limit would allow.
+	// Since we can't easily set max_points_in_geometry via process variable in
+	// test, we just test a valid large geometry passes (exercising the count path).
+	payload := "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7, 8 8, 9 9)"
+	inputs := []FunctionTestInput{
+		NewFunctionTestInput(types.T_varchar.ToType(), []string{"LINESTRING"}, nil),
+		NewFunctionTestInput(types.T_geometry.ToType(), []string{payload}, nil),
+	}
+	expect := NewFunctionTestResult(types.T_geometry.ToType(), false, []string{payload}, nil)
+	tcc := NewFunctionTestCase(proc, inputs, expect, CastGeometryToSubtype)
+	succeed, info := tcc.Run()
+	require.True(t, succeed, info)
+}
+
+func TestValidateGeometryHelpers(t *testing.T) {
+	t.Run("encodeGeometryPayload without SRID", func(t *testing.T) {
+		result := encodeGeometryPayload("POINT(1 2)", 0, false)
+		require.Equal(t, "POINT(1 2)", string(result))
+	})
+
+	t.Run("encodeGeometryPayload with SRID", func(t *testing.T) {
+		result := encodeGeometryPayload("POINT(1 2)", 4326, true)
+		require.Equal(t, "SRID=4326;POINT(1 2)", string(result))
+	})
+
+	t.Run("decodeGeometryPayload with SRID", func(t *testing.T) {
+		wkt, srid, defined, err := decodeGeometryPayload([]byte("SRID=4326;POINT(1 2)"))
+		require.NoError(t, err)
+		require.Equal(t, "POINT(1 2)", wkt)
+		require.Equal(t, uint32(4326), srid)
+		require.True(t, defined)
+	})
+
+	t.Run("decodeGeometryPayload without SRID", func(t *testing.T) {
+		wkt, srid, defined, err := decodeGeometryPayload([]byte("POINT(1 2)"))
+		require.NoError(t, err)
+		require.Equal(t, "POINT(1 2)", wkt)
+		require.Equal(t, uint32(0), srid)
+		require.False(t, defined)
+	})
+
+	t.Run("decodeGeometryPayload malformed SRID", func(t *testing.T) {
+		_, _, _, err := decodeGeometryPayload([]byte("SRID=abc;POINT(1 2)"))
+		require.Error(t, err)
+	})
+
+	t.Run("decodeGeometryPayload SRID no semicolon", func(t *testing.T) {
+		_, _, _, err := decodeGeometryPayload([]byte("SRID=4326"))
+		require.Error(t, err)
+	})
+
+	t.Run("decodeGeometryPayload SRID empty WKT", func(t *testing.T) {
+		_, _, _, err := decodeGeometryPayload([]byte("SRID=4326; "))
+		require.Error(t, err)
+	})
+
+	t.Run("geometryTypeNameFromText valid types", func(t *testing.T) {
+		for _, name := range []string{"POINT(1 2)", "LINESTRING(0 0, 1 1)", "POLYGON((0 0, 1 0, 1 1, 0 0))",
+			"MULTIPOINT(0 0)", "MULTILINESTRING((0 0, 1 1))", "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 0)))",
+			"GEOMETRYCOLLECTION(POINT(0 0))"} {
+			_, err := geometryTypeNameFromText(name)
+			require.NoError(t, err, "should parse: %s", name)
+		}
+	})
+
+	t.Run("geometryTypeNameFromText EMPTY variants", func(t *testing.T) {
+		for _, name := range []string{"POINT EMPTY", "LINESTRING EMPTY", "POLYGON EMPTY",
+			"MULTIPOINT EMPTY", "MULTILINESTRING EMPTY", "MULTIPOLYGON EMPTY", "GEOMETRYCOLLECTION EMPTY"} {
+			typeName, err := geometryTypeNameFromText(name)
+			require.NoError(t, err, "should parse: %s", name)
+			require.NotEmpty(t, typeName)
+		}
+	})
+
+	t.Run("geometryTypeNameFromText invalid EMPTY", func(t *testing.T) {
+		_, err := geometryTypeNameFromText("FOOBAR EMPTY")
+		require.Error(t, err)
+	})
+
+	t.Run("splitTopLevelGeometryItemsStrict unbalanced parens", func(t *testing.T) {
+		_, err := splitTopLevelGeometryItemsStrict("(0 0, (1 1)", "err")
+		require.Error(t, err)
+	})
+
+	t.Run("splitTopLevelGeometryItemsStrict empty item", func(t *testing.T) {
+		_, err := splitTopLevelGeometryItemsStrict("0 0,,1 1", "err")
+		require.Error(t, err)
+	})
+
+	t.Run("splitTopLevelGeometryItemsStrict trailing comma", func(t *testing.T) {
+		_, err := splitTopLevelGeometryItemsStrict("0 0, 1 1, ", "err")
+		require.Error(t, err)
+	})
+
+	t.Run("validateFiniteCoordinatesInGeometryText valid", func(t *testing.T) {
+		err := validateFiniteCoordinatesInGeometryText("POINT(1.5 -2.3)")
+		require.NoError(t, err)
+	})
+
+	t.Run("validateFiniteCoordinatesInGeometryText with non-numeric tokens", func(t *testing.T) {
+		// Non-numeric tokens like type names are not floats and not Inf/NaN, so they pass
+		err := validateFiniteCoordinatesInGeometryText("POINT(1 2)")
+		require.NoError(t, err)
+	})
+
+	t.Run("maxPointsInGeometryLimit nil proc", func(t *testing.T) {
+		limit := maxPointsInGeometryLimit(nil)
+		require.Equal(t, defaultMaxPointsInGeometry, limit)
+	})
+
+	t.Run("maxPointsInGeometryLimit with int64 variable", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		proc.SetResolveVariableFunc(func(varName string, isSystemVar, isGlobalVar bool) (interface{}, error) {
+			if varName == "max_points_in_geometry" {
+				return int64(100), nil
+			}
+			return nil, nil
+		})
+		limit := maxPointsInGeometryLimit(proc)
+		require.Equal(t, int64(100), limit)
+	})
+
+	t.Run("maxPointsInGeometryLimit with int32 variable", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		proc.SetResolveVariableFunc(func(varName string, isSystemVar, isGlobalVar bool) (interface{}, error) {
+			if varName == "max_points_in_geometry" {
+				return int32(200), nil
+			}
+			return nil, nil
+		})
+		limit := maxPointsInGeometryLimit(proc)
+		require.Equal(t, int64(200), limit)
+	})
+
+	t.Run("maxPointsInGeometryLimit with uint64 variable", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		proc.SetResolveVariableFunc(func(varName string, isSystemVar, isGlobalVar bool) (interface{}, error) {
+			if varName == "max_points_in_geometry" {
+				return uint64(300), nil
+			}
+			return nil, nil
+		})
+		limit := maxPointsInGeometryLimit(proc)
+		require.Equal(t, int64(300), limit)
+	})
+
+	t.Run("maxPointsInGeometryLimit with uint32 variable", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		proc.SetResolveVariableFunc(func(varName string, isSystemVar, isGlobalVar bool) (interface{}, error) {
+			if varName == "max_points_in_geometry" {
+				return uint32(400), nil
+			}
+			return nil, nil
+		})
+		limit := maxPointsInGeometryLimit(proc)
+		require.Equal(t, int64(400), limit)
+	})
+
+	t.Run("maxPointsInGeometryLimit with int variable", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		proc.SetResolveVariableFunc(func(varName string, isSystemVar, isGlobalVar bool) (interface{}, error) {
+			if varName == "max_points_in_geometry" {
+				return int(500), nil
+			}
+			return nil, nil
+		})
+		limit := maxPointsInGeometryLimit(proc)
+		require.Equal(t, int64(500), limit)
+	})
+
+	t.Run("maxPointsInGeometryLimit with uint variable", func(t *testing.T) {
+		proc := testutil.NewProcess(t)
+		proc.SetResolveVariableFunc(func(varName string, isSystemVar, isGlobalVar bool) (interface{}, error) {
+			if varName == "max_points_in_geometry" {
+				return uint(600), nil
+			}
+			return nil, nil
+		})
+		limit := maxPointsInGeometryLimit(proc)
+		require.Equal(t, int64(600), limit)
+	})
+
+	t.Run("validateGeometryTextForStorage exceeds point limit", func(t *testing.T) {
+		err := validateGeometryTextForStorage("LINESTRING(0 0, 1 1, 2 2)", 2)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds max_points_in_geometry")
+	})
+
+	t.Run("validateGeometryTextForStorage zero limit skips count", func(t *testing.T) {
+		err := validateGeometryTextForStorage("LINESTRING(0 0, 1 1, 2 2)", 0)
+		require.NoError(t, err)
+	})
+
+	t.Run("validateGenericGeometryTextContent valid", func(t *testing.T) {
+		err := validateGenericGeometryTextContent("POINT(1 2)", 0)
+		require.NoError(t, err)
+	})
+
+	t.Run("validateGenericGeometryTextContent multiple items rejected", func(t *testing.T) {
+		err := validateGenericGeometryTextContent("POINT(1 2), POINT(3 4)", 0)
+		require.Error(t, err)
+	})
+
+	t.Run("validateGeometryCollectionTextContent exceeds nesting depth", func(t *testing.T) {
+		err := validateGeometryCollectionTextContent("POINT(0 0)", maxGeometryCollectionNestingDepth)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "nesting depth")
+	})
+
+	t.Run("multiLineStringPointCountFromTextContent empty", func(t *testing.T) {
+		count, err := multiLineStringPointCountFromTextContent("")
+		require.NoError(t, err)
+		require.Equal(t, int64(0), count)
+	})
+
+	t.Run("multiLineStringPointCountFromTextContent valid", func(t *testing.T) {
+		count, err := multiLineStringPointCountFromTextContent("(0 0, 1 1), (2 2, 3 3, 4 4)")
+		require.NoError(t, err)
+		require.Equal(t, int64(5), count)
+	})
+
+	t.Run("multiLineStringPointCountFromTextContent malformed", func(t *testing.T) {
+		_, err := multiLineStringPointCountFromTextContent("0 0, 1 1")
+		require.Error(t, err)
+	})
+
+	t.Run("multiPolygonPointCountFromTextContent empty", func(t *testing.T) {
+		count, err := multiPolygonPointCountFromTextContent("")
+		require.NoError(t, err)
+		require.Equal(t, int64(0), count)
+	})
+
+	t.Run("multiPolygonPointCountFromTextContent valid", func(t *testing.T) {
+		count, err := multiPolygonPointCountFromTextContent("((0 0, 1 0, 1 1, 0 0))")
+		require.NoError(t, err)
+		require.Equal(t, int64(4), count)
+	})
+
+	t.Run("multiPolygonPointCountFromTextContent malformed", func(t *testing.T) {
+		_, err := multiPolygonPointCountFromTextContent("0 0, 1 0")
+		require.Error(t, err)
+	})
+
+	t.Run("genericGeometryPointCountFromTextContent valid", func(t *testing.T) {
+		count, err := genericGeometryPointCountFromTextContent("POINT(1 2)", 0)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), count)
+	})
+
+	t.Run("genericGeometryPointCountFromTextContent multiple items", func(t *testing.T) {
+		_, err := genericGeometryPointCountFromTextContent("POINT(1 2), POINT(3 4)", 0)
+		require.Error(t, err)
+	})
+}

--- a/pkg/sql/plan/function/func_testcase.go
+++ b/pkg/sql/plan/function/func_testcase.go
@@ -578,7 +578,7 @@ func (fc *FunctionTestCase) Run() (succeed bool, errInfo string) {
 			}
 		}
 	case types.T_char, types.T_varchar,
-		types.T_binary, types.T_varbinary, types.T_blob, types.T_text, types.T_datalink:
+		types.T_binary, types.T_varbinary, types.T_blob, types.T_text, types.T_datalink, types.T_geometry:
 		r := vector.GenerateFunctionStrParameter(v)
 		s := vector.GenerateFunctionStrParameter(vExpected)
 		for i = 0; i < uint64(fc.fnLength); i++ {
@@ -832,7 +832,7 @@ func newVectorByType(mp *mpool.MPool, typ types.Type, val any, nsp *nulls.Nulls)
 	case types.T_timestamp:
 		values := val.([]types.Timestamp)
 		vector.AppendFixedList(vec, values, nil, mp)
-	case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary, types.T_blob, types.T_text, types.T_datalink:
+	case types.T_char, types.T_varchar, types.T_binary, types.T_varbinary, types.T_blob, types.T_text, types.T_datalink, types.T_geometry:
 		values := val.([]string)
 		vector.AppendStringList(vec, values, nil, mp)
 	case types.T_array_float32:

--- a/pkg/sql/plan/function/function_id.go
+++ b/pkg/sql/plan/function/function_id.go
@@ -431,9 +431,11 @@ const (
 
 	YEARWEEK = 354
 
+	CAST_GEOMETRY_TO_SUBTYPE = 355
+
 	// FUNCTION_END_NUMBER is not a function, just a flag to record the max number of function.
 	// TODO: every one should put the new function id in front of this one if you want to make a new function.
-	FUNCTION_END_NUMBER = 355
+	FUNCTION_END_NUMBER = 356
 )
 
 // functionIdRegister is what function we have registered already.
@@ -746,6 +748,7 @@ var functionIdRegister = map[string]int32{
 	"cast_index_value_to_index":      CAST_INDEX_VALUE_TO_INDEX,
 	"cast_nano_to_timestamp":         CAST_NANO_TO_TIMESTAMP,
 	"cast_range_value_unit":          CAST_RANGE_VALUE_UNIT,
+	"cast_geometry_to_subtype":       CAST_GEOMETRY_TO_SUBTYPE,
 	"to_upper":                       UPPER,
 	"upper":                          UPPER,
 	"ucase":                          UPPER,

--- a/pkg/sql/plan/function/function_id_test.go
+++ b/pkg/sql/plan/function/function_id_test.go
@@ -405,7 +405,9 @@ var predefinedFunids = map[int]int{
 	GET_FORMAT:      353,
 	YEARWEEK:        354,
 
-	FUNCTION_END_NUMBER: 355,
+	CAST_GEOMETRY_TO_SUBTYPE: 355,
+
+	FUNCTION_END_NUMBER: 356,
 }
 
 func Test_funids(t *testing.T) {

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -7172,6 +7172,29 @@ var supportedOthersBuiltIns = []FuncNew{
 		},
 	},
 
+	// function `cast_geometry_to_subtype`
+	{
+		functionId: CAST_GEOMETRY_TO_SUBTYPE,
+		class:      plan.Function_STRICT,
+		layout:     STANDARD_FUNCTION,
+		checkFn:    fixedTypeMatch,
+
+		Overloads: []overload{
+			{
+				overloadId:      0,
+				args:            []types.T{types.T_varchar, types.T_geometry},
+				volatile:        true,
+				realTimeRelated: true,
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_geometry.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return CastGeometryToSubtype
+				},
+			},
+		},
+	},
+
 	// function `mo_table_rows`
 	{
 		functionId: MO_TABLE_ROWS,

--- a/pkg/sql/plan/make.go
+++ b/pkg/sql/plan/make.go
@@ -589,6 +589,13 @@ func makePlan2CastExpr(ctx context.Context, expr *Expr, targetType Type) (*Expr,
 		}
 	}
 
+	if isGeometryPlanType(&targetType) {
+		expr, err = funcCastForGeometryType(ctx, expr, targetType)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	t1, t2 := makeTypeByPlan2Expr(expr), makeTypeByPlan2Type(targetType)
 	fGet, err := function.GetFunctionByName(ctx, "cast", []types.Type{t1, t2})
 	if err != nil {

--- a/pkg/sql/plan/make.go
+++ b/pkg/sql/plan/make.go
@@ -573,6 +573,12 @@ func makePlan2CastExpr(ctx context.Context, expr *Expr, targetType Type) (*Expr,
 			return nil, err
 		}
 	}
+	if isGeometryPlanType(&targetType) {
+		expr, err = funcCastForGeometryType(ctx, expr, targetType)
+		if err != nil {
+			return nil, err
+		}
+	}
 	if isSameColumnType(expr.Typ, targetType) {
 		return expr, nil
 	}
@@ -584,13 +590,6 @@ func makePlan2CastExpr(ctx context.Context, expr *Expr, targetType Type) (*Expr,
 
 	if targetType.Id == int32(types.T_enum) {
 		expr, err = funcCastForEnumType(ctx, expr, targetType)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if isGeometryPlanType(&targetType) {
-		expr, err = funcCastForGeometryType(ctx, expr, targetType)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/plan/mysql_special_types.go
+++ b/pkg/sql/plan/mysql_special_types.go
@@ -15,10 +15,12 @@
 package plan
 
 import (
+	"context"
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
 
 func isEnumPlanType(typ *plan.Type) bool {
@@ -72,4 +74,44 @@ func normalizeGeometrySubtype(subtype string) string {
 	default:
 		return ""
 	}
+}
+
+func funcCastForGeometryType(ctx context.Context, expr *Expr, targetType Type) (*Expr, error) {
+	if !isGeometryPlanType(&targetType) {
+		return expr, nil
+	}
+	targetType.NotNullable = expr.Typ.NotNullable
+	if types.T(expr.Typ.Id) == types.T_any || isGeometryNullLiteralExpr(expr) {
+		expr.Typ = targetType
+		return expr, nil
+	}
+	targetMetadata := targetType.Enumvalues
+	if isGeometryPlanType(&expr.Typ) && expr.Typ.GetEnumvalues() == targetMetadata {
+		expr.Typ = targetType
+		return expr, nil
+	}
+
+	args := make([]*Expr, 2)
+	binder := NewDefaultBinder(ctx, nil, nil, targetType, nil)
+	targetSubtypeExpr, err := binder.BindExpr(tree.NewNumVal(targetMetadata, targetMetadata, false, tree.P_char), 0, false)
+	if err != nil {
+		return nil, err
+	}
+	args[0] = targetSubtypeExpr
+	args[1] = expr
+
+	castedExpr, err := BindFuncExprImplByPlanExpr(ctx, moGeometryCastToSubtypeFun, args)
+	if err != nil {
+		return nil, err
+	}
+	castedExpr.Typ = targetType
+	return castedExpr, nil
+}
+
+func isGeometryNullLiteralExpr(expr *Expr) bool {
+	if expr == nil {
+		return false
+	}
+	lit, ok := expr.Expr.(*plan.Expr_Lit)
+	return ok && lit.Lit != nil && lit.Lit.Isnull
 }

--- a/pkg/sql/plan/mysql_special_types_test.go
+++ b/pkg/sql/plan/mysql_special_types_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsGeometryNullLiteralExpr(t *testing.T) {
+	require.False(t, isGeometryNullLiteralExpr(nil))
+
+	nonNull := &Expr{
+		Expr: &plan.Expr_Lit{
+			Lit: &plan.Literal{Value: &plan.Literal_Sval{Sval: "POINT(1 2)"}},
+		},
+	}
+	require.False(t, isGeometryNullLiteralExpr(nonNull))
+
+	nullExpr := &Expr{
+		Expr: &plan.Expr_Lit{
+			Lit: &plan.Literal{Isnull: true},
+		},
+	}
+	require.True(t, isGeometryNullLiteralExpr(nullExpr))
+
+	colExpr := &Expr{
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{RelPos: 0, ColPos: 0},
+		},
+	}
+	require.False(t, isGeometryNullLiteralExpr(colExpr))
+}
+
+func TestFuncCastForGeometryType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("non-geometry target returns expr unchanged", func(t *testing.T) {
+		expr := &Expr{
+			Typ: plan.Type{Id: int32(types.T_varchar)},
+			Expr: &plan.Expr_Lit{
+				Lit: &plan.Literal{Value: &plan.Literal_Sval{Sval: "hello"}},
+			},
+		}
+		target := plan.Type{Id: int32(types.T_varchar)}
+		result, err := funcCastForGeometryType(ctx, expr, target)
+		require.NoError(t, err)
+		require.Equal(t, expr, result)
+	})
+
+	t.Run("T_any expr gets target type assigned", func(t *testing.T) {
+		expr := &Expr{
+			Typ: plan.Type{Id: int32(types.T_any)},
+			Expr: &plan.Expr_Lit{
+				Lit: &plan.Literal{Value: &plan.Literal_Sval{Sval: ""}},
+			},
+		}
+		target := plan.Type{Id: int32(types.T_geometry), Enumvalues: "POINT"}
+		result, err := funcCastForGeometryType(ctx, expr, target)
+		require.NoError(t, err)
+		require.Equal(t, int32(types.T_geometry), result.Typ.Id)
+	})
+
+	t.Run("null literal expr gets target type assigned", func(t *testing.T) {
+		expr := &Expr{
+			Typ: plan.Type{Id: int32(types.T_geometry)},
+			Expr: &plan.Expr_Lit{
+				Lit: &plan.Literal{Isnull: true},
+			},
+		}
+		target := plan.Type{Id: int32(types.T_geometry), Enumvalues: "POINT"}
+		result, err := funcCastForGeometryType(ctx, expr, target)
+		require.NoError(t, err)
+		require.Equal(t, "POINT", result.Typ.Enumvalues)
+	})
+
+	t.Run("same geometry subtype skips cast", func(t *testing.T) {
+		expr := &Expr{
+			Typ: plan.Type{Id: int32(types.T_geometry), Enumvalues: "POINT"},
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{RelPos: 0, ColPos: 0},
+			},
+		}
+		target := plan.Type{Id: int32(types.T_geometry), Enumvalues: "POINT"}
+		result, err := funcCastForGeometryType(ctx, expr, target)
+		require.NoError(t, err)
+		require.Equal(t, "POINT", result.Typ.Enumvalues)
+	})
+
+	t.Run("different geometry subtype generates cast function", func(t *testing.T) {
+		expr := &Expr{
+			Typ: plan.Type{Id: int32(types.T_geometry), Enumvalues: ""},
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{RelPos: 0, ColPos: 0},
+			},
+		}
+		target := plan.Type{Id: int32(types.T_geometry), Enumvalues: "POINT"}
+		result, err := funcCastForGeometryType(ctx, expr, target)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		fn := result.GetF()
+		require.NotNil(t, fn)
+		require.Equal(t, "cast_geometry_to_subtype", fn.Func.ObjName)
+	})
+}
+
+func TestIsGeometryPlanType(t *testing.T) {
+	require.False(t, isGeometryPlanType(nil))
+
+	varcharType := &plan.Type{Id: int32(types.T_varchar)}
+	require.False(t, isGeometryPlanType(varcharType))
+
+	geomType := &plan.Type{Id: int32(types.T_geometry)}
+	require.True(t, isGeometryPlanType(geomType))
+}
+
+func TestGeometrySubtypeName(t *testing.T) {
+	require.Equal(t, "", geometrySubtypeName(&plan.Type{Id: int32(types.T_varchar)}))
+	require.Equal(t, "", geometrySubtypeName(&plan.Type{Id: int32(types.T_geometry), Enumvalues: ""}))
+	require.Equal(t, "", geometrySubtypeName(&plan.Type{Id: int32(types.T_geometry), Enumvalues: "GEOMETRY"}))
+	require.Equal(t, "POINT", geometrySubtypeName(&plan.Type{Id: int32(types.T_geometry), Enumvalues: "POINT"}))
+	require.Equal(t, "LINESTRING", geometrySubtypeName(&plan.Type{Id: int32(types.T_geometry), Enumvalues: "linestring"}))
+}
+
+func TestNormalizeGeometrySubtype(t *testing.T) {
+	require.Equal(t, "POINT", normalizeGeometrySubtype("point"))
+	require.Equal(t, "LINESTRING", normalizeGeometrySubtype("LINESTRING"))
+	require.Equal(t, "POLYGON", normalizeGeometrySubtype("Polygon"))
+	require.Equal(t, "MULTIPOINT", normalizeGeometrySubtype("multipoint"))
+	require.Equal(t, "MULTILINESTRING", normalizeGeometrySubtype("MULTILINESTRING"))
+	require.Equal(t, "MULTIPOLYGON", normalizeGeometrySubtype("MultiPolygon"))
+	require.Equal(t, "GEOMETRYCOLLECTION", normalizeGeometrySubtype("geometrycollection"))
+	require.Equal(t, "", normalizeGeometrySubtype("GEOMETRY"))
+	require.Equal(t, "", normalizeGeometrySubtype(""))
+	require.Equal(t, "", normalizeGeometrySubtype("INVALID"))
+}

--- a/pkg/sql/plan/tools.go
+++ b/pkg/sql/plan/tools.go
@@ -18,4 +18,5 @@ const (
 	moEnumCastIndexToValueFun      = "cast_index_to_value"
 	moEnumCastValueToIndexFun      = "cast_value_to_index"
 	moEnumCastIndexValueToIndexFun = "cast_index_value_to_index"
+	moGeometryCastToSubtypeFun     = "cast_geometry_to_subtype"
 )


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24350

## What this PR does / why we need it:

Ports the `cast_geometry_to_subtype` runtime function from `main` to `3.0-dev` so that INSERT/UPDATE operations validate the WKT geometry subtype and SRID against the column declaration. Previously on `3.0-dev`, a column declared as `POINT` could silently accept a `LINESTRING` value.

### Changes:
- Register `CAST_GEOMETRY_TO_SUBTYPE` function ID and built-in overload
- Implement `CastGeometryToSubtype` runtime function with full WKT structure validation
- Add `funcCastForGeometryType` planner function that wraps geometry expressions with subtype/SRID validation
- Wire geometry cast into all INSERT/UPDATE bind paths (bind_insert, bind_update, build_update, build_constraint_util, make.go)
- Add unit tests covering subtype match/reject, SRID mismatch, malformed structure, and non-finite coordinates
- Add `T_geometry` support to the function test framework

🤖 Generated with [Claude Code](https://claude.com/claude-code)