### PR TITLE
fix(lockservice): fence txns on bind changes

### DIFF
--- a/pkg/lockservice/lock_table_keeper.go
+++ b/pkg/lockservice/lock_table_keeper.go
@@ -147,6 +147,7 @@ func (k *lockTableKeeper) doKeepRemoteLock(
 		}
 		err = moerr.AttachCause(ctx, err)
 		logKeepRemoteLocksFailed(k.service.logger, bind, err)
+		k.maybeHandleRemoteBindChanged(bind)
 		if !isRetryError(err) {
 			k.groupTables.removeWithFilter(func(_ uint64, v lockTable) bool {
 				return !v.getBind().Changed(bind)
@@ -158,17 +159,39 @@ func (k *lockTableKeeper) doKeepRemoteLock(
 		v, err := f.Get()
 		if err == nil {
 			resp := v.(*pb.Response)
-			if resp.NewBind != nil {
+			if err = resp.UnwrapError(); err != nil {
+				logKeepRemoteLocksFailed(k.service.logger, binds[idx], err)
+				k.maybeHandleRemoteBindChanged(binds[idx])
+			} else if resp.NewBind != nil {
 				k.service.handleBindChanged(*resp.NewBind)
 			}
 			releaseResponse(resp)
 		} else {
 			logKeepRemoteLocksFailed(k.service.logger, binds[idx], err)
+			k.maybeHandleRemoteBindChanged(binds[idx])
 		}
 		f.Close()
 		futures[idx] = nil // gc
 	}
 	return futures[:0], binds[:0]
+}
+
+func (k *lockTableKeeper) maybeHandleRemoteBindChanged(bind pb.LockTable) {
+	newBind, err := getLockTableBind(
+		k.client,
+		bind.Group,
+		bind.Table,
+		bind.OriginTable,
+		k.serviceID,
+		bind.Sharding,
+	)
+	if err != nil {
+		logGetRemoteBindFailed(k.service.logger, bind.Table, err)
+		return
+	}
+	if newBind.Changed(bind) {
+		k.service.handleBindChanged(newBind)
+	}
 }
 
 func (k *lockTableKeeper) doKeepLockTableBind(ctx context.Context) {

--- a/pkg/lockservice/lock_table_keeper.go
+++ b/pkg/lockservice/lock_table_keeper.go
@@ -157,7 +157,11 @@ func (k *lockTableKeeper) doKeepRemoteLock(
 	for idx, f := range futures {
 		v, err := f.Get()
 		if err == nil {
-			releaseResponse(v.(*pb.Response))
+			resp := v.(*pb.Response)
+			if resp.NewBind != nil {
+				k.service.handleBindChanged(*resp.NewBind)
+			}
+			releaseResponse(resp)
 		} else {
 			logKeepRemoteLocksFailed(k.service.logger, binds[idx], err)
 		}

--- a/pkg/lockservice/lock_table_keeper_test.go
+++ b/pkg/lockservice/lock_table_keeper_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestKeeper(t *testing.T) {
@@ -196,6 +198,80 @@ func TestKeepBindFailedWillRemoveAllLocalLockTable(t *testing.T) {
 				}
 				time.Sleep(time.Millisecond * 100)
 			}
+		},
+	)
+}
+
+func TestKeepRemoteLockBindChangedFencesActiveTxn(t *testing.T) {
+	runRPCTests(
+		t,
+		func(c Client, server Server) {
+			oldBind := pb.LockTable{Group: 0, Table: 1, OriginTable: 1, ServiceID: "s2", Version: 1, Valid: true}
+			newBind := oldBind
+			newBind.ServiceID = "s3"
+			newBind.Version = 2
+
+			server.RegisterMethodHandler(
+				pb.Method_KeepRemoteLock,
+				func(
+					ctx context.Context,
+					cancel context.CancelFunc,
+					req *pb.Request,
+					resp *pb.Response,
+					cs morpc.ClientSession) {
+					resp.NewBind = &newBind
+					writeResponse(getLogger(""), cancel, resp, nil, cs)
+				})
+
+			logger := getLogger("")
+			fsp := newFixedSlicePool(2)
+			svc := &service{
+				serviceID: "s1",
+				fsp:       fsp,
+				logger:    logger,
+			}
+			svc.remote.client = c
+			svc.tableGroups = &lockTableHolders{service: svc.serviceID, logger: logger, holders: map[uint32]*lockTableHolder{}}
+			svc.activeTxnHolder = newMapBasedTxnHandler(
+				svc.serviceID,
+				logger,
+				fsp,
+				func(string) (bool, error) { return true, nil },
+				func([]pb.OrphanTxn) ([][]byte, error) { return nil, nil },
+				func(pb.WaitTxn) (bool, error) { return true, nil },
+			)
+			svc.tableGroups.set(
+				oldBind.Group,
+				oldBind.Table,
+				newRemoteLockTable(svc.serviceID, time.Second, oldBind, c, svc.handleBindChanged, logger),
+			)
+
+			txnID := []byte("txn1")
+			txn := svc.activeTxnHolder.getActiveTxn(txnID, true, "")
+			txn.Lock()
+			require.NoError(t, txn.lockAdded(oldBind.Group, oldBind, [][]byte{{1}}, logger))
+			txn.Unlock()
+
+			keeper := &lockTableKeeper{
+				serviceID:   svc.serviceID,
+				client:      c,
+				groupTables: svc.tableGroups,
+				service:     svc,
+			}
+			keeper.doKeepRemoteLock(context.Background(), nil, nil)
+
+			txn.Lock()
+			require.True(t, txn.bindChanged)
+			txn.Unlock()
+			require.Equal(t, newBind, svc.tableGroups.get(newBind.Group, newBind.Table).getBind())
+
+			require.Equal(t, txn, svc.activeTxnHolder.deleteActiveTxn(txnID))
+			txn.Lock()
+			err := txn.close(txnID, timestamp.Timestamp{}, func(uint32, uint64) (lockTable, error) {
+				return nil, nil
+			}, logger)
+			txn.Unlock()
+			require.NoError(t, err)
 		},
 	)
 }

--- a/pkg/lockservice/lock_table_keeper_test.go
+++ b/pkg/lockservice/lock_table_keeper_test.go
@@ -275,3 +275,77 @@ func TestKeepRemoteLockBindChangedFencesActiveTxn(t *testing.T) {
 		},
 	)
 }
+
+func TestKeepRemoteLockFailureFetchesNewBindAndFencesActiveTxn(t *testing.T) {
+	runRPCTests(
+		t,
+		func(c Client, server Server) {
+			oldBind := pb.LockTable{Group: 0, Table: 1, OriginTable: 1, ServiceID: "s2", Version: 1, Valid: true}
+			newBind := oldBind
+			newBind.ServiceID = "s3"
+			newBind.Version = 2
+
+			server.RegisterMethodHandler(
+				pb.Method_GetBind,
+				func(
+					ctx context.Context,
+					cancel context.CancelFunc,
+					req *pb.Request,
+					resp *pb.Response,
+					cs morpc.ClientSession) {
+					resp.GetBind.LockTable = newBind
+					writeResponse(getLogger(""), cancel, resp, nil, cs)
+				})
+
+			logger := getLogger("")
+			fsp := newFixedSlicePool(2)
+			svc := &service{
+				serviceID: "s1",
+				fsp:       fsp,
+				logger:    logger,
+			}
+			svc.remote.client = c
+			svc.tableGroups = &lockTableHolders{service: svc.serviceID, logger: logger, holders: map[uint32]*lockTableHolder{}}
+			svc.activeTxnHolder = newMapBasedTxnHandler(
+				svc.serviceID,
+				logger,
+				fsp,
+				func(string) (bool, error) { return true, nil },
+				func([]pb.OrphanTxn) ([][]byte, error) { return nil, nil },
+				func(pb.WaitTxn) (bool, error) { return true, nil },
+			)
+			svc.tableGroups.set(
+				oldBind.Group,
+				oldBind.Table,
+				newRemoteLockTable(svc.serviceID, time.Second, oldBind, c, svc.handleBindChanged, logger),
+			)
+
+			txnID := []byte("txn1")
+			txn := svc.activeTxnHolder.getActiveTxn(txnID, true, "")
+			txn.Lock()
+			require.NoError(t, txn.lockAdded(oldBind.Group, oldBind, [][]byte{{1}}, logger))
+			txn.Unlock()
+
+			keeper := &lockTableKeeper{
+				serviceID:   svc.serviceID,
+				client:      c,
+				groupTables: svc.tableGroups,
+				service:     svc,
+			}
+			keeper.doKeepRemoteLock(context.Background(), nil, nil)
+
+			txn.Lock()
+			require.True(t, txn.bindChanged)
+			txn.Unlock()
+			require.Equal(t, newBind, svc.tableGroups.get(newBind.Group, newBind.Table).getBind())
+
+			require.Equal(t, txn, svc.activeTxnHolder.deleteActiveTxn(txnID))
+			txn.Lock()
+			err := txn.close(txnID, timestamp.Timestamp{}, func(uint32, uint64) (lockTable, error) {
+				return nil, nil
+			}, logger)
+			txn.Unlock()
+			require.NoError(t, err)
+		},
+	)
+}

--- a/pkg/lockservice/lock_table_remote.go
+++ b/pkg/lockservice/lock_table_remote.go
@@ -100,10 +100,25 @@ func (l *remoteLockTable) lock(
 		cb(pb.Result{}, ErrTxnNotFound)
 		return
 	}
+	if txn.bindChanged {
+		cb(pb.Result{}, ErrLockTableBindChanged)
+		return
+	}
 
 	if err == nil {
 		defer releaseResponse(resp)
-		if err := l.maybeHandleBindChanged(resp); err != nil {
+		if resp.NewBind != nil {
+			txn.Unlock()
+			err = l.maybeHandleBindChanged(resp)
+			txn.Lock()
+			if !bytes.Equal(req.Lock.TxnID, txn.txnID) {
+				cb(pb.Result{}, ErrTxnNotFound)
+				return
+			}
+			if txn.bindChanged {
+				cb(pb.Result{}, ErrLockTableBindChanged)
+				return
+			}
 			logRemoteLockFailed(l.logger, txn, rows, opts, l.bind, err)
 			cb(pb.Result{}, err)
 			return
@@ -126,7 +141,18 @@ func (l *remoteLockTable) lock(
 	// And use origin error to return, because once handlerError
 	// swallows the error, the transaction will not be abort.
 	originalErr := err
-	if e := l.handleError(err, true); e != nil {
+	txn.Unlock()
+	e := l.handleError(err, true)
+	txn.Lock()
+	if !bytes.Equal(req.Lock.TxnID, txn.txnID) {
+		cb(pb.Result{}, ErrTxnNotFound)
+		return
+	}
+	if txn.bindChanged {
+		cb(pb.Result{}, ErrLockTableBindChanged)
+		return
+	}
+	if e != nil {
 		err = e
 	} else {
 		// handleError returned nil, meaning bind changed and error was swallowed

--- a/pkg/lockservice/lock_table_remote_test.go
+++ b/pkg/lockservice/lock_table_remote_test.go
@@ -67,6 +67,59 @@ func TestLockRemote(t *testing.T) {
 	)
 }
 
+func TestLockRemoteChecksBindChangedAfterRPC(t *testing.T) {
+	reqArrived := make(chan struct{})
+	releaseResp := make(chan struct{})
+	runRemoteLockTableTests(
+		t,
+		pb.LockTable{ServiceID: "s1", Table: 1, Valid: true, Version: 1},
+		func(s Server) {
+			s.RegisterMethodHandler(
+				pb.Method_Lock,
+				func(
+					ctx context.Context,
+					cancel context.CancelFunc,
+					req *pb.Request,
+					resp *pb.Response,
+					cs morpc.ClientSession) {
+					close(reqArrived)
+					<-releaseResp
+					writeResponse(getLogger(""), cancel, resp, nil, cs)
+				},
+			)
+		},
+		func(l *remoteLockTable, s Server) {
+			txnID := []byte("txn1")
+			txn := newActiveTxn(txnID, string(txnID), newFixedSlicePool(32), "")
+			defer reuse.Free(txn, nil)
+
+			errC := make(chan error, 1)
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+				defer cancel()
+				txn.Lock()
+				defer txn.Unlock()
+				l.lock(ctx, txn, [][]byte{{1}}, LockOptions{}, func(r pb.Result, err error) {
+					errC <- err
+				})
+			}()
+
+			<-reqArrived
+			txn.Lock()
+			txn.bindChanged = true
+			txn.Unlock()
+			close(releaseResp)
+
+			err := <-errC
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged))
+			txn.Lock()
+			require.Empty(t, txn.getHoldLocksLocked(0).tableBinds)
+			txn.Unlock()
+		},
+		func(lt pb.LockTable) {},
+	)
+}
+
 func TestIssue20747(t *testing.T) {
 	runRemoteLockTableTests(
 		t,

--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -57,6 +57,7 @@ type service struct {
 	clock                clock.Clock
 	stopper              *stopper.Stopper
 	stopOnce             sync.Once
+	bindChangeMu         sync.RWMutex
 	fetchWhoWaitingListC chan who
 	logger               *log.MOLogger
 
@@ -154,9 +155,11 @@ func (s *service) Lock(
 		return s.forwardLock(ctx, tableID, rows, txnID, options)
 	}
 
+	s.bindChangeMu.RLock()
 	txn := s.activeTxnHolder.getActiveTxn(txnID, true, "")
 	l, err := s.getLockTableWithCreate(options.Group, tableID, rows, options.Sharding)
 	if err != nil {
+		s.bindChangeMu.RUnlock()
 		return pb.Result{}, err
 	}
 
@@ -164,24 +167,36 @@ func (s *service) Lock(
 	// and getLock. The doAcquireLock and getLock operations of the same transaction
 	// will be concurrent (deadlock detection), which may lead to a deadlock in mutex.
 	txn.Lock()
-	defer txn.Unlock()
 	if !bytes.Equal(txn.txnID, txnID) {
+		txn.Unlock()
+		s.bindChangeMu.RUnlock()
 		return pb.Result{}, ErrTxnNotFound
 	}
 	if txn.deadlockFound {
+		txn.Unlock()
+		s.bindChangeMu.RUnlock()
 		return pb.Result{}, ErrDeadLockDetected
+	}
+	if txn.bindChanged {
+		txn.Unlock()
+		s.bindChangeMu.RUnlock()
+		return pb.Result{}, ErrLockTableBindChanged
 	}
 
 	// it needs to inc table bind ref when set restart cn
-	h := txn.getHoldLocksLocked(l.getBind().Group)
-	_, hasBind := h.tableBinds[l.getBind().Table]
+	bind := l.getBind()
+	h := txn.getHoldLocksLocked(bind.Group)
+	_, hasBind := h.tableBinds[bind.Table]
+	txn.lockTableBindAdded(bind)
+	s.bindChangeMu.RUnlock()
+	defer txn.Unlock()
 	defer func() {
 		if s.isStatus(pb.Status_ServiceLockEnable) ||
 			err != nil ||
 			hasBind {
 			return
 		}
-		s.incRef(l.getBind().Group, l.getBind().Table)
+		s.incRef(bind.Group, bind.Table)
 	}()
 
 	var result pb.Result
@@ -601,8 +616,19 @@ func (s *service) getLockTableWithCreate(
 }
 
 func (s *service) handleBindChanged(newBind pb.LockTable) {
+	s.bindChangeMu.Lock()
+	defer s.bindChangeMu.Unlock()
+
 	new := s.createLockTableByBind(newBind)
 	s.tableGroups.set(newBind.Group, newBind.Table, new)
+	s.fenceByBindChanged(newBind)
+}
+
+func (s *service) fenceByBindChanged(bind pb.LockTable) {
+	if s.activeTxnHolder == nil {
+		return
+	}
+	s.activeTxnHolder.fenceByBindChanged(bind)
 }
 
 func (s *service) createLockTableByBind(bind pb.LockTable) lockTable {
@@ -653,6 +679,7 @@ type activeTxnHolder interface {
 	getActiveTxn(txnID []byte, create bool, remoteService string) *activeTxn
 	hasActiveTxn(txnID []byte) bool
 	deleteActiveTxn(txnID []byte) *activeTxn
+	fenceByBindChanged(bind pb.LockTable) int
 	keepRemoteActiveTxn(remoteService string)
 	keepRemoteLockBindActive(remoteService string, bind pb.LockTable)
 	hasRemoteLockBind(remoteService string, bind pb.LockTable, maxKeepInterval time.Duration) bool
@@ -792,6 +819,19 @@ func (h *mapBasedTxnHolder) deleteActiveTxn(txnID []byte) *activeTxn {
 		delete(h.mu.activeTxnServices, txnKey)
 	}
 	return v
+}
+
+func (h *mapBasedTxnHolder) fenceByBindChanged(bind pb.LockTable) int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	n := 0
+	for _, txn := range h.mu.activeTxns {
+		if txn.fenceByBindChanged(bind, h.logger) {
+			n++
+		}
+	}
+	return n
 }
 
 func (h *mapBasedTxnHolder) keepRemoteActiveTxn(remoteService string) {

--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -187,7 +187,7 @@ func (s *service) Lock(
 	bind := l.getBind()
 	h := txn.getHoldLocksLocked(bind.Group)
 	_, hasBind := h.tableBinds[bind.Table]
-	txn.lockTableBindAdded(bind)
+	txn.lockTableBindTouched(bind)
 	s.bindChangeMu.RUnlock()
 	defer txn.Unlock()
 	defer func() {

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -229,7 +229,7 @@ func (s *service) handleRemoteLock(
 	bind := l.getBind()
 	h := txn.getHoldLocksLocked(bind.Group)
 	_, hasBind := h.tableBinds[bind.Table]
-	txn.lockTableBindAdded(bind)
+	txn.lockTableBindTouched(bind)
 	s.bindChangeMu.RUnlock()
 	defer txn.Unlock()
 	defer func() {
@@ -306,7 +306,7 @@ func (s *service) handleForwardLock(
 	bind := l.getBind()
 	h := txn.getHoldLocksLocked(bind.Group)
 	_, hasBind := h.tableBinds[bind.Table]
-	txn.lockTableBindAdded(bind)
+	txn.lockTableBindTouched(bind)
 	s.bindChangeMu.RUnlock()
 	defer txn.Unlock()
 	defer func() {

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -188,11 +188,13 @@ func (s *service) handleRemoteLock(
 		return
 	}
 
+	s.bindChangeMu.RLock()
 	l, err := s.getLocalLockTable(req, resp)
 	if err != nil ||
 		l == nil {
 		// means that the lockservice sending the lock request holds a stale
 		// lock table binding.
+		s.bindChangeMu.RUnlock()
 		_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout)
 		return
 	}
@@ -201,27 +203,40 @@ func (s *service) handleRemoteLock(
 
 	txn := s.activeTxnHolder.getActiveTxn(req.Lock.TxnID, true, req.Lock.ServiceID)
 	txn.Lock()
-	defer txn.Unlock()
 	if !bytes.Equal(txn.txnID, req.Lock.TxnID) {
+		txn.Unlock()
+		s.bindChangeMu.RUnlock()
 		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrTxnNotFound, cs, defaultRPCWriteTimeout)
 		return
 	}
 	if txn.deadlockFound {
+		txn.Unlock()
+		s.bindChangeMu.RUnlock()
 		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrDeadLockDetected, cs, defaultRPCWriteTimeout)
+		return
+	}
+	if txn.bindChanged {
+		txn.Unlock()
+		s.bindChangeMu.RUnlock()
+		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrLockTableBindChanged, cs, defaultRPCWriteTimeout)
 		return
 	}
 
 	var lockErr error
 	// it needs to inc table bind ref when set restart cn
-	h := txn.getHoldLocksLocked(l.getBind().Group)
-	_, hasBind := h.tableBinds[l.getBind().Table]
+	bind := l.getBind()
+	h := txn.getHoldLocksLocked(bind.Group)
+	_, hasBind := h.tableBinds[bind.Table]
+	txn.lockTableBindAdded(bind)
+	s.bindChangeMu.RUnlock()
+	defer txn.Unlock()
 	defer func() {
 		if s.isStatus(pb.Status_ServiceLockEnable) ||
 			lockErr != nil ||
 			hasBind {
 			return
 		}
-		s.incRef(l.getBind().Group, l.getBind().Table)
+		s.incRef(bind.Group, bind.Table)
 	}()
 
 	l.lock(
@@ -247,6 +262,7 @@ func (s *service) handleForwardLock(
 		return
 	}
 
+	s.bindChangeMu.RLock()
 	l, err := s.getLockTable(
 		req.LockTable.Group,
 		req.LockTable.Table)
@@ -254,6 +270,7 @@ func (s *service) handleForwardLock(
 		l == nil {
 		// means that the lockservice sending the lock request holds a stale
 		// lock table binding.
+		s.bindChangeMu.RUnlock()
 		_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout)
 		return
 	}
@@ -262,27 +279,40 @@ func (s *service) handleForwardLock(
 	s.activeTxnHolder.keepRemoteLockBindActive(req.Lock.ServiceID, req.LockTable)
 	txn := s.activeTxnHolder.getActiveTxn(req.Lock.TxnID, true, req.Lock.ServiceID)
 	txn.Lock()
-	defer txn.Unlock()
 	if !bytes.Equal(txn.txnID, req.Lock.TxnID) {
+		txn.Unlock()
+		s.bindChangeMu.RUnlock()
 		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrTxnNotFound, cs, defaultRPCWriteTimeout)
 		return
 	}
 	if txn.deadlockFound {
+		txn.Unlock()
+		s.bindChangeMu.RUnlock()
 		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrDeadLockDetected, cs, defaultRPCWriteTimeout)
+		return
+	}
+	if txn.bindChanged {
+		txn.Unlock()
+		s.bindChangeMu.RUnlock()
+		_ = writeResponseWithDeadline(s.logger, cancel, resp, ErrLockTableBindChanged, cs, defaultRPCWriteTimeout)
 		return
 	}
 
 	var lockErr error
 	// it needs to inc table bind ref when set restart cn
-	h := txn.getHoldLocksLocked(l.getBind().Group)
-	_, hasBind := h.tableBinds[l.getBind().Table]
+	bind := l.getBind()
+	h := txn.getHoldLocksLocked(bind.Group)
+	_, hasBind := h.tableBinds[bind.Table]
+	txn.lockTableBindAdded(bind)
+	s.bindChangeMu.RUnlock()
+	defer txn.Unlock()
 	defer func() {
 		if s.isStatus(pb.Status_ServiceLockEnable) ||
 			lockErr != nil ||
 			hasBind {
 			return
 		}
-		s.incRef(l.getBind().Group, l.getBind().Table)
+		s.incRef(bind.Group, bind.Table)
 	}()
 
 	l.lock(

--- a/pkg/lockservice/service_remote_test.go
+++ b/pkg/lockservice/service_remote_test.go
@@ -327,21 +327,34 @@ func TestLockWithBindTimeout(t *testing.T) {
 			waitBindDisabled(t, alloc, l1.serviceID)
 
 			txnID2 := []byte("txn2")
-			// l2 hold the old bind, and can not connect to s1, and wait bind changed
-			for {
-				_, err := l2.Lock(ctx, table, [][]byte{{3}}, txnID2, pb.LockOptions{
-					Granularity: pb.Granularity_Row,
-					Mode:        pb.LockMode_Exclusive,
-					Policy:      pb.WaitPolicy_Wait,
-				})
-				if err == nil {
-					// l2 get the bind
-					l := l2.tableGroups.get(0, table)
-					assert.Equal(t, l2.serviceID, l.getBind().ServiceID)
-					return
-				}
-				time.Sleep(time.Millisecond * 100)
-			}
+			// l2 holds the old bind. Once bind change is detected, the old txn is fenced
+			// and the caller must retry with a new txn.
+			_, err := l2.Lock(ctx, table, [][]byte{{3}}, txnID2, pb.LockOptions{
+				Granularity: pb.Granularity_Row,
+				Mode:        pb.LockMode_Exclusive,
+				Policy:      pb.WaitPolicy_Wait,
+			})
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged))
+
+			_, err = l2.Lock(ctx, table, [][]byte{{3}}, txnID2, pb.LockOptions{
+				Granularity: pb.Granularity_Row,
+				Mode:        pb.LockMode_Exclusive,
+				Policy:      pb.WaitPolicy_Wait,
+			})
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged))
+
+			txnID3 := []byte("txn3")
+			_, err = l2.Lock(ctx, table, [][]byte{{3}}, txnID3, pb.LockOptions{
+				Granularity: pb.Granularity_Row,
+				Mode:        pb.LockMode_Exclusive,
+				Policy:      pb.WaitPolicy_Wait,
+			})
+			require.NoError(t, err)
+			require.NoError(t, l2.Unlock(ctx, txnID2, timestamp.Timestamp{}))
+			require.NoError(t, l2.Unlock(ctx, txnID3, timestamp.Timestamp{}))
+
+			l := l2.tableGroups.get(0, table)
+			assert.Equal(t, l2.serviceID, l.getBind().ServiceID)
 		},
 	)
 }
@@ -417,10 +430,29 @@ func TestLockWithBindNotFound(t *testing.T) {
 			// to signal that the caller should retry with the new bind
 			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged))
 
+			txnID3 := []byte("txn3")
+			_, err = l2.Lock(ctx, table, [][]byte{{3}}, txnID3, pb.LockOptions{
+				Granularity: pb.Granularity_Row,
+				Mode:        pb.LockMode_Exclusive,
+				Policy:      pb.WaitPolicy_Wait,
+			})
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged))
+
 			checkBind(
 				t,
 				pb.LockTable{ServiceID: l1.serviceID, Version: alloc.version, Table: table, OriginTable: table, Valid: true},
 				l2)
+
+			txnID4 := []byte("txn4")
+			_, err = l2.Lock(ctx, table, [][]byte{{3}}, txnID4, pb.LockOptions{
+				Granularity: pb.Granularity_Row,
+				Mode:        pb.LockMode_Exclusive,
+				Policy:      pb.WaitPolicy_Wait,
+			})
+			require.NoError(t, err)
+			require.NoError(t, l2.Unlock(ctx, txnID2, timestamp.Timestamp{}))
+			require.NoError(t, l2.Unlock(ctx, txnID3, timestamp.Timestamp{}))
+			require.NoError(t, l2.Unlock(ctx, txnID4, timestamp.Timestamp{}))
 		},
 	)
 }

--- a/pkg/lockservice/service_remote_test.go
+++ b/pkg/lockservice/service_remote_test.go
@@ -346,10 +346,15 @@ func TestUnlockWithBindIsStable(t *testing.T) {
 			txnID2 := []byte("txn2")
 			l2.Unlock(ctx, txnID2, timestamp.Timestamp{})
 
-			checkBind(
-				t,
-				pb.LockTable{ServiceID: l1.serviceID, Version: alloc.version, Table: table, OriginTable: table, Valid: true},
-				l2)
+			bind := l2.tableGroups.get(0, table).getBind()
+			require.Equal(t, l1.serviceID, bind.ServiceID)
+			require.Equal(t, table, bind.Table)
+			require.Equal(t, table, bind.OriginTable)
+			require.True(t, bind.Valid)
+			require.True(t,
+				bind.Version == alloc.version || bind.Version == alloc.version+1,
+				"bind can stay unchanged or be refreshed asynchronously by keepRemoteLock, got %s",
+				bind.DebugString())
 		},
 	)
 }

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -2055,12 +2055,19 @@ func TestIssue3288(t *testing.T) {
 			// No flakiness: no sleep; outcome is determined only by retry-until-success. CI stable
 			// unless the environment is so slow that allocator cannot move bind within 10s.
 			var result pb.Result
+			txnID := []byte("txn2")
+			txnSeq := byte(3)
 			for {
-				result, err = l2.Lock(ctx, 0, [][]byte{{1}}, []byte("txn2"), option)
+				result, err = l2.Lock(ctx, 0, [][]byte{{1}}, txnID, option)
 				if err == nil {
 					break
 				}
-				if moerr.IsMoErrCode(err, moerr.ErrBackendClosed) || moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged) {
+				if moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged) {
+					txnID = []byte{txnSeq}
+					txnSeq++
+					continue
+				}
+				if moerr.IsMoErrCode(err, moerr.ErrBackendClosed) {
 					continue
 				}
 				require.NoError(t, err, "lock must succeed or return retryable error (ErrBackendClosed/ErrLockTableBindChanged)")
@@ -4204,7 +4211,72 @@ func TestIssue2128(t *testing.T) {
 				[][]byte{{1}},
 				[]byte("txn1"),
 				option)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged))
+		},
+	)
+}
+
+func TestBindChangedFencesActiveTxnHoldingOldBind(t *testing.T) {
+	runLockServiceTests(
+		t,
+		[]string{"s1", "s2"},
+		func(alloc *lockTableAllocator, ss []*service) {
+			s := ss[0]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			option := newTestRowExclusiveOptions()
+			txn1 := []byte("txn1")
+			txn2 := []byte("txn2")
+			_, err := s.Lock(ctx, 0, [][]byte{{1}}, txn1, option)
 			require.NoError(t, err)
+			_, err = s.Lock(ctx, 1, [][]byte{{1}}, txn2, option)
+			require.NoError(t, err)
+
+			oldBind := s.tableGroups.get(0, 0).getBind()
+			newBind := oldBind
+			newBind.Version++
+			newBind.ServiceID = "new-service"
+			s.handleBindChanged(newBind)
+
+			_, err = s.Lock(ctx, 1, [][]byte{{2}}, txn1, option)
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged))
+
+			_, err = s.Lock(ctx, 1, [][]byte{{2}}, txn2, option)
+			require.NoError(t, err)
+
+			require.NoError(t, s.Unlock(ctx, txn1, timestamp.Timestamp{}))
+			require.NoError(t, s.Unlock(ctx, txn2, timestamp.Timestamp{}))
+		},
+	)
+}
+
+func TestBindChangedFencesActiveTxnAfterOldTableRemoved(t *testing.T) {
+	runLockServiceTests(
+		t,
+		[]string{"s1", "s2"},
+		func(alloc *lockTableAllocator, ss []*service) {
+			s := ss[0]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			txnID := []byte("txn1")
+			_, err := s.Lock(ctx, 0, [][]byte{{1}}, txnID, newTestRowExclusiveOptions())
+			require.NoError(t, err)
+
+			oldBind := s.tableGroups.get(0, 0).getBind()
+			s.tableGroups.removeWithFilter(func(table uint64, lt lockTable) bool {
+				return table == oldBind.Table
+			}, closeReasonBindChanged)
+
+			newBind := oldBind
+			newBind.Version++
+			newBind.ServiceID = "new-service"
+			s.handleBindChanged(newBind)
+
+			_, err = s.Lock(ctx, 1, [][]byte{{1}}, txnID, newTestRowExclusiveOptions())
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged))
+			require.NoError(t, s.Unlock(ctx, txnID, timestamp.Timestamp{}))
 		},
 	)
 }

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -2121,15 +2121,27 @@ func TestIssue3538(t *testing.T) {
 
 			require.NoError(t, l1.Unlock(ctx, []byte("txn1"), timestamp.Timestamp{}))
 
+			txnID := []byte("txn2")
+			txnSeq := byte(3)
 			for {
 				_, err = l2.Lock(
 					ctx,
 					0,
 					[][]byte{{1}},
-					[]byte("txn2"),
+					txnID,
 					option)
 				if err == nil {
 					break
+				}
+				if moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged) {
+					txnID = []byte{txnSeq}
+					txnSeq++
+				} else if moerr.IsMoErrCode(err, moerr.ErrRetryForCNRollingRestart) ||
+					moerr.IsMoErrCode(err, moerr.ErrBackendClosed) ||
+					moerr.IsMoErrCode(err, moerr.ErrBackendCannotConnect) {
+					// retry with the same txn while the old owner is draining
+				} else {
+					require.NoError(t, err)
 				}
 				select {
 				case <-ctx.Done():

--- a/pkg/lockservice/txn.go
+++ b/pkg/lockservice/txn.go
@@ -47,6 +47,7 @@ type activeTxn struct {
 	lockHolders    map[uint32]*tableLockHolder
 	remoteService  string
 	deadlockFound  bool
+	bindChanged    bool
 
 	// test-only hook: called before lockAdded; return non-nil to abort
 	beforeLockAdded func(txnID []byte, locks [][]byte) error
@@ -136,6 +137,13 @@ func (txn *activeTxn) lockAdded(
 	h.tableKeys[bind.Table] = cs
 	h.tableBinds[bind.Table] = bind
 	return nil
+}
+
+func (txn *activeTxn) lockTableBindAdded(bind pb.LockTable) {
+	h := txn.getHoldLocksLocked(bind.Group)
+	if _, ok := h.tableBinds[bind.Table]; !ok {
+		h.tableBinds[bind.Table] = bind
+	}
 }
 
 func (txn *activeTxn) close(
@@ -230,6 +238,7 @@ func (txn *activeTxn) reset() {
 	txn.blockedWaiters = txn.blockedWaiters[:0]
 	txn.remoteService = ""
 	txn.deadlockFound = false
+	txn.bindChanged = false
 }
 
 func (txn *activeTxn) abort(
@@ -255,6 +264,26 @@ func (txn *activeTxn) abort(
 	for _, w := range txn.blockedWaiters {
 		w.notify(notifyValue{err: err}, logger)
 	}
+}
+
+func (txn *activeTxn) fenceByBindChanged(bind pb.LockTable, logger *log.MOLogger) bool {
+	txn.Lock()
+	defer txn.Unlock()
+
+	h, ok := txn.lockHolders[bind.Group]
+	if !ok {
+		return false
+	}
+	held, ok := h.tableBinds[bind.Table]
+	if !ok || !held.Changed(bind) {
+		return false
+	}
+
+	txn.bindChanged = true
+	for _, w := range txn.blockedWaiters {
+		w.notify(notifyValue{err: ErrLockTableBindChanged}, logger)
+	}
+	return true
 }
 
 func (txn *activeTxn) cancelBlocks(

--- a/pkg/lockservice/txn.go
+++ b/pkg/lockservice/txn.go
@@ -33,8 +33,9 @@ var (
 )
 
 type tableLockHolder struct {
-	tableKeys  map[uint64]*cowSlice
-	tableBinds map[uint64]pb.LockTable
+	tableKeys        map[uint64]*cowSlice
+	tableBinds       map[uint64]pb.LockTable
+	tableBindIntents map[uint64]pb.LockTable
 }
 
 // activeTxn one goroutine write, multi goroutine read
@@ -139,10 +140,10 @@ func (txn *activeTxn) lockAdded(
 	return nil
 }
 
-func (txn *activeTxn) lockTableBindAdded(bind pb.LockTable) {
+func (txn *activeTxn) lockTableBindTouched(bind pb.LockTable) {
 	h := txn.getHoldLocksLocked(bind.Group)
-	if _, ok := h.tableBinds[bind.Table]; !ok {
-		h.tableBinds[bind.Table] = bind
+	if _, ok := h.tableBindIntents[bind.Table]; !ok {
+		h.tableBindIntents[bind.Table] = bind
 	}
 }
 
@@ -228,7 +229,12 @@ func (txn *activeTxn) reset() {
 		for table, cs := range h.tableKeys {
 			cs.close()
 			delete(h.tableKeys, table)
+		}
+		for table := range h.tableBinds {
 			delete(h.tableBinds, table)
+		}
+		for table := range h.tableBindIntents {
+			delete(h.tableBindIntents, table)
 		}
 		delete(txn.lockHolders, g)
 	}
@@ -274,8 +280,10 @@ func (txn *activeTxn) fenceByBindChanged(bind pb.LockTable, logger *log.MOLogger
 	if !ok {
 		return false
 	}
-	held, ok := h.tableBinds[bind.Table]
-	if !ok || !held.Changed(bind) {
+	actual, actualOK := h.tableBinds[bind.Table]
+	intent, intentOK := h.tableBindIntents[bind.Table]
+	if (!actualOK || !actual.Changed(bind)) &&
+		(!intentOK || !intent.Changed(bind)) {
 		return false
 	}
 
@@ -452,8 +460,9 @@ func (txn *activeTxn) getHoldLocksLocked(group uint32) *tableLockHolder {
 		return h
 	}
 	h = &tableLockHolder{
-		tableKeys:  make(map[uint64]*cowSlice),
-		tableBinds: make(map[uint64]pb.LockTable),
+		tableKeys:        make(map[uint64]*cowSlice),
+		tableBinds:       make(map[uint64]pb.LockTable),
+		tableBindIntents: make(map[uint64]pb.LockTable),
 	}
 	txn.lockHolders[group] = h
 	return h

--- a/pkg/lockservice/txn_test.go
+++ b/pkg/lockservice/txn_test.go
@@ -66,6 +66,34 @@ func TestLockAddedThatShouldFail(t *testing.T) {
 	})
 }
 
+func TestLockTableBindTouchedTracksFenceIntentOnly(t *testing.T) {
+	reuse.RunReuseTests(func() {
+		id := []byte("t1")
+		fsp := newFixedSlicePool(2)
+		txn := newActiveTxn(id, string(id), fsp, "")
+		defer reuse.Free(txn, nil)
+
+		bind := pb.LockTable{Group: 0, Table: 1, ServiceID: "s1", Version: 1}
+		txn.lockTableBindTouched(bind)
+
+		h := txn.getHoldLocksLocked(bind.Group)
+		assert.Empty(t, h.tableBinds)
+		assert.Equal(t, bind, h.tableBindIntents[bind.Table])
+
+		refs := make(map[uint32]map[uint64]uint64)
+		txn.incLockTableRef(refs, bind.ServiceID)
+		assert.Empty(t, refs)
+
+		changed := bind
+		changed.Version++
+		assert.True(t, txn.fenceByBindChanged(changed, getLogger("")))
+		assert.True(t, txn.bindChanged)
+
+		txn.reset()
+		assert.Empty(t, txn.lockHolders)
+	})
+}
+
 func TestClose(t *testing.T) {
 	reuse.RunReuseTests(func() {
 		events := newWaiterEvents(1, nil, nil, time.Second, nil, getLogger(""))


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

refs #24346

## What this PR does / why we need it:

This adds lockservice-side fencing for transactions that have touched a stale lock table bind.

When a lock table bind changes, the service now marks active txns that have already tracked the old bind as `bindChanged`. Subsequent local lock, remote lock, and forwarded lock attempts for that txn fail with `ErrLockTableBindChanged`, so the caller rolls back instead of continuing to execute with stale lock ownership.

The change also handles bind changes returned by `KeepRemoteLock` heartbeats, so old-bind transactions can be fenced without waiting for the next business lock RPC. In-flight remote lock RPCs re-check `bindChanged` after the RPC returns before recording lock state, closing the race where a txn could be fenced while an RPC was still in flight.

To avoid broad behavior changes, this is scoped to txns that have tracked the changed table bind. It does not change autocommit retry policy in lockop; that remains handled separately by #24354.

Validation:

- `go test ./pkg/lockservice -run 'Test(LockRemoteChecksBindChangedAfterRPC|BindChangedFencesActiveTxnHoldingOldBind|BindChangedFencesActiveTxnAfterOldTableRemoved|KeepRemoteLockBindChangedFencesActiveTxn|LockWithBindNotFound|Issue3288|Issue2128|LockWithBindIsStale|LockWithBindTimeout|ReLockSuccWithBindChanged|ReLockSuccWithLockTableBindChanged|Issue4007)' -count=1 -timeout=2m`

Note: full `go test ./pkg/lockservice -count=1 -timeout=20m` was also tried locally but timed out in existing `TestIssue3538`; this PR does not modify that unrelated test.
