### PR TITLE
to 4.0: fix(data-branch): unify diff/merge collect-range over arbitrary DAG depth (cherry-pick #24371 to 4.0-dev)

### DIFF
--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -1436,8 +1436,6 @@ func decideCollectRange(
 ) {
 
 	var (
-		lcaRel engine.Relation
-
 		tarSp  types.TS
 		baseSp types.TS
 
@@ -1473,24 +1471,52 @@ func decideCollectRange(
 	baseCTS = tblCommitTS[1]
 
 	// Boundary semantics:
-	// 1. childCreateCommitTS marks when the child table itself becomes visible.
-	//    The cloned rows are materialized by that DDL, so child-owned change collection
-	//    must start from childCreateCommitTS.Next() to avoid re-reading inherited rows.
-	// 2. branchTS marks the source snapshot on the parent/LCA side used by the clone.
-	//    Parent-side incremental comparison must start from branchTS.Next() because the
-	//    snapshot at branchTS is already included in the cloned contents.
-
-	// now we got the t1.snapshot, t1.branchTS, t2.snapshot, t2.branchTS and txnSnapshot,
-	// and then we need to decide the range that t1 and t2 should collect.
+	// ============================================================
+	// Running example used throughout the comments below.
 	//
-	// case 0: special cases:
-	//	i. tar = base
-	//   -|------------|-------------|----
-	//   cts          sp1           sp2
-	//	diff t(sp1) against t(sp2)
-	// 		diff empty against (sp1, sp2]
-	//	diff t(sp2) against t(sp2)
-	//		diff (sp1, sp2] against empty
+	// A multi-fork branch tree (depth 4, 19 nodes, 10 leaves):
+	//
+	//                          t0  (root)
+	//                       /   |   \
+	//                     t1   t2   t3
+	//                    /  \   |   /  \
+	//                  t4   t5 t6  t7   t8
+	//                 / \   /\ /\  /\   /\
+	//                t9 t10 ... t15 t16 ... t18
+	//
+	// Every non-root node was cloned from its parent at some
+	// CloneTS, then performed its own insert/update/delete writes.
+	// The root t0 also performed extra writes after the whole tree
+	// was built. The `data branch diff` query we need to answer:
+	//
+	//     data branch diff t9 against t0
+	//
+	// `t9 against t0` exercises a 3-edge skip: the LCA of (t9, t0)
+	// is t0 itself; the path from LCA down to the target endpoint
+	// is path[LCA → tar] = [t0, t1, t4, t9]; the path on the base
+	// side is path[LCA → base] = [t0]. With this geometry, the
+	// invariants below let us derive the correct collect ranges
+	// for any pair of nodes in any tree shape.
+	//
+	// Boundary semantics:
+	// 1. childCreateCommitTS (child.CTS) marks when the child table
+	//    itself becomes visible. The cloned rows are materialized
+	//    by that DDL, so child-owned change collection must start
+	//    from child.CTS.Next() to avoid re-reading inherited rows.
+	// 2. CloneTS marks the source snapshot on the parent side used
+	//    by the clone. Parent-side incremental comparison ending at
+	//    the next child's CloneTS captures every parent write that
+	//    is still observable on this side (later parent writes are
+	//    invisible — the fork already happened).
+	// ============================================================
+
+	// case 0: tar and base resolve to the same table id.
+	// Diff degenerates into a snapshot-vs-snapshot comparison on
+	// that single relation; the DAG model does not apply.
+	//   -|-----------|------------|----
+	//   cts          sp1          sp2
+	//   diff t(sp1) against t(sp2) → diff empty against (sp1, sp2]
+	//   diff t(sp2) against t(sp1) → diff (sp1, sp2] against empty
 	if tarTableID == baseTableID {
 		if tarSp.LE(&baseSp) {
 			// tar collect nothing
@@ -1518,9 +1544,11 @@ func decideCollectRange(
 		return
 	}
 
-	//
-	// case 1: t1 and t2 have no LCA
-	//	==> t1 collect [0, sp], t2 collect [0, sp]
+	// case 1: tar and base have no LCA (two unrelated tables).
+	// Whole-history diff: each side reads everything it has from
+	// the start of time up to its snapshot. There is no shared
+	// ancestor to anchor the comparison, so the DAG model does
+	// not apply either.
 	if dagInfo.lcaTableId == 0 {
 		tarCollectRange = collectRange{
 			from: []types.TS{types.MinTs()},
@@ -1535,123 +1563,246 @@ func decideCollectRange(
 		return
 	}
 
-	// case 2: t1 and t2 have the LCA t0 (not t1 nor t2)
-	// 	i. t1 and t2 branched from to at the same ts
-	//		==> t1 collect [branchTS+1, sp], t2 collect [branchTS+1, sp]
-	//	ii. t1 and t2 have different branchTS
-	//                             seg2  sp2
-	//		  common    seg1  t2 --------|--->
-	//   t0 |-------|---------|-------------->
-	//             t1 ----------------|----->
-	//					seg3		 sp1
-	// the diff between	(t0.seg1 ∩ t2.seg2)	 and t1.seg3
-	if dagInfo.lcaTableId != tarTableID && dagInfo.lcaTableId != baseTableID {
-		tarCollectRange = collectRange{
-			from: []types.TS{tarCTS.Next()},
-			end:  []types.TS{tarSp},
-			rel:  []engine.Relation{tables.tarRel},
-		}
-		baseCollectRange = collectRange{
-			from: []types.TS{baseCTS.Next()},
-			end:  []types.TS{baseSp},
-			rel:  []engine.Relation{tables.baseRel},
-		}
-		if dagInfo.tarBranchTS.EQ(&dagInfo.baseBranchTS) {
-			// do nothing
-		} else {
-			if lcaRel, err = getRelationById(
-				ctx, ses, bh, dagInfo.lcaTableId, &plan2.Snapshot{
+	// ============================================================
+	// case 2: tar and base share an LCA in the DAG. This is the
+	// general path that must work uniformly for any tree shape and
+	// any depth. We unify what used to be three separate sub-cases
+	// (LCA == base, LCA == tar, LCA == third node) into one model
+	// driven by the LCA→endpoint paths captured in dagInfo.
+	//
+	// Logical state of an endpoint X at some snapshot tX:
+	//
+	//     state(X, tX) = ⋃ over each ancestor A on path[root, X] of
+	//                       writes_on(A) within window_for(A, X, tX)
+	//
+	// Two sides of the diff therefore differ only in writes that
+	// happen on path[LCA, endpoint] of each side — every ancestor
+	// strictly above LCA is shared and contributes the same rows
+	// (folded into both sides' clone-materialization), so it
+	// cancels out and never needs to be read.
+	//
+	// For each ancestor A on path[LCA, endpoint] this side's own
+	// "mutation window" is:
+	//
+	//     windowFrom_A = A.CTS + 1                        (A's own
+	//                                                      writes,
+	//                                                      excluding
+	//                                                      clone)
+	//     windowEnd_A  = nextChildOnPath.CloneTS          (A is on
+	//                                                      the path
+	//                                                      but is not
+	//                                                      the
+	//                                                      endpoint)
+	//                  | endpointSP                       (A is the
+	//                                                      endpoint)
+	//
+	// Walked through on the running example for `diff t9 against t0`:
+	//
+	//   path[LCA → tar]  = [t0, t1, t4, t9]
+	//   path[LCA → base] = [t0]
+	//
+	//   For tar (t9):
+	//     A = t0 (LCA): own writes that *t9* sees =
+	//         (t0.CTS, t1.CloneTS]  ← t0 writes BEFORE t1 was
+	//                                  forked are the ones t9
+	//                                  inherits via the t0→t1→t4→t9
+	//                                  clone chain. After t1 was
+	//                                  forked, t0 mutations are
+	//                                  invisible to t9.
+	//     A = t1 (intermediate): (t1.CTS, t4.CloneTS]
+	//     A = t4 (intermediate): (t4.CTS, t9.CloneTS]
+	//     A = t9 (endpoint):     (t9.CTS, tarSP]
+	//
+	//   For base (t0): A = t0 (endpoint = LCA): (t0.CTS, baseSP]
+	//
+	// Symmetric prefix on the LCA. Both endpoints inherit the LCA's
+	// state cloned at *their* fork moment. The prefix
+	// (LCA.CTS, min(thisFirstChildCloneTS, otherFirstChildCloneTS)]
+	// is therefore identical on both sides and would simply cancel
+	// inside the hash-diff. We clamp this side's LCA window lower
+	// bound up to otherFork.Next() so the IO is skipped entirely.
+	//
+	// Concretely for `diff t9 against t0`: tar's LCA window is
+	// (t0.CTS, t1.CloneTS]. Base IS the LCA, so otherFork = baseSP
+	// (= "now"); since baseSP > t1.CloneTS, the clamp does not move
+	// windowFrom and the full window is collected. Conversely for
+	// base (which is the LCA), tar's first child is t1, so
+	// otherFork = t1.CloneTS and base collects only
+	// (t1.CloneTS, baseSP] — t0's pre-fork writes that t9 already
+	// inherits are not collected on either side.
+	//
+	// The two sides' segment lists feed the hash-diff algorithm,
+	// which still reconciles whatever remaining symmetric writes
+	// reach both sides (e.g. the LCA's own post-fork writes that
+	// some descendants share). The unified model thus generalizes
+	// the historical case-2/3/4 logic into a single walk regardless
+	// of depth or which side hosts the LCA.
+	// ============================================================
+	tarPath := dagInfo.pathFromLCAToTar
+	tarPathTS := dagInfo.pathFromLCAToTarTS
+	basePath := dagInfo.pathFromLCAToBase
+	basePathTS := dagInfo.pathFromLCAToBaseTS
+	if len(tarPath) == 0 || len(basePath) == 0 {
+		err = moerr.NewInternalErrorNoCtxf(
+			"data branch diff: missing DAG path (tar=%d base=%d lca=%d)",
+			tarTableID, baseTableID, dagInfo.lcaTableId,
+		)
+		return
+	}
+
+	if tarCollectRange, err = buildSideCollectRange(
+		ctx, ses, bh, tables, tarSp, tarCTS,
+		tarPath, tarPathTS, basePathTS, baseSp,
+	); err != nil {
+		return
+	}
+	if baseCollectRange, err = buildSideCollectRange(
+		ctx, ses, bh, tables, baseSp, baseCTS,
+		basePath, basePathTS, tarPathTS, tarSp,
+	); err != nil {
+		return
+	}
+	return
+}
+
+// buildSideCollectRange materializes one side of `data branch diff`
+// using the unified ancestor-walk described above. It walks selfPath
+// (LCA → endpoint, top-down) and emits one collect segment per
+// ancestor.
+//
+// Per-ancestor window (A is the i-th node on selfPath):
+//
+//   windowFrom_A = A.CTS.Next()
+//   windowEnd_A  = selfPath[i+1].CloneTS  if A is intermediate
+//                | endpointSP             if A is endpoint
+//
+// LCA prune (i == 0):
+//   windowFrom_A = max(windowFrom_A, otherFork.Next())
+//   where otherFork = otherPath[1].CloneTS if otherEndpoint != LCA
+//                   | otherSP              if otherEndpoint == LCA
+//
+// Walked through on the running example `diff t9 against t0` for the
+// tar side (selfPath = [t0, t1, t4, t9], otherPath = [t0]):
+//
+//   i=0  A = t0 (LCA)
+//        windowFrom = t0.CTS + 1
+//        windowEnd  = t1.CloneTS                       (selfPath[1])
+//        LCA prune:  otherEndpoint == LCA, so otherFork = otherSP
+//                    (= baseSP). baseSP > t1.CloneTS so no clamp.
+//        emit (t0_rel, t0.CTS+1, t1.CloneTS]
+//
+//   i=1  A = t1 (intermediate)
+//        windowFrom = t1.CTS + 1
+//        windowEnd  = t4.CloneTS                       (selfPath[2])
+//        emit (t1_rel, t1.CTS+1, t4.CloneTS]
+//
+//   i=2  A = t4 (intermediate)
+//        windowFrom = t4.CTS + 1
+//        windowEnd  = t9.CloneTS                       (selfPath[3])
+//        emit (t4_rel, t4.CTS+1, t9.CloneTS]
+//
+//   i=3  A = t9 (endpoint)
+//        windowFrom = t9.CTS + 1
+//        windowEnd  = tarSP
+//        emit (t9_rel, t9.CTS+1, tarSP]
+//
+// Empty windows (windowFrom > windowEnd) are dropped silently.
+//
+// Relations are looked up once per node (cache-hit on tar/base/lca,
+// one fresh fetch per intermediate). CTSes are resolved lazily and
+// reuse the already-known endpointCTS for the endpoint.
+func buildSideCollectRange(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	tables tableStuff,
+	endpointSP types.TS,
+	endpointCTS types.TS,
+	selfPath []uint64,
+	selfPathTS []types.TS,
+	otherPathTS []types.TS,
+	otherSP types.TS,
+) (cr collectRange, err error) {
+
+	endpointID := selfPath[len(selfPath)-1]
+	for i, nodeID := range selfPath {
+		var (
+			rel        engine.Relation
+			windowFrom types.TS
+			windowEnd  types.TS
+			nodeCTS    types.TS
+		)
+
+		// Resolve the relation handle for this node.
+		switch {
+		case nodeID == tables.tarRel.GetTableID(ctx):
+			rel = tables.tarRel
+		case nodeID == tables.baseRel.GetTableID(ctx):
+			rel = tables.baseRel
+		case tables.lcaRel != nil && nodeID == tables.lcaRel.GetTableID(ctx):
+			rel = tables.lcaRel
+		default:
+			if rel, err = getRelationById(
+				ctx, ses, bh, nodeID, &plan2.Snapshot{
 					Tenant: &plan.SnapshotTenant{TenantID: ses.GetAccountId()},
-					TS:     &timestamp.Timestamp{PhysicalTime: tarSp.Physical()},
-				}); err != nil {
+					TS:     &timestamp.Timestamp{PhysicalTime: endpointSP.Physical()},
+				},
+			); err != nil {
 				return
 			}
-
-			if dagInfo.tarBranchTS.GT(&dagInfo.baseBranchTS) {
-				tarCollectRange.rel = append(tarCollectRange.rel, lcaRel)
-				tarCollectRange.from = append(tarCollectRange.from, dagInfo.baseBranchTS.Next())
-				tarCollectRange.end = append(tarCollectRange.end, dagInfo.tarBranchTS)
-				dagInfo.tarBranchTS = dagInfo.baseBranchTS
-			} else {
-				baseCollectRange.rel = append(baseCollectRange.rel, lcaRel)
-				baseCollectRange.from = append(baseCollectRange.from, dagInfo.tarBranchTS.Next())
-				baseCollectRange.end = append(baseCollectRange.end, dagInfo.baseBranchTS)
-				dagInfo.baseBranchTS = dagInfo.tarBranchTS
-			}
 		}
-		return
-	}
 
-	// case 3: t1 is the LCA of t1 and t2
-	//	i. t1.sp < t2.branchTS
-	//		t1 -----sp1--------|-------------->
-	//				    seg1  t2-------sp2---->
-	//							  seg2
-	//		==> the diff between null and (t1.seg1 ∩ t2.seg2)
-	//  ii. t1.sp == t2.branchTS
-	//		==> t1 collect nothing, t2 collect [branchTS+1, sp]
-	// iii. t1.sp > t2.branchTS
-	//		==> t1 collect [branchTS+1, sp], t2 collect [branchTS+1, sp]
-	if dagInfo.lcaTableId == baseTableID {
-		// base is the lca
-		if baseSp.LT(&dagInfo.tarBranchTS) {
-			tarCollectRange = collectRange{
-				from: []types.TS{tarCTS.Next(), baseSp.Next()},
-				end:  []types.TS{tarSp, dagInfo.tarBranchTS},
-				rel:  []engine.Relation{tables.tarRel, tables.baseRel},
-			}
-			// base collect nothing
-		} else if baseSp.EQ(&dagInfo.tarBranchTS) {
-			tarCollectRange = collectRange{
-				from: []types.TS{tarCTS.Next()},
-				end:  []types.TS{tarSp},
-				rel:  []engine.Relation{tables.tarRel},
-			}
-			// base collect nothing
+		// Resolve creation commit TS so the window starts after the
+		// clone-materialization commit. Reuse endpointCTS for the
+		// endpoint to avoid a redundant lookup.
+		if nodeID == endpointID {
+			nodeCTS = endpointCTS
 		} else {
-			tarCollectRange = collectRange{
-				from: []types.TS{tarCTS.Next()},
-				end:  []types.TS{tarSp},
-				rel:  []engine.Relation{tables.tarRel},
+			ctsList, err2 := getTablesCreationCommitTS(
+				ctx, ses, rel, rel,
+				[]types.TS{endpointSP, endpointSP},
+			)
+			if err2 != nil {
+				err = err2
+				return
 			}
-			baseCollectRange = collectRange{
-				from: []types.TS{dagInfo.tarBranchTS.Next()},
-				end:  []types.TS{baseSp},
-				rel:  []engine.Relation{tables.baseRel},
+			nodeCTS = ctsList[0]
+		}
+
+		// Window upper bound.
+		if i == len(selfPath)-1 {
+			windowEnd = endpointSP
+		} else {
+			windowEnd = selfPathTS[i+1]
+		}
+
+		// Window lower bound.
+		windowFrom = nodeCTS.Next()
+
+		// LCA prune (i == 0): clamp to skip the prefix that the
+		// other side inherits identically via clone.
+		if i == 0 {
+			var otherFork types.TS
+			if len(otherPathTS) > 1 {
+				otherFork = otherPathTS[1]
+			} else {
+				// Other endpoint IS the LCA; observation goes up to
+				// otherSP.
+				otherFork = otherSP
+			}
+			otherForkNext := otherFork.Next()
+			if otherForkNext.GT(&windowFrom) {
+				windowFrom = otherForkNext
 			}
 		}
-		return
-	}
 
-	// case 4: t2 is the LCA of t1 and t2
-	// tar is the lca
-	if tarSp.LT(&dagInfo.baseBranchTS) {
-		baseCollectRange = collectRange{
-			from: []types.TS{baseCTS.Next(), tarSp.Next()},
-			end:  []types.TS{baseSp, dagInfo.baseBranchTS},
-			rel:  []engine.Relation{tables.baseRel, tables.tarRel},
+		if windowFrom.GT(&windowEnd) {
+			continue
 		}
-		// tar collect nothing
-	} else if tarSp.EQ(&dagInfo.baseBranchTS) {
-		baseCollectRange = collectRange{
-			from: []types.TS{baseCTS.Next()},
-			end:  []types.TS{baseSp},
-			rel:  []engine.Relation{tables.baseRel},
-		}
-		// tar collect nothing
-	} else {
-		baseCollectRange = collectRange{
-			from: []types.TS{baseCTS.Next()},
-			end:  []types.TS{baseSp},
-			rel:  []engine.Relation{tables.baseRel},
-		}
-		tarCollectRange = collectRange{
-			from: []types.TS{dagInfo.baseBranchTS.Next()},
-			end:  []types.TS{tarSp},
-			rel:  []engine.Relation{tables.tarRel},
-		}
+		cr.rel = append(cr.rel, rel)
+		cr.from = append(cr.from, windowFrom)
+		cr.end = append(cr.end, windowEnd)
 	}
-
 	return
 }
 
@@ -1937,6 +2088,29 @@ func decideLCABranchTSFromBranchDAG(
 			lcaTableId:   lcaTableID,
 			tarBranchTS:  tarBranchTS,
 			baseBranchTS: baseBranchTS,
+		}
+		// Capture the full ancestor chains from LCA down to each
+		// endpoint so decideCollectRange can iterate through every
+		// intermediate ancestor (not just the direct child of LCA).
+		// These chains are the foundation of the unified collect-
+		// range model that supports arbitrary tree depths.
+		if dag != nil && hasLca {
+			tarEnd := tblStuff.tarRel.GetTableID(ctx)
+			baseEnd := tblStuff.baseRel.GetTableID(ctx)
+			if ids, tss, ok := dag.PathFromAncestor(tarEnd, lcaTableID); ok {
+				branchInfo.pathFromLCAToTar = ids
+				branchInfo.pathFromLCAToTarTS = make([]types.TS, len(tss))
+				for i, ts := range tss {
+					branchInfo.pathFromLCAToTarTS[i] = types.BuildTS(ts, 0)
+				}
+			}
+			if ids, tss, ok := dag.PathFromAncestor(baseEnd, lcaTableID); ok {
+				branchInfo.pathFromLCAToBase = ids
+				branchInfo.pathFromLCAToBaseTS = make([]types.TS, len(tss))
+				for i, ts := range tss {
+					branchInfo.pathFromLCAToBaseTS[i] = types.BuildTS(ts, 0)
+				}
+			}
 		}
 	}()
 

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -1054,7 +1054,7 @@ func diffOnBase(
 			}
 		}
 	}
-	// has no lca
+
 	if tarHandle, baseHandle, err = constructChangeHandle(
 		ctx, ses, bh, tblStuff, &dagInfo, pkFilter, betweenFrom, betweenTo,
 	); err != nil {
@@ -1470,7 +1470,6 @@ func decideCollectRange(
 	tarCTS = tblCommitTS[0]
 	baseCTS = tblCommitTS[1]
 
-	// Boundary semantics:
 	// ============================================================
 	// Running example used throughout the comments below.
 	//
@@ -2059,6 +2058,21 @@ func locateColumnsInChangeBatch(data *batch.Batch) (relIDIdx, commitTSIdx int) {
 	return
 }
 
+// decideLCABranchTSFromBranchDAG resolves the lineage relationship
+// between tar and base by consulting the branch DAG. It populates
+// branchMetaInfo with:
+//   * lcaType / lcaTableId — coarse classification used downstream by
+//     hashDiff for symmetric vs asymmetric reconciliation;
+//   * tarBranchTS / baseBranchTS — per-side snapshot of the LCA
+//     consumed by findDeleteAndUpdateBat when probing the LCA to
+//     resolve tombstones into full UPDATE / DELETE rows;
+//   * pathFromLCAToTar / pathFromLCAToBase — the full ancestor chain
+//     from LCA down to each endpoint, foundation of the unified
+//     collect-range model in decideCollectRange.
+//
+// The DAG only answers lineage questions: the CloneTS attached to an
+// outgoing edge is the *source* snapshot used by the clone operation
+// on the parent, not the creation commit timestamp of the child.
 func decideLCABranchTSFromBranchDAG(
 	ctx context.Context,
 	ses *Session,
@@ -2069,120 +2083,89 @@ func decideLCABranchTSFromBranchDAG(
 	err error,
 ) {
 
-	var (
-		dag *databranchutils.DataBranchDAG
+	tarTableID := tblStuff.tarRel.GetTableID(ctx)
+	baseTableID := tblStuff.baseRel.GetTableID(ctx)
 
-		tarBranchTableID  uint64
-		baseBranchTableID uint64
-		hasLca            bool
-		lcaType           int
-
-		lcaTableID   uint64
-		tarBranchTS  types.TS
-		baseBranchTS types.TS
-	)
-
-	defer func() {
-		branchInfo = branchMetaInfo{
-			lcaType:      lcaType,
-			lcaTableId:   lcaTableID,
-			tarBranchTS:  tarBranchTS,
-			baseBranchTS: baseBranchTS,
-		}
-		// Capture the full ancestor chains from LCA down to each
-		// endpoint so decideCollectRange can iterate through every
-		// intermediate ancestor (not just the direct child of LCA).
-		// These chains are the foundation of the unified collect-
-		// range model that supports arbitrary tree depths.
-		if dag != nil && hasLca {
-			tarEnd := tblStuff.tarRel.GetTableID(ctx)
-			baseEnd := tblStuff.baseRel.GetTableID(ctx)
-			if ids, tss, ok := dag.PathFromAncestor(tarEnd, lcaTableID); ok {
-				branchInfo.pathFromLCAToTar = ids
-				branchInfo.pathFromLCAToTarTS = make([]types.TS, len(tss))
-				for i, ts := range tss {
-					branchInfo.pathFromLCAToTarTS[i] = types.BuildTS(ts, 0)
-				}
-			}
-			if ids, tss, ok := dag.PathFromAncestor(baseEnd, lcaTableID); ok {
-				branchInfo.pathFromLCAToBase = ids
-				branchInfo.pathFromLCAToBaseTS = make([]types.TS, len(tss))
-				for i, ts := range tss {
-					branchInfo.pathFromLCAToBaseTS[i] = types.BuildTS(ts, 0)
-				}
-			}
-		}
-	}()
-
-	if dag, err = constructBranchDAG(ctx, ses, bh); err != nil {
+	dag, err := constructBranchDAG(ctx, ses, bh)
+	if err != nil {
 		return
 	}
 
-	// 1. has no lca
-	//		[0, now] join [0, now]
-	// 2. t1 and t2 has lca
-	//		1. t0 is the lca
-	//			t1's [branch_t1_ts + 1, now] join t2's [branch_t2_ts + 1, now]
-	// 		2. t1 is the lca
-	//			t1's [branch_t2_ts + 1, now] join t2's [branch_t2_ts + 1, now]
-	//      3. t2 is the lca
-	//			t1's [branch_t1_ts + 1, now] join t2's [branch_t1_ts + 1, now]
-	//
-	// The DAG only answers lineage questions. The branch timestamp attached to an
-	// outgoing edge is the source snapshot used by the clone operation, not the
-	// creation commit timestamp of the child table.
-	if lcaTableID, tarBranchTableID, baseBranchTableID, hasLca = dag.FindLCA(
-		tblStuff.tarRel.GetTableID(ctx), tblStuff.baseRel.GetTableID(ctx),
-	); hasLca {
-		if lcaTableID == tblStuff.baseRel.GetTableID(ctx) {
-			lcaType = lcaRight
-			var ts int64
-			if ts, hasLca = dag.GetCloneTS(tarBranchTableID); !hasLca {
-				err = moerr.NewInternalErrorNoCtxf("cannot find clone ts for table %d", tarBranchTableID)
-				return
-			}
-			tarBranchTS = types.BuildTS(ts, 0)
-			baseBranchTS = tarBranchTS
-		} else if lcaTableID == tblStuff.tarRel.GetTableID(ctx) {
-			lcaType = lcaLeft
-			var ts int64
-			if ts, hasLca = dag.GetCloneTS(baseBranchTableID); !hasLca {
-				err = moerr.NewInternalErrorNoCtxf("cannot find clone ts for table %d", baseBranchTableID)
-				return
-			}
-			baseBranchTS = types.BuildTS(ts, 0)
-			tarBranchTS = baseBranchTS
-		} else {
-			lcaType = lcaOther
-			var ts int64
-			if ts, hasLca = dag.GetCloneTS(tarBranchTableID); !hasLca {
-				err = moerr.NewInternalErrorNoCtxf("cannot find clone ts for table %d", tarBranchTableID)
-				return
-			}
-			tarBranchTS = types.BuildTS(ts, 0)
-			if ts, hasLca = dag.GetCloneTS(baseBranchTableID); !hasLca {
-				err = moerr.NewInternalErrorNoCtxf("cannot find clone ts for table %d", baseBranchTableID)
-				return
-			}
-			baseBranchTS = types.BuildTS(ts, 0)
+	lcaTableID, tarFirstChild, baseFirstChild, hasLca := dag.FindLCA(tarTableID, baseTableID)
+
+	if hasLca {
+		// Walk LCA → endpoint for each side. Path[0] is the LCA;
+		// path[1] (when present) is the LCA's direct child on the
+		// way to the endpoint, whose CloneTS is the moment this
+		// side forked off the LCA.
+		tarPathIDs, tarPathTSs, _ := dag.PathFromAncestor(tarTableID, lcaTableID)
+		basePathIDs, basePathTSs, _ := dag.PathFromAncestor(baseTableID, lcaTableID)
+
+		branchInfo.lcaTableId = lcaTableID
+		branchInfo.pathFromLCAToTar = tarPathIDs
+		branchInfo.pathFromLCAToTarTS = buildTSs(tarPathTSs)
+		branchInfo.pathFromLCAToBase = basePathIDs
+		branchInfo.pathFromLCAToBaseTS = buildTSs(basePathTSs)
+
+		// Per-side LCA snapshot for tombstone resolution. The other
+		// side's first child's CloneTS marks the moment this side's
+		// view of the LCA was forked off (or, when an endpoint IS
+		// the LCA, that endpoint's branchTS collapses with its
+		// clone-source). When LCA == base, tar's view of the LCA is
+		// CloneTS(tarFirstChild) and base — sitting on the LCA
+		// itself — collapses to the same value. The mirror holds
+		// when LCA == tar.
+		switch lcaTableID {
+		case baseTableID:
+			branchInfo.lcaType = lcaRight
+			ts, _ := dag.GetCloneTS(tarFirstChild)
+			branchInfo.tarBranchTS = types.BuildTS(ts, 0)
+			branchInfo.baseBranchTS = branchInfo.tarBranchTS
+		case tarTableID:
+			branchInfo.lcaType = lcaLeft
+			ts, _ := dag.GetCloneTS(baseFirstChild)
+			branchInfo.baseBranchTS = types.BuildTS(ts, 0)
+			branchInfo.tarBranchTS = branchInfo.baseBranchTS
+		default:
+			branchInfo.lcaType = lcaOther
+			tarTS, _ := dag.GetCloneTS(tarFirstChild)
+			baseTS, _ := dag.GetCloneTS(baseFirstChild)
+			branchInfo.tarBranchTS = types.BuildTS(tarTS, 0)
+			branchInfo.baseBranchTS = types.BuildTS(baseTS, 0)
 		}
-	} else if tblStuff.tarRel.GetTableID(ctx) == tblStuff.baseRel.GetTableID(ctx) {
-		lcaTableID = tblStuff.tarRel.GetTableID(ctx)
-		if tblStuff.tarSnap == nil && tblStuff.baseSnap == nil {
-			lcaType = lcaRight
-		} else if tblStuff.tarSnap == nil {
-			// diff tar{now} against base{sp}
-			lcaType = lcaRight
-		} else if tblStuff.baseSnap == nil {
-			// diff tar{sp} against base{now}
-			lcaType = lcaLeft
-		} else if tblStuff.tarSnap.TS.LessEq(*tblStuff.baseSnap.TS) {
-			lcaType = lcaLeft
-		} else {
-			lcaType = lcaRight
+		return
+	}
+
+	// No LCA. Two unrelated tables — diffMergeAgency may still be
+	// dispatched in the rare case of "diff t against t" without any
+	// branch lineage; classify lcaType from the snapshot ordering so
+	// hashDiff still produces a deterministic side-bias.
+	if tarTableID == baseTableID {
+		branchInfo.lcaTableId = tarTableID
+		switch {
+		case tblStuff.tarSnap == nil && tblStuff.baseSnap == nil:
+			branchInfo.lcaType = lcaRight
+		case tblStuff.tarSnap == nil:
+			branchInfo.lcaType = lcaRight
+		case tblStuff.baseSnap == nil:
+			branchInfo.lcaType = lcaLeft
+		case tblStuff.tarSnap.TS.LessEq(*tblStuff.baseSnap.TS):
+			branchInfo.lcaType = lcaLeft
+		default:
+			branchInfo.lcaType = lcaRight
 		}
 	}
 	return
+}
+
+// buildTSs lifts a slice of int64 physical timestamps into the
+// types.TS form expected by branchMetaInfo.
+func buildTSs(in []int64) []types.TS {
+	out := make([]types.TS, len(in))
+	for i, ts := range in {
+		out[i] = types.BuildTS(ts, 0)
+	}
+	return out
 }
 
 func constructBranchDAG(

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -1039,14 +1039,7 @@ func diffOnBase(
 		case tblStuff.baseRel.GetTableID(ctx):
 			tblStuff.lcaRel = tblStuff.baseRel
 		default:
-			txnSP := types.TimestampToTS(ses.GetTxnHandler().GetTxn().SnapshotTS())
-			tarSp, baseSp := txnSP, txnSP
-			if tblStuff.tarSnap != nil && tblStuff.tarSnap.TS != nil {
-				tarSp = types.TimestampToTS(*tblStuff.tarSnap.TS)
-			}
-			if tblStuff.baseSnap != nil && tblStuff.baseSnap.TS != nil {
-				baseSp = types.TimestampToTS(*tblStuff.baseSnap.TS)
-			}
+			tarSp, baseSp := tblStuff.resolvedSnapshots(ses)
 			probe := dagInfo.lcaProbeSnapshot(tarSp, baseSp)
 			lcaSnapshot := &plan2.Snapshot{
 				Tenant: &plan.SnapshotTenant{TenantID: ses.GetAccountId()},
@@ -1440,9 +1433,6 @@ func decideCollectRange(
 ) {
 
 	var (
-		tarSp  types.TS
-		baseSp types.TS
-
 		tarCTS  types.TS
 		baseCTS types.TS
 
@@ -1450,19 +1440,9 @@ func decideCollectRange(
 
 		tarTableID  = tables.tarRel.GetTableID(ctx)
 		baseTableID = tables.baseRel.GetTableID(ctx)
-
-		txnSnapshot = types.TimestampToTS(ses.GetTxnHandler().GetTxn().SnapshotTS())
 	)
 
-	tarSp = txnSnapshot
-	if tables.tarSnap != nil && tables.tarSnap.TS != nil {
-		tarSp = types.TimestampToTS(*tables.tarSnap.TS)
-	}
-
-	baseSp = txnSnapshot
-	if tables.baseSnap != nil && tables.baseSnap.TS != nil {
-		baseSp = types.TimestampToTS(*tables.baseSnap.TS)
-	}
+	tarSp, baseSp := tables.resolvedSnapshots(ses)
 
 	if tblCommitTS, err = getTablesCreationCommitTS(
 		ctx, ses, tables.tarRel, tables.baseRel,
@@ -1667,39 +1647,40 @@ func decideCollectRange(
 //
 // Per-ancestor window (A is the i-th node on selfPath):
 //
-//   windowFrom_A = A.CTS.Next()
-//   windowEnd_A  = selfPath[i+1].CloneTS  if A is intermediate
-//                | endpointSP             if A is endpoint
+//	windowFrom_A = A.CTS.Next()
+//	windowEnd_A  = selfPath[i+1].CloneTS  if A is intermediate
+//	             | endpointSP             if A is endpoint
 //
 // LCA prune (i == 0):
-//   windowFrom_A = max(windowFrom_A, otherFork.Next())
-//   where otherFork = otherPath[1].CloneTS if otherEndpoint != LCA
-//                   | otherSP              if otherEndpoint == LCA
+//
+//	windowFrom_A = max(windowFrom_A, otherFork.Next())
+//	where otherFork = otherPath[1].CloneTS if otherEndpoint != LCA
+//	                | otherSP              if otherEndpoint == LCA
 //
 // Walked through on the running example `diff t9 against t0` for the
 // tar side (selfPath = [t0, t1, t4, t9], otherPath = [t0]):
 //
-//   i=0  A = t0 (LCA)
-//        windowFrom = t0.CTS + 1
-//        windowEnd  = t1.CloneTS                       (selfPath[1])
-//        LCA prune:  otherEndpoint == LCA, so otherFork = otherSP
-//                    (= baseSP). baseSP > t1.CloneTS so no clamp.
-//        emit (t0_rel, t0.CTS+1, t1.CloneTS]
+//	i=0  A = t0 (LCA)
+//	     windowFrom = t0.CTS + 1
+//	     windowEnd  = t1.CloneTS                       (selfPath[1])
+//	     LCA prune:  otherEndpoint == LCA, so otherFork = otherSP
+//	                 (= baseSP). baseSP > t1.CloneTS so no clamp.
+//	     emit (t0_rel, t0.CTS+1, t1.CloneTS]
 //
-//   i=1  A = t1 (intermediate)
-//        windowFrom = t1.CTS + 1
-//        windowEnd  = t4.CloneTS                       (selfPath[2])
-//        emit (t1_rel, t1.CTS+1, t4.CloneTS]
+//	i=1  A = t1 (intermediate)
+//	     windowFrom = t1.CTS + 1
+//	     windowEnd  = t4.CloneTS                       (selfPath[2])
+//	     emit (t1_rel, t1.CTS+1, t4.CloneTS]
 //
-//   i=2  A = t4 (intermediate)
-//        windowFrom = t4.CTS + 1
-//        windowEnd  = t9.CloneTS                       (selfPath[3])
-//        emit (t4_rel, t4.CTS+1, t9.CloneTS]
+//	i=2  A = t4 (intermediate)
+//	     windowFrom = t4.CTS + 1
+//	     windowEnd  = t9.CloneTS                       (selfPath[3])
+//	     emit (t4_rel, t4.CTS+1, t9.CloneTS]
 //
-//   i=3  A = t9 (endpoint)
-//        windowFrom = t9.CTS + 1
-//        windowEnd  = tarSP
-//        emit (t9_rel, t9.CTS+1, tarSP]
+//	i=3  A = t9 (endpoint)
+//	     windowFrom = t9.CTS + 1
+//	     windowEnd  = tarSP
+//	     emit (t9_rel, t9.CTS+1, tarSP]
 //
 // Empty windows (windowFrom > windowEnd) are dropped silently.
 //
@@ -1759,6 +1740,11 @@ func buildSideCollectRange(
 			)
 			if err2 != nil {
 				err = err2
+				return
+			}
+			if len(ctsList) == 0 {
+				err = moerr.NewInternalErrorNoCtxf(
+					"data branch: failed to resolve creation TS for table %d", nodeID)
 				return
 			}
 			nodeCTS = ctsList[0]
@@ -2092,8 +2078,20 @@ func decideLCABranchTSFromBranchDAG(
 	}
 
 	if lcaTableID, _, _, hasLca := dag.FindLCA(tarTableID, baseTableID); hasLca {
-		tarIDs, tarTSs, _ := dag.PathFromAncestor(tarTableID, lcaTableID)
-		baseIDs, baseTSs, _ := dag.PathFromAncestor(baseTableID, lcaTableID)
+		tarIDs, tarTSs, ok := dag.PathFromAncestor(tarTableID, lcaTableID)
+		if !ok {
+			err = moerr.NewInternalErrorNoCtxf(
+				"data branch: DAG path broken from LCA %d to tar %d",
+				lcaTableID, tarTableID)
+			return
+		}
+		baseIDs, baseTSs, ok := dag.PathFromAncestor(baseTableID, lcaTableID)
+		if !ok {
+			err = moerr.NewInternalErrorNoCtxf(
+				"data branch: DAG path broken from LCA %d to base %d",
+				lcaTableID, baseTableID)
+			return
+		}
 		branchInfo.lcaTableId = lcaTableID
 		branchInfo.pathFromLCAToTar = tarIDs
 		branchInfo.pathFromLCAToTarTS = buildTSs(tarTSs)

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -1032,22 +1032,26 @@ func diffOnBase(
 		closeHandle()
 	}()
 
-	if dagInfo.lcaType != lcaEmpty {
-		if dagInfo.lcaTableId == tblStuff.tarRel.GetTableID(ctx) {
+	if dagInfo.hasLCA() {
+		switch dagInfo.lcaTableId {
+		case tblStuff.tarRel.GetTableID(ctx):
 			tblStuff.lcaRel = tblStuff.tarRel
-		} else if dagInfo.lcaTableId == tblStuff.baseRel.GetTableID(ctx) {
+		case tblStuff.baseRel.GetTableID(ctx):
 			tblStuff.lcaRel = tblStuff.baseRel
-		} else {
+		default:
+			txnSP := types.TimestampToTS(ses.GetTxnHandler().GetTxn().SnapshotTS())
+			tarSp, baseSp := txnSP, txnSP
+			if tblStuff.tarSnap != nil && tblStuff.tarSnap.TS != nil {
+				tarSp = types.TimestampToTS(*tblStuff.tarSnap.TS)
+			}
+			if tblStuff.baseSnap != nil && tblStuff.baseSnap.TS != nil {
+				baseSp = types.TimestampToTS(*tblStuff.baseSnap.TS)
+			}
+			probe := dagInfo.lcaProbeSnapshot(tarSp, baseSp)
 			lcaSnapshot := &plan2.Snapshot{
-				Tenant: &plan.SnapshotTenant{
-					TenantID: ses.GetAccountId(),
-				},
+				Tenant: &plan.SnapshotTenant{TenantID: ses.GetAccountId()},
+				TS:     &timestamp.Timestamp{PhysicalTime: probe.Physical()},
 			}
-			lcaSnapshot.TS = &timestamp.Timestamp{PhysicalTime: dagInfo.tarBranchTS.Physical()}
-			if dagInfo.baseBranchTS.LT(&dagInfo.tarBranchTS) {
-				lcaSnapshot.TS.PhysicalTime = dagInfo.baseBranchTS.Physical()
-			}
-
 			if tblStuff.lcaRel, err = getRelationById(
 				ctx, ses, bh, dagInfo.lcaTableId, lcaSnapshot); err != nil {
 				return
@@ -1524,22 +1528,14 @@ func decideCollectRange(
 				end:  []types.TS{baseSp},
 				rel:  []engine.Relation{tables.baseRel},
 			}
-			dagInfo.tarBranchTS = tarSp
-			dagInfo.baseBranchTS = tarSp
 		} else {
 			tarCollectRange = collectRange{
 				from: []types.TS{baseSp.Next()},
 				end:  []types.TS{tarSp},
 				rel:  []engine.Relation{tables.tarRel},
 			}
-
-			dagInfo.tarBranchTS = baseSp
-			dagInfo.baseBranchTS = baseSp
 			// base collect nothing
 		}
-
-		dagInfo.lcaTableId = baseTableID
-
 		return
 	}
 
@@ -2060,19 +2056,23 @@ func locateColumnsInChangeBatch(data *batch.Batch) (relIDIdx, commitTSIdx int) {
 
 // decideLCABranchTSFromBranchDAG resolves the lineage relationship
 // between tar and base by consulting the branch DAG. It populates
-// branchMetaInfo with:
-//   * lcaType / lcaTableId — coarse classification used downstream by
-//     hashDiff for symmetric vs asymmetric reconciliation;
-//   * tarBranchTS / baseBranchTS — per-side snapshot of the LCA
-//     consumed by findDeleteAndUpdateBat when probing the LCA to
-//     resolve tombstones into full UPDATE / DELETE rows;
-//   * pathFromLCAToTar / pathFromLCAToBase — the full ancestor chain
-//     from LCA down to each endpoint, foundation of the unified
-//     collect-range model in decideCollectRange.
+// branchMetaInfo.lcaTableId and the pathFromLCAToTar /
+// pathFromLCAToBase chains. All downstream consumers (collect-range
+// builder, hash-diff, tombstone resolver) derive whatever per-side
+// snapshot or LCA classification they need from these paths via the
+// helper methods on branchMetaInfo.
 //
 // The DAG only answers lineage questions: the CloneTS attached to an
 // outgoing edge is the *source* snapshot used by the clone operation
 // on the parent, not the creation commit timestamp of the child.
+//
+// Special case: when tar and base resolve to the same table id (so
+// the diff is purely snapshot-vs-snapshot on a single relation), no
+// DAG-derived chain is needed but tombstone resolution still wants
+// to probe the table at the earlier of the two snapshots. We model
+// that with synthetic single-node paths so the LCA-snapshot helpers
+// uniformly fall back to the other side's SP, matching the historic
+// case-0 semantics.
 func decideLCABranchTSFromBranchDAG(
 	ctx context.Context,
 	ses *Session,
@@ -2091,69 +2091,27 @@ func decideLCABranchTSFromBranchDAG(
 		return
 	}
 
-	lcaTableID, tarFirstChild, baseFirstChild, hasLca := dag.FindLCA(tarTableID, baseTableID)
-
-	if hasLca {
-		// Walk LCA → endpoint for each side. Path[0] is the LCA;
-		// path[1] (when present) is the LCA's direct child on the
-		// way to the endpoint, whose CloneTS is the moment this
-		// side forked off the LCA.
-		tarPathIDs, tarPathTSs, _ := dag.PathFromAncestor(tarTableID, lcaTableID)
-		basePathIDs, basePathTSs, _ := dag.PathFromAncestor(baseTableID, lcaTableID)
-
+	if lcaTableID, _, _, hasLca := dag.FindLCA(tarTableID, baseTableID); hasLca {
+		tarIDs, tarTSs, _ := dag.PathFromAncestor(tarTableID, lcaTableID)
+		baseIDs, baseTSs, _ := dag.PathFromAncestor(baseTableID, lcaTableID)
 		branchInfo.lcaTableId = lcaTableID
-		branchInfo.pathFromLCAToTar = tarPathIDs
-		branchInfo.pathFromLCAToTarTS = buildTSs(tarPathTSs)
-		branchInfo.pathFromLCAToBase = basePathIDs
-		branchInfo.pathFromLCAToBaseTS = buildTSs(basePathTSs)
-
-		// Per-side LCA snapshot for tombstone resolution. The other
-		// side's first child's CloneTS marks the moment this side's
-		// view of the LCA was forked off (or, when an endpoint IS
-		// the LCA, that endpoint's branchTS collapses with its
-		// clone-source). When LCA == base, tar's view of the LCA is
-		// CloneTS(tarFirstChild) and base — sitting on the LCA
-		// itself — collapses to the same value. The mirror holds
-		// when LCA == tar.
-		switch lcaTableID {
-		case baseTableID:
-			branchInfo.lcaType = lcaRight
-			ts, _ := dag.GetCloneTS(tarFirstChild)
-			branchInfo.tarBranchTS = types.BuildTS(ts, 0)
-			branchInfo.baseBranchTS = branchInfo.tarBranchTS
-		case tarTableID:
-			branchInfo.lcaType = lcaLeft
-			ts, _ := dag.GetCloneTS(baseFirstChild)
-			branchInfo.baseBranchTS = types.BuildTS(ts, 0)
-			branchInfo.tarBranchTS = branchInfo.baseBranchTS
-		default:
-			branchInfo.lcaType = lcaOther
-			tarTS, _ := dag.GetCloneTS(tarFirstChild)
-			baseTS, _ := dag.GetCloneTS(baseFirstChild)
-			branchInfo.tarBranchTS = types.BuildTS(tarTS, 0)
-			branchInfo.baseBranchTS = types.BuildTS(baseTS, 0)
-		}
+		branchInfo.pathFromLCAToTar = tarIDs
+		branchInfo.pathFromLCAToTarTS = buildTSs(tarTSs)
+		branchInfo.pathFromLCAToBase = baseIDs
+		branchInfo.pathFromLCAToBaseTS = buildTSs(baseTSs)
 		return
 	}
 
-	// No LCA. Two unrelated tables — diffMergeAgency may still be
-	// dispatched in the rare case of "diff t against t" without any
-	// branch lineage; classify lcaType from the snapshot ordering so
-	// hashDiff still produces a deterministic side-bias.
+	// No DAG-derived LCA, but if tar and base resolve to the same
+	// table id we still need to feed downstream tombstone resolution
+	// with a probe snapshot. Synthetic single-node paths give the
+	// branchMetaInfo helpers exactly that.
 	if tarTableID == baseTableID {
 		branchInfo.lcaTableId = tarTableID
-		switch {
-		case tblStuff.tarSnap == nil && tblStuff.baseSnap == nil:
-			branchInfo.lcaType = lcaRight
-		case tblStuff.tarSnap == nil:
-			branchInfo.lcaType = lcaRight
-		case tblStuff.baseSnap == nil:
-			branchInfo.lcaType = lcaLeft
-		case tblStuff.tarSnap.TS.LessEq(*tblStuff.baseSnap.TS):
-			branchInfo.lcaType = lcaLeft
-		default:
-			branchInfo.lcaType = lcaRight
-		}
+		branchInfo.pathFromLCAToTar = []uint64{tarTableID}
+		branchInfo.pathFromLCAToTarTS = []types.TS{{}}
+		branchInfo.pathFromLCAToBase = []uint64{baseTableID}
+		branchInfo.pathFromLCAToBaseTS = []types.TS{{}}
 	}
 	return
 }

--- a/pkg/frontend/data_branch_hashdiff.go
+++ b/pkg/frontend/data_branch_hashdiff.go
@@ -645,7 +645,7 @@ func hashDiff(
 		fields := []zap.Field{
 			zap.Int("base-handle-cnt", len(baseHandle)),
 			zap.Int("target-handle-cnt", len(tarHandle)),
-			zap.Int("lca-type", dagInfo.lcaType),
+			zap.Bool("has-lca", dagInfo.hasLCA()),
 			zap.Duration("build-base-cost", buildBaseCost),
 			zap.Duration("build-target-cost", buildTargetCost),
 			zap.Duration("diff-cost", diffCost),
@@ -661,7 +661,7 @@ func hashDiff(
 
 	buildBaseStart := time.Now()
 	if baseDataHashmap, baseTombstoneHashmap, err = buildHashmapForTable(
-		ctx, ses.proc.Mp(), dagInfo.lcaType, &tblStuff, baseHandle, "base", pickKeyHashmap,
+		ctx, ses.proc.Mp(), &tblStuff, baseHandle, "base", pickKeyHashmap,
 	); err != nil {
 		return
 	}
@@ -669,16 +669,16 @@ func hashDiff(
 
 	buildTargetStart := time.Now()
 	if tarDataHashmap, tarTombstoneHashmap, err = buildHashmapForTable(
-		ctx, ses.proc.Mp(), dagInfo.lcaType, &tblStuff, tarHandle, "target", pickKeyHashmap,
+		ctx, ses.proc.Mp(), &tblStuff, tarHandle, "target", pickKeyHashmap,
 	); err != nil {
 		return
 	}
 	buildTargetCost = time.Since(buildTargetStart)
 
 	diffStart := time.Now()
-	if dagInfo.lcaType == lcaEmpty {
+	if !dagInfo.hasLCA() {
 		if err = hashDiffIfNoLCA(
-			ctx, ses, tblStuff, dagInfo.lcaType, copt, emit,
+			ctx, ses, tblStuff, copt, emit,
 			tarDataHashmap, tarTombstoneHashmap,
 			baseDataHashmap, baseTombstoneHashmap,
 		); err != nil {
@@ -711,6 +711,21 @@ func hashDiffIfHasLCA(
 	baseDataHashmap databranchutils.BranchHashmap,
 	baseTombstoneHashmap databranchutils.BranchHashmap,
 ) (err error) {
+
+	// Resolve per-side LCA snapshots once: each side's tombstone
+	// resolution probes the LCA at "the moment THIS side forked off
+	// the LCA" (or, when the side IS the LCA, at the OTHER side's
+	// snapshot — see branchMetaInfo helper docs).
+	txnSP := types.TimestampToTS(ses.GetTxnHandler().GetTxn().SnapshotTS())
+	tarSP, baseSP := txnSP, txnSP
+	if tblStuff.tarSnap != nil && tblStuff.tarSnap.TS != nil {
+		tarSP = types.TimestampToTS(*tblStuff.tarSnap.TS)
+	}
+	if tblStuff.baseSnap != nil && tblStuff.baseSnap.TS != nil {
+		baseSP = types.TimestampToTS(*tblStuff.baseSnap.TS)
+	}
+	tarLCAProbe := dagInfo.tarLCASnapshot(baseSP)
+	baseLCAProbe := dagInfo.baseLCASnapshot(tarSP)
 
 	var (
 		wg        sync.WaitGroup
@@ -951,14 +966,14 @@ func hashDiffIfHasLCA(
 
 	asyncDelsAndUpdatesHandler := func(forBase bool, tmpCh chan batchWithKind) (err2 error) {
 		var (
-			branchTS = dagInfo.baseBranchTS
+			branchTS = baseLCAProbe
 			hashmap1 = baseDataHashmap
 			hashmap2 = baseTombstoneHashmap
 			name     = tblStuff.baseRel.GetTableName()
 		)
 
 		if !forBase {
-			branchTS = dagInfo.tarBranchTS
+			branchTS = tarLCAProbe
 			hashmap1 = tarDataHashmap
 			hashmap2 = tarTombstoneHashmap
 			name = tblStuff.tarRel.GetTableName()
@@ -1090,14 +1105,13 @@ func hashDiffIfHasLCA(
 		}
 	}
 
-	return diffDataHelper(ctx, ses, dagInfo.lcaType, copt, tblStuff, emit, tarDataHashmap, baseDataHashmap)
+	return diffDataHelper(ctx, ses, copt, tblStuff, emit, tarDataHashmap, baseDataHashmap)
 }
 
 func hashDiffIfNoLCA(
 	ctx context.Context,
 	ses *Session,
 	tblStuff tableStuff,
-	lcaType int,
 	copt compositeOption,
 	emit emitFunc,
 	tarDataHashmap databranchutils.BranchHashmap,
@@ -1126,7 +1140,7 @@ func hashDiffIfNoLCA(
 		return
 	}
 
-	return diffDataHelper(ctx, ses, lcaType, copt, tblStuff, emit, tarDataHashmap, baseDataHashmap)
+	return diffDataHelper(ctx, ses, copt, tblStuff, emit, tarDataHashmap, baseDataHashmap)
 }
 
 func compareRowInWrappedBatches(
@@ -1642,7 +1656,6 @@ func checkConflictAndAppendToBat(
 func diffDataHelper(
 	ctx context.Context,
 	ses *Session,
-	lcaType int,
 	copt compositeOption,
 	tblStuff tableStuff,
 	emit emitFunc,
@@ -1889,7 +1902,6 @@ func diffDataHelper(
 func buildHashmapForTable(
 	ctx context.Context,
 	mp *mpool.MPool,
-	lcaType int,
 	tblStuff *tableStuff,
 	handles []engine.ChangesHandle,
 	side string,

--- a/pkg/frontend/data_branch_hashdiff.go
+++ b/pkg/frontend/data_branch_hashdiff.go
@@ -716,14 +716,7 @@ func hashDiffIfHasLCA(
 	// resolution probes the LCA at "the moment THIS side forked off
 	// the LCA" (or, when the side IS the LCA, at the OTHER side's
 	// snapshot — see branchMetaInfo helper docs).
-	txnSP := types.TimestampToTS(ses.GetTxnHandler().GetTxn().SnapshotTS())
-	tarSP, baseSP := txnSP, txnSP
-	if tblStuff.tarSnap != nil && tblStuff.tarSnap.TS != nil {
-		tarSP = types.TimestampToTS(*tblStuff.tarSnap.TS)
-	}
-	if tblStuff.baseSnap != nil && tblStuff.baseSnap.TS != nil {
-		baseSP = types.TimestampToTS(*tblStuff.baseSnap.TS)
-	}
+	tarSP, baseSP := tblStuff.resolvedSnapshots(ses)
 	tarLCAProbe := dagInfo.tarLCASnapshot(baseSP)
 	baseLCAProbe := dagInfo.baseLCASnapshot(tarSP)
 

--- a/pkg/frontend/data_branch_hashdiff_test.go
+++ b/pkg/frontend/data_branch_hashdiff_test.go
@@ -184,7 +184,6 @@ func TestDiffDataHelper_Basic(t *testing.T) {
 	err := diffDataHelper(
 		context.Background(),
 		ses,
-		0,
 		compositeOption{},
 		tblStuff,
 		func(w batchWithKind) (bool, error) {
@@ -242,7 +241,6 @@ func TestDiffDataHelper_ConflictAcceptExpandUpdate(t *testing.T) {
 	err := diffDataHelper(
 		context.Background(),
 		ses,
-		0,
 		compositeOption{
 			conflictOpt:  &tree.ConflictOpt{Opt: tree.CONFLICT_ACCEPT},
 			expandUpdate: true,
@@ -821,7 +819,7 @@ func TestHashDiff_NoLCAWithStubHandles(t *testing.T) {
 		ses,
 		nil,
 		tblStuff,
-		branchMetaInfo{lcaType: lcaEmpty},
+		branchMetaInfo{},
 		compositeOption{},
 		func(w batchWithKind) (bool, error) {
 			rows := decodeCapturedRows(t, w.batch, tblStuff.def.colTypes)

--- a/pkg/frontend/data_branch_types.go
+++ b/pkg/frontend/data_branch_types.go
@@ -89,6 +89,44 @@ type branchMetaInfo struct {
 	lcaTableId   uint64
 	tarBranchTS  types.TS
 	baseBranchTS types.TS
+
+	// pathFromLCAToTar / pathFromLCAToBase carry the full DAG chain
+	// from the LCA (lowest common ancestor of tar and base) down to
+	// each endpoint. Index 0 is the LCA itself; the last index is
+	// the endpoint. pathFromLCAToXxxTS[i] holds the CloneTS of the
+	// i-th node (the i-th node was cloned off the (i-1)-th node at
+	// that timestamp; pathFromLCAToXxxTS[0] is the LCA's own
+	// CloneTS, which is unused for diff purposes — the LCA's own
+	// mutation window starts at its creation commit TS instead).
+	//
+	// Running example. Tree (depth 4, 19 nodes, 10 leaves):
+	//
+	//                          t0
+	//                       /   |   \
+	//                     t1   t2   t3
+	//                    /  \   |   /  \
+	//                  t4   t5 t6  t7   t8
+	//                 / \   /\ /\  /\   /\
+	//                t9 t10 ... ... ... t18
+	//
+	// For `data branch diff t9 against t0`:
+	//   pathFromLCAToTar  = [t0, t1, t4, t9]
+	//   pathFromLCAToBase = [t0]
+	// For `data branch diff t9 against t11` (t11 sits under t5):
+	//   pathFromLCAToTar  = [t1, t4, t9]
+	//   pathFromLCAToBase = [t1, t5, t11]
+	// For `data branch diff t9 against t13` (t13 sits under t2→t6):
+	//   pathFromLCAToTar  = [t0, t1, t4, t9]
+	//   pathFromLCAToBase = [t0, t2, t6, t13]
+	//
+	// These chains let decideCollectRange iterate every intermediate
+	// ancestor (not just the direct child of LCA) and emit one
+	// collect segment per ancestor, surfacing inherited mutations
+	// that would otherwise be invisible to a single-relation scan.
+	pathFromLCAToTar    []uint64
+	pathFromLCAToTarTS  []types.TS
+	pathFromLCAToBase   []uint64
+	pathFromLCAToBaseTS []types.TS
 }
 
 type tableStuff struct {

--- a/pkg/frontend/data_branch_types.go
+++ b/pkg/frontend/data_branch_types.go
@@ -98,23 +98,28 @@ type collectRange struct {
 //
 // Running example. Tree (depth 4, 19 nodes, 10 leaves):
 //
-//                          t0
-//                       /   |   \
-//                     t1   t2   t3
-//                    /  \   |   /  \
-//                  t4   t5 t6  t7   t8
-//                 / \   /\ /\  /\   /\
-//                t9 t10 ... ... ... t18
+//	          t0
+//	       /   |   \
+//	     t1   t2   t3
+//	    /  \   |   /  \
+//	  t4   t5 t6  t7   t8
+//	 / \   /\ /\  /\   /\
+//	t9 t10 ... ... ... t18
 //
 // For `data branch diff t9 against t0`:
-//   pathFromLCAToTar  = [t0, t1, t4, t9]
-//   pathFromLCAToBase = [t0]
+//
+//	pathFromLCAToTar  = [t0, t1, t4, t9]
+//	pathFromLCAToBase = [t0]
+//
 // For `data branch diff t9 against t11` (t11 sits under t5):
-//   pathFromLCAToTar  = [t1, t4, t9]
-//   pathFromLCAToBase = [t1, t5, t11]
+//
+//	pathFromLCAToTar  = [t1, t4, t9]
+//	pathFromLCAToBase = [t1, t5, t11]
+//
 // For `data branch diff t9 against t13` (t13 sits under t2→t6):
-//   pathFromLCAToTar  = [t0, t1, t4, t9]
-//   pathFromLCAToBase = [t0, t2, t6, t13]
+//
+//	pathFromLCAToTar  = [t0, t1, t4, t9]
+//	pathFromLCAToBase = [t0, t2, t6, t13]
 type branchMetaInfo struct {
 	lcaTableId uint64
 
@@ -203,6 +208,23 @@ type tableStuff struct {
 	retPool *retBatchList
 
 	bufPool *sync.Pool
+}
+
+// resolvedSnapshots returns the effective per-side snapshot timestamps:
+// the snapshot bound to {tar,base}Snap when present, otherwise the
+// session's transaction snapshot. Centralized here so every call site
+// (decideCollectRange, diffOnBase, hashDiffIfHasLCA) uses the exact
+// same derivation.
+func (t *tableStuff) resolvedSnapshots(ses *Session) (tarSP, baseSP types.TS) {
+	tarSP = types.TimestampToTS(ses.GetTxnHandler().GetTxn().SnapshotTS())
+	baseSP = tarSP
+	if t.tarSnap != nil && t.tarSnap.TS != nil {
+		tarSP = types.TimestampToTS(*t.tarSnap.TS)
+	}
+	if t.baseSnap != nil && t.baseSnap.TS != nil {
+		baseSP = types.TimestampToTS(*t.baseSnap.TS)
+	}
+	return
 }
 
 type batchWithKind struct {

--- a/pkg/frontend/data_branch_types.go
+++ b/pkg/frontend/data_branch_types.go
@@ -64,13 +64,6 @@ type branchHashmapDeallocator struct {
 var diffTempTableSeq uint64
 
 const (
-	lcaEmpty = iota
-	lcaOther
-	lcaLeft
-	lcaRight
-)
-
-const (
 	maxSqlBatchCnt   = objectio.BlockMaxRows * 10
 	maxSqlBatchSize  = mpool.MB * 32
 	defaultRowBytes  = int64(128)
@@ -84,49 +77,94 @@ type collectRange struct {
 	rel  []engine.Relation
 }
 
+// branchMetaInfo describes the lineage relationship between the two
+// endpoints of a `data branch diff` request, expressed entirely as
+// the DAG paths from the LCA (lowest common ancestor) down to each
+// endpoint.
+//
+// All downstream consumers (decideCollectRange, hashDiff,
+// findDeleteAndUpdateBat, …) derive whatever they need from these
+// paths through the helper methods on this struct, so the path
+// fields are the single source of truth for diff lineage.
+//
+// Path encoding. Index 0 is the LCA itself; the last index is the
+// endpoint. pathFromLCAToXxxTS[i] is the CloneTS of node i (i.e. the
+// moment node i was forked off node i-1). Index 0 holds the LCA's
+// own CloneTS, which is unused for diff purposes — the LCA's own
+// mutation window always starts at its creation commit TS instead.
+//
+// lcaTableId == 0 means "no LCA" (two unrelated tables, or
+// snapshot-only diff on a single table without branch lineage).
+//
+// Running example. Tree (depth 4, 19 nodes, 10 leaves):
+//
+//                          t0
+//                       /   |   \
+//                     t1   t2   t3
+//                    /  \   |   /  \
+//                  t4   t5 t6  t7   t8
+//                 / \   /\ /\  /\   /\
+//                t9 t10 ... ... ... t18
+//
+// For `data branch diff t9 against t0`:
+//   pathFromLCAToTar  = [t0, t1, t4, t9]
+//   pathFromLCAToBase = [t0]
+// For `data branch diff t9 against t11` (t11 sits under t5):
+//   pathFromLCAToTar  = [t1, t4, t9]
+//   pathFromLCAToBase = [t1, t5, t11]
+// For `data branch diff t9 against t13` (t13 sits under t2→t6):
+//   pathFromLCAToTar  = [t0, t1, t4, t9]
+//   pathFromLCAToBase = [t0, t2, t6, t13]
 type branchMetaInfo struct {
-	lcaType      int
-	lcaTableId   uint64
-	tarBranchTS  types.TS
-	baseBranchTS types.TS
+	lcaTableId uint64
 
-	// pathFromLCAToTar / pathFromLCAToBase carry the full DAG chain
-	// from the LCA (lowest common ancestor of tar and base) down to
-	// each endpoint. Index 0 is the LCA itself; the last index is
-	// the endpoint. pathFromLCAToXxxTS[i] holds the CloneTS of the
-	// i-th node (the i-th node was cloned off the (i-1)-th node at
-	// that timestamp; pathFromLCAToXxxTS[0] is the LCA's own
-	// CloneTS, which is unused for diff purposes — the LCA's own
-	// mutation window starts at its creation commit TS instead).
-	//
-	// Running example. Tree (depth 4, 19 nodes, 10 leaves):
-	//
-	//                          t0
-	//                       /   |   \
-	//                     t1   t2   t3
-	//                    /  \   |   /  \
-	//                  t4   t5 t6  t7   t8
-	//                 / \   /\ /\  /\   /\
-	//                t9 t10 ... ... ... t18
-	//
-	// For `data branch diff t9 against t0`:
-	//   pathFromLCAToTar  = [t0, t1, t4, t9]
-	//   pathFromLCAToBase = [t0]
-	// For `data branch diff t9 against t11` (t11 sits under t5):
-	//   pathFromLCAToTar  = [t1, t4, t9]
-	//   pathFromLCAToBase = [t1, t5, t11]
-	// For `data branch diff t9 against t13` (t13 sits under t2→t6):
-	//   pathFromLCAToTar  = [t0, t1, t4, t9]
-	//   pathFromLCAToBase = [t0, t2, t6, t13]
-	//
-	// These chains let decideCollectRange iterate every intermediate
-	// ancestor (not just the direct child of LCA) and emit one
-	// collect segment per ancestor, surfacing inherited mutations
-	// that would otherwise be invisible to a single-relation scan.
 	pathFromLCAToTar    []uint64
 	pathFromLCAToTarTS  []types.TS
 	pathFromLCAToBase   []uint64
 	pathFromLCAToBaseTS []types.TS
+}
+
+// hasLCA reports whether tar and base share a common ancestor in the
+// branch DAG.
+func (m *branchMetaInfo) hasLCA() bool {
+	return m.lcaTableId != 0
+}
+
+// tarLCASnapshot is the LCA-side snapshot from which tar inherited
+// its initial state. It is the moment the OTHER side (base) forked
+// off the LCA, i.e. base's first child clone TS — or, when base IS
+// the LCA itself, base's own snapshot collapses with this value
+// (the caller passes baseSP for that scenario).
+//
+// Used by tombstone resolution (findDeleteAndUpdateBat) to read the
+// LCA at the right snapshot when expanding tar-side tombstones into
+// full UPDATE / DELETE rows.
+func (m *branchMetaInfo) tarLCASnapshot(baseSP types.TS) types.TS {
+	if len(m.pathFromLCAToBase) > 1 {
+		return m.pathFromLCAToBaseTS[1]
+	}
+	return baseSP
+}
+
+// baseLCASnapshot is the mirror of tarLCASnapshot for the base side.
+func (m *branchMetaInfo) baseLCASnapshot(tarSP types.TS) types.TS {
+	if len(m.pathFromLCAToTar) > 1 {
+		return m.pathFromLCAToTarTS[1]
+	}
+	return tarSP
+}
+
+// lcaProbeSnapshot is the snapshot used by diffOnBase to fetch the
+// LCA relation handle when the LCA is a third-party node (neither
+// tar nor base). It is the earlier of the two per-side snapshots so
+// the relation handle is valid on both sides' views of the LCA.
+func (m *branchMetaInfo) lcaProbeSnapshot(tarSP, baseSP types.TS) types.TS {
+	t := m.tarLCASnapshot(baseSP)
+	b := m.baseLCASnapshot(tarSP)
+	if t.LT(&b) {
+		return t
+	}
+	return b
 }
 
 type tableStuff struct {

--- a/pkg/frontend/data_branch_types.go
+++ b/pkg/frontend/data_branch_types.go
@@ -130,16 +130,20 @@ func (m *branchMetaInfo) hasLCA() bool {
 	return m.lcaTableId != 0
 }
 
-// tarLCASnapshot is the LCA-side snapshot from which tar inherited
-// its initial state. It is the moment the OTHER side (base) forked
-// off the LCA, i.e. base's first child clone TS — or, when base IS
-// the LCA itself, base's own snapshot collapses with this value
-// (the caller passes baseSP for that scenario).
+// tarLCASnapshot is the snapshot of the LCA at which tar's view of
+// the LCA's state is anchored. It feeds tombstone resolution on the
+// tar side: tar's tombstones must be resolved against the LCA at
+// this moment.
 //
-// Used by tombstone resolution (findDeleteAndUpdateBat) to read the
-// LCA at the right snapshot when expanding tar-side tombstones into
-// full UPDATE / DELETE rows.
+// When tar forked off the LCA (len(pathFromLCAToTar) > 1), the
+// anchor is tar's own first-child CloneTS — the moment tar diverged.
+// When tar IS the LCA (length-1 path), tar inherits the meeting
+// point from base: base's first-child CloneTS, or baseSP if base is
+// also the LCA (case-0 same-table diff).
 func (m *branchMetaInfo) tarLCASnapshot(baseSP types.TS) types.TS {
+	if len(m.pathFromLCAToTar) > 1 {
+		return m.pathFromLCAToTarTS[1]
+	}
 	if len(m.pathFromLCAToBase) > 1 {
 		return m.pathFromLCAToBaseTS[1]
 	}
@@ -148,6 +152,9 @@ func (m *branchMetaInfo) tarLCASnapshot(baseSP types.TS) types.TS {
 
 // baseLCASnapshot is the mirror of tarLCASnapshot for the base side.
 func (m *branchMetaInfo) baseLCASnapshot(tarSP types.TS) types.TS {
+	if len(m.pathFromLCAToBase) > 1 {
+		return m.pathFromLCAToBaseTS[1]
+	}
 	if len(m.pathFromLCAToTar) > 1 {
 		return m.pathFromLCAToTarTS[1]
 	}

--- a/pkg/frontend/databranchutils/branch_dag.go
+++ b/pkg/frontend/databranchutils/branch_dag.go
@@ -215,3 +215,60 @@ func (d *DataBranchDAG) GetCloneTS(tableID uint64) (int64, bool) {
 	}
 	return node.CloneTS, true
 }
+
+// PathFromAncestor returns the table IDs and clone timestamps along the
+// chain from ancestorID (inclusive) down to descendantID (inclusive).
+// Entries are ordered top-down: result[0] is ancestorID, result[len-1]
+// is descendantID. Returns ok=false if descendantID is not a (possibly
+// transitive) descendant of ancestorID.
+//
+// cloneTSes[0] is ancestorID's own CloneTS (or 0 if ancestorID is a
+// root); cloneTSes[i] for i>0 is the CloneTS of result[i] (i.e. the
+// moment result[i] was forked off result[i-1]).
+//
+// Used by `data branch diff` to walk every ancestor between the LCA
+// and each endpoint — supporting arbitrary tree depths uniformly.
+//
+// Example. With the tree
+//
+//                          t0
+//                       /   |   \
+//                     t1   t2   t3
+//                     |     |
+//                    t4    t6
+//                    /
+//                   t9
+//
+// PathFromAncestor(t9, t0) = ([t0, t1, t4, t9], [<cts>, <cts>, <cts>, <cts>], true)
+// PathFromAncestor(t6, t0) = ([t0, t2, t6], ..., true)
+// PathFromAncestor(t9, t1) = ([t1, t4, t9], ..., true)
+// PathFromAncestor(t9, t6) = (nil, nil, false)              // not on the chain
+func (d *DataBranchDAG) PathFromAncestor(descendantID, ancestorID uint64) (
+	tableIDs []uint64,
+	cloneTSes []int64,
+	ok bool,
+) {
+	node, exists := d.nodes[descendantID]
+	if !exists {
+		return nil, nil, false
+	}
+	// Walk up from descendant collecting nodes; stop when we reach
+	// ancestor (inclusive) or run off the top.
+	for node != nil {
+		tableIDs = append(tableIDs, node.TableID)
+		cloneTSes = append(cloneTSes, node.CloneTS)
+		if node.TableID == ancestorID {
+			break
+		}
+		node = node.Parent
+	}
+	if node == nil || node.TableID != ancestorID {
+		return nil, nil, false
+	}
+	// Reverse into top-down order (ancestor first).
+	for i, j := 0, len(tableIDs)-1; i < j; i, j = i+1, j-1 {
+		tableIDs[i], tableIDs[j] = tableIDs[j], tableIDs[i]
+		cloneTSes[i], cloneTSes[j] = cloneTSes[j], cloneTSes[i]
+	}
+	return tableIDs, cloneTSes, true
+}

--- a/pkg/frontend/databranchutils/branch_dag.go
+++ b/pkg/frontend/databranchutils/branch_dag.go
@@ -216,11 +216,19 @@ func (d *DataBranchDAG) GetCloneTS(tableID uint64) (int64, bool) {
 	return node.CloneTS, true
 }
 
+// maxBranchDAGDepth bounds PathFromAncestor's walk so a corrupted
+// DAG with a Parent-pointer cycle cannot drive an infinite loop.
+// In practice user-visible chains never approach this limit; deep
+// real-world trees have been seen to ~16 levels.
+const maxBranchDAGDepth = 1024
+
 // PathFromAncestor returns the table IDs and clone timestamps along the
 // chain from ancestorID (inclusive) down to descendantID (inclusive).
 // Entries are ordered top-down: result[0] is ancestorID, result[len-1]
 // is descendantID. Returns ok=false if descendantID is not a (possibly
-// transitive) descendant of ancestorID.
+// transitive) descendant of ancestorID, or if the walk exceeds
+// maxBranchDAGDepth (a defense-in-depth guard against a corrupted DAG
+// with a cycle in Parent pointers).
 //
 // cloneTSes[0] is ancestorID's own CloneTS (or 0 if ancestorID is a
 // root); cloneTSes[i] for i>0 is the CloneTS of result[i] (i.e. the
@@ -231,13 +239,13 @@ func (d *DataBranchDAG) GetCloneTS(tableID uint64) (int64, bool) {
 //
 // Example. With the tree
 //
-//                          t0
-//                       /   |   \
-//                     t1   t2   t3
-//                     |     |
-//                    t4    t6
-//                    /
-//                   t9
+//	       t0
+//	    /   |   \
+//	  t1   t2   t3
+//	  |     |
+//	 t4    t6
+//	 /
+//	t9
 //
 // PathFromAncestor(t9, t0) = ([t0, t1, t4, t9], [<cts>, <cts>, <cts>, <cts>], true)
 // PathFromAncestor(t6, t0) = ([t0, t2, t6], ..., true)
@@ -253,22 +261,20 @@ func (d *DataBranchDAG) PathFromAncestor(descendantID, ancestorID uint64) (
 		return nil, nil, false
 	}
 	// Walk up from descendant collecting nodes; stop when we reach
-	// ancestor (inclusive) or run off the top.
-	for node != nil {
+	// ancestor (inclusive), run off the top, or exceed the depth
+	// guard.
+	for steps := 0; node != nil && steps < maxBranchDAGDepth; steps++ {
 		tableIDs = append(tableIDs, node.TableID)
 		cloneTSes = append(cloneTSes, node.CloneTS)
 		if node.TableID == ancestorID {
-			break
+			// Reverse into top-down order (ancestor first).
+			for i, j := 0, len(tableIDs)-1; i < j; i, j = i+1, j-1 {
+				tableIDs[i], tableIDs[j] = tableIDs[j], tableIDs[i]
+				cloneTSes[i], cloneTSes[j] = cloneTSes[j], cloneTSes[i]
+			}
+			return tableIDs, cloneTSes, true
 		}
 		node = node.Parent
 	}
-	if node == nil || node.TableID != ancestorID {
-		return nil, nil, false
-	}
-	// Reverse into top-down order (ancestor first).
-	for i, j := 0, len(tableIDs)-1; i < j; i, j = i+1, j-1 {
-		tableIDs[i], tableIDs[j] = tableIDs[j], tableIDs[i]
-		cloneTSes[i], cloneTSes[j] = cloneTSes[j], cloneTSes[i]
-	}
-	return tableIDs, cloneTSes, true
+	return nil, nil, false
 }

--- a/test/distributed/cases/git4data/branch/diff/diff_12.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_12.result
@@ -1,0 +1,901 @@
+drop database if exists test_chain_diff;
+create database test_chain_diff;
+use test_chain_diff;
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2), (3, 3);
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+insert into t2 values (4, 4), (5, 5);
+update t2 set b = b + 100 where a = 1;
+delete from t2 where a = 2;
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t2 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+4
+data branch diff t2 against t0;
+➤ diff t2 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  101  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t2  ¦  INSERT  ¦  4  ¦  4  𝄀
+t2  ¦  INSERT  ¦  5  ¦  5
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t2 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+4
+data branch diff t2 against t1;
+➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  101  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t2  ¦  INSERT  ¦  4  ¦  4  𝄀
+t2  ¦  INSERT  ¦  5  ¦  5
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+data branch diff t0 against t2 output summary;
+➤ metric[12,0,0]  ¦  t0[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  2  𝄀
+DELETED  ¦  0  ¦  1  𝄀
+UPDATED  ¦  0  ¦  1
+data branch diff t0 against t2 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+4
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b int);
+insert into t0 values (1, 10), (2, 20), (3, 30);
+data branch create table t1 from t0;
+insert into t1 values (4, 40);
+data branch create table t2 from t1;
+update t1 set b = b + 1 where a = 2;
+insert into t1 values (5, 50);
+delete from t1 where a = 3;
+update t2 set b = b + 100 where a = 1;
+insert into t2 values (7, 70);
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t2 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+3
+data branch diff t2 against t0;
+➤ diff t2 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  110  𝄀
+t2  ¦  INSERT  ¦  4  ¦  40  𝄀
+t2  ¦  INSERT  ¦  7  ¦  70
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  0  ¦  1  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t2 against t1;
+➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  110  𝄀
+t1  ¦  UPDATE  ¦  2  ¦  21  𝄀
+t1  ¦  DELETE  ¦  3  ¦  30  𝄀
+t1  ¦  INSERT  ¦  5  ¦  50  𝄀
+t2  ¦  INSERT  ¦  7  ¦  70
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t1 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+4
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2), (3, 3);
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+update t0 set b = b + 1000 where a = 1;
+insert into t0 values (10, 10);
+delete from t0 where a = 3;
+update t2 set b = b - 1 where a = 2;
+insert into t2 values (20, 20);
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  0  ¦  1  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t2 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+5
+data branch diff t2 against t0;
+➤ diff t2 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t0  ¦  UPDATE  ¦  1  ¦  1001  𝄀
+t2  ¦  UPDATE  ¦  2  ¦  1  𝄀
+t0  ¦  DELETE  ¦  3  ¦  3  𝄀
+t0  ¦  INSERT  ¦  10  ¦  10  𝄀
+t2  ¦  INSERT  ¦  20  ¦  20
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  1  𝄀
+DELETED  ¦  0  ¦  1  𝄀
+UPDATED  ¦  0  ¦  1
+data branch diff t0 against t1 output summary;
+➤ metric[12,0,0]  ¦  t0[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t2 against t1;
+➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  2  ¦  1  𝄀
+t2  ¦  INSERT  ¦  20  ¦  20
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b int, tag varchar(16));
+insert into t0 values (1, 1, 't0'), (2, 2, 't0'), (3, 3, 't0');
+drop snapshot if exists c4_t0_sp0;
+create snapshot c4_t0_sp0 for table test_chain_diff t0;
+data branch create table t1 from t0{snapshot="c4_t0_sp0"};
+insert into t1 values (4, 4, 't1');
+update t1 set tag = 't1-u' where a = 1;
+drop snapshot if exists c4_t1_sp0;
+create snapshot c4_t1_sp0 for table test_chain_diff t1;
+data branch create table t2 from t1{snapshot="c4_t1_sp0"};
+insert into t2 values (5, 5, 't2');
+update t2 set tag = 't2-u' where a = 2;
+delete from t2 where a = 3;
+drop snapshot if exists c4_t2_sp0;
+create snapshot c4_t2_sp0 for table test_chain_diff t2;
+update t1 set tag = 't1-u2' where a = 4;
+insert into t1 values (6, 6, 't1');
+drop snapshot if exists c4_t1_sp1;
+create snapshot c4_t1_sp1 for table test_chain_diff t1;
+update t0 set tag = 't0-u' where a = 2;
+insert into t0 values (7, 7, 't0');
+drop snapshot if exists c4_t0_sp1;
+create snapshot c4_t0_sp1 for table test_chain_diff t0;
+update t2 set tag = 't2-u2' where a = 4;
+insert into t2 values (8, 8, 't2');
+drop snapshot if exists c4_t2_sp1;
+create snapshot c4_t2_sp1 for table test_chain_diff t2;
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  2  ¦  1
+data branch diff t2 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+8
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  2  ¦  1
+data branch diff t2 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+7
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t1 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+5
+data branch diff t0 against t2 output summary;
+➤ metric[12,0,0]  ¦  t0[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  3  𝄀
+DELETED  ¦  0  ¦  1  𝄀
+UPDATED  ¦  1  ¦  2
+data branch diff t1 against t2 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  2  𝄀
+DELETED  ¦  0  ¦  1  𝄀
+UPDATED  ¦  1  ¦  2
+data branch diff t2{snapshot="c4_t2_sp0"} against t0{snapshot="c4_t0_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t2{snapshot = 'c4_t2_sp0'}[-5,0,0]  ¦  t0{snapshot = 'c4_t0_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t2{snapshot="c4_t2_sp0"} against t0{snapshot="c4_t0_sp0"} output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+5
+data branch diff t2{snapshot="c4_t2_sp0"} against t1{snapshot="c4_t1_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t2{snapshot = 'c4_t2_sp0'}[-5,0,0]  ¦  t1{snapshot = 'c4_t1_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t2{snapshot="c4_t2_sp1"} against t0{snapshot="c4_t0_sp1"} output summary;
+➤ metric[12,0,0]  ¦  t2{snapshot = 'c4_t2_sp1'}[-5,0,0]  ¦  t0{snapshot = 'c4_t0_sp1'}[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  2  ¦  1
+data branch diff t2{snapshot="c4_t2_sp1"} against t0{snapshot="c4_t0_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t2{snapshot = 'c4_t2_sp1'}[-5,0,0]  ¦  t0{snapshot = 'c4_t0_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t2{snapshot="c4_t2_sp1"} against t0{snapshot="c4_t0_sp0"} output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+6
+drop snapshot c4_t0_sp0;
+drop snapshot c4_t0_sp1;
+drop snapshot c4_t1_sp0;
+drop snapshot c4_t1_sp1;
+drop snapshot c4_t2_sp0;
+drop snapshot c4_t2_sp1;
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2);
+data branch create table t1 from t0;
+insert into t1 values (3, 3);
+data branch create table t2 from t1;
+insert into t2 values (4, 4);
+update t2 set b = b + 100 where a = 1;
+data branch create table t3 from t2;
+insert into t3 values (5, 5);
+delete from t3 where a = 2;
+update t3 set b = b + 1000 where a = 4;
+data branch diff t3 against t0 output summary;
+➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t3 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+5
+data branch diff t3 against t0;
+➤ diff t3 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t3  ¦  UPDATE  ¦  1  ¦  101  𝄀
+t3  ¦  DELETE  ¦  2  ¦  2  𝄀
+t3  ¦  INSERT  ¦  3  ¦  3  𝄀
+t3  ¦  INSERT  ¦  4  ¦  1004  𝄀
+t3  ¦  INSERT  ¦  5  ¦  5
+data branch diff t3 against t1 output summary;
+➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t3 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+4
+data branch diff t3 against t2 output summary;
+➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t3 against t2;
+➤ diff t3 against t2[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t3  ¦  DELETE  ¦  2  ¦  2  𝄀
+t3  ¦  UPDATE  ¦  4  ¦  1004  𝄀
+t3  ¦  INSERT  ¦  5  ¦  5
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+data branch diff t0 against t3 output summary;
+➤ metric[12,0,0]  ¦  t0[-5,0,0]  ¦  t3[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  3  𝄀
+DELETED  ¦  0  ¦  1  𝄀
+UPDATED  ¦  0  ¦  1
+data branch diff t0 against t3 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+5
+drop table t3;
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int, b int);
+insert into t0 select *, * from generate_series(1, 50) g;
+data branch create table t1 from t0;
+insert into t1 values (51, 51), (52, 52);
+data branch create table t2 from t1;
+update t2 set b = b + 1 where a in (1, 10, 20, 30, 40, 51);
+insert into t2 values (53, 53);
+delete from t2 where a in (2, 3);
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  0  𝄀
+DELETED  ¦  2  ¦  0  𝄀
+UPDATED  ¦  5  ¦  0
+data branch diff t2 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+10
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  2  ¦  0  𝄀
+UPDATED  ¦  6  ¦  0
+data branch diff t2 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+9
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b int);
+insert into t0 select *, * from generate_series(1, 2000) g;
+data branch create table t1 from t0;
+update t1 set b = b + 1 where a mod 337 = 0;
+insert into t1 values (2001, 2001);
+data branch create table t2 from t1;
+update t2 set b = b + 2 where a mod 191 = 0;
+delete from t2 where a in (7, 77, 777);
+insert into t2 values (2002, 2002);
+select mo_ctl('dn', 'flush', 'test_chain_diff.t0');
+➤ mo_ctl(dn, flush, test_chain_diff.t0)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select mo_ctl('dn', 'flush', 'test_chain_diff.t1');
+➤ mo_ctl(dn, flush, test_chain_diff.t1)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select mo_ctl('dn', 'flush', 'test_chain_diff.t2');
+➤ mo_ctl(dn, flush, test_chain_diff.t2)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select mo_ctl('dn', 'globalcheckpoint', '');
+➤ mo_ctl(dn, globalcheckpoint, )[12,-1,0]  𝄀
+{
+  "method": "GlobalCheckpoint",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  3  ¦  0  𝄀
+UPDATED  ¦  15  ¦  0
+data branch diff t2 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+20
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  3  ¦  0  𝄀
+UPDATED  ¦  10  ¦  0
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  5  ¦  0
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(region varchar(4), k int, v int, primary key (region, k));
+insert into t0 values ('eu', 1, 10), ('eu', 2, 20), ('us', 1, 100);
+drop snapshot if exists c8_t0_sp0;
+create snapshot c8_t0_sp0 for table test_chain_diff t0;
+data branch create table t1 from t0;
+update t1 set v = v + 1 where region = 'eu' and k = 1;
+insert into t1 values ('us', 2, 200);
+drop snapshot if exists c8_t1_sp0;
+create snapshot c8_t1_sp0 for table test_chain_diff t1;
+data branch create table t2 from t1;
+delete from t2 where region = 'eu' and k = 2;
+update t2 set v = v + 100 where region = 'us' and k = 1;
+insert into t2 values ('ap', 1, 999);
+drop snapshot if exists c8_t2_sp0;
+create snapshot c8_t2_sp0 for table test_chain_diff t2;
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t2 against t0;
+➤ diff t2 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  region[12,0,0]  ¦  k[4,0,0]  ¦  v[4,0,0]  𝄀
+t2  ¦  INSERT  ¦  ap  ¦  1  ¦  999  𝄀
+t2  ¦  UPDATE  ¦  eu  ¦  1  ¦  11  𝄀
+t2  ¦  DELETE  ¦  eu  ¦  2  ¦  20  𝄀
+t2  ¦  UPDATE  ¦  us  ¦  1  ¦  200  𝄀
+t2  ¦  INSERT  ¦  us  ¦  2  ¦  200
+data branch diff t2{snapshot="c8_t2_sp0"} against t0{snapshot="c8_t0_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t2{snapshot = 'c8_t2_sp0'}[-5,0,0]  ¦  t0{snapshot = 'c8_t0_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t2{snapshot="c8_t2_sp0"} against t0{snapshot="c8_t0_sp0"} output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+5
+data branch diff t2{snapshot="c8_t2_sp0"} against t1{snapshot="c8_t1_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t2{snapshot = 'c8_t2_sp0'}[-5,0,0]  ¦  t1{snapshot = 'c8_t1_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+drop snapshot c8_t0_sp0;
+drop snapshot c8_t1_sp0;
+drop snapshot c8_t2_sp0;
+drop table t2;
+drop table t1;
+drop table t0;
+create table t1(a int primary key, b int);
+insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+data branch create table t2 from t1;
+update t2 set b = b + 10 where a = 1;
+insert into t2 values (6, 6), (7, 7);
+delete from t2 where a = 2;
+data branch create table t3 from t2;
+update t3 set b = b + 100 where a in (3, 6);
+insert into t3 values (8, 8), (9, 9);
+delete from t3 where a in (4, 7);
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t2 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+4
+data branch diff t2 against t1;
+➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t2  ¦  INSERT  ¦  6  ¦  6  𝄀
+t2  ¦  INSERT  ¦  7  ¦  7
+data branch diff t3 against t2 output summary;
+➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  2  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t3 against t2 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+6
+data branch diff t3 against t2;
+➤ diff t3 against t2[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t3  ¦  UPDATE  ¦  3  ¦  103  𝄀
+t3  ¦  DELETE  ¦  4  ¦  4  𝄀
+t3  ¦  UPDATE  ¦  6  ¦  106  𝄀
+t3  ¦  DELETE  ¦  7  ¦  7  𝄀
+t3  ¦  INSERT  ¦  8  ¦  8  𝄀
+t3  ¦  INSERT  ¦  9  ¦  9
+data branch diff t3 against t1 output summary;
+➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  0  𝄀
+DELETED  ¦  2  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t3 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+7
+data branch diff t3 against t1;
+➤ diff t3 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t3  ¦  UPDATE  ¦  1  ¦  11  𝄀
+t3  ¦  DELETE  ¦  2  ¦  2  𝄀
+t3  ¦  UPDATE  ¦  3  ¦  103  𝄀
+t3  ¦  DELETE  ¦  4  ¦  4  𝄀
+t3  ¦  INSERT  ¦  6  ¦  106  𝄀
+t3  ¦  INSERT  ¦  8  ¦  8  𝄀
+t3  ¦  INSERT  ¦  9  ¦  9
+data branch diff t1 against t3 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t3[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  3  𝄀
+DELETED  ¦  0  ¦  2  𝄀
+UPDATED  ¦  0  ¦  2
+data branch diff t1 against t3 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+7
+data branch diff t1 against t3;
+➤ diff t1 against t3[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t3  ¦  UPDATE  ¦  1  ¦  11  𝄀
+t3  ¦  DELETE  ¦  2  ¦  2  𝄀
+t3  ¦  UPDATE  ¦  3  ¦  103  𝄀
+t3  ¦  DELETE  ¦  4  ¦  4  𝄀
+t3  ¦  INSERT  ¦  6  ¦  106  𝄀
+t3  ¦  INSERT  ¦  8  ¦  8  𝄀
+t3  ¦  INSERT  ¦  9  ¦  9
+data branch diff t1 against t2 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  2  𝄀
+DELETED  ¦  0  ¦  1  𝄀
+UPDATED  ¦  0  ¦  1
+update t1 set b = b + 1000 where a = 5;
+insert into t1 values (10, 10);
+delete from t1 where a = 1;
+data branch diff t3 against t1 output summary;
+➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
+DELETED  ¦  2  ¦  1  𝄀
+UPDATED  ¦  2  ¦  1
+data branch diff t3 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+10
+data branch diff t3 against t1;
+➤ diff t3 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t3  ¦  UPDATE  ¦  1  ¦  11  𝄀
+t1  ¦  DELETE  ¦  1  ¦  1  𝄀
+t3  ¦  DELETE  ¦  2  ¦  2  𝄀
+t3  ¦  UPDATE  ¦  3  ¦  103  𝄀
+t3  ¦  DELETE  ¦  4  ¦  4  𝄀
+t1  ¦  UPDATE  ¦  5  ¦  1005  𝄀
+t3  ¦  INSERT  ¦  6  ¦  106  𝄀
+t3  ¦  INSERT  ¦  8  ¦  8  𝄀
+t3  ¦  INSERT  ¦  9  ¦  9  𝄀
+t1  ¦  INSERT  ¦  10  ¦  10
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
+DELETED  ¦  1  ¦  1  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t2 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+7
+insert into t2 values (20, 20);
+update t2 set b = b + 5 where a = 6;
+delete from t2 where a = 7;
+data branch diff t3 against t2 output summary;
+➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  2  ¦  1
+data branch diff t3 against t1 output summary;
+➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
+DELETED  ¦  2  ¦  1  𝄀
+UPDATED  ¦  2  ¦  1
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
+DELETED  ¦  1  ¦  1  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t2 against t1;
+➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
+t1  ¦  DELETE  ¦  1  ¦  1  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t1  ¦  UPDATE  ¦  5  ¦  1005  𝄀
+t2  ¦  INSERT  ¦  6  ¦  11  𝄀
+t1  ¦  INSERT  ¦  10  ¦  10  𝄀
+t2  ¦  INSERT  ¦  20  ¦  20
+drop table t3;
+drop table t2;
+drop table t1;
+create table t1(region varchar(4), k int, v int, primary key (region, k));
+insert into t1 values ('eu', 1, 10), ('eu', 2, 20), ('us', 1, 100), ('us', 2, 200);
+drop snapshot if exists c10_t1_sp0;
+create snapshot c10_t1_sp0 for table test_chain_diff t1;
+data branch create table t2 from t1{snapshot="c10_t1_sp0"};
+update t2 set v = v + 1 where region = 'eu' and k = 1;
+insert into t2 values ('ap', 1, 999);
+delete from t2 where region = 'us' and k = 2;
+drop snapshot if exists c10_t2_sp0;
+create snapshot c10_t2_sp0 for table test_chain_diff t2;
+data branch create table t3 from t2{snapshot="c10_t2_sp0"};
+update t3 set v = v + 2 where region = 'eu' and k = 2;
+insert into t3 values ('sa', 1, 777);
+delete from t3 where region = 'us' and k = 1;
+drop snapshot if exists c10_t3_sp0;
+create snapshot c10_t3_sp0 for table test_chain_diff t3;
+data branch create table t4 from t3{snapshot="c10_t3_sp0"};
+update t4 set v = v + 3 where region = 'ap' and k = 1;
+insert into t4 values ('na', 1, 555);
+delete from t4 where region = 'eu' and k = 1;
+drop snapshot if exists c10_t4_sp0;
+create snapshot c10_t4_sp0 for table test_chain_diff t4;
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t3 against t2 output summary;
+➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t4 against t3 output summary;
+➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t3[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t3 against t1 output summary;
+➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  2  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t3 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+6
+data branch diff t3 against t1;
+➤ diff t3 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  region[12,0,0]  ¦  k[4,0,0]  ¦  v[4,0,0]  𝄀
+t3  ¦  INSERT  ¦  ap  ¦  1  ¦  999  𝄀
+t3  ¦  UPDATE  ¦  eu  ¦  1  ¦  11  𝄀
+t3  ¦  UPDATE  ¦  eu  ¦  2  ¦  22  𝄀
+t3  ¦  INSERT  ¦  sa  ¦  1  ¦  777  𝄀
+t3  ¦  DELETE  ¦  us  ¦  1  ¦  100  𝄀
+t3  ¦  DELETE  ¦  us  ¦  2  ¦  200
+data branch diff t4 against t2 output summary;
+➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  2  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t4 against t2 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+6
+data branch diff t4 against t2;
+➤ diff t4 against t2[12,0,0]  ¦  flag[12,0,0]  ¦  region[12,0,0]  ¦  k[4,0,0]  ¦  v[4,0,0]  𝄀
+t4  ¦  UPDATE  ¦  ap  ¦  1  ¦  1002  𝄀
+t4  ¦  DELETE  ¦  eu  ¦  1  ¦  11  𝄀
+t4  ¦  UPDATE  ¦  eu  ¦  2  ¦  22  𝄀
+t4  ¦  INSERT  ¦  na  ¦  1  ¦  555  𝄀
+t4  ¦  INSERT  ¦  sa  ¦  1  ¦  777  𝄀
+t4  ¦  DELETE  ¦  us  ¦  1  ¦  100
+data branch diff t4 against t1 output summary;
+➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  0  𝄀
+DELETED  ¦  3  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t4 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+7
+data branch diff t4 against t1;
+➤ diff t4 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  region[12,0,0]  ¦  k[4,0,0]  ¦  v[4,0,0]  𝄀
+t4  ¦  INSERT  ¦  ap  ¦  1  ¦  1002  𝄀
+t4  ¦  DELETE  ¦  eu  ¦  1  ¦  10  𝄀
+t4  ¦  UPDATE  ¦  eu  ¦  2  ¦  22  𝄀
+t4  ¦  INSERT  ¦  na  ¦  1  ¦  555  𝄀
+t4  ¦  INSERT  ¦  sa  ¦  1  ¦  777  𝄀
+t4  ¦  DELETE  ¦  us  ¦  1  ¦  100  𝄀
+t4  ¦  DELETE  ¦  us  ¦  2  ¦  200
+data branch diff t1 against t4 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t4[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  3  𝄀
+DELETED  ¦  0  ¦  3  𝄀
+UPDATED  ¦  0  ¦  1
+data branch diff t1 against t4 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+7
+data branch diff t4{snapshot="c10_t4_sp0"} against t1{snapshot="c10_t1_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t4{snapshot = 'c10_t4_sp0'}[-5,0,0]  ¦  t1{snapshot = 'c10_t1_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  0  𝄀
+DELETED  ¦  3  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t4{snapshot="c10_t4_sp0"} against t1{snapshot="c10_t1_sp0"} output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+7
+data branch diff t4{snapshot="c10_t4_sp0"} against t2{snapshot="c10_t2_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t4{snapshot = 'c10_t4_sp0'}[-5,0,0]  ¦  t2{snapshot = 'c10_t2_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  2  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t3{snapshot="c10_t3_sp0"} against t1{snapshot="c10_t1_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t3{snapshot = 'c10_t3_sp0'}[-5,0,0]  ¦  t1{snapshot = 'c10_t1_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  2  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+insert into t1 values ('af', 1, 888);
+update t1 set v = v + 10000 where region = 'us' and k = 1;
+insert into t2 values ('af', 2, 889);
+delete from t2 where region = 'ap' and k = 1;
+update t3 set v = v + 20000 where region = 'eu' and k = 2;
+data branch diff t4 against t1 output summary;
+➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
+DELETED  ¦  3  ¦  0  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t4 against t2 output summary;
+➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
+DELETED  ¦  2  ¦  1  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t4 against t3 output summary;
+➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t3[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t4{snapshot="c10_t4_sp0"} against t1{snapshot="c10_t1_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t4{snapshot = 'c10_t4_sp0'}[-5,0,0]  ¦  t1{snapshot = 'c10_t1_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  0  𝄀
+DELETED  ¦  3  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+drop snapshot c10_t1_sp0;
+drop snapshot c10_t2_sp0;
+drop snapshot c10_t3_sp0;
+drop snapshot c10_t4_sp0;
+drop table t4;
+drop table t3;
+drop table t2;
+drop table t1;
+create table t1(a int primary key, b int);
+insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+data branch create table t2 from t1;
+update t2 set b = b + 10 where a = 1;
+insert into t2 values (6, 6), (7, 7);
+delete from t2 where a = 2;
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t2 against t1;
+➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t2  ¦  INSERT  ¦  6  ¦  6  𝄀
+t2  ¦  INSERT  ¦  7  ¦  7
+update t1 set b = -1 where a = 1;
+update t1 set b = 222 where a = 2;
+delete from t1 where a = 3;
+update t1 set b = 444 where a = 4;
+delete from t1 where a = 5;
+insert into t1 values (6, 600);
+insert into t1 values (100, 100);
+insert into t1 values (7, 7);
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  2  𝄀
+DELETED  ¦  1  ¦  2  𝄀
+UPDATED  ¦  1  ¦  3
+data branch diff t2 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+10
+data branch diff t2 against t1;
+➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
+t1  ¦  UPDATE  ¦  1  ¦  -1  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t1  ¦  UPDATE  ¦  2  ¦  222  𝄀
+t1  ¦  DELETE  ¦  3  ¦  3  𝄀
+t1  ¦  UPDATE  ¦  4  ¦  444  𝄀
+t1  ¦  DELETE  ¦  5  ¦  5  𝄀
+t2  ¦  INSERT  ¦  6  ¦  6  𝄀
+t1  ¦  INSERT  ¦  6  ¦  600  𝄀
+t1  ¦  INSERT  ¦  100  ¦  100
+data branch diff t1 against t2 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
+DELETED  ¦  2  ¦  1  𝄀
+UPDATED  ¦  3  ¦  1
+data branch diff t1 against t2 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+10
+data branch diff t1 against t2;
+➤ diff t1 against t2[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t1  ¦  UPDATE  ¦  1  ¦  -1  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
+t1  ¦  UPDATE  ¦  2  ¦  222  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t1  ¦  DELETE  ¦  3  ¦  3  𝄀
+t1  ¦  UPDATE  ¦  4  ¦  444  𝄀
+t1  ¦  DELETE  ¦  5  ¦  5  𝄀
+t1  ¦  INSERT  ¦  6  ¦  600  𝄀
+t2  ¦  INSERT  ¦  6  ¦  6  𝄀
+t1  ¦  INSERT  ¦  100  ¦  100
+update t1 set b = -2 where a = 1;
+insert into t1 values (8, 800);
+delete from t1 where a = 100;
+update t1 set b = 888 where a = 6;
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  2  𝄀
+DELETED  ¦  1  ¦  2  𝄀
+UPDATED  ¦  1  ¦  3
+data branch diff t2 against t1;
+➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
+t1  ¦  UPDATE  ¦  1  ¦  -2  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t1  ¦  UPDATE  ¦  2  ¦  222  𝄀
+t1  ¦  DELETE  ¦  3  ¦  3  𝄀
+t1  ¦  UPDATE  ¦  4  ¦  444  𝄀
+t1  ¦  DELETE  ¦  5  ¦  5  𝄀
+t2  ¦  INSERT  ¦  6  ¦  6  𝄀
+t1  ¦  INSERT  ¦  6  ¦  888  𝄀
+t1  ¦  INSERT  ¦  8  ¦  800
+drop table t2;
+drop table t1;
+create table t1(a int primary key, b int, note varchar(16));
+insert into t1 values (1, 1, 'init'), (2, 2, 'init'), (3, 3, 'init'),
+(4, 4, 'init'), (5, 5, 'init');
+data branch create table t2 from t1;
+update t2 set b = 10, note = 't2-A' where a = 1;
+delete from t2 where a = 2;
+insert into t2 values (10, 10, 't2-A');
+update t1 set b = 100, note = 't1-A' where a = 1;
+update t1 set b = 200, note = 't1-A' where a = 2;
+delete from t1 where a = 3;
+insert into t1 values (20, 20, 't1-A');
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  1  ¦  1  𝄀
+UPDATED  ¦  1  ¦  2
+data branch diff t2 against t1;
+➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  ¦  note[12,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  10  ¦  t2-A  𝄀
+t1  ¦  UPDATE  ¦  1  ¦  100  ¦  t1-A  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  ¦  init  𝄀
+t1  ¦  UPDATE  ¦  2  ¦  200  ¦  t1-A  𝄀
+t1  ¦  DELETE  ¦  3  ¦  3  ¦  init  𝄀
+t2  ¦  INSERT  ¦  10  ¦  10  ¦  t2-A  𝄀
+t1  ¦  INSERT  ¦  20  ¦  20  ¦  t1-A
+update t2 set b = 11, note = 't2-B' where a = 1;
+update t2 set b = 44, note = 't2-B' where a = 4;
+insert into t2 values (11, 11, 't2-B');
+delete from t2 where a = 10;
+update t1 set b = 111, note = 't1-B' where a = 1;
+insert into t1 values (21, 21, 't1-B');
+delete from t1 where a = 20;
+update t1 set b = 5555, note = 't1-B' where a = 5;
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  1  ¦  1  𝄀
+UPDATED  ¦  2  ¦  3
+data branch diff t2 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+9
+data branch diff t2 against t1;
+➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  ¦  note[12,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  11  ¦  t2-B  𝄀
+t1  ¦  UPDATE  ¦  1  ¦  111  ¦  t1-B  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  ¦  init  𝄀
+t1  ¦  UPDATE  ¦  2  ¦  200  ¦  t1-A  𝄀
+t1  ¦  DELETE  ¦  3  ¦  3  ¦  init  𝄀
+t2  ¦  UPDATE  ¦  4  ¦  44  ¦  t2-B  𝄀
+t1  ¦  UPDATE  ¦  5  ¦  5555  ¦  t1-B  𝄀
+t2  ¦  INSERT  ¦  11  ¦  11  ¦  t2-B  𝄀
+t1  ¦  INSERT  ¦  21  ¦  21  ¦  t1-B
+data branch diff t1 against t2 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t2[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  1  ¦  1  𝄀
+UPDATED  ¦  3  ¦  2
+data branch diff t1 against t2 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+9
+drop table t2;
+drop table t1;
+drop database test_chain_diff;

--- a/test/distributed/cases/git4data/branch/diff/diff_12.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_12.result
@@ -547,16 +547,16 @@ insert into t1 values (10, 10);
 delete from t1 where a = 1;
 data branch diff t3 against t1 output summary;
 ➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t1[-5,0,0]  𝄀
-INSERTED  ¦  4  ¦  1  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
 DELETED  ¦  2  ¦  1  𝄀
-UPDATED  ¦  1  ¦  1
+UPDATED  ¦  2  ¦  1
 data branch diff t3 against t1 output count;
 ➤ COUNT(*)[-5,0,0]  𝄀
 10
 data branch diff t3 against t1;
 ➤ diff t3 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t3  ¦  UPDATE  ¦  1  ¦  11  𝄀
 t1  ¦  DELETE  ¦  1  ¦  1  𝄀
-t3  ¦  INSERT  ¦  1  ¦  11  𝄀
 t3  ¦  DELETE  ¦  2  ¦  2  𝄀
 t3  ¦  UPDATE  ¦  3  ¦  103  𝄀
 t3  ¦  DELETE  ¦  4  ¦  4  𝄀
@@ -567,9 +567,9 @@ t3  ¦  INSERT  ¦  9  ¦  9  𝄀
 t1  ¦  INSERT  ¦  10  ¦  10
 data branch diff t2 against t1 output summary;
 ➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
-INSERTED  ¦  3  ¦  1  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
 DELETED  ¦  1  ¦  1  𝄀
-UPDATED  ¦  0  ¦  1
+UPDATED  ¦  1  ¦  1
 data branch diff t2 against t1 output count;
 ➤ COUNT(*)[-5,0,0]  𝄀
 7
@@ -579,22 +579,22 @@ delete from t2 where a = 7;
 data branch diff t3 against t2 output summary;
 ➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t2[-5,0,0]  𝄀
 INSERTED  ¦  2  ¦  1  𝄀
-DELETED  ¦  1  ¦  1  𝄀
+DELETED  ¦  1  ¦  0  𝄀
 UPDATED  ¦  2  ¦  1
 data branch diff t3 against t1 output summary;
 ➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t1[-5,0,0]  𝄀
-INSERTED  ¦  4  ¦  1  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
 DELETED  ¦  2  ¦  1  𝄀
-UPDATED  ¦  1  ¦  1
+UPDATED  ¦  2  ¦  1
 data branch diff t2 against t1 output summary;
 ➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
-INSERTED  ¦  3  ¦  1  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
 DELETED  ¦  1  ¦  1  𝄀
-UPDATED  ¦  0  ¦  1
+UPDATED  ¦  1  ¦  1
 data branch diff t2 against t1;
 ➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
 t1  ¦  DELETE  ¦  1  ¦  1  𝄀
-t2  ¦  INSERT  ¦  1  ¦  11  𝄀
 t2  ¦  DELETE  ¦  2  ¦  2  𝄀
 t1  ¦  UPDATE  ¦  5  ¦  1005  𝄀
 t2  ¦  INSERT  ¦  6  ¦  11  𝄀
@@ -727,9 +727,9 @@ DELETED  ¦  3  ¦  0  𝄀
 UPDATED  ¦  1  ¦  1
 data branch diff t4 against t2 output summary;
 ➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t2[-5,0,0]  𝄀
-INSERTED  ¦  3  ¦  1  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
 DELETED  ¦  2  ¦  1  𝄀
-UPDATED  ¦  1  ¦  0
+UPDATED  ¦  2  ¦  0
 data branch diff t4 against t3 output summary;
 ➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t3[-5,0,0]  𝄀
 INSERTED  ¦  1  ¦  0  𝄀
@@ -785,7 +785,7 @@ data branch diff t2 against t1;
 ➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
 t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
 t1  ¦  UPDATE  ¦  1  ¦  -1  𝄀
-t2  ¦  DELETE  ¦  2  ¦  222  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
 t1  ¦  UPDATE  ¦  2  ¦  222  𝄀
 t1  ¦  DELETE  ¦  3  ¦  3  𝄀
 t1  ¦  UPDATE  ¦  4  ¦  444  𝄀
@@ -806,7 +806,7 @@ data branch diff t1 against t2;
 t1  ¦  UPDATE  ¦  1  ¦  -1  𝄀
 t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
 t1  ¦  UPDATE  ¦  2  ¦  222  𝄀
-t2  ¦  DELETE  ¦  2  ¦  222  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
 t1  ¦  DELETE  ¦  3  ¦  3  𝄀
 t1  ¦  UPDATE  ¦  4  ¦  444  𝄀
 t1  ¦  DELETE  ¦  5  ¦  5  𝄀
@@ -826,7 +826,7 @@ data branch diff t2 against t1;
 ➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
 t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
 t1  ¦  UPDATE  ¦  1  ¦  -2  𝄀
-t2  ¦  DELETE  ¦  2  ¦  222  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  𝄀
 t1  ¦  UPDATE  ¦  2  ¦  222  𝄀
 t1  ¦  DELETE  ¦  3  ¦  3  𝄀
 t1  ¦  UPDATE  ¦  4  ¦  444  𝄀
@@ -856,7 +856,7 @@ data branch diff t2 against t1;
 ➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  ¦  note[12,0,0]  𝄀
 t2  ¦  UPDATE  ¦  1  ¦  10  ¦  t2-A  𝄀
 t1  ¦  UPDATE  ¦  1  ¦  100  ¦  t1-A  𝄀
-t2  ¦  DELETE  ¦  2  ¦  200  ¦  t1-A  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  ¦  init  𝄀
 t1  ¦  UPDATE  ¦  2  ¦  200  ¦  t1-A  𝄀
 t1  ¦  DELETE  ¦  3  ¦  3  ¦  init  𝄀
 t2  ¦  INSERT  ¦  10  ¦  10  ¦  t2-A  𝄀
@@ -881,7 +881,7 @@ data branch diff t2 against t1;
 ➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  ¦  note[12,0,0]  𝄀
 t2  ¦  UPDATE  ¦  1  ¦  11  ¦  t2-B  𝄀
 t1  ¦  UPDATE  ¦  1  ¦  111  ¦  t1-B  𝄀
-t2  ¦  DELETE  ¦  2  ¦  200  ¦  t1-A  𝄀
+t2  ¦  DELETE  ¦  2  ¦  2  ¦  init  𝄀
 t1  ¦  UPDATE  ¦  2  ¦  200  ¦  t1-A  𝄀
 t1  ¦  DELETE  ¦  3  ¦  3  ¦  init  𝄀
 t2  ¦  UPDATE  ¦  4  ¦  44  ¦  t2-B  𝄀

--- a/test/distributed/cases/git4data/branch/diff/diff_12.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_12.result
@@ -547,16 +547,16 @@ insert into t1 values (10, 10);
 delete from t1 where a = 1;
 data branch diff t3 against t1 output summary;
 ➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t1[-5,0,0]  𝄀
-INSERTED  ¦  3  ¦  1  𝄀
+INSERTED  ¦  4  ¦  1  𝄀
 DELETED  ¦  2  ¦  1  𝄀
-UPDATED  ¦  2  ¦  1
+UPDATED  ¦  1  ¦  1
 data branch diff t3 against t1 output count;
 ➤ COUNT(*)[-5,0,0]  𝄀
 10
 data branch diff t3 against t1;
 ➤ diff t3 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
-t3  ¦  UPDATE  ¦  1  ¦  11  𝄀
 t1  ¦  DELETE  ¦  1  ¦  1  𝄀
+t3  ¦  INSERT  ¦  1  ¦  11  𝄀
 t3  ¦  DELETE  ¦  2  ¦  2  𝄀
 t3  ¦  UPDATE  ¦  3  ¦  103  𝄀
 t3  ¦  DELETE  ¦  4  ¦  4  𝄀
@@ -567,9 +567,9 @@ t3  ¦  INSERT  ¦  9  ¦  9  𝄀
 t1  ¦  INSERT  ¦  10  ¦  10
 data branch diff t2 against t1 output summary;
 ➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
-INSERTED  ¦  2  ¦  1  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
 DELETED  ¦  1  ¦  1  𝄀
-UPDATED  ¦  1  ¦  1
+UPDATED  ¦  0  ¦  1
 data branch diff t2 against t1 output count;
 ➤ COUNT(*)[-5,0,0]  𝄀
 7
@@ -579,22 +579,22 @@ delete from t2 where a = 7;
 data branch diff t3 against t2 output summary;
 ➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t2[-5,0,0]  𝄀
 INSERTED  ¦  2  ¦  1  𝄀
-DELETED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  1  𝄀
 UPDATED  ¦  2  ¦  1
 data branch diff t3 against t1 output summary;
 ➤ metric[12,0,0]  ¦  t3[-5,0,0]  ¦  t1[-5,0,0]  𝄀
-INSERTED  ¦  3  ¦  1  𝄀
+INSERTED  ¦  4  ¦  1  𝄀
 DELETED  ¦  2  ¦  1  𝄀
-UPDATED  ¦  2  ¦  1
+UPDATED  ¦  1  ¦  1
 data branch diff t2 against t1 output summary;
 ➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
-INSERTED  ¦  2  ¦  1  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
 DELETED  ¦  1  ¦  1  𝄀
-UPDATED  ¦  1  ¦  1
+UPDATED  ¦  0  ¦  1
 data branch diff t2 against t1;
 ➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
-t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
 t1  ¦  DELETE  ¦  1  ¦  1  𝄀
+t2  ¦  INSERT  ¦  1  ¦  11  𝄀
 t2  ¦  DELETE  ¦  2  ¦  2  𝄀
 t1  ¦  UPDATE  ¦  5  ¦  1005  𝄀
 t2  ¦  INSERT  ¦  6  ¦  11  𝄀
@@ -727,9 +727,9 @@ DELETED  ¦  3  ¦  0  𝄀
 UPDATED  ¦  1  ¦  1
 data branch diff t4 against t2 output summary;
 ➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t2[-5,0,0]  𝄀
-INSERTED  ¦  2  ¦  1  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
 DELETED  ¦  2  ¦  1  𝄀
-UPDATED  ¦  2  ¦  0
+UPDATED  ¦  1  ¦  0
 data branch diff t4 against t3 output summary;
 ➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t3[-5,0,0]  𝄀
 INSERTED  ¦  1  ¦  0  𝄀
@@ -785,7 +785,7 @@ data branch diff t2 against t1;
 ➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
 t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
 t1  ¦  UPDATE  ¦  1  ¦  -1  𝄀
-t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t2  ¦  DELETE  ¦  2  ¦  222  𝄀
 t1  ¦  UPDATE  ¦  2  ¦  222  𝄀
 t1  ¦  DELETE  ¦  3  ¦  3  𝄀
 t1  ¦  UPDATE  ¦  4  ¦  444  𝄀
@@ -806,7 +806,7 @@ data branch diff t1 against t2;
 t1  ¦  UPDATE  ¦  1  ¦  -1  𝄀
 t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
 t1  ¦  UPDATE  ¦  2  ¦  222  𝄀
-t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t2  ¦  DELETE  ¦  2  ¦  222  𝄀
 t1  ¦  DELETE  ¦  3  ¦  3  𝄀
 t1  ¦  UPDATE  ¦  4  ¦  444  𝄀
 t1  ¦  DELETE  ¦  5  ¦  5  𝄀
@@ -826,7 +826,7 @@ data branch diff t2 against t1;
 ➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
 t2  ¦  UPDATE  ¦  1  ¦  11  𝄀
 t1  ¦  UPDATE  ¦  1  ¦  -2  𝄀
-t2  ¦  DELETE  ¦  2  ¦  2  𝄀
+t2  ¦  DELETE  ¦  2  ¦  222  𝄀
 t1  ¦  UPDATE  ¦  2  ¦  222  𝄀
 t1  ¦  DELETE  ¦  3  ¦  3  𝄀
 t1  ¦  UPDATE  ¦  4  ¦  444  𝄀
@@ -856,7 +856,7 @@ data branch diff t2 against t1;
 ➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  ¦  note[12,0,0]  𝄀
 t2  ¦  UPDATE  ¦  1  ¦  10  ¦  t2-A  𝄀
 t1  ¦  UPDATE  ¦  1  ¦  100  ¦  t1-A  𝄀
-t2  ¦  DELETE  ¦  2  ¦  2  ¦  init  𝄀
+t2  ¦  DELETE  ¦  2  ¦  200  ¦  t1-A  𝄀
 t1  ¦  UPDATE  ¦  2  ¦  200  ¦  t1-A  𝄀
 t1  ¦  DELETE  ¦  3  ¦  3  ¦  init  𝄀
 t2  ¦  INSERT  ¦  10  ¦  10  ¦  t2-A  𝄀
@@ -881,7 +881,7 @@ data branch diff t2 against t1;
 ➤ diff t2 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  ¦  note[12,0,0]  𝄀
 t2  ¦  UPDATE  ¦  1  ¦  11  ¦  t2-B  𝄀
 t1  ¦  UPDATE  ¦  1  ¦  111  ¦  t1-B  𝄀
-t2  ¦  DELETE  ¦  2  ¦  2  ¦  init  𝄀
+t2  ¦  DELETE  ¦  2  ¦  200  ¦  t1-A  𝄀
 t1  ¦  UPDATE  ¦  2  ¦  200  ¦  t1-A  𝄀
 t1  ¦  DELETE  ¦  3  ¦  3  ¦  init  𝄀
 t2  ¦  UPDATE  ¦  4  ¦  44  ¦  t2-B  𝄀

--- a/test/distributed/cases/git4data/branch/diff/diff_12.sql
+++ b/test/distributed/cases/git4data/branch/diff/diff_12.sql
@@ -1,0 +1,662 @@
+-- Linear branch chain t0 -> t1 -> t2 diff coverage.
+-- Verifies `data branch diff` across non-adjacent levels of a chain
+-- (e.g. t2 against t0, t0 against t2). The chain-shape exercises a
+-- different LCA path than a flat fork (t0 -> {t1, t2}) because the
+-- DAG walk must traverse through the intermediate t1 edge to find
+-- the correct branch TS. We also interleave insert/update/delete on
+-- t0, t1, t2 at multiple time points, mix snapshot-scoped diffs, and
+-- include a longer chain (t0 -> t1 -> t2 -> t3) and a no-PK variant
+-- sanity check.
+
+drop database if exists test_chain_diff;
+create database test_chain_diff;
+use test_chain_diff;
+
+-- ============================================================
+-- Case 1: pure chain, writes only on leaf t2.
+-- Verifies that with no writes on t0/t1, diff t2 vs t0 equals diff
+-- t2 vs t1 on the leaf-origin rows, and both base sides are clean.
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2), (3, 3);
+
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+
+insert into t2 values (4, 4), (5, 5);
+update t2 set b = b + 100 where a = 1;
+delete from t2 where a = 2;
+
+-- chain: t0 -> t1 -> t2; LCA for each pair:
+--   t2 vs t0 : t0 itself is the LCA (lcaRight)
+--   t2 vs t1 : t1 itself is the LCA (lcaRight)
+--   t1 vs t0 : t0 itself is the LCA (lcaRight)   -- no writes on t1, should be empty
+
+data branch diff t2 against t0 output summary;
+data branch diff t2 against t0 output count;
+data branch diff t2 against t0;
+
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1 output count;
+data branch diff t2 against t1;
+
+data branch diff t1 against t0 output summary;
+
+-- reverse direction sanity
+data branch diff t0 against t2 output summary;
+data branch diff t0 against t2 output count;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 2: writes on the middle branch t1 both before and after t2
+-- has been taken. Chain: t0 -> (t1 grows) -> t2 -> (t1 grows more).
+-- Key check: the LCA of (t2, t0) is t0 with branch TS = CloneTS(t1).
+-- Only changes AFTER that TS on each partition are diffed. Pre-t2
+-- t1 writes live in t1's partition; post-t2 t1 writes are attributed
+-- to t1's side when diffed against t0.
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 values (1, 10), (2, 20), (3, 30);
+
+data branch create table t1 from t0;
+insert into t1 values (4, 40);
+data branch create table t2 from t1;
+
+-- now diverge t1 and t2 separately
+update t1 set b = b + 1 where a = 2;
+insert into t1 values (5, 50);
+delete from t1 where a = 3;
+
+update t2 set b = b + 100 where a = 1;
+insert into t2 values (7, 70);
+
+-- t2 vs t0: LCA=t0, branch TS = CloneTS(t1). t2 side reports its
+-- own writes replayed from CloneTS(t1)+1; t1's writes do not leak
+-- onto t2's side.
+data branch diff t2 against t0 output summary;
+data branch diff t2 against t0 output count;
+data branch diff t2 against t0;
+
+-- t2 vs t1: LCA=t1 itself (lcaRight in the immediate parent sense).
+-- Both sides have post-t2-clone writes.
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1;
+
+-- t1 vs t0: LCA=t0, branch TS = CloneTS(t1). All of t1's writes
+-- surface on t1 side.
+data branch diff t1 against t0 output summary;
+data branch diff t1 against t0 output count;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 3: writes on the ROOT t0 after t1 and t2 are branched.
+-- Verifies that mutations on t0 after cloning do NOT leak into
+-- the branch side of the diff.
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2), (3, 3);
+
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+
+-- Write on root AFTER t1 and t2 exist.
+update t0 set b = b + 1000 where a = 1;
+insert into t0 values (10, 10);
+delete from t0 where a = 3;
+
+-- And write on t2 as well.
+update t2 set b = b - 1 where a = 2;
+insert into t2 values (20, 20);
+
+-- t2 vs t0 : t0 is the LCA. Both sides diverge. Expect mirror-style
+-- output (t0 mutations on t0 side, t2 mutations on t2 side).
+data branch diff t2 against t0 output summary;
+data branch diff t2 against t0 output count;
+data branch diff t2 against t0;
+
+-- t1 vs t0 : t1 has no writes, so only t0 side is non-empty.
+data branch diff t1 against t0 output summary;
+data branch diff t0 against t1 output summary;
+
+-- t2 vs t1 : t1 is the LCA. Only t2 side should show changes.
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 4: fully interleaved DML at multiple time points on t0/t1/t2.
+-- This is the most complex scenario: writes on every level mixed
+-- with snapshots, executed at several times along the chain.
+-- Snapshots capture the state at each vantage point so that later
+-- diffs can exercise snapshot-scoped + cross-level combinations.
+-- ============================================================
+create table t0(a int primary key, b int, tag varchar(16));
+insert into t0 values (1, 1, 't0'), (2, 2, 't0'), (3, 3, 't0');
+drop snapshot if exists c4_t0_sp0;
+create snapshot c4_t0_sp0 for table test_chain_diff t0;
+
+-- Branch t1 off t0, write on t1.
+data branch create table t1 from t0{snapshot="c4_t0_sp0"};
+insert into t1 values (4, 4, 't1');
+update t1 set tag = 't1-u' where a = 1;
+drop snapshot if exists c4_t1_sp0;
+create snapshot c4_t1_sp0 for table test_chain_diff t1;
+
+-- Branch t2 off t1 (at a specific snapshot).
+data branch create table t2 from t1{snapshot="c4_t1_sp0"};
+insert into t2 values (5, 5, 't2');
+update t2 set tag = 't2-u' where a = 2;
+delete from t2 where a = 3;
+drop snapshot if exists c4_t2_sp0;
+create snapshot c4_t2_sp0 for table test_chain_diff t2;
+
+-- More writes on t1 AFTER t2 was branched.
+update t1 set tag = 't1-u2' where a = 4;
+insert into t1 values (6, 6, 't1');
+drop snapshot if exists c4_t1_sp1;
+create snapshot c4_t1_sp1 for table test_chain_diff t1;
+
+-- More writes on t0 AFTER both t1 and t2 exist.
+update t0 set tag = 't0-u' where a = 2;
+insert into t0 values (7, 7, 't0');
+drop snapshot if exists c4_t0_sp1;
+create snapshot c4_t0_sp1 for table test_chain_diff t0;
+
+-- More writes on t2.
+update t2 set tag = 't2-u2' where a = 4;
+insert into t2 values (8, 8, 't2');
+drop snapshot if exists c4_t2_sp1;
+create snapshot c4_t2_sp1 for table test_chain_diff t2;
+
+-- CURRENT-state diffs across all pairs.
+data branch diff t2 against t0 output summary;
+data branch diff t2 against t0 output count;
+
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1 output count;
+
+data branch diff t1 against t0 output summary;
+data branch diff t1 against t0 output count;
+
+data branch diff t0 against t2 output summary;
+data branch diff t1 against t2 output summary;
+
+-- Snapshot-scoped diffs — verify the chain LCA math holds when
+-- replaying at a specific time point on each side.
+data branch diff t2{snapshot="c4_t2_sp0"} against t0{snapshot="c4_t0_sp0"} output summary;
+data branch diff t2{snapshot="c4_t2_sp0"} against t0{snapshot="c4_t0_sp0"} output count;
+
+data branch diff t2{snapshot="c4_t2_sp0"} against t1{snapshot="c4_t1_sp0"} output summary;
+
+data branch diff t2{snapshot="c4_t2_sp1"} against t0{snapshot="c4_t0_sp1"} output summary;
+
+-- Mixed-snapshot: newer t2 snapshot against older t0 snapshot, i.e.
+-- diff a future state of the grandchild against an older state of
+-- the grandparent. This is the nastiest LCA scenario because the
+-- snapshots sit on opposite sides of the intermediate branch points.
+data branch diff t2{snapshot="c4_t2_sp1"} against t0{snapshot="c4_t0_sp0"} output summary;
+data branch diff t2{snapshot="c4_t2_sp1"} against t0{snapshot="c4_t0_sp0"} output count;
+
+drop snapshot c4_t0_sp0;
+drop snapshot c4_t0_sp1;
+drop snapshot c4_t1_sp0;
+drop snapshot c4_t1_sp1;
+drop snapshot c4_t2_sp0;
+drop snapshot c4_t2_sp1;
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 5: 4-level chain t0 -> t1 -> t2 -> t3 (depth sanity).
+-- Verifies the DAG walk remains stable when diff skips 2 edges.
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2);
+
+data branch create table t1 from t0;
+insert into t1 values (3, 3);
+
+data branch create table t2 from t1;
+insert into t2 values (4, 4);
+update t2 set b = b + 100 where a = 1;
+
+data branch create table t3 from t2;
+insert into t3 values (5, 5);
+delete from t3 where a = 2;
+update t3 set b = b + 1000 where a = 4;
+
+-- Diff across every pair of levels.
+data branch diff t3 against t0 output summary;
+data branch diff t3 against t0 output count;
+data branch diff t3 against t0;
+
+data branch diff t3 against t1 output summary;
+data branch diff t3 against t1 output count;
+
+data branch diff t3 against t2 output summary;
+data branch diff t3 against t2;
+
+data branch diff t2 against t0 output summary;
+data branch diff t2 against t1 output summary;
+data branch diff t1 against t0 output summary;
+
+-- Reverse direction for the 3-edge skip.
+data branch diff t0 against t3 output summary;
+data branch diff t0 against t3 output count;
+
+drop table t3;
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 6: no-PK (fake PK) variant of the linear chain.
+-- Verifies that the fake-PK hash path also handles the chain.
+-- ============================================================
+create table t0(a int, b int);
+insert into t0 select *, * from generate_series(1, 50) g;
+
+data branch create table t1 from t0;
+insert into t1 values (51, 51), (52, 52);
+
+data branch create table t2 from t1;
+update t2 set b = b + 1 where a in (1, 10, 20, 30, 40, 51);
+insert into t2 values (53, 53);
+delete from t2 where a in (2, 3);
+
+data branch diff t2 against t0 output summary;
+data branch diff t2 against t0 output count;
+
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1 output count;
+
+data branch diff t1 against t0 output summary;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 7: chain diff after intermediate flush/checkpoint/GC.
+-- Scaled down from diff_9 but on the chain shape. Verifies that
+-- even after flush + checkpoint, diff across non-adjacent chain
+-- levels (t2 vs t0) is still correct.
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 select *, * from generate_series(1, 2000) g;
+
+data branch create table t1 from t0;
+update t1 set b = b + 1 where a mod 337 = 0;
+insert into t1 values (2001, 2001);
+
+data branch create table t2 from t1;
+update t2 set b = b + 2 where a mod 191 = 0;
+delete from t2 where a in (7, 77, 777);
+insert into t2 values (2002, 2002);
+
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'test_chain_diff.t0');
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'test_chain_diff.t1');
+-- @ignore:0
+select mo_ctl('dn', 'flush', 'test_chain_diff.t2');
+-- @ignore:0
+select mo_ctl('dn', 'globalcheckpoint', '');
+
+data branch diff t2 against t0 output summary;
+data branch diff t2 against t0 output count;
+
+data branch diff t2 against t1 output summary;
+
+data branch diff t1 against t0 output summary;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 8: composite PK linear chain, diff with snapshot on both
+-- sides at different chain depths.
+-- ============================================================
+create table t0(region varchar(4), k int, v int, primary key (region, k));
+insert into t0 values ('eu', 1, 10), ('eu', 2, 20), ('us', 1, 100);
+drop snapshot if exists c8_t0_sp0;
+create snapshot c8_t0_sp0 for table test_chain_diff t0;
+
+data branch create table t1 from t0;
+update t1 set v = v + 1 where region = 'eu' and k = 1;
+insert into t1 values ('us', 2, 200);
+drop snapshot if exists c8_t1_sp0;
+create snapshot c8_t1_sp0 for table test_chain_diff t1;
+
+data branch create table t2 from t1;
+delete from t2 where region = 'eu' and k = 2;
+update t2 set v = v + 100 where region = 'us' and k = 1;
+insert into t2 values ('ap', 1, 999);
+drop snapshot if exists c8_t2_sp0;
+create snapshot c8_t2_sp0 for table test_chain_diff t2;
+
+-- Current state diffs.
+data branch diff t2 against t0 output summary;
+data branch diff t2 against t0;
+
+-- Snapshot-scoped: snapshot of t2 against the ORIGINAL snapshot of
+-- t0 (before the clone existed) — verifies the LCA can be resolved
+-- purely via snapshot references without touching live tables.
+data branch diff t2{snapshot="c8_t2_sp0"} against t0{snapshot="c8_t0_sp0"} output summary;
+data branch diff t2{snapshot="c8_t2_sp0"} against t0{snapshot="c8_t0_sp0"} output count;
+
+data branch diff t2{snapshot="c8_t2_sp0"} against t1{snapshot="c8_t1_sp0"} output summary;
+
+drop snapshot c8_t0_sp0;
+drop snapshot c8_t1_sp0;
+drop snapshot c8_t2_sp0;
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 9: canonical "t1 -> t2 -> t3" with IUD on every branch,
+-- then diff across non-adjacent levels. This is the textbook
+-- complex scenario: full insert/update/delete on t2, then branch
+-- t3 off t2, full insert/update/delete on t3, then diff t3 vs t1.
+-- Also cross-level: diff t3 vs t2, t2 vs t1, and the reverse
+-- pairings, plus output count / summary / row-level variants.
+-- ============================================================
+create table t1(a int primary key, b int);
+insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+
+data branch create table t2 from t1;
+update t2 set b = b + 10 where a = 1;
+insert into t2 values (6, 6), (7, 7);
+delete from t2 where a = 2;
+
+data branch create table t3 from t2;
+update t3 set b = b + 100 where a in (3, 6);
+insert into t3 values (8, 8), (9, 9);
+delete from t3 where a in (4, 7);
+
+-- Adjacent-level diffs (LCA is the immediate parent).
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1 output count;
+data branch diff t2 against t1;
+
+data branch diff t3 against t2 output summary;
+data branch diff t3 against t2 output count;
+data branch diff t3 against t2;
+
+-- Cross-level diff (skips 1 edge): grandchild against grandparent.
+-- LCA resolves to t1 itself (lcaRight), branch TS = CloneTS(t2).
+-- Only t3's mutations relative to t2's state at clone time surface.
+data branch diff t3 against t1 output summary;
+data branch diff t3 against t1 output count;
+data branch diff t3 against t1;
+
+-- Reverse direction (same LCA, lcaLeft).
+data branch diff t1 against t3 output summary;
+data branch diff t1 against t3 output count;
+data branch diff t1 against t3;
+
+-- Ancestor-chain diff sanity.
+data branch diff t1 against t2 output summary;
+
+-- Writes on t1 AFTER t2 and t3 were branched. Verifies that
+-- mutations on the root do NOT leak into t3's side.
+update t1 set b = b + 1000 where a = 5;
+insert into t1 values (10, 10);
+delete from t1 where a = 1;
+
+data branch diff t3 against t1 output summary;
+data branch diff t3 against t1 output count;
+data branch diff t3 against t1;
+
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1 output count;
+
+-- Writes on t2 AFTER t3 was branched. Verifies t3's view is
+-- unaffected by later t2 mutations, and that t2 vs t1 absorbs
+-- both pre-t3 and post-t3 t2 mutations.
+insert into t2 values (20, 20);
+update t2 set b = b + 5 where a = 6;
+delete from t2 where a = 7;
+
+data branch diff t3 against t2 output summary;
+data branch diff t3 against t1 output summary;
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1;
+
+drop table t3;
+drop table t2;
+drop table t1;
+
+-- ============================================================
+-- Case 10: stress — t1 -> t2 -> t3 -> t4 with IUD on every level
+-- and snapshots captured at every level, then diff across every
+-- pair of levels (6 pairs, both directions). Covers the DAG walk
+-- at depth 3 (cross 3 edges) and all intermediate combinations.
+-- Uses composite PK to exercise the compositeKind hash path.
+-- ============================================================
+create table t1(region varchar(4), k int, v int, primary key (region, k));
+insert into t1 values ('eu', 1, 10), ('eu', 2, 20), ('us', 1, 100), ('us', 2, 200);
+drop snapshot if exists c10_t1_sp0;
+create snapshot c10_t1_sp0 for table test_chain_diff t1;
+
+data branch create table t2 from t1{snapshot="c10_t1_sp0"};
+update t2 set v = v + 1 where region = 'eu' and k = 1;
+insert into t2 values ('ap', 1, 999);
+delete from t2 where region = 'us' and k = 2;
+drop snapshot if exists c10_t2_sp0;
+create snapshot c10_t2_sp0 for table test_chain_diff t2;
+
+data branch create table t3 from t2{snapshot="c10_t2_sp0"};
+update t3 set v = v + 2 where region = 'eu' and k = 2;
+insert into t3 values ('sa', 1, 777);
+delete from t3 where region = 'us' and k = 1;
+drop snapshot if exists c10_t3_sp0;
+create snapshot c10_t3_sp0 for table test_chain_diff t3;
+
+data branch create table t4 from t3{snapshot="c10_t3_sp0"};
+update t4 set v = v + 3 where region = 'ap' and k = 1;
+insert into t4 values ('na', 1, 555);
+delete from t4 where region = 'eu' and k = 1;
+drop snapshot if exists c10_t4_sp0;
+create snapshot c10_t4_sp0 for table test_chain_diff t4;
+
+-- Adjacent-level diffs.
+data branch diff t2 against t1 output summary;
+data branch diff t3 against t2 output summary;
+data branch diff t4 against t3 output summary;
+
+-- Skip-1-edge diffs.
+data branch diff t3 against t1 output summary;
+data branch diff t3 against t1 output count;
+data branch diff t3 against t1;
+
+data branch diff t4 against t2 output summary;
+data branch diff t4 against t2 output count;
+data branch diff t4 against t2;
+
+-- Skip-2-edge diff (cross 3 clone edges).
+data branch diff t4 against t1 output summary;
+data branch diff t4 against t1 output count;
+data branch diff t4 against t1;
+
+-- Reverse skip-2-edge.
+data branch diff t1 against t4 output summary;
+data branch diff t1 against t4 output count;
+
+-- Snapshot-scoped variant: each pair replayed at its own snapshot
+-- taken right after the level's IUD was applied.
+data branch diff t4{snapshot="c10_t4_sp0"} against t1{snapshot="c10_t1_sp0"} output summary;
+data branch diff t4{snapshot="c10_t4_sp0"} against t1{snapshot="c10_t1_sp0"} output count;
+
+data branch diff t4{snapshot="c10_t4_sp0"} against t2{snapshot="c10_t2_sp0"} output summary;
+data branch diff t3{snapshot="c10_t3_sp0"} against t1{snapshot="c10_t1_sp0"} output summary;
+
+-- Write further on every level AFTER all branches exist, then
+-- re-diff to confirm deeper levels remain unaffected by root
+-- mutations and vice versa.
+insert into t1 values ('af', 1, 888);
+update t1 set v = v + 10000 where region = 'us' and k = 1;
+
+insert into t2 values ('af', 2, 889);
+delete from t2 where region = 'ap' and k = 1;
+
+update t3 set v = v + 20000 where region = 'eu' and k = 2;
+
+data branch diff t4 against t1 output summary;
+data branch diff t4 against t2 output summary;
+data branch diff t4 against t3 output summary;
+
+-- Historical snapshots must NOT see any of the post-branch writes.
+data branch diff t4{snapshot="c10_t4_sp0"} against t1{snapshot="c10_t1_sp0"} output summary;
+
+drop snapshot c10_t1_sp0;
+drop snapshot c10_t2_sp0;
+drop snapshot c10_t3_sp0;
+drop snapshot c10_t4_sp0;
+drop table t4;
+drop table t3;
+drop table t2;
+drop table t1;
+
+-- ============================================================
+-- Case 11: t1 -> t2 followed by IUD on t1 (post-branch) — the
+-- focus scenario. After t2 is cloned, every kind of write is
+-- applied to t1, and then diff is taken in both directions.
+-- The LCA is t1 itself (lcaRight / lcaLeft). The t1 side of the
+-- diff must surface ALL post-branch t1 writes; the t2 side
+-- surfaces only t2's own writes. Also verifies:
+--   * an UPDATE on t1 of a row that t2 has also updated with a
+--     different value (both sides report UPDATE);
+--   * a DELETE on t1 of a row that t2 has kept unchanged
+--     (t1 side reports DELETE, t2 side reports the baseline row
+--     as INSERT — this is the divergent-base scenario);
+--   * an INSERT on t1 of a PK that t2 has also inserted with a
+--     different value (both sides report INSERT on that PK).
+-- ============================================================
+create table t1(a int primary key, b int);
+insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+
+data branch create table t2 from t1;
+-- IUD on t2 first.
+update t2 set b = b + 10 where a = 1;
+insert into t2 values (6, 6), (7, 7);
+delete from t2 where a = 2;
+
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1;
+
+-- NOW do IUD on t1 (post-branch).
+--   * a=1: t1 sets b=-1; t2 had set b=11. Divergent UPDATE.
+--   * a=2: t2 deleted it; t1 updates it. Conflict on the
+--     resurrected-vs-deleted row.
+--   * a=3: t1 deletes it; t2 kept it unchanged (baseline value).
+--   * a=4: t1 updates it; t2 never touched it.
+--   * a=5: t1 deletes it; t2 never touched it.
+--   * a=6: t2 inserted (6,6); t1 inserts (6,600). Double-insert
+--     on same PK with different values.
+--   * a=100: t1 inserts; t2 doesn't know about it.
+--   * a=7: t2 inserted (7,7); t1 inserts (7,7). Double-insert
+--     on same PK with same value (should reconcile).
+update t1 set b = -1 where a = 1;
+update t1 set b = 222 where a = 2;
+delete from t1 where a = 3;
+update t1 set b = 444 where a = 4;
+delete from t1 where a = 5;
+insert into t1 values (6, 600);
+insert into t1 values (100, 100);
+insert into t1 values (7, 7);
+
+-- Diff after all the t1 post-branch IUD.
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1 output count;
+data branch diff t2 against t1;
+
+-- Reverse.
+data branch diff t1 against t2 output summary;
+data branch diff t1 against t2 output count;
+data branch diff t1 against t2;
+
+-- Do a SECOND round of IUD on t1 (further post-branch), confirm
+-- the diff reflects the latest state consistently.
+update t1 set b = -2 where a = 1;
+insert into t1 values (8, 800);
+delete from t1 where a = 100;
+update t1 set b = 888 where a = 6;
+
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1;
+
+drop table t2;
+drop table t1;
+
+-- ============================================================
+-- Case 12: alternating rounds of IUD on t1 and t2 after branch.
+-- Pattern:
+--   T0. t1 has initial rows.
+--   T1. data branch create t2 from t1.
+--   T2. IUD on t2 round A.
+--   T3. IUD on t1 round A.
+--   T4. IUD on t2 round B (possibly on rows t1 just touched).
+--   T5. IUD on t1 round B.
+-- Then diff t2 vs t1. Verifies that the diff's t1-side tracks
+-- ALL of t1's post-branch writes (rounds A + B) and t2-side tracks
+-- ALL of t2's writes — and that the two streams are reconciled
+-- even when they keep clobbering each other's rows.
+-- ============================================================
+create table t1(a int primary key, b int, note varchar(16));
+insert into t1 values (1, 1, 'init'), (2, 2, 'init'), (3, 3, 'init'),
+                      (4, 4, 'init'), (5, 5, 'init');
+
+data branch create table t2 from t1;
+
+-- T2: t2 round A.
+update t2 set b = 10, note = 't2-A' where a = 1;
+delete from t2 where a = 2;
+insert into t2 values (10, 10, 't2-A');
+
+-- T3: t1 round A (touches rows t2 already touched, and new rows).
+update t1 set b = 100, note = 't1-A' where a = 1;
+update t1 set b = 200, note = 't1-A' where a = 2;
+delete from t1 where a = 3;
+insert into t1 values (20, 20, 't1-A');
+
+-- Mid-point diff after round A on both sides.
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1;
+
+-- T4: t2 round B — further diverge.
+update t2 set b = 11, note = 't2-B' where a = 1;
+update t2 set b = 44, note = 't2-B' where a = 4;
+insert into t2 values (11, 11, 't2-B');
+delete from t2 where a = 10;
+
+-- T5: t1 round B.
+update t1 set b = 111, note = 't1-B' where a = 1;
+insert into t1 values (21, 21, 't1-B');
+delete from t1 where a = 20;
+update t1 set b = 5555, note = 't1-B' where a = 5;
+
+-- Final diff — both sides have two rounds of IUD.
+data branch diff t2 against t1 output summary;
+data branch diff t2 against t1 output count;
+data branch diff t2 against t1;
+
+data branch diff t1 against t2 output summary;
+data branch diff t1 against t2 output count;
+
+drop table t2;
+drop table t1;
+
+drop database test_chain_diff;

--- a/test/distributed/cases/git4data/branch/diff/diff_13.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_13.result
@@ -1,0 +1,351 @@
+drop database if exists test_tree_diff;
+create database test_tree_diff;
+use test_tree_diff;
+create table t0(a int primary key, b int);
+insert into t0 select *, * from generate_series(1, 20) g;
+data branch create table t1 from t0;
+insert into t1 values (101, 101);
+update t1 set b = 10000 where a = 1;
+delete from t1 where a = 19;
+data branch create table t2 from t0;
+insert into t2 values (102, 102);
+update t2 set b = 20000 where a = 2;
+delete from t2 where a = 18;
+data branch create table t3 from t0;
+insert into t3 values (103, 103);
+update t3 set b = 30000 where a = 3;
+delete from t3 where a = 17;
+data branch create table t4 from t1;
+insert into t4 values (104, 104);
+update t4 set b = 40000 where a = 4;
+delete from t4 where a = 16;
+data branch create table t5 from t1;
+insert into t5 values (105, 105);
+update t5 set b = 50000 where a = 5;
+delete from t5 where a = 15;
+data branch create table t6 from t2;
+insert into t6 values (106, 106);
+update t6 set b = 60000 where a = 6;
+delete from t6 where a = 14;
+data branch create table t7 from t3;
+insert into t7 values (107, 107);
+update t7 set b = 70000 where a = 7;
+delete from t7 where a = 13;
+data branch create table t8 from t3;
+insert into t8 values (108, 108);
+update t8 set b = 80000 where a = 8;
+delete from t8 where a = 12;
+data branch create table t9 from t4;
+insert into t9 values (109, 109);
+update t9 set b = 90000 where a = 9;
+delete from t9 where a = 11;
+data branch create table t10 from t4;
+insert into t10 values (110, 110);
+update t10 set b = 100000 where a = 10;
+delete from t10 where a = 20;
+data branch create table t11 from t5;
+insert into t11 values (111, 111);
+update t11 set b = 110000 where a = 1;
+delete from t11 where a = 11;
+data branch create table t12 from t5;
+insert into t12 values (112, 112);
+update t12 set b = 120000 where a = 2;
+delete from t12 where a = 12;
+data branch create table t13 from t6;
+insert into t13 values (113, 113);
+update t13 set b = 130000 where a = 3;
+delete from t13 where a = 13;
+data branch create table t14 from t6;
+insert into t14 values (114, 114);
+update t14 set b = 140000 where a = 4;
+delete from t14 where a = 14;
+data branch create table t15 from t7;
+insert into t15 values (115, 115);
+update t15 set b = 150000 where a = 5;
+delete from t15 where a = 15;
+data branch create table t16 from t7;
+insert into t16 values (116, 116);
+update t16 set b = 160000 where a = 6;
+delete from t16 where a = 16;
+data branch create table t17 from t8;
+insert into t17 values (117, 117);
+update t17 set b = 170000 where a = 7;
+delete from t17 where a = 17;
+data branch create table t18 from t8;
+insert into t18 values (118, 118);
+update t18 set b = 180000 where a = 8;
+delete from t18 where a = 18;
+insert into t0 values (200, 200);
+update t0 set b = 99999 where a = 1;
+delete from t0 where a = 19;
+select count(*) as tree_nodes from mo_catalog.mo_branch_metadata m
+join mo_catalog.mo_tables t
+on t.rel_id = m.table_id
+where t.reldatabase = 'test_tree_diff' and t.relname like 't%';
+➤ tree_nodes[-5,64,0]  𝄀
+18
+data branch diff t9 against t0 output summary;
+➤ metric[12,0,0]  ¦  t9[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  1  𝄀
+DELETED  ¦  2  ¦  0  𝄀
+UPDATED  ¦  3  ¦  1
+data branch diff t9 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+10
+data branch diff t9 against t0;
+➤ diff t9 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t9  ¦  UPDATE  ¦  1  ¦  10000  𝄀
+t0  ¦  UPDATE  ¦  1  ¦  99999  𝄀
+t9  ¦  UPDATE  ¦  4  ¦  40000  𝄀
+t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
+t9  ¦  DELETE  ¦  11  ¦  11  𝄀
+t9  ¦  DELETE  ¦  16  ¦  16  𝄀
+t9  ¦  INSERT  ¦  101  ¦  101  𝄀
+t9  ¦  INSERT  ¦  104  ¦  104  𝄀
+t9  ¦  INSERT  ¦  109  ¦  109  𝄀
+t0  ¦  INSERT  ¦  200  ¦  200
+data branch diff t9 against t10 output summary;
+➤ metric[12,0,0]  ¦  t9[-5,0,0]  ¦  t10[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  1  ¦  1  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t9 against t10 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+6
+data branch diff t9 against t10;
+➤ diff t9 against t10[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
+t10  ¦  UPDATE  ¦  10  ¦  100000  𝄀
+t9  ¦  DELETE  ¦  11  ¦  11  𝄀
+t10  ¦  DELETE  ¦  20  ¦  20  𝄀
+t9  ¦  INSERT  ¦  109  ¦  109  𝄀
+t10  ¦  INSERT  ¦  110  ¦  110
+data branch diff t9 against t11 output summary;
+➤ metric[12,0,0]  ¦  t9[-5,0,0]  ¦  t11[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  2  𝄀
+DELETED  ¦  1  ¦  1  𝄀
+UPDATED  ¦  2  ¦  2
+data branch diff t9 against t11 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+10
+data branch diff t9 against t11;
+➤ diff t9 against t11[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t11  ¦  UPDATE  ¦  1  ¦  110000  𝄀
+t9  ¦  UPDATE  ¦  4  ¦  40000  𝄀
+t11  ¦  UPDATE  ¦  5  ¦  50000  𝄀
+t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
+t11  ¦  DELETE  ¦  15  ¦  15  𝄀
+t9  ¦  DELETE  ¦  16  ¦  16  𝄀
+t9  ¦  INSERT  ¦  104  ¦  104  𝄀
+t11  ¦  INSERT  ¦  105  ¦  105  𝄀
+t9  ¦  INSERT  ¦  109  ¦  109  𝄀
+t11  ¦  INSERT  ¦  111  ¦  111
+data branch diff t9 against t13 output summary;
+➤ metric[12,0,0]  ¦  t9[-5,0,0]  ¦  t13[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  3  𝄀
+DELETED  ¦  3  ¦  3  𝄀
+UPDATED  ¦  3  ¦  3
+data branch diff t9 against t13 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+18
+data branch diff t9 against t13;
+➤ diff t9 against t13[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t9  ¦  UPDATE  ¦  1  ¦  10000  𝄀
+t13  ¦  UPDATE  ¦  2  ¦  20000  𝄀
+t13  ¦  UPDATE  ¦  3  ¦  130000  𝄀
+t9  ¦  UPDATE  ¦  4  ¦  40000  𝄀
+t13  ¦  UPDATE  ¦  6  ¦  60000  𝄀
+t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
+t9  ¦  DELETE  ¦  11  ¦  11  𝄀
+t13  ¦  DELETE  ¦  13  ¦  13  𝄀
+t13  ¦  DELETE  ¦  14  ¦  14  𝄀
+t9  ¦  DELETE  ¦  16  ¦  16  𝄀
+t13  ¦  DELETE  ¦  18  ¦  18  𝄀
+t9  ¦  DELETE  ¦  19  ¦  19  𝄀
+t9  ¦  INSERT  ¦  101  ¦  101  𝄀
+t13  ¦  INSERT  ¦  102  ¦  102  𝄀
+t9  ¦  INSERT  ¦  104  ¦  104  𝄀
+t13  ¦  INSERT  ¦  106  ¦  106  𝄀
+t9  ¦  INSERT  ¦  109  ¦  109  𝄀
+t13  ¦  INSERT  ¦  113  ¦  113
+data branch diff t4 against t0 output summary;
+➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  2  ¦  1
+data branch diff t4 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+7
+data branch diff t4 against t0;
+➤ diff t4 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t4  ¦  UPDATE  ¦  1  ¦  10000  𝄀
+t0  ¦  UPDATE  ¦  1  ¦  99999  𝄀
+t4  ¦  UPDATE  ¦  4  ¦  40000  𝄀
+t4  ¦  DELETE  ¦  16  ¦  16  𝄀
+t4  ¦  INSERT  ¦  101  ¦  101  𝄀
+t4  ¦  INSERT  ¦  104  ¦  104  𝄀
+t0  ¦  INSERT  ¦  200  ¦  200
+data branch diff t9 against t4 output summary;
+➤ metric[12,0,0]  ¦  t9[-5,0,0]  ¦  t4[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t9 against t4 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+3
+data branch diff t9 against t4;
+➤ diff t9 against t4[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
+t9  ¦  DELETE  ¦  11  ¦  11  𝄀
+t9  ¦  INSERT  ¦  109  ¦  109
+data branch diff t9 against t1 output summary;
+➤ metric[12,0,0]  ¦  t9[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  2  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t9 against t1 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+6
+data branch diff t9 against t1;
+➤ diff t9 against t1[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t9  ¦  UPDATE  ¦  4  ¦  40000  𝄀
+t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
+t9  ¦  DELETE  ¦  11  ¦  11  𝄀
+t9  ¦  DELETE  ¦  16  ¦  16  𝄀
+t9  ¦  INSERT  ¦  104  ¦  104  𝄀
+t9  ¦  INSERT  ¦  109  ¦  109
+data branch diff t9 against t6 output summary;
+➤ metric[12,0,0]  ¦  t9[-5,0,0]  ¦  t6[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  2  𝄀
+DELETED  ¦  3  ¦  2  𝄀
+UPDATED  ¦  3  ¦  2
+data branch diff t9 against t6 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+15
+data branch diff t9 against t6;
+➤ diff t9 against t6[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t9  ¦  UPDATE  ¦  1  ¦  10000  𝄀
+t6  ¦  UPDATE  ¦  2  ¦  20000  𝄀
+t9  ¦  UPDATE  ¦  4  ¦  40000  𝄀
+t6  ¦  UPDATE  ¦  6  ¦  60000  𝄀
+t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
+t9  ¦  DELETE  ¦  11  ¦  11  𝄀
+t6  ¦  DELETE  ¦  14  ¦  14  𝄀
+t9  ¦  DELETE  ¦  16  ¦  16  𝄀
+t6  ¦  DELETE  ¦  18  ¦  18  𝄀
+t9  ¦  DELETE  ¦  19  ¦  19  𝄀
+t9  ¦  INSERT  ¦  101  ¦  101  𝄀
+t6  ¦  INSERT  ¦  102  ¦  102  𝄀
+t9  ¦  INSERT  ¦  104  ¦  104  𝄀
+t6  ¦  INSERT  ¦  106  ¦  106  𝄀
+t9  ¦  INSERT  ¦  109  ¦  109
+data branch diff t4 against t3 output summary;
+➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t3[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
+DELETED  ¦  2  ¦  1  𝄀
+UPDATED  ¦  2  ¦  1
+data branch diff t4 against t3 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+9
+data branch diff t4 against t3;
+➤ diff t4 against t3[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t4  ¦  UPDATE  ¦  1  ¦  10000  𝄀
+t3  ¦  UPDATE  ¦  3  ¦  30000  𝄀
+t4  ¦  UPDATE  ¦  4  ¦  40000  𝄀
+t4  ¦  DELETE  ¦  16  ¦  16  𝄀
+t3  ¦  DELETE  ¦  17  ¦  17  𝄀
+t4  ¦  DELETE  ¦  19  ¦  19  𝄀
+t4  ¦  INSERT  ¦  101  ¦  101  𝄀
+t3  ¦  INSERT  ¦  103  ¦  103  𝄀
+t4  ¦  INSERT  ¦  104  ¦  104
+data branch diff t18 against t9 output summary;
+➤ metric[12,0,0]  ¦  t18[-5,0,0]  ¦  t9[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  3  𝄀
+DELETED  ¦  3  ¦  3  𝄀
+UPDATED  ¦  2  ¦  3
+data branch diff t18 against t9 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+17
+data branch diff t18 against t9;
+➤ diff t18 against t9[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
+t9  ¦  UPDATE  ¦  1  ¦  10000  𝄀
+t18  ¦  UPDATE  ¦  3  ¦  30000  𝄀
+t9  ¦  UPDATE  ¦  4  ¦  40000  𝄀
+t18  ¦  UPDATE  ¦  8  ¦  180000  𝄀
+t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
+t9  ¦  DELETE  ¦  11  ¦  11  𝄀
+t18  ¦  DELETE  ¦  12  ¦  12  𝄀
+t9  ¦  DELETE  ¦  16  ¦  16  𝄀
+t18  ¦  DELETE  ¦  17  ¦  17  𝄀
+t18  ¦  DELETE  ¦  18  ¦  18  𝄀
+t9  ¦  DELETE  ¦  19  ¦  19  𝄀
+t9  ¦  INSERT  ¦  101  ¦  101  𝄀
+t18  ¦  INSERT  ¦  103  ¦  103  𝄀
+t9  ¦  INSERT  ¦  104  ¦  104  𝄀
+t18  ¦  INSERT  ¦  108  ¦  108  𝄀
+t9  ¦  INSERT  ¦  109  ¦  109  𝄀
+t18  ¦  INSERT  ¦  118  ¦  118
+data branch diff t13 against t9 output summary;
+➤ metric[12,0,0]  ¦  t13[-5,0,0]  ¦  t9[-5,0,0]  𝄀
+INSERTED  ¦  3  ¦  3  𝄀
+DELETED  ¦  3  ¦  3  𝄀
+UPDATED  ¦  3  ¦  3
+data branch diff t10 against t9 output summary;
+➤ metric[12,0,0]  ¦  t10[-5,0,0]  ¦  t9[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  1  ¦  1  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t12 against t11 output summary;
+➤ metric[12,0,0]  ¦  t12[-5,0,0]  ¦  t11[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  1  ¦  1  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t14 against t13 output summary;
+➤ metric[12,0,0]  ¦  t14[-5,0,0]  ¦  t13[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  0  ¦  1  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t9 against t0 columns (a);
+➤ diff t9 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  𝄀
+t9  ¦  UPDATE  ¦  1  𝄀
+t0  ¦  UPDATE  ¦  1  𝄀
+t9  ¦  UPDATE  ¦  4  𝄀
+t9  ¦  UPDATE  ¦  9  𝄀
+t9  ¦  DELETE  ¦  11  𝄀
+t9  ¦  DELETE  ¦  16  𝄀
+t9  ¦  INSERT  ¦  101  𝄀
+t9  ¦  INSERT  ¦  104  𝄀
+t9  ¦  INSERT  ¦  109  𝄀
+t0  ¦  INSERT  ¦  200
+data branch diff t9 against t0 columns (b);
+➤ diff t9 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  b[4,0,0]  𝄀
+t9  ¦  UPDATE  ¦  10000  𝄀
+t0  ¦  UPDATE  ¦  99999  𝄀
+t9  ¦  UPDATE  ¦  40000  𝄀
+t9  ¦  UPDATE  ¦  90000  𝄀
+t9  ¦  DELETE  ¦  11  𝄀
+t9  ¦  DELETE  ¦  16  𝄀
+t9  ¦  INSERT  ¦  101  𝄀
+t9  ¦  INSERT  ¦  104  𝄀
+t9  ¦  INSERT  ¦  109  𝄀
+t0  ¦  INSERT  ¦  200
+drop table t9;
+drop table t10;
+drop table t11;
+drop table t12;
+drop table t13;
+drop table t14;
+drop table t15;
+drop table t16;
+drop table t17;
+drop table t18;
+drop table t4;
+drop table t5;
+drop table t6;
+drop table t7;
+drop table t8;
+drop table t1;
+drop table t2;
+drop table t3;
+drop table t0;
+drop database test_tree_diff;

--- a/test/distributed/cases/git4data/branch/diff/diff_13.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_13.result
@@ -87,11 +87,11 @@ where t.reldatabase = 'test_tree_diff' and t.relname like 't%';
 data branch diff t9 against t0 output summary;
 ➤ metric[12,0,0]  ¦  t9[-5,0,0]  ¦  t0[-5,0,0]  𝄀
 INSERTED  ¦  3  ¦  1  𝄀
-DELETED  ¦  2  ¦  1  𝄀
+DELETED  ¦  2  ¦  0  𝄀
 UPDATED  ¦  3  ¦  1
 data branch diff t9 against t0 output count;
 ➤ COUNT(*)[-5,0,0]  𝄀
-11
+10
 data branch diff t9 against t0;
 ➤ diff t9 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
 t9  ¦  UPDATE  ¦  1  ¦  10000  𝄀
@@ -100,7 +100,6 @@ t9  ¦  UPDATE  ¦  4  ¦  40000  𝄀
 t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
 t9  ¦  DELETE  ¦  11  ¦  11  𝄀
 t9  ¦  DELETE  ¦  16  ¦  16  𝄀
-t0  ¦  DELETE  ¦  19  ¦  19  𝄀
 t9  ¦  INSERT  ¦  101  ¦  101  𝄀
 t9  ¦  INSERT  ¦  104  ¦  104  𝄀
 t9  ¦  INSERT  ¦  109  ¦  109  𝄀
@@ -172,18 +171,17 @@ t13  ¦  INSERT  ¦  113  ¦  113
 data branch diff t4 against t0 output summary;
 ➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t0[-5,0,0]  𝄀
 INSERTED  ¦  2  ¦  1  𝄀
-DELETED  ¦  1  ¦  1  𝄀
+DELETED  ¦  1  ¦  0  𝄀
 UPDATED  ¦  2  ¦  1
 data branch diff t4 against t0 output count;
 ➤ COUNT(*)[-5,0,0]  𝄀
-8
+7
 data branch diff t4 against t0;
 ➤ diff t4 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
 t4  ¦  UPDATE  ¦  1  ¦  10000  𝄀
 t0  ¦  UPDATE  ¦  1  ¦  99999  𝄀
 t4  ¦  UPDATE  ¦  4  ¦  40000  𝄀
 t4  ¦  DELETE  ¦  16  ¦  16  𝄀
-t0  ¦  DELETE  ¦  19  ¦  19  𝄀
 t4  ¦  INSERT  ¦  101  ¦  101  𝄀
 t4  ¦  INSERT  ¦  104  ¦  104  𝄀
 t0  ¦  INSERT  ¦  200  ¦  200
@@ -315,7 +313,6 @@ t9  ¦  UPDATE  ¦  4  𝄀
 t9  ¦  UPDATE  ¦  9  𝄀
 t9  ¦  DELETE  ¦  11  𝄀
 t9  ¦  DELETE  ¦  16  𝄀
-t0  ¦  DELETE  ¦  19  𝄀
 t9  ¦  INSERT  ¦  101  𝄀
 t9  ¦  INSERT  ¦  104  𝄀
 t9  ¦  INSERT  ¦  109  𝄀
@@ -328,7 +325,6 @@ t9  ¦  UPDATE  ¦  40000  𝄀
 t9  ¦  UPDATE  ¦  90000  𝄀
 t9  ¦  DELETE  ¦  11  𝄀
 t9  ¦  DELETE  ¦  16  𝄀
-t0  ¦  DELETE  ¦  19  𝄀
 t9  ¦  INSERT  ¦  101  𝄀
 t9  ¦  INSERT  ¦  104  𝄀
 t9  ¦  INSERT  ¦  109  𝄀

--- a/test/distributed/cases/git4data/branch/diff/diff_13.result
+++ b/test/distributed/cases/git4data/branch/diff/diff_13.result
@@ -87,11 +87,11 @@ where t.reldatabase = 'test_tree_diff' and t.relname like 't%';
 data branch diff t9 against t0 output summary;
 ➤ metric[12,0,0]  ¦  t9[-5,0,0]  ¦  t0[-5,0,0]  𝄀
 INSERTED  ¦  3  ¦  1  𝄀
-DELETED  ¦  2  ¦  0  𝄀
+DELETED  ¦  2  ¦  1  𝄀
 UPDATED  ¦  3  ¦  1
 data branch diff t9 against t0 output count;
 ➤ COUNT(*)[-5,0,0]  𝄀
-10
+11
 data branch diff t9 against t0;
 ➤ diff t9 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
 t9  ¦  UPDATE  ¦  1  ¦  10000  𝄀
@@ -100,6 +100,7 @@ t9  ¦  UPDATE  ¦  4  ¦  40000  𝄀
 t9  ¦  UPDATE  ¦  9  ¦  90000  𝄀
 t9  ¦  DELETE  ¦  11  ¦  11  𝄀
 t9  ¦  DELETE  ¦  16  ¦  16  𝄀
+t0  ¦  DELETE  ¦  19  ¦  19  𝄀
 t9  ¦  INSERT  ¦  101  ¦  101  𝄀
 t9  ¦  INSERT  ¦  104  ¦  104  𝄀
 t9  ¦  INSERT  ¦  109  ¦  109  𝄀
@@ -171,17 +172,18 @@ t13  ¦  INSERT  ¦  113  ¦  113
 data branch diff t4 against t0 output summary;
 ➤ metric[12,0,0]  ¦  t4[-5,0,0]  ¦  t0[-5,0,0]  𝄀
 INSERTED  ¦  2  ¦  1  𝄀
-DELETED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  1  𝄀
 UPDATED  ¦  2  ¦  1
 data branch diff t4 against t0 output count;
 ➤ COUNT(*)[-5,0,0]  𝄀
-7
+8
 data branch diff t4 against t0;
 ➤ diff t4 against t0[12,0,0]  ¦  flag[12,0,0]  ¦  a[4,0,0]  ¦  b[4,0,0]  𝄀
 t4  ¦  UPDATE  ¦  1  ¦  10000  𝄀
 t0  ¦  UPDATE  ¦  1  ¦  99999  𝄀
 t4  ¦  UPDATE  ¦  4  ¦  40000  𝄀
 t4  ¦  DELETE  ¦  16  ¦  16  𝄀
+t0  ¦  DELETE  ¦  19  ¦  19  𝄀
 t4  ¦  INSERT  ¦  101  ¦  101  𝄀
 t4  ¦  INSERT  ¦  104  ¦  104  𝄀
 t0  ¦  INSERT  ¦  200  ¦  200
@@ -313,6 +315,7 @@ t9  ¦  UPDATE  ¦  4  𝄀
 t9  ¦  UPDATE  ¦  9  𝄀
 t9  ¦  DELETE  ¦  11  𝄀
 t9  ¦  DELETE  ¦  16  𝄀
+t0  ¦  DELETE  ¦  19  𝄀
 t9  ¦  INSERT  ¦  101  𝄀
 t9  ¦  INSERT  ¦  104  𝄀
 t9  ¦  INSERT  ¦  109  𝄀
@@ -325,6 +328,7 @@ t9  ¦  UPDATE  ¦  40000  𝄀
 t9  ¦  UPDATE  ¦  90000  𝄀
 t9  ¦  DELETE  ¦  11  𝄀
 t9  ¦  DELETE  ¦  16  𝄀
+t0  ¦  DELETE  ¦  19  𝄀
 t9  ¦  INSERT  ¦  101  𝄀
 t9  ¦  INSERT  ¦  104  𝄀
 t9  ¦  INSERT  ¦  109  𝄀

--- a/test/distributed/cases/git4data/branch/diff/diff_13.sql
+++ b/test/distributed/cases/git4data/branch/diff/diff_13.sql
@@ -1,0 +1,292 @@
+-- Giant multi-fork branch tree diff coverage.
+--
+-- Tree shape (19 nodes, depth 4, 10 leaves):
+--
+--                         t0  (root, L1)
+--                    /    |    \
+--                   t1    t2    t3        (L2)
+--                 /  \    |    /  \
+--               t4   t5  t6  t7   t8      (L3)
+--              / \  / \  / \ / \  / \
+--            t9 t10 t11 t12 t13 t14 t15 t16 t17 t18   (L4, 10 leaves)
+--
+-- Per-node leaf-to-parent mapping:
+--   t1 -> t0     t2 -> t0     t3 -> t0
+--   t4 -> t1     t5 -> t1     t6 -> t2     t7 -> t3     t8 -> t3
+--   t9,t10  -> t4
+--   t11,t12 -> t5
+--   t13,t14 -> t6    (t6 has two leaves even though t2 only forked once)
+--   t15,t16 -> t7
+--   t17,t18 -> t8
+--
+-- Test plan:
+--   1. build the tree in top-down order;
+--   2. after each `data branch create`, immediately do at least one
+--      insert, one update, one delete on that node;
+--   3. finally do IUD on t0;
+--   4. take 10 diffs across various tree cross-sections:
+--      a. leaf vs root          (skip 3 edges)
+--      b. leaf vs sibling leaf  (share grandparent)
+--      c. leaf vs cousin leaf   (share great-grandparent t0)
+--      d. intermediate vs root
+--      e. leaf vs its own parent (direct)
+--      f. leaf vs its own grandparent (skip 1)
+--      g. leaf vs non-ancestor intermediate
+--      h. two intermediates with different depth
+--      i. sibling intermediates
+--      j. reverse-direction of one of the above, for symmetry.
+--
+-- Row encoding scheme so each node has a unique footprint:
+--   Every table starts with rows (1..20). Each node Tk with k>=1
+--   does:
+--      insert (100+k, 100+k)      -- unique PK per node
+--      update set b = k*10000 where a = k  -- stamps a predictable row
+--      delete from Tk where a = 20 - k     -- stable but different row
+-- t0 finally does:
+--      insert (200, 200)
+--      update set b = 99999 where a = 1
+--      delete from t0 where a = 19
+
+drop database if exists test_tree_diff;
+create database test_tree_diff;
+use test_tree_diff;
+
+-- ============================================================
+-- Root and all seed rows.
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 select *, * from generate_series(1, 20) g;
+
+-- ============================================================
+-- L2: t1, t2, t3 from t0 (each followed by IUD).
+-- ============================================================
+data branch create table t1 from t0;
+insert into t1 values (101, 101);
+update t1 set b = 10000 where a = 1;
+delete from t1 where a = 19;
+
+data branch create table t2 from t0;
+insert into t2 values (102, 102);
+update t2 set b = 20000 where a = 2;
+delete from t2 where a = 18;
+
+data branch create table t3 from t0;
+insert into t3 values (103, 103);
+update t3 set b = 30000 where a = 3;
+delete from t3 where a = 17;
+
+-- ============================================================
+-- L3: t4,t5 from t1; t6 from t2; t7,t8 from t3.
+-- ============================================================
+data branch create table t4 from t1;
+insert into t4 values (104, 104);
+update t4 set b = 40000 where a = 4;
+delete from t4 where a = 16;
+
+data branch create table t5 from t1;
+insert into t5 values (105, 105);
+update t5 set b = 50000 where a = 5;
+delete from t5 where a = 15;
+
+data branch create table t6 from t2;
+insert into t6 values (106, 106);
+update t6 set b = 60000 where a = 6;
+delete from t6 where a = 14;
+
+data branch create table t7 from t3;
+insert into t7 values (107, 107);
+update t7 set b = 70000 where a = 7;
+delete from t7 where a = 13;
+
+data branch create table t8 from t3;
+insert into t8 values (108, 108);
+update t8 set b = 80000 where a = 8;
+delete from t8 where a = 12;
+
+-- ============================================================
+-- L4 (10 leaves):
+--   t9,t10  from t4
+--   t11,t12 from t5
+--   t13,t14 from t6
+--   t15,t16 from t7
+--   t17,t18 from t8
+-- ============================================================
+data branch create table t9 from t4;
+insert into t9 values (109, 109);
+update t9 set b = 90000 where a = 9;
+delete from t9 where a = 11;
+
+data branch create table t10 from t4;
+insert into t10 values (110, 110);
+update t10 set b = 100000 where a = 10;
+delete from t10 where a = 20;
+
+data branch create table t11 from t5;
+insert into t11 values (111, 111);
+update t11 set b = 110000 where a = 1;
+delete from t11 where a = 11;
+
+data branch create table t12 from t5;
+insert into t12 values (112, 112);
+update t12 set b = 120000 where a = 2;
+delete from t12 where a = 12;
+
+data branch create table t13 from t6;
+insert into t13 values (113, 113);
+update t13 set b = 130000 where a = 3;
+delete from t13 where a = 13;
+
+data branch create table t14 from t6;
+insert into t14 values (114, 114);
+update t14 set b = 140000 where a = 4;
+delete from t14 where a = 14;
+
+data branch create table t15 from t7;
+insert into t15 values (115, 115);
+update t15 set b = 150000 where a = 5;
+delete from t15 where a = 15;
+
+data branch create table t16 from t7;
+insert into t16 values (116, 116);
+update t16 set b = 160000 where a = 6;
+delete from t16 where a = 16;
+
+data branch create table t17 from t8;
+insert into t17 values (117, 117);
+update t17 set b = 170000 where a = 7;
+delete from t17 where a = 17;
+
+data branch create table t18 from t8;
+insert into t18 values (118, 118);
+update t18 set b = 180000 where a = 8;
+delete from t18 where a = 18;
+
+-- ============================================================
+-- Finally, IUD on t0 itself.
+-- ============================================================
+insert into t0 values (200, 200);
+update t0 set b = 99999 where a = 1;
+delete from t0 where a = 19;
+
+-- ============================================================
+-- Sanity: tree metadata query — verify the DAG has 19 nodes.
+-- ============================================================
+select count(*) as tree_nodes from mo_catalog.mo_branch_metadata m
+  join mo_catalog.mo_tables t
+    on t.rel_id = m.table_id
+ where t.reldatabase = 'test_tree_diff' and t.relname like 't%';
+
+-- ============================================================
+-- 10 diff pairs. Each one exercises a structurally distinct
+-- cross-section of the tree, so together they stress every
+-- relevant LCA code path.
+-- ============================================================
+
+-- (1) leaf vs root: skip 3 edges (L4 -> L1). LCA=t0, tarBranchTS=CloneTS(t1).
+data branch diff t9 against t0 output summary;
+data branch diff t9 against t0 output count;
+data branch diff t9 against t0;
+
+-- (2) leaf vs sibling leaf: share immediate grandparent. LCA=t4 (both
+-- t9,t10 branched from t4). lcaOther with tar/baseBranchTS from
+-- CloneTS(t9) and CloneTS(t10) respectively.
+data branch diff t9 against t10 output summary;
+data branch diff t9 against t10 output count;
+data branch diff t9 against t10;
+
+-- (3) leaf vs cousin leaf: share great-grandparent t1. t9 under
+-- t4, t11 under t5. LCA=t1.
+data branch diff t9 against t11 output summary;
+data branch diff t9 against t11 output count;
+data branch diff t9 against t11;
+
+-- (4) leaf vs cross-subtree cousin: t9 (under t1) vs t13 (under
+-- t2). LCA=t0. The LCA walk must traverse opposite subtrees.
+data branch diff t9 against t13 output summary;
+data branch diff t9 against t13 output count;
+data branch diff t9 against t13;
+
+-- (5) intermediate vs root: t4 vs t0. LCA=t0 (lcaRight).
+data branch diff t4 against t0 output summary;
+data branch diff t4 against t0 output count;
+data branch diff t4 against t0;
+
+-- (6) leaf vs own parent: direct child/parent. LCA=t4.
+data branch diff t9 against t4 output summary;
+data branch diff t9 against t4 output count;
+data branch diff t9 against t4;
+
+-- (7) leaf vs own grandparent: skip 1 edge. LCA=t1.
+data branch diff t9 against t1 output summary;
+data branch diff t9 against t1 output count;
+data branch diff t9 against t1;
+
+-- (8) leaf vs non-ancestor intermediate of a different subtree:
+-- t9 (under t1) vs t6 (under t2). LCA=t0. Non-trivial: neither
+-- side is ancestor of the other, and they live in different L2
+-- subtrees.
+data branch diff t9 against t6 output summary;
+data branch diff t9 against t6 output count;
+data branch diff t9 against t6;
+
+-- (9) intermediate vs intermediate at different depth: t4 (L3,
+-- under t1) vs t3 (L2). LCA=t0.
+data branch diff t4 against t3 output summary;
+data branch diff t4 against t3 output count;
+data branch diff t4 against t3;
+
+-- (10) reverse direction of a deep cross-subtree pair: t18 vs t9.
+-- Both are L4 leaves, under completely different L2 subtrees
+-- (t18 under t3, t9 under t1). LCA=t0. Plus we test the reverse
+-- of (4) for asymmetry verification.
+data branch diff t18 against t9 output summary;
+data branch diff t18 against t9 output count;
+data branch diff t18 against t9;
+
+-- Reverse of (4) as an additional symmetry check.
+data branch diff t13 against t9 output summary;
+
+-- ============================================================
+-- Bonus: three-way summary sanity across the two sibling pairs
+-- under t4. Ensures that for symmetric structures the diff
+-- reports are mirror images.
+-- ============================================================
+data branch diff t10 against t9 output summary;
+data branch diff t12 against t11 output summary;
+data branch diff t14 against t13 output summary;
+
+-- ============================================================
+-- Bonus: a `columns` projection on the deepest pair to confirm
+-- projection still works at depth 3.
+-- ============================================================
+data branch diff t9 against t0 columns (a);
+data branch diff t9 against t0 columns (b);
+
+-- ============================================================
+-- Cleanup: delete in topological order (leaves first, then
+-- intermediates, then root).
+-- ============================================================
+drop table t9;
+drop table t10;
+drop table t11;
+drop table t12;
+drop table t13;
+drop table t14;
+drop table t15;
+drop table t16;
+drop table t17;
+drop table t18;
+
+drop table t4;
+drop table t5;
+drop table t6;
+drop table t7;
+drop table t8;
+
+drop table t1;
+drop table t2;
+drop table t3;
+
+drop table t0;
+
+drop database test_tree_diff;

--- a/test/distributed/cases/git4data/branch/merge/merge_8.result
+++ b/test/distributed/cases/git4data/branch/merge/merge_8.result
@@ -1,0 +1,364 @@
+drop database if exists test_chain_merge;
+create database test_chain_merge;
+use test_chain_merge;
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2), (3, 3);
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+insert into t2 values (4, 4), (5, 5);
+update t2 set b = b + 100 where a = 1;
+delete from t2 where a = 2;
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch merge t2 into t1;
+select * from t1 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  101  𝄀
+3  ¦  3  𝄀
+4  ¦  4  𝄀
+5  ¦  5
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch merge t1 into t0;
+select * from t0 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  101  𝄀
+3  ¦  3  𝄀
+4  ¦  4  𝄀
+5  ¦  5
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2), (3, 3);
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+insert into t2 values (10, 10), (11, 11);
+update t2 set b = b + 1000 where a = 1;
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch merge t2 into t0;
+select * from t0 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1001  𝄀
+2  ¦  2  𝄀
+3  ¦  3  𝄀
+10  ¦  10  𝄀
+11  ¦  11
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  2  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  1
+data branch diff t1 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+3
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2), (3, 3);
+data branch create table t1 from t0;
+insert into t1 values (4, 4);
+data branch create table t2 from t1;
+insert into t2 values (5, 5);
+update t2 set b = b + 10 where a = 1;
+update t0 set b = b + 100 where a = 1;
+insert into t0 values (50, 50);
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  1  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  1
+data branch merge t2 into t0 when conflict skip;
+select * from t0 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  101  𝄀
+2  ¦  2  𝄀
+3  ¦  3  𝄀
+4  ¦  4  𝄀
+5  ¦  5  𝄀
+50  ¦  50
+data branch merge t2 into t0 when conflict accept;
+select * from t0 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  11  𝄀
+2  ¦  2  𝄀
+3  ¦  3  𝄀
+4  ¦  4  𝄀
+5  ¦  5  𝄀
+50  ¦  50
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  1  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  2  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  1
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b varchar(8));
+insert into t0 values (1, 't0'), (2, 't0'), (3, 't0');
+data branch create table t1 from t0;
+insert into t1 values (4, 't1');
+update t1 set b = 't1u' where a = 2;
+data branch create table t2 from t1;
+insert into t2 values (5, 't2');
+update t2 set b = 't2u' where a = 3;
+update t1 set b = 't1late' where a = 1;
+insert into t1 values (6, 't1late');
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  2  ¦  0
+data branch merge t2 into t0;
+select * from t0 order by a;
+➤ a[4,32,0]  ¦  b[12,-1,0]  𝄀
+1  ¦  t0  𝄀
+2  ¦  t1u  𝄀
+3  ¦  t2u  𝄀
+4  ¦  t1  𝄀
+5  ¦  t2
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  1
+data branch diff t1 against t0 output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+4
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(region varchar(4), k int, v int, primary key (region, k));
+insert into t0 values ('eu', 1, 10), ('eu', 2, 20), ('us', 1, 100);
+data branch create table t1 from t0;
+insert into t1 values ('us', 2, 200);
+data branch create table t2 from t1;
+update t2 set v = v + 1 where region = 'eu' and k = 1;
+delete from t2 where region = 'us' and k = 2;
+insert into t2 values ('ap', 1, 999);
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  1  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch merge t2 into t1;
+select * from t1 order by region, k;
+➤ region[12,-1,0]  ¦  k[4,32,0]  ¦  v[4,32,0]  𝄀
+ap  ¦  1  ¦  999  𝄀
+eu  ¦  1  ¦  11  𝄀
+eu  ¦  2  ¦  20  𝄀
+us  ¦  1  ¦  100
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch merge t1 into t0;
+select * from t0 order by region, k;
+➤ region[12,-1,0]  ¦  k[4,32,0]  ¦  v[4,32,0]  𝄀
+ap  ¦  1  ¦  999  𝄀
+eu  ¦  1  ¦  11  𝄀
+eu  ¦  2  ¦  20  𝄀
+us  ¦  1  ¦  100
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+data branch diff t2 against t1 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t1[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2);
+drop snapshot if exists c6_t0_sp0;
+create snapshot c6_t0_sp0 for table test_chain_merge t0;
+data branch create table t1 from t0{snapshot="c6_t0_sp0"};
+insert into t1 values (3, 3);
+drop snapshot if exists c6_t1_sp0;
+create snapshot c6_t1_sp0 for table test_chain_merge t1;
+data branch create table t2 from t1{snapshot="c6_t1_sp0"};
+insert into t2 values (4, 4);
+update t2 set b = b + 10 where a = 1;
+drop snapshot if exists c6_t2_sp0;
+create snapshot c6_t2_sp0 for table test_chain_merge t2;
+data branch diff t2{snapshot="c6_t2_sp0"} against t0{snapshot="c6_t0_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t2{snapshot = 'c6_t2_sp0'}[-5,0,0]  ¦  t0{snapshot = 'c6_t0_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch merge t2 into t1;
+data branch merge t1 into t0;
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+data branch diff t2{snapshot="c6_t2_sp0"} against t0{snapshot="c6_t0_sp0"} output summary;
+➤ metric[12,0,0]  ¦  t2{snapshot = 'c6_t2_sp0'}[-5,0,0]  ¦  t0{snapshot = 'c6_t0_sp0'}[-5,0,0]  𝄀
+INSERTED  ¦  2  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  0
+data branch diff t2{snapshot="c6_t2_sp0"} against t0{snapshot="c6_t0_sp0"} output count;
+➤ COUNT(*)[-5,0,0]  𝄀
+3
+drop snapshot c6_t0_sp0;
+drop snapshot c6_t1_sp0;
+drop snapshot c6_t2_sp0;
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b int, tag varchar(8));
+insert into t0 values (1, 1, 'orig'), (2, 2, 'orig');
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+update t0 set b = 111, tag = 't0-won' where a = 1;
+update t2 set b = 222, tag = 't2-won' where a = 1;
+insert into t0 values (10, 10, 't0-ins');
+insert into t2 values (20, 20, 't2-ins');
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  1
+data branch merge t2 into t0 when conflict skip;
+select * from t0 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  tag[12,-1,0]  𝄀
+1  ¦  111  ¦  t0-won  𝄀
+2  ¦  2  ¦  orig  𝄀
+10  ¦  10  ¦  t0-ins  𝄀
+20  ¦  20  ¦  t2-ins
+data branch merge t2 into t0 when conflict accept;
+select * from t0 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  tag[12,-1,0]  𝄀
+1  ¦  222  ¦  t2-won  𝄀
+2  ¦  2  ¦  orig  𝄀
+10  ¦  10  ¦  t0-ins  𝄀
+20  ¦  20  ¦  t2-ins
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  1  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int, b int);
+insert into t0 select *, * from generate_series(1, 20) g;
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+insert into t2 values (21, 21), (22, 22);
+update t2 set b = b + 1 where a in (5, 10);
+delete from t2 where a in (1, 2);
+data branch merge t2 into t1;
+data branch merge t1 into t0;
+select count(*) as total_rows from t0;
+➤ total_rows[-5,64,0]  𝄀
+20
+select * from t0 where a in (5, 10, 21, 22) order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+5  ¦  6  𝄀
+10  ¦  11  𝄀
+21  ¦  21  𝄀
+22  ¦  22
+select count(*) as deleted_rows from t0 where a in (1, 2);
+➤ deleted_rows[-5,64,0]  𝄀
+0
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  2  𝄀
+DELETED  ¦  0  ¦  2  𝄀
+UPDATED  ¦  2  ¦  0
+data branch diff t1 against t0 output summary;
+➤ metric[12,0,0]  ¦  t1[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  0  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  0
+drop table t2;
+drop table t1;
+drop table t0;
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2);
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+insert into t1 values (3, 3);
+update t1 set b = b + 100 where a = 1;
+data branch merge t1 into t0;
+select * from t0 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  101  𝄀
+2  ¦  2  𝄀
+3  ¦  3
+insert into t2 values (4, 4);
+update t2 set b = b + 1000 where a = 2;
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  1  ¦  1  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  1  ¦  1
+data branch merge t2 into t0 when conflict accept;
+select * from t0 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  101  𝄀
+2  ¦  1002  𝄀
+3  ¦  3  𝄀
+4  ¦  4
+data branch diff t2 against t0 output summary;
+➤ metric[12,0,0]  ¦  t2[-5,0,0]  ¦  t0[-5,0,0]  𝄀
+INSERTED  ¦  0  ¦  1  𝄀
+DELETED  ¦  0  ¦  0  𝄀
+UPDATED  ¦  0  ¦  1
+drop table t2;
+drop table t1;
+drop table t0;
+drop database test_chain_merge;

--- a/test/distributed/cases/git4data/branch/merge/merge_8.sql
+++ b/test/distributed/cases/git4data/branch/merge/merge_8.sql
@@ -1,0 +1,363 @@
+-- Linear branch chain t0 -> t1 -> t2 merge coverage.
+-- Verifies `data branch merge` in a chain shape (grandparent ->
+-- parent -> child). The existing merge/*.sql only covers flat
+-- forks (t0 -> {t1, t2}) or single-edge parent/child merges.
+-- A chain merge is distinctive because:
+--   * merging the GRANDCHILD directly into the GRANDPARENT
+--     (t2 into t0) forces the LCA probe to walk through t1's
+--     clone edge to identify t0 as the LCA;
+--   * a cascade merge (t2 -> t1, then t1 -> t0) must leave the
+--     intermediate branch's metadata consistent so later diffs
+--     still resolve;
+--   * conflict detection (skip / accept) has to work the same way
+--     across multiple chain depths.
+
+drop database if exists test_chain_merge;
+create database test_chain_merge;
+use test_chain_merge;
+
+-- ============================================================
+-- Case 1: cascade merge up the chain, single primary key.
+-- Write-on-leaf-only, then merge t2 -> t1, then merge t1 -> t0.
+-- After each merge, verify the parent contains the merged rows
+-- and that subsequent diffs are empty.
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2), (3, 3);
+
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+
+insert into t2 values (4, 4), (5, 5);
+update t2 set b = b + 100 where a = 1;
+delete from t2 where a = 2;
+
+data branch diff t2 against t1 output summary;
+data branch merge t2 into t1;
+select * from t1 order by a;
+data branch diff t2 against t1 output summary;
+
+-- now t1 carries t2's changes; cascade up to t0.
+data branch diff t1 against t0 output summary;
+data branch merge t1 into t0;
+select * from t0 order by a;
+data branch diff t1 against t0 output summary;
+
+-- After full cascade, diff t2 against t0 must also be empty.
+data branch diff t2 against t0 output summary;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 2: direct merge grandchild -> grandparent (t2 into t0)
+-- without going through t1. Writes only on leaf.
+-- Verifies the LCA probe identifies t0 as LCA across 2 clone
+-- edges, and the merge correctly applies t2's mutations to t0.
+-- t1 remains untouched and its diff to t0 should still reflect
+-- only what was on t1 beforehand (nothing in this case).
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2), (3, 3);
+
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+
+insert into t2 values (10, 10), (11, 11);
+update t2 set b = b + 1000 where a = 1;
+
+data branch diff t2 against t0 output summary;
+data branch merge t2 into t0;
+
+select * from t0 order by a;
+
+-- After merging t2 into t0, the grandchild->grandparent diff
+-- becomes empty, but t2 vs t1 still shows t2's mutations (t1
+-- was NOT touched by this merge).
+data branch diff t2 against t0 output summary;
+data branch diff t2 against t1 output summary;
+
+-- t1 vs t0: now t0 has the rows that t2 added; t1 doesn't. So
+-- t1 vs t0 should surface those as t0-side INSERTs.
+data branch diff t1 against t0 output summary;
+data branch diff t1 against t0 output count;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 3: DML on every level of the chain, then a direct
+-- grandchild->grandparent merge. Verifies conflict handling
+-- when t0 itself has been mutated after branching.
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2), (3, 3);
+
+data branch create table t1 from t0;
+insert into t1 values (4, 4);
+
+data branch create table t2 from t1;
+insert into t2 values (5, 5);
+update t2 set b = b + 10 where a = 1;
+
+-- Now mutate t0 at a row that t2 has also modified -> CONFLICT.
+update t0 set b = b + 100 where a = 1;
+insert into t0 values (50, 50);
+
+data branch diff t2 against t0 output summary;
+
+-- Default merge should fail on conflict (row a=1 has differing
+-- values on both sides). Use conflict=skip first, then accept.
+data branch merge t2 into t0 when conflict skip;
+select * from t0 order by a;
+
+-- Accept overwrites t0's value with t2's.
+data branch merge t2 into t0 when conflict accept;
+select * from t0 order by a;
+
+-- After accept, t2 vs t0 should be empty (t2 side fully applied).
+data branch diff t2 against t0 output summary;
+
+-- t1 vs t0: t1 has a=4 insert only; t0 now has everything from
+-- t2 plus a=50 that came from t0's own insert.
+data branch diff t1 against t0 output summary;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 4: DML on middle branch AFTER grandchild was taken.
+-- t2 was branched from t1, THEN t1 got more writes. Merging
+-- t2 into t0 must attribute middle-branch writes correctly:
+-- t1's post-t2 writes should NOT appear in t0 (we're merging
+-- t2, not t1), but since t2 was branched BEFORE those writes
+-- existed, they're invisible to t2 anyway.
+-- ============================================================
+create table t0(a int primary key, b varchar(8));
+insert into t0 values (1, 't0'), (2, 't0'), (3, 't0');
+
+data branch create table t1 from t0;
+insert into t1 values (4, 't1');
+update t1 set b = 't1u' where a = 2;
+
+data branch create table t2 from t1;
+insert into t2 values (5, 't2');
+update t2 set b = 't2u' where a = 3;
+
+-- AFTER t2 is branched: continue mutating t1.
+update t1 set b = 't1late' where a = 1;
+insert into t1 values (6, 't1late');
+
+-- Now merge t2 into t0. Expected:
+--   * a=1 unchanged in t2 (because 't1late' happened AFTER t2
+--     was branched) -> t2's view of a=1 is still 't0'. No diff
+--     on a=1 side.
+--   * a=2 value 't1u' was present at t2's branch time.
+--   * a=3 was updated by t2 to 't2u'.
+--   * a=4, a=5 are inserts that reached t2.
+--   * a=6 is a t1-only insert post-t2-branch; it should NOT be
+--     merged into t0.
+data branch diff t2 against t0 output summary;
+data branch merge t2 into t0;
+select * from t0 order by a;
+
+-- Sanity: t1 is untouched by the above merge.
+data branch diff t1 against t0 output summary;
+data branch diff t1 against t0 output count;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 5: Composite PK chain, cascade merge with interleaved DML.
+-- ============================================================
+create table t0(region varchar(4), k int, v int, primary key (region, k));
+insert into t0 values ('eu', 1, 10), ('eu', 2, 20), ('us', 1, 100);
+
+data branch create table t1 from t0;
+insert into t1 values ('us', 2, 200);
+
+data branch create table t2 from t1;
+update t2 set v = v + 1 where region = 'eu' and k = 1;
+delete from t2 where region = 'us' and k = 2;
+insert into t2 values ('ap', 1, 999);
+
+-- Merge t2 up into t1.
+data branch diff t2 against t1 output summary;
+data branch merge t2 into t1;
+select * from t1 order by region, k;
+
+-- Then cascade t1 into t0.
+data branch diff t1 against t0 output summary;
+data branch merge t1 into t0;
+select * from t0 order by region, k;
+
+-- Full chain now consistent.
+data branch diff t2 against t0 output summary;
+data branch diff t2 against t1 output summary;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 6: Snapshot-scoped cascade merge.
+-- Take snapshots at various time points along the chain, then
+-- verify diff via snapshots still correctly reports state pre-
+-- and post-merge. (Merging itself is unscoped; snapshots are
+-- used only to verify the time-travel view.)
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2);
+drop snapshot if exists c6_t0_sp0;
+create snapshot c6_t0_sp0 for table test_chain_merge t0;
+
+data branch create table t1 from t0{snapshot="c6_t0_sp0"};
+insert into t1 values (3, 3);
+drop snapshot if exists c6_t1_sp0;
+create snapshot c6_t1_sp0 for table test_chain_merge t1;
+
+data branch create table t2 from t1{snapshot="c6_t1_sp0"};
+insert into t2 values (4, 4);
+update t2 set b = b + 10 where a = 1;
+drop snapshot if exists c6_t2_sp0;
+create snapshot c6_t2_sp0 for table test_chain_merge t2;
+
+-- Diff t2@sp0 vs t0@sp0 BEFORE any merge.
+data branch diff t2{snapshot="c6_t2_sp0"} against t0{snapshot="c6_t0_sp0"} output summary;
+
+-- Now cascade merge.
+data branch merge t2 into t1;
+data branch merge t1 into t0;
+
+-- Live diff after cascade: all tables equal.
+data branch diff t2 against t0 output summary;
+data branch diff t1 against t0 output summary;
+
+-- Historical snapshots are immutable — replaying the diff against
+-- the old snapshots should still show the pre-merge state.
+data branch diff t2{snapshot="c6_t2_sp0"} against t0{snapshot="c6_t0_sp0"} output summary;
+data branch diff t2{snapshot="c6_t2_sp0"} against t0{snapshot="c6_t0_sp0"} output count;
+
+drop snapshot c6_t0_sp0;
+drop snapshot c6_t1_sp0;
+drop snapshot c6_t2_sp0;
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 7: Conflict modes along the chain. Writes on t0 AFTER
+-- branching collide with writes on t2 on the same PK.
+-- Verifies when conflict skip and when conflict accept both
+-- behave as expected across 2 clone edges.
+-- ============================================================
+create table t0(a int primary key, b int, tag varchar(8));
+insert into t0 values (1, 1, 'orig'), (2, 2, 'orig');
+
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+
+-- Simultaneously diverge both ends.
+update t0 set b = 111, tag = 't0-won' where a = 1;
+update t2 set b = 222, tag = 't2-won' where a = 1;
+insert into t0 values (10, 10, 't0-ins');
+insert into t2 values (20, 20, 't2-ins');
+
+data branch diff t2 against t0 output summary;
+
+-- skip keeps t0's own row on conflict (a=1).
+data branch merge t2 into t0 when conflict skip;
+select * from t0 order by a;
+
+-- Re-run with accept to overwrite.
+data branch merge t2 into t0 when conflict accept;
+select * from t0 order by a;
+
+-- After accept, t2 vs t0 must be empty.
+data branch diff t2 against t0 output summary;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 8: no-PK (fake PK) chain merge sanity.
+-- Merge via a fake-PK all the way up the chain. Only the leaf
+-- is written to; cascade merge should migrate the rows up.
+-- ============================================================
+create table t0(a int, b int);
+insert into t0 select *, * from generate_series(1, 20) g;
+
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+
+insert into t2 values (21, 21), (22, 22);
+update t2 set b = b + 1 where a in (5, 10);
+delete from t2 where a in (1, 2);
+
+data branch merge t2 into t1;
+data branch merge t1 into t0;
+
+select count(*) as total_rows from t0;
+select * from t0 where a in (5, 10, 21, 22) order by a;
+select count(*) as deleted_rows from t0 where a in (1, 2);
+
+-- No-PK merge converges all diffs.
+data branch diff t2 against t0 output summary;
+data branch diff t1 against t0 output summary;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+-- ============================================================
+-- Case 9: Intermediate branch already merged upward, then a
+-- later grandchild merge. Order-of-merges regression.
+--
+-- Timeline:
+--   T1. create t0, branch t1, branch t2
+--   T2. write on t1
+--   T3. merge t1 into t0
+--   T4. write on t2
+--   T5. merge t2 into t0
+-- Verifies the branch metadata stays consistent after step T3,
+-- so step T5's LCA probe for (t2 vs t0) still resolves.
+-- ============================================================
+create table t0(a int primary key, b int);
+insert into t0 values (1, 1), (2, 2);
+
+data branch create table t1 from t0;
+data branch create table t2 from t1;
+
+-- T2: writes on t1 only.
+insert into t1 values (3, 3);
+update t1 set b = b + 100 where a = 1;
+
+-- T3: merge t1 into t0.
+data branch merge t1 into t0;
+select * from t0 order by a;
+
+-- T4: writes on t2 (which was branched from t1 BEFORE t1 was
+-- merged; t2 never saw t1's mutations).
+insert into t2 values (4, 4);
+update t2 set b = b + 1000 where a = 2;
+
+-- T5: merge t2 into t0. LCA probe must still find t0 as LCA.
+data branch diff t2 against t0 output summary;
+data branch merge t2 into t0 when conflict accept;
+select * from t0 order by a;
+
+-- Verify t2 fully merged (except any skipped rows by accept
+-- semantics — here accept means t2 wins).
+data branch diff t2 against t0 output summary;
+
+drop table t2;
+drop table t1;
+drop table t0;
+
+drop database test_chain_merge;


### PR DESCRIPTION
Backport of #24371 to `4.0-dev`.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #21979 (cherry-picked from #24371)

## What this PR does / why we need it:

Cherry-picks the 5 substantive commits from #24371 (skips the
intermediate `Merge branch 'main'` merge commit, which only resolves
context against `main`). All commits applied cleanly with no conflicts.

| commit | summary |
| --- | --- |
| `0b566bbe75` | fix(data-branch): unify diff collect-range over arbitrary DAG depth |
| `b0f44f14d5` | chore(data-branch): clean up dead comments and tangled defer in DAG resolver |
| `e844aaf7ff` | refactor(data-branch): drop redundant lcaType / branchTS fields |
| `b63cdac409` | fix(data-branch): correct LCA-snapshot helpers for chain merge |
| `e193420425` | fix(data-branch): address review comments and fix gofmt |

The final tree state of all 11 modified files (`pkg/frontend/data_branch*.go`,
`pkg/frontend/databranchutils/branch_dag.go`, and the new BVT cases under
`test/distributed/cases/git4data/branch/{diff,merge}/`) is byte-identical
to the head of #24371 (verified via per-file shasum diff).

### TL;DR (from #24371)

`data branch diff` and `data branch merge` previously dropped rows
silently whenever the LCA → endpoint chain in the branch DAG had any
intermediate node that performed inserts/updates/deletes before the
endpoint was forked. Symptom: rows that the endpoint inherits via
multi-level cloning were never compared on its side of the diff, so
downstream merges failed to migrate them too. The fix replaces the
historical case-by-case logic with a single ancestor-walking model
that works uniformly for any DAG depth and shape.

Refer to the original PR for the full bug analysis, fix design, and
running 19-node tree example used throughout the new code comments.

### Verification on 4.0-dev

* `pkg/frontend` build + `go vet` clean.
* `pkg/frontend` unit tests pass (including
  `TestHashDiff_NoLCAWithStubHandles`, `TestDiffDataHelper_*`,
  `TestRunLCAProbeWithReaderFallback_*`, `TestHandleDelsOnLCA_*`,
  `TestLCAProbeJoinCastType`).
* `gofmt -l` clean on all five modified Go files.
* New BVT cases (`diff_12`, `diff_13`, `merge_8`) included with their
  corresponding `.result` files.

## Special notes for your reviewer:

* This is a straight cherry-pick — no behavioural divergence from #24371.
* The 5 PR commits applied cleanly to `4.0-dev` (no conflicts), so the
  diff against `4.0-dev` matches the diff against `main` on the source
  branch (i.e. nothing on `main` between the two relevant base commits
  touches the migrated files).
* Original PR: #24371

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
