### PR TITLE
fix: prevent OOM in PKPersistedBetween under high-concurrency lock checks (cherry-pick to 4.0-dev)

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1494,7 +1494,7 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 				if numParts > 1 && hasUnsafeRangeOp(fn) {
 					continue
 				}
-				if isSingleRangeOp(fn) && node.Stats != nil && node.Stats.TableCnt >= 50000 {
+				if isRangeOp(fn) && node.Stats != nil && node.Stats.TableCnt >= 50000 {
 					if node.Stats.Selectivity >= InFilterSelectivityLimit || node.Stats.Outcnt >= float64(InFilterCardLimitNonPK) {
 						continue
 					}
@@ -1533,9 +1533,9 @@ func hasUnsafeRangeOp(fn *plan.Function) bool {
 	return op == "<=" || op == ">"
 }
 
-func isSingleRangeOp(fn *plan.Function) bool {
+func isRangeOp(fn *plan.Function) bool {
 	switch fn.Func.ObjName {
-	case ">=", ">", "<=", "<":
+	case ">=", ">", "<=", "<", "in_range":
 		return true
 	}
 	return false

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -1206,3 +1206,25 @@ func TestRangeFilterConstValue(t *testing.T) {
 	require.NotNil(t, val2)
 	assert.Equal(t, int64(42), val2.GetLit().GetI64Val())
 }
+
+func TestIsRangeOp(t *testing.T) {
+	tests := []struct {
+		op       string
+		expected bool
+	}{
+		{">=", true},
+		{">", true},
+		{"<=", true},
+		{"<", true},
+		{"in_range", true},
+		{"=", false},
+		{"in", false},
+		{"between", false},
+		{"or", false},
+		{"prefix_in_range", false},
+	}
+	for _, tt := range tests {
+		fn := &planpb.Function{Func: &planpb.ObjectRef{ObjName: tt.op}}
+		assert.Equal(t, tt.expected, isRangeOp(fn), "isRangeOp(%q)", tt.op)
+	}
+}

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -101,6 +101,7 @@ var (
 	TxnPKChangeCheckTotalCounter   = txnPKChangeCheckCounter.WithLabelValues("total")
 	TxnPKChangeCheckChangedCounter = txnPKChangeCheckCounter.WithLabelValues("changed")
 	TxnPKChangeCheckIOCounter      = txnPKChangeCheckCounter.WithLabelValues("io")
+	TxnPKChangeCheckBailoutCounter = txnPKChangeCheckCounter.WithLabelValues("bailout")
 
 	txnPKMayBeChangedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/pkg/vm/engine/disttae/pk_check_guard_test.go
+++ b/pkg/vm/engine/disttae/pk_check_guard_test.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disttae
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPkCheckSemaphore_LimitsConcurrency(t *testing.T) {
+	// Verify the semaphore actually limits concurrent goroutines.
+	const workers = 100
+	semCap := cap(pkCheckSemaphore) // should be 16
+
+	var maxConcurrent atomic.Int32
+	var current atomic.Int32
+	var wg sync.WaitGroup
+
+	ctx := context.Background()
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case pkCheckSemaphore <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-pkCheckSemaphore }()
+
+			c := current.Add(1)
+			for {
+				old := maxConcurrent.Load()
+				if c <= old || maxConcurrent.CompareAndSwap(old, c) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+			current.Add(-1)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.LessOrEqual(t, int(maxConcurrent.Load()), semCap,
+		"concurrent goroutines should not exceed semaphore capacity %d", semCap)
+	assert.Greater(t, int(maxConcurrent.Load()), 1,
+		"should have some concurrency")
+}
+
+func TestPkCheckSemaphore_RespectsContextCancellation(t *testing.T) {
+	// Fill the semaphore completely.
+	for i := 0; i < cap(pkCheckSemaphore); i++ {
+		pkCheckSemaphore <- struct{}{}
+	}
+	defer func() {
+		for i := 0; i < cap(pkCheckSemaphore); i++ {
+			<-pkCheckSemaphore
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Should not block — context is already cancelled.
+	select {
+	case pkCheckSemaphore <- struct{}{}:
+		t.Fatal("should not have acquired semaphore")
+		<-pkCheckSemaphore
+	case <-ctx.Done():
+		// expected
+	}
+}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -70,6 +70,10 @@ const (
 var traceFilterExprInterval atomic.Uint64
 var traceFilterExprInterval2 atomic.Uint64
 
+// pkCheckSemaphore limits concurrent block I/O in PKPersistedBetween to prevent
+// mpool explosion when many transactions simultaneously check primary key conflicts.
+var pkCheckSemaphore = make(chan struct{}, 16)
+
 var _ engine.Relation = new(txnTable)
 
 func newTxnTable(
@@ -2484,6 +2488,16 @@ func (tbl *txnTable) PKPersistedBetween(
 
 	//only check data objects.
 	delObjs, cObjs := p.GetChangedObjsBetween(from.Next(), types.MaxTs())
+
+	// Under high-concurrency workloads (e.g., 1000 TPCC terminals), many transactions
+	// write to the same table, producing many changed objects. If there are too many,
+	// conservatively return true to avoid thundering-herd block I/O that causes OOM.
+	const maxChangedObjectsForIO = 64
+	if len(cObjs)+len(delObjs) > maxChangedObjectsForIO {
+		v2.TxnPKChangeCheckChangedCounter.Inc()
+		return true, nil
+	}
+
 	isFakePK := tbl.GetTableDef(ctx).Pkey.PkeyColName == catalog.FakePrimaryKeyColName
 	if err := ForeachCommittedObjects(cObjs, delObjs, p,
 		func(obj objectio.ObjectEntry) (err2 error) {
@@ -2594,13 +2608,30 @@ func (tbl *txnTable) PKPersistedBetween(
 		}
 	}
 
+	// If too many candidate blocks, conservatively return true to avoid excessive
+	// concurrent block reads that cause mpool explosion under high concurrency.
+	const maxCandidateBlksForIO = 32
+	if len(candidateBlks) > maxCandidateBlksForIO {
+		v2.TxnPKChangeCheckChangedCounter.Inc()
+		return true, nil
+	}
+
 	cacheVectors := containers.NewVectors(1)
-	//read block ,check if keys exist in the block.
 	pkDef := tbl.tableDef.Cols[tbl.primaryIdx]
 	pkSeq := pkDef.Seqnum
 	pkType := plan2.ExprType2Type(&pkDef.Typ)
 	if len(candidateBlks) > 0 {
 		v2.TxnPKChangeCheckIOCounter.Inc()
+
+		// Acquire semaphore to limit concurrent block I/O across all transactions.
+		// This prevents 1000 goroutines from simultaneously reading blocks and
+		// exhausting mpool capacity.
+		select {
+		case pkCheckSemaphore <- struct{}{}:
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+		defer func() { <-pkCheckSemaphore }()
 	}
 	for _, blk := range candidateBlks {
 		release, err := ioutil.LoadColumns(

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2490,11 +2490,12 @@ func (tbl *txnTable) PKPersistedBetween(
 	delObjs, cObjs := p.GetChangedObjsBetween(from.Next(), types.MaxTs())
 
 	// Under high-concurrency workloads (e.g., 1000 TPCC terminals), many transactions
-	// write to the same table, producing many changed objects. If there are too many,
-	// conservatively return true to avoid thundering-herd block I/O that causes OOM.
+	// write to the same table, producing many changed objects. Only inserted objects
+	// (cObjs) can contain conflicting PKs; deleted objects are excluded from the count
+	// since they don't contribute to PK conflict I/O.
 	const maxChangedObjectsForIO = 64
-	if len(cObjs)+len(delObjs) > maxChangedObjectsForIO {
-		v2.TxnPKChangeCheckChangedCounter.Inc()
+	if len(cObjs) > maxChangedObjectsForIO {
+		v2.TxnPKChangeCheckBailoutCounter.Inc()
 		return true, nil
 	}
 
@@ -2612,7 +2613,7 @@ func (tbl *txnTable) PKPersistedBetween(
 	// concurrent block reads that cause mpool explosion under high concurrency.
 	const maxCandidateBlksForIO = 32
 	if len(candidateBlks) > maxCandidateBlksForIO {
-		v2.TxnPKChangeCheckChangedCounter.Inc()
+		v2.TxnPKChangeCheckBailoutCounter.Inc()
 		return true, nil
 	}
 
@@ -2621,43 +2622,47 @@ func (tbl *txnTable) PKPersistedBetween(
 	pkSeq := pkDef.Seqnum
 	pkType := plan2.ExprType2Type(&pkDef.Typ)
 	if len(candidateBlks) > 0 {
-		v2.TxnPKChangeCheckIOCounter.Inc()
-
 		// Acquire semaphore to limit concurrent block I/O across all transactions.
 		// This prevents 1000 goroutines from simultaneously reading blocks and
-		// exhausting mpool capacity.
+		// exhausting mpool capacity. Scoped to the block loop only — tombstone
+		// checking below is not rate-limited by this semaphore.
 		select {
 		case pkCheckSemaphore <- struct{}{}:
 		case <-ctx.Done():
 			return false, ctx.Err()
 		}
-		defer func() { <-pkCheckSemaphore }()
-	}
-	for _, blk := range candidateBlks {
-		release, err := ioutil.LoadColumns(
-			ctx,
-			[]uint16{uint16(pkSeq)},
-			[]types.Type{pkType},
-			fs,
-			blk.MetaLocation(),
-			cacheVectors,
-			tbl.proc.Load().GetMPool(),
-			fileservice.Policy(0),
-		)
-		if err != nil {
-			return true, err
-		}
 
-		searchFunc := filter.DecideSearchFunc(blk.IsSorted())
-		if searchFunc == nil {
-			searchFunc = buildUnsortedFilter()
-		}
+		v2.TxnPKChangeCheckIOCounter.Inc()
 
-		sels := searchFunc(cacheVectors)
-		release()
-		if len(sels) > 0 {
-			return true, nil
+		for _, blk := range candidateBlks {
+			release, err := ioutil.LoadColumns(
+				ctx,
+				[]uint16{uint16(pkSeq)},
+				[]types.Type{pkType},
+				fs,
+				blk.MetaLocation(),
+				cacheVectors,
+				tbl.proc.Load().GetMPool(),
+				fileservice.Policy(0),
+			)
+			if err != nil {
+				<-pkCheckSemaphore
+				return true, err
+			}
+
+			searchFunc := filter.DecideSearchFunc(blk.IsSorted())
+			if searchFunc == nil {
+				searchFunc = buildUnsortedFilter()
+			}
+
+			sels := searchFunc(cacheVectors)
+			release()
+			if len(sels) > 0 {
+				<-pkCheckSemaphore
+				return true, nil
+			}
 		}
+		<-pkCheckSemaphore
 	}
 	if checkTombstone {
 		pkDef := tbl.tableDef.Cols[tbl.primaryIdx]


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) does this PR fix or relate to?

Cherry-pick of #24373 to 4.0-dev branch.

Fixes #24348

## What this PR does / why we need it:

Under 1000 concurrent TPCC NEW_ORDER transactions, each `LockOp` triggers `PKPersistedBetween` to verify primary key conflicts. This path loads object metadata, bloom filters, and block PK columns for all changed objects since the transaction's snapshot. With many concurrent writers on the same table (e.g., `stock`), this produces a thundering-herd of block I/O that exhausts mpool capacity → OOM.

### Changes

**`pkg/vm/engine/disttae/txn_table.go`** — Three mitigations in `PKPersistedBetween`:

| Mechanism | Threshold | Effect |
|-----------|-----------|--------|
| Changed objects cap | 64 | Conservatively return `true` to skip expensive I/O |
| Candidate blocks cap | 32 | Avoid reading too many blocks that passed zonemap + BF |
| Global semaphore | 16 concurrent | Cap peak mpool allocations from `LoadColumns` |

**`pkg/sql/plan/apply_indices.go`** — Extend selectivity guard in `getIndexForNonEquiCond` to cover `in_range` operators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)