### PR TITLE
fix(lockservice): refine keeper bind refresh on keep failures

### DIFF
--- a/pkg/lockservice/lock_table_keeper.go
+++ b/pkg/lockservice/lock_table_keeper.go
@@ -121,7 +121,7 @@ func (k *lockTableKeeper) doKeepRemoteLock(
 		version   uint64
 	}
 
-	allBinds := make([]pb.LockTable, 0, len(binds))
+	allBinds := make([]pb.LockTable, 0, cap(binds))
 	binds = binds[:0]
 	futures = futures[:0]
 	checkedBinds := make(map[bindKey]struct{})

--- a/pkg/lockservice/lock_table_keeper.go
+++ b/pkg/lockservice/lock_table_keeper.go
@@ -114,9 +114,30 @@ func (k *lockTableKeeper) doKeepRemoteLock(
 	ctx context.Context,
 	futures []*morpc.Future,
 	binds []pb.LockTable) ([]*morpc.Future, []pb.LockTable) {
+	type bindKey struct {
+		group     uint32
+		table     uint64
+		serviceID string
+		version   uint64
+	}
+
 	allBinds := make([]pb.LockTable, 0, len(binds))
 	binds = binds[:0]
 	futures = futures[:0]
+	checkedBinds := make(map[bindKey]struct{})
+	maybeHandleRemoteBindChanged := func(bind pb.LockTable) {
+		key := bindKey{
+			group:     bind.Group,
+			table:     bind.Table,
+			serviceID: bind.ServiceID,
+			version:   bind.Version,
+		}
+		if _, ok := checkedBinds[key]; ok {
+			return
+		}
+		checkedBinds[key] = struct{}{}
+		k.maybeHandleRemoteBindChanged(bind)
+	}
 
 	k.groupTables.iter(func(_ uint64, v lockTable) bool {
 		bind := v.getBind()
@@ -147,7 +168,7 @@ func (k *lockTableKeeper) doKeepRemoteLock(
 		}
 		err = moerr.AttachCause(ctx, err)
 		logKeepRemoteLocksFailed(k.service.logger, bind, err)
-		k.maybeHandleRemoteBindChanged(bind)
+		maybeHandleRemoteBindChanged(bind)
 		if !isRetryError(err) {
 			k.groupTables.removeWithFilter(func(_ uint64, v lockTable) bool {
 				return !v.getBind().Changed(bind)
@@ -161,19 +182,26 @@ func (k *lockTableKeeper) doKeepRemoteLock(
 			resp := v.(*pb.Response)
 			if err = resp.UnwrapError(); err != nil {
 				logKeepRemoteLocksFailed(k.service.logger, binds[idx], err)
-				k.maybeHandleRemoteBindChanged(binds[idx])
+				if canRefreshRemoteBindOnKeepError(err) {
+					maybeHandleRemoteBindChanged(binds[idx])
+				}
 			} else if resp.NewBind != nil {
 				k.service.handleBindChanged(*resp.NewBind)
 			}
 			releaseResponse(resp)
 		} else {
 			logKeepRemoteLocksFailed(k.service.logger, binds[idx], err)
-			k.maybeHandleRemoteBindChanged(binds[idx])
+			maybeHandleRemoteBindChanged(binds[idx])
 		}
 		f.Close()
 		futures[idx] = nil // gc
 	}
 	return futures[:0], binds[:0]
+}
+
+func canRefreshRemoteBindOnKeepError(err error) bool {
+	return moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged) ||
+		moerr.IsMoErrCode(err, moerr.ErrLockTableNotFound)
 }
 
 func (k *lockTableKeeper) maybeHandleRemoteBindChanged(bind pb.LockTable) {

--- a/pkg/lockservice/lock_table_keeper_test.go
+++ b/pkg/lockservice/lock_table_keeper_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/lock"
@@ -348,6 +349,90 @@ func TestKeepRemoteLockFailureFetchesNewBindAndFencesActiveTxn(t *testing.T) {
 			require.True(t, txn.bindChanged)
 			txn.Unlock()
 			require.Equal(t, newBind, svc.tableGroups.get(newBind.Group, newBind.Table).getBind())
+
+			require.Equal(t, txn, svc.activeTxnHolder.deleteActiveTxn(txnID))
+			txn.Lock()
+			err := txn.close(txnID, timestamp.Timestamp{}, func(uint32, uint64) (lockTable, error) {
+				return nil, nil
+			}, logger)
+			txn.Unlock()
+			require.NoError(t, err)
+		},
+	)
+}
+
+func TestKeepRemoteLockIgnoresNonBindResponseErrors(t *testing.T) {
+	runRPCTests(
+		t,
+		func(c Client, server Server) {
+			oldBind := pb.LockTable{Group: 0, Table: 1, OriginTable: 1, ServiceID: "s2", Version: 1, Valid: true}
+			getBindCalls := atomic.Uint64{}
+
+			server.RegisterMethodHandler(
+				pb.Method_GetBind,
+				func(
+					ctx context.Context,
+					cancel context.CancelFunc,
+					req *pb.Request,
+					resp *pb.Response,
+					cs morpc.ClientSession) {
+					getBindCalls.Add(1)
+					writeResponse(getLogger(""), cancel, resp, nil, cs)
+				})
+			server.RegisterMethodHandler(
+				pb.Method_KeepRemoteLock,
+				func(
+					ctx context.Context,
+					cancel context.CancelFunc,
+					req *pb.Request,
+					resp *pb.Response,
+					cs morpc.ClientSession) {
+					writeResponse(getLogger(""), cancel, resp, moerr.NewInternalErrorNoCtx("boom"), cs)
+				})
+
+			logger := getLogger("")
+			fsp := newFixedSlicePool(2)
+			svc := &service{
+				serviceID: "s1",
+				fsp:       fsp,
+				logger:    logger,
+			}
+			svc.remote.client = c
+			svc.tableGroups = &lockTableHolders{service: svc.serviceID, logger: logger, holders: map[uint32]*lockTableHolder{}}
+			svc.activeTxnHolder = newMapBasedTxnHandler(
+				svc.serviceID,
+				logger,
+				fsp,
+				func(string) (bool, error) { return true, nil },
+				func([]pb.OrphanTxn) ([][]byte, error) { return nil, nil },
+				func(pb.WaitTxn) (bool, error) { return true, nil },
+			)
+			svc.tableGroups.set(
+				oldBind.Group,
+				oldBind.Table,
+				newRemoteLockTable(svc.serviceID, time.Second, oldBind, c, svc.handleBindChanged, logger),
+			)
+
+			txnID := []byte("txn1")
+			txn := svc.activeTxnHolder.getActiveTxn(txnID, true, "")
+			txn.Lock()
+			require.NoError(t, txn.lockAdded(oldBind.Group, oldBind, [][]byte{{1}}, logger))
+			txn.Unlock()
+
+			keeper := &lockTableKeeper{
+				serviceID:   svc.serviceID,
+				client:      c,
+				groupTables: svc.tableGroups,
+				service:     svc,
+			}
+			keeper.doKeepRemoteLock(context.Background(), nil, nil)
+
+			require.Equal(t, uint64(0), getBindCalls.Load())
+
+			txn.Lock()
+			require.False(t, txn.bindChanged)
+			txn.Unlock()
+			require.Equal(t, oldBind, svc.tableGroups.get(oldBind.Group, oldBind.Table).getBind())
 
 			require.Equal(t, txn, svc.activeTxnHolder.deleteActiveTxn(txnID))
 			txn.Lock()

--- a/pkg/lockservice/lock_table_keeper_test.go
+++ b/pkg/lockservice/lock_table_keeper_test.go
@@ -296,6 +296,16 @@ func TestKeepRemoteLockFailureFetchesNewBindAndFencesActiveTxn(t *testing.T) {
 					resp.GetBind.LockTable = newBind
 					writeResponse(getLogger(""), cancel, resp, nil, cs)
 				})
+			server.RegisterMethodHandler(
+				pb.Method_KeepRemoteLock,
+				func(
+					ctx context.Context,
+					cancel context.CancelFunc,
+					req *pb.Request,
+					resp *pb.Response,
+					cs morpc.ClientSession) {
+					writeResponse(getLogger(""), cancel, resp, ErrLockTableNotFound, cs)
+				})
 
 			logger := getLogger("")
 			fsp := newFixedSlicePool(2)

--- a/pkg/lockservice/txn.go
+++ b/pkg/lockservice/txn.go
@@ -33,8 +33,10 @@ var (
 )
 
 type tableLockHolder struct {
-	tableKeys        map[uint64]*cowSlice
-	tableBinds       map[uint64]pb.LockTable
+	tableKeys  map[uint64]*cowSlice
+	tableBinds map[uint64]pb.LockTable
+	// tableBindIntents records bind versions touched before a lock attempt
+	// finishes, so bind-change fencing also covers failed in-flight attempts.
 	tableBindIntents map[uint64]pb.LockTable
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Refs #24346

## What this PR does / why we need it:

This is a small follow-up hardening change after #24363 merged. It keeps the data-consistency fix intact while making the keepRemoteLock failure path more conservative:

- deduplicate allocator refresh checks for the same stale bind within a single keeper pass
- only refresh binds for bind-related response errors (`ErrLockTableBindChanged` / `ErrLockTableNotFound`)
- clarify the intent-only bind tracking comment used by active txn fencing

This avoids broadening failure-path behavior on main while preserving the OOM/stale-bind correctness closure for #24346.

## Validation

- `go test ./pkg/lockservice -count=1 -timeout=5m`