### PR TITLE
ci(mergify): add queue and merge rules for 4.0-dev branch

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,6 +25,19 @@ queue_rules:
 
 
       Approved by: @{{ approved_reviews_by | join(', @') }}
+  - name: release-4.0
+    merge_conditions: []
+    checks_timeout: 4h
+    merge_method: squash
+    commit_message_template: >
+      {{ title }} (#{{ number }})
+
+
+      {{ body.split("___\n\n### **PR Type**")[0] | trim | get_section("## What
+      this PR does / why we need it:") }}
+
+
+      Approved by: @{{ approved_reviews_by | join(', @') }}
   - name: release-2.2
     merge_conditions: []
     checks_timeout: 4h
@@ -69,6 +82,15 @@ pull_request_rules:
     actions:
       queue:
         name: release-3.0
+  - name: Automatic queue on approval for release-4.0
+    conditions:
+      - "#changes-requested-reviews-by<=0"
+      - label!=do-not-merge/wip
+      - base=4.0-dev
+      - approved-reviews-by=XuPeng-SH
+    actions:
+      queue:
+        name: release-4.0
   - name: Automatic queue on approval for release-2.2
     conditions:
       - "#changes-requested-reviews-by<=0"


### PR DESCRIPTION
## Summary
- Add Mergify queue rule `release-4.0` for the `4.0-dev` branch
- Add pull request rule to auto-queue PRs targeting `4.0-dev` when approved by XuPeng-SH (same as 3.0-dev)
- Unblocks PR #24383 and future 4.0-dev PRs from merging via Mergify

## Test plan
- [ ] Verify Mergify picks up the new config after merge
- [ ] Confirm PR #24383 enters the merge queue once XuPeng-SH approves

🤖 Generated with [Claude Code](https://claude.com/claude-code)