### PR TITLE
fix(lockservice): check bind before lock success

### DIFF
--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -209,6 +209,12 @@ func (s *service) Lock(
 			result = r
 			err = e
 		})
+	if err == nil {
+		if e := s.checkBindChangedBeforeLockSuccess(txn, txnID, bind); e != nil {
+			result = pb.Result{}
+			err = e
+		}
+	}
 	return result, err
 }
 
@@ -629,6 +635,31 @@ func (s *service) fenceByBindChanged(bind pb.LockTable) {
 		return
 	}
 	s.activeTxnHolder.fenceByBindChanged(bind)
+}
+
+func (s *service) checkBindChangedBeforeLockSuccess(
+	txn *activeTxn,
+	txnID []byte,
+	bind pb.LockTable,
+) error {
+	// Let any pending bind-change fence complete before reporting lock success.
+	// Keep the lock order consistent with Lock: bindChangeMu before txn.Lock.
+	txn.Unlock()
+	s.bindChangeMu.RLock()
+	txn.Lock()
+	defer s.bindChangeMu.RUnlock()
+
+	if !bytes.Equal(txn.txnID, txnID) {
+		return ErrTxnNotFound
+	}
+	if txn.bindChanged {
+		return ErrLockTableBindChanged
+	}
+	l := s.tableGroups.get(bind.Group, bind.Table)
+	if l == nil || l.getBind().Changed(bind) {
+		return ErrLockTableBindChanged
+	}
+	return nil
 }
 
 func (s *service) createLockTableByBind(bind pb.LockTable) lockTable {

--- a/pkg/lockservice/service_remote.go
+++ b/pkg/lockservice/service_remote.go
@@ -230,6 +230,7 @@ func (s *service) handleRemoteLock(
 	h := txn.getHoldLocksLocked(bind.Group)
 	_, hasBind := h.tableBinds[bind.Table]
 	txn.lockTableBindTouched(bind)
+	txnID := append([]byte(nil), req.Lock.TxnID...)
 	s.bindChangeMu.RUnlock()
 	defer txn.Unlock()
 	defer func() {
@@ -247,6 +248,12 @@ func (s *service) handleRemoteLock(
 		req.Lock.Rows,
 		LockOptions{LockOptions: req.Lock.Options, async: true},
 		func(result pb.Result, err error) {
+			if err == nil {
+				if e := s.checkBindChangedBeforeLockSuccess(txn, txnID, bind); e != nil {
+					result = pb.Result{}
+					err = e
+				}
+			}
 			lockErr = err
 			resp.Lock.Result = result
 			_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout, logFields)
@@ -307,6 +314,7 @@ func (s *service) handleForwardLock(
 	h := txn.getHoldLocksLocked(bind.Group)
 	_, hasBind := h.tableBinds[bind.Table]
 	txn.lockTableBindTouched(bind)
+	txnID := append([]byte(nil), req.Lock.TxnID...)
 	s.bindChangeMu.RUnlock()
 	defer txn.Unlock()
 	defer func() {
@@ -324,6 +332,12 @@ func (s *service) handleForwardLock(
 		req.Lock.Rows,
 		LockOptions{LockOptions: req.Lock.Options, async: true},
 		func(result pb.Result, err error) {
+			if err == nil {
+				if e := s.checkBindChangedBeforeLockSuccess(txn, txnID, bind); e != nil {
+					result = pb.Result{}
+					err = e
+				}
+			}
 			lockErr = err
 			resp.Lock.Result = result
 			_ = writeResponseWithDeadline(s.logger, cancel, resp, err, cs, defaultRPCWriteTimeout, logFields)

--- a/pkg/lockservice/service_test.go
+++ b/pkg/lockservice/service_test.go
@@ -4293,6 +4293,55 @@ func TestBindChangedFencesActiveTxnAfterOldTableRemoved(t *testing.T) {
 	)
 }
 
+func TestBindChangedBeforeLockSuccessReturnsBindChanged(t *testing.T) {
+	runLockServiceTests(
+		t,
+		[]string{"s1"},
+		func(alloc *lockTableAllocator, ss []*service) {
+			s := ss[0]
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+			defer cancel()
+
+			txnID := []byte("txn1")
+			txn := s.activeTxnHolder.getActiveTxn(txnID, true, "")
+			fenceDone := make(chan struct{})
+			var once sync.Once
+			txn.beforeLockAdded = func([]byte, [][]byte) error {
+				once.Do(func() {
+					oldBind := s.tableGroups.get(0, 0).getBind()
+					newBind := oldBind
+					newBind.Version++
+					newBind.ServiceID = "new-service"
+					go func() {
+						s.handleBindChanged(newBind)
+						close(fenceDone)
+					}()
+					require.Eventually(t, func() bool {
+						if s.bindChangeMu.TryRLock() {
+							s.bindChangeMu.RUnlock()
+							return false
+						}
+						return true
+					}, time.Second, time.Millisecond)
+				})
+				return nil
+			}
+
+			_, err := s.Lock(ctx, 0, [][]byte{{1}}, txnID, newTestRowExclusiveOptions())
+			require.True(t, moerr.IsMoErrCode(err, moerr.ErrLockTableBindChanged))
+			require.Eventually(t, func() bool {
+				select {
+				case <-fenceDone:
+					return true
+				default:
+					return false
+				}
+			}, time.Second, time.Millisecond)
+			require.NoError(t, s.Unlock(ctx, txnID, timestamp.Timestamp{}))
+		},
+	)
+}
+
 func TestLeakWaiterForErr(t *testing.T) {
 	runLockServiceTests(
 		t,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Refs #24346

## What this PR does / why we need it:

This is a focused follow-up for the bind-change fencing fix. It closes the stale-success race where a bind change has already started and is waiting behind the active txn lock while an in-flight lock operation is about to return success.

The change adds a final success-path check before returning local lock success or writing remote/forward lock success responses. The check releases the txn lock, waits behind any pending bind-change fence using the existing bindChangeMu ordering, reacquires the txn lock, and only then allows success if the txn and bind are still current.

This keeps the fix narrow: no retry policy, allocator behavior, commit validation, or logging behavior is changed.

## Validation

- `go test ./pkg/lockservice -run 'Test(BindChangedBeforeLockSuccessReturnsBindChanged|BindChangedFencesActiveTxnHoldingOldBind|BindChangedFencesActiveTxnAfterOldTableRemoved|Issue3538)$' -count=1 -timeout=3m`\n- `go test ./pkg/lockservice -count=1 -timeout=5m`