### PR TITLE
fix groupconcat

### DIFF
--- a/pkg/sql/colexec/window/window.go
+++ b/pkg/sql/colexec/window/window.go
@@ -129,7 +129,14 @@ func (window *Window) Call(proc *process.Process) (vm.CallResult, error) {
 				if function.GetFunctionIsWinValueFunByName(winName) {
 					continue
 				}
-				ctr.bat.Aggs[i], err = aggexec.MakeAgg(proc, ag.GetAggID(), ag.IsDistinct(), window.Types[i])
+				argTypes := ctr.aggVecs[i].Typ
+				for _, typ := range argTypes {
+					if typ.Oid == types.T_any {
+						argTypes = []types.Type{window.Types[i]}
+						break
+					}
+				}
+				ctr.bat.Aggs[i], err = aggexec.MakeAgg(proc, ag.GetAggID(), ag.IsDistinct(), argTypes...)
 				if err != nil {
 					return result, err
 				}

--- a/pkg/sql/plan/having_binder.go
+++ b/pkg/sql/plan/having_binder.go
@@ -257,7 +257,7 @@ func (b *HavingBinder) processForceWindows(funcName string, astExpr *tree.FuncEx
 			case tree.Int:
 				colPos, _ := numVal.Int64()
 				if numVal.Negative() {
-					moerr.NewSyntaxErrorf(b.GetContext(), "ORDER BY position %v is negative", colPos)
+					return moerr.NewSyntaxErrorf(b.GetContext(), "ORDER BY position %v is negative", colPos)
 				}
 				if colPos < 1 || int(colPos) > len(astExpr.Exprs)-1 {
 					return moerr.NewSyntaxErrorf(b.GetContext(), "ORDER BY position %v is not in group_concat arguments", colPos)

--- a/test/distributed/cases/function/function_group_concat.result
+++ b/test/distributed/cases/function/function_group_concat.result
@@ -292,3 +292,20 @@ create table g18 (a int);
 select group_concat(a order by a) from g18;
 group_concat(a, ,order by a)
 drop table if exists g18;
+DROP TABLE IF EXISTS group_concat_24359;
+CREATE TABLE group_concat_24359 (g INT, k INT, a VARCHAR(10), b VARCHAR(10));
+INSERT INTO group_concat_24359 VALUES (1, 2, 'a2', 'b2'), (1, 1, 'a1', 'b1');
+SELECT g, GROUP_CONCAT(a, ':', b ORDER BY k) AS gc FROM group_concat_24359 GROUP BY g;
+g    gc
+1    a1:b1,a2:b2
+DROP TABLE IF EXISTS group_concat_order_bug;
+CREATE TABLE group_concat_order_bug (g INT, a VARCHAR(10), b VARCHAR(10), x INT, y INT);
+INSERT INTO group_concat_order_bug VALUES (1, 'a1', 'b1', 1, 2), (1, 'a2', 'b2', 2, 1);
+SELECT
+g,
+GROUP_CONCAT(a ORDER BY x) AS by_x,
+GROUP_CONCAT(b ORDER BY y) AS by_y
+FROM group_concat_order_bug
+GROUP BY g;
+g    by_x    by_y
+1    a1,a2    b2,b1

--- a/test/distributed/cases/function/function_group_concat.sql
+++ b/test/distributed/cases/function/function_group_concat.sql
@@ -237,3 +237,20 @@ drop table if exists g18;
 create table g18 (a int);
 select group_concat(a order by a) from g18;
 drop table if exists g18;
+
+-- regression for issue #24359: multi-argument group_concat with ORDER BY
+DROP TABLE IF EXISTS group_concat_24359;
+CREATE TABLE group_concat_24359 (g INT, k INT, a VARCHAR(10), b VARCHAR(10));
+INSERT INTO group_concat_24359 VALUES (1, 2, 'a2', 'b2'), (1, 1, 'a1', 'b1');
+SELECT g, GROUP_CONCAT(a, ':', b ORDER BY k) AS gc FROM group_concat_24359 GROUP BY g;
+
+-- regression: multiple group_concat functions can have independent orderings
+DROP TABLE IF EXISTS group_concat_order_bug;
+CREATE TABLE group_concat_order_bug (g INT, a VARCHAR(10), b VARCHAR(10), x INT, y INT);
+INSERT INTO group_concat_order_bug VALUES (1, 'a1', 'b1', 1, 2), (1, 'a2', 'b2', 2, 1);
+SELECT
+  g,
+  GROUP_CONCAT(a ORDER BY x) AS by_x,
+  GROUP_CONCAT(b ORDER BY y) AS by_y
+FROM group_concat_order_bug
+GROUP BY g;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24359

## What this PR does / why we need it:

旧代码只传 `window.Types[i]` 一个类型，导致 `GROUP_CONCAT(a, b, c ORDER BY k)` 运行时 `vectors` 有多个，但 `argTypes` 只有一个，最终在 `groupConcatExec.Fill` 中越界。

核心修复 `pkg/sql/colexec/window/window.go`：创建 window aggregate executor 时，不要只传 `window.Types[i]` 一个类型，而要传当前聚合全部参数的类型。


 `compile/operator.go::constructWindow` 暂时不建议改 separator 逻辑。当前 parser 对 `GROUP_CONCAT` 会始终把 separator 作为最后一个 `FuncExpr.Exprs` 追加进去，默认 separator 也是 `","`，所以 constructWindow 剥掉最后一个参数作为 separator 在此版本中是合理的。

pr解决:
1. 解决 `GROUP_CONCAT` 多个表达式参数的 panic：

```sql
SELECT g, GROUP_CONCAT(a, ':', b ORDER BY k) FROM gc_24359 GROUP BY g;
```

2. 解决多个 `GROUP_CONCAT` 同时使用不同 ORDER BY 的语义问题：

```sql
SELECT
  g,
  GROUP_CONCAT(a ORDER BY x),
  GROUP_CONCAT(b ORDER BY y)
FROM gc_order_bug
GROUP BY g;
```
