### PR TITLE
fix(readutil): reduce PK filter memory pressure

### DIFF
--- a/pkg/vm/engine/readutil/expr_filter.go
+++ b/pkg/vm/engine/readutil/expr_filter.go
@@ -36,6 +36,8 @@ type SeekFirstBlockOp func(objectio.ObjectDataMeta) int
 type BlockFilterOp func(int, objectio.BlockObject, objectio.BloomFilter) (bool, bool, error)
 type LoadOpFactory func(fileservice.FileService) LoadOp
 
+const maxPKInBloomFilterKeys = 10
+
 var loadMetadataOnlyOpFactory LoadOpFactory
 var loadMetadataAndBFOpFactory LoadOpFactory
 
@@ -827,7 +829,7 @@ func CompileFilterExpr(
 					return obj.SortKeyZoneMap().PrefixIn(vec), nil
 				}
 			}
-			highSelectivityHint = isPK && vec.Length() <= 10
+			highSelectivityHint = isPK && vec.Length() <= maxPKInBloomFilterKeys
 			loadOp = loadMetadataOnlyOpFactory(fs)
 			seqNum := colDef.Seqnum
 			objectFilterOp = func(meta objectio.ObjectMeta, _ objectio.BloomFilter) (bool, error) {
@@ -929,13 +931,14 @@ func CompileFilterExpr(
 					return obj.SortKeyZoneMap().AnyIn(vec), nil
 				}
 			}
-			if isPK {
+			useBloomFilter := isPK && vec.Length() <= maxPKInBloomFilterKeys
+			if useBloomFilter {
 				loadOp = loadMetadataAndBFOpFactory(fs)
 			} else {
 				loadOp = loadMetadataOnlyOpFactory(fs)
 			}
 
-			highSelectivityHint = isPK && vec.Length() <= 10
+			highSelectivityHint = useBloomFilter
 
 			seqNum := colDef.Seqnum
 			objectFilterOp = func(meta objectio.ObjectMeta, _ objectio.BloomFilter) (bool, error) {
@@ -959,7 +962,7 @@ func CompileFilterExpr(
 				if !zm.AnyIn(vec) {
 					return false, false, nil
 				}
-				if isPK {
+				if useBloomFilter {
 					blkBf := bf.GetBloomFilter(uint32(blkIdx))
 					blkBfIdx := index.NewEmptyBloomFilter()
 					if err := index.DecodeBloomFilter(blkBfIdx, blkBf); err != nil {

--- a/pkg/vm/engine/readutil/expr_filter.go
+++ b/pkg/vm/engine/readutil/expr_filter.go
@@ -36,6 +36,7 @@ type SeekFirstBlockOp func(objectio.ObjectDataMeta) int
 type BlockFilterOp func(int, objectio.BlockObject, objectio.BloomFilter) (bool, bool, error)
 type LoadOpFactory func(fileservice.FileService) LoadOp
 
+// Large PK IN filters are not selective enough to justify loading object BloomFilters.
 const maxPKInBloomFilterKeys = 10
 
 var loadMetadataOnlyOpFactory LoadOpFactory

--- a/pkg/vm/engine/readutil/filter_test.go
+++ b/pkg/vm/engine/readutil/filter_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
@@ -2807,4 +2808,99 @@ func TestCompileFilterExpr_PrefixSortedSeekOps(t *testing.T) {
 			require.NotNil(t, seekOp, "seekOp should be set for sorted %s", name)
 		})
 	}
+}
+
+func TestCompileFilterExpr_PKLargerInSkipsBloomFilterLoad(t *testing.T) {
+	origMetaOnly := loadMetadataOnlyOpFactory
+	origMetaAndBF := loadMetadataAndBFOpFactory
+	defer func() {
+		loadMetadataOnlyOpFactory = origMetaOnly
+		loadMetadataAndBFOpFactory = origMetaAndBF
+	}()
+
+	var usedMetaOnly, usedMetaAndBF bool
+	loadMetadataOnlyOpFactory = func(fileservice.FileService) LoadOp {
+		return func(
+			context.Context, *objectio.ObjectStats, objectio.ObjectMeta, objectio.BloomFilter,
+		) (objectio.ObjectMeta, objectio.BloomFilter, error) {
+			usedMetaOnly = true
+			return nil, nil, nil
+		}
+	}
+	loadMetadataAndBFOpFactory = func(fileservice.FileService) LoadOp {
+		return func(
+			context.Context, *objectio.ObjectStats, objectio.ObjectMeta, objectio.BloomFilter,
+		) (objectio.ObjectMeta, objectio.BloomFilter, error) {
+			usedMetaAndBF = true
+			return nil, nil, nil
+		}
+	}
+
+	tableDef := &plan.TableDef{
+		Name:          "t",
+		Name2ColIndex: map[string]int32{"pk": 0},
+		Pkey: &plan.PrimaryKeyDef{
+			Names:       []string{"pk"},
+			PkeyColName: "pk",
+		},
+		Cols: []*plan.ColDef{
+			{
+				Name:    "pk",
+				Seqnum:  0,
+				Primary: true,
+				Typ:     plan.Type{Id: int32(types.T_int64)},
+			},
+		},
+	}
+	m := mpool.MustNew(t.Name())
+	vals := make([]int64, maxPKInBloomFilterKeys+1)
+	for i := range vals {
+		vals[i] = int64(i)
+	}
+	expr := MakeFunctionExprForTest("in", []*plan.Expr{
+		MakeColExprForTest(0, types.T_int64, "pk"),
+		plan2.MakePlan2Int64VecExprWithType(m, vals...),
+	})
+
+	_, loadOp, _, _, _, canCompile, highSelectivityHint := CompileFilterExpr(expr, tableDef, nil)
+	require.True(t, canCompile)
+	require.NotNil(t, loadOp)
+	require.False(t, highSelectivityHint)
+
+	_, _, err := loadOp(context.Background(), nil, nil, nil)
+	require.NoError(t, err)
+	require.True(t, usedMetaOnly)
+	require.False(t, usedMetaAndBF)
+}
+
+func TestConstructBlockPKFilterIntersectsLargePrefixHitsWithoutMaps(t *testing.T) {
+	m := mpool.MustNew(t.Name())
+	rowCount := objectio.BlockMaxRows
+	pkVec := vector.NewVec(types.T_varchar.ToType())
+	defer pkVec.Free(m)
+	for i := 0; i < rowCount; i++ {
+		require.NoError(t, vector.AppendBytes(pkVec, []byte(fmt.Sprintf("warehouse-1-%05d", i)), false, m))
+	}
+
+	bf := bloomfilter.NewCBloomFilterWithProbability(int64(rowCount), 0.00001)
+	defer bf.Free()
+	bf.Add([]byte("warehouse-1-00001"))
+	bf.Add([]byte("warehouse-1-01000"))
+	bf.Add([]byte("warehouse-1-08191"))
+
+	filter, err := ConstructBlockPKFilter(false, BasePKFilter{
+		Valid: true,
+		Op:    function.PREFIX_EQ,
+		Oid:   types.T_varchar,
+		LB:    []byte("warehouse-1-"),
+	}, bf)
+	require.NoError(t, err)
+	require.True(t, filter.Valid)
+	require.NotNil(t, filter.SortedSearchFunc)
+
+	offsets := filter.SortedSearchFunc(containers.Vectors{*pkVec})
+	require.Contains(t, offsets, int64(1))
+	require.Contains(t, offsets, int64(1000))
+	require.Contains(t, offsets, int64(8191))
+	require.Less(t, len(offsets), rowCount)
 }

--- a/pkg/vm/engine/readutil/pk_filter.go
+++ b/pkg/vm/engine/readutil/pk_filter.go
@@ -144,8 +144,9 @@ func ConstructBlockPKFilter(
 
 	// Reusable temporary variables (defined outside closure to avoid allocation on each call)
 	var (
-		reusableSels   []int64
-		reusableExists map[int]bool
+		reusableSels       []int64
+		reusableCandidates []bool
+		reusableHits       []bool
 	)
 
 	bfVec := func(cacheVectors containers.Vectors) *vector.Vector {
@@ -209,44 +210,35 @@ func ConstructBlockPKFilter(
 				return offsets
 			}
 
-			var exists map[int]bool
-			var bfHits int
-
-			// Reuse exists map - use more efficient reallocation for large maps
-			if reusableExists == nil || rowCount > len(reusableExists)*2 {
-				reusableExists = make(map[int]bool, rowCount)
-			} else if len(reusableExists) > 0 {
-				// For small maps, clear by reallocating (more efficient than delete loop)
-				if len(reusableExists) < 100 {
-					// For small maps, use delete loop
-					for k := range reusableExists {
-						delete(reusableExists, k)
-					}
-				} else {
-					// For larger maps, reallocate is more efficient
-					reusableExists = make(map[int]bool, rowCount)
-				}
+			if cap(reusableCandidates) < rowCount {
+				reusableCandidates = make([]bool, rowCount)
+			} else {
+				reusableCandidates = reusableCandidates[:rowCount]
+				clear(reusableCandidates)
 			}
-			exists = reusableExists
+			if cap(reusableHits) < rowCount {
+				reusableHits = make([]bool, rowCount)
+			} else {
+				reusableHits = reusableHits[:rowCount]
+				clear(reusableHits)
+			}
 
 			// Test BloomFilter on vec, but only for rows that passed inner filter.
-			rowSet := make(map[int]bool, len(offsets))
 			for _, off := range offsets {
 				if int(off) >= 0 && int(off) < rowCount {
-					rowSet[int(off)] = true
+					reusableCandidates[int(off)] = true
 				}
 			}
 			bf.TestVector(vec, func(exist bool, isnull bool, row int) {
 				// Add strict boundary check to prevent index out of range
-				if exist && row >= 0 && row < rowCount && rowSet[row] {
-					exists[row] = true
-					bfHits++
+				if exist && row >= 0 && row < rowCount && reusableCandidates[row] {
+					reusableHits[row] = true
 				}
 			})
 
 			out := offsets[:0]
 			for _, off := range offsets {
-				if exists[int(off)] {
+				if reusableHits[int(off)] {
 					out = append(out, off)
 				}
 			}
@@ -259,10 +251,8 @@ func ConstructBlockPKFilter(
 	readFilter.Valid = true
 	// Set cleanup function
 	readFilter.Cleanup = func() {
-		// Clear reusableExists map by reallocating for better memory efficiency
-		if reusableExists != nil {
-			reusableExists = nil
-		}
+		reusableCandidates = nil
+		reusableHits = nil
 	}
 
 	readFilter.Valid = true

--- a/pkg/vm/engine/readutil/pk_filter.go
+++ b/pkg/vm/engine/readutil/pk_filter.go
@@ -238,7 +238,8 @@ func ConstructBlockPKFilter(
 
 			out := offsets[:0]
 			for _, off := range offsets {
-				if reusableHits[int(off)] {
+				idx := int(off)
+				if idx >= 0 && idx < rowCount && reusableHits[idx] {
 					out = append(out, off)
 				}
 			}


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG
- [x] Improvement
- [ ] API-change
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #24346

## What this PR does / why we need it:

Nightly TPCH -> TPCC runs can OOM during the TPCC REPLACE INTO hot path after composite-PK filtering became more aggressive. The first hard failure in run 25868266977 happened during the repeated statement:

```sql
replace into tpcc_10.bmsql_stock
select * from tpcc_10.bmsql_stock
order by s_w_id, s_i_id desc
limit 5000;
```

CI Loki showed repeated 5000-row bmsql_stock commits immediately before the first CN restart. Prometheus showed CN RSS/working-set near the 55GiB cgroup limit. Pyroscope before the restart pointed at readutil PK/block filtering and object BF/meta loading, with additional expected pressure from Top and MultiUpdate buffering.

This patch reduces the memory-heavy fast path without changing filtering correctness:

1. For primary-key IN filters, only load object BloomFilters when the IN-list is small enough to remain highly selective. Large IN filters now use metadata-only zonemap filtering instead of loading BF data for every candidate object.
2. In BlockReadFilter BF intersection, replace per-call rowSet/existence maps with reusable bool slices. This keeps FilterHint.BF semantics intact while avoiding large temporary map allocations for broad prefix hits.

## Validation

```bash
source ./setup_env.sh && go test ./pkg/vm/engine/readutil -count=1
```

## Root cause notes

The root cause document used for this PR is in the investigation artifact: tpcc-replace-oom-root-cause.md. The key point is that this is not the previously fixed PKPersistedBetween path; it is BF/meta and row-filter memory amplification when large composite-PK filters meet REPLACE INTO buffering.