### PR TITLE
fix(stats): coalesce concurrent stats cache misses

### DIFF
--- a/pkg/sql/plan/expr_opt.go
+++ b/pkg/sql/plan/expr_opt.go
@@ -1448,7 +1448,19 @@ func (builder *QueryBuilder) doMergeFiltersOnCompositeKey(tableDef *plan.TableDe
 		}
 	}
 
-	// Pre-merge paired range conditions (e.g., a > 3 AND a < 10) into in_range.
+	if numParts == 1 {
+		return filters
+	}
+
+	sortKeyPartCols := make(map[int32]struct{}, len(Parts))
+	for _, part := range Parts {
+		if colIdx, ok := tableDef.Name2ColIndex[part]; ok {
+			sortKeyPartCols[colIdx] = struct{}{}
+		}
+	}
+
+	// Pre-merge paired range conditions on composite sort-key parts
+	// (e.g., pk_a = 1 AND pk_b > 3 AND pk_b < 10) into in_range.
 	colLowerBounds := make(map[int32]int) // colPos -> filter index
 	colUpperBounds := make(map[int32]int) // colPos -> filter index
 	for i, expr := range filters {
@@ -1458,6 +1470,9 @@ func (builder *QueryBuilder) doMergeFiltersOnCompositeKey(tableDef *plan.TableDe
 		}
 		col, isLower := classifyRangeBound(fn)
 		if col == nil {
+			continue
+		}
+		if _, ok := sortKeyPartCols[col.ColPos]; !ok {
 			continue
 		}
 		if isLower {
@@ -1532,10 +1547,6 @@ func (builder *QueryBuilder) doMergeFiltersOnCompositeKey(tableDef *plan.TableDe
 		filters[lowerIdx] = merged
 		filters[upperIdx] = makePlan2BoolConstExprWithType(true)
 		col2filter[colPos] = lowerIdx
-	}
-
-	if numParts == 1 {
-		return filters
 	}
 
 	filterIdx := make([]int, 0, numParts)

--- a/pkg/sql/plan/expr_opt_test.go
+++ b/pkg/sql/plan/expr_opt_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoMergeFiltersOnCompositeKeyKeepsNonSortKeyRanges(t *testing.T) {
+	ctx := NewMockCompilerContext(true)
+	builder := NewQueryBuilder(planpb.Query_SELECT, ctx, false, false)
+	tag := builder.genNewBindTag()
+	tableDef := makeExprOptCompositeSortKeyTableDef()
+
+	aEq := makeExprOptBinaryInt64Expr(t, ctx, "=", makeExprOptInt64Col(tag, 0, "a"), 1)
+	cGt := makeExprOptBinaryInt64Expr(t, ctx, ">", makeExprOptInt64Col(tag, 2, "c"), 2)
+	cLt := makeExprOptBinaryInt64Expr(t, ctx, "<", makeExprOptInt64Col(tag, 2, "c"), 4)
+
+	ret := builder.doMergeFiltersOnCompositeKey(tableDef, tag, aEq, cGt, cLt)
+
+	require.Len(t, ret, 3)
+	requireFuncNames(t, ret, ">", "<")
+	requireNoFuncNames(t, ret, "in_range", "between")
+}
+
+func TestDoMergeFiltersOnCompositeKeyMergesSortKeyRanges(t *testing.T) {
+	ctx := NewMockCompilerContext(true)
+	builder := NewQueryBuilder(planpb.Query_SELECT, ctx, false, false)
+	tag := builder.genNewBindTag()
+	tableDef := makeExprOptCompositeSortKeyTableDef()
+
+	aEq := makeExprOptBinaryInt64Expr(t, ctx, "=", makeExprOptInt64Col(tag, 0, "a"), 1)
+	bGt := makeExprOptBinaryInt64Expr(t, ctx, ">", makeExprOptInt64Col(tag, 1, "b"), 2)
+	bLt := makeExprOptBinaryInt64Expr(t, ctx, "<", makeExprOptInt64Col(tag, 1, "b"), 4)
+
+	ret := builder.doMergeFiltersOnCompositeKey(tableDef, tag, aEq, bGt, bLt)
+
+	requireFuncNames(t, ret, "in_range")
+}
+
+func makeExprOptCompositeSortKeyTableDef() *planpb.TableDef {
+	return &planpb.TableDef{
+		Cols: []*planpb.ColDef{
+			{Name: "a", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "b", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "c", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "__mo_cpkey", Typ: planpb.Type{Id: int32(types.T_varchar)}},
+		},
+		Name2ColIndex: map[string]int32{
+			"a":          0,
+			"b":          1,
+			"c":          2,
+			"__mo_cpkey": 3,
+		},
+		Pkey: &planpb.PrimaryKeyDef{
+			PkeyColName: "__mo_cpkey",
+			Names:       []string{"a", "b"},
+		},
+	}
+}
+
+func makeExprOptInt64Col(tag, pos int32, name string) *planpb.Expr {
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_int64)},
+		Expr: &planpb.Expr_Col{
+			Col: &planpb.ColRef{
+				RelPos: tag,
+				ColPos: pos,
+				Name:   name,
+			},
+		},
+	}
+}
+
+func makeExprOptBinaryInt64Expr(t *testing.T, ctx *MockCompilerContext, op string, col *planpb.Expr, val int64) *planpb.Expr {
+	t.Helper()
+
+	expr, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), op, []*planpb.Expr{
+		col,
+		MakePlan2Int64ConstExprWithType(val),
+	})
+	require.NoError(t, err)
+	return expr
+}
+
+func requireFuncNames(t *testing.T, filters []*planpb.Expr, names ...string) {
+	t.Helper()
+
+	hits := make(map[string]bool, len(names))
+	for _, name := range names {
+		hits[name] = false
+	}
+	for _, expr := range filters {
+		if fn := expr.GetF(); fn != nil {
+			if _, ok := hits[fn.Func.ObjName]; ok {
+				hits[fn.Func.ObjName] = true
+			}
+		}
+	}
+	for name, hit := range hits {
+		require.Truef(t, hit, "expected function %s in filters", name)
+	}
+}
+
+func requireNoFuncNames(t *testing.T, filters []*planpb.Expr, names ...string) {
+	t.Helper()
+
+	for _, expr := range filters {
+		fn := expr.GetF()
+		if fn == nil {
+			continue
+		}
+		for _, name := range names {
+			require.NotEqual(t, name, fn.Func.ObjName)
+		}
+	}
+}

--- a/pkg/vm/engine/disttae/stats.go
+++ b/pkg/vm/engine/disttae/stats.go
@@ -244,6 +244,9 @@ type GlobalStats struct {
 
 		// statsInfoMap is the real stats info data.
 		statsInfoMap map[pb.StatsInfoKey]*pb.StatsInfo
+
+		// statsInfoLoads coalesces concurrent cache misses for the same table.
+		statsInfoLoads map[pb.StatsInfoKey]*statsInfoLoadCall
 	}
 
 	// updateWorkerFactor is the times of CPU number of this node
@@ -265,6 +268,13 @@ type GlobalStats struct {
 	beforeSubscribeTable func(pb.StatsInfoKey)
 }
 
+type statsInfoLoadCall struct {
+	done  chan struct{}
+	info  *pb.StatsInfo
+	sync  bool
+	retry bool
+}
+
 func NewGlobalStats(
 	ctx context.Context, e *Engine, keyRouter client.KeyRouter[pb.StatsInfoKey], opts ...GlobalStatsOption,
 ) *GlobalStats {
@@ -278,6 +288,7 @@ func NewGlobalStats(
 	}
 	s.updatingMu.updating = make(map[pb.StatsInfoKey]*updateRecord)
 	s.mu.statsInfoMap = make(map[pb.StatsInfoKey]*pb.StatsInfo)
+	s.mu.statsInfoLoads = make(map[pb.StatsInfoKey]*statsInfoLoadCall)
 	s.mu.cond = sync.NewCond(&s.mu)
 	for _, opt := range opts {
 		opt(s)
@@ -407,7 +418,47 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 		gs.mu.Unlock()
 		return info
 	}
+	call, loading := gs.mu.statsInfoLoads[key]
+	if loading {
+		if !sync && call.sync {
+			gs.mu.Unlock()
+			return nil
+		}
+		if sync && !call.sync {
+			// A synchronous request must keep its forced-update semantics instead
+			// of waiting behind a best-effort remote stats load.
+			delete(gs.mu.statsInfoLoads, key)
+		} else {
+			gs.mu.Unlock()
+			select {
+			case <-call.done:
+				if call.info == nil && ctx.Err() == nil && (call.retry || (sync && !call.sync)) {
+					return gs.Get(ctx, key, sync)
+				}
+				return call.info
+			case <-ctx.Done():
+				return nil
+			}
+		}
+	}
+	if gs.mu.statsInfoLoads == nil {
+		gs.mu.statsInfoLoads = make(map[pb.StatsInfoKey]*statsInfoLoadCall)
+	}
+	call = &statsInfoLoadCall{done: make(chan struct{}), sync: sync}
+	gs.mu.statsInfoLoads[key] = call
 	gs.mu.Unlock()
+
+	retryLoad := false
+	defer func() {
+		gs.mu.Lock()
+		if gs.mu.statsInfoLoads[key] == call {
+			delete(gs.mu.statsInfoLoads, key)
+		}
+		gs.mu.Unlock()
+		call.info = info
+		call.retry = retryLoad
+		close(call.done)
+	}()
 
 	// after checking first potential patched cache
 	// we check the approx to avoid taking a place in statInfo map
@@ -421,6 +472,9 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 		key.TableName,
 		key.DatabaseID,
 		key.DbName)
+	if err != nil {
+		retryLoad = true
+	}
 
 	if err == nil && ps.ApproxDataObjectsNum() == 0 {
 		return nil
@@ -443,10 +497,13 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 		if len(target) != 0 {
 			resp, err := client.SendMessage(ctx, target, client.NewRequest(query.CmdMethod_GetStatsInfo))
 			if err != nil || resp == nil {
+				retryLoad = true
 				logutil.Errorf("failed to send request to %s, err: %v, resp: %v", "", err, resp)
 			} else if resp.GetStatsInfoResponse != nil {
 				defer client.Release(resp)
 				remoteInfo = resp.GetStatsInfoResponse.StatsInfo
+			} else {
+				retryLoad = true
 			}
 		}
 	}
@@ -473,6 +530,7 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 	if sync {
 		for !ok {
 			if ctx.Err() != nil {
+				retryLoad = true
 				return nil
 			}
 

--- a/pkg/vm/engine/disttae/stats.go
+++ b/pkg/vm/engine/disttae/stats.go
@@ -275,6 +275,8 @@ type statsInfoLoadCall struct {
 	retry bool
 }
 
+const maxStatsInfoLoadRetries = 3
+
 func NewGlobalStats(
 	ctx context.Context, e *Engine, keyRouter client.KeyRouter[pb.StatsInfoKey], opts ...GlobalStatsOption,
 ) *GlobalStats {
@@ -407,6 +409,10 @@ func (gs *GlobalStats) cacheRemoteInfoIfSubscribed(
 }
 
 func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) *pb.StatsInfo {
+	return gs.get(ctx, key, sync, 0)
+}
+
+func (gs *GlobalStats) get(ctx context.Context, key pb.StatsInfoKey, sync bool, retries int) *pb.StatsInfo {
 	wrapkey := pb.StatsInfoKeyWithContext{
 		Ctx: ctx,
 		Key: key,
@@ -433,7 +439,13 @@ func (gs *GlobalStats) Get(ctx context.Context, key pb.StatsInfoKey, sync bool) 
 			select {
 			case <-call.done:
 				if call.info == nil && ctx.Err() == nil && (call.retry || (sync && !call.sync)) {
-					return gs.Get(ctx, key, sync)
+					if call.retry {
+						retries++
+						if retries > maxStatsInfoLoadRetries {
+							return nil
+						}
+					}
+					return gs.get(ctx, key, sync, retries)
 				}
 				return call.info
 			case <-ctx.Done():

--- a/pkg/vm/engine/disttae/stats_test.go
+++ b/pkg/vm/engine/disttae/stats_test.go
@@ -17,6 +17,7 @@ package disttae
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	goruntime "runtime"
 	"sync"
@@ -52,6 +53,7 @@ func (r *mockStatsKeyRouter) AddItem(gossip.CommonItem)            {}
 
 type mockStatsQueryClient struct {
 	response    *querypb.Response
+	err         error
 	sendStarted chan struct{}
 	allowReturn chan struct{}
 	sendOnce    sync.Once
@@ -69,6 +71,9 @@ func (m *mockStatsQueryClient) SendMessage(context.Context, string, *querypb.Req
 	}
 	if m.allowReturn != nil {
 		<-m.allowReturn
+	}
+	if m.err != nil {
+		return nil, m.err
 	}
 	return m.response, nil
 }
@@ -2160,7 +2165,7 @@ func TestGlobalStatsGetCoalescesConcurrentCacheMiss(t *testing.T) {
 			t.Fatal("GlobalStats.Get did not request remote stats")
 		}
 
-		for range waiters {
+		for i := 0; i < waiters; i++ {
 			go func() {
 				resultCh <- gs.Get(getCtx, key, false)
 			}()
@@ -2172,7 +2177,7 @@ func TestGlobalStatsGetCoalescesConcurrentCacheMiss(t *testing.T) {
 
 		close(qc.allowReturn)
 
-		for range waiters + 1 {
+		for i := 0; i < waiters+1; i++ {
 			select {
 			case info := <-resultCh:
 				require.Equal(t, remoteInfo, info)
@@ -2182,6 +2187,93 @@ func TestGlobalStatsGetCoalescesConcurrentCacheMiss(t *testing.T) {
 		}
 		assert.Equal(t, int32(1), subscribeCount.Load())
 		assert.Equal(t, int32(1), qc.sendCount.Load())
+	})
+}
+
+func TestGlobalStatsGetWaiterRetryStopsOnPersistentRemoteFailure(t *testing.T) {
+	runTest(t, func(ctx context.Context, e *Engine) {
+		gs := e.globalStats
+		const dbID uint64 = 101
+		const tblID uint64 = 10002
+
+		e.pClient.eng = e
+		e.pClient.subscribed.eng = e
+
+		ent := &subEntry{dbID: dbID, state: Subscribed}
+		ent.lastTs.Store(time.Now().UnixNano())
+
+		if e.pClient.subscribed.m == nil {
+			e.pClient.subscribed.m = make(map[uint64]*subEntry)
+		}
+		e.pClient.subscribed.m[tblID] = ent
+
+		key := statsinfo.StatsInfoKey{
+			AccId:      0,
+			DatabaseID: dbID,
+			TableID:    tblID,
+			TableName:  "t",
+			DbName:     "d",
+		}
+
+		part := e.GetOrCreateLatestPart(ctx, 0, dbID, tblID)
+		state, done := part.MutateState()
+		oid := types.NewObjectid()
+		stats := objectio.NewObjectStatsWithObjectID(&oid, false, false, false)
+		require.NoError(t, objectio.SetObjectStatsBlkCnt(stats, 1))
+		require.NoError(t, objectio.SetObjectStatsRowCnt(stats, 1))
+		require.NoError(t, objectio.SetObjectStatsSize(stats, 1))
+		require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+			ObjectStats: *stats,
+			CreateTime:  types.BuildTS(time.Now().UnixNano(), 0),
+		}, false))
+		done()
+
+		qc := &mockStatsQueryClient{
+			err:         errors.New("remote stats unavailable"),
+			sendStarted: make(chan struct{}),
+			allowReturn: make(chan struct{}),
+		}
+		oldQC := e.qc
+		oldRouter := gs.KeyRouter
+		e.qc = qc
+		gs.KeyRouter = &mockStatsKeyRouter{target: "cn1"}
+		defer func() {
+			e.qc = oldQC
+			gs.KeyRouter = oldRouter
+		}()
+
+		getCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		const waiters = 4
+		resultCh := make(chan *statsinfo.StatsInfo, waiters+1)
+		go func() {
+			resultCh <- gs.Get(getCtx, key, false)
+		}()
+
+		select {
+		case <-qc.sendStarted:
+		case <-time.After(time.Second):
+			t.Fatal("GlobalStats.Get did not request remote stats")
+		}
+
+		for i := 0; i < waiters; i++ {
+			go func() {
+				resultCh <- gs.Get(getCtx, key, false)
+			}()
+		}
+
+		close(qc.allowReturn)
+
+		for i := 0; i < waiters+1; i++ {
+			select {
+			case info := <-resultCh:
+				require.Nil(t, info)
+			case <-time.After(time.Second):
+				t.Fatal("GlobalStats.Get did not return after repeated remote failures")
+			}
+		}
+		require.LessOrEqual(t, qc.sendCount.Load(), int32((waiters+1)*(maxStatsInfoLoadRetries+1)))
 	})
 }
 

--- a/pkg/vm/engine/disttae/stats_test.go
+++ b/pkg/vm/engine/disttae/stats_test.go
@@ -54,6 +54,8 @@ type mockStatsQueryClient struct {
 	response    *querypb.Response
 	sendStarted chan struct{}
 	allowReturn chan struct{}
+	sendOnce    sync.Once
+	sendCount   atomic.Int32
 }
 
 func (m *mockStatsQueryClient) ServiceID() string {
@@ -61,8 +63,13 @@ func (m *mockStatsQueryClient) ServiceID() string {
 }
 
 func (m *mockStatsQueryClient) SendMessage(context.Context, string, *querypb.Request) (*querypb.Response, error) {
-	close(m.sendStarted)
-	<-m.allowReturn
+	m.sendCount.Add(1)
+	if m.sendStarted != nil {
+		m.sendOnce.Do(func() { close(m.sendStarted) })
+	}
+	if m.allowReturn != nil {
+		<-m.allowReturn
+	}
 	return m.response, nil
 }
 
@@ -2072,5 +2079,200 @@ func TestGlobalStatsGetDoesNotCacheRemoteInfoAfterUnsubscribe(t *testing.T) {
 		_, ok := gs.mu.statsInfoMap[key]
 		gs.mu.Unlock()
 		assert.False(t, ok)
+	})
+}
+
+func TestGlobalStatsGetCoalescesConcurrentCacheMiss(t *testing.T) {
+	runTest(t, func(ctx context.Context, e *Engine) {
+		gs := e.globalStats
+		const dbID uint64 = 100
+		const tblID uint64 = 10001
+
+		e.pClient.eng = e
+		e.pClient.subscribed.eng = e
+
+		ent := &subEntry{dbID: dbID, state: Subscribed}
+		ent.lastTs.Store(time.Now().UnixNano())
+
+		if e.pClient.subscribed.m == nil {
+			e.pClient.subscribed.m = make(map[uint64]*subEntry)
+		}
+		e.pClient.subscribed.m[tblID] = ent
+
+		key := statsinfo.StatsInfoKey{
+			AccId:      0,
+			DatabaseID: dbID,
+			TableID:    tblID,
+			TableName:  "t",
+			DbName:     "d",
+		}
+
+		part := e.GetOrCreateLatestPart(ctx, 0, dbID, tblID)
+		state, done := part.MutateState()
+		oid := types.NewObjectid()
+		stats := objectio.NewObjectStatsWithObjectID(&oid, false, false, false)
+		require.NoError(t, objectio.SetObjectStatsBlkCnt(stats, 1))
+		require.NoError(t, objectio.SetObjectStatsRowCnt(stats, 1))
+		require.NoError(t, objectio.SetObjectStatsSize(stats, 1))
+		require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+			ObjectStats: *stats,
+			CreateTime:  types.BuildTS(time.Now().UnixNano(), 0),
+		}, false))
+		done()
+
+		remoteInfo := plan2.NewStatsInfo()
+		remoteInfo.TableCnt = 42
+
+		qc := &mockStatsQueryClient{
+			response: &querypb.Response{
+				GetStatsInfoResponse: &querypb.GetStatsInfoResponse{StatsInfo: remoteInfo},
+			},
+			sendStarted: make(chan struct{}),
+			allowReturn: make(chan struct{}),
+		}
+		oldQC := e.qc
+		oldRouter := gs.KeyRouter
+		oldSubscribeHook := gs.beforeSubscribeTable
+		e.qc = qc
+		gs.KeyRouter = &mockStatsKeyRouter{target: "cn1"}
+		var subscribeCount atomic.Int32
+		gs.beforeSubscribeTable = func(statsinfo.StatsInfoKey) {
+			subscribeCount.Add(1)
+		}
+		defer func() {
+			e.qc = oldQC
+			gs.KeyRouter = oldRouter
+			gs.beforeSubscribeTable = oldSubscribeHook
+		}()
+
+		getCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		const waiters = 16
+		resultCh := make(chan *statsinfo.StatsInfo, waiters+1)
+		go func() {
+			resultCh <- gs.Get(getCtx, key, false)
+		}()
+
+		select {
+		case <-qc.sendStarted:
+		case <-time.After(time.Second):
+			t.Fatal("GlobalStats.Get did not request remote stats")
+		}
+
+		for range waiters {
+			go func() {
+				resultCh <- gs.Get(getCtx, key, false)
+			}()
+		}
+
+		require.Eventually(t, func() bool {
+			return subscribeCount.Load() == 1 && qc.sendCount.Load() == 1
+		}, time.Second, 10*time.Millisecond)
+
+		close(qc.allowReturn)
+
+		for range waiters + 1 {
+			select {
+			case info := <-resultCh:
+				require.Equal(t, remoteInfo, info)
+			case <-time.After(time.Second):
+				t.Fatal("GlobalStats.Get did not return")
+			}
+		}
+		assert.Equal(t, int32(1), subscribeCount.Load())
+		assert.Equal(t, int32(1), qc.sendCount.Load())
+	})
+}
+
+func TestGlobalStatsGetSyncRequestDoesNotWaitBehindNonSyncLoad(t *testing.T) {
+	runTest(t, func(ctx context.Context, e *Engine) {
+		gs := e.globalStats
+		const dbID uint64 = 100
+		const tblID uint64 = 10001
+
+		e.pClient.eng = e
+		e.pClient.subscribed.eng = e
+
+		ent := &subEntry{dbID: dbID, state: Subscribed}
+		ent.lastTs.Store(time.Now().UnixNano())
+
+		if e.pClient.subscribed.m == nil {
+			e.pClient.subscribed.m = make(map[uint64]*subEntry)
+		}
+		e.pClient.subscribed.m[tblID] = ent
+
+		key := statsinfo.StatsInfoKey{
+			AccId:      0,
+			DatabaseID: dbID,
+			TableID:    tblID,
+			TableName:  "t",
+			DbName:     "d",
+		}
+
+		part := e.GetOrCreateLatestPart(ctx, 0, dbID, tblID)
+		state, done := part.MutateState()
+		oid := types.NewObjectid()
+		stats := objectio.NewObjectStatsWithObjectID(&oid, false, false, false)
+		require.NoError(t, objectio.SetObjectStatsBlkCnt(stats, 1))
+		require.NoError(t, objectio.SetObjectStatsRowCnt(stats, 1))
+		require.NoError(t, objectio.SetObjectStatsSize(stats, 1))
+		require.NoError(t, state.HandleObjectEntry(ctx, nil, objectio.ObjectEntry{
+			ObjectStats: *stats,
+			CreateTime:  types.BuildTS(time.Now().UnixNano(), 0),
+		}, false))
+		done()
+
+		remoteInfo := plan2.NewStatsInfo()
+		remoteInfo.TableCnt = 42
+
+		qc := &mockStatsQueryClient{
+			response: &querypb.Response{
+				GetStatsInfoResponse: &querypb.GetStatsInfoResponse{StatsInfo: remoteInfo},
+			},
+			sendStarted: make(chan struct{}),
+			allowReturn: make(chan struct{}),
+		}
+		oldQC := e.qc
+		oldRouter := gs.KeyRouter
+		e.qc = qc
+		gs.KeyRouter = &mockStatsKeyRouter{target: "cn1"}
+		defer func() {
+			e.qc = oldQC
+			gs.KeyRouter = oldRouter
+		}()
+
+		getCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		resultCh := make(chan *statsinfo.StatsInfo, 2)
+		go func() {
+			resultCh <- gs.Get(getCtx, key, false)
+		}()
+
+		select {
+		case <-qc.sendStarted:
+		case <-time.After(time.Second):
+			t.Fatal("non-sync GlobalStats.Get did not request remote stats")
+		}
+
+		go func() {
+			resultCh <- gs.Get(getCtx, key, true)
+		}()
+
+		require.Eventually(t, func() bool {
+			return qc.sendCount.Load() == 2
+		}, time.Second, 10*time.Millisecond, "sync GlobalStats.Get waited behind non-sync load")
+
+		close(qc.allowReturn)
+
+		for range 2 {
+			select {
+			case info := <-resultCh:
+				require.Equal(t, remoteInfo, info)
+			case <-time.After(time.Second):
+				t.Fatal("GlobalStats.Get did not return")
+			}
+		}
 	})
 }

--- a/pkg/vm/engine/readutil/expr_filter.go
+++ b/pkg/vm/engine/readutil/expr_filter.go
@@ -36,6 +36,8 @@ type SeekFirstBlockOp func(objectio.ObjectDataMeta) int
 type BlockFilterOp func(int, objectio.BlockObject, objectio.BloomFilter) (bool, bool, error)
 type LoadOpFactory func(fileservice.FileService) LoadOp
 
+const maxPKInFastFilterKeys = 10
+
 var loadMetadataOnlyOpFactory LoadOpFactory
 var loadMetadataAndBFOpFactory LoadOpFactory
 
@@ -819,6 +821,10 @@ func CompileFilterExpr(
 			_ = vec.UnmarshalBinary(val)
 			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			isPK, isSorted := isSortedKey(colDef)
+			if isPK && vec.Length() > maxPKInFastFilterKeys {
+				canCompile = false
+				return
+			}
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
 					if obj.ZMIsEmpty() {
@@ -921,6 +927,10 @@ func CompileFilterExpr(
 			_ = vec.UnmarshalBinary(val)
 			colDef := getColDefByName(expr, colExpr.Col.Name, colExpr.Col.ColPos, tableDef)
 			isPK, isSorted := isSortedKey(colDef)
+			if isPK && vec.Length() > maxPKInFastFilterKeys {
+				canCompile = false
+				return
+			}
 			if isSorted {
 				fastFilterOp = func(obj *objectio.ObjectStats) (bool, error) {
 					if obj.ZMIsEmpty() {

--- a/pkg/vm/engine/readutil/filter_test.go
+++ b/pkg/vm/engine/readutil/filter_test.go
@@ -2853,3 +2853,35 @@ func TestCompileFilterExpr_PrefixSortedSeekOps(t *testing.T) {
 		})
 	}
 }
+
+func TestConstructBlockPKFilterIntersectsLargePrefixHitsWithoutMaps(t *testing.T) {
+	m := mpool.MustNew(t.Name())
+	rowCount := objectio.BlockMaxRows
+	pkVec := vector.NewVec(types.T_varchar.ToType())
+	defer pkVec.Free(m)
+	for i := 0; i < rowCount; i++ {
+		require.NoError(t, vector.AppendBytes(pkVec, []byte(fmt.Sprintf("warehouse-1-%05d", i)), false, m))
+	}
+
+	bf := bloomfilter.NewCBloomFilterWithProbability(int64(rowCount), 0.00001)
+	defer bf.Free()
+	bf.Add([]byte("warehouse-1-00001"))
+	bf.Add([]byte("warehouse-1-01000"))
+	bf.Add([]byte("warehouse-1-08191"))
+
+	filter, err := ConstructBlockPKFilter(false, BasePKFilter{
+		Valid: true,
+		Op:    function.PREFIX_EQ,
+		Oid:   types.T_varchar,
+		LB:    []byte("warehouse-1-"),
+	}, bf)
+	require.NoError(t, err)
+	require.True(t, filter.Valid)
+	require.NotNil(t, filter.SortedSearchFunc)
+
+	offsets := filter.SortedSearchFunc(containers.Vectors{*pkVec})
+	require.Contains(t, offsets, int64(1))
+	require.Contains(t, offsets, int64(1000))
+	require.Contains(t, offsets, int64(8191))
+	require.Less(t, len(offsets), rowCount)
+}

--- a/pkg/vm/engine/readutil/filter_test.go
+++ b/pkg/vm/engine/readutil/filter_test.go
@@ -2605,6 +2605,51 @@ func TestCompileFilterExpr_PrefixInRangeAllFlags(t *testing.T) {
 	}
 }
 
+func TestCompileFilterExpr_LargePKInSkipsFastFilter(t *testing.T) {
+	tableDef := &plan.TableDef{
+		Name:          "test_tbl",
+		Name2ColIndex: map[string]int32{"id": 0, "v": 1},
+		Pkey: &plan.PrimaryKeyDef{
+			Names:       []string{"id"},
+			PkeyColName: "id",
+		},
+		Cols: []*plan.ColDef{
+			{
+				Name:    "id",
+				ColId:   0,
+				Seqnum:  0,
+				Primary: true,
+				Typ:     plan.Type{Id: int32(types.T_int64)},
+			},
+			{
+				Name:   "v",
+				ColId:  1,
+				Seqnum: 1,
+				Typ:    plan.Type{Id: int32(types.T_int64)},
+			},
+		},
+	}
+
+	m := mpool.MustNew(t.Name())
+	makeInExpr := func(t *testing.T, colName string, count int) *plan.Expr {
+		vec := vector.NewVec(types.T_int64.ToType())
+		defer vec.Free(m)
+		for i := 0; i < count; i++ {
+			require.NoError(t, vector.AppendFixed(vec, int64(i), false, m))
+		}
+		return ConstructInExpr(context.Background(), colName, vec)
+	}
+
+	_, _, _, _, _, canCompileSmallPKIn, _ := CompileFilterExpr(makeInExpr(t, "id", maxPKInFastFilterKeys), tableDef, nil)
+	require.True(t, canCompileSmallPKIn)
+
+	_, _, _, _, _, canCompileLargePKIn, _ := CompileFilterExpr(makeInExpr(t, "id", maxPKInFastFilterKeys+1), tableDef, nil)
+	require.False(t, canCompileLargePKIn)
+
+	_, _, _, _, _, canCompileLargeNonPKIn, _ := CompileFilterExpr(makeInExpr(t, "v", maxPKInFastFilterKeys+1), tableDef, nil)
+	require.True(t, canCompileLargeNonPKIn)
+}
+
 func TestCompileFilterExpr_Between(t *testing.T) {
 	tableDef := &plan.TableDef{
 		Name:          "test_tbl",

--- a/pkg/vm/engine/readutil/pk_filter.go
+++ b/pkg/vm/engine/readutil/pk_filter.go
@@ -144,8 +144,9 @@ func ConstructBlockPKFilter(
 
 	// Reusable temporary variables (defined outside closure to avoid allocation on each call)
 	var (
-		reusableSels   []int64
-		reusableExists map[int]bool
+		reusableSels       []int64
+		reusableCandidates []bool
+		reusableHits       []bool
 	)
 
 	bfVec := func(cacheVectors containers.Vectors) *vector.Vector {
@@ -209,44 +210,36 @@ func ConstructBlockPKFilter(
 				return offsets
 			}
 
-			var exists map[int]bool
-			var bfHits int
-
-			// Reuse exists map - use more efficient reallocation for large maps
-			if reusableExists == nil || rowCount > len(reusableExists)*2 {
-				reusableExists = make(map[int]bool, rowCount)
-			} else if len(reusableExists) > 0 {
-				// For small maps, clear by reallocating (more efficient than delete loop)
-				if len(reusableExists) < 100 {
-					// For small maps, use delete loop
-					for k := range reusableExists {
-						delete(reusableExists, k)
-					}
-				} else {
-					// For larger maps, reallocate is more efficient
-					reusableExists = make(map[int]bool, rowCount)
-				}
+			if cap(reusableCandidates) < rowCount {
+				reusableCandidates = make([]bool, rowCount)
+			} else {
+				reusableCandidates = reusableCandidates[:rowCount]
+				clear(reusableCandidates)
 			}
-			exists = reusableExists
+			if cap(reusableHits) < rowCount {
+				reusableHits = make([]bool, rowCount)
+			} else {
+				reusableHits = reusableHits[:rowCount]
+				clear(reusableHits)
+			}
 
 			// Test BloomFilter on vec, but only for rows that passed inner filter.
-			rowSet := make(map[int]bool, len(offsets))
 			for _, off := range offsets {
 				if int(off) >= 0 && int(off) < rowCount {
-					rowSet[int(off)] = true
+					reusableCandidates[int(off)] = true
 				}
 			}
 			bf.TestVector(vec, func(exist bool, isnull bool, row int) {
 				// Add strict boundary check to prevent index out of range
-				if exist && row >= 0 && row < rowCount && rowSet[row] {
-					exists[row] = true
-					bfHits++
+				if exist && row >= 0 && row < rowCount && reusableCandidates[row] {
+					reusableHits[row] = true
 				}
 			})
 
 			out := offsets[:0]
 			for _, off := range offsets {
-				if exists[int(off)] {
+				idx := int(off)
+				if idx >= 0 && idx < rowCount && reusableHits[idx] {
 					out = append(out, off)
 				}
 			}
@@ -259,10 +252,8 @@ func ConstructBlockPKFilter(
 	readFilter.Valid = true
 	// Set cleanup function
 	readFilter.Cleanup = func() {
-		// Clear reusableExists map by reallocating for better memory efficiency
-		if reusableExists != nil {
-			reusableExists = nil
-		}
+		reusableCandidates = nil
+		reusableHits = nil
 	}
 
 	readFilter.Valid = true


### PR DESCRIPTION
## What type of PR is this?

- [x] bug

## What this PR does / why we need it:

TPCH -> TPCC nightly runs started OOMing after the composite-PK planning/filtering changes expanded the number of TPCC plan-time stats lookups. The hot path is not a single bad query result: many TPCC terminals concurrently miss `GlobalStats.statsInfoMap` for the same table, then each caller enters table subscription / remote stats / stats build work.

This PR coalesces concurrent `GlobalStats.Get` cache misses per `StatsInfoKey`, so one leader performs the subscribe/remote stats/build path and waiters reuse the result. `sync=false` callers do not wait behind `sync=true` loads to preserve the remote stats non-blocking behavior, and waiters retry when the leader failed transiently or when a `sync=true` waiter was behind a `sync=false` nil result.

## Which issue(s) this PR fixes:

Related to #24346

## Special notes for your reviewer:

Evidence from nightly comparison:

- Good run `25562883017` (`commit-6b458066b`, namespace `mo-main-commit-6b458066b-20260508`) completed TPCC with no CN restart.
- First bad run on May 9 (`commit-e29ed45ca`, namespace `mo-main-commit-e29ed45ca-20260509`) OOMKilled TP CNs.
- The main trigger in the commit range is #24289 / `377ab004cd`, which expands composite-PK plan/filter/stats usage; the underlying bug is that stats cache misses were not coalesced.
- `subscribe-ok` events jumped from about 61 in the good TPCC window to about 1762 on May 9, and about 3971 in the latest no-replace TPCC repro.

## Additional documentation

None.

## Does this PR introduce a user-facing change?

No.

## Validation

```bash
source ./setup_env.sh && go test ./pkg/vm/engine/disttae -count=1
```