### PR TITLE
fix(plan): limit range merge to composite sort keys

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -28,6 +28,7 @@ const (
 	EqualIndexCondition       = 1
 	NonEqualIndexCondition    = 2
 	SpatialIndexCondition     = 3
+	RangeIndexCondition       = 4
 
 	// MaxOverFetchFactor is the maximum multiplier for over-fetching candidates
 	// in auto mode vector search. This cap prevents excessive memory usage and
@@ -949,7 +950,11 @@ func (builder *QueryBuilder) applyIndicesForFiltersRegularIndex(nodeID int32, no
 
 	idxToChoose, filterIdx = builder.getIndexForNonEquiCond(indexes, node)
 	if idxToChoose != -1 {
-		retID, idxTableNodeID := builder.applyIndexJoin(indexes[idxToChoose], node, NonEqualIndexCondition, filterIdx, scanSnapshot)
+		condType := NonEqualIndexCondition
+		if len(filterIdx) == 2 {
+			condType = RangeIndexCondition
+		}
+		retID, idxTableNodeID := builder.applyIndexJoin(indexes[idxToChoose], node, condType, filterIdx, scanSnapshot)
 		builder.applyExtraFiltersOnIndex(indexes[idxToChoose], node, builder.qry.Nodes[idxTableNodeID], filterIdx)
 		return retID
 	}
@@ -1488,7 +1493,39 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 		}
 	}
 
-	// Find non-equi conditions (in, between, in_range, or, single range ops)
+	// First pass: detect paired range conditions on index leading columns.
+	colLowerBounds := make(map[int32]int32) // colPos -> filter index
+	colUpperBounds := make(map[int32]int32) // colPos -> filter index
+
+	for i := range node.FilterList {
+		fn := node.FilterList[i].GetF()
+		if fn == nil || len(fn.Args) < 2 {
+			continue
+		}
+		col, isLower := classifyRangeBound(fn)
+		if col == nil {
+			continue
+		}
+		if _, ok := colPos2Idx[col.ColPos]; !ok {
+			continue
+		}
+		if isLower {
+			colLowerBounds[col.ColPos] = int32(i)
+		} else {
+			colUpperBounds[col.ColPos] = int32(i)
+		}
+	}
+
+	for colPos, lowerIdx := range colLowerBounds {
+		upperIdx, hasUpper := colUpperBounds[colPos]
+		if !hasUpper {
+			continue
+		}
+		idxPos := colPos2Idx[colPos]
+		return idxPos, []int32{lowerIdx, upperIdx}
+	}
+
+	// Second pass: find non-equi conditions (in, between, in_range, or, single range ops)
 	for i := range node.FilterList {
 		filterType, col := checkIndexFilter(node.FilterList[i].GetF())
 		if filterType == NonEqualIndexCondition {
@@ -1584,6 +1621,50 @@ func rangeFilterConstValue(fn *plan.Function) *plan.Expr {
 	return nil
 }
 
+func (builder *QueryBuilder) replaceRangePairCondition(filterList []*plan.Expr, filterIdx []int32, idxTag int32, idxTableDef *plan.TableDef, numParts int) *plan.Expr {
+	lowerFn := filterList[filterIdx[0]].GetF()
+	upperFn := filterList[filterIdx[1]].GetF()
+
+	lowerOp := canonicalRangeOp(lowerFn)
+	upperOp := canonicalRangeOp(upperFn)
+
+	colExpr := GetColExpr(idxTableDef.Cols[0].Typ, idxTag, 0)
+	lowerVal := DeepCopyExpr(rangeFilterConstValue(lowerFn))
+	upperVal := DeepCopyExpr(rangeFilterConstValue(upperFn))
+
+	compositeFilterSel := filterList[filterIdx[0]].Selectivity * filterList[filterIdx[1]].Selectivity
+
+	if numParts > 1 {
+		lowerVal, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{lowerVal})
+		upperVal, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{upperVal})
+	}
+
+	if lowerOp == ">=" && upperOp == "<=" {
+		funcName := "between"
+		if numParts > 1 {
+			funcName = "prefix_between"
+		}
+		expr, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), funcName, []*plan.Expr{colExpr, lowerVal, upperVal})
+		expr.Selectivity = compositeFilterSel
+		return expr
+	}
+
+	var flag uint8
+	if lowerOp == ">" {
+		flag |= 1
+	}
+	if upperOp == "<" {
+		flag |= 2
+	}
+	funcName := "in_range"
+	if numParts > 1 {
+		funcName = "prefix_in_range"
+	}
+	expr, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), funcName, []*plan.Expr{colExpr, lowerVal, upperVal, MakePlan2Uint8ConstExprWithType(flag)})
+	expr.Selectivity = compositeFilterSel
+	return expr
+}
+
 func (builder *QueryBuilder) applyIndexJoin(idxDef *IndexDef, node *plan.Node, filterType int, filterIdx []int32, scanSnapshot *Snapshot) (int32, int32) {
 	idxTag := builder.genNewBindTag()
 	idxObjRef, idxTableDef, err := builder.compCtx.ResolveIndexTableByRef(node.ObjRef, idxDef.IndexTableName, scanSnapshot)
@@ -1599,6 +1680,8 @@ func (builder *QueryBuilder) applyIndexJoin(idxDef *IndexDef, node *plan.Node, f
 	} else if filterType == SpatialIndexCondition {
 		spatialColMap := buildSpatialIndexColMap(idxDef, node, idxTag, idxTableDef)
 		idxFilter = replaceColumnsForExpr(DeepCopyExpr(node.FilterList[filterIdx[0]]), spatialColMap)
+	} else if filterType == RangeIndexCondition {
+		idxFilter = builder.replaceRangePairCondition(node.FilterList, filterIdx, idxTag, idxTableDef, numParts)
 	} else {
 		idxFilter = builder.replaceNonEqualCondition(node.FilterList[filterIdx[0]], idxTag, idxTableDef, numParts)
 	}

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -984,6 +984,70 @@ func TestTryMatchMoreLeadingFiltersRequiresContiguousPrefix(t *testing.T) {
 	}
 }
 
+func TestGetIndexForNonEquiCond_DetectsPairedRangeOnIndexColumn(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	bindTag := builder.genNewBindTag()
+	idxDef := &IndexDef{
+		IndexName:      "idx_price",
+		Parts:          []string{"price", catalog.FakePrimaryKeyColName},
+		Unique:         false,
+		IndexTableName: "__mo_index_secondary_idx_price",
+	}
+
+	node := &planpb.Node{
+		BindingTags: []int32{bindTag},
+		TableDef: &planpb.TableDef{
+			Name2ColIndex: map[string]int32{
+				catalog.FakePrimaryKeyColName: 0,
+				"price":                       1,
+			},
+			Cols: []*planpb.ColDef{
+				{Name: catalog.FakePrimaryKeyColName, Typ: planpb.Type{Id: int32(types.T_uint64)}},
+				{Name: "price", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			},
+			Pkey:    &planpb.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+			Indexes: []*planpb.IndexDef{idxDef},
+		},
+		FilterList: []*planpb.Expr{
+			makeRangeFilterExpr(bindTag, 1, ">=", 99),
+			makeRangeFilterExpr(bindTag, 1, "<=", 299),
+		},
+	}
+
+	idxPos, filterIdx := builder.getIndexForNonEquiCond([]*planpb.IndexDef{idxDef}, node)
+	require.Equal(t, 0, idxPos)
+	require.ElementsMatch(t, []int32{0, 1}, filterIdx)
+}
+
+func TestReplaceRangePairCondition_UsesPrefixBetweenForSecondaryIndex(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	bindTag := builder.genNewBindTag()
+	filters := []*planpb.Expr{
+		makeRangeFilterExpr(bindTag, 1, ">=", 99),
+		makeRangeFilterExpr(bindTag, 1, "<=", 299),
+	}
+	filters[0].Selectivity = 0.3
+	filters[1].Selectivity = 0.4
+
+	idxTableDef := &planpb.TableDef{
+		Cols: []*planpb.ColDef{
+			{
+				Name: catalog.IndexTableIndexColName,
+				Typ:  planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen},
+			},
+			{
+				Name: catalog.IndexTablePrimaryColName,
+				Typ:  planpb.Type{Id: int32(types.T_uint64)},
+			},
+		},
+	}
+
+	expr := builder.replaceRangePairCondition(filters, []int32{0, 1}, 42, idxTableDef, 2)
+	require.NotNil(t, expr.GetF())
+	require.Equal(t, "prefix_between", expr.GetF().Func.ObjName)
+	require.InDelta(t, 0.12, expr.Selectivity, 1e-9)
+}
+
 func makeEqFilterExpr(colPos int32) *planpb.Expr {
 	return &planpb.Expr{
 		Expr: &planpb.Expr_F{
@@ -1002,6 +1066,33 @@ func makeEqFilterExpr(colPos int32) *planpb.Expr {
 						Expr: &planpb.Expr_Lit{
 							Lit: &planpb.Literal{
 								Value: &planpb.Literal_I64Val{I64Val: 1},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeRangeFilterExpr(relPos, colPos int32, op string, val int64) *planpb.Expr {
+	return &planpb.Expr{
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: op},
+				Args: []*planpb.Expr{
+					{
+						Expr: &planpb.Expr_Col{
+							Col: &planpb.ColRef{
+								RelPos: relPos,
+								ColPos: colPos,
+							},
+						},
+					},
+					{
+						Expr: &planpb.Expr_Lit{
+							Lit: &planpb.Literal{
+								Value: &planpb.Literal_I64Val{I64Val: val},
 							},
 						},
 					},

--- a/pkg/sql/plan/expr_opt.go
+++ b/pkg/sql/plan/expr_opt.go
@@ -1448,7 +1448,19 @@ func (builder *QueryBuilder) doMergeFiltersOnCompositeKey(tableDef *plan.TableDe
 		}
 	}
 
-	// Pre-merge paired range conditions (e.g., a > 3 AND a < 10) into in_range.
+	if numParts == 1 {
+		return filters
+	}
+
+	sortKeyPartCols := make(map[int32]struct{}, len(Parts))
+	for _, part := range Parts {
+		if colIdx, ok := tableDef.Name2ColIndex[part]; ok {
+			sortKeyPartCols[colIdx] = struct{}{}
+		}
+	}
+
+	// Pre-merge paired range conditions on composite sort-key parts
+	// (e.g., pk_a = 1 AND pk_b > 3 AND pk_b < 10) into in_range.
 	colLowerBounds := make(map[int32]int) // colPos -> filter index
 	colUpperBounds := make(map[int32]int) // colPos -> filter index
 	for i, expr := range filters {
@@ -1458,6 +1470,9 @@ func (builder *QueryBuilder) doMergeFiltersOnCompositeKey(tableDef *plan.TableDe
 		}
 		col, isLower := classifyRangeBound(fn)
 		if col == nil {
+			continue
+		}
+		if _, ok := sortKeyPartCols[col.ColPos]; !ok {
 			continue
 		}
 		if isLower {
@@ -1532,10 +1547,6 @@ func (builder *QueryBuilder) doMergeFiltersOnCompositeKey(tableDef *plan.TableDe
 		filters[lowerIdx] = merged
 		filters[upperIdx] = makePlan2BoolConstExprWithType(true)
 		col2filter[colPos] = lowerIdx
-	}
-
-	if numParts == 1 {
-		return filters
 	}
 
 	filterIdx := make([]int, 0, numParts)

--- a/pkg/sql/plan/expr_opt_test.go
+++ b/pkg/sql/plan/expr_opt_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	planpb "github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDoMergeFiltersOnCompositeKeyKeepsNonSortKeyRanges(t *testing.T) {
+	ctx := NewMockCompilerContext(true)
+	builder := NewQueryBuilder(planpb.Query_SELECT, ctx, false, false)
+	tag := builder.genNewBindTag()
+	tableDef := makeExprOptCompositeSortKeyTableDef()
+
+	aEq := makeExprOptBinaryInt64Expr(t, ctx, "=", makeExprOptInt64Col(tag, 0, "a"), 1)
+	cGt := makeExprOptBinaryInt64Expr(t, ctx, ">", makeExprOptInt64Col(tag, 2, "c"), 2)
+	cLt := makeExprOptBinaryInt64Expr(t, ctx, "<", makeExprOptInt64Col(tag, 2, "c"), 4)
+
+	ret := builder.doMergeFiltersOnCompositeKey(tableDef, tag, aEq, cGt, cLt)
+
+	require.Len(t, ret, 3)
+	requireFuncNames(t, ret, ">", "<")
+	requireNoFuncNames(t, ret, "in_range", "between")
+}
+
+func TestDoMergeFiltersOnCompositeKeyMergesSortKeyRanges(t *testing.T) {
+	ctx := NewMockCompilerContext(true)
+	builder := NewQueryBuilder(planpb.Query_SELECT, ctx, false, false)
+	tag := builder.genNewBindTag()
+	tableDef := makeExprOptCompositeSortKeyTableDef()
+
+	aEq := makeExprOptBinaryInt64Expr(t, ctx, "=", makeExprOptInt64Col(tag, 0, "a"), 1)
+	bGt := makeExprOptBinaryInt64Expr(t, ctx, ">", makeExprOptInt64Col(tag, 1, "b"), 2)
+	bLt := makeExprOptBinaryInt64Expr(t, ctx, "<", makeExprOptInt64Col(tag, 1, "b"), 4)
+
+	ret := builder.doMergeFiltersOnCompositeKey(tableDef, tag, aEq, bGt, bLt)
+
+	requireFuncNames(t, ret, "in_range")
+}
+
+func makeExprOptCompositeSortKeyTableDef() *planpb.TableDef {
+	return &planpb.TableDef{
+		Cols: []*planpb.ColDef{
+			{Name: "a", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "b", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "c", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "__mo_cpkey", Typ: planpb.Type{Id: int32(types.T_varchar)}},
+		},
+		Name2ColIndex: map[string]int32{
+			"a":          0,
+			"b":          1,
+			"c":          2,
+			"__mo_cpkey": 3,
+		},
+		Pkey: &planpb.PrimaryKeyDef{
+			PkeyColName: "__mo_cpkey",
+			Names:       []string{"a", "b"},
+		},
+	}
+}
+
+func makeExprOptInt64Col(tag, pos int32, name string) *planpb.Expr {
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_int64)},
+		Expr: &planpb.Expr_Col{
+			Col: &planpb.ColRef{
+				RelPos: tag,
+				ColPos: pos,
+				Name:   name,
+			},
+		},
+	}
+}
+
+func makeExprOptBinaryInt64Expr(t *testing.T, ctx *MockCompilerContext, op string, col *planpb.Expr, val int64) *planpb.Expr {
+	t.Helper()
+
+	expr, err := BindFuncExprImplByPlanExpr(ctx.GetContext(), op, []*planpb.Expr{
+		col,
+		MakePlan2Int64ConstExprWithType(val),
+	})
+	require.NoError(t, err)
+	return expr
+}
+
+func requireFuncNames(t *testing.T, filters []*planpb.Expr, names ...string) {
+	t.Helper()
+
+	hits := make(map[string]bool, len(names))
+	for _, name := range names {
+		hits[name] = false
+	}
+	for _, expr := range filters {
+		if fn := expr.GetF(); fn != nil {
+			if _, ok := hits[fn.Func.ObjName]; ok {
+				hits[fn.Func.ObjName] = true
+			}
+		}
+	}
+	for name, hit := range hits {
+		require.Truef(t, hit, "expected function %s in filters", name)
+	}
+}
+
+func requireNoFuncNames(t *testing.T, filters []*planpb.Expr, names ...string) {
+	t.Helper()
+
+	for _, expr := range filters {
+		fn := expr.GetF()
+		if fn == nil {
+			continue
+		}
+		for _, name := range names {
+			require.NotEqual(t, name, fn.Func.ObjName)
+		}
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Ref https://github.com/matrixorigin/matrixone/issues/24348

## What this PR does / why we need it:

PR #24289 added prefix range PK filters for composite keys, but its paired range pre-merge step was applied before checking whether the range column belongs to the composite sort key. As a result, ordinary predicates like `col > x AND col < y` on non-sort-key columns could be rewritten into `in_range` during normal table-scan filter normalization.

That rewrite expands the new readutil/ObjectMeta fast-filter path beyond the intended composite-key optimization. In large TPCH scans, low-selectivity ordinary range filters can then spend extra time loading object metadata, building block lists, and shipping larger pipeline block-list messages. This matches the TPCH slowdown and higher post-TPCH RSS observed after #24289, which later leaves too little memory headroom for TPCC under the 55Gi limit.

This PR limits the paired range merge to the intended scope:

- skip this paired-range rewrite for single-part sort keys;
- only merge paired ranges when the range column is one of the composite sort-key parts;
- preserve #24289's intended optimization for cases such as `pk_a = ? AND pk_b > ? AND pk_b < ?`;
- keep ordinary non-sort-key ranges as their original comparison filters.

Added planner tests for both sides: non-sort-key ranges stay as `>`/`<`, while composite sort-key ranges still merge into `in_range`.

## Validation

```bash
source /Users/shenjiangwei/Work/code/matrixone/setup_env.sh && go test ./pkg/sql/plan ./pkg/vm/engine/readutil -count=1
```
