### PR TITLE
fix(plan): make paired range index selection deterministic

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1516,12 +1516,21 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 		}
 	}
 
-	for colPos, lowerIdx := range colLowerBounds {
-		upperIdx, hasUpper := colUpperBounds[colPos]
-		if !hasUpper {
+	for i := range node.FilterList {
+		fn := node.FilterList[i].GetF()
+		if fn == nil || len(fn.Args) < 2 {
 			continue
 		}
-		idxPos := colPos2Idx[colPos]
+		col, _ := classifyRangeBound(fn)
+		if col == nil {
+			continue
+		}
+		lowerIdx, hasLower := colLowerBounds[col.ColPos]
+		upperIdx, hasUpper := colUpperBounds[col.ColPos]
+		if !hasLower || !hasUpper {
+			continue
+		}
+		idxPos := colPos2Idx[col.ColPos]
 		return idxPos, []int32{lowerIdx, upperIdx}
 	}
 

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1516,33 +1516,22 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 		}
 	}
 
-	for i := range node.FilterList {
-		fn := node.FilterList[i].GetF()
-		if fn == nil || len(fn.Args) < 2 {
-			continue
-		}
-		col, _ := classifyRangeBound(fn)
-		if col == nil {
-			continue
-		}
-		lowerIdx, hasLower := colLowerBounds[col.ColPos]
-		upperIdx, hasUpper := colUpperBounds[col.ColPos]
-		if !hasLower || !hasUpper {
-			continue
-		}
-		idxPos := colPos2Idx[col.ColPos]
-		return idxPos, []int32{lowerIdx, upperIdx}
-	}
-
 	// Second pass: find non-equi conditions (in, between, in_range, or, single range ops)
 	for i := range node.FilterList {
-		filterType, col := checkIndexFilter(node.FilterList[i].GetF())
+		fn := node.FilterList[i].GetF()
+		filterType, col := checkIndexFilter(fn)
 		if filterType == NonEqualIndexCondition {
 			idxPos, ok := colPos2Idx[col.ColPos]
 			if !ok {
 				continue
 			}
-			fn := node.FilterList[i].GetF()
+			if rangeCol, _ := classifyRangeBound(fn); rangeCol != nil {
+				lowerIdx, hasLower := colLowerBounds[rangeCol.ColPos]
+				upperIdx, hasUpper := colUpperBounds[rangeCol.ColPos]
+				if hasLower && hasUpper && int32(i) == min(lowerIdx, upperIdx) {
+					return idxPos, []int32{lowerIdx, upperIdx}
+				}
+			}
 			if fn != nil {
 				numParts := len(indexes[idxPos].Parts)
 				if numParts > 1 && hasUnsafeRangeOp(fn) {

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -1048,6 +1048,51 @@ func TestReplaceRangePairCondition_UsesPrefixBetweenForSecondaryIndex(t *testing
 	require.InDelta(t, 0.12, expr.Selectivity, 1e-9)
 }
 
+func TestGetIndexForNonEquiCond_PrefersFirstPairedRangeByFilterOrder(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	bindTag := builder.genNewBindTag()
+	idxPrice := &IndexDef{
+		IndexName:      "idx_price",
+		Parts:          []string{"price", catalog.FakePrimaryKeyColName},
+		Unique:         false,
+		IndexTableName: "__mo_index_secondary_idx_price",
+	}
+	idxQuantity := &IndexDef{
+		IndexName:      "idx_quantity",
+		Parts:          []string{"quantity", catalog.FakePrimaryKeyColName},
+		Unique:         false,
+		IndexTableName: "__mo_index_secondary_idx_quantity",
+	}
+
+	node := &planpb.Node{
+		BindingTags: []int32{bindTag},
+		TableDef: &planpb.TableDef{
+			Name2ColIndex: map[string]int32{
+				catalog.FakePrimaryKeyColName: 0,
+				"price":                       1,
+				"quantity":                    2,
+			},
+			Cols: []*planpb.ColDef{
+				{Name: catalog.FakePrimaryKeyColName, Typ: planpb.Type{Id: int32(types.T_uint64)}},
+				{Name: "price", Typ: planpb.Type{Id: int32(types.T_int64)}},
+				{Name: "quantity", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			},
+			Pkey:    &planpb.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+			Indexes: []*planpb.IndexDef{idxPrice, idxQuantity},
+		},
+		FilterList: []*planpb.Expr{
+			makeRangeFilterExpr(bindTag, 2, ">=", 10),
+			makeRangeFilterExpr(bindTag, 2, "<=", 20),
+			makeRangeFilterExpr(bindTag, 1, ">=", 100),
+			makeRangeFilterExpr(bindTag, 1, "<=", 200),
+		},
+	}
+
+	idxPos, filterIdx := builder.getIndexForNonEquiCond([]*planpb.IndexDef{idxPrice, idxQuantity}, node)
+	require.Equal(t, 1, idxPos)
+	require.Equal(t, []int32{0, 1}, filterIdx)
+}
+
 func makeEqFilterExpr(colPos int32) *planpb.Expr {
 	return &planpb.Expr{
 		Expr: &planpb.Expr_F{

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -1093,6 +1093,50 @@ func TestGetIndexForNonEquiCond_PrefersFirstPairedRangeByFilterOrder(t *testing.
 	require.Equal(t, []int32{0, 1}, filterIdx)
 }
 
+func TestGetIndexForNonEquiCond_KeepsEarlierNonPairedFilterPriority(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	bindTag := builder.genNewBindTag()
+	idxPrice := &IndexDef{
+		IndexName:      "idx_price",
+		Parts:          []string{"price", catalog.FakePrimaryKeyColName},
+		Unique:         false,
+		IndexTableName: "__mo_index_secondary_idx_price",
+	}
+	idxQuantity := &IndexDef{
+		IndexName:      "idx_quantity",
+		Parts:          []string{"quantity", catalog.FakePrimaryKeyColName},
+		Unique:         false,
+		IndexTableName: "__mo_index_secondary_idx_quantity",
+	}
+
+	node := &planpb.Node{
+		BindingTags: []int32{bindTag},
+		TableDef: &planpb.TableDef{
+			Name2ColIndex: map[string]int32{
+				catalog.FakePrimaryKeyColName: 0,
+				"price":                       1,
+				"quantity":                    2,
+			},
+			Cols: []*planpb.ColDef{
+				{Name: catalog.FakePrimaryKeyColName, Typ: planpb.Type{Id: int32(types.T_uint64)}},
+				{Name: "price", Typ: planpb.Type{Id: int32(types.T_int64)}},
+				{Name: "quantity", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			},
+			Pkey:    &planpb.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+			Indexes: []*planpb.IndexDef{idxPrice, idxQuantity},
+		},
+		FilterList: []*planpb.Expr{
+			makeRangeFilterExpr(bindTag, 1, ">=", 100),
+			makeRangeFilterExpr(bindTag, 2, ">=", 10),
+			makeRangeFilterExpr(bindTag, 2, "<=", 20),
+		},
+	}
+
+	idxPos, filterIdx := builder.getIndexForNonEquiCond([]*planpb.IndexDef{idxPrice, idxQuantity}, node)
+	require.Equal(t, 0, idxPos)
+	require.Equal(t, []int32{0}, filterIdx)
+}
+
 func makeEqFilterExpr(colPos int32) *planpb.Expr {
 	return &planpb.Expr{
 		Expr: &planpb.Expr_F{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Ref https://github.com/matrixorigin/matrixone/issues/24348

## What this PR does / why we need it:

#24417 fixed the root cause of PR #24289 by limiting paired range rewrite on table-scan filters to composite sort-key parts only.

This follow-up keeps that behavior unchanged, but removes a small remaining source of nondeterminism in `getIndexForNonEquiCond`: when multiple indexed columns each form a paired range, the previous implementation could pick a candidate based on Go map iteration order.

That did not imply incorrect results, but it could make plan selection and EXPLAIN output drift. This PR makes the choice deterministic by honoring `node.FilterList` order, which matches the old pre-paired-range behavior more closely.

Added a unit test covering the multi-paired-range case.

## Validation

```bash
source /Users/shenjiangwei/Work/code/matrixone/setup_env.sh && go test ./pkg/sql/plan ./pkg/vm/engine/readutil -count=1
```
