### PR TITLE
fix: allow lock tables in transactions

### DIFF
--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -1252,6 +1252,8 @@ func Test_statement_type(t *testing.T) {
 			{&tree.Insert{}},
 			{&tree.BeginTransaction{}},
 			{&tree.ShowTables{}},
+			{&tree.LockTableStmt{}},
+			{&tree.UnLockTableStmt{}},
 			{&tree.Use{}},
 		}
 		ctrl := gomock.NewController(t)
@@ -1267,10 +1269,43 @@ func Test_statement_type(t *testing.T) {
 		convey.So(IsAdministrativeStatement(&tree.CreateAccount{}), convey.ShouldBeTrue)
 		convey.So(IsParameterModificationStatement(&tree.SetVar{}), convey.ShouldBeTrue)
 		convey.So(NeedToBeCommittedInActiveTransaction(&tree.SetVar{}), convey.ShouldBeTrue)
+		convey.So(NeedToBeCommittedInActiveTransaction(&tree.LockTableStmt{}), convey.ShouldBeTrue)
+		convey.So(NeedToBeCommittedInActiveTransaction(&tree.UnLockTableStmt{}), convey.ShouldBeFalse)
 		convey.So(NeedToBeCommittedInActiveTransaction(&tree.DropTable{}), convey.ShouldBeFalse)
 		convey.So(NeedToBeCommittedInActiveTransaction(&tree.CreateAccount{}), convey.ShouldBeTrue)
 		convey.So(NeedToBeCommittedInActiveTransaction(nil), convey.ShouldBeFalse)
 	})
+}
+
+func TestLockTablesSessionState(t *testing.T) {
+	ses := &Session{}
+
+	lockCtx := &ExecCtx{
+		reqCtx: context.Background(),
+		stmt:   &tree.LockTableStmt{},
+	}
+	_, err := execInFrontend(ses, lockCtx)
+	require.NoError(t, err)
+	require.True(t, ses.hasLockedTables.Load())
+	require.False(t, lockCtx.txnOpt.byCommit)
+
+	unlockCtx := &ExecCtx{
+		reqCtx: context.Background(),
+		stmt:   &tree.UnLockTableStmt{},
+	}
+	_, err = execInFrontend(ses, unlockCtx)
+	require.NoError(t, err)
+	require.True(t, unlockCtx.txnOpt.byCommit)
+	require.False(t, ses.hasLockedTables.Load())
+
+	unlockAgainCtx := &ExecCtx{
+		reqCtx: context.Background(),
+		stmt:   &tree.UnLockTableStmt{},
+	}
+	_, err = execInFrontend(ses, unlockAgainCtx)
+	require.NoError(t, err)
+	require.False(t, unlockAgainCtx.txnOpt.byCommit)
+	require.False(t, ses.hasLockedTables.Load())
 }
 
 func Test_convert_type(t *testing.T) {

--- a/pkg/frontend/self_handle.go
+++ b/pkg/frontend/self_handle.go
@@ -492,9 +492,11 @@ func execInFrontend(ses *Session, execCtx *ExecCtx) (stats statistic.StatsArray,
 		defer ses.ExitFPrint(FPSetTransaction)
 		//TODO: handle set transaction
 	case *tree.LockTableStmt:
-
+		ses.hasLockedTables.Store(true)
 	case *tree.UnLockTableStmt:
-
+		if ses.hasLockedTables.Swap(false) {
+			execCtx.txnOpt.byCommit = true
+		}
 	case *tree.BackupStart:
 		ses.EnterFPrint(FPBackupStart)
 		defer ses.ExitFPrint(FPBackupStart)

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -137,7 +137,8 @@ type Session struct {
 	tempTables map[string]string
 	// tempTablesRev records the reverse relationship.
 	// Key: realName, Value: dbName.alias
-	tempTablesRev map[string]string
+	tempTablesRev   map[string]string
+	hasLockedTables atomic.Bool
 
 	prepareStmts map[string]*PrepareStmt
 	lastStmtId   uint32

--- a/pkg/frontend/stmt_kind.go
+++ b/pkg/frontend/stmt_kind.go
@@ -103,7 +103,15 @@ func NeedToBeCommittedInActiveTransaction(stmt tree.Statement) bool {
 	if stmt == nil {
 		return false
 	}
-	return IsCreateDropSequence(stmt) || IsAdministrativeStatement(stmt) || IsParameterModificationStatement(stmt)
+	return IsCreateDropSequence(stmt) || IsAdministrativeStatement(stmt) || IsParameterModificationStatement(stmt) || isLockTableStatement(stmt)
+}
+
+func isLockTableStatement(stmt tree.Statement) bool {
+	switch stmt.(type) {
+	case *tree.LockTableStmt:
+		return true
+	}
+	return false
 }
 
 /*
@@ -218,6 +226,8 @@ func statementCanBeExecutedInUncommittedTransaction(
 		}
 		return statementCanBeExecutedInUncommittedTransaction(ctx, ses, preStmt.PrepareStmt)
 	case *tree.Deallocate, *tree.Reset:
+		return true, nil
+	case *tree.LockTableStmt, *tree.UnLockTableStmt:
 		return true, nil
 	case *tree.Use:
 		/*

--- a/test/distributed/cases/pessimistic_transaction/lock_tables_in_txn.result
+++ b/test/distributed/cases/pessimistic_transaction/lock_tables_in_txn.result
@@ -1,0 +1,46 @@
+drop database if exists issue_23129;
+create database issue_23129;
+use issue_23129;
+create table txn_lock_table (id int primary key, note varchar(20));
+insert into txn_lock_table values (1, 'read');
+start transaction;
+lock tables txn_lock_table read;
+select * from txn_lock_table order by id;
+➤ id[4,32,0]  ¦  note[12,-1,0]  𝄀
+1  ¦  read
+unlock tables;
+commit;
+start transaction;
+lock tables txn_lock_table write;
+insert into txn_lock_table values (2, 'write');
+select * from txn_lock_table order by id;
+➤ id[4,32,0]  ¦  note[12,-1,0]  𝄀
+1  ¦  read  𝄀
+2  ¦  write
+unlock tables;
+commit;
+select * from txn_lock_table order by id;
+➤ id[4,32,0]  ¦  note[12,-1,0]  𝄀
+1  ¦  read  𝄀
+2  ¦  write
+start transaction;
+insert into txn_lock_table values (3, 'before_lock');
+lock tables txn_lock_table write;
+rollback;
+select * from txn_lock_table order by id;
+➤ id[4,32,0]  ¦  note[12,-1,0]  𝄀
+1  ¦  read  𝄀
+2  ¦  write  𝄀
+3  ¦  before_lock
+start transaction;
+lock tables txn_lock_table write;
+insert into txn_lock_table values (4, 'before_unlock');
+unlock tables;
+rollback;
+select * from txn_lock_table order by id;
+➤ id[4,32,0]  ¦  note[12,-1,0]  𝄀
+1  ¦  read  𝄀
+2  ¦  write  𝄀
+3  ¦  before_lock  𝄀
+4  ¦  before_unlock
+drop database issue_23129;

--- a/test/distributed/cases/pessimistic_transaction/lock_tables_in_txn.sql
+++ b/test/distributed/cases/pessimistic_transaction/lock_tables_in_txn.sql
@@ -1,0 +1,36 @@
+drop database if exists issue_23129;
+create database issue_23129;
+use issue_23129;
+
+create table txn_lock_table (id int primary key, note varchar(20));
+insert into txn_lock_table values (1, 'read');
+
+start transaction;
+lock tables txn_lock_table read;
+select * from txn_lock_table order by id;
+unlock tables;
+commit;
+
+start transaction;
+lock tables txn_lock_table write;
+insert into txn_lock_table values (2, 'write');
+select * from txn_lock_table order by id;
+unlock tables;
+commit;
+
+select * from txn_lock_table order by id;
+
+start transaction;
+insert into txn_lock_table values (3, 'before_lock');
+lock tables txn_lock_table write;
+rollback;
+select * from txn_lock_table order by id;
+
+start transaction;
+lock tables txn_lock_table write;
+insert into txn_lock_table values (4, 'before_unlock');
+unlock tables;
+rollback;
+select * from txn_lock_table order by id;
+
+drop database issue_23129;


### PR DESCRIPTION
 ## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) does this PR fix or relate to?

Fixes #23129

## What this PR does / why we need it:

fix: allow lock tables in transactions
