### PR TITLE
fix(plan): guard paired range index selection

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1529,6 +1529,9 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 				lowerIdx, hasLower := colLowerBounds[rangeCol.ColPos]
 				upperIdx, hasUpper := colUpperBounds[rangeCol.ColPos]
 				if hasLower && hasUpper && int32(i) == min(lowerIdx, upperIdx) {
+					if shouldSkipLargeRangeIndexByStats(node) {
+						continue
+					}
 					return idxPos, []int32{lowerIdx, upperIdx}
 				}
 			}
@@ -1537,16 +1540,21 @@ func (builder *QueryBuilder) getIndexForNonEquiCond(indexes []*IndexDef, node *p
 				if numParts > 1 && hasUnsafeRangeOp(fn) {
 					continue
 				}
-				if isRangeOp(fn) && node.Stats != nil && node.Stats.TableCnt >= 50000 {
-					if node.Stats.Selectivity >= InFilterSelectivityLimit || node.Stats.Outcnt >= float64(InFilterCardLimitNonPK) {
-						continue
-					}
+				if isRangeOp(fn) && shouldSkipLargeRangeIndexByStats(node) {
+					continue
 				}
 			}
 			return idxPos, []int32{int32(i)}
 		}
 	}
 	return -1, nil
+}
+
+func shouldSkipLargeRangeIndexByStats(node *plan.Node) bool {
+	if node == nil || node.Stats == nil || node.Stats.TableCnt < 50000 {
+		return false
+	}
+	return node.Stats.Selectivity >= InFilterSelectivityLimit || node.Stats.Outcnt >= float64(InFilterCardLimitNonPK)
 }
 
 // hasUnsafeRangeOp returns true if fn (or any OR arm within it) uses <= or >

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -1019,6 +1019,46 @@ func TestGetIndexForNonEquiCond_DetectsPairedRangeOnIndexColumn(t *testing.T) {
 	require.ElementsMatch(t, []int32{0, 1}, filterIdx)
 }
 
+func TestGetIndexForNonEquiCond_SkipsLargePairedRangeByStats(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	bindTag := builder.genNewBindTag()
+	idxDef := &IndexDef{
+		IndexName:      "idx_price",
+		Parts:          []string{"price", catalog.FakePrimaryKeyColName},
+		Unique:         false,
+		IndexTableName: "__mo_index_secondary_idx_price",
+	}
+
+	node := &planpb.Node{
+		BindingTags: []int32{bindTag},
+		TableDef: &planpb.TableDef{
+			Name2ColIndex: map[string]int32{
+				catalog.FakePrimaryKeyColName: 0,
+				"price":                       1,
+			},
+			Cols: []*planpb.ColDef{
+				{Name: catalog.FakePrimaryKeyColName, Typ: planpb.Type{Id: int32(types.T_uint64)}},
+				{Name: "price", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			},
+			Pkey:    &planpb.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+			Indexes: []*planpb.IndexDef{idxDef},
+		},
+		Stats: &planpb.Stats{
+			TableCnt:    100000,
+			Outcnt:      float64(InFilterCardLimitNonPK),
+			Selectivity: 0.05,
+		},
+		FilterList: []*planpb.Expr{
+			makeRangeFilterExpr(bindTag, 1, ">=", 99),
+			makeRangeFilterExpr(bindTag, 1, "<=", 299),
+		},
+	}
+
+	idxPos, filterIdx := builder.getIndexForNonEquiCond([]*planpb.IndexDef{idxDef}, node)
+	require.Equal(t, -1, idxPos)
+	require.Nil(t, filterIdx)
+}
+
 func TestReplaceRangePairCondition_UsesPrefixBetweenForSecondaryIndex(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
 	bindTag := builder.genNewBindTag()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Ref https://github.com/matrixorigin/matrixone/issues/24348

## What this PR does / why we need it:

Ref https://github.com/matrixorigin/matrixone/issues/24348

The deterministic paired-range path in `getIndexForNonEquiCond` still returned before the existing non-PK range guard ran, so a large secondary-index paired range could bypass the `InFilterCardLimitNonPK` / selectivity cutoff that already protected single-range candidates. On large tables that can reopen the same expensive index-join choice the earlier guard was meant to avoid.

This change applies the same stats guard to paired-range candidates and adds a focused unit test for the large-range case. The planner behavior for small/selective paired ranges is unchanged.

To keep this follow-up low risk, it does not add new distributed BVT cases: the existing `expr_opt_test.go` coverage already checks that non-sort-key composite filters are preserved, and this PR only touches the local secondary-index candidate selection guard.

## Validation

```bash
source /Users/shenjiangwei/Work/code/matrixone/setup_env.sh && go test ./pkg/sql/plan ./pkg/vm/engine/readutil -count=1
```