### PR TITLE
fix: skip full-file preloads for long scans (3.0-dev)

### DIFF
--- a/pkg/vm/engine/readutil/reader.go
+++ b/pkg/vm/engine/readutil/reader.go
@@ -669,12 +669,7 @@ func (r *reader) Read(
 		statsCtx, numRead, numHit = prepareGatherStats(ctx)
 	}
 
-	var policy fileservice.Policy
-
-	if r.readBlockCnt > r.threshHold {
-		policy = fileservice.SkipMemoryCacheWrites
-	}
-	r.readBlockCnt++
+	policy := r.nextBlockReadPolicy()
 
 	if len(r.cacheVectors) == 0 {
 		r.cacheVectors = containers.NewVectors(len(r.columns.seqnums) + 1)
@@ -732,4 +727,15 @@ func GetThresholdForReader(readerNum int) uint64 {
 		return uint64(1024 / readerNum)
 	}
 	return 128
+}
+
+func (r *reader) nextBlockReadPolicy() fileservice.Policy {
+	var policy fileservice.Policy
+	if r.readBlockCnt > r.threshHold {
+		// Long scans should not populate memory cache, nor should they trigger
+		// full-object preloads into disk cache and OS page cache.
+		policy = fileservice.SkipMemoryCacheWrites | fileservice.SkipFullFilePreloads
+	}
+	r.readBlockCnt++
+	return policy
 }

--- a/pkg/vm/engine/readutil/relation_data_test.go
+++ b/pkg/vm/engine/readutil/relation_data_test.go
@@ -15,8 +15,10 @@
 package readutil
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/stretchr/testify/require"
 )
 
 // Add for just pass UT coverage check
@@ -55,6 +57,18 @@ func TestEmptyRelationData(t *testing.T) {
 	})
 
 	require.Equal(t, 0, relData.DataCnt())
+}
+
+func TestReaderNextBlockReadPolicySkipsFullFilePreloadAfterThreshold(t *testing.T) {
+	r := &reader{threshHold: 1}
+
+	require.Zero(t, r.nextBlockReadPolicy())
+	require.Zero(t, r.nextBlockReadPolicy())
+
+	policy := r.nextBlockReadPolicy()
+	require.True(t, policy.Any(fileservice.SkipMemoryCacheWrites))
+	require.True(t, policy.Any(fileservice.SkipFullFilePreloads))
+	require.False(t, policy.CacheFullFile())
 }
 
 //func TestQueryMetadataScan(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24456

## What this PR does / why we need it:

Backport of the long-scan fileservice policy fix to `3.0-dev`.

When a readutil reader exceeds the long-scan threshold, the old code only set `SkipMemoryCacheWrites`. That avoids memory-cache pollution, but it still allows full-file preloads, so small range reads can amplify into full-object disk cache writes and OS page cache growth.

This PR changes the long-scan path to use `SkipMemoryCacheWrites | SkipFullFilePreloads`, which preserves the original intent while preventing the amplification seen on sjb8t. It also adds a focused unit test covering the new policy behavior.
