### PR TITLE
fix: skip full-file preloads for long scans

### DIFF
--- a/pkg/vm/engine/readutil/reader.go
+++ b/pkg/vm/engine/readutil/reader.go
@@ -718,12 +718,7 @@ func (r *reader) Read(
 		statsCtx, numRead, numHit = prepareGatherStats(ctx)
 	}
 
-	var policy fileservice.Policy
-
-	if r.readBlockCnt > r.threshHold {
-		policy = fileservice.SkipMemoryCacheWrites
-	}
-	r.readBlockCnt++
+	policy := r.nextBlockReadPolicy()
 
 	if len(r.cacheVectors) == 0 {
 		r.cacheVectors = containers.NewVectors(len(r.columns.seqnums) + 1)
@@ -781,4 +776,15 @@ func GetThresholdForReader(readerNum int) uint64 {
 		return uint64(1024 / readerNum)
 	}
 	return 128
+}
+
+func (r *reader) nextBlockReadPolicy() fileservice.Policy {
+	var policy fileservice.Policy
+	if r.readBlockCnt > r.threshHold {
+		// Long scans should not populate memory cache, nor should they trigger
+		// full-object preloads into disk cache and OS page cache.
+		policy = fileservice.SkipMemoryCacheWrites | fileservice.SkipFullFilePreloads
+	}
+	r.readBlockCnt++
+	return policy
 }

--- a/pkg/vm/engine/readutil/relation_data_test.go
+++ b/pkg/vm/engine/readutil/relation_data_test.go
@@ -15,8 +15,10 @@
 package readutil
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/stretchr/testify/require"
 )
 
 // Add for just pass UT coverage check
@@ -55,6 +57,18 @@ func TestEmptyRelationData(t *testing.T) {
 	})
 
 	require.Equal(t, 0, relData.DataCnt())
+}
+
+func TestReaderNextBlockReadPolicySkipsFullFilePreloadAfterThreshold(t *testing.T) {
+	r := &reader{threshHold: 1}
+
+	require.Zero(t, r.nextBlockReadPolicy())
+	require.Zero(t, r.nextBlockReadPolicy())
+
+	policy := r.nextBlockReadPolicy()
+	require.True(t, policy.Any(fileservice.SkipMemoryCacheWrites))
+	require.True(t, policy.Any(fileservice.SkipFullFilePreloads))
+	require.False(t, policy.CacheFullFile())
 }
 
 //func TestQueryMetadataScan(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24456

## What this PR does / why we need it:

This fixes a long-standing fileservice policy bug in the readutil long-scan path.

After a reader exceeds the long-scan threshold, the old code only set `SkipMemoryCacheWrites`. That prevents memory-cache pollution, but it still allows full-file preloads, so small range reads can expand into full-object disk cache writes and large OS page cache growth.

The sjb8t incident showed the impact clearly: long-running `mo_cloud.storage` scans entered the `Policy:2` path, full-object preloads amplified small logical reads into whole-object reads (about 190-200x in the parsed slow-event sample), and disk/page-cache usage exploded. pmw44 did not enter the same path.

This PR changes the long-scan policy to `SkipMemoryCacheWrites | SkipFullFilePreloads` and adds a focused test to lock the behavior down.
