### PR TITLE
fix: skip stale merge scheduler todo

### DIFF
--- a/pkg/vm/engine/tae/db/merge/scheduler.go
+++ b/pkg/vm/engine/tae/db/merge/scheduler.go
@@ -1041,6 +1041,16 @@ func (a *MergeScheduler) doSched(todo *todoItem) {
 	}
 
 	supp := a.supps[todo.table.ID()]
+	if supp == nil {
+		// Table metadata commits such as ALTER can enqueue more than one todo
+		// for the same table. If the table is later dropped, another todo may
+		// already have removed its supporter from supps; drop this stale todo
+		// as well so the queue does not keep peeking it.
+		if todo.index >= 0 && todo.index < a.pq.Len() {
+			heap.Remove(&a.pq, todo.index)
+		}
+		return
+	}
 
 	now := a.clock.Now()
 

--- a/pkg/vm/engine/tae/db/merge/scheduler_test.go
+++ b/pkg/vm/engine/tae/db/merge/scheduler_test.go
@@ -15,6 +15,7 @@
 package merge
 
 import (
+	"container/heap"
 	"context"
 	"iter"
 	"testing"
@@ -120,6 +121,29 @@ func TestHandleTaskTriggerNilPointerFixed(t *testing.T) {
 	require.NotPanics(t, func() {
 		scheduler.handleTaskTrigger(msg)
 	}, "Should not panic after moving nil check before vacuum check")
+}
+
+func TestDoSchedNilSupporter(t *testing.T) {
+	scheduler := &MergeScheduler{
+		supps: make(map[uint64]*todoSupporter),
+		clock: NewStdClock(),
+	}
+
+	db := catalog.MockDBEntryWithAccInfo(1, 999)
+	table := catalog.MockTableEntryWithDB(db, 1000)
+	mockTable := catalog.ToMergeTable(table)
+
+	require.NotPanics(t, func() {
+		scheduler.doSched(&todoItem{table: mockTable})
+	})
+
+	todo := &todoItem{table: mockTable, readyAt: scheduler.clock.Now()}
+	heap.Push(&scheduler.pq, todo)
+
+	require.NotPanics(t, func() {
+		scheduler.doSched(todo)
+	})
+	require.Equal(t, 0, scheduler.pq.Len())
 }
 
 func TestScheduler(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24446

Backport of #24449 to v3.0.6-hotfix-20260321.

## What this PR does / why we need it:

Merge scheduler can keep stale todos in its priority queue after repeated table metadata commits enqueue multiple todos for the same table. If a later DROP removes the table supporter from `supps`, `doSched` may still peek an older todo from the queue and panic when it assumes the supporter exists.

This PR skips stale todos whose supporter has already been removed, removing them from the priority queue so the scheduler does not keep peeking the same stale item.

It also adds coverage for the nil-supporter path.

Test:

```
CGO_CFLAGS="-I/home/mo/matrixone/thirdparties/install/include" CGO_LDFLAGS="-L/home/mo/matrixone/thirdparties/install/lib" LD_LIBRARY_PATH="/home/mo/matrixone/thirdparties/install/lib:${LD_LIBRARY_PATH}" go test -mod=mod ./pkg/vm/engine/tae/db/merge
```
