### PR TITLE
fix: zero out event._args before returning events slice to sync.Pool

### DIFF
--- a/pkg/fileservice/event_logger.go
+++ b/pkg/fileservice/event_logger.go
@@ -91,7 +91,14 @@ func LogSlowEvent(ctx context.Context, threshold time.Duration) {
 
 	logger.mu.Lock()
 	defer func() {
-		*logger.events = (*logger.events)[:0]
+		events := *logger.events
+		for i := range events {
+			events[i].args = nil
+			for j := range events[i]._args {
+				events[i]._args[j] = nil
+			}
+		}
+		*logger.events = events[:0]
 		eventsPool.Put(logger.events)
 		logger.events = nil
 		logger.closed = true

--- a/pkg/fileservice/event_logger_test.go
+++ b/pkg/fileservice/event_logger_test.go
@@ -28,6 +28,33 @@ func TestEventLogger(t *testing.T) {
 	LogSlowEvent(ctx, time.Nanosecond)
 }
 
+func TestEventLoggerPoolCleanup(t *testing.T) {
+	// Use a large arg to verify it gets zeroed before pool return.
+	type heavy struct {
+		data [1024]byte
+	}
+	held := &heavy{}
+
+	ctx := context.Background()
+	ctx = WithEventLogger(ctx)
+	LogEvent(ctx, str_to_cache_data_begin, held)
+	LogEvent(ctx, str_to_cache_data_end, held)
+	LogSlowEvent(ctx, time.Nanosecond) // returns slice to pool
+
+	// Grab the slice back from the pool and check all args are nil.
+	events := eventsPool.Get().(*[]event)
+	for i, ev := range *events {
+		if ev.args != nil {
+			t.Errorf("event[%d].args = %v, want nil", i, ev.args)
+		}
+		for j, arg := range ev._args {
+			if arg != nil {
+				t.Errorf("event[%d]._args[%d] = %v, want nil", i, j, arg)
+			}
+		}
+	}
+}
+
 func BenchmarkEventLogger(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ctx := context.Background()

--- a/pkg/fileservice/event_logger_test.go
+++ b/pkg/fileservice/event_logger_test.go
@@ -41,6 +41,8 @@ func TestEventLoggerPoolCleanup(t *testing.T) {
 	LogEvent(ctx, str_to_cache_data_end, held)
 	LogSlowEvent(ctx, time.Nanosecond) // returns slice to pool
 
+	_ = held.data
+
 	// Grab the slice back from the pool and check all args are nil.
 	events := eventsPool.Get().(*[]event)
 	for i, ev := range *events {


### PR DESCRIPTION
## What this PR does / why we need it:

`LogSlowEvent` resets the events slice with `[:0]` before returning it to `eventsPool`, but this only clears the length — the backing array retains stale `interface{}` pointers in `event._args[16]any` slots. These retained references prevent GC from collecting pointed-to objects (`*IOVector`, `[]byte`, etc.), contributing to heap growth under high concurrency.

- Zero out `event.args` and `event._args` for every event before returning the slice to the pool
- Add `TestEventLoggerPoolCleanup` to verify pooled slices are clean on reuse

This fix addresses the retention side (stale pointers in pooled slices), not the allocation rate. Whether this alone resolves the OOM needs stability test verification.

## Which issue(s) this PR fixes:

#24400

## Test plan

- [x] `go test -count=1 ./pkg/fileservice/...` — all pass
- [x] `go test -race -run TestEventLogger` — clean
- [ ] Stability test on a cluster with this patch

___

### **PR Type**

- [ ] Bug
- [ ] Feature
- [x] Improvement
- [ ] Documentation
- [ ] Test and CI
- [ ] Code Refactoring
- [ ] API-change