### PR TITLE
fix: skip full file preload for readutil long scans

### DIFF
--- a/pkg/vm/engine/readutil/reader.go
+++ b/pkg/vm/engine/readutil/reader.go
@@ -669,12 +669,7 @@ func (r *reader) Read(
 		statsCtx, numRead, numHit = prepareGatherStats(ctx)
 	}
 
-	var policy fileservice.Policy
-
-	if r.readBlockCnt > r.threshHold {
-		policy = fileservice.SkipMemoryCacheWrites
-	}
-	r.readBlockCnt++
+	policy := r.nextBlockReadPolicy()
 
 	if len(r.cacheVectors) == 0 {
 		r.cacheVectors = containers.NewVectors(len(r.columns.seqnums) + 1)
@@ -732,4 +727,15 @@ func GetThresholdForReader(readerNum int) uint64 {
 		return uint64(1024 / readerNum)
 	}
 	return 128
+}
+
+func (r *reader) nextBlockReadPolicy() fileservice.Policy {
+	var policy fileservice.Policy
+	if r.readBlockCnt > r.threshHold {
+		// Long scans should not populate memory cache, nor should they trigger
+		// full-object preloads into disk cache and OS page cache.
+		policy = fileservice.SkipMemoryCacheWrites | fileservice.SkipFullFilePreloads
+	}
+	r.readBlockCnt++
+	return policy
 }

--- a/pkg/vm/engine/readutil/relation_data_test.go
+++ b/pkg/vm/engine/readutil/relation_data_test.go
@@ -15,8 +15,10 @@
 package readutil
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/stretchr/testify/require"
 )
 
 // Add for just pass UT coverage check
@@ -55,6 +57,18 @@ func TestEmptyRelationData(t *testing.T) {
 	})
 
 	require.Equal(t, 0, relData.DataCnt())
+}
+
+func TestReaderNextBlockReadPolicySkipsFullFilePreloadAfterThreshold(t *testing.T) {
+	r := &reader{threshHold: 1}
+
+	require.Zero(t, r.nextBlockReadPolicy())
+	require.Zero(t, r.nextBlockReadPolicy())
+
+	policy := r.nextBlockReadPolicy()
+	require.True(t, policy.Any(fileservice.SkipMemoryCacheWrites))
+	require.True(t, policy.Any(fileservice.SkipFullFilePreloads))
+	require.False(t, policy.CacheFullFile())
 }
 
 //func TestQueryMetadataScan(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `SkipFullFilePreloads` to readutil long-scan policy after `readBlockCnt > threshHold`
- preserve existing `SkipMemoryCacheWrites` behavior
- keep the fix scoped to the readutil caller; no fileservice global logic is changed
- add a regression test for the long-scan policy bits

## Root cause
`Policy:2` only skipped memory-cache writes. For readutil long scans, the caller could still trigger full-object preloads into disk cache and OS page cache, amplifying range reads into full-file downloads. The missing caller flag is `SkipFullFilePreloads`; this PR only adds it on the existing long-scan threshold path.

## Tests
- `go test ./pkg/vm/engine/readutil -count=1`