### PR TITLE
cherry-pick: fix unique-key conflict in REPLACE (#24425)

### DIFF
--- a/pkg/sql/plan/bind_replace.go
+++ b/pkg/sql/plan/bind_replace.go
@@ -82,16 +82,15 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 
 	oldColName2Idx := make(map[string][2]int32)
 
+	// Check whether the table has any unique secondary index.
 	// For fake PK tables with no unique indexes (no PK, no UK), REPLACE behaves like INSERT.
 	// Skip the LEFT JOIN to avoid a cross join (empty join condition) that would incorrectly
 	// match and delete all existing rows.
 	hasUniqueIdx := false
-	if isFakePK {
-		for _, idxDef := range tableDef.Indexes {
-			if idxDef.Unique {
-				hasUniqueIdx = true
-				break
-			}
+	for _, idxDef := range tableDef.Indexes {
+		if idxDef.Unique {
+			hasUniqueIdx = true
+			break
 		}
 	}
 
@@ -118,7 +117,11 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 			}
 		}
 	}
-	useMergedMainScan := !isFakePK && !hasMultiPartIdx
+	// Merged-scan is disabled when the table has unique secondary indexes because
+	// a unique-key conflict (without a PK conflict) requires the LEFT JOIN to
+	// retrieve old-row columns for deletion. The merged-scan path only captures
+	// old columns on PK conflict, leaving them NULL when only a UK conflicts.
+	useMergedMainScan := !isFakePK && !hasMultiPartIdx && !hasUniqueIdx
 	if isFakePK && !hasUniqueIdx {
 		// No PK/UK: use NULL expressions for old columns so MULTI_UPDATE only inserts
 		for _, col := range tableDef.Cols {
@@ -302,8 +305,50 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 					},
 				},
 			}
-			cond, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{leftExpr, rightExpr})
-			joinConds = append(joinConds, cond)
+			pkCond, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{leftExpr, rightExpr})
+			joinConds = append(joinConds, pkCond)
+
+			for _, idxDef := range tableDef.Indexes {
+				if !idxDef.Unique {
+					continue
+				}
+				var ukPartConds []*plan.Expr
+				for _, part := range idxDef.Parts {
+					colName := catalog.ResolveAlias(part)
+					colIdx := tableDef.Name2ColIndex[colName]
+					colTyp := tableDef.Cols[colIdx].Typ
+					lExpr := &plan.Expr{
+						Typ: colTyp,
+						Expr: &plan.Expr_Col{
+							Col: &plan.ColRef{
+								RelPos: selectTag,
+								ColPos: colName2Idx[tableDef.Name+"."+colName],
+							},
+						},
+					}
+					rExpr := &plan.Expr{
+						Typ: colTyp,
+						Expr: &plan.Expr_Col{
+							Col: &plan.ColRef{
+								RelPos: oldScanTag,
+								ColPos: colIdx,
+							},
+						},
+					}
+					partCond, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{lExpr, rExpr})
+					ukPartConds = append(ukPartConds, partCond)
+				}
+				var ukCond *plan.Expr
+				if len(ukPartConds) == 1 {
+					ukCond = ukPartConds[0]
+				} else {
+					ukCond = ukPartConds[0]
+					for _, c := range ukPartConds[1:] {
+						ukCond, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "and", []*plan.Expr{ukCond, c})
+					}
+				}
+				joinConds = append(joinConds, ukCond)
+			}
 		}
 
 		var joinOnList []*plan.Expr
@@ -311,8 +356,12 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 			joinOnList = joinConds
 		} else if len(joinConds) > 1 {
 			combined := joinConds[0]
+			combineOp := "and"
+			if !isFakePK {
+				combineOp = "or"
+			}
 			for _, c := range joinConds[1:] {
-				combined, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "and", []*plan.Expr{combined, c})
+				combined, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), combineOp, []*plan.Expr{combined, c})
 			}
 			joinOnList = []*plan.Expr{combined}
 		}

--- a/pkg/sql/plan/index_table_dml_test.go
+++ b/pkg/sql/plan/index_table_dml_test.go
@@ -409,3 +409,129 @@ func TestMultiTableUpdate(t *testing.T) {
 
 	runTestShouldPass(mock, t, sqls, false, false)
 }
+
+// TestBindReplaceWithUniqueSecondaryIndex verifies that REPLACE INTO on a table
+// with both an AUTO_INCREMENT PK and a unique secondary index disables the
+// merged-scan optimization and falls back to the legacy LEFT JOIN path with
+// OR'ed unique-key conditions, so unique-key conflicts can be resolved by
+// deleting the old row instead of raising a duplicate-entry error.
+func TestBindReplaceWithUniqueSecondaryIndex(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	sql := "replace into constraint_test.dept(dname, loc) values ('SALES', 'CHICAGO')"
+
+	stmts, err := mysql.Parse(mock.CurrentContext().GetContext(), sql, 1)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	stmt, ok := stmts[0].(*tree.Replace)
+	require.True(t, ok)
+
+	builder := NewQueryBuilder(planpb.Query_INSERT, mock.CurrentContext(), false, true)
+	bindCtx := NewBindContext(builder, nil)
+
+	dmlCtx := NewDMLContext()
+	objRef, tableDef, err := builder.compCtx.Resolve("constraint_test", "dept", nil)
+	require.NoError(t, err)
+	dmlCtx.objRefs = []*planpb.ObjectRef{objRef}
+	dmlCtx.tableDefs = []*planpb.TableDef{tableDef}
+
+	hasUnique := false
+	for _, idxDef := range tableDef.Indexes {
+		if idxDef.Unique {
+			hasUnique = true
+			break
+		}
+	}
+	require.True(t, hasUnique, "dept table is expected to have a unique secondary index")
+
+	lastNodeID, colName2Idx, skipUniqueIdx, err := builder.initInsertReplaceStmt(
+		bindCtx, stmt.Rows, stmt.Columns, dmlCtx.objRefs[0], dmlCtx.tableDefs[0], true,
+	)
+	require.NoError(t, err)
+
+	rootID, err := builder.appendDedupAndMultiUpdateNodesForBindReplace(
+		bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx,
+	)
+	require.NoError(t, err)
+	require.NotZero(t, rootID)
+
+	leftJoinFound := false
+	leftJoinHasOr := false
+	for _, n := range builder.qry.Nodes {
+		if n.NodeType != planpb.Node_JOIN || n.JoinType != planpb.Node_LEFT {
+			continue
+		}
+		leftJoinFound = true
+		for _, cond := range n.OnList {
+			if f := cond.GetF(); f != nil && f.Func != nil && f.Func.ObjName == "or" {
+				leftJoinHasOr = true
+				break
+			}
+		}
+		if leftJoinHasOr {
+			break
+		}
+	}
+	require.True(t, leftJoinFound, "REPLACE on table with unique secondary index should use legacy LEFT JOIN path")
+	require.True(t, leftJoinHasOr, "LEFT JOIN ON clause should combine PK and UK equality with OR")
+}
+
+// TestBindReplaceWithCompositeUniqueIndex verifies that for tables with a
+// composite unique secondary index the planner generates an AND-chain for the
+// UK parts inside the OR-combined LEFT JOIN ON clause.
+func TestBindReplaceWithCompositeUniqueIndex(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	sql := "replace into constraint_test.dept_composite_uk(dname, loc) values ('SALES', 'CHICAGO')"
+
+	stmts, err := mysql.Parse(mock.CurrentContext().GetContext(), sql, 1)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	stmt, ok := stmts[0].(*tree.Replace)
+	require.True(t, ok)
+
+	builder := NewQueryBuilder(planpb.Query_INSERT, mock.CurrentContext(), false, true)
+	bindCtx := NewBindContext(builder, nil)
+
+	dmlCtx := NewDMLContext()
+	objRef, tableDef, err := builder.compCtx.Resolve("constraint_test", "dept_composite_uk", nil)
+	require.NoError(t, err)
+	dmlCtx.objRefs = []*planpb.ObjectRef{objRef}
+	dmlCtx.tableDefs = []*planpb.TableDef{tableDef}
+
+	lastNodeID, colName2Idx, skipUniqueIdx, err := builder.initInsertReplaceStmt(
+		bindCtx, stmt.Rows, stmt.Columns, dmlCtx.objRefs[0], dmlCtx.tableDefs[0], true,
+	)
+	require.NoError(t, err)
+
+	rootID, err := builder.appendDedupAndMultiUpdateNodesForBindReplace(
+		bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx,
+	)
+	require.NoError(t, err)
+	require.NotZero(t, rootID)
+
+	// The LEFT JOIN ON clause should be: pk_match OR (dname_match AND loc_match).
+	// Verify that the OR node contains an AND child (the composite UK condition).
+	leftJoinFound := false
+	orHasAndChild := false
+	for _, n := range builder.qry.Nodes {
+		if n.NodeType != planpb.Node_JOIN || n.JoinType != planpb.Node_LEFT {
+			continue
+		}
+		leftJoinFound = true
+		for _, cond := range n.OnList {
+			f := cond.GetF()
+			if f == nil || f.Func == nil || f.Func.ObjName != "or" {
+				continue
+			}
+			for _, arg := range f.Args {
+				if af := arg.GetF(); af != nil && af.Func != nil && af.Func.ObjName == "and" {
+					orHasAndChild = true
+				}
+			}
+		}
+		if orHasAndChild {
+			break
+		}
+	}
+	require.True(t, leftJoinFound, "REPLACE on table with composite unique index should use LEFT JOIN path")
+	require.True(t, orHasAndChild, "OR clause should contain an AND child for composite UK parts")
+}

--- a/pkg/sql/plan/mock.go
+++ b/pkg/sql/plan/mock.go
@@ -695,6 +695,48 @@ func NewMockCompilerContext(isDml bool) *MockCompilerContext {
 	}
 
 	/*
+		create table dept_composite_uk(
+			deptno int unsigned auto_increment,
+			dname varchar(15),
+			loc varchar(50),
+			primary key(deptno),
+			unique key uk_dname_loc(dname, loc)
+		);
+	*/
+	constraintTestSchema["dept_composite_uk"] = &Schema{
+		tblId: 88889,
+		cols: []col{
+			{"deptno", types.T_uint32, true, 32, 0},
+			{"dname", types.T_varchar, true, 15, 0},
+			{"loc", types.T_varchar, true, 50, 0},
+			{catalog.Row_ID, types.T_Rowid, true, 0, 0},
+		},
+		pks: []int{0},
+		idxs: []index{
+			{
+				indexName: "uk_dname_loc",
+				tableName: catalog.UniqueIndexTableNamePrefix + "dept-composite-uk-idx",
+				parts:     []string{"dname", "loc"},
+				cols: []col{
+					{catalog.IndexTableIndexColName, types.T_varchar, true, 255, 0},
+				},
+				tableExist: true,
+				unique:     true,
+			},
+		},
+		outcnt: 4,
+	}
+	constraintTestSchema[catalog.UniqueIndexTableNamePrefix+"dept-composite-uk-idx"] = &Schema{
+		cols: []col{
+			{catalog.IndexTableIndexColName, types.T_varchar, true, 255, 0},
+			{catalog.IndexTablePrimaryColName, types.T_uint32, true, 32, 0},
+			{catalog.Row_ID, types.T_Rowid, true, 0, 0},
+		},
+		pks:    []int{0},
+		outcnt: 4,
+	}
+
+	/*
 		create table fake_pk_t (
 			a int,
 			b varchar(64),

--- a/test/distributed/cases/dml/replace/replace.result
+++ b/test/distributed/cases/dml/replace/replace.result
@@ -135,3 +135,42 @@ id    a    b
 1    30    updated
 2    20    second
 drop table t_pk_uk;
+drop table if exists ai_replace_test;
+create table ai_replace_test (id int auto_increment primary key, name varchar(50) unique, value int);
+insert into ai_replace_test (name, value) values ('key1', 100), ('key2', 200);
+replace into ai_replace_test (name, value) values ('key1', 300);
+select * from ai_replace_test order by id;
+id    name    value
+2    key2    200
+3    key1    300
+insert into ai_replace_test (name, value) values ('key3', 400);
+select * from ai_replace_test order by id;
+id    name    value
+2    key2    200
+3    key1    300
+4    key3    400
+drop table ai_replace_test;
+drop table if exists ai_composite_uk;
+create table ai_composite_uk (id int auto_increment primary key, a int, b int, value int, unique key uk_ab(a, b));
+insert into ai_composite_uk (a, b, value) values (1, 1, 100), (1, 2, 150), (2, 2, 200);
+replace into ai_composite_uk (a, b, value) values (1, 1, 300);
+select * from ai_composite_uk order by id;
+id    a    b    value
+2    1    2    150
+3    2    2    200
+4    1    1    300
+drop table ai_composite_uk;
+drop table if exists ai_multi_uk;
+create table ai_multi_uk (id int auto_increment primary key, name varchar(50) unique, email varchar(100) unique, value int);
+insert into ai_multi_uk (name, email, value) values ('n1', 'n1@a.com', 100), ('n2', 'n2@a.com', 200);
+replace into ai_multi_uk (name, email, value) values ('n1', 'n1_new@a.com', 300);
+select * from ai_multi_uk order by id;
+id    name    email    value
+2    n2    n2@a.com    200
+3    n1    n1_new@a.com    300
+replace into ai_multi_uk (name, email, value) values ('n_new', 'n2@a.com', 400);
+select * from ai_multi_uk order by id;
+id    name    email    value
+3    n1    n1_new@a.com    300
+4    n_new    n2@a.com    400
+drop table ai_multi_uk;

--- a/test/distributed/cases/dml/replace/replace.test
+++ b/test/distributed/cases/dml/replace/replace.test
@@ -101,3 +101,35 @@ insert into t_pk_uk values (1, 10, 'first'), (2, 20, 'second');
 replace into t_pk_uk values (1, 30, 'updated');
 select * from t_pk_uk order by id;
 drop table t_pk_uk;
+
+-- test REPLACE on AUTO_INCREMENT table with UNIQUE constraint
+-- only the UNIQUE column conflicts; PK is auto-generated
+drop table if exists ai_replace_test;
+create table ai_replace_test (id int auto_increment primary key, name varchar(50) unique, value int);
+insert into ai_replace_test (name, value) values ('key1', 100), ('key2', 200);
+replace into ai_replace_test (name, value) values ('key1', 300);
+select * from ai_replace_test order by id;
+insert into ai_replace_test (name, value) values ('key3', 400);
+select * from ai_replace_test order by id;
+drop table ai_replace_test;
+
+-- test REPLACE on AUTO_INCREMENT table with composite UNIQUE key
+-- Distractor row (1, 2) shares the first key part with (1, 1) but must NOT be
+-- deleted when REPLACE targets (1, 1). This ensures the planner matches on
+-- ALL composite-key parts, not just the first one.
+drop table if exists ai_composite_uk;
+create table ai_composite_uk (id int auto_increment primary key, a int, b int, value int, unique key uk_ab(a, b));
+insert into ai_composite_uk (a, b, value) values (1, 1, 100), (1, 2, 150), (2, 2, 200);
+replace into ai_composite_uk (a, b, value) values (1, 1, 300);
+select * from ai_composite_uk order by id;
+drop table ai_composite_uk;
+
+-- test REPLACE on AUTO_INCREMENT table with multiple UNIQUE indexes
+drop table if exists ai_multi_uk;
+create table ai_multi_uk (id int auto_increment primary key, name varchar(50) unique, email varchar(100) unique, value int);
+insert into ai_multi_uk (name, email, value) values ('n1', 'n1@a.com', 100), ('n2', 'n2@a.com', 200);
+replace into ai_multi_uk (name, email, value) values ('n1', 'n1_new@a.com', 300);
+select * from ai_multi_uk order by id;
+replace into ai_multi_uk (name, email, value) values ('n_new', 'n2@a.com', 400);
+select * from ai_multi_uk order by id;
+drop table ai_multi_uk;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23144

## What this PR does / why we need it:

Cherry-pick of #24425 to `4.0-dev`.

When executing `REPLACE INTO` on a table with both a primary key (e.g. `AUTO_INCREMENT`) and one or more unique secondary indexes, a row that conflicts **only on a unique key** (no PK conflict) was not detected, so the conflicting old row was never deleted and the subsequent INSERT failed with a duplicate-key error.

### Root cause

In `pkg/sql/plan/bind_replace.go`, `appendDedupAndMultiUpdateNodesForBindReplace` planned the conflict-detection step as follows for tables with a real PK:

- `useMergedMainScan = !isFakePK && !hasMultiPartIdx` → always true for tables with a real PK and no multi-part index.
- The merged-scan path only captures old-row columns when the **PK** matches; UK-only conflicts leave the old columns NULL, so MULTI_UPDATE never deletes the conflicting row.
- The fallback LEFT JOIN path also matched **only on the PK** for non-fake-PK tables, so even when taken it could not detect UK conflicts.

For AUTO_INCREMENT tables the inserted PK is `0` at this stage, so PK matching never finds the old row; combined with the merged-scan path ignoring UK columns, the planner had no way to identify the UK conflict.

### Fix

In `bind_replace.go`:

1. Compute `hasUniqueIdx` for **all** tables (previously only fake-PK tables).
2. Disable the merged-scan path when the table has a unique secondary index: `useMergedMainScan = !isFakePK && !hasMultiPartIdx && !hasUniqueIdx`, forcing the LEFT JOIN path so old-row columns are projected on UK-only conflicts.
3. In the LEFT JOIN ON-list for non-fake-PK tables, emit one condition per conflict source — the PK equality, plus one AND-of-parts equality per unique secondary index — and combine them with **OR**:
   ```
   pk_match OR (uk1_part1 AND uk1_part2 …) OR (uk2_part1 AND …) OR …
   ```
   so the join captures a conflicting old row whether the conflict is via PK or via any UK. Fake-PK tables retain the previous AND-combine semantics.

### Tests

- Unit tests in `pkg/sql/plan/index_table_dml_test.go` covering the planner output for AUTO_INCREMENT + single UK, composite UK, and multiple UK scenarios.
- BVT cases in `test/distributed/cases/dml/replace/replace.test`:
  - REPLACE on AUTO_INCREMENT + single UNIQUE (UK-only conflict).
  - REPLACE on AUTO_INCREMENT + composite UNIQUE key, with a distractor row sharing the first key part to verify the planner matches on **all** composite parts, not just the first.
  - REPLACE on AUTO_INCREMENT + multiple UNIQUE indexes (each REPLACE conflicts via one UK at a time).

### Known limitation (out of scope, tracked in #24428)

A single REPLACE row that simultaneously conflicts with **multiple** existing rows via **different** unique keys still fails (the OR-based LEFT JOIN emits N rows, and `MULTI_UPDATE` treats them as N inserts). This scenario also fails on `main` (with a different failure mode — old rows are never deleted because the merged-scan path only matches on PK), so it is not a regression. Tracked separately in #24428.