### PR TITLE
fix(plan): avoid shuffle for replace capture dedup join

### DIFF
--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -1635,3 +1635,36 @@ func TestReplaceCaptureList_NotEmittedWhenMergedScanDisabled(t *testing.T) {
 		})
 	}
 }
+
+func TestReplaceCaptureDedupJoinDoesNotShuffle(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	logicPlan, err := runOneStmt(mock, t,
+		"REPLACE INTO self_ref VALUES (1, NULL, 'root')")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	query := logicPlan.GetQuery()
+	assert.NotNil(t, query)
+
+	for _, node := range query.Nodes {
+		if node.NodeType != plan.Node_JOIN || node.JoinType != plan.Node_DEDUP {
+			continue
+		}
+		if node.DedupJoinCtx == nil || len(node.DedupJoinCtx.OldColCaptureList) == 0 {
+			continue
+		}
+
+		rightChild := query.Nodes[node.Children[1]]
+		rightChild.Stats.Outcnt = 320001
+		node.Stats = DefaultStats()
+
+		builder := &QueryBuilder{qry: query}
+		determineShuffleForJoin(node, builder)
+
+		assert.False(t, node.Stats.HashmapStats.Shuffle)
+		assert.Equal(t, int32(-1), node.Stats.HashmapStats.ShuffleColIdx)
+		return
+	}
+
+	t.Fatal("expected REPLACE plan to contain a DEDUP JOIN with OldColCaptureList")
+}

--- a/pkg/sql/plan/shuffle.go
+++ b/pkg/sql/plan/shuffle.go
@@ -475,7 +475,11 @@ func determineShuffleForJoin(node *plan.Node, builder *QueryBuilder) {
 
 	switch node.JoinType {
 	case plan.Node_DEDUP:
-		if node.OnDuplicateAction == plan.Node_FAIL && len(node.GetDedupJoinCtx().GetOldColList()) > 0 {
+		dedupJoinCtx := node.GetDedupJoinCtx()
+		if len(dedupJoinCtx.GetOldColCaptureList()) > 0 {
+			return
+		}
+		if node.OnDuplicateAction == plan.Node_FAIL && len(dedupJoinCtx.GetOldColList()) > 0 {
 			return
 		}
 

--- a/pkg/sql/plan/shuffle_test.go
+++ b/pkg/sql/plan/shuffle_test.go
@@ -242,6 +242,68 @@ func TestShouldSkipObjByShuffle(t *testing.T) {
 	ShouldSkipObjByShuffle(rsp, stats)
 }
 
+func TestDetermineShuffleForDedupJoin(t *testing.T) {
+	cases := []struct {
+		name        string
+		dedupCtx    *plan.DedupJoinCtx
+		wantShuffle bool
+	}{
+		{
+			name:        "plain_dedup_join_large_build_side_can_shuffle",
+			dedupCtx:    &plan.DedupJoinCtx{},
+			wantShuffle: true,
+		},
+		{
+			name: "old_col_list_disables_shuffle",
+			dedupCtx: &plan.DedupJoinCtx{
+				OldColList: []plan.ColRef{{RelPos: 1, ColPos: 0}},
+			},
+		},
+		{
+			name: "old_col_capture_list_disables_shuffle",
+			dedupCtx: &plan.DedupJoinCtx{
+				OldColCaptureList: []plan.OldColCapture{
+					{
+						BuildPlaceholder: plan.ColRef{RelPos: 1, ColPos: 0},
+						ProbeSource:      plan.ColRef{RelPos: 2, ColPos: 0},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			builder := &QueryBuilder{
+				qry: &plan.Query{
+					Nodes: []*plan.Node{
+						{Stats: DefaultStats()},
+						{Stats: &plan.Stats{Outcnt: 320001, HashmapStats: &plan.HashMapStats{}}},
+					},
+				},
+			}
+			node := &plan.Node{
+				NodeType:          plan.Node_JOIN,
+				JoinType:          plan.Node_DEDUP,
+				Children:          []int32{0, 1},
+				OnDuplicateAction: plan.Node_FAIL,
+				DedupJoinCtx:      c.dedupCtx,
+				Stats:             DefaultStats(),
+			}
+
+			determineShuffleForJoin(node, builder)
+
+			require.Equal(t, c.wantShuffle, node.Stats.HashmapStats.Shuffle)
+			if c.wantShuffle {
+				require.Equal(t, int32(0), node.Stats.HashmapStats.ShuffleColIdx)
+				require.Equal(t, plan.ShuffleType_Hash, node.Stats.HashmapStats.ShuffleType)
+			} else {
+				require.Equal(t, int32(-1), node.Stats.HashmapStats.ShuffleColIdx)
+			}
+		})
+	}
+}
+
 func TestGetRangeShuffleIndexForZM(t *testing.T) {
 	zm := index2.NewZM(types.T_datetime, 0)
 	defer func() {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24472

## What this PR does / why we need it:

`REPLACE INTO ... SELECT ... FROM` can build a DEDUP join with `OldColCaptureList` on the merged main-table scan path. For large source scans, the planner could still mark that DEDUP join as shuffle, but the compile layer does not support shuffle DEDUP joins with old-column capture and fails with:

```text
shuffle DedupJoin with OldColCapture is not supported
```

This PR disables shuffle planning for DEDUP joins that carry `DedupJoinCtx.OldColCaptureList`, keeping those REPLACE plans on the supported non-shuffle capture path. The existing `OldColList` guard is preserved.

Tests added:

- cover plain large DEDUP joins still being eligible for shuffle
- cover `OldColList` and `OldColCaptureList` disabling shuffle
- cover the actual REPLACE merged-scan plan shape so capture DEDUP joins do not become shuffle plans

Validation:

- `go test ./pkg/sql/plan -run 'TestReplaceCaptureList|TestReplaceCaptureDedupJoinDoesNotShuffle|TestDetermineShuffleForDedupJoin' -count=1`\n- `go test ./pkg/sql/plan -count=1`\n- `git diff --check`\n- `make`\n- `make static-check`