### PR TITLE
fix: guard prepared phy scope shape mismatch

### DIFF
--- a/pkg/sql/compile/analyze_module.go
+++ b/pkg/sql/compile/analyze_module.go
@@ -327,6 +327,9 @@ func UpdatePreparePhyScope(scope *Scope, phyScope models.PhyScope) bool {
 		phyScope.PrepareTimeConsumed = scope.ScopeAnalyzer.TimeConsumed
 	}
 
+	if len(scope.PreScopes) != len(phyScope.PreScopes) {
+		return false
+	}
 	for i, preScope := range scope.PreScopes {
 		res = UpdatePreparePhyScope(preScope, phyScope.PreScopes[i])
 		if !res {
@@ -438,6 +441,9 @@ func UpdatePreparePhyOperator(op vm.Operator, phyOp *models.PhyOperator) bool {
 	if op == nil {
 		return true
 	}
+	if phyOp == nil {
+		return false
+	}
 
 	if op.GetOperatorBase().OpAnalyzer != nil {
 		phyOp.OpStats = op.GetOperatorBase().OpAnalyzer.GetOpStats()
@@ -504,6 +510,9 @@ func (c *Compile) UpdatePreparePhyPlan(runC *Compile) bool {
 	c.anal.phyPlan.RetryTime = runC.anal.retryTimes
 	c.anal.curNodeIdx = runC.anal.curNodeIdx
 
+	if len(runC.scopes) != len(c.anal.phyPlan.LocalScope) {
+		return false
+	}
 	if len(runC.scopes) > 0 {
 		for i := range runC.scopes {
 			res := UpdatePreparePhyScope(runC.scopes[i], c.anal.phyPlan.LocalScope[i])

--- a/pkg/sql/compile/analyze_module_test.go
+++ b/pkg/sql/compile/analyze_module_test.go
@@ -733,6 +733,29 @@ func Test_UpdatePreparePhyScope(t *testing.T) {
 	require.Equal(t, false, res)
 }
 
+func Test_UpdatePreparePhyScopePreScopeShapeMismatch(t *testing.T) {
+	scope := &Scope{
+		PreScopes: []*Scope{{}},
+	}
+	phyScope := models.PhyScope{}
+
+	require.False(t, UpdatePreparePhyScope(scope, phyScope))
+}
+
+func Test_UpdatePreparePhyPlanLocalScopeShapeMismatch(t *testing.T) {
+	c := &Compile{
+		anal: &AnalyzeModule{
+			phyPlan: models.NewPhyPlan(),
+		},
+	}
+	runC := &Compile{
+		anal:   &AnalyzeModule{},
+		scopes: []*Scope{{}},
+	}
+
+	require.False(t, c.UpdatePreparePhyPlan(runC))
+}
+
 func TestHandleTailNodeReceiver(t *testing.T) {
 	buf := bytes.NewBuffer(make([]byte, 0, 300))
 	mp := make(map[*process.WaitRegister]int)


### PR DESCRIPTION
## What type of PR is this?


- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) does this PR fix or relate to?
Fixes #24510

## What this PR does / why we need it:

## Summary
- return false when prepared physical plan local scope/pre-scope/operator shape differs from the runtime scope
- allow AnalyzeExecPlan to regenerate the physical plan instead of panicking on cached plan reuse
- add regression coverage for local scope and pre-scope shape mismatches

## Tests
- CGO_CFLAGS="-I$(pwd)/thirdparties/install/include" CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib" LD_LIBRARY_PATH="$(pwd)/thirdparties/install/lib:${LD_LIBRARY_PATH}" go test ./pkg/sql/compile -count=1