### PR TITLE
fix(preinsert): expand const columns by row count

### DIFF
--- a/pkg/sql/colexec/preinsert/preinsert.go
+++ b/pkg/sql/colexec/preinsert/preinsert.go
@@ -135,7 +135,11 @@ func (preInsert *PreInsert) constructColBuf(proc *proc, bat *batch.Batch, first 
 			} else {
 				preInsert.ctr.buf.Vecs[idx] = vector.NewOffHeapVecWithType(*typ)
 			}
-			if err = vector.GetUnionAllFunction(*typ, proc.Mp())(preInsert.ctr.buf.Vecs[idx], bat.Vecs[idx]); err != nil {
+			cnt := bat.Vecs[idx].Length()
+			if bat.Vecs[idx].IsConst() {
+				cnt = bat.RowCount()
+			}
+			if err = preInsert.ctr.buf.Vecs[idx].UnionBatch(bat.Vecs[idx], 0, cnt, nil, proc.Mp()); err != nil {
 				return err
 			}
 		} else {
@@ -144,7 +148,7 @@ func (preInsert *PreInsert) constructColBuf(proc *proc, bat *batch.Batch, first 
 				//expland const vector
 				typ := bat.Vecs[idx].GetType()
 				tmpVec := vector.NewOffHeapVecWithType(*typ)
-				if err = vector.GetUnionAllFunction(*typ, proc.Mp())(tmpVec, bat.Vecs[idx]); err != nil {
+				if err = tmpVec.UnionBatch(bat.Vecs[idx], 0, bat.RowCount(), nil, proc.Mp()); err != nil {
 					tmpVec.Free(proc.Mp())
 					return err
 				}

--- a/pkg/sql/colexec/preinsert/preinsert_test.go
+++ b/pkg/sql/colexec/preinsert/preinsert_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
@@ -100,6 +101,46 @@ func TestPreInsertNormal(t *testing.T) {
 	argument1.Free(proc, false, nil)
 	proc.Free()
 	require.Equal(t, int64(0), proc.GetMPool().CurrNB())
+}
+
+func TestPreInsertExpandsConstVectorToBatchRowCount(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	arg := &PreInsert{
+		ctr: container{
+			canFreeVecIdx: make(map[int]bool),
+		},
+		TableDef: &plan.TableDef{
+			Cols: []*plan.ColDef{
+				{Name: "id", Typ: i64typ},
+				{Name: "payload", Typ: varchartyp},
+			},
+			Pkey: &plan.PrimaryKeyDef{},
+		},
+		Attrs: []string{"id", "payload"},
+	}
+
+	bat := batch.NewWithSize(2)
+	bat.Vecs[0] = testutil.MakeInt64Vector([]int64{1, 2}, nil, proc.Mp())
+	constVec, err := vector.NewConstBytes(types.T_varchar.ToType(), []byte("{}"), 1, proc.Mp())
+	require.NoError(t, err)
+	bat.Vecs[1] = constVec
+	bat.SetRowCount(2)
+
+	require.NoError(t, arg.constructColBuf(proc, bat, true))
+	require.Equal(t, 2, arg.ctr.buf.Vecs[1].Length())
+
+	bat2 := batch.NewWithSize(2)
+	bat2.Vecs[0] = testutil.MakeInt64Vector([]int64{3, 4, 5}, nil, proc.Mp())
+	constVec2, err := vector.NewConstBytes(types.T_varchar.ToType(), []byte("[]"), 1, proc.Mp())
+	require.NoError(t, err)
+	bat2.Vecs[1] = constVec2
+	bat2.SetRowCount(3)
+
+	require.NoError(t, arg.constructColBuf(proc, bat2, false))
+	require.Equal(t, 3, arg.ctr.buf.Vecs[1].Length())
+	arg.Free(proc, false, nil)
 }
 
 func TestPreInsertNullCheck(t *testing.T) {

--- a/pkg/vm/engine/tae/rpc/handle.go
+++ b/pkg/vm/engine/tae/rpc/handle.go
@@ -894,29 +894,15 @@ func (h *Handle) HandleWrite(
 			return
 		}
 		//check the input batch passed by cn is valid.
-		for i, vec := range req.Batch.Vecs {
-			if vec == nil {
-				logutil.Fatal(
-					"INVALID-INSERT-BATCH-NIL-VEC",
-					zap.Int("idx", i),
-					zap.Uint64("table-id", req.TableID),
-					zap.String("table-name", req.TableName),
-					zap.String("txn", txn.String()),
-				)
-			}
-			if i == 0 {
-				inMemoryInsertRows = vec.Length()
-			}
-			if vec.Length() != inMemoryInsertRows {
-				logutil.Fatal(
-					"INVALID-INSERT-BATCH-DIFF-LENGTH",
-					zap.Int("idx", i),
-					zap.Uint64("table-id", req.TableID),
-					zap.String("table-name", req.TableName),
-					zap.String("rows", fmt.Sprintf("%d/%d", vec.Length(), inMemoryInsertRows)),
-					zap.String("txn", txn.String()),
-				)
-			}
+		if inMemoryInsertRows, err = validateInsertBatch(ctx, req); err != nil {
+			logutil.Error(
+				"invalid insert batch",
+				zap.Error(err),
+				zap.Uint64("table-id", req.TableID),
+				zap.String("table-name", req.TableName),
+				zap.String("txn", txn.String()),
+			)
+			return
 		}
 
 		// TODO: debug for #13342, remove me later
@@ -1054,6 +1040,43 @@ func (h *Handle) HandleWrite(
 	//	}
 	//}
 	err = tb.DeleteByPhyAddrKeys(rowIDVec, pkVec, handle.DT_Normal)
+	return
+}
+
+func validateInsertBatch(ctx context.Context, req *cmd_util.WriteReq) (rows int, err error) {
+	if req.Batch == nil {
+		return 0, moerr.NewInternalErrorf(
+			ctx,
+			"INVALID-INSERT-BATCH-NIL-BATCH table-id=%d table-name=%s",
+			req.TableID,
+			req.TableName,
+		)
+	}
+	for i, vec := range req.Batch.Vecs {
+		if vec == nil {
+			return 0, moerr.NewInternalErrorf(
+				ctx,
+				"INVALID-INSERT-BATCH-NIL-VEC idx=%d table-id=%d table-name=%s",
+				i,
+				req.TableID,
+				req.TableName,
+			)
+		}
+		if i == 0 {
+			rows = vec.Length()
+		}
+		if vec.Length() != rows {
+			return 0, moerr.NewInternalErrorf(
+				ctx,
+				"INVALID-INSERT-BATCH-DIFF-LENGTH idx=%d table-id=%d table-name=%s rows=%d/%d",
+				i,
+				req.TableID,
+				req.TableName,
+				vec.Length(),
+				rows,
+			)
+		}
+	}
 	return
 }
 

--- a/pkg/vm/engine/tae/rpc/handle_validate_test.go
+++ b/pkg/vm/engine/tae/rpc/handle_validate_test.go
@@ -1,0 +1,67 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/cmd_util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateInsertBatchReturnsErrorForInvalidBatch(t *testing.T) {
+	ctx := context.Background()
+	mp := mpool.MustNewZero()
+
+	_, err := validateInsertBatch(ctx, &cmd_util.WriteReq{
+		TableID:   1,
+		TableName: "t",
+	})
+	require.ErrorContains(t, err, "INVALID-INSERT-BATCH-NIL-BATCH")
+
+	_, err = validateInsertBatch(ctx, &cmd_util.WriteReq{
+		TableID:   1,
+		TableName: "t",
+		Batch:     batch.NewWithSize(1),
+	})
+	require.ErrorContains(t, err, "INVALID-INSERT-BATCH-NIL-VEC")
+
+	bat := batch.NewWithSize(2)
+	bat.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_int64.ToType())
+	require.NoError(t, vector.AppendFixed[int64](bat.Vecs[0], 1, false, mp))
+	require.NoError(t, vector.AppendFixed[int64](bat.Vecs[0], 2, false, mp))
+	require.NoError(t, vector.AppendFixed[int64](bat.Vecs[1], 1, false, mp))
+	_, err = validateInsertBatch(ctx, &cmd_util.WriteReq{
+		TableID:   1,
+		TableName: "t",
+		Batch:     bat,
+	})
+	require.ErrorContains(t, err, "INVALID-INSERT-BATCH-DIFF-LENGTH")
+
+	require.NoError(t, vector.AppendFixed[int64](bat.Vecs[1], 2, false, mp))
+	rows, err := validateInsertBatch(ctx, &cmd_util.WriteReq{
+		TableID:   1,
+		TableName: "t",
+		Batch:     bat,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, rows)
+}


### PR DESCRIPTION
 ## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) does this PR fix or relate to?

Fixes #24514

## What this PR does / why we need it:

## Summary
- Match MySQL INSERT ... SELECT behavior by expanding const vectors to the input batch row count in preinsert
- Keep TAE insert batch validation non-fatal as a defensive guard, returning an internal error instead of terminating mo-service if a malformed batch still reaches TN
- Add regression coverage for const-vector expansion and invalid insert batch validation

Fixes #24514

## Tests
- CGO_CFLAGS="-I$(pwd)/thirdparties/install/include" go test ./pkg/sql/colexec/preinsert -run 'TestPreInsertExpandsConstVectorToBatchRowCount|TestPreInsertNormal' -count=1\n- CGO_CFLAGS="-I$(pwd)/thirdparties/install/include" go test ./pkg/vm/engine/tae/rpc -run TestValidateInsertBatchReturnsErrorForInvalidBatch -count=1\n- make build\n- Started mo-service and verified issue INSERT ... SELECT ... WHERE NOT EXISTS SQL, including multi-row SELECT constants and auto-increment ids; service stayed alive\n