### PR TITLE
fix(bootstrap): reconcile deleted tenant upgrade tasks (#24396)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -945,12 +945,12 @@ static-check: config err-check
 	$(CGO_OPTS) golangci-lint run -v -c .golangci.yml ./...
 
 fmtErrs := $(shell grep -onr 'fmt.Errorf' pkg/ --exclude-dir=.git --exclude-dir=vendor \
-				--exclude=*.pb.go --exclude=system_vars.go --exclude=Makefile)
-errNews := $(shell grep -onr 'errors.New' pkg/ --exclude-dir=.git --exclude-dir=vendor \
-				--exclude=*.pb.go --exclude=system_vars.go --exclude=Makefile)
-withTimeout := $(shell grep -onr 'context.WithTimeout' pkg/ --exclude-dir=.git --exclude-dir=vendor \
 				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
-withDeadline := $(shell grep -onr 'context.WithDeadline' pkg/ --exclude-dir=.git --exclude-dir=vendor \
+errNews := $(shell grep -onr 'errors.New' pkg/ --exclude-dir=.git --exclude-dir=vendor \
+				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
+withTimeout := $(shell grep -onr 'context\.WithTimeout[^C]' pkg/ --exclude-dir=.git --exclude-dir=vendor \
+				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
+withDeadline := $(shell grep -onr 'context\.WithDeadline[^C]' pkg/ --exclude-dir=.git --exclude-dir=vendor \
 				--exclude=*.pb.go --exclude=*_test.go --exclude=system_vars.go --exclude=Makefile)
 
 
@@ -967,11 +967,11 @@ ifneq ("$(strip $(fmtErrs))$(strip $(errNews))", "")
  endif
  ifneq ("$(strip $(withTimeout))", "")
  		$(warning 'context.WithTimeout' is found.)
- 		$(warning One of 'context.WithTimeout' is called at: $(shell printf "%s\n" $(errNews) | head -1))
+ 		$(warning One of 'context.WithTimeout' is called at: $(shell printf "%s\n" $(withTimeout) | head -1))
  endif
  ifneq ("$(strip $(withDeadline))", "")
  		$(warning 'context.WithDeadline' is found.)
- 		$(warning One of 'context.WithDeadline' is called at: $(shell printf "%s\n" $(errNews) | head -1))
+ 		$(warning One of 'context.WithDeadline' is called at: $(shell printf "%s\n" $(withDeadline) | head -1))
  endif
 	$(error Use moerr instead.)
 else

--- a/pkg/bootstrap/service_test.go
+++ b/pkg/bootstrap/service_test.go
@@ -501,6 +501,58 @@ func TestDoUpgrade(t *testing.T) {
 	)
 }
 
+func TestPerformUpgradeReturnsWhenTenantUpgradeInProgress(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			b := newServiceForTest(
+				sid,
+				&memLocker{},
+				clock.NewHLCClock(func() int64 { return 0 }, 0),
+				nil,
+				executor.NewMemExecutor(func(sql string) (executor.Result, error) {
+					return executor.Result{}, nil
+				}),
+				func(s *service) {
+					s.handles = append(s.handles, newTestVersionHandler("3.0.1", "3.0.0", versions.Yes, versions.Yes, 2))
+				},
+			)
+
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			txnExecutor := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+				switch {
+				case strings.Contains(sql, "select state from mo_version") &&
+					strings.Contains(sql, "version = '3.0.1'") &&
+					strings.Contains(sql, "version_offset = 2") &&
+					strings.Contains(sql, "for update"):
+					memRes := executor.NewMemResult(
+						[]types.Type{types.New(types.T_int32, 32, 0)},
+						mpool.MustNewZero(),
+					)
+					memRes.NewBatchWithRowCount(1)
+					executor.AppendFixedRows(memRes, 0, []int32{versions.StateCreated})
+					return memRes.GetResult(), nil
+				case strings.Contains(sql, "from mo_upgrade") &&
+					strings.Contains(sql, "final_version = '3.0.1'") &&
+					strings.Contains(sql, "final_version_offset = 2") &&
+					strings.Contains(sql, "order by upgrade_order asc") &&
+					strings.Contains(sql, "for update"):
+					return buildUpgradeVersionResult(100, versions.StateUpgradingTenant, "3.0.0", "3.0.1", 2, 0, versions.Yes, versions.Yes, 3, 1), nil
+				default:
+					return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+				}
+			}, txnOperator)
+
+			completed, err := b.performUpgrade(context.Background(), txnExecutor)
+			require.NoError(t, err)
+			require.False(t, completed)
+		},
+	)
+}
+
 // tolerance test
 func TestUpgradeTenant(t *testing.T) {
 	sid := ""

--- a/pkg/bootstrap/service_upgrade.go
+++ b/pkg/bootstrap/service_upgrade.go
@@ -391,7 +391,7 @@ func (s *service) performUpgrade(
 		case versions.StateUpgradingTenant:
 			// we must wait all tenant upgrade completed, and then upgrade to
 			// next version
-			s.logger.Info("upgrade version in tenant upgrading",
+			s.logger.Debug("upgrade version in tenant upgrading",
 				zap.String("upgrade", u.String()),
 				zap.String("final", final.Version))
 			return false, nil

--- a/pkg/bootstrap/service_upgrade_tenant.go
+++ b/pkg/bootstrap/service_upgrade_tenant.go
@@ -151,7 +151,7 @@ func (s *service) asyncUpgradeTenantTask(ctx context.Context) {
 					return err
 				}
 
-				s.logger.Info("get upgrading tenant version",
+				s.logger.Debug("get upgrading tenant version",
 					zap.String("upgrade", upgrade.String()),
 					zap.Bool("has", ok))
 				if !ok || upgrade.TotalTenant == upgrade.ReadyTenant {
@@ -168,7 +168,7 @@ func (s *service) asyncUpgradeTenantTask(ctx context.Context) {
 				}
 
 				// select task and tenants for update
-				taskID, tenants, createVersions, err := versions.GetUpgradeTenantTasks(upgrade.ID, txn)
+				taskID, tenants, createVersions, hasDeletedTenantTasks, hasConflictTenantTasks, err := versions.GetUpgradeTenantTasks(upgrade.ID, txn)
 				if err != nil {
 					s.logger.Error("failed to load upgrade tenants",
 						zap.String("upgrade", upgrade.String()),
@@ -176,11 +176,64 @@ func (s *service) asyncUpgradeTenantTask(ctx context.Context) {
 					return err
 				}
 
-				s.logger.Info("load upgrade tenants",
+				s.logger.Debug("load upgrade tenants",
 					zap.Int("count", len(tenants)),
 					zap.String("upgrade", upgrade.String()))
 				if len(tenants) == 0 {
-					return nil
+					hasUnreadyTasks, err := versions.HasUnreadyUpgradeTenantTasks(upgrade.ID, txn)
+					if err != nil {
+						s.logger.Error("failed to check remaining tenant upgrade tasks",
+							zap.String("upgrade", upgrade.String()),
+							zap.Error(err))
+						return err
+					}
+					if hasConflictTenantTasks {
+						return nil
+					}
+
+					reconciledDeletedTaskCount := int64(0)
+					if hasUnreadyTasks {
+						reconciledDeletedTaskCount, err = versions.ReconcileDeletedUpgradeTenantTasks(upgrade.ID, txn)
+						if err != nil {
+							s.logger.Error("failed to reconcile deleted tenant upgrade tasks",
+								zap.String("upgrade", upgrade.String()),
+								zap.Error(err))
+							return err
+						}
+						hasUnreadyTasks, err = versions.HasUnreadyUpgradeTenantTasks(upgrade.ID, txn)
+						if err != nil {
+							s.logger.Error("failed to recheck remaining tenant upgrade tasks",
+								zap.String("upgrade", upgrade.String()),
+								zap.Error(err))
+							return err
+						}
+						if hasUnreadyTasks {
+							return nil
+						}
+					}
+
+					reloadedUpgrade, err := versions.GetUpgradeVersionForUpdateByID(upgrade.ID, txn)
+					if err != nil {
+						s.logger.Error("failed to reload upgrade after tenant task reconciliation",
+							zap.String("upgrade", upgrade.String()),
+							zap.Error(err))
+						return err
+					}
+					if reloadedUpgrade.ReadyTenant >= reloadedUpgrade.TotalTenant {
+						return nil
+					}
+					reloadedUpgrade.ReadyTenant = reloadedUpgrade.TotalTenant
+					fields := []zap.Field{
+						zap.String("upgrade", reloadedUpgrade.String()),
+						zap.Int64("reconciled-deleted-task-count", reconciledDeletedTaskCount),
+						zap.Bool("deleted-tenant-tasks-detected", hasDeletedTenantTasks),
+					}
+					if reconciledDeletedTaskCount > 0 {
+						s.logger.Warn("tenant upgrade task counters reconciled to current tenants", fields...)
+					} else {
+						s.logger.Info("tenant upgrade task counters reconciled to current tenants", fields...)
+					}
+					return versions.UpdateVersionUpgradeTasks(reloadedUpgrade, txn)
 				}
 
 				hasUpgradeTenants = true

--- a/pkg/bootstrap/service_upgrade_tenant_test.go
+++ b/pkg/bootstrap/service_upgrade_tenant_test.go
@@ -16,15 +16,20 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/bootstrap/versions"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
 	"github.com/matrixorigin/matrixone/pkg/txn/clock"
@@ -74,4 +79,341 @@ func Test_asyncUpgradeTenantTask(t *testing.T) {
 			b.asyncUpgradeTenantTask(ctx)
 		},
 	)
+}
+
+func Test_asyncUpgradeTenantTask_AutoCompletesDeletedTenantTasks(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			var finalized atomic.Bool
+			var deletedTasksReconciled atomic.Bool
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*20)
+			defer cancel()
+
+			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
+				switch {
+				case strings.Contains(sql, "from mo_upgrade") &&
+					strings.Contains(sql, "where state = 1") &&
+					!strings.Contains(sql, "for update"):
+					return buildUpgradeVersionResult(100, 1, "3.0.0", "3.0.1", 0, 1, 1, 1, 3, 2), nil
+				case strings.Contains(sql, "from mo_upgrade_tenant where from_account_id >= 0"):
+					return buildUpgradeTenantTaskRows([]uint64{200}, []int32{10}, []int32{12}), nil
+				case strings.Contains(sql, "select account_id, create_version from mo_account where account_id >= 10 and account_id <= 12"):
+					return buildUpgradeTenantAccountRows(nil, nil), nil
+				case strings.Contains(sql, "from mo_upgrade_tenant where from_account_id >= 13"):
+					return buildUpgradeTenantTaskRows(nil, nil, nil), nil
+				case strings.Contains(sql, "select 1 from mo_upgrade_tenant where upgrade_id = 100 and ready = 0"):
+					if deletedTasksReconciled.Load() {
+						return executor.Result{}, nil
+					}
+					return buildExistsResult(), nil
+				case strings.Contains(sql, "update mo_upgrade_tenant set ready = 1") &&
+					strings.Contains(sql, "where upgrade_id = 100") &&
+					strings.Contains(sql, "not exists"):
+					deletedTasksReconciled.Store(true)
+					return executor.Result{AffectedRows: 1}, nil
+				case strings.Contains(sql, "from mo_upgrade") &&
+					strings.Contains(sql, "where id = 100 for update"):
+					return buildUpgradeVersionResult(100, 1, "3.0.0", "3.0.1", 0, 1, 1, 1, 3, 2), nil
+				case strings.Contains(sql, "update mo_upgrade set total_tenant = 3, ready_tenant = 3") &&
+					strings.Contains(sql, "state = 2"):
+					finalized.Store(true)
+					cancel()
+					return executor.Result{AffectedRows: 1}, nil
+				default:
+					return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+				}
+			})
+
+			h := newTestVersionHandler("3.0.1", "3.0.0", versions.Yes, versions.Yes, 0)
+			s := newServiceForTest(
+				sid,
+				&memLocker{},
+				clock.NewHLCClock(func() int64 { return 0 }, 0),
+				nil,
+				sqlExecutor,
+				func(s *service) {
+					s.handles = append(s.handles, h)
+				},
+				WithCheckUpgradeTenantDuration(time.Millisecond),
+			)
+
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			s.exec = executor.NewMemExecutor2(func(sql string) (executor.Result, error) {
+				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
+			}, txnOperator)
+
+			s.asyncUpgradeTenantTask(ctx)
+			require.True(t, finalized.Load())
+			require.Zero(t, h.callHandleTenantUpgrade.Load())
+		},
+	)
+}
+
+func Test_asyncUpgradeTenantTask_ReconcilesReadyCountWhenTasksAlreadyFinished(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			var finalized atomic.Bool
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*20)
+			defer cancel()
+
+			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
+				switch {
+				case strings.Contains(sql, "from mo_upgrade") &&
+					strings.Contains(sql, "where state = 1") &&
+					!strings.Contains(sql, "for update"):
+					return buildUpgradeVersionResult(100, 1, "3.0.0", "3.0.1", 0, 1, 1, 1, 3, 2), nil
+				case strings.Contains(sql, "from mo_upgrade_tenant where from_account_id >= 0"):
+					return executor.Result{}, nil
+				case strings.Contains(sql, "select 1 from mo_upgrade_tenant where upgrade_id = 100 and ready = 0"):
+					return executor.Result{}, nil
+				case strings.Contains(sql, "from mo_upgrade") &&
+					strings.Contains(sql, "where id = 100 for update"):
+					return buildUpgradeVersionResult(100, 1, "3.0.0", "3.0.1", 0, 1, 1, 1, 3, 2), nil
+				case strings.Contains(sql, "update mo_upgrade set total_tenant = 3, ready_tenant = 3") &&
+					strings.Contains(sql, "state = 2"):
+					finalized.Store(true)
+					cancel()
+					return executor.Result{AffectedRows: 1}, nil
+				default:
+					return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+				}
+			})
+
+			h := newTestVersionHandler("3.0.1", "3.0.0", versions.Yes, versions.Yes, 0)
+			s := newServiceForTest(
+				sid,
+				&memLocker{},
+				clock.NewHLCClock(func() int64 { return 0 }, 0),
+				nil,
+				sqlExecutor,
+				func(s *service) {
+					s.handles = append(s.handles, h)
+				},
+				WithCheckUpgradeTenantDuration(time.Millisecond),
+			)
+
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			s.exec = executor.NewMemExecutor2(func(sql string) (executor.Result, error) {
+				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
+			}, txnOperator)
+
+			s.asyncUpgradeTenantTask(ctx)
+			require.True(t, finalized.Load())
+			require.Zero(t, h.callHandleTenantUpgrade.Load())
+		},
+	)
+}
+
+func Test_asyncUpgradeTenantTask_SkipsReconcileWhenConflictTasksRemain(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			var reconciled atomic.Bool
+			var upgraded atomic.Bool
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*20)
+			defer cancel()
+
+			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
+				switch {
+				case strings.Contains(sql, "from mo_upgrade") &&
+					strings.Contains(sql, "where state = 1") &&
+					!strings.Contains(sql, "for update"):
+					return buildUpgradeVersionResult(100, 1, "3.0.0", "3.0.1", 0, 1, 1, 1, 3, 2), nil
+				case strings.Contains(sql, "from mo_upgrade_tenant where from_account_id >= 0"):
+					return buildUpgradeTenantTaskRows([]uint64{200}, []int32{10}, []int32{12}), nil
+				case strings.Contains(sql, "select account_id, create_version from mo_account where account_id >= 10 and account_id <= 12"):
+					return executor.Result{}, moerr.NewLockConflictNoCtx()
+				case strings.Contains(sql, "from mo_upgrade_tenant where from_account_id >= 13"):
+					return executor.Result{}, nil
+				case strings.Contains(sql, "select 1 from mo_upgrade_tenant where upgrade_id = 100 and ready = 0"):
+					return buildExistsResult(), nil
+				case strings.Contains(sql, "update mo_upgrade_tenant set ready = 1"):
+					reconciled.Store(true)
+					return executor.Result{AffectedRows: 1}, nil
+				case strings.Contains(sql, "update mo_upgrade set total_tenant = 3, ready_tenant = 3"):
+					upgraded.Store(true)
+					return executor.Result{AffectedRows: 1}, nil
+				default:
+					return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+				}
+			})
+
+			h := newTestVersionHandler("3.0.1", "3.0.0", versions.Yes, versions.Yes, 0)
+			s := newServiceForTest(
+				sid,
+				&memLocker{},
+				clock.NewHLCClock(func() int64 { return 0 }, 0),
+				nil,
+				sqlExecutor,
+				func(s *service) {
+					s.handles = append(s.handles, h)
+				},
+				WithCheckUpgradeTenantDuration(time.Millisecond),
+			)
+
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			s.exec = executor.NewMemExecutor2(func(sql string) (executor.Result, error) {
+				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
+			}, txnOperator)
+
+			s.asyncUpgradeTenantTask(ctx)
+			require.False(t, reconciled.Load())
+			require.False(t, upgraded.Load())
+			require.Zero(t, h.callHandleTenantUpgrade.Load())
+		},
+	)
+}
+
+func Test_asyncUpgradeTenantTask_SkipsAlreadyReconciledUpgradeCounts(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			var upgraded atomic.Bool
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*20)
+			defer cancel()
+
+			sqlExecutor := executor.NewMemExecutor(func(sql string) (executor.Result, error) {
+				switch {
+				case strings.Contains(sql, "from mo_upgrade") &&
+					strings.Contains(sql, "where state = 1") &&
+					!strings.Contains(sql, "for update"):
+					return buildUpgradeVersionResult(100, 1, "3.0.0", "3.0.1", 0, 1, 1, 1, 3, 2), nil
+				case strings.Contains(sql, "from mo_upgrade_tenant where from_account_id >= 0"):
+					return executor.Result{}, nil
+				case strings.Contains(sql, "select 1 from mo_upgrade_tenant where upgrade_id = 100 and ready = 0"):
+					return executor.Result{}, nil
+				case strings.Contains(sql, "from mo_upgrade") &&
+					strings.Contains(sql, "where id = 100 for update"):
+					return buildUpgradeVersionResult(100, 1, "3.0.0", "3.0.1", 0, 1, 1, 1, 3, 3), nil
+				case strings.Contains(sql, "update mo_upgrade set total_tenant = 3, ready_tenant = 3"):
+					upgraded.Store(true)
+					return executor.Result{AffectedRows: 1}, nil
+				default:
+					return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+				}
+			})
+
+			h := newTestVersionHandler("3.0.1", "3.0.0", versions.Yes, versions.Yes, 0)
+			s := newServiceForTest(
+				sid,
+				&memLocker{},
+				clock.NewHLCClock(func() int64 { return 0 }, 0),
+				nil,
+				sqlExecutor,
+				func(s *service) {
+					s.handles = append(s.handles, h)
+				},
+				WithCheckUpgradeTenantDuration(time.Millisecond),
+			)
+
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			s.exec = executor.NewMemExecutor2(func(sql string) (executor.Result, error) {
+				return sqlExecutor.Exec(context.Background(), sql, executor.Options{})
+			}, txnOperator)
+
+			s.asyncUpgradeTenantTask(ctx)
+			require.False(t, upgraded.Load())
+			require.Zero(t, h.callHandleTenantUpgrade.Load())
+		},
+	)
+}
+
+func buildUpgradeVersionResult(
+	id uint64,
+	state int32,
+	fromVersion, toVersion string,
+	finalVersionOffset uint32,
+	upgradeOrder, upgradeCluster, upgradeTenant, totalTenant, readyTenant int32,
+) executor.Result {
+	memRes := executor.NewMemResult(
+		[]types.Type{
+			types.New(types.T_uint64, 64, 0),
+			types.New(types.T_varchar, 50, 0),
+			types.New(types.T_varchar, 50, 0),
+			types.New(types.T_varchar, 50, 0),
+			types.New(types.T_uint32, 32, 0),
+			types.New(types.T_int32, 32, 0),
+			types.New(types.T_int32, 32, 0),
+			types.New(types.T_int32, 32, 0),
+			types.New(types.T_int32, 32, 0),
+			types.New(types.T_int32, 32, 0),
+			types.New(types.T_int32, 32, 0),
+		},
+		mpool.MustNewZero(),
+	)
+	memRes.NewBatchWithRowCount(1)
+	executor.AppendFixedRows(memRes, 0, []uint64{id})
+	executor.AppendStringRows(memRes, 1, []string{fromVersion})
+	executor.AppendStringRows(memRes, 2, []string{toVersion})
+	executor.AppendStringRows(memRes, 3, []string{toVersion})
+	executor.AppendFixedRows(memRes, 4, []uint32{finalVersionOffset})
+	executor.AppendFixedRows(memRes, 5, []int32{state})
+	executor.AppendFixedRows(memRes, 6, []int32{upgradeOrder})
+	executor.AppendFixedRows(memRes, 7, []int32{upgradeCluster})
+	executor.AppendFixedRows(memRes, 8, []int32{upgradeTenant})
+	executor.AppendFixedRows(memRes, 9, []int32{totalTenant})
+	executor.AppendFixedRows(memRes, 10, []int32{readyTenant})
+	return memRes.GetResult()
+}
+
+func buildUpgradeTenantTaskRows(taskIDs []uint64, fromIDs, toIDs []int32) executor.Result {
+	if len(taskIDs) == 0 {
+		return executor.Result{}
+	}
+	memRes := executor.NewMemResult(
+		[]types.Type{
+			types.New(types.T_uint64, 64, 0),
+			types.New(types.T_int32, 32, 0),
+			types.New(types.T_int32, 32, 0),
+		},
+		mpool.MustNewZero(),
+	)
+	memRes.NewBatchWithRowCount(len(taskIDs))
+	executor.AppendFixedRows(memRes, 0, taskIDs)
+	executor.AppendFixedRows(memRes, 1, fromIDs)
+	executor.AppendFixedRows(memRes, 2, toIDs)
+	return memRes.GetResult()
+}
+
+func buildUpgradeTenantAccountRows(tenantIDs []int32, createVersions []string) executor.Result {
+	if len(tenantIDs) == 0 {
+		return executor.Result{}
+	}
+	memRes := executor.NewMemResult(
+		[]types.Type{
+			types.New(types.T_int32, 32, 0),
+			types.New(types.T_varchar, 50, 0),
+		},
+		mpool.MustNewZero(),
+	)
+	memRes.NewBatchWithRowCount(len(tenantIDs))
+	executor.AppendFixedRows(memRes, 0, tenantIDs)
+	executor.AppendStringRows(memRes, 1, createVersions)
+	return memRes.GetResult()
+}
+
+func buildExistsResult() executor.Result {
+	memRes := executor.NewMemResult(
+		[]types.Type{
+			types.New(types.T_int32, 32, 0),
+		},
+		mpool.MustNewZero(),
+	)
+	memRes.NewBatchWithRowCount(1)
+	executor.AppendFixedRows(memRes, 0, []int32{1})
+	return memRes.GetResult()
 }

--- a/pkg/bootstrap/versions/upgrade_tenant_task.go
+++ b/pkg/bootstrap/versions/upgrade_tenant_task.go
@@ -68,13 +68,60 @@ func UpdateUpgradeTenantTaskState(
 	return nil
 }
 
+func ReconcileDeletedUpgradeTenantTasks(
+	upgradeID uint64,
+	txn executor.TxnExecutor) (int64, error) {
+	sql := fmt.Sprintf(`update %s set ready = %d, update_at = current_timestamp()
+		where upgrade_id = %d and ready != %d
+		and not exists (
+			select 1 from mo_account
+			where account_id >= %s.from_account_id
+			  and account_id <= %s.to_account_id
+		)`,
+		catalog.MOUpgradeTenantTable,
+		Yes,
+		upgradeID,
+		Yes,
+		catalog.MOUpgradeTenantTable,
+		catalog.MOUpgradeTenantTable)
+	res, err := txn.Exec(sql, executor.StatementOption{})
+	if err != nil {
+		return 0, err
+	}
+	res.Close()
+	return int64(res.AffectedRows), nil
+}
+
+func HasUnreadyUpgradeTenantTasks(
+	upgradeID uint64,
+	txn executor.TxnExecutor) (bool, error) {
+	sql := fmt.Sprintf("select 1 from %s where upgrade_id = %d and ready = %d limit 1",
+		catalog.MOUpgradeTenantTable,
+		upgradeID,
+		No)
+	res, err := txn.Exec(sql, executor.StatementOption{})
+	if err != nil {
+		return false, err
+	}
+	defer res.Close()
+
+	hasUnready := false
+	res.ReadRows(func(rows int, cols []*vector.Vector) bool {
+		hasUnready = true
+		return false
+	})
+	return hasUnready, nil
+}
+
 func GetUpgradeTenantTasks(
 	upgradeID uint64,
-	txn executor.TxnExecutor) (uint64, []int32, []string, error) {
+	txn executor.TxnExecutor) (uint64, []int32, []string, bool, bool, error) {
 	taskID := uint64(0)
 	tenants := make([]int32, 0)
 	versions := make([]string, 0)
 	after := int32(0)
+	hasDeletedTenantTasks := false
+	hasConflictTenantTasks := false
 	for {
 		sql := fmt.Sprintf("select id, from_account_id, to_account_id from %s where from_account_id >= %d and upgrade_id = %d and ready = %d order by id limit 1",
 			catalog.MOUpgradeTenantTable,
@@ -83,7 +130,7 @@ func GetUpgradeTenantTasks(
 			No)
 		res, err := txn.Exec(sql, executor.StatementOption{})
 		if err != nil {
-			return 0, nil, nil, err
+			return 0, nil, nil, hasDeletedTenantTasks, hasConflictTenantTasks, err
 		}
 		from := int32(-1)
 		to := int32(-1)
@@ -95,18 +142,25 @@ func GetUpgradeTenantTasks(
 		})
 		res.Close()
 		if from == -1 {
-			return 0, nil, nil, nil
+			return 0, nil, nil, hasDeletedTenantTasks, hasConflictTenantTasks, nil
 		}
 
+		tenants = tenants[:0]
+		versions = versions[:0]
 		sql = fmt.Sprintf("select account_id, create_version from mo_account where account_id >= %d and account_id <= %d for update",
 			from, to)
 		res, err = txn.Exec(sql, executor.StatementOption{}.WithWaitPolicy(lock.WaitPolicy_FastFail))
 		if err != nil {
 			if isConflictError(err) {
-				after = to + 1
+				hasConflictTenantTasks = true
+				next, ok := nextUpgradeTenantTaskAfter(to)
+				if !ok {
+					return 0, nil, nil, hasDeletedTenantTasks, hasConflictTenantTasks, nil
+				}
+				after = next
 				continue
 			}
-			return 0, nil, nil, err
+			return 0, nil, nil, hasDeletedTenantTasks, hasConflictTenantTasks, err
 		}
 		res.ReadRows(func(rows int, cols []*vector.Vector) bool {
 			for i := 0; i < rows; i++ {
@@ -116,8 +170,25 @@ func GetUpgradeTenantTasks(
 			return true
 		})
 		res.Close()
-		return taskID, tenants, versions, nil
+		if len(tenants) == 0 {
+			hasDeletedTenantTasks = true
+			next, ok := nextUpgradeTenantTaskAfter(to)
+			if !ok {
+				return 0, nil, nil, hasDeletedTenantTasks, hasConflictTenantTasks, nil
+			}
+			after = next
+			continue
+		}
+		return taskID, tenants, versions, hasDeletedTenantTasks, hasConflictTenantTasks, nil
 	}
+}
+
+func nextUpgradeTenantTaskAfter(accountID int32) (int32, bool) {
+	const maxInt32 = int32(^uint32(0) >> 1)
+	if accountID == maxInt32 {
+		return 0, false
+	}
+	return accountID + 1, true
 }
 
 func GetTenantCreateVersionForUpdate(

--- a/pkg/bootstrap/versions/upgrade_tenant_task_test.go
+++ b/pkg/bootstrap/versions/upgrade_tenant_task_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -32,7 +33,7 @@ import (
 )
 
 func TestGetTenantCreateVersionForUpdate(t *testing.T) {
-	prefixMatchSql := fmt.Sprintf("select create_version from mo_account where account_id = %d for update", catalog.System_Account)
+	prefixMatchSQL := fmt.Sprintf("select create_version from mo_account where account_id = %d for update", catalog.System_Account)
 
 	sid := ""
 	runtime.RunTest(
@@ -41,29 +42,21 @@ func TestGetTenantCreateVersionForUpdate(t *testing.T) {
 			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
 			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
 
-			executor := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
-				if strings.EqualFold(sql, prefixMatchSql) {
-					typs := []types.Type{
-						types.New(types.T_varchar, 50, 0),
-					}
-
-					memRes := executor.NewMemResult(typs, mpool.MustNewZero())
-					memRes.NewBatchWithRowCount(1)
-
-					executor.AppendStringRows(memRes, 0, []string{"1.2.3"})
-					result := memRes.GetResult()
-					return result, nil
+			exec := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+				if strings.EqualFold(sql, prefixMatchSQL) {
+					return buildTenantVersionRows([]string{"1.2.3"}), nil
 				}
 				return executor.Result{}, nil
 			}, txnOperator)
-			_, err := GetTenantCreateVersionForUpdate(int32(catalog.System_Account), executor)
+			_, err := GetTenantCreateVersionForUpdate(int32(catalog.System_Account), exec)
 			require.NoError(t, err)
 		},
 	)
 }
 
 func TestGetTenantVersion(t *testing.T) {
-	prefixMatchSql := fmt.Sprintf("select create_version from mo_account where account_id = %d", catalog.System_Account)
+	prefixMatchSQL := fmt.Sprintf("select create_version from mo_account where account_id = %d", catalog.System_Account)
+
 	sid := ""
 	runtime.RunTest(
 		sid,
@@ -71,23 +64,281 @@ func TestGetTenantVersion(t *testing.T) {
 			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
 			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
 
-			executor := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
-				if strings.EqualFold(sql, prefixMatchSql) {
-					typs := []types.Type{
-						types.New(types.T_varchar, 50, 0),
-					}
-
-					memRes := executor.NewMemResult(typs, mpool.MustNewZero())
-					memRes.NewBatchWithRowCount(1)
-
-					executor.AppendStringRows(memRes, 0, []string{"1.2.3"})
-					result := memRes.GetResult()
-					return result, nil
+			exec := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+				if strings.EqualFold(sql, prefixMatchSQL) {
+					return buildTenantVersionRows([]string{"1.2.3"}), nil
 				}
 				return executor.Result{}, nil
 			}, txnOperator)
-			_, err := GetTenantVersion(int32(catalog.System_Account), executor)
+			_, err := GetTenantVersion(int32(catalog.System_Account), exec)
 			require.NoError(t, err)
 		},
 	)
+}
+
+func TestGetUpgradeTenantTasksSkipsDeletedRanges(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			firstTaskSQL := fmt.Sprintf("select id, from_account_id, to_account_id from %s where from_account_id >= %d and upgrade_id = %d and ready = %d order by id limit 1",
+				catalog.MOUpgradeTenantTable, 0, 10, No)
+			firstTenantSQL := "select account_id, create_version from mo_account where account_id >= 1 and account_id <= 4 for update"
+			secondTaskSQL := fmt.Sprintf("select id, from_account_id, to_account_id from %s where from_account_id >= %d and upgrade_id = %d and ready = %d order by id limit 1",
+				catalog.MOUpgradeTenantTable, 5, 10, No)
+			secondTenantSQL := "select account_id, create_version from mo_account where account_id >= 10 and account_id <= 12 for update"
+
+			exec := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+				switch {
+				case strings.EqualFold(sql, firstTaskSQL):
+					return buildUpgradeTenantTaskResult([]uint64{100}, []int32{1}, []int32{4}), nil
+				case strings.EqualFold(sql, firstTenantSQL):
+					return buildUpgradeTenantRows(nil, nil), nil
+				case strings.EqualFold(sql, secondTaskSQL):
+					return buildUpgradeTenantTaskResult([]uint64{200}, []int32{10}, []int32{12}), nil
+				case strings.EqualFold(sql, secondTenantSQL):
+					return buildUpgradeTenantRows([]int32{10, 12}, []string{"3.0.0", "3.0.0"}), nil
+				default:
+					return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+				}
+			}, txnOperator)
+
+			taskID, tenants, createVersions, hasDeletedTenantTasks, hasConflictTenantTasks, err := GetUpgradeTenantTasks(10, exec)
+			require.NoError(t, err)
+			require.True(t, hasDeletedTenantTasks)
+			require.False(t, hasConflictTenantTasks)
+			require.Equal(t, uint64(200), taskID)
+			require.Equal(t, []int32{10, 12}, tenants)
+			require.Equal(t, []string{"3.0.0", "3.0.0"}, createVersions)
+		},
+	)
+}
+
+func TestGetUpgradeTenantTasksReturnsConflictHint(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			firstTaskSQL := fmt.Sprintf("select id, from_account_id, to_account_id from %s where from_account_id >= %d and upgrade_id = %d and ready = %d order by id limit 1",
+				catalog.MOUpgradeTenantTable, 0, 10, No)
+			firstTenantSQL := "select account_id, create_version from mo_account where account_id >= 1 and account_id <= 4 for update"
+			secondTaskSQL := fmt.Sprintf("select id, from_account_id, to_account_id from %s where from_account_id >= %d and upgrade_id = %d and ready = %d order by id limit 1",
+				catalog.MOUpgradeTenantTable, 5, 10, No)
+			secondTenantSQL := "select account_id, create_version from mo_account where account_id >= 10 and account_id <= 12 for update"
+			finalTaskSQL := fmt.Sprintf("select id, from_account_id, to_account_id from %s where from_account_id >= %d and upgrade_id = %d and ready = %d order by id limit 1",
+				catalog.MOUpgradeTenantTable, 13, 10, No)
+
+			exec := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+				switch {
+				case strings.EqualFold(sql, firstTaskSQL):
+					return buildUpgradeTenantTaskResult([]uint64{100}, []int32{1}, []int32{4}), nil
+				case strings.EqualFold(sql, firstTenantSQL):
+					return executor.Result{}, moerr.NewLockConflictNoCtx()
+				case strings.EqualFold(sql, secondTaskSQL):
+					return buildUpgradeTenantTaskResult([]uint64{200}, []int32{10}, []int32{12}), nil
+				case strings.EqualFold(sql, secondTenantSQL):
+					return buildUpgradeTenantRows(nil, nil), nil
+				case strings.EqualFold(sql, finalTaskSQL):
+					return executor.Result{}, nil
+				default:
+					return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+				}
+			}, txnOperator)
+
+			taskID, tenants, createVersions, hasDeletedTenantTasks, hasConflictTenantTasks, err := GetUpgradeTenantTasks(10, exec)
+			require.NoError(t, err)
+			require.True(t, hasDeletedTenantTasks)
+			require.True(t, hasConflictTenantTasks)
+			require.Zero(t, taskID)
+			require.Nil(t, tenants)
+			require.Nil(t, createVersions)
+		},
+	)
+}
+
+func TestReconcileDeletedUpgradeTenantTasks(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			exec := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+				if strings.Contains(sql, "update mo_upgrade_tenant set ready = 1") &&
+					strings.Contains(sql, "where upgrade_id = 10") &&
+					strings.Contains(sql, "not exists") {
+					return executor.Result{AffectedRows: 2}, nil
+				}
+				return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+			}, txnOperator)
+
+			affected, err := ReconcileDeletedUpgradeTenantTasks(10, exec)
+			require.NoError(t, err)
+			require.Equal(t, int64(2), affected)
+		},
+	)
+}
+
+func TestHasUnreadyUpgradeTenantTasks(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			exec := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+				if strings.Contains(sql, "select 1 from mo_upgrade_tenant where upgrade_id = 10 and ready = 0 limit 1") {
+					return buildExistsResult(), nil
+				}
+				return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+			}, txnOperator)
+
+			hasUnready, err := HasUnreadyUpgradeTenantTasks(10, exec)
+			require.NoError(t, err)
+			require.True(t, hasUnready)
+		},
+	)
+}
+
+func TestGetUpgradeTenantTasksStopsAtMaxInt32Conflict(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			maxInt32 := int32(^uint32(0) >> 1)
+			taskSQL := fmt.Sprintf("select id, from_account_id, to_account_id from %s where from_account_id >= %d and upgrade_id = %d and ready = %d order by id limit 1",
+				catalog.MOUpgradeTenantTable, 0, 10, No)
+			tenantSQL := fmt.Sprintf("select account_id, create_version from mo_account where account_id >= %d and account_id <= %d for update",
+				maxInt32, maxInt32)
+
+			exec := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+				switch {
+				case strings.EqualFold(sql, taskSQL):
+					return buildUpgradeTenantTaskResult([]uint64{100}, []int32{maxInt32}, []int32{maxInt32}), nil
+				case strings.EqualFold(sql, tenantSQL):
+					return executor.Result{}, moerr.NewLockConflictNoCtx()
+				default:
+					return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+				}
+			}, txnOperator)
+
+			taskID, tenants, createVersions, hasDeletedTenantTasks, hasConflictTenantTasks, err := GetUpgradeTenantTasks(10, exec)
+			require.NoError(t, err)
+			require.Zero(t, taskID)
+			require.Nil(t, tenants)
+			require.Nil(t, createVersions)
+			require.False(t, hasDeletedTenantTasks)
+			require.True(t, hasConflictTenantTasks)
+		},
+	)
+}
+
+func TestGetUpgradeTenantTasksStopsAtMaxInt32DeletedRange(t *testing.T) {
+	sid := ""
+	runtime.RunTest(
+		sid,
+		func(rt runtime.Runtime) {
+			txnOperator := mock_frontend.NewMockTxnOperator(gomock.NewController(t))
+			txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{CN: sid}).AnyTimes()
+
+			maxInt32 := int32(^uint32(0) >> 1)
+			taskSQL := fmt.Sprintf("select id, from_account_id, to_account_id from %s where from_account_id >= %d and upgrade_id = %d and ready = %d order by id limit 1",
+				catalog.MOUpgradeTenantTable, 0, 10, No)
+			tenantSQL := fmt.Sprintf("select account_id, create_version from mo_account where account_id >= %d and account_id <= %d for update",
+				maxInt32, maxInt32)
+
+			exec := executor.NewMemTxnExecutor(func(sql string) (executor.Result, error) {
+				switch {
+				case strings.EqualFold(sql, taskSQL):
+					return buildUpgradeTenantTaskResult([]uint64{100}, []int32{maxInt32}, []int32{maxInt32}), nil
+				case strings.EqualFold(sql, tenantSQL):
+					return executor.Result{}, nil
+				default:
+					return executor.Result{}, fmt.Errorf("unexpected sql: %s", sql)
+				}
+			}, txnOperator)
+
+			taskID, tenants, createVersions, hasDeletedTenantTasks, hasConflictTenantTasks, err := GetUpgradeTenantTasks(10, exec)
+			require.NoError(t, err)
+			require.Zero(t, taskID)
+			require.Nil(t, tenants)
+			require.Nil(t, createVersions)
+			require.True(t, hasDeletedTenantTasks)
+			require.False(t, hasConflictTenantTasks)
+		},
+	)
+}
+
+func buildExistsResult() executor.Result {
+	memRes := executor.NewMemResult(
+		[]types.Type{
+			types.New(types.T_int32, 32, 0),
+		},
+		mpool.MustNewZero(),
+	)
+	memRes.NewBatchWithRowCount(1)
+	executor.AppendFixedRows(memRes, 0, []int32{1})
+	return memRes.GetResult()
+}
+
+func buildTenantVersionRows(versions []string) executor.Result {
+	if len(versions) == 0 {
+		return executor.Result{}
+	}
+	memRes := executor.NewMemResult(
+		[]types.Type{
+			types.New(types.T_varchar, 50, 0),
+		},
+		mpool.MustNewZero(),
+	)
+	memRes.NewBatchWithRowCount(len(versions))
+	executor.AppendStringRows(memRes, 0, versions)
+	return memRes.GetResult()
+}
+
+func buildUpgradeTenantTaskResult(taskIDs []uint64, fromIDs, toIDs []int32) executor.Result {
+	if len(taskIDs) == 0 {
+		return executor.Result{}
+	}
+	memRes := executor.NewMemResult(
+		[]types.Type{
+			types.New(types.T_uint64, 64, 0),
+			types.New(types.T_int32, 32, 0),
+			types.New(types.T_int32, 32, 0),
+		},
+		mpool.MustNewZero(),
+	)
+	memRes.NewBatchWithRowCount(len(taskIDs))
+	executor.AppendFixedRows(memRes, 0, taskIDs)
+	executor.AppendFixedRows(memRes, 1, fromIDs)
+	executor.AppendFixedRows(memRes, 2, toIDs)
+	return memRes.GetResult()
+}
+
+func buildUpgradeTenantRows(tenantIDs []int32, createVersions []string) executor.Result {
+	if len(tenantIDs) == 0 {
+		return executor.Result{}
+	}
+	memRes := executor.NewMemResult(
+		[]types.Type{
+			types.New(types.T_int32, 32, 0),
+			types.New(types.T_varchar, 50, 0),
+		},
+		mpool.MustNewZero(),
+	)
+	memRes.NewBatchWithRowCount(len(tenantIDs))
+	executor.AppendFixedRows(memRes, 0, tenantIDs)
+	executor.AppendStringRows(memRes, 1, createVersions)
+	return memRes.GetResult()
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixflow/issues/10214

## What this PR does / why we need it:
The tenant upgrade framework can get stuck when tenant upgrade tasks reference tenants that were deleted after the task ranges were generated. In that case `ready_tenant` can stay below `total_tenant` forever, and the upgrade framework keeps polling and emitting repetitive INFO logs.

This PR fixes that by:
- distinguishing deleted-task scans from live-task lock conflicts while selecting tenant upgrade work;
- reconciling upgrade counters when only deleted tenants remain, or when all tasks are already ready but the counters lag behind;
- lowering the hottest tenant-upgrade polling logs from INFO to DEBUG;
- adding tests for deleted-task skipping, conflict detection, and counter reconciliation.