### PR TITLE
fix(insert): keep memory pressure flush concurrency fixed

### DIFF
--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -17,7 +17,6 @@ package insert
 import (
 	"bytes"
 	"context"
-	goruntime "runtime"
 	"sync/atomic"
 	"time"
 
@@ -37,21 +36,11 @@ import (
 // flushSemaphore limits concurrent flushS3WriterOnMemoryPressure calls to
 // prevent thundering-herd mpool explosion when many workers are denied memory
 // simultaneously and all try to flush + read objectio metadata at once.
-var flushSemaphore = make(chan struct{}, flushConcurrency())
-var flushBypassSemaphore = make(chan struct{}, 1)
+const flushConcurrencyLimit = 4
+
+var flushSemaphore = make(chan struct{}, flushConcurrencyLimit)
 var flushSemaphoreAcquireTimeout = 200 * time.Millisecond
 var flushBypassRetryInterval = 20 * time.Millisecond
-
-func flushConcurrency() int {
-	n := goruntime.GOMAXPROCS(0) / 2
-	if n < 4 {
-		n = 4
-	}
-	if n > 16 {
-		n = 16
-	}
-	return n
-}
 
 const opName = "insert"
 
@@ -348,10 +337,8 @@ func acquireFlushSlot(ctx context.Context) (func(), error) {
 		select {
 		case flushSemaphore <- struct{}{}:
 			return func() { <-flushSemaphore }, nil
-		case flushBypassSemaphore <- struct{}{}:
-			v2.TxnStatementInsertS3FlushBypassCounter.Add(1)
-			return func() { <-flushBypassSemaphore }, nil
 		case <-ticker.C:
+			v2.TxnStatementInsertS3FlushBypassCounter.Add(1)
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}

--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -44,7 +44,6 @@ const (
 
 var flushSemaphore = make(chan struct{}, flushConcurrency())
 var flushSemaphoreAcquireTimeout = 200 * time.Millisecond
-var flushBypassRetryInterval = 20 * time.Millisecond
 
 func flushConcurrency() int {
 	return flushConcurrencyForGOMAXPROCS(goruntime.GOMAXPROCS(0))
@@ -350,14 +349,10 @@ func acquireFlushSlot(ctx context.Context) (func(), error) {
 		return nil, ctx.Err()
 	}
 
-	ticker := time.NewTicker(flushBypassRetryInterval)
-	defer ticker.Stop()
 	for {
 		select {
 		case flushSemaphore <- struct{}{}:
 			return func() { <-flushSemaphore }, nil
-		case <-ticker.C:
-			v2.TxnStatementInsertS3FlushBypassCounter.Add(1)
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}

--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	goruntime "runtime"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -42,8 +43,49 @@ const (
 	maxFlushConcurrencyLimit = 16
 )
 
-var flushSemaphore = make(chan struct{}, flushConcurrency())
+type flushLimiter struct {
+	mu     sync.Mutex
+	inUse  int
+	notify chan struct{}
+}
+
+var flushLimiterState = newFlushLimiter()
+var flushConcurrencyForAcquire = flushConcurrency
 var flushSemaphoreAcquireTimeout = 200 * time.Millisecond
+var flushConcurrencyRefreshInterval = 20 * time.Millisecond
+
+func newFlushLimiter() *flushLimiter {
+	return &flushLimiter{notify: make(chan struct{})}
+}
+
+func (l *flushLimiter) tryAcquire() (func(), <-chan struct{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.inUse < flushConcurrencyForAcquire() {
+		l.inUse++
+		return l.release, nil
+	}
+	return nil, l.notify
+}
+
+func (l *flushLimiter) release() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.inUse <= 0 {
+		panic("flush limiter released without acquire")
+	}
+	l.inUse--
+	close(l.notify)
+	l.notify = make(chan struct{})
+}
+
+func (l *flushLimiter) inUseCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.inUse
+}
 
 func flushConcurrency() int {
 	return flushConcurrencyForGOMAXPROCS(goruntime.GOMAXPROCS(0))
@@ -341,18 +383,31 @@ func acquireFlushSlot(ctx context.Context) (func(), error) {
 	timer := time.NewTimer(flushSemaphoreAcquireTimeout)
 	defer timer.Stop()
 
-	select {
-	case flushSemaphore <- struct{}{}:
-		return func() { <-flushSemaphore }, nil
-	case <-timer.C:
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	for {
+		release, waitCh := flushLimiterState.tryAcquire()
+		if release != nil {
+			return release, nil
+		}
+		select {
+		case <-waitCh:
+		case <-timer.C:
+			goto retry
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 
+retry:
+	ticker := time.NewTicker(flushConcurrencyRefreshInterval)
+	defer ticker.Stop()
 	for {
+		release, waitCh := flushLimiterState.tryAcquire()
+		if release != nil {
+			return release, nil
+		}
 		select {
-		case flushSemaphore <- struct{}{}:
-			return func() { <-flushSemaphore }, nil
+		case <-waitCh:
+		case <-ticker.C:
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}

--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -17,6 +17,7 @@ package insert
 import (
 	"bytes"
 	"context"
+	goruntime "runtime"
 	"sync/atomic"
 	"time"
 
@@ -36,11 +37,29 @@ import (
 // flushSemaphore limits concurrent flushS3WriterOnMemoryPressure calls to
 // prevent thundering-herd mpool explosion when many workers are denied memory
 // simultaneously and all try to flush + read objectio metadata at once.
-const flushConcurrencyLimit = 4
+const (
+	minFlushConcurrencyLimit = 4
+	maxFlushConcurrencyLimit = 16
+)
 
-var flushSemaphore = make(chan struct{}, flushConcurrencyLimit)
+var flushSemaphore = make(chan struct{}, flushConcurrency())
 var flushSemaphoreAcquireTimeout = 200 * time.Millisecond
 var flushBypassRetryInterval = 20 * time.Millisecond
+
+func flushConcurrency() int {
+	return flushConcurrencyForGOMAXPROCS(goruntime.GOMAXPROCS(0))
+}
+
+func flushConcurrencyForGOMAXPROCS(gomaxprocs int) int {
+	n := gomaxprocs / 2
+	if n < minFlushConcurrencyLimit {
+		n = minFlushConcurrencyLimit
+	}
+	if n > maxFlushConcurrencyLimit {
+		n = maxFlushConcurrencyLimit
+	}
+	return n
+}
 
 const opName = "insert"
 

--- a/pkg/sql/colexec/insert/insert_test.go
+++ b/pkg/sql/colexec/insert/insert_test.go
@@ -394,49 +394,65 @@ func TestInsertFlushS3WriterOnMemoryPressureAppendsBlockInfo(t *testing.T) {
 	require.Greater(t, insert.ctr.buf.RowCount(), 0)
 }
 
-func TestAcquireFlushSlotUsesBoundedBypassAfterTimeout(t *testing.T) {
+func TestAcquireFlushSlotWaitsForFlushSlotAfterTimeout(t *testing.T) {
 	oldFlushSemaphore := flushSemaphore
-	oldBypassSemaphore := flushBypassSemaphore
 	oldAcquireTimeout := flushSemaphoreAcquireTimeout
 	oldRetryInterval := flushBypassRetryInterval
 	defer func() {
 		flushSemaphore = oldFlushSemaphore
-		flushBypassSemaphore = oldBypassSemaphore
 		flushSemaphoreAcquireTimeout = oldAcquireTimeout
 		flushBypassRetryInterval = oldRetryInterval
 	}()
 
 	flushSemaphore = make(chan struct{}, 1)
-	flushBypassSemaphore = make(chan struct{}, 1)
 	flushSemaphoreAcquireTimeout = time.Millisecond
 	flushBypassRetryInterval = time.Millisecond
 	flushSemaphore <- struct{}{}
 
-	release, err := acquireFlushSlot(context.Background())
-	require.NoError(t, err)
-	require.Len(t, flushBypassSemaphore, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	releaseCh := make(chan func(), 1)
+	go func() {
+		release, err := acquireFlushSlot(ctx)
+		if release != nil {
+			releaseCh <- release
+		}
+		errCh <- err
+	}()
+
+	require.Never(t, func() bool {
+		return len(releaseCh) > 0
+	}, 5*time.Millisecond, time.Millisecond)
+	require.Len(t, flushSemaphore, 1)
+	<-flushSemaphore
+
+	release := <-releaseCh
+	require.NoError(t, <-errCh)
+	require.Len(t, flushSemaphore, 1)
 	release()
-	require.Len(t, flushBypassSemaphore, 0)
+	require.Len(t, flushSemaphore, 0)
+}
+
+func TestFlushConcurrencyLimitIsStable(t *testing.T) {
+	require.Equal(t, 4, flushConcurrencyLimit)
+	require.Equal(t, flushConcurrencyLimit, cap(flushSemaphore))
 }
 
 func TestAcquireFlushSlotWaitsWhenNormalAndBypassAreFull(t *testing.T) {
 	oldFlushSemaphore := flushSemaphore
-	oldBypassSemaphore := flushBypassSemaphore
 	oldAcquireTimeout := flushSemaphoreAcquireTimeout
 	oldRetryInterval := flushBypassRetryInterval
 	defer func() {
 		flushSemaphore = oldFlushSemaphore
-		flushBypassSemaphore = oldBypassSemaphore
 		flushSemaphoreAcquireTimeout = oldAcquireTimeout
 		flushBypassRetryInterval = oldRetryInterval
 	}()
 
 	flushSemaphore = make(chan struct{}, 1)
-	flushBypassSemaphore = make(chan struct{}, 1)
 	flushSemaphoreAcquireTimeout = time.Millisecond
 	flushBypassRetryInterval = time.Millisecond
 	flushSemaphore <- struct{}{}
-	flushBypassSemaphore <- struct{}{}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
@@ -452,7 +468,6 @@ func TestAcquireFlushSlotWaitsWhenNormalAndBypassAreFull(t *testing.T) {
 	cancel()
 	require.ErrorIs(t, <-errCh, context.Canceled)
 	require.Len(t, flushSemaphore, 1)
-	require.Len(t, flushBypassSemaphore, 1)
 }
 
 func testInsertS3TableDef() *plan.TableDef {

--- a/pkg/sql/colexec/insert/insert_test.go
+++ b/pkg/sql/colexec/insert/insert_test.go
@@ -434,9 +434,12 @@ func TestAcquireFlushSlotWaitsForFlushSlotAfterTimeout(t *testing.T) {
 	require.Len(t, flushSemaphore, 0)
 }
 
-func TestFlushConcurrencyLimitIsStable(t *testing.T) {
-	require.Equal(t, 4, flushConcurrencyLimit)
-	require.Equal(t, flushConcurrencyLimit, cap(flushSemaphore))
+func TestFlushConcurrencyLimitScalesWithGOMAXPROCS(t *testing.T) {
+	require.Equal(t, minFlushConcurrencyLimit, flushConcurrencyForGOMAXPROCS(1))
+	require.Equal(t, minFlushConcurrencyLimit, flushConcurrencyForGOMAXPROCS(8))
+	require.Equal(t, 8, flushConcurrencyForGOMAXPROCS(16))
+	require.Equal(t, maxFlushConcurrencyLimit, flushConcurrencyForGOMAXPROCS(64))
+	require.Equal(t, flushConcurrency(), cap(flushSemaphore))
 }
 
 func TestAcquireFlushSlotWaitsWhenNormalAndBypassAreFull(t *testing.T) {

--- a/pkg/sql/colexec/insert/insert_test.go
+++ b/pkg/sql/colexec/insert/insert_test.go
@@ -16,6 +16,7 @@ package insert
 
 import (
 	"context"
+	goruntime "runtime"
 	"testing"
 	"time"
 
@@ -395,16 +396,24 @@ func TestInsertFlushS3WriterOnMemoryPressureAppendsBlockInfo(t *testing.T) {
 }
 
 func TestAcquireFlushSlotWaitsForFlushSlotAfterTimeout(t *testing.T) {
-	oldFlushSemaphore := flushSemaphore
+	oldFlushLimiterState := flushLimiterState
+	oldFlushConcurrencyForAcquire := flushConcurrencyForAcquire
 	oldAcquireTimeout := flushSemaphoreAcquireTimeout
+	oldRefreshInterval := flushConcurrencyRefreshInterval
 	defer func() {
-		flushSemaphore = oldFlushSemaphore
+		flushLimiterState = oldFlushLimiterState
+		flushConcurrencyForAcquire = oldFlushConcurrencyForAcquire
 		flushSemaphoreAcquireTimeout = oldAcquireTimeout
+		flushConcurrencyRefreshInterval = oldRefreshInterval
 	}()
 
-	flushSemaphore = make(chan struct{}, 1)
+	flushLimiterState = newFlushLimiter()
+	flushConcurrencyForAcquire = func() int { return 1 }
 	flushSemaphoreAcquireTimeout = time.Millisecond
-	flushSemaphore <- struct{}{}
+	flushConcurrencyRefreshInterval = time.Millisecond
+	heldRelease, waitCh := flushLimiterState.tryAcquire()
+	require.NotNil(t, heldRelease)
+	require.Nil(t, waitCh)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -421,14 +430,14 @@ func TestAcquireFlushSlotWaitsForFlushSlotAfterTimeout(t *testing.T) {
 	require.Never(t, func() bool {
 		return len(releaseCh) > 0
 	}, 5*time.Millisecond, time.Millisecond)
-	require.Len(t, flushSemaphore, 1)
-	<-flushSemaphore
+	require.Equal(t, 1, flushLimiterState.inUseCount())
+	heldRelease()
 
 	release := <-releaseCh
 	require.NoError(t, <-errCh)
-	require.Len(t, flushSemaphore, 1)
+	require.Equal(t, 1, flushLimiterState.inUseCount())
 	release()
-	require.Len(t, flushSemaphore, 0)
+	require.Equal(t, 0, flushLimiterState.inUseCount())
 }
 
 func TestFlushConcurrencyLimitScalesWithGOMAXPROCS(t *testing.T) {
@@ -436,20 +445,35 @@ func TestFlushConcurrencyLimitScalesWithGOMAXPROCS(t *testing.T) {
 	require.Equal(t, minFlushConcurrencyLimit, flushConcurrencyForGOMAXPROCS(8))
 	require.Equal(t, 8, flushConcurrencyForGOMAXPROCS(16))
 	require.Equal(t, maxFlushConcurrencyLimit, flushConcurrencyForGOMAXPROCS(64))
-	require.Equal(t, flushConcurrency(), cap(flushSemaphore))
+
+	oldGOMAXPROCS := goruntime.GOMAXPROCS(0)
+	defer goruntime.GOMAXPROCS(oldGOMAXPROCS)
+	goruntime.GOMAXPROCS(16)
+	require.Equal(t, 8, flushConcurrencyForAcquire())
+	goruntime.GOMAXPROCS(64)
+	require.Equal(t, maxFlushConcurrencyLimit, flushConcurrencyForAcquire())
 }
 
 func TestAcquireFlushSlotWaitsWhenNormalSlotsAreFull(t *testing.T) {
-	oldFlushSemaphore := flushSemaphore
+	oldFlushLimiterState := flushLimiterState
+	oldFlushConcurrencyForAcquire := flushConcurrencyForAcquire
 	oldAcquireTimeout := flushSemaphoreAcquireTimeout
+	oldRefreshInterval := flushConcurrencyRefreshInterval
 	defer func() {
-		flushSemaphore = oldFlushSemaphore
+		flushLimiterState = oldFlushLimiterState
+		flushConcurrencyForAcquire = oldFlushConcurrencyForAcquire
 		flushSemaphoreAcquireTimeout = oldAcquireTimeout
+		flushConcurrencyRefreshInterval = oldRefreshInterval
 	}()
 
-	flushSemaphore = make(chan struct{}, 1)
+	flushLimiterState = newFlushLimiter()
+	flushConcurrencyForAcquire = func() int { return 1 }
 	flushSemaphoreAcquireTimeout = time.Millisecond
-	flushSemaphore <- struct{}{}
+	flushConcurrencyRefreshInterval = time.Millisecond
+	heldRelease, waitCh := flushLimiterState.tryAcquire()
+	require.NotNil(t, heldRelease)
+	require.Nil(t, waitCh)
+	defer heldRelease()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
@@ -464,7 +488,7 @@ func TestAcquireFlushSlotWaitsWhenNormalSlotsAreFull(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 	cancel()
 	require.ErrorIs(t, <-errCh, context.Canceled)
-	require.Len(t, flushSemaphore, 1)
+	require.Equal(t, 1, flushLimiterState.inUseCount())
 }
 
 func testInsertS3TableDef() *plan.TableDef {

--- a/pkg/sql/colexec/insert/insert_test.go
+++ b/pkg/sql/colexec/insert/insert_test.go
@@ -397,16 +397,13 @@ func TestInsertFlushS3WriterOnMemoryPressureAppendsBlockInfo(t *testing.T) {
 func TestAcquireFlushSlotWaitsForFlushSlotAfterTimeout(t *testing.T) {
 	oldFlushSemaphore := flushSemaphore
 	oldAcquireTimeout := flushSemaphoreAcquireTimeout
-	oldRetryInterval := flushBypassRetryInterval
 	defer func() {
 		flushSemaphore = oldFlushSemaphore
 		flushSemaphoreAcquireTimeout = oldAcquireTimeout
-		flushBypassRetryInterval = oldRetryInterval
 	}()
 
 	flushSemaphore = make(chan struct{}, 1)
 	flushSemaphoreAcquireTimeout = time.Millisecond
-	flushBypassRetryInterval = time.Millisecond
 	flushSemaphore <- struct{}{}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -442,19 +439,16 @@ func TestFlushConcurrencyLimitScalesWithGOMAXPROCS(t *testing.T) {
 	require.Equal(t, flushConcurrency(), cap(flushSemaphore))
 }
 
-func TestAcquireFlushSlotWaitsWhenNormalAndBypassAreFull(t *testing.T) {
+func TestAcquireFlushSlotWaitsWhenNormalSlotsAreFull(t *testing.T) {
 	oldFlushSemaphore := flushSemaphore
 	oldAcquireTimeout := flushSemaphoreAcquireTimeout
-	oldRetryInterval := flushBypassRetryInterval
 	defer func() {
 		flushSemaphore = oldFlushSemaphore
 		flushSemaphoreAcquireTimeout = oldAcquireTimeout
-		flushBypassRetryInterval = oldRetryInterval
 	}()
 
 	flushSemaphore = make(chan struct{}, 1)
 	flushSemaphoreAcquireTimeout = time.Millisecond
-	flushBypassRetryInterval = time.Millisecond
 	flushSemaphore <- struct{}{}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
 ## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) does this PR fix or relate to?

Fixes https://github.com/matrixorigin/matrixone/issues/24348

## What this PR does / why we need it:

## Summary
- keep memory-pressure S3 writer flush concurrency fixed at 4
- remove the timeout bypass slot so TPCC-style memory pressure cannot exceed the intended flush cap
- add/update tests for the stable flush concurrency behavior

## Tests
- `go test ./pkg/sql/colexec/insert`
