### PR TITLE
fix: reduce CN RSS pressure under TPCC

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -75,6 +75,27 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
+const rssCacheFamilyEvictTimeout = 10 * time.Second
+
+var (
+	evictMemoryCachesToCapacityPercent = fileservice.EvictMemoryCachesToCapacityPercent
+	evictMetaCacheToCapacityPercent    = objectio.EvictCacheToCapacityPercent
+)
+
+func makeRSSCacheEvictor(timeout time.Duration) func(context.Context, int64) {
+	return func(_ context.Context, targetPercent int64) {
+		// Use independent bounded contexts so one cache family timing out
+		// does not prevent the other family from being pressure-evicted.
+		memoryCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		evictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
+		cancel()
+
+		metaCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		evictMetaCacheToCapacityPercent(metaCtx, targetPercent)
+		cancel()
+	}
+}
+
 func NewService(
 	cfg *Config,
 	ctx context.Context,
@@ -205,17 +226,7 @@ func NewService(
 		90.0/100.0,
 		rscthrottler.WithAcquirePolicy(rscthrottler.AcquirePolicyForCNFlushS3),
 		rscthrottler.WithRSSScavenging(),
-		rscthrottler.WithRSSCacheEvictor(func(ctx context.Context, targetPercent int64) {
-			// Use independent bounded contexts so one cache family timing out
-			// does not prevent the other family from being pressure-evicted.
-			memoryCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			fileservice.EvictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
-			cancel()
-
-			metaCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			objectio.EvictCacheToCapacityPercent(metaCtx, targetPercent)
-			cancel()
-		}),
+		rscthrottler.WithRSSCacheEvictor(makeRSSCacheEvictor(rssCacheFamilyEvictTimeout)),
 	)
 
 	srv.pu.LockService = srv.lockService

--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -47,6 +47,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/lockservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	"github.com/matrixorigin/matrixone/pkg/partitionservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
@@ -204,6 +205,10 @@ func NewService(
 		90.0/100.0,
 		rscthrottler.WithAcquirePolicy(rscthrottler.AcquirePolicyForCNFlushS3),
 		rscthrottler.WithRSSScavenging(),
+		rscthrottler.WithRSSCacheEvictor(func(ctx context.Context, targetPercent int64) {
+			fileservice.EvictMemoryCachesToCapacityPercent(ctx, targetPercent)
+			objectio.EvictCacheToCapacityPercent(ctx, targetPercent)
+		}),
 	)
 
 	srv.pu.LockService = srv.lockService

--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -206,8 +206,15 @@ func NewService(
 		rscthrottler.WithAcquirePolicy(rscthrottler.AcquirePolicyForCNFlushS3),
 		rscthrottler.WithRSSScavenging(),
 		rscthrottler.WithRSSCacheEvictor(func(ctx context.Context, targetPercent int64) {
-			fileservice.EvictMemoryCachesToCapacityPercent(ctx, targetPercent)
-			objectio.EvictCacheToCapacityPercent(ctx, targetPercent)
+			// Use independent bounded contexts so one cache family timing out
+			// does not prevent the other family from being pressure-evicted.
+			memoryCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			fileservice.EvictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
+			cancel()
+
+			metaCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			objectio.EvictCacheToCapacityPercent(metaCtx, targetPercent)
+			cancel()
 		}),
 	)
 

--- a/pkg/cnservice/server_test.go
+++ b/pkg/cnservice/server_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -215,4 +216,40 @@ func Test_tenant(t *testing.T) {
 
 	err = sv.UpgradeTenant(ctx, "acc3", 1, true)
 	assert.Error(t, err)
+}
+
+func TestMakeRSSCacheEvictorUsesIndependentTimeouts(t *testing.T) {
+	oldMem := evictMemoryCachesToCapacityPercent
+	oldMeta := evictMetaCacheToCapacityPercent
+	defer func() {
+		evictMemoryCachesToCapacityPercent = oldMem
+		evictMetaCacheToCapacityPercent = oldMeta
+	}()
+
+	var (
+		memCalled  bool
+		metaCalled bool
+	)
+	evictMemoryCachesToCapacityPercent = func(ctx context.Context, targetPercent int64) map[string]int64 {
+		memCalled = true
+		assert.Equal(t, int64(80), targetPercent)
+		_, ok := ctx.Deadline()
+		assert.True(t, ok)
+		<-ctx.Done()
+		assert.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+		return nil
+	}
+	evictMetaCacheToCapacityPercent = func(ctx context.Context, targetPercent int64) int64 {
+		metaCalled = true
+		assert.Equal(t, int64(80), targetPercent)
+		_, ok := ctx.Deadline()
+		assert.True(t, ok)
+		assert.NoError(t, ctx.Err())
+		return 0
+	}
+
+	makeRSSCacheEvictor(10*time.Millisecond)(context.Background(), 80)
+
+	assert.True(t, memCalled)
+	assert.True(t, metaCalled)
 }

--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -15,6 +15,7 @@
 package rscthrottler
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -36,6 +37,10 @@ const (
 	rssScavengeInterval    = time.Minute
 	rssScavengeTriggerRate = 0.85
 	rssScavengeVisibleRate = 0.70
+	rssCacheEvictSoftRate  = 0.90
+	rssCacheEvictHardRate  = 0.95
+	rssCacheSoftTarget     = int64(70)
+	rssCacheHardTarget     = int64(50)
 
 	MemoryThrottlerLogHeader = "MemoryThrottler"
 )
@@ -81,6 +86,7 @@ type memThrottler struct {
 		specializedForMerge bool
 
 		enableRSSScavenging bool
+		rssCacheEvictor     func(context.Context, int64)
 	}
 }
 
@@ -189,7 +195,15 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 	if visible < 0 {
 		visible = 0
 	}
-	if float64(visible) >= float64(rss)*rssScavengeVisibleRate {
+	shouldFreeOSMemory := float64(visible) < float64(rss)*rssScavengeVisibleRate
+	cacheTargetPercent := int64(0)
+	if float64(rss) >= float64(actualMaxMemory)*rssCacheEvictHardRate {
+		cacheTargetPercent = rssCacheHardTarget
+	} else if float64(rss) >= float64(actualMaxMemory)*rssCacheEvictSoftRate {
+		cacheTargetPercent = rssCacheSoftTarget
+	}
+	shouldEvictCache := cacheTargetPercent > 0 && m.options.rssCacheEvictor != nil
+	if !shouldFreeOSMemory && !shouldEvictCache {
 		return
 	}
 	last := m.lastRSSScavenge.Load()
@@ -204,9 +218,16 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 		zap.String("rss", common.HumanReadableBytes(int(rss))),
 		zap.String("visible", common.HumanReadableBytes(int(visible))),
 		zap.String("actual-total-memory", common.HumanReadableBytes(int(actualMaxMemory))),
+		zap.Bool("free-os-memory", shouldFreeOSMemory),
+		zap.Int64("cache-target-percent", cacheTargetPercent),
 		zap.String("detail", m.String()),
 	)
-	freeOSMemory()
+	if shouldEvictCache {
+		m.options.rssCacheEvictor(context.Background(), cacheTargetPercent)
+	}
+	if shouldFreeOSMemory || shouldEvictCache {
+		freeOSMemory()
+	}
 }
 
 /*
@@ -370,6 +391,12 @@ func WithSpecializedForMerge() MemThrottlerOption {
 func WithRSSScavenging() MemThrottlerOption {
 	return func(throttler *memThrottler) {
 		throttler.options.enableRSSScavenging = true
+	}
+}
+
+func WithRSSCacheEvictor(evictor func(context.Context, int64)) MemThrottlerOption {
+	return func(throttler *memThrottler) {
+		throttler.options.rssCacheEvictor = evictor
 	}
 }
 

--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"os"
 	"runtime/debug"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -73,6 +74,7 @@ type memThrottler struct {
 	lastRSSScavenge    atomic.Int64
 	lastRSSCacheEvict  atomic.Int64
 	lastRSSCacheTarget atomic.Int64
+	rssScavengeMu      sync.Mutex
 
 	mergeAvailDebounce atomic.Int64
 
@@ -207,16 +209,17 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 
 	shouldEvictCache := false
 	if cacheTargetPercent > 0 && m.options.rssCacheEvictor != nil {
+		m.rssScavengeMu.Lock()
 		lastCacheEvict := m.lastRSSCacheEvict.Load()
 		lastTarget := m.lastRSSCacheTarget.Load()
 		cacheEvictExpired := time.Duration(now-lastCacheEvict) > rssScavengeInterval
 		cacheEvictEscalated := lastTarget == 0 || cacheTargetPercent < lastTarget
 		if cacheEvictExpired || cacheEvictEscalated {
-			if m.lastRSSCacheEvict.CompareAndSwap(lastCacheEvict, now) {
-				m.lastRSSCacheTarget.Store(cacheTargetPercent)
-				shouldEvictCache = true
-			}
+			m.lastRSSCacheEvict.Store(now)
+			m.lastRSSCacheTarget.Store(cacheTargetPercent)
+			shouldEvictCache = true
 		}
+		m.rssScavengeMu.Unlock()
 	}
 
 	shouldFreeOSMemory := false

--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -69,8 +69,10 @@ type memThrottler struct {
 	name      string
 	limitRate float64
 
-	lastRefresh     atomic.Int64
-	lastRSSScavenge atomic.Int64
+	lastRefresh        atomic.Int64
+	lastRSSScavenge    atomic.Int64
+	lastRSSCacheEvict  atomic.Int64
+	lastRSSCacheTarget atomic.Int64
 
 	mergeAvailDebounce atomic.Int64
 
@@ -195,22 +197,37 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 	if visible < 0 {
 		visible = 0
 	}
-	shouldFreeOSMemory := float64(visible) < float64(rss)*rssScavengeVisibleRate
+	needFreeOSMemory := float64(visible) < float64(rss)*rssScavengeVisibleRate
 	cacheTargetPercent := int64(0)
 	if float64(rss) >= float64(actualMaxMemory)*rssCacheEvictHardRate {
 		cacheTargetPercent = rssCacheHardTarget
 	} else if float64(rss) >= float64(actualMaxMemory)*rssCacheEvictSoftRate {
 		cacheTargetPercent = rssCacheSoftTarget
 	}
-	shouldEvictCache := cacheTargetPercent > 0 && m.options.rssCacheEvictor != nil
+
+	shouldEvictCache := false
+	if cacheTargetPercent > 0 && m.options.rssCacheEvictor != nil {
+		lastCacheEvict := m.lastRSSCacheEvict.Load()
+		lastTarget := m.lastRSSCacheTarget.Load()
+		cacheEvictExpired := time.Duration(now-lastCacheEvict) > rssScavengeInterval
+		cacheEvictEscalated := lastTarget == 0 || cacheTargetPercent < lastTarget
+		if cacheEvictExpired || cacheEvictEscalated {
+			if m.lastRSSCacheEvict.CompareAndSwap(lastCacheEvict, now) {
+				m.lastRSSCacheTarget.Store(cacheTargetPercent)
+				shouldEvictCache = true
+			}
+		}
+	}
+
+	shouldFreeOSMemory := false
+	if needFreeOSMemory {
+		last := m.lastRSSScavenge.Load()
+		if time.Duration(now-last) > rssScavengeInterval &&
+			m.lastRSSScavenge.CompareAndSwap(last, now) {
+			shouldFreeOSMemory = true
+		}
+	}
 	if !shouldFreeOSMemory && !shouldEvictCache {
-		return
-	}
-	last := m.lastRSSScavenge.Load()
-	if time.Duration(now-last) <= rssScavengeInterval {
-		return
-	}
-	if !m.lastRSSScavenge.CompareAndSwap(last, now) {
 		return
 	}
 	logutil.Info(
@@ -224,6 +241,7 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 	)
 	if shouldEvictCache {
 		m.options.rssCacheEvictor(context.Background(), cacheTargetPercent)
+		m.lastRSSScavenge.Store(now)
 	}
 	if shouldFreeOSMemory || shouldEvictCache {
 		freeOSMemory()

--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -88,7 +88,7 @@ type memThrottler struct {
 		specializedForMerge bool
 
 		enableRSSScavenging bool
-		rssCacheEvictor     func(context.Context, int64)
+		rssCacheEvictor     func(ctx context.Context, targetPercent int64)
 	}
 }
 
@@ -412,7 +412,7 @@ func WithRSSScavenging() MemThrottlerOption {
 	}
 }
 
-func WithRSSCacheEvictor(evictor func(context.Context, int64)) MemThrottlerOption {
+func WithRSSCacheEvictor(evictor func(ctx context.Context, targetPercent int64)) MemThrottlerOption {
 	return func(throttler *memThrottler) {
 		throttler.options.rssCacheEvictor = evictor
 	}

--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -36,11 +36,12 @@ import (
 const (
 	refreshMaxInterval     = time.Second * 10
 	rssScavengeInterval    = time.Minute
+	rssCacheEvictTimeout   = time.Second * 10
 	rssScavengeTriggerRate = 0.85
 	rssScavengeVisibleRate = 0.70
-	rssCacheEvictSoftRate  = 0.90
-	rssCacheEvictHardRate  = 0.95
-	rssCacheSoftTarget     = int64(70)
+	rssCacheEvictSoftRate  = 0.85
+	rssCacheEvictHardRate  = 0.92
+	rssCacheSoftTarget     = int64(80)
 	rssCacheHardTarget     = int64(50)
 
 	MemoryThrottlerLogHeader = "MemoryThrottler"
@@ -243,7 +244,9 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 		zap.String("detail", m.String()),
 	)
 	if shouldEvictCache {
-		m.options.rssCacheEvictor(context.Background(), cacheTargetPercent)
+		evictCtx, cancel := context.WithTimeout(context.Background(), rssCacheEvictTimeout)
+		m.options.rssCacheEvictor(evictCtx, cacheTargetPercent)
+		cancel()
 		m.lastRSSScavenge.Store(now)
 	}
 	if shouldFreeOSMemory || shouldEvictCache {

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -222,8 +222,11 @@ func TestMemThrottlerRSSCacheEvictionByRSSRate(t *testing.T) {
 	require.Equal(t, int32(1), freeCalls.Load())
 	require.Equal(t, rssCacheSoftTarget, target.Load())
 
-	throttler.lastRSSScavenge.Store(now - int64(rssScavengeInterval) - int64(time.Second))
-	throttler.tryScavengeRSS(now, 960*mpool.GB)
+	throttler.tryScavengeRSS(now+int64(time.Second), 960*mpool.GB)
+	require.Equal(t, int32(2), freeCalls.Load())
+	require.Equal(t, rssCacheHardTarget, target.Load())
+
+	throttler.tryScavengeRSS(now+2*int64(time.Second), 960*mpool.GB)
 	require.Equal(t, int32(2), freeCalls.Load())
 	require.Equal(t, rssCacheHardTarget, target.Load())
 }

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -231,6 +231,56 @@ func TestMemThrottlerRSSCacheEvictionByRSSRate(t *testing.T) {
 	require.Equal(t, rssCacheHardTarget, target.Load())
 }
 
+func TestMemThrottlerRSSCacheEvictionConcurrentEscalation(t *testing.T) {
+	oldFreeOSMemory := freeOSMemory
+	defer func() { freeOSMemory = oldFreeOSMemory }()
+
+	var freeCalls atomic.Int32
+	freeOSMemory = func() {
+		freeCalls.Add(1)
+	}
+
+	var minTarget atomic.Int64
+	minTarget.Store(100)
+
+	now := time.Now().UnixNano()
+	throttler := &memThrottler{limitRate: 0.90}
+	throttler.options.enableRSSScavenging = true
+	throttler.options.rssCacheEvictor = func(_ context.Context, targetPercent int64) {
+		for {
+			old := minTarget.Load()
+			if targetPercent >= old || minTarget.CompareAndSwap(old, targetPercent) {
+				return
+			}
+		}
+	}
+	throttler.actualTotalMemory.Store(1000 * mpool.GB)
+	throttler.limit.Store(900 * mpool.GB)
+	throttler.reserved.Store(800 * mpool.GB)
+	throttler.lastRSSScavenge.Store(now - int64(rssScavengeInterval) - int64(time.Second))
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		throttler.tryScavengeRSS(now, 910*mpool.GB)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		throttler.tryScavengeRSS(now, 960*mpool.GB)
+	}()
+
+	close(start)
+	wg.Wait()
+
+	require.GreaterOrEqual(t, freeCalls.Load(), int32(1))
+	require.Equal(t, int64(rssCacheHardTarget), minTarget.Load())
+	require.Equal(t, int64(rssCacheHardTarget), throttler.lastRSSCacheTarget.Load())
+}
+
 func TestMemThrottlerRSSScavengingDisabled(t *testing.T) {
 	oldFreeOSMemory := freeOSMemory
 	defer func() { freeOSMemory = oldFreeOSMemory }()

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -214,19 +214,23 @@ func TestMemThrottlerRSSCacheEvictionByRSSRate(t *testing.T) {
 	}
 	throttler.actualTotalMemory.Store(1000 * mpool.GB)
 	throttler.limit.Store(900 * mpool.GB)
-	throttler.rss.Store(910 * mpool.GB)
+	throttler.rss.Store(850 * mpool.GB)
 	throttler.reserved.Store(800 * mpool.GB)
 	throttler.lastRSSScavenge.Store(now - int64(rssScavengeInterval) - int64(time.Second))
 
-	throttler.tryScavengeRSS(now, 910*mpool.GB)
+	throttler.tryScavengeRSS(now, 840*mpool.GB)
+	require.Equal(t, int32(0), freeCalls.Load())
+	require.Equal(t, int64(0), target.Load())
+
+	throttler.tryScavengeRSS(now+int64(time.Second), 850*mpool.GB)
 	require.Equal(t, int32(1), freeCalls.Load())
 	require.Equal(t, rssCacheSoftTarget, target.Load())
 
-	throttler.tryScavengeRSS(now+int64(time.Second), 960*mpool.GB)
+	throttler.tryScavengeRSS(now+2*int64(time.Second), 920*mpool.GB)
 	require.Equal(t, int32(2), freeCalls.Load())
 	require.Equal(t, rssCacheHardTarget, target.Load())
 
-	throttler.tryScavengeRSS(now+2*int64(time.Second), 960*mpool.GB)
+	throttler.tryScavengeRSS(now+3*int64(time.Second), 920*mpool.GB)
 	require.Equal(t, int32(2), freeCalls.Load())
 	require.Equal(t, rssCacheHardTarget, target.Load())
 }
@@ -265,12 +269,12 @@ func TestMemThrottlerRSSCacheEvictionConcurrentEscalation(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-start
-		throttler.tryScavengeRSS(now, 910*mpool.GB)
+		throttler.tryScavengeRSS(now, 850*mpool.GB)
 	}()
 	go func() {
 		defer wg.Done()
 		<-start
-		throttler.tryScavengeRSS(now, 960*mpool.GB)
+		throttler.tryScavengeRSS(now, 920*mpool.GB)
 	}()
 
 	close(start)

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -15,6 +15,7 @@
 package rscthrottler
 
 import (
+	"context"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -193,6 +194,38 @@ func TestMemThrottlerRSSScavenging(t *testing.T) {
 
 	throttler.tryScavengeRSS(now+int64(time.Second), 900*mpool.GB)
 	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestMemThrottlerRSSCacheEvictionByRSSRate(t *testing.T) {
+	oldFreeOSMemory := freeOSMemory
+	defer func() { freeOSMemory = oldFreeOSMemory }()
+
+	var freeCalls atomic.Int32
+	freeOSMemory = func() {
+		freeCalls.Add(1)
+	}
+
+	var target atomic.Int64
+	now := time.Now().UnixNano()
+	throttler := &memThrottler{limitRate: 0.90}
+	throttler.options.enableRSSScavenging = true
+	throttler.options.rssCacheEvictor = func(_ context.Context, targetPercent int64) {
+		target.Store(targetPercent)
+	}
+	throttler.actualTotalMemory.Store(1000 * mpool.GB)
+	throttler.limit.Store(900 * mpool.GB)
+	throttler.rss.Store(910 * mpool.GB)
+	throttler.reserved.Store(800 * mpool.GB)
+	throttler.lastRSSScavenge.Store(now - int64(rssScavengeInterval) - int64(time.Second))
+
+	throttler.tryScavengeRSS(now, 910*mpool.GB)
+	require.Equal(t, int32(1), freeCalls.Load())
+	require.Equal(t, rssCacheSoftTarget, target.Load())
+
+	throttler.lastRSSScavenge.Store(now - int64(rssScavengeInterval) - int64(time.Second))
+	throttler.tryScavengeRSS(now, 960*mpool.GB)
+	require.Equal(t, int32(2), freeCalls.Load())
+	require.Equal(t, rssCacheHardTarget, target.Load())
 }
 
 func TestMemThrottlerRSSScavengingDisabled(t *testing.T) {

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -210,6 +210,26 @@ func EvictMemoryCaches(ctx context.Context) map[string]int64 {
 	return ret
 }
 
+func EvictMemoryCachesToCapacityPercent(ctx context.Context, percent int64) map[string]int64 {
+	ret := make(map[string]int64)
+
+	allMemoryCaches.Range(func(k, v any) bool {
+		cache := k.(*MemCache)
+		name := v.(string)
+		target := cache.EvictToCapacityPercent(ctx, percent)
+		ret[name] = target
+		logutil.Info("memory cache pressure evicted",
+			zap.Any("name", name),
+			zap.Int64("target", target),
+			zap.Int64("target-percent", percent),
+		)
+
+		return true
+	})
+
+	return ret
+}
+
 func EvictDiskCaches(ctx context.Context) map[string]int64 {
 	ret := make(map[string]int64)
 	ch := make(chan int64, 1)

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -216,11 +216,11 @@ func EvictMemoryCachesToCapacityPercent(ctx context.Context, percent int64) map[
 	allMemoryCaches.Range(func(k, v any) bool {
 		cache := k.(*MemCache)
 		name := v.(string)
-		target := cache.EvictToCapacityPercent(ctx, percent)
-		ret[name] = target
+		used := cache.EvictToCapacityPercent(ctx, percent)
+		ret[name] = used
 		logutil.Info("memory cache pressure evicted",
 			zap.Any("name", name),
-			zap.Int64("target", target),
+			zap.Int64("used", used),
 			zap.Int64("target-percent", percent),
 		)
 

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -216,12 +216,28 @@ func EvictMemoryCachesToCapacityPercent(ctx context.Context, percent int64) map[
 	allMemoryCaches.Range(func(k, v any) bool {
 		cache := k.(*MemCache)
 		name := v.(string)
+		capacity := cache.cache.Capacity()
+		target := capacity * percent / 100
+		beforeUsed := cache.cache.Used()
+		start := time.Now()
+		logutil.Info("memory cache pressure evict begin",
+			zap.Any("name", name),
+			zap.Int64("used-before", beforeUsed),
+			zap.Int64("capacity", capacity),
+			zap.Int64("target", target),
+			zap.Int64("target-percent", percent),
+		)
 		used := cache.EvictToCapacityPercent(ctx, percent)
 		ret[name] = used
 		logutil.Info("memory cache pressure evicted",
 			zap.Any("name", name),
-			zap.Int64("used", used),
+			zap.Int64("used-before", beforeUsed),
+			zap.Int64("used-after", used),
+			zap.Int64("capacity", capacity),
+			zap.Int64("target", target),
 			zap.Int64("target-percent", percent),
+			zap.Duration("duration", time.Since(start)),
+			zap.Error(ctx.Err()),
 		)
 
 		return true

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -913,3 +913,7 @@ func (*countingDataCache) DeletePaths(context.Context, []string) {}
 func (*countingDataCache) Flush(context.Context) {}
 
 func (*countingDataCache) Evict(context.Context, chan int64) {}
+
+func (*countingDataCache) EvictToTargetWithWait(context.Context, int64) int64 { return 0 }
+
+func (*countingDataCache) ForceEvictWithWait(context.Context, int64) int64 { return 0 }

--- a/pkg/fileservice/fifocache/data_cache.go
+++ b/pkg/fileservice/fifocache/data_cache.go
@@ -118,6 +118,14 @@ func (d *DataCache) Evict(ctx context.Context, ch chan int64) {
 	d.fifo.Evict(ctx, ch, 0)
 }
 
+func (d *DataCache) EvictToTargetWithWait(ctx context.Context, target int64) int64 {
+	return d.fifo.EvictToTargetWithWait(ctx, target)
+}
+
+func (d *DataCache) ForceEvictWithWait(ctx context.Context, n int64) int64 {
+	return d.fifo.ForceEvictWithWait(ctx, n)
+}
+
 func (d *DataCache) Flush(ctx context.Context) {
 	d.fifo.Evict(ctx, nil, math.MaxInt64)
 }

--- a/pkg/fileservice/fifocache/data_cache.go
+++ b/pkg/fileservice/fifocache/data_cache.go
@@ -108,7 +108,7 @@ func (d *DataCache) EnsureNBytes(ctx context.Context, want int) {
 	used := d.Used()
 	capacity := d.Capacity()
 	if used+int64(want) > capacity {
-		d.fifo.EvictWithWait(ctx, int64(want))
+		_ = d.fifo.EvictWithWait(ctx, int64(want))
 	} else {
 		d.fifo.Evict(ctx, nil, int64(want))
 	}

--- a/pkg/fileservice/fifocache/fifo.go
+++ b/pkg/fileservice/fifocache/fifo.go
@@ -24,7 +24,11 @@ import (
 	"golang.org/x/sys/cpu"
 )
 
-const numShards = 256
+const (
+	numShards               = 256
+	pressureEvictBatchItems = 64
+	pressureEvictBatchBytes = 64 << 20
+)
 
 // Cache implements an in-memory cache with FIFO-based eviction
 type Cache[K comparable, V any] struct {
@@ -481,8 +485,8 @@ func (c *Cache[K, V]) ForceEvictWithWait(ctx context.Context, n int64) int64 {
 }
 
 // EvictToTargetWithWait best-effort evicts until used bytes are no greater
-// than target. If ctx is canceled, it may return with used bytes still above
-// target.
+// than target and returns the actual used bytes after eviction stops. If ctx
+// is canceled, it may return with used bytes still above target.
 func (c *Cache[K, V]) EvictToTargetWithWait(ctx context.Context, target int64) int64 {
 	if target < 0 {
 		target = 0
@@ -491,55 +495,91 @@ func (c *Cache[K, V]) EvictToTargetWithWait(ctx context.Context, target int64) i
 	if target > capacity {
 		target = capacity
 	}
-	c.EvictWithWait(ctx, capacity-target)
-	return target
+	return c.EvictWithWait(ctx, capacity-target)
 }
 
 // EvictWithWait is like Evict but blocks until the eviction lock is acquired,
 // guaranteeing that eviction actually runs before returning. This is used by
 // EnsureNBytes to prevent unbounded memory growth under high concurrency where
-// TryLock-based Evict would skip eviction entirely.
-func (c *Cache[K, V]) EvictWithWait(ctx context.Context, capacityCut int64) {
-	c.queueLock.Lock()
-	var pendingPostEvicts []_PendingPostEvict[K, V]
-	defer func() {
-		c.queueLock.Unlock()
-		if c.postEvict != nil {
-			for i := range pendingPostEvicts {
-				c.postEvictItem(ctx, pendingPostEvicts[i], true)
-				pendingPostEvicts[i] = _PendingPostEvict[K, V]{}
-			}
-		}
-	}()
-
+// TryLock-based Evict would skip eviction entirely. It returns the actual used
+// bytes after eviction stops.
+func (c *Cache[K, V]) EvictWithWait(ctx context.Context, capacityCut int64) int64 {
+	if capacityCut < 0 {
+		capacityCut = 0
+	}
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return c.used()
 		default:
 		}
-		c.helpEnqueue()
-		globalCapacityCut := c.capacityCut.Swap(0)
-		target := c.capacity() - capacityCut - globalCapacityCut
+		pendingPostEvicts, used, evicted := c.evictBatch(&capacityCut)
+		c.runPendingPostEvicts(ctx, pendingPostEvicts)
+		target := c.capacity() - capacityCut
 		if target < 0 {
 			target = 0
 		}
-		if c.used1+c.used2 <= target {
-			break
+		if used <= target || !evicted {
+			return used
 		}
-		target1 := c.capacity1() - capacityCut - globalCapacityCut
+	}
+}
+
+func (c *Cache[K, V]) evictBatch(capacityCut *int64) (pending []_PendingPostEvict[K, V], used int64, evicted bool) {
+	c.queueLock.Lock()
+	defer c.queueLock.Unlock()
+
+	var (
+		pendingBytes int64
+		pendingCount int
+	)
+
+	for {
+		c.helpEnqueue()
+		*capacityCut += c.capacityCut.Swap(0)
+		target := c.capacity() - *capacityCut
+		if target < 0 {
+			target = 0
+		}
+		used = c.used1 + c.used2
+		if used <= target {
+			return pending, used, evicted
+		}
+		target1 := c.capacity1() - *capacityCut
 		if target1 < 0 {
 			target1 = 0
 		}
+		var (
+			pe _PendingPostEvict[K, V]
+			ok bool
+		)
 		if c.used1 > target1 {
-			if pe, ok := c.evict1(); ok {
-				pendingPostEvicts = append(pendingPostEvicts, pe)
-			}
+			pe, ok = c.evict1()
 		} else {
-			if pe, ok := c.evict2(); ok {
-				pendingPostEvicts = append(pendingPostEvicts, pe)
-			}
+			pe, ok = c.evict2()
 		}
+		if !ok {
+			return pending, c.used1 + c.used2, evicted
+		}
+		evicted = true
+		pendingCount++
+		pendingBytes += pe.size
+		if c.postEvict != nil {
+			pending = append(pending, pe)
+		}
+		if pendingCount >= pressureEvictBatchItems || pendingBytes >= pressureEvictBatchBytes {
+			return pending, c.used1 + c.used2, evicted
+		}
+	}
+}
+
+func (c *Cache[K, V]) runPendingPostEvicts(ctx context.Context, pendingPostEvicts []_PendingPostEvict[K, V]) {
+	if c.postEvict == nil {
+		return
+	}
+	for i := range pendingPostEvicts {
+		c.postEvictItem(ctx, pendingPostEvicts[i], true)
+		pendingPostEvicts[i] = _PendingPostEvict[K, V]{}
 	}
 }
 

--- a/pkg/fileservice/fifocache/fifo.go
+++ b/pkg/fileservice/fifocache/fifo.go
@@ -550,15 +550,20 @@ func (c *Cache[K, V]) evictBatch(capacityCut *int64) (pending []_PendingPostEvic
 			target1 = 0
 		}
 		var (
-			pe _PendingPostEvict[K, V]
-			ok bool
+			used1Before int64
+			pe          _PendingPostEvict[K, V]
+			ok          bool
 		)
 		if c.used1 > target1 {
+			used1Before = c.used1
 			pe, ok = c.evict1()
 		} else {
 			pe, ok = c.evict2()
 		}
 		if !ok {
+			if used1Before > 0 && c.used1 != used1Before {
+				continue
+			}
 			return pending, c.used1 + c.used2, evicted
 		}
 		evicted = true

--- a/pkg/fileservice/fifocache/fifo.go
+++ b/pkg/fileservice/fifocache/fifo.go
@@ -480,7 +480,9 @@ func (c *Cache[K, V]) ForceEvictWithWait(ctx context.Context, n int64) int64 {
 	return c.EvictToTargetWithWait(ctx, target)
 }
 
-// EvictToTargetWithWait evicts until used bytes are no greater than target.
+// EvictToTargetWithWait best-effort evicts until used bytes are no greater
+// than target. If ctx is canceled, it may return with used bytes still above
+// target.
 func (c *Cache[K, V]) EvictToTargetWithWait(ctx context.Context, target int64) int64 {
 	if target < 0 {
 		target = 0

--- a/pkg/fileservice/fifocache/fifo.go
+++ b/pkg/fileservice/fifocache/fifo.go
@@ -467,6 +467,32 @@ func (c *Cache[K, V]) ForceEvict(ctx context.Context, n int64) {
 	c.Evict(ctx, nil, capacityCut)
 }
 
+// ForceEvictWithWait evicts n bytes despite capacity and waits for the
+// eviction callbacks to finish before returning.
+func (c *Cache[K, V]) ForceEvictWithWait(ctx context.Context, n int64) int64 {
+	if n <= 0 {
+		return c.used()
+	}
+	target := c.used() - n
+	if target < 0 {
+		target = 0
+	}
+	return c.EvictToTargetWithWait(ctx, target)
+}
+
+// EvictToTargetWithWait evicts until used bytes are no greater than target.
+func (c *Cache[K, V]) EvictToTargetWithWait(ctx context.Context, target int64) int64 {
+	if target < 0 {
+		target = 0
+	}
+	capacity := c.capacity()
+	if target > capacity {
+		target = capacity
+	}
+	c.EvictWithWait(ctx, capacity-target)
+	return target
+}
+
 // EvictWithWait is like Evict but blocks until the eviction lock is acquired,
 // guaranteeing that eviction actually runs before returning. This is used by
 // EnsureNBytes to prevent unbounded memory growth under high concurrency where
@@ -519,6 +545,14 @@ func (c *Cache[K, V]) used() int64 {
 	c.queueLock.RLock()
 	defer c.queueLock.RUnlock()
 	return c.used1 + c.used2
+}
+
+func (c *Cache[K, V]) Used() int64 {
+	return c.used()
+}
+
+func (c *Cache[K, V]) Capacity() int64 {
+	return c.capacity()
 }
 
 func (c *Cache[K, V]) evict1() (pe _PendingPostEvict[K, V], evicted bool) {

--- a/pkg/fileservice/fifocache/fifo_test.go
+++ b/pkg/fileservice/fifocache/fifo_test.go
@@ -344,6 +344,36 @@ func TestEvictToTargetWithWaitReturnsActualUsedOnContextCancel(t *testing.T) {
 	assert.Equal(t, int32(1), evicted.Load())
 }
 
+func TestEvictToTargetWithWaitEvictsHotItemsAfterPromotion(t *testing.T) {
+	ctx := context.Background()
+	cache := New[int, int](fscache.ConstCapacity(3), ShardInt[int], nil, nil, nil)
+
+	cache.Set(ctx, 1, 1, 1)
+	cache.Set(ctx, 2, 2, 1)
+	cache.Set(ctx, 3, 3, 1)
+
+	_, ok := cache.Get(ctx, 1)
+	assert.True(t, ok)
+	_, ok = cache.Get(ctx, 1)
+	assert.True(t, ok)
+	_, ok = cache.Get(ctx, 2)
+	assert.True(t, ok)
+	_, ok = cache.Get(ctx, 2)
+	assert.True(t, ok)
+	_, ok = cache.Get(ctx, 3)
+	assert.True(t, ok)
+	_, ok = cache.Get(ctx, 3)
+	assert.True(t, ok)
+
+	used := cache.EvictToTargetWithWait(ctx, 0)
+
+	assert.Equal(t, int64(0), used)
+	assert.Equal(t, int64(0), cache.used())
+	assert.False(t, cache.Contains(1))
+	assert.False(t, cache.Contains(2))
+	assert.False(t, cache.Contains(3))
+}
+
 // TestPostEvictRunsOutsideQueueLock verifies that postEvict callbacks execute
 // outside the queueLock by attempting a concurrent Set() while a postEvict is
 // blocked. If postEvict ran under the lock, the concurrent Set would deadlock.

--- a/pkg/fileservice/fifocache/fifo_test.go
+++ b/pkg/fileservice/fifocache/fifo_test.go
@@ -316,6 +316,34 @@ func TestEvictWithWaitReturnsWhenContextCanceled(t *testing.T) {
 	}
 }
 
+func TestEvictToTargetWithWaitReturnsActualUsedOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	itemSize := int64(pressureEvictBatchBytes + 1)
+	var evicted atomic.Int32
+	cache := New(
+		fscache.ConstCapacity(3*itemSize),
+		ShardInt[int],
+		nil,
+		nil,
+		func(context.Context, int, int, int64, uint64) {
+			if evicted.Add(1) == 1 {
+				cancel()
+			}
+		},
+	)
+	cache.Set(context.Background(), 1, 1, itemSize)
+	cache.Set(context.Background(), 2, 2, itemSize)
+	cache.Set(context.Background(), 3, 3, itemSize)
+
+	used := cache.EvictToTargetWithWait(ctx, 0)
+
+	assert.Equal(t, int64(2*itemSize), used)
+	assert.Equal(t, used, cache.used())
+	assert.Equal(t, int32(1), evicted.Load())
+}
+
 // TestPostEvictRunsOutsideQueueLock verifies that postEvict callbacks execute
 // outside the queueLock by attempting a concurrent Set() while a postEvict is
 // blocked. If postEvict ran under the lock, the concurrent Set would deadlock.

--- a/pkg/fileservice/fscache/data_cache.go
+++ b/pkg/fileservice/fscache/data_cache.go
@@ -31,4 +31,6 @@ type DataCache interface {
 	DeletePaths(context.Context, []string)
 	Flush(ctx context.Context)
 	Evict(ctx context.Context, done chan int64)
+	EvictToTargetWithWait(ctx context.Context, target int64) int64
+	ForceEvictWithWait(ctx context.Context, n int64) int64
 }

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -265,6 +265,21 @@ func (m *MemCache) Evict(ctx context.Context, done chan int64) {
 	m.cache.Evict(ctx, done)
 }
 
+func (m *MemCache) EvictToTarget(ctx context.Context, target int64) int64 {
+	return m.cache.EvictToTargetWithWait(ctx, target)
+}
+
+func (m *MemCache) EvictToCapacityPercent(ctx context.Context, percent int64) int64 {
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	target := m.cache.Capacity() * percent / 100
+	return m.EvictToTarget(ctx, target)
+}
+
 func (m *MemCache) Close(ctx context.Context) {
 	m.Flush(ctx)
 	allMemoryCaches.Delete(m)

--- a/pkg/fileservice/mem_cache_test.go
+++ b/pkg/fileservice/mem_cache_test.go
@@ -516,3 +516,24 @@ func TestMemoryCacheGlobalSizeHint(t *testing.T) {
 	}
 
 }
+
+func TestMemoryCacheEvictToCapacityPercent(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemCache(
+		fscache.ConstCapacity(10),
+		nil,
+		nil,
+		"test-target-evict",
+	)
+	defer cache.Close(ctx)
+
+	for i := 0; i < 10; i++ {
+		key := fscache.CacheKey{Path: fmt.Sprintf("key-%d", i), Offset: int64(i), Sz: 1}
+		assert.NoError(t, cache.cache.Set(ctx, key, staticTestData([]byte{byte(i)})))
+	}
+	assert.Equal(t, int64(10), cache.cache.Used())
+
+	ret := EvictMemoryCachesToCapacityPercent(ctx, 50)
+	assert.Equal(t, int64(5), ret["test-target-evict"])
+	assert.LessOrEqual(t, cache.cache.Used(), int64(5))
+}

--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -160,6 +160,22 @@ func EvictCache(ctx context.Context) (target int64) {
 	return
 }
 
+func EvictCacheToCapacityPercent(ctx context.Context, percent int64) (target int64) {
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	target = metaCache.Capacity() * percent / 100
+	target = metaCache.EvictToTargetWithWait(ctx, target)
+	logutil.Info("metadata cache pressure evicted",
+		zap.Any("target", target),
+		zap.Int64("target-percent", percent),
+	)
+	return
+}
+
 func encodeCacheKey(name ObjectNameShort, cacheKeyType uint16) mataCacheKey {
 	var key mataCacheKey
 	copy(key[:], name[:])

--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -160,17 +160,17 @@ func EvictCache(ctx context.Context) (target int64) {
 	return
 }
 
-func EvictCacheToCapacityPercent(ctx context.Context, percent int64) (target int64) {
+func EvictCacheToCapacityPercent(ctx context.Context, percent int64) (used int64) {
 	if percent < 0 {
 		percent = 0
 	}
 	if percent > 100 {
 		percent = 100
 	}
-	target = metaCache.Capacity() * percent / 100
-	target = metaCache.EvictToTargetWithWait(ctx, target)
+	target := metaCache.Capacity() * percent / 100
+	used = metaCache.EvictToTargetWithWait(ctx, target)
 	logutil.Info("metadata cache pressure evicted",
-		zap.Any("target", target),
+		zap.Any("used", used),
 		zap.Int64("target-percent", percent),
 	)
 	return

--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -167,11 +168,25 @@ func EvictCacheToCapacityPercent(ctx context.Context, percent int64) (used int64
 	if percent > 100 {
 		percent = 100
 	}
-	target := metaCache.Capacity() * percent / 100
+	capacity := metaCache.Capacity()
+	target := capacity * percent / 100
+	beforeUsed := metaCache.Used()
+	start := time.Now()
+	logutil.Info("metadata cache pressure evict begin",
+		zap.Int64("used-before", beforeUsed),
+		zap.Int64("capacity", capacity),
+		zap.Int64("target", target),
+		zap.Int64("target-percent", percent),
+	)
 	used = metaCache.EvictToTargetWithWait(ctx, target)
 	logutil.Info("metadata cache pressure evicted",
-		zap.Any("used", used),
+		zap.Int64("used-before", beforeUsed),
+		zap.Int64("used-after", used),
+		zap.Int64("capacity", capacity),
+		zap.Int64("target", target),
 		zap.Int64("target-percent", percent),
+		zap.Duration("duration", time.Since(start)),
+		zap.Error(ctx.Err()),
 	)
 	return
 }

--- a/pkg/objectio/ioutil/funcs.go
+++ b/pkg/objectio/ioutil/funcs.go
@@ -333,7 +333,7 @@ func IsRowDeletedByLocation(
 
 	attrs := objectio.GetTombstoneAttrs(hidden)
 	data := containers.NewVectors(len(attrs))
-	_, release, err := ReadDeletes(ctx, location, fs, createdByCN, data, nil)
+	_, release, err := ReadDeletes(ctx, location, fs, createdByCN, data, nil, fileservice.GetFileServicePolicy(ctx))
 	if err != nil {
 		return
 	}
@@ -388,7 +388,7 @@ func FillBlockDeleteMask(
 	persistedDeletes := containers.NewVectors(len(attrs))
 
 	if meta, release, err = ReadDeletes(
-		ctx, location, fs, createdByCN, persistedDeletes, nil,
+		ctx, location, fs, createdByCN, persistedDeletes, nil, fileservice.GetFileServicePolicy(ctx),
 	); err != nil {
 		return
 	}
@@ -409,7 +409,7 @@ func FillBlockDeleteMask(
 	return
 }
 
-// ReadDeletes will read the pk column if pk type not nil
+// ReadDeletes will read the pk column if pk type not nil.
 func ReadDeletes(
 	ctx context.Context,
 	deltaLoc objectio.Location,
@@ -417,6 +417,7 @@ func ReadDeletes(
 	isPersistedByCN bool,
 	cacheVectors containers.Vectors,
 	pkType *types.Type,
+	policy fileservice.Policy,
 ) (objectio.ObjectDataMeta, func(), error) {
 
 	var cols []uint16
@@ -436,7 +437,7 @@ func ReadDeletes(
 	}
 
 	return LoadTombstoneColumns(
-		ctx, cols, typs, fs, deltaLoc, cacheVectors, nil, fileservice.Policy(0),
+		ctx, cols, typs, fs, deltaLoc, cacheVectors, nil, policy,
 	)
 }
 

--- a/pkg/objectio/ioutil/loadfuncs_test.go
+++ b/pkg/objectio/ioutil/loadfuncs_test.go
@@ -59,6 +59,16 @@ func (fs *corruptColumnReadFS) Read(ctx context.Context, vector *fileservice.IOV
 	return nil
 }
 
+type policyCaptureFS struct {
+	fileservice.FileService
+	policies []fileservice.Policy
+}
+
+func (fs *policyCaptureFS) Read(ctx context.Context, vector *fileservice.IOVector) error {
+	fs.policies = append(fs.policies, vector.Policy)
+	return fs.FileService.Read(ctx, vector)
+}
+
 func TestLoadColumnsDataReturnsErrorOnCorruptedColumnData(t *testing.T) {
 	ctx := context.Background()
 	fs := testutil.NewSharedFS()
@@ -101,4 +111,48 @@ func TestLoadColumnsDataReturnsErrorOnCorruptedColumnData(t *testing.T) {
 	require.Nil(t, release)
 	require.NotNil(t, dataMeta)
 	require.Contains(t, err.Error(), "invalid object meta")
+}
+
+func TestLoadColumnsDataPropagatesPolicy(t *testing.T) {
+	ctx := context.Background()
+	fs := testutil.NewSharedFS()
+	mp := mpool.MustNewZero()
+
+	writer := ConstructWriter(0, []uint16{0}, -1, false, false, fs)
+	bat := batch.NewWithSize(1)
+	bat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	require.NoError(t, vector.AppendFixed(bat.Vecs[0], int32(11), false, mp))
+	require.NoError(t, vector.AppendFixed(bat.Vecs[0], int32(22), false, mp))
+	bat.SetRowCount(2)
+
+	_, err := writer.WriteBatch(bat)
+	require.NoError(t, err)
+	blocks, _, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+
+	location := objectio.BuildLocation(
+		writer.GetName(),
+		blocks[0].GetExtent(),
+		uint32(bat.RowCount()),
+		blocks[0].GetID(),
+	)
+
+	cacheVectors := containers.NewVectors(1)
+	cacheVectors[0] = *vector.NewVec(types.T_int32.ToType())
+	recordingFS := &policyCaptureFS{FileService: fs}
+	_, release, err := LoadColumnsData(
+		ctx,
+		[]uint16{0},
+		[]types.Type{types.T_int32.ToType()},
+		recordingFS,
+		location,
+		cacheVectors,
+		mp,
+		fileservice.SkipFullFilePreloads,
+	)
+	require.NoError(t, err)
+	defer release()
+	require.GreaterOrEqual(t, len(recordingFS.policies), 2)
+	require.Equal(t, fileservice.Policy(fileservice.SkipFullFilePreloads), recordingFS.policies[1])
 }

--- a/pkg/objectio/meta_test.go
+++ b/pkg/objectio/meta_test.go
@@ -130,3 +130,21 @@ func TestDedupLoadCleansUpAfterLoadCancel(t *testing.T) {
 	metaLoadMu.Unlock()
 	assert.False(t, ok)
 }
+
+func TestEvictCacheToCapacityPercent(t *testing.T) {
+	oldMetaCache := metaCache
+	metaCache = newMetaCache(fscache.ConstCapacity(10))
+	defer func() {
+		metaCache = oldMetaCache
+	}()
+
+	ctx := context.Background()
+	var key mataCacheKey
+	key[0] = 3
+	metaCache.Set(ctx, key, []byte("1234567890"), 10)
+
+	used := EvictCacheToCapacityPercent(ctx, 50)
+
+	assert.LessOrEqual(t, used, int64(5))
+	assert.Equal(t, used, metaCache.Used())
+}

--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -1431,7 +1431,7 @@ func (ls *LocalDisttaeDataSource) batchApplyTombstoneObjects(
 			location = obj.ObjectStats.BlockLocation(uint16(idx), objectio.BlockMaxRows)
 
 			if _, release, err = ioutil.ReadDeletes(
-				ls.ctx, location, ls.fs, obj.GetCNCreated(), cacheVectors, nil,
+				ls.ctx, location, ls.fs, obj.GetCNCreated(), cacheVectors, nil, fileservice.GetFileServicePolicy(ls.ctx),
 			); err != nil {
 				return err
 			}

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -1618,7 +1618,7 @@ func (p *PartitionState) countTombstoneStatsLinear(
 		func(blk objectio.BlockInfo, blkMeta objectio.BlockObject) bool {
 			var release func()
 			if _, release, readErr = ioutil.ReadDeletes(
-				ctx, blk.MetaLoc[:], fs, cnCreated, persistedDeletes, nil,
+				ctx, blk.MetaLoc[:], fs, cnCreated, persistedDeletes, nil, fileservice.GetFileServicePolicy(ctx),
 			); readErr != nil {
 				return false
 			}
@@ -1717,7 +1717,7 @@ func (p *PartitionState) countTombstoneStatsWithMap(
 			func(blk objectio.BlockInfo, blkMeta objectio.BlockObject) bool {
 				var release func()
 				if _, release, readErr = ioutil.ReadDeletes(
-					ctx, blk.MetaLoc[:], fs, cnCreated, persistedDeletes, nil,
+					ctx, blk.MetaLoc[:], fs, cnCreated, persistedDeletes, nil, fileservice.GetFileServicePolicy(ctx),
 				); readErr != nil {
 					return false
 				}
@@ -1850,7 +1850,7 @@ func (it *tombstoneBlockIterator) loadNextBlock() bool {
 
 	cnCreated := it.obj.GetCNCreated()
 	if _, it.release, it.err = ioutil.ReadDeletes(
-		it.ctx, blk.MetaLoc[:], it.fs, cnCreated, it.persistedDel, nil,
+		it.ctx, blk.MetaLoc[:], it.fs, cnCreated, it.persistedDel, nil, fileservice.GetFileServicePolicy(it.ctx),
 	); it.err != nil {
 		return false
 	}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -70,12 +70,21 @@ const (
 var traceFilterExprInterval atomic.Uint64
 var traceFilterExprInterval2 atomic.Uint64
 
-// pkCheckSemaphore limits concurrent block I/O in PKPersistedBetween to prevent
+// pkCheckSemaphore limits concurrent PK conflict I/O in PKPersistedBetween to prevent
 // mpool explosion when many transactions simultaneously check primary key conflicts.
 var pkCheckSemaphore = make(chan struct{}, 16)
 
 const maxChangedObjectsForIO = 64
 const maxCandidateBlksForIO = 32
+
+func acquirePKCheckSemaphore(ctx context.Context) (func(), error) {
+	select {
+	case pkCheckSemaphore <- struct{}{}:
+		return func() { <-pkCheckSemaphore }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
 
 func shouldBailoutOnChangedObjects(cnt int) bool {
 	return cnt > maxChangedObjectsForIO
@@ -2508,6 +2517,13 @@ func (tbl *txnTable) PKPersistedBetween(
 		v2.TxnPKChangeCheckBailoutCounter.Inc()
 		return true, nil
 	}
+	if len(cObjs) > 0 || len(delObjs) > 0 || checkTombstone {
+		release, err := acquirePKCheckSemaphore(ctx)
+		if err != nil {
+			return false, err
+		}
+		defer release()
+	}
 
 	isFakePK := tbl.GetTableDef(ctx).Pkey.PkeyColName == catalog.FakePrimaryKeyColName
 	if err := ForeachCommittedObjects(cObjs, delObjs, p,
@@ -2631,16 +2647,6 @@ func (tbl *txnTable) PKPersistedBetween(
 	pkSeq := pkDef.Seqnum
 	pkType := plan2.ExprType2Type(&pkDef.Typ)
 	if len(candidateBlks) > 0 {
-		// Acquire semaphore to limit concurrent block I/O across all transactions.
-		// This prevents 1000 goroutines from simultaneously reading blocks and
-		// exhausting mpool capacity. Scoped to the block loop only — tombstone
-		// checking below is not rate-limited by this semaphore.
-		select {
-		case pkCheckSemaphore <- struct{}{}:
-		case <-ctx.Done():
-			return false, ctx.Err()
-		}
-
 		v2.TxnPKChangeCheckIOCounter.Inc()
 
 		for _, blk := range candidateBlks {
@@ -2655,7 +2661,6 @@ func (tbl *txnTable) PKPersistedBetween(
 				fileservice.Policy(0),
 			)
 			if err != nil {
-				<-pkCheckSemaphore
 				return true, err
 			}
 
@@ -2667,11 +2672,9 @@ func (tbl *txnTable) PKPersistedBetween(
 			sels := searchFunc(cacheVectors)
 			release()
 			if len(sels) > 0 {
-				<-pkCheckSemaphore
 				return true, nil
 			}
 		}
-		<-pkCheckSemaphore
 	}
 	if checkTombstone {
 		pkDef := tbl.tableDef.Cols[tbl.primaryIdx]

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2517,13 +2517,6 @@ func (tbl *txnTable) PKPersistedBetween(
 		v2.TxnPKChangeCheckBailoutCounter.Inc()
 		return true, nil
 	}
-	if len(cObjs) > 0 || len(delObjs) > 0 || checkTombstone {
-		release, err := acquirePKCheckSemaphore(ctx)
-		if err != nil {
-			return false, err
-		}
-		defer release()
-	}
 
 	isFakePK := tbl.GetTableDef(ctx).Pkey.PkeyColName == catalog.FakePrimaryKeyColName
 	if err := ForeachCommittedObjects(cObjs, delObjs, p,
@@ -2542,10 +2535,15 @@ func (tbl *txnTable) PKPersistedBetween(
 			var objMeta objectio.ObjectMeta
 			location := obj.Location()
 
+			semRelease, err := acquirePKCheckSemaphore(ctx)
+			if err != nil {
+				return err
+			}
 			// load object metadata
 			if objMeta, err2 = objectio.FastLoadObjectMeta(
 				ctx, &location, false, fs,
 			); err2 != nil {
+				semRelease()
 				return
 			}
 
@@ -2556,6 +2554,7 @@ func (tbl *txnTable) PKPersistedBetween(
 			// If object zone map doesn't contains the pk value, we need to check bloom filter
 			if !zmCkecked {
 				if !meta.MustGetColumn(uint16(primaryIdx)).ZoneMap().AnyIn(keys) {
+					semRelease()
 					return
 				}
 			}
@@ -2566,9 +2565,11 @@ func (tbl *txnTable) PKPersistedBetween(
 				if bf, err2 = objectio.LoadBFWithMeta(
 					ctx, meta, location, fs,
 				); err2 != nil {
+					semRelease()
 					return
 				}
 			}
+			semRelease()
 
 			objectio.ForeachBlkInObjStatsList(false, meta,
 				func(blk objectio.BlockInfo, blkMeta objectio.BlockObject) bool {
@@ -2650,7 +2651,11 @@ func (tbl *txnTable) PKPersistedBetween(
 		v2.TxnPKChangeCheckIOCounter.Inc()
 
 		for _, blk := range candidateBlks {
-			release, err := ioutil.LoadColumns(
+			semRelease, err := acquirePKCheckSemaphore(ctx)
+			if err != nil {
+				return false, err
+			}
+			dataRelease, err := ioutil.LoadColumns(
 				ctx,
 				[]uint16{uint16(pkSeq)},
 				[]types.Type{pkType},
@@ -2660,6 +2665,7 @@ func (tbl *txnTable) PKPersistedBetween(
 				tbl.proc.Load().GetMPool(),
 				fileservice.Policy(0),
 			)
+			semRelease()
 			if err != nil {
 				return true, err
 			}
@@ -2670,7 +2676,7 @@ func (tbl *txnTable) PKPersistedBetween(
 			}
 
 			sels := searchFunc(cacheVectors)
-			release()
+			dataRelease()
 			if len(sels) > 0 {
 				return true, nil
 			}
@@ -2717,13 +2723,18 @@ func tombstonePKExistsInRange(
 				vecCount = 2
 			}
 			tombVectors := containers.NewVectors(vecCount)
-			_, release, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType)
+			semRelease, err := acquirePKCheckSemaphore(ctx)
+			if err != nil {
+				return false, err
+			}
+			_, dataRelease, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType)
+			semRelease()
 			if err != nil {
 				return true, nil
 			}
 			pkVec := tombVectors[1]
 			hits := searchKeys(&pkVec)
-			release()
+			dataRelease()
 			if len(hits) > 0 {
 				return true, nil
 			}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -73,6 +73,7 @@ var traceFilterExprInterval2 atomic.Uint64
 // pkCheckSemaphore limits concurrent PK conflict I/O in PKPersistedBetween to prevent
 // mpool explosion when many transactions simultaneously check primary key conflicts.
 var pkCheckSemaphore = make(chan struct{}, 16)
+var pkConflictReadPolicy fileservice.Policy = fileservice.SkipFullFilePreloads
 
 const maxChangedObjectsForIO = 64
 const maxCandidateBlksForIO = 32
@@ -865,7 +866,7 @@ func (tbl *txnTable) countSingleTombstoneObject(
 			var release func()
 			// cnCreated=true because uncommitted tombstones are always CN-created
 			if _, release, readErr = ioutil.ReadDeletes(
-				ctx, blk.MetaLoc[:], fs, true, persistedDeletes, nil,
+				ctx, blk.MetaLoc[:], fs, true, persistedDeletes, nil, fileservice.GetFileServicePolicy(ctx),
 			); readErr != nil {
 				return false
 			}
@@ -2663,7 +2664,7 @@ func (tbl *txnTable) PKPersistedBetween(
 				blk.MetaLocation(),
 				cacheVectors,
 				tbl.proc.Load().GetMPool(),
-				fileservice.Policy(0),
+				pkConflictReadPolicy,
 			)
 			semRelease()
 			if err != nil {
@@ -2727,7 +2728,7 @@ func tombstonePKExistsInRange(
 			if err != nil {
 				return false, err
 			}
-			_, dataRelease, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType)
+			_, dataRelease, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType, pkConflictReadPolicy)
 			semRelease()
 			if err != nil {
 				return true, nil

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2666,8 +2666,8 @@ func (tbl *txnTable) PKPersistedBetween(
 				tbl.proc.Load().GetMPool(),
 				pkConflictReadPolicy,
 			)
-			semRelease()
 			if err != nil {
+				semRelease()
 				return true, err
 			}
 
@@ -2678,6 +2678,7 @@ func (tbl *txnTable) PKPersistedBetween(
 
 			sels := searchFunc(cacheVectors)
 			dataRelease()
+			semRelease()
 			if len(sels) > 0 {
 				return true, nil
 			}
@@ -2729,13 +2730,14 @@ func tombstonePKExistsInRange(
 				return false, err
 			}
 			_, dataRelease, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType, pkConflictReadPolicy)
-			semRelease()
 			if err != nil {
+				semRelease()
 				return true, nil
 			}
 			pkVec := tombVectors[1]
 			hits := searchKeys(&pkVec)
 			dataRelease()
+			semRelease()
 			if len(hits) > 0 {
 				return true, nil
 			}

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -41,6 +41,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type policyCaptureFS struct {
+	fileservice.FileService
+	policies []fileservice.Policy
+}
+
+func (fs *policyCaptureFS) Read(ctx context.Context, vector *fileservice.IOVector) error {
+	fs.policies = append(fs.policies, vector.Policy)
+	return fs.FileService.Read(ctx, vector)
+}
+
 func TestLinearSearchOffsetByValFactory_Varchar(t *testing.T) {
 	mp := mpool.MustNewZero()
 
@@ -167,6 +177,42 @@ func TestTombstonePKExistsInRange(t *testing.T) {
 	changed, err = tombstonePKExistsInRange(ctx, pState, types.BuildTS(25, 0), keys1, int32Type, fs)
 	require.NoError(t, err)
 	require.False(t, changed)
+}
+
+func TestTombstonePKExistsInRangeSkipsFullFilePreloads(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	proc := testutil.NewProc(t)
+	baseFS, err := fileservice.Get[fileservice.FileService](proc.GetFileService(), defines.SharedFileServiceName)
+	require.NoError(t, err)
+
+	pState := logtailreplay.NewPartitionState("", true, 0, false)
+	int32Type := types.T_int32.ToType()
+	writer := colexec.NewCNS3TombstoneWriter(proc.Mp(), baseFS, int32Type, -1)
+	bat := readutil.NewCNTombstoneBatch(&int32Type, objectio.HiddenColumnSelection_None)
+	require.NoError(t, vector.AppendFixed[types.Rowid](bat.Vecs[0], types.RandomRowid(), false, proc.GetMPool()))
+	require.NoError(t, vector.AppendFixed[int32](bat.Vecs[1], 100, false, proc.GetMPool()))
+	bat.SetRowCount(1)
+	require.NoError(t, writer.Write(ctx, bat))
+	stats, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+
+	require.NoError(t, pState.HandleObjectEntry(ctx, baseFS, objectio.ObjectEntry{
+		ObjectStats: stats[0],
+		CreateTime:  types.BuildTS(15, 0),
+	}, true))
+
+	keys := vector.NewVec(int32Type)
+	require.NoError(t, vector.AppendFixed[int32](keys, 100, false, proc.GetMPool()))
+
+	recordingFS := &policyCaptureFS{FileService: baseFS}
+	changed, err := tombstonePKExistsInRange(ctx, pState, types.BuildTS(10, 0), keys, int32Type, recordingFS)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.GreaterOrEqual(t, len(recordingFS.policies), 2)
+	require.Equal(t, fileservice.Policy(fileservice.SkipFullFilePreloads), recordingFS.policies[1])
 }
 
 func TestTombstonePKExistsInRangeEmptyFastPathSkipsSemaphore(t *testing.T) {

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -169,6 +169,26 @@ func TestTombstonePKExistsInRange(t *testing.T) {
 	require.False(t, changed)
 }
 
+func TestTombstonePKExistsInRangeEmptyFastPathSkipsSemaphore(t *testing.T) {
+	for i := 0; i < cap(pkCheckSemaphore); i++ {
+		pkCheckSemaphore <- struct{}{}
+	}
+	defer func() {
+		for i := 0; i < cap(pkCheckSemaphore); i++ {
+			<-pkCheckSemaphore
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	pState := logtailreplay.NewPartitionState("", true, 0, false)
+	keys := vector.NewVec(types.T_int32.ToType())
+	changed, err := tombstonePKExistsInRange(ctx, pState, types.BuildTS(10, 0), keys, types.T_int32.ToType(), nil)
+	require.NoError(t, err)
+	require.False(t, changed)
+}
+
 func TestBlockMetaMarshal(t *testing.T) {
 	location := []byte("test")
 	var info objectio.BlockInfo


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24534

## What this PR does / why we need it:

This PR reduces CN RSS pressure under high-concurrency TPCC / sysbench workloads.

1. Adds real target-based pressure eviction APIs for FileService memory cache and objectio metadata cache. Existing `EvictMemoryCaches` / `EvictCache` only evict to current capacity and do not release RSS when caches are already under cap.
2. Hooks CN RSS scavenging to evict caches by RSS watermark: >=85% actual memory lowers cache targets to 80% capacity, and >=92% lowers them to 50% capacity. A `debug.FreeOSMemory()` pass is also run after cache pressure eviction.
3. Adds begin/end logs for memory-cache and metadata-cache pressure eviction, including used-before, used-after, capacity, target, target-percent, duration, and context error, so we can tell whether eviction actually started and completed before an OOM.
4. Disables full-file preload only on the PK conflict / tombstone PK check paths. Normal scan workloads keep their default full-file preload behavior.
5. Moves `PKPersistedBetween` throttling earlier so the semaphore covers real metadata/BF/block/tombstone reads.
6. Adds tests for target-based cache eviction, RSS cache-eviction triggering/escalation, and policy propagation for PK/tombstone reads.

Validation:

```text
go test ./pkg/common/rscthrottler ./pkg/fileservice ./pkg/objectio -run 'TestMemThrottlerRSSCacheEvictionByRSSRate|TestMemThrottlerRSSCacheEvictionConcurrentEscalation|TestMemoryCacheEvictToCapacityPercent|TestNonExistent' -count=1
go test ./pkg/cnservice -run TestNonExistent -count=0
go test ./pkg/objectio/ioutil ./pkg/vm/engine/disttae ./pkg/common/rscthrottler -run 'TestLoadColumnsDataPropagatesPolicy|TestTombstonePKExistsInRangeSkipsFullFilePreloads|TestTombstonePKExistsInRange|TestMemThrottlerRSSCacheEvictionConcurrentEscalation|TestNonExistent' -count=1
```
