### PR TITLE
fix: cap fileservice event logger during cache eviction

### DIFF
--- a/pkg/fileservice/bytes.go
+++ b/pkg/fileservice/bytes.go
@@ -107,16 +107,16 @@ type cacheCapacityGuardedAllocator struct {
 var _ CacheDataAllocator = cacheCapacityGuardedAllocator{}
 
 func (c cacheCapacityGuardedAllocator) AllocateCacheData(ctx context.Context, size int) fscache.Data {
-	c.cache.EnsureNBytes(ctx, size)
+	c.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	return c.allocator.AllocateCacheData(ctx, size)
 }
 
 func (c cacheCapacityGuardedAllocator) AllocateCacheDataWithHint(ctx context.Context, size int, hints malloc.Hints) fscache.Data {
-	c.cache.EnsureNBytes(ctx, size)
+	c.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	return c.allocator.AllocateCacheDataWithHint(ctx, size, hints)
 }
 
 func (c cacheCapacityGuardedAllocator) CopyToCacheData(ctx context.Context, data []byte) fscache.Data {
-	c.cache.EnsureNBytes(ctx, len(data))
+	c.cache.EnsureNBytes(withoutEventLogger(ctx), len(data))
 	return c.allocator.CopyToCacheData(ctx, data)
 }

--- a/pkg/fileservice/event_logger.go
+++ b/pkg/fileservice/event_logger.go
@@ -26,11 +26,14 @@ import (
 )
 
 type eventLogger struct {
-	begin  time.Time
-	mu     sync.Mutex
-	events *[]event
-	closed bool
+	begin   time.Time
+	mu      sync.Mutex
+	events  *[]event
+	dropped int
+	closed  bool
 }
+
+const maxEventLoggerEvents = 1024
 
 type event struct {
 	time  time.Duration
@@ -61,17 +64,28 @@ func WithEventLogger(ctx context.Context) context.Context {
 
 func LogEvent(ctx context.Context, ev stringRef, args ...any) {
 	v := ctx.Value(EventLoggerKey)
-	if v == nil {
+	logger, ok := v.(*eventLogger)
+	if !ok || logger == nil {
 		return
 	}
-	logger := v.(*eventLogger)
 	logger.emit(ev, args...)
+}
+
+func withoutEventLogger(ctx context.Context) context.Context {
+	if ctx.Value(EventLoggerKey) == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, EventLoggerKey, nil)
 }
 
 func (e *eventLogger) emit(ev stringRef, args ...any) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.closed {
+		return
+	}
+	if len(*e.events) >= maxEventLoggerEvents {
+		e.dropped++
 		return
 	}
 	*e.events = append(*e.events, event{})
@@ -91,8 +105,11 @@ func LogSlowEvent(ctx context.Context, threshold time.Duration) {
 
 	logger.mu.Lock()
 	defer func() {
-		*logger.events = (*logger.events)[:0]
-		eventsPool.Put(logger.events)
+		events := logger.events
+		*events = (*events)[:0]
+		if cap(*events) <= maxEventLoggerEvents {
+			eventsPool.Put(events)
+		}
 		logger.events = nil
 		logger.closed = true
 		logger.mu.Unlock()
@@ -122,6 +139,7 @@ func LogSlowEvent(ctx context.Context, threshold time.Duration) {
 
 	logutil.Info("slow event",
 		zap.String("events", buf.String()),
+		zap.Int("dropped-events", logger.dropped),
 	)
 }
 

--- a/pkg/fileservice/event_logger_test.go
+++ b/pkg/fileservice/event_logger_test.go
@@ -28,6 +28,49 @@ func TestEventLogger(t *testing.T) {
 	LogSlowEvent(ctx, time.Nanosecond)
 }
 
+func TestEventLoggerDropsAfterLimit(t *testing.T) {
+	ctx := WithEventLogger(context.Background())
+	logger := ctx.Value(EventLoggerKey).(*eventLogger)
+
+	for i := 0; i < maxEventLoggerEvents+7; i++ {
+		LogEvent(ctx, str_to_cache_data_begin, i)
+	}
+
+	logger.mu.Lock()
+	if n := len(*logger.events); n != maxEventLoggerEvents {
+		t.Fatalf("got %d events, want %d", n, maxEventLoggerEvents)
+	}
+	if logger.dropped != 7 {
+		t.Fatalf("got %d dropped events, want 7", logger.dropped)
+	}
+	logger.mu.Unlock()
+
+	LogSlowEvent(ctx, time.Hour)
+}
+
+func TestWithoutEventLogger(t *testing.T) {
+	ctx := WithEventLogger(context.Background())
+	logger := ctx.Value(EventLoggerKey).(*eventLogger)
+
+	child := withoutEventLogger(ctx)
+	LogEvent(child, str_to_cache_data_begin)
+
+	logger.mu.Lock()
+	if n := len(*logger.events); n != 0 {
+		t.Fatalf("got %d parent events after child log, want 0", n)
+	}
+	logger.mu.Unlock()
+
+	LogEvent(ctx, str_to_cache_data_begin)
+	logger.mu.Lock()
+	if n := len(*logger.events); n != 1 {
+		t.Fatalf("got %d parent events after parent log, want 1", n)
+	}
+	logger.mu.Unlock()
+
+	LogSlowEvent(ctx, time.Hour)
+}
+
 func BenchmarkEventLogger(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ctx := context.Background()

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -121,21 +121,21 @@ func NewLocalFS(
 
 func (l *LocalFS) AllocateCacheData(ctx context.Context, size int) fscache.Data {
 	if l.memCache != nil {
-		l.memCache.cache.EnsureNBytes(ctx, size)
+		l.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	}
 	return DefaultCacheDataAllocator().AllocateCacheData(ctx, size)
 }
 
 func (l *LocalFS) AllocateCacheDataWithHint(ctx context.Context, size int, hints malloc.Hints) fscache.Data {
 	if l.memCache != nil {
-		l.memCache.cache.EnsureNBytes(ctx, size)
+		l.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	}
 	return DefaultCacheDataAllocator().AllocateCacheDataWithHint(ctx, size, hints)
 }
 
 func (l *LocalFS) CopyToCacheData(ctx context.Context, data []byte) fscache.Data {
 	if l.memCache != nil {
-		l.memCache.cache.EnsureNBytes(ctx, len(data))
+		l.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), len(data))
 	}
 	return DefaultCacheDataAllocator().CopyToCacheData(ctx, data)
 }

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -161,21 +161,21 @@ func NewS3FS(
 
 func (s *S3FS) AllocateCacheData(ctx context.Context, size int) fscache.Data {
 	if s.memCache != nil {
-		s.memCache.cache.EnsureNBytes(ctx, size)
+		s.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	}
 	return DefaultCacheDataAllocator().AllocateCacheData(ctx, size)
 }
 
 func (s *S3FS) AllocateCacheDataWithHint(ctx context.Context, size int, hints malloc.Hints) fscache.Data {
 	if s.memCache != nil {
-		s.memCache.cache.EnsureNBytes(ctx, size)
+		s.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	}
 	return DefaultCacheDataAllocator().AllocateCacheDataWithHint(ctx, size, hints)
 }
 
 func (s *S3FS) CopyToCacheData(ctx context.Context, data []byte) fscache.Data {
 	if s.memCache != nil {
-		s.memCache.cache.EnsureNBytes(ctx, len(data))
+		s.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), len(data))
 	}
 	return DefaultCacheDataAllocator().CopyToCacheData(ctx, data)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24534

## What this PR does / why we need it:

Follow-up to #24535 for the remaining CN OOM path seen in nightly regression.

The previous RSS cache-eviction fix does trigger and can evict SHARED memory
cache to the hard target, but high-concurrency point-select reads may still
enter `EnsureNBytes -> EvictWithWait -> runPendingPostEvicts` while carrying
the request-scoped fileservice event logger. Each evicted memory-cache entry
then appends post-evict events to the same slow-event buffer, amplifying Go heap
while the CN is already under RSS pressure.

This PR:

1. Caps per-request fileservice event logger entries and reports dropped event
   count in slow-event logs.
2. Keeps cache-capacity eviction done before cache-data allocation out of the
   request event logger, so post-evict callbacks cannot inflate a single read
   request's event buffer.
3. Adds focused tests for event dropping and event logger stripping.

Validation:

```text
GOCACHE=/private/tmp/go-build-cache go test ./pkg/fileservice -run 'TestEventLogger|TestWithoutEventLogger|TestDiskCacheReadEnsuresMemoryCacheCapacity|TestMemoryCacheEvictToCapacityPercent' -count=1
```
