### PR TITLE
fix: keep cache pressure target under high RSS

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -75,7 +75,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
-const rssCacheFamilyEvictTimeout = 10 * time.Second
+const (
+	rssCacheFamilyEvictTimeout   = 10 * time.Second
+	rssCacheAdmissionPressureTTL = 2 * time.Minute
+)
 
 var (
 	evictMemoryCachesToCapacityPercent = fileservice.EvictMemoryCachesToCapacityPercent
@@ -83,16 +86,31 @@ var (
 )
 
 func makeRSSCacheEvictor(timeout time.Duration) func(context.Context, int64) {
-	return func(_ context.Context, targetPercent int64) {
+	return func(ctx context.Context, targetPercent int64) {
+		// Keep admission throttled after eviction; otherwise high-concurrency
+		// reads can refill SHARED/meta caches before the next RSS sample.
+		pressureUntil := time.Now().Add(rssCacheAdmissionPressureTTL)
+		fileservice.SetMemoryCachePressureTargetPercent(targetPercent, pressureUntil)
+		objectio.SetMetaCachePressureTargetPercent(targetPercent, pressureUntil)
+
 		// Use independent bounded contexts so one cache family timing out
 		// does not prevent the other family from being pressure-evicted.
-		memoryCtx, cancel := context.WithTimeout(context.Background(), timeout)
-		evictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
-		cancel()
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			memoryCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			evictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
+		}()
 
-		metaCtx, cancel := context.WithTimeout(context.Background(), timeout)
-		evictMetaCacheToCapacityPercent(metaCtx, targetPercent)
-		cancel()
+		go func() {
+			defer wg.Done()
+			metaCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			evictMetaCacheToCapacityPercent(metaCtx, targetPercent)
+		}()
+		wg.Wait()
 	}
 }
 

--- a/pkg/cnservice/server_test.go
+++ b/pkg/cnservice/server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/lockservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/pipeline"
 	qclient "github.com/matrixorigin/matrixone/pkg/queryservice/client"
@@ -219,6 +220,9 @@ func Test_tenant(t *testing.T) {
 }
 
 func TestMakeRSSCacheEvictorUsesIndependentTimeouts(t *testing.T) {
+	defer fileservice.SetMemoryCachePressureTargetPercent(0, time.Time{})
+	defer objectio.SetMetaCachePressureTargetPercent(0, time.Time{})
+
 	oldMem := evictMemoryCachesToCapacityPercent
 	oldMeta := evictMetaCacheToCapacityPercent
 	defer func() {

--- a/pkg/fileservice/fifocache/data_cache.go
+++ b/pkg/fileservice/fifocache/data_cache.go
@@ -49,6 +49,10 @@ func NewDataCacheWithPrepareSet(
 	}
 }
 
+func (d *DataCache) SetAdmissionTarget(admissionTarget func(capacity int64) (int64, bool)) {
+	d.fifo.SetAdmissionTarget(admissionTarget)
+}
+
 var seed = maphash.MakeSeed()
 
 func shardCacheKey(key fscache.CacheKey) uint64 {

--- a/pkg/fileservice/fifocache/fifo.go
+++ b/pkg/fileservice/fifocache/fifo.go
@@ -35,6 +35,11 @@ type Cache[K comparable, V any] struct {
 	capacity     fscache.CapacityFunc
 	capacity1    fscache.CapacityFunc
 	keyShardFunc func(K) uint64
+	// admissionTarget, when active, applies an additional pressure target to
+	// new insertions. The actual check is performed under queueLock in the
+	// insertion/accounting path so concurrent Set callers do not all admit
+	// against the same stale Used() snapshot.
+	admissionTarget func(capacity int64) (int64, bool)
 
 	prepareSet func(ctx context.Context, key K, value V, size int64, seq uint64) func(inserted bool)
 	postSet    func(ctx context.Context, key K, value V, size int64, seq uint64)
@@ -145,7 +150,11 @@ func NewWithPrepareSet[K comparable, V any](
 	return ret
 }
 
-func (c *Cache[K, V]) set(ctx context.Context, key K, value V, size int64, seq uint64) (item *_CacheItem[K, V], ghostItemSet bool) {
+func (c *Cache[K, V]) SetAdmissionTarget(admissionTarget func(capacity int64) (int64, bool)) {
+	c.admissionTarget = admissionTarget
+}
+
+func (c *Cache[K, V]) set(ctx context.Context, key K, value V, size int64, seq uint64) (item *_CacheItem[K, V], replacedGhost *_CacheItem[K, V]) {
 	shard := &c.shards[c.keyShardFunc(key)%numShards]
 	shard.Lock()
 	defer shard.Unlock()
@@ -165,11 +174,11 @@ func (c *Cache[K, V]) set(ctx context.Context, key K, value V, size int64, seq u
 			}
 			// replacing the oldItem. oldItem will be evicted from ghost queue eventually.
 			shard.values[key] = item
-			return item, true
+			return item, oldItem
 		}
 
 		// existed and value ok, skip set
-		return nil, false
+		return nil, nil
 	}
 
 	item = &_CacheItem[K, V]{
@@ -181,7 +190,7 @@ func (c *Cache[K, V]) set(ctx context.Context, key K, value V, size int64, seq u
 	}
 	shard.values[key] = item
 
-	return item, false
+	return item, nil
 }
 
 func (c *Cache[K, V]) Set(ctx context.Context, key K, value V, size int64) {
@@ -197,7 +206,28 @@ func (c *Cache[K, V]) Set(ctx context.Context, key K, value V, size int64) {
 			finishSet(inserted)
 		}
 	}()
-	if item, ghostItemSet := c.set(ctx, key, value, size, seq); item != nil {
+	if item, replacedGhost := c.set(ctx, key, value, size, seq); item != nil {
+		ghostItemSet := replacedGhost != nil
+		if c.shouldApplyAdmissionTarget() {
+			if !c.enqueueWithAdmission(item, ghostItemSet) {
+				inserted = c.rollbackRejectedSet(item, replacedGhost)
+				if finishSet != nil {
+					finishSet(inserted)
+					finished = true
+				}
+				return
+			}
+			inserted = true
+			if c.postSet != nil {
+				c.postSet(ctx, key, value, size, item.seq)
+			}
+			if finishSet != nil {
+				finishSet(true)
+				finished = true
+			}
+			c.Evict(ctx, nil, 0)
+			return
+		}
 		inserted = true
 		if c.postSet != nil {
 			c.postSet(ctx, key, value, size, item.seq)
@@ -213,6 +243,69 @@ func (c *Cache[K, V]) Set(ctx context.Context, key K, value V, size int64) {
 		finishSet(false)
 		finished = true
 	}
+}
+
+func (c *Cache[K, V]) shouldApplyAdmissionTarget() bool {
+	_, ok := c.currentAdmissionTarget()
+	return ok
+}
+
+func (c *Cache[K, V]) currentAdmissionTarget() (int64, bool) {
+	if c.admissionTarget == nil {
+		return 0, false
+	}
+	return c.admissionTarget(c.capacity())
+}
+
+func (c *Cache[K, V]) enqueueWithAdmission(item *_CacheItem[K, V], ghostItemSet bool) bool {
+	c.queueLock.Lock()
+	defer c.queueLock.Unlock()
+
+	c.helpEnqueue()
+
+	queue := cacheItemQueue1
+	if ghostItemSet {
+		queue = cacheItemQueue2
+	}
+
+	target, ok := c.currentAdmissionTarget()
+	if !ok {
+		c.enqueuePendingItem(item, queue)
+		c.helpEnqueue()
+		return item.queue == queue
+	}
+	if c.used1+c.used2+item.size > target {
+		return false
+	}
+
+	c.enqueuePendingItem(item, queue)
+	c.helpEnqueue()
+	return item.queue == queue
+}
+
+func (c *Cache[K, V]) rollbackRejectedSet(item, replacedGhost *_CacheItem[K, V]) (finishInserted bool) {
+	shard := &c.shards[c.keyShardFunc(item.key)%numShards]
+	shard.Lock()
+	defer shard.Unlock()
+
+	if !item.valueOK {
+		// Another path already purged and released the item value (for example
+		// Delete racing with Set). Preserve inserted=true when finishing so
+		// prepareSet does not release the value a second time.
+		return true
+	}
+
+	if shard.values[item.key] == item {
+		if replacedGhost != nil && replacedGhost.queue == cacheItemGhost {
+			shard.values[item.key] = replacedGhost
+		} else {
+			delete(shard.values, item.key)
+		}
+	}
+	item.valueOK = false
+	var zero V
+	item.value = zero
+	return false
 }
 
 func (c *Cache[K, V]) enqueue(item *_CacheItem[K, V], ghostItemSet bool) {

--- a/pkg/fileservice/fifocache/fifo_test.go
+++ b/pkg/fileservice/fifocache/fifo_test.go
@@ -16,6 +16,7 @@ package fifocache
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -166,6 +167,39 @@ func TestGhostQueue(t *testing.T) {
 	// 2 is in the ghost queue now
 	cache.Set(t.Context(), 3, 3, 1)
 	// 2 was evicted from ghost queue
+}
+
+func TestCachePressureAdmissionIsAtomic(t *testing.T) {
+	cache := New[int, int](
+		fscache.ConstCapacity(100),
+		ShardInt[int],
+		nil, nil, nil,
+	)
+	cache.SetAdmissionTarget(func(capacity int64) (int64, bool) {
+		return 50, true
+	})
+
+	ctx := t.Context()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cache.Set(ctx, i, i, 1)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(50), cache.used())
+
+	live := 0
+	for i := 0; i < 100; i++ {
+		_, ok := cache.Get(ctx, i)
+		if ok {
+			live++
+		}
+	}
+	assert.Equal(t, 50, live)
 }
 
 func TestReplaceUpdatesUsedBytes(t *testing.T) {

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"hash/maphash"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/fifocache"
@@ -33,6 +35,60 @@ type MemCache struct {
 }
 
 var memCacheCallbackSeed = maphash.MakeSeed()
+
+var (
+	memCachePressureMu            sync.Mutex
+	memCachePressureTargetPercent atomic.Int64
+	memCachePressureDeadline      atomic.Int64
+)
+
+// SetMemoryCachePressureTargetPercent keeps memory cache admission below a
+// capacity percentage until the deadline. A stricter active target is not
+// loosened by a softer target.
+func SetMemoryCachePressureTargetPercent(percent int64, until time.Time) {
+	now := time.Now()
+	if percent <= 0 || !until.After(now) {
+		memCachePressureMu.Lock()
+		memCachePressureTargetPercent.Store(0)
+		memCachePressureDeadline.Store(0)
+		memCachePressureMu.Unlock()
+		return
+	}
+	if percent > 100 {
+		percent = 100
+	}
+
+	memCachePressureMu.Lock()
+	defer memCachePressureMu.Unlock()
+
+	oldDeadline := memCachePressureDeadline.Load()
+	oldPercent := memCachePressureTargetPercent.Load()
+	if oldDeadline > now.UnixNano() && oldPercent > 0 && oldPercent < percent {
+		return
+	}
+	memCachePressureTargetPercent.Store(percent)
+	memCachePressureDeadline.Store(until.UnixNano())
+}
+
+func clearMemoryCachePressureTargetForTest() {
+	memCachePressureTargetPercent.Store(0)
+	memCachePressureDeadline.Store(0)
+}
+
+func memoryCachePressureTarget(capacity int64) (int64, bool) {
+	deadline := memCachePressureDeadline.Load()
+	if deadline == 0 || time.Now().UnixNano() > deadline {
+		return 0, false
+	}
+	percent := memCachePressureTargetPercent.Load()
+	if percent <= 0 {
+		return 0, false
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	return capacity * percent / 100, true
+}
 
 func (m *MemCache) callbacksLock(key fscache.CacheKey) *sync.Mutex {
 	var hasher maphash.Hash
@@ -242,11 +298,27 @@ func (m *MemCache) Update(
 			Sz:     entry.Size,
 		}
 
+		size := entry.Size
+		if size <= 0 {
+			size = int64(len(entry.CachedData.Bytes()))
+		}
+		if m.shouldSkipPressureAdmission(size) {
+			continue
+		}
+
 		LogEvent(ctx, str_set_memory_cache_entry_begin)
 		m.cache.Set(ctx, key, entry.CachedData)
 		LogEvent(ctx, str_set_memory_cache_entry_end)
 	}
 	return nil
+}
+
+func (m *MemCache) shouldSkipPressureAdmission(size int64) bool {
+	target, ok := memoryCachePressureTarget(m.cache.Capacity())
+	if !ok {
+		return false
+	}
+	return m.cache.Used()+size > target
 }
 
 func (m *MemCache) Flush(ctx context.Context) {

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -207,6 +207,7 @@ func NewMemCache(
 	}
 
 	dataCache = fifocache.NewDataCacheWithPrepareSet(capacityFunc, prepareSetFn, postSetFn, postGetFn, postEvictFn)
+	dataCache.SetAdmissionTarget(memoryCachePressureTarget)
 
 	ret.cache = dataCache
 
@@ -298,27 +299,11 @@ func (m *MemCache) Update(
 			Sz:     entry.Size,
 		}
 
-		size := entry.Size
-		if size <= 0 {
-			size = int64(len(entry.CachedData.Bytes()))
-		}
-		if m.shouldSkipPressureAdmission(size) {
-			continue
-		}
-
 		LogEvent(ctx, str_set_memory_cache_entry_begin)
 		m.cache.Set(ctx, key, entry.CachedData)
 		LogEvent(ctx, str_set_memory_cache_entry_end)
 	}
 	return nil
-}
-
-func (m *MemCache) shouldSkipPressureAdmission(size int64) bool {
-	target, ok := memoryCachePressureTarget(m.cache.Capacity())
-	if !ok {
-		return false
-	}
-	return m.cache.Used()+size > target
 }
 
 func (m *MemCache) Flush(ctx context.Context) {

--- a/pkg/fileservice/mem_cache_test.go
+++ b/pkg/fileservice/mem_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
@@ -536,4 +537,74 @@ func TestMemoryCacheEvictToCapacityPercent(t *testing.T) {
 	ret := EvictMemoryCachesToCapacityPercent(ctx, 50)
 	assert.Equal(t, int64(5), ret["test-target-evict"])
 	assert.LessOrEqual(t, cache.cache.Used(), int64(5))
+}
+
+func TestMemoryCachePressureAdmissionSkipsWritesAboveTarget(t *testing.T) {
+	ctx := context.Background()
+	clearMemoryCachePressureTargetForTest()
+	defer clearMemoryCachePressureTargetForTest()
+
+	cache := NewMemCache(
+		fscache.ConstCapacity(10),
+		nil,
+		nil,
+		"",
+	)
+	defer cache.Close(ctx)
+
+	SetMemoryCachePressureTargetPercent(50, time.Now().Add(time.Minute))
+
+	for i := 0; i < 5; i++ {
+		vec := &IOVector{
+			FilePath: "foo",
+			Entries: []IOEntry{{
+				Offset:     int64(i),
+				Size:       1,
+				CachedData: staticTestData([]byte{byte(i)}),
+			}},
+		}
+		assert.NoError(t, cache.Update(ctx, vec, false))
+	}
+	assert.Equal(t, int64(5), cache.cache.Used())
+
+	vec := &IOVector{
+		FilePath: "foo",
+		Entries: []IOEntry{{
+			Offset:     5,
+			Size:       1,
+			CachedData: staticTestData([]byte{5}),
+		}},
+	}
+	assert.NoError(t, cache.Update(ctx, vec, false))
+	assert.Equal(t, int64(5), cache.cache.Used())
+
+	_, ok := cache.cache.Get(ctx, fscache.CacheKey{Path: "foo", Offset: 5, Sz: 1})
+	assert.False(t, ok)
+}
+
+func TestMemoryCachePressureAdmissionExpires(t *testing.T) {
+	ctx := context.Background()
+	clearMemoryCachePressureTargetForTest()
+	defer clearMemoryCachePressureTargetForTest()
+
+	cache := NewMemCache(
+		fscache.ConstCapacity(10),
+		nil,
+		nil,
+		"",
+	)
+	defer cache.Close(ctx)
+
+	SetMemoryCachePressureTargetPercent(50, time.Now().Add(-time.Second))
+
+	vec := &IOVector{
+		FilePath: "foo",
+		Entries: []IOEntry{{
+			Offset:     0,
+			Size:       1,
+			CachedData: staticTestData([]byte{1}),
+		}},
+	}
+	assert.NoError(t, cache.Update(ctx, vec, false))
+	assert.Equal(t, int64(1), cache.cache.Used())
 }

--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -78,6 +78,12 @@ type mataCacheKey [cacheKeyLen]byte
 var metaCache *fifocache.Cache[mataCacheKey, []byte]
 var onceInit sync.Once
 
+var (
+	metaCachePressureMu            sync.Mutex
+	metaCachePressureTargetPercent atomic.Int64
+	metaCachePressureDeadline      atomic.Int64
+)
+
 // metaLoadGroup deduplicates concurrent loads for the same cache key,
 // preventing cache stampede when many goroutines miss the same entry simultaneously.
 // Uses mutex+map instead of sync.Map so entries are fully reclaimed after deletion.
@@ -132,6 +138,62 @@ func InitMetaCache(size int64) {
 	onceInit.Do(func() {
 		metaCache = newMetaCache(cacheCapacityFunc(size))
 	})
+}
+
+// SetMetaCachePressureTargetPercent keeps metadata cache admission below a
+// capacity percentage until the deadline. A stricter active target is not
+// loosened by a softer target.
+func SetMetaCachePressureTargetPercent(percent int64, until time.Time) {
+	now := time.Now()
+	if percent <= 0 || !until.After(now) {
+		metaCachePressureMu.Lock()
+		metaCachePressureTargetPercent.Store(0)
+		metaCachePressureDeadline.Store(0)
+		metaCachePressureMu.Unlock()
+		return
+	}
+	if percent > 100 {
+		percent = 100
+	}
+
+	metaCachePressureMu.Lock()
+	defer metaCachePressureMu.Unlock()
+
+	oldDeadline := metaCachePressureDeadline.Load()
+	oldPercent := metaCachePressureTargetPercent.Load()
+	if oldDeadline > now.UnixNano() && oldPercent > 0 && oldPercent < percent {
+		return
+	}
+	metaCachePressureTargetPercent.Store(percent)
+	metaCachePressureDeadline.Store(until.UnixNano())
+}
+
+func clearMetaCachePressureTargetForTest() {
+	metaCachePressureTargetPercent.Store(0)
+	metaCachePressureDeadline.Store(0)
+}
+
+func metaCachePressureTarget(capacity int64) (int64, bool) {
+	deadline := metaCachePressureDeadline.Load()
+	if deadline == 0 || time.Now().UnixNano() > deadline {
+		return 0, false
+	}
+	percent := metaCachePressureTargetPercent.Load()
+	if percent <= 0 {
+		return 0, false
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	return capacity * percent / 100, true
+}
+
+func shouldSkipMetaCacheAdmission(size int64) bool {
+	target, ok := metaCachePressureTarget(metaCache.Capacity())
+	if !ok {
+		return false
+	}
+	return metaCache.Used()+size > target
 }
 
 func newMetaCache(capacity fscache.CapacityFunc) *fifocache.Cache[mataCacheKey, []byte] {
@@ -308,7 +370,7 @@ func dedupLoad(ctx context.Context, key mataCacheKey, load func() ([]byte, error
 	}()
 
 	call.val, call.err = load()
-	if call.err == nil {
+	if call.err == nil && !shouldSkipMetaCacheAdmission(int64(len(call.val))) {
 		metaCache.Set(ctx, key, call.val, int64(len(call.val)))
 	}
 	return call.val, call.err

--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -188,18 +188,10 @@ func metaCachePressureTarget(capacity int64) (int64, bool) {
 	return capacity * percent / 100, true
 }
 
-func shouldSkipMetaCacheAdmission(size int64) bool {
-	target, ok := metaCachePressureTarget(metaCache.Capacity())
-	if !ok {
-		return false
-	}
-	return metaCache.Used()+size > target
-}
-
 func newMetaCache(capacity fscache.CapacityFunc) *fifocache.Cache[mataCacheKey, []byte] {
 	inuseBytes, capacityBytes := metric.GetFsCacheBytesGauge("", "meta")
 	capacityBytes.Set(float64(capacity()))
-	return fifocache.New[mataCacheKey, []byte](
+	ret := fifocache.New[mataCacheKey, []byte](
 		capacity,
 		shardMetaCacheKey,
 		func(_ context.Context, _ mataCacheKey, _ []byte, size int64, _ uint64) { // postSet
@@ -211,6 +203,8 @@ func newMetaCache(capacity fscache.CapacityFunc) *fifocache.Cache[mataCacheKey, 
 			inuseBytes.Add(float64(-size))
 			capacityBytes.Set(float64(capacity()))
 		})
+	ret.SetAdmissionTarget(metaCachePressureTarget)
+	return ret
 }
 
 func EvictCache(ctx context.Context) (target int64) {
@@ -370,7 +364,7 @@ func dedupLoad(ctx context.Context, key mataCacheKey, load func() ([]byte, error
 	}()
 
 	call.val, call.err = load()
-	if call.err == nil && !shouldSkipMetaCacheAdmission(int64(len(call.val))) {
+	if call.err == nil {
 		metaCache.Set(ctx, key, call.val, int64(len(call.val)))
 	}
 	return call.val, call.err

--- a/pkg/objectio/meta_test.go
+++ b/pkg/objectio/meta_test.go
@@ -148,3 +148,54 @@ func TestEvictCacheToCapacityPercent(t *testing.T) {
 	assert.LessOrEqual(t, used, int64(5))
 	assert.Equal(t, used, metaCache.Used())
 }
+
+func TestMetaCachePressureAdmissionSkipsWritesAboveTarget(t *testing.T) {
+	oldMetaCache := metaCache
+	metaCache = newMetaCache(fscache.ConstCapacity(10))
+	clearMetaCachePressureTargetForTest()
+	defer func() {
+		clearMetaCachePressureTargetForTest()
+		metaCache = oldMetaCache
+	}()
+
+	ctx := context.Background()
+	var existingKey mataCacheKey
+	existingKey[0] = 4
+	metaCache.Set(ctx, existingKey, []byte("12345"), 5)
+
+	SetMetaCachePressureTargetPercent(50, time.Now().Add(time.Minute))
+
+	var key mataCacheKey
+	key[0] = 5
+	v, err := dedupLoad(ctx, key, func() ([]byte, error) {
+		return []byte("6"), nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("6"), v)
+	assert.Equal(t, int64(5), metaCache.Used())
+
+	_, ok := metaCache.Get(ctx, key)
+	assert.False(t, ok)
+}
+
+func TestMetaCachePressureAdmissionExpires(t *testing.T) {
+	oldMetaCache := metaCache
+	metaCache = newMetaCache(fscache.ConstCapacity(10))
+	clearMetaCachePressureTargetForTest()
+	defer func() {
+		clearMetaCachePressureTargetForTest()
+		metaCache = oldMetaCache
+	}()
+
+	ctx := context.Background()
+	SetMetaCachePressureTargetPercent(50, time.Now().Add(-time.Second))
+
+	var key mataCacheKey
+	key[0] = 6
+	v, err := dedupLoad(ctx, key, func() ([]byte, error) {
+		return []byte("1"), nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("1"), v)
+	assert.Equal(t, int64(1), metaCache.Used())
+}

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -37,6 +37,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/lockservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
@@ -58,6 +59,38 @@ import (
 )
 
 var _ engine.Engine = new(Engine)
+
+const (
+	workspaceRSSCacheFamilyEvictTimeout   = 10 * time.Second
+	workspaceRSSCacheAdmissionPressureTTL = 2 * time.Minute
+)
+
+func makeWorkspaceRSSCacheEvictor(timeout time.Duration) func(context.Context, int64) {
+	return func(ctx context.Context, targetPercent int64) {
+		// Workspace traffic is often the first path to observe hard RSS
+		// pressure, so apply the same sticky cache target used by CNFlushS3.
+		pressureUntil := time.Now().Add(workspaceRSSCacheAdmissionPressureTTL)
+		fileservice.SetMemoryCachePressureTargetPercent(targetPercent, pressureUntil)
+		objectio.SetMetaCachePressureTargetPercent(targetPercent, pressureUntil)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			memoryCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			fileservice.EvictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
+		}()
+
+		go func() {
+			defer wg.Done()
+			metaCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			objectio.EvictCacheToCapacityPercent(metaCtx, targetPercent)
+		}()
+		wg.Wait()
+	}
+}
 
 func New(
 	ctx context.Context,
@@ -141,18 +174,23 @@ func New(
 	}
 
 	if e.config.memThrottler == nil {
+		throttlerOptions := []rscthrottler.MemThrottlerOption{
+			rscthrottler.WithRSSScavenging(),
+			rscthrottler.WithRSSCacheEvictor(
+				makeWorkspaceRSSCacheEvictor(workspaceRSSCacheFamilyEvictTimeout),
+			),
+		}
 		if e.config.quota.Load() != 0 {
-			e.config.memThrottler = rscthrottler.NewMemThrottler(
-				"Workspace",
-				5.0/100.0,
+			throttlerOptions = append(
+				throttlerOptions,
 				rscthrottler.WithConstLimit(int64(e.config.quota.Load())),
 			)
-		} else {
-			e.config.memThrottler = rscthrottler.NewMemThrottler(
-				"Workspace",
-				5.0/100.0,
-			)
 		}
+		e.config.memThrottler = rscthrottler.NewMemThrottler(
+			"Workspace",
+			5.0/100.0,
+			throttlerOptions...,
+		)
 
 		v2.TxnExtraWorkspaceQuotaGauge.Set(float64(e.config.memThrottler.Available()))
 	}


### PR DESCRIPTION
## Summary

Fixes #24534.

This follows the post-#24542 OOM evidence from the 4.0-dev nightly run:

- `nightly-regression-dis-tp-cn-6t6mx` was OOMKilled during sysbench update-index 1000.
- The image already included #24542, and Pyroscope no longer showed `fileservice.eventLogger.emit` as the dominant heap owner.
- RSS reached hard pressure while `Workspace` observed the pressure, but only the CNFlushS3 throttler had RSS cache eviction configured.
- SHARED memory cache was evicted once, then refilled back near its cap before the next RSS sample.

## Changes

- Enable RSS scavenging/cache eviction on the default `Workspace` throttler, so hard RSS observed by workspace allocation paths can evict memory/meta caches to the hard target.
- Add sticky pressure admission targets for fileservice memory cache and objectio metadata cache.
- Keep stricter active targets from being loosened by later softer targets.
- Skip memory/meta cache writes while a pressure target is active and the write would refill cache above that target.

## Tests

- `GOCACHE=/private/tmp/matrixone-rss-cache-gocache go test ./pkg/fileservice -run 'TestMemoryCachePressureAdmission|TestMemoryCacheEvictToCapacityPercent'`

Local broader package tests are blocked by existing environment dependencies:

- `go test ./pkg/objectio ...` and `go test ./pkg/cnservice ...` fail during build because this machine is missing `usearch.h` and `xxhash.h`.
- Full `pkg/fileservice` tests also hit sandbox networking restrictions in `httptest` listener setup.
