### PR TITLE
to 4.0: fix(plan): support nested correlated subqueries (cherry-pick #24537)

### DIFF
--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -1053,6 +1053,19 @@ func TestSubQuery(t *testing.T) {
 		"SELECT * FROM NATION where N_REGIONKEY > (select max(R_REGIONKEY) + 1 from REGION where R_REGIONKEY < N_REGIONKEY)",                         // non-eq agg scalar subquery with computed projection
 	}
 	runTestShouldError(mock, t, sqls)
+
+	sql := `SELECT * FROM NATION n1 WHERE n1.N_NATIONKEY > ANY (
+		SELECT n2.N_NATIONKEY FROM NATION n2 WHERE n2.N_NATIONKEY = ANY (
+			SELECT n3.N_NATIONKEY FROM NATION n3
+			WHERE (n3.N_NATIONKEY = n2.N_NATIONKEY AND n2.N_REGIONKEY = n1.N_REGIONKEY)
+				OR n3.N_REGIONKEY = 1
+		)
+	)`
+	_, err := runOneStmt(mock, t, sql)
+	assert.Error(t, err)
+	if err != nil {
+		assert.Contains(t, err.Error(), "deep correlated predicate containing inner columns cannot be pulled above mark join")
+	}
 }
 
 func TestMysqlCompatibilityMode(t *testing.T) {

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -1005,6 +1005,30 @@ func TestSubQuery(t *testing.T) {
 		"SELECT * FROM NATION where N_REGIONKEY > (select max(R_REGIONKEY) from REGION where N_NAME = R_NAME and R_REGIONKEY < N_REGIONKEY)", // mixed eq + non-eq predicates -> two pullup-added GroupBy entries
 		"SELECT * FROM NATION where (select count(*) from REGION where N_NAME = R_NAME and R_REGIONKEY < N_REGIONKEY) = 1",                   // count(*) with mixed eq + non-eq predicates
 		"SELECT * FROM NATION where (select avg(R_REGIONKEY) from REGION where N_NAME = R_NAME and R_REGIONKEY < N_REGIONKEY) = 1",           // avg with mixed eq + non-eq predicates
+		`SELECT * FROM NATION n1 WHERE EXISTS (
+			SELECT 1 FROM NATION n2 WHERE EXISTS (
+				SELECT 1 FROM NATION n3
+				WHERE n3.N_NATIONKEY = n2.N_NATIONKEY AND n2.N_NATIONKEY = n1.N_NATIONKEY
+			)
+		)`, // two-level correlated EXISTS subquery
+		`SELECT * FROM NATION n1 WHERE NOT EXISTS (
+			SELECT 1 FROM NATION n2 WHERE EXISTS (
+				SELECT 1 FROM NATION n3
+				WHERE n3.N_NATIONKEY = n2.N_NATIONKEY AND n2.N_NATIONKEY = n1.N_NATIONKEY
+			)
+		)`, // two-level correlated NOT EXISTS subquery
+		`SELECT * FROM NATION n1 WHERE n1.N_NATIONKEY IN (
+			SELECT n2.N_NATIONKEY FROM NATION n2 WHERE n2.N_NATIONKEY IN (
+				SELECT n3.N_NATIONKEY FROM NATION n3
+				WHERE n3.N_NATIONKEY = n2.N_NATIONKEY AND n2.N_NATIONKEY = n1.N_NATIONKEY
+			)
+		)`, // two-level correlated IN subquery
+		`SELECT * FROM NATION n1 WHERE n1.N_NATIONKEY NOT IN (
+			SELECT n2.N_NATIONKEY FROM NATION n2 WHERE n2.N_NATIONKEY IN (
+				SELECT n3.N_NATIONKEY FROM NATION n3
+				WHERE n3.N_NATIONKEY = n2.N_NATIONKEY AND n2.N_NATIONKEY = n1.N_NATIONKEY
+			)
+		)`, // two-level correlated NOT IN subquery
 	}
 	runTestShouldPass(mock, t, sqls, false, false)
 

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -1029,6 +1029,18 @@ func TestSubQuery(t *testing.T) {
 				WHERE n3.N_NATIONKEY = n2.N_NATIONKEY AND n2.N_NATIONKEY = n1.N_NATIONKEY
 			)
 		)`, // two-level correlated NOT IN subquery
+		`SELECT * FROM NATION n1 WHERE n1.N_NATIONKEY = ANY (
+			SELECT n2.N_NATIONKEY FROM NATION n2 WHERE n2.N_NATIONKEY = ANY (
+				SELECT n3.N_NATIONKEY FROM NATION n3
+				WHERE n3.N_NATIONKEY = n2.N_NATIONKEY AND n2.N_NATIONKEY = n1.N_NATIONKEY
+			)
+		)`, // two-level correlated ANY subquery
+		`SELECT * FROM NATION n1 WHERE n1.N_NATIONKEY > ALL (
+			SELECT n2.N_NATIONKEY FROM NATION n2 WHERE n2.N_NATIONKEY = ANY (
+				SELECT n3.N_NATIONKEY FROM NATION n3
+				WHERE n3.N_NATIONKEY = n2.N_NATIONKEY AND n2.N_NATIONKEY < n1.N_NATIONKEY
+			)
+		)`, // two-level correlated ALL subquery
 	}
 	runTestShouldPass(mock, t, sqls, false, false)
 

--- a/pkg/sql/plan/flatten_subquery.go
+++ b/pkg/sql/plan/flatten_subquery.go
@@ -280,7 +280,13 @@ func (builder *QueryBuilder) flattenSubquery(nodeID int32, subquery *plan.Subque
 			return 0, nil, err
 		}
 
-		return builder.insertMarkJoin(nodeID, subID, joinPreds, outerPred, false, ctx)
+		var markExpr *plan.Expr
+		nodeID, markExpr, err = builder.insertMarkJoin(nodeID, subID, joinPreds, outerPred, false, ctx)
+		if err != nil {
+			return 0, nil, err
+		}
+		nodeID = builder.appendDeepCorrelatedFilters(nodeID, filterPreds, ctx)
+		return nodeID, markExpr, nil
 
 	case plan.SubqueryRef_ALL:
 		outerPred, err := builder.generateRowComparison(subquery.Op, subquery.Child, subCtx, false)
@@ -293,7 +299,13 @@ func (builder *QueryBuilder) flattenSubquery(nodeID int32, subquery *plan.Subque
 			return 0, nil, err
 		}
 
-		return builder.insertMarkJoin(nodeID, subID, joinPreds, outerPred, true, ctx)
+		var markExpr *plan.Expr
+		nodeID, markExpr, err = builder.insertMarkJoin(nodeID, subID, joinPreds, outerPred, true, ctx)
+		if err != nil {
+			return 0, nil, err
+		}
+		nodeID = builder.appendDeepCorrelatedFilters(nodeID, filterPreds, ctx)
+		return nodeID, markExpr, nil
 
 	default:
 		return 0, nil, moerr.NewNotSupportedf(builder.GetContext(), "%s subquery not supported", subquery.Typ.String())
@@ -350,7 +362,8 @@ func (builder *QueryBuilder) insertMarkJoin(left, right int32, joinPreds []*plan
 
 func canPullupDeepCorrelatedPredicates(typ plan.SubqueryRef_Type) bool {
 	switch typ {
-	case plan.SubqueryRef_EXISTS, plan.SubqueryRef_NOT_EXISTS, plan.SubqueryRef_IN, plan.SubqueryRef_NOT_IN:
+	case plan.SubqueryRef_EXISTS, plan.SubqueryRef_NOT_EXISTS, plan.SubqueryRef_IN, plan.SubqueryRef_NOT_IN,
+		plan.SubqueryRef_ANY, plan.SubqueryRef_ALL:
 		return true
 	default:
 		return false

--- a/pkg/sql/plan/flatten_subquery.go
+++ b/pkg/sql/plan/flatten_subquery.go
@@ -137,7 +137,7 @@ func (builder *QueryBuilder) flattenSubquery(nodeID int32, subquery *plan.Subque
 
 	filterPreds, joinPreds := decreaseDepthAndDispatch(preds)
 
-	if len(filterPreds) > 0 && subquery.Typ >= plan.SubqueryRef_SCALAR {
+	if len(filterPreds) > 0 && !canPullupDeepCorrelatedPredicates(subquery.Typ) {
 		return 0, nil, moerr.NewNYIf(builder.GetContext(), "correlated columns in %s subquery deeper than 1 level will be supported in future version", subquery.Typ.String())
 	}
 
@@ -224,7 +224,13 @@ func (builder *QueryBuilder) flattenSubquery(nodeID int32, subquery *plan.Subque
 			joinPreds = append(joinPreds, constTrue)
 		}
 
-		return builder.insertMarkJoin(nodeID, subID, joinPreds, nil, false, ctx)
+		var markExpr *plan.Expr
+		nodeID, markExpr, err = builder.insertMarkJoin(nodeID, subID, joinPreds, nil, false, ctx)
+		if err != nil {
+			return 0, nil, err
+		}
+		nodeID = builder.appendDeepCorrelatedFilters(nodeID, filterPreds, ctx)
+		return nodeID, markExpr, nil
 
 	case plan.SubqueryRef_NOT_EXISTS:
 		// Uncorrelated subquery
@@ -232,7 +238,13 @@ func (builder *QueryBuilder) flattenSubquery(nodeID int32, subquery *plan.Subque
 			joinPreds = append(joinPreds, constTrue)
 		}
 
-		return builder.insertMarkJoin(nodeID, subID, joinPreds, nil, true, ctx)
+		var markExpr *plan.Expr
+		nodeID, markExpr, err = builder.insertMarkJoin(nodeID, subID, joinPreds, nil, true, ctx)
+		if err != nil {
+			return 0, nil, err
+		}
+		nodeID = builder.appendDeepCorrelatedFilters(nodeID, filterPreds, ctx)
+		return nodeID, markExpr, nil
 
 	case plan.SubqueryRef_IN:
 		outerPred, err := builder.generateRowComparison("=", subquery.Child, subCtx, false)
@@ -240,7 +252,13 @@ func (builder *QueryBuilder) flattenSubquery(nodeID int32, subquery *plan.Subque
 			return 0, nil, err
 		}
 
-		return builder.insertMarkJoin(nodeID, subID, joinPreds, outerPred, false, ctx)
+		var markExpr *plan.Expr
+		nodeID, markExpr, err = builder.insertMarkJoin(nodeID, subID, joinPreds, outerPred, false, ctx)
+		if err != nil {
+			return 0, nil, err
+		}
+		nodeID = builder.appendDeepCorrelatedFilters(nodeID, filterPreds, ctx)
+		return nodeID, markExpr, nil
 
 	case plan.SubqueryRef_NOT_IN:
 		outerPred, err := builder.generateRowComparison("=", subquery.Child, subCtx, false)
@@ -248,7 +266,13 @@ func (builder *QueryBuilder) flattenSubquery(nodeID int32, subquery *plan.Subque
 			return 0, nil, err
 		}
 
-		return builder.insertMarkJoin(nodeID, subID, joinPreds, outerPred, true, ctx)
+		var markExpr *plan.Expr
+		nodeID, markExpr, err = builder.insertMarkJoin(nodeID, subID, joinPreds, outerPred, true, ctx)
+		if err != nil {
+			return 0, nil, err
+		}
+		nodeID = builder.appendDeepCorrelatedFilters(nodeID, filterPreds, ctx)
+		return nodeID, markExpr, nil
 
 	case plan.SubqueryRef_ANY:
 		outerPred, err := builder.generateRowComparison(subquery.Op, subquery.Child, subCtx, false)
@@ -322,6 +346,27 @@ func (builder *QueryBuilder) insertMarkJoin(left, right int32, joinPreds []*plan
 	}
 
 	return
+}
+
+func canPullupDeepCorrelatedPredicates(typ plan.SubqueryRef_Type) bool {
+	switch typ {
+	case plan.SubqueryRef_EXISTS, plan.SubqueryRef_NOT_EXISTS, plan.SubqueryRef_IN, plan.SubqueryRef_NOT_IN:
+		return true
+	default:
+		return false
+	}
+}
+
+func (builder *QueryBuilder) appendDeepCorrelatedFilters(nodeID int32, filterPreds []*plan.Expr, ctx *BindContext) int32 {
+	if len(filterPreds) == 0 {
+		return nodeID
+	}
+
+	return builder.appendNode(&plan.Node{
+		NodeType:   plan.Node_FILTER,
+		Children:   []int32{nodeID},
+		FilterList: filterPreds,
+	}, ctx)
 }
 
 func getProjectExpr(idx int, ctx *BindContext, strip bool) *plan.Expr {

--- a/pkg/sql/plan/flatten_subquery.go
+++ b/pkg/sql/plan/flatten_subquery.go
@@ -137,8 +137,13 @@ func (builder *QueryBuilder) flattenSubquery(nodeID int32, subquery *plan.Subque
 
 	filterPreds, joinPreds := decreaseDepthAndDispatch(preds)
 
-	if len(filterPreds) > 0 && !canPullupDeepCorrelatedPredicates(subquery.Typ) {
-		return 0, nil, moerr.NewNYIf(builder.GetContext(), "correlated columns in %s subquery deeper than 1 level will be supported in future version", subquery.Typ.String())
+	if len(filterPreds) > 0 {
+		if !canPullupDeepCorrelatedPredicates(subquery.Typ) {
+			return 0, nil, moerr.NewNYIf(builder.GetContext(), "correlated columns in %s subquery deeper than 1 level will be supported in future version", subquery.Typ.String())
+		}
+		if builder.hasInnerColumnInDeepCorrelatedFilters(subID, filterPreds) {
+			return 0, nil, moerr.NewNYIf(builder.GetContext(), "deep correlated predicate containing inner columns cannot be pulled above mark join")
+		}
 	}
 
 	switch subquery.Typ {
@@ -368,6 +373,22 @@ func canPullupDeepCorrelatedPredicates(typ plan.SubqueryRef_Type) bool {
 	default:
 		return false
 	}
+}
+
+func (builder *QueryBuilder) hasInnerColumnInDeepCorrelatedFilters(subID int32, filterPreds []*plan.Expr) bool {
+	if len(filterPreds) == 0 {
+		return false
+	}
+
+	innerTags := builder.collectBindingTags(builder.qry.Nodes[subID])
+	for _, pred := range filterPreds {
+		for tag := range innerTags {
+			if containsTag(pred, tag) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (builder *QueryBuilder) appendDeepCorrelatedFilters(nodeID int32, filterPreds []*plan.Expr, ctx *BindContext) int32 {

--- a/pkg/sql/plan/flatten_subquery_test.go
+++ b/pkg/sql/plan/flatten_subquery_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanPullupDeepCorrelatedPredicates(t *testing.T) {
+	for _, tc := range []struct {
+		typ  plan.SubqueryRef_Type
+		want bool
+	}{
+		{typ: plan.SubqueryRef_EXISTS, want: true},
+		{typ: plan.SubqueryRef_NOT_EXISTS, want: true},
+		{typ: plan.SubqueryRef_IN, want: true},
+		{typ: plan.SubqueryRef_NOT_IN, want: true},
+		{typ: plan.SubqueryRef_ANY, want: true},
+		{typ: plan.SubqueryRef_ALL, want: true},
+		{typ: plan.SubqueryRef_SCALAR, want: false},
+	} {
+		t.Run(tc.typ.String(), func(t *testing.T) {
+			require.Equal(t, tc.want, canPullupDeepCorrelatedPredicates(tc.typ))
+		})
+	}
+}
+
+func TestHasInnerColumnInDeepCorrelatedFilters(t *testing.T) {
+	const (
+		subID    int32 = 0
+		innerTag int32 = 1
+		outerTag int32 = 2
+	)
+
+	builder := &QueryBuilder{
+		qry: &plan.Query{
+			Nodes: []*plan.Node{
+				{
+					NodeId:      subID,
+					NodeType:    plan.Node_TABLE_SCAN,
+					BindingTags: []int32{innerTag},
+				},
+			},
+		},
+	}
+
+	require.False(t, builder.hasInnerColumnInDeepCorrelatedFilters(subID, nil))
+	require.False(t, builder.hasInnerColumnInDeepCorrelatedFilters(subID, []*plan.Expr{}))
+	require.True(t, builder.hasInnerColumnInDeepCorrelatedFilters(subID, []*plan.Expr{
+		newFlattenSubqueryTestColExpr(innerTag),
+	}))
+	require.False(t, builder.hasInnerColumnInDeepCorrelatedFilters(subID, []*plan.Expr{
+		newFlattenSubqueryTestColExpr(outerTag),
+	}))
+}
+
+func newFlattenSubqueryTestColExpr(tag int32) *plan.Expr {
+	return &plan.Expr{
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{
+				RelPos: tag,
+			},
+		},
+	}
+}

--- a/test/distributed/cases/subquery/subquery-with-any.result
+++ b/test/distributed/cases/subquery/subquery-with-any.result
@@ -539,3 +539,64 @@ id
 DROP TABLE IF EXISTS corr_any_t1;
 DROP TABLE IF EXISTS corr_any_t2;
 DROP TABLE IF EXISTS corr_any_t3;
+DROP TABLE IF EXISTS corr_quant_outer;
+DROP TABLE IF EXISTS corr_quant_mid;
+DROP TABLE IF EXISTS corr_quant_inner;
+create table corr_quant_outer(id int, grp int);
+create table corr_quant_mid(grp int, val int);
+create table corr_quant_inner(grp int, val int);
+insert into corr_quant_outer values (1, 1), (2, 1), (4, 1), (5, 9), (7, 3);
+insert into corr_quant_mid values (1, 1), (1, 3), (3, null);
+insert into corr_quant_inner values (1, 1), (1, 3), (3, null);
+select o.id from corr_quant_outer o where o.grp = 1 and o.id > any (
+select m.val from corr_quant_mid m where m.val = any (
+select i.val from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+)
+) order by o.id;
+id
+2
+4
+select o.id from corr_quant_outer o where o.grp = 1 and o.id > all (
+select m.val from corr_quant_mid m where m.val = any (
+select i.val from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+)
+) order by o.id;
+id
+4
+select o.id from corr_quant_outer o where o.grp = 9 and o.id > any (
+select m.val from corr_quant_mid m where m.val = any (
+select i.val from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+)
+) order by o.id;
+id
+select o.id from corr_quant_outer o where o.grp = 9 and o.id > all (
+select m.val from corr_quant_mid m where m.val = any (
+select i.val from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+)
+) order by o.id;
+id
+5
+select o.id from corr_quant_outer o where o.grp = 3 and (o.id = any (
+select m.val from corr_quant_mid m where m.grp = any (
+select i.grp from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+)
+)) is null order by o.id;
+id
+7
+select o.id from corr_quant_outer o where o.grp = 3 and (o.id > all (
+select m.val from corr_quant_mid m where m.grp = any (
+select i.grp from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+)
+)) is null order by o.id;
+id
+7
+select o.id from corr_quant_outer o where o.grp = 3 and (o.id not in (
+select m.val from corr_quant_mid m where m.grp = any (
+select i.grp from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+)
+)) is null order by o.id;
+id
+7
+DROP TABLE IF EXISTS corr_quant_outer;
+DROP TABLE IF EXISTS corr_quant_mid;
+DROP TABLE IF EXISTS corr_quant_inner;

--- a/test/distributed/cases/subquery/subquery-with-any.result
+++ b/test/distributed/cases/subquery/subquery-with-any.result
@@ -503,3 +503,39 @@ SQL syntax error: column "t2s.i" must appear in the GROUP BY clause or be used i
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t1s;
 DROP TABLE IF EXISTS t2s;
+DROP TABLE IF EXISTS corr_any_t1;
+DROP TABLE IF EXISTS corr_any_t2;
+DROP TABLE IF EXISTS corr_any_t3;
+create table corr_any_t1(id int);
+create table corr_any_t2(id int);
+create table corr_any_t3(id int);
+insert into corr_any_t1 values (1), (2), (3);
+insert into corr_any_t2 values (1), (2);
+insert into corr_any_t3 values (1);
+select c1.id from corr_any_t1 c1 where c1.id = any (
+select c2.id from corr_any_t2 c2 where c2.id = any (
+select c3.id from corr_any_t3 c3 where c3.id = c2.id and c2.id = c1.id
+)
+) order by c1.id;
+id
+1
+select c1.id from corr_any_t1 c1 where c1.id > any (
+select c2.id from corr_any_t2 c2 where c2.id = any (
+select c3.id from corr_any_t3 c3 where c3.id = c2.id and c2.id < c1.id
+)
+) order by c1.id;
+id
+2
+3
+select c1.id from corr_any_t1 c1 where c1.id > all (
+select c2.id from corr_any_t2 c2 where c2.id = any (
+select c3.id from corr_any_t3 c3 where c3.id = c2.id and c2.id < c1.id
+)
+) order by c1.id;
+id
+1
+2
+3
+DROP TABLE IF EXISTS corr_any_t1;
+DROP TABLE IF EXISTS corr_any_t2;
+DROP TABLE IF EXISTS corr_any_t3;

--- a/test/distributed/cases/subquery/subquery-with-any.sql
+++ b/test/distributed/cases/subquery/subquery-with-any.sql
@@ -366,6 +366,57 @@ DROP TABLE IF EXISTS corr_any_t1;
 DROP TABLE IF EXISTS corr_any_t2;
 DROP TABLE IF EXISTS corr_any_t3;
 
+-- @case
+-- @desc:test nested correlated ANY/ALL/NOT IN quantifier semantics with NULL and empty set
+-- @label:bvt
+DROP TABLE IF EXISTS corr_quant_outer;
+DROP TABLE IF EXISTS corr_quant_mid;
+DROP TABLE IF EXISTS corr_quant_inner;
+create table corr_quant_outer(id int, grp int);
+create table corr_quant_mid(grp int, val int);
+create table corr_quant_inner(grp int, val int);
+insert into corr_quant_outer values (1, 1), (2, 1), (4, 1), (5, 9), (7, 3);
+insert into corr_quant_mid values (1, 1), (1, 3), (3, null);
+insert into corr_quant_inner values (1, 1), (1, 3), (3, null);
+select o.id from corr_quant_outer o where o.grp = 1 and o.id > any (
+    select m.val from corr_quant_mid m where m.val = any (
+        select i.val from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+    )
+) order by o.id;
+select o.id from corr_quant_outer o where o.grp = 1 and o.id > all (
+    select m.val from corr_quant_mid m where m.val = any (
+        select i.val from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+    )
+) order by o.id;
+select o.id from corr_quant_outer o where o.grp = 9 and o.id > any (
+    select m.val from corr_quant_mid m where m.val = any (
+        select i.val from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+    )
+) order by o.id;
+select o.id from corr_quant_outer o where o.grp = 9 and o.id > all (
+    select m.val from corr_quant_mid m where m.val = any (
+        select i.val from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+    )
+) order by o.id;
+select o.id from corr_quant_outer o where o.grp = 3 and (o.id = any (
+    select m.val from corr_quant_mid m where m.grp = any (
+        select i.grp from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+    )
+)) is null order by o.id;
+select o.id from corr_quant_outer o where o.grp = 3 and (o.id > all (
+    select m.val from corr_quant_mid m where m.grp = any (
+        select i.grp from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+    )
+)) is null order by o.id;
+select o.id from corr_quant_outer o where o.grp = 3 and (o.id not in (
+    select m.val from corr_quant_mid m where m.grp = any (
+        select i.grp from corr_quant_inner i where i.grp = m.grp and m.grp = o.grp
+    )
+)) is null order by o.id;
+DROP TABLE IF EXISTS corr_quant_outer;
+DROP TABLE IF EXISTS corr_quant_mid;
+DROP TABLE IF EXISTS corr_quant_inner;
+
 
 
 

--- a/test/distributed/cases/subquery/subquery-with-any.sql
+++ b/test/distributed/cases/subquery/subquery-with-any.sql
@@ -335,6 +335,37 @@ DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t1s;
 DROP TABLE IF EXISTS t2s;
 
+-- @case
+-- @desc:test for nested correlated ANY and ALL subquery
+-- @label:bvt
+DROP TABLE IF EXISTS corr_any_t1;
+DROP TABLE IF EXISTS corr_any_t2;
+DROP TABLE IF EXISTS corr_any_t3;
+create table corr_any_t1(id int);
+create table corr_any_t2(id int);
+create table corr_any_t3(id int);
+insert into corr_any_t1 values (1), (2), (3);
+insert into corr_any_t2 values (1), (2);
+insert into corr_any_t3 values (1);
+select c1.id from corr_any_t1 c1 where c1.id = any (
+    select c2.id from corr_any_t2 c2 where c2.id = any (
+        select c3.id from corr_any_t3 c3 where c3.id = c2.id and c2.id = c1.id
+    )
+) order by c1.id;
+select c1.id from corr_any_t1 c1 where c1.id > any (
+    select c2.id from corr_any_t2 c2 where c2.id = any (
+        select c3.id from corr_any_t3 c3 where c3.id = c2.id and c2.id < c1.id
+    )
+) order by c1.id;
+select c1.id from corr_any_t1 c1 where c1.id > all (
+    select c2.id from corr_any_t2 c2 where c2.id = any (
+        select c3.id from corr_any_t3 c3 where c3.id = c2.id and c2.id < c1.id
+    )
+) order by c1.id;
+DROP TABLE IF EXISTS corr_any_t1;
+DROP TABLE IF EXISTS corr_any_t2;
+DROP TABLE IF EXISTS corr_any_t3;
+
 
 
 

--- a/test/distributed/cases/subquery/subquery-with-exists.result
+++ b/test/distributed/cases/subquery/subquery-with-exists.result
@@ -519,3 +519,30 @@ SELECT * FROM t1  WHERE EXISTS (SELECT DISTINCT a FROM t2 WHERE t1.a < t2.a ORDE
 SQL syntax error: for SELECT DISTINCT, ORDER BY expressions must appear in select list
 drop table if exists t1;
 drop table if exists t2;
+drop table if exists corr_exists_t1;
+drop table if exists corr_exists_t2;
+drop table if exists corr_exists_t3;
+create table corr_exists_t1(id int);
+create table corr_exists_t2(id int);
+create table corr_exists_t3(id int);
+insert into corr_exists_t1 values (1), (2), (3);
+insert into corr_exists_t2 values (1), (2);
+insert into corr_exists_t3 values (1);
+select c1.id from corr_exists_t1 c1 where exists (
+select 1 from corr_exists_t2 c2 where exists (
+select 1 from corr_exists_t3 c3 where c3.id = c2.id and c2.id = c1.id
+)
+) order by c1.id;
+id
+1
+select c1.id from corr_exists_t1 c1 where not exists (
+select 1 from corr_exists_t2 c2 where exists (
+select 1 from corr_exists_t3 c3 where c3.id = c2.id and c2.id = c1.id
+)
+) order by c1.id;
+id
+2
+3
+drop table if exists corr_exists_t1;
+drop table if exists corr_exists_t2;
+drop table if exists corr_exists_t3;

--- a/test/distributed/cases/subquery/subquery-with-exists.sql
+++ b/test/distributed/cases/subquery/subquery-with-exists.sql
@@ -406,3 +406,28 @@ SELECT * FROM t1  WHERE EXISTS (SELECT DISTINCT a FROM t2 WHERE t1.a < t2.a ORDE
 
 drop table if exists t1;
 drop table if exists t2;
+-- @case
+-- @desc:test for nested correlated EXISTS subquery
+-- @label:bvt
+drop table if exists corr_exists_t1;
+drop table if exists corr_exists_t2;
+drop table if exists corr_exists_t3;
+create table corr_exists_t1(id int);
+create table corr_exists_t2(id int);
+create table corr_exists_t3(id int);
+insert into corr_exists_t1 values (1), (2), (3);
+insert into corr_exists_t2 values (1), (2);
+insert into corr_exists_t3 values (1);
+select c1.id from corr_exists_t1 c1 where exists (
+    select 1 from corr_exists_t2 c2 where exists (
+        select 1 from corr_exists_t3 c3 where c3.id = c2.id and c2.id = c1.id
+    )
+) order by c1.id;
+select c1.id from corr_exists_t1 c1 where not exists (
+    select 1 from corr_exists_t2 c2 where exists (
+        select 1 from corr_exists_t3 c3 where c3.id = c2.id and c2.id = c1.id
+    )
+) order by c1.id;
+drop table if exists corr_exists_t1;
+drop table if exists corr_exists_t2;
+drop table if exists corr_exists_t3;

--- a/test/distributed/cases/subquery/subquery-with-in.result
+++ b/test/distributed/cases/subquery/subquery-with-in.result
@@ -1650,5 +1650,32 @@ id    count(*)
 24    1
 25    1
 26    1
+drop table if exists corr_in_t1;
+drop table if exists corr_in_t2;
+drop table if exists corr_in_t3;
+create table corr_in_t1(id int);
+create table corr_in_t2(id int);
+create table corr_in_t3(id int);
+insert into corr_in_t1 values (1), (2), (3);
+insert into corr_in_t2 values (1), (2);
+insert into corr_in_t3 values (1);
+select c1.id from corr_in_t1 c1 where c1.id in (
+select c2.id from corr_in_t2 c2 where c2.id in (
+select c3.id from corr_in_t3 c3 where c3.id = c2.id and c2.id = c1.id
+)
+) order by c1.id;
+id
+1
+select c1.id from corr_in_t1 c1 where c1.id not in (
+select c2.id from corr_in_t2 c2 where c2.id in (
+select c3.id from corr_in_t3 c3 where c3.id = c2.id and c2.id = c1.id
+)
+) order by c1.id;
+id
+2
+3
+drop table if exists corr_in_t1;
+drop table if exists corr_in_t2;
+drop table if exists corr_in_t3;
 drop table test;
 drop database test;

--- a/test/distributed/cases/subquery/subquery-with-in.sql
+++ b/test/distributed/cases/subquery/subquery-with-in.sql
@@ -1188,5 +1188,31 @@ select id, count(*) from test group by id order by count(*) desc;
 update test set status = 3 where is_deleted = 0 and (id in (10, 11, 12, 10, 13, 10) and is_deleted = 0 and tenant_id = '000000');
 select id, count(*) from test group by id order by count(*) desc;
 
+-- @case
+-- @desc:test for nested correlated IN subquery
+-- @label:bvt
+drop table if exists corr_in_t1;
+drop table if exists corr_in_t2;
+drop table if exists corr_in_t3;
+create table corr_in_t1(id int);
+create table corr_in_t2(id int);
+create table corr_in_t3(id int);
+insert into corr_in_t1 values (1), (2), (3);
+insert into corr_in_t2 values (1), (2);
+insert into corr_in_t3 values (1);
+select c1.id from corr_in_t1 c1 where c1.id in (
+    select c2.id from corr_in_t2 c2 where c2.id in (
+        select c3.id from corr_in_t3 c3 where c3.id = c2.id and c2.id = c1.id
+    )
+) order by c1.id;
+select c1.id from corr_in_t1 c1 where c1.id not in (
+    select c2.id from corr_in_t2 c2 where c2.id in (
+        select c3.id from corr_in_t3 c3 where c3.id = c2.id and c2.id = c1.id
+    )
+) order by c1.id;
+drop table if exists corr_in_t1;
+drop table if exists corr_in_t2;
+drop table if exists corr_in_t3;
+
 drop table test;
 drop database test;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23110

## What this PR does / why we need it:

Cherry-picks #24537 to `4.0-dev`.

- Extends nested correlated subquery flattening for `EXISTS`, `IN`, `ANY`, and `ALL`.
- Appends supported deep correlated filters after mark joins.
- Rejects unsafe deep correlated mark filters that still reference inner columns.
- Adds planner and BVT coverage for nested correlated quantifier cases.

Cherry-picked commits:

- 3f3f20d3ae27befdb5e732b959f24be4adc1671d `fix(plan): support nested correlated exists and in subqueries`
- d4b5b491107e8f6c9f2ab19db779642a479f4af4 `fix(plan): support nested correlated any and all subqueries`
- 2d262929c16eefe2027fbe65890965b1b143e032 `test: cover nested correlated quantifier edge cases`
- 1539b4f414e53c3ef5acbad12c5cd78800f3a818 `fix(plan): reject unsafe deep correlated mark filters`
- fedc13f96972ab545ef761d81b37018905c17883 `test(plan): cover deep correlated mark filter guards`

Validation: not run, per cherry-pick request.