### PR TITLE
Cherry pick: rename table & null/negative limit and offset

### DIFF
--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -3741,16 +3741,34 @@ func buildAlterView(stmt *tree.AlterView, ctx CompilerContext) (*Plan, error) {
 
 func buildRenameTable(stmt *tree.RenameTable, ctx CompilerContext) (*Plan, error) {
 
+	type renamedInfo struct {
+		objRef   *ObjectRef
+		tableDef *TableDef
+	}
 	alterTables := stmt.AlterTables
 	renameTables := make([]*plan.AlterTable, 0)
+	removed := make(map[string]bool)
+	nameMapping := make(map[string]*renamedInfo)
 	for _, alterTable := range alterTables {
 		schemaName, tableName := string(alterTable.Table.Schema()), string(alterTable.Table.Name())
 		if schemaName == "" {
 			schemaName = ctx.DefaultDatabase()
 		}
-		objRef, tableDef, err := ctx.Resolve(schemaName, tableName, nil)
-		if err != nil {
-			return nil, err
+		srcKey := schemaName + "." + tableName
+		var objRef *ObjectRef
+		var tableDef *TableDef
+		var err error
+		if info, ok := nameMapping[srcKey]; ok {
+			objRef = info.objRef
+			tableDef = DeepCopyTableDef(info.tableDef, true)
+			tableDef.Name = tableName
+		} else if removed[srcKey] {
+			return nil, moerr.NewNoSuchTable(ctx.GetContext(), schemaName, tableName)
+		} else {
+			objRef, tableDef, err = ctx.Resolve(schemaName, tableName, nil)
+			if err != nil {
+				return nil, err
+			}
 		}
 		if tableDef == nil {
 			return nil, moerr.NewNoSuchTable(ctx.GetContext(), schemaName, tableName)
@@ -3787,15 +3805,21 @@ func buildRenameTable(stmt *tree.RenameTable, ctx CompilerContext) (*Plan, error
 		for i, option := range alterTable.Options {
 			switch opt := option.(type) {
 			case *tree.AlterOptionTableName:
-				oldName := tableDef.Name
+				oldName := tableName
 				newName := string(opt.Name.ToTableName().ObjectName)
+				dstKey := schemaName + "." + newName
 				if oldName != newName {
-					_, tableDef, err := ctx.Resolve(schemaName, newName, nil)
-					if err != nil {
-						return nil, err
-					}
-					if tableDef != nil {
+					if _, ok := nameMapping[dstKey]; ok {
 						return nil, moerr.NewTableAlreadyExists(ctx.GetContext(), newName)
+					}
+					if !removed[dstKey] {
+						_, existDef, err := ctx.Resolve(schemaName, newName, nil)
+						if err != nil {
+							return nil, err
+						}
+						if existDef != nil {
+							return nil, moerr.NewTableAlreadyExists(ctx.GetContext(), newName)
+						}
 					}
 				}
 				alterTablePlan.Actions[i] = &plan.AlterTable_Action{
@@ -3807,9 +3831,12 @@ func buildRenameTable(stmt *tree.RenameTable, ctx CompilerContext) (*Plan, error
 					},
 				}
 				updateSqls = append(updateSqls, getSqlForRenameTable(schemaName, oldName, newName)...)
+				delete(nameMapping, srcKey)
+				removed[srcKey] = true
+				nameMapping[dstKey] = &renamedInfo{objRef: objRef, tableDef: tableDef}
+				delete(removed, dstKey)
 
 			default:
-				// return err
 				return nil, moerr.NewNotSupportedf(ctx.GetContext(), "statement: '%v'", tree.String(stmt, dialect.MYSQL))
 			}
 			alterTablePlan.UpdateFkSqls = updateSqls

--- a/pkg/sql/plan/limit_binder.go
+++ b/pkg/sql/plan/limit_binder.go
@@ -21,20 +21,34 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
 
-func NewLimitBinder(builder *QueryBuilder, ctx *BindContext) *LimitBinder {
+func NewLimitBinder(builder *QueryBuilder, ctx *BindContext, isOffset bool) *LimitBinder {
 	lb := &LimitBinder{}
 	lb.sysCtx = builder.GetContext()
 	lb.builder = builder
 	lb.ctx = ctx
 	lb.impl = lb
+	lb.isOffset = isOffset
 	return lb
 }
 
 func (b *LimitBinder) BindExpr(astExpr tree.Expr, depth int32, isRoot bool) (*plan.Expr, error) {
 	switch astExpr.(type) {
 	case *tree.UnqualifiedStar:
-		// need check other expr
 		return nil, moerr.NewSyntaxError(b.GetContext(), "unsupported expr in limit clause")
+	}
+
+	// Handle LIMIT -N / OFFSET -N: unary minus applied to a numeric literal.
+	// The parser produces tree.UnaryExpr{UNARY_MINUS, NumVal}, and baseBindExpr
+	// does not fold this into a negative literal, so we must intercept it here.
+	if unary, ok := astExpr.(*tree.UnaryExpr); ok && unary.Op == tree.UNARY_MINUS {
+		if _, ok := unary.Expr.(*tree.NumVal); ok {
+			clause := "LIMIT"
+			if b.isOffset {
+				clause = "OFFSET"
+			}
+			return nil, moerr.NewSyntaxErrorf(b.GetContext(),
+				"%s must be a non-negative integer", clause)
+		}
 	}
 
 	expr, err := b.baseBindExpr(astExpr, depth, isRoot)
@@ -42,14 +56,28 @@ func (b *LimitBinder) BindExpr(astExpr tree.Expr, depth int32, isRoot bool) (*pl
 		return nil, err
 	}
 
+	// NULL check: reject NULL in LIMIT/OFFSET with a clear message.
+	if cExpr, ok := expr.Expr.(*plan.Expr_Lit); ok && cExpr.Lit != nil && cExpr.Lit.GetIsnull() {
+		clause := "LIMIT"
+		if b.isOffset {
+			clause = "OFFSET"
+		}
+		return nil, moerr.NewSyntaxErrorf(b.GetContext(), "%s cannot be NULL", clause)
+	}
+
 	if expr.Typ.Id != int32(types.T_uint64) {
 		if expr.Typ.Id == int32(types.T_int64) {
 			if cExpr, ok := expr.Expr.(*plan.Expr_Lit); ok {
 				if c, ok := cExpr.Lit.Value.(*plan.Literal_I64Val); ok {
 					if c.I64Val < 0 {
-						return nil, moerr.NewSyntaxError(b.GetContext(), "offset value must be nonnegative")
+						clause := "LIMIT"
+						if b.isOffset {
+							clause = "OFFSET"
+						}
+						return nil, moerr.NewSyntaxErrorf(b.GetContext(),
+							"%s must be a non-negative integer", clause)
 					}
-					//convert to uint64 instead of CAST
+					// convert to uint64 instead of CAST
 					expr = makePlan2Uint64ConstExprWithType(uint64(c.I64Val))
 					return expr, nil
 				}
@@ -71,8 +99,6 @@ func (b *LimitBinder) BindExpr(astExpr tree.Expr, depth int32, isRoot bool) (*pl
 			return appendCastBeforeExpr(b.GetContext(), expr, planTargetType)
 		} else if expr.GetV() != nil {
 			// SELECT IFNULL(CAST(@var AS BIGINT), 1) => CASE( ISNULL(@var), 1, CAST(@var AS BIGINT))
-
-			//ISNULL(@var)
 			arg0, err := BindFuncExprImplByPlanExpr(b.GetContext(), "isnull", []*plan.Expr{
 				expr,
 			})
@@ -80,10 +106,8 @@ func (b *LimitBinder) BindExpr(astExpr tree.Expr, depth int32, isRoot bool) (*pl
 				return nil, err
 			}
 
-			// CAST( 1 AS BIGINT UNSIGNED)
 			arg1 := makePlan2Uint64ConstExprWithType(1)
 
-			// CAST(@var AS BIGINT UNSIGNED)
 			targetType := types.T_uint64.ToType()
 			planTargetType := makePlan2Type(&targetType)
 			arg2, err := appendCastBeforeExpr(b.GetContext(), expr, planTargetType)
@@ -97,7 +121,12 @@ func (b *LimitBinder) BindExpr(astExpr tree.Expr, depth int32, isRoot bool) (*pl
 				arg2,
 			})
 		} else {
-			return nil, moerr.NewSyntaxError(b.GetContext(), "only uint64 support in limit/offset clause")
+			clause := "LIMIT"
+			if b.isOffset {
+				clause = "OFFSET"
+			}
+			return nil, moerr.NewSyntaxErrorf(b.GetContext(),
+				"only uint64 support in %s clause", clause)
 		}
 	}
 

--- a/pkg/sql/plan/limit_binder_test.go
+++ b/pkg/sql/plan/limit_binder_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/stretchr/testify/require"
+)
+
+func parseLimit(t *testing.T, sql string) *tree.Limit {
+	t.Helper()
+	stmts, err := parsers.Parse(context.TODO(), dialect.MYSQL, sql, 1)
+	require.NoError(t, err)
+	sel, ok := stmts[0].(*tree.Select)
+	require.True(t, ok, "expected SELECT statement")
+	return sel.Limit
+}
+
+func bindLimitExpr(t *testing.T, astExpr tree.Expr, isOffset bool) (*plan.Expr, error) {
+	t.Helper()
+	builder, bindCtx := genBuilderAndCtx()
+	binder := NewLimitBinder(builder, bindCtx, isOffset)
+	return binder.BindExpr(astExpr, 0, true)
+}
+
+func TestLimitBinder_Limit0(t *testing.T) {
+	astLimit := parseLimit(t, "SELECT 1 LIMIT 0")
+	require.NotNil(t, astLimit.Count)
+
+	expr, err := bindLimitExpr(t, astLimit.Count, false)
+	require.NoError(t, err)
+	require.Equal(t, int32(types.T_uint64), expr.Typ.Id)
+
+	lit, ok := expr.Expr.(*plan.Expr_Lit)
+	require.True(t, ok)
+	uval, ok := lit.Lit.Value.(*plan.Literal_U64Val)
+	require.True(t, ok)
+	require.Equal(t, uint64(0), uval.U64Val)
+}
+
+func TestLimitBinder_LimitPositive(t *testing.T) {
+	astLimit := parseLimit(t, "SELECT 1 LIMIT 10")
+	require.NotNil(t, astLimit.Count)
+
+	expr, err := bindLimitExpr(t, astLimit.Count, false)
+	require.NoError(t, err)
+	require.Equal(t, int32(types.T_uint64), expr.Typ.Id)
+
+	lit, ok := expr.Expr.(*plan.Expr_Lit)
+	require.True(t, ok)
+	uval, ok := lit.Lit.Value.(*plan.Literal_U64Val)
+	require.True(t, ok)
+	require.Equal(t, uint64(10), uval.U64Val)
+}
+
+func TestLimitBinder_Offset0(t *testing.T) {
+	astLimit := parseLimit(t, "SELECT 1 LIMIT 5 OFFSET 0")
+	require.NotNil(t, astLimit.Offset)
+
+	expr, err := bindLimitExpr(t, astLimit.Offset, true)
+	require.NoError(t, err)
+	require.Equal(t, int32(types.T_uint64), expr.Typ.Id)
+
+	lit, ok := expr.Expr.(*plan.Expr_Lit)
+	require.True(t, ok)
+	uval, ok := lit.Lit.Value.(*plan.Literal_U64Val)
+	require.True(t, ok)
+	require.Equal(t, uint64(0), uval.U64Val)
+}
+
+func TestLimitBinder_LimitNegative(t *testing.T) {
+	astLimit := parseLimit(t, "SELECT 1 LIMIT -1")
+	require.NotNil(t, astLimit.Count)
+
+	_, err := bindLimitExpr(t, astLimit.Count, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "LIMIT must be a non-negative integer")
+}
+
+func TestLimitBinder_OffsetNegative(t *testing.T) {
+	astLimit := parseLimit(t, "SELECT 1 LIMIT 1 OFFSET -5")
+	require.NotNil(t, astLimit.Offset)
+
+	_, err := bindLimitExpr(t, astLimit.Offset, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "OFFSET must be a non-negative integer")
+}
+
+func TestLimitBinder_LimitNull(t *testing.T) {
+	astLimit := parseLimit(t, "SELECT 1 LIMIT NULL")
+	require.NotNil(t, astLimit.Count)
+
+	_, err := bindLimitExpr(t, astLimit.Count, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "LIMIT cannot be NULL")
+}
+
+func TestLimitBinder_OffsetNull(t *testing.T) {
+	astLimit := parseLimit(t, "SELECT 1 LIMIT 1 OFFSET NULL")
+	require.NotNil(t, astLimit.Offset)
+
+	_, err := bindLimitExpr(t, astLimit.Offset, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "OFFSET cannot be NULL")
+}
+
+func TestLimitBinder_LimitString(t *testing.T) {
+	astLimit := parseLimit(t, "SELECT 1 LIMIT '10'")
+	require.NotNil(t, astLimit.Count)
+
+	expr, err := bindLimitExpr(t, astLimit.Count, false)
+	require.NoError(t, err)
+	require.Equal(t, int32(types.T_uint64), expr.Typ.Id)
+}
+
+func TestLimitBinder_LargeUint64(t *testing.T) {
+	sql := "SELECT 1 LIMIT 18446744073709551615"
+	stmts, err := parsers.Parse(context.TODO(), dialect.MYSQL, sql, 1)
+	require.NoError(t, err)
+	sel, ok := stmts[0].(*tree.Select)
+	require.True(t, ok)
+
+	expr, err := bindLimitExpr(t, sel.Limit.Count, false)
+	require.NoError(t, err)
+	require.Equal(t, int32(types.T_uint64), expr.Typ.Id)
+}
+
+func TestLimitBinder_StarInLimit(t *testing.T) {
+	builder, bindCtx := genBuilderAndCtx()
+	binder := NewLimitBinder(builder, bindCtx, false)
+
+	_, err := binder.BindExpr(&tree.UnqualifiedStar{}, 0, true)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "unsupported expr in limit clause"))
+}

--- a/pkg/sql/plan/limit_binder_test.go
+++ b/pkg/sql/plan/limit_binder_test.go
@@ -153,3 +153,77 @@ func TestLimitBinder_StarInLimit(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "unsupported expr in limit clause"))
 }
+
+func TestLimitBinder_BindColRefRejected(t *testing.T) {
+	builder, bindCtx := genBuilderAndCtx()
+	binder := NewLimitBinder(builder, bindCtx, false)
+
+	_, err := binder.BindColRef(tree.NewUnresolvedName(tree.NewCStr("a", 1)), 0, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "column not allowed in limit clause")
+}
+
+func TestLimitBinder_BindAggFuncRejected(t *testing.T) {
+	builder, bindCtx := genBuilderAndCtx()
+	binder := NewLimitBinder(builder, bindCtx, false)
+
+	fn := &tree.FuncExpr{
+		Func: tree.FuncName2ResolvableFunctionReference(tree.NewUnresolvedName(tree.NewCStr("count", 1))),
+		Exprs: tree.Exprs{
+			tree.NewNumVal("1", "1", false, tree.P_int64),
+		},
+	}
+	_, err := binder.BindAggFunc("count", fn, 0, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "aggregate function not allowed in limit clause")
+}
+
+func TestLimitBinder_BindWinFuncRejected(t *testing.T) {
+	builder, bindCtx := genBuilderAndCtx()
+	binder := NewLimitBinder(builder, bindCtx, false)
+
+	fn := &tree.FuncExpr{
+		Func: tree.FuncName2ResolvableFunctionReference(tree.NewUnresolvedName(tree.NewCStr("row_number", 1))),
+	}
+	_, err := binder.BindWinFunc("row_number", fn, 0, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "window function not allowed in limit clause")
+}
+
+func TestLimitBinder_BindSubqueryRejected(t *testing.T) {
+	builder, bindCtx := genBuilderAndCtx()
+	binder := NewLimitBinder(builder, bindCtx, false)
+
+	subquery := &tree.Subquery{Select: &tree.Select{}}
+	_, err := binder.BindSubquery(subquery, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "subquery not allowed in limit clause")
+}
+
+func TestLimitBinder_BindTimeWindowFuncRejected(t *testing.T) {
+	builder, bindCtx := genBuilderAndCtx()
+	binder := NewLimitBinder(builder, bindCtx, false)
+
+	fn := &tree.FuncExpr{
+		Func: tree.FuncName2ResolvableFunctionReference(tree.NewUnresolvedName(tree.NewCStr("hop", 1))),
+	}
+	_, err := binder.BindTimeWindowFunc("hop", fn, 0, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot bind time window functions 'hop'")
+}
+
+func TestLimitBinder_VarExprWrapsCase(t *testing.T) {
+	expr, err := bindLimitExpr(t, tree.NewVarExpr("v1", false, false, nil), false)
+	require.NoError(t, err)
+	require.Equal(t, int32(types.T_uint64), expr.Typ.Id)
+	require.NotNil(t, expr.GetF())
+}
+
+func TestLimitBinder_UnsupportedTypeRejected(t *testing.T) {
+	builder, bindCtx := genBuilderAndCtx()
+	binder := NewLimitBinder(builder, bindCtx, false)
+
+	_, err := binder.BindExpr(tree.NewNumVal("1.5", "1.5", false, tree.P_decimal), 0, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only uint64 support in LIMIT clause")
+}

--- a/pkg/sql/plan/query_builder.go
+++ b/pkg/sql/plan/query_builder.go
@@ -2444,14 +2444,15 @@ func (builder *QueryBuilder) buildUnion(stmt *tree.UnionClause, astOrderBy tree.
 	if astLimit != nil {
 		node := builder.qry.Nodes[lastNodeID]
 
-		limitBinder := NewLimitBinder(builder, ctx)
 		if astLimit.Offset != nil {
-			node.Offset, err = limitBinder.BindExpr(astLimit.Offset, 0, true)
+			offsetBinder := NewLimitBinder(builder, ctx, true)
+			node.Offset, err = offsetBinder.BindExpr(astLimit.Offset, 0, true)
 			if err != nil {
 				return 0, err
 			}
 		}
 		if astLimit.Count != nil {
+			limitBinder := NewLimitBinder(builder, ctx, false)
 			node.Limit, err = limitBinder.BindExpr(astLimit.Count, 0, true)
 			if err != nil {
 				return 0, err
@@ -2686,14 +2687,15 @@ func (builder *QueryBuilder) bindRecursiveCte(
 	var limitExpr *Expr
 	var offsetExpr *Expr
 	if s.Limit != nil {
-		limitBinder := NewLimitBinder(builder, ctx)
 		if s.Limit.Offset != nil {
-			offsetExpr, err = limitBinder.BindExpr(s.Limit.Offset, 0, true)
+			offsetBinder := NewLimitBinder(builder, ctx, true)
+			offsetExpr, err = offsetBinder.BindExpr(s.Limit.Offset, 0, true)
 			if err != nil {
 				return 0, err
 			}
 		}
 		if s.Limit.Count != nil {
+			limitBinder := NewLimitBinder(builder, ctx, false)
 			limitExpr, err = limitBinder.BindExpr(s.Limit.Count, 0, true)
 			if err != nil {
 				return 0, err
@@ -3230,7 +3232,7 @@ func (builder *QueryBuilder) bindSelectClause(
 		case tree.UnqualifiedStar:
 			if astLimit != nil && astLimit.Count != nil {
 				var limitExpr *plan.Expr
-				limitBinder := NewLimitBinder(builder, ctx)
+				limitBinder := NewLimitBinder(builder, ctx, false)
 				if limitExpr, err = limitBinder.BindExpr(astLimit.Count, 0, true); err != nil {
 					return
 				}
@@ -3654,13 +3656,14 @@ func (builder *QueryBuilder) bindLimit(
 	astRankOption *tree.RankOption,
 ) (boundOffsetExpr, boundCountExpr *Expr, rankOption *plan.RankOption, err error) {
 	if astLimit != nil {
-		limitBinder := NewLimitBinder(builder, ctx)
 		if astLimit.Offset != nil {
-			if boundOffsetExpr, err = limitBinder.BindExpr(astLimit.Offset, 0, true); err != nil {
+			offsetBinder := NewLimitBinder(builder, ctx, true)
+			if boundOffsetExpr, err = offsetBinder.BindExpr(astLimit.Offset, 0, true); err != nil {
 				return
 			}
 		}
 		if astLimit.Count != nil {
+			limitBinder := NewLimitBinder(builder, ctx, false)
 			if boundCountExpr, err = limitBinder.BindExpr(astLimit.Count, 0, true); err != nil {
 				return
 			}

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -441,6 +441,7 @@ type OrderBinder struct {
 
 type LimitBinder struct {
 	baseBinder
+	isOffset bool // true when binding OFFSET value, false when binding LIMIT count
 }
 
 type PartitionBinder struct {

--- a/test/distributed/cases/ddl/rename_table_chained.result
+++ b/test/distributed/cases/ddl/rename_table_chained.result
@@ -1,0 +1,37 @@
+drop database if exists test_rename_chain;
+create database test_rename_chain;
+use test_rename_chain;
+create table t_live (id int);
+create table t_shadow (id int);
+insert into t_live values (100);
+insert into t_shadow values (200);
+rename table t_live to t_tmp, t_shadow to t_live, t_tmp to t_shadow;
+select * from t_live;
+id
+200
+select * from t_shadow;
+id
+100
+drop table t_live, t_shadow;
+create table a (id int);
+create table b (id int);
+insert into a values (1);
+insert into b values (2);
+rename table a to c, b to a;
+select * from a;
+id
+2
+select * from c;
+id
+1
+drop table a, c;
+create table x (id int);
+create table y (id int);
+rename table x to y;
+table y already exists
+drop table if exists x, y;
+create table m (id int);
+create table n (id int);
+rename table m to xx, m to yy;
+no such table test_rename_chain.m
+drop database test_rename_chain;

--- a/test/distributed/cases/ddl/rename_table_chained.sql
+++ b/test/distributed/cases/ddl/rename_table_chained.sql
@@ -1,0 +1,44 @@
+-- @suite
+-- @case
+-- @desc: regression test for #24408 — chained RENAME TABLE (MySQL atomic swap pattern)
+
+drop database if exists test_rename_chain;
+create database test_rename_chain;
+use test_rename_chain;
+
+-- 3-pair atomic swap
+create table t_live (id int);
+create table t_shadow (id int);
+insert into t_live values (100);
+insert into t_shadow values (200);
+
+rename table t_live to t_tmp, t_shadow to t_live, t_tmp to t_shadow;
+
+select * from t_live;
+select * from t_shadow;
+
+-- 2-pair rename (non-conflicting)
+drop table t_live, t_shadow;
+create table a (id int);
+create table b (id int);
+insert into a values (1);
+insert into b values (2);
+
+rename table a to c, b to a;
+
+select * from a;
+select * from c;
+
+-- real conflict should still error
+drop table a, c;
+create table x (id int);
+create table y (id int);
+rename table x to y;
+
+-- double-rename same source should error
+drop table if exists x, y;
+create table m (id int);
+create table n (id int);
+rename table m to xx, m to yy;
+
+drop database test_rename_chain;

--- a/test/distributed/cases/dml/select/limit.result
+++ b/test/distributed/cases/dml/select/limit.result
@@ -14,9 +14,9 @@ a
 select * from t1 limit 18446744073709551615,0;
 a
 select * from t1 limit -1,18446744073709551615;
-SQL syntax error: only uint64 support in limit/offset clause
+SQL syntax error: OFFSET must be a non-negative integer
 select * from t1 limit 0,-1;
-SQL syntax error: only uint64 support in limit/offset clause
+SQL syntax error: LIMIT must be a non-negative integer
 select * from t1 limit 0,0;
 a
 select * from t1 limit 0,3;
@@ -46,9 +46,9 @@ a
 select * from t1 order by a limit 18446744073709551615,0;
 a
 select * from t1 order by a limit -1,18446744073709551615;
-SQL syntax error: only uint64 support in limit/offset clause
+SQL syntax error: OFFSET must be a non-negative integer
 select * from t1 order by a limit 0,-1;
-SQL syntax error: only uint64 support in limit/offset clause
+SQL syntax error: LIMIT must be a non-negative integer
 select * from t1 order by a limit 0,0;
 a
 drop table if exists t1;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24481

## What this PR does / why we need it:

[cherry-pick] fix: support LIMIT 0 and improve error messages for NULL/negative LIMIT/OFFSET (#24455)
[cherry-pick] fix(plan): support MySQL-compatible chained RENAME TABLE (#24470)