### PR TITLE
perf(replace): reduce allocations and vector copies in REPLACE INTO hot path (cherry-pick #24389)

### DIFF
--- a/pkg/sql/colexec/dedupjoin/join.go
+++ b/pkg/sql/colexec/dedupjoin/join.go
@@ -742,9 +742,16 @@ func (ctr *container) evalJoinCondition(bat *batch.Batch, proc *process.Process)
 	return nil
 }
 
-// unionSelsByBatch groups sels by their build-batch index and performs one
-// batch Union call per group, avoiding per-row UnionOne overhead.
 func unionSelsByBatch(dst *vector.Vector, batches []*batch.Batch, colPos int32, sels []int32, proc *process.Process) error {
+	if len(sels) <= 16 {
+		for _, sel := range sels {
+			idx1, idx2 := sel/colexec.DefaultBatchSize, sel%colexec.DefaultBatchSize
+			if err := dst.UnionOne(batches[idx1].Vecs[colPos], int64(idx2), proc.Mp()); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 	offsets := make([]int64, 0, len(sels))
 	prevIdx := int32(-1)
 	for _, sel := range sels {

--- a/pkg/sql/colexec/dedupjoin/join.go
+++ b/pkg/sql/colexec/dedupjoin/join.go
@@ -311,6 +311,24 @@ func (ctr *container) finalize(ap *DedupJoin, proc *process.Process) error {
 
 	if ap.OnDuplicateAction != plan.Node_UPDATE || ctr.mp.HashOnUnique() {
 		if ctr.matched.Count() == 0 {
+			// constructDedupJoin copies node.ProjectList into ap.Result without
+			// dedup, and the REPLACE planner can alias multiple projections onto
+			// the same build column, so a non-capture build position may be
+			// referenced more than once. Ownership transfer (steal the build
+			// vector and nil it out) is only safe when a position is referenced
+			// exactly once; duplicates must copy, otherwise the second reference
+			// reads a nil vector. Count references first.
+			buildPosRefCount := make(map[int32]int, len(ap.Result))
+			for j, rp := range ap.Result {
+				if rp.Rel != 1 {
+					continue
+				}
+				if len(ctr.captureResultIdx) > 0 && ctr.captureResultIdx[j] >= 0 {
+					continue
+				}
+				buildPosRefCount[rp.Pos]++
+			}
+
 			ap.ctr.buf = make([]*batch.Batch, len(ctr.batches))
 			for i := range ap.ctr.buf {
 				ap.ctr.buf[i] = batch.NewOffHeapWithSize(len(ap.Result))
@@ -339,11 +357,22 @@ func (ctr *container) finalize(ap *DedupJoin, proc *process.Process) error {
 									return err
 								}
 							}
-						} else {
-							// Non-capture build column: transfer ownership from
-							// the build batch to avoid a full copy.
+						} else if buildPosRefCount[rp.Pos] == 1 {
+							// Non-capture build column referenced exactly once:
+							// transfer ownership from the build batch to avoid a
+							// full copy.
 							ap.ctr.buf[i].Vecs[j] = bat.Vecs[rp.Pos]
 							bat.Vecs[rp.Pos] = nil
+						} else {
+							// Non-capture build column referenced more than once
+							// (aliased projections). Copy so every reference gets
+							// its own valid vector; ownership transfer here would
+							// leave later references reading a nil vector.
+							typ := ap.RightTypes[rp.Pos]
+							ap.ctr.buf[i].Vecs[j] = vector.NewOffHeapVecWithType(typ)
+							if err := vector.GetUnionAllFunction(typ, proc.Mp())(ap.ctr.buf[i].Vecs[j], bat.Vecs[rp.Pos]); err != nil {
+								return err
+							}
 						}
 					} else {
 						ap.ctr.buf[i].Vecs[j] = vector.NewOffHeapVecWithType(ap.LeftTypes[rp.Pos])

--- a/pkg/sql/colexec/dedupjoin/join.go
+++ b/pkg/sql/colexec/dedupjoin/join.go
@@ -560,7 +560,10 @@ func (ctr *container) probe(bat *batch.Batch, ap *DedupJoin, proc *process.Proce
 
 	rowCntInc := 0
 	count := bat.RowCount()
-	itr := ctr.mp.NewIterator()
+	if ctr.cachedItr == nil {
+		ctr.cachedItr = ctr.mp.NewIterator()
+	}
+	itr := ctr.cachedItr
 	isPessimistic := proc.GetTxnOperator().Txn().IsPessimistic()
 	for i := 0; i < count; i += hashmap.UnitLimit {
 		n := count - i

--- a/pkg/sql/colexec/dedupjoin/join.go
+++ b/pkg/sql/colexec/dedupjoin/join.go
@@ -322,17 +322,28 @@ func (ctr *container) finalize(ap *DedupJoin, proc *process.Process) error {
 				capOffset := int64(i) * int64(colexec.DefaultBatchSize)
 				for j, rp := range ap.Result {
 					if rp.Rel == 1 {
-						typ := ap.RightTypes[rp.Pos]
-						ap.ctr.buf[i].Vecs[j] = vector.NewOffHeapVecWithType(typ)
 						if len(ctr.captureResultIdx) > 0 && ctr.captureResultIdx[j] >= 0 {
+							// Capture column: when matched==0, no probe hit any
+							// bucket, so capturedVecs are still all-NULL. Emit a
+							// pre-filled NULL vector directly instead of copying.
 							cIdx := ctr.captureResultIdx[j]
-							if err := ap.ctr.buf[i].Vecs[j].UnionBatch(ctr.capturedVecs[cIdx], capOffset, batSize, nil, proc.Mp()); err != nil {
-								return err
+							if ctr.captured != nil && ctr.captured.Count() > 0 {
+								typ := ap.RightTypes[rp.Pos]
+								ap.ctr.buf[i].Vecs[j] = vector.NewOffHeapVecWithType(typ)
+								if err := ap.ctr.buf[i].Vecs[j].UnionBatch(ctr.capturedVecs[cIdx], capOffset, batSize, nil, proc.Mp()); err != nil {
+									return err
+								}
+							} else {
+								ap.ctr.buf[i].Vecs[j] = vector.NewOffHeapVecWithType(ap.RightTypes[rp.Pos])
+								if err := vector.AppendMultiFixed(ap.ctr.buf[i].Vecs[j], 0, true, batSize, proc.Mp()); err != nil {
+									return err
+								}
 							}
 						} else {
-							if err := vector.GetUnionAllFunction(typ, proc.Mp())(ap.ctr.buf[i].Vecs[j], bat.Vecs[rp.Pos]); err != nil {
-								return err
-							}
+							// Non-capture build column: transfer ownership from
+							// the build batch to avoid a full copy.
+							ap.ctr.buf[i].Vecs[j] = bat.Vecs[rp.Pos]
+							bat.Vecs[rp.Pos] = nil
 						}
 					} else {
 						ap.ctr.buf[i].Vecs[j] = vector.NewOffHeapVecWithType(ap.LeftTypes[rp.Pos])
@@ -375,11 +386,8 @@ func (ctr *container) finalize(ap *DedupJoin, proc *process.Process) error {
 			for j, rp := range ap.Result {
 				if rp.Rel == 1 {
 					ap.ctr.buf[i].Vecs[j] = vector.NewOffHeapVecWithType(ap.RightTypes[rp.Pos])
-					for _, sel := range newSels {
-						idx1, idx2 := sel/colexec.DefaultBatchSize, sel%colexec.DefaultBatchSize
-						if err := ap.ctr.buf[i].Vecs[j].UnionOne(ctr.batches[idx1].Vecs[rp.Pos], int64(idx2), proc.Mp()); err != nil {
-							return err
-						}
+					if err := unionSelsByBatch(ap.ctr.buf[i].Vecs[j], ctr.batches, rp.Pos, newSels, proc); err != nil {
+						return err
 					}
 				} else {
 					ap.ctr.buf[i].Vecs[j] = vector.NewOffHeapVecWithType(ap.LeftTypes[rp.Pos])
@@ -730,6 +738,33 @@ func (ctr *container) evalJoinCondition(bat *batch.Batch, proc *process.Process)
 		}
 		ctr.vecs[i] = vec
 		ctr.evecs[i].vec = vec
+	}
+	return nil
+}
+
+// unionSelsByBatch groups sels by their build-batch index and performs one
+// batch Union call per group, avoiding per-row UnionOne overhead.
+func unionSelsByBatch(dst *vector.Vector, batches []*batch.Batch, colPos int32, sels []int32, proc *process.Process) error {
+	offsets := make([]int64, 0, len(sels))
+	prevIdx := int32(-1)
+	for _, sel := range sels {
+		idx1 := sel / colexec.DefaultBatchSize
+		idx2 := int64(sel % colexec.DefaultBatchSize)
+		if idx1 != prevIdx {
+			if prevIdx >= 0 && len(offsets) > 0 {
+				if err := dst.Union(batches[prevIdx].Vecs[colPos], offsets, proc.Mp()); err != nil {
+					return err
+				}
+				offsets = offsets[:0]
+			}
+			prevIdx = idx1
+		}
+		offsets = append(offsets, idx2)
+	}
+	if len(offsets) > 0 {
+		if err := dst.Union(batches[prevIdx].Vecs[colPos], offsets, proc.Mp()); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/sql/colexec/dedupjoin/join_finalize_optimize_test.go
+++ b/pkg/sql/colexec/dedupjoin/join_finalize_optimize_test.go
@@ -238,15 +238,15 @@ func TestDedupJoinFinalize_UnionSelsByBatch_PartialMatch(t *testing.T) {
 		OperatorBase:      vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
 	}
 	buildArg := &hashbuild.HashBuild{
-		NeedHashMap:      true,
-		NeedBatches:      true,
-		Conditions:       conditions[1],
-		IsDedup:          true,
-		DelColIdx:        -1,
-		JoinMapTag:       curTag,
-		JoinMapRefCnt:    1,
+		NeedHashMap:       true,
+		NeedBatches:       true,
+		Conditions:        conditions[1],
+		IsDedup:           true,
+		DelColIdx:         -1,
+		JoinMapTag:        curTag,
+		JoinMapRefCnt:     1,
 		OnDuplicateAction: plan.Node_IGNORE,
-		OperatorBase:     vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+		OperatorBase:      vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
 	}
 
 	out := runFinalizeFixture(t, dedupArg, buildArg, proc, buildBat, probeBat)

--- a/pkg/sql/colexec/dedupjoin/join_finalize_optimize_test.go
+++ b/pkg/sql/colexec/dedupjoin/join_finalize_optimize_test.go
@@ -1,0 +1,398 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dedupjoin
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/hashbuild"
+	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"github.com/stretchr/testify/require"
+)
+
+// runFinalizeFixture wires a HashBuild + DedupJoin pair, runs the build
+// phase, then drives the dedupjoin to completion by calling Exec until it
+// returns nil. Result batches are collected (caller-owned via the returned
+// slice; do NOT Free them here — they live inside dedupArg.ctr.buf).
+func runFinalizeFixture(
+	t *testing.T,
+	dedupArg *DedupJoin,
+	buildArg *hashbuild.HashBuild,
+	proc *process.Process,
+	buildBat, probeBat *batch.Batch,
+) []*batch.Batch {
+	t.Helper()
+
+	buildArg.Children = nil
+	buildArg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{buildBat}))
+	dedupArg.Children = nil
+	dedupArg.AppendChild(colexec.NewMockOperator().WithBatchs([]*batch.Batch{probeBat}))
+
+	require.NoError(t, buildArg.Prepare(proc))
+	require.NoError(t, dedupArg.Prepare(proc))
+
+	res, err := vm.Exec(buildArg, proc)
+	require.NoError(t, err)
+	require.True(t, res.Batch == nil, "build phase should drain to nil")
+
+	var out []*batch.Batch
+	for {
+		res, err = vm.Exec(dedupArg, proc)
+		require.NoError(t, err)
+		if res.Batch == nil {
+			break
+		}
+		if res.Batch.RowCount() > 0 {
+			out = append(out, res.Batch)
+		}
+	}
+	return out
+}
+
+// TestDedupJoinFinalizeMatchedZero_NonCapture exercises the non-capture
+// fast path at finalize() lines 312-360: matched.Count()==0 and no capture
+// columns, so each Result column with rp.Rel==1 is transferred from the
+// build batch (bat.Vecs[rp.Pos] = nil). Verifies output equals build content
+// row-for-row, and Reset/Free do not panic on the nilled-out slots.
+func TestDedupJoinFinalizeMatchedZero_NonCapture(t *testing.T) {
+	proc, ctrl := newCaptureTestProc(t)
+	defer ctrl.Finish()
+
+	int32Typ := types.T_int32.ToType()
+	tag++
+	curTag := tag
+
+	// Build keys [10,20,30] with payload col [100,200,300].
+	buildBat := makeInt32Batch(proc.Mp(), [][]int32{{10, 20, 30}, {100, 200, 300}}, nil)
+	// Probe key [99] misses every build bucket → matched stays at 0.
+	probeBat := makeInt32Batch(proc.Mp(), [][]int32{{99}, {0}}, nil)
+
+	conditions := [][]*plan.Expr{
+		{newExpr(0, int32Typ)},
+		{newExpr(0, int32Typ)},
+	}
+
+	dedupArg := &DedupJoin{
+		LeftTypes:  []types.Type{int32Typ, int32Typ},
+		RightTypes: []types.Type{int32Typ, int32Typ},
+		Conditions: conditions,
+		Result: []colexec.ResultPos{
+			colexec.NewResultPos(1, 0), // build key
+			colexec.NewResultPos(1, 1), // build payload — exercises transfer path
+		},
+		OnDuplicateAction: plan.Node_FAIL, // no capture, no matched marking
+		JoinMapTag:        curTag,
+		OperatorBase:      vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+	buildArg := &hashbuild.HashBuild{
+		NeedHashMap:   true,
+		NeedBatches:   true,
+		Conditions:    conditions[1],
+		IsDedup:       true,
+		DelColIdx:     -1,
+		JoinMapTag:    curTag,
+		JoinMapRefCnt: 1,
+		OperatorBase:  vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+
+	out := runFinalizeFixture(t, dedupArg, buildArg, proc, buildBat, probeBat)
+	require.Len(t, out, 1)
+	require.Equal(t, 3, out[0].RowCount())
+
+	col0 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[0])
+	col1 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[1])
+	require.Equal(t, []int32{10, 20, 30}, col0)
+	require.Equal(t, []int32{100, 200, 300}, col1)
+
+	// Reset should walk JoinMap.batches whose Vecs slots are now nil-aliased
+	// into the output buf — must not panic / double-free.
+	dedupArg.Reset(proc, false, nil)
+	buildArg.Reset(proc, false, nil)
+
+	dedupArg.Free(proc, false, nil)
+	buildArg.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+// TestDedupJoinFinalizeMatchedZero_WithCapture exercises the capture branch
+// at finalize() lines 326-341: matched==0 AND ctr.captured.Count()==0, so
+// the capture column is filled with NULLs via AppendMultiFixed (no UnionBatch
+// from capturedVecs). The non-capture build column still goes through the
+// transfer path.
+func TestDedupJoinFinalizeMatchedZero_WithCapture(t *testing.T) {
+	proc, ctrl := newCaptureTestProc(t)
+	defer ctrl.Finish()
+
+	int32Typ := types.T_int32.ToType()
+	tag++
+	curTag := tag
+
+	// Build keys [10,20] with NULL placeholder col1.
+	buildBat := makeInt32Batch(proc.Mp(), [][]int32{{10, 20}, {0, 0}}, [][]uint64{nil, {0, 1}})
+	// Probe miss → captured stays empty.
+	probeBat := makeInt32Batch(proc.Mp(), [][]int32{{99}, {0}}, nil)
+
+	conditions := [][]*plan.Expr{
+		{newExpr(0, int32Typ)},
+		{newExpr(0, int32Typ)},
+	}
+
+	dedupArg := &DedupJoin{
+		LeftTypes:  []types.Type{int32Typ, int32Typ},
+		RightTypes: []types.Type{int32Typ, int32Typ},
+		Conditions: conditions,
+		Result: []colexec.ResultPos{
+			colexec.NewResultPos(1, 0), // build key — non-capture column, transfer path
+			colexec.NewResultPos(1, 1), // capture target — must be NULL-filled
+		},
+		OnDuplicateAction:               plan.Node_FAIL,
+		OldColCapturePlaceholderIdxList: []int32{1},
+		OldColCaptureProbeIdxList:       []int32{1},
+		JoinMapTag:                      curTag,
+		OperatorBase:                    vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+	buildArg := &hashbuild.HashBuild{
+		NeedHashMap:   true,
+		NeedBatches:   true,
+		Conditions:    conditions[1],
+		IsDedup:       true,
+		DelColIdx:     -1,
+		JoinMapTag:    curTag,
+		JoinMapRefCnt: 1,
+		OperatorBase:  vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+
+	out := runFinalizeFixture(t, dedupArg, buildArg, proc, buildBat, probeBat)
+	require.Len(t, out, 1)
+	require.Equal(t, 2, out[0].RowCount())
+
+	// col 0: transferred build keys
+	col0 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[0])
+	require.Equal(t, []int32{10, 20}, col0)
+
+	// col 1: capture target — both rows must be NULL.
+	require.True(t, out[0].Vecs[1].GetNulls().Contains(0), "row 0 capture col must be NULL")
+	require.True(t, out[0].Vecs[1].GetNulls().Contains(1), "row 1 capture col must be NULL")
+	require.Equal(t, 2, out[0].Vecs[1].Length(),
+		"NULL-fill path should still allocate length==batSize")
+
+	dedupArg.Reset(proc, false, nil)
+	buildArg.Reset(proc, false, nil)
+	dedupArg.Free(proc, false, nil)
+	buildArg.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+// TestDedupJoinFinalize_UnionSelsByBatch_PartialMatch covers the matched>0
+// non-UPDATE branch at finalize() lines 367-401. The new helper
+// unionSelsByBatch is invoked here with a small sels slice (≤16 elements),
+// so it takes the per-element UnionOne fallback path.
+func TestDedupJoinFinalize_UnionSelsByBatch_PartialMatch(t *testing.T) {
+	proc, ctrl := newCaptureTestProc(t)
+	defer ctrl.Finish()
+
+	int32Typ := types.T_int32.ToType()
+	tag++
+	curTag := tag
+
+	// Build keys [10,20,30,40], payload [100,200,300,400].
+	buildBat := makeInt32Batch(proc.Mp(), [][]int32{{10, 20, 30, 40}, {100, 200, 300, 400}}, nil)
+	// Probe matches keys 10 and 30 → matched bitmap = {0, 2}.
+	probeBat := makeInt32Batch(proc.Mp(), [][]int32{{10, 30}, {0, 0}}, nil)
+
+	conditions := [][]*plan.Expr{
+		{newExpr(0, int32Typ)},
+		{newExpr(0, int32Typ)},
+	}
+
+	dedupArg := &DedupJoin{
+		LeftTypes:  []types.Type{int32Typ, int32Typ},
+		RightTypes: []types.Type{int32Typ, int32Typ},
+		Conditions: conditions,
+		Result: []colexec.ResultPos{
+			colexec.NewResultPos(1, 0),
+			colexec.NewResultPos(1, 1),
+		},
+		OnDuplicateAction: plan.Node_IGNORE, // sets matched bitmap on hit
+		JoinMapTag:        curTag,
+		OperatorBase:      vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+	buildArg := &hashbuild.HashBuild{
+		NeedHashMap:      true,
+		NeedBatches:      true,
+		Conditions:       conditions[1],
+		IsDedup:          true,
+		DelColIdx:        -1,
+		JoinMapTag:       curTag,
+		JoinMapRefCnt:    1,
+		OnDuplicateAction: plan.Node_IGNORE,
+		OperatorBase:     vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+
+	out := runFinalizeFixture(t, dedupArg, buildArg, proc, buildBat, probeBat)
+	require.Len(t, out, 1)
+	require.Equal(t, 2, out[0].RowCount(), "should emit the 2 unmatched build rows")
+
+	col0 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[0])
+	col1 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[1])
+	require.Equal(t, []int32{20, 40}, col0)
+	require.Equal(t, []int32{200, 400}, col1)
+
+	dedupArg.Reset(proc, false, nil)
+	buildArg.Reset(proc, false, nil)
+	dedupArg.Free(proc, false, nil)
+	buildArg.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}
+
+// makeInt32Vec builds a single-vector helper for unionSelsByBatch tests.
+func makeInt32Vec(t *testing.T, proc *process.Process, vals []int32) *vector.Vector {
+	t.Helper()
+	v := vector.NewOffHeapVecWithType(types.T_int32.ToType())
+	for _, x := range vals {
+		require.NoError(t, vector.AppendFixed(v, x, false, proc.Mp()))
+	}
+	return v
+}
+
+// TestUnionSelsByBatch directly exercises the helper, covering both the
+// ≤16 fallback (per-element UnionOne) and the >16 grouped Union path.
+func TestUnionSelsByBatch(t *testing.T) {
+	proc, ctrl := newCaptureTestProc(t)
+	defer ctrl.Finish()
+
+	t.Run("small_sels_single_batch", func(t *testing.T) {
+		vals := []int32{10, 20, 30, 40, 50}
+		bat := batch.New([]string{"v"})
+		bat.Vecs[0] = makeInt32Vec(t, proc, vals)
+		bat.SetRowCount(len(vals))
+		defer bat.Clean(proc.Mp())
+
+		dst := vector.NewOffHeapVecWithType(types.T_int32.ToType())
+		defer dst.Free(proc.Mp())
+
+		sels := []int32{0, 2, 4} // length 3 ≤ 16
+		require.NoError(t, unionSelsByBatch(dst, []*batch.Batch{bat}, 0, sels, proc))
+
+		got := vector.MustFixedColNoTypeCheck[int32](dst)
+		require.Equal(t, []int32{10, 30, 50}, got)
+	})
+
+	t.Run("large_sels_single_batch", func(t *testing.T) {
+		// 32 values; sels picks 17 of them so we trip the >16 grouped path.
+		vals := make([]int32, 32)
+		for i := range vals {
+			vals[i] = int32(i * 10)
+		}
+		bat := batch.New([]string{"v"})
+		bat.Vecs[0] = makeInt32Vec(t, proc, vals)
+		bat.SetRowCount(len(vals))
+		defer bat.Clean(proc.Mp())
+
+		sels := make([]int32, 17)
+		want := make([]int32, 17)
+		for i := range sels {
+			sels[i] = int32(i)
+			want[i] = vals[i]
+		}
+
+		dst := vector.NewOffHeapVecWithType(types.T_int32.ToType())
+		defer dst.Free(proc.Mp())
+		require.NoError(t, unionSelsByBatch(dst, []*batch.Batch{bat}, 0, sels, proc))
+
+		got := vector.MustFixedColNoTypeCheck[int32](dst)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("large_sels_cross_batch", func(t *testing.T) {
+		// Two batches; sels span batch boundary using global index sel /
+		// DefaultBatchSize. Batch 0 holds 32 values, batch 1 holds 8.
+		vals0 := make([]int32, 32)
+		for i := range vals0 {
+			vals0[i] = int32(i + 1000)
+		}
+		vals1 := make([]int32, 8)
+		for i := range vals1 {
+			vals1[i] = int32(i + 9000)
+		}
+		bat0 := batch.New([]string{"v"})
+		bat0.Vecs[0] = makeInt32Vec(t, proc, vals0)
+		bat0.SetRowCount(len(vals0))
+		defer bat0.Clean(proc.Mp())
+
+		bat1 := batch.New([]string{"v"})
+		bat1.Vecs[0] = makeInt32Vec(t, proc, vals1)
+		bat1.SetRowCount(len(vals1))
+		defer bat1.Clean(proc.Mp())
+
+		// 17 sels: 14 from batch 0, then 3 from batch 1. Crosses prevIdx
+		// boundary, exercising the flush-on-batch-change branch.
+		sels := []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+			colexec.DefaultBatchSize, colexec.DefaultBatchSize + 1, colexec.DefaultBatchSize + 2}
+		want := []int32{
+			vals0[0], vals0[1], vals0[2], vals0[3], vals0[4], vals0[5], vals0[6],
+			vals0[7], vals0[8], vals0[9], vals0[10], vals0[11], vals0[12], vals0[13],
+			vals1[0], vals1[1], vals1[2],
+		}
+
+		dst := vector.NewOffHeapVecWithType(types.T_int32.ToType())
+		defer dst.Free(proc.Mp())
+		require.NoError(t, unionSelsByBatch(dst, []*batch.Batch{bat0, bat1}, 0, sels, proc))
+
+		got := vector.MustFixedColNoTypeCheck[int32](dst)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("equivalence_small_vs_large", func(t *testing.T) {
+		// Same data, same projection, two paths: ≤16 sels (UnionOne) vs
+		// >16 sels (grouped Union). Padding the input lets both cases hit
+		// identical content so we can compare bit-for-bit.
+		vals := make([]int32, 40)
+		for i := range vals {
+			vals[i] = int32(i * 7)
+		}
+		bat := batch.New([]string{"v"})
+		bat.Vecs[0] = makeInt32Vec(t, proc, vals)
+		bat.SetRowCount(len(vals))
+		defer bat.Clean(proc.Mp())
+
+		// Pick the same 17 indices in both runs.
+		sels := []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+		dstLarge := vector.NewOffHeapVecWithType(types.T_int32.ToType())
+		defer dstLarge.Free(proc.Mp())
+		require.NoError(t, unionSelsByBatch(dstLarge, []*batch.Batch{bat}, 0, sels, proc))
+
+		// Drop one to force the ≤16 fallback path.
+		dstSmall := vector.NewOffHeapVecWithType(types.T_int32.ToType())
+		defer dstSmall.Free(proc.Mp())
+		require.NoError(t, unionSelsByBatch(dstSmall, []*batch.Batch{bat}, 0, sels[:16], proc))
+
+		require.Equal(t,
+			vector.MustFixedColNoTypeCheck[int32](dstSmall),
+			vector.MustFixedColNoTypeCheck[int32](dstLarge)[:16])
+	})
+
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}

--- a/pkg/sql/colexec/dedupjoin/join_finalize_optimize_test.go
+++ b/pkg/sql/colexec/dedupjoin/join_finalize_optimize_test.go
@@ -396,3 +396,76 @@ func TestUnionSelsByBatch(t *testing.T) {
 	proc.Free()
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
+
+// TestDedupJoinFinalizeMatchedZero_DuplicateBuildPos guards the matched==0
+// fast path against aliased projections. constructDedupJoin copies
+// node.ProjectList into ap.Result without dedup, and the REPLACE planner can
+// alias multiple projections onto the same build column, so a non-capture
+// build position may appear in ap.Result more than once. Ownership transfer
+// (steal the build vector, nil it out) is only valid for positions referenced
+// exactly once; a naive transfer leaves the second reference reading a nil
+// vector, corrupting the output / panicking downstream. Here build payload
+// pos 1 is projected twice and must yield identical, fully-populated columns.
+func TestDedupJoinFinalizeMatchedZero_DuplicateBuildPos(t *testing.T) {
+	proc, ctrl := newCaptureTestProc(t)
+	defer ctrl.Finish()
+
+	int32Typ := types.T_int32.ToType()
+	tag++
+	curTag := tag
+
+	// Build keys [10,20,30] with payload col [100,200,300].
+	buildBat := makeInt32Batch(proc.Mp(), [][]int32{{10, 20, 30}, {100, 200, 300}}, nil)
+	// Probe key [99] misses every build bucket → matched stays at 0.
+	probeBat := makeInt32Batch(proc.Mp(), [][]int32{{99}, {0}}, nil)
+
+	conditions := [][]*plan.Expr{
+		{newExpr(0, int32Typ)},
+		{newExpr(0, int32Typ)},
+	}
+
+	dedupArg := &DedupJoin{
+		LeftTypes:  []types.Type{int32Typ, int32Typ},
+		RightTypes: []types.Type{int32Typ, int32Typ},
+		Conditions: conditions,
+		Result: []colexec.ResultPos{
+			colexec.NewResultPos(1, 0), // build key
+			colexec.NewResultPos(1, 1), // build payload
+			colexec.NewResultPos(1, 1), // SAME build payload — aliased projection
+		},
+		OnDuplicateAction: plan.Node_FAIL, // no capture, no matched marking
+		JoinMapTag:        curTag,
+		OperatorBase:      vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+	buildArg := &hashbuild.HashBuild{
+		NeedHashMap:   true,
+		NeedBatches:   true,
+		Conditions:    conditions[1],
+		IsDedup:       true,
+		DelColIdx:     -1,
+		JoinMapTag:    curTag,
+		JoinMapRefCnt: 1,
+		OperatorBase:  vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+
+	out := runFinalizeFixture(t, dedupArg, buildArg, proc, buildBat, probeBat)
+	require.Len(t, out, 1)
+	require.Equal(t, 3, out[0].RowCount())
+	require.Equal(t, 3, len(out[0].Vecs))
+
+	col0 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[0])
+	col1 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[1])
+	col2 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[2])
+	require.Equal(t, []int32{10, 20, 30}, col0)
+	// Both projections of build pos 1 must be fully populated and identical;
+	// before the fix col2 would be nil (the vector was stolen by col1).
+	require.Equal(t, []int32{100, 200, 300}, col1)
+	require.Equal(t, []int32{100, 200, 300}, col2)
+
+	dedupArg.Reset(proc, false, nil)
+	buildArg.Reset(proc, false, nil)
+	dedupArg.Free(proc, false, nil)
+	buildArg.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}

--- a/pkg/sql/colexec/dedupjoin/types.go
+++ b/pkg/sql/colexec/dedupjoin/types.go
@@ -16,6 +16,7 @@ package dedupjoin
 
 import (
 	"github.com/matrixorigin/matrixone/pkg/common/bitmap"
+	"github.com/matrixorigin/matrixone/pkg/common/hashmap"
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -86,7 +87,8 @@ type container struct {
 	evecs []evalVector
 	vecs  []*vector.Vector
 
-	mp *message.JoinMap
+	mp        *message.JoinMap
+	cachedItr hashmap.Iterator
 
 	matched     *bitmap.Bitmap
 	handledLast bool
@@ -258,6 +260,7 @@ func (ctr *container) cleanBatch(proc *process.Process) {
 }
 
 func (ctr *container) cleanHashMap() {
+	ctr.cachedItr = nil
 	if ctr.mp != nil {
 		ctr.mp.Free()
 		ctr.mp = nil

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -1345,13 +1346,13 @@ func dedupLockRows(rows [][]byte) [][]byte {
 	if len(rows) <= 1 {
 		return rows
 	}
-	seen := make(map[string]struct{}, len(rows))
-	deduped := rows[:0]
-	for _, r := range rows {
-		k := string(r)
-		if _, exists := seen[k]; !exists {
-			seen[k] = struct{}{}
-			deduped = append(deduped, r)
+	sort.Slice(rows, func(i, j int) bool {
+		return bytes.Compare(rows[i], rows[j]) < 0
+	})
+	deduped := rows[:1]
+	for i := 1; i < len(rows); i++ {
+		if !bytes.Equal(rows[i], rows[i-1]) {
+			deduped = append(deduped, rows[i])
 		}
 	}
 	return deduped

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -524,6 +524,10 @@ func doLock(
 		return false, false, timestamp.Timestamp{}, nil
 	}
 
+	if g == lock.Granularity_Row && len(rows) > 1 {
+		rows = dedupLockRows(rows)
+	}
+
 	txn := txnOp.Txn()
 	options := lock.LockOptions{
 		Granularity:     g,
@@ -1335,6 +1339,22 @@ func (lockOp *LockOp) cleanParker() {
 		lockOp.ctr.parker.Close()
 		lockOp.ctr.parker = nil
 	}
+}
+
+func dedupLockRows(rows [][]byte) [][]byte {
+	if len(rows) <= 1 {
+		return rows
+	}
+	seen := make(map[string]struct{}, len(rows))
+	deduped := rows[:0]
+	for _, r := range rows {
+		k := string(r)
+		if _, exists := seen[k]; !exists {
+			seen[k] = struct{}{}
+			deduped = append(deduped, r)
+		}
+	}
+	return deduped
 }
 
 func getRowsFilter(

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -119,7 +119,11 @@ func (lockOp *LockOp) Prepare(proc *process.Process) error {
 			}
 		}
 	}
-	lockOp.ctr.parker = types.NewPacker()
+	if lockOp.ctr.parker == nil {
+		lockOp.ctr.parker = types.NewPacker()
+	} else {
+		lockOp.ctr.parker.Reset()
+	}
 	return nil
 }
 

--- a/pkg/sql/colexec/lockop/lock_op_test.go
+++ b/pkg/sql/colexec/lockop/lock_op_test.go
@@ -1374,3 +1374,73 @@ func TestLockTableIfLockCountIsZeroWithLockRows(t *testing.T) {
 		arg.Free(proc, false, nil)
 	})
 }
+
+func TestDedupLockRows(t *testing.T) {
+	cases := []struct {
+		name string
+		in   [][]byte
+		want [][]byte
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "empty",
+			in:   [][]byte{},
+			want: [][]byte{},
+		},
+		{
+			name: "single",
+			in:   [][]byte{{0x01}},
+			want: [][]byte{{0x01}},
+		},
+		{
+			name: "no-dup-already-sorted",
+			in:   [][]byte{{0x01}, {0x02}, {0x03}},
+			want: [][]byte{{0x01}, {0x02}, {0x03}},
+		},
+		{
+			name: "no-dup-unsorted-output-sorted",
+			in:   [][]byte{{0x03}, {0x01}, {0x02}},
+			want: [][]byte{{0x01}, {0x02}, {0x03}},
+		},
+		{
+			name: "with-dup-mixed",
+			in:   [][]byte{{0x02}, {0x01}, {0x02}, {0x03}, {0x01}},
+			want: [][]byte{{0x01}, {0x02}, {0x03}},
+		},
+		{
+			name: "all-dup",
+			in:   [][]byte{{0x05}, {0x05}, {0x05}},
+			want: [][]byte{{0x05}},
+		},
+		{
+			name: "multibyte-keys",
+			in:   [][]byte{{0x01, 0x02}, {0x01, 0x01}, {0x01, 0x02}},
+			want: [][]byte{{0x01, 0x01}, {0x01, 0x02}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := dedupLockRows(c.in)
+			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestDedupLockRows_PreservesSetSemantics(t *testing.T) {
+	a := [][]byte{{0x03}, {0x01}, {0x02}, {0x01}, {0x03}}
+	b := [][]byte{{0x01}, {0x02}, {0x03}, {0x02}, {0x01}}
+
+	require.Equal(t, dedupLockRows(a), dedupLockRows(b),
+		"different orderings of the same multiset must dedupe to the same slice")
+}
+
+func TestDedupLockRows_Idempotent(t *testing.T) {
+	in := [][]byte{{0x01}, {0x02}, {0x03}, {0x04}}
+	once := dedupLockRows(in)
+	twice := dedupLockRows(append([][]byte(nil), once...))
+	require.Equal(t, once, twice)
+}

--- a/pkg/sql/colexec/multi_update/insert.go
+++ b/pkg/sql/colexec/multi_update/insert.go
@@ -132,33 +132,61 @@ func (update *MultiUpdate) insert_table(
 	inputBatch *batch.Batch,
 	insertBatch *batch.Batch,
 ) (err error) {
-
-	insertBatch.CleanOnlyData()
-	for insertIdx, inputIdx := range updateCtx.InsertCols {
-		err = insertBatch.Vecs[insertIdx].UnionBatch(inputBatch.Vecs[inputIdx], 0, inputBatch.Vecs[inputIdx].Length(), nil, proc.GetMPool())
-		if err != nil {
-			return err
-		}
+	rowCount := inputBatch.RowCount()
+	if rowCount == 0 {
+		return
 	}
-	rowCount := insertBatch.Vecs[0].Length()
-	if rowCount > 0 {
-		insertBatch.SetRowCount(rowCount)
-		tableType := update.ctr.updateCtxInfos[updateCtx.TableDef.Name].tableType
-		update.addInsertAffectRows(tableType, uint64(rowCount))
-		source := update.ctr.updateCtxInfos[updateCtx.TableDef.Name].Source
 
-		crs := analyzer.GetOpCounterSet()
-		newCtx := perfcounter.AttachS3RequestKey(proc.Ctx, crs)
-		err = source.Write(newCtx, insertBatch)
-		if err != nil {
-			return err
+	// Fast path: when InsertCols form a contiguous 0-based sequence matching
+	// the insertBatch layout, we can build a zero-copy reference batch that
+	// shares the input vectors directly, avoiding UnionBatch memcpy overhead.
+	writeBatch := insertBatch
+	if isContiguousMapping(updateCtx.InsertCols) {
+		writeBatch = batch.NewOffHeapWithSize(len(updateCtx.InsertCols))
+		for insertIdx, inputIdx := range updateCtx.InsertCols {
+			writeBatch.Vecs[insertIdx] = inputBatch.Vecs[inputIdx]
 		}
-		analyzer.AddWrittenRows(int64(insertBatch.RowCount()))
-		analyzer.AddS3RequestCount(crs)
-		analyzer.AddFileServiceCacheInfo(crs)
-		analyzer.AddDiskIO(crs)
+		writeBatch.SetAttributes(insertBatch.Attrs)
+		writeBatch.SetRowCount(rowCount)
+	} else {
+		insertBatch.CleanOnlyData()
+		for insertIdx, inputIdx := range updateCtx.InsertCols {
+			err = insertBatch.Vecs[insertIdx].UnionBatch(inputBatch.Vecs[inputIdx], 0, inputBatch.Vecs[inputIdx].Length(), nil, proc.GetMPool())
+			if err != nil {
+				return err
+			}
+		}
+		insertBatch.SetRowCount(insertBatch.Vecs[0].Length())
 	}
+
+	tableType := update.ctr.updateCtxInfos[updateCtx.TableDef.Name].tableType
+	update.addInsertAffectRows(tableType, uint64(writeBatch.RowCount()))
+	source := update.ctr.updateCtxInfos[updateCtx.TableDef.Name].Source
+
+	crs := analyzer.GetOpCounterSet()
+	newCtx := perfcounter.AttachS3RequestKey(proc.Ctx, crs)
+	err = source.Write(newCtx, writeBatch)
+	if err != nil {
+		return err
+	}
+	analyzer.AddWrittenRows(int64(writeBatch.RowCount()))
+	analyzer.AddS3RequestCount(crs)
+	analyzer.AddFileServiceCacheInfo(crs)
+	analyzer.AddDiskIO(crs)
 	return
+}
+
+func isContiguousMapping(cols []int) bool {
+	if len(cols) == 0 {
+		return false
+	}
+	base := cols[0]
+	for i, col := range cols {
+		if col != base+i {
+			return false
+		}
+	}
+	return true
 }
 
 func (update *MultiUpdate) check_null_and_insert_table(

--- a/pkg/sql/colexec/multi_update/insert.go
+++ b/pkg/sql/colexec/multi_update/insert.go
@@ -137,17 +137,18 @@ func (update *MultiUpdate) insert_table(
 		return
 	}
 
-	// Fast path: when InsertCols form a contiguous 0-based sequence matching
-	// the insertBatch layout, we can build a zero-copy reference batch that
-	// shares the input vectors directly, avoiding UnionBatch memcpy overhead.
+	info := update.ctr.updateCtxInfos[updateCtx.TableDef.Name]
 	writeBatch := insertBatch
-	if isContiguousMapping(updateCtx.InsertCols) {
-		writeBatch = batch.NewOffHeapWithSize(len(updateCtx.InsertCols))
-		for insertIdx, inputIdx := range updateCtx.InsertCols {
-			writeBatch.Vecs[insertIdx] = inputBatch.Vecs[inputIdx]
+	if info.isContiguous {
+		if info.refBatch == nil {
+			info.refBatch = batch.NewOffHeapWithSize(len(updateCtx.InsertCols))
+			info.refBatch.SetAttributes(insertBatch.Attrs)
 		}
-		writeBatch.SetAttributes(insertBatch.Attrs)
-		writeBatch.SetRowCount(rowCount)
+		for insertIdx, inputIdx := range updateCtx.InsertCols {
+			info.refBatch.Vecs[insertIdx] = inputBatch.Vecs[inputIdx]
+		}
+		info.refBatch.SetRowCount(rowCount)
+		writeBatch = info.refBatch
 	} else {
 		insertBatch.CleanOnlyData()
 		for insertIdx, inputIdx := range updateCtx.InsertCols {
@@ -159,13 +160,11 @@ func (update *MultiUpdate) insert_table(
 		insertBatch.SetRowCount(insertBatch.Vecs[0].Length())
 	}
 
-	tableType := update.ctr.updateCtxInfos[updateCtx.TableDef.Name].tableType
-	update.addInsertAffectRows(tableType, uint64(writeBatch.RowCount()))
-	source := update.ctr.updateCtxInfos[updateCtx.TableDef.Name].Source
+	update.addInsertAffectRows(info.tableType, uint64(writeBatch.RowCount()))
 
 	crs := analyzer.GetOpCounterSet()
 	newCtx := perfcounter.AttachS3RequestKey(proc.Ctx, crs)
-	err = source.Write(newCtx, writeBatch)
+	err = info.Source.Write(newCtx, writeBatch)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/colexec/multi_update/insert_table_test.go
+++ b/pkg/sql/colexec/multi_update/insert_table_test.go
@@ -1,0 +1,327 @@
+// Copyright 2021-2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multi_update
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsContiguousMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		cols []int
+		want bool
+	}{
+		{"empty", []int{}, false},
+		{"single-zero", []int{0}, true},
+		{"single-nonzero", []int{7}, true},
+		{"contiguous-from-zero", []int{0, 1, 2, 3}, true},
+		{"contiguous-from-nonzero", []int{3, 4, 5}, true},
+		{"reordered", []int{2, 0, 1}, false},
+		{"jump", []int{0, 1, 3}, false},
+		{"jump-late", []int{3, 4, 6}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, isContiguousMapping(c.cols))
+		})
+	}
+}
+
+// insertTableHarness wires up just enough of MultiUpdate state for
+// insert_table to run, capturing every batch that Source.Write receives.
+type insertTableHarness struct {
+	op         *MultiUpdate
+	updateCtx  *MultiUpdateCtx
+	info       *updateCtxInfo
+	written    []*batch.Batch // captured batches passed to Source.Write
+	insertBuf  *batch.Batch   // pre-allocated buffer (used by non-contiguous path)
+	tableName  string
+}
+
+func newInsertTableHarness(
+	t *testing.T,
+	ctrl *gomock.Controller,
+	mp *mpool.MPool,
+	insertCols []int,
+	colTypes []types.Type,
+	attrs []string,
+) *insertTableHarness {
+	t.Helper()
+
+	tableName := "t_unit"
+	updateCtx := &MultiUpdateCtx{
+		InsertCols: insertCols,
+		TableDef:   nil,
+	}
+
+	h := &insertTableHarness{tableName: tableName, updateCtx: updateCtx}
+
+	rel := mock_frontend.NewMockRelation(ctrl)
+	rel.EXPECT().
+		Write(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, b *batch.Batch) error {
+			h.written = append(h.written, b)
+			return nil
+		}).AnyTimes()
+
+	h.info = &updateCtxInfo{
+		Source:       rel,
+		tableType:    UpdateMainTable,
+		isContiguous: isContiguousMapping(insertCols),
+	}
+
+	h.op = &MultiUpdate{
+		ctr: container{
+			updateCtxInfos: map[string]*updateCtxInfo{tableName: h.info},
+			action:         actionInsert,
+		},
+		MultiUpdateCtx: []*MultiUpdateCtx{updateCtx},
+	}
+	h.op.addAffectedRowsFunc = h.op.doAddAffectedRows
+
+	// insert_table only reads updateCtx.TableDef.Name on the hot path.
+	updateCtx.TableDef = &plan.TableDef{Name: tableName}
+
+	// Pre-allocate the insertBuf only for the non-contiguous path. Contiguous
+	// path never reads it; passing it in keeps the call site's signature happy.
+	insertBuf := batch.NewOffHeapWithSize(len(insertCols))
+	insertBuf.SetAttributes(attrs)
+	for i := range insertCols {
+		insertBuf.Vecs[i] = vector.NewOffHeapVecWithType(colTypes[i])
+	}
+	h.insertBuf = insertBuf
+	return h
+}
+
+func (h *insertTableHarness) cleanup(mp *mpool.MPool) {
+	if h.insertBuf != nil {
+		h.insertBuf.Clean(mp)
+	}
+}
+
+func makeInputBatch(t *testing.T, mp *mpool.MPool, rowCount int) *batch.Batch {
+	t.Helper()
+	a := testutil.MakeInt64Vector(makeTestPkArray(0, rowCount), nil, mp)
+	b := testutil.NewInt32Vector(rowCount, types.T_int32.ToType(), mp, false, nil, nil)
+	c := testutil.NewInt32Vector(rowCount, types.T_int32.ToType(), mp, false, nil, nil)
+	d := testutil.NewInt32Vector(rowCount, types.T_int32.ToType(), mp, false, nil, nil)
+	bat := &batch.Batch{
+		Vecs:  []*vector.Vector{a, b, c, d},
+		Attrs: []string{"a", "b", "c", "d"},
+	}
+	bat.SetRowCount(rowCount)
+	return bat
+}
+
+func TestInsertTable_Contiguous_BorrowsVectors(t *testing.T) {
+	_, ctrl, proc := prepareTestCtx(t, false)
+	defer ctrl.Finish()
+	mp := proc.GetMPool()
+
+	insertCols := []int{1, 2, 3}
+	colTypes := []types.Type{
+		types.T_int32.ToType(),
+		types.T_int32.ToType(),
+		types.T_int32.ToType(),
+	}
+	attrs := []string{"b", "c", "d"}
+	h := newInsertTableHarness(t, ctrl, mp, insertCols, colTypes, attrs)
+	defer h.cleanup(mp)
+
+	require.True(t, h.info.isContiguous, "InsertCols=[1,2,3] must be contiguous")
+
+	input := makeInputBatch(t, mp, 4)
+	defer input.Clean(mp)
+
+	analyzer := process.NewTempAnalyzer()
+	require.NoError(t, h.op.insert_table(proc, analyzer, h.updateCtx, input, h.insertBuf))
+
+	require.Len(t, h.written, 1)
+	written := h.written[0]
+	require.Same(t, h.info.refBatch, written, "writeBatch must be info.refBatch on contiguous path")
+	require.Equal(t, input.RowCount(), written.RowCount())
+
+	// Vector ownership stays with input; refBatch.Vecs[i] are borrowed pointers.
+	for i, inputIdx := range insertCols {
+		require.Same(t, input.Vecs[inputIdx], written.Vecs[i],
+			"contiguous path must borrow input vector at slot %d", i)
+	}
+	require.EqualValues(t, input.RowCount(), h.op.GetAffectedRows())
+}
+
+func TestInsertTable_Contiguous_RefBatchReused(t *testing.T) {
+	_, ctrl, proc := prepareTestCtx(t, false)
+	defer ctrl.Finish()
+	mp := proc.GetMPool()
+
+	insertCols := []int{0, 1, 2, 3}
+	colTypes := []types.Type{
+		types.T_int64.ToType(),
+		types.T_int32.ToType(),
+		types.T_int32.ToType(),
+		types.T_int32.ToType(),
+	}
+	attrs := []string{"a", "b", "c", "d"}
+	h := newInsertTableHarness(t, ctrl, mp, insertCols, colTypes, attrs)
+	defer h.cleanup(mp)
+
+	analyzer := process.NewTempAnalyzer()
+	in1 := makeInputBatch(t, mp, 3)
+	defer in1.Clean(mp)
+	in2 := makeInputBatch(t, mp, 5)
+	defer in2.Clean(mp)
+
+	require.NoError(t, h.op.insert_table(proc, analyzer, h.updateCtx, in1, h.insertBuf))
+	firstRef := h.info.refBatch
+	require.NotNil(t, firstRef)
+
+	require.NoError(t, h.op.insert_table(proc, analyzer, h.updateCtx, in2, h.insertBuf))
+	require.Same(t, firstRef, h.info.refBatch,
+		"second insert_table call must reuse the same refBatch struct")
+
+	// And the borrowed vectors should now point at in2's vectors.
+	for i, inputIdx := range insertCols {
+		require.Same(t, in2.Vecs[inputIdx], h.info.refBatch.Vecs[i])
+	}
+	require.Equal(t, in2.RowCount(), h.info.refBatch.RowCount())
+}
+
+func TestInsertTable_NonContiguous_CopiesVectors(t *testing.T) {
+	_, ctrl, proc := prepareTestCtx(t, false)
+	defer ctrl.Finish()
+	mp := proc.GetMPool()
+
+	insertCols := []int{0, 2, 3}
+	colTypes := []types.Type{
+		types.T_int64.ToType(),
+		types.T_int32.ToType(),
+		types.T_int32.ToType(),
+	}
+	attrs := []string{"a", "c", "d"}
+	h := newInsertTableHarness(t, ctrl, mp, insertCols, colTypes, attrs)
+	defer h.cleanup(mp)
+	require.False(t, h.info.isContiguous, "InsertCols=[0,2,3] must be non-contiguous")
+
+	input := makeInputBatch(t, mp, 4)
+	defer input.Clean(mp)
+
+	analyzer := process.NewTempAnalyzer()
+	require.NoError(t, h.op.insert_table(proc, analyzer, h.updateCtx, input, h.insertBuf))
+
+	require.Len(t, h.written, 1)
+	written := h.written[0]
+	require.Same(t, h.insertBuf, written,
+		"non-contiguous path writes via insertBuf, never via refBatch")
+	require.Nil(t, h.info.refBatch, "non-contiguous path must not allocate refBatch")
+	require.Equal(t, input.RowCount(), written.RowCount())
+
+	// Copied vectors are owned by insertBuf — distinct from input vectors.
+	for i, inputIdx := range insertCols {
+		require.NotSame(t, input.Vecs[inputIdx], written.Vecs[i],
+			"non-contiguous path must copy, not borrow, slot %d", i)
+	}
+}
+
+func TestInsertTable_PathEquivalence(t *testing.T) {
+	_, ctrl, proc := prepareTestCtx(t, false)
+	defer ctrl.Finish()
+	mp := proc.GetMPool()
+
+	// Use a contiguous mapping; we'll force the non-contiguous path by
+	// flipping the flag, so both runs handle the *same* logical projection.
+	insertCols := []int{0, 1, 2, 3}
+	colTypes := []types.Type{
+		types.T_int64.ToType(),
+		types.T_int32.ToType(),
+		types.T_int32.ToType(),
+		types.T_int32.ToType(),
+	}
+	attrs := []string{"a", "b", "c", "d"}
+
+	hContig := newInsertTableHarness(t, ctrl, mp, insertCols, colTypes, attrs)
+	defer hContig.cleanup(mp)
+	require.True(t, hContig.info.isContiguous)
+
+	hCopy := newInsertTableHarness(t, ctrl, mp, insertCols, colTypes, attrs)
+	defer hCopy.cleanup(mp)
+	hCopy.info.isContiguous = false // force the slow path
+
+	input := makeInputBatch(t, mp, 6)
+	defer input.Clean(mp)
+
+	analyzer := process.NewTempAnalyzer()
+	require.NoError(t, hContig.op.insert_table(proc, analyzer, hContig.updateCtx, input, hContig.insertBuf))
+	require.NoError(t, hCopy.op.insert_table(proc, analyzer, hCopy.updateCtx, input, hCopy.insertBuf))
+
+	require.Len(t, hContig.written, 1)
+	require.Len(t, hCopy.written, 1)
+	a, b := hContig.written[0], hCopy.written[0]
+	require.Equal(t, a.RowCount(), b.RowCount())
+	require.Equal(t, len(a.Vecs), len(b.Vecs))
+	for i := range a.Vecs {
+		require.Equal(t, a.Vecs[i].String(), b.Vecs[i].String(),
+			"vector %d (%s) must be identical between paths", i, attrs[i])
+	}
+}
+
+func TestMultiUpdate_Free_RefBatchNoDoubleFree(t *testing.T) {
+	_, ctrl, proc := prepareTestCtx(t, false)
+	defer ctrl.Finish()
+	mp := proc.GetMPool()
+
+	insertCols := []int{1, 2, 3}
+	colTypes := []types.Type{
+		types.T_int32.ToType(),
+		types.T_int32.ToType(),
+		types.T_int32.ToType(),
+	}
+	attrs := []string{"b", "c", "d"}
+	h := newInsertTableHarness(t, ctrl, mp, insertCols, colTypes, attrs)
+
+	input := makeInputBatch(t, mp, 4)
+	analyzer := process.NewTempAnalyzer()
+	require.NoError(t, h.op.insert_table(proc, analyzer, h.updateCtx, input, h.insertBuf))
+	require.NotNil(t, h.info.refBatch)
+
+	// Free should drop updateCtxInfos without touching the borrowed vectors;
+	// input still owns them and must remain usable.
+	h.op.Free(proc, false, nil)
+	require.Nil(t, h.op.ctr.updateCtxInfos)
+
+	for i, inputIdx := range insertCols {
+		v := input.Vecs[inputIdx]
+		require.NotNil(t, v, "input.Vecs[%d] must survive operator Free", inputIdx)
+		require.Equal(t, input.RowCount(), v.Length(),
+			"slot %d data still readable after Free", i)
+	}
+
+	// Cleanup leaves no mpool drift.
+	input.Clean(mp)
+	h.insertBuf.Clean(mp)
+	require.Equal(t, int64(0), mp.CurrNB())
+}

--- a/pkg/sql/colexec/multi_update/insert_table_test.go
+++ b/pkg/sql/colexec/multi_update/insert_table_test.go
@@ -55,12 +55,12 @@ func TestIsContiguousMapping(t *testing.T) {
 // insertTableHarness wires up just enough of MultiUpdate state for
 // insert_table to run, capturing every batch that Source.Write receives.
 type insertTableHarness struct {
-	op         *MultiUpdate
-	updateCtx  *MultiUpdateCtx
-	info       *updateCtxInfo
-	written    []*batch.Batch // captured batches passed to Source.Write
-	insertBuf  *batch.Batch   // pre-allocated buffer (used by non-contiguous path)
-	tableName  string
+	op        *MultiUpdate
+	updateCtx *MultiUpdateCtx
+	info      *updateCtxInfo
+	written   []*batch.Batch // captured batches passed to Source.Write
+	insertBuf *batch.Batch   // pre-allocated buffer (used by non-contiguous path)
+	tableName string
 }
 
 func newInsertTableHarness(

--- a/pkg/sql/colexec/multi_update/multi_update.go
+++ b/pkg/sql/colexec/multi_update/multi_update.go
@@ -71,6 +71,7 @@ func (update *MultiUpdate) Prepare(proc *process.Process) error {
 				tableType = UpdateSecondaryIndexTable
 			}
 			info.tableType = tableType
+			info.isContiguous = isContiguousMapping(updateCtx.InsertCols)
 			update.ctr.updateCtxInfos[updateCtx.TableDef.Name] = info
 		}
 	}

--- a/pkg/sql/colexec/multi_update/types.go
+++ b/pkg/sql/colexec/multi_update/types.go
@@ -85,9 +85,11 @@ type MultiUpdate struct {
 }
 
 type updateCtxInfo struct {
-	Source      engine.Relation
-	tableType   UpdateTableType
-	insertAttrs []string
+	Source       engine.Relation
+	tableType    UpdateTableType
+	insertAttrs  []string
+	isContiguous bool
+	refBatch     *batch.Batch
 }
 
 type container struct {

--- a/pkg/sql/plan/bind_replace.go
+++ b/pkg/sql/plan/bind_replace.go
@@ -162,6 +162,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 			if err != nil {
 				return 0, err
 			}
+			ensureName2ColIndexForReplace(idxTableDefs[i])
 
 			// Spatial indexes look up the old index-table row via the primary
 			// column (indexLookupColumnName returns IndexTablePrimaryColName).
@@ -216,6 +217,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 			if err != nil {
 				return 0, err
 			}
+			ensureName2ColIndexForReplace(idxTableDefs[i])
 			oldColName2Idx[idxDef.IndexTableName+"."+catalog.IndexTablePrimaryColName] = oldColName2Idx[tableDef.Name+"."+tableDef.Pkey.PkeyColName]
 
 			if !indexTableStoresSerializedKey(idxDef) {
@@ -743,7 +745,12 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 		}
 
 		oldRowIdPos := int32(len(finalProjList))
-		oldColRef := oldColName2Idx[idxDef.IndexTableName+"."+catalog.Row_ID]
+		oldRowIDKey := idxTableDefs[i].Name + "." + catalog.Row_ID
+		oldColRef, ok := oldColName2Idx[oldRowIDKey]
+		if !ok {
+			return 0, moerr.NewInternalErrorf(builder.GetContext(),
+				"bind replace err, can not find old index rowid colName = %s", oldRowIDKey)
+		}
 		rowIdExpr := &plan.Expr{
 			Typ: idxTableDefs[i].Cols[idxTableDefs[i].Name2ColIndex[catalog.Row_ID]].Typ,
 			Expr: &plan.Expr_Col{
@@ -758,7 +765,12 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 		oldIdxPos := int32(len(finalProjList))
 		lookupColName := indexLookupColumnName(idxDef)
 		lookupColIdx := idxTableDefs[i].Name2ColIndex[lookupColName]
-		oldColRef = oldColName2Idx[idxDef.IndexTableName+"."+lookupColName]
+		oldLookupKey := idxTableDefs[i].Name + "." + lookupColName
+		oldColRef, ok = oldColName2Idx[oldLookupKey]
+		if !ok {
+			return 0, moerr.NewInternalErrorf(builder.GetContext(),
+				"bind replace err, can not find old index lookup colName = %s", oldLookupKey)
+		}
 		idxExpr := &plan.Expr{
 			Typ: idxTableDefs[i].Cols[lookupColIdx].Typ,
 			Expr: &plan.Expr_Col{
@@ -834,6 +846,16 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 	}, bindCtx)
 
 	return lastNodeID, nil
+}
+
+func ensureName2ColIndexForReplace(tableDef *TableDef) {
+	if len(tableDef.Name2ColIndex) > 0 {
+		return
+	}
+	tableDef.Name2ColIndex = make(map[string]int32, len(tableDef.Cols))
+	for colIdx, col := range tableDef.Cols {
+		tableDef.Name2ColIndex[col.Name] = int32(colIdx)
+	}
 }
 
 func (builder *QueryBuilder) appendNodesForReplaceStmt(

--- a/pkg/sql/plan/bind_replace.go
+++ b/pkg/sql/plan/bind_replace.go
@@ -80,7 +80,7 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 	idxObjRefs := make([]*plan.ObjectRef, len(tableDef.Indexes))
 	idxTableDefs := make([]*plan.TableDef, len(tableDef.Indexes))
 
-	oldColName2Idx := make(map[string][2]int32)
+	oldColName2Idx := make(map[string][2]int32, len(tableDef.Cols)+len(tableDef.Indexes)*2)
 
 	// Check whether the table has any unique secondary index.
 	// For fake PK tables with no unique indexes (no PK, no UK), REPLACE behaves like INSERT.
@@ -440,13 +440,23 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 
 		dedupJoinCtx := &plan.DedupJoinCtx{}
 		if useMergedMainScan {
-			// Merged-scan mode: the DEDUP JOIN captures every main-table column
-			// from its own probe-side scan into the build-side NULL placeholder
-			// slots set up in fullProjList above. The old DelRows/OldColList
-			// path is no longer needed because the captured values feed
-			// downstream consumers directly.
-			captureList := make([]plan.OldColCapture, 0, len(tableDef.Cols))
+			// Merged-scan mode: only capture the old columns that downstream
+			// actually needs (RowID, PK, and index-key columns), not every
+			// main-table column. The remaining NULL placeholders in fullProjList
+			// stay as-is — they are never read by MULTI_UPDATE.
+			requiredOldCols := make(map[string]struct{}, 2+len(tableDef.Indexes))
+			requiredOldCols[catalog.Row_ID] = struct{}{}
+			requiredOldCols[tableDef.Pkey.PkeyColName] = struct{}{}
+			for _, idxDef := range tableDef.Indexes {
+				if !indexTableStoresSerializedKey(idxDef) {
+					requiredOldCols[indexPrimaryPartName(idxDef)] = struct{}{}
+				}
+			}
+			captureList := make([]plan.OldColCapture, 0, len(requiredOldCols))
 			for i, col := range tableDef.Cols {
+				if _, needed := requiredOldCols[col.Name]; !needed {
+					continue
+				}
 				placeholderPos := oldColName2Idx[tableDef.Name+"."+col.Name]
 				captureList = append(captureList, plan.OldColCapture{
 					BuildPlaceholder: plan.ColRef{
@@ -833,7 +843,8 @@ func (builder *QueryBuilder) appendNodesForReplaceStmt(
 	objRef *ObjectRef,
 	insertColToExpr map[string]*Expr,
 ) (int32, map[string]int32, []bool, error) {
-	colName2Idx := make(map[string]int32)
+	colCount := len(tableDef.Cols)
+	colName2Idx := make(map[string]int32, colCount+len(tableDef.Indexes)*2)
 	hasAutoCol := false
 	for _, col := range tableDef.Cols {
 		if col.Typ.AutoIncr {
@@ -842,8 +853,8 @@ func (builder *QueryBuilder) appendNodesForReplaceStmt(
 		}
 	}
 
-	projList1 := make([]*plan.Expr, 0, len(tableDef.Cols)-1)
-	projList2 := make([]*plan.Expr, 0, len(tableDef.Cols)-1)
+	projList1 := make([]*plan.Expr, 0, colCount-1)
+	projList2 := make([]*plan.Expr, 0, colCount-1)
 	projTag1 := builder.genNewBindTag()
 	preInsertTag := builder.genNewBindTag()
 
@@ -852,11 +863,11 @@ func (builder *QueryBuilder) appendNodesForReplaceStmt(
 		clusterByExpr *plan.Expr
 	)
 
-	columnIsNull := make(map[string]bool)
+	columnIsNull := make(map[string]bool, colCount)
 	hasCompClusterBy := tableDef.ClusterBy != nil && util.JudgeIsCompositeClusterByColumn(tableDef.ClusterBy.Name)
-	colIdxToProjPos := make(map[int32]int32)
-	genColIdxToProj1Pos := make(map[int]int)
-	genColIdxToProj2Pos := make(map[int]int)
+	colIdxToProjPos := make(map[int32]int32, colCount)
+	genColIdxToProj1Pos := make(map[int]int, colCount)
+	genColIdxToProj2Pos := make(map[int]int, colCount)
 	generatedColIdxs := make([]int, 0)
 
 	for i, col := range tableDef.Cols {

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -814,6 +814,74 @@ func TestReplacePlanStructure(t *testing.T) {
 	assert.True(t, hasDedupJoin, "REPLACE plan should contain DEDUP JOIN node")
 }
 
+func TestReplaceNonUniqueSingleIndexDeleteUsesIndexRowID(t *testing.T) {
+	mock := NewMockOptimizer(true)
+
+	logicPlan, err := runOneStmt(mock, t,
+		"REPLACE INTO single_idx_t VALUES (1, 100)")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	query := logicPlan.GetQuery()
+	assert.NotNil(t, query)
+
+	var multiUpdate *plan.Node
+	for _, node := range query.Nodes {
+		if node.NodeType == plan.Node_MULTI_UPDATE {
+			multiUpdate = node
+			break
+		}
+	}
+	if multiUpdate == nil {
+		t.Fatal("REPLACE plan should contain MULTI_UPDATE node")
+	}
+
+	var idxUpdateCtx *plan.UpdateCtx
+	for _, updateCtx := range multiUpdate.UpdateCtxList {
+		if updateCtx.TableDef == nil {
+			continue
+		}
+		if strings.HasPrefix(updateCtx.TableDef.Name, catalog.SecondaryIndexTableNamePrefix) {
+			idxUpdateCtx = updateCtx
+			break
+		}
+	}
+	if idxUpdateCtx == nil {
+		t.Fatal("REPLACE plan should contain UpdateCtx for the secondary index table")
+	}
+	if len(idxUpdateCtx.DeleteCols) < 2 {
+		t.Fatal("secondary index UpdateCtx should contain delete columns")
+	}
+	if len(multiUpdate.Children) != 1 {
+		t.Fatalf("MULTI_UPDATE should have one child, got %d", len(multiUpdate.Children))
+	}
+
+	oldRowIDDeleteCol := idxUpdateCtx.DeleteCols[0]
+	oldIdxDeleteCol := idxUpdateCtx.DeleteCols[1]
+	child := query.Nodes[multiUpdate.Children[0]]
+	if oldRowIDDeleteCol.ColPos < 0 || int(oldRowIDDeleteCol.ColPos) >= len(child.ProjectList) {
+		t.Fatalf("DeleteCols[0] ColPos %d out of child project range %d",
+			oldRowIDDeleteCol.ColPos, len(child.ProjectList))
+	}
+	if oldIdxDeleteCol.ColPos < 0 || int(oldIdxDeleteCol.ColPos) >= len(child.ProjectList) {
+		t.Fatalf("DeleteCols[1] ColPos %d out of child project range %d",
+			oldIdxDeleteCol.ColPos, len(child.ProjectList))
+	}
+	wantRowIDName := idxUpdateCtx.TableDef.Name + "." + catalog.Row_ID
+	wantIdxName := idxUpdateCtx.TableDef.Name + "." + catalog.IndexTableIndexColName
+	assert.Equal(t, wantRowIDName, oldRowIDDeleteCol.Name,
+		"DeleteCols[0] should read Row_ID from the secondary index table")
+	assert.Equal(t, wantIdxName, oldIdxDeleteCol.Name,
+		"DeleteCols[1] should read the secondary index key column")
+	assert.Equal(t, int32(types.T_Rowid), child.ProjectList[oldRowIDDeleteCol.ColPos].Typ.Id,
+		"DeleteCols[0] should point at a Row_ID vector in the MULTI_UPDATE input")
+	assert.NotEqual(t, oldRowIDDeleteCol.ColPos, oldIdxDeleteCol.ColPos,
+		"Row_ID and index key delete columns must not collapse to the same input column")
+	assert.False(t, oldRowIDDeleteCol.RelPos == 0 && oldRowIDDeleteCol.ColPos == 0 &&
+		oldRowIDDeleteCol.Name != wantRowIDName,
+		"DeleteCols[0] must not fall back to a zero-value ColRef")
+}
+
 func TestReplaceSelfRefPlanStructure(t *testing.T) {
 	mock := NewMockOptimizer(true)
 

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -1531,3 +1531,107 @@ func Test_bind_delete(t *testing.T) {
 	_, err := canDeleteRewriteToTruncate(compileCtx, dmlCtx)
 	assert.Error(t, err)
 }
+
+// findDedupJoinCaptureList walks the plan looking for the DEDUP JOIN whose
+// build side carries the OldColCaptureList — there is at most one in a
+// REPLACE plan that took the merged-main-scan path.
+func findDedupJoinCaptureList(t *testing.T, query *plan.Query) []plan.OldColCapture {
+	t.Helper()
+	for _, node := range query.Nodes {
+		if node.NodeType != plan.Node_JOIN || node.JoinType != plan.Node_DEDUP {
+			continue
+		}
+		if node.DedupJoinCtx == nil {
+			continue
+		}
+		if len(node.DedupJoinCtx.OldColCaptureList) > 0 {
+			return node.DedupJoinCtx.OldColCaptureList
+		}
+	}
+	return nil
+}
+
+// TestReplaceCaptureListNarrowed pins the merged-main-scan capture list to
+// exactly the columns MULTI_UPDATE actually consumes — Row_ID + PK + (per
+// non-serialized index, the leading part column). If the narrowing in
+// appendDedupAndMultiUpdateNodesForBindReplace regresses to "capture every
+// main-table column", this test will catch it.
+//
+// We assert by total count rather than by exact ColPos, because the build-side
+// projection list may have leading slots prepended before main-table cols
+// (cluster keys, etc.) — so absolute positions are layout-sensitive but the
+// count formula is not.
+func TestReplaceCaptureListNarrowed(t *testing.T) {
+	mock := NewMockOptimizer(true)
+
+	// self_ref: id PK + parent_id + name + Row_ID; zero indexes.
+	// requiredOldCols = {Row_ID, id} ⇒ capture list length == 2.
+	// Pre-narrowing the planner emitted one capture per main-table column
+	// (length == 4), which is the regression this test guards against.
+	logicPlan, err := runOneStmt(mock, t,
+		"REPLACE INTO self_ref VALUES (1, NULL, 'root')")
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	query := logicPlan.GetQuery()
+	assert.NotNil(t, query)
+
+	captureList := findDedupJoinCaptureList(t, query)
+	assert.NotNil(t, captureList,
+		"self_ref REPLACE should take the merged-main-scan capture path")
+
+	const totalCols = 4 // 3 user cols + Row_ID
+	assert.Less(t, len(captureList), totalCols,
+		"capture list must be narrower than the full main-table col set")
+	assert.Len(t, captureList, 2,
+		"expected Row_ID + PK only; if this changes the formula 1+1+#single_part_idx is wrong")
+
+	relPos := captureList[0].BuildPlaceholder.RelPos
+	seen := map[int32]bool{}
+	for _, c := range captureList {
+		assert.Equal(t, relPos, c.BuildPlaceholder.RelPos,
+			"all captures must share one build-side bind tag")
+		assert.False(t, seen[c.BuildPlaceholder.ColPos],
+			"capture positions must be distinct, got duplicate ColPos=%d",
+			c.BuildPlaceholder.ColPos)
+		seen[c.BuildPlaceholder.ColPos] = true
+	}
+}
+
+// TestReplaceCaptureList_NotEmittedWhenMergedScanDisabled documents the
+// negative side: tables that fail the useMergedMainScan guard
+// (fake PK or any multi-part index) must produce an empty capture list. This
+// guards against accidentally enabling capture on a path the optimizer
+// can't yet feed correctly.
+func TestReplaceCaptureList_NotEmittedWhenMergedScanDisabled(t *testing.T) {
+	mock := NewMockOptimizer(true)
+
+	cases := []struct {
+		name string
+		sql  string
+		why  string
+	}{
+		{
+			name: "dept_has_multi_part_idx",
+			sql:  "REPLACE INTO dept VALUES (1, 'Sales', 'NY')",
+			why:  "dept has a (loc, dname) index → hasMultiPartIdx=true",
+		},
+		{
+			name: "fake_pk_t",
+			sql:  "REPLACE INTO fake_pk_t VALUES (1, 'hello')",
+			why:  "fake_pk_t has no real PK → isFakePK=true",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			logicPlan, err := runOneStmt(mock, t, c.sql)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			query := logicPlan.GetQuery()
+			assert.NotNil(t, query)
+			assert.Nil(t, findDedupJoinCaptureList(t, query),
+				"%s: %s, no DEDUP JOIN should carry a capture list", c.name, c.why)
+		})
+	}
+}

--- a/pkg/sql/plan/mock.go
+++ b/pkg/sql/plan/mock.go
@@ -632,6 +632,45 @@ func NewMockCompilerContext(isDml bool) *MockCompilerContext {
 	}
 
 	/*
+		create table single_idx_t(
+			id int primary key,
+			val int,
+			index idx_val(val)
+		);
+	*/
+	constraintTestSchema["single_idx_t"] = &Schema{
+		tblId: 88900,
+		cols: []col{
+			{"id", types.T_int32, true, 32, 0},
+			{"val", types.T_int32, true, 32, 0},
+			{catalog.Row_ID, types.T_Rowid, true, 0, 0},
+		},
+		pks: []int{0},
+		idxs: []index{
+			{
+				indexName: "idx_val",
+				tableName: catalog.SecondaryIndexTableNamePrefix + "single-idx-t-idx-val",
+				parts:     []string{"val"},
+				cols: []col{
+					{catalog.IndexTableIndexColName, types.T_int32, true, 32, 0},
+				},
+				tableExist: true,
+				unique:     false,
+			},
+		},
+		outcnt: 4,
+	}
+	constraintTestSchema[catalog.SecondaryIndexTableNamePrefix+"single-idx-t-idx-val"] = &Schema{
+		cols: []col{
+			{catalog.IndexTableIndexColName, types.T_int32, true, 32, 0},
+			{catalog.IndexTablePrimaryColName, types.T_int32, true, 32, 0},
+			{catalog.Row_ID, types.T_Rowid, true, 0, 0},
+		},
+		pks:    []int{0},
+		outcnt: 4,
+	}
+
+	/*
 		create table dept(
 			deptno int unsigned auto_increment,
 			dname varchar(15),


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23946

## What this PR does / why we need it:

Cherry-pick of #24389 to 4.0-dev.

Three targeted optimizations to reduce overhead in the REPLACE INTO execution path (DedupJoin → LockOp → MultiUpdate):

**1. Cache hashmap iterator in DedupJoin probe loop** (`dedupjoin/join.go`)
- `ctr.mp.NewIterator()` was called on every batch; now cached in `ctr.cachedItr` and reused across batches, avoiding repeated allocation.

**2. Reduce vector copies in DedupJoin finalize** (`dedupjoin/join.go`)
- Non-capture build columns: transfer vector ownership (`bat.Vecs[rp.Pos] = nil`) instead of `GetUnionAllFunction` full copy.
- Capture columns with no matched rows: emit a pre-filled NULL vector via `AppendMultiFixed` instead of copying from `capturedVecs`.
- Replace per-row `UnionOne` loop with `unionSelsByBatch`, which groups selections by build-batch index and issues one `Union` call per group (with a ≤16-sels fast path to avoid grouping overhead for small inputs).

**3. Reduce lock and insert overhead** (`lockop/lock_op.go`, `multi_update/insert.go`, `multi_update/types.go`)
- `dedupLockRows`: replace map-based dedup with sort + adjacent-compare dedup, eliminating string allocations per lock row.
- Reuse `types.NewPacker()` across `Prepare` calls instead of allocating a new one each time.
- `insert_table`: detect contiguous `InsertCols` mappings at init time (`isContiguous`); when true, point a cached `refBatch` at input vectors directly (zero-copy) instead of `UnionBatch`-copying into `insertBatch`.

**Benchmark (YCSB REPLACE INTO, standalone MO, 100k rows, batchsize=1000):**

| threads | main | this PR |  vs main |
|---------|------|---------|----------|
| 32 | 1982.85 ops/s | 2154.52 ops/s | **+8.66%** |
| 64 | 1924.70 ops/s | 2042.75 ops/s | **+6.14%** |
