### PR TITLE
fix: enable vector index with single-row vector providers (cherry-pick #24394)

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -528,6 +528,7 @@ func getColSeqFromColDef(tblCol *plan.ColDef) string {
 
 func (builder *QueryBuilder) applyIndicesForProject(nodeID int32, projNode *plan.Node, colRefCnt map[[2]int32]int, idxColMap map[[2]int32]*plan.Expr) (int32, error) {
 	defer builder.clearProjectGuard(projNode.NodeId)
+	var vecCtx *vectorSortContext
 	// FullText
 	{
 		// support the followings:
@@ -544,20 +545,20 @@ func (builder *QueryBuilder) applyIndicesForProject(nodeID int32, projNode *plan
 			if sortNode == nil {
 				aggNode = builder.resolveAggNode(projNode, 1)
 				if aggNode == nil {
-					goto END0
+					goto END_FULLTEXT
 				}
 			}
 
 			if sortNode != nil {
 				scanNode = builder.resolveScanNodeWithIndex(sortNode, 1)
 				if scanNode == nil {
-					goto END0
+					goto END_FULLTEXT
 				}
 			}
 			if aggNode != nil {
 				scanNode = builder.resolveScanNodeWithIndex(aggNode, 1)
 				if scanNode == nil {
-					goto END0
+					goto END_FULLTEXT
 				}
 			}
 		}
@@ -586,11 +587,16 @@ func (builder *QueryBuilder) applyIndicesForProject(nodeID int32, projNode *plan
 			}
 		}
 	}
+END_FULLTEXT:
 
 	// 1. Vector Index Check
 	// Handle Queries like
 	// SELECT id,embedding FROM tbl ORDER BY l2_distance(embedding, "[1,2,3]") LIMIT 10;
-	if vecCtx := builder.buildVectorSortContext(projNode); vecCtx != nil {
+	vecCtx = builder.buildVectorSortContext(projNode)
+	if vecCtx == nil {
+		vecCtx = builder.buildVectorSortContextThroughJoin(projNode)
+	}
+	if vecCtx != nil {
 		multiTableIndexes := builder.collectVectorIndexes(vecCtx.scanNode)
 		if len(multiTableIndexes) == 0 {
 			return nodeID, nil
@@ -620,7 +626,6 @@ func (builder *QueryBuilder) applyIndicesForProject(nodeID int32, projNode *plan
 
 		builder.stabilizeExactVectorSort(vecCtx)
 	}
-END0:
 	// 2. Regular Index Check
 	{
 		if ctx := builder.buildRegularIndexTopSortContext(projNode); ctx != nil {
@@ -815,6 +820,9 @@ func (builder *QueryBuilder) detectFullTextGuard(projNode *plan.Node) []int32 {
 
 func (builder *QueryBuilder) detectVectorGuard(projNode *plan.Node) []int32 {
 	vecCtx := builder.buildVectorSortContext(projNode)
+	if vecCtx == nil {
+		vecCtx = builder.buildVectorSortContextThroughJoin(projNode)
+	}
 	if vecCtx == nil || vecCtx.scanNode == nil {
 		return nil
 	}

--- a/pkg/sql/plan/apply_indices_hnsw.go
+++ b/pkg/sql/plan/apply_indices_hnsw.go
@@ -82,7 +82,17 @@ func (builder *QueryBuilder) prepareHnswIndexContext(vecCtx *vectorSortContext, 
 
 	keyPart := idxDef.Parts[0]
 	partPos := vecCtx.scanNode.TableDef.Name2ColIndex[keyPart]
-	_, vecLitArg, found := builder.getArgsFromDistFn(vecCtx.distFnExpr, partPos)
+	var vecLitArg *plan.Expr
+	var found bool
+	if vecCtx.vecArgExpr != nil {
+		_, vecLitArg, found = builder.getArgsFromDistFnForJoin(
+			vecCtx.distFnExpr,
+			partPos,
+			vecCtx.scanNode.BindingTags[0],
+		)
+	} else {
+		_, vecLitArg, found = builder.getArgsFromDistFn(vecCtx.distFnExpr, partPos)
+	}
 	if !found {
 		return nil, nil
 	}
@@ -151,6 +161,7 @@ func (builder *QueryBuilder) applyIndicesForSortUsingHnsw(nodeID int32, vecCtx *
 			Cols: DeepCopyColDefList(kHNSWSearchColDefs),
 		},
 		BindingTags: []int32{tableFuncTag},
+		Children:    vectorSearchProviderChildren(vecCtx),
 		TblFuncExprList: []*plan.Expr{
 			{
 				Typ: plan.Type{
@@ -327,4 +338,30 @@ func (builder *QueryBuilder) getArgsFromDistFn(distFnExpr *plan.Function, partPo
 	}
 
 	return vecColArg, vecLitArg, true
+}
+
+func (builder *QueryBuilder) getArgsFromDistFnForJoin(
+	distFnExpr *plan.Function,
+	partPos int32,
+	scanTag int32,
+) (key *plan.Expr, value *plan.Expr, found bool) {
+	if _, ok := metric.DistFuncOpTypes[distFnExpr.Func.ObjName]; !ok {
+		return
+	}
+
+	distFnArgs := distFnExpr.Args
+	if distFnArgs[0].Typ.GetId() != int32(types.T_array_float32) &&
+		distFnArgs[0].Typ.GetId() != int32(types.T_array_float64) {
+		return
+	}
+
+	if col := distFnArgs[0].GetCol(); col != nil && col.RelPos == scanTag && col.ColPos == partPos {
+		distFnArgs[1].Typ = distFnArgs[0].Typ
+		return distFnArgs[0], distFnArgs[1], true
+	}
+	if col := distFnArgs[1].GetCol(); col != nil && col.RelPos == scanTag && col.ColPos == partPos {
+		distFnArgs[0].Typ = distFnArgs[1].Typ
+		return distFnArgs[1], distFnArgs[0], true
+	}
+	return
 }

--- a/pkg/sql/plan/apply_indices_ivfflat.go
+++ b/pkg/sql/plan/apply_indices_ivfflat.go
@@ -267,7 +267,17 @@ func (builder *QueryBuilder) prepareIvfIndexContext(vecCtx *vectorSortContext, m
 
 	keyPart := idxDef.Parts[0]
 	partPos := vecCtx.scanNode.TableDef.Name2ColIndex[keyPart]
-	_, vecLitArg, found := builder.getArgsFromDistFn(vecCtx.distFnExpr, partPos)
+	var vecLitArg *plan.Expr
+	var found bool
+	if vecCtx.vecArgExpr != nil {
+		_, vecLitArg, found = builder.getArgsFromDistFnForJoin(
+			vecCtx.distFnExpr,
+			partPos,
+			vecCtx.scanNode.BindingTags[0],
+		)
+	} else {
+		_, vecLitArg, found = builder.getArgsFromDistFn(vecCtx.distFnExpr, partPos)
+	}
 	if !found {
 		return nil, nil
 	}
@@ -357,6 +367,9 @@ func (builder *QueryBuilder) getDistRangeFromFilters(filters []*plan.Expr, ivfCt
 			goto NO_RANGE
 		}
 
+		if fdist.Args[1].GetLit() == nil || ivfCtx.vecLitArg.GetLit() == nil {
+			goto NO_RANGE
+		}
 		vecLit = fdist.Args[1].GetLit().GetVecVal()
 		if vecLit == "" || vecLit != ivfCtx.vecLitArg.GetLit().GetVecVal() {
 			goto NO_RANGE
@@ -474,6 +487,7 @@ func (builder *QueryBuilder) applyIndicesForSortUsingIvfflat(nodeID int32, vecCt
 			Cols: DeepCopyColDefList(kIVFSearchColDefs),
 		},
 		BindingTags: []int32{tableFuncTag},
+		Children:    vectorSearchProviderChildren(vecCtx),
 		TblFuncExprList: []*plan.Expr{
 			{
 				Typ: plan.Type{

--- a/pkg/sql/plan/apply_indices_vector.go
+++ b/pkg/sql/plan/apply_indices_vector.go
@@ -14,7 +14,10 @@
 
 package plan
 
-import "github.com/matrixorigin/matrixone/pkg/pb/plan"
+import (
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+)
 
 type vectorSortContext struct {
 	projNode      *plan.Node
@@ -26,6 +29,9 @@ type vectorSortContext struct {
 	sortDirection plan.OrderBySpec_OrderByFlag
 	limit         *plan.Expr
 	rankOption    *plan.RankOption
+
+	providerNodeID int32
+	vecArgExpr     *plan.Expr
 }
 
 func (builder *QueryBuilder) resolveScanNodeWithIndex(node *plan.Node, depth int32) *plan.Node {
@@ -90,6 +96,413 @@ func (builder *QueryBuilder) buildVectorSortContext(projNode *plan.Node) *vector
 		limit:         limit,
 		rankOption:    rankOption,
 	}
+}
+
+func (builder *QueryBuilder) buildVectorSortContextThroughJoin(projNode *plan.Node) *vectorSortContext {
+	sortNode := builder.resolveSortNode(projNode, 1)
+	if sortNode == nil || len(sortNode.OrderBy) != 1 {
+		return nil
+	}
+
+	joinNode, childNode := builder.resolveJoinNodeForVectorSort(sortNode)
+	if joinNode == nil || len(joinNode.Children) != 2 || !isVectorProviderJoin(joinNode) {
+		return nil
+	}
+
+	orderExpr := sortNode.OrderBy[0].Expr
+	distFnExpr := orderExpr.GetF()
+	if distFnExpr == nil && childNode != nil {
+		orderCol := orderExpr.GetCol()
+		if orderCol == nil || orderCol.ColPos < 0 || int(orderCol.ColPos) >= len(childNode.ProjectList) {
+			return nil
+		}
+		distFnExpr = childNode.ProjectList[orderCol.ColPos].GetF()
+	}
+	if distFnExpr == nil || len(distFnExpr.Args) != 2 {
+		return nil
+	}
+
+	leftNodeID, rightNodeID := joinNode.Children[0], joinNode.Children[1]
+	leftNode, rightNode := builder.qry.Nodes[leftNodeID], builder.qry.Nodes[rightNodeID]
+	leftTags := builder.collectBindingTags(leftNode)
+	rightTags := builder.collectBindingTags(rightNode)
+
+	scanNode, providerNodeID, providerTags, vecArgExpr := builder.pickJoinThroughVectorSides(
+		leftNodeID,
+		leftNode,
+		leftTags,
+		rightNodeID,
+		rightNode,
+		rightTags,
+		distFnExpr,
+	)
+	if scanNode == nil || vecArgExpr == nil {
+		return nil
+	}
+	if !builder.isJoinThroughProjectionSafe(projNode, childNode, orderExpr, providerTags) {
+		return nil
+	}
+
+	limit, rankOption := pickVectorLimit(sortNode, scanNode, projNode)
+	if limit == nil {
+		return nil
+	}
+
+	return &vectorSortContext{
+		projNode:       projNode,
+		sortNode:       sortNode,
+		scanNode:       scanNode,
+		childNode:      childNode,
+		orderExpr:      orderExpr,
+		distFnExpr:     distFnExpr,
+		sortDirection:  sortNode.OrderBy[0].Flag,
+		limit:          limit,
+		rankOption:     rankOption,
+		providerNodeID: providerNodeID,
+		vecArgExpr:     vecArgExpr,
+	}
+}
+
+func (builder *QueryBuilder) resolveJoinNodeForVectorSort(sortNode *plan.Node) (*plan.Node, *plan.Node) {
+	if sortNode == nil || len(sortNode.Children) != 1 {
+		return nil, nil
+	}
+
+	childNode := builder.qry.Nodes[sortNode.Children[0]]
+	if childNode.NodeType == plan.Node_JOIN {
+		return childNode, nil
+	}
+	if childNode.NodeType == plan.Node_PROJECT && len(childNode.Children) == 1 {
+		joinNode := builder.qry.Nodes[childNode.Children[0]]
+		if joinNode.NodeType == plan.Node_JOIN {
+			return joinNode, childNode
+		}
+	}
+	return nil, nil
+}
+
+func isVectorProviderJoin(joinNode *plan.Node) bool {
+	return joinNode.JoinType == plan.Node_INNER && isTrivialJoinOnList(joinNode.OnList)
+}
+
+func isTrivialJoinOnList(onList []*plan.Expr) bool {
+	for _, expr := range onList {
+		lit := expr.GetLit()
+		if lit == nil || !lit.GetBval() {
+			return false
+		}
+	}
+	return true
+}
+
+func (builder *QueryBuilder) pickJoinThroughVectorSides(
+	leftNodeID int32,
+	leftNode *plan.Node,
+	leftTags map[int32]bool,
+	rightNodeID int32,
+	rightNode *plan.Node,
+	rightTags map[int32]bool,
+	distFnExpr *plan.Function,
+) (*plan.Node, int32, map[int32]bool, *plan.Expr) {
+	if scanNode, vecArgExpr := builder.tryJoinThroughVectorSide(leftNode, leftTags, rightNode, rightTags, distFnExpr); scanNode != nil {
+		return scanNode, rightNodeID, rightTags, vecArgExpr
+	}
+	if scanNode, vecArgExpr := builder.tryJoinThroughVectorSide(rightNode, rightTags, leftNode, leftTags, distFnExpr); scanNode != nil {
+		return scanNode, leftNodeID, leftTags, vecArgExpr
+	}
+	return nil, -1, nil, nil
+}
+
+func (builder *QueryBuilder) tryJoinThroughVectorSide(
+	mainNode *plan.Node,
+	mainTags map[int32]bool,
+	providerNode *plan.Node,
+	providerTags map[int32]bool,
+	distFnExpr *plan.Function,
+) (*plan.Node, *plan.Expr) {
+	scanNode := builder.directScanWithVectorIndex(mainNode)
+	if scanNode == nil || len(scanNode.BindingTags) == 0 || !builder.isSingleRowVectorProvider(providerNode) {
+		return nil, nil
+	}
+
+	vecArgExpr := extractJoinThroughProviderVectorArg(distFnExpr, scanNode.BindingTags[0], mainTags, providerTags)
+	if vecArgExpr == nil {
+		return nil, nil
+	}
+	if !builder.isNonNullVectorProviderArg(providerNode, vecArgExpr) {
+		return nil, nil
+	}
+	return scanNode, vecArgExpr
+}
+
+func (builder *QueryBuilder) directScanWithVectorIndex(node *plan.Node) *plan.Node {
+	if node == nil || node.NodeType != plan.Node_TABLE_SCAN || node.TableDef == nil || len(node.BindingTags) == 0 {
+		return nil
+	}
+	for _, idx := range node.TableDef.Indexes {
+		if catalog.IsIvfIndexAlgo(idx.IndexAlgo) || catalog.IsHnswIndexAlgo(idx.IndexAlgo) {
+			return node
+		}
+	}
+	return nil
+}
+
+func extractJoinThroughProviderVectorArg(
+	distFnExpr *plan.Function,
+	scanTag int32,
+	mainTags map[int32]bool,
+	providerTags map[int32]bool,
+) *plan.Expr {
+	if distFnExpr == nil || len(distFnExpr.Args) != 2 {
+		return nil
+	}
+
+	arg0Col := distFnExpr.Args[0].GetCol()
+	arg1Col := distFnExpr.Args[1].GetCol()
+	if arg0Col == nil || arg1Col == nil {
+		return nil
+	}
+	if arg0Col.RelPos == scanTag && mainTags[arg0Col.RelPos] && providerTags[arg1Col.RelPos] {
+		return distFnExpr.Args[1]
+	}
+	if arg1Col.RelPos == scanTag && mainTags[arg1Col.RelPos] && providerTags[arg0Col.RelPos] {
+		return distFnExpr.Args[0]
+	}
+	return nil
+}
+
+func (builder *QueryBuilder) isJoinThroughProjectionSafe(
+	projNode *plan.Node,
+	childNode *plan.Node,
+	orderExpr *plan.Expr,
+	providerTags map[int32]bool,
+) bool {
+	if exprListRefsAnyTag(projNode.ProjectList, providerTags) {
+		return false
+	}
+	if childNode == nil {
+		return true
+	}
+
+	sortIdx := int32(-1)
+	if orderCol := orderExpr.GetCol(); orderCol != nil {
+		sortIdx = orderCol.ColPos
+	}
+	for i, expr := range childNode.ProjectList {
+		if int32(i) == sortIdx {
+			continue
+		}
+		if exprRefsAnyTag(expr, providerTags) {
+			return false
+		}
+	}
+	return true
+}
+
+func exprListRefsAnyTag(exprs []*plan.Expr, tags map[int32]bool) bool {
+	for _, expr := range exprs {
+		if exprRefsAnyTag(expr, tags) {
+			return true
+		}
+	}
+	return false
+}
+
+func exprRefsAnyTag(expr *plan.Expr, tags map[int32]bool) bool {
+	if expr == nil {
+		return false
+	}
+	switch impl := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		return tags[impl.Col.RelPos]
+	case *plan.Expr_F:
+		return exprListRefsAnyTag(impl.F.Args, tags)
+	case *plan.Expr_List:
+		return exprListRefsAnyTag(impl.List.List, tags)
+	case *plan.Expr_Sub:
+		return false
+	default:
+		return false
+	}
+}
+
+func (builder *QueryBuilder) collectBindingTags(node *plan.Node) map[int32]bool {
+	tags := make(map[int32]bool)
+	builder.collectBindingTagsRecursive(node, tags, make(map[int32]struct{}))
+	return tags
+}
+
+func (builder *QueryBuilder) collectBindingTagsRecursive(node *plan.Node, tags map[int32]bool, visited map[int32]struct{}) {
+	if node == nil {
+		return
+	}
+	if _, ok := visited[node.NodeId]; ok {
+		return
+	}
+	visited[node.NodeId] = struct{}{}
+	for _, tag := range node.BindingTags {
+		tags[tag] = true
+	}
+	for _, childID := range node.Children {
+		builder.collectBindingTagsRecursive(builder.qry.Nodes[childID], tags, visited)
+	}
+}
+
+func (builder *QueryBuilder) isSingleRowVectorProvider(node *plan.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.NodeType {
+	case plan.Node_TABLE_SCAN:
+		return tableScanHasSingleRowFilter(node)
+	case plan.Node_PROJECT, plan.Node_SORT:
+		if len(node.Children) != 1 {
+			return false
+		}
+		return builder.isSingleRowVectorProvider(builder.qry.Nodes[node.Children[0]])
+	default:
+		return false
+	}
+}
+
+func (builder *QueryBuilder) isNonNullVectorProviderArg(providerNode *plan.Node, vecArgExpr *plan.Expr) bool {
+	if vecArgExpr == nil {
+		return false
+	}
+	if vecArgExpr.Typ.NotNullable {
+		return true
+	}
+	col := vecArgExpr.GetCol()
+	if col == nil {
+		return false
+	}
+	return builder.providerColIsNonNull(providerNode, col.RelPos, col.ColPos)
+}
+
+func (builder *QueryBuilder) providerColIsNonNull(node *plan.Node, tag int32, colPos int32) bool {
+	if node == nil {
+		return false
+	}
+	if filterListHasIsNotNullOnCol(node.FilterList, tag, colPos) {
+		return true
+	}
+	switch node.NodeType {
+	case plan.Node_TABLE_SCAN:
+		if len(node.BindingTags) == 0 || node.BindingTags[0] != tag || node.TableDef == nil {
+			return false
+		}
+		return colPos >= 0 && int(colPos) < len(node.TableDef.Cols) && node.TableDef.Cols[colPos].Typ.NotNullable
+	case plan.Node_PROJECT:
+		if len(node.BindingTags) > 0 && node.BindingTags[0] == tag {
+			if colPos < 0 || int(colPos) >= len(node.ProjectList) {
+				return false
+			}
+			projectExpr := node.ProjectList[colPos]
+			if projectExpr.Typ.NotNullable {
+				return true
+			}
+			if projectCol := projectExpr.GetCol(); projectCol != nil && len(node.Children) == 1 {
+				return builder.providerColIsNonNull(
+					builder.qry.Nodes[node.Children[0]],
+					projectCol.RelPos,
+					projectCol.ColPos,
+				)
+			}
+			return false
+		}
+	case plan.Node_SORT:
+		if filterListHasIsNotNullOnCol(node.FilterList, tag, colPos) {
+			return true
+		}
+	}
+	for _, childID := range node.Children {
+		if builder.providerColIsNonNull(builder.qry.Nodes[childID], tag, colPos) {
+			return true
+		}
+	}
+	return false
+}
+
+func tableScanHasSingleRowFilter(node *plan.Node) bool {
+	if node == nil || node.TableDef == nil || len(node.BindingTags) == 0 {
+		return false
+	}
+	tag := node.BindingTags[0]
+	if node.TableDef.Pkey != nil {
+		pkCols := node.TableDef.Pkey.Names
+		if len(pkCols) == 0 && node.TableDef.Pkey.PkeyColName != "" {
+			pkCols = []string{node.TableDef.Pkey.PkeyColName}
+		}
+		if filterListHasConstEqualityOnCols(node.FilterList, node.TableDef, tag, pkCols) {
+			return true
+		}
+	}
+	for _, idx := range node.TableDef.Indexes {
+		if idx.Unique && filterListHasConstEqualityOnCols(node.FilterList, node.TableDef, tag, idx.Parts) {
+			return true
+		}
+	}
+	return false
+}
+
+func filterListHasConstEqualityOnCols(filters []*plan.Expr, tableDef *plan.TableDef, tag int32, colNames []string) bool {
+	if len(colNames) == 0 {
+		return false
+	}
+	for _, colName := range colNames {
+		colPos, ok := tableDef.Name2ColIndex[catalog.ResolveAlias(colName)]
+		if !ok {
+			return false
+		}
+		if !filterListHasConstEqualityOnCol(filters, tag, colPos) {
+			return false
+		}
+	}
+	return true
+}
+
+func filterListHasConstEqualityOnCol(filters []*plan.Expr, tag int32, colPos int32) bool {
+	for _, filter := range filters {
+		fn := filter.GetF()
+		if fn == nil || fn.Func.ObjName != "=" || len(fn.Args) != 2 {
+			continue
+		}
+		if exprIsCol(fn.Args[0], tag, colPos) && isRuntimeConstExpr(fn.Args[1]) {
+			return true
+		}
+		if exprIsCol(fn.Args[1], tag, colPos) && isRuntimeConstExpr(fn.Args[0]) {
+			return true
+		}
+	}
+	return false
+}
+
+func filterListHasIsNotNullOnCol(filters []*plan.Expr, tag int32, colPos int32) bool {
+	for _, filter := range filters {
+		fn := filter.GetF()
+		if fn == nil || len(fn.Args) != 1 {
+			continue
+		}
+		if fn.Func.ObjName != "isnotnull" && fn.Func.ObjName != "is_not_null" {
+			continue
+		}
+		if exprIsCol(fn.Args[0], tag, colPos) {
+			return true
+		}
+	}
+	return false
+}
+
+func exprIsCol(expr *plan.Expr, tag int32, colPos int32) bool {
+	col := expr.GetCol()
+	return col != nil && col.RelPos == tag && col.ColPos == colPos
+}
+
+func vectorSearchProviderChildren(vecCtx *vectorSortContext) []int32 {
+	if vecCtx == nil || vecCtx.vecArgExpr == nil || vecCtx.providerNodeID < 0 {
+		return nil
+	}
+	return []int32{vecCtx.providerNodeID}
 }
 
 func pickVectorLimit(sortNode, scanNode, projNode *plan.Node) (*plan.Expr, *plan.RankOption) {

--- a/pkg/sql/plan/apply_indices_vector_join_test.go
+++ b/pkg/sql/plan/apply_indices_vector_join_test.go
@@ -1,0 +1,801 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/vectorindex/metric"
+	"github.com/stretchr/testify/require"
+)
+
+func newVectorJoinMockCtx() *customMockCompilerContext {
+	baseMockCtx := NewMockCompilerContext(false)
+	return &customMockCompilerContext{
+		MockCompilerContext: baseMockCtx,
+		resolveVarFunc: func(varName string, isSystem, isGlobal bool) (interface{}, error) {
+			switch varName {
+			case "hnsw_threads_search", "ivf_threads_search":
+				return int64(4), nil
+			case "probe_limit":
+				return int64(10), nil
+			case "enable_vector_prefilter_by_default", "enable_vector_auto_mode_by_default":
+				return int8(0), nil
+			default:
+				return baseMockCtx.ResolveVariable(varName, isSystem, isGlobal)
+			}
+		},
+	}
+}
+
+func newVectorJoinTableDef(withVectorIndex bool, vectorNotNull bool) *plan.TableDef {
+	tableDef := &plan.TableDef{
+		Name: "t1",
+		Cols: []*plan.ColDef{
+			{Name: "id", Typ: plan.Type{Id: int32(types.T_varchar)}},
+			{Name: "v", Typ: plan.Type{Id: int32(types.T_array_float32), NotNullable: vectorNotNull}},
+		},
+		Pkey:          &plan.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+		Name2ColIndex: map[string]int32{"id": 0, "v": 1},
+	}
+	if withVectorIndex {
+		idxAlgoParams := `{"op_type": "` + metric.DistFuncOpTypes["l2_distance"] + `"}`
+		tableDef.Indexes = []*plan.IndexDef{
+			{
+				IndexName:          "idx_hnsw_v",
+				IndexAlgo:          catalog.MoIndexHnswAlgo.ToString(),
+				IndexAlgoTableType: catalog.Hnsw_TblType_Metadata,
+				IndexTableName:     "hnsw_meta",
+				Parts:              []string{"v"},
+				IndexAlgoParams:    idxAlgoParams,
+			},
+			{
+				IndexName:          "idx_hnsw_v",
+				IndexAlgo:          catalog.MoIndexHnswAlgo.ToString(),
+				IndexAlgoTableType: catalog.Hnsw_TblType_Storage,
+				IndexTableName:     "hnsw_storage",
+				Parts:              []string{"v"},
+				IndexAlgoParams:    idxAlgoParams,
+			},
+		}
+	}
+	return tableDef
+}
+
+func newVectorJoinHnswIndex() *MultiTableIndex {
+	idxAlgoParams := `{"op_type": "` + metric.DistFuncOpTypes["l2_distance"] + `"}`
+	return &MultiTableIndex{
+		IndexAlgo: catalog.MoIndexHnswAlgo.ToString(),
+		IndexDefs: map[string]*plan.IndexDef{
+			catalog.Hnsw_TblType_Metadata: {
+				IndexTableName:  "hnsw_meta",
+				IndexAlgoParams: idxAlgoParams,
+			},
+			catalog.Hnsw_TblType_Storage: {
+				IndexTableName:  "hnsw_storage",
+				Parts:           []string{"v"},
+				IndexAlgoParams: idxAlgoParams,
+			},
+		},
+	}
+}
+
+func newVectorJoinIvfIndex() *MultiTableIndex {
+	idxAlgoParams := `{"op_type": "` + metric.DistFuncOpTypes["l2_distance"] + `", "lists": 10}`
+	return &MultiTableIndex{
+		IndexAlgo: catalog.MoIndexIvfFlatAlgo.ToString(),
+		IndexDefs: map[string]*plan.IndexDef{
+			catalog.SystemSI_IVFFLAT_TblType_Metadata: {
+				IndexTableName:  "ivf_meta",
+				IndexAlgoParams: idxAlgoParams,
+			},
+			catalog.SystemSI_IVFFLAT_TblType_Centroids: {
+				IndexTableName:  "ivf_centroids",
+				Parts:           []string{"v"},
+				IndexAlgoParams: idxAlgoParams,
+			},
+			catalog.SystemSI_IVFFLAT_TblType_Entries: {
+				IndexTableName: "ivf_entries",
+			},
+		},
+	}
+}
+
+func newVectorJoinEqFilter(tag int32, colPos int32) *plan.Expr {
+	return &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_bool)},
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{ObjName: "="},
+			Args: []*plan.Expr{
+				{
+					Typ: plan.Type{Id: int32(types.T_varchar)},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: tag,
+						ColPos: colPos,
+						Name:   "id",
+					}},
+				},
+				{
+					Typ: plan.Type{Id: int32(types.T_varchar)},
+					Expr: &plan.Expr_Lit{Lit: &plan.Literal{
+						Value: &plan.Literal_Sval{Sval: "ref"},
+					}},
+				},
+			},
+		}},
+	}
+}
+
+func newVectorJoinIsNotNullFilter(tag int32, colPos int32) *plan.Expr {
+	return &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_bool), NotNullable: true},
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{ObjName: "isnotnull"},
+			Args: []*plan.Expr{
+				{
+					Typ: plan.Type{Id: int32(types.T_array_float32)},
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: tag,
+						ColPos: colPos,
+						Name:   "v",
+					}},
+				},
+			},
+		}},
+	}
+}
+
+func newVectorJoinColExpr(tag int32, colPos int32, name string, typ plan.Type) *plan.Expr {
+	return &plan.Expr{
+		Typ: typ,
+		Expr: &plan.Expr_Col{Col: &plan.ColRef{
+			RelPos: tag,
+			ColPos: colPos,
+			Name:   name,
+		}},
+	}
+}
+
+func newVectorJoinStringLitExpr() *plan.Expr {
+	return &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_varchar)},
+		Expr: &plan.Expr_Lit{Lit: &plan.Literal{
+			Value: &plan.Literal_Sval{Sval: "ref"},
+		}},
+	}
+}
+
+func newVectorJoinConstEqFilter(tag int32, colPos int32, name string, typ plan.Type) *plan.Expr {
+	return &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_bool)},
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{ObjName: "="},
+			Args: []*plan.Expr{
+				newVectorJoinColExpr(tag, colPos, name, typ),
+				newVectorJoinStringLitExpr(),
+			},
+		}},
+	}
+}
+
+func newVectorJoinReverseConstEqFilter(tag int32, colPos int32, name string, typ plan.Type) *plan.Expr {
+	return &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_bool)},
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{ObjName: "="},
+			Args: []*plan.Expr{
+				newVectorJoinStringLitExpr(),
+				newVectorJoinColExpr(tag, colPos, name, typ),
+			},
+		}},
+	}
+}
+
+type vectorJoinPlanCase struct {
+	builder        *QueryBuilder
+	ctx            *BindContext
+	projNode       *plan.Node
+	projNodeID     int32
+	mainScanNodeID int32
+	providerNodeID int32
+}
+
+type vectorJoinPlanOptions struct {
+	joinType                    plan.Node_JoinType
+	providerSingle              bool
+	providerVectorNotNull       bool
+	providerVectorNotNullFilter bool
+	providerLimitOne            bool
+	projectProvider             bool
+}
+
+func newVectorJoinPlanCase(t *testing.T, opts vectorJoinPlanOptions) vectorJoinPlanCase {
+	t.Helper()
+
+	builder := NewQueryBuilder(plan.Query_SELECT, newVectorJoinMockCtx(), false, true)
+	ctx := NewBindContext(builder, nil)
+	mainTableDef := newVectorJoinTableDef(true, false)
+	providerTableDef := newVectorJoinTableDef(true, opts.providerVectorNotNull)
+	mainVecTyp := mainTableDef.Cols[1].Typ
+	providerVecTyp := providerTableDef.Cols[1].Typ
+
+	mainScanNode := &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		TableDef:    mainTableDef,
+		ObjRef:      &plan.ObjectRef{SchemaName: "db"},
+		BindingTags: []int32{builder.genNewBindTag()},
+	}
+	mainScanNodeID := builder.appendNode(mainScanNode, ctx)
+
+	providerScanNode := &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		TableDef:    providerTableDef,
+		ObjRef:      &plan.ObjectRef{SchemaName: "db"},
+		BindingTags: []int32{builder.genNewBindTag()},
+	}
+	var providerFilters []*plan.Expr
+	if opts.providerSingle {
+		providerFilters = append(providerFilters, newVectorJoinEqFilter(providerScanNode.BindingTags[0], 0))
+	}
+	if opts.providerVectorNotNullFilter {
+		providerFilters = append(providerFilters, newVectorJoinIsNotNullFilter(providerScanNode.BindingTags[0], 1))
+	}
+	providerScanNode.FilterList = providerFilters
+	if opts.providerLimitOne {
+		providerScanNode.Limit = &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{
+			Value: &plan.Literal_U64Val{U64Val: 1},
+		}}}
+	}
+	providerScanNodeID := builder.appendNode(providerScanNode, ctx)
+
+	joinNode := &plan.Node{
+		NodeType: plan.Node_JOIN,
+		JoinType: opts.joinType,
+		Children: []int32{mainScanNodeID, providerScanNodeID},
+	}
+	joinNodeID := builder.appendNode(joinNode, ctx)
+
+	distFnExpr := &plan.Function{
+		Func: &plan.ObjectRef{ObjName: "l2_distance"},
+		Args: []*plan.Expr{
+			{
+				Typ: mainVecTyp,
+				Expr: &plan.Expr_Col{Col: &plan.ColRef{
+					RelPos: mainScanNode.BindingTags[0],
+					ColPos: 1,
+					Name:   "v",
+				}},
+			},
+			{
+				Typ: providerVecTyp,
+				Expr: &plan.Expr_Col{Col: &plan.ColRef{
+					RelPos: providerScanNode.BindingTags[0],
+					ColPos: 1,
+					Name:   "v",
+				}},
+			},
+		},
+	}
+
+	sortChildID := joinNodeID
+	sortExpr := &plan.Expr{Typ: plan.Type{Id: int32(types.T_float64)}, Expr: &plan.Expr_F{F: distFnExpr}}
+	if opts.projectProvider {
+		projectTag := builder.genNewBindTag()
+		projectNode := &plan.Node{
+			NodeType: plan.Node_PROJECT,
+			Children: []int32{joinNodeID},
+			ProjectList: []*plan.Expr{
+				{
+					Typ: mainTableDef.Cols[0].Typ,
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: mainScanNode.BindingTags[0],
+						ColPos: 0,
+						Name:   "id",
+					}},
+				},
+				{
+					Typ: providerTableDef.Cols[1].Typ,
+					Expr: &plan.Expr_Col{Col: &plan.ColRef{
+						RelPos: providerScanNode.BindingTags[0],
+						ColPos: 1,
+						Name:   "v",
+					}},
+				},
+				{Typ: plan.Type{Id: int32(types.T_float64)}, Expr: &plan.Expr_F{F: distFnExpr}},
+			},
+			BindingTags: []int32{projectTag},
+		}
+		sortChildID = builder.appendNode(projectNode, ctx)
+		sortExpr = &plan.Expr{
+			Typ:  plan.Type{Id: int32(types.T_float64)},
+			Expr: &plan.Expr_Col{Col: &plan.ColRef{RelPos: projectTag, ColPos: 2}},
+		}
+	}
+
+	sortNode := &plan.Node{
+		NodeType: plan.Node_SORT,
+		Children: []int32{sortChildID},
+		OrderBy: []*plan.OrderBySpec{{
+			Expr: sortExpr,
+			Flag: plan.OrderBySpec_ASC,
+		}},
+		Limit: &plan.Expr{Expr: &plan.Expr_Lit{Lit: &plan.Literal{
+			Value: &plan.Literal_U64Val{U64Val: 10},
+		}}},
+	}
+	sortNodeID := builder.appendNode(sortNode, ctx)
+
+	projNode := &plan.Node{
+		NodeType: plan.Node_PROJECT,
+		Children: []int32{sortNodeID},
+	}
+	projNodeID := builder.appendNode(projNode, ctx)
+
+	for i := 0; i < 40; i++ {
+		builder.ctxByNode = append(builder.ctxByNode, ctx)
+	}
+
+	return vectorJoinPlanCase{
+		builder:        builder,
+		ctx:            ctx,
+		projNode:       projNode,
+		projNodeID:     projNodeID,
+		mainScanNodeID: mainScanNodeID,
+		providerNodeID: providerScanNodeID,
+	}
+}
+
+func TestBuildVectorSortContextThroughJoin_RejectsSingleJoinProvider(t *testing.T) {
+	tc := newVectorJoinPlanCase(t, vectorJoinPlanOptions{
+		joinType:              plan.Node_SINGLE,
+		providerSingle:        true,
+		providerVectorNotNull: true,
+	})
+
+	vecCtx := tc.builder.buildVectorSortContextThroughJoin(tc.projNode)
+	require.Nil(t, vecCtx)
+}
+
+func TestBuildVectorSortContextThroughJoin_InnerJoinSingleRowProvider(t *testing.T) {
+	tc := newVectorJoinPlanCase(t, vectorJoinPlanOptions{
+		joinType:              plan.Node_INNER,
+		providerSingle:        true,
+		providerVectorNotNull: true,
+	})
+
+	vecCtx := tc.builder.buildVectorSortContextThroughJoin(tc.projNode)
+	require.NotNil(t, vecCtx)
+	require.Equal(t, tc.builder.qry.Nodes[tc.mainScanNodeID], vecCtx.scanNode)
+	require.Equal(t, tc.providerNodeID, vecCtx.providerNodeID)
+	require.NotNil(t, vecCtx.vecArgExpr)
+}
+
+func TestBuildVectorSortContextThroughJoin_InnerJoinProviderWithIsNotNullFilter(t *testing.T) {
+	tc := newVectorJoinPlanCase(t, vectorJoinPlanOptions{
+		joinType:                    plan.Node_INNER,
+		providerSingle:              true,
+		providerVectorNotNullFilter: true,
+	})
+
+	vecCtx := tc.builder.buildVectorSortContextThroughJoin(tc.projNode)
+	require.NotNil(t, vecCtx)
+	require.Equal(t, tc.providerNodeID, vecCtx.providerNodeID)
+}
+
+func TestBuildVectorSortContextThroughJoin_RejectsMultiRowProvider(t *testing.T) {
+	tc := newVectorJoinPlanCase(t, vectorJoinPlanOptions{
+		joinType:              plan.Node_INNER,
+		providerVectorNotNull: true,
+	})
+
+	vecCtx := tc.builder.buildVectorSortContextThroughJoin(tc.projNode)
+	require.Nil(t, vecCtx)
+}
+
+func TestBuildVectorSortContextThroughJoin_RejectsProviderProjection(t *testing.T) {
+	tc := newVectorJoinPlanCase(t, vectorJoinPlanOptions{
+		joinType:              plan.Node_INNER,
+		providerSingle:        true,
+		providerVectorNotNull: true,
+		projectProvider:       true,
+	})
+
+	vecCtx := tc.builder.buildVectorSortContextThroughJoin(tc.projNode)
+	require.Nil(t, vecCtx)
+}
+
+func TestBuildVectorSortContextThroughJoin_RejectsNullableProviderVector(t *testing.T) {
+	tc := newVectorJoinPlanCase(t, vectorJoinPlanOptions{
+		joinType:       plan.Node_INNER,
+		providerSingle: true,
+	})
+
+	vecCtx := tc.builder.buildVectorSortContextThroughJoin(tc.projNode)
+	require.Nil(t, vecCtx)
+}
+
+func TestBuildVectorSortContextThroughJoin_RejectsLimitOnlyProvider(t *testing.T) {
+	tc := newVectorJoinPlanCase(t, vectorJoinPlanOptions{
+		joinType:              plan.Node_INNER,
+		providerVectorNotNull: true,
+		providerLimitOne:      true,
+	})
+
+	vecCtx := tc.builder.buildVectorSortContextThroughJoin(tc.projNode)
+	require.Nil(t, vecCtx)
+}
+
+func TestApplyIndicesForSortUsingHnsw_JoinThroughKeepsProviderChild(t *testing.T) {
+	tc := newVectorJoinPlanCase(t, vectorJoinPlanOptions{
+		joinType:              plan.Node_INNER,
+		providerSingle:        true,
+		providerVectorNotNull: true,
+	})
+	vecCtx := tc.builder.buildVectorSortContextThroughJoin(tc.projNode)
+	require.NotNil(t, vecCtx)
+
+	newNodeID, err := tc.builder.applyIndicesForSortUsingHnsw(tc.projNodeID, vecCtx, newVectorJoinHnswIndex())
+	require.NoError(t, err)
+	require.Equal(t, tc.projNodeID, newNodeID)
+
+	funcScan := findFirstNodeByType(tc.builder, plan.Node_FUNCTION_SCAN)
+	require.NotNil(t, funcScan)
+	require.Equal(t, []int32{tc.providerNodeID}, funcScan.Children)
+	require.Equal(t, tc.providerNodeID, funcScan.Children[0])
+	require.Equal(t, int32(1), funcScan.TblFuncExprList[1].GetCol().ColPos)
+}
+
+func TestApplyIndicesForSortUsingIvfflat_JoinThroughKeepsProviderChild(t *testing.T) {
+	tc := newVectorJoinPlanCase(t, vectorJoinPlanOptions{
+		joinType:              plan.Node_INNER,
+		providerSingle:        true,
+		providerVectorNotNull: true,
+	})
+	vecCtx := tc.builder.buildVectorSortContextThroughJoin(tc.projNode)
+	require.NotNil(t, vecCtx)
+
+	newNodeID, err := tc.builder.applyIndicesForSortUsingIvfflat(tc.projNodeID, vecCtx, newVectorJoinIvfIndex(), nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, tc.projNodeID, newNodeID)
+
+	funcScan := findFirstNodeByType(tc.builder, plan.Node_FUNCTION_SCAN)
+	require.NotNil(t, funcScan)
+	require.Equal(t, []int32{tc.providerNodeID}, funcScan.Children)
+	require.Equal(t, int32(1), funcScan.TblFuncExprList[1].GetCol().ColPos)
+}
+
+func TestApplyIndicesForProject_JoinThroughReachesVectorRule(t *testing.T) {
+	tc := newVectorJoinPlanCase(t, vectorJoinPlanOptions{
+		joinType:              plan.Node_INNER,
+		providerSingle:        true,
+		providerVectorNotNull: true,
+	})
+
+	newNodeID, err := tc.builder.applyIndicesForProject(tc.projNodeID, tc.projNode, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, tc.projNodeID, newNodeID)
+
+	funcScan := findFirstNodeByType(tc.builder, plan.Node_FUNCTION_SCAN)
+	require.NotNil(t, funcScan)
+	require.Equal(t, []int32{tc.providerNodeID}, funcScan.Children)
+}
+
+func TestGetArgsFromDistFnForJoinBranches(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, newVectorJoinMockCtx(), false, true)
+	floatTyp := plan.Type{Id: int32(types.T_array_float32)}
+	intTyp := plan.Type{Id: int32(types.T_int64)}
+	scanTag := int32(7)
+	providerTag := int32(8)
+
+	scanArg := newVectorJoinColExpr(scanTag, 1, "v", floatTyp)
+	providerArg := newVectorJoinColExpr(providerTag, 1, "v", floatTyp)
+	distFn := &plan.Function{
+		Func: &plan.ObjectRef{ObjName: "l2_distance"},
+		Args: []*plan.Expr{providerArg, scanArg},
+	}
+
+	key, value, found := builder.getArgsFromDistFnForJoin(distFn, 1, scanTag)
+	require.True(t, found)
+	require.Equal(t, scanArg, key)
+	require.Equal(t, providerArg, value)
+	require.Equal(t, scanArg.Typ, providerArg.Typ)
+
+	_, _, found = builder.getArgsFromDistFnForJoin(&plan.Function{
+		Func: &plan.ObjectRef{ObjName: "not_a_distance"},
+		Args: []*plan.Expr{scanArg, providerArg},
+	}, 1, scanTag)
+	require.False(t, found)
+
+	_, _, found = builder.getArgsFromDistFnForJoin(&plan.Function{
+		Func: &plan.ObjectRef{ObjName: "l2_distance"},
+		Args: []*plan.Expr{
+			newVectorJoinColExpr(scanTag, 1, "id", intTyp),
+			providerArg,
+		},
+	}, 1, scanTag)
+	require.False(t, found)
+
+	_, _, found = builder.getArgsFromDistFnForJoin(&plan.Function{
+		Func: &plan.ObjectRef{ObjName: "l2_distance"},
+		Args: []*plan.Expr{providerArg, scanArg},
+	}, 2, scanTag)
+	require.False(t, found)
+}
+
+func TestExtractJoinThroughProviderVectorArgBranches(t *testing.T) {
+	floatTyp := plan.Type{Id: int32(types.T_array_float32)}
+	mainTag := int32(10)
+	providerTag := int32(11)
+	mainTags := map[int32]bool{mainTag: true}
+	providerTags := map[int32]bool{providerTag: true}
+	mainArg := newVectorJoinColExpr(mainTag, 1, "v", floatTyp)
+	providerArg := newVectorJoinColExpr(providerTag, 1, "v", floatTyp)
+
+	distFn := &plan.Function{
+		Func: &plan.ObjectRef{ObjName: "l2_distance"},
+		Args: []*plan.Expr{providerArg, mainArg},
+	}
+	require.Equal(t, providerArg, extractJoinThroughProviderVectorArg(distFn, mainTag, mainTags, providerTags))
+
+	require.Nil(t, extractJoinThroughProviderVectorArg(nil, mainTag, mainTags, providerTags))
+	require.Nil(t, extractJoinThroughProviderVectorArg(&plan.Function{
+		Func: &plan.ObjectRef{ObjName: "l2_distance"},
+		Args: []*plan.Expr{mainArg},
+	}, mainTag, mainTags, providerTags))
+	require.Nil(t, extractJoinThroughProviderVectorArg(&plan.Function{
+		Func: &plan.ObjectRef{ObjName: "l2_distance"},
+		Args: []*plan.Expr{newVectorJoinStringLitExpr(), mainArg},
+	}, mainTag, mainTags, providerTags))
+	require.Nil(t, extractJoinThroughProviderVectorArg(distFn, mainTag, mainTags, map[int32]bool{12: true}))
+}
+
+func TestVectorProviderNonNullProofBranches(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, newVectorJoinMockCtx(), false, true)
+	ctx := NewBindContext(builder, nil)
+	floatTyp := plan.Type{Id: int32(types.T_array_float32)}
+	notNullFloatTyp := plan.Type{Id: int32(types.T_array_float32), NotNullable: true}
+
+	scanTag := builder.genNewBindTag()
+	scanNode := &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		TableDef:    newVectorJoinTableDef(false, true),
+		BindingTags: []int32{scanTag},
+	}
+	scanNodeID := builder.appendNode(scanNode, ctx)
+
+	require.True(t, builder.providerColIsNonNull(scanNode, scanTag, 1))
+	require.False(t, builder.providerColIsNonNull(scanNode, scanTag+100, 1))
+	require.False(t, builder.providerColIsNonNull(scanNode, scanTag, 99))
+	require.False(t, builder.providerColIsNonNull(nil, scanTag, 1))
+	require.False(t, builder.providerColIsNonNull(&plan.Node{NodeType: plan.Node_TABLE_SCAN}, scanTag, 1))
+
+	require.True(t, builder.isNonNullVectorProviderArg(scanNode, newVectorJoinColExpr(scanTag, 1, "v", floatTyp)))
+	require.True(t, builder.isNonNullVectorProviderArg(scanNode, &plan.Expr{
+		Typ:  notNullFloatTyp,
+		Expr: &plan.Expr_Lit{Lit: &plan.Literal{}},
+	}))
+	require.False(t, builder.isNonNullVectorProviderArg(scanNode, nil))
+	require.False(t, builder.isNonNullVectorProviderArg(scanNode, newVectorJoinStringLitExpr()))
+
+	projectTag := builder.genNewBindTag()
+	projectNode := &plan.Node{
+		NodeType:    plan.Node_PROJECT,
+		Children:    []int32{scanNodeID},
+		BindingTags: []int32{projectTag},
+		ProjectList: []*plan.Expr{
+			newVectorJoinColExpr(scanTag, 1, "v", floatTyp),
+			{Typ: notNullFloatTyp, Expr: &plan.Expr_Lit{Lit: &plan.Literal{}}},
+			newVectorJoinStringLitExpr(),
+		},
+	}
+	projectNodeID := builder.appendNode(projectNode, ctx)
+	require.True(t, builder.providerColIsNonNull(projectNode, projectTag, 0))
+	require.True(t, builder.providerColIsNonNull(projectNode, projectTag, 1))
+	require.False(t, builder.providerColIsNonNull(projectNode, projectTag, 2))
+	require.False(t, builder.providerColIsNonNull(projectNode, projectTag, 9))
+
+	sortNode := &plan.Node{
+		NodeType: plan.Node_SORT,
+		Children: []int32{projectNodeID},
+		FilterList: []*plan.Expr{
+			newVectorJoinIsNotNullFilter(projectTag, 0),
+		},
+	}
+	require.True(t, builder.providerColIsNonNull(sortNode, projectTag, 0))
+
+	wrapperNode := &plan.Node{
+		NodeType: plan.Node_JOIN,
+		Children: []int32{scanNodeID},
+	}
+	require.True(t, builder.providerColIsNonNull(wrapperNode, scanTag, 1))
+	require.False(t, builder.providerColIsNonNull(&plan.Node{NodeType: plan.Node_JOIN}, scanTag, 1))
+}
+
+func TestSingleRowVectorProviderProofBranches(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, newVectorJoinMockCtx(), false, true)
+	ctx := NewBindContext(builder, nil)
+	varcharTyp := plan.Type{Id: int32(types.T_varchar)}
+	floatTyp := plan.Type{Id: int32(types.T_array_float32)}
+	tag := builder.genNewBindTag()
+
+	tableDef := newVectorJoinTableDef(false, false)
+	tableDef.Pkey = nil
+	tableDef.Indexes = []*plan.IndexDef{{Unique: true, Parts: []string{"id", "v"}}}
+	scanNode := &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		TableDef:    tableDef,
+		BindingTags: []int32{tag},
+		FilterList: []*plan.Expr{
+			newVectorJoinConstEqFilter(tag, 0, "id", varcharTyp),
+			newVectorJoinReverseConstEqFilter(tag, 1, "v", floatTyp),
+		},
+	}
+	scanNodeID := builder.appendNode(scanNode, ctx)
+	require.True(t, builder.isSingleRowVectorProvider(scanNode))
+
+	missingFilterScan := &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		TableDef:    tableDef,
+		BindingTags: []int32{tag},
+		FilterList: []*plan.Expr{
+			newVectorJoinConstEqFilter(tag, 0, "id", varcharTyp),
+		},
+	}
+	require.False(t, builder.isSingleRowVectorProvider(missingFilterScan))
+
+	missingColDef := newVectorJoinTableDef(false, false)
+	missingColDef.Pkey = nil
+	missingColDef.Indexes = []*plan.IndexDef{{Unique: true, Parts: []string{"missing_col"}}}
+	require.False(t, tableScanHasSingleRowFilter(&plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		TableDef:    missingColDef,
+		BindingTags: []int32{tag},
+	}))
+
+	projectNode := &plan.Node{
+		NodeType: plan.Node_PROJECT,
+		Children: []int32{scanNodeID},
+	}
+	require.True(t, builder.isSingleRowVectorProvider(projectNode))
+	require.False(t, builder.isSingleRowVectorProvider(&plan.Node{NodeType: plan.Node_PROJECT}))
+	require.True(t, builder.isSingleRowVectorProvider(&plan.Node{
+		NodeType: plan.Node_SORT,
+		Children: []int32{scanNodeID},
+	}))
+	require.False(t, builder.isSingleRowVectorProvider(nil))
+	require.False(t, builder.isSingleRowVectorProvider(&plan.Node{NodeType: plan.Node_JOIN}))
+}
+
+func TestVectorExprAndTagHelpersBranches(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, newVectorJoinMockCtx(), false, true)
+	ctx := NewBindContext(builder, nil)
+	varcharTyp := plan.Type{Id: int32(types.T_varchar)}
+	tags := map[int32]bool{1: true}
+	colExpr := newVectorJoinColExpr(1, 0, "id", varcharTyp)
+
+	require.False(t, exprRefsAnyTag(nil, tags))
+	require.True(t, exprRefsAnyTag(colExpr, tags))
+	require.False(t, exprRefsAnyTag(newVectorJoinColExpr(2, 0, "id", varcharTyp), tags))
+	require.True(t, exprRefsAnyTag(&plan.Expr{Expr: &plan.Expr_F{F: &plan.Function{
+		Func: &plan.ObjectRef{ObjName: "abs"},
+		Args: []*plan.Expr{colExpr},
+	}}}, tags))
+	require.True(t, exprRefsAnyTag(&plan.Expr{Expr: &plan.Expr_List{List: &plan.ExprList{
+		List: []*plan.Expr{colExpr},
+	}}}, tags))
+	require.False(t, exprRefsAnyTag(&plan.Expr{Expr: &plan.Expr_Sub{}}, tags))
+	require.False(t, exprRefsAnyTag(newVectorJoinStringLitExpr(), tags))
+	require.False(t, exprListRefsAnyTag(nil, tags))
+
+	childNode := &plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		BindingTags: []int32{3},
+	}
+	childNodeID := builder.appendNode(childNode, ctx)
+	parentNode := &plan.Node{
+		NodeType:    plan.Node_PROJECT,
+		BindingTags: []int32{4},
+		Children:    []int32{childNodeID, childNodeID},
+	}
+	builder.appendNode(parentNode, ctx)
+
+	collectedTags := builder.collectBindingTags(parentNode)
+	require.True(t, collectedTags[3])
+	require.True(t, collectedTags[4])
+	builder.collectBindingTagsRecursive(nil, collectedTags, make(map[int32]struct{}))
+	require.False(t, collectedTags[5])
+}
+
+func TestVectorJoinGuardHelperBranches(t *testing.T) {
+	floatTyp := plan.Type{Id: int32(types.T_array_float32)}
+	require.False(t, isVectorProviderJoin(&plan.Node{JoinType: plan.Node_SINGLE}))
+	require.False(t, isVectorProviderJoin(&plan.Node{
+		JoinType: plan.Node_INNER,
+		OnList: []*plan.Expr{
+			{Expr: &plan.Expr_Lit{Lit: &plan.Literal{Value: &plan.Literal_Bval{Bval: false}}}},
+		},
+	}))
+	require.False(t, isVectorProviderJoin(&plan.Node{
+		JoinType: plan.Node_INNER,
+		OnList: []*plan.Expr{
+			newVectorJoinColExpr(1, 0, "id", plan.Type{Id: int32(types.T_varchar)}),
+		},
+	}))
+
+	builder := NewQueryBuilder(plan.Query_SELECT, newVectorJoinMockCtx(), false, true)
+	require.Nil(t, builder.directScanWithVectorIndex(nil))
+	require.Nil(t, builder.directScanWithVectorIndex(&plan.Node{NodeType: plan.Node_TABLE_SCAN}))
+	require.Nil(t, builder.directScanWithVectorIndex(&plan.Node{
+		NodeType:    plan.Node_TABLE_SCAN,
+		TableDef:    newVectorJoinTableDef(false, false),
+		BindingTags: []int32{1},
+	}))
+
+	require.Nil(t, vectorSearchProviderChildren(nil))
+	require.Nil(t, vectorSearchProviderChildren(&vectorSortContext{providerNodeID: 1}))
+	require.Nil(t, vectorSearchProviderChildren(&vectorSortContext{
+		providerNodeID: -1,
+		vecArgExpr:     newVectorJoinColExpr(1, 1, "v", floatTyp),
+	}))
+}
+
+func TestGetDistRangeFromFiltersWithJoinVectorArg(t *testing.T) {
+	builder := NewQueryBuilder(plan.Query_SELECT, newVectorJoinMockCtx(), false, true)
+	floatTyp := plan.Type{Id: int32(types.T_array_float32)}
+	filter := &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_bool)},
+		Expr: &plan.Expr_F{F: &plan.Function{
+			Func: &plan.ObjectRef{ObjName: "<"},
+			Args: []*plan.Expr{
+				{
+					Typ: plan.Type{Id: int32(types.T_float64)},
+					Expr: &plan.Expr_F{F: &plan.Function{
+						Func: &plan.ObjectRef{ObjName: "l2_distance"},
+						Args: []*plan.Expr{
+							newVectorJoinColExpr(1, 1, "v", floatTyp),
+							newVectorJoinColExpr(2, 1, "v", floatTyp),
+						},
+					}},
+				},
+				{
+					Typ: plan.Type{Id: int32(types.T_float64)},
+					Expr: &plan.Expr_Lit{Lit: &plan.Literal{
+						Value: &plan.Literal_Dval{Dval: 10},
+					}},
+				},
+			},
+		}},
+	}
+
+	remainingFilters, distRange := builder.getDistRangeFromFilters([]*plan.Expr{filter}, &ivfIndexContext{
+		partPos:      1,
+		origFuncName: "l2_distance",
+		vecLitArg:    newVectorJoinColExpr(2, 1, "v", floatTyp),
+	})
+	require.Nil(t, distRange)
+	require.Equal(t, []*plan.Expr{filter}, remainingFilters)
+}
+
+func findFirstNodeByType(builder *QueryBuilder, nodeType plan.Node_NodeType) *plan.Node {
+	for _, node := range builder.qry.Nodes {
+		if node.NodeType == nodeType {
+			return node
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23158

## What this PR does / why we need it:

Cherry-pick of #24394 to 4.0-dev.

This PR enables a conservative vector index rewrite when the query vector is provided by a single-row derived table in a trivial INNER JOIN.