### PR TITLE
fix(dedupjoin): copy aliased build columns in matched==0 fast path

### DIFF
--- a/pkg/sql/colexec/dedupjoin/join.go
+++ b/pkg/sql/colexec/dedupjoin/join.go
@@ -311,6 +311,24 @@ func (ctr *container) finalize(ap *DedupJoin, proc *process.Process) error {
 
 	if ap.OnDuplicateAction != plan.Node_UPDATE || ctr.mp.HashOnUnique() {
 		if ctr.matched.Count() == 0 {
+			// constructDedupJoin copies node.ProjectList into ap.Result without
+			// dedup, and the REPLACE planner can alias multiple projections onto
+			// the same build column, so a non-capture build position may be
+			// referenced more than once. Ownership transfer (steal the build
+			// vector and nil it out) is only safe when a position is referenced
+			// exactly once; duplicates must copy, otherwise the second reference
+			// reads a nil vector. Count references first.
+			buildPosRefCount := make(map[int32]int, len(ap.Result))
+			for j, rp := range ap.Result {
+				if rp.Rel != 1 {
+					continue
+				}
+				if len(ctr.captureResultIdx) > 0 && ctr.captureResultIdx[j] >= 0 {
+					continue
+				}
+				buildPosRefCount[rp.Pos]++
+			}
+
 			ap.ctr.buf = make([]*batch.Batch, len(ctr.batches))
 			for i := range ap.ctr.buf {
 				ap.ctr.buf[i] = batch.NewOffHeapWithSize(len(ap.Result))
@@ -339,11 +357,22 @@ func (ctr *container) finalize(ap *DedupJoin, proc *process.Process) error {
 									return err
 								}
 							}
-						} else {
-							// Non-capture build column: transfer ownership from
-							// the build batch to avoid a full copy.
+						} else if buildPosRefCount[rp.Pos] == 1 {
+							// Non-capture build column referenced exactly once:
+							// transfer ownership from the build batch to avoid a
+							// full copy.
 							ap.ctr.buf[i].Vecs[j] = bat.Vecs[rp.Pos]
 							bat.Vecs[rp.Pos] = nil
+						} else {
+							// Non-capture build column referenced more than once
+							// (aliased projections). Copy so every reference gets
+							// its own valid vector; ownership transfer here would
+							// leave later references reading a nil vector.
+							typ := ap.RightTypes[rp.Pos]
+							ap.ctr.buf[i].Vecs[j] = vector.NewOffHeapVecWithType(typ)
+							if err := vector.GetUnionAllFunction(typ, proc.Mp())(ap.ctr.buf[i].Vecs[j], bat.Vecs[rp.Pos]); err != nil {
+								return err
+							}
 						}
 					} else {
 						ap.ctr.buf[i].Vecs[j] = vector.NewOffHeapVecWithType(ap.LeftTypes[rp.Pos])

--- a/pkg/sql/colexec/dedupjoin/join_finalize_optimize_test.go
+++ b/pkg/sql/colexec/dedupjoin/join_finalize_optimize_test.go
@@ -396,3 +396,76 @@ func TestUnionSelsByBatch(t *testing.T) {
 	proc.Free()
 	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
+
+// TestDedupJoinFinalizeMatchedZero_DuplicateBuildPos guards the matched==0
+// fast path against aliased projections. constructDedupJoin copies
+// node.ProjectList into ap.Result without dedup, and the REPLACE planner can
+// alias multiple projections onto the same build column, so a non-capture
+// build position may appear in ap.Result more than once. Ownership transfer
+// (steal the build vector, nil it out) is only valid for positions referenced
+// exactly once; a naive transfer leaves the second reference reading a nil
+// vector, corrupting the output / panicking downstream. Here build payload
+// pos 1 is projected twice and must yield identical, fully-populated columns.
+func TestDedupJoinFinalizeMatchedZero_DuplicateBuildPos(t *testing.T) {
+	proc, ctrl := newCaptureTestProc(t)
+	defer ctrl.Finish()
+
+	int32Typ := types.T_int32.ToType()
+	tag++
+	curTag := tag
+
+	// Build keys [10,20,30] with payload col [100,200,300].
+	buildBat := makeInt32Batch(proc.Mp(), [][]int32{{10, 20, 30}, {100, 200, 300}}, nil)
+	// Probe key [99] misses every build bucket → matched stays at 0.
+	probeBat := makeInt32Batch(proc.Mp(), [][]int32{{99}, {0}}, nil)
+
+	conditions := [][]*plan.Expr{
+		{newExpr(0, int32Typ)},
+		{newExpr(0, int32Typ)},
+	}
+
+	dedupArg := &DedupJoin{
+		LeftTypes:  []types.Type{int32Typ, int32Typ},
+		RightTypes: []types.Type{int32Typ, int32Typ},
+		Conditions: conditions,
+		Result: []colexec.ResultPos{
+			colexec.NewResultPos(1, 0), // build key
+			colexec.NewResultPos(1, 1), // build payload
+			colexec.NewResultPos(1, 1), // SAME build payload — aliased projection
+		},
+		OnDuplicateAction: plan.Node_FAIL, // no capture, no matched marking
+		JoinMapTag:        curTag,
+		OperatorBase:      vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+	buildArg := &hashbuild.HashBuild{
+		NeedHashMap:   true,
+		NeedBatches:   true,
+		Conditions:    conditions[1],
+		IsDedup:       true,
+		DelColIdx:     -1,
+		JoinMapTag:    curTag,
+		JoinMapRefCnt: 1,
+		OperatorBase:  vm.OperatorBase{OperatorInfo: vm.OperatorInfo{Idx: 0}},
+	}
+
+	out := runFinalizeFixture(t, dedupArg, buildArg, proc, buildBat, probeBat)
+	require.Len(t, out, 1)
+	require.Equal(t, 3, out[0].RowCount())
+	require.Equal(t, 3, len(out[0].Vecs))
+
+	col0 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[0])
+	col1 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[1])
+	col2 := vector.MustFixedColNoTypeCheck[int32](out[0].Vecs[2])
+	require.Equal(t, []int32{10, 20, 30}, col0)
+	// Both projections of build pos 1 must be fully populated and identical;
+	// before the fix col2 would be nil (the vector was stolen by col1).
+	require.Equal(t, []int32{100, 200, 300}, col1)
+	require.Equal(t, []int32{100, 200, 300}, col2)
+
+	dedupArg.Reset(proc, false, nil)
+	buildArg.Reset(proc, false, nil)
+	dedupArg.Free(proc, false, nil)
+	buildArg.Free(proc, false, nil)
+	proc.Free()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23946

## What this PR does / why we need it:

Fixes a correctness regression introduced by #24389 in the DedupJoin `matched.Count()==0` fast path (`pkg/sql/colexec/dedupjoin/join.go`).

That fast path transfers ownership of build-batch vectors to the output (steal the vector, then `bat.Vecs[rp.Pos] = nil`), which assumes each non-capture build `ResultPos` is unique. But `constructDedupJoin` copies `node.ProjectList` into `ap.Result` without dedup, and the REPLACE planner can alias multiple projections onto the same build column, so a non-capture build position may be referenced more than once. With duplicates, the first projection steals the vector and the second reads `nil`, corrupting the output batch / panicking downstream (`vector.(*Vector).Size`).

**Fix:** count references per non-capture build position before the loop and transfer ownership only when a position is referenced exactly once; otherwise copy via `GetUnionAllFunction` so every reference gets its own valid vector.

**Test:** adds `TestDedupJoinFinalizeMatchedZero_DuplicateBuildPos`, which projects the same build column twice in the `matched==0` path. It panics on the pre-fix code and passes with the fix.
