### PR TITLE
fix: free merge group spill aggregate states

### DIFF
--- a/pkg/sql/colexec/group/group_test.go
+++ b/pkg/sql/colexec/group/group_test.go
@@ -269,6 +269,33 @@ func TestMergeGroupPreservesLateNullableGroupKeys(t *testing.T) {
 	merge.Free(proc, false, nil)
 }
 
+func TestMergeGroupFreesSpillAggListAfterBatchMerge(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	defer proc.Free()
+
+	first := batch.NewWithSize(2)
+	first.Vecs[0] = testutil.MakeInt32Vector([]int32{1, 1}, nil, proc.Mp())
+	first.Vecs[1] = testutil.MakeInt32Vector([]int32{10, 10}, nil, proc.Mp())
+	first.SetRowCount(2)
+
+	second := batch.NewWithSize(2)
+	second.Vecs[0] = testutil.MakeInt32Vector([]int32{2, 2}, nil, proc.Mp())
+	second.Vecs[1] = testutil.MakeInt32Vector([]int32{20, 20}, nil, proc.Mp())
+	second.SetRowCount(2)
+
+	partialBatches := buildPartialGroupBatches(t, proc, []*batch.Batch{first, second}, false)
+
+	merge := newMergeGroupOp([]aggexec.AggFuncExecExpression{countStarAgg()})
+	require.NoError(t, merge.Prepare(proc))
+	defer merge.Free(proc, false, nil)
+
+	for _, partial := range partialBatches {
+		_, err := merge.buildOneBatch(proc, partial)
+		require.NoError(t, err)
+		require.Nil(t, merge.ctr.spillAggList)
+	}
+}
+
 func TestFreeAggListPartial(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	defer proc.Free()

--- a/pkg/sql/colexec/group/mergeGroup.go
+++ b/pkg/sql/colexec/group/mergeGroup.go
@@ -135,16 +135,12 @@ func (mergeGroup *MergeGroup) Call(proc *process.Process) (vm.CallResult, error)
 func (mergeGroup *MergeGroup) buildOneBatch(proc *process.Process, bat *batch.Batch) (bool, error) {
 	var err error
 
-	defer func() {
-		if err != nil {
-			mergeGroup.ctr.freeSpillAggList()
-		}
-	}()
-
+	mergeGroup.ctr.freeSpillAggList()
 	mergeGroup.ctr.spillAggList, err = mergeGroup.ctr.makeAggList(mergeGroup.Aggs)
 	if err != nil {
 		return false, err
 	}
+	defer mergeGroup.ctr.freeSpillAggList()
 
 	// deserialize extra buf2.
 	if len(bat.ExtraBuf) != 0 {
@@ -246,5 +242,6 @@ func (mergeGroup *MergeGroup) buildOneBatch(proc *process.Process, bat *batch.Ba
 		}
 	}
 
+	mergeGroup.ctr.freeSpillAggList()
 	return mergeGroup.ctr.needSpill(mergeGroup.OpAnalyzer), nil
 }

--- a/pkg/sql/colexec/group/mergeGroup.go
+++ b/pkg/sql/colexec/group/mergeGroup.go
@@ -140,7 +140,12 @@ func (mergeGroup *MergeGroup) buildOneBatch(proc *process.Process, bat *batch.Ba
 	if err != nil {
 		return false, err
 	}
-	defer mergeGroup.ctr.freeSpillAggList()
+	needCleanupSpillAggList := true
+	defer func() {
+		if needCleanupSpillAggList {
+			mergeGroup.ctr.freeSpillAggList()
+		}
+	}()
 
 	// deserialize extra buf2.
 	if len(bat.ExtraBuf) != 0 {
@@ -243,5 +248,6 @@ func (mergeGroup *MergeGroup) buildOneBatch(proc *process.Process, bat *batch.Ba
 	}
 
 	mergeGroup.ctr.freeSpillAggList()
+	needCleanupSpillAggList = false
 	return mergeGroup.ctr.needSpill(mergeGroup.OpAnalyzer), nil
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/issues/24570

## What this PR does / why we need it:
MergeGroup.buildOneBatch creates ctr.spillAggList for each incoming partial aggregate batch, then restores temporary aggregate state through aggExec.UnmarshalFromReader and merges it into ctr.aggList.

The previous code only released spillAggList on error. On the success path, the next input batch overwrote ctr.spillAggList, so previously restored aggregate state vectors were no longer reachable and their offheap mpool allocations remained live.

This PR:

releases any existing temporary spillAggList before creating a new one;
releases spillAggList after the partial aggregate state is merged and before needSpill() reads ctr.mp.CurrNB();
keeps deferred cleanup for error paths;
adds a regression test asserting that successful batch merge leaves ctr.spillAggList cleared.