### PR TITLE
fix: narrow pk check semaphore scope

### DIFF
--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -70,8 +70,9 @@ const (
 var traceFilterExprInterval atomic.Uint64
 var traceFilterExprInterval2 atomic.Uint64
 
-// pkCheckSemaphore limits concurrent PK conflict I/O in PKPersistedBetween to prevent
-// mpool explosion when many transactions simultaneously check primary key conflicts.
+// pkCheckSemaphore limits concurrent PK conflict block reads in PKPersistedBetween
+// to prevent mpool explosion when many transactions simultaneously check primary
+// key conflicts.
 var pkCheckSemaphore = make(chan struct{}, 16)
 var pkConflictReadPolicy fileservice.Policy = fileservice.SkipFullFilePreloads
 
@@ -2536,15 +2537,10 @@ func (tbl *txnTable) PKPersistedBetween(
 			var objMeta objectio.ObjectMeta
 			location := obj.Location()
 
-			semRelease, err := acquirePKCheckSemaphore(ctx)
-			if err != nil {
-				return err
-			}
 			// load object metadata
 			if objMeta, err2 = objectio.FastLoadObjectMeta(
 				ctx, &location, false, fs,
 			); err2 != nil {
-				semRelease()
 				return
 			}
 
@@ -2555,7 +2551,6 @@ func (tbl *txnTable) PKPersistedBetween(
 			// If object zone map doesn't contains the pk value, we need to check bloom filter
 			if !zmCkecked {
 				if !meta.MustGetColumn(uint16(primaryIdx)).ZoneMap().AnyIn(keys) {
-					semRelease()
 					return
 				}
 			}
@@ -2566,11 +2561,9 @@ func (tbl *txnTable) PKPersistedBetween(
 				if bf, err2 = objectio.LoadBFWithMeta(
 					ctx, meta, location, fs,
 				); err2 != nil {
-					semRelease()
 					return
 				}
 			}
-			semRelease()
 
 			objectio.ForeachBlkInObjStatsList(false, meta,
 				func(blk objectio.BlockInfo, blkMeta objectio.BlockObject) bool {
@@ -2651,11 +2644,11 @@ func (tbl *txnTable) PKPersistedBetween(
 	if len(candidateBlks) > 0 {
 		v2.TxnPKChangeCheckIOCounter.Inc()
 
+		semRelease, err := acquirePKCheckSemaphore(ctx)
+		if err != nil {
+			return false, err
+		}
 		for _, blk := range candidateBlks {
-			semRelease, err := acquirePKCheckSemaphore(ctx)
-			if err != nil {
-				return false, err
-			}
 			dataRelease, err := ioutil.LoadColumns(
 				ctx,
 				[]uint16{uint16(pkSeq)},
@@ -2678,11 +2671,12 @@ func (tbl *txnTable) PKPersistedBetween(
 
 			sels := searchFunc(cacheVectors)
 			dataRelease()
-			semRelease()
 			if len(sels) > 0 {
+				semRelease()
 				return true, nil
 			}
 		}
+		semRelease()
 	}
 	if checkTombstone {
 		pkDef := tbl.tableDef.Cols[tbl.primaryIdx]
@@ -2725,19 +2719,13 @@ func tombstonePKExistsInRange(
 				vecCount = 2
 			}
 			tombVectors := containers.NewVectors(vecCount)
-			semRelease, err := acquirePKCheckSemaphore(ctx)
-			if err != nil {
-				return false, err
-			}
 			_, dataRelease, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType, pkConflictReadPolicy)
 			if err != nil {
-				semRelease()
 				return true, nil
 			}
 			pkVec := tombVectors[1]
 			hits := searchKeys(&pkVec)
 			dataRelease()
-			semRelease()
 			if len(hits) > 0 {
 				return true, nil
 			}

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -208,7 +208,17 @@ func TestTombstonePKExistsInRangeSkipsFullFilePreloads(t *testing.T) {
 	require.NoError(t, vector.AppendFixed[int32](keys, 100, false, proc.GetMPool()))
 
 	recordingFS := &policyCaptureFS{FileService: baseFS}
-	changed, err := tombstonePKExistsInRange(ctx, pState, types.BuildTS(10, 0), keys, int32Type, recordingFS)
+	for i := 0; i < cap(pkCheckSemaphore); i++ {
+		pkCheckSemaphore <- struct{}{}
+	}
+	defer func() {
+		for i := 0; i < cap(pkCheckSemaphore); i++ {
+			<-pkCheckSemaphore
+		}
+	}()
+	readCtx, readCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer readCancel()
+	changed, err := tombstonePKExistsInRange(readCtx, pState, types.BuildTS(10, 0), keys, int32Type, recordingFS)
 	require.NoError(t, err)
 	require.True(t, changed)
 	require.GreaterOrEqual(t, len(recordingFS.policies), 2)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24592

## What this PR does / why we need it:

This narrows the `pkCheckSemaphore` scope in `PKPersistedBetween` back to the expensive candidate block PK-column reads only.

`18d8b4d20f83a59d27550ed999790dda48100752` expanded the global semaphore to object metadata loads, bloom filter loads, per-block acquisition, and tombstone reads. Under standalone TPC-C 1000/1000, that can serialize high-frequency write-path PK conflict checks behind the 16-slot guard and create enough latency/backlog for the benchmark client to abort, which then appears in the service log as frontend `write: broken pipe` errors.

The fix keeps `fileservice.SkipFullFilePreloads` for PK conflict reads, but avoids putting metadata/BF/tombstone checks behind the same global guard. It also adds a regression assertion that tombstone PK checks continue to work when `pkCheckSemaphore` is full.

Validation:

- `git diff --check`
- `go test ./pkg/vm/engine/disttae -run 'TestTombstonePKExistsInRangeSkipsFullFilePreloads|TestTombstonePKExistsInRangeEmptyFastPathSkipsSemaphore|TestPkCheckSemaphore' -count=1` could not run in this local checkout because native headers are missing: `usearch.h` and `xxhash.h`.
- `CGO_ENABLED=0 go test ./pkg/vm/engine/disttae -run 'TestTombstonePKExistsInRangeSkipsFullFilePreloads|TestTombstonePKExistsInRangeEmptyFastPathSkipsSemaphore|TestPkCheckSemaphore' -count=1` also cannot run because the usearch package has no non-cgo build files.
