### PR TITLE
fix: make pk check guard pressure based

### DIFF
--- a/pkg/cnservice/distributed_tae.go
+++ b/pkg/cnservice/distributed_tae.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/common/rscthrottler"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/config"
 	"github.com/matrixorigin/matrixone/pkg/defines"
@@ -68,6 +69,23 @@ func (s *service) initDistributedTAE(
 		return err
 	}
 	s.distributeTaeMp = distributeTaeMp
+	engineOptions := []disttae.EngineOptions{
+		disttae.WithCNTransferTxnLifespanThreshold(
+			s.cfg.Engine.CNTransferTxnLifespanThreshold,
+		),
+		disttae.WithPrefetchOnSubscribed(
+			s.cfg.Engine.PrefetchOnSubscribed,
+		),
+		disttae.WithMoTableStatsConf(s.cfg.Engine.Stats),
+		disttae.WithPKCheckGuardConfig(s.cfg.Engine.PKCheckGuard),
+		disttae.WithSQLExecFunc(internalExecutorFactory),
+		disttae.WithMoServerStateChecker(func() bool {
+			return frontend.MoServerIsStarted(s.cfg.UUID)
+		}),
+	}
+	if provider, ok := s.CNMemoryThrottler.(rscthrottler.MemoryPressureProvider); ok {
+		engineOptions = append(engineOptions, disttae.WithPKCheckPressureProvider(provider))
+	}
 	s.storeEngine = disttae.New(
 		ctx,
 		s.cfg.UUID,
@@ -77,18 +95,7 @@ func (s *service) initDistributedTAE(
 		hakeeper,
 		s.gossipNode.StatsKeyRouter(),
 		s.cfg.LogtailUpdateWorkerFactor,
-
-		disttae.WithCNTransferTxnLifespanThreshold(
-			s.cfg.Engine.CNTransferTxnLifespanThreshold,
-		),
-		disttae.WithPrefetchOnSubscribed(
-			s.cfg.Engine.PrefetchOnSubscribed,
-		),
-		disttae.WithMoTableStatsConf(s.cfg.Engine.Stats),
-		disttae.WithSQLExecFunc(internalExecutorFactory),
-		disttae.WithMoServerStateChecker(func() bool {
-			return frontend.MoServerIsStarted(s.cfg.UUID)
-		}),
+		engineOptions...,
 	)
 	pu.StorageEngine = s.storeEngine
 

--- a/pkg/cnservice/types.go
+++ b/pkg/cnservice/types.go
@@ -140,6 +140,8 @@ type Config struct {
 		MoTableStatsUseOldImpl         bool          `toml:"mo-table-stats-use-old-impl"`
 		CNTransferTxnLifespanThreshold time.Duration `toml:"cn-transfer-txn-lifespan-threshold"`
 
+		PKCheckGuard disttae.PKCheckGuardConfig `toml:"pk-check-guard"`
+
 		Stats disttae.MoTableStatsConfig `toml:"stats"`
 	}
 

--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -57,6 +57,18 @@ type RSCThrottler interface {
 	Available() int64
 }
 
+type MemoryPressureLevel int
+
+const (
+	MemoryPressureNormal MemoryPressureLevel = iota
+	MemoryPressureSoft
+	MemoryPressureHard
+)
+
+type MemoryPressureProvider interface {
+	MemoryPressure() MemoryPressureLevel
+}
+
 type memThrottler struct {
 	limit    atomic.Int64
 	rss      atomic.Int64
@@ -116,6 +128,21 @@ func (m *memThrottler) pinnedRate() float64 {
 	pinned := float64(m.reserved.Load())
 
 	return pinned / limit
+}
+
+func (m *memThrottler) MemoryPressure() MemoryPressureLevel {
+	actualMaxMemory := int64(m.actualTotalMemory.Load())
+	if actualMaxMemory <= 0 || actualMaxMemory == math.MaxInt64 {
+		return MemoryPressureNormal
+	}
+	rss := m.rss.Load()
+	if float64(rss) >= float64(actualMaxMemory)*rssCacheEvictHardRate {
+		return MemoryPressureHard
+	}
+	if float64(rss) >= float64(actualMaxMemory)*rssCacheEvictSoftRate {
+		return MemoryPressureSoft
+	}
+	return MemoryPressureNormal
 }
 
 func (m *memThrottler) Refresh() {

--- a/pkg/util/metric/v2/txn.go
+++ b/pkg/util/metric/v2/txn.go
@@ -99,10 +99,13 @@ var (
 			Name:      "pk_change_check_total",
 			Help:      "Total number of pk change check.",
 		}, []string{"type"})
-	TxnPKChangeCheckTotalCounter   = txnPKChangeCheckCounter.WithLabelValues("total")
-	TxnPKChangeCheckChangedCounter = txnPKChangeCheckCounter.WithLabelValues("changed")
-	TxnPKChangeCheckIOCounter      = txnPKChangeCheckCounter.WithLabelValues("io")
-	TxnPKChangeCheckBailoutCounter = txnPKChangeCheckCounter.WithLabelValues("bailout")
+	TxnPKChangeCheckTotalCounter                = txnPKChangeCheckCounter.WithLabelValues("total")
+	TxnPKChangeCheckChangedCounter              = txnPKChangeCheckCounter.WithLabelValues("changed")
+	TxnPKChangeCheckIOCounter                   = txnPKChangeCheckCounter.WithLabelValues("io")
+	TxnPKChangeCheckBailoutCounter              = txnPKChangeCheckCounter.WithLabelValues("bailout")
+	TxnPKChangeCheckGuardAcquireCounter         = txnPKChangeCheckCounter.WithLabelValues("guard_acquire")
+	TxnPKChangeCheckGuardSaturatedCounter       = txnPKChangeCheckCounter.WithLabelValues("guard_saturated")
+	TxnPKChangeCheckGuardPressureBailoutCounter = txnPKChangeCheckCounter.WithLabelValues("guard_pressure_bailout")
 
 	txnPKMayBeChangedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -194,6 +194,15 @@ func New(
 
 		v2.TxnExtraWorkspaceQuotaGauge.Set(float64(e.config.memThrottler.Available()))
 	}
+	if e.config.pkCheckPressureProvider == nil {
+		if provider, ok := e.config.memThrottler.(rscthrottler.MemoryPressureProvider); ok {
+			e.config.pkCheckPressureProvider = provider
+		}
+	}
+	e.config.pkCheckGuard = newPKCheckGuard(
+		e.config.pkCheckGuardConfig,
+		e.config.pkCheckPressureProvider,
+	)
 
 	e.cloneTxnCache = newCloneTxnCache()
 	e.ccprTxnCache = NewCCPRTxnCache(e.gcPool, e.fs)
@@ -205,6 +214,8 @@ func New(
 		zap.Uint64("WriteWorkspaceThreshold", e.config.writeWorkspaceThreshold),
 		zap.Int64("ExtraWorkspaceThresholdQuota", e.config.memThrottler.Available()),
 		zap.Duration("CNTransferTxnLifespanThreshold", e.config.cnTransferTxnLifespanThreshold),
+		zap.String("PKCheckGuardMode", e.config.pkCheckGuard.mode),
+		zap.Int("PKCheckGuardConcurrency", e.config.pkCheckGuard.capacity()),
 	)
 
 	return e

--- a/pkg/vm/engine/disttae/pk_check_guard.go
+++ b/pkg/vm/engine/disttae/pk_check_guard.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disttae
+
+import (
+	"runtime"
+	"strings"
+
+	"github.com/matrixorigin/matrixone/pkg/common/rscthrottler"
+)
+
+const (
+	PKCheckGuardModeOff      = "off"
+	PKCheckGuardModePressure = "pressure"
+
+	maxPKCheckGuardAutoConcurrency       = 64
+	minPKCheckGuardAutoConcurrency       = 16
+	maxPKCheckGuardConfiguredConcurrency = 512
+)
+
+type PKCheckGuardConfig struct {
+	Mode        string `toml:"mode"`
+	Concurrency int    `toml:"concurrency"`
+}
+
+type pkCheckGuard struct {
+	mode             string
+	sem              chan struct{}
+	pressureProvider rscthrottler.MemoryPressureProvider
+}
+
+func newPKCheckGuard(
+	cfg PKCheckGuardConfig,
+	pressureProvider rscthrottler.MemoryPressureProvider,
+) *pkCheckGuard {
+	cfg = normalizePKCheckGuardConfig(cfg)
+	return &pkCheckGuard{
+		mode:             cfg.Mode,
+		sem:              make(chan struct{}, cfg.Concurrency),
+		pressureProvider: pressureProvider,
+	}
+}
+
+func normalizePKCheckGuardConfig(cfg PKCheckGuardConfig) PKCheckGuardConfig {
+	cfg.Mode = strings.ToLower(strings.TrimSpace(cfg.Mode))
+	switch cfg.Mode {
+	case PKCheckGuardModeOff, PKCheckGuardModePressure:
+	default:
+		cfg.Mode = PKCheckGuardModePressure
+	}
+
+	if cfg.Concurrency <= 0 {
+		cfg.Concurrency = defaultPKCheckGuardConcurrency()
+	} else if cfg.Concurrency > maxPKCheckGuardConfiguredConcurrency {
+		cfg.Concurrency = maxPKCheckGuardConfiguredConcurrency
+	}
+
+	return cfg
+}
+
+func defaultPKCheckGuardConcurrency() int {
+	return min(max(runtime.GOMAXPROCS(0), minPKCheckGuardAutoConcurrency), maxPKCheckGuardAutoConcurrency)
+}
+
+func (g *pkCheckGuard) tryAcquire() (func(), bool) {
+	if g == nil || g.mode == PKCheckGuardModeOff {
+		return nil, true
+	}
+	if g.mode == PKCheckGuardModePressure && !g.underPressure() {
+		return nil, true
+	}
+	select {
+	case g.sem <- struct{}{}:
+		return func() { <-g.sem }, true
+	default:
+		return nil, false
+	}
+}
+
+func (g *pkCheckGuard) underPressure() bool {
+	if g.pressureProvider == nil {
+		return false
+	}
+	return g.pressureProvider.MemoryPressure() != rscthrottler.MemoryPressureNormal
+}
+
+func (g *pkCheckGuard) capacity() int {
+	if g == nil {
+		return 0
+	}
+	return cap(g.sem)
+}

--- a/pkg/vm/engine/disttae/pk_check_guard_test.go
+++ b/pkg/vm/engine/disttae/pk_check_guard_test.go
@@ -16,13 +16,20 @@ package disttae
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/rscthrottler"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type testPressureProvider struct {
+	level rscthrottler.MemoryPressureLevel
+}
+
+func (p *testPressureProvider) MemoryPressure() rscthrottler.MemoryPressureLevel {
+	return p.level
+}
 
 func TestShouldBailoutOnChangedObjects(t *testing.T) {
 	assert.False(t, shouldBailoutOnChangedObjects(0))
@@ -38,68 +45,79 @@ func TestShouldBailoutOnCandidateBlocks(t *testing.T) {
 	assert.True(t, shouldBailoutOnCandidateBlocks(1000))
 }
 
-func TestPkCheckSemaphore_LimitsConcurrency(t *testing.T) {
-	// Verify the semaphore actually limits concurrent goroutines.
-	const workers = 100
-	semCap := cap(pkCheckSemaphore) // should be 16
+func TestPKCheckGuardConfigHardening(t *testing.T) {
+	cfg := normalizePKCheckGuardConfig(PKCheckGuardConfig{
+		Mode:        "bad",
+		Concurrency: -1,
+	})
+	assert.Equal(t, PKCheckGuardModePressure, cfg.Mode)
+	assert.GreaterOrEqual(t, cfg.Concurrency, minPKCheckGuardAutoConcurrency)
+	assert.LessOrEqual(t, cfg.Concurrency, maxPKCheckGuardAutoConcurrency)
 
-	var maxConcurrent atomic.Int32
-	var current atomic.Int32
-	var wg sync.WaitGroup
-
-	ctx := context.Background()
-
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			select {
-			case pkCheckSemaphore <- struct{}{}:
-			case <-ctx.Done():
-				return
-			}
-			defer func() { <-pkCheckSemaphore }()
-
-			c := current.Add(1)
-			for {
-				old := maxConcurrent.Load()
-				if c <= old || maxConcurrent.CompareAndSwap(old, c) {
-					break
-				}
-			}
-			time.Sleep(time.Millisecond)
-			current.Add(-1)
-		}()
-	}
-
-	wg.Wait()
-
-	assert.LessOrEqual(t, int(maxConcurrent.Load()), semCap,
-		"concurrent goroutines should not exceed semaphore capacity %d", semCap)
-	assert.Greater(t, int(maxConcurrent.Load()), 1,
-		"should have some concurrency")
+	cfg = normalizePKCheckGuardConfig(PKCheckGuardConfig{
+		Mode:        " OFF ",
+		Concurrency: maxPKCheckGuardConfiguredConcurrency + 1,
+	})
+	assert.Equal(t, PKCheckGuardModeOff, cfg.Mode)
+	assert.Equal(t, maxPKCheckGuardConfiguredConcurrency, cfg.Concurrency)
 }
 
-func TestPkCheckSemaphore_RespectsContextCancellation(t *testing.T) {
-	// Fill the semaphore completely.
-	for i := 0; i < cap(pkCheckSemaphore); i++ {
-		pkCheckSemaphore <- struct{}{}
-	}
-	defer func() {
-		for i := 0; i < cap(pkCheckSemaphore); i++ {
-			<-pkCheckSemaphore
-		}
-	}()
+func TestPKCheckGuardPressureModeSkipsAcquireWithoutPressure(t *testing.T) {
+	provider := &testPressureProvider{level: rscthrottler.MemoryPressureNormal}
+	guard := newPKCheckGuard(PKCheckGuardConfig{
+		Mode:        PKCheckGuardModePressure,
+		Concurrency: 1,
+	}, provider)
+
+	guard.sem <- struct{}{}
+	release, ok, err := acquirePKCheckGuard(context.Background(), guard)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Nil(t, release)
+}
+
+func TestPKCheckGuardPressureModeSaturatedBailsOut(t *testing.T) {
+	provider := &testPressureProvider{level: rscthrottler.MemoryPressureSoft}
+	guard := newPKCheckGuard(PKCheckGuardConfig{
+		Mode:        PKCheckGuardModePressure,
+		Concurrency: 1,
+	}, provider)
+
+	guard.sem <- struct{}{}
+	release, ok, err := acquirePKCheckGuard(context.Background(), guard)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, release)
+}
+
+func TestPKCheckGuardPressureModeAcquiresUnderPressure(t *testing.T) {
+	provider := &testPressureProvider{level: rscthrottler.MemoryPressureHard}
+	guard := newPKCheckGuard(PKCheckGuardConfig{
+		Mode:        PKCheckGuardModePressure,
+		Concurrency: 1,
+	}, provider)
+
+	release, ok, err := acquirePKCheckGuard(context.Background(), guard)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, release)
+	assert.Len(t, guard.sem, 1)
+	release()
+	assert.Len(t, guard.sem, 0)
+}
+
+func TestPKCheckGuardRespectsContextCancellation(t *testing.T) {
+	provider := &testPressureProvider{level: rscthrottler.MemoryPressureSoft}
+	guard := newPKCheckGuard(PKCheckGuardConfig{
+		Mode:        PKCheckGuardModePressure,
+		Concurrency: 1,
+	}, provider)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	// Should not block — context is already cancelled.
-	select {
-	case pkCheckSemaphore <- struct{}{}:
-		t.Fatal("should not have acquired semaphore")
-		<-pkCheckSemaphore
-	case <-ctx.Done():
-		// expected
-	}
+	release, ok, err := acquirePKCheckGuard(ctx, guard)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, ok)
+	require.Nil(t, release)
 }

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -70,22 +70,10 @@ const (
 var traceFilterExprInterval atomic.Uint64
 var traceFilterExprInterval2 atomic.Uint64
 
-// pkCheckSemaphore limits concurrent PK conflict I/O in PKPersistedBetween to prevent
-// mpool explosion when many transactions simultaneously check primary key conflicts.
-var pkCheckSemaphore = make(chan struct{}, 16)
 var pkConflictReadPolicy fileservice.Policy = fileservice.SkipFullFilePreloads
 
 const maxChangedObjectsForIO = 64
 const maxCandidateBlksForIO = 32
-
-func acquirePKCheckSemaphore(ctx context.Context) (func(), error) {
-	select {
-	case pkCheckSemaphore <- struct{}{}:
-		return func() { <-pkCheckSemaphore }, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-}
 
 func shouldBailoutOnChangedObjects(cnt int) bool {
 	return cnt > maxChangedObjectsForIO
@@ -93,6 +81,22 @@ func shouldBailoutOnChangedObjects(cnt int) bool {
 
 func shouldBailoutOnCandidateBlocks(cnt int) bool {
 	return cnt > maxCandidateBlksForIO
+}
+
+func acquirePKCheckGuard(ctx context.Context, guard *pkCheckGuard) (func(), bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	release, ok := guard.tryAcquire()
+	if !ok {
+		v2.TxnPKChangeCheckGuardSaturatedCounter.Inc()
+		v2.TxnPKChangeCheckGuardPressureBailoutCounter.Inc()
+		return nil, false, nil
+	}
+	if release != nil {
+		v2.TxnPKChangeCheckGuardAcquireCounter.Inc()
+	}
+	return release, true, nil
 }
 
 var _ engine.Relation = new(txnTable)
@@ -2536,15 +2540,10 @@ func (tbl *txnTable) PKPersistedBetween(
 			var objMeta objectio.ObjectMeta
 			location := obj.Location()
 
-			semRelease, err := acquirePKCheckSemaphore(ctx)
-			if err != nil {
-				return err
-			}
 			// load object metadata
 			if objMeta, err2 = objectio.FastLoadObjectMeta(
 				ctx, &location, false, fs,
 			); err2 != nil {
-				semRelease()
 				return
 			}
 
@@ -2555,7 +2554,6 @@ func (tbl *txnTable) PKPersistedBetween(
 			// If object zone map doesn't contains the pk value, we need to check bloom filter
 			if !zmCkecked {
 				if !meta.MustGetColumn(uint16(primaryIdx)).ZoneMap().AnyIn(keys) {
-					semRelease()
 					return
 				}
 			}
@@ -2566,11 +2564,9 @@ func (tbl *txnTable) PKPersistedBetween(
 				if bf, err2 = objectio.LoadBFWithMeta(
 					ctx, meta, location, fs,
 				); err2 != nil {
-					semRelease()
 					return
 				}
 			}
-			semRelease()
 
 			objectio.ForeachBlkInObjStatsList(false, meta,
 				func(blk objectio.BlockInfo, blkMeta objectio.BlockObject) bool {
@@ -2651,10 +2647,14 @@ func (tbl *txnTable) PKPersistedBetween(
 	if len(candidateBlks) > 0 {
 		v2.TxnPKChangeCheckIOCounter.Inc()
 
+		guard := tbl.getTxn().engine.config.pkCheckGuard
 		for _, blk := range candidateBlks {
-			semRelease, err := acquirePKCheckSemaphore(ctx)
+			guardRelease, ok, err := acquirePKCheckGuard(ctx, guard)
 			if err != nil {
 				return false, err
+			}
+			if !ok {
+				return true, nil
 			}
 			dataRelease, err := ioutil.LoadColumns(
 				ctx,
@@ -2667,7 +2667,9 @@ func (tbl *txnTable) PKPersistedBetween(
 				pkConflictReadPolicy,
 			)
 			if err != nil {
-				semRelease()
+				if guardRelease != nil {
+					guardRelease()
+				}
 				return true, err
 			}
 
@@ -2678,7 +2680,9 @@ func (tbl *txnTable) PKPersistedBetween(
 
 			sels := searchFunc(cacheVectors)
 			dataRelease()
-			semRelease()
+			if guardRelease != nil {
+				guardRelease()
+			}
 			if len(sels) > 0 {
 				return true, nil
 			}
@@ -2687,7 +2691,7 @@ func (tbl *txnTable) PKPersistedBetween(
 	if checkTombstone {
 		pkDef := tbl.tableDef.Cols[tbl.primaryIdx]
 		pkType := plan2.ExprType2Type(&pkDef.Typ)
-		return tombstonePKExistsInRange(ctx, p, from, keys, pkType, fs)
+		return tombstonePKExistsInRange(ctx, p, from, keys, pkType, fs, tbl.getTxn().engine.config.pkCheckGuard)
 	}
 	return false, nil
 }
@@ -2702,6 +2706,7 @@ func tombstonePKExistsInRange(
 	keys *vector.Vector,
 	pkType types.Type,
 	fs fileservice.FileService,
+	guards ...*pkCheckGuard,
 ) (bool, error) {
 	tombObjs := p.GetChangedTombstoneObjsBetween(from)
 	if len(tombObjs) == 0 {
@@ -2716,6 +2721,10 @@ func tombstonePKExistsInRange(
 		}
 	}
 	searchKeys := LinearSearchOffsetByValFactory(keys)
+	var guard *pkCheckGuard
+	if len(guards) > 0 {
+		guard = guards[0]
+	}
 	for _, obj := range tombObjs {
 		for blkIdx := uint32(0); blkIdx < obj.BlkCnt(); blkIdx++ {
 			loc := obj.BlockLocation(uint16(blkIdx), objectio.BlockMaxRows)
@@ -2725,19 +2734,26 @@ func tombstonePKExistsInRange(
 				vecCount = 2
 			}
 			tombVectors := containers.NewVectors(vecCount)
-			semRelease, err := acquirePKCheckSemaphore(ctx)
+			guardRelease, ok, err := acquirePKCheckGuard(ctx, guard)
 			if err != nil {
 				return false, err
 			}
+			if !ok {
+				return true, nil
+			}
 			_, dataRelease, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType, pkConflictReadPolicy)
 			if err != nil {
-				semRelease()
+				if guardRelease != nil {
+					guardRelease()
+				}
 				return true, nil
 			}
 			pkVec := tombVectors[1]
 			hits := searchKeys(&pkVec)
 			dataRelease()
-			semRelease()
+			if guardRelease != nil {
+				guardRelease()
+			}
 			if len(hits) > 0 {
 				return true, nil
 			}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -70,22 +70,10 @@ const (
 var traceFilterExprInterval atomic.Uint64
 var traceFilterExprInterval2 atomic.Uint64
 
-// pkCheckSemaphore limits concurrent PK conflict I/O in PKPersistedBetween to prevent
-// mpool explosion when many transactions simultaneously check primary key conflicts.
-var pkCheckSemaphore = make(chan struct{}, 16)
 var pkConflictReadPolicy fileservice.Policy = fileservice.SkipFullFilePreloads
 
 const maxChangedObjectsForIO = 64
 const maxCandidateBlksForIO = 32
-
-func acquirePKCheckSemaphore(ctx context.Context) (func(), error) {
-	select {
-	case pkCheckSemaphore <- struct{}{}:
-		return func() { <-pkCheckSemaphore }, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-}
 
 func shouldBailoutOnChangedObjects(cnt int) bool {
 	return cnt > maxChangedObjectsForIO
@@ -93,6 +81,22 @@ func shouldBailoutOnChangedObjects(cnt int) bool {
 
 func shouldBailoutOnCandidateBlocks(cnt int) bool {
 	return cnt > maxCandidateBlksForIO
+}
+
+func acquirePKCheckGuard(ctx context.Context, guard *pkCheckGuard) (func(), bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	release, ok := guard.tryAcquire()
+	if !ok {
+		v2.TxnPKChangeCheckGuardSaturatedCounter.Inc()
+		v2.TxnPKChangeCheckGuardPressureBailoutCounter.Inc()
+		return nil, false, nil
+	}
+	if release != nil {
+		v2.TxnPKChangeCheckGuardAcquireCounter.Inc()
+	}
+	return release, true, nil
 }
 
 var _ engine.Relation = new(txnTable)
@@ -2536,15 +2540,10 @@ func (tbl *txnTable) PKPersistedBetween(
 			var objMeta objectio.ObjectMeta
 			location := obj.Location()
 
-			semRelease, err := acquirePKCheckSemaphore(ctx)
-			if err != nil {
-				return err
-			}
 			// load object metadata
 			if objMeta, err2 = objectio.FastLoadObjectMeta(
 				ctx, &location, false, fs,
 			); err2 != nil {
-				semRelease()
 				return
 			}
 
@@ -2555,7 +2554,6 @@ func (tbl *txnTable) PKPersistedBetween(
 			// If object zone map doesn't contains the pk value, we need to check bloom filter
 			if !zmCkecked {
 				if !meta.MustGetColumn(uint16(primaryIdx)).ZoneMap().AnyIn(keys) {
-					semRelease()
 					return
 				}
 			}
@@ -2566,11 +2564,9 @@ func (tbl *txnTable) PKPersistedBetween(
 				if bf, err2 = objectio.LoadBFWithMeta(
 					ctx, meta, location, fs,
 				); err2 != nil {
-					semRelease()
 					return
 				}
 			}
-			semRelease()
 
 			objectio.ForeachBlkInObjStatsList(false, meta,
 				func(blk objectio.BlockInfo, blkMeta objectio.BlockObject) bool {
@@ -2651,10 +2647,14 @@ func (tbl *txnTable) PKPersistedBetween(
 	if len(candidateBlks) > 0 {
 		v2.TxnPKChangeCheckIOCounter.Inc()
 
+		guard := tbl.getTxn().engine.config.pkCheckGuard
 		for _, blk := range candidateBlks {
-			semRelease, err := acquirePKCheckSemaphore(ctx)
+			guardRelease, ok, err := acquirePKCheckGuard(ctx, guard)
 			if err != nil {
 				return false, err
+			}
+			if !ok {
+				return true, nil
 			}
 			dataRelease, err := ioutil.LoadColumns(
 				ctx,
@@ -2667,7 +2667,9 @@ func (tbl *txnTable) PKPersistedBetween(
 				pkConflictReadPolicy,
 			)
 			if err != nil {
-				semRelease()
+				if guardRelease != nil {
+					guardRelease()
+				}
 				return true, err
 			}
 
@@ -2678,7 +2680,9 @@ func (tbl *txnTable) PKPersistedBetween(
 
 			sels := searchFunc(cacheVectors)
 			dataRelease()
-			semRelease()
+			if guardRelease != nil {
+				guardRelease()
+			}
 			if len(sels) > 0 {
 				return true, nil
 			}
@@ -2687,7 +2691,7 @@ func (tbl *txnTable) PKPersistedBetween(
 	if checkTombstone {
 		pkDef := tbl.tableDef.Cols[tbl.primaryIdx]
 		pkType := plan2.ExprType2Type(&pkDef.Typ)
-		return tombstonePKExistsInRange(ctx, p, from, keys, pkType, fs)
+		return tombstonePKExistsInRange(ctx, p, from, keys, pkType, fs, tbl.getTxn().engine.config.pkCheckGuard)
 	}
 	return false, nil
 }
@@ -2702,6 +2706,7 @@ func tombstonePKExistsInRange(
 	keys *vector.Vector,
 	pkType types.Type,
 	fs fileservice.FileService,
+	guards ...*pkCheckGuard,
 ) (bool, error) {
 	tombObjs := p.GetChangedTombstoneObjsBetween(from)
 	if len(tombObjs) == 0 {
@@ -2716,6 +2721,10 @@ func tombstonePKExistsInRange(
 		}
 	}
 	searchKeys := LinearSearchOffsetByValFactory(keys)
+	var guard *pkCheckGuard
+	if len(guards) > 0 {
+		guard = guards[0]
+	}
 	for _, obj := range tombObjs {
 		for blkIdx := uint32(0); blkIdx < obj.BlkCnt(); blkIdx++ {
 			loc := obj.BlockLocation(uint16(blkIdx), objectio.BlockMaxRows)
@@ -2725,19 +2734,29 @@ func tombstonePKExistsInRange(
 				vecCount = 2
 			}
 			tombVectors := containers.NewVectors(vecCount)
-			semRelease, err := acquirePKCheckSemaphore(ctx)
+			guardRelease, ok, err := acquirePKCheckGuard(ctx, guard)
 			if err != nil {
 				return false, err
 			}
+			if !ok {
+				return true, nil
+			}
 			_, dataRelease, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType, pkConflictReadPolicy)
 			if err != nil {
-				semRelease()
+				if guardRelease != nil {
+					guardRelease()
+				}
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return false, ctxErr
+				}
 				return true, nil
 			}
 			pkVec := tombVectors[1]
 			hits := searchKeys(&pkVec)
 			dataRelease()
-			semRelease()
+			if guardRelease != nil {
+				guardRelease()
+			}
 			if len(hits) > 0 {
 				return true, nil
 			}

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -253,6 +253,18 @@ func WithMoServerStateChecker(checker func() bool) EngineOptions {
 	}
 }
 
+func WithPKCheckGuardConfig(cfg PKCheckGuardConfig) EngineOptions {
+	return func(e *Engine) {
+		e.config.pkCheckGuardConfig = cfg
+	}
+}
+
+func WithPKCheckPressureProvider(provider rscthrottler.MemoryPressureProvider) EngineOptions {
+	return func(e *Engine) {
+		e.config.pkCheckPressureProvider = provider
+	}
+}
+
 type Engine struct {
 	sync.RWMutex
 	service  string
@@ -281,6 +293,10 @@ type Engine struct {
 		ieFactory            func() ie.InternalExecutor
 		statsConf            MoTableStatsConfig
 		moServerStateChecker func() bool
+
+		pkCheckGuardConfig      PKCheckGuardConfig
+		pkCheckPressureProvider rscthrottler.MemoryPressureProvider
+		pkCheckGuard            *pkCheckGuard
 	}
 
 	//latest catalog will be loaded from TN when engine is initialized.

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/lni/goutils/leaktest"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/common/rscthrottler"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -215,22 +216,19 @@ func TestTombstonePKExistsInRangeSkipsFullFilePreloads(t *testing.T) {
 	require.Equal(t, fileservice.Policy(fileservice.SkipFullFilePreloads), recordingFS.policies[1])
 }
 
-func TestTombstonePKExistsInRangeEmptyFastPathSkipsSemaphore(t *testing.T) {
-	for i := 0; i < cap(pkCheckSemaphore); i++ {
-		pkCheckSemaphore <- struct{}{}
-	}
-	defer func() {
-		for i := 0; i < cap(pkCheckSemaphore); i++ {
-			<-pkCheckSemaphore
-		}
-	}()
-
+func TestTombstonePKExistsInRangeEmptyFastPathSkipsGuard(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	pState := logtailreplay.NewPartitionState("", true, 0, false)
 	keys := vector.NewVec(types.T_int32.ToType())
-	changed, err := tombstonePKExistsInRange(ctx, pState, types.BuildTS(10, 0), keys, types.T_int32.ToType(), nil)
+	guard := newPKCheckGuard(PKCheckGuardConfig{
+		Mode:        PKCheckGuardModePressure,
+		Concurrency: 1,
+	}, &testPressureProvider{level: rscthrottler.MemoryPressureSoft})
+	guard.sem <- struct{}{}
+
+	changed, err := tombstonePKExistsInRange(ctx, pState, types.BuildTS(10, 0), keys, types.T_int32.ToType(), nil, guard)
 	require.NoError(t, err)
 	require.False(t, changed)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fix https://github.com/matrixorigin/matrixone/issues/24534

## What this PR does / why we need it:

PR #24535 added a global blocking semaphore in the `PKPersistedBetween` primary-key conflict check path to reduce RSS pressure under TPCC. That protected memory, but it also made the semaphore active during normal operation. In high-concurrency TPCC `SELECT ... FOR UPDATE` / RC retry paths, the fixed 16-slot blocking semaphore can create server-side queuing and client 60s timeouts.

This PR changes the PK check protection from an always-on blocking semaphore to a pressure-triggered, non-blocking guard:

- Adds `cn.Engine.pk-check-guard` with `mode = off|pressure`, defaulting to `pressure`.
- Adds configurable `concurrency`; `0` uses conservative auto concurrency: `min(max(GOMAXPROCS, 16), 64)`.
- Reuses the existing CN memory throttler RSS pressure state through a read-only `MemoryPressure()` interface.
- Does not acquire the guard when there is no RSS/memory pressure.
- Under pressure, uses try-acquire only. If saturated, it conservatively returns `may changed = true` instead of waiting.
- Limits guard scope to a single `LoadColumns` / `ReadDeletes` call. Metadata and bloom-filter reads are no longer guarded.
- Adds PK check guard metrics: `guard_acquire`, `guard_saturated`, and `guard_pressure_bailout`.

This preserves the RSS protection goal of #24535 while avoiding normal-path latency regression for customer workloads.

## Test

```sh
GOCACHE=/Users/shenjiangwei/Work/code/view/matrixone/.gocache \
CGO_CFLAGS='-I/Users/shenjiangwei/Work/code/view/matrixone/cgo -I/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/install/include -I/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/usearch-2.17.1/c' \
CGO_LDFLAGS='-L/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/install/lib' \
go test ./pkg/vm/engine/disttae -run 'TestPKCheckGuard|TestTombstonePKExistsInRange' -count=1
```

```sh
GOCACHE=/Users/shenjiangwei/Work/code/view/matrixone/.gocache \
CGO_CFLAGS='-I/Users/shenjiangwei/Work/code/view/matrixone/cgo -I/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/install/include -I/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/usearch-2.17.1/c' \
CGO_LDFLAGS='-L/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/install/lib' \
go test ./pkg/cnservice -run 'TestParse|TestMakeRSSCacheEvictorUsesIndependentTimeouts' -count=1
```

```sh
GOCACHE=/Users/shenjiangwei/Work/code/view/matrixone/.gocache \
CGO_CFLAGS='-I/Users/shenjiangwei/Work/code/view/matrixone/cgo -I/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/install/include -I/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/usearch-2.17.1/c' \
CGO_LDFLAGS='-L/Users/shenjiangwei/Work/code/view/matrixone/thirdparties/install/lib' \
go test ./pkg/common/rscthrottler -count=1
```
