### PR TITLE
fix: limit pk check throttling to load columns

### DIFF
--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -244,12 +244,15 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 		zap.String("detail", m.String()),
 	)
 	if shouldEvictCache {
-		evictCtx, cancel := context.WithTimeout(context.Background(), rssCacheEvictTimeout)
-		m.options.rssCacheEvictor(evictCtx, cacheTargetPercent)
-		cancel()
+		go func(targetPercent int64) {
+			evictCtx, cancel := context.WithTimeout(context.Background(), rssCacheEvictTimeout)
+			defer cancel()
+			m.options.rssCacheEvictor(evictCtx, targetPercent)
+			freeOSMemory()
+		}(cacheTargetPercent)
 		m.lastRSSScavenge.Store(now)
 	}
-	if shouldFreeOSMemory || shouldEvictCache {
+	if shouldFreeOSMemory {
 		freeOSMemory()
 	}
 }

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -223,12 +223,20 @@ func TestMemThrottlerRSSCacheEvictionByRSSRate(t *testing.T) {
 	require.Equal(t, int64(0), target.Load())
 
 	throttler.tryScavengeRSS(now+int64(time.Second), 850*mpool.GB)
-	require.Equal(t, int32(1), freeCalls.Load())
-	require.Equal(t, rssCacheSoftTarget, target.Load())
+	require.Eventually(t, func() bool {
+		return target.Load() == rssCacheSoftTarget
+	}, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool {
+		return freeCalls.Load() == 1
+	}, time.Second, time.Millisecond)
 
 	throttler.tryScavengeRSS(now+2*int64(time.Second), 920*mpool.GB)
-	require.Equal(t, int32(2), freeCalls.Load())
-	require.Equal(t, rssCacheHardTarget, target.Load())
+	require.Eventually(t, func() bool {
+		return target.Load() == rssCacheHardTarget
+	}, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool {
+		return freeCalls.Load() == 2
+	}, time.Second, time.Millisecond)
 
 	throttler.tryScavengeRSS(now+3*int64(time.Second), 920*mpool.GB)
 	require.Equal(t, int32(2), freeCalls.Load())
@@ -280,8 +288,12 @@ func TestMemThrottlerRSSCacheEvictionConcurrentEscalation(t *testing.T) {
 	close(start)
 	wg.Wait()
 
-	require.GreaterOrEqual(t, freeCalls.Load(), int32(1))
-	require.Equal(t, int64(rssCacheHardTarget), minTarget.Load())
+	require.Eventually(t, func() bool {
+		return minTarget.Load() == int64(rssCacheHardTarget)
+	}, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool {
+		return freeCalls.Load() >= 1
+	}, time.Second, time.Millisecond)
 	require.Equal(t, int64(rssCacheHardTarget), throttler.lastRSSCacheTarget.Load())
 }
 

--- a/pkg/fileservice/fifocache/fifo.go
+++ b/pkg/fileservice/fifocache/fifo.go
@@ -629,7 +629,10 @@ func (c *Cache[K, V]) evictBatch(capacityCut *int64) (pending []_PendingPostEvic
 
 	for {
 		c.helpEnqueue()
-		*capacityCut += c.capacityCut.Swap(0)
+		// EvictWithWait is used on foreground read paths to reserve space for
+		// the current I/O. Do not drain the global async eviction debt here, or
+		// one unlucky reader can inherit all skipped TryLock evictions and block
+		// IO merger waiters for seconds.
 		target := c.capacity() - *capacityCut
 		if target < 0 {
 			target = 0

--- a/pkg/objectio/ioutil/funcs.go
+++ b/pkg/objectio/ioutil/funcs.go
@@ -333,7 +333,7 @@ func IsRowDeletedByLocation(
 
 	attrs := objectio.GetTombstoneAttrs(hidden)
 	data := containers.NewVectors(len(attrs))
-	_, release, err := ReadDeletes(ctx, location, fs, createdByCN, data, nil, fileservice.GetFileServicePolicy(ctx))
+	_, release, err := ReadDeletes(ctx, location, fs, createdByCN, data, nil, fileservice.Policy(0))
 	if err != nil {
 		return
 	}
@@ -388,7 +388,7 @@ func FillBlockDeleteMask(
 	persistedDeletes := containers.NewVectors(len(attrs))
 
 	if meta, release, err = ReadDeletes(
-		ctx, location, fs, createdByCN, persistedDeletes, nil, fileservice.GetFileServicePolicy(ctx),
+		ctx, location, fs, createdByCN, persistedDeletes, nil, fileservice.Policy(0),
 	); err != nil {
 		return
 	}

--- a/pkg/vm/engine/disttae/local_disttae_datasource.go
+++ b/pkg/vm/engine/disttae/local_disttae_datasource.go
@@ -1431,7 +1431,7 @@ func (ls *LocalDisttaeDataSource) batchApplyTombstoneObjects(
 			location = obj.ObjectStats.BlockLocation(uint16(idx), objectio.BlockMaxRows)
 
 			if _, release, err = ioutil.ReadDeletes(
-				ls.ctx, location, ls.fs, obj.GetCNCreated(), cacheVectors, nil, fileservice.GetFileServicePolicy(ls.ctx),
+				ls.ctx, location, ls.fs, obj.GetCNCreated(), cacheVectors, nil, fileservice.Policy(0),
 			); err != nil {
 				return err
 			}

--- a/pkg/vm/engine/disttae/logtailreplay/partition_state.go
+++ b/pkg/vm/engine/disttae/logtailreplay/partition_state.go
@@ -1618,7 +1618,7 @@ func (p *PartitionState) countTombstoneStatsLinear(
 		func(blk objectio.BlockInfo, blkMeta objectio.BlockObject) bool {
 			var release func()
 			if _, release, readErr = ioutil.ReadDeletes(
-				ctx, blk.MetaLoc[:], fs, cnCreated, persistedDeletes, nil, fileservice.GetFileServicePolicy(ctx),
+				ctx, blk.MetaLoc[:], fs, cnCreated, persistedDeletes, nil, fileservice.Policy(0),
 			); readErr != nil {
 				return false
 			}
@@ -1717,7 +1717,7 @@ func (p *PartitionState) countTombstoneStatsWithMap(
 			func(blk objectio.BlockInfo, blkMeta objectio.BlockObject) bool {
 				var release func()
 				if _, release, readErr = ioutil.ReadDeletes(
-					ctx, blk.MetaLoc[:], fs, cnCreated, persistedDeletes, nil, fileservice.GetFileServicePolicy(ctx),
+					ctx, blk.MetaLoc[:], fs, cnCreated, persistedDeletes, nil, fileservice.Policy(0),
 				); readErr != nil {
 					return false
 				}
@@ -1850,7 +1850,7 @@ func (it *tombstoneBlockIterator) loadNextBlock() bool {
 
 	cnCreated := it.obj.GetCNCreated()
 	if _, it.release, it.err = ioutil.ReadDeletes(
-		it.ctx, blk.MetaLoc[:], it.fs, cnCreated, it.persistedDel, nil, fileservice.GetFileServicePolicy(it.ctx),
+		it.ctx, blk.MetaLoc[:], it.fs, cnCreated, it.persistedDel, nil, fileservice.Policy(0),
 	); it.err != nil {
 		return false
 	}

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -77,6 +77,15 @@ var pkCheckSemaphore = make(chan struct{}, 16)
 const maxChangedObjectsForIO = 64
 const maxCandidateBlksForIO = 32
 
+func acquirePKCheckSemaphore(ctx context.Context) (func(), error) {
+	select {
+	case pkCheckSemaphore <- struct{}{}:
+		return func() { <-pkCheckSemaphore }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 func shouldBailoutOnChangedObjects(cnt int) bool {
 	return cnt > maxChangedObjectsForIO
 }
@@ -2631,19 +2640,13 @@ func (tbl *txnTable) PKPersistedBetween(
 	pkSeq := pkDef.Seqnum
 	pkType := plan2.ExprType2Type(&pkDef.Typ)
 	if len(candidateBlks) > 0 {
-		// Acquire semaphore to limit concurrent block I/O across all transactions.
-		// This prevents 1000 goroutines from simultaneously reading blocks and
-		// exhausting mpool capacity. Scoped to the block loop only -- tombstone
-		// checking below is not rate-limited by this semaphore.
-		select {
-		case pkCheckSemaphore <- struct{}{}:
-		case <-ctx.Done():
-			return false, ctx.Err()
-		}
-
 		v2.TxnPKChangeCheckIOCounter.Inc()
 
 		for _, blk := range candidateBlks {
+			semRelease, err := acquirePKCheckSemaphore(ctx)
+			if err != nil {
+				return false, err
+			}
 			release, err := ioutil.LoadColumns(
 				ctx,
 				[]uint16{uint16(pkSeq)},
@@ -2654,8 +2657,8 @@ func (tbl *txnTable) PKPersistedBetween(
 				tbl.proc.Load().GetMPool(),
 				fileservice.Policy(0),
 			)
+			semRelease()
 			if err != nil {
-				<-pkCheckSemaphore
 				return true, err
 			}
 
@@ -2667,11 +2670,9 @@ func (tbl *txnTable) PKPersistedBetween(
 			sels := searchFunc(cacheVectors)
 			release()
 			if len(sels) > 0 {
-				<-pkCheckSemaphore
 				return true, nil
 			}
 		}
-		<-pkCheckSemaphore
 	}
 	if checkTombstone {
 		pkDef := tbl.tableDef.Cols[tbl.primaryIdx]

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -70,22 +70,12 @@ const (
 var traceFilterExprInterval atomic.Uint64
 var traceFilterExprInterval2 atomic.Uint64
 
-// pkCheckSemaphore limits concurrent PK conflict I/O in PKPersistedBetween to prevent
+// pkCheckSemaphore limits concurrent block I/O in PKPersistedBetween to prevent
 // mpool explosion when many transactions simultaneously check primary key conflicts.
 var pkCheckSemaphore = make(chan struct{}, 16)
-var pkConflictReadPolicy fileservice.Policy = fileservice.SkipFullFilePreloads
 
 const maxChangedObjectsForIO = 64
 const maxCandidateBlksForIO = 32
-
-func acquirePKCheckSemaphore(ctx context.Context) (func(), error) {
-	select {
-	case pkCheckSemaphore <- struct{}{}:
-		return func() { <-pkCheckSemaphore }, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-}
 
 func shouldBailoutOnChangedObjects(cnt int) bool {
 	return cnt > maxChangedObjectsForIO
@@ -866,7 +856,7 @@ func (tbl *txnTable) countSingleTombstoneObject(
 			var release func()
 			// cnCreated=true because uncommitted tombstones are always CN-created
 			if _, release, readErr = ioutil.ReadDeletes(
-				ctx, blk.MetaLoc[:], fs, true, persistedDeletes, nil, fileservice.GetFileServicePolicy(ctx),
+				ctx, blk.MetaLoc[:], fs, true, persistedDeletes, nil, fileservice.Policy(0),
 			); readErr != nil {
 				return false
 			}
@@ -2536,15 +2526,10 @@ func (tbl *txnTable) PKPersistedBetween(
 			var objMeta objectio.ObjectMeta
 			location := obj.Location()
 
-			semRelease, err := acquirePKCheckSemaphore(ctx)
-			if err != nil {
-				return err
-			}
 			// load object metadata
 			if objMeta, err2 = objectio.FastLoadObjectMeta(
 				ctx, &location, false, fs,
 			); err2 != nil {
-				semRelease()
 				return
 			}
 
@@ -2555,7 +2540,6 @@ func (tbl *txnTable) PKPersistedBetween(
 			// If object zone map doesn't contains the pk value, we need to check bloom filter
 			if !zmCkecked {
 				if !meta.MustGetColumn(uint16(primaryIdx)).ZoneMap().AnyIn(keys) {
-					semRelease()
 					return
 				}
 			}
@@ -2566,11 +2550,9 @@ func (tbl *txnTable) PKPersistedBetween(
 				if bf, err2 = objectio.LoadBFWithMeta(
 					ctx, meta, location, fs,
 				); err2 != nil {
-					semRelease()
 					return
 				}
 			}
-			semRelease()
 
 			objectio.ForeachBlkInObjStatsList(false, meta,
 				func(blk objectio.BlockInfo, blkMeta objectio.BlockObject) bool {
@@ -2649,14 +2631,20 @@ func (tbl *txnTable) PKPersistedBetween(
 	pkSeq := pkDef.Seqnum
 	pkType := plan2.ExprType2Type(&pkDef.Typ)
 	if len(candidateBlks) > 0 {
+		// Acquire semaphore to limit concurrent block I/O across all transactions.
+		// This prevents 1000 goroutines from simultaneously reading blocks and
+		// exhausting mpool capacity. Scoped to the block loop only -- tombstone
+		// checking below is not rate-limited by this semaphore.
+		select {
+		case pkCheckSemaphore <- struct{}{}:
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+
 		v2.TxnPKChangeCheckIOCounter.Inc()
 
 		for _, blk := range candidateBlks {
-			semRelease, err := acquirePKCheckSemaphore(ctx)
-			if err != nil {
-				return false, err
-			}
-			dataRelease, err := ioutil.LoadColumns(
+			release, err := ioutil.LoadColumns(
 				ctx,
 				[]uint16{uint16(pkSeq)},
 				[]types.Type{pkType},
@@ -2664,10 +2652,10 @@ func (tbl *txnTable) PKPersistedBetween(
 				blk.MetaLocation(),
 				cacheVectors,
 				tbl.proc.Load().GetMPool(),
-				pkConflictReadPolicy,
+				fileservice.Policy(0),
 			)
 			if err != nil {
-				semRelease()
+				<-pkCheckSemaphore
 				return true, err
 			}
 
@@ -2677,12 +2665,13 @@ func (tbl *txnTable) PKPersistedBetween(
 			}
 
 			sels := searchFunc(cacheVectors)
-			dataRelease()
-			semRelease()
+			release()
 			if len(sels) > 0 {
+				<-pkCheckSemaphore
 				return true, nil
 			}
 		}
+		<-pkCheckSemaphore
 	}
 	if checkTombstone {
 		pkDef := tbl.tableDef.Cols[tbl.primaryIdx]
@@ -2725,19 +2714,13 @@ func tombstonePKExistsInRange(
 				vecCount = 2
 			}
 			tombVectors := containers.NewVectors(vecCount)
-			semRelease, err := acquirePKCheckSemaphore(ctx)
+			_, dataRelease, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType, fileservice.Policy(0))
 			if err != nil {
-				return false, err
-			}
-			_, dataRelease, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType, pkConflictReadPolicy)
-			if err != nil {
-				semRelease()
 				return true, nil
 			}
 			pkVec := tombVectors[1]
 			hits := searchKeys(&pkVec)
 			dataRelease()
-			semRelease()
 			if len(hits) > 0 {
 				return true, nil
 			}

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -179,7 +179,7 @@ func TestTombstonePKExistsInRange(t *testing.T) {
 	require.False(t, changed)
 }
 
-func TestTombstonePKExistsInRangeSkipsFullFilePreloads(t *testing.T) {
+func TestTombstonePKExistsInRangeUsesDefaultReadPolicy(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -212,24 +212,66 @@ func TestTombstonePKExistsInRangeSkipsFullFilePreloads(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, changed)
 	require.GreaterOrEqual(t, len(recordingFS.policies), 2)
-	require.Equal(t, fileservice.Policy(fileservice.SkipFullFilePreloads), recordingFS.policies[1])
+	require.Equal(t, fileservice.Policy(0), recordingFS.policies[1])
 }
 
-func TestTombstonePKExistsInRangeEmptyFastPathSkipsSemaphore(t *testing.T) {
+func fillPKCheckSemaphoreForTest() func() {
 	for i := 0; i < cap(pkCheckSemaphore); i++ {
 		pkCheckSemaphore <- struct{}{}
 	}
-	defer func() {
+
+	return func() {
 		for i := 0; i < cap(pkCheckSemaphore); i++ {
 			<-pkCheckSemaphore
 		}
-	}()
+	}
+}
+
+func TestTombstonePKExistsInRangeSkipsSemaphore(t *testing.T) {
+	releaseSemaphore := fillPKCheckSemaphoreForTest()
+	defer releaseSemaphore()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
+	proc := testutil.NewProc(t)
+	fs, err := fileservice.Get[fileservice.FileService](proc.GetFileService(), defines.SharedFileServiceName)
+	require.NoError(t, err)
+
 	pState := logtailreplay.NewPartitionState("", true, 0, false)
-	keys := vector.NewVec(types.T_int32.ToType())
+	int32Type := types.T_int32.ToType()
+	writer := colexec.NewCNS3TombstoneWriter(proc.Mp(), fs, int32Type, -1)
+	bat := readutil.NewCNTombstoneBatch(&int32Type, objectio.HiddenColumnSelection_None)
+	require.NoError(t, vector.AppendFixed[types.Rowid](bat.Vecs[0], types.RandomRowid(), false, proc.GetMPool()))
+	require.NoError(t, vector.AppendFixed[int32](bat.Vecs[1], 100, false, proc.GetMPool()))
+	bat.SetRowCount(1)
+	require.NoError(t, writer.Write(ctx, bat))
+	stats, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+
+	require.NoError(t, pState.HandleObjectEntry(ctx, fs, objectio.ObjectEntry{
+		ObjectStats: stats[0],
+		CreateTime:  types.BuildTS(15, 0),
+	}, true))
+
+	keys := vector.NewVec(int32Type)
+	require.NoError(t, vector.AppendFixed[int32](keys, 100, false, proc.GetMPool()))
+	changed, err := tombstonePKExistsInRange(ctx, pState, types.BuildTS(10, 0), keys, int32Type, fs)
+	require.NoError(t, err)
+	require.True(t, changed)
+}
+
+func TestTombstonePKExistsInRangeEmptyFastPathSkipsSemaphore(t *testing.T) {
+	releaseSemaphore := fillPKCheckSemaphoreForTest()
+	defer releaseSemaphore()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	int32Type := types.T_int32.ToType()
+	pState := logtailreplay.NewPartitionState("", true, 0, false)
+	keys := vector.NewVec(int32Type)
 	changed, err := tombstonePKExistsInRange(ctx, pState, types.BuildTS(10, 0), keys, types.T_int32.ToType(), nil)
 	require.NoError(t, err)
 	require.False(t, changed)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fix https://github.com/matrixorigin/matrixone/issues/24534
Related to #24535

## What this PR does / why we need it:

#24535 introduced several broad read/cache behavior changes while trying to reduce CN RSS pressure under TPCC. Nightly TPCC 1000 showed connection stalls after #24535. Debug runs confirmed the main stall chain:

- foreground full-file reads entered `fifocache.EvictWithWait`
- `EvictWithWait` repeatedly inherited global async eviction debt via `capacityCut`
- the IO merger initiator was blocked by cache eviction for tens of seconds
- IO merger waiters accumulated, then jTPCC connections hit the 60s socket timeout

This PR narrows the behavior back to a bounded foreground path:

- PK semaphore is scoped to each individual `LoadColumns` call only
- metadata / BF reads are not throttled by the PK semaphore
- tombstone `ReadDeletes` is not throttled by the PK semaphore
- PK/tombstone reads use the default fileservice policy, matching pre-#24535 behavior
- foreground `EvictWithWait` no longer drains global async eviction debt
- RSS cache eviction is triggered asynchronously so memory sampling does not synchronously block on cache family eviction
- tombstone read failures keep the existing conservative behavior: return `true, nil`

## Tests:

- `git diff --check`
- `GOCACHE=/private/tmp/mo-gocache go test ./pkg/fileservice/fifocache -run 'TestEvict|TestPostEvict|TestMemoryCache' -count=1`
- `GOCACHE=/private/tmp/mo-gocache go test ./pkg/fileservice -run 'TestMemoryCacheEvictToCapacityPercent|TestMemoryCacheGlobalSizeHint|TestCache' -count=1`

Local note: full `pkg/fileservice` hits sandbox port-listen restrictions in `httptest`; `pkg/common/rscthrottler` is blocked locally by missing CGO headers (`usearch.h` / `xxhash.h`).
