### PR TITLE
fix(replace): resolve unique-key conflict when PK is auto-generated (cherry-pick #24425)

### DIFF
--- a/pkg/sql/plan/bind_replace.go
+++ b/pkg/sql/plan/bind_replace.go
@@ -168,17 +168,68 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 				},
 			},
 		}
+		var joinConds []*plan.Expr
+		pkCond, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{leftExpr, rightExpr})
+		joinConds = append(joinConds, pkCond)
 
-		joinCond, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{
-			leftExpr,
-			rightExpr,
-		})
+		for _, idxDef := range tableDef.Indexes {
+			if !idxDef.Unique {
+				continue
+			}
+			var ukPartConds []*plan.Expr
+			for _, part := range idxDef.Parts {
+				colName := catalog.ResolveAlias(part)
+				colIdx := tableDef.Name2ColIndex[colName]
+				colTyp := tableDef.Cols[colIdx].Typ
+				lExpr := &plan.Expr{
+					Typ: colTyp,
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{
+							RelPos: selectTag,
+							ColPos: colName2Idx[tableDef.Name+"."+colName],
+						},
+					},
+				}
+				rExpr := &plan.Expr{
+					Typ: colTyp,
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{
+							RelPos: oldScanTag,
+							ColPos: colIdx,
+						},
+					},
+				}
+				partCond, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "=", []*plan.Expr{lExpr, rExpr})
+				ukPartConds = append(ukPartConds, partCond)
+			}
+			var ukCond *plan.Expr
+			if len(ukPartConds) == 1 {
+				ukCond = ukPartConds[0]
+			} else {
+				ukCond = ukPartConds[0]
+				for _, c := range ukPartConds[1:] {
+					ukCond, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "and", []*plan.Expr{ukCond, c})
+				}
+			}
+			joinConds = append(joinConds, ukCond)
+		}
+
+		var joinOnList []*plan.Expr
+		if len(joinConds) == 1 {
+			joinOnList = joinConds
+		} else if len(joinConds) > 1 {
+			combined := joinConds[0]
+			for _, c := range joinConds[1:] {
+				combined, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "or", []*plan.Expr{combined, c})
+			}
+			joinOnList = []*plan.Expr{combined}
+		}
 
 		lastNodeID = builder.appendNode(&plan.Node{
 			NodeType: plan.Node_JOIN,
 			Children: []int32{lastNodeID, oldScanNodeID},
 			JoinType: plan.Node_LEFT,
-			OnList:   []*plan.Expr{joinCond},
+			OnList:   joinOnList,
 		}, bindCtx)
 
 		lastNodeID = builder.appendNode(&plan.Node{

--- a/pkg/sql/plan/index_table_dml_test.go
+++ b/pkg/sql/plan/index_table_dml_test.go
@@ -572,4 +572,3 @@ func TestBindReplaceWithUniqueSecondaryIndex(t *testing.T) {
 	require.True(t, leftJoinFound, "REPLACE on table with unique secondary index should use legacy LEFT JOIN path")
 	require.True(t, leftJoinHasOr, "LEFT JOIN ON clause should combine PK and UK equality with OR")
 }
-

--- a/pkg/sql/plan/index_table_dml_test.go
+++ b/pkg/sql/plan/index_table_dml_test.go
@@ -507,3 +507,69 @@ func TestMultiTableUpdate(t *testing.T) {
 
 	runTestShouldPass(mock, t, sqls, false, false)
 }
+
+// TestBindReplaceWithUniqueSecondaryIndex verifies that REPLACE INTO on a table
+// with both an AUTO_INCREMENT PK and a unique secondary index disables the
+// merged-scan optimization and falls back to the legacy LEFT JOIN path with
+// OR'ed unique-key conditions, so unique-key conflicts can be resolved by
+// deleting the old row instead of raising a duplicate-entry error.
+func TestBindReplaceWithUniqueSecondaryIndex(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	sql := "replace into constraint_test.dept(dname, loc) values ('SALES', 'CHICAGO')"
+
+	stmts, err := mysql.Parse(mock.CurrentContext().GetContext(), sql, 1)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	stmt, ok := stmts[0].(*tree.Replace)
+	require.True(t, ok)
+
+	builder := NewQueryBuilder(planpb.Query_INSERT, mock.CurrentContext(), false, true)
+	bindCtx := NewBindContext(builder, nil)
+
+	dmlCtx := NewDMLContext()
+	objRef, tableDef, err := builder.compCtx.Resolve("constraint_test", "dept", nil)
+	require.NoError(t, err)
+	dmlCtx.objRefs = []*planpb.ObjectRef{objRef}
+	dmlCtx.tableDefs = []*planpb.TableDef{tableDef}
+
+	hasUnique := false
+	for _, idxDef := range tableDef.Indexes {
+		if idxDef.Unique {
+			hasUnique = true
+			break
+		}
+	}
+	require.True(t, hasUnique, "dept table is expected to have a unique secondary index")
+
+	lastNodeID, colName2Idx, skipUniqueIdx, err := builder.initInsertReplaceStmt(
+		bindCtx, stmt.Rows, stmt.Columns, dmlCtx.objRefs[0], dmlCtx.tableDefs[0], true,
+	)
+	require.NoError(t, err)
+
+	rootID, err := builder.appendDedupAndMultiUpdateNodesForBindReplace(
+		bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx,
+	)
+	require.NoError(t, err)
+	require.NotZero(t, rootID)
+
+	leftJoinFound := false
+	leftJoinHasOr := false
+	for _, n := range builder.qry.Nodes {
+		if n.NodeType != planpb.Node_JOIN || n.JoinType != planpb.Node_LEFT {
+			continue
+		}
+		leftJoinFound = true
+		for _, cond := range n.OnList {
+			if f := cond.GetF(); f != nil && f.Func != nil && f.Func.ObjName == "or" {
+				leftJoinHasOr = true
+				break
+			}
+		}
+		if leftJoinHasOr {
+			break
+		}
+	}
+	require.True(t, leftJoinFound, "REPLACE on table with unique secondary index should use legacy LEFT JOIN path")
+	require.True(t, leftJoinHasOr, "LEFT JOIN ON clause should combine PK and UK equality with OR")
+}
+

--- a/pkg/sql/plan/index_table_dml_test.go
+++ b/pkg/sql/plan/index_table_dml_test.go
@@ -572,3 +572,64 @@ func TestBindReplaceWithUniqueSecondaryIndex(t *testing.T) {
 	require.True(t, leftJoinFound, "REPLACE on table with unique secondary index should use legacy LEFT JOIN path")
 	require.True(t, leftJoinHasOr, "LEFT JOIN ON clause should combine PK and UK equality with OR")
 }
+
+// TestBindReplaceWithCompositeUniqueIndex verifies that for tables with a
+// composite unique secondary index the planner generates an AND-chain for the
+// UK parts inside the OR-combined LEFT JOIN ON clause.
+func TestBindReplaceWithCompositeUniqueIndex(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	sql := "replace into constraint_test.dept_composite_uk(dname, loc) values ('SALES', 'CHICAGO')"
+
+	stmts, err := mysql.Parse(mock.CurrentContext().GetContext(), sql, 1)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	stmt, ok := stmts[0].(*tree.Replace)
+	require.True(t, ok)
+
+	builder := NewQueryBuilder(planpb.Query_INSERT, mock.CurrentContext(), false, true)
+	bindCtx := NewBindContext(builder, nil)
+
+	dmlCtx := NewDMLContext()
+	objRef, tableDef, err := builder.compCtx.Resolve("constraint_test", "dept_composite_uk", nil)
+	require.NoError(t, err)
+	dmlCtx.objRefs = []*planpb.ObjectRef{objRef}
+	dmlCtx.tableDefs = []*planpb.TableDef{tableDef}
+
+	lastNodeID, colName2Idx, skipUniqueIdx, err := builder.initInsertReplaceStmt(
+		bindCtx, stmt.Rows, stmt.Columns, dmlCtx.objRefs[0], dmlCtx.tableDefs[0], true,
+	)
+	require.NoError(t, err)
+
+	rootID, err := builder.appendDedupAndMultiUpdateNodesForBindReplace(
+		bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx,
+	)
+	require.NoError(t, err)
+	require.NotZero(t, rootID)
+
+	// The LEFT JOIN ON clause should be: pk_match OR (dname_match AND loc_match).
+	// Verify that the OR node contains an AND child (the composite UK condition).
+	leftJoinFound := false
+	orHasAndChild := false
+	for _, n := range builder.qry.Nodes {
+		if n.NodeType != planpb.Node_JOIN || n.JoinType != planpb.Node_LEFT {
+			continue
+		}
+		leftJoinFound = true
+		for _, cond := range n.OnList {
+			f := cond.GetF()
+			if f == nil || f.Func == nil || f.Func.ObjName != "or" {
+				continue
+			}
+			for _, arg := range f.Args {
+				if af := arg.GetF(); af != nil && af.Func != nil && af.Func.ObjName == "and" {
+					orHasAndChild = true
+				}
+			}
+		}
+		if orHasAndChild {
+			break
+		}
+	}
+	require.True(t, leftJoinFound, "REPLACE on table with composite unique index should use LEFT JOIN path")
+	require.True(t, orHasAndChild, "OR clause should contain an AND child for composite UK parts")
+}

--- a/pkg/sql/plan/mock.go
+++ b/pkg/sql/plan/mock.go
@@ -688,6 +688,49 @@ func NewMockCompilerContext(isDml bool) *MockCompilerContext {
 		pks:    []int{0},
 		outcnt: 4,
 	}
+
+	/*
+		create table dept_composite_uk(
+			deptno int unsigned auto_increment,
+			dname varchar(15),
+			loc varchar(50),
+			primary key(deptno),
+			unique key uk_dname_loc(dname, loc)
+		);
+	*/
+	constraintTestSchema["dept_composite_uk"] = &Schema{
+		tblId: 88889,
+		cols: []col{
+			{"deptno", types.T_uint32, true, 32, 0},
+			{"dname", types.T_varchar, true, 15, 0},
+			{"loc", types.T_varchar, true, 50, 0},
+			{catalog.Row_ID, types.T_Rowid, true, 0, 0},
+		},
+		pks: []int{0},
+		idxs: []index{
+			{
+				indexName: "uk_dname_loc",
+				tableName: catalog.UniqueIndexTableNamePrefix + "dept-composite-uk-idx",
+				parts:     []string{"dname", "loc"},
+				cols: []col{
+					{catalog.IndexTableIndexColName, types.T_varchar, true, 255, 0},
+				},
+				tableExist: true,
+				unique:     true,
+			},
+		},
+		outcnt: 4,
+	}
+	constraintTestSchema[catalog.UniqueIndexTableNamePrefix+"dept-composite-uk-idx"] = &Schema{
+		cols: []col{
+			{catalog.IndexTableIndexColName, types.T_varchar, true, 255, 0},
+			{catalog.IndexTablePrimaryColName, types.T_uint32, true, 32, 0},
+			{catalog.Row_ID, types.T_Rowid, true, 0, 0},
+		},
+		pks:    []int{0},
+		outcnt: 4,
+	}
+
 	/*
 		create table products (
 			pid int not null,

--- a/test/distributed/cases/dml/replace/replace.result
+++ b/test/distributed/cases/dml/replace/replace.result
@@ -86,3 +86,90 @@ mo_ctl(dn, flush, replace_db.bug_22340)
 REPLACE INTO bug_22340 VALUES (1,100,'[1, 2, 3]'),(2,100,'[1, 2, 3]'),(3,100,'[1, 2, 3]'),(4,100,'[1, 2, 3]'),(5,100,'[1, 2, 3]'),(6,100,'[1, 2, 3]'),(7,100,'[1, 2, 3]'),(8,100,'[1, 2, 3]'),(9,100,'[1, 2, 3]'),(10,100,'[1, 2, 3]');
 drop table bug_22340;
 drop database replace_db;
+use `replace`;
+drop table if exists t_null_uk;
+create table t_null_uk(id int primary key, a int, b varchar(64), unique key(a));
+replace into t_null_uk values (1, NULL, 'first');
+replace into t_null_uk values (2, NULL, 'second');
+select id, a, b from t_null_uk order by id;
+id    a    b
+1    null    first
+2    null    second
+replace into t_null_uk values (3, 1, 'third');
+select id, a, b from t_null_uk order by id;
+id    a    b
+1    null    first
+2    null    second
+3    1    third
+drop table t_null_uk;
+drop table if exists t_fake_pk;
+create table t_fake_pk(a int unique key, b varchar(64));
+replace into t_fake_pk values (1, 'hello');
+select * from t_fake_pk;
+a    b
+1    hello
+replace into t_fake_pk values (1, 'world');
+select * from t_fake_pk;
+a    b
+1    world
+replace into t_fake_pk values (2, 'foo');
+select * from t_fake_pk order by a;
+a    b
+1    world
+2    foo
+drop table t_fake_pk;
+drop table if exists t_odku;
+create table t_odku(id int primary key, name varchar(64), val int);
+insert into t_odku values (1, 'a', 10);
+insert into t_odku values (1, 'b', 20) on duplicate key update name = values(name), val = values(val);
+select * from t_odku;
+id    name    val
+1    b    20
+drop table t_odku;
+drop table if exists t_pk_uk;
+create table t_pk_uk(id int primary key, a int unique, b varchar(64));
+insert into t_pk_uk values (1, 10, 'first'), (2, 20, 'second');
+replace into t_pk_uk values (1, 30, 'updated');
+select * from t_pk_uk order by id;
+id    a    b
+1    30    updated
+2    20    second
+drop table t_pk_uk;
+drop table if exists ai_replace_test;
+create table ai_replace_test (id int auto_increment primary key, name varchar(50) unique, value int);
+insert into ai_replace_test (name, value) values ('key1', 100), ('key2', 200);
+replace into ai_replace_test (name, value) values ('key1', 300);
+select * from ai_replace_test order by id;
+id    name    value
+2    key2    200
+3    key1    300
+insert into ai_replace_test (name, value) values ('key3', 400);
+select * from ai_replace_test order by id;
+id    name    value
+2    key2    200
+3    key1    300
+4    key3    400
+drop table ai_replace_test;
+drop table if exists ai_composite_uk;
+create table ai_composite_uk (id int auto_increment primary key, a int, b int, value int, unique key uk_ab(a, b));
+insert into ai_composite_uk (a, b, value) values (1, 1, 100), (2, 2, 200);
+replace into ai_composite_uk (a, b, value) values (1, 1, 300);
+select * from ai_composite_uk order by id;
+id    a    b    value
+2    2    2    200
+3    1    1    300
+drop table ai_composite_uk;
+drop table if exists ai_multi_uk;
+create table ai_multi_uk (id int auto_increment primary key, name varchar(50) unique, email varchar(100) unique, value int);
+insert into ai_multi_uk (name, email, value) values ('n1', 'n1@a.com', 100), ('n2', 'n2@a.com', 200);
+replace into ai_multi_uk (name, email, value) values ('n1', 'n1_new@a.com', 300);
+select * from ai_multi_uk order by id;
+id    name    email    value
+2    n2    n2@a.com    200
+3    n1    n1_new@a.com    300
+replace into ai_multi_uk (name, email, value) values ('n_new', 'n2@a.com', 400);
+select * from ai_multi_uk order by id;
+id    name    email    value
+3    n1    n1_new@a.com    300
+4    n_new    n2@a.com    400
+drop table ai_multi_uk;

--- a/test/distributed/cases/dml/replace/replace.result
+++ b/test/distributed/cases/dml/replace/replace.result
@@ -152,12 +152,13 @@ id    name    value
 drop table ai_replace_test;
 drop table if exists ai_composite_uk;
 create table ai_composite_uk (id int auto_increment primary key, a int, b int, value int, unique key uk_ab(a, b));
-insert into ai_composite_uk (a, b, value) values (1, 1, 100), (2, 2, 200);
+insert into ai_composite_uk (a, b, value) values (1, 1, 100), (1, 2, 150), (2, 2, 200);
 replace into ai_composite_uk (a, b, value) values (1, 1, 300);
 select * from ai_composite_uk order by id;
 id    a    b    value
-2    2    2    200
-3    1    1    300
+2    1    2    150
+3    2    2    200
+4    1    1    300
 drop table ai_composite_uk;
 drop table if exists ai_multi_uk;
 create table ai_multi_uk (id int auto_increment primary key, name varchar(50) unique, email varchar(100) unique, value int);

--- a/test/distributed/cases/dml/replace/replace.test
+++ b/test/distributed/cases/dml/replace/replace.test
@@ -114,9 +114,12 @@ select * from ai_replace_test order by id;
 drop table ai_replace_test;
 
 -- test REPLACE on AUTO_INCREMENT table with composite UNIQUE key
+-- Distractor row (1, 2) shares the first key part with (1, 1) but must NOT be
+-- deleted when REPLACE targets (1, 1). This ensures the planner matches on
+-- ALL composite-key parts, not just the first one.
 drop table if exists ai_composite_uk;
 create table ai_composite_uk (id int auto_increment primary key, a int, b int, value int, unique key uk_ab(a, b));
-insert into ai_composite_uk (a, b, value) values (1, 1, 100), (2, 2, 200);
+insert into ai_composite_uk (a, b, value) values (1, 1, 100), (1, 2, 150), (2, 2, 200);
 replace into ai_composite_uk (a, b, value) values (1, 1, 300);
 select * from ai_composite_uk order by id;
 drop table ai_composite_uk;

--- a/test/distributed/cases/dml/replace/replace.test
+++ b/test/distributed/cases/dml/replace/replace.test
@@ -63,3 +63,70 @@ REPLACE INTO bug_22340 VALUES (1,100,'[1, 2, 3]'),(2,100,'[1, 2, 3]'),(3,100,'[1
 drop table bug_22340;
 
 drop database replace_db;
+use `replace`;
+
+-- test NULL on unique key column: multiple NULLs should not conflict
+drop table if exists t_null_uk;
+create table t_null_uk(id int primary key, a int, b varchar(64), unique key(a));
+replace into t_null_uk values (1, NULL, 'first');
+replace into t_null_uk values (2, NULL, 'second');
+select id, a, b from t_null_uk order by id;
+replace into t_null_uk values (3, 1, 'third');
+select id, a, b from t_null_uk order by id;
+drop table t_null_uk;
+
+-- test fake PK table with unique key only
+drop table if exists t_fake_pk;
+create table t_fake_pk(a int unique key, b varchar(64));
+replace into t_fake_pk values (1, 'hello');
+select * from t_fake_pk;
+replace into t_fake_pk values (1, 'world');
+select * from t_fake_pk;
+replace into t_fake_pk values (2, 'foo');
+select * from t_fake_pk order by a;
+drop table t_fake_pk;
+
+-- test INSERT ON DUPLICATE KEY UPDATE rewrite to REPLACE
+drop table if exists t_odku;
+create table t_odku(id int primary key, name varchar(64), val int);
+insert into t_odku values (1, 'a', 10);
+insert into t_odku values (1, 'b', 20) on duplicate key update name = values(name), val = values(val);
+select * from t_odku;
+drop table t_odku;
+
+-- test PK + UK conflict
+drop table if exists t_pk_uk;
+create table t_pk_uk(id int primary key, a int unique, b varchar(64));
+insert into t_pk_uk values (1, 10, 'first'), (2, 20, 'second');
+replace into t_pk_uk values (1, 30, 'updated');
+select * from t_pk_uk order by id;
+drop table t_pk_uk;
+
+-- test REPLACE on AUTO_INCREMENT table with UNIQUE constraint
+-- only the UNIQUE column conflicts; PK is auto-generated
+drop table if exists ai_replace_test;
+create table ai_replace_test (id int auto_increment primary key, name varchar(50) unique, value int);
+insert into ai_replace_test (name, value) values ('key1', 100), ('key2', 200);
+replace into ai_replace_test (name, value) values ('key1', 300);
+select * from ai_replace_test order by id;
+insert into ai_replace_test (name, value) values ('key3', 400);
+select * from ai_replace_test order by id;
+drop table ai_replace_test;
+
+-- test REPLACE on AUTO_INCREMENT table with composite UNIQUE key
+drop table if exists ai_composite_uk;
+create table ai_composite_uk (id int auto_increment primary key, a int, b int, value int, unique key uk_ab(a, b));
+insert into ai_composite_uk (a, b, value) values (1, 1, 100), (2, 2, 200);
+replace into ai_composite_uk (a, b, value) values (1, 1, 300);
+select * from ai_composite_uk order by id;
+drop table ai_composite_uk;
+
+-- test REPLACE on AUTO_INCREMENT table with multiple UNIQUE indexes
+drop table if exists ai_multi_uk;
+create table ai_multi_uk (id int auto_increment primary key, name varchar(50) unique, email varchar(100) unique, value int);
+insert into ai_multi_uk (name, email, value) values ('n1', 'n1@a.com', 100), ('n2', 'n2@a.com', 200);
+replace into ai_multi_uk (name, email, value) values ('n1', 'n1_new@a.com', 300);
+select * from ai_multi_uk order by id;
+replace into ai_multi_uk (name, email, value) values ('n_new', 'n2@a.com', 400);
+select * from ai_multi_uk order by id;
+drop table ai_multi_uk;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23144

## What this PR does / why we need it:

Cherry-pick of #24425 to 3.0-dev.

When executing `REPLACE INTO` on a table with both a primary key (e.g. `AUTO_INCREMENT`) and one or more unique secondary indexes, a row that conflicts **only on a unique key** (no PK conflict) was not detected, so the conflicting old row was never deleted and the statement raised "Duplicate entry".

Fix: extend the legacy LEFT JOIN with OR'ed per-UK equality conditions so a UK-only conflict still retrieves the old row for deletion.

## Special notes for your reviewer:

Conflict resolution: 3.0-dev does not have the merged-scan optimization from main, so only the LEFT JOIN UK-condition fix was applied.

## Additional information: