### PR TITLE
feat: support HLL sketch functions

### DIFF
--- a/pkg/sql/colexec/aggexec/approx_count2.go
+++ b/pkg/sql/colexec/aggexec/approx_count2.go
@@ -19,6 +19,7 @@ import (
 	"slices"
 
 	hll "github.com/axiomhq/hyperloglog"
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -37,6 +38,9 @@ func (s *hllSketch) MarshalBinary() ([]byte, error) {
 }
 
 func (s *hllSketch) UnmarshalBinary(data []byte) error {
+	if s.Sketch == nil {
+		s.Sketch = hll.NewNoSparse()
+	}
 	return s.Sketch.UnmarshalBinary(data)
 }
 
@@ -45,10 +49,18 @@ func (s *hllSketch) UnmarshalFromReader(r io.Reader) error {
 	if err != nil {
 		return err
 	}
+	return s.UnmarshalBinary(bs)
+}
+
+func (s *hllSketch) mergeBytes(data []byte) error {
+	other := &hllSketch{}
+	if err := other.UnmarshalBinary(data); err != nil {
+		return moerr.NewInvalidInputNoCtxf("invalid HLL sketch: %v", err)
+	}
 	if s.Sketch == nil {
 		s.Sketch = hll.NewNoSparse()
 	}
-	return s.Sketch.UnmarshalBinary(bs)
+	return s.Merge(other.Sketch)
 }
 
 type approxCountExec struct {
@@ -161,8 +173,235 @@ func (exec *approxCountExec) Flush() (_ []*vector.Vector, retErr error) {
 }
 
 func (exec *approxCountExec) Size() int64 {
+	return hllStateSize(exec.state)
+}
+
+func (exec *approxCountExec) Free() {
+	exec.aggExec.Free()
+}
+
+type hllAddExec struct {
+	aggExec
+}
+
+func makeHllAdd(mp *mpool.MPool, id int64, arg types.Type) AggFuncExec {
+	var exec hllAddExec
+	exec.mp = mp
+	exec.aggInfo = aggInfo{
+		aggId:                    id,
+		isDistinct:               false,
+		argTypes:                 []types.Type{arg},
+		retType:                  types.T_varbinary.ToType(),
+		emptyNull:                false,
+		saveArg:                  false,
+		makeMarshalerUnmarshaler: makeHllSketch,
+	}
+	return &exec
+}
+
+func (exec *hllAddExec) GroupGrow(more int) error {
+	start := exec.GetNumGroups()
+	if err := exec.aggExec.GroupGrow(more); err != nil {
+		return err
+	}
+	for i := start; i < start+more; i++ {
+		x, y := exec.getXY(uint64(i))
+		if exec.state[x].mobs[y] == nil {
+			exec.state[x].mobs[y], _ = makeHllSketch(exec.mp)
+		}
+	}
+	return nil
+}
+
+func (exec *hllAddExec) Fill(groupIndex int, row int, vectors []*vector.Vector) error {
+	return exec.BatchFill(row, []uint64{uint64(groupIndex + 1)}, vectors)
+}
+
+func (exec *hllAddExec) BulkFill(groupIndex int, vectors []*vector.Vector) error {
+	return exec.BatchFill(0, slices.Repeat([]uint64{uint64(groupIndex + 1)}, vectors[0].Length()), vectors)
+}
+
+func (exec *hllAddExec) BatchFill(offset int, groups []uint64, vectors []*vector.Vector) error {
+	for i, grp := range groups {
+		if grp == GroupNotMatched {
+			continue
+		}
+		idx := offset + i
+		if vectors[0].IsConst() {
+			idx = 0
+		}
+		if vectors[0].IsNull(uint64(idx)) {
+			continue
+		}
+		x, y := exec.getXY(grp - 1)
+		exec.state[x].mobs[y].(*hllSketch).Insert(vectors[0].GetRawBytesAt(idx))
+	}
+	return nil
+}
+
+func (exec *hllAddExec) Merge(next AggFuncExec, groupIdx1, groupIdx2 int) error {
+	return exec.BatchMerge(next, groupIdx2, []uint64{uint64(groupIdx1 + 1)})
+}
+
+func (exec *hllAddExec) BatchMerge(next AggFuncExec, offset int, groups []uint64) error {
+	other := next.(*hllAddExec)
+	for i, grp := range groups {
+		if grp == GroupNotMatched {
+			continue
+		}
+		x1, y1 := exec.getXY(grp - 1)
+		x2, y2 := other.getXY(uint64(offset + i))
+		if err := exec.state[x1].mobs[y1].(*hllSketch).Merge(other.state[x2].mobs[y2].(*hllSketch).Sketch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (exec *hllAddExec) SetExtraInformation(partialResult any, groupIndex int) error {
+	return nil
+}
+
+func (exec *hllAddExec) Flush() ([]*vector.Vector, error) {
+	return flushHllSketches(&exec.aggExec)
+}
+
+func (exec *hllAddExec) Size() int64 {
+	return hllStateSize(exec.state)
+}
+
+func (exec *hllAddExec) Free() {
+	exec.aggExec.Free()
+}
+
+type hllMergeExec struct {
+	aggExec
+}
+
+func makeHllMerge(mp *mpool.MPool, id int64, arg types.Type) AggFuncExec {
+	var exec hllMergeExec
+	exec.mp = mp
+	exec.aggInfo = aggInfo{
+		aggId:                    id,
+		isDistinct:               false,
+		argTypes:                 []types.Type{arg},
+		retType:                  types.T_varbinary.ToType(),
+		emptyNull:                false,
+		saveArg:                  false,
+		makeMarshalerUnmarshaler: makeHllSketch,
+	}
+	return &exec
+}
+
+func (exec *hllMergeExec) GroupGrow(more int) error {
+	start := exec.GetNumGroups()
+	if err := exec.aggExec.GroupGrow(more); err != nil {
+		return err
+	}
+	for i := start; i < start+more; i++ {
+		x, y := exec.getXY(uint64(i))
+		if exec.state[x].mobs[y] == nil {
+			exec.state[x].mobs[y], _ = makeHllSketch(exec.mp)
+		}
+	}
+	return nil
+}
+
+func (exec *hllMergeExec) Fill(groupIndex int, row int, vectors []*vector.Vector) error {
+	return exec.BatchFill(row, []uint64{uint64(groupIndex + 1)}, vectors)
+}
+
+func (exec *hllMergeExec) BulkFill(groupIndex int, vectors []*vector.Vector) error {
+	return exec.BatchFill(0, slices.Repeat([]uint64{uint64(groupIndex + 1)}, vectors[0].Length()), vectors)
+}
+
+func (exec *hllMergeExec) BatchFill(offset int, groups []uint64, vectors []*vector.Vector) error {
+	for i, grp := range groups {
+		if grp == GroupNotMatched {
+			continue
+		}
+		idx := offset + i
+		if vectors[0].IsConst() {
+			idx = 0
+		}
+		if vectors[0].IsNull(uint64(idx)) {
+			continue
+		}
+		x, y := exec.getXY(grp - 1)
+		if err := exec.state[x].mobs[y].(*hllSketch).mergeBytes(vectors[0].GetBytesAt(idx)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (exec *hllMergeExec) Merge(next AggFuncExec, groupIdx1, groupIdx2 int) error {
+	return exec.BatchMerge(next, groupIdx2, []uint64{uint64(groupIdx1 + 1)})
+}
+
+func (exec *hllMergeExec) BatchMerge(next AggFuncExec, offset int, groups []uint64) error {
+	other := next.(*hllMergeExec)
+	for i, grp := range groups {
+		if grp == GroupNotMatched {
+			continue
+		}
+		x1, y1 := exec.getXY(grp - 1)
+		x2, y2 := other.getXY(uint64(offset + i))
+		if err := exec.state[x1].mobs[y1].(*hllSketch).Merge(other.state[x2].mobs[y2].(*hllSketch).Sketch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (exec *hllMergeExec) SetExtraInformation(partialResult any, groupIndex int) error {
+	return nil
+}
+
+func (exec *hllMergeExec) Flush() ([]*vector.Vector, error) {
+	return flushHllSketches(&exec.aggExec)
+}
+
+func (exec *hllMergeExec) Size() int64 {
+	return hllStateSize(exec.state)
+}
+
+func (exec *hllMergeExec) Free() {
+	exec.aggExec.Free()
+}
+
+func flushHllSketches(exec *aggExec) (_ []*vector.Vector, retErr error) {
+	vecs := make([]*vector.Vector, len(exec.state))
+	defer func() {
+		if retErr != nil {
+			for _, v := range vecs {
+				if v != nil {
+					v.Free(exec.mp)
+				}
+			}
+		}
+	}()
+	for i, st := range exec.state {
+		vecs[i] = vector.NewOffHeapVecWithType(types.T_varbinary.ToType())
+		if err := vecs[i].PreExtend(int(st.length), exec.mp); err != nil {
+			return nil, err
+		}
+		for j := 0; j < int(st.length); j++ {
+			bs, err := st.mobs[j].(*hllSketch).MarshalBinary()
+			if err != nil {
+				return nil, err
+			}
+			if err := vector.AppendBytes(vecs[i], bs, false, exec.mp); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return vecs, nil
+}
+
+func hllStateSize(states []aggState) int64 {
 	var size int64
-	for _, st := range exec.state {
+	for _, st := range states {
 		size += int64(cap(st.mobs)) * 8
 		for _, mob := range st.mobs {
 			if mob != nil {
@@ -173,8 +412,4 @@ func (exec *approxCountExec) Size() int64 {
 		}
 	}
 	return size
-}
-
-func (exec *approxCountExec) Free() {
-	exec.aggExec.Free()
 }

--- a/pkg/sql/colexec/aggexec/approx_count2_test.go
+++ b/pkg/sql/colexec/aggexec/approx_count2_test.go
@@ -88,3 +88,102 @@ func TestApproxCountExecFillMergeFlush(t *testing.T) {
 	left.Free()
 	right.Free()
 }
+
+func TestHllAddExecFillMergeFlush(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	left := makeHllAdd(mp, 1, types.T_int64.ToType()).(*hllAddExec)
+	right := makeHllAdd(mp, 1, types.T_int64.ToType()).(*hllAddExec)
+	require.NoError(t, left.GroupGrow(2))
+	require.NoError(t, right.GroupGrow(2))
+
+	values := vector.NewVec(types.T_int64.ToType())
+	require.NoError(t, vector.AppendFixedList(values, []int64{1, 2, 2, 3}, nil, mp))
+	require.NoError(t, left.BatchFill(0, []uint64{1, 1, 1, GroupNotMatched}, []*vector.Vector{values}))
+
+	rightValues := vector.NewVec(types.T_int64.ToType())
+	require.NoError(t, vector.AppendFixedList(rightValues, []int64{3, 4}, nil, mp))
+	require.NoError(t, right.BatchFill(0, []uint64{1, 2}, []*vector.Vector{rightValues}))
+
+	require.NoError(t, left.SetExtraInformation(nil, 0))
+	require.NoError(t, left.BatchMerge(right, 0, []uint64{1, 2}))
+	require.NoError(t, left.Merge(right, 0, 0))
+	require.Greater(t, left.Size(), int64(0))
+
+	vecs, err := left.Flush()
+	require.NoError(t, err)
+	require.False(t, vecs[0].IsNull(0))
+	require.False(t, vecs[0].IsNull(1))
+
+	group1 := &hllSketch{}
+	require.NoError(t, group1.UnmarshalBinary(vecs[0].GetBytesAt(0)))
+	require.Equal(t, uint64(3), group1.Estimate())
+
+	group2 := &hllSketch{}
+	require.NoError(t, group2.UnmarshalBinary(vecs[0].GetBytesAt(1)))
+	require.Equal(t, uint64(1), group2.Estimate())
+
+	values.Free(mp)
+	rightValues.Free(mp)
+	vecs[0].Free(mp)
+	left.Free()
+	right.Free()
+}
+
+func TestHllMergeExecFillMergeFlush(t *testing.T) {
+	mp := mpool.MustNewZero()
+
+	buildSketch := func(values ...int64) []byte {
+		sketch, err := makeHllSketch(mp)
+		require.NoError(t, err)
+		hlls := sketch.(*hllSketch)
+		for _, value := range values {
+			hlls.Insert(types.EncodeInt64(&value))
+		}
+		data, err := hlls.MarshalBinary()
+		require.NoError(t, err)
+		return data
+	}
+
+	left := makeHllMerge(mp, 1, types.T_varbinary.ToType()).(*hllMergeExec)
+	right := makeHllMerge(mp, 1, types.T_varbinary.ToType()).(*hllMergeExec)
+	require.NoError(t, left.GroupGrow(2))
+	require.NoError(t, right.GroupGrow(2))
+
+	values := vector.NewVec(types.T_varbinary.ToType())
+	require.NoError(t, vector.AppendBytes(values, buildSketch(1, 2), false, mp))
+	require.NoError(t, vector.AppendBytes(values, buildSketch(2, 3), false, mp))
+	require.NoError(t, vector.AppendBytes(values, nil, true, mp))
+	require.NoError(t, left.BatchFill(0, []uint64{1, 1, 2}, []*vector.Vector{values}))
+
+	rightValues := vector.NewVec(types.T_varbinary.ToType())
+	require.NoError(t, vector.AppendBytes(rightValues, buildSketch(3, 4), false, mp))
+	require.NoError(t, vector.AppendBytes(rightValues, buildSketch(5), false, mp))
+	require.NoError(t, right.BatchFill(0, []uint64{1, 2}, []*vector.Vector{rightValues}))
+
+	require.NoError(t, left.BatchMerge(right, 0, []uint64{1, 2}))
+	require.NoError(t, left.Merge(right, 0, 0))
+	require.Greater(t, left.Size(), int64(0))
+
+	vecs, err := left.Flush()
+	require.NoError(t, err)
+
+	group1 := &hllSketch{}
+	require.NoError(t, group1.UnmarshalBinary(vecs[0].GetBytesAt(0)))
+	require.Equal(t, uint64(4), group1.Estimate())
+
+	group2 := &hllSketch{}
+	require.NoError(t, group2.UnmarshalBinary(vecs[0].GetBytesAt(1)))
+	require.Equal(t, uint64(1), group2.Estimate())
+
+	invalid := vector.NewVec(types.T_varbinary.ToType())
+	require.NoError(t, vector.AppendBytes(invalid, []byte("bad"), false, mp))
+	require.Error(t, left.BatchFill(0, []uint64{1}, []*vector.Vector{invalid}))
+
+	values.Free(mp)
+	rightValues.Free(mp)
+	invalid.Free(mp)
+	vecs[0].Free(mp)
+	left.Free()
+	right.Free()
+}

--- a/pkg/sql/colexec/aggexec/register.go
+++ b/pkg/sql/colexec/aggexec/register.go
@@ -114,6 +114,16 @@ func RegisterApproxCountAgg(id int64) {
 	AggIdOfApproxCount = id
 }
 
+func RegisterHllAddAgg(id int64) {
+	specialAgg[id] = true
+	AggIdOfHllAdd = id
+}
+
+func RegisterHllMergeAgg(id int64) {
+	specialAgg[id] = true
+	AggIdOfHllMerge = id
+}
+
 func RegisterMedian(id int64) {
 	specialAgg[id] = true
 	AggIdOfMedian = id
@@ -222,6 +232,8 @@ var (
 	WinIdOfPercentRank     = int64(-32)
 	AggIdOfAvgTwCache      = int64(-33)
 	AggIdOfAvgTwResult     = int64(-34)
+	AggIdOfHllAdd          = int64(-35)
+	AggIdOfHllMerge        = int64(-36)
 	groupConcatSep         = ","
 	getGroupConcatRet      = func(args ...types.Type) types.Type {
 		for _, p := range args {

--- a/pkg/sql/colexec/aggexec/types.go
+++ b/pkg/sql/colexec/aggexec/types.go
@@ -190,6 +190,10 @@ func makeSpecialAggExec(
 			return makeGroupConcat(mp, id, isDistinct, params, getGroupConcatRet(params...), groupConcatSep), true, nil
 		case AggIdOfApproxCount:
 			return makeApproxCount(mp, id, params[0]), true, nil
+		case AggIdOfHllAdd:
+			return makeHllAdd(mp, id, params[0]), true, nil
+		case AggIdOfHllMerge:
+			return makeHllMerge(mp, id, params[0]), true, nil
 		case AggIdOfJsonArrayAgg:
 			exec, err := makeJsonArrayAgg(mp, id, isDistinct, params)
 			return exec, true, err

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -43,6 +43,7 @@ import (
 	"unsafe"
 
 	"github.com/RoaringBitmap/roaring/v2"
+	hll "github.com/axiomhq/hyperloglog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/system"
@@ -6310,6 +6311,16 @@ func BitmapCount(parameters []*vector.Vector, result vector.FunctionResultWrappe
 			return 0
 		}
 		return bmp.GetCardinality()
+	}, selectList)
+}
+
+func HllCardinality(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	return opUnaryBytesToFixedWithErrorCheck[uint64](parameters, result, proc, length, func(v []byte) (uint64, error) {
+		sketch := hll.NewNoSparse()
+		if err := sketch.UnmarshalBinary(v); err != nil {
+			return 0, moerr.NewInvalidInputf(proc.Ctx, "invalid HLL sketch: %v", err)
+		}
+		return sketch.Estimate(), nil
 	}, selectList)
 }
 

--- a/pkg/sql/plan/function/func_unary_test.go
+++ b/pkg/sql/plan/function/func_unary_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	hll "github.com/axiomhq/hyperloglog"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/functionUtil"
 
 	"github.com/stretchr/testify/assert"
@@ -7088,6 +7089,47 @@ func TestSHA1(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	for _, tc := range testCases {
 		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, SHA1Func)
+		s, info := fcTC.Run()
+		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
+	}
+}
+
+func TestHllCardinality(t *testing.T) {
+	sketch := hll.NewNoSparse()
+	sketch.Insert([]byte("a"))
+	sketch.Insert([]byte("b"))
+	sketch.Insert([]byte("b"))
+	data, err := sketch.MarshalBinary()
+	require.NoError(t, err)
+
+	testCases := []tcTemp{
+		{
+			info: "test hll cardinality",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varbinary.ToType(),
+					[]string{string(data), "", string(data)},
+					[]bool{false, true, false}),
+			},
+			expect: NewFunctionTestResult(types.T_uint64.ToType(), false,
+				[]uint64{2, 0, 2},
+				[]bool{false, true, false}),
+		},
+		{
+			info: "test invalid hll sketch",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varbinary.ToType(),
+					[]string{"bad"},
+					[]bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_uint64.ToType(), true,
+				[]uint64{0},
+				[]bool{false}),
+		},
+	}
+
+	proc := testutil.NewProcess(t)
+	for _, tc := range testCases {
+		fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, HllCardinality)
 		s, info := fcTC.Run()
 		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
 	}

--- a/pkg/sql/plan/function/function_id.go
+++ b/pkg/sql/plan/function/function_id.go
@@ -635,9 +635,14 @@ const (
 
 	JSON_LENGTH = 452
 
+	// hll function
+	HLL_ADD_AGG     = 453
+	HLL_MERGE_AGG   = 454
+	HLL_CARDINALITY = 455
+
 	// FUNCTION_END_NUMBER is not a function, just a flag to record the max number of function.
 	// TODO: every one should put the new function id in front of this one if you want to make a new function.
-	FUNCTION_END_NUMBER = 453
+	FUNCTION_END_NUMBER = 456
 )
 
 // functionIdRegister is what function we have registered already.
@@ -726,6 +731,8 @@ var functionIdRegister = map[string]int32{
 	"var_samp":              VAR_SAMPLE,
 	"approx_count":          APPROX_COUNT,
 	"approx_count_distinct": APPROX_COUNT_DISTINCT,
+	"hll_add_agg":           HLL_ADD_AGG,
+	"hll_merge_agg":         HLL_MERGE_AGG,
 	"any_value":             ANY_VALUE,
 	"median":                MEDIAN,
 	// count window
@@ -911,6 +918,7 @@ var functionIdRegister = map[string]int32{
 	"json_insert":                    JSON_INSERT,
 	"json_replace":                   JSON_REPLACE,
 	"json_length":                    JSON_LENGTH,
+	"hll_cardinality":                HLL_CARDINALITY,
 	"jq":                             JQ,
 	"try_jq":                         TRY_JQ,
 	"moplugin":                       WASM,

--- a/pkg/sql/plan/function/function_id_test.go
+++ b/pkg/sql/plan/function/function_id_test.go
@@ -506,7 +506,10 @@ var predefinedFunids = map[int]int{
 	ST_COVERS:                     450,
 	ST_COVEREDBY:                  451,
 	JSON_LENGTH:                   452,
-	FUNCTION_END_NUMBER:           453,
+	HLL_ADD_AGG:                   453,
+	HLL_MERGE_AGG:                 454,
+	HLL_CARDINALITY:               455,
+	FUNCTION_END_NUMBER:           456,
 }
 
 func Test_funids(t *testing.T) {

--- a/pkg/sql/plan/function/list_agg.go
+++ b/pkg/sql/plan/function/list_agg.go
@@ -618,6 +618,69 @@ var supportedAggInNewFramework = []FuncNew{
 			},
 		},
 	},
+
+	// function `HLL_ADD_AGG`
+	{
+		functionId: HLL_ADD_AGG,
+		class:      plan.Function_AGG | plan.Function_PRODUCE_NO_NULL,
+		layout:     STANDARD_FUNCTION,
+		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
+			if len(inputs) == 1 {
+				if inputs[0].Oid == types.T_any {
+					return newCheckResultWithCast(0, []types.Type{types.T_uint64.ToType()})
+				}
+				return newCheckResultWithSuccess(0)
+			}
+			return newCheckResultWithFailure(failedAggParametersWrong)
+		},
+
+		Overloads: []overload{
+			{
+				overloadId: 0,
+				isAgg:      true,
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_varbinary.ToType()
+				},
+				aggFramework: aggregationLogicOfOverload{
+					str:         "hll_add_agg",
+					aggRegister: aggexec.RegisterHllAddAgg,
+				},
+			},
+		},
+	},
+
+	// function `HLL_MERGE_AGG`
+	{
+		functionId: HLL_MERGE_AGG,
+		class:      plan.Function_AGG | plan.Function_PRODUCE_NO_NULL,
+		layout:     STANDARD_FUNCTION,
+		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
+			if len(inputs) != 1 {
+				return newCheckResultWithFailure(failedAggParametersWrong)
+			}
+			switch inputs[0].Oid {
+			case types.T_any:
+				return newCheckResultWithCast(0, []types.Type{types.T_varbinary.ToType()})
+			case types.T_binary, types.T_varbinary, types.T_blob:
+				return newCheckResultWithSuccess(0)
+			}
+			return newCheckResultWithFailure(failedAggParametersWrong)
+		},
+
+		Overloads: []overload{
+			{
+				overloadId: 0,
+				isAgg:      true,
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_varbinary.ToType()
+				},
+				aggFramework: aggregationLogicOfOverload{
+					str:         "hll_merge_agg",
+					aggRegister: aggexec.RegisterHllMergeAgg,
+				},
+			},
+		},
+	},
 }
 
 var SumSupportedTypes = []types.T{

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -11494,6 +11494,37 @@ var supportedOthersBuiltIns = []FuncNew{
 		},
 	},
 
+	// function `HLL_CARDINALITY`
+	{
+		functionId: HLL_CARDINALITY,
+		class:      plan.Function_STRICT,
+		layout:     STANDARD_FUNCTION,
+		checkFn: func(overloads []overload, inputs []types.Type) checkResult {
+			if len(inputs) != 1 {
+				return newCheckResultWithFailure(failedFunctionParametersWrong)
+			}
+			switch inputs[0].Oid {
+			case types.T_any:
+				return newCheckResultWithCast(0, []types.Type{types.T_varbinary.ToType()})
+			case types.T_binary, types.T_varbinary, types.T_blob:
+				return newCheckResultWithSuccess(0)
+			}
+			return newCheckResultWithFailure(failedFunctionParametersWrong)
+		},
+
+		Overloads: []overload{
+			{
+				overloadId: 0,
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_uint64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return HllCardinality
+				},
+			},
+		},
+	},
+
 	// function `SHA1`
 	{
 		functionId: SHA1,

--- a/test/distributed/cases/function/func_hll.result
+++ b/test/distributed/cases/function/func_hll.result
@@ -1,0 +1,26 @@
+drop table if exists hll_01;
+drop table if exists hll_daily;
+create table hll_01(dt date, user_id int);
+insert into hll_01 values ('2026-05-01', 1), ('2026-05-01', 1), ('2026-05-01', 2), ('2026-05-02', 2), ('2026-05-02', 3), ('2026-05-02', null);
+select hll_cardinality(hll_add_agg(user_id)) from hll_01;
+➤ hll_cardinality(hll_add_agg(user_id))[-5,64,0]  𝄀
+3
+select dt, hll_cardinality(hll_add_agg(user_id)) from hll_01 group by dt order by dt;
+➤ dt[91,64,0]  ¦  hll_cardinality(hll_add_agg(user_id))[-5,64,0]  𝄀
+2026-05-01  ¦  2  𝄀
+2026-05-02  ¦  2
+create table hll_daily(dt date, sketch blob);
+insert into hll_daily select dt, hll_add_agg(user_id) from hll_01 group by dt;
+select hll_cardinality(hll_merge_agg(sketch)) from hll_daily;
+➤ hll_cardinality(hll_merge_agg(sketch))[-5,64,0]  𝄀
+3
+select hll_cardinality(hll_merge_agg(null));
+➤ hll_cardinality(hll_merge_agg(null))[-5,64,0]  𝄀
+0
+select hll_cardinality(null);
+➤ hll_cardinality(null)[-5,64,0]  𝄀
+NULL
+select hll_cardinality(cast('bad' as varbinary));
+invalid input: invalid HLL sketch: too short binary
+drop table hll_daily;
+drop table hll_01;

--- a/test/distributed/cases/function/func_hll.sql
+++ b/test/distributed/cases/function/func_hll.sql
@@ -1,0 +1,18 @@
+drop table if exists hll_01;
+drop table if exists hll_daily;
+
+create table hll_01(dt date, user_id int);
+insert into hll_01 values ('2026-05-01', 1), ('2026-05-01', 1), ('2026-05-01', 2), ('2026-05-02', 2), ('2026-05-02', 3), ('2026-05-02', null);
+
+select hll_cardinality(hll_add_agg(user_id)) from hll_01;
+select dt, hll_cardinality(hll_add_agg(user_id)) from hll_01 group by dt order by dt;
+
+create table hll_daily(dt date, sketch blob);
+insert into hll_daily select dt, hll_add_agg(user_id) from hll_01 group by dt;
+select hll_cardinality(hll_merge_agg(sketch)) from hll_daily;
+select hll_cardinality(hll_merge_agg(null));
+select hll_cardinality(null);
+select hll_cardinality(cast('bad' as varbinary));
+
+drop table hll_daily;
+drop table hll_01;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23356

## What this PR does / why we need it:

This PR adds HyperLogLog sketch functions for approximate distinct counting:

- `hll_add_agg(expr)` builds a serialized HLL sketch from non-NULL input values.
- `hll_merge_agg(sketch)` merges serialized HLL sketches from `binary`/`varbinary`/`blob` inputs.
- `hll_cardinality(sketch)` returns the estimated cardinality of a serialized HLL sketch.

The current implementation stores HLL sketches as `varbinary`/`blob` values and does not add a dedicated SQL `HLL` type yet.

Validation:

- `git diff --check`
- `CGO_CFLAGS="-I$(pwd)/thirdparties/install/include" go test ./pkg/sql/colexec/aggexec -count=1`
- `CGO_CFLAGS="-I$(pwd)/thirdparties/install/include" go test ./pkg/sql/plan/function -count=1`
- `CGO_CFLAGS="-I$(pwd)/thirdparties/install/include" go test ./pkg/sql/plan -run '^$' -count=1`
- `CGO_CFLAGS="-I$(pwd)/thirdparties/install/include" go test ./pkg/sql/colexec/aggexec ./pkg/sql/plan/function -run 'TestHll|TestApproxCount|Test_funids' -count=1`
- Built `mo-service` locally and ran `test/distributed/cases/function/func_hll.sql` against a temporary MatrixOne service on port `16001`; valid HLL queries returned `3`, `2`, `2`, `3`, `0`, `NULL`, and invalid sketch input returned `invalid input: invalid HLL sketch: too short binary`.
