### PR TITLE
fix: port minimal RSS cache pressure protection to main

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -47,6 +47,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/lockservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/objectio/ioutil"
 	"github.com/matrixorigin/matrixone/pkg/partitionservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
@@ -73,6 +74,32 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
+
+const (
+	rssCacheFamilyEvictTimeout   = 10 * time.Second
+	rssCacheAdmissionPressureTTL = 2 * time.Minute
+)
+
+var (
+	evictMemoryCachesToCapacityPercent = fileservice.EvictMemoryCachesToCapacityPercent
+	evictMetaCacheToCapacityPercent    = objectio.EvictCacheToCapacityPercent
+)
+
+func makeRSSCacheEvictor(timeout time.Duration) func(context.Context, int64) {
+	return func(ctx context.Context, targetPercent int64) {
+		pressureUntil := time.Now().Add(rssCacheAdmissionPressureTTL)
+		fileservice.SetMemoryCachePressureTargetPercent(targetPercent, pressureUntil)
+		objectio.SetMetaCachePressureTargetPercent(targetPercent, pressureUntil)
+
+		memoryCtx, cancel := context.WithTimeout(ctx, timeout)
+		evictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
+		cancel()
+
+		metaCtx, cancel := context.WithTimeout(ctx, timeout)
+		evictMetaCacheToCapacityPercent(metaCtx, targetPercent)
+		cancel()
+	}
+}
 
 func NewService(
 	cfg *Config,
@@ -204,6 +231,7 @@ func NewService(
 		90.0/100.0,
 		rscthrottler.WithAcquirePolicy(rscthrottler.AcquirePolicyForCNFlushS3),
 		rscthrottler.WithRSSScavenging(),
+		rscthrottler.WithRSSCacheEvictor(makeRSSCacheEvictor(rssCacheFamilyEvictTimeout)),
 	)
 
 	srv.pu.LockService = srv.lockService

--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -91,13 +91,21 @@ func makeRSSCacheEvictor(timeout time.Duration) func(context.Context, int64) {
 		fileservice.SetMemoryCachePressureTargetPercent(targetPercent, pressureUntil)
 		objectio.SetMetaCachePressureTargetPercent(targetPercent, pressureUntil)
 
-		memoryCtx, cancel := context.WithTimeout(ctx, timeout)
-		evictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
-		cancel()
-
-		metaCtx, cancel := context.WithTimeout(ctx, timeout)
-		evictMetaCacheToCapacityPercent(metaCtx, targetPercent)
-		cancel()
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			memoryCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			evictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
+		}()
+		go func() {
+			defer wg.Done()
+			metaCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			evictMetaCacheToCapacityPercent(metaCtx, targetPercent)
+		}()
+		wg.Wait()
 	}
 }
 

--- a/pkg/cnservice/server_test.go
+++ b/pkg/cnservice/server_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -39,6 +40,65 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/util/address"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
+
+func TestMakeRSSCacheEvictorRunsCacheFamiliesConcurrently(t *testing.T) {
+	oldMemoryEvictor := evictMemoryCachesToCapacityPercent
+	oldMetaEvictor := evictMetaCacheToCapacityPercent
+	defer func() {
+		evictMemoryCachesToCapacityPercent = oldMemoryEvictor
+		evictMetaCacheToCapacityPercent = oldMetaEvictor
+	}()
+
+	memoryStarted := make(chan struct{})
+	releaseMemory := make(chan struct{})
+	metaStarted := make(chan struct{})
+
+	evictMemoryCachesToCapacityPercent = func(ctx context.Context, targetPercent int64) map[string]int64 {
+		close(memoryStarted)
+		select {
+		case <-releaseMemory:
+		case <-ctx.Done():
+		}
+		return nil
+	}
+	evictMetaCacheToCapacityPercent = func(ctx context.Context, targetPercent int64) int64 {
+		close(metaStarted)
+		return 0
+	}
+
+	done := make(chan struct{})
+	go func() {
+		makeRSSCacheEvictor(time.Second)(context.Background(), 50)
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-memoryStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool {
+		select {
+		case <-metaStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	close(releaseMemory)
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
 
 func Test_InitServer(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -247,11 +247,13 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 		zap.String("detail", m.String()),
 	)
 	if shouldEvictCache {
+		evictor := m.options.rssCacheEvictor
+		free := freeOSMemory
 		go func(targetPercent int64) {
 			evictCtx, cancel := context.WithTimeout(context.Background(), rssCacheEvictTimeout)
 			defer cancel()
-			m.options.rssCacheEvictor(evictCtx, targetPercent)
-			freeOSMemory()
+			evictor(evictCtx, targetPercent)
+			free()
 		}(cacheTargetPercent)
 	}
 	if shouldFreeOSMemory {

--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -15,10 +15,12 @@
 package rscthrottler
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
 	"runtime/debug"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
 	"github.com/matrixorigin/matrixone/pkg/objectio"
+	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/common"
 	"github.com/shirou/gopsutil/v3/process"
 	"go.uber.org/zap"
@@ -34,8 +37,13 @@ import (
 const (
 	refreshMaxInterval     = time.Second * 10
 	rssScavengeInterval    = time.Minute
+	rssCacheEvictTimeout   = time.Second * 10
 	rssScavengeTriggerRate = 0.85
 	rssScavengeVisibleRate = 0.70
+	rssCacheEvictSoftRate  = 0.85
+	rssCacheEvictHardRate  = 0.92
+	rssCacheSoftTarget     = int64(80)
+	rssCacheHardTarget     = int64(50)
 
 	MemoryThrottlerLogHeader = "MemoryThrottler"
 )
@@ -64,8 +72,11 @@ type memThrottler struct {
 	name      string
 	limitRate float64
 
-	lastRefresh     atomic.Int64
-	lastRSSScavenge atomic.Int64
+	lastRefresh        atomic.Int64
+	lastRSSScavenge    atomic.Int64
+	lastRSSCacheEvict  atomic.Int64
+	lastRSSCacheTarget atomic.Int64
+	rssScavengeMu      sync.Mutex
 
 	mergeAvailDebounce atomic.Int64
 
@@ -81,6 +92,7 @@ type memThrottler struct {
 		specializedForMerge bool
 
 		enableRSSScavenging bool
+		rssCacheEvictor     func(ctx context.Context, targetPercent int64)
 	}
 }
 
@@ -189,24 +201,62 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 	if visible < 0 {
 		visible = 0
 	}
-	if float64(visible) >= float64(rss)*rssScavengeVisibleRate {
+	needFreeOSMemory := float64(visible) < float64(rss)*rssScavengeVisibleRate
+	cacheTargetPercent := int64(0)
+	if float64(rss) >= float64(actualMaxMemory)*rssCacheEvictHardRate {
+		cacheTargetPercent = rssCacheHardTarget
+	} else if float64(rss) >= float64(actualMaxMemory)*rssCacheEvictSoftRate {
+		cacheTargetPercent = rssCacheSoftTarget
+	}
+
+	shouldEvictCache := false
+	if cacheTargetPercent > 0 && m.options.rssCacheEvictor != nil {
+		m.rssScavengeMu.Lock()
+		lastCacheEvict := m.lastRSSCacheEvict.Load()
+		lastTarget := m.lastRSSCacheTarget.Load()
+		cacheEvictExpired := time.Duration(now-lastCacheEvict) > rssScavengeInterval
+		cacheEvictEscalated := lastTarget == 0 || cacheTargetPercent < lastTarget
+		if cacheEvictExpired || cacheEvictEscalated {
+			m.lastRSSCacheEvict.Store(now)
+			m.lastRSSCacheTarget.Store(cacheTargetPercent)
+			shouldEvictCache = true
+		}
+		m.rssScavengeMu.Unlock()
+	}
+
+	shouldFreeOSMemory := false
+	if needFreeOSMemory {
+		last := m.lastRSSScavenge.Load()
+		if time.Duration(now-last) > rssScavengeInterval &&
+			m.lastRSSScavenge.CompareAndSwap(last, now) {
+			shouldFreeOSMemory = true
+		}
+	}
+	if !shouldFreeOSMemory && !shouldEvictCache {
 		return
 	}
-	last := m.lastRSSScavenge.Load()
-	if time.Duration(now-last) <= rssScavengeInterval {
-		return
-	}
-	if !m.lastRSSScavenge.CompareAndSwap(last, now) {
-		return
-	}
+	metric.FSCachePressureTriggerCounter.Inc()
 	logutil.Info(
 		fmt.Sprintf("%s-RSSScavenge", MemoryThrottlerLogHeader),
 		zap.String("rss", common.HumanReadableBytes(int(rss))),
 		zap.String("visible", common.HumanReadableBytes(int(visible))),
 		zap.String("actual-total-memory", common.HumanReadableBytes(int(actualMaxMemory))),
+		zap.Bool("free-os-memory", shouldFreeOSMemory),
+		zap.Bool("evict-cache", shouldEvictCache),
+		zap.Int64("cache-target-percent", cacheTargetPercent),
 		zap.String("detail", m.String()),
 	)
-	freeOSMemory()
+	if shouldEvictCache {
+		go func(targetPercent int64) {
+			evictCtx, cancel := context.WithTimeout(context.Background(), rssCacheEvictTimeout)
+			defer cancel()
+			m.options.rssCacheEvictor(evictCtx, targetPercent)
+			freeOSMemory()
+		}(cacheTargetPercent)
+	}
+	if shouldFreeOSMemory {
+		freeOSMemory()
+	}
 }
 
 /*
@@ -370,6 +420,12 @@ func WithSpecializedForMerge() MemThrottlerOption {
 func WithRSSScavenging() MemThrottlerOption {
 	return func(throttler *memThrottler) {
 		throttler.options.enableRSSScavenging = true
+	}
+}
+
+func WithRSSCacheEvictor(evictor func(ctx context.Context, targetPercent int64)) MemThrottlerOption {
+	return func(throttler *memThrottler) {
+		throttler.options.rssCacheEvictor = evictor
 	}
 }
 

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -15,6 +15,7 @@
 package rscthrottler
 
 import (
+	"context"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -193,6 +194,123 @@ func TestMemThrottlerRSSScavenging(t *testing.T) {
 
 	throttler.tryScavengeRSS(now+int64(time.Second), 900*mpool.GB)
 	require.Equal(t, int32(1), calls.Load())
+}
+
+func TestMemThrottlerRSSCacheEvictionByRSSRate(t *testing.T) {
+	oldFreeOSMemory := freeOSMemory
+	defer func() { freeOSMemory = oldFreeOSMemory }()
+
+	var freeCalls atomic.Int32
+	freeOSMemory = func() {
+		freeCalls.Add(1)
+	}
+
+	targets := make(chan int64, 4)
+	now := time.Now().UnixNano()
+	throttler := &memThrottler{limitRate: 0.90}
+	throttler.options.enableRSSScavenging = true
+	throttler.options.rssCacheEvictor = func(_ context.Context, targetPercent int64) {
+		targets <- targetPercent
+	}
+	throttler.actualTotalMemory.Store(1000 * mpool.GB)
+	throttler.limit.Store(900 * mpool.GB)
+	throttler.reserved.Store(800 * mpool.GB)
+	throttler.lastRSSScavenge.Store(now - int64(rssScavengeInterval) - int64(time.Second))
+
+	throttler.tryScavengeRSS(now, 840*mpool.GB)
+	select {
+	case target := <-targets:
+		t.Fatalf("unexpected cache evict target %d", target)
+	default:
+	}
+	require.Equal(t, int32(0), freeCalls.Load())
+
+	throttler.tryScavengeRSS(now+int64(time.Second), 850*mpool.GB)
+	require.Eventually(t, func() bool {
+		return recvTarget(targets) == rssCacheSoftTarget
+	}, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool {
+		return freeCalls.Load() == 1
+	}, time.Second, time.Millisecond)
+
+	throttler.tryScavengeRSS(now+2*int64(time.Second), 920*mpool.GB)
+	require.Eventually(t, func() bool {
+		return recvTarget(targets) == rssCacheHardTarget
+	}, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool {
+		return freeCalls.Load() == 2
+	}, time.Second, time.Millisecond)
+
+	throttler.tryScavengeRSS(now+3*int64(time.Second), 920*mpool.GB)
+	select {
+	case target := <-targets:
+		t.Fatalf("unexpected duplicate cache evict target %d", target)
+	default:
+	}
+	require.Equal(t, int64(rssCacheHardTarget), throttler.lastRSSCacheTarget.Load())
+}
+
+func TestMemThrottlerRSSCacheEvictionConcurrentEscalation(t *testing.T) {
+	oldFreeOSMemory := freeOSMemory
+	defer func() { freeOSMemory = oldFreeOSMemory }()
+
+	var freeCalls atomic.Int32
+	freeOSMemory = func() {
+		freeCalls.Add(1)
+	}
+
+	var minTarget atomic.Int64
+	minTarget.Store(100)
+
+	now := time.Now().UnixNano()
+	throttler := &memThrottler{limitRate: 0.90}
+	throttler.options.enableRSSScavenging = true
+	throttler.options.rssCacheEvictor = func(_ context.Context, targetPercent int64) {
+		for {
+			old := minTarget.Load()
+			if targetPercent >= old || minTarget.CompareAndSwap(old, targetPercent) {
+				return
+			}
+		}
+	}
+	throttler.actualTotalMemory.Store(1000 * mpool.GB)
+	throttler.limit.Store(900 * mpool.GB)
+	throttler.reserved.Store(800 * mpool.GB)
+	throttler.lastRSSScavenge.Store(now - int64(rssScavengeInterval) - int64(time.Second))
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		throttler.tryScavengeRSS(now, 850*mpool.GB)
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		throttler.tryScavengeRSS(now, 920*mpool.GB)
+	}()
+
+	close(start)
+	wg.Wait()
+
+	require.Eventually(t, func() bool {
+		return minTarget.Load() == rssCacheHardTarget
+	}, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool {
+		return freeCalls.Load() >= 1
+	}, time.Second, time.Millisecond)
+	require.Equal(t, int64(rssCacheHardTarget), throttler.lastRSSCacheTarget.Load())
+}
+
+func recvTarget(ch <-chan int64) int64 {
+	select {
+	case target := <-ch:
+		return target
+	default:
+		return 0
+	}
 }
 
 func TestMemThrottlerRSSScavengingDisabled(t *testing.T) {

--- a/pkg/fileservice/bytes.go
+++ b/pkg/fileservice/bytes.go
@@ -107,16 +107,16 @@ type cacheCapacityGuardedAllocator struct {
 var _ CacheDataAllocator = cacheCapacityGuardedAllocator{}
 
 func (c cacheCapacityGuardedAllocator) AllocateCacheData(ctx context.Context, size int) fscache.Data {
-	c.cache.EnsureNBytes(ctx, size)
+	c.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	return c.allocator.AllocateCacheData(ctx, size)
 }
 
 func (c cacheCapacityGuardedAllocator) AllocateCacheDataWithHint(ctx context.Context, size int, hints malloc.Hints) fscache.Data {
-	c.cache.EnsureNBytes(ctx, size)
+	c.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	return c.allocator.AllocateCacheDataWithHint(ctx, size, hints)
 }
 
 func (c cacheCapacityGuardedAllocator) CopyToCacheData(ctx context.Context, data []byte) fscache.Data {
-	c.cache.EnsureNBytes(ctx, len(data))
+	c.cache.EnsureNBytes(withoutEventLogger(ctx), len(data))
 	return c.allocator.CopyToCacheData(ctx, data)
 }

--- a/pkg/fileservice/cache.go
+++ b/pkg/fileservice/cache.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/gossip"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/query"
 	"github.com/matrixorigin/matrixone/pkg/queryservice/client"
+	metric "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/util/toml"
 )
 
@@ -202,6 +203,51 @@ func EvictMemoryCaches(ctx context.Context) map[string]int64 {
 		logutil.Info("memory cache forced evicted",
 			zap.Any("name", name),
 			zap.Any("target", target),
+		)
+
+		return true
+	})
+
+	return ret
+}
+
+func EvictMemoryCachesToCapacityPercent(ctx context.Context, percent int64) map[string]int64 {
+	ret := make(map[string]int64)
+
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+
+	allMemoryCaches.Range(func(k, v any) bool {
+		cache := k.(*MemCache)
+		name := v.(string)
+		capacity := cache.cache.Capacity()
+		target := capacity * percent / 100
+		beforeUsed := cache.cache.Used()
+		start := time.Now()
+		logutil.Info("memory cache pressure evict begin",
+			zap.Any("name", name),
+			zap.Int64("used-before", beforeUsed),
+			zap.Int64("capacity", capacity),
+			zap.Int64("target", target),
+			zap.Int64("target-percent", percent),
+		)
+		used := cache.EvictToCapacityPercent(ctx, percent)
+		metric.FSCachePressureMemoryEvictCounter.Inc()
+		metric.FSCachePressureMemoryEvictDuration.Observe(time.Since(start).Seconds())
+		ret[name] = used
+		logutil.Info("memory cache pressure evicted",
+			zap.Any("name", name),
+			zap.Int64("used-before", beforeUsed),
+			zap.Int64("used-after", used),
+			zap.Int64("capacity", capacity),
+			zap.Int64("target", target),
+			zap.Int64("target-percent", percent),
+			zap.Duration("duration", time.Since(start)),
+			zap.Error(ctx.Err()),
 		)
 
 		return true

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -913,3 +913,5 @@ func (*countingDataCache) DeletePaths(context.Context, []string) {}
 func (*countingDataCache) Flush(context.Context) {}
 
 func (*countingDataCache) Evict(context.Context, chan int64) {}
+
+func (*countingDataCache) EvictToTargetWithWait(context.Context, int64) int64 { return 0 }

--- a/pkg/fileservice/event_logger.go
+++ b/pkg/fileservice/event_logger.go
@@ -26,11 +26,14 @@ import (
 )
 
 type eventLogger struct {
-	begin  time.Time
-	mu     sync.Mutex
-	events *[]event
-	closed bool
+	begin   time.Time
+	mu      sync.Mutex
+	events  *[]event
+	dropped int
+	closed  bool
 }
+
+const maxEventLoggerEvents = 1024
 
 type event struct {
 	time  time.Duration
@@ -61,17 +64,28 @@ func WithEventLogger(ctx context.Context) context.Context {
 
 func LogEvent(ctx context.Context, ev stringRef, args ...any) {
 	v := ctx.Value(EventLoggerKey)
-	if v == nil {
+	logger, ok := v.(*eventLogger)
+	if !ok || logger == nil {
 		return
 	}
-	logger := v.(*eventLogger)
 	logger.emit(ev, args...)
+}
+
+func withoutEventLogger(ctx context.Context) context.Context {
+	if ctx.Value(EventLoggerKey) == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, EventLoggerKey, nil)
 }
 
 func (e *eventLogger) emit(ev stringRef, args ...any) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.closed {
+		return
+	}
+	if len(*e.events) >= maxEventLoggerEvents {
+		e.dropped++
 		return
 	}
 	*e.events = append(*e.events, event{})
@@ -99,7 +113,9 @@ func LogSlowEvent(ctx context.Context, threshold time.Duration) {
 			}
 		}
 		*logger.events = events[:0]
-		eventsPool.Put(logger.events)
+		if cap(*logger.events) <= maxEventLoggerEvents {
+			eventsPool.Put(logger.events)
+		}
 		logger.events = nil
 		logger.closed = true
 		logger.mu.Unlock()
@@ -129,6 +145,7 @@ func LogSlowEvent(ctx context.Context, threshold time.Duration) {
 
 	logutil.Info("slow event",
 		zap.String("events", buf.String()),
+		zap.Int("dropped-events", logger.dropped),
 	)
 }
 

--- a/pkg/fileservice/event_logger_test.go
+++ b/pkg/fileservice/event_logger_test.go
@@ -57,6 +57,49 @@ func TestEventLoggerPoolCleanup(t *testing.T) {
 	}
 }
 
+func TestEventLoggerDropsAfterLimit(t *testing.T) {
+	ctx := WithEventLogger(context.Background())
+	logger := ctx.Value(EventLoggerKey).(*eventLogger)
+
+	for i := 0; i < maxEventLoggerEvents+7; i++ {
+		LogEvent(ctx, str_to_cache_data_begin, i)
+	}
+
+	logger.mu.Lock()
+	if n := len(*logger.events); n != maxEventLoggerEvents {
+		t.Fatalf("got %d events, want %d", n, maxEventLoggerEvents)
+	}
+	if logger.dropped != 7 {
+		t.Fatalf("got %d dropped events, want 7", logger.dropped)
+	}
+	logger.mu.Unlock()
+
+	LogSlowEvent(ctx, time.Hour)
+}
+
+func TestWithoutEventLogger(t *testing.T) {
+	ctx := WithEventLogger(context.Background())
+	logger := ctx.Value(EventLoggerKey).(*eventLogger)
+
+	child := withoutEventLogger(ctx)
+	LogEvent(child, str_to_cache_data_begin)
+
+	logger.mu.Lock()
+	if n := len(*logger.events); n != 0 {
+		t.Fatalf("got %d parent events after child log, want 0", n)
+	}
+	logger.mu.Unlock()
+
+	LogEvent(ctx, str_to_cache_data_begin)
+	logger.mu.Lock()
+	if n := len(*logger.events); n != 1 {
+		t.Fatalf("got %d parent events after parent log, want 1", n)
+	}
+	logger.mu.Unlock()
+
+	LogSlowEvent(ctx, time.Hour)
+}
+
 func BenchmarkEventLogger(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ctx := context.Background()

--- a/pkg/fileservice/fifocache/data_cache.go
+++ b/pkg/fileservice/fifocache/data_cache.go
@@ -49,6 +49,10 @@ func NewDataCacheWithPrepareSet(
 	}
 }
 
+func (d *DataCache) SetAdmissionTarget(admissionTarget func(capacity int64) (int64, bool)) {
+	d.fifo.SetAdmissionTarget(admissionTarget)
+}
+
 var seed = maphash.MakeSeed()
 
 func shardCacheKey(key fscache.CacheKey) uint64 {
@@ -108,7 +112,7 @@ func (d *DataCache) EnsureNBytes(ctx context.Context, want int) {
 	used := d.Used()
 	capacity := d.Capacity()
 	if used+int64(want) > capacity {
-		d.fifo.EvictWithWait(ctx, int64(want))
+		_ = d.fifo.EvictWithWait(ctx, int64(want))
 	} else {
 		d.fifo.Evict(ctx, nil, int64(want))
 	}
@@ -116,6 +120,14 @@ func (d *DataCache) EnsureNBytes(ctx context.Context, want int) {
 
 func (d *DataCache) Evict(ctx context.Context, ch chan int64) {
 	d.fifo.Evict(ctx, ch, 0)
+}
+
+func (d *DataCache) EvictToTargetWithWait(ctx context.Context, target int64) int64 {
+	return d.fifo.EvictToTargetWithWait(ctx, target)
+}
+
+func (d *DataCache) ForceEvictWithWait(ctx context.Context, n int64) int64 {
+	return d.fifo.ForceEvictWithWait(ctx, n)
 }
 
 func (d *DataCache) Flush(ctx context.Context) {

--- a/pkg/fileservice/fifocache/fifo.go
+++ b/pkg/fileservice/fifocache/fifo.go
@@ -24,13 +24,18 @@ import (
 	"golang.org/x/sys/cpu"
 )
 
-const numShards = 256
+const (
+	numShards               = 256
+	pressureEvictBatchItems = 64
+	pressureEvictBatchBytes = 64 << 20
+)
 
 // Cache implements an in-memory cache with FIFO-based eviction
 type Cache[K comparable, V any] struct {
-	capacity     fscache.CapacityFunc
-	capacity1    fscache.CapacityFunc
-	keyShardFunc func(K) uint64
+	capacity        fscache.CapacityFunc
+	capacity1       fscache.CapacityFunc
+	keyShardFunc    func(K) uint64
+	admissionTarget func(capacity int64) (int64, bool)
 
 	prepareSet func(ctx context.Context, key K, value V, size int64, seq uint64) func(inserted bool)
 	postSet    func(ctx context.Context, key K, value V, size int64, seq uint64)
@@ -141,7 +146,11 @@ func NewWithPrepareSet[K comparable, V any](
 	return ret
 }
 
-func (c *Cache[K, V]) set(ctx context.Context, key K, value V, size int64, seq uint64) (item *_CacheItem[K, V], ghostItemSet bool) {
+func (c *Cache[K, V]) SetAdmissionTarget(admissionTarget func(capacity int64) (int64, bool)) {
+	c.admissionTarget = admissionTarget
+}
+
+func (c *Cache[K, V]) set(ctx context.Context, key K, value V, size int64, seq uint64) (item *_CacheItem[K, V], replacedGhost *_CacheItem[K, V]) {
 	shard := &c.shards[c.keyShardFunc(key)%numShards]
 	shard.Lock()
 	defer shard.Unlock()
@@ -161,11 +170,11 @@ func (c *Cache[K, V]) set(ctx context.Context, key K, value V, size int64, seq u
 			}
 			// replacing the oldItem. oldItem will be evicted from ghost queue eventually.
 			shard.values[key] = item
-			return item, true
+			return item, oldItem
 		}
 
 		// existed and value ok, skip set
-		return nil, false
+		return nil, nil
 	}
 
 	item = &_CacheItem[K, V]{
@@ -177,7 +186,7 @@ func (c *Cache[K, V]) set(ctx context.Context, key K, value V, size int64, seq u
 	}
 	shard.values[key] = item
 
-	return item, false
+	return item, nil
 }
 
 func (c *Cache[K, V]) Set(ctx context.Context, key K, value V, size int64) {
@@ -193,7 +202,28 @@ func (c *Cache[K, V]) Set(ctx context.Context, key K, value V, size int64) {
 			finishSet(inserted)
 		}
 	}()
-	if item, ghostItemSet := c.set(ctx, key, value, size, seq); item != nil {
+	if item, replacedGhost := c.set(ctx, key, value, size, seq); item != nil {
+		ghostItemSet := replacedGhost != nil
+		if c.shouldApplyAdmissionTarget() {
+			if !c.enqueueWithAdmission(item, ghostItemSet) {
+				inserted = c.rollbackRejectedSet(item, replacedGhost)
+				if finishSet != nil {
+					finishSet(inserted)
+					finished = true
+				}
+				return
+			}
+			inserted = true
+			if c.postSet != nil {
+				c.postSet(ctx, key, value, size, item.seq)
+			}
+			if finishSet != nil {
+				finishSet(true)
+				finished = true
+			}
+			c.Evict(ctx, nil, 0)
+			return
+		}
 		inserted = true
 		if c.postSet != nil {
 			c.postSet(ctx, key, value, size, item.seq)
@@ -209,6 +239,66 @@ func (c *Cache[K, V]) Set(ctx context.Context, key K, value V, size int64) {
 		finishSet(false)
 		finished = true
 	}
+}
+
+func (c *Cache[K, V]) shouldApplyAdmissionTarget() bool {
+	_, ok := c.currentAdmissionTarget()
+	return ok
+}
+
+func (c *Cache[K, V]) currentAdmissionTarget() (int64, bool) {
+	if c.admissionTarget == nil {
+		return 0, false
+	}
+	return c.admissionTarget(c.capacity())
+}
+
+func (c *Cache[K, V]) enqueueWithAdmission(item *_CacheItem[K, V], ghostItemSet bool) bool {
+	c.queueLock.Lock()
+	defer c.queueLock.Unlock()
+
+	c.helpEnqueue()
+
+	queue := cacheItemQueue1
+	if ghostItemSet {
+		queue = cacheItemQueue2
+	}
+
+	target, ok := c.currentAdmissionTarget()
+	if !ok {
+		c.enqueuePendingItem(item, queue)
+		c.helpEnqueue()
+		return item.queue == queue
+	}
+	if c.used1+c.used2+item.size > target {
+		return false
+	}
+
+	c.enqueuePendingItem(item, queue)
+	c.helpEnqueue()
+	return item.queue == queue
+}
+
+func (c *Cache[K, V]) rollbackRejectedSet(item, replacedGhost *_CacheItem[K, V]) (finishInserted bool) {
+	shard := &c.shards[c.keyShardFunc(item.key)%numShards]
+	shard.Lock()
+	defer shard.Unlock()
+
+	if !item.valueOK {
+		return true
+	}
+
+	if shard.values[item.key] == item {
+		if replacedGhost != nil && replacedGhost.queue == cacheItemGhost {
+			shard.values[item.key] = replacedGhost
+		} else {
+			delete(shard.values, item.key)
+		}
+	}
+	item.valueOK = false
+	var zero V
+	item.value = zero
+	return false
 }
 
 func (c *Cache[K, V]) enqueue(item *_CacheItem[K, V], ghostItemSet bool) {
@@ -467,51 +557,122 @@ func (c *Cache[K, V]) ForceEvict(ctx context.Context, n int64) {
 	c.Evict(ctx, nil, capacityCut)
 }
 
+// ForceEvictWithWait evicts n bytes despite capacity and waits for callbacks.
+func (c *Cache[K, V]) ForceEvictWithWait(ctx context.Context, n int64) int64 {
+	if n <= 0 {
+		return c.used()
+	}
+	target := c.used() - n
+	if target < 0 {
+		target = 0
+	}
+	return c.EvictToTargetWithWait(ctx, target)
+}
+
+func (c *Cache[K, V]) EvictToTargetWithWait(ctx context.Context, target int64) int64 {
+	if target < 0 {
+		target = 0
+	}
+	capacity := c.capacity()
+	if target > capacity {
+		target = capacity
+	}
+	return c.evictWithWait(ctx, capacity-target, false)
+}
+
 // EvictWithWait is like Evict but blocks until the eviction lock is acquired,
 // guaranteeing that eviction actually runs before returning. This is used by
 // EnsureNBytes to prevent unbounded memory growth under high concurrency where
-// TryLock-based Evict would skip eviction entirely.
-func (c *Cache[K, V]) EvictWithWait(ctx context.Context, capacityCut int64) {
-	c.queueLock.Lock()
-	var pendingPostEvicts []_PendingPostEvict[K, V]
-	defer func() {
-		c.queueLock.Unlock()
-		if c.postEvict != nil {
-			for i := range pendingPostEvicts {
-				c.postEvictItem(ctx, pendingPostEvicts[i], true)
-				pendingPostEvicts[i] = _PendingPostEvict[K, V]{}
-			}
-		}
-	}()
+// TryLock-based Evict would skip eviction entirely. It returns actual used
+// bytes after eviction stops.
+func (c *Cache[K, V]) EvictWithWait(ctx context.Context, capacityCut int64) int64 {
+	return c.evictWithWait(ctx, capacityCut, false)
+}
 
+func (c *Cache[K, V]) evictWithWait(ctx context.Context, capacityCut int64, includeAsyncDebt bool) int64 {
+	if capacityCut < 0 {
+		capacityCut = 0
+	}
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return c.used()
 		default:
 		}
-		c.helpEnqueue()
-		globalCapacityCut := c.capacityCut.Swap(0)
-		target := c.capacity() - capacityCut - globalCapacityCut
+		pendingPostEvicts, used, evicted := c.evictBatch(&capacityCut, includeAsyncDebt)
+		c.runPendingPostEvicts(ctx, pendingPostEvicts)
+		target := c.capacity() - capacityCut
 		if target < 0 {
 			target = 0
 		}
-		if c.used1+c.used2 <= target {
-			break
+		if used <= target || !evicted {
+			return used
 		}
-		target1 := c.capacity1() - capacityCut - globalCapacityCut
+	}
+}
+
+func (c *Cache[K, V]) evictBatch(capacityCut *int64, includeAsyncDebt bool) (pending []_PendingPostEvict[K, V], used int64, evicted bool) {
+	c.queueLock.Lock()
+	defer c.queueLock.Unlock()
+
+	var (
+		pendingBytes int64
+		pendingCount int
+	)
+
+	for {
+		c.helpEnqueue()
+		if includeAsyncDebt {
+			*capacityCut += c.capacityCut.Swap(0)
+		}
+		target := c.capacity() - *capacityCut
+		if target < 0 {
+			target = 0
+		}
+		used = c.used1 + c.used2
+		if used <= target {
+			return pending, used, evicted
+		}
+		target1 := c.capacity1() - *capacityCut
 		if target1 < 0 {
 			target1 = 0
 		}
+		var (
+			used1Before int64
+			pe          _PendingPostEvict[K, V]
+			ok          bool
+		)
 		if c.used1 > target1 {
-			if pe, ok := c.evict1(); ok {
-				pendingPostEvicts = append(pendingPostEvicts, pe)
-			}
+			used1Before = c.used1
+			pe, ok = c.evict1()
 		} else {
-			if pe, ok := c.evict2(); ok {
-				pendingPostEvicts = append(pendingPostEvicts, pe)
-			}
+			pe, ok = c.evict2()
 		}
+		if !ok {
+			if used1Before > 0 && c.used1 != used1Before {
+				continue
+			}
+			return pending, c.used1 + c.used2, evicted
+		}
+		evicted = true
+		pendingCount++
+		pendingBytes += pe.size
+		if c.postEvict != nil {
+			pending = append(pending, pe)
+		}
+		if pendingCount >= pressureEvictBatchItems || pendingBytes >= pressureEvictBatchBytes {
+			return pending, c.used1 + c.used2, evicted
+		}
+	}
+}
+
+func (c *Cache[K, V]) runPendingPostEvicts(ctx context.Context, pendingPostEvicts []_PendingPostEvict[K, V]) {
+	if c.postEvict == nil {
+		return
+	}
+	for i := range pendingPostEvicts {
+		c.postEvictItem(ctx, pendingPostEvicts[i], true)
+		pendingPostEvicts[i] = _PendingPostEvict[K, V]{}
 	}
 }
 
@@ -519,6 +680,14 @@ func (c *Cache[K, V]) used() int64 {
 	c.queueLock.RLock()
 	defer c.queueLock.RUnlock()
 	return c.used1 + c.used2
+}
+
+func (c *Cache[K, V]) Used() int64 {
+	return c.used()
+}
+
+func (c *Cache[K, V]) Capacity() int64 {
+	return c.capacity()
 }
 
 func (c *Cache[K, V]) evict1() (pe _PendingPostEvict[K, V], evicted bool) {

--- a/pkg/fileservice/fifocache/fifo_test.go
+++ b/pkg/fileservice/fifocache/fifo_test.go
@@ -16,6 +16,7 @@ package fifocache
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -187,6 +188,39 @@ func TestEvictWithWaitReturnsWhenContextCanceled(t *testing.T) {
 	}
 }
 
+func TestCachePressureAdmissionIsAtomic(t *testing.T) {
+	cache := New[int, int](
+		fscache.ConstCapacity(100),
+		ShardInt[int],
+		nil, nil, nil,
+	)
+	cache.SetAdmissionTarget(func(capacity int64) (int64, bool) {
+		return 50, true
+	})
+
+	ctx := t.Context()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cache.Set(ctx, i, i, 1)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(50), cache.used())
+
+	live := 0
+	for i := 0; i < 100; i++ {
+		_, ok := cache.Get(ctx, i)
+		if ok {
+			live++
+		}
+	}
+	assert.Equal(t, 50, live)
+}
+
 func TestReplaceUpdatesUsedBytes(t *testing.T) {
 	cache := New[int, int](
 		fscache.ConstCapacity(20),
@@ -314,6 +348,64 @@ func TestDirectEnqueueSkipsDeletedItem(t *testing.T) {
 
 	assert.Equal(t, int64(0), cache.used())
 	assert.False(t, cache.Contains(1))
+}
+
+func TestEvictToTargetWithWaitReturnsActualUsedOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	itemSize := int64(pressureEvictBatchBytes + 1)
+	var evicted atomic.Int32
+	cache := New(
+		fscache.ConstCapacity(3*itemSize),
+		ShardInt[int],
+		nil,
+		nil,
+		func(context.Context, int, int, int64, uint64) {
+			if evicted.Add(1) == 1 {
+				cancel()
+			}
+		},
+	)
+	cache.Set(context.Background(), 1, 1, itemSize)
+	cache.Set(context.Background(), 2, 2, itemSize)
+	cache.Set(context.Background(), 3, 3, itemSize)
+
+	used := cache.EvictToTargetWithWait(ctx, 0)
+
+	assert.Equal(t, int64(2*itemSize), used)
+	assert.Equal(t, used, cache.used())
+	assert.Equal(t, int32(1), evicted.Load())
+}
+
+func TestEvictToTargetWithWaitEvictsHotItemsAfterPromotion(t *testing.T) {
+	ctx := context.Background()
+	cache := New[int, int](fscache.ConstCapacity(3), ShardInt[int], nil, nil, nil)
+
+	cache.Set(ctx, 1, 1, 1)
+	cache.Set(ctx, 2, 2, 1)
+	cache.Set(ctx, 3, 3, 1)
+
+	_, ok := cache.Get(ctx, 1)
+	assert.True(t, ok)
+	_, ok = cache.Get(ctx, 1)
+	assert.True(t, ok)
+	_, ok = cache.Get(ctx, 2)
+	assert.True(t, ok)
+	_, ok = cache.Get(ctx, 2)
+	assert.True(t, ok)
+	_, ok = cache.Get(ctx, 3)
+	assert.True(t, ok)
+	_, ok = cache.Get(ctx, 3)
+	assert.True(t, ok)
+
+	used := cache.EvictToTargetWithWait(ctx, 0)
+
+	assert.Equal(t, int64(0), used)
+	assert.Equal(t, int64(0), cache.used())
+	assert.False(t, cache.Contains(1))
+	assert.False(t, cache.Contains(2))
+	assert.False(t, cache.Contains(3))
 }
 
 // TestPostEvictRunsOutsideQueueLock verifies that postEvict callbacks execute

--- a/pkg/fileservice/fscache/data_cache.go
+++ b/pkg/fileservice/fscache/data_cache.go
@@ -31,4 +31,5 @@ type DataCache interface {
 	DeletePaths(context.Context, []string)
 	Flush(ctx context.Context)
 	Evict(ctx context.Context, done chan int64)
+	EvictToTargetWithWait(ctx context.Context, target int64) int64
 }

--- a/pkg/fileservice/local_fs.go
+++ b/pkg/fileservice/local_fs.go
@@ -121,21 +121,21 @@ func NewLocalFS(
 
 func (l *LocalFS) AllocateCacheData(ctx context.Context, size int) fscache.Data {
 	if l.memCache != nil {
-		l.memCache.cache.EnsureNBytes(ctx, size)
+		l.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	}
 	return DefaultCacheDataAllocator().AllocateCacheData(ctx, size)
 }
 
 func (l *LocalFS) AllocateCacheDataWithHint(ctx context.Context, size int, hints malloc.Hints) fscache.Data {
 	if l.memCache != nil {
-		l.memCache.cache.EnsureNBytes(ctx, size)
+		l.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	}
 	return DefaultCacheDataAllocator().AllocateCacheDataWithHint(ctx, size, hints)
 }
 
 func (l *LocalFS) CopyToCacheData(ctx context.Context, data []byte) fscache.Data {
 	if l.memCache != nil {
-		l.memCache.cache.EnsureNBytes(ctx, len(data))
+		l.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), len(data))
 	}
 	return DefaultCacheDataAllocator().CopyToCacheData(ctx, data)
 }

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"hash/maphash"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/util"
 	"github.com/matrixorigin/matrixone/pkg/fileservice/fifocache"
@@ -33,6 +35,57 @@ type MemCache struct {
 }
 
 var memCacheCallbackSeed = maphash.MakeSeed()
+
+var (
+	memCachePressureMu            sync.Mutex
+	memCachePressureTargetPercent atomic.Int64
+	memCachePressureDeadline      atomic.Int64
+)
+
+func SetMemoryCachePressureTargetPercent(percent int64, until time.Time) {
+	now := time.Now()
+	if percent <= 0 || !until.After(now) {
+		memCachePressureMu.Lock()
+		memCachePressureTargetPercent.Store(0)
+		memCachePressureDeadline.Store(0)
+		memCachePressureMu.Unlock()
+		return
+	}
+	if percent > 100 {
+		percent = 100
+	}
+
+	memCachePressureMu.Lock()
+	defer memCachePressureMu.Unlock()
+
+	oldDeadline := memCachePressureDeadline.Load()
+	oldPercent := memCachePressureTargetPercent.Load()
+	if oldDeadline > now.UnixNano() && oldPercent > 0 && oldPercent < percent {
+		return
+	}
+	memCachePressureTargetPercent.Store(percent)
+	memCachePressureDeadline.Store(until.UnixNano())
+}
+
+func clearMemoryCachePressureTargetForTest() {
+	memCachePressureTargetPercent.Store(0)
+	memCachePressureDeadline.Store(0)
+}
+
+func memoryCachePressureTarget(capacity int64) (int64, bool) {
+	deadline := memCachePressureDeadline.Load()
+	if deadline == 0 || time.Now().UnixNano() > deadline {
+		return 0, false
+	}
+	percent := memCachePressureTargetPercent.Load()
+	if percent <= 0 {
+		return 0, false
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	return capacity * percent / 100, true
+}
 
 func (m *MemCache) callbacksLock(key fscache.CacheKey) *sync.Mutex {
 	var hasher maphash.Hash
@@ -151,6 +204,7 @@ func NewMemCache(
 	}
 
 	dataCache = fifocache.NewDataCacheWithPrepareSet(capacityFunc, prepareSetFn, postSetFn, postGetFn, postEvictFn)
+	dataCache.SetAdmissionTarget(memoryCachePressureTarget)
 
 	ret.cache = dataCache
 
@@ -241,6 +295,11 @@ func (m *MemCache) Update(
 			Offset: entry.Offset,
 			Sz:     entry.Size,
 		}
+		if target, ok := memoryCachePressureTarget(m.cache.Capacity()); ok &&
+			m.cache.Used()+int64(len(entry.CachedData.Bytes())) > target {
+			metric.FSCachePressureMemorySkipCounter.Inc()
+			continue
+		}
 
 		LogEvent(ctx, str_set_memory_cache_entry_begin)
 		m.cache.Set(ctx, key, entry.CachedData)
@@ -263,6 +322,21 @@ func (m *MemCache) DeletePaths(
 
 func (m *MemCache) Evict(ctx context.Context, done chan int64) {
 	m.cache.Evict(ctx, done)
+}
+
+func (m *MemCache) EvictToTarget(ctx context.Context, target int64) int64 {
+	return m.cache.EvictToTargetWithWait(ctx, target)
+}
+
+func (m *MemCache) EvictToCapacityPercent(ctx context.Context, percent int64) int64 {
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	target := m.cache.Capacity() * percent / 100
+	return m.EvictToTarget(ctx, target)
 }
 
 func (m *MemCache) Close(ctx context.Context) {

--- a/pkg/fileservice/mem_cache_test.go
+++ b/pkg/fileservice/mem_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/fileservice/fscache"
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
@@ -515,4 +516,95 @@ func TestMemoryCacheGlobalSizeHint(t *testing.T) {
 		t.Fatalf("got %v", ret)
 	}
 
+}
+
+func TestMemoryCacheEvictToCapacityPercent(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemCache(
+		fscache.ConstCapacity(10),
+		nil,
+		nil,
+		"test-target-evict",
+	)
+	defer cache.Close(ctx)
+
+	for i := 0; i < 10; i++ {
+		key := fscache.CacheKey{Path: fmt.Sprintf("key-%d", i), Offset: int64(i), Sz: 1}
+		assert.NoError(t, cache.cache.Set(ctx, key, staticTestData([]byte{byte(i)})))
+	}
+	assert.Equal(t, int64(10), cache.cache.Used())
+
+	ret := EvictMemoryCachesToCapacityPercent(ctx, 50)
+	assert.Equal(t, int64(5), ret["test-target-evict"])
+	assert.LessOrEqual(t, cache.cache.Used(), int64(5))
+}
+
+func TestMemoryCachePressureAdmissionSkipsWritesAboveTarget(t *testing.T) {
+	ctx := context.Background()
+	clearMemoryCachePressureTargetForTest()
+	defer clearMemoryCachePressureTargetForTest()
+
+	cache := NewMemCache(
+		fscache.ConstCapacity(10),
+		nil,
+		nil,
+		"",
+	)
+	defer cache.Close(ctx)
+
+	SetMemoryCachePressureTargetPercent(50, time.Now().Add(time.Minute))
+
+	for i := 0; i < 5; i++ {
+		vec := &IOVector{
+			FilePath: "foo",
+			Entries: []IOEntry{{
+				Offset:     int64(i),
+				Size:       1,
+				CachedData: staticTestData([]byte{byte(i)}),
+			}},
+		}
+		assert.NoError(t, cache.Update(ctx, vec, false))
+	}
+	assert.Equal(t, int64(5), cache.cache.Used())
+
+	vec := &IOVector{
+		FilePath: "foo",
+		Entries: []IOEntry{{
+			Offset:     5,
+			Size:       1,
+			CachedData: staticTestData([]byte{5}),
+		}},
+	}
+	assert.NoError(t, cache.Update(ctx, vec, false))
+	assert.Equal(t, int64(5), cache.cache.Used())
+
+	_, ok := cache.cache.Get(ctx, fscache.CacheKey{Path: "foo", Offset: 5, Sz: 1})
+	assert.False(t, ok)
+}
+
+func TestMemoryCachePressureAdmissionExpires(t *testing.T) {
+	ctx := context.Background()
+	clearMemoryCachePressureTargetForTest()
+	defer clearMemoryCachePressureTargetForTest()
+
+	cache := NewMemCache(
+		fscache.ConstCapacity(10),
+		nil,
+		nil,
+		"",
+	)
+	defer cache.Close(ctx)
+
+	SetMemoryCachePressureTargetPercent(50, time.Now().Add(-time.Second))
+
+	vec := &IOVector{
+		FilePath: "foo",
+		Entries: []IOEntry{{
+			Offset:     0,
+			Size:       1,
+			CachedData: staticTestData([]byte{1}),
+		}},
+	}
+	assert.NoError(t, cache.Update(ctx, vec, false))
+	assert.Equal(t, int64(1), cache.cache.Used())
 }

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -161,21 +161,21 @@ func NewS3FS(
 
 func (s *S3FS) AllocateCacheData(ctx context.Context, size int) fscache.Data {
 	if s.memCache != nil {
-		s.memCache.cache.EnsureNBytes(ctx, size)
+		s.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	}
 	return DefaultCacheDataAllocator().AllocateCacheData(ctx, size)
 }
 
 func (s *S3FS) AllocateCacheDataWithHint(ctx context.Context, size int, hints malloc.Hints) fscache.Data {
 	if s.memCache != nil {
-		s.memCache.cache.EnsureNBytes(ctx, size)
+		s.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), size)
 	}
 	return DefaultCacheDataAllocator().AllocateCacheDataWithHint(ctx, size, hints)
 }
 
 func (s *S3FS) CopyToCacheData(ctx context.Context, data []byte) fscache.Data {
 	if s.memCache != nil {
-		s.memCache.cache.EnsureNBytes(ctx, len(data))
+		s.memCache.cache.EnsureNBytes(withoutEventLogger(ctx), len(data))
 	}
 	return DefaultCacheDataAllocator().CopyToCacheData(ctx, data)
 }

--- a/pkg/objectio/cache.go
+++ b/pkg/objectio/cache.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -77,6 +78,12 @@ type mataCacheKey [cacheKeyLen]byte
 var metaCache *fifocache.Cache[mataCacheKey, []byte]
 var onceInit sync.Once
 
+var (
+	metaCachePressureMu            sync.Mutex
+	metaCachePressureTargetPercent atomic.Int64
+	metaCachePressureDeadline      atomic.Int64
+)
+
 // metaLoadGroup deduplicates concurrent loads for the same cache key,
 // preventing cache stampede when many goroutines miss the same entry simultaneously.
 // Uses mutex+map instead of sync.Map so entries are fully reclaimed after deletion.
@@ -133,10 +140,55 @@ func InitMetaCache(size int64) {
 	})
 }
 
+func SetMetaCachePressureTargetPercent(percent int64, until time.Time) {
+	now := time.Now()
+	if percent <= 0 || !until.After(now) {
+		metaCachePressureMu.Lock()
+		metaCachePressureTargetPercent.Store(0)
+		metaCachePressureDeadline.Store(0)
+		metaCachePressureMu.Unlock()
+		return
+	}
+	if percent > 100 {
+		percent = 100
+	}
+
+	metaCachePressureMu.Lock()
+	defer metaCachePressureMu.Unlock()
+
+	oldDeadline := metaCachePressureDeadline.Load()
+	oldPercent := metaCachePressureTargetPercent.Load()
+	if oldDeadline > now.UnixNano() && oldPercent > 0 && oldPercent < percent {
+		return
+	}
+	metaCachePressureTargetPercent.Store(percent)
+	metaCachePressureDeadline.Store(until.UnixNano())
+}
+
+func clearMetaCachePressureTargetForTest() {
+	metaCachePressureTargetPercent.Store(0)
+	metaCachePressureDeadline.Store(0)
+}
+
+func metaCachePressureTarget(capacity int64) (int64, bool) {
+	deadline := metaCachePressureDeadline.Load()
+	if deadline == 0 || time.Now().UnixNano() > deadline {
+		return 0, false
+	}
+	percent := metaCachePressureTargetPercent.Load()
+	if percent <= 0 {
+		return 0, false
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	return capacity * percent / 100, true
+}
+
 func newMetaCache(capacity fscache.CapacityFunc) *fifocache.Cache[mataCacheKey, []byte] {
 	inuseBytes, capacityBytes := metric.GetFsCacheBytesGauge("", "meta")
 	capacityBytes.Set(float64(capacity()))
-	return fifocache.New[mataCacheKey, []byte](
+	ret := fifocache.New[mataCacheKey, []byte](
 		capacity,
 		shardMetaCacheKey,
 		func(_ context.Context, _ mataCacheKey, _ []byte, size int64, _ uint64) { // postSet
@@ -148,6 +200,8 @@ func newMetaCache(capacity fscache.CapacityFunc) *fifocache.Cache[mataCacheKey, 
 			inuseBytes.Add(float64(-size))
 			capacityBytes.Set(float64(capacity()))
 		})
+	ret.SetAdmissionTarget(metaCachePressureTarget)
+	return ret
 }
 
 func EvictCache(ctx context.Context) (target int64) {
@@ -156,6 +210,38 @@ func EvictCache(ctx context.Context) (target int64) {
 	target = <-ch
 	logutil.Info("metadata cache forced evicted",
 		zap.Any("target", target),
+	)
+	return
+}
+
+func EvictCacheToCapacityPercent(ctx context.Context, percent int64) (used int64) {
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	capacity := metaCache.Capacity()
+	target := capacity * percent / 100
+	beforeUsed := metaCache.Used()
+	start := time.Now()
+	logutil.Info("metadata cache pressure evict begin",
+		zap.Int64("used-before", beforeUsed),
+		zap.Int64("capacity", capacity),
+		zap.Int64("target", target),
+		zap.Int64("target-percent", percent),
+	)
+	used = metaCache.EvictToTargetWithWait(ctx, target)
+	metric.FSCachePressureMetaEvictCounter.Inc()
+	metric.FSCachePressureMetaEvictDuration.Observe(time.Since(start).Seconds())
+	logutil.Info("metadata cache pressure evicted",
+		zap.Int64("used-before", beforeUsed),
+		zap.Int64("used-after", used),
+		zap.Int64("capacity", capacity),
+		zap.Int64("target", target),
+		zap.Int64("target-percent", percent),
+		zap.Duration("duration", time.Since(start)),
+		zap.Error(ctx.Err()),
 	)
 	return
 }
@@ -278,6 +364,11 @@ func dedupLoad(ctx context.Context, key mataCacheKey, load func() ([]byte, error
 
 	call.val, call.err = load()
 	if call.err == nil {
+		if target, ok := metaCachePressureTarget(metaCache.Capacity()); ok &&
+			metaCache.Used()+int64(len(call.val)) > target {
+			metric.FSCachePressureMetaSkipCounter.Inc()
+			return call.val, call.err
+		}
 		metaCache.Set(ctx, key, call.val, int64(len(call.val)))
 	}
 	return call.val, call.err

--- a/pkg/objectio/meta_test.go
+++ b/pkg/objectio/meta_test.go
@@ -130,3 +130,72 @@ func TestDedupLoadCleansUpAfterLoadCancel(t *testing.T) {
 	metaLoadMu.Unlock()
 	assert.False(t, ok)
 }
+
+func TestEvictCacheToCapacityPercent(t *testing.T) {
+	oldMetaCache := metaCache
+	metaCache = newMetaCache(fscache.ConstCapacity(10))
+	defer func() {
+		metaCache = oldMetaCache
+	}()
+
+	ctx := context.Background()
+	var key mataCacheKey
+	key[0] = 3
+	metaCache.Set(ctx, key, []byte("1234567890"), 10)
+
+	used := EvictCacheToCapacityPercent(ctx, 50)
+
+	assert.LessOrEqual(t, used, int64(5))
+	assert.Equal(t, used, metaCache.Used())
+}
+
+func TestMetaCachePressureAdmissionSkipsWritesAboveTarget(t *testing.T) {
+	oldMetaCache := metaCache
+	metaCache = newMetaCache(fscache.ConstCapacity(10))
+	clearMetaCachePressureTargetForTest()
+	defer func() {
+		clearMetaCachePressureTargetForTest()
+		metaCache = oldMetaCache
+	}()
+
+	ctx := context.Background()
+	var existingKey mataCacheKey
+	existingKey[0] = 4
+	metaCache.Set(ctx, existingKey, []byte("12345"), 5)
+
+	SetMetaCachePressureTargetPercent(50, time.Now().Add(time.Minute))
+
+	var key mataCacheKey
+	key[0] = 5
+	v, err := dedupLoad(ctx, key, func() ([]byte, error) {
+		return []byte("6"), nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("6"), v)
+	assert.Equal(t, int64(5), metaCache.Used())
+
+	_, ok := metaCache.Get(ctx, key)
+	assert.False(t, ok)
+}
+
+func TestMetaCachePressureAdmissionExpires(t *testing.T) {
+	oldMetaCache := metaCache
+	metaCache = newMetaCache(fscache.ConstCapacity(10))
+	clearMetaCachePressureTargetForTest()
+	defer func() {
+		clearMetaCachePressureTargetForTest()
+		metaCache = oldMetaCache
+	}()
+
+	ctx := context.Background()
+	SetMetaCachePressureTargetPercent(50, time.Now().Add(-time.Second))
+
+	var key mataCacheKey
+	key[0] = 6
+	v, err := dedupLoad(ctx, key, func() ([]byte, error) {
+		return []byte("1"), nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("1"), v)
+	assert.Equal(t, int64(1), metaCache.Used())
+}

--- a/pkg/util/metric/v2/fileservice.go
+++ b/pkg/util/metric/v2/fileservice.go
@@ -166,6 +166,36 @@ var (
 		}, []string{"component", "type"})
 )
 
+var (
+	fsCachePressureCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "fs",
+			Name:      "cache_pressure_total",
+			Help:      "Total number of fs cache pressure events.",
+		}, []string{"component", "event"})
+
+	FSCachePressureTriggerCounter     = fsCachePressureCounter.WithLabelValues("rss", "trigger")
+	FSCachePressureMemoryEvictCounter = fsCachePressureCounter.WithLabelValues("memory", "evict")
+	FSCachePressureMetaEvictCounter   = fsCachePressureCounter.WithLabelValues("meta", "evict")
+	FSCachePressureMemorySkipCounter  = fsCachePressureCounter.WithLabelValues("memory", "admission-skip")
+	FSCachePressureMetaSkipCounter    = fsCachePressureCounter.WithLabelValues("meta", "admission-skip")
+)
+
+var (
+	fsCachePressureEvictDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "mo",
+			Subsystem: "fs",
+			Name:      "cache_pressure_evict_duration_seconds",
+			Help:      "Bucketed histogram of fs cache pressure eviction duration.",
+			Buckets:   getDurationBuckets(),
+		}, []string{"component"})
+
+	FSCachePressureMemoryEvictDuration = fsCachePressureEvictDuration.WithLabelValues("memory")
+	FSCachePressureMetaEvictDuration   = fsCachePressureEvictDuration.WithLabelValues("meta")
+)
+
 // GetFsCacheBytesGauge return inuse, cap Gauge metric
 // {typ} should be [mem, disk, meta]
 func GetFsCacheBytesGauge(name, typ string) (inuse prometheus.Gauge, capacity prometheus.Gauge) {

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -97,6 +97,8 @@ func initTaskMetrics() {
 func initFileServiceMetrics() {
 	registry.MustRegister(fsReadCounter)
 	registry.MustRegister(fsCacheBytes)
+	registry.MustRegister(fsCachePressureCounter)
+	registry.MustRegister(fsCachePressureEvictDuration)
 
 	registry.MustRegister(s3IOBytesHistogram)
 	registry.MustRegister(s3ConnDurationHistogram)

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -37,6 +37,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/lockservice"
 	"github.com/matrixorigin/matrixone/pkg/logservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/statsinfo"
@@ -58,6 +59,35 @@ import (
 )
 
 var _ engine.Engine = new(Engine)
+
+const (
+	workspaceRSSCacheFamilyEvictTimeout   = 10 * time.Second
+	workspaceRSSCacheAdmissionPressureTTL = 2 * time.Minute
+)
+
+func makeWorkspaceRSSCacheEvictor(timeout time.Duration) func(context.Context, int64) {
+	return func(ctx context.Context, targetPercent int64) {
+		pressureUntil := time.Now().Add(workspaceRSSCacheAdmissionPressureTTL)
+		fileservice.SetMemoryCachePressureTargetPercent(targetPercent, pressureUntil)
+		objectio.SetMetaCachePressureTargetPercent(targetPercent, pressureUntil)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			memoryCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			fileservice.EvictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
+		}()
+		go func() {
+			defer wg.Done()
+			metaCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			objectio.EvictCacheToCapacityPercent(metaCtx, targetPercent)
+		}()
+		wg.Wait()
+	}
+}
 
 func New(
 	ctx context.Context,
@@ -141,18 +171,23 @@ func New(
 	}
 
 	if e.config.memThrottler == nil {
+		throttlerOptions := []rscthrottler.MemThrottlerOption{
+			rscthrottler.WithRSSScavenging(),
+			rscthrottler.WithRSSCacheEvictor(
+				makeWorkspaceRSSCacheEvictor(workspaceRSSCacheFamilyEvictTimeout),
+			),
+		}
 		if e.config.quota.Load() != 0 {
-			e.config.memThrottler = rscthrottler.NewMemThrottler(
-				"Workspace",
-				5.0/100.0,
+			throttlerOptions = append(
+				throttlerOptions,
 				rscthrottler.WithConstLimit(int64(e.config.quota.Load())),
 			)
-		} else {
-			e.config.memThrottler = rscthrottler.NewMemThrottler(
-				"Workspace",
-				5.0/100.0,
-			)
 		}
+		e.config.memThrottler = rscthrottler.NewMemThrottler(
+			"Workspace",
+			5.0/100.0,
+			throttlerOptions...,
+		)
 
 		v2.TxnExtraWorkspaceQuotaGauge.Set(float64(e.config.memThrottler.Available()))
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Closes #24617

## What this PR does / why we need it:

This PR ports the final minimal RSS cache pressure protection from #24612 to `main`.

Background:

- #24535 tried to reduce CN RSS pressure under TPCC/sysbench, but it mixed cache pressure handling with broader PK, tombstone, metadata, and BF read-path behavior changes.
- #24542 added fileservice event logger capacity protection.
- #24543 kept cache pressure admission targets active under high RSS.
- #24612 reverted the risky mixed behavior on `4.0-dev` and restored only the smaller validated RSS cache pressure protection.

`main` does not contain the risky #24535/#24542/#24543 commits, so this PR does not cherry-pick those revert commits. It ports the final net behavior directly:

- cap fileservice event logger events;
- avoid carrying request event logs into cache capacity eviction;
- asynchronously trigger memory cache and metadata cache eviction under RSS pressure;
- keep a short pressure admission TTL to prevent immediate cache refill;
- keep foreground `EvictWithWait` from absorbing async eviction debt;
- add cache pressure trigger / eviction / admission-skip / eviction-duration metrics;
- run CN memory/meta cache family eviction concurrently with independent timeouts;
- add focused coverage for cache admission, target eviction, event logger caps, RSS soft/hard target escalation, and CN concurrent eviction.

One `main` port adjustment:

- `tryScavengeRSS` captures the evictor and `freeOSMemory` hook before launching the async goroutine, preserving behavior while avoiding a race-detector issue in tests that replace the package-level hook.

Validation:

```text
GOCACHE=/private/tmp/mo-gocache-main go test ./pkg/fileservice/fifocache -run 'TestEvict|TestPostEvict|TestMemoryCache|TestCachePressure|TestEvictToTarget' -count=1
GOCACHE=/private/tmp/mo-gocache-main go test ./pkg/fileservice -run 'TestEventLogger|TestWithoutEventLogger|TestMemoryCache|TestDiskCacheReadEnsuresMemoryCacheCapacity' -count=1
GOCACHE=/private/tmp/mo-gocache-main go test ./pkg/objectio -run 'TestMetaCachePressure' -count=1
GOCACHE=/private/tmp/mo-gocache-main go test ./pkg/common/rscthrottler -run 'TestMemThrottlerRSS|TestAcquirePolicyForCNFlushS3|TestAcquirePolicyForDataBranch' -count=1
GOCACHE=/private/tmp/mo-gocache-main go test ./pkg/cnservice -run 'TestMakeRSSCacheEvictor|Test_InitServer|Test_tenant' -count=1
GOCACHE=/private/tmp/mo-gocache-main go test ./pkg/util/metric/v2 -run TestNonExistent -count=0
GOCACHE=/private/tmp/mo-gocache-main go test -race ./pkg/common/rscthrottler -run 'TestMemThrottlerRSSCacheEviction' -count=10
GOCACHE=/private/tmp/mo-gocache-main go test -race ./pkg/cnservice -run 'TestMakeRSSCacheEvictor' -count=10
git diff --check base/main...HEAD
```
