### PR TITLE
fix(lockservice): clean stale range waiters

### DIFF
--- a/pkg/lockservice/lock.go
+++ b/pkg/lockservice/lock.go
@@ -210,15 +210,15 @@ func (l Lock) closeWaiter(w *waiter, logger *log.MOLogger) bool {
 	return canRemove
 }
 
-func (l Lock) removeWaiter(w *waiter, logger *log.MOLogger) bool {
+func (l Lock) removeWaiter(w *waiter, logger *log.MOLogger) (bool, bool) {
 	removed, wasFirst := l.waiters.remove(w)
 	if !removed {
-		return l.isEmpty()
+		return false, l.isEmpty()
 	}
 	if l.holders.size() == 0 && wasFirst && l.waiters.size() > 0 {
 		l.waiters.notify(notifyValue{defChanged: l.isLockTableDefChanged()})
 	}
-	return l.isEmpty()
+	return true, l.isEmpty()
 }
 
 func (l Lock) closeTxn(

--- a/pkg/lockservice/lock.go
+++ b/pkg/lockservice/lock.go
@@ -210,6 +210,17 @@ func (l Lock) closeWaiter(w *waiter, logger *log.MOLogger) bool {
 	return canRemove
 }
 
+func (l Lock) removeWaiter(w *waiter, logger *log.MOLogger) bool {
+	removed, wasFirst := l.waiters.remove(w)
+	if !removed {
+		return l.isEmpty()
+	}
+	if l.holders.size() == 0 && wasFirst && l.waiters.size() > 0 {
+		l.waiters.notify(notifyValue{defChanged: l.isLockTableDefChanged()})
+	}
+	return l.isEmpty()
+}
+
 func (l Lock) closeTxn(
 	txn *activeTxn,
 	notify notifyValue) (lockCanRemoved bool) {

--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -515,6 +515,10 @@ func (l *localLockTable) handleLockConflictLocked(
 		return ErrLockConflict
 	}
 
+	if c.opts.Granularity == pb.Granularity_Range {
+		l.closeRangeLastWaiterLocked(c)
+	}
+
 	c.w.conflictKey.Store(&key)
 	c.w.lt.Store(l)
 	c.w.waitFor = c.w.waitFor[:0]
@@ -541,25 +545,40 @@ func (l *localLockTable) handleLockConflictLocked(
 	// waiter added, we need to active deadlock check.
 	logLocalLockWaitOn(l.logger, c.txn, l.bind.Table, c.w, key, conflictWith)
 
-	if c.opts.Granularity != pb.Granularity_Range {
-		return nil
-	}
-
-	if len(c.rangeLastWaitKey) > 0 {
-		v, ok := l.mu.store.Get(c.rangeLastWaitKey)
-		if !ok {
-			l.logger.Error("missing range last wait key when moving waiter to next conflict",
-				zap.Uint64("table", l.bind.Table),
-				zap.String("txn", c.txn.txnKey),
-				zap.Binary("last-wait-key", c.rangeLastWaitKey),
-				zap.Binary("next-conflict-key", key))
-		}
-		if ok && v.closeWaiter(c.w, l.logger) {
-			l.mu.store.Delete(c.rangeLastWaitKey)
-		}
-	}
 	c.rangeLastWaitKey = key
 	return nil
+}
+
+func (l *localLockTable) closeRangeLastWaiterLocked(c *lockContext) {
+	if len(c.rangeLastWaitKey) == 0 {
+		return
+	}
+
+	v, ok := l.mu.store.Get(c.rangeLastWaitKey)
+	if ok {
+		if v.removeWaiter(c.w, l.logger) {
+			l.mu.store.Delete(c.rangeLastWaitKey)
+		}
+		c.rangeLastWaitKey = nil
+		return
+	}
+
+	l.logger.Error("missing range last wait key when moving waiter to next conflict",
+		zap.Uint64("table", l.bind.Table),
+		zap.String("txn", c.txn.txnKey),
+		zap.Binary("last-wait-key", c.rangeLastWaitKey))
+
+	var deleteKeys [][]byte
+	l.mu.store.Iter(func(key []byte, lock Lock) bool {
+		if lock.removeWaiter(c.w, l.logger) {
+			deleteKeys = append(deleteKeys, append([]byte(nil), key...))
+		}
+		return true
+	})
+	for _, key := range deleteKeys {
+		l.mu.store.Delete(key)
+	}
+	c.rangeLastWaitKey = nil
 }
 
 func (l *localLockTable) addRangeLockLocked(

--- a/pkg/lockservice/lock_table_local.go
+++ b/pkg/lockservice/lock_table_local.go
@@ -556,21 +556,29 @@ func (l *localLockTable) closeRangeLastWaiterLocked(c *lockContext) {
 
 	v, ok := l.mu.store.Get(c.rangeLastWaitKey)
 	if ok {
-		if v.removeWaiter(c.w, l.logger) {
+		removed, empty := v.removeWaiter(c.w, l.logger)
+		if removed {
+			if empty {
+				l.mu.store.Delete(c.rangeLastWaitKey)
+			}
+			c.rangeLastWaitKey = nil
+			return
+		}
+		if empty {
 			l.mu.store.Delete(c.rangeLastWaitKey)
 		}
-		c.rangeLastWaitKey = nil
-		return
 	}
 
 	l.logger.Error("missing range last wait key when moving waiter to next conflict",
 		zap.Uint64("table", l.bind.Table),
 		zap.String("txn", c.txn.txnKey),
-		zap.Binary("last-wait-key", c.rangeLastWaitKey))
+		zap.Binary("last-wait-key", c.rangeLastWaitKey),
+		zap.Bool("last-wait-key-exists", ok))
 
 	var deleteKeys [][]byte
 	l.mu.store.Iter(func(key []byte, lock Lock) bool {
-		if lock.removeWaiter(c.w, l.logger) {
+		removed, empty := lock.removeWaiter(c.w, l.logger)
+		if removed && empty {
 			deleteKeys = append(deleteKeys, append([]byte(nil), key...))
 		}
 		return true

--- a/pkg/lockservice/lock_table_local_test.go
+++ b/pkg/lockservice/lock_table_local_test.go
@@ -1716,6 +1716,17 @@ func TestHandleLockConflictLockedLogOnMissingRangeKey(t *testing.T) {
 				waitTxn := pb.WaitTxn{TxnID: txnID, CreatedOn: "test"}
 				w := acquireWaiter(waitTxn, "test", logger)
 
+				staleKey := []byte{2}
+				staleWaiters := newWaiterQueue()
+				staleWaiters.init(logger)
+				staleWaiters.put(w)
+				lt.mu.store.Add(staleKey, Lock{
+					createAt: time.Now(),
+					holders:  newHolders(),
+					waiters:  staleWaiters,
+				})
+
+				nextConflictKey := []byte{1}
 				holderTxnID := []byte("holder1")
 				holderWaitTxn := pb.WaitTxn{TxnID: holderTxnID, CreatedOn: "test"}
 				h := newHolders()
@@ -1727,6 +1738,7 @@ func TestHandleLockConflictLockedLogOnMissingRangeKey(t *testing.T) {
 					holders:  h,
 					waiters:  wq,
 				}
+				lt.mu.store.Add(nextConflictKey, conflictWith)
 
 				c := &lockContext{
 					ctx:     context.Background(),
@@ -1744,11 +1756,18 @@ func TestHandleLockConflictLockedLogOnMissingRangeKey(t *testing.T) {
 					result:           pb.Result{},
 				}
 
-				// rangeLastWaitKey {99} is not in the store, so the error log
-				// branch (previously a panic) should execute without crashing.
-				err := lt.handleLockConflictLocked(c, []byte{1}, conflictWith)
+				// rangeLastWaitKey {99} is not in the store, but the same waiter
+				// may have been moved to another queue by a range merge. Leaving it
+				// in that stale no-holder lock would block later lockers forever.
+				err := lt.handleLockConflictLocked(c, nextConflictKey, conflictWith)
 				assert.NoError(t, err)
-				assert.Equal(t, []byte{1}, c.rangeLastWaitKey)
+				assert.Equal(t, nextConflictKey, c.rangeLastWaitKey)
+				_, ok := lt.mu.store.Get(staleKey)
+				assert.False(t, ok)
+
+				nextLock, ok := lt.mu.store.Get(nextConflictKey)
+				require.True(t, ok)
+				assert.Equal(t, 1, nextLock.waiters.size())
 			})
 		},
 	)

--- a/pkg/lockservice/lock_table_local_test.go
+++ b/pkg/lockservice/lock_table_local_test.go
@@ -1726,6 +1726,17 @@ func TestHandleLockConflictLockedLogOnMissingRangeKey(t *testing.T) {
 					waiters:  staleWaiters,
 				})
 
+				recreatedKey := []byte{99}
+				recreatedHolders := newHolders()
+				recreatedHolders.add(pb.WaitTxn{TxnID: []byte("recreated-holder"), CreatedOn: "test"})
+				recreatedWaiters := newWaiterQueue()
+				recreatedWaiters.init(logger)
+				lt.mu.store.Add(recreatedKey, Lock{
+					createAt: time.Now(),
+					holders:  recreatedHolders,
+					waiters:  recreatedWaiters,
+				})
+
 				nextConflictKey := []byte{1}
 				holderTxnID := []byte("holder1")
 				holderWaitTxn := pb.WaitTxn{TxnID: holderTxnID, CreatedOn: "test"}
@@ -1752,18 +1763,20 @@ func TestHandleLockConflictLockedLogOnMissingRangeKey(t *testing.T) {
 						},
 					},
 					w:                w,
-					rangeLastWaitKey: []byte{99},
+					rangeLastWaitKey: recreatedKey,
 					result:           pb.Result{},
 				}
 
-				// rangeLastWaitKey {99} is not in the store, but the same waiter
-				// may have been moved to another queue by a range merge. Leaving it
-				// in that stale no-holder lock would block later lockers forever.
+				// rangeLastWaitKey was removed by a range merge and recreated by
+				// another txn without this waiter, but the waiter may still exist
+				// in another stale no-holder lock queue.
 				err := lt.handleLockConflictLocked(c, nextConflictKey, conflictWith)
 				assert.NoError(t, err)
 				assert.Equal(t, nextConflictKey, c.rangeLastWaitKey)
 				_, ok := lt.mu.store.Get(staleKey)
 				assert.False(t, ok)
+				_, ok = lt.mu.store.Get(recreatedKey)
+				assert.True(t, ok)
 
 				nextLock, ok := lt.mu.store.Get(nextConflictKey)
 				require.True(t, ok)

--- a/pkg/lockservice/waiter_queue.go
+++ b/pkg/lockservice/waiter_queue.go
@@ -31,6 +31,7 @@ type waiterQueue interface {
 	resetCommittedAt(timestamp.Timestamp)
 	moveTo(to waiterQueue)
 	put(...*waiter)
+	remove(*waiter) (bool, bool)
 	notify(value notifyValue)
 	notifyAll(value notifyValue)
 	first() *waiter
@@ -77,6 +78,28 @@ func (q *sliceBasedWaiterQueue) put(ws ...*waiter) {
 	}
 	q.waiters = append(q.waiters, ws...)
 	v2.TxnLockWaitersTotalHistogram.Observe(float64(len(q.waiters)))
+}
+
+func (q *sliceBasedWaiterQueue) remove(w *waiter) (bool, bool) {
+	q.Lock()
+	defer q.Unlock()
+
+	if q.beginChangeIdx != -1 {
+		panic("BUG: cannot remove waiter in changing waiter queue")
+	}
+
+	for i, v := range q.waiters {
+		if v != w {
+			continue
+		}
+		v.close("sliceBasedWaiterQueue remove", q.logger)
+		copy(q.waiters[i:], q.waiters[i+1:])
+		q.waiters[len(q.waiters)-1] = nil
+		q.waiters = q.waiters[:len(q.waiters)-1]
+		v2.TxnLockWaitersTotalHistogram.Observe(float64(len(q.waiters)))
+		return true, i == 0
+	}
+	return false, false
 }
 
 func (q *sliceBasedWaiterQueue) notifyAll(value notifyValue) {


### PR DESCRIPTION
 ## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) does this PR fix or relate to?

Fixes https://github.com/matrixorigin/matrixone/issues/24623

## What this PR does / why we need it:

This fixes stale range waiter cleanup in the local lock table. When a range lock waiter moves to the next conflicting key, the previous `rangeLastWaitKey` can already have been removed by range lock merge/delete. The old path only logged `missing range last wait key` and then attached the same waiter to the next conflict key, which could leave a stale waiter in an old no-holder lock queue and cause later lockers to wait forever.

Changes:
- remove the moving range waiter from its previous conflict lock before attaching it to the next key
- if `rangeLastWaitKey` is missing, scan local locks and remove any stale reference to that waiter
- if `rangeLastWaitKey` was deleted and then recreated by another txn, fall back to the same full-table stale waiter scan when the recreated lock does not contain this waiter
- make `Lock.removeWaiter` report both whether the waiter was found/removed and whether the lock is empty
- wake the next waiter when removing the first waiter from a no-holder lock queue
- add unit coverage for both the stale waiter cleanup and recreated-key fallback

Regression / introduction:
- The `rangeLastWaitKey` waiter movement logic was introduced by `10965f92a9` / #20453 on 2024-11-29.
- #24051 (`88d075766d`, 2026-04-06) changed the missing-key path from panic to ERROR-only, which exposed the Issue #24623 long-hang behavior seen on `main`.
- Bad commit `a218298346` contains both commits above; it did not introduce the issue itself.

Local reproduction:
- Bad commit: `a218298346`
- Workload: sysbench 100 threads, 10 tables x 100k rows, range UPDATE plus point DELETE/INSERT variant to force row-lock to table-lock upgrade and range waiter movement
- Result: sysbench did not exit after its configured 300s run and was killed by outer timeout; MO logs showed `missing range last wait`, `Row lock upgraded`, and repeated `wait too long`
- Observed counts: `missing range last wait`: 23, `Row lock upgraded`: 387, `wait too long`: 4410

Test:
- `go test -mod=mod ./pkg/lockservice -count=1`
