### PR TITLE
fix(4.0-dev): sync Name2ColIndex when appending __mo_rowid to index table TableDef

### DIFF
--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -1185,6 +1185,7 @@ func TestDropDatabaseSkipsDeletedRelationsWhenCollectingTables(t *testing.T) {
 	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
 	txnOp.EXPECT().Txn().Return(txnMeta).AnyTimes()
 	txnOp.EXPECT().SnapshotTS().Return(timestamp.Timestamp{}).AnyTimes()
+	txnOp.EXPECT().SetSnapshotTS(gomock.Any()).AnyTimes()
 	txnOp.EXPECT().TxnRef().Return(&txnMeta).AnyTimes()
 	txnOp.EXPECT().GetWorkspace().Return(&Ws{}).AnyTimes()
 	proc.Base.TxnOperator = txnOp
@@ -1259,6 +1260,7 @@ func TestDropDatabaseReturnsInternalRelationErrorWhenCollectingTables(t *testing
 	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
 	txnOp.EXPECT().Txn().Return(txnMeta).AnyTimes()
 	txnOp.EXPECT().SnapshotTS().Return(timestamp.Timestamp{}).AnyTimes()
+	txnOp.EXPECT().SetSnapshotTS(gomock.Any()).AnyTimes()
 	txnOp.EXPECT().TxnRef().Return(&txnMeta).AnyTimes()
 	txnOp.EXPECT().GetWorkspace().Return(&Ws{}).AnyTimes()
 	proc.Base.TxnOperator = txnOp

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -1504,6 +1504,7 @@ func (tbl *txnTable) GetTableDef(ctx context.Context) *plan.TableDef {
 		if !hasRowId {
 			rowIdCol := plan2.MakeRowIdColDef()
 			cols = append(cols, rowIdCol)
+			name2index[catalog.Row_ID] = int32(len(cols) - 1)
 		}
 
 		tbl.tableDef = &plan.TableDef{

--- a/test/distributed/cases/pessimistic_transaction/index_table_rowid_eob.result
+++ b/test/distributed/cases/pessimistic_transaction/index_table_rowid_eob.result
@@ -1,0 +1,26 @@
+drop table if exists mowl_workflow_cases;
+CREATE TABLE mowl_workflow_cases (
+id VARCHAR(36) NOT NULL,
+task_id VARCHAR(36) DEFAULT NULL,
+PRIMARY KEY (id),
+KEY idx_task_id (task_id)
+);
+INSERT INTO mowl_workflow_cases VALUES ('case-001', 'task-001');
+INSERT INTO mowl_workflow_cases VALUES ('case-002', 'task-002');
+BEGIN;
+ALTER TABLE mowl_workflow_cases ADD COLUMN scheduler_visible TINYINT(1) NOT NULL DEFAULT 1;
+CREATE INDEX idx_cases_scheduler ON mowl_workflow_cases (scheduler_visible);
+UPDATE mowl_workflow_cases SET scheduler_visible = 0 WHERE id = 'case-001';
+COMMIT;
+SELECT id, scheduler_visible FROM mowl_workflow_cases ORDER BY id;
+id	scheduler_visible
+case-001	0
+case-002	1
+BEGIN;
+CREATE INDEX idx_cases_task ON mowl_workflow_cases (task_id);
+DELETE FROM mowl_workflow_cases WHERE id = 'case-002';
+COMMIT;
+SELECT COUNT(*) FROM mowl_workflow_cases;
+COUNT(*)
+1
+drop table mowl_workflow_cases;

--- a/test/distributed/cases/pessimistic_transaction/index_table_rowid_eob.sql
+++ b/test/distributed/cases/pessimistic_transaction/index_table_rowid_eob.sql
@@ -1,0 +1,37 @@
+-- Test for index table __mo_rowid Name2ColIndex consistency bug
+-- This test verifies that DML operations on index tables created within the same transaction work correctly
+-- Bug: When CREATE INDEX is executed in a transaction, the index table's Name2ColIndex map was not synced
+-- with the Cols array when __mo_rowid was appended, causing ExpectedEOB errors during subsequent DML operations.
+
+drop table if exists mowl_workflow_cases;
+
+CREATE TABLE mowl_workflow_cases (
+    id VARCHAR(36) NOT NULL,
+    task_id VARCHAR(36) DEFAULT NULL,
+    PRIMARY KEY (id),
+    KEY idx_task_id (task_id)
+);
+
+INSERT INTO mowl_workflow_cases VALUES ('case-001', 'task-001');
+INSERT INTO mowl_workflow_cases VALUES ('case-002', 'task-002');
+
+-- Test 1: ALTER TABLE ADD COLUMN + CREATE INDEX + UPDATE in same transaction
+BEGIN;
+ALTER TABLE mowl_workflow_cases ADD COLUMN scheduler_visible TINYINT(1) NOT NULL DEFAULT 1;
+CREATE INDEX idx_cases_scheduler ON mowl_workflow_cases (scheduler_visible);
+UPDATE mowl_workflow_cases SET scheduler_visible = 0 WHERE id = 'case-001';
+COMMIT;
+
+-- Verify the UPDATE succeeded
+SELECT id, scheduler_visible FROM mowl_workflow_cases ORDER BY id;
+
+-- Test 2: CREATE INDEX + DELETE in same transaction
+BEGIN;
+CREATE INDEX idx_cases_task ON mowl_workflow_cases (task_id);
+DELETE FROM mowl_workflow_cases WHERE id = 'case-002';
+COMMIT;
+
+-- Verify the DELETE succeeded
+SELECT COUNT(*) FROM mowl_workflow_cases;
+
+drop table mowl_workflow_cases;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24621
issue #24635

## What this PR does / why we need it:

### Root Cause

`txn_table.go` `GetTableDef()` appends `__mo_rowid` to the `Cols` array but did not update the `Name2ColIndex` map. For index tables created within the same transaction, `Name2ColIndex[catalog.Row_ID]` returned `0` (the default int32 value) instead of the actual column position.

This causes `ExpectedEOB` during commit when DELETE operations on index tables use the wrong column as rowid. The bug triggers in same-transaction DDL + DML scenarios:
- `CREATE INDEX` + `UPDATE`/`DELETE` on the indexed table
- `ALTER TABLE ADD INDEX` + DML
- `CREATE TABLE` with inline index + DML

### Fix

Add `name2index[catalog.Row_ID] = int32(len(cols) - 1)` when appending `__mo_rowid` in `txn_table.go`, ensuring `Cols` and `Name2ColIndex` stay in sync.

This allows removal of all workaround scans in `bind_update.go`, `bind_delete.go`, `bind_insert.go`, `bind_replace.go`, and `query_builder.go` that were compensating for the inconsistency.

### Verification

- Added BVT test `index_table_rowid_eob` covering `CREATE INDEX` + `UPDATE`/`DELETE` in same transaction
- Without the fix: test fails with `ExpectedEOB` on COMMIT (75% success rate)
- With the fix: test passes 100%

### Note

Same fix as #24668 (targeting 3.0-dev) and #24669 (targeting main), cherry-picked to 4.0-dev.