### PR TITLE
fix(plan): sanitize non-finite plan stats

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -24,7 +24,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
+	"reflect"
 	gotrace "runtime/trace"
 	"slices"
 	"sort"
@@ -4047,6 +4049,7 @@ func (h *marshalPlanHandler) allocBufferIfNeeded() {
 func (h *marshalPlanHandler) Marshal(ctx context.Context) (jsonBytes []byte) {
 	var err error
 	if h.marshalPlan != nil {
+		sanitizeNonFiniteFloatValues(h.marshalPlan)
 		h.allocBufferIfNeeded()
 		h.buffer.Reset()
 		var jsonBytesLen = 0
@@ -4076,6 +4079,62 @@ func (h *marshalPlanHandler) Marshal(ctx context.Context) (jsonBytes []byte) {
 		return sqlQueryNoRecordExecPlan
 	}
 	return
+}
+
+func sanitizeNonFiniteFloatValues(v any) {
+	sanitizeNonFiniteFloatValue(reflect.ValueOf(v), make(map[uintptr]struct{}))
+}
+
+func sanitizeNonFiniteFloatValue(v reflect.Value, seen map[uintptr]struct{}) {
+	if !v.IsValid() {
+		return
+	}
+	switch v.Kind() {
+	case reflect.Interface:
+		if !v.IsNil() {
+			sanitizeNonFiniteFloatValue(v.Elem(), seen)
+		}
+	case reflect.Ptr:
+		if v.IsNil() {
+			return
+		}
+		ptr := v.Pointer()
+		if _, ok := seen[ptr]; ok {
+			return
+		}
+		seen[ptr] = struct{}{}
+		sanitizeNonFiniteFloatValue(v.Elem(), seen)
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			sanitizeNonFiniteFloatValue(v.Field(i), seen)
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			sanitizeNonFiniteFloatValue(v.Index(i), seen)
+		}
+	case reflect.Map:
+		if v.IsNil() {
+			return
+		}
+		for _, key := range v.MapKeys() {
+			value := v.MapIndex(key)
+			if !value.IsValid() {
+				continue
+			}
+			copied := reflect.New(value.Type()).Elem()
+			copied.Set(value)
+			sanitizeNonFiniteFloatValue(copied, seen)
+			v.SetMapIndex(key, copied)
+		}
+	case reflect.Float32, reflect.Float64:
+		if !v.CanSet() {
+			return
+		}
+		f := v.Float()
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			v.SetFloat(0)
+		}
+	}
 }
 
 var sqlQueryIgnoreExecPlan = []byte(`{}`)

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1351,6 +1352,37 @@ func TestSerializePlanToJson(t *testing.T) {
 		require.Equal(t, int64(0), stats.BytesScan)
 		t.Logf("SQL plan to json : %s\n", string(json))
 	}
+}
+
+func TestMarshalPlanHandlerSanitizesNonFinitePlanStats(t *testing.T) {
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+	stmt := &motrace.StatementInfo{
+		StatementID: uid,
+		Statement:   []byte("select 1"),
+		RequestAt:   time.Now().Add(-2 * time.Second),
+	}
+	logicPlan := &plan0.Plan{
+		Plan: &plan0.Plan_Query{
+			Query: &plan0.Query{
+				Nodes: []*plan0.Node{
+					{
+						NodeId:   0,
+						NodeType: plan0.Node_VALUE_SCAN,
+						Stats: &plan0.Stats{
+							Cost: math.Inf(1),
+						},
+					},
+				},
+				Steps: []int32{0},
+			},
+		},
+	}
+
+	h := NewMarshalPlanHandler(context.Background(), stmt, logicPlan, nil)
+	jsonBytes := h.Marshal(context.Background())
+
+	require.NotContains(t, string(jsonBytes), "serialize plan to json error")
 }
 
 func buildSingleSql(opt plan.Optimizer, t *testing.T, sql string) (*plan.Plan, error) {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -1191,7 +1191,7 @@ func ReCalcNodeStats(nodeID int32, builder *QueryBuilder, recursive bool, leafNo
 			node.Stats.BlockNum = leftStats.BlockNum
 
 		case plan.Node_ANTI:
-			node.Stats.Outcnt = leftStats.Outcnt * (1 - rightStats.Selectivity) * 0.5
+			node.Stats.Outcnt = leftStats.Outcnt * (1 - rightSelectivity) * 0.5
 			node.Stats.Cost = leftStats.Cost + rightStats.Cost
 			node.Stats.HashmapStats.HashmapSize = rightStats.Outcnt
 			node.Stats.Selectivity = selectivity_out

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -75,8 +75,19 @@ func safeRatio(numerator float64, denominator float64, fallback float64) float64
 	return finiteOr(numerator/denominator, fallback)
 }
 
+func clampSelectivity(value float64, fallback float64) float64 {
+	value = finiteOr(value, fallback)
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}
+
 func safeSelectivityRatio(numerator float64, denominator float64) float64 {
-	return safeRatio(numerator, denominator, 1)
+	return clampSelectivity(safeRatio(numerator, denominator, 1), 1)
 }
 
 func SetForceScanOnMultiCN(v bool) {
@@ -626,7 +637,7 @@ func estimateEqualitySelectivity(expr *plan.Expr, builder *QueryBuilder, s *pb.S
 	}
 	ndv := getExprNdv(expr, builder)
 	if ndv > 0 {
-		return 1 / ndv
+		return safeSelectivityRatio(1, ndv)
 	}
 	return 0.01
 }
@@ -926,7 +937,7 @@ func estimateExprSelectivity(expr *plan.Expr, builder *QueryBuilder, s *pb.Stats
 				ret = orSelectivity(ret, sel2)
 			}
 		case "not":
-			ret = 1 - estimateExprSelectivity(exprImpl.F.Args[0], builder, s)
+			ret = clampSelectivity(1-estimateExprSelectivity(exprImpl.F.Args[0], builder, s), 1)
 		case "like":
 			ret = 0.2
 		case "prefix_eq":
@@ -968,6 +979,7 @@ func estimateExprSelectivity(expr *plan.Expr, builder *QueryBuilder, s *pb.Stats
 	case *plan.Expr_Lit:
 		ret = 1.0
 	}
+	ret = clampSelectivity(ret, 1)
 	expr.Selectivity = ret
 	return ret
 }
@@ -1107,8 +1119,10 @@ func ReCalcNodeStats(nodeID int32, builder *QueryBuilder, recursive bool, leafNo
 		//will fix this in the future
 		//isCrossJoin := (len(node.OnList) == 0)
 		isCrossJoin := false
-		selectivity := math.Pow(rightStats.Selectivity, math.Pow(leftStats.Selectivity, 0.2))
-		selectivity_out := andSelectivity(leftStats.Selectivity, rightStats.Selectivity)
+		leftSelectivity := clampSelectivity(leftStats.Selectivity, 1)
+		rightSelectivity := clampSelectivity(rightStats.Selectivity, 1)
+		selectivity := clampSelectivity(math.Pow(rightSelectivity, math.Pow(leftSelectivity, 0.2)), 1)
+		selectivity_out := andSelectivity(leftSelectivity, rightSelectivity)
 
 		for _, pred := range node.OnList {
 			if node.JoinType == plan.Node_DEDUP && node.IsRightJoin {
@@ -1874,21 +1888,21 @@ func compareStats(stats1, stats2 *Stats) bool {
 }
 
 func andSelectivity(s1, s2 float64) float64 {
-	s1 = finiteOr(s1, 1)
-	s2 = finiteOr(s2, 1)
+	s1 = clampSelectivity(s1, 1)
+	s2 = clampSelectivity(s2, 1)
 	if s1 < s2 {
 		s1, s2 = s2, s1
 	}
 	if s1 > 0.02 && s2 > 0.02 {
-		return s1 * s2
+		return clampSelectivity(s1*s2, 1)
 	}
-	return math.Min(s1, s2) * math.Max(math.Pow(s1, s2), math.Pow(s2, s1))
+	return clampSelectivity(math.Min(s1, s2)*math.Max(math.Pow(s1, s2), math.Pow(s2, s1)), 1)
 }
 
 func orSelectivity(s1, s2 float64) float64 {
 	var s float64
-	s1 = finiteOr(s1, 1)
-	s2 = finiteOr(s2, 1)
+	s1 = clampSelectivity(s1, 1)
+	s2 = clampSelectivity(s2, 1)
 	if s1 < s2 {
 		s1, s2 = s2, s1
 	}
@@ -1900,7 +1914,7 @@ func orSelectivity(s1, s2 float64) float64 {
 	if s > 1 {
 		return 1
 	} else {
-		return s
+		return clampSelectivity(s, 1)
 	}
 }
 

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -61,6 +61,24 @@ const LargeBlockThresholdForMultiCN = 32
 // for test
 var ForceScanOnMultiCN atomic.Bool
 
+func finiteOr(value float64, fallback float64) float64 {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return fallback
+	}
+	return value
+}
+
+func safeRatio(numerator float64, denominator float64, fallback float64) float64 {
+	if denominator == 0 || math.IsNaN(denominator) || math.IsInf(denominator, 0) {
+		return fallback
+	}
+	return finiteOr(numerator/denominator, fallback)
+}
+
+func safeSelectivityRatio(numerator float64, denominator float64) float64 {
+	return safeRatio(numerator, denominator, 1)
+}
+
 func SetForceScanOnMultiCN(v bool) {
 	ForceScanOnMultiCN.Store(v)
 }
@@ -426,7 +444,7 @@ func (builder *QueryBuilder) getColNDVRatio(cols []int32, tableDef *TableDef) fl
 	for i := range cols {
 		totalNDV *= s.NdvMap[tableDef.Cols[cols[i]].Name]
 	}
-	result := totalNDV / s.TableCnt
+	result := safeRatio(totalNDV, s.TableCnt, 0)
 	if result > 1 {
 		result = 1
 	}
@@ -498,9 +516,9 @@ func getNullSelectivity(arg *plan.Expr, builder *QueryBuilder, isnull bool) floa
 		s := w.GetStats()
 		nullCnt := float64(s.NullCntMap[col.Name])
 		if isnull {
-			return nullCnt / s.TableCnt
+			return safeRatio(nullCnt, s.TableCnt, 0.1)
 		} else {
-			return 1 - (nullCnt / s.TableCnt)
+			return 1 - safeRatio(nullCnt, s.TableCnt, 0.1)
 		}
 	}
 
@@ -601,7 +619,7 @@ func estimateEqualitySelectivity(expr *plan.Expr, builder *QueryBuilder, s *pb.S
 	}
 	if col.Name == catalog.CPrimaryKeyColName {
 		if s != nil {
-			return 1 / s.TableCnt
+			return safeRatio(1, s.TableCnt, 0.0000001)
 		} else {
 			return 0.0000001
 		}
@@ -914,7 +932,7 @@ func estimateExprSelectivity(expr *plan.Expr, builder *QueryBuilder, s *pb.Stats
 		case "prefix_eq":
 			if containsDynamicParam(expr) {
 				if s != nil {
-					return 100 / s.TableCnt
+					return safeRatio(100, s.TableCnt, 0.0000001)
 				} else {
 					return 0.0000001
 				}
@@ -1362,7 +1380,7 @@ func ReCalcNodeStats(nodeID int32, builder *QueryBuilder, recursive bool, leafNo
 		if cExpr, ok := node.Limit.Expr.(*plan.Expr_Lit); ok {
 			if c, ok := cExpr.Lit.Value.(*plan.Literal_U64Val); ok {
 				node.Stats.Outcnt = float64(c.U64Val)
-				node.Stats.Selectivity = node.Stats.Outcnt / node.Stats.Cost
+				node.Stats.Selectivity = safeSelectivityRatio(node.Stats.Outcnt, node.Stats.Cost)
 			}
 		} else {
 			// Slow path: need to fold the expression
@@ -1375,7 +1393,7 @@ func ReCalcNodeStats(nodeID int32, builder *QueryBuilder, recursive bool, leafNo
 			if cExpr, ok := limitExpr.Expr.(*plan.Expr_Lit); ok {
 				if c, ok := cExpr.Lit.Value.(*plan.Literal_U64Val); ok {
 					node.Stats.Outcnt = float64(c.U64Val)
-					node.Stats.Selectivity = node.Stats.Outcnt / node.Stats.Cost
+					node.Stats.Selectivity = safeSelectivityRatio(node.Stats.Outcnt, node.Stats.Cost)
 				}
 			}
 		}
@@ -1385,7 +1403,7 @@ func ReCalcNodeStats(nodeID int32, builder *QueryBuilder, recursive bool, leafNo
 			if cExpr, ok := node.IndexReaderParam.Limit.Expr.(*plan.Expr_Lit); ok {
 				if c, ok := cExpr.Lit.Value.(*plan.Literal_U64Val); ok {
 					node.Stats.Outcnt = float64(c.U64Val)
-					node.Stats.Selectivity = node.Stats.Outcnt / node.Stats.Cost
+					node.Stats.Selectivity = safeSelectivityRatio(node.Stats.Outcnt, node.Stats.Cost)
 				}
 			} else {
 				// Slow path: need to fold the expression
@@ -1398,7 +1416,7 @@ func ReCalcNodeStats(nodeID int32, builder *QueryBuilder, recursive bool, leafNo
 				if cExpr, ok := limitExpr.Expr.(*plan.Expr_Lit); ok {
 					if c, ok := cExpr.Lit.Value.(*plan.Literal_U64Val); ok {
 						node.Stats.Outcnt = float64(c.U64Val)
-						node.Stats.Selectivity = node.Stats.Outcnt / node.Stats.Cost
+						node.Stats.Selectivity = safeSelectivityRatio(node.Stats.Outcnt, node.Stats.Cost)
 					}
 				}
 			}
@@ -1557,10 +1575,10 @@ func recalcStatsByRuntimeFilter(scanNode *plan.Node, joinNode *plan.Node, builde
 		if scanNode.Stats.Cost > scanNode.Stats.TableCnt {
 			scanNode.Stats.Cost = scanNode.Stats.TableCnt
 		}
-		scanNode.Stats.Selectivity = scanNode.Stats.Outcnt / scanNode.Stats.TableCnt
+		scanNode.Stats.Selectivity = safeSelectivityRatio(scanNode.Stats.Outcnt, scanNode.Stats.TableCnt)
 		return
 	}
-	runtimeFilterSel := builder.qry.Nodes[joinNode.Children[1]].Stats.Selectivity
+	runtimeFilterSel := finiteOr(builder.qry.Nodes[joinNode.Children[1]].Stats.Selectivity, 1)
 	scanNode.Stats.Cost *= runtimeFilterSel
 	scanNode.Stats.Outcnt *= runtimeFilterSel
 	if scanNode.Stats.Cost < 1 {
@@ -1677,7 +1695,7 @@ func forceScanNodeStatsTP(nodeID int32, builder *QueryBuilder) {
 	if stats.BlockNum > 16 {
 		stats.BlockNum = 16
 	}
-	stats.Selectivity = stats.Outcnt / stats.TableCnt
+	stats.Selectivity = safeSelectivityRatio(stats.Outcnt, stats.TableCnt)
 }
 
 func shouldReturnMinimalStats(node *plan.Node) bool {
@@ -1856,6 +1874,8 @@ func compareStats(stats1, stats2 *Stats) bool {
 }
 
 func andSelectivity(s1, s2 float64) float64 {
+	s1 = finiteOr(s1, 1)
+	s2 = finiteOr(s2, 1)
 	if s1 < s2 {
 		s1, s2 = s2, s1
 	}
@@ -1867,6 +1887,8 @@ func andSelectivity(s1, s2 float64) float64 {
 
 func orSelectivity(s1, s2 float64) float64 {
 	var s float64
+	s1 = finiteOr(s1, 1)
+	s2 = finiteOr(s2, 1)
 	if s1 < s2 {
 		s1, s2 = s2, s1
 	}

--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -196,6 +196,43 @@ func TestStatsSelectivityClampAvoidsNonFiniteJoin(t *testing.T) {
 		require.LessOrEqual(t, join.Stats.Selectivity, 1.0)
 		require.True(t, isFinite(join.Stats.Outcnt), "outcnt = %v", join.Stats.Outcnt)
 	})
+
+	t.Run("anti join clamps invalid right selectivity for outcnt", func(t *testing.T) {
+		builder := NewQueryBuilder(planpb.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		left := &planpb.Node{
+			NodeType: planpb.Node_VALUE_SCAN,
+			Stats: &planpb.Stats{
+				Outcnt:      100,
+				Cost:        100,
+				Selectivity: 0.5,
+				BlockNum:    1,
+			},
+		}
+		right := &planpb.Node{
+			NodeType: planpb.Node_VALUE_SCAN,
+			Stats: &planpb.Stats{
+				Outcnt:      10,
+				Cost:        10,
+				Selectivity: math.Inf(1),
+				BlockNum:    1,
+			},
+		}
+		join := &planpb.Node{
+			NodeType: planpb.Node_JOIN,
+			JoinType: planpb.Node_ANTI,
+			Children: []int32{0, 1},
+			Stats:    DefaultStats(),
+		}
+		builder.qry.Nodes = []*planpb.Node{left, right, join}
+
+		ReCalcNodeStats(2, builder, false, false, false)
+
+		require.True(t, isFinite(join.Stats.Outcnt), "outcnt = %v", join.Stats.Outcnt)
+		require.GreaterOrEqual(t, join.Stats.Outcnt, 0.0)
+		require.True(t, isFinite(join.Stats.Selectivity), "selectivity = %v", join.Stats.Selectivity)
+		require.GreaterOrEqual(t, join.Stats.Selectivity, 0.0)
+		require.LessOrEqual(t, join.Stats.Selectivity, 1.0)
+	})
 }
 
 func newStatsTestBuilderWithNDV(colName string, ndv float64) *QueryBuilder {

--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -114,6 +114,122 @@ func TestSafeStatsRatiosAvoidNonFiniteSelectivity(t *testing.T) {
 	})
 }
 
+func TestStatsSelectivityClampAvoidsNonFiniteJoin(t *testing.T) {
+	t.Run("not over year equality stays in range", func(t *testing.T) {
+		builder := newStatsTestBuilderWithNDV("d", 1)
+		col := &planpb.Expr{
+			Expr: &planpb.Expr_Col{
+				Col: &planpb.ColRef{RelPos: 0, ColPos: 0, Name: "d"},
+			},
+		}
+		yearExpr := &planpb.Expr{
+			Expr: &planpb.Expr_F{
+				F: &planpb.Function{
+					Func: &planpb.ObjectRef{ObjName: "year"},
+					Args: []*planpb.Expr{col},
+				},
+			},
+		}
+		eqExpr := &planpb.Expr{
+			Expr: &planpb.Expr_F{
+				F: &planpb.Function{
+					Func: &planpb.ObjectRef{ObjName: "="},
+					Args: []*planpb.Expr{
+						yearExpr,
+						{
+							Expr: &planpb.Expr_P{
+								P: &planpb.ParamRef{Pos: 0},
+							},
+						},
+					},
+				},
+			},
+		}
+		notExpr := &planpb.Expr{
+			Expr: &planpb.Expr_F{
+				F: &planpb.Function{
+					Func: &planpb.ObjectRef{ObjName: "not"},
+					Args: []*planpb.Expr{eqExpr},
+				},
+			},
+		}
+
+		selectivity := estimateExprSelectivity(notExpr, builder, nil)
+
+		require.True(t, isFinite(selectivity), "selectivity = %v", selectivity)
+		require.GreaterOrEqual(t, selectivity, 0.0)
+		require.LessOrEqual(t, selectivity, 1.0)
+	})
+
+	t.Run("join clamps invalid child selectivity before pow", func(t *testing.T) {
+		builder := NewQueryBuilder(planpb.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		left := &planpb.Node{
+			NodeType: planpb.Node_VALUE_SCAN,
+			Stats: &planpb.Stats{
+				Outcnt:      10,
+				Cost:        10,
+				Selectivity: -364,
+				BlockNum:    1,
+			},
+		}
+		right := &planpb.Node{
+			NodeType: planpb.Node_VALUE_SCAN,
+			Stats: &planpb.Stats{
+				Outcnt:      10,
+				Cost:        10,
+				Selectivity: 0.5,
+				BlockNum:    1,
+			},
+		}
+		join := &planpb.Node{
+			NodeType: planpb.Node_JOIN,
+			JoinType: planpb.Node_INNER,
+			Children: []int32{0, 1},
+			Stats:    DefaultStats(),
+		}
+		builder.qry.Nodes = []*planpb.Node{left, right, join}
+
+		ReCalcNodeStats(2, builder, false, false, false)
+
+		require.True(t, isFinite(join.Stats.Selectivity), "selectivity = %v", join.Stats.Selectivity)
+		require.GreaterOrEqual(t, join.Stats.Selectivity, 0.0)
+		require.LessOrEqual(t, join.Stats.Selectivity, 1.0)
+		require.True(t, isFinite(join.Stats.Outcnt), "outcnt = %v", join.Stats.Outcnt)
+	})
+}
+
+func newStatsTestBuilderWithNDV(colName string, ndv float64) *QueryBuilder {
+	statsCache := NewStatsCache()
+	stats := NewStatsInfo()
+	stats.TableCnt = 1000
+	stats.NdvMap[colName] = ndv
+	statsCache.Set(1, stats)
+	ctx := &statsCacheCompilerContext{
+		MockCompilerContext: &MockCompilerContext{ctx: context.Background()},
+		statsCache:          statsCache,
+	}
+	builder := NewQueryBuilder(planpb.Query_SELECT, ctx, false, false)
+	builder.tag2Table[0] = &planpb.TableDef{
+		TblId: 1,
+		Cols: []*planpb.ColDef{
+			{
+				Name: colName,
+				Typ:  planpb.Type{Id: int32(types.T_date)},
+			},
+		},
+	}
+	return builder
+}
+
+type statsCacheCompilerContext struct {
+	*MockCompilerContext
+	statsCache *StatsCache
+}
+
+func (ctx *statsCacheCompilerContext) GetStatsCache() *StatsCache {
+	return ctx.statsCache
+}
+
 func isFinite(v float64) bool {
 	return !math.IsNaN(v) && !math.IsInf(v, 0)
 }

--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -26,6 +27,96 @@ import (
 	index2 "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSafeStatsRatiosAvoidNonFiniteSelectivity(t *testing.T) {
+	t.Run("limit over zero cost", func(t *testing.T) {
+		builder := NewQueryBuilder(planpb.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		node := &planpb.Node{
+			NodeType: planpb.Node_VALUE_SCAN,
+			Stats:    &planpb.Stats{},
+			Limit: &planpb.Expr{
+				Expr: &planpb.Expr_Lit{
+					Lit: &planpb.Literal{
+						Value: &planpb.Literal_U64Val{U64Val: 10},
+					},
+				},
+			},
+		}
+		builder.qry.Nodes = []*planpb.Node{node}
+
+		ReCalcNodeStats(0, builder, false, false, false)
+
+		require.True(t, isFinite(node.Stats.Selectivity), "selectivity = %v", node.Stats.Selectivity)
+	})
+
+	t.Run("runtime filter over zero table count", func(t *testing.T) {
+		builder := NewQueryBuilder(planpb.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		scanNode := &planpb.Node{
+			NodeType: planpb.Node_TABLE_SCAN,
+			Stats: &planpb.Stats{
+				TableCnt: 0,
+				Outcnt:   5,
+				BlockNum: 1,
+			},
+		}
+		buildNode := &planpb.Node{
+			NodeType: planpb.Node_VALUE_SCAN,
+			Stats: &planpb.Stats{
+				Outcnt: 10,
+			},
+		}
+		joinNode := &planpb.Node{
+			NodeType: planpb.Node_JOIN,
+			JoinType: planpb.Node_INDEX,
+			Children: []int32{0, 1},
+		}
+		builder.qry.Nodes = []*planpb.Node{scanNode, buildNode, joinNode}
+
+		recalcStatsByRuntimeFilter(scanNode, joinNode, builder)
+
+		require.True(t, isFinite(scanNode.Stats.Selectivity), "selectivity = %v", scanNode.Stats.Selectivity)
+	})
+
+	t.Run("prefix equality over zero table count", func(t *testing.T) {
+		builder := NewQueryBuilder(planpb.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		expr := &planpb.Expr{
+			Expr: &planpb.Expr_F{
+				F: &planpb.Function{
+					Func: &planpb.ObjectRef{ObjName: "prefix_eq"},
+					Args: []*planpb.Expr{
+						{Expr: &planpb.Expr_P{P: &planpb.ParamRef{Pos: 0}}},
+					},
+				},
+			},
+		}
+		stats := &pb.StatsInfo{TableCnt: 0}
+
+		selectivity := estimateExprSelectivity(expr, builder, stats)
+
+		require.True(t, isFinite(selectivity), "selectivity = %v", selectivity)
+	})
+
+	t.Run("tp force over zero table count", func(t *testing.T) {
+		builder := NewQueryBuilder(planpb.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		node := &planpb.Node{
+			NodeType: planpb.Node_TABLE_SCAN,
+			Stats: &planpb.Stats{
+				TableCnt: 0,
+				Outcnt:   10,
+				Cost:     10,
+			},
+		}
+		builder.qry.Nodes = []*planpb.Node{node}
+
+		forceScanNodeStatsTP(0, builder)
+
+		require.True(t, isFinite(node.Stats.Selectivity), "selectivity = %v", node.Stats.Selectivity)
+	})
+}
+
+func isFinite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}
 
 func makeQueryWithScan(tableType string, rowsize float64, blockNum int32) *planpb.Query {
 	n := &planpb.Node{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24520

## What this PR does / why we need it:

Cherry-pick PR #24643 to 4.0-dev.

This PR prevents non-finite planner statistics from leaking into plan JSON and cost estimation paths by:

- guarding stats ratio calculations against division by zero and non-finite results;
- sanitizing non-finite float values before plan JSON marshaling;
- clamping expression and join selectivity to the valid [0, 1] range;
- clamping ANTI JOIN right-side selectivity before computing output rows;
- adding regression coverage for zero stats, year(...) equality selectivity, NOT/JOIN propagation, ANTI JOIN, and JSON marshal sanitization.
