### PR TITLE
cherry-pick: add rss pressure cache controller

### DIFF
--- a/pkg/cnservice/server.go
+++ b/pkg/cnservice/server.go
@@ -77,6 +77,7 @@ import (
 const (
 	rssCacheFamilyEvictTimeout   = 10 * time.Second
 	rssCacheAdmissionPressureTTL = 2 * time.Minute
+	rssCachePressureTargetOwner  = "cn-rss"
 )
 
 var (
@@ -85,13 +86,22 @@ var (
 
 func makeRSSCacheEvictor(timeout time.Duration) func(context.Context, int64) {
 	return func(ctx context.Context, targetPercent int64) {
-		pressureUntil := time.Now().Add(rssCacheAdmissionPressureTTL)
-		fileservice.SetMemoryCachePressureTargetPercent(targetPercent, pressureUntil)
-
 		memoryCtx, cancel := context.WithTimeoutCause(ctx, timeout, moerr.CauseRSSCacheEvict)
 		defer cancel()
 		evictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
 	}
+}
+
+func setRSSCachePressureTarget(targetPercent int64) {
+	fileservice.SetMemoryCachePressureTargetPercentByOwner(
+		rssCachePressureTargetOwner,
+		targetPercent,
+		time.Now().Add(rssCacheAdmissionPressureTTL),
+	)
+}
+
+func clearRSSCachePressureTarget() {
+	fileservice.ClearMemoryCachePressureTargetByOwner(rssCachePressureTargetOwner)
 }
 
 func NewService(
@@ -224,6 +234,10 @@ func NewService(
 		90.0/100.0,
 		rscthrottler.WithAcquirePolicy(rscthrottler.AcquirePolicyForCNFlushS3),
 		rscthrottler.WithRSSScavenging(),
+		rscthrottler.WithRSSCachePressureTarget(
+			setRSSCachePressureTarget,
+			clearRSSCachePressureTarget,
+		),
 		rscthrottler.WithRSSCacheEvictor(makeRSSCacheEvictor(rssCacheFamilyEvictTimeout)),
 	)
 

--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -38,10 +38,11 @@ const (
 	refreshMaxInterval     = time.Second * 10
 	rssScavengeInterval    = time.Minute
 	rssCacheEvictTimeout   = time.Second * 10
-	rssScavengeTriggerRate = 0.85
 	rssScavengeVisibleRate = 0.70
-	rssCacheEvictSoftRate  = 0.85
-	rssCacheEvictHardRate  = 0.92
+	rssPressureSoftEnter   = 0.85
+	rssPressureHardEnter   = 0.92
+	rssPressureHardExit    = 0.88
+	rssPressureSoftExit    = 0.80
 	rssCacheSoftTarget     = int64(80)
 	rssCacheHardTarget     = int64(50)
 
@@ -49,6 +50,25 @@ const (
 )
 
 var freeOSMemory = debug.FreeOSMemory
+
+type rssPressureState int64
+
+const (
+	rssPressureNone rssPressureState = iota
+	rssPressureSoft
+	rssPressureHard
+)
+
+func (s rssPressureState) String() string {
+	switch s {
+	case rssPressureSoft:
+		return "soft"
+	case rssPressureHard:
+		return "hard"
+	default:
+		return "none"
+	}
+}
 
 type RSCThrottler interface {
 	Refresh()
@@ -76,6 +96,8 @@ type memThrottler struct {
 	lastRSSScavenge    atomic.Int64
 	lastRSSCacheEvict  atomic.Int64
 	lastRSSCacheTarget atomic.Int64
+	rssPressureState   atomic.Int64
+	rssPressureGen     atomic.Int64
 	rssScavengeMu      sync.Mutex
 
 	mergeAvailDebounce atomic.Int64
@@ -91,8 +113,10 @@ type memThrottler struct {
 
 		specializedForMerge bool
 
-		enableRSSScavenging bool
-		rssCacheEvictor     func(ctx context.Context, targetPercent int64)
+		enableRSSScavenging   bool
+		rssCacheEvictor       func(ctx context.Context, targetPercent int64)
+		rssCacheTargetSetter  func(targetPercent int64)
+		rssCacheTargetClearer func()
 	}
 }
 
@@ -194,37 +218,75 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 	if actualMaxMemory <= 0 || actualMaxMemory == math.MaxInt64 {
 		return
 	}
-	if float64(rss) < float64(actualMaxMemory)*rssScavengeTriggerRate {
-		return
-	}
 	visible := m.reserved.Load() + mpool.GlobalStats().NumCurrBytes.Load()
 	if visible < 0 {
 		visible = 0
 	}
-	needFreeOSMemory := float64(visible) < float64(rss)*rssScavengeVisibleRate
-	cacheTargetPercent := int64(0)
-	if float64(rss) >= float64(actualMaxMemory)*rssCacheEvictHardRate {
-		cacheTargetPercent = rssCacheHardTarget
-	} else if float64(rss) >= float64(actualMaxMemory)*rssCacheEvictSoftRate {
-		cacheTargetPercent = rssCacheSoftTarget
+	rssRate := float64(rss) / float64(actualMaxMemory)
+
+	var (
+		prevState              rssPressureState
+		nextState              rssPressureState
+		cacheTargetPercent     int64
+		shouldEvictCache       bool
+		shouldFreeOSMemory     bool
+		shouldSetCacheTarget   bool
+		resetCacheTargetFirst  bool
+		shouldClearCacheTarget bool
+		generation             int64
+	)
+
+	m.rssScavengeMu.Lock()
+	prevState = rssPressureState(m.rssPressureState.Load())
+	nextState = nextRSSPressureState(prevState, rssRate)
+	cacheTargetPercent = rssPressureCacheTarget(nextState)
+
+	if nextState != prevState {
+		generation = m.rssPressureGen.Add(1)
+		m.rssPressureState.Store(int64(nextState))
+	} else {
+		generation = m.rssPressureGen.Load()
 	}
 
-	shouldEvictCache := false
+	if cacheTargetPercent > 0 && m.options.rssCacheTargetSetter != nil {
+		shouldSetCacheTarget = true
+		resetCacheTargetFirst = prevState == rssPressureHard && nextState == rssPressureSoft
+	}
+	if nextState == rssPressureNone && prevState != rssPressureNone {
+		m.lastRSSCacheTarget.Store(0)
+		shouldClearCacheTarget = true
+	}
+
 	if cacheTargetPercent > 0 && m.options.rssCacheEvictor != nil {
-		m.rssScavengeMu.Lock()
 		lastCacheEvict := m.lastRSSCacheEvict.Load()
 		lastTarget := m.lastRSSCacheTarget.Load()
 		cacheEvictExpired := time.Duration(now-lastCacheEvict) > rssScavengeInterval
 		cacheEvictEscalated := lastTarget == 0 || cacheTargetPercent < lastTarget
-		if cacheEvictExpired || cacheEvictEscalated {
+		cachePressureEntered := prevState == rssPressureNone && nextState != rssPressureNone
+		cachePressureDowngraded := prevState == rssPressureHard && nextState == rssPressureSoft
+		if cachePressureDowngraded {
+			m.lastRSSCacheTarget.Store(cacheTargetPercent)
+		}
+		if !cachePressureDowngraded && (cachePressureEntered || cacheEvictExpired || cacheEvictEscalated) {
 			m.lastRSSCacheEvict.Store(now)
 			m.lastRSSCacheTarget.Store(cacheTargetPercent)
 			shouldEvictCache = true
 		}
-		m.rssScavengeMu.Unlock()
 	}
 
-	shouldFreeOSMemory := false
+	if shouldClearCacheTarget && m.options.rssCacheTargetClearer != nil {
+		m.options.rssCacheTargetClearer()
+	}
+	if shouldSetCacheTarget {
+		if resetCacheTargetFirst && m.options.rssCacheTargetClearer != nil {
+			m.options.rssCacheTargetClearer()
+		}
+		m.options.rssCacheTargetSetter(cacheTargetPercent)
+	}
+	m.rssScavengeMu.Unlock()
+
+	needFreeOSMemory := nextState != rssPressureNone &&
+		float64(visible) < float64(rss)*rssScavengeVisibleRate
 	if needFreeOSMemory {
 		last := m.lastRSSScavenge.Load()
 		if time.Duration(now-last) > rssScavengeInterval &&
@@ -232,7 +294,7 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 			shouldFreeOSMemory = true
 		}
 	}
-	if !shouldFreeOSMemory && !shouldEvictCache {
+	if !shouldFreeOSMemory && !shouldEvictCache && !shouldClearCacheTarget && nextState == prevState {
 		return
 	}
 	metric.FSCachePressureTriggerCounter.Inc()
@@ -243,19 +305,67 @@ func (m *memThrottler) tryScavengeRSS(now int64, rss int64) {
 		zap.String("actual-total-memory", common.HumanReadableBytes(int(actualMaxMemory))),
 		zap.Bool("free-os-memory", shouldFreeOSMemory),
 		zap.Bool("evict-cache", shouldEvictCache),
+		zap.Bool("clear-cache-target", shouldClearCacheTarget),
 		zap.Int64("cache-target-percent", cacheTargetPercent),
+		zap.String("pressure-state", nextState.String()),
+		zap.String("previous-pressure-state", prevState.String()),
 		zap.String("detail", m.String()),
 	)
 	if shouldEvictCache {
-		go func(targetPercent int64) {
+		evictor := m.options.rssCacheEvictor
+		free := freeOSMemory
+		go func(targetPercent int64, gen int64) {
+			if m.rssPressureGen.Load() != gen {
+				return
+			}
 			evictCtx, cancel := context.WithTimeout(context.Background(), rssCacheEvictTimeout)
 			defer cancel()
-			m.options.rssCacheEvictor(evictCtx, targetPercent)
-			freeOSMemory()
-		}(cacheTargetPercent)
+			evictor(evictCtx, targetPercent)
+			free()
+		}(cacheTargetPercent, generation)
 	}
 	if shouldFreeOSMemory {
 		freeOSMemory()
+	}
+}
+
+func nextRSSPressureState(prev rssPressureState, rssRate float64) rssPressureState {
+	switch prev {
+	case rssPressureHard:
+		if rssRate <= rssPressureSoftExit {
+			return rssPressureNone
+		}
+		if rssRate <= rssPressureHardExit {
+			return rssPressureSoft
+		}
+		return rssPressureHard
+	case rssPressureSoft:
+		if rssRate >= rssPressureHardEnter {
+			return rssPressureHard
+		}
+		if rssRate <= rssPressureSoftExit {
+			return rssPressureNone
+		}
+		return rssPressureSoft
+	default:
+		if rssRate >= rssPressureHardEnter {
+			return rssPressureHard
+		}
+		if rssRate >= rssPressureSoftEnter {
+			return rssPressureSoft
+		}
+		return rssPressureNone
+	}
+}
+
+func rssPressureCacheTarget(state rssPressureState) int64 {
+	switch state {
+	case rssPressureSoft:
+		return rssCacheSoftTarget
+	case rssPressureHard:
+		return rssCacheHardTarget
+	default:
+		return 0
 	}
 }
 
@@ -426,6 +536,16 @@ func WithRSSScavenging() MemThrottlerOption {
 func WithRSSCacheEvictor(evictor func(ctx context.Context, targetPercent int64)) MemThrottlerOption {
 	return func(throttler *memThrottler) {
 		throttler.options.rssCacheEvictor = evictor
+	}
+}
+
+func WithRSSCachePressureTarget(
+	setter func(targetPercent int64),
+	clearer func(),
+) MemThrottlerOption {
+	return func(throttler *memThrottler) {
+		throttler.options.rssCacheTargetSetter = setter
+		throttler.options.rssCacheTargetClearer = clearer
 	}
 }
 

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -250,6 +250,67 @@ func TestMemThrottlerRSSCacheEvictionByRSSRate(t *testing.T) {
 	require.Equal(t, int64(rssCacheHardTarget), throttler.lastRSSCacheTarget.Load())
 }
 
+func TestMemThrottlerRSSPressureStateTargetLifecycle(t *testing.T) {
+	oldFreeOSMemory := freeOSMemory
+	defer func() { freeOSMemory = oldFreeOSMemory }()
+	freeOSMemory = func() {}
+
+	var setTargets []int64
+	var clearCalls int
+	evictTargets := make(chan int64, 4)
+
+	now := time.Now().UnixNano()
+	throttler := &memThrottler{limitRate: 0.90}
+	throttler.options.enableRSSScavenging = true
+	throttler.options.rssCacheTargetSetter = func(targetPercent int64) {
+		setTargets = append(setTargets, targetPercent)
+	}
+	throttler.options.rssCacheTargetClearer = func() {
+		clearCalls++
+	}
+	throttler.options.rssCacheEvictor = func(_ context.Context, targetPercent int64) {
+		evictTargets <- targetPercent
+	}
+	throttler.actualTotalMemory.Store(1000 * mpool.GB)
+	throttler.limit.Store(900 * mpool.GB)
+	throttler.reserved.Store(800 * mpool.GB)
+
+	throttler.tryScavengeRSS(now, 850*mpool.GB)
+	require.Equal(t, rssPressureSoft, rssPressureState(throttler.rssPressureState.Load()))
+	require.Equal(t, []int64{rssCacheSoftTarget}, setTargets)
+	require.Eventually(t, func() bool {
+		return recvTarget(evictTargets) == rssCacheSoftTarget
+	}, time.Second, time.Millisecond)
+
+	throttler.tryScavengeRSS(now+int64(time.Second), 920*mpool.GB)
+	require.Equal(t, rssPressureHard, rssPressureState(throttler.rssPressureState.Load()))
+	require.Equal(t, []int64{rssCacheSoftTarget, rssCacheHardTarget}, setTargets)
+	require.Eventually(t, func() bool {
+		return recvTarget(evictTargets) == rssCacheHardTarget
+	}, time.Second, time.Millisecond)
+
+	throttler.tryScavengeRSS(now+2*int64(time.Second), 870*mpool.GB)
+	require.Equal(t, rssPressureSoft, rssPressureState(throttler.rssPressureState.Load()))
+	require.Equal(t, []int64{rssCacheSoftTarget, rssCacheHardTarget, rssCacheSoftTarget}, setTargets)
+	require.Equal(t, 1, clearCalls)
+	select {
+	case target := <-evictTargets:
+		t.Fatalf("unexpected downgrade cache evict target %d", target)
+	default:
+	}
+
+	throttler.tryScavengeRSS(now+3*int64(time.Second), 920*mpool.GB)
+	require.Equal(t, rssPressureHard, rssPressureState(throttler.rssPressureState.Load()))
+	require.Equal(t, []int64{rssCacheSoftTarget, rssCacheHardTarget, rssCacheSoftTarget, rssCacheHardTarget}, setTargets)
+	require.Eventually(t, func() bool {
+		return recvTarget(evictTargets) == rssCacheHardTarget
+	}, time.Second, time.Millisecond)
+
+	throttler.tryScavengeRSS(now+4*int64(time.Second), 800*mpool.GB)
+	require.Equal(t, rssPressureNone, rssPressureState(throttler.rssPressureState.Load()))
+	require.Equal(t, 2, clearCalls)
+}
+
 func TestMemThrottlerRSSCacheEvictionConcurrentEscalation(t *testing.T) {
 	oldFreeOSMemory := freeOSMemory
 	defer func() { freeOSMemory = oldFreeOSMemory }()
@@ -284,7 +345,7 @@ func TestMemThrottlerRSSCacheEvictionConcurrentEscalation(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-start
-		throttler.tryScavengeRSS(now, 850*mpool.GB)
+		throttler.tryScavengeRSS(now, 890*mpool.GB)
 	}()
 	go func() {
 		defer wg.Done()

--- a/pkg/fileservice/mem_cache.go
+++ b/pkg/fileservice/mem_cache.go
@@ -38,18 +38,25 @@ type MemCache struct {
 var memCacheCallbackSeed = maphash.MakeSeed()
 
 var (
-	memCachePressureMu            sync.Mutex
-	memCachePressureTargetPercent atomic.Int64
-	memCachePressureDeadline      atomic.Int64
+	memCachePressureMu                sync.Mutex
+	memCachePressureTargets           = make(map[string]memCachePressureTargetState)
+	memCachePressureEffectivePercent  atomic.Int64
+	memCachePressureEffectiveDeadline atomic.Int64
 )
 
+type memCachePressureTargetState struct {
+	percent  int64
+	deadline int64
+}
+
 func SetMemoryCachePressureTargetPercent(percent int64, until time.Time) {
+	SetMemoryCachePressureTargetPercentByOwner("", percent, until)
+}
+
+func SetMemoryCachePressureTargetPercentByOwner(owner string, percent int64, until time.Time) {
 	now := time.Now()
 	if percent <= 0 || !until.After(now) {
-		memCachePressureMu.Lock()
-		memCachePressureTargetPercent.Store(0)
-		memCachePressureDeadline.Store(0)
-		memCachePressureMu.Unlock()
+		ClearMemoryCachePressureTargetByOwner(owner)
 		return
 	}
 	if percent > 100 {
@@ -59,33 +66,83 @@ func SetMemoryCachePressureTargetPercent(percent int64, until time.Time) {
 	memCachePressureMu.Lock()
 	defer memCachePressureMu.Unlock()
 
-	oldDeadline := memCachePressureDeadline.Load()
-	oldPercent := memCachePressureTargetPercent.Load()
+	old := memCachePressureTargets[owner]
+	oldDeadline := old.deadline
+	oldPercent := old.percent
 	if oldDeadline > now.UnixNano() && oldPercent > 0 && oldPercent < percent {
 		return
 	}
-	memCachePressureTargetPercent.Store(percent)
-	memCachePressureDeadline.Store(until.UnixNano())
+	memCachePressureTargets[owner] = memCachePressureTargetState{
+		percent:  percent,
+		deadline: until.UnixNano(),
+	}
+	recomputeMemoryCachePressureTargetLocked(now.UnixNano())
+}
+
+func ClearMemoryCachePressureTarget() {
+	memCachePressureMu.Lock()
+	clear(memCachePressureTargets)
+	recomputeMemoryCachePressureTargetLocked(time.Now().UnixNano())
+	memCachePressureMu.Unlock()
+}
+
+func ClearMemoryCachePressureTargetByOwner(owner string) {
+	memCachePressureMu.Lock()
+	delete(memCachePressureTargets, owner)
+	recomputeMemoryCachePressureTargetLocked(time.Now().UnixNano())
+	memCachePressureMu.Unlock()
 }
 
 func clearMemoryCachePressureTargetForTest() {
-	memCachePressureTargetPercent.Store(0)
-	memCachePressureDeadline.Store(0)
+	ClearMemoryCachePressureTarget()
 }
 
 func memoryCachePressureTarget(capacity int64) (int64, bool) {
-	deadline := memCachePressureDeadline.Load()
-	if deadline == 0 || time.Now().UnixNano() > deadline {
-		return 0, false
+	now := time.Now().UnixNano()
+
+	deadline := memCachePressureEffectiveDeadline.Load()
+	percent := memCachePressureEffectivePercent.Load()
+	if deadline > now && percent > 0 {
+		if percent > 100 {
+			percent = 100
+		}
+		return capacity * percent / 100, true
 	}
-	percent := memCachePressureTargetPercent.Load()
-	if percent <= 0 {
+
+	memCachePressureMu.Lock()
+	defer memCachePressureMu.Unlock()
+
+	percent, _ = recomputeMemoryCachePressureTargetLocked(now)
+	if percent == 0 {
 		return 0, false
 	}
 	if percent > 100 {
 		percent = 100
 	}
 	return capacity * percent / 100, true
+}
+
+func recomputeMemoryCachePressureTargetLocked(now int64) (int64, int64) {
+	percent := int64(0)
+	deadline := int64(0)
+	for owner, target := range memCachePressureTargets {
+		if target.deadline == 0 || now > target.deadline {
+			delete(memCachePressureTargets, owner)
+			continue
+		}
+		if target.percent <= 0 {
+			continue
+		}
+		if percent == 0 || target.percent < percent {
+			percent = target.percent
+			deadline = target.deadline
+		} else if target.percent == percent && target.deadline < deadline {
+			deadline = target.deadline
+		}
+	}
+	memCachePressureEffectivePercent.Store(percent)
+	memCachePressureEffectiveDeadline.Store(deadline)
+	return percent, deadline
 }
 
 func (m *MemCache) callbacksLock(key fscache.CacheKey) *sync.Mutex {

--- a/pkg/fileservice/mem_cache_test.go
+++ b/pkg/fileservice/mem_cache_test.go
@@ -582,6 +582,41 @@ func TestMemoryCachePressureAdmissionSkipsWritesAboveTarget(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestClearMemoryCachePressureTarget(t *testing.T) {
+	clearMemoryCachePressureTargetForTest()
+	defer clearMemoryCachePressureTargetForTest()
+
+	SetMemoryCachePressureTargetPercent(50, time.Now().Add(time.Minute))
+	target, ok := memoryCachePressureTarget(10)
+	assert.True(t, ok)
+	assert.Equal(t, int64(5), target)
+
+	ClearMemoryCachePressureTarget()
+	_, ok = memoryCachePressureTarget(10)
+	assert.False(t, ok)
+}
+
+func TestMemoryCachePressureTargetOwnerIsolation(t *testing.T) {
+	clearMemoryCachePressureTargetForTest()
+	defer clearMemoryCachePressureTargetForTest()
+
+	SetMemoryCachePressureTargetPercentByOwner("cn-rss", 50, time.Now().Add(time.Minute))
+	SetMemoryCachePressureTargetPercentByOwner("workspace-rss", 80, time.Now().Add(time.Minute))
+
+	target, ok := memoryCachePressureTarget(100)
+	assert.True(t, ok)
+	assert.Equal(t, int64(50), target)
+
+	ClearMemoryCachePressureTargetByOwner("workspace-rss")
+	target, ok = memoryCachePressureTarget(100)
+	assert.True(t, ok)
+	assert.Equal(t, int64(50), target)
+
+	ClearMemoryCachePressureTargetByOwner("cn-rss")
+	_, ok = memoryCachePressureTarget(100)
+	assert.False(t, ok)
+}
+
 func TestMemoryCachePressureAdmissionAdmitsGhostEntry(t *testing.T) {
 	ctx := context.Background()
 	clearMemoryCachePressureTargetForTest()

--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -62,17 +62,27 @@ var _ engine.Engine = new(Engine)
 const (
 	workspaceRSSCacheFamilyEvictTimeout   = 10 * time.Second
 	workspaceRSSCacheAdmissionPressureTTL = 2 * time.Minute
+	workspaceRSSCachePressureTargetOwner  = "workspace-rss"
 )
 
 func makeWorkspaceRSSCacheEvictor(timeout time.Duration) func(context.Context, int64) {
 	return func(ctx context.Context, targetPercent int64) {
-		pressureUntil := time.Now().Add(workspaceRSSCacheAdmissionPressureTTL)
-		fileservice.SetMemoryCachePressureTargetPercent(targetPercent, pressureUntil)
-
 		memoryCtx, cancel := context.WithTimeoutCause(ctx, timeout, moerr.CauseWorkspaceRSSCacheEvict)
 		defer cancel()
 		fileservice.EvictMemoryCachesToCapacityPercent(memoryCtx, targetPercent)
 	}
+}
+
+func setWorkspaceRSSCachePressureTarget(targetPercent int64) {
+	fileservice.SetMemoryCachePressureTargetPercentByOwner(
+		workspaceRSSCachePressureTargetOwner,
+		targetPercent,
+		time.Now().Add(workspaceRSSCacheAdmissionPressureTTL),
+	)
+}
+
+func clearWorkspaceRSSCachePressureTarget() {
+	fileservice.ClearMemoryCachePressureTargetByOwner(workspaceRSSCachePressureTargetOwner)
 }
 
 func New(
@@ -159,6 +169,10 @@ func New(
 	if e.config.memThrottler == nil {
 		throttlerOptions := []rscthrottler.MemThrottlerOption{
 			rscthrottler.WithRSSScavenging(),
+			rscthrottler.WithRSSCachePressureTarget(
+				setWorkspaceRSSCachePressureTarget,
+				clearWorkspaceRSSCachePressureTarget,
+			),
 			rscthrottler.WithRSSCacheEvictor(
 				makeWorkspaceRSSCacheEvictor(workspaceRSSCacheFamilyEvictTimeout),
 			),


### PR DESCRIPTION
### What type of PR is this?

/kind improvement

### What this PR does / why we need it:

Cherry-pick #24665 to 4.0-dev.

This backports the RSS pressure controller state machine and cache pressure target lifecycle improvements:
- use none / soft / hard RSS pressure states with hysteresis;
- keep memory cache pressure target as a lease while RSS pressure is active, and clear it immediately after pressure exits;
- separate action throttling from pressure state transitions;
- use owner-scoped memory cache pressure targets so CN and Workspace controllers do not clear each other;
- keep async cache eviction guarded by pressure generation to avoid stale eviction actions from rewriting controller state.

### Which issue(s) this PR fixes:

Refs #24664
Backport of #24665

### Special notes for your reviewer:

The cherry-pick had one conflict in pkg/common/rscthrottler/resource_throttler.go. The conflict was resolved by keeping the main-branch generation guard for async cache eviction.

### Does this PR introduce a user-facing change?

NONE

### How to test:

- GOCACHE=/private/tmp/mo-gocache-pr24665-4dev go test ./pkg/common/rscthrottler ./pkg/fileservice ./pkg/cnservice -run 'TestMemThrottlerRSS|TestMemoryCachePressure|TestClearMemoryCachePressureTarget|TestMakeRSSCacheEvictor' -count=1