### PR TITLE
fix: recompute generated columns in update fallback

### DIFF
--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -701,6 +701,128 @@ func TestUpdate(t *testing.T) {
 	runTestShouldError(mock, t, sqls)
 }
 
+func TestUpdateFallbackGeneratedColumnChainUsesFreshExpr(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	setMockGeneratedColumn(t, mock, "emp", "mgr", "empno")
+	setMockGeneratedColumn(t, mock, "emp", "deptno", "mgr")
+
+	logicPlan, err := runOneStmt(mock, t,
+		"UPDATE emp, dept SET emp.comm = 1, dept.loc = 'chain-marker' WHERE emp.deptno = dept.deptno")
+	if err != nil {
+		t.Fatalf("build fallback update with generated column chain: %v", err)
+	}
+
+	generatedExpr := requireFallbackSourceProjectExpr(t, logicPlan.GetQuery(),
+		len(mock.ctxt.tables["emp"].Cols)+3+len(mock.ctxt.tables["dept"].Cols)+1,
+		len(mock.ctxt.tables["emp"].Cols)+2, "chain-marker")
+	if !exprContainsColName(generatedExpr, "empno") || exprContainsColName(generatedExpr, "mgr") {
+		t.Fatalf("generated column chain should use freshly recomputed earlier generated column, got %s", generatedExpr.String())
+	}
+}
+
+func setMockGeneratedColumn(t *testing.T, mock *MockOptimizer, tableName, generatedName, sourceName string) {
+	tableDef := mock.ctxt.tables[tableName]
+	if tableDef == nil {
+		t.Fatalf("missing mock table %s", tableName)
+	}
+
+	var generatedCol *ColDef
+	var sourceCol *ColDef
+	var sourcePos int32
+	for idx, col := range tableDef.Cols {
+		switch col.Name {
+		case generatedName:
+			generatedCol = col
+		case sourceName:
+			sourceCol = col
+			sourcePos = int32(idx)
+		}
+	}
+	if generatedCol == nil {
+		t.Fatalf("missing generated column %s.%s", tableName, generatedName)
+	}
+	if sourceCol == nil {
+		t.Fatalf("missing generated source column %s.%s", tableName, sourceName)
+	}
+
+	generatedCol.GeneratedCol = &plan.GeneratedCol{
+		Expr: &plan.Expr{
+			Typ: sourceCol.Typ,
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{
+					RelPos: 0,
+					ColPos: sourcePos,
+					Name:   sourceName,
+				},
+			},
+		},
+		IsStored: true,
+	}
+}
+
+func requireFallbackSourceProjectExpr(t *testing.T, query *Query, projectLen int, pos int, marker string) *plan.Expr {
+	for _, node := range query.Nodes {
+		if node.NodeType != plan.Node_PROJECT || len(node.ProjectList) != projectLen || pos >= len(node.ProjectList) {
+			continue
+		}
+		hasMarker := false
+		for _, expr := range node.ProjectList {
+			if exprContainsStringLiteral(expr, marker) {
+				hasMarker = true
+				break
+			}
+		}
+		if !hasMarker {
+			continue
+		}
+		return node.ProjectList[pos]
+	}
+	t.Fatalf("missing fallback source project with length %d and marker %q", projectLen, marker)
+	return nil
+}
+
+func exprContainsStringLiteral(expr *plan.Expr, value string) bool {
+	switch e := expr.Expr.(type) {
+	case *plan.Expr_Lit:
+		if sval, ok := e.Lit.Value.(*plan.Literal_Sval); ok {
+			return sval.Sval == value
+		}
+	case *plan.Expr_F:
+		for _, arg := range e.F.Args {
+			if exprContainsStringLiteral(arg, value) {
+				return true
+			}
+		}
+	case *plan.Expr_List:
+		for _, item := range e.List.List {
+			if exprContainsStringLiteral(item, value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func exprContainsColName(expr *plan.Expr, name string) bool {
+	switch e := expr.Expr.(type) {
+	case *plan.Expr_Col:
+		return e.Col.Name == name || strings.HasSuffix(e.Col.Name, "."+name)
+	case *plan.Expr_F:
+		for _, arg := range e.F.Args {
+			if exprContainsColName(arg, name) {
+				return true
+			}
+		}
+	case *plan.Expr_List:
+		for _, item := range e.List.List {
+			if exprContainsColName(item, name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func TestDelete(t *testing.T) {
 	mock := NewMockOptimizer(true)
 	// should pass

--- a/pkg/sql/plan/build_update.go
+++ b/pkg/sql/plan/build_update.go
@@ -43,6 +43,10 @@ func buildTableUpdate(stmt *tree.Update, ctx CompilerContext, isPrepareStmt bool
 	if err != nil {
 		return nil, err
 	}
+	err = rewriteGeneratedColumnsForUpdate(builder, updatePlanCtxs, lastNodeId)
+	if err != nil {
+		return nil, err
+	}
 
 	sourceStep := builder.appendStep(lastNodeId)
 	query, err := builder.createQuery()
@@ -190,6 +194,68 @@ func rewriteUpdateQueryLastNode(builder *QueryBuilder, planCtxs []*dmlPlanCtx, l
 	return nil
 }
 
+func rewriteGeneratedColumnsForUpdate(builder *QueryBuilder, planCtxs []*dmlPlanCtx, lastNodeId int32) error {
+	selectNode := builder.qry.Nodes[lastNodeId]
+	tableBase := int32(0)
+	for _, upPlanCtx := range planCtxs {
+		tableDef := upPlanCtx.tableDef
+		hasGenerated := false
+		for _, col := range tableDef.Cols {
+			if col.GeneratedCol != nil {
+				hasGenerated = true
+				break
+			}
+		}
+		if hasGenerated {
+			baseLookup := make([]*plan.Expr, len(tableDef.Cols))
+			for ci, col := range tableDef.Cols {
+				if newOff, ok := upPlanCtx.updateColPosMap[col.Name]; ok {
+					baseLookup[ci] = selectNode.ProjectList[tableBase+int32(newOff)]
+				} else {
+					baseLookup[ci] = selectNode.ProjectList[tableBase+int32(ci)]
+				}
+			}
+			for ci, col := range tableDef.Cols {
+				if col.GeneratedCol == nil {
+					continue
+				}
+				if _, alreadySet := upPlanCtx.updateColPosMap[col.Name]; alreadySet {
+					// SET on a generated column is rejected earlier, except SET = DEFAULT,
+					// which is dropped from updateColPosMap and recomputed here.
+					continue
+				}
+				genExpr := substituteColRefsInExpr(col.GeneratedCol.Expr, baseLookup, 0)
+				insertPos := int(tableBase) + len(tableDef.Cols) + upPlanCtx.updateColLength
+				selectNode.ProjectList = append(selectNode.ProjectList, nil)
+				copy(selectNode.ProjectList[insertPos+1:], selectNode.ProjectList[insertPos:])
+				selectNode.ProjectList[insertPos] = genExpr
+				newOffset := int32(insertPos) - tableBase
+				upPlanCtx.updateColPosMap[col.Name] = int(newOffset)
+				upPlanCtx.updateColLength++
+				baseLookup[ci] = genExpr
+			}
+		}
+		tableBase += int32(len(tableDef.Cols) + upPlanCtx.updateColLength)
+	}
+
+	for _, upPlanCtx := range planCtxs {
+		tableDef := upPlanCtx.tableDef
+		for idx, col := range tableDef.Cols {
+			// row_id, compPrimaryKey, clusterByKey are not inserted from old data.
+			if col.Hidden && col.Name != catalog.FakePrimaryKeyColName {
+				continue
+			}
+			if offset, ok := upPlanCtx.updateColPosMap[col.Name]; ok {
+				upPlanCtx.insertColPos = append(upPlanCtx.insertColPos, offset)
+			} else {
+				upPlanCtx.insertColPos = append(upPlanCtx.insertColPos, idx)
+			}
+		}
+	}
+
+	return nil
+}
+
 func selectUpdateTables(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.Update, tableInfo *dmlTableInfo) (int32, []*dmlPlanCtx, error) {
 	fromTables := &tree.From{
 		Tables: stmt.Tables,
@@ -266,18 +332,6 @@ func selectUpdateTables(builder *QueryBuilder, bindCtx *BindContext, stmt *tree.
 		upPlanCtx.allDelTables = map[FkReferKey]struct{}{}
 		upPlanCtx.checkInsertPkDup = true
 		upPlanCtx.updatePkCol = updatePkCol
-
-		for idx, col := range tableDef.Cols {
-			// row_id、compPrimaryKey、clusterByKey will not inserted from old data
-			if col.Hidden && col.Name != catalog.FakePrimaryKeyColName {
-				continue
-			}
-			if offset, ok := updateColPosMap[col.Name]; ok {
-				upPlanCtx.insertColPos = append(upPlanCtx.insertColPos, offset)
-			} else {
-				upPlanCtx.insertColPos = append(upPlanCtx.insertColPos, idx)
-			}
-		}
 
 		updatePlanCtxs[i] = upPlanCtx
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24520

## What this PR does / why we need it:

Fallback UPDATE did not recompute generated columns from the final row image before building the source project for the write path. When generated columns formed a chain, a later generated column could still reference the stale earlier generated column expression instead of the freshly recomputed one.

This change rewrites generated columns in the UPDATE fallback path using the same final-row-image approach already used by INSERT/REPLACE-style flows, then rebuilds insert column positions from the rewritten project layout. It also adds a regression test that covers a fallback multi-table UPDATE with chained generated columns so CI keeps this path stable.