### PR TITLE
fix(plan): sanitize non-finite plan stats (cherry-pick #24672)

### DIFF
--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -24,7 +24,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
+	"reflect"
 	gotrace "runtime/trace"
 	"slices"
 	"sort"
@@ -3829,6 +3831,7 @@ func (h *marshalPlanHandler) allocBufferIfNeeded() {
 func (h *marshalPlanHandler) Marshal(ctx context.Context) (jsonBytes []byte) {
 	var err error
 	if h.marshalPlan != nil {
+		sanitizeNonFiniteFloatValues(h.marshalPlan)
 		h.allocBufferIfNeeded()
 		h.buffer.Reset()
 		var jsonBytesLen = 0
@@ -3858,6 +3861,62 @@ func (h *marshalPlanHandler) Marshal(ctx context.Context) (jsonBytes []byte) {
 		return sqlQueryNoRecordExecPlan
 	}
 	return
+}
+
+func sanitizeNonFiniteFloatValues(v any) {
+	sanitizeNonFiniteFloatValue(reflect.ValueOf(v), make(map[uintptr]struct{}))
+}
+
+func sanitizeNonFiniteFloatValue(v reflect.Value, seen map[uintptr]struct{}) {
+	if !v.IsValid() {
+		return
+	}
+	switch v.Kind() {
+	case reflect.Interface:
+		if !v.IsNil() {
+			sanitizeNonFiniteFloatValue(v.Elem(), seen)
+		}
+	case reflect.Ptr:
+		if v.IsNil() {
+			return
+		}
+		ptr := v.Pointer()
+		if _, ok := seen[ptr]; ok {
+			return
+		}
+		seen[ptr] = struct{}{}
+		sanitizeNonFiniteFloatValue(v.Elem(), seen)
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			sanitizeNonFiniteFloatValue(v.Field(i), seen)
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			sanitizeNonFiniteFloatValue(v.Index(i), seen)
+		}
+	case reflect.Map:
+		if v.IsNil() {
+			return
+		}
+		for _, key := range v.MapKeys() {
+			value := v.MapIndex(key)
+			if !value.IsValid() {
+				continue
+			}
+			copied := reflect.New(value.Type()).Elem()
+			copied.Set(value)
+			sanitizeNonFiniteFloatValue(copied, seen)
+			v.SetMapIndex(key, copied)
+		}
+	case reflect.Float32, reflect.Float64:
+		if !v.CanSet() {
+			return
+		}
+		f := v.Float()
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			v.SetFloat(0)
+		}
+	}
 }
 
 var sqlQueryIgnoreExecPlan = []byte(`{}`)

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -3755,7 +3755,11 @@ func NewMarshalPlanHandler(ctx context.Context, stmt *motrace.StatementInfo, pla
 		h.marshalPlan = explain.BuildJsonPlan(ctx, h.uuid, &explain.MarshalPlanOptions, h.query)
 		h.marshalPlan.NewPlanStats.SetWaitActiveCost(h.waitActiveCost)
 		if phyPlan != nil {
-			h.marshalPlan.PhyPlan = *phyPlan
+			// Deep copy: Marshal sanitizes non-finite floats in place, and a
+			// shallow copy would share slices and the OperatorStats pointers
+			// (whose BackgroundQueries hold live *plan.Query stats), letting the
+			// sanitizer mutate the caller's physical plan.
+			h.marshalPlan.PhyPlan = deepCopyPhyPlan(phyPlan)
 		}
 	}
 	return h
@@ -3861,6 +3865,79 @@ func (h *marshalPlanHandler) Marshal(ctx context.Context) (jsonBytes []byte) {
 		return sqlQueryNoRecordExecPlan
 	}
 	return
+}
+
+func deepCopyPhyPlan(src *models.PhyPlan) models.PhyPlan {
+	dst := *src
+	dst.LocalScope = deepCopyPhyScopes(src.LocalScope)
+	dst.RemoteScope = deepCopyPhyScopes(src.RemoteScope)
+	return dst
+}
+
+func deepCopyPhyScopes(src []models.PhyScope) []models.PhyScope {
+	if src == nil {
+		return nil
+	}
+	dst := make([]models.PhyScope, len(src))
+	for i := range src {
+		dst[i] = deepCopyPhyScope(src[i])
+	}
+	return dst
+}
+
+func deepCopyPhyScope(src models.PhyScope) models.PhyScope {
+	dst := src
+	if src.Receiver != nil {
+		dst.Receiver = append([]models.PhyReceiver(nil), src.Receiver...)
+	}
+	if src.DataSource != nil {
+		ds := *src.DataSource
+		if src.DataSource.Attributes != nil {
+			ds.Attributes = append([]string(nil), src.DataSource.Attributes...)
+		}
+		dst.DataSource = &ds
+	}
+	dst.PreScopes = deepCopyPhyScopes(src.PreScopes)
+	dst.RootOperator = deepCopyPhyOperator(src.RootOperator)
+	return dst
+}
+
+func deepCopyPhyOperator(src *models.PhyOperator) *models.PhyOperator {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	if src.DestReceiver != nil {
+		dst.DestReceiver = append([]models.PhyReceiver(nil), src.DestReceiver...)
+	}
+	dst.OpStats = deepCopyOperatorStats(src.OpStats)
+	if src.Children != nil {
+		dst.Children = make([]*models.PhyOperator, len(src.Children))
+		for i := range src.Children {
+			dst.Children[i] = deepCopyPhyOperator(src.Children[i])
+		}
+	}
+	return &dst
+}
+
+func deepCopyOperatorStats(src *process.OperatorStats) *process.OperatorStats {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	if src.OperatorMetrics != nil {
+		dst.OperatorMetrics = make(map[process.MetricType]int64, len(src.OperatorMetrics))
+		for k, v := range src.OperatorMetrics {
+			dst.OperatorMetrics[k] = v
+		}
+	}
+	if src.BackgroundQueries != nil {
+		dst.BackgroundQueries = make([]*plan.Query, len(src.BackgroundQueries))
+		for i := range src.BackgroundQueries {
+			dst.BackgroundQueries[i] = plan2.DeepCopyQuery(src.BackgroundQueries[i])
+		}
+	}
+	return &dst
 }
 
 func sanitizeNonFiniteFloatValues(v any) {

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -17,6 +17,7 @@ package frontend
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -47,6 +48,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	plan0 "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/txn"
+	"github.com/matrixorigin/matrixone/pkg/sql/models"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
@@ -1153,7 +1155,64 @@ func TestMarshalPlanHandlerSanitizesNonFinitePlanStats(t *testing.T) {
 	h := NewMarshalPlanHandler(context.Background(), stmt, logicPlan, nil)
 	jsonBytes := h.Marshal(context.Background())
 
-	require.NotContains(t, string(jsonBytes), "serialize plan to json error")
+	jsonStr := string(jsonBytes)
+	require.NotContains(t, jsonStr, "serialize plan to json error")
+	require.NotEqual(t, string(sqlQueryIgnoreExecPlan), jsonStr)
+	require.NotEqual(t, string(sqlQueryNoRecordExecPlan), jsonStr)
+	require.NotContains(t, jsonStr, "Inf")
+	require.NotContains(t, jsonStr, "NaN")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(jsonBytes, &decoded), "plan json must be parseable: %s", jsonStr)
+	require.NotEmpty(t, decoded)
+	// the non-finite Cost must have been replaced by a finite value
+	require.Contains(t, jsonStr, `"cost":0`)
+}
+
+// TestMarshalPlanHandlerDoesNotMutateSharedPhyPlan guards against the sanitizer
+// mutating the caller's physical plan: PhyPlan is deep-copied before marshaling,
+// so non-finite stats reachable through OperatorStats.BackgroundQueries (live
+// *plan.Query objects) must be sanitized only on the copy, not the original.
+func TestMarshalPlanHandlerDoesNotMutateSharedPhyPlan(t *testing.T) {
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+	stmt := &motrace.StatementInfo{
+		StatementID: uid,
+		Statement:   []byte("select 1"),
+		RequestAt:   time.Now().Add(-2 * time.Second),
+	}
+	logicPlan := &plan0.Plan{
+		Plan: &plan0.Plan_Query{
+			Query: &plan0.Query{
+				Nodes: []*plan0.Node{{NodeId: 0, NodeType: plan0.Node_VALUE_SCAN, Stats: &plan0.Stats{}}},
+				Steps: []int32{0},
+			},
+		},
+	}
+
+	bgQuery := &plan0.Query{
+		Nodes: []*plan0.Node{
+			{NodeId: 0, NodeType: plan0.Node_VALUE_SCAN, Stats: &plan0.Stats{Cost: math.Inf(1)}},
+		},
+		Steps: []int32{0},
+	}
+	phyPlan := &models.PhyPlan{
+		LocalScope: []models.PhyScope{
+			{
+				Magic: "Normal",
+				RootOperator: &models.PhyOperator{
+					OpName:  "test",
+					OpStats: &process.OperatorStats{BackgroundQueries: []*plan0.Query{bgQuery}},
+				},
+			},
+		},
+	}
+
+	h := NewMarshalPlanHandler(context.Background(), stmt, logicPlan, phyPlan)
+	_ = h.Marshal(context.Background())
+
+	// the caller's live plan stats must be untouched
+	require.True(t, math.IsInf(bgQuery.Nodes[0].Stats.Cost, 1), "shared PhyPlan was mutated by Marshal")
 }
 
 func buildSingleSql(opt plan.Optimizer, t *testing.T, sql string) (*plan.Plan, error) {

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1122,6 +1123,37 @@ func TestSerializePlanToJson(t *testing.T) {
 		require.Equal(t, int64(0), stats.BytesScan)
 		t.Logf("SQL plan to json : %s\n", string(json))
 	}
+}
+
+func TestMarshalPlanHandlerSanitizesNonFinitePlanStats(t *testing.T) {
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+	stmt := &motrace.StatementInfo{
+		StatementID: uid,
+		Statement:   []byte("select 1"),
+		RequestAt:   time.Now().Add(-2 * time.Second),
+	}
+	logicPlan := &plan0.Plan{
+		Plan: &plan0.Plan_Query{
+			Query: &plan0.Query{
+				Nodes: []*plan0.Node{
+					{
+						NodeId:   0,
+						NodeType: plan0.Node_VALUE_SCAN,
+						Stats: &plan0.Stats{
+							Cost: math.Inf(1),
+						},
+					},
+				},
+				Steps: []int32{0},
+			},
+		},
+	}
+
+	h := NewMarshalPlanHandler(context.Background(), stmt, logicPlan, nil)
+	jsonBytes := h.Marshal(context.Background())
+
+	require.NotContains(t, string(jsonBytes), "serialize plan to json error")
 }
 
 func buildSingleSql(opt plan.Optimizer, t *testing.T, sql string) (*plan.Plan, error) {

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -701,6 +701,11 @@ func calcSelectivityByMinMaxForDecimal(funcName string, min, max float64, expr *
 		return 0.1
 	}
 
+	if math.IsNaN(ret) {
+		// max == min with a non-matching bound divides 0/0; the predicate
+		// cannot match, so return the low selectivity instead of leaking NaN.
+		return 0.00000001
+	}
 	if ret < 0 {
 		// Value out of range, return low selectivity
 		return 0.00000001
@@ -753,6 +758,11 @@ func calcSelectivityByMinMax(funcName string, min, max float64, typ types.T, val
 		ret = 0.1
 	}
 
+	if math.IsNaN(ret) {
+		// max == min with a non-matching bound divides 0/0; the predicate
+		// cannot match, so return the low selectivity instead of leaking NaN.
+		return 0.00000001
+	}
 	if ret < 0 {
 		// val out of range, return low sel
 		return 0.00000001
@@ -893,7 +903,7 @@ func estimateExprSelectivity(expr *plan.Expr, builder *QueryBuilder, s *pb.Stats
 		return 1.0
 	}
 	if expr.Selectivity != 0 {
-		return expr.Selectivity // already calculated
+		return clampSelectivity(expr.Selectivity, 1) // already calculated
 	}
 
 	ret := 1.0
@@ -935,7 +945,7 @@ func estimateExprSelectivity(expr *plan.Expr, builder *QueryBuilder, s *pb.Stats
 		case "prefix_eq":
 			if containsDynamicParam(expr) {
 				if s != nil {
-					return safeRatio(100, s.TableCnt, 0.0000001)
+					return clampSelectivity(safeRatio(100, s.TableCnt, 0.0000001), 1)
 				} else {
 					return 0.0000001
 				}

--- a/pkg/sql/plan/stats.go
+++ b/pkg/sql/plan/stats.go
@@ -62,6 +62,35 @@ const LargeBlockThresholdForMultiCN = 32
 // for test
 var ForceScanOnMultiCN atomic.Bool
 
+func finiteOr(value float64, fallback float64) float64 {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return fallback
+	}
+	return value
+}
+
+func safeRatio(numerator float64, denominator float64, fallback float64) float64 {
+	if denominator == 0 || math.IsNaN(denominator) || math.IsInf(denominator, 0) {
+		return fallback
+	}
+	return finiteOr(numerator/denominator, fallback)
+}
+
+func clampSelectivity(value float64, fallback float64) float64 {
+	value = finiteOr(value, fallback)
+	if value < 0 {
+		return 0
+	}
+	if value > 1 {
+		return 1
+	}
+	return value
+}
+
+func safeSelectivityRatio(numerator float64, denominator float64) float64 {
+	return clampSelectivity(safeRatio(numerator, denominator, 1), 1)
+}
+
 func SetForceScanOnMultiCN(v bool) {
 	ForceScanOnMultiCN.Store(v)
 }
@@ -429,7 +458,7 @@ func (builder *QueryBuilder) getColNDVRatio(cols []int32, tableDef *TableDef) fl
 	for i := range cols {
 		totalNDV *= w.Stats.NdvMap[tableDef.Cols[cols[i]].Name]
 	}
-	result := totalNDV / w.Stats.TableCnt
+	result := safeRatio(totalNDV, w.Stats.TableCnt, 0)
 	if result > 1 {
 		result = 1
 	}
@@ -492,9 +521,9 @@ func getNullSelectivity(arg *plan.Expr, builder *QueryBuilder, isnull bool) floa
 		}
 		nullCnt := float64(w.Stats.NullCntMap[col.Name])
 		if isnull {
-			return nullCnt / w.Stats.TableCnt
+			return safeRatio(nullCnt, w.Stats.TableCnt, 0.1)
 		} else {
-			return 1 - (nullCnt / w.Stats.TableCnt)
+			return 1 - safeRatio(nullCnt, w.Stats.TableCnt, 0.1)
 		}
 	}
 
@@ -595,14 +624,14 @@ func estimateEqualitySelectivity(expr *plan.Expr, builder *QueryBuilder, s *pb.S
 	}
 	if col.Name == catalog.CPrimaryKeyColName {
 		if s != nil {
-			return 1 / s.TableCnt
+			return safeRatio(1, s.TableCnt, 0.0000001)
 		} else {
 			return 0.0000001
 		}
 	}
 	ndv := getExprNdv(expr, builder)
 	if ndv > 0 {
-		return 1 / ndv
+		return safeSelectivityRatio(1, ndv)
 	}
 	return 0.01
 }
@@ -900,13 +929,13 @@ func estimateExprSelectivity(expr *plan.Expr, builder *QueryBuilder, s *pb.Stats
 				ret = orSelectivity(ret, sel2)
 			}
 		case "not":
-			ret = 1 - estimateExprSelectivity(exprImpl.F.Args[0], builder, s)
+			ret = clampSelectivity(1-estimateExprSelectivity(exprImpl.F.Args[0], builder, s), 1)
 		case "like":
 			ret = 0.2
 		case "prefix_eq":
 			if containsDynamicParam(expr) {
 				if s != nil {
-					return 100 / s.TableCnt
+					return safeRatio(100, s.TableCnt, 0.0000001)
 				} else {
 					return 0.0000001
 				}
@@ -942,6 +971,7 @@ func estimateExprSelectivity(expr *plan.Expr, builder *QueryBuilder, s *pb.Stats
 	case *plan.Expr_Lit:
 		ret = 1.0
 	}
+	ret = clampSelectivity(ret, 1)
 	expr.Selectivity = ret
 	return ret
 }
@@ -1081,8 +1111,10 @@ func ReCalcNodeStats(nodeID int32, builder *QueryBuilder, recursive bool, leafNo
 		//will fix this in the future
 		//isCrossJoin := (len(node.OnList) == 0)
 		isCrossJoin := false
-		selectivity := math.Pow(rightStats.Selectivity, math.Pow(leftStats.Selectivity, 0.2))
-		selectivity_out := andSelectivity(leftStats.Selectivity, rightStats.Selectivity)
+		leftSelectivity := clampSelectivity(leftStats.Selectivity, 1)
+		rightSelectivity := clampSelectivity(rightStats.Selectivity, 1)
+		selectivity := clampSelectivity(math.Pow(rightSelectivity, math.Pow(leftSelectivity, 0.2)), 1)
+		selectivity_out := andSelectivity(leftSelectivity, rightSelectivity)
 
 		for _, pred := range node.OnList {
 			if node.JoinType == plan.Node_DEDUP && node.IsRightJoin {
@@ -1151,7 +1183,7 @@ func ReCalcNodeStats(nodeID int32, builder *QueryBuilder, recursive bool, leafNo
 			node.Stats.BlockNum = leftStats.BlockNum
 
 		case plan.Node_ANTI:
-			node.Stats.Outcnt = leftStats.Outcnt * (1 - rightStats.Selectivity) * 0.5
+			node.Stats.Outcnt = leftStats.Outcnt * (1 - rightSelectivity) * 0.5
 			node.Stats.Cost = leftStats.Cost + rightStats.Cost
 			node.Stats.HashmapStats.HashmapSize = rightStats.Outcnt
 			node.Stats.Selectivity = selectivity_out
@@ -1359,7 +1391,7 @@ func ReCalcNodeStats(nodeID int32, builder *QueryBuilder, recursive bool, leafNo
 		if cExpr, ok := limitExpr.Expr.(*plan.Expr_Lit); ok {
 			if c, ok := cExpr.Lit.Value.(*plan.Literal_U64Val); ok {
 				node.Stats.Outcnt = float64(c.U64Val)
-				node.Stats.Selectivity = node.Stats.Outcnt / node.Stats.Cost
+				node.Stats.Selectivity = safeSelectivityRatio(node.Stats.Outcnt, node.Stats.Cost)
 			}
 		}
 	}
@@ -1516,10 +1548,10 @@ func recalcStatsByRuntimeFilter(scanNode *plan.Node, joinNode *plan.Node, builde
 		if scanNode.Stats.Cost > scanNode.Stats.TableCnt {
 			scanNode.Stats.Cost = scanNode.Stats.TableCnt
 		}
-		scanNode.Stats.Selectivity = scanNode.Stats.Outcnt / scanNode.Stats.TableCnt
+		scanNode.Stats.Selectivity = safeSelectivityRatio(scanNode.Stats.Outcnt, scanNode.Stats.TableCnt)
 		return
 	}
-	runtimeFilterSel := builder.qry.Nodes[joinNode.Children[1]].Stats.Selectivity
+	runtimeFilterSel := finiteOr(builder.qry.Nodes[joinNode.Children[1]].Stats.Selectivity, 1)
 	scanNode.Stats.Cost *= runtimeFilterSel
 	scanNode.Stats.Outcnt *= runtimeFilterSel
 	if scanNode.Stats.Cost < 1 {
@@ -1630,7 +1662,7 @@ func forceScanNodeStatsTP(nodeID int32, builder *QueryBuilder) {
 	if stats.BlockNum > 16 {
 		stats.BlockNum = 16
 	}
-	stats.Selectivity = stats.Outcnt / stats.TableCnt
+	stats.Selectivity = safeSelectivityRatio(stats.Outcnt, stats.TableCnt)
 }
 
 func shouldReturnMinimalStats(node *plan.Node) bool {
@@ -1803,17 +1835,21 @@ func compareStats(stats1, stats2 *Stats) bool {
 }
 
 func andSelectivity(s1, s2 float64) float64 {
+	s1 = clampSelectivity(s1, 1)
+	s2 = clampSelectivity(s2, 1)
 	if s1 < s2 {
 		s1, s2 = s2, s1
 	}
 	if s1 > 0.02 && s2 > 0.02 {
-		return s1 * s2
+		return clampSelectivity(s1*s2, 1)
 	}
-	return math.Min(s1, s2) * math.Max(math.Pow(s1, s2), math.Pow(s2, s1))
+	return clampSelectivity(math.Min(s1, s2)*math.Max(math.Pow(s1, s2), math.Pow(s2, s1)), 1)
 }
 
 func orSelectivity(s1, s2 float64) float64 {
 	var s float64
+	s1 = clampSelectivity(s1, 1)
+	s2 = clampSelectivity(s2, 1)
 	if s1 < s2 {
 		s1, s2 = s2, s1
 	}
@@ -1825,7 +1861,7 @@ func orSelectivity(s1, s2 float64) float64 {
 	if s > 1 {
 		return 1
 	} else {
-		return s
+		return clampSelectivity(s, 1)
 	}
 }
 

--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
@@ -26,6 +27,249 @@ import (
 	index2 "github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSafeStatsRatiosAvoidNonFiniteSelectivity(t *testing.T) {
+	t.Run("limit over zero cost", func(t *testing.T) {
+		builder := NewQueryBuilder(plan.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		node := &plan.Node{
+			NodeType: plan.Node_VALUE_SCAN,
+			Stats:    &plan.Stats{},
+			Limit: &plan.Expr{
+				Expr: &plan.Expr_Lit{
+					Lit: &plan.Literal{
+						Value: &plan.Literal_U64Val{U64Val: 10},
+					},
+				},
+			},
+		}
+		builder.qry.Nodes = []*plan.Node{node}
+
+		ReCalcNodeStats(0, builder, false, false, false)
+
+		require.True(t, isFinite(node.Stats.Selectivity), "selectivity = %v", node.Stats.Selectivity)
+	})
+
+	t.Run("runtime filter over zero table count", func(t *testing.T) {
+		builder := NewQueryBuilder(plan.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		scanNode := &plan.Node{
+			NodeType: plan.Node_TABLE_SCAN,
+			Stats: &plan.Stats{
+				TableCnt: 0,
+				Outcnt:   5,
+				BlockNum: 1,
+			},
+		}
+		buildNode := &plan.Node{
+			NodeType: plan.Node_VALUE_SCAN,
+			Stats: &plan.Stats{
+				Outcnt: 10,
+			},
+		}
+		joinNode := &plan.Node{
+			NodeType: plan.Node_JOIN,
+			JoinType: plan.Node_INDEX,
+			Children: []int32{0, 1},
+		}
+		builder.qry.Nodes = []*plan.Node{scanNode, buildNode, joinNode}
+
+		recalcStatsByRuntimeFilter(scanNode, joinNode, builder)
+
+		require.True(t, isFinite(scanNode.Stats.Selectivity), "selectivity = %v", scanNode.Stats.Selectivity)
+	})
+
+	t.Run("prefix equality over zero table count", func(t *testing.T) {
+		builder := NewQueryBuilder(plan.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		expr := &plan.Expr{
+			Expr: &plan.Expr_F{
+				F: &plan.Function{
+					Func: &plan.ObjectRef{ObjName: "prefix_eq"},
+					Args: []*plan.Expr{
+						{Expr: &plan.Expr_P{P: &plan.ParamRef{Pos: 0}}},
+					},
+				},
+			},
+		}
+		stats := &pb.StatsInfo{TableCnt: 0}
+
+		selectivity := estimateExprSelectivity(expr, builder, stats)
+
+		require.True(t, isFinite(selectivity), "selectivity = %v", selectivity)
+	})
+
+	t.Run("tp force over zero table count", func(t *testing.T) {
+		builder := NewQueryBuilder(plan.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		node := &plan.Node{
+			NodeType: plan.Node_TABLE_SCAN,
+			Stats: &plan.Stats{
+				TableCnt: 0,
+				Outcnt:   10,
+				Cost:     10,
+			},
+		}
+		builder.qry.Nodes = []*plan.Node{node}
+
+		forceScanNodeStatsTP(0, builder)
+
+		require.True(t, isFinite(node.Stats.Selectivity), "selectivity = %v", node.Stats.Selectivity)
+	})
+}
+
+func TestStatsSelectivityClampAvoidsNonFiniteJoin(t *testing.T) {
+	t.Run("not over year equality stays in range", func(t *testing.T) {
+		builder := newStatsTestBuilderWithNDV("d", 1)
+		col := &plan.Expr{
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{RelPos: 0, ColPos: 0, Name: "d"},
+			},
+		}
+		yearExpr := &plan.Expr{
+			Expr: &plan.Expr_F{
+				F: &plan.Function{
+					Func: &plan.ObjectRef{ObjName: "year"},
+					Args: []*plan.Expr{col},
+				},
+			},
+		}
+		eqExpr := &plan.Expr{
+			Expr: &plan.Expr_F{
+				F: &plan.Function{
+					Func: &plan.ObjectRef{ObjName: "="},
+					Args: []*plan.Expr{
+						yearExpr,
+						{
+							Expr: &plan.Expr_P{
+								P: &plan.ParamRef{Pos: 0},
+							},
+						},
+					},
+				},
+			},
+		}
+		notExpr := &plan.Expr{
+			Expr: &plan.Expr_F{
+				F: &plan.Function{
+					Func: &plan.ObjectRef{ObjName: "not"},
+					Args: []*plan.Expr{eqExpr},
+				},
+			},
+		}
+
+		selectivity := estimateExprSelectivity(notExpr, builder, nil)
+
+		require.True(t, isFinite(selectivity), "selectivity = %v", selectivity)
+		require.GreaterOrEqual(t, selectivity, 0.0)
+		require.LessOrEqual(t, selectivity, 1.0)
+	})
+
+	t.Run("join clamps invalid child selectivity before pow", func(t *testing.T) {
+		builder := NewQueryBuilder(plan.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		left := &plan.Node{
+			NodeType: plan.Node_VALUE_SCAN,
+			Stats: &plan.Stats{
+				Outcnt:      10,
+				Cost:        10,
+				Selectivity: -364,
+				BlockNum:    1,
+			},
+		}
+		right := &plan.Node{
+			NodeType: plan.Node_VALUE_SCAN,
+			Stats: &plan.Stats{
+				Outcnt:      10,
+				Cost:        10,
+				Selectivity: 0.5,
+				BlockNum:    1,
+			},
+		}
+		join := &plan.Node{
+			NodeType: plan.Node_JOIN,
+			JoinType: plan.Node_INNER,
+			Children: []int32{0, 1},
+			Stats:    DefaultStats(),
+		}
+		builder.qry.Nodes = []*plan.Node{left, right, join}
+
+		ReCalcNodeStats(2, builder, false, false, false)
+
+		require.True(t, isFinite(join.Stats.Selectivity), "selectivity = %v", join.Stats.Selectivity)
+		require.GreaterOrEqual(t, join.Stats.Selectivity, 0.0)
+		require.LessOrEqual(t, join.Stats.Selectivity, 1.0)
+		require.True(t, isFinite(join.Stats.Outcnt), "outcnt = %v", join.Stats.Outcnt)
+	})
+
+	t.Run("anti join clamps invalid right selectivity for outcnt", func(t *testing.T) {
+		builder := NewQueryBuilder(plan.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		left := &plan.Node{
+			NodeType: plan.Node_VALUE_SCAN,
+			Stats: &plan.Stats{
+				Outcnt:      100,
+				Cost:        100,
+				Selectivity: 0.5,
+				BlockNum:    1,
+			},
+		}
+		right := &plan.Node{
+			NodeType: plan.Node_VALUE_SCAN,
+			Stats: &plan.Stats{
+				Outcnt:      10,
+				Cost:        10,
+				Selectivity: math.Inf(1),
+				BlockNum:    1,
+			},
+		}
+		join := &plan.Node{
+			NodeType: plan.Node_JOIN,
+			JoinType: plan.Node_ANTI,
+			Children: []int32{0, 1},
+			Stats:    DefaultStats(),
+		}
+		builder.qry.Nodes = []*plan.Node{left, right, join}
+
+		ReCalcNodeStats(2, builder, false, false, false)
+
+		require.True(t, isFinite(join.Stats.Outcnt), "outcnt = %v", join.Stats.Outcnt)
+		require.GreaterOrEqual(t, join.Stats.Outcnt, 0.0)
+		require.True(t, isFinite(join.Stats.Selectivity), "selectivity = %v", join.Stats.Selectivity)
+		require.GreaterOrEqual(t, join.Stats.Selectivity, 0.0)
+		require.LessOrEqual(t, join.Stats.Selectivity, 1.0)
+	})
+}
+
+func newStatsTestBuilderWithNDV(colName string, ndv float64) *QueryBuilder {
+	statsCache := NewStatsCache()
+	stats := NewStatsInfo()
+	stats.TableCnt = 1000
+	stats.NdvMap[colName] = ndv
+	statsCache.SetStatsInfo(1, stats)
+	ctx := &statsCacheCompilerContext{
+		MockCompilerContext: &MockCompilerContext{ctx: context.Background()},
+		statsCache:          statsCache,
+	}
+	builder := NewQueryBuilder(plan.Query_SELECT, ctx, false, false)
+	builder.tag2Table[0] = &plan.TableDef{
+		TblId: 1,
+		Cols: []*plan.ColDef{
+			{
+				Name: colName,
+				Typ:  plan.Type{Id: int32(types.T_date)},
+			},
+		},
+	}
+	return builder
+}
+
+type statsCacheCompilerContext struct {
+	*MockCompilerContext
+	statsCache *StatsCache
+}
+
+func (ctx *statsCacheCompilerContext) GetStatsCache() *StatsCache {
+	return ctx.statsCache
+}
+
+func isFinite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}
 
 // TestUpdateStatsInfo_Decimal64_NegativeValues tests that negative decimal64 values
 // are correctly converted to float64 for statistics

--- a/pkg/sql/plan/stats_test.go
+++ b/pkg/sql/plan/stats_test.go
@@ -96,6 +96,28 @@ func TestSafeStatsRatiosAvoidNonFiniteSelectivity(t *testing.T) {
 		require.True(t, isFinite(selectivity), "selectivity = %v", selectivity)
 	})
 
+	t.Run("prefix equality on small table stays within range", func(t *testing.T) {
+		builder := NewQueryBuilder(plan.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
+		expr := &plan.Expr{
+			Expr: &plan.Expr_F{
+				F: &plan.Function{
+					Func: &plan.ObjectRef{ObjName: "prefix_eq"},
+					Args: []*plan.Expr{
+						{Expr: &plan.Expr_P{P: &plan.ParamRef{Pos: 0}}},
+					},
+				},
+			},
+		}
+		// TableCnt < 100 would make the raw 100/TableCnt ratio exceed 1.
+		stats := &pb.StatsInfo{TableCnt: 10}
+
+		selectivity := estimateExprSelectivity(expr, builder, stats)
+
+		require.True(t, isFinite(selectivity), "selectivity = %v", selectivity)
+		require.GreaterOrEqual(t, selectivity, 0.0)
+		require.LessOrEqual(t, selectivity, 1.0)
+	})
+
 	t.Run("tp force over zero table count", func(t *testing.T) {
 		builder := NewQueryBuilder(plan.Query_SELECT, &MockCompilerContext{ctx: context.Background()}, false, false)
 		node := &plan.Node{
@@ -229,9 +251,31 @@ func TestStatsSelectivityClampAvoidsNonFiniteJoin(t *testing.T) {
 
 		require.True(t, isFinite(join.Stats.Outcnt), "outcnt = %v", join.Stats.Outcnt)
 		require.GreaterOrEqual(t, join.Stats.Outcnt, 0.0)
+		// ANTI outcnt = leftOutcnt * (1 - clamp(rightSel)) * 0.5; clamp(+Inf)=1,
+		// so the (1 - 1) factor forces outcnt to exactly 0.
+		require.Equal(t, 0.0, join.Stats.Outcnt)
 		require.True(t, isFinite(join.Stats.Selectivity), "selectivity = %v", join.Stats.Selectivity)
 		require.GreaterOrEqual(t, join.Stats.Selectivity, 0.0)
 		require.LessOrEqual(t, join.Stats.Selectivity, 1.0)
+	})
+}
+
+func TestCalcSelectivityByMinMaxZeroWidthRange(t *testing.T) {
+	// max == min with a non-matching bound divides 0/0 -> NaN. The helpers must
+	// not leak NaN (which the caller would clamp to full-table selectivity 1);
+	// an impossible predicate must get the low selectivity instead.
+	t.Run("int64 min==max non-matching bound", func(t *testing.T) {
+		// col is always 5; "col > 6" matches nothing. numerator (5-6+1)=0, denom 0.
+		sel := calcSelectivityByMinMax(">", 5, 5, types.T_int64,
+			[]*plan.Literal{{Value: &plan.Literal_I64Val{I64Val: 6}}})
+		require.True(t, isFinite(sel), "selectivity = %v", sel)
+		require.Less(t, sel, 0.001)
+	})
+
+	t.Run("decimal min==max non-matching bound", func(t *testing.T) {
+		sel := calcSelectivityByMinMaxForDecimal(">", 5, 5, makeDecimalComparisonExpr(">", 6.0, 2))
+		require.True(t, isFinite(sel), "selectivity = %v", sel)
+		require.Less(t, sel, 0.001)
 	})
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24520

## What this PR does / why we need it:

Cherry-pick PR #24672 to 3.0-dev.

3.0-dev is affected by the same defect: optimizer stats can produce non-finite (`+Inf`/`NaN`) selectivity via unchecked divisions in `pkg/sql/plan/stats.go`, which then breaks plan JSON marshaling on CN (`serialize plan to json error: json: unsupported value: +Inf`) and drops client connections under load.

This PR prevents non-finite planner statistics from leaking into plan JSON and cost estimation paths by:

- guarding stats ratio calculations against division by zero and non-finite results;
- sanitizing non-finite float values before plan JSON marshaling;
- clamping expression and join selectivity to the valid [0, 1] range;
- clamping ANTI JOIN right-side selectivity before computing output rows;
- adding regression coverage for zero stats, year(...) equality selectivity, NOT/JOIN propagation, ANTI JOIN, and JSON marshal sanitization.

Conflicts were resolved to match 3.0-dev (e.g. `w.Stats` accessor naming, `pb/plan` import alias, and dropping the FUNCTION_SCAN IndexReaderParam path absent in 3.0-dev).