### PR TITLE
fix(frontend): clarify data branch transaction error

### DIFF
--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -868,6 +868,9 @@ func handleBranchMerge(
 	ses *Session,
 	stmt *tree.DataBranchMerge,
 ) (err error) {
+	if ses.proc.GetTxnOperator().TxnOptions().ByBegin {
+		return moerr.NewInternalError(execCtx.reqCtx, dataBranchMergePickExplicitTxnErrorInfo())
+	}
 
 	if stmt.ConflictOpt == nil {
 		stmt.ConflictOpt = &tree.ConflictOpt{

--- a/pkg/frontend/data_branch_pick.go
+++ b/pkg/frontend/data_branch_pick.go
@@ -81,7 +81,7 @@ func handleBranchPick(
 	stmt *tree.DataBranchPick,
 ) (err error) {
 	if ses.proc.GetTxnOperator().TxnOptions().ByBegin {
-		return moerr.NewInternalError(execCtx.reqCtx, "DATA BRANCH PICK is not supported in explicit transactions")
+		return moerr.NewInternalError(execCtx.reqCtx, dataBranchMergePickExplicitTxnErrorInfo())
 	}
 	if stmt.ConflictOpt == nil {
 		stmt.ConflictOpt = &tree.ConflictOpt{

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -95,6 +95,10 @@ func unclassifiedStatementInUncommittedTxnErrorInfo() string {
 	return "unclassified statement appears in uncommitted transaction"
 }
 
+func dataBranchMergePickExplicitTxnErrorInfo() string {
+	return "DATA BRANCH MERGE/PICK is not supported in explicit transactions"
+}
+
 func writeWriteConflictsErrorInfo() string {
 	return "Write conflicts detected. Previous transaction need to be aborted."
 }
@@ -2401,8 +2405,9 @@ func canExecuteStatementInUncommittedTransaction(
 		return err
 	}
 	if !can {
-		if _, ok := stmt.(*tree.DataBranchPick); ok {
-			return moerr.NewInternalError(reqCtx, "DATA BRANCH PICK is not supported in explicit transactions")
+		switch stmt.(type) {
+		case *tree.DataBranchMerge, *tree.DataBranchPick:
+			return moerr.NewInternalError(reqCtx, dataBranchMergePickExplicitTxnErrorInfo())
 		}
 		//is ddl statement
 		if IsCreateDropDatabase(stmt) {

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -1082,6 +1082,25 @@ func Test_statement_type(t *testing.T) {
 	})
 }
 
+func TestCanExecuteDataBranchMergePickInUncommittedTransaction(t *testing.T) {
+	ses := &Session{
+		feSessionImpl: feSessionImpl{},
+	}
+
+	for _, stmt := range []tree.Statement{
+		&tree.DataBranchMerge{},
+		&tree.DataBranchPick{},
+	} {
+		can, err := statementCanBeExecutedInUncommittedTransaction(context.TODO(), ses, stmt)
+		require.NoError(t, err)
+		require.False(t, can)
+
+		err = canExecuteStatementInUncommittedTransaction(context.TODO(), ses, stmt)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), dataBranchMergePickExplicitTxnErrorInfo())
+	}
+}
+
 func Test_convert_type(t *testing.T) {
 	ctx := context.TODO()
 	convey.Convey("type conversion", t, func() {

--- a/pkg/frontend/stmt_kind.go
+++ b/pkg/frontend/stmt_kind.go
@@ -238,7 +238,7 @@ func statementCanBeExecutedInUncommittedTransaction(
 		*tree.DataBranchDeleteTable,
 		*tree.DataBranchDeleteDatabase:
 		return true, nil
-	case *tree.DataBranchPick:
+	case *tree.DataBranchMerge, *tree.DataBranchPick:
 		return false, nil
 	case *tree.CallStmt:
 		// Call procedure can be executed in an uncommitted transaction, usually used in

--- a/pkg/tests/dml/merge_test.go
+++ b/pkg/tests/dml/merge_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 )
 
+const dataBranchMergePickExplicitTxnError = "DATA BRANCH MERGE/PICK is not supported in explicit transactions"
+
 func TestDataBranchMerge(t *testing.T) {
 	embed.RunBaseClusterTests(
 		func(c embed.Cluster) {
@@ -45,6 +47,9 @@ func TestDataBranchMerge(t *testing.T) {
 
 			t.Log("merge simple LCA regression")
 			runMergeSimpleLCARegression(t, ctx, sqlDB)
+
+			t.Log("merge and pick reject explicit transactions")
+			runDataBranchMergePickExplicitTxnError(t, ctx, sqlDB)
 		},
 	)
 }
@@ -92,4 +97,35 @@ func runMergeSimpleLCARegression(t *testing.T, parentCtx context.Context, db *sq
 		},
 		queryStringRows(t, ctx, db, "data branch diff t2 against t1"),
 	)
+}
+
+func runDataBranchMergePickExplicitTxnError(t *testing.T, parentCtx context.Context, db *sql.DB) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
+	defer cancel()
+
+	dbName := testutils.GetDatabaseName(t)
+	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
+	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
+	defer func() {
+		execSQLDB(t, ctx, db, "use mo_catalog")
+		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
+	}()
+
+	execSQLDB(t, ctx, db, "create table base (id int primary key, v int)")
+	execSQLDB(t, ctx, db, "insert into base values (1,1),(2,2)")
+
+	execSQLDB(t, ctx, db, "data branch create table src from base")
+	execSQLDB(t, ctx, db, "update src set v = 9 where id = 1")
+	execSQLDB(t, ctx, db, "begin")
+	errMsg := execExpectError(t, ctx, db, "data branch merge src into base when conflict accept")
+	require.Contains(t, errMsg, dataBranchMergePickExplicitTxnError)
+	execSQLDB(t, ctx, db, "rollback")
+
+	execSQLDB(t, ctx, db, "data branch create table pick_src from base")
+	execSQLDB(t, ctx, db, "insert into pick_src values (3,3)")
+	execSQLDB(t, ctx, db, "begin")
+	errMsg = execExpectError(t, ctx, db, "data branch pick pick_src into base keys(3)")
+	require.Contains(t, errMsg, dataBranchMergePickExplicitTxnError)
+	execSQLDB(t, ctx, db, "rollback")
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24544

## What this PR does / why we need it:

`DATA BRANCH MERGE` previously fell through the uncommitted transaction classifier and returned the generic internal error `unclassified statement appears in uncommitted transaction` when executed inside an explicit transaction.

This PR classifies both `DATA BRANCH MERGE` and `DATA BRANCH PICK` as unsupported in explicit uncommitted transactions and returns a clear shared error:

`DATA BRANCH MERGE/PICK is not supported in explicit transactions`

It also keeps the merge/pick handlers consistent as runtime fallbacks and adds unit plus embedded DML coverage for the explicit transaction error path.

Validation:

- `git diff --check`
- `go test ./pkg/frontend -run TestCanExecuteDataBranchMergePickInUncommittedTransaction -count=1`
- `go test ./pkg/frontend -run 'Test_statement_type|Test_StatementClassify|TestCanExecuteDataBranchMergePickInUncommittedTransaction' -count=1`\n- `go test ./pkg/tests/dml -run TestDataBranchMerge -count=1`\n- `make`\n- `make static-check`