### PR TITLE
fix: truncate decimal integer division

### DIFF
--- a/pkg/container/types/decimal.go
+++ b/pkg/container/types/decimal.go
@@ -1038,6 +1038,12 @@ func (x Decimal128) div128Trunc(y Decimal128) (Decimal128, error) {
 	return x, nil
 }
 
+// Div128Trunc is the exported version of div128Trunc for integer division (DIV)
+// which truncates toward zero instead of rounding half-up.
+func (x Decimal128) Div128Trunc(y Decimal128) (Decimal128, error) {
+	return x.div128Trunc(y)
+}
+
 func (x Decimal256) Div256(y Decimal256) (Decimal256, error) {
 	if y.B128_191 == 0 && y.B192_255 == 0 && y.B64_127 == 0 {
 		if y.B0_63 == 0 {
@@ -1110,6 +1116,12 @@ func (x Decimal256) div256Trunc(y Decimal256) (Decimal256, error) {
 		}
 	}
 	return z.Right(1), nil
+}
+
+// Div256Trunc is the exported version of div256Trunc for integer division (DIV)
+// which truncates toward zero instead of rounding half-up.
+func (x Decimal256) Div256Trunc(y Decimal256) (Decimal256, error) {
+	return x.div256Trunc(y)
 }
 
 func (x Decimal64) Mod64(y Decimal64) (Decimal64, error) {

--- a/pkg/sql/plan/function/arith_decimal_fast.go
+++ b/pkg/sql/plan/function/arith_decimal_fast.go
@@ -1051,6 +1051,112 @@ func d128DivInline(x types.Decimal128, absY64 uint64, signy uint64,
 	return true
 }
 
+// d128IntDivInline is the fast inline path for D128 integer division (DIV).
+// Same as d128DivInline but truncates toward zero instead of rounding half-up.
+func d128IntDivInline(x types.Decimal128, absY64 uint64, signy uint64,
+	scaleFactor uint64, dst *types.Decimal128) bool {
+
+	signx := d128Abs(&x)
+
+	// Inline Scale: multiply |x| by scaleFactor (a uint64 power of 10).
+	var zHi, zLo uint64
+	zHi, zLo = bits.Mul64(x.B0_63, scaleFactor)
+	if x.B64_127 != 0 {
+		crossHi, crossLo := bits.Mul64(x.B64_127, scaleFactor)
+		var carry uint64
+		zHi, carry = bits.Add64(zHi, crossLo, 0)
+		if crossHi|carry|(zHi>>63) != 0 {
+			return false
+		}
+	} else if zHi>>63 != 0 {
+		return false
+	}
+
+	// Inline Div128 for 64-bit divisor: two bits.Div64 calls; no rounding.
+	var rem uint64
+	zHi, rem = bits.Div64(0, zHi, absY64)
+	zLo, _ = bits.Div64(rem, zLo, absY64)
+
+	// Branchless sign restore.
+	z := types.Decimal128{B0_63: zLo, B64_127: zHi}
+	d128Negate(&z, signx^signy)
+	*dst = z
+	return true
+}
+
+// d128IntDivOne computes a single D128 integer division with scale adjustment.
+// Same as d128DivOne but truncates toward zero instead of rounding half-up.
+func d128IntDivOne(x, y types.Decimal128, dst *types.Decimal128, scaleAdj int32, rsnull *nulls.Nulls, idx uint64, shouldError bool, scale1, scale2 int32) error {
+	if d128IsZero(y) {
+		if shouldError {
+			return moerr.NewDivByZeroNoCtx()
+		}
+		rsnull.Add(idx)
+		return nil
+	}
+
+	signxU := d128Abs(&x)
+	signyU := d128Abs(&y)
+	neg := signxU ^ signyU
+
+	if scaleAdj >= 0 {
+		// Scale up x by 10^scaleAdj, then divide by y.
+		z := x
+		if !d128MulPow10(&z, scaleAdj) {
+			// Overflow in scale: fall back to D256 division.
+			x2 := types.Decimal256{B0_63: x.B0_63, B64_127: x.B64_127}
+			y2 := types.Decimal256{B0_63: y.B0_63, B64_127: y.B64_127}
+			if !d256MulPow10(&x2, scaleAdj) {
+				return moerr.NewInvalidInputNoCtxf("Decimal128 IntDiv overflow: %s DIV %s", x.Format(scale1), y.Format(scale2))
+			}
+			x2, divErr := x2.Div256Trunc(y2)
+			if divErr != nil || x2.B192_255 != 0 || x2.B128_191 != 0 || x2.B64_127>>63 != 0 {
+				return moerr.NewInvalidInputNoCtxf("Decimal128 IntDiv overflow: %s DIV %s", x.Format(scale1), y.Format(scale2))
+			}
+			z = types.Decimal128{B0_63: x2.B0_63, B64_127: x2.B64_127}
+			d128Negate(&z, neg)
+			*dst = z
+			return nil
+		}
+		var err error
+		z, err = z.Div128Trunc(y)
+		if err != nil {
+			return err
+		}
+		d128Negate(&z, neg)
+		*dst = z
+		return nil
+	}
+
+	// scaleAdj < 0: scale up y by 10^(-scaleAdj), then divide x by scaled y.
+	negScaleAdj := -scaleAdj
+	scaledY := y
+	if !d128MulPow10(&scaledY, negScaleAdj) {
+		// Overflow in scale: fall back to D256 division.
+		x2 := types.Decimal256{B0_63: x.B0_63, B64_127: x.B64_127}
+		y2 := types.Decimal256{B0_63: y.B0_63, B64_127: y.B64_127}
+		if !d256MulPow10(&y2, negScaleAdj) {
+			return moerr.NewInvalidInputNoCtxf("Decimal128 IntDiv overflow: %s DIV %s", x.Format(scale1), y.Format(scale2))
+		}
+		x2, divErr := x2.Div256Trunc(y2)
+		if divErr != nil || x2.B192_255 != 0 || x2.B128_191 != 0 || x2.B64_127>>63 != 0 {
+			return moerr.NewInvalidInputNoCtxf("Decimal128 IntDiv overflow: %s DIV %s", x.Format(scale1), y.Format(scale2))
+		}
+		z := types.Decimal128{B0_63: x2.B0_63, B64_127: x2.B64_127}
+		d128Negate(&z, neg)
+		*dst = z
+		return nil
+	}
+	var err error
+	z, err := x.Div128Trunc(scaledY)
+	if err != nil {
+		return err
+	}
+	d128Negate(&z, neg)
+	*dst = z
+	return nil
+}
+
 // ---- Decimal128 modulo ----
 
 func d128ModKernel(shouldError bool) func(v1, v2, rs []types.Decimal128, scale1, scale2 int32, rsnull *nulls.Nulls) error {
@@ -1540,36 +1646,15 @@ func d128IntDivKernel(proc *process.Process, selectList *FunctionSelectList) fun
 func d128IntDiv(v1, v2 []types.Decimal128, rs []int64, scale1, scale2 int32, rsnull *nulls.Nulls, shouldError bool) error {
 	bmp := rsnull.GetBitmap()
 	hasNull := !rsnull.IsEmpty()
-	// Compute result scale (same as Decimal128.Div).
-	scale := int32(12)
-	if scale > scale1+6 {
-		scale = scale1 + 6
-	}
-	if scale < scale1 {
-		scale = scale1
-	}
+	// For integer division (DIV), result scale is 0; we want trunc(v1/v2) with no decimal places.
+	// scaleAdj compensates for input scales: scaleAdj = scale2 - scale1.
+	scale := int32(0)
 	scaleAdj := scale - scale1 + scale2
 
 	var scaleFactor uint64
 	canInline := scaleAdj >= 0 && scaleAdj <= 19
 	if canInline {
 		scaleFactor = types.Pow10[scaleAdj]
-	}
-
-	// Hoist pow10 factors for scale-down outside the loop.
-	var sdPow10a uint64
-	var sdTwoStep bool
-	var sdPow10b uint64
-	if scale > 0 {
-		sdPow10a, sdTwoStep, sdPow10b = scalePow10Factors(scale)
-	}
-
-	// Inline IntDiv element: divide, scale-down, convert to int64.
-	intDivElem := func(divResult types.Decimal128) (int64, error) {
-		if scale > 0 {
-			d128ScaleDownPow10(&divResult, sdPow10a, sdTwoStep, sdPow10b)
-		}
-		return decimal128ToInt64(divResult)
 	}
 
 	len1, len2 := len(v1), len(v2)
@@ -1590,13 +1675,13 @@ func d128IntDiv(v1, v2 []types.Decimal128, rs []int64, scale1, scale2 int32, rsn
 				}
 				signy := d128Abs(&y)
 				var divResult types.Decimal128
-				if !d128DivInline(v1[i], y.B0_63, signy, scaleFactor, &divResult) {
-					if err := d128DivOne(v1[i], v2[i], &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+				if !d128IntDivInline(v1[i], y.B0_63, signy, scaleFactor, &divResult) {
+					if err := d128IntDivOne(v1[i], v2[i], &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 						return err
 					}
 				}
 				var err error
-				rs[i], err = intDivElem(divResult)
+				rs[i], err = decimal128ToInt64(divResult)
 				if err != nil {
 					return err
 				}
@@ -1616,11 +1701,25 @@ func d128IntDiv(v1, v2 []types.Decimal128, rs []int64, scale1, scale2 int32, rsn
 				continue
 			}
 			var divResult types.Decimal128
-			if err := d128DivOneDispatch(a, b, &divResult, scaleAdj, scaleFactor, canInline, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+			if canInline {
+				absY := b
+				signyU := d128Abs(&absY)
+				if absY.B64_127 == 0 {
+					if d128IntDivInline(a, absY.B0_63, signyU, scaleFactor, &divResult) {
+						val, err := decimal128ToInt64(divResult)
+						rs[i] = val
+						if err != nil {
+							return err
+						}
+						continue
+					}
+				}
+			}
+			if err := d128IntDivOne(a, b, &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 				return err
 			}
 			var err error
-			rs[i], err = intDivElem(divResult)
+			rs[i], err = decimal128ToInt64(divResult)
 			if err != nil {
 				return err
 			}
@@ -1642,13 +1741,13 @@ func d128IntDiv(v1, v2 []types.Decimal128, rs []int64, scale1, scale2 int32, rsn
 				}
 				signy := d128Abs(&y)
 				var divResult types.Decimal128
-				if !d128DivInline(a, y.B0_63, signy, scaleFactor, &divResult) {
-					if err := d128DivOne(a, v2[i], &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+				if !d128IntDivInline(a, y.B0_63, signy, scaleFactor, &divResult) {
+					if err := d128IntDivOne(a, v2[i], &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 						return err
 					}
 				}
 				var err error
-				rs[i], err = intDivElem(divResult)
+				rs[i], err = decimal128ToInt64(divResult)
 				if err != nil {
 					return err
 				}
@@ -1667,11 +1766,25 @@ func d128IntDiv(v1, v2 []types.Decimal128, rs []int64, scale1, scale2 int32, rsn
 				continue
 			}
 			var divResult types.Decimal128
-			if err := d128DivOneDispatch(a, v2[i], &divResult, scaleAdj, scaleFactor, canInline, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+			if canInline {
+				absY := v2[i]
+				signyU := d128Abs(&absY)
+				if absY.B64_127 == 0 {
+					if d128IntDivInline(a, absY.B0_63, signyU, scaleFactor, &divResult) {
+						val, err := decimal128ToInt64(divResult)
+						rs[i] = val
+						if err != nil {
+							return err
+						}
+						continue
+					}
+				}
+			}
+			if err := d128IntDivOne(a, v2[i], &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 				return err
 			}
 			var err error
-			rs[i], err = intDivElem(divResult)
+			rs[i], err = decimal128ToInt64(divResult)
 			if err != nil {
 				return err
 			}
@@ -1699,13 +1812,13 @@ func d128IntDiv(v1, v2 []types.Decimal128, rs []int64, scale1, scale2 int32, rsn
 					continue
 				}
 				var divResult types.Decimal128
-				if !d128DivInline(v1[i], absY64, signyU, scaleFactor, &divResult) {
-					if err := d128DivOne(v1[i], b, &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+				if !d128IntDivInline(v1[i], absY64, signyU, scaleFactor, &divResult) {
+					if err := d128IntDivOne(v1[i], b, &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 						return err
 					}
 				}
 				var err error
-				rs[i], err = intDivElem(divResult)
+				rs[i], err = decimal128ToInt64(divResult)
 				if err != nil {
 					return err
 				}
@@ -1717,11 +1830,11 @@ func d128IntDiv(v1, v2 []types.Decimal128, rs []int64, scale1, scale2 int32, rsn
 				continue
 			}
 			var divResult types.Decimal128
-			if err := d128DivOne(v1[i], b, &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+			if err := d128IntDivOne(v1[i], b, &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 				return err
 			}
 			var err error
-			rs[i], err = intDivElem(divResult)
+			rs[i], err = decimal128ToInt64(divResult)
 			if err != nil {
 				return err
 			}
@@ -3342,14 +3455,9 @@ func d256IntDiv(v1, v2 []types.Decimal256, rs []int64, scale1, scale2 int32, rsn
 		bmp = rsnull.GetBitmap()
 	}
 
-	// Pre-compute D128 scale factors for fast path.
-	scale := int32(12)
-	if scale > scale1+6 {
-		scale = scale1 + 6
-	}
-	if scale < scale1 {
-		scale = scale1
-	}
+	// For integer division (DIV), result scale is 0; we want trunc(v1/v2) with no decimal places.
+	// scaleAdj compensates for input scales: scaleAdj = scale2 - scale1.
+	scale := int32(0)
 	scaleAdj := scale - scale1 + scale2
 
 	// Pre-scan: if all elements fit in D128, use the fast D128 division path.
@@ -3357,13 +3465,40 @@ func d256IntDiv(v1, v2 []types.Decimal256, rs []int64, scale1, scale2 int32, rsn
 		return d256IntDivViaD128(v1, v2, rs, scale, scaleAdj, rsnull, shouldError, scale1, scale2, hasNull, bmp)
 	}
 
-	// Slow path: generic D256 division.
+	// Slow path: generic D256 integer division.
+	// For integer division, we scale v1 by 10^scaleAdj to compensate for input scales,
+	// then divide by v2 and truncate to int64; no decimal result scale.
 	divGeneric := func(a, b types.Decimal256, dst *int64) error {
-		divResult, resultScale, err := a.Div(b, scale1, scale2)
-		if err != nil {
-			return moerr.NewInvalidInputNoCtxf("Decimal256 Div overflow: %s/%s", a.Format(scale1), b.Format(scale2))
+		signx := a.Sign()
+		signy := b.Sign()
+		absA := a
+		if signx {
+			absA = absA.Minus()
 		}
-		d256ScaleDown(&divResult, resultScale)
+		absB := b
+		if signy {
+			absB = absB.Minus()
+		}
+		if scaleAdj > 0 {
+			var err error
+			absA, err = absA.Scale(scaleAdj)
+			if err != nil {
+				return moerr.NewInvalidInputNoCtxf("Decimal256 IntDiv overflow: %s DIV %s", a.Format(scale1), b.Format(scale2))
+			}
+		} else if scaleAdj < 0 {
+			var err error
+			absB, err = absB.Scale(-scaleAdj)
+			if err != nil {
+				return moerr.NewInvalidInputNoCtxf("Decimal256 IntDiv overflow: %s DIV %s", a.Format(scale1), b.Format(scale2))
+			}
+		}
+		divResult, err := absA.Div256Trunc(absB)
+		if err != nil {
+			return moerr.NewInvalidInputNoCtxf("Decimal256 IntDiv overflow: %s DIV %s", a.Format(scale1), b.Format(scale2))
+		}
+		if signx != signy {
+			divResult = divResult.Minus()
+		}
 		*dst, err = decimal256ToInt64(divResult)
 		return err
 	}
@@ -3430,26 +3565,11 @@ func d256IntDivViaD128(v1, v2 []types.Decimal256, rs []int64, scale, scaleAdj in
 		return types.Decimal128{B0_63: d.B0_63, B64_127: d.B64_127}
 	}
 
-	// Hoist pow10 factors for scale-down.
-	var sdPow10a uint64
-	var sdTwoStep bool
-	var sdPow10b uint64
-	if scale > 0 {
-		sdPow10a, sdTwoStep, sdPow10b = scalePow10Factors(scale)
-	}
-
 	// Pre-compute inline fast path parameters.
 	var scaleFactor uint64
 	canInline := scaleAdj >= 0 && scaleAdj <= 19
 	if canInline {
 		scaleFactor = types.Pow10[scaleAdj]
-	}
-
-	intDivElem := func(divResult types.Decimal128) (int64, error) {
-		if scale > 0 {
-			d128ScaleDownPow10(&divResult, sdPow10a, sdTwoStep, sdPow10b)
-		}
-		return decimal128ToInt64(divResult)
 	}
 
 	// Branchless prescan: check if all D256 divisors (narrowed to D128) fit in 64 bits.
@@ -3463,11 +3583,11 @@ func d256IntDivViaD128(v1, v2 []types.Decimal256, rs []int64, scale, scaleAdj in
 
 	divOneFallback := func(x, y types.Decimal128, dst *int64, idx uint64) error {
 		var divResult types.Decimal128
-		if err := d128DivOne(x, y, &divResult, scaleAdj, rsnull, idx, shouldError, scale1, scale2); err != nil {
+		if err := d128IntDivOne(x, y, &divResult, scaleAdj, rsnull, idx, shouldError, scale1, scale2); err != nil {
 			return err
 		}
 		var err error
-		*dst, err = intDivElem(divResult)
+		*dst, err = decimal128ToInt64(divResult)
 		return err
 	}
 
@@ -3487,14 +3607,14 @@ func d256IntDivViaD128(v1, v2 []types.Decimal256, rs []int64, scale, scaleAdj in
 				}
 				signy := d128Abs(&y)
 				var divResult types.Decimal128
-				if !d128DivInline(d256toD128(v1[i]), y.B0_63, signy, scaleFactor, &divResult) {
+				if !d128IntDivInline(d256toD128(v1[i]), y.B0_63, signy, scaleFactor, &divResult) {
 					if err := divOneFallback(d256toD128(v1[i]), d256toD128(v2[i]), &rs[i], uint64(i)); err != nil {
 						return err
 					}
 					continue
 				}
 				var err error
-				rs[i], err = intDivElem(divResult)
+				rs[i], err = decimal128ToInt64(divResult)
 				if err != nil {
 					return err
 				}
@@ -3534,14 +3654,14 @@ func d256IntDivViaD128(v1, v2 []types.Decimal256, rs []int64, scale, scaleAdj in
 				}
 				signy := d128Abs(&y)
 				var divResult types.Decimal128
-				if !d128DivInline(x, y.B0_63, signy, scaleFactor, &divResult) {
+				if !d128IntDivInline(x, y.B0_63, signy, scaleFactor, &divResult) {
 					if err := divOneFallback(x, d256toD128(v2[i]), &rs[i], uint64(i)); err != nil {
 						return err
 					}
 					continue
 				}
 				var err error
-				rs[i], err = intDivElem(divResult)
+				rs[i], err = decimal128ToInt64(divResult)
 				if err != nil {
 					return err
 				}
@@ -3584,14 +3704,14 @@ func d256IntDivViaD128(v1, v2 []types.Decimal256, rs []int64, scale, scaleAdj in
 						continue
 					}
 					var divResult types.Decimal128
-					if !d128DivInline(d256toD128(v1[i]), absY64, signyU, scaleFactor, &divResult) {
+					if !d128IntDivInline(d256toD128(v1[i]), absY64, signyU, scaleFactor, &divResult) {
 						if err := divOneFallback(d256toD128(v1[i]), y, &rs[i], uint64(i)); err != nil {
 							return err
 						}
 						continue
 					}
 					var err error
-					rs[i], err = intDivElem(divResult)
+					rs[i], err = decimal128ToInt64(divResult)
 					if err != nil {
 						return err
 					}
@@ -4591,7 +4711,7 @@ func d64Mod(v1, v2, rs []types.Decimal64, scale1, scale2 int32, rsnull *nulls.Nu
 
 // ---- Decimal64 integer division ----
 
-// d64IntDivKernel returns a closure for Decimal64 → int64 integer division.
+// d64IntDivKernel returns a closure for Decimal64 to int64 integer division.
 func d64IntDivKernel(proc *process.Process, selectList *FunctionSelectList) func(v1, v2 []types.Decimal64, rs []int64, scale1, scale2 int32, rsnull *nulls.Nulls) error {
 	shouldError := checkDivisionByZeroBehavior(proc, selectList)
 	return func(v1, v2 []types.Decimal64, rs []int64, scale1, scale2 int32, rsnull *nulls.Nulls) error {
@@ -4599,18 +4719,13 @@ func d64IntDivKernel(proc *process.Process, selectList *FunctionSelectList) func
 	}
 }
 
-// d128IntDivKernel returns a closure for Decimal128 → int64 integer division.
+// d64IntDiv computes Decimal64 integer division into int64 results.
 func d64IntDiv(v1, v2 []types.Decimal64, rs []int64, scale1, scale2 int32, rsnull *nulls.Nulls, shouldError bool) error {
 	bmp := rsnull.GetBitmap()
 	hasNull := !rsnull.IsEmpty()
-	// Compute result scale (same as Decimal128.Div).
-	scale := int32(12)
-	if scale > scale1+6 {
-		scale = scale1 + 6
-	}
-	if scale < scale1 {
-		scale = scale1
-	}
+	// For integer division (DIV), result scale is 0; we want trunc(v1/v2) with no decimal places.
+	// scaleAdj compensates for input scales: scaleAdj = scale2 - scale1.
+	scale := int32(0)
 	scaleAdj := scale - scale1 + scale2
 
 	var scaleFactor uint64
@@ -4621,21 +4736,6 @@ func d64IntDiv(v1, v2 []types.Decimal64, rs []int64, scale1, scale2 int32, rsnul
 
 	d64toD128 := func(v types.Decimal64) types.Decimal128 {
 		return types.Decimal128{B0_63: uint64(v), B64_127: uint64(int64(v) >> 63)}
-	}
-
-	// Hoist pow10 factors for scale-down outside the loop.
-	var sdPow10a uint64
-	var sdTwoStep bool
-	var sdPow10b uint64
-	if scale > 0 {
-		sdPow10a, sdTwoStep, sdPow10b = scalePow10Factors(scale)
-	}
-
-	intDivElem := func(divResult types.Decimal128) (int64, error) {
-		if scale > 0 {
-			d128ScaleDownPow10(&divResult, sdPow10a, sdTwoStep, sdPow10b)
-		}
-		return decimal128ToInt64(divResult)
 	}
 
 	len1, len2 := len(v1), len(v2)
@@ -4658,13 +4758,13 @@ func d64IntDiv(v1, v2 []types.Decimal64, rs []int64, scale1, scale2 int32, rsnul
 				absY64 := (uint64(v2[i]) ^ (-signyBit)) + signyBit
 				x := d64toD128(v1[i])
 				var divResult types.Decimal128
-				if !d128DivInline(x, absY64, signyBit, scaleFactor, &divResult) {
-					if err := d128DivOne(x, d64toD128(v2[i]), &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+				if !d128IntDivInline(x, absY64, signyBit, scaleFactor, &divResult) {
+					if err := d128IntDivOne(x, d64toD128(v2[i]), &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 						return err
 					}
 				}
 				var err error
-				rs[i], err = intDivElem(divResult)
+				rs[i], err = decimal128ToInt64(divResult)
 				if err != nil {
 					return err
 				}
@@ -4685,11 +4785,25 @@ func d64IntDiv(v1, v2 []types.Decimal64, rs []int64, scale1, scale2 int32, rsnul
 			}
 			x, y := d64toD128(a), d64toD128(b)
 			var divResult types.Decimal128
-			if err := d128DivOneDispatch(x, y, &divResult, scaleAdj, scaleFactor, canInline, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+			if canInline {
+				absY := y
+				signyU := d128Abs(&absY)
+				if absY.B64_127 == 0 {
+					if d128IntDivInline(x, absY.B0_63, signyU, scaleFactor, &divResult) {
+						val, err := decimal128ToInt64(divResult)
+						rs[i] = val
+						if err != nil {
+							return err
+						}
+						continue
+					}
+				}
+			}
+			if err := d128IntDivOne(x, y, &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 				return err
 			}
 			var err error
-			rs[i], err = intDivElem(divResult)
+			rs[i], err = decimal128ToInt64(divResult)
 			if err != nil {
 				return err
 			}
@@ -4712,13 +4826,13 @@ func d64IntDiv(v1, v2 []types.Decimal64, rs []int64, scale1, scale2 int32, rsnul
 				signyBit := uint64(v2[i]) >> 63
 				absY64 := (uint64(v2[i]) ^ (-signyBit)) + signyBit
 				var divResult types.Decimal128
-				if !d128DivInline(x, absY64, signyBit, scaleFactor, &divResult) {
-					if err := d128DivOne(x, d64toD128(v2[i]), &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+				if !d128IntDivInline(x, absY64, signyBit, scaleFactor, &divResult) {
+					if err := d128IntDivOne(x, d64toD128(v2[i]), &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 						return err
 					}
 				}
 				var err error
-				rs[i], err = intDivElem(divResult)
+				rs[i], err = decimal128ToInt64(divResult)
 				if err != nil {
 					return err
 				}
@@ -4737,11 +4851,25 @@ func d64IntDiv(v1, v2 []types.Decimal64, rs []int64, scale1, scale2 int32, rsnul
 				continue
 			}
 			var divResult types.Decimal128
-			if err := d128DivOneDispatch(x, d64toD128(v2[i]), &divResult, scaleAdj, scaleFactor, canInline, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+			if canInline {
+				absY := d64toD128(v2[i])
+				signyU := d128Abs(&absY)
+				if absY.B64_127 == 0 {
+					if d128IntDivInline(x, absY.B0_63, signyU, scaleFactor, &divResult) {
+						val, err := decimal128ToInt64(divResult)
+						rs[i] = val
+						if err != nil {
+							return err
+						}
+						continue
+					}
+				}
+			}
+			if err := d128IntDivOne(x, d64toD128(v2[i]), &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 				return err
 			}
 			var err error
-			rs[i], err = intDivElem(divResult)
+			rs[i], err = decimal128ToInt64(divResult)
 			if err != nil {
 				return err
 			}
@@ -4770,13 +4898,13 @@ func d64IntDiv(v1, v2 []types.Decimal64, rs []int64, scale1, scale2 int32, rsnul
 				}
 				x := d64toD128(v1[i])
 				var divResult types.Decimal128
-				if !d128DivInline(x, absY64, signyU, scaleFactor, &divResult) {
-					if err := d128DivOne(x, y, &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+				if !d128IntDivInline(x, absY64, signyU, scaleFactor, &divResult) {
+					if err := d128IntDivOne(x, y, &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 						return err
 					}
 				}
 				var err error
-				rs[i], err = intDivElem(divResult)
+				rs[i], err = decimal128ToInt64(divResult)
 				if err != nil {
 					return err
 				}
@@ -4789,11 +4917,11 @@ func d64IntDiv(v1, v2 []types.Decimal64, rs []int64, scale1, scale2 int32, rsnul
 			}
 			x := d64toD128(v1[i])
 			var divResult types.Decimal128
-			if err := d128DivOne(x, y, &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
+			if err := d128IntDivOne(x, y, &divResult, scaleAdj, rsnull, uint64(i), shouldError, scale1, scale2); err != nil {
 				return err
 			}
 			var err error
-			rs[i], err = intDivElem(divResult)
+			rs[i], err = decimal128ToInt64(divResult)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/plan/function/arith_decimal_fast_test.go
+++ b/pkg/sql/plan/function/arith_decimal_fast_test.go
@@ -2950,14 +2950,17 @@ func BenchmarkD256IntDiv_Generic(b *testing.B) {
 
 // refD128IntDiv computes the reference result for D128 integer division.
 func refD128IntDiv(x, y types.Decimal128, scale1, scale2 int32) (int64, error) {
-	r, rScale, err := x.Div(y, scale1, scale2)
-	if err != nil {
-		return 0, err
+	signx := x.Sign()
+	signy := y.Sign()
+	if signx {
+		x = x.Minus()
 	}
-	if rScale > 0 {
-		r, _ = r.Scale(-rScale)
+	if signy {
+		y = y.Minus()
 	}
-	return decimal128ToInt64(r)
+	x256 := types.Decimal256{B0_63: x.B0_63, B64_127: x.B64_127}
+	y256 := types.Decimal256{B0_63: y.B0_63, B64_127: y.B64_127}
+	return refD256IntDivUnsigned(x256, y256, signx != signy, scale1, scale2)
 }
 
 func TestD64IntDiv(t *testing.T) {
@@ -3169,12 +3172,34 @@ func TestD128IntDiv(t *testing.T) {
 
 // refD256IntDiv computes the reference result for D256 integer division.
 func refD256IntDiv(x, y types.Decimal256, scale1, scale2 int32) (int64, error) {
-	r, rScale, err := x.Div(y, scale1, scale2)
+	signx := x.Sign()
+	signy := y.Sign()
+	if signx {
+		x = x.Minus()
+	}
+	if signy {
+		y = y.Minus()
+	}
+	return refD256IntDivUnsigned(x, y, signx != signy, scale1, scale2)
+}
+
+func refD256IntDivUnsigned(x, y types.Decimal256, neg bool, scale1, scale2 int32) (int64, error) {
+	scaleAdj := scale2 - scale1
+	var err error
+	if scaleAdj > 0 {
+		x, err = x.Scale(scaleAdj)
+	} else if scaleAdj < 0 {
+		y, err = y.Scale(-scaleAdj)
+	}
 	if err != nil {
 		return 0, err
 	}
-	if rScale > 0 {
-		r, _ = r.Scale(-rScale)
+	r, err := x.Div256Trunc(y)
+	if err != nil {
+		return 0, err
+	}
+	if neg {
+		r = r.Minus()
 	}
 	return decimal256ToInt64(r)
 }
@@ -3197,6 +3222,18 @@ func TestD256IntDiv(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, want, rs[i], "d256IntDiv[%d]", i)
 		}
+	})
+
+	t.Run("GenericPathTruncates", func(t *testing.T) {
+		x := types.Decimal256{B128_191: 5}
+		y := types.Decimal256{B128_191: 2}
+		v1 := []types.Decimal256{x, x.Minus()}
+		v2 := []types.Decimal256{y, y}
+		rs := make([]int64, len(v1))
+		nul := nulls.NewWithSize(len(v1))
+
+		require.NoError(t, d256IntDiv(v1, v2, rs, 0, 0, nul, true))
+		require.Equal(t, []int64{2, -2}, rs)
 	})
 
 	t.Run("ScalarVec", func(t *testing.T) {

--- a/pkg/sql/plan/function/decimal256_support_test.go
+++ b/pkg/sql/plan/function/decimal256_support_test.go
@@ -368,7 +368,7 @@ func TestDecimal256ArithmeticFns(t *testing.T) {
 			NewFunctionTestInput(dec4, []types.Decimal256{left}, []bool{false}),
 			NewFunctionTestInput(dec2, []types.Decimal256{right}, []bool{false}),
 		},
-		NewFunctionTestResult(types.T_int64.ToType(), false, []int64{3}, []bool{false}),
+		NewFunctionTestResult(types.T_int64.ToType(), false, []int64{2}, []bool{false}),
 		integerDivFn,
 	)
 	ok, info = intDivTC.Run()

--- a/pkg/sql/plan/function/div_issue_test.go
+++ b/pkg/sql/plan/function/div_issue_test.go
@@ -1,0 +1,51 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecimal128IntDivCorrectness(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	typ := types.T_decimal128.ToType()
+
+	testCases := []struct {
+		info     string
+		left     types.Decimal128
+		right    types.Decimal128
+		expected int64
+	}{
+		{"14 DIV 3 = 4", mustParseD128("14"), mustParseD128("3"), 4},
+		{"12 DIV 3 = 4", mustParseD128("12"), mustParseD128("3"), 4},
+		{"10 DIV 3 = 3", mustParseD128("10"), mustParseD128("3"), 3},
+		{"5 DIV 3 = 1", mustParseD128("5"), mustParseD128("3"), 1},
+		{"100 DIV 7 = 14", mustParseD128("100"), mustParseD128("7"), 14},
+		{"1 DIV 3 = 0", mustParseD128("1"), mustParseD128("3"), 0},
+		{"0 DIV 3 = 0", mustParseD128("0"), mustParseD128("3"), 0},
+	}
+
+	for _, tc := range testCases {
+		tcc := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(typ, []types.Decimal128{tc.left}, []bool{false}),
+				NewFunctionTestInput(typ, []types.Decimal128{tc.right}, []bool{false}),
+			},
+			NewFunctionTestResult(types.T_int64.ToType(), false, []int64{tc.expected}, []bool{false}),
+			integerDivFn,
+		)
+		succeed, info := tcc.Run()
+		require.True(t, succeed, tc.info, info)
+	}
+}
+
+func mustParseD128(s string) types.Decimal128 {
+	d, err := types.ParseDecimal128(s, 38, 0)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}


### PR DESCRIPTION
 ## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) does this PR fix or relate to?

Fixes https://github.com/matrixorigin/matrixone/issues/24108

## What this PR does / why we need it:
## Summary
- backport decimal DIV truncation fix from main
- make decimal integer division use scale 0 and truncation toward zero
- include decimal DIV regression tests, including D256 generic-path coverage

## Tests
- C_INCLUDE_PATH=$PWD/thirdparties/install/include CPATH=$PWD/thirdparties/install/include LIBRARY_PATH=$PWD/thirdparties/install/lib go test ./pkg/sql/plan/function/ -count=1
- C_INCLUDE_PATH=$PWD/thirdparties/install/include CPATH=$PWD/thirdparties/install/include LIBRARY_PATH=$PWD/thirdparties/install/lib go build ./pkg/sql/plan/function/