### PR TITLE
fix: truncate decimal integer division

### DIFF
--- a/pkg/container/types/decimal.go
+++ b/pkg/container/types/decimal.go
@@ -827,6 +827,28 @@ func (x Decimal128) Div128(y Decimal128) (Decimal128, error) {
 	return x, nil
 }
 
+func (x Decimal128) Div128Trunc(y Decimal128) (Decimal128, error) {
+	if y.B0_63 == 0 && y.B64_127 == 0 {
+		return x, moerr.NewInvalidInputNoCtxf("Decimal128 Div by Zero: %s/%s", x.Format(0), y.Format(0))
+	}
+	if y.B64_127 == 0 {
+		x.B64_127, y.B64_127 = bits.Div64(0, x.B64_127, y.B0_63)
+		x.B0_63, _ = bits.Div64(y.B64_127, x.B0_63, y.B0_63)
+	} else {
+		if x.Less(y) {
+			x.B64_127 = 0
+			x.B0_63 = 0
+		} else {
+			n := bits.LeadingZeros64(y.B64_127)
+			v, _ := bits.Div64(x.B64_127, x.B0_63, y.Right(64-n).B0_63)
+			v >>= 63 - n
+			x.B0_63 = v >> 1
+			x.B64_127 = 0
+		}
+	}
+	return x, nil
+}
+
 func (x Decimal256) Div256(y Decimal256) (Decimal256, error) {
 	if y.B128_191 == 0 && y.B192_255 == 0 && y.B64_127 == 0 {
 		if y.B0_63 == 0 {

--- a/pkg/sql/plan/function/arithmetic.go
+++ b/pkg/sql/plan/function/arithmetic.go
@@ -704,50 +704,11 @@ func decimalIntegerDiv[T types.Decimal64 | types.Decimal128](parameters []*vecto
 		case types.Decimal128:
 			d1 := any(v1).(types.Decimal128)
 			d2 := any(v2).(types.Decimal128)
-			// For integer DIV: align scales then use truncating integer division.
-			// When scales are equal, raw1/raw2 is the correct truncated integer quotient.
-			if scale1 != scale2 {
-				if scale1 < scale2 {
-					d1, err = d1.Scale(scale2 - scale1)
-				} else {
-					d2, err = d2.Scale(scale1 - scale2)
-				}
-				if err != nil {
-					return err
-				}
-			}
-			// Truncating integer division via decimal128ToInt64 then int64 division
-			n1, convErr := decimal128ToInt64(d1)
-			if convErr != nil {
-				return convErr
-			}
-			n2, convErr := decimal128ToInt64(d2)
-			if convErr != nil {
-				return convErr
-			}
-			rss[i] = n1 / n2
+			rss[i], err = decimal128IntDivToInt64(d1, d2, scale1, scale2)
 		case types.Decimal64:
 			d1Val := any(v1).(types.Decimal64)
 			d2Val := any(v2).(types.Decimal64)
-			n1 := int64(d1Val)
-			n2 := int64(d2Val)
-			if scale1 != scale2 {
-				// Align scales by multiplying the smaller-scale value
-				if scale1 < scale2 {
-					for s := scale1; s < scale2; s++ {
-						n1 *= 10
-					}
-				} else {
-					for s := scale2; s < scale1; s++ {
-						n2 *= 10
-					}
-				}
-			}
-			if n2 == 0 {
-				rsNull.Add(i)
-				continue
-			}
-			rss[i] = n1 / n2
+			rss[i], err = decimal128IntDivToInt64(decimal64ToDecimal128(d1Val), decimal64ToDecimal128(d2Val), scale1, scale2)
 		default:
 			panic("unsupported decimal type")
 		}
@@ -756,6 +717,41 @@ func decimalIntegerDiv[T types.Decimal64 | types.Decimal128](parameters []*vecto
 		}
 	}
 	return nil
+}
+
+func decimal64ToDecimal128(v types.Decimal64) types.Decimal128 {
+	return types.Decimal128{B0_63: uint64(v), B64_127: uint64(int64(v) >> 63)}
+}
+
+func decimal128IntDivToInt64(x, y types.Decimal128, scale1, scale2 int32) (int64, error) {
+	signx := x.Sign()
+	signy := y.Sign()
+	if signx {
+		x = x.Minus()
+	}
+	if signy {
+		y = y.Minus()
+	}
+
+	scaleAdj := scale2 - scale1
+	var err error
+	if scaleAdj > 0 {
+		x, err = x.Scale(scaleAdj)
+	} else if scaleAdj < 0 {
+		y, err = y.Scale(-scaleAdj)
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	x, err = x.Div128Trunc(y)
+	if err != nil {
+		return 0, err
+	}
+	if signx != signy {
+		x = x.Minus()
+	}
+	return decimal128ToInt64(x)
 }
 
 func modFn(parameters []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {

--- a/pkg/sql/plan/function/div_issue_test.go
+++ b/pkg/sql/plan/function/div_issue_test.go
@@ -1,0 +1,51 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecimal128IntDivCorrectness(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	typ := types.New(types.T_decimal128, 38, 0)
+
+	testCases := []struct {
+		info     string
+		left     types.Decimal128
+		right    types.Decimal128
+		expected int64
+	}{
+		{"14 DIV 3 = 4", mustParseD128("14"), mustParseD128("3"), 4},
+		{"12 DIV 3 = 4", mustParseD128("12"), mustParseD128("3"), 4},
+		{"10 DIV 3 = 3", mustParseD128("10"), mustParseD128("3"), 3},
+		{"5 DIV 3 = 1", mustParseD128("5"), mustParseD128("3"), 1},
+		{"100 DIV 7 = 14", mustParseD128("100"), mustParseD128("7"), 14},
+		{"1 DIV 3 = 0", mustParseD128("1"), mustParseD128("3"), 0},
+		{"0 DIV 3 = 0", mustParseD128("0"), mustParseD128("3"), 0},
+		{"-14 DIV 3 = -4", mustParseD128("-14"), mustParseD128("3"), -4},
+	}
+
+	for _, tc := range testCases {
+		tcc := NewFunctionTestCase(proc,
+			[]FunctionTestInput{
+				NewFunctionTestInput(typ, []types.Decimal128{tc.left}, []bool{false}),
+				NewFunctionTestInput(typ, []types.Decimal128{tc.right}, []bool{false}),
+			},
+			NewFunctionTestResult(types.T_int64.ToType(), false, []int64{tc.expected}, []bool{false}),
+			integerDivFn,
+		)
+		succeed, info := tcc.Run()
+		require.True(t, succeed, tc.info, info)
+	}
+}
+
+func mustParseD128(s string) types.Decimal128 {
+	d, err := types.ParseDecimal128(s, 38, 0)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}


### PR DESCRIPTION
 ## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) does this PR fix or relate to?

Fixes https://github.com/matrixorigin/matrixone/issues/24108

## What this PR does / why we need it:
## Summary
- backport decimal DIV truncation behavior to the 3.0-dev arithmetic path
- add Decimal128 truncating division and use it after scale compensation for decimal64/decimal128 DIV
- add decimal DIV regression coverage for truncation toward zero

## Tests
- C_INCLUDE_PATH=$PWD/thirdparties/install/include CPATH=$PWD/thirdparties/install/include LIBRARY_PATH=$PWD/thirdparties/install/lib LD_LIBRARY_PATH=$PWD/thirdparties/install/lib go test ./pkg/sql/plan/function/ -run 'TestDecimal128IntDivCorrectness|Test_IntegerDivFn_Decimal' -count=1\n- C_INCLUDE_PATH=$PWD/thirdparties/install/include CPATH=$PWD/thirdparties/install/include LIBRARY_PATH=$PWD/thirdparties/install/lib go build ./pkg/sql/plan/function/\n- C_INCLUDE_PATH=$PWD/thirdparties/install/include CPATH=$PWD/thirdparties/install/include LIBRARY_PATH=$PWD/thirdparties/install/lib LD_LIBRARY_PATH=$PWD/thirdparties/install/lib go test ./pkg/sql/plan/function/ -count=1