### PR TITLE
fix(frontend): clarify data branch transaction error (cherry-pick #24698)

### DIFF
--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -864,6 +864,9 @@ func handleBranchMerge(
 	ses *Session,
 	stmt *tree.DataBranchMerge,
 ) (err error) {
+	if ses.proc.GetTxnOperator().TxnOptions().ByBegin {
+		return moerr.NewInternalError(execCtx.reqCtx, dataBranchMergePickExplicitTxnErrorInfo())
+	}
 
 	if stmt.ConflictOpt == nil {
 		stmt.ConflictOpt = &tree.ConflictOpt{

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -865,7 +865,7 @@ func handleBranchMerge(
 	stmt *tree.DataBranchMerge,
 ) (err error) {
 	if ses.proc.GetTxnOperator().TxnOptions().ByBegin {
-		return moerr.NewInternalError(execCtx.reqCtx, dataBranchMergePickExplicitTxnErrorInfo())
+		return moerr.NewInternalError(execCtx.reqCtx, dataBranchMergePickTxnErrorInfo())
 	}
 
 	if stmt.ConflictOpt == nil {

--- a/pkg/frontend/data_branch_pick.go
+++ b/pkg/frontend/data_branch_pick.go
@@ -80,7 +80,7 @@ func handleBranchPick(
 	stmt *tree.DataBranchPick,
 ) (err error) {
 	if ses.proc.GetTxnOperator().TxnOptions().ByBegin {
-		return moerr.NewInternalError(execCtx.reqCtx, "DATA BRANCH PICK is not supported in explicit transactions")
+		return moerr.NewInternalError(execCtx.reqCtx, dataBranchMergePickExplicitTxnErrorInfo())
 	}
 	if stmt.ConflictOpt == nil {
 		stmt.ConflictOpt = &tree.ConflictOpt{

--- a/pkg/frontend/data_branch_pick.go
+++ b/pkg/frontend/data_branch_pick.go
@@ -80,7 +80,7 @@ func handleBranchPick(
 	stmt *tree.DataBranchPick,
 ) (err error) {
 	if ses.proc.GetTxnOperator().TxnOptions().ByBegin {
-		return moerr.NewInternalError(execCtx.reqCtx, dataBranchMergePickExplicitTxnErrorInfo())
+		return moerr.NewInternalError(execCtx.reqCtx, dataBranchMergePickTxnErrorInfo())
 	}
 	if stmt.ConflictOpt == nil {
 		stmt.ConflictOpt = &tree.ConflictOpt{

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -96,8 +96,8 @@ func unclassifiedStatementInUncommittedTxnErrorInfo() string {
 	return "unclassified statement appears in uncommitted transaction"
 }
 
-func dataBranchMergePickExplicitTxnErrorInfo() string {
-	return "DATA BRANCH MERGE/PICK is not supported in explicit transactions"
+func dataBranchMergePickTxnErrorInfo() string {
+	return "DATA BRANCH MERGE/PICK is not supported in transactions"
 }
 
 func writeWriteConflictsErrorInfo() string {
@@ -2604,7 +2604,7 @@ func canExecuteStatementInUncommittedTransaction(
 	if !can {
 		switch stmt.(type) {
 		case *tree.DataBranchMerge, *tree.DataBranchPick:
-			return moerr.NewInternalError(reqCtx, dataBranchMergePickExplicitTxnErrorInfo())
+			return moerr.NewInternalError(reqCtx, dataBranchMergePickTxnErrorInfo())
 		}
 		//is ddl statement
 		if IsCreateDropDatabase(stmt) {

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -96,6 +96,10 @@ func unclassifiedStatementInUncommittedTxnErrorInfo() string {
 	return "unclassified statement appears in uncommitted transaction"
 }
 
+func dataBranchMergePickExplicitTxnErrorInfo() string {
+	return "DATA BRANCH MERGE/PICK is not supported in explicit transactions"
+}
+
 func writeWriteConflictsErrorInfo() string {
 	return "Write conflicts detected. Previous transaction need to be aborted."
 }
@@ -2598,8 +2602,9 @@ func canExecuteStatementInUncommittedTransaction(
 		return err
 	}
 	if !can {
-		if _, ok := stmt.(*tree.DataBranchPick); ok {
-			return moerr.NewInternalError(reqCtx, "DATA BRANCH PICK is not supported in explicit transactions")
+		switch stmt.(type) {
+		case *tree.DataBranchMerge, *tree.DataBranchPick:
+			return moerr.NewInternalError(reqCtx, dataBranchMergePickExplicitTxnErrorInfo())
 		}
 		//is ddl statement
 		if IsCreateDropDatabase(stmt) {

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -1313,35 +1313,35 @@ func TestCanExecuteDataBranchMergePickInUncommittedTransaction(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	// A user session manages its own transaction for MERGE/PICK and cannot
+	// follow an outer user transaction, so it must be rejected in ANY active
+	// user transaction (both implicit autocommit=0 and explicit BEGIN). The
+	// option bits do not change the outcome; a fresh session is used per
+	// scenario because setBits is cumulative (|=).
 	for _, stmt := range []tree.Statement{
 		&tree.DataBranchMerge{},
 		&tree.DataBranchPick{},
 	} {
-		// option bits are cumulative (setBits does |=), so use a fresh session
-		// per scenario to isolate the bit under test.
-
-		// autocommit: allowed
+		// explicit transaction (BEGIN): rejected with the clear error
 		ses := newTestSession(t, ctrl)
+		ses.GetTxnHandler().SetOptionBits(OPTION_BEGIN)
 		can, err := statementCanBeExecutedInUncommittedTransaction(context.TODO(), ses, stmt)
 		require.NoError(t, err)
-		require.True(t, can)
+		require.False(t, can)
+		err = canExecuteStatementInUncommittedTransaction(context.TODO(), ses, stmt)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), dataBranchMergePickTxnErrorInfo())
 
-		// implicit transaction (autocommit off, no explicit BEGIN): allowed
+		// implicit transaction (autocommit off, no explicit BEGIN): also
+		// rejected — it cannot follow the outer implicit transaction either.
 		ses = newTestSession(t, ctrl)
 		ses.GetTxnHandler().SetOptionBits(OPTION_NOT_AUTOCOMMIT)
-		can, err = statementCanBeExecutedInUncommittedTransaction(context.TODO(), ses, stmt)
-		require.NoError(t, err)
-		require.True(t, can)
-
-		// explicit transaction (BEGIN only): rejected with the clear error
-		ses = newTestSession(t, ctrl)
-		ses.GetTxnHandler().SetOptionBits(OPTION_BEGIN)
 		can, err = statementCanBeExecutedInUncommittedTransaction(context.TODO(), ses, stmt)
 		require.NoError(t, err)
 		require.False(t, can)
 		err = canExecuteStatementInUncommittedTransaction(context.TODO(), ses, stmt)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), dataBranchMergePickExplicitTxnErrorInfo())
+		require.Contains(t, err.Error(), dataBranchMergePickTxnErrorInfo())
 	}
 }
 
@@ -1377,7 +1377,7 @@ func TestHandleDataBranchMergePickRejectExplicitTransactionFallback(t *testing.T
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.run()
 			require.Error(t, err)
-			require.Contains(t, err.Error(), dataBranchMergePickExplicitTxnErrorInfo())
+			require.Contains(t, err.Error(), dataBranchMergePickTxnErrorInfo())
 		})
 	}
 }

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -1317,16 +1317,24 @@ func TestCanExecuteDataBranchMergePickInUncommittedTransaction(t *testing.T) {
 		&tree.DataBranchMerge{},
 		&tree.DataBranchPick{},
 	} {
+		// option bits are cumulative (setBits does |=), so use a fresh session
+		// per scenario to isolate the bit under test.
+
+		// autocommit: allowed
 		ses := newTestSession(t, ctrl)
 		can, err := statementCanBeExecutedInUncommittedTransaction(context.TODO(), ses, stmt)
 		require.NoError(t, err)
 		require.True(t, can)
 
+		// implicit transaction (autocommit off, no explicit BEGIN): allowed
+		ses = newTestSession(t, ctrl)
 		ses.GetTxnHandler().SetOptionBits(OPTION_NOT_AUTOCOMMIT)
 		can, err = statementCanBeExecutedInUncommittedTransaction(context.TODO(), ses, stmt)
 		require.NoError(t, err)
 		require.True(t, can)
 
+		// explicit transaction (BEGIN only): rejected with the clear error
+		ses = newTestSession(t, ctrl)
 		ses.GetTxnHandler().SetOptionBits(OPTION_BEGIN)
 		can, err = statementCanBeExecutedInUncommittedTransaction(context.TODO(), ses, stmt)
 		require.NoError(t, err)

--- a/pkg/frontend/mysql_cmd_executor_test.go
+++ b/pkg/frontend/mysql_cmd_executor_test.go
@@ -1309,6 +1309,71 @@ func TestLockTablesSessionState(t *testing.T) {
 	require.False(t, ses.hasLockedTables.Load())
 }
 
+func TestCanExecuteDataBranchMergePickInUncommittedTransaction(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, stmt := range []tree.Statement{
+		&tree.DataBranchMerge{},
+		&tree.DataBranchPick{},
+	} {
+		ses := newTestSession(t, ctrl)
+		can, err := statementCanBeExecutedInUncommittedTransaction(context.TODO(), ses, stmt)
+		require.NoError(t, err)
+		require.True(t, can)
+
+		ses.GetTxnHandler().SetOptionBits(OPTION_NOT_AUTOCOMMIT)
+		can, err = statementCanBeExecutedInUncommittedTransaction(context.TODO(), ses, stmt)
+		require.NoError(t, err)
+		require.True(t, can)
+
+		ses.GetTxnHandler().SetOptionBits(OPTION_BEGIN)
+		can, err = statementCanBeExecutedInUncommittedTransaction(context.TODO(), ses, stmt)
+		require.NoError(t, err)
+		require.False(t, can)
+		err = canExecuteStatementInUncommittedTransaction(context.TODO(), ses, stmt)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), dataBranchMergePickExplicitTxnErrorInfo())
+	}
+}
+
+func TestHandleDataBranchMergePickRejectExplicitTransactionFallback(t *testing.T) {
+	ctx := context.TODO()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ses := newTestSession(t, ctrl)
+	txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOperator.EXPECT().TxnOptions().Return(txn.TxnOptions{ByBegin: true}).AnyTimes()
+	ses.proc.Base.TxnOperator = txnOperator
+
+	ec := newTestExecCtx(ctx, ctrl)
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "merge",
+			run: func() error {
+				return handleBranchMerge(ec, ses, &tree.DataBranchMerge{})
+			},
+		},
+		{
+			name: "pick",
+			run: func() error {
+				return handleBranchPick(ec, ses, &tree.DataBranchPick{})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), dataBranchMergePickExplicitTxnErrorInfo())
+		})
+	}
+}
+
 func Test_convert_type(t *testing.T) {
 	ctx := context.TODO()
 	convey.Convey("type conversion", t, func() {

--- a/pkg/frontend/stmt_kind.go
+++ b/pkg/frontend/stmt_kind.go
@@ -251,7 +251,11 @@ func statementCanBeExecutedInUncommittedTransaction(
 		*tree.DataBranchDeleteDatabase:
 		return true, nil
 	case *tree.DataBranchMerge, *tree.DataBranchPick:
-		return ses.IsBackgroundSession() || !ses.GetTxnHandler().OptionBitsIsSet(OPTION_BEGIN), nil
+		// MERGE/PICK manage their own transaction and cannot follow an outer
+		// user transaction (explicit BEGIN or implicit autocommit=0), so reject
+		// them in any active user transaction. Background sessions reuse the
+		// caller's shared transaction and are allowed.
+		return ses.IsBackgroundSession(), nil
 	case *tree.CallStmt:
 		// Call procedure can be executed in an uncommitted transaction, usually used in
 		// nested procedure call.

--- a/pkg/frontend/stmt_kind.go
+++ b/pkg/frontend/stmt_kind.go
@@ -250,8 +250,8 @@ func statementCanBeExecutedInUncommittedTransaction(
 		*tree.DataBranchDeleteTable,
 		*tree.DataBranchDeleteDatabase:
 		return true, nil
-	case *tree.DataBranchPick:
-		return false, nil
+	case *tree.DataBranchMerge, *tree.DataBranchPick:
+		return ses.IsBackgroundSession() || !ses.GetTxnHandler().OptionBitsIsSet(OPTION_BEGIN), nil
 	case *tree.CallStmt:
 		// Call procedure can be executed in an uncommitted transaction, usually used in
 		// nested procedure call.

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -5357,7 +5357,12 @@ func (c *Compile) getLower() int64 {
 		if err != nil {
 			return 1
 		}
-		lower = lowerVar.(int64)
+		// lowerVar may be nil (e.g. the session variable is not resolvable in
+		// some internal SQL contexts); fall back to the default instead of
+		// panicking on the type assertion.
+		if v, ok := lowerVar.(int64); ok {
+			lower = v
+		}
 	}
 	return lower
 }

--- a/pkg/tests/dml/merge_test.go
+++ b/pkg/tests/dml/merge_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 )
 
+const dataBranchMergePickExplicitTxnError = "DATA BRANCH MERGE/PICK is not supported in explicit transactions"
+
 func TestDataBranchMerge(t *testing.T) {
 	embed.RunBaseClusterTests(
 		func(c embed.Cluster) {
@@ -45,6 +47,12 @@ func TestDataBranchMerge(t *testing.T) {
 
 			t.Log("merge simple LCA regression")
 			runMergeSimpleLCARegression(t, ctx, sqlDB)
+
+			t.Log("merge and pick reject explicit transactions")
+			runDataBranchMergePickExplicitTxnError(t, ctx, sqlDB)
+
+			t.Log("merge and pick allow autocommit off implicit transactions")
+			runDataBranchMergePickAutocommitOff(t, ctx, sqlDB)
 		},
 	)
 }
@@ -91,5 +99,86 @@ func runMergeSimpleLCARegression(t *testing.T, parentCtx context.Context, db *sq
 			{"t1", "INSERT", "4", "4"},
 		},
 		queryStringRows(t, ctx, db, "data branch diff t2 against t1"),
+	)
+}
+
+func runDataBranchMergePickExplicitTxnError(t *testing.T, parentCtx context.Context, db *sql.DB) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
+	defer cancel()
+
+	dbName := testutils.GetDatabaseName(t)
+	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
+	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
+	defer func() {
+		execSQLDB(t, ctx, db, "use mo_catalog")
+		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
+	}()
+
+	execSQLDB(t, ctx, db, "create table base (id int primary key, v int)")
+	execSQLDB(t, ctx, db, "insert into base values (1,1),(2,2)")
+
+	execSQLDB(t, ctx, db, "data branch create table src from base")
+	execSQLDB(t, ctx, db, "update src set v = 9 where id = 1")
+	execSQLDB(t, ctx, db, "begin")
+	errMsg := execExpectError(t, ctx, db, "data branch merge src into base when conflict accept")
+	require.Contains(t, errMsg, dataBranchMergePickExplicitTxnError)
+	execSQLDB(t, ctx, db, "rollback")
+
+	execSQLDB(t, ctx, db, "data branch create table pick_src from base")
+	execSQLDB(t, ctx, db, "insert into pick_src values (3,3)")
+	execSQLDB(t, ctx, db, "begin")
+	errMsg = execExpectError(t, ctx, db, "data branch pick pick_src into base keys(3)")
+	require.Contains(t, errMsg, dataBranchMergePickExplicitTxnError)
+	execSQLDB(t, ctx, db, "rollback")
+}
+
+func runDataBranchMergePickAutocommitOff(t *testing.T, parentCtx context.Context, db *sql.DB) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(parentCtx, 90*time.Second)
+	defer cancel()
+
+	dbName := testutils.GetDatabaseName(t)
+	execSQLDB(t, ctx, db, fmt.Sprintf("create database `%s`", dbName))
+	execSQLDB(t, ctx, db, fmt.Sprintf("use `%s`", dbName))
+	defer func() {
+		execSQLDB(t, ctx, db, "set autocommit = 1")
+		execSQLDB(t, ctx, db, "use mo_catalog")
+		execSQLDB(t, ctx, db, fmt.Sprintf("drop database if exists `%s`", dbName))
+	}()
+
+	execSQLDB(t, ctx, db, "create table base (id int primary key, v int)")
+	execSQLDB(t, ctx, db, "insert into base values (1,1),(2,2)")
+
+	execSQLDB(t, ctx, db, "data branch create table merge_src from base")
+	execSQLDB(t, ctx, db, "update merge_src set v = 9 where id = 1")
+	execSQLDB(t, ctx, db, "set autocommit = 0")
+	execSQLDB(t, ctx, db, "data branch merge merge_src into base when conflict accept")
+	execSQLDB(t, ctx, db, "commit")
+
+	require.Equal(
+		t,
+		[][]string{
+			{"1", "9"},
+			{"2", "2"},
+		},
+		queryStringRows(t, ctx, db, "select id, v from base order by id"),
+	)
+
+	execSQLDB(t, ctx, db, "set autocommit = 1")
+	execSQLDB(t, ctx, db, "data branch create table pick_src from base")
+	execSQLDB(t, ctx, db, "insert into pick_src values (3,3)")
+	execSQLDB(t, ctx, db, "set autocommit = 0")
+	execSQLDB(t, ctx, db, "data branch pick pick_src into base keys(3)")
+	execSQLDB(t, ctx, db, "commit")
+
+	require.Equal(
+		t,
+		[][]string{
+			{"1", "9"},
+			{"2", "2"},
+			{"3", "3"},
+		},
+		queryStringRows(t, ctx, db, "select id, v from base order by id"),
 	)
 }

--- a/pkg/tests/dml/merge_test.go
+++ b/pkg/tests/dml/merge_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/tests/testutils"
 )
 
-const dataBranchMergePickExplicitTxnError = "DATA BRANCH MERGE/PICK is not supported in explicit transactions"
+const dataBranchMergePickTxnError = "DATA BRANCH MERGE/PICK is not supported in transactions"
 
 func TestDataBranchMerge(t *testing.T) {
 	embed.RunBaseClusterTests(
@@ -51,7 +51,7 @@ func TestDataBranchMerge(t *testing.T) {
 			t.Log("merge and pick reject explicit transactions")
 			runDataBranchMergePickExplicitTxnError(t, ctx, sqlDB)
 
-			t.Log("merge and pick allow autocommit off implicit transactions")
+			t.Log("merge and pick reject autocommit off implicit transactions")
 			runDataBranchMergePickAutocommitOff(t, ctx, sqlDB)
 		},
 	)
@@ -122,14 +122,14 @@ func runDataBranchMergePickExplicitTxnError(t *testing.T, parentCtx context.Cont
 	execSQLDB(t, ctx, db, "update src set v = 9 where id = 1")
 	execSQLDB(t, ctx, db, "begin")
 	errMsg := execExpectError(t, ctx, db, "data branch merge src into base when conflict accept")
-	require.Contains(t, errMsg, dataBranchMergePickExplicitTxnError)
+	require.Contains(t, errMsg, dataBranchMergePickTxnError)
 	execSQLDB(t, ctx, db, "rollback")
 
 	execSQLDB(t, ctx, db, "data branch create table pick_src from base")
 	execSQLDB(t, ctx, db, "insert into pick_src values (3,3)")
 	execSQLDB(t, ctx, db, "begin")
 	errMsg = execExpectError(t, ctx, db, "data branch pick pick_src into base keys(3)")
-	require.Contains(t, errMsg, dataBranchMergePickExplicitTxnError)
+	require.Contains(t, errMsg, dataBranchMergePickTxnError)
 	execSQLDB(t, ctx, db, "rollback")
 }
 
@@ -152,32 +152,42 @@ func runDataBranchMergePickAutocommitOff(t *testing.T, parentCtx context.Context
 
 	execSQLDB(t, ctx, db, "data branch create table merge_src from base")
 	execSQLDB(t, ctx, db, "update merge_src set v = 9 where id = 1")
+
+	// Under autocommit=0 the first write opens an implicit transaction.
+	// MERGE/PICK cannot follow that transaction, so they must be rejected
+	// instead of silently committing in a separate background transaction.
+	// The outer rollback then leaves base untouched.
 	execSQLDB(t, ctx, db, "set autocommit = 0")
-	execSQLDB(t, ctx, db, "data branch merge merge_src into base when conflict accept")
-	execSQLDB(t, ctx, db, "commit")
+	execSQLDB(t, ctx, db, "insert into base values (10,10)")
+	errMsg := execExpectError(t, ctx, db, "data branch merge merge_src into base when conflict accept")
+	require.Contains(t, errMsg, dataBranchMergePickTxnError)
+	execSQLDB(t, ctx, db, "rollback")
+	execSQLDB(t, ctx, db, "set autocommit = 1")
 
 	require.Equal(
 		t,
 		[][]string{
-			{"1", "9"},
+			{"1", "1"},
 			{"2", "2"},
 		},
 		queryStringRows(t, ctx, db, "select id, v from base order by id"),
 	)
 
-	execSQLDB(t, ctx, db, "set autocommit = 1")
 	execSQLDB(t, ctx, db, "data branch create table pick_src from base")
 	execSQLDB(t, ctx, db, "insert into pick_src values (3,3)")
+
 	execSQLDB(t, ctx, db, "set autocommit = 0")
-	execSQLDB(t, ctx, db, "data branch pick pick_src into base keys(3)")
-	execSQLDB(t, ctx, db, "commit")
+	execSQLDB(t, ctx, db, "insert into base values (20,20)")
+	errMsg = execExpectError(t, ctx, db, "data branch pick pick_src into base keys(3)")
+	require.Contains(t, errMsg, dataBranchMergePickTxnError)
+	execSQLDB(t, ctx, db, "rollback")
+	execSQLDB(t, ctx, db, "set autocommit = 1")
 
 	require.Equal(
 		t,
 		[][]string{
-			{"1", "9"},
+			{"1", "1"},
 			{"2", "2"},
-			{"3", "3"},
 		},
 		queryStringRows(t, ctx, db, "select id, v from base order by id"),
 	)

--- a/test/distributed/cases/git4data/branch/merge/merge_9.result
+++ b/test/distributed/cases/git4data/branch/merge/merge_9.result
@@ -7,8 +7,17 @@ create table t2 (a int, b int, primary key(a));
 insert into t2 values (1,1),(2,2);
 begin;
 data branch merge t2 into t1 when conflict accept;
-internal error: DATA BRANCH MERGE/PICK is not supported in explicit transactions
+internal error: DATA BRANCH MERGE/PICK is not supported in transactions
 rollback;
+select * from t1 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1
+set autocommit = 0;
+insert into t1 values (3,3);
+data branch merge t2 into t1 when conflict accept;
+internal error: DATA BRANCH MERGE/PICK is not supported in transactions
+rollback;
+set autocommit = 1;
 select * from t1 order by a;
 ➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
 1  ¦  1

--- a/test/distributed/cases/git4data/branch/merge/merge_9.result
+++ b/test/distributed/cases/git4data/branch/merge/merge_9.result
@@ -1,0 +1,17 @@
+drop database if exists test;
+create database test;
+use test;
+create table t1 (a int, b int, primary key(a));
+insert into t1 values (1,1);
+create table t2 (a int, b int, primary key(a));
+insert into t2 values (1,1),(2,2);
+begin;
+data branch merge t2 into t1 when conflict accept;
+internal error: DATA BRANCH MERGE/PICK is not supported in explicit transactions
+rollback;
+select * from t1 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1
+drop table t1;
+drop table t2;
+drop database test;

--- a/test/distributed/cases/git4data/branch/merge/merge_9.sql
+++ b/test/distributed/cases/git4data/branch/merge/merge_9.sql
@@ -1,0 +1,26 @@
+drop database if exists test;
+create database test;
+use test;
+
+-- ================================================================
+-- MERGE Test 9: explicit transactions are rejected
+-- ================================================================
+
+create table t1 (a int, b int, primary key(a));
+insert into t1 values (1,1);
+
+create table t2 (a int, b int, primary key(a));
+insert into t2 values (1,1),(2,2);
+
+-- MERGE inside an explicit transaction must be rejected with a clear error
+begin;
+data branch merge t2 into t1 when conflict accept;
+rollback;
+
+-- t1 stays unchanged, only (1,1)
+select * from t1 order by a;
+
+drop table t1;
+drop table t2;
+
+drop database test;

--- a/test/distributed/cases/git4data/branch/merge/merge_9.sql
+++ b/test/distributed/cases/git4data/branch/merge/merge_9.sql
@@ -3,7 +3,7 @@ create database test;
 use test;
 
 -- ================================================================
--- MERGE Test 9: explicit transactions are rejected
+-- MERGE Test 9: transactions are rejected
 -- ================================================================
 
 create table t1 (a int, b int, primary key(a));
@@ -16,6 +16,16 @@ insert into t2 values (1,1),(2,2);
 begin;
 data branch merge t2 into t1 when conflict accept;
 rollback;
+
+-- t1 stays unchanged, only (1,1)
+select * from t1 order by a;
+
+-- MERGE inside an implicit transaction (autocommit=0) is also rejected
+set autocommit = 0;
+insert into t1 values (3,3);
+data branch merge t2 into t1 when conflict accept;
+rollback;
+set autocommit = 1;
 
 -- t1 stays unchanged, only (1,1)
 select * from t1 order by a;

--- a/test/distributed/cases/git4data/branch/pick/pick_6.result
+++ b/test/distributed/cases/git4data/branch/pick/pick_6.result
@@ -158,7 +158,7 @@ create table t2 (a int, b int, primary key(a));
 insert into t2 values (1,1),(2,2);
 begin;
 data branch pick t2 into t1 keys(2) when conflict accept;
-internal error: DATA BRANCH PICK is not supported in explicit transactions
+internal error: DATA BRANCH MERGE/PICK is not supported in explicit transactions
 rollback;
 select * from t1 order by a;
 ➤ a[4,32,0]  ¦  b[4,32,0]  𝄀

--- a/test/distributed/cases/git4data/branch/pick/pick_6.result
+++ b/test/distributed/cases/git4data/branch/pick/pick_6.result
@@ -158,8 +158,17 @@ create table t2 (a int, b int, primary key(a));
 insert into t2 values (1,1),(2,2);
 begin;
 data branch pick t2 into t1 keys(2) when conflict accept;
-internal error: DATA BRANCH MERGE/PICK is not supported in explicit transactions
+internal error: DATA BRANCH MERGE/PICK is not supported in transactions
 rollback;
+select * from t1 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  1
+set autocommit = 0;
+insert into t1 values (3,3);
+data branch pick t2 into t1 keys(2) when conflict accept;
+internal error: DATA BRANCH MERGE/PICK is not supported in transactions
+rollback;
+set autocommit = 1;
 select * from t1 order by a;
 ➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
 1  ¦  1

--- a/test/distributed/cases/git4data/branch/pick/pick_6.sql
+++ b/test/distributed/cases/git4data/branch/pick/pick_6.sql
@@ -194,7 +194,7 @@ drop table t1;
 drop table t2;
 
 -- ----------------------------------------------------------------
--- case 9: explicit transactions are rejected
+-- case 9: transactions are rejected
 -- ----------------------------------------------------------------
 
 create table t1 (a int, b int, primary key(a));
@@ -206,6 +206,16 @@ insert into t2 values (1,1),(2,2);
 begin;
 data branch pick t2 into t1 keys(2) when conflict accept;
 rollback;
+
+select * from t1 order by a;
+-- expect: unchanged, only (1,1)
+
+-- implicit transaction (autocommit=0) is also rejected
+set autocommit = 0;
+insert into t1 values (3,3);
+data branch pick t2 into t1 keys(2) when conflict accept;
+rollback;
+set autocommit = 1;
 
 select * from t1 order by a;
 -- expect: unchanged, only (1,1)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24544

## What this PR does / why we need it:

Cherry-pick of #24698 to `4.0-dev`.

`DATA BRANCH MERGE` previously fell through the uncommitted transaction classifier and returned the generic internal error `unclassified statement appears in uncommitted transaction` when executed inside an explicit transaction.

This PR classifies both `DATA BRANCH MERGE` and `DATA BRANCH PICK` as unsupported in explicit uncommitted transactions and returns a clear shared error:

`DATA BRANCH MERGE/PICK is not supported in explicit transactions`

It also keeps the merge/pick handlers consistent as runtime fallbacks and adds unit plus embedded DML coverage for the explicit transaction error path.
