### PR TITLE
fix(fileservice): avoid full-file preload regressions

### DIFF
--- a/pkg/fileservice/read_mode.go
+++ b/pkg/fileservice/read_mode.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	defaultFullFilePreloadMaxObjectBytes = int64(32 << 20)
+	defaultFullFilePreloadMaxObjectBytes = int64(256 << 20)
 	defaultFullFilePreloadMaxInflight    = int64(16)
-	defaultFullFilePreloadUnknownBytes   = int64(16 << 20)
+	defaultFullFilePreloadUnknownBytes   = defaultFullFilePreloadMaxObjectBytes
 	minFullFilePreloadBudgetBytes        = int64(512 << 20)
 	maxFullFilePreloadBudgetBytes        = int64(2 << 30)
 )
@@ -111,12 +111,7 @@ func (i *IOVector) resolveS3ReadMode() {
 	}
 
 	estimatedBytes, knownSize := i.fullFilePreloadEstimatedBytes()
-	if !knownSize {
-		i.disableFullFilePreload(fullFilePreloadReasonUnknownSize)
-		metric.ObserveFSFullFilePreloadAdmission("downgrade", fullFilePreloadReasonUnknownSize)
-		return
-	}
-	if estimatedBytes > fullFilePreloadMaxObjectBytes.Load() {
+	if knownSize && estimatedBytes > fullFilePreloadMaxObjectBytes.Load() {
 		i.disableFullFilePreload(fullFilePreloadReasonLargeObject)
 		metric.ObserveFSFullFilePreloadAdmission("downgrade", fullFilePreloadReasonLargeObject)
 		return
@@ -132,12 +127,7 @@ func (i *IOVector) acquireFullFilePreloadForS3() bool {
 	if !i.readFullObject || i.preloadToken != nil {
 		return true
 	}
-	estimatedBytes, knownSize := i.fullFilePreloadEstimatedBytes()
-	if !knownSize {
-		i.disableFullFilePreload(fullFilePreloadReasonUnknownSize)
-		metric.ObserveFSFullFilePreloadAdmission("downgrade", fullFilePreloadReasonUnknownSize)
-		return false
-	}
+	estimatedBytes, _ := i.fullFilePreloadEstimatedBytes()
 	token, ok, reason := acquireFullFilePreloadToken(estimatedBytes)
 	if !ok {
 		i.disableFullFilePreload(reason)
@@ -179,6 +169,9 @@ func (i *IOVector) fullFilePreloadEstimatedBytes() (int64, bool) {
 	if i.FullFileSizeHint > 0 {
 		return i.FullFileSizeHint, true
 	}
+	// Unknown-size reads are still bounded by the token budget and the actual
+	// read limit. Treating them as range reads by default regresses normal scan
+	// workloads that rely on full-file disk-cache warmup.
 	return defaultFullFilePreloadUnknownBytes, false
 }
 

--- a/pkg/fileservice/read_mode.go
+++ b/pkg/fileservice/read_mode.go
@@ -110,21 +110,23 @@ func (i *IOVector) resolveS3ReadMode() {
 		return
 	}
 
+	if !fullFilePreloadUnderPressure() {
+		return
+	}
+
 	estimatedBytes, knownSize := i.fullFilePreloadEstimatedBytes()
 	if knownSize && estimatedBytes > fullFilePreloadMaxObjectBytes.Load() {
 		i.disableFullFilePreload(fullFilePreloadReasonLargeObject)
 		metric.ObserveFSFullFilePreloadAdmission("downgrade", fullFilePreloadReasonLargeObject)
 		return
 	}
-	if fullFilePreloadUnderPressure() {
-		i.disableFullFilePreload(fullFilePreloadReasonPressure)
-		metric.ObserveFSFullFilePreloadAdmission("downgrade", fullFilePreloadReasonPressure)
-		return
-	}
 }
 
 func (i *IOVector) acquireFullFilePreloadForS3() bool {
 	if !i.readFullObject || i.preloadToken != nil {
+		return true
+	}
+	if !fullFilePreloadUnderPressure() {
 		return true
 	}
 	estimatedBytes, _ := i.fullFilePreloadEstimatedBytes()

--- a/pkg/fileservice/read_mode_test.go
+++ b/pkg/fileservice/read_mode_test.go
@@ -62,13 +62,13 @@ func TestFullFilePreloadReadRangeDoesNotAcquireToken(t *testing.T) {
 	require.Equal(t, int64(0), fullFilePreloadInflight.Load())
 }
 
-func TestFullFilePreloadReadModeDowngradesOnPressure(t *testing.T) {
+func TestFullFilePreloadReadModeDowngradesLargeObjectOnPressure(t *testing.T) {
 	defer resetFullFilePreloadForTest(64<<20, 4, 128<<20)()
 
 	SetMemoryCachePressureTargetPercentByOwner("test-rss", 80, time.Now().Add(time.Minute))
 	vec := &IOVector{
 		FilePath:         "foo",
-		FullFileSizeHint: 8 << 20,
+		FullFileSizeHint: 128 << 20,
 		Entries: []IOEntry{
 			{Offset: 1024, Size: 4096},
 		},
@@ -85,6 +85,7 @@ func TestFullFilePreloadReadModeDowngradesOnPressure(t *testing.T) {
 
 func TestIOMergeKeyUsesResolvedReadMode(t *testing.T) {
 	defer resetFullFilePreloadForTest(64<<20, 4, 4<<20)()
+	SetMemoryCachePressureTargetPercentByOwner("test-rss", 80, time.Now().Add(time.Minute))
 
 	vec := &IOVector{
 		FilePath:         "foo",
@@ -107,6 +108,7 @@ func TestIOMergeKeyUsesResolvedReadMode(t *testing.T) {
 
 func TestS3FSReadUsesDowngradedRange(t *testing.T) {
 	defer resetFullFilePreloadForTest(64<<20, 4, 4<<20)()
+	SetMemoryCachePressureTargetPercentByOwner("test-rss", 80, time.Now().Add(time.Minute))
 
 	storage := &rangeRecordingObjectStorage{data: "0123456789abcdef"}
 	fs := &S3FS{
@@ -151,6 +153,7 @@ func TestS3FSReadWithoutSizeHintUsesBoundedFullFilePreload(t *testing.T) {
 
 func TestS3FSReadWithoutSizeHintFallsBackWhenActualSizeExceedsLimit(t *testing.T) {
 	defer resetFullFilePreloadForTest(8<<20, 4, 512<<20)()
+	SetMemoryCachePressureTargetPercentByOwner("test-rss", 80, time.Now().Add(time.Minute))
 
 	storage := &rangeRecordingObjectStorage{data: strings.Repeat("a", 8<<20+1)}
 	fs := &S3FS{
@@ -174,6 +177,7 @@ func TestS3FSReadWithoutSizeHintFallsBackWhenActualSizeExceedsLimit(t *testing.T
 
 func TestS3FSFullFilePreloadTokenCoversResultProcessing(t *testing.T) {
 	defer resetFullFilePreloadForTest(64<<20, 4, 128<<20)()
+	SetMemoryCachePressureTargetPercentByOwner("test-rss", 80, time.Now().Add(time.Minute))
 
 	storage := &rangeRecordingObjectStorage{data: "0123456789abcdef"}
 	fs := &S3FS{
@@ -202,6 +206,7 @@ func TestS3FSFullFilePreloadTokenCoversResultProcessing(t *testing.T) {
 
 func TestS3FSFullFilePreloadStaleLowHintFallsBackToRange(t *testing.T) {
 	defer resetFullFilePreloadForTest(64<<20, 4, 128<<20)()
+	SetMemoryCachePressureTargetPercentByOwner("test-rss", 80, time.Now().Add(time.Minute))
 
 	storage := &rangeRecordingObjectStorage{data: "0123456789abcdef"}
 	fs := &S3FS{

--- a/pkg/fileservice/read_mode_test.go
+++ b/pkg/fileservice/read_mode_test.go
@@ -127,8 +127,8 @@ func TestS3FSReadUsesDowngradedRange(t *testing.T) {
 	require.Equal(t, readRangeRecord{min: ptrTo[int64](4), max: ptrTo[int64](7)}, storage.ranges[0])
 }
 
-func TestS3FSReadWithoutSizeHintUsesRange(t *testing.T) {
-	defer resetFullFilePreloadForTest(64<<20, 4, 128<<20)()
+func TestS3FSReadWithoutSizeHintUsesBoundedFullFilePreload(t *testing.T) {
+	defer resetFullFilePreloadForTest(64<<20, 4, 512<<20)()
 
 	storage := &rangeRecordingObjectStorage{data: "0123456789abcdef"}
 	fs := &S3FS{
@@ -145,8 +145,31 @@ func TestS3FSReadWithoutSizeHintUsesRange(t *testing.T) {
 	require.NoError(t, fs.Read(context.Background(), vec))
 	require.Equal(t, []byte("456"), vec.Entries[0].Data)
 	require.Len(t, storage.ranges, 1)
-	require.Equal(t, readRangeRecord{min: ptrTo[int64](4), max: ptrTo[int64](7)}, storage.ranges[0])
+	require.Equal(t, readRangeRecord{min: ptrTo[int64](0), max: nil}, storage.ranges[0])
 	require.Equal(t, int64(0), fullFilePreloadInflight.Load())
+}
+
+func TestS3FSReadWithoutSizeHintFallsBackWhenActualSizeExceedsLimit(t *testing.T) {
+	defer resetFullFilePreloadForTest(8<<20, 4, 512<<20)()
+
+	storage := &rangeRecordingObjectStorage{data: strings.Repeat("a", 8<<20+1)}
+	fs := &S3FS{
+		storage:  storage,
+		ioMerger: NewIOMerger(),
+	}
+
+	vec := &IOVector{
+		FilePath: "foo",
+		Entries: []IOEntry{
+			{Offset: 4, Size: 3},
+		},
+	}
+	require.NoError(t, fs.Read(context.Background(), vec))
+	require.Equal(t, []byte("aaa"), vec.Entries[0].Data)
+	require.Equal(t, int64(0), fullFilePreloadInflight.Load())
+	require.Len(t, storage.ranges, 2)
+	require.Equal(t, readRangeRecord{min: ptrTo[int64](0), max: nil}, storage.ranges[0])
+	require.Equal(t, readRangeRecord{min: ptrTo[int64](4), max: ptrTo[int64](7)}, storage.ranges[1])
 }
 
 func TestS3FSFullFilePreloadTokenCoversResultProcessing(t *testing.T) {

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -2741,7 +2741,7 @@ func (tbl *txnTable) PKPersistedBetween(
 				blk.MetaLocation(),
 				cacheVectors,
 				tbl.proc.Load().GetMPool(),
-				fileservice.SkipFullFilePreloads,
+				fileservice.Policy(0),
 			)
 			if err != nil {
 				releasePKCheckSemaphore()
@@ -2819,9 +2819,7 @@ func tombstonePKExistsInRange(
 				vecCount = 2
 			}
 			tombVectors := containers.NewVectors(vecCount)
-			_, release, err := ioutil.ReadDeletesWithPolicy(
-				ctx, loc, fs, isCNCreated, tombVectors, &pkType, fileservice.SkipFullFilePreloads,
-			)
+			_, release, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType)
 			if err != nil {
 				return true, "tombstone_read_error", nil
 			}


### PR DESCRIPTION
## What

Related to #24709 and follow-up to #24710.

This narrows #24710 so it does not change normal read-path semantics broadly.

- restore default fileservice policy for TPCC data-block PK validation
- restore default tombstone delete read path for TPCC tombstone PK validation
- keep unknown-size S3 reads eligible for full-file preload instead of forcing range reads
- raise the pressure-mode full-file preload per-object cap from 32MiB to 256MiB so normal ~120MiB objects are not misclassified as too large
- most importantly: apply the full-file preload admission budget only when RSS/cache pressure is active; normal no-pressure reads keep the previous full-file preload behavior

## Why

#24710 correctly targeted RSS spikes from full-file preload, but the implementation changed the default behavior too broadly:

- high-frequency TPCC PK/tombstone checks were forced to SkipFullFilePreloads
- SSB/scan reads without FullFileSizeHint were forced to range reads and lost disk-cache warmup
- sysbench OLTP hot reads could also be affected because normal no-pressure full-file preloads were gated by a global admission budget and downgraded when the budget was exhausted

That violates the requirement that normal business workloads should not lose performance unless the system is actually under memory pressure.

This PR keeps the protection path for pressure scenarios, but avoids turning the optimization into a default-path limiter.

## Observed regressions after #24710

Compared bcc6201ac with 1285f0ef7:

- TPCC tpcc100.100: about 55.9k tpmTOTAL -> about 21.6k, with 5 connection timeouts
- TPCC tpcc100.1000: about 48.8k tpmTOTAL -> about 30.9k, with 5 connection timeouts
- SSB 1G avg cost: 1606 ms -> 15412 ms
- SSB 10G avg cost: 3991 ms -> 18065 ms
- SSB 100G avg cost: 31083 ms -> 187666 ms

Sysbench 1000w also showed broad slowdown symptoms in the running bcc6201ac job. The root risk is the same: #24710 changed normal no-pressure full-file preload admission globally.

## Tests

- GOCACHE=/private/tmp/mo-gocache-regression-fix go test -mod=mod ./pkg/fileservice -run 'TestFullFilePreload|TestS3FSFullFilePreload|TestS3FSReadWithoutSizeHint|TestS3FSReadUsesDowngradedRange|TestIOMergeKeyUsesResolvedReadMode|TestS3FSIOMerger|^TestS3FS$|^TestLocalFS$' -count=1
- GOCACHE=/private/tmp/mo-gocache-regression-fix go test -mod=mod ./pkg/fileservice -count=1
- GOCACHE=/private/tmp/mo-gocache-regression-fix go test -mod=mod ./pkg/objectio ./pkg/vm/engine/disttae -run 'TestReadOneBlockWithMetaReleasesPartialReadOnError|Test.*PK|Test.*Tombstone' -count=1