### PR TITLE
test: cover hive partition auto inference (4.0-dev)

### DIFF
--- a/test/distributed/cases/table/hive_partition_external_table.result
+++ b/test/distributed/cases/table/hive_partition_external_table.result
@@ -34,6 +34,11 @@ create external table hive_err3 (
 id int, amount double
 ) infile{'filepath'='$resources/hive_partition/single_level/', 'format'='parquet', 'hive_partitioning'='true', 'hive_partition_columns'='nonexistent'};
 invalid configuration: partition column 'nonexistent' not found in table columns
+drop table if exists hive_err3_auto;
+create external table hive_err3_auto (
+id int, amount double
+) infile{'filepath'='$resources/hive_partition/single_level/', 'format'='parquet', 'hive_partitioning'='true'};
+invalid configuration: partition column 'year' not found in table columns
 drop table if exists hive_err4;
 create external table hive_err4 (
 id int, year int
@@ -266,6 +271,26 @@ group by year, month order by year, month;
 ➤ year[4,32,0]  ¦  month[12,-1,0]  ¦  cnt[-5,64,0]  𝄀
 2024  ¦  01  ¦  3  𝄀
 2025  ¦  02  ¦  3
+drop table if exists hive_multi_auto;
+create external table hive_multi_auto (
+id int,
+amount double,
+year int,
+month varchar(2)
+) infile{'filepath'='$resources/hive_partition/multi_level/', 'format'='parquet', 'hive_partitioning'='true'};
+select year, month, count(*) as cnt from hive_multi_auto group by year, month order by year, month;
+➤ year[4,32,0]  ¦  month[12,-1,0]  ¦  cnt[-5,64,0]  𝄀
+2024  ¦  01  ¦  3  𝄀
+2024  ¦  02  ¦  3  𝄀
+2024  ¦  03  ¦  3  𝄀
+2025  ¦  01  ¦  3  𝄀
+2025  ¦  02  ¦  3  𝄀
+2025  ¦  03  ¦  3
+select id, year, month from hive_multi_auto where year = 2024 and month = '02' order by id;
+➤ id[4,32,0]  ¦  year[4,32,0]  ¦  month[12,-1,0]  𝄀
+202420  ¦  2024  ¦  02  𝄀
+202421  ¦  2024  ¦  02  𝄀
+202422  ¦  2024  ¦  02
 drop table if exists hive_string;
 create external table hive_string (
 id int,

--- a/test/distributed/cases/table/hive_partition_external_table.sql
+++ b/test/distributed/cases/table/hive_partition_external_table.sql
@@ -53,6 +53,12 @@ create external table hive_err3 (
     id int, amount double
 ) infile{'filepath'='$resources/hive_partition/single_level/', 'format'='parquet', 'hive_partitioning'='true', 'hive_partition_columns'='nonexistent'};
 
+-- 1.4.1 DDL error: inferred partition column must exist in table schema
+drop table if exists hive_err3_auto;
+create external table hive_err3_auto (
+    id int, amount double
+) infile{'filepath'='$resources/hive_partition/single_level/', 'format'='parquet', 'hive_partitioning'='true'};
+
 -- 1.5 DDL error: duplicate hive key
 drop table if exists hive_err4;
 create external table hive_err4 (
@@ -241,6 +247,18 @@ select year, mc from (
 select year, month, count(*) as cnt from hive_multi
 where (year = 2024 and month = '01') or (year = 2025 and month = '02')
 group by year, month order by year, month;
+
+-- 3.13 Multi-level partition columns auto inference
+drop table if exists hive_multi_auto;
+create external table hive_multi_auto (
+    id int,
+    amount double,
+    year int,
+    month varchar(2)
+) infile{'filepath'='$resources/hive_partition/multi_level/', 'format'='parquet', 'hive_partitioning'='true'};
+
+select year, month, count(*) as cnt from hive_multi_auto group by year, month order by year, month;
+select id, year, month from hive_multi_auto where year = 2024 and month = '02' order by id;
 
 -- ============================================================================
 -- 4. String Partition


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24390

## What this PR does / why we need it:

Add BVT coverage for the current Hive partition behavior on `4.0-dev`:

- Multi-level Hive partition columns can be inferred from `year=.../month=...` paths when the partition columns are declared in the external table schema and `hive_partition_columns` is omitted.
- Inferred partition columns must still exist in the table schema. MO does not auto-expand the schema to create virtual partition columns, so omitting `year` from the table definition returns `partition column 'year' not found in table columns`.

Verified locally while checking #24390 across `main`, `3.0-dev`, and `4.0-dev`.
