### PR TITLE
4.0: fix: restore database delete skip for already deleted relations

### DIFF
--- a/pkg/vm/engine/disttae/engine.go
+++ b/pkg/vm/engine/disttae/engine.go
@@ -330,6 +330,7 @@ func (e *Engine) Create(ctx context.Context, name string, op client.TxnOperator)
 
 	key := genDatabaseKey(accountId, name)
 	txn.databaseOps.addCreateDatabase(key, txn.statementID, &txnDatabase{
+		accountId:    accountId,
 		op:           op,
 		databaseId:   databaseId,
 		databaseName: name,
@@ -486,6 +487,7 @@ func (e *Engine) Database(
 	}
 
 	return &txnDatabase{
+		accountId:         accountId,
 		op:                op,
 		databaseName:      name,
 		databaseId:        item.Id,
@@ -693,6 +695,8 @@ func (e *Engine) Delete(ctx context.Context, name string, op client.TxnOperator)
 	if err != nil {
 		return err
 	}
+	txnDB := toDelDB.(*txnDatabase)
+	rels = filterDeleteDatabaseRelations(txnDB, rels, name, op)
 	for _, relName := range rels {
 		if err := toDelDB.Delete(ctx, relName); err != nil {
 			return err
@@ -700,7 +704,7 @@ func (e *Engine) Delete(ctx context.Context, name string, op client.TxnOperator)
 	}
 
 	// fetch (accountid, databaseid, rowid) to delete the database
-	databaseId := toDelDB.(*txnDatabase).databaseId
+	databaseId := txnDB.databaseId
 	accountId, err := defines.GetAccountId(ctx)
 	if err != nil {
 		return err
@@ -749,6 +753,31 @@ func (e *Engine) Delete(ctx context.Context, name string, op client.TxnOperator)
 	key := genDatabaseKey(accountId, name)
 	txn.databaseOps.addDeleteDatabase(key, txn.statementID, databaseId)
 	return nil
+}
+
+func filterDeleteDatabaseRelations(db *txnDatabase, rels []string, databaseName string, op client.TxnOperator) []string {
+	filtered := make([]string, 0, len(rels))
+	for _, relName := range rels {
+		if isDeleteDatabaseRelationDeletedInTxn(db, db.accountId, relName) {
+			logutil.Info(
+				"skip table already deleted in txn during database delete",
+				zap.String("database", databaseName),
+				zap.String("table", relName),
+				zap.String("txn", op.Txn().DebugString()),
+			)
+			continue
+		}
+		filtered = append(filtered, relName)
+	}
+	return filtered
+}
+
+func isDeleteDatabaseRelationDeletedInTxn(db *txnDatabase, accountId uint32, relName string) bool {
+	if db.databaseId == catalog.MO_CATALOG_ID && catalog.IsSystemTableByName(relName) {
+		accountId = catalog.System_Account
+	}
+	key := genTableKey(accountId, relName, db.databaseId, db.databaseName)
+	return db.getTxn().tableOps.existAndDeleted(key)
 }
 
 func (e *Engine) New(ctx context.Context, op client.TxnOperator) error {

--- a/pkg/vm/engine/disttae/engine_test.go
+++ b/pkg/vm/engine/disttae/engine_test.go
@@ -172,3 +172,91 @@ func newTxnMeta(snapshotTS int64) txn.TxnMeta {
 	}
 }
 */
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
+	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
+	txnpb "github.com/matrixorigin/matrixone/pkg/pb/txn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterDeleteDatabaseRelationsSkipsAlreadyDeletedRelation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	txn := &Transaction{tableOps: newTableOps()}
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().GetWorkspace().Return(txn).AnyTimes()
+	txnOp.EXPECT().Txn().Return(txnpb.TxnMeta{}).AnyTimes()
+
+	const (
+		accountID    = uint32(7)
+		databaseID   = uint64(11)
+		dbName       = "acc_test02"
+		deletedTable = "aff01"
+		activeTable  = "pri01"
+		tableID      = uint64(13)
+	)
+	db := &txnDatabase{
+		accountId:    accountID,
+		databaseId:   databaseID,
+		databaseName: dbName,
+		op:           txnOp,
+	}
+	txn.tableOps.addDeleteTable(genTableKey(accountID, deletedTable, databaseID, dbName), 0, tableID)
+
+	rels := filterDeleteDatabaseRelations(db, []string{deletedTable, activeTable}, dbName, txnOp)
+	require.Equal(t, []string{activeTable}, rels)
+}
+
+func TestIsDeleteDatabaseRelationDeletedInTxn(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	txn := &Transaction{tableOps: newTableOps()}
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().GetWorkspace().Return(txn).AnyTimes()
+
+	const (
+		accountID  = uint32(7)
+		databaseID = uint64(11)
+		dbName     = "acc_test02"
+		tableName  = "aff01"
+		tableID    = uint64(13)
+	)
+	db := &txnDatabase{
+		databaseId:   databaseID,
+		databaseName: dbName,
+		op:           txnOp,
+	}
+
+	require.False(t, isDeleteDatabaseRelationDeletedInTxn(db, accountID, tableName))
+
+	txn.tableOps.addDeleteTable(genTableKey(accountID, tableName, databaseID, dbName), 0, tableID)
+	require.True(t, isDeleteDatabaseRelationDeletedInTxn(db, accountID, tableName))
+
+	require.False(t, isDeleteDatabaseRelationDeletedInTxn(db, accountID+1, tableName))
+	require.False(t, isDeleteDatabaseRelationDeletedInTxn(db, accountID, "other_table"))
+}
+
+func TestIsDeleteDatabaseRelationDeletedInTxnUsesSystemAccount(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	txn := &Transaction{tableOps: newTableOps()}
+	txnOp := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOp.EXPECT().GetWorkspace().Return(txn).AnyTimes()
+
+	const tableName = catalog.MO_TABLES
+	db := &txnDatabase{
+		databaseId:   catalog.MO_CATALOG_ID,
+		databaseName: catalog.MO_CATALOG,
+		op:           txnOp,
+	}
+
+	txn.tableOps.addDeleteTable(genTableKey(catalog.System_Account, tableName, catalog.MO_CATALOG_ID, catalog.MO_CATALOG), 0, catalog.MO_TABLES_ID)
+	require.True(t, isDeleteDatabaseRelationDeletedInTxn(db, uint32(99), tableName))
+}

--- a/pkg/vm/engine/disttae/types.go
+++ b/pkg/vm/engine/disttae/types.go
@@ -1129,6 +1129,7 @@ func (e *Entry) isCatalog() bool {
 
 // txnDatabase represents an opened database in a transaction
 type txnDatabase struct {
+	accountId         uint32
 	databaseId        uint64
 	databaseName      string
 	databaseType      string


### PR DESCRIPTION
This reverts commit aac3d03054a0945ae8a4f704a27e24a6ad71f4f9.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24711

## What this PR does / why we need it:

Restore the 4.0-dev fix from #24716 after #24724 reverted it.

The original fix is still needed for restore-account database delete: when a relation was already deleted in the current transaction, `Engine.Delete(database)` should skip that relation only when `tableOps.existAndDeleted` proves it was deleted, while preserving other errors.

Tested with:

```
source $HOME/.zshrc && moenv && go test ./pkg/vm/engine/disttae
```
