### PR TITLE
cherry-pick to 4.0: Fix alter copy add primary key precheck

### DIFF
--- a/pkg/objectio/ioutil/sink_pool_test.go
+++ b/pkg/objectio/ioutil/sink_pool_test.go
@@ -605,6 +605,54 @@ func TestSinker_WithPipelineFlush_WithSortKeyGroupsBlocks(t *testing.T) {
 	require.NoError(t, sinker.Close())
 }
 
+func TestSinker_WithPipelineFlush_SubmitThresholdBelowCap(t *testing.T) {
+	proc := testutil.NewProc(t)
+	fs, err := fileservice.Get[fileservice.FileService](
+		proc.GetFileService(), defines.SharedFileServiceName)
+	require.NoError(t, err)
+
+	attrs, typs, seqnums := mockSchema(3, 2)
+
+	factory := NewFSinkerImplFactory(
+		seqnums,
+		2,
+		true,
+		false,
+		0,
+	)
+
+	// Use a threshold below the 64MB cap so the cap branch is NOT triggered.
+	// This exercises the "threshold stays as-is" path in trySpillMergeSortPipeline.
+	sinker := NewSinker(
+		2,
+		attrs,
+		typs,
+		factory,
+		proc.Mp(),
+		fs,
+		WithMemorySizeThreshold(mpool.MB*32),
+		WithAllMergeSorted(),
+		WithPipelineFlush(),
+	)
+
+	for i := 0; i < 3; i++ {
+		bat := containers.MockBatch(typs, 8192, 2, nil)
+		err = sinker.Write(context.Background(), containers.ToCNBatch(bat))
+		assert.NoError(t, err)
+	}
+
+	err = sinker.Sync(context.Background())
+	assert.NoError(t, err)
+
+	totalRows := uint32(0)
+	for j := 0; j < len(sinker.result.persisted); j++ {
+		totalRows += sinker.result.persisted[j].Rows()
+	}
+	require.Equal(t, uint32(8192*3), totalRows)
+
+	require.NoError(t, sinker.Close())
+}
+
 func TestSinker_WithPipelineFlush_Reset(t *testing.T) {
 	proc := testutil.NewProc(t)
 	fs, err := fileservice.Get[fileservice.FileService](

--- a/pkg/objectio/ioutil/sink_pool_test.go
+++ b/pkg/objectio/ioutil/sink_pool_test.go
@@ -561,6 +561,50 @@ func TestSinker_WithPipelineFlush_WithSortKey(t *testing.T) {
 	require.NoError(t, sinker.Close())
 }
 
+func TestSinker_WithPipelineFlush_WithSortKeyGroupsBlocks(t *testing.T) {
+	proc := testutil.NewProc(t)
+	fs, err := fileservice.Get[fileservice.FileService](
+		proc.GetFileService(), defines.SharedFileServiceName)
+	require.NoError(t, err)
+
+	attrs, typs, seqnums := mockSchema(3, 2)
+
+	factory := NewFSinkerImplFactory(
+		seqnums,
+		2,
+		true,
+		false,
+		0,
+	)
+
+	sinker := NewSinker(
+		2,
+		attrs,
+		typs,
+		factory,
+		proc.Mp(),
+		fs,
+		WithMemorySizeThreshold(1<<30),
+		WithAllMergeSorted(),
+		WithPipelineFlush(),
+	)
+
+	for i := 0; i < 3; i++ {
+		bat := containers.MockBatch(typs, 8192, 2, nil)
+		err = sinker.Write(context.Background(), containers.ToCNBatch(bat))
+		assert.NoError(t, err)
+	}
+
+	err = sinker.Sync(context.Background())
+	assert.NoError(t, err)
+
+	require.Len(t, sinker.result.persisted, 1)
+	require.Equal(t, uint32(8192*3), sinker.result.persisted[0].Rows())
+	require.Equal(t, uint32(3), sinker.result.persisted[0].BlkCnt())
+
+	require.NoError(t, sinker.Close())
+}
+
 func TestSinker_WithPipelineFlush_Reset(t *testing.T) {
 	proc := testutil.NewProc(t)
 	fs, err := fileservice.Get[fileservice.FileService](

--- a/pkg/objectio/ioutil/sinker.go
+++ b/pkg/objectio/ioutil/sinker.go
@@ -34,6 +34,7 @@ import (
 )
 
 const DefaultInMemoryStagedSize = mpool.MB * 16
+const pipelineSortKeySubmitThreshold = mpool.MB * 64
 
 type pipelineFlushKeyType struct{}
 
@@ -747,13 +748,54 @@ func (sinker *Sinker) trySpillMergeSortAccumulate(
 	return nil
 }
 
-// trySpillMergeSortPipeline merge-sorts staged data and submits each sorted
-// block to the pipeline as it is produced, avoiding accumulating all sorted
-// batches in memory (which would double peak memory usage).
-func (sinker *Sinker) trySpillMergeSortPipeline(ctx context.Context) error {
+// trySpillMergeSortPipeline merge-sorts staged data and submits sorted blocks
+// to the pipeline in bounded groups. Grouping keeps the pipeline async path from
+// turning every BlockMaxRows output block into its own tiny persisted object.
+func (sinker *Sinker) trySpillMergeSortPipeline(ctx context.Context) (err error) {
+	submitThreshold := sinker.staged.memorySizeThreshold
+	if submitThreshold <= 0 {
+		submitThreshold = DefaultInMemoryStagedSize
+	}
+	if submitThreshold > pipelineSortKeySubmitThreshold {
+		submitThreshold = pipelineSortKeySubmitThreshold
+	}
+
+	var (
+		pending     []*batch.Batch
+		pendingSize int
+	)
+	cleanupPending := func() {
+		for _, bat := range pending {
+			if bat != nil {
+				sinker.putBackBuffer(bat)
+			}
+		}
+		pending = nil
+		pendingSize = 0
+	}
+	defer func() {
+		if err != nil {
+			cleanupPending()
+		}
+	}()
+
+	submitPending := func() error {
+		if len(pending) == 0 {
+			return nil
+		}
+		jobData := pending
+		pending = nil
+		pendingSize = 0
+		return sinker.pipelineSubmit(ctx, jobData)
+	}
+
 	streamSubmit := func(data *batch.Batch) (*batch.Batch, error) {
-		if err := sinker.pipelineSubmit(ctx, []*batch.Batch{data}); err != nil {
-			return nil, err
+		pending = append(pending, data)
+		pendingSize += data.Size()
+		if pendingSize >= submitThreshold {
+			if err := submitPending(); err != nil {
+				return nil, err
+			}
 		}
 		return sinker.fetchBuffer()
 	}
@@ -770,8 +812,16 @@ func (sinker *Sinker) trySpillMergeSortPipeline(ctx context.Context) error {
 		sinker.mp,
 		sinker.putBackOneInMemory,
 	)
-	sinker.putBackBuffer(buffer)
-	return err
+	if buffer != nil {
+		sinker.putBackBuffer(buffer)
+	}
+	if err != nil {
+		return err
+	}
+	if err := submitPending(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (sinker *Sinker) resetFileSinker() {

--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -54,8 +55,215 @@ func convertDBEOBToNoSuchTable(ctx context.Context, e error, dbName, tblName str
 	return e
 }
 
-func shouldEnableAlterCopyPipelineFlush(qry *plan.AlterTable) bool {
-	return qry != nil && qry.Options != nil && qry.Options.SkipPkDedup
+func shouldEnableAlterCopyPipelineFlush(opt *plan.AlterCopyOpt) bool {
+	return opt != nil && opt.SkipPkDedup
+}
+
+func alterCopyStatementOption(alterOpt *plan.AlterCopyOpt) executor.StatementOption {
+	opt := executor.StatementOption{}
+	if alterOpt != nil &&
+		(alterOpt.SkipPkDedup || len(alterOpt.SkipUniqueIdxDedup) > 0) {
+		opt = opt.WithAlterCopyOpt(alterOpt)
+	}
+	return opt
+}
+
+func alterCopyPkPrecheckColumns(tableDef *plan.TableDef) []string {
+	if tableDef == nil || tableDef.GetPkey() == nil {
+		return nil
+	}
+	pk := tableDef.GetPkey()
+	if len(pk.GetNames()) > 0 {
+		return slices.DeleteFunc(slices.Clone(pk.GetNames()), func(name string) bool { return name == "" })
+	}
+
+	pkColName := pk.GetPkeyColName()
+	if pkColName == "" || catalog.IsFakePkName(pkColName) || pkColName == catalog.CPrimaryKeyColName {
+		return nil
+	}
+	return []string{pkColName}
+}
+
+func alterCopyPkColumnValueUnchanged(oldCol, newCol *plan.ColDef) bool {
+	if oldCol == nil || newCol == nil {
+		return false
+	}
+	oldTyp := oldCol.GetTyp()
+	newTyp := newCol.GetTyp()
+	return oldTyp.GetId() == newTyp.GetId() &&
+		oldTyp.GetAutoIncr() == newTyp.GetAutoIncr() &&
+		oldTyp.GetWidth() == newTyp.GetWidth() &&
+		oldTyp.GetScale() == newTyp.GetScale() &&
+		oldTyp.GetTable() == newTyp.GetTable() &&
+		oldTyp.GetEnumvalues() == newTyp.GetEnumvalues()
+}
+
+func getAlterCopyPkPrecheck(qry *plan.AlterTable) (pkCols []string, checkNotNull bool) {
+	if qry == nil || qry.Options == nil || qry.Options.GetSkipPkDedup() {
+		return nil, false
+	}
+
+	pkCols = alterCopyPkPrecheckColumns(qry.CopyTableDef)
+	if len(pkCols) == 0 {
+		return nil, false
+	}
+	for _, colName := range pkCols {
+		oldCol := plan2.FindColumn(qry.GetTableDef().GetCols(), colName)
+		newCol := plan2.FindColumn(qry.CopyTableDef.GetCols(), colName)
+		if !alterCopyPkColumnValueUnchanged(oldCol, newCol) {
+			return nil, false
+		}
+		if !oldCol.GetNotNull() && !oldCol.GetTyp().NotNullable {
+			checkNotNull = true
+		}
+	}
+	return pkCols, checkNotNull
+}
+
+func quoteAlterCopyIdentifier(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+func quoteAlterCopyTableName(dbName, tblName string) string {
+	return quoteAlterCopyIdentifier(dbName) + "." + quoteAlterCopyIdentifier(tblName)
+}
+
+func buildAlterCopyPkNullCheckSQL(dbName, tblName string, pkCols []string) string {
+	selectCols := make([]string, 0, len(pkCols))
+	nullPredicates := make([]string, 0, len(pkCols))
+	for _, col := range pkCols {
+		quotedCol := quoteAlterCopyIdentifier(col)
+		selectCols = append(selectCols, quotedCol)
+		nullPredicates = append(nullPredicates, quotedCol+" IS NULL")
+	}
+	return fmt.Sprintf("SELECT %s FROM %s WHERE %s LIMIT 1",
+		strings.Join(selectCols, ", "),
+		quoteAlterCopyTableName(dbName, tblName),
+		strings.Join(nullPredicates, " OR "),
+	)
+}
+
+func buildAlterCopyPkDuplicateCheckSQL(dbName, tblName string, pkCols []string) string {
+	groupByCols := make([]string, 0, len(pkCols))
+	for _, col := range pkCols {
+		groupByCols = append(groupByCols, quoteAlterCopyIdentifier(col))
+	}
+	groupBy := strings.Join(groupByCols, ", ")
+	return fmt.Sprintf("SELECT %s FROM %s GROUP BY %s HAVING count(*) > 1 LIMIT 1",
+		groupBy,
+		quoteAlterCopyTableName(dbName, tblName),
+		groupBy,
+	)
+}
+
+func firstAlterCopyResultRow(res executor.Result, colCount int) ([]string, []bool, bool) {
+	for _, bat := range res.Batches {
+		if bat == nil || bat.RowCount() == 0 {
+			continue
+		}
+
+		values := make([]string, colCount)
+		nulls := make([]bool, colCount)
+		for i := 0; i < colCount; i++ {
+			if i >= len(bat.Vecs) || bat.Vecs[i] == nil || bat.Vecs[i].Length() == 0 {
+				continue
+			}
+			nulls[i] = bat.Vecs[i].IsNull(0)
+			if nulls[i] {
+				values[i] = "null"
+				continue
+			}
+			values[i] = bat.Vecs[i].RowToString(0)
+		}
+		return values, nulls, true
+	}
+	return nil, nil, false
+}
+
+func formatAlterCopyPkValue(values []string) string {
+	if len(values) == 1 {
+		return values[0]
+	}
+	return "(" + strings.Join(values, ",") + ")"
+}
+
+func alterCopyDedupColName(pkCols []string) string {
+	if len(pkCols) == 1 {
+		return pkCols[0]
+	}
+	return "(" + strings.Join(pkCols, ",") + ")"
+}
+
+func cloneAlterCopyOpt(opt *plan.AlterCopyOpt) *plan.AlterCopyOpt {
+	if opt == nil {
+		return nil
+	}
+	clone := *opt
+	if opt.SkipUniqueIdxDedup != nil {
+		clone.SkipUniqueIdxDedup = make(map[string]bool, len(opt.SkipUniqueIdxDedup))
+		for k, v := range opt.SkipUniqueIdxDedup {
+			clone.SkipUniqueIdxDedup[k] = v
+		}
+	}
+	if opt.SkipIndexesCopy != nil {
+		clone.SkipIndexesCopy = make(map[string]bool, len(opt.SkipIndexesCopy))
+		for k, v := range opt.SkipIndexesCopy {
+			clone.SkipIndexesCopy[k] = v
+		}
+	}
+	return &clone
+}
+
+func (c *Compile) precheckAlterCopyPkDedup(dbName, tblName string, qry *plan.AlterTable) (*plan.AlterCopyOpt, error) {
+	if qry == nil || qry.Options == nil {
+		return nil, nil
+	}
+	if qry.Options.GetSkipPkDedup() {
+		return qry.Options, nil
+	}
+
+	pkCols, checkNotNull := getAlterCopyPkPrecheck(qry)
+	if len(pkCols) == 0 {
+		return qry.Options, nil
+	}
+
+	if checkNotNull {
+		nullCheckSQL := buildAlterCopyPkNullCheckSQL(dbName, tblName, pkCols)
+		nullCheckRes, err := c.runSqlWithResultAndOptions(nullCheckSQL, NoAccountId, executor.StatementOption{}.WithDisableLog())
+		if err != nil {
+			c.proc.Errorf(c.proc.Ctx, "alter copy primary key null check failed, sql is %s", nullCheckSQL)
+			return nil, err
+		}
+		defer nullCheckRes.Close()
+
+		if _, nulls, ok := firstAlterCopyResultRow(nullCheckRes, len(pkCols)); ok {
+			for i, isNull := range nulls {
+				if isNull {
+					return nil, moerr.NewConstraintViolation(c.proc.Ctx, fmt.Sprintf("Column '%s' cannot be null", pkCols[i]))
+				}
+			}
+			return nil, moerr.NewConstraintViolation(c.proc.Ctx, fmt.Sprintf("Column '%s' cannot be null", pkCols[0]))
+		}
+	}
+
+	duplicateCheckSQL := buildAlterCopyPkDuplicateCheckSQL(dbName, tblName, pkCols)
+	duplicateCheckRes, err := c.runSqlWithResultAndOptions(duplicateCheckSQL, NoAccountId, executor.StatementOption{}.WithDisableLog())
+	if err != nil {
+		c.proc.Errorf(c.proc.Ctx, "alter copy primary key duplicate check failed, sql is %s", duplicateCheckSQL)
+		return nil, err
+	}
+	defer duplicateCheckRes.Close()
+
+	if values, _, ok := firstAlterCopyResultRow(duplicateCheckRes, len(pkCols)); ok {
+		return nil, moerr.NewDuplicateEntry(c.proc.Ctx, formatAlterCopyPkValue(values), alterCopyDedupColName(pkCols))
+	}
+
+	opt := cloneAlterCopyOpt(qry.Options)
+	if opt.TargetTableName == "" {
+		opt.TargetTableName = qry.CopyTableDef.GetName()
+	}
+	opt.SkipPkDedup = true
+	return opt, nil
 }
 
 func (s *Scope) AlterTableCopy(c *Compile) error {
@@ -165,10 +373,6 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 			zap.Error(err))
 		return err
 	}
-	opt := executor.StatementOption{}
-	if qry.Options.SkipPkDedup || len(qry.Options.SkipUniqueIdxDedup) > 0 {
-		opt = opt.WithAlterCopyOpt(qry.Options)
-	}
 
 	//4. obtain relation for new tables
 	newRel, err := dbSource.Relation(c.proc.Ctx, qry.CopyTableDef.Name, nil)
@@ -196,13 +400,23 @@ func (s *Scope) AlterTableCopy(c *Compile) error {
 	}
 
 	// 6. copy the original table data to the temporary replica table
+	alterCopyOpt, err := c.precheckAlterCopyPkDedup(dbName, tblName, qry)
+	if err != nil {
+		c.proc.Error(c.proc.Ctx, "precheck primary key for alter table copy",
+			zap.String("databaseName", dbName),
+			zap.String("origin tableName", qry.GetTableDef().Name),
+			zap.String("copy tableName", qry.CopyTableDef.Name),
+			zap.Error(err))
+		return err
+	}
+	opt := alterCopyStatementOption(alterCopyOpt)
 	err = func() error {
-		if !shouldEnableAlterCopyPipelineFlush(qry) {
+		if !shouldEnableAlterCopyPipelineFlush(alterCopyOpt) {
 			return c.runSqlWithOptions(qry.InsertTmpDataSql, opt)
 		}
 
-		// Enable pipeline flush only when PK dedup can be skipped. Add/change PK
-		// still needs the normal insert-copy path to avoid excessive conflict checks.
+		// Enable pipeline flush only when PK dedup can be skipped or was proven safe
+		// by the alter-copy precheck.
 		origCtx := c.proc.Ctx
 		restoreCtx := origCtx
 		if restoreCtx == nil {

--- a/pkg/sql/compile/alter_test.go
+++ b/pkg/sql/compile/alter_test.go
@@ -29,7 +29,11 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/buffer"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	moruntime "github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	mock_lock "github.com/matrixorigin/matrixone/pkg/frontend/test/mock_lock"
@@ -47,13 +51,8 @@ import (
 
 func TestShouldEnableAlterCopyPipelineFlush(t *testing.T) {
 	assert.False(t, shouldEnableAlterCopyPipelineFlush(nil))
-	assert.False(t, shouldEnableAlterCopyPipelineFlush(&plan2.AlterTable{}))
-	assert.False(t, shouldEnableAlterCopyPipelineFlush(&plan2.AlterTable{
-		Options: &plan2.AlterCopyOpt{SkipPkDedup: false},
-	}))
-	assert.True(t, shouldEnableAlterCopyPipelineFlush(&plan2.AlterTable{
-		Options: &plan2.AlterCopyOpt{SkipPkDedup: true},
-	}))
+	assert.False(t, shouldEnableAlterCopyPipelineFlush(&plan2.AlterCopyOpt{SkipPkDedup: false}))
+	assert.True(t, shouldEnableAlterCopyPipelineFlush(&plan2.AlterCopyOpt{SkipPkDedup: true}))
 }
 
 type alterCopyInsertSpyExecutor struct {
@@ -61,17 +60,36 @@ type alterCopyInsertSpyExecutor struct {
 	insertErr    error
 	insertCtx    context.Context
 	insertOption executor.StatementOption
+	results      map[string]executor.Result
+	errs         map[string]error
+	executedSQLs []string
 }
+
+const (
+	alterCopyTestPkNullCheckSQL      = "SELECT `col4` FROM `test`.`dept` WHERE `col4` IS NULL LIMIT 1"
+	alterCopyTestPkDuplicateCheckSQL = "SELECT `col4` FROM `test`.`dept` GROUP BY `col4` HAVING count(*) > 1 LIMIT 1"
+)
 
 func (e *alterCopyInsertSpyExecutor) Exec(
 	ctx context.Context,
 	sql string,
 	opts executor.Options,
 ) (executor.Result, error) {
+	e.executedSQLs = append(e.executedSQLs, sql)
 	if sql == e.insertSQL {
 		e.insertCtx = ctx
 		e.insertOption = opts.StatementOption()
 		return executor.Result{}, e.insertErr
+	}
+	if e.errs != nil {
+		if err, ok := e.errs[sql]; ok {
+			return executor.Result{}, err
+		}
+	}
+	if e.results != nil {
+		if res, ok := e.results[sql]; ok {
+			return res, nil
+		}
 	}
 	return executor.Result{}, nil
 }
@@ -232,6 +250,364 @@ func TestScopeAlterTableCopyInsertTmpDataPipelineFlush(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetAlterCopyPkPrecheck(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		tableDef         *plan.TableDef
+		copyTableDef     *plan.TableDef
+		skipPkDedup      bool
+		wantCols         []string
+		wantCheckNotNull bool
+	}{
+		{
+			name: "add pk on nullable original column",
+			tableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", Typ: plan.Type{Id: int32(types.T_int32)}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+			},
+			copyTableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", NotNull: true, Primary: true, Typ: plan.Type{Id: int32(types.T_int32)}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: "col4", Names: []string{"col4"}},
+			},
+			wantCols:         []string{"col4"},
+			wantCheckNotNull: true,
+		},
+		{
+			name: "add pk on not null original column",
+			tableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", NotNull: true, Typ: plan.Type{Id: int32(types.T_int32)}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+			},
+			copyTableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", NotNull: true, Typ: plan.Type{Id: int32(types.T_int32)}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: "col4", Names: []string{"col4"}},
+			},
+			wantCols: []string{"col4"},
+		},
+		{
+			name: "static skip pk dedup needs no precheck",
+			tableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", Typ: plan.Type{Id: int32(types.T_int32)}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: "col4", Names: []string{"col4"}},
+			},
+			copyTableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", Typ: plan.Type{Id: int32(types.T_int32)}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: "col4", Names: []string{"col4"}},
+			},
+			skipPkDedup: true,
+		},
+		{
+			name: "pk column is not copied from original table",
+			tableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", Typ: plan.Type{Id: int32(types.T_int32)}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+			},
+			copyTableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "new_col", Typ: plan.Type{Id: int32(types.T_int32)}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: "new_col", Names: []string{"new_col"}},
+			},
+		},
+		{
+			name: "pk column type change can change dedup key value",
+			tableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", Typ: plan.Type{Id: int32(types.T_varchar), Width: 16}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+			},
+			copyTableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", NotNull: true, Primary: true, Typ: plan.Type{Id: int32(types.T_int32)}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: "col4", Names: []string{"col4"}},
+			},
+		},
+		{
+			name: "pk column width change can change dedup key value",
+			tableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", Typ: plan.Type{Id: int32(types.T_varchar), Width: 32}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+			},
+			copyTableDef: &plan.TableDef{
+				Cols: []*plan.ColDef{{Name: "col4", NotNull: true, Primary: true, Typ: plan.Type{Id: int32(types.T_varchar), Width: 8}}},
+				Pkey: &plan.PrimaryKeyDef{PkeyColName: "col4", Names: []string{"col4"}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			qry := &plan2.AlterTable{
+				TableDef:     tc.tableDef,
+				CopyTableDef: tc.copyTableDef,
+				Options: &plan2.AlterCopyOpt{
+					SkipPkDedup:     tc.skipPkDedup,
+					TargetTableName: "dept_copy",
+				},
+			}
+			pkCols, checkNotNull := getAlterCopyPkPrecheck(qry)
+			assert.Equal(t, tc.wantCols, pkCols)
+			assert.Equal(t, tc.wantCheckNotNull, checkNotNull)
+		})
+	}
+}
+
+func TestScopeAlterTableCopyPrecheckPrimaryKeyThenSkipDedup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	proc := testutil.NewProcess(t)
+	proc.Base.SessionInfo.Buf = buffer.New()
+	proc.Base.SessionInfo.TimeZone = time.Local
+
+	serviceID := "alter-copy-pk-precheck"
+	lockSvc := mock_lock.NewMockLockService(ctrl)
+	lockSvc.EXPECT().GetConfig().Return(lockservice.Config{ServiceID: serviceID}).AnyTimes()
+	proc.Base.LockService = lockSvc
+	require.Equal(t, serviceID, proc.GetService())
+
+	const accountID = catalog.System_Account
+	ctx := defines.AttachAccountId(context.Background(), accountID)
+	proc.Ctx = ctx
+	proc.ReplaceTopCtx(ctx)
+
+	txnCli, txnOp := newTestTxnClientAndOp(ctrl)
+	proc.Base.TxnClient = txnCli
+	proc.Base.TxnOperator = txnOp
+
+	tableDef := &plan.TableDef{
+		TblId: 1,
+		Name:  "dept",
+		Cols: []*plan.ColDef{
+			{Name: "col4", Typ: plan.Type{Id: int32(types.T_int32)}},
+		},
+		Pkey: &plan.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+	}
+	copyTableDef := &plan.TableDef{
+		TblId: 2,
+		Name:  "dept_copy",
+		Cols: []*plan.ColDef{
+			{Name: "col4", Typ: plan.Type{Id: int32(types.T_int32)}},
+		},
+		Pkey: &plan.PrimaryKeyDef{PkeyColName: "col4", Names: []string{"col4"}},
+	}
+	alterTable := &plan2.AlterTable{
+		Database:          "test",
+		TableDef:          tableDef,
+		CopyTableDef:      copyTableDef,
+		CreateTmpTableSql: "create table dept_copy",
+		InsertTmpDataSql:  "insert into dept_copy select * from dept",
+		Options: &plan2.AlterCopyOpt{
+			SkipPkDedup:     false,
+			TargetTableName: "dept_copy",
+		},
+	}
+	s := &Scope{
+		Magic: AlterTable,
+		Plan: &plan.Plan{
+			Plan: &plan2.Plan_Ddl{
+				Ddl: &plan2.DataDefinition{
+					DdlType: plan2.DataDefinition_ALTER_TABLE,
+					Definition: &plan2.DataDefinition_AlterTable{
+						AlterTable: alterTable,
+					},
+				},
+			},
+		},
+	}
+
+	originRel := mock_frontend.NewMockRelation(ctrl)
+	originRel.EXPECT().GetTableID(gomock.Any()).Return(uint64(1)).AnyTimes()
+
+	copyRel := mock_frontend.NewMockRelation(ctrl)
+	copyRel.EXPECT().CopyTableDef(gomock.Any()).Return(copyTableDef).AnyTimes()
+
+	mockDb := mock_frontend.NewMockDatabase(ctrl)
+	mockDb.EXPECT().Relation(gomock.Any(), "dept", gomock.Any()).Return(originRel, nil).AnyTimes()
+	mockDb.EXPECT().Relation(gomock.Any(), "dept_copy", gomock.Any()).Return(copyRel, nil).AnyTimes()
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	eng.EXPECT().Database(gomock.Any(), "test", gomock.Any()).Return(mockDb, nil).AnyTimes()
+
+	insertErr := errors.New("stop after insert-copy")
+	spyExec := &alterCopyInsertSpyExecutor{
+		insertSQL: alterTable.InsertTmpDataSql,
+		insertErr: insertErr,
+	}
+	rt := moruntime.DefaultRuntime()
+	rt.SetGlobalVariables(moruntime.InternalSQLExecutor, spyExec)
+	moruntime.SetupServiceBasedRuntime(proc.GetService(), rt)
+
+	c := NewCompile("test", "test", "alter table dept", "", "", eng, proc, nil, false, nil, time.Now())
+	c.pn = s.Plan
+
+	err := s.AlterTableCopy(c)
+	require.ErrorIs(t, err, insertErr)
+	assert.False(t, alterTable.Options.SkipPkDedup)
+	require.NotNil(t, spyExec.insertCtx)
+	assert.Equal(t, true, spyExec.insertCtx.Value(ioutil.PipelineFlushKey) == true)
+	require.NotSame(t, alterTable.Options, spyExec.insertOption.AlterCopyDedupOpt())
+	require.True(t, spyExec.insertOption.AlterCopyDedupOpt().SkipPkDedup)
+	require.Equal(t, alterTable.Options.TargetTableName, spyExec.insertOption.AlterCopyDedupOpt().TargetTableName)
+	assert.Equal(t, []string{
+		alterTable.CreateTmpTableSql,
+		alterCopyTestPkNullCheckSQL,
+		alterCopyTestPkDuplicateCheckSQL,
+		alterTable.InsertTmpDataSql,
+	}, spyExec.executedSQLs)
+}
+
+func TestPrecheckAlterCopyPkDedupRejectsNull(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	alterTable := testAlterCopyAddPrimaryKeyPlan()
+	spyExec := &alterCopyInsertSpyExecutor{}
+	c := newAlterCopyPrecheckCompile(t, ctrl, spyExec)
+	spyExec.results = map[string]executor.Result{
+		alterCopyTestPkNullCheckSQL: newAlterCopyConstNullResult(c.proc.Mp(), types.T_int32.ToType()),
+	}
+
+	opt, err := c.precheckAlterCopyPkDedup("test", "dept", alterTable)
+	require.Error(t, err)
+	require.Nil(t, opt)
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrConstraintViolation))
+	assert.False(t, alterTable.Options.SkipPkDedup)
+	assert.Equal(t, []string{alterCopyTestPkNullCheckSQL}, spyExec.executedSQLs)
+}
+
+func TestPrecheckAlterCopyPkDedupRejectsDuplicate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	alterTable := testAlterCopyAddPrimaryKeyPlan()
+	spyExec := &alterCopyInsertSpyExecutor{}
+	c := newAlterCopyPrecheckCompile(t, ctrl, spyExec)
+	spyExec.results = map[string]executor.Result{
+		alterCopyTestPkDuplicateCheckSQL: newAlterCopyFixedResult(t, c.proc.Mp(), types.T_int32.ToType(), []int32{7}),
+	}
+
+	opt, err := c.precheckAlterCopyPkDedup("test", "dept", alterTable)
+	require.Error(t, err)
+	require.Nil(t, opt)
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrDuplicateEntry))
+	assert.False(t, alterTable.Options.SkipPkDedup)
+	assert.Equal(t, []string{alterCopyTestPkNullCheckSQL, alterCopyTestPkDuplicateCheckSQL}, spyExec.executedSQLs)
+}
+
+func TestPrecheckAlterCopyPkDedupCanSkipNullCheck(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	alterTable := testAlterCopyAddPrimaryKeyPlan()
+	alterTable.TableDef.Cols[0].NotNull = true
+	spyExec := &alterCopyInsertSpyExecutor{}
+	c := newAlterCopyPrecheckCompile(t, ctrl, spyExec)
+
+	opt, err := c.precheckAlterCopyPkDedup("test", "dept", alterTable)
+	require.NoError(t, err)
+	require.NotNil(t, opt)
+	assert.True(t, opt.SkipPkDedup)
+	assert.False(t, alterTable.Options.SkipPkDedup)
+	require.NotSame(t, alterTable.Options, opt)
+	assert.Equal(t, []string{alterCopyTestPkDuplicateCheckSQL}, spyExec.executedSQLs)
+}
+
+func TestPrecheckAlterCopyPkDedupDoesNotMutatePlanOption(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	alterTable := testAlterCopyAddPrimaryKeyPlan()
+	spyExec := &alterCopyInsertSpyExecutor{}
+	c := newAlterCopyPrecheckCompile(t, ctrl, spyExec)
+
+	firstOpt, err := c.precheckAlterCopyPkDedup("test", "dept", alterTable)
+	require.NoError(t, err)
+	require.NotNil(t, firstOpt)
+	require.True(t, firstOpt.SkipPkDedup)
+	require.False(t, alterTable.Options.SkipPkDedup)
+
+	secondOpt, err := c.precheckAlterCopyPkDedup("test", "dept", alterTable)
+	require.NoError(t, err)
+	require.NotNil(t, secondOpt)
+	require.True(t, secondOpt.SkipPkDedup)
+	require.False(t, alterTable.Options.SkipPkDedup)
+	require.NotSame(t, firstOpt, secondOpt)
+
+	assert.Equal(t, []string{
+		alterCopyTestPkNullCheckSQL,
+		alterCopyTestPkDuplicateCheckSQL,
+		alterCopyTestPkNullCheckSQL,
+		alterCopyTestPkDuplicateCheckSQL,
+	}, spyExec.executedSQLs)
+}
+
+func testAlterCopyAddPrimaryKeyPlan() *plan2.AlterTable {
+	return &plan2.AlterTable{
+		Database: "test",
+		TableDef: &plan.TableDef{
+			Name: "dept",
+			Cols: []*plan.ColDef{
+				{Name: "col4", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey: &plan.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+		},
+		CopyTableDef: &plan.TableDef{
+			Name: "dept_copy",
+			Cols: []*plan.ColDef{
+				{Name: "col4", Typ: plan.Type{Id: int32(types.T_int32)}},
+			},
+			Pkey: &plan.PrimaryKeyDef{PkeyColName: "col4", Names: []string{"col4"}},
+		},
+		Options: &plan2.AlterCopyOpt{
+			SkipPkDedup:     false,
+			TargetTableName: "dept_copy",
+		},
+	}
+}
+
+func newAlterCopyPrecheckCompile(t *testing.T, ctrl *gomock.Controller, exec executor.SQLExecutor) *Compile {
+	proc := testutil.NewProcess(t)
+	proc.Base.SessionInfo.Buf = buffer.New()
+	proc.Base.SessionInfo.TimeZone = time.Local
+
+	serviceID := "alter-copy-precheck-" + t.Name()
+	lockSvc := mock_lock.NewMockLockService(ctrl)
+	lockSvc.EXPECT().GetConfig().Return(lockservice.Config{ServiceID: serviceID}).AnyTimes()
+	proc.Base.LockService = lockSvc
+
+	ctx := defines.AttachAccountId(context.Background(), catalog.System_Account)
+	proc.Ctx = ctx
+	proc.ReplaceTopCtx(ctx)
+
+	txnCli, txnOp := newTestTxnClientAndOp(ctrl)
+	proc.Base.TxnClient = txnCli
+	proc.Base.TxnOperator = txnOp
+
+	rt := moruntime.DefaultRuntime()
+	rt.SetGlobalVariables(moruntime.InternalSQLExecutor, exec)
+	moruntime.SetupServiceBasedRuntime(proc.GetService(), rt)
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	c := NewCompile("test", "test", "alter table dept", "", "", eng, proc, nil, false, nil, time.Now())
+	c.pn = &plan.Plan{
+		Plan: &plan2.Plan_Ddl{
+			Ddl: &plan2.DataDefinition{
+				DdlType: plan2.DataDefinition_ALTER_TABLE,
+			},
+		},
+	}
+	return c
+}
+
+func newAlterCopyConstNullResult(mp *mpool.MPool, typ types.Type) executor.Result {
+	bat := batch.NewWithSize(1)
+	bat.SetRowCount(1)
+	bat.Vecs[0] = vector.NewConstNull(typ, 1, mp)
+	return executor.Result{Mp: mp, Batches: []*batch.Batch{bat}}
+}
+
+func newAlterCopyFixedResult[T any](t *testing.T, mp *mpool.MPool, typ types.Type, values []T) executor.Result {
+	memRes := executor.NewMemResult([]types.Type{typ}, mp)
+	memRes.NewBatchWithRowCount(len(values))
+	require.NoError(t, executor.AppendFixedRows(memRes, 0, values))
+	return memRes.GetResult()
 }
 
 func TestScope_AlterTableInplace(t *testing.T) {

--- a/pkg/sql/compile/alter_test.go
+++ b/pkg/sql/compile/alter_test.go
@@ -348,6 +348,69 @@ func TestGetAlterCopyPkPrecheck(t *testing.T) {
 	}
 }
 
+func TestAlterCopyPrecheckHelpers(t *testing.T) {
+	assert.Nil(t, alterCopyPkPrecheckColumns(nil))
+	assert.Nil(t, alterCopyPkPrecheckColumns(&plan.TableDef{}))
+	assert.Nil(t, alterCopyPkPrecheckColumns(&plan.TableDef{
+		Pkey: &plan.PrimaryKeyDef{PkeyColName: catalog.FakePrimaryKeyColName},
+	}))
+	assert.Nil(t, alterCopyPkPrecheckColumns(&plan.TableDef{
+		Pkey: &plan.PrimaryKeyDef{PkeyColName: catalog.CPrimaryKeyColName},
+	}))
+	assert.Equal(t, []string{"a", "b"}, alterCopyPkPrecheckColumns(&plan.TableDef{
+		Pkey: &plan.PrimaryKeyDef{Names: []string{"a", "", "b"}},
+	}))
+
+	assert.Equal(t, "`db``name`.`tbl``name`", quoteAlterCopyTableName("db`name", "tbl`name"))
+	assert.Equal(t, "(1,2)", formatAlterCopyPkValue([]string{"1", "2"}))
+	assert.Equal(t, "(a,b)", alterCopyDedupColName([]string{"a", "b"}))
+
+	assert.Nil(t, cloneAlterCopyOpt(nil))
+	opt := &plan2.AlterCopyOpt{
+		SkipPkDedup:        true,
+		SkipUniqueIdxDedup: map[string]bool{"u": true},
+		SkipIndexesCopy:    map[string]bool{"i": true},
+	}
+	clone := cloneAlterCopyOpt(opt)
+	require.NotNil(t, clone)
+	require.NotSame(t, opt, clone)
+	clone.SkipUniqueIdxDedup["u"] = false
+	clone.SkipIndexesCopy["i"] = false
+	assert.True(t, opt.SkipUniqueIdxDedup["u"])
+	assert.True(t, opt.SkipIndexesCopy["i"])
+}
+
+func TestFirstAlterCopyResultRowEmptyAndShortRows(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer func() {
+		require.Equal(t, int64(0), mp.CurrNB())
+	}()
+
+	values, nulls, ok := firstAlterCopyResultRow(executor.Result{}, 2)
+	require.False(t, ok)
+	require.Nil(t, values)
+	require.Nil(t, nulls)
+
+	empty := batch.NewWithSize(1)
+	empty.SetRowCount(0)
+	res := executor.Result{Mp: mp, Batches: []*batch.Batch{nil, empty}}
+	values, nulls, ok = firstAlterCopyResultRow(res, 1)
+	require.False(t, ok)
+	require.Nil(t, values)
+	require.Nil(t, nulls)
+
+	bat := batch.NewWithSize(1)
+	bat.SetRowCount(1)
+	bat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	require.NoError(t, vector.AppendFixed[int32](bat.Vecs[0], 42, false, mp))
+	defer bat.Clean(mp)
+
+	values, nulls, ok = firstAlterCopyResultRow(executor.Result{Mp: mp, Batches: []*batch.Batch{bat}}, 2)
+	require.True(t, ok)
+	assert.Equal(t, []string{"42", ""}, values)
+	assert.Equal(t, []bool{false, false}, nulls)
+}
+
 func TestScopeAlterTableCopyPrecheckPrimaryKeyThenSkipDedup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/vm/engine/disttae/pk_check_guard_test.go
+++ b/pkg/vm/engine/disttae/pk_check_guard_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
@@ -146,4 +147,62 @@ func TestPKCommitTSMatchedInRange(t *testing.T) {
 	changed, ok = pkCommitTSMatchedInRange(constNull, []int64{0}, from, to)
 	require.False(t, ok)
 	require.False(t, changed)
+
+	// nil vector returns (false, false)
+	changed, ok = pkCommitTSMatchedInRange(nil, []int64{0}, from, to)
+	require.False(t, ok)
+	require.False(t, changed)
+
+	// Wrong type (non-TS) returns (false, false)
+	wrongTypeVec := vector.NewVec(types.T_int64.ToType())
+	defer wrongTypeVec.Free(mp)
+	require.NoError(t, vector.AppendFixed[int64](wrongTypeVec, 42, false, mp))
+	changed, ok = pkCommitTSMatchedInRange(wrongTypeVec, []int64{0}, from, to)
+	require.False(t, ok)
+	require.False(t, changed)
+
+	// Out-of-range sel returns (false, false)
+	vec2 := vector.NewVec(types.T_TS.ToType())
+	defer vec2.Free(mp)
+	require.NoError(t, vector.AppendFixed(vec2, types.BuildTS(15, 0), false, mp))
+	changed, ok = pkCommitTSMatchedInRange(vec2, []int64{5}, from, to)
+	require.False(t, ok)
+	require.False(t, changed)
+
+	// Negative sel returns (false, false)
+	changed, ok = pkCommitTSMatchedInRange(vec2, []int64{-1}, from, to)
+	require.False(t, ok)
+	require.False(t, changed)
+}
+
+func TestPkCheckBailoutOnChangedObjects(t *testing.T) {
+	// Below threshold — no bailout, no counter increment.
+	assert.False(t, pkCheckBailoutOnChangedObjects(0))
+	assert.False(t, pkCheckBailoutOnChangedObjects(maxChangedObjectsForIO))
+
+	// Above threshold — bailout fires.
+	assert.True(t, pkCheckBailoutOnChangedObjects(maxChangedObjectsForIO+1))
+	assert.True(t, pkCheckBailoutOnChangedObjects(1000))
+}
+
+func TestPkCheckBailoutOnCandidateBlocks(t *testing.T) {
+	// Below threshold — no bailout.
+	assert.False(t, pkCheckBailoutOnCandidateBlocks(0))
+	assert.False(t, pkCheckBailoutOnCandidateBlocks(maxCandidateBlksForIO))
+
+	// Above threshold — bailout fires.
+	assert.True(t, pkCheckBailoutOnCandidateBlocks(maxCandidateBlksForIO+1))
+	assert.True(t, pkCheckBailoutOnCandidateBlocks(1000))
+}
+
+func TestShouldLogPKPersistedChanged(t *testing.T) {
+	// System catalog tables should log.
+	assert.True(t, shouldLogPKPersistedChanged(catalog.MO_DATABASE_ID))
+	assert.True(t, shouldLogPKPersistedChanged(catalog.MO_TABLES_ID))
+	assert.True(t, shouldLogPKPersistedChanged(catalog.MO_COLUMNS_ID))
+
+	// Regular user tables should not log.
+	assert.False(t, shouldLogPKPersistedChanged(0))
+	assert.False(t, shouldLogPKPersistedChanged(1000))
+	assert.False(t, shouldLogPKPersistedChanged(999999))
 }

--- a/pkg/vm/engine/disttae/pk_check_guard_test.go
+++ b/pkg/vm/engine/disttae/pk_check_guard_test.go
@@ -21,7 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldBailoutOnChangedObjects(t *testing.T) {
@@ -102,4 +106,44 @@ func TestPkCheckSemaphore_RespectsContextCancellation(t *testing.T) {
 	case <-ctx.Done():
 		// expected
 	}
+}
+
+func TestPKCommitTSMatchedInRange(t *testing.T) {
+	mp := mpool.MustNewZero()
+	defer func() {
+		require.Equal(t, int64(0), mp.CurrNB())
+	}()
+
+	from := types.BuildTS(10, 0)
+	to := types.BuildTS(20, 0)
+
+	vec := vector.NewVec(types.T_TS.ToType())
+	defer vec.Free(mp)
+	require.NoError(t, vector.AppendFixed(vec, types.BuildTS(10, 0), false, mp))
+	require.NoError(t, vector.AppendFixed(vec, types.BuildTS(11, 0), false, mp))
+	require.NoError(t, vector.AppendFixed(vec, types.BuildTS(20, 0), false, mp))
+	require.NoError(t, vector.AppendFixed(vec, types.BuildTS(21, 0), false, mp))
+
+	changed, ok := pkCommitTSMatchedInRange(vec, []int64{0, 3}, from, to)
+	require.True(t, ok)
+	require.False(t, changed)
+
+	changed, ok = pkCommitTSMatchedInRange(vec, []int64{1}, from, to)
+	require.True(t, ok)
+	require.True(t, changed)
+
+	changed, ok = pkCommitTSMatchedInRange(vec, []int64{2}, from, to)
+	require.True(t, ok)
+	require.True(t, changed)
+
+	vec.SetNull(1)
+	changed, ok = pkCommitTSMatchedInRange(vec, []int64{1}, from, to)
+	require.False(t, ok)
+	require.False(t, changed)
+
+	constNull := vector.NewConstNull(types.T_TS.ToType(), 1, mp)
+	defer constNull.Free(mp)
+	changed, ok = pkCommitTSMatchedInRange(constNull, []int64{0}, from, to)
+	require.False(t, ok)
+	require.False(t, changed)
 }

--- a/pkg/vm/engine/disttae/pk_check_guard_test.go
+++ b/pkg/vm/engine/disttae/pk_check_guard_test.go
@@ -109,6 +109,24 @@ func TestPkCheckSemaphore_RespectsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestAcquireReleasePKCheckSemaphore(t *testing.T) {
+	require.NoError(t, acquirePKCheckSemaphore(context.Background()))
+	releasePKCheckSemaphore()
+
+	for i := 0; i < cap(pkCheckSemaphore); i++ {
+		require.NoError(t, acquirePKCheckSemaphore(context.Background()))
+	}
+	defer func() {
+		for i := 0; i < cap(pkCheckSemaphore); i++ {
+			releasePKCheckSemaphore()
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, acquirePKCheckSemaphore(ctx), context.Canceled)
+}
+
 func TestPKCommitTSMatchedInRange(t *testing.T) {
 	mp := mpool.MustNewZero()
 	defer func() {

--- a/pkg/vm/engine/disttae/txn_table.go
+++ b/pkg/vm/engine/disttae/txn_table.go
@@ -85,6 +85,44 @@ func shouldBailoutOnCandidateBlocks(cnt int) bool {
 	return cnt > maxCandidateBlksForIO
 }
 
+func pkCheckBailoutOnChangedObjects(cnt int) bool {
+	if !shouldBailoutOnChangedObjects(cnt) {
+		return false
+	}
+	v2.TxnPKChangeCheckBailoutCounter.Inc()
+	return true
+}
+
+func pkCheckBailoutOnCandidateBlocks(cnt int) bool {
+	if !shouldBailoutOnCandidateBlocks(cnt) {
+		return false
+	}
+	v2.TxnPKChangeCheckBailoutCounter.Inc()
+	return true
+}
+
+func acquirePKCheckSemaphore(ctx context.Context) error {
+	select {
+	case pkCheckSemaphore <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func releasePKCheckSemaphore() {
+	<-pkCheckSemaphore
+}
+
+func shouldLogPKPersistedChanged(tableID uint64) bool {
+	switch tableID {
+	case catalog.MO_DATABASE_ID, catalog.MO_TABLES_ID, catalog.MO_COLUMNS_ID:
+		return true
+	default:
+		return false
+	}
+}
+
 var _ engine.Relation = new(txnTable)
 
 func newTxnTable(
@@ -2473,6 +2511,35 @@ func (tbl *txnTable) getPartitionState(
 	return
 }
 
+// pkCommitTSMatchedInRange narrows PK hits with row-level commit-ts. The second
+// return value is false when the commit-ts vector is unavailable or unusable;
+// callers should keep the original conservative behavior in that case.
+func pkCommitTSMatchedInRange(
+	commitTSVec *vector.Vector,
+	sels []int64,
+	from, to types.TS,
+) (bool, bool) {
+	if commitTSVec == nil ||
+		commitTSVec.GetType().Oid != types.T_TS ||
+		commitTSVec.IsConstNull() {
+		return false, false
+	}
+	timestamps := vector.MustFixedColWithTypeCheck[types.TS](commitTSVec)
+	for _, sel := range sels {
+		if sel < 0 || int(sel) >= len(timestamps) {
+			return false, false
+		}
+		if commitTSVec.IsNull(uint64(sel)) {
+			return false, false
+		}
+		ts := timestamps[sel]
+		if ts.GT(&from) && ts.LE(&to) {
+			return true, true
+		}
+	}
+	return false, true
+}
+
 func (tbl *txnTable) PKPersistedBetween(
 	p *logtailreplay.PartitionState,
 	from types.TS,
@@ -2481,10 +2548,38 @@ func (tbl *txnTable) PKPersistedBetween(
 	checkTombstone bool,
 ) (changed bool, err error) {
 
+	start := time.Now()
+	reason := ""
+	delObjs := make(map[objectio.ObjectNameShort]struct{})
+	cObjs := make(map[objectio.ObjectNameShort]struct{})
+	candidateBlks := make(map[types.Blockid]*objectio.BlockInfo)
 	v2.TxnPKChangeCheckTotalCounter.Inc()
 	defer func() {
-		if err != nil && changed {
+		if err == nil && changed {
 			v2.TxnPKChangeCheckChangedCounter.Inc()
+		}
+		if changed {
+			if !shouldLogPKPersistedChanged(tbl.tableId) {
+				return
+			}
+			if reason == "" {
+				reason = "unknown"
+			}
+			logutil.Info(
+				"txn pk persisted check changed",
+				zap.String("reason", reason),
+				zap.String("table-name", tbl.tableName),
+				zap.String("txn", tbl.db.op.Txn().DebugString()),
+				zap.String("from", from.ToString()),
+				zap.String("to", to.ToString()),
+				zap.Int("key-count", keys.Length()),
+				zap.Int("changed-objects", len(cObjs)),
+				zap.Int("deleted-objects", len(delObjs)),
+				zap.Int("candidate-blocks", len(candidateBlks)),
+				zap.Bool("check-tombstone", checkTombstone),
+				zap.Duration("duration", time.Since(start)),
+				zap.Error(err),
+			)
 		}
 	}()
 	ctx := tbl.proc.Load().Ctx
@@ -2496,17 +2591,15 @@ func (tbl *txnTable) PKPersistedBetween(
 		bf   objectio.BloomFilter
 	)
 
-	candidateBlks := make(map[types.Blockid]*objectio.BlockInfo)
-
 	//only check data objects.
-	delObjs, cObjs := p.GetChangedObjsBetween(from.Next(), types.MaxTs())
+	delObjs, cObjs = p.GetChangedObjsBetween(from.Next(), types.MaxTs())
 
 	// Under high-concurrency workloads (e.g., 1000 TPCC terminals), many transactions
 	// write to the same table, producing many changed objects. Only inserted objects
 	// (cObjs) can contain conflicting PKs; deleted objects are excluded from the count
 	// since they don't contribute to PK conflict I/O.
-	if shouldBailoutOnChangedObjects(len(cObjs)) {
-		v2.TxnPKChangeCheckBailoutCounter.Inc()
+	if pkCheckBailoutOnChangedObjects(len(cObjs)) {
+		reason = "changed_objects_bailout"
 		return true, nil
 	}
 
@@ -2583,6 +2676,7 @@ func (tbl *txnTable) PKPersistedBetween(
 
 			return
 		}); err != nil {
+		reason = "data_object_check_error"
 		return true, err
 	}
 
@@ -2622,12 +2716,12 @@ func (tbl *txnTable) PKPersistedBetween(
 
 	// If too many candidate blocks, conservatively return true to avoid excessive
 	// concurrent block reads that cause mpool explosion under high concurrency.
-	if shouldBailoutOnCandidateBlocks(len(candidateBlks)) {
-		v2.TxnPKChangeCheckBailoutCounter.Inc()
+	if pkCheckBailoutOnCandidateBlocks(len(candidateBlks)) {
+		reason = "candidate_blocks_bailout"
 		return true, nil
 	}
 
-	cacheVectors := containers.NewVectors(1)
+	cacheVectors := containers.NewVectors(2)
 	pkDef := tbl.tableDef.Cols[tbl.primaryIdx]
 	pkSeq := pkDef.Seqnum
 	pkType := plan2.ExprType2Type(&pkDef.Typ)
@@ -2636,10 +2730,8 @@ func (tbl *txnTable) PKPersistedBetween(
 		// This prevents 1000 goroutines from simultaneously reading blocks and
 		// exhausting mpool capacity. Scoped to the block loop only — tombstone
 		// checking below is not rate-limited by this semaphore.
-		select {
-		case pkCheckSemaphore <- struct{}{}:
-		case <-ctx.Done():
-			return false, ctx.Err()
+		if err := acquirePKCheckSemaphore(ctx); err != nil {
+			return false, err
 		}
 
 		v2.TxnPKChangeCheckIOCounter.Inc()
@@ -2647,8 +2739,8 @@ func (tbl *txnTable) PKPersistedBetween(
 		for _, blk := range candidateBlks {
 			release, err := ioutil.LoadColumns(
 				ctx,
-				[]uint16{uint16(pkSeq)},
-				[]types.Type{pkType},
+				[]uint16{uint16(pkSeq), objectio.SEQNUM_COMMITTS},
+				[]types.Type{pkType, types.T_TS.ToType()},
 				fs,
 				blk.MetaLocation(),
 				cacheVectors,
@@ -2656,7 +2748,8 @@ func (tbl *txnTable) PKPersistedBetween(
 				fileservice.Policy(0),
 			)
 			if err != nil {
-				<-pkCheckSemaphore
+				releasePKCheckSemaphore()
+				reason = "data_block_read_error"
 				return true, err
 			}
 
@@ -2666,18 +2759,32 @@ func (tbl *txnTable) PKPersistedBetween(
 			}
 
 			sels := searchFunc(cacheVectors)
-			release()
 			if len(sels) > 0 {
-				<-pkCheckSemaphore
-				return true, nil
+				changed, ok := pkCommitTSMatchedInRange(&cacheVectors[1], sels, from, to)
+				release()
+				if !ok || changed {
+					releasePKCheckSemaphore()
+					if ok {
+						reason = "data_commit_ts_hit"
+					} else {
+						reason = "data_commit_ts_unavailable"
+					}
+					return true, nil
+				}
+				continue
 			}
+			release()
 		}
-		<-pkCheckSemaphore
+		releasePKCheckSemaphore()
 	}
 	if checkTombstone {
 		pkDef := tbl.tableDef.Cols[tbl.primaryIdx]
 		pkType := plan2.ExprType2Type(&pkDef.Typ)
-		return tombstonePKExistsInRange(ctx, p, from, keys, pkType, fs)
+		changed, tombstoneReason, err := tombstonePKExistsInRange(ctx, p, from, to, keys, pkType, fs)
+		if changed {
+			reason = tombstoneReason
+		}
+		return changed, err
 	}
 	return false, nil
 }
@@ -2689,20 +2796,21 @@ func tombstonePKExistsInRange(
 	ctx context.Context,
 	p *logtailreplay.PartitionState,
 	from types.TS,
+	to types.TS,
 	keys *vector.Vector,
 	pkType types.Type,
 	fs fileservice.FileService,
-) (bool, error) {
+) (bool, string, error) {
 	tombObjs := p.GetChangedTombstoneObjsBetween(from)
 	if len(tombObjs) == 0 {
-		return false, nil
+		return false, "", nil
 	}
 	const tombstoneRowsThreshold = 50000
 	var totalRows uint32
 	for i := range tombObjs {
 		totalRows += tombObjs[i].Rows()
 		if totalRows > tombstoneRowsThreshold {
-			return true, nil
+			return true, "tombstone_rows_bailout", nil
 		}
 	}
 	searchKeys := LinearSearchOffsetByValFactory(keys)
@@ -2717,17 +2825,29 @@ func tombstonePKExistsInRange(
 			tombVectors := containers.NewVectors(vecCount)
 			_, release, err := ioutil.ReadDeletes(ctx, loc, fs, isCNCreated, tombVectors, &pkType)
 			if err != nil {
-				return true, nil
+				return true, "tombstone_read_error", nil
 			}
 			pkVec := tombVectors[1]
 			hits := searchKeys(&pkVec)
-			release()
 			if len(hits) > 0 {
-				return true, nil
+				if isCNCreated {
+					release()
+					return true, "tombstone_cn_hit", nil
+				}
+				changed, ok := pkCommitTSMatchedInRange(&tombVectors[2], hits, from, to)
+				release()
+				if !ok || changed {
+					if ok {
+						return true, "tombstone_commit_ts_hit", nil
+					}
+					return true, "tombstone_commit_ts_unavailable", nil
+				}
+				continue
 			}
+			release()
 		}
 	}
-	return false, nil
+	return false, "", nil
 }
 
 func (tbl *txnTable) PrimaryKeysMayBeUpserted(

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -169,6 +169,47 @@ func TestTombstonePKExistsInRange(t *testing.T) {
 	require.False(t, changed)
 }
 
+func TestTombstonePKExistsInRangeRowsThresholdBailout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	proc := testutil.NewProc(t)
+	fs, err := fileservice.Get[fileservice.FileService](proc.GetFileService(), defines.SharedFileServiceName)
+	require.NoError(t, err)
+
+	pState := logtailreplay.NewPartitionState("", true, 0, false)
+	int32Type := types.T_int32.ToType()
+
+	// Write a real CN tombstone so we get a valid ObjectStats base.
+	writer := colexec.NewCNS3TombstoneWriter(proc.Mp(), fs, int32Type, -1)
+	bat := readutil.NewCNTombstoneBatch(&int32Type, objectio.HiddenColumnSelection_None)
+	require.NoError(t, vector.AppendFixed[types.Rowid](bat.Vecs[0], types.RandomRowid(), false, proc.GetMPool()))
+	require.NoError(t, vector.AppendFixed[int32](bat.Vecs[1], 100, false, proc.GetMPool()))
+	bat.SetRowCount(1)
+	require.NoError(t, writer.Write(ctx, bat))
+	stats, err := writer.Sync(ctx)
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+
+	// Override the row count to exceed the 50000 threshold.
+	require.NoError(t, objectio.SetObjectStatsRowCnt(&stats[0], 60000))
+
+	require.NoError(t, pState.HandleObjectEntry(ctx, fs, objectio.ObjectEntry{
+		ObjectStats: stats[0],
+		CreateTime:  types.BuildTS(15, 0),
+	}, true))
+
+	keys := vector.NewVec(int32Type)
+	require.NoError(t, vector.AppendFixed[int32](keys, 100, false, proc.GetMPool()))
+
+	changed, reason, err := tombstonePKExistsInRange(
+		ctx, pState, types.BuildTS(10, 0), types.MaxTs(), keys, int32Type, fs,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "tombstone_rows_bailout", reason)
+}
+
 func TestBlockMetaMarshal(t *testing.T) {
 	location := []byte("test")
 	var info objectio.BlockInfo

--- a/pkg/vm/engine/disttae/util_test.go
+++ b/pkg/vm/engine/disttae/util_test.go
@@ -145,26 +145,26 @@ func TestTombstonePKExistsInRange(t *testing.T) {
 	// Case 1: search for PK=200, should find it
 	keys1 := vector.NewVec(int32Type)
 	require.NoError(t, vector.AppendFixed[int32](keys1, 200, false, proc.GetMPool()))
-	changed, err := tombstonePKExistsInRange(ctx, pState, from, keys1, int32Type, fs)
+	changed, _, err := tombstonePKExistsInRange(ctx, pState, from, types.MaxTs(), keys1, int32Type, fs)
 	require.NoError(t, err)
 	require.True(t, changed)
 
 	// Case 2: search for PK=999, should not find it
 	keys2 := vector.NewVec(int32Type)
 	require.NoError(t, vector.AppendFixed[int32](keys2, 999, false, proc.GetMPool()))
-	changed, err = tombstonePKExistsInRange(ctx, pState, from, keys2, int32Type, fs)
+	changed, _, err = tombstonePKExistsInRange(ctx, pState, from, types.MaxTs(), keys2, int32Type, fs)
 	require.NoError(t, err)
 	require.False(t, changed)
 
 	// Case 3: search for PK=500, should find it in second tombstone
 	keys3 := vector.NewVec(int32Type)
 	require.NoError(t, vector.AppendFixed[int32](keys3, 500, false, proc.GetMPool()))
-	changed, err = tombstonePKExistsInRange(ctx, pState, from, keys3, int32Type, fs)
+	changed, _, err = tombstonePKExistsInRange(ctx, pState, from, types.MaxTs(), keys3, int32Type, fs)
 	require.NoError(t, err)
 	require.True(t, changed)
 
 	// Case 4: no tombstone objects changed after from=25
-	changed, err = tombstonePKExistsInRange(ctx, pState, types.BuildTS(25, 0), keys1, int32Type, fs)
+	changed, _, err = tombstonePKExistsInRange(ctx, pState, types.BuildTS(25, 0), types.MaxTs(), keys1, int32Type, fs)
 	require.NoError(t, err)
 	require.False(t, changed)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24584

## What this PR does / why we need it:

This PR adds a precheck for ALTER TABLE COPY when adding a primary key on existing columns:

- checks NULL values and duplicate primary-key values on the source table before the copy insert
- skips the normal insert PK dedup only after the precheck succeeds
- keeps the normal insert dedup path when the old and new PK column definitions may produce different key values, such as type or width changes
- enables pipeline flush for the copy insert after PK dedup is proven unnecessary

Tested with:

```sh
go test -mod=mod ./pkg/sql/compile ./pkg/sql/plan -run 'TestShouldEnableAlterCopyPipelineFlush|TestScopeAlterTableCopyInsertTmpDataPipelineFlush|TestScopeAlterTableCopyPrecheckPrimaryKeyThenSkipDedup|TestPrecheckAlterCopyPkDedupRejectsNull|TestPrecheckAlterCopyPkDedupRejectsDuplicate|TestPrecheckAlterCopyPkDedupCanSkipNullCheck|TestGetAlterCopyPkPrecheck'
```