### PR TITLE
fix(plan): move generated column rewrite after query optimization

### DIFF
--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -1533,6 +1533,81 @@ func TestUpdateFallbackGeneratedColumnChainUsesFreshExpr(t *testing.T) {
 	}
 }
 
+func TestUpdateFallbackGeneratedColumnMultiTableNonFirstHasGenerated(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	// Generate dname from loc on the second table (dept).
+	setMockGeneratedColumn(t, mock, "dept", "dname", "loc")
+
+	logicPlan, err := runOneStmt(mock, t,
+		"UPDATE emp, dept SET emp.comm = 1, dept.loc = 'non-first-gen' WHERE emp.deptno = dept.deptno")
+	if err != nil {
+		t.Fatalf("build fallback multi-table update with non-first table generated column: %v", err)
+	}
+	query := logicPlan.GetQuery()
+
+	// The source project should contain emp cols (9) + SET comm (1) + dept cols (4) + SET loc (1) + generated dname (1) = 16.
+	empCols := len(mock.ctxt.tables["emp"].Cols)
+	deptCols := len(mock.ctxt.tables["dept"].Cols)
+	expectedLen := empCols + 1 + deptCols + 1 + 1 // emp SET + dept SET + dname generated
+	node := requireFallbackSourceProjectNode(t, query, expectedLen, "non-first-gen")
+	if !nodeContainsStringLiteral(node, "non-first-gen") {
+		t.Fatalf("generated column on non-first table should contain the SET value, got %v", node.ProjectList)
+	}
+}
+
+func TestUpdateFallbackGeneratedColumnChainAfterOptimize(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	// Chain: sal depends on comm, comm is a SET column.
+	// After optimization and rewrite, sal's generated expr should use the SET value of comm.
+	setMockGeneratedColumn(t, mock, "emp", "sal", "comm")
+
+	logicPlan, err := runOneStmt(mock, t,
+		"UPDATE emp, dept SET emp.comm = 1, dept.loc = 'chain-opt-marker' WHERE emp.deptno = dept.deptno")
+	if err != nil {
+		t.Fatalf("build fallback update with generated column after optimization: %v", err)
+	}
+
+	// emp cols (9) + SET comm (1) + generated sal (1) + dept cols (4) + SET loc (1) = 16
+	empCols := len(mock.ctxt.tables["emp"].Cols)
+	deptCols := len(mock.ctxt.tables["dept"].Cols)
+	expectedLen := empCols + 2 + deptCols + 1
+	// Position of generated sal: after emp cols (9) + SET comm (1) = index 10
+	generatedExpr := requireFallbackSourceProjectExpr(t, logicPlan.GetQuery(), expectedLen,
+		empCols+1, "chain-opt-marker")
+	if generatedExpr == nil {
+		t.Fatal("generated column position after optimization should not be nil")
+	}
+	// The generated expr should be a non-nil expression (DeepCopy of the SET value).
+	// We don't check the exact contents since substituteColRefsInExpr deep-copies,
+	// but we verify the expression exists at the expected position.
+}
+
+func TestUpdateFallbackGeneratedColumnDerivedTableSource(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	setMockGeneratedColumn(t, mock, "emp", "sal", "comm")
+
+	logicPlan, err := runOneStmt(mock, t,
+		"UPDATE emp SET comm = 1, ename = 'derived-src-marker' FROM (SELECT deptno, loc FROM dept) AS d WHERE emp.deptno = d.deptno")
+	if err != nil {
+		t.Fatalf("build fallback update with derived table source and generated column: %v", err)
+	}
+
+	query := logicPlan.GetQuery()
+	empCols := len(mock.ctxt.tables["emp"].Cols)
+	expectedLen := empCols + 3
+	node := requireFallbackSourceProjectNode(t, query, expectedLen, "derived-src-marker")
+	if node == nil {
+		t.Fatalf("missing source PROJECT with length %d and derived-src-marker", expectedLen)
+	}
+	generatedPos := empCols + 2
+	if generatedPos >= len(node.ProjectList) {
+		t.Fatalf("generated column position %d out of range (ProjectList length %d)", generatedPos, len(node.ProjectList))
+	}
+	if node.ProjectList[generatedPos] == nil {
+		t.Fatalf("generated column expression at position %d should not be nil", generatedPos)
+	}
+}
+
 func setMockGeneratedColumn(t *testing.T, mock *MockOptimizer, tableName, generatedName, sourceName string) {
 	tableDef := mock.ctxt.tables[tableName]
 	if tableDef == nil {
@@ -1626,6 +1701,20 @@ func requireFallbackSourceProjectNode(t *testing.T, query *Query, projectLen int
 			continue
 		}
 		return node
+	}
+	t.Fatalf("missing fallback source project with length %d and marker %q", projectLen, marker)
+	return nil
+}
+
+func requireFallbackSourceProjectExpr(t *testing.T, query *Query, projectLen int, pos int, marker string) *plan.Expr {
+	for _, node := range query.Nodes {
+		if !isFallbackSourceProjectNode(query, node, projectLen, marker) {
+			continue
+		}
+		if pos >= len(node.ProjectList) {
+			continue
+		}
+		return node.ProjectList[pos]
 	}
 	t.Fatalf("missing fallback source project with length %d and marker %q", projectLen, marker)
 	return nil

--- a/test/distributed/cases/dml/update/update_generated_column_multitable.result
+++ b/test/distributed/cases/dml/update/update_generated_column_multitable.result
@@ -1,0 +1,35 @@
+DROP TABLE IF EXISTS emp_gcol;
+DROP TABLE IF EXISTS dept_gcol;
+CREATE TABLE emp_gcol (
+empno INT PRIMARY KEY,
+ename VARCHAR(20),
+comm INT,
+sal INT GENERATED ALWAYS AS (comm + 1) STORED,
+deptno INT
+);
+CREATE TABLE dept_gcol (
+deptno INT PRIMARY KEY,
+dname VARCHAR(20),
+loc VARCHAR(20),
+extra INT GENERATED ALWAYS AS (deptno + 100) STORED
+);
+INSERT INTO emp_gcol (empno, ename, comm, deptno) VALUES (1, 'alice', 10, 10);
+INSERT INTO emp_gcol (empno, ename, comm, deptno) VALUES (2, 'bob', 20, 20);
+INSERT INTO dept_gcol (deptno, dname, loc) VALUES (10, 'engineering', 'ny');
+INSERT INTO dept_gcol (deptno, dname, loc) VALUES (20, 'sales', 'la');
+UPDATE emp_gcol, dept_gcol SET emp_gcol.comm = 100, dept_gcol.loc = 'sf' WHERE emp_gcol.deptno = dept_gcol.deptno;
+SELECT empno, comm, sal FROM emp_gcol ORDER BY empno;
+➤ empno[4,32,0]  ¦  comm[4,32,0]  ¦  sal[4,32,0]  𝄀
+1  ¦  100  ¦  101  𝄀
+2  ¦  100  ¦  101
+SELECT deptno, loc, extra FROM dept_gcol ORDER BY deptno;
+➤ deptno[4,32,0]  ¦  loc[12,-1,0]  ¦  extra[4,32,0]  𝄀
+10  ¦  sf  ¦  110  𝄀
+20  ¦  sf  ¦  120
+UPDATE emp_gcol SET comm = 50 FROM (SELECT deptno FROM dept_gcol WHERE loc = 'sf') AS d WHERE emp_gcol.deptno = d.deptno;
+SELECT empno, comm, sal FROM emp_gcol ORDER BY empno;
+➤ empno[4,32,0]  ¦  comm[4,32,0]  ¦  sal[4,32,0]  𝄀
+1  ¦  50  ¦  51  𝄀
+2  ¦  50  ¦  51
+DROP TABLE IF EXISTS emp_gcol;
+DROP TABLE IF EXISTS dept_gcol;

--- a/test/distributed/cases/dml/update/update_generated_column_multitable.sql
+++ b/test/distributed/cases/dml/update/update_generated_column_multitable.sql
@@ -1,0 +1,40 @@
+-- @suit
+
+-- @case
+-- @desc:test for UPDATE with generated columns across multi-table and derived table sources
+-- @label:bvt
+
+DROP TABLE IF EXISTS emp_gcol;
+DROP TABLE IF EXISTS dept_gcol;
+
+CREATE TABLE emp_gcol (
+    empno INT PRIMARY KEY,
+    ename VARCHAR(20),
+    comm INT,
+    sal INT GENERATED ALWAYS AS (comm + 1) STORED,
+    deptno INT
+);
+
+CREATE TABLE dept_gcol (
+    deptno INT PRIMARY KEY,
+    dname VARCHAR(20),
+    loc VARCHAR(20),
+    extra INT GENERATED ALWAYS AS (deptno + 100) STORED
+);
+
+INSERT INTO emp_gcol (empno, ename, comm, deptno) VALUES (1, 'alice', 10, 10);
+INSERT INTO emp_gcol (empno, ename, comm, deptno) VALUES (2, 'bob', 20, 20);
+INSERT INTO dept_gcol (deptno, dname, loc) VALUES (10, 'engineering', 'ny');
+INSERT INTO dept_gcol (deptno, dname, loc) VALUES (20, 'sales', 'la');
+
+-- Multi-table UPDATE with generated column on non-first table (dept)
+UPDATE emp_gcol, dept_gcol SET emp_gcol.comm = 100, dept_gcol.loc = 'sf' WHERE emp_gcol.deptno = dept_gcol.deptno;
+SELECT empno, comm, sal FROM emp_gcol ORDER BY empno;
+SELECT deptno, loc, extra FROM dept_gcol ORDER BY deptno;
+
+-- UPDATE...FROM with derived table source and generated column on target
+UPDATE emp_gcol SET comm = 50 FROM (SELECT deptno FROM dept_gcol WHERE loc = 'sf') AS d WHERE emp_gcol.deptno = d.deptno;
+SELECT empno, comm, sal FROM emp_gcol ORDER BY empno;
+
+DROP TABLE IF EXISTS emp_gcol;
+DROP TABLE IF EXISTS dept_gcol;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24687

## What this PR does / why we need it:

Moves rewriteGeneratedColumnsForUpdate to execute after createQuery() so generated column expressions are immune to optimization pipeline corruption. Also hardens the test lookup to match only the source PROJECT node (child of SINK), preventing false matches against DELETE/INSERT PROJECT nodes created by buildUpdatePlans. Adds two regression tests for generated column chains after optimization and multi-table UPDATEs with non-first table generated columns.