### PR TITLE
fix: align time functions with MySQL semantics

### DIFF
--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -3930,7 +3930,7 @@ func makeTimeFormat(ctx context.Context, hour uint64, minute, sec uint8, msec ui
 	case 'S', 's':
 		FormatInt2BufByWidth(int(sec), 2, buf)
 	case 'T':
-		fmt.Fprintf(buf, "%02d:%02d:%02d", hour%24, minute, sec)
+		fmt.Fprintf(buf, "%02d:%02d:%02d", hour, minute, sec)
 	default:
 		// For unsupported format specifiers, just write the character as-is
 		// This matches MySQL behavior where non-time format specifiers are ignored
@@ -6976,7 +6976,7 @@ func MakeDateString(
 }
 
 // makeTimeFromInt64: Helper function to create Time from int64 values
-func makeTimeFromInt64(hour, minute, second int64, rs *vector.FunctionResult[types.Time], i uint64) error {
+func makeTimeFromInt64(hour, minute, second int64, microsecond uint32, rs *vector.FunctionResult[types.Time], i uint64) error {
 	// MySQL allows hour to be in range [0, 838] (TIME type range)
 	// minute and second should be in range [0, 59]
 	// If values are out of range, MySQL returns NULL
@@ -6990,7 +6990,7 @@ func makeTimeFromInt64(hour, minute, second int64, rs *vector.FunctionResult[typ
 
 	// Create Time value using TimeFromClock
 	// hour can be up to 838, so we use uint64 for hour
-	timeValue := types.TimeFromClock(false, uint64(hour), uint8(minute), uint8(second), 0)
+	timeValue := types.TimeFromClock(false, uint64(hour), uint8(minute), uint8(second), microsecond)
 
 	// Validate the resulting time
 	h := timeValue.Hour()
@@ -7016,7 +7016,7 @@ func MakeTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, _ *pr
 	// Create parameter wrappers based on types (these can be reused for all rows)
 	var getHourValue func(uint64) (int64, bool)
 	var getMinuteValue func(uint64) (int64, bool)
-	var getSecondValue func(uint64) (int64, bool)
+	var getSecondValue func(uint64) (int64, uint32, bool)
 
 	// Setup hour parameter extractor
 	switch hourType {
@@ -7106,39 +7106,48 @@ func MakeTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, _ *pr
 	switch secondType {
 	case types.T_int8:
 		secondParam := vector.GenerateFunctionFixedTypeParameter[int8](ivecs[2])
-		getSecondValue = func(i uint64) (int64, bool) {
+		getSecondValue = func(i uint64) (int64, uint32, bool) {
 			val, null := secondParam.GetValue(i)
-			return int64(val), null
+			return int64(val), 0, null
 		}
 	case types.T_int16:
 		secondParam := vector.GenerateFunctionFixedTypeParameter[int16](ivecs[2])
-		getSecondValue = func(i uint64) (int64, bool) {
+		getSecondValue = func(i uint64) (int64, uint32, bool) {
 			val, null := secondParam.GetValue(i)
-			return int64(val), null
+			return int64(val), 0, null
 		}
 	case types.T_int32:
 		secondParam := vector.GenerateFunctionFixedTypeParameter[int32](ivecs[2])
-		getSecondValue = func(i uint64) (int64, bool) {
+		getSecondValue = func(i uint64) (int64, uint32, bool) {
 			val, null := secondParam.GetValue(i)
-			return int64(val), null
+			return int64(val), 0, null
 		}
 	case types.T_int64:
 		secondParam := vector.GenerateFunctionFixedTypeParameter[int64](ivecs[2])
-		getSecondValue = func(i uint64) (int64, bool) {
+		getSecondValue = func(i uint64) (int64, uint32, bool) {
 			val, null := secondParam.GetValue(i)
-			return val, null
+			return val, 0, null
 		}
 	case types.T_uint8, types.T_uint16, types.T_uint32, types.T_uint64:
 		secondParam := vector.GenerateFunctionFixedTypeParameter[uint64](ivecs[2])
-		getSecondValue = func(i uint64) (int64, bool) {
+		getSecondValue = func(i uint64) (int64, uint32, bool) {
 			val, null := secondParam.GetValue(i)
-			return int64(val), null
+			return int64(val), 0, null
 		}
 	case types.T_float32, types.T_float64:
 		secondParam := vector.GenerateFunctionFixedTypeParameter[float64](ivecs[2])
-		getSecondValue = func(i uint64) (int64, bool) {
+		getSecondValue = func(i uint64) (int64, uint32, bool) {
 			val, null := secondParam.GetValue(i)
-			return int64(val), null // Truncate decimal part
+			if val < 0 {
+				return int64(val), 0, null
+			}
+			second := int64(val)
+			microsecond := uint32(math.Round((val - float64(second)) * float64(types.MicroSecsPerSec)))
+			if microsecond >= types.MicroSecsPerSec {
+				second++
+				microsecond = 0
+			}
+			return second, microsecond, null
 		}
 	default:
 		return moerr.NewInvalidArgNoCtx("MAKETIME second parameter", secondType)
@@ -7148,7 +7157,7 @@ func MakeTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, _ *pr
 	for i := uint64(0); i < uint64(length); i++ {
 		hourInt, null1 := getHourValue(i)
 		minuteInt, null2 := getMinuteValue(i)
-		secondInt, null3 := getSecondValue(i)
+		secondInt, microsecond, null3 := getSecondValue(i)
 
 		if null1 || null2 || null3 {
 			if err := rs.Append(types.Time(0), true); err != nil {
@@ -7157,7 +7166,7 @@ func MakeTime(ivecs []*vector.Vector, result vector.FunctionResultWrapper, _ *pr
 			continue
 		}
 
-		if err := makeTimeFromInt64(hourInt, minuteInt, secondInt, rs, i); err != nil {
+		if err := makeTimeFromInt64(hourInt, minuteInt, secondInt, microsecond, rs, i); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/plan/function/func_binary_test.go
+++ b/pkg/sql/plan/function/func_binary_test.go
@@ -8519,6 +8519,7 @@ func initTimeFormatTestCase() []tcTemp {
 	t2, _ := types.ParseTime("00:00:00", 6)
 	t3, _ := types.ParseTime("23:59:59.123456", 6)
 	t4, _ := types.ParseTime("12:34:56.789012", 6)
+	t5, _ := types.ParseTime("123:45:06", 6)
 
 	return []tcTemp{
 		{
@@ -8537,13 +8538,13 @@ func initTimeFormatTestCase() []tcTemp {
 			info: "test time_format - %T",
 			inputs: []FunctionTestInput{
 				NewFunctionTestInput(types.T_time.ToType(),
-					[]types.Time{t1},
-					[]bool{false}),
+					[]types.Time{t1, t5},
+					[]bool{false, false}),
 				NewFunctionTestConstInput(types.T_varchar.ToType(), []string{"%T"}, []bool{false}),
 			},
 			expect: NewFunctionTestResult(types.T_varchar.ToType(), false,
-				[]string{"15:30:45"},
-				[]bool{false}),
+				[]string{"15:30:45", "123:45:06"},
+				[]bool{false, false}),
 		},
 		{
 			info: "test time_format - %h:%i:%s %p",
@@ -8605,6 +8606,22 @@ func TestTimeFormat(t *testing.T) {
 		s, info := fcTC.Run()
 		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
 	}
+}
+
+func TestMakeTimePreservesFractionalSeconds(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	fcTC := NewFunctionTestCase(proc,
+		[]FunctionTestInput{
+			NewFunctionTestInput(types.T_float64.ToType(), []float64{12}, []bool{false}),
+			NewFunctionTestInput(types.T_float64.ToType(), []float64{34}, []bool{false}),
+			NewFunctionTestInput(types.T_float64.ToType(), []float64{56.789012}, []bool{false}),
+		},
+		NewFunctionTestResult(types.T_time.ToType(), false,
+			[]types.Time{types.TimeFromClock(false, 12, 34, 56, 789012)},
+			[]bool{false}),
+		MakeTime)
+	s, info := fcTC.Run()
+	require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", "test maketime fractional seconds", info))
 }
 
 // TestTimestampDiffDateString tests TIMESTAMPDIFF with DATE and string arguments

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -3695,10 +3695,9 @@ func DatetimeToHour(ivecs []*vector.Vector, result vector.FunctionResultWrapper,
 }
 
 func TimeToHour(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
-	return opUnaryFixedToFixed[types.Time, uint8](ivecs, result, proc, length, func(v types.Time) uint8 {
+	return opUnaryFixedToFixed[types.Time, uint16](ivecs, result, proc, length, func(v types.Time) uint16 {
 		hour, _, _, _, _ := v.ClockFormat()
-		// HOUR function returns 0-23, so we need to take modulo 24
-		return uint8(hour % 24)
+		return uint16(hour)
 	}, selectList)
 }
 

--- a/pkg/sql/plan/function/func_unary_test.go
+++ b/pkg/sql/plan/function/func_unary_test.go
@@ -3698,6 +3698,7 @@ func initHourTestCase() []tcTemp {
 	t1, _ := types.ParseTime("15:30:45", 6)
 	t2, _ := types.ParseTime("00:00:00", 6)
 	t3, _ := types.ParseTime("23:59:59", 6)
+	t4, _ := types.ParseTime("272:59:59", 6)
 
 	return []tcTemp{
 		{
@@ -3729,12 +3730,12 @@ func initHourTestCase() []tcTemp {
 			typ:  types.T_time,
 			inputs: []FunctionTestInput{
 				NewFunctionTestInput(types.T_time.ToType(),
-					[]types.Time{t1, t2, t3},
-					[]bool{false, false, false}),
+					[]types.Time{t1, t2, t3, t4},
+					[]bool{false, false, false, false}),
 			},
-			expect: NewFunctionTestResult(types.T_uint8.ToType(), false,
-				[]uint8{15, 0, 23},
-				[]bool{false, false, false}),
+			expect: NewFunctionTestResult(types.T_uint16.ToType(), false,
+				[]uint16{15, 0, 23, 272},
+				[]bool{false, false, false, false}),
 		},
 	}
 }

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -7591,7 +7591,7 @@ var supportedDateAndTimeBuiltIns = []FuncNew{
 				overloadId: 2,
 				args:       []types.T{types.T_time},
 				retType: func(parameters []types.Type) types.Type {
-					return types.T_uint8.ToType()
+					return types.T_uint16.ToType()
 				},
 				newOp: func() executeLogicOfOverload {
 					return TimeToHour


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24784

## What this PR does / why we need it:

This PR fixes three MySQL compatibility issues in time functions on 4.0-dev:

- `HOUR(TIME)` now returns the full TIME hour part instead of folding it with `% 24`. MySQL TIME values can represent intervals up to `838:59:59`, so `HOUR("272:59:59")` should return `272`.
- `TIME_FORMAT(time, "%T")` now preserves the full hour part instead of formatting `hour % 24`.
- `MAKETIME(hour, minute, second)` now preserves fractional seconds from floating second arguments when constructing the TIME value.

Regression tests cover large-hour `HOUR`, large-hour `%T`, and fractional-second `MAKETIME`.

Local validation:

- `git diff --check` passes.
- `go test ./pkg/sql/plan/function -run 'TestHour|TestTimeFormat|TestMakeTimePreservesFractionalSeconds' -count=1` is blocked in this local environment by missing cgo headers: `usearch.h` and `xxhash.h`.