### PR TITLE
fix: close txn operator on wait failure

### DIFF
--- a/pkg/txn/client/operator.go
+++ b/pkg/txn/client/operator.go
@@ -823,6 +823,9 @@ func (tc *txnOperator) WriteAndCommit(ctx context.Context, requests []txn.TxnReq
 
 func (tc *txnOperator) Commit(ctx context.Context) (err error) {
 	if err := tc.CancelAndWaitRunningSQLWithSQL(ctx, 0, "<commit>"); err != nil {
+		// Commit can be called with an already-canceled context while SQL is still running.
+		// The commit has not been sent yet, so close locally as aborted to release active/leak state.
+		tc.closeAsAborted(ctx, err)
 		return err
 	}
 
@@ -874,6 +877,9 @@ func (tc *txnOperator) Commit(ctx context.Context) (err error) {
 
 func (tc *txnOperator) Rollback(ctx context.Context) (err error) {
 	if err := tc.CancelAndWaitRunningSQLWithSQL(ctx, 0, "<rollback>"); err != nil {
+		// Rollback can be called from connection cleanup with an already-canceled context.
+		// Still close the operator locally so txnClient active/leak-check state is released.
+		tc.closeAsAborted(ctx, err)
 		return err
 	}
 
@@ -1510,6 +1516,17 @@ func (tc *txnOperator) closeLocked(ctx context.Context) {
 				Txn:   tc.mu.txn,
 				Err:   tc.reset.commitErr,
 			})
+	}
+}
+
+func (tc *txnOperator) closeAsAborted(ctx context.Context, err error) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	if !tc.mu.closed {
+		tc.reset.commitErr = err
+		tc.mu.txn.Status = txn.TxnStatus_Aborted
+		tc.closeLocked(ctx)
 	}
 }
 

--- a/pkg/txn/client/operator_events_test.go
+++ b/pkg/txn/client/operator_events_test.go
@@ -37,6 +37,64 @@ func TestClosedEvent(t *testing.T) {
 		txn.TxnStatus_Aborted)
 }
 
+func TestCommitClosedEventWhenWaitRunningSQLFails(t *testing.T) {
+	runOperatorTests(
+		t,
+		func(ctx context.Context, tc *txnOperator, _ *testTxnSender) {
+			_, sqlCancel := context.WithCancel(context.Background())
+			token := tc.EnterRunSqlWithTokenAndSQL(sqlCancel, "select 1")
+			defer tc.ExitRunSqlWithToken(token)
+			defer sqlCancel()
+
+			commitCtx, cancelCommit := context.WithCancel(ctx)
+			cancelCommit()
+
+			cnt := 0
+			tc.AppendEventCallback(ClosedEvent,
+				TxnEventCallback{
+					Func: func(ctx context.Context, tc TxnOperator, event TxnEvent, value any) error {
+						cnt++
+						assert.Equal(t, txn.TxnStatus_Aborted, event.Txn.Status)
+						assert.Error(t, event.Err)
+						return nil
+					},
+				})
+
+			require.Error(t, tc.Commit(commitCtx))
+			assert.Equal(t, 1, cnt)
+			assert.True(t, tc.mu.closed)
+		})
+}
+
+func TestRollbackClosedEventWhenWaitRunningSQLFails(t *testing.T) {
+	runOperatorTests(
+		t,
+		func(ctx context.Context, tc *txnOperator, _ *testTxnSender) {
+			_, sqlCancel := context.WithCancel(context.Background())
+			token := tc.EnterRunSqlWithTokenAndSQL(sqlCancel, "select 1")
+			defer tc.ExitRunSqlWithToken(token)
+			defer sqlCancel()
+
+			rollbackCtx, cancelRollback := context.WithCancel(ctx)
+			cancelRollback()
+
+			cnt := 0
+			tc.AppendEventCallback(ClosedEvent,
+				TxnEventCallback{
+					Func: func(ctx context.Context, tc TxnOperator, event TxnEvent, value any) error {
+						cnt++
+						assert.Equal(t, txn.TxnStatus_Aborted, event.Txn.Status)
+						assert.Error(t, event.Err)
+						return nil
+					},
+				})
+
+			require.Error(t, tc.Rollback(rollbackCtx))
+			assert.Equal(t, 1, cnt)
+			assert.True(t, tc.mu.closed)
+		})
+}
+
 func runClosedEventTests(
 	t *testing.T,
 	getAction func(tc *txnOperator) func(context.Context) error,


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Refs #24766

## What this PR does / why we need it:

This ports the txn operator cleanup fix to main.

`Commit()` and `Rollback()` can return early when `CancelAndWaitRunningSQLWithSQL` fails, for example when the caller context is already canceled while SQL is still running. Without closing the operator on that path, the frontend can later drop its handler reference while the txn operator remains registered in `txnClient.activeTxns` and the leak checker.

The fix closes the operator locally as aborted before returning the wait error, so `ClosedEvent` still releases the active/leak-check state. Regression tests cover both commit and rollback wait-failure paths.

Local validation:

- `go test ./pkg/txn/client -run 'Test(Commit|Rollback)ClosedEventWhenWaitRunningSQLFails' -count=1`
- `go test ./pkg/txn/client -count=1`