### PR TITLE
fix: fold variable expressions before remote run

### DIFF
--- a/pkg/sql/colexec/aggexec/types.go
+++ b/pkg/sql/colexec/aggexec/types.go
@@ -60,6 +60,26 @@ func (expr AggFuncExecExpression) GetArgExpressions() []*plan.Expr {
 	return expr.argExpressions
 }
 
+func (expr *AggFuncExecExpression) RewriteArgExpressions(rewrite func(*plan.Expr) (*plan.Expr, bool, error)) (bool, error) {
+	folded := false
+	args := make([]*plan.Expr, len(expr.argExpressions))
+	copy(args, expr.argExpressions)
+	for i := range args {
+		arg, argFolded, err := rewrite(args[i])
+		if err != nil {
+			return false, err
+		}
+		if argFolded {
+			args[i] = arg
+			folded = true
+		}
+	}
+	if folded {
+		expr.argExpressions = args
+	}
+	return folded, nil
+}
+
 func (expr AggFuncExecExpression) GetExtraConfig() []byte {
 	return expr.extraConfig
 }

--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -358,7 +358,11 @@ type VarExpressionExecutor struct {
 }
 
 func (expr *VarExpressionExecutor) Eval(proc *process.Process, batches []*batch.Batch, _ []bool) (*vector.Vector, error) {
-	val, err := proc.GetResolveVariableFunc()(expr.name, expr.system, expr.global)
+	resolveVariableFunc := proc.GetResolveVariableFunc()
+	if resolveVariableFunc == nil {
+		return nil, moerr.NewInternalErrorf(proc.Ctx, "resolve variable function is not set for variable %s", expr.name)
+	}
+	val, err := resolveVariableFunc(expr.name, expr.system, expr.global)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colexec/evalExpression_test.go
+++ b/pkg/sql/colexec/evalExpression_test.go
@@ -209,6 +209,27 @@ func TestVarExpressionExecutor(t *testing.T) {
 	// require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
+func TestVarExpressionExecutorWithoutResolveVariableFunc(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	varExpr := &plan.Expr{
+		Expr: &plan.Expr_V{
+			V: &plan.VarRef{
+				Name:   "test_var",
+				System: true,
+			},
+		},
+		Typ: plan.Type{
+			Id: int32(types.T_text),
+		},
+	}
+
+	varExprExecutor, err := NewExpressionExecutor(proc, varExpr)
+	require.NoError(t, err)
+	_, err = varExprExecutor.Eval(proc, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "resolve variable function is not set")
+}
+
 func TestColumnExpressionExecutor(t *testing.T) {
 	proc := testutil.NewProcess(t)
 

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -1111,6 +1111,36 @@ func (lockOp *LockOp) AddLockTargetWithMode(
 	return lockOp
 }
 
+func (lockOp *LockOp) GetLockRowsExpressions() []*plan.Expr {
+	exprs := make([]*plan.Expr, 0, len(lockOp.targets))
+	for i := range lockOp.targets {
+		if lockOp.targets[i].lockRows != nil {
+			exprs = append(exprs, lockOp.targets[i].lockRows)
+		}
+	}
+	return exprs
+}
+
+func (lockOp *LockOp) RewriteLockRowsExpressions(rewrite func(*plan.Expr) (*plan.Expr, bool, error)) (bool, error) {
+	folded := false
+	targets := make([]lockTarget, len(lockOp.targets))
+	copy(targets, lockOp.targets)
+	for i := range targets {
+		expr, exprFolded, err := rewrite(targets[i].lockRows)
+		if err != nil {
+			return false, err
+		}
+		if exprFolded {
+			targets[i].lockRows = expr
+			folded = true
+		}
+	}
+	if folded {
+		lockOp.targets = targets
+	}
+	return folded, nil
+}
+
 // LockTable lock all table, used for delete, truncate and drop table
 func (lockOp *LockOp) LockTable(
 	tableID uint64,

--- a/pkg/sql/colexec/lockop/lock_op.go
+++ b/pkg/sql/colexec/lockop/lock_op.go
@@ -1126,6 +1126,9 @@ func (lockOp *LockOp) RewriteLockRowsExpressions(rewrite func(*plan.Expr) (*plan
 	targets := make([]lockTarget, len(lockOp.targets))
 	copy(targets, lockOp.targets)
 	for i := range targets {
+		if targets[i].lockRows == nil {
+			continue
+		}
 		expr, exprFolded, err := rewrite(targets[i].lockRows)
 		if err != nil {
 			return false, err

--- a/pkg/sql/compile/remote_expr.go
+++ b/pkg/sql/compile/remote_expr.go
@@ -1,0 +1,436 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compile
+
+import (
+	"reflect"
+
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/rule"
+	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+var (
+	planExprPtrType   = reflect.TypeOf((*plan.Expr)(nil))
+	operatorBaseType  = reflect.TypeOf(vm.OperatorBase{})
+	operatorBasePType = reflect.TypeOf((*vm.OperatorBase)(nil))
+)
+
+type argExpressionsGetter interface {
+	GetArgExpressions() []*plan.Expr
+}
+
+type argExpressionsRewriter interface {
+	RewriteArgExpressions(func(*plan.Expr) (*plan.Expr, bool, error)) (bool, error)
+}
+
+type lockRowsExpressionsGetter interface {
+	GetLockRowsExpressions() []*plan.Expr
+}
+
+type lockRowsExpressionsRewriter interface {
+	RewriteLockRowsExpressions(func(*plan.Expr) (*plan.Expr, bool, error)) (bool, error)
+}
+
+func scopeContainsVarExpr(s *Scope) bool {
+	if s == nil {
+		return false
+	}
+	if sourceContainsVarExpr(s.DataSource) {
+		return true
+	}
+
+	found := false
+	if s.RootOp != nil {
+		_ = vm.HandleAllOp(s.RootOp, func(_ vm.Operator, op vm.Operator) error {
+			if operatorContainsVarExpr(op) {
+				found = true
+			}
+			return nil
+		})
+		if found {
+			return true
+		}
+	}
+
+	for _, pre := range s.PreScopes {
+		if scopeContainsVarExpr(pre) {
+			return true
+		}
+	}
+	return false
+}
+
+func foldVarExprsInScope(s *Scope, proc *process.Process) (bool, error) {
+	if s == nil {
+		return false, nil
+	}
+
+	folded, err := foldVarExprsInValue(reflect.ValueOf(s.DataSource), nil, proc)
+	if err != nil {
+		return false, err
+	}
+
+	if s.RootOp != nil {
+		var opErr error
+		_ = vm.HandleAllOp(s.RootOp, func(_ vm.Operator, op vm.Operator) error {
+			var opFolded bool
+			opFolded, opErr = foldVarExprsInValue(reflect.ValueOf(op), nil, proc)
+			folded = folded || opFolded
+			return opErr
+		})
+		if opErr != nil {
+			return false, opErr
+		}
+	}
+
+	for _, pre := range s.PreScopes {
+		preFolded, err := foldVarExprsInScope(pre, proc)
+		if err != nil {
+			return false, err
+		}
+		folded = folded || preFolded
+	}
+	return folded, nil
+}
+
+func sourceContainsVarExpr(source *Source) bool {
+	if source == nil {
+		return false
+	}
+	return containsVarExpr(source.FilterExpr) ||
+		containsVarExprInValue(reflect.ValueOf(source.FilterList), nil) ||
+		containsVarExprInValue(reflect.ValueOf(source.BlockFilterList), nil) ||
+		containsVarExprInValue(reflect.ValueOf(source.RuntimeFilterSpecs), nil) ||
+		containsVarExprInValue(reflect.ValueOf(source.OrderBy), nil) ||
+		containsVarExprInValue(reflect.ValueOf(source.BlockOrderBy), nil)
+}
+
+func operatorContainsVarExpr(op vm.Operator) bool {
+	return containsVarExprInValue(reflect.ValueOf(op), nil)
+}
+
+func containsVarExpr(expr *plan.Expr) bool {
+	if expr == nil {
+		return false
+	}
+	if _, ok := expr.Expr.(*plan.Expr_V); ok {
+		return true
+	}
+	return containsVarExprInValue(reflect.ValueOf(expr.Expr), nil)
+}
+
+func containsVarExprInValue(v reflect.Value, seen map[uintptr]struct{}) bool {
+	if !v.IsValid() {
+		return false
+	}
+
+	if v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return false
+		}
+		return containsVarExprInValue(v.Elem(), seen)
+	}
+
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return false
+		}
+		if v.Type() == planExprPtrType {
+			return containsVarExpr(v.Interface().(*plan.Expr))
+		}
+		if containsVarExprInHiddenExpressions(v) {
+			return true
+		}
+		if seen == nil {
+			seen = make(map[uintptr]struct{})
+		}
+		ptr := v.Pointer()
+		if _, ok := seen[ptr]; ok {
+			return false
+		}
+		seen[ptr] = struct{}{}
+		return containsVarExprInValue(v.Elem(), seen)
+	}
+
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if containsVarExprInValue(v.Index(i), seen) {
+				return true
+			}
+		}
+	case reflect.Map:
+		iter := v.MapRange()
+		for iter.Next() {
+			if containsVarExprInValue(iter.Key(), seen) || containsVarExprInValue(iter.Value(), seen) {
+				return true
+			}
+		}
+	case reflect.Struct:
+		if v.Type() == operatorBaseType || v.Type() == operatorBasePType {
+			return false
+		}
+		if containsVarExprInHiddenExpressions(v) {
+			return true
+		}
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Type().Field(i)
+			if !field.IsExported() || field.Name == "OperatorBase" {
+				continue
+			}
+			if containsVarExprInValue(v.Field(i), seen) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func foldVarExprsInExpr(expr *plan.Expr, proc *process.Process) (*plan.Expr, bool, error) {
+	if expr == nil {
+		return nil, false, nil
+	}
+	if !containsVarExpr(expr) {
+		return expr, false, nil
+	}
+	expr = plan2.DeepCopyExpr(expr)
+	folded, err := foldVarExprsInExprInPlace(expr, proc)
+	return expr, folded, err
+}
+
+func foldVarExprsInExprInPlace(expr *plan.Expr, proc *process.Process) (bool, error) {
+	if expr == nil {
+		return false, nil
+	}
+	if _, ok := expr.Expr.(*plan.Expr_V); ok {
+		vec, free, err := colexec.GetReadonlyResultFromExpression(proc, expr, []*batch.Batch{batch.EmptyForConstFoldBatch})
+		if err != nil {
+			return false, err
+		}
+		defer free()
+
+		lit := rule.GetConstantValue(vec, false, 0)
+		if lit == nil {
+			return false, nil
+		}
+		expr.Expr = &plan.Expr_Lit{Lit: lit}
+		return true, nil
+	}
+	return foldVarExprsInValue(reflect.ValueOf(expr.Expr), nil, proc)
+}
+
+func foldVarExprInSettableValue(v reflect.Value, proc *process.Process) (bool, error) {
+	if !v.IsValid() || v.Type() != planExprPtrType {
+		return false, nil
+	}
+	expr, _ := v.Interface().(*plan.Expr)
+	foldedExpr, folded, err := foldVarExprsInExpr(expr, proc)
+	if err != nil || !folded {
+		return false, err
+	}
+	if !v.CanSet() {
+		return false, nil
+	}
+	v.Set(reflect.ValueOf(foldedExpr))
+	return true, nil
+}
+
+func foldVarExprsInValue(v reflect.Value, seen map[uintptr]struct{}, proc *process.Process) (bool, error) {
+	if !v.IsValid() {
+		return false, nil
+	}
+
+	if v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return false, nil
+		}
+		return foldVarExprsInValue(v.Elem(), seen, proc)
+	}
+
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return false, nil
+		}
+		if v.Type() == planExprPtrType {
+			return foldVarExprInSettableValue(v, proc)
+		}
+		hiddenFolded, err := foldVarExprsInHiddenExpressions(v, proc)
+		if err != nil {
+			return false, err
+		}
+		if seen == nil {
+			seen = make(map[uintptr]struct{})
+		}
+		ptr := v.Pointer()
+		if _, ok := seen[ptr]; ok {
+			return hiddenFolded, nil
+		}
+		seen[ptr] = struct{}{}
+		folded, err := foldVarExprsInValue(v.Elem(), seen, proc)
+		return hiddenFolded || folded, err
+	}
+
+	folded := false
+	switch v.Kind() {
+	case reflect.Slice:
+		if !containsVarExprInValue(v, nil) || !v.CanSet() {
+			return false, nil
+		}
+		copied := reflect.MakeSlice(v.Type(), v.Len(), v.Len())
+		reflect.Copy(copied, v)
+		for i := 0; i < copied.Len(); i++ {
+			itemFolded, err := foldVarExprsInValue(copied.Index(i), seen, proc)
+			if err != nil {
+				return false, err
+			}
+			folded = folded || itemFolded
+		}
+		if folded {
+			v.Set(copied)
+		}
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			itemFolded, err := foldVarExprsInValue(v.Index(i), seen, proc)
+			if err != nil {
+				return false, err
+			}
+			folded = folded || itemFolded
+		}
+	case reflect.Map:
+		if !containsVarExprInValue(v, nil) || !v.CanSet() {
+			return false, nil
+		}
+		copied := reflect.MakeMapWithSize(v.Type(), v.Len())
+		iter := v.MapRange()
+		for iter.Next() {
+			value := iter.Value()
+			newValue := value
+			valueFolded := false
+			if value.Type() == planExprPtrType {
+				expr, _ := value.Interface().(*plan.Expr)
+				foldedExpr, exprFolded, err := foldVarExprsInExpr(expr, proc)
+				if err != nil {
+					return false, err
+				}
+				if exprFolded {
+					newValue = reflect.ValueOf(foldedExpr)
+					valueFolded = true
+				}
+			}
+			copied.SetMapIndex(iter.Key(), newValue)
+			folded = folded || valueFolded
+		}
+		if folded {
+			v.Set(copied)
+		}
+	case reflect.Struct:
+		if v.Type() == operatorBaseType || v.Type() == operatorBasePType {
+			return false, nil
+		}
+		hiddenFolded, err := foldVarExprsInHiddenExpressions(v, proc)
+		if err != nil {
+			return false, err
+		}
+		folded = folded || hiddenFolded
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Type().Field(i)
+			if !field.IsExported() || field.Name == "OperatorBase" {
+				continue
+			}
+			fieldFolded, err := foldVarExprsInValue(v.Field(i), seen, proc)
+			if err != nil {
+				return false, err
+			}
+			folded = folded || fieldFolded
+		}
+	}
+	return folded, nil
+}
+
+func foldVarExprsInHiddenExpressions(v reflect.Value, proc *process.Process) (bool, error) {
+	if !v.IsValid() {
+		return false, nil
+	}
+	if v.CanInterface() {
+		folded, err := foldVarExprsInExpressionGetters(v.Interface(), proc)
+		if err != nil || folded {
+			return folded, err
+		}
+	}
+	if v.Kind() != reflect.Pointer && v.CanAddr() && v.Addr().CanInterface() {
+		return foldVarExprsInExpressionGetters(v.Addr().Interface(), proc)
+	}
+	return false, nil
+}
+
+func foldVarExprsInExpressionGetters(value any, proc *process.Process) (bool, error) {
+	folded := false
+	if rewriter, ok := value.(argExpressionsRewriter); ok {
+		rewritten, err := rewriter.RewriteArgExpressions(func(expr *plan.Expr) (*plan.Expr, bool, error) {
+			return foldVarExprsInExpr(expr, proc)
+		})
+		if err != nil {
+			return false, err
+		}
+		folded = folded || rewritten
+	}
+	if rewriter, ok := value.(lockRowsExpressionsRewriter); ok {
+		rewritten, err := rewriter.RewriteLockRowsExpressions(func(expr *plan.Expr) (*plan.Expr, bool, error) {
+			return foldVarExprsInExpr(expr, proc)
+		})
+		if err != nil {
+			return false, err
+		}
+		folded = folded || rewritten
+	}
+	return folded, nil
+}
+
+func containsVarExprInHiddenExpressions(v reflect.Value) bool {
+	if !v.IsValid() {
+		return false
+	}
+	if v.CanInterface() {
+		if containsVarExprInExpressionGetters(v.Interface()) {
+			return true
+		}
+	}
+	if v.Kind() != reflect.Pointer && v.CanAddr() && v.Addr().CanInterface() {
+		if containsVarExprInExpressionGetters(v.Addr().Interface()) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsVarExprInExpressionGetters(value any) bool {
+	if getter, ok := value.(argExpressionsGetter); ok {
+		if containsVarExprInValue(reflect.ValueOf(getter.GetArgExpressions()), nil) {
+			return true
+		}
+	}
+	if getter, ok := value.(lockRowsExpressionsGetter); ok {
+		if containsVarExprInValue(reflect.ValueOf(getter.GetLockRowsExpressions()), nil) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sql/compile/remote_expr.go
+++ b/pkg/sql/compile/remote_expr.go
@@ -110,6 +110,54 @@ func foldVarExprsInScope(s *Scope, proc *process.Process) (bool, error) {
 	return folded, nil
 }
 
+func foldVarExprsInRemoteRunScope(s *Scope, proc *process.Process) (*Scope, bool, error) {
+	if !scopeContainsVarExpr(s) {
+		return s, false, nil
+	}
+	copied := copyScopeForVarExprFold(s)
+	folded, err := foldVarExprsInScope(copied, proc)
+	return copied, folded, err
+}
+
+func copyScopeForVarExprFold(s *Scope) *Scope {
+	if s == nil {
+		return nil
+	}
+	copied := *s
+	if s.DataSource != nil {
+		dataSource := *s.DataSource
+		copied.DataSource = &dataSource
+	}
+	if s.RootOp != nil {
+		copied.RootOp = copyOperatorTreeForVarExprFold(s.RootOp)
+	}
+	if len(s.PreScopes) > 0 {
+		copied.PreScopes = make([]*Scope, len(s.PreScopes))
+		for i := range s.PreScopes {
+			copied.PreScopes[i] = copyScopeForVarExprFold(s.PreScopes[i])
+		}
+	}
+	return &copied
+}
+
+func copyOperatorTreeForVarExprFold(op vm.Operator) vm.Operator {
+	if op == nil {
+		return nil
+	}
+	value := reflect.ValueOf(op)
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return op
+	}
+	copiedValue := reflect.New(value.Elem().Type())
+	copiedValue.Elem().Set(value.Elem())
+	copied := copiedValue.Interface().(vm.Operator)
+	copied.GetOperatorBase().SetChildren(nil)
+	for i := 0; i < op.GetOperatorBase().NumChildren(); i++ {
+		copied.GetOperatorBase().AppendChild(copyOperatorTreeForVarExprFold(op.GetOperatorBase().GetChildren(i)))
+	}
+	return copied
+}
+
 func sourceContainsVarExpr(source *Source) bool {
 	if source == nil {
 		return false
@@ -271,6 +319,12 @@ func foldVarExprsInValue(v reflect.Value, seen map[uintptr]struct{}, proc *proce
 		}
 		if v.Type() == planExprPtrType {
 			return foldVarExprInSettableValue(v, proc)
+		}
+		if v.CanSet() && containsVarExprInValue(v, nil) {
+			copied := reflect.New(v.Type().Elem())
+			copied.Elem().Set(v.Elem())
+			v.Set(copied)
+			v = copied
 		}
 		hiddenFolded, err := foldVarExprsInHiddenExpressions(v, proc)
 		if err != nil {

--- a/pkg/sql/compile/remote_expr_test.go
+++ b/pkg/sql/compile/remote_expr_test.go
@@ -132,6 +132,39 @@ func TestFoldVarExprsInScopeUsesPrivateExprCopies(t *testing.T) {
 	require.Equal(t, "TRADITIONAL", proj2.ProjectList[0].GetLit().GetSval())
 }
 
+func TestFoldVarExprsInRemoteRunScopeDoesNotMutateReusableScope(t *testing.T) {
+	shared := makeTestVarExpr("sql_mode")
+	proc1 := newResolveVariableProcess(t, "ANSI")
+	proc2 := newResolveVariableProcess(t, "TRADITIONAL")
+
+	scope := newScope(Remote)
+	proj := projection.NewArgument()
+	proj.ProjectList = []*plan.Expr{shared}
+	scope.setRootOperator(proj)
+
+	remoteScope1, folded, err := foldVarExprsInRemoteRunScope(scope, proc1)
+	require.NoError(t, err)
+	require.True(t, folded)
+	remoteProj1 := remoteScope1.RootOp.(*projection.Projection)
+	require.Equal(t, "ANSI", remoteProj1.ProjectList[0].GetLit().GetSval())
+
+	require.True(t, scopeContainsVarExpr(scope))
+	require.IsType(t, &plan.Expr_V{}, shared.Expr)
+	require.Same(t, shared, proj.ProjectList[0])
+
+	remoteScope2, folded, err := foldVarExprsInRemoteRunScope(scope, proc2)
+	require.NoError(t, err)
+	require.True(t, folded)
+	remoteProj2 := remoteScope2.RootOp.(*projection.Projection)
+	require.Equal(t, "TRADITIONAL", remoteProj2.ProjectList[0].GetLit().GetSval())
+
+	require.NotSame(t, scope, remoteScope1)
+	require.NotSame(t, scope.RootOp, remoteScope1.RootOp)
+	require.NotSame(t, remoteScope1.RootOp, remoteScope2.RootOp)
+	require.NotSame(t, remoteProj1.ProjectList[0], remoteProj2.ProjectList[0])
+	require.True(t, scopeContainsVarExpr(scope))
+}
+
 func TestFoldVarExprsInHiddenExpressionsUsePrivateCopies(t *testing.T) {
 	proc := newResolveVariableProcess(t, "ANSI")
 	sharedAggExpr := makeTestVarExpr("sql_mode")
@@ -143,9 +176,20 @@ func TestFoldVarExprsInHiddenExpressionsUsePrivateCopies(t *testing.T) {
 		aggexec.MakeAggFunctionExpression(function.AggSumOverloadID, false, []*plan.Expr{sharedAggExpr}, nil),
 	}
 	lockOp := lockop.NewArgumentByEngine(nil)
+	lockOp.AddLockTarget(2, nil, 0, types.T_int64.ToType(), -1, -1, nil, false)
 	lockOp.AddLockTarget(1, nil, 0, types.T_int64.ToType(), -1, -1, sharedLockRows, false)
 	groupOp.AppendChild(lockOp)
 	scope.setRootOperator(groupOp)
+
+	rewriteCalls := 0
+	rewritten, err := lockOp.RewriteLockRowsExpressions(func(expr *plan.Expr) (*plan.Expr, bool, error) {
+		require.NotNil(t, expr)
+		rewriteCalls++
+		return expr, false, nil
+	})
+	require.NoError(t, err)
+	require.False(t, rewritten)
+	require.Equal(t, 1, rewriteCalls)
 
 	folded, err := foldVarExprsInScope(scope, proc)
 	require.NoError(t, err)

--- a/pkg/sql/compile/remote_expr_test.go
+++ b/pkg/sql/compile/remote_expr_test.go
@@ -1,0 +1,207 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compile
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/aggexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/filter"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/group"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/lockop"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/onduplicatekey"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/projection"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopeContainsVarExpr(t *testing.T) {
+	scope := newScope(Normal)
+	proj := projection.NewArgument()
+	proj.ProjectList = []*plan.Expr{makeTestVarExpr("sql_mode")}
+	f := filter.NewArgument()
+	f.FilterExprs = []*plan.Expr{makeTestConstBoolExpr(true)}
+	f.AppendChild(proj)
+	scope.setRootOperator(f)
+
+	require.True(t, scopeContainsVarExpr(scope))
+}
+
+func TestScopeContainsVarExprInSource(t *testing.T) {
+	scope := newScope(Normal)
+	scope.DataSource = &Source{
+		FilterList: []*plan.Expr{makeTestVarExpr("sql_mode")},
+	}
+
+	require.True(t, scopeContainsVarExpr(scope))
+}
+
+func TestScopeContainsVarExprInOperatorMap(t *testing.T) {
+	scope := newScope(Normal)
+	op := onduplicatekey.NewArgument()
+	op.OnDuplicateExpr = map[string]*plan.Expr{
+		"col": makeTestVarExpr("sql_mode"),
+	}
+	scope.setRootOperator(op)
+
+	require.True(t, scopeContainsVarExpr(scope))
+}
+
+func TestScopeContainsVarExprInAggArguments(t *testing.T) {
+	scope := newScope(Normal)
+	op := group.NewArgument()
+	op.Aggs = []aggexec.AggFuncExecExpression{
+		aggexec.MakeAggFunctionExpression(function.AggSumOverloadID, false, []*plan.Expr{makeTestVarExpr("sql_mode")}, nil),
+	}
+	scope.setRootOperator(op)
+
+	require.True(t, scopeContainsVarExpr(scope))
+}
+
+func TestScopeContainsVarExprInLockRows(t *testing.T) {
+	scope := newScope(Normal)
+	op := lockop.NewArgumentByEngine(nil)
+	op.AddLockTarget(1, nil, 0, types.T_int64.ToType(), -1, -1, makeTestVarExpr("sql_mode"), false)
+	scope.setRootOperator(op)
+
+	require.True(t, scopeContainsVarExpr(scope))
+}
+
+func TestFoldVarExprsInScope(t *testing.T) {
+	proc := newResolveVariableProcess(t, "STRICT_TRANS_TABLES")
+	scope := newScope(Normal)
+	scope.DataSource = &Source{
+		FilterList: []*plan.Expr{makeTestVarExpr("sql_mode")},
+	}
+
+	folded, err := foldVarExprsInScope(scope, proc)
+	require.NoError(t, err)
+	require.True(t, folded)
+	require.False(t, scopeContainsVarExpr(scope))
+
+	lit, ok := scope.DataSource.FilterList[0].Expr.(*plan.Expr_Lit)
+	require.True(t, ok)
+	require.Equal(t, "STRICT_TRANS_TABLES", lit.Lit.GetSval())
+}
+
+func TestFoldVarExprsInScopeUsesPrivateExprCopies(t *testing.T) {
+	shared := makeTestVarExpr("sql_mode")
+	proc1 := newResolveVariableProcess(t, "ANSI")
+	proc2 := newResolveVariableProcess(t, "TRADITIONAL")
+
+	scope1 := newScope(Normal)
+	proj1 := projection.NewArgument()
+	proj1.ProjectList = []*plan.Expr{shared}
+	scope1.setRootOperator(proj1)
+
+	scope2 := newScope(Normal)
+	proj2 := projection.NewArgument()
+	proj2.ProjectList = []*plan.Expr{shared}
+	scope2.setRootOperator(proj2)
+
+	folded, err := foldVarExprsInScope(scope1, proc1)
+	require.NoError(t, err)
+	require.True(t, folded)
+	folded, err = foldVarExprsInScope(scope2, proc2)
+	require.NoError(t, err)
+	require.True(t, folded)
+
+	require.IsType(t, &plan.Expr_V{}, shared.Expr)
+	require.NotSame(t, shared, proj1.ProjectList[0])
+	require.NotSame(t, shared, proj2.ProjectList[0])
+	require.NotSame(t, proj1.ProjectList[0], proj2.ProjectList[0])
+	require.Equal(t, "ANSI", proj1.ProjectList[0].GetLit().GetSval())
+	require.Equal(t, "TRADITIONAL", proj2.ProjectList[0].GetLit().GetSval())
+}
+
+func TestFoldVarExprsInHiddenExpressionsUsePrivateCopies(t *testing.T) {
+	proc := newResolveVariableProcess(t, "ANSI")
+	sharedAggExpr := makeTestVarExpr("sql_mode")
+	sharedLockRows := makeTestVarExpr("sql_mode")
+
+	scope := newScope(Normal)
+	groupOp := group.NewArgument()
+	groupOp.Aggs = []aggexec.AggFuncExecExpression{
+		aggexec.MakeAggFunctionExpression(function.AggSumOverloadID, false, []*plan.Expr{sharedAggExpr}, nil),
+	}
+	lockOp := lockop.NewArgumentByEngine(nil)
+	lockOp.AddLockTarget(1, nil, 0, types.T_int64.ToType(), -1, -1, sharedLockRows, false)
+	groupOp.AppendChild(lockOp)
+	scope.setRootOperator(groupOp)
+
+	folded, err := foldVarExprsInScope(scope, proc)
+	require.NoError(t, err)
+	require.True(t, folded)
+
+	aggArg := groupOp.Aggs[0].GetArgExpressions()[0]
+	lockRows := lockOp.GetLockRowsExpressions()[0]
+	require.IsType(t, &plan.Expr_V{}, sharedAggExpr.Expr)
+	require.IsType(t, &plan.Expr_V{}, sharedLockRows.Expr)
+	require.NotSame(t, sharedAggExpr, aggArg)
+	require.NotSame(t, sharedLockRows, lockRows)
+	require.Equal(t, "ANSI", aggArg.GetLit().GetSval())
+	require.Equal(t, "ANSI", lockRows.GetLit().GetSval())
+}
+
+func TestScopeContainsVarExprReturnsFalseWithoutVar(t *testing.T) {
+	scope := newScope(Normal)
+	f := filter.NewArgument()
+	f.FilterExprs = []*plan.Expr{makeTestConstBoolExpr(true)}
+	scope.setRootOperator(f)
+
+	require.False(t, scopeContainsVarExpr(scope))
+}
+
+func makeTestVarExpr(name string) *plan.Expr {
+	typ := types.T_text.ToType()
+	return &plan.Expr{
+		Typ: plan2.MakePlan2Type(&typ),
+		Expr: &plan.Expr_V{
+			V: &plan.VarRef{
+				Name:   name,
+				System: true,
+			},
+		},
+	}
+}
+
+func newResolveVariableProcess(t *testing.T, sqlMode string) *process.Process {
+	proc := testutil.NewProcess(t)
+	proc.SetResolveVariableFunc(func(name string, system, global bool) (interface{}, error) {
+		if name == "sql_mode" {
+			return sqlMode, nil
+		}
+		return nil, moerr.NewInternalErrorNoCtx("variable not found")
+	})
+	return proc
+}
+
+func makeTestConstBoolExpr(v bool) *plan.Expr {
+	typ := types.T_bool.ToType()
+	return &plan.Expr{
+		Typ: plan2.MakePlan2Type(&typ),
+		Expr: &plan.Expr_Lit{
+			Lit: &plan.Literal{
+				Value: &plan.Literal_Bval{Bval: v},
+			},
+		},
+	}
+}

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -63,10 +63,16 @@ func (s *Scope) remoteRun(c *Compile) (sender *messageSenderOnClient, err error)
 
 	// encode structures which need to send.
 	var scopeEncodeData, processEncodeData []byte
-	var withoutOutput bool
-	scopeEncodeData, withoutOutput, processEncodeData, err = prepareRemoteRunSendingData(c.sql, s)
+	var withoutOutput, folded bool
+	scopeEncodeData, withoutOutput, processEncodeData, folded, err = prepareRemoteRunSendingData(c.sql, s, c.proc)
 	if err != nil {
 		return nil, err
+	}
+	if folded {
+		getLogger(s.Proc.GetService()).
+			Debug("fold variable expressions before remote run",
+				zap.String("local-address", c.addr),
+				zap.String("remote-address", s.NodeInfo.Addr))
 	}
 
 	// generate a new sender to do send work.
@@ -171,41 +177,24 @@ func checkPipelineStandaloneExecutableAtRemote(s *Scope) bool {
 	return true
 }
 
-func prepareRemoteRunSendingData(sqlStr string, s *Scope) (scopeData []byte, withoutOutput bool, processData []byte, err error) {
-	// if simpleRun is true, it indicates that this pipeline will not produce any output.
-	withoutOutput = true
-
-	// if the last operator is a sender operator, we need to keep it in local for sending batch to its receivers correctly.
-	if lastOpType := s.RootOp.OpType(); lastOpType == vm.Connector || lastOpType == vm.Dispatch {
-		withoutOutput = false
-
-		originRoot := s.RootOp
-		if originRoot.GetOperatorBase().NumChildren() == 0 {
-			s.RootOp = nil
-		} else {
-			s.RootOp = originRoot.GetOperatorBase().GetChildren(0)
-		}
-
-		// todo: the following code to set children to nil must be a bug.
-		// 		but I kept it here because there will be an operator release twice bug once I remove this code.
-		//		I cannot find it why, maybe two scopes hold the same operator list pointer.
-		originRoot.GetOperatorBase().SetChildren(nil)
-		defer func() {
-			s.doSetRootOperator(originRoot)
-		}()
+func prepareRemoteRunSendingData(sqlStr string, s *Scope, proc *process.Process) (scopeData []byte, withoutOutput bool, processData []byte, folded bool, err error) {
+	encodedScope, withoutOutput := getScopeForRemoteRunEncoding(s)
+	encodedScope, folded, err = foldVarExprsInRemoteRunScope(encodedScope, proc)
+	if err != nil {
+		return nil, false, nil, false, err
 	}
 
 	// Encode the ScopeList which need to be sent.
-	if scopeData, err = encodeScope(s); err != nil {
-		return nil, false, nil, err
+	if scopeData, err = encodeScope(encodedScope); err != nil {
+		return nil, false, nil, false, err
 	}
 
 	// Encode the Process related information.
 	if processData, err = encodeProcessInfo(s.Proc, sqlStr); err != nil {
-		return nil, false, nil, err
+		return nil, false, nil, false, err
 	}
 
-	return scopeData, withoutOutput, processData, nil
+	return scopeData, withoutOutput, processData, folded, nil
 }
 
 func receiveMessageFromCnServer(s *Scope, withoutOutput bool, sender *messageSenderOnClient) error {
@@ -313,6 +302,25 @@ func receiveMessageFromCnServerIfDispatch(s *Scope, sender *messageSenderOnClien
 			return errCall
 		}
 	}
+}
+
+func getScopeForRemoteRunEncoding(s *Scope) (*Scope, bool) {
+	withoutOutput := true
+	if s.RootOp == nil {
+		return s, withoutOutput
+	}
+
+	if lastOpType := s.RootOp.OpType(); lastOpType == vm.Connector || lastOpType == vm.Dispatch {
+		withoutOutput = false
+		copied := *s
+		if s.RootOp.GetOperatorBase().NumChildren() == 0 {
+			copied.RootOp = nil
+		} else {
+			copied.RootOp = s.RootOp.GetOperatorBase().GetChildren(0)
+		}
+		return &copied, withoutOutput
+	}
+	return s, withoutOutput
 }
 
 // messageSenderOnClient support a series of methods

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -566,7 +566,7 @@ func Test_prepareRemoteRunSendingData(t *testing.T) {
 		Proc:   proc,
 		RootOp: connector.NewArgument(),
 	}
-	_, withoutOut, _, err := prepareRemoteRunSendingData("", s1)
+	_, withoutOut, _, _, err := prepareRemoteRunSendingData("", s1, proc)
 	require.NoError(t, err)
 	require.False(t, withoutOut)
 
@@ -577,9 +577,12 @@ func Test_prepareRemoteRunSendingData(t *testing.T) {
 		RootOp: dispatch.NewArgument(),
 	}
 	s2.RootOp.AppendChild(value_scan.NewArgument())
-	_, withoutOut, _, err = prepareRemoteRunSendingData("", s2)
+	originChild := s2.RootOp.GetOperatorBase().GetChildren(0)
+	_, withoutOut, _, _, err = prepareRemoteRunSendingData("", s2, proc)
 	require.NoError(t, err)
 	require.False(t, withoutOut)
+	require.Equal(t, 1, s2.RootOp.GetOperatorBase().NumChildren())
+	require.Same(t, originChild, s2.RootOp.GetOperatorBase().GetChildren(0))
 
 	// if this is a pipeline no need to sent back message, like "scan -> scan".
 	// this should return withoutOut == true.
@@ -588,7 +591,7 @@ func Test_prepareRemoteRunSendingData(t *testing.T) {
 		RootOp: value_scan.NewArgument(),
 	}
 	s3.RootOp.AppendChild(value_scan.NewArgument())
-	_, withoutOut, _, err = prepareRemoteRunSendingData("", s3)
+	_, withoutOut, _, _, err = prepareRemoteRunSendingData("", s3, proc)
 	require.NoError(t, err)
 	require.True(t, withoutOut)
 }

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -411,18 +411,6 @@ func (s *Scope) RemoteRun(c *Compile) error {
 	if !checkPipelineStandaloneExecutableAtRemote(s) {
 		return s.MergeRun(c)
 	}
-	if scopeContainsVarExpr(s) {
-		folded, err := foldVarExprsInScope(s, c.proc)
-		if err != nil {
-			return err
-		}
-		if folded {
-			runtime.ServiceRuntime(s.Proc.GetService()).Logger().
-				Debug("fold variable expressions before remote run",
-					zap.String("local-address", c.addr),
-					zap.String("remote-address", s.NodeInfo.Addr))
-		}
-	}
 	runtime.ServiceRuntime(s.Proc.GetService()).Logger().
 		Debug("remote run pipeline",
 			zap.String("local-address", c.addr),

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -411,7 +411,18 @@ func (s *Scope) RemoteRun(c *Compile) error {
 	if !checkPipelineStandaloneExecutableAtRemote(s) {
 		return s.MergeRun(c)
 	}
-
+	if scopeContainsVarExpr(s) {
+		folded, err := foldVarExprsInScope(s, c.proc)
+		if err != nil {
+			return err
+		}
+		if folded {
+			runtime.ServiceRuntime(s.Proc.GetService()).Logger().
+				Debug("fold variable expressions before remote run",
+					zap.String("local-address", c.addr),
+					zap.String("remote-address", s.NodeInfo.Addr))
+		}
+	}
 	runtime.ServiceRuntime(s.Proc.GetService()).Logger().
 		Debug("remote run pipeline",
 			zap.String("local-address", c.addr),

--- a/test/distributed/cases/system_variable/remote_var_expr.result
+++ b/test/distributed/cases/system_variable/remote_var_expr.result
@@ -1,0 +1,40 @@
+drop database if exists remote_var_expr_db;
+create database remote_var_expr_db;
+use remote_var_expr_db;
+create table t(a int primary key, b varchar(64));
+insert into t values (1, 'ONLY_FULL_GROUP_BY'), (2, 'STRICT_TRANS_TABLES'), (3, 'x');
+set @@sql_mode = 'ONLY_FULL_GROUP_BY';
+select @@sql_mode as mode;
+mode
+ONLY_FULL_GROUP_BY
+select count(*) as matched from t where b = @@sql_mode;
+matched
+1
+begin;
+select a, b from t where b = @@sql_mode for update;
+a    b
+1    ONLY_FULL_GROUP_BY
+commit;
+select sum(length(@@sql_mode)) as mode_len_sum from t;
+mode_len_sum
+54
+prepare stmt_remote_var from 'select count(*) as matched from t where b = @@sql_mode';
+execute stmt_remote_var;
+matched
+1
+set @@sql_mode = 'STRICT_TRANS_TABLES';
+select @@sql_mode as mode;
+mode
+STRICT_TRANS_TABLES
+select count(*) as matched from t where b = @@sql_mode;
+matched
+1
+select sum(length(@@sql_mode)) as mode_len_sum from t;
+mode_len_sum
+57
+execute stmt_remote_var;
+matched
+1
+deallocate prepare stmt_remote_var;
+set @@sql_mode = default;
+drop database remote_var_expr_db;

--- a/test/distributed/cases/system_variable/remote_var_expr.sql
+++ b/test/distributed/cases/system_variable/remote_var_expr.sql
@@ -1,0 +1,32 @@
+-- @suit
+
+-- @case
+-- @desc:test session variable expressions folded before remote run
+-- @label:bvt
+
+drop database if exists remote_var_expr_db;
+create database remote_var_expr_db;
+use remote_var_expr_db;
+
+create table t(a int primary key, b varchar(64));
+insert into t values (1, 'ONLY_FULL_GROUP_BY'), (2, 'STRICT_TRANS_TABLES'), (3, 'x');
+
+set @@sql_mode = 'ONLY_FULL_GROUP_BY';
+select @@sql_mode as mode;
+select count(*) as matched from t where b = @@sql_mode;
+begin;
+select a, b from t where b = @@sql_mode for update;
+commit;
+select sum(length(@@sql_mode)) as mode_len_sum from t;
+prepare stmt_remote_var from 'select count(*) as matched from t where b = @@sql_mode';
+execute stmt_remote_var;
+
+set @@sql_mode = 'STRICT_TRANS_TABLES';
+select @@sql_mode as mode;
+select count(*) as matched from t where b = @@sql_mode;
+select sum(length(@@sql_mode)) as mode_len_sum from t;
+execute stmt_remote_var;
+
+deallocate prepare stmt_remote_var;
+set @@sql_mode = default;
+drop database remote_var_expr_db;


### PR DESCRIPTION
Fixes #24799.

## Summary
- fold `@@` variable expressions on the source CN before a scope is shipped to a remote CN, preserving the remote execution path
- deep-copy expression containers before folding and write copied expressions back to the parent field/slice/map, avoiding shared-plan mutation, data races, and prepare-plan cache pollution
- cover exported expression fields, slices/maps, agg argument expressions, and lockRows hidden expressions
- keep the VarExpressionExecutor nil-resolver guard so any missed case returns a normal error instead of panicking

## Testing
- `GOCACHE=/private/tmp/mo-gocache-var-expr-30-copy GOFLAGS=-mod=mod go test ./pkg/sql/colexec ./pkg/sql/compile -run 'TestVarExpressionExecutorWithoutResolveVariableFunc|TestScopeContainsVarExpr|TestFoldVarExprs' -count=1`
