### PR TITLE
fix: align CDC pause visible state

### DIFF
--- a/pkg/cdc/sql_builder.go
+++ b/pkg/cdc/sql_builder.go
@@ -123,6 +123,12 @@ const (
 		"WHERE " +
 		"1=1 AND account_id = %d AND task_id = '%s'"
 
+	CDCUpdateTaskStateByTaskIdAndStateSqlTemplate = "UPDATE " +
+		"`mo_catalog`.`mo_cdc_task` " +
+		"SET state = '%s' " +
+		"WHERE " +
+		"1=1 AND account_id = %d AND task_id = '%s' AND state = '%s'"
+
 	CDCGetDataKeySqlTemplate = "SELECT " +
 		"encrypted_key " +
 		"FROM mo_catalog.mo_data_key " +
@@ -262,8 +268,9 @@ const (
 	CDCOnDuplicateUpdateWatermarkErrMsgTemplate_Idx = 19
 	CDCClearTaskTableErrorsSQL_Idx                  = 20
 	CDCUpdateTaskStateByTaskIdSQL_Idx               = 21
+	CDCUpdateTaskStateByTaskIdAndStateSQL_Idx       = 22
 
-	CDCSqlTemplateCount = 22
+	CDCSqlTemplateCount = 23
 )
 
 var CDCSQLTemplates = [CDCSqlTemplateCount]struct {
@@ -313,6 +320,9 @@ var CDCSQLTemplates = [CDCSqlTemplateCount]struct {
 	},
 	CDCUpdateTaskStateByTaskIdSQL_Idx: {
 		SQL: CDCUpdateTaskStateByTaskIdSqlTemplate,
+	},
+	CDCUpdateTaskStateByTaskIdAndStateSQL_Idx: {
+		SQL: CDCUpdateTaskStateByTaskIdAndStateSqlTemplate,
 	},
 	CDCInsertWatermarkSqlTemplate_Idx: {
 		SQL: CDCInsertWatermarkSqlTemplate,
@@ -530,6 +540,21 @@ func (b cdcSQLBuilder) UpdateTaskStateByTaskIdSQL(
 		state,
 		accountId,
 		taskId,
+	)
+}
+
+func (b cdcSQLBuilder) UpdateTaskStateByTaskIdAndStateSQL(
+	accountId uint64,
+	taskId string,
+	state string,
+	currentState string,
+) string {
+	return fmt.Sprintf(
+		CDCSQLTemplates[CDCUpdateTaskStateByTaskIdAndStateSQL_Idx].SQL,
+		state,
+		accountId,
+		taskId,
+		currentState,
 	)
 }
 

--- a/pkg/cdc/sql_builder.go
+++ b/pkg/cdc/sql_builder.go
@@ -25,6 +25,7 @@ const (
 	CDCWatermarkErrMsgMaxLen = 256
 
 	CDCState_Running = "running"
+	CDCState_Pausing = "pausing"
 	CDCState_Paused  = "paused"
 	CDCState_Failed  = "failed"
 )
@@ -113,6 +114,12 @@ const (
 	CDCUpdateTaskStateAndErrMsgSqlTemplate = "UPDATE " +
 		"`mo_catalog`.`mo_cdc_task` " +
 		"SET state = '%s', err_msg = '%s' " +
+		"WHERE " +
+		"1=1 AND account_id = %d AND task_id = '%s'"
+
+	CDCUpdateTaskStateByTaskIdSqlTemplate = "UPDATE " +
+		"`mo_catalog`.`mo_cdc_task` " +
+		"SET state = '%s' " +
 		"WHERE " +
 		"1=1 AND account_id = %d AND task_id = '%s'"
 
@@ -254,8 +261,9 @@ const (
 	CDCOnDuplicateUpdateWatermarkTemplate_Idx       = 18
 	CDCOnDuplicateUpdateWatermarkErrMsgTemplate_Idx = 19
 	CDCClearTaskTableErrorsSQL_Idx                  = 20
+	CDCUpdateTaskStateByTaskIdSQL_Idx               = 21
 
-	CDCSqlTemplateCount = 21
+	CDCSqlTemplateCount = 22
 )
 
 var CDCSQLTemplates = [CDCSqlTemplateCount]struct {
@@ -302,6 +310,9 @@ var CDCSQLTemplates = [CDCSqlTemplateCount]struct {
 	},
 	CDCUpdateTaskStateAndErrMsgSQL_Idx: {
 		SQL: CDCUpdateTaskStateAndErrMsgSqlTemplate,
+	},
+	CDCUpdateTaskStateByTaskIdSQL_Idx: {
+		SQL: CDCUpdateTaskStateByTaskIdSqlTemplate,
 	},
 	CDCInsertWatermarkSqlTemplate_Idx: {
 		SQL: CDCInsertWatermarkSqlTemplate,
@@ -504,6 +515,19 @@ func (b cdcSQLBuilder) UpdateTaskStateAndErrMsgSQL(
 		CDCSQLTemplates[CDCUpdateTaskStateAndErrMsgSQL_Idx].SQL,
 		state,
 		errMsg,
+		accountId,
+		taskId,
+	)
+}
+
+func (b cdcSQLBuilder) UpdateTaskStateByTaskIdSQL(
+	accountId uint64,
+	taskId string,
+	state string,
+) string {
+	return fmt.Sprintf(
+		CDCSQLTemplates[CDCUpdateTaskStateByTaskIdSQL_Idx].SQL,
+		state,
 		accountId,
 		taskId,
 	)

--- a/pkg/cnservice/server_task.go
+++ b/pkg/cnservice/server_task.go
@@ -203,6 +203,10 @@ func (s *service) startTaskRunner() {
 		return
 	}
 
+	ieFactory := func() ie.InternalExecutor {
+		return frontend.NewInternalExecutor(s.cfg.UUID)
+	}
+
 	s.task.runner = taskservice.NewTaskRunner(s.cfg.UUID,
 		ts,
 		s.canClaimDaemonTask,
@@ -223,6 +227,9 @@ func (s *service) startTaskRunner() {
 				return client
 			}),
 		taskservice.WithCnUUID(s.cfg.UUID),
+		taskservice.WithRunnerPauseTaskCompleted(
+			frontend.CDCPauseTaskCompleteHook(ieFactory),
+		),
 	)
 
 	s.registerExecutorsLocked()

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -578,6 +578,9 @@ func (exec *CDCTaskExecutor) Pause() error {
 			// Channel full or Start() already exited, ignore
 		}
 	}
+	if err := exec.updateTaskState(context.Background(), cdc.CDCState_Paused); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -813,6 +816,38 @@ func (exec *CDCTaskExecutor) updateErrMsg(ctx context.Context, errMsg string) (e
 		sql,
 		ie.SessionOverrideOptions{},
 	)
+}
+
+func (exec *CDCTaskExecutor) updateTaskState(ctx context.Context, state string) error {
+	if exec.ie == nil || exec.spec == nil || len(exec.spec.Accounts) == 0 {
+		logutil.Warn(
+			"cdc.frontend.task.update_state.skipped",
+			zap.String("state", state),
+		)
+		return nil
+	}
+	accountID := uint64(exec.spec.Accounts[0].GetId())
+	sql := cdc.CDCSQLBuilder.UpdateTaskStateByTaskIdSQL(
+		accountID,
+		exec.spec.TaskId,
+		state,
+	)
+	if err := exec.ie.Exec(
+		defines.AttachAccountId(ctx, catalog.System_Account),
+		sql,
+		ie.SessionOverrideOptions{},
+	); err != nil {
+		logutil.Error(
+			"cdc.frontend.task.update_state.failed",
+			zap.String("task-id", exec.spec.TaskId),
+			zap.String("task-name", exec.spec.TaskName),
+			zap.Uint64("account-id", accountID),
+			zap.String("state", state),
+			zap.Error(err),
+		)
+		return err
+	}
+	return nil
 }
 
 // clearAllTableErrors clears error messages for all tables in this task

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -860,10 +860,11 @@ func updateCDCTaskState(
 		return nil
 	}
 	accountID := uint64(spec.Accounts[0].GetId())
-	sql := cdc.CDCSQLBuilder.UpdateTaskStateByTaskIdSQL(
+	sql := cdc.CDCSQLBuilder.UpdateTaskStateByTaskIdAndStateSQL(
 		accountID,
 		spec.TaskId,
 		state,
+		cdc.CDCState_Pausing,
 	)
 	if err := sqlExecutor.Exec(
 		defines.AttachAccountId(ctx, catalog.System_Account),

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -472,7 +472,8 @@ func (exec *CDCTaskExecutor) Restart() error {
 
 // Pause cdc task
 func (exec *CDCTaskExecutor) Pause() error {
-	if exec.stateMachine.State() == StatePaused {
+	state := exec.stateMachine.State()
+	if state == StatePaused {
 		logutil.Info(
 			"cdc.frontend.task.pause_skip_already_paused",
 			zap.String("task-id", exec.spec.TaskId),
@@ -482,11 +483,13 @@ func (exec *CDCTaskExecutor) Pause() error {
 	}
 
 	// Check if running before state transition
-	wasRunning := exec.stateMachine.IsRunning()
+	wasRunning := state == StateRunning || state == StateStarting
 
 	// Transition to Pausing state
-	if err := exec.stateMachine.Transition(TransitionPause); err != nil {
-		return moerr.NewInternalErrorf(context.Background(), "cannot pause: %v", err)
+	if state != StatePausing {
+		if err := exec.stateMachine.Transition(TransitionPause); err != nil {
+			return moerr.NewInternalErrorf(context.Background(), "cannot pause: %v", err)
+		}
 	}
 
 	// FIX: Mark task as paused ASAP to maximize blocking window
@@ -509,31 +512,6 @@ func (exec *CDCTaskExecutor) Pause() error {
 		zap.String("state", exec.stateMachine.State().String()),
 		zap.Bool("was-running", wasRunning),
 	)
-	defer func() {
-		pauseDuration := time.Since(pauseStartTime)
-		// Transition to Paused state
-		if err := exec.stateMachine.Transition(TransitionPauseComplete); err != nil {
-			logutil.Warn(
-				"cdc.frontend.task.transition_paused_failed",
-				zap.Error(err),
-			)
-		}
-
-		// Metrics: task paused
-		if wasRunning {
-			v2.CdcTaskTotalGauge.WithLabelValues("running").Dec()
-			v2.CdcTaskTotalGauge.WithLabelValues("paused").Inc()
-			v2.CdcTaskStateChangeCounter.WithLabelValues("running", "paused").Inc()
-		}
-
-		logutil.Info(
-			"cdc.frontend.task.pause_success",
-			zap.String("task-id", exec.spec.TaskId),
-			zap.String("task-name", exec.spec.TaskName),
-			zap.String("state", exec.stateMachine.State().String()),
-			zap.Duration("pause-duration", pauseDuration),
-		)
-	}()
 
 	if wasRunning {
 		cdc.GetTableDetector(exec.cnUUID).UnRegister(exec.spec.TaskId)
@@ -546,47 +524,63 @@ func (exec *CDCTaskExecutor) Pause() error {
 		// Note: task was marked as paused earlier (before ClosePause) to maximize blocking window
 		// This may cause some watermark updates during stopAllReaders to be blocked,
 		// leading to minor data duplication on resume, but prevents data loss
-
-		// FIX: Force flush watermarks with timeout
-		// This ensures all legitimate watermarks (from commits completed before pause)
-		// are persisted to database before marking pause as complete
-		// Without this, watermarks in cacheUncommitted would be lost, causing data duplication on resume
-		if exec.watermarkUpdater != nil {
-			flushCtx, cancel := context.WithTimeout(
-				defines.AttachAccountId(context.Background(), uint32(exec.spec.Accounts[0].GetId())),
-				30*time.Second, // 30s timeout to prevent hanging
-			)
-			defer cancel()
-
-			if err := exec.watermarkUpdater.ForceFlush(flushCtx); err != nil {
-				logutil.Error(
-					"cdc.frontend.task.pause_force_flush_failed",
-					zap.String("task-id", exec.spec.TaskId),
-					zap.Error(err),
-				)
-				// Return error to ensure data consistency
-				// Pause failure is acceptable, data inconsistency is not
-				return moerr.NewInternalErrorf(context.Background(),
-					"pause failed: unable to flush watermarks: %v", err)
-			}
-
-			logutil.Info(
-				"cdc.frontend.task.pause_watermark_flushed",
-				zap.String("task-id", exec.spec.TaskId),
-			)
-		}
-
-		// Log watermark states after all readers stopped and watermarks flushed
-		exec.logCurrentWatermarks("after_pause")
-
-		// let Start() go
-		select {
-		case exec.holdCh <- 1:
-			// Signal sent successfully
-		default:
-			// Channel full or Start() already exited, ignore
-		}
 	}
+
+	// FIX: Force flush watermarks with timeout
+	// This ensures all legitimate watermarks (from commits completed before pause)
+	// are persisted to database before marking pause as complete
+	// Without this, watermarks in cacheUncommitted would be lost, causing data duplication on resume
+	if exec.watermarkUpdater != nil {
+		flushCtx, cancel := context.WithTimeout(
+			defines.AttachAccountId(context.Background(), uint32(exec.spec.Accounts[0].GetId())),
+			30*time.Second, // 30s timeout to prevent hanging
+		)
+		defer cancel()
+
+		if err := exec.watermarkUpdater.ForceFlush(flushCtx); err != nil {
+			logutil.Error(
+				"cdc.frontend.task.pause_force_flush_failed",
+				zap.String("task-id", exec.spec.TaskId),
+				zap.Error(err),
+			)
+			// Return error to ensure data consistency
+			// Pause failure is acceptable, data inconsistency is not
+			return moerr.NewInternalErrorf(context.Background(),
+				"pause failed: unable to flush watermarks: %v", err)
+		}
+
+		logutil.Info(
+			"cdc.frontend.task.pause_watermark_flushed",
+			zap.String("task-id", exec.spec.TaskId),
+		)
+	}
+
+	// Log watermark states after all readers stopped and watermarks flushed
+	exec.logCurrentWatermarks("after_pause")
+	// let Start() go after the critical pause work has completed successfully
+	select {
+	case exec.holdCh <- 1:
+		// Signal sent successfully
+	default:
+		// Channel full or Start() already exited, ignore
+	}
+	if err := exec.stateMachine.Transition(TransitionPauseComplete); err != nil {
+		return moerr.NewInternalErrorf(context.Background(), "cannot complete pause: %v", err)
+	}
+
+	if wasRunning {
+		v2.CdcTaskTotalGauge.WithLabelValues("running").Dec()
+		v2.CdcTaskTotalGauge.WithLabelValues("paused").Inc()
+		v2.CdcTaskStateChangeCounter.WithLabelValues("running", "paused").Inc()
+	}
+
+	logutil.Info(
+		"cdc.frontend.task.pause_success",
+		zap.String("task-id", exec.spec.TaskId),
+		zap.String("task-name", exec.spec.TaskName),
+		zap.String("state", exec.stateMachine.State().String()),
+		zap.Duration("pause-duration", time.Since(pauseStartTime)),
+	)
 	return nil
 }
 

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -819,7 +819,7 @@ func (exec *CDCTaskExecutor) updateErrMsg(ctx context.Context, errMsg string) (e
 }
 
 func CDCPauseTaskCompleteHook(sqlExecutorFactory func() ie.InternalExecutor) taskservice.PauseTaskCompletedHook {
-	return func(ctx context.Context, daemonTask task.DaemonTask) error {
+	return func(_ context.Context, daemonTask task.DaemonTask) error {
 		if daemonTask.Details == nil {
 			return nil
 		}

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -472,6 +472,15 @@ func (exec *CDCTaskExecutor) Restart() error {
 
 // Pause cdc task
 func (exec *CDCTaskExecutor) Pause() error {
+	if exec.stateMachine.State() == StatePaused {
+		logutil.Info(
+			"cdc.frontend.task.pause_skip_already_paused",
+			zap.String("task-id", exec.spec.TaskId),
+			zap.String("task-name", exec.spec.TaskName),
+		)
+		return nil
+	}
+
 	// Check if running before state transition
 	wasRunning := exec.stateMachine.IsRunning()
 

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -824,6 +824,8 @@ func CDCPauseTaskCompleteHook(sqlExecutorFactory func() ie.InternalExecutor) tas
 		if !ok || details.CreateCdc == nil {
 			return nil
 		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
 		return updateCDCTaskState(
 			ctx,
 			sqlExecutorFactory,

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -578,9 +578,6 @@ func (exec *CDCTaskExecutor) Pause() error {
 			// Channel full or Start() already exited, ignore
 		}
 	}
-	if err := exec.updateTaskState(context.Background(), cdc.CDCState_Paused); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -818,29 +815,60 @@ func (exec *CDCTaskExecutor) updateErrMsg(ctx context.Context, errMsg string) (e
 	)
 }
 
-func (exec *CDCTaskExecutor) updateTaskState(ctx context.Context, state string) error {
-	if exec.ie == nil || exec.spec == nil || len(exec.spec.Accounts) == 0 {
+func CDCPauseTaskCompleteHook(sqlExecutorFactory func() ie.InternalExecutor) taskservice.PauseTaskCompletedHook {
+	return func(ctx context.Context, daemonTask task.DaemonTask) error {
+		if daemonTask.Details == nil {
+			return nil
+		}
+		details, ok := daemonTask.Details.Details.(*task.Details_CreateCdc)
+		if !ok || details.CreateCdc == nil {
+			return nil
+		}
+		return updateCDCTaskState(
+			ctx,
+			sqlExecutorFactory,
+			details.CreateCdc,
+			cdc.CDCState_Paused,
+		)
+	}
+}
+
+func updateCDCTaskState(
+	ctx context.Context,
+	sqlExecutorFactory func() ie.InternalExecutor,
+	spec *task.CreateCdcDetails,
+	state string,
+) error {
+	if sqlExecutorFactory == nil || spec == nil || len(spec.Accounts) == 0 {
 		logutil.Warn(
 			"cdc.frontend.task.update_state.skipped",
 			zap.String("state", state),
 		)
 		return nil
 	}
-	accountID := uint64(exec.spec.Accounts[0].GetId())
+	sqlExecutor := sqlExecutorFactory()
+	if sqlExecutor == nil {
+		logutil.Warn(
+			"cdc.frontend.task.update_state.skipped",
+			zap.String("state", state),
+		)
+		return nil
+	}
+	accountID := uint64(spec.Accounts[0].GetId())
 	sql := cdc.CDCSQLBuilder.UpdateTaskStateByTaskIdSQL(
 		accountID,
-		exec.spec.TaskId,
+		spec.TaskId,
 		state,
 	)
-	if err := exec.ie.Exec(
+	if err := sqlExecutor.Exec(
 		defines.AttachAccountId(ctx, catalog.System_Account),
 		sql,
 		ie.SessionOverrideOptions{},
 	); err != nil {
 		logutil.Error(
 			"cdc.frontend.task.update_state.failed",
-			zap.String("task-id", exec.spec.TaskId),
-			zap.String("task-name", exec.spec.TaskName),
+			zap.String("task-id", spec.TaskId),
+			zap.String("task-name", spec.TaskName),
 			zap.Uint64("account-id", accountID),
 			zap.String("state", state),
 			zap.Error(err),

--- a/pkg/frontend/cdc_handle.go
+++ b/pkg/frontend/cdc_handle.go
@@ -374,7 +374,7 @@ func onPreUpdateCDCTasks(
 	//step2: update or cancel cdc task
 	var targetCDCStatus string
 	if targetTaskStatus == task.TaskStatus_PauseRequested {
-		targetCDCStatus = cdc.CDCState_Paused
+		targetCDCStatus = cdc.CDCState_Pausing
 	} else {
 		targetCDCStatus = cdc.CDCState_Running
 	}

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -2372,7 +2372,7 @@ func TestCDCPauseTaskCompleteHookUpdatesCatalogState(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	sql := "UPDATE `mo_catalog`.`mo_cdc_task` SET state = 'paused' WHERE 1=1 AND account_id = 1 AND task_id = 'task1'"
+	sql := "UPDATE `mo_catalog`.`mo_cdc_task` SET state = 'paused' WHERE 1=1 AND account_id = 1 AND task_id = 'task1' AND state = 'pausing'"
 	mock.ExpectExec(sql).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	hook := CDCPauseTaskCompleteHook(func() ie.InternalExecutor {
@@ -2424,6 +2424,7 @@ func TestCDCPauseTaskCompleteHookUsesFreshContext(t *testing.T) {
 	}))
 	require.NoError(t, capture.execCtxErr)
 	require.Contains(t, capture.execSQL, "state = 'paused'")
+	require.Contains(t, capture.execSQL, "AND state = 'pausing'")
 }
 
 func TestCdcTask_PauseWhileStarting(t *testing.T) {

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -1196,7 +1196,7 @@ func Test_updateCdcTask_pause(t *testing.T) {
 	mock.ExpectPrepare(sql11)
 
 	sql12 := "UPDATE `mo_catalog`.`mo_cdc_task` SET state = .* WHERE 1=1 AND account_id = 0 AND task_name = 'task1'"
-	mock.ExpectExec(sql12).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(sql12).WithArgs("pausing").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	sql13 := "DELETE FROM `mo_catalog`.`mo_cdc_task` WHERE 1=1 AND account_id = 0 AND task_name = 'task1'"
 	mock.ExpectExec(sql13).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -2328,6 +2328,41 @@ func TestCdcTask_Pause(t *testing.T) {
 	_ = executor.stateMachine.Transition(TransitionStartSuccess)
 	err := executor.Pause()
 	assert.NoErrorf(t, err, "Pause()")
+}
+
+func TestCdcTask_PauseUpdatesCatalogStateAfterPauseComplete(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	sql := "UPDATE `mo_catalog`.`mo_cdc_task` SET state = 'paused' WHERE 1=1 AND account_id = 1 AND task_id = 'task1'"
+	mock.ExpectExec(sql).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	executor := &CDCTaskExecutor{
+		activeRoutine: cdc.NewCdcActiveRoutine(),
+		ie: &testIE{
+			db: db,
+			genIdx: func(sql string) int {
+				return -1
+			},
+		},
+		cnUUID:         "test-cn",
+		runningReaders: &sync.Map{},
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task1",
+			TaskName: "task1",
+			Accounts: []*task.Account{
+				{Id: 1},
+			},
+		},
+		stateMachine: NewExecutorStateMachine(),
+		holdCh:       make(chan int, 1),
+	}
+	require.NoError(t, executor.stateMachine.Transition(TransitionStart))
+	require.NoError(t, executor.stateMachine.Transition(TransitionStartSuccess))
+
+	require.NoError(t, executor.Pause())
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestCdcTask_PauseWhileStarting(t *testing.T) {

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -845,6 +845,26 @@ func (tie *testIE) ApplySessionOverride(options ie.SessionOverrideOptions) {
 	panic("implement me")
 }
 
+var _ ie.InternalExecutor = new(captureExecContextIE)
+
+type captureExecContextIE struct {
+	execCtxErr error
+	execSQL    string
+}
+
+func (e *captureExecContextIE) Exec(ctx context.Context, sql string, options ie.SessionOverrideOptions) error {
+	e.execCtxErr = ctx.Err()
+	e.execSQL = sql
+	return nil
+}
+
+func (e *captureExecContextIE) Query(ctx context.Context, sql string, options ie.SessionOverrideOptions) ie.InternalExecResult {
+	panic("unexpected query")
+}
+
+func (e *captureExecContextIE) ApplySessionOverride(options ie.SessionOverrideOptions) {
+}
+
 const (
 	mSqlIdx1 int = iota
 	mSqlIdx2
@@ -2361,6 +2381,32 @@ func TestCDCPauseTaskCompleteHookUpdatesCatalogState(t *testing.T) {
 		},
 	}))
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCDCPauseTaskCompleteHookUsesFreshContext(t *testing.T) {
+	capture := &captureExecContextIE{}
+	hook := CDCPauseTaskCompleteHook(func() ie.InternalExecutor {
+		return capture
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, hook(ctx, task.DaemonTask{
+		Details: &task.Details{
+			Details: &task.Details_CreateCdc{
+				CreateCdc: &task.CreateCdcDetails{
+					TaskId:   "task1",
+					TaskName: "task1",
+					Accounts: []*task.Account{
+						{Id: 1},
+					},
+				},
+			},
+		},
+	}))
+	require.NoError(t, capture.execCtxErr)
+	require.Contains(t, capture.execSQL, "state = 'paused'")
 }
 
 func TestCdcTask_PauseWhileStarting(t *testing.T) {

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -2330,7 +2330,7 @@ func TestCdcTask_Pause(t *testing.T) {
 	assert.NoErrorf(t, err, "Pause()")
 }
 
-func TestCdcTask_PauseUpdatesCatalogStateAfterPauseComplete(t *testing.T) {
+func TestCDCPauseTaskCompleteHookUpdatesCatalogState(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer db.Close()
@@ -2338,30 +2338,28 @@ func TestCdcTask_PauseUpdatesCatalogStateAfterPauseComplete(t *testing.T) {
 	sql := "UPDATE `mo_catalog`.`mo_cdc_task` SET state = 'paused' WHERE 1=1 AND account_id = 1 AND task_id = 'task1'"
 	mock.ExpectExec(sql).WillReturnResult(sqlmock.NewResult(1, 1))
 
-	executor := &CDCTaskExecutor{
-		activeRoutine: cdc.NewCdcActiveRoutine(),
-		ie: &testIE{
+	hook := CDCPauseTaskCompleteHook(func() ie.InternalExecutor {
+		return &testIE{
 			db: db,
 			genIdx: func(sql string) int {
 				return -1
 			},
-		},
-		cnUUID:         "test-cn",
-		runningReaders: &sync.Map{},
-		spec: &task.CreateCdcDetails{
-			TaskId:   "task1",
-			TaskName: "task1",
-			Accounts: []*task.Account{
-				{Id: 1},
+		}
+	})
+
+	require.NoError(t, hook(context.Background(), task.DaemonTask{
+		Details: &task.Details{
+			Details: &task.Details_CreateCdc{
+				CreateCdc: &task.CreateCdcDetails{
+					TaskId:   "task1",
+					TaskName: "task1",
+					Accounts: []*task.Account{
+						{Id: 1},
+					},
+				},
 			},
 		},
-		stateMachine: NewExecutorStateMachine(),
-		holdCh:       make(chan int, 1),
-	}
-	require.NoError(t, executor.stateMachine.Transition(TransitionStart))
-	require.NoError(t, executor.stateMachine.Transition(TransitionStartSuccess))
-
-	require.NoError(t, executor.Pause())
+	}))
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -2350,6 +2350,23 @@ func TestCdcTask_Pause(t *testing.T) {
 	assert.NoErrorf(t, err, "Pause()")
 }
 
+func TestCdcTask_PauseAlreadyPausedIsIdempotent(t *testing.T) {
+	executor := &CDCTaskExecutor{
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task1",
+			TaskName: "task1",
+		},
+		stateMachine: NewExecutorStateMachine(),
+	}
+	require.NoError(t, executor.stateMachine.Transition(TransitionStart))
+	require.NoError(t, executor.stateMachine.Transition(TransitionStartSuccess))
+	require.NoError(t, executor.stateMachine.Transition(TransitionPause))
+	require.NoError(t, executor.stateMachine.Transition(TransitionPauseComplete))
+
+	require.NoError(t, executor.Pause())
+	require.Equal(t, StatePaused, executor.stateMachine.State())
+}
+
 func TestCDCPauseTaskCompleteHookUpdatesCatalogState(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -3824,6 +3824,61 @@ func TestCDCTaskExecutor_Pause_WithWatermarkFlushSuccess(t *testing.T) {
 	assert.Equal(t, StatePaused, executor.stateMachine.State())
 }
 
+func TestCDCTaskExecutor_Pause_RetriesForceFlushBeforePaused(t *testing.T) {
+	holdCh := make(chan int, 1)
+	flushCalls := 0
+	u := cdc.NewCDCWatermarkUpdater(
+		t.Name(),
+		&mockLogWatermarksIe{hasError: false, rowCount: 1},
+		cdc.WithCustomizedScheduleJob(func(job *cdc.UpdaterJob) error {
+			flushCalls++
+			if flushCalls == 1 {
+				return moerr.NewInternalErrorNoCtx("force flush failed")
+			}
+			job.DoneWithResult(nil)
+			return nil
+		}),
+	)
+
+	executor := &CDCTaskExecutor{
+		activeRoutine:    cdc.NewCdcActiveRoutine(),
+		watermarkUpdater: u,
+		cnUUID:           "test-cn",
+		runningReaders:   &sync.Map{},
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task1",
+			TaskName: "task1",
+			Accounts: []*task.Account{
+				{Id: 100},
+			},
+		},
+		stateMachine: NewExecutorStateMachine(),
+		holdCh:       holdCh,
+		ie:           &mockLogWatermarksIe{hasError: false, rowCount: 1},
+	}
+	require.NoError(t, executor.stateMachine.Transition(TransitionStart))
+	require.NoError(t, executor.stateMachine.Transition(TransitionStartSuccess))
+
+	err := executor.Pause()
+	require.ErrorContains(t, err, "force flush failed")
+	require.Equal(t, StatePausing, executor.stateMachine.State())
+	require.Equal(t, 1, flushCalls)
+	select {
+	case <-holdCh:
+		t.Fatal("pause should not release Start before ForceFlush succeeds")
+	default:
+	}
+
+	require.NoError(t, executor.Pause())
+	require.Equal(t, StatePaused, executor.stateMachine.State())
+	require.Equal(t, 2, flushCalls)
+	select {
+	case <-holdCh:
+	default:
+		t.Fatal("pause should release Start after ForceFlush succeeds")
+	}
+}
+
 // Mock IE for logCurrentWatermarks tests
 type mockLogWatermarksIe struct {
 	hasError       bool

--- a/pkg/taskservice/daemon_task.go
+++ b/pkg/taskservice/daemon_task.go
@@ -336,7 +336,7 @@ func (t *pauseTask) Handle(ctx context.Context) error {
 			t.runner.logger.Debug("cdc.task.pause.skip.already-paused",
 				zap.Uint64("task-id", tk.ID),
 				zap.String("task-name", taskNameFromDetails(tk)))
-			return nil
+			return t.runner.pauseTaskCompleted(ctx, tk)
 		}
 		t.runner.logger.Warn("cdc.task.pause.skip.invalid-status",
 			zap.Uint64("task-id", tk.ID),
@@ -360,12 +360,29 @@ func (t *pauseTask) Handle(ctx context.Context) error {
 			return err
 		}
 	}
+	if err := t.runner.pauseTaskCompleted(ctx, tk); err != nil {
+		return err
+	}
 	t.runner.logger.Info("cdc.task.pause.finish",
 		zap.Uint64("task-id", tk.ID),
 		zap.String("task-name", taskNameFromDetails(tk)),
 		zap.String("new-status", tk.TaskStatus.String()),
 		zap.Duration("elapsed", time.Since(start)),
 	)
+	return nil
+}
+
+func (r *taskRunner) pauseTaskCompleted(ctx context.Context, tk task.DaemonTask) error {
+	if r.options.pauseTaskCompleted == nil {
+		return nil
+	}
+	if err := r.options.pauseTaskCompleted(ctx, tk); err != nil {
+		r.logger.Error("cdc.task.pause.complete-hook.failed",
+			zap.Uint64("task-id", tk.ID),
+			zap.String("task-name", taskNameFromDetails(tk)),
+			zap.Error(err))
+		return err
+	}
 	return nil
 }
 

--- a/pkg/taskservice/daemon_task.go
+++ b/pkg/taskservice/daemon_task.go
@@ -344,12 +344,6 @@ func (t *pauseTask) Handle(ctx context.Context) error {
 			zap.String("current-status", tk.TaskStatus.String()))
 		return nil
 	}
-	tk.TaskStatus = task.TaskStatus_Paused
-	_, err = t.runner.service.UpdateDaemonTask(ctx, []task.DaemonTask{tk})
-	if err != nil {
-		return moerr.AttachCause(ctx, err)
-	}
-
 	if t.runner.exists(tk.ID) {
 		ar := t.task.activeRoutine.Load()
 		if ar == nil || *ar == nil {
@@ -360,6 +354,15 @@ func (t *pauseTask) Handle(ctx context.Context) error {
 			return err
 		}
 	}
+
+	tk.TaskStatus = task.TaskStatus_Paused
+	updateCtx, updateCancel := context.WithTimeoutCause(context.Background(), time.Second*5, moerr.CausePauseTaskHandle)
+	defer updateCancel()
+	_, err = t.runner.service.UpdateDaemonTask(updateCtx, []task.DaemonTask{tk})
+	if err != nil {
+		return moerr.AttachCause(updateCtx, err)
+	}
+
 	if err := t.runner.pauseTaskCompleted(ctx, tk); err != nil {
 		return err
 	}
@@ -732,7 +735,22 @@ func (r *taskRunner) pauseTasks(ctx context.Context) []task.DaemonTask {
 		WithTaskStatusCond(task.TaskStatus_PauseRequested),
 		WithLastHeartbeat(LE, time.Now().UnixNano()-r.options.heartbeatTimeout.Nanoseconds()),
 	)
-	tasks := r.mergeTasks(localPause, laggedPause)
+	// A CDC pause completion hook may fail after the daemon task has already been
+	// persisted as Paused. Keep polling Paused CDC tasks so the hook has a retry path.
+	var localPausedFinalize, laggedPausedFinalize []task.DaemonTask
+	if r.options.pauseTaskCompleted != nil {
+		localPausedFinalize = r.queryDaemonTasks(ctx,
+			WithTaskStatusCond(task.TaskStatus_Paused),
+			WithTaskRunnerCond(EQ, r.runnerID),
+			WithTaskExecutorCond(EQ, task.TaskCode_InitCdc),
+		)
+		laggedPausedFinalize = r.queryDaemonTasks(ctx,
+			WithTaskStatusCond(task.TaskStatus_Paused),
+			WithLastHeartbeat(LE, time.Now().UnixNano()-r.options.heartbeatTimeout.Nanoseconds()),
+			WithTaskExecutorCond(EQ, task.TaskCode_InitCdc),
+		)
+	}
+	tasks := r.mergeTasks(localPause, laggedPause, localPausedFinalize, laggedPausedFinalize)
 	if len(tasks) > 0 {
 		for _, t := range tasks {
 			r.logger.Info("cdc.task.pause.enqueue",
@@ -746,6 +764,8 @@ func (r *taskRunner) pauseTasks(ctx context.Context) []task.DaemonTask {
 		r.logger.Debug("cdc.task.pause.enqueue.none",
 			zap.Int("local-candidates", len(localPause)),
 			zap.Int("lagged-candidates", len(laggedPause)),
+			zap.Int("local-paused-finalize-candidates", len(localPausedFinalize)),
+			zap.Int("lagged-paused-finalize-candidates", len(laggedPausedFinalize)),
 		)
 	}
 	return tasks

--- a/pkg/taskservice/daemon_task.go
+++ b/pkg/taskservice/daemon_task.go
@@ -333,6 +333,12 @@ func (t *pauseTask) Handle(ctx context.Context) error {
 	// Pause must be idempotent; repeated pause requests should not call activeRoutine.Pause again.
 	if tk.TaskStatus != task.TaskStatus_PauseRequested {
 		if tk.TaskStatus == task.TaskStatus_Paused {
+			if t.runner.isPauseTaskCompleted(tk.ID) {
+				t.runner.logger.Debug("cdc.task.pause.skip.completed",
+					zap.Uint64("task-id", tk.ID),
+					zap.String("task-name", taskNameFromDetails(tk)))
+				return nil
+			}
 			t.runner.logger.Debug("cdc.task.pause.skip.already-paused",
 				zap.Uint64("task-id", tk.ID),
 				zap.String("task-name", taskNameFromDetails(tk)))
@@ -344,6 +350,7 @@ func (t *pauseTask) Handle(ctx context.Context) error {
 			zap.String("current-status", tk.TaskStatus.String()))
 		return nil
 	}
+	t.runner.clearPauseTaskCompleted(tk.ID)
 	if t.runner.exists(tk.ID) {
 		ar := t.task.activeRoutine.Load()
 		if ar == nil || *ar == nil {
@@ -386,7 +393,45 @@ func (r *taskRunner) pauseTaskCompleted(ctx context.Context, tk task.DaemonTask)
 			zap.Error(err))
 		return err
 	}
+	r.markPauseTaskCompleted(tk.ID)
 	return nil
+}
+
+func (r *taskRunner) markPauseTaskCompleted(id uint64) {
+	r.pauseCompletedTasks.Lock()
+	defer r.pauseCompletedTasks.Unlock()
+	r.pauseCompletedTasks.m[id] = struct{}{}
+}
+
+func (r *taskRunner) clearPauseTaskCompleted(id uint64) {
+	r.pauseCompletedTasks.Lock()
+	defer r.pauseCompletedTasks.Unlock()
+	delete(r.pauseCompletedTasks.m, id)
+}
+
+func (r *taskRunner) isPauseTaskCompleted(id uint64) bool {
+	r.pauseCompletedTasks.Lock()
+	defer r.pauseCompletedTasks.Unlock()
+	_, ok := r.pauseCompletedTasks.m[id]
+	return ok
+}
+
+func (r *taskRunner) filterUncompletedPauseTasks(tasks []task.DaemonTask) []task.DaemonTask {
+	if len(tasks) == 0 {
+		return tasks
+	}
+	r.pauseCompletedTasks.Lock()
+	defer r.pauseCompletedTasks.Unlock()
+
+	n := 0
+	for _, tk := range tasks {
+		if _, ok := r.pauseCompletedTasks.m[tk.ID]; ok {
+			continue
+		}
+		tasks[n] = tk
+		n++
+	}
+	return tasks[:n]
 }
 
 type cancelTask struct {
@@ -744,11 +789,13 @@ func (r *taskRunner) pauseTasks(ctx context.Context) []task.DaemonTask {
 			WithTaskRunnerCond(EQ, r.runnerID),
 			WithTaskExecutorCond(EQ, task.TaskCode_InitCdc),
 		)
+		localPausedFinalize = r.filterUncompletedPauseTasks(localPausedFinalize)
 		laggedPausedFinalize = r.queryDaemonTasks(ctx,
 			WithTaskStatusCond(task.TaskStatus_Paused),
 			WithLastHeartbeat(LE, time.Now().UnixNano()-r.options.heartbeatTimeout.Nanoseconds()),
 			WithTaskExecutorCond(EQ, task.TaskCode_InitCdc),
 		)
+		laggedPausedFinalize = r.filterUncompletedPauseTasks(laggedPausedFinalize)
 	}
 	tasks := r.mergeTasks(localPause, laggedPause, localPausedFinalize, laggedPausedFinalize)
 	if len(tasks) > 0 {

--- a/pkg/taskservice/daemon_task.go
+++ b/pkg/taskservice/daemon_task.go
@@ -101,17 +101,18 @@ func newResumeTask(r *taskRunner, t *daemonTask) *resumeTask {
 }
 
 func (t *resumeTask) Handle(ctx context.Context) error {
-	ctx, cancel := context.WithTimeoutCause(ctx, time.Second*5, moerr.CauseResumeTaskHandle)
+	handleCtx, cancel := context.WithTimeoutCause(ctx, time.Second*5, moerr.CauseResumeTaskHandle)
 	defer cancel()
-	tasks, err := t.runner.service.QueryDaemonTask(ctx, WithTaskIDCond(EQ, t.task.task.ID))
+	tasks, err := t.runner.service.QueryDaemonTask(handleCtx, WithTaskIDCond(EQ, t.task.task.ID))
 	if err != nil {
-		return moerr.AttachCause(ctx, err)
+		return moerr.AttachCause(handleCtx, err)
 	}
 	if len(tasks) != 1 {
-		return moerr.NewInternalErrorf(ctx, "count of tasks is wrong %d", len(tasks))
+		return moerr.NewInternalErrorf(handleCtx, "count of tasks is wrong %d", len(tasks))
 	}
 
 	tk := tasks[0]
+	t.runner.clearPauseTaskCompleted(tk.ID)
 	start := time.Now()
 	t.runner.logger.Info("cdc.task.resume.start",
 		zap.Uint64("task-id", tk.ID),
@@ -122,7 +123,7 @@ func (t *resumeTask) Handle(ctx context.Context) error {
 	)
 	// We cannot resume a task which is not on local runner.
 	if !strings.EqualFold(tk.TaskRunner, t.runner.runnerID) {
-		return moerr.NewInternalErrorf(ctx, "the task is not on local runner, prev runner %s, "+
+		return moerr.NewInternalErrorf(handleCtx, "the task is not on local runner, prev runner %s, "+
 			"local runner %s", tk.TaskRunner, t.runner.runnerID)
 	}
 	// Skip duplicate or stale control requests to keep resume idempotent.
@@ -144,9 +145,9 @@ func (t *resumeTask) Handle(ctx context.Context) error {
 	nowTime := time.Now()
 	tk.LastRun = nowTime
 	tk.LastHeartbeat = nowTime
-	_, err = t.runner.service.UpdateDaemonTask(ctx, []task.DaemonTask{tk})
+	_, err = t.runner.service.UpdateDaemonTask(handleCtx, []task.DaemonTask{tk})
 	if err != nil {
-		return moerr.AttachCause(ctx, err)
+		return moerr.AttachCause(handleCtx, err)
 	}
 	t.runner.logger.Info("cdc.task.resume.finish",
 		zap.Uint64("task-id", tk.ID),
@@ -158,7 +159,7 @@ func (t *resumeTask) Handle(ctx context.Context) error {
 
 	ar := t.task.activeRoutine.Load()
 	if ar == nil || *ar == nil {
-		return moerr.NewInternalErrorf(ctx, "cannot handle resume operation, "+
+		return moerr.NewInternalErrorf(handleCtx, "cannot handle resume operation, "+
 			"active routine not set for task %d", t.task.task.ID)
 	}
 	return (*ar).Resume()
@@ -177,25 +178,26 @@ func newRestartTask(r *taskRunner, t *daemonTask) *restartTask {
 }
 
 func (t *restartTask) Handle(ctx context.Context) error {
-	ctx, cancel := context.WithTimeoutCause(ctx, time.Second*5, moerr.CauseRestartTaskHandle)
+	handleCtx, cancel := context.WithTimeoutCause(ctx, time.Second*5, moerr.CauseRestartTaskHandle)
 	defer cancel()
-	tasks, err := t.runner.service.QueryDaemonTask(ctx, WithTaskIDCond(EQ, t.task.task.ID))
+	tasks, err := t.runner.service.QueryDaemonTask(handleCtx, WithTaskIDCond(EQ, t.task.task.ID))
 	if err != nil {
 		t.runner.logger.Error("cdc.task.restart.query_failed",
 			zap.Uint64("task-id", t.task.task.ID),
 			zap.Error(err),
 		)
-		return moerr.AttachCause(ctx, err)
+		return moerr.AttachCause(handleCtx, err)
 	}
 	if len(tasks) != 1 {
 		t.runner.logger.Error("cdc.task.restart.query_wrong_count",
 			zap.Uint64("task-id", t.task.task.ID),
 			zap.Int("task-count", len(tasks)),
 		)
-		return moerr.NewInternalErrorf(ctx, "count of tasks is wrong %d", len(tasks))
+		return moerr.NewInternalErrorf(handleCtx, "count of tasks is wrong %d", len(tasks))
 	}
 
 	tk := tasks[0]
+	t.runner.clearPauseTaskCompleted(tk.ID)
 	start := time.Now()
 	t.runner.logger.Info("cdc.task.restart.start",
 		zap.Uint64("task-id", tk.ID),
@@ -228,7 +230,7 @@ func (t *restartTask) Handle(ctx context.Context) error {
 			zap.String("task-runner", tk.TaskRunner),
 			zap.String("local-runner", t.runner.runnerID),
 		)
-		return moerr.NewInternalErrorf(ctx, "the task is not on local runner, prev runner %s, "+
+		return moerr.NewInternalErrorf(handleCtx, "the task is not on local runner, prev runner %s, "+
 			"local runner %s", tk.TaskRunner, t.runner.runnerID)
 	}
 
@@ -246,13 +248,13 @@ func (t *restartTask) Handle(ctx context.Context) error {
 	nowTime := time.Now()
 	tk.LastRun = nowTime
 	tk.LastHeartbeat = nowTime
-	_, err = t.runner.service.UpdateDaemonTask(ctx, []task.DaemonTask{tk})
+	_, err = t.runner.service.UpdateDaemonTask(handleCtx, []task.DaemonTask{tk})
 	if err != nil {
 		t.runner.logger.Error("cdc.task.restart.update_status_failed",
 			zap.Uint64("task-id", tk.ID),
 			zap.Error(err),
 		)
-		return moerr.AttachCause(ctx, err)
+		return moerr.AttachCause(handleCtx, err)
 	}
 
 	t.runner.logger.Info("cdc.task.restart.status_updated",
@@ -268,7 +270,7 @@ func (t *restartTask) Handle(ctx context.Context) error {
 			zap.Uint64("task-id", tk.ID),
 			zap.String("task-name", taskNameFromDetails(tk)),
 		)
-		return moerr.NewInternalErrorf(ctx, "cannot handle restart operation, "+
+		return moerr.NewInternalErrorf(handleCtx, "cannot handle restart operation, "+
 			"active routine not set for task %d", t.task.task.ID)
 	}
 
@@ -311,15 +313,15 @@ func newPauseTask(r *taskRunner, t *daemonTask) *pauseTask {
 }
 
 func (t *pauseTask) Handle(ctx context.Context) error {
-	ctx, cancel := context.WithTimeoutCause(ctx, time.Second*5, moerr.CausePauseTaskHandle)
+	handleCtx, cancel := context.WithTimeoutCause(ctx, time.Second*5, moerr.CausePauseTaskHandle)
 	defer cancel()
 	start := time.Now()
-	tasks, err := t.runner.service.QueryDaemonTask(ctx, WithTaskIDCond(EQ, t.task.task.ID))
+	tasks, err := t.runner.service.QueryDaemonTask(handleCtx, WithTaskIDCond(EQ, t.task.task.ID))
 	if err != nil {
-		return moerr.AttachCause(ctx, err)
+		return moerr.AttachCause(handleCtx, err)
 	}
 	if len(tasks) != 1 {
-		return moerr.NewInternalErrorf(ctx, "count of tasks is wrong %d", len(tasks))
+		return moerr.NewInternalErrorf(handleCtx, "count of tasks is wrong %d", len(tasks))
 	}
 
 	tk := tasks[0]
@@ -354,7 +356,7 @@ func (t *pauseTask) Handle(ctx context.Context) error {
 	if t.runner.exists(tk.ID) {
 		ar := t.task.activeRoutine.Load()
 		if ar == nil || *ar == nil {
-			return moerr.NewInternalErrorf(ctx, "cannot handle pause operation, "+
+			return moerr.NewInternalErrorf(handleCtx, "cannot handle pause operation, "+
 				"active routine not set for task %d", t.task.task.ID)
 		}
 		if err := (*ar).Pause(); err != nil {
@@ -447,17 +449,18 @@ func newCancelTask(r *taskRunner, t *daemonTask) *cancelTask {
 }
 
 func (t *cancelTask) Handle(ctx context.Context) error {
-	ctx, cancel := context.WithTimeoutCause(ctx, time.Second*5, moerr.CauseCancelTaskHandle)
+	handleCtx, cancel := context.WithTimeoutCause(ctx, time.Second*5, moerr.CauseCancelTaskHandle)
 	defer cancel()
-	tasks, err := t.runner.service.QueryDaemonTask(ctx, WithTaskIDCond(EQ, t.task.task.ID))
+	tasks, err := t.runner.service.QueryDaemonTask(handleCtx, WithTaskIDCond(EQ, t.task.task.ID))
 	if err != nil {
-		return moerr.AttachCause(ctx, err)
+		return moerr.AttachCause(handleCtx, err)
 	}
 	if len(tasks) != 1 {
-		return moerr.NewInternalErrorf(ctx, "count of tasks is wrong %d", len(tasks))
+		return moerr.NewInternalErrorf(handleCtx, "count of tasks is wrong %d", len(tasks))
 	}
 
 	tk := tasks[0]
+	t.runner.clearPauseTaskCompleted(tk.ID)
 	// Cancel should only be executed from CancelRequested.
 	if tk.TaskStatus != task.TaskStatus_CancelRequested {
 		if tk.TaskStatus == task.TaskStatus_Canceled {
@@ -474,14 +477,14 @@ func (t *cancelTask) Handle(ctx context.Context) error {
 	}
 	tk.TaskStatus = task.TaskStatus_Canceled
 	tk.EndAt = time.Now()
-	_, err = t.runner.service.UpdateDaemonTask(ctx, []task.DaemonTask{tk})
+	_, err = t.runner.service.UpdateDaemonTask(handleCtx, []task.DaemonTask{tk})
 	if err != nil {
-		return moerr.AttachCause(ctx, err)
+		return moerr.AttachCause(handleCtx, err)
 	}
 	if t.runner.exists(tk.ID) {
 		ar := t.task.activeRoutine.Load()
 		if ar == nil || *ar == nil {
-			return moerr.NewInternalErrorf(ctx, "cannot handle cancel operation, "+
+			return moerr.NewInternalErrorf(handleCtx, "cannot handle cancel operation, "+
 				"active routine not set for task %d", t.task.task.ID)
 		}
 		return (*ar).Cancel()
@@ -633,11 +636,11 @@ func (r *taskRunner) dispatchTaskHandle(ctx context.Context) {
 }
 
 func (r *taskRunner) queryDaemonTasks(ctx context.Context, c ...Condition) []task.DaemonTask {
-	ctx, cancel := context.WithTimeoutCause(ctx, r.options.fetchTimeout, moerr.CauseQueryDaemonTasks)
+	queryCtx, cancel := context.WithTimeoutCause(ctx, r.options.fetchTimeout, moerr.CauseQueryDaemonTasks)
 	defer cancel()
-	t, err := r.service.QueryDaemonTask(ctx, c...)
+	t, err := r.service.QueryDaemonTask(queryCtx, c...)
 	if err != nil {
-		err = moerr.AttachCause(ctx, err)
+		err = moerr.AttachCause(queryCtx, err)
 		r.logger.Error("failed to get tasks", zap.Error(err))
 		return nil
 	}
@@ -954,6 +957,7 @@ func (r *taskRunner) getDaemonTask(id uint64) (*daemonTask, bool) {
 }
 
 func (r *taskRunner) removeDaemonTask(id uint64) {
+	r.clearPauseTaskCompleted(id)
 	r.daemonTasks.Lock()
 	defer r.daemonTasks.Unlock()
 	delete(r.daemonTasks.m, id)

--- a/pkg/taskservice/daemon_task_test.go
+++ b/pkg/taskservice/daemon_task_test.go
@@ -387,6 +387,35 @@ func TestPauseAndCancelTaskHandleBranchesDirect(t *testing.T) {
 	require.ErrorContains(t, cancelH.Handle(context.Background()), "cancel failed")
 }
 
+func TestPauseTaskHandleCallsCompleteHookForNonLocalTask(t *testing.T) {
+	r, store := newDaemonHandleTestRunner(t)
+
+	completed := make(chan task.DaemonTask, 1)
+	r.options.pauseTaskCompleted = func(ctx context.Context, tk task.DaemonTask) error {
+		completed <- tk
+		return nil
+	}
+
+	dt := newDaemonTaskForTest(1, task.TaskStatus_PauseRequested, "r2")
+	dt.Metadata.ID = "pause-non-local-1"
+	mustAddTestDaemonTask(t, store, 1, dt)
+
+	pauseH := newPauseTask(r, &daemonTask{task: dt})
+	require.NoError(t, pauseH.Handle(context.Background()))
+
+	select {
+	case tk := <-completed:
+		require.Equal(t, dt.ID, tk.ID)
+		require.Equal(t, task.TaskStatus_Paused, tk.TaskStatus)
+	case <-time.After(time.Second):
+		t.Fatal("pause complete hook was not called")
+	}
+
+	tasks := mustGetTestDaemonTask(t, store, 1, WithTaskIDCond(EQ, dt.ID))
+	require.Len(t, tasks, 1)
+	require.Equal(t, task.TaskStatus_Paused, tasks[0].TaskStatus)
+}
+
 func TestRunDaemonTask(t *testing.T) {
 	runTaskRunnerTest(t, func(r *taskRunner, s TaskService, store TaskStorage) {
 		c := make(chan struct{})

--- a/pkg/taskservice/daemon_task_test.go
+++ b/pkg/taskservice/daemon_task_test.go
@@ -468,6 +468,7 @@ func TestPauseTasksRetriesPausedCDCFinalize(t *testing.T) {
 	retryH := newPauseTask(r, &daemonTask{task: retryTasks[0]})
 	require.NoError(t, retryH.Handle(context.Background()))
 	require.Equal(t, int32(2), calls.Load())
+	require.Empty(t, r.pauseTasks(context.Background()))
 }
 
 func TestRunDaemonTask(t *testing.T) {

--- a/pkg/taskservice/daemon_task_test.go
+++ b/pkg/taskservice/daemon_task_test.go
@@ -471,6 +471,34 @@ func TestPauseTasksRetriesPausedCDCFinalize(t *testing.T) {
 	require.Empty(t, r.pauseTasks(context.Background()))
 }
 
+func TestPauseCompletedTasksClearedByLifecycle(t *testing.T) {
+	r, store := newDaemonHandleTestRunner(t)
+
+	resumeDT := newDaemonTaskForTest(1, task.TaskStatus_ResumeRequested, r.runnerID)
+	resumeDT.Metadata.ID = "pause-completed-resume-1"
+	mustAddTestDaemonTask(t, store, 1, resumeDT)
+	resumeRef := &daemonTask{task: resumeDT}
+	resumeAR := ActiveRoutine(newMockActiveRoutine())
+	resumeRef.activeRoutine.Store(&resumeAR)
+	r.markPauseTaskCompleted(resumeDT.ID)
+	require.NoError(t, newResumeTask(r, resumeRef).Handle(context.Background()))
+	require.False(t, r.isPauseTaskCompleted(resumeDT.ID))
+
+	cancelDT := newDaemonTaskForTest(2, task.TaskStatus_CancelRequested, r.runnerID)
+	cancelDT.Metadata.ID = "pause-completed-cancel-1"
+	mustAddTestDaemonTask(t, store, 1, cancelDT)
+	r.markPauseTaskCompleted(cancelDT.ID)
+	require.NoError(t, newCancelTask(r, &daemonTask{task: cancelDT}).Handle(context.Background()))
+	require.False(t, r.isPauseTaskCompleted(cancelDT.ID))
+
+	removeDT := newDaemonTaskForTest(3, task.TaskStatus_Paused, r.runnerID)
+	removeDT.Metadata.ID = "pause-completed-remove-1"
+	r.addDaemonTask(&daemonTask{task: removeDT})
+	r.markPauseTaskCompleted(removeDT.ID)
+	r.removeDaemonTask(removeDT.ID)
+	require.False(t, r.isPauseTaskCompleted(removeDT.ID))
+}
+
 func TestRunDaemonTask(t *testing.T) {
 	runTaskRunnerTest(t, func(r *taskRunner, s TaskService, store TaskStorage) {
 		c := make(chan struct{})

--- a/pkg/taskservice/daemon_task_test.go
+++ b/pkg/taskservice/daemon_task_test.go
@@ -16,6 +16,7 @@ package taskservice
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -414,6 +415,59 @@ func TestPauseTaskHandleCallsCompleteHookForNonLocalTask(t *testing.T) {
 	tasks := mustGetTestDaemonTask(t, store, 1, WithTaskIDCond(EQ, dt.ID))
 	require.Len(t, tasks, 1)
 	require.Equal(t, task.TaskStatus_Paused, tasks[0].TaskStatus)
+}
+
+func TestPauseTaskHandleKeepsPauseRequestedWhenActivePauseFails(t *testing.T) {
+	r, store := newDaemonHandleTestRunner(t)
+
+	dt := newDaemonTaskForTest(1, task.TaskStatus_PauseRequested, r.runnerID)
+	dt.Metadata.ID = "pause-active-fail-1"
+	mustAddTestDaemonTask(t, store, 1, dt)
+	taskRef := &daemonTask{task: dt}
+	r.addDaemonTask(taskRef)
+
+	ar := ActiveRoutine(&mockErrActiveRoutine{pauseErr: errors.New("pause failed")})
+	taskRef.activeRoutine.Store(&ar)
+
+	pauseH := newPauseTask(r, taskRef)
+	require.ErrorContains(t, pauseH.Handle(context.Background()), "pause failed")
+
+	tasks := mustGetTestDaemonTask(t, store, 1, WithTaskIDCond(EQ, dt.ID))
+	require.Equal(t, task.TaskStatus_PauseRequested, tasks[0].TaskStatus)
+}
+
+func TestPauseTasksRetriesPausedCDCFinalize(t *testing.T) {
+	r, store := newDaemonHandleTestRunner(t)
+
+	calls := atomic.Int32{}
+	r.options.pauseTaskCompleted = func(ctx context.Context, tk task.DaemonTask) error {
+		if calls.Add(1) == 1 {
+			return errors.New("finalize failed")
+		}
+		return nil
+	}
+
+	dt := newDaemonTaskForTest(1, task.TaskStatus_PauseRequested, "r2")
+	dt.Metadata.ID = "pause-finalize-retry-1"
+	dt.Metadata.Executor = task.TaskCode_InitCdc
+	dt.LastHeartbeat = time.Time{}
+	mustAddTestDaemonTask(t, store, 1, dt)
+
+	pauseH := newPauseTask(r, &daemonTask{task: dt})
+	require.ErrorContains(t, pauseH.Handle(context.Background()), "finalize failed")
+	require.Equal(t, int32(1), calls.Load())
+
+	tasks := mustGetTestDaemonTask(t, store, 1, WithTaskIDCond(EQ, dt.ID))
+	require.Equal(t, task.TaskStatus_Paused, tasks[0].TaskStatus)
+
+	retryTasks := r.pauseTasks(context.Background())
+	require.Len(t, retryTasks, 1)
+	require.Equal(t, dt.ID, retryTasks[0].ID)
+	require.Equal(t, task.TaskStatus_Paused, retryTasks[0].TaskStatus)
+
+	retryH := newPauseTask(r, &daemonTask{task: retryTasks[0]})
+	require.NoError(t, retryH.Handle(context.Background()))
+	require.Equal(t, int32(2), calls.Load())
 }
 
 func TestRunDaemonTask(t *testing.T) {

--- a/pkg/taskservice/task_runner.go
+++ b/pkg/taskservice/task_runner.go
@@ -34,6 +34,9 @@ import (
 // RunnerOption option for create task runner
 type RunnerOption func(*taskRunner)
 
+// PauseTaskCompletedHook is called after a daemon task pause has been completed.
+type PauseTaskCompletedHook func(context.Context, task.DaemonTask) error
+
 // WithRunnerLogger set logger
 func WithRunnerLogger(logger *zap.Logger) RunnerOption {
 	return func(r *taskRunner) {
@@ -121,6 +124,12 @@ func WithRunnerRetryInterval(interval time.Duration) RunnerOption {
 	}
 }
 
+func WithRunnerPauseTaskCompleted(hook PauseTaskCompletedHook) RunnerOption {
+	return func(r *taskRunner) {
+		r.options.pauseTaskCompleted = hook
+	}
+}
+
 func WithHaKeeperClient(getClient func() util.HAKeeperClient) RunnerOption {
 	return func(r *taskRunner) {
 		r.getClient = getClient
@@ -172,14 +181,15 @@ type taskRunner struct {
 	}
 
 	options struct {
-		queryLimit        int
-		parallelism       int
-		maxWaitTasks      int
-		fetchInterval     time.Duration
-		fetchTimeout      time.Duration
-		retryInterval     time.Duration
-		heartbeatInterval time.Duration
-		heartbeatTimeout  time.Duration
+		queryLimit         int
+		parallelism        int
+		maxWaitTasks       int
+		fetchInterval      time.Duration
+		fetchTimeout       time.Duration
+		retryInterval      time.Duration
+		heartbeatInterval  time.Duration
+		heartbeatTimeout   time.Duration
+		pauseTaskCompleted PauseTaskCompletedHook
 	}
 
 	getClient func() util.HAKeeperClient

--- a/pkg/taskservice/task_runner.go
+++ b/pkg/taskservice/task_runner.go
@@ -180,6 +180,11 @@ type taskRunner struct {
 		m map[uint64]*daemonTask
 	}
 
+	pauseCompletedTasks struct {
+		sync.Mutex
+		m map[uint64]struct{}
+	}
+
 	options struct {
 		queryLimit         int
 		parallelism        int
@@ -220,6 +225,7 @@ func NewTaskRunner(runnerID string, service TaskService, claimFn func(string) bo
 	r.runningTasks.completedTasks = make(map[uint64]struct{})
 	r.pendingTaskHandle = make(chan TaskHandler, 20)
 	r.daemonTasks.m = make(map[uint64]*daemonTask)
+	r.pauseCompletedTasks.m = make(map[uint64]struct{})
 	return r
 }
 


### PR DESCRIPTION
 ## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) does this PR fix or relate to?

https://github.com/matrixorigin/matrixone/issues/24797

## What this PR does / why we need it:
- Backport CDC pause visible-state alignment to `3.0-dev`.
- Show `pausing` while the daemon task is still `PauseRequested`.
- Update `mo_catalog.mo_cdc_task.state` to `paused` after the CDC executor actually completes pause.

## Why
`show cdc task` could report `paused` before the daemon task reached `Paused`, so an immediate resume could fail while the daemon task was still `PauseRequested`.

## Testing
- `go test -mod=mod ./pkg/frontend -run 'Test_updateCdcTask_pause|TestCdcTask_Pause' -count=1`\n\nLocal test note: used temporary `/tmp` usearch C headers/libs matching the Go binding because local `thirdparties/install` contains an older `usearch.h`.