### PR TITLE
compile: fix remote dispatch notify for local fallback

### DIFF
--- a/pkg/cnservice/cnclient/client.go
+++ b/pkg/cnservice/cnclient/client.go
@@ -15,10 +15,7 @@
 package cnclient
 
 import (
-	"fmt"
-
 	"github.com/fagongzi/goetty/v2"
-	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
@@ -111,9 +108,6 @@ func NewPipelineClient(
 }
 
 func (c *pipelineClient) NewStream(backend string) (morpc.Stream, error) {
-	if backend == c.localServiceAddress {
-		return nil, moerr.NewInternalErrorNoCtx(fmt.Sprintf("remote run pipeline in local: %s", backend))
-	}
 	return c.client.NewStream(backend, true)
 }
 

--- a/pkg/cnservice/cnclient/client_test.go
+++ b/pkg/cnservice/cnclient/client_test.go
@@ -1,0 +1,55 @@
+// Copyright 2021 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cnclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/morpc"
+	"github.com/stretchr/testify/require"
+)
+
+type testRPCClient struct {
+	backend string
+	lock    bool
+}
+
+func (c *testRPCClient) Send(ctx context.Context, backend string, request morpc.Message) (*morpc.Future, error) {
+	return nil, nil
+}
+
+func (c *testRPCClient) NewStream(backend string, lock bool) (morpc.Stream, error) {
+	c.backend = backend
+	c.lock = lock
+	return nil, nil
+}
+
+func (c *testRPCClient) Ping(ctx context.Context, backend string) error { return nil }
+func (c *testRPCClient) Close() error                                   { return nil }
+func (c *testRPCClient) CloseBackend() error                            { return nil }
+
+func TestPipelineClient_NewStreamAllowsLocalBackend(t *testing.T) {
+	rpcClient := &testRPCClient{}
+	client := &pipelineClient{
+		localServiceAddress: "127.0.0.1:1234",
+		client:              rpcClient,
+	}
+
+	_, err := client.NewStream("127.0.0.1:1234")
+	require.NoError(t, err)
+	require.Equal(t, "127.0.0.1:1234", rpcClient.backend)
+	require.True(t, rpcClient.lock)
+}

--- a/pkg/sql/colexec/dispatch/dispatch.go
+++ b/pkg/sql/colexec/dispatch/dispatch.go
@@ -133,6 +133,9 @@ func (dispatch *Dispatch) Call(proc *process.Process) (vm.CallResult, error) {
 	whichToSend := result.Batch
 	if result.Batch == nil {
 		result.Status = vm.ExecStop
+		if err := dispatch.waitRemoteRegsReadyBeforeStop(proc); err != nil {
+			return result, err
+		}
 		printShuffleResult(dispatch)
 		return result, nil
 	}
@@ -156,6 +159,14 @@ func (dispatch *Dispatch) Call(proc *process.Process) (vm.CallResult, error) {
 		result.Status = vm.ExecStop
 	}
 	return result, err
+}
+
+func (dispatch *Dispatch) waitRemoteRegsReadyBeforeStop(proc *process.Process) error {
+	if dispatch.ctr == nil || !dispatch.ctr.isRemote || dispatch.ctr.prepared {
+		return nil
+	}
+	_, err := dispatch.waitRemoteRegsReady(proc)
+	return err
 }
 
 func (dispatch *Dispatch) waitRemoteRegsReady(proc *process.Process) (bool, error) {

--- a/pkg/sql/colexec/dispatch/dispatch.go
+++ b/pkg/sql/colexec/dispatch/dispatch.go
@@ -188,7 +188,7 @@ func (dispatch *Dispatch) prepareRemote(proc *process.Process) error {
 	dispatch.ctr.isRemote = true
 	dispatch.ctr.remoteReceivers = make([]*process.WrapCs, 0, dispatch.ctr.remoteRegsCnt)
 	dispatch.ctr.remoteToIdx = make(map[uuid.UUID]int)
-	dispatch.ctr.remoteInfo = make(chan *process.WrapCs)
+	dispatch.ctr.remoteInfo = make(chan *process.WrapCs, dispatch.ctr.remoteRegsCnt)
 	for i, rr := range dispatch.RemoteRegs {
 		if dispatch.FuncId == ShuffleToAllFunc {
 			dispatch.ctr.remoteToIdx[rr.Uuid] = dispatch.ShuffleRegIdxRemote[i]

--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -15,6 +15,7 @@
 package dispatch
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/google/uuid"
@@ -23,8 +24,32 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
+
+type eofChildOp struct {
+	vm.OperatorBase
+}
+
+func (op *eofChildOp) Free(*process.Process, bool, error)  {}
+func (op *eofChildOp) Reset(*process.Process, bool, error) {}
+func (op *eofChildOp) Release()                            {}
+func (op *eofChildOp) String(buf *bytes.Buffer)            { buf.WriteString("eof_child") }
+func (op *eofChildOp) OpType() vm.OpType                   { return vm.Mock }
+func (op *eofChildOp) GetOperatorBase() *vm.OperatorBase   { return &op.OperatorBase }
+func (op *eofChildOp) ExecProjection(_ *process.Process, input *batch.Batch) (*batch.Batch, error) {
+	return input, nil
+}
+func (op *eofChildOp) Prepare(*process.Process) error {
+	op.OpAnalyzer = process.NewAnalyzer(0, false, false, "eof_child")
+	return nil
+}
+func (op *eofChildOp) Call(*process.Process) (vm.CallResult, error) {
+	result := vm.NewCallResult()
+	result.Status = vm.ExecStop
+	return result, nil
+}
 
 func TestPrepareRemote(t *testing.T) {
 	_ = colexec.NewServer(nil)
@@ -65,6 +90,45 @@ func TestPrepareRemote(t *testing.T) {
 	require.False(t, end)
 	require.True(t, d.ctr.prepared)
 	require.Equal(t, []*process.WrapCs{wcs}, d.ctr.remoteReceivers)
+}
+
+func TestDispatchCallWaitsRemoteReceiversOnNoData(t *testing.T) {
+	_ = colexec.NewServer(nil)
+
+	proc := testutil.NewProcess(t)
+
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	d := &Dispatch{
+		FuncId:              ShuffleToAllFunc,
+		ShuffleRegIdxRemote: []int{0},
+		RemoteRegs: []colexec.ReceiveInfo{
+			{Uuid: uid},
+		},
+	}
+	d.AppendChild(&eofChildOp{})
+	require.NoError(t, vm.Prepare(d, proc))
+
+	wcs := &process.WrapCs{
+		Uid: uid,
+		Err: make(chan error, 1),
+	}
+	d.ctr.remoteInfo <- wcs
+
+	result, err := d.Call(proc)
+	require.NoError(t, err)
+	require.Equal(t, vm.ExecStop, result.Status)
+	require.True(t, d.ctr.prepared)
+	require.Equal(t, []*process.WrapCs{wcs}, d.ctr.remoteReceivers)
+
+	d.Reset(proc, false, nil)
+	select {
+	case err = <-wcs.Err:
+		require.NoError(t, err)
+	default:
+		require.Fail(t, "remote receiver should be notified when a remote dispatch ends without data")
+	}
 }
 
 // TestReceiverDone_OldBehavior tests the old behavior (kept for backward compatibility verification)

--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -36,7 +36,9 @@ func TestPrepareRemote(t *testing.T) {
 
 	d := Dispatch{
 		FuncId: SendToAllFunc,
-		ctr:    &container{},
+		ctr: &container{
+			remoteRegsCnt: 1,
+		},
 		RemoteRegs: []colexec.ReceiveInfo{
 			{Uuid: uid},
 		},
@@ -49,6 +51,20 @@ func TestPrepareRemote(t *testing.T) {
 	require.True(t, b)
 	require.Equal(t, proc, p)
 	require.Equal(t, d.ctr.remoteInfo, c)
+	require.Equal(t, len(d.RemoteRegs), cap(c))
+
+	wcs := &process.WrapCs{Uid: uid}
+	select {
+	case c <- wcs:
+	default:
+		require.Fail(t, "remote receiver notification should not block before dispatch receives the first batch")
+	}
+
+	end, err := d.waitRemoteRegsReady(proc)
+	require.NoError(t, err)
+	require.False(t, end)
+	require.True(t, d.ctr.prepared)
+	require.Equal(t, []*process.WrapCs{wcs}, d.ctr.remoteReceivers)
 }
 
 // TestReceiverDone_OldBehavior tests the old behavior (kept for backward compatibility verification)

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -518,6 +518,8 @@ func (c *Compile) runOnce() (err error) {
 		c.proc.Base.StageCache.Clear()
 	}()
 
+	rewriteRemoteRunLocalFallbacks(c.addr, c.scopes)
+
 	if c.IsTpQuery() && len(c.scopes) == 1 {
 		if err = c.run(c.scopes[0]); err != nil {
 			return err

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -32,6 +32,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/dispatch"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/value_scan"
 	"github.com/matrixorigin/matrixone/pkg/sql/models"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/util/fault"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm"
@@ -305,7 +306,7 @@ func rewriteRemoteDispatchesForLocalSource(
 			}
 
 			receiverInfo := &binding.scope.RemoteReceivRegInfos[binding.infoIdx]
-			if binding.scope.ipAddrMatch(localAddr) {
+			if binding.scope.ipAddrMatch(localAddr) && !shouldKeepRemoteReceiverForLocalFallback(dispatchOp) {
 				if reg, ok := getReceiverWaitRegister(binding); ok {
 					reg.NilBatchCnt = source.NodeInfo.Mcpu
 					dispatchOp.LocalRegs = append(dispatchOp.LocalRegs, reg)
@@ -329,6 +330,14 @@ func rewriteRemoteDispatchesForLocalSource(
 		normalizeDispatchFuncAfterRemoteRewrite(dispatchOp)
 		return nil
 	})
+}
+
+func shouldKeepRemoteReceiverForLocalFallback(dispatchOp *dispatch.Dispatch) bool {
+	if dispatchOp.FuncId != dispatch.ShuffleToAllFunc {
+		return false
+	}
+	return dispatchOp.ShuffleType == plan2.ShuffleToLocalMatchedReg ||
+		dispatchOp.ShuffleType == plan2.ShuffleToMultiMatchedReg
 }
 
 func getReceiverWaitRegister(binding remoteReceiverBinding) (*process.WaitRegister, bool) {

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -336,8 +336,7 @@ func shouldKeepRemoteReceiverForLocalFallback(dispatchOp *dispatch.Dispatch) boo
 	if dispatchOp.FuncId != dispatch.ShuffleToAllFunc {
 		return false
 	}
-	return dispatchOp.ShuffleType == plan2.ShuffleToLocalMatchedReg ||
-		dispatchOp.ShuffleType == plan2.ShuffleToMultiMatchedReg
+	return dispatchOp.ShuffleType != plan2.ShuffleToRegIndex
 }
 
 func getReceiverWaitRegister(binding remoteReceiverBinding) (*process.WaitRegister, bool) {

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/cnservice/cnclient"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/morpc"
@@ -112,6 +113,13 @@ func (s *Scope) remoteRun(c *Compile) (sender *messageSenderOnClient, err error)
 //
 // it returns true if the pipeline has only the root operator capable of sending data to other outer pipeline.
 func checkPipelineStandaloneExecutableAtRemote(s *Scope) bool {
+	return checkPipelineStandaloneExecutableAtRemoteWithLog(s, true)
+}
+
+func checkPipelineStandaloneExecutableAtRemoteWithLog(s *Scope, enableLog bool) bool {
+	if s == nil {
+		return true
+	}
 	var regs = make(map[*process.WaitRegister]struct{})
 	var toScan []*Scope
 	// record which mergeReceivers this scope tree holds.
@@ -125,8 +133,10 @@ func checkPipelineStandaloneExecutableAtRemote(s *Scope) bool {
 				toScan = append(toScan, node.PreScopes...)
 			}
 
-			for i := range node.Proc.Reg.MergeReceivers {
-				regs[node.Proc.Reg.MergeReceivers[i]] = struct{}{}
+			if node.Proc != nil {
+				for i := range node.Proc.Reg.MergeReceivers {
+					regs[node.Proc.Reg.MergeReceivers[i]] = struct{}{}
+				}
 			}
 		}
 	}
@@ -145,14 +155,19 @@ func checkPipelineStandaloneExecutableAtRemote(s *Scope) bool {
 				toScan = append(toScan, node.PreScopes...)
 			}
 
+			if node.RootOp == nil {
+				continue
+			}
 			if node.RootOp.OpType() == vm.Dispatch {
 				t := node.RootOp.(*dispatch.Dispatch)
 				for i := range t.LocalRegs {
 					if _, ok := regs[t.LocalRegs[i]]; !ok {
-						s.Proc.Infof(
-							s.Proc.Ctx,
-							"txn id : %s, the pipeline %p convert to execute locally because it holds a dispatch operator will send data to other local pipeline tree.",
-							s.Proc.GetTxnOperator().Txn().ID, s)
+						if enableLog {
+							s.Proc.Infof(
+								s.Proc.Ctx,
+								"txn id : %s, the pipeline %p convert to execute locally because it holds a dispatch operator will send data to other local pipeline tree.",
+								s.Proc.GetTxnOperator().Txn().ID, s)
+						}
 
 						return false
 					}
@@ -162,10 +177,12 @@ func checkPipelineStandaloneExecutableAtRemote(s *Scope) bool {
 			if node.RootOp.OpType() == vm.Connector {
 				t := node.RootOp.(*connector.Connector)
 				if _, ok := regs[t.Reg]; !ok {
-					s.Proc.Infof(
-						s.Proc.Ctx,
-						"txn id : %s, the pipeline %p convert to execute locally because it holds a connector operator will send data to other local pipeline tree.",
-						s.Proc.GetTxnOperator().Txn().ID, s)
+					if enableLog {
+						s.Proc.Infof(
+							s.Proc.Ctx,
+							"txn id : %s, the pipeline %p convert to execute locally because it holds a connector operator will send data to other local pipeline tree.",
+							s.Proc.GetTxnOperator().Txn().ID, s)
+					}
 
 					return false
 				}
@@ -175,6 +192,189 @@ func checkPipelineStandaloneExecutableAtRemote(s *Scope) bool {
 	}
 
 	return true
+}
+
+type remoteReceiverBinding struct {
+	scope   *Scope
+	infoIdx int
+}
+
+func rewriteRemoteRunLocalFallbacks(localAddr string, roots []*Scope) {
+	if len(roots) == 0 {
+		return
+	}
+
+	receiverByUuid := make(map[uuid.UUID]remoteReceiverBinding)
+	for _, root := range roots {
+		collectRemoteReceiverBindings(root, receiverByUuid)
+	}
+	if len(receiverByUuid) == 0 {
+		return
+	}
+
+	localSources := make([]*Scope, 0)
+	seenLocalSource := make(map[*Scope]struct{})
+	for _, root := range roots {
+		collectRemoteRunLocalFallbackSources(root, localAddr, &localSources, seenLocalSource)
+	}
+	if len(localSources) == 0 {
+		return
+	}
+
+	removedReceivers := make(map[uuid.UUID]struct{})
+	for _, source := range localSources {
+		rewriteRemoteDispatchesForLocalSource(source, localAddr, receiverByUuid, removedReceivers)
+	}
+	if len(removedReceivers) > 0 {
+		for _, root := range roots {
+			removeRemoteReceiverBindings(root, removedReceivers)
+		}
+	}
+}
+
+func collectRemoteReceiverBindings(s *Scope, receiverByUuid map[uuid.UUID]remoteReceiverBinding) {
+	if s == nil {
+		return
+	}
+	for i := range s.RemoteReceivRegInfos {
+		receiverByUuid[s.RemoteReceivRegInfos[i].Uuid] = remoteReceiverBinding{
+			scope:   s,
+			infoIdx: i,
+		}
+	}
+	for _, preScope := range s.PreScopes {
+		collectRemoteReceiverBindings(preScope, receiverByUuid)
+	}
+}
+
+func collectRemoteRunLocalFallbackSources(s *Scope, localAddr string, result *[]*Scope, seen map[*Scope]struct{}) {
+	if s == nil {
+		return
+	}
+	if s.Magic == Remote &&
+		!s.ipAddrMatch(localAddr) &&
+		!checkPipelineStandaloneExecutableAtRemoteWithLog(s, false) {
+		collectScopesRunLocallyByRemoteFallback(s, result, seen)
+	}
+	for _, preScope := range s.PreScopes {
+		collectRemoteRunLocalFallbackSources(preScope, localAddr, result, seen)
+	}
+}
+
+func collectScopesRunLocallyByRemoteFallback(s *Scope, result *[]*Scope, seen map[*Scope]struct{}) {
+	if s == nil {
+		return
+	}
+	if _, ok := seen[s]; !ok {
+		seen[s] = struct{}{}
+		*result = append(*result, s)
+	}
+	for _, preScope := range s.PreScopes {
+		if preScope.Magic == Remote {
+			continue
+		}
+		collectScopesRunLocallyByRemoteFallback(preScope, result, seen)
+	}
+}
+
+func rewriteRemoteDispatchesForLocalSource(
+	source *Scope,
+	localAddr string,
+	receiverByUuid map[uuid.UUID]remoteReceiverBinding,
+	removedReceivers map[uuid.UUID]struct{},
+) {
+	vm.HandleAllOp(source.RootOp, func(parentOp vm.Operator, op vm.Operator) error {
+		dispatchOp, ok := op.(*dispatch.Dispatch)
+		if !ok || len(dispatchOp.RemoteRegs) == 0 {
+			return nil
+		}
+
+		originalRemoteRegs := dispatchOp.RemoteRegs
+		originalShuffleRegIdxRemote := dispatchOp.ShuffleRegIdxRemote
+		remoteRegs := originalRemoteRegs[:0]
+		remoteShuffleRegIdx := originalShuffleRegIdxRemote[:0]
+
+		for i, remoteReg := range originalRemoteRegs {
+			binding, ok := receiverByUuid[remoteReg.Uuid]
+			if !ok {
+				remoteRegs = append(remoteRegs, remoteReg)
+				if i < len(originalShuffleRegIdxRemote) {
+					remoteShuffleRegIdx = append(remoteShuffleRegIdx, originalShuffleRegIdxRemote[i])
+				}
+				continue
+			}
+
+			receiverInfo := &binding.scope.RemoteReceivRegInfos[binding.infoIdx]
+			if binding.scope.ipAddrMatch(localAddr) {
+				if reg, ok := getReceiverWaitRegister(binding); ok {
+					reg.NilBatchCnt = source.NodeInfo.Mcpu
+					dispatchOp.LocalRegs = append(dispatchOp.LocalRegs, reg)
+					if i < len(originalShuffleRegIdxRemote) {
+						dispatchOp.ShuffleRegIdxLocal = append(dispatchOp.ShuffleRegIdxLocal, originalShuffleRegIdxRemote[i])
+					}
+					removedReceivers[remoteReg.Uuid] = struct{}{}
+					continue
+				}
+			}
+
+			receiverInfo.FromAddr = localAddr
+			remoteRegs = append(remoteRegs, remoteReg)
+			if i < len(originalShuffleRegIdxRemote) {
+				remoteShuffleRegIdx = append(remoteShuffleRegIdx, originalShuffleRegIdxRemote[i])
+			}
+		}
+
+		dispatchOp.RemoteRegs = remoteRegs
+		dispatchOp.ShuffleRegIdxRemote = remoteShuffleRegIdx
+		normalizeDispatchFuncAfterRemoteRewrite(dispatchOp)
+		return nil
+	})
+}
+
+func getReceiverWaitRegister(binding remoteReceiverBinding) (*process.WaitRegister, bool) {
+	if binding.scope == nil || binding.scope.Proc == nil {
+		return nil, false
+	}
+	if binding.infoIdx < 0 || binding.infoIdx >= len(binding.scope.RemoteReceivRegInfos) {
+		return nil, false
+	}
+	receiverIdx := binding.scope.RemoteReceivRegInfos[binding.infoIdx].Idx
+	if receiverIdx < 0 || receiverIdx >= len(binding.scope.Proc.Reg.MergeReceivers) {
+		return nil, false
+	}
+	reg := binding.scope.Proc.Reg.MergeReceivers[receiverIdx]
+	return reg, reg != nil
+}
+
+func normalizeDispatchFuncAfterRemoteRewrite(dispatchOp *dispatch.Dispatch) {
+	if len(dispatchOp.RemoteRegs) > 0 {
+		return
+	}
+	switch dispatchOp.FuncId {
+	case dispatch.SendToAllFunc:
+		dispatchOp.FuncId = dispatch.SendToAllLocalFunc
+	case dispatch.SendToAnyFunc:
+		dispatchOp.FuncId = dispatch.SendToAnyLocalFunc
+	}
+}
+
+func removeRemoteReceiverBindings(s *Scope, removed map[uuid.UUID]struct{}) {
+	if s == nil {
+		return
+	}
+	if len(s.RemoteReceivRegInfos) > 0 {
+		infos := s.RemoteReceivRegInfos[:0]
+		for i := range s.RemoteReceivRegInfos {
+			if _, ok := removed[s.RemoteReceivRegInfos[i].Uuid]; ok {
+				continue
+			}
+			infos = append(infos, s.RemoteReceivRegInfos[i])
+		}
+		s.RemoteReceivRegInfos = infos
+	}
+	for _, preScope := range s.PreScopes {
+		removeRemoteReceiverBindings(preScope, removed)
+	}
 }
 
 func prepareRemoteRunSendingData(sqlStr string, s *Scope, proc *process.Process) (scopeData []byte, withoutOutput bool, processData []byte, folded bool, err error) {

--- a/pkg/sql/compile/remoterunClient.go
+++ b/pkg/sql/compile/remoterunClient.go
@@ -156,43 +156,50 @@ func checkPipelineStandaloneExecutableAtRemoteWithLog(s *Scope, enableLog bool) 
 				toScan = append(toScan, node.PreScopes...)
 			}
 
-			if node.RootOp == nil {
-				continue
-			}
-			if node.RootOp.OpType() == vm.Dispatch {
-				t := node.RootOp.(*dispatch.Dispatch)
-				for i := range t.LocalRegs {
-					if _, ok := regs[t.LocalRegs[i]]; !ok {
-						if enableLog {
-							s.Proc.Infof(
-								s.Proc.Ctx,
-								"txn id : %s, the pipeline %p convert to execute locally because it holds a dispatch operator will send data to other local pipeline tree.",
-								s.Proc.GetTxnOperator().Txn().ID, s)
-						}
-
-						return false
-					}
-				}
-				continue
-			}
-			if node.RootOp.OpType() == vm.Connector {
-				t := node.RootOp.(*connector.Connector)
-				if _, ok := regs[t.Reg]; !ok {
-					if enableLog {
-						s.Proc.Infof(
-							s.Proc.Ctx,
-							"txn id : %s, the pipeline %p convert to execute locally because it holds a connector operator will send data to other local pipeline tree.",
-							s.Proc.GetTxnOperator().Txn().ID, s)
-					}
-
-					return false
-				}
-				continue
+			if scopeHoldsLocalTargetOutsideTree(node, regs, enableLog, s) {
+				return false
 			}
 		}
 	}
 
 	return true
+}
+
+func scopeHoldsLocalTargetOutsideTree(s *Scope, regs map[*process.WaitRegister]struct{}, enableLog bool, logScope *Scope) bool {
+	if s == nil || s.RootOp == nil {
+		return false
+	}
+
+	found := false
+	vm.HandleAllOp(s.RootOp, func(parentOp vm.Operator, op vm.Operator) error {
+		switch t := op.(type) {
+		case *dispatch.Dispatch:
+			for i := range t.LocalRegs {
+				if _, ok := regs[t.LocalRegs[i]]; !ok {
+					if enableLog && !found {
+						logScope.Proc.Infof(
+							logScope.Proc.Ctx,
+							"txn id : %s, the pipeline %p convert to execute locally because it holds a dispatch operator will send data to other local pipeline tree.",
+							logScope.Proc.GetTxnOperator().Txn().ID, logScope)
+					}
+					found = true
+					return nil
+				}
+			}
+		case *connector.Connector:
+			if _, ok := regs[t.Reg]; !ok {
+				if enableLog && !found {
+					logScope.Proc.Infof(
+						logScope.Proc.Ctx,
+						"txn id : %s, the pipeline %p convert to execute locally because it holds a connector operator will send data to other local pipeline tree.",
+						logScope.Proc.GetTxnOperator().Txn().ID, logScope)
+				}
+				found = true
+			}
+		}
+		return nil
+	})
+	return found
 }
 
 type remoteReceiverBinding struct {
@@ -217,6 +224,7 @@ func rewriteRemoteRunLocalFallbacks(localAddr string, roots []*Scope) {
 	seenLocalSource := make(map[*Scope]struct{})
 	for _, root := range roots {
 		collectRemoteRunLocalFallbackSources(root, localAddr, &localSources, seenLocalSource)
+		collectRemoteRunLocalOutputDispatchSources(root, localAddr, &localSources, seenLocalSource)
 	}
 	if len(localSources) == 0 {
 		return
@@ -246,6 +254,35 @@ func collectRemoteReceiverBindings(s *Scope, receiverByUuid map[uuid.UUID]remote
 	for _, preScope := range s.PreScopes {
 		collectRemoteReceiverBindings(preScope, receiverByUuid)
 	}
+}
+
+func collectRemoteRunLocalOutputDispatchSources(s *Scope, localAddr string, result *[]*Scope, seen map[*Scope]struct{}) {
+	if s == nil {
+		return
+	}
+
+	if s.Magic == Remote && !s.ipAddrMatch(localAddr) &&
+		checkPipelineStandaloneExecutableAtRemoteWithLog(s, false) {
+		if scopeRootDispatchRunsOnLocal(s) {
+			if _, ok := seen[s]; !ok {
+				seen[s] = struct{}{}
+				*result = append(*result, s)
+			}
+		}
+		return
+	}
+
+	for _, preScope := range s.PreScopes {
+		collectRemoteRunLocalOutputDispatchSources(preScope, localAddr, result, seen)
+	}
+}
+
+func scopeRootDispatchRunsOnLocal(s *Scope) bool {
+	if s == nil || s.RootOp == nil {
+		return false
+	}
+	_, ok := s.RootOp.(*dispatch.Dispatch)
+	return ok
 }
 
 func collectRemoteRunLocalFallbackSources(s *Scope, localAddr string, result *[]*Scope, seen map[*Scope]struct{}) {

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -86,6 +86,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
@@ -801,5 +802,148 @@ func Test_checkPipelineStandaloneExecutableAtRemote(t *testing.T) {
 		s1.PreScopes = append(s1.PreScopes, s2)
 
 		require.False(t, checkPipelineStandaloneExecutableAtRemote(s0))
+	}
+}
+
+func Test_rewriteRemoteRunLocalFallbacksConvertsLocalReceiver(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	localAddr := "cn-local:6001"
+	remoteAddr := "cn-remote:6001"
+
+	localReceiver := &Scope{
+		Magic:    Merge,
+		NodeInfo: engine.Node{Addr: localAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(1),
+		RootOp:   merge.NewArgument(),
+	}
+	receiverUuid, err := uuid.NewV7()
+	require.NoError(t, err)
+	localReceiver.RemoteReceivRegInfos = []RemoteReceivRegInfo{{
+		Idx:      0,
+		Uuid:     receiverUuid,
+		FromAddr: remoteAddr,
+	}}
+
+	source := &Scope{
+		Magic:    Remote,
+		NodeInfo: engine.Node{Addr: remoteAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(0),
+	}
+	sourceDispatch := dispatch.NewArgument()
+	sourceDispatch.FuncId = dispatch.SendToAllFunc
+	sourceDispatch.RemoteRegs = []colexec.ReceiveInfo{{
+		Uuid:     receiverUuid,
+		NodeAddr: localAddr,
+	}}
+	sourceDispatch.ShuffleRegIdxRemote = []int{3}
+	source.RootOp = sourceDispatch
+	source.PreScopes = []*Scope{newScopeWithExternalLocalDispatch(proc)}
+
+	rewriteRemoteRunLocalFallbacks(localAddr, []*Scope{source, localReceiver})
+
+	require.Empty(t, sourceDispatch.RemoteRegs)
+	require.Equal(t, dispatch.SendToAllLocalFunc, sourceDispatch.FuncId)
+	require.Len(t, sourceDispatch.LocalRegs, 1)
+	require.Same(t, localReceiver.Proc.Reg.MergeReceivers[0], sourceDispatch.LocalRegs[0])
+	require.Equal(t, 1, localReceiver.Proc.Reg.MergeReceivers[0].NilBatchCnt)
+	require.Equal(t, []int{3}, sourceDispatch.ShuffleRegIdxLocal)
+	require.Empty(t, sourceDispatch.ShuffleRegIdxRemote)
+	require.Empty(t, localReceiver.RemoteReceivRegInfos)
+}
+
+func Test_rewriteRemoteRunLocalFallbacksUpdatesRemainingRemoteReceiver(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	localAddr := "cn-local:6001"
+	sourceAddr := "cn-source:6001"
+	targetAddr := "cn-target:6001"
+
+	remoteReceiver := &Scope{
+		Magic:    Remote,
+		NodeInfo: engine.Node{Addr: targetAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(1),
+		RootOp:   merge.NewArgument(),
+	}
+	receiverUuid, err := uuid.NewV7()
+	require.NoError(t, err)
+	remoteReceiver.RemoteReceivRegInfos = []RemoteReceivRegInfo{{
+		Idx:      0,
+		Uuid:     receiverUuid,
+		FromAddr: sourceAddr,
+	}}
+
+	source := &Scope{
+		Magic:    Remote,
+		NodeInfo: engine.Node{Addr: sourceAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(0),
+	}
+	sourceDispatch := dispatch.NewArgument()
+	sourceDispatch.FuncId = dispatch.SendToAllFunc
+	sourceDispatch.RemoteRegs = []colexec.ReceiveInfo{{
+		Uuid:     receiverUuid,
+		NodeAddr: targetAddr,
+	}}
+	sourceDispatch.ShuffleRegIdxRemote = []int{5}
+	source.RootOp = sourceDispatch
+	source.PreScopes = []*Scope{newScopeWithExternalLocalDispatch(proc)}
+
+	rewriteRemoteRunLocalFallbacks(localAddr, []*Scope{source, remoteReceiver})
+
+	require.Len(t, sourceDispatch.RemoteRegs, 1)
+	require.Equal(t, dispatch.SendToAllFunc, sourceDispatch.FuncId)
+	require.Empty(t, sourceDispatch.LocalRegs)
+	require.Equal(t, []int{5}, sourceDispatch.ShuffleRegIdxRemote)
+	require.Len(t, remoteReceiver.RemoteReceivRegInfos, 1)
+	require.Equal(t, localAddr, remoteReceiver.RemoteReceivRegInfos[0].FromAddr)
+}
+
+func Test_rewriteRemoteRunLocalFallbacksKeepsStandaloneRemoteScope(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	localAddr := "cn-local:6001"
+	remoteAddr := "cn-remote:6001"
+
+	localReceiver := &Scope{
+		Magic:    Merge,
+		NodeInfo: engine.Node{Addr: localAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(1),
+		RootOp:   merge.NewArgument(),
+	}
+	receiverUuid, err := uuid.NewV7()
+	require.NoError(t, err)
+	localReceiver.RemoteReceivRegInfos = []RemoteReceivRegInfo{{
+		Idx:      0,
+		Uuid:     receiverUuid,
+		FromAddr: remoteAddr,
+	}}
+
+	source := &Scope{
+		Magic:    Remote,
+		NodeInfo: engine.Node{Addr: remoteAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(0),
+	}
+	sourceDispatch := dispatch.NewArgument()
+	sourceDispatch.FuncId = dispatch.SendToAllFunc
+	sourceDispatch.RemoteRegs = []colexec.ReceiveInfo{{
+		Uuid:     receiverUuid,
+		NodeAddr: localAddr,
+	}}
+	source.RootOp = sourceDispatch
+
+	rewriteRemoteRunLocalFallbacks(localAddr, []*Scope{source, localReceiver})
+
+	require.Len(t, sourceDispatch.RemoteRegs, 1)
+	require.Empty(t, sourceDispatch.LocalRegs)
+	require.Len(t, localReceiver.RemoteReceivRegInfos, 1)
+	require.Equal(t, remoteAddr, localReceiver.RemoteReceivRegInfos[0].FromAddr)
+}
+
+func newScopeWithExternalLocalDispatch(proc *process.Process) *Scope {
+	localDispatch := dispatch.NewArgument()
+	localDispatch.LocalRegs = []*process.WaitRegister{{
+		Ch2: make(chan process.PipelineSignal, 1),
+	}}
+	return &Scope{
+		Magic:  Normal,
+		Proc:   proc.NewContextChildProc(0),
+		RootOp: localDispatch,
 	}
 }

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -851,6 +851,60 @@ func Test_rewriteRemoteRunLocalFallbacksConvertsLocalReceiver(t *testing.T) {
 	require.Empty(t, localReceiver.RemoteReceivRegInfos)
 }
 
+func Test_rewriteRemoteRunLocalFallbacksConvertsShuffleRegIndexLocalReceiver(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	localAddr := "cn-local:6001"
+	remoteAddr := "cn-remote:6001"
+
+	localReceiver := &Scope{
+		Magic:    Merge,
+		NodeInfo: engine.Node{Addr: localAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(1),
+		RootOp:   merge.NewArgument(),
+	}
+	receiverUuid, err := uuid.NewV7()
+	require.NoError(t, err)
+	localReceiver.RemoteReceivRegInfos = []RemoteReceivRegInfo{{
+		Idx:      0,
+		Uuid:     receiverUuid,
+		FromAddr: remoteAddr,
+	}}
+
+	originalLocalRegs := []*process.WaitRegister{
+		{Ch2: make(chan process.PipelineSignal, 1)},
+		{Ch2: make(chan process.PipelineSignal, 1)},
+	}
+	source := &Scope{
+		Magic:    Remote,
+		NodeInfo: engine.Node{Addr: remoteAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(0),
+	}
+	sourceDispatch := dispatch.NewArgument()
+	sourceDispatch.FuncId = dispatch.ShuffleToAllFunc
+	sourceDispatch.ShuffleType = plan.ShuffleToRegIndex
+	sourceDispatch.LocalRegs = append(sourceDispatch.LocalRegs, originalLocalRegs...)
+	sourceDispatch.RemoteRegs = []colexec.ReceiveInfo{{
+		Uuid:     receiverUuid,
+		NodeAddr: localAddr,
+	}}
+	sourceDispatch.ShuffleRegIdxLocal = []int{0, 1}
+	sourceDispatch.ShuffleRegIdxRemote = []int{2}
+	source.RootOp = sourceDispatch
+	source.PreScopes = []*Scope{newScopeWithExternalLocalDispatch(proc)}
+
+	rewriteRemoteRunLocalFallbacks(localAddr, []*Scope{source, localReceiver})
+
+	require.Equal(t, dispatch.ShuffleToAllFunc, sourceDispatch.FuncId)
+	require.Empty(t, sourceDispatch.RemoteRegs)
+	require.Len(t, sourceDispatch.LocalRegs, 3)
+	require.Same(t, originalLocalRegs[0], sourceDispatch.LocalRegs[0])
+	require.Same(t, originalLocalRegs[1], sourceDispatch.LocalRegs[1])
+	require.Same(t, localReceiver.Proc.Reg.MergeReceivers[0], sourceDispatch.LocalRegs[2])
+	require.Equal(t, []int{0, 1, 2}, sourceDispatch.ShuffleRegIdxLocal)
+	require.Empty(t, sourceDispatch.ShuffleRegIdxRemote)
+	require.Empty(t, localReceiver.RemoteReceivRegInfos)
+}
+
 func Test_rewriteRemoteRunLocalFallbacksKeepsHybridShuffleLocalReceiverRemote(t *testing.T) {
 	testCases := []struct {
 		name        string

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -851,6 +851,80 @@ func Test_rewriteRemoteRunLocalFallbacksConvertsLocalReceiver(t *testing.T) {
 	require.Empty(t, localReceiver.RemoteReceivRegInfos)
 }
 
+func Test_rewriteRemoteRunLocalFallbacksKeepsHybridShuffleLocalReceiverRemote(t *testing.T) {
+	testCases := []struct {
+		name        string
+		shuffleType int32
+	}{
+		{
+			name:        "local matched",
+			shuffleType: plan.ShuffleToLocalMatchedReg,
+		},
+		{
+			name:        "multi matched",
+			shuffleType: plan.ShuffleToMultiMatchedReg,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proc := testutil.NewProcess(t)
+			localAddr := "cn-local:6001"
+			remoteAddr := "cn-remote:6001"
+
+			localReceiver := &Scope{
+				Magic:    Merge,
+				NodeInfo: engine.Node{Addr: localAddr, Mcpu: 1},
+				Proc:     proc.NewContextChildProc(1),
+				RootOp:   merge.NewArgument(),
+			}
+			receiverUuid, err := uuid.NewV7()
+			require.NoError(t, err)
+			localReceiver.RemoteReceivRegInfos = []RemoteReceivRegInfo{{
+				Idx:      0,
+				Uuid:     receiverUuid,
+				FromAddr: remoteAddr,
+			}}
+
+			originalLocalRegs := []*process.WaitRegister{
+				{Ch2: make(chan process.PipelineSignal, 1)},
+				{Ch2: make(chan process.PipelineSignal, 1)},
+			}
+			source := &Scope{
+				Magic:    Remote,
+				NodeInfo: engine.Node{Addr: remoteAddr, Mcpu: 1},
+				Proc:     proc.NewContextChildProc(0),
+			}
+			sourceDispatch := dispatch.NewArgument()
+			sourceDispatch.FuncId = dispatch.ShuffleToAllFunc
+			sourceDispatch.ShuffleType = tc.shuffleType
+			sourceDispatch.LocalRegs = append(sourceDispatch.LocalRegs, originalLocalRegs...)
+			sourceDispatch.RemoteRegs = []colexec.ReceiveInfo{{
+				Uuid:     receiverUuid,
+				NodeAddr: localAddr,
+			}}
+			sourceDispatch.ShuffleRegIdxLocal = []int{0, 1}
+			sourceDispatch.ShuffleRegIdxRemote = []int{2}
+			source.RootOp = sourceDispatch
+			source.PreScopes = []*Scope{newScopeWithExternalLocalDispatch(proc)}
+
+			rewriteRemoteRunLocalFallbacks(localAddr, []*Scope{source, localReceiver})
+
+			require.Equal(t, dispatch.ShuffleToAllFunc, sourceDispatch.FuncId)
+			require.Len(t, sourceDispatch.LocalRegs, len(originalLocalRegs))
+			require.Same(t, originalLocalRegs[0], sourceDispatch.LocalRegs[0])
+			require.Same(t, originalLocalRegs[1], sourceDispatch.LocalRegs[1])
+			require.Len(t, sourceDispatch.RemoteRegs, 1)
+			require.Equal(t, receiverUuid, sourceDispatch.RemoteRegs[0].Uuid)
+			require.Equal(t, localAddr, sourceDispatch.RemoteRegs[0].NodeAddr)
+			require.Equal(t, []int{0, 1}, sourceDispatch.ShuffleRegIdxLocal)
+			require.Equal(t, []int{2}, sourceDispatch.ShuffleRegIdxRemote)
+			require.Len(t, localReceiver.RemoteReceivRegInfos, 1)
+			require.Equal(t, localAddr, localReceiver.RemoteReceivRegInfos[0].FromAddr)
+		})
+	}
+}
+
 func Test_rewriteRemoteRunLocalFallbacksUpdatesRemainingRemoteReceiver(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	localAddr := "cn-local:6001"

--- a/pkg/sql/compile/remoterun_test.go
+++ b/pkg/sql/compile/remoterun_test.go
@@ -756,6 +756,18 @@ func Test_checkPipelineStandaloneExecutableAtRemote(t *testing.T) {
 		require.False(t, checkPipelineStandaloneExecutableAtRemote(s0))
 	}
 
+	// a root dispatch is a legal remote-run output boundary and runs on the coordinator side.
+	{
+		s0 := &Scope{
+			Proc: proc.NewContextChildProc(0),
+		}
+		op1 := dispatch.NewArgument()
+		op1.LocalRegs = []*process.WaitRegister{{}}
+		s0.RootOp = op1
+
+		require.True(t, checkPipelineStandaloneExecutableAtRemote(s0))
+	}
+
 	// a pipeline holds an invalid connector should return false.
 	{
 		// s0, pre: s1
@@ -1024,6 +1036,52 @@ func Test_rewriteRemoteRunLocalFallbacksUpdatesRemainingRemoteReceiver(t *testin
 	require.Equal(t, localAddr, remoteReceiver.RemoteReceivRegInfos[0].FromAddr)
 }
 
+func Test_rewriteRemoteRunLocalFallbacksUpdatesRemoteReceiverForRemoteRootDispatch(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	localAddr := "cn-local:6001"
+	sourceAddr := "cn-source:6001"
+	targetAddr := "cn-target:6001"
+
+	remoteReceiver := &Scope{
+		Magic:    Remote,
+		NodeInfo: engine.Node{Addr: targetAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(1),
+		RootOp:   merge.NewArgument(),
+	}
+	receiverUuid, err := uuid.NewV7()
+	require.NoError(t, err)
+	remoteReceiver.RemoteReceivRegInfos = []RemoteReceivRegInfo{{
+		Idx:      0,
+		Uuid:     receiverUuid,
+		FromAddr: sourceAddr,
+	}}
+
+	source := &Scope{
+		Magic:    Remote,
+		NodeInfo: engine.Node{Addr: sourceAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(0),
+	}
+	sourceDispatch := dispatch.NewArgument()
+	sourceDispatch.FuncId = dispatch.SendToAllFunc
+	sourceDispatch.LocalRegs = []*process.WaitRegister{{
+		Ch2: make(chan process.PipelineSignal, 1),
+	}}
+	sourceDispatch.RemoteRegs = []colexec.ReceiveInfo{{
+		Uuid:     receiverUuid,
+		NodeAddr: targetAddr,
+	}}
+	source.RootOp = sourceDispatch
+
+	require.True(t, checkPipelineStandaloneExecutableAtRemote(source))
+
+	rewriteRemoteRunLocalFallbacks(localAddr, []*Scope{source, remoteReceiver})
+
+	require.Len(t, sourceDispatch.RemoteRegs, 1)
+	require.Len(t, sourceDispatch.LocalRegs, 1)
+	require.Len(t, remoteReceiver.RemoteReceivRegInfos, 1)
+	require.Equal(t, localAddr, remoteReceiver.RemoteReceivRegInfos[0].FromAddr)
+}
+
 func Test_rewriteRemoteRunLocalFallbacksKeepsStandaloneRemoteScope(t *testing.T) {
 	proc := testutil.NewProcess(t)
 	localAddr := "cn-local:6001"
@@ -1046,6 +1104,12 @@ func Test_rewriteRemoteRunLocalFallbacksKeepsStandaloneRemoteScope(t *testing.T)
 	source := &Scope{
 		Magic:    Remote,
 		NodeInfo: engine.Node{Addr: remoteAddr, Mcpu: 1},
+		Proc:     proc.NewContextChildProc(1),
+		RootOp:   merge.NewArgument(),
+	}
+	remotePayloadChild := &Scope{
+		Magic:    Normal,
+		NodeInfo: engine.Node{Addr: remoteAddr, Mcpu: 1},
 		Proc:     proc.NewContextChildProc(0),
 	}
 	sourceDispatch := dispatch.NewArgument()
@@ -1054,7 +1118,8 @@ func Test_rewriteRemoteRunLocalFallbacksKeepsStandaloneRemoteScope(t *testing.T)
 		Uuid:     receiverUuid,
 		NodeAddr: localAddr,
 	}}
-	source.RootOp = sourceDispatch
+	remotePayloadChild.RootOp = sourceDispatch
+	source.PreScopes = []*Scope{remotePayloadChild}
 
 	rewriteRemoteRunLocalFallbacks(localAddr, []*Scope{source, localReceiver})
 

--- a/pkg/vm/message/message.go
+++ b/pkg/vm/message/message.go
@@ -28,6 +28,7 @@ import (
 )
 
 const messageTimeout = 300 * time.Second
+const multiCNMessageBoardRetainDuration = 2 * messageTimeout
 const ALLCN = "ALLCN"
 const CURRENTCN = "CURRENTCN"
 
@@ -78,6 +79,8 @@ type MessageBoard struct {
 	multiCN       bool
 	stmtId        uuid.UUID
 	messageCenter *MessageCenter
+	refCount      int
+	releasedAt    time.Time
 	messages      []*Message
 	waiters       []chan bool
 	rwMutex       *sync.RWMutex
@@ -116,16 +119,27 @@ func (m *MessageBoard) DebugString() string {
 }
 
 func (m *MessageBoard) SetMultiCN(center *MessageCenter, stmtId uuid.UUID) *MessageBoard {
+	now := time.Now()
 	center.RwMutex.Lock()
 	defer center.RwMutex.Unlock()
+	center.cleanupReleasedBoardsLocked(now)
+
 	mb, ok := center.StmtIDToBoard[stmtId]
 	if ok {
+		mb.rwMutex.Lock()
+		mb.reset = false
+		mb.refCount++
+		mb.releasedAt = time.Time{}
+		mb.rwMutex.Unlock()
 		return mb
 	}
 	m.rwMutex.Lock()
+	m.reset = false
 	m.multiCN = true
 	m.stmtId = stmtId
 	m.messageCenter = center
+	m.refCount = 1
+	m.releasedAt = time.Time{}
 	m.rwMutex.Unlock()
 	center.StmtIDToBoard[stmtId] = m
 	return m
@@ -141,10 +155,25 @@ func (m *MessageBoard) BeforeRunonce() {
 func (m *MessageBoard) Reset() *MessageBoard {
 	if m.multiCN {
 		m.messageCenter.RwMutex.Lock()
-		delete(m.messageCenter.StmtIDToBoard, m.stmtId)
+		if current, ok := m.messageCenter.StmtIDToBoard[m.stmtId]; ok && current == m {
+			m.rwMutex.Lock()
+			if m.refCount > 0 {
+				m.refCount--
+			}
+			if m.refCount == 0 && m.releasedAt.IsZero() {
+				releasedAt := time.Now()
+				m.releasedAt = releasedAt
+				m.cleanupWaitersLocked()
+				m.rwMutex.Unlock()
+				m.messageCenter.scheduleReleasedBoardCleanup(m.stmtId, m, releasedAt)
+			} else {
+				m.rwMutex.Unlock()
+			}
+		}
 		m.messageCenter.RwMutex.Unlock()
-		// other pipeline could still access thie messageBoard
-		// so reset current message board to a new one
+		// Other remote pipelines for the same statement may not have reached SetMultiCN
+		// yet. Keep the shared board briefly so late fragments can reuse queued
+		// runtime filter and join map messages.
 		return NewMessageBoard()
 	}
 	m.rwMutex.Lock()
@@ -153,6 +182,49 @@ func (m *MessageBoard) Reset() *MessageBoard {
 	m.multiCN = false
 	m.reset = true
 	return m
+}
+
+func (mc *MessageCenter) cleanupReleasedBoardsLocked(now time.Time) {
+	for stmtID, mb := range mc.StmtIDToBoard {
+		if mb == nil {
+			delete(mc.StmtIDToBoard, stmtID)
+			continue
+		}
+
+		mb.rwMutex.RLock()
+		refCount := mb.refCount
+		releasedAt := mb.releasedAt
+		mb.rwMutex.RUnlock()
+		if refCount != 0 || releasedAt.IsZero() {
+			continue
+		}
+		if now.Sub(releasedAt) < multiCNMessageBoardRetainDuration {
+			continue
+		}
+		delete(mc.StmtIDToBoard, stmtID)
+		mb.cleanupQueuedMessages()
+	}
+}
+
+func (mc *MessageCenter) scheduleReleasedBoardCleanup(stmtID uuid.UUID, mb *MessageBoard, releasedAt time.Time) {
+	time.AfterFunc(multiCNMessageBoardRetainDuration, func() {
+		mc.RwMutex.Lock()
+		defer mc.RwMutex.Unlock()
+
+		current, ok := mc.StmtIDToBoard[stmtID]
+		if !ok || current != mb {
+			return
+		}
+
+		mb.rwMutex.RLock()
+		shouldCleanup := mb.refCount == 0 && mb.releasedAt.Equal(releasedAt)
+		mb.rwMutex.RUnlock()
+		if !shouldCleanup {
+			return
+		}
+		delete(mc.StmtIDToBoard, stmtID)
+		mb.cleanupQueuedMessages()
+	})
 }
 
 func (m *MessageBoard) cleanupQueuedMessages() {
@@ -174,6 +246,10 @@ func (m *MessageBoard) cleanupQueuedMessagesLocked() {
 		m.messages[i] = nil
 	}
 	m.messages = m.messages[:0]
+	m.waiters = m.waiters[:0]
+}
+
+func (m *MessageBoard) cleanupWaitersLocked() {
 	m.waiters = m.waiters[:0]
 }
 

--- a/pkg/vm/message/message.go
+++ b/pkg/vm/message/message.go
@@ -28,6 +28,7 @@ import (
 )
 
 const messageTimeout = 300 * time.Second
+const multiCNMessageBoardRetainDuration = 2 * messageTimeout
 const ALLCN = "ALLCN"
 const CURRENTCN = "CURRENTCN"
 
@@ -78,6 +79,8 @@ type MessageBoard struct {
 	multiCN       bool
 	stmtId        uuid.UUID
 	messageCenter *MessageCenter
+	refCount      int
+	releasedAt    time.Time
 	messages      []*Message
 	waiters       []chan bool
 	rwMutex       *sync.RWMutex
@@ -116,16 +119,23 @@ func (m *MessageBoard) DebugString() string {
 }
 
 func (m *MessageBoard) SetMultiCN(center *MessageCenter, stmtId uuid.UUID) *MessageBoard {
+	now := time.Now()
 	center.RwMutex.Lock()
 	defer center.RwMutex.Unlock()
+	center.cleanupReleasedBoardsLocked(now)
+
 	mb, ok := center.StmtIDToBoard[stmtId]
 	if ok {
+		mb.refCount++
+		mb.releasedAt = time.Time{}
 		return mb
 	}
 	m.rwMutex.Lock()
 	m.multiCN = true
 	m.stmtId = stmtId
 	m.messageCenter = center
+	m.refCount = 1
+	m.releasedAt = time.Time{}
 	m.rwMutex.Unlock()
 	center.StmtIDToBoard[stmtId] = m
 	return m
@@ -141,10 +151,19 @@ func (m *MessageBoard) BeforeRunonce() {
 func (m *MessageBoard) Reset() *MessageBoard {
 	if m.multiCN {
 		m.messageCenter.RwMutex.Lock()
-		delete(m.messageCenter.StmtIDToBoard, m.stmtId)
+		if current, ok := m.messageCenter.StmtIDToBoard[m.stmtId]; ok && current == m {
+			if m.refCount > 0 {
+				m.refCount--
+			}
+			if m.refCount == 0 {
+				m.releasedAt = time.Now()
+				m.cleanupWaiters()
+			}
+		}
 		m.messageCenter.RwMutex.Unlock()
-		// other pipeline could still access thie messageBoard
-		// so reset current message board to a new one
+		// Other remote pipelines for the same statement may not have reached SetMultiCN yet.
+		// Keep the board and its queued messages briefly so late receivers can still see
+		// messages sent by earlier pipelines.
 		return NewMessageBoard()
 	}
 	m.rwMutex.Lock()
@@ -153,6 +172,19 @@ func (m *MessageBoard) Reset() *MessageBoard {
 	m.multiCN = false
 	m.reset = true
 	return m
+}
+
+func (mc *MessageCenter) cleanupReleasedBoardsLocked(now time.Time) {
+	for stmtID, mb := range mc.StmtIDToBoard {
+		if mb == nil || mb.refCount != 0 || mb.releasedAt.IsZero() {
+			continue
+		}
+		if now.Sub(mb.releasedAt) < multiCNMessageBoardRetainDuration {
+			continue
+		}
+		delete(mc.StmtIDToBoard, stmtID)
+		mb.cleanupQueuedMessages()
+	}
 }
 
 func (m *MessageBoard) cleanupQueuedMessages() {
@@ -174,6 +206,15 @@ func (m *MessageBoard) cleanupQueuedMessagesLocked() {
 		m.messages[i] = nil
 	}
 	m.messages = m.messages[:0]
+	m.waiters = m.waiters[:0]
+}
+
+func (m *MessageBoard) cleanupWaiters() {
+	if m == nil || m.rwMutex == nil {
+		return
+	}
+	m.rwMutex.Lock()
+	defer m.rwMutex.Unlock()
 	m.waiters = m.waiters[:0]
 }
 

--- a/pkg/vm/message/message.go
+++ b/pkg/vm/message/message.go
@@ -155,9 +155,11 @@ func (m *MessageBoard) Reset() *MessageBoard {
 			if m.refCount > 0 {
 				m.refCount--
 			}
-			if m.refCount == 0 {
-				m.releasedAt = time.Now()
+			if m.refCount == 0 && m.releasedAt.IsZero() {
+				releasedAt := time.Now()
+				m.releasedAt = releasedAt
 				m.cleanupWaiters()
+				m.messageCenter.scheduleReleasedBoardCleanup(m.stmtId, m, releasedAt)
 			}
 		}
 		m.messageCenter.RwMutex.Unlock()
@@ -185,6 +187,20 @@ func (mc *MessageCenter) cleanupReleasedBoardsLocked(now time.Time) {
 		delete(mc.StmtIDToBoard, stmtID)
 		mb.cleanupQueuedMessages()
 	}
+}
+
+func (mc *MessageCenter) scheduleReleasedBoardCleanup(stmtID uuid.UUID, mb *MessageBoard, releasedAt time.Time) {
+	time.AfterFunc(multiCNMessageBoardRetainDuration, func() {
+		mc.RwMutex.Lock()
+		defer mc.RwMutex.Unlock()
+
+		current, ok := mc.StmtIDToBoard[stmtID]
+		if !ok || current != mb || mb.refCount != 0 || !mb.releasedAt.Equal(releasedAt) {
+			return
+		}
+		delete(mc.StmtIDToBoard, stmtID)
+		mb.cleanupQueuedMessages()
+	})
 }
 
 func (m *MessageBoard) cleanupQueuedMessages() {

--- a/pkg/vm/message/message.go
+++ b/pkg/vm/message/message.go
@@ -155,11 +155,9 @@ func (m *MessageBoard) Reset() *MessageBoard {
 			if m.refCount > 0 {
 				m.refCount--
 			}
-			if m.refCount == 0 && m.releasedAt.IsZero() {
-				releasedAt := time.Now()
-				m.releasedAt = releasedAt
+			if m.refCount == 0 {
+				m.releasedAt = time.Now()
 				m.cleanupWaiters()
-				m.messageCenter.scheduleReleasedBoardCleanup(m.stmtId, m, releasedAt)
 			}
 		}
 		m.messageCenter.RwMutex.Unlock()
@@ -187,20 +185,6 @@ func (mc *MessageCenter) cleanupReleasedBoardsLocked(now time.Time) {
 		delete(mc.StmtIDToBoard, stmtID)
 		mb.cleanupQueuedMessages()
 	}
-}
-
-func (mc *MessageCenter) scheduleReleasedBoardCleanup(stmtID uuid.UUID, mb *MessageBoard, releasedAt time.Time) {
-	time.AfterFunc(multiCNMessageBoardRetainDuration, func() {
-		mc.RwMutex.Lock()
-		defer mc.RwMutex.Unlock()
-
-		current, ok := mc.StmtIDToBoard[stmtID]
-		if !ok || current != mb || mb.refCount != 0 || !mb.releasedAt.Equal(releasedAt) {
-			return
-		}
-		delete(mc.StmtIDToBoard, stmtID)
-		mb.cleanupQueuedMessages()
-	})
 }
 
 func (m *MessageBoard) cleanupQueuedMessages() {

--- a/pkg/vm/message/message.go
+++ b/pkg/vm/message/message.go
@@ -28,7 +28,6 @@ import (
 )
 
 const messageTimeout = 300 * time.Second
-const multiCNMessageBoardRetainDuration = 2 * messageTimeout
 const ALLCN = "ALLCN"
 const CURRENTCN = "CURRENTCN"
 
@@ -79,8 +78,6 @@ type MessageBoard struct {
 	multiCN       bool
 	stmtId        uuid.UUID
 	messageCenter *MessageCenter
-	refCount      int
-	releasedAt    time.Time
 	messages      []*Message
 	waiters       []chan bool
 	rwMutex       *sync.RWMutex
@@ -119,23 +116,16 @@ func (m *MessageBoard) DebugString() string {
 }
 
 func (m *MessageBoard) SetMultiCN(center *MessageCenter, stmtId uuid.UUID) *MessageBoard {
-	now := time.Now()
 	center.RwMutex.Lock()
 	defer center.RwMutex.Unlock()
-	center.cleanupReleasedBoardsLocked(now)
-
 	mb, ok := center.StmtIDToBoard[stmtId]
 	if ok {
-		mb.refCount++
-		mb.releasedAt = time.Time{}
 		return mb
 	}
 	m.rwMutex.Lock()
 	m.multiCN = true
 	m.stmtId = stmtId
 	m.messageCenter = center
-	m.refCount = 1
-	m.releasedAt = time.Time{}
 	m.rwMutex.Unlock()
 	center.StmtIDToBoard[stmtId] = m
 	return m
@@ -151,19 +141,10 @@ func (m *MessageBoard) BeforeRunonce() {
 func (m *MessageBoard) Reset() *MessageBoard {
 	if m.multiCN {
 		m.messageCenter.RwMutex.Lock()
-		if current, ok := m.messageCenter.StmtIDToBoard[m.stmtId]; ok && current == m {
-			if m.refCount > 0 {
-				m.refCount--
-			}
-			if m.refCount == 0 {
-				m.releasedAt = time.Now()
-				m.cleanupWaiters()
-			}
-		}
+		delete(m.messageCenter.StmtIDToBoard, m.stmtId)
 		m.messageCenter.RwMutex.Unlock()
-		// Other remote pipelines for the same statement may not have reached SetMultiCN yet.
-		// Keep the board and its queued messages briefly so late receivers can still see
-		// messages sent by earlier pipelines.
+		// other pipeline could still access thie messageBoard
+		// so reset current message board to a new one
 		return NewMessageBoard()
 	}
 	m.rwMutex.Lock()
@@ -172,19 +153,6 @@ func (m *MessageBoard) Reset() *MessageBoard {
 	m.multiCN = false
 	m.reset = true
 	return m
-}
-
-func (mc *MessageCenter) cleanupReleasedBoardsLocked(now time.Time) {
-	for stmtID, mb := range mc.StmtIDToBoard {
-		if mb == nil || mb.refCount != 0 || mb.releasedAt.IsZero() {
-			continue
-		}
-		if now.Sub(mb.releasedAt) < multiCNMessageBoardRetainDuration {
-			continue
-		}
-		delete(mc.StmtIDToBoard, stmtID)
-		mb.cleanupQueuedMessages()
-	}
 }
 
 func (m *MessageBoard) cleanupQueuedMessages() {
@@ -206,15 +174,6 @@ func (m *MessageBoard) cleanupQueuedMessagesLocked() {
 		m.messages[i] = nil
 	}
 	m.messages = m.messages[:0]
-	m.waiters = m.waiters[:0]
-}
-
-func (m *MessageBoard) cleanupWaiters() {
-	if m == nil || m.rwMutex == nil {
-		return
-	}
-	m.rwMutex.Lock()
-	defer m.rwMutex.Unlock()
 	m.waiters = m.waiters[:0]
 }
 

--- a/pkg/vm/message/message_test.go
+++ b/pkg/vm/message/message_test.go
@@ -15,6 +15,7 @@
 package message
 
 import (
+	"context"
 	"runtime"
 	"runtime/debug"
 	"sync"
@@ -96,16 +97,8 @@ func TestMessageBoardFinalizerDestroysQueuedMessages(t *testing.T) {
 	var destroyed atomic.Int32
 
 	func() {
-		center := &MessageCenter{
-			StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
-			RwMutex:       &sync.Mutex{},
-		}
-		mb := NewMessageBoard().SetMultiCN(center, uuid.New())
+		mb := NewMessageBoard()
 		SendMessage(testMessage{tag: 1, destroyed: &destroyed}, mb)
-
-		newBoard := mb.Reset()
-		require.NotSame(t, mb, newBoard)
-		require.Empty(t, center.StmtIDToBoard)
 	}()
 
 	require.Eventually(t, func() bool {
@@ -113,4 +106,69 @@ func TestMessageBoardFinalizerDestroysQueuedMessages(t *testing.T) {
 		debug.FreeOSMemory()
 		return destroyed.Load() == 1
 	}, 5*time.Second, 20*time.Millisecond)
+}
+
+func TestMultiCNMessageBoardResetRetainsBoardForSameStatement(t *testing.T) {
+	center := &MessageCenter{
+		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
+		RwMutex:       &sync.Mutex{},
+	}
+	stmtID := uuid.New()
+	mb := NewMessageBoard().SetMultiCN(center, stmtID)
+
+	newBoard := mb.Reset()
+	require.NotSame(t, mb, newBoard)
+	require.Same(t, mb, center.StmtIDToBoard[stmtID])
+
+	reused := NewMessageBoard().SetMultiCN(center, stmtID)
+	require.Same(t, mb, reused)
+	require.Equal(t, 1, reused.refCount)
+	require.True(t, reused.releasedAt.IsZero())
+}
+
+func TestMultiCNMessageBoardResetKeepsQueuedMessagesForLateReceiver(t *testing.T) {
+	center := &MessageCenter{
+		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
+		RwMutex:       &sync.Mutex{},
+	}
+	stmtID := uuid.New()
+	mb := NewMessageBoard().SetMultiCN(center, stmtID)
+	SendMessage(testMessage{tag: 1}, mb)
+
+	_ = mb.Reset()
+
+	reused := NewMessageBoard().SetMultiCN(center, stmtID)
+	receiver := NewMessageReceiver([]int32{1}, AddrBroadCastOnCurrentCN(), reused)
+	msgs, ctxDone, err := receiver.ReceiveMessage(false, context.Background())
+
+	require.NoError(t, err)
+	require.False(t, ctxDone)
+	require.Len(t, msgs, 1)
+	require.IsType(t, testMessage{}, msgs[0])
+}
+
+func TestMultiCNMessageBoardCleanupReleasedBoards(t *testing.T) {
+	var destroyed atomic.Int32
+	center := &MessageCenter{
+		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
+		RwMutex:       &sync.Mutex{},
+	}
+	stmtID := uuid.New()
+	mb := NewMessageBoard().SetMultiCN(center, stmtID)
+	SendMessage(testMessage{tag: 1, destroyed: &destroyed}, mb)
+
+	_ = mb.Reset()
+	require.Len(t, center.StmtIDToBoard, 1)
+	require.Equal(t, int32(0), destroyed.Load())
+	require.Len(t, mb.messages, 1)
+	require.Empty(t, mb.waiters)
+
+	center.RwMutex.Lock()
+	mb.releasedAt = time.Now().Add(-multiCNMessageBoardRetainDuration - time.Second)
+	center.cleanupReleasedBoardsLocked(time.Now())
+	center.RwMutex.Unlock()
+
+	require.Empty(t, center.StmtIDToBoard)
+	require.Equal(t, int32(1), destroyed.Load())
+	require.Empty(t, mb.messages)
 }

--- a/pkg/vm/message/message_test.go
+++ b/pkg/vm/message/message_test.go
@@ -15,7 +15,6 @@
 package message
 
 import (
-	"context"
 	"runtime"
 	"runtime/debug"
 	"sync"
@@ -97,8 +96,16 @@ func TestMessageBoardFinalizerDestroysQueuedMessages(t *testing.T) {
 	var destroyed atomic.Int32
 
 	func() {
-		mb := NewMessageBoard()
+		center := &MessageCenter{
+			StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
+			RwMutex:       &sync.Mutex{},
+		}
+		mb := NewMessageBoard().SetMultiCN(center, uuid.New())
 		SendMessage(testMessage{tag: 1, destroyed: &destroyed}, mb)
+
+		newBoard := mb.Reset()
+		require.NotSame(t, mb, newBoard)
+		require.Empty(t, center.StmtIDToBoard)
 	}()
 
 	require.Eventually(t, func() bool {
@@ -106,69 +113,4 @@ func TestMessageBoardFinalizerDestroysQueuedMessages(t *testing.T) {
 		debug.FreeOSMemory()
 		return destroyed.Load() == 1
 	}, 5*time.Second, 20*time.Millisecond)
-}
-
-func TestMultiCNMessageBoardResetRetainsBoardForSameStatement(t *testing.T) {
-	center := &MessageCenter{
-		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
-		RwMutex:       &sync.Mutex{},
-	}
-	stmtID := uuid.New()
-	mb := NewMessageBoard().SetMultiCN(center, stmtID)
-
-	newBoard := mb.Reset()
-	require.NotSame(t, mb, newBoard)
-	require.Same(t, mb, center.StmtIDToBoard[stmtID])
-
-	reused := NewMessageBoard().SetMultiCN(center, stmtID)
-	require.Same(t, mb, reused)
-	require.Equal(t, 1, reused.refCount)
-	require.True(t, reused.releasedAt.IsZero())
-}
-
-func TestMultiCNMessageBoardResetKeepsQueuedMessagesForLateReceiver(t *testing.T) {
-	center := &MessageCenter{
-		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
-		RwMutex:       &sync.Mutex{},
-	}
-	stmtID := uuid.New()
-	mb := NewMessageBoard().SetMultiCN(center, stmtID)
-	SendMessage(testMessage{tag: 1}, mb)
-
-	_ = mb.Reset()
-
-	reused := NewMessageBoard().SetMultiCN(center, stmtID)
-	receiver := NewMessageReceiver([]int32{1}, AddrBroadCastOnCurrentCN(), reused)
-	msgs, ctxDone, err := receiver.ReceiveMessage(false, context.Background())
-
-	require.NoError(t, err)
-	require.False(t, ctxDone)
-	require.Len(t, msgs, 1)
-	require.IsType(t, testMessage{}, msgs[0])
-}
-
-func TestMultiCNMessageBoardCleanupReleasedBoards(t *testing.T) {
-	var destroyed atomic.Int32
-	center := &MessageCenter{
-		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
-		RwMutex:       &sync.Mutex{},
-	}
-	stmtID := uuid.New()
-	mb := NewMessageBoard().SetMultiCN(center, stmtID)
-	SendMessage(testMessage{tag: 1, destroyed: &destroyed}, mb)
-
-	_ = mb.Reset()
-	require.Len(t, center.StmtIDToBoard, 1)
-	require.Equal(t, int32(0), destroyed.Load())
-	require.Len(t, mb.messages, 1)
-	require.Empty(t, mb.waiters)
-
-	center.RwMutex.Lock()
-	mb.releasedAt = time.Now().Add(-multiCNMessageBoardRetainDuration - time.Second)
-	center.cleanupReleasedBoardsLocked(time.Now())
-	center.RwMutex.Unlock()
-
-	require.Empty(t, center.StmtIDToBoard)
-	require.Equal(t, int32(1), destroyed.Load())
-	require.Empty(t, mb.messages)
 }

--- a/pkg/vm/message/message_test.go
+++ b/pkg/vm/message/message_test.go
@@ -15,6 +15,7 @@
 package message
 
 import (
+	"context"
 	"runtime"
 	"runtime/debug"
 	"sync"
@@ -96,16 +97,8 @@ func TestMessageBoardFinalizerDestroysQueuedMessages(t *testing.T) {
 	var destroyed atomic.Int32
 
 	func() {
-		center := &MessageCenter{
-			StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
-			RwMutex:       &sync.Mutex{},
-		}
-		mb := NewMessageBoard().SetMultiCN(center, uuid.New())
+		mb := NewMessageBoard()
 		SendMessage(testMessage{tag: 1, destroyed: &destroyed}, mb)
-
-		newBoard := mb.Reset()
-		require.NotSame(t, mb, newBoard)
-		require.Empty(t, center.StmtIDToBoard)
 	}()
 
 	require.Eventually(t, func() bool {
@@ -113,4 +106,110 @@ func TestMessageBoardFinalizerDestroysQueuedMessages(t *testing.T) {
 		debug.FreeOSMemory()
 		return destroyed.Load() == 1
 	}, 5*time.Second, 20*time.Millisecond)
+}
+
+func TestMultiCNMessageBoardResetRetainsBoardForSameStatement(t *testing.T) {
+	center := &MessageCenter{
+		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
+		RwMutex:       &sync.Mutex{},
+	}
+	stmtID := uuid.New()
+	mb := NewMessageBoard().SetMultiCN(center, stmtID)
+
+	newBoard := mb.Reset()
+	require.NotSame(t, mb, newBoard)
+	require.Same(t, mb, center.StmtIDToBoard[stmtID])
+
+	reused := NewMessageBoard().SetMultiCN(center, stmtID)
+	require.Same(t, mb, reused)
+	require.Equal(t, 1, reused.refCount)
+	require.True(t, reused.releasedAt.IsZero())
+}
+
+func TestMultiCNMessageBoardResetKeepsQueuedMessagesForLateReceiver(t *testing.T) {
+	center := &MessageCenter{
+		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
+		RwMutex:       &sync.Mutex{},
+	}
+	stmtID := uuid.New()
+	mb := NewMessageBoard().SetMultiCN(center, stmtID)
+	SendMessage(testMessage{tag: 1}, mb)
+
+	_ = mb.Reset()
+
+	reused := NewMessageBoard().SetMultiCN(center, stmtID)
+	receiver := NewMessageReceiver([]int32{1}, AddrBroadCastOnCurrentCN(), reused)
+	msgs, ctxDone, err := receiver.ReceiveMessage(false, context.Background())
+
+	require.NoError(t, err)
+	require.False(t, ctxDone)
+	require.Len(t, msgs, 1)
+	require.IsType(t, testMessage{}, msgs[0])
+}
+
+func TestMultiCNMessageBoardResetWaitsForAllActiveRefs(t *testing.T) {
+	center := &MessageCenter{
+		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
+		RwMutex:       &sync.Mutex{},
+	}
+	stmtID := uuid.New()
+	mb := NewMessageBoard().SetMultiCN(center, stmtID)
+	reused := NewMessageBoard().SetMultiCN(center, stmtID)
+	require.Same(t, mb, reused)
+	require.Equal(t, 2, mb.refCount)
+
+	mb.waiters = append(mb.waiters, make(chan bool, 1))
+	_ = mb.Reset()
+
+	require.Same(t, mb, center.StmtIDToBoard[stmtID])
+	require.Equal(t, 1, mb.refCount)
+	require.True(t, mb.releasedAt.IsZero())
+	require.Len(t, mb.waiters, 1)
+
+	_ = reused.Reset()
+	require.Same(t, mb, center.StmtIDToBoard[stmtID])
+	require.Equal(t, 0, mb.refCount)
+	require.False(t, mb.releasedAt.IsZero())
+	require.Empty(t, mb.waiters)
+}
+
+func TestMultiCNMessageBoardSetMultiCNClearsStaleResetFlag(t *testing.T) {
+	center := &MessageCenter{
+		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
+		RwMutex:       &sync.Mutex{},
+	}
+	mb := NewMessageBoard()
+	mb = mb.Reset()
+	require.True(t, mb.reset)
+
+	mb = mb.SetMultiCN(center, uuid.New())
+
+	require.True(t, mb.multiCN)
+	require.False(t, mb.reset)
+}
+
+func TestMultiCNMessageBoardCleanupReleasedBoards(t *testing.T) {
+	var destroyed atomic.Int32
+	center := &MessageCenter{
+		StmtIDToBoard: make(map[uuid.UUID]*MessageBoard),
+		RwMutex:       &sync.Mutex{},
+	}
+	stmtID := uuid.New()
+	mb := NewMessageBoard().SetMultiCN(center, stmtID)
+	SendMessage(testMessage{tag: 1, destroyed: &destroyed}, mb)
+
+	_ = mb.Reset()
+	require.Len(t, center.StmtIDToBoard, 1)
+	require.Equal(t, int32(0), destroyed.Load())
+	require.Len(t, mb.messages, 1)
+	require.Empty(t, mb.waiters)
+
+	center.RwMutex.Lock()
+	mb.releasedAt = time.Now().Add(-multiCNMessageBoardRetainDuration - time.Second)
+	center.cleanupReleasedBoardsLocked(time.Now())
+	center.RwMutex.Unlock()
+
+	require.Empty(t, center.StmtIDToBoard)
+	require.Equal(t, int32(1), destroyed.Load())
+	require.Empty(t, mb.messages)
 }


### PR DESCRIPTION
## Summary

This PR fixes a chain of remote pipeline coordination failures that can hang multi-CN shuffle workloads on `3.0-dev`.

The fix covers three protocol gaps exposed by the same workload:

- dispatch prepare-done notifications must be able to reach a dispatch that executes on the coordinator;
- remote dispatch must register and later release remote receivers even if it produces no data batches;
- remote pipeline fragments for the same statement must keep sharing the same MultiCN message board until all active fragments are done.

## Problem

Large multi-CN `INSERT ... SELECT ... JOIN` workloads can hang or time out in the remote shuffle/dispatch path.

Observed failure modes included:

- `remote run pipeline in local` when the notify stream targets the local CN;
- `get dispatch process by uuid timeout` when a receiver notifies the originally planned source CN instead of the coordinator;
- `send notify msg to dispatch operator timeout` when a receiver notifies before the dispatch operator starts waiting;
- `waiting messsage timeout` for join map/runtime filter tags, with message board debug output such as `messageBoard has been reseted!` and empty boards.

## Root Cause

Remote receiver metadata is generated from planned source/target CN addresses during scope construction. Later, receivers send `PrepareDoneNotifyMessage` to `RemoteReceivRegInfos.FromAddr`, and the target CN uses the receiver uuid to find the registered dispatch process.

The workload exposes several related edge cases:

1. A planned remote source scope can fall back to local execution when it contains a dispatch or connector that sends to another local pipeline tree. The dispatch process is then registered on the coordinator, but receiver metadata could still point to the originally planned remote source CN.
2. A remote scope whose `RootOp` is a dispatch operator is a boundary case: the remote payload runs on the remote CN, but the root dispatch itself executes on the coordinator side. Receivers for that root dispatch must notify the coordinator.
3. `dispatch.prepareRemote` registered the dispatch process with an unbuffered `remoteInfo` channel. A receiver could send prepare-done before the dispatch operator produced its first output batch and entered `waitRemoteRegsReady`, causing the server-side notify send to time out.
4. If a remote dispatch source produced no data batches, `Dispatch.Call` returned `ExecStop` before calling `waitRemoteRegsReady`. Receiver notifications could already be queued in `remoteInfo`, but they were never moved into `remoteReceivers`. `Reset` therefore did not signal those receivers, so the remote server did not send `EndMessage` back to receiver streams.
5. Each remote `PipelineMessage` creates and clears its own `Compile`, while runtime filters and join maps are shared by statement id through `MessageCenter.StmtIDToBoard`. The old MultiCN `MessageBoard.Reset()` immediately removed the shared board entry. If an early remote fragment finished before later fragments for the same statement reached `SetMultiCN`, the later fragments could attach to a different or already reset board and miss queued join map/runtime filter messages.

## Changes

- Allow `pipelineClient.NewStream` to create a notify stream to the local CN address.
- Run `rewriteRemoteRunLocalFallbacks` at the beginning of `Compile.runOnce`, before root scopes are started concurrently.
- Rewrite receiver metadata for fallback-local source dispatches:
  - convert coordinator-local receivers from `RemoteRegs` to `LocalRegs` only when routing semantics allow it;
  - move the matching shuffle index from `ShuffleRegIdxRemote` to `ShuffleRegIdxLocal`;
  - remove the corresponding `RemoteReceivRegInfos` entry when the receiver is fully local;
  - downgrade `SendToAllFunc` / `SendToAnyFunc` to local variants when no remote receivers remain;
  - otherwise keep the receiver remote and rewrite `FromAddr` to the coordinator address.
- Preserve hybrid shuffle invariants:
  - for `ShuffleToAllFunc`, only `ShuffleToRegIndex` may move a receiver from `RemoteRegs` to `LocalRegs`;
  - modulo-based shuffle modes keep remote receiver entries so `len(LocalRegs)` remains stable.
- Handle root dispatch remote-run boundaries by rewriting only the dispatch operator that executes on the coordinator, not dispatch operators that stay inside the remote payload.
- Buffer `dispatch.ctr.remoteInfo` by `remoteRegsCnt`, allowing prepare-done notifications to arrive before the first data batch.
- In the remote dispatch EOF path, wait for remote receiver notifications before returning `ExecStop`, so `Reset` can notify remote receivers even when no data was produced.
- Retain MultiCN `MessageBoard` entries by statement id while remote fragments are active:
  - add a reference count for active remote compiles using the shared board;
  - after the last active reference is released, keep the board and queued messages for a bounded retention window;
  - clear stale waiters only after the board has no active references;
  - clean up retained boards and queued messages after the retention window;
  - clear stale `reset` debug state when a board is promoted or reused as MultiCN.

## Testing

Passed:

```bash
GOCACHE=/private/tmp/mo-gocache-24839-message-retain go test ./pkg/vm/message -count=1
GOCACHE=/private/tmp/mo-gocache-24839-dispatch-zero go test ./pkg/sql/colexec/dispatch -count=1
GOCACHE=/private/tmp/mo-gocache-24839-compile-rewrite go test ./pkg/sql/compile -run 'Test_checkPipelineStandaloneExecutableAtRemote|Test_rewriteRemoteRunLocalFallbacks' -count=1
git diff --check
```

Coverage added or updated:

- local notify stream self-connection;
- fallback-local dispatch metadata rewrite;
- remote root dispatch notify address rewrite;
- hybrid shuffle receiver conversion guard;
- buffered remote receiver notification delivery;
- remote dispatch shutdown when no data batches are produced;
- MultiCN message board reuse, active-reference accounting, late receiver reuse, stale reset flag clearing, and bounded cleanup.

## Manual Verification

The hang was reproduced on a 2-CN docker cluster with:

```sql
insert into c
select a.id, a.k, a.pad, b.pad
from a join b on a.k = b.k;
```

After the dispatch fixes, the remaining hang no longer showed the old uuid lookup failure. The latest logs showed `waiting messsage timeout` for join map/runtime filter tags, with empty reset MultiCN boards on the remote CN. Goroutine dumps showed probe workers waiting in `ReceiveJoinMap` / runtime filter handling while remote pipeline fragments had already reset their shared message board.

## Risk Assessment

- Local-only dispatch paths are unchanged.
- Remote dispatches that send at least one data batch keep the existing wait path; this PR adds the same wait barrier to the no-data EOF path.
- Hybrid shuffle routing semantics are preserved by avoiding receiver conversion for modulo-based shuffle modes.
- Single-CN message board reset semantics are unchanged.
- MultiCN board retention is scoped by statement id, reference-counted by active remote fragments, and bounded by a cleanup timer.
