### PR TITLE
fix(spill): stop at max level instead of erroring, fix memory leaks

### DIFF
--- a/pkg/sql/colexec/group/helper.go
+++ b/pkg/sql/colexec/group/helper.go
@@ -200,13 +200,13 @@ func (ctr *container) spillDataToDisk(proc *process.Process, parentBkt *spillBuc
 
 	// if current spill bucket is not created, create a new one.
 	if ctr.currentSpillBkt == nil {
-		// check parent level, if it is too deep, return error.
+		// check parent level, if it is too deep, stop spilling and keep data in memory.
 		// we only allow to spill up to spillMaxPass passes.
 		// each pass we take spillMaskBits bits from the hashCode, and use them as the index
 		// to select the spill bucket.  Default params, 32^3 = 32768 spill buckets -- if this
-		// is still not enough, probably we cannot do much anyway, just fail the query.
+		// is still not enough, probably we cannot do much anyway, keep the remaining data in memory.
 		if parentLv >= spillMaxPass {
-			return 0, 0, moerr.NewInternalError(proc.Ctx, "spill level too deep")
+			return 0, 0, nil
 		}
 
 		var parentName string
@@ -420,6 +420,7 @@ func (ctr *container) loadSpilledData(proc *process.Process, opAnalyzer process.
 		if err := bkt.free(); err != nil && retErr == nil {
 			retErr = err
 		}
+		ctr.freeSpillAggList()
 	}()
 
 	// reposition to the start of the file.

--- a/pkg/sql/colexec/group/types2.go
+++ b/pkg/sql/colexec/group/types2.go
@@ -238,6 +238,13 @@ func (ctr *container) free() {
 		ctr.spillGbBatch.Clean(ctr.mp)
 		ctr.spillGbBatch = nil
 	}
+	ctr.spillBuf = nil
+	ctr.spillReader = nil
+	ctr.spillHashCodes = nil
+	ctr.spillChunkFlags = nil
+	ctr.spillFlagFlat = nil
+	ctr.spillNonEmptyBuckets = nil
+	ctr.spillBucketRowIds = nil
 
 	mpool.DeleteMPool(ctr.mp)
 	ctr.mp = nil

--- a/pkg/sql/colexec/hashbuild/types.go
+++ b/pkg/sql/colexec/hashbuild/types.go
@@ -144,6 +144,11 @@ func (hashBuild *HashBuild) Free(proc *process.Process, pipelineFailed bool, err
 	hashBuild.cleanupSpillFiles(proc)
 	hashBuild.ctr.hashmapBuilder.Free(proc)
 	hashBuild.ctr.cleanSpillBufferPool(proc)
+	hashBuild.ctr.freeSpillExprExecs()
+	hashBuild.ctr.spillKeyVecs = nil
+	hashBuild.ctr.spillHashValues = nil
+	hashBuild.ctr.spillBucketRowIds = nil
+	hashBuild.ctr.spillNonEmptyBuckets = nil
 }
 
 func (hashBuild *HashBuild) cleanupSpillFiles(proc *process.Process) {

--- a/pkg/sql/colexec/hashjoin/types.go
+++ b/pkg/sql/colexec/hashjoin/types.go
@@ -222,6 +222,9 @@ func (hashJoin *HashJoin) Free(proc *process.Process, pipelineFailed bool, err e
 	ctr.cleanNonEqCondExecutor()
 	ctr.cleanEqCondExecutors()
 	ctr.cleanupSpillFiles(proc)
+	ctr.freeSpillBuildExprExecs()
+	ctr.spillBucketRowIds = nil
+	ctr.spillNonEmptyBuckets = nil
 }
 
 func (ctr *container) cleanupSpillFiles(proc *process.Process) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #23353
Fixes #24836

## What this PR does / why we need it:

Cherry-pick of #24848 to 4.0-dev. Four fixes in the spill code:

**1. Spill max level: stop instead of erroring.** When group-by spill hits the 3-level limit, now returns nil instead of erroring — data stays in memory.

**2. `spillAggList` leak on error paths.** Added `freeSpillAggList()` to deferred cleanup in `loadSpilledData`.

**3. Group spill cached buffers never freed.** Nil `spillBuf`, `spillReader`, `spillHashCodes`, `spillChunkFlags`, `spillFlagFlat`, `spillNonEmptyBuckets`, `spillBucketRowIds` in `free()`.

**4. Hashbuild/hashjoin spill executors and buffers never freed.** Added `freeSpillExprExecs`/`freeSpillBuildExprExecs` and buffer nil to `Free()`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>