### PR TITLE
fix: keep large LOAD external scan multi-CN

### DIFF
--- a/pkg/sql/plan/bind_load.go
+++ b/pkg/sql/plan/bind_load.go
@@ -184,7 +184,7 @@ func (builder *QueryBuilder) bindExternalScan(
 
 	externalScanNode := &plan.Node{
 		NodeType: plan.Node_EXTERNAL_SCAN,
-		Stats:    makeLoadExternalStats(stmt.Param, offset),
+		Stats:    makeLoadExternalStats(stmt.Param, tableDef, offset),
 		ObjRef:   objRef,
 		TableDef: tableDef,
 		ExternScan: &plan.ExternScan{

--- a/pkg/sql/plan/bind_load.go
+++ b/pkg/sql/plan/bind_load.go
@@ -184,7 +184,7 @@ func (builder *QueryBuilder) bindExternalScan(
 
 	externalScanNode := &plan.Node{
 		NodeType: plan.Node_EXTERNAL_SCAN,
-		Stats:    makeLoadExternalStats(stmt.Param, tableDef, offset),
+		Stats:    makeLoadExternalStats(stmt.Param, tableDef, offset, ctx.GetContext()),
 		ObjRef:   objRef,
 		TableDef: tableDef,
 		ExternScan: &plan.ExternScan{

--- a/pkg/sql/plan/build_load.go
+++ b/pkg/sql/plan/build_load.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"io"
+	"math"
 	"strings"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/util/csvparser"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 )
 
 const (
@@ -285,13 +287,11 @@ func hasLoadUserVariable(cols []tree.LoadColumn) bool {
 	return false
 }
 
-func makeLoadExternalStats(param *tree.ExternParam, offset int64) *plan.Stats {
+func makeLoadExternalStats(param *tree.ExternParam, tableDef *TableDef, offset int64) *plan.Stats {
 	// LOAD external scan parallelism is currently sized by
 	// getParallelSizeForExternalScan as Cost*Rowsize/WriteS3Threshold.
-	// Use input bytes as Cost and keep Rowsize=1 to provide a byte-size hint
-	// without changing that compile-time formula. This stats shape is valid
-	// only for LOAD external scan sizing; do not reuse it for query planning
-	// paths where Cost is interpreted as optimizer cost or row cardinality.
+	// Keep Cost*Rowsize close to input bytes, but express Cost/Outcnt/BlockNum
+	// as row/cardinality estimates so large LOAD keeps the expected AP path.
 	stats := &plan.Stats{Rowsize: 1}
 	if param == nil {
 		return stats
@@ -305,13 +305,46 @@ func makeLoadExternalStats(param *tree.ExternParam, offset int64) *plan.Stats {
 	if inputSize < 0 {
 		inputSize = 0
 	}
-	stats.Cost = float64(inputSize)
-	if inputSize > 0 {
-		stats.BlockNum = 1
-		stats.TableCnt = 1
-		stats.Outcnt = 1
+	if inputSize == 0 {
+		return stats
 	}
+
+	rowSize := estimateLoadRowsize(param, tableDef, inputSize)
+	rowCount := math.Ceil(float64(inputSize) / rowSize)
+	if rowCount < 1 {
+		rowCount = 1
+	}
+	stats.Cost = rowCount
+	stats.Outcnt = rowCount
+	stats.TableCnt = rowCount
+	stats.Rowsize = rowSize
+	stats.Selectivity = 1
+	stats.BlockNum = int32(rowCount/float64(options.DefaultBlockMaxRows)) + 1
 	return stats
+}
+
+func estimateLoadRowsize(param *tree.ExternParam, tableDef *TableDef, inputSize int64) float64 {
+	if param != nil && param.ScanType == tree.INLINE && param.Format == tree.CSV {
+		if idx := strings.Index(param.Data, "\n"); idx > 0 {
+			return clampLoadRowsize(float64(idx), inputSize)
+		}
+	}
+	if tableDef != nil {
+		if rowSize := GetRowSizeFromTableDef(tableDef, true) * 0.8; rowSize > 0 {
+			return clampLoadRowsize(rowSize, inputSize)
+		}
+	}
+	return clampLoadRowsize(1, inputSize)
+}
+
+func clampLoadRowsize(rowSize float64, inputSize int64) float64 {
+	if rowSize < 1 {
+		return 1
+	}
+	if inputSize > 0 && rowSize > float64(inputSize) {
+		return float64(inputSize)
+	}
+	return rowSize
 }
 
 func loadParquetMayListFiles(param *tree.ExternParam) bool {
@@ -420,7 +453,7 @@ func buildLoad(stmt *tree.Load, ctx CompilerContext, isPrepareStmt bool) (*Plan,
 
 	externalScanNode := &plan.Node{
 		NodeType:    plan.Node_EXTERNAL_SCAN,
-		Stats:       makeLoadExternalStats(stmt.Param, offset),
+		Stats:       makeLoadExternalStats(stmt.Param, tableDef, offset),
 		ProjectList: externalProject,
 		ObjRef:      objRef,
 		TableDef:    tableDef,

--- a/pkg/sql/plan/build_load.go
+++ b/pkg/sql/plan/build_load.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 	"math"
@@ -287,7 +288,7 @@ func hasLoadUserVariable(cols []tree.LoadColumn) bool {
 	return false
 }
 
-func makeLoadExternalStats(param *tree.ExternParam, tableDef *TableDef, offset int64) *plan.Stats {
+func makeLoadExternalStats(param *tree.ExternParam, tableDef *TableDef, offset int64, ctx context.Context) *plan.Stats {
 	// LOAD external scan parallelism is currently sized by
 	// getParallelSizeForExternalScan as Cost*Rowsize/WriteS3Threshold.
 	// Keep Cost*Rowsize close to input bytes, but express Cost/Outcnt/BlockNum
@@ -309,7 +310,7 @@ func makeLoadExternalStats(param *tree.ExternParam, tableDef *TableDef, offset i
 		return stats
 	}
 
-	rowSize := estimateLoadRowsize(param, tableDef, inputSize)
+	rowSize := estimateLoadRowsize(param, tableDef, inputSize, offset, ctx)
 	rowCount := math.Ceil(float64(inputSize) / rowSize)
 	if rowCount < 1 {
 		rowCount = 1
@@ -319,15 +320,18 @@ func makeLoadExternalStats(param *tree.ExternParam, tableDef *TableDef, offset i
 	stats.TableCnt = rowCount
 	stats.Rowsize = rowSize
 	stats.Selectivity = 1
-	stats.BlockNum = int32(rowCount/float64(options.DefaultBlockMaxRows)) + 1
+	stats.BlockNum = int32(math.Ceil(rowCount / float64(options.DefaultBlockMaxRows)))
 	return stats
 }
 
-func estimateLoadRowsize(param *tree.ExternParam, tableDef *TableDef, inputSize int64) float64 {
+func estimateLoadRowsize(param *tree.ExternParam, tableDef *TableDef, inputSize int64, offset int64, ctx context.Context) float64 {
 	if param != nil && param.ScanType == tree.INLINE && param.Format == tree.CSV {
-		if idx := strings.Index(param.Data, "\n"); idx > 0 {
-			return clampLoadRowsize(float64(idx), inputSize)
+		if rowSize := inlineCSVRowsize(param.Data, loadLinesTerminatedBy(param)); rowSize > 0 {
+			return clampLoadRowsize(rowSize, inputSize)
 		}
+	}
+	if rowSize := estimateLoadRowsizeFromFirstLine(param, inputSize, offset, ctx); rowSize > 0 {
+		return rowSize
 	}
 	if tableDef != nil {
 		if rowSize := GetRowSizeFromTableDef(tableDef, true) * 0.8; rowSize > 0 {
@@ -335,6 +339,93 @@ func estimateLoadRowsize(param *tree.ExternParam, tableDef *TableDef, inputSize 
 		}
 	}
 	return clampLoadRowsize(1, inputSize)
+}
+
+func inlineCSVRowsize(data string, terminatedBy string) float64 {
+	if terminatedBy == "" {
+		terminatedBy = "\n"
+	}
+	if idx := strings.Index(data, terminatedBy); idx >= 0 {
+		return float64(idx + len(terminatedBy))
+	}
+	return float64(len(data))
+}
+
+func loadLinesTerminatedBy(param *tree.ExternParam) string {
+	if param != nil && param.Tail != nil && param.Tail.Lines != nil {
+		if terminated := param.Tail.Lines.TerminatedBy; terminated != nil && terminated.Value != "" {
+			return terminated.Value
+		}
+	}
+	return "\n"
+}
+
+func estimateLoadRowsizeFromFirstLine(param *tree.ExternParam, inputSize int64, offset int64, ctx context.Context) float64 {
+	lineTerminator := loadLinesTerminatedBy(param)
+	if param == nil ||
+		param.ScanType == tree.INLINE ||
+		param.Local ||
+		param.Format == tree.PARQUET ||
+		getCompressType(param, param.Filepath) != tree.NOCOMPRESS ||
+		(lineTerminator != "\n" && lineTerminator != "\r\n") ||
+		strings.HasPrefix(param.Filepath, "SHARED:/query_result/") {
+		return 0
+	}
+
+	if size := readExternalFirstLineSize(param, offset, ctx); size > 0 {
+		return clampLoadRowsize(float64(size), inputSize)
+	}
+	return 0
+}
+
+func readExternalFirstLineSize(param *tree.ExternParam, offset int64, ctx context.Context) int {
+	if param == nil {
+		return 0
+	}
+	if ctx == nil {
+		ctx = param.Ctx
+	}
+	if ctx == nil {
+		return 0
+	}
+
+	fs, readPath, err := GetForETLWithType(param, param.Filepath)
+	if err != nil {
+		return 0
+	}
+	var r io.ReadCloser
+	vec := fileservice.IOVector{
+		FilePath: readPath,
+		Entries: []fileservice.IOEntry{
+			0: {
+				Offset:            offset,
+				Size:              -1,
+				ReadCloserForRead: &r,
+			},
+		},
+	}
+	if err = fs.Read(ctx, &vec); err != nil {
+		return 0
+	}
+	if r == nil {
+		return 0
+	}
+	defer r.Close()
+
+	reader := bufio.NewReader(r)
+	if offset == 0 && param.Tail != nil {
+		for i := uint64(0); i < param.Tail.IgnoredLines; i++ {
+			if _, err := reader.ReadString('\n'); err != nil {
+				return 0
+			}
+		}
+	}
+
+	line, err := reader.ReadString('\n')
+	if len(line) == 0 && err != nil {
+		return 0
+	}
+	return len(line)
 }
 
 func clampLoadRowsize(rowSize float64, inputSize int64) float64 {
@@ -453,7 +544,7 @@ func buildLoad(stmt *tree.Load, ctx CompilerContext, isPrepareStmt bool) (*Plan,
 
 	externalScanNode := &plan.Node{
 		NodeType:    plan.Node_EXTERNAL_SCAN,
-		Stats:       makeLoadExternalStats(stmt.Param, tableDef, offset),
+		Stats:       makeLoadExternalStats(stmt.Param, tableDef, offset, ctx.GetContext()),
 		ProjectList: externalProject,
 		ObjRef:      objRef,
 		TableDef:    tableDef,

--- a/pkg/sql/plan/build_load_parquet_test.go
+++ b/pkg/sql/plan/build_load_parquet_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
@@ -292,7 +293,7 @@ func TestMakeLoadExternalStatsUsesInputBytes(t *testing.T) {
 	}
 	stats := makeLoadExternalStats(&tree.ExternParam{
 		ExParamConst: tree.ExParamConst{FileSize: 100},
-	}, tableDef, 25)
+	}, tableDef, 25, context.Background())
 	require.GreaterOrEqual(t, stats.Cost, float64(1))
 	require.GreaterOrEqual(t, stats.Rowsize, float64(1))
 	requireLoadByteHint(t, stats, 75)
@@ -301,7 +302,7 @@ func TestMakeLoadExternalStatsUsesInputBytes(t *testing.T) {
 
 	stats = makeLoadExternalStats(&tree.ExternParam{
 		ExParamConst: tree.ExParamConst{FileSize: 10},
-	}, tableDef, 20)
+	}, tableDef, 20, context.Background())
 	require.Equal(t, float64(0), stats.Cost)
 	require.Equal(t, float64(1), stats.Rowsize)
 	require.Equal(t, int32(0), stats.BlockNum)
@@ -312,9 +313,43 @@ func TestMakeLoadExternalStatsUsesInputBytes(t *testing.T) {
 			Format:   tree.CSV,
 			Data:     "1,2\n3,4\n",
 		},
-	}, tableDef, 0)
-	require.Equal(t, float64(3), stats.Rowsize)
+	}, tableDef, 0, context.Background())
+	require.Equal(t, float64(4), stats.Rowsize)
+	require.Equal(t, float64(2), stats.Cost)
 	requireLoadByteHint(t, stats, 8)
+
+	stats = makeLoadExternalStats(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{
+			ScanType: tree.INLINE,
+			Format:   tree.CSV,
+			Data:     "a\nb\nc\n",
+		},
+	}, tableDef, 0, context.Background())
+	require.Equal(t, float64(2), stats.Rowsize)
+	require.Equal(t, float64(3), stats.Cost)
+	requireLoadByteHint(t, stats, 6)
+
+	stats = makeLoadExternalStats(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{
+			ScanType: tree.INLINE,
+			Format:   tree.CSV,
+			Data:     "a|b|c|",
+			Tail: &tree.TailParameter{
+				Lines: &tree.Lines{
+					TerminatedBy: &tree.Terminated{Value: "|"},
+				},
+			},
+		},
+	}, tableDef, 0, context.Background())
+	require.Equal(t, float64(2), stats.Rowsize)
+	require.Equal(t, float64(3), stats.Cost)
+	requireLoadByteHint(t, stats, 6)
+
+	rowSize := GetRowSizeFromTableDef(tableDef, true) * 0.8
+	stats = makeLoadExternalStats(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{FileSize: int64(float64(options.DefaultBlockMaxRows) * rowSize)},
+	}, tableDef, 0, context.Background())
+	require.Equal(t, int32(1), stats.BlockNum)
 }
 
 func TestMakeLoadExternalStatsKeepsLargeLoadMultiCN(t *testing.T) {
@@ -327,7 +362,7 @@ func TestMakeLoadExternalStatsKeepsLargeLoadMultiCN(t *testing.T) {
 	inputSize := int64(float64(options.DefaultBlockMaxRows) * GetRowSizeFromTableDef(tableDef, true) * 0.8 * float64(BlockThresholdForOneCN+1))
 	stats := makeLoadExternalStats(&tree.ExternParam{
 		ExParamConst: tree.ExParamConst{FileSize: inputSize},
-	}, tableDef, 0)
+	}, tableDef, 0, context.Background())
 	require.Greater(t, stats.BlockNum, int32(BlockThresholdForOneCN))
 	require.Greater(t, stats.Cost, float64(costThresholdForOneCN))
 	require.Equal(t, ExecTypeAP_MULTICN, GetExecType(&Query{
@@ -337,6 +372,135 @@ func TestMakeLoadExternalStatsKeepsLargeLoadMultiCN(t *testing.T) {
 		}},
 		Steps: []int32{0},
 	}, false, false))
+}
+
+func TestMakeLoadExternalStatsUsesFirstLineForTextLoad(t *testing.T) {
+	ctx := context.Background()
+	fs, err := fileservice.NewMemoryFS("memory", fileservice.DisabledCacheConfig, nil)
+	require.NoError(t, err)
+	filePath := fileservice.JoinPath(fs.Name(), "wide.csv")
+	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
+		FilePath: filePath,
+		Entries: []fileservice.IOEntry{{
+			Offset: 0,
+			Size:   int64(len("1,2\n3,4\n")),
+			Data:   []byte("1,2\n3,4\n"),
+		}},
+	}))
+
+	tableDef := &TableDef{
+		Cols: []*ColDef{
+			{Name: "a", Typ: Type{Id: int32(types.T_varchar), Width: 65535}},
+			{Name: "b", Typ: Type{Id: int32(types.T_varchar), Width: 65535}},
+		},
+	}
+	inputSize := int64(4 * options.DefaultBlockMaxRows * (BlockThresholdForOneCN + 1))
+	stats := makeLoadExternalStats(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{
+			Filepath: filePath,
+			FileSize: inputSize,
+			Format:   tree.CSV,
+		},
+		ExParam: tree.ExParam{
+			FileService: fs,
+			Ctx:         ctx,
+		},
+	}, tableDef, 0, context.Background())
+
+	require.Equal(t, float64(4), stats.Rowsize)
+	require.Greater(t, stats.BlockNum, int32(BlockThresholdForOneCN))
+	require.Equal(t, ExecTypeAP_MULTICN, GetExecType(&Query{
+		Nodes: []*Node{{
+			NodeType: pbplan.Node_EXTERNAL_SCAN,
+			Stats:    stats,
+		}},
+		Steps: []int32{0},
+	}, false, false))
+
+	crlfPath := fileservice.JoinPath(fs.Name(), "crlf.csv")
+	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
+		FilePath: crlfPath,
+		Entries: []fileservice.IOEntry{{
+			Offset: 0,
+			Size:   int64(len("1,2\r\n3,4\r\n")),
+			Data:   []byte("1,2\r\n3,4\r\n"),
+		}},
+	}))
+	stats = makeLoadExternalStats(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{
+			Filepath: crlfPath,
+			FileSize: inputSize,
+			Format:   tree.CSV,
+			Tail: &tree.TailParameter{
+				Lines: &tree.Lines{
+					TerminatedBy: &tree.Terminated{Value: "\r\n"},
+				},
+			},
+		},
+		ExParam: tree.ExParam{
+			FileService: fs,
+			Ctx:         ctx,
+		},
+	}, tableDef, 0, context.Background())
+	require.Equal(t, float64(5), stats.Rowsize)
+
+	ignoredPath := fileservice.JoinPath(fs.Name(), "ignored.csv")
+	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
+		FilePath: ignoredPath,
+		Entries: []fileservice.IOEntry{{
+			Offset: 0,
+			Size:   int64(len("long_header_value\n1,2\n3,4\n")),
+			Data:   []byte("long_header_value\n1,2\n3,4\n"),
+		}},
+	}))
+	stats = makeLoadExternalStats(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{
+			Filepath: ignoredPath,
+			FileSize: inputSize,
+			Format:   tree.CSV,
+			Tail: &tree.TailParameter{
+				IgnoredLines: 1,
+			},
+		},
+		ExParam: tree.ExParam{
+			FileService: fs,
+			Ctx:         ctx,
+		},
+	}, tableDef, 0, context.Background())
+	require.Equal(t, float64(4), stats.Rowsize)
+
+	schemaRowSize := GetRowSizeFromTableDef(tableDef, true) * 0.8
+	stats = makeLoadExternalStats(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{
+			Filepath:     filePath,
+			FileSize:     inputSize,
+			Format:       tree.CSV,
+			CompressType: tree.GZIP,
+		},
+		ExParam: tree.ExParam{
+			FileService: fs,
+			Ctx:         ctx,
+		},
+	}, tableDef, 0, context.Background())
+	require.Equal(t, schemaRowSize, stats.Rowsize)
+
+	stats = makeLoadExternalStats(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{
+			Filepath: filePath,
+			FileSize: inputSize,
+			Format:   tree.CSV,
+			Tail: &tree.TailParameter{
+				Lines: &tree.Lines{
+					TerminatedBy: &tree.Terminated{Value: "|"},
+				},
+			},
+		},
+		ExParam: tree.ExParam{
+			FileService: fs,
+			Ctx:         ctx,
+		},
+	}, tableDef, 0, context.Background())
+	require.Equal(t, schemaRowSize, stats.Rowsize)
 }
 
 func requireLoadByteHint(t *testing.T, stats *Stats, inputSize int64) {

--- a/pkg/sql/plan/build_load_parquet_test.go
+++ b/pkg/sql/plan/build_load_parquet_test.go
@@ -19,7 +19,10 @@ import (
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
 	"github.com/stretchr/testify/require"
 )
 
@@ -281,18 +284,24 @@ func TestValidateLoadParquetOptionsIgnoresNonParquet(t *testing.T) {
 }
 
 func TestMakeLoadExternalStatsUsesInputBytes(t *testing.T) {
+	tableDef := &TableDef{
+		Cols: []*ColDef{
+			{Name: "a", Typ: Type{Id: int32(types.T_int64), Width: 64}},
+			{Name: "b", Typ: Type{Id: int32(types.T_char), Width: 1}},
+		},
+	}
 	stats := makeLoadExternalStats(&tree.ExternParam{
 		ExParamConst: tree.ExParamConst{FileSize: 100},
-	}, 25)
-	require.Equal(t, float64(75), stats.Cost)
-	require.Equal(t, float64(1), stats.Rowsize)
-	require.Equal(t, int32(1), stats.BlockNum)
-	require.Equal(t, float64(1), stats.TableCnt)
-	require.Equal(t, float64(1), stats.Outcnt)
+	}, tableDef, 25)
+	require.GreaterOrEqual(t, stats.Cost, float64(1))
+	require.GreaterOrEqual(t, stats.Rowsize, float64(1))
+	requireLoadByteHint(t, stats, 75)
+	require.Equal(t, stats.Cost, stats.TableCnt)
+	require.Equal(t, stats.Cost, stats.Outcnt)
 
 	stats = makeLoadExternalStats(&tree.ExternParam{
 		ExParamConst: tree.ExParamConst{FileSize: 10},
-	}, 20)
+	}, tableDef, 20)
 	require.Equal(t, float64(0), stats.Cost)
 	require.Equal(t, float64(1), stats.Rowsize)
 	require.Equal(t, int32(0), stats.BlockNum)
@@ -300,11 +309,41 @@ func TestMakeLoadExternalStatsUsesInputBytes(t *testing.T) {
 	stats = makeLoadExternalStats(&tree.ExternParam{
 		ExParamConst: tree.ExParamConst{
 			ScanType: tree.INLINE,
+			Format:   tree.CSV,
 			Data:     "1,2\n3,4\n",
 		},
-	}, 0)
-	require.Equal(t, float64(8), stats.Cost)
-	require.Equal(t, float64(1), stats.Rowsize)
+	}, tableDef, 0)
+	require.Equal(t, float64(3), stats.Rowsize)
+	requireLoadByteHint(t, stats, 8)
+}
+
+func TestMakeLoadExternalStatsKeepsLargeLoadMultiCN(t *testing.T) {
+	tableDef := &TableDef{
+		Cols: []*ColDef{
+			{Name: "a", Typ: Type{Id: int32(types.T_int64), Width: 64}},
+			{Name: "b", Typ: Type{Id: int32(types.T_char), Width: 1}},
+		},
+	}
+	inputSize := int64(float64(options.DefaultBlockMaxRows) * GetRowSizeFromTableDef(tableDef, true) * 0.8 * float64(BlockThresholdForOneCN+1))
+	stats := makeLoadExternalStats(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{FileSize: inputSize},
+	}, tableDef, 0)
+	require.Greater(t, stats.BlockNum, int32(BlockThresholdForOneCN))
+	require.Greater(t, stats.Cost, float64(costThresholdForOneCN))
+	require.Equal(t, ExecTypeAP_MULTICN, GetExecType(&Query{
+		Nodes: []*Node{{
+			NodeType: pbplan.Node_EXTERNAL_SCAN,
+			Stats:    stats,
+		}},
+		Steps: []int32{0},
+	}, false, false))
+}
+
+func requireLoadByteHint(t *testing.T, stats *Stats, inputSize int64) {
+	t.Helper()
+	estimatedBytes := stats.Cost * stats.Rowsize
+	require.GreaterOrEqual(t, estimatedBytes, float64(inputSize))
+	require.Less(t, estimatedBytes, float64(inputSize)+stats.Rowsize)
 }
 
 func TestLoadParquetMayListFiles(t *testing.T) {

--- a/pkg/sql/plan/external.go
+++ b/pkg/sql/plan/external.go
@@ -15,17 +15,14 @@
 package plan
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
-	"io"
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
-	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
@@ -153,7 +150,7 @@ func getExternalStats(node *plan.Node, builder *QueryBuilder) *Stats {
 		totolSize := len(externScan.Data)
 		lineSize := float64(0.0)
 		if externScan.Format == tree.CSV {
-			lineSize = float64(strings.Index(externScan.Data, "\n"))
+			lineSize = inlineCSVRowsize(externScan.Data, "\n")
 		}
 
 		if externScan.Format == tree.JSONLINE {
@@ -220,28 +217,10 @@ func getExternalStats(node *plan.Node, builder *QueryBuilder) *Stats {
 		return DefaultStats()
 	}
 
-	//read one line
-	fs, readPath, err := GetForETLWithType(param, param.Filepath)
-	if err != nil {
+	size := readExternalFirstLineSize(param, 0, param.Ctx)
+	if size == 0 {
 		return DefaultHugeStats()
 	}
-	var r io.ReadCloser
-	vec := fileservice.IOVector{
-		FilePath: readPath,
-		Entries: []fileservice.IOEntry{
-			0: {
-				Offset:            0,
-				Size:              -1,
-				ReadCloserForRead: &r,
-			},
-		},
-	}
-	if err = fs.Read(param.Ctx, &vec); err != nil {
-		return DefaultHugeStats()
-	}
-	r2 := bufio.NewReader(r)
-	line, _ := r2.ReadString('\n')
-	size := len(line)
 	cost = cost / float64(size)
 
 	return &plan.Stats{


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24846

## What this PR does / why we need it:

This fixes LOAD external scan stats so large LOAD jobs keep row/cardinality semantics for `Cost`, `Outcnt`, `TableCnt`, and `BlockNum`, while preserving `Cost * Rowsize` as the input-size hint used by external scan parallel sizing.

Previously the LOAD stats used input bytes as `Cost` with `Rowsize=1` and forced `BlockNum=1` / `TableCnt=1`. That can make large CSV/TBL LOAD choose `AP_ONECN` instead of the expected multi-CN AP path.

Tests:

```sh
CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" go test ./pkg/sql/plan -count=1
```