### PR TITLE
fix(fileservice): bound full-object cache wait fallback

### DIFF
--- a/pkg/fileservice/disk_cache.go
+++ b/pkg/fileservice/disk_cache.go
@@ -340,23 +340,22 @@ func (d *DiskCache) Read(
 				}
 			} else {
 				// open file
-				if d.isUpdating(diskPath) {
-					return nil
-				}
-				LogEvent(ctx, str_disk_cache_file_open_begin)
-				diskFile, err := os.Open(diskPath)
-				LogEvent(ctx, str_disk_cache_file_open_end)
-				if err == nil {
-					defer func() {
-						openedFiles[diskPath] = diskFile
-					}()
-					numOpenFull++
-					// seek
-					LogEvent(ctx, str_disk_cache_file_seek_begin)
-					_, err = diskFile.Seek(entry.Offset, io.SeekStart)
-					LogEvent(ctx, str_disk_cache_file_seek_end)
+				if d.waitUpdateCompleteFor(ctx, diskPath, shortIOWaitDuration) {
+					LogEvent(ctx, str_disk_cache_file_open_begin)
+					diskFile, err := os.Open(diskPath)
+					LogEvent(ctx, str_disk_cache_file_open_end)
 					if err == nil {
-						file = diskFile
+						defer func() {
+							openedFiles[diskPath] = diskFile
+						}()
+						numOpenFull++
+						// seek
+						LogEvent(ctx, str_disk_cache_file_seek_begin)
+						_, err = diskFile.Seek(entry.Offset, io.SeekStart)
+						LogEvent(ctx, str_disk_cache_file_seek_end)
+						if err == nil {
+							file = diskFile
+						}
 					}
 				}
 			}
@@ -657,6 +656,40 @@ func (d *DiskCache) waitUpdateComplete(ctx context.Context, path string) {
 		d.updatingPaths.Wait()
 	}
 	d.updatingPaths.L.Unlock()
+}
+
+func (d *DiskCache) waitUpdateCompleteFor(ctx context.Context, path string, timeout time.Duration) bool {
+	d.updatingPaths.L.Lock()
+	updating := d.updatingPaths.m[path]
+	d.updatingPaths.L.Unlock()
+	if !updating {
+		return true
+	}
+	if timeout <= 0 {
+		return false
+	}
+
+	LogEvent(ctx, str_disk_cache_wait_update_complete_begin)
+	defer LogEvent(ctx, str_disk_cache_wait_update_complete_end)
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond * 10)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-deadline.C:
+			return false
+		case <-ticker.C:
+		}
+		d.updatingPaths.L.Lock()
+		updating := d.updatingPaths.m[path]
+		d.updatingPaths.L.Unlock()
+		if !updating {
+			return true
+		}
+	}
 }
 
 func (d *DiskCache) isUpdating(path string) bool {

--- a/pkg/fileservice/disk_cache_test.go
+++ b/pkg/fileservice/disk_cache_test.go
@@ -35,6 +35,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func countLoggedEvents(ctx context.Context, ev stringRef) int {
+	logger, _ := ctx.Value(EventLoggerKey).(*eventLogger)
+	if logger == nil {
+		return 0
+	}
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+
+	var count int
+	for _, event := range *logger.events {
+		if event.ev == ev {
+			count++
+		}
+	}
+	return count
+}
+
 func TestDiskCache(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
@@ -408,6 +425,63 @@ func TestDiskCacheReadSkipsFullFileWhileUpdating(t *testing.T) {
 	}
 	require.False(t, readVector.Entries[0].done)
 	readVector.Release()
+}
+
+func TestDiskCacheReadWaitsForFullFileUpdateWithinShortWait(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	cache, err := NewDiskCache(ctx, dir, fscache.ConstCapacity(1<<20), nil, false, nil, "")
+	require.NoError(t, err)
+	defer cache.Close(ctx)
+
+	err = cache.SetFile(ctx, "foo", func(context.Context) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("abcdef"))), nil
+	})
+	require.NoError(t, err)
+
+	diskPath := cache.pathForFile("foo")
+	doneUpdate := cache.startUpdate(diskPath)
+	released := false
+	release := func() {
+		if !released {
+			doneUpdate()
+			released = true
+		}
+	}
+	defer release()
+
+	readCtx := WithEventLogger(ctx)
+	readVector := &IOVector{
+		FilePath: "foo",
+		Entries: []IOEntry{
+			{
+				Offset: 1,
+				Size:   3,
+			},
+		},
+	}
+	defer readVector.Release()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cache.Read(readCtx, readVector)
+	}()
+
+	require.Eventually(t, func() bool {
+		return countLoggedEvents(readCtx, str_disk_cache_wait_update_complete_begin) >= 2
+	}, time.Second, time.Millisecond)
+
+	release()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("disk cache read should finish after the full-file update completes")
+	}
+	require.True(t, readVector.Entries[0].done)
+	require.Equal(t, []byte("bcd"), readVector.Entries[0].Data)
+	require.Equal(t, cache, readVector.Entries[0].fromCache)
 }
 
 func TestDiskCacheStaleRepairReplacesCacheEntrySize(t *testing.T) {

--- a/pkg/fileservice/io_merger.go
+++ b/pkg/fileservice/io_merger.go
@@ -44,6 +44,8 @@ var slowIOWaitDuration = time.Second * 10
 
 var maxIOWaitDuration = time.Minute
 
+var shortIOWaitDuration = time.Millisecond * 200
+
 func (i *IOMerger) makeWaitFunc(key IOMergeKey, ch chan struct{}, maxWaitDuration time.Duration) func() {
 	metric.IOMergerCounterWait.Add(1)
 	return func() {
@@ -51,14 +53,23 @@ func (i *IOMerger) makeWaitFunc(key IOMergeKey, ch chan struct{}, maxWaitDuratio
 		defer func() {
 			metric.IOMergerDurationWait.Observe(time.Since(t0).Seconds())
 		}()
+		deadline := time.Now().Add(maxWaitDuration)
 		for {
-			timer := time.NewTimer(slowIOWaitDuration)
+			waitDuration := slowIOWaitDuration
+			if maxWaitDuration > 0 {
+				remaining := time.Until(deadline)
+				if remaining <= 0 {
+					return
+				}
+				waitDuration = min(waitDuration, remaining)
+			}
+			timer := time.NewTimer(waitDuration)
 			select {
 			case <-ch:
 				timer.Stop()
 				return
 			case <-timer.C:
-				if time.Since(t0) > maxWaitDuration {
+				if maxWaitDuration > 0 && !time.Now().Before(deadline) {
 					// don't wait too long
 					// number of I/O requests may increase, but we don't want to hurt latencies too much.
 					return
@@ -114,20 +125,6 @@ func (i *IOVector) ioMergeKey() IOMergeKey {
 		return key
 	}
 	return i.ioMergeKeyWithRange(key, min, max)
-}
-
-func (i *IOVector) ioMergeKeyForMinimalRange() IOMergeKey {
-	key := IOMergeKey{
-		Path:   i.FilePath,
-		Policy: i.Policy,
-	}
-	min, max := i.readMinimalRange()
-	return i.ioMergeKeyWithRange(key, min, max)
-}
-
-func (i *IOVector) canBypassFullObjectMergeWait() bool {
-	min, max := i.readMinimalRange()
-	return min != nil && (*min != 0 || max != nil)
 }
 
 func (i *IOVector) ioMergeKeyWithRange(key IOMergeKey, min *int64, max *int64) IOMergeKey {

--- a/pkg/fileservice/io_merger_test.go
+++ b/pkg/fileservice/io_merger_test.go
@@ -108,6 +108,30 @@ func TestIOMergerMaxWait(t *testing.T) {
 	wait()
 }
 
+func TestIOMergerShortMaxWait(t *testing.T) {
+	merger := NewIOMerger()
+	key := IOMergeKey{
+		Path: "foo",
+	}
+
+	done, wait := merger.Merge(key, time.Second)
+	if done == nil || wait != nil {
+		t.Fatal("expected first merge to initiate")
+	}
+	defer done()
+
+	_, wait = merger.Merge(key, time.Millisecond*20)
+	if wait == nil {
+		t.Fatal("expected second merge to wait")
+	}
+
+	t0 := time.Now()
+	wait()
+	if elapsed := time.Since(t0); elapsed > time.Second {
+		t.Fatalf("short max wait was delayed by slow wait duration: %v", elapsed)
+	}
+}
+
 func TestIOMergerIsMerging(t *testing.T) {
 	merger := NewIOMerger()
 	key := IOMergeKey{

--- a/pkg/fileservice/s3_fs.go
+++ b/pkg/fileservice/s3_fs.go
@@ -654,19 +654,11 @@ read_disk_cache:
 		LogEvent(ctx, str_ioMerger_Merge_begin)
 		startLock := time.Now()
 		mergeKey := vector.ioMergeKey()
-		if skipFullObjectRead, err := s.shouldSkipFullObjectDiskCacheForUpdating(vector); err != nil {
-			return err
-		} else if skipFullObjectRead {
-			mergeKey = vector.ioMergeKeyForMinimalRange()
-			forceMinimalRangeRead = true
+		waitDuration := maxIOWaitDuration
+		if mergeKey.FullObject {
+			waitDuration = shortIOWaitDuration
 		}
-		if mergeKey.FullObject &&
-			vector.canBypassFullObjectMergeWait() &&
-			s.ioMerger.IsMerging(mergeKey) {
-			mergeKey = vector.ioMergeKeyForMinimalRange()
-			forceMinimalRangeRead = true
-		}
-		done, wait := s.ioMerger.Merge(mergeKey, maxIOWaitDuration)
+		done, wait := s.ioMerger.Merge(mergeKey, waitDuration)
 		if done != nil {
 			defer done()
 			stats.AddS3FSReadIOMergerTimeConsumption(time.Since(startLock))
@@ -679,6 +671,10 @@ read_disk_cache:
 			stats.AddS3FSReadIOMergerTimeConsumption(time.Since(startLock))
 			metric.FSReadDurationIOMerger.Observe(time.Since(startLock).Seconds())
 			LogEvent(ctx, str_ioMerger_Merge_end)
+			if mergeKey.FullObject && s.ioMerger.IsMerging(mergeKey) {
+				forceMinimalRangeRead = true
+				goto read_s3
+			}
 			if mayReadMemoryCache {
 				goto read_memory_cache
 			} else {
@@ -687,6 +683,7 @@ read_disk_cache:
 		}
 	}
 
+read_s3:
 	// Count bytes that will be read from S3 (entries that are not done yet)
 	var s3ReadBytes int64
 	for _, entry := range vector.Entries {
@@ -757,7 +754,7 @@ func (s *S3FS) read(ctx context.Context, vector *IOVector, forceMinimalRangeRead
 	}
 
 	min, max, readFullObject := vector.readRange()
-	if readFullObject && (forceMinimalRangeRead || s.isFullObjectDiskCacheUpdating(vector.FilePath, path.File)) {
+	if readFullObject && forceMinimalRangeRead {
 		min, max = vector.readMinimalRange()
 		readFullObject = false
 	}
@@ -1014,32 +1011,6 @@ func (s *S3FS) read(ctx context.Context, vector *IOVector, forceMinimalRangeRead
 	return nil
 }
 
-func (s *S3FS) isFullObjectDiskCacheUpdating(vectorPath string, filePath string) bool {
-	if s.diskCache == nil {
-		return false
-	}
-	if s.diskCache.isUpdating(s.diskCache.pathForFile(filePath)) {
-		return true
-	}
-	if vectorPath != filePath && s.diskCache.isUpdating(s.diskCache.pathForFile(vectorPath)) {
-		return true
-	}
-	return false
-}
-
-func (s *S3FS) shouldSkipFullObjectDiskCacheForUpdating(vector *IOVector) (bool, error) {
-	if s.diskCache == nil ||
-		!vector.Policy.CacheFullFile() ||
-		vector.Policy.Any(SkipDiskCache) {
-		return false, nil
-	}
-	path, err := ParsePathAtService(vector.FilePath, s.name)
-	if err != nil {
-		return false, err
-	}
-	return s.isFullObjectDiskCacheUpdating(vector.FilePath, path.File), nil
-}
-
 func (s *S3FS) shouldStreamFullObjectToDiskCache(vector *IOVector) bool {
 	if s.diskCache == nil || vector.Policy.Any(SkipDiskCacheWrites) {
 		return false
@@ -1195,7 +1166,8 @@ func (r *fullObjectDiskCacheReader) fillVector(
 			entry.Size = int64(len(data))
 		}
 
-		if int64(len(entry.Data)) < entry.Size {
+		usingCapturedData := int64(len(entry.Data)) < entry.Size
+		if usingCapturedData {
 			entry.Data = data
 		} else {
 			copy(entry.Data, data)
@@ -1203,6 +1175,9 @@ func (r *fullObjectDiskCacheReader) fillVector(
 
 		if err := entry.setCachedData(ctx, allocator); err != nil {
 			return err
+		}
+		if usingCapturedData && entry.CachedData != nil && entry.ReadCloserForRead == nil {
+			entry.Data = nil
 		}
 		r.vector.Entries[capture.index] = entry
 	}

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -36,6 +36,46 @@ import (
 	"go.uber.org/zap"
 )
 
+type objectStorageReadRange struct {
+	key string
+	min *int64
+	max *int64
+}
+
+type readRangeRecordingObjectStorage struct {
+	ObjectStorage
+	mu    sync.Mutex
+	reads []objectStorageReadRange
+}
+
+func (r *readRangeRecordingObjectStorage) Read(ctx context.Context, key string, min *int64, max *int64) (io.ReadCloser, error) {
+	r.mu.Lock()
+	r.reads = append(r.reads, objectStorageReadRange{
+		key: key,
+		min: cloneInt64Pointer(min),
+		max: cloneInt64Pointer(max),
+	})
+	r.mu.Unlock()
+	return r.ObjectStorage.Read(ctx, key, min, max)
+}
+
+func (r *readRangeRecordingObjectStorage) lastRead() (objectStorageReadRange, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.reads) == 0 {
+		return objectStorageReadRange{}, false
+	}
+	return r.reads[len(r.reads)-1], true
+}
+
+func cloneInt64Pointer(v *int64) *int64 {
+	if v == nil {
+		return nil
+	}
+	ret := *v
+	return &ret
+}
+
 func TestS3FS(
 	t *testing.T,
 ) {
@@ -875,6 +915,11 @@ func TestS3FSRangeReadSkipsFullObjectIOMergeBeforeDiskCacheUpdate(t *testing.T) 
 	})
 	assert.Nil(t, err)
 
+	recorder := &readRangeRecordingObjectStorage{
+		ObjectStorage: fs.storage,
+	}
+	fs.storage = recorder
+
 	fullObjectVec := &IOVector{
 		FilePath: "foo/bar",
 		Entries: []IOEntry{
@@ -923,7 +968,16 @@ func TestS3FSRangeReadSkipsFullObjectIOMergeBeforeDiskCacheUpdate(t *testing.T) 
 	case result := <-readDone:
 		assert.Nil(t, result.err)
 		assert.Equal(t, data[123:130], result.data)
+		assert.True(t, fs.ioMerger.IsMerging(fullObjectVec.ioMergeKey()))
 		assert.False(t, fs.diskCache.isUpdating(fs.diskCache.pathForFile("foo/bar")))
+		read, ok := recorder.lastRead()
+		assert.True(t, ok)
+		if assert.NotNil(t, read.min) {
+			assert.Equal(t, int64(123), *read.min)
+		}
+		if assert.NotNil(t, read.max) {
+			assert.Equal(t, int64(130), *read.max)
+		}
 	case <-time.After(2 * time.Second):
 		releaseMerge()
 		result := <-readDone

--- a/pkg/fileservice/s3_fs_test.go
+++ b/pkg/fileservice/s3_fs_test.go
@@ -682,6 +682,63 @@ func TestS3FSFullObjectDiskCacheFillDoesNotRetainWholeObjectBuffer(t *testing.T)
 	hitVec.Release()
 }
 
+func TestS3FSFullObjectDiskCacheFillDoesNotReturnWholeObjectDataWithCachedData(t *testing.T) {
+	ctx := context.Background()
+	var pcSet perfcounter.CounterSet
+	ctx = perfcounter.WithCounterSet(ctx, &pcSet)
+
+	fs, err := NewS3FS(
+		ctx,
+		ObjectStorageArguments{
+			Name:      "s3",
+			Endpoint:  "disk",
+			Bucket:    t.TempDir(),
+			KeyPrefix: time.Now().Format("2006-01-02.15:04:05.000000"),
+		},
+		CacheConfig{
+			DiskPath:     ptrTo(t.TempDir()),
+			DiskCapacity: ptrTo[toml.ByteSize](1 << 30),
+		},
+		nil,
+		false,
+		false,
+	)
+	assert.Nil(t, err)
+	defer fs.Close(ctx)
+
+	data := bytes.Repeat([]byte("abcd"), 1<<18)
+	err = fs.Write(ctx, IOVector{
+		FilePath: "foo/bar",
+		Entries: []IOEntry{
+			{
+				Size: int64(len(data)),
+				Data: data,
+			},
+		},
+		Policy: SkipDiskCache | SkipMemoryCache,
+	})
+	assert.Nil(t, err)
+
+	vec := &IOVector{
+		FilePath: "foo/bar",
+		Entries: []IOEntry{
+			{
+				Size:        int64(len(data)),
+				ToCacheData: CacheOriginalData,
+			},
+		},
+	}
+	err = fs.Read(ctx, vec)
+	assert.Nil(t, err)
+	assert.NotNil(t, vec.Entries[0].CachedData)
+	if vec.Entries[0].CachedData != nil {
+		assert.Equal(t, data, vec.Entries[0].CachedData.Bytes())
+	}
+	assert.Nil(t, vec.Entries[0].Data)
+	assert.Equal(t, int64(1), pcSet.FileService.S3.Get.Load())
+	vec.Release()
+}
+
 func TestS3FSRangeReadSkipsFullObjectDiskCacheUpdate(t *testing.T) {
 	ctx := context.Background()
 	fs, err := NewS3FS(


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24870

## What this PR does / why we need it:
## Summary

- add a short bounded wait before full-file disk cache reads miss while the full-file cache is being updated
- use the same short bound for full-object `IOMerger` waits, then fall back to minimal S3 range read only if the full-object merge is still active
- keep the streaming full-object disk-cache fill from #24759 and release the captured `Data` slice after `CachedData` is produced
- remove the immediate full-object bypass helper path that caused cache reuse loss during warmup

## Root Cause

#24759 correctly fixed RSS pressure by streaming full-object disk cache fill, but the same PR also made concurrent range reads bypass full-object disk-cache update and full-object `IOMerger` immediately. Under TPCC/sysbench warmup this can turn one shared full-object fill into many independent S3 range reads, reducing cache convergence and increasing S3 fan-out.

A full revert to the old unbounded wait was tested in nightly run 26930027366 and made TPCC 1000w load too slow. The bounded-wait probe in nightly run 26935873712 kept the completed sysbench cases clean (`ignored errors: 0`) and let the TPCC job succeed, so this PR keeps the no-long-wait property while restoring a short opportunity for cache reuse.