### PR TITLE
fix: bound LOAD first-line row size sampling

### DIFF
--- a/pkg/sql/plan/build_load.go
+++ b/pkg/sql/plan/build_load.go
@@ -36,8 +36,9 @@ import (
 )
 
 const (
-	LoadParallelMinSize = int(colexec.WriteS3Threshold)
-	LoadWriteS3MinSize  = 1 << 20
+	LoadParallelMinSize     = int(colexec.WriteS3Threshold)
+	LoadWriteS3MinSize      = 1 << 20
+	loadFirstLineSampleSize = 1 << 20
 )
 
 func getNormalExternalProject(stmt *tree.Load, ctx CompilerContext, tableDef *TableDef, tblName string) ([]*Expr, map[string]int32, map[string]int32, *TableDef, error) {
@@ -372,13 +373,13 @@ func estimateLoadRowsizeFromFirstLine(param *tree.ExternParam, inputSize int64, 
 		return 0
 	}
 
-	if size := readExternalFirstLineSize(param, offset, ctx); size > 0 {
+	if size := readExternalFirstLineSize(param, inputSize, offset, ctx); size > 0 {
 		return clampLoadRowsize(float64(size), inputSize)
 	}
 	return 0
 }
 
-func readExternalFirstLineSize(param *tree.ExternParam, offset int64, ctx context.Context) int {
+func readExternalFirstLineSize(param *tree.ExternParam, inputSize int64, offset int64, ctx context.Context) int {
 	if param == nil {
 		return 0
 	}
@@ -386,6 +387,14 @@ func readExternalFirstLineSize(param *tree.ExternParam, offset int64, ctx contex
 		ctx = param.Ctx
 	}
 	if ctx == nil {
+		return 0
+	}
+
+	sampleSize := int64(loadFirstLineSampleSize)
+	if inputSize > 0 && inputSize < sampleSize {
+		sampleSize = inputSize
+	}
+	if sampleSize <= 0 {
 		return 0
 	}
 
@@ -399,7 +408,7 @@ func readExternalFirstLineSize(param *tree.ExternParam, offset int64, ctx contex
 		Entries: []fileservice.IOEntry{
 			0: {
 				Offset:            offset,
-				Size:              -1,
+				Size:              sampleSize,
 				ReadCloserForRead: &r,
 			},
 		},
@@ -415,17 +424,24 @@ func readExternalFirstLineSize(param *tree.ExternParam, offset int64, ctx contex
 	reader := bufio.NewReader(r)
 	if offset == 0 && param.Tail != nil {
 		for i := uint64(0); i < param.Tail.IgnoredLines; i++ {
-			if _, err := reader.ReadString('\n'); err != nil {
+			line, err := reader.ReadString('\n')
+			if err != nil || !strings.HasSuffix(line, "\n") {
 				return 0
 			}
 		}
 	}
 
 	line, err := reader.ReadString('\n')
-	if len(line) == 0 && err != nil {
+	if len(line) == 0 {
 		return 0
 	}
-	return len(line)
+	if strings.HasSuffix(line, "\n") {
+		return len(line)
+	}
+	if err == io.EOF && inputSize > 0 && inputSize <= sampleSize {
+		return len(line)
+	}
+	return 0
 }
 
 func clampLoadRowsize(rowSize float64, inputSize int64) float64 {

--- a/pkg/sql/plan/build_load_parquet_test.go
+++ b/pkg/sql/plan/build_load_parquet_test.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -379,12 +380,13 @@ func TestMakeLoadExternalStatsUsesFirstLineForTextLoad(t *testing.T) {
 	fs, err := fileservice.NewMemoryFS("memory", fileservice.DisabledCacheConfig, nil)
 	require.NoError(t, err)
 	filePath := fileservice.JoinPath(fs.Name(), "wide.csv")
+	data := strings.Repeat("1,2\n", loadFirstLineSampleSize/len("1,2\n")+1)
 	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
 		FilePath: filePath,
 		Entries: []fileservice.IOEntry{{
 			Offset: 0,
-			Size:   int64(len("1,2\n3,4\n")),
-			Data:   []byte("1,2\n3,4\n"),
+			Size:   int64(len(data)),
+			Data:   []byte(data),
 		}},
 	}))
 
@@ -418,12 +420,13 @@ func TestMakeLoadExternalStatsUsesFirstLineForTextLoad(t *testing.T) {
 	}, false, false))
 
 	crlfPath := fileservice.JoinPath(fs.Name(), "crlf.csv")
+	crlfData := strings.Repeat("1,2\r\n", loadFirstLineSampleSize/len("1,2\r\n")+1)
 	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
 		FilePath: crlfPath,
 		Entries: []fileservice.IOEntry{{
 			Offset: 0,
-			Size:   int64(len("1,2\r\n3,4\r\n")),
-			Data:   []byte("1,2\r\n3,4\r\n"),
+			Size:   int64(len(crlfData)),
+			Data:   []byte(crlfData),
 		}},
 	}))
 	stats = makeLoadExternalStats(&tree.ExternParam{
@@ -445,12 +448,13 @@ func TestMakeLoadExternalStatsUsesFirstLineForTextLoad(t *testing.T) {
 	require.Equal(t, float64(5), stats.Rowsize)
 
 	ignoredPath := fileservice.JoinPath(fs.Name(), "ignored.csv")
+	ignoredData := "long_header_value\n" + strings.Repeat("1,2\n", loadFirstLineSampleSize/len("1,2\n")+1)
 	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
 		FilePath: ignoredPath,
 		Entries: []fileservice.IOEntry{{
 			Offset: 0,
-			Size:   int64(len("long_header_value\n1,2\n3,4\n")),
-			Data:   []byte("long_header_value\n1,2\n3,4\n"),
+			Size:   int64(len(ignoredData)),
+			Data:   []byte(ignoredData),
 		}},
 	}))
 	stats = makeLoadExternalStats(&tree.ExternParam{
@@ -501,6 +505,104 @@ func TestMakeLoadExternalStatsUsesFirstLineForTextLoad(t *testing.T) {
 		},
 	}, tableDef, 0, context.Background())
 	require.Equal(t, schemaRowSize, stats.Rowsize)
+}
+
+func TestMakeLoadExternalStatsUsesBoundedFirstLineSample(t *testing.T) {
+	ctx := context.Background()
+	fs, err := fileservice.NewMemoryFS("memory", fileservice.DisabledCacheConfig, nil)
+	require.NoError(t, err)
+	filePath := fileservice.JoinPath(fs.Name(), "long-row.csv")
+	data := strings.Repeat("a", loadFirstLineSampleSize+128)
+	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
+		FilePath: filePath,
+		Entries: []fileservice.IOEntry{{
+			Offset: 0,
+			Size:   int64(len(data)),
+			Data:   []byte(data),
+		}},
+	}))
+
+	tableDef := &TableDef{
+		Cols: []*ColDef{
+			{Name: "a", Typ: Type{Id: int32(types.T_int32)}},
+			{Name: "b", Typ: Type{Id: int32(types.T_varchar), Width: 96}},
+		},
+	}
+	schemaRowSize := GetRowSizeFromTableDef(tableDef, true) * 0.8
+	stats := makeLoadExternalStats(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{
+			Filepath: filePath,
+			FileSize: int64(len(data)),
+			Format:   tree.CSV,
+		},
+		ExParam: tree.ExParam{
+			FileService: fs,
+			Ctx:         ctx,
+		},
+	}, tableDef, 0, ctx)
+
+	require.Equal(t, schemaRowSize, stats.Rowsize)
+	requireLoadByteHint(t, stats, int64(len(data)))
+}
+
+func TestReadExternalFirstLineSizeUsesBoundedRange(t *testing.T) {
+	ctx := context.Background()
+	fs, err := fileservice.NewMemoryFS("memory", fileservice.DisabledCacheConfig, nil)
+	require.NoError(t, err)
+	filePath := fileservice.JoinPath(fs.Name(), "with-newline.csv")
+	data := "abcd\n" + strings.Repeat("x", loadFirstLineSampleSize+128)
+	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
+		FilePath: filePath,
+		Entries: []fileservice.IOEntry{{
+			Offset: 0,
+			Size:   int64(len(data)),
+			Data:   []byte(data),
+		}},
+	}))
+
+	size := readExternalFirstLineSize(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{
+			Filepath: filePath,
+			FileSize: int64(len(data)),
+			Format:   tree.CSV,
+		},
+		ExParam: tree.ExParam{
+			FileService: fs,
+			Ctx:         ctx,
+		},
+	}, int64(len(data)), 0, ctx)
+
+	require.Equal(t, len("abcd\n"), size)
+}
+
+func TestReadExternalFirstLineSizeUsesSmallFileWithoutTrailingNewline(t *testing.T) {
+	ctx := context.Background()
+	fs, err := fileservice.NewMemoryFS("memory", fileservice.DisabledCacheConfig, nil)
+	require.NoError(t, err)
+	filePath := fileservice.JoinPath(fs.Name(), "small.csv")
+	data := "abcd"
+	require.NoError(t, fs.Write(ctx, fileservice.IOVector{
+		FilePath: filePath,
+		Entries: []fileservice.IOEntry{{
+			Offset: 0,
+			Size:   int64(len(data)),
+			Data:   []byte(data),
+		}},
+	}))
+
+	size := readExternalFirstLineSize(&tree.ExternParam{
+		ExParamConst: tree.ExParamConst{
+			Filepath: filePath,
+			FileSize: int64(len(data)),
+			Format:   tree.CSV,
+		},
+		ExParam: tree.ExParam{
+			FileService: fs,
+			Ctx:         ctx,
+		},
+	}, int64(len(data)), 0, ctx)
+
+	require.Equal(t, len(data), size)
 }
 
 func requireLoadByteHint(t *testing.T, stats *Stats, inputSize int64) {

--- a/pkg/sql/plan/build_load_parquet_test.go
+++ b/pkg/sql/plan/build_load_parquet_test.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -24,7 +25,9 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	pbplan "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/options"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,6 +38,15 @@ type parquetLoadTestCtx struct {
 
 func (c parquetLoadTestCtx) GetContext() context.Context {
 	return c.ctx
+}
+
+type externalStatsTestCtx struct {
+	*MockCompilerContext
+	proc *process.Process
+}
+
+func (c externalStatsTestCtx) GetProcess() *process.Process {
+	return c.proc
 }
 
 func TestValidateLoadParquetOptionsRejectsUnsupportedOptions(t *testing.T) {
@@ -603,6 +615,54 @@ func TestReadExternalFirstLineSizeUsesSmallFileWithoutTrailingNewline(t *testing
 	}, int64(len(data)), 0, ctx)
 
 	require.Equal(t, len(data), size)
+}
+
+func TestGetExternalStatsUsesKnownFileSizeForSmallFile(t *testing.T) {
+	ctx := context.Background()
+	proc := testutil.NewProcess(t)
+	filePath := "etl:/small.csv"
+	data := "abcd"
+	require.NoError(t, proc.GetFileService().Write(ctx, fileservice.IOVector{
+		FilePath: filePath,
+		Entries: []fileservice.IOEntry{{
+			Offset: 0,
+			Size:   int64(len(data)),
+			Data:   []byte(data),
+		}},
+	}))
+
+	builder := NewQueryBuilder(pbplan.Query_SELECT, externalStatsTestCtx{
+		MockCompilerContext: &MockCompilerContext{ctx: ctx},
+		proc:                proc,
+	}, false, false)
+	node := &pbplan.Node{
+		NodeType: pbplan.Node_EXTERNAL_SCAN,
+		ExternScan: &pbplan.ExternScan{
+			Type: int32(pbplan.ExternType_EXTERNAL_TB),
+		},
+		TableDef: &pbplan.TableDef{
+			Createsql: mustMarshalExternParam(t, &tree.ExternParam{
+				ExParamConst: tree.ExParamConst{
+					Option: []string{
+						"filepath", filePath,
+						"format", tree.CSV,
+					},
+				},
+			}),
+		},
+	}
+
+	stats := getExternalStats(node, builder)
+
+	require.Equal(t, float64(len(data)), stats.Rowsize)
+	require.Equal(t, float64(1), stats.Outcnt)
+}
+
+func mustMarshalExternParam(t *testing.T, param *tree.ExternParam) string {
+	t.Helper()
+	data, err := json.Marshal(param)
+	require.NoError(t, err)
+	return string(data)
 }
 
 func requireLoadByteHint(t *testing.T, stats *Stats, inputSize int64) {

--- a/pkg/sql/plan/external.go
+++ b/pkg/sql/plan/external.go
@@ -217,7 +217,7 @@ func getExternalStats(node *plan.Node, builder *QueryBuilder) *Stats {
 		return DefaultStats()
 	}
 
-	size := readExternalFirstLineSize(param, 0, param.Ctx)
+	size := readExternalFirstLineSize(param, 0, 0, param.Ctx)
 	if size == 0 {
 		return DefaultHugeStats()
 	}

--- a/pkg/sql/plan/external.go
+++ b/pkg/sql/plan/external.go
@@ -217,7 +217,7 @@ func getExternalStats(node *plan.Node, builder *QueryBuilder) *Stats {
 		return DefaultStats()
 	}
 
-	size := readExternalFirstLineSize(param, 0, 0, param.Ctx)
+	size := readExternalFirstLineSize(param, totalLoadFileSize(fileSize), 0, param.Ctx)
 	if size == 0 {
 		return DefaultHugeStats()
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue https://github.com/matrixorigin/matrixone/pull/24855

## What this PR does / why we need it:

After #24855, LOAD stats estimate row size from the first data line. For the TPCH 1T `lineitem` load on TKE/COS, the planner opened the object with `Size: -1` and then closed the reader after reading the first line. That made the plan stage spend a long time draining/closing a huge object stream before execution could start.

This PR keeps the cardinality fix from #24855 while making the first-line read bounded. It:

- Bounds LOAD first-line row-size sampling to 1MiB instead of reading the rest of the object.
- Falls back to schema-based row size when no complete line is found in the bounded sample.
- Keeps closing the bounded reader and routes generic external stats through the same bounded helper.
- Adds coverage for long rows without a newline in the sample, bounded reads with a newline, and small files without a trailing newline.

Tests:

- `git diff --check`
- `go test ./pkg/sql/plan -run 'TestMakeLoadExternalStats|TestReadExternalFirstLineSize|TestLoadParquetMayListFiles|TestTotalLoadFileSize' -count=1`