### PR TITLE
fix(plan): dedup update from source matches (cherry-pick #24932)

### DIFF
--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -1021,7 +1021,6 @@ func (builder *QueryBuilder) appendUpdateFromDedupNode(
 		GroupBy:     groupByExprs,
 		AggList:     aggList,
 		BindingTags: []int32{groupTag, aggregateTag},
-		SpillMem:    builder.aggSpillMem,
 	}
 	lastNodeID = builder.appendNode(aggNode, bindCtx)
 

--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -200,6 +200,13 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 
 	selectNode := builder.qry.Nodes[lastNodeID]
 	selectNodeTag := selectNode.BindingTags[0]
+	if stmt.From != nil && len(stmt.From.Tables) > 0 {
+		lastNodeID, selectNode, selectNodeTag, err = builder.appendUpdateFromDedupNode(
+			bindCtx, lastNodeID, selectNode, selectNodeTag, dmlCtx, oldColName2Idx, newColName2Idx)
+		if err != nil {
+			return 0, err
+		}
+	}
 
 	for i, alias := range dmlCtx.aliases {
 		if len(dmlCtx.updateCol2Expr[i]) == 0 {
@@ -906,4 +913,124 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 	lastNodeID = builder.appendNode(dmlNode, bindCtx)
 
 	return lastNodeID, err
+}
+
+func (builder *QueryBuilder) appendUpdateFromDedupNode(
+	bindCtx *BindContext,
+	lastNodeID int32,
+	selectNode *plan.Node,
+	selectNodeTag int32,
+	dmlCtx *DMLContext,
+	oldColName2Idx map[string]int32,
+	newColName2Idx map[string]int32,
+) (int32, *plan.Node, int32, error) {
+	groupByExprs := make([]*plan.Expr, 0)
+	aggList := make([]*plan.Expr, 0)
+	groupPos := make(map[int32]int32)
+	aggPos := make(map[int32]int32)
+	groupTag := builder.genNewBindTag()
+	aggregateTag := builder.genNewBindTag()
+
+	childColExpr := func(pos int32) *plan.Expr {
+		e := selectNode.ProjectList[pos]
+		name := ""
+		if col, ok := e.Expr.(*plan.Expr_Col); ok {
+			name = col.Col.Name
+		}
+		return &plan.Expr{
+			Typ: e.Typ,
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{
+					RelPos: selectNodeTag,
+					ColPos: pos,
+					Name:   name,
+				},
+			},
+		}
+	}
+
+	for i, alias := range dmlCtx.aliases {
+		if len(dmlCtx.updateCol2Expr[i]) == 0 {
+			continue
+		}
+
+		for _, col := range dmlCtx.tableDefs[i].Cols {
+			key := alias + "." + col.Name
+			oldPos, ok := oldColName2Idx[key]
+			if !ok {
+				continue
+			}
+			if _, exists := groupPos[oldPos]; !exists {
+				groupPos[oldPos] = int32(len(groupByExprs))
+				groupByExprs = append(groupByExprs, childColExpr(oldPos))
+			}
+
+			updatePos, ok := newColName2Idx[key]
+			if !ok {
+				continue
+			}
+			if _, exists := aggPos[updatePos]; exists {
+				continue
+			}
+			aggExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "any_value", []*plan.Expr{childColExpr(updatePos)})
+			if err != nil {
+				return 0, nil, 0, err
+			}
+			aggPos[updatePos] = int32(len(aggList))
+			aggList = append(aggList, aggExpr)
+		}
+	}
+
+	projectList := make([]*plan.Expr, len(selectNode.ProjectList))
+	for pos, e := range selectNode.ProjectList {
+		colPos := int32(pos)
+		relPos := groupTag
+		if aggColPos, ok := aggPos[colPos]; ok {
+			colPos = aggColPos
+			relPos = aggregateTag
+		} else if groupColPos, ok := groupPos[colPos]; ok {
+			colPos = groupColPos
+		} else {
+			aggExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "any_value", []*plan.Expr{childColExpr(int32(pos))})
+			if err != nil {
+				return 0, nil, 0, err
+			}
+			colPos = int32(len(aggList))
+			relPos = aggregateTag
+			aggList = append(aggList, aggExpr)
+		}
+		name := ""
+		if col, ok := e.Expr.(*plan.Expr_Col); ok {
+			name = col.Col.Name
+		}
+		projectList[pos] = &plan.Expr{
+			Typ: e.Typ,
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{
+					RelPos: relPos,
+					ColPos: colPos,
+					Name:   name,
+				},
+			},
+		}
+	}
+
+	aggNode := &plan.Node{
+		NodeType:    plan.Node_AGG,
+		Children:    []int32{lastNodeID},
+		GroupBy:     groupByExprs,
+		AggList:     aggList,
+		BindingTags: []int32{groupTag, aggregateTag},
+		SpillMem:    builder.aggSpillMem,
+	}
+	lastNodeID = builder.appendNode(aggNode, bindCtx)
+
+	projectNode := &plan.Node{
+		NodeType:    plan.Node_PROJECT,
+		Children:    []int32{lastNodeID},
+		ProjectList: projectList,
+		BindingTags: []int32{builder.genNewBindTag()},
+	}
+	lastNodeID = builder.appendNode(projectNode, bindCtx)
+	return lastNodeID, projectNode, projectNode.BindingTags[0], nil
 }

--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -200,13 +200,6 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 
 	selectNode := builder.qry.Nodes[lastNodeID]
 	selectNodeTag := selectNode.BindingTags[0]
-	if stmt.From != nil && len(stmt.From.Tables) > 0 {
-		lastNodeID, selectNode, selectNodeTag, err = builder.appendUpdateFromDedupNode(
-			bindCtx, lastNodeID, selectNode, selectNodeTag, dmlCtx, oldColName2Idx, newColName2Idx)
-		if err != nil {
-			return 0, err
-		}
-	}
 
 	for i, alias := range dmlCtx.aliases {
 		if len(dmlCtx.updateCol2Expr[i]) == 0 {
@@ -267,6 +260,14 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 					return 0, err
 				}
 			}
+		}
+	}
+
+	if stmt.From != nil && len(stmt.From.Tables) > 0 {
+		lastNodeID, selectNode, selectNodeTag, err = builder.appendUpdateFromDedupNode(
+			bindCtx, lastNodeID, selectNode, selectNodeTag, dmlCtx, oldColName2Idx, newColName2Idx)
+		if err != nil {
+			return 0, err
 		}
 	}
 

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -733,6 +733,128 @@ func TestUpdatePgStyleFromDedupsDuplicateSourceMatchesOnNewPath(t *testing.T) {
 	t.Fatalf("UPDATE FROM should dedup duplicate source matches with AGG any_value over update columns")
 }
 
+func TestUpdatePgStyleFromDedupExpandsDefaultBeforeAnyValue(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	setMockDefaultExpr(t, mock, "nation", "n_name", "name-default")
+
+	logicPlan, err := runOneStmt(mock, t,
+		"UPDATE NATION SET N_NAME = DEFAULT FROM NATION2 WHERE NATION.N_REGIONKEY = NATION2.R_REGIONKEY")
+	if err != nil {
+		t.Fatalf("build UPDATE FROM with DEFAULT: %v", err)
+	}
+
+	for _, node := range logicPlan.GetQuery().Nodes {
+		if node.NodeType != plan.Node_AGG {
+			continue
+		}
+		for _, aggExpr := range node.AggList {
+			if exprContainsDefaultVal(aggExpr) {
+				t.Fatalf("dedup any_value should not wrap raw DEFAULT marker: %v", aggExpr)
+			}
+			if fn := aggExpr.GetF(); fn != nil && fn.Func.ObjName == "any_value" &&
+				exprContainsStringLiteral(aggExpr, "name-default") {
+				return
+			}
+		}
+	}
+	t.Fatalf("UPDATE FROM dedup should aggregate the expanded DEFAULT expression")
+}
+
+func TestUpdatePgStyleFromDedupAllowsVectorUpdateColumn(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	vecTyp := plan.Type{Id: int32(types.T_array_float32), Width: 4}
+	setMockColumnType(t, mock, "nation", "n_comment", vecTyp)
+	setMockColumnType(t, mock, "nation2", "n_comment", vecTyp)
+
+	_, err := runOneStmt(mock, t,
+		"UPDATE NATION SET N_COMMENT = NATION2.N_COMMENT FROM NATION2 WHERE NATION.N_REGIONKEY = NATION2.R_REGIONKEY")
+	if err != nil {
+		t.Fatalf("UPDATE FROM should allow vector update columns through any_value dedup: %v", err)
+	}
+}
+
+func setMockDefaultExpr(t *testing.T, mock *MockOptimizer, tableName, colName, value string) {
+	col := requireMockColumn(t, mock, tableName, colName)
+	col.Default = &plan.Default{
+		Expr:         makeStringConstExpr(col.Typ, value),
+		OriginString: value,
+		NullAbility:  true,
+	}
+}
+
+func setMockColumnType(t *testing.T, mock *MockOptimizer, tableName, colName string, typ plan.Type) {
+	col := requireMockColumn(t, mock, tableName, colName)
+	col.Typ = typ
+}
+
+func requireMockColumn(t *testing.T, mock *MockOptimizer, tableName, colName string) *ColDef {
+	tableDef := mock.ctxt.tables[tableName]
+	if tableDef == nil {
+		t.Fatalf("missing mock table %s", tableName)
+	}
+	for _, col := range tableDef.Cols {
+		if col.Name == colName {
+			return col
+		}
+	}
+	t.Fatalf("missing mock column %s.%s", tableName, colName)
+	return nil
+}
+
+func makeStringConstExpr(typ plan.Type, value string) *plan.Expr {
+	return &plan.Expr{
+		Typ: typ,
+		Expr: &plan.Expr_Lit{
+			Lit: &plan.Literal{
+				Value: &plan.Literal_Sval{Sval: value},
+			},
+		},
+	}
+}
+
+func exprContainsStringLiteral(expr *plan.Expr, value string) bool {
+	switch e := expr.Expr.(type) {
+	case *plan.Expr_Lit:
+		if sval, ok := e.Lit.Value.(*plan.Literal_Sval); ok {
+			return sval.Sval == value
+		}
+	case *plan.Expr_F:
+		for _, arg := range e.F.Args {
+			if exprContainsStringLiteral(arg, value) {
+				return true
+			}
+		}
+	case *plan.Expr_List:
+		for _, item := range e.List.List {
+			if exprContainsStringLiteral(item, value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func exprContainsDefaultVal(expr *plan.Expr) bool {
+	switch e := expr.Expr.(type) {
+	case *plan.Expr_Lit:
+		_, ok := e.Lit.Value.(*plan.Literal_Defaultval)
+		return ok
+	case *plan.Expr_F:
+		for _, arg := range e.F.Args {
+			if exprContainsDefaultVal(arg) {
+				return true
+			}
+		}
+	case *plan.Expr_List:
+		for _, item := range e.List.List {
+			if exprContainsDefaultVal(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func TestDelete(t *testing.T) {
 	mock := NewMockOptimizer(true)
 	// should pass

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -773,6 +773,37 @@ func TestUpdatePgStyleFromDedupAllowsVectorUpdateColumn(t *testing.T) {
 	}
 }
 
+func TestUpdatePgStyleFromDedupAllowsDecimal256AndEnumUpdateColumns(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  plan.Type
+		sql  string
+	}{
+		{
+			name: "decimal256",
+			typ:  plan.Type{Id: int32(types.T_decimal256), Width: 65, Scale: 30},
+			sql:  "UPDATE NATION SET N_COMMENT = 1.23 FROM NATION2 WHERE NATION.N_REGIONKEY = NATION2.R_REGIONKEY",
+		},
+		{
+			name: "enum",
+			typ:  plan.Type{Id: int32(types.T_enum), Enumvalues: "small,medium,large"},
+			sql:  "UPDATE NATION SET N_COMMENT = 'small' FROM NATION2 WHERE NATION.N_REGIONKEY = NATION2.R_REGIONKEY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := NewMockOptimizer(true)
+			setMockColumnType(t, mock, "nation", "n_comment", tt.typ)
+
+			_, err := runOneStmt(mock, t, tt.sql)
+			if err != nil {
+				t.Fatalf("UPDATE FROM should allow %s update columns through any_value dedup: %v", tt.name, err)
+			}
+		})
+	}
+}
+
 func setMockDefaultExpr(t *testing.T, mock *MockOptimizer, tableName, colName, value string) {
 	col := requireMockColumn(t, mock, tableName, colName)
 	col.Default = &plan.Default{

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -709,6 +709,30 @@ func TestUpdate(t *testing.T) {
 	runTestShouldError(mock, t, sqls)
 }
 
+func TestUpdatePgStyleFromDedupsDuplicateSourceMatchesOnNewPath(t *testing.T) {
+	mock := NewMockOptimizer(true)
+
+	logicPlan, err := runOneStmt(mock, t,
+		"UPDATE NATION SET N_NAME = NATION2.N_NAME FROM NATION2 WHERE NATION.N_REGIONKEY = NATION2.R_REGIONKEY")
+	if err != nil {
+		t.Fatalf("build UPDATE FROM plan: %v", err)
+	}
+
+	tableDef := mock.ctxt.tables["nation"]
+	for _, node := range logicPlan.GetQuery().Nodes {
+		if node.NodeType != plan.Node_AGG {
+			continue
+		}
+		if len(node.GroupBy) != len(tableDef.Cols) || len(node.AggList) != 1 {
+			continue
+		}
+		if fn := node.AggList[0].GetF(); fn != nil && fn.Func.ObjName == "any_value" {
+			return
+		}
+	}
+	t.Fatalf("UPDATE FROM should dedup duplicate source matches with AGG any_value over update columns")
+}
+
 func TestDelete(t *testing.T) {
 	mock := NewMockOptimizer(true)
 	// should pass

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -782,12 +782,12 @@ func TestUpdatePgStyleFromDedupAllowsDecimal256AndEnumUpdateColumns(t *testing.T
 		{
 			name: "decimal256",
 			typ:  plan.Type{Id: int32(types.T_decimal256), Width: 65, Scale: 30},
-			sql:  "UPDATE NATION SET N_COMMENT = 1.23 FROM NATION2 WHERE NATION.N_REGIONKEY = NATION2.R_REGIONKEY",
+			sql:  "UPDATE NATION SET N_COMMENT = REGION.R_COMMENT FROM REGION WHERE NATION.N_REGIONKEY = REGION.R_REGIONKEY",
 		},
 		{
 			name: "enum",
 			typ:  plan.Type{Id: int32(types.T_enum), Enumvalues: "small,medium,large"},
-			sql:  "UPDATE NATION SET N_COMMENT = 'small' FROM NATION2 WHERE NATION.N_REGIONKEY = NATION2.R_REGIONKEY",
+			sql:  "UPDATE NATION SET N_COMMENT = CASE WHEN 1 > 0 THEN 'small' ELSE 'medium' END FROM REGION WHERE NATION.N_REGIONKEY = REGION.R_REGIONKEY",
 		},
 	}
 
@@ -795,6 +795,7 @@ func TestUpdatePgStyleFromDedupAllowsDecimal256AndEnumUpdateColumns(t *testing.T
 		t.Run(tt.name, func(t *testing.T) {
 			mock := NewMockOptimizer(true)
 			setMockColumnType(t, mock, "nation", "n_comment", tt.typ)
+			setMockColumnType(t, mock, "region", "r_comment", tt.typ)
 
 			_, err := runOneStmt(mock, t, tt.sql)
 			if err != nil {

--- a/pkg/sql/plan/function/agg/any_value.go
+++ b/pkg/sql/plan/function/agg/any_value.go
@@ -146,6 +146,8 @@ var AnyValueSupportedTypes = []types.T{
 	types.T_varchar, types.T_char, types.T_blob, types.T_text, types.T_datalink,
 	types.T_uuid,
 	types.T_binary, types.T_varbinary, types.T_json,
+	types.T_array_float32, types.T_array_float64,
+	types.T_geometry, types.T_geometry32,
 	types.T_Rowid,
 }
 

--- a/pkg/sql/plan/function/agg/any_value.go
+++ b/pkg/sql/plan/function/agg/any_value.go
@@ -147,7 +147,7 @@ var AnyValueSupportedTypes = []types.T{
 	types.T_uuid,
 	types.T_binary, types.T_varbinary, types.T_json,
 	types.T_array_float32, types.T_array_float64,
-	types.T_geometry, types.T_geometry32,
+	types.T_geometry,
 	types.T_enum,
 	types.T_Rowid,
 }

--- a/pkg/sql/plan/function/agg/any_value.go
+++ b/pkg/sql/plan/function/agg/any_value.go
@@ -140,7 +140,7 @@ var AnyValueSupportedTypes = []types.T{
 	types.T_float32, types.T_float64,
 	types.T_date, types.T_datetime,
 	types.T_timestamp, types.T_time,
-	types.T_decimal64, types.T_decimal128,
+	types.T_decimal64, types.T_decimal128, types.T_decimal256,
 	types.T_bool,
 	types.T_bit,
 	types.T_varchar, types.T_char, types.T_blob, types.T_text, types.T_datalink,
@@ -148,6 +148,7 @@ var AnyValueSupportedTypes = []types.T{
 	types.T_binary, types.T_varbinary, types.T_json,
 	types.T_array_float32, types.T_array_float64,
 	types.T_geometry, types.T_geometry32,
+	types.T_enum,
 	types.T_Rowid,
 }
 

--- a/test/distributed/cases/dml/update/update_pg_style_from.result
+++ b/test/distributed/cases/dml/update/update_pg_style_from.result
@@ -166,6 +166,28 @@ id    p_id    v
 DROP TABLE dup_t;
 DROP TABLE dup_p;
 DROP TABLE dup_s;
+DROP TABLE IF EXISTS dup_no_fk_t;
+DROP TABLE IF EXISTS dup_no_fk_s;
+CREATE TABLE dup_no_fk_t (
+id INT PRIMARY KEY,
+v VARCHAR(20)
+);
+CREATE TABLE dup_no_fk_s (
+t_id INT,
+v VARCHAR(20)
+);
+INSERT INTO dup_no_fk_t VALUES (1, 'orig'), (2, 'orig');
+INSERT INTO dup_no_fk_s VALUES (1, 'first'), (1, 'second'), (2, 'only');
+UPDATE dup_no_fk_t SET v = s.v FROM dup_no_fk_s s WHERE s.t_id = dup_no_fk_t.id;
+SELECT COUNT(*) AS row_cnt, COUNT(DISTINCT id) AS id_cnt FROM dup_no_fk_t;
+➤ row_cnt[-5,64,0]  ¦  id_cnt[-5,64,0]  𝄀
+2  ¦  2
+SELECT id, COUNT(*) AS per_id_cnt FROM dup_no_fk_t GROUP BY id ORDER BY id;
+➤ id[4,32,0]  ¦  per_id_cnt[-5,64,0]  𝄀
+1  ¦  1  𝄀
+2  ¦  1
+DROP TABLE dup_no_fk_t;
+DROP TABLE dup_no_fk_s;
 DROP TABLE IF EXISTS company;
 DROP TABLE IF EXISTS vec_join_case;
 DROP TABLE IF EXISTS region;

--- a/test/distributed/cases/dml/update/update_pg_style_from.result
+++ b/test/distributed/cases/dml/update/update_pg_style_from.result
@@ -186,6 +186,9 @@ SELECT id, COUNT(*) AS per_id_cnt FROM dup_no_fk_t GROUP BY id ORDER BY id;
 ➤ id[4,32,0]  ¦  per_id_cnt[-5,64,0]  𝄀
 1  ¦  1  𝄀
 2  ¦  1
+SELECT v FROM dup_no_fk_t WHERE id = 2;
+➤ v[12,-1,0]  𝄀
+only
 DROP TABLE dup_no_fk_t;
 DROP TABLE dup_no_fk_s;
 DROP TABLE IF EXISTS company;

--- a/test/distributed/cases/dml/update/update_pg_style_from.sql
+++ b/test/distributed/cases/dml/update/update_pg_style_from.sql
@@ -166,6 +166,26 @@ DROP TABLE dup_t;
 DROP TABLE dup_p;
 DROP TABLE dup_s;
 
+-- Duplicate-match on the new UPDATE path without FK constraints must still
+-- update each target row once instead of producing duplicate primary keys.
+DROP TABLE IF EXISTS dup_no_fk_t;
+DROP TABLE IF EXISTS dup_no_fk_s;
+CREATE TABLE dup_no_fk_t (
+    id INT PRIMARY KEY,
+    v VARCHAR(20)
+);
+CREATE TABLE dup_no_fk_s (
+    t_id INT,
+    v VARCHAR(20)
+);
+INSERT INTO dup_no_fk_t VALUES (1, 'orig'), (2, 'orig');
+INSERT INTO dup_no_fk_s VALUES (1, 'first'), (1, 'second'), (2, 'only');
+UPDATE dup_no_fk_t SET v = s.v FROM dup_no_fk_s s WHERE s.t_id = dup_no_fk_t.id;
+SELECT COUNT(*) AS row_cnt, COUNT(DISTINCT id) AS id_cnt FROM dup_no_fk_t;
+SELECT id, COUNT(*) AS per_id_cnt FROM dup_no_fk_t GROUP BY id ORDER BY id;
+DROP TABLE dup_no_fk_t;
+DROP TABLE dup_no_fk_s;
+
 DROP TABLE IF EXISTS company;
 DROP TABLE IF EXISTS vec_join_case;
 DROP TABLE IF EXISTS region;

--- a/test/distributed/cases/dml/update/update_pg_style_from.sql
+++ b/test/distributed/cases/dml/update/update_pg_style_from.sql
@@ -183,6 +183,7 @@ INSERT INTO dup_no_fk_s VALUES (1, 'first'), (1, 'second'), (2, 'only');
 UPDATE dup_no_fk_t SET v = s.v FROM dup_no_fk_s s WHERE s.t_id = dup_no_fk_t.id;
 SELECT COUNT(*) AS row_cnt, COUNT(DISTINCT id) AS id_cnt FROM dup_no_fk_t;
 SELECT id, COUNT(*) AS per_id_cnt FROM dup_no_fk_t GROUP BY id ORDER BY id;
+SELECT v FROM dup_no_fk_t WHERE id = 2;
 DROP TABLE dup_no_fk_t;
 DROP TABLE dup_no_fk_s;
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23137

## What this PR does / why we need it:

Cherry-pick of #24932 to `3.0-dev`.

This PR fixes the PostgreSQL-style `UPDATE ... SET ... FROM ... WHERE ...` path when duplicate source rows match the same target row on tables without FK constraints.

The new UPDATE path previously fed duplicate joined rows directly into the update pipeline, which could materialize duplicate primary-key rows for one target row. This change adds a planner-side dedup step for `UPDATE ... FROM`: group by the target row's original columns and use `any_value()` for updated columns, matching the existing fallback path behavior.

3.0-dev adaptation:

- Removed the `SpillMem` field initialization from the new AGG node because `3.0-dev` does not have `plan.Node.SpillMem` or `QueryBuilder.aggSpillMem`.

Tested with:

- `git diff --check`
- `go test ./pkg/sql/plan -run TestUpdatePgStyleFromDedupsDuplicateSourceMatchesOnNewPath -count=1`
