### PR TITLE
3.0: fix data branch create table clone SQL

### DIFF
--- a/pkg/frontend/clone.go
+++ b/pkg/frontend/clone.go
@@ -17,7 +17,7 @@ package frontend
 import (
 	"context"
 	"fmt"
-	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,7 +27,6 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/objectio"
 	plan2 "github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
-	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan"
@@ -126,6 +125,39 @@ func resolveSnapshot(
 	}
 
 	return snapshot, nil
+}
+
+func newMoTimestampHint(snapshotTS int64) *tree.AtTimeStamp {
+	origin := strconv.FormatInt(snapshotTS, 10)
+	return &tree.AtTimeStamp{
+		Type: tree.ATMOTIMESTAMP,
+		Expr: tree.NewNumVal[int64](snapshotTS, origin, false, tree.P_int64),
+	}
+}
+
+func cloneTableRestoreSQL(stmt *tree.CloneTable, snapshotTS int64) string {
+	restoreStmt := *stmt
+	restoreStmt.ToAccountOpt = nil
+	if snapshotTS != 0 {
+		restoreStmt.SrcTable.AtTsExpr = newMoTimestampHint(snapshotTS)
+	}
+	return tree.StringWithOpts(
+		&restoreStmt,
+		dialect.MYSQL,
+		tree.WithQuoteIdentifier(),
+		tree.WithSingleQuoteString(),
+	)
+}
+
+func newQualifiedCloneTableName(dbName, tblName string, atTsExpr *tree.AtTimeStamp) tree.TableName {
+	return *tree.NewTableName(
+		tree.Identifier(tblName),
+		tree.ObjectNamePrefix{
+			SchemaName:     tree.Identifier(dbName),
+			ExplicitSchema: true,
+		},
+		atTsExpr,
+	)
 }
 
 func getOpAndToAccountId(
@@ -261,11 +293,7 @@ func handleCloneTable(
 
 	ctx = defines.AttachAccountId(reqCtx, toAccountId)
 
-	sql := execCtx.input.sql
-	if stmt.ToAccountOpt != nil {
-		// create table to account x
-		sql, _, _ = strings.Cut(strings.ToLower(sql), " to account ")
-	}
+	var sql string
 
 	if snapshot == nil {
 		if snapshotTS, err = tryToIncreaseTxnPhysicalTS(
@@ -273,10 +301,8 @@ func handleCloneTable(
 		); err != nil {
 			return
 		}
-
-		sql, _ = strings.CutSuffix(sql, ";")
-		sql = sql + fmt.Sprintf(" {MO_TS = %d}", snapshotTS)
 	}
+	sql = cloneTableRestoreSQL(stmt, snapshotTS)
 
 	if err = bh.ExecRestore(ctx, sql, opAccountId, toAccountId); err != nil {
 		return
@@ -300,8 +326,6 @@ func handleCloneTable(
 
 	return
 }
-
-var snapConditionRegex = regexp.MustCompile(`\{[^}]+}`)
 
 // create database x clone y {MO_TS, SNAPSHOT}
 // create database x clone y {MO_TS, SNAPSHOT} to account t
@@ -327,10 +351,9 @@ func handleCloneDatabase(
 
 		viewMap = make(map[string]*tableInfo)
 
-		sortedViews   []string
-		sortedFkTbls  []string
-		fkTableMap    map[string]*tableInfo
-		snapCondition string
+		sortedViews  []string
+		sortedFkTbls []string
+		fkTableMap   map[string]*tableInfo
 
 		snapshotTS int64
 		subMeta    *plan2.SubscriptionMeta
@@ -404,8 +427,6 @@ func handleCloneDatabase(
 		return
 	}
 
-	snapCondition = snapConditionRegex.FindString(execCtx.input.sql)
-
 	if sortedFkTbls, err = fkTablesTopoSort(
 		reqCtx, bh, snapshot, srcDBName, "",
 	); err != nil {
@@ -418,7 +439,7 @@ func handleCloneDatabase(
 		return
 	}
 
-	if len(snapCondition) == 0 {
+	if stmt.AtTsExpr == nil {
 		// consider the following example:
 		// (within a session)
 		//   ...
@@ -439,40 +460,30 @@ func handleCloneDatabase(
 	}
 
 	cloneTable := func(dstDb, dstTbl, srcDb, srcTbl string) error {
-		sql := fmt.Sprintf(
-			"create table `%s`.`%s` clone `%s`.`%s`",
-			dstDb, dstTbl, srcDb, srcTbl,
-		)
-
-		if len(snapCondition) != 0 {
-			sql = sql + " " + snapCondition
-		} else {
-			sql = sql + fmt.Sprintf(" {MO_TS = %d}", snapshotTS)
+		srcTable := newQualifiedCloneTableName(srcDb, srcTbl, stmt.AtTsExpr)
+		if stmt.AtTsExpr == nil && snapshotTS != 0 {
+			srcTable.AtTsExpr = newMoTimestampHint(snapshotTS)
 		}
-
-		if stmt.ToAccountOpt != nil {
-			sql = sql + fmt.Sprintf(" to account %s", stmt.ToAccountOpt.AccountName)
+		dstTable := newQualifiedCloneTableName(dstDb, dstTbl, nil)
+		cloneStmt := &tree.CloneTable{
+			SrcTable: srcTable,
+			CreateTable: tree.CreateTable{
+				Table:         dstTable,
+				LikeTableName: srcTable,
+				IsAsLike:      true,
+			},
+			ToAccountOpt: stmt.ToAccountOpt,
 		}
 
 		var (
 			receipt     cloneReceipt
-			cloneStmts  []tree.Statement
 			tempExecCtx = &ExecCtx{
 				reqCtx: reqCtx,
-				input:  &UserInput{sql: sql},
 			}
 		)
 
-		if cloneStmts, err = parsers.Parse(reqCtx, dialect.MYSQL, sql, 0); err != nil {
-			return err
-		}
-
-		defer func() {
-			cloneStmts[0].Free()
-		}()
-
 		if receipt, err = handleCloneTable(
-			tempExecCtx, ses, cloneStmts[0].(*tree.CloneTable), bh,
+			tempExecCtx, ses, cloneStmt, bh,
 		); err != nil {
 			return err
 		}

--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -297,11 +296,10 @@ func dataBranchCreateTable(
 	stmt *tree.DataBranchCreateTable,
 ) (err error) {
 	var (
-		bh          BackgroundExec
-		deferred    func(error) error
-		receipt     cloneReceipt
-		cloneStmt   *tree.CloneTable
-		tempExecCtx *ExecCtx
+		bh        BackgroundExec
+		deferred  func(error) error
+		receipt   cloneReceipt
+		cloneStmt *tree.CloneTable
 	)
 
 	if bh, deferred, err = getBackExecutor(execCtx.reqCtx, ses); err != nil {
@@ -325,23 +323,9 @@ func dataBranchCreateTable(
 		ses.GetTxnCompileCtx().SetDatabase(oldDefault)
 	}()
 
-	//data branch create table xxx from yyy snap_opt to_account_op;
-	re := regexp.MustCompile(`(?i)^DATA\s+BRANCH\s+CREATE\s+TABLE\s+(\S+)\s+FROM\s+(.+?);?$`)
-	srcAndDst := re.FindStringSubmatch(execCtx.input.sql)
-	if srcAndDst == nil {
-		return moerr.NewInternalErrorNoCtxf("cannot find src and dst table: %s", execCtx.input.sql)
-	}
-
-	sql := fmt.Sprintf("CREATE TABLE %s CLONE %s", srcAndDst[1], srcAndDst[2])
-
 	execCtx.reqCtx = context.WithValue(execCtx.reqCtx, tree.CloneLevelCtxKey{}, tree.NormalCloneLevelTable)
 
-	tempExecCtx = &ExecCtx{
-		reqCtx: execCtx.reqCtx,
-		input:  &UserInput{sql: sql},
-	}
-
-	if receipt, err = handleCloneTable(tempExecCtx, ses, cloneStmt, bh); err != nil {
+	if receipt, err = handleCloneTable(execCtx, ses, cloneStmt, bh); err != nil {
 		return
 	}
 

--- a/pkg/frontend/data_branch_helpers.go
+++ b/pkg/frontend/data_branch_helpers.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,6 +38,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 	"go.uber.org/zap"
 )
+
+var snapConditionRegex = regexp.MustCompile(`\{[^}]+}`)
 
 func containsDataBranchTempTableName(sqlLower string) bool {
 	return containsTempTableMarker(sqlLower, "__mo_diff_del_") ||

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql.go
@@ -21746,6 +21746,8 @@ yydefault:
 //line mysql_sql.y:8601
 		{
 			t := tree.NewCloneTable()
+			t.CreateTable.Temporary = yyDollar[2].boolValUnion()
+			t.CreateTable.IfNotExists = yyDollar[4].ifNotExistsUnion()
 			t.CreateTable.Table = *yyDollar[5].tableNameUnion()
 			t.CreateTable.LikeTableName = *yyDollar[7].tableNameUnion()
 			t.CreateTable.IsAsLike = true

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql.y
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql.y
@@ -8599,13 +8599,15 @@ create_table_stmt:
     }
 |   CREATE temporary_opt TABLE not_exists_opt table_name CLONE table_name to_account_opt
     {
-	t := tree.NewCloneTable()
-	t.CreateTable.Table = *$5
-	t.CreateTable.LikeTableName = *$7
-	t.CreateTable.IsAsLike = true
-	t.SrcTable = *$7
-	t.ToAccountOpt = $8
-	$$ = t
+        t := tree.NewCloneTable()
+        t.CreateTable.Temporary = $2
+        t.CreateTable.IfNotExists = $4
+        t.CreateTable.Table = *$5
+        t.CreateTable.LikeTableName = *$7
+        t.CreateTable.IsAsLike = true
+        t.SrcTable = *$7
+        t.ToAccountOpt = $8
+        $$ = t
     }
 
 load_param_opt_2:

--- a/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
+++ b/pkg/sql/parsers/dialect/mysql/mysql_sql_test.go
@@ -94,6 +94,58 @@ func TestPositionFunctionSyntax(t *testing.T) {
 	}
 }
 
+func TestCloneTableParsePreservesCloneOptions(t *testing.T) {
+	stmt, err := ParseOne(
+		context.TODO(),
+		"create temporary table if not exists dst clone src to account acc",
+		1,
+	)
+	require.NoError(t, err)
+
+	cloneStmt, ok := stmt.(*tree.CloneTable)
+	require.True(t, ok)
+	require.True(t, cloneStmt.CreateTable.Temporary)
+	require.True(t, cloneStmt.CreateTable.IfNotExists)
+	require.Equal(t, tree.Identifier("dst"), cloneStmt.CreateTable.Table.ObjectName)
+	require.Equal(t, tree.Identifier("src"), cloneStmt.SrcTable.ObjectName)
+	require.NotNil(t, cloneStmt.ToAccountOpt)
+	require.Equal(t, tree.Identifier("acc"), cloneStmt.ToAccountOpt.AccountName)
+
+	require.Equal(
+		t,
+		"create temporary table if not exists `dst` clone `src` to account `acc`",
+		tree.StringWithOpts(cloneStmt, dialect.MYSQL, tree.WithQuoteIdentifier(), tree.WithSingleQuoteString()),
+	)
+}
+
+func TestCloneTableParseFormattedMoTimestamp(t *testing.T) {
+	stmt, err := ParseOne(
+		context.TODO(),
+		"create table dst clone src{MO_TS = 123}",
+		1,
+	)
+	require.NoError(t, err)
+
+	cloneStmt, ok := stmt.(*tree.CloneTable)
+	require.True(t, ok)
+	require.NotNil(t, cloneStmt.SrcTable.AtTsExpr)
+	require.Equal(t, tree.ATMOTIMESTAMP, cloneStmt.SrcTable.AtTsExpr.Type)
+}
+
+func TestDataBranchCreateTableParsesWithLeadingComment(t *testing.T) {
+	stmt, err := ParseOne(
+		context.TODO(),
+		"/* cloud_user */\n  data branch create table dst from src",
+		1,
+	)
+	require.NoError(t, err)
+
+	branchStmt, ok := stmt.(*tree.DataBranchCreateTable)
+	require.True(t, ok)
+	require.Equal(t, tree.Identifier("dst"), branchStmt.CreateTable.Table.ObjectName)
+	require.Equal(t, tree.Identifier("src"), branchStmt.SrcTable.ObjectName)
+}
+
 func TestDataBranchDiffOutputModes(t *testing.T) {
 	stmt, err := ParseOne(context.TODO(), `data branch diff t1{snapshot="sp1"} against t2{snapshot="sp2"} output summary`, 1)
 	require.NoError(t, err)

--- a/pkg/sql/parsers/tree/clone.go
+++ b/pkg/sql/parsers/tree/clone.go
@@ -16,7 +16,6 @@ package tree
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/matrixorigin/matrixone/pkg/common/reuse"
 	plan2 "github.com/matrixorigin/matrixone/pkg/pb/plan"
@@ -73,6 +72,11 @@ type ToAccountOpt struct {
 	AccountName Identifier
 }
 
+func (node *ToAccountOpt) Format(ctx *FmtCtx) {
+	ctx.WriteString("to account ")
+	ctx.WriteIdentifier(node.AccountName)
+}
+
 type CloneTable struct {
 	statementImpl
 
@@ -101,8 +105,22 @@ func (node *CloneTable) FlipStmtKind() {
 }
 
 func (node *CloneTable) Format(ctx *FmtCtx) {
-	ctx.WriteString("clone table: ")
-	node.CreateTable.Format(ctx)
+	ctx.WriteString("create")
+	if node.CreateTable.Temporary {
+		ctx.WriteString(" temporary")
+	}
+	ctx.WriteString(" table")
+	if node.CreateTable.IfNotExists {
+		ctx.WriteString(" if not exists")
+	}
+	ctx.WriteByte(' ')
+	node.CreateTable.Table.Format(ctx)
+	ctx.WriteString(" clone ")
+	node.SrcTable.Format(ctx)
+	if node.ToAccountOpt != nil {
+		ctx.WriteByte(' ')
+		node.ToAccountOpt.Format(ctx)
+	}
 }
 
 func (node *CloneTable) GetStatementType() string { return "CREATE TABLE CLONE" }
@@ -150,9 +168,17 @@ func (node *CloneDatabase) StmtKind() StmtKind {
 }
 
 func (node *CloneDatabase) Format(ctx *FmtCtx) {
-	ctx.WriteString(fmt.Sprintf(
-		"create database %s clone %s",
-		node.SrcDatabase.String(), node.DstDatabase.String()))
+	ctx.WriteString("create database ")
+	ctx.WriteIdentifier(node.DstDatabase)
+	ctx.WriteString(" clone ")
+	ctx.WriteIdentifier(node.SrcDatabase)
+	if node.AtTsExpr != nil {
+		node.AtTsExpr.Format(ctx)
+	}
+	if node.ToAccountOpt != nil {
+		ctx.WriteByte(' ')
+		node.ToAccountOpt.Format(ctx)
+	}
 }
 
 func NewCloneDatabase() *CloneDatabase {

--- a/pkg/sql/parsers/tree/clone_test.go
+++ b/pkg/sql/parsers/tree/clone_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
+	"github.com/stretchr/testify/require"
+)
+
+func makeCloneTableName(dbName, tblName string, atTsExpr *AtTimeStamp) TableName {
+	return *NewTableName(
+		Identifier(tblName),
+		ObjectNamePrefix{
+			SchemaName:     Identifier(dbName),
+			ExplicitSchema: true,
+		},
+		atTsExpr,
+	)
+}
+
+func TestCloneTableFormat(t *testing.T) {
+	stmt := &CloneTable{
+		SrcTable: makeCloneTableName("src_db", "src`tbl", &AtTimeStamp{
+			Type: ATTIMESTAMPSNAPSHOT,
+			Expr: NewNumVal("sp1", "sp1", false, P_char),
+		}),
+		CreateTable: CreateTable{
+			Temporary:   true,
+			IfNotExists: true,
+			Table:       makeCloneTableName("dst_db", "dst`tbl", nil),
+		},
+		ToAccountOpt: &ToAccountOpt{AccountName: Identifier("acc`name")},
+	}
+
+	require.Equal(
+		t,
+		"create temporary table if not exists `dst_db`.`dst``tbl` clone `src_db`.`src``tbl`{snapshot = 'sp1'} to account `acc``name`",
+		StringWithOpts(stmt, dialect.MYSQL, WithQuoteIdentifier(), WithSingleQuoteString()),
+	)
+}
+
+func TestCloneDatabaseFormat(t *testing.T) {
+	stmt := &CloneDatabase{
+		DstDatabase: Identifier("dst`db"),
+		SrcDatabase: Identifier("src`db"),
+		AtTsExpr: &AtTimeStamp{
+			Type: ATTIMESTAMPSNAPSHOT,
+			Expr: NewNumVal("sp1", "sp1", false, P_char),
+		},
+		ToAccountOpt: &ToAccountOpt{AccountName: Identifier("acc`name")},
+	}
+
+	require.Equal(
+		t,
+		"create database `dst``db` clone `src``db`{snapshot = 'sp1'} to account `acc``name`",
+		StringWithOpts(stmt, dialect.MYSQL, WithQuoteIdentifier(), WithSingleQuoteString()),
+	)
+}

--- a/pkg/sql/parsers/tree/identifier.go
+++ b/pkg/sql/parsers/tree/identifier.go
@@ -14,6 +14,8 @@
 
 package tree
 
+import "strings"
+
 // IdentifierName is referenced in the expression
 type IdentifierName interface {
 	Expr
@@ -42,6 +44,16 @@ func (node *IdentifierList) Format(ctx *FmtCtx) {
 		}
 		ctx.WriteString(string((*node)[i]))
 	}
+}
+
+func (ctx *FmtCtx) WriteIdentifier(identifier Identifier) {
+	if ctx.quoteIdentifier {
+		ctx.WriteByte('`')
+		ctx.WriteString(strings.ReplaceAll(string(identifier), "`", "``"))
+		ctx.WriteByte('`')
+		return
+	}
+	ctx.WriteString(string(identifier))
 }
 
 type ColumnItem struct {

--- a/pkg/sql/parsers/tree/table_name.go
+++ b/pkg/sql/parsers/tree/table_name.go
@@ -21,27 +21,15 @@ type TableName struct {
 }
 
 func (tn TableName) Format(ctx *FmtCtx) {
-	if ctx.quoteIdentifier {
-		if tn.ExplicitCatalog {
-			ctx.WriteString("`" + string(tn.CatalogName) + "`")
-			ctx.WriteByte('.')
-		}
-		if tn.ExplicitSchema {
-			ctx.WriteString("`" + string(tn.SchemaName) + "`")
-			ctx.WriteByte('.')
-		}
-		ctx.WriteString("`" + string(tn.ObjectName) + "`")
-	} else {
-		if tn.ExplicitCatalog {
-			ctx.WriteString(string(tn.CatalogName))
-			ctx.WriteByte('.')
-		}
-		if tn.ExplicitSchema {
-			ctx.WriteString(string(tn.SchemaName))
-			ctx.WriteByte('.')
-		}
-		ctx.WriteString(string(tn.ObjectName))
+	if tn.ExplicitCatalog {
+		ctx.WriteIdentifier(tn.CatalogName)
+		ctx.WriteByte('.')
 	}
+	if tn.ExplicitSchema {
+		ctx.WriteIdentifier(tn.SchemaName)
+		ctx.WriteByte('.')
+	}
+	ctx.WriteIdentifier(tn.ObjectName)
 	if tn.AtTsExpr != nil {
 		tn.AtTsExpr.Format(ctx)
 	}
@@ -119,8 +107,8 @@ func (a ATTimeStampType) String() string {
 		return "timestamp"
 	case ATTIMESTAMPSNAPSHOT: // format: {snapshot = expr}
 		return "snapshot"
-	case ATMOTIMESTAMP: // format: {mo-timestamp = expr}
-		return "mo-timestamp"
+	case ATMOTIMESTAMP: // format: {MO_TS = expr}
+		return "MO_TS"
 	case ASOFTIMESTAMP: // format: {as of timestamp = expr}
 		return "as of timestamp"
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24944

## What this PR does / why we need it:

`DATA BRANCH CREATE TABLE` rebuilt clone SQL by applying a regexp to the original input SQL. That made the command sensitive to leading comments or whitespace, so statements such as `/* cloud_user */DATA BRANCH CREATE TABLE ...` could fail before reaching the clone implementation.

This PR moves the data branch create-table path to use the parsed AST directly, and centralizes clone SQL generation through AST formatting instead of reparsing hand-built SQL strings. It also makes clone table/database formatting produce executable SQL, quotes identifiers through a shared helper, preserves `TEMPORARY` / `IF NOT EXISTS` clone table options in the parser, and formats internal MO timestamp hints as `MO_TS` so generated SQL can be parsed by the existing grammar.

Validation on `3.0-dev`:

- `go test ./pkg/sql/parsers/tree ./pkg/sql/parsers/dialect/mysql ./pkg/frontend -count=1`
- `make build`
- SQL regression on local MO: `/* cloud_user */DATA BRANCH CREATE TABLE b_cmt FROM src` returns the expected cloned rows
- Branch BVT with mo-tester `3.0-dev`: `./run.sh -p /tmp/mo24944-3.0/test/distributed/cases/git4data/branch/ -r 100`
  - `TOTAL: 2998`
  - `SUCCESS: 2998`
  - `FAILED: 0`
  - `SUCCESS RATE: 100%`
