### PR TITLE
fix(logservice): update dragonboat snapshot import fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ replace github.com/hashicorp/memberlist => github.com/matrixorigin/memberlist v0
 replace (
 	github.com/elastic/gosigar v0.14.2 => github.com/matrixorigin/gosigar v0.14.3-0.20241204071856-40aab500bfac
 	github.com/fagongzi/goetty/v2 v2.0.3-0.20230628075727-26c9a2fd5fb8 => github.com/matrixorigin/goetty/v2 v2.0.0-20240611082008-a4de209fff3d
-	github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef => github.com/matrixorigin/dragonboat/v4 v4.0.0-20251214113216-2ddf81ef2a85
+	github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef => github.com/matrixorigin/dragonboat/v4 v4.0.0-20260612094223-103d119addce
 	github.com/lni/goutils v1.3.1-0.20220604063047-388d67b4dbc4 => github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4
 	github.com/lni/vfs v0.2.1-0.20220616104132-8852fd867376 => github.com/matrixorigin/vfs v0.2.1-0.20220616104132-8852fd867376
 )

--- a/go.sum
+++ b/go.sum
@@ -534,6 +534,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matrixorigin/dragonboat/v4 v4.0.0-20251214113216-2ddf81ef2a85 h1:8zwV6ypyx3/TXgOG1k6pY5FiFWlYh97zf0Bsc0qj9bY=
 github.com/matrixorigin/dragonboat/v4 v4.0.0-20251214113216-2ddf81ef2a85/go.mod h1:B1VfuDzGm7Uk0xoRkRJynA6n4i31m/1ZJIPfIyJfYQg=
+github.com/matrixorigin/dragonboat/v4 v4.0.0-20260612094223-103d119addce h1:QM8vkwQ5hkbKwPTApzoUTKosXupynQa1VbRmwXBlyOg=
+github.com/matrixorigin/dragonboat/v4 v4.0.0-20260612094223-103d119addce/go.mod h1:B1VfuDzGm7Uk0xoRkRJynA6n4i31m/1ZJIPfIyJfYQg=
 github.com/matrixorigin/goetty/v2 v2.0.0-20240611082008-a4de209fff3d h1:wSlkJlWXZ3if1sH8Bc/lUUOWhTw91lgYGSFOHqy1tcw=
 github.com/matrixorigin/goetty/v2 v2.0.0-20240611082008-a4de209fff3d/go.mod h1:OwIBpVwRW1HjF/Jhc2Av3UvG2NygMg+bdqGxZaqwhU0=
 github.com/matrixorigin/gosigar v0.14.3-0.20241204071856-40aab500bfac h1:KRPOwOcSZRfWT7w8mr7BmFLoFB75ljgqjkg47xkN/Pc=


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24966

## What this PR does / why we need it:

This PR updates the MatrixOne `3.0-dev` branch to use the Dragonboat snapshot import metadata fix merged in:

- https://github.com/matrixorigin/dragonboat/commit/103d119addcea5c7452a8b1ae96a1430eff233fc
- https://github.com/matrixorigin/dragonboat/pull/14

Main changes:

- Update the `github.com/lni/dragonboat/v4` replacement to `github.com/matrixorigin/dragonboat/v4 v4.0.0-20260612094223-103d119addce`.
- Add the corresponding `go.sum` entries for the updated Dragonboat module.

Why this is needed:

- The upstream fix prevents imported snapshots from synthesizing `Membership.ConfigChangeId` from the snapshot index.
- HAKeeper uses Dragonboat membership `ConfigChangeId` as the LogService shard epoch.
- Without this fix, an old imported membership can be reported with a large fake epoch and be treated as newer than the live membership view.
- The upstream fix also preserves online imported snapshot membership consistently and rejects invalid target membership before restore.

Validation:

- `git diff --check`
- `GOTELEMETRY=off go mod download github.com/lni/dragonboat/v4`
- `GOTELEMETRY=off go list -m -json github.com/lni/dragonboat/v4`
- `GOTELEMETRY=off GOCACHE=/private/tmp/mo-dragonboat-3dev-gocache go test github.com/lni/dragonboat/v4/tools github.com/lni/dragonboat/v4/internal/rsm github.com/lni/dragonboat/v4/internal/raft -run '^$' -count=0`

Local limitation:

- `GOTELEMETRY=off GOCACHE=/private/tmp/mo-dragonboat-3dev-gocache go test ./pkg/logservice -run '^$' -count=0` could not complete in the local environment because the native `usearch.h` header is missing.
