### PR TITLE
fix: rebuild txn-local secondary indexes in alter copy

### DIFF
--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -1229,15 +1229,11 @@ func cloneUnaffectedIndexes(
 					return moerr.NewInternalErrorNoCtxf("missing cloned index definition for %s", idxName)
 				}
 				logutil.Infof("cloneUnaffectedIndex: rebuild txn-local index %s into %s\n", idxName, newIdxTblName.IndexTableName)
-				if catalog.IsMasterIndexAlgo(oriIdxTblNames.IndexAlgo) {
-					insertSQLs := genInsertIndexTableSqlForMasterIndex(newTblDef, newIdxDef, dbName)
-					for _, insertSQL := range insertSQLs {
-						if err = c.runSql(insertSQL); err != nil {
-							return err
-						}
-					}
-				} else {
-					insertSQL := genInsertIndexTableSql(newTblDef, newIdxDef, dbName, oriIdxTblNames.Unique)
+				insertSQLs, err := genRebuildTxnLocalIndexCloneSQLs(newTblDef, newIdxDef, dbName, oriIdxTblNames)
+				if err != nil {
+					return err
+				}
+				for _, insertSQL := range insertSQLs {
 					if err = c.runSql(insertSQL); err != nil {
 						return err
 					}
@@ -1287,10 +1283,24 @@ func shouldRebuildTxnLocalIndexClone(checker txnLocalTableChecker, idxTblDef *pl
 	}
 	if !(idxInfo.Unique ||
 		catalog.IsMasterIndexAlgo(idxInfo.IndexAlgo) ||
+		catalog.IsFullTextIndexAlgo(idxInfo.IndexAlgo) ||
 		(catalog.IsRegularIndexAlgo(idxInfo.IndexAlgo) && !catalog.IsRTreeIndexAlgo(idxInfo.IndexAlgo))) {
 		return false
 	}
 	return checker.IsTableCreatedInTxn(idxTblDef.TblId) || checker.HasTableWritesInTxn(idxTblDef.TblId)
+}
+
+func genRebuildTxnLocalIndexCloneSQLs(tableDef *plan.TableDef, idxDef *plan.IndexDef, dbName string, idxInfo *unaffectedIndexTableInfo) ([]string, error) {
+	if idxInfo == nil {
+		return nil, moerr.NewInternalErrorNoCtx("missing txn-local index clone info")
+	}
+	if catalog.IsMasterIndexAlgo(idxInfo.IndexAlgo) {
+		return genInsertIndexTableSqlForMasterIndex(tableDef, idxDef, dbName), nil
+	}
+	if catalog.IsFullTextIndexAlgo(idxInfo.IndexAlgo) {
+		return genInsertIndexTableSqlForFullTextIndex(tableDef, idxDef, dbName)
+	}
+	return []string{genInsertIndexTableSql(tableDef, idxDef, dbName, idxInfo.Unique)}, nil
 }
 
 func findIndexDefByName(tableDef *plan.TableDef, idxName string) *plan.IndexDef {

--- a/pkg/sql/compile/alter.go
+++ b/pkg/sql/compile/alter.go
@@ -1012,6 +1012,18 @@ func notifyParentTableFkTableIdChange(c *Compile, fkey *plan.ForeignKeyDef, oldT
 	return fatherRelation.UpdateConstraint(c.proc.Ctx, oldCt)
 }
 
+type unaffectedIndexTypeInfo struct {
+	IndexTableName string
+	AlgoTableType  string
+}
+
+type unaffectedIndexTableInfo struct {
+	Unique          bool
+	IndexAlgo       string
+	IndexAlgoParams string
+	Indexes         []unaffectedIndexTypeInfo
+}
+
 func cloneUnaffectedIndexes(
 	c *Compile,
 	dbName string,
@@ -1022,18 +1034,6 @@ func cloneUnaffectedIndexes(
 	cloneSnapshot *plan.Snapshot,
 ) (err error) {
 
-	type IndexTypeInfo struct {
-		IndexTableName string
-		AlgoTableType  string
-	}
-
-	type IndexTableInfo struct {
-		Unique          bool
-		IndexAlgo       string
-		IndexAlgoParams string
-		Indexes         []IndexTypeInfo
-	}
-
 	var (
 		clone *table_clone.TableClone
 
@@ -1042,8 +1042,8 @@ func cloneUnaffectedIndexes(
 
 		newTblDef = newRel.GetTableDef(c.proc.Ctx)
 
-		oriIdxColNameToTblName = make(map[string]*IndexTableInfo)
-		newIdxColNameToTblName = make(map[string]*IndexTableInfo)
+		oriIdxColNameToTblName = make(map[string]*unaffectedIndexTableInfo)
+		newIdxColNameToTblName = make(map[string]*unaffectedIndexTableInfo)
 	)
 
 	logutil.Infof("cloneUnaffectedIndex: affected cols %v\n", affectedCols)
@@ -1109,17 +1109,17 @@ func cloneUnaffectedIndexes(
 
 		m, ok := oriIdxColNameToTblName[idxTbl.IndexName]
 		if !ok {
-			m = &IndexTableInfo{
+			m = &unaffectedIndexTableInfo{
 				Unique:          idxTbl.Unique,
 				IndexAlgo:       idxTbl.IndexAlgo,
 				IndexAlgoParams: idxTbl.IndexAlgoParams,
-				Indexes:         make([]IndexTypeInfo, 0, 3),
+				Indexes:         make([]unaffectedIndexTypeInfo, 0, 3),
 			}
 
 		}
 
 		m.Indexes = append(m.Indexes,
-			IndexTypeInfo{IndexTableName: idxTbl.IndexTableName,
+			unaffectedIndexTypeInfo{IndexTableName: idxTbl.IndexTableName,
 				AlgoTableType: idxTbl.IndexAlgoTableType})
 		oriIdxColNameToTblName[idxTbl.IndexName] = m
 	}
@@ -1131,16 +1131,16 @@ func cloneUnaffectedIndexes(
 
 		m, ok := newIdxColNameToTblName[idxTbl.IndexName]
 		if !ok {
-			m = &IndexTableInfo{
+			m = &unaffectedIndexTableInfo{
 				Unique:          idxTbl.Unique,
 				IndexAlgo:       idxTbl.IndexAlgo,
 				IndexAlgoParams: idxTbl.IndexAlgoParams,
-				Indexes:         make([]IndexTypeInfo, 0, 3),
+				Indexes:         make([]unaffectedIndexTypeInfo, 0, 3),
 			}
 		}
 
 		m.Indexes = append(m.Indexes,
-			IndexTypeInfo{IndexTableName: idxTbl.IndexTableName,
+			unaffectedIndexTypeInfo{IndexTableName: idxTbl.IndexTableName,
 				AlgoTableType: idxTbl.IndexAlgoTableType})
 		newIdxColNameToTblName[idxTbl.IndexName] = m
 		logutil.Infof("cloneUnaffectedIndex: new %s parts %v\n", idxTbl.IndexTableName, idxTbl.Parts)
@@ -1151,6 +1151,10 @@ func cloneUnaffectedIndexes(
 		defaultDB: dbName,
 		engine:    c.e,
 		proc:      c.proc,
+	}
+	var txnLocalChecker txnLocalTableChecker
+	if txnOp := c.proc.GetTxnOperator(); txnOp != nil {
+		txnLocalChecker, _ = txnOp.GetWorkspace().(txnLocalTableChecker)
 	}
 
 	for idxName, oriIdxTblNames := range oriIdxColNameToTblName {
@@ -1174,7 +1178,7 @@ func cloneUnaffectedIndexes(
 
 		for _, oriIdxTblName := range oriIdxTblNames.Indexes {
 
-			var newIdxTblName IndexTypeInfo
+			var newIdxTblName unaffectedIndexTypeInfo
 			found := false
 			for _, idxinfo := range newIdxTblNames.Indexes {
 				if oriIdxTblName.AlgoTableType == idxinfo.AlgoTableType {
@@ -1215,6 +1219,32 @@ func cloneUnaffectedIndexes(
 				return err
 			}
 
+			if shouldRebuildTxnLocalIndexClone(txnLocalChecker, oriIdxTblDef, oriIdxTblNames) {
+				sql := fmt.Sprintf("DELETE FROM `%s`.`%s` WHERE TRUE", dbName, newIdxTblName.IndexTableName)
+				if err = c.runSql(sql); err != nil {
+					return err
+				}
+				newIdxDef := findIndexDefByName(newTblDef, idxName)
+				if newIdxDef == nil {
+					return moerr.NewInternalErrorNoCtxf("missing cloned index definition for %s", idxName)
+				}
+				logutil.Infof("cloneUnaffectedIndex: rebuild txn-local index %s into %s\n", idxName, newIdxTblName.IndexTableName)
+				if catalog.IsMasterIndexAlgo(oriIdxTblNames.IndexAlgo) {
+					insertSQLs := genInsertIndexTableSqlForMasterIndex(newTblDef, newIdxDef, dbName)
+					for _, insertSQL := range insertSQLs {
+						if err = c.runSql(insertSQL); err != nil {
+							return err
+						}
+					}
+				} else {
+					insertSQL := genInsertIndexTableSql(newTblDef, newIdxDef, dbName, oriIdxTblNames.Unique)
+					if err = c.runSql(insertSQL); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+
 			clonePlan := plan.CloneTable{
 				CreateTable:     nil,
 				ScanSnapshot:    cloneSnapshot,
@@ -1243,5 +1273,34 @@ func cloneUnaffectedIndexes(
 		}
 	}
 
+	return nil
+}
+
+type txnLocalTableChecker interface {
+	IsTableCreatedInTxn(tableID uint64) bool
+	HasTableWritesInTxn(tableID uint64) bool
+}
+
+func shouldRebuildTxnLocalIndexClone(checker txnLocalTableChecker, idxTblDef *plan.TableDef, idxInfo *unaffectedIndexTableInfo) bool {
+	if checker == nil || idxTblDef == nil || idxInfo == nil {
+		return false
+	}
+	if !(idxInfo.Unique ||
+		catalog.IsMasterIndexAlgo(idxInfo.IndexAlgo) ||
+		(catalog.IsRegularIndexAlgo(idxInfo.IndexAlgo) && !catalog.IsRTreeIndexAlgo(idxInfo.IndexAlgo))) {
+		return false
+	}
+	return checker.IsTableCreatedInTxn(idxTblDef.TblId) || checker.HasTableWritesInTxn(idxTblDef.TblId)
+}
+
+func findIndexDefByName(tableDef *plan.TableDef, idxName string) *plan.IndexDef {
+	if tableDef == nil {
+		return nil
+	}
+	for _, idxDef := range tableDef.Indexes {
+		if idxDef.IndexName == idxName {
+			return idxDef
+		}
+	}
 	return nil
 }

--- a/pkg/sql/compile/alter_test.go
+++ b/pkg/sql/compile/alter_test.go
@@ -55,6 +55,115 @@ func TestShouldEnableAlterCopyPipelineFlush(t *testing.T) {
 	assert.True(t, shouldEnableAlterCopyPipelineFlush(&plan2.AlterCopyOpt{SkipPkDedup: true}))
 }
 
+type alterCopyTxnLocalIndexChecker struct {
+	created map[uint64]bool
+	written map[uint64]bool
+}
+
+func (c alterCopyTxnLocalIndexChecker) IsTableCreatedInTxn(tableID uint64) bool {
+	return c.created[tableID]
+}
+
+func (c alterCopyTxnLocalIndexChecker) HasTableWritesInTxn(tableID uint64) bool {
+	return c.written[tableID]
+}
+
+func TestShouldRebuildTxnLocalIndexClone(t *testing.T) {
+	const idxTableID uint64 = 42
+
+	for _, tc := range []struct {
+		name    string
+		checker txnLocalTableChecker
+		idxDef  *plan.TableDef
+		idxInfo *unaffectedIndexTableInfo
+		want    bool
+	}{
+		{
+			name: "nil checker",
+			idxDef: &plan.TableDef{
+				TblId: idxTableID,
+			},
+			idxInfo: &unaffectedIndexTableInfo{},
+		},
+		{
+			name:    "nil table def",
+			checker: alterCopyTxnLocalIndexChecker{created: map[uint64]bool{idxTableID: true}},
+			idxInfo: &unaffectedIndexTableInfo{},
+		},
+		{
+			name:    "nil index info",
+			checker: alterCopyTxnLocalIndexChecker{created: map[uint64]bool{idxTableID: true}},
+			idxDef: &plan.TableDef{
+				TblId: idxTableID,
+			},
+		},
+		{
+			name:    "regular index table created in txn",
+			checker: alterCopyTxnLocalIndexChecker{created: map[uint64]bool{idxTableID: true}},
+			idxDef: &plan.TableDef{
+				TblId: idxTableID,
+			},
+			idxInfo: &unaffectedIndexTableInfo{},
+			want:    true,
+		},
+		{
+			name:    "regular index table written in txn",
+			checker: alterCopyTxnLocalIndexChecker{written: map[uint64]bool{idxTableID: true}},
+			idxDef: &plan.TableDef{
+				TblId: idxTableID,
+			},
+			idxInfo: &unaffectedIndexTableInfo{},
+			want:    true,
+		},
+		{
+			name:    "regular index table has no txn local state",
+			checker: alterCopyTxnLocalIndexChecker{},
+			idxDef: &plan.TableDef{
+				TblId: idxTableID,
+			},
+			idxInfo: &unaffectedIndexTableInfo{},
+		},
+		{
+			name:    "unique index table created in txn",
+			checker: alterCopyTxnLocalIndexChecker{created: map[uint64]bool{idxTableID: true}},
+			idxDef: &plan.TableDef{
+				TblId: idxTableID,
+			},
+			idxInfo: &unaffectedIndexTableInfo{Unique: true},
+			want:    true,
+		},
+		{
+			name:    "rtree index keeps clone path",
+			checker: alterCopyTxnLocalIndexChecker{created: map[uint64]bool{idxTableID: true}},
+			idxDef: &plan.TableDef{
+				TblId: idxTableID,
+			},
+			idxInfo: &unaffectedIndexTableInfo{IndexAlgo: catalog.MoIndexRTreeAlgo.ToString()},
+		},
+		{
+			name:    "master index table created in txn",
+			checker: alterCopyTxnLocalIndexChecker{created: map[uint64]bool{idxTableID: true}},
+			idxDef: &plan.TableDef{
+				TblId: idxTableID,
+			},
+			idxInfo: &unaffectedIndexTableInfo{IndexAlgo: catalog.MOIndexMasterAlgo.ToString()},
+			want:    true,
+		},
+		{
+			name:    "fulltext index keeps clone path",
+			checker: alterCopyTxnLocalIndexChecker{created: map[uint64]bool{idxTableID: true}},
+			idxDef: &plan.TableDef{
+				TblId: idxTableID,
+			},
+			idxInfo: &unaffectedIndexTableInfo{IndexAlgo: catalog.MOIndexFullTextAlgo.ToString()},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, shouldRebuildTxnLocalIndexClone(tc.checker, tc.idxDef, tc.idxInfo))
+		})
+	}
+}
+
 type alterCopyInsertSpyExecutor struct {
 	insertSQL    string
 	insertErr    error

--- a/pkg/sql/compile/alter_test.go
+++ b/pkg/sql/compile/alter_test.go
@@ -150,18 +150,45 @@ func TestShouldRebuildTxnLocalIndexClone(t *testing.T) {
 			want:    true,
 		},
 		{
-			name:    "fulltext index keeps clone path",
+			name:    "fulltext index table created in txn",
 			checker: alterCopyTxnLocalIndexChecker{created: map[uint64]bool{idxTableID: true}},
 			idxDef: &plan.TableDef{
 				TblId: idxTableID,
 			},
 			idxInfo: &unaffectedIndexTableInfo{IndexAlgo: catalog.MOIndexFullTextAlgo.ToString()},
+			want:    true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, shouldRebuildTxnLocalIndexClone(tc.checker, tc.idxDef, tc.idxInfo))
 		})
 	}
+}
+
+func TestGenRebuildTxnLocalIndexCloneSQLsFullText(t *testing.T) {
+	tableDef := &plan.TableDef{
+		Name: "ft_src",
+		Pkey: &plan.PrimaryKeyDef{
+			PkeyColName: "id",
+		},
+	}
+	idxDef := &plan.IndexDef{
+		IndexTableName:  "__mo_index_fulltext_ft",
+		IndexAlgo:       catalog.MOIndexFullTextAlgo.ToString(),
+		IndexAlgoParams: `{"parser":"ngram"}`,
+		Parts:           []string{"title", "body"},
+	}
+	idxInfo := &unaffectedIndexTableInfo{IndexAlgo: catalog.MOIndexFullTextAlgo.ToString()}
+
+	sqls, err := genRebuildTxnLocalIndexCloneSQLs(tableDef, idxDef, "test_db", idxInfo)
+	require.NoError(t, err)
+	require.Len(t, sqls, 1)
+	assert.Contains(t, sqls[0], "fulltext_index_tokenize")
+	assert.Contains(t, sqls[0], "`test_db`.`__mo_index_fulltext_ft`")
+	assert.Contains(t, sqls[0], "`test_db`.`ft_src`")
+	assert.Contains(t, sqls[0], "src.id")
+	assert.Contains(t, sqls[0], "src.title,src.body")
+	assert.NotContains(t, sqls[0], "serial_full")
 }
 
 type alterCopyInsertSpyExecutor struct {

--- a/pkg/vm/engine/disttae/txn.go
+++ b/pkg/vm/engine/disttae/txn.go
@@ -2372,6 +2372,31 @@ func (c *tableOpsChain) existCreatedInTxn(tid uint64) bool {
 	return exist
 }
 
+// IsTableCreatedInTxn reports whether the table id belongs to a table created
+// in the current transaction.
+func (txn *Transaction) IsTableCreatedInTxn(tid uint64) bool {
+	if txn == nil || txn.tableOps == nil {
+		return false
+	}
+	return txn.tableOps.existCreatedInTxn(tid)
+}
+
+// HasTableWritesInTxn reports whether the table has uncommitted workspace
+// writes in the current transaction.
+func (txn *Transaction) HasTableWritesInTxn(tid uint64) bool {
+	if txn == nil {
+		return false
+	}
+	txn.Lock()
+	defer txn.Unlock()
+	for _, entry := range txn.writes {
+		if entry.tableId == tid && entry.bat != nil && entry.bat.RowCount() > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *tableOpsChain) addCreateTable(key tableKey, statementId int, t *txnTable) {
 	c.Lock()
 	defer c.Unlock()

--- a/pkg/vm/engine/disttae/txn_test.go
+++ b/pkg/vm/engine/disttae/txn_test.go
@@ -446,6 +446,44 @@ func TestTransactionGetTableNilGuards(t *testing.T) {
 	require.Contains(t, err.Error(), "disttae txn operator is nil")
 }
 
+func TestTransactionIsTableCreatedInTxn(t *testing.T) {
+	var nilTxn *Transaction
+	require.False(t, nilTxn.IsTableCreatedInTxn(42))
+
+	txn := &Transaction{}
+	require.False(t, txn.IsTableCreatedInTxn(42))
+
+	txn.tableOps = newTableOps()
+	require.False(t, txn.IsTableCreatedInTxn(42))
+
+	txn.tableOps.addCreatedInTxn(42, 1)
+	require.True(t, txn.IsTableCreatedInTxn(42))
+	require.False(t, txn.IsTableCreatedInTxn(43))
+}
+
+func TestTransactionHasTableWritesInTxn(t *testing.T) {
+	var nilTxn *Transaction
+	require.False(t, nilTxn.HasTableWritesInTxn(42))
+
+	proc := testutil.NewProc(t)
+	emptyBat := batch.NewWithSize(1)
+	emptyBat.SetRowCount(0)
+	writtenBat := newInt64BatchForTest(t, proc, []string{"pk"}, []int64{1, 2})
+	defer writtenBat.Clean(proc.Mp())
+
+	txn := &Transaction{
+		writes: []Entry{
+			{tableId: 42},
+			{tableId: 42, bat: emptyBat},
+			{tableId: 43, bat: writtenBat},
+		},
+	}
+	require.False(t, txn.HasTableWritesInTxn(42))
+
+	txn.writes = append(txn.writes, Entry{tableId: 42, bat: writtenBat})
+	require.True(t, txn.HasTableWritesInTxn(42))
+}
+
 func TestResolvePKCheckPosForWriteEarlyExit(t *testing.T) {
 	txn := &Transaction{}
 

--- a/test/distributed/cases/ddl/alter_copy_secondary_index_txn.result
+++ b/test/distributed/cases/ddl/alter_copy_secondary_index_txn.result
@@ -1,9 +1,9 @@
 drop table if exists alter_copy_secondary_index_txn_t;
 create table alter_copy_secondary_index_txn_t (
-    k varchar(32) not null,
-    s varchar(32) not null,
-    body text not null,
-    key idx_k_s (k, s)
+k varchar(32) not null,
+s varchar(32) not null,
+body text not null,
+key idx_k_s (k, s)
 );
 insert into alter_copy_secondary_index_txn_t (k, s, body) values ('a', 'x', '{}');
 select count(*) from alter_copy_secondary_index_txn_t where k = 'a' and s = 'x';
@@ -26,11 +26,11 @@ count(*)
 drop table alter_copy_secondary_index_txn_t;
 drop table if exists alter_copy_master_index_txn_t;
 create table alter_copy_master_index_txn_t (
-    k varchar(32) not null,
-    s varchar(32) not null,
-    pk varchar(32) primary key,
-    body text not null,
-    index idx_k_s using master (k, s)
+k varchar(32) not null,
+s varchar(32) not null,
+pk varchar(32) primary key,
+body text not null,
+index idx_k_s using master (k, s)
 );
 insert into alter_copy_master_index_txn_t (k, s, pk, body) values ('a', 'x', '1', '{}');
 begin;
@@ -50,10 +50,10 @@ count(*)
 drop table alter_copy_master_index_txn_t;
 drop table if exists alter_copy_secondary_index_txn_write_t;
 create table alter_copy_secondary_index_txn_write_t (
-    k varchar(32) not null,
-    s varchar(32) not null,
-    body text not null,
-    key idx_k_s (k, s)
+k varchar(32) not null,
+s varchar(32) not null,
+body text not null,
+key idx_k_s (k, s)
 );
 insert into alter_copy_secondary_index_txn_write_t (k, s, body) values ('a', 'x', '{}');
 begin;
@@ -72,10 +72,10 @@ count(*)
 drop table alter_copy_secondary_index_txn_write_t;
 drop table if exists alter_copy_fulltext_index_txn_t;
 create table alter_copy_fulltext_index_txn_t (
-    id int primary key,
-    title varchar(200) not null,
-    body text not null,
-    fulltext index ftx_title(title)
+id int primary key,
+title varchar(200) not null,
+body text not null,
+fulltext index ftx_title(title)
 );
 insert into alter_copy_fulltext_index_txn_t values (1, 'database tutorial', '{}');
 select count(*) from alter_copy_fulltext_index_txn_t where match(title) against('database' in natural language mode);

--- a/test/distributed/cases/ddl/alter_copy_secondary_index_txn.result
+++ b/test/distributed/cases/ddl/alter_copy_secondary_index_txn.result
@@ -1,0 +1,72 @@
+drop table if exists alter_copy_secondary_index_txn_t;
+create table alter_copy_secondary_index_txn_t (
+    k varchar(32) not null,
+    s varchar(32) not null,
+    body text not null,
+    key idx_k_s (k, s)
+);
+insert into alter_copy_secondary_index_txn_t (k, s, body) values ('a', 'x', '{}');
+select count(*) from alter_copy_secondary_index_txn_t where k = 'a' and s = 'x';
+count(*)
+1
+begin;
+alter table alter_copy_secondary_index_txn_t add column c int not null default 0;
+alter table alter_copy_secondary_index_txn_t modify column body longtext not null;
+commit;
+select count(*) from alter_copy_secondary_index_txn_t where k = 'a' and s = 'x';
+count(*)
+1
+select count(*) from alter_copy_secondary_index_txn_t where binary k = binary 'a' and binary s = binary 'x';
+count(*)
+1
+insert into alter_copy_secondary_index_txn_t (k, s, body) values ('a', 'x', '{new}');
+select count(*) from alter_copy_secondary_index_txn_t where k = 'a' and s = 'x';
+count(*)
+2
+drop table alter_copy_secondary_index_txn_t;
+drop table if exists alter_copy_master_index_txn_t;
+create table alter_copy_master_index_txn_t (
+    k varchar(32) not null,
+    s varchar(32) not null,
+    pk varchar(32) primary key,
+    body text not null,
+    index idx_k_s using master (k, s)
+);
+insert into alter_copy_master_index_txn_t (k, s, pk, body) values ('a', 'x', '1', '{}');
+begin;
+alter table alter_copy_master_index_txn_t add column c int not null default 0;
+alter table alter_copy_master_index_txn_t modify column body longtext not null;
+commit;
+select count(*) from alter_copy_master_index_txn_t where k = 'a' and s = 'x';
+count(*)
+1
+select count(*) from alter_copy_master_index_txn_t where binary k = binary 'a' and binary s = binary 'x';
+count(*)
+1
+insert into alter_copy_master_index_txn_t (k, s, pk, body) values ('a', 'x', '2', '{new}');
+select count(*) from alter_copy_master_index_txn_t where k = 'a' and s = 'x';
+count(*)
+2
+drop table alter_copy_master_index_txn_t;
+drop table if exists alter_copy_secondary_index_txn_write_t;
+create table alter_copy_secondary_index_txn_write_t (
+    k varchar(32) not null,
+    s varchar(32) not null,
+    body text not null,
+    key idx_k_s (k, s)
+);
+insert into alter_copy_secondary_index_txn_write_t (k, s, body) values ('a', 'x', '{}');
+begin;
+insert into alter_copy_secondary_index_txn_write_t (k, s, body) values ('b', 'y', '{txn}');
+alter table alter_copy_secondary_index_txn_write_t add column c int not null default 0;
+commit;
+select count(*) from alter_copy_secondary_index_txn_write_t where k = 'a' and s = 'x';
+count(*)
+1
+select count(*) from alter_copy_secondary_index_txn_write_t where k = 'b' and s = 'y';
+count(*)
+1
+select count(*) from alter_copy_secondary_index_txn_write_t where binary k = binary 'b' and binary s = binary 'y';
+count(*)
+1
+drop table alter_copy_secondary_index_txn_write_t;

--- a/test/distributed/cases/ddl/alter_copy_secondary_index_txn.result
+++ b/test/distributed/cases/ddl/alter_copy_secondary_index_txn.result
@@ -70,3 +70,32 @@ select count(*) from alter_copy_secondary_index_txn_write_t where binary k = bin
 count(*)
 1
 drop table alter_copy_secondary_index_txn_write_t;
+drop table if exists alter_copy_fulltext_index_txn_t;
+create table alter_copy_fulltext_index_txn_t (
+    id int primary key,
+    title varchar(200) not null,
+    body text not null,
+    fulltext index ftx_title(title)
+);
+insert into alter_copy_fulltext_index_txn_t values (1, 'database tutorial', '{}');
+select count(*) from alter_copy_fulltext_index_txn_t where match(title) against('database' in natural language mode);
+count(*)
+1
+begin;
+alter table alter_copy_fulltext_index_txn_t add column c int not null default 0;
+alter table alter_copy_fulltext_index_txn_t modify column body longtext not null;
+commit;
+select count(*) from alter_copy_fulltext_index_txn_t where match(title) against('database' in natural language mode);
+count(*)
+1
+select count(*) from alter_copy_fulltext_index_txn_t where title like '%database%';
+count(*)
+1
+insert into alter_copy_fulltext_index_txn_t values (2, 'database guide', '{new}', 0);
+select count(*) from alter_copy_fulltext_index_txn_t where match(title) against('database' in natural language mode);
+count(*)
+2
+select count(*) from alter_copy_fulltext_index_txn_t where title like '%database%';
+count(*)
+2
+drop table alter_copy_fulltext_index_txn_t;

--- a/test/distributed/cases/ddl/alter_copy_secondary_index_txn.sql
+++ b/test/distributed/cases/ddl/alter_copy_secondary_index_txn.sql
@@ -52,3 +52,23 @@ select count(*) from alter_copy_secondary_index_txn_write_t where k = 'a' and s 
 select count(*) from alter_copy_secondary_index_txn_write_t where k = 'b' and s = 'y';
 select count(*) from alter_copy_secondary_index_txn_write_t where binary k = binary 'b' and binary s = binary 'y';
 drop table alter_copy_secondary_index_txn_write_t;
+
+drop table if exists alter_copy_fulltext_index_txn_t;
+create table alter_copy_fulltext_index_txn_t (
+    id int primary key,
+    title varchar(200) not null,
+    body text not null,
+    fulltext index ftx_title(title)
+);
+insert into alter_copy_fulltext_index_txn_t values (1, 'database tutorial', '{}');
+select count(*) from alter_copy_fulltext_index_txn_t where match(title) against('database' in natural language mode);
+begin;
+alter table alter_copy_fulltext_index_txn_t add column c int not null default 0;
+alter table alter_copy_fulltext_index_txn_t modify column body longtext not null;
+commit;
+select count(*) from alter_copy_fulltext_index_txn_t where match(title) against('database' in natural language mode);
+select count(*) from alter_copy_fulltext_index_txn_t where title like '%database%';
+insert into alter_copy_fulltext_index_txn_t values (2, 'database guide', '{new}', 0);
+select count(*) from alter_copy_fulltext_index_txn_t where match(title) against('database' in natural language mode);
+select count(*) from alter_copy_fulltext_index_txn_t where title like '%database%';
+drop table alter_copy_fulltext_index_txn_t;

--- a/test/distributed/cases/ddl/alter_copy_secondary_index_txn.sql
+++ b/test/distributed/cases/ddl/alter_copy_secondary_index_txn.sql
@@ -1,0 +1,54 @@
+drop table if exists alter_copy_secondary_index_txn_t;
+create table alter_copy_secondary_index_txn_t (
+    k varchar(32) not null,
+    s varchar(32) not null,
+    body text not null,
+    key idx_k_s (k, s)
+);
+insert into alter_copy_secondary_index_txn_t (k, s, body) values ('a', 'x', '{}');
+select count(*) from alter_copy_secondary_index_txn_t where k = 'a' and s = 'x';
+begin;
+alter table alter_copy_secondary_index_txn_t add column c int not null default 0;
+alter table alter_copy_secondary_index_txn_t modify column body longtext not null;
+commit;
+select count(*) from alter_copy_secondary_index_txn_t where k = 'a' and s = 'x';
+select count(*) from alter_copy_secondary_index_txn_t where binary k = binary 'a' and binary s = binary 'x';
+insert into alter_copy_secondary_index_txn_t (k, s, body) values ('a', 'x', '{new}');
+select count(*) from alter_copy_secondary_index_txn_t where k = 'a' and s = 'x';
+drop table alter_copy_secondary_index_txn_t;
+
+drop table if exists alter_copy_master_index_txn_t;
+create table alter_copy_master_index_txn_t (
+    k varchar(32) not null,
+    s varchar(32) not null,
+    pk varchar(32) primary key,
+    body text not null,
+    index idx_k_s using master (k, s)
+);
+insert into alter_copy_master_index_txn_t (k, s, pk, body) values ('a', 'x', '1', '{}');
+begin;
+alter table alter_copy_master_index_txn_t add column c int not null default 0;
+alter table alter_copy_master_index_txn_t modify column body longtext not null;
+commit;
+select count(*) from alter_copy_master_index_txn_t where k = 'a' and s = 'x';
+select count(*) from alter_copy_master_index_txn_t where binary k = binary 'a' and binary s = binary 'x';
+insert into alter_copy_master_index_txn_t (k, s, pk, body) values ('a', 'x', '2', '{new}');
+select count(*) from alter_copy_master_index_txn_t where k = 'a' and s = 'x';
+drop table alter_copy_master_index_txn_t;
+
+drop table if exists alter_copy_secondary_index_txn_write_t;
+create table alter_copy_secondary_index_txn_write_t (
+    k varchar(32) not null,
+    s varchar(32) not null,
+    body text not null,
+    key idx_k_s (k, s)
+);
+insert into alter_copy_secondary_index_txn_write_t (k, s, body) values ('a', 'x', '{}');
+begin;
+insert into alter_copy_secondary_index_txn_write_t (k, s, body) values ('b', 'y', '{txn}');
+alter table alter_copy_secondary_index_txn_write_t add column c int not null default 0;
+commit;
+select count(*) from alter_copy_secondary_index_txn_write_t where k = 'a' and s = 'x';
+select count(*) from alter_copy_secondary_index_txn_write_t where k = 'b' and s = 'y';
+select count(*) from alter_copy_secondary_index_txn_write_t where binary k = binary 'b' and binary s = binary 'y';
+drop table alter_copy_secondary_index_txn_write_t;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24762

## What this PR does / why we need it:

When multiple ALTER TABLE COPY DDLs run in the same explicit transaction, a later DDL can clone a hidden secondary index table that was created or written by an earlier DDL in the same transaction. table_clone reads from the snapshot path and cannot see txn-local workspace rows, so the newly cloned hidden index table can miss old rows. Queries that use the secondary index then miss data while base-table scans still find it.

This PR detects txn-local source hidden index tables during cloneUnaffectedIndexes. For regular secondary, unique, master, and sync fulltext indexes, it rebuilds the target hidden index table from the current copied base table instead of using table_clone. Master indexes keep their dedicated backfill SQL, and sync fulltext uses fulltext_index_tokenize instead of the generic serial_full secondary-index SQL. Async fulltext remains on the existing skip/ISCP flow because its index table may be incomplete during ALTER COPY.

It adds UT coverage for the txn-local rebuild predicate and generated fulltext rebuild SQL, plus distributed SQL regressions covering:

- the varchar composite secondary index repro from the issue
- the same txn-local clone problem for USING MASTER indexes
- txn-local hidden index writes before ALTER COPY in the same transaction
- sync fulltext search before/after begin; two COPY DDLs; commit; and after inserting a new row

Tests:

- make build
- go test ./pkg/vm/engine/disttae -run TestTransaction -count=1 with the same CGO include/rpath settings as make build
- go test ./pkg/sql/compile -run TestShouldRebuildTxnLocalIndexClone -count=1 with the same CGO include/rpath settings as make build
- go test ./pkg/sql/compile -run TestShouldRebuildTxnLocalIndexClone\|TestGenRebuildTxnLocalIndexCloneSQLsFullText -count=1 with the same CGO include/rpath settings as make build
- Manually ran test/distributed/cases/ddl/alter_copy_secondary_index_txn.sql against a rebuilt local mo-service; all counts matched the expected result
- Manually verified the focused sync fulltext repro now returns 1 -> 1 -> 2 for match(...) counts, matching the table-scan counts
