### PR TITLE
[codex] fix logservice stale replica truncation

### DIFF
--- a/pkg/logservice/snapshot.go
+++ b/pkg/logservice/snapshot.go
@@ -350,6 +350,15 @@ func (sm *snapshotManager) Remove(shardID uint64, replicaID uint64, index uint64
 	return nil
 }
 
+// RemoveReplica removes all exported snapshots tracked for the specified
+// replica. It is used when local metadata still references a replica that has
+// already been superseded on this store.
+func (sm *snapshotManager) RemoveReplica(shardID uint64, replicaID uint64) error {
+	nid := nodeID{shardID: shardID, replicaID: replicaID}
+	delete(sm.snapshots, nid)
+	return sm.cfg.FS.RemoveAll(sm.exportPath(shardID, replicaID))
+}
+
 // NewestIndex returns the index of the newest exported snapshot tracked
 // by the manager for (shardID, replicaID), or 0 if no items exist.
 // Callers use this to realign shardSnapshotInfo.snapshotIndex after an

--- a/pkg/logservice/truncation.go
+++ b/pkg/logservice/truncation.go
@@ -128,15 +128,59 @@ func (l *store) truncationWorker(ctx context.Context) {
 // processTruncateLog process log truncation for all shards excpet
 // hakeeper shard.
 func (l *store) processTruncateLog(ctx context.Context) error {
+	activeReplicas := l.startedReplicaIDs()
+	processed := make(map[uint64]struct{})
 	for _, shard := range l.getShards() {
 		if shard.ShardID == hakeeper.DefaultHAKeeperShardID {
 			continue
 		}
-		if err := l.processShardTruncateLog(ctx, shard.ShardID); err != nil {
+		replicas := activeReplicas[shard.ShardID]
+		if _, ok := replicas[shard.ReplicaID]; !ok {
+			if len(replicas) > 0 {
+				l.cleanupStaleReplica(shard.ShardID, shard.ReplicaID)
+			}
+			continue
+		}
+		if _, ok := processed[shard.ShardID]; ok {
+			continue
+		}
+		processed[shard.ShardID] = struct{}{}
+		if err := l.processShardTruncateLogWithReplica(ctx, shard.ShardID, shard.ReplicaID); err != nil {
 			l.runtime.Logger().Error("process truncate log failed", zap.Error(err))
 		}
 	}
 	return nil
+}
+
+func (l *store) startedReplicaIDs() map[uint64]map[uint64]struct{} {
+	opts := dragonboat.NodeHostInfoOption{SkipLogInfo: true}
+	nhi := l.nh.GetNodeHostInfo(opts)
+	replicas := make(map[uint64]map[uint64]struct{})
+	for _, ci := range nhi.ShardInfoList {
+		if ci.Pending {
+			continue
+		}
+		if _, ok := replicas[ci.ShardID]; !ok {
+			replicas[ci.ShardID] = make(map[uint64]struct{})
+		}
+		replicas[ci.ShardID][ci.ReplicaID] = struct{}{}
+	}
+	return replicas
+}
+
+func (l *store) cleanupStaleReplica(shardID uint64, replicaID uint64) {
+	l.runtime.Logger().Info("remove stale log replica metadata",
+		zap.Uint64("shardID", shardID),
+		zap.Uint64("replicaID", replicaID),
+	)
+	l.removeMetadata(shardID, replicaID)
+	if err := l.snapshotMgr.RemoveReplica(shardID, replicaID); err != nil {
+		l.runtime.Logger().Error("remove stale exported snapshots failed",
+			zap.Uint64("shardID", shardID),
+			zap.Uint64("replicaID", replicaID),
+			zap.Error(err),
+		)
+	}
 }
 
 // exportSnapshot just export the snapshot but do NOT truncate logs.
@@ -347,6 +391,14 @@ func (l *store) dropNewestOnTimeout(shardID uint64, replicaID uint64) {
 }
 
 func (l *store) processShardTruncateLog(ctx context.Context, shardID uint64) error {
+	replicaID := l.getReplicaID(shardID)
+	if replicaID <= 0 {
+		return nil
+	}
+	return l.processShardTruncateLogWithReplica(ctx, shardID, uint64(replicaID))
+}
+
+func (l *store) processShardTruncateLogWithReplica(ctx context.Context, shardID uint64, replicaID uint64) error {
 	// Do NOT process before leader is OK.
 	leaderID, err := l.leaderID(shardID)
 	if err != nil {
@@ -378,11 +430,8 @@ func (l *store) processShardTruncateLog(ctx context.Context, shardID uint64) err
 		// of wedging permanently. See issue #24315.
 		l.runtime.Logger().Warn("get truncated lsn timed out, tick skipped",
 			zap.Uint64("shardID", shardID), zap.Error(err))
-		if rid := l.getReplicaID(shardID); rid > 0 {
-			replicaID := uint64(rid)
-			if l.snapshotMgr.Count(shardID, replicaID) >= l.cfg.MaxExportedSnapshot {
-				l.dropNewestOnTimeout(shardID, replicaID)
-			}
+		if l.snapshotMgr.Count(shardID, replicaID) >= l.cfg.MaxExportedSnapshot {
+			l.dropNewestOnTimeout(shardID, replicaID)
 		}
 		return nil
 	}
@@ -391,7 +440,6 @@ func (l *store) processShardTruncateLog(ctx context.Context, shardID uint64) err
 		return nil
 	}
 
-	replicaID := uint64(l.getReplicaID(shardID))
 	dir, lsn := l.snapshotMgr.EvalImportSnapshot(shardID, replicaID, lsnInSM)
 	if l.shouldDoImport(ctx, shardID, lsnInSM, lsn, dir) {
 		if err := l.importSnapshot(ctx, shardID, replicaID, lsn, dir); err != nil {

--- a/pkg/logservice/truncation_test.go
+++ b/pkg/logservice/truncation_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/hakeeper"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -88,6 +89,57 @@ func TestTruncationExportSnapshot(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	runServiceTest(t, false, true, fn)
+}
+
+func TestTruncationSkipsStaleReplicaMetadata(t *testing.T) {
+	const (
+		shardID       = uint64(1)
+		staleReplica  = uint64(99)
+		activeReplica = uint64(1)
+	)
+
+	tests := []struct {
+		name   string
+		shards []metadata.LogShard
+	}{
+		{
+			name: "stale before active",
+			shards: []metadata.LogShard{
+				{ShardID: shardID, ReplicaID: staleReplica},
+				{ShardID: shardID, ReplicaID: activeReplica},
+			},
+		},
+		{
+			name: "stale after active",
+			shards: []metadata.LogShard{
+				{ShardID: shardID, ReplicaID: activeReplica},
+				{ShardID: shardID, ReplicaID: staleReplica},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := func(t *testing.T, s *Service) {
+				nid := nodeID{shardID: shardID, replicaID: staleReplica}
+				testPrepareSnapshot(t, s.store.snapshotMgr, nid, snapshotIndex(100))
+				assert.NoError(t, s.store.snapshotMgr.Init(shardID, staleReplica))
+				assert.Equal(t, 1, s.store.snapshotMgr.Count(shardID, staleReplica))
+
+				s.store.mu.Lock()
+				s.store.mu.metadata.Shards = append([]metadata.LogShard(nil), tc.shards...)
+				s.store.mu.Unlock()
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+				defer cancel()
+				assert.NoError(t, s.store.processTruncateLog(ctx))
+
+				assert.Equal(t, int64(activeReplica), s.store.getReplicaID(shardID))
+				assert.Equal(t, 0, s.store.snapshotMgr.Count(shardID, staleReplica))
+			}
+			runServiceTest(t, false, true, fn)
+		})
+	}
 }
 
 func TestTruncationImportSnapshot(t *testing.T) {


### PR DESCRIPTION
## What changed

This PR makes the logservice truncation loop operate only on replicas that are actually running in the local Dragonboat NodeHost.

When local metadata still contains an older replica for a shard that has already been superseded by a new replica on the same store, the truncation loop now:

- detects the active replica set from `GetNodeHostInfo`
- skips stale metadata records instead of using their replica IDs for snapshot import/export
- removes the stale metadata record and its exported snapshot tracking directory once a replacement replica for the same shard is active
- continues truncation with the active replica ID

A regression test covers the case where metadata contains both an old replica and the active replacement replica for the same shard.

## Why

In the reproduced logservice zombie/restore scenario, a store can keep two local metadata records for the same log shard after a replacement replica is added. The truncation worker used the first metadata record returned by `getReplicaID`, so it could attempt to import an exported snapshot into an old replica that Dragonboat no longer runs. That produces repeated `shard not found` failures during truncation and leaves the service in a noisy, unhealthy state even after the zombie startup fix.

## Validation

Attempted focused logservice tests locally:

```sh
GOCACHE=/private/tmp/mo-gocache-logservice-stale GOFLAGS=-mod=mod go test ./pkg/logservice -run 'TestTruncationSkipsStaleReplicaMetadata|TestTruncationExportSnapshot|TestTruncationImportSnapshot|TestTruncationDropNewestOnTimeout' -count=1
```

The local run did not reach test execution because this machine is missing native build headers required by existing dependencies:

- `usearch.h`
- `xxhash.h`
