### PR TITLE
fix hnsw sync add model test timeout

### DIFF
--- a/pkg/vectorindex/hnsw/sync_test.go
+++ b/pkg/vectorindex/hnsw/sync_test.go
@@ -409,24 +409,34 @@ func TestSyncDeleteAndUpsert(t *testing.T) {
 	require.Nil(t, err)
 }
 
-// total 1000100 items and should have two models
+// existing 100 items + 150 inserts should have two models
 func TestSyncAddOneModel(t *testing.T) {
 
 	m := mpool.MustNewZero()
 	proc := testutil.NewProcessWithMPool(t, "", m)
 	sqlproc := sqlexec.NewSqlProcess(proc)
+	proc.SetResolveVariableFunc(func(key string, b1 bool, b2 bool) (any, error) {
+		switch key {
+		case "hnsw_max_index_capacity":
+			return int64(200), nil
+		case "hnsw_threads_build":
+			return int64(8), nil
+		default:
+			return int64(0), nil
+		}
+	})
 
 	runSql = mock_runSql
 	runSql_streaming = mock_runSql_streaming
 	runTxn = mock_runTxn
 	indexes := mockMoIndexes()
 
-	cdc := vectorindex.VectorIndexCdc[float32]{Data: make([]vectorindex.VectorIndexCdcEntry[float32], 0, 1000000)}
+	cdc := vectorindex.VectorIndexCdc[float32]{Data: make([]vectorindex.VectorIndexCdcEntry[float32], 0, 150)}
 
 	key := int64(1000)
 	v := []float32{0.1, 0.2, 0.3}
 
-	for i := 0; i < 1000000; i++ {
+	for i := 0; i < 150; i++ {
 		e := vectorindex.VectorIndexCdcEntry[float32]{Type: vectorindex.CDC_UPSERT, PKey: key, Vec: v}
 		cdc.Data = append(cdc.Data, e)
 		key += 1
@@ -437,7 +447,11 @@ func TestSyncAddOneModel(t *testing.T) {
 
 	sync, err := NewHnswSync[float32](sqlproc, "db", "src", "idx", indexes, int32(types.T_array_float32), 3)
 	require.Nil(t, err)
-	err = sync.RunOnce(sqlproc, &cdc)
+	defer sync.Destroy()
+	err = sync.Update(sqlproc, &cdc)
+	require.Nil(t, err)
+	require.Len(t, sync.indexes, 2)
+	err = sync.Save(sqlproc)
 	require.Nil(t, err)
 }
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24977

## What this PR does / why we need it:

TestSyncAddOneModel used to append 1,000,000 CDC rows to an existing HNSW test model so the total row count crossed the default 1,000,000 model capacity. In coverage CI this made the test spend minutes in the real HNSW add path and it could hit the 10 minute UT timeout.

This PR keeps the same behavior under test but scales the fixture down:

- set hnsw_max_index_capacity to 200 inside the test
- insert 150 new rows into the existing 100-row fixture model
- assert that sync creates the second model before saving

This still covers the add-one-model path without requiring a million-vector HNSW build during CI.

Validation:

- git diff --check
- go test ./pkg/vectorindex/hnsw -run '^TestSyncAddOneModel$' -count=1 -v
- go test ./pkg/vectorindex/hnsw -count=1