### PR TITLE
fix(hnsw): force single-thread build on the CDC/sync write path

### DIFF
--- a/pkg/vectorindex/hnsw/model.go
+++ b/pkg/vectorindex/hnsw/model.go
@@ -63,19 +63,9 @@ type HnswModel[T types.RealNumbers] struct {
 }
 
 // New HnswModel struct
-func NewHnswModelForBuild[T types.RealNumbers](id string, cfg vectorindex.IndexConfig, _ int, max_capacity uint) (*HnswModel[T], error) {
+func NewHnswModelForBuild[T types.RealNumbers](id string, cfg vectorindex.IndexConfig, nthread int, max_capacity uint) (*HnswModel[T], error) {
 	var err error
 	idx := &HnswModel[T]{}
-
-	// MatrixOne #24849 / USearch #735 (open): concurrent add() can orphan nodes --
-	// the vector is stored (contains() returns true) but is never linked into the
-	// HNSW graph, so search() can never reach it, producing flaky recall@1 (an
-	// exact match is intermittently missed). NewHnswBuild forces a single build
-	// thread for the create-index path, but the CDC / sync path still creates
-	// models with ThreadsBuild here. Pin every build model to a single thread so
-	// idx.Index.ChangeThreadsAdd(1) is applied on all write paths until the
-	// upstream race is fixed.
-	nthread := 1
 
 	idx.Id = id
 	idx.NThread = uint(nthread)

--- a/pkg/vectorindex/hnsw/sync.go
+++ b/pkg/vectorindex/hnsw/sync.go
@@ -91,7 +91,10 @@ func NewHnswSync[T types.RealNumbers](sqlproc *sqlexec.SqlProcess,
 		if err != nil {
 			return nil, err
 		}
-		idxtblcfg.ThreadsBuild = vectorindex.GetConcurrencyForBuild(val.(int64))
+		// Force single-thread build until USearch #735 is fixed (concurrent add()
+		// orphans HNSW graph nodes -> flaky recall@1). See
+		// vectorindex.GetConcurrencyForSingleThreadBuild for the one-line revert.
+		idxtblcfg.ThreadsBuild = vectorindex.GetConcurrencyForSingleThreadBuild(val.(int64))
 
 		idxcap, err := sqlproc.GetResolveVariableFunc()("hnsw_max_index_capacity", true, false)
 		if err != nil {
@@ -100,7 +103,10 @@ func NewHnswSync[T types.RealNumbers](sqlproc *sqlexec.SqlProcess,
 		idxtblcfg.IndexCapacity = idxcap.(int64)
 	} else {
 
-		idxtblcfg.ThreadsBuild = vectorindex.GetConcurrencyForBuild(0)
+		// Force single-thread build until USearch #735 is fixed (concurrent add()
+		// orphans HNSW graph nodes -> flaky recall@1). See
+		// vectorindex.GetConcurrencyForSingleThreadBuild for the one-line revert.
+		idxtblcfg.ThreadsBuild = vectorindex.GetConcurrencyForSingleThreadBuild(0)
 		idxtblcfg.IndexCapacity = 1000000
 	}
 

--- a/pkg/vectorindex/types.go
+++ b/pkg/vectorindex/types.go
@@ -317,3 +317,15 @@ func GetConcurrencyForBuild(nthread int64) int64 {
 	}
 	return int64(runtime.NumCPU())
 }
+
+// GetConcurrencyForSingleThreadBuild returns the build concurrency for the HNSW
+// write paths (CDC/sync). While MatrixOne #24849 / USearch #735 (open) is
+// unresolved, concurrent USearch add() can orphan graph nodes — the vector is
+// stored (contains() is true) but never linked into the HNSW graph, so search()
+// can never reach it, producing flaky recall@1. So every HNSW build/sync path
+// must add from a single thread (the model is likewise pinned to
+// ChangeThreadsAdd(1) in NewHnswModelForBuild). When usearch fixes the race,
+// this is a one-line revert: `return GetConcurrencyForBuild(nthread)`.
+func GetConcurrencyForSingleThreadBuild(nthread int64) int64 {
+	return 1
+}


### PR DESCRIPTION
USearch #735 / MatrixOne #24849 (open): concurrent USearch add() can orphan HNSW graph nodes — the vector is stored (contains()==true) but never linked into the graph, so search() can never reach it, producing flaky recall@1. The create-index path (build.go) already forces a single build thread, but the CDC/sync path (HnswSync) still drove insertAllInParallel with ThreadsBuild (= NumCPU by default), issuing concurrent AddUnsafe() to the same index.

- types.go: add GetConcurrencyForSingleThreadBuild (returns 1) with a one-line revert note for when usearch fixes the race. Scoped to HNSW — ivfflat (ivf_create.go) keeps GetConcurrencyForBuild and stays parallel.
- sync.go: NewHnswSync routes ThreadsBuild through the new helper (both the sysvar and default branches), with an inline comment at each call site. The hnsw_threads_build / hnsw_max_index_capacity reads are untouched.
- model.go: revert NewHnswModelForBuild to honor its nthread param again (commit 57a991ec6 had hardcoded nthread:=1). With both callers now passing 1 (build.go forces 1; sync uses the helper) the hardcode is redundant, and removing it avoids a hidden override that would silently keep the model single-threaded even after the helper/build.go are reverted.

Net: AddUnsafe() is single-threaded on all build/write paths (create-index, sequentialUpdate, insertAllInParallel with nthread=1 -> one goroutine; each also ChangeThreadsAdd(1)). Verified: insertAllInParallel nthread=1 at runtime; TestSyncAddOneModel passes single-threaded with no hang.

## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24977

## What this PR does / why we need it:

fix the bug to keep ThreadsBuild to 1 in all build path.