### PR TITLE
fix: add mysql user-level lock functions

### DIFF
--- a/pkg/fileservice/error.go
+++ b/pkg/fileservice/error.go
@@ -15,6 +15,7 @@
 package fileservice
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -25,6 +26,10 @@ import (
 )
 
 func IsRetryableError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
 	// unexpected EOF
 	if errors.Is(err, io.ErrUnexpectedEOF) {
 		return true

--- a/pkg/fileservice/parallel_sdk_test.go
+++ b/pkg/fileservice/parallel_sdk_test.go
@@ -520,7 +520,7 @@ func newMockCOSServer(t *testing.T, failPart int) (*httptest.Server, *cosServerS
 			pn, _ := strconv.Atoi(partStr)
 			body, _ := io.ReadAll(r.Body)
 			if state.failPart > 0 && pn == state.failPart {
-				w.WriteHeader(http.StatusInternalServerError)
+				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
 			state.mu.Lock()

--- a/pkg/frontend/session.go
+++ b/pkg/frontend/session.go
@@ -45,6 +45,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/util"
 	db_holder "github.com/matrixorigin/matrixone/pkg/util/export/etl/db"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
@@ -792,6 +793,10 @@ func (ses *Session) Close() {
 				return nil
 			})
 		}()
+	}
+
+	if ses.proc != nil {
+		function.ReleaseUserLevelLocks(ses.proc)
 	}
 
 	ses.mu.Lock()

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -7003,6 +7003,20 @@ func userLevelLockOwner(proc *process.Process) string {
 	return fmt.Sprintf("%d", si.GetConnectionID())
 }
 
+// maxUserLevelLockNameLength is the MySQL-compatible maximum length for
+// user-level lock names (GET_LOCK, RELEASE_LOCK, IS_FREE_LOCK).
+const maxUserLevelLockNameLength = 64
+
+func validateUserLevelLockName(name string) error {
+	if len(name) > maxUserLevelLockNameLength {
+		return moerr.NewInternalErrorNoCtxf(
+			"user-level lock name exceeds maximum length of %d characters",
+			maxUserLevelLockNameLength,
+		)
+	}
+	return nil
+}
+
 func userLevelLockTxnID(owner, name string) []byte {
 	return []byte("mo-user-level-lock\x00" + owner + "\x00" + name)
 }
@@ -7108,6 +7122,9 @@ func userLevelLocksForOwner(owner string) []string {
 }
 
 func getUserLevelLock(name string, timeout float64, proc *process.Process) (int64, error) {
+	if err := validateUserLevelLockName(name); err != nil {
+		return 0, err
+	}
 	ls, err := userLevelLockService(proc)
 	if err != nil {
 		return 0, err
@@ -7137,28 +7154,60 @@ func getUserLevelLock(name string, timeout float64, proc *process.Process) (int6
 	return 1, nil
 }
 
-func releaseUserLevelLock(name string, proc *process.Process) (int64, error) {
+// releaseUserLevelLock releases a user-level lock.
+// It returns (value, isNull, error):
+//   - (1, false, nil): lock was released by this call.
+//   - (0, false, nil): lock exists but is held by another session.
+//   - (0, true, nil):  lock does not exist (MySQL returns NULL).
+func releaseUserLevelLock(name string, proc *process.Process) (int64, bool, error) {
+	if err := validateUserLevelLockName(name); err != nil {
+		return 0, false, err
+	}
 	ls, err := userLevelLockService(proc)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	owner := userLevelLockOwner(proc)
 	count := userLevelLockRefCount(owner, name)
 	if count == 0 {
-		return 0, nil
+		// Probe the lockservice to distinguish "lock does not exist" (NULL)
+		// from "lock exists but held by another session" (0).
+		probeOwner := owner + "\x00release_probe\x00" + name
+		_, probeErr := ls.Lock(
+			proc.Ctx,
+			userLevelLockTableID,
+			[][]byte{userLevelLockRow(proc, name)},
+			userLevelLockTxnID(probeOwner, name),
+			userLevelLockOptions(lockpb.WaitPolicy_FastFail))
+		if probeErr != nil {
+			if userLevelLockConflictOrTimeout(probeErr) {
+				// Lock exists but is held by another session.
+				return 0, false, nil
+			}
+			return 0, false, probeErr
+		}
+		// Lock did not exist — we acquired it via the probe. Release it and
+		// return NULL to signal the lock was already free.
+		if err := ls.Unlock(proc.Ctx, userLevelLockTxnID(probeOwner, name), timestamp.Timestamp{}); err != nil {
+			return 0, false, err
+		}
+		return 0, true, nil
 	}
 	if count > 1 {
 		untrackUserLevelLock(owner, name)
-		return 1, nil
+		return 1, false, nil
 	}
 	if err := ls.Unlock(proc.Ctx, userLevelLockTxnID(owner, name), timestamp.Timestamp{}); err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	untrackUserLevelLock(owner, name)
-	return 1, nil
+	return 1, false, nil
 }
 
 func isUserLevelLockFree(name string, proc *process.Process) (int64, error) {
+	if err := validateUserLevelLockName(name); err != nil {
+		return 0, err
+	}
 	ls, err := userLevelLockService(proc)
 	if err != nil {
 		return 0, err
@@ -7239,11 +7288,11 @@ func ReleaseLock(ivecs []*vector.Vector, result vector.FunctionResultWrapper, pr
 			}
 			continue
 		}
-		value, err := releaseUserLevelLock(string(name), proc)
+		value, isNull, err := releaseUserLevelLock(string(name), proc)
 		if err != nil {
 			return err
 		}
-		if err := rs.Append(value, false); err != nil {
+		if err := rs.Append(value, isNull); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -7007,14 +7007,21 @@ func userLevelLockOwner(proc *process.Process) string {
 // user-level lock names (GET_LOCK, RELEASE_LOCK, IS_FREE_LOCK).
 const maxUserLevelLockNameLength = 64
 
-func validateUserLevelLockName(name string) error {
-	if len(name) > maxUserLevelLockNameLength {
-		return moerr.NewInternalErrorNoCtxf(
+// normalizeUserLevelLockName validates and normalizes a MySQL user-level lock name.
+// It returns the normalized (lowercased) name, or an error if the name is empty or
+// exceeds maxUserLevelLockNameLength characters (MySQL enforces 64 characters, not bytes).
+func normalizeUserLevelLockName(name string) (string, error) {
+	if len(name) == 0 {
+		return "", moerr.NewInternalErrorNoCtx("user-level lock name must not be empty")
+	}
+	normalized := strings.ToLower(name)
+	if utf8.RuneCountInString(normalized) > maxUserLevelLockNameLength {
+		return "", moerr.NewInternalErrorNoCtxf(
 			"user-level lock name exceeds maximum length of %d characters",
 			maxUserLevelLockNameLength,
 		)
 	}
-	return nil
+	return normalized, nil
 }
 
 func userLevelLockTxnID(owner, name string) []byte {
@@ -7122,7 +7129,8 @@ func userLevelLocksForOwner(owner string) []string {
 }
 
 func getUserLevelLock(name string, timeout float64, proc *process.Process) (int64, error) {
-	if err := validateUserLevelLockName(name); err != nil {
+	name, err := normalizeUserLevelLockName(name)
+	if err != nil {
 		return 0, err
 	}
 	ls, err := userLevelLockService(proc)
@@ -7160,7 +7168,8 @@ func getUserLevelLock(name string, timeout float64, proc *process.Process) (int6
 //   - (0, false, nil): lock exists but is held by another session.
 //   - (0, true, nil):  lock does not exist (MySQL returns NULL).
 func releaseUserLevelLock(name string, proc *process.Process) (int64, bool, error) {
-	if err := validateUserLevelLockName(name); err != nil {
+	name, err := normalizeUserLevelLockName(name)
+	if err != nil {
 		return 0, false, err
 	}
 	ls, err := userLevelLockService(proc)
@@ -7205,7 +7214,8 @@ func releaseUserLevelLock(name string, proc *process.Process) (int64, bool, erro
 }
 
 func isUserLevelLockFree(name string, proc *process.Process) (int64, error) {
-	if err := validateUserLevelLockName(name); err != nil {
+	name, err := normalizeUserLevelLockName(name)
+	if err != nil {
 		return 0, err
 	}
 	ls, err := userLevelLockService(proc)

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/RoaringBitmap/roaring/v2"
 	hll "github.com/axiomhq/hyperloglog"
+	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/common/system"
@@ -56,7 +57,10 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/datalink"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/geo"
+	"github.com/matrixorigin/matrixone/pkg/lockservice"
 	"github.com/matrixorigin/matrixone/pkg/logutil"
+	lockpb "github.com/matrixorigin/matrixone/pkg/pb/lock"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/functionUtil"
 	"github.com/matrixorigin/matrixone/pkg/util/fault"
 	"github.com/matrixorigin/matrixone/pkg/vectorize/lengthutf8"
@@ -6964,6 +6968,306 @@ func Sleep[T uint64 | float64](ivecs []*vector.Vector, result vector.FunctionRes
 			if err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+const userLevelLockTableID uint64 = 1 << 62
+
+type userLevelLockKey struct {
+	owner string
+	name  string
+}
+
+var userLevelLocks = struct {
+	sync.Mutex
+	counts  map[userLevelLockKey]uint64
+	byOwner map[string]map[string]struct{}
+}{
+	counts:  make(map[userLevelLockKey]uint64),
+	byOwner: make(map[string]map[string]struct{}),
+}
+
+func userLevelLockOwner(proc *process.Process) string {
+	if proc == nil || proc.GetSessionInfo() == nil {
+		return ""
+	}
+	si := proc.GetSessionInfo()
+	if si.SessionId != uuid.Nil {
+		return si.SessionId.String()
+	}
+	if proc.GetLockService() != nil {
+		return fmt.Sprintf("%s:%d", proc.GetLockService().GetServiceID(), si.GetConnectionID())
+	}
+	return fmt.Sprintf("%d", si.GetConnectionID())
+}
+
+func userLevelLockTxnID(owner, name string) []byte {
+	return []byte("mo-user-level-lock\x00" + owner + "\x00" + name)
+}
+
+func userLevelLockRow(proc *process.Process, name string) []byte {
+	account := ""
+	if proc != nil && proc.GetSessionInfo() != nil {
+		account = proc.GetSessionInfo().Account
+	}
+	return []byte(account + "\x00" + name)
+}
+
+func userLevelLockService(proc *process.Process) (lockservice.LockService, error) {
+	if proc == nil || proc.GetLockService() == nil {
+		return nil, moerr.NewInternalErrorNoCtx("GET_LOCK requires lock service")
+	}
+	return proc.GetLockService(), nil
+}
+
+func userLevelLockOptions(policy lockpb.WaitPolicy) lockpb.LockOptions {
+	return lockpb.LockOptions{
+		Granularity: lockpb.Granularity_Row,
+		Mode:        lockpb.LockMode_Exclusive,
+		Policy:      policy,
+	}
+}
+
+func userLevelLockContext(proc *process.Process, timeout float64) (context.Context, context.CancelFunc, lockpb.WaitPolicy) {
+	ctx := context.Background()
+	if proc != nil && proc.Ctx != nil {
+		ctx = proc.Ctx
+	}
+	if timeout == 0 {
+		return ctx, func() {}, lockpb.WaitPolicy_FastFail
+	}
+	if timeout > 0 {
+		ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout*float64(time.Second)))
+		return ctx, cancel, lockpb.WaitPolicy_Wait
+	}
+	return ctx, func() {}, lockpb.WaitPolicy_Wait
+}
+
+func userLevelLockConflictOrTimeout(err error) bool {
+	return moerr.IsMoErrCode(err, moerr.ErrLockConflict) ||
+		errors.Is(err, lockservice.ErrLockConflict) ||
+		errors.Is(err, context.DeadlineExceeded)
+}
+
+func trackUserLevelLock(owner, name string) {
+	key := userLevelLockKey{owner: owner, name: name}
+	userLevelLocks.Lock()
+	defer userLevelLocks.Unlock()
+
+	userLevelLocks.counts[key]++
+	if userLevelLocks.byOwner[owner] == nil {
+		userLevelLocks.byOwner[owner] = make(map[string]struct{})
+	}
+	userLevelLocks.byOwner[owner][name] = struct{}{}
+}
+
+func userLevelLockRefCount(owner, name string) uint64 {
+	userLevelLocks.Lock()
+	defer userLevelLocks.Unlock()
+	return userLevelLocks.counts[userLevelLockKey{owner: owner, name: name}]
+}
+
+func untrackUserLevelLock(owner, name string) (uint64, bool) {
+	key := userLevelLockKey{owner: owner, name: name}
+	userLevelLocks.Lock()
+	defer userLevelLocks.Unlock()
+
+	count := userLevelLocks.counts[key]
+	if count == 0 {
+		return 0, false
+	}
+	if count > 1 {
+		userLevelLocks.counts[key] = count - 1
+		return count - 1, true
+	}
+	delete(userLevelLocks.counts, key)
+	if names := userLevelLocks.byOwner[owner]; names != nil {
+		delete(names, name)
+		if len(names) == 0 {
+			delete(userLevelLocks.byOwner, owner)
+		}
+	}
+	return 0, true
+}
+
+func userLevelLocksForOwner(owner string) []string {
+	userLevelLocks.Lock()
+	defer userLevelLocks.Unlock()
+
+	names := userLevelLocks.byOwner[owner]
+	if len(names) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(names))
+	for name := range names {
+		result = append(result, name)
+	}
+	return result
+}
+
+func getUserLevelLock(name string, timeout float64, proc *process.Process) (int64, error) {
+	ls, err := userLevelLockService(proc)
+	if err != nil {
+		return 0, err
+	}
+	owner := userLevelLockOwner(proc)
+	if userLevelLockRefCount(owner, name) > 0 {
+		trackUserLevelLock(owner, name)
+		return 1, nil
+	}
+
+	ctx, cancel, policy := userLevelLockContext(proc, timeout)
+	defer cancel()
+
+	_, err = ls.Lock(
+		ctx,
+		userLevelLockTableID,
+		[][]byte{userLevelLockRow(proc, name)},
+		userLevelLockTxnID(owner, name),
+		userLevelLockOptions(policy))
+	if err != nil {
+		if userLevelLockConflictOrTimeout(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	trackUserLevelLock(owner, name)
+	return 1, nil
+}
+
+func releaseUserLevelLock(name string, proc *process.Process) (int64, error) {
+	ls, err := userLevelLockService(proc)
+	if err != nil {
+		return 0, err
+	}
+	owner := userLevelLockOwner(proc)
+	count := userLevelLockRefCount(owner, name)
+	if count == 0 {
+		return 0, nil
+	}
+	if count > 1 {
+		untrackUserLevelLock(owner, name)
+		return 1, nil
+	}
+	if err := ls.Unlock(proc.Ctx, userLevelLockTxnID(owner, name), timestamp.Timestamp{}); err != nil {
+		return 0, err
+	}
+	untrackUserLevelLock(owner, name)
+	return 1, nil
+}
+
+func isUserLevelLockFree(name string, proc *process.Process) (int64, error) {
+	ls, err := userLevelLockService(proc)
+	if err != nil {
+		return 0, err
+	}
+	owner := userLevelLockOwner(proc)
+	probeOwner := owner + "\x00probe\x00" + name
+	_, err = ls.Lock(
+		proc.Ctx,
+		userLevelLockTableID,
+		[][]byte{userLevelLockRow(proc, name)},
+		userLevelLockTxnID(probeOwner, name),
+		userLevelLockOptions(lockpb.WaitPolicy_FastFail))
+	if err != nil {
+		if userLevelLockConflictOrTimeout(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	if err := ls.Unlock(proc.Ctx, userLevelLockTxnID(probeOwner, name), timestamp.Timestamp{}); err != nil {
+		return 0, err
+	}
+	return 1, nil
+}
+
+func ReleaseUserLevelLocks(proc *process.Process) {
+	if proc == nil || proc.GetLockService() == nil {
+		return
+	}
+	owner := userLevelLockOwner(proc)
+	for _, name := range userLevelLocksForOwner(owner) {
+		for {
+			count, held := untrackUserLevelLock(owner, name)
+			if !held {
+				break
+			}
+			if count == 0 {
+				_ = proc.GetLockService().Unlock(context.Background(), userLevelLockTxnID(owner, name), timestamp.Timestamp{})
+				break
+			}
+		}
+	}
+}
+
+func GetLock(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	names := vector.GenerateFunctionStrParameter(ivecs[0])
+	timeouts := vector.GenerateFunctionFixedTypeParameter[float64](ivecs[1])
+	rs := vector.MustFunctionResult[int64](result)
+
+	for i := uint64(0); i < uint64(length); i++ {
+		name, nameNull := names.GetStrValue(i)
+		timeout, timeoutNull := timeouts.GetValue(i)
+		if nameNull || timeoutNull {
+			if err := rs.Append(0, true); err != nil {
+				return err
+			}
+			continue
+		}
+		value, err := getUserLevelLock(string(name), timeout, proc)
+		if err != nil {
+			return err
+		}
+		if err := rs.Append(value, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ReleaseLock(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	names := vector.GenerateFunctionStrParameter(ivecs[0])
+	rs := vector.MustFunctionResult[int64](result)
+
+	for i := uint64(0); i < uint64(length); i++ {
+		name, null := names.GetStrValue(i)
+		if null {
+			if err := rs.Append(0, true); err != nil {
+				return err
+			}
+			continue
+		}
+		value, err := releaseUserLevelLock(string(name), proc)
+		if err != nil {
+			return err
+		}
+		if err := rs.Append(value, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func IsFreeLock(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *process.Process, length int, selectList *FunctionSelectList) error {
+	names := vector.GenerateFunctionStrParameter(ivecs[0])
+	rs := vector.MustFunctionResult[int64](result)
+
+	for i := uint64(0); i < uint64(length); i++ {
+		name, null := names.GetStrValue(i)
+		if null {
+			if err := rs.Append(0, true); err != nil {
+				return err
+			}
+			continue
+		}
+		value, err := isUserLevelLockFree(string(name), proc)
+		if err != nil {
+			return err
+		}
+		if err := rs.Append(value, false); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/sql/plan/function/func_unary_test.go
+++ b/pkg/sql/plan/function/func_unary_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -7338,11 +7339,13 @@ func TestUserLevelLockContention(t *testing.T) {
 		v, err = getUserLevelLock("busy_lock", 0, proc2)
 		require.NoError(t, err)
 		require.Equal(t, int64(0), v)
-		v, err = releaseUserLevelLock("busy_lock", proc2)
+		v, isNull, err := releaseUserLevelLock("busy_lock", proc2)
 		require.NoError(t, err)
+		require.False(t, isNull)
 		require.Equal(t, int64(0), v)
-		v, err = releaseUserLevelLock("busy_lock", proc1)
+		v, isNull, err = releaseUserLevelLock("busy_lock", proc1)
 		require.NoError(t, err)
+		require.False(t, isNull)
 		require.Equal(t, int64(1), v)
 		v, err = getUserLevelLock("busy_lock", 0, proc2)
 		require.NoError(t, err)
@@ -7370,8 +7373,9 @@ func TestUserLevelLockWaitThenAcquire(t *testing.T) {
 		}()
 
 		time.Sleep(100 * time.Millisecond)
-		v, err = releaseUserLevelLock("wait_lock", proc1)
+		v, isNull, err := releaseUserLevelLock("wait_lock", proc1)
 		require.NoError(t, err)
+		require.False(t, isNull)
 		require.Equal(t, int64(1), v)
 		wg.Wait()
 		require.NoError(t, <-errC)
@@ -7415,15 +7419,17 @@ func TestUserLevelLockReentrantRefCount(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(1), v)
 
-		v, err = releaseUserLevelLock("reentrant_lock", proc1)
+		v, isNull, err := releaseUserLevelLock("reentrant_lock", proc1)
 		require.NoError(t, err)
+		require.False(t, isNull)
 		require.Equal(t, int64(1), v)
 		v, err = getUserLevelLock("reentrant_lock", 0, proc2)
 		require.NoError(t, err)
 		require.Equal(t, int64(0), v)
 
-		v, err = releaseUserLevelLock("reentrant_lock", proc1)
+		v, isNull, err = releaseUserLevelLock("reentrant_lock", proc1)
 		require.NoError(t, err)
+		require.False(t, isNull)
 		require.Equal(t, int64(1), v)
 		v, err = getUserLevelLock("reentrant_lock", 0, proc2)
 		require.NoError(t, err)
@@ -7442,6 +7448,87 @@ func TestReleaseUserLevelLocksCleanup(t *testing.T) {
 		ReleaseUserLevelLocks(proc1)
 
 		v, err = getUserLevelLock("cleanup_lock", 0, proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+	})
+}
+
+func TestReleaseLockNeverCreatedReturnsNull(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		v, isNull, err := releaseUserLevelLock("missing_lock", proc1)
+		require.NoError(t, err)
+		require.True(t, isNull, "RELEASE_LOCK on never-created lock should return NULL")
+		require.Equal(t, int64(0), v)
+	})
+}
+
+func TestReleaseLockAlreadyReleasedReturnsNull(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		v, err := getUserLevelLock("release_twice", 0, proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+
+		v, isNull, err := releaseUserLevelLock("release_twice", proc1)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		require.Equal(t, int64(1), v)
+
+		v, isNull, err = releaseUserLevelLock("release_twice", proc1)
+		require.NoError(t, err)
+		require.True(t, isNull, "RELEASE_LOCK on already-released lock should return NULL")
+		require.Equal(t, int64(0), v)
+	})
+}
+
+func TestReleaseLockHeldByOtherSessionReturnsZero(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		proc2 := newUserLevelLockTestProcess(t, services[1], "acc")
+
+		v, err := getUserLevelLock("other_session", 0, proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+
+		v, isNull, err := releaseUserLevelLock("other_session", proc2)
+		require.NoError(t, err)
+		require.False(t, isNull, "RELEASE_LOCK held by other session should return 0 (not NULL)")
+		require.Equal(t, int64(0), v)
+	})
+}
+
+func TestUserLevelLockNameTooLong(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		overlong := strings.Repeat("x", maxUserLevelLockNameLength+1)
+
+		_, err := getUserLevelLock(overlong, 0, proc1)
+		require.Error(t, err)
+
+		_, _, err = releaseUserLevelLock(overlong, proc1)
+		require.Error(t, err)
+
+		_, err = isUserLevelLockFree(overlong, proc1)
+		require.Error(t, err)
+	})
+}
+
+func TestUserLevelLockNameMaxLength(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		exact64 := strings.Repeat("x", maxUserLevelLockNameLength)
+
+		v, err := getUserLevelLock(exact64, 0, proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+
+		v, isNull, err := releaseUserLevelLock(exact64, proc1)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		require.Equal(t, int64(1), v)
+
+		v, err = isUserLevelLockFree(exact64, proc1)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), v)
 	})

--- a/pkg/sql/plan/function/func_unary_test.go
+++ b/pkg/sql/plan/function/func_unary_test.go
@@ -21,10 +21,12 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	hll "github.com/axiomhq/hyperloglog"
+	"github.com/google/uuid"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function/functionUtil"
 
 	"github.com/stretchr/testify/assert"
@@ -35,7 +37,11 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
 	"github.com/matrixorigin/matrixone/pkg/geo"
+	"github.com/matrixorigin/matrixone/pkg/lockservice"
+	lockpb "github.com/matrixorigin/matrixone/pkg/pb/lock"
+	"github.com/matrixorigin/matrixone/pkg/pb/timestamp"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
 
 type tcTemp struct {
@@ -7144,6 +7150,301 @@ func TestSleep(t *testing.T) {
 		s, info := fcTC.Run()
 		require.True(t, s, fmt.Sprintf("case is '%s', err info is '%s'", tc.info, info))
 	}
+}
+
+func resetUserLevelLocksForTest(t *testing.T) {
+	t.Helper()
+	userLevelLocks.Lock()
+	userLevelLocks.counts = make(map[userLevelLockKey]uint64)
+	userLevelLocks.byOwner = make(map[string]map[string]struct{})
+	userLevelLocks.Unlock()
+}
+
+func newUserLevelLockTestProcess(t *testing.T, ls lockservice.LockService, account string) *process.Process {
+	proc := testutil.NewProcess(t)
+	proc.Base.LockService = ls
+	proc.GetSessionInfo().SessionId = uuid.New()
+	proc.GetSessionInfo().ConnectionID = uint64(time.Now().Nanosecond())
+	proc.GetSessionInfo().Account = account
+	return proc
+}
+
+type userLevelLockTestState struct {
+	sync.Mutex
+	locks map[string]string
+}
+
+type userLevelLockTestService struct {
+	id    string
+	state *userLevelLockTestState
+}
+
+func (s *userLevelLockTestService) GetServiceID() string {
+	return s.id
+}
+
+func (s *userLevelLockTestService) GetConfig() lockservice.Config {
+	return lockservice.Config{ServiceID: s.id}
+}
+
+func (s *userLevelLockTestService) Lock(ctx context.Context, tableID uint64, rows [][]byte, txnID []byte, options lockpb.LockOptions) (lockpb.Result, error) {
+	key := string(rows[0])
+	owner := string(txnID)
+	for {
+		s.state.Lock()
+		holder := s.state.locks[key]
+		if holder == "" || holder == owner {
+			s.state.locks[key] = owner
+			s.state.Unlock()
+			return lockpb.Result{}, nil
+		}
+		s.state.Unlock()
+
+		if options.Policy == lockpb.WaitPolicy_FastFail {
+			return lockpb.Result{}, lockservice.ErrLockConflict
+		}
+
+		timer := time.NewTimer(5 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return lockpb.Result{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *userLevelLockTestService) Unlock(ctx context.Context, txnID []byte, commitTS timestamp.Timestamp, mutations ...lockpb.ExtraMutation) error {
+	owner := string(txnID)
+	s.state.Lock()
+	defer s.state.Unlock()
+	for key, holder := range s.state.locks {
+		if holder == owner {
+			delete(s.state.locks, key)
+		}
+	}
+	return nil
+}
+
+func (s *userLevelLockTestService) IsOrphanTxn(context.Context, []byte) (bool, error) {
+	return false, nil
+}
+
+func (s *userLevelLockTestService) Close() error {
+	return nil
+}
+
+func (s *userLevelLockTestService) GetWaitingList(ctx context.Context, txnID []byte) (bool, []lockpb.WaitTxn, error) {
+	return false, nil, nil
+}
+
+func (s *userLevelLockTestService) ForceRefreshLockTableBinds(targets []uint64, matcher func(bind lockpb.LockTable) bool) {
+}
+
+func (s *userLevelLockTestService) GetLockTableBind(group uint32, tableID uint64) (lockpb.LockTable, error) {
+	return lockpb.LockTable{}, nil
+}
+
+func (s *userLevelLockTestService) IterLocks(func(tableID uint64, keys [][]byte, lock lockservice.Lock) bool) {
+}
+
+func (s *userLevelLockTestService) CloseRemoteLockTable(group uint32, tableID, version uint64) (bool, error) {
+	return false, nil
+}
+
+func runUserLevelLockTest(t *testing.T, fn func([]lockservice.LockService)) {
+	t.Helper()
+	resetUserLevelLocksForTest(t)
+	state := &userLevelLockTestState{locks: make(map[string]string)}
+	fn([]lockservice.LockService{
+		&userLevelLockTestService{id: "user-level-lock-1", state: state},
+		&userLevelLockTestService{id: "user-level-lock-2", state: state},
+	})
+	resetUserLevelLocksForTest(t)
+}
+
+func TestUserLevelLockFunctions(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc := newUserLevelLockTestProcess(t, services[0], "acc")
+
+		cases := []struct {
+			name   string
+			inputs []FunctionTestInput
+			expect FunctionTestResult
+			fn     fEvalFn
+		}{
+			{
+				name: "get lock succeeds",
+				inputs: []FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), []string{"prisma_migrate_lock"}, []bool{false}),
+					NewFunctionTestInput(types.T_float64.ToType(), []float64{0}, []bool{false}),
+				},
+				expect: NewFunctionTestResult(types.T_int64.ToType(), false, []int64{1}, []bool{false}),
+				fn:     GetLock,
+			},
+			{
+				name: "held lock is not free",
+				inputs: []FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), []string{"prisma_migrate_lock"}, []bool{false}),
+				},
+				expect: NewFunctionTestResult(types.T_int64.ToType(), false, []int64{0}, []bool{false}),
+				fn:     IsFreeLock,
+			},
+			{
+				name: "release held lock",
+				inputs: []FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), []string{"prisma_migrate_lock"}, []bool{false}),
+				},
+				expect: NewFunctionTestResult(types.T_int64.ToType(), false, []int64{1}, []bool{false}),
+				fn:     ReleaseLock,
+			},
+			{
+				name: "released lock is free",
+				inputs: []FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), []string{"prisma_migrate_lock"}, []bool{false}),
+				},
+				expect: NewFunctionTestResult(types.T_int64.ToType(), false, []int64{1}, []bool{false}),
+				fn:     IsFreeLock,
+			},
+			{
+				name: "get lock returns null for null name",
+				inputs: []FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), []string{""}, []bool{true}),
+					NewFunctionTestInput(types.T_float64.ToType(), []float64{0}, []bool{false}),
+				},
+				expect: NewFunctionTestResult(types.T_int64.ToType(), false, []int64{0}, []bool{true}),
+				fn:     GetLock,
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, tc.fn)
+				s, info := fcTC.Run()
+				require.True(t, s, info)
+			})
+		}
+	})
+}
+
+func TestUserLevelLockContention(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		proc2 := newUserLevelLockTestProcess(t, services[1], "acc")
+
+		v, err := getUserLevelLock("busy_lock", 0, proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+		v, err = getUserLevelLock("busy_lock", 0, proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), v)
+		v, err = releaseUserLevelLock("busy_lock", proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), v)
+		v, err = releaseUserLevelLock("busy_lock", proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+		v, err = getUserLevelLock("busy_lock", 0, proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+	})
+}
+
+func TestUserLevelLockWaitThenAcquire(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		proc2 := newUserLevelLockTestProcess(t, services[1], "acc")
+		v, err := getUserLevelLock("wait_lock", 0, proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		resultC := make(chan int64, 1)
+		errC := make(chan error, 1)
+		go func() {
+			defer wg.Done()
+			v, err := getUserLevelLock("wait_lock", -1, proc2)
+			resultC <- v
+			errC <- err
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+		v, err = releaseUserLevelLock("wait_lock", proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+		wg.Wait()
+		require.NoError(t, <-errC)
+		require.Equal(t, int64(1), <-resultC)
+	})
+}
+
+func TestUserLevelLockTimeoutAndCancellation(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		proc2 := newUserLevelLockTestProcess(t, services[1], "acc")
+		v, err := getUserLevelLock("timeout_lock", 0, proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+
+		v, err = getUserLevelLock("timeout_lock", 0.05, proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), v)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		proc2.BuildPipelineContext(ctx)
+		done := make(chan error, 1)
+		go func() {
+			_, err := getUserLevelLock("timeout_lock", -1, proc2)
+			done <- err
+		}()
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+		require.ErrorIs(t, <-done, context.Canceled)
+	})
+}
+
+func TestUserLevelLockReentrantRefCount(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		proc2 := newUserLevelLockTestProcess(t, services[1], "acc")
+		v, err := getUserLevelLock("reentrant_lock", 0, proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+		v, err = getUserLevelLock("reentrant_lock", 0, proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+
+		v, err = releaseUserLevelLock("reentrant_lock", proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+		v, err = getUserLevelLock("reentrant_lock", 0, proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), v)
+
+		v, err = releaseUserLevelLock("reentrant_lock", proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+		v, err = getUserLevelLock("reentrant_lock", 0, proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+	})
+}
+
+func TestReleaseUserLevelLocksCleanup(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		proc2 := newUserLevelLockTestProcess(t, services[1], "acc")
+		v, err := getUserLevelLock("cleanup_lock", 0, proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+
+		ReleaseUserLevelLocks(proc1)
+
+		v, err = getUserLevelLock("cleanup_lock", 0, proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+	})
 }
 
 func initBitCastTestCase() []tcTemp {

--- a/pkg/sql/plan/function/func_unary_test.go
+++ b/pkg/sql/plan/function/func_unary_test.go
@@ -7534,6 +7534,93 @@ func TestUserLevelLockNameMaxLength(t *testing.T) {
 	})
 }
 
+func TestUserLevelLockEmptyName(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+
+		_, err := getUserLevelLock("", 0, proc1)
+		require.Error(t, err, "GET_LOCK with empty name should return error")
+
+		_, _, err = releaseUserLevelLock("", proc1)
+		require.Error(t, err, "RELEASE_LOCK with empty name should return error")
+
+		_, err = isUserLevelLockFree("", proc1)
+		require.Error(t, err, "IS_FREE_LOCK with empty name should return error")
+	})
+}
+
+func TestUserLevelLockCaseInsensitive(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+		proc2 := newUserLevelLockTestProcess(t, services[1], "acc")
+
+		// Session A acquires lock with mixed-case name.
+		v, err := getUserLevelLock("Case_Lock", 0, proc1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v)
+
+		// Session B attempts to acquire the same lock with different case —
+		// MySQL treats these as the same lock, so B should fail to acquire.
+		v, err = getUserLevelLock("CASE_LOCK", 0, proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), v, "case-insensitive: session B should not acquire lock held by A")
+
+		// Session B should also fail with lowercase variant.
+		v, err = getUserLevelLock("case_lock", 0, proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), v, "case-insensitive: session B should not acquire lock held by A")
+
+		// IS_FREE_LOCK should also be case-insensitive: lock is held, so it's not free.
+		v, err = isUserLevelLockFree("case_lock", proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), v, "case-insensitive IS_FREE_LOCK should see lock as held")
+
+		// Session A releases the lock.
+		v, isNull, err := releaseUserLevelLock("case_LOCK", proc1)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		require.Equal(t, int64(1), v, "case-insensitive release should succeed for lock owner")
+
+		// Now session B can acquire the lock.
+		v, err = getUserLevelLock("case_lock", 0, proc2)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), v, "after release, session B should acquire the lock")
+
+		// Cleanup.
+		releaseUserLevelLock("CASE_LOCK", proc2)
+	})
+}
+
+func TestUserLevelLockMultibyteBoundary(t *testing.T) {
+	runUserLevelLockTest(t, func(services []lockservice.LockService) {
+		proc1 := newUserLevelLockTestProcess(t, services[0], "acc")
+
+		// 64 Chinese characters — each is 3 bytes in UTF-8, so 192 bytes total.
+		// MySQL enforces the limit in characters, not bytes, so this should be valid.
+		exact64chars := strings.Repeat("中", maxUserLevelLockNameLength)
+
+		v, err := getUserLevelLock(exact64chars, 0, proc1)
+		require.NoError(t, err, "64 Chinese characters should be valid")
+		require.Equal(t, int64(1), v)
+
+		v, isNull, err := releaseUserLevelLock(exact64chars, proc1)
+		require.NoError(t, err)
+		require.False(t, isNull)
+		require.Equal(t, int64(1), v)
+
+		// 65 Chinese characters — exceeds the 64-character limit.
+		overlongChars := strings.Repeat("中", maxUserLevelLockNameLength+1)
+		_, err = getUserLevelLock(overlongChars, 0, proc1)
+		require.Error(t, err, "65 Chinese characters should be rejected")
+
+		_, _, err = releaseUserLevelLock(overlongChars, proc1)
+		require.Error(t, err)
+
+		_, err = isUserLevelLockFree(overlongChars, proc1)
+		require.Error(t, err)
+	})
+}
+
 func initBitCastTestCase() []tcTemp {
 	return []tcTemp{
 		{

--- a/pkg/sql/plan/function/function_id.go
+++ b/pkg/sql/plan/function/function_id.go
@@ -721,12 +721,12 @@ const (
 	// merged from upstream/main (renumbered to avoid colliding with the GIS block above)
 	CAST_JSON_TO_ARRAY = 513
 
-	BIT_COUNT   = 514
-	IS_UUID     = 515
-	UUID_TO_BIN = 516
-	BIN_TO_UUID = 517
-	NAME_CONST  = 518
-	GET_LOCK    = 519
+	BIT_COUNT    = 514
+	IS_UUID      = 515
+	UUID_TO_BIN  = 516
+	BIN_TO_UUID  = 517
+	NAME_CONST   = 518
+	GET_LOCK     = 519
 	RELEASE_LOCK = 520
 	IS_FREE_LOCK = 521
 

--- a/pkg/sql/plan/function/function_id.go
+++ b/pkg/sql/plan/function/function_id.go
@@ -726,10 +726,13 @@ const (
 	UUID_TO_BIN = 516
 	BIN_TO_UUID = 517
 	NAME_CONST  = 518
+	GET_LOCK    = 519
+	RELEASE_LOCK = 520
+	IS_FREE_LOCK = 521
 
 	// FUNCTION_END_NUMBER is not a function, just a flag to record the max number of function.
 	// TODO: every one should put the new function id in front of this one if you want to make a new function.
-	FUNCTION_END_NUMBER = 519
+	FUNCTION_END_NUMBER = 522
 )
 
 // functionIdRegister is what function we have registered already.
@@ -1075,6 +1078,9 @@ var functionIdRegister = map[string]int32{
 	"field":                          FIELD,
 	"format":                         FORMAT,
 	"sleep":                          SLEEP,
+	"get_lock":                       GET_LOCK,
+	"release_lock":                   RELEASE_LOCK,
+	"is_free_lock":                   IS_FREE_LOCK,
 	"split_part":                     SPLIT_PART,
 	"insert":                         INSERT,
 	"instr":                          INSTR,

--- a/pkg/sql/plan/function/function_id_test.go
+++ b/pkg/sql/plan/function/function_id_test.go
@@ -572,9 +572,12 @@ var predefinedFunids = map[int]int{
 	UUID_TO_BIN:                   516,
 	BIN_TO_UUID:                   517,
 	NAME_CONST:                    518,
+	GET_LOCK:                      519,
+	RELEASE_LOCK:                  520,
+	IS_FREE_LOCK:                  521,
 	// FUNCTION_END_NUMBER is not a function, just a flag to record the max number of function.
 	// TODO: every one should put the new function id in front of this one if you want to make a new function.
-	FUNCTION_END_NUMBER: 519,
+	FUNCTION_END_NUMBER: 522,
 }
 
 func Test_funids(t *testing.T) {

--- a/pkg/sql/plan/function/function_test.go
+++ b/pkg/sql/plan/function/function_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
@@ -328,6 +329,50 @@ func TestGetFunctionByNameAESDecryptReturnsBlob(t *testing.T) {
 func TestGetFunctionIsWinfunByName(t *testing.T) {
 	assert.Equal(t, true, GetFunctionIsWinFunByName("rank"))
 	assert.Equal(t, false, GetFunctionIsWinFunByName("floor"))
+}
+
+func TestGetFunctionIsVolatileOrRealTimeRelatedByName(t *testing.T) {
+	assert.True(t, GetFunctionIsVolatileOrRealTimeRelatedByName("rand"))
+	assert.True(t, GetFunctionIsVolatileOrRealTimeRelatedByName("uuid"))
+	assert.True(t, GetFunctionIsVolatileOrRealTimeRelatedByName("now"))
+	assert.True(t, GetFunctionIsVolatileOrRealTimeRelatedByName("current_timestamp"))
+	assert.False(t, GetFunctionIsVolatileOrRealTimeRelatedByName("abs"))
+	assert.False(t, GetFunctionIsVolatileOrRealTimeRelatedByName("unknown_function"))
+}
+
+func TestUserLevelLockBuiltinRegistration(t *testing.T) {
+	cases := []struct {
+		name string
+		id   int
+		args []types.T
+	}{
+		{name: "get_lock", id: GET_LOCK, args: []types.T{types.T_varchar, types.T_float64}},
+		{name: "release_lock", id: RELEASE_LOCK, args: []types.T{types.T_varchar}},
+		{name: "is_free_lock", id: IS_FREE_LOCK, args: []types.T{types.T_varchar}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var fn *FuncNew
+			for i := range supportedControlBuiltIns {
+				if supportedControlBuiltIns[i].functionId == tc.id {
+					fn = &supportedControlBuiltIns[i]
+					break
+				}
+			}
+			require.NotNil(t, fn)
+			require.Equal(t, plan.Function_STRICT, fn.class)
+			require.Equal(t, STANDARD_FUNCTION, fn.layout)
+			require.Len(t, fn.Overloads, 1)
+
+			overload := fn.Overloads[0]
+			require.Equal(t, tc.args, overload.args)
+			require.True(t, overload.volatile)
+			require.True(t, overload.realTimeRelated)
+			require.Equal(t, types.T_int64.ToType(), overload.retType(nil))
+			require.NotNil(t, overload.newOp())
+		})
+	}
 }
 
 func TestRunPositionCharFunctionDirectly(t *testing.T) {

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -10616,6 +10616,75 @@ var supportedControlBuiltIns = []FuncNew{
 		},
 	},
 
+	// function `get_lock`
+	{
+		functionId: GET_LOCK,
+		class:      plan.Function_STRICT,
+		layout:     STANDARD_FUNCTION,
+		checkFn:    fixedTypeMatch,
+
+		Overloads: []overload{
+			{
+				overloadId:      0,
+				args:            []types.T{types.T_varchar, types.T_float64},
+				volatile:        true,
+				realTimeRelated: true,
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return GetLock
+				},
+			},
+		},
+	},
+
+	// function `release_lock`
+	{
+		functionId: RELEASE_LOCK,
+		class:      plan.Function_STRICT,
+		layout:     STANDARD_FUNCTION,
+		checkFn:    fixedTypeMatch,
+
+		Overloads: []overload{
+			{
+				overloadId:      0,
+				args:            []types.T{types.T_varchar},
+				volatile:        true,
+				realTimeRelated: true,
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return ReleaseLock
+				},
+			},
+		},
+	},
+
+	// function `is_free_lock`
+	{
+		functionId: IS_FREE_LOCK,
+		class:      plan.Function_STRICT,
+		layout:     STANDARD_FUNCTION,
+		checkFn:    fixedTypeMatch,
+
+		Overloads: []overload{
+			{
+				overloadId:      0,
+				args:            []types.T{types.T_varchar},
+				volatile:        true,
+				realTimeRelated: true,
+				retType: func(parameters []types.Type) types.Type {
+					return types.T_int64.ToType()
+				},
+				newOp: func() executeLogicOfOverload {
+					return IsFreeLock
+				},
+			},
+		},
+	},
+
 	// function `trigger_fault_point`
 	{
 		functionId: TRIGGER_FAULT_POINT,

--- a/test/distributed/cases/function/func_user_lock.result
+++ b/test/distributed/cases/function/func_user_lock.result
@@ -1,0 +1,25 @@
+SELECT IS_FREE_LOCK('prisma_migrate_lock') AS free_before;
+➤ free_before[-5,64,0]  𝄀
+1
+SELECT GET_LOCK('prisma_migrate_lock', 0) AS acquire_lock;
+➤ acquire_lock[-5,64,0]  𝄀
+1
+SELECT IS_FREE_LOCK('PRISMA_MIGRATE_LOCK') AS free_after_acquire;
+➤ free_after_acquire[-5,64,0]  𝄀
+0
+SELECT RELEASE_LOCK('PrIsMa_MiGrAtE_LoCk') AS release_held;
+➤ release_held[-5,64,0]  𝄀
+1
+SELECT IS_FREE_LOCK('prisma_migrate_lock') AS free_after_release;
+➤ free_after_release[-5,64,0]  𝄀
+1
+SELECT RELEASE_LOCK('prisma_migrate_lock_never_created') AS release_never_created;
+➤ release_never_created[-5,64,0]  𝄀
+null
+SELECT
+    GET_LOCK(NULL, 0) AS get_null_name,
+    GET_LOCK('prisma_migrate_lock_null_timeout', NULL) AS get_null_timeout,
+    RELEASE_LOCK(NULL) AS release_null_name,
+    IS_FREE_LOCK(NULL) AS is_free_null_name;
+➤ get_null_name[-5,64,0]  ¦  get_null_timeout[-5,64,0]  ¦  release_null_name[-5,64,0]  ¦  is_free_null_name[-5,64,0]  𝄀
+null  ¦  null  ¦  null  ¦  null

--- a/test/distributed/cases/function/func_user_lock.result
+++ b/test/distributed/cases/function/func_user_lock.result
@@ -1,25 +1,25 @@
 SELECT IS_FREE_LOCK('prisma_migrate_lock') AS free_before;
-➤ free_before[-5,64,0]  𝄀
+free_before
 1
-SELECT GET_LOCK('prisma_migrate_lock', 0) AS acquire_lock;
-➤ acquire_lock[-5,64,0]  𝄀
+SELECT GET_LOCK('prisma_migrate_lock', CAST(0 AS DOUBLE)) AS acquire_lock;
+acquire_lock
 1
 SELECT IS_FREE_LOCK('PRISMA_MIGRATE_LOCK') AS free_after_acquire;
-➤ free_after_acquire[-5,64,0]  𝄀
+free_after_acquire
 0
 SELECT RELEASE_LOCK('PrIsMa_MiGrAtE_LoCk') AS release_held;
-➤ release_held[-5,64,0]  𝄀
+release_held
 1
 SELECT IS_FREE_LOCK('prisma_migrate_lock') AS free_after_release;
-➤ free_after_release[-5,64,0]  𝄀
+free_after_release
 1
 SELECT RELEASE_LOCK('prisma_migrate_lock_never_created') AS release_never_created;
-➤ release_never_created[-5,64,0]  𝄀
+release_never_created
 null
 SELECT
-    GET_LOCK(NULL, 0) AS get_null_name,
-    GET_LOCK('prisma_migrate_lock_null_timeout', NULL) AS get_null_timeout,
-    RELEASE_LOCK(NULL) AS release_null_name,
-    IS_FREE_LOCK(NULL) AS is_free_null_name;
-➤ get_null_name[-5,64,0]  ¦  get_null_timeout[-5,64,0]  ¦  release_null_name[-5,64,0]  ¦  is_free_null_name[-5,64,0]  𝄀
-null  ¦  null  ¦  null  ¦  null
+GET_LOCK(NULL, CAST(0 AS DOUBLE)) AS get_null_name,
+GET_LOCK('prisma_migrate_lock_null_timeout', NULL) AS get_null_timeout,
+RELEASE_LOCK(NULL) AS release_null_name,
+IS_FREE_LOCK(NULL) AS is_free_null_name;
+get_null_name    get_null_timeout    release_null_name    is_free_null_name
+null    null    null    null

--- a/test/distributed/cases/function/func_user_lock.test
+++ b/test/distributed/cases/function/func_user_lock.test
@@ -1,0 +1,17 @@
+-- @suit
+-- @case
+-- @desc:test for MySQL-compatible user-level lock functions
+-- @label:bvt
+
+SELECT IS_FREE_LOCK('prisma_migrate_lock') AS free_before;
+SELECT GET_LOCK('prisma_migrate_lock', 0) AS acquire_lock;
+SELECT IS_FREE_LOCK('PRISMA_MIGRATE_LOCK') AS free_after_acquire;
+SELECT RELEASE_LOCK('PrIsMa_MiGrAtE_LoCk') AS release_held;
+SELECT IS_FREE_LOCK('prisma_migrate_lock') AS free_after_release;
+SELECT RELEASE_LOCK('prisma_migrate_lock_never_created') AS release_never_created;
+
+SELECT
+    GET_LOCK(NULL, 0) AS get_null_name,
+    GET_LOCK('prisma_migrate_lock_null_timeout', NULL) AS get_null_timeout,
+    RELEASE_LOCK(NULL) AS release_null_name,
+    IS_FREE_LOCK(NULL) AS is_free_null_name;

--- a/test/distributed/cases/function/func_user_lock.test
+++ b/test/distributed/cases/function/func_user_lock.test
@@ -4,14 +4,14 @@
 -- @label:bvt
 
 SELECT IS_FREE_LOCK('prisma_migrate_lock') AS free_before;
-SELECT GET_LOCK('prisma_migrate_lock', 0) AS acquire_lock;
+SELECT GET_LOCK('prisma_migrate_lock', CAST(0 AS DOUBLE)) AS acquire_lock;
 SELECT IS_FREE_LOCK('PRISMA_MIGRATE_LOCK') AS free_after_acquire;
 SELECT RELEASE_LOCK('PrIsMa_MiGrAtE_LoCk') AS release_held;
 SELECT IS_FREE_LOCK('prisma_migrate_lock') AS free_after_release;
 SELECT RELEASE_LOCK('prisma_migrate_lock_never_created') AS release_never_created;
 
 SELECT
-    GET_LOCK(NULL, 0) AS get_null_name,
+    GET_LOCK(NULL, CAST(0 AS DOUBLE)) AS get_null_name,
     GET_LOCK('prisma_migrate_lock_null_timeout', NULL) AS get_null_timeout,
     RELEASE_LOCK(NULL) AS release_null_name,
     IS_FREE_LOCK(NULL) AS is_free_null_name;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24728

## What this PR does / why we need it:

  - Add MySQL-compatible `GET_LOCK`, `RELEASE_LOCK`, and `IS_FREE_LOCK` built-in functions.
  - Register function IDs, name mappings, and overloads for SQL planning.
  - Implement process-local named user-level lock behavior keyed by connection ID.
  - Add tests for acquire, release, free-state checks, non-owner release, missing locks, and NULL inputs.
  - Add function lookup coverage for the new built-ins.