### PR TITLE
fix: keep file stage external writes on current CN

### DIFF
--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -4111,6 +4111,13 @@ func (c *Compile) compileInsert(nodes []*plan.Node, node *plan.Node, ss []*Scope
 		// One timestamp per statement: all scopes must expand WRITE_FILE_PATTERN
 		// time directives against the same instant.
 		stmtAt := externalInsertStmtTime(c.proc, c.startAt)
+		localFileStage, err := externalInsertTargetIsLocalFile(c.proc, node, stmtAt)
+		if err != nil {
+			return nil, err
+		}
+		if localFileStage && (len(ss) != 1 || ss[0].NodeInfo.Mcpu != 1 || !isSameCN(ss[0].NodeInfo.Addr, c.addr)) {
+			ss = []*Scope{c.newMergeScope(ss)}
+		}
 		for i := range ss {
 			insertArg, err := constructExternalInsert(c.proc, node, c.e, stmtAt)
 			if err != nil {

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -4115,8 +4115,20 @@ func (c *Compile) compileInsert(nodes []*plan.Node, node *plan.Node, ss []*Scope
 		if err != nil {
 			return nil, err
 		}
-		if localFileStage && (len(ss) != 1 || ss[0].NodeInfo.Mcpu != 1 || !isSameCN(ss[0].NodeInfo.Addr, c.addr)) {
-			ss = []*Scope{c.newMergeScope(ss)}
+		if localFileStage {
+			// Only merge scopes that would execute on a remote CN.
+			// Same-CN parallel writers share the same filesystem and
+			// use unique filename directives (%U / %<n>N), so they are safe.
+			hasRemote := false
+			for _, s := range ss {
+				if !isSameCN(s.NodeInfo.Addr, c.addr) {
+					hasRemote = true
+					break
+				}
+			}
+			if hasRemote {
+				ss = []*Scope{c.newMergeScope(ss)}
+			}
 		}
 		for i := range ss {
 			insertArg, err := constructExternalInsert(c.proc, node, c.e, stmtAt)

--- a/pkg/sql/compile/compile.go
+++ b/pkg/sql/compile/compile.go
@@ -4116,19 +4116,23 @@ func (c *Compile) compileInsert(nodes []*plan.Node, node *plan.Node, ss []*Scope
 			return nil, err
 		}
 		if localFileStage {
-			// Only merge scopes that would execute on a remote CN.
+			// Only merge scopes on remote CNs onto the current CN.
 			// Same-CN parallel writers share the same filesystem and
-			// use unique filename directives (%U / %<n>N), so they are safe.
-			hasRemote := false
+			// use unique filename directives (%U / %<n>N), so they are safe
+			// to keep unmerged.
+			var localSS, remoteSS []*Scope
 			for _, s := range ss {
-				if !isSameCN(s.NodeInfo.Addr, c.addr) {
-					hasRemote = true
-					break
+				if isSameCN(s.NodeInfo.Addr, c.addr) {
+					localSS = append(localSS, s)
+				} else {
+					remoteSS = append(remoteSS, s)
 				}
 			}
-			if hasRemote {
-				ss = []*Scope{c.newMergeScope(ss)}
+			if len(remoteSS) > 0 {
+				mergedRemote := c.newMergeScope(remoteSS)
+				localSS = append(localSS, mergedRemote)
 			}
+			ss = localSS
 		}
 		for i := range ss {
 			insertArg, err := constructExternalInsert(c.proc, node, c.e, stmtAt)

--- a/pkg/sql/compile/operator.go
+++ b/pkg/sql/compile/operator.go
@@ -93,6 +93,8 @@ import (
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/rule"
+	"github.com/matrixorigin/matrixone/pkg/stage"
+	"github.com/matrixorigin/matrixone/pkg/stage/stageutil"
 	"github.com/matrixorigin/matrixone/pkg/util/executor"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -940,6 +942,33 @@ func constructExternalInsert(
 ) (vm.Operator, error) {
 	oldCtx := node.InsertCtx
 	return buildExternalInsertArg(proc.Ctx, oldCtx.Ref, oldCtx.TableDef, oldCtx.AddAffectedRows, eng, stmtAt)
+}
+
+// externalInsertTargetIsLocalFile reports whether WRITE_FILE_PATTERN resolves
+// through a stage backed by file://. Such paths are local to the CN that writes
+// them, so remote CN writers would make files invisible to the coordinator's
+// follow-up external-table scan.
+func externalInsertTargetIsLocalFile(proc *process.Process, node *plan.Node, stmtAt time.Time) (bool, error) {
+	if node == nil || node.InsertCtx == nil || node.InsertCtx.TableDef == nil {
+		return false, nil
+	}
+	param := &tree.ExternParam{}
+	if err := json.Unmarshal([]byte(node.InsertCtx.TableDef.Createsql), param); err != nil {
+		return false, err
+	}
+	pattern, ok := plan2.GetWriteFilePattern(param)
+	if !ok {
+		return false, nil
+	}
+	expanded, err := externalwrite.ExpandFilePattern(pattern, stmtAt)
+	if err != nil {
+		return false, err
+	}
+	sdef, err := stageutil.UrlToStageDef(expanded, proc)
+	if err != nil {
+		return false, err
+	}
+	return sdef.Url.Scheme == stage.FILE_PROTOCOL, nil
 }
 
 // buildExternalInsertArg builds the external-write insert operator from the

--- a/pkg/sql/compile/operator_extwrite_test.go
+++ b/pkg/sql/compile/operator_extwrite_test.go
@@ -17,6 +17,7 @@ package compile
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 	"testing"
 	"time"
 
@@ -25,6 +26,9 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/insert"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/matrixorigin/matrixone/pkg/stage"
+	"github.com/matrixorigin/matrixone/pkg/vm"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 	"github.com/stretchr/testify/require"
 )
@@ -117,6 +121,152 @@ func TestExternalInsertStmtTime(t *testing.T) {
 	arg := op.(*insert.Insert)
 	defer arg.Release()
 	require.True(t, arg.InsertCtx.ExternalConfig.Stmt.Equal(want))
+}
+
+func TestExternalInsertTargetIsLocalFile(t *testing.T) {
+	proc := process.NewTopProcess(context.Background(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	fileURL, err := url.Parse("file:///tmp/wext")
+	require.NoError(t, err)
+	s3URL, err := url.Parse("s3://bucket/wext")
+	require.NoError(t, err)
+	proc.GetStageCache().Set("local_stage", stage.StageDef{Name: "local_stage", Url: fileURL})
+	proc.GetStageCache().Set("s3_stage", stage.StageDef{Name: "s3_stage", Url: s3URL})
+
+	node := &plan.Node{InsertCtx: &plan.InsertCtx{TableDef: &plan.TableDef{
+		TableType: catalog.SystemExternalRel,
+		Createsql: extWriteCreatesql(t, "stage://local_stage/p-%U.csv"),
+	}}}
+	isLocal, err := externalInsertTargetIsLocalFile(proc, node, time.Unix(1, 0).UTC())
+	require.NoError(t, err)
+	require.True(t, isLocal)
+
+	node.InsertCtx.TableDef.Createsql = extWriteCreatesql(t, "stage://s3_stage/p-%U.csv")
+	isLocal, err = externalInsertTargetIsLocalFile(proc, node, time.Unix(1, 0).UTC())
+	require.NoError(t, err)
+	require.False(t, isLocal)
+
+	isLocal, err = externalInsertTargetIsLocalFile(proc, nil, time.Unix(1, 0).UTC())
+	require.NoError(t, err)
+	require.False(t, isLocal)
+
+	node.InsertCtx.TableDef.Createsql = "{not json"
+	isLocal, err = externalInsertTargetIsLocalFile(proc, node, time.Unix(1, 0).UTC())
+	require.Error(t, err)
+	require.False(t, isLocal)
+
+	node.InsertCtx.TableDef.Createsql = extWriteCreatesql(t, "")
+	isLocal, err = externalInsertTargetIsLocalFile(proc, node, time.Unix(1, 0).UTC())
+	require.NoError(t, err)
+	require.False(t, isLocal)
+
+	node.InsertCtx.TableDef.Createsql = extWriteCreatesql(t, "stage://local_stage/p-%.csv")
+	isLocal, err = externalInsertTargetIsLocalFile(proc, node, time.Unix(1, 0).UTC())
+	require.Error(t, err)
+	require.False(t, isLocal)
+
+	node.InsertCtx.TableDef.Createsql = extWriteCreatesql(t, "file:///tmp/wext/p-%U.csv")
+	isLocal, err = externalInsertTargetIsLocalFile(proc, node, time.Unix(1, 0).UTC())
+	require.Error(t, err)
+	require.False(t, isLocal)
+}
+
+func TestCompileExternalInsertFileStageMergesToCurrentCN(t *testing.T) {
+	proc := process.NewTopProcess(context.Background(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	fileURL, err := url.Parse("file:///tmp/wext")
+	require.NoError(t, err)
+	proc.GetStageCache().Set("local_stage", stage.StageDef{Name: "local_stage", Url: fileURL})
+
+	c := NewCompile("127.0.0.1:6001", "db", "insert into wext select * from src", "tenant", "uid", nil, proc, nil, false, nil, time.Unix(1, 0).UTC())
+	c.anal = &AnalyzeModule{isFirst: true}
+	node := &plan.Node{InsertCtx: &plan.InsertCtx{
+		Ref:             &plan.ObjectRef{ObjName: "wext"},
+		AddAffectedRows: true,
+		TableDef: &plan.TableDef{
+			Name:      "wext",
+			TableType: catalog.SystemExternalRel,
+			Createsql: extWriteCreatesql(t, "stage://local_stage/p-%U.csv"),
+			Cols:      []*plan.ColDef{{Name: "a"}},
+		},
+	}}
+	input := []*Scope{
+		{Magic: Remote, NodeInfo: engine.Node{Addr: "127.0.0.2:6001", Mcpu: 1}, Proc: proc.NewNoContextChildProc(1)},
+		{Magic: Remote, NodeInfo: engine.Node{Addr: "127.0.0.3:6001", Mcpu: 1}, Proc: proc.NewNoContextChildProc(1)},
+	}
+
+	out, err := c.compileInsert(nil, node, input)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, "127.0.0.1:6001", out[0].NodeInfo.Addr)
+	require.Len(t, out[0].PreScopes, 2)
+	require.IsType(t, &insert.Insert{}, out[0].RootOp)
+	require.Equal(t, vm.Insert, out[0].RootOp.OpType())
+
+	c.anal = &AnalyzeModule{isFirst: true}
+	input = []*Scope{
+		{Magic: Remote, NodeInfo: engine.Node{Addr: "127.0.0.2:6001", Mcpu: 1}, Proc: proc.NewNoContextChildProc(1)},
+	}
+	out, err = c.compileInsert(nil, node, input)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, "127.0.0.1:6001", out[0].NodeInfo.Addr)
+	require.Len(t, out[0].PreScopes, 1)
+}
+
+func TestCompileExternalInsertReturnsFileStageResolveError(t *testing.T) {
+	proc := process.NewTopProcess(context.Background(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	c := NewCompile("127.0.0.1:6001", "db", "insert into wext select * from src", "tenant", "uid", nil, proc, nil, false, nil, time.Unix(1, 0).UTC())
+	c.anal = &AnalyzeModule{isFirst: true}
+	node := &plan.Node{InsertCtx: &plan.InsertCtx{
+		TableDef: &plan.TableDef{
+			Name:      "wext",
+			TableType: catalog.SystemExternalRel,
+			Createsql: extWriteCreatesql(t, "file:///tmp/wext/p-%U.csv"),
+			Cols:      []*plan.ColDef{{Name: "a"}},
+		},
+	}}
+	input := []*Scope{
+		{Magic: Remote, NodeInfo: engine.Node{Addr: "127.0.0.2:6001", Mcpu: 1}, Proc: proc.NewNoContextChildProc(1)},
+	}
+
+	out, err := c.compileInsert(nil, node, input)
+	require.Error(t, err)
+	require.Nil(t, out)
+}
+
+func TestCompileExternalInsertS3StageKeepsRemoteScopes(t *testing.T) {
+	proc := process.NewTopProcess(context.Background(), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	s3URL, err := url.Parse("s3://bucket/wext")
+	require.NoError(t, err)
+	proc.GetStageCache().Set("s3_stage", stage.StageDef{Name: "s3_stage", Url: s3URL})
+
+	c := NewCompile("127.0.0.1:6001", "db", "insert into wext select * from src", "tenant", "uid", nil, proc, nil, false, nil, time.Unix(1, 0).UTC())
+	c.anal = &AnalyzeModule{isFirst: true}
+	node := &plan.Node{InsertCtx: &plan.InsertCtx{
+		Ref:             &plan.ObjectRef{ObjName: "wext"},
+		AddAffectedRows: true,
+		TableDef: &plan.TableDef{
+			Name:      "wext",
+			TableType: catalog.SystemExternalRel,
+			Createsql: extWriteCreatesql(t, "stage://s3_stage/p-%U.csv"),
+			Cols:      []*plan.ColDef{{Name: "a"}},
+		},
+	}}
+	input := []*Scope{
+		{Magic: Remote, NodeInfo: engine.Node{Addr: "127.0.0.2:6001", Mcpu: 1}, Proc: proc.NewNoContextChildProc(1)},
+		{Magic: Remote, NodeInfo: engine.Node{Addr: "127.0.0.3:6001", Mcpu: 1}, Proc: proc.NewNoContextChildProc(1)},
+	}
+
+	out, err := c.compileInsert(nil, node, input)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	require.Equal(t, "127.0.0.2:6001", out[0].NodeInfo.Addr)
+	require.Equal(t, "127.0.0.3:6001", out[1].NodeInfo.Addr)
+	require.Empty(t, out[0].PreScopes)
+	require.Empty(t, out[1].PreScopes)
+	require.IsType(t, &insert.Insert{}, out[0].RootOp)
+	require.Equal(t, vm.Insert, out[0].RootOp.OpType())
+	require.IsType(t, &insert.Insert{}, out[1].RootOp)
+	require.Equal(t, vm.Insert, out[1].RootOp.OpType())
 }
 
 // TestExternalInsertDupOperator ensures parallelizing a scope keeps the


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #24995

## What this PR does / why we need it:

Writable external tables can target a `stage://` path backed by `file://`. That file storage is local to the CN that performs the write. When an `INSERT ... SELECT` plan is distributed across remote CNs, remote writers create files on their own local filesystems, so the coordinator CN may only read a subset of the generated files later.

This PR detects whether `WRITE_FILE_PATTERN` resolves to a `file://` stage and, for that case only, merges distributed insert input back to the current CN before building the external write operator. Shared stages such as S3 keep the existing distributed behavior.

Tests added/updated:

- detect whether a writable external target resolves to local file storage
- verify `file://` stage inserts merge back to current CN
- verify S3-backed stages keep remote scopes

Tested with:

```sh
make thirdparties
CGO_ENABLED=1 CGO_CFLAGS="-I$(pwd)/thirdparties/install/include" CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -Wl,-rpath,$(pwd)/thirdparties/install/lib" LD_LIBRARY_PATH="$(pwd)/thirdparties/install/lib:${LD_LIBRARY_PATH}" go test ./pkg/sql/compile -run 'TestExternalInsert(TargetIsLocalFile|FileStageMergesToCurrentCN|S3StageKeepsRemoteScopes|StmtTime|RemoteRunRoundtrip|RemoteRunTailParity|DupOperator)'\n```