### PR TITLE
fix: honor if exists for missing drop index

### DIFF
--- a/pkg/sql/compile/ddl.go
+++ b/pkg/sql/compile/ddl.go
@@ -2443,6 +2443,10 @@ func (s *Scope) DropIndex(c *Compile) error {
 	defer s.ScopeAnalyzer.Stop()
 
 	qry := s.Plan.GetDdl().GetDropIndex()
+	if qry.GetIndexName() == "" {
+		// Planner uses an empty index name for DROP INDEX IF EXISTS no-op plans.
+		return nil
+	}
 
 	// resolve temporary table real name if needed
 	if session := c.proc.GetSession(); session != nil {

--- a/pkg/sql/compile/ddl_test.go
+++ b/pkg/sql/compile/ddl_test.go
@@ -164,6 +164,20 @@ func TestTableScopedDDLDatabaseEOBMapsToNoSuchTable(t *testing.T) {
 		require.True(t, moerr.IsMoErrCode(err, moerr.ErrNoSuchTable))
 	})
 
+	t.Run("DropIndexIfExistsNoop", func(t *testing.T) {
+		s := &Scope{Plan: &plan2.Plan{Plan: &plan2.Plan_Ddl{Ddl: &plan2.DataDefinition{
+			Definition: &plan2.DataDefinition_DropIndex{
+				DropIndex: &plan2.DropIndex{
+					Database: "db1",
+					Table:    "t2",
+				},
+			},
+		}}}}
+
+		err := s.DropIndex(newCompileWithStubEngine(t, newStubEngine(), "drop index if exists t2_idx on t2"))
+		require.NoError(t, err)
+	})
+
 	t.Run("DropTableSingle", func(t *testing.T) {
 		eng := newStubEngine()
 		eng.dbErr = moerr.GetOkExpectedEOB()

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -3756,7 +3756,12 @@ func buildDropIndex(stmt *tree.DropIndex, ctx CompilerContext) (*Plan, error) {
 	}
 
 	if !found {
-		return nil, moerr.NewInternalErrorf(ctx.GetContext(), "not found index: %s", dropIndex.IndexName)
+		if stmt.IfExists {
+			// An empty index name represents the no-op path for DROP INDEX IF EXISTS.
+			dropIndex.IndexName = ""
+		} else {
+			return nil, moerr.NewInternalErrorf(ctx.GetContext(), "not found index: %s", dropIndex.IndexName)
+		}
 	}
 
 	return &Plan{

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -736,18 +736,6 @@ func TestDropIndexIfExistsMissingIndex(t *testing.T) {
 	require.Contains(t, err.Error(), "not found index: nonexist")
 }
 
-func TestUpdateFromUsesAggDedup(t *testing.T) {
-	mock := NewMockOptimizer(true)
-
-	logicPlan, err := runOneStmt(mock, t,
-		"UPDATE emp SET emp.sal = dept.deptno FROM dept WHERE emp.deptno = dept.deptno")
-	if err != nil {
-		t.Fatalf("build PostgreSQL-style update from: %v", err)
-	}
-
-	assertFallbackUpdateAggDedupWithAnyValue(t, logicPlan.GetQuery())
-}
-
 func TestUpdateFallbackMultiTargetGeneratedColumnsKeepProjectLayout(t *testing.T) {
 	mock := NewMockOptimizer(true)
 	setMockGeneratedColumn(t, mock, "emp", "ename", "job")

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"

--- a/pkg/sql/plan/build_test.go
+++ b/pkg/sql/plan/build_test.go
@@ -720,6 +720,33 @@ func TestUpdate(t *testing.T) {
 	runTestShouldError(mock, t, sqls)
 }
 
+func TestDropIndexIfExistsMissingIndex(t *testing.T) {
+	mock := NewMockOptimizer(true)
+
+	logicPlan, err := runOneStmt(mock, t, "drop index if exists nonexist on test_idx")
+	require.NoError(t, err)
+	testDeepCopy(logicPlan)
+	dropIndex := logicPlan.GetDdl().GetDropIndex()
+	require.NotNil(t, dropIndex)
+	require.Equal(t, "", dropIndex.GetIndexName())
+
+	_, err = runOneStmt(mock, t, "drop index nonexist on test_idx")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found index: nonexist")
+}
+
+func TestUpdateFromUsesAggDedup(t *testing.T) {
+	mock := NewMockOptimizer(true)
+
+	logicPlan, err := runOneStmt(mock, t,
+		"UPDATE emp SET emp.sal = dept.deptno FROM dept WHERE emp.deptno = dept.deptno")
+	if err != nil {
+		t.Fatalf("build PostgreSQL-style update from: %v", err)
+	}
+
+	assertFallbackUpdateAggDedupWithAnyValue(t, logicPlan.GetQuery())
+}
+
 func TestUpdateFallbackMultiTargetGeneratedColumnsKeepProjectLayout(t *testing.T) {
 	mock := NewMockOptimizer(true)
 	setMockGeneratedColumn(t, mock, "emp", "ename", "job")

--- a/test/distributed/cases/ddl/drop_if_exists.result
+++ b/test/distributed/cases/ddl/drop_if_exists.result
@@ -36,6 +36,9 @@ drop view if exists v1;
 No database selected
 use db1;
 drop index if exists idx1 on t1;
+drop index if exists idx1 on t1;
+drop index idx1 on t1;
+internal error: not found index: idx1
 show index from t1;
 Table    Non_unique    Key_name    Seq_in_index    Column_name    Collation    Cardinality    Sub_part    Packed    Null    Index_type    Comment    Index_comment    Index_params    Visible    Expression
 t1    0    PRIMARY    1    empno    A    0    NULL    NULL                        YES    empno

--- a/test/distributed/cases/ddl/drop_if_exists.sql
+++ b/test/distributed/cases/ddl/drop_if_exists.sql
@@ -39,6 +39,8 @@ drop view if exists v1;
 
 use db1;
 drop index if exists idx1 on t1;
+drop index if exists idx1 on t1;
+drop index idx1 on t1;
 show index from t1;
 drop view if exists v1;
 drop table if exists t1;
@@ -62,7 +64,6 @@ select disable_fault_injection();
 commit;
 
 drop database test;
-
 
 
 

--- a/test/distributed/cases/pessimistic_transaction/vector/vector.result
+++ b/test/distributed/cases/pessimistic_transaction/vector/vector.result
@@ -47,7 +47,6 @@ id    title    category    price    emb
 1    doc-1    a    10.5    [0.12, 0.22, 0.32, 0.42]
 3    doc-3    a    11.1    [0.2, 0.12, 0.01, 0.55]
 drop index if exists idx_items_emb on items;
-internal error: not found index: idx_items_emb
 create index idx_items_emb using hnsw on items (emb) op_type "vector_l2_ops" m 48 ef_construction 64 ef_search 64;
 show create table items;
 Table    Create Table


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24821

## What this PR does / why we need it:

Cherry-pick #25006 to `4.0-dev`.

- Treat missing indexes as a no-op for `DROP INDEX IF EXISTS` instead of returning `not found index`.
- Keep the existing error behavior for `DROP INDEX` without `IF EXISTS`.
- Add planner, compile, and BVT coverage for the missing-index path.

Validation:

- `gofmt`
- `git show --check --oneline HEAD`
- `go test ./pkg/sql/plan` and `go test ./pkg/sql/compile` were blocked locally by missing C headers: `usearch.h` and `xxhash.h`.
- Focused mo-tester was not repeated for this cherry-pick because the same local flow hung during cleanup without producing a fresh report while validating #25006.
