### PR TITLE
fix: maintain vector/fulltext index synchronously on REPLACE (#25000)

### DIFF
--- a/pkg/sql/plan/bind_replace.go
+++ b/pkg/sql/plan/bind_replace.go
@@ -39,12 +39,258 @@ func (builder *QueryBuilder) bindReplace(stmt *tree.Replace, bindCtx *BindContex
 		return 0, err
 	}
 
+	// Collect the irregular (vector) indexes that must be maintained synchronously
+	// BEFORE initInsertReplaceStmt strips them from tableDef.Indexes. The modern
+	// REPLACE path otherwise drops these indexes silently, leaving newly inserted /
+	// replaced rows unsearchable until the next cron reindex (issue #25000).
+	syncIvfIndexes, err := collectSyncIvfMultiIndexes(dmlCtx.tableDefs[0])
+	if err != nil {
+		return 0, err
+	}
+	syncFulltextIndexes, err := collectSyncFulltextIndexes(dmlCtx.tableDefs[0])
+	if err != nil {
+		return 0, err
+	}
+
 	lastNodeID, colName2Idx, skipUniqueIdx, err := builder.initInsertReplaceStmt(bindCtx, stmt.Rows, stmt.Columns, dmlCtx.objRefs[0], dmlCtx.tableDefs[0], true)
 	if err != nil {
 		return 0, err
 	}
 
-	return builder.appendDedupAndMultiUpdateNodesForBindReplace(bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx)
+	return builder.appendDedupAndMultiUpdateNodesForBindReplace(bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx, syncIvfIndexes, syncFulltextIndexes)
+}
+
+// deferredReplaceIvfCtx captures everything needed to build the synchronous
+// ivfflat entries maintenance sub-plans for a REPLACE, deferred until after
+// createQuery. A REPLACE inserts new entries for every incoming row (insert side)
+// and deletes the old entries of every conflicting row (delete side). Both sides
+// read the same processed-new-rows sink: on a primary-key conflict the new PK
+// equals the replaced row's PK, so deleting the entries whose org_pk matches an
+// incoming PK removes exactly the stale entries; a brand-new PK matches no entry
+// and deletes nothing.
+type deferredReplaceIvfCtx struct {
+	objRef            *plan.ObjectRef
+	tableDef          *plan.TableDef
+	multiTableIndexes map[string]*MultiTableIndex
+	fulltextIndexes   []*plan.IndexDef
+	newRowsSourceStep int32
+}
+
+// drainDeferredReplaceIvf builds the ivfflat entries-insert sub-plans collected
+// while binding REPLACE. It must be called AFTER createQuery: the sub-plans use
+// the legacy sink-based builders (positional column references, hand-optimized),
+// which would panic / be mis-rewritten if run through createQuery's per-step
+// optimize+remap pipeline — the same reason the legacy insert path builds its
+// index plans after createQuery.
+func (builder *QueryBuilder) drainDeferredReplaceIvf() error {
+	if len(builder.deferredReplaceIvf) == 0 {
+		return nil
+	}
+
+	stepCountBefore := len(builder.qry.Steps)
+	for _, ivf := range builder.deferredReplaceIvf {
+		if len(ivf.multiTableIndexes) > 0 {
+			// delete side: remove the stale entries of the conflicting rows first.
+			if err := builder.buildReplaceIvfDelete(ivf); err != nil {
+				return err
+			}
+			// insert side: add entries for every incoming row.
+			ivfBindCtx := NewBindContext(builder, nil)
+			if err := buildPreInsertMultiTableIndexes(builder.compCtx, builder, ivfBindCtx,
+				ivf.objRef, ivf.tableDef, ivf.newRowsSourceStep, ivf.multiTableIndexes); err != nil {
+				return err
+			}
+		}
+
+		// fulltext: one POSTDML node per index deletes the conflicting rows' stale
+		// inverted entries (by doc id = the incoming PK) and re-tokenizes the new
+		// rows, all reading the same processed-new-rows sink.
+		if err := builder.buildReplaceFulltext(ivf); err != nil {
+			return err
+		}
+	}
+	builder.deferredReplaceIvf = nil
+
+	// Finalize ONLY the newly appended index steps, the same lightweight pass the
+	// legacy DML paths apply via tempOptimizeForDML (stats + hash-map / joinmap
+	// message tags). The main REPLACE step was already fully finalized by
+	// createQuery and must not be reprocessed.
+	for i := stepCountBefore; i < len(builder.qry.Steps); i++ {
+		rootID := builder.qry.Steps[i]
+		ReCalcNodeStats(rootID, builder, true, false, true)
+		builder.handleHashMapMessages(rootID)
+	}
+	return nil
+}
+
+// buildReplaceIvfDelete appends the ivfflat entries-delete sub-plan that removes
+// the stale index entries of the rows a REPLACE conflicts on. It reads the
+// processed new rows (the same sink the insert side uses) and projects them into a
+// tableDef.Cols layout carrying the incoming primary key (NULL for the other
+// columns), then feeds the legacy buildDeleteMultiTableIndexes (isUpdate=false),
+// which joins the entries table on org_pk = the incoming PK and deletes the match.
+//
+// On a primary-key conflict the incoming PK equals the replaced row's PK, so its
+// old entry (org_pk == that PK) is deleted; the insert side then re-adds the entry
+// for the new vector. A brand-new PK matches no entry and deletes nothing.
+func (builder *QueryBuilder) buildReplaceIvfDelete(ivf *deferredReplaceIvfCtx) error {
+	tableDef := ivf.tableDef
+	delBindCtx := NewBindContext(builder, nil)
+
+	// SINK_SCAN the processed new rows (projList2 layout: tableDef.Cols order with
+	// Row_ID dropped, so the primary key sits at its tableDef.Cols index).
+	scanID := appendSinkScanNode(builder, delBindCtx, ivf.newRowsSourceStep)
+
+	pkColIdx := tableDef.Name2ColIndex[tableDef.Pkey.PkeyColName]
+	oldRowProj := make([]*plan.Expr, len(tableDef.Cols))
+	for i, col := range tableDef.Cols {
+		if int32(i) == pkColIdx {
+			oldRowProj[i] = &plan.Expr{
+				Typ: col.Typ,
+				Expr: &plan.Expr_Col{
+					Col: &plan.ColRef{RelPos: 0, ColPos: pkColIdx},
+				},
+			}
+		} else {
+			oldRowProj[i] = &plan.Expr{
+				Typ:  col.Typ,
+				Expr: &plan.Expr_Lit{Lit: &plan.Literal{Isnull: true}},
+			}
+		}
+	}
+	projID := builder.appendNode(&plan.Node{
+		NodeType:    plan.Node_PROJECT,
+		Children:    []int32{scanID},
+		ProjectList: oldRowProj,
+	}, delBindCtx)
+
+	sinkID := appendSinkNode(builder, delBindCtx, projID)
+	oldRowsStep := builder.appendStep(sinkID)
+
+	delCtx := &dmlPlanCtx{
+		objRef:          ivf.objRef,
+		tableDef:        tableDef,
+		sourceStep:      oldRowsStep,
+		updateColLength: 0,
+	}
+	return buildDeleteMultiTableIndexes(builder.compCtx, builder, delBindCtx, delCtx, ivf.multiTableIndexes)
+}
+
+// buildReplaceFulltext appends, for each synchronously-maintained fulltext index,
+// a single POSTDML node that maintains the inverted-index table for the REPLACE.
+// It reads the processed new rows and, with both delete and insert enabled,
+// removes each row's stale inverted entries keyed by the incoming primary key
+// (doc id) and then re-tokenizes the new row. For a brand-new PK the delete part
+// matches nothing and only the insert part takes effect.
+func (builder *QueryBuilder) buildReplaceFulltext(ivf *deferredReplaceIvfCtx) error {
+	for idx, indexdef := range ivf.fulltextIndexes {
+		ftBindCtx := NewBindContext(builder, nil)
+		indexObjRef, indexTableDef, err := builder.compCtx.ResolveIndexTableByRef(ivf.objRef, indexdef.IndexTableName, nil)
+		if err != nil {
+			return err
+		}
+		if indexTableDef == nil {
+			return moerr.NewNoSuchTable(builder.GetContext(), ivf.objRef.SchemaName, indexdef.IndexName)
+		}
+		const (
+			isDelete               = true
+			isInsert               = true
+			isDeleteWithoutFilters = false
+		)
+		if err := buildPostDmlFullTextIndex(builder.compCtx, builder, ftBindCtx,
+			indexObjRef, indexTableDef, ivf.tableDef, ivf.newRowsSourceStep,
+			indexdef, idx, isDelete, isInsert, isDeleteWithoutFilters); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// collectSyncIvfMultiIndexes groups the non-async ivfflat index definitions of a
+// table by index name (metadata / centroids / entries), mirroring the grouping in
+// buildInsertPlansWithRelatedHiddenTable. These are the irregular indexes the
+// modern REPLACE path must maintain synchronously. Async-maintained indexes
+// (catalog.IsIndexAsync) are left to the cron and excluded here, exactly as the
+// legacy insert/update paths do.
+func collectSyncIvfMultiIndexes(tableDef *plan.TableDef) (map[string]*MultiTableIndex, error) {
+	res := make(map[string]*MultiTableIndex)
+	for _, indexdef := range tableDef.Indexes {
+		if !indexdef.TableExist || !catalog.IsIvfIndexAlgo(indexdef.IndexAlgo) {
+			continue
+		}
+		async, err := catalog.IsIndexAsync(indexdef.IndexAlgoParams)
+		if err != nil {
+			return nil, err
+		}
+		if async {
+			continue
+		}
+		if _, ok := res[indexdef.IndexName]; !ok {
+			res[indexdef.IndexName] = &MultiTableIndex{
+				IndexAlgo:       catalog.ToLower(indexdef.IndexAlgo),
+				IndexAlgoParams: indexdef.IndexAlgoParams,
+				IndexDefs:       make(map[string]*IndexDef),
+			}
+		}
+		res[indexdef.IndexName].IndexDefs[catalog.ToLower(indexdef.IndexAlgoTableType)] = indexdef
+	}
+	return res, nil
+}
+
+// collectSyncFulltextIndexes returns the non-async fulltext index definitions of a
+// table that the modern REPLACE path must maintain synchronously. Async indexes
+// are left to the cron, exactly as the legacy insert/update paths do.
+func collectSyncFulltextIndexes(tableDef *plan.TableDef) ([]*plan.IndexDef, error) {
+	var res []*plan.IndexDef
+	for _, indexdef := range tableDef.Indexes {
+		if !indexdef.TableExist || !catalog.IsFullTextIndexAlgo(indexdef.IndexAlgo) {
+			continue
+		}
+		async, err := catalog.IsIndexAsync(indexdef.IndexAlgoParams)
+		if err != nil {
+			return nil, err
+		}
+		if async {
+			continue
+		}
+		res = append(res, indexdef)
+	}
+	return res, nil
+}
+
+// sinkNewRowsForReplace materializes the processed new-row projection into a SINK
+// step and returns the step id together with a SINK_SCAN node that re-exposes the
+// rows under the original binding tag. The caller keeps using the same tag for the
+// main conflict-resolution branch, while index-maintenance sub-plans read the same
+// step via their own SINK_SCAN — guaranteeing the new rows are computed once.
+func (builder *QueryBuilder) sinkNewRowsForReplace(bindCtx *BindContext, nodeID, tag int32) (int32, int32) {
+	sinkProj := getProjectionByLastNode(builder, nodeID)
+	sinkID := builder.appendNode(&plan.Node{
+		NodeType:    plan.Node_SINK,
+		Children:    []int32{nodeID},
+		ProjectList: sinkProj,
+	}, bindCtx)
+	sourceStep := builder.appendStep(sinkID)
+
+	scanProj := make([]*plan.Expr, len(sinkProj))
+	for i, e := range sinkProj {
+		scanProj[i] = &plan.Expr{
+			Typ: e.Typ,
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{
+					RelPos: tag,
+					ColPos: int32(i),
+				},
+			},
+		}
+	}
+	scanID := builder.appendNode(&plan.Node{
+		NodeType:    plan.Node_SINK_SCAN,
+		SourceStep:  []int32{sourceStep},
+		ProjectList: scanProj,
+		BindingTags: []int32{tag},
+	}, bindCtx)
+	return sourceStep, scanID
 }
 
 func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
@@ -53,6 +299,8 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 	lastNodeID int32,
 	colName2Idx map[string]int32,
 	skipUniqueIdx []bool,
+	syncIvfIndexes map[string]*MultiTableIndex,
+	syncFulltextIndexes []*plan.IndexDef,
 ) (int32, error) {
 	objRef := dmlCtx.objRefs[0]
 	tableDef := dmlCtx.tableDefs[0]
@@ -62,6 +310,31 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindReplace(
 
 	selectNode := builder.qry.Nodes[lastNodeID]
 	selectTag := selectNode.BindingTags[0]
+
+	// Synchronous ivfflat maintenance (issue #25000): the processed new-row
+	// projection must be materialized once and shared, so that auto-increment /
+	// generated columns are evaluated a single time and the same values flow into
+	// both the main conflict-resolution branch and the index-entries insert branch.
+	// Sink it and point the main branch at a SINK_SCAN carrying the same binding
+	// tag (so every downstream ColRef on selectTag stays valid). The main branch
+	// copies the entire new-row projection into fullProjList below, so remap keeps
+	// all sink columns and the tableDef.Cols layout the entries sub-plan relies on
+	// is preserved. The entries-insert sub-plan itself is built AFTER createQuery
+	// (see drainDeferredReplaceIvf), exactly like the legacy insert path, because
+	// it is hand-built with positional column refs and must not be re-optimized.
+	if len(syncIvfIndexes) > 0 || len(syncFulltextIndexes) > 0 {
+		newRowsStep, newScanID := builder.sinkNewRowsForReplace(bindCtx, lastNodeID, selectTag)
+		lastNodeID = newScanID
+		selectNode = builder.qry.Nodes[lastNodeID]
+
+		builder.deferredReplaceIvf = append(builder.deferredReplaceIvf, &deferredReplaceIvfCtx{
+			objRef:            objRef,
+			tableDef:          tableDef,
+			newRowsSourceStep: newRowsStep,
+			multiTableIndexes: syncIvfIndexes,
+			fulltextIndexes:   syncFulltextIndexes,
+		})
+	}
 
 	fullProjTag := builder.genNewBindTag()
 	fullProjList := make([]*plan.Expr, 0, len(selectNode.ProjectList)+len(tableDef.Cols))

--- a/pkg/sql/plan/build.go
+++ b/pkg/sql/plan/build.go
@@ -126,6 +126,14 @@ func bindAndOptimizeReplaceQuery(ctx CompilerContext, stmt *tree.Replace, isPrep
 		return nil, err
 	}
 
+	// Build the synchronous ivfflat index-maintenance sub-plans (issue #25000)
+	// AFTER createQuery, mirroring the legacy insert sequencing: these sink-based
+	// sub-plans use positional column references and must not be re-run through
+	// createQuery's optimize/remap pipeline.
+	if err = builder.drainDeferredReplaceIvf(); err != nil {
+		return nil, err
+	}
+
 	// Generate DetectSqls for self-referencing FK constraint checks.
 	tblInfo, err := getDmlTableInfo(ctx, tree.TableExprs{stmt.Table}, nil, nil, "replace")
 	if err != nil {

--- a/pkg/sql/plan/index_table_dml_test.go
+++ b/pkg/sql/plan/index_table_dml_test.go
@@ -24,6 +24,76 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestCollectSyncIvfMultiIndexes verifies that REPLACE collects only the
+// synchronously-maintained ivfflat index groups: async ivf indexes, regular
+// secondary indexes and not-yet-created index tables are excluded, and the three
+// ivf table-type defs of one index are grouped under that index name.
+func TestCollectSyncIvfMultiIndexes(t *testing.T) {
+	ivfAlgo := catalog.MoIndexIvfFlatAlgo.ToString()
+	mkIvf := func(name, tblType, params string) *planpb.IndexDef {
+		return &planpb.IndexDef{
+			IndexName:          name,
+			IndexAlgo:          ivfAlgo,
+			IndexAlgoTableType: tblType,
+			IndexAlgoParams:    params,
+			TableExist:         true,
+		}
+	}
+
+	tableDef := &planpb.TableDef{
+		Indexes: []*planpb.IndexDef{
+			mkIvf("idx", catalog.SystemSI_IVFFLAT_TblType_Metadata, ""),
+			mkIvf("idx", catalog.SystemSI_IVFFLAT_TblType_Centroids, ""),
+			mkIvf("idx", catalog.SystemSI_IVFFLAT_TblType_Entries, ""),
+			// async ivf index -> maintained by cron, excluded
+			mkIvf("idx_async", catalog.SystemSI_IVFFLAT_TblType_Metadata, `{"async":"true"}`),
+			// regular secondary index -> handled by MULTI_UPDATE, excluded
+			{IndexName: "reg", IndexAlgo: "", TableExist: true},
+			// ivf index whose hidden table is not created yet -> excluded
+			{IndexName: "idx_notbl", IndexAlgo: ivfAlgo, IndexAlgoTableType: catalog.SystemSI_IVFFLAT_TblType_Metadata, TableExist: false},
+		},
+	}
+
+	res, err := collectSyncIvfMultiIndexes(tableDef)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Contains(t, res, "idx")
+	require.Len(t, res["idx"].IndexDefs, 3)
+	require.NotContains(t, res, "idx_async")
+	require.NotContains(t, res, "reg")
+	require.NotContains(t, res, "idx_notbl")
+
+	// A table without any ivf index yields an empty (non-nil) map.
+	empty, err := collectSyncIvfMultiIndexes(&planpb.TableDef{})
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}
+
+// TestCollectSyncFulltextIndexes verifies that REPLACE collects only the
+// synchronously-maintained fulltext indexes: async fulltext indexes, non-fulltext
+// indexes and not-yet-created index tables are excluded.
+func TestCollectSyncFulltextIndexes(t *testing.T) {
+	ftAlgo := catalog.MOIndexFullTextAlgo.ToString()
+	tableDef := &planpb.TableDef{
+		Indexes: []*planpb.IndexDef{
+			{IndexName: "ft", IndexAlgo: ftAlgo, TableExist: true},
+			{IndexName: "ft_async", IndexAlgo: ftAlgo, TableExist: true, IndexAlgoParams: `{"async":"true"}`},
+			{IndexName: "ft_notbl", IndexAlgo: ftAlgo, TableExist: false},
+			{IndexName: "ivf", IndexAlgo: catalog.MoIndexIvfFlatAlgo.ToString(), TableExist: true},
+			{IndexName: "reg", IndexAlgo: "", TableExist: true},
+		},
+	}
+
+	res, err := collectSyncFulltextIndexes(tableDef)
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, "ft", res[0].IndexName)
+
+	empty, err := collectSyncFulltextIndexes(&planpb.TableDef{})
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}
+
 // only use in developing
 func TestSingleSQLQuery(t *testing.T) {
 	//sql := "update emp set comm = 1200 where deptno = 10"
@@ -449,7 +519,7 @@ func TestBindReplaceWithUniqueSecondaryIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	rootID, err := builder.appendDedupAndMultiUpdateNodesForBindReplace(
-		bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx,
+		bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx, nil, nil,
 	)
 	require.NoError(t, err)
 	require.NotZero(t, rootID)
@@ -503,7 +573,7 @@ func TestBindReplaceWithCompositeUniqueIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	rootID, err := builder.appendDedupAndMultiUpdateNodesForBindReplace(
-		bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx,
+		bindCtx, dmlCtx, lastNodeID, colName2Idx, skipUniqueIdx, nil, nil,
 	)
 	require.NoError(t, err)
 	require.NotZero(t, rootID)

--- a/pkg/sql/plan/types.go
+++ b/pkg/sql/plan/types.go
@@ -200,6 +200,13 @@ type QueryBuilder struct {
 
 	deleteNode map[uint64]int32 //delete node in this query. key is tableId, value is the nodeId of sinkScan node in the delete plan
 
+	// deferredReplaceIvf carries the synchronous ivfflat index maintenance for a
+	// REPLACE statement (issue #25000). It is populated while binding REPLACE and
+	// consumed AFTER createQuery, mirroring the legacy insert sequencing: the
+	// index sub-plans are hand-built with positional column references and must
+	// not be re-run through createQuery's per-step optimize/remap pipeline.
+	deferredReplaceIvf []*deferredReplaceIvfCtx
+
 	// spill memory for aggregate function
 	aggSpillMem int64
 

--- a/test/distributed/cases/fulltext/fulltext_replace.result
+++ b/test/distributed/cases/fulltext/fulltext_replace.result
@@ -1,0 +1,37 @@
+drop database if exists ft_replace;
+create database ft_replace;
+use ft_replace;
+create table t(id int primary key, body text);
+insert into t values(1,'apple banana'),(2,'cherry date'),(3,'elderberry fig');
+create fulltext index ftidx on t(body);
+replace into t values(5,'grape kiwi');
+select id from t where match(body) against('grape') order by id;
+➤ id[4,32,0]
+select id from t where match(body) against('kiwi') order by id;
+➤ id[4,32,0]
+replace into t values(1,'mango melon');
+select id from t where match(body) against('mango') order by id;
+➤ id[4,32,0]
+select id from t where match(body) against('apple') order by id;
+➤ id[4,32,0]  𝄀
+1
+select id from t where match(body) against('banana') order by id;
+➤ id[4,32,0]  𝄀
+1
+replace into t values(2,'mango pear'),(7,'apple quince'),(3,'mango plum');
+select id from t where match(body) against('mango') order by id;
+➤ id[4,32,0]
+select id from t where match(body) against('apple') order by id;
+➤ id[4,32,0]  𝄀
+1
+select id from t where match(body) against('cherry') order by id;
+➤ id[4,32,0]  𝄀
+2
+select id, body from t order by id;
+➤ id[4,32,0]  ¦  body[12,0,0]  𝄀
+1  ¦  mango melon  𝄀
+2  ¦  mango pear  𝄀
+3  ¦  mango plum  𝄀
+5  ¦  grape kiwi  𝄀
+7  ¦  apple quince
+drop database if exists ft_replace;

--- a/test/distributed/cases/fulltext/fulltext_replace.result
+++ b/test/distributed/cases/fulltext/fulltext_replace.result
@@ -6,27 +6,30 @@ insert into t values(1,'apple banana'),(2,'cherry date'),(3,'elderberry fig');
 create fulltext index ftidx on t(body);
 replace into t values(5,'grape kiwi');
 select id from t where match(body) against('grape') order by id;
-➤ id[4,32,0]
+➤ id[4,32,0]  𝄀
+5
 select id from t where match(body) against('kiwi') order by id;
-➤ id[4,32,0]
+➤ id[4,32,0]  𝄀
+5
 replace into t values(1,'mango melon');
 select id from t where match(body) against('mango') order by id;
-➤ id[4,32,0]
+➤ id[4,32,0]  𝄀
+1
 select id from t where match(body) against('apple') order by id;
-➤ id[4,32,0]  𝄀
-1
+➤ id[4,32,0]
 select id from t where match(body) against('banana') order by id;
-➤ id[4,32,0]  𝄀
-1
+➤ id[4,32,0]
 replace into t values(2,'mango pear'),(7,'apple quince'),(3,'mango plum');
 select id from t where match(body) against('mango') order by id;
-➤ id[4,32,0]
+➤ id[4,32,0]  𝄀
+1  𝄀
+2  𝄀
+3
 select id from t where match(body) against('apple') order by id;
 ➤ id[4,32,0]  𝄀
-1
+7
 select id from t where match(body) against('cherry') order by id;
-➤ id[4,32,0]  𝄀
-2
+➤ id[4,32,0]
 select id, body from t order by id;
 ➤ id[4,32,0]  ¦  body[12,0,0]  𝄀
 1  ¦  mango melon  𝄀

--- a/test/distributed/cases/fulltext/fulltext_replace.sql
+++ b/test/distributed/cases/fulltext/fulltext_replace.sql
@@ -1,0 +1,33 @@
+-- REPLACE INTO must keep a fulltext index consistent, the same way INSERT does:
+-- a row inserted or whose indexed text is changed via REPLACE has to be
+-- immediately reflected in a MATCH ... AGAINST search, and the stale tokens of a
+-- replaced row must no longer match.
+
+drop database if exists ft_replace;
+create database ft_replace;
+use ft_replace;
+
+create table t(id int primary key, body text);
+insert into t values(1,'apple banana'),(2,'cherry date'),(3,'elderberry fig');
+create fulltext index ftidx on t(body);
+
+-- REPLACE a brand-new PK row (= insert): its tokens must be searchable.
+replace into t values(5,'grape kiwi');
+select id from t where match(body) against('grape') order by id;
+select id from t where match(body) against('kiwi') order by id;
+
+-- REPLACE an existing row's text: the new tokens match, the stale tokens do not.
+replace into t values(1,'mango melon');
+select id from t where match(body) against('mango') order by id;
+select id from t where match(body) against('apple') order by id;
+select id from t where match(body) against('banana') order by id;
+
+-- Multi-row REPLACE mixing new and existing rows.
+replace into t values(2,'mango pear'),(7,'apple quince'),(3,'mango plum');
+select id from t where match(body) against('mango') order by id;
+select id from t where match(body) against('apple') order by id;
+select id from t where match(body) against('cherry') order by id;
+
+select id, body from t order by id;
+
+drop database if exists ft_replace;

--- a/test/distributed/cases/vector/vector_ivf_replace.result
+++ b/test/distributed/cases/vector/vector_ivf_replace.result
@@ -9,43 +9,43 @@ replace into t values(7,'[5,5,6]');
 select id from t order by l2_distance(b,'[5,5,5]') limit 3;
 ➤ id[4,32,0]  𝄀
 5  𝄀
-4  𝄀
-3
+7  𝄀
+4
 insert into t values(8,'[5,4,5]');
 select id from t order by l2_distance(b,'[5,5,5]') limit 4;
 ➤ id[4,32,0]  𝄀
 5  𝄀
+7  𝄀
 8  𝄀
-4  𝄀
-3
+4
 replace into t values(1,'[5,5,4]');
 select id from t where id=1;
 ➤ id[4,32,0]  𝄀
 1
 select id from t order by l2_distance(b,'[1,1,1]') limit 3;
 ➤ id[4,32,0]  𝄀
-1  𝄀
 2  𝄀
-3
+3  𝄀
+4
 select id from t order by l2_distance(b,'[5,5,5]') limit 5;
 ➤ id[4,32,0]  𝄀
 5  𝄀
+1  𝄀
+7  𝄀
 8  𝄀
-4  𝄀
-3  𝄀
-2
+4
 replace into t values(2,'[5,5,3]'),(9,'[5,6,5]'),(3,'[0,0,0]');
 select id from t order by l2_distance(b,'[5,5,5]') limit 6;
 ➤ id[4,32,0]  𝄀
 5  𝄀
+9  𝄀
+7  𝄀
 8  𝄀
-4  𝄀
-3  𝄀
-2  𝄀
-1
+1  𝄀
+4
 select id from t order by l2_distance(b,'[3,3,3]') limit 3;
 ➤ id[4,32,0]  𝄀
-3  𝄀
 4  𝄀
-2
+2  𝄀
+1
 drop database if exists vec_ivf_replace;

--- a/test/distributed/cases/vector/vector_ivf_replace.result
+++ b/test/distributed/cases/vector/vector_ivf_replace.result
@@ -1,0 +1,51 @@
+drop database if exists vec_ivf_replace;
+create database vec_ivf_replace;
+use vec_ivf_replace;
+set probe_limit=2;
+create table t(id int primary key, b vecf32(3));
+insert into t values(1,'[1,1,1]'),(2,'[2,2,2]'),(3,'[3,3,3]'),(4,'[4,4,4]'),(5,'[5,5,5]');
+create index idx using ivfflat on t(b) lists=2 op_type 'vector_l2_ops';
+replace into t values(7,'[5,5,6]');
+select id from t order by l2_distance(b,'[5,5,5]') limit 3;
+➤ id[4,32,0]  𝄀
+5  𝄀
+4  𝄀
+3
+insert into t values(8,'[5,4,5]');
+select id from t order by l2_distance(b,'[5,5,5]') limit 4;
+➤ id[4,32,0]  𝄀
+5  𝄀
+8  𝄀
+4  𝄀
+3
+replace into t values(1,'[5,5,4]');
+select id from t where id=1;
+➤ id[4,32,0]  𝄀
+1
+select id from t order by l2_distance(b,'[1,1,1]') limit 3;
+➤ id[4,32,0]  𝄀
+1  𝄀
+2  𝄀
+3
+select id from t order by l2_distance(b,'[5,5,5]') limit 5;
+➤ id[4,32,0]  𝄀
+5  𝄀
+8  𝄀
+4  𝄀
+3  𝄀
+2
+replace into t values(2,'[5,5,3]'),(9,'[5,6,5]'),(3,'[0,0,0]');
+select id from t order by l2_distance(b,'[5,5,5]') limit 6;
+➤ id[4,32,0]  𝄀
+5  𝄀
+8  𝄀
+4  𝄀
+3  𝄀
+2  𝄀
+1
+select id from t order by l2_distance(b,'[3,3,3]') limit 3;
+➤ id[4,32,0]  𝄀
+3  𝄀
+4  𝄀
+2
+drop database if exists vec_ivf_replace;

--- a/test/distributed/cases/vector/vector_ivf_replace.sql
+++ b/test/distributed/cases/vector/vector_ivf_replace.sql
@@ -1,0 +1,40 @@
+-- REPLACE INTO must keep a synchronous ivfflat index consistent, the same way
+-- INSERT does: a row inserted or whose vector is changed via REPLACE has to be
+-- immediately reflected in an index-ordered ANN/KNN query.
+-- lists=2 with probe_limit>=lists probes every centroid, so results are
+-- deterministic.
+
+drop database if exists vec_ivf_replace;
+create database vec_ivf_replace;
+use vec_ivf_replace;
+
+set probe_limit=2;
+
+create table t(id int primary key, b vecf32(3));
+insert into t values(1,'[1,1,1]'),(2,'[2,2,2]'),(3,'[3,3,3]'),(4,'[4,4,4]'),(5,'[5,5,5]');
+create index idx using ivfflat on t(b) lists=2 op_type 'vector_l2_ops';
+
+-- REPLACE a brand-new PK row (= insert): it must be searchable immediately.
+replace into t values(7,'[5,5,6]');
+select id from t order by l2_distance(b,'[5,5,5]') limit 3;
+
+-- Plain INSERT of a brand-new row, for comparison.
+insert into t values(8,'[5,4,5]');
+select id from t order by l2_distance(b,'[5,5,5]') limit 4;
+
+-- REPLACE an existing row's vector: the KNN must use the NEW vector, the stale
+-- indexed vector must be gone.
+replace into t values(1,'[5,5,4]');
+select id from t where id=1;
+-- id=1 is now far from [1,1,1], so it must NOT come back as the nearest there.
+select id from t order by l2_distance(b,'[1,1,1]') limit 3;
+-- id=1 is now near [5,5,5], so it must show up there.
+select id from t order by l2_distance(b,'[5,5,5]') limit 5;
+
+-- Multi-row REPLACE mixing new and existing rows.
+replace into t values(2,'[5,5,3]'),(9,'[5,6,5]'),(3,'[0,0,0]');
+select id from t order by l2_distance(b,'[5,5,5]') limit 6;
+-- id=3 is now [0,0,0]; the stale [3,3,3] entry must be gone.
+select id from t order by l2_distance(b,'[3,3,3]') limit 3;
+
+drop database if exists vec_ivf_replace;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG

## Which issue(s) this PR fixes:

issue #25000

## What this PR does / why we need it:

`REPLACE` into a table carrying an irregular index (ivfflat vector index or fulltext index) succeeded but did **not** maintain the index. As a result, a row inserted (or whose indexed value changed) via `REPLACE` was not reflected in a subsequent index-backed ANN/KNN or `MATCH ... AGAINST` query until the next cron reindex. `INSERT` was not affected.

Root cause: the modern operator-based `REPLACE` path (DEDUP JOIN + MULTI_UPDATE, introduced by #24044) stripped irregular indexes via `getValidIndexes` and relied on async maintenance. This PR restores synchronous maintenance for **non-async** ivfflat and fulltext indexes, leaving async ones to the cron exactly as the legacy insert/update paths do.

### How

- Collect the non-async ivf / fulltext index defs before they are stripped from `tableDef.Indexes`.
- Sink the processed new rows once (a tag-preserving `SINK_SCAN`) so auto-increment / generated columns are evaluated a single time and the same rows feed both the main conflict-resolution branch and the index-maintenance sub-plans.
- Build the index sub-plans **after** `createQuery` (the same sequencing the legacy insert path uses): they use positional column refs and hand-built nodes, so they must not go through the per-step optimize/remap pipeline. Only the newly appended steps are finalized via `handleHashMapMessages`.
- **ivf**: insert entries for every incoming row, and delete the stale entries of conflicting rows. On a primary-key conflict the new PK equals the replaced row's PK, so the old entry keyed by `org_pk` is removed; a brand-new PK matches nothing and deletes nothing.
- **fulltext**: a single `POSTDML` node per index deletes the stale inverted entries (by doc id = the incoming PK) and re-tokenizes the new rows.

Regular tables and regular secondary indexes are unaffected.

Known limitation: for the rare case of a table with both an irregular index and a unique secondary index, a unique-key-only conflict (where the replaced row's PK differs from the incoming PK) is not yet covered for the irregular index; tracked as a follow-up.

### Tests

- New BVT `test/distributed/cases/vector/vector_ivf_replace.sql` and `test/distributed/cases/fulltext/fulltext_replace.sql` covering new-row REPLACE, existing-row REPLACE (stale value cleared) and multi-row REPLACE.
- New unit tests `TestCollectSyncIvfMultiIndexes` and `TestCollectSyncFulltextIndexes`.
- `go test ./pkg/sql/plan` passes; existing `vector_ivf_membership` / `fulltext` / `fulltext_membership` BVTs pass with no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)