### PR TITLE
fix: report event_scheduler as DISABLED since CREATE EVENT is unsupported

### DIFF
--- a/pkg/frontend/variables.go
+++ b/pkg/frontend/variables.go
@@ -1845,7 +1845,7 @@ var gSysVarsDefs = map[string]SystemVariable{
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              InitSystemSystemEnumType("event_scheduler", "ON", "OFF", "DISABLED"),
-		Default:           "ON",
+		Default:           "DISABLED",
 	},
 	"explain_format": {
 		Name:              "explain_format",

--- a/pkg/frontend/variables_test.go
+++ b/pkg/frontend/variables_test.go
@@ -23,6 +23,18 @@ import (
 	"github.com/smartystreets/goconvey/convey"
 )
 
+func TestEventSchedulerDefaultDisabled(t *testing.T) {
+	convey.Convey("event_scheduler default should be DISABLED", t, func() {
+		sv, ok := gSysVarsDefs["event_scheduler"]
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(sv.Default, convey.ShouldEqual, "DISABLED")
+		// DISABLED must be a valid enum value so the default is convertible.
+		got, err := sv.Type.Convert(sv.Default)
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(got, convey.ShouldEqual, "DISABLED")
+	})
+}
+
 func TestScope(t *testing.T) {
 	convey.Convey("test scope", t, func() {
 		wanted := make(map[Scope]string)

--- a/test/distributed/cases/system_variable/event_scheduler.result
+++ b/test/distributed/cases/system_variable/event_scheduler.result
@@ -1,0 +1,9 @@
+show variables like 'event_scheduler';
+➤ Variable_name[12,0,0]  ¦  Value[12,0,0]  𝄀
+event_scheduler  ¦  DISABLED
+select @@event_scheduler;
+➤ @@event_scheduler[12,0,0]  𝄀
+DISABLED
+select @@global.event_scheduler;
+➤ @@event_scheduler[12,0,0]  𝄀
+DISABLED

--- a/test/distributed/cases/system_variable/event_scheduler.sql
+++ b/test/distributed/cases/system_variable/event_scheduler.sql
@@ -1,0 +1,9 @@
+-- @suit
+
+-- @case
+-- @desc:event_scheduler is not supported, the variable should report DISABLED instead of ON
+-- @label:bvt
+
+show variables like 'event_scheduler';
+select @@event_scheduler;
+select @@global.event_scheduler;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG

## Which issue(s) this PR fixes:

issue #24830

## What this PR does / why we need it:

`@@event_scheduler` defaulted to `ON`, but MatrixOne does not support `CREATE EVENT` (the parser rejects it), so the variable advertised an unsupported feature and misled users.

This changes the default to `DISABLED`, which accurately reflects that the event scheduler is unavailable and cannot be enabled at runtime.

- `pkg/frontend/variables.go`: `event_scheduler` default `ON` -> `DISABLED`
- added unit test asserting the default is `DISABLED`
- added bvt case `system_variable/event_scheduler`