### PR TITLE
fix(show7): replace sleep with @wait_expect for statement_info readiness

### DIFF
--- a/test/distributed/cases/dml/show/show7.result
+++ b/test/distributed/cases/dml/show/show7.result
@@ -1,22 +1,19 @@
 drop account if exists show_table_status_acc_10163;
 create account show_table_status_acc_10163 admin_name = 'admin' identified by '111';
 select 1;
-1
+➤ 1[-5,64,0]  𝄀
 1
 select 2;
-2
+➤ 2[-5,64,0]  𝄀
 2
 select 3;
+➤ 3[-5,64,0]  𝄀
 3
-3
-select case when count(*) > 0 then 0 else sleep(15) end as wait_for_statement_info_ready from system.statement_info;
-wait_for_statement_info_ready
-0
 select count(*) > 0 as has_data from system.statement_info;
-has_data
+➤ has_data[-7,1,0]  𝄀
 1
 show table status from system like 'statement_info';
--- @regex("(?m)^statement_info.*Tae.*Dynamic.*[1-9][0-9]*.*$",true)
+-- @regex("(?m)^statement_info.*Tae.*Dynamic.*[1-9][0-9]*.*$", true)
 ➤ Name[12,-1,0]  ¦  Engine[12,-1,0]  ¦  Row_format[12,-1,0]  ¦  Rows[-5,64,0]  ¦  Avg_row_length[-5,64,0]  ¦  Data_length[-5,64,0]  ¦  Max_data_length[-5,64,0]  ¦  Index_length[-5,64,0]  ¦  Data_free[12,-1,0]  ¦  Auto_increment[-5,64,0]  ¦  Create_time[93,64,0]  ¦  Update_time[12,-1,0]  ¦  Check_time[12,-1,0]  ¦  Collation[12,-1,0]  ¦  Checksum[12,-1,0]  ¦  Create_options[1,0,0]  ¦  Comment[12,-1,0]  ¦  Role_id[4,32,0]  ¦  Role_name[12,-1,0]  𝄀
-statement_info  ¦  Tae  ¦  Dynamic  ¦  1  ¦  0  ¦  0  ¦  0  ¦  0  ¦  NULL  ¦  1  ¦  2026-02-28 16:08:26  ¦  NULL  ¦  NULL  ¦  utf8mb4_bin  ¦  NULL  ¦    ¦  record each statement and stats info[mo_no_del_hint]  ¦  2  ¦  accountadmin
+statement_info  ¦  Tae  ¦  Dynamic  ¦  2  ¦  0  ¦  0  ¦  0  ¦  0  ¦  NULL  ¦  1  ¦  2026-06-17 17:46:12  ¦  NULL  ¦  NULL  ¦  utf8mb4_bin  ¦  NULL  ¦    ¦  record each statement and stats info[mo_no_del_hint]  ¦  2  ¦  accountadmin
 drop account show_table_status_acc_10163;

--- a/test/distributed/cases/dml/show/show7.sql
+++ b/test/distributed/cases/dml/show/show7.sql
@@ -5,8 +5,8 @@ create account show_table_status_acc_10163 admin_name = 'admin' identified by '1
 select 1;
 select 2;
 select 3;
-select case when count(*) > 0 then 0 else sleep(15) end as wait_for_statement_info_ready from system.statement_info;
 
+-- @wait_expect(2, 30)
 select count(*) > 0 as has_data from system.statement_info;
 -- @ignore:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18
 -- @metacmp(false)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

fixes #25018

## What this PR does / why we need it:

`show7.sql` used a fixed `sleep(15)` to wait for `system.statement_info` to be populated before asserting `select count(*) > 0`. In Multi-CN PROXY mode the async audit pipeline can exceed 15s under CI pressure, causing the BVT to flake (the assertion at the next line gets `0` instead of `1`).

Replace the blind sleep with mo-tester native `-- @wait_expect(2, 30)`:
- Polls every 2s, up to 30s, and stops as soon as the result matches the expected `1`.
- Fast path: ~4s when data lands quickly (vs fixed 15s).
- Slow path: tolerates up to 30s of audit pipeline delay.
- First use of `@wait_expect` in BVT; mo-tester implementation reviewed (no infinite-loop / statement-leak / session hazard).

`.result` regenerated via `run.sh -m genrs` (type headers preserved).

## Verification

```
[run mode, -n]
COST: 4s, TOTAL: 8, SUCCESS: 8, FAILED: 0, SUCCESS RATE: 100%

log shows polling working:
[row:10] Starting wait_expect: interval=2s, timeout=30s
[2x] RSRow mismatch (0 != 1)   <- retries
[final] cost: 4.377s, success: 8/8   <- data landed, pass
```