### PR TITLE
fix(plan): support enum and prefix text indexes (cherry-pick #24809)

### DIFF
--- a/pkg/catalog/secondary_index_utils.go
+++ b/pkg/catalog/secondary_index_utils.go
@@ -17,6 +17,8 @@ package catalog
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -120,6 +122,8 @@ const (
 	IndexAlgoParamKmeansTrainPercent = "kmeans_train_percent"
 	IndexAlgoParamKmeansMaxIteration = "kmeans_max_iteration"
 	IndexAlgoParamMaxIndexCapacity   = "max_index_capacity"
+
+	IndexAlgoParamPrefixLengths = "prefix_lengths"
 )
 
 /* 1. ToString Functions */
@@ -253,6 +257,90 @@ func IndexParamsMapToJsonString(res map[string]string) (string, error) {
 		return "", err
 	}
 	return string(str), nil
+}
+
+func AddIndexPrefixLengthsToParams(indexParams string, keyParts []*tree.KeyPart) (string, error) {
+	prefixLengths := IndexPrefixLengthsToString(keyParts)
+	if prefixLengths == "" {
+		return indexParams, nil
+	}
+
+	params := make(map[string]string)
+	if indexParams != "" {
+		existing, err := IndexParamsStringToMap(indexParams)
+		if err != nil {
+			return "", err
+		}
+		params = existing
+	}
+	params[IndexAlgoParamPrefixLengths] = prefixLengths
+	return IndexParamsMapToJsonString(params)
+}
+
+func IndexPrefixLengthsToString(keyParts []*tree.KeyPart) string {
+	if len(keyParts) == 0 {
+		return ""
+	}
+
+	prefixLengths := make(map[string]int, len(keyParts))
+	for _, keyPart := range keyParts {
+		if keyPart == nil || keyPart.ColName == nil || keyPart.Length <= 0 {
+			continue
+		}
+		prefixLengths[keyPart.ColName.ColName()] = keyPart.Length
+	}
+	if len(prefixLengths) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(prefixLengths))
+	for part := range prefixLengths {
+		parts = append(parts, part)
+	}
+	sort.Strings(parts)
+
+	encoded := make([]string, 0, len(parts))
+	for _, part := range parts {
+		encoded = append(encoded, fmt.Sprintf("%s:%d", part, prefixLengths[part]))
+	}
+	return strings.Join(encoded, ",")
+}
+
+func IndexPrefixLengthsFromParams(indexParams string) map[string]int {
+	prefixLengths, err := IndexPrefixLengthsFromParamsWithError(indexParams)
+	if err != nil {
+		return nil
+	}
+	return prefixLengths
+}
+
+func IndexPrefixLengthsFromParamsWithError(indexParams string) (map[string]int, error) {
+	if indexParams == "" {
+		return nil, nil
+	}
+	params, err := IndexParamsStringToMap(indexParams)
+	if err != nil {
+		return nil, err
+	}
+
+	encoded := params[IndexAlgoParamPrefixLengths]
+	if encoded == "" {
+		return nil, nil
+	}
+
+	prefixLengths := make(map[string]int)
+	for _, item := range strings.Split(encoded, ",") {
+		part, lengthText, ok := strings.Cut(item, ":")
+		if !ok || part == "" || lengthText == "" {
+			return nil, moerr.NewInvalidInputNoCtxf("invalid index prefix length item %q", item)
+		}
+		length, err := strconv.Atoi(lengthText)
+		if err != nil || length <= 0 {
+			return nil, moerr.NewInvalidInputNoCtxf("invalid index prefix length %q", item)
+		}
+		prefixLengths[part] = length
+	}
+	return prefixLengths, nil
 }
 
 /* 2. ToMap Functions */

--- a/pkg/catalog/secondary_index_utils_test.go
+++ b/pkg/catalog/secondary_index_utils_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,6 +51,13 @@ func TestIndexBuildParamsRoundTrip(t *testing.T) {
 	require.False(t, strings.Contains(s, IndexAlgoParamMaxIndexCapacity), s)
 }
 
+func newPrefixKeyPart(colName string, length int) *tree.KeyPart {
+	return &tree.KeyPart{
+		ColName: tree.NewUnresolvedColName(colName),
+		Length:  length,
+	}
+}
+
 func TestIsIndexAsync(t *testing.T) {
 
 	var (
@@ -76,4 +84,171 @@ func TestIsIndexAsync(t *testing.T) {
 	json = `{"async": 1}`
 	_, err = IsIndexAsync(json)
 	require.NotNil(t, err)
+}
+
+func TestIndexPrefixLengthsFromParamsWithError(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    string
+		want      map[string]int
+		wantError bool
+	}{
+		{
+			name:   "empty params",
+			params: "",
+		},
+		{
+			name:   "no prefix lengths",
+			params: `{"lists":"1"}`,
+		},
+		{
+			name:   "valid prefix lengths",
+			params: `{"prefix_lengths":"b:20,t:10"}`,
+			want: map[string]int{
+				"b": 20,
+				"t": 10,
+			},
+		},
+		{
+			name:      "invalid json",
+			params:    "{bad json",
+			wantError: true,
+		},
+		{
+			name:      "missing separator",
+			params:    `{"prefix_lengths":"t"}`,
+			wantError: true,
+		},
+		{
+			name:      "non numeric length",
+			params:    `{"prefix_lengths":"t:abc"}`,
+			wantError: true,
+		},
+		{
+			name:      "non positive length",
+			params:    `{"prefix_lengths":"t:0"}`,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IndexPrefixLengthsFromParamsWithError(tt.params)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIndexPrefixLengthsToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		keyParts []*tree.KeyPart
+		want     string
+	}{
+		{
+			name:     "nil key parts",
+			keyParts: nil,
+			want:     "",
+		},
+		{
+			name: "all without length",
+			keyParts: []*tree.KeyPart{
+				newPrefixKeyPart("a", 0),
+				newPrefixKeyPart("b", 0),
+			},
+			want: "",
+		},
+		{
+			name: "single prefix",
+			keyParts: []*tree.KeyPart{
+				newPrefixKeyPart("t", 10),
+			},
+			want: "t:10",
+		},
+		{
+			name: "sorted by column name",
+			keyParts: []*tree.KeyPart{
+				newPrefixKeyPart("b", 20),
+				newPrefixKeyPart("a", 10),
+			},
+			want: "a:10,b:20",
+		},
+		{
+			name: "skip nil and zero length entries",
+			keyParts: []*tree.KeyPart{
+				{ColName: nil, Length: 5},
+				newPrefixKeyPart("a", 0),
+				newPrefixKeyPart("b", 7),
+			},
+			want: "b:7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IndexPrefixLengthsToString(tt.keyParts))
+		})
+	}
+}
+
+func TestAddIndexPrefixLengthsToParams(t *testing.T) {
+	t.Run("no prefix returns input unchanged", func(t *testing.T) {
+		got, err := AddIndexPrefixLengthsToParams(`{"lists":"1"}`, []*tree.KeyPart{
+			newPrefixKeyPart("a", 0),
+		})
+		require.NoError(t, err)
+		require.Equal(t, `{"lists":"1"}`, got)
+	})
+
+	t.Run("empty params with prefix", func(t *testing.T) {
+		got, err := AddIndexPrefixLengthsToParams("", []*tree.KeyPart{
+			newPrefixKeyPart("t", 10),
+		})
+		require.NoError(t, err)
+
+		prefixLengths := IndexPrefixLengthsFromParams(got)
+		require.Equal(t, map[string]int{"t": 10}, prefixLengths)
+	})
+
+	t.Run("merge into existing params", func(t *testing.T) {
+		got, err := AddIndexPrefixLengthsToParams(`{"lists":"1"}`, []*tree.KeyPart{
+			newPrefixKeyPart("t", 10),
+		})
+		require.NoError(t, err)
+
+		params, err := IndexParamsStringToMap(got)
+		require.NoError(t, err)
+		require.Equal(t, "1", params[IndexAlgoParamLists])
+		require.Equal(t, "t:10", params[IndexAlgoParamPrefixLengths])
+	})
+
+	t.Run("invalid existing params", func(t *testing.T) {
+		_, err := AddIndexPrefixLengthsToParams("{bad json", []*tree.KeyPart{
+			newPrefixKeyPart("t", 10),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("round trip", func(t *testing.T) {
+		keyParts := []*tree.KeyPart{
+			newPrefixKeyPart("b", 20),
+			newPrefixKeyPart("a", 10),
+		}
+		got, err := AddIndexPrefixLengthsToParams("", keyParts)
+		require.NoError(t, err)
+		require.Equal(t, map[string]int{"a": 10, "b": 20}, IndexPrefixLengthsFromParams(got))
+	})
+}
+
+func TestIndexPrefixLengthsFromParams(t *testing.T) {
+	require.Equal(t, map[string]int{"t": 10}, IndexPrefixLengthsFromParams(`{"prefix_lengths":"t:10"}`))
+	require.Nil(t, IndexPrefixLengthsFromParams(""))
+	// invalid params return nil instead of panicking.
+	require.Nil(t, IndexPrefixLengthsFromParams("{bad json"))
+	require.Nil(t, IndexPrefixLengthsFromParams(`{"prefix_lengths":"t:0"}`))
 }

--- a/pkg/sql/colexec/preinsertsecondaryindex/preinsertsecondaryindex.go
+++ b/pkg/sql/colexec/preinsertsecondaryindex/preinsertsecondaryindex.go
@@ -70,7 +70,11 @@ func (preInsertSecIdx *PreInsertSecIdx) initBuf(bat *batch.Batch, secondaryColum
 	}
 
 	if len(secondaryColumnPos) == 1 {
-		preInsertSecIdx.ctr.buf.Vecs[0] = vector.NewVec(*bat.Vecs[secondaryColumnPos[0]].GetType())
+		ukType := preInsertSecIdx.PreInsertCtx.UkType
+		keyType := types.T(ukType.Id).ToType()
+		keyType.Width = ukType.Width
+		keyType.Scale = ukType.Scale
+		preInsertSecIdx.ctr.buf.Vecs[0] = vector.NewVec(keyType)
 	} else {
 		preInsertSecIdx.ctr.buf.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
 	}

--- a/pkg/sql/colexec/preinsertsecondaryindex/preinsertsecondaryindex_test.go
+++ b/pkg/sql/colexec/preinsertsecondaryindex/preinsertsecondaryindex_test.go
@@ -23,9 +23,11 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -128,6 +130,35 @@ func TestPreInsertSecondaryIndex(t *testing.T) {
 		tc.arg.Free(proc, false, nil)
 		require.Equal(t, int64(0), proc.Mp().CurrNB())
 	}
+}
+
+func TestPreInsertSecondarySingleVarcharUsesSizedUkType(t *testing.T) {
+	proc := testutil.NewProc(t)
+	bat := batch.NewWithSize(2)
+	bat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	require.NoError(t, vector.AppendFixed(bat.Vecs[0], int32(1), false, proc.Mp()))
+	require.NoError(t, vector.AppendBytes(bat.Vecs[1], []byte("CODE001"), false, proc.Mp()))
+	bat.SetRowCount(1)
+	defer bat.Clean(proc.Mp())
+
+	arg := &PreInsertSecIdx{
+		PreInsertCtx: &plan.PreInsertUkCtx{
+			Columns:  []int32{1},
+			PkColumn: 0,
+			UkType: plan.Type{
+				Id:    int32(types.T_varchar),
+				Width: 50,
+			},
+		},
+	}
+	arg.initBuf(bat, arg.PreInsertCtx.Columns, int(arg.PreInsertCtx.PkColumn), false)
+	defer arg.Free(proc, false, nil)
+
+	require.NotZero(t, arg.ctr.buf.Vecs[indexColPos].GetType().TypeSize())
+	_, err := util.CompactSingleIndexCol(bat.Vecs[1], arg.ctr.buf.Vecs[indexColPos], proc)
+	require.NoError(t, err)
+	require.Equal(t, 1, arg.ctr.buf.Vecs[indexColPos].Length())
 }
 
 func resetChildren(arg *PreInsertSecIdx, m *mpool.MPool) {

--- a/pkg/sql/colexec/preinsertunique/preinsertunique.go
+++ b/pkg/sql/colexec/preinsertunique/preinsertunique.go
@@ -70,7 +70,11 @@ func (preInsertUnique *PreInsertUnique) initBuf(bat *batch.Batch, uniqueColumnPo
 	}
 
 	if len(uniqueColumnPos) == 1 {
-		preInsertUnique.ctr.buf.Vecs[0] = vector.NewVec(*bat.Vecs[uniqueColumnPos[0]].GetType())
+		ukType := preInsertUnique.PreInsertCtx.UkType
+		keyType := types.T(ukType.Id).ToType()
+		keyType.Width = ukType.Width
+		keyType.Scale = ukType.Scale
+		preInsertUnique.ctr.buf.Vecs[0] = vector.NewVec(keyType)
 	} else {
 		preInsertUnique.ctr.buf.Vecs[0] = vector.NewVec(types.T_varchar.ToType())
 	}

--- a/pkg/sql/colexec/preinsertunique/preinsertunique_test.go
+++ b/pkg/sql/colexec/preinsertunique/preinsertunique_test.go
@@ -23,9 +23,11 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	mock_frontend "github.com/matrixorigin/matrixone/pkg/frontend/test"
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/util"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
@@ -128,6 +130,35 @@ func TestPreInsertUnique(t *testing.T) {
 		require.Equal(t, int64(0), proc.Mp().CurrNB())
 	}
 
+}
+
+func TestPreInsertUniqueSingleVarcharUsesSizedUkType(t *testing.T) {
+	proc := testutil.NewProc(t)
+	bat := batch.NewWithSize(2)
+	bat.Vecs[0] = vector.NewVec(types.T_int32.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	require.NoError(t, vector.AppendFixed(bat.Vecs[0], int32(1), false, proc.Mp()))
+	require.NoError(t, vector.AppendBytes(bat.Vecs[1], []byte("CODE001"), false, proc.Mp()))
+	bat.SetRowCount(1)
+	defer bat.Clean(proc.Mp())
+
+	arg := &PreInsertUnique{
+		PreInsertCtx: &plan.PreInsertUkCtx{
+			Columns:  []int32{1},
+			PkColumn: 0,
+			UkType: plan.Type{
+				Id:    int32(types.T_varchar),
+				Width: 50,
+			},
+		},
+	}
+	arg.initBuf(bat, arg.PreInsertCtx.Columns, int(arg.PreInsertCtx.PkColumn), false)
+	defer arg.Free(proc, false, nil)
+
+	require.NotZero(t, arg.ctr.buf.Vecs[indexColPos].GetType().TypeSize())
+	_, err := util.CompactSingleIndexCol(bat.Vecs[1], arg.ctr.buf.Vecs[indexColPos], proc)
+	require.NoError(t, err)
+	require.Equal(t, 1, arg.ctr.buf.Vecs[indexColPos].Length())
 }
 
 func resetChildren(arg *PreInsertUnique, m *mpool.MPool) {

--- a/pkg/sql/compile/ddl_index_algo.go
+++ b/pkg/sql/compile/ddl_index_algo.go
@@ -59,21 +59,32 @@ func (s *Scope) createAndInsertForUniqueOrRegularIndexTable(c *Compile, indexDef
 	if c.isCCPRTaskTransaction() && isTableFromPublication(originalTableDef) {
 		return nil
 	}
-	insertSQL := genInsertIndexTableSql(originalTableDef, indexDef, qryDatabase, indexDef.Unique)
+	insertSQL, err := genInsertIndexTableSql(originalTableDef, indexDef, qryDatabase, indexDef.Unique)
+	if err != nil {
+		return err
+	}
 	if indexDef.Unique {
 		return c.precheckAndInsertUniqueIndexTable(qryDatabase, originalTableDef, indexDef, insertSQL)
 	}
 	return c.runSql(insertSQL)
 }
 
-func buildCreateUniqueIndexDuplicateCheckSQL(dbName string, tableDef *plan.TableDef, indexDef *plan.IndexDef) string {
-	groupExpr := partsToColsStr(indexDef.Parts)
+func buildCreateUniqueIndexDuplicateCheckSQL(dbName string, tableDef *plan.TableDef, indexDef *plan.IndexDef) (string, error) {
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(indexDef.IndexAlgoParams)
+	if err != nil {
+		return "", err
+	}
+	groupExpr := partsToIndexExprStr(indexDef.Parts, prefixLengths)
 	nullCheckExpr := fmt.Sprintf("%s IS NOT NULL", groupExpr)
 	if len(indexDef.Parts) > 1 {
 		nullChecks := make([]string, 0, len(indexDef.Parts))
 		for _, part := range indexDef.Parts {
 			part = catalog.ResolveAlias(part)
-			nullChecks = append(nullChecks, fmt.Sprintf("%s IS NOT NULL", quoteMySQLQualifiedIdent(part)))
+			partExpr := quoteMySQLQualifiedIdent(part)
+			if length := prefixLengths[part]; length > 0 {
+				partExpr = fmt.Sprintf("substring(%s, 1, %d)", partExpr, length)
+			}
+			nullChecks = append(nullChecks, fmt.Sprintf("%s IS NOT NULL", partExpr))
 		}
 		nullCheckExpr = strings.Join(nullChecks, " AND ")
 	}
@@ -83,7 +94,7 @@ func buildCreateUniqueIndexDuplicateCheckSQL(dbName string, tableDef *plan.Table
 		quoteMySQLIdent(tableDef.Name),
 		nullCheckExpr,
 		groupExpr,
-	)
+	), nil
 }
 
 func (c *Compile) precheckAndInsertUniqueIndexTable(
@@ -94,7 +105,10 @@ func (c *Compile) precheckAndInsertUniqueIndexTable(
 ) error {
 	// Unique indexes allow NULL keys, so the check mirrors the hidden-index
 	// backfill filter and only groups non-NULL keys.
-	duplicateCheckSQL := buildCreateUniqueIndexDuplicateCheckSQL(dbName, tableDef, indexDef)
+	duplicateCheckSQL, err := buildCreateUniqueIndexDuplicateCheckSQL(dbName, tableDef, indexDef)
+	if err != nil {
+		return err
+	}
 	duplicateCheckRes, err := c.runSqlWithResultAndOptions(duplicateCheckSQL, NoAccountId, executor.StatementOption{}.WithDisableLog())
 	if err != nil {
 		c.proc.Errorf(c.proc.Ctx, "create unique index duplicate check failed, sql is %s", duplicateCheckSQL)

--- a/pkg/sql/compile/util.go
+++ b/pkg/sql/compile/util.go
@@ -152,13 +152,17 @@ var (
 )
 
 // genInsertIndexTableSql: Generate an insert statement for inserting data into the index table
-func genInsertIndexTableSql(originTableDef *plan.TableDef, indexDef *plan.IndexDef, DBName string, isUnique bool) string {
+func genInsertIndexTableSql(originTableDef *plan.TableDef, indexDef *plan.IndexDef, DBName string, isUnique bool) (string, error) {
 	// insert data into index table
 	var insertSQL string
-	temp := partsToColsStr(indexDef.Parts)
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(indexDef.IndexAlgoParams)
+	if err != nil {
+		return "", err
+	}
+	temp := partsToIndexExprStr(indexDef.Parts, prefixLengths)
 	spatialIndex := catalog.IsRTreeIndexAlgo(indexDef.IndexAlgo)
 	if spatialIndex && len(indexDef.Parts) > 0 {
-		temp = partsToColsStr(indexDef.Parts[:1])
+		temp = partsToIndexExprStr(indexDef.Parts[:1], prefixLengths)
 	}
 	if len(originTableDef.Pkey.PkeyColName) == 0 {
 		if len(indexDef.Parts) == 1 || spatialIndex {
@@ -192,7 +196,7 @@ func genInsertIndexTableSql(originTableDef *plan.TableDef, indexDef *plan.IndexD
 			}
 		}
 	}
-	return insertSQL
+	return insertSQL, nil
 }
 
 // genInsertIndexTableSqlForMasterIndex: Create inserts for master index table
@@ -496,15 +500,18 @@ func (s *Scope) checkTableWithValidIndexes(c *Compile, relation engine.Relation)
 	return nil
 }
 
-func partsToColsStr(parts []string) string {
+func partsToIndexExprStr(parts []string, prefixLengths map[string]int) string {
 	var temp string
 	for i, part := range parts {
 		part = catalog.ResolveAlias(part)
-		part = quoteMySQLQualifiedIdent(part)
+		partExpr := quoteMySQLQualifiedIdent(part)
+		if length := prefixLengths[part]; length > 0 {
+			partExpr = fmt.Sprintf("substring(%s, 1, %d)", partExpr, length)
+		}
 		if i == 0 {
-			temp += part
+			temp += partExpr
 		} else {
-			temp += "," + part
+			temp += "," + partExpr
 		}
 	}
 	return temp

--- a/pkg/sql/compile/util_index_sql_test.go
+++ b/pkg/sql/compile/util_index_sql_test.go
@@ -52,10 +52,32 @@ func TestGenInsertIndexTableSql_QuotesReservedKeywordColumn(t *testing.T) {
 		Unique:         false,
 	}
 
-	sql := genInsertIndexTableSql(originTableDef, indexDef, "test", false)
+	sql, err := genInsertIndexTableSql(originTableDef, indexDef, "test", false)
+	require.NoError(t, err)
 
 	require.Contains(t, sql, "serial_full(`order`,`id`)")
 	require.Contains(t, sql, "select serial_full(`order`,`id`), `id` from `test`.`files_related_mph`;")
+}
+
+func TestGenInsertIndexTableSql_UsesPrefixExpression(t *testing.T) {
+	originTableDef := &planpb.TableDef{
+		Name: "orders",
+		Pkey: &planpb.PrimaryKeyDef{
+			PkeyColName: "id",
+			Names:       []string{"id"},
+		},
+	}
+	indexDef := &planpb.IndexDef{
+		IndexTableName:  "__mo_index_unique_test",
+		Parts:           []string{"order"},
+		Unique:          true,
+		IndexAlgoParams: `{"prefix_lengths":"order:5"}`,
+	}
+
+	sql, err := genInsertIndexTableSql(originTableDef, indexDef, "test", true)
+	require.NoError(t, err)
+
+	require.Equal(t, "insert into  `test`.`__mo_index_unique_test` select (substring(`order`, 1, 5)), `id` from `test`.`orders` where (substring(`order`, 1, 5)) is not null;", sql)
 }
 
 func TestGenInsertIndexTableSql_SpatialIndexUsesRawGeometryColumn(t *testing.T) {
@@ -73,7 +95,8 @@ func TestGenInsertIndexTableSql_SpatialIndexUsesRawGeometryColumn(t *testing.T) 
 		IndexAlgo:      "rtree",
 	}
 
-	sql := genInsertIndexTableSql(originTableDef, indexDef, "test", false)
+	sql, err := genInsertIndexTableSql(originTableDef, indexDef, "test", false)
+	require.NoError(t, err)
 
 	require.Contains(t, sql, "select (`g`), `id` from `test`.`geo_t` where (`g`) is not null;")
 	require.NotContains(t, sql, "serial_full")
@@ -90,7 +113,8 @@ func TestBuildCreateUniqueIndexDuplicateCheckSQL(t *testing.T) {
 			Unique:         true,
 		}
 
-		sql := buildCreateUniqueIndexDuplicateCheckSQL("test", tableDef, indexDef)
+		sql, err := buildCreateUniqueIndexDuplicateCheckSQL("test", tableDef, indexDef)
+		require.NoError(t, err)
 
 		require.Equal(t, "SELECT `order` FROM `test`.`orders` WHERE `order` IS NOT NULL GROUP BY `order` HAVING count(*) > 1 LIMIT 1", sql)
 	})
@@ -103,10 +127,58 @@ func TestBuildCreateUniqueIndexDuplicateCheckSQL(t *testing.T) {
 			Unique:         true,
 		}
 
-		sql := buildCreateUniqueIndexDuplicateCheckSQL("test", tableDef, indexDef)
+		sql, err := buildCreateUniqueIndexDuplicateCheckSQL("test", tableDef, indexDef)
+		require.NoError(t, err)
 
 		require.Equal(t, "SELECT `order`,`id` FROM `test`.`orders` WHERE `order` IS NOT NULL AND `id` IS NOT NULL GROUP BY `order`,`id` HAVING count(*) > 1 LIMIT 1", sql)
 	})
+
+	t.Run("prefix column", func(t *testing.T) {
+		indexDef := &planpb.IndexDef{
+			IndexName:       "u_order",
+			IndexTableName:  "__mo_index_unique_test",
+			Parts:           []string{"order"},
+			Unique:          true,
+			IndexAlgoParams: `{"prefix_lengths":"order:5"}`,
+		}
+
+		sql, err := buildCreateUniqueIndexDuplicateCheckSQL("test", tableDef, indexDef)
+		require.NoError(t, err)
+
+		require.Equal(t, "SELECT substring(`order`, 1, 5) FROM `test`.`orders` WHERE substring(`order`, 1, 5) IS NOT NULL GROUP BY substring(`order`, 1, 5) HAVING count(*) > 1 LIMIT 1", sql)
+	})
+
+	t.Run("invalid prefix params", func(t *testing.T) {
+		indexDef := &planpb.IndexDef{
+			IndexName:       "u_order",
+			IndexTableName:  "__mo_index_unique_test",
+			Parts:           []string{"order"},
+			Unique:          true,
+			IndexAlgoParams: `{"prefix_lengths":"order:bad"}`,
+		}
+
+		_, err := buildCreateUniqueIndexDuplicateCheckSQL("test", tableDef, indexDef)
+		require.Error(t, err)
+	})
+}
+
+func TestGenInsertIndexTableSqlRejectsInvalidPrefixParams(t *testing.T) {
+	originTableDef := &planpb.TableDef{
+		Name: "orders",
+		Pkey: &planpb.PrimaryKeyDef{
+			PkeyColName: "id",
+			Names:       []string{"id"},
+		},
+	}
+	indexDef := &planpb.IndexDef{
+		IndexTableName:  "__mo_index_unique_test",
+		Parts:           []string{"order"},
+		Unique:          true,
+		IndexAlgoParams: `{"prefix_lengths":"order:bad"}`,
+	}
+
+	_, err := genInsertIndexTableSql(originTableDef, indexDef, "test", true)
+	require.Error(t, err)
 }
 
 func TestPrecheckAndInsertUniqueIndexTableUsesSkipDedupAndPipelineFlush(t *testing.T) {

--- a/pkg/sql/plan/bind_delete.go
+++ b/pkg/sql/plan/bind_delete.go
@@ -143,6 +143,22 @@ func (builder *QueryBuilder) bindDelete(ctx CompilerContext, stmt *tree.Delete, 
 	if selectNode.NodeType != plan.Node_PROJECT {
 		return 0, moerr.NewUnsupportedDML(builder.GetContext(), "malformed select node")
 	}
+	selectNodeTag := selectNode.BindingTags[0]
+
+	makeDeleteIndexPartExpr := func(colPos int32, partName string, prefixLengths map[string]int) (*plan.Expr, error) {
+		partName = catalog.ResolveAlias(partName)
+		inputExpr := &plan.Expr{
+			Typ: selectNode.ProjectList[colPos].Typ,
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{
+					RelPos: selectNodeTag,
+					ColPos: colPos,
+					Name:   partName,
+				},
+			},
+		}
+		return builder.makeIndexPartExprFromInputExpr(inputExpr, partName, prefixLengths)
+	}
 
 	idxScanNodes := make([][]*plan.Node, len(dmlCtx.tableDefs))
 
@@ -202,38 +218,42 @@ func (builder *QueryBuilder) bindDelete(ctx CompilerContext, stmt *tree.Delete, 
 					Typ: pkTyp,
 					Expr: &plan.Expr_Col{
 						Col: &plan.ColRef{
-							RelPos: selectNode.BindingTags[0],
+							RelPos: selectNodeTag,
 							ColPos: int32(pkPos),
 						},
 					},
 				}
 			} else if !indexTableStoresSerializedKey(idxDef) {
-				leftExpr = &plan.Expr{
-					Typ: pkTyp,
-					Expr: &plan.Expr_Col{
-						Col: &plan.ColRef{
-							RelPos: selectNode.BindingTags[0],
-							ColPos: int32(colName2Idx[i][indexPrimaryPartName(idxDef)]),
-						},
-					},
+				prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+				if err != nil {
+					return 0, err
+				}
+				partName := indexPrimaryPartName(idxDef)
+				colPos, ok := colName2Idx[i][partName]
+				if !ok {
+					return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind delete err, can not find colName = %s", partName)
+				}
+				leftExpr, err = makeDeleteIndexPartExpr(colPos, partName, prefixLengths)
+				if err != nil {
+					return 0, err
 				}
 			} else {
 				args := make([]*plan.Expr, argsLen)
+				prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+				if err != nil {
+					return 0, err
+				}
 				var colPos int32
 				var ok bool
 				for k, colName := range idxDef.Parts {
-					if colPos, ok = colName2Idx[i][catalog.ResolveAlias(colName)]; !ok {
+					colName = catalog.ResolveAlias(colName)
+					if colPos, ok = colName2Idx[i][colName]; !ok {
 						errMsg := fmt.Sprintf("bind delete err, can not find colName = %s", colName)
 						return 0, moerr.NewInternalError(builder.GetContext(), errMsg)
 					}
-					args[k] = &plan.Expr{
-						Typ: selectNode.ProjectList[colPos].Typ,
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: selectNode.BindingTags[0],
-								ColPos: colPos,
-							},
-						},
+					args[k], err = makeDeleteIndexPartExpr(colPos, colName, prefixLengths)
+					if err != nil {
+						return 0, err
 					}
 				}
 
@@ -267,7 +287,6 @@ func (builder *QueryBuilder) bindDelete(ctx CompilerContext, stmt *tree.Delete, 
 		NodeType:    plan.Node_MULTI_UPDATE,
 		BindingTags: []int32{builder.genNewBindTag()},
 	}
-	selectNodeTag := selectNode.BindingTags[0]
 	var lockTargets []*plan.LockTarget
 
 	for i, tableDef := range dmlCtx.tableDefs {

--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -78,6 +78,92 @@ func (builder *QueryBuilder) canSkipDedup(tableDef *plan.TableDef) bool {
 	return catalog.IsSecondaryIndexTable(tableDef.Name)
 }
 
+func (builder *QueryBuilder) makeIndexPartExpr(
+	inputTag int32,
+	colPos int32,
+	colName string,
+	colType plan.Type,
+	prefixLengths map[string]int,
+) (*plan.Expr, error) {
+	expr := &plan.Expr{
+		Typ: colType,
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{
+				RelPos: inputTag,
+				ColPos: colPos,
+				Name:   colName,
+			},
+		},
+	}
+
+	length := prefixLengths[colName]
+	if length <= 0 {
+		return expr, nil
+	}
+
+	prefixExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "substring", []*plan.Expr{
+		expr,
+		makePlan2Int64ConstExprWithType(1),
+		makePlan2Int64ConstExprWithType(int64(length)),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if prefixType, ok := indexTableKeyTypeForPrefix(colType); ok {
+		prefixExpr, err = appendCastBeforeExpr(builder.GetContext(), prefixExpr, prefixType)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return prefixExpr, nil
+}
+
+func (builder *QueryBuilder) makeIndexPartExprFromInputExpr(
+	inputExpr *plan.Expr,
+	colName string,
+	prefixLengths map[string]int,
+) (*plan.Expr, error) {
+	expr := DeepCopyExpr(inputExpr)
+	length := prefixLengths[colName]
+	if length <= 0 {
+		return expr, nil
+	}
+
+	prefixExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "substring", []*plan.Expr{
+		expr,
+		makePlan2Int64ConstExprWithType(1),
+		makePlan2Int64ConstExprWithType(int64(length)),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if prefixType, ok := indexTableKeyTypeForPrefix(inputExpr.Typ); ok {
+		prefixExpr, err = appendCastBeforeExpr(builder.GetContext(), prefixExpr, prefixType)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return prefixExpr, nil
+}
+
+func (builder *QueryBuilder) makeInsertIndexPartExpr(
+	selectNode *plan.Node,
+	selectTag int32,
+	tableDef *plan.TableDef,
+	colName2Idx map[string]int32,
+	part string,
+	prefixLengths map[string]int,
+) (*plan.Expr, error) {
+	partName := catalog.ResolveAlias(part)
+	colPos, ok := colName2Idx[tableDef.Name+"."+partName]
+	if !ok {
+		return nil, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", partName)
+	}
+	return builder.makeIndexPartExpr(selectTag, colPos, partName, selectNode.ProjectList[colPos].Typ, prefixLengths)
+}
+
 func getValidIndexes(tableDef *plan.TableDef) (indexes []*plan.IndexDef, hasIrregularIndex bool) {
 	if tableDef == nil || len(tableDef.Indexes) == 0 {
 		return
@@ -263,26 +349,47 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 		}
 	}
 
-	// Materialize lock keys for composite unique indexes in advance.
+	// Materialize lock keys for composite and prefix unique indexes in advance.
 	// This guarantees the lock target can find __mo_index_idx_col in colName2Idx.
 	for i, idxDef := range tableDef.Indexes {
-		if !idxDef.Unique || skipUniqueIdx[i] || len(idxDef.Parts) <= 1 {
+		prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+		if err != nil {
+			return 0, err
+		}
+		if !idxDef.Unique || skipUniqueIdx[i] || (len(idxDef.Parts) <= 1 && len(prefixLengths) == 0) {
 			continue
 		}
 		lockColName := idxDef.IndexTableName + "." + catalog.IndexTableIndexColName
 		if _, ok := colName2Idx[lockColName]; ok {
 			continue
 		}
-		args := make([]*plan.Expr, len(idxDef.Parts))
-		for k := range idxDef.Parts {
-			partName := catalog.ResolveAlias(idxDef.Parts[k])
+
+		var lockExpr *plan.Expr
+		if len(idxDef.Parts) == 1 {
+			partName := catalog.ResolveAlias(idxDef.Parts[0])
 			partPos, ok := colName2Idx[tableDef.Name+"."+partName]
 			if !ok {
 				return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", partName)
 			}
-			args[k] = DeepCopyExpr(selectNode.ProjectList[partPos])
+			lockExpr, err = builder.makeIndexPartExprFromInputExpr(selectNode.ProjectList[partPos], partName, prefixLengths)
+			if err != nil {
+				return 0, err
+			}
+		} else {
+			args := make([]*plan.Expr, len(idxDef.Parts))
+			for k := range idxDef.Parts {
+				partName := catalog.ResolveAlias(idxDef.Parts[k])
+				partPos, ok := colName2Idx[tableDef.Name+"."+partName]
+				if !ok {
+					return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", partName)
+				}
+				args[k], err = builder.makeIndexPartExprFromInputExpr(selectNode.ProjectList[partPos], partName, prefixLengths)
+				if err != nil {
+					return 0, err
+				}
+			}
+			lockExpr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", args)
 		}
-		lockExpr, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", args)
 		colName2Idx[lockColName] = int32(len(selectNode.ProjectList))
 		selectNode.ProjectList = append(selectNode.ProjectList, lockExpr)
 	}
@@ -317,7 +424,11 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 		}
 		var pkIdxInBat int32
 
-		if len(idxDef.Parts) == 1 {
+		prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+		if err != nil {
+			return 0, err
+		}
+		if len(idxDef.Parts) == 1 && len(prefixLengths) == 0 {
 			var ok bool
 			pkIdxInBat, ok = colName2Idx[tableDef.Name+"."+idxDef.Parts[0]]
 			if !ok {
@@ -443,33 +554,21 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 		// __mo_index_idx_col projection for index columns
 		argsLen := len(idxDef.Parts)
 		var idxIndexColExpr *plan.Expr
+		prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+		if err != nil {
+			return 0, err
+		}
 		if argsLen == 1 {
-			colFullName := tableDef.Name + "." + idxDef.Parts[0]
-			idxIndexColExpr = &plan.Expr{
-				Typ: selectNode.ProjectList[colName2Idx[colFullName]].Typ,
-				Expr: &plan.Expr_Col{
-					Col: &plan.ColRef{
-						RelPos: selectTag,
-						ColPos: colName2Idx[colFullName],
-					},
-				},
+			idxIndexColExpr, err = builder.makeInsertIndexPartExpr(selectNode, selectTag, tableDef, colName2Idx, idxDef.Parts[0], prefixLengths)
+			if err != nil {
+				return 0, err
 			}
 		} else {
 			args := make([]*plan.Expr, argsLen)
-			var colPos int32
-			var ok bool
 			for k := range argsLen {
-				if colPos, ok = colName2Idx[tableDef.Name+"."+catalog.ResolveAlias(idxDef.Parts[k])]; !ok {
-					return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", idxDef.Parts[k])
-				}
-				args[k] = &plan.Expr{
-					Typ: selectNode.ProjectList[colPos].Typ,
-					Expr: &plan.Expr_Col{
-						Col: &plan.ColRef{
-							RelPos: selectTag,
-							ColPos: colPos,
-						},
-					},
+				args[k], err = builder.makeInsertIndexPartExpr(selectNode, selectTag, tableDef, colName2Idx, idxDef.Parts[k], prefixLengths)
+				if err != nil {
+					return 0, err
 				}
 			}
 
@@ -779,40 +878,20 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 			idxTableName := idxDef.IndexTableName
 
 			serialIdxPkExpr := func(idxDef *plan.IndexDef) (*plan.Expr, error) {
+				prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+				if err != nil {
+					return nil, err
+				}
 				if !indexTableStoresSerializedKey(idxDef) {
-					colName := tableDef.Name + "." + indexPrimaryPartName(idxDef)
-					colPos, ok := colName2Idx[colName]
-					if !ok {
-						return nil, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", indexPrimaryPartName(idxDef))
-					}
-					return &plan.Expr{
-						Typ: selectNode.ProjectList[colPos].Typ,
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: selectTag,
-								ColPos: colPos,
-							},
-						},
-					}, nil
+					return builder.makeInsertIndexPartExpr(selectNode, selectTag, tableDef, colName2Idx, indexPrimaryPartName(idxDef), prefixLengths)
 				}
 
-				var colPos int32
 				args := make([]*plan.Expr, len(idxDef.Parts))
-				var ok bool
 				for k, part := range idxDef.Parts {
-					if colPos, ok = colName2Idx[tableDef.Name+"."+catalog.ResolveAlias(part)]; !ok {
-						return nil, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", part)
-					}
-					// build from selectTag because we want to insert the row into the index table
-					args[k] = &plan.Expr{
-						// projectListAfterDedup just appends elements on the tail, so here use selectNode is ok
-						Typ: selectNode.ProjectList[colPos].Typ,
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: selectTag,
-								ColPos: colPos,
-							},
-						},
+					var err error
+					args[k], err = builder.makeInsertIndexPartExpr(selectNode, selectTag, tableDef, colName2Idx, part, prefixLengths)
+					if err != nil {
+						return nil, err
 					}
 				}
 				return BindFuncExprImplByPlanExpr(builder.GetContext(), "serial_full", args)
@@ -858,19 +937,18 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 				*/
 
 				var delIdxExpr *plan.Expr
+				prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+				if err != nil {
+					return 0, err
+				}
 				if !indexTableStoresSerializedKey(idxDef) {
 					colPos, ok := tableDef.Name2ColIndex[indexPrimaryPartName(idxDef)]
 					if !ok {
 						return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", indexPrimaryPartName(idxDef))
 					}
-					delIdxExpr = &plan.Expr{
-						Typ: selectNode.ProjectList[colPos].Typ,
-						Expr: &plan.Expr_Col{
-							Col: &plan.ColRef{
-								RelPos: scanTag,
-								ColPos: colPos,
-							},
-						},
+					delIdxExpr, err = builder.makeIndexPartExpr(scanTag, colPos, indexPrimaryPartName(idxDef), tableDef.Cols[colPos].Typ, prefixLengths)
+					if err != nil {
+						return 0, err
 					}
 				} else {
 					delArgs := make([]*plan.Expr, len(idxDef.Parts))
@@ -882,15 +960,9 @@ func (builder *QueryBuilder) appendDedupAndMultiUpdateNodesForBindInsert(
 							return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind insert err, can not find colName = %s", part)
 						}
 
-						delArgs[k] = &plan.Expr{
-							Typ: selectNode.ProjectList[colPos].Typ,
-							Expr: &plan.Expr_Col{
-								Col: &plan.ColRef{
-									// use scanTag because we want to delete the row that is not null.
-									RelPos: scanTag,
-									ColPos: colPos,
-								},
-							},
+						delArgs[k], err = builder.makeIndexPartExpr(scanTag, colPos, catalog.ResolveAlias(part), tableDef.Cols[colPos].Typ, prefixLengths)
+						if err != nil {
+							return 0, err
 						}
 					}
 

--- a/pkg/sql/plan/bind_update.go
+++ b/pkg/sql/plan/bind_update.go
@@ -375,6 +375,21 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 		}
 		lastNodeID = builder.appendNode(newProjNode, bindCtx)
 
+		makeUpdateIndexPartExpr := func(colPos int32, partName string, prefixLengths map[string]int) (*plan.Expr, error) {
+			partName = catalog.ResolveAlias(partName)
+			inputExpr := &plan.Expr{
+				Typ: selectNode.ProjectList[colPos].Typ,
+				Expr: &plan.Expr_Col{
+					Col: &plan.ColRef{
+						RelPos: selectNodeTag,
+						ColPos: colPos,
+						Name:   partName,
+					},
+				},
+			}
+			return builder.makeIndexPartExprFromInputExpr(inputExpr, partName, prefixLengths)
+		}
+
 		for i, tableDef := range dmlCtx.tableDefs {
 			if len(dmlCtx.updateCol2Expr[i]) == 0 {
 				continue
@@ -501,20 +516,24 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 				}
 				idxTableNodeID := builder.appendNode(idxScanNode, bindCtx)
 
+				prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+				if err != nil {
+					return 0, err
+				}
+
 				if len(idxDef.Parts) > 1 {
 					oldColName2Idx[idxTableDef.Name+"."+catalog.IndexTableIndexColName] = int32(len(newProjNode.ProjectList))
 					oldArgs := make([]*plan.Expr, len(idxDef.Parts))
 
 					for j, colName := range idxDef.Parts {
-						colPos := int32(oldColName2Idx[alias+"."+colName])
-						oldArgs[j] = &plan.Expr{
-							Typ: selectNode.ProjectList[colPos].Typ,
-							Expr: &plan.Expr_Col{
-								Col: &plan.ColRef{
-									RelPos: selectNodeTag,
-									ColPos: colPos,
-								},
-							},
+						colName = catalog.ResolveAlias(colName)
+						colPos, ok := oldColName2Idx[alias+"."+colName]
+						if !ok {
+							return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind update err, can not find colName = %s", colName)
+						}
+						oldArgs[j], err = makeUpdateIndexPartExpr(colPos, colName, prefixLengths)
+						if err != nil {
+							return 0, err
 						}
 					}
 
@@ -525,27 +544,51 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 					newArgs := make([]*plan.Expr, len(idxDef.Parts))
 
 					for j, colName := range idxDef.Parts {
-						colPos := oldColName2Idx[alias+"."+colName]
+						colName = catalog.ResolveAlias(colName)
+						colPos, ok := oldColName2Idx[alias+"."+colName]
+						if !ok {
+							return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind update err, can not find colName = %s", colName)
+						}
 						if updateIdx, ok := newColName2Idx[alias+"."+colName]; ok {
 							colPos = updateIdx
 						}
 
-						newArgs[j] = &plan.Expr{
-							Typ: selectNode.ProjectList[colPos].Typ,
-							Expr: &plan.Expr_Col{
-								Col: &plan.ColRef{
-									RelPos: selectNodeTag,
-									ColPos: colPos,
-								},
-							},
+						newArgs[j], err = makeUpdateIndexPartExpr(colPos, colName, prefixLengths)
+						if err != nil {
+							return 0, err
 						}
 					}
 
 					newUkExpr, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", newArgs)
 					newProjNode.ProjectList = append(newProjNode.ProjectList, newUkExpr)
 				} else {
-					oldColName2Idx[idxTableDef.Name+"."+catalog.IndexTableIndexColName] = oldColName2Idx[alias+"."+idxDef.Parts[0]]
-					newColName2Idx[idxTableDef.Name+"."+catalog.IndexTableIndexColName] = newColName2Idx[alias+"."+idxDef.Parts[0]]
+					partName := catalog.ResolveAlias(idxDef.Parts[0])
+					if prefixLengths[partName] > 0 {
+						oldColName2Idx[idxTableDef.Name+"."+catalog.IndexTableIndexColName] = int32(len(newProjNode.ProjectList))
+						oldPartPos, ok := oldColName2Idx[alias+"."+partName]
+						if !ok {
+							return 0, moerr.NewInternalErrorf(builder.GetContext(), "bind update err, can not find colName = %s", partName)
+						}
+						oldPartExpr, err := makeUpdateIndexPartExpr(oldPartPos, partName, prefixLengths)
+						if err != nil {
+							return 0, err
+						}
+						newProjNode.ProjectList = append(newProjNode.ProjectList, oldPartExpr)
+
+						newColName2Idx[idxTableDef.Name+"."+catalog.IndexTableIndexColName] = int32(len(newProjNode.ProjectList))
+						newPartPos, ok := newColName2Idx[alias+"."+partName]
+						if !ok {
+							newPartPos = oldPartPos
+						}
+						newPartExpr, err := makeUpdateIndexPartExpr(newPartPos, partName, prefixLengths)
+						if err != nil {
+							return 0, err
+						}
+						newProjNode.ProjectList = append(newProjNode.ProjectList, newPartExpr)
+					} else {
+						oldColName2Idx[idxTableDef.Name+"."+catalog.IndexTableIndexColName] = oldColName2Idx[alias+"."+partName]
+						newColName2Idx[idxTableDef.Name+"."+catalog.IndexTableIndexColName] = newColName2Idx[alias+"."+partName]
+					}
 				}
 
 				rightPkPos := idxTableDef.Name2ColIndex[catalog.IndexTableIndexColName]
@@ -673,21 +716,32 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 			} else {
 				args := make([]*plan.Expr, len(idxDef.Parts))
 
+				prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+				if err != nil {
+					return 0, err
+				}
+
 				var colPos int32
 				var ok bool
 				for k, colName := range idxDef.Parts {
-					if colPos, ok = oldColName2Idx[alias+"."+catalog.ResolveAlias(colName)]; !ok {
+					colName = catalog.ResolveAlias(colName)
+					if colPos, ok = oldColName2Idx[alias+"."+colName]; !ok {
 						errMsg := fmt.Sprintf("bind update err, can not find colName = %s", colName)
 						return 0, moerr.NewInternalError(builder.GetContext(), errMsg)
 					}
-					args[k] = &plan.Expr{
+					inputExpr := &plan.Expr{
 						Typ: selectNode.ProjectList[colPos].Typ,
 						Expr: &plan.Expr_Col{
 							Col: &plan.ColRef{
 								RelPos: selectNodeTag,
 								ColPos: colPos,
+								Name:   colName,
 							},
 						},
+					}
+					args[k], err = builder.makeIndexPartExprFromInputExpr(inputExpr, colName, prefixLengths)
+					if err != nil {
+						return 0, err
 					}
 				}
 
@@ -856,6 +910,10 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 			newIdx := oldIdx
 
 			idxDef := tableDef.Indexes[j]
+			prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+			if err != nil {
+				return 0, err
+			}
 			if idxDef.Unique {
 				if idxNeedUpdate[i][j] {
 					newPos := newColName2Idx[idxNode.TableDef.Name+"."+catalog.IndexTableIndexColName]
@@ -880,14 +938,19 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 					if updateIdx, ok := newColName2Idx[alias+"."+realColName]; ok {
 						colPos = int32(updateIdx)
 					}
-					newIdxExpr = &plan.Expr{
+					inputExpr := &plan.Expr{
 						Typ: selectNode.ProjectList[colPos].Typ,
 						Expr: &plan.Expr_Col{
 							Col: &plan.ColRef{
 								RelPos: selectNodeTag,
 								ColPos: colPos,
+								Name:   realColName,
 							},
 						},
+					}
+					newIdxExpr, err = builder.makeIndexPartExprFromInputExpr(inputExpr, realColName, prefixLengths)
+					if err != nil {
+						return 0, err
 					}
 				} else {
 					args := make([]*plan.Expr, len(idxDef.Parts))
@@ -904,8 +967,13 @@ func (builder *QueryBuilder) bindUpdate(stmt *tree.Update, bindCtx *BindContext)
 								Col: &plan.ColRef{
 									RelPos: selectNodeTag,
 									ColPos: colPos,
+									Name:   realColName,
 								},
 							},
+						}
+						args[k], err = builder.makeIndexPartExprFromInputExpr(args[k], realColName, prefixLengths)
+						if err != nil {
+							return 0, err
 						}
 					}
 

--- a/pkg/sql/plan/build_ddl.go
+++ b/pkg/sql/plan/build_ddl.go
@@ -1097,8 +1097,6 @@ func buildCreateTable(
 func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *plan.CreateTable, asSelectCols []*ColDef) error {
 	// all below fields' key is lower case
 	var primaryKeys []string
-	var indexs []string
-	var fulltext_indexs []string
 	colMap := make(map[string]*ColDef)
 	defaultMap := make(map[string]string)
 	uniqueIndexInfos := make([]*tree.UniqueIndex, 0)
@@ -1216,9 +1214,6 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 						return moerr.NewNotSupported(ctx.GetContext(), "the auto_incr column is only support integer type now")
 					}
 				case *tree.AttributeUnique, *tree.AttributeUniqueKey:
-					if isEnumPlanType(&colType) {
-						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("ENUM column '%s' cannot be in unique index", colNameOrigin))
-					}
 					if isSetPlanType(&colType) {
 						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("SET column '%s' cannot be in unique index", colNameOrigin))
 
@@ -1230,7 +1225,6 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 						KeyParts: []*tree.KeyPart{{ColName: def.Name}},
 						Name:     colName,
 					})
-					indexs = append(indexs, colName)
 				}
 			}
 			if len(pks) > 0 {
@@ -1330,24 +1324,20 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 				}
 
 				if col, ok := colMap[name]; ok {
-					if isEnumPlanType(&col.Typ) {
-						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("ENUM column '%s' cannot be in primary key", name))
-					}
-					if isSetPlanType(&col.Typ) {
-						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("SET column '%s' cannot be in primary key", name))
-					}
-					if isGeometryPlanType(&col.Typ) {
-						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("GEOMETRY column '%s' cannot be in primary key", name))
+					if err := checkIndexColumnSupportability(ctx.GetContext(), col, key, "primary"); err != nil {
+						return err
 					}
 				}
 
 				primaryKeys = append(primaryKeys, name)
 				pksMap[name] = true
-				indexs = append(indexs, name)
 			}
 		case *tree.Index:
 			err := checkIndexKeypartSupportability(ctx.GetContext(), def.KeyParts)
 			if err != nil {
+				return err
+			}
+			if err = checkSpatialIndexColumnSupport(ctx, def, colMap); err != nil {
 				return err
 			}
 
@@ -1356,15 +1346,10 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 				name := key.ColName.ColName()
 
 				if col, ok := colMap[name]; ok {
-					if isEnumPlanType(&col.Typ) {
-						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("ENUM column '%s' cannot be in secondary index", name))
-					}
-					if isGeometryPlanType(&col.Typ) && def.KeyType != tree.INDEX_TYPE_RTREE {
-						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("GEOMETRY column '%s' cannot be in index", name))
+					if err := checkIndexColumnSupportability(ctx.GetContext(), col, key, indexColumnCheckKind(def.KeyType)); err != nil {
+						return err
 					}
 				}
-
-				indexs = append(indexs, name)
 			}
 		case *tree.UniqueIndex:
 			err := checkIndexKeypartSupportability(ctx.GetContext(), def.KeyParts)
@@ -1377,18 +1362,10 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 				name := key.ColName.ColName()
 
 				if col, ok := colMap[name]; ok {
-					if isEnumPlanType(&col.Typ) {
-						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("ENUM column '%s' cannot be in unique index", name))
-					}
-					if isSetPlanType(&col.Typ) {
-						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("SET column '%s' cannot be in unique index", name))
-					}
-					if isGeometryPlanType(&col.Typ) {
-						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("GEOMETRY column '%s' cannot be in unique index", name))
+					if err := checkIndexColumnSupportability(ctx.GetContext(), col, key, "unique"); err != nil {
+						return err
 					}
 				}
-
-				indexs = append(indexs, name)
 			}
 		case *tree.FullTextIndex:
 			err := checkIndexKeypartSupportability(ctx.GetContext(), def.KeyParts)
@@ -1399,7 +1376,11 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 			fullTextIndexInfos = append(fullTextIndexInfos, def)
 			for _, key := range def.KeyParts {
 				name := key.ColName.ColName()
-				fulltext_indexs = append(fulltext_indexs, name)
+				if col, ok := colMap[name]; ok {
+					if col.Typ.Id == int32(types.T_blob) {
+						return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("BLOB column '%s' cannot be in index", key.ColName.ColNameOrigin()))
+					}
+				}
 			}
 		case *tree.ForeignKey:
 			if createTable.Temporary {
@@ -1664,38 +1645,6 @@ func buildTableDefs(stmt *tree.CreateTable, ctx CompilerContext, createTable *pl
 		}
 	}
 
-	// check index invalid on the type
-	for _, str := range indexs {
-		if _, ok := colMap[str]; !ok {
-			return moerr.NewInvalidInputf(ctx.GetContext(), "column '%s' is not exist", str)
-		}
-		if colMap[str].Typ.Id == int32(types.T_blob) {
-			return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("BLOB column '%s' cannot be in index", str))
-		}
-		if colMap[str].Typ.Id == int32(types.T_text) {
-			return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("TEXT column '%s' cannot be in index", str))
-		}
-		if colMap[str].Typ.Id == int32(types.T_datalink) {
-			return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("DATALINK column '%s' cannot be in index", str))
-		}
-		if colMap[str].Typ.Id == int32(types.T_json) {
-			return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("JSON column '%s' cannot be in index", str))
-		}
-		if isGeometryPlanType(&colMap[str].Typ) {
-			return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("GEOMETRY column '%s' cannot be in index", str))
-		}
-	}
-
-	// check fulltext index invalid on the typ
-	for _, str := range fulltext_indexs {
-		if _, ok := colMap[str]; !ok {
-			return moerr.NewInvalidInputf(ctx.GetContext(), "column '%s' is not exist", str)
-		}
-		if colMap[str].Typ.Id == int32(types.T_blob) {
-			return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("BLOB column '%s' cannot be in index", str))
-		}
-	}
-
 	// check Constraint Name (include index/ unique)
 	err := checkConstraintNames(uniqueIndexInfos, secondaryIndexInfos, ctx.GetContext())
 	if err != nil {
@@ -1907,23 +1856,8 @@ func buildUniqueIndexTable(createTable *plan.CreateTable, indexInfos []*tree.Uni
 			if _, ok := colMap[name]; !ok {
 				return moerr.NewInvalidInputf(ctx.GetContext(), "column '%s' is not exist", nameOrigin)
 			}
-			if colMap[name].Typ.Id == int32(types.T_blob) {
-				return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("BLOB column '%s' cannot be in index", nameOrigin))
-			}
-			if colMap[name].Typ.Id == int32(types.T_text) {
-				return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("TEXT column '%s' cannot be in index", nameOrigin))
-			}
-			if colMap[name].Typ.Id == int32(types.T_datalink) {
-				return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("DATALINK column '%s' cannot be in index", nameOrigin))
-			}
-			if colMap[name].Typ.Id == int32(types.T_json) {
-				return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("JSON column '%s' cannot be in index", nameOrigin))
-			}
-			if colMap[name].Typ.Id == int32(types.T_array_float32) || colMap[name].Typ.Id == int32(types.T_array_float64) {
-				return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("VECTOR column '%s' cannot be in index", nameOrigin))
-			}
-			if isGeometryPlanType(&colMap[name].Typ) {
-				return moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("GEOMETRY column '%s' cannot be in index", nameOrigin))
+			if err := checkIndexColumnSupportability(ctx.GetContext(), colMap[name], keyPart, "unique"); err != nil {
+				return err
 			}
 
 			indexParts = append(indexParts, name)
@@ -1932,15 +1866,12 @@ func buildUniqueIndexTable(createTable *plan.CreateTable, indexInfos []*tree.Uni
 		var keyName string
 		if len(indexInfo.KeyParts) == 1 {
 			keyName = catalog.IndexTableIndexColName
-			colName := indexInfo.KeyParts[0].ColName.ColName()
+			keyPart := indexInfo.KeyParts[0]
+			colName := keyPart.ColName.ColName()
 			colDef := &ColDef{
 				Name: keyName,
 				Alg:  plan.CompressType_Lz4,
-				Typ: Type{
-					Id:    colMap[colName].Typ.Id,
-					Width: colMap[colName].Typ.Width,
-					Scale: colMap[colName].Typ.Scale,
-				},
+				Typ:  indexTableKeyTypeForSinglePart(colMap[colName], keyPart),
 				Default: &plan.Default{
 					NullAbility:  false,
 					Expr:         nil,
@@ -2014,6 +1945,10 @@ func buildUniqueIndexTable(createTable *plan.CreateTable, indexInfos []*tree.Uni
 			indexDef.Comment = indexInfo.IndexOption.Comment
 		} else {
 			indexDef.Comment = ""
+		}
+		indexDef.IndexAlgoParams, err = catalog.AddIndexPrefixLengthsToParams(indexDef.IndexAlgoParams, indexInfo.KeyParts)
+		if err != nil {
+			return err
 		}
 		createTable.IndexTables = append(createTable.IndexTables, tableDef)
 		createTable.TableDef.Indexes = append(createTable.TableDef.Indexes, indexDef)
@@ -2223,6 +2158,10 @@ func buildMasterSecondaryIndexDef(ctx CompilerContext, indexInfo *tree.Index, co
 		indexDef.Comment = ""
 		indexDef.IndexAlgoParams = ""
 	}
+	indexDef.IndexAlgoParams, err = catalog.AddIndexPrefixLengthsToParams(indexDef.IndexAlgoParams, indexInfo.KeyParts)
+	if err != nil {
+		return nil, nil, err
+	}
 	return []*plan.IndexDef{indexDef}, []*TableDef{tableDef}, nil
 }
 
@@ -2269,27 +2208,15 @@ func buildRegularSecondaryIndexDef(ctx CompilerContext, indexInfo *tree.Index, c
 	isPkAlreadyPresentInIndexParts := false
 	for _, keyPart := range indexInfo.KeyParts {
 		name := keyPart.ColName.ColName()
-		nameOrigin := keyPart.ColName.ColNameOrigin()
 		if _, ok := colMap[name]; !ok {
-			return nil, nil, moerr.NewInvalidInputf(ctx.GetContext(), "column '%s' is not exist", nameOrigin)
+			return nil, nil, moerr.NewInvalidInputf(ctx.GetContext(), "column '%s' is not exist", keyPart.ColName.ColNameOrigin())
 		}
-		if colMap[name].Typ.Id == int32(types.T_blob) {
-			return nil, nil, moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("BLOB column '%s' cannot be in index", nameOrigin))
+		indexKind := "secondary"
+		if indexInfo.KeyType == tree.INDEX_TYPE_RTREE {
+			indexKind = "rtree"
 		}
-		if colMap[name].Typ.Id == int32(types.T_text) {
-			return nil, nil, moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("TEXT column '%s' cannot be in index", nameOrigin))
-		}
-		if colMap[name].Typ.Id == int32(types.T_datalink) {
-			return nil, nil, moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("DATALINK column '%s' cannot be in index", nameOrigin))
-		}
-		if colMap[name].Typ.Id == int32(types.T_json) {
-			return nil, nil, moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("JSON column '%s' cannot be in index", nameOrigin))
-		}
-		if colMap[name].Typ.Id == int32(types.T_array_float32) || colMap[name].Typ.Id == int32(types.T_array_float64) {
-			return nil, nil, moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("VECTOR column '%s' cannot be in index", nameOrigin))
-		}
-		if isGeometryPlanType(&colMap[name].Typ) && indexInfo.KeyType != tree.INDEX_TYPE_RTREE {
-			return nil, nil, moerr.NewNotSupported(ctx.GetContext(), fmt.Sprintf("GEOMETRY column '%s' cannot be in index", nameOrigin))
+		if err := checkIndexColumnSupportability(ctx.GetContext(), colMap[name], keyPart, indexKind); err != nil {
+			return nil, nil, err
 		}
 
 		if strings.Compare(name, pkeyName) == 0 || catalog.IsAlias(name) {
@@ -2419,6 +2346,10 @@ func buildRegularSecondaryIndexDef(ctx CompilerContext, indexInfo *tree.Index, c
 	} else {
 		indexDef.Comment = ""
 		indexDef.IndexAlgoParams = ""
+	}
+	indexDef.IndexAlgoParams, err = catalog.AddIndexPrefixLengthsToParams(indexDef.IndexAlgoParams, indexInfo.KeyParts)
+	if err != nil {
+		return nil, nil, err
 	}
 	return []*plan.IndexDef{indexDef}, []*TableDef{tableDef}, nil
 }

--- a/pkg/sql/plan/build_ddl_test.go
+++ b/pkg/sql/plan/build_ddl_test.go
@@ -493,6 +493,93 @@ func TestBuildAlterTableError(t *testing.T) {
 	runTestShouldError(mock, t, sqls)
 }
 
+func TestBuildIndexAllowsEnumAndTextBlobPrefix(t *testing.T) {
+	mock := NewMockOptimizer(false)
+	sqls := []string{
+		"CREATE TABLE enum_idx_ok1 (id VARCHAR(191) PRIMARY KEY, role ENUM('a','b','c'), INDEX idx_role(role));",
+		"CREATE TABLE enum_idx_ok2 (id VARCHAR(191) PRIMARY KEY, role ENUM('a','b','c'), UNIQUE INDEX uq_role(role));",
+		"CREATE TABLE enum_idx_ok3 (id VARCHAR(191) PRIMARY KEY, name VARCHAR(191), role ENUM('a','b','c'), INDEX idx_name_role(name, role));",
+		"CREATE TABLE text_prefix_ok1 (id INT PRIMARY KEY, t TEXT, INDEX idx_t(t(100)));",
+		"CREATE TABLE text_prefix_ok2 (id INT PRIMARY KEY, t TEXT, UNIQUE INDEX uq_t(t(100)));",
+		"CREATE TABLE blob_prefix_ok1 (id INT PRIMARY KEY, b BLOB, INDEX idx_b(b(100)));",
+	}
+	runTestShouldPass(mock, t, sqls, false, false)
+}
+
+func TestBuildIndexRejectsTextBlobPlainIndex(t *testing.T) {
+	mock := NewMockOptimizer(false)
+	sqlerrs := []string{
+		"CREATE TABLE text_plain_err1 (id INT PRIMARY KEY, t TEXT, INDEX idx_t(t));",
+		"CREATE TABLE text_plain_err2 (id INT PRIMARY KEY, t TEXT, UNIQUE INDEX uq_t(t));",
+		"CREATE TABLE text_comp_pk_err (id INT, t TEXT, PRIMARY KEY(id, t));",
+		"CREATE TABLE blob_plain_err1 (id INT PRIMARY KEY, b BLOB, INDEX idx_b(b));",
+		"CREATE TABLE blob_comp_pk_err (b BLOB, id INT, PRIMARY KEY(b, id));",
+	}
+	runTestShouldError(mock, t, sqlerrs)
+}
+
+func TestBuildRegularSecondaryIndexPersistsPrefixLengths(t *testing.T) {
+	mock := NewMockOptimizer(false)
+	tests := []struct {
+		name   string
+		sql    string
+		column string
+		length int
+	}{
+		{
+			name:   "text",
+			sql:    "CREATE TABLE text_prefix_secondary_ok (id INT PRIMARY KEY, t TEXT, INDEX idx_t(t(100)));",
+			column: "t",
+			length: 100,
+		},
+		{
+			name:   "blob",
+			sql:    "CREATE TABLE blob_prefix_secondary_ok (id INT PRIMARY KEY, b BLOB, INDEX idx_b(b(100)));",
+			column: "b",
+			length: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logicPlan, err := runOneStmt(mock, t, tt.sql)
+			require.NoError(t, err)
+
+			createTable := logicPlan.GetDdl().GetCreateTable()
+			require.NotNil(t, createTable)
+			require.Len(t, createTable.GetTableDef().GetIndexes(), 1)
+
+			indexDef := createTable.GetTableDef().GetIndexes()[0]
+			prefixLengths := catalog.IndexPrefixLengthsFromParams(indexDef.IndexAlgoParams)
+			require.Equal(t, tt.length, prefixLengths[tt.column])
+		})
+	}
+}
+
+func TestBuildVectorIndexAllowsIvfFlatOnly(t *testing.T) {
+	mock := NewMockOptimizer(false)
+	sqls := []string{
+		"CREATE TABLE vec_idx_ok1 (id INT PRIMARY KEY, embedding VECF32(3), KEY idx_emb USING ivfflat (embedding) lists = 2 op_type 'vector_l2_ops');",
+		"CREATE TABLE vec_idx_ok2 (id INT PRIMARY KEY, embedding VECF64(3), KEY idx_emb USING ivfflat (embedding) lists = 2 op_type 'vector_l2_ops');",
+	}
+	runTestShouldPass(mock, t, sqls, false, false)
+
+	sqlerrs := []string{
+		"CREATE TABLE vec_idx_err1 (id INT PRIMARY KEY, embedding VECF32(3), KEY idx_emb (embedding));",
+		"CREATE TABLE vec_idx_err2 (id INT PRIMARY KEY, embedding VECF64(3), KEY idx_emb (embedding));",
+	}
+	runTestShouldError(mock, t, sqlerrs)
+}
+
+func TestBuildIndexAllowsRTreeGeometry(t *testing.T) {
+	mock := NewMockOptimizer(false)
+	sqls := []string{
+		"CREATE TABLE geo_spatial_ok (id INT PRIMARY KEY, g POINT NOT NULL, KEY idx_g USING RTREE (g));",
+		"CREATE TABLE geo_spatial_nullable_ok (id INT PRIMARY KEY, g POINT, KEY idx_g USING RTREE (g));",
+	}
+	runTestShouldPass(mock, t, sqls, false, false)
+}
+
 func TestGeometryDDLGuardsSQLPaths(t *testing.T) {
 	mock := NewMockOptimizer(false)
 	rt := moruntime.DefaultRuntime()
@@ -506,7 +593,6 @@ func TestGeometryDDLGuardsSQLPaths(t *testing.T) {
 		"CREATE TABLE geo_pk_err (g GEOMETRY PRIMARY KEY);",
 		"CREATE TABLE geo_uk_err (g GEOMETRY UNIQUE KEY);",
 		"CREATE TABLE geo_idx_err (g GEOMETRY, KEY(g));",
-		"CREATE TABLE geo_spatial_nullable_err (id INT PRIMARY KEY, g POINT, KEY idx_g USING RTREE (g));",
 		"ALTER TABLE emp ADD COLUMN g GEOMETRY UNIQUE KEY;",
 		"ALTER TABLE emp ADD COLUMN g GEOMETRY PRIMARY KEY;",
 	}

--- a/pkg/sql/plan/build_dml_util.go
+++ b/pkg/sql/plan/build_dml_util.go
@@ -2200,6 +2200,10 @@ func appendPreInsertPlan(
 	var useColumns []int32
 	idxDef := tableDef.Indexes[indexIdx]
 	colsMap := make(map[string]int)
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(idxDef.IndexAlgoParams)
+	if err != nil {
+		return 0, err
+	}
 
 	for i, col := range tableDef.Cols {
 		colsMap[col.Name] = i
@@ -2217,10 +2221,14 @@ func appendPreInsertPlan(
 
 	pkColumn, originPkType := getPkPos(tableDef, false)
 	lastNodeId = recomputeMoCPKeyViaProjection(builder, bindCtx, tableDef, lastNodeId, pkColumn)
+	lastNodeId, useColumns, err = appendIndexPrefixProjection(builder, bindCtx, tableDef, lastNodeId, keyParts, colsMap, useColumns, prefixLengths)
+	if err != nil {
+		return -1, err
+	}
 
 	var ukType Type
 	if len(idxDef.Parts) == 1 || isSpatialIndexDef(idxDef) {
-		ukType = tableDef.Cols[useColumns[0]].Typ
+		ukType = builder.qry.Nodes[lastNodeId].ProjectList[useColumns[0]].Typ
 	} else {
 		ukType = Type{
 			Id:    int32(types.T_varchar),
@@ -2412,34 +2420,36 @@ func appendDeleteIndexTablePlan(
 	// append join node
 	var joinConds []*Expr
 	var leftExpr *Expr
+	prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(indexdef.IndexAlgoParams)
+	if err != nil {
+		return -1, err
+	}
 	partsLength := len(indexdef.Parts)
 	if partsLength == 1 {
-		orginIndexColumnName := indexdef.Parts[0]
-		typ := typMap[orginIndexColumnName]
-		leftExpr = &Expr{
-			Typ: typ,
-			Expr: &plan.Expr_Col{
-				Col: &plan.ColRef{
-					RelPos: 1,
-					ColPos: int32(posMap[orginIndexColumnName]),
-					Name:   orginIndexColumnName,
-				},
-			},
+		originIndexColumnName := catalog.ResolveAlias(indexdef.Parts[0])
+		leftExpr, err = builder.makeIndexPartExpr(
+			1,
+			int32(posMap[originIndexColumnName]),
+			originIndexColumnName,
+			typMap[originIndexColumnName],
+			prefixLengths,
+		)
+		if err != nil {
+			return -1, err
 		}
 	} else {
 		args := make([]*Expr, partsLength)
 		for i, column := range indexdef.Parts {
 			column = catalog.ResolveAlias(column)
-			typ := typMap[column]
-			args[i] = &plan.Expr{
-				Typ: typ,
-				Expr: &plan.Expr_Col{
-					Col: &plan.ColRef{
-						RelPos: 1,
-						ColPos: int32(posMap[column]),
-						Name:   column,
-					},
-				},
+			args[i], err = builder.makeIndexPartExpr(
+				1,
+				int32(posMap[column]),
+				column,
+				typMap[column],
+				prefixLengths,
+			)
+			if err != nil {
+				return -1, err
 			}
 		}
 		if isUK {
@@ -2525,6 +2535,88 @@ func appendDeleteIndexTablePlan(
 	}, bindCtx)
 	recalcStatsByRuntimeFilter(builder.qry.Nodes[leftId], builder.qry.Nodes[lastNodeId], builder)
 	return lastNodeId, nil
+}
+
+func appendIndexPrefixProjection(
+	builder *QueryBuilder,
+	bindCtx *BindContext,
+	tableDef *TableDef,
+	lastNodeId int32,
+	keyParts []string,
+	colsMap map[string]int,
+	useColumns []int32,
+	prefixLengths map[string]int,
+) (int32, []int32, error) {
+	if len(prefixLengths) == 0 {
+		return lastNodeId, useColumns, nil
+	}
+
+	lastProject := builder.qry.Nodes[lastNodeId].ProjectList
+	projectProjection := make([]*Expr, len(lastProject), len(lastProject)+len(prefixLengths))
+	for i := range lastProject {
+		projectProjection[i] = &plan.Expr{
+			Typ: lastProject[i].Typ,
+			Expr: &plan.Expr_Col{
+				Col: &plan.ColRef{
+					RelPos: 0,
+					ColPos: int32(i),
+				},
+			},
+		}
+	}
+
+	newUseColumns := make([]int32, 0, len(useColumns))
+	hasPrefixPart := false
+	for _, part := range keyParts {
+		part = catalog.ResolveAlias(part)
+		pos, ok := colsMap[part]
+		if !ok {
+			continue
+		}
+		length := prefixLengths[part]
+		if length <= 0 {
+			newUseColumns = append(newUseColumns, int32(pos))
+			continue
+		}
+
+		prefixExpr, err := BindFuncExprImplByPlanExpr(builder.GetContext(), "substring", []*Expr{
+			{
+				Typ: lastProject[pos].Typ,
+				Expr: &plan.Expr_Col{
+					Col: &plan.ColRef{
+						RelPos: 0,
+						ColPos: int32(pos),
+						Name:   part,
+					},
+				},
+			},
+			makePlan2Int64ConstExprWithType(1),
+			makePlan2Int64ConstExprWithType(int64(length)),
+		})
+		if err != nil {
+			return -1, nil, err
+		}
+		if prefixType, ok := indexTableKeyTypeForPrefix(lastProject[pos].Typ); ok {
+			prefixExpr, err = appendCastBeforeExpr(builder.GetContext(), prefixExpr, prefixType)
+			if err != nil {
+				return -1, nil, err
+			}
+		}
+		newUseColumns = append(newUseColumns, int32(len(projectProjection)))
+		projectProjection = append(projectProjection, prefixExpr)
+		hasPrefixPart = true
+	}
+
+	if !hasPrefixPart {
+		return lastNodeId, useColumns, nil
+	}
+
+	projectNode := &Node{
+		NodeType:    plan.Node_PROJECT,
+		Children:    []int32{lastNodeId},
+		ProjectList: projectProjection,
+	}
+	return builder.appendNode(projectNode, bindCtx), newUseColumns, nil
 }
 
 func appendDeleteMasterTablePlan(builder *QueryBuilder, bindCtx *BindContext,

--- a/pkg/sql/plan/build_dml_util_test.go
+++ b/pkg/sql/plan/build_dml_util_test.go
@@ -16,9 +16,11 @@ package plan
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/stretchr/testify/require"
@@ -167,4 +169,431 @@ func TestMakeInsertValueConstExprGeometry(t *testing.T) {
 	require.Equal(t, int32(types.T_varchar), fn.Args[0].Typ.Id)
 	require.Equal(t, "POINT(1 1)", fn.Args[0].GetLit().GetSval())
 	require.Equal(t, int32(types.T_geometry), fn.Args[1].Typ.Id)
+}
+
+func TestAppendIndexPrefixProjection(t *testing.T) {
+	newBuilder := func(t *testing.T) (*QueryBuilder, *BindContext, int32) {
+		t.Helper()
+
+		builder := NewQueryBuilder(plan.Query_SELECT, NewMockCompilerContext(true), false, true)
+		bindCtx := NewBindContext(builder, nil)
+		lastNodeID := builder.appendNode(&plan.Node{
+			NodeType: plan.Node_PROJECT,
+			ProjectList: []*plan.Expr{
+				{
+					Typ: plan.Type{Id: int32(types.T_int64)},
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{Name: "id", ColPos: 0},
+					},
+				},
+				{
+					Typ: plan.Type{Id: int32(types.T_text), Width: types.MaxVarcharLen},
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{Name: "body", ColPos: 1},
+					},
+				},
+			},
+		}, bindCtx)
+		return builder, bindCtx, lastNodeID
+	}
+
+	t.Run("empty prefix lengths keeps original projection", func(t *testing.T) {
+		builder, bindCtx, lastNodeID := newBuilder(t)
+		useColumns := []int32{1}
+
+		gotNodeID, gotUseColumns, err := appendIndexPrefixProjection(
+			builder,
+			bindCtx,
+			&plan.TableDef{Name: "t"},
+			lastNodeID,
+			[]string{"body"},
+			map[string]int{"body": 1},
+			useColumns,
+			nil,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, lastNodeID, gotNodeID)
+		require.Equal(t, useColumns, gotUseColumns)
+		require.Len(t, builder.qry.Nodes, 1)
+	})
+
+	t.Run("prefix key appends substring projection", func(t *testing.T) {
+		builder, bindCtx, lastNodeID := newBuilder(t)
+
+		gotNodeID, gotUseColumns, err := appendIndexPrefixProjection(
+			builder,
+			bindCtx,
+			&plan.TableDef{Name: "t"},
+			lastNodeID,
+			[]string{"body"},
+			map[string]int{"id": 0, "body": 1},
+			[]int32{1},
+			map[string]int{"body": 8},
+		)
+
+		require.NoError(t, err)
+		require.NotEqual(t, lastNodeID, gotNodeID)
+		require.Equal(t, []int32{2}, gotUseColumns)
+		require.Len(t, builder.qry.Nodes, 2)
+
+		projectNode := builder.qry.Nodes[gotNodeID]
+		require.Equal(t, plan.Node_PROJECT, projectNode.NodeType)
+		require.Equal(t, []int32{lastNodeID}, projectNode.Children)
+		require.Len(t, projectNode.ProjectList, 3)
+
+		prefixExpr := projectNode.ProjectList[2]
+		require.Equal(t, int32(types.T_varchar), prefixExpr.Typ.Id)
+		require.Equal(t, int32(types.MaxVarcharLen), prefixExpr.Typ.Width)
+
+		castFn := prefixExpr.GetF()
+		require.NotNil(t, castFn)
+		require.Equal(t, "cast", castFn.Func.ObjName)
+		require.Len(t, castFn.Args, 2)
+
+		substringFn := castFn.Args[0].GetF()
+		require.NotNil(t, substringFn)
+		require.Equal(t, "substring", substringFn.Func.ObjName)
+		require.Len(t, substringFn.Args, 3)
+		require.Equal(t, "body", substringFn.Args[0].GetCol().Name)
+		require.Equal(t, int64(1), substringFn.Args[1].GetLit().GetI64Val())
+		require.Equal(t, int64(8), substringFn.Args[2].GetLit().GetI64Val())
+	})
+
+	t.Run("missing and non-positive prefix parts do not append projection", func(t *testing.T) {
+		builder, bindCtx, lastNodeID := newBuilder(t)
+		useColumns := []int32{0}
+
+		gotNodeID, gotUseColumns, err := appendIndexPrefixProjection(
+			builder,
+			bindCtx,
+			&plan.TableDef{Name: "t"},
+			lastNodeID,
+			[]string{"missing", "id"},
+			map[string]int{"id": 0, "body": 1},
+			useColumns,
+			map[string]int{"missing": 4, "id": 0},
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, lastNodeID, gotNodeID)
+		require.Equal(t, useColumns, gotUseColumns)
+		require.Len(t, builder.qry.Nodes, 1)
+	})
+}
+
+func TestAppendDeleteIndexTablePlanUsesPrefixLookupKey(t *testing.T) {
+	newBuilder := func(t *testing.T) (*QueryBuilder, *BindContext, int32) {
+		t.Helper()
+
+		builder := NewQueryBuilder(plan.Query_SELECT, NewMockCompilerContext(true), false, true)
+		bindCtx := NewBindContext(builder, nil)
+		lastNodeID := builder.appendNode(&plan.Node{
+			NodeType: plan.Node_PROJECT,
+			Stats:    &plan.Stats{Selectivity: 1, Outcnt: 1, Cost: 1, TableCnt: 1},
+			ProjectList: []*plan.Expr{
+				{
+					Typ: plan.Type{Id: int32(types.T_int64)},
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{Name: "id", ColPos: 0},
+					},
+				},
+				{
+					Typ: plan.Type{Id: int32(types.T_text), Width: types.MaxVarcharLen},
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{Name: "body", ColPos: 1},
+					},
+				},
+				{
+					Typ: plan.Type{Id: int32(types.T_varchar), Width: 32},
+					Expr: &plan.Expr_Col{
+						Col: &plan.ColRef{Name: "tenant", ColPos: 2},
+					},
+				},
+			},
+		}, bindCtx)
+		return builder, bindCtx, lastNodeID
+	}
+
+	indexTableDef := &plan.TableDef{
+		Name: "idx_body",
+		Cols: []*plan.ColDef{
+			{
+				Name: catalog.Row_ID,
+				Typ:  plan.Type{Id: int32(types.T_Rowid), Width: 16},
+			},
+			{
+				Name: catalog.IndexTableIndexColName,
+				Typ:  plan.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen},
+			},
+		},
+		Pkey: &plan.PrimaryKeyDef{PkeyColName: catalog.IndexTableIndexColName},
+	}
+	typMap := map[string]plan.Type{
+		"id":     {Id: int32(types.T_int64)},
+		"body":   {Id: int32(types.T_text), Width: types.MaxVarcharLen},
+		"tenant": {Id: int32(types.T_varchar), Width: 32},
+	}
+	posMap := map[string]int{
+		"id":     0,
+		"body":   1,
+		"tenant": 2,
+	}
+
+	extractLookupExpr := func(t *testing.T, joinNode *plan.Node) *plan.Expr {
+		t.Helper()
+		require.Equal(t, plan.Node_JOIN, joinNode.NodeType)
+		require.Len(t, joinNode.OnList, 1)
+
+		joinFn := joinNode.OnList[0].GetF()
+		require.NotNil(t, joinFn)
+		require.Equal(t, "=", joinFn.Func.ObjName)
+		require.Len(t, joinFn.Args, 2)
+		return joinFn.Args[1]
+	}
+	requirePrefixExpr := func(t *testing.T, expr *plan.Expr, colName string, length int64) {
+		t.Helper()
+
+		castFn := expr.GetF()
+		require.NotNil(t, castFn)
+		require.Equal(t, "cast", castFn.Func.ObjName)
+		require.Len(t, castFn.Args, 2)
+
+		substringFn := castFn.Args[0].GetF()
+		require.NotNil(t, substringFn)
+		require.Equal(t, "substring", substringFn.Func.ObjName)
+		require.Len(t, substringFn.Args, 3)
+		require.Equal(t, colName, substringFn.Args[0].GetCol().Name)
+		require.Equal(t, int32(1), substringFn.Args[0].GetCol().RelPos)
+		require.Equal(t, int64(1), substringFn.Args[1].GetLit().GetI64Val())
+		require.Equal(t, length, substringFn.Args[2].GetLit().GetI64Val())
+	}
+
+	t.Run("single prefix part", func(t *testing.T) {
+		builder, bindCtx, lastNodeID := newBuilder(t)
+
+		gotNodeID, err := appendDeleteIndexTablePlan(
+			builder,
+			bindCtx,
+			&plan.ObjectRef{ObjName: "idx_body"},
+			indexTableDef,
+			&plan.IndexDef{
+				Parts:           []string{"body"},
+				IndexAlgoParams: `{"prefix_lengths":"body:8"}`,
+			},
+			typMap,
+			posMap,
+			lastNodeID,
+			true,
+		)
+
+		require.NoError(t, err)
+		lookupExpr := extractLookupExpr(t, builder.qry.Nodes[gotNodeID])
+		requirePrefixExpr(t, lookupExpr, "body", 8)
+	})
+
+	t.Run("composite prefix part", func(t *testing.T) {
+		builder, bindCtx, lastNodeID := newBuilder(t)
+
+		gotNodeID, err := appendDeleteIndexTablePlan(
+			builder,
+			bindCtx,
+			&plan.ObjectRef{ObjName: "idx_body_tenant"},
+			indexTableDef,
+			&plan.IndexDef{
+				Parts:           []string{"body", "tenant"},
+				IndexAlgoParams: `{"prefix_lengths":"body:8"}`,
+			},
+			typMap,
+			posMap,
+			lastNodeID,
+			false,
+		)
+
+		require.NoError(t, err)
+		lookupExpr := extractLookupExpr(t, builder.qry.Nodes[gotNodeID])
+
+		serialFn := lookupExpr.GetF()
+		require.NotNil(t, serialFn)
+		require.Equal(t, "serial_full", serialFn.Func.ObjName)
+		require.Len(t, serialFn.Args, 2)
+		requirePrefixExpr(t, serialFn.Args[0], "body", 8)
+		require.Equal(t, "tenant", serialFn.Args[1].GetCol().Name)
+	})
+
+	t.Run("composite unique prefix part", func(t *testing.T) {
+		builder, bindCtx, lastNodeID := newBuilder(t)
+
+		gotNodeID, err := appendDeleteIndexTablePlan(
+			builder,
+			bindCtx,
+			&plan.ObjectRef{ObjName: "idx_body_tenant"},
+			indexTableDef,
+			&plan.IndexDef{
+				Parts:           []string{"body", "tenant"},
+				IndexAlgoParams: `{"prefix_lengths":"body:8"}`,
+			},
+			typMap,
+			posMap,
+			lastNodeID,
+			true,
+		)
+
+		require.NoError(t, err)
+		lookupExpr := extractLookupExpr(t, builder.qry.Nodes[gotNodeID])
+
+		serialFn := lookupExpr.GetF()
+		require.NotNil(t, serialFn)
+		require.Equal(t, "serial", serialFn.Func.ObjName)
+		require.Len(t, serialFn.Args, 2)
+		requirePrefixExpr(t, serialFn.Args[0], "body", 8)
+		require.Equal(t, "tenant", serialFn.Args[1].GetCol().Name)
+	})
+}
+
+func TestPrefixIndexDMLPlansMaterializePrefixKeys(t *testing.T) {
+	mock := NewMockOptimizer(true)
+	emp := mock.ctxt.tables["emp"]
+	require.NotNil(t, emp)
+	require.NotEmpty(t, emp.Indexes)
+	for _, idxDef := range emp.Indexes {
+		idxDef.IndexAlgoParams = `{"prefix_lengths":"ename:4"}`
+	}
+
+	assertPlanHasEnamePrefix := func(t *testing.T, sql string) {
+		t.Helper()
+
+		logicPlan, err := runOneStmt(mock, t, sql)
+		require.NoError(t, err)
+		require.NotNil(t, logicPlan.GetQuery())
+
+		require.True(
+			t,
+			queryHasPrefixSubstring(logicPlan.GetQuery(), "ename", 4),
+			"expected plan for %q to materialize prefix index key with substring(ename, 1, 4)",
+			sql,
+		)
+	}
+
+	assertPlanHasEnamePrefix(t, "update constraint_test.emp set ename = 'abcdef-long' where empno = 1")
+	assertPlanHasEnamePrefix(t, "delete from constraint_test.emp where empno = 1")
+
+	assertPlanHasPrefixCount := func(t *testing.T, sql, colName string, minCount int) {
+		t.Helper()
+
+		logicPlan, err := runOneStmt(mock, t, sql)
+		require.NoError(t, err)
+		require.NotNil(t, logicPlan.GetQuery())
+
+		got := countQueryPrefixSubstrings(logicPlan.GetQuery(), colName, 4)
+		require.GreaterOrEqual(t, got, minCount, "expected plan for %q to materialize at least %d prefix keys", sql, minCount)
+	}
+
+	dept := mock.ctxt.tables["dept"]
+	require.NotNil(t, dept)
+	for _, idxDef := range dept.Indexes {
+		if len(idxDef.Parts) == 1 && idxDef.Parts[0] == "dname" {
+			idxDef.IndexAlgoParams = `{"prefix_lengths":"dname:4"}`
+		}
+	}
+	assertPlanHasPrefixCount(t, "update constraint_test.dept set dname = 'abcdef-long' where deptno = 1", "dname", 1)
+	assertPlanHasPrefixCount(t, "delete from constraint_test.dept where deptno = 1", "dname", 1)
+
+	singleIdx := mock.ctxt.tables["single_idx_t"]
+	require.NotNil(t, singleIdx)
+	require.Len(t, singleIdx.Indexes, 1)
+	singleIdx.Cols[1].Typ = plan.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}
+	singleIdx.Indexes[0].IndexAlgoParams = `{"prefix_lengths":"val:4"}`
+	singleIdxIndexTable := mock.ctxt.tables[singleIdx.Indexes[0].IndexTableName]
+	require.NotNil(t, singleIdxIndexTable)
+	singleIdxIndexTable.Cols[0].Typ = plan.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}
+	assertPlanHasPrefixCount(t, "insert into constraint_test.single_idx_t values (1, 'abcdef-long') on duplicate key update val = values(val)", "val", 2)
+	assertPlanHasPrefixCount(t, "update constraint_test.single_idx_t set val = 'abcdef-long' where id = 1", "val", 2)
+	assertPlanHasPrefixCount(t, "delete from constraint_test.single_idx_t where id = 1", "val", 1)
+}
+
+func queryHasPrefixSubstring(query *plan.Query, colName string, length int64) bool {
+	return countQueryPrefixSubstrings(query, colName, length) > 0
+}
+
+func countQueryPrefixSubstrings(query *plan.Query, colName string, length int64) int {
+	count := 0
+	for _, node := range query.Nodes {
+		count += countExprListPrefixSubstrings(node.ProjectList, colName, length)
+		count += countExprListPrefixSubstrings(node.OnList, colName, length)
+		count += countExprListPrefixSubstrings(node.FilterList, colName, length)
+	}
+	return count
+}
+
+func countExprListPrefixSubstrings(exprs []*plan.Expr, colName string, length int64) int {
+	count := 0
+	for _, expr := range exprs {
+		count += countExprPrefixSubstrings(expr, colName, length)
+	}
+	return count
+}
+
+func countExprPrefixSubstrings(expr *plan.Expr, colName string, length int64) int {
+	if expr == nil {
+		return 0
+	}
+
+	fn := expr.GetF()
+	if fn == nil {
+		list := expr.GetList()
+		if list == nil {
+			return 0
+		}
+		return countExprListPrefixSubstrings(list.List, colName, length)
+	}
+
+	count := 0
+	if fn.Func.ObjName == "substring" && len(fn.Args) == 3 {
+		start := fn.Args[1].GetLit()
+		prefixLen := fn.Args[2].GetLit()
+		if exprContainsColumn(fn.Args[0], colName) &&
+			start != nil && start.GetI64Val() == 1 &&
+			prefixLen != nil && prefixLen.GetI64Val() == length {
+			count++
+		}
+	}
+
+	return count + countExprListPrefixSubstrings(fn.Args, colName, length)
+}
+
+func exprContainsColumn(expr *plan.Expr, colName string) bool {
+	if expr == nil {
+		return false
+	}
+
+	if col := expr.GetCol(); col != nil {
+		if col.Name == "" {
+			return true
+		}
+		return columnNameMatches(col.Name, colName)
+	}
+
+	if fn := expr.GetF(); fn != nil {
+		for _, arg := range fn.Args {
+			if exprContainsColumn(arg, colName) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if list := expr.GetList(); list != nil {
+		for _, item := range list.List {
+			if exprContainsColumn(item, colName) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func columnNameMatches(got, want string) bool {
+	return got == want || strings.HasSuffix(got, "."+want)
 }

--- a/pkg/sql/plan/build_index_util.go
+++ b/pkg/sql/plan/build_index_util.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
 )
 
@@ -131,6 +132,105 @@ func checkIndexKeypartSupportability(context context.Context, keyParts []*tree.K
 	for _, key := range keyParts {
 		if key.Expr != nil {
 			return moerr.NewInternalError(context, "unsupported index which using expression as keypart")
+		}
+	}
+	return nil
+}
+
+func indexTableKeyTypeForSinglePart(col *ColDef, keyPart *tree.KeyPart) Type {
+	if col == nil {
+		return Type{}
+	}
+	if keyPart != nil && keyPart.Length > 0 {
+		if prefixType, ok := indexTableKeyTypeForPrefix(col.Typ); ok {
+			return prefixType
+		}
+	}
+	return Type{
+		Id:    col.Typ.Id,
+		Width: col.Typ.Width,
+		Scale: col.Typ.Scale,
+	}
+}
+
+func indexTableKeyTypeForPrefix(colType Type) (Type, bool) {
+	switch colType.Id {
+	case int32(types.T_text):
+		return Type{
+			Id:    int32(types.T_varchar),
+			Width: types.MaxVarcharLen,
+		}, true
+	case int32(types.T_blob):
+		return Type{
+			Id:    int32(types.T_varbinary),
+			Width: types.MaxVarBinaryLen,
+		}, true
+	default:
+		return Type{}, false
+	}
+}
+
+func indexColumnCheckKind(indexType tree.IndexType) string {
+	switch indexType {
+	case tree.INDEX_TYPE_IVFFLAT:
+		return "ivfflat"
+	case tree.INDEX_TYPE_HNSW:
+		return "hnsw"
+	case tree.INDEX_TYPE_RTREE:
+		return "rtree"
+	default:
+		return "secondary"
+	}
+}
+
+func checkIndexColumnSupportability(ctx context.Context, col *ColDef, keyPart *tree.KeyPart, indexKind string) error {
+	if col == nil || keyPart == nil || keyPart.ColName == nil {
+		return moerr.NewInternalError(ctx, "index column definition is nil")
+	}
+
+	colName := keyPart.ColName.ColNameOrigin()
+
+	switch col.Typ.Id {
+	case int32(types.T_blob):
+		if keyPart.Length > 0 && indexKind != "primary" {
+			return nil
+		}
+		return moerr.NewNotSupported(ctx, fmt.Sprintf("BLOB column '%s' cannot be in index", colName))
+	case int32(types.T_text):
+		if keyPart.Length > 0 && indexKind != "primary" {
+			return nil
+		}
+		return moerr.NewNotSupported(ctx, fmt.Sprintf("TEXT column '%s' cannot be in index", colName))
+	case int32(types.T_datalink):
+		return moerr.NewNotSupported(ctx, fmt.Sprintf("DATALINK column '%s' cannot be in index", colName))
+	case int32(types.T_json):
+		return moerr.NewNotSupported(ctx, fmt.Sprintf("JSON column '%s' cannot be in index", colName))
+	case int32(types.T_array_float32), int32(types.T_array_float64):
+		if indexKind == "ivfflat" || indexKind == "hnsw" {
+			return nil
+		}
+		return moerr.NewNotSupported(ctx, fmt.Sprintf("VECTOR column '%s' cannot be in index", colName))
+	}
+
+	if isEnumPlanType(&col.Typ) && indexKind == "primary" {
+		return moerr.NewNotSupported(ctx, fmt.Sprintf("ENUM column '%s' cannot be in primary key", colName))
+	}
+	if isSetPlanType(&col.Typ) {
+		switch indexKind {
+		case "primary":
+			return moerr.NewNotSupported(ctx, fmt.Sprintf("SET column '%s' cannot be in primary key", colName))
+		case "unique":
+			return moerr.NewNotSupported(ctx, fmt.Sprintf("SET column '%s' cannot be in unique index", colName))
+		}
+	}
+	if isGeometryPlanType(&col.Typ) && indexKind != "rtree" {
+		switch indexKind {
+		case "primary":
+			return moerr.NewNotSupported(ctx, fmt.Sprintf("GEOMETRY column '%s' cannot be in primary key", colName))
+		case "unique":
+			return moerr.NewNotSupported(ctx, fmt.Sprintf("GEOMETRY column '%s' cannot be in unique index", colName))
+		default:
+			return moerr.NewNotSupported(ctx, fmt.Sprintf("GEOMETRY column '%s' cannot be in index", colName))
 		}
 	}
 	return nil

--- a/pkg/sql/plan/build_index_util_test.go
+++ b/pkg/sql/plan/build_index_util_test.go
@@ -1,0 +1,184 @@
+// Copyright 2023 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/stretchr/testify/require"
+)
+
+func keyPartWithLength(colName string, length int) *tree.KeyPart {
+	return &tree.KeyPart{
+		ColName: tree.NewUnresolvedColName(colName),
+		Length:  length,
+	}
+}
+
+func TestIndexTableKeyTypeForPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeId   types.T
+		wantOk   bool
+		wantId   types.T
+		wantWide int32
+	}{
+		{name: "text", typeId: types.T_text, wantOk: true, wantId: types.T_varchar, wantWide: types.MaxVarcharLen},
+		{name: "blob", typeId: types.T_blob, wantOk: true, wantId: types.T_varbinary, wantWide: types.MaxVarBinaryLen},
+		{name: "varchar not prefixable", typeId: types.T_varchar, wantOk: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := indexTableKeyTypeForPrefix(Type{Id: int32(tt.typeId)})
+			require.Equal(t, tt.wantOk, ok)
+			if tt.wantOk {
+				require.Equal(t, int32(tt.wantId), got.Id)
+				require.Equal(t, tt.wantWide, got.Width)
+			}
+		})
+	}
+}
+
+func TestIndexTableKeyTypeForSinglePart(t *testing.T) {
+	t.Run("nil column returns empty type", func(t *testing.T) {
+		require.Equal(t, Type{}, indexTableKeyTypeForSinglePart(nil, keyPartWithLength("t", 10)))
+	})
+
+	t.Run("text prefix maps to varchar", func(t *testing.T) {
+		col := &ColDef{Typ: Type{Id: int32(types.T_text), Width: int32(types.MaxVarcharLen)}}
+		got := indexTableKeyTypeForSinglePart(col, keyPartWithLength("t", 10))
+		require.Equal(t, int32(types.T_varchar), got.Id)
+		require.Equal(t, int32(types.MaxVarcharLen), got.Width)
+	})
+
+	t.Run("blob prefix maps to varbinary", func(t *testing.T) {
+		col := &ColDef{Typ: Type{Id: int32(types.T_blob), Width: int32(types.MaxVarBinaryLen)}}
+		got := indexTableKeyTypeForSinglePart(col, keyPartWithLength("b", 10))
+		require.Equal(t, int32(types.T_varbinary), got.Id)
+		require.Equal(t, int32(types.MaxVarBinaryLen), got.Width)
+	})
+
+	t.Run("non prefixable column keeps original type even with length", func(t *testing.T) {
+		col := &ColDef{Typ: Type{Id: int32(types.T_varchar), Width: 50, Scale: 0}}
+		got := indexTableKeyTypeForSinglePart(col, keyPartWithLength("v", 10))
+		require.Equal(t, int32(types.T_varchar), got.Id)
+		require.Equal(t, int32(50), got.Width)
+	})
+
+	t.Run("no length keeps original type", func(t *testing.T) {
+		col := &ColDef{Typ: Type{Id: int32(types.T_text), Width: 100, Scale: 2}}
+		got := indexTableKeyTypeForSinglePart(col, keyPartWithLength("t", 0))
+		require.Equal(t, int32(types.T_text), got.Id)
+		require.Equal(t, int32(100), got.Width)
+		require.Equal(t, int32(2), got.Scale)
+	})
+
+	t.Run("nil key part keeps original type", func(t *testing.T) {
+		col := &ColDef{Typ: Type{Id: int32(types.T_text), Width: 100}}
+		got := indexTableKeyTypeForSinglePart(col, nil)
+		require.Equal(t, int32(types.T_text), got.Id)
+		require.Equal(t, int32(100), got.Width)
+	})
+}
+
+func TestIndexColumnCheckKind(t *testing.T) {
+	tests := []struct {
+		indexType tree.IndexType
+		want      string
+	}{
+		{tree.INDEX_TYPE_IVFFLAT, "ivfflat"},
+		{tree.INDEX_TYPE_HNSW, "hnsw"},
+		{tree.INDEX_TYPE_RTREE, "rtree"},
+		{tree.INDEX_TYPE_BTREE, "secondary"},
+		{tree.INDEX_TYPE_INVALID, "secondary"},
+	}
+
+	for _, tt := range tests {
+		require.Equal(t, tt.want, indexColumnCheckKind(tt.indexType))
+	}
+}
+
+func TestCheckIndexColumnSupportability(t *testing.T) {
+	ctx := context.Background()
+
+	colOf := func(typeId types.T, enumValues ...string) *ColDef {
+		typ := plan.Type{Id: int32(typeId)}
+		if len(enumValues) > 0 {
+			typ.Enumvalues = strings.Join(enumValues, ",")
+		}
+		return &ColDef{Name: "c", Typ: typ}
+	}
+	keyPart := keyPartWithLength("c", 0)
+	prefixKeyPart := keyPartWithLength("c", 10)
+
+	t.Run("nil inputs", func(t *testing.T) {
+		require.Error(t, checkIndexColumnSupportability(ctx, nil, keyPart, "secondary"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_int64), nil, "secondary"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_int64), &tree.KeyPart{}, "secondary"))
+	})
+
+	t.Run("blob requires prefix in non-primary index", func(t *testing.T) {
+		require.NoError(t, checkIndexColumnSupportability(ctx, colOf(types.T_blob), prefixKeyPart, "secondary"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_blob), keyPart, "secondary"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_blob), prefixKeyPart, "primary"))
+	})
+
+	t.Run("text requires prefix in non-primary index", func(t *testing.T) {
+		require.NoError(t, checkIndexColumnSupportability(ctx, colOf(types.T_text), prefixKeyPart, "unique"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_text), keyPart, "secondary"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_text), prefixKeyPart, "primary"))
+	})
+
+	t.Run("datalink and json never allowed", func(t *testing.T) {
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_datalink), keyPart, "secondary"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_json), keyPart, "secondary"))
+	})
+
+	t.Run("vector only allowed for ivfflat and hnsw", func(t *testing.T) {
+		require.NoError(t, checkIndexColumnSupportability(ctx, colOf(types.T_array_float32), keyPart, "ivfflat"))
+		require.NoError(t, checkIndexColumnSupportability(ctx, colOf(types.T_array_float64), keyPart, "hnsw"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_array_float32), keyPart, "secondary"))
+	})
+
+	t.Run("enum rejected only in primary key", func(t *testing.T) {
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_enum, "a", "b"), keyPart, "primary"))
+		require.NoError(t, checkIndexColumnSupportability(ctx, colOf(types.T_enum, "a", "b"), keyPart, "secondary"))
+		require.NoError(t, checkIndexColumnSupportability(ctx, colOf(types.T_enum, "a", "b"), keyPart, "unique"))
+	})
+
+	t.Run("set rejected in primary and unique", func(t *testing.T) {
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_uint64, "a", "b"), keyPart, "primary"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_uint64, "a", "b"), keyPart, "unique"))
+		require.NoError(t, checkIndexColumnSupportability(ctx, colOf(types.T_uint64, "a", "b"), keyPart, "secondary"))
+	})
+
+	t.Run("geometry only allowed for rtree", func(t *testing.T) {
+		require.NoError(t, checkIndexColumnSupportability(ctx, colOf(types.T_geometry), keyPart, "rtree"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_geometry), keyPart, "primary"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_geometry), keyPart, "unique"))
+		require.Error(t, checkIndexColumnSupportability(ctx, colOf(types.T_geometry), keyPart, "secondary"))
+	})
+
+	t.Run("ordinary column allowed", func(t *testing.T) {
+		require.NoError(t, checkIndexColumnSupportability(ctx, colOf(types.T_int64), keyPart, "primary"))
+		require.NoError(t, checkIndexColumnSupportability(ctx, colOf(types.T_varchar), keyPart, "secondary"))
+	})
+}

--- a/pkg/sql/plan/build_show_util.go
+++ b/pkg/sql/plan/build_show_util.go
@@ -272,6 +272,10 @@ func ConstructCreateTableSQL(
 				if !catalog.IsNullIndexAlgo(indexdef.IndexAlgo) {
 					rewriteIndexStr += fmt.Sprintf("USING %s ", indexdef.IndexAlgo)
 				}
+				prefixLengths, err := catalog.IndexPrefixLengthsFromParamsWithError(indexdef.IndexAlgoParams)
+				if err != nil {
+					return "", nil, err
+				}
 				indexStr += "("
 				rewriteIndexStr += "("
 				i := 0
@@ -284,9 +288,14 @@ func ConstructCreateTableSQL(
 						rewriteIndexStr += ","
 					}
 
-					part = colNameToOriginName[part]
-					indexStr += fmt.Sprintf("`%s`", formatStr(part))
-					rewriteIndexStr += fmt.Sprintf("`%s`", formatStr(part))
+					originPart := colNameToOriginName[part]
+					indexStr += fmt.Sprintf("`%s`", formatStr(originPart))
+					rewriteIndexStr += fmt.Sprintf("`%s`", formatStr(originPart))
+					if length, ok := prefixLengths[part]; ok {
+						prefixLength := fmt.Sprintf("(%d)", length)
+						indexStr += prefixLength
+						rewriteIndexStr += prefixLength
+					}
 					i++
 				}
 

--- a/pkg/sql/plan/build_show_util_test.go
+++ b/pkg/sql/plan/build_show_util_test.go
@@ -181,6 +181,27 @@ func Test_buildShowCreateTableSpatialIndex(t *testing.T) {
 	require.Equal(t, "CREATE TABLE `spatial_src` (\n  `id` int NOT NULL,\n  `g` point NOT NULL,\n  PRIMARY KEY (`id`),\n  SPATIAL KEY `idx_g` (`g`)\n)", got)
 }
 
+func TestShowCreateTablePreservesIndexPrefixLengths(t *testing.T) {
+	mock := NewMockOptimizer(false)
+	tableDef, err := buildTestCreateTableStmt(mock, `CREATE TABLE prefix_show_src (
+		id INT PRIMARY KEY,
+		name VARCHAR(191),
+		t TEXT,
+		b BLOB,
+		KEY idx_t(t(100)),
+		UNIQUE KEY uq_b(b(20)),
+		KEY idx_mix(name, t(30))
+	)`)
+	require.NoError(t, err)
+
+	var snapshot *plan.Snapshot
+	got, _, err := ConstructCreateTableSQL(&mock.ctxt, tableDef, snapshot, false, nil)
+	require.NoError(t, err)
+	require.Contains(t, got, "KEY `idx_t` (`t`(100))")
+	require.Contains(t, got, "UNIQUE KEY `uq_b` (`b`(20))")
+	require.Contains(t, got, "KEY `idx_mix` (`name`,`t`(30))")
+}
+
 func Test_ShowCreateTableUsesStoredDDLForChecks(t *testing.T) {
 	const sql = `CREATE TABLE t_numeric_types (
 		id BIGINT NOT NULL AUTO_INCREMENT,

--- a/test/distributed/cases/ddl/create_index.result
+++ b/test/distributed/cases/ddl/create_index.result
@@ -109,17 +109,50 @@ show create table t11;
 Table    Create Table
 t11    CREATE TABLE `t11` (\n  `a` int DEFAULT NULL,\n  `b` int DEFAULT NULL,\n  UNIQUE KEY `a` (`a`) COMMENT 'a',\n  UNIQUE KEY `x` (`a`) COMMENT 'x',\n  KEY `xx` (`a`) COMMENT 'xx'\n)
 drop table t11;
-create table t12(a text);
+create table t12(a text, b int);
 create unique index x on t12(a);
 not supported: TEXT column 'a' cannot be in index
 create index x2 on t12(a);
 not supported: TEXT column 'a' cannot be in index
+create index x3 on t12(a(100));
+create unique index x4 on t12(a(100));
+show create table t12;
+Table    Create Table
+t12    CREATE TABLE `t12` (\n  `a` text DEFAULT NULL,\n  `b` int DEFAULT NULL,\n  KEY `x3` (`a`(100)),\n  UNIQUE KEY `x4` (`a`(100))\n)
+insert into t12 values ('alpha',1),('beta',2);
+select * from t12 where a = 'alpha';
+a    b
+alpha    1
+update t12 set b = 3 where a = 'alpha';
+select * from t12 where a = 'alpha';
+a    b
+alpha    3
+delete from t12 where b = 2;
+select count(*) from t12 where a = 'beta';
+count(*)
+0
 drop table t12;
-create table t13(a blob);
+create table t13(a blob, b int);
 create unique index x on t13(a);
 not supported: BLOB column 'a' cannot be in index
 create index x2 on t13(a);
 not supported: BLOB column 'a' cannot be in index
+create index x3 on t13(a(100));
+show create table t13;
+Table    Create Table
+t13    CREATE TABLE `t13` (\n  `a` blob DEFAULT NULL,\n  `b` int DEFAULT NULL,\n  KEY `x3` (`a`(100))\n)
+insert into t13 values ('alpha',1),('beta',2);
+select * from t13 where a = 'alpha';
+a    b
+alpha    1
+update t13 set b = 3 where a = 'alpha';
+select * from t13 where a = 'alpha';
+a    b
+alpha    3
+delete from t13 where b = 2;
+select count(*) from t13 where a = 'beta';
+count(*)
+0
 drop table t13;
 create table t14(a json);
 create unique index x on t14(a);

--- a/test/distributed/cases/ddl/create_index.sql
+++ b/test/distributed/cases/ddl/create_index.sql
@@ -82,14 +82,31 @@ create index xx ON t11(a) comment 'xx';
 show create table t11;
 drop table t11;
 
-create table t12(a text);
+create table t12(a text, b int);
 create unique index x on t12(a);
 create index x2 on t12(a);
+create index x3 on t12(a(100));
+create unique index x4 on t12(a(100));
+show create table t12;
+insert into t12 values ('alpha',1),('beta',2);
+select * from t12 where a = 'alpha';
+update t12 set b = 3 where a = 'alpha';
+select * from t12 where a = 'alpha';
+delete from t12 where b = 2;
+select count(*) from t12 where a = 'beta';
 drop table t12;
 
-create table t13(a blob);
+create table t13(a blob, b int);
 create unique index x on t13(a);
 create index x2 on t13(a);
+create index x3 on t13(a(100));
+show create table t13;
+insert into t13 values ('alpha',1),('beta',2);
+select * from t13 where a = 'alpha';
+update t13 set b = 3 where a = 'alpha';
+select * from t13 where a = 'alpha';
+delete from t13 where b = 2;
+select count(*) from t13 where a = 'beta';
 drop table t13;
 
 create table t14(a json);

--- a/test/distributed/cases/ddl/prefix_index_dml.result
+++ b/test/distributed/cases/ddl/prefix_index_dml.result
@@ -1,0 +1,52 @@
+drop table if exists prefix_idx_dml_sk;
+create table prefix_idx_dml_sk(id int primary key, a varchar(32), b int, index idx_a(a(4)));
+insert into prefix_idx_dml_sk values (1, 'abcdef-long', 10);
+update prefix_idx_dml_sk set a = 'uvwxyz-long' where id = 1;
+select id, a, b from prefix_idx_dml_sk where a = 'uvwxyz-long';
+➤ id[4,32,0]  ¦  a[12,-1,0]  ¦  b[4,32,0]  𝄀
+1  ¦  uvwxyz-long  ¦  10
+delete from prefix_idx_dml_sk where id = 1;
+select count(*) from prefix_idx_dml_sk where a = 'uvwxyz-long';
+➤ count(*)[-5,64,0]  𝄀
+0
+drop table prefix_idx_dml_sk;
+drop table if exists prefix_idx_dml_uk;
+create table prefix_idx_dml_uk(id int primary key, a varchar(32), b int, unique index uq_a(a(4)));
+insert into prefix_idx_dml_uk values (1, 'abcdef-long', 10);
+insert into prefix_idx_dml_uk values (2, 'abcdzz-conflict', 20);
+Duplicate entry 'abcd' for key '(a|__mo_index_idx_col)'
+update prefix_idx_dml_uk set a = 'uvwxyz-long' where id = 1;
+insert into prefix_idx_dml_uk values (2, 'abcdef-new', 20);
+delete from prefix_idx_dml_uk where id = 1;
+insert into prefix_idx_dml_uk values (3, 'uvwxyz-new', 30);
+select id, a, b from prefix_idx_dml_uk order by id;
+➤ id[4,32,0]  ¦  a[12,-1,0]  ¦  b[4,32,0]  𝄀
+2  ¦  abcdef-new  ¦  20  𝄀
+3  ¦  uvwxyz-new  ¦  30
+drop table prefix_idx_dml_uk;
+drop table if exists prefix_idx_dml_create_backfill;
+create table prefix_idx_dml_create_backfill(id int primary key, a varchar(32), b int);
+insert into prefix_idx_dml_create_backfill values (1, 'abcdef-long', 10), (2, 'lmnopq-long', 20);
+create index idx_a on prefix_idx_dml_create_backfill(a(4));
+update prefix_idx_dml_create_backfill set a = 'uvwxyz-long' where id = 1;
+select id, a, b from prefix_idx_dml_create_backfill where a = 'uvwxyz-long';
+➤ id[4,32,0]  ¦  a[12,-1,0]  ¦  b[4,32,0]  𝄀
+1  ¦  uvwxyz-long  ¦  10
+delete from prefix_idx_dml_create_backfill where id = 2;
+select count(*) from prefix_idx_dml_create_backfill where a = 'lmnopq-long';
+➤ count(*)[-5,64,0]  𝄀
+0
+drop table prefix_idx_dml_create_backfill;
+drop table if exists prefix_idx_dml_alter_add;
+create table prefix_idx_dml_alter_add(id int primary key, a varchar(32), b int);
+insert into prefix_idx_dml_alter_add values (1, 'abcdef-long', 10), (2, 'lmnopq-long', 20);
+alter table prefix_idx_dml_alter_add add index idx_a(a(4));
+update prefix_idx_dml_alter_add set a = 'uvwxyz-long' where id = 1;
+select id, a, b from prefix_idx_dml_alter_add where a = 'uvwxyz-long';
+➤ id[4,32,0]  ¦  a[12,-1,0]  ¦  b[4,32,0]  𝄀
+1  ¦  uvwxyz-long  ¦  10
+delete from prefix_idx_dml_alter_add where id = 2;
+select count(*) from prefix_idx_dml_alter_add where a = 'lmnopq-long';
+➤ count(*)[-5,64,0]  𝄀
+0
+drop table prefix_idx_dml_alter_add;

--- a/test/distributed/cases/ddl/prefix_index_dml.sql
+++ b/test/distributed/cases/ddl/prefix_index_dml.sql
@@ -1,0 +1,40 @@
+drop table if exists prefix_idx_dml_sk;
+create table prefix_idx_dml_sk(id int primary key, a varchar(32), b int, index idx_a(a(4)));
+insert into prefix_idx_dml_sk values (1, 'abcdef-long', 10);
+update prefix_idx_dml_sk set a = 'uvwxyz-long' where id = 1;
+select id, a, b from prefix_idx_dml_sk where a = 'uvwxyz-long';
+delete from prefix_idx_dml_sk where id = 1;
+select count(*) from prefix_idx_dml_sk where a = 'uvwxyz-long';
+drop table prefix_idx_dml_sk;
+
+drop table if exists prefix_idx_dml_uk;
+create table prefix_idx_dml_uk(id int primary key, a varchar(32), b int, unique index uq_a(a(4)));
+insert into prefix_idx_dml_uk values (1, 'abcdef-long', 10);
+-- @pattern
+insert into prefix_idx_dml_uk values (2, 'abcdzz-conflict', 20);
+update prefix_idx_dml_uk set a = 'uvwxyz-long' where id = 1;
+insert into prefix_idx_dml_uk values (2, 'abcdef-new', 20);
+delete from prefix_idx_dml_uk where id = 1;
+insert into prefix_idx_dml_uk values (3, 'uvwxyz-new', 30);
+select id, a, b from prefix_idx_dml_uk order by id;
+drop table prefix_idx_dml_uk;
+
+drop table if exists prefix_idx_dml_create_backfill;
+create table prefix_idx_dml_create_backfill(id int primary key, a varchar(32), b int);
+insert into prefix_idx_dml_create_backfill values (1, 'abcdef-long', 10), (2, 'lmnopq-long', 20);
+create index idx_a on prefix_idx_dml_create_backfill(a(4));
+update prefix_idx_dml_create_backfill set a = 'uvwxyz-long' where id = 1;
+select id, a, b from prefix_idx_dml_create_backfill where a = 'uvwxyz-long';
+delete from prefix_idx_dml_create_backfill where id = 2;
+select count(*) from prefix_idx_dml_create_backfill where a = 'lmnopq-long';
+drop table prefix_idx_dml_create_backfill;
+
+drop table if exists prefix_idx_dml_alter_add;
+create table prefix_idx_dml_alter_add(id int primary key, a varchar(32), b int);
+insert into prefix_idx_dml_alter_add values (1, 'abcdef-long', 10), (2, 'lmnopq-long', 20);
+alter table prefix_idx_dml_alter_add add index idx_a(a(4));
+update prefix_idx_dml_alter_add set a = 'uvwxyz-long' where id = 1;
+select id, a, b from prefix_idx_dml_alter_add where a = 'uvwxyz-long';
+delete from prefix_idx_dml_alter_add where id = 2;
+select count(*) from prefix_idx_dml_alter_add where a = 'lmnopq-long';
+drop table prefix_idx_dml_alter_add;

--- a/test/distributed/cases/dtype/enum.result
+++ b/test/distributed/cases/dtype/enum.result
@@ -226,6 +226,40 @@ table_name    column_name    data_type    is_nullable
 pri04    col1    INT    YES
 pri04    col2    ENUM    YES
 drop table pri04;
+drop table if exists enum_idx01;
+create table enum_idx01 (id varchar(191) primary key, role enum('a','b','c'), index idx_role(role));
+show create table enum_idx01;
+Table    Create Table
+enum_idx01    CREATE TABLE `enum_idx01` (\n  `id` varchar(191) NOT NULL,\n  `role` enum('a','b','c') DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_role` (`role`)\n)
+drop table enum_idx01;
+drop table if exists enum_idx02;
+create table enum_idx02 (id varchar(191) primary key, role enum('a','b','c'), unique index uq_role(role));
+show create table enum_idx02;
+Table    Create Table
+enum_idx02    CREATE TABLE `enum_idx02` (\n  `id` varchar(191) NOT NULL,\n  `role` enum('a','b','c') DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `uq_role` (`role`)\n)
+drop table enum_idx02;
+drop table if exists enum_idx03;
+create table enum_idx03 (id varchar(191) primary key, name varchar(191), role enum('a','b','c'), index idx_name_role(name, role));
+show create table enum_idx03;
+Table    Create Table
+enum_idx03    CREATE TABLE `enum_idx03` (\n  `id` varchar(191) NOT NULL,\n  `name` varchar(191) DEFAULT NULL,\n  `role` enum('a','b','c') DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_name_role` (`name`,`role`)\n)
+drop table enum_idx03;
+drop table if exists enum_idx04;
+create table enum_idx04 (id varchar(191) primary key, name varchar(191), role enum('a','b','c'), unique index uq_role_name(role, name));
+show create table enum_idx04;
+Table    Create Table
+enum_idx04    CREATE TABLE `enum_idx04` (\n  `id` varchar(191) NOT NULL,\n  `name` varchar(191) DEFAULT NULL,\n  `role` enum('a','b','c') DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `uq_role_name` (`role`,`name`)\n)
+insert into enum_idx04 values ('1','alice','a'),('2','bob','b'),('3','carol','c');
+select * from enum_idx04 where role = 'b';
+id    name    role
+2    bob    b
+update enum_idx04 set role = 'c' where id = '2';
+delete from enum_idx04 where role = 'a';
+select * from enum_idx04 order by id;
+id    name    role
+2    bob    c
+3    carol    c
+drop table enum_idx04;
 drop table if exists inert01;
 create table insert01 (id int primary key,
 order_number VARCHAR(20),
@@ -506,13 +540,10 @@ create table agg01 (col1 int, col2 enum('egwjqebwq', 'qwewqewqeqewq', 'weueiwqeo
 not supported: ENUM column 'col2' cannot be in primary key
 drop table if exists agg01;
 create table agg01 (col1 int, col2 enum('egwjqebwq', 'qwewqewqeqewq', 'weueiwqeowqehwgqjhenw') unique);
-not supported: ENUM column 'col2' cannot be in unique index
 drop table if exists agg01;
 create table agg01 (col1 int, col2 enum('egwjqebwq', 'qwewqewqeqewq', 'weueiwqeowqehwgqjhenw'), unique key (col2));
-not supported: ENUM column 'col2' cannot be in unique index
 drop table if exists agg01;
 create table agg01 (col1 int, col2 enum('egwjqebwq', 'qwewqewqeqewq', 'weueiwqeowqehwgqjhenw'), key (col2));
-not supported: ENUM column 'col2' cannot be in secondary index
 drop table if exists agg01;
 drop table if exists test_enum_order;
 create table test_enum_order (id int, val enum('low', 'medium', 'high', 'critical'));

--- a/test/distributed/cases/dtype/enum.sql
+++ b/test/distributed/cases/dtype/enum.sql
@@ -155,6 +155,30 @@ select * from pri04 where col2 = 'database';
 select table_name, COLUMN_NAME, data_type, is_nullable from information_schema.columns where table_name like 'pri04' and COLUMN_NAME not like '__mo%';
 drop table pri04;
 
+drop table if exists enum_idx01;
+create table enum_idx01 (id varchar(191) primary key, role enum('a','b','c'), index idx_role(role));
+show create table enum_idx01;
+drop table enum_idx01;
+
+drop table if exists enum_idx02;
+create table enum_idx02 (id varchar(191) primary key, role enum('a','b','c'), unique index uq_role(role));
+show create table enum_idx02;
+drop table enum_idx02;
+
+drop table if exists enum_idx03;
+create table enum_idx03 (id varchar(191) primary key, name varchar(191), role enum('a','b','c'), index idx_name_role(name, role));
+show create table enum_idx03;
+drop table enum_idx03;
+
+drop table if exists enum_idx04;
+create table enum_idx04 (id varchar(191) primary key, name varchar(191), role enum('a','b','c'), unique index uq_role_name(role, name));
+show create table enum_idx04;
+insert into enum_idx04 values ('1','alice','a'),('2','bob','b'),('3','carol','c');
+select * from enum_idx04 where role = 'b';
+update enum_idx04 set role = 'c' where id = '2';
+delete from enum_idx04 where role = 'a';
+select * from enum_idx04 order by id;
+drop table enum_idx04;
 
 -- insert into table,  either use a number to represent a number or insert a specific value
 -- query, update, or delete data, can also use numeric numbers or specific values


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24740
Fixes #24729

## What this PR does / why we need it:

- Allows ENUM columns in secondary, unique, and composite indexes while keeping ENUM primary keys rejected.
- Allows TEXT/BLOB prefix indexes and keeps plain TEXT/BLOB indexes rejected.
- Persists index prefix lengths in index metadata and applies prefix expressions during index backfill, insert, unique dedup, and lock-key generation.
- Adds focused unit coverage and BVT cases for ENUM indexes and TEXT/BLOB prefix indexes.

Validation:

- `go test ./pkg/sql/plan -run 'TestBuildIndexAllowsEnumAndTextBlobPrefix|TestBuildIndexRejectsTextBlobPlainIndex' -count=1`
- `go test ./pkg/sql/compile -run 'TestGenInsertIndexTableSql_UsesPrefixExpression|TestBuildCreateUniqueIndexDuplicateCheckSQL' -count=1`
- `go test ./pkg/sql/colexec/preinsertunique ./pkg/sql/colexec/preinsertsecondaryindex -count=1`
- `./run.sh -p /Users/LoveYY/Develop/matrixorigin/matrixone/.worktrees/issue-24740/test/distributed/cases/ddl/create_index.sql -g -n`
- `./run.sh -p /Users/LoveYY/Develop/matrixorigin/matrixone/.worktrees/issue-24740/test/distributed/cases/dtype/enum.sql -g -n`
- `git diff --check`
- `make`
- `make static-check`

