### PR TITLE
fix: prioritize stalled checkpoint bounded flush (#24933)

### DIFF
--- a/pkg/vm/engine/tae/db/checkpoint/flusher.go
+++ b/pkg/vm/engine/tae/db/checkpoint/flusher.go
@@ -42,6 +42,10 @@ import (
 
 var ErrFlusherStopped = moerr.NewInternalErrorNoCtx("flusher stopped")
 
+const (
+	stalledCheckpointFlushAge = checkpointIntentOldAge
+)
+
 type FlushCfg struct {
 	ForceFlushTimeout       time.Duration
 	ForceFlushCheckInterval time.Duration
@@ -76,9 +80,33 @@ type Flusher interface {
 
 var _ Flusher = (*flusher)(nil)
 
+type flushRequestMode uint8
+
+const (
+	flushRequestCron flushRequestMode = iota
+	flushRequestCheckpointBounded
+	flushRequestForce
+)
+
+type flushScheduleMode uint8
+
+const (
+	flushScheduleCron flushScheduleMode = iota
+	flushScheduleCheckpointBounded
+	flushScheduleForce
+)
+
+func (mode flushScheduleMode) bypassFlushReady() bool {
+	return mode == flushScheduleCheckpointBounded || mode == flushScheduleForce
+}
+
+func (mode flushScheduleMode) resetFlushDeadline() bool {
+	return mode != flushScheduleCheckpointBounded
+}
+
 type FlushRequest struct {
-	force bool
-	tree  *logtail.DirtyTreeEntry
+	mode flushRequestMode
+	tree *logtail.DirtyTreeEntry
 }
 
 type FlusherOption func(*flushImpl)
@@ -303,6 +331,8 @@ type flushImpl struct {
 
 	objMemSizeList []tableAndSize
 
+	stalledCheckpointPickBounded bool
+
 	// Log throttling for collectTableMemUsage
 	logThrottleMu   sync.Mutex
 	lastLogTime     time.Time
@@ -385,34 +415,93 @@ func (flusher *flushImpl) triggerJob(ctx context.Context) {
 		return
 	}
 	flusher.sourcer.Run(flusher.flushLag)
-	entry := flusher.sourcer.GetAndRefreshMerged()
-	if !entry.IsEmpty() {
-		request := new(FlushRequest)
-		request.tree = entry
-		flusher.flushRequestQ.Enqueue(request)
+	var entry *logtail.DirtyTreeEntry
+	mode := flushRequestCron
+	intent := flusher.checkpointSchduler.PendingIncrementalCheckpoint()
+	if bounded := flusher.pickStalledCheckpointFlushEntry(intent); bounded {
+		entry = flusher.makeStalledCheckpointFlushEntry()
+		if entry == nil {
+			entry = flusher.sourcer.GetAndRefreshMerged()
+		} else {
+			mode = flushRequestCheckpointBounded
+		}
+	} else {
+		entry = flusher.sourcer.GetAndRefreshMerged()
 	}
+	flusher.enqueueFlush(entry, mode)
 	_, ts := entry.GetTimeRange()
 	flusher.checkpointSchduler.TryScheduleCheckpoint(ts, false)
 }
 
+func (flusher *flushImpl) pickStalledCheckpointFlushEntry(intent *CheckpointEntry) bool {
+	if !shouldScheduleStalledCheckpointFlush(intent, stalledCheckpointFlushAge) {
+		flusher.stalledCheckpointPickBounded = false
+		return false
+	}
+	flusher.stalledCheckpointPickBounded = !flusher.stalledCheckpointPickBounded
+	return flusher.stalledCheckpointPickBounded
+}
+
+func (flusher *flushImpl) enqueueCronFlush(entry *logtail.DirtyTreeEntry) {
+	flusher.enqueueFlush(entry, flushRequestCron)
+}
+
+func (flusher *flushImpl) enqueueFlush(entry *logtail.DirtyTreeEntry, mode flushRequestMode) {
+	if entry == nil || entry.IsEmpty() {
+		return
+	}
+	request := &FlushRequest{
+		mode: mode,
+		tree: entry,
+	}
+	flusher.flushRequestQ.Enqueue(request)
+}
+
 func (flusher *flushImpl) onFlushRequest(items ...any) {
-	fromCrons := logtail.NewEmptyDirtyTreeEntry()
-	fromForce := logtail.NewEmptyDirtyTreeEntry()
+	fromCrons, fromForce, fromCheckpointBounded := mergeFlushRequests(items...)
+	flusher.scheduleFlush(fromForce, flushScheduleForce)
+	for _, entry := range fromCheckpointBounded {
+		flusher.scheduleFlush(entry, flushScheduleCheckpointBounded)
+	}
+	flusher.scheduleFlush(fromCrons, flushScheduleCron)
+}
+
+func mergeFlushRequests(items ...any) (
+	fromCrons *logtail.DirtyTreeEntry,
+	fromForce *logtail.DirtyTreeEntry,
+	fromCheckpointBounded []*logtail.DirtyTreeEntry,
+) {
+	mergeEntry := func(merged, entry *logtail.DirtyTreeEntry) *logtail.DirtyTreeEntry {
+		if merged == nil {
+			start, end := entry.GetTimeRange()
+			merged = logtail.NewDirtyTreeEntry(start, end, model.NewTree())
+		}
+		merged.Merge(entry)
+		return merged
+	}
 	for _, item := range items {
 		e := item.(*FlushRequest)
-		if e.force {
-			fromForce.Merge(e.tree)
-		} else {
-			fromCrons.Merge(e.tree)
+		switch e.mode {
+		case flushRequestForce:
+			fromForce = mergeEntry(fromForce, e.tree)
+		case flushRequestCheckpointBounded:
+			fromCheckpointBounded = append(fromCheckpointBounded, e.tree)
+		default:
+			fromCrons = mergeEntry(fromCrons, e.tree)
 		}
 	}
-	flusher.scheduleFlush(fromForce, true)
-	flusher.scheduleFlush(fromCrons, false)
+	if fromCrons == nil {
+		fromCrons = logtail.NewEmptyDirtyTreeEntry()
+	}
+	if fromForce == nil {
+		fromForce = logtail.NewEmptyDirtyTreeEntry()
+	}
+	return
 }
 
 func (flusher *flushImpl) scheduleFlush(
 	entry *logtail.DirtyTreeEntry,
-	force bool,
+	mode flushScheduleMode,
 ) {
 	if _, injected := objectio.PrintFlushEntryInjected(); injected {
 		logutil.Infof("scheduleFlush: %v", entry.String())
@@ -429,7 +518,45 @@ func (flusher *flushImpl) scheduleFlush(
 		}
 	}
 	pressure := flusher.collectTableMemUsage(entry, lastCkp)
-	flusher.checkFlushConditionAndFire(entry, force, pressure, lastCkp)
+	flusher.checkFlushConditionAndFire(entry, mode, pressure, lastCkp)
+}
+
+func (flusher *flushImpl) makeStalledCheckpointFlushEntry() *logtail.DirtyTreeEntry {
+	if flusher.sourcer == nil || flusher.checkpointSchduler == nil {
+		return nil
+	}
+	intent := flusher.checkpointSchduler.PendingIncrementalCheckpoint()
+	return makeStalledCheckpointFlushEntry(flusher.sourcer, intent, stalledCheckpointFlushAge)
+}
+
+func makeStalledCheckpointFlushEntry(
+	sourcer logtail.Collector,
+	intent *CheckpointEntry,
+	threshold time.Duration,
+) *logtail.DirtyTreeEntry {
+	if sourcer == nil || !shouldScheduleStalledCheckpointFlush(intent, threshold) {
+		return nil
+	}
+	start, end := intent.GetStart(), intent.GetEnd()
+	entry := sourcer.ScanInRangePruned(start, end)
+	if entry.IsEmpty() {
+		return nil
+	}
+	logutil.Info(
+		"flusher.ckp.bounded",
+		zap.String("start", start.ToString()),
+		zap.String("end", end.ToString()),
+		zap.Duration("age", intent.Age()),
+		zap.Int("tables", entry.GetTree().TableCount()),
+	)
+	return entry
+}
+
+func shouldScheduleStalledCheckpointFlush(intent *CheckpointEntry, threshold time.Duration) bool {
+	if intent == nil || !intent.IsPendding() || intent.IsFlushChecked() {
+		return false
+	}
+	return intent.Age() > threshold
 }
 
 func foreachAobjBefore(_ context.Context,
@@ -663,20 +790,24 @@ nextChunk:
 }
 
 func (flusher *flushImpl) checkFlushConditionAndFire(
-	entry *logtail.DirtyTreeEntry, force bool, pressure float64, lastCkp types.TS,
+	entry *logtail.DirtyTreeEntry, mode flushScheduleMode, pressure float64, lastCkp types.TS,
 ) {
 	count := 0
 	_, end := entry.GetTimeRange()
 	for _, ticket := range flusher.objMemSizeList {
 		table, asize, dsize := ticket.tbl, ticket.asize, ticket.dsize
 
-		if force {
+		if mode.bypassFlushReady() {
+			logName := "flusher.force"
+			if mode == flushScheduleCheckpointBounded {
+				logName = "flusher.ckp.bounded.flush"
+			}
 			logutil.Info(
-				"flusher.force",
+				logName,
 				zap.Uint64("id", table.ID),
 				zap.String("name", table.GetLastestSchemaLocked(false).Name),
 			)
-			if err := flusher.fireFlushTabletail(table, end, lastCkp); err == nil {
+			if err := flusher.fireFlushTabletail(table, end, lastCkp); err == nil && mode.resetFlushDeadline() {
 				table.Stats.ResetDeadline(flusher.flushInterval)
 			}
 			continue
@@ -756,9 +887,10 @@ func (flusher *flushImpl) ForceFlushWithInterval(
 			return nil
 		}
 		entry := logtail.NewDirtyTreeEntry(types.TS{}, ts, tree.GetTree())
-		request := new(FlushRequest)
-		request.tree = entry
-		request.force = true
+		request := &FlushRequest{
+			mode: flushRequestForce,
+			tree: entry,
+		}
 		// logutil.Infof("try flush %v",tree.String())
 		return request
 	}
@@ -820,9 +952,10 @@ func (flusher *flushImpl) FlushTable(
 		nTree := model.NewTree()
 		nTree.Tables[tableID] = tableTree
 		entry := logtail.NewDirtyTreeEntry(types.TS{}, ts, nTree)
-		request := new(FlushRequest)
-		request.tree = entry
-		request.force = true
+		request := &FlushRequest{
+			mode: flushRequestForce,
+			tree: entry,
+		}
 		return request
 	}
 

--- a/pkg/vm/engine/tae/db/checkpoint/flusher_test.go
+++ b/pkg/vm/engine/tae/db/checkpoint/flusher_test.go
@@ -20,6 +20,9 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/catalog"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,4 +61,409 @@ func Test_RestartFlusher(t *testing.T) {
 	assert.False(t, f.IsNoop())
 	fCfg = f.GetCfg()
 	assert.Equal(t, cfg, fCfg)
+}
+
+func TestShouldScheduleStalledCheckpointFlush(t *testing.T) {
+	threshold := 5 * time.Minute
+
+	assert.False(t, shouldScheduleStalledCheckpointFlush(nil, threshold))
+
+	intent := NewCheckpointEntry("", types.TS{}, types.BuildTS(100, 0), ET_Incremental)
+	intent.bornTime = time.Now().Add(-threshold + time.Second)
+	assert.False(t, shouldScheduleStalledCheckpointFlush(intent, threshold))
+
+	intent.bornTime = time.Now().Add(-threshold - time.Second)
+	assert.True(t, shouldScheduleStalledCheckpointFlush(intent, threshold))
+
+	intent.SetFlushChecked()
+	assert.False(t, shouldScheduleStalledCheckpointFlush(intent, threshold))
+
+	intent = NewCheckpointEntry("", types.TS{}, types.BuildTS(100, 0), ET_Incremental)
+	intent.bornTime = time.Now().Add(-threshold - time.Second)
+	intent.SetState(ST_Running)
+	assert.False(t, shouldScheduleStalledCheckpointFlush(intent, threshold))
+}
+
+func TestStalledCheckpointFlushAgeMatchesIntentOldAge(t *testing.T) {
+	assert.Equal(t, checkpointIntentOldAge, stalledCheckpointFlushAge)
+}
+
+func TestMakeStalledCheckpointFlushEntry(t *testing.T) {
+	threshold := 5 * time.Minute
+	start := types.BuildTS(100, 0)
+	end := types.BuildTS(200, 0)
+	intent := NewCheckpointEntry("", start, end, ET_Incremental)
+	intent.bornTime = time.Now().Add(-threshold - time.Second)
+
+	sourcer := &stalledCheckpointFlushCollector{}
+	entry := makeStalledCheckpointFlushEntry(sourcer, intent, threshold)
+
+	assert.NotNil(t, entry)
+	assert.True(t, sourcer.scanCalled)
+	assert.Equal(t, start, sourcer.scanFrom)
+	assert.Equal(t, end, sourcer.scanTo)
+	requestStart, requestEnd := entry.GetTimeRange()
+	assert.Equal(t, start, requestStart)
+	assert.Equal(t, end, requestEnd)
+	assert.Equal(t, 1, entry.GetTree().TableCount())
+
+	intent.bornTime = time.Now().Add(-threshold + time.Second)
+	sourcer = &stalledCheckpointFlushCollector{}
+	assert.Nil(t, makeStalledCheckpointFlushEntry(sourcer, intent, threshold))
+	assert.False(t, sourcer.scanCalled)
+
+	intent.bornTime = time.Now().Add(-threshold - time.Second)
+	sourcer = &stalledCheckpointFlushCollector{empty: true}
+	assert.Nil(t, makeStalledCheckpointFlushEntry(sourcer, intent, threshold))
+	assert.True(t, sourcer.scanCalled)
+}
+
+func TestPickStalledCheckpointFlushEntryAlternatesWithNormal(t *testing.T) {
+	intent := NewCheckpointEntry("", types.BuildTS(2, 0), types.BuildTS(5, 0), ET_Incremental)
+	intent.bornTime = time.Now().Add(-stalledCheckpointFlushAge - time.Second)
+	flusher := &flushImpl{}
+
+	assert.True(t, flusher.pickStalledCheckpointFlushEntry(intent))
+	assert.False(t, flusher.pickStalledCheckpointFlushEntry(intent))
+	assert.True(t, flusher.pickStalledCheckpointFlushEntry(intent))
+	assert.False(t, flusher.pickStalledCheckpointFlushEntry(intent))
+
+	assert.False(t, flusher.pickStalledCheckpointFlushEntry(nil))
+	assert.False(t, flusher.stalledCheckpointPickBounded)
+	assert.True(t, flusher.pickStalledCheckpointFlushEntry(intent))
+}
+
+func TestEnqueueCronFlushEnqueuesNonEmptyEntries(t *testing.T) {
+	queue := newFlushRequestQueue()
+	flusher := &flushImpl{flushRequestQ: queue}
+	first := newTestDirtyTreeEntry(types.BuildTS(1, 0), types.BuildTS(10, 0), 1)
+	second := newTestDirtyTreeEntry(types.BuildTS(2, 0), types.BuildTS(5, 0), 2)
+
+	flusher.enqueueCronFlush(first)
+	flusher.enqueueCronFlush(logtail.NewEmptyDirtyTreeEntry())
+	flusher.enqueueCronFlush(second)
+
+	assert.Len(t, queue.items, 2)
+	assert.Same(t, first, queue.items[0].(*FlushRequest).tree)
+	assert.Same(t, second, queue.items[1].(*FlushRequest).tree)
+	assert.Equal(t, flushRequestCron, queue.items[0].(*FlushRequest).mode)
+	assert.Equal(t, flushRequestCron, queue.items[1].(*FlushRequest).mode)
+}
+
+func TestMergeFlushRequestsKeepsBoundedSeparateFromCron(t *testing.T) {
+	cron1 := newTestDirtyTreeEntry(types.BuildTS(1, 0), types.BuildTS(10, 0), 1)
+	cron2 := newTestDirtyTreeEntry(types.BuildTS(10, 0), types.BuildTS(20, 0), 2)
+	bounded := newTestDirtyTreeEntry(types.BuildTS(2, 0), types.BuildTS(5, 0), 3)
+	force := newTestDirtyTreeEntry(types.BuildTS(3, 0), types.BuildTS(8, 0), 4)
+
+	fromCrons, fromForce, fromCheckpointBounded := mergeFlushRequests(
+		&FlushRequest{mode: flushRequestCron, tree: cron1},
+		&FlushRequest{mode: flushRequestCheckpointBounded, tree: bounded},
+		&FlushRequest{mode: flushRequestCron, tree: cron2},
+		&FlushRequest{mode: flushRequestForce, tree: force},
+	)
+
+	assert.Len(t, fromCheckpointBounded, 1)
+	assert.Same(t, bounded, fromCheckpointBounded[0])
+	cronStart, cronEnd := fromCrons.GetTimeRange()
+	assert.Equal(t, types.BuildTS(1, 0), cronStart)
+	assert.Equal(t, types.BuildTS(20, 0), cronEnd)
+	assert.Equal(t, 2, fromCrons.GetTree().TableCount())
+	forceStart, forceEnd := fromForce.GetTimeRange()
+	assert.Equal(t, types.BuildTS(3, 0), forceStart)
+	assert.Equal(t, types.BuildTS(8, 0), forceEnd)
+	assert.Equal(t, 1, fromForce.GetTree().TableCount())
+}
+
+func TestCheckpointBoundedScheduleBypassesFlushReady(t *testing.T) {
+	assert.False(t, flushScheduleCron.bypassFlushReady())
+	assert.True(t, flushScheduleCheckpointBounded.bypassFlushReady())
+	assert.True(t, flushScheduleForce.bypassFlushReady())
+}
+
+func TestCheckpointBoundedScheduleDoesNotResetFlushDeadline(t *testing.T) {
+	assert.True(t, flushScheduleCron.resetFlushDeadline())
+	assert.False(t, flushScheduleCheckpointBounded.resetFlushDeadline())
+	assert.True(t, flushScheduleForce.resetFlushDeadline())
+}
+
+func TestCheckpointBoundedFlushDoesNotResetTableDeadline(t *testing.T) {
+	flusher := &flushImpl{flushInterval: time.Hour}
+	table := catalog.MockStaloneTableEntry(1, catalog.NewEmptySchema("test"))
+	table.Stats.Init(flusher.flushInterval)
+	originalDeadline := table.Stats.GetFlushDeadline()
+	entry := newTestDirtyTreeEntry(types.BuildTS(1, 0), types.BuildTS(2, 0), table.ID)
+	flusher.objMemSizeList = []tableAndSize{{tbl: table}}
+
+	flusher.checkFlushConditionAndFire(
+		entry,
+		flushScheduleCheckpointBounded,
+		0,
+		types.BuildTS(1, 0),
+	)
+
+	assert.Equal(t, originalDeadline, table.Stats.GetFlushDeadline())
+
+	flusher.checkFlushConditionAndFire(
+		entry,
+		flushScheduleForce,
+		0,
+		types.BuildTS(1, 0),
+	)
+
+	assert.NotEqual(t, originalDeadline, table.Stats.GetFlushDeadline())
+}
+
+func TestTriggerJobFallsBackToNormalWhenBoundedEntryIsEmpty(t *testing.T) {
+	intentStart := types.BuildTS(2, 0)
+	intentEnd := types.BuildTS(5, 0)
+	intent := NewCheckpointEntry("", intentStart, intentEnd, ET_Incremental)
+	intent.bornTime = time.Now().Add(-stalledCheckpointFlushAge - time.Second)
+
+	normal := newTestDirtyTreeEntry(types.BuildTS(1, 0), types.BuildTS(10, 0), 1)
+	sourcer := &triggerJobFallbackCollector{normal: normal}
+	scheduler := &triggerJobCheckpointScheduler{pending: intent}
+	queue := newFlushRequestQueue()
+	flusher := &flushImpl{
+		sourcer:            sourcer,
+		checkpointSchduler: scheduler,
+		flushRequestQ:      queue,
+	}
+
+	flusher.triggerJob(context.Background())
+
+	assert.True(t, sourcer.runCalled)
+	assert.True(t, sourcer.scanCalled)
+	assert.Equal(t, intentStart, sourcer.scanFrom)
+	assert.Equal(t, intentEnd, sourcer.scanTo)
+	assert.True(t, sourcer.getMergedCalled)
+	assert.Len(t, queue.items, 1)
+	assert.Same(t, normal, queue.items[0].(*FlushRequest).tree)
+	assert.True(t, scheduler.scheduleCalled)
+	_, normalEnd := normal.GetTimeRange()
+	assert.Equal(t, normalEnd, scheduler.scheduledTS)
+	assert.False(t, scheduler.force)
+}
+
+func TestTriggerJobEnqueuesBoundedFlushWhenStalledCheckpointHasDirtyEntry(t *testing.T) {
+	intentStart := types.BuildTS(2, 0)
+	intentEnd := types.BuildTS(5, 0)
+	intent := NewCheckpointEntry("", intentStart, intentEnd, ET_Incremental)
+	intent.bornTime = time.Now().Add(-stalledCheckpointFlushAge - time.Second)
+
+	sourcer := &triggerJobBoundedCollector{}
+	scheduler := &triggerJobCheckpointScheduler{pending: intent}
+	queue := newFlushRequestQueue()
+	flusher := &flushImpl{
+		sourcer:            sourcer,
+		checkpointSchduler: scheduler,
+		flushRequestQ:      queue,
+	}
+
+	flusher.triggerJob(context.Background())
+
+	assert.True(t, sourcer.runCalled)
+	assert.True(t, sourcer.scanCalled)
+	assert.Equal(t, intentStart, sourcer.scanFrom)
+	assert.Equal(t, intentEnd, sourcer.scanTo)
+	assert.False(t, sourcer.getMergedCalled)
+	assert.Len(t, queue.items, 1)
+	request := queue.items[0].(*FlushRequest)
+	assert.Equal(t, flushRequestCheckpointBounded, request.mode)
+	requestStart, requestEnd := request.tree.GetTimeRange()
+	assert.Equal(t, intentStart, requestStart)
+	assert.Equal(t, intentEnd, requestEnd)
+	assert.True(t, scheduler.scheduleCalled)
+	assert.Equal(t, intentEnd, scheduler.scheduledTS)
+	assert.False(t, scheduler.force)
+}
+
+func newTestDirtyTreeEntry(start, end types.TS, tableID uint64) *logtail.DirtyTreeEntry {
+	tree := model.NewTree()
+	tree.AddTable(1, tableID)
+	return logtail.NewDirtyTreeEntry(start, end, tree)
+}
+
+type stalledCheckpointFlushCollector struct {
+	scanCalled bool
+	scanFrom   types.TS
+	scanTo     types.TS
+	empty      bool
+}
+
+func (c *stalledCheckpointFlushCollector) String() string    { return "" }
+func (c *stalledCheckpointFlushCollector) Run(time.Duration) {}
+func (c *stalledCheckpointFlushCollector) ScanInRange(from, to types.TS) (*logtail.DirtyTreeEntry, int) {
+	return c.ScanInRangePruned(from, to), 1
+}
+func (c *stalledCheckpointFlushCollector) ScanInRangePruned(from, to types.TS) *logtail.DirtyTreeEntry {
+	c.scanCalled = true
+	c.scanFrom = from
+	c.scanTo = to
+	tree := model.NewTree()
+	if !c.empty {
+		tree.AddTable(1, 2)
+	}
+	return logtail.NewDirtyTreeEntry(from, to, tree)
+}
+func (c *stalledCheckpointFlushCollector) GetAndRefreshMerged() *logtail.DirtyTreeEntry {
+	return logtail.NewEmptyDirtyTreeEntry()
+}
+func (c *stalledCheckpointFlushCollector) Merge() *logtail.DirtyTreeEntry {
+	return logtail.NewEmptyDirtyTreeEntry()
+}
+func (c *stalledCheckpointFlushCollector) GetMaxLSN(types.TS, types.TS) uint64 { return 0 }
+func (c *stalledCheckpointFlushCollector) Init(types.TS)                       {}
+
+type flushRequestQueue struct {
+	items []any
+}
+
+func newFlushRequestQueue() *flushRequestQueue {
+	return &flushRequestQueue{items: make([]any, 0)}
+}
+
+func (q *flushRequestQueue) Start() {}
+func (q *flushRequestQueue) Stop()  {}
+func (q *flushRequestQueue) Enqueue(item any) (any, error) {
+	q.items = append(q.items, item)
+	return nil, nil
+}
+
+type triggerJobFallbackCollector struct {
+	normal          *logtail.DirtyTreeEntry
+	runCalled       bool
+	scanCalled      bool
+	getMergedCalled bool
+	scanFrom        types.TS
+	scanTo          types.TS
+}
+
+func (c *triggerJobFallbackCollector) String() string { return "" }
+func (c *triggerJobFallbackCollector) Run(time.Duration) {
+	c.runCalled = true
+}
+func (c *triggerJobFallbackCollector) ScanInRange(from, to types.TS) (*logtail.DirtyTreeEntry, int) {
+	return c.ScanInRangePruned(from, to), 1
+}
+func (c *triggerJobFallbackCollector) ScanInRangePruned(from, to types.TS) *logtail.DirtyTreeEntry {
+	c.scanCalled = true
+	c.scanFrom = from
+	c.scanTo = to
+	return logtail.NewDirtyTreeEntry(from, to, model.NewTree())
+}
+func (c *triggerJobFallbackCollector) GetAndRefreshMerged() *logtail.DirtyTreeEntry {
+	c.getMergedCalled = true
+	return c.normal
+}
+func (c *triggerJobFallbackCollector) Merge() *logtail.DirtyTreeEntry {
+	return c.normal
+}
+func (c *triggerJobFallbackCollector) GetMaxLSN(types.TS, types.TS) uint64 { return 0 }
+func (c *triggerJobFallbackCollector) Init(types.TS)                       {}
+
+type triggerJobBoundedCollector struct {
+	runCalled       bool
+	scanCalled      bool
+	getMergedCalled bool
+	scanFrom        types.TS
+	scanTo          types.TS
+}
+
+func (c *triggerJobBoundedCollector) String() string { return "" }
+func (c *triggerJobBoundedCollector) Run(time.Duration) {
+	c.runCalled = true
+}
+func (c *triggerJobBoundedCollector) ScanInRange(from, to types.TS) (*logtail.DirtyTreeEntry, int) {
+	return c.ScanInRangePruned(from, to), 1
+}
+func (c *triggerJobBoundedCollector) ScanInRangePruned(from, to types.TS) *logtail.DirtyTreeEntry {
+	c.scanCalled = true
+	c.scanFrom = from
+	c.scanTo = to
+	tree := model.NewTree()
+	tree.AddTable(1, 7)
+	return logtail.NewDirtyTreeEntry(from, to, tree)
+}
+func (c *triggerJobBoundedCollector) GetAndRefreshMerged() *logtail.DirtyTreeEntry {
+	c.getMergedCalled = true
+	return newTestDirtyTreeEntry(types.BuildTS(1, 0), types.BuildTS(10, 0), 8)
+}
+func (c *triggerJobBoundedCollector) Merge() *logtail.DirtyTreeEntry {
+	return logtail.NewEmptyDirtyTreeEntry()
+}
+func (c *triggerJobBoundedCollector) GetMaxLSN(types.TS, types.TS) uint64 { return 0 }
+func (c *triggerJobBoundedCollector) Init(types.TS)                       {}
+
+type triggerJobCheckpointScheduler struct {
+	pending        *CheckpointEntry
+	scheduleCalled bool
+	scheduledTS    types.TS
+	force          bool
+}
+
+func (s *triggerJobCheckpointScheduler) TryScheduleCheckpoint(ts types.TS, force bool) (Intent, error) {
+	s.scheduleCalled = true
+	s.scheduledTS = ts
+	s.force = force
+	return nil, nil
+}
+func (s *triggerJobCheckpointScheduler) String() string { return "" }
+func (s *triggerJobCheckpointScheduler) GetAllIncrementalCheckpoints() []*CheckpointEntry {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) GetAllGlobalCheckpoints() []*CheckpointEntry {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) GetIncrementalCountAfterGlobal() int {
+	return 0
+}
+func (s *triggerJobCheckpointScheduler) CollectCheckpointsInRange(
+	context.Context,
+	types.TS,
+	types.TS,
+) (string, types.TS, error) {
+	return "", types.TS{}, nil
+}
+func (s *triggerJobCheckpointScheduler) ICKPSeekLT(types.TS, int) []*CheckpointEntry {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) GetLowWaterMark() types.TS {
+	return types.TS{}
+}
+func (s *triggerJobCheckpointScheduler) MaxLSN() uint64 {
+	return 0
+}
+func (s *triggerJobCheckpointScheduler) GetCatalog() *catalog.Catalog {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) GetCheckpointMetaFiles() map[string]struct{} {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) ICKPRange(*types.TS, *types.TS, int) []*CheckpointEntry {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) GetCompacted() *CheckpointEntry {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) GetAllCheckpoints() []*CheckpointEntry {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) GetAllCheckpointsForBackup(*CheckpointEntry) []*CheckpointEntry {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) MaxGlobalCheckpoint() *CheckpointEntry {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) MaxIncrementalCheckpoint() *CheckpointEntry {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) PendingIncrementalCheckpoint() *CheckpointEntry {
+	return s.pending
+}
+func (s *triggerJobCheckpointScheduler) MinIncrementalCheckpoint() *CheckpointEntry {
+	return nil
+}
+func (s *triggerJobCheckpointScheduler) GetDirtyCollector() logtail.Collector {
+	return nil
 }

--- a/pkg/vm/engine/tae/db/checkpoint/info.go
+++ b/pkg/vm/engine/tae/db/checkpoint/info.go
@@ -53,6 +53,7 @@ type RunnerReader interface {
 
 	MaxGlobalCheckpoint() *CheckpointEntry
 	MaxIncrementalCheckpoint() *CheckpointEntry
+	PendingIncrementalCheckpoint() *CheckpointEntry
 	MinIncrementalCheckpoint() *CheckpointEntry
 	GetDirtyCollector() logtail.Collector
 }
@@ -114,6 +115,10 @@ func (r *runner) MaxGlobalCheckpoint() *CheckpointEntry {
 
 func (r *runner) MaxIncrementalCheckpoint() *CheckpointEntry {
 	return r.store.MaxIncrementalCheckpoint()
+}
+
+func (r *runner) PendingIncrementalCheckpoint() *CheckpointEntry {
+	return r.store.GetICKPIntent()
 }
 
 func (r *runner) MinIncrementalCheckpoint() *CheckpointEntry {

--- a/pkg/vm/engine/tae/db/checkpoint/runner.go
+++ b/pkg/vm/engine/tae/db/checkpoint/runner.go
@@ -36,6 +36,8 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/logtail"
 )
 
+const checkpointIntentOldAge = 2 * time.Minute
+
 type timeBasedPolicy struct {
 	interval time.Duration
 }
@@ -215,7 +217,7 @@ func NewRunner(
 	cfg = r.GetCfg()
 
 	// Note: we can't change the global history interval in runtime
-	r.store = newRunnerStore(r.rt.SID(), cfg.GlobalHistoryDuration, time.Minute*2)
+	r.store = newRunnerStore(r.rt.SID(), cfg.GlobalHistoryDuration, checkpointIntentOldAge)
 
 	r.gcCheckpointQueue = sm.NewSafeQueue(100, 100, r.onGCCheckpointEntries)
 	r.postCheckpointQueue = sm.NewSafeQueue(1000, 1, r.onPostCheckpointEntries)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24900

## What this PR does / why we need it:

Cherry-pick changes from #24901 to 4.0-dev.

Picked commits:
- d7041008f8 fix: prioritize stalled checkpoint bounded flush
- 9f546cf371 fix: keep bounded checkpoint flush requests isolated
- 97872cc608 fix: preserve flush request time ranges
- 6f9c2bacf6 fix: bypass flush readiness for stalled checkpoints
- 62ca6d848f fix: preserve deadline for bounded checkpoint flush

Local verification:
- `go test ./pkg/vm/engine/tae/db/checkpoint` blocked by inconsistent vendor metadata in this checkout.
- `go test -mod=mod ./pkg/vm/engine/tae/db/checkpoint` reached compilation but failed because local CGO headers are missing (`usearch.h`, `xxhash.h`).
- `CGO_ENABLED=0 go test -mod=mod ./pkg/vm/engine/tae/db/checkpoint` is not supported because this package graph depends on CGO allocator/usearch bindings.

(cherry picked from commit 45165ee5a65fcbcb9841795e9f0d482890e3b268)