### PR TITLE
fix logservice stale replica truncation for 4.0 (#24983)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -264,7 +264,7 @@ replace github.com/hashicorp/memberlist => github.com/matrixorigin/memberlist v0
 replace (
 	github.com/elastic/gosigar v0.14.2 => github.com/matrixorigin/gosigar v0.14.3-0.20241204071856-40aab500bfac
 	github.com/fagongzi/goetty/v2 v2.0.3-0.20230628075727-26c9a2fd5fb8 => github.com/matrixorigin/goetty/v2 v2.0.0-20240611082008-a4de209fff3d
-	github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef => github.com/matrixorigin/dragonboat/v4 v4.0.0-20251214113216-2ddf81ef2a85
+	github.com/lni/dragonboat/v4 v4.0.0-20220815145555-6f622e8bcbef => github.com/matrixorigin/dragonboat/v4 v4.0.0-20260612094223-103d119addce
 	github.com/lni/goutils v1.3.1-0.20220604063047-388d67b4dbc4 => github.com/matrixorigin/goutils v1.3.1-0.20220604063047-388d67b4dbc4
 	github.com/lni/vfs v0.2.1-0.20220616104132-8852fd867376 => github.com/matrixorigin/vfs v0.2.1-0.20220616104132-8852fd867376
 

--- a/go.sum
+++ b/go.sum
@@ -559,6 +559,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matrixorigin/dragonboat/v4 v4.0.0-20251214113216-2ddf81ef2a85 h1:8zwV6ypyx3/TXgOG1k6pY5FiFWlYh97zf0Bsc0qj9bY=
 github.com/matrixorigin/dragonboat/v4 v4.0.0-20251214113216-2ddf81ef2a85/go.mod h1:B1VfuDzGm7Uk0xoRkRJynA6n4i31m/1ZJIPfIyJfYQg=
+github.com/matrixorigin/dragonboat/v4 v4.0.0-20260612094223-103d119addce h1:QM8vkwQ5hkbKwPTApzoUTKosXupynQa1VbRmwXBlyOg=
+github.com/matrixorigin/dragonboat/v4 v4.0.0-20260612094223-103d119addce/go.mod h1:B1VfuDzGm7Uk0xoRkRJynA6n4i31m/1ZJIPfIyJfYQg=
 github.com/matrixorigin/goetty/v2 v2.0.0-20240611082008-a4de209fff3d h1:wSlkJlWXZ3if1sH8Bc/lUUOWhTw91lgYGSFOHqy1tcw=
 github.com/matrixorigin/goetty/v2 v2.0.0-20240611082008-a4de209fff3d/go.mod h1:OwIBpVwRW1HjF/Jhc2Av3UvG2NygMg+bdqGxZaqwhU0=
 github.com/matrixorigin/gosigar v0.14.3-0.20241204071856-40aab500bfac h1:KRPOwOcSZRfWT7w8mr7BmFLoFB75ljgqjkg47xkN/Pc=

--- a/pkg/logservice/snapshot.go
+++ b/pkg/logservice/snapshot.go
@@ -240,6 +240,7 @@ func (ss *snapshotRecord) remove(index snapshotIndex) error {
 // external directory, the snapshot would be imported to system. And then,
 // the log entries can be removed safely.
 type snapshotManager struct {
+	mu        sync.RWMutex
 	cfg       *Config
 	snapshots map[nodeID]*snapshotRecord // shardID => *snapshotRecord
 }
@@ -311,9 +312,11 @@ func (sm *snapshotManager) Init(shardID uint64, replicaID uint64) error {
 	}
 	// The snapshots in the manager must be sorted.
 	sort.Ints(indexes)
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 	for _, idx := range indexes {
 		if idx > 0 {
-			_ = sm.Add(shardID, replicaID, uint64(idx))
+			_ = sm.addLocked(shardID, replicaID, uint64(idx))
 		}
 	}
 	return nil
@@ -321,6 +324,8 @@ func (sm *snapshotManager) Init(shardID uint64, replicaID uint64) error {
 
 // Count implements the ISnapshotManager interface.
 func (sm *snapshotManager) Count(shardID uint64, replicaID uint64) int {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
 	nid := nodeID{shardID: shardID, replicaID: replicaID}
 	if s, ok := sm.snapshots[nid]; ok {
 		return len(s.items)
@@ -330,6 +335,12 @@ func (sm *snapshotManager) Count(shardID uint64, replicaID uint64) int {
 
 // Add implements the ISnapshotManager interface.
 func (sm *snapshotManager) Add(shardID uint64, replicaID uint64, index uint64) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.addLocked(shardID, replicaID, index)
+}
+
+func (sm *snapshotManager) addLocked(shardID uint64, replicaID uint64, index uint64) error {
 	si := snapshotIndex(index)
 	nid := nodeID{shardID: shardID, replicaID: replicaID}
 	dir := sm.snapshotPath(nid, si)
@@ -342,11 +353,27 @@ func (sm *snapshotManager) Add(shardID uint64, replicaID uint64, index uint64) e
 
 // Remove implements the ISnapshotManager interface.
 func (sm *snapshotManager) Remove(shardID uint64, replicaID uint64, index uint64) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 	si := snapshotIndex(index)
 	nid := nodeID{shardID: shardID, replicaID: replicaID}
 	if ss, ok := sm.snapshots[nid]; ok {
 		return ss.remove(si)
 	}
+	return nil
+}
+
+// RemoveReplica removes all exported snapshots tracked for the specified
+// replica. It is used when local metadata still references a replica that has
+// already been superseded on this store.
+func (sm *snapshotManager) RemoveReplica(shardID uint64, replicaID uint64) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	nid := nodeID{shardID: shardID, replicaID: replicaID}
+	if err := sm.cfg.FS.RemoveAll(sm.exportPath(shardID, replicaID)); err != nil {
+		return err
+	}
+	delete(sm.snapshots, nid)
 	return nil
 }
 
@@ -356,6 +383,8 @@ func (sm *snapshotManager) Remove(shardID uint64, replicaID uint64, index uint64
 // escape-valve deletion so shouldDoExport does not suppress a needed
 // re-export on a quiescent shard. See issue #24315.
 func (sm *snapshotManager) NewestIndex(shardID uint64, replicaID uint64) uint64 {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
 	nid := nodeID{shardID: shardID, replicaID: replicaID}
 	ss, ok := sm.snapshots[nid]
 	if !ok {
@@ -383,6 +412,8 @@ func (sm *snapshotManager) NewestIndex(shardID uint64, replicaID uint64) uint64 
 // direct path back to a successful import. The cost is at most one
 // redundant export round. See issue #24315.
 func (sm *snapshotManager) DropNewest(shardID uint64, replicaID uint64) (uint64, error) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 	nid := nodeID{shardID: shardID, replicaID: replicaID}
 	ss, ok := sm.snapshots[nid]
 	if !ok {
@@ -401,6 +432,8 @@ func (sm *snapshotManager) DropNewest(shardID uint64, replicaID uint64) (uint64,
 
 // EvalImportSnapshot implements the ISnapshotManager interface.
 func (sm *snapshotManager) EvalImportSnapshot(shardID uint64, replicaID uint64, index uint64) (string, uint64) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
 	nid := nodeID{shardID: shardID, replicaID: replicaID}
 	ss, ok := sm.snapshots[nid]
 	if !ok {

--- a/pkg/logservice/store_metadata.go
+++ b/pkg/logservice/store_metadata.go
@@ -297,6 +297,7 @@ func (l *store) removeMetadata(shardID uint64, replicaID uint64) {
 		}
 	}
 	l.mu.metadata.Shards = shards
+	delete(l.mu.skippedZombies, zombieKey{shardID: shardID, replicaID: replicaID})
 	l.mustSaveMetadata()
 }
 

--- a/pkg/logservice/truncation.go
+++ b/pkg/logservice/truncation.go
@@ -128,15 +128,89 @@ func (l *store) truncationWorker(ctx context.Context) {
 // processTruncateLog process log truncation for all shards excpet
 // hakeeper shard.
 func (l *store) processTruncateLog(ctx context.Context) error {
+	activeReplicas := l.startedReplicaIDs()
+	processed := make(map[uint64]struct{})
 	for _, shard := range l.getShards() {
 		if shard.ShardID == hakeeper.DefaultHAKeeperShardID {
 			continue
 		}
-		if err := l.processShardTruncateLog(ctx, shard.ShardID); err != nil {
+		replicas := activeReplicas[shard.ShardID]
+		if _, ok := replicas[shard.ReplicaID]; !ok {
+			if len(replicas) > 0 ||
+				l.isSkippedZombie(shard.ShardID, shard.ReplicaID) {
+				// NodeHost state and local metadata are independent snapshots.
+				// Re-read NodeHost immediately before cleanup so a replica that
+				// became active after the outer snapshot is never classified as stale.
+				replicas = l.startedReplicaIDs()[shard.ShardID]
+				if _, ok := replicas[shard.ReplicaID]; ok {
+					continue
+				}
+				if len(replicas) == 0 &&
+					!l.isSkippedZombie(shard.ShardID, shard.ReplicaID) {
+					continue
+				}
+				l.cleanupStaleReplica(shard.ShardID, shard.ReplicaID,
+					l.newestActiveSnapshotIndex(shard.ShardID, replicas))
+			}
+			continue
+		}
+		if _, ok := processed[shard.ShardID]; ok {
+			continue
+		}
+		processed[shard.ShardID] = struct{}{}
+		if err := l.processShardTruncateLogWithReplica(ctx, shard.ShardID, shard.ReplicaID); err != nil {
 			l.runtime.Logger().Error("process truncate log failed", zap.Error(err))
 		}
 	}
 	return nil
+}
+
+func (l *store) startedReplicaIDs() map[uint64]map[uint64]struct{} {
+	opts := dragonboat.NodeHostInfoOption{SkipLogInfo: true}
+	nhi := l.nh.GetNodeHostInfo(opts)
+	replicas := make(map[uint64]map[uint64]struct{})
+	for _, ci := range nhi.ShardInfoList {
+		if ci.Pending {
+			continue
+		}
+		if _, ok := replicas[ci.ShardID]; !ok {
+			replicas[ci.ShardID] = make(map[uint64]struct{})
+		}
+		replicas[ci.ShardID][ci.ReplicaID] = struct{}{}
+	}
+	return replicas
+}
+
+func (l *store) newestActiveSnapshotIndex(
+	shardID uint64, replicas map[uint64]struct{},
+) uint64 {
+	var index uint64
+	for replicaID := range replicas {
+		if newest := l.snapshotMgr.NewestIndex(shardID, replicaID); newest > index {
+			index = newest
+		}
+	}
+	return index
+}
+
+func (l *store) cleanupStaleReplica(
+	shardID uint64, replicaID uint64, activeSnapshotIndex uint64,
+) {
+	if err := l.snapshotMgr.RemoveReplica(shardID, replicaID); err != nil {
+		l.runtime.Logger().Error("remove stale exported snapshots failed",
+			zap.Uint64("shardID", shardID),
+			zap.Uint64("replicaID", replicaID),
+			zap.Error(err),
+		)
+		return
+	}
+	l.shardSnapshotInfo.setSnapshotIndex(shardID, activeSnapshotIndex)
+	l.runtime.Logger().Info("remove stale log replica metadata",
+		zap.Uint64("shardID", shardID),
+		zap.Uint64("replicaID", replicaID),
+		zap.Uint64("activeSnapshotIndex", activeSnapshotIndex),
+	)
+	l.removeMetadata(shardID, replicaID)
 }
 
 // exportSnapshot just export the snapshot but do NOT truncate logs.
@@ -347,6 +421,14 @@ func (l *store) dropNewestOnTimeout(shardID uint64, replicaID uint64) {
 }
 
 func (l *store) processShardTruncateLog(ctx context.Context, shardID uint64) error {
+	replicaID := l.getReplicaID(shardID)
+	if replicaID <= 0 {
+		return nil
+	}
+	return l.processShardTruncateLogWithReplica(ctx, shardID, uint64(replicaID))
+}
+
+func (l *store) processShardTruncateLogWithReplica(ctx context.Context, shardID uint64, replicaID uint64) error {
 	// Do NOT process before leader is OK.
 	leaderID, err := l.leaderID(shardID)
 	if err != nil {
@@ -378,11 +460,8 @@ func (l *store) processShardTruncateLog(ctx context.Context, shardID uint64) err
 		// of wedging permanently. See issue #24315.
 		l.runtime.Logger().Warn("get truncated lsn timed out, tick skipped",
 			zap.Uint64("shardID", shardID), zap.Error(err))
-		if rid := l.getReplicaID(shardID); rid > 0 {
-			replicaID := uint64(rid)
-			if l.snapshotMgr.Count(shardID, replicaID) >= l.cfg.MaxExportedSnapshot {
-				l.dropNewestOnTimeout(shardID, replicaID)
-			}
+		if l.snapshotMgr.Count(shardID, replicaID) >= l.cfg.MaxExportedSnapshot {
+			l.dropNewestOnTimeout(shardID, replicaID)
 		}
 		return nil
 	}
@@ -391,7 +470,6 @@ func (l *store) processShardTruncateLog(ctx context.Context, shardID uint64) err
 		return nil
 	}
 
-	replicaID := uint64(l.getReplicaID(shardID))
 	dir, lsn := l.snapshotMgr.EvalImportSnapshot(shardID, replicaID, lsnInSM)
 	if l.shouldDoImport(ctx, shardID, lsnInSM, lsn, dir) {
 		if err := l.importSnapshot(ctx, shardID, replicaID, lsn, dir); err != nil {

--- a/pkg/logservice/truncation_test.go
+++ b/pkg/logservice/truncation_test.go
@@ -21,10 +21,12 @@ import (
 
 	"github.com/lni/dragonboat/v4"
 	"github.com/lni/goutils/leaktest"
+	"github.com/lni/vfs"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/runtime"
 	"github.com/matrixorigin/matrixone/pkg/hakeeper"
 	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
+	"github.com/matrixorigin/matrixone/pkg/pb/metadata"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -86,6 +88,263 @@ func TestTruncationExportSnapshot(t *testing.T) {
 		err = s.store.processShardTruncateLog(ctx, 1)
 		// truncate lsn not advanced, no error is returned.
 		assert.NoError(t, err)
+	}
+	runServiceTest(t, false, true, fn)
+}
+
+func TestTruncationSkipsStaleReplicaMetadata(t *testing.T) {
+	const (
+		shardID       = uint64(1)
+		staleReplica  = uint64(99)
+		activeReplica = uint64(1)
+	)
+	logShard := func(replicaID uint64) metadata.LogShard {
+		return metadata.LogShard{
+			LogShardRecord: metadata.LogShardRecord{ShardID: shardID},
+			ReplicaID:      replicaID,
+		}
+	}
+
+	tests := []struct {
+		name   string
+		shards []metadata.LogShard
+	}{
+		{
+			name: "stale before active",
+			shards: []metadata.LogShard{
+				logShard(staleReplica),
+				logShard(activeReplica),
+			},
+		},
+		{
+			name: "stale after active",
+			shards: []metadata.LogShard{
+				logShard(activeReplica),
+				logShard(staleReplica),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := func(t *testing.T, s *Service) {
+				nid := nodeID{shardID: shardID, replicaID: staleReplica}
+				testPrepareSnapshot(t, s.store.snapshotMgr, nid, snapshotIndex(100))
+				assert.NoError(t, s.store.snapshotMgr.Init(shardID, staleReplica))
+				assert.Equal(t, 1, s.store.snapshotMgr.Count(shardID, staleReplica))
+
+				s.store.mu.Lock()
+				s.store.mu.metadata.Shards = append([]metadata.LogShard(nil), tc.shards...)
+				s.store.mu.Unlock()
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+				defer cancel()
+				assert.NoError(t, s.store.processTruncateLog(ctx))
+
+				assert.Equal(t, int64(activeReplica), s.store.getReplicaID(shardID))
+				assert.Equal(t, 0, s.store.snapshotMgr.Count(shardID, staleReplica))
+			}
+			runServiceTest(t, false, true, fn)
+		})
+	}
+}
+
+func TestTruncationCleansSkippedZombieReplicaMetadata(t *testing.T) {
+	const (
+		shardID      = uint64(1)
+		staleReplica = uint64(99)
+	)
+	logShard := metadata.LogShard{
+		LogShardRecord: metadata.LogShardRecord{ShardID: shardID},
+		ReplicaID:      staleReplica,
+	}
+
+	tests := []struct {
+		name    string
+		skipped bool
+	}{
+		{
+			name:    "skipped zombie without active replacement",
+			skipped: true,
+		},
+		{
+			name: "ordinary metadata without active replica",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := func(t *testing.T, s *Service) {
+				nid := nodeID{shardID: shardID, replicaID: staleReplica}
+				testPrepareSnapshot(t, s.store.snapshotMgr, nid, snapshotIndex(100))
+				assert.NoError(t, s.store.snapshotMgr.Init(shardID, staleReplica))
+				assert.Equal(t, 1, s.store.snapshotMgr.Count(shardID, staleReplica))
+
+				s.store.mu.Lock()
+				s.store.mu.metadata.Shards = []metadata.LogShard{logShard}
+				if tc.skipped {
+					s.store.mu.skippedZombies = map[zombieKey]struct{}{
+						{shardID: shardID, replicaID: staleReplica}: {},
+					}
+				}
+				s.store.mu.Unlock()
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+				defer cancel()
+				assert.NoError(t, s.store.processTruncateLog(ctx))
+
+				if tc.skipped {
+					assert.Equal(t, int64(-1), s.store.getReplicaID(shardID))
+					assert.Equal(t, 0, s.store.snapshotMgr.Count(shardID, staleReplica))
+					assert.False(t, s.store.isSkippedZombie(shardID, staleReplica))
+					return
+				}
+				assert.Equal(t, int64(staleReplica), s.store.getReplicaID(shardID))
+				assert.Equal(t, 1, s.store.snapshotMgr.Count(shardID, staleReplica))
+			}
+			runServiceTest(t, false, false, fn)
+		})
+	}
+}
+
+func TestTruncationRealignsSnapshotIndexAfterStaleReplicaCleanup(t *testing.T) {
+	const (
+		shardID       = uint64(1)
+		staleReplica  = uint64(99)
+		activeReplica = uint64(1)
+		staleIndex    = uint64(100)
+	)
+	logShard := func(replicaID uint64) metadata.LogShard {
+		return metadata.LogShard{
+			LogShardRecord: metadata.LogShardRecord{ShardID: shardID},
+			ReplicaID:      replicaID,
+		}
+	}
+
+	tests := []struct {
+		name              string
+		shards            []metadata.LogShard
+		activeBeforeStale bool
+	}{
+		{
+			name: "stale before active",
+			shards: []metadata.LogShard{
+				logShard(staleReplica),
+				logShard(activeReplica),
+			},
+		},
+		{
+			name: "stale after active",
+			shards: []metadata.LogShard{
+				logShard(activeReplica),
+				logShard(staleReplica),
+			},
+			activeBeforeStale: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := func(t *testing.T, s *Service) {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+				defer cancel()
+
+				tnID := uint64(100)
+				req := pb.Request{
+					Method: pb.CONNECT_RO,
+					LogRequest: pb.LogRequest{
+						ShardID: shardID,
+						TNID:    tnID,
+					},
+				}
+				resp := s.handleConnect(ctx, req)
+				assert.Equal(t, uint32(moerr.Ok), resp.ErrorCode)
+
+				for i := 0; i < 10; i++ {
+					data := make([]byte, 8)
+					cmd := getTestAppendCmd(tnID, data)
+					req = pb.Request{
+						Method: pb.APPEND,
+						LogRequest: pb.LogRequest{
+							ShardID: shardID,
+						},
+					}
+					resp = s.handleAppend(ctx, req, cmd)
+					assert.Equal(t, uint32(moerr.Ok), resp.ErrorCode)
+				}
+
+				req = pb.Request{
+					Method: pb.TRUNCATE,
+					LogRequest: pb.LogRequest{
+						ShardID: shardID,
+						Lsn:     4,
+					},
+				}
+				resp = s.handleTruncate(ctx, req)
+				assert.Equal(t, uint32(moerr.Ok), resp.ErrorCode)
+
+				nid := nodeID{shardID: shardID, replicaID: staleReplica}
+				testPrepareSnapshot(t, s.store.snapshotMgr, nid, snapshotIndex(staleIndex))
+				assert.NoError(t, s.store.snapshotMgr.Init(shardID, staleReplica))
+				assert.Equal(t, 1, s.store.snapshotMgr.Count(shardID, staleReplica))
+				s.store.shardSnapshotInfo.setSnapshotIndex(shardID, staleIndex)
+
+				s.store.mu.Lock()
+				s.store.mu.metadata.Shards = append([]metadata.LogShard(nil), tc.shards...)
+				s.store.mu.Unlock()
+
+				assert.NoError(t, s.store.processTruncateLog(ctx))
+				assert.Equal(t, 0, s.store.snapshotMgr.Count(shardID, staleReplica))
+				if tc.activeBeforeStale {
+					assert.Equal(t, 0, s.store.snapshotMgr.Count(shardID, activeReplica))
+					assert.NoError(t, s.store.processTruncateLog(ctx))
+				}
+
+				assert.Equal(t, 1, s.store.snapshotMgr.Count(shardID, activeReplica))
+				assert.Equal(t,
+					s.store.snapshotMgr.NewestIndex(shardID, activeReplica),
+					s.store.shardSnapshotInfo.getSnapshotIndex(shardID))
+			}
+			runServiceTest(t, false, true, fn)
+		})
+	}
+}
+
+func TestTruncationKeepsStaleReplicaMetadataOnSnapshotCleanupFailure(t *testing.T) {
+	const (
+		shardID      = uint64(1)
+		staleReplica = uint64(99)
+	)
+	logShard := metadata.LogShard{
+		LogShardRecord: metadata.LogShardRecord{ShardID: shardID},
+		ReplicaID:      staleReplica,
+	}
+
+	fn := func(t *testing.T, s *Service) {
+		nid := nodeID{shardID: shardID, replicaID: staleReplica}
+		testPrepareSnapshot(t, s.store.snapshotMgr, nid, snapshotIndex(100))
+		assert.NoError(t, s.store.snapshotMgr.Init(shardID, staleReplica))
+		assert.Equal(t, 1, s.store.snapshotMgr.Count(shardID, staleReplica))
+
+		s.store.mu.Lock()
+		s.store.mu.metadata.Shards = []metadata.LogShard{logShard}
+		s.store.mu.Unlock()
+
+		originalSnapshotCfg := s.store.snapshotMgr.cfg
+		failingSnapshotCfg := *originalSnapshotCfg
+		failingSnapshotCfg.FS = vfs.Wrap(originalSnapshotCfg.FS, vfs.OnIndex(0, vfs.OpWrite))
+		s.store.snapshotMgr.cfg = &failingSnapshotCfg
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancel()
+		assert.NoError(t, s.store.processTruncateLog(ctx))
+		assert.Equal(t, int64(staleReplica), s.store.getReplicaID(shardID))
+		assert.Equal(t, 1, s.store.snapshotMgr.Count(shardID, staleReplica))
+
+		s.store.snapshotMgr.cfg = originalSnapshotCfg
+		assert.NoError(t, s.store.processTruncateLog(ctx))
+		assert.Equal(t, int64(-1), s.store.getReplicaID(shardID))
+		assert.Equal(t, 0, s.store.snapshotMgr.Count(shardID, staleReplica))
 	}
 	runServiceTest(t, false, true, fn)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #24966

## What this PR does / why we need it:
Why this is needed:

- The upstream fix prevents imported snapshots from synthesizing `Membership.ConfigChangeId` from the snapshot index.
- HAKeeper uses Dragonboat membership `ConfigChangeId` as the LogService shard epoch.
- Without this fix, an old imported membership can be reported with a large fake epoch and be treated as newer than the live membership view.
- The upstream fix also preserves online imported snapshot membership consistently and rejects invalid target membership before restore.

Validation:

- `git diff --check`
- `GOTELEMETRY=off go mod download github.com/lni/dragonboat/v4`
- `GOTELEMETRY=off go list -m -json github.com/lni/dragonboat/v4`
- `GOTELEMETRY=off GOCACHE=/private/tmp/mo-dragonboat-3dev-gocache go test github.com/lni/dragonboat/v4/tools
github.com/lni/dragonboat/v4/internal/rsm
github.com/lni/dragonboat/v4/internal/raft -run '^$' -count=0`

Fixes logservice stale replica recovery with the previous MO-side stale truncation metadata cleanup plus the Dragonboat snapshot import metadata fix from #24967. This keeps truncation from processing stale local replica metadata/exported snapshots, and updates Dragonboat so imported snapshots no longer synthesize membership ConfigChangeId from snapshot index.
