### PR TITLE
4.0-dev: fix(frontend): optimize no-pk data branch merge apply

### DIFF
--- a/pkg/frontend/data_branch.go
+++ b/pkg/frontend/data_branch.go
@@ -51,6 +51,21 @@ import (
 
 const dataBranchMetadataIDBatchSize = 512
 
+func isDataBranchUserVisibleColumn(col *plan.ColDef) bool {
+	if col == nil {
+		return false
+	}
+	if col.Hidden {
+		return false
+	}
+	switch col.Name {
+	case catalog.Row_ID, catalog.FakePrimaryKeyColName, catalog.CPrimaryKeyColName:
+		return false
+	default:
+		return true
+	}
+}
+
 func newBranchHashmapAllocator(limitRate float64) *branchHashmapAllocator {
 	throttler := rscthrottler.NewMemThrottler(
 		"DataBranchHashmap",
@@ -951,12 +966,9 @@ func getTableStuff(
 		tblStuff.def.colNames = append(tblStuff.def.colNames, col.Name)
 		tblStuff.def.colTypes = append(tblStuff.def.colTypes, t)
 
-		if col.Name == catalog.FakePrimaryKeyColName ||
-			col.Name == catalog.CPrimaryKeyColName {
-			continue
+		if isDataBranchUserVisibleColumn(col) {
+			tblStuff.def.visibleIdxes = append(tblStuff.def.visibleIdxes, i)
 		}
-
-		tblStuff.def.visibleIdxes = append(tblStuff.def.visibleIdxes, i)
 	}
 
 	tblStuff.retPool = &retBatchList{}

--- a/pkg/frontend/data_branch_hashdiff.go
+++ b/pkg/frontend/data_branch_hashdiff.go
@@ -144,10 +144,19 @@ func handleDelsOnLCA(
 			}
 		}
 
+		selectCols := make([]string, len(tblStuff.def.colNames)+1)
+		selectCols[0] = "pks.__idx_"
+		for i, colName := range tblStuff.def.colNames {
+			selectCols[i+1] = fmt.Sprintf("lca.%s", quoteIdentifierForSQL(colName))
+		}
+
 		sqlBuf.Reset()
 		sqlBuf.WriteString(fmt.Sprintf(
-			"select pks.__idx_, lca.* from %s.%s%s as lca ",
-			lcaTblDef.DbName, lcaTblDef.Name, mots),
+			"select %s from %s.%s%s as lca ",
+			strings.Join(selectCols, ", "),
+			quoteIdentifierForSQL(lcaTblDef.DbName),
+			quoteIdentifierForSQL(lcaTblDef.Name),
+			mots),
 		)
 		sqlBuf.WriteString(fmt.Sprintf(
 			"right join (values %s) as pks(__idx_,%s) on ",
@@ -252,8 +261,6 @@ func handleDelsOnLCA(
 
 	dBat = tblStuff.retPool.acquireRetBatch(tblStuff, false)
 
-	endIdx := dBat.VectorCount() - 1
-
 	sels := make([]int64, 0, 100)
 	joinedRows := 0
 	lcaHitRows := 0
@@ -275,17 +282,6 @@ func handleDelsOnLCA(
 				}
 			}
 
-			// For composite/fake PK tables, the hidden PK column (__cpkey__
-			// or __mo_fake_pk_col) may not be returned by SQL "select *".
-			// Fill it from the tombstone batch when the loop above didn't
-			// cover endIdx.  The reader fallback returns ALL columns so the
-			// loop already fills endIdx — skip the extra append to avoid
-			// doubling Vecs[endIdx].Length() vs RowCount().
-			if tblStuff.def.pkKind != normalKind && len(cols)-2 < endIdx {
-				if err = dBat.Vecs[endIdx].UnionOne(tBat.Vecs[0], int64(i), ses.proc.Mp()); err != nil {
-					return false
-				}
-			}
 		}
 
 		dBat.SetRowCount(dBat.Vecs[0].Length())

--- a/pkg/frontend/data_branch_output.go
+++ b/pkg/frontend/data_branch_output.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
@@ -66,6 +67,122 @@ func makeFileName(
 	)
 }
 
+type applyBatchInfo struct {
+	dbName             string
+	baseTable          string
+	deleteTable        string
+	insertTable        string
+	deleteKeyNames     []string
+	deleteStageNames   []string
+	visibleNames       []string
+	disableInsertStage bool
+}
+
+func newSQLValuesAppender(
+	ctx context.Context,
+	ses *Session,
+	bh BackgroundExec,
+	tblStuff tableStuff,
+	mode dataBranchApplyMode,
+	deleteCnt *int,
+	deleteBuf *bytes.Buffer,
+	insertCnt *int,
+	insertBuf *bytes.Buffer,
+	writeFile func([]byte) error,
+) sqlValuesAppender {
+	deleteByFullRow, deleteKeyColIdxes, batchInfo := buildDataBranchApplyLayout(ctx, ses, tblStuff, mode)
+	return sqlValuesAppender{
+		ctx:               ctx,
+		ses:               ses,
+		bh:                bh,
+		tblStuff:          tblStuff,
+		deleteByFullRow:   deleteByFullRow,
+		deleteKeyColIdxes: deleteKeyColIdxes,
+		batchInfo:         batchInfo,
+		deleteCnt:         deleteCnt,
+		deleteBuf:         deleteBuf,
+		insertCnt:         insertCnt,
+		insertBuf:         insertBuf,
+		writeFile:         writeFile,
+	}
+}
+
+func (sva sqlValuesAppender) extraColIdxesForRow(kind string) []int {
+	if kind != diffDelete || sva.deleteByFullRow {
+		return nil
+	}
+	return sva.deleteKeyColIdxes
+}
+
+func buildDataBranchApplyLayout(
+	ctx context.Context,
+	ses *Session,
+	tblStuff tableStuff,
+	mode dataBranchApplyMode,
+) (deleteByFullRow bool, deleteKeyColIdxes []int, batchInfo *applyBatchInfo) {
+	if mode == dataBranchApplyModePortableSQL && tblStuff.def.pkKind == fakeKind {
+		return true, nil, nil
+	}
+
+	deleteKeyColIdxes = dataBranchDeleteKeyColIdxes(tblStuff, mode)
+	disableInsertStage := tblStuff.def.pkKind == fakeKind && mode == dataBranchApplyModeOnline
+	return false, deleteKeyColIdxes, newApplyBatchInfo(ctx, ses, tblStuff, deleteKeyColIdxes, disableInsertStage)
+}
+
+func dataBranchDeleteKeyColIdxes(tblStuff tableStuff, mode dataBranchApplyMode) []int {
+	if tblStuff.def.pkKind == fakeKind && mode == dataBranchApplyModeOnline {
+		return []int{tblStuff.def.pkColIdx}
+	}
+	return append([]int(nil), tblStuff.def.pkColIdxes...)
+}
+
+func newApplyBatchInfo(
+	ctx context.Context,
+	ses *Session,
+	tblStuff tableStuff,
+	deleteKeyColIdxes []int,
+	disableInsertStage bool,
+) *applyBatchInfo {
+	if len(deleteKeyColIdxes) == 0 {
+		return nil
+	}
+
+	deleteKeyNames := make([]string, len(deleteKeyColIdxes))
+	deleteStageNames := make([]string, len(deleteKeyColIdxes))
+	for i, idx := range deleteKeyColIdxes {
+		deleteKeyNames[i] = tblStuff.def.colNames[idx]
+		deleteStageNames[i] = fmt.Sprintf("branch_apply_key_%d", i)
+	}
+
+	visibleNames := make([]string, len(tblStuff.def.visibleIdxes))
+	for i, idx := range tblStuff.def.visibleIdxes {
+		visibleNames[i] = tblStuff.def.colNames[idx]
+	}
+
+	seq := atomic.AddUint64(&diffTempTableSeq, 1)
+	sessionTag := strings.ReplaceAll(ses.GetUUIDString(), "-", "")
+	return &applyBatchInfo{
+		dbName:             tblStuff.baseRel.GetTableDef(ctx).DbName,
+		baseTable:          tblStuff.baseRel.GetTableName(),
+		deleteTable:        fmt.Sprintf("__mo_diff_del_%s_%d", sessionTag, seq),
+		insertTable:        fmt.Sprintf("__mo_diff_ins_%s_%d", sessionTag, seq),
+		deleteKeyNames:     deleteKeyNames,
+		deleteStageNames:   deleteStageNames,
+		visibleNames:       visibleNames,
+		disableInsertStage: disableInsertStage,
+	}
+}
+
+func (batchInfo *applyBatchInfo) effectiveDeleteStageNames() []string {
+	if batchInfo == nil {
+		return nil
+	}
+	if len(batchInfo.deleteStageNames) == len(batchInfo.deleteKeyNames) && len(batchInfo.deleteStageNames) > 0 {
+		return batchInfo.deleteStageNames
+	}
+	return batchInfo.deleteKeyNames
+}
+
 func mergeDiffs(
 	ctx context.Context,
 	cancel context.CancelFunc,
@@ -97,23 +214,15 @@ func mergeDiffs(
 		cancel()
 	}()
 
-	appender := sqlValuesAppender{
-		ctx:             ctx,
-		ses:             ses,
-		bh:              bh,
-		tblStuff:        tblStuff,
-		deleteByFullRow: tblStuff.def.pkKind == fakeKind,
-		pkInfo:          newPKBatchInfo(ctx, ses, tblStuff),
-		deleteCnt:       &deleteCnt,
-		deleteBuf:       deleteFromVals,
-		insertCnt:       &insertCnt,
-		insertBuf:       insertIntoVals,
-	}
-	if err = initPKTables(ctx, ses, bh, appender.pkInfo, appender.writeFile); err != nil {
+	appender := newSQLValuesAppender(
+		ctx, ses, bh, tblStuff, dataBranchApplyModeOnline,
+		&deleteCnt, deleteFromVals, &insertCnt, insertIntoVals, nil,
+	)
+	if err = initApplyTables(ctx, ses, bh, appender.batchInfo, appender.writeFile); err != nil {
 		return err
 	}
 	defer func() {
-		if err2 := dropPKTables(ctx, ses, bh, appender.pkInfo, appender.writeFile); err2 != nil && err == nil {
+		if err2 := dropApplyTables(ctx, ses, bh, appender.batchInfo, appender.writeFile); err2 != nil && err == nil {
 			err = err2
 		}
 	}()
@@ -459,26 +568,17 @@ func satisfyDiffOutputOpt(
 			return
 		}
 
-		appender := sqlValuesAppender{
-			ctx:             ctx,
-			ses:             ses,
-			bh:              bh,
-			tblStuff:        tblStuff,
-			deleteByFullRow: tblStuff.def.pkKind == fakeKind,
-			pkInfo:          newPKBatchInfo(ctx, ses, tblStuff),
-			deleteCnt:       &deleteCnt,
-			deleteBuf:       deleteFromValsBuffer,
-			insertCnt:       &insertCnt,
-			insertBuf:       insertIntoValsBuffer,
-			writeFile:       writeFile,
-		}
+		appender := newSQLValuesAppender(
+			ctx, ses, bh, tblStuff, dataBranchApplyModePortableSQL,
+			&deleteCnt, deleteFromValsBuffer, &insertCnt, insertIntoValsBuffer, writeFile,
+		)
 		if writeFile != nil {
 			// Make generated SQL runnable in one transaction.
 			if err = writeFile([]byte("BEGIN;\n")); err != nil {
 				return
 			}
 		}
-		if err = initPKTables(ctx, ses, bh, appender.pkInfo, appender.writeFile); err != nil {
+		if err = initApplyTables(ctx, ses, bh, appender.batchInfo, appender.writeFile); err != nil {
 			return
 		}
 
@@ -531,7 +631,7 @@ func satisfyDiffOutputOpt(
 			cancel()
 		}
 		if first == nil {
-			if err = dropPKTables(ctx, ses, bh, appender.pkInfo, appender.writeFile); err != nil {
+			if err = dropApplyTables(ctx, ses, bh, appender.batchInfo, appender.writeFile); err != nil {
 				return err
 			}
 		}
@@ -655,9 +755,11 @@ func tryDiffAsCSV(
 	}
 
 	sql := fmt.Sprintf(
-		"SELECT COUNT(*) FROM %s.%s",
-		tblStuff.baseRel.GetTableDef(ctx).DbName,
-		tblStuff.baseRel.GetTableDef(ctx).Name,
+		"SELECT COUNT(*) FROM %s",
+		qualifiedTableName(
+			tblStuff.baseRel.GetTableDef(ctx).DbName,
+			tblStuff.baseRel.GetTableDef(ctx).Name,
+		),
 	)
 
 	if tblStuff.baseSnap != nil && tblStuff.baseSnap.TS != nil {
@@ -716,9 +818,11 @@ func writeCSV(
 	}
 
 	// output as csv
-	sql := fmt.Sprintf("SELECT * FROM %s.%s%s;",
-		tblStuff.tarRel.GetTableDef(ctx).DbName,
-		tblStuff.tarRel.GetTableDef(ctx).Name,
+	sql := fmt.Sprintf("SELECT * FROM %s%s;",
+		qualifiedTableName(
+			tblStuff.tarRel.GetTableDef(ctx).DbName,
+			tblStuff.tarRel.GetTableDef(ctx).Name,
+		),
 		snap,
 	)
 
@@ -962,15 +1066,17 @@ func writeDeleteRowSQLFull(
 ) error {
 	// Use NULL-aware equality and LIMIT 1 to preserve duplicate-row semantics.
 	buf.WriteString(fmt.Sprintf(
-		"delete from %s.%s where ",
-		tblStuff.baseRel.GetTableDef(ctx).DbName,
-		tblStuff.baseRel.GetTableDef(ctx).Name,
+		"delete from %s where ",
+		qualifiedTableName(
+			tblStuff.baseRel.GetTableDef(ctx).DbName,
+			tblStuff.baseRel.GetTableDef(ctx).Name,
+		),
 	))
 	for i, idx := range tblStuff.def.visibleIdxes {
 		if i > 0 {
 			buf.WriteString(" and ")
 		}
-		colName := tblStuff.def.colNames[idx]
+		colName := quoteIdentifierForSQL(tblStuff.def.colNames[idx])
 		if row[idx] == nil {
 			buf.WriteString(colName)
 			buf.WriteString(" is null")
@@ -984,6 +1090,103 @@ func writeDeleteRowSQLFull(
 	}
 	buf.WriteString(" limit 1;\n")
 	return nil
+}
+
+func extractDataBranchApplyRow(
+	ctx context.Context,
+	ses *Session,
+	tblStuff tableStuff,
+	bat *batch.Batch,
+	rowIdx int,
+	extraColIdxes []int,
+	row []any,
+	errorPrefix string,
+) (err error) {
+	extractCol := func(colIdx int) error {
+		vec := bat.Vecs[colIdx]
+		if rowIdx >= vec.Length() {
+			return moerr.NewInternalErrorNoCtxf(
+				"%s: row=%d batchRows=%d col=%d vecLen=%d type=%s",
+				errorPrefix, rowIdx, bat.RowCount(), colIdx, vec.Length(), vec.GetType().String(),
+			)
+		}
+		if err = extractDataBranchSQLRowValue(ctx, ses, vec, colIdx, row, rowIdx); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	for _, colIdx := range tblStuff.def.visibleIdxes {
+		if err = extractCol(colIdx); err != nil {
+			return err
+		}
+	}
+	for i, colIdx := range extraColIdxes {
+		alreadyExtracted := false
+		for _, visibleIdx := range tblStuff.def.visibleIdxes {
+			if visibleIdx == colIdx {
+				alreadyExtracted = true
+				break
+			}
+		}
+		if alreadyExtracted {
+			continue
+		}
+		for j := 0; j < i; j++ {
+			if extraColIdxes[j] == colIdx {
+				alreadyExtracted = true
+				break
+			}
+		}
+		if alreadyExtracted {
+			continue
+		}
+		if err = extractCol(colIdx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendDataBranchApplyRowAsSQLValues(
+	ctx context.Context,
+	ses *Session,
+	tblStuff tableStuff,
+	kind string,
+	row []any,
+	tmpValsBuffer *bytes.Buffer,
+	appender sqlValuesAppender,
+) (err error) {
+	tmpValsBuffer.Reset()
+	if kind == diffDelete {
+		if appender.deleteByFullRow {
+			if err = writeDeleteRowSQLFull(ctx, ses, tblStuff, row, tmpValsBuffer); err != nil {
+				return err
+			}
+		} else if appender.batchInfo != nil {
+			if err = writeDeleteRowValuesWithColIdxes(
+				ses, tblStuff, row, appender.deleteKeyColIdxes, tmpValsBuffer, true,
+			); err != nil {
+				return err
+			}
+		} else {
+			if err = writeDeleteRowValuesWithColIdxes(
+				ses, tblStuff, row, appender.deleteKeyColIdxes, tmpValsBuffer, false,
+			); err != nil {
+				return err
+			}
+		}
+	} else {
+		if err = writeInsertRowValues(ses, tblStuff, row, tmpValsBuffer); err != nil {
+			return err
+		}
+	}
+
+	if tmpValsBuffer.Len() == 0 {
+		return nil
+	}
+
+	return appender.appendRow(kind, tmpValsBuffer.Bytes())
 }
 
 func appendBatchRowsAsSQLValues(
@@ -1003,70 +1206,15 @@ func appendBatchRowsAsSQLValues(
 			return ctx.Err()
 		}
 
-		for _, colIdx := range tblStuff.def.visibleIdxes {
-			//seenCols[colIdx] = struct{}{}
-			vec := wrapped.batch.Vecs[colIdx]
-			if rowIdx >= vec.Length() {
-				return moerr.NewInternalErrorNoCtxf(
-					"data branch output batch shape mismatch: row=%d batchRows=%d col=%d vecLen=%d type=%s",
-					rowIdx, wrapped.batch.RowCount(), colIdx, vec.Length(), vec.GetType().String(),
-				)
-			}
-			if err = extractDataBranchSQLRowValue(ctx, ses, vec, colIdx, row, rowIdx); err != nil {
-				return
-			}
+		if err = extractDataBranchApplyRow(
+			ctx, ses, tblStuff, wrapped.batch, rowIdx, appender.extraColIdxesForRow(wrapped.kind), row,
+			"data branch output batch shape mismatch",
+		); err != nil {
+			return
 		}
-
-		//for _, pkIdx := range tblStuff.def.pkColIdxes {
-		//	if _, ok := seenCols[pkIdx]; ok {
-		//		continue
-		//	}
-		//	vec := wrapped.batch.Vecs[pkIdx]
-		//	if vec.GetNulls().Contains(uint64(rowIdx)) {
-		//		row[pkIdx] = nil
-		//		continue
-		//	}
-		//
-		//	switch vec.GetType().Oid {
-		//	case types.T_datetime, types.T_timestamp, types.T_decimal64,
-		//		types.T_decimal128, types.T_time:
-		//		bb := vec.GetRawBytesAt(rowIdx)
-		//		row[pkIdx] = types.DecodeValue(bb, vec.GetType().Oid)
-		//	default:
-		//		if err = extractRowFromVector(
-		//			ctx, ses, vec, pkIdx, row, rowIdx, false,
-		//		); err != nil {
-		//			return
-		//		}
-		//	}
-		//}
-
-		tmpValsBuffer.Reset()
-		if wrapped.kind == diffDelete {
-			if appender.deleteByFullRow {
-				if err = writeDeleteRowSQLFull(ctx, ses, tblStuff, row, tmpValsBuffer); err != nil {
-					return
-				}
-			} else if appender.pkInfo != nil {
-				if err = writeDeleteRowValuesAsTuple(ses, tblStuff, row, tmpValsBuffer); err != nil {
-					return
-				}
-			} else {
-				if err = writeDeleteRowValues(ses, tblStuff, row, tmpValsBuffer); err != nil {
-					return
-				}
-			}
-		} else {
-			if err = writeInsertRowValues(ses, tblStuff, row, tmpValsBuffer); err != nil {
-				return
-			}
-		}
-
-		if tmpValsBuffer.Len() == 0 {
-			continue
-		}
-
-		if err = appender.appendRow(wrapped.kind, tmpValsBuffer.Bytes()); err != nil {
+		if err = appendDataBranchApplyRowAsSQLValues(
+			ctx, ses, tblStuff, wrapped.kind, row, tmpValsBuffer, appender,
+		); err != nil {
 			return
 		}
 	}
@@ -1109,8 +1257,10 @@ func prepareFSForDiffAsFile(
 
 	sqlRetHint = fmt.Sprintf(
 		"DELETE FROM %s.%s, INSERT INTO %s.%s",
-		tblStuff.baseRel.GetTableDef(ctx).DbName, tblStuff.baseRel.GetTableName(),
-		tblStuff.baseRel.GetTableDef(ctx).DbName, tblStuff.baseRel.GetTableName(),
+		tblStuff.baseRel.GetTableDef(ctx).DbName,
+		tblStuff.baseRel.GetTableName(),
+		tblStuff.baseRel.GetTableDef(ctx).DbName,
+		tblStuff.baseRel.GetTableName(),
 	)
 
 	var (
@@ -1293,7 +1443,7 @@ func tryFlushDeletesOrInserts(
 	newValsLen int,
 	newRowCnt int,
 	deleteByFullRow bool,
-	pkInfo *pkBatchInfo,
+	batchInfo *applyBatchInfo,
 	deleteCnt *int,
 	deletesBuf *bytes.Buffer,
 	insertCnt *int,
@@ -1303,7 +1453,7 @@ func tryFlushDeletesOrInserts(
 
 	flushDeletes := func() error {
 		if err = flushSqlValues(
-			ctx, ses, bh, tblStuff, deletesBuf, true, deleteByFullRow, pkInfo, writeFile,
+			ctx, ses, bh, tblStuff, deletesBuf, true, deleteByFullRow, batchInfo, writeFile,
 		); err != nil {
 			return err
 		}
@@ -1315,7 +1465,7 @@ func tryFlushDeletesOrInserts(
 
 	flushInserts := func() error {
 		if err = flushSqlValues(
-			ctx, ses, bh, tblStuff, insertBuf, false, false, pkInfo, writeFile,
+			ctx, ses, bh, tblStuff, insertBuf, false, false, batchInfo, writeFile,
 		); err != nil {
 			return err
 		}
@@ -1361,60 +1511,25 @@ func tryFlushDeletesOrInserts(
 	return nil
 }
 
-type pkBatchInfo struct {
-	dbName       string
-	baseTable    string
-	deleteTable  string
-	insertTable  string
-	pkNames      []string
-	visibleNames []string
-}
-
-func newPKBatchInfo(ctx context.Context, ses *Session, tblStuff tableStuff) *pkBatchInfo {
-	if tblStuff.def.pkKind == fakeKind {
-		return nil
-	}
-
-	pkNames := make([]string, len(tblStuff.def.pkColIdxes))
-	for i, idx := range tblStuff.def.pkColIdxes {
-		pkNames[i] = tblStuff.def.colNames[idx]
-	}
-
-	visibleNames := make([]string, len(tblStuff.def.visibleIdxes))
-	for i, idx := range tblStuff.def.visibleIdxes {
-		visibleNames[i] = tblStuff.def.colNames[idx]
-	}
-
-	seq := atomic.AddUint64(&diffTempTableSeq, 1)
-	sessionTag := strings.ReplaceAll(ses.GetUUIDString(), "-", "")
-	return &pkBatchInfo{
-		dbName:       tblStuff.baseRel.GetTableDef(ctx).DbName,
-		baseTable:    tblStuff.baseRel.GetTableName(),
-		deleteTable:  fmt.Sprintf("__mo_diff_del_%s_%d", sessionTag, seq),
-		insertTable:  fmt.Sprintf("__mo_diff_ins_%s_%d", sessionTag, seq),
-		pkNames:      pkNames,
-		visibleNames: visibleNames,
-	}
-}
-
 type sqlValuesAppender struct {
-	ctx             context.Context
-	ses             *Session
-	bh              BackgroundExec
-	tblStuff        tableStuff
-	deleteByFullRow bool
-	pkInfo          *pkBatchInfo
-	deleteCnt       *int
-	deleteBuf       *bytes.Buffer
-	insertCnt       *int
-	insertBuf       *bytes.Buffer
-	writeFile       func([]byte) error
+	ctx               context.Context
+	ses               *Session
+	bh                BackgroundExec
+	tblStuff          tableStuff
+	deleteByFullRow   bool
+	deleteKeyColIdxes []int
+	batchInfo         *applyBatchInfo
+	deleteCnt         *int
+	deleteBuf         *bytes.Buffer
+	insertCnt         *int
+	insertBuf         *bytes.Buffer
+	writeFile         func([]byte) error
 }
 
 func (sva sqlValuesAppender) flushAll() error {
 	return tryFlushDeletesOrInserts(
 		sva.ctx, sva.ses, sva.bh, sva.tblStuff, "",
-		0, 0, sva.deleteByFullRow, sva.pkInfo, sva.deleteCnt, sva.deleteBuf, sva.insertCnt, sva.insertBuf, sva.writeFile,
+		0, 0, sva.deleteByFullRow, sva.batchInfo, sva.deleteCnt, sva.deleteBuf, sva.insertCnt, sva.insertBuf, sva.writeFile,
 	)
 }
 
@@ -1438,28 +1553,33 @@ func writeInsertRowValues(
 	return nil
 }
 
+func quotedColumnNamesByIdxes(tblStuff tableStuff, idxes []int) []string {
+	names := make([]string, len(idxes))
+	for i, idx := range idxes {
+		names[i] = quoteIdentifierForSQL(tblStuff.def.colNames[idx])
+	}
+	return names
+}
+
+func quotedColumnNames(names []string) []string {
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = quoteIdentifierForSQL(name)
+	}
+	return quoted
+}
+
+func joinQuotedColumnNames(names []string) string {
+	return strings.Join(quotedColumnNames(names), ",")
+}
+
 func writeDeleteRowValues(
 	ses *Session,
 	tblStuff tableStuff,
 	row []any,
 	buf *bytes.Buffer,
 ) error {
-	if len(tblStuff.def.pkColIdxes) > 1 {
-		buf.WriteString("(")
-	}
-	for i, colIdx := range tblStuff.def.pkColIdxes {
-		if err := formatValIntoString(ses, row[colIdx], tblStuff.def.colTypes[colIdx], buf); err != nil {
-			return err
-		}
-		if i != len(tblStuff.def.pkColIdxes)-1 {
-			buf.WriteString(",")
-		}
-	}
-	if len(tblStuff.def.pkColIdxes) > 1 {
-		buf.WriteString(")")
-	}
-
-	return nil
+	return writeDeleteRowValuesWithColIdxes(ses, tblStuff, row, tblStuff.def.pkColIdxes, buf, false)
 }
 
 func writeDeleteRowValuesAsTuple(
@@ -1468,16 +1588,34 @@ func writeDeleteRowValuesAsTuple(
 	row []any,
 	buf *bytes.Buffer,
 ) error {
-	buf.WriteString("(")
-	for i, colIdx := range tblStuff.def.pkColIdxes {
+	return writeDeleteRowValuesWithColIdxes(ses, tblStuff, row, tblStuff.def.pkColIdxes, buf, true)
+}
+
+func writeDeleteRowValuesWithColIdxes(
+	ses *Session,
+	tblStuff tableStuff,
+	row []any,
+	colIdxes []int,
+	buf *bytes.Buffer,
+	alwaysTuple bool,
+) error {
+	if len(colIdxes) == 0 {
+		return moerr.NewInternalErrorNoCtx("data branch delete key columns are empty")
+	}
+	if alwaysTuple || len(colIdxes) > 1 {
+		buf.WriteString("(")
+	}
+	for i, colIdx := range colIdxes {
 		if err := formatValIntoString(ses, row[colIdx], tblStuff.def.colTypes[colIdx], buf); err != nil {
 			return err
 		}
-		if i != len(tblStuff.def.pkColIdxes)-1 {
+		if i != len(colIdxes)-1 {
 			buf.WriteString(",")
 		}
 	}
-	buf.WriteString(")")
+	if alwaysTuple || len(colIdxes) > 1 {
+		buf.WriteString(")")
+	}
 	return nil
 }
 
@@ -1494,7 +1632,7 @@ func (sva sqlValuesAppender) appendRow(kind string, rowValues []byte) error {
 			newValsLen := len(rowValues)
 			if err := tryFlushDeletesOrInserts(
 				sva.ctx, sva.ses, sva.bh, sva.tblStuff, kind, newValsLen, 1, sva.deleteByFullRow,
-				sva.pkInfo, sva.deleteCnt, sva.deleteBuf, sva.insertCnt, sva.insertBuf, sva.writeFile,
+				sva.batchInfo, sva.deleteCnt, sva.deleteBuf, sva.insertCnt, sva.insertBuf, sva.writeFile,
 			); err != nil {
 				return err
 			}
@@ -1515,7 +1653,7 @@ func (sva sqlValuesAppender) appendRow(kind string, rowValues []byte) error {
 
 	if err := tryFlushDeletesOrInserts(
 		sva.ctx, sva.ses, sva.bh, sva.tblStuff, kind, newValsLen, 1, sva.deleteByFullRow,
-		sva.pkInfo, sva.deleteCnt, sva.deleteBuf, sva.insertCnt, sva.insertBuf, sva.writeFile,
+		sva.batchInfo, sva.deleteCnt, sva.deleteBuf, sva.insertCnt, sva.insertBuf, sva.writeFile,
 	); err != nil {
 		return err
 	}
@@ -1529,7 +1667,7 @@ func (sva sqlValuesAppender) appendRow(kind string, rowValues []byte) error {
 }
 
 func qualifiedTableName(dbName, tableName string) string {
-	return fmt.Sprintf("%s.%s", dbName, tableName)
+	return fmt.Sprintf("%s.%s", quoteIdentifierForSQL(dbName), quoteIdentifierForSQL(tableName))
 }
 
 func execSQLStatements(
@@ -1560,51 +1698,66 @@ func execSQLStatements(
 	return nil
 }
 
-func initPKTables(
+func initApplyTables(
 	ctx context.Context,
 	ses *Session,
 	bh BackgroundExec,
-	pkInfo *pkBatchInfo,
+	batchInfo *applyBatchInfo,
 	writeFile func([]byte) error,
 ) error {
-	if pkInfo == nil {
+	if batchInfo == nil {
 		return nil
 	}
 
-	baseTable := qualifiedTableName(pkInfo.dbName, pkInfo.baseTable)
-	deleteTable := qualifiedTableName(pkInfo.dbName, pkInfo.deleteTable)
-	insertTable := qualifiedTableName(pkInfo.dbName, pkInfo.insertTable)
+	baseTable := qualifiedTableName(batchInfo.dbName, batchInfo.baseTable)
+	deleteTable := qualifiedTableName(batchInfo.dbName, batchInfo.deleteTable)
+	insertTable := qualifiedTableName(batchInfo.dbName, batchInfo.insertTable)
 
-	deleteCols := strings.Join(pkInfo.pkNames, ",")
-	insertCols := strings.Join(pkInfo.visibleNames, ",")
+	deleteStageNames := batchInfo.effectiveDeleteStageNames()
+	deleteSelectExprs := make([]string, len(batchInfo.deleteKeyNames))
+	for i := range batchInfo.deleteKeyNames {
+		deleteSelectExprs[i] = fmt.Sprintf(
+			"%s as %s",
+			quoteIdentifierForSQL(batchInfo.deleteKeyNames[i]),
+			quoteIdentifierForSQL(deleteStageNames[i]),
+		)
+	}
+	deleteCols := strings.Join(deleteSelectExprs, ",")
+	insertCols := joinQuotedColumnNames(batchInfo.visibleNames)
 
 	stmts := []string{
 		fmt.Sprintf("drop table if exists %s", deleteTable),
-		fmt.Sprintf("drop table if exists %s", insertTable),
 		fmt.Sprintf("create table %s as select %s from %s where 1=0", deleteTable, deleteCols, baseTable),
-		fmt.Sprintf("create table %s as select %s from %s where 1=0", insertTable, insertCols, baseTable),
+	}
+	if !batchInfo.disableInsertStage {
+		stmts = append(stmts,
+			fmt.Sprintf("drop table if exists %s", insertTable),
+			fmt.Sprintf("create table %s as select %s from %s where 1=0", insertTable, insertCols, baseTable),
+		)
 	}
 
 	return execSQLStatements(ctx, ses, bh, writeFile, stmts)
 }
 
-func dropPKTables(
+func dropApplyTables(
 	ctx context.Context,
 	ses *Session,
 	bh BackgroundExec,
-	pkInfo *pkBatchInfo,
+	batchInfo *applyBatchInfo,
 	writeFile func([]byte) error,
 ) error {
-	if pkInfo == nil {
+	if batchInfo == nil {
 		return nil
 	}
 
-	deleteTable := qualifiedTableName(pkInfo.dbName, pkInfo.deleteTable)
-	insertTable := qualifiedTableName(pkInfo.dbName, pkInfo.insertTable)
+	deleteTable := qualifiedTableName(batchInfo.dbName, batchInfo.deleteTable)
+	insertTable := qualifiedTableName(batchInfo.dbName, batchInfo.insertTable)
 
 	stmts := []string{
 		fmt.Sprintf("drop table if exists %s", deleteTable),
-		fmt.Sprintf("drop table if exists %s", insertTable),
+	}
+	if !batchInfo.disableInsertStage {
+		stmts = append(stmts, fmt.Sprintf("drop table if exists %s", insertTable))
 	}
 	return execSQLStatements(ctx, ses, bh, writeFile, stmts)
 }
@@ -1619,7 +1772,7 @@ func flushSqlValues(
 	buf *bytes.Buffer,
 	isDeleteFrom bool,
 	deleteByFullRow bool,
-	pkInfo *pkBatchInfo,
+	batchInfo *applyBatchInfo,
 	writeFile func([]byte) error,
 ) (err error) {
 
@@ -1648,33 +1801,36 @@ func flushSqlValues(
 		return nil
 	}
 
-	if pkInfo != nil {
-		baseTable := qualifiedTableName(pkInfo.dbName, pkInfo.baseTable)
-		deleteTable := qualifiedTableName(pkInfo.dbName, pkInfo.deleteTable)
-		insertTable := qualifiedTableName(pkInfo.dbName, pkInfo.insertTable)
+	if batchInfo != nil {
+		baseTable := qualifiedTableName(batchInfo.dbName, batchInfo.baseTable)
+		deleteTable := qualifiedTableName(batchInfo.dbName, batchInfo.deleteTable)
+		insertTable := qualifiedTableName(batchInfo.dbName, batchInfo.insertTable)
+		deleteStageNames := batchInfo.effectiveDeleteStageNames()
 
 		if isDeleteFrom {
 			insertStmt := fmt.Sprintf("insert into %s values %s", deleteTable, buf.String())
-			pkExpr := pkInfo.pkNames[0]
-			if len(pkInfo.pkNames) > 1 {
-				pkExpr = fmt.Sprintf("(%s)", strings.Join(pkInfo.pkNames, ","))
+			pkExpr := quoteIdentifierForSQL(batchInfo.deleteKeyNames[0])
+			if len(batchInfo.deleteKeyNames) > 1 {
+				pkExpr = fmt.Sprintf("(%s)", joinQuotedColumnNames(batchInfo.deleteKeyNames))
 			}
 			deleteStmt := fmt.Sprintf(
 				"delete from %s where %s in (select %s from %s)",
-				baseTable, pkExpr, strings.Join(pkInfo.pkNames, ","), deleteTable,
+				baseTable, pkExpr, joinQuotedColumnNames(deleteStageNames), deleteTable,
 			)
 			clearStmt := fmt.Sprintf("delete from %s", deleteTable)
 			return execSQLStatements(ctx, ses, bh, writeFile, []string{insertStmt, deleteStmt, clearStmt})
 		}
 
-		insertStmt := fmt.Sprintf("insert into %s values %s", insertTable, buf.String())
-		cols := strings.Join(pkInfo.visibleNames, ",")
-		applyStmt := fmt.Sprintf(
-			"insert into %s (%s) select %s from %s",
-			baseTable, cols, cols, insertTable,
-		)
-		clearStmt := fmt.Sprintf("delete from %s", insertTable)
-		return execSQLStatements(ctx, ses, bh, writeFile, []string{insertStmt, applyStmt, clearStmt})
+		if !batchInfo.disableInsertStage {
+			insertStmt := fmt.Sprintf("insert into %s values %s", insertTable, buf.String())
+			cols := joinQuotedColumnNames(batchInfo.visibleNames)
+			applyStmt := fmt.Sprintf(
+				"insert into %s (%s) select %s from %s",
+				baseTable, cols, cols, insertTable,
+			)
+			clearStmt := fmt.Sprintf("delete from %s", insertTable)
+			return execSQLStatements(ctx, ses, bh, writeFile, []string{insertStmt, applyStmt, clearStmt})
+		}
 	}
 
 	sqlBuffer := acquireBuffer(tblStuff.bufPool)
@@ -1682,29 +1838,33 @@ func flushSqlValues(
 
 	initInsertIntoBuf := func() {
 		sqlBuffer.WriteString(fmt.Sprintf(
-			"insert into %s.%s values ",
-			tblStuff.baseRel.GetTableDef(ctx).DbName,
-			tblStuff.baseRel.GetTableDef(ctx).Name,
+			"insert into %s (%s) values ",
+			qualifiedTableName(
+				tblStuff.baseRel.GetTableDef(ctx).DbName,
+				tblStuff.baseRel.GetTableDef(ctx).Name,
+			),
+			strings.Join(quotedColumnNamesByIdxes(tblStuff, tblStuff.def.visibleIdxes), ","),
 		))
 	}
 
 	initDeleteFromBuf := func() {
 		if len(tblStuff.def.pkColIdxes) == 1 {
 			sqlBuffer.WriteString(fmt.Sprintf(
-				"delete from %s.%s where %s in (",
-				tblStuff.baseRel.GetTableDef(ctx).DbName,
-				tblStuff.baseRel.GetTableDef(ctx).Name,
-				tblStuff.def.colNames[tblStuff.def.pkColIdx],
+				"delete from %s where %s in (",
+				qualifiedTableName(
+					tblStuff.baseRel.GetTableDef(ctx).DbName,
+					tblStuff.baseRel.GetTableDef(ctx).Name,
+				),
+				quoteIdentifierForSQL(tblStuff.def.colNames[tblStuff.def.pkColIdx]),
 			))
 		} else {
-			pkNames := make([]string, len(tblStuff.def.pkColIdxes))
-			for i, pkColIdx := range tblStuff.def.pkColIdxes {
-				pkNames[i] = tblStuff.def.colNames[pkColIdx]
-			}
+			pkNames := quotedColumnNamesByIdxes(tblStuff, tblStuff.def.pkColIdxes)
 			sqlBuffer.WriteString(fmt.Sprintf(
-				"delete from %s.%s where (%s) in (",
-				tblStuff.baseRel.GetTableDef(ctx).DbName,
-				tblStuff.baseRel.GetTableDef(ctx).Name,
+				"delete from %s where (%s) in (",
+				qualifiedTableName(
+					tblStuff.baseRel.GetTableDef(ctx).DbName,
+					tblStuff.baseRel.GetTableDef(ctx).Name,
+				),
 				strings.Join(pkNames, ","),
 			))
 		}

--- a/pkg/frontend/data_branch_output_test.go
+++ b/pkg/frontend/data_branch_output_test.go
@@ -51,7 +51,8 @@ func TestDataBranchOutputConfigAndQualifiedTableName(t *testing.T) {
 	require.Equal(t, "\n", cfg.Lines.TerminatedBy.Value)
 	require.False(t, cfg.Header)
 
-	require.Equal(t, "db.t", qualifiedTableName("db", "t"))
+	require.Equal(t, "`db`.`t`", qualifiedTableName("db", "t"))
+	require.Equal(t, "`d``b`.`t``1`", qualifiedTableName("d`b", "t`1"))
 }
 
 func TestDataBranchOutputMakeFileName(t *testing.T) {
@@ -456,6 +457,9 @@ func TestDataBranchOutputWriteRowValues(t *testing.T) {
 	alwaysTupleBuf := &bytes.Buffer{}
 	require.NoError(t, writeDeleteRowValuesAsTuple(nil, tblStuff, row, alwaysTupleBuf))
 	require.Equal(t, "(7,'alice')", alwaysTupleBuf.String())
+
+	emptyKeyBuf := &bytes.Buffer{}
+	require.Error(t, writeDeleteRowValuesWithColIdxes(nil, tblStuff, row, nil, emptyKeyBuf, false))
 }
 
 func TestDataBranchOutputWriteDeleteRowSQLFull(t *testing.T) {
@@ -478,7 +482,7 @@ func TestDataBranchOutputWriteDeleteRowSQLFull(t *testing.T) {
 	row := []any{int64(9), nil}
 	buf := &bytes.Buffer{}
 	require.NoError(t, writeDeleteRowSQLFull(context.Background(), nil, tblStuff, row, buf))
-	require.Equal(t, "delete from db1.t1 where id = 9 and name is null limit 1;\n", buf.String())
+	require.Equal(t, "delete from `db1`.`t1` where `id` = 9 and `name` is null limit 1;\n", buf.String())
 }
 
 func TestDataBranchOutputExecSQLStatementsWithWriteFile(t *testing.T) {
@@ -499,14 +503,15 @@ func TestDataBranchOutputExecSQLStatementsWithWriteFile(t *testing.T) {
 	require.Equal(t, "select 1;\ninsert into t values (1);\n", out.String())
 }
 
-func TestDataBranchOutputInitAndDropPKTablesWithWriteFile(t *testing.T) {
-	pkInfo := &pkBatchInfo{
-		dbName:       "db1",
-		baseTable:    "base_t",
-		deleteTable:  "__mo_diff_del_x",
-		insertTable:  "__mo_diff_ins_x",
-		pkNames:      []string{"id"},
-		visibleNames: []string{"id", "name"},
+func TestDataBranchOutputInitAndDropApplyTablesWithWriteFile(t *testing.T) {
+	batchInfo := &applyBatchInfo{
+		dbName:           "db1",
+		baseTable:        "base_t",
+		deleteTable:      "__mo_diff_del_x",
+		insertTable:      "__mo_diff_ins_x",
+		deleteKeyNames:   []string{"id"},
+		deleteStageNames: []string{"branch_apply_key_0"},
+		visibleNames:     []string{"id", "name"},
 	}
 
 	var out bytes.Buffer
@@ -515,14 +520,14 @@ func TestDataBranchOutputInitAndDropPKTablesWithWriteFile(t *testing.T) {
 		return err
 	}
 
-	require.NoError(t, initPKTables(context.Background(), nil, nil, pkInfo, writeFile))
-	require.NoError(t, dropPKTables(context.Background(), nil, nil, pkInfo, writeFile))
+	require.NoError(t, initApplyTables(context.Background(), nil, nil, batchInfo, writeFile))
+	require.NoError(t, dropApplyTables(context.Background(), nil, nil, batchInfo, writeFile))
 
 	got := out.String()
-	require.Contains(t, got, "drop table if exists db1.__mo_diff_del_x;\n")
-	require.Contains(t, got, "drop table if exists db1.__mo_diff_ins_x;\n")
-	require.Contains(t, got, "create table db1.__mo_diff_del_x as select id from db1.base_t where 1=0;\n")
-	require.Contains(t, got, "create table db1.__mo_diff_ins_x as select id,name from db1.base_t where 1=0;\n")
+	require.Contains(t, got, "drop table if exists `db1`.`__mo_diff_del_x`;\n")
+	require.Contains(t, got, "drop table if exists `db1`.`__mo_diff_ins_x`;\n")
+	require.Contains(t, got, "create table `db1`.`__mo_diff_del_x` as select `id` as `branch_apply_key_0` from `db1`.`base_t` where 1=0;\n")
+	require.Contains(t, got, "create table `db1`.`__mo_diff_ins_x` as select `id`,`name` from `db1`.`base_t` where 1=0;\n")
 }
 
 func TestDataBranchOutputFlushSqlValuesWithWriteFile(t *testing.T) {
@@ -539,16 +544,18 @@ func TestDataBranchOutputFlushSqlValuesWithWriteFile(t *testing.T) {
 		baseRel: baseRel,
 	}
 	tblStuff.def.colNames = []string{"id", "name"}
+	tblStuff.def.visibleIdxes = []int{0, 1}
 	tblStuff.def.pkColIdx = 0
 	tblStuff.def.pkColIdxes = []int{0, 1}
 
-	pkInfo := &pkBatchInfo{
-		dbName:       "db1",
-		baseTable:    "t1",
-		deleteTable:  "__mo_diff_del_x",
-		insertTable:  "__mo_diff_ins_x",
-		pkNames:      []string{"id", "name"},
-		visibleNames: []string{"id", "name"},
+	batchInfo := &applyBatchInfo{
+		dbName:           "db1",
+		baseTable:        "t1",
+		deleteTable:      "__mo_diff_del_x",
+		insertTable:      "__mo_diff_ins_x",
+		deleteKeyNames:   []string{"id", "name"},
+		deleteStageNames: []string{"branch_apply_key_0", "branch_apply_key_1"},
+		visibleNames:     []string{"id", "name"},
 	}
 
 	var out bytes.Buffer
@@ -577,7 +584,7 @@ func TestDataBranchOutputFlushSqlValuesWithWriteFile(t *testing.T) {
 		bytes.NewBufferString("(1,'a')"),
 		true,
 		false,
-		pkInfo,
+		batchInfo,
 		writeFile,
 	))
 
@@ -595,19 +602,19 @@ func TestDataBranchOutputFlushSqlValuesWithWriteFile(t *testing.T) {
 
 	got := out.String()
 	require.Contains(t, got, "delete from db1.t1 where id = 1 limit 1;\n")
-	require.Contains(t, got, "insert into db1.__mo_diff_del_x values (1,'a');\n")
-	require.Contains(t, got, "delete from db1.t1 where (id,name) in (select id,name from db1.__mo_diff_del_x);\n")
-	require.Contains(t, got, "insert into db1.t1 values (2,'b');\n")
+	require.Contains(t, got, "insert into `db1`.`__mo_diff_del_x` values (1,'a');\n")
+	require.Contains(t, got, "delete from `db1`.`t1` where (`id`,`name`) in (select `branch_apply_key_0`,`branch_apply_key_1` from `db1`.`__mo_diff_del_x`);\n")
+	require.Contains(t, got, "insert into `db1`.`t1` (`id`,`name`) values (2,'b');\n")
 }
 
 func TestDataBranchOutputTryFlushDeletesOrInserts(t *testing.T) {
-	pkInfo := &pkBatchInfo{
-		dbName:       "db1",
-		baseTable:    "t1",
-		deleteTable:  "__mo_diff_del_x",
-		insertTable:  "__mo_diff_ins_x",
-		pkNames:      []string{"id"},
-		visibleNames: []string{"id", "name"},
+	batchInfo := &applyBatchInfo{
+		dbName:         "db1",
+		baseTable:      "t1",
+		deleteTable:    "__mo_diff_del_x",
+		insertTable:    "__mo_diff_ins_x",
+		deleteKeyNames: []string{"id"},
+		visibleNames:   []string{"id", "name"},
 	}
 
 	t.Run("force flush both buffers", func(t *testing.T) {
@@ -631,7 +638,7 @@ func TestDataBranchOutputTryFlushDeletesOrInserts(t *testing.T) {
 			0,
 			0,
 			false,
-			pkInfo,
+			batchInfo,
 			&deleteCnt,
 			deleteBuf,
 			&insertCnt,
@@ -643,8 +650,8 @@ func TestDataBranchOutputTryFlushDeletesOrInserts(t *testing.T) {
 		require.Equal(t, 0, insertCnt)
 		require.Equal(t, 0, deleteBuf.Len())
 		require.Equal(t, 0, insertBuf.Len())
-		require.Contains(t, out.String(), "delete from db1.t1 where id in (select id from db1.__mo_diff_del_x);\n")
-		require.Contains(t, out.String(), "insert into db1.t1 (id,name) select id,name from db1.__mo_diff_ins_x;\n")
+		require.Contains(t, out.String(), "delete from `db1`.`t1` where `id` in (select `id` from `db1`.`__mo_diff_del_x`);\n")
+		require.Contains(t, out.String(), "insert into `db1`.`t1` (`id`,`name`) select `id`,`name` from `db1`.`__mo_diff_ins_x`;\n")
 	})
 
 	t.Run("do nothing when thresholds are not reached", func(t *testing.T) {
@@ -668,7 +675,7 @@ func TestDataBranchOutputTryFlushDeletesOrInserts(t *testing.T) {
 			1,
 			1,
 			false,
-			pkInfo,
+			batchInfo,
 			&deleteCnt,
 			deleteBuf,
 			&insertCnt,
@@ -700,7 +707,7 @@ func TestDataBranchOutputTryFlushDeletesOrInserts(t *testing.T) {
 			1,
 			1,
 			false,
-			pkInfo,
+			batchInfo,
 			&deleteCnt,
 			deleteBuf,
 			&insertCnt,
@@ -710,15 +717,15 @@ func TestDataBranchOutputTryFlushDeletesOrInserts(t *testing.T) {
 		require.NoError(t, err)
 
 		got := out.String()
-		deletePos := strings.Index(got, "insert into db1.__mo_diff_del_x")
-		insertPos := strings.Index(got, "insert into db1.__mo_diff_ins_x")
+		deletePos := strings.Index(got, "insert into `db1`.`__mo_diff_del_x`")
+		insertPos := strings.Index(got, "insert into `db1`.`__mo_diff_ins_x`")
 		require.NotEqual(t, -1, deletePos)
 		require.NotEqual(t, -1, insertPos)
 		require.Less(t, deletePos, insertPos)
 	})
 }
 
-func TestDataBranchOutputNewPKBatchInfo(t *testing.T) {
+func TestDataBranchOutputBuildDataBranchApplyLayout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -737,27 +744,49 @@ func TestDataBranchOutputNewPKBatchInfo(t *testing.T) {
 	tblStuff.def.visibleIdxes = []int{0, 1, 2}
 	tblStuff.def.pkKind = normalKind
 
-	info := newPKBatchInfo(context.Background(), &Session{}, tblStuff)
+	deleteByFullRow, deleteKeyColIdxes, info := buildDataBranchApplyLayout(
+		context.Background(), &Session{}, tblStuff, dataBranchApplyModeOnline,
+	)
+	require.False(t, deleteByFullRow)
+	require.Equal(t, []int{0, 2}, deleteKeyColIdxes)
 	require.NotNil(t, info)
 	require.Equal(t, "db1", info.dbName)
 	require.Equal(t, "t1", info.baseTable)
-	require.Equal(t, []string{"id", "age"}, info.pkNames)
+	require.Equal(t, []string{"id", "age"}, info.deleteKeyNames)
+	require.Equal(t, []string{"branch_apply_key_0", "branch_apply_key_1"}, info.deleteStageNames)
 	require.Equal(t, []string{"id", "name", "age"}, info.visibleNames)
+	require.False(t, info.disableInsertStage)
 	require.True(t, strings.HasPrefix(info.deleteTable, "__mo_diff_del_"))
 	require.True(t, strings.HasPrefix(info.insertTable, "__mo_diff_ins_"))
 
-	tblStuff.def.pkKind = fakeKind
-	require.Nil(t, newPKBatchInfo(context.Background(), &Session{}, tblStuff))
+	fakeTblStuff := newFakePKBranchTableStuff(ctrl)
+	deleteByFullRow, deleteKeyColIdxes, info = buildDataBranchApplyLayout(
+		context.Background(), &Session{}, fakeTblStuff, dataBranchApplyModeOnline,
+	)
+	require.False(t, deleteByFullRow)
+	require.Equal(t, []int{2}, deleteKeyColIdxes)
+	require.NotNil(t, info)
+	require.Equal(t, []string{"__mo_fake_pk_col"}, info.deleteKeyNames)
+	require.Equal(t, []string{"branch_apply_key_0"}, info.deleteStageNames)
+	require.Equal(t, []string{"id", "name"}, info.visibleNames)
+	require.True(t, info.disableInsertStage)
+
+	deleteByFullRow, deleteKeyColIdxes, info = buildDataBranchApplyLayout(
+		context.Background(), &Session{}, fakeTblStuff, dataBranchApplyModePortableSQL,
+	)
+	require.True(t, deleteByFullRow)
+	require.Nil(t, deleteKeyColIdxes)
+	require.Nil(t, info)
 }
 
 func TestDataBranchOutputAppenderAppendRowAndFlushAll(t *testing.T) {
-	pkInfo := &pkBatchInfo{
-		dbName:       "db1",
-		baseTable:    "t1",
-		deleteTable:  "__mo_diff_del_x",
-		insertTable:  "__mo_diff_ins_x",
-		pkNames:      []string{"id"},
-		visibleNames: []string{"id", "name"},
+	batchInfo := &applyBatchInfo{
+		dbName:         "db1",
+		baseTable:      "t1",
+		deleteTable:    "__mo_diff_del_x",
+		insertTable:    "__mo_diff_ins_x",
+		deleteKeyNames: []string{"id"},
+		visibleNames:   []string{"id", "name"},
 	}
 
 	t.Run("append delete in full-row mode", func(t *testing.T) {
@@ -769,7 +798,7 @@ func TestDataBranchOutputAppenderAppendRowAndFlushAll(t *testing.T) {
 		appender := sqlValuesAppender{
 			ctx:             context.Background(),
 			deleteByFullRow: true,
-			pkInfo:          pkInfo,
+			batchInfo:       batchInfo,
 			deleteCnt:       &deleteCnt,
 			deleteBuf:       deleteBuf,
 			insertCnt:       &insertCnt,
@@ -791,7 +820,7 @@ func TestDataBranchOutputAppenderAppendRowAndFlushAll(t *testing.T) {
 		appender := sqlValuesAppender{
 			ctx:             context.Background(),
 			deleteByFullRow: false,
-			pkInfo:          pkInfo,
+			batchInfo:       batchInfo,
 			deleteCnt:       &deleteCnt,
 			deleteBuf:       deleteBuf,
 			insertCnt:       &insertCnt,
@@ -818,7 +847,7 @@ func TestDataBranchOutputAppenderAppendRowAndFlushAll(t *testing.T) {
 		appender := sqlValuesAppender{
 			ctx:             context.Background(),
 			deleteByFullRow: false,
-			pkInfo:          pkInfo,
+			batchInfo:       batchInfo,
 			deleteCnt:       &deleteCnt,
 			deleteBuf:       deleteBuf,
 			insertCnt:       &insertCnt,
@@ -831,8 +860,8 @@ func TestDataBranchOutputAppenderAppendRowAndFlushAll(t *testing.T) {
 		require.Equal(t, 0, insertCnt)
 		require.Equal(t, 0, deleteBuf.Len())
 		require.Equal(t, 0, insertBuf.Len())
-		require.Contains(t, out.String(), "insert into db1.__mo_diff_del_x values (1);")
-		require.Contains(t, out.String(), "insert into db1.__mo_diff_ins_x values (1,'a');")
+		require.Contains(t, out.String(), "insert into `db1`.`__mo_diff_del_x` values (1);")
+		require.Contains(t, out.String(), "insert into `db1`.`__mo_diff_ins_x` values (1,'a');")
 	})
 }
 
@@ -946,12 +975,13 @@ func TestDataBranchOutputAppendBatchRowsAsSQLValues(t *testing.T) {
 		deleteBuf := &bytes.Buffer{}
 		insertBuf := &bytes.Buffer{}
 		appender := sqlValuesAppender{
-			ctx:       context.Background(),
-			tblStuff:  tblStuff,
-			deleteCnt: &deleteCnt,
-			deleteBuf: deleteBuf,
-			insertCnt: &insertCnt,
-			insertBuf: insertBuf,
+			ctx:               context.Background(),
+			tblStuff:          tblStuff,
+			deleteKeyColIdxes: []int{0},
+			deleteCnt:         &deleteCnt,
+			deleteBuf:         deleteBuf,
+			insertCnt:         &insertCnt,
+			insertBuf:         insertBuf,
 		}
 
 		insertBat := buildVisibleComparisonBatch(t, ses.proc.Mp(), [][]any{
@@ -996,12 +1026,13 @@ func TestDataBranchOutputAppendBatchRowsAsSQLValues(t *testing.T) {
 		deleteBuf := &bytes.Buffer{}
 		insertBuf := &bytes.Buffer{}
 		appender := sqlValuesAppender{
-			ctx:       context.Background(),
-			tblStuff:  tblStuff,
-			deleteCnt: &deleteCnt,
-			deleteBuf: deleteBuf,
-			insertCnt: &insertCnt,
-			insertBuf: insertBuf,
+			ctx:               context.Background(),
+			tblStuff:          tblStuff,
+			deleteKeyColIdxes: []int{0},
+			deleteCnt:         &deleteCnt,
+			deleteBuf:         deleteBuf,
+			insertCnt:         &insertCnt,
+			insertBuf:         insertBuf,
 		}
 
 		bat := batch.NewWithSize(2)
@@ -1026,4 +1057,215 @@ func TestDataBranchOutputAppendBatchRowsAsSQLValues(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "batch shape mismatch")
 	})
+}
+
+func TestDataBranchOutputNoPKDeleteModes(t *testing.T) {
+	ses := newValidateSession(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tblStuff := newFakePKBranchTableStuff(ctrl)
+
+	t.Run("online merge deletes by fake pk", func(t *testing.T) {
+		var out bytes.Buffer
+		writeFile := func(b []byte) error {
+			_, err := out.Write(b)
+			return err
+		}
+
+		tmpValsBuffer := &bytes.Buffer{}
+		deleteCnt := 0
+		insertCnt := 0
+		deleteBuf := &bytes.Buffer{}
+		insertBuf := &bytes.Buffer{}
+		appender := newSQLValuesAppender(
+			context.Background(),
+			ses,
+			nil,
+			tblStuff,
+			dataBranchApplyModeOnline,
+			&deleteCnt,
+			deleteBuf,
+			&insertCnt,
+			insertBuf,
+			writeFile,
+		)
+
+		deleteBat := buildFakePKComparisonBatch(t, ses.proc.Mp(), [][]any{
+			{int64(1), "alpha", uint64(101)},
+			{int64(2), "beta", uint64(202)},
+		})
+		defer deleteBat.Clean(ses.proc.Mp())
+
+		require.NoError(t, appendBatchRowsAsSQLValues(
+			context.Background(),
+			ses,
+			tblStuff,
+			batchWithKind{kind: diffDelete, batch: deleteBat},
+			tmpValsBuffer,
+			appender,
+		))
+		require.Equal(t, 2, deleteCnt)
+		require.Equal(t, "(101),(202)", deleteBuf.String())
+		require.True(t, appender.batchInfo.disableInsertStage)
+		require.NoError(t, appender.flushAll())
+
+		got := out.String()
+		require.Contains(t, got, "insert into `db1`.`__mo_diff_del_")
+		require.Contains(t, got, "values (101),(202);")
+		require.Equal(t, []string{"branch_apply_key_0"}, appender.batchInfo.deleteStageNames)
+		require.Contains(t, got, "delete from `db1`.`base` where `__mo_fake_pk_col` in (select `branch_apply_key_0` from `db1`.`__mo_diff_del_")
+		require.NotContains(t, got, "delete from `db1`.`base` where `id` =")
+	})
+
+	t.Run("portable sql deletes by full row", func(t *testing.T) {
+		tmpValsBuffer := &bytes.Buffer{}
+		deleteCnt := 0
+		insertCnt := 0
+		deleteBuf := &bytes.Buffer{}
+		insertBuf := &bytes.Buffer{}
+		appender := newSQLValuesAppender(
+			context.Background(),
+			ses,
+			nil,
+			tblStuff,
+			dataBranchApplyModePortableSQL,
+			&deleteCnt,
+			deleteBuf,
+			&insertCnt,
+			insertBuf,
+			nil,
+		)
+
+		deleteBat := buildFakePKComparisonBatch(t, ses.proc.Mp(), [][]any{
+			{int64(1), "alpha", uint64(101)},
+			{int64(2), "beta", uint64(202)},
+		})
+		defer deleteBat.Clean(ses.proc.Mp())
+
+		require.NoError(t, appendBatchRowsAsSQLValues(
+			context.Background(),
+			ses,
+			tblStuff,
+			batchWithKind{kind: diffDelete, batch: deleteBat},
+			tmpValsBuffer,
+			appender,
+		))
+		require.True(t, appender.deleteByFullRow)
+		require.Nil(t, appender.batchInfo)
+		require.Equal(t, 2, deleteCnt)
+		require.Contains(t, deleteBuf.String(), "delete from `db1`.`base` where `id` = 1 and `name` = 'alpha' limit 1;\n")
+		require.Contains(t, deleteBuf.String(), "delete from `db1`.`base` where `id` = 2 and `name` = 'beta' limit 1;\n")
+		require.NotContains(t, deleteBuf.String(), "__mo_fake_pk_col")
+	})
+
+	t.Run("online merge inserts keep direct insert path", func(t *testing.T) {
+		var out bytes.Buffer
+		writeFile := func(b []byte) error {
+			_, err := out.Write(b)
+			return err
+		}
+
+		tmpValsBuffer := &bytes.Buffer{}
+		deleteCnt := 0
+		insertCnt := 0
+		deleteBuf := &bytes.Buffer{}
+		insertBuf := &bytes.Buffer{}
+		appender := newSQLValuesAppender(
+			context.Background(),
+			ses,
+			nil,
+			tblStuff,
+			dataBranchApplyModeOnline,
+			&deleteCnt,
+			deleteBuf,
+			&insertCnt,
+			insertBuf,
+			writeFile,
+		)
+
+		insertBat := buildFakePKInsertBatchWithoutFakePKValue(t, ses.proc.Mp(), [][]any{
+			{int64(3), "gamma"},
+		})
+		defer insertBat.Clean(ses.proc.Mp())
+
+		require.NoError(t, appendBatchRowsAsSQLValues(
+			context.Background(),
+			ses,
+			tblStuff,
+			batchWithKind{kind: diffInsert, batch: insertBat},
+			tmpValsBuffer,
+			appender,
+		))
+		require.True(t, appender.batchInfo.disableInsertStage)
+		require.NoError(t, appender.flushAll())
+		require.Contains(t, out.String(), "insert into `db1`.`base` (`id`,`name`) values (3,'gamma');")
+		require.NotContains(t, out.String(), "__mo_diff_ins_")
+	})
+}
+
+func newFakePKBranchTableStuff(ctrl *gomock.Controller) tableStuff {
+	baseRel := mock_frontend.NewMockRelation(ctrl)
+	baseDef := &plan.TableDef{
+		DbName: "db1",
+		Name:   "base",
+		Pkey: &plan.PrimaryKeyDef{
+			Names:       []string{"__mo_fake_pk_col"},
+			PkeyColName: "__mo_fake_pk_col",
+		},
+	}
+
+	baseRel.EXPECT().GetTableName().Return("base").AnyTimes()
+	baseRel.EXPECT().GetTableDef(gomock.Any()).Return(baseDef).AnyTimes()
+
+	var tblStuff tableStuff
+	tblStuff.baseRel = baseRel
+	tblStuff.def.colNames = []string{"id", "name", "__mo_fake_pk_col"}
+	tblStuff.def.colTypes = []types.Type{
+		types.T_int64.ToType(),
+		types.T_varchar.ToType(),
+		types.T_uint64.ToType(),
+	}
+	tblStuff.def.visibleIdxes = []int{0, 1}
+	tblStuff.def.pkColIdx = 2
+	tblStuff.def.pkColIdxes = []int{0, 1}
+	tblStuff.def.pkKind = fakeKind
+	return tblStuff
+}
+
+func buildFakePKComparisonBatch(t *testing.T, mp *mpool.MPool, rows [][]any) *batch.Batch {
+	t.Helper()
+
+	bat := batch.NewWithSize(3)
+	bat.SetAttributes([]string{"id", "name", "__mo_fake_pk_col"})
+	bat.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat.Vecs[2] = vector.NewVec(types.T_uint64.ToType())
+
+	for _, row := range rows {
+		require.Len(t, row, 3)
+		require.NoError(t, vector.AppendFixed(bat.Vecs[0], row[0].(int64), false, mp))
+		require.NoError(t, vector.AppendBytes(bat.Vecs[1], []byte(row[1].(string)), false, mp))
+		require.NoError(t, vector.AppendFixed(bat.Vecs[2], row[2].(uint64), false, mp))
+	}
+	bat.SetRowCount(len(rows))
+	return bat
+}
+
+func buildFakePKInsertBatchWithoutFakePKValue(t *testing.T, mp *mpool.MPool, rows [][]any) *batch.Batch {
+	t.Helper()
+
+	bat := batch.NewWithSize(3)
+	bat.SetAttributes([]string{"id", "name", "__mo_fake_pk_col"})
+	bat.Vecs[0] = vector.NewVec(types.T_int64.ToType())
+	bat.Vecs[1] = vector.NewVec(types.T_varchar.ToType())
+	bat.Vecs[2] = vector.NewVec(types.T_uint64.ToType())
+
+	for _, row := range rows {
+		require.Len(t, row, 2)
+		require.NoError(t, vector.AppendFixed(bat.Vecs[0], row[0].(int64), false, mp))
+		require.NoError(t, vector.AppendBytes(bat.Vecs[1], []byte(row[1].(string)), false, mp))
+	}
+	bat.SetRowCount(len(rows))
+	return bat
 }

--- a/pkg/frontend/data_branch_pick.go
+++ b/pkg/frontend/data_branch_pick.go
@@ -170,23 +170,15 @@ func pickMergeDiffs(
 		skipSet = make(map[string]struct{})
 	}
 
-	appender := sqlValuesAppender{
-		ctx:             ctx,
-		ses:             ses,
-		bh:              bh,
-		tblStuff:        tblStuff,
-		deleteByFullRow: tblStuff.def.pkKind == fakeKind,
-		pkInfo:          newPKBatchInfo(ctx, ses, tblStuff),
-		deleteCnt:       &deleteCnt,
-		deleteBuf:       deleteFromVals,
-		insertCnt:       &insertCnt,
-		insertBuf:       insertIntoVals,
-	}
-	if err = initPKTables(ctx, ses, bh, appender.pkInfo, appender.writeFile); err != nil {
+	appender := newSQLValuesAppender(
+		ctx, ses, bh, tblStuff, dataBranchApplyModeOnline,
+		&deleteCnt, deleteFromVals, &insertCnt, insertIntoVals, nil,
+	)
+	if err = initApplyTables(ctx, ses, bh, appender.batchInfo, appender.writeFile); err != nil {
 		return err
 	}
 	defer func() {
-		if err2 := dropPKTables(ctx, ses, bh, appender.pkInfo, appender.writeFile); err2 != nil && err == nil {
+		if err2 := dropApplyTables(ctx, ses, bh, appender.batchInfo, appender.writeFile); err2 != nil && err == nil {
 			err = err2
 		}
 	}()
@@ -307,46 +299,15 @@ func appendPickedBatchRows(
 			}
 		}
 
-		// Row is in KEYS set and passed conflict checks — extract all visible column values.
-		for _, colIdx := range tblStuff.def.visibleIdxes {
-			vec := wrapped.batch.Vecs[colIdx]
-			if rowIdx >= vec.Length() {
-				return moerr.NewInternalErrorNoCtxf(
-					"data branch pick batch shape mismatch: row=%d batchRows=%d col=%d vecLen=%d",
-					rowIdx, wrapped.batch.RowCount(), colIdx, vec.Length(),
-				)
-			}
-			if err = extractDataBranchSQLRowValue(ctx, ses, vec, colIdx, row, rowIdx); err != nil {
-				return
-			}
+		if err = extractDataBranchApplyRow(
+			ctx, ses, tblStuff, wrapped.batch, rowIdx, appender.extraColIdxesForRow(wrapped.kind), row,
+			"data branch pick batch shape mismatch",
+		); err != nil {
+			return
 		}
-
-		tmpValsBuffer.Reset()
-		if wrapped.kind == diffDelete {
-			if appender.deleteByFullRow {
-				if err = writeDeleteRowSQLFull(ctx, ses, tblStuff, row, tmpValsBuffer); err != nil {
-					return
-				}
-			} else if appender.pkInfo != nil {
-				if err = writeDeleteRowValuesAsTuple(ses, tblStuff, row, tmpValsBuffer); err != nil {
-					return
-				}
-			} else {
-				if err = writeDeleteRowValues(ses, tblStuff, row, tmpValsBuffer); err != nil {
-					return
-				}
-			}
-		} else {
-			if err = writeInsertRowValues(ses, tblStuff, row, tmpValsBuffer); err != nil {
-				return
-			}
-		}
-
-		if tmpValsBuffer.Len() == 0 {
-			continue
-		}
-
-		if err = appender.appendRow(wrapped.kind, tmpValsBuffer.Bytes()); err != nil {
+		if err = appendDataBranchApplyRowAsSQLValues(
+			ctx, ses, tblStuff, wrapped.kind, row, tmpValsBuffer, appender,
+		); err != nil {
 			return
 		}
 	}

--- a/pkg/frontend/data_branch_test.go
+++ b/pkg/frontend/data_branch_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/matrixorigin/matrixone/pkg/catalog"
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/config"
@@ -30,10 +31,19 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/container/vector"
 	"github.com/matrixorigin/matrixone/pkg/defines"
 	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/stage"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDataBranchUserVisibleColumn(t *testing.T) {
+	require.True(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: "tenant"}))
+	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: catalog.FakePrimaryKeyColName, Hidden: true}))
+	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: catalog.CPrimaryKeyColName, Hidden: true}))
+	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: "__mo_cbkey_006tenant003seq", Hidden: true}))
+	require.False(t, isDataBranchUserVisibleColumn(&plan.ColDef{Name: catalog.Row_ID, Hidden: true}))
+}
 
 func TestFormatValIntoString_StringEscaping(t *testing.T) {
 	var buf bytes.Buffer

--- a/pkg/frontend/data_branch_types.go
+++ b/pkg/frontend/data_branch_types.go
@@ -48,7 +48,14 @@ const (
 	diffSideBase
 )
 
+const (
+	dataBranchApplyModeOnline dataBranchApplyMode = iota
+	dataBranchApplyModePortableSQL
+)
+
 const dataBranchHashmapLimitRate = 0.8
+
+type dataBranchApplyMode int
 
 type branchHashmapAllocator struct {
 	upstream  malloc.Allocator

--- a/pkg/tests/dml/dml_test.go
+++ b/pkg/tests/dml/dml_test.go
@@ -215,7 +215,7 @@ func runSinglePKWithBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
 
 	sqlContent := readSQLFile(t, diffPath)
 	lowerContent := strings.ToLower(sqlContent)
-	require.Contains(t, lowerContent, fmt.Sprintf("insert into %s.%s", strings.ToLower(dbName), base))
+	require.Contains(t, lowerContent, "insert into "+diffSQLTable(dbName, base))
 
 	applyDiffStatements(t, ctx, db, sqlContent)
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
@@ -255,8 +255,8 @@ func runMultiPKWithBase(t *testing.T, parentCtx context.Context, db *sql.DB) {
 
 	sqlContent := readSQLFile(t, diffPath)
 	lowerContent := strings.ToLower(sqlContent)
-	require.Contains(t, lowerContent, fmt.Sprintf("insert into %s.%s", strings.ToLower(dbName), base))
-	require.Contains(t, lowerContent, fmt.Sprintf("delete from %s.%s where (org_id,event_id)", strings.ToLower(dbName), base))
+	require.Contains(t, lowerContent, "insert into "+diffSQLTable(dbName, base))
+	require.Contains(t, lowerContent, "delete from "+diffSQLTable(dbName, base)+" where "+diffSQLColumns("org_id", "event_id"))
 
 	applyDiffStatements(t, ctx, db, sqlContent)
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
@@ -415,8 +415,8 @@ from generate_series(10001, 10800) as g`, branch)
 
 	sqlContent := readSQLFile(t, diffPath)
 	lowerContent := strings.ToLower(sqlContent)
-	require.Contains(t, lowerContent, fmt.Sprintf("insert into %s.%s", strings.ToLower(dbName), base))
-	require.Contains(t, lowerContent, fmt.Sprintf("delete from %s.%s", strings.ToLower(dbName), base))
+	require.Contains(t, lowerContent, "insert into "+diffSQLTable(dbName, base))
+	require.Contains(t, lowerContent, "delete from "+diffSQLTable(dbName, base))
 
 	applyDiffStatements(t, ctx, db, sqlContent)
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
@@ -850,8 +850,8 @@ func runDiffOutputToStage(t *testing.T, parentCtx context.Context, db *sql.DB) {
 	require.NotEmpty(t, payload, "stage diff payload is empty")
 
 	sqlContent := strings.ToLower(string(payload))
-	require.Contains(t, sqlContent, fmt.Sprintf("insert into %s.%s", strings.ToLower(dbName), base))
-	require.Contains(t, sqlContent, fmt.Sprintf("delete from %s.%s", strings.ToLower(dbName), base))
+	require.Contains(t, sqlContent, "insert into "+diffSQLTable(dbName, base))
+	require.Contains(t, sqlContent, "delete from "+diffSQLTable(dbName, base))
 
 	applyDiffStatements(t, ctx, db, string(payload))
 	assertTablesEqual(t, ctx, db, dbName, branch, base)
@@ -889,8 +889,8 @@ func runUpdateSplitDiffAsFile(t *testing.T, parentCtx context.Context, db *sql.D
 
 	sqlContent := readSQLFile(t, diffPath)
 	lowerContent := strings.ToLower(sqlContent)
-	require.Contains(t, lowerContent, fmt.Sprintf("insert into %s.%s", strings.ToLower(dbName), base))
-	require.Contains(t, lowerContent, fmt.Sprintf("delete from %s.%s where id in", strings.ToLower(dbName), base))
+	require.Contains(t, lowerContent, "insert into "+diffSQLTable(dbName, base))
+	require.Contains(t, lowerContent, "delete from "+diffSQLTable(dbName, base)+" where "+diffSQLIdent("id")+" in")
 	require.NotContains(t, lowerContent, "update ")
 
 	applyDiffStatements(t, ctx, db, sqlContent)
@@ -930,8 +930,8 @@ func runCompositeUpdateSplitDiffAsFile(t *testing.T, parentCtx context.Context, 
 
 	sqlContent := readSQLFile(t, diffPath)
 	lowerContent := strings.ToLower(sqlContent)
-	require.Contains(t, lowerContent, fmt.Sprintf("insert into %s.%s", strings.ToLower(dbName), base))
-	require.Contains(t, lowerContent, fmt.Sprintf("delete from %s.%s where (org_id,event_id) in", strings.ToLower(dbName), base))
+	require.Contains(t, lowerContent, "insert into "+diffSQLTable(dbName, base))
+	require.Contains(t, lowerContent, "delete from "+diffSQLTable(dbName, base)+" where "+diffSQLColumns("org_id", "event_id")+" in")
 	require.Contains(t, lowerContent, "null")
 	require.NotContains(t, lowerContent, "update ")
 
@@ -984,8 +984,8 @@ func runNoPKDuplicateDiffAsFile(t *testing.T, parentCtx context.Context, db *sql
 
 	sqlContent := readSQLFile(t, diffPath)
 	lowerContent := strings.ToLower(sqlContent)
-	require.Contains(t, lowerContent, fmt.Sprintf("insert into %s.%s", strings.ToLower(dbName), base))
-	require.Contains(t, lowerContent, fmt.Sprintf("delete from %s.%s", strings.ToLower(dbName), base))
+	require.Contains(t, lowerContent, "insert into "+diffSQLTable(dbName, base))
+	require.Contains(t, lowerContent, "delete from "+diffSQLTable(dbName, base))
 	require.Contains(t, lowerContent, "limit 1")
 	require.Contains(t, lowerContent, "is null")
 	require.NotContains(t, lowerContent, "update ")
@@ -1043,8 +1043,8 @@ create table %s (
 
 	sqlContent := readSQLFile(t, diffPath)
 	lowerContent := strings.ToLower(sqlContent)
-	require.Contains(t, lowerContent, fmt.Sprintf("insert into %s.%s", strings.ToLower(dbName), base))
-	require.Contains(t, lowerContent, fmt.Sprintf("delete from %s.%s", strings.ToLower(dbName), base))
+	require.Contains(t, lowerContent, "insert into "+diffSQLTable(dbName, base))
+	require.Contains(t, lowerContent, "delete from "+diffSQLTable(dbName, base))
 	require.Contains(t, lowerContent, "null")
 	require.Contains(t, lowerContent, "''")
 	require.NotContains(t, lowerContent, "update ")
@@ -1100,6 +1100,22 @@ func readSQLFile(t *testing.T, path string) string {
 	require.NoError(t, err)
 	require.NotEmpty(t, data, "diff sql output is empty")
 	return string(data)
+}
+
+func diffSQLIdent(name string) string {
+	return "`" + strings.ReplaceAll(strings.ToLower(name), "`", "``") + "`"
+}
+
+func diffSQLTable(dbName, tableName string) string {
+	return diffSQLIdent(dbName) + "." + diffSQLIdent(tableName)
+}
+
+func diffSQLColumns(cols ...string) string {
+	quoted := make([]string, 0, len(cols))
+	for _, col := range cols {
+		quoted = append(quoted, diffSQLIdent(col))
+	}
+	return "(" + strings.Join(quoted, ",") + ")"
 }
 
 func applyDiffStatements(t *testing.T, ctx context.Context, db *sql.DB, sqlContent string) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #21863

## What this PR does / why we need it:

This PR optimizes online DATA BRANCH MERGE and PICK apply for no-primary-key tables by using MatrixOne fake primary key values for delete application.

Before this change, no-pk online merge applied delete rows by matching the full visible row. For update-heavy workloads this makes each logical update pay the full-row delete cost before inserting the new version, which scales poorly and causes no-pk merge to become much slower than the primary-key path.

The change splits online apply from portable SQL output:

- online MERGE and PICK use fake-pk-backed delete matching for no-pk tables
- diff exported as SQL remains portable and continues to emit visible-column full-row deletes
- insert generation only uses visible table columns, so hidden fake pk values are not inserted back into user tables
- LCA probing explicitly selects the table column layout instead of relying on lca.* column ordering

Local validation:

- CGO_CFLAGS="-I/Users/ghs-mo/MOWorkSpace/matrixone-1st/thirdparties/install/include" go test ./pkg/frontend -run TestDataBranch
- make build
- Full git4data/branch BVT passed on the same data-branch code before clean cherry-pick: TOTAL 3558, SUCCESS 3514, FAILED 0, IGNORED 44

Local no-pk merge benchmark, 200k base rows:

- 1k changed rows: 1.089s baseline -> 0.305s optimized, 3.58x faster
- 10k changed rows: 17.322s baseline -> 2.454s optimized, 7.06x faster
- 50k changed rows: baseline was still running after more than 3.5 minutes and was stopped; optimized completed in 2.672s
