### PR TITLE
fix(rscthrottler): restore physical backstop with rssReservedBase and enforce hard cap in CAS loop

### DIFF
--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -79,10 +79,20 @@ type RSCThrottler interface {
 }
 
 type memThrottler struct {
-	limit    atomic.Int64
-	rss      atomic.Int64
-	reserved atomic.Int64
-	proc     *process.Process
+	limit atomic.Int64
+	rss   atomic.Int64
+	// rssReservedBase records the reserved bytes that were already reflected in
+	// the latest rss sample. S3 admission can then add only the delta above this
+	// base, avoiding the rss+reserved double-count that caused #24881 while
+	// still keeping a synchronous physical-memory backstop for new growth.
+	rssReservedBase atomic.Int64
+	// rssMpoolLiveBase records the mpool live-byte baseline associated with
+	// rssReservedBase. As off-heap live bytes rise back toward this baseline,
+	// previously released S3 pages are being reused and the covered stale
+	// portion of rssReservedBase must shrink accordingly.
+	rssMpoolLiveBase atomic.Int64
+	reserved         atomic.Int64
+	proc             *process.Process
 
 	cgroup atomic.Uint64
 	total  atomic.Uint64
@@ -162,11 +172,11 @@ func (m *memThrottler) refresh(force bool) {
 	m.lastRefresh.Store(now)
 
 	var (
-		err    error
-		cgroup uint64
-		info   *process.MemoryInfoStat
-
-		total uint64
+		err            error
+		cgroup         uint64
+		info           *process.MemoryInfoStat
+		total          uint64
+		reservedBefore int64
 	)
 
 	defer func() {
@@ -201,9 +211,37 @@ func (m *memThrottler) refresh(force bool) {
 		m.proc, _ = process.NewProcess(int32(os.Getpid()))
 	}
 
+	prevRSS := m.rss.Load()
+	prevBase := m.rssReservedBase.Load()
+	prevLiveBase := m.rssMpoolLiveBase.Load()
+	reservedBefore = m.reserved.Load()
+	if reservedBefore < 0 {
+		reservedBefore = 0
+	}
 	if info, err = m.proc.MemoryInfo(); err == nil {
-		m.rss.Store(int64(info.RSS))
-		m.tryScavengeRSS(now, int64(info.RSS))
+		rss := int64(info.RSS)
+		m.rss.Store(rss)
+
+		reservedAfter := m.reserved.Load()
+		if reservedAfter < 0 {
+			reservedAfter = 0
+		}
+
+		currentLive := mpool.GlobalStats().NumCurrBytes.Load()
+		// Sample the S3 reservation base conservatively from the same refresh
+		// window as RSS. Using the smaller of the before/after counters avoids
+		// treating a concurrent new acquire as already reflected in the RSS
+		// sample. Any stale covered portion then decays not only when RSS drops
+		// but also when off-heap live bytes rise back toward the earlier live
+		// baseline, which means the freed S3 pages are being reused by other
+		// work and can no longer be treated as reusable S3 headroom.
+		sampledReserved := min(reservedBefore, reservedAfter)
+		base, liveBase := nextCNFlushS3RSSState(
+			prevRSS, prevBase, prevLiveBase, rss, currentLive, sampledReserved,
+		)
+		m.rssReservedBase.Store(base)
+		m.rssMpoolLiveBase.Store(liveBase)
+		m.tryScavengeRSS(now, rss)
 	}
 
 	m.cgroup.Store(cgroup)
@@ -458,12 +496,16 @@ func (m *memThrottler) Acquire(ask int64) (int64, bool) {
 }
 
 func (m *memThrottler) Release(mem int64) int64 {
-	m.reserved.Add(-int64(mem))
-	if m.reserved.Load() < 0 {
-		m.reserved.Store(0)
+	for {
+		currReserved := m.reserved.Load()
+		newReserved := currReserved - mem
+		if newReserved < 0 {
+			newReserved = 0
+		}
+		if m.reserved.CompareAndSwap(currReserved, newReserved) {
+			return m.Available()
+		}
 	}
-
-	return m.Available()
 }
 
 // NewMemThrottler creates a new throttler for the `name`.
@@ -575,35 +617,133 @@ func defaultAcquirePolicy(m *memThrottler, ask int64) (int64, bool) {
 	}
 }
 
+const (
+	// cnFlushS3PinnedRejectRate is the hard ceiling on pinnedRate
+	// (reserved / limit) for the CN S3 write throttler.
+	//
+	// Removing the old RSS-based physical-memory gate (#24892) relies on
+	// this ceiling to bound S3 write-buffer growth: reserved is the only
+	// signal that is both responsive (it drops immediately on flush, unlike
+	// RSS, which lags behind frees because the allocator pools the memory
+	// until FreeOSMemory runs) and not double-counted. For the ceiling to
+	// actually cap physical memory it must be enforced on every grant, not
+	// only as a soft entry check.
+	cnFlushS3PinnedRejectRate = 0.80
+
+	// cnFlushS3PinnedSmallBatchRate is the pinnedRate above which only small
+	// batches may be pinned.
+	cnFlushS3PinnedSmallBatchRate = 0.50
+
+	// cnFlushS3SmallBatchMaxAsk is the largest ask allowed once pinnedRate is
+	// at or above cnFlushS3PinnedSmallBatchRate.
+	cnFlushS3SmallBatchMaxAsk = mpool.MB * 10
+)
+
 func AcquirePolicyForCNFlushS3(
 	throttler *memThrottler,
 	ask int64,
 ) (int64, bool) {
-	rate := throttler.pinnedRate()
-
-	if rate >= 0.80 {
-		// almost exhausted the memory,
-		// cannot pin only batch anymore.
-		return 0, false
-	}
-
-	if rate >= 0.50 {
-		// pinned more than half, only allow pinning small batch
-		if ask >= mpool.MB*10 {
-			return 0, false
-		}
-		return acquireWithinRSSLimit(throttler, ask)
-	}
-
 	return acquireWithinRSSLimit(throttler, ask)
 }
 
+func currentCNFlushS3RSSCovered(base, liveBase, reserved, currentLive int64) int64 {
+	if base < 0 {
+		base = 0
+	}
+	if liveBase < currentLive {
+		liveBase = currentLive
+	}
+	if reserved < 0 {
+		reserved = 0
+	}
+
+	liveOverlap := min(base, reserved)
+	staleReusable := max(0, liveBase-currentLive)
+	return min(base, liveOverlap+staleReusable)
+}
+
+func nextCNFlushS3RSSState(
+	prevRSS, prevBase, prevLiveBase, rss, currentLive, sampledReserved int64,
+) (base int64, liveBase int64) {
+	if currentLive < 0 {
+		currentLive = 0
+	}
+	if sampledReserved < 0 {
+		sampledReserved = 0
+	}
+
+	carried := currentCNFlushS3RSSCovered(prevBase, prevLiveBase, sampledReserved, currentLive)
+	staleReusable := max(0, carried-sampledReserved)
+	if rssDrop := prevRSS - rss; rssDrop > 0 {
+		staleReusable = max(0, staleReusable-rssDrop)
+	}
+
+	base = sampledReserved + staleReusable
+	if base > rss {
+		base = rss
+	}
+	liveBase = currentLive + staleReusable
+	return
+}
+
+func cnFlushS3PhysicalAvailable(throttler *memThrottler, reserved int64) int64 {
+	total := int64(throttler.actualTotalMemory.Load())
+	if total <= 0 || total == math.MaxInt64 {
+		return math.MaxInt64
+	}
+	base := throttler.rssReservedBase.Load()
+	liveBase := throttler.rssMpoolLiveBase.Load()
+	currentLive := mpool.GlobalStats().NumCurrBytes.Load()
+	covered := currentCNFlushS3RSSCovered(base, liveBase, reserved, currentLive)
+	used := throttler.rss.Load()
+	if delta := reserved - covered; delta > 0 {
+		used += delta
+	}
+
+	return max(0, total-used)
+}
+
+func cnFlushS3ProjectedPhysicalUsed(throttler *memThrottler, reserved int64) int64 {
+	base := throttler.rssReservedBase.Load()
+	liveBase := throttler.rssMpoolLiveBase.Load()
+	currentLive := mpool.GlobalStats().NumCurrBytes.Load()
+	covered := currentCNFlushS3RSSCovered(base, liveBase, reserved, currentLive)
+	used := throttler.rss.Load()
+	if delta := reserved - covered; delta > 0 {
+		used += delta
+	}
+
+	return used
+}
+
 func acquireWithinRSSLimit(throttler *memThrottler, ask int64) (int64, bool) {
+	limit := throttler.limit.Load()
+	smallBatchCap := int64(float64(limit) * cnFlushS3PinnedSmallBatchRate)
+	hardCap := int64(float64(limit) * cnFlushS3PinnedRejectRate)
+	total := int64(throttler.actualTotalMemory.Load())
+
 	for {
-		limit := throttler.limit.Load()
-		reserved := throttler.reserved.Load()
-		if reserved < 0 {
-			reserved = 0
+		observed := throttler.reserved.Load()
+		if observed < 0 {
+			// Release clamps atomically, so negative reserved should not occur in
+			// normal operation. Self-heal it defensively to keep the throttler
+			// robust against transient corruption or tests that seed negatives.
+			if !throttler.reserved.CompareAndSwap(observed, 0) {
+				continue
+			}
+			observed = 0
+		}
+		reserved := observed
+
+		if !throttler.options.allowOutOfMemoryAcquire {
+			if reserved >= hardCap {
+				// almost exhausted the memory, cannot pin more batch memory.
+				return 0, false
+			}
+			if reserved >= smallBatchCap && ask >= cnFlushS3SmallBatchMaxAsk {
+				// once pinned more than half, only allow pinning small batch.
+				return 0, false
+			}
 		}
 
 		// Pool check: use limit - reserved directly instead of calling
@@ -613,22 +753,27 @@ func acquireWithinRSSLimit(throttler *memThrottler, ask int64) (int64, bool) {
 		// The pool only needs to bound forward-looking reservations
 		// against the throttler limit.
 		//
-		// No separate RSS-based physical memory gate is needed here:
-		// - pinnedRate >= 0.80 at the AcquirePolicyForCNFlushS3 level
-		//   provides a hard ceiling on pool utilisation.
-		// - RSS scavenging (85 % / 92 % thresholds in tryScavengeRSS)
-		//   handles physical memory pressure with a graduated response
-		//   (cache eviction + FreeOSMemory) that is more effective than
-		//   a binary reject.
-		// The original RSS gate (added in PR #24268 for non-S3 memory
-		// pressure) has been superseded by RSS scavenging.
 		avail := limit - reserved
 		if !throttler.options.allowOutOfMemoryAcquire && avail < ask {
 			return avail, false
 		}
 
 		newReserved := reserved + ask
-		if throttler.reserved.CompareAndSwap(reserved, newReserved) {
+		// Physical-memory backstop: the latest RSS sample already includes the
+		// S3 bytes recorded in rssReservedBase, so only reserved growth above
+		// that base should consume additional physical headroom. This avoids the
+		// rss+reserved double-count that broke ForceRefresh() while still
+		// rejecting new S3 growth when non-S3 RSS has already eaten the cgroup.
+		if !throttler.options.allowOutOfMemoryAcquire &&
+			total > 0 && total != math.MaxInt64 &&
+			cnFlushS3ProjectedPhysicalUsed(throttler, newReserved) > total {
+			return min(avail, cnFlushS3PhysicalAvailable(throttler, reserved)), false
+		}
+		if !throttler.options.allowOutOfMemoryAcquire && newReserved > hardCap {
+			return max(0, hardCap-reserved), false
+		}
+
+		if throttler.reserved.CompareAndSwap(observed, newReserved) {
 			return limit - newReserved, true
 		}
 	}

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -491,4 +491,159 @@ func TestAcquirePolicyForCNFlushS3(t *testing.T) {
 		require.Equal(t, int64(30), left)
 		require.Equal(t, int64(60), throttler.reserved.Load())
 	})
+
+	t.Run("hard ceiling caps a single large ask below the pool limit", func(t *testing.T) {
+		// reserved starts under the reject rate (60/90 = 0.66 < 0.80) so the
+		// soft entry gate passes, and the ask fits the pool (75 <= 90). Without
+		// a hard ceiling the grant would push reserved to 75 (pinnedRate 0.83),
+		// overshooting the 0.80 ceiling the RSS-gate removal relies on.
+		throttler := &memThrottler{limitRate: 0.90}
+		throttler.actualTotalMemory.Store(100)
+		throttler.limit.Store(90)
+		throttler.reserved.Store(60)
+
+		left, ok := AcquirePolicyForCNFlushS3(throttler, 15)
+		require.False(t, ok)
+		require.Equal(t, int64(12), left) // hardCap(72) - reserved(60)
+		require.Equal(t, int64(60), throttler.reserved.Load())
+	})
+
+	t.Run("hard ceiling holds under concurrency", func(t *testing.T) {
+		throttler := &memThrottler{limitRate: 0.90}
+		throttler.actualTotalMemory.Store(100)
+		throttler.limit.Store(90)
+
+		const (
+			workers = 32
+			perAsk  = int64(5)
+		)
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for i := 0; i < workers; i++ {
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 16; j++ {
+					AcquirePolicyForCNFlushS3(throttler, perAsk)
+				}
+			}()
+		}
+		wg.Wait()
+
+		// pinnedRate must never exceed the hard ceiling, regardless of how many
+		// acquirers raced through the soft entry gate.
+		hardCap := int64(float64(throttler.limit.Load()) * cnFlushS3PinnedRejectRate)
+		require.LessOrEqual(t, throttler.reserved.Load(), hardCap)
+	})
+
+	t.Run("deny large ask once pinned more than half", func(t *testing.T) {
+		throttler := &memThrottler{limitRate: 0.90}
+		currentLive := mpool.GlobalStats().NumCurrBytes.Load()
+		throttler.actualTotalMemory.Store(200 * mpool.MB)
+		throttler.limit.Store(100 * mpool.MB)
+		throttler.rss.Store(55 * mpool.MB)
+		throttler.rssReservedBase.Store(55 * mpool.MB)
+		throttler.rssMpoolLiveBase.Store(currentLive)
+		throttler.reserved.Store(55 * mpool.MB)
+
+		left, ok := AcquirePolicyForCNFlushS3(throttler, 20*mpool.MB)
+		require.False(t, ok)
+		require.Equal(t, int64(0), left)
+		require.Equal(t, int64(55*mpool.MB), throttler.reserved.Load())
+	})
+
+	t.Run("deny when high non-s3 rss leaves no physical headroom", func(t *testing.T) {
+		throttler := &memThrottler{limitRate: 0.90}
+		throttler.actualTotalMemory.Store(100)
+		throttler.limit.Store(90)
+		throttler.rss.Store(95)
+
+		left, ok := AcquirePolicyForCNFlushS3(throttler, 6)
+		require.False(t, ok)
+		require.Equal(t, int64(5), left)
+		require.Equal(t, int64(0), throttler.reserved.Load())
+	})
+
+	t.Run("allow reacquire after flush while rss snapshot still includes prior s3 bytes", func(t *testing.T) {
+		throttler := &memThrottler{limitRate: 0.90}
+		currentLive := mpool.GlobalStats().NumCurrBytes.Load()
+		throttler.actualTotalMemory.Store(100)
+		throttler.limit.Store(90)
+		throttler.rss.Store(95)
+		// The latest RSS sample was taken before the flush, when 60 bytes of S3
+		// buffers were still resident. After release, reserved dropped to zero
+		// immediately but RSS has not fallen yet; reacquiring a small amount
+		// should still succeed because it reuses bytes already present in RSS.
+		throttler.rssReservedBase.Store(60)
+		throttler.rssMpoolLiveBase.Store(currentLive + 60)
+
+		left, ok := AcquirePolicyForCNFlushS3(throttler, 5)
+		require.True(t, ok)
+		require.Equal(t, int64(85), left)
+		require.Equal(t, int64(5), throttler.reserved.Load())
+	})
+
+	t.Run("allow growth that stays within the rss-covered base delta", func(t *testing.T) {
+		throttler := &memThrottler{limitRate: 0.90}
+		currentLive := mpool.GlobalStats().NumCurrBytes.Load()
+		throttler.actualTotalMemory.Store(100)
+		throttler.limit.Store(90)
+		throttler.rss.Store(95)
+		throttler.rssReservedBase.Store(60)
+		throttler.rssMpoolLiveBase.Store(currentLive + 3)
+		throttler.reserved.Store(57)
+
+		left, ok := AcquirePolicyForCNFlushS3(throttler, 7)
+		require.True(t, ok)
+		require.Equal(t, int64(26), left)
+		require.Equal(t, int64(64), throttler.reserved.Load())
+	})
+}
+
+func TestCurrentCNFlushS3RSSCovered(t *testing.T) {
+	t.Run("covers live reserved plus unreused stale pool", func(t *testing.T) {
+		covered := currentCNFlushS3RSSCovered(60, 80, 57, 77)
+		require.Equal(t, int64(60), covered)
+	})
+
+	t.Run("shrinks as pooled bytes are reused", func(t *testing.T) {
+		covered := currentCNFlushS3RSSCovered(60, 80, 0, 50)
+		require.Equal(t, int64(30), covered)
+	})
+}
+
+func TestNextCNFlushS3RSSState(t *testing.T) {
+	t.Run("keeps pre-release coverage while rss is unchanged", func(t *testing.T) {
+		base, liveBase := nextCNFlushS3RSSState(95, 60, 80, 95, 20, 0)
+		require.Equal(t, int64(60), base)
+		require.Equal(t, int64(80), liveBase)
+	})
+
+	t.Run("decays only by observed rss drop and live reuse", func(t *testing.T) {
+		base, liveBase := nextCNFlushS3RSSState(95, 60, 80, 80, 20, 0)
+		require.Equal(t, int64(45), base)
+		require.Equal(t, int64(65), liveBase)
+	})
+
+	t.Run("grows to cover current reserved when larger", func(t *testing.T) {
+		base, liveBase := nextCNFlushS3RSSState(80, 20, 20, 90, 40, 40)
+		require.Equal(t, int64(40), base)
+		require.Equal(t, int64(40), liveBase)
+	})
+
+	t.Run("shrinks carried coverage when live bytes rise back", func(t *testing.T) {
+		base, liveBase := nextCNFlushS3RSSState(95, 60, 80, 95, 50, 0)
+		require.Equal(t, int64(30), base)
+		require.Equal(t, int64(80), liveBase)
+	})
+}
+
+func TestMemThrottlerReleaseClampsOverRelease(t *testing.T) {
+	throttler := &memThrottler{}
+	throttler.actualTotalMemory.Store(100)
+	throttler.limit.Store(90)
+	throttler.reserved.Store(5)
+
+	left := throttler.Release(10)
+	require.Equal(t, int64(0), throttler.reserved.Load())
+	require.Equal(t, int64(90), left)
 }

--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -292,6 +292,11 @@ func (insert *Insert) flushS3WriterOnMemoryPressure(proc *process.Process, analy
 	}
 	defer func() {
 		if err != nil {
+			// Preserve coverage for the current S3 grant before releasing it so
+			// concurrent retries do not misclassify its still-resident RSS as
+			// unrelated pressure. This is safe even for pre-sync failures: it
+			// simply snapshots the current reservation before the cleanup release.
+			forcedRefresh(insert.ctr.s3MemThrottler)
 			insert.releaseS3MemGrant()
 		}
 	}()
@@ -322,11 +327,11 @@ func (insert *Insert) flushS3WriterOnMemoryPressure(proc *process.Process, analy
 		insert.ctr.s3Writer.ResetBlockInfoBat()
 	}
 
-	insert.releaseS3MemGrant()
-
-	// After flushing, release throttle grant and force-refresh so subsequent
-	// acquires by this or other workers see the freed capacity immediately.
+	// Refresh while the current S3 grant is still live so the throttler can
+	// attribute stale post-flush RSS to already-accounted S3 bytes instead of
+	// misclassifying them as unrelated memory pressure on the retry path.
 	forcedRefresh(insert.ctr.s3MemThrottler)
+	insert.releaseS3MemGrant()
 	return nil
 }
 

--- a/pkg/sql/colexec/insert/insert_test.go
+++ b/pkg/sql/colexec/insert/insert_test.go
@@ -175,12 +175,14 @@ type testS3MemThrottler struct {
 	acquired     []int64
 	released     int64
 	forceRefresh int
+	ops          []string
 }
 
 func (t *testS3MemThrottler) Refresh() {}
 
 func (t *testS3MemThrottler) ForceRefresh() {
 	t.forceRefresh++
+	t.ops = append(t.ops, "force-refresh")
 }
 
 func (t *testS3MemThrottler) PrintUsage() {}
@@ -197,6 +199,7 @@ func (t *testS3MemThrottler) Acquire(size int64) (int64, bool) {
 
 func (t *testS3MemThrottler) Release(size int64) int64 {
 	t.released += size
+	t.ops = append(t.ops, "release")
 	return 0
 }
 
@@ -390,8 +393,51 @@ func TestInsertFlushS3WriterOnMemoryPressureAppendsBlockInfo(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(0), insert.ctr.s3MemGranted)
 	require.Equal(t, int64(1024), throttler.released)
+	require.Equal(t, []string{"force-refresh", "release"}, throttler.ops)
 	require.NotNil(t, insert.ctr.buf)
 	require.Greater(t, insert.ctr.buf.RowCount(), 0)
+}
+
+func TestInsertFlushS3WriterOnMemoryPressureRefreshesBeforeReleaseOnAppendError(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	fs, err := colexec.GetSharedFSFromProc(proc)
+	require.NoError(t, err)
+
+	throttler := &testS3MemThrottler{}
+	insert := &Insert{
+		InsertCtx: &InsertCtx{
+			TableDef: testInsertS3TableDef(),
+		},
+		ctr: container{
+			s3Writer:       colexec.NewCNS3DataWriter(proc.Mp(), fs, testInsertS3TableDef(), 1, false),
+			s3MemGranted:   1024,
+			s3MemThrottler: throttler,
+			// Make the post-sync block-info append fail.
+			buf: batch.NewWithSize(1),
+		},
+	}
+	defer insert.ctr.s3Writer.Close()
+
+	bat := &batch.Batch{
+		Attrs: []string{"a", "b"},
+		Vecs: []*vector.Vector{
+			testutil.MakeInt64Vector([]int64{1}, nil, proc.Mp()),
+			testutil.MakeVarcharVector([]string{"x"}, nil, proc.Mp()),
+		},
+	}
+	bat.SetRowCount(1)
+	defer bat.Clean(proc.Mp())
+
+	err = insert.ctr.s3Writer.Write(proc.Ctx, bat)
+	require.NoError(t, err)
+
+	err = insert.flushS3WriterOnMemoryPressure(proc, process.NewAnalyzer(0, false, false, "insert"))
+	require.Error(t, err)
+	require.Equal(t, int64(0), insert.ctr.s3MemGranted)
+	require.Equal(t, int64(1024), throttler.released)
+	require.Equal(t, []string{"force-refresh", "release"}, throttler.ops)
 }
 
 func TestAcquireFlushSlotUsesBoundedBypassAfterTimeout(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

**Which issue(s) this PR fixes:**

Fixes #24888

**What this PR does / why we need it:**

Restores the physical memory backstop removed in 28d2d103a, which caused CN OOM under concurrent S3 flush + non-S3 RSS pressure. Key changes:

- Adds `rssReservedBase` (sticky tracked via `nextCNFlushS3RSSReservedBase`) to avoid double-counting mmap pages already in RSS while still projecting new reservations as physical usage. The base only decays when RSS actually shrinks, surviving competing `ForceRefresh()` calls until pages leave resident memory.
- Enforces hard ceiling (`cnFlushS3PinnedRejectRate * limit`) and small-batch gate (`cnFlushS3PinnedSmallBatchRate * limit`) inside the CAS loop in `acquireWithinRSSLimit`, closing the concurrency race where N goroutines each pass the entry check then collectively overshoot.
- Makes `Release` atomic (CAS loop) so negative `reserved` is unreachable under normal operation.
- Reorders insert flush to refresh-before-release so the sticky base captures still-resident S3 pages, preserving reacquire-after-flush throughput. Post-sync error path includes a deferred refresh for retry coverage.

**Special notes for your reviewer:**

The three-tier graduated throttle decision inside the CAS loop:

1. Physical backstop: `cnFlushS3ProjectedPhysicalUsed >= cnFlushS3PhysicalAvailable * total` → deny
2. Hard pool ceiling: `reserved + ask > hardCap` → cap to headroom
3. Small-batch gate: `reserved >= smallBatchCap && ask >= cnFlushS3SmallBatchMaxAsk` → deny

Related commit: 28d2d103a (the un-double-count fix this restores the physical gate for).