### PR TITLE
cherrypick: fix bit_count on arm

### DIFF
--- a/pkg/sql/plan/function/func_bit_count_test.go
+++ b/pkg/sql/plan/function/func_bit_count_test.go
@@ -78,12 +78,14 @@ func TestBitCountFloat(t *testing.T) {
 			NewFunctionTestInput(types.T_float64.ToType(), []float64{
 				1.4, 1.5, 2.5, 3.5,
 				-1.4, -1.5, -2.5, -3.5,
+				-9223372036854774784.0, -9223372036854775808.0,
 				math.Inf(1), math.Inf(-1),
 			}, nil),
 		},
 		NewFunctionTestResult(types.T_uint64.ToType(), false, []uint64{
 			1, 1, 1, 1,
 			64, 63, 63, 62,
+			2, 1,
 			64, 1,
 		}, nil),
 		BitCountFloat[float64])

--- a/pkg/sql/plan/function/func_unary.go
+++ b/pkg/sql/plan/function/func_unary.go
@@ -627,6 +627,9 @@ func bitCountFromFloat[T constraints.Float](v T, proc *process.Process) (uint64,
 	if rounded <= float64(math.MinInt64) {
 		return bitCountFromUint64(minInt64BitPattern), nil
 	}
+	if rounded < 0 {
+		return bitCountFromUint64(uint64(int64(rounded))), nil
+	}
 	if rounded >= ULLONG_MAX_DOUBLE {
 		return bitCountFromUint64(uint64(math.MaxUint64)), nil
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25046

## What this PR does / why we need it:

原因:
```
BIT_COUNT(negative DOUBLE) comment 是对的
我用最小程序复现了 /mnt/fastdata/temp2/matrixone/pkg/sql/plan/function/func_unary.go:605 的逻辑：

rounded := math.RoundToEven(val)
uint64(rounded)

结果：

amd64/go1.25.x：

-1.4 -> rounded=-1 -> uint64=0xffffffffffffffff -> bits=64
arm64/go1.25.4：

-1.4 -> rounded=-1 -> uint64=0 -> bits=0
所以 comment 里说的 ARM64 上“负浮点转 uint64 变成 0”我已经实测确认了。
这说明 bitCountFromFloat() 的实现确实有跨架构问题，不应该依赖这个转换行为。
```
修改方案: 先转in64, 再转uint64. 已经在arm64上验证了.