### PR TITLE
fix: restore defense-in-depth for CN flush S3 memory throttling

### DIFF
--- a/pkg/common/rscthrottler/resource_throttler.go
+++ b/pkg/common/rscthrottler/resource_throttler.go
@@ -716,6 +716,20 @@ func cnFlushS3ProjectedPhysicalUsed(throttler *memThrottler, reserved int64) int
 	return used
 }
 
+func (m *memThrottler) ShouldRefreshBeforeRelease() bool {
+	reserved := m.reserved.Load()
+	if reserved <= 0 {
+		return false
+	}
+	currentLive := mpool.GlobalStats().NumCurrBytes.Load()
+	covered := currentCNFlushS3RSSCovered(
+		m.rssReservedBase.Load(),
+		m.rssMpoolLiveBase.Load(),
+		reserved,
+		currentLive,
+	)
+	return covered < reserved
+}
 func acquireWithinRSSLimit(throttler *memThrottler, ask int64) (int64, bool) {
 	limit := throttler.limit.Load()
 	smallBatchCap := int64(float64(limit) * cnFlushS3PinnedSmallBatchRate)

--- a/pkg/common/rscthrottler/resource_throttler_test.go
+++ b/pkg/common/rscthrottler/resource_throttler_test.go
@@ -647,3 +647,29 @@ func TestMemThrottlerReleaseClampsOverRelease(t *testing.T) {
 	require.Equal(t, int64(0), throttler.reserved.Load())
 	require.Equal(t, int64(90), left)
 }
+
+func TestMemThrottlerShouldRefreshBeforeRelease(t *testing.T) {
+	currentLive := mpool.GlobalStats().NumCurrBytes.Load()
+
+	t.Run("refreshes when current reserved is not yet covered", func(t *testing.T) {
+		throttler := &memThrottler{}
+		throttler.reserved.Store(20)
+		require.True(t, throttler.ShouldRefreshBeforeRelease())
+	})
+
+	t.Run("skips refresh when existing coverage already covers current reserved", func(t *testing.T) {
+		throttler := &memThrottler{}
+		throttler.reserved.Store(20)
+		throttler.rssReservedBase.Store(60)
+		throttler.rssMpoolLiveBase.Store(currentLive)
+		require.False(t, throttler.ShouldRefreshBeforeRelease())
+	})
+
+	t.Run("refreshes when live reuse shrinks covered bytes below current reserved", func(t *testing.T) {
+		throttler := &memThrottler{}
+		throttler.reserved.Store(40)
+		throttler.rssReservedBase.Store(20)
+		throttler.rssMpoolLiveBase.Store(currentLive)
+		require.True(t, throttler.ShouldRefreshBeforeRelease())
+	})
+}

--- a/pkg/sql/colexec/insert/insert.go
+++ b/pkg/sql/colexec/insert/insert.go
@@ -149,7 +149,7 @@ func (insert *Insert) insert_s3(proc *process.Process, analyzer process.Analyzer
 	}()
 	defer func() {
 		if err != nil {
-			insert.releaseS3MemGrant()
+			insert.refreshAndReleaseS3MemGrant()
 		}
 	}()
 
@@ -201,7 +201,7 @@ func (insert *Insert) insert_s3(proc *process.Process, analyzer process.Analyzer
 			insert.ctr.state = vm.End
 			return result, err
 		}
-		insert.releaseS3MemGrant()
+		insert.refreshAndReleaseS3MemGrant()
 		insert.ctr.state = vm.End
 		return result, nil
 	}
@@ -292,12 +292,7 @@ func (insert *Insert) flushS3WriterOnMemoryPressure(proc *process.Process, analy
 	}
 	defer func() {
 		if err != nil {
-			// Preserve coverage for the current S3 grant before releasing it so
-			// concurrent retries do not misclassify its still-resident RSS as
-			// unrelated pressure. This is safe even for pre-sync failures: it
-			// simply snapshots the current reservation before the cleanup release.
-			forcedRefresh(insert.ctr.s3MemThrottler)
-			insert.releaseS3MemGrant()
+			insert.refreshAndReleaseS3MemGrant()
 		}
 	}()
 
@@ -327,11 +322,7 @@ func (insert *Insert) flushS3WriterOnMemoryPressure(proc *process.Process, analy
 		insert.ctr.s3Writer.ResetBlockInfoBat()
 	}
 
-	// Refresh while the current S3 grant is still live so the throttler can
-	// attribute stale post-flush RSS to already-accounted S3 bytes instead of
-	// misclassifying them as unrelated memory pressure on the retry path.
-	forcedRefresh(insert.ctr.s3MemThrottler)
-	insert.releaseS3MemGrant()
+	insert.refreshAndReleaseS3MemGrant()
 	return nil
 }
 

--- a/pkg/sql/colexec/insert/insert_test.go
+++ b/pkg/sql/colexec/insert/insert_test.go
@@ -207,6 +207,15 @@ func (t *testS3MemThrottler) Available() int64 {
 	return 0
 }
 
+type testS3MemThrottlerWithDecision struct {
+	testS3MemThrottler
+	shouldRefresh bool
+}
+
+func (t *testS3MemThrottlerWithDecision) ShouldRefreshBeforeRelease() bool {
+	return t.shouldRefresh
+}
+
 type testRefreshOnlyThrottler struct {
 	refreshed int
 }
@@ -438,6 +447,105 @@ func TestInsertFlushS3WriterOnMemoryPressureRefreshesBeforeReleaseOnAppendError(
 	require.Equal(t, int64(0), insert.ctr.s3MemGranted)
 	require.Equal(t, int64(1024), throttler.released)
 	require.Equal(t, []string{"force-refresh", "release"}, throttler.ops)
+}
+
+func TestInsertS3FinalFlushRefreshesBeforeReleaseOnSuccess(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	fs, err := colexec.GetSharedFSFromProc(proc)
+	require.NoError(t, err)
+
+	throttler := &testS3MemThrottler{}
+	insert := &Insert{
+		InsertCtx: &InsertCtx{
+			TableDef: testInsertS3TableDef(),
+		},
+		ctr: container{
+			state:          vm.Eval,
+			s3Writer:       colexec.NewCNS3DataWriter(proc.Mp(), fs, testInsertS3TableDef(), 1, false),
+			s3MemGranted:   1024,
+			s3MemThrottler: throttler,
+		},
+	}
+	insert.initBufForS3()
+	defer insert.ctr.s3Writer.Close()
+
+	bat := &batch.Batch{
+		Attrs: []string{"a", "b"},
+		Vecs: []*vector.Vector{
+			testutil.MakeInt64Vector([]int64{1}, nil, proc.Mp()),
+			testutil.MakeVarcharVector([]string{"x"}, nil, proc.Mp()),
+		},
+	}
+	bat.SetRowCount(1)
+	defer bat.Clean(proc.Mp())
+
+	err = insert.ctr.s3Writer.Write(proc.Ctx, bat)
+	require.NoError(t, err)
+
+	_, err = insert.insert_s3(proc, process.NewAnalyzer(0, false, false, "insert"))
+	require.NoError(t, err)
+	require.Equal(t, int64(0), insert.ctr.s3MemGranted)
+	require.Equal(t, int64(1024), throttler.released)
+	require.Equal(t, []string{"force-refresh", "release"}, throttler.ops)
+}
+
+func TestInsertS3FinalFlushRefreshesBeforeReleaseOnError(t *testing.T) {
+	proc := testutil.NewProc(t)
+	defer proc.Free()
+
+	fs, err := colexec.GetSharedFSFromProc(proc)
+	require.NoError(t, err)
+
+	throttler := &testS3MemThrottler{}
+	insert := &Insert{
+		InsertCtx: &InsertCtx{
+			TableDef: testInsertS3TableDef(),
+		},
+		ctr: container{
+			state:          vm.Eval,
+			s3Writer:       colexec.NewCNS3DataWriter(proc.Mp(), fs, testInsertS3TableDef(), 1, false),
+			s3MemGranted:   1024,
+			s3MemThrottler: throttler,
+			buf:            batch.NewWithSize(1),
+		},
+	}
+	defer insert.ctr.s3Writer.Close()
+
+	bat := &batch.Batch{
+		Attrs: []string{"a", "b"},
+		Vecs: []*vector.Vector{
+			testutil.MakeInt64Vector([]int64{1}, nil, proc.Mp()),
+			testutil.MakeVarcharVector([]string{"x"}, nil, proc.Mp()),
+		},
+	}
+	bat.SetRowCount(1)
+	defer bat.Clean(proc.Mp())
+
+	err = insert.ctr.s3Writer.Write(proc.Ctx, bat)
+	require.NoError(t, err)
+
+	_, err = insert.insert_s3(proc, process.NewAnalyzer(0, false, false, "insert"))
+	require.Error(t, err)
+	require.Equal(t, int64(0), insert.ctr.s3MemGranted)
+	require.Equal(t, int64(1024), throttler.released)
+	require.Equal(t, []string{"force-refresh", "release"}, throttler.ops)
+}
+
+func TestRefreshAndReleaseS3MemGrantSkipsRefreshWhenCoverageIsAlreadyEnough(t *testing.T) {
+	throttler := &testS3MemThrottlerWithDecision{shouldRefresh: false}
+	insert := &Insert{
+		ctr: container{
+			s3MemGranted:   1024,
+			s3MemThrottler: throttler,
+		},
+	}
+
+	insert.refreshAndReleaseS3MemGrant()
+	require.Equal(t, int64(0), insert.ctr.s3MemGranted)
+	require.Equal(t, int64(1024), throttler.released)
+	require.Equal(t, []string{"release"}, throttler.ops)
 }
 
 func TestAcquireFlushSlotUsesBoundedBypassAfterTimeout(t *testing.T) {

--- a/pkg/sql/colexec/insert/types.go
+++ b/pkg/sql/colexec/insert/types.go
@@ -147,6 +147,19 @@ func (insert *Insert) releaseS3MemGrant() {
 	}
 }
 
+func (insert *Insert) refreshAndReleaseS3MemGrant() {
+	type refreshBeforeReleaseDecider interface {
+		ShouldRefreshBeforeRelease() bool
+	}
+
+	if insert.ctr.s3MemThrottler != nil && insert.ctr.s3MemGranted > 0 {
+		if decider, ok := insert.ctr.s3MemThrottler.(refreshBeforeReleaseDecider); !ok || decider.ShouldRefreshBeforeRelease() {
+			forcedRefresh(insert.ctr.s3MemThrottler)
+		}
+	}
+	insert.releaseS3MemGrant()
+}
+
 func (insert *Insert) ExecProjection(proc *process.Process, input *batch.Batch) (*batch.Batch, error) {
 	return input, nil
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Backport of #25064  
Related issue #24888

## What this PR does / why we need it:

This PR backports the remaining changes from #25064 to `4.0-dev`.

`4.0-dev` already contains the main rscthrottler backport from #25062, so this PR carries only the missing delta.

Cherry-picked source commit:
- 101f821abcceff9d8275eff757fadcbb668157b9

Conflict resolution for `4.0-dev`:
- Kept the existing semaphore-based flush-slot tests on `4.0-dev`
- Preserved the refresh-before-release behavior from #25064