### PR TITLE
fix: keep ETL DB conn valid during reconnect

### DIFF
--- a/pkg/util/export/etl/content.go
+++ b/pkg/util/export/etl/content.go
@@ -219,6 +219,8 @@ func (f *SQLFlusher) FlushBuffer(buf *bytes.Buffer) (int, error) {
 	}
 	if err != nil {
 		_ = db_holder.DBConnErrCount.Count()
+	} else {
+		db_holder.DBConnErrCount.Reset()
 	}
 
 	return 0, err

--- a/pkg/util/export/etl/content_test.go
+++ b/pkg/util/export/etl/content_test.go
@@ -186,3 +186,41 @@ func TestWriteRowRecords_WithBackoff(t *testing.T) {
 
 	require.True(t, newConn)
 }
+
+func TestSQLFlusher_ResetBackoffAfterSuccessfulFlush(t *testing.T) {
+	old := db_holder.DBConnErrCount
+	defer func() {
+		db_holder.DBConnErrCount = old
+	}()
+
+	db_holder.DBConnErrCount = db_holder.NewReConnectionBackOff(time.Hour, 0)
+	db_holder.DBConnErrCount.Count()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	for i := 0; i < 3; i++ {
+		mock.ExpectExec(regexp.QuoteMeta(`LOAD DATA INLINE FORMAT='csv', DATA='record1' INTO TABLE testDB.testTable FIELDS TERMINATED BY ','`)).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+	}
+
+	var forceNewConnFlags []bool
+	stubs := gostub.Stub(&db_holder.GetOrInitDBConn, func(forceNewConn bool, randomCN bool) (*sql.DB, error) {
+		forceNewConnFlags = append(forceNewConnFlags, forceNewConn)
+		return db, nil
+	})
+	defer stubs.Reset()
+
+	f := &SQLFlusher{
+		database: "testDB",
+		table:    "testTable",
+	}
+	for i := 0; i < 3; i++ {
+		_, err = f.FlushBuffer(bytes.NewBufferString("record1"))
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, []bool{true, false, false}, forceNewConnFlags)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -204,6 +204,9 @@ func rebuildDBConn(forceNewConn bool, randomCN bool) (*sql.DB, error) {
 	oldDBConn := setDBConnLocked(newDBConn)
 	dbMux.Unlock()
 	closeStaleDBConn(oldDBConn)
+	if forceNewConn {
+		DBConnErrCount.Reset()
+	}
 
 	return newDBConn, nil
 }
@@ -262,6 +265,7 @@ func WriteRowRecords(records [][]string, tbl *table.Table, timeout time.Duration
 		return 0, err
 	}
 
+	DBConnErrCount.Reset()
 	return len(records), nil
 }
 
@@ -482,6 +486,14 @@ func (b *ReConnectionBackOff) Count() bool {
 	b.count++
 	b.last = time.Now()
 	return b.count <= b.threshold
+}
+
+func (b *ReConnectionBackOff) Reset() {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	b.count = 0
+	b.last = time.Now()
 }
 
 // Check return same as Count, but without changed.

--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -44,7 +44,9 @@ var (
 	db            atomic.Pointer[sql.DB]
 	dbRefreshTime time.Time
 
-	dbMux sync.Mutex
+	dbMux        sync.Mutex
+	dbRebuildMux sync.Mutex
+	openDBConn   = sql.Open
 
 	DBConnErrCount = NewReConnectionBackOff(time.Minute, DBConnRetryThreshold)
 )
@@ -55,6 +57,7 @@ const MaxConnectionNumber = 1
 const DBConnRetryThreshold = 8
 
 const DBRefreshTime = time.Hour
+const staleDBConnCloseDelay = 30 * time.Second
 
 type DBUser struct {
 	UserName string
@@ -90,72 +93,139 @@ func GetSQLWriterDBAddressFunc() func(context.Context, bool) (string, error) {
 	}
 }
 
+func setDBConnLocked(conn *sql.DB) *sql.DB {
+	old := db.Swap(conn)
+	if conn == nil {
+		dbRefreshTime = time.Time{}
+	} else {
+		dbRefreshTime = time.Now().Add(DBRefreshTime)
+	}
+	if old == conn {
+		return nil
+	}
+	return old
+}
+
 func SetDBConn(conn *sql.DB) {
-	db.Store(conn)
-	dbRefreshTime = time.Now().Add(DBRefreshTime)
+	dbRebuildMux.Lock()
+	defer dbRebuildMux.Unlock()
+
+	dbMux.Lock()
+	defer dbMux.Unlock()
+	setDBConnLocked(conn)
 }
 
 func CloseDBConn() {
-	dbConn := db.Load()
+	dbRebuildMux.Lock()
+	defer dbRebuildMux.Unlock()
+
+	dbMux.Lock()
+	dbConn := setDBConnLocked(nil)
+	dbMux.Unlock()
+	closeDBConn(dbConn)
+}
+
+func closeDBConn(dbConn *sql.DB) {
 	if dbConn != nil {
-		dbConn.Close()
+		_ = dbConn.Close()
 	}
 }
 
+func closeStaleDBConn(dbConn *sql.DB) {
+	if dbConn == nil {
+		return
+	}
+	// DB.Close prevents new operations. Delay it so goroutines that already loaded
+	// the old pointer just before a swap do not fail immediately with a closed DB.
+	time.AfterFunc(staleDBConnCloseDelay, func() {
+		closeDBConn(dbConn)
+	})
+}
+
+func getDBConnSnapshot() (*sql.DB, bool) {
+	dbMux.Lock()
+	defer dbMux.Unlock()
+
+	dbConn := db.Load()
+	return dbConn, dbConn != nil && time.Now().After(dbRefreshTime)
+}
+
+func buildDBConn(randomCN bool) (*sql.DB, error) {
+	dbUser, _ := GetSQLWriterDBUser()
+	if dbUser == nil {
+		return nil, errNotReady
+	}
+
+	// TODO: trigger with new selected-CN, converge all connections
+	addressFunc := GetSQLWriterDBAddressFunc()
+	if addressFunc == nil {
+		return nil, errNotReady
+	}
+	dbAddress, err := addressFunc(context.Background(), randomCN)
+	if err != nil {
+		return nil, err
+	}
+	dsn :=
+		fmt.Sprintf("%s:%s@tcp(%s)/?readTimeout=10s&writeTimeout=15s&timeout=15s&maxAllowedPacket=0&disable_txn_trace=1",
+			dbUser.UserName,
+			dbUser.Password,
+			dbAddress)
+	newDBConn, err := openDBConn("mysql", dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	//45s suggest by xzxiong
+	newDBConn.SetConnMaxLifetime(45 * time.Second)
+	newDBConn.SetMaxOpenConns(MaxConnectionNumber)
+	newDBConn.SetMaxIdleConns(MaxConnectionNumber)
+	if err = newDBConn.Ping(); err != nil {
+		closeDBConn(newDBConn)
+		return nil, err
+	}
+	return newDBConn, nil
+}
+
+func rebuildDBConn(forceNewConn bool, randomCN bool) (*sql.DB, error) {
+	current, refreshDue := getDBConnSnapshot()
+	if current != nil && !forceNewConn && !refreshDue {
+		return current, nil
+	}
+
+	newDBConn, err := buildDBConn(randomCN)
+	if err != nil {
+		if current != nil && !forceNewConn {
+			return current, nil
+		}
+		return nil, err
+	}
+
+	dbMux.Lock()
+	oldDBConn := setDBConnLocked(newDBConn)
+	dbMux.Unlock()
+	closeStaleDBConn(oldDBConn)
+
+	return newDBConn, nil
+}
+
 // GetOrInitDBConn get the target cn to do the load query.
-// if @forceNewConn is true, it will force close old db conn, and re-find new cn.
+// if @forceNewConn is true, it will re-find new cn and replace the old db conn after the new one is ready.
 // if @forceNewConn is false, it will normally fetch the current db connection. BUT in 1 cases, it will re-find the cn:
 //  1. DBRefreshTime interval, it will try to fetch the 'new' ob-sys cn.
 var GetOrInitDBConn = func(forceNewConn bool, randomCN bool) (*sql.DB, error) {
-	dbMux.Lock()
-	defer dbMux.Unlock()
-	initFunc := func() error {
-		CloseDBConn()
-		dbUser, _ := GetSQLWriterDBUser()
-		if dbUser == nil {
-			return errNotReady
-		}
-
-		// TODO: trigger with new selected-CN, converge all connections
-		addressFunc := GetSQLWriterDBAddressFunc()
-		if addressFunc == nil {
-			return errNotReady
-		}
-		dbAddress, err := addressFunc(context.Background(), randomCN)
-		if err != nil {
-			return err
-		}
-		dsn :=
-			fmt.Sprintf("%s:%s@tcp(%s)/?readTimeout=10s&writeTimeout=15s&timeout=15s&maxAllowedPacket=0&disable_txn_trace=1",
-				dbUser.UserName,
-				dbUser.Password,
-				dbAddress)
-		newDBConn, err := sql.Open("mysql", dsn)
-		if err != nil {
-			return err
-		}
-
-		//45s suggest by xzxiong
-		newDBConn.SetConnMaxLifetime(45 * time.Second)
-		newDBConn.SetMaxOpenConns(MaxConnectionNumber)
-		newDBConn.SetMaxIdleConns(MaxConnectionNumber)
-		SetDBConn(newDBConn)
-		return nil
+	current, refreshDue := getDBConnSnapshot()
+	if current != nil && !forceNewConn && !refreshDue {
+		return current, nil
 	}
-
-	if forceNewConn || db.Load() == nil {
-		err := initFunc()
-		if err != nil {
-			return nil, err
-		}
-	} else if time.Now().After(dbRefreshTime) {
-		err := initFunc()
-		if err != nil {
-			return nil, err
-		}
+	if current != nil && !forceNewConn && refreshDue && !dbRebuildMux.TryLock() {
+		return current, nil
 	}
+	if current == nil || forceNewConn || !refreshDue {
+		dbRebuildMux.Lock()
+	}
+	defer dbRebuildMux.Unlock()
 
-	return db.Load(), nil
+	return rebuildDBConn(forceNewConn, randomCN)
 }
 
 func WriteRowRecords(records [][]string, tbl *table.Table, timeout time.Duration) (int, error) {
@@ -176,7 +246,7 @@ func WriteRowRecords(records [][]string, tbl *table.Table, timeout time.Duration
 		_ = DBConnErrCount.Count()
 		return 0, err
 	}
-	if dbConn.Ping() != nil {
+	if err = dbConn.Ping(); err != nil {
 		v2.TraceMOLoggerErrorPingDBCounter.Inc()
 		_ = DBConnErrCount.Count()
 		return 0, err

--- a/pkg/util/export/etl/db/db_holder.go
+++ b/pkg/util/export/etl/db/db_holder.go
@@ -213,6 +213,8 @@ func rebuildDBConn(forceNewConn bool, randomCN bool) (*sql.DB, error) {
 
 // GetOrInitDBConn get the target cn to do the load query.
 // if @forceNewConn is true, it will re-find new cn and replace the old db conn after the new one is ready.
+// The reconnect decision is rechecked after acquiring the rebuild lock, so callers queued behind a successful
+// reconnect reuse the fresh current db conn instead of serially rebuilding more pools.
 // if @forceNewConn is false, it will normally fetch the current db connection. BUT in 1 cases, it will re-find the cn:
 //  1. DBRefreshTime interval, it will try to fetch the 'new' ob-sys cn.
 var GetOrInitDBConn = func(forceNewConn bool, randomCN bool) (*sql.DB, error) {
@@ -227,6 +229,13 @@ var GetOrInitDBConn = func(forceNewConn bool, randomCN bool) (*sql.DB, error) {
 		dbRebuildMux.Lock()
 	}
 	defer dbRebuildMux.Unlock()
+
+	if forceNewConn {
+		current, _ = getDBConnSnapshot()
+		if current != nil && DBConnErrCount.Check() {
+			return current, nil
+		}
+	}
 
 	return rebuildDBConn(forceNewConn, randomCN)
 }

--- a/pkg/util/export/etl/db/db_holder_test.go
+++ b/pkg/util/export/etl/db/db_holder_test.go
@@ -17,6 +17,7 @@ package db_holder
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"reflect"
 	"regexp"
 	"sync"
@@ -247,6 +248,217 @@ func TestCheck(t *testing.T) {
 	backOff.last = time.Now().Add(time.Hour)
 	got = backOff.Check()
 	require.Equal(t, true, got)
+}
+
+func TestCloseDBConnClearsGlobalPointer(t *testing.T) {
+	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		CloseDBConn()
+		dbConn, _, err := sqlmock.New()
+		require.NoError(t, err)
+
+		SetDBConn(dbConn)
+		require.Same(t, dbConn, db.Load())
+
+		CloseDBConn()
+		require.Nil(t, db.Load())
+		require.Error(t, dbConn.Ping())
+	})
+}
+
+func TestGetOrInitDBConn_RebuildFailureKeepsCurrentConn(t *testing.T) {
+	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		CloseDBConn()
+		dbConn, _, err := sqlmock.New()
+		require.NoError(t, err)
+		SetDBConn(dbConn)
+		defer CloseDBConn()
+
+		SetSQLWriterDBUser("user", "password")
+		wantErr := errors.New("address failed")
+		SetSQLWriterDBAddressFunc(func(context.Context, bool) (string, error) {
+			return "", wantErr
+		})
+
+		got, err := GetOrInitDBConn(true, true)
+		require.ErrorIs(t, err, wantErr)
+		require.Nil(t, got)
+		require.Same(t, dbConn, db.Load())
+		require.NoError(t, dbConn.Ping())
+	})
+}
+
+func TestGetOrInitDBConn_OpenFailureKeepsCurrentConn(t *testing.T) {
+	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		CloseDBConn()
+		dbConn, _, err := sqlmock.New()
+		require.NoError(t, err)
+		SetDBConn(dbConn)
+		defer CloseDBConn()
+
+		SetSQLWriterDBUser("user", "password")
+		SetSQLWriterDBAddressFunc(func(context.Context, bool) (string, error) {
+			return "127.0.0.1:6001", nil
+		})
+
+		wantErr := errors.New("open failed")
+		stubs := gostub.Stub(&openDBConn, func(string, string) (*sql.DB, error) {
+			return nil, wantErr
+		})
+		defer stubs.Reset()
+
+		got, err := GetOrInitDBConn(true, true)
+		require.ErrorIs(t, err, wantErr)
+		require.Nil(t, got)
+		require.Same(t, dbConn, db.Load())
+		require.NoError(t, dbConn.Ping())
+	})
+}
+
+func TestGetOrInitDBConn_NewConnPingFailureKeepsCurrentConn(t *testing.T) {
+	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		CloseDBConn()
+		dbConn, _, err := sqlmock.New()
+		require.NoError(t, err)
+		SetDBConn(dbConn)
+		defer CloseDBConn()
+
+		newDBConn, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+		require.NoError(t, err)
+		wantErr := errors.New("ping failed")
+		mock.ExpectPing().WillReturnError(wantErr)
+		mock.ExpectClose()
+
+		SetSQLWriterDBUser("user", "password")
+		SetSQLWriterDBAddressFunc(func(context.Context, bool) (string, error) {
+			return "127.0.0.1:6001", nil
+		})
+
+		stubs := gostub.Stub(&openDBConn, func(string, string) (*sql.DB, error) {
+			return newDBConn, nil
+		})
+		defer stubs.Reset()
+
+		got, err := GetOrInitDBConn(true, true)
+		require.ErrorIs(t, err, wantErr)
+		require.Nil(t, got)
+		require.Same(t, dbConn, db.Load())
+		require.NoError(t, dbConn.Ping())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestGetOrInitDBConn_RefreshFailureUsesCurrentConn(t *testing.T) {
+	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		CloseDBConn()
+		dbConn, _, err := sqlmock.New()
+		require.NoError(t, err)
+		SetDBConn(dbConn)
+		dbRefreshTime = time.Now().Add(-time.Second)
+		defer CloseDBConn()
+
+		SetSQLWriterDBUser("user", "password")
+		SetSQLWriterDBAddressFunc(func(context.Context, bool) (string, error) {
+			return "", errors.New("address failed")
+		})
+
+		got, err := GetOrInitDBConn(false, false)
+		require.NoError(t, err)
+		require.Same(t, dbConn, got)
+		require.Same(t, dbConn, db.Load())
+		require.NoError(t, dbConn.Ping())
+	})
+}
+
+func TestGetOrInitDBConn_RefreshInProgressUsesCurrentConn(t *testing.T) {
+	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		CloseDBConn()
+		dbConn, _, err := sqlmock.New()
+		require.NoError(t, err)
+		SetDBConn(dbConn)
+		dbRefreshTime = time.Now().Add(-time.Second)
+		defer CloseDBConn()
+
+		newDBConn, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+		require.NoError(t, err)
+		mock.ExpectPing()
+
+		SetSQLWriterDBUser("user", "password")
+		SetSQLWriterDBAddressFunc(func(context.Context, bool) (string, error) {
+			return "127.0.0.1:6001", nil
+		})
+
+		started := make(chan struct{})
+		release := make(chan struct{})
+		var releaseOnce sync.Once
+		defer releaseOnce.Do(func() { close(release) })
+
+		stubs := gostub.Stub(&openDBConn, func(string, string) (*sql.DB, error) {
+			close(started)
+			<-release
+			return newDBConn, nil
+		})
+		defer stubs.Reset()
+
+		done := make(chan struct{})
+		var refreshConn *sql.DB
+		var refreshErr error
+		go func() {
+			refreshConn, refreshErr = GetOrInitDBConn(false, false)
+			close(done)
+		}()
+
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("refresh did not start")
+		}
+
+		start := time.Now()
+		got, err := GetOrInitDBConn(false, false)
+		require.NoError(t, err)
+		require.Same(t, dbConn, got)
+		require.Less(t, time.Since(start), 100*time.Millisecond)
+
+		releaseOnce.Do(func() { close(release) })
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("refresh did not finish")
+		}
+		require.NoError(t, refreshErr)
+		require.Same(t, newDBConn, refreshConn)
+		require.Same(t, newDBConn, db.Load())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestWriteRowRecords_ReturnsPingError(t *testing.T) {
+	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		old := DBConnErrCount
+		defer func() {
+			DBConnErrCount = old
+		}()
+		DBConnErrCount = NewReConnectionBackOff(time.Hour, DBConnRetryThreshold)
+
+		dbConn, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		mock.ExpectClose()
+		require.NoError(t, dbConn.Close())
+
+		stubs := gostub.Stub(&GetOrInitDBConn, func(bool, bool) (*sql.DB, error) {
+			return dbConn, nil
+		})
+		defer stubs.Reset()
+
+		tbl := &table.Table{
+			Database: "testDB",
+			Table:    "testTable",
+			Columns:  []table.Column{{Name: "str", ColType: table.TVarchar}},
+		}
+		_, err = WriteRowRecords([][]string{{"record1"}}, tbl, time.Second)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "database is closed")
+	})
 }
 
 func Test_WriteRowRecords2(t *testing.T) {

--- a/pkg/util/export/etl/db/db_holder_test.go
+++ b/pkg/util/export/etl/db/db_holder_test.go
@@ -250,6 +250,16 @@ func TestCheck(t *testing.T) {
 	require.Equal(t, true, got)
 }
 
+func TestReset(t *testing.T) {
+	backOff := NewReConnectionBackOff(time.Hour, 0)
+	backOff.Count()
+	require.False(t, backOff.Check())
+
+	backOff.Reset()
+	require.True(t, backOff.Check())
+	require.Equal(t, 0, backOff.count)
+}
+
 func TestCloseDBConnClearsGlobalPointer(t *testing.T) {
 	SyncTestWriteRowRecords(t, func(t *testing.T) {
 		CloseDBConn()
@@ -262,6 +272,44 @@ func TestCloseDBConnClearsGlobalPointer(t *testing.T) {
 		CloseDBConn()
 		require.Nil(t, db.Load())
 		require.Error(t, dbConn.Ping())
+	})
+}
+
+func TestGetOrInitDBConn_ForceReconnectSuccessResetsBackoff(t *testing.T) {
+	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		old := DBConnErrCount
+		defer func() {
+			DBConnErrCount = old
+		}()
+		DBConnErrCount = NewReConnectionBackOff(time.Hour, 0)
+		DBConnErrCount.Count()
+		require.False(t, DBConnErrCount.Check())
+
+		CloseDBConn()
+		dbConn, _, err := sqlmock.New()
+		require.NoError(t, err)
+		SetDBConn(dbConn)
+		defer CloseDBConn()
+
+		newDBConn, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+		require.NoError(t, err)
+		mock.ExpectPing()
+
+		SetSQLWriterDBUser("user", "password")
+		SetSQLWriterDBAddressFunc(func(context.Context, bool) (string, error) {
+			return "127.0.0.1:6001", nil
+		})
+
+		stubs := gostub.Stub(&openDBConn, func(string, string) (*sql.DB, error) {
+			return newDBConn, nil
+		})
+		defer stubs.Reset()
+
+		got, err := GetOrInitDBConn(true, true)
+		require.NoError(t, err)
+		require.Same(t, newDBConn, got)
+		require.True(t, DBConnErrCount.Check())
+		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }
 
@@ -428,6 +476,47 @@ func TestGetOrInitDBConn_RefreshInProgressUsesCurrentConn(t *testing.T) {
 		require.NoError(t, refreshErr)
 		require.Same(t, newDBConn, refreshConn)
 		require.Same(t, newDBConn, db.Load())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestWriteRowRecords_ResetBackoffAfterSuccessfulWrite(t *testing.T) {
+	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		old := DBConnErrCount
+		defer func() {
+			DBConnErrCount = old
+		}()
+		DBConnErrCount = NewReConnectionBackOff(time.Hour, 0)
+		DBConnErrCount.Count()
+
+		dbConn, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer dbConn.Close()
+
+		for i := 0; i < 3; i++ {
+			mock.ExpectExec(regexp.QuoteMeta(`LOAD DATA INLINE FORMAT='csv', DATA='record1
+' INTO TABLE testDB.testTable`)).WillReturnResult(sqlmock.NewResult(1, 1))
+		}
+
+		var forceNewConnFlags []bool
+		stubs := gostub.Stub(&GetOrInitDBConn, func(forceNewConn bool, randomCN bool) (*sql.DB, error) {
+			forceNewConnFlags = append(forceNewConnFlags, forceNewConn)
+			return dbConn, nil
+		})
+		defer stubs.Reset()
+
+		tbl := &table.Table{
+			Database: "testDB",
+			Table:    "testTable",
+			Columns:  []table.Column{{Name: "str", ColType: table.TVarchar}},
+		}
+		for i := 0; i < 3; i++ {
+			n, err := WriteRowRecords([][]string{{"record1"}}, tbl, time.Second)
+			require.NoError(t, err)
+			require.Equal(t, 1, n)
+		}
+
+		require.Equal(t, []bool{true, false, false}, forceNewConnFlags)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }

--- a/pkg/util/export/etl/db/db_holder_test.go
+++ b/pkg/util/export/etl/db/db_holder_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"regexp"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,6 +41,17 @@ func SyncTestWriteRowRecords(t *testing.T, f func(t *testing.T)) {
 	testWriteRowRecordsMux.Lock()
 	defer testWriteRowRecordsMux.Unlock()
 	f(t)
+}
+
+func setDBConnBackoffExceeded(t *testing.T) {
+	t.Helper()
+
+	old := DBConnErrCount
+	DBConnErrCount = NewReConnectionBackOff(time.Hour, 0)
+	DBConnErrCount.Count()
+	t.Cleanup(func() {
+		DBConnErrCount = old
+	})
 }
 
 func TestBulkInsert(t *testing.T) {
@@ -277,12 +289,7 @@ func TestCloseDBConnClearsGlobalPointer(t *testing.T) {
 
 func TestGetOrInitDBConn_ForceReconnectSuccessResetsBackoff(t *testing.T) {
 	SyncTestWriteRowRecords(t, func(t *testing.T) {
-		old := DBConnErrCount
-		defer func() {
-			DBConnErrCount = old
-		}()
-		DBConnErrCount = NewReConnectionBackOff(time.Hour, 0)
-		DBConnErrCount.Count()
+		setDBConnBackoffExceeded(t)
 		require.False(t, DBConnErrCount.Check())
 
 		CloseDBConn()
@@ -313,8 +320,91 @@ func TestGetOrInitDBConn_ForceReconnectSuccessResetsBackoff(t *testing.T) {
 	})
 }
 
+func TestGetOrInitDBConn_ConcurrentForceReconnectBuildsOnce(t *testing.T) {
+	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		setDBConnBackoffExceeded(t)
+
+		CloseDBConn()
+		dbConn, _, err := sqlmock.New()
+		require.NoError(t, err)
+		SetDBConn(dbConn)
+		defer CloseDBConn()
+
+		newDBConn, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+		require.NoError(t, err)
+		mock.ExpectPing()
+
+		SetSQLWriterDBUser("user", "password")
+		SetSQLWriterDBAddressFunc(func(context.Context, bool) (string, error) {
+			return "127.0.0.1:6001", nil
+		})
+
+		firstOpenStarted := make(chan struct{})
+		releaseOpen := make(chan struct{})
+		var releaseOnce sync.Once
+		defer releaseOnce.Do(func() { close(releaseOpen) })
+
+		var openCount atomic.Int32
+		stubs := gostub.Stub(&openDBConn, func(string, string) (*sql.DB, error) {
+			if openCount.Add(1) == 1 {
+				close(firstOpenStarted)
+				<-releaseOpen
+				return newDBConn, nil
+			}
+			return nil, errors.New("unexpected extra rebuild")
+		})
+		defer stubs.Reset()
+
+		const callers = 8
+		results := make(chan *sql.DB, callers)
+		errs := make(chan error, callers)
+		var wg sync.WaitGroup
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := GetOrInitDBConn(true, true)
+			results <- conn
+			errs <- err
+		}()
+
+		select {
+		case <-firstOpenStarted:
+		case <-time.After(time.Second):
+			t.Fatal("first reconnect did not start")
+		}
+
+		for i := 1; i < callers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				conn, err := GetOrInitDBConn(true, true)
+				results <- conn
+				errs <- err
+			}()
+		}
+
+		releaseOnce.Do(func() { close(releaseOpen) })
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for err := range errs {
+			require.NoError(t, err)
+		}
+		for conn := range results {
+			require.Same(t, newDBConn, conn)
+		}
+		require.Equal(t, int32(1), openCount.Load())
+		require.True(t, DBConnErrCount.Check())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
 func TestGetOrInitDBConn_RebuildFailureKeepsCurrentConn(t *testing.T) {
 	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		setDBConnBackoffExceeded(t)
+
 		CloseDBConn()
 		dbConn, _, err := sqlmock.New()
 		require.NoError(t, err)
@@ -337,6 +427,8 @@ func TestGetOrInitDBConn_RebuildFailureKeepsCurrentConn(t *testing.T) {
 
 func TestGetOrInitDBConn_OpenFailureKeepsCurrentConn(t *testing.T) {
 	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		setDBConnBackoffExceeded(t)
+
 		CloseDBConn()
 		dbConn, _, err := sqlmock.New()
 		require.NoError(t, err)
@@ -364,6 +456,8 @@ func TestGetOrInitDBConn_OpenFailureKeepsCurrentConn(t *testing.T) {
 
 func TestGetOrInitDBConn_NewConnPingFailureKeepsCurrentConn(t *testing.T) {
 	SyncTestWriteRowRecords(t, func(t *testing.T) {
+		setDBConnBackoffExceeded(t)
+
 		CloseDBConn()
 		dbConn, _, err := sqlmock.New()
 		require.NoError(t, err)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Refs #25136
Cherry-pick of #25137 to `4.0-dev`.

## What this PR does / why we need it:

This cherry-picks the ETL SQL writer DB holder reconnect fix to `4.0-dev`.

- Builds and validates the replacement DB connection before swapping it into the global holder.
- Clears the global DB pointer before explicit close, so callers cannot keep loading a closed handle.
- Keeps using the existing DB connection when ordinary refresh fails.
- Avoids blocking ordinary callers on an in-progress refresh when an old connection is still available.
- Rechecks reconnect state after acquiring the rebuild lock, so callers queued behind a successful forced reconnect reuse the fresh DB pool instead of serially rebuilding more pools.
- Delays stale connection close after swap to reduce the window where a goroutine that already loaded the old pointer immediately hits `sql: database is closed`.
- Resets reconnect backoff after successful forced reconnect and successful SQL write, so recovery does not keep rebuilding a new DB pool on every healthy batch during the remaining backoff window.
- Returns the real `Ping()` error from `WriteRowRecords`.
- Adds regression coverage for address lookup failure, `sql.Open` failure, new connection `Ping` failure, refresh fallback, refresh-in-progress fallback, explicit close cleanup, `Ping()` error propagation, backoff reset after recovery, and concurrent forced reconnect coalescing.

Validation on `4.0-dev`:

```text
go test ./pkg/util/export/etl/db
go test -race ./pkg/util/export/etl/db
CGO_CFLAGS="-I/home/xupeng/matrixone/thirdparties/install/include" CGO_LDFLAGS="-L/home/xupeng/matrixone/thirdparties/install/lib -Wl,-rpath,/home/xupeng/matrixone/thirdparties/install/lib" go test ./pkg/util/export/etl
```