### PR TITLE
fix lockservice orphan remote txn validation

### DIFF
--- a/pkg/lockservice/orphan_txn_test.go
+++ b/pkg/lockservice/orphan_txn_test.go
@@ -804,6 +804,20 @@ func TestValidTxnWithInvalidRemoteTxn(t *testing.T) {
 	require.False(t, hold.isValidRemoteTxn(pb.WaitTxn{TxnID: []byte{1}, CreatedOn: "s0"}))
 }
 
+func TestValidTxnWithInactiveRemoteTxnAndNotifyFoundCommitting(t *testing.T) {
+	hold := newMapBasedTxnHandler(
+		"s1",
+		getLogger(""),
+		newFixedSlicePool(16),
+		func(sid string) (bool, error) { return false, nil },
+		func(ot []pb.OrphanTxn) ([][]byte, error) { return [][]byte{{1}}, nil },
+		func(txn pb.WaitTxn) (bool, error) {
+			return false, nil
+		},
+	).(*mapBasedTxnHolder)
+	require.True(t, hold.isValidRemoteTxn(pb.WaitTxn{TxnID: []byte{1}, CreatedOn: "s0"}))
+}
+
 func TestValidTxnWithInvalidRemoteTxnAndNotifyOK(t *testing.T) {
 	hold := newMapBasedTxnHandler(
 		"s1",

--- a/pkg/lockservice/service.go
+++ b/pkg/lockservice/service.go
@@ -930,7 +930,13 @@ func (h *mapBasedTxnHolder) isValidRemoteTxn(txn pb.WaitTxn) bool {
 
 	valid, err := h.validTxn(txn)
 	if err == nil {
-		return valid
+		if valid {
+			return true
+		}
+		// A remote CN active-txn miss does not prove the txn is safe to unlock.
+		// The commit response may be lost after TN has already committed it, so
+		// require the allocator to confirm the txn cannot still be committing.
+		return !h.canUnlockRemoteTxn(txn)
 	}
 	logValidTxnFailed(h.logger, txn, err)
 	if isRetryError(err) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25126
issue #22791

## What this PR does / why we need it:

Backport of #25150 to 3.0-dev.

Remote lock orphan cleanup used to treat a missing remote CN active transaction as enough proof that the holder could be unlocked. That is unsafe when the commit response is lost after TN has already accepted or is processing the commit: the waiter can release the holder lock with an empty commit timestamp and continue on an old snapshot.

This PR makes the remote orphan check ask the allocator before releasing such a holder. If the allocator reports the txn is still committing, lockservice keeps the holder valid and does not unlock it as an orphan. Only txns confirmed as not committing continue down the orphan unlock path.

A unit test covers the inactive-remote-txn plus committing-in-allocator case so the waiter orphan cleanup path does not regress.

## Test

```
GOCACHE=/private/tmp/mo-gocache-issue25126-3dev go test ./pkg/lockservice -run 'TestValidTxnWith|TestCanUnlockRemoteTxn' -count=1
```
