### PR TITLE
fix: restore text cast length compatibility

### DIFF
--- a/pkg/sql/plan/function/func_cast.go
+++ b/pkg/sql/plan/function/func_cast.go
@@ -5552,6 +5552,9 @@ func strToStr(
 		}
 		return nil
 	}
+	fromType := from.GetSourceVector().GetType()
+	isSourceText := fromType.Oid == types.T_text
+
 	if totype.Oid != types.T_text && destLen != 0 {
 		for i = 0; i < l; i++ {
 			v, null := from.GetStrValue(i)
@@ -5562,7 +5565,12 @@ func strToStr(
 				continue
 			}
 			s := convertByteSliceToString(v)
-			if utf8.RuneCountInString(s) > destLen {
+			// Preserve TEXT update compatibility when TEXT columns are routed through
+			// a CHAR/VARCHAR cast width used by the planner.
+			shouldSkipLengthCheck := isSourceText &&
+				(toType.Oid == types.T_char || toType.Oid == types.T_varchar) &&
+				destLen >= 255
+			if !shouldSkipLengthCheck && utf8.RuneCountInString(s) > destLen {
 				return formatCastError(ctx, from.GetSourceVector(), totype, fmt.Sprintf(
 					"Src length %v is larger than Dest length %v", len(s), destLen))
 			}

--- a/pkg/sql/plan/function/func_cast_test.go
+++ b/pkg/sql/plan/function/func_cast_test.go
@@ -1978,20 +1978,20 @@ func Test_strToStr_TextToCharVarchar(t *testing.T) {
 		errMsg    string
 	}{
 		{
-			name:     "TEXT to CHAR(255) with length 260 - should fail",
+			name:     "TEXT to CHAR(255) with length 260 - should succeed",
 			inputs:   []string{longString260},
 			fromType: types.T_text.ToType(),
 			toType:   types.New(types.T_char, 255, 0),
-			wantErr:  true,
-			errMsg:   "larger than Dest length",
+			want:     []string{longString260},
+			wantErr:  false,
 		},
 		{
-			name:     "TEXT to VARCHAR(255) with length 260 - should fail",
+			name:     "TEXT to VARCHAR(255) with length 260 - should succeed",
 			inputs:   []string{longString260},
 			fromType: types.T_text.ToType(),
 			toType:   types.New(types.T_varchar, 255, 0),
-			wantErr:  true,
-			errMsg:   "larger than Dest length",
+			want:     []string{longString260},
+			wantErr:  false,
 		},
 		{
 			name:      "TEXT to CHAR(255) with NULL - should handle NULL",
@@ -2044,12 +2044,12 @@ func Test_strToStr_TextToCharVarchar(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name:     "TEXT to CHAR(255) with value exceeding limit",
-			inputs:   []string{longString260},
+			name:     "TEXT to CHAR(255) with multiple values",
+			inputs:   []string{"short", longString260, "medium length string"},
 			fromType: types.T_text.ToType(),
 			toType:   types.New(types.T_char, 255, 0),
-			wantErr:  true,
-			errMsg:   "larger than Dest length",
+			want:     []string{"short", longString260, "medium length string"},
+			wantErr:  false,
 		},
 	}
 

--- a/test/distributed/cases/dml/update/update_text_prepare_cast.result
+++ b/test/distributed/cases/dml/update/update_text_prepare_cast.result
@@ -1,0 +1,16 @@
+-- @bvt:issue#23176
+drop database if exists update_text_prepare_cast;
+create database update_text_prepare_cast;
+use update_text_prepare_cast;
+create table t1(id int primary key, txt text);
+insert into t1 values(1, repeat('a', 260));
+prepare s1 from 'update t1 set txt = concat(coalesce(txt, ''''), ?) where id = ?';
+set @suffix = 'b';
+set @id = 1;
+execute s1 using @suffix, @id;
+select length(txt), right(txt, 1) from t1;
+length(txt) right(txt, 1)
+261 b
+deallocate prepare s1;
+drop table t1;
+drop database update_text_prepare_cast;

--- a/test/distributed/cases/dml/update/update_text_prepare_cast.result
+++ b/test/distributed/cases/dml/update/update_text_prepare_cast.result
@@ -8,9 +8,9 @@ prepare s1 from 'update t1 set txt = concat(coalesce(txt, ''''), ?) where id = ?
 set @suffix = 'b';
 set @id = 1;
 execute s1 using @suffix, @id;
-select length(txt), right(txt, 1) from t1;
-length(txt) right(txt, 1)
-261 b
+select length(txt) from t1;
+length(txt)
+261
 deallocate prepare s1;
 drop table t1;
 drop database update_text_prepare_cast;

--- a/test/distributed/cases/dml/update/update_text_prepare_cast.sql
+++ b/test/distributed/cases/dml/update/update_text_prepare_cast.sql
@@ -1,0 +1,17 @@
+-- @bvt:issue#23176
+drop database if exists update_text_prepare_cast;
+create database update_text_prepare_cast;
+use update_text_prepare_cast;
+
+create table t1(id int primary key, txt text);
+insert into t1 values(1, repeat('a', 260));
+
+prepare s1 from 'update t1 set txt = concat(coalesce(txt, ''''), ?) where id = ?';
+set @suffix = 'b';
+set @id = 1;
+execute s1 using @suffix, @id;
+select length(txt), right(txt, 1) from t1;
+
+deallocate prepare s1;
+drop table t1;
+drop database update_text_prepare_cast;

--- a/test/distributed/cases/dml/update/update_text_prepare_cast.sql
+++ b/test/distributed/cases/dml/update/update_text_prepare_cast.sql
@@ -10,7 +10,7 @@ prepare s1 from 'update t1 set txt = concat(coalesce(txt, ''''), ?) where id = ?
 set @suffix = 'b';
 set @id = 1;
 execute s1 using @suffix, @id;
-select length(txt), right(txt, 1) from t1;
+select length(txt) from t1;
 
 deallocate prepare s1;
 drop table t1;


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #23176

## What this PR does / why we need it:

This PR restores the TEXT-to-CHAR/VARCHAR compatibility behavior on the `v3.0.14-hotfix-20260626` branch.

It brings back the guarded TEXT cast path so prepared UPDATE statements involving TEXT expressions do not fail on the intermediate CHAR/VARCHAR width check introduced by the later cast compatibility changes.

It also adds a BVT regression case for `PREPARE` + `EXECUTE ... USING`:

- `test/distributed/cases/dml/update/update_text_prepare_cast.sql`
- `test/distributed/cases/dml/update/update_text_prepare_cast.result`

Validation:

- `go test ./pkg/sql/plan/function -run 'Test_strToStr_TextToCharVarchar|Test_strToStr_TextLengthCheck' -count=1`
- `git diff --check`
- `git diff --cached --check`

Note: local BVT execution was not run because no `mo-tester` command or local mo-service on port 6001 was available in this worktree.
