### PR TITLE
add mysql compatibility type conversion bvt cases

### DIFF
--- a/test/distributed/cases/dtype/mysql_compat_type_conversion.result
+++ b/test/distributed/cases/dtype/mysql_compat_type_conversion.result
@@ -1,0 +1,71 @@
+drop database if exists mysql_compat_type_conversion;
+create database mysql_compat_type_conversion;
+use mysql_compat_type_conversion;
+set time_zone = '+00:00';
+drop table if exists t_string_number;
+create table t_string_number (id int primary key, s varchar(20));
+insert into t_string_number values
+(1, '0007'),
+(2, '15'),
+(3, '-2'),
+(4, '  12');
+select id, s, s + 1 as plus_one, cast(s as decimal(10,2)) as as_decimal
+from t_string_number order by id;
+id    s    plus_one    as_decimal
+1    0007    8    7.00
+2    15    16    15.00
+3    -2    -1    -2.00
+4      12    13    12.00
+select id from t_string_number where s = 7 order by id;
+id
+1
+drop table t_string_number;
+select '9' between 2 and 10 as str_between_num,
+'9' in (8, 9, '10') as str_in_mixed,
+'08' = 8 as leading_zero_eq;
+str_between_num    str_in_mixed    leading_zero_eq
+1    1    1
+select value_col
+from (select '1' as value_col union all select 2 union all select 3.50) as u
+order by cast(value_col as decimal(10,2));
+value_col
+1
+2
+3.50
+drop table if exists t_json_compat;
+create table t_json_compat (id int primary key, j json);
+insert into t_json_compat values
+(1, '{"a": "12", "b": 2}'),
+(2, '{"a": "003", "b": 4}');
+select id, json_extract(j, '$.a') as a_json,
+cast(json_unquote(json_extract(j, '$.a')) as signed) as a_signed,
+cast(json_extract(j, '$.b') as unsigned) as b_unsigned
+from t_json_compat order by id;
+id    a_json    a_signed    b_unsigned
+1    "12"    12    2
+2    "003"    3    4
+drop table t_json_compat;
+select if(1, '2', 3) as if_string_number,
+if(0, '2', 3) as if_number_branch,
+if(1, '2', 3) + 1 as if_plus_one;
+if_string_number    if_number_branch    if_plus_one
+2    3    3
+select case when 1 then '12.50' else 3.25 end as case_string_decimal,
+(case when 1 then '12.50' else 3.25 end) + 0.50 as case_decimal_plus;
+case_string_decimal    case_decimal_plus
+12.50    13.0
+select coalesce(null, '8', 9) as coalesce_string_number,
+coalesce(null, '8', 9) + 1 as coalesce_plus_one;
+coalesce_string_number    coalesce_plus_one
+8    9
+select ifnull(null, '8') as ifnull_string,
+ifnull(null, '8') + 1 as ifnull_plus_one,
+ifnull(7, '8') as ifnull_first_number;
+ifnull_string    ifnull_plus_one    ifnull_first_number
+8    9    7
+select nullif('8', 8) as nullif_equal,
+nullif('8', 9) as nullif_not_equal,
+nullif(8, '8') as nullif_num_str;
+nullif_equal    nullif_not_equal    nullif_num_str
+null    8    null
+drop database mysql_compat_type_conversion;

--- a/test/distributed/cases/dtype/mysql_compat_type_conversion.sql
+++ b/test/distributed/cases/dtype/mysql_compat_type_conversion.sql
@@ -1,0 +1,64 @@
+-- @suite
+-- @case
+-- @desc: MySQL compatibility cases for mixed type conversion, batch 1
+-- @label:bvt
+
+drop database if exists mysql_compat_type_conversion;
+create database mysql_compat_type_conversion;
+use mysql_compat_type_conversion;
+set time_zone = '+00:00';
+
+-- varchar column values used in numeric expressions and comparisons
+drop table if exists t_string_number;
+create table t_string_number (id int primary key, s varchar(20));
+insert into t_string_number values
+  (1, '0007'),
+  (2, '15'),
+  (3, '-2'),
+  (4, '  12');
+select id, s, s + 1 as plus_one, cast(s as decimal(10,2)) as as_decimal
+from t_string_number order by id;
+select id from t_string_number where s = 7 order by id;
+drop table t_string_number;
+
+-- mixed string and numeric comparisons
+select '9' between 2 and 10 as str_between_num,
+       '9' in (8, 9, '10') as str_in_mixed,
+       '08' = 8 as leading_zero_eq;
+
+select value_col
+from (select '1' as value_col union all select 2 union all select 3.50) as u
+order by cast(value_col as decimal(10,2));
+
+-- JSON-extracted scalar conversion
+drop table if exists t_json_compat;
+create table t_json_compat (id int primary key, j json);
+insert into t_json_compat values
+  (1, '{"a": "12", "b": 2}'),
+  (2, '{"a": "003", "b": 4}');
+select id, json_extract(j, '$.a') as a_json,
+       cast(json_unquote(json_extract(j, '$.a')) as signed) as a_signed,
+       cast(json_extract(j, '$.b') as unsigned) as b_unsigned
+from t_json_compat order by id;
+drop table t_json_compat;
+
+-- conditional expression values with mixed string and numeric branches
+select if(1, '2', 3) as if_string_number,
+       if(0, '2', 3) as if_number_branch,
+       if(1, '2', 3) + 1 as if_plus_one;
+
+select case when 1 then '12.50' else 3.25 end as case_string_decimal,
+       (case when 1 then '12.50' else 3.25 end) + 0.50 as case_decimal_plus;
+
+select coalesce(null, '8', 9) as coalesce_string_number,
+       coalesce(null, '8', 9) + 1 as coalesce_plus_one;
+
+select ifnull(null, '8') as ifnull_string,
+       ifnull(null, '8') + 1 as ifnull_plus_one,
+       ifnull(7, '8') as ifnull_first_number;
+
+select nullif('8', 8) as nullif_equal,
+       nullif('8', 9) as nullif_not_equal,
+       nullif(8, '8') as nullif_num_str;
+
+drop database mysql_compat_type_conversion;


### PR DESCRIPTION
## What changed

Added a focused BVT case for MySQL-compatible mixed type conversion behavior:

- varchar values in numeric expressions and numeric comparisons
- mixed string/number `BETWEEN`, `IN`, and equality comparison
- mixed string/number `UNION` result values
- JSON scalar extraction followed by numeric casts
- mixed string/number value behavior for `IF`, `CASE`, `COALESCE`, `IFNULL`, and `NULLIF`

## Why

These cases come from MySQL compatibility exploration for the type system/type conversion area. They are limited to statements whose output matches MySQL and avoid known incompatible cases that were filed separately.

## Duplicate check

Compared the retained scenarios against latest `origin/main` (`24d9d1ede`) and removed overlapping blocks such as YEAR, binary basics, basic CAST/CONVERT, temporal conversion, decimal/scientific notation, unsigned boundary values, and broad implicit insert matrices.

## Validation

- MySQL 8.0.45 vs MatrixOne 3.0-dev full-file diff: `DIFF_STATUS=0`
- `mo-tester` genrs completed successfully
- `mo-tester` run: `TOTAL:23, SUCCESS:23, FAILED:0, SUCCESS RATE:100%`
