### PR TITLE
fix: bound pipeline cleanup waits (cherry-pick #24972)

### DIFF
--- a/pkg/container/pSpool/sender.go
+++ b/pkg/container/pSpool/sender.go
@@ -16,8 +16,11 @@ package pSpool
 
 import (
 	"context"
-	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
 )
 
 const (
@@ -45,6 +48,8 @@ type PipelineSpool struct {
 	//
 	// the data producer should wait all consumers done before its close.
 	csDoneSignal chan struct{}
+
+	cleanupOnce sync.Once
 }
 
 // pipelineSpoolMessage is the element of PipelineSpool.
@@ -115,12 +120,65 @@ func (ps *PipelineSpool) ReceiveBatch(idx int) (data *batch.Batch, info error) {
 
 // Close the sender and receivers, and do memory clean.
 func (ps *PipelineSpool) Close() {
+	ps.CloseWithTimeout(0)
+}
+
+func (ps *PipelineSpool) CloseWithTimeout(timeout time.Duration) bool {
+	timer := (*time.Timer)(nil)
+	if timeout > 0 {
+		timer = time.NewTimer(timeout)
+		defer timer.Stop()
+	}
+
 	// wait for all receivers done its work first.
 	requireEndingReceiver := len(ps.rs)
 	for requireEndingReceiver > 0 {
 		requireEndingReceiver--
 
-		<-ps.csDoneSignal
+		if timer == nil {
+			<-ps.csDoneSignal
+			continue
+		}
+
+		select {
+		case <-ps.csDoneSignal:
+		case <-timer.C:
+			return false
+		}
+	}
+
+	ps.ForceCleanup()
+	return true
+}
+
+// ForceCleanup releases any spool-owned batch memory without waiting for
+// receivers. It is intended for query teardown after pipeline cleanup has
+// already stopped making progress.
+func (ps *PipelineSpool) ForceCleanup() {
+	if ps == nil {
+		return
+	}
+	ps.cleanupOnce.Do(ps.forceCleanup)
+}
+
+func (ps *PipelineSpool) forceCleanup() {
+	freeSlots := make([]bool, len(ps.shardPool))
+	for i := len(ps.freeShardPool); i > 0; i-- {
+		slot := <-ps.freeShardPool
+		freeSlots[slot] = true
+	}
+
+	for i := range ps.shardPool {
+		if freeSlots[i] {
+			continue
+		}
+
+		msg := &ps.shardPool[i]
+		ps.cache.CacheBatch(msg.useCache, msg.cacheID, msg.dataContent)
+		msg.dataContent = nil
+		msg.errContent = nil
+		msg.useCache = false
+		msg.cacheID = 0
 	}
 
 	ps.cache.free()

--- a/pkg/container/pSpool/sender_test.go
+++ b/pkg/container/pSpool/sender_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pSpool
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+)
+
+func TestPipelineSpoolForceCleanupSkipsFreedSlotsAndIsIdempotent(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := batch.NewWithSize(1)
+	src.Vecs[0] = vector.NewVec(types.New(types.T_int64, 0, 0))
+	values := make([]int64, 1024)
+	for i := range values {
+		values[i] = int64(i + 1)
+	}
+	require.NoError(t, vector.AppendFixedList[int64](src.Vecs[0], values, nil, srcMP))
+	src.SetRowCount(len(values))
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	sp := InitMyPipelineSpool(mp, 1)
+
+	queryDone, err := sp.SendBatch(context.Background(), 0, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	got, info := sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	require.NotNil(t, got)
+	sp.ReleaseCurrent(0)
+
+	queryDone, err = sp.SendBatch(context.Background(), 0, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	require.Greater(t, mp.CurrNB(), int64(0))
+
+	sp.ForceCleanup()
+	require.Equal(t, int64(0), mp.CurrNB())
+
+	sp.ForceCleanup()
+	require.Equal(t, int64(0), mp.CurrNB())
+}
+
+func TestPipelineSpoolCloseWithTimeoutCleansMemoryExactlyOnce(t *testing.T) {
+	mp := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(mp)
+	})
+
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := batch.NewWithSize(1)
+	src.Vecs[0] = vector.NewVec(types.New(types.T_int64, 0, 0))
+	values := []int64{1, 2, 3, 4}
+	require.NoError(t, vector.AppendFixedList[int64](src.Vecs[0], values, nil, srcMP))
+	src.SetRowCount(len(values))
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	sp := InitMyPipelineSpool(mp, 1)
+
+	queryDone, err := sp.SendBatch(context.Background(), 0, src, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	got, info := sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	require.NotNil(t, got)
+
+	queryDone, err = sp.SendBatch(context.Background(), 0, nil, nil)
+	require.NoError(t, err)
+	require.False(t, queryDone)
+	got, info = sp.ReceiveBatch(0)
+	require.NoError(t, info)
+	require.Nil(t, got)
+
+	require.True(t, sp.CloseWithTimeout(time.Second))
+	require.Equal(t, int64(0), mp.CurrNB())
+
+	sp.ForceCleanup()
+	require.Equal(t, int64(0), mp.CurrNB())
+}

--- a/pkg/sql/colexec/connector/types.go
+++ b/pkg/sql/colexec/connector/types.go
@@ -30,7 +30,8 @@ var _ vm.Operator = new(Connector)
 type Connector struct {
 	ctr container
 
-	Reg *process.WaitRegister
+	Reg          *process.WaitRegister
+	cleanupSpool *pSpool.PipelineSpool
 	vm.OperatorBase
 }
 
@@ -79,15 +80,100 @@ func (connector *Connector) Release() {
 }
 
 func (connector *Connector) Reset(proc *process.Process, pipelineFailed bool, err error) {
-	if connector.ctr.sp != nil {
-		_, _ = connector.ctr.sp.SendBatch(context.TODO(), pSpool.SendToAllLocal, nil, err)
-		connector.Reg.Ch2 <- process.NewPipelineSignalToGetFromSpool(connector.ctr.sp, 0)
+	newDirectSignal := func() process.PipelineSignal {
+		if proc == nil {
+			return process.NewPipelineSignalToDirectly(nil, err, nil)
+		}
+		return process.NewPipelineSignalToDirectly(nil, err, proc.Mp())
+	}
 
-		connector.ctr.sp.Close()
+	if connector.ctr.sp != nil {
+		sp := connector.ctr.sp
+		sendCtx, cancel := context.WithTimeout(context.TODO(), process.PipelineSignalSendTimeout)
+		queryDone, sendErr := sp.SendBatch(sendCtx, pSpool.SendToAllLocal, nil, err)
+		cancel()
+
+		terminalSignal := newDirectSignal()
+		terminalSignalName := "direct"
+		if sendErr == nil && !queryDone {
+			terminalSignal = process.NewPipelineSignalToGetFromSpool(sp, 0)
+			terminalSignalName = "spool"
+		} else {
+			process.WarnPipelineCleanupf(
+				proc,
+				"connector_cleanup_enqueue_terminal_spool",
+				"connector cleanup timed out enqueueing terminal spool message: timeout=%s query_done=%t err=%v",
+				process.PipelineSignalSendTimeout,
+				queryDone,
+				sendErr)
+		}
+
+		sentTerminalSignal := process.SendPipelineSignalWithTimeout(connector.Reg, terminalSignal, process.PipelineSignalSendTimeout)
+		if !sentTerminalSignal {
+			chLen, chCap := process.WaitRegisterChannelState(connector.Reg)
+			process.WarnPipelineCleanupf(
+				proc,
+				"connector_cleanup_send_terminal_signal",
+				"connector cleanup timed out sending terminal %s signal: timeout=%s channel_len=%d channel_cap=%d pipeline_failed=%t err=%v",
+				terminalSignalName,
+				process.PipelineSignalSendTimeout,
+				chLen,
+				chCap,
+				pipelineFailed,
+				err)
+		}
+
+		spoolClosed := false
+		if terminalSignalName == "spool" && sentTerminalSignal {
+			spoolClosed = sp.CloseWithTimeout(process.PipelineSignalSendTimeout)
+			if !spoolClosed {
+				process.WarnPipelineCleanupf(
+					proc,
+					"connector_cleanup_close_spool",
+					"connector cleanup timed out closing pipeline spool: timeout=%s pipeline_failed=%t err=%v",
+					process.PipelineSignalSendTimeout,
+					pipelineFailed,
+					err)
+			}
+		} else {
+			process.WarnPipelineCleanupf(
+				proc,
+				"connector_cleanup_skip_spool_close",
+				"connector cleanup skipped waiting for pipeline spool close after terminal %s signal delivery failed or fell back: delivered=%t pipeline_failed=%t err=%v",
+				terminalSignalName,
+				sentTerminalSignal,
+				pipelineFailed,
+				err)
+		}
+		if !spoolClosed {
+			connector.cleanupSpool = sp
+		}
 		connector.ctr.sp = nil
 	} else {
-		connector.Reg.Ch2 <- process.NewPipelineSignalToDirectly(nil, err, proc.Mp())
+		if !process.SendPipelineSignalWithTimeout(
+			connector.Reg,
+			newDirectSignal(),
+			process.PipelineSignalSendTimeout) {
+			chLen, chCap := process.WaitRegisterChannelState(connector.Reg)
+			process.WarnPipelineCleanupf(
+				proc,
+				"connector_cleanup_send_terminal_signal",
+				"connector cleanup timed out sending terminal direct signal: timeout=%s channel_len=%d channel_cap=%d pipeline_failed=%t err=%v",
+				process.PipelineSignalSendTimeout,
+				chLen,
+				chCap,
+				pipelineFailed,
+				err)
+		}
 	}
+}
+
+func (connector *Connector) CleanupDeferredSpool() {
+	if connector.cleanupSpool == nil {
+		return
+	}
+	connector.cleanupSpool.ForceCleanup()
+	connector.cleanupSpool = nil
 }
 
 func (connector *Connector) Free(proc *process.Process, pipelineFailed bool, err error) {

--- a/pkg/sql/colexec/connector/types_test.go
+++ b/pkg/sql/colexec/connector/types_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connector
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+func TestConnectorResetReleasesDeferredSpoolMemoryAfterCleanupBarrier(t *testing.T) {
+	oldSignalSendTimeout := process.PipelineSignalSendTimeout
+	process.PipelineSignalSendTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		process.PipelineSignalSendTimeout = oldSignalSendTimeout
+	})
+
+	proc := testutil.NewProcess(t)
+	connector := NewArgument().WithReg(&process.WaitRegister{Ch2: make(chan process.PipelineSignal, 1)})
+	require.NoError(t, connector.Prepare(proc))
+
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := testutil.NewBatch([]types.Type{types.New(types.T_int64, 0, 0)}, true, 1024, srcMP)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	for i := 0; i < 2; i++ {
+		queryDone, err := connector.ctr.sp.SendBatch(context.Background(), 0, src, nil)
+		require.NoError(t, err)
+		require.False(t, queryDone)
+	}
+
+	require.Greater(t, proc.Mp().CurrNB(), int64(0))
+
+	connector.Reset(proc, true, moerr.NewInternalErrorNoCtx("cleanup"))
+	require.Greater(t, proc.Mp().CurrNB(), int64(0))
+
+	connector.CleanupDeferredSpool()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
+}

--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -15,14 +15,19 @@
 package dispatch
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/require"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
+	"github.com/matrixorigin/matrixone/pkg/container/pSpool"
+	"github.com/matrixorigin/matrixone/pkg/container/types"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
 	"github.com/matrixorigin/matrixone/pkg/testutil"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
@@ -78,6 +83,112 @@ func TestDispatchAdoptCleanupState_NilSafe(t *testing.T) {
 		target.AdoptCleanupState(nil)
 	})
 	require.Nil(t, target.ctr)
+}
+
+func TestDispatchResetDoesNotBlockWhenRemoteErrChannelIsFull(t *testing.T) {
+	_ = colexec.NewServer(nil)
+
+	proc := testutil.NewProcess(t)
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	errCh := make(chan error, 1)
+	errCh <- moerr.NewInternalErrorNoCtx("already notified")
+	d := &Dispatch{
+		ctr: &container{
+			isRemote: true,
+			remoteReceivers: []*process.WrapCs{
+				{Err: errCh, Uid: uid, MsgId: 1},
+			},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		d.Reset(proc, true, moerr.NewInternalErrorNoCtx("cleanup"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Dispatch.Reset blocked on a full remote receiver error channel")
+	}
+}
+
+func TestDispatchResetSendsHealthyLocalRegWhenEarlierRegIsFull(t *testing.T) {
+	oldSignalSendTimeout := process.PipelineSignalSendTimeout
+	process.PipelineSignalSendTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		process.PipelineSignalSendTimeout = oldSignalSendTimeout
+	})
+
+	fullReg := &process.WaitRegister{Ch2: make(chan process.PipelineSignal, 1)}
+	fullReg.Ch2 <- process.NewPipelineSignalToDirectly(nil, nil, nil)
+	healthyReg := &process.WaitRegister{Ch2: make(chan process.PipelineSignal, 1)}
+
+	d := &Dispatch{
+		LocalRegs: []*process.WaitRegister{fullReg, healthyReg},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		d.Reset(nil, true, moerr.NewInternalErrorNoCtx("cleanup"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Dispatch.Reset blocked on a full local receiver channel")
+	}
+
+	select {
+	case <-healthyReg.Ch2:
+	default:
+		t.Fatal("Dispatch.Reset did not notify a healthy local receiver after an earlier receiver channel was full")
+	}
+}
+
+func TestDispatchResetReleasesDeferredSpoolMemoryAfterCleanupBarrier(t *testing.T) {
+	oldSignalSendTimeout := process.PipelineSignalSendTimeout
+	process.PipelineSignalSendTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		process.PipelineSignalSendTimeout = oldSignalSendTimeout
+	})
+
+	proc := testutil.NewProcess(t)
+	dispatch := &Dispatch{
+		FuncId: SendToAllLocalFunc,
+		LocalRegs: []*process.WaitRegister{
+			{Ch2: make(chan process.PipelineSignal, 1)},
+			{Ch2: make(chan process.PipelineSignal, 1)},
+		},
+	}
+	require.NoError(t, dispatch.Prepare(proc))
+
+	srcMP := mpool.MustNewZeroNoFixed()
+	t.Cleanup(func() {
+		mpool.DeleteMPool(srcMP)
+	})
+	src := testutil.NewBatch([]types.Type{types.New(types.T_int64, 0, 0)}, true, 1024, srcMP)
+	t.Cleanup(func() {
+		src.Clean(srcMP)
+	})
+
+	for i := 0; i < 2; i++ {
+		queryDone, err := dispatch.ctr.sp.SendBatch(context.Background(), pSpool.SendToAllLocal, src, nil)
+		require.NoError(t, err)
+		require.False(t, queryDone)
+	}
+
+	require.Greater(t, proc.Mp().CurrNB(), int64(0))
+
+	dispatch.Reset(proc, true, moerr.NewInternalErrorNoCtx("cleanup"))
+	require.Greater(t, proc.Mp().CurrNB(), int64(0))
+
+	dispatch.CleanupDeferredSpool()
+	require.Equal(t, int64(0), proc.Mp().CurrNB())
 }
 
 // TestReceiverDone_OldBehavior tests the old behavior (kept for backward compatibility verification)

--- a/pkg/sql/colexec/dispatch/types.go
+++ b/pkg/sql/colexec/dispatch/types.go
@@ -72,7 +72,8 @@ type container struct {
 }
 
 type Dispatch struct {
-	ctr *container
+	ctr          *container
+	cleanupSpool *pSpool.PipelineSpool
 
 	// IsSink means this is a Sink Node
 	IsSink bool
@@ -139,10 +140,37 @@ func (dispatch *Dispatch) AdoptCleanupState(from *Dispatch) {
 }
 
 func (dispatch *Dispatch) Reset(proc *process.Process, pipelineFailed bool, err error) {
+	newDirectSignal := func() process.PipelineSignal {
+		if proc == nil {
+			return process.NewPipelineSignalToDirectly(nil, err, nil)
+		}
+		return process.NewPipelineSignalToDirectly(nil, err, proc.Mp())
+	}
+
 	if dispatch.ctr != nil {
 		if dispatch.ctr.isRemote {
 			for _, r := range dispatch.ctr.remoteReceivers {
-				r.Err <- err
+				if r == nil || r.Err == nil {
+					process.WarnPipelineCleanupf(
+						proc,
+						"dispatch_cleanup_remote_receiver_nil",
+						"dispatch cleanup skipped remote receiver error notification because receiver is nil: pipeline_failed=%t err=%v",
+						pipelineFailed,
+						err)
+					continue
+				}
+				select {
+				case r.Err <- err:
+				default:
+					process.WarnPipelineCleanupf(
+						proc,
+						"dispatch_cleanup_remote_err_channel_full",
+						"dispatch cleanup skipped remote receiver error notification because channel is full: receiver_uuid=%s msg_id=%d pipeline_failed=%t err=%v",
+						r.Uid.String(),
+						r.MsgId,
+						pipelineFailed,
+						err)
+				}
 			}
 
 			uuids := make([]uuid.UUID, 0, len(dispatch.RemoteRegs))
@@ -155,19 +183,129 @@ func (dispatch *Dispatch) Reset(proc *process.Process, pipelineFailed bool, err 
 
 	// told the local receiver to stop if it is still running.
 	if dispatch.ctr != nil && dispatch.ctr.sp != nil {
-		_, _ = dispatch.ctr.sp.SendBatch(context.TODO(), pSpool.SendToAllLocal, nil, err)
-		for i, reg := range dispatch.LocalRegs {
-			reg.Ch2 <- process.NewPipelineSignalToGetFromSpool(dispatch.ctr.sp, i)
+		sp := dispatch.ctr.sp
+		sendCtx, cancel := context.WithTimeout(context.TODO(), process.PipelineSignalSendTimeout)
+		queryDone, sendErr := sp.SendBatch(sendCtx, pSpool.SendToAllLocal, nil, err)
+		cancel()
+
+		terminalSignalName := "direct"
+		if sendErr == nil && !queryDone {
+			terminalSignalName = "spool"
+		} else {
+			process.WarnPipelineCleanupf(
+				proc,
+				"dispatch_cleanup_enqueue_terminal_spool",
+				"dispatch cleanup timed out enqueueing terminal spool message: timeout=%s query_done=%t err=%v",
+				process.PipelineSignalSendTimeout,
+				queryDone,
+				sendErr)
 		}
 
-		dispatch.ctr.sp.Close()
+		allTerminalSignalsSent := true
+		pendingLocalRegs := make([]int, 0, len(dispatch.LocalRegs))
+		for i, reg := range dispatch.LocalRegs {
+			terminalSignal := newDirectSignal()
+			if terminalSignalName == "spool" {
+				terminalSignal = process.NewPipelineSignalToGetFromSpool(sp, i)
+			}
+			if process.TrySendPipelineSignal(reg, terminalSignal) {
+				continue
+			}
+			pendingLocalRegs = append(pendingLocalRegs, i)
+		}
+
+		signalCtx, signalCancel := context.WithTimeout(context.TODO(), process.PipelineSignalSendTimeout)
+		for _, i := range pendingLocalRegs {
+			terminalSignal := newDirectSignal()
+			if terminalSignalName == "spool" {
+				terminalSignal = process.NewPipelineSignalToGetFromSpool(sp, i)
+			}
+			sentTerminalSignal := process.SendPipelineSignalWithContext(signalCtx, dispatch.LocalRegs[i], terminalSignal)
+			if !sentTerminalSignal {
+				allTerminalSignalsSent = false
+			}
+			if !sentTerminalSignal {
+				chLen, chCap := process.WaitRegisterChannelState(dispatch.LocalRegs[i])
+				process.WarnPipelineCleanupf(
+					proc,
+					"dispatch_cleanup_send_terminal_signal",
+					"dispatch cleanup timed out sending terminal %s signal: timeout=%s local_reg_idx=%d channel_len=%d channel_cap=%d pipeline_failed=%t err=%v",
+					terminalSignalName,
+					process.PipelineSignalSendTimeout,
+					i,
+					chLen,
+					chCap,
+					pipelineFailed,
+					err)
+			}
+		}
+		signalCancel()
+
+		spoolClosed := false
+		if terminalSignalName == "spool" && allTerminalSignalsSent {
+			spoolClosed = sp.CloseWithTimeout(process.PipelineSignalSendTimeout)
+			if !spoolClosed {
+				process.WarnPipelineCleanupf(
+					proc,
+					"dispatch_cleanup_close_spool",
+					"dispatch cleanup timed out closing pipeline spool: timeout=%s pipeline_failed=%t err=%v",
+					process.PipelineSignalSendTimeout,
+					pipelineFailed,
+					err)
+			}
+		} else {
+			process.WarnPipelineCleanupf(
+				proc,
+				"dispatch_cleanup_skip_spool_close",
+				"dispatch cleanup skipped waiting for pipeline spool close after terminal %s signal delivery failed or fell back: delivered_all=%t pipeline_failed=%t err=%v",
+				terminalSignalName,
+				allTerminalSignalsSent,
+				pipelineFailed,
+				err)
+		}
+		if !spoolClosed {
+			dispatch.cleanupSpool = sp
+		}
 		dispatch.ctr.sp = nil
 	} else {
-		for _, reg := range dispatch.LocalRegs {
-			reg.Ch2 <- process.NewPipelineSignalToDirectly(nil, err, proc.Mp())
+		pendingLocalRegs := make([]int, 0, len(dispatch.LocalRegs))
+		for i, reg := range dispatch.LocalRegs {
+			if process.TrySendPipelineSignal(reg, newDirectSignal()) {
+				continue
+			}
+			pendingLocalRegs = append(pendingLocalRegs, i)
 		}
+
+		signalCtx, signalCancel := context.WithTimeout(context.TODO(), process.PipelineSignalSendTimeout)
+		for _, i := range pendingLocalRegs {
+			if !process.SendPipelineSignalWithContext(
+				signalCtx,
+				dispatch.LocalRegs[i],
+				newDirectSignal()) {
+				chLen, chCap := process.WaitRegisterChannelState(dispatch.LocalRegs[i])
+				process.WarnPipelineCleanupf(
+					proc,
+					"dispatch_cleanup_send_terminal_signal",
+					"dispatch cleanup timed out sending terminal direct signal: timeout=%s local_reg_idx=%d channel_len=%d channel_cap=%d pipeline_failed=%t err=%v",
+					process.PipelineSignalSendTimeout,
+					i,
+					chLen,
+					chCap,
+					pipelineFailed,
+					err)
+			}
+		}
+		signalCancel()
 	}
 	dispatch.ctr = nil
+}
+
+func (dispatch *Dispatch) CleanupDeferredSpool() {
+	if dispatch.cleanupSpool == nil {
+		return
+	}
+	dispatch.cleanupSpool.ForceCleanup()
+	dispatch.cleanupSpool = nil
 }
 
 func (dispatch *Dispatch) Free(proc *process.Process, pipelineFailed bool, err error) {

--- a/pkg/sql/colexec/merge/types.go
+++ b/pkg/sql/colexec/merge/types.go
@@ -84,7 +84,20 @@ func (merge *Merge) Reset(proc *process.Process, pipelineFailed bool, err error)
 	if merge.ctr.receiver == nil {
 		_ = merge.Prepare(proc)
 	}
-	merge.ctr.receiver.WaitingEnd()
+	if !merge.ctr.receiver.WaitingEndWithTimeout(process.PipelineCleanupWaitTimeout) {
+		state := merge.ctr.receiver.State()
+		process.WarnPipelineCleanupf(
+			proc,
+			"merge_cleanup_wait_end_timeout",
+			"merge cleanup timed out waiting for pipeline end signals: timeout=%s alive=%d nil_batch_count=%v channel_len=%v channel_cap=%v pipeline_failed=%t err=%v",
+			process.PipelineCleanupWaitTimeout,
+			state.Alive,
+			state.NilBatches,
+			state.ChannelLen,
+			state.ChannelCap,
+			pipelineFailed,
+			err)
+	}
 }
 
 func (merge *Merge) Free(proc *process.Process, pipelineFailed bool, err error) {

--- a/pkg/sql/compile/scope.go
+++ b/pkg/sql/compile/scope.go
@@ -817,7 +817,20 @@ func (s *Scope) sendNotifyMessage(wg *sync.WaitGroup, resultChan chan notifyMess
 	// if context has done, it means the user or other part of the pipeline stops this query.
 	closeWithError := func(err error, reg *process.WaitRegister, sender *messageSenderOnClient) {
 		err = suppressRemoteRunCancelError(s.Proc.Ctx, err)
-		reg.Ch2 <- process.NewPipelineSignalToDirectly(nil, err, s.Proc.Mp())
+		if !process.SendPipelineSignalWithTimeout(
+			reg,
+			process.NewPipelineSignalToDirectly(nil, err, s.Proc.Mp()),
+			process.PipelineSignalSendTimeout) {
+			chLen, chCap := process.WaitRegisterChannelState(reg)
+			process.WarnPipelineCleanupf(
+				s.Proc,
+				"remote_notify_cleanup_send_terminal_signal",
+				"remote notify cleanup timed out sending terminal signal: timeout=%s channel_len=%d channel_cap=%d err=%v",
+				process.PipelineSignalSendTimeout,
+				chLen,
+				chCap,
+				err)
+		}
 		resultChan <- notifyMessageResult{err: err, sender: sender}
 		wg.Done()
 	}

--- a/pkg/util/metric/v2/metrics.go
+++ b/pkg/util/metric/v2/metrics.go
@@ -262,6 +262,7 @@ func initFrontendMetrics() {
 func initPipelineMetrics() {
 	registry.MustRegister(PipelineServerDurationHistogram)
 	registry.MustRegister(pipelineStreamGauge)
+	registry.MustRegister(PipelineCleanupEventCounter)
 }
 
 func initLogServiceMetrics() {

--- a/pkg/util/metric/v2/pipeline.go
+++ b/pkg/util/metric/v2/pipeline.go
@@ -36,4 +36,12 @@ var (
 			Help:      "Current number of stream connections to send messages to other CN (living senders).",
 		}, []string{"type"})
 	PipelineMessageSenderGauge = pipelineStreamGauge.WithLabelValues("living")
+
+	PipelineCleanupEventCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mo",
+			Subsystem: "pipeline",
+			Name:      "cleanup_event",
+			Help:      "Total number of abnormal pipeline cleanup events.",
+		}, []string{"event"})
 )

--- a/pkg/vm/pipeline/types.go
+++ b/pkg/vm/pipeline/types.go
@@ -15,6 +15,7 @@
 package pipeline
 
 import (
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/connector"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/dispatch"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec/merge"
 	"github.com/matrixorigin/matrixone/pkg/vm"
@@ -31,6 +32,26 @@ type Pipeline struct {
 	rootOp vm.Operator
 }
 
+type deferredSpoolCleaner interface {
+	CleanupDeferredSpool()
+}
+
+func cleanupDeferredSpool(op vm.Operator) {
+	if cleaner, ok := op.(deferredSpoolCleaner); ok {
+		cleaner.CleanupDeferredSpool()
+	}
+}
+
+func cleanupDeferredSpools(root vm.Operator) {
+	if root == nil {
+		return
+	}
+	_ = vm.HandleAllOp(root, func(_ vm.Operator, op vm.Operator) error {
+		cleanupDeferredSpool(op)
+		return nil
+	})
+}
+
 func IsCtePipelineAtLoop(rootOp vm.Operator) (isMergeCte bool, atLoop bool) {
 	// required:
 	// 1. it is a linked tree.
@@ -41,6 +62,32 @@ func IsCtePipelineAtLoop(rootOp vm.Operator) (isMergeCte bool, atLoop bool) {
 	return false, false
 }
 
+func getLeafMerge(root vm.Operator) (*merge.Merge, bool) {
+	if root == nil {
+		return nil, false
+	}
+	for {
+		children := root.GetOperatorBase().Children
+		if len(children) == 0 {
+			m, ok := root.(*merge.Merge)
+			return m, ok
+		}
+		if len(children) != 1 {
+			return nil, false
+		}
+		root = children[0]
+	}
+}
+
+func isTerminalSender(root vm.Operator) bool {
+	switch root.(type) {
+	case *connector.Connector, *dispatch.Dispatch:
+		return true
+	default:
+		return false
+	}
+}
+
 // CleanRootOperator only do free or reset work for the last operator.
 // this is just used for RemoteRun because we kept the root operator of remote-pipeline at local.
 func (p *Pipeline) CleanRootOperator(proc *process.Process, pipelineFailed bool, isPrepare bool, err error) {
@@ -48,6 +95,7 @@ func (p *Pipeline) CleanRootOperator(proc *process.Process, pipelineFailed bool,
 		return
 	}
 	p.rootOp.Reset(proc, pipelineFailed, err)
+	cleanupDeferredSpool(p.rootOp)
 	if !isPrepare {
 		p.rootOp.Free(proc, pipelineFailed, err)
 	}
@@ -60,9 +108,17 @@ func (p *Pipeline) Cleanup(proc *process.Process, pipelineFailed bool, isPrepare
 	proc.Cancel(err)
 
 	// do special cleanup for the pipeline at a loop.
-	if isMergeCte, isSpecial := IsCtePipelineAtLoop(p.rootOp); isSpecial {
+	isMergeCte, isSpecial := IsCtePipelineAtLoop(p.rootOp)
+	if isSpecial {
 		if proc.Base.GetContextBase().DoSpecialCleanUp(isMergeCte) {
 			p.cleanupLoopPipeline(proc, pipelineFailed, isPrepare, err)
+			return
+		}
+	}
+
+	if !isSpecial && isTerminalSender(p.rootOp) {
+		if mergeOperator, ok := getLeafMerge(p.rootOp); ok {
+			p.cleanupSenderReceiverPipeline(proc, pipelineFailed, isPrepare, err, mergeOperator)
 			return
 		}
 	}
@@ -77,9 +133,68 @@ func (p *Pipeline) cleanupInOrder(proc *process.Process, pipelineFailed bool, is
 			op.Reset(proc, pipelineFailed, err)
 			return nil
 		})
+		cleanupDeferredSpools(root)
 
 		if !isPrepare {
 			_ = vm.HandleAllOp(p.rootOp, func(aprentOp vm.Operator, op vm.Operator) error {
+				op.Free(proc, pipelineFailed, err)
+				return nil
+			})
+		}
+	}
+}
+
+func (p *Pipeline) cleanupSenderReceiverPipeline(
+	proc *process.Process,
+	pipelineFailed bool,
+	isPrepare bool,
+	err error,
+	mergeOperator *merge.Merge) {
+	// This cleanup order assumes the terminal sender Reset
+	// (Connector/Dispatch) does not read child operator state. It only sends
+	// terminal signals to unblock the leaf Merge, then the remaining children
+	// are reset in their original post-order.
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		mergeOperator.Reset(proc, pipelineFailed, err)
+		if !isPrepare {
+			mergeOperator.Free(proc, pipelineFailed, err)
+		}
+	}()
+
+	p.rootOp.Reset(proc, pipelineFailed, err)
+	if !isPrepare {
+		p.rootOp.Free(proc, pipelineFailed, err)
+	}
+	wg.Wait()
+	cleanupDeferredSpool(p.rootOp)
+
+	p.cleanupChildrenExceptMerge(proc, pipelineFailed, isPrepare, err, mergeOperator)
+}
+
+func (p *Pipeline) cleanupChildrenExceptMerge(
+	proc *process.Process,
+	pipelineFailed bool,
+	isPrepare bool,
+	err error,
+	skip *merge.Merge) {
+	for _, child := range p.rootOp.GetOperatorBase().Children {
+		_ = vm.HandleAllOp(child, func(_ vm.Operator, op vm.Operator) error {
+			if op == skip {
+				return nil
+			}
+			op.Reset(proc, pipelineFailed, err)
+			return nil
+		})
+		cleanupDeferredSpools(child)
+		if !isPrepare {
+			_ = vm.HandleAllOp(child, func(_ vm.Operator, op vm.Operator) error {
+				if op == skip {
+					return nil
+				}
 				op.Free(proc, pipelineFailed, err)
 				return nil
 			})
@@ -112,11 +227,11 @@ func (p *Pipeline) cleanupLoopPipeline(proc *process.Process, pipelineFailed boo
 	wg.Add(1)
 
 	go func() {
+		defer wg.Done()
 		mergeOperator.Reset(proc, pipelineFailed, err)
 		if !isPrepare {
 			mergeOperator.Free(proc, pipelineFailed, err)
 		}
-		wg.Done()
 	}()
 
 	dispatchOperator.Reset(proc, pipelineFailed, err)
@@ -124,19 +239,9 @@ func (p *Pipeline) cleanupLoopPipeline(proc *process.Process, pipelineFailed boo
 		dispatchOperator.Free(proc, pipelineFailed, err)
 	}
 	wg.Wait()
+	cleanupDeferredSpool(dispatchOperator)
 
 	// from first to last to clean up the left operators.
 
-	for _, child := range p.rootOp.GetOperatorBase().Children {
-		_ = vm.HandleAllOp(child, func(_ vm.Operator, op vm.Operator) error {
-			op.Reset(proc, pipelineFailed, err)
-			return nil
-		})
-		if !isPrepare {
-			_ = vm.HandleAllOp(child, func(_ vm.Operator, op vm.Operator) error {
-				op.Free(proc, pipelineFailed, err)
-				return nil
-			})
-		}
-	}
+	p.cleanupChildrenExceptMerge(proc, pipelineFailed, isPrepare, err, mergeOperator)
 }

--- a/pkg/vm/pipeline/types_test.go
+++ b/pkg/vm/pipeline/types_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/mpool"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/connector"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/merge"
+	"github.com/matrixorigin/matrixone/pkg/vm/process"
+)
+
+func TestCleanupInOrderReturnsWhenMergeEndSignalIsMissing(t *testing.T) {
+	oldCleanupWaitTimeout := process.PipelineCleanupWaitTimeout
+	oldSignalSendTimeout := process.PipelineSignalSendTimeout
+	process.PipelineCleanupWaitTimeout = time.Second
+	process.PipelineSignalSendTimeout = time.Second
+	t.Cleanup(func() {
+		process.PipelineCleanupWaitTimeout = oldCleanupWaitTimeout
+		process.PipelineSignalSendTimeout = oldSignalSendTimeout
+	})
+
+	proc := process.NewTopProcess(context.Background(), mpool.MustNewZeroNoFixed(), nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	proc.BuildPipelineContext(context.Background())
+
+	reg := &process.WaitRegister{Ch2: make(chan process.PipelineSignal, 1)}
+	proc.Reg.MergeReceivers = []*process.WaitRegister{reg}
+
+	mergeOp := merge.NewArgument()
+	t.Cleanup(mergeOp.Release)
+
+	connectorOp := connector.NewArgument().WithReg(reg)
+	t.Cleanup(connectorOp.Release)
+	connectorOp.AppendChild(mergeOp)
+	if err := connectorOp.Prepare(proc); err != nil {
+		t.Fatal(err)
+	}
+
+	p := New(0, nil, connectorOp)
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		p.Cleanup(proc, true, true, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+			t.Fatalf("pipeline cleanup did not take the sender/receiver fast cleanup path, elapsed %s", elapsed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("pipeline cleanup did not return after the merge cleanup timeout")
+	}
+}

--- a/pkg/vm/process/process_cleanup_log.go
+++ b/pkg/vm/process/process_cleanup_log.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+import (
+	"sync"
+	"time"
+
+	metricv2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+)
+
+const (
+	pipelineCleanupWarnInterval       = 10 * time.Second
+	pipelineCleanupWarnBurstCount     = int64(3)
+	pipelineCleanupWarnSampleInterval = int64(100)
+)
+
+var pipelineCleanupWarnLimiter = newCleanupWarnLimiter()
+
+type cleanupWarnLimiter struct {
+	mu     sync.Mutex
+	states map[string]*cleanupWarnState
+}
+
+type cleanupWarnState struct {
+	count      int64
+	suppressed int64
+	lastLog    time.Time
+}
+
+func newCleanupWarnLimiter() *cleanupWarnLimiter {
+	return &cleanupWarnLimiter{
+		states: make(map[string]*cleanupWarnState),
+	}
+}
+
+func (l *cleanupWarnLimiter) allow(key string) (bool, int64, int64) {
+	if key == "" {
+		key = "pipeline_cleanup"
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	state, ok := l.states[key]
+	if !ok {
+		state = &cleanupWarnState{}
+		l.states[key] = state
+	}
+
+	state.count++
+	count := state.count
+	now := time.Now()
+
+	shouldLog := count <= pipelineCleanupWarnBurstCount ||
+		count%pipelineCleanupWarnSampleInterval == 0 ||
+		now.Sub(state.lastLog) >= pipelineCleanupWarnInterval
+	if !shouldLog {
+		state.suppressed++
+		return false, count, 0
+	}
+
+	suppressed := state.suppressed
+	state.suppressed = 0
+	state.lastLog = now
+	return true, count, suppressed
+}
+
+func WarnPipelineCleanupf(proc *Process, key string, format string, args ...any) {
+	if key == "" {
+		key = "pipeline_cleanup"
+	}
+	metricv2.PipelineCleanupEventCounter.WithLabelValues(key).Inc()
+
+	if proc == nil {
+		return
+	}
+
+	allowed, occurrence, suppressed := pipelineCleanupWarnLimiter.allow(key)
+	if !allowed {
+		return
+	}
+
+	format += " occurrence=%d"
+	args = append(args, occurrence)
+	if suppressed > 0 {
+		format += " suppressed=%d"
+		args = append(args, suppressed)
+	}
+
+	proc.Warnf(proc.Ctx, format, args...)
+}

--- a/pkg/vm/process/process_spoolr.go
+++ b/pkg/vm/process/process_spoolr.go
@@ -16,11 +16,22 @@ package process
 
 import (
 	"context"
+	"slices"
+
 	"github.com/matrixorigin/matrixone/pkg/common/mpool"
 	"github.com/matrixorigin/matrixone/pkg/container/batch"
 	"github.com/matrixorigin/matrixone/pkg/container/pSpool"
 	"reflect"
 	"time"
+)
+
+var (
+	// PipelineCleanupWaitTimeout bounds cleanup-only waits for terminal
+	// pipeline signals. Normal query execution does not use this timeout.
+	PipelineCleanupWaitTimeout = 30 * time.Second
+
+	// PipelineSignalSendTimeout bounds cleanup-only terminal signal sends.
+	PipelineSignalSendTimeout = 30 * time.Second
 )
 
 type PipelineActionType uint8
@@ -66,6 +77,55 @@ func NewPipelineSignalToDirectly(data *batch.Batch, err error, mp *mpool.MPool) 
 	}
 }
 
+func SendPipelineSignalWithTimeout(reg *WaitRegister, signal PipelineSignal, timeout time.Duration) bool {
+	if reg == nil || reg.Ch2 == nil {
+		return false
+	}
+	if timeout <= 0 {
+		reg.Ch2 <- signal
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+	defer cancel()
+
+	return SendPipelineSignalWithContext(ctx, reg, signal)
+}
+
+func SendPipelineSignalWithContext(ctx context.Context, reg *WaitRegister, signal PipelineSignal) bool {
+	if reg == nil || reg.Ch2 == nil {
+		return false
+	}
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+	select {
+	case reg.Ch2 <- signal:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func TrySendPipelineSignal(reg *WaitRegister, signal PipelineSignal) bool {
+	if reg == nil || reg.Ch2 == nil {
+		return false
+	}
+	select {
+	case reg.Ch2 <- signal:
+		return true
+	default:
+		return false
+	}
+}
+
+func WaitRegisterChannelState(reg *WaitRegister) (int, int) {
+	if reg == nil || reg.Ch2 == nil {
+		return 0, 0
+	}
+	return len(reg.Ch2), cap(reg.Ch2)
+}
+
 // Action will get the input batch from one place according to which type this signal is.
 //
 // the result batch of this function is an READ-ONLY one.
@@ -91,6 +151,13 @@ type PipelineSignalReceiver struct {
 
 	// currentSignal is the current signal this receiver was using.
 	currentSignal *PipelineSignal
+}
+
+type PipelineSignalReceiverState struct {
+	Alive      int
+	NilBatches []int
+	ChannelLen []int
+	ChannelCap []int
 }
 
 func InitPipelineSignalReceiver(runningCtx context.Context, regs []*WaitRegister) *PipelineSignalReceiver {
@@ -209,6 +276,27 @@ func (receiver *PipelineSignalReceiver) removeIdxReceiver(chosen int) {
 	}
 }
 
+func (receiver *PipelineSignalReceiver) State() PipelineSignalReceiverState {
+	if receiver == nil {
+		return PipelineSignalReceiverState{}
+	}
+
+	state := PipelineSignalReceiverState{
+		Alive:      receiver.alive,
+		NilBatches: slices.Clone(receiver.nbs),
+		ChannelLen: make([]int, len(receiver.srcReg)),
+		ChannelCap: make([]int, len(receiver.srcReg)),
+	}
+	for i, reg := range receiver.srcReg {
+		if reg == nil || reg.Ch2 == nil {
+			continue
+		}
+		state.ChannelLen[i] = len(reg.Ch2)
+		state.ChannelCap[i] = cap(reg.Ch2)
+	}
+	return state
+}
+
 func (receiver *PipelineSignalReceiver) listenToAll() (int, PipelineSignal) {
 	// hard codes for less interface convert and less reflect.
 	switch len(receiver.srcReg) {
@@ -242,16 +330,35 @@ func (receiver *PipelineSignalReceiver) listenToAll() (int, PipelineSignal) {
 }
 
 func (receiver *PipelineSignalReceiver) WaitingEnd() {
+	receiver.WaitingEndWithTimeout(PipelineCleanupWaitTimeout)
+}
+
+// WaitingEndWithTimeout is cleanup-only. It intentionally uses a detached
+// cleanup context because Pipeline.Cleanup cancels the process context before
+// operator Reset runs, but cleanup still needs a bounded chance to drain
+// terminal pipeline signals and release spool references.
+func (receiver *PipelineSignalReceiver) WaitingEndWithTimeout(timeout time.Duration) bool {
+	cleanupCtx := context.TODO()
+	cancel := func() {}
+	if timeout > 0 {
+		cleanupCtx, cancel = context.WithTimeout(context.TODO(), timeout)
+	}
+	defer cancel()
+
 	if len(receiver.regs) > 0 {
-		receiver.regs[0] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(context.TODO().Done())}
+		receiver.regs[0] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(cleanupCtx.Done())}
 	}
 
-	receiver.usrCtx = context.TODO()
+	receiver.usrCtx = cleanupCtx
 	for {
 		if receiver.alive == 0 {
-			return
+			return true
 		}
 		_, _ = receiver.GetNextBatch(nil)
+		if cleanupCtx.Err() != nil {
+			receiver.releaseCurrent()
+			return false
+		}
 	}
 }
 

--- a/pkg/vm/process/process_spoolr_test.go
+++ b/pkg/vm/process/process_spoolr_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestPipelineSignalReceiverWaitingEndUsesCleanupTimeout(t *testing.T) {
+	oldCleanupWaitTimeout := PipelineCleanupWaitTimeout
+	PipelineCleanupWaitTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		PipelineCleanupWaitTimeout = oldCleanupWaitTimeout
+	})
+
+	reg := &WaitRegister{Ch2: make(chan PipelineSignal, 1)}
+	receiver := InitPipelineSignalReceiver(context.Background(), []*WaitRegister{reg})
+	done := make(chan struct{})
+	go func() {
+		receiver.WaitingEnd()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("WaitingEnd did not return after its cleanup timeout")
+	}
+}
+
+func TestPipelineSignalReceiverWaitingEndWithTimeoutReturnsWhenEndSignalIsMissing(t *testing.T) {
+	reg := &WaitRegister{Ch2: make(chan PipelineSignal, 1)}
+	receiver := InitPipelineSignalReceiver(context.Background(), []*WaitRegister{reg})
+
+	done := make(chan bool)
+	go func() {
+		done <- receiver.WaitingEndWithTimeout(10 * time.Millisecond)
+	}()
+
+	select {
+	case completed := <-done:
+		if completed {
+			t.Fatal("WaitingEndWithTimeout completed without receiving an end signal")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitingEndWithTimeout did not return after its timeout")
+	}
+}
+
+func TestPipelineSignalReceiverWaitingEndWithTimeoutCompletesWhenEndSignalArrives(t *testing.T) {
+	reg := &WaitRegister{Ch2: make(chan PipelineSignal, 1)}
+	reg.Ch2 <- NewPipelineSignalToDirectly(nil, nil, nil)
+	receiver := InitPipelineSignalReceiver(context.Background(), []*WaitRegister{reg})
+
+	if !receiver.WaitingEndWithTimeout(time.Second) {
+		t.Fatal("WaitingEndWithTimeout timed out after receiving an end signal")
+	}
+}
+
+func TestSendPipelineSignalWithTimeoutReturnsWhenChannelIsFull(t *testing.T) {
+	reg := &WaitRegister{Ch2: make(chan PipelineSignal, 1)}
+	reg.Ch2 <- NewPipelineSignalToDirectly(nil, nil, nil)
+
+	if SendPipelineSignalWithTimeout(reg, NewPipelineSignalToDirectly(nil, nil, nil), 10*time.Millisecond) {
+		t.Fatal("SendPipelineSignalWithTimeout succeeded on a full channel with no receiver")
+	}
+}
+
+func TestCleanupWarnLimiterSuppressesStorm(t *testing.T) {
+	limiter := newCleanupWarnLimiter()
+
+	for i := int64(1); i <= pipelineCleanupWarnBurstCount; i++ {
+		allowed, occurrence, suppressed := limiter.allow("storm")
+		if !allowed || occurrence != i || suppressed != 0 {
+			t.Fatalf("unexpected burst decision: allowed=%t occurrence=%d suppressed=%d", allowed, occurrence, suppressed)
+		}
+	}
+
+	for i := pipelineCleanupWarnBurstCount + 1; i < pipelineCleanupWarnSampleInterval; i++ {
+		allowed, _, _ := limiter.allow("storm")
+		if allowed {
+			t.Fatalf("unexpected log allowed before sample interval at occurrence %d", i)
+		}
+	}
+
+	allowed, occurrence, suppressed := limiter.allow("storm")
+	if !allowed || occurrence != pipelineCleanupWarnSampleInterval {
+		t.Fatalf("sample log was not allowed: allowed=%t occurrence=%d", allowed, occurrence)
+	}
+	wantSuppressed := pipelineCleanupWarnSampleInterval - pipelineCleanupWarnBurstCount - 1
+	if suppressed != wantSuppressed {
+		t.Fatalf("unexpected suppressed count: got %d, want %d", suppressed, wantSuppressed)
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #25025.

## What this PR does / why we need it:

Cherry-pick of #24972 ("fix: bound pipeline cleanup waits") from `main` to
`4.0-dev`.

`4.0-dev` still carries the old unbounded pipeline teardown path, where
`PipelineSpool.Close()` and the connector/dispatch cleanup can block forever
waiting for receivers to drain, leaving a query unkillable and table locks
held until the CN is restarted.

This backport brings the bounded-cleanup framework already on `main`:

- `PipelineSpool.CloseWithTimeout` / `ForceCleanup` (`cleanupOnce`) — bounded
  wait + deferred force cleanup instead of blocking forever on `csDoneSignal`
- connector / dispatch cleanup rewritten around `PipelineSignalSendTimeout`,
  terminal spool signals, and `cleanupSpool` for later force-cleanup
- `WarnPipelineCleanupf` diagnostics + cleanup metrics
- `process_spoolr` / `pipeline` teardown bounding

Cherry-picked cleanly from commit `629f58da6` (no conflicts).

### Verification

- `go build` of all changed packages: OK.
- Unit tests pass: `pkg/container/pSpool`, `pkg/sql/colexec/connector`,
  `pkg/sql/colexec/dispatch`, `pkg/vm/pipeline`, `pkg/vm/process`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
