### PR TITLE
fix: make CnServerMessageHandler wait observe messageCtx cancellation (4.0-dev counterpart of #25224)

### DIFF
--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -117,7 +117,13 @@ func CnServerMessageHandler(
 		// to prevent some strange handle order between 'stop sending message' and others.
 		// todo: it is tcp connection now. should be very careful, we should listen to stream context next day.
 		if err == nil {
-			<-receiver.connectionCtx.Done()
+			// Also observe messageCtx cancellation so a killed query
+			// doesn't leave this handler blocked forever waiting for
+			// the TCP connection to close (issue #25025).
+			select {
+			case <-receiver.connectionCtx.Done():
+			case <-receiver.messageCtx.Done():
+			}
 		}
 		colexec.Get().RemoveRelatedPipeline(receiver.clientSession, receiver.messageId)
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Related to #25025.

## What this PR does / why we need it:

4.0-dev counterpart of #25224 (the same one-line hardening already proposed for
`main`).

The `CnServerMessageHandler` wait blocks on `connectionCtx` (TCP close) only and
ignores query cancellation:

```go
if err == nil {
    <-receiver.connectionCtx.Done()
}
```

Make it also observe `receiver.messageCtx`, so a killed/cancelled query doesn't
leave the handler blocked forever waiting for the TCP connection to close:

```go
if err == nil {
    select {
    case <-receiver.connectionCtx.Done():
    case <-receiver.messageCtx.Done():
    }
}
```

This complements the #24972 backport (#25223), which brings the bounded
pipeline-cleanup framework to 4.0-dev but does not touch this handler. Hardening
only; it does not fix the cross-CN shuffle root cause (issue #25025, fixed
separately by #25158).

### Verification

- `go build ./pkg/sql/compile/`: OK.
- gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
