### PR TITLE
fix(logservice): restore HAKeeper IDs and WAL during rebuild

### DIFF
--- a/cmd/mo-service/launch.go
+++ b/cmd/mo-service/launch.go
@@ -244,9 +244,13 @@ func waitHAKeeperReady(
 	}
 }
 
-func waitHAKeeperRunning(client logservice.CNHAKeeperClient) error {
-	ctx, cancel := context.WithTimeoutCause(context.TODO(), time.Minute*2, moerr.CauseWaitHAKeeperRunning)
+func waitHAKeeperRunning(client logservice.CNHAKeeperClient, timeout time.Duration) error {
+	// Use the configured timeout for waiting HAKeeper to be running.
+	// This is useful during disaster recovery when WAL recovery may take a long time.
+	ctx, cancel := context.WithTimeoutCause(context.TODO(), timeout, moerr.CauseWaitHAKeeperRunning)
 	defer cancel()
+
+	logutil.Info("wait.hakeeper.running", zap.Duration("timeout", timeout))
 
 	// wait HAKeeper running
 	for {
@@ -265,7 +269,7 @@ func waitHAKeeperRunning(client logservice.CNHAKeeperClient) error {
 	}
 }
 
-func waitAnyShardReady(client logservice.CNHAKeeperClient) error {
+func waitAnyShardReady(client logservice.CNHAKeeperClient, _ time.Duration) error {
 	ctx, cancel := context.WithTimeoutCause(context.TODO(), time.Second*30, moerr.CauseWaitAnyShardReady)
 	defer cancel()
 
@@ -302,13 +306,17 @@ func waitAnyShardReady(client logservice.CNHAKeeperClient) error {
 func waitClusterCondition(
 	service string,
 	cfg logservice.HAKeeperClientConfig,
-	waitFunc func(logservice.CNHAKeeperClient) error,
+	waitFunc func(logservice.CNHAKeeperClient, time.Duration) error,
 ) error {
 	client, err := waitHAKeeperReady(service, cfg)
 	if err != nil {
 		return err
 	}
-	if err := waitFunc(client); err != nil {
+	timeout := cfg.GetHAKeeperRunningTimeout()
+	if err := waitFunc(client, timeout); err != nil {
+		if closeErr := client.Close(); closeErr != nil {
+			logutil.Error("close hakeeper client failed", zap.Error(closeErr))
+		}
 		return err
 	}
 	if err := client.Close(); err != nil {

--- a/pkg/embed/operator.go
+++ b/pkg/embed/operator.go
@@ -382,6 +382,9 @@ func (op *operator) waitClusterConditionLocked(
 		return err
 	}
 	if err := waitFunc(client); err != nil {
+		if closeErr := client.Close(); closeErr != nil {
+			op.reset.logger.Error("close hakeeper client failed", zap.Error(closeErr))
+		}
 		return err
 	}
 	if err := client.Close(); err != nil {
@@ -393,7 +396,10 @@ func (op *operator) waitClusterConditionLocked(
 func (op *operator) waitHAKeeperRunningLocked(
 	client logservice.CNHAKeeperClient,
 ) error {
-	ctx, cancel := context.WithTimeoutCause(context.TODO(), time.Minute*2, moerr.CauseWaitHAKeeperRunningLocked)
+	// Use the configured timeout for waiting HAKeeper to be running.
+	// This is useful during disaster recovery when WAL recovery may take a long time.
+	timeout := op.cfg.HAKeeperClient.GetHAKeeperRunningTimeout()
+	ctx, cancel := context.WithTimeoutCause(context.TODO(), timeout, moerr.CauseWaitHAKeeperRunningLocked)
 	defer cancel()
 
 	// wait HAKeeper running

--- a/pkg/hakeeper/rsm.go
+++ b/pkg/hakeeper/rsm.go
@@ -98,6 +98,13 @@ func GetInitialClusterRequestCmd(
 	return cmd
 }
 
+// GetRestoreIDWatermarkCmd returns an explicit, idempotent restore request.
+// Zero shard counts are not valid for initial cluster creation, so they mark
+// this command as an ID-only restore without adding a new protobuf command.
+func GetRestoreIDWatermarkCmd(nextID uint64, nextIDByKey map[string]uint64) []byte {
+	return GetInitialClusterRequestCmd(0, 0, 0, nextID, nextIDByKey, nil)
+}
+
 func parseInitialClusterRequestCmd(cmd []byte) pb.InitialClusterRequest {
 	if parseCmdTag(cmd) != pb.InitialClusterUpdate {
 		panic("not a initial cluster update")
@@ -674,10 +681,16 @@ func (s *stateMachine) handleLogShardUpdate(cmd []byte) sm.Result {
 // set to HAKeeperBootstrapping.
 func (s *stateMachine) handleInitialClusterRequestCmd(cmd []byte) sm.Result {
 	result := sm.Result{Value: uint64(s.state.State)}
+	req := parseInitialClusterRequestCmd(cmd)
+	if isRestoreIDWatermarkRequest(req) {
+		if s.state.State != pb.HAKeeperCreated {
+			s.patchRestoreIDWatermarks(req)
+		}
+		return result
+	}
 	if s.state.State != pb.HAKeeperCreated {
 		return result
 	}
-	req := parseInitialClusterRequestCmd(cmd)
 
 	// The number of TN shard should only be 1.
 	// There is one corresponding Log shard with that TN shard.
@@ -744,6 +757,37 @@ func (s *stateMachine) handleInitialClusterRequestCmd(cmd []byte) sm.Result {
 	return result
 }
 
+func isRestoreIDWatermarkRequest(req pb.InitialClusterRequest) bool {
+	return req.NumOfLogShards == 0 &&
+		req.NumOfTNShards == 0 &&
+		req.NumOfLogReplicas == 0 &&
+		len(req.NonVotingLocality) == 0 &&
+		(req.NextID != 0 || len(req.NextIDByKey) != 0)
+}
+
+func (s *stateMachine) patchRestoreIDWatermarks(req pb.InitialClusterRequest) {
+	updated := false
+	if req.NextID > s.state.NextID {
+		s.state.NextID = req.NextID
+		updated = true
+	}
+	if len(req.NextIDByKey) > 0 {
+		if s.state.NextIDByKey == nil {
+			s.state.NextIDByKey = make(map[string]uint64)
+		}
+		for key, nextID := range req.NextIDByKey {
+			if nextID > s.state.NextIDByKey[key] {
+				s.state.NextIDByKey[key] = nextID
+				updated = true
+			}
+		}
+	}
+	if updated {
+		plog.Infof("patched HAKeeper ID watermarks from restore data, next-id %d, next-id-by-key %v",
+			s.state.NextID, s.state.NextIDByKey)
+	}
+}
+
 func (s *stateMachine) assertState() {
 	if s.state.State != pb.HAKeeperRunning && s.state.State != pb.HAKeeperBootstrapping {
 		panic(fmt.Sprintf("HAKeeper not in the running state, in %s", s.state.State.String()))
@@ -765,7 +809,12 @@ func (s *stateMachine) Update(e sm.Entry) (sm.Result, error) {
 	case pb.TickUpdate:
 		return s.handleTick(cmd), nil
 	case pb.GetIDUpdate:
-		s.assertState()
+		if s.state.State != pb.HAKeeperRunning && s.state.State != pb.HAKeeperBootstrapping {
+			// ID allocation is an external request. Reject it deterministically
+			// while bootstrap commands are being applied instead of panicking the
+			// replicated state machine.
+			return sm.Result{}, nil
+		}
 		return s.handleGetIDCmd(cmd), nil
 	case pb.ScheduleCommandUpdate:
 		return s.handleUpdateCommandsCmd(cmd), nil

--- a/pkg/hakeeper/rsm_test.go
+++ b/pkg/hakeeper/rsm_test.go
@@ -211,6 +211,25 @@ func TestGetIDCmd(t *testing.T) {
 	assert.Equal(t, sm.Result{Value: 202}, result)
 }
 
+func TestGetIDCmdRejectedDuringBootstrapCommandsReceived(t *testing.T) {
+	tsm1 := NewStateMachine(0, 1).(*stateMachine)
+	tsm1.state.State = pb.HAKeeperBootstrapCommandsReceived
+	tsm1.state.NextID = 50000000
+	tsm1.state.NextIDByKey["____server_conn_id"] = 900
+
+	cmd := GetAllocateIDCmd(pb.CNAllocateID{Batch: 100})
+	result, err := tsm1.Update(sm.Entry{Cmd: cmd})
+	assert.NoError(t, err)
+	assert.Equal(t, sm.Result{}, result)
+	assert.Equal(t, uint64(50000000), tsm1.state.NextID)
+
+	cmd = GetAllocateIDCmd(pb.CNAllocateID{Key: "____server_conn_id", Batch: 100})
+	result, err = tsm1.Update(sm.Entry{Cmd: cmd})
+	assert.NoError(t, err)
+	assert.Equal(t, sm.Result{}, result)
+	assert.Equal(t, uint64(900), tsm1.state.NextIDByKey["____server_conn_id"])
+}
+
 func TestAllocateIDByKeyCmd(t *testing.T) {
 	tsm1 := NewStateMachine(0, 1).(*stateMachine)
 	tsm1.state.State = pb.HAKeeperRunning
@@ -661,6 +680,58 @@ func TestHandleInitialClusterRequestCmd(t *testing.T) {
 	assert.Equal(t, pb.HAKeeperBootstrapping, rsm.state.State)
 	assert.Equal(t, K8SIDRangeEnd+10, rsm.state.NextID)
 	assert.Equal(t, nextIDByKey, rsm.state.NextIDByKey)
+}
+
+func TestHandleInitialClusterRequestCmdPatchesIDsWhenAlreadyInitialized(t *testing.T) {
+	rsm := NewStateMachine(0, 1).(*stateMachine)
+	rsm.state.State = pb.HAKeeperRunning
+	rsm.state.NextID = 1000
+	rsm.state.NextIDByKey = map[string]uint64{
+		"index_key":          100,
+		"____server_conn_id": 900,
+	}
+	rsm.state.ClusterInfo = pb.ClusterInfo{
+		LogShards: []metadata.LogShardRecord{
+			{
+				ShardID:          10,
+				NumberOfReplicas: 3,
+			},
+		},
+	}
+
+	cmd := GetRestoreIDWatermarkCmd(
+		5000,
+		map[string]uint64{
+			"index_key":          200,
+			"____server_conn_id": 800,
+			"_mo_bootstrap":      1,
+		},
+	)
+	result, err := rsm.Update(sm.Entry{Cmd: cmd})
+	require.NoError(t, err)
+
+	assert.Equal(t, sm.Result{Value: uint64(pb.HAKeeperRunning)}, result)
+	assert.Equal(t, pb.HAKeeperRunning, rsm.state.State)
+	assert.Equal(t, uint64(5000), rsm.state.NextID)
+	assert.Equal(t, uint64(200), rsm.state.NextIDByKey["index_key"])
+	assert.Equal(t, uint64(900), rsm.state.NextIDByKey["____server_conn_id"])
+	assert.Equal(t, uint64(1), rsm.state.NextIDByKey["_mo_bootstrap"])
+	assert.Equal(t, uint64(10), rsm.state.ClusterInfo.LogShards[0].ShardID)
+
+	// A normal duplicate initial-cluster request remains a no-op, even when
+	// its ID fields are higher than the live state.
+	cmd = GetInitialClusterRequestCmd(
+		1,
+		1,
+		3,
+		9000,
+		map[string]uint64{"index_key": 9000},
+		nil,
+	)
+	_, err = rsm.Update(sm.Entry{Cmd: cmd})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5000), rsm.state.NextID)
+	assert.Equal(t, uint64(200), rsm.state.NextIDByKey["index_key"])
 }
 
 func TestGetCommandBatch(t *testing.T) {

--- a/pkg/logservice/config.go
+++ b/pkg/logservice/config.go
@@ -215,9 +215,15 @@ type Config struct {
 			// FilePath is the path of the file, which contains the backup data.
 			// If is not set, nothing will be done for restore.
 			FilePath string `toml:"file-path"`
-			// Force means that we force to do restore even if RESTORED tag file
-			// already exists.
+			// Force is retained for restore configuration compatibility. HAKeeper
+			// ID watermarks are restored idempotently, and a completed WAL is never
+			// replayed into a non-empty Log shard even when Force is true.
 			Force bool `toml:"force"`
+			// WALDataPath is the path to the WAL data file extracted from damaged LogService.
+			// When set, LogService will replay WAL entries from this file during bootstrap.
+			// This is used for disaster recovery when the original LogService cluster is
+			// completely damaged but Raft logs can still be read offline.
+			WALDataPath string `toml:"wal-data-path"`
 		} `toml:"restore"`
 		// NonVotingLocality is the locality for non-voting replicas.
 		NonVotingLocality string `toml:"non-voting-locality" user_setting:"advanced"`
@@ -394,6 +400,14 @@ func (c *Config) Validate() error {
 			return moerr.NewBadConfigNoCtx("InitHAKeeperMembers does not match NumOfLogShardReplicas")
 		}
 	}
+	if c.BootstrapConfig.Restore.WALDataPath != "" {
+		if c.BootstrapConfig.Restore.FilePath == "" {
+			return moerr.NewBadConfigNoCtx("HAKeeper restore file path is required for WAL recovery")
+		}
+		if _, ok := c.Bootstrapping(); !ok {
+			return moerr.NewBadConfigNoCtx("WAL recovery must run on an initial HAKeeper member")
+		}
+	}
 
 	return nil
 }
@@ -455,8 +469,9 @@ func DefaultConfig() Config {
 			NumOfLogShardReplicas uint64   `toml:"num-of-log-shard-replicas"`
 			InitHAKeeperMembers   []string `toml:"init-hakeeper-members" user_setting:"advanced"`
 			Restore               struct {
-				FilePath string `toml:"file-path"`
-				Force    bool   `toml:"force"`
+				FilePath    string `toml:"file-path"`
+				Force       bool   `toml:"force"`
+				WALDataPath string `toml:"wal-data-path"`
 			} `toml:"restore"`
 			NonVotingLocality string `toml:"non-voting-locality" user_setting:"advanced"`
 			StandbyEnabled    bool   `toml:"standby-enabled" user_setting:"advanced"`
@@ -467,8 +482,9 @@ func DefaultConfig() Config {
 			NumOfLogShardReplicas uint64
 			InitHAKeeperMembers   []string
 			Restore               struct {
-				FilePath string
-				Force    bool
+				FilePath    string
+				Force       bool
+				WALDataPath string
 			}
 			NonVotingLocality string
 			StandbyEnabled    bool
@@ -479,11 +495,13 @@ func DefaultConfig() Config {
 			NumOfLogShardReplicas: 1,
 			InitHAKeeperMembers:   []string{"131072:" + uid},
 			Restore: struct {
-				FilePath string
-				Force    bool
+				FilePath    string
+				Force       bool
+				WALDataPath string
 			}{
-				FilePath: defaultRestoreFilePath,
-				Force:    false,
+				FilePath:    defaultRestoreFilePath,
+				Force:       false,
+				WALDataPath: "",
 			},
 			NonVotingLocality: "",
 			StandbyEnabled:    false,
@@ -565,6 +583,11 @@ type HAKeeperClientConfig struct {
 	AllocateIDBatch uint64 `toml:"allocate-id-batch"`
 	// EnableCompress enable compress
 	EnableCompress bool `toml:"enable-compress"`
+	// HAKeeperRunningTimeout is the timeout for waiting HAKeeper to be running.
+	// This is useful during disaster recovery when WAL recovery may take a long time.
+	// Default remains 2 minutes for compatibility. Set a larger value (e.g., 30m)
+	// on clients that should wait through a long disaster recovery.
+	HAKeeperRunningTimeout toml.Duration `toml:"hakeeper-running-timeout"`
 }
 
 // Validate validates the HAKeeperClientConfig.
@@ -575,7 +598,22 @@ func (c *HAKeeperClientConfig) Validate() error {
 	if c.AllocateIDBatch == 0 {
 		c.AllocateIDBatch = 100
 	}
+	if c.HAKeeperRunningTimeout.Duration < 0 {
+		return moerr.NewBadConfigNoCtx("HAKeeperRunningTimeout cannot be negative")
+	}
+	if c.HAKeeperRunningTimeout.Duration == 0 {
+		c.HAKeeperRunningTimeout.Duration = time.Minute * 2
+	}
 	return nil
+}
+
+// GetHAKeeperRunningTimeout returns the timeout for waiting HAKeeper to be running.
+// Returns the configured value or the compatibility default of 2 minutes.
+func (c *HAKeeperClientConfig) GetHAKeeperRunningTimeout() time.Duration {
+	if c.HAKeeperRunningTimeout.Duration == 0 {
+		return time.Minute * 2
+	}
+	return c.HAKeeperRunningTimeout.Duration
 }
 
 // ClientConfig is the configuration for log service clients.

--- a/pkg/logservice/config_test.go
+++ b/pkg/logservice/config_test.go
@@ -16,6 +16,7 @@ package logservice
 
 import (
 	"testing"
+	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
 	"github.com/stretchr/testify/assert"
@@ -134,6 +135,10 @@ func TestConfigCanBeValidated(t *testing.T) {
 func TestBootstrapConfigCanBeValidated(t *testing.T) {
 	c := getTestConfig()
 	assert.NoError(t, c.Validate())
+	nonBootstrapRecovery := c
+	nonBootstrapRecovery.BootstrapConfig.Restore.WALDataPath = "/recovery/wal_data.bin"
+	err := nonBootstrapRecovery.Validate()
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
 
 	c.BootstrapConfig.BootstrapCluster = true
 	c.BootstrapConfig.NumOfLogShards = 3
@@ -144,7 +149,7 @@ func TestBootstrapConfigCanBeValidated(t *testing.T) {
 
 	c1 := c
 	c1.BootstrapConfig.NumOfLogShards = 0
-	err := c1.Validate()
+	err = c1.Validate()
 	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
 
 	c2 := c
@@ -160,6 +165,21 @@ func TestBootstrapConfigCanBeValidated(t *testing.T) {
 	c4 := c
 	c4.BootstrapConfig.NumOfLogShardReplicas = 2
 	err = c4.Validate()
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
+
+	recovery := c
+	recovery.UUID = "9c4dccb4-4d3c-41f8-b482-5251dc7a41bf"
+	recovery.BootstrapConfig.Restore.FilePath = "/recovery/hakeeper_backup.data"
+	recovery.BootstrapConfig.Restore.WALDataPath = "/recovery/wal_data.bin"
+	assert.NoError(t, recovery.Validate())
+
+	recovery.BootstrapConfig.Restore.FilePath = ""
+	err = recovery.Validate()
+	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
+
+	recovery.BootstrapConfig.Restore.FilePath = "/recovery/hakeeper_backup.data"
+	recovery.UUID = "9c4dccb4-4d3c-41f8-b482-5251dc7a41be"
+	err = recovery.Validate()
 	assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
 }
 
@@ -199,6 +219,11 @@ func TestClientConfigValidate(t *testing.T) {
 			assert.True(t, moerr.IsMoErrCode(err, moerr.ErrBadConfig))
 		}
 	}
+	cfg := HAKeeperClientConfig{}
+	require.NoError(t, cfg.Validate())
+	assert.Equal(t, 2*time.Minute, cfg.GetHAKeeperRunningTimeout())
+	cfg.HAKeeperRunningTimeout.Duration = -time.Second
+	assert.True(t, moerr.IsMoErrCode(cfg.Validate(), moerr.ErrBadConfig))
 }
 
 func TestHAKeeperClientConfigValidate(t *testing.T) {

--- a/pkg/logservice/service.go
+++ b/pkg/logservice/service.go
@@ -192,6 +192,12 @@ func NewService(
 	service.server = server
 	service.pool = pool
 	service.respPool = respPool
+	if cfg.BootstrapConfig.Restore.WALDataPath != "" {
+		// Set this before the heartbeat worker starts. The status is carried in
+		// LogStore heartbeats, so whichever HAKeeper replica becomes leader can
+		// keep the cluster out of Running state until replay completes.
+		service.setWALRecoveryInProgress(true)
+	}
 
 	server.RegisterRequestHandler(service.handleRPCRequest)
 	// TODO: before making the service available to the outside world, restore all

--- a/pkg/logservice/service_bootstrap.go
+++ b/pkg/logservice/service_bootstrap.go
@@ -16,6 +16,9 @@ package logservice
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/lni/dragonboat/v4"
@@ -82,69 +85,142 @@ func (s *Service) BootstrapHAKeeper(ctx context.Context, cfg Config) error {
 
 	var nextID uint64
 	var nextIDByKey map[string]uint64
+	backupRestoreTagExists := false
 	backup, err := s.getBackupData(ctx)
 	if err != nil {
 		s.runtime.SubLogger(runtime.SystemInit).Error("failed to get backup data", zap.Error(err))
 		return err
 	}
 	if backup != nil { // We are trying to restore from a backup.
-		// If a backup has already been issued, ignore this time.
 		_, err := fs.StatFile(ctx, restoredTagFile)
-		if s.cfg.BootstrapConfig.Restore.Force || // force is true, we do restore whatever.
-			(err != nil && moerr.IsMoErrCode(err, moerr.ErrFileNotFound)) {
-			s.runtime.SubLogger(runtime.SystemInit).Info("restore hakeeper data",
-				zap.Uint64("next ID", backup.NextID),
-				zap.Any("next ID by key", backup.NextIDByKey),
-			)
-			// Restored tag file does not exist, we can do backup.
-			nextID = backup.NextID
-			nextIDByKey = backup.NextIDByKey
-
-			// After backup, create a restore file.
-			if err := fs.Write(ctx, fileservice.IOVector{
-				FilePath: restoredTagFile,
-				Entries: []fileservice.IOEntry{
-					{
-						Offset: 0,
-						Size:   1,
-						Data:   []byte{1},
-					},
-				},
-			}); err != nil {
-				s.runtime.SubLogger(runtime.SystemInit).Error("failed to write restore tag file",
-					zap.Error(err))
-				return err
-			}
+		if err == nil {
+			backupRestoreTagExists = true
+		} else if !moerr.IsMoErrCode(err, moerr.ErrFileNotFound) {
+			s.runtime.SubLogger(runtime.SystemInit).Error("failed to stat restore tag file",
+				zap.Error(err))
+			return err
 		}
+		s.runtime.SubLogger(runtime.SystemInit).Info("restore hakeeper data",
+			zap.Uint64("next ID", backup.NextID),
+			zap.Any("next ID by key", backup.NextIDByKey),
+			zap.Bool("restore tag exists", backupRestoreTagExists),
+			zap.Bool("force", s.cfg.BootstrapConfig.Restore.Force),
+		)
+		// Always carry backup IDs into the initial-cluster proposal when
+		// restore is configured. RESTORED is only an acknowledgement that a
+		// previous restore reached HAKeeper state; old versions wrote it too
+		// early, so it must not suppress the backup payload by itself.
+		nextID = backup.NextID
+		nextIDByKey = backup.NextIDByKey
 	} else {
 		s.runtime.SubLogger(runtime.SystemInit).Info("backup is nil")
 	}
+
+	walRecoveryConfigured := cfg.BootstrapConfig.Restore.WALDataPath != ""
+	restoreConfigured := backup != nil || walRecoveryConfigured
+	if walRecoveryConfigured && backup == nil {
+		return moerr.NewInternalError(ctx,
+			"WAL recovery requires a valid HAKeeper backup file")
+	}
+
+	initialClusterProposed := false
+	var lastInitialClusterErr error
 	for i := 0; i < checkBootstrapCycles; i++ {
 		select {
 		case <-ctx.Done():
 			s.runtime.SubLogger(runtime.SystemInit).Error("context error", zap.Error(ctx.Err()))
+			if restoreConfigured {
+				return moerr.AttachCause(ctx, ctx.Err())
+			}
 			return nil
 		default:
 		}
 		s.runtime.SubLogger(runtime.SystemInit).Info("before initial cluster info")
-		if err := s.store.setInitialClusterInfo(
+		applied, err := s.store.setInitialClusterInfoWithResult(
 			numOfLogShards,
 			numOfTNShards,
 			numOfLogReplicas,
 			nextID,
 			nextIDByKey,
 			nonVotingLocality,
-		); err != nil {
+		)
+		if err != nil {
+			lastInitialClusterErr = err
 			s.runtime.SubLogger(runtime.SystemInit).Error("failed to set initial cluster info", zap.Error(err))
-			if err == dragonboat.ErrShardNotFound {
+			if errors.Is(err, dragonboat.ErrShardNotFound) {
+				if restoreConfigured {
+					return err
+				}
 				return nil
 			}
 			time.Sleep(time.Second)
 			continue
 		}
-		s.runtime.SubLogger(runtime.SystemInit).Info("initial cluster info set")
+		initialClusterProposed = true
+		s.runtime.SubLogger(runtime.SystemInit).Info("initial cluster info set",
+			zap.Bool("applied", applied))
 		break
 	}
+	if backup != nil {
+		if !initialClusterProposed {
+			if lastInitialClusterErr != nil {
+				return lastInitialClusterErr
+			}
+			return moerr.NewInternalError(ctx, "restore backup configured but initial cluster info was not proposed")
+		}
+		// A different LogService may have won the initial-cluster proposal with
+		// default IDs. Apply the restore watermarks through an explicit,
+		// idempotent HAKeeper command before validating the replicated state.
+		if err := s.store.restoreIDWatermarks(backup.NextID, backup.NextIDByKey); err != nil {
+			return err
+		}
+		state, err := s.store.getCheckerState()
+		if err != nil {
+			s.runtime.SubLogger(runtime.SystemInit).Error("failed to verify restored hakeeper state",
+				zap.Error(err))
+			return err
+		}
+		if !restoredHAKeeperStateReached(backup, state) {
+			return moerr.NewInternalErrorf(ctx,
+				"restored HAKeeper state did not reach backup ID watermarks: nextID %d, backup nextID %d, nextIDByKey %v, backup nextIDByKey %v",
+				state.NextId, backup.NextID, state.NextIDByKey, backup.NextIDByKey)
+		}
+		if !backupRestoreTagExists {
+			if err := writeRestoredTag(ctx, fs); err != nil {
+				s.runtime.SubLogger(runtime.SystemInit).Error("failed to write restore tag file",
+					zap.Error(err))
+				return err
+			}
+		}
+	}
+
+	// Recover WAL data if configured
+	// This must be done after the cluster is initialized and Log shard is running
+	if walRecoveryConfigured {
+		coordinator, err := s.waitWALRecoveryCoordinator(ctx, numOfLogReplicas)
+		if err != nil {
+			return err
+		}
+		if !coordinator {
+			// This store has the recovery files but was not elected. Publishing
+			// complete prevents its heartbeat from blocking the elected store;
+			// only the elected store is allowed to append the WAL.
+			s.setWALRecoveryInProgress(false)
+			return nil
+		}
+		s.runtime.SubLogger(runtime.SystemInit).Info("WAL recovery: starting WAL data recovery",
+			zap.String("wal_data_path", cfg.BootstrapConfig.Restore.WALDataPath))
+		if err := s.RecoverWALData(ctx, cfg); err != nil {
+			s.runtime.SubLogger(runtime.SystemInit).Error("WAL recovery: failed to recover WAL data", zap.Error(err))
+			return err
+		}
+		// Publish completion only after replay and its durable completion record
+		// have succeeded. On any failure the replicated heartbeat status remains
+		// pending and HAKeeper cannot expose the cluster as Running.
+		s.setWALRecoveryInProgress(false)
+		s.runtime.SubLogger(runtime.SystemInit).Info("WAL recovery: completed, HAKeeper can now report running state")
+	}
+
 	return nil
 }
 
@@ -152,6 +228,14 @@ func (s *Service) getBackupData(ctx context.Context) (*pb.BackupData, error) {
 	filePath := s.cfg.BootstrapConfig.Restore.FilePath
 	if filePath == "" {
 		return nil, nil
+	}
+
+	if filepath.IsAbs(filePath) {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, err
+		}
+		return parseBackupData(data)
 	}
 
 	path, err := fileservice.ParsePath(filePath)
@@ -175,6 +259,9 @@ func (s *Service) getBackupData(ctx context.Context) (*pb.BackupData, error) {
 	st, err := fs.StatFile(ctx, filePath)
 	if err != nil {
 		if moerr.IsMoErrCode(err, moerr.ErrFileNotFound) {
+			if filePath != defaultRestoreFilePath {
+				return nil, err
+			}
 			return nil, nil
 		}
 		return nil, err
@@ -195,9 +282,45 @@ func (s *Service) getBackupData(ctx context.Context) (*pb.BackupData, error) {
 	}
 	defer ioVec.Release()
 
-	var data pb.BackupData
-	if err := data.Unmarshal(ioVec.Entries[0].Data); err != nil {
+	return parseBackupData(ioVec.Entries[0].Data)
+}
+
+func parseBackupData(data []byte) (*pb.BackupData, error) {
+	var backup pb.BackupData
+	if err := backup.Unmarshal(data); err != nil {
 		return nil, err
 	}
-	return &data, nil
+	return &backup, nil
+}
+
+func restoredHAKeeperStateReached(backup *pb.BackupData, state *pb.CheckerState) bool {
+	if backup == nil {
+		return true
+	}
+	expectedNextID := backup.NextID
+	if expectedNextID < hakeeper.K8SIDRangeEnd {
+		expectedNextID = hakeeper.K8SIDRangeEnd
+	}
+	if state.NextId < expectedNextID {
+		return false
+	}
+	for key, backupNextID := range backup.NextIDByKey {
+		if state.NextIDByKey[key] < backupNextID {
+			return false
+		}
+	}
+	return true
+}
+
+func writeRestoredTag(ctx context.Context, fs fileservice.FileService) error {
+	return fs.Write(ctx, fileservice.IOVector{
+		FilePath: restoredTagFile,
+		Entries: []fileservice.IOEntry{
+			{
+				Offset: 0,
+				Size:   1,
+				Data:   []byte{1},
+			},
+		},
+	})
 }

--- a/pkg/logservice/service_bootstrap_test.go
+++ b/pkg/logservice/service_bootstrap_test.go
@@ -16,7 +16,8 @@ package logservice
 
 import (
 	"context"
-	"path"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -59,8 +60,9 @@ func TestGetBackupData(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, restore)
 
+	const localBackupData = "restore_data"
 	ioVec := fileservice.IOVector{
-		FilePath: path.Join(dir, name),
+		FilePath: localBackupData,
 		Entries:  make([]fileservice.IOEntry, 1),
 	}
 	ioVec.Entries[0] = fileservice.IOEntry{
@@ -75,12 +77,67 @@ func TestGetBackupData(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, restore)
 
-	s.cfg.BootstrapConfig.Restore.FilePath = path.Join(dir, name)
+	s.cfg.BootstrapConfig.Restore.FilePath = "missing_backup_data"
+	restore, err = s.getBackupData(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, restore)
+
+	s.cfg.BootstrapConfig.Restore.FilePath = localBackupData
 	restore, err = s.getBackupData(ctx)
 	assert.NoError(t, err)
 	assert.NotNil(t, restore)
 	assert.Equal(t, nextID, restore.NextID)
 	assert.Equal(t, nextIDByKey, restore.NextIDByKey)
+
+	rawPath := filepath.Join(dir, "raw_backup_data")
+	assert.NoError(t, os.WriteFile(rawPath, data, 0644))
+	s.cfg.BootstrapConfig.Restore.FilePath = rawPath
+	restore, err = s.getBackupData(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, restore)
+	assert.Equal(t, nextID, restore.NextID)
+	assert.Equal(t, nextIDByKey, restore.NextIDByKey)
+}
+
+func TestRestoredHAKeeperStateReached(t *testing.T) {
+	backup := &pb.BackupData{
+		NextID: hakeeper.K8SIDRangeEnd + 10,
+		NextIDByKey: map[string]uint64{
+			"index_key":          200,
+			"____server_conn_id": 900,
+			"_mo_bootstrap":      1,
+		},
+	}
+	assert.False(t, restoredHAKeeperStateReached(backup, &pb.CheckerState{
+		NextId:      hakeeper.K8SIDRangeEnd + 9,
+		NextIDByKey: backup.NextIDByKey,
+	}))
+	assert.False(t, restoredHAKeeperStateReached(backup, &pb.CheckerState{
+		NextId: hakeeper.K8SIDRangeEnd + 10,
+		NextIDByKey: map[string]uint64{
+			"index_key":          199,
+			"____server_conn_id": 900,
+			"_mo_bootstrap":      1,
+		},
+	}))
+	assert.True(t, restoredHAKeeperStateReached(backup, &pb.CheckerState{
+		NextId: hakeeper.K8SIDRangeEnd + 10,
+		NextIDByKey: map[string]uint64{
+			"index_key":          200,
+			"____server_conn_id": 900,
+			"_mo_bootstrap":      1,
+		},
+	}))
+
+	backup.NextID = 10
+	assert.False(t, restoredHAKeeperStateReached(backup, &pb.CheckerState{
+		NextId:      hakeeper.K8SIDRangeEnd - 1,
+		NextIDByKey: backup.NextIDByKey,
+	}))
+	assert.True(t, restoredHAKeeperStateReached(backup, &pb.CheckerState{
+		NextId:      hakeeper.K8SIDRangeEnd,
+		NextIDByKey: backup.NextIDByKey,
+	}))
 }
 
 func TestServiceBootstrap(t *testing.T) {
@@ -109,6 +166,23 @@ func TestServiceBootstrap(t *testing.T) {
 			s.cfg.UUID = parts[1]
 			s.cfg.BootstrapConfig.Restore.FilePath = ""
 			assert.NoError(t, s.BootstrapHAKeeper(ctx, s.cfg))
+		}
+		runServiceTest(t, false, false, fn)
+	})
+
+	t.Run("WAL recovery requires HAKeeper backup", func(t *testing.T) {
+		fn := func(t *testing.T, s *Service) {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			member := s.cfg.BootstrapConfig.InitHAKeeperMembers[0]
+			parts := strings.Split(member, ":")
+			require.Equal(t, 2, len(parts))
+			s.cfg.UUID = parts[1]
+			s.cfg.BootstrapConfig.Restore.FilePath = ""
+			s.cfg.BootstrapConfig.Restore.WALDataPath = filepath.Join(t.TempDir(), "wal_data.bin")
+			err := s.BootstrapHAKeeper(ctx, s.cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "requires a valid HAKeeper backup")
 		}
 		runServiceTest(t, false, false, fn)
 	})

--- a/pkg/logservice/store.go
+++ b/pkg/logservice/store.go
@@ -828,6 +828,9 @@ func (l *store) cnAllocateID(ctx context.Context,
 		l.runtime.Logger().Error("propose get id failed", zap.Error(err))
 		return 0, err
 	}
+	if result.Value == 0 {
+		return 0, moerr.NewInternalError(ctx, "HAKeeper is not ready for ID allocation")
+	}
 	return result.Value, nil
 }
 

--- a/pkg/logservice/store_hakeeper_check.go
+++ b/pkg/logservice/store_hakeeper_check.go
@@ -87,6 +87,25 @@ func (l *store) setInitialClusterInfo(
 	nextIDByKey map[string]uint64,
 	nonVotingLocality map[string]string,
 ) error {
+	_, err := l.setInitialClusterInfoWithResult(
+		numOfLogShards,
+		numOfTNShards,
+		numOfLogReplicas,
+		nextID,
+		nextIDByKey,
+		nonVotingLocality,
+	)
+	return err
+}
+
+func (l *store) setInitialClusterInfoWithResult(
+	numOfLogShards uint64,
+	numOfTNShards uint64,
+	numOfLogReplicas uint64,
+	nextID uint64,
+	nextIDByKey map[string]uint64,
+	nonVotingLocality map[string]string,
+) (bool, error) {
 	cmd := hakeeper.GetInitialClusterRequestCmd(
 		numOfLogShards,
 		numOfTNShards,
@@ -102,13 +121,31 @@ func (l *store) setInitialClusterInfo(
 	if err != nil {
 		err = moerr.AttachCause(ctx, err)
 		l.runtime.Logger().Error("failed to propose initial cluster info", zap.Error(err))
-		return err
+		return false, err
 	}
 	if result.Value == uint64(pb.HAKeeperBootstrapFailed) {
 		panic("bootstrap failed")
 	}
 	if result.Value != uint64(pb.HAKeeperCreated) {
 		l.runtime.Logger().Error("initial cluster info already set")
+		return false, nil
+	}
+	return true, nil
+}
+
+func (l *store) restoreIDWatermarks(nextID uint64, nextIDByKey map[string]uint64) error {
+	cmd := hakeeper.GetRestoreIDWatermarkCmd(nextID, nextIDByKey)
+	ctx, cancel := context.WithTimeoutCause(
+		context.Background(), hakeeperDefaultTimeout, moerr.CauseSetInitialClusterInfo)
+	defer cancel()
+	session := l.nh.GetNoOPSession(hakeeper.DefaultHAKeeperShardID)
+	result, err := l.propose(ctx, session, cmd)
+	if err != nil {
+		return moerr.AttachCause(ctx, err)
+	}
+	if result.Value == uint64(pb.HAKeeperCreated) {
+		return moerr.NewInternalError(ctx,
+			"cannot restore HAKeeper ID watermarks before initial cluster state is applied")
 	}
 	return nil
 }
@@ -123,6 +160,9 @@ func (l *store) updateIDAlloc(count uint64) error {
 		err = moerr.AttachCause(ctx, err)
 		l.runtime.Logger().Error("propose get id failed", zap.Error(err))
 		return err
+	}
+	if result.Value == 0 {
+		return moerr.NewInternalError(ctx, "HAKeeper is not ready for ID allocation")
 	}
 	// TODO: add a test for this
 	l.alloc.Set(result.Value, result.Value+count-1)
@@ -312,6 +352,13 @@ func (l *store) checkBootstrap(state *pb.CheckerState) {
 	if !l.bootstrapMgr.CheckBootstrap(state.LogState) {
 		l.bootstrapCheckCycles--
 	} else {
+		// Recovery status is replicated through LogStore heartbeats. Do not use
+		// the leader process's local flag here: the recovery coordinator and the
+		// HAKeeper leader are not guaranteed to be the same LogService pod.
+		if walRecoveryPending(state) {
+			l.runtime.Logger().Info("bootstrap complete but WAL recovery is pending")
+			return
+		}
 		if err := l.setBootstrapState(true); err != nil {
 			panic(err)
 		}

--- a/pkg/logservice/store_hakeeper_check_test.go
+++ b/pkg/logservice/store_hakeeper_check_test.go
@@ -569,32 +569,65 @@ func TestSetInitialClusterInfo(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, pb.HAKeeperCreated, state.State)
 		nextIDByKey := map[string]uint64{"a": 1, "b": 2}
-		require.NoError(t, store.setInitialClusterInfo(
+		applied, err := store.setInitialClusterInfoWithResult(
 			1,
 			1,
 			1,
 			hakeeper.K8SIDRangeEnd+10,
 			nextIDByKey,
 			nil,
-		))
+		)
+		require.NoError(t, err)
+		assert.True(t, applied)
 		state, err = store.getCheckerState()
 		require.NoError(t, err)
 		assert.Equal(t, pb.HAKeeperBootstrapping, state.State)
 		assert.Equal(t, hakeeper.K8SIDRangeEnd+10, state.NextId)
 		assert.Equal(t, nextIDByKey, state.NextIDByKey)
+
+		applied, err = store.setInitialClusterInfoWithResult(
+			1,
+			1,
+			1,
+			hakeeper.K8SIDRangeEnd+50,
+			map[string]uint64{"a": 10, "b": 1},
+			nil,
+		)
+		require.NoError(t, err)
+		assert.False(t, applied)
+		state, err = store.getCheckerState()
+		require.NoError(t, err)
+		assert.Equal(t, pb.HAKeeperBootstrapping, state.State)
+		assert.Equal(t, hakeeper.K8SIDRangeEnd+10, state.NextId)
+		assert.Equal(t, nextIDByKey, state.NextIDByKey)
+
+		require.NoError(t, store.restoreIDWatermarks(
+			hakeeper.K8SIDRangeEnd+50,
+			map[string]uint64{"a": 10, "b": 1, "c": 3},
+		))
+		state, err = store.getCheckerState()
+		require.NoError(t, err)
+		assert.Equal(t, hakeeper.K8SIDRangeEnd+50, state.NextId)
+		assert.Equal(t, uint64(10), state.NextIDByKey["a"])
+		assert.Equal(t, uint64(2), state.NextIDByKey["b"])
+		assert.Equal(t, uint64(3), state.NextIDByKey["c"])
 	}
 	runHAKeeperStoreTest(t, false, fn)
 }
 
 func TestFailedBootstrap(t *testing.T) {
-	testBootstrap(t, true)
+	testBootstrap(t, true, false)
 }
 
 func TestBootstrap(t *testing.T) {
-	testBootstrap(t, false)
+	testBootstrap(t, false, false)
 }
 
-func testBootstrap(t *testing.T, fail bool) {
+func TestBootstrapWaitsForRemoteWALRecovery(t *testing.T) {
+	testBootstrap(t, false, true)
+}
+
+func testBootstrap(t *testing.T, fail bool, remoteRecoveryPending bool) {
 	fn := func(t *testing.T, store *store) {
 		state, err := store.getCheckerState()
 		require.NoError(t, err)
@@ -663,6 +696,17 @@ func testBootstrap(t *testing.T, fail bool) {
 			assert.True(t, cb.Commands[0].Bootstrapping)
 			service := &Service{store: store}
 			service.handleStartReplica(cb.Commands[0])
+			if remoteRecoveryPending {
+				_, err = store.addLogStoreHeartbeat(ctx, pb.LogStoreHeartbeat{
+					UUID: "remote-recovery-coordinator",
+					ConfigData: &pb.ConfigData{Content: map[string]*pb.ConfigItem{
+						walRecoveryStatusConfigKey: {
+							CurrentValue: walRecoveryStatusPending,
+						},
+					}},
+				})
+				require.NoError(t, err)
+			}
 
 			for i := 0; i < 100; i++ {
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -673,6 +717,24 @@ func testBootstrap(t *testing.T, fail bool) {
 
 				state, err = store.getCheckerState()
 				require.NoError(t, err)
+				if remoteRecoveryPending && store.bootstrapMgr.CheckBootstrap(state.LogState) {
+					store.checkBootstrap(state)
+					state, err = store.getCheckerState()
+					require.NoError(t, err)
+					assert.Equal(t, pb.HAKeeperBootstrapCommandsReceived, state.State)
+
+					_, err = store.addLogStoreHeartbeat(ctx, pb.LogStoreHeartbeat{
+						UUID: "remote-recovery-coordinator",
+						ConfigData: &pb.ConfigData{Content: map[string]*pb.ConfigItem{
+							walRecoveryStatusConfigKey: {
+								CurrentValue: walRecoveryStatusComplete,
+							},
+						}},
+					})
+					require.NoError(t, err)
+					remoteRecoveryPending = false
+					continue
+				}
 				store.checkBootstrap(state)
 
 				state, err = store.getCheckerState()

--- a/pkg/logservice/wal_recovery.go
+++ b/pkg/logservice/wal_recovery.go
@@ -1,0 +1,792 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logservice
+
+import (
+	"container/heap"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	"github.com/matrixorigin/matrixone/pkg/defines"
+	"github.com/matrixorigin/matrixone/pkg/fileservice"
+	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
+	"go.uber.org/zap"
+)
+
+const (
+	walRecoveredTagFilePrefix = "./WAL_RECOVERED"
+	walRecoveryStateVersion   = 1
+	walRecoveryStateSuffix    = ".restore-state.json"
+
+	logEntrySafeDSNOffset = 50
+
+	walDataFileCountSize       = 4
+	walDataFileEntryHeaderSize = 40
+
+	maxWALRecoveryEntries         = 10 * 1000 * 1000
+	maxWALRecoveryEntryDataSize   = defaultMaxMessageSize
+	maxWALRecoveryPreallocEntries = 64 * 1024
+	maxWALRecoveryFileSize        = 10 * defaultMaxMessageSize
+
+	leaseHolderIDSize = 8
+)
+
+// WALEntry represents a WAL entry read from the recovery file
+type WALEntry struct {
+	DSN        uint64
+	SafeDSN    uint64
+	RaftIndex  uint64
+	RaftTerm   uint64
+	EntryCount uint32
+	RawData    []byte
+}
+
+// WALRecoveryData contains all WAL entries to be recovered
+type WALRecoveryData struct {
+	Entries []WALEntry
+	Digest  string
+}
+
+type walRecoveryState struct {
+	Version    int    `json:"version"`
+	WALDigest  string `json:"wal_digest"`
+	EntryCount uint64 `json:"entry_count"`
+	BaseLSN    uint64 `json:"base_lsn"`
+	Complete   bool   `json:"complete"`
+}
+
+// RecoverWALData recovers WAL data from the specified file during LogService bootstrap.
+// This function is called when LogService starts in recovery mode with a WAL data file.
+// It reads the WAL entries extracted from the damaged LogService's Raft logs and
+// replays them into the new LogService's Log shard.
+func (s *Service) RecoverWALData(ctx context.Context, cfg Config) error {
+	walDataPath := cfg.BootstrapConfig.Restore.WALDataPath
+	if walDataPath == "" {
+		return nil
+	}
+
+	logger := s.runtime.SubLogger(runtime.SystemInit)
+	logger.Info("WAL recovery: checking WAL data file",
+		zap.String("path", walDataPath))
+
+	// Check if WAL recovery has already been done
+	fs, err := fileservice.Get[fileservice.FileService](s.fileService, defines.LocalFileServiceName)
+	if err != nil {
+		logger.Error("WAL recovery: failed to get file service", zap.Error(err))
+		return err
+	}
+	walRecoveredTagFile := getWALRecoveredTagFile(walDataPath)
+	walRecoveryStateFile := getWALRecoveryStateFile(walDataPath)
+
+	// Preserve compatibility with recovery images that only wrote the legacy
+	// completion tag. Force must not replay an already completed WAL into a
+	// non-empty shard; rebuilding empty LogService storage is the safe retry.
+	if _, stateErr := os.Stat(walRecoveryStateFile); os.IsNotExist(stateErr) {
+		_, err := fs.StatFile(ctx, walRecoveredTagFile)
+		if err == nil {
+			logger.Info("WAL recovery: legacy completion tag found, skipping replay",
+				zap.Bool("force_ignored", cfg.BootstrapConfig.Restore.Force),
+				zap.String("tag_file", walRecoveredTagFile))
+			return nil
+		}
+		if !moerr.IsMoErrCode(err, moerr.ErrFileNotFound) {
+			logger.Error("WAL recovery: failed to check recovery tag file", zap.Error(err))
+			return err
+		}
+	}
+
+	// Read WAL data from file
+	walData, err := s.readWALDataFile(ctx, walDataPath)
+	if err != nil {
+		logger.Error("WAL recovery: failed to read WAL data file",
+			zap.String("path", walDataPath),
+			zap.Error(err))
+		return err
+	}
+
+	if len(walData.Entries) == 0 {
+		logger.Info("WAL recovery: no entries to recover")
+		if err := completeEmptyWALRecovery(ctx, walRecoveryStateFile, walData.Digest); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	logger.Info("WAL recovery: loaded WAL entries",
+		zap.Int("count", len(walData.Entries)),
+		zap.Uint64("first_raft_index", walData.Entries[0].RaftIndex),
+		zap.Uint64("last_raft_index", walData.Entries[len(walData.Entries)-1].RaftIndex),
+		zap.Uint64("first_entry_dsn", walData.Entries[0].DSN),
+		zap.Uint64("last_entry_dsn", walData.Entries[len(walData.Entries)-1].DSN),
+		zap.Uint64("first_entry_safe_dsn", walData.Entries[0].SafeDSN),
+		zap.Uint64("last_entry_safe_dsn", walData.Entries[len(walData.Entries)-1].SafeDSN))
+
+	// Replay WAL entries to Log shard
+	if err := s.replayWALEntries(ctx, cfg, walData); err != nil {
+		logger.Error("WAL recovery: failed to replay WAL entries", zap.Error(err))
+		return err
+	}
+
+	// Keep writing the legacy tag so a rollback to an older recovery image
+	// cannot replay a WAL that this version already completed.
+	if err := fs.Write(ctx, fileservice.IOVector{
+		FilePath: walRecoveredTagFile,
+		Entries: []fileservice.IOEntry{
+			{
+				Offset: 0,
+				Size:   int64(len(walData.Digest)),
+				Data:   []byte(walData.Digest),
+			},
+		},
+	}); err != nil {
+		if moerr.IsMoErrCode(err, moerr.ErrFileAlreadyExists) {
+			logger.Info("WAL recovery: recovery tag file already exists")
+		} else {
+			logger.Warn("WAL recovery: failed to write legacy recovery tag",
+				zap.Error(err))
+		}
+	}
+
+	logger.Info("WAL recovery: completed successfully",
+		zap.Int("entries_recovered", len(walData.Entries)))
+
+	return nil
+}
+
+func getWALRecoveredTagFile(walDataPath string) string {
+	key := filepath.Clean(walDataPath)
+	if abs, err := filepath.Abs(walDataPath); err == nil {
+		key = abs
+	}
+	sum := sha256.Sum256([]byte(key))
+	return walRecoveredTagFilePrefix + "_" + hex.EncodeToString(sum[:8])
+}
+
+func getWALRecoveryStateFile(walDataPath string) string {
+	return filepath.Clean(walDataPath) + walRecoveryStateSuffix
+}
+
+func readWALRecoveryState(ctx context.Context, path string) (*walRecoveryState, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var state walRecoveryState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, moerr.NewInternalErrorf(ctx,
+			"invalid WAL recovery state file %s: %v", path, err)
+	}
+	if state.Version != walRecoveryStateVersion {
+		return nil, moerr.NewInternalErrorf(ctx,
+			"unsupported WAL recovery state version %d in %s", state.Version, path)
+	}
+	return &state, nil
+}
+
+func writeWALRecoveryState(ctx context.Context, path string, state walRecoveryState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".wal-restore-state-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = tmp.Close()
+		}
+		_ = os.Remove(tmpPath)
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	closed = true
+	if err := os.Rename(tmpPath, path); err != nil {
+		return moerr.NewInternalErrorf(ctx,
+			"failed to publish WAL recovery state %s: %v", path, err)
+	}
+	dir, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	if err := dir.Sync(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateWALRecoveryState(
+	ctx context.Context,
+	state *walRecoveryState,
+	digest string,
+	entryCount uint64,
+) error {
+	if state.WALDigest != digest {
+		return moerr.NewInternalErrorf(ctx,
+			"WAL recovery file changed after replay started: state digest %s, current digest %s",
+			state.WALDigest, digest)
+	}
+	if state.EntryCount != entryCount {
+		return moerr.NewInternalErrorf(ctx,
+			"WAL recovery entry count changed after replay started: state %d, current %d",
+			state.EntryCount, entryCount)
+	}
+	return nil
+}
+
+func completeEmptyWALRecovery(ctx context.Context, path, digest string) error {
+	state, err := readWALRecoveryState(ctx, path)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		state = &walRecoveryState{
+			Version:   walRecoveryStateVersion,
+			WALDigest: digest,
+			Complete:  true,
+		}
+		return writeWALRecoveryState(ctx, path, *state)
+	}
+	if err := validateWALRecoveryState(ctx, state, digest, 0); err != nil {
+		return err
+	}
+	if state.Complete {
+		return nil
+	}
+	state.Complete = true
+	return writeWALRecoveryState(ctx, path, *state)
+}
+
+// readWALDataFile reads WAL entries from the binary data file
+// File format:
+// [count:4][entry1_header:40][entry1_data]...[entryN_header:40][entryN_data]
+// Entry header format:
+// [DSN:8][SafeDSN:8][RaftIndex:8][RaftTerm:8][EntryCount:4][DataLen:4]
+func (s *Service) readWALDataFile(ctx context.Context, filePath string) (*WALRecoveryData, error) {
+	logger := s.runtime.SubLogger(runtime.SystemInit)
+
+	// Open the file
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, moerr.NewInternalErrorf(ctx, "failed to open WAL data file: %v", err)
+	}
+	defer f.Close()
+
+	fileInfo, err := f.Stat()
+	if err != nil {
+		return nil, moerr.NewInternalErrorf(ctx, "failed to stat WAL data file: %v", err)
+	}
+	if fileInfo.Size() < walDataFileCountSize {
+		return nil, moerr.NewInternalErrorf(ctx,
+			"WAL data file too small: size %d, need at least %d bytes",
+			fileInfo.Size(), walDataFileCountSize)
+	}
+	if fileInfo.Size() > maxWALRecoveryFileSize {
+		return nil, moerr.NewInternalErrorf(ctx,
+			"WAL data file size %d exceeds in-memory recovery limit %d",
+			fileInfo.Size(), maxWALRecoveryFileSize)
+	}
+	hasher := sha256.New()
+	reader := io.TeeReader(f, hasher)
+
+	// Read entry count
+	countBuf := make([]byte, walDataFileCountSize)
+	if _, err := io.ReadFull(reader, countBuf); err != nil {
+		return nil, moerr.NewInternalErrorf(ctx, "failed to read entry count: %v", err)
+	}
+	count := binary.LittleEndian.Uint32(countBuf)
+	if count > maxWALRecoveryEntries {
+		return nil, moerr.NewInternalErrorf(ctx,
+			"WAL data file entry count %d exceeds limit %d",
+			count, maxWALRecoveryEntries)
+	}
+	maxEntriesByFileSize := uint64(fileInfo.Size()-walDataFileCountSize) / walDataFileEntryHeaderSize
+	if uint64(count) > maxEntriesByFileSize {
+		return nil, moerr.NewInternalErrorf(ctx,
+			"WAL data file entry count %d exceeds max possible entries %d for file size %d",
+			count, maxEntriesByFileSize, fileInfo.Size())
+	}
+
+	logger.Info("WAL recovery: reading entries from file",
+		zap.Uint32("count", count),
+		zap.String("file", filePath))
+
+	entries := make([]WALEntry, 0, walRecoveryPreallocEntries(count))
+
+	// Read each entry
+	headerBuf := make([]byte, walDataFileEntryHeaderSize)
+	bytesRead := int64(walDataFileCountSize)
+	for i := uint32(0); i < count; i++ {
+		// Read header
+		if _, err := io.ReadFull(reader, headerBuf); err != nil {
+			return nil, moerr.NewInternalErrorf(ctx, "failed to read entry %d header: %v", i, err)
+		}
+		bytesRead += walDataFileEntryHeaderSize
+
+		entry := WALEntry{
+			DSN:        binary.LittleEndian.Uint64(headerBuf[0:8]),
+			SafeDSN:    binary.LittleEndian.Uint64(headerBuf[8:16]),
+			RaftIndex:  binary.LittleEndian.Uint64(headerBuf[16:24]),
+			RaftTerm:   binary.LittleEndian.Uint64(headerBuf[24:32]),
+			EntryCount: binary.LittleEndian.Uint32(headerBuf[32:36]),
+			RawData:    nil,
+		}
+		dataLen := binary.LittleEndian.Uint32(headerBuf[36:40])
+		if dataLen > maxWALRecoveryEntryDataSize {
+			return nil, moerr.NewInternalErrorf(ctx,
+				"WAL data file entry %d data length %d exceeds limit %d",
+				i, dataLen, maxWALRecoveryEntryDataSize)
+		}
+		remaining := fileInfo.Size() - bytesRead
+		if remaining < 0 || uint64(dataLen) > uint64(remaining) {
+			return nil, moerr.NewInternalErrorf(ctx,
+				"WAL data file entry %d data length %d exceeds remaining file bytes %d",
+				i, dataLen, remaining)
+		}
+
+		// Read raw data
+		entry.RawData = make([]byte, int(dataLen))
+		if _, err := io.ReadFull(reader, entry.RawData); err != nil {
+			return nil, moerr.NewInternalErrorf(ctx, "failed to read entry %d data: %v", i, err)
+		}
+		bytesRead += int64(dataLen)
+
+		entries = append(entries, entry)
+	}
+	if bytesRead < fileInfo.Size() {
+		return nil, moerr.NewInternalErrorf(ctx,
+			"WAL data file has %d trailing bytes", fileInfo.Size()-bytesRead)
+	}
+
+	// Replay must follow the original LogService PSN order. The backup file
+	// stores the source raft index, which is the old LogService LSN/PSN.
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].RaftIndex < entries[j].RaftIndex
+	})
+	normalizeWALEntrySafeDSN(entries)
+
+	return &WALRecoveryData{
+		Entries: entries,
+		Digest:  hex.EncodeToString(hasher.Sum(nil)),
+	}, nil
+}
+
+func walRecoveryPreallocEntries(count uint32) int {
+	if count > maxWALRecoveryPreallocEntries {
+		return maxWALRecoveryPreallocEntries
+	}
+	return int(count)
+}
+
+func normalizeWALEntrySafeDSN(entries []WALEntry) {
+	baseSafeDSN := firstNormalDSN(entries)
+	if baseSafeDSN > 0 {
+		baseSafeDSN--
+	}
+
+	contiguousDSN := baseSafeDSN
+	pending := make(dsnIntervalHeap, 0)
+	for i := range entries {
+		entry := &entries[i]
+		if entry.DSN != 0 && entry.EntryCount != 0 {
+			start := entry.DSN
+			end := entry.DSN + uint64(entry.EntryCount) - 1
+			if start <= contiguousDSN+1 {
+				if end > contiguousDSN {
+					contiguousDSN = end
+				}
+				contiguousDSN = drainContiguousIntervals(&pending, contiguousDSN)
+			} else {
+				heap.Push(&pending, dsnInterval{start: start, end: end})
+			}
+		}
+
+		safeDSN := entry.SafeDSN
+		if safeDSN == 0 || safeDSN > contiguousDSN {
+			safeDSN = contiguousDSN
+		}
+		if safeDSN < baseSafeDSN {
+			safeDSN = baseSafeDSN
+		}
+		entry.SafeDSN = safeDSN
+		if len(entry.RawData) >= logEntrySafeDSNOffset+8 {
+			binary.LittleEndian.PutUint64(entry.RawData[logEntrySafeDSNOffset:], safeDSN)
+		}
+	}
+}
+
+func firstNormalDSN(entries []WALEntry) uint64 {
+	for _, entry := range entries {
+		if entry.DSN != 0 && entry.EntryCount != 0 {
+			return entry.DSN
+		}
+	}
+	return 0
+}
+
+func drainContiguousIntervals(pending *dsnIntervalHeap, contiguousDSN uint64) uint64 {
+	for pending.Len() > 0 {
+		next := (*pending)[0]
+		if next.start > contiguousDSN+1 {
+			break
+		}
+		heap.Pop(pending)
+		if next.end > contiguousDSN {
+			contiguousDSN = next.end
+		}
+	}
+	return contiguousDSN
+}
+
+type dsnInterval struct {
+	start uint64
+	end   uint64
+}
+
+type dsnIntervalHeap []dsnInterval
+
+func (h dsnIntervalHeap) Len() int { return len(h) }
+
+func (h dsnIntervalHeap) Less(i, j int) bool {
+	if h[i].start != h[j].start {
+		return h[i].start < h[j].start
+	}
+	return h[i].end < h[j].end
+}
+
+func (h dsnIntervalHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *dsnIntervalHeap) Push(x any) {
+	*h = append(*h, x.(dsnInterval))
+}
+
+func (h *dsnIntervalHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+// buildUserEntryCmd builds a LogService command for UserEntryUpdate.
+// LogService command format:
+// - UpdateType: 4 bytes (big-endian uint32) = 2 (UserEntryUpdate)
+// - LeaseHolderID: 8 bytes (big-endian uint64)
+// - Payload: LogEntry data
+func buildUserEntryCmd(leaseHolderID uint64, payload []byte) []byte {
+	cmd := make([]byte, headerSize+leaseHolderIDSize+len(payload))
+	binaryEnc.PutUint32(cmd[0:4], uint32(pb.UserEntryUpdate))
+	binaryEnc.PutUint64(cmd[headerSize:], leaseHolderID)
+	copy(cmd[headerSize+leaseHolderIDSize:], payload)
+	return cmd
+}
+
+func walRecoveryResumeIndex(
+	ctx context.Context,
+	state *walRecoveryState,
+	walData *WALRecoveryData,
+	currentLSN uint64,
+) (int, error) {
+	entryCount := uint64(len(walData.Entries))
+	if err := validateWALRecoveryState(ctx, state, walData.Digest, entryCount); err != nil {
+		return 0, err
+	}
+	if currentLSN < state.BaseLSN {
+		return 0, moerr.NewInternalErrorf(ctx,
+			"Log shard latest LSN %d is below WAL recovery base LSN %d",
+			currentLSN, state.BaseLSN)
+	}
+	replayed := currentLSN - state.BaseLSN
+	if state.Complete {
+		if replayed < entryCount {
+			return 0, moerr.NewInternalErrorf(ctx,
+				"completed WAL recovery is missing entries: destination has %d, expected at least %d",
+				replayed, entryCount)
+		}
+		return len(walData.Entries), nil
+	}
+	if replayed > entryCount {
+		return 0, moerr.NewInternalErrorf(ctx,
+			"destination Log shard advanced by %d entries during WAL recovery, expected at most %d",
+			replayed, entryCount)
+	}
+	return int(replayed), nil
+}
+
+// replayWALEntries replays WAL entries to the Log shard.
+//
+// BootstrapHAKeeper elects exactly one configured LogService as the recovery
+// coordinator. It may not be the Log shard leader, so WAL replay appends
+// through the normal LogService client path. The client uses discovery/service
+// addresses to reach the current shard leader instead of proposing through
+// this pod's local NodeHost.
+func (s *Service) replayWALEntries(ctx context.Context, cfg Config, walData *WALRecoveryData) error {
+	logger := s.runtime.SubLogger(runtime.SystemInit)
+
+	// Get the Log shard ID (first log shard)
+	shardID := firstLogShardID
+
+	logger.Info("WAL recovery: starting replay to Log shard",
+		zap.Uint64("shard_id", shardID),
+		zap.Int("entry_count", len(walData.Entries)))
+
+	// Wait for Log shard to be ready before replaying.
+	logger.Info("WAL recovery: waiting for Log shard to be ready",
+		zap.Uint64("shard_id", shardID))
+
+	maxWaitTime := 5 * time.Minute
+	waitStart := time.Now()
+	leaderServiceAddress := ""
+	for {
+		select {
+		case <-ctx.Done():
+			return moerr.AttachCause(ctx, ctx.Err())
+		default:
+		}
+		if time.Since(waitStart) > maxWaitTime {
+			return moerr.NewInternalErrorf(ctx, "timeout waiting for Log shard %d to be ready", shardID)
+		}
+
+		info, ok := s.getShardInfo(shardID)
+		if ok && info.LeaderID != 0 {
+			logger.Info("WAL recovery: Log shard is ready",
+				zap.Uint64("shard_id", shardID),
+				zap.Uint64("leader_id", info.LeaderID))
+			if err := waitWALRecoveryInterval(ctx, 5*time.Second); err != nil {
+				return err
+			}
+
+			info2, ok2 := s.getShardInfo(shardID)
+			if ok2 && info2.LeaderID != 0 {
+				if replicaInfo, ok := info2.Replicas[info2.LeaderID]; ok {
+					leaderServiceAddress = replicaInfo.ServiceAddress
+				}
+				logger.Info("WAL recovery: Log shard leader confirmed",
+					zap.Uint64("shard_id", shardID),
+					zap.Uint64("leader_id", info2.LeaderID),
+					zap.String("leader_service_address", leaderServiceAddress))
+				break
+			}
+			logger.Warn("WAL recovery: Log shard leader lost after wait, retrying...")
+			continue
+		}
+
+		logger.Info("WAL recovery: Log shard not ready yet, waiting...",
+			zap.Uint64("shard_id", shardID),
+			zap.Bool("found", ok))
+		if err := waitWALRecoveryInterval(ctx, time.Second); err != nil {
+			return err
+		}
+	}
+
+	// Replay each entry
+	logger.Info("WAL recovery: starting entry replay loop",
+		zap.Int("total_entries", len(walData.Entries)))
+
+	appendCtx, cancel := context.WithTimeoutCause(ctx, 30*time.Second, moerr.CauseLogServiceBootstrap)
+	v, err := s.store.read(appendCtx, shardID, leaseHolderIDQuery{})
+	cancel()
+
+	var leaseHolderID uint64
+	if err != nil {
+		logger.Warn("WAL recovery: failed to get lease holder ID, using 0",
+			zap.Error(err))
+		leaseHolderID = 0
+	} else {
+		leaseHolderID = v.(uint64)
+		logger.Info("WAL recovery: got current lease holder ID",
+			zap.Uint64("lease_holder_id", leaseHolderID))
+	}
+
+	replayClient, err := s.newWALRecoveryClient(ctx, cfg, leaderServiceAddress)
+	if err != nil {
+		logger.Error("WAL recovery: failed to create replay client", zap.Error(err))
+		return err
+	}
+	defer func() {
+		if err := replayClient.close(); err != nil {
+			logger.Warn("WAL recovery: failed to close replay client", zap.Error(err))
+		}
+	}()
+	logger.Info("WAL recovery: replay client connected",
+		zap.String("address", replayClient.addr),
+		zap.String("discovery_address", cfg.HAKeeperClientConfig.DiscoveryAddress),
+		zap.Strings("service_addresses", cfg.HAKeeperClientConfig.ServiceAddresses))
+
+	lsnCtx, cancel := context.WithTimeoutCause(ctx, 30*time.Second, moerr.CauseLogServiceBootstrap)
+	currentLSN, err := replayClient.doGetLatestLsn(lsnCtx)
+	cancel()
+	if err != nil {
+		return moerr.NewInternalErrorf(ctx, "failed to get Log shard latest LSN: %v", err)
+	}
+
+	statePath := getWALRecoveryStateFile(cfg.BootstrapConfig.Restore.WALDataPath)
+	recoveryState, err := readWALRecoveryState(ctx, statePath)
+	if err != nil {
+		return err
+	}
+	if recoveryState == nil {
+		recoveryState = &walRecoveryState{
+			Version:    walRecoveryStateVersion,
+			WALDigest:  walData.Digest,
+			EntryCount: uint64(len(walData.Entries)),
+			BaseLSN:    uint64(currentLSN),
+		}
+		// The recovery state must be durable before the first append. On a
+		// restart, the destination LSN then provides the authoritative number
+		// of entries already replayed, including a crash immediately after an
+		// append but before any local progress update.
+		if err := writeWALRecoveryState(ctx, statePath, *recoveryState); err != nil {
+			return err
+		}
+	}
+	startIndex, err := walRecoveryResumeIndex(ctx, recoveryState, walData, uint64(currentLSN))
+	if err != nil {
+		return err
+	}
+	if recoveryState.Complete {
+		logger.Info("WAL recovery: durable completion state found, skipping replay",
+			zap.Int("entries", len(walData.Entries)),
+			zap.Bool("force_ignored", cfg.BootstrapConfig.Restore.Force))
+		return nil
+	}
+	logger.Info("WAL recovery: resume position",
+		zap.Int("completed_entries", startIndex),
+		zap.Uint64("base_lsn", recoveryState.BaseLSN),
+		zap.Uint64("current_lsn", uint64(currentLSN)))
+
+	for i := startIndex; i < len(walData.Entries); i++ {
+		entry := walData.Entries[i]
+		if i == startIndex {
+			logger.Info("WAL recovery: processing first entry",
+				zap.Int("index", i),
+				zap.Uint64("dsn", entry.DSN),
+				zap.Uint64("safe_dsn", entry.SafeDSN),
+				zap.Uint64("raft_index", entry.RaftIndex),
+				zap.Int("data_len", len(entry.RawData)))
+		}
+
+		cmd := buildUserEntryCmd(leaseHolderID, entry.RawData)
+		appendCtx, cancel := context.WithTimeoutCause(ctx, 30*time.Second, moerr.CauseLogServiceBootstrap)
+
+		if i == startIndex {
+			logger.Info("WAL recovery: calling append for first entry",
+				zap.Int("cmd_len", len(cmd)))
+		}
+
+		lsn, err := replayClient.doAppend(appendCtx, pb.LogRecord{Data: cmd})
+		cancel()
+
+		if i == startIndex {
+			logger.Info("WAL recovery: first append completed",
+				zap.Uint64("lsn", lsn),
+				zap.Error(err))
+		}
+
+		if err != nil {
+			logger.Error("WAL recovery: failed to append entry",
+				zap.Int("index", i),
+				zap.Uint64("dsn", entry.DSN),
+				zap.Error(err))
+			return moerr.NewInternalErrorf(ctx, "failed to append WAL entry %d (DSN=%d): %v", i, entry.DSN, err)
+		}
+		expectedLSN := recoveryState.BaseLSN + uint64(i) + 1
+		if uint64(lsn) != expectedLSN {
+			return moerr.NewInternalErrorf(ctx,
+				"unexpected LSN while replaying WAL entry %d: got %d, expected %d; another writer may be active",
+				i, lsn, expectedLSN)
+		}
+
+		if i%1000 == 0 || i == len(walData.Entries)-1 {
+			logger.Info("WAL recovery: progress",
+				zap.Int("current", i+1),
+				zap.Int("total", len(walData.Entries)),
+				zap.Uint64("dsn", entry.DSN),
+				zap.Uint64("safe_dsn", entry.SafeDSN),
+				zap.Uint64("raft_index", entry.RaftIndex),
+				zap.Uint64("lsn", lsn))
+		}
+	}
+
+	recoveryState.Complete = true
+	if err := writeWALRecoveryState(ctx, statePath, *recoveryState); err != nil {
+		return err
+	}
+
+	logger.Info("WAL recovery: replay completed",
+		zap.Int("entries_replayed", len(walData.Entries)-startIndex),
+		zap.Int("entries_total", len(walData.Entries)))
+
+	return nil
+}
+
+func waitWALRecoveryInterval(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return moerr.AttachCause(ctx, ctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (s *Service) newWALRecoveryClient(
+	ctx context.Context,
+	cfg Config,
+	leaderServiceAddress string,
+) (*client, error) {
+	serviceAddresses := append([]string{}, cfg.HAKeeperClientConfig.ServiceAddresses...)
+	if cfg.HAKeeperClientConfig.DiscoveryAddress == "" && leaderServiceAddress != "" {
+		serviceAddresses = []string{leaderServiceAddress}
+	}
+	clientCfg := ClientConfig{
+		Tag:              "wal-recovery",
+		ReadOnly:         true,
+		LogShardID:       firstLogShardID,
+		DiscoveryAddress: cfg.HAKeeperClientConfig.DiscoveryAddress,
+		ServiceAddresses: serviceAddresses,
+		MaxMessageSize:   int(cfg.RPC.MaxMessageSize),
+		EnableCompress:   cfg.RPC.EnableCompress,
+	}
+	connectCtx, cancel := context.WithTimeoutCause(ctx, 30*time.Second, moerr.CauseLogServiceBootstrap)
+	defer cancel()
+	return newClient(connectCtx, cfg.UUID, clientCfg)
+}

--- a/pkg/logservice/wal_recovery_status.go
+++ b/pkg/logservice/wal_recovery_status.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logservice
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/matrixorigin/matrixone/pkg/common/moerr"
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
+	"go.uber.org/zap"
+)
+
+const (
+	walRecoveryStatusConfigKey = "logservice.internal.wal-recovery-status"
+	walRecoveryStatusPending   = "pending"
+	walRecoveryStatusComplete  = "complete"
+	walRecoveryCoordinatorWait = 5 * time.Minute
+)
+
+func (s *Service) setWALRecoveryInProgress(pending bool) {
+	status := walRecoveryStatusComplete
+	if pending {
+		status = walRecoveryStatusPending
+	}
+	s.config.Set(walRecoveryStatusConfigKey, &pb.ConfigItem{
+		Name:         walRecoveryStatusConfigKey,
+		CurrentValue: status,
+		DefaultValue: walRecoveryStatusComplete,
+		Internal:     "internal",
+	})
+}
+
+func walRecoveryPending(state *pb.CheckerState) bool {
+	if state == nil {
+		return false
+	}
+	for _, store := range state.LogState.Stores {
+		if store.ConfigData == nil {
+			continue
+		}
+		item := store.ConfigData.Content[walRecoveryStatusConfigKey]
+		if item != nil && item.CurrentValue == walRecoveryStatusPending {
+			return true
+		}
+	}
+	return false
+}
+
+// walRecoveryCoordinator returns the lexicographically first recovering store
+// after every voting replica of the new Log shard has reported to HAKeeper.
+// Waiting for the complete membership prevents two recovering processes from
+// observing different partial store sets and both starting WAL replay.
+func walRecoveryCoordinator(state *pb.CheckerState, expectedReplicas uint64) (string, bool) {
+	if state == nil || expectedReplicas == 0 {
+		return "", false
+	}
+	shard, ok := state.LogState.Shards[firstLogShardID]
+	if !ok || uint64(len(shard.Replicas)) < expectedReplicas {
+		return "", false
+	}
+
+	pending := make([]string, 0, len(shard.Replicas))
+	for _, storeID := range shard.Replicas {
+		store, ok := state.LogState.Stores[storeID]
+		if !ok {
+			return "", false
+		}
+		if store.ConfigData == nil {
+			continue
+		}
+		item := store.ConfigData.Content[walRecoveryStatusConfigKey]
+		if item != nil && item.CurrentValue == walRecoveryStatusPending {
+			pending = append(pending, storeID)
+		}
+	}
+	if len(pending) == 0 {
+		return "", false
+	}
+	sort.Strings(pending)
+	return pending[0], true
+}
+
+func (s *Service) waitWALRecoveryCoordinator(ctx context.Context, expectedReplicas uint64) (bool, error) {
+	logger := s.runtime.SubLogger(runtime.SystemInit)
+	timer := time.NewTimer(walRecoveryCoordinatorWait)
+	defer timer.Stop()
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		state, err := s.store.getCheckerState()
+		if err != nil {
+			lastErr = err
+		} else if coordinator, ready := walRecoveryCoordinator(state, expectedReplicas); ready {
+			if coordinator == s.cfg.UUID {
+				logger.Info("WAL recovery: selected as recovery coordinator",
+					zap.String("coordinator", coordinator))
+				return true, nil
+			}
+			logger.Info("WAL recovery: another LogService is the recovery coordinator",
+				zap.String("coordinator", coordinator))
+			return false, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return false, moerr.AttachCause(ctx, ctx.Err())
+		case <-timer.C:
+			if lastErr != nil {
+				return false, moerr.NewInternalErrorf(ctx,
+					"timeout waiting for WAL recovery coordinator: last HAKeeper error: %v", lastErr)
+			}
+			return false, moerr.NewInternalError(ctx,
+				"timeout waiting for all LogService replicas to elect a WAL recovery coordinator")
+		case <-ticker.C:
+		}
+	}
+}

--- a/pkg/logservice/wal_recovery_test.go
+++ b/pkg/logservice/wal_recovery_test.go
@@ -1,0 +1,389 @@
+// Copyright 2024 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logservice
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/common/runtime"
+	pb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
+)
+
+func TestReadWALDataFileOrdersByRaftIndex(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wal_data.bin")
+	input := []WALEntry{
+		{DSN: 1, SafeDSN: 10, RaftIndex: 300, RaftTerm: 1, EntryCount: 1, RawData: []byte{1}},
+		{DSN: 2, SafeDSN: 20, RaftIndex: 100, RaftTerm: 1, EntryCount: 1, RawData: []byte{2}},
+		{DSN: 3, SafeDSN: 30, RaftIndex: 200, RaftTerm: 1, EntryCount: 1, RawData: []byte{3}},
+	}
+	if err := writeTestWALDataFile(path, input); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Service{runtime: runtime.DefaultRuntime()}
+	data, err := s.readWALDataFile(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data.Digest == "" {
+		t.Fatal("expected WAL content digest")
+	}
+
+	gotRaftIndexes := make([]uint64, 0, len(data.Entries))
+	gotDSNs := make([]uint64, 0, len(data.Entries))
+	for _, entry := range data.Entries {
+		gotRaftIndexes = append(gotRaftIndexes, entry.RaftIndex)
+		gotDSNs = append(gotDSNs, entry.DSN)
+	}
+
+	if want := []uint64{100, 200, 300}; !reflect.DeepEqual(gotRaftIndexes, want) {
+		t.Fatalf("unexpected raft index order: got %v, want %v", gotRaftIndexes, want)
+	}
+	if want := []uint64{2, 3, 1}; !reflect.DeepEqual(gotDSNs, want) {
+		t.Fatalf("unexpected DSN order: got %v, want %v", gotDSNs, want)
+	}
+}
+
+func TestReadWALDataFileNormalizesSafeDSN(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wal_data.bin")
+	input := []WALEntry{
+		{DSN: 10, SafeDSN: 60, RaftIndex: 100, RaftTerm: 1, EntryCount: 11, RawData: testRawLogEntry(60)},
+		{DSN: 50, SafeDSN: 60, RaftIndex: 200, RaftTerm: 1, EntryCount: 11, RawData: testRawLogEntry(60)},
+		{DSN: 21, SafeDSN: 60, RaftIndex: 300, RaftTerm: 1, EntryCount: 29, RawData: testRawLogEntry(60)},
+	}
+	if err := writeTestWALDataFile(path, input); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Service{runtime: runtime.DefaultRuntime()}
+	data, err := s.readWALDataFile(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotSafeDSNs := make([]uint64, 0, len(data.Entries))
+	gotPayloadSafeDSNs := make([]uint64, 0, len(data.Entries))
+	for _, entry := range data.Entries {
+		gotSafeDSNs = append(gotSafeDSNs, entry.SafeDSN)
+		gotPayloadSafeDSNs = append(
+			gotPayloadSafeDSNs,
+			binary.LittleEndian.Uint64(entry.RawData[logEntrySafeDSNOffset:]),
+		)
+	}
+
+	if want := []uint64{20, 20, 60}; !reflect.DeepEqual(gotSafeDSNs, want) {
+		t.Fatalf("unexpected safe DSNs: got %v, want %v", gotSafeDSNs, want)
+	}
+	if want := []uint64{20, 20, 60}; !reflect.DeepEqual(gotPayloadSafeDSNs, want) {
+		t.Fatalf("unexpected payload safe DSNs: got %v, want %v", gotPayloadSafeDSNs, want)
+	}
+}
+
+func TestReadWALDataFileRejectsMalformedFiles(t *testing.T) {
+	s := &Service{runtime: runtime.DefaultRuntime()}
+	testCases := []struct {
+		name       string
+		writeFile  func(string) error
+		wantErrMsg string
+	}{
+		{
+			name: "too small",
+			writeFile: func(path string) error {
+				return os.WriteFile(path, []byte{1, 2, 3}, 0644)
+			},
+			wantErrMsg: "too small",
+		},
+		{
+			name: "count exceeds limit",
+			writeFile: func(path string) error {
+				data := make([]byte, walDataFileCountSize)
+				binary.LittleEndian.PutUint32(data, uint32(maxWALRecoveryEntries+1))
+				return os.WriteFile(path, data, 0644)
+			},
+			wantErrMsg: "exceeds limit",
+		},
+		{
+			name: "file exceeds memory limit",
+			writeFile: func(path string) error {
+				f, err := os.Create(path)
+				if err != nil {
+					return err
+				}
+				if err := f.Truncate(maxWALRecoveryFileSize + 1); err != nil {
+					_ = f.Close()
+					return err
+				}
+				return f.Close()
+			},
+			wantErrMsg: "exceeds in-memory recovery limit",
+		},
+		{
+			name: "count exceeds file size",
+			writeFile: func(path string) error {
+				data := make([]byte, walDataFileCountSize)
+				binary.LittleEndian.PutUint32(data, 1)
+				return os.WriteFile(path, data, 0644)
+			},
+			wantErrMsg: "exceeds max possible entries",
+		},
+		{
+			name: "trailing bytes",
+			writeFile: func(path string) error {
+				data := make([]byte, walDataFileCountSize+1)
+				return os.WriteFile(path, data, 0644)
+			},
+			wantErrMsg: "trailing bytes",
+		},
+		{
+			name: "data length exceeds limit",
+			writeFile: func(path string) error {
+				data := make([]byte, walDataFileCountSize+walDataFileEntryHeaderSize)
+				binary.LittleEndian.PutUint32(data[:walDataFileCountSize], 1)
+				binary.LittleEndian.PutUint32(data[walDataFileCountSize+36:], uint32(maxWALRecoveryEntryDataSize+1))
+				return os.WriteFile(path, data, 0644)
+			},
+			wantErrMsg: "exceeds limit",
+		},
+		{
+			name: "data length exceeds remaining bytes",
+			writeFile: func(path string) error {
+				data := make([]byte, walDataFileCountSize+walDataFileEntryHeaderSize)
+				binary.LittleEndian.PutUint32(data[:walDataFileCountSize], 1)
+				binary.LittleEndian.PutUint32(data[walDataFileCountSize+36:], 8)
+				return os.WriteFile(path, data, 0644)
+			},
+			wantErrMsg: "exceeds remaining file bytes",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "wal_data.bin")
+			if err := tc.writeFile(path); err != nil {
+				t.Fatal(err)
+			}
+			_, err := s.readWALDataFile(context.Background(), path)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrMsg) {
+				t.Fatalf("unexpected error: got %v, want containing %q", err, tc.wantErrMsg)
+			}
+		})
+	}
+}
+
+func TestBuildUserEntryCmdUsesLogserviceCommandLayout(t *testing.T) {
+	payload := []byte{1, 2, 3}
+	cmd := buildUserEntryCmd(42, payload)
+
+	if got := parseCmdTag(cmd); got != pb.UserEntryUpdate {
+		t.Fatalf("unexpected command tag: got %v, want %v", got, pb.UserEntryUpdate)
+	}
+	if got := parseLeaseHolderID(cmd); got != 42 {
+		t.Fatalf("unexpected lease holder ID: got %d, want 42", got)
+	}
+	if !bytes.Equal(cmd[headerSize+leaseHolderIDSize:], payload) {
+		t.Fatalf("unexpected payload: got %v, want %v", cmd[headerSize+leaseHolderIDSize:], payload)
+	}
+}
+
+func TestGetWALRecoveredTagFileUsesWALDataPath(t *testing.T) {
+	first := getWALRecoveredTagFile(filepath.Join(t.TempDir(), "wal_data.bin"))
+	second := getWALRecoveredTagFile(filepath.Join(t.TempDir(), "wal_data.bin"))
+
+	if first == walRecoveredTagFilePrefix {
+		t.Fatalf("unexpected generic WAL recovery tag path: %s", first)
+	}
+	if first == second {
+		t.Fatalf("expected different WAL paths to use different tag files: %s", first)
+	}
+	if !strings.HasPrefix(first, walRecoveredTagFilePrefix+"_") {
+		t.Fatalf("unexpected WAL recovery tag path: %s", first)
+	}
+}
+
+func TestWALRecoveryResumeIndex(t *testing.T) {
+	ctx := context.Background()
+	data := &WALRecoveryData{
+		Entries: []WALEntry{{}, {}, {}},
+		Digest:  "digest-a",
+	}
+	state := &walRecoveryState{
+		Version:    walRecoveryStateVersion,
+		WALDigest:  data.Digest,
+		EntryCount: 3,
+		BaseLSN:    10,
+	}
+
+	index, err := walRecoveryResumeIndex(ctx, state, data, 12)
+	if err != nil || index != 2 {
+		t.Fatalf("unexpected resume result: index=%d err=%v", index, err)
+	}
+	if _, err := walRecoveryResumeIndex(ctx, state, data, 14); err == nil {
+		t.Fatal("expected concurrent append detection")
+	}
+
+	state.Complete = true
+	index, err = walRecoveryResumeIndex(ctx, state, data, 20)
+	if err != nil || index != len(data.Entries) {
+		t.Fatalf("completed recovery must skip replay: index=%d err=%v", index, err)
+	}
+	if _, err := walRecoveryResumeIndex(ctx, state, data, 12); err == nil {
+		t.Fatal("expected completed recovery truncation detection")
+	}
+
+	state.WALDigest = "digest-b"
+	if _, err := walRecoveryResumeIndex(ctx, state, data, 13); err == nil {
+		t.Fatal("expected WAL digest mismatch")
+	}
+}
+
+func TestWALRecoveryStateRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "wal_data.bin"+walRecoveryStateSuffix)
+	want := walRecoveryState{
+		Version:    walRecoveryStateVersion,
+		WALDigest:  "abc123",
+		EntryCount: 42,
+		BaseLSN:    3,
+		Complete:   true,
+	}
+	if err := writeWALRecoveryState(ctx, path, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readWALRecoveryState(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*got, want) {
+		t.Fatalf("unexpected state: got %+v, want %+v", *got, want)
+	}
+}
+
+func TestWALRecoveryPendingUsesReplicatedStoreState(t *testing.T) {
+	state := &pb.CheckerState{
+		LogState: pb.LogState{
+			Stores: map[string]pb.LogStoreInfo{
+				"remote-log-store": {
+					ConfigData: &pb.ConfigData{Content: map[string]*pb.ConfigItem{
+						walRecoveryStatusConfigKey: {
+							CurrentValue: walRecoveryStatusPending,
+						},
+					}},
+				},
+			},
+		},
+	}
+	if !walRecoveryPending(state) {
+		t.Fatal("expected remote LogStore recovery status to block bootstrap")
+	}
+	state.LogState.Stores["remote-log-store"].ConfigData.
+		Content[walRecoveryStatusConfigKey].CurrentValue = walRecoveryStatusComplete
+	if walRecoveryPending(state) {
+		t.Fatal("completed remote recovery must not block bootstrap")
+	}
+	if walRecoveryPending(&pb.CheckerState{}) {
+		t.Fatal("normal cluster without recovery status must not be blocked")
+	}
+}
+
+func TestWALRecoveryCoordinator(t *testing.T) {
+	recoveryStore := func(status string) pb.LogStoreInfo {
+		return pb.LogStoreInfo{ConfigData: &pb.ConfigData{Content: map[string]*pb.ConfigItem{
+			walRecoveryStatusConfigKey: {CurrentValue: status},
+		}}}
+	}
+	state := &pb.CheckerState{
+		LogState: pb.LogState{
+			Shards: map[uint64]pb.LogShardInfo{
+				firstLogShardID: {
+					ShardID: firstLogShardID,
+					Replicas: map[uint64]string{
+						10: "store-b",
+						11: "store-a",
+						12: "store-c",
+					},
+				},
+			},
+			Stores: map[string]pb.LogStoreInfo{
+				"store-a": recoveryStore(walRecoveryStatusPending),
+				"store-b": recoveryStore(walRecoveryStatusPending),
+			},
+		},
+	}
+
+	_, ready := walRecoveryCoordinator(state, 3)
+	if ready {
+		t.Fatal("all replica stores must report before election")
+	}
+
+	state.LogState.Stores["store-c"] = recoveryStore(walRecoveryStatusComplete)
+	coordinator, ready := walRecoveryCoordinator(state, 3)
+	if !ready || coordinator != "store-a" {
+		t.Fatalf("unexpected coordinator: ready=%v, coordinator=%q", ready, coordinator)
+	}
+
+	state.LogState.Stores["store-a"] = recoveryStore(walRecoveryStatusComplete)
+	coordinator, ready = walRecoveryCoordinator(state, 3)
+	if !ready || coordinator != "store-b" {
+		t.Fatalf("unexpected coordinator: ready=%v, coordinator=%q", ready, coordinator)
+	}
+}
+
+func writeTestWALDataFile(path string, entries []WALEntry) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	countBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(countBuf, uint32(len(entries)))
+	if _, err := f.Write(countBuf); err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		header := make([]byte, walDataFileEntryHeaderSize)
+		binary.LittleEndian.PutUint64(header[0:8], entry.DSN)
+		binary.LittleEndian.PutUint64(header[8:16], entry.SafeDSN)
+		binary.LittleEndian.PutUint64(header[16:24], entry.RaftIndex)
+		binary.LittleEndian.PutUint64(header[24:32], entry.RaftTerm)
+		binary.LittleEndian.PutUint32(header[32:36], entry.EntryCount)
+		binary.LittleEndian.PutUint32(header[36:40], uint32(len(entry.RawData)))
+		if _, err := f.Write(header); err != nil {
+			return err
+		}
+		if _, err := f.Write(entry.RawData); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testRawLogEntry(safeDSN uint64) []byte {
+	data := make([]byte, logEntrySafeDSNOffset+8)
+	binary.LittleEndian.PutUint64(data[logEntrySafeDSNOffset:], safeDSN)
+	return data
+}

--- a/pkg/util/dump_config.go
+++ b/pkg/util/dump_config.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/matrixorigin/matrixone/pkg/common/moerr"
@@ -259,9 +260,12 @@ func MergeConfig(dst *ConfigData, src map[string]*logservicepb.ConfigItem) {
 	if dst == nil || dst.configData == nil || src == nil {
 		return
 	}
+	dst.mu.Lock()
+	defer dst.mu.Unlock()
 	for s, item := range src {
 		dst.configData[s] = item
 	}
+	dst.count.Store(count)
 }
 
 const (
@@ -269,6 +273,7 @@ const (
 )
 
 type ConfigData struct {
+	mu         sync.RWMutex
 	count      atomic.Int32
 	configData map[string]*logservicepb.ConfigItem
 }
@@ -287,15 +292,41 @@ func NewConfigData(data map[string]*logservicepb.ConfigItem) *ConfigData {
 
 func (cd *ConfigData) GetData() *logservicepb.ConfigData {
 	if cd.count.Load() > 0 {
+		cd.mu.RLock()
+		defer cd.mu.RUnlock()
+		content := make(map[string]*logservicepb.ConfigItem, len(cd.configData))
+		for key, item := range cd.configData {
+			content[key] = item
+		}
 		return &logservicepb.ConfigData{
-			Content: cd.configData,
+			Content: content,
 		}
 	}
 	return nil
 }
 
+// Set updates a dynamic config item and schedules it to be sent in upcoming
+// heartbeats. The copy prevents callers from mutating heartbeat data after Set
+// returns.
+func (cd *ConfigData) Set(key string, item *logservicepb.ConfigItem) {
+	if cd == nil || key == "" || item == nil {
+		return
+	}
+	copyItem := *item
+	cd.mu.Lock()
+	cd.configData[key] = &copyItem
+	cd.mu.Unlock()
+	cd.count.Store(count)
+}
+
 func (cd *ConfigData) DecrCount() {
-	if cd.count.Load() > 0 {
-		cd.count.Add(-1)
+	for {
+		current := cd.count.Load()
+		if current <= 0 {
+			return
+		}
+		if cd.count.CompareAndSwap(current, current-1) {
+			return
+		}
 	}
 }

--- a/pkg/util/dump_config_test.go
+++ b/pkg/util/dump_config_test.go
@@ -15,8 +15,10 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	logservicepb "github.com/matrixorigin/matrixone/pkg/pb/logservice"
+	"github.com/stretchr/testify/assert"
 )
 
 type abc struct {
@@ -76,4 +78,24 @@ func Test_flatten(t *testing.T) {
 	err = flatten(k, "", "", "", exp)
 	assert.NoError(t, err)
 	exp.Print()
+}
+
+func TestConfigDataSetReschedulesHeartbeatData(t *testing.T) {
+	data := NewConfigData(map[string]*logservicepb.ConfigItem{
+		"static": {Name: "static", CurrentValue: "value"},
+	})
+	for i := 0; i < count; i++ {
+		data.DecrCount()
+	}
+	assert.Nil(t, data.GetData())
+
+	item := &logservicepb.ConfigItem{Name: "dynamic", CurrentValue: "pending"}
+	data.Set("dynamic", item)
+	item.CurrentValue = "mutated"
+
+	got := data.GetData()
+	if assert.NotNil(t, got) {
+		assert.Equal(t, "pending", got.Content["dynamic"].CurrentValue)
+		assert.Equal(t, "value", got.Content["static"].CurrentValue)
+	}
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Fixes #24966.

## What this PR does / why we need it:

This PR adds a fail-closed LogService rebuild path that consumes `hakeeper_backup.data` and `wal_data.bin` generated offline by `mo_br`.

- Restores both HAKeeper `NextID` and `NextIDByKey` through an explicit idempotent command. Watermarks only move forward, so retries cannot roll live IDs back.
- Writes `RESTORED` only after the replicated HAKeeper state is verified. An old or prematurely written marker no longer suppresses ID restoration.
- Replays WAL through the current Log shard leader and records durable progress in a digest-bound sidecar file. A restart resumes from the destination LSN instead of appending the WAL again.
- Replicates WAL recovery status through LogStore heartbeats. HAKeeper cannot enter `Running` while recovery is pending, even when the HAKeeper leader and recovery pod are different.
- Elects one recovery coordinator after all new Log shard replicas report. Configuring multiple Log pods with recovery files cannot create concurrent WAL writers.
- Rejects ID allocation while HAKeeper is in a non-running bootstrap state instead of panicking the HAKeeper state machine.
- Allows CN, TN, and embedded services to use a configurable HAKeeper-running timeout; the normal default remains two minutes.

The normal LogService startup path is unchanged when `wal-data-path` is empty. Ordinary duplicate initial-cluster requests remain no-ops, and WAL recovery requires an explicit valid HAKeeper backup.

## Validation

- `go test ./pkg/logservice -count=1`
- `go test ./pkg/hakeeper/... ./pkg/util -count=1`
- `go test -race ./pkg/util ./pkg/logservice -run 'TestConfigDataSetReschedulesHeartbeatData|TestWALRecoveryCoordinator|TestWALRecoveryPendingUsesReplicatedStoreState|TestWALRecoveryStateRoundTrip|TestBootstrapWaitsForRemoteWALRecovery' -count=1`
- `go test ./cmd/mo-service ./pkg/embed -run '^$' -count=1`
- `make err-check`

The original offline export, three-LogService rebuild, WAL replay, and TN/CN restart workflow was also validated in the isolated `50` kind environment.
