### PR TITLE
morpc: add default read timeout to prevent goroutine leak in query_client backends

### DIFF
--- a/pkg/common/morpc/cfg.go
+++ b/pkg/common/morpc/cfg.go
@@ -32,6 +32,7 @@ var (
 	defaultBufferSize            = 1024
 	defaultPayloadCopyBufferSize = 16 * 1024
 	defaultMaxMessageSize        = 1024 * 1024 * 100 // 100MB
+	defaultBackendReadTimeout    = 10 * time.Second
 )
 
 // Config rpc client config
@@ -198,6 +199,7 @@ func (c Config) getBackendOptions(logger *zap.Logger) []BackendOption {
 		WithBackendLogger(logger),
 		WithBackendBusyBufferSize(c.BusyQueueSize),
 		WithBackendBufferSize(c.SendQueueSize),
+		WithBackendReadTimeout(defaultBackendReadTimeout),
 		WithBackendGoettyOptions(goetty.WithSessionRWBUfferSize(
 			int(c.ReadBufferSize),
 			int(c.WriteBufferSize))))


### PR DESCRIPTION
## Summary

Fix goroutine leak in `readLoop` when remote CN becomes unresponsive.

`getBackendOptions()` in `cfg.go` does not set `WithBackendReadTimeout`, causing
backends created via `Config.NewClient()` (used by `query_client`) to call
`conn.Read()` with `Timeout: 0`. When the remote CN is alive at TCP level but
stops responding, the `readLoop` goroutine blocks permanently on `conn.Read()`
and is never reclaimed.

The `MethodBasedClient` path already sets `WithBackendReadTimeout(10s)` before
calling `NewClient()`, but the generic `Config.NewClient()` path misses it.

## Fix

Add `WithBackendReadTimeout(defaultBackendReadTimeout)` (10s) to
`getBackendOptions()`. This aligns the generic path with `MethodBasedClient`
behavior. Callers can still override via `BackendOptions` since user-supplied
options are appended after the defaults.

```diff
+	defaultBackendReadTimeout    = 10 * time.Second

 func (c Config) getBackendOptions(logger *zap.Logger) []BackendOption {
     var opts []BackendOption
     opts = append(opts,
         WithBackendLogger(logger),
         WithBackendBusyBufferSize(c.BusyQueueSize),
         WithBackendBufferSize(c.SendQueueSize),
+        WithBackendReadTimeout(defaultBackendReadTimeout),
         WithBackendGoettyOptions(goetty.WithSessionRWBUfferSize(
```

## Root Cause Analysis

```
query_client.go:83  NewQueryClient()
  → cfg.go:129       Config.NewClient()
    → cfg.go:195-206 getBackendOptions()   ← missing WithBackendReadTimeout
      → backend.go:660 readLoop: conn.Read(ReadOptions{Timeout: 0})  ← blocks forever
```

## Test Plan

- [x] Existing `morpc` tests pass (`go test ./pkg/common/morpc/...`)
- [x] Multi-CN cluster with simulated unresponsive CN (iptables drop) — verify `readLoop` goroutines exit after 10s timeout
- [x] Verify no regression in `MethodBasedClient` path (timeout already set, appended user options override)

---

⚡ **GrapeRoot static analysis** scanned 26 files · 7,708 lines · 365 symbols indexed · 0.30s · $0.00 *(vs $0.23 for an equivalent LLM code review)*

*Identified via [GrapeRoot](https://graperoot.dev) cross-file structural analysis — goroutine leak detector traced the missing timeout from the blocked `readLoop` through `getBackendOptions()` to the `Config.NewClient()` call path.*

Fixes #25191