### PR TITLE
fix(plan): handle NULL left operand in IN predicates

### DIFF
--- a/pkg/common/moerr/error.go
+++ b/pkg/common/moerr/error.go
@@ -88,6 +88,7 @@ const (
 	ErrUpgrateError         uint16 = 20311
 	ErrInvalidTz            uint16 = 20312
 	ErrUnsupportedDML       uint16 = 20313
+	ErrOperandColumns       uint16 = 20314
 
 	// Group 4: unexpected state and io errors
 	ErrInvalidState                             uint16 = 20400
@@ -387,6 +388,7 @@ var errorMsgRefer = map[uint16]moErrorMsgItem{
 	ErrWrongDatetimeSpec:    {ER_WRONG_DATETIME_SPEC, []string{MySQLDefaultSqlState}, "wrong date/time format specifier: %s"},
 	ErrUpgrateError:         {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "CN upgrade table or view '%s.%s' under tenant '%s:%d' reports error: %s"},
 	ErrUnsupportedDML:       {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "unsupported DML: %s"},
+	ErrOperandColumns:       {ER_OPERAND_COLUMNS, []string{"21000"}, "Operand should contain %d column(s)"},
 
 	// Group 4: unexpected state or file io error
 	ErrInvalidState:                             {ER_UNKNOWN_ERROR, []string{MySQLDefaultSqlState}, "invalid state %s"},
@@ -1400,6 +1402,10 @@ func NewDuplicateEntry(ctx context.Context, entry string, key string) *Error {
 
 func NewWrongValueCountOnRow(ctx context.Context, row int) *Error {
 	return newError(ctx, ErrWrongValueCountOnRow, row)
+}
+
+func NewOperandColumns(ctx context.Context, columns int) *Error {
+	return newError(ctx, ErrOperandColumns, columns)
 }
 
 func NewBadFieldError(ctx context.Context, column, table string) *Error {

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1925,9 +1925,17 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 		//if all the expr in the in list can safely cast to left type, we call it safe
 		if rightList := args[1].GetList(); rightList != nil {
 			typLeft := makeTypeByPlan2Expr(args[0])
+			leftIsConstNull := typLeft.Oid == types.T_any && args[0].GetLit() != nil && args[0].GetLit().Isnull
 			var inExprList, orExprList []*plan.Expr
 
 			for _, rightVal := range rightList.List {
+				if _, ok := rightVal.Expr.(*plan.Expr_List); ok && !partitionIn {
+					return nil, moerr.NewOperandColumns(ctx, 1)
+				}
+				if leftIsConstNull && !partitionIn {
+					orExprList = append(orExprList, rightVal)
+					continue
+				}
 				if checkNoNeedCast(makeTypeByPlan2Expr(rightVal), typLeft, rightVal) || partitionIn {
 					inExpr, err := appendCastBeforeExpr(ctx, rightVal, args[0].Typ)
 					if err != nil {

--- a/test/distributed/cases/operator/row_constructor.result
+++ b/test/distributed/cases/operator/row_constructor.result
@@ -87,6 +87,22 @@ null
 select (1,2) not in ((1,null),(2,2));
 (1, 2) not in ((1, null), (2, 2))
 null
+select null in (1, null) as r;
+r
+null
+select null not in (1, null) as r;
+r
+null
+create sequence seq_null_in;
+select null in (nextval('seq_null_in')) as r;
+r
+null
+select currval('seq_null_in') as v;
+v
+1
+drop sequence seq_null_in;
+select null in ((1,2));
+Operand should contain 1 column(s)
 select (1,2,3) > (-1,-3+2,2*3);
 (1, 2, 3) > (-1, -3 + 2, 2 * 3)
 1

--- a/test/distributed/cases/operator/row_constructor.sql
+++ b/test/distributed/cases/operator/row_constructor.sql
@@ -35,6 +35,13 @@ select (1,2) in ((1,null),(1,2));
 select (1,2) not in ((1,null));
 select (1,null) in ((1,null));
 select (1,2) not in ((1,null),(2,2));
+select null in (1, null) as r;
+select null not in (1, null) as r;
+create sequence seq_null_in;
+select null in (nextval('seq_null_in')) as r;
+select currval('seq_null_in') as v;
+drop sequence seq_null_in;
+select null in ((1,2));
 
 -- + - * / % mod
 select (1,2,3) > (-1,-3+2,2*3);


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25221 

## What this PR does / why we need it:

 - Return a typed boolean NULL when scalar IN / NOT IN has a constant NULL left operand.
  - Avoid generating invalid casts to ANY for expressions like `NULL IN (1, NULL)`.
  - Add regression coverage for `NULL IN (1, NULL)` and `NULL NOT IN (1, NULL)`.