### PR TITLE
fix: register remote dispatch receivers early

### DIFF
--- a/pkg/sql/colexec/dispatch/dispatch.go
+++ b/pkg/sql/colexec/dispatch/dispatch.go
@@ -216,8 +216,7 @@ func (dispatch *Dispatch) prepareRemote(proc *process.Process) error {
 		}
 		if needRegister {
 			if err := colexec.Get().PutProcIntoUuidMap(rr.Uuid, proc, dispatch.ctr.remoteInfo); err != nil {
-				colexec.Get().DeleteUuids(registered)
-				colexec.Get().DeleteUuids(registered)
+				rollbackRemoteReceiverRegistrations(registered)
 				dispatch.ctr.remoteInfo = nil
 				return err
 			}
@@ -225,6 +224,13 @@ func (dispatch *Dispatch) prepareRemote(proc *process.Process) error {
 		}
 	}
 	return nil
+}
+
+func rollbackRemoteReceiverRegistrations(registered []uuid.UUID) {
+	colexec.Get().DeleteUuids(registered)
+	for _, u := range registered {
+		colexec.Get().GetProcByUuid(u, false)
+	}
 }
 
 func (dispatch *Dispatch) prepareLocal() {

--- a/pkg/sql/colexec/dispatch/dispatch.go
+++ b/pkg/sql/colexec/dispatch/dispatch.go
@@ -209,14 +209,19 @@ func (dispatch *Dispatch) prepareRemote(proc *process.Process) error {
 	if needRegister {
 		dispatch.ctr.remoteInfo = make(chan *process.WrapCs)
 	}
+	registered := make([]uuid.UUID, 0, len(dispatch.RemoteRegs))
 	for i, rr := range dispatch.RemoteRegs {
 		if dispatch.FuncId == ShuffleToAllFunc {
 			dispatch.ctr.remoteToIdx[rr.Uuid] = dispatch.ShuffleRegIdxRemote[i]
 		}
 		if needRegister {
 			if err := colexec.Get().PutProcIntoUuidMap(rr.Uuid, proc, dispatch.ctr.remoteInfo); err != nil {
+				colexec.Get().DeleteUuids(registered)
+				colexec.Get().DeleteUuids(registered)
+				dispatch.ctr.remoteInfo = nil
 				return err
 			}
+			registered = append(registered, rr.Uuid)
 		}
 	}
 	return nil

--- a/pkg/sql/colexec/dispatch/dispatch.go
+++ b/pkg/sql/colexec/dispatch/dispatch.go
@@ -41,7 +41,10 @@ func (dispatch *Dispatch) Prepare(proc *process.Process) error {
 		dispatch.OpAnalyzer.Reset()
 	}
 
-	ctr := new(container)
+	ctr := dispatch.ctr
+	if ctr == nil {
+		ctr = new(container)
+	}
 	dispatch.ctr = ctr
 	ctr.localRegsCnt = len(dispatch.LocalRegs)
 	ctr.remoteRegsCnt = len(dispatch.RemoteRegs)
@@ -184,18 +187,36 @@ func (dispatch *Dispatch) waitRemoteRegsReady(proc *process.Process) (bool, erro
 	return false, nil
 }
 
+// RegisterRemoteReceivers publishes remote receiver UUIDs before the dispatch
+// operator reaches Prepare, so remote notify streams can attach early.
+func (dispatch *Dispatch) RegisterRemoteReceivers(proc *process.Process) error {
+	if len(dispatch.RemoteRegs) == 0 {
+		return nil
+	}
+	if dispatch.ctr == nil {
+		dispatch.ctr = new(container)
+	}
+	return dispatch.prepareRemote(proc)
+}
+
 func (dispatch *Dispatch) prepareRemote(proc *process.Process) error {
 	dispatch.ctr.prepared = false
 	dispatch.ctr.isRemote = true
+	dispatch.ctr.remoteRegsCnt = len(dispatch.RemoteRegs)
 	dispatch.ctr.remoteReceivers = make([]*process.WrapCs, 0, dispatch.ctr.remoteRegsCnt)
 	dispatch.ctr.remoteToIdx = make(map[uuid.UUID]int)
-	dispatch.ctr.remoteInfo = make(chan *process.WrapCs)
+	needRegister := dispatch.ctr.remoteInfo == nil
+	if needRegister {
+		dispatch.ctr.remoteInfo = make(chan *process.WrapCs)
+	}
 	for i, rr := range dispatch.RemoteRegs {
 		if dispatch.FuncId == ShuffleToAllFunc {
 			dispatch.ctr.remoteToIdx[rr.Uuid] = dispatch.ShuffleRegIdxRemote[i]
 		}
-		if err := colexec.Get().PutProcIntoUuidMap(rr.Uuid, proc, dispatch.ctr.remoteInfo); err != nil {
-			return err
+		if needRegister {
+			if err := colexec.Get().PutProcIntoUuidMap(rr.Uuid, proc, dispatch.ctr.remoteInfo); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -58,6 +58,37 @@ func TestPrepareRemote(t *testing.T) {
 	require.Equal(t, d.ctr.remoteInfo, c)
 }
 
+func TestRegisterRemoteReceiversBeforePrepare(t *testing.T) {
+	_ = colexec.NewServer(nil)
+
+	proc := testutil.NewProcess(t)
+
+	uid, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	d := Dispatch{
+		FuncId: SendToAllFunc,
+		RemoteRegs: []colexec.ReceiveInfo{
+			{Uuid: uid},
+		},
+	}
+
+	require.NoError(t, d.RegisterRemoteReceivers(proc))
+	require.NotNil(t, d.ctr)
+	earlyNotifyCh := d.ctr.remoteInfo
+	require.NotNil(t, earlyNotifyCh)
+
+	require.NoError(t, d.Prepare(proc))
+	require.Equal(t, earlyNotifyCh, d.ctr.remoteInfo)
+
+	p, notifyCh, ok := colexec.Get().GetProcByUuid(uid, false)
+	require.True(t, ok)
+	require.Same(t, proc, p)
+	require.Equal(t, earlyNotifyCh, notifyCh)
+
+	colexec.Get().DeleteUuids([]uuid.UUID{uid})
+}
+
 func TestDispatchAdoptCleanupState_TransfersOwnership(t *testing.T) {
 	original := &container{sendCnt: 1}
 	target := &Dispatch{ctr: &container{sendCnt: 99}}

--- a/pkg/sql/colexec/dispatch/dispatch_test.go
+++ b/pkg/sql/colexec/dispatch/dispatch_test.go
@@ -89,6 +89,34 @@ func TestRegisterRemoteReceiversBeforePrepare(t *testing.T) {
 	colexec.Get().DeleteUuids([]uuid.UUID{uid})
 }
 
+func TestRegisterRemoteReceiversRollbackOnPartialFailure(t *testing.T) {
+	_ = colexec.NewServer(nil)
+
+	proc := testutil.NewProcess(t)
+
+	uid1, err := uuid.NewV7()
+	require.NoError(t, err)
+	uid2, err := uuid.NewV7()
+	require.NoError(t, err)
+
+	colexec.Get().GetProcByUuid(uid2, true)
+	d := Dispatch{
+		FuncId: SendToAllFunc,
+		RemoteRegs: []colexec.ReceiveInfo{
+			{Uuid: uid1},
+			{Uuid: uid2},
+		},
+	}
+
+	require.Error(t, d.RegisterRemoteReceivers(proc))
+	require.Nil(t, d.ctr.remoteInfo)
+
+	p, notifyCh, ok := colexec.Get().GetProcByUuid(uid1, false)
+	require.False(t, ok)
+	require.Nil(t, p)
+	require.Nil(t, notifyCh)
+}
+
 func TestDispatchAdoptCleanupState_TransfersOwnership(t *testing.T) {
 	original := &container{sendCnt: 1}
 	target := &Dispatch{ctr: &container{sendCnt: 99}}

--- a/pkg/sql/compile/remoterunServer.go
+++ b/pkg/sql/compile/remoterunServer.go
@@ -37,12 +37,14 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/perfcounter"
 	qclient "github.com/matrixorigin/matrixone/pkg/queryservice/client"
 	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec/dispatch"
 	"github.com/matrixorigin/matrixone/pkg/sql/models"
 	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	"github.com/matrixorigin/matrixone/pkg/udf"
 	"github.com/matrixorigin/matrixone/pkg/util/debug/goroutine"
 	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
+	"github.com/matrixorigin/matrixone/pkg/vm"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/disttae"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
@@ -199,6 +201,9 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) error {
 			runCompile.Release()
 		}()
 
+		if err := registerRemoteDispatchReceivers(s, runCompile.proc); err != nil {
+			return err
+		}
 		colexec.Get().RecordBuiltPipeline(receiver.clientSession, receiver.messageId, runCompile.proc)
 
 		// running pipeline.
@@ -219,6 +224,29 @@ func handlePipelineMessage(receiver *messageReceiverOnServer) error {
 
 	default:
 		panic(fmt.Sprintf("unknown pipeline message type %d.", receiver.messageTyp))
+	}
+	return nil
+}
+
+func registerRemoteDispatchReceivers(s *Scope, proc *process.Process) error {
+	if s == nil {
+		return nil
+	}
+	if s.RootOp != nil {
+		if err := vm.HandleAllOp(s.RootOp, func(_ vm.Operator, op vm.Operator) error {
+			d, ok := op.(*dispatch.Dispatch)
+			if !ok {
+				return nil
+			}
+			return d.RegisterRemoteReceivers(proc)
+		}); err != nil {
+			return err
+		}
+	}
+	for _, pre := range s.PreScopes {
+		if err := registerRemoteDispatchReceivers(pre, proc); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25211

## What this PR does / why we need it:

  - register remote dispatch receiver UUIDs immediately after decoding the remote scope, before `MergeRun`
  - make dispatch remote receiver registration idempotent so `Prepare` reuses the early notification channel
  - add coverage for early registration followed by dispatch `Prepare`