### PR TITLE
cherrypick: fix conv

### DIFF
--- a/pkg/sql/plan/function/func_binary.go
+++ b/pkg/sql/plan/function/func_binary.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/big"
 	"sort"
 	"strconv"
 	"strings"
@@ -2557,9 +2558,17 @@ func Conv(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *pro
 		return nil
 	}
 
-	// Validate base ranges (2-36)
-	if fromBase < 2 || fromBase > 36 || toBase < 2 || toBase > 36 {
-		return moerr.NewInvalidInputf(proc.Ctx, "conv base must be between 2 and 36, got from_base=%d, to_base=%d", fromBase, toBase)
+	absFromBase := absInt64(fromBase)
+	absToBase := absInt64(toBase)
+
+	// Invalid bases return NULL.
+	if absFromBase < 2 || absFromBase > 36 || absToBase < 2 || absToBase > 36 {
+		for i := uint64(0); i < uint64(length); i++ {
+			if err = rs.AppendBytes(nil, true); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	// Handle different input types for N
@@ -2606,6 +2615,21 @@ func Conv(ivecs []*vector.Vector, result vector.FunctionResultWrapper, proc *pro
 	}
 }
 
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func formatUnsignedToBase(val uint64, toBase int64) string {
+	base := absInt64(toBase)
+	if toBase < 0 {
+		return strings.ToUpper(strconv.FormatInt(int64(val), int(base)))
+	}
+	return strings.ToUpper(strconv.FormatUint(val, int(base)))
+}
+
 func convString(nVec *vector.Vector, fromBase, toBase int64, rs *vector.FunctionResult[types.Varlena], length int, selectList *FunctionSelectList) error {
 	nParam := vector.GenerateFunctionStrParameter(nVec)
 
@@ -2624,50 +2648,106 @@ func convString(nVec *vector.Vector, fromBase, toBase int64, rs *vector.Function
 			}
 			continue
 		}
-
-		// Parse the number from from_base
-		// strconv.ParseInt can handle bases 2-36
-		val, err := strconv.ParseInt(strings.TrimSpace(string(nStr)), int(fromBase), 64)
-		if err != nil {
-			// If parsing as signed int fails, try unsigned
-			uval, uerr := strconv.ParseUint(strings.TrimSpace(string(nStr)), int(fromBase), 64)
-			if uerr != nil {
-				// Return NULL if parsing fails (MySQL behavior)
-				if err := rs.AppendBytes(nil, true); err != nil {
-					return err
-				}
-				continue
-			}
-			// Convert unsigned to string in to_base
-			result := strconv.FormatUint(uval, int(toBase))
-			if err := rs.AppendBytes([]byte(result), false); err != nil {
+		if len(strings.TrimSpace(string(nStr))) == 0 {
+			if err := rs.AppendBytes(nil, true); err != nil {
 				return err
 			}
-		} else {
-			// Convert signed int to string in to_base
-			// For negative numbers, MySQL returns the unsigned representation
-			if val < 0 {
-				uval := uint64(val)
-				result := strconv.FormatUint(uval, int(toBase))
-				if err := rs.AppendBytes([]byte(result), false); err != nil {
-					return err
-				}
-			} else {
-				result := strconv.FormatInt(val, int(toBase))
-				if err := rs.AppendBytes([]byte(result), false); err != nil {
-					return err
-				}
+			continue
+		}
+
+		signedVal, unsignedVal, signed, err := parseConvStrictString(string(nStr), fromBase)
+		if err != nil {
+			return err
+		}
+		if signed {
+			if err := rs.AppendBytes([]byte(formatSignedToBase(signedVal, toBase)), false); err != nil {
+				return err
 			}
+			continue
+		}
+		if err := rs.AppendBytes([]byte(formatUnsignedToBase(unsignedVal, toBase)), false); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
 func formatSignedToBase(val int64, toBase int64) string {
-	if val < 0 {
-		return strconv.FormatUint(uint64(val), int(toBase))
+	base := absInt64(toBase)
+	if toBase < 0 {
+		return strings.ToUpper(strconv.FormatInt(val, int(base)))
 	}
-	return strconv.FormatInt(val, int(toBase))
+	if val < 0 {
+		return strings.ToUpper(strconv.FormatUint(uint64(val), int(base)))
+	}
+	return strings.ToUpper(strconv.FormatInt(val, int(base)))
+}
+
+func parseConvStrictString(n string, fromBase int64) (int64, uint64, bool, error) {
+	s := strings.TrimSpace(n)
+	if len(s) == 0 {
+		return 0, 0, false, nil
+	}
+
+	base := int(absInt64(fromBase))
+	signOffset := 0
+	if strings.HasPrefix(s, "-") || strings.HasPrefix(s, "+") {
+		signOffset = 1
+	}
+	if signOffset == len(s) {
+		return 0, 0, false, moerr.NewInvalidInputNoCtxf("invalid conv input %q for base %d", n, base)
+	}
+	for _, ch := range s[signOffset:] {
+		var digit int
+		switch {
+		case ch >= '0' && ch <= '9':
+			digit = int(ch - '0')
+		case ch >= 'A' && ch <= 'Z':
+			digit = int(ch-'A') + 10
+		case ch >= 'a' && ch <= 'z':
+			digit = int(ch-'a') + 10
+		default:
+			return 0, 0, false, moerr.NewInvalidInputNoCtxf("invalid conv input %q for base %d", n, base)
+		}
+		if digit >= base {
+			return 0, 0, false, moerr.NewInvalidInputNoCtxf("invalid conv input %q for base %d", n, base)
+		}
+	}
+
+	if fromBase < 0 {
+		val, err := strconv.ParseInt(s, base, 64)
+		if err != nil {
+			if numErr, ok := err.(*strconv.NumError); ok && numErr.Err == strconv.ErrRange {
+				if strings.HasPrefix(s, "-") {
+					return math.MinInt64, 0, true, nil
+				}
+				return math.MaxInt64, 0, true, nil
+			}
+			return 0, 0, false, moerr.NewInvalidInputNoCtxf("invalid conv input %q for base %d", n, base)
+		}
+		return val, 0, true, nil
+	}
+
+	if strings.HasPrefix(s, "-") {
+		magnitudeStr := s[1:]
+		magnitude, ok := new(big.Int).SetString(magnitudeStr, base)
+		if !ok {
+			return 0, 0, false, moerr.NewInvalidInputNoCtxf("invalid conv input %q for base %d", n, base)
+		}
+		reduced := new(big.Int).Mod(magnitude, new(big.Int).Lsh(big.NewInt(1), 64))
+		return 0, uint64(0) - reduced.Uint64(), false, nil
+	}
+
+	s = strings.TrimPrefix(s, "+")
+
+	uval, err := strconv.ParseUint(s, base, 64)
+	if err != nil {
+		if numErr, ok := err.(*strconv.NumError); ok && numErr.Err == strconv.ErrRange {
+			return 0, math.MaxUint64, false, nil
+		}
+		return 0, 0, false, moerr.NewInvalidInputNoCtxf("invalid conv input %q for base %d", n, base)
+	}
+	return 0, uval, false, nil
 }
 
 func convInt8Direct(nVec *vector.Vector, toBase int64, rs *vector.FunctionResult[types.Varlena], length int, selectList *FunctionSelectList) error {
@@ -2797,7 +2877,7 @@ func convUint8Direct(nVec *vector.Vector, toBase int64, rs *vector.FunctionResul
 			continue
 		}
 
-		result := strconv.FormatUint(uint64(n), int(toBase))
+		result := formatUnsignedToBase(uint64(n), toBase)
 		if err := rs.AppendBytes([]byte(result), false); err != nil {
 			return err
 		}
@@ -2824,7 +2904,7 @@ func convUint16Direct(nVec *vector.Vector, toBase int64, rs *vector.FunctionResu
 			continue
 		}
 
-		result := strconv.FormatUint(uint64(n), int(toBase))
+		result := formatUnsignedToBase(uint64(n), toBase)
 		if err := rs.AppendBytes([]byte(result), false); err != nil {
 			return err
 		}
@@ -2851,7 +2931,7 @@ func convUint32Direct(nVec *vector.Vector, toBase int64, rs *vector.FunctionResu
 			continue
 		}
 
-		result := strconv.FormatUint(uint64(n), int(toBase))
+		result := formatUnsignedToBase(uint64(n), toBase)
 		if err := rs.AppendBytes([]byte(result), false); err != nil {
 			return err
 		}
@@ -2879,7 +2959,7 @@ func convUint64Direct(nVec *vector.Vector, toBase int64, rs *vector.FunctionResu
 		}
 
 		// Convert uint64 to string in to_base
-		result := strconv.FormatUint(n, int(toBase))
+		result := formatUnsignedToBase(n, toBase)
 		if err := rs.AppendBytes([]byte(result), false); err != nil {
 			return err
 		}

--- a/pkg/sql/plan/function/func_binary_test.go
+++ b/pkg/sql/plan/function/func_binary_test.go
@@ -2775,6 +2775,210 @@ func TestConvertTz(t *testing.T) {
 	}
 }
 
+func TestConvSemantics(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	cases := []struct {
+		name   string
+		inputs []FunctionTestInput
+		expect FunctionTestResult
+	}{
+		{
+			name: "uppercase output",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"255"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{10}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"FF"}, []bool{false}),
+		},
+		{
+			name: "null base returns null",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"10"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{0}, []bool{true}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{""}, []bool{true}),
+		},
+		{
+			name: "invalid base returns null",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"10"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{1}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{""}, []bool{true}),
+		},
+		{
+			name: "negative from_base signed parse",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"-17"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{-10}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"FFFFFFFFFFFFFFEF"}, []bool{false}),
+		},
+		{
+			name: "negative to_base signed output",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_int64.ToType(), []int64{-17}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{10}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{-18}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"-H"}, []bool{false}),
+		},
+		{
+			name: "unsigned parse with negative to_base",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"ffffffffffffffff"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{-10}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"-1"}, []bool{false}),
+		},
+		{
+			name: "decimal overflow saturates to uint64 max",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"18446744073709551616"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{10}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"FFFFFFFFFFFFFFFF"}, []bool{false}),
+		},
+		{
+			name: "negative decimal overflow wraps modulo uint64",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"-18446744073709551616"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{10}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"0"}, []bool{false}),
+		},
+		{
+			name: "hex overflow saturates to uint64 max",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"10000000000000000"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{10}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"18446744073709551615"}, []bool{false}),
+		},
+		{
+			name: "plus prefixed unsigned above max int64",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"+9223372036854775808"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{10}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"8000000000000000"}, []bool{false}),
+		},
+		{
+			name: "plus prefixed unsigned near uint64 max",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"+18446744073709551614"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{10}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"FFFFFFFFFFFFFFFE"}, []bool{false}),
+		},
+		{
+			name: "plus prefixed unsigned hex max",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(), []string{"+FFFFFFFFFFFFFFFF"}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+				NewFunctionTestConstInput(types.T_int64.ToType(), []int64{10}, []bool{false}),
+			},
+			expect: NewFunctionTestResult(types.T_varchar.ToType(), false, []string{"18446744073709551615"}, []bool{false}),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fcTC := NewFunctionTestCase(proc, tc.inputs, tc.expect, Conv)
+			s, info := fcTC.Run()
+			require.True(t, s, info)
+		})
+	}
+}
+
+func TestConvInvalidInputReturnsError(t *testing.T) {
+	proc := testutil.NewProcess(t)
+
+	cases := []struct {
+		name  string
+		value string
+		base  int64
+	}{
+		{name: "invalid character", value: "g", base: 16},
+		{name: "prefix truncation", value: "10xyz", base: 10},
+		{name: "invalid digit for base", value: "2", base: 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fcTC := NewFunctionTestCase(proc,
+				[]FunctionTestInput{
+					NewFunctionTestInput(types.T_varchar.ToType(), []string{tc.value}, []bool{false}),
+					NewFunctionTestConstInput(types.T_int64.ToType(), []int64{tc.base}, []bool{false}),
+					NewFunctionTestConstInput(types.T_int64.ToType(), []int64{16}, []bool{false}),
+				},
+				NewFunctionTestResult(types.T_varchar.ToType(), true, []string{""}, []bool{false}),
+				Conv,
+			)
+			s, info := fcTC.Run()
+			require.True(t, s, info)
+		})
+	}
+}
+
+func TestConvTypeCheckAcceptsNullBase(t *testing.T) {
+	_, err := GetFunctionByName(context.Background(), "conv", []types.Type{
+		types.T_varchar.ToType(),
+		types.T_any.ToType(),
+		types.T_int64.ToType(),
+	})
+	require.NoError(t, err)
+
+	_, err = GetFunctionByName(context.Background(), "conv", []types.Type{
+		types.T_varchar.ToType(),
+		types.T_int64.ToType(),
+		types.T_any.ToType(),
+	})
+	require.NoError(t, err)
+}
+
+func TestParseConvStrictStringEdgeCases(t *testing.T) {
+	t.Run("empty string returns zero values without error", func(t *testing.T) {
+		signedVal, unsignedVal, signed, err := parseConvStrictString("", 10)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), signedVal)
+		require.Equal(t, uint64(0), unsignedVal)
+		require.False(t, signed)
+	})
+
+	t.Run("sign only is invalid", func(t *testing.T) {
+		_, _, _, err := parseConvStrictString("+", 10)
+		require.Error(t, err)
+	})
+
+	t.Run("negative base positive overflow saturates to max int64", func(t *testing.T) {
+		signedVal, unsignedVal, signed, err := parseConvStrictString("9223372036854775808", -10)
+		require.NoError(t, err)
+		require.True(t, signed)
+		require.Equal(t, int64(math.MaxInt64), signedVal)
+		require.Equal(t, uint64(0), unsignedVal)
+	})
+
+	t.Run("negative base negative overflow saturates to min int64", func(t *testing.T) {
+		signedVal, unsignedVal, signed, err := parseConvStrictString("-9223372036854775809", -10)
+		require.NoError(t, err)
+		require.True(t, signed)
+		require.Equal(t, int64(math.MinInt64), signedVal)
+		require.Equal(t, uint64(0), unsignedVal)
+	})
+}
+
 func initFormatTestCase() []tcTemp {
 	format := `%b %M %m %c %D %d %e %j %k %h %i %p %r %T %s %f %U %u %V %v %a %W %w %X %x %Y %y %%`
 

--- a/pkg/sql/plan/function/list_builtIn.go
+++ b/pkg/sql/plan/function/list_builtIn.go
@@ -1637,8 +1637,9 @@ var supportedStringBuiltIns = []FuncNew{
 				return newCheckResultWithFailure(failedFunctionParametersWrong)
 			}
 			// First parameter can be any type (string or numeric)
-			// Second and third parameters must be int64 (bases)
-			if inputs[1].Oid != types.T_int64 || inputs[2].Oid != types.T_int64 {
+			// Second and third parameters must be int64, but NULL constants arrive as ANY
+			if (inputs[1].Oid != types.T_int64 && inputs[1].Oid != types.T_any) ||
+				(inputs[2].Oid != types.T_int64 && inputs[2].Oid != types.T_any) {
 				return newCheckResultWithFailure(failedFunctionParametersWrong)
 			}
 			return newCheckResultWithSuccess(0)

--- a/test/distributed/cases/function/func_conv.result
+++ b/test/distributed/cases/function/func_conv.result
@@ -2,120 +2,120 @@ drop database if exists conv_func;
 create database conv_func;
 use conv_func;
 select conv('a', 16, 10) as result1;
-➤ result1[12,65,0]  𝄀
+➤ result1[12,-1,0]  𝄀
 10
 select conv('1010', 2, 10) as result3;
-➤ result3[12,65,0]  𝄀
+➤ result3[12,-1,0]  𝄀
 10
 select conv('10', 10, 2) as result4;
-➤ result4[12,65,0]  𝄀
+➤ result4[12,-1,0]  𝄀
 1010
 select conv('12', 8, 10) as result5;
-➤ result5[12,65,0]  𝄀
+➤ result5[12,-1,0]  𝄀
 10
 select conv(null, 10, 16) as result7;
-➤ result7[12,65,0]  𝄀
+➤ result7[12,-1,0]  𝄀
 null
 select conv('a', 16, 10) as hex_to_dec;
-➤ hex_to_dec[12,65,0]  𝄀
+➤ hex_to_dec[12,-1,0]  𝄀
 10
 select conv('ff', 16, 10) as hex_to_dec;
-➤ hex_to_dec[12,65,0]  𝄀
+➤ hex_to_dec[12,-1,0]  𝄀
 255
 select conv('1a', 16, 10) as hex_to_dec;
-➤ hex_to_dec[12,65,0]  𝄀
+➤ hex_to_dec[12,-1,0]  𝄀
 26
 select conv('1010', 2, 10) as bin_to_dec;
-➤ bin_to_dec[12,65,0]  𝄀
+➤ bin_to_dec[12,-1,0]  𝄀
 10
 select conv('11111111', 2, 10) as bin_to_dec;
-➤ bin_to_dec[12,65,0]  𝄀
+➤ bin_to_dec[12,-1,0]  𝄀
 255
 select conv('10', 10, 2) as dec_to_bin;
-➤ dec_to_bin[12,65,0]  𝄀
+➤ dec_to_bin[12,-1,0]  𝄀
 1010
 select conv('255', 10, 2) as dec_to_bin;
-➤ dec_to_bin[12,65,0]  𝄀
+➤ dec_to_bin[12,-1,0]  𝄀
 11111111
 select conv('12', 8, 10) as oct_to_dec;
-➤ oct_to_dec[12,65,0]  𝄀
+➤ oct_to_dec[12,-1,0]  𝄀
 10
 select conv('377', 8, 10) as oct_to_dec;
-➤ oct_to_dec[12,65,0]  𝄀
+➤ oct_to_dec[12,-1,0]  𝄀
 255
 select conv('10', 10, 8) as dec_to_oct;
-➤ dec_to_oct[12,65,0]  𝄀
+➤ dec_to_oct[12,-1,0]  𝄀
 12
 select conv('255', 10, 8) as dec_to_oct;
-➤ dec_to_oct[12,65,0]  𝄀
+➤ dec_to_oct[12,-1,0]  𝄀
 377
 select conv('ff', 16, 2) as hex_to_bin;
-➤ hex_to_bin[12,65,0]  𝄀
+➤ hex_to_bin[12,-1,0]  𝄀
 11111111
 select conv('ff', 16, 8) as hex_to_oct;
-➤ hex_to_oct[12,65,0]  𝄀
+➤ hex_to_oct[12,-1,0]  𝄀
 377
 select conv('0', 10, 2) as zero_dec_to_bin;
-➤ zero_dec_to_bin[12,65,0]  𝄀
+➤ zero_dec_to_bin[12,-1,0]  𝄀
 0
 select conv('0', 16, 10) as zero_hex_to_dec;
-➤ zero_hex_to_dec[12,65,0]  𝄀
+➤ zero_hex_to_dec[12,-1,0]  𝄀
 0
 select conv('-1', 10, 2) as negative_dec_to_bin;
-➤ negative_dec_to_bin[12,65,0]  𝄀
+➤ negative_dec_to_bin[12,-1,0]  𝄀
 1111111111111111111111111111111111111111111111111111111111111111
 select conv('ffffffffffffffff', 16, 10) as large_hex_to_dec;
-➤ large_hex_to_dec[12,65,0]  𝄀
+➤ large_hex_to_dec[12,-1,0]  𝄀
 18446744073709551615
 select conv('abc', 16, 10) as lowercase_hex;
-➤ lowercase_hex[12,65,0]  𝄀
+➤ lowercase_hex[12,-1,0]  𝄀
 2748
 select conv('abc', 16, 10) as uppercase_hex;
-➤ uppercase_hex[12,65,0]  𝄀
+➤ uppercase_hex[12,-1,0]  𝄀
 2748
 select conv('abc', 16, 10) as mixed_case_hex;
-➤ mixed_case_hex[12,65,0]  𝄀
+➤ mixed_case_hex[12,-1,0]  𝄀
 2748
 select conv('z', 36, 10) as base36_to_dec;
-➤ base36_to_dec[12,65,0]  𝄀
+➤ base36_to_dec[12,-1,0]  𝄀
 35
 select conv('10', 36, 10) as base36_to_dec;
-➤ base36_to_dec[12,65,0]  𝄀
+➤ base36_to_dec[12,-1,0]  𝄀
 36
 select conv('12', 3, 10) as base3_to_dec;
-➤ base3_to_dec[12,65,0]  𝄀
+➤ base3_to_dec[12,-1,0]  𝄀
 5
 select conv('5', 10, 3) as dec_to_base3;
-➤ dec_to_base3[12,65,0]  𝄀
+➤ dec_to_base3[12,-1,0]  𝄀
 12
 select conv('24', 5, 10) as base5_to_dec;
-➤ base5_to_dec[12,65,0]  𝄀
+➤ base5_to_dec[12,-1,0]  𝄀
 14
 select conv('14', 10, 5) as dec_to_base5;
-➤ dec_to_base5[12,65,0]  𝄀
+➤ dec_to_base5[12,-1,0]  𝄀
 24
 select conv(null, 10, 16) as null_number;
-➤ null_number[12,65,0]  𝄀
+➤ null_number[12,-1,0]  𝄀
 null
 select conv(255, 10, 2) as numeric_input_bin;
-➤ numeric_input_bin[12,65,0]  𝄀
+➤ numeric_input_bin[12,-1,0]  𝄀
 11111111
 select conv('', 10, 16) as empty_string;
-➤ empty_string[12,65,0]  𝄀
+➤ empty_string[12,-1,0]  𝄀
 null
 select conv('ff', 16, 10) as red,
 conv('00', 16, 10) as green,
 conv('00', 16, 10) as blue;
-➤ red[12,65,0]  ¦  green[12,65,0]  ¦  blue[12,65,0]  𝄀
+➤ red[12,-1,0]  ¦  green[12,-1,0]  ¦  blue[12,-1,0]  𝄀
 255  ¦  0  ¦  0
 select conv('755', 8, 2) as file_permissions;
-➤ file_permissions[12,65,0]  𝄀
+➤ file_permissions[12,-1,0]  𝄀
 111101101
 select upper(conv('255', 10, 16)) as upper_hex;
-➤ upper_hex[12,65,0]  𝄀
+➤ upper_hex[12,-1,0]  𝄀
 FF
 select lower(conv('255', 10, 16)) as lower_hex;
-➤ lower_hex[12,65,0]  𝄀
+➤ lower_hex[12,-1,0]  𝄀
 ff
 create table if not exists test_conv (
 id int,
@@ -125,65 +125,137 @@ insert into test_conv values (1, 'a'), (2, 'ff'), (3, '1a');
 select id, hex_value, conv(hex_value, 16, 10) as decimal_value
 from test_conv
 where conv(hex_value, 16, 10) > 15;
-➤ id[4,11,0]  ¦  hex_value[12,20,0]  ¦  decimal_value[12,65,0]  𝄀
+➤ id[4,32,0]  ¦  hex_value[12,-1,0]  ¦  decimal_value[12,-1,0]  𝄀
 2  ¦  ff  ¦  255  𝄀
 3  ¦  1a  ¦  26
 drop table if exists test_conv;
 select conv('255', 10, 16) as result2;
-[unknown result because it is related to issue#23845]
+➤ result2[12,-1,0]  𝄀
+FF
 select conv('-1', 10, 16) as result6;
-[unknown result because it is related to issue#23845]
+➤ result6[12,-1,0]  𝄀
+FFFFFFFFFFFFFFFF
 select conv('10', 10, 16) as dec_to_hex;
-[unknown result because it is related to issue#23845]
+➤ dec_to_hex[12,-1,0]  𝄀
+A
 select conv('255', 10, 16) as dec_to_hex;
-[unknown result because it is related to issue#23845]
+➤ dec_to_hex[12,-1,0]  𝄀
+FF
 select conv('26', 10, 16) as dec_to_hex;
-[unknown result because it is related to issue#23845]
+➤ dec_to_hex[12,-1,0]  𝄀
+1A
 select conv('11111111', 2, 16) as bin_to_hex;
-[unknown result because it is related to issue#23845]
+➤ bin_to_hex[12,-1,0]  𝄀
+FF
 select conv('377', 8, 16) as oct_to_hex;
-[unknown result because it is related to issue#23845]
+➤ oct_to_hex[12,-1,0]  𝄀
+FF
 select conv('-10', 10, 16) as negative_dec_to_hex;
-[unknown result because it is related to issue#23845]
+➤ negative_dec_to_hex[12,-1,0]  𝄀
+FFFFFFFFFFFFFFF6
 select conv('18446744073709551615', 10, 16) as large_dec_to_hex;
-[unknown result because it is related to issue#23845]
+➤ large_dec_to_hex[12,-1,0]  𝄀
+FFFFFFFFFFFFFFFF
 select conv('35', 10, 36) as dec_to_base36;
-[unknown result because it is related to issue#23845]
+➤ dec_to_base36[12,-1,0]  𝄀
+Z
 select conv(' 10 ', 10, 16) as whitespace_input;
-[unknown result because it is related to issue#23845]
+➤ whitespace_input[12,-1,0]  𝄀
+A
 select conv('+10', 10, 16) as plus_sign;
-[unknown result because it is related to issue#23845]
+➤ plus_sign[12,-1,0]  𝄀
+A
 select conv('192', 10, 16) as ip_part1,
 conv('168', 10, 16) as ip_part2,
 conv('1', 10, 16) as ip_part3,
 conv('1', 10, 16) as ip_part4;
-[unknown result because it is related to issue#23845]
+➤ ip_part1[12,-1,0]  ¦  ip_part2[12,-1,0]  ¦  ip_part3[12,-1,0]  ¦  ip_part4[12,-1,0]  𝄀
+C0  ¦  A8  ¦  1  ¦  1
 select concat('0x', conv('255', 10, 16)) as hex_with_prefix;
-[unknown result because it is related to issue#23845]
+➤ hex_with_prefix[12,-1,0]  𝄀
+0xFF
 select conv('g', 16, 10) as result8;
-[unknown result because it is related to issue#23845]
+invalid input: invalid conv input "g" for base 16
 select conv('10', 1, 10) as result9;
-[unknown result because it is related to issue#23845]
+➤ result9[12,-1,0]  𝄀
+null
 select conv('abc', 16, 10) as result10;
-[unknown result because it is related to issue#23845]
+➤ result10[12,-1,0]  𝄀
+2748
 select conv('10', null, 16) as null_from_base;
-[unknown result because it is related to issue#23845]
+➤ null_from_base[12,-1,0]  𝄀
+null
 select conv('10', 10, null) as null_to_base;
-[unknown result because it is related to issue#23845]
+➤ null_to_base[12,-1,0]  𝄀
+null
 select conv('g', 16, 10) as invalid_hex_char;
-[unknown result because it is related to issue#23845]
+invalid input: invalid conv input "g" for base 16
 select conv('2', 2, 10) as invalid_binary_char;
-[unknown result because it is related to issue#23845]
+invalid input: invalid conv input "2" for base 2
 select conv('8', 8, 10) as invalid_octal_char;
-[unknown result because it is related to issue#23845]
+invalid input: invalid conv input "8" for base 8
 select conv('10', 1, 10) as invalid_from_base;
-[unknown result because it is related to issue#23845]
+➤ invalid_from_base[12,-1,0]  𝄀
+null
 select conv('10', 10, 1) as invalid_to_base;
-[unknown result because it is related to issue#23845]
+➤ invalid_to_base[12,-1,0]  𝄀
+null
 select conv('10', 37, 10) as invalid_from_base_high;
-[unknown result because it is related to issue#23845]
+➤ invalid_from_base_high[12,-1,0]  𝄀
+null
 select conv('10', 10, 37) as invalid_to_base_high;
-[unknown result because it is related to issue#23845]
+➤ invalid_to_base_high[12,-1,0]  𝄀
+null
 select conv(10, 10, 16) as numeric_input;
-[unknown result because it is related to issue#23845]
+➤ numeric_input[12,-1,0]  𝄀
+A
+select conv(-17, 10, -18) as negative_to_negative_base;
+➤ negative_to_negative_base[12,-1,0]  𝄀
+-H
+select conv(17, 10, -18) as positive_to_negative_base;
+➤ positive_to_negative_base[12,-1,0]  𝄀
+H
+select conv('-17', -10, 16) as negative_from_negative_base;
+➤ negative_from_negative_base[12,-1,0]  𝄀
+FFFFFFFFFFFFFFEF
+select conv('17', -10, 16) as positive_from_negative_base;
+➤ positive_from_negative_base[12,-1,0]  𝄀
+11
+select conv('ffffffffffffffff', 16, -10) as unsigned_to_negative_base;
+➤ unsigned_to_negative_base[12,-1,0]  𝄀
+-1
+select conv('-9223372036854775808', 10, 16) as negative_int64_min;
+➤ negative_int64_min[12,-1,0]  𝄀
+8000000000000000
+select conv('-9223372036854775809', 10, 16) as negative_below_int64_min;
+➤ negative_below_int64_min[12,-1,0]  𝄀
+7FFFFFFFFFFFFFFF
+select conv('-18446744073709551615', 10, 16) as negative_uint64_max_minus_one;
+➤ negative_uint64_max_minus_one[12,-1,0]  𝄀
+1
+select conv('-18446744073709551616', 10, 16) as negative_uint64_overflow;
+➤ negative_uint64_overflow[12,-1,0]  𝄀
+0
+select conv('10xyz', 10, 16) as invalid_suffix;
+invalid input: invalid conv input "10xyz" for base 10
+select conv('18446744073709551616', 10, 16) as overflow_decimal_to_hex;
+➤ overflow_decimal_to_hex[12,-1,0]  𝄀
+FFFFFFFFFFFFFFFF
+select conv('-18446744073709551616', 10, 16) as overflow_negative_decimal_to_hex;
+➤ overflow_negative_decimal_to_hex[12,-1,0]  𝄀
+0
+select conv('10000000000000000', 16, 10) as overflow_hex_to_decimal;
+➤ overflow_hex_to_decimal[12,-1,0]  𝄀
+18446744073709551615
+select conv('+9223372036854775808', 10, 16) as plus_prefixed_above_max_int64;
+➤ plus_prefixed_above_max_int64[12,-1,0]  𝄀
+8000000000000000
+select conv('+18446744073709551614', 10, 16) as plus_prefixed_near_uint64_max;
+➤ plus_prefixed_near_uint64_max[12,-1,0]  𝄀
+FFFFFFFFFFFFFFFE
+select conv('+FFFFFFFFFFFFFFFF', 16, 10) as plus_prefixed_hex_uint64_max;
+➤ plus_prefixed_hex_uint64_max[12,-1,0]  𝄀
+18446744073709551615
+select conv('+', 10, 16) as sign_only_invalid;
+invalid input: invalid conv input "+" for base 10
 drop database conv_func;

--- a/test/distributed/cases/function/func_conv.sql
+++ b/test/distributed/cases/function/func_conv.sql
@@ -203,7 +203,6 @@ drop table if exists test_conv;
 -- MO vs MySQL differing cases (issue #23845)
 -- All failures are case sensitivity: MySQL returns uppercase, MO returns lowercase
 -- ============================================
--- @bvt:issue#23845
 -- test 2: decimal to hex
 select conv('255', 10, 16) as result2;
 -- expected: ff
@@ -260,43 +259,96 @@ select concat('0x', conv('255', 10, 16)) as hex_with_prefix;
 -- expected: 0xff
 
 select conv('g', 16, 10) as result8;
--- expected: MySQL returns 0, MO returns null
+-- expected: MO returns error on invalid character
 
 select conv('10', 1, 10) as result9;
--- expected: MySQL returns null, MO returns error
+-- expected: null
 
 select conv('abc', 16, 10) as result10;
--- expected: 2748 (MO result parsing issue)
+-- expected: 2748
 
 select conv('10', null, 16) as null_from_base;
--- expected: MySQL returns null, MO returns error
+-- expected: null
 
 select conv('10', 10, null) as null_to_base;
--- expected: MySQL returns null, MO returns error
+-- expected: null
 
 select conv('g', 16, 10) as invalid_hex_char;
--- expected: MySQL returns 0, MO returns null
+-- expected: MO returns error on invalid character
 
 select conv('2', 2, 10) as invalid_binary_char;
--- expected: MySQL returns 0, MO returns null
+-- expected: MO returns error on invalid character
 
 select conv('8', 8, 10) as invalid_octal_char;
--- expected: MySQL returns 0, MO returns null
+-- expected: MO returns error on invalid character
 
 select conv('10', 1, 10) as invalid_from_base;
--- expected: MySQL returns null, MO returns error
+-- expected: null
 
 select conv('10', 10, 1) as invalid_to_base;
--- expected: MySQL returns null, MO returns error
+-- expected: null
 
 select conv('10', 37, 10) as invalid_from_base_high;
--- expected: MySQL returns null, MO returns error
+-- expected: null
 
 select conv('10', 10, 37) as invalid_to_base_high;
--- expected: MySQL returns null, MO returns error
+-- expected: null
 
 select conv(10, 10, 16) as numeric_input;
--- expected: a (MO result parsing issue)
--- @bvt:issue
+-- expected: A
+
+-- negative base semantics
+select conv(-17, 10, -18) as negative_to_negative_base;
+-- expected: -H
+
+select conv(17, 10, -18) as positive_to_negative_base;
+-- expected: H
+
+select conv('-17', -10, 16) as negative_from_negative_base;
+-- expected: FFFFFFFFFFFFFFEF
+
+select conv('17', -10, 16) as positive_from_negative_base;
+-- expected: 11
+
+select conv('ffffffffffffffff', 16, -10) as unsigned_to_negative_base;
+-- expected: -1
+
+select conv('-9223372036854775808', 10, 16) as negative_int64_min;
+-- expected: 8000000000000000
+
+select conv('-9223372036854775809', 10, 16) as negative_below_int64_min;
+-- expected: 7FFFFFFFFFFFFFFF
+
+select conv('-18446744073709551615', 10, 16) as negative_uint64_max_minus_one;
+-- expected: 1
+
+select conv('-18446744073709551616', 10, 16) as negative_uint64_overflow;
+-- expected: 0
+
+select conv('10xyz', 10, 16) as invalid_suffix;
+-- expected: MO returns error on prefix truncation / invalid suffix
+
+-- overflow semantics (saturate to uint64 max)
+select conv('18446744073709551616', 10, 16) as overflow_decimal_to_hex;
+-- expected: FFFFFFFFFFFFFFFF
+
+select conv('-18446744073709551616', 10, 16) as overflow_negative_decimal_to_hex;
+-- expected: 0
+
+select conv('10000000000000000', 16, 10) as overflow_hex_to_decimal;
+-- expected: 18446744073709551615
+
+-- plus-prefixed unsigned values above int64 must still use unsigned parsing
+select conv('+9223372036854775808', 10, 16) as plus_prefixed_above_max_int64;
+-- expected: 8000000000000000
+
+select conv('+18446744073709551614', 10, 16) as plus_prefixed_near_uint64_max;
+-- expected: FFFFFFFFFFFFFFFE
+
+select conv('+FFFFFFFFFFFFFFFF', 16, 10) as plus_prefixed_hex_uint64_max;
+-- expected: 18446744073709551615
+
+select conv('+', 10, 16) as sign_only_invalid;
+-- expected: MO returns error on sign-only invalid input
 
 drop database conv_func;

--- a/test/distributed/cases/function/func_other_conv.result
+++ b/test/distributed/cases/function/func_other_conv.result
@@ -1,72 +1,70 @@
 SELECT CONV('A', 16, 10) AS result1;
-result1
+➤ result1[12,-1,0]  𝄀
 10
 SELECT CONV('A', 16, 10) AS hex_to_dec;
-hex_to_dec
+➤ hex_to_dec[12,-1,0]  𝄀
 10
 SELECT CONV('10', 10, 16) AS dec_to_hex;
-dec_to_hex
-a
+➤ dec_to_hex[12,-1,0]  𝄀
+A
 SELECT CONV('1010', 2, 10) AS bin_to_dec;
-bin_to_dec
+➤ bin_to_dec[12,-1,0]  𝄀
 10
 SELECT CONV('10', 10, 2) AS dec_to_bin;
-dec_to_bin
+➤ dec_to_bin[12,-1,0]  𝄀
 1010
 SELECT CONV('FF', 16, 2) AS hex_to_bin;
-hex_to_bin
+➤ hex_to_bin[12,-1,0]  𝄀
 11111111
 SELECT CONV('Z', 36, 10) AS base36_to_dec;
-base36_to_dec
+➤ base36_to_dec[12,-1,0]  𝄀
 35
 SELECT CONV('35', 10, 36) AS dec_to_base36;
-dec_to_base36
-z
+➤ dec_to_base36[12,-1,0]  𝄀
+Z
 SELECT CONV('100', 8, 10) AS oct_to_dec;
-oct_to_dec
+➤ oct_to_dec[12,-1,0]  𝄀
 64
 SELECT CONV('64', 10, 8) AS dec_to_oct;
-dec_to_oct
+➤ dec_to_oct[12,-1,0]  𝄀
 100
 SELECT CONV(10, 10, 16) AS int_to_hex;
-int_to_hex
-a
+➤ int_to_hex[12,-1,0]  𝄀
+A
 SELECT CONV(255, 10, 2) AS int_to_bin;
-int_to_bin
+➤ int_to_bin[12,-1,0]  𝄀
 11111111
 SELECT CONV(100, 10, 8) AS int_to_oct;
-int_to_oct
+➤ int_to_oct[12,-1,0]  𝄀
 144
 SELECT CONV('0', 10, 16) AS zero;
-zero
+➤ zero[12,-1,0]  𝄀
 0
 SELECT CONV('1', 10, 2) AS one;
-one
+➤ one[12,-1,0]  𝄀
 1
 SELECT CONV(NULL, 10, 16) AS null_input;
-null_input
+➤ null_input[12,-1,0]  𝄀
 null
 SELECT CONV('G', 16, 10) AS invalid_hex;
-invalid_hex
-null
+invalid input: invalid conv input "G" for base 16
 SELECT CONV('2', 2, 10) AS invalid_bin;
-invalid_bin
-null
+invalid input: invalid conv input "2" for base 2
 CREATE TABLE t1(num_str VARCHAR(10), num_val INT);
 INSERT INTO t1 VALUES ('A', 10), ('FF', 255), ('1010', 10);
 SELECT CONV(num_str, 16, 10) AS hex_val, CONV(num_val, 10, 16) AS hex_str FROM t1;
-hex_val	hex_str
-10	a
-255	ff
-4112	a
+➤ hex_val[12,-1,0]  ¦  hex_str[12,-1,0]  𝄀
+10  ¦  A  𝄀
+255  ¦  FF  𝄀
+4112  ¦  A
 DROP TABLE t1;
 CREATE TABLE t1(val VARCHAR(10));
 INSERT INTO t1 VALUES ('A'), ('B'), ('C');
 SELECT * FROM t1 WHERE CONV(val, 16, 10) > 10;
-val
-B
+➤ val[12,-1,0]  𝄀
+B  𝄀
 C
 DROP TABLE t1;
 SELECT CONV('A', 16, 10) AS val1, CONV('B', 16, 10) AS val2, CONV('C', 16, 10) AS val3;
-val1    val2    val3
-10    11    12
+➤ val1[12,-1,0]  ¦  val2[12,-1,0]  ¦  val3[12,-1,0]  𝄀
+10  ¦  11  ¦  12


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #https://github.com/matrixorigin/matrixone/issues/23845

## What this PR does / why we need it:

修改 conv  基数转换函数的兼容性问题.

对于` CONV('g', 16, 10), CONV('2', 2, 10), or CONV('10xyz', 10, 16)` 这类场景,  mo一直的行为是返回错误. mysql是返回0,NULL. 这一点上mo不会与mysql对齐.