### PR TITLE
feat: add mo-dev agent skill and gitignore updates

### DIFF
--- a/.agents/skills/mo-bug-triage/SKILL.md
+++ b/.agents/skills/mo-bug-triage/SKILL.md
@@ -1,0 +1,567 @@
+# MO Bug Triage Skill v4
+
+Systematic triage of MatrixOne `kind/bug` issues with calibrated severity, batched processing, rollback safety, and drift prevention.
+
+---
+
+## When to Use
+
+User asks to triage MO bugs, classify severity, update GitHub metadata (milestone, severity, project), or audit existing classifications. Trigger phrases: "triage bugs", "分析 bugs", "更新 issue", "bug report".
+
+---
+
+## TL;DR Quick Start
+
+```
+Phase 1: LOCK STANDARDS   (~15min, 0 writes)
+  → Sample 8-12 bugs by domain → user approves STANDARDS.md → gate locked
+
+Phase 2: BATCHED PROCESS  (~5min per batch of 50)
+  → Each batch: fetch→classify→report→snapshot→dry-run→update→progress
+  → Batch N failure never touches Batch 1..N-1 (already committed)
+
+Phase 3: FINAL VERIFY      (~10min)
+  → Domain clustering audit + severity cross-check + full batch spot-check + sampled API verify
+```
+
+Total time: ~310 issues ≈ 6 batches ≈ **30-45 min** (dominated by GitHub rate limit: 5000/hr for authenticated REST).
+
+---
+
+## Core Rules
+
+### Severity Hierarchy
+
+| Severity | Criteria | Examples |
+|----------|----------|----------|
+| **s-1** | **MUST be conservative**. Only: multi-tenant isolation breach. Refer to existing project s-1 count (≤5). If unsure → s0. | #15972 tenant isolation break |
+| **s0** | **THE MAIN BUCKET** (~70% of bugs). Panic/crash, hung/deadlock, OOM/memory exhaustion, data integrity violation, resource leak, commonly-used feature broken, performance regression on core paths. | INSERT panic, subquery hung, LOAD DATA OOM, lockservice leak, ORDER BY wrong, Prisma compat |
+| **s1** | **Lower priority** (~20%). Partition bugs, streaming bugs, cold/infrequently-used features, edge-case functions, subtasks of larger features, backward-compat-only paths. | partition pruning, streaming CTE, collation, stored procedures, backup/restore, role admin, REPLACE subtasks |
+| **s2** | **Very low priority** (~10%). Feature requests mislabeled as bugs, tech debt refactoring, typos, code style, non-functional cleanup. | "support X", refactor internal API, doc fix |
+
+### Domain-Based Severity Override
+
+These domains are **auto-downgraded** unless a higher-severity exception applies:
+
+| Domain | Default | Exception (keeps original severity) |
+|--------|---------|-------------------------------------|
+| Partition | s1 | Panic/crash → s0; data integrity → s0 |
+| Streaming | s1 | Panic/crash → s0; data integrity → s0 |
+| Cold features (stored procedures, CTE, window functions, collation, fulltext, backup, role/DCL, REPLACE) | s1 | Panic/crash → s0; data integrity → s0 |
+| Feature Requests (even if labeled `kind/bug`) | s2 | N/A — exclude from bug triage entirely |
+
+### Skip List
+
+Skip these assignees entirely — do not classify, do not update:
+- `heni02`
+- `Ariznawlll`
+
+### Severity Inflation Guard
+
+- Before assigning s-1: verify the issue matches **exactly** the existing project s-1 pattern (multi-tenant isolation break only). If unsure → s0.
+- Before assigning s0: verify the issue actually causes panic/hung/OOM/data-integrity/common-function-break. If it's a partition/streaming/cold-feature bug without those → s1.
+- Default for any ambiguity → **one tier lower** than your instinct.
+
+---
+
+## Phase 1: LOCK STANDARDS (Read-Only, ~15 min)
+
+### Step 1.1: Discover Total Count
+
+```bash
+gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 1 --json totalCount
+```
+
+Record `total_count`. Plan batches: `ceil(total_count / 50)`. Estimate: ~310 issues → 7 batches.
+
+### Step 1.2: Query Existing Severity Distribution
+
+```bash
+gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 500 --json labels --jq '.[].labels[].name' | grep '^severity/' | sort | uniq -c | sort -rn
+```
+
+This establishes the team's **actual usage pattern**. Your output distribution must roughly match (s-1 ≤ 5, s0 ~70%, s1 ~20%, s2 ~10%).
+
+### Step 1.3: Domain-Stratified Sampling
+
+Fetch 8-12 issues representing **every major domain** (at least 1-2 per domain):
+
+```bash
+# Sample by scanning recent issues across domains
+gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 100 --json number,title,labels,assignees
+```
+
+Domains to cover: Transaction, DML, DDL, Partition, Streaming, Proxy/CN, Logservice/TN, Memory/OOM, Lock, Prisma/Compat, Backup/Restore, Access Control, Other.
+
+### Step 1.4: Show STANDARDS.md → User Approval Gate
+
+Present the sampled issues with proposed severities. Output a `STANDARDS.md` file:
+
+```markdown
+# MO Bug Triage Standards — [Date]
+
+## Approved: false   ← MUST be set to true before Phase 2
+
+## Severity Rules (locked after approval)
+| Severity | Criteria |
+|----------|----------|
+| s-1 | Multi-tenant isolation breach ONLY |
+| s0 | Panic/crash, hung/deadlock, OOM, data integrity, resource leak, common feature broken, perf regression |
+| s1 | Partition, streaming, cold features (SP/CTE/window/collation/fulltext/backup/role/DCL/REPLACE) |
+| s2 | Feature request, tech debt, typos |
+
+## Domain Downgrade Table
+...
+
+## Sampled Examples (user-confirmed)
+| # | Issue | Domain | Proposed Severity | User Decision |
+|---|-------|--------|-------------------|---------------|
+| 1 | ... | ... | s0 | ✅ |
+| 2 | ... | ... | s0 | ⬆️ s-1 |
+...
+```
+
+**Wait for user to explicitly say "approved" or "looks good" before proceeding.** Then:
+
+```bash
+# Lock the gate
+sed -i 's/Approved: false/Approved: true/' STANDARDS.md
+```
+
+### Step 1.5: Technical Gate Check (script requirement)
+
+All Phase 2 scripts **MUST** check this before executing:
+
+```python
+def gate_check():
+    import sys, re
+    with open("STANDARDS.md") as f:
+        content = f.read()
+    m = re.search(r'^## Approved:\s*(true|false)', content, re.MULTILINE)
+    if not m or m.group(1) != "true":
+        print("FATAL: STANDARDS.md not approved. Run Phase 1 first.")
+        print("  Set '## Approved: true' after user confirmation.")
+        sys.exit(1)
+    print("✅ Gate passed: STANDARDS.md approved")
+```
+
+---
+
+## Phase 2: BATCHED PROCESS (Each Batch Independent, ~5 min/batch)
+
+Each batch is a self-contained unit:
+- Fetch → Classify → Report → **Snapshot** → Dry-Run → Update → Progress
+- Batch N failure = only N is affected; Batches 1..N-1 are safely committed to GitHub
+- Batch N never starts until Batch N-1's update is confirmed complete
+
+### Step 2a: Fetch One Batch (per_page=50, with fallback)
+
+```bash
+PAGE=$1
+gh api -H "Accept: application/vnd.github+json" \
+  "/repos/matrixorigin/matrixone/issues?state=open&labels=kind/bug&per_page=50&page=${PAGE}&sort=created&direction=desc" \
+  --jq '.[] | {number,title,labels:[.labels[].name],assignee:.assignee.login,state}' \
+  > batch_${PAGE}_raw.json
+```
+
+**Fallback**: if per_page=100 fails, retry with 50. If 50 fails, retry with 30. Log the actual page size used.
+
+### Step 2b: Classify with Complete Rules
+
+```python
+def classify_severity(issue):
+    """
+    Full classification logic. Must match STANDARDS.md.
+    Returns: (severity, project, notes)
+    """
+    title = (issue.get("title") or "").lower()
+    labels = [l["name"].lower() if isinstance(l, dict) else l.lower() 
+              for l in issue.get("labels", [])]
+    body = (issue.get("body") or "").lower()
+    
+    # -- s-1: multi-tenant isolation ONLY --
+    if any(kw in title for kw in ["tenant isolation", "cross-tenant"]):
+        return ("severity/s-1", "MOEngine-Compute", "tenant isolation breach")
+    
+    # -- Domain detection (for downgrade logic) --
+    is_partition = any(kw in title for kw in 
+        ["partition", "subpartition", "sub-partition", "repartition"])
+    is_streaming = any(kw in title for kw in 
+        ["streaming", "stream", "cte", "changefeed", "cdc"])
+    is_cold_feature = any(kw in title for kw in [
+        "stored procedure", "backup", "restore", "collat", "fulltext",
+        "role", "grant", "revoke", "replace into", "window function",
+        "trigger", "event scheduler", "load data", "import"
+    ])
+    
+    has_panic = any(kw in (title + " " + body) for kw in [
+        "panic", "nil pointer", "index out of range", "fatal",
+        "makeslice", "segmentation", "nil dereference"
+    ])
+    has_hung = any(kw in (title + " " + body) for kw in [
+        "hung", "deadlock", "stuck", "blocked", "infinite", "never",
+        "cannot kill", "can't cancel", "waiting", "timeout"
+    ])
+    has_oom = any(kw in (title + " " + body) for kw in [
+        "oom", "out of memory", "memory leak", "memory exhaust",
+        "oomkilled", "consuming memory", "memory growth", "memory blow"
+    ])
+    has_data_integrity = any(kw in (title + " " + body) for kw in [
+        "data integrity", "wrong result", "incorrect result", "inconsistent",
+        "duplicate key", "unique constraint", "check constraint",
+        "foreign key", "corrupt", "data loss", "wrong data"
+    ])
+    has_resource_leak = any(kw in (title + " " + body) for kw in [
+        "leak", "orphaned", "stale", "never cleaned", "growing",
+        "accumulate", "not released", "not freed"
+    ])
+    
+    # -- Core severity decision --
+    # Panic/crash → s0 regardless of domain (exception to downgrade)
+    if has_panic:
+        proj = "MOEngine-Compute"
+        if any(kw in title for kw in ["logservice", "tn", "wal", "replica"]):
+            proj = "MOEngine-Storage"
+        return ("severity/s0", proj, "panic/crash")
+    
+    # Hung/deadlock → s0
+    if has_hung:
+        return ("severity/s0", "MOEngine-Compute", "hung/deadlock")
+    
+    # OOM/memory → s0
+    if has_oom:
+        return ("severity/s0", "MOEngine-Compute", "oom/memory")
+    
+    # Data integrity → s0
+    if has_data_integrity:
+        return ("severity/s0", "MOEngine-Compute", "data integrity")
+    
+    # Resource leak → s0
+    if has_resource_leak:
+        return ("severity/s0", "MOEngine-Compute", "resource leak")
+    
+    # -- Downgraded domains → s1 (no panic/hung/OOM/data-integrity/leak detected) --
+    if is_partition:
+        return ("severity/s1", "MOEngine-Compute", "partition domain downgrade")
+    if is_streaming:
+        return ("severity/s1", "MOEngine-Compute", "streaming domain downgrade")
+    if is_cold_feature:
+        return ("severity/s1", "MOEngine-Compute", "cold feature downgrade")
+    
+    # -- Default: commonly used = s0 --
+    # (Anything not in a downgrade domain and not hitting a specific severity trigger)
+    return ("severity/s0", "MOEngine-Compute", "default common feature")
+```
+
+**Key**: Panic/hung/OOM/data-integrity/resource-leak **always s0** even in partition/streaming/cold-feature domains. Downgrade to s1 only when none of these triggers fire.
+
+### Step 2c: Generate Batch Report (with build metadata)
+
+```markdown
+# MO Bug Triage — Batch N
+**Generated**: 2026-07-01T10:23:45Z
+**Source file**: batch_N_classified.json (sha256: abc123...)
+**DO NOT EDIT MANUALLY** — re-run classifier to regenerate.
+
+## Batch Summary
+| Metric | Value |
+|--------|-------|
+| Range | #25260 → #24997 |
+| Total fetched | 50 |
+| Skipped (heni02/Ariznawlll) | 3 |
+| Classified | 47 |
+
+## Severity Distribution
+| Severity | Count |
+|----------|-------|
+| s-1 | 0 |
+| s0 | 35 |
+| s1 | 10 |
+| s2 | 2 |
+
+... (issue details as before) ...
+```
+
+**Drift prevention**: include `generated_at` timestamp and source file checksum. Phase 3 verification compares this against file mtime.
+
+### Step 2d: Save Before-Snapshot (Rollback Safety)
+
+```python
+# Before any GitHub writes for this batch, save current state
+def save_snapshot(batch_file):
+    """
+    Read batch_N_classified.json → fetch current GitHub state for each issue
+    → save to batch_N_before_snapshot.json
+    """
+    # For each issue: {number, old_milestone, old_severity_labels, old_project}
+    snapshots = []
+    for issue in read_classified(batch_file):
+        current = gh_api_get(f"/repos/matrixorigin/matrixone/issues/{issue['number']}")
+        snapshots.append({
+            "number": issue["number"],
+            "old_milestone": current.get("milestone", {}).get("title"),
+            "old_labels": [l["name"] for l in current.get("labels", []) if "severity/" in l["name"]],
+        })
+    with open(batch_file.replace(".json", "_before_snapshot.json"), "w") as f:
+        json.dump({"generated_at": now_iso(), "issues": snapshots}, f, indent=2)
+```
+
+### Step 2e: Dry-Run (5 issues, verify)
+
+Update only the first 5 issues in the batch. Then verify:
+
+```bash
+# Dry-run update 5 issues
+# ... (REST PATCH calls for first 5) ...
+
+# Verify
+gh issue view <N> --json milestone,labels
+```
+
+**If any mismatch → stop batch, investigate, rollback if needed.** Only proceed to full batch update after dry-run passes.
+
+### Step 2f: Full Batch Update + Progress Display
+
+```bash
+# After every batch update, show progress
+echo "========================================"
+echo "BATCH $N COMPLETE"
+echo "Progress: ████████░░ 43%  (3/7 batches)"
+echo "Running totals: s-1:1  s0:89  s1:48  s2:12"
+echo "Next: Batch $((N+1)) (#XXXXX → #YYYYY)"
+echo "========================================"
+```
+
+### Rollback Procedure (if batch fails mid-update)
+
+```bash
+# Read before_snapshot for this batch
+# For each issue already updated in this batch, restore:
+gh api -X PATCH /repos/matrixorigin/matrixone/issues/$NUMBER \
+  -f milestone="$OLD_MILESTONE"
+
+# Restore severity labels
+gh api -X DELETE /repos/matrixorigin/matrixone/issues/$NUMBER/labels/severity/sX
+gh api -X POST /repos/matrixorigin/matrixone/issues/$NUMBER/labels \
+  -f labels='["severity/s0"]'  # old value from snapshot
+```
+
+**Never try to "fix forward" a half-updated batch** — always rollback and restart.
+
+---
+
+## Phase 3: FINAL VERIFY (Read-Only, ~10 min)
+
+### Step 3a: Domain Clustering Audit (Automated)
+
+Run against all batch reports combined:
+
+```python
+def domain_clustering_audit(all_classified):
+    """
+    Check: does any domain anomalously cluster in wrong severity tier?
+    Alert if: >30% of s1 issues are non-downgrade domains
+    Alert if: >10% of s0 issues are partition/streaming without panic/hung/OOM
+    """
+    for severity in ["severity/s0", "severity/s1"]:
+        issues = [i for i in all_classified if i["severity"] == severity]
+        domains = Counter(classify_domain(i) for i in issues)
+        for domain, count in domains.items():
+            if domain in ("partition", "streaming") and severity == "severity/s0":
+                # Check each has a valid s0 trigger
+                without_trigger = [i for i in issues 
+                    if classify_domain(i) == domain 
+                    and not has_s0_trigger(i)]
+                if without_trigger:
+                    print(f"⚠️  {len(without_trigger)} {domain} issues in s0 without panic/hung/OOM trigger")
+                    print(f"    Examples: {[i['number'] for i in without_trigger[:3]]}")
+    
+    # Check cold-feature in s0
+    cold_in_s0 = [i for i in s0_issues if classify_domain(i) in COLD_DOMAINS and not has_s0_trigger(i)]
+    if cold_in_s0:
+        print(f"⚠️  {len(cold_in_s0)} cold-feature issues in s0 without trigger")
+```
+
+### Step 3b: Severity Count Cross-Validation
+
+```python
+def cross_validate(all_classified):
+    """
+    Assert: count of severity/s-1 in reports == count on GitHub
+    """
+    report_counts = Counter(i["severity"] for i in all_classified)
+    
+    # Query GitHub for actual labels
+    gh_counts = query_github_severity_distribution()
+    
+    for sev in ["severity/s-1", "severity/s0", "severity/s1", "severity/s2"]:
+        report = report_counts.get(sev, 0)
+        gh = gh_counts.get(sev, 0)
+        if report != gh:
+            print(f"❌ MISMATCH: {sev}: reports={report} GitHub={gh}")
+            print("   Drift detected. Regenerate ALL reports and re-update.")
+            return False
+    print("✅ Severity counts match between reports and GitHub")
+    return True
+```
+
+### Step 3c: Full Batch Spot-Check
+
+Pick one complete batch report (50 issues). Manually scan ALL 50 classifications in the report file. This is a 5% overall sample but 100% of one batch — catches systematic misclassification patterns that random sampling misses.
+
+### Step 3d: Sampled API Verify
+
+Verify 5 random issues on GitHub match the report:
+
+```bash
+for num in $(shuf -e <list_of_all_numbers> | head -5); do
+  echo "=== #$num ==="
+  gh issue view $num --json milestone,labels --jq '{milestone:.milestone.title,severity:[.labels[].name|select(startswith("severity/"))]}'
+done
+```
+
+### Step 3e: Drift Detection
+
+```python
+def detect_drift(batch_files):
+    """
+    Compare generated_at in report vs file mtime.
+    If mtime > generated_at + 5min → the file was manually edited after generation.
+    """
+    for bf in batch_files:
+        gen_time = extract_generated_at(bf)
+        mtime = os.path.getmtime(bf)
+        if mtime - gen_time > 300:  # 5 minutes
+            print(f"❌ DRIFT: {bf} was edited after generation")
+            print(f"   Report generated: {datetime.fromtimestamp(gen_time)}")
+            print(f"   File modified:    {datetime.fromtimestamp(mtime)}")
+            print(f"   ACTION: Re-run classifier for this batch, then re-update GitHub")
+            return True
+    return False
+```
+
+### Step 3f: Final Summary
+
+```
+========================================
+TRIAGE COMPLETE
+========================================
+Total open kind/bug: 311
+Classified:         291
+Skipped:             20 (heni02/Ariznawlll)
+
+Severity Distribution (on GitHub):
+  s-1:    1  (#15972 tenant isolation)
+  s0:   221  (panic/hung/OOM/integrity/leak/common)
+  s1:    57  (partition/streaming/cold-feature)
+  s2:    12  (tech-debt/misfiled)
+
+All issues updated: milestone=MO-202607, type=Bug
+Batch reports: /home/xupeng/mo_bug_analysis_batch{1..7}.md
+Standards:     STANDARDS.md
+========================================
+```
+
+---
+
+## GitHub API Reference
+
+### Rate Limit Budget
+
+| Auth | Limit | Capacity for 300 issues |
+|------|-------|------------------------|
+| Unauthenticated | 60/hr | ❌ Impossible |
+| Authenticated (`gh`) | 5000/hr | ✅ ~16 batches/hr |
+| GraphQL (token with `project` scope) | 5000/hr | Required for ProjectV2 |
+
+**Realistic timeline**: 300 issues × 2 API calls each (1 read + 1 write) = 600 requests. At 5000/hr → ~7 minutes minimum. With batch overhead → **15-20 min realistic**.
+
+### Set Milestone + Severity (REST)
+
+```bash
+# Set milestone
+gh api -X PATCH /repos/matrixorigin/matrixone/issues/$NUMBER \
+  -f milestone="MO-202607"
+
+# Replace severity label (remove old, add new)
+gh api -X DELETE "/repos/matrixorigin/matrixone/issues/$NUMBER/labels/severity%2Fs0"
+gh api -X POST /repos/matrixorigin/matrixone/issues/$NUMBER/labels \
+  -f 'labels[]=severity/s0'
+```
+
+### Set Project (GraphQL — requires `project` OAuth scope)
+
+```graphql
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PVT_kwDOA4Uifs4AAGab"
+    itemId: "PVTI_lADOA4Uifs4AAGabz..."
+    fieldId: "PVTSSF_lADOA4Uifs4AAGac..."
+    value: { singleSelectOptionId: "04b8c8f2" }
+  }) { projectV2Item { id } }
+}
+```
+
+If token lacks `project` scope, document project assignment in reports for manual allocation.
+
+### Fallback: if gh CLI unavailable
+
+```bash
+curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/matrixorigin/matrixone/issues?state=open&labels=kind/bug&per_page=100&page=1"
+```
+
+---
+
+## Common Pitfalls (10 — All from Real Sessions)
+
+| # | Pitfall | Symptom | Root Cause | Fix in v4 |
+|---|---------|---------|------------|-----------|
+| 1 | **Page size mismatch** | 139 issues silently missed | per_page=50 vs per_page=100 pagination misalignment | Phase 1: query total_count first, plan batches explicitly. Fallback chain: 100→50→30 |
+| 2 | **Severity inflation** | 8 s-1 assigned, project only has 4 | Did not calibrate against existing project severity usage | Phase 1.2: query existing distribution, force conservative s-1 |
+| 3 | **Whole-batch failure** | User changes rule → all 300+ must redo | Single-pass classification without rule lock-in | Phase 1 gate: STANDARDS.md approval before any writes. Phase 2 batch isolation |
+| 4 | **Severity drift** | Reports say s0 but GitHub shows s1 | Manually edited reports after generation, forgot to re-update | Step 2c: generated_at + checksum. Phase 3e: drift detection via mtime comparison |
+| 5 | **Half-updated batch** | Batch 4 crashes mid-update → 23 of 50 updated, 27 not | No rollback safety, no before-snapshot | Step 2d: before_snapshot.json. Rollback procedure. Never "fix forward" |
+| 6 | **Rate limit blind spot** | Script hangs for hours, user thinks it's stuck | Did not estimate API calls vs rate limit budget | Phase 2f: progress display. API reference with rate limit math. 300 issues ≈ 15-20 min |
+| 7 | **Project assignment fails** | Token missing `project` OAuth scope, all project writes fail silently | Did not verify token scope before Phase 2 | API Reference: document scope requirement. Fallback: mark in report for manual allocation |
+| 8 | **Title is N/A** | Batch 7 supplement had all titles as N/A | GraphQL N+1 query for batch 7's 119 issues hit rate limit; fallback JSON parse missed titles | Prefer REST API (returns full data). GraphQL only for project writes |
+| 9 | **Cross-batch duplicates** | Same issue appears in batch 3 and batch 5 | Pagination race condition: new issues created during triage change sort order | Track seen issue numbers globally. Deduplicate before final count |
+| 10 | **No progress visibility** | User doesn't know how far along, cancels early | Batch process silent between updates | Phase 2f: mandatory progress bar + running totals after every batch |
+| 11 | **Rule change without impact analysis** | User says "partition 低优" → 40 issues change, unexpected | No preview of rule change blast radius | Phase 4 (review): show impact analysis before applying rule change |
+
+---
+
+## Script Checklist
+
+Scripts that accompany this skill must:
+
+- [ ] Check `STANDARDS.md` `Approved: true` gate before any GitHub write
+- [ ] Accept `--dry-run` flag (default: first 5 issues per batch)
+- [ ] Save `batch_N_before_snapshot.json` before updating each batch
+- [ ] Print progress bar + running totals after each batch completion
+- [ ] Detect `generated_at` vs file mtime drift (warn, don't block)
+- [ ] Cross-validate severity counts (reports vs GitHub) in Phase 3
+- [ ] Support `--rollback batch_N` to restore from snapshot
+- [ ] Log every API call (method, URL, status code) to `triage_YYYYMMDD.log`
+
+---
+
+## Refinement Loop (when user gives feedback mid-triage)
+
+1. **User says "change X"** → pause current batch, DO NOT start new batch
+2. **Run impact analysis**: which already-processed batches are affected? How many issues?
+3. **Show impact preview** to user, get confirmation
+4. **Re-classify affected batches** (only those), regenerate reports (with new timestamps)
+5. **Re-update GitHub** for affected batches (snapshot → update → verify)
+6. **Resume from next unprocessed batch**
+
+Impact analysis template:
+
+```
+⚠️  Rule change: "partition bugs → s1 instead of s0"
+    Affected batches: 1, 3, 5 (already processed)
+    Issues to re-classify: 18
+    Severity changes: 13 (s0→s1) + 2 (s0 stays, has panic) + 3 (no change)
+    Proceed? [y/N]
+```

--- a/.agents/skills/mo-dev/SKILL.md
+++ b/.agents/skills/mo-dev/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: mo-dev
+description: MatrixOne database kernel development - CGo build/test environment setup, operator lifecycle contracts (Call/Reset), pipeline protocol, layered testing strategy. Use when modifying colexec operators, process signal types, compile pipeline construction, or debugging CGo link errors (undefined symbols, missing headers, library not found).
+compatibility: Designed for Codex CLI and compatible agents. Requires Go 1.22+, GNU Make, C/C++ toolchain (gcc/clang), and pre-built thirdparties.
+metadata:
+  project: matrixone
+  repository: matrixorigin/matrixone
+  language: go
+  cgo: true
+---
+
+## Enforcement Gates
+
+This skill gates four decision points. Consult the corresponding section before acting:
+
+| Gate | When | Action |
+|------|------|--------|
+| **G-MODIFY** | Before editing any `colexec` operator or `process` signal type | Read §3 (operator contract) + §7 (forbidden patterns) |
+| **G-CGO-ERR** | Any build/test returns `file not found`, `Undefined symbols`/`undefined symbol:`, or `dyld:`/`error while loading shared libraries:` | Read §2.2 (symptom table) + §2.4 (stash protocol) |
+| **G-DONE** | Before declaring "done"/"complete"/"passes" | Read §4.3 (completion gate) — all 5 boxes MUST be checked |
+| **G-TEST-FAIL** | `go test` returns non-zero or hangs >10s | Read §5 (diagnosis) + §2.4 (stash protocol) before attributing cause |
+
+---
+
+## 1. Project Structure
+
+```
+pkg/sql/compile/       ← DAG compilation, operator instantiation, pipeline build, launch
+pkg/sql/colexec/       ← execution operators (connector/dispatch/merge/join/scan/...)
+pkg/vm/process/        ← execution context (Process), WaitRegister, signal channels
+pkg/vm/pipeline/       ← Pipeline lifecycle management
+pkg/container/         ← Batch/Vector/pSpool and other base data structures
+pkg/frontend/          ← MySQL protocol compatibility layer
+pkg/txn/               ← transaction management and MVCC
+pkg/sql/plan/          ← query plan construction
+cgo/                   ← CGo adapter layer (libmo.dylib / libmo.so)
+```
+
+**Operator file convention** under `pkg/sql/colexec/<op>/`:
+- `types.go` — Arg struct definition
+- `<op>.go` — main logic (Prepare/Call/Reset)
+- Optional `sendfunc.go`/`dispatch.go` helpers
+
+**Key dependency chain**: `compile` instantiates operators → `colexec` executes → `process` manages context and signals → `container` carries data.
+
+---
+
+## 2. Build, Test, Verify
+
+### 2.1 Basic Commands
+
+```bash
+# Compile check
+go build ./pkg/target/...
+
+# Static analysis
+go vet ./pkg/target/...
+
+# Run tests (-count=1 disables cache)
+go test -v -count=1 ./pkg/target/...
+
+# Single test
+go test -v -count=1 -run TestXxx ./pkg/target/...
+
+# Timeout control (integration tests can be slow)
+go test -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+### 2.2 CGo Environment (Three-Layer Variables)
+
+MO's CGo involves three independent layers: **compilation** (headers), **linking own lib** (`libmo`), and **third-party libs** (`libusearch_c`).
+
+```makefile
+# Makefile:203 — header paths for compilation
+CGO_OPTS := CGO_CFLAGS="-I$(CGO_DIR) -I$(THIRDPARTIES_INSTALL_DIR)/include"
+
+# Makefile:204-207 — link libmo (rpath varies by OS)
+# Linux:   -Wl,-rpath,$$ORIGIN/lib
+# macOS:   -Wl,-rpath,@executable_path/lib
+GOLDFLAGS := -ldflags="-extldflags '-L$(CGO_DIR) -lmo -L$(THIRDPARTIES_INSTALL_DIR)/lib $(RPATH)'"
+```
+
+**Note**: Makefile does **not** set `CGO_LDFLAGS` — `libmo` link flags all go through `-ldflags` → `-extldflags`. However, the `usearch` Go module ships its own `#cgo LDFLAGS: -lusearch_c`, causing the linker to prefer system paths. `CGO_LDFLAGS` overrides this.
+
+#### macOS vs Linux
+
+| Aspect | macOS | Linux |
+|--------|-------|-------|
+| Dynamic library | `libmo.dylib` | `libmo.so` |
+| Runtime path env | `DYLD_LIBRARY_PATH` | `LD_LIBRARY_PATH` |
+| rpath flag | `-Wl,-rpath,@executable_path/lib` | `-Wl,-rpath,\$ORIGIN/lib` |
+| C header flags | `CGO_CFLAGS="-I{root}/cgo -I{root}/thirdparties/install/include"` | Same |
+| usearch link flags | `CGO_LDFLAGS="-L{root}/thirdparties/install/lib -lusearch_c"` | Same |
+
+#### Full Test Commands
+
+**macOS:**
+```bash
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
+DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
+  -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+**Linux:**
+```bash
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
+LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib'" \
+  -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+#### Symptom → Root Cause
+
+| Symptom | Missing Variable | Root Cause |
+|---------|-----------------|------------|
+| `fatal error: 'xxhash.h' file not found` | `CGO_CFLAGS` | Compiler can't find thirdparties headers |
+| `Undefined symbols: _usearch_hardware_acceleration_*` (macOS) or `undefined symbol:` (Linux) | `CGO_LDFLAGS` | usearch module's `#cgo LDFLAGS` found old `libusearch_c` |
+| `ld: library 'mo' not found` (macOS) or `cannot find -lmo` (Linux) | `-ldflags="-extldflags '-L... -lmo'"` | Linker can't find `libmo` |
+| `dyld: Library not loaded: libmo.dylib` (macOS) or `error while loading shared libraries: libmo.so` (Linux) | `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Runtime can't find dynamic library |
+
+### 2.3 Layered Testing Strategy
+
+| Layer | Example Packages | CGo Behavior | Variables Needed |
+|-------|-----------------|-------------|-----------------|
+| **Pure Go** | `pkg/vm/process`, `pkg/container/pSpool`, `pkg/vm/pipeline` | Zero CGo in transitive closure | None |
+| **CGo-transitive** | `pkg/sql/colexec/connector`, `dispatch`, `merge` | Test binary links usearch Go module | `CGO_CFLAGS` + `CGO_LDFLAGS` |
+| **CGo-direct** | `pkg/sql/compile` | Test binary directly links `libmo` + `libusearch_c` | All four: CGO_CFLAGS + CGO_LDFLAGS + ldflags + DYLD/LD_LIBRARY_PATH |
+| **Integration** | `pkg/frontend`, cmd packages | Full MO binary, needs external services | All + services |
+
+**Copy-paste per layer:**
+
+Layer 1 (Pure Go):
+```bash
+go test -v -count=1 -timeout 120s ./pkg/vm/process/... ./pkg/container/pSpool/...
+```
+
+Layer 2 (CGo-transitive, macOS):
+```bash
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+go test -v -count=1 -timeout 120s ./pkg/sql/colexec/connector/... ./pkg/sql/colexec/dispatch/...
+```
+
+Layer 3 (CGo-direct, macOS):
+```bash
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+export DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib"
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
+  -v -count=1 -timeout 120s ./pkg/sql/compile/...
+```
+
+#### Variable → Purpose
+
+| Variable | What It Does | When Needed |
+|---------|-------------|-------------|
+| `CGO_CFLAGS` | Tells C compiler where to find headers | Package in transitive closure has CGo C code |
+| `CGO_LDFLAGS` | Overrides usearch module's own `#cgo LDFLAGS` path | usearch Go module is linked |
+| `-ldflags "-extldflags ..."` | Tells external linker where to find `libmo` + sets rpath | Package directly links `libmo` |
+| `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Tells OS runtime loader where to find `.dylib` / `.so` | Test binary loads `libmo` at runtime |
+
+**Why bottom-up matters**: Pure Go tests finish in seconds with zero env setup. If they fail, the problem is in your code — not CGo. Debug top-down wastes time chasing link errors when there's a real bug.
+
+#### 2.3.1 `go build` vs `go test` — Not Equivalent
+
+| Command | CGo Behavior |
+|---------|-------------|
+| `go build ./pkg/sql/colexec/connector/...` | May succeed without CGo flags (compiles package only, no test binary linking) |
+| `go test ./pkg/sql/colexec/connector/...` | Compiles AND links test binary — full CGo path fires |
+
+**Rule**: "`go build` passes" does not mean "`go test` will pass." Always verify with `go test`.
+
+### 2.4 Stash Protocol — Verify "Pre-existing" Claims
+
+**Hard rule**: Never claim a test failure is "pre-existing" without proving it.
+
+```bash
+# 1. Stash current changes
+git stash
+
+# 2. Run the same test from clean state
+go test -v -count=1 -timeout 120s ./pkg/target/...
+
+# 3. If it fails: genuinely pre-existing — document it
+# 4. If it passes: YOUR code caused it — investigate
+git stash pop
+```
+
+---
+
+## 3. Operator Lifecycle Contracts
+
+### 3.1 Call() vs Reset() — Hard Boundary
+
+| Method | Purpose | Must NOT Do |
+|--------|---------|-------------|
+| `Call()` | Process one batch. Receive from upstream, compute, send downstream. | Send terminal signals (End/Error/Abort). That's `Reset()`'s job. |
+| `Reset()` | Cleanup. Notify downstream the operator is done. | Block waiting for receiver acknowledgment. Use Abort(), not CloseWithTimeout(). |
+
+**This is the single most common source of subtle bugs.** Violating it causes: premature pipeline termination, spurious timeouts, dead receivers.
+
+### 3.2 PipelineSpool Lifecycle
+
+| Method | Behavior | Use When |
+|--------|---------|---------|
+| `Close()` | Wait for all consumers to acknowledge end of stream (consumes nil batches from spool) | Graceful completion path |
+| `CloseWithTimeout()` | Same as `Close()` but with timeout | Legacy cleanup — deprecated for typed signals |
+| `ForceCleanup()` / `Abort()` | Synchronous release of all un-consumed slots. No waiting. Idempotent (`sync.Once`). | Cleanup path with explicit terminal signals |
+
+**Critical rule**: If you replaced implicit nil-batch end-of-stream with explicit typed signals (EventEnd/EventError/EventAbort), use `Abort()` instead of `CloseWithTimeout()`. `CloseWithTimeout()` waits for nil batches that will never arrive.
+
+### 3.3 Pipeline Signal Types (Explicit Protocol)
+
+| Signal | Constructor | Meaning |
+|--------|------------|---------|
+| `EventData` | `NewDataSignal(batch)` | Normal data batch |
+| `EventEnd` | `NewEndSignal()` | Graceful end of stream |
+| `EventError` | `NewErrorSignal(err)` | Operator encountered an error |
+| `EventAbort` | `NewAbortSignal()` | Forceful termination |
+
+**Dual-protocol compatibility**: `GetNextBatch` handles both explicit typed signals AND legacy nil-batch convention (`content == nil`). Old operators using implicit nil-batch continue to work.
+
+---
+
+## 4. Post-Modification Verification
+
+### 4.1 Test Freshness
+
+Test output must be **from the current turn**. Verify:
+1. `go test` command appears in current turn's bash calls
+2. Exit code 0 (not "it compiled" or "trust me")
+3. Timestamp is after the last `str_replace`/`write_file`
+
+### 4.2 Completion Gate (G-DONE)
+
+Before declaring any change "done", all 5 boxes must be checked:
+
+```
+□ go build ./pkg/.../modified_package...    → exit 0
+□ go vet ./pkg/.../modified_package...      → exit 0
+□ go test -v -count=1 ./pkg/.../...         → exit 0, no hangs
+□ git diff --stat                            → inspected, no unintended files
+□ Regression: at least one test from dependent package passes
+```
+
+**Hang = failure**: If `go test` produces >10s of no output → the test is hung, not "still running." Investigate.
+
+---
+
+## 5. Fault Diagnosis
+
+| Symptom | Look At |
+|---------|---------|
+| Test hangs exactly 30s | `CloseWithTimeout` waiting for nil-batch that never arrives. Check if typed signals are being sent instead. |
+| Test hangs >5s, no output | Deadlock or blocking channel send. Check: is `done` channel closed? Is `sendSignal` using a non-blocking `select`? |
+| `context deadline exceeded` after 30s | `WaitingEndWithTimeout` timed out. Check: did all senders call `Reset()`? Did they send typed terminal signals? |
+| `CGO_CFLAGS` not working | Run `go env CGO_CFLAGS` to verify. Use `export` (not inline without export) if the package has sub-packages. |
+
+---
+
+## 6. Common Pitfalls
+
+### 6.1 Structural Changes — Check Both Ends
+When changing the communication protocol between operators (connector ↔ merge, dispatch ↔ merge), both sender and receiver must be updated. A sender change without the corresponding receiver change causes deadlock.
+
+**Identification**: exact 30s timeout in cleanup → `CloseWithTimeout` + typed signal mismatch.
+
+### 6.2 CGo Link Errors — Verify the Third Party Build
+CGo link errors (`Undefined symbols`, `cannot find -lmo`) are environment issues, not code bugs. The C shared libraries (`libmo.dylib`, `libusearch_c.dylib`) must be pre-built via `make cgo` and `make thirdparties`.
+
+### 6.3 Pipeline Cleanup — Abort, Don't Wait
+During pipeline cleanup, operators should use non-blocking or timeout-gated communication. Never block waiting for a receiver that may have already exited.
+
+### 6.4 Channel Full Edge Cases
+When sending terminal signals into a bounded channel, the send may fail because the channel is full. Ensure the terminal state is still recorded even when the channel send fails — the `done` channel must close regardless of delivery success.
+
+---
+
+## 7. Forbidden Patterns
+
+1. **Never send terminal signals (End/Error/Abort) from `Call()`.** Only `Reset()` sends terminal signals.
+2. **Never call `sp.CloseWithTimeout()` after switching to explicit typed terminal signals.** Use `sp.Abort()`.
+3. **Never claim "pre-existing" without `git stash` proof.** Run the test on clean HEAD first.
+4. **Never declare done without fresh test output.** All 5 completion gate boxes must be checked.
+5. **Never assume `go build` success means `go test` will pass.** Build only compiles packages; test compiles AND links test binaries.
+6. **Never skip bottom-up testing.** Start with pure Go packages, then CGo-transitive, then CGo-direct.

--- a/.claude/skills/mo-bug-triage/SKILL.md
+++ b/.claude/skills/mo-bug-triage/SKILL.md
@@ -1,0 +1,567 @@
+# MO Bug Triage Skill v4
+
+Systematic triage of MatrixOne `kind/bug` issues with calibrated severity, batched processing, rollback safety, and drift prevention.
+
+---
+
+## When to Use
+
+User asks to triage MO bugs, classify severity, update GitHub metadata (milestone, severity, project), or audit existing classifications. Trigger phrases: "triage bugs", "分析 bugs", "更新 issue", "bug report".
+
+---
+
+## TL;DR Quick Start
+
+```
+Phase 1: LOCK STANDARDS   (~15min, 0 writes)
+  → Sample 8-12 bugs by domain → user approves STANDARDS.md → gate locked
+
+Phase 2: BATCHED PROCESS  (~5min per batch of 50)
+  → Each batch: fetch→classify→report→snapshot→dry-run→update→progress
+  → Batch N failure never touches Batch 1..N-1 (already committed)
+
+Phase 3: FINAL VERIFY      (~10min)
+  → Domain clustering audit + severity cross-check + full batch spot-check + sampled API verify
+```
+
+Total time: ~310 issues ≈ 6 batches ≈ **30-45 min** (dominated by GitHub rate limit: 5000/hr for authenticated REST).
+
+---
+
+## Core Rules
+
+### Severity Hierarchy
+
+| Severity | Criteria | Examples |
+|----------|----------|----------|
+| **s-1** | **MUST be conservative**. Only: multi-tenant isolation breach. Refer to existing project s-1 count (≤5). If unsure → s0. | #15972 tenant isolation break |
+| **s0** | **THE MAIN BUCKET** (~70% of bugs). Panic/crash, hung/deadlock, OOM/memory exhaustion, data integrity violation, resource leak, commonly-used feature broken, performance regression on core paths. | INSERT panic, subquery hung, LOAD DATA OOM, lockservice leak, ORDER BY wrong, Prisma compat |
+| **s1** | **Lower priority** (~20%). Partition bugs, streaming bugs, cold/infrequently-used features, edge-case functions, subtasks of larger features, backward-compat-only paths. | partition pruning, streaming CTE, collation, stored procedures, backup/restore, role admin, REPLACE subtasks |
+| **s2** | **Very low priority** (~10%). Feature requests mislabeled as bugs, tech debt refactoring, typos, code style, non-functional cleanup. | "support X", refactor internal API, doc fix |
+
+### Domain-Based Severity Override
+
+These domains are **auto-downgraded** unless a higher-severity exception applies:
+
+| Domain | Default | Exception (keeps original severity) |
+|--------|---------|-------------------------------------|
+| Partition | s1 | Panic/crash → s0; data integrity → s0 |
+| Streaming | s1 | Panic/crash → s0; data integrity → s0 |
+| Cold features (stored procedures, CTE, window functions, collation, fulltext, backup, role/DCL, REPLACE) | s1 | Panic/crash → s0; data integrity → s0 |
+| Feature Requests (even if labeled `kind/bug`) | s2 | N/A — exclude from bug triage entirely |
+
+### Skip List
+
+Skip these assignees entirely — do not classify, do not update:
+- `heni02`
+- `Ariznawlll`
+
+### Severity Inflation Guard
+
+- Before assigning s-1: verify the issue matches **exactly** the existing project s-1 pattern (multi-tenant isolation break only). If unsure → s0.
+- Before assigning s0: verify the issue actually causes panic/hung/OOM/data-integrity/common-function-break. If it's a partition/streaming/cold-feature bug without those → s1.
+- Default for any ambiguity → **one tier lower** than your instinct.
+
+---
+
+## Phase 1: LOCK STANDARDS (Read-Only, ~15 min)
+
+### Step 1.1: Discover Total Count
+
+```bash
+gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 1 --json totalCount
+```
+
+Record `total_count`. Plan batches: `ceil(total_count / 50)`. Estimate: ~310 issues → 7 batches.
+
+### Step 1.2: Query Existing Severity Distribution
+
+```bash
+gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 500 --json labels --jq '.[].labels[].name' | grep '^severity/' | sort | uniq -c | sort -rn
+```
+
+This establishes the team's **actual usage pattern**. Your output distribution must roughly match (s-1 ≤ 5, s0 ~70%, s1 ~20%, s2 ~10%).
+
+### Step 1.3: Domain-Stratified Sampling
+
+Fetch 8-12 issues representing **every major domain** (at least 1-2 per domain):
+
+```bash
+# Sample by scanning recent issues across domains
+gh issue list -R matrixorigin/matrixone -l kind/bug -s open --limit 100 --json number,title,labels,assignees
+```
+
+Domains to cover: Transaction, DML, DDL, Partition, Streaming, Proxy/CN, Logservice/TN, Memory/OOM, Lock, Prisma/Compat, Backup/Restore, Access Control, Other.
+
+### Step 1.4: Show STANDARDS.md → User Approval Gate
+
+Present the sampled issues with proposed severities. Output a `STANDARDS.md` file:
+
+```markdown
+# MO Bug Triage Standards — [Date]
+
+## Approved: false   ← MUST be set to true before Phase 2
+
+## Severity Rules (locked after approval)
+| Severity | Criteria |
+|----------|----------|
+| s-1 | Multi-tenant isolation breach ONLY |
+| s0 | Panic/crash, hung/deadlock, OOM, data integrity, resource leak, common feature broken, perf regression |
+| s1 | Partition, streaming, cold features (SP/CTE/window/collation/fulltext/backup/role/DCL/REPLACE) |
+| s2 | Feature request, tech debt, typos |
+
+## Domain Downgrade Table
+...
+
+## Sampled Examples (user-confirmed)
+| # | Issue | Domain | Proposed Severity | User Decision |
+|---|-------|--------|-------------------|---------------|
+| 1 | ... | ... | s0 | ✅ |
+| 2 | ... | ... | s0 | ⬆️ s-1 |
+...
+```
+
+**Wait for user to explicitly say "approved" or "looks good" before proceeding.** Then:
+
+```bash
+# Lock the gate
+sed -i 's/Approved: false/Approved: true/' STANDARDS.md
+```
+
+### Step 1.5: Technical Gate Check (script requirement)
+
+All Phase 2 scripts **MUST** check this before executing:
+
+```python
+def gate_check():
+    import sys, re
+    with open("STANDARDS.md") as f:
+        content = f.read()
+    m = re.search(r'^## Approved:\s*(true|false)', content, re.MULTILINE)
+    if not m or m.group(1) != "true":
+        print("FATAL: STANDARDS.md not approved. Run Phase 1 first.")
+        print("  Set '## Approved: true' after user confirmation.")
+        sys.exit(1)
+    print("✅ Gate passed: STANDARDS.md approved")
+```
+
+---
+
+## Phase 2: BATCHED PROCESS (Each Batch Independent, ~5 min/batch)
+
+Each batch is a self-contained unit:
+- Fetch → Classify → Report → **Snapshot** → Dry-Run → Update → Progress
+- Batch N failure = only N is affected; Batches 1..N-1 are safely committed to GitHub
+- Batch N never starts until Batch N-1's update is confirmed complete
+
+### Step 2a: Fetch One Batch (per_page=50, with fallback)
+
+```bash
+PAGE=$1
+gh api -H "Accept: application/vnd.github+json" \
+  "/repos/matrixorigin/matrixone/issues?state=open&labels=kind/bug&per_page=50&page=${PAGE}&sort=created&direction=desc" \
+  --jq '.[] | {number,title,labels:[.labels[].name],assignee:.assignee.login,state}' \
+  > batch_${PAGE}_raw.json
+```
+
+**Fallback**: if per_page=100 fails, retry with 50. If 50 fails, retry with 30. Log the actual page size used.
+
+### Step 2b: Classify with Complete Rules
+
+```python
+def classify_severity(issue):
+    """
+    Full classification logic. Must match STANDARDS.md.
+    Returns: (severity, project, notes)
+    """
+    title = (issue.get("title") or "").lower()
+    labels = [l["name"].lower() if isinstance(l, dict) else l.lower() 
+              for l in issue.get("labels", [])]
+    body = (issue.get("body") or "").lower()
+    
+    # -- s-1: multi-tenant isolation ONLY --
+    if any(kw in title for kw in ["tenant isolation", "cross-tenant"]):
+        return ("severity/s-1", "MOEngine-Compute", "tenant isolation breach")
+    
+    # -- Domain detection (for downgrade logic) --
+    is_partition = any(kw in title for kw in 
+        ["partition", "subpartition", "sub-partition", "repartition"])
+    is_streaming = any(kw in title for kw in 
+        ["streaming", "stream", "cte", "changefeed", "cdc"])
+    is_cold_feature = any(kw in title for kw in [
+        "stored procedure", "backup", "restore", "collat", "fulltext",
+        "role", "grant", "revoke", "replace into", "window function",
+        "trigger", "event scheduler", "load data", "import"
+    ])
+    
+    has_panic = any(kw in (title + " " + body) for kw in [
+        "panic", "nil pointer", "index out of range", "fatal",
+        "makeslice", "segmentation", "nil dereference"
+    ])
+    has_hung = any(kw in (title + " " + body) for kw in [
+        "hung", "deadlock", "stuck", "blocked", "infinite", "never",
+        "cannot kill", "can't cancel", "waiting", "timeout"
+    ])
+    has_oom = any(kw in (title + " " + body) for kw in [
+        "oom", "out of memory", "memory leak", "memory exhaust",
+        "oomkilled", "consuming memory", "memory growth", "memory blow"
+    ])
+    has_data_integrity = any(kw in (title + " " + body) for kw in [
+        "data integrity", "wrong result", "incorrect result", "inconsistent",
+        "duplicate key", "unique constraint", "check constraint",
+        "foreign key", "corrupt", "data loss", "wrong data"
+    ])
+    has_resource_leak = any(kw in (title + " " + body) for kw in [
+        "leak", "orphaned", "stale", "never cleaned", "growing",
+        "accumulate", "not released", "not freed"
+    ])
+    
+    # -- Core severity decision --
+    # Panic/crash → s0 regardless of domain (exception to downgrade)
+    if has_panic:
+        proj = "MOEngine-Compute"
+        if any(kw in title for kw in ["logservice", "tn", "wal", "replica"]):
+            proj = "MOEngine-Storage"
+        return ("severity/s0", proj, "panic/crash")
+    
+    # Hung/deadlock → s0
+    if has_hung:
+        return ("severity/s0", "MOEngine-Compute", "hung/deadlock")
+    
+    # OOM/memory → s0
+    if has_oom:
+        return ("severity/s0", "MOEngine-Compute", "oom/memory")
+    
+    # Data integrity → s0
+    if has_data_integrity:
+        return ("severity/s0", "MOEngine-Compute", "data integrity")
+    
+    # Resource leak → s0
+    if has_resource_leak:
+        return ("severity/s0", "MOEngine-Compute", "resource leak")
+    
+    # -- Downgraded domains → s1 (no panic/hung/OOM/data-integrity/leak detected) --
+    if is_partition:
+        return ("severity/s1", "MOEngine-Compute", "partition domain downgrade")
+    if is_streaming:
+        return ("severity/s1", "MOEngine-Compute", "streaming domain downgrade")
+    if is_cold_feature:
+        return ("severity/s1", "MOEngine-Compute", "cold feature downgrade")
+    
+    # -- Default: commonly used = s0 --
+    # (Anything not in a downgrade domain and not hitting a specific severity trigger)
+    return ("severity/s0", "MOEngine-Compute", "default common feature")
+```
+
+**Key**: Panic/hung/OOM/data-integrity/resource-leak **always s0** even in partition/streaming/cold-feature domains. Downgrade to s1 only when none of these triggers fire.
+
+### Step 2c: Generate Batch Report (with build metadata)
+
+```markdown
+# MO Bug Triage — Batch N
+**Generated**: 2026-07-01T10:23:45Z
+**Source file**: batch_N_classified.json (sha256: abc123...)
+**DO NOT EDIT MANUALLY** — re-run classifier to regenerate.
+
+## Batch Summary
+| Metric | Value |
+|--------|-------|
+| Range | #25260 → #24997 |
+| Total fetched | 50 |
+| Skipped (heni02/Ariznawlll) | 3 |
+| Classified | 47 |
+
+## Severity Distribution
+| Severity | Count |
+|----------|-------|
+| s-1 | 0 |
+| s0 | 35 |
+| s1 | 10 |
+| s2 | 2 |
+
+... (issue details as before) ...
+```
+
+**Drift prevention**: include `generated_at` timestamp and source file checksum. Phase 3 verification compares this against file mtime.
+
+### Step 2d: Save Before-Snapshot (Rollback Safety)
+
+```python
+# Before any GitHub writes for this batch, save current state
+def save_snapshot(batch_file):
+    """
+    Read batch_N_classified.json → fetch current GitHub state for each issue
+    → save to batch_N_before_snapshot.json
+    """
+    # For each issue: {number, old_milestone, old_severity_labels, old_project}
+    snapshots = []
+    for issue in read_classified(batch_file):
+        current = gh_api_get(f"/repos/matrixorigin/matrixone/issues/{issue['number']}")
+        snapshots.append({
+            "number": issue["number"],
+            "old_milestone": current.get("milestone", {}).get("title"),
+            "old_labels": [l["name"] for l in current.get("labels", []) if "severity/" in l["name"]],
+        })
+    with open(batch_file.replace(".json", "_before_snapshot.json"), "w") as f:
+        json.dump({"generated_at": now_iso(), "issues": snapshots}, f, indent=2)
+```
+
+### Step 2e: Dry-Run (5 issues, verify)
+
+Update only the first 5 issues in the batch. Then verify:
+
+```bash
+# Dry-run update 5 issues
+# ... (REST PATCH calls for first 5) ...
+
+# Verify
+gh issue view <N> --json milestone,labels
+```
+
+**If any mismatch → stop batch, investigate, rollback if needed.** Only proceed to full batch update after dry-run passes.
+
+### Step 2f: Full Batch Update + Progress Display
+
+```bash
+# After every batch update, show progress
+echo "========================================"
+echo "BATCH $N COMPLETE"
+echo "Progress: ████████░░ 43%  (3/7 batches)"
+echo "Running totals: s-1:1  s0:89  s1:48  s2:12"
+echo "Next: Batch $((N+1)) (#XXXXX → #YYYYY)"
+echo "========================================"
+```
+
+### Rollback Procedure (if batch fails mid-update)
+
+```bash
+# Read before_snapshot for this batch
+# For each issue already updated in this batch, restore:
+gh api -X PATCH /repos/matrixorigin/matrixone/issues/$NUMBER \
+  -f milestone="$OLD_MILESTONE"
+
+# Restore severity labels
+gh api -X DELETE /repos/matrixorigin/matrixone/issues/$NUMBER/labels/severity/sX
+gh api -X POST /repos/matrixorigin/matrixone/issues/$NUMBER/labels \
+  -f labels='["severity/s0"]'  # old value from snapshot
+```
+
+**Never try to "fix forward" a half-updated batch** — always rollback and restart.
+
+---
+
+## Phase 3: FINAL VERIFY (Read-Only, ~10 min)
+
+### Step 3a: Domain Clustering Audit (Automated)
+
+Run against all batch reports combined:
+
+```python
+def domain_clustering_audit(all_classified):
+    """
+    Check: does any domain anomalously cluster in wrong severity tier?
+    Alert if: >30% of s1 issues are non-downgrade domains
+    Alert if: >10% of s0 issues are partition/streaming without panic/hung/OOM
+    """
+    for severity in ["severity/s0", "severity/s1"]:
+        issues = [i for i in all_classified if i["severity"] == severity]
+        domains = Counter(classify_domain(i) for i in issues)
+        for domain, count in domains.items():
+            if domain in ("partition", "streaming") and severity == "severity/s0":
+                # Check each has a valid s0 trigger
+                without_trigger = [i for i in issues 
+                    if classify_domain(i) == domain 
+                    and not has_s0_trigger(i)]
+                if without_trigger:
+                    print(f"⚠️  {len(without_trigger)} {domain} issues in s0 without panic/hung/OOM trigger")
+                    print(f"    Examples: {[i['number'] for i in without_trigger[:3]]}")
+    
+    # Check cold-feature in s0
+    cold_in_s0 = [i for i in s0_issues if classify_domain(i) in COLD_DOMAINS and not has_s0_trigger(i)]
+    if cold_in_s0:
+        print(f"⚠️  {len(cold_in_s0)} cold-feature issues in s0 without trigger")
+```
+
+### Step 3b: Severity Count Cross-Validation
+
+```python
+def cross_validate(all_classified):
+    """
+    Assert: count of severity/s-1 in reports == count on GitHub
+    """
+    report_counts = Counter(i["severity"] for i in all_classified)
+    
+    # Query GitHub for actual labels
+    gh_counts = query_github_severity_distribution()
+    
+    for sev in ["severity/s-1", "severity/s0", "severity/s1", "severity/s2"]:
+        report = report_counts.get(sev, 0)
+        gh = gh_counts.get(sev, 0)
+        if report != gh:
+            print(f"❌ MISMATCH: {sev}: reports={report} GitHub={gh}")
+            print("   Drift detected. Regenerate ALL reports and re-update.")
+            return False
+    print("✅ Severity counts match between reports and GitHub")
+    return True
+```
+
+### Step 3c: Full Batch Spot-Check
+
+Pick one complete batch report (50 issues). Manually scan ALL 50 classifications in the report file. This is a 5% overall sample but 100% of one batch — catches systematic misclassification patterns that random sampling misses.
+
+### Step 3d: Sampled API Verify
+
+Verify 5 random issues on GitHub match the report:
+
+```bash
+for num in $(shuf -e <list_of_all_numbers> | head -5); do
+  echo "=== #$num ==="
+  gh issue view $num --json milestone,labels --jq '{milestone:.milestone.title,severity:[.labels[].name|select(startswith("severity/"))]}'
+done
+```
+
+### Step 3e: Drift Detection
+
+```python
+def detect_drift(batch_files):
+    """
+    Compare generated_at in report vs file mtime.
+    If mtime > generated_at + 5min → the file was manually edited after generation.
+    """
+    for bf in batch_files:
+        gen_time = extract_generated_at(bf)
+        mtime = os.path.getmtime(bf)
+        if mtime - gen_time > 300:  # 5 minutes
+            print(f"❌ DRIFT: {bf} was edited after generation")
+            print(f"   Report generated: {datetime.fromtimestamp(gen_time)}")
+            print(f"   File modified:    {datetime.fromtimestamp(mtime)}")
+            print(f"   ACTION: Re-run classifier for this batch, then re-update GitHub")
+            return True
+    return False
+```
+
+### Step 3f: Final Summary
+
+```
+========================================
+TRIAGE COMPLETE
+========================================
+Total open kind/bug: 311
+Classified:         291
+Skipped:             20 (heni02/Ariznawlll)
+
+Severity Distribution (on GitHub):
+  s-1:    1  (#15972 tenant isolation)
+  s0:   221  (panic/hung/OOM/integrity/leak/common)
+  s1:    57  (partition/streaming/cold-feature)
+  s2:    12  (tech-debt/misfiled)
+
+All issues updated: milestone=MO-202607, type=Bug
+Batch reports: /home/xupeng/mo_bug_analysis_batch{1..7}.md
+Standards:     STANDARDS.md
+========================================
+```
+
+---
+
+## GitHub API Reference
+
+### Rate Limit Budget
+
+| Auth | Limit | Capacity for 300 issues |
+|------|-------|------------------------|
+| Unauthenticated | 60/hr | ❌ Impossible |
+| Authenticated (`gh`) | 5000/hr | ✅ ~16 batches/hr |
+| GraphQL (token with `project` scope) | 5000/hr | Required for ProjectV2 |
+
+**Realistic timeline**: 300 issues × 2 API calls each (1 read + 1 write) = 600 requests. At 5000/hr → ~7 minutes minimum. With batch overhead → **15-20 min realistic**.
+
+### Set Milestone + Severity (REST)
+
+```bash
+# Set milestone
+gh api -X PATCH /repos/matrixorigin/matrixone/issues/$NUMBER \
+  -f milestone="MO-202607"
+
+# Replace severity label (remove old, add new)
+gh api -X DELETE "/repos/matrixorigin/matrixone/issues/$NUMBER/labels/severity%2Fs0"
+gh api -X POST /repos/matrixorigin/matrixone/issues/$NUMBER/labels \
+  -f 'labels[]=severity/s0'
+```
+
+### Set Project (GraphQL — requires `project` OAuth scope)
+
+```graphql
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PVT_kwDOA4Uifs4AAGab"
+    itemId: "PVTI_lADOA4Uifs4AAGabz..."
+    fieldId: "PVTSSF_lADOA4Uifs4AAGac..."
+    value: { singleSelectOptionId: "04b8c8f2" }
+  }) { projectV2Item { id } }
+}
+```
+
+If token lacks `project` scope, document project assignment in reports for manual allocation.
+
+### Fallback: if gh CLI unavailable
+
+```bash
+curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/matrixorigin/matrixone/issues?state=open&labels=kind/bug&per_page=100&page=1"
+```
+
+---
+
+## Common Pitfalls (10 — All from Real Sessions)
+
+| # | Pitfall | Symptom | Root Cause | Fix in v4 |
+|---|---------|---------|------------|-----------|
+| 1 | **Page size mismatch** | 139 issues silently missed | per_page=50 vs per_page=100 pagination misalignment | Phase 1: query total_count first, plan batches explicitly. Fallback chain: 100→50→30 |
+| 2 | **Severity inflation** | 8 s-1 assigned, project only has 4 | Did not calibrate against existing project severity usage | Phase 1.2: query existing distribution, force conservative s-1 |
+| 3 | **Whole-batch failure** | User changes rule → all 300+ must redo | Single-pass classification without rule lock-in | Phase 1 gate: STANDARDS.md approval before any writes. Phase 2 batch isolation |
+| 4 | **Severity drift** | Reports say s0 but GitHub shows s1 | Manually edited reports after generation, forgot to re-update | Step 2c: generated_at + checksum. Phase 3e: drift detection via mtime comparison |
+| 5 | **Half-updated batch** | Batch 4 crashes mid-update → 23 of 50 updated, 27 not | No rollback safety, no before-snapshot | Step 2d: before_snapshot.json. Rollback procedure. Never "fix forward" |
+| 6 | **Rate limit blind spot** | Script hangs for hours, user thinks it's stuck | Did not estimate API calls vs rate limit budget | Phase 2f: progress display. API reference with rate limit math. 300 issues ≈ 15-20 min |
+| 7 | **Project assignment fails** | Token missing `project` OAuth scope, all project writes fail silently | Did not verify token scope before Phase 2 | API Reference: document scope requirement. Fallback: mark in report for manual allocation |
+| 8 | **Title is N/A** | Batch 7 supplement had all titles as N/A | GraphQL N+1 query for batch 7's 119 issues hit rate limit; fallback JSON parse missed titles | Prefer REST API (returns full data). GraphQL only for project writes |
+| 9 | **Cross-batch duplicates** | Same issue appears in batch 3 and batch 5 | Pagination race condition: new issues created during triage change sort order | Track seen issue numbers globally. Deduplicate before final count |
+| 10 | **No progress visibility** | User doesn't know how far along, cancels early | Batch process silent between updates | Phase 2f: mandatory progress bar + running totals after every batch |
+| 11 | **Rule change without impact analysis** | User says "partition 低优" → 40 issues change, unexpected | No preview of rule change blast radius | Phase 4 (review): show impact analysis before applying rule change |
+
+---
+
+## Script Checklist
+
+Scripts that accompany this skill must:
+
+- [ ] Check `STANDARDS.md` `Approved: true` gate before any GitHub write
+- [ ] Accept `--dry-run` flag (default: first 5 issues per batch)
+- [ ] Save `batch_N_before_snapshot.json` before updating each batch
+- [ ] Print progress bar + running totals after each batch completion
+- [ ] Detect `generated_at` vs file mtime drift (warn, don't block)
+- [ ] Cross-validate severity counts (reports vs GitHub) in Phase 3
+- [ ] Support `--rollback batch_N` to restore from snapshot
+- [ ] Log every API call (method, URL, status code) to `triage_YYYYMMDD.log`
+
+---
+
+## Refinement Loop (when user gives feedback mid-triage)
+
+1. **User says "change X"** → pause current batch, DO NOT start new batch
+2. **Run impact analysis**: which already-processed batches are affected? How many issues?
+3. **Show impact preview** to user, get confirmation
+4. **Re-classify affected batches** (only those), regenerate reports (with new timestamps)
+5. **Re-update GitHub** for affected batches (snapshot → update → verify)
+6. **Resume from next unprocessed batch**
+
+Impact analysis template:
+
+```
+⚠️  Rule change: "partition bugs → s1 instead of s0"
+    Affected batches: 1, 3, 5 (already processed)
+    Issues to re-classify: 18
+    Severity changes: 13 (s0→s1) + 2 (s0 stays, has panic) + 3 (no change)
+    Proceed? [y/N]
+```

--- a/.claude/skills/mo-dev/SKILL.md
+++ b/.claude/skills/mo-dev/SKILL.md
@@ -1,0 +1,356 @@
+# MatrixOne Development Skill (mo-dev)
+
+## Trigger
+Activated automatically when operating in the MatrixOne codebase.
+
+---
+
+## Enforcement Gates (READ FIRST)
+
+This skill is not optional reference — activate it at these **mandatory checkpoints**:
+
+| Gate | When | Action |
+|------|------|--------|
+| **G-MODIFY** | Before any `str_replace`/`write_file` on a `colexec` operator or `process` signal type | Read §3 (operator contract) + §7 (forbidden patterns) |
+| **G-CGO-ERR** | Any build/test returns `file not found`, `Undefined symbols`/`undefined symbol:`, or `dyld:`/`error while loading shared libraries:` | Read §2.2 (symptom table) + §2.4 (stash protocol) |
+| **G-DONE** | Before declaring "done"/"complete"/"passes" | Read §4.3 (completion gate) — all 5 boxes MUST be checked |
+| **G-TEST-FAIL** | `go test` returns non-zero or hangs >10s | Read §5 (diagnosis) + §2.4 (stash protocol) before attributing cause |
+
+**How to use**: At each gate, verify the corresponding section's conditions. If a condition fails, fix it before proceeding. Never skip a gate.
+
+---
+
+## 1. Project Structure
+
+```
+pkg/sql/compile/       ← DAG compilation, operator instantiation, pipeline build, launch
+pkg/sql/colexec/       ← execution operators (connector/dispatch/merge/join/scan/...)
+pkg/vm/process/        ← execution context (Process), WaitRegister, signal channels
+pkg/vm/pipeline/       ← Pipeline lifecycle management
+pkg/container/         ← Batch/Vector/pSpool and other base data structures
+pkg/frontend/          ← MySQL protocol compatibility layer
+pkg/txn/               ← transaction management and MVCC
+pkg/sql/plan/          ← query plan construction
+cgo/                   ← CGo adapter layer (libmo.dylib)
+```
+
+**Operator file convention**: under `pkg/sql/colexec/<op>/`:
+- `types.go` — Arg struct definition
+- `<op>.go` — main logic (Prepare/Call/Reset)
+- Optional `sendfunc.go`/`dispatch.go` helpers
+
+**Key dependency chain**: `compile` instantiates operators → `colexec` executes → `process` manages context and signals → `container` carries data.
+
+---
+
+## 2. Build, Test, Verify
+
+### 2.1 Basic Commands
+
+```bash
+# Compile check
+go build ./pkg/target/...
+
+# Static analysis
+go vet ./pkg/target/...
+
+# Run tests (-count=1 disables cache)
+go test -v -count=1 ./pkg/target/...
+
+# Single test
+go test -v -count=1 -run TestXxx ./pkg/target/...
+
+# Timeout control (integration tests can be slow)
+go test -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+### 2.2 CGo Environment (Three-Layer Variables)
+
+MO's CGo involves **compilation** (headers), **linking** (own library `libmo`), and **third-party libraries** (`libusearch_c`) as three independent layers. Corresponding Makefile config:
+
+```makefile
+# Makefile:203 — header paths for compilation
+CGO_OPTS := CGO_CFLAGS="-I$(CGO_DIR) -I$(THIRDPARTIES_INSTALL_DIR)/include"
+
+# Makefile:204-207 — link libmo (rpath varies by OS)
+# Linux:   -Wl,-rpath,$$ORIGIN/lib
+# macOS:   -Wl,-rpath,@executable_path/lib
+GOLDFLAGS := -ldflags="-extldflags '-L$(CGO_DIR) -lmo -L$(THIRDPARTIES_INSTALL_DIR)/lib $(RPATH)'"
+```
+
+**Note**: Makefile does **not** set `CGO_LDFLAGS` — `libmo` link flags all go through `-ldflags` → `-extldflags`. However, the `usearch` Go module ships its own `#cgo LDFLAGS: -lusearch_c`, causing the linker to prefer system paths which may find an outdated version missing required symbols. In that case, `CGO_LDFLAGS` is needed to point to the MO-compiled version.
+
+#### macOS vs Linux — All Differences
+
+| Aspect | macOS | Linux |
+|--------|-------|-------|
+| Dynamic library name | `libmo.dylib` | `libmo.so` |
+| Third-party lib prefix | `libusearch_c.dylib` | `libusearch_c.so` |
+| Linker flag (make static) | `gcc -dynamiclib` | `gcc -shared` |
+| Runtime library path env | `DYLD_LIBRARY_PATH` | `LD_LIBRARY_PATH` |
+| rpath in ldflags | `@executable_path/lib` | `$$ORIGIN/lib` (double-escape in Makefile) |
+| `-rpath` flag | `-Wl,-rpath,@executable_path/lib` | `-Wl,-rpath,\$\$ORIGIN/lib` or `-Wl,-rpath,$ORIGIN/lib` in shell |
+| C header flags | `CGO_CFLAGS="-I.../cgo -I.../thirdparties/install/include"` | **Same** |
+| usearch link flags | `CGO_LDFLAGS="-L.../thirdparties/install/lib -lusearch_c"` | **Same** |
+
+#### Full Test Environment Variables
+
+**macOS:**
+```bash
+# 1. Headers (required for any package with CGo code)
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+
+# 2. libusearch_c (required for packages needing usearch symbols)
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+
+# 3. Runtime dynamic library (required when running tests)
+export DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib:$DYLD_LIBRARY_PATH"
+
+# go test one-liner:
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
+DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
+  -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+**Linux:**
+```bash
+# 1. Headers
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+
+# 2. libusearch_c
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+
+# 3. Runtime dynamic library
+export LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib:$LD_LIBRARY_PATH"
+
+# go test one-liner:
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c" \
+LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib" \
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib'" \
+  -v -count=1 -timeout 120s ./pkg/target/...
+```
+
+#### Symptom → Root Cause Quick Reference
+
+| Symptom (macOS) | Symptom (Linux) | Missing Variable | Root Cause |
+|-----------------|-----------------|-----------------|------------|
+| `fatal error: 'xxhash.h' file not found` | **Same error** | `CGO_CFLAGS` | Compiler can't find thirdparties headers |
+| `Undefined symbols: _usearch_hardware_acceleration_*` | **Same error** (`undefined symbol:` prefix) | `CGO_LDFLAGS` | usearch module's `#cgo LDFLAGS` found an old `libusearch_c` without this symbol |
+| `ld: library 'mo' not found` | `/usr/bin/ld: cannot find -lmo` | `-ldflags="-extldflags '-L... -lmo'"` | Linker can't find `libmo.dylib`/`libmo.so` |
+| `dyld: Library not loaded: libmo.dylib` | `error while loading shared libraries: libmo.so` | `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Runtime can't find dynamic library |
+
+### 2.3 Layered Testing Strategy
+
+MO packages fall into four layers by CGo dependency depth. **Must validate bottom-up**.
+
+#### Layer Map
+
+| Layer | Example Packages | What Happens at `go test` | Variables Needed |
+|-------|-----------------|--------------------------|-----------------|
+| **Pure Go** | `pkg/vm/process`, `pkg/container/pSpool`, `pkg/vm/pipeline` | Compiles + links test binary. Zero CGo code in the transitive closure. | **None** |
+| **CGo-transitive** | `pkg/sql/colexec/connector`, `dispatch`, `merge` | Test binary links `usearch` Go module, which has `#cgo LDFLAGS: -lusearch_c`. Full CGo compile + link path fires. | `CGO_CFLAGS` + `CGO_LDFLAGS` |
+| **CGo-direct** | `pkg/sql/compile`, `pkg/sql/colexec/...` (some) | Test binary directly links `libmo` + `libusearch_c`. Both libraries must be findable at build-time AND loadable at run-time. | `CGO_CFLAGS` + `CGO_LDFLAGS` + `-ldflags "-extldflags ..."` + `DYLD_LIBRARY_PATH`/`LD_LIBRARY_PATH` |
+| **Integration** | `pkg/frontend`, cmd packages | Full MO binary. Needs external services (MySQL protocol, storage, etc). | All + services |
+
+#### Copy-Paste Commands Per Layer
+
+**Layer 1 — Pure Go** (nothing needed):
+```bash
+go test -v -count=1 -timeout 120s ./pkg/vm/process/... ./pkg/container/pSpool/...
+```
+
+**Layer 2 — CGo-transitive** (needs headers + usearch link):
+```bash
+# macOS
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+go test -v -count=1 -timeout 120s ./pkg/sql/colexec/connector/... ./pkg/sql/colexec/dispatch/...
+
+# Linux
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+go test -v -count=1 -timeout 120s ./pkg/sql/colexec/connector/...
+```
+
+**Layer 3 — CGo-direct** (all four — macOS):
+```bash
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+export DYLD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib"
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,@executable_path/lib'" \
+  -v -count=1 -timeout 120s ./pkg/sql/compile/...
+```
+
+Layer 3 — Linux:
+```bash
+export CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include"
+export CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c"
+export LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib"
+go test -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib'" \
+  -v -count=1 -timeout 120s ./pkg/sql/compile/...
+```
+
+#### Variable → Purpose Quick Card
+
+| Variable | What It Does | When Needed |
+|---------|-------------|-------------|
+| `CGO_CFLAGS` | Tells the C compiler where to find headers (`xxhash.h`, `mo.h`, etc.) | Anytime a package in the transitive closure has CGo C code |
+| `CGO_LDFLAGS` | Tells the Go linker where to find `libusearch_c` (overrides the outdated path in usearch module's own `#cgo LDFLAGS`) | Anytime the usearch Go module is linked (most `colexec` packages) |
+| `-ldflags "-extldflags ..."` | Tells the external linker where to find `libmo` + sets rpath for runtime | Only when the package directly links `libmo` (CGo-direct layer) |
+| `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` | Tells the OS runtime loader where to find `.dylib` / `.so` files | Only when the test binary loads `libmo` (CGo-direct layer) |
+
+**Why this order matters**: Pure Go package tests are fastest (seconds), and failures are 100% code issues. If pure Go fails, don't waste time debugging CGo link errors on upper layers.
+
+#### 2.3.1 `go build` vs `go test` — Not the Same
+
+| Command | What It Does | CGo Impact |
+|---------|-------------|------------|
+| `go build ./pkg/sql/colexec/connector/...` | Compiles the **package**, does not link a test binary | May succeed without CGo flags |
+| `go test ./pkg/sql/colexec/connector/...` | Compiles and links a **test binary** including all transitive deps | May fail if transitive deps need CGo symbols |
+
+**Consequence**: `go build` passing does NOT prove `go test` will pass. When adding a new import chain that reaches `cgo/`, `go build` may still succeed while `go test` breaks. Only `go test` output is authoritative.
+
+### 2.4 Isolate Environment Issues (Stash Verification Protocol)
+
+```bash
+# Step 1: Save current changes
+git stash
+
+# Step 2: Run same test with same variables
+CGO_CFLAGS="..." go test -count=1 ./failing/package/...
+
+# Step 3a: Still fails → environment issue, unrelated to code changes
+# Step 3b: Passes       → code change introduced the problem
+
+# Step 4: Restore changes
+git stash pop
+```
+
+**Hard rule**: A "pre-existing issue" claim without stash verification is not credible. When seeing `Undefined symbols` or `file not found`, never assert "this is pre-existing" — must prove it via stash.
+
+---
+
+## 3. Operator Lifecycle
+
+MatrixOne `colexec` operators follow a three-phase lifecycle:
+
+| Phase | Method | When Called | Constraint |
+|-------|--------|-------------|------------|
+| Init | `Prepare()` | After DAG compile, before first execution | Allocate Reg, init state |
+| Execute | `Call()` | Called repeatedly as each batch of data arrives | Data forwarding only, **never send terminal signals** |
+| Cleanup | `Reset()` | During Pipeline Cleanup phase | Release resources, **solely responsible for sending terminal signals** |
+
+**Hard boundary between Call() and Reset()**: This is the most important operator contract in MO. `Call()` handles the "still has data" path. `Reset()` handles the "completely done" path. Confusing the two causes receivers to terminate early or dead-wait for timeout.
+
+---
+
+## 4. Code Change Workflow
+
+### 4.1 Before Changing
+
+1. Read target files to confirm current content
+2. `grep` for all references to the symbol being changed (code + tests)
+3. Confirm whether each reference is affected by the change
+4. List packages to test manually (starting from bottom pure-Go packages)
+
+### 4.2 After Changing (Strict Order)
+
+```
+go build ./pkg/A/... ./pkg/B/...    ← Compile (all changed packages)
+go vet ./pkg/A/... ./pkg/B/...      ← Static check
+go test -v -count=1 ./pkg/A/...     ← Unit tests (bottom-up)
+go test -v -count=1 ./pkg/B/...
+git diff --stat                      ← Confirm no unexpected file changes
+go test -count=1 ./pkg/upstream/...  ← Regression tests
+```
+
+**Hard rule**: Test output must be fresh from this turn's `go test -count=1`. Results from previous turns are stale and cannot be used to justify "it passes."
+
+**Freshness verification**: A test result is only valid if ALL of these hold:
+1. The `go test -count=1` command ran in the **current turn** (not a previous turn)
+2. The output includes the **test binary's own timestamp** (e.g., `ok  pkg/vm/process  0.123s`), not just a cached summary
+3. If the test package is CGo-transitive, the command includes the full `CGO_CFLAGS` + `CGO_LDFLAGS` + `DYLD_LIBRARY_PATH` prefix
+
+**Anti-pattern**: Seeing `go test` output in context and concluding "tests pass" without checking whether that output is from the current turn or a stale earlier turn.
+
+### 4.3 Completion Gate
+
+Before claiming any change is "done" or "complete", all of the following MUST be true:
+
+```
+□ All changed packages pass go build
+□ All changed packages pass go vet
+□ All changed packages pass go test -count=1 (fresh output from this turn)
+□ No test hung >10s (each package must print "ok" or "FAIL" within expected time)
+□ git diff --stat shows only intended files
+□ Upstream regression tests pass or failures are confirmed pre-existing via stash
+```
+
+**Never claim done when any box is unchecked.** If a test fails, fix it; if an environment blocks testing, state it explicitly rather than implying it passed.
+
+**Test hang is a failure**: A test that produces no output for >10s is either deadlocked or blocked. It is not "still running" — it is a bug. Common MO causes:
+- `sp.CloseWithTimeout()` waiting for nil-batch that never arrives → exactly 30s hang
+- goroutine blocked on channel send/receive with no timeout → infinite hang
+- `context.TODO()` used where a real context with deadline was needed → infinite hang
+
+---
+
+## 5. Test Failure Diagnosis
+
+### 5.1 Test Hangs With No Output (>10s)
+
+```
+→ goroutine blocked or deadlocked
+→ Analyze the wait chain: who is blocking on select/recv?
+→ Check whether the channel communication peer is working
+```
+
+### 5.2 Exact 30s Timeout
+
+```
+→ Some wait path triggered context/time.Sleep timeout
+→ Usually waiting for a signal or data that will never arrive
+→ Check whether upstream changed send timing
+```
+
+### 5.3 CGo Link Error
+
+```
+→ First, stash-verify it's not a code issue (see §2.4)
+→ Environment: DYLD_LIBRARY_PATH, libmo.dylib version
+→ Code: check whether cgo/lib.go was accidentally modified
+```
+
+### 5.4 Vet Error
+
+Do not ignore. Packages that pass vet may still have runtime bugs, but packages that **fail** vet almost certainly have code problems.
+
+---
+
+## 6. MO Common Pitfalls
+
+1. **Operators are modified in pairs**: connector/dispatch (send side) and merge (receive side) share a communication protocol. Changing one side must check the other.
+
+2. **Protocol migration compatibility window**: When adding new signal types, the old path must remain compatible until all callers are migrated.
+
+3. **Channel capacity**: `make(chan T, N)` — N determines buffer size. N=0 means senders drop data when receivers are not ready. Check whether channel capacity fits the use case.
+
+4. **Resource ownership**: `Batch` in MO is a heavyweight object. Confirm who creates it, who holds the last reference, and who is responsible for `Clean()`.
+
+---
+
+## 7. Forbidden Patterns
+
+These are HARD rules. Violating any of them has caused real bugs in past MO development sessions.
+
+| # | Pattern | Why Forbidden |
+|---|---------|---------------|
+| 7.1 | Modifying `Call()` to send terminal signals | Violates the operator lifecycle contract (§3). Terminal signals go in `Reset()` only. |
+| 7.2 | Using `sp.CloseWithTimeout()` after switching from implicit nil-batch to explicit signals | `CloseWithTimeout` waits for a nil-batch that will never arrive → guaranteed 30s timeout |
+| 7.3 | Claiming a test failure is "pre-existing" without `git stash` proof | The failure may actually be caused by your change. §2.4 protocol is mandatory. |
+| 7.4 | Adding `CGO_CFLAGS` directives to `cgo/lib.go` | This file is committed to the repo. Environment-specific paths belong in shell variables, not source files. |
+| 7.5 | Declaring completion without fresh `go test -count=1` output in the current turn | Stale test results from earlier turns do not prove the current code works. |
+| 7.6 | Changing protocol on one side of a sender/receiver pair without checking the other | Every sender has a corresponding receiver. connector↔merge, dispatch↔merge. |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .kiro/
 .cursor/
+.claude/
 /CLAUDE.md
 *.o
 *.a
@@ -81,3 +82,4 @@ etc/docker-multi-cn-local-disk/*.toml
 # python
 **/__pycache__/
 *.pyc
+.agents/

--- a/cgo/.gitignore
+++ b/cgo/.gitignore
@@ -1,4 +1,5 @@
 *.o
 *.a
 *.so
+*.dylib
 __.SYMDEF*


### PR DESCRIPTION
## Summary

Closes [#25267](https://github.com/matrixorigin/matrixone/issues/25267).

## What Changed

### New: `mo-dev` agent skill (Astra + Codex compatible)

Covers all MatrixOne-specific development concerns:
- CGo multi-layer linking (`CGO_CFLAGS`, `CGO_LDFLAGS`, `-ldflags`)
- macOS vs Linux platform differences for `go test`
- Pipeline operator lifecycle contracts (`Call`/`Reset`, `Abort`/`CloseWithTimeout`)
- Completion gate checklist before declaring work done
- Forbidden patterns that cause spool timeouts and data leaks

| File | Ecosystem |
|------|-----------|
| `.claude/skills/mo-dev/SKILL.md` | Astra |
| `.agents/skills/mo-dev/SKILL.md` | Codex / agentskills.io |

### Modified: `.gitignore`, `cgo/.gitignore`

- Track specific skill files while ignoring entire `.claude/` and `.agents/` directories
- Add `*.dylib` to `cgo/.gitignore` (only build artifact not covered)

## References

This skill was developed from lessons learned while working on [#24971](https://github.com/matrixorigin/matrixone/issues/24971) (pipeline cleanup refactoring).