### PR TITLE
fix: improve skills SKILL.md compatibility format

### DIFF
--- a/.claude/skills/mo-bug-triage/SKILL.md
+++ b/.claude/skills/mo-bug-triage/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: mo-bug-triage
 description: Systematic triage and classification of MatrixOne kind/bug issues — calibrated severity assessment, batched GitHub metadata updates (milestone, severity, project), rollback-safe batch processing, and drift prevention. Use when asked to triage, classify, or bulk-update MO bugs.
-compatibility: Designed for Codex CLI and compatible agents. Requires GitHub CLI (gh) with authenticated access (5000 req/hr) and repo write scope.
+compatibility:
+  agents: Codex CLI and compatible agents
+  requires:
+    - GitHub CLI (gh) with authenticated access (5000 req/hr)
+    - repo write scope
 metadata:
   project: matrixone
   repository: matrixorigin/matrixone

--- a/.claude/skills/mo-dev/SKILL.md
+++ b/.claude/skills/mo-dev/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: mo-dev
 description: MatrixOne database kernel development - CGo build/test environment setup, operator lifecycle contracts (Call/Reset), pipeline protocol, layered testing strategy. Use when modifying colexec operators, process signal types, compile pipeline construction, or debugging CGo link errors (undefined symbols, missing headers, library not found).
-compatibility: Designed for Codex CLI and compatible agents. Requires Go 1.22+, GNU Make, C/C++ toolchain (gcc/clang), and pre-built thirdparties.
+compatibility:
+  agents: Codex CLI and compatible agents
+  requires:
+    - Go 1.22+
+    - GNU Make
+    - C/C++ toolchain (gcc/clang)
+    - pre-built thirdparties
 metadata:
   project: matrixone
   repository: matrixorigin/matrixone


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [x] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25267

## What this PR does / why we need it:

Convert the `compatibility` field in `mo-bug-triage` and `mo-dev` skill SKILL.md from single-line text format to structured YAML format with explicit `agents` and `requires` keys. This improves machine readability and makes it easier for agent platforms to parse compatibility requirements programmatically.