### PR TITLE
fix(logservice): reuse pooled client for remote truncate

### DIFF
--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool_test.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool_test.go
@@ -15,6 +15,7 @@
 package logservicedriver
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -72,4 +73,36 @@ func TestNewClientPoolPanicsWhenFactoryAlwaysFail(t *testing.T) {
 	require.PanicsWithError(t, moerr.NewInternalErrorNoCtx("always fail").Error(), func() {
 		newClientPool(cfg)
 	})
+}
+
+func TestTruncateFromRemoteUsesPooledClient(t *testing.T) {
+	var creations atomic.Int32
+	backend := NewMockBackend()
+
+	cfg := &Config{
+		ClientMaxCount:      1,
+		ClientBufSize:       128,
+		MaxTimeout:          time.Second,
+		ClientRetryTimes:    1,
+		ClientRetryInterval: time.Millisecond,
+		ClientRetryDuration: time.Millisecond,
+		ClientFactory: func() (logservice.Client, error) {
+			creations.Add(1)
+			return newMockBackendClient(backend), nil
+		},
+	}
+	cfg.fillDefaults()
+	cfg.validate()
+
+	driver := &LogServiceDriver{
+		config:     *cfg,
+		clientPool: newClientPool(cfg),
+	}
+	t.Cleanup(driver.clientPool.Close)
+
+	psnTruncated, err := driver.truncateFromRemote(context.Background(), 1, 0)
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), psnTruncated)
+	require.Equal(t, int32(1), creations.Load())
 }

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/truncate.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/truncate.go
@@ -162,7 +162,7 @@ func (d *LogServiceDriver) truncateFromRemote(
 		)
 	}()
 
-	if client, err = d.clientPool.GetOnFly(); err == ErrClientPoolClosed {
+	if client, err = d.clientPool.Get(); err != nil {
 		return
 	}
 	defer client.Putback()


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25276

## What this PR does / why we need it:
  This PR changes truncateFromRemote to borrow an existing client from clientPool instead of creating a new on-the-fly logservice client for every truncate operation.

  Previously, remote truncate used GetOnFly(), which created a fresh client each time. When logservice client creation was slow because of unreachable or stale replica addresses, truncate could repeatedly trigger
  expensive connection attempts.

  Changes:

  - Replace clientPool.GetOnFly() with clientPool.Get() in truncateFromRemote.
  - Return the borrowed client to the pool with the existing Putback() flow.
  - Add a regression test verifying remote truncate does not create an extra client beyond the pool-initialized client.