### PR TITLE
fix(logservice): create on-fly clients outside pool lock

### DIFF
--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool.go
@@ -318,11 +318,25 @@ func (c *clientPool) Close() {
 
 func (c *clientPool) GetOnFly() (*wrappedClient, error) {
 	c.cond.L.Lock()
-	defer c.cond.L.Unlock()
 	if c.closed {
+		c.cond.L.Unlock()
 		return nil, ErrClientPoolClosed
 	}
-	return NewClient(c.cfg.ClientFactory, c.cfg.ClientBufSize, c.cfg.ClientRetryTimes, c.cfg.ClientRetryInterval, c.cfg.ClientRetryDuration)
+	c.cond.L.Unlock()
+
+	client, err := NewClient(c.cfg.ClientFactory, c.cfg.ClientBufSize, c.cfg.ClientRetryTimes, c.cfg.ClientRetryInterval, c.cfg.ClientRetryDuration)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cond.L.Lock()
+	closed := c.closed
+	c.cond.L.Unlock()
+	if closed {
+		client.Close()
+		return nil, ErrClientPoolClosed
+	}
+	return client, nil
 }
 
 func (c *clientPool) Get() (client *wrappedClient, err error) {

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool_test.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool_test.go
@@ -15,6 +15,7 @@
 package logservicedriver
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -72,4 +73,69 @@ func TestNewClientPoolPanicsWhenFactoryAlwaysFail(t *testing.T) {
 	require.PanicsWithError(t, moerr.NewInternalErrorNoCtx("always fail").Error(), func() {
 		newClientPool(cfg)
 	})
+}
+
+func TestGetOnFlyDoesNotBlockPoolGetWhileCreatingClient(t *testing.T) {
+	backend := NewMockBackend()
+	var attempts atomic.Int32
+	factoryEntered := make(chan struct{})
+	releaseFactory := make(chan struct{})
+
+	cfg := &Config{
+		ClientMaxCount:      1,
+		ClientBufSize:       128,
+		MaxTimeout:          time.Second,
+		ClientRetryTimes:    1,
+		ClientRetryInterval: time.Nanosecond,
+		ClientRetryDuration: time.Second,
+		ClientFactory: func() (logservice.Client, error) {
+			if attempts.Add(1) == 1 {
+				return newMockBackendClient(backend), nil
+			}
+			close(factoryEntered)
+			<-releaseFactory
+			return newMockBackendClient(backend), nil
+		},
+	}
+	cfg.fillDefaults()
+	cfg.validate()
+
+	pool := newClientPool(cfg)
+	t.Cleanup(pool.Close)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var onFlyClient *wrappedClient
+	var onFlyErr error
+	go func() {
+		defer wg.Done()
+		onFlyClient, onFlyErr = pool.GetOnFly()
+	}()
+
+	select {
+	case <-factoryEntered:
+	case <-time.After(time.Second):
+		t.Fatal("GetOnFly did not enter the blocking client factory")
+	}
+
+	got := make(chan *wrappedClient, 1)
+	go func() {
+		client, err := pool.Get()
+		require.NoError(t, err)
+		got <- client
+	}()
+
+	var pooled *wrappedClient
+	select {
+	case pooled = <-got:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("pool Get blocked while GetOnFly was creating a client")
+	}
+	pooled.Putback()
+
+	close(releaseFactory)
+	wg.Wait()
+	require.NoError(t, onFlyErr)
+	require.NotNil(t, onFlyClient)
+	onFlyClient.Close()
 }

--- a/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool_test.go
+++ b/pkg/vm/engine/tae/logstore/driver/logservicedriver/clientpool_test.go
@@ -80,6 +80,7 @@ func TestGetOnFlyDoesNotBlockPoolGetWhileCreatingClient(t *testing.T) {
 	var attempts atomic.Int32
 	factoryEntered := make(chan struct{})
 	releaseFactory := make(chan struct{})
+	var releaseOnce sync.Once
 
 	cfg := &Config{
 		ClientMaxCount:      1,
@@ -111,6 +112,10 @@ func TestGetOnFlyDoesNotBlockPoolGetWhileCreatingClient(t *testing.T) {
 		defer wg.Done()
 		onFlyClient, onFlyErr = pool.GetOnFly()
 	}()
+	defer func() {
+		releaseOnce.Do(func() { close(releaseFactory) })
+		wg.Wait()
+	}()
 
 	select {
 	case <-factoryEntered:
@@ -118,24 +123,106 @@ func TestGetOnFlyDoesNotBlockPoolGetWhileCreatingClient(t *testing.T) {
 		t.Fatal("GetOnFly did not enter the blocking client factory")
 	}
 
-	got := make(chan *wrappedClient, 1)
+	type getResult struct {
+		client *wrappedClient
+		err    error
+	}
+	got := make(chan getResult, 1)
 	go func() {
 		client, err := pool.Get()
-		require.NoError(t, err)
-		got <- client
+		got <- getResult{client: client, err: err}
 	}()
 
 	var pooled *wrappedClient
 	select {
-	case pooled = <-got:
+	case result := <-got:
+		require.NoError(t, result.err)
+		pooled = result.client
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("pool Get blocked while GetOnFly was creating a client")
 	}
 	pooled.Putback()
 
-	close(releaseFactory)
+	releaseOnce.Do(func() { close(releaseFactory) })
 	wg.Wait()
 	require.NoError(t, onFlyErr)
 	require.NotNil(t, onFlyClient)
 	onFlyClient.Close()
+}
+
+func TestGetOnFlyClosesCreatedClientWhenPoolClosesConcurrently(t *testing.T) {
+	backend := NewMockBackend()
+	var attempts atomic.Int32
+	var closed atomic.Int32
+	factoryEntered := make(chan struct{})
+	releaseFactory := make(chan struct{})
+	var releaseOnce sync.Once
+
+	cfg := &Config{
+		ClientMaxCount:      1,
+		ClientBufSize:       128,
+		MaxTimeout:          time.Second,
+		ClientRetryTimes:    1,
+		ClientRetryInterval: time.Nanosecond,
+		ClientRetryDuration: time.Second,
+		ClientFactory: func() (logservice.Client, error) {
+			if attempts.Add(1) == 1 {
+				return newMockBackendClient(backend), nil
+			}
+			close(factoryEntered)
+			<-releaseFactory
+			return &closeCountingClient{
+				Client: newMockBackendClient(backend),
+				closed: &closed,
+			}, nil
+		},
+	}
+	cfg.fillDefaults()
+	cfg.validate()
+
+	pool := newClientPool(cfg)
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseFactory) })
+		pool.Close()
+	})
+
+	result := make(chan struct {
+		client *wrappedClient
+		err    error
+	}, 1)
+	go func() {
+		client, err := pool.GetOnFly()
+		result <- struct {
+			client *wrappedClient
+			err    error
+		}{client: client, err: err}
+	}()
+
+	select {
+	case <-factoryEntered:
+	case <-time.After(time.Second):
+		t.Fatal("GetOnFly did not enter the blocking client factory")
+	}
+
+	pool.Close()
+	releaseOnce.Do(func() { close(releaseFactory) })
+
+	select {
+	case res := <-result:
+		require.ErrorIs(t, res.err, ErrClientPoolClosed)
+		require.Nil(t, res.client)
+	case <-time.After(time.Second):
+		t.Fatal("GetOnFly did not return after the pool was closed")
+	}
+	require.Equal(t, int32(1), closed.Load())
+}
+
+type closeCountingClient struct {
+	logservice.Client
+	closed *atomic.Int32
+}
+
+func (c *closeCountingClient) Close() error {
+	c.closed.Add(1)
+	return c.Client.Close()
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25275

## What this PR does / why we need it:

  This PR prevents clientPool.GetOnFly from holding the pool mutex while creating a new logservice client.

  Previously, GetOnFly held c.cond.L during NewClient, which may perform network I/O and block for a long time when logservice replicas are unreachable. While that lock was held, normal pool operations such as Get, Put,
  and GetWithWriteToken could not proceed, causing the WAL commit path to stall.

  Changes:
  - Move NewClient execution outside the clientPool mutex.
  - Keep the lock only for checking whether the pool is closed.
  - Re-check the closed state after client creation.
  - Close the newly created client and return ErrClientPoolClosed if the pool was closed during creation.
  - Add a regression test proving that pool Get is not blocked while GetOnFly is creating a client.