### PR TITLE
[4.1-dev] fix: propagate rewrite hints to INSERT...SELECT inner query

### DIFF
--- a/pkg/sql/parsers/sqlparse.go
+++ b/pkg/sql/parsers/sqlparse.go
@@ -289,7 +289,7 @@ func AddRewriteHints(ctx context.Context, stmts []tree.Statement, sql string) er
 	}
 	for i, stmt := range stmts {
 		switch stmt.(type) {
-		case *tree.Select, *tree.ParenSelect:
+		case *tree.Select, *tree.ParenSelect, *tree.Insert:
 			// ok
 		default:
 			continue
@@ -350,6 +350,13 @@ func AddRewriteHints(ctx context.Context, stmts []tree.Statement, sql string) er
 			case *tree.ParenSelect:
 				if s.Select != nil {
 					s.Select.RewriteOption = rewriteOption
+				}
+			case *tree.Insert:
+				if s.Rows != nil {
+					s.Rows.RewriteOption = rewriteOption
+					if ps, ok := s.Rows.Select.(*tree.ParenSelect); ok && ps.Select != nil {
+						ps.Select.RewriteOption = rewriteOption
+					}
 				}
 			}
 		}

--- a/pkg/sql/parsers/sqlparse_test.go
+++ b/pkg/sql/parsers/sqlparse_test.go
@@ -390,17 +390,67 @@ func TestAddRewriteHints_ValidWithBangPlusComment(t *testing.T) {
 	}
 }
 
-func TestAddRewriteHints_IgnoresNonSelectStatements(t *testing.T) {
+func TestAddRewriteHints_InsertValues(t *testing.T) {
 	sql := "/*+ {\"rewrites\": {\"db3.t3\": \"select 1\"}} */ insert into db3.t3 values (1)"
 	stmts, err := parseAndApply(t, sql)
 	require.NoError(t, err)
 	require.Len(t, stmts, 1)
-	// Should be ignored; no panic or error and no rewrite option
-	_, isSelect := stmts[0].(*tree.Select)
-	if isSelect {
-		sel := stmts[0].(*tree.Select)
-		require.Nil(t, sel.RewriteOption)
-	}
+	// INSERT...VALUES: hint is attached to Rows but never read (bindSelect not called for VALUES)
+	ins, ok := stmts[0].(*tree.Insert)
+	require.True(t, ok)
+	require.NotNil(t, ins.Rows)
+	require.NotNil(t, ins.Rows.RewriteOption)
+}
+
+func TestAddRewriteHints_InsertSelect(t *testing.T) {
+	sql := "/*+ {\"rewrites\": {\"db4.t4\": \"select 1\"}} */ insert into db4.t4 select * from db4.t4"
+	stmts, err := parseAndApply(t, sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	ins, ok := stmts[0].(*tree.Insert)
+	require.True(t, ok)
+	require.NotNil(t, ins.Rows)
+	require.NotNil(t, ins.Rows.RewriteOption)
+	require.Contains(t, ins.Rows.RewriteOption.Rewrites, "db4.t4")
+}
+
+func TestAddRewriteHints_InsertParenSelect(t *testing.T) {
+	sql := "/*+ {\"rewrites\": {\"db5.t5\": \"select 1\"}} */ insert into db5.t5 (select * from db5.t5)"
+	stmts, err := parseAndApply(t, sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	ins, ok := stmts[0].(*tree.Insert)
+	require.True(t, ok)
+	require.NotNil(t, ins.Rows)
+	ps, ok := ins.Rows.Select.(*tree.ParenSelect)
+	require.True(t, ok)
+	require.NotNil(t, ps.Select)
+	require.NotNil(t, ps.Select.RewriteOption)
+	require.Contains(t, ps.Select.RewriteOption.Rewrites, "db5.t5")
+}
+
+func TestAddRewriteHints_InsertSelect_ON_DUPLICATE_KEY(t *testing.T) {
+	sql := "/*+ {\"rewrites\": {\"db6.t6\": \"select 1\"}} */ insert into db6.t6 select * from db6.t6 on duplicate key update a=1"
+	stmts, err := parseAndApply(t, sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	ins, ok := stmts[0].(*tree.Insert)
+	require.True(t, ok)
+	require.NotNil(t, ins.Rows)
+	require.NotNil(t, ins.Rows.RewriteOption)
+	require.Contains(t, ins.Rows.RewriteOption.Rewrites, "db6.t6")
+}
+
+func TestAddRewriteHints_InsertSelect_WithCTE(t *testing.T) {
+	sql := "/*+ {\"rewrites\": {\"db7.t7\": \"select 1\"}} */ with cte as (select 1) insert into db7.t7 select * from cte"
+	stmts, err := parseAndApply(t, sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	ins, ok := stmts[0].(*tree.Insert)
+	require.True(t, ok)
+	require.NotNil(t, ins.Rows)
+	require.NotNil(t, ins.Rows.RewriteOption)
+	require.Contains(t, ins.Rows.RewriteOption.Rewrites, "db7.t7")
 }
 
 func TestAddRewriteHints_NoJsonObjectHint_IsIgnored(t *testing.T) {

--- a/test/distributed/cases/dml/select/remap_hint.result
+++ b/test/distributed/cases/dml/select/remap_hint.result
@@ -7,42 +7,42 @@ create table db2.t1 (a int, b int, c int);
 insert into db2.t1 values(1, 2, 3), (4, 5, 6), (7, 8, 9);
 use db1;
 /*+ { "rewrites" : { "db1.t1": "select a from db1.t1" } } */ Select * from t1;
-a
-1
-4
+➤ a[4,32,0]  𝄀
+1  𝄀
+4  𝄀
 7
 /*+ { "rewrites" : { "db1.t1": "select sum(a) as sb from db1.t1" } } */ Select l.sb from db1.t1 as l;
-sb
+➤ sb[-5,64,0]  𝄀
 12
 /*+ { "rewrites" : { "db1.t1": "select a from db1.t1" } } */ Select * from db1.t1;
-a
-1
-4
+➤ a[4,32,0]  𝄀
+1  𝄀
+4  𝄀
 7
 /*+ { "rewrites" : { "db2.t1": "select a from db2.t1" } } */ Select * from db1.t1;
-a    b    c
-1    2    3
-4    5    6
-7    8    9
+➤ a[4,32,0]  ¦  b[4,32,0]  ¦  c[4,32,0]  𝄀
+1  ¦  2  ¦  3  𝄀
+4  ¦  5  ¦  6  𝄀
+7  ¦  8  ¦  9
 /*+ { "rewrites" : { "db1.t1": "select a from db1.t1" } } */ Select db1.t1.c from db1.t1;
 invalid input: column 'db1.t1.c' does not exist
 /*+ { "rewrites" : { "db1.t1": "select a from db1.t1" } } */ Select db1.t1.a from db1.t1;
-a
-1
-4
+➤ a[4,32,0]  𝄀
+1  𝄀
+4  𝄀
 7
 /*+ {"rewrites": {"db1.t1":"(select a,b from db1.t1 where a>1)","db2.t1":"(select a,c from db2.t1 where c<9)"}} */ select l.a,r.c from db1.t1 l join db2.t1 r on l.a=r.a;
-a    c
-4    6
+➤ a[4,32,0]  ¦  c[4,32,0]  𝄀
+4  ¦  6
 /*+ {"rewrites": {"db1.t1":"(select a,b*10 as b,c from db1.t1)","db2.t1":"(select a,b,c from db2.t1)"}} */ select l.a,l.b,r.c from db1.t1 l join db2.t1 r on l.a=r.a;
-a    b    c
-1    20    3
-4    50    6
-7    80    9
+➤ a[4,32,0]  ¦  b[-5,64,0]  ¦  c[4,32,0]  𝄀
+1  ¦  20  ¦  3  𝄀
+4  ¦  50  ¦  6  𝄀
+7  ¦  80  ¦  9
 /*+ {"rewrites": {"db1.t1":"(select a from db1.t1 where a<=4)","db2.t1":"(select a,b from db2.t1)"}} */ select l.a,r.b from db1.t1 l left join db2.t1 r on l.a=r.a where r.b is not null;
-a    b
-1    2
-4    5
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+1  ¦  2  𝄀
+4  ¦  5
 drop database if exists db1;
 drop database if exists db2;
 create database if not exists hint_test;
@@ -51,24 +51,52 @@ drop table if exists sales;
 create table sales (sale_id int primary key, product_id int, quantity int, sale_date date);
 insert into sales values (1, 1, 10, '2025-01-01'), (2, 1, 15, '2025-01-02'), (3, 2, 20, '2025-01-01'), (4, 2, 25, '2025-01-03'), (5, 3, 30, '2025-01-02');
 /*+ { "rewrites": { "hint_test.sales_summary": "SELECT product_id, SUM(quantity) as total_quantity, COUNT(*) as sale_count FROM sales GROUP BY product_id" } } */ select * from hint_test.sales_summary where total_quantity > 20;
-product_id    total_quantity    sale_count
-1    25    2
-2    45    2
-3    30    1
+➤ product_id[4,32,0]  ¦  total_quantity[-5,64,0]  ¦  sale_count[-5,64,0]  𝄀
+1  ¦  25  ¦  2  𝄀
+2  ¦  45  ¦  2  𝄀
+3  ¦  30  ¦  1
 drop table if exists users;
 create table users (id int primary key, name varchar(50), age int, city varchar(50));
 insert into users values (1, 'Alice', 25, 'Beijing'), (2, 'Bob', 30, 'Shanghai'), (3, 'Charlie', 35, 'Guangzhou'), (4, 'David', 28, 'Shenzhen');
 drop view if exists active_users;
 create view active_users as select id, name, age, city from users where age between 25 and 35;
 /*+ { "rewrites": { "hint_test.user_list": "SELECT * FROM active_users" } } */ select * from user_list where city = 'Shanghai';
-id    name    age    city
-2    Bob    30    Shanghai
+➤ id[4,32,0]  ¦  name[12,-1,0]  ¦  age[4,32,0]  ¦  city[12,-1,0]  𝄀
+2  ¦  Bob  ¦  30  ¦  Shanghai
 drop table if exists transactions;
 create table transactions (trans_id int, user_id int, amount decimal(10,2), trans_date date, trans_type varchar(20));
 insert into transactions values (1, 1, 100.00, '2024-01-01', 'purchase'), (2, 1, 200.00, '2024-01-01', 'purchase'), (3, 2, 50.00, '2024-01-01', 'refund'), (4, 2, 300.00, '2024-01-02', 'purchase'), (5, 3, 150.00, '2024-01-02', 'purchase'), (6, 1, 75.00, '2024-01-03', 'refund');
 /*+ { "rewrites": { "hint_test.daily_summary": "SELECT trans_date, trans_type, COUNT(*) as trans_count, SUM(amount) as total_amount FROM transactions GROUP BY trans_date, trans_type" } } */ select trans_date, trans_type, total_amount from daily_summary where trans_type = 'purchase' order by trans_date;
-trans_date    trans_type    total_amount
-2024-01-01    purchase    300.00
-2024-01-02    purchase    450.00
+➤ trans_date[91,64,0]  ¦  trans_type[12,-1,0]  ¦  total_amount[3,38,2]  𝄀
+2024-01-01  ¦  purchase  ¦  300.00  𝄀
+2024-01-02  ¦  purchase  ¦  450.00
 drop database if exists hint_test;
+create database issue25186;
+use issue25186;
+create table src (a int, b int);
+create table dst (a int, b int);
+insert into src values (1, 100), (2, 200), (3, 300);
+/*+ { "rewrites": { "issue25186.src": "select a, b from issue25186.src where a > 1" } } */
+insert into dst select * from src;
+select * from dst order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+2  ¦  200  𝄀
+3  ¦  300
+drop table if exists dst2;
+create table dst2 (a int);
+/*+ { "rewrites": { "issue25186.src": "select a from issue25186.src where a = 3" } } */
+insert into dst2 select * from src;
+select * from dst2 order by a;
+➤ a[4,32,0]  𝄀
+3
+drop table if exists dst3;
+create table dst3 (a int primary key, b int);
+insert into dst3 values (2, 0);
+/*+ { "rewrites": { "issue25186.src": "select a, b from issue25186.src where a >= 2" } } */
+insert into dst3 select * from src on duplicate key update b = values(b);
+select * from dst3 order by a;
+➤ a[4,32,0]  ¦  b[4,32,0]  𝄀
+2  ¦  200  𝄀
+3  ¦  300
+drop database issue25186;
 set enable_remap_hint = 0;

--- a/test/distributed/cases/dml/select/remap_hint.sql
+++ b/test/distributed/cases/dml/select/remap_hint.sql
@@ -34,4 +34,31 @@ create table transactions (trans_id int, user_id int, amount decimal(10,2), tran
 insert into transactions values (1, 1, 100.00, '2024-01-01', 'purchase'), (2, 1, 200.00, '2024-01-01', 'purchase'), (3, 2, 50.00, '2024-01-01', 'refund'), (4, 2, 300.00, '2024-01-02', 'purchase'), (5, 3, 150.00, '2024-01-02', 'purchase'), (6, 1, 75.00, '2024-01-03', 'refund');
 /*+ { "rewrites": { "hint_test.daily_summary": "SELECT trans_date, trans_type, COUNT(*) as trans_count, SUM(amount) as total_amount FROM transactions GROUP BY trans_date, trans_type" } } */ select trans_date, trans_type, total_amount from daily_summary where trans_type = 'purchase' order by trans_date;
 drop database if exists hint_test;
+
+-- issue #25186: INSERT...SELECT with rewrite hint — basic filter
+create database issue25186;
+use issue25186;
+create table src (a int, b int);
+create table dst (a int, b int);
+insert into src values (1, 100), (2, 200), (3, 300);
+/*+ { "rewrites": { "issue25186.src": "select a, b from issue25186.src where a > 1" } } */
+insert into dst select * from src;
+select * from dst order by a;
+
+-- issue #25186: INSERT...SELECT with rewrite — column subset
+drop table if exists dst2;
+create table dst2 (a int);
+/*+ { "rewrites": { "issue25186.src": "select a from issue25186.src where a = 3" } } */
+insert into dst2 select * from src;
+select * from dst2 order by a;
+
+-- issue #25186: INSERT...ON DUPLICATE KEY UPDATE with rewrite
+drop table if exists dst3;
+create table dst3 (a int primary key, b int);
+insert into dst3 values (2, 0);
+/*+ { "rewrites": { "issue25186.src": "select a, b from issue25186.src where a >= 2" } } */
+insert into dst3 select * from src on duplicate key update b = values(b);
+select * from dst3 order by a;
+
+drop database issue25186;
 set enable_remap_hint = 0;


### PR DESCRIPTION
## What type of PR is this?

- [x] BUG

## Which issue(s) this PR fixes:

issue #25186

## What this PR does / why we need it:

INSERT...SELECT ignores query rewrite hints. Cherry-pick of #25310 to 4.1-dev.

Two changes in `AddRewriteHints`: add `*tree.Insert` to pass-through and attachment switches. RewriteOption flows to the inner SELECT via stmt.Rows.

| File | Change |
|------|--------|
| `pkg/sql/parsers/sqlparse.go` | +6 lines |
| `pkg/sql/parsers/sqlparse_test.go` | +60 lines |
| `test/.../remap_hint.sql` | +26 lines |
| `test/.../remap_hint.result` | regenerated |

🤖 Generated with [Claude Code](https://claude.com/claude-code)