### PR TITLE
feat: mo-dev GPU/index-plugin guidance + mo-self-review skill

### DIFF
--- a/.agents/skills/mo-dev/SKILL.md
+++ b/.agents/skills/mo-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mo-dev
-description: MatrixOne database kernel development - CGo build/test environment setup, operator lifecycle contracts (Call/Reset), pipeline protocol, layered testing strategy. Use when modifying colexec operators, process signal types, compile pipeline construction, or debugging CGo link errors (undefined symbols, missing headers, library not found).
+description: MatrixOne database kernel development - CGo build/test environment setup, GPU builds (MO_CL_CUDA=1 / cuVS), operator lifecycle contracts (Call/Reset), pipeline protocol, layered testing strategy, and the vector/fulltext index-plugin framework (pkg/indexplugin AlgoPlugin registry). Use when modifying colexec operators, process signal types, compile pipeline construction, adding or editing an index algorithm (HNSW/IVFFLAT/IVF-PQ/CAGRA/fulltext), or debugging CGo link errors (undefined symbols, missing headers, library not found).
 compatibility: Designed for Codex CLI and compatible agents. Requires Go 1.22+, GNU Make, C/C++ toolchain (gcc/clang), and pre-built thirdparties.
 metadata:
   project: matrixone
@@ -11,13 +11,16 @@ metadata:
 
 ## Enforcement Gates
 
-This skill gates four decision points. Consult the corresponding section before acting:
+This skill gates seven decision points. Consult the corresponding section before acting:
 
 | Gate | When | Action |
 |------|------|--------|
 | **G-MODIFY** | Before editing any `colexec` operator or `process` signal type | Read §3 (operator contract) + §7 (forbidden patterns) |
 | **G-CGO-ERR** | Any build/test returns `file not found`, `Undefined symbols`/`undefined symbol:`, or `dyld:`/`error while loading shared libraries:` | Read §2.2 (symptom table) + §2.4 (stash protocol) |
-| **G-DONE** | Before declaring "done"/"complete"/"passes" | Read §4.3 (completion gate) — all 5 boxes MUST be checked |
+| **G-GPU** | Before a GPU build/test (`MO_CL_CUDA=1`), or on CUDA/cuVS errors (`CONDA_PREFIX`, `nvcc`, `-lcuvs`/`-lcudart`, `unsupported index type: ivfpq\|cagra`) | Read §2.5 (GPU build) |
+| **G-IDXPLUGIN** | Before adding/editing an index-algorithm plugin, OR adding any `switch`/`if` that branches on an index **algo** name (`IsIvfIndexAlgo`, `== "ivfpq"`, `KeyType`, …) in `pkg/sql/{compile,plan}` or `pkg/catalog` | Read §8 (index-plugin framework) — route through the registry; new algo switches are forbidden |
+| **G-IDXREVIEW** | When **reviewing** a diff (yours or `/code-review`) that touches index-algorithm dispatch, any `pkg/vectorindex/<algo>/plugin/` / `pkg/fulltext/plugin`, or `pkg/indexplugin` | Read §9 (index-plugin review checklist) — run each grep before approving |
+| **G-DONE** | Before declaring "done"/"complete"/"passes" | Read §4.2 (completion gate) — all 5 boxes MUST be checked |
 | **G-TEST-FAIL** | `go test` returns non-zero or hangs >10s | Read §5 (diagnosis) + §2.4 (stash protocol) before attributing cause |
 
 ---
@@ -189,6 +192,54 @@ go test -v -count=1 -timeout 120s ./pkg/target/...
 git stash pop
 ```
 
+### 2.5 GPU Build (`MO_CL_CUDA=1`) — cuVS / CUDA
+
+GPU support compiles the CUDA-backed vector index algorithms (**CAGRA**, **IVF-PQ**) into `libmo` and turns on the `gpu` Go build tag. **Linux x86_64 only** — the macOS `Makefile` branch (`Makefile:234-236`) carries no CUDA flags, so **macOS builds are always CPU-only**. Do not try to enable it on Darwin.
+
+**Prerequisites (one-time):**
+1. CUDA toolkit 12.0 / 13.0+ installed under `/usr/local/cuda`.
+2. cuVS Go bindings installed via conda (`rapidsai/cuvs`), then the env **activated** so `CONDA_PREFIX` is exported:
+   ```bash
+   conda env create --name go -f conda/environments/go_cuda-130_arch-$(uname -m).yaml
+   conda activate go     # exports CONDA_PREFIX — every GPU build/test hard-errors without it
+   ```
+
+**Build:**
+```bash
+MO_CL_CUDA=1 make -j8
+```
+
+**What `MO_CL_CUDA=1` flips** (vs. the default CPU build):
+
+| Layer | CPU build | GPU build (`MO_CL_CUDA=1`) |
+|-------|-----------|----------------------------|
+| Go build tag | none | `-tags gpu` (`Makefile:224`) — registers CAGRA + IVF-PQ, compiles `*_gpu.go` |
+| `cgo/` compiler | `gcc`/`clang` | `/usr/local/cuda/bin/nvcc` (`cgo/Makefile:31`, multi-arch `sm_75…sm_90`) |
+| `libmo` objects | C objects only | + `cuda/*.o` + `cuvs/*.o` |
+| Link flags | `-lusearch_c -lroaring` | + `-lcuvs -lcuvs_c -lcudart -lcuda -lrmm -lstdc++` |
+| Header/lib roots | thirdparties only | + `$CONDA_PREFIX/{include,lib}`, `/usr/local/cuda/...` |
+
+**Guardrails baked into the Makefiles:**
+- **`CONDA_PREFIX env variable not found`** → conda env not activated. Run `conda activate <env>` first. Both `Makefile:217` and `cgo/Makefile:28` hard-error on this — it is *not* a code bug.
+- **`libmo` is re-linked on every GPU build** (`cgo/Makefile` order-only `cuda_objs`/`cuvs_objs` prereqs). Deliberate: `mo-service` loads `libmo.so` **dynamically**, so a stale `.so` silently runs old C++ (hours of "my fix didn't take"). The old `rm -f cgo/libmo.so cgo/libmo.a` workaround is no longer needed.
+
+**The `gpu` tag gates index-plugin registration — memorize this.** CAGRA and IVF-PQ register **only** under `//go:build gpu` (`pkg/indexplugin/all/all_gpu.go`). On a CPU binary their plugins are absent from the registry, so `CREATE INDEX … USING ivfpq|cagra` fails cleanly at plan-build with `unsupported index type: <algo>` — **before** any hidden table is created. This is intentional. Do **not** "fix" it by moving those imports into `all.go` (see §8.6).
+
+**Prerequisite — the linked `libmo` must itself be GPU-built:** run `MO_CL_CUDA=1 make -j8 cgo` first. A CPU `libmo` lacks the `cuda/`+`cuvs/` objects, so `gpu`-tagged Go (which cgo-includes `cgo/cuvs/*.h` via `pkg/cuvs`) fails to link with undefined `cuvs_*` / `cuda*` symbols — this is a *stale-library* error, not a flag error, so re-check §2.2 before chasing `CGO_LDFLAGS`.
+
+**GPU tests** — add `-tags gpu` plus the CUDA search paths (mirror the Makefile's `CUDA_CFLAGS`/`CUDA_LDFLAGS`, `Makefile:220-223`); Linux only:
+```bash
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include -I$CONDA_PREFIX/include -I/usr/local/cuda/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c -L$CONDA_PREFIX/lib -lcuvs -lcuvs_c" \
+LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib:$CONDA_PREFIX/lib:/usr/local/cuda/lib64" \
+go test -tags gpu \
+  -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib -fopenmp'" \
+  -v -count=1 -timeout 300s ./pkg/vectorindex/ivfpq/...
+```
+The **authoritative** flag source is the `Makefile` (`CUDA_CFLAGS`/`CUDA_LDFLAGS`), not this snippet — if a GPU link error appears, diff your flags against those lines.
+
+**Tag-split test files are a trap:** `*_gpu.go` / `//go:build gpu` tests (e.g. `pkg/vectorindex/ivfpq/search_test.go`, `model_test.go`) compile **only** under `-tags gpu`. A plain `go test ./pkg/vectorindex/ivfpq/...` runs the `//go:build !gpu` / `*_cpu.go` stubs instead. **"CPU tests pass" ≠ "GPU path tested."**
+
 ---
 
 ## 3. Operator Lifecycle Contracts
@@ -287,3 +338,265 @@ When sending terminal signals into a bounded channel, the send may fail because 
 4. **Never declare done without fresh test output.** All 5 completion gate boxes must be checked.
 5. **Never assume `go build` success means `go test` will pass.** Build only compiles packages; test compiles AND links test binaries.
 6. **Never skip bottom-up testing.** Start with pure Go packages, then CGo-transitive, then CGo-direct.
+7. **Never add a per-algorithm `switch`/`if` on an index algo name in the SQL layer.** Route through `indexplugin.Get(algo)` — see §8.
+
+---
+
+## 8. Vector / Fulltext Index-Plugin Framework
+
+### 8.1 Why this exists (and what NOT to undo)
+
+Adding a vector index used to mean editing 8+ files across `pkg/sql/compile`,
+`pkg/sql/plan`, `pkg/catalog`, and `pkg/vectorindex`, wired through ~6
+switch/if-chain seams. Miss one seam → the algorithm silently misbehaves. The
+`pkg/indexplugin` framework collapses those seams into **one registry lookup**:
+an algorithm registers **one** `AlgoPlugin`, and the compiler enforces every
+required hook exists.
+
+**The guarded failure mode:** a change that re-introduces a per-algorithm
+`switch algo` / `if IsXxxIndexAlgo || …` in the SQL layer, or otherwise bypasses
+the registry, quietly re-opens the "forgot a seam" bug class. Work **through**
+the framework — do not route around it.
+
+### 8.2 Architecture
+
+`pkg/indexplugin` is the framework. It must **not** import `pkg/sql/{compile,plan}`;
+hook methods receive narrow `Context` interfaces the SQL layer satisfies.
+
+```
+pkg/indexplugin/
+├── plugin.go          -- AlgoPlugin interface; Register/Get/All; IsVectorIndexAlgo/IsFullTextIndexAlgo/IsPluginAlgo
+├── catalog/hooks.go   -- catalog.Hooks   (metadata: params, hidden tables, op/vector/pk types, quantization)
+├── compile/hooks.go   -- compile.Hooks   (DDL execution: create/reindex/drop/restore) + CompileContext
+├── plan/hooks.go      -- plan.Hooks      (schema defs + tablefunc + thin ANN redirects) + PlanBuilder/CompilerContext
+├── idxcron/hooks.go   -- idxcron.Hooks   (scheduled-rebuild gating: Updatable)
+└── all/
+    ├── all.go         -- blank-imports CPU-safe plugins (fulltext, hnsw, ivfflat)
+    └── all_gpu.go     -- //go:build gpu — blank-imports GPU-only plugins (cagra, ivfpq)
+
+pkg/vectorindex/<algo>/plugin/   -- one dir per algorithm; assembles the hooks into an AlgoPlugin
+pkg/fulltext/plugin/             -- fulltext is a plugin too (kind = fulltext, not vector)
+```
+
+**Dispatch flow** — every SQL-layer site that used to `switch algo` now does:
+
+```go
+p, ok := indexplugin.Get(algo)      // case-insensitive, trims whitespace
+if ok { return p.Compile().HandleCreateIndex(cctx, defs) }
+```
+
+`indexplugin.IsVectorIndexAlgo(algo)` replaces the
+`IsIvfIndexAlgo || IsHnswIndexAlgo || IsCagraIndexAlgo || IsIvfpqIndexAlgo`
+chain. Use `IsFullTextIndexAlgo` for fulltext, `IsPluginAlgo` for "registered at
+all (vector OR fulltext)". Live dispatch sites already exist in
+`pkg/sql/plan/build_ddl.go` (`indexplugin.Get(...KeyType.ToString())` →
+`unsupported index type: %s`) and `pkg/sql/plan/apply_indices.go`
+(`p.Plan().CanApply`).
+
+### 8.3 Registry contract — the compiler is the safety net
+
+```go
+// pkg/indexplugin/plugin.go
+type AlgoPlugin interface {
+    Algo() string                       // must == catalog.MoIndex<X>Algo.ToString() (lower-cased)
+    Catalog() catalogplugin.Hooks
+    Compile() compileplugin.Hooks
+    Plan()    planplugin.Hooks
+    Idxcron() idxcronplugin.Hooks
+}
+func Register(p AlgoPlugin)              // panics on duplicate Algo(); call from init()
+func Get(algo string) (AlgoPlugin, bool)
+```
+
+Each plugin keeps compile-time interface assertions:
+
+```go
+var _ plugin.AlgoPlugin = (*Plugin)(nil)   // in <algo>/plugin/plugin.go
+var _ Hooks = Hooks{}                        // in each hooks sub-package impl
+```
+
+If `AlgoPlugin` or a `Hooks` interface gains a method and a plugin isn't updated,
+these lines **stop the build**. That compile error *is* the "did I miss a seam?"
+answer. **Never delete or `//nolint` these assertions to green a build** —
+implement the missing method.
+
+### 8.4 Plugin package layout (canonical: IVF-PQ)
+
+`pkg/vectorindex/ivfpq/plugin/plugin.go` is the **authoritative walkthrough** —
+read its package doc before adding an algorithm. A full plugin (see
+`pkg/vectorindex/ivfflat/plugin/`) is:
+
+```
+pkg/vectorindex/<algo>/plugin/
+├── plugin.go            -- assembles the 4 Hooks into one Plugin; init() { plugin.Register(New()) }
+├── runtime/runtime.go   -- catalog.Hooks impl  (algorithm metadata constants)
+├── compile/compile.go   -- compile.Hooks impl  (CREATE/ALTER/DROP/REINDEX execution)
+├── plan/
+│   ├── plan.go          -- plan.Hooks: thin ApplyForSort/CanApply redirect (~10 LoC) into *plan.QueryBuilder
+│   ├── schema.go        -- BuildSecondaryIndexDefs body (hidden-table TableDefs + IndexDefs)
+│   └── tablefunc.go     -- <algo>_create / <algo>_search FUNCTION_SCAN builder registrations
+├── idxcron/idxcron.go   -- idxcron.Hooks impl  (Updatable: scheduled-rebuild gating)
+└── iscp/iscp.go         -- CDC / import sync (may be //go:build gpu for GPU algos)
+```
+
+**Which sub-package gets lifted code:** from `pkg/sql/compile/*.go` → `compile/`;
+from `pkg/sql/plan/*.go` → `plan/`; algorithm-metadata constants → `runtime/`
+(lifted code goes in the sub-package matching `pkg/sql/<layer>` of the call site).
+
+### 8.5 Adding a new algorithm — steps
+
+Follow `pkg/vectorindex/ivfpq/plugin/plugin.go`'s doc. Summary:
+
+1. **Catalog constants.** Add `MoIndex<X>Algo` in
+   `pkg/catalog/secondary_index_utils.go`; hidden-table-type constants in
+   `pkg/catalog/types.go` (one per hidden table). A `tree.INDEX_TYPE_<X>` parser
+   keyword only if it needs new CREATE INDEX syntax.
+2. **Copy** `pkg/vectorindex/ivfpq/plugin/` → `pkg/vectorindex/<x>/plugin/`;
+   rename packages/imports.
+3. **Implement the four Hooks** (let the `var _ Hooks = …` assertions tell you
+   what's missing):
+   - `catalog.Hooks` — `HiddenTableTypes`, `ParamsFromTree`, `DefaultOptions`,
+     `SupportedOpTypes`, `SupportedVectorTypes`, `SupportedPrimaryKeyTypes`,
+     `SupportedIncludeColumnTypes`, `ValidQuantization`, `ExperimentalFlag`,
+     `AlterTableCloneBehavior`, `RestoreBehavior`, `BuildSessionVars`,
+     `ShouldTruncateHiddenTable`, `SyncDescriptor`.
+   - `compile.Hooks` — `HandleCreateIndex`, `HandleReindex`,
+     `ValidateReindexParams`, `HandleDropIndex`, `RestoreInitSQL`,
+     `IdxcronMetadata`.
+   - `plan.Hooks` — `BuildSecondaryIndexDefs`, `BuildFullTextIndexDefs`,
+     `CanApply`, `ApplyForSort`.
+   - `idxcron.Hooks` — `Updatable` (return "always yes" if the algo has no
+     minimum-size / cadence constraint).
+4. **ANN rewrite body** (only if the algo supports `ORDER BY <distfn>(col,v)
+   LIMIT k`): add `applyIndicesForSortUsing<X>` + `prepare<X>IndexContext` in
+   `pkg/sql/plan/apply_indices_<x>.go`, redirect methods on `*QueryBuilder` in
+   `pkg/sql/plan/plugin_builder.go`, and the dispatch case in
+   `pkg/sql/plan/apply_indices.go` (which calls `p.Plan().CanApply`).
+5. **Register:** `init()` in `plugin.go` calls `plugin.Register(New())`. Add
+   **one** blank-import line to `pkg/indexplugin/all/all.go` — **or**
+   `all_gpu.go` if GPU-only (§8.6). That aggregator is the *only* wiring edit;
+   `pkg/sql/plan` and `pkg/sql/compile` already blank-import `.../all`.
+6. **SQL test** under `test/distributed/cases/vector/` exercising CREATE INDEX,
+   `ORDER BY <distfn>(col,v) LIMIT k`, ALTER REINDEX, DROP INDEX, DROP TABLE.
+
+> If the plugin compiles and every hook is implemented, you did **not** miss a
+> dispatch site. Do not add manual dispatch "to be safe."
+
+### 8.6 CPU vs GPU registration (ties to §2.5)
+
+| File | Build tag | Registers | Rationale |
+|------|-----------|-----------|-----------|
+| `pkg/indexplugin/all/all.go` | (none) | fulltext, hnsw, ivfflat | CPU-safe algorithms |
+| `pkg/indexplugin/all/all_gpu.go` | `//go:build gpu` | cagra, ivfpq | CUDA-backed table functions exist only under `gpu` |
+
+CAGRA / IVF-PQ have `cagra_create` / `ivfpq_create` table functions implemented
+**only** under `//go:build gpu`. Registering them on a CPU binary would let
+`CREATE INDEX … USING cagra|ivfpq` proceed until the BUILD SQL fails mid-flight —
+after hidden tables are created and DELETEs run. Gating registration behind the
+`gpu` tag makes plan-build return `unsupported index type: <algo>` **before any
+DDL side effect**. The `gpu` tag is enabled by `MO_CL_CUDA=1 make` (§2.5).
+
+**Pairing rule:** an algo with `build_gpu.go` (`//go:build gpu`) must have a
+`//go:build !gpu` CPU counterpart (`*_cpu.go` stub) so the package still compiles
+on CPU, *and* its plugin blank-import belongs in `all_gpu.go`, never `all.go`.
+
+### 8.7 Forbidden patterns (index-plugin)
+
+1. **Never re-introduce per-algorithm dispatch in the SQL layer.** A new
+   `switch idx.IndexAlgo`, `if catalog.IsIvfIndexAlgo(a) || …`, or `case
+   MoIndex<X>Algo:` in `pkg/sql/{compile,plan}` / `pkg/catalog` re-opens the bug
+   class the framework closed. Need a new per-algo decision? Add a **method to
+   the relevant `Hooks` interface** (compiler forces every algo to answer) — not
+   a switch.
+2. **Never import `pkg/sql/plan` or `pkg/sql/compile` from a plugin package.**
+   Those packages blank-import the plugins for `init()` registration → an import
+   cycle. Plugins receive `compile.CompileContext` / `plan.PlanBuilder` /
+   `plan.CompilerContext` and call *through* them. `plan/` bodies that need
+   `*QueryBuilder` internals live in `pkg/sql/plan/apply_indices_<x>.go`, reached
+   via the thin redirect (§8.5 step 4).
+3. **Never register a GPU-only algo in `all.go`** — use `all_gpu.go` (§8.6).
+4. **Never weaken the `var _ AlgoPlugin` / `var _ Hooks` assertions** to green a
+   build. Implement the missing method.
+5. **Keep runtime out of the plugin.** The plugin owns compile + plan + catalog +
+   idxcron metadata only. Real build/search kernels stay in
+   `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go`, invoked from
+   `pkg/sql/colexec/table_function/<algo>_*.go`. Do not copy kernel logic in.
+6. **Never pollute `pkg/indexplugin` with algorithm-specific code — it is
+   interfaces + metadata only.** The framework package holds only the interfaces
+   (`AlgoPlugin`, the `Hooks` + `Context` interfaces), the registry, and
+   *algorithm-agnostic* shared helpers/metadata (e.g. `AlgoParamInt`,
+   `IdxcronVarSpec` / `BuildIdxcronMetadata` — generic, zero algo branching).
+   Every concrete hook body and per-algo constant lives in
+   `pkg/vectorindex/<algo>/plugin/` (or `pkg/fulltext/plugin/`). Do **not** add a
+   `switch algo` / `if IsXxxIndexAlgo`, a concrete `Hooks` implementation, or any
+   algorithm-named symbol under `pkg/indexplugin/*`. The *only* files there that
+   may name a concrete algorithm are the `all/` and `iscp/` aggregators — and
+   only as blank imports.
+
+### 8.8 Testing & completion (index-plugin)
+
+Index-plugin changes have a **coverage trap**: the end-to-end BVT cases under
+`test/distributed/cases/vector/` are GPU-gated (skipped in non-GPU CI), so
+`plan.go` / `schema.go` read **0% coverage** and fail the 0.75 gate unless you
+add CPU-runnable unit tests (tablefunc_test / runtime_test style — see
+`pkg/vectorindex/ivfflat/plugin/{runtime,idxcron}/*_test.go`). On top of the §4.2
+completion gate:
+
+```
+□ CPU unit tests exist for plan/schema/runtime hooks (not just GPU-gated BVT)  → run, exit 0
+□ GPU-only hooks also run with `-tags gpu` per §2.5                            → exit 0
+□ grep: NO new `switch algo` / `IsXxxIndexAlgo ||` added in pkg/sql/*
+□ git diff --stat: the ONLY all.go/all_gpu.go edit is one blank import
+```
+
+**Known in-progress seams — do not add NEW ones.** A few DML-sync sites still
+call `catalog.IsIvfIndexAlgo` directly (`pkg/sql/plan/build_dml_util.go`,
+`pkg/sql/plan/bind_insert.go`) — the IVFFLAT-hardcoded resolution is mid-migration
+into `plan.Hooks`. These are **legacy**, not a license to add more. When you
+touch one, prefer moving it behind a hook; never model a *new* algorithm on them.
+
+---
+
+## 9. Reviewing an index-plugin change (G-IDXREVIEW)
+
+Apply this when reviewing a diff — your own before "done", or via `/code-review`
+— that touches index-algorithm dispatch, any `pkg/vectorindex/<algo>/plugin/`,
+`pkg/fulltext/plugin`, or `pkg/indexplugin`. Each item maps to a §8.7 forbidden
+pattern; the grep is the fast check. **Request changes if any check fails**, and
+cite the §8.7 rule number in the finding.
+
+1. **No new per-algo dispatch** (§8.7 #1). The diff adds no `switch …IndexAlgo`,
+   `case MoIndex<X>Algo:`, or `IsIvfIndexAlgo || …` in `pkg/sql/{compile,plan}` /
+   `pkg/catalog`. Legacy holdouts (`build_dml_util.go`, `bind_insert.go`) may
+   remain — but **no new ones**.
+   ```bash
+   git diff -U0 pkg/sql pkg/catalog | grep -E '^\+' \
+     | grep -E 'IsIvfIndexAlgo|IsHnswIndexAlgo|IsCagraIndexAlgo|IsIvfpqIndexAlgo|IndexAlgo *==|case .*Algo\b'
+   ```
+2. **No import cycle** (§8.7 #2). No plugin sub-package imports `pkg/sql/plan` or
+   `pkg/sql/compile`.
+   ```bash
+   git diff pkg/vectorindex/*/plugin pkg/fulltext/plugin \
+     | grep -E '^\+.*matrixorigin/matrixone/pkg/sql/(plan|compile)"'   # expect empty
+   ```
+3. **`indexplugin` not polluted** (§8.7 #6). No file under `pkg/indexplugin/`
+   (except `all/`, `iscp/`) imports a concrete algo package or gains
+   algorithm-named / `switch algo` code.
+   ```bash
+   git diff pkg/indexplugin \
+     | grep -E '^\+.*(vectorindex/(ivfflat|ivfpq|cagra|hnsw)/plugin|fulltext/plugin)'  # only all*.go / iscp allowed
+   ```
+4. **GPU registration correct** (§8.6, §8.7 #3). A GPU-only algo's blank import is
+   in `all_gpu.go` (`//go:build gpu`), not `all.go`; each `build_gpu.go` has a
+   `//go:build !gpu` CPU counterpart.
+5. **Assertions intact** (§8.7 #4). The diff does not delete / comment /
+   `//nolint` any `var _ AlgoPlugin` or `var _ Hooks` line.
+   ```bash
+   git diff | grep -E '^-.*var _ (plugin\.)?(AlgoPlugin|Hooks)'   # expect empty
+   ```
+6. **Runtime kept out** (§8.7 #5). No build/search kernel logic copied into the
+   plugin; it still calls `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go`.
+7. **New-algo completeness** (§8.5, §8.8). If a new algorithm: blank-imported in
+   `all/` or `all_gpu/`, has an SQL case under `test/distributed/cases/vector/`,
+   and CPU unit tests cover the plan/schema/runtime hooks (not just GPU-gated
+   BVT).

--- a/.agents/skills/mo-self-review/SKILL.md
+++ b/.agents/skills/mo-self-review/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: mo-self-review
+description: Pre-push self-review gate for MatrixOne changes — a systematic, multi-angle, first-principles review of your OWN diff with complete functional-closure investigation and unhappy-path coverage, calibrated to the merge bar. Run BEFORE pushing / opening / updating a PR so the human or bot PR review finds nothing new — breaking the review→modify loop. Use before declaring a change "done", before push, or when a PR keeps drawing new review rounds. Complements unhappy-path-audit (Q1–Q3 depth) and /code-review.
+compatibility: Designed for Codex CLI and compatible agents. Requires a git working tree with a diff vs the base branch and the unhappy-path-audit skill (for Q1-Q3 depth).
+metadata:
+  project: matrixone
+  repository: matrixorigin/matrixone
+  language: go
+---
+
+## Running this skill IS the review (don't retype the long prompt)
+
+Invoking this skill — `/mo-self-review [target]` or the Skill tool — **runs the
+whole gate for you**. First resolve the **target** from the args:
+
+| Args | Target to review |
+|------|------------------|
+| *(empty)* | current branch **vs `main`** |
+| a git ref / branch / tag / commit (e.g. `develop`, `origin/release-2.0`, `abc123`) | current branch **vs that ref** |
+| `vs <ref>` / `base=<ref>` | current branch **vs `<ref>`** |
+| all-digits (e.g. `25199`) | that **GitHub PR** |
+| anything else (e.g. `pkg/vectorindex focus on quantizer`) | scope/focus, still **vs `main`** |
+| `<ref> <scope…>` | **vs `<ref>`**, restricted to the trailing scope |
+| `docs` / `help` | just show §1–§8, run nothing |
+
+Then execute (do not shortcut):
+
+1. Launch the **code-review** workflow at **high** on the resolved target — state the
+   base you resolved ("this branch compared to `<base>`") — appending verbatim:
+   `多角度评审，第一性原则，系统性思考问题，涉及到的修改需要调研完整的功能闭环，unhappy path cover.`
+   Pass any scope/skip instructions through too.
+2. On results, apply **§3** (trace each finding's functional closure to its terminal
+   node; personally spot-check any *cluster of refutations* — a verifier can repeat
+   one wrong call) and **§5** (severity LAST, calibrated to the merge bar;
+   decision-log every won't-fix/known-gap with its reason; no finding without a
+   concrete failure).
+3. Present a converged, ranked findings list, each with a **fix-or-decision-log
+   recommendation** — not another review round.
+
+§1–§8 below are the methodology this executes; consult them when applying the
+discipline or running the gate manually. When this skill is surfaced only as
+background reference (not explicitly invoked), treat §1–§8 as guidance — do **not**
+auto-launch a workflow.
+
+---
+
+## Purpose — break the review → modify loop
+
+The review→modify→review loop repeats because each review pass is *incremental*:
+a new pass finds something the last one didn't (a fresh angle, a missed branch),
+and re-flags items already decided "won't fix." This gate front-loads **one
+exhaustive, calibrated self-review of your own diff** so the eventual PR review
+(human or bot) has **nothing new to add** → the loop ends.
+
+Run it on your working diff BEFORE `git push` / opening / updating a PR. It is a
+*gate*: it either passes (§7) or produces a fix/decision list — not an endless
+stream of nitpicks.
+
+---
+
+## Enforcement gate
+
+| Gate | When | Action |
+|------|------|--------|
+| **G-SELF-REVIEW** | Before `git push`, before opening/updating a PR, or before declaring a change "done" | Run §1–§4 over the full diff, apply §5 convergence discipline, then check the §7 exit gate. Do not push until it passes. |
+
+Scope = the complete diff vs the base branch (`git diff <base>...HEAD` + staged/unstaged), **not** just the last file you touched.
+
+---
+
+## 1. Multi-angle (多角度) — run each lens as a separate pass
+
+Do not spot-check. Sweep the whole diff once per lens; a defect invisible to one
+lens is obvious to another.
+
+| Lens | Ask |
+|------|-----|
+| **Correctness** | Does each changed function produce the right output for ordinary AND boundary inputs (0, 1, max, empty, nil, overflow)? |
+| **Concurrency** | Shared state touched by >1 goroutine? Races, lost wakeups, double-close, ordering assumptions? (`-race` the new tests.) |
+| **Resource lifecycle** | Every fd/goroutine/lock/alloc created on the change's paths — closed/released on **every** branch incl. error/panic? (→ §4 Q1) |
+| **Compatibility / boundary** | On-disk/wire format, config default, API signature, catalog metadata: does the change stay backward-compatible? New format opt-in, not a flipped default? Mismatch detected (fail-fast) not silently misread? |
+| **Failure modes** | Every error return handled; partial failure leaves consistent state; no silent fallback that hides corruption. |
+| **Contract / API** | Callers updated on both ends of a protocol change; interface impls complete (compile-time `var _` checks intact). |
+
+---
+
+## 2. First principles (第一性原则)
+
+**Prove it breaks — don't report "looks like it might."** For each candidate
+defect, state a concrete failure: *inputs/state → wrong output / crash / hang*.
+If you can't, exhaust every bypass path (defer, cancel watcher, timer, retry,
+guard) before ruling — then drop it. This is the single biggest source of
+review-loop noise: unproven "might" findings that get fixed, re-reviewed, and
+spawn more "might" findings.
+
+---
+
+## 3. Complete functional closure (功能闭环)
+
+For every change, trace the **entire loop it participates in**, not just the
+edited line — most missed-in-review defects live one hop away, in the *other
+half* of the closure. Trace to the terminal node.
+
+| Change kind | Closure to walk end-to-end |
+|-------------|----------------------------|
+| storage / on-disk format | create → write → **read** → backup → **restore** → upgrade → restart |
+| operator (colexec) | Prepare → Call → **Reset** → Cleanup (+ the error branch) |
+| index / CDC | CREATE (+ InitSQL) → sync → query → reindex → DROP |
+| resource handle | create → hand-off → … → **Destroy/Free/Close** (all holders) |
+| config / flag | parse → default-fill → consume → the *other* backend/mode that shares it |
+
+Rule: if you changed one arc of a closure, open and read the arcs that *consume*
+or *reverse* it (the reader for a writer, the restore for a backup, the Reset for
+a Call). A change is not reviewed until its closure is closed.
+
+---
+
+## 4. Unhappy-path coverage
+
+Run the **unhappy-path-audit** skill's Q1–Q3 over the resources/waits/growth the
+diff touches:
+- **Q1 leak** — every creation has a guaranteed destruction (incl. error paths).
+- **Q2 hung** — every wait has a guaranteed release (exhaust all broadcast/cancel/timeout paths).
+- **Q3 OOM** — every accumulation has a bound / recycle.
+
+Apply its 5-gate false-positive filter (G1 full-graph, G2 can-fail, G3 symmetry,
+G4 line-reread, G5 calibrate-last) before keeping any finding.
+
+---
+
+## 5. Convergence discipline — this is what actually breaks the loop
+
+1. **Calibrate to the merge bar.** Flag only what would block merge or cause a
+   real defect (correctness, data loss, leak, hang, incompatibility). Style /
+   micro-nits: fix silently or skip — never loop on them. (Assign severity LAST,
+   per unhappy-path-audit G5.)
+2. **Keep a decision log.** Record every intentional design choice and every
+   "won't fix / acceptable" item (with the why). Re-reviews and PR reviewers
+   re-surface these constantly; a written decision lets you dismiss them in one
+   line instead of re-litigating. (This is the #1 loop cause after unproven findings.)
+3. **Verify before flagging.** No finding survives without a concrete failure
+   (§2) that passed the 5 gates (§4).
+4. **One thorough pass beats many incremental.** The whole point: exhaust §1–§4
+   now so the next reviewer finds nothing. If you're tempted to "just fix this
+   one and re-run," you're back in the loop — finish the sweep first.
+
+---
+
+## 6. How to run
+
+**On your own working diff (the default — this is a *self* gate):**
+- Fastest: `/code-review high` (workflow-backed, multi-angle finders + verify
+  pass) — then apply §3 closure + §5 discipline to the results.
+- Or invoke the review workflow directly with these emphases as args, e.g.
+  `Workflow(code-review, "high <target>. 多角度评审、第一性原则、系统性思考、完整功能闭环、unhappy path cover")`.
+- Or manually: walk §1 lens-by-lens → §3 closure → §4 Q1–Q3 → §5 gate.
+
+**On a PR (same methodology, later in the lifecycle):** `/code-review ultra <PR#>`
+or `/review <PR#>`. But the point of *this* skill is to run BEFORE the PR so those
+find nothing.
+
+Depth delegation: for the leak/hung/OOM analysis, drive the **unhappy-path-audit**
+skill; for CGo build/test env and MO operator/format specifics, see **mo-dev**.
+
+---
+
+## 7. Exit gate — the diff is self-review-clean when ALL hold
+
+```
+□ every §1 lens swept over the whole diff
+□ every changed arc's functional closure (§3) traced to its terminal node
+□ Q1–Q3 unhappy paths (§4) checked on touched resources/waits/growth
+□ every finding either FIXED or written to the decision log (§5.2)
+□ severity calibrated to the merge bar (§5.1) — zero open blockers
+□ new/changed tests run green (incl. -race where concurrency changed)
+□ applicable domain guards passed (index-plugin → §8) — additive to the §1–§4 sweep above, never a substitute for it
+```
+
+Only then push / open the PR. If a subsequent PR review still finds a real
+blocker, that's a gap in §1/§3 coverage — add the missed lens/closure arc here so
+the gate catches it next time (the gate improves; the loop still ends).
+
+---
+
+## 8. Domain guard — index-plugin changes
+
+> **A domain guard is a supplement to §1–§5, never a replacement.** Always run the
+> full multi-angle sweep over the ENTIRE diff (§1–§4) regardless of whether this
+> guard applies; §8 only *adds* algo-specific checks when index-plugin files are
+> touched. Passing §8 alone is not a review.
+
+Apply when the diff touches index-algorithm dispatch, any
+`pkg/vectorindex/<algo>/plugin/`, `pkg/fulltext/plugin`, or `pkg/indexplugin`.
+These layer on top of §1–§4; each maps to a **mo-dev §8.7** forbidden pattern
+(read **mo-dev §8** for the framework). Any failing check is a merge blocker —
+the whole point of the plugin registry is that adding/editing an algorithm never
+needs a per-algo `switch`, so a diff that reintroduces one re-opens the
+"forgot-a-seam" bug class.
+
+1. **No new per-algo dispatch** — no new `switch …IndexAlgo` / `case MoIndex<X>Algo:` /
+   `IsIvfIndexAlgo || …` in `pkg/sql/{compile,plan}` / `pkg/catalog`; route through
+   `indexplugin.Get(algo)` / `IsVectorIndexAlgo`. (Legacy holdouts in
+   `build_dml_util.go` / `bind_insert.go` may remain — no NEW ones.)
+   ```bash
+   git diff -U0 pkg/sql pkg/catalog | grep -E '^\+' \
+     | grep -E 'IsIvfIndexAlgo|IsHnswIndexAlgo|IsCagraIndexAlgo|IsIvfpqIndexAlgo|IndexAlgo *==|case .*Algo\b'
+   ```
+2. **No import cycle** — no plugin sub-package imports `pkg/sql/plan` or `pkg/sql/compile`:
+   ```bash
+   git diff pkg/vectorindex/*/plugin pkg/fulltext/plugin \
+     | grep -E '^\+.*matrixorigin/matrixone/pkg/sql/(plan|compile)"'   # expect empty
+   ```
+3. **`indexplugin` not polluted** — no file under `pkg/indexplugin/` (except `all/`, `iscp/`)
+   imports a concrete algo package or gains algorithm-named / `switch algo` code:
+   ```bash
+   git diff pkg/indexplugin \
+     | grep -E '^\+.*(vectorindex/(ivfflat|ivfpq|cagra|hnsw)/plugin|fulltext/plugin)'  # only all*.go / iscp
+   ```
+4. **GPU registration correct** — a GPU-only algo's blank import is in `all_gpu.go`
+   (`//go:build gpu`), not `all.go`; each `build_gpu.go` has a `//go:build !gpu` CPU counterpart.
+5. **Assertions intact** — no deleted / commented / `//nolint`'d `var _ AlgoPlugin` or `var _ Hooks`:
+   ```bash
+   git diff | grep -E '^-.*var _ (plugin\.)?(AlgoPlugin|Hooks)'   # expect empty
+   ```
+6. **Runtime kept out** — no build/search kernel logic copied into the plugin; it still
+   calls `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go`.
+7. **New-algo completeness** — blank-imported in `all/` or `all_gpu/`, an SQL case under
+   `test/distributed/cases/vector/`, and CPU unit tests for the plan/schema/runtime hooks
+   (not just the GPU-gated BVT, which reads 0% coverage in non-GPU CI).

--- a/.claude/skills/mo-dev/SKILL.md
+++ b/.claude/skills/mo-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mo-dev
-description: MatrixOne database kernel development - CGo build/test environment setup, operator lifecycle contracts (Call/Reset), pipeline protocol, layered testing strategy. Use when modifying colexec operators, process signal types, compile pipeline construction, or debugging CGo link errors (undefined symbols, missing headers, library not found).
+description: MatrixOne database kernel development - CGo build/test environment setup, GPU builds (MO_CL_CUDA=1 / cuVS), operator lifecycle contracts (Call/Reset), pipeline protocol, layered testing strategy, and the vector/fulltext index-plugin framework (pkg/indexplugin AlgoPlugin registry). Use when modifying colexec operators, process signal types, compile pipeline construction, adding or editing an index algorithm (HNSW/IVFFLAT/IVF-PQ/CAGRA/fulltext), or debugging CGo link errors (undefined symbols, missing headers, library not found).
 compatibility:
   agents: Codex CLI and compatible agents
   requires:
@@ -17,13 +17,16 @@ metadata:
 
 ## Enforcement Gates
 
-This skill gates four decision points. Consult the corresponding section before acting:
+This skill gates seven decision points. Consult the corresponding section before acting:
 
 | Gate | When | Action |
 |------|------|--------|
 | **G-MODIFY** | Before editing any `colexec` operator or `process` signal type | Read §3 (operator contract) + §7 (forbidden patterns) |
 | **G-CGO-ERR** | Any build/test returns `file not found`, `Undefined symbols`/`undefined symbol:`, or `dyld:`/`error while loading shared libraries:` | Read §2.2 (symptom table) + §2.4 (stash protocol) |
-| **G-DONE** | Before declaring "done"/"complete"/"passes" | Read §4.3 (completion gate) — all 5 boxes MUST be checked |
+| **G-GPU** | Before a GPU build/test (`MO_CL_CUDA=1`), or on CUDA/cuVS errors (`CONDA_PREFIX`, `nvcc`, `-lcuvs`/`-lcudart`, `unsupported index type: ivfpq\|cagra`) | Read §2.5 (GPU build) |
+| **G-IDXPLUGIN** | Before adding/editing an index-algorithm plugin, OR adding any `switch`/`if` that branches on an index **algo** name (`IsIvfIndexAlgo`, `== "ivfpq"`, `KeyType`, …) in `pkg/sql/{compile,plan}` or `pkg/catalog` | Read §8 (index-plugin framework) — route through the registry; new algo switches are forbidden |
+| **G-IDXREVIEW** | When **reviewing** a diff (yours or `/code-review`) that touches index-algorithm dispatch, any `pkg/vectorindex/<algo>/plugin/` / `pkg/fulltext/plugin`, or `pkg/indexplugin` | Read §9 (index-plugin review checklist) — run each grep before approving |
+| **G-DONE** | Before declaring "done"/"complete"/"passes" | Read §4.2 (completion gate) — all 5 boxes MUST be checked |
 | **G-TEST-FAIL** | `go test` returns non-zero or hangs >10s | Read §5 (diagnosis) + §2.4 (stash protocol) before attributing cause |
 
 ---
@@ -195,6 +198,54 @@ go test -v -count=1 -timeout 120s ./pkg/target/...
 git stash pop
 ```
 
+### 2.5 GPU Build (`MO_CL_CUDA=1`) — cuVS / CUDA
+
+GPU support compiles the CUDA-backed vector index algorithms (**CAGRA**, **IVF-PQ**) into `libmo` and turns on the `gpu` Go build tag. **Linux x86_64 only** — the macOS `Makefile` branch (`Makefile:234-236`) carries no CUDA flags, so **macOS builds are always CPU-only**. Do not try to enable it on Darwin.
+
+**Prerequisites (one-time):**
+1. CUDA toolkit 12.0 / 13.0+ installed under `/usr/local/cuda`.
+2. cuVS Go bindings installed via conda (`rapidsai/cuvs`), then the env **activated** so `CONDA_PREFIX` is exported:
+   ```bash
+   conda env create --name go -f conda/environments/go_cuda-130_arch-$(uname -m).yaml
+   conda activate go     # exports CONDA_PREFIX — every GPU build/test hard-errors without it
+   ```
+
+**Build:**
+```bash
+MO_CL_CUDA=1 make -j8
+```
+
+**What `MO_CL_CUDA=1` flips** (vs. the default CPU build):
+
+| Layer | CPU build | GPU build (`MO_CL_CUDA=1`) |
+|-------|-----------|----------------------------|
+| Go build tag | none | `-tags gpu` (`Makefile:224`) — registers CAGRA + IVF-PQ, compiles `*_gpu.go` |
+| `cgo/` compiler | `gcc`/`clang` | `/usr/local/cuda/bin/nvcc` (`cgo/Makefile:31`, multi-arch `sm_75…sm_90`) |
+| `libmo` objects | C objects only | + `cuda/*.o` + `cuvs/*.o` |
+| Link flags | `-lusearch_c -lroaring` | + `-lcuvs -lcuvs_c -lcudart -lcuda -lrmm -lstdc++` |
+| Header/lib roots | thirdparties only | + `$CONDA_PREFIX/{include,lib}`, `/usr/local/cuda/...` |
+
+**Guardrails baked into the Makefiles:**
+- **`CONDA_PREFIX env variable not found`** → conda env not activated. Run `conda activate <env>` first. Both `Makefile:217` and `cgo/Makefile:28` hard-error on this — it is *not* a code bug.
+- **`libmo` is re-linked on every GPU build** (`cgo/Makefile` order-only `cuda_objs`/`cuvs_objs` prereqs). Deliberate: `mo-service` loads `libmo.so` **dynamically**, so a stale `.so` silently runs old C++ (hours of "my fix didn't take"). The old `rm -f cgo/libmo.so cgo/libmo.a` workaround is no longer needed.
+
+**The `gpu` tag gates index-plugin registration — memorize this.** CAGRA and IVF-PQ register **only** under `//go:build gpu` (`pkg/indexplugin/all/all_gpu.go`). On a CPU binary their plugins are absent from the registry, so `CREATE INDEX … USING ivfpq|cagra` fails cleanly at plan-build with `unsupported index type: <algo>` — **before** any hidden table is created. This is intentional. Do **not** "fix" it by moving those imports into `all.go` (see §8.6).
+
+**Prerequisite — the linked `libmo` must itself be GPU-built:** run `MO_CL_CUDA=1 make -j8 cgo` first. A CPU `libmo` lacks the `cuda/`+`cuvs/` objects, so `gpu`-tagged Go (which cgo-includes `cgo/cuvs/*.h` via `pkg/cuvs`) fails to link with undefined `cuvs_*` / `cuda*` symbols — this is a *stale-library* error, not a flag error, so re-check §2.2 before chasing `CGO_LDFLAGS`.
+
+**GPU tests** — add `-tags gpu` plus the CUDA search paths (mirror the Makefile's `CUDA_CFLAGS`/`CUDA_LDFLAGS`, `Makefile:220-223`); Linux only:
+```bash
+CGO_CFLAGS="-I$(pwd)/cgo -I$(pwd)/thirdparties/install/include -I$CONDA_PREFIX/include -I/usr/local/cuda/include" \
+CGO_LDFLAGS="-L$(pwd)/thirdparties/install/lib -lusearch_c -L$CONDA_PREFIX/lib -lcuvs -lcuvs_c" \
+LD_LIBRARY_PATH="$(pwd)/cgo:$(pwd)/thirdparties/install/lib:$CONDA_PREFIX/lib:/usr/local/cuda/lib64" \
+go test -tags gpu \
+  -ldflags="-extldflags '-L$(pwd)/cgo -lmo -L$(pwd)/thirdparties/install/lib -Wl,-rpath,\$ORIGIN/lib -fopenmp'" \
+  -v -count=1 -timeout 300s ./pkg/vectorindex/ivfpq/...
+```
+The **authoritative** flag source is the `Makefile` (`CUDA_CFLAGS`/`CUDA_LDFLAGS`), not this snippet — if a GPU link error appears, diff your flags against those lines.
+
+**Tag-split test files are a trap:** `*_gpu.go` / `//go:build gpu` tests (e.g. `pkg/vectorindex/ivfpq/search_test.go`, `model_test.go`) compile **only** under `-tags gpu`. A plain `go test ./pkg/vectorindex/ivfpq/...` runs the `//go:build !gpu` / `*_cpu.go` stubs instead. **"CPU tests pass" ≠ "GPU path tested."**
+
 ---
 
 ## 3. Operator Lifecycle Contracts
@@ -293,3 +344,265 @@ When sending terminal signals into a bounded channel, the send may fail because 
 4. **Never declare done without fresh test output.** All 5 completion gate boxes must be checked.
 5. **Never assume `go build` success means `go test` will pass.** Build only compiles packages; test compiles AND links test binaries.
 6. **Never skip bottom-up testing.** Start with pure Go packages, then CGo-transitive, then CGo-direct.
+7. **Never add a per-algorithm `switch`/`if` on an index algo name in the SQL layer.** Route through `indexplugin.Get(algo)` — see §8.
+
+---
+
+## 8. Vector / Fulltext Index-Plugin Framework
+
+### 8.1 Why this exists (and what NOT to undo)
+
+Adding a vector index used to mean editing 8+ files across `pkg/sql/compile`,
+`pkg/sql/plan`, `pkg/catalog`, and `pkg/vectorindex`, wired through ~6
+switch/if-chain seams. Miss one seam → the algorithm silently misbehaves. The
+`pkg/indexplugin` framework collapses those seams into **one registry lookup**:
+an algorithm registers **one** `AlgoPlugin`, and the compiler enforces every
+required hook exists.
+
+**The guarded failure mode:** a change that re-introduces a per-algorithm
+`switch algo` / `if IsXxxIndexAlgo || …` in the SQL layer, or otherwise bypasses
+the registry, quietly re-opens the "forgot a seam" bug class. Work **through**
+the framework — do not route around it.
+
+### 8.2 Architecture
+
+`pkg/indexplugin` is the framework. It must **not** import `pkg/sql/{compile,plan}`;
+hook methods receive narrow `Context` interfaces the SQL layer satisfies.
+
+```
+pkg/indexplugin/
+├── plugin.go          -- AlgoPlugin interface; Register/Get/All; IsVectorIndexAlgo/IsFullTextIndexAlgo/IsPluginAlgo
+├── catalog/hooks.go   -- catalog.Hooks   (metadata: params, hidden tables, op/vector/pk types, quantization)
+├── compile/hooks.go   -- compile.Hooks   (DDL execution: create/reindex/drop/restore) + CompileContext
+├── plan/hooks.go      -- plan.Hooks      (schema defs + tablefunc + thin ANN redirects) + PlanBuilder/CompilerContext
+├── idxcron/hooks.go   -- idxcron.Hooks   (scheduled-rebuild gating: Updatable)
+└── all/
+    ├── all.go         -- blank-imports CPU-safe plugins (fulltext, hnsw, ivfflat)
+    └── all_gpu.go     -- //go:build gpu — blank-imports GPU-only plugins (cagra, ivfpq)
+
+pkg/vectorindex/<algo>/plugin/   -- one dir per algorithm; assembles the hooks into an AlgoPlugin
+pkg/fulltext/plugin/             -- fulltext is a plugin too (kind = fulltext, not vector)
+```
+
+**Dispatch flow** — every SQL-layer site that used to `switch algo` now does:
+
+```go
+p, ok := indexplugin.Get(algo)      // case-insensitive, trims whitespace
+if ok { return p.Compile().HandleCreateIndex(cctx, defs) }
+```
+
+`indexplugin.IsVectorIndexAlgo(algo)` replaces the
+`IsIvfIndexAlgo || IsHnswIndexAlgo || IsCagraIndexAlgo || IsIvfpqIndexAlgo`
+chain. Use `IsFullTextIndexAlgo` for fulltext, `IsPluginAlgo` for "registered at
+all (vector OR fulltext)". Live dispatch sites already exist in
+`pkg/sql/plan/build_ddl.go` (`indexplugin.Get(...KeyType.ToString())` →
+`unsupported index type: %s`) and `pkg/sql/plan/apply_indices.go`
+(`p.Plan().CanApply`).
+
+### 8.3 Registry contract — the compiler is the safety net
+
+```go
+// pkg/indexplugin/plugin.go
+type AlgoPlugin interface {
+    Algo() string                       // must == catalog.MoIndex<X>Algo.ToString() (lower-cased)
+    Catalog() catalogplugin.Hooks
+    Compile() compileplugin.Hooks
+    Plan()    planplugin.Hooks
+    Idxcron() idxcronplugin.Hooks
+}
+func Register(p AlgoPlugin)              // panics on duplicate Algo(); call from init()
+func Get(algo string) (AlgoPlugin, bool)
+```
+
+Each plugin keeps compile-time interface assertions:
+
+```go
+var _ plugin.AlgoPlugin = (*Plugin)(nil)   // in <algo>/plugin/plugin.go
+var _ Hooks = Hooks{}                        // in each hooks sub-package impl
+```
+
+If `AlgoPlugin` or a `Hooks` interface gains a method and a plugin isn't updated,
+these lines **stop the build**. That compile error *is* the "did I miss a seam?"
+answer. **Never delete or `//nolint` these assertions to green a build** —
+implement the missing method.
+
+### 8.4 Plugin package layout (canonical: IVF-PQ)
+
+`pkg/vectorindex/ivfpq/plugin/plugin.go` is the **authoritative walkthrough** —
+read its package doc before adding an algorithm. A full plugin (see
+`pkg/vectorindex/ivfflat/plugin/`) is:
+
+```
+pkg/vectorindex/<algo>/plugin/
+├── plugin.go            -- assembles the 4 Hooks into one Plugin; init() { plugin.Register(New()) }
+├── runtime/runtime.go   -- catalog.Hooks impl  (algorithm metadata constants)
+├── compile/compile.go   -- compile.Hooks impl  (CREATE/ALTER/DROP/REINDEX execution)
+├── plan/
+│   ├── plan.go          -- plan.Hooks: thin ApplyForSort/CanApply redirect (~10 LoC) into *plan.QueryBuilder
+│   ├── schema.go        -- BuildSecondaryIndexDefs body (hidden-table TableDefs + IndexDefs)
+│   └── tablefunc.go     -- <algo>_create / <algo>_search FUNCTION_SCAN builder registrations
+├── idxcron/idxcron.go   -- idxcron.Hooks impl  (Updatable: scheduled-rebuild gating)
+└── iscp/iscp.go         -- CDC / import sync (may be //go:build gpu for GPU algos)
+```
+
+**Which sub-package gets lifted code:** from `pkg/sql/compile/*.go` → `compile/`;
+from `pkg/sql/plan/*.go` → `plan/`; algorithm-metadata constants → `runtime/`
+(lifted code goes in the sub-package matching `pkg/sql/<layer>` of the call site).
+
+### 8.5 Adding a new algorithm — steps
+
+Follow `pkg/vectorindex/ivfpq/plugin/plugin.go`'s doc. Summary:
+
+1. **Catalog constants.** Add `MoIndex<X>Algo` in
+   `pkg/catalog/secondary_index_utils.go`; hidden-table-type constants in
+   `pkg/catalog/types.go` (one per hidden table). A `tree.INDEX_TYPE_<X>` parser
+   keyword only if it needs new CREATE INDEX syntax.
+2. **Copy** `pkg/vectorindex/ivfpq/plugin/` → `pkg/vectorindex/<x>/plugin/`;
+   rename packages/imports.
+3. **Implement the four Hooks** (let the `var _ Hooks = …` assertions tell you
+   what's missing):
+   - `catalog.Hooks` — `HiddenTableTypes`, `ParamsFromTree`, `DefaultOptions`,
+     `SupportedOpTypes`, `SupportedVectorTypes`, `SupportedPrimaryKeyTypes`,
+     `SupportedIncludeColumnTypes`, `ValidQuantization`, `ExperimentalFlag`,
+     `AlterTableCloneBehavior`, `RestoreBehavior`, `BuildSessionVars`,
+     `ShouldTruncateHiddenTable`, `SyncDescriptor`.
+   - `compile.Hooks` — `HandleCreateIndex`, `HandleReindex`,
+     `ValidateReindexParams`, `HandleDropIndex`, `RestoreInitSQL`,
+     `IdxcronMetadata`.
+   - `plan.Hooks` — `BuildSecondaryIndexDefs`, `BuildFullTextIndexDefs`,
+     `CanApply`, `ApplyForSort`.
+   - `idxcron.Hooks` — `Updatable` (return "always yes" if the algo has no
+     minimum-size / cadence constraint).
+4. **ANN rewrite body** (only if the algo supports `ORDER BY <distfn>(col,v)
+   LIMIT k`): add `applyIndicesForSortUsing<X>` + `prepare<X>IndexContext` in
+   `pkg/sql/plan/apply_indices_<x>.go`, redirect methods on `*QueryBuilder` in
+   `pkg/sql/plan/plugin_builder.go`, and the dispatch case in
+   `pkg/sql/plan/apply_indices.go` (which calls `p.Plan().CanApply`).
+5. **Register:** `init()` in `plugin.go` calls `plugin.Register(New())`. Add
+   **one** blank-import line to `pkg/indexplugin/all/all.go` — **or**
+   `all_gpu.go` if GPU-only (§8.6). That aggregator is the *only* wiring edit;
+   `pkg/sql/plan` and `pkg/sql/compile` already blank-import `.../all`.
+6. **SQL test** under `test/distributed/cases/vector/` exercising CREATE INDEX,
+   `ORDER BY <distfn>(col,v) LIMIT k`, ALTER REINDEX, DROP INDEX, DROP TABLE.
+
+> If the plugin compiles and every hook is implemented, you did **not** miss a
+> dispatch site. Do not add manual dispatch "to be safe."
+
+### 8.6 CPU vs GPU registration (ties to §2.5)
+
+| File | Build tag | Registers | Rationale |
+|------|-----------|-----------|-----------|
+| `pkg/indexplugin/all/all.go` | (none) | fulltext, hnsw, ivfflat | CPU-safe algorithms |
+| `pkg/indexplugin/all/all_gpu.go` | `//go:build gpu` | cagra, ivfpq | CUDA-backed table functions exist only under `gpu` |
+
+CAGRA / IVF-PQ have `cagra_create` / `ivfpq_create` table functions implemented
+**only** under `//go:build gpu`. Registering them on a CPU binary would let
+`CREATE INDEX … USING cagra|ivfpq` proceed until the BUILD SQL fails mid-flight —
+after hidden tables are created and DELETEs run. Gating registration behind the
+`gpu` tag makes plan-build return `unsupported index type: <algo>` **before any
+DDL side effect**. The `gpu` tag is enabled by `MO_CL_CUDA=1 make` (§2.5).
+
+**Pairing rule:** an algo with `build_gpu.go` (`//go:build gpu`) must have a
+`//go:build !gpu` CPU counterpart (`*_cpu.go` stub) so the package still compiles
+on CPU, *and* its plugin blank-import belongs in `all_gpu.go`, never `all.go`.
+
+### 8.7 Forbidden patterns (index-plugin)
+
+1. **Never re-introduce per-algorithm dispatch in the SQL layer.** A new
+   `switch idx.IndexAlgo`, `if catalog.IsIvfIndexAlgo(a) || …`, or `case
+   MoIndex<X>Algo:` in `pkg/sql/{compile,plan}` / `pkg/catalog` re-opens the bug
+   class the framework closed. Need a new per-algo decision? Add a **method to
+   the relevant `Hooks` interface** (compiler forces every algo to answer) — not
+   a switch.
+2. **Never import `pkg/sql/plan` or `pkg/sql/compile` from a plugin package.**
+   Those packages blank-import the plugins for `init()` registration → an import
+   cycle. Plugins receive `compile.CompileContext` / `plan.PlanBuilder` /
+   `plan.CompilerContext` and call *through* them. `plan/` bodies that need
+   `*QueryBuilder` internals live in `pkg/sql/plan/apply_indices_<x>.go`, reached
+   via the thin redirect (§8.5 step 4).
+3. **Never register a GPU-only algo in `all.go`** — use `all_gpu.go` (§8.6).
+4. **Never weaken the `var _ AlgoPlugin` / `var _ Hooks` assertions** to green a
+   build. Implement the missing method.
+5. **Keep runtime out of the plugin.** The plugin owns compile + plan + catalog +
+   idxcron metadata only. Real build/search kernels stay in
+   `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go`, invoked from
+   `pkg/sql/colexec/table_function/<algo>_*.go`. Do not copy kernel logic in.
+6. **Never pollute `pkg/indexplugin` with algorithm-specific code — it is
+   interfaces + metadata only.** The framework package holds only the interfaces
+   (`AlgoPlugin`, the `Hooks` + `Context` interfaces), the registry, and
+   *algorithm-agnostic* shared helpers/metadata (e.g. `AlgoParamInt`,
+   `IdxcronVarSpec` / `BuildIdxcronMetadata` — generic, zero algo branching).
+   Every concrete hook body and per-algo constant lives in
+   `pkg/vectorindex/<algo>/plugin/` (or `pkg/fulltext/plugin/`). Do **not** add a
+   `switch algo` / `if IsXxxIndexAlgo`, a concrete `Hooks` implementation, or any
+   algorithm-named symbol under `pkg/indexplugin/*`. The *only* files there that
+   may name a concrete algorithm are the `all/` and `iscp/` aggregators — and
+   only as blank imports.
+
+### 8.8 Testing & completion (index-plugin)
+
+Index-plugin changes have a **coverage trap**: the end-to-end BVT cases under
+`test/distributed/cases/vector/` are GPU-gated (skipped in non-GPU CI), so
+`plan.go` / `schema.go` read **0% coverage** and fail the 0.75 gate unless you
+add CPU-runnable unit tests (tablefunc_test / runtime_test style — see
+`pkg/vectorindex/ivfflat/plugin/{runtime,idxcron}/*_test.go`). On top of the §4.2
+completion gate:
+
+```
+□ CPU unit tests exist for plan/schema/runtime hooks (not just GPU-gated BVT)  → run, exit 0
+□ GPU-only hooks also run with `-tags gpu` per §2.5                            → exit 0
+□ grep: NO new `switch algo` / `IsXxxIndexAlgo ||` added in pkg/sql/*
+□ git diff --stat: the ONLY all.go/all_gpu.go edit is one blank import
+```
+
+**Known in-progress seams — do not add NEW ones.** A few DML-sync sites still
+call `catalog.IsIvfIndexAlgo` directly (`pkg/sql/plan/build_dml_util.go`,
+`pkg/sql/plan/bind_insert.go`) — the IVFFLAT-hardcoded resolution is mid-migration
+into `plan.Hooks`. These are **legacy**, not a license to add more. When you
+touch one, prefer moving it behind a hook; never model a *new* algorithm on them.
+
+---
+
+## 9. Reviewing an index-plugin change (G-IDXREVIEW)
+
+Apply this when reviewing a diff — your own before "done", or via `/code-review`
+— that touches index-algorithm dispatch, any `pkg/vectorindex/<algo>/plugin/`,
+`pkg/fulltext/plugin`, or `pkg/indexplugin`. Each item maps to a §8.7 forbidden
+pattern; the grep is the fast check. **Request changes if any check fails**, and
+cite the §8.7 rule number in the finding.
+
+1. **No new per-algo dispatch** (§8.7 #1). The diff adds no `switch …IndexAlgo`,
+   `case MoIndex<X>Algo:`, or `IsIvfIndexAlgo || …` in `pkg/sql/{compile,plan}` /
+   `pkg/catalog`. Legacy holdouts (`build_dml_util.go`, `bind_insert.go`) may
+   remain — but **no new ones**.
+   ```bash
+   git diff -U0 pkg/sql pkg/catalog | grep -E '^\+' \
+     | grep -E 'IsIvfIndexAlgo|IsHnswIndexAlgo|IsCagraIndexAlgo|IsIvfpqIndexAlgo|IndexAlgo *==|case .*Algo\b'
+   ```
+2. **No import cycle** (§8.7 #2). No plugin sub-package imports `pkg/sql/plan` or
+   `pkg/sql/compile`.
+   ```bash
+   git diff pkg/vectorindex/*/plugin pkg/fulltext/plugin \
+     | grep -E '^\+.*matrixorigin/matrixone/pkg/sql/(plan|compile)"'   # expect empty
+   ```
+3. **`indexplugin` not polluted** (§8.7 #6). No file under `pkg/indexplugin/`
+   (except `all/`, `iscp/`) imports a concrete algo package or gains
+   algorithm-named / `switch algo` code.
+   ```bash
+   git diff pkg/indexplugin \
+     | grep -E '^\+.*(vectorindex/(ivfflat|ivfpq|cagra|hnsw)/plugin|fulltext/plugin)'  # only all*.go / iscp allowed
+   ```
+4. **GPU registration correct** (§8.6, §8.7 #3). A GPU-only algo's blank import is
+   in `all_gpu.go` (`//go:build gpu`), not `all.go`; each `build_gpu.go` has a
+   `//go:build !gpu` CPU counterpart.
+5. **Assertions intact** (§8.7 #4). The diff does not delete / comment /
+   `//nolint` any `var _ AlgoPlugin` or `var _ Hooks` line.
+   ```bash
+   git diff | grep -E '^-.*var _ (plugin\.)?(AlgoPlugin|Hooks)'   # expect empty
+   ```
+6. **Runtime kept out** (§8.7 #5). No build/search kernel logic copied into the
+   plugin; it still calls `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go`.
+7. **New-algo completeness** (§8.5, §8.8). If a new algorithm: blank-imported in
+   `all/` or `all_gpu/`, has an SQL case under `test/distributed/cases/vector/`,
+   and CPU unit tests cover the plan/schema/runtime hooks (not just GPU-gated
+   BVT).

--- a/.claude/skills/mo-self-review/SKILL.md
+++ b/.claude/skills/mo-self-review/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: mo-self-review
+description: Pre-push self-review gate for MatrixOne changes — a systematic, multi-angle, first-principles review of your OWN diff with complete functional-closure investigation and unhappy-path coverage, calibrated to the merge bar. Run BEFORE pushing / opening / updating a PR so the human or bot PR review finds nothing new — breaking the review→modify loop. Use before declaring a change "done", before push, or when a PR keeps drawing new review rounds. Complements unhappy-path-audit (Q1–Q3 depth) and /code-review.
+compatibility:
+  agents: Codex CLI and compatible agents
+  requires:
+    - git working tree with a diff vs the base branch
+    - unhappy-path-audit skill (for Q1–Q3 depth)
+metadata:
+  project: matrixone
+  repository: matrixorigin/matrixone
+  language: go
+---
+
+## Running this skill IS the review (don't retype the long prompt)
+
+Invoking this skill — `/mo-self-review [target]` or the Skill tool — **runs the
+whole gate for you**. First resolve the **target** from the args:
+
+| Args | Target to review |
+|------|------------------|
+| *(empty)* | current branch **vs `main`** |
+| a git ref / branch / tag / commit (e.g. `develop`, `origin/release-2.0`, `abc123`) | current branch **vs that ref** |
+| `vs <ref>` / `base=<ref>` | current branch **vs `<ref>`** |
+| all-digits (e.g. `25199`) | that **GitHub PR** |
+| anything else (e.g. `pkg/vectorindex focus on quantizer`) | scope/focus, still **vs `main`** |
+| `<ref> <scope…>` | **vs `<ref>`**, restricted to the trailing scope |
+| `docs` / `help` | just show §1–§8, run nothing |
+
+Then execute (do not shortcut):
+
+1. Launch the **code-review** workflow at **high** on the resolved target — state the
+   base you resolved ("this branch compared to `<base>`") — appending verbatim:
+   `多角度评审，第一性原则，系统性思考问题，涉及到的修改需要调研完整的功能闭环，unhappy path cover.`
+   Pass any scope/skip instructions through too.
+2. On results, apply **§3** (trace each finding's functional closure to its terminal
+   node; personally spot-check any *cluster of refutations* — a verifier can repeat
+   one wrong call) and **§5** (severity LAST, calibrated to the merge bar;
+   decision-log every won't-fix/known-gap with its reason; no finding without a
+   concrete failure).
+3. Present a converged, ranked findings list, each with a **fix-or-decision-log
+   recommendation** — not another review round.
+
+§1–§8 below are the methodology this executes; consult them when applying the
+discipline or running the gate manually. When this skill is surfaced only as
+background reference (not explicitly invoked), treat §1–§8 as guidance — do **not**
+auto-launch a workflow.
+
+---
+
+## Purpose — break the review → modify loop
+
+The review→modify→review loop repeats because each review pass is *incremental*:
+a new pass finds something the last one didn't (a fresh angle, a missed branch),
+and re-flags items already decided "won't fix." This gate front-loads **one
+exhaustive, calibrated self-review of your own diff** so the eventual PR review
+(human or bot) has **nothing new to add** → the loop ends.
+
+Run it on your working diff BEFORE `git push` / opening / updating a PR. It is a
+*gate*: it either passes (§7) or produces a fix/decision list — not an endless
+stream of nitpicks.
+
+---
+
+## Enforcement gate
+
+| Gate | When | Action |
+|------|------|--------|
+| **G-SELF-REVIEW** | Before `git push`, before opening/updating a PR, or before declaring a change "done" | Run §1–§4 over the full diff, apply §5 convergence discipline, then check the §7 exit gate. Do not push until it passes. |
+
+Scope = the complete diff vs the base branch (`git diff <base>...HEAD` + staged/unstaged), **not** just the last file you touched.
+
+---
+
+## 1. Multi-angle (多角度) — run each lens as a separate pass
+
+Do not spot-check. Sweep the whole diff once per lens; a defect invisible to one
+lens is obvious to another.
+
+| Lens | Ask |
+|------|-----|
+| **Correctness** | Does each changed function produce the right output for ordinary AND boundary inputs (0, 1, max, empty, nil, overflow)? |
+| **Concurrency** | Shared state touched by >1 goroutine? Races, lost wakeups, double-close, ordering assumptions? (`-race` the new tests.) |
+| **Resource lifecycle** | Every fd/goroutine/lock/alloc created on the change's paths — closed/released on **every** branch incl. error/panic? (→ §4 Q1) |
+| **Compatibility / boundary** | On-disk/wire format, config default, API signature, catalog metadata: does the change stay backward-compatible? New format opt-in, not a flipped default? Mismatch detected (fail-fast) not silently misread? |
+| **Failure modes** | Every error return handled; partial failure leaves consistent state; no silent fallback that hides corruption. |
+| **Contract / API** | Callers updated on both ends of a protocol change; interface impls complete (compile-time `var _` checks intact). |
+
+---
+
+## 2. First principles (第一性原则)
+
+**Prove it breaks — don't report "looks like it might."** For each candidate
+defect, state a concrete failure: *inputs/state → wrong output / crash / hang*.
+If you can't, exhaust every bypass path (defer, cancel watcher, timer, retry,
+guard) before ruling — then drop it. This is the single biggest source of
+review-loop noise: unproven "might" findings that get fixed, re-reviewed, and
+spawn more "might" findings.
+
+---
+
+## 3. Complete functional closure (功能闭环)
+
+For every change, trace the **entire loop it participates in**, not just the
+edited line — most missed-in-review defects live one hop away, in the *other
+half* of the closure. Trace to the terminal node.
+
+| Change kind | Closure to walk end-to-end |
+|-------------|----------------------------|
+| storage / on-disk format | create → write → **read** → backup → **restore** → upgrade → restart |
+| operator (colexec) | Prepare → Call → **Reset** → Cleanup (+ the error branch) |
+| index / CDC | CREATE (+ InitSQL) → sync → query → reindex → DROP |
+| resource handle | create → hand-off → … → **Destroy/Free/Close** (all holders) |
+| config / flag | parse → default-fill → consume → the *other* backend/mode that shares it |
+
+Rule: if you changed one arc of a closure, open and read the arcs that *consume*
+or *reverse* it (the reader for a writer, the restore for a backup, the Reset for
+a Call). A change is not reviewed until its closure is closed.
+
+---
+
+## 4. Unhappy-path coverage
+
+Run the **unhappy-path-audit** skill's Q1–Q3 over the resources/waits/growth the
+diff touches:
+- **Q1 leak** — every creation has a guaranteed destruction (incl. error paths).
+- **Q2 hung** — every wait has a guaranteed release (exhaust all broadcast/cancel/timeout paths).
+- **Q3 OOM** — every accumulation has a bound / recycle.
+
+Apply its 5-gate false-positive filter (G1 full-graph, G2 can-fail, G3 symmetry,
+G4 line-reread, G5 calibrate-last) before keeping any finding.
+
+---
+
+## 5. Convergence discipline — this is what actually breaks the loop
+
+1. **Calibrate to the merge bar.** Flag only what would block merge or cause a
+   real defect (correctness, data loss, leak, hang, incompatibility). Style /
+   micro-nits: fix silently or skip — never loop on them. (Assign severity LAST,
+   per unhappy-path-audit G5.)
+2. **Keep a decision log.** Record every intentional design choice and every
+   "won't fix / acceptable" item (with the why). Re-reviews and PR reviewers
+   re-surface these constantly; a written decision lets you dismiss them in one
+   line instead of re-litigating. (This is the #1 loop cause after unproven findings.)
+3. **Verify before flagging.** No finding survives without a concrete failure
+   (§2) that passed the 5 gates (§4).
+4. **One thorough pass beats many incremental.** The whole point: exhaust §1–§4
+   now so the next reviewer finds nothing. If you're tempted to "just fix this
+   one and re-run," you're back in the loop — finish the sweep first.
+
+---
+
+## 6. How to run
+
+**On your own working diff (the default — this is a *self* gate):**
+- Fastest: `/code-review high` (workflow-backed, multi-angle finders + verify
+  pass) — then apply §3 closure + §5 discipline to the results.
+- Or invoke the review workflow directly with these emphases as args, e.g.
+  `Workflow(code-review, "high <target>. 多角度评审、第一性原则、系统性思考、完整功能闭环、unhappy path cover")`.
+- Or manually: walk §1 lens-by-lens → §3 closure → §4 Q1–Q3 → §5 gate.
+
+**On a PR (same methodology, later in the lifecycle):** `/code-review ultra <PR#>`
+or `/review <PR#>`. But the point of *this* skill is to run BEFORE the PR so those
+find nothing.
+
+Depth delegation: for the leak/hung/OOM analysis, drive the **unhappy-path-audit**
+skill; for CGo build/test env and MO operator/format specifics, see **mo-dev**.
+
+---
+
+## 7. Exit gate — the diff is self-review-clean when ALL hold
+
+```
+□ every §1 lens swept over the whole diff
+□ every changed arc's functional closure (§3) traced to its terminal node
+□ Q1–Q3 unhappy paths (§4) checked on touched resources/waits/growth
+□ every finding either FIXED or written to the decision log (§5.2)
+□ severity calibrated to the merge bar (§5.1) — zero open blockers
+□ new/changed tests run green (incl. -race where concurrency changed)
+□ applicable domain guards passed (index-plugin → §8) — additive to the §1–§4 sweep above, never a substitute for it
+```
+
+Only then push / open the PR. If a subsequent PR review still finds a real
+blocker, that's a gap in §1/§3 coverage — add the missed lens/closure arc here so
+the gate catches it next time (the gate improves; the loop still ends).
+
+---
+
+## 8. Domain guard — index-plugin changes
+
+> **A domain guard is a supplement to §1–§5, never a replacement.** Always run the
+> full multi-angle sweep over the ENTIRE diff (§1–§4) regardless of whether this
+> guard applies; §8 only *adds* algo-specific checks when index-plugin files are
+> touched. Passing §8 alone is not a review.
+
+Apply when the diff touches index-algorithm dispatch, any
+`pkg/vectorindex/<algo>/plugin/`, `pkg/fulltext/plugin`, or `pkg/indexplugin`.
+These layer on top of §1–§4; each maps to a **mo-dev §8.7** forbidden pattern
+(read **mo-dev §8** for the framework). Any failing check is a merge blocker —
+the whole point of the plugin registry is that adding/editing an algorithm never
+needs a per-algo `switch`, so a diff that reintroduces one re-opens the
+"forgot-a-seam" bug class.
+
+1. **No new per-algo dispatch** — no new `switch …IndexAlgo` / `case MoIndex<X>Algo:` /
+   `IsIvfIndexAlgo || …` in `pkg/sql/{compile,plan}` / `pkg/catalog`; route through
+   `indexplugin.Get(algo)` / `IsVectorIndexAlgo`. (Legacy holdouts in
+   `build_dml_util.go` / `bind_insert.go` may remain — no NEW ones.)
+   ```bash
+   git diff -U0 pkg/sql pkg/catalog | grep -E '^\+' \
+     | grep -E 'IsIvfIndexAlgo|IsHnswIndexAlgo|IsCagraIndexAlgo|IsIvfpqIndexAlgo|IndexAlgo *==|case .*Algo\b'
+   ```
+2. **No import cycle** — no plugin sub-package imports `pkg/sql/plan` or `pkg/sql/compile`:
+   ```bash
+   git diff pkg/vectorindex/*/plugin pkg/fulltext/plugin \
+     | grep -E '^\+.*matrixorigin/matrixone/pkg/sql/(plan|compile)"'   # expect empty
+   ```
+3. **`indexplugin` not polluted** — no file under `pkg/indexplugin/` (except `all/`, `iscp/`)
+   imports a concrete algo package or gains algorithm-named / `switch algo` code:
+   ```bash
+   git diff pkg/indexplugin \
+     | grep -E '^\+.*(vectorindex/(ivfflat|ivfpq|cagra|hnsw)/plugin|fulltext/plugin)'  # only all*.go / iscp
+   ```
+4. **GPU registration correct** — a GPU-only algo's blank import is in `all_gpu.go`
+   (`//go:build gpu`), not `all.go`; each `build_gpu.go` has a `//go:build !gpu` CPU counterpart.
+5. **Assertions intact** — no deleted / commented / `//nolint`'d `var _ AlgoPlugin` or `var _ Hooks`:
+   ```bash
+   git diff | grep -E '^-.*var _ (plugin\.)?(AlgoPlugin|Hooks)'   # expect empty
+   ```
+6. **Runtime kept out** — no build/search kernel logic copied into the plugin; it still
+   calls `pkg/vectorindex/<algo>/{build_gpu,search_gpu}.go`.
+7. **New-algo completeness** — blank-imported in `all/` or `all_gpu/`, an SQL case under
+   `test/distributed/cases/vector/`, and CPU unit tests for the plan/schema/runtime hooks
+   (not just the GPU-gated BVT, which reads 0% coverage in non-GPU CI).


### PR DESCRIPTION
Skills-only change (Claude .claude + Codex .agents copies kept in sync):

- mo-dev: add §2.5 GPU build (MO_CL_CUDA=1), §8 index-plugin framework and §9 index-plugin review checklist, plus G-GPU/G-IDXPLUGIN/G-IDXREVIEW gates and forbidden patterns — enforces the plugin registry so adding/editing an algorithm never needs a per-algo switch.
- mo-self-review: new pre-push self-review gate. Invoking it runs the whole gate (resolve target → code-review high with multi-angle emphases → §3 functional-closure + §5 convergence discipline), calibrated to the merge bar to break the review→modify loop. Includes an index-plugin domain guard (§8) cross-referencing mo-dev.

Ported from cuvs_quantize onto a clean branch off main.

## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25392

## What this PR does / why we need it:

- Add GPU build
- Enforce index plugin
- add mo-self-review skill

  | Command | Reviews |
  |---------|---------|
  | `/mo-self-review` | current branch **vs `main`** (default) |
  | `/mo-self-review develop` | current branch **vs `develop`** |
  | `/mo-self-review origin/release-2.0` | current branch **vs that ref** |
  | `/mo-self-review vs abc123` | current branch **vs commit `abc123`** |
  | `/mo-self-review base=main` | current branch **vs `main`** (explicit) |
  | `/mo-self-review 25199` | **GitHub PR #25199** |
  | `/mo-self-review pkg/vectorindex focus on quantizer` | vs `main`, scoped to that focus |
  | `/mo-self-review develop pkg/fulltext` | **vs `develop`**, scoped to `pkg/fulltext` |
  | `/mo-self-review docs` | show the methodology (§1–§8), run nothing |

  **Target rule:** the first ref-looking token (branch / tag / commit / `vs <ref>` /
  `base=<ref>`) is the base; an all-digits token is a PR number; anything else is
  treated as scope (still vs `main`).

  ## What it does
  
  1. Launches the `code-review` workflow at **high** on the resolved target, with the
     emphases: 多角度评审、第一性原则、系统性思考、完整功能闭环、unhappy-path cover.
  2. Applies **§3** closure (traces each finding to its terminal node; spot-checks
     refutation clusters) and **§5** convergence (severity last, calibrated to the
     merge bar; decision-log for won't-fix items).
  3. Returns a ranked findings list, each with a **fix-or-decision** recommendation.

  ## Also usable as reference

  The Skill tool can invoke it programmatically, and §1–§8 can be consulted manually:
  - §1 multi-angle lenses · §2 first-principles · §3 functional closure ·
    §4 unhappy-path (Q1–Q3) · §5 convergence · §6 how-to-run · §7 exit gate ·
    §8 index-plugin domain guard
