### PR TITLE
[4.1-dev] fix: maintain covering secondary indexes

### DIFF
--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -728,7 +728,7 @@ func isRegularIndexFullPrefixEquality(expr *plan.Expr, numKeyParts int) bool {
 		return false
 	}
 	serialFn := fn.Args[1].GetF()
-	return serialFn != nil && serialFn.Func.ObjName == "serial" && len(serialFn.Args) == numKeyParts
+	return serialFn != nil && serialFn.Func.ObjName == "serial_full" && len(serialFn.Args) == numKeyParts
 }
 
 func hasTopValueMessage(node *plan.Node) bool {
@@ -925,7 +925,7 @@ func (builder *QueryBuilder) applyIndicesForFiltersRegularIndex(nodeID int32, no
 	indexes := make([]*IndexDef, 0, len(node.TableDef.Indexes))
 	spatialIndexes := make([]*IndexDef, 0, len(node.TableDef.Indexes))
 	for i := range node.TableDef.Indexes {
-		if node.TableDef.Indexes[i].IndexAlgo == "fulltext" || !node.TableDef.Indexes[i].TableExist {
+		if !node.TableDef.Indexes[i].TableExist || !catalog.IsRegularIndexAlgo(node.TableDef.Indexes[i].IndexAlgo) {
 			continue
 		}
 		if isSpatialIndexDef(node.TableDef.Indexes[i]) {
@@ -1174,7 +1174,8 @@ func findLeadingFilter(idxDef *IndexDef, node *plan.Node) ([]int32, bool) {
 	return nil, false
 }
 
-func (builder *QueryBuilder) replaceEqualCondition(filterList []*plan.Expr, filterPos []int32, idxTag int32, idxTableDef *plan.TableDef, numParts int) *plan.Expr {
+func (builder *QueryBuilder) replaceEqualCondition(idxDef *IndexDef, filterList []*plan.Expr, filterPos []int32, idxTag int32, idxTableDef *plan.TableDef) *plan.Expr {
+	numParts := len(idxDef.Parts)
 	if numParts == 1 { //directly equal
 		expr := DeepCopyExpr(filterList[filterPos[0]])
 		args := expr.GetF().Args
@@ -1191,7 +1192,7 @@ func (builder *QueryBuilder) replaceEqualCondition(filterList []*plan.Expr, filt
 		serialArgs[i] = DeepCopyExpr(filter.GetF().Args[1])
 		compositeFilterSel = compositeFilterSel * filter.Selectivity
 	}
-	rightArg, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", serialArgs)
+	rightArg, _ := BindFuncExprImplByPlanExpr(builder.GetContext(), indexTableLookupSerialFunc(idxDef), serialArgs)
 
 	funcName := "="
 	if len(filterPos) < numParts {
@@ -1203,12 +1204,13 @@ func (builder *QueryBuilder) replaceEqualCondition(filterList []*plan.Expr, filt
 	return expr
 }
 
-func (builder *QueryBuilder) replaceNonEqualCondition(filter *plan.Expr, idxTag int32, idxTableDef *plan.TableDef, numParts int) *plan.Expr {
+func (builder *QueryBuilder) replaceNonEqualCondition(idxDef *IndexDef, filter *plan.Expr, idxTag int32, idxTableDef *plan.TableDef) *plan.Expr {
+	numParts := len(idxDef.Parts)
 	expr := DeepCopyExpr(filter)
 	fn := expr.GetF()
 	if fn.Func.ObjName == "or" {
 		for i := range expr.GetF().Args {
-			expr.GetF().Args[i] = builder.replaceNonEqualCondition(expr.GetF().Args[i], idxTag, idxTableDef, numParts)
+			expr.GetF().Args[i] = builder.replaceNonEqualCondition(idxDef, expr.GetF().Args[i], idxTag, idxTableDef)
 		}
 		return expr
 	}
@@ -1235,31 +1237,32 @@ func (builder *QueryBuilder) replaceNonEqualCondition(filter *plan.Expr, idxTag 
 	fn.Args[0].GetCol().ColPos = 0
 	fn.Args[0].Typ = idxTableDef.Cols[0].Typ
 	if numParts > 1 {
+		serialFunc := indexTableLookupSerialFunc(idxDef)
 		switch fn.Func.ObjName {
 		case "between":
-			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[1]})
-			fn.Args[2], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[2]})
+			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[1]})
+			fn.Args[2], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[2]})
 			expr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "prefix_between", fn.Args)
 		case "in":
-			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[1]})
+			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[1]})
 			expr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "prefix_in", fn.Args)
 		case ">", ">=", "<", "<=":
-			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[1]})
+			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[1]})
 			expr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), fn.Func.ObjName, fn.Args)
 		case "in_range":
-			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[1]})
-			fn.Args[2], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{fn.Args[2]})
+			fn.Args[1], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[1]})
+			fn.Args[2], _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{fn.Args[2]})
 			expr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "prefix_in_range", fn.Args)
 		}
 	}
 	return expr
 }
 
-func (builder *QueryBuilder) replaceLeadingFilter(filterList []*plan.Expr, leadingPos []int32, leadingEqualCond bool, idxTag int32, idxTableDef *plan.TableDef, numParts int) *plan.Expr {
+func (builder *QueryBuilder) replaceLeadingFilter(idxDef *IndexDef, filterList []*plan.Expr, leadingPos []int32, leadingEqualCond bool, idxTag int32, idxTableDef *plan.TableDef) *plan.Expr {
 	if !leadingEqualCond { // a IN (1, 2, 3), a BETWEEN 1 AND 2
-		return builder.replaceNonEqualCondition(filterList[leadingPos[0]], idxTag, idxTableDef, numParts)
+		return builder.replaceNonEqualCondition(idxDef, filterList[leadingPos[0]], idxTag, idxTableDef)
 	}
-	return builder.replaceEqualCondition(filterList, leadingPos, idxTag, idxTableDef, numParts)
+	return builder.replaceEqualCondition(idxDef, filterList, leadingPos, idxTag, idxTableDef)
 }
 
 func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node, colRefCnt map[[2]int32]int, idxColMap map[[2]int32]*plan.Expr, scanSnapshot *Snapshot) int32 {
@@ -1363,7 +1366,7 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 		}
 	}
 
-	newLeadingFilter := builder.replaceLeadingFilter(node.FilterList, leadingPos, leadingEqualCond, idxTag, idxTableDef, numParts)
+	newLeadingFilter := builder.replaceLeadingFilter(idxDef, node.FilterList, leadingPos, leadingEqualCond, idxTag, idxTableDef)
 	newFilterList := make([]*plan.Expr, 0, len(node.FilterList))
 	newFilterList = append(newFilterList, newLeadingFilter)
 	for _, idx := range missFilterIdx {
@@ -1658,7 +1661,8 @@ func rangeFilterConstValue(fn *plan.Function) *plan.Expr {
 	return nil
 }
 
-func (builder *QueryBuilder) replaceRangePairCondition(filterList []*plan.Expr, filterIdx []int32, idxTag int32, idxTableDef *plan.TableDef, numParts int) *plan.Expr {
+func (builder *QueryBuilder) replaceRangePairCondition(idxDef *IndexDef, filterList []*plan.Expr, filterIdx []int32, idxTag int32, idxTableDef *plan.TableDef) *plan.Expr {
+	numParts := len(idxDef.Parts)
 	lowerFn := filterList[filterIdx[0]].GetF()
 	upperFn := filterList[filterIdx[1]].GetF()
 
@@ -1672,8 +1676,9 @@ func (builder *QueryBuilder) replaceRangePairCondition(filterList []*plan.Expr, 
 	compositeFilterSel := filterList[filterIdx[0]].Selectivity * filterList[filterIdx[1]].Selectivity
 
 	if numParts > 1 {
-		lowerVal, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{lowerVal})
-		upperVal, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", []*plan.Expr{upperVal})
+		serialFunc := indexTableLookupSerialFunc(idxDef)
+		lowerVal, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{lowerVal})
+		upperVal, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), serialFunc, []*plan.Expr{upperVal})
 	}
 
 	if lowerOp == ">=" && upperOp == "<=" {
@@ -1710,17 +1715,16 @@ func (builder *QueryBuilder) applyIndexJoin(idxDef *IndexDef, node *plan.Node, f
 	}
 	builder.addNameByColRef(idxTag, idxTableDef)
 
-	numParts := len(idxDef.Parts)
 	var idxFilter *plan.Expr
 	if filterType == EqualIndexCondition {
-		idxFilter = builder.replaceEqualCondition(node.FilterList, filterIdx, idxTag, idxTableDef, numParts)
+		idxFilter = builder.replaceEqualCondition(idxDef, node.FilterList, filterIdx, idxTag, idxTableDef)
 	} else if filterType == SpatialIndexCondition {
 		spatialColMap := buildSpatialIndexColMap(idxDef, node, idxTag, idxTableDef)
 		idxFilter = replaceColumnsForExpr(DeepCopyExpr(node.FilterList[filterIdx[0]]), spatialColMap)
 	} else if filterType == RangeIndexCondition {
-		idxFilter = builder.replaceRangePairCondition(node.FilterList, filterIdx, idxTag, idxTableDef, numParts)
+		idxFilter = builder.replaceRangePairCondition(idxDef, node.FilterList, filterIdx, idxTag, idxTableDef)
 	} else {
-		idxFilter = builder.replaceNonEqualCondition(node.FilterList[filterIdx[0]], idxTag, idxTableDef, numParts)
+		idxFilter = builder.replaceNonEqualCondition(idxDef, node.FilterList[filterIdx[0]], idxTag, idxTableDef)
 	}
 
 	// recod index table scan info
@@ -1978,7 +1982,7 @@ func (builder *QueryBuilder) applyIndicesForJoins(nodeID int32, node *plan.Node,
 					},
 				}
 			}
-			rfBuildExpr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), "serial", serialArgs)
+			rfBuildExpr, _ = BindFuncExprImplByPlanExpr(builder.GetContext(), indexTableLookupSerialFunc(idxDef), serialArgs)
 		}
 
 		probeExpr := &plan.Expr{

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1265,8 +1265,79 @@ func (builder *QueryBuilder) replaceLeadingFilter(idxDef *IndexDef, filterList [
 	return builder.replaceEqualCondition(idxDef, filterList, leadingPos, idxTag, idxTableDef)
 }
 
-func needsIndexOnlyResidualLeadingFilters(idxDef *IndexDef) bool {
-	return indexTableLookupSerialFunc(idxDef) == "serial_full"
+func needsIndexOnlyResidualLeadingFilters(idxDef *IndexDef, filterList []*plan.Expr, leadingPos []int32) bool {
+	if indexTableLookupSerialFunc(idxDef) != "serial_full" {
+		return false
+	}
+	for _, pos := range leadingPos {
+		if pos < 0 || int(pos) >= len(filterList) {
+			continue
+		}
+		if indexFilterMayCompareNullAtRuntime(filterList[pos]) {
+			return true
+		}
+	}
+	return false
+}
+
+func indexFilterMayCompareNullAtRuntime(expr *plan.Expr) bool {
+	if expr == nil {
+		return false
+	}
+	fn := expr.GetF()
+	if fn == nil || fn.Func == nil {
+		return false
+	}
+	switch fn.Func.ObjName {
+	case "=":
+		return len(fn.Args) > 1 && (runtimeConstMayBeNull(fn.Args[0]) || runtimeConstMayBeNull(fn.Args[1]))
+	case "in":
+		return len(fn.Args) > 1 && runtimeConstMayBeNull(fn.Args[1])
+	case "between":
+		return len(fn.Args) > 2 && (runtimeConstMayBeNull(fn.Args[1]) || runtimeConstMayBeNull(fn.Args[2]))
+	case ">", ">=", "<", "<=":
+		return len(fn.Args) > 1 && (runtimeConstMayBeNull(fn.Args[0]) || runtimeConstMayBeNull(fn.Args[1]))
+	case "in_range":
+		return len(fn.Args) > 2 && (runtimeConstMayBeNull(fn.Args[1]) || runtimeConstMayBeNull(fn.Args[2]))
+	case "or":
+		for _, arg := range fn.Args {
+			if indexFilterMayCompareNullAtRuntime(arg) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func runtimeConstMayBeNull(expr *plan.Expr) bool {
+	if expr == nil {
+		return false
+	}
+	switch exprImpl := expr.Expr.(type) {
+	case *plan.Expr_P, *plan.Expr_V:
+		return true
+	case *plan.Expr_Lit:
+		return exprImpl.Lit != nil && exprImpl.Lit.GetIsnull()
+	case *plan.Expr_List:
+		if exprImpl.List == nil {
+			return false
+		}
+		for _, item := range exprImpl.List.List {
+			if runtimeConstMayBeNull(item) {
+				return true
+			}
+		}
+	case *plan.Expr_F:
+		if exprImpl.F == nil {
+			return false
+		}
+		for _, arg := range exprImpl.F.Args {
+			if runtimeConstMayBeNull(arg) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node, colRefCnt map[[2]int32]int, idxColMap map[[2]int32]*plan.Expr, scanSnapshot *Snapshot) int32 {
@@ -1373,7 +1444,7 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 	newLeadingFilter := builder.replaceLeadingFilter(idxDef, node.FilterList, leadingPos, leadingEqualCond, idxTag, idxTableDef)
 	newFilterList := make([]*plan.Expr, 0, len(node.FilterList))
 	newFilterList = append(newFilterList, newLeadingFilter)
-	if needsIndexOnlyResidualLeadingFilters(idxDef) {
+	if needsIndexOnlyResidualLeadingFilters(idxDef, node.FilterList, leadingPos) {
 		// serial_full preserves NULL as key bytes. Keep the original SQL
 		// predicate as a residual recheck so prepared NULL values still follow
 		// SQL three-valued logic on covering index-only scans.

--- a/pkg/sql/plan/apply_indices.go
+++ b/pkg/sql/plan/apply_indices.go
@@ -1265,6 +1265,10 @@ func (builder *QueryBuilder) replaceLeadingFilter(idxDef *IndexDef, filterList [
 	return builder.replaceEqualCondition(idxDef, filterList, leadingPos, idxTag, idxTableDef)
 }
 
+func needsIndexOnlyResidualLeadingFilters(idxDef *IndexDef) bool {
+	return indexTableLookupSerialFunc(idxDef) == "serial_full"
+}
+
 func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node, colRefCnt map[[2]int32]int, idxColMap map[[2]int32]*plan.Expr, scanSnapshot *Snapshot) int32 {
 	// check if this index contains all columns needed
 	for i := range node.TableDef.Cols {
@@ -1369,6 +1373,14 @@ func (builder *QueryBuilder) tryIndexOnlyScan(idxDef *IndexDef, node *plan.Node,
 	newLeadingFilter := builder.replaceLeadingFilter(idxDef, node.FilterList, leadingPos, leadingEqualCond, idxTag, idxTableDef)
 	newFilterList := make([]*plan.Expr, 0, len(node.FilterList))
 	newFilterList = append(newFilterList, newLeadingFilter)
+	if needsIndexOnlyResidualLeadingFilters(idxDef) {
+		// serial_full preserves NULL as key bytes. Keep the original SQL
+		// predicate as a residual recheck so prepared NULL values still follow
+		// SQL three-valued logic on covering index-only scans.
+		for _, idx := range leadingPos {
+			newFilterList = append(newFilterList, replaceColumnsForExpr(DeepCopyExpr(node.FilterList[idx]), idxColMap))
+		}
+	}
 	for _, idx := range missFilterIdx {
 		newFilterList = append(newFilterList, replaceColumnsForExpr(node.FilterList[idx], idxColMap))
 	}
@@ -1920,7 +1932,7 @@ func (builder *QueryBuilder) applyIndicesForJoins(nodeID int32, node *plan.Node,
 	indexes := leftChild.TableDef.Indexes
 	condIdx := make([]int, 0, len(col2Cond))
 	for _, idxDef := range indexes {
-		if !idxDef.TableExist {
+		if !idxDef.TableExist || !catalog.IsRegularIndexAlgo(idxDef.IndexAlgo) || isSpatialIndexDef(idxDef) {
 			continue
 		}
 

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -380,6 +380,56 @@ func TestFullTextScanProtectionSkipsRegularIndexRule(t *testing.T) {
 	require.Len(t, leftScan.FilterList, 1)
 }
 
+func TestRegularIndexRuleSkipsIrregularIndexes(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	bindTag := builder.genNewBindTag()
+	nodeID := int32(12)
+	node := &planpb.Node{
+		NodeId:      nodeID,
+		BindingTags: []int32{bindTag},
+		TableDef: &planpb.TableDef{
+			Name: "t",
+			Name2ColIndex: map[string]int32{
+				"id":     0,
+				"status": 1,
+			},
+			Cols: []*planpb.ColDef{
+				{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+				{Name: "status", Typ: planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}},
+			},
+			Pkey: &planpb.PrimaryKeyDef{
+				Names:       []string{"id"},
+				PkeyColName: "id",
+			},
+			Indexes: []*planpb.IndexDef{
+				{
+					IndexName:      "idx_master_status",
+					IndexAlgo:      catalog.MOIndexMasterAlgo.ToString(),
+					IndexTableName: "__mo_index_master_status",
+					Parts:          []string{"status", "id"},
+					TableExist:     true,
+				},
+				{
+					IndexName:      "idx_ivf_status",
+					IndexAlgo:      catalog.MoIndexIvfFlatAlgo.ToString(),
+					IndexTableName: "__mo_index_ivf_status",
+					Parts:          []string{"status", "id"},
+					TableExist:     true,
+				},
+			},
+		},
+		Stats: &planpb.Stats{TableCnt: 10, Outcnt: 1, Selectivity: 0.1},
+		FilterList: []*planpb.Expr{
+			makeStringEqFilterExpr(bindTag, 1, "active"),
+		},
+	}
+
+	got := builder.applyIndicesForFiltersRegularIndex(nodeID, node, map[[2]int32]int{}, map[[2]int32]*planpb.Expr{})
+
+	require.Equal(t, nodeID, got)
+	require.Empty(t, builder.qry.Nodes)
+}
+
 func TestFindMatchFullTextIndexRequiresScanBindingAndLiteralPattern(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
 	ftDef := makeFullTextJoinTestTableDef("ft", true)
@@ -844,6 +894,10 @@ func TestCalculateFilteredPostModeOverFetchFactor_ActualValues(t *testing.T) {
 }
 
 func makeTestRegularIndexPrefixEq(t *testing.T, numArgs int) *planpb.Expr {
+	return makeTestRegularIndexPrefixEqWithSerialFunc(t, numArgs, "serial_full")
+}
+
+func makeTestRegularIndexPrefixEqWithSerialFunc(t *testing.T, numArgs int, serialFunc string) *planpb.Expr {
 	t.Helper()
 	args := make([]*planpb.Expr, 0, numArgs)
 	for i := 0; i < numArgs; i++ {
@@ -856,7 +910,7 @@ func makeTestRegularIndexPrefixEq(t *testing.T, numArgs int) *planpb.Expr {
 			},
 		})
 	}
-	serialExpr, err := BindFuncExprImplByPlanExpr(context.Background(), "serial", args)
+	serialExpr, err := BindFuncExprImplByPlanExpr(context.Background(), serialFunc, args)
 	require.NoError(t, err)
 	prefixExpr, err := BindFuncExprImplByPlanExpr(context.Background(), "prefix_eq", []*planpb.Expr{
 		GetColExpr(planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}, 100, 0),
@@ -1146,6 +1200,11 @@ func TestHandleMessageFromTopToScanKeepsPKOrderWhenPrefixIncomplete(t *testing.T
 	assert.Equal(t, catalog.IndexTablePrimaryColName, scanOrderCol.Name)
 }
 
+func TestRegularIndexFullPrefixEqualityRequiresSerialFull(t *testing.T) {
+	assert.True(t, isRegularIndexFullPrefixEquality(makeTestRegularIndexPrefixEq(t, 2), 2))
+	assert.False(t, isRegularIndexFullPrefixEquality(makeTestRegularIndexPrefixEqWithSerialFunc(t, 2, "serial"), 2))
+}
+
 func TestApplyIndicesForProjectSkipsRegularIndexPKOrderWithoutFullPrefixEquality(t *testing.T) {
 	builder, rootNodeID := makeTestRegularIndexProjectBuilder(
 		t,
@@ -1420,9 +1479,77 @@ func TestGetIndexForNonEquiCond_SkipsLargePairedRangeByStats(t *testing.T) {
 	require.Nil(t, filterIdx)
 }
 
+func TestIndexTableLookupSerialFunc(t *testing.T) {
+	assert.Equal(t, "serial_full", indexTableLookupSerialFunc(&planpb.IndexDef{
+		Parts:  []string{"status", catalog.CreateAlias(catalog.CPrimaryKeyColName)},
+		Unique: false,
+	}))
+	assert.Equal(t, "serial", indexTableLookupSerialFunc(&planpb.IndexDef{
+		Parts:  []string{"status", "due"},
+		Unique: true,
+	}))
+	assert.Equal(t, "serial", indexTableLookupSerialFunc(&planpb.IndexDef{
+		Parts:  []string{"status"},
+		Unique: false,
+	}))
+}
+
+func TestReplaceEqualConditionUsesSerialFullForNonUniqueCompositeIndex(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"status", "due", catalog.CreateAlias(catalog.CPrimaryKeyColName)},
+		Unique: false,
+	}
+	idxTableDef := makeTestIndexTableDef()
+	filters := []*planpb.Expr{makeStringEqFilterExpr(0, 3, "active")}
+
+	expr := builder.replaceEqualCondition(idxDef, filters, []int32{0}, 42, idxTableDef)
+
+	require.NotNil(t, expr.GetF())
+	require.Equal(t, "prefix_eq", expr.GetF().Func.ObjName)
+	assert.Equal(t, "serial_full", wrappedSerialFuncName(t, expr.GetF().Args[1]))
+}
+
+func TestReplaceEqualConditionKeepsSerialForUniqueCompositeIndex(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"status", "due"},
+		Unique: true,
+	}
+	idxTableDef := makeTestIndexTableDef()
+	filters := []*planpb.Expr{
+		makeStringEqFilterExpr(0, 3, "active"),
+		makeStringEqFilterExpr(0, 4, "2026-07-02 00:00:00"),
+	}
+
+	expr := builder.replaceEqualCondition(idxDef, filters, []int32{0, 1}, 42, idxTableDef)
+
+	require.NotNil(t, expr.GetF())
+	require.Equal(t, "=", expr.GetF().Func.ObjName)
+	assert.Equal(t, "serial", wrappedSerialFuncName(t, expr.GetF().Args[1]))
+}
+
+func TestReplaceNonEqualConditionUsesSerialFullForNonUniqueCompositeIndexIn(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"status", "due", catalog.CreateAlias(catalog.CPrimaryKeyColName)},
+		Unique: false,
+	}
+
+	expr := builder.replaceNonEqualCondition(idxDef, makeStringInFilterExpr(0, 3, "active", "expiring"), 42, makeTestIndexTableDef())
+
+	require.NotNil(t, expr.GetF())
+	require.Equal(t, "prefix_in", expr.GetF().Func.ObjName)
+	assert.Equal(t, "serial_full", wrappedSerialFuncName(t, expr.GetF().Args[1]))
+}
+
 func TestReplaceRangePairCondition_UsesPrefixBetweenForSecondaryIndex(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
 	bindTag := builder.genNewBindTag()
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"price", catalog.CreateAlias(catalog.CPrimaryKeyColName)},
+		Unique: false,
+	}
 	filters := []*planpb.Expr{
 		makeRangeFilterExpr(bindTag, 1, ">=", 99),
 		makeRangeFilterExpr(bindTag, 1, "<=", 299),
@@ -1443,9 +1570,11 @@ func TestReplaceRangePairCondition_UsesPrefixBetweenForSecondaryIndex(t *testing
 		},
 	}
 
-	expr := builder.replaceRangePairCondition(filters, []int32{0, 1}, 42, idxTableDef, 2)
+	expr := builder.replaceRangePairCondition(idxDef, filters, []int32{0, 1}, 42, idxTableDef)
 	require.NotNil(t, expr.GetF())
 	require.Equal(t, "prefix_between", expr.GetF().Func.ObjName)
+	assert.Equal(t, "serial_full", wrappedSerialFuncName(t, expr.GetF().Args[1]))
+	assert.Equal(t, "serial_full", wrappedSerialFuncName(t, expr.GetF().Args[2]))
 	require.InDelta(t, 0.12, expr.Selectivity, 1e-9)
 }
 
@@ -1563,6 +1692,100 @@ func makeEqFilterExpr(colPos int32) *planpb.Expr {
 			},
 		},
 	}
+}
+
+func makeTestIndexTableDef() *planpb.TableDef {
+	return &planpb.TableDef{
+		Cols: []*planpb.ColDef{
+			{
+				Name: catalog.IndexTableIndexColName,
+				Typ:  planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen},
+			},
+			{
+				Name: catalog.IndexTablePrimaryColName,
+				Typ:  planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen},
+			},
+		},
+	}
+}
+
+func makeStringEqFilterExpr(relPos, colPos int32, val string) *planpb.Expr {
+	typ := planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "="},
+				Args: []*planpb.Expr{
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Col{
+							Col: &planpb.ColRef{
+								RelPos: relPos,
+								ColPos: colPos,
+							},
+						},
+					},
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Lit{
+							Lit: &planpb.Literal{
+								Value: &planpb.Literal_Sval{Sval: val},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeStringInFilterExpr(relPos, colPos int32, vals ...string) *planpb.Expr {
+	typ := planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}
+	list := make([]*planpb.Expr, 0, len(vals))
+	for _, val := range vals {
+		list = append(list, &planpb.Expr{
+			Typ: typ,
+			Expr: &planpb.Expr_Lit{
+				Lit: &planpb.Literal{
+					Value: &planpb.Literal_Sval{Sval: val},
+				},
+			},
+		})
+	}
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "in"},
+				Args: []*planpb.Expr{
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Col{
+							Col: &planpb.ColRef{
+								RelPos: relPos,
+								ColPos: colPos,
+							},
+						},
+					},
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_List{
+							List: &planpb.ExprList{List: list},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func wrappedSerialFuncName(t *testing.T, expr *planpb.Expr) string {
+	t.Helper()
+	require.NotNil(t, expr)
+	fn := expr.GetF()
+	require.NotNil(t, fn)
+	return fn.Func.ObjName
 }
 
 func makeRangeFilterExpr(relPos, colPos int32, op string, val int64) *planpb.Expr {

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -1540,7 +1540,27 @@ func TestReplaceNonEqualConditionUsesSerialFullForNonUniqueCompositeIndexIn(t *t
 
 	require.NotNil(t, expr.GetF())
 	require.Equal(t, "prefix_in", expr.GetF().Func.ObjName)
-	assert.Equal(t, "serial_full", wrappedSerialFuncName(t, expr.GetF().Args[1]))
+	assertListItemsWrappedBySerialFunc(t, expr.GetF().Args[1], "serial_full", 2)
+}
+
+func TestReplaceNonEqualConditionWrapsEachPreparedInListItemWithSerialFull(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	idxDef := &planpb.IndexDef{
+		Parts:  []string{"b", catalog.CreateAlias(catalog.CPrimaryKeyColName)},
+		Unique: false,
+	}
+
+	expr := builder.replaceNonEqualCondition(idxDef, makeParamInFilterExpr(0, 1, 10), 42, makeTestIndexTableDef())
+
+	require.NotNil(t, expr.GetF())
+	require.Equal(t, "prefix_in", expr.GetF().Func.ObjName)
+	assertListItemsWrappedBySerialFunc(t, expr.GetF().Args[1], "serial_full", 10)
+	for i, item := range expr.GetF().Args[1].GetList().List {
+		args := item.GetF().Args
+		require.Len(t, args, 1)
+		require.NotNil(t, args[0].GetP())
+		assert.Equal(t, int32(i), args[0].GetP().Pos)
+	}
 }
 
 func TestReplaceRangePairCondition_UsesPrefixBetweenForSecondaryIndex(t *testing.T) {
@@ -1786,6 +1806,55 @@ func wrappedSerialFuncName(t *testing.T, expr *planpb.Expr) string {
 	fn := expr.GetF()
 	require.NotNil(t, fn)
 	return fn.Func.ObjName
+}
+
+func assertListItemsWrappedBySerialFunc(t *testing.T, expr *planpb.Expr, serialFunc string, expectedLen int) {
+	t.Helper()
+	require.NotNil(t, expr)
+	list := expr.GetList()
+	require.NotNil(t, list)
+	require.Len(t, list.List, expectedLen)
+	for _, item := range list.List {
+		assert.Equal(t, serialFunc, wrappedSerialFuncName(t, item))
+	}
+}
+
+func makeParamInFilterExpr(relPos, colPos int32, n int) *planpb.Expr {
+	typ := planpb.Type{Id: int32(types.T_int32)}
+	list := make([]*planpb.Expr, 0, n)
+	for i := 0; i < n; i++ {
+		list = append(list, &planpb.Expr{
+			Typ: typ,
+			Expr: &planpb.Expr_P{
+				P: &planpb.ParamRef{Pos: int32(i)},
+			},
+		})
+	}
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "in"},
+				Args: []*planpb.Expr{
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Col{
+							Col: &planpb.ColRef{
+								RelPos: relPos,
+								ColPos: colPos,
+							},
+						},
+					},
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_List{
+							List: &planpb.ExprList{List: list},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func makeRangeFilterExpr(relPos, colPos int32, op string, val int64) *planpb.Expr {

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -430,6 +430,83 @@ func TestRegularIndexRuleSkipsIrregularIndexes(t *testing.T) {
 	require.Empty(t, builder.qry.Nodes)
 }
 
+func TestApplyIndicesForJoinsSkipsIrregularIndexes(t *testing.T) {
+	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+	ctx := NewBindContext(builder, nil)
+	leftTag := builder.genNewBindTag()
+	rightTag := builder.genNewBindTag()
+
+	leftDef := &planpb.TableDef{
+		Name: "left_t",
+		Cols: []*planpb.ColDef{
+			{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+			{Name: "status", Typ: planpb.Type{Id: int32(types.T_int32)}},
+		},
+		Name2ColIndex: map[string]int32{
+			"id":     0,
+			"status": 1,
+		},
+		Pkey: &planpb.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+		Indexes: []*planpb.IndexDef{
+			{
+				IndexName:      "idx_master_status",
+				IndexAlgo:      catalog.MOIndexMasterAlgo.ToString(),
+				IndexTableName: "__mo_master_status",
+				Parts:          []string{"status", "id"},
+				TableExist:     true,
+			},
+			{
+				IndexName:      "idx_fulltext_status",
+				IndexAlgo:      catalog.MOIndexFullTextAlgo.ToString(),
+				IndexTableName: "__mo_fulltext_status",
+				Parts:          []string{"status", "id"},
+				TableExist:     true,
+			},
+			{
+				IndexName:      "idx_vector_status",
+				IndexAlgo:      catalog.MoIndexIvfFlatAlgo.ToString(),
+				IndexTableName: "__mo_vector_status",
+				Parts:          []string{"status", "id"},
+				TableExist:     true,
+			},
+			{
+				IndexName:      "idx_spatial_status",
+				IndexAlgo:      catalog.MoIndexRTreeAlgo.ToString(),
+				IndexTableName: "__mo_spatial_status",
+				Parts:          []string{"status", "id"},
+				TableExist:     true,
+			},
+		},
+	}
+	rightDef := &planpb.TableDef{
+		Name: "right_t",
+		Cols: []*planpb.ColDef{
+			{Name: "status", Typ: planpb.Type{Id: int32(types.T_int32)}},
+		},
+		Name2ColIndex: map[string]int32{"status": 0},
+	}
+
+	leftScanID := builder.appendNode(makeJoinIndexTestScan(leftDef, leftTag), ctx)
+	rightScanID := builder.appendNode(makeJoinIndexTestScan(rightDef, rightTag), ctx)
+	joinCond := ftjMakeEqExpr(t, ftjColExpr(leftDef, leftTag, 1), ftjColExpr(rightDef, rightTag, 0))
+	joinID := builder.appendNode(&planpb.Node{
+		NodeType: planpb.Node_JOIN,
+		Children: []int32{leftScanID, rightScanID},
+		JoinType: planpb.Node_INNER,
+		OnList:   []*planpb.Expr{joinCond},
+	}, ctx)
+
+	newID, err := builder.applyIndicesForJoins(joinID, builder.qry.Nodes[joinID], map[[2]int32]int{}, map[[2]int32]*planpb.Expr{})
+	require.NoError(t, err)
+	require.Equal(t, joinID, newID)
+
+	joinNode := builder.qry.Nodes[joinID]
+	require.Equal(t, leftScanID, joinNode.Children[0])
+	require.Equal(t, rightScanID, joinNode.Children[1])
+	require.Empty(t, joinNode.RuntimeFilterBuildList)
+	require.Len(t, builder.qry.Nodes, 3)
+}
+
 func TestFindMatchFullTextIndexRequiresScanBindingAndLiteralPattern(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
 	ftDef := makeFullTextJoinTestTableDef("ft", true)
@@ -577,6 +654,21 @@ func makeFullTextJoinTestScan(tableDef *planpb.TableDef, tag int32, filters []*p
 		ObjRef:      &planpb.ObjectRef{SchemaName: "test", ObjName: tableDef.Name},
 		BindingTags: []int32{tag},
 		FilterList:  filters,
+		Stats: &planpb.Stats{
+			TableCnt:    1000,
+			Outcnt:      100,
+			Selectivity: 0.1,
+			Cost:        1000,
+		},
+	}
+}
+
+func makeJoinIndexTestScan(tableDef *planpb.TableDef, tag int32) *planpb.Node {
+	return &planpb.Node{
+		NodeType:    planpb.Node_TABLE_SCAN,
+		TableDef:    tableDef,
+		ObjRef:      &planpb.ObjectRef{SchemaName: "test", ObjName: tableDef.Name},
+		BindingTags: []int32{tag},
 		Stats: &planpb.Stats{
 			TableCnt:    1000,
 			Outcnt:      100,
@@ -1563,6 +1655,89 @@ func TestReplaceNonEqualConditionWrapsEachPreparedInListItemWithSerialFull(t *te
 	}
 }
 
+func TestTryIndexOnlyScanKeepsResidualFilterForSerialFullNullSemantics(t *testing.T) {
+	tests := []struct {
+		name         string
+		makeFilter   func(relPos int32) *planpb.Expr
+		lookupFunc   string
+		residualFunc string
+	}{
+		{
+			name: "prepared equality",
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeParamEqFilterExpr(relPos, 1, 0)
+			},
+			lookupFunc:   "prefix_eq",
+			residualFunc: "=",
+		},
+		{
+			name: "prepared in list",
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeParamInFilterExpr(relPos, 1, 2)
+			},
+			lookupFunc:   "prefix_in",
+			residualFunc: "in",
+		},
+		{
+			name: "prepared between",
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeParamBetweenFilterExpr(relPos, 1, 0, 1)
+			},
+			lookupFunc:   "prefix_between",
+			residualFunc: "between",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+			ctx := NewBindContext(builder, nil)
+			bindTag := builder.genNewBindTag()
+			idxDef := &planpb.IndexDef{
+				IndexName:      "idx_status_id",
+				IndexAlgo:      catalog.MoIndexDefaultAlgo.ToString(),
+				IndexTableName: "__mo_idx_status_id",
+				Parts:          []string{"status", "id"},
+				Unique:         false,
+				TableExist:     true,
+			}
+			registerMockIndexTable(t, builder, idxDef.IndexTableName)
+			node := &planpb.Node{
+				NodeType:    planpb.Node_TABLE_SCAN,
+				ObjRef:      &planpb.ObjectRef{SchemaName: "test", ObjName: "t"},
+				BindingTags: []int32{bindTag},
+				TableDef: &planpb.TableDef{
+					Name: "t",
+					Cols: []*planpb.ColDef{
+						{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+						{Name: "status", Typ: planpb.Type{Id: int32(types.T_int32)}},
+					},
+					Name2ColIndex: map[string]int32{
+						"id":     0,
+						"status": 1,
+					},
+					Pkey: &planpb.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+				},
+				Stats:      &planpb.Stats{TableCnt: 100, Outcnt: 1, Selectivity: 0.01, Cost: 100},
+				FilterList: []*planpb.Expr{tt.makeFilter(bindTag)},
+			}
+			scanID := builder.appendNode(node, ctx)
+
+			idxNodeID := builder.tryIndexOnlyScan(idxDef, builder.qry.Nodes[scanID], map[[2]int32]int{{bindTag, 1}: 1}, map[[2]int32]*planpb.Expr{}, &Snapshot{})
+			require.NotEqual(t, int32(-1), idxNodeID)
+
+			idxNode := builder.qry.Nodes[idxNodeID]
+			require.Len(t, idxNode.FilterList, 2)
+			require.Equal(t, tt.lookupFunc, idxNode.FilterList[0].GetF().Func.ObjName)
+
+			residual := idxNode.FilterList[1].GetF()
+			require.NotNil(t, residual)
+			require.Equal(t, tt.residualFunc, residual.Func.ObjName)
+			require.Equal(t, "serial_extract", wrappedSerialFuncName(t, residual.Args[0]))
+		})
+	}
+}
+
 func TestReplaceRangePairCondition_UsesPrefixBetweenForSecondaryIndex(t *testing.T) {
 	builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
 	bindTag := builder.genNewBindTag()
@@ -1716,6 +1891,7 @@ func makeEqFilterExpr(colPos int32) *planpb.Expr {
 
 func makeTestIndexTableDef() *planpb.TableDef {
 	return &planpb.TableDef{
+		Name: "__mo_index_table",
 		Cols: []*planpb.ColDef{
 			{
 				Name: catalog.IndexTableIndexColName,
@@ -1726,6 +1902,30 @@ func makeTestIndexTableDef() *planpb.TableDef {
 				Typ:  planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen},
 			},
 		},
+		Name2ColIndex: map[string]int32{
+			catalog.IndexTableIndexColName:   0,
+			catalog.IndexTablePrimaryColName: 1,
+		},
+	}
+}
+
+func registerMockIndexTable(t *testing.T, builder *QueryBuilder, indexTableName string) {
+	t.Helper()
+
+	key := strings.ToLower(indexTableName)
+	objRef := &planpb.ObjectRef{SchemaName: "test", ObjName: indexTableName}
+	tableDef := makeTestIndexTableDef()
+	tableDef.Name = indexTableName
+
+	switch mockCtx := builder.compCtx.(type) {
+	case *MockCompilerContext:
+		mockCtx.objects[key] = objRef
+		mockCtx.tables[key] = tableDef
+	case *fullTextJoinMockCompilerContext:
+		mockCtx.objects[key] = objRef
+		mockCtx.tables[key] = tableDef
+	default:
+		t.Fatalf("unexpected compiler context %T", builder.compCtx)
 	}
 }
 
@@ -1752,6 +1952,35 @@ func makeStringEqFilterExpr(relPos, colPos int32, val string) *planpb.Expr {
 							Lit: &planpb.Literal{
 								Value: &planpb.Literal_Sval{Sval: val},
 							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeParamEqFilterExpr(relPos, colPos, paramPos int32) *planpb.Expr {
+	typ := planpb.Type{Id: int32(types.T_int32)}
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "="},
+				Args: []*planpb.Expr{
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Col{
+							Col: &planpb.ColRef{
+								RelPos: relPos,
+								ColPos: colPos,
+							},
+						},
+					},
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_P{
+							P: &planpb.ParamRef{Pos: paramPos},
 						},
 					},
 				},
@@ -1849,6 +2078,41 @@ func makeParamInFilterExpr(relPos, colPos int32, n int) *planpb.Expr {
 						Typ: typ,
 						Expr: &planpb.Expr_List{
 							List: &planpb.ExprList{List: list},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeParamBetweenFilterExpr(relPos, colPos, lowerParamPos, upperParamPos int32) *planpb.Expr {
+	typ := planpb.Type{Id: int32(types.T_int32)}
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "between"},
+				Args: []*planpb.Expr{
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Col{
+							Col: &planpb.ColRef{
+								RelPos: relPos,
+								ColPos: colPos,
+							},
+						},
+					},
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_P{
+							P: &planpb.ParamRef{Pos: lowerParamPos},
+						},
+					},
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_P{
+							P: &planpb.ParamRef{Pos: upperParamPos},
 						},
 					},
 				},

--- a/pkg/sql/plan/apply_indices_test.go
+++ b/pkg/sql/plan/apply_indices_test.go
@@ -1679,6 +1679,22 @@ func TestTryIndexOnlyScanKeepsResidualFilterForSerialFullNullSemantics(t *testin
 			residualFunc: "in",
 		},
 		{
+			name: "literal null equality",
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeNullEqFilterExpr(relPos, 1)
+			},
+			lookupFunc:   "prefix_eq",
+			residualFunc: "=",
+		},
+		{
+			name: "literal null in list",
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeIntInFilterExprWithNull(relPos, 1)
+			},
+			lookupFunc:   "prefix_in",
+			residualFunc: "in",
+		},
+		{
 			name: "prepared between",
 			makeFilter: func(relPos int32) *planpb.Expr {
 				return makeParamBetweenFilterExpr(relPos, 1, 0, 1)
@@ -1734,6 +1750,80 @@ func TestTryIndexOnlyScanKeepsResidualFilterForSerialFullNullSemantics(t *testin
 			require.NotNil(t, residual)
 			require.Equal(t, tt.residualFunc, residual.Func.ObjName)
 			require.Equal(t, "serial_extract", wrappedSerialFuncName(t, residual.Args[0]))
+		})
+	}
+}
+
+func TestTryIndexOnlyScanSkipsResidualFilterForNonNullSerialFullLiterals(t *testing.T) {
+	tests := []struct {
+		name       string
+		makeFilter func(relPos int32) *planpb.Expr
+		lookupFunc string
+	}{
+		{
+			name: "literal equality",
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringEqFilterExpr(relPos, 1, "active")
+			},
+			lookupFunc: "prefix_eq",
+		},
+		{
+			name: "literal in list",
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringInFilterExpr(relPos, 1, "active", "expired")
+			},
+			lookupFunc: "prefix_in",
+		},
+		{
+			name: "literal between",
+			makeFilter: func(relPos int32) *planpb.Expr {
+				return makeStringBetweenFilterExpr(relPos, 1, "active", "expired")
+			},
+			lookupFunc: "prefix_between",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewQueryBuilder(planpb.Query_SELECT, NewMockCompilerContext(true), false, true)
+			ctx := NewBindContext(builder, nil)
+			bindTag := builder.genNewBindTag()
+			idxDef := &planpb.IndexDef{
+				IndexName:      "idx_status_id",
+				IndexAlgo:      catalog.MoIndexDefaultAlgo.ToString(),
+				IndexTableName: "__mo_idx_status_id",
+				Parts:          []string{"status", "id"},
+				Unique:         false,
+				TableExist:     true,
+			}
+			registerMockIndexTable(t, builder, idxDef.IndexTableName)
+			node := &planpb.Node{
+				NodeType:    planpb.Node_TABLE_SCAN,
+				ObjRef:      &planpb.ObjectRef{SchemaName: "test", ObjName: "t"},
+				BindingTags: []int32{bindTag},
+				TableDef: &planpb.TableDef{
+					Name: "t",
+					Cols: []*planpb.ColDef{
+						{Name: "id", Typ: planpb.Type{Id: int32(types.T_int64)}},
+						{Name: "status", Typ: planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}},
+					},
+					Name2ColIndex: map[string]int32{
+						"id":     0,
+						"status": 1,
+					},
+					Pkey: &planpb.PrimaryKeyDef{PkeyColName: "id", Names: []string{"id"}},
+				},
+				Stats:      &planpb.Stats{TableCnt: 100, Outcnt: 1, Selectivity: 0.01, Cost: 100},
+				FilterList: []*planpb.Expr{tt.makeFilter(bindTag)},
+			}
+			scanID := builder.appendNode(node, ctx)
+
+			idxNodeID := builder.tryIndexOnlyScan(idxDef, builder.qry.Nodes[scanID], map[[2]int32]int{{bindTag, 1}: 1}, map[[2]int32]*planpb.Expr{}, &Snapshot{})
+			require.NotEqual(t, int32(-1), idxNodeID)
+
+			idxNode := builder.qry.Nodes[idxNodeID]
+			require.Len(t, idxNode.FilterList, 1)
+			require.Equal(t, tt.lookupFunc, idxNode.FilterList[0].GetF().Func.ObjName)
 		})
 	}
 }
@@ -1989,6 +2079,35 @@ func makeParamEqFilterExpr(relPos, colPos, paramPos int32) *planpb.Expr {
 	}
 }
 
+func makeNullEqFilterExpr(relPos, colPos int32) *planpb.Expr {
+	typ := planpb.Type{Id: int32(types.T_int32)}
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "="},
+				Args: []*planpb.Expr{
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Col{
+							Col: &planpb.ColRef{
+								RelPos: relPos,
+								ColPos: colPos,
+							},
+						},
+					},
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Lit{
+							Lit: &planpb.Literal{Isnull: true},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func makeStringInFilterExpr(relPos, colPos int32, vals ...string) *planpb.Expr {
 	typ := planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}
 	list := make([]*planpb.Expr, 0, len(vals))
@@ -2021,6 +2140,89 @@ func makeStringInFilterExpr(relPos, colPos int32, vals ...string) *planpb.Expr {
 						Typ: typ,
 						Expr: &planpb.Expr_List{
 							List: &planpb.ExprList{List: list},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeIntInFilterExprWithNull(relPos, colPos int32) *planpb.Expr {
+	typ := planpb.Type{Id: int32(types.T_int32)}
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "in"},
+				Args: []*planpb.Expr{
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Col{
+							Col: &planpb.ColRef{
+								RelPos: relPos,
+								ColPos: colPos,
+							},
+						},
+					},
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_List{
+							List: &planpb.ExprList{List: []*planpb.Expr{
+								{
+									Typ: typ,
+									Expr: &planpb.Expr_Lit{
+										Lit: &planpb.Literal{
+											Value: &planpb.Literal_I32Val{I32Val: 1},
+										},
+									},
+								},
+								{
+									Typ: typ,
+									Expr: &planpb.Expr_Lit{
+										Lit: &planpb.Literal{Isnull: true},
+									},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeStringBetweenFilterExpr(relPos, colPos int32, lower, upper string) *planpb.Expr {
+	typ := planpb.Type{Id: int32(types.T_varchar), Width: types.MaxVarcharLen}
+	return &planpb.Expr{
+		Typ: planpb.Type{Id: int32(types.T_bool)},
+		Expr: &planpb.Expr_F{
+			F: &planpb.Function{
+				Func: &planpb.ObjectRef{ObjName: "between"},
+				Args: []*planpb.Expr{
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Col{
+							Col: &planpb.ColRef{
+								RelPos: relPos,
+								ColPos: colPos,
+							},
+						},
+					},
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Lit{
+							Lit: &planpb.Literal{
+								Value: &planpb.Literal_Sval{Sval: lower},
+							},
+						},
+					},
+					{
+						Typ: typ,
+						Expr: &planpb.Expr_Lit{
+							Lit: &planpb.Literal{
+								Value: &planpb.Literal_Sval{Sval: upper},
+							},
 						},
 					},
 				},

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1586,6 +1586,37 @@ between_fallback:
 	return retExpr, nil
 }
 
+func bindSerialFuncOverExprList(ctx context.Context, name string, args []*Expr) (*plan.Expr, bool, error) {
+	if name != function.SerialFunctionName && name != function.SerialFullFunctionName {
+		return nil, false, nil
+	}
+	if len(args) != 1 {
+		return nil, false, nil
+	}
+
+	listExpr, ok := args[0].Expr.(*plan.Expr_List)
+	if !ok {
+		return nil, false, nil
+	}
+	if listExpr.List == nil || len(listExpr.List.List) == 0 {
+		return args[0], true, nil
+	}
+
+	// An IN-list is a set of scalar candidates, not one row-wise vector argument.
+	// Bind serial(v0, v1, ...) as list(serial(v0), serial(v1), ...).
+	for i, subExpr := range listExpr.List.List {
+		newSubExpr, err := BindFuncExprImplByPlanExpr(ctx, name, []*Expr{subExpr})
+		if err != nil {
+			return nil, true, err
+		}
+		listExpr.List.List[i] = newSubExpr
+		if i == 0 {
+			args[0].Typ = newSubExpr.Typ
+		}
+	}
+	return args[0], true, nil
+}
+
 func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) (*plan.Expr, error) {
 	var err error
 
@@ -2986,37 +3017,6 @@ func validNameConstValueExpr(arg *plan.Expr) bool {
 		return false
 	}
 	return fn.Args[0].GetLit() != nil || isDecimalLiteralCast(fn.Args[0])
-}
-
-func bindSerialFuncOverExprList(ctx context.Context, name string, args []*Expr) (*plan.Expr, bool, error) {
-	if name != function.SerialFunctionName && name != function.SerialFullFunctionName {
-		return nil, false, nil
-	}
-	if len(args) != 1 {
-		return nil, false, nil
-	}
-
-	listExpr, ok := args[0].Expr.(*plan.Expr_List)
-	if !ok {
-		return nil, false, nil
-	}
-	if listExpr.List == nil || len(listExpr.List.List) == 0 {
-		return args[0], true, nil
-	}
-
-	// An IN-list is a set of scalar candidates, not one row-wise vector argument.
-	// Bind serial(v0, v1, ...) as list(serial(v0), serial(v1), ...).
-	for i, subExpr := range listExpr.List.List {
-		newSubExpr, err := BindFuncExprImplByPlanExpr(ctx, name, []*Expr{subExpr})
-		if err != nil {
-			return nil, true, err
-		}
-		listExpr.List.List[i] = newSubExpr
-		if i == 0 {
-			args[0].Typ = newSubExpr.Typ
-		}
-	}
-	return args[0], true, nil
 }
 
 func validNameConstNameAst(args []tree.Expr) bool {

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1590,24 +1590,11 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 	var err error
 
 	// deal with some special function
-	switch name {
-	case "serial", "serial_full":
-		if len(args) == 1 {
-			if listExpr, ok := args[0].Expr.(*plan.Expr_List); ok {
-				for i, subExpr := range listExpr.List.List {
-					newSubExpr, err := BindFuncExprImplByPlanExpr(ctx, name, []*Expr{subExpr})
-					if err != nil {
-						return nil, err
-					}
-					listExpr.List.List[i] = newSubExpr
-					if i == 0 {
-						args[0].Typ = newSubExpr.Typ
-					}
-				}
-				return args[0], nil
-			}
-		}
+	if listExpr, ok, err := bindSerialFuncOverExprList(ctx, name, args); ok || err != nil {
+		return listExpr, err
+	}
 
+	switch name {
 	case "and", "or", "not", "xor":
 		// why not append cast function?
 		// for i := 0; i < len(args); i++ {
@@ -2999,6 +2986,37 @@ func validNameConstValueExpr(arg *plan.Expr) bool {
 		return false
 	}
 	return fn.Args[0].GetLit() != nil || isDecimalLiteralCast(fn.Args[0])
+}
+
+func bindSerialFuncOverExprList(ctx context.Context, name string, args []*Expr) (*plan.Expr, bool, error) {
+	if name != function.SerialFunctionName && name != function.SerialFullFunctionName {
+		return nil, false, nil
+	}
+	if len(args) != 1 {
+		return nil, false, nil
+	}
+
+	listExpr, ok := args[0].Expr.(*plan.Expr_List)
+	if !ok {
+		return nil, false, nil
+	}
+	if listExpr.List == nil || len(listExpr.List.List) == 0 {
+		return args[0], true, nil
+	}
+
+	// An IN-list is a set of scalar candidates, not one row-wise vector argument.
+	// Bind serial(v0, v1, ...) as list(serial(v0), serial(v1), ...).
+	for i, subExpr := range listExpr.List.List {
+		newSubExpr, err := BindFuncExprImplByPlanExpr(ctx, name, []*Expr{subExpr})
+		if err != nil {
+			return nil, true, err
+		}
+		listExpr.List.List[i] = newSubExpr
+		if i == 0 {
+			args[0].Typ = newSubExpr.Typ
+		}
+	}
+	return args[0], true, nil
 }
 
 func validNameConstNameAst(args []tree.Expr) bool {

--- a/pkg/sql/plan/base_binder.go
+++ b/pkg/sql/plan/base_binder.go
@@ -1591,15 +1591,18 @@ func BindFuncExprImplByPlanExpr(ctx context.Context, name string, args []*Expr) 
 
 	// deal with some special function
 	switch name {
-	case "serial":
+	case "serial", "serial_full":
 		if len(args) == 1 {
 			if listExpr, ok := args[0].Expr.(*plan.Expr_List); ok {
 				for i, subExpr := range listExpr.List.List {
-					newSubExpr, err := BindFuncExprImplByPlanExpr(ctx, "serial", []*Expr{subExpr})
+					newSubExpr, err := BindFuncExprImplByPlanExpr(ctx, name, []*Expr{subExpr})
 					if err != nil {
 						return nil, err
 					}
 					listExpr.List.List[i] = newSubExpr
+					if i == 0 {
+						args[0].Typ = newSubExpr.Typ
+					}
 				}
 				return args[0], nil
 			}

--- a/pkg/sql/plan/base_binder_test.go
+++ b/pkg/sql/plan/base_binder_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect"
 	"github.com/matrixorigin/matrixone/pkg/sql/parsers/tree"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,6 +58,63 @@ func TestBindFuncExprImplByPlanExpr_PowAlias(t *testing.T) {
 		require.NotNil(t, f)
 		require.Equal(t, "power", f.Func.GetObjName())
 	})
+}
+
+func TestBindSerialFunctionMapsExprListItems(t *testing.T) {
+	ctx := context.Background()
+
+	for _, name := range []string{function.SerialFunctionName, function.SerialFullFunctionName} {
+		t.Run(name, func(t *testing.T) {
+			arg := &plan.Expr{
+				Typ: plan.Type{Id: int32(types.T_int64)},
+				Expr: &plan.Expr_List{
+					List: &plan.ExprList{
+						List: []*plan.Expr{
+							MakePlan2Int64ConstExprWithType(1),
+							MakePlan2Int64ConstExprWithType(2),
+						},
+					},
+				},
+			}
+
+			result, err := BindFuncExprImplByPlanExpr(ctx, name, []*plan.Expr{arg})
+			require.NoError(t, err)
+			require.Same(t, arg, result)
+			require.Equal(t, int32(types.T_varchar), result.Typ.Id)
+
+			list := result.GetList()
+			require.NotNil(t, list)
+			require.Len(t, list.List, 2)
+			for i, item := range list.List {
+				f := item.GetF()
+				require.NotNil(t, f)
+				require.Equal(t, name, f.Func.GetObjName())
+				require.Len(t, f.Args, 1)
+				require.Equal(t, int64(i+1), f.Args[0].GetLit().GetI64Val())
+			}
+		})
+	}
+}
+
+func TestBindSerialFunctionOverEmptyExprListDoesNotPanic(t *testing.T) {
+	ctx := context.Background()
+
+	for _, name := range []string{function.SerialFunctionName, function.SerialFullFunctionName} {
+		t.Run(name, func(t *testing.T) {
+			arg := &plan.Expr{
+				Typ: plan.Type{Id: int32(types.T_int64)},
+				Expr: &plan.Expr_List{
+					List: &plan.ExprList{},
+				},
+			}
+
+			result, err := BindFuncExprImplByPlanExpr(ctx, name, []*plan.Expr{arg})
+			require.NoError(t, err)
+			require.Same(t, arg, result)
+			require.NotNil(t, result.GetList())
+			require.Empty(t, result.GetList().List)
+		})
+	}
 }
 
 func TestBindUnaryMinusUint64MinInt64Boundary(t *testing.T) {

--- a/pkg/sql/plan/bind_insert.go
+++ b/pkg/sql/plan/bind_insert.go
@@ -200,22 +200,10 @@ func getValidIndexes(tableDef *plan.TableDef) (indexes []*plan.IndexDef, hasIrre
 			continue
 		}
 
-		colMap := make(map[string]bool)
-		for _, part := range idxDef.Parts {
-			colMap[part] = true
-		}
-
-		notCoverPk := false
-		for _, part := range tableDef.Pkey.Names {
-			if !colMap[part] {
-				notCoverPk = true
-				break
-			}
-		}
-
-		if notCoverPk {
-			indexes = append(indexes, idxDef)
-		}
+		// If a regular index table exists, DML must maintain it even when the
+		// index parts include the full primary key. The optimizer can still choose
+		// that hidden table for leading-prefix predicates.
+		indexes = append(indexes, idxDef)
 	}
 
 	return

--- a/pkg/sql/plan/bind_insert_test.go
+++ b/pkg/sql/plan/bind_insert_test.go
@@ -22,6 +22,57 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGetValidIndexesKeepsRegularIndexThatCoversPrimaryKey(t *testing.T) {
+	tableDef := &plan.TableDef{
+		Pkey: &plan.PrimaryKeyDef{
+			Names:       []string{"user_id", "session_id", "id"},
+			PkeyColName: catalog.CPrimaryKeyColName,
+		},
+		Indexes: []*plan.IndexDef{
+			{
+				IndexName:  "idx_ret",
+				IndexAlgo:  catalog.MoIndexDefaultAlgo.ToString(),
+				TableExist: true,
+				Unique:     false,
+				Parts: []string{
+					"status",
+					"due",
+					"user_id",
+					"session_id",
+					"id",
+					catalog.CreateAlias(catalog.CPrimaryKeyColName),
+				},
+			},
+			{
+				IndexName:  "uq_token_pk",
+				IndexAlgo:  catalog.MoIndexDefaultAlgo.ToString(),
+				TableExist: true,
+				Unique:     true,
+				Parts: []string{
+					"token",
+					"user_id",
+					"session_id",
+					"id",
+				},
+			},
+			{
+				IndexName:  "idx_pending",
+				IndexAlgo:  catalog.MoIndexDefaultAlgo.ToString(),
+				TableExist: false,
+				Parts:      []string{"status"},
+			},
+		},
+	}
+
+	got, hasIrregular := getValidIndexes(tableDef)
+
+	assert.False(t, hasIrregular)
+	if assert.Len(t, got, 2) {
+		assert.Equal(t, "idx_ret", got[0].IndexName)
+		assert.Equal(t, "uq_token_pk", got[1].IndexName)
+	}
+}
+
 // TestGetIrregularIndexes verifies that existing IVF / fulltext / master indexes
 // (synchronously maintained) are returned, while regular indexes, indexes whose
 // hidden table has not been created, and HNSW/CAGRA/IVF-PQ indexes (cron-maintained)

--- a/pkg/sql/plan/function/func_prefix.go
+++ b/pkg/sql/plan/function/func_prefix.go
@@ -136,6 +136,12 @@ func (op *implPrefixIn) doPrefixIn(parameters []*vector.Vector, result vector.Fu
 
 	lvec := parameters[0]
 	res := vector.MustFixedColWithTypeCheck[bool](result.GetResultVector())
+	if len(op.vals) == 0 {
+		for i := range length {
+			res[i] = false
+		}
+		return nil
+	}
 
 	lcol, larea := vector.MustVarlenaRawData(lvec)
 	lvecHasNull := lvec.HasNull()

--- a/pkg/sql/plan/function/func_prefix_test.go
+++ b/pkg/sql/plan/function/func_prefix_test.go
@@ -413,6 +413,17 @@ func TestPrefixInAdvanced(t *testing.T) {
 			expect: NewFunctionTestResult(types.T_bool.ToType(), false,
 				[]bool{false, false, true}, []bool{true, true, false}),
 		},
+		{
+			info: "& test prefix_in with empty prefix set",
+			inputs: []FunctionTestInput{
+				NewFunctionTestInput(types.T_varchar.ToType(),
+					[]string{"aa12", "bb22", "cc33"}, []bool{false, false, false}),
+				NewFunctionTestInput(types.T_varchar.ToType(),
+					[]string{}, []bool{}),
+			},
+			expect: NewFunctionTestResult(types.T_bool.ToType(), false,
+				[]bool{false, false, false}, []bool{false, false, false}),
+		},
 	}
 
 	proc := testutil.NewProcess(t)

--- a/pkg/sql/plan/index_helpers.go
+++ b/pkg/sql/plan/index_helpers.go
@@ -27,6 +27,13 @@ func indexTableStoresSerializedKey(idxDef *planpb.IndexDef) bool {
 	return idxDef != nil && !isSpatialIndexDef(idxDef) && len(idxDef.Parts) > 1
 }
 
+func indexTableLookupSerialFunc(idxDef *planpb.IndexDef) string {
+	if idxDef != nil && !idxDef.Unique && indexTableStoresSerializedKey(idxDef) {
+		return "serial_full"
+	}
+	return "serial"
+}
+
 func indexLookupColumnName(idxDef *planpb.IndexDef) string {
 	if isSpatialIndexDef(idxDef) {
 		return catalog.IndexTablePrimaryColName

--- a/test/distributed/cases/optimizer/secondary_index_range.result
+++ b/test/distributed/cases/optimizer/secondary_index_range.result
@@ -775,4 +775,106 @@ select * from t8 where price > 9.99 and price < 99.99 order by id;
 2  ¦  19.99  𝄀
 3  ¦  29.99  𝄀
 4  ¦  49.99
+drop table if exists t9;
+create table t9 (
+    id varchar(64) not null,
+    user_id varchar(64) not null,
+    session_id varchar(64) not null,
+    status varchar(32) not null,
+    due datetime(6) null,
+    attempts int not null,
+    primary key (user_id, session_id, id),
+    index idx_ret(status, due, user_id, session_id, id)
+);
+insert into t9 values
+    ('a1', 'u1', 's1', 'active', '2026-07-02 00:00:00.000001', 10),
+    ('a2', 'u1', 's2', 'expired', '2026-07-03 00:00:00.000002', 20),
+    ('a3', 'u2', 's1', 'expiring', '2026-07-04 00:00:00.000003', 30),
+    ('a4', 'u2', 's2', 'active', NULL, 40);
+select mo_ctl('dn', 'flush', 'd1.t9');
+➤ mo_ctl(dn, flush, d1.t9)[12,-1,0]  𝄀
+{
+  "method": "Flush",
+  "result": [
+    {
+      "returnStr": "OK"
+    }
+  ]
+}
+
+select Sleep(1);
+➤ Sleep(1)[-6,8,0]  𝄀
+0
+explain select count(*) from t9 where status = 'active';
+-- @regex("Index Table Scan", true)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Index Table Scan on t9.idx_ret  𝄀
+              Filter Cond: prefix_eq(__mo_index_idx_col)
+explain select count(*) from t9 where status in ('active', 'expiring');
+-- @regex("prefix_in", true)
+➤ TP QUERY PLAN[12,0,0]  𝄀
+Project  𝄀
+  ->  Aggregate  𝄀
+        Aggregate Functions: starcount(1)  𝄀
+        ->  Index Table Scan on t9.idx_ret  𝄀
+              Filter Cond: prefix_in(__mo_index_idx_col)
+select count(*) as count_eq from t9 where status = 'active';
+➤ count_eq[-5,64,0]  𝄀
+2
+select count(*) as count_in from t9 where status in ('active', 'expiring');
+➤ count_in[-5,64,0]  𝄀
+3
+select count(*) as count_range from t9 where status >= 'active' and status <= 'expired';
+➤ count_range[-5,64,0]  𝄀
+3
+select count(*) as count_nullsafe from t9 where status <=> 'active';
+➤ count_nullsafe[-5,64,0]  𝄀
+2
+select id, status, status = 'active' as row_eq, status <=> 'active' as row_nullsafe from t9 order by id;
+➤ id[12,-1,0]  ¦  status[12,-1,0]  ¦  row_eq[1,0,0]  ¦  row_nullsafe[1,0,0]  𝄀
+a1  ¦  active  ¦  1  ¦  1  𝄀
+a2  ¦  expired  ¦  0  ¦  0  𝄀
+a3  ¦  expiring  ¦  0  ¦  0  𝄀
+a4  ¦  active  ¦  1  ¦  1
+update t9 set status = 'active', due = '2026-07-05 00:00:00.000004' where id = 'a2';
+select count(*) as count_after_update_into_active from t9 where status = 'active';
+➤ count_after_update_into_active[-5,64,0]  𝄀
+3
+select count(*) as count_after_update_out_of_expired from t9 where status = 'expired';
+➤ count_after_update_out_of_expired[-5,64,0]  𝄀
+0
+update t9 set status = 'done' where id = 'a1';
+select count(*) as count_after_update_out_of_active from t9 where status = 'active';
+➤ count_after_update_out_of_active[-5,64,0]  𝄀
+2
+select count(*) as count_after_update_into_done from t9 where status = 'done';
+➤ count_after_update_into_done[-5,64,0]  𝄀
+1
+delete from t9 where id = 'a4';
+select count(*) as count_after_delete_active from t9 where status = 'active';
+➤ count_after_delete_active[-5,64,0]  𝄀
+1
+replace into t9 values ('a3', 'u2', 's1', 'active', '2026-07-06 00:00:00.000005', 44);
+select count(*) as count_after_replace_active from t9 where status = 'active';
+➤ count_after_replace_active[-5,64,0]  𝄀
+2
+select count(*) as count_after_replace_expiring from t9 where status = 'expiring';
+➤ count_after_replace_expiring[-5,64,0]  𝄀
+0
+insert into t9 values ('a3', 'u2', 's1', 'closed', '2026-07-07 00:00:00.000006', 55)
+    on duplicate key update status = values(status), due = values(due), attempts = values(attempts);
+select count(*) as count_after_odku_active from t9 where status = 'active';
+➤ count_after_odku_active[-5,64,0]  𝄀
+1
+select count(*) as count_after_odku_closed from t9 where status = 'closed';
+➤ count_after_odku_closed[-5,64,0]  𝄀
+1
+select id, status, attempts from t9 order by id;
+➤ id[12,-1,0]  ¦  status[12,-1,0]  ¦  attempts[4,32,0]  𝄀
+a1  ¦  done  ¦  10  𝄀
+a2  ¦  active  ¦  20  𝄀
+a3  ¦  closed  ¦  55
 drop database d1;

--- a/test/distributed/cases/optimizer/secondary_index_range.result
+++ b/test/distributed/cases/optimizer/secondary_index_range.result
@@ -589,7 +589,7 @@ explain select * from t5 where val >= 100 and val <= 50;
 ➤ TP QUERY PLAN[12,0,0]  𝄀
 Project  𝄀
   ->  Index Table Scan on t5.idx_val  𝄀
-        Filter Cond: (__mo_index_idx_col >= ':d'), (serial_extract(__mo_index_idx_col, 0, INT)) <= 50)
+        Filter Cond: (__mo_index_idx_col >= ':d'), (serial_extract(__mo_index_idx_col, 0, INT)) >= 100), (serial_extract(__mo_index_idx_col, 0, INT)) <= 50)
 select * from t5 where val >= 100 and val <= 50;
 ➤ id[4,32,0]  ¦  val[4,32,0]
 select * from t5 where val > 30 and val < 10;
@@ -694,7 +694,7 @@ explain select * from t7 where d >= '2024-03-01' and d <= '2024-09-30';
 ➤ TP QUERY PLAN[12,0,0]  𝄀
 Project  𝄀
   ->  Index Table Scan on t7.idx_d  𝄀
-        Filter Cond: (__mo_index_idx_col >= 'AF�'), (serial_extract(__mo_index_idx_col, 0, DATE)) <= 2024-09-30)
+        Filter Cond: (__mo_index_idx_col >= 'AF�'), (serial_extract(__mo_index_idx_col, 0, DATE)) >= 2024-03-01), (serial_extract(__mo_index_idx_col, 0, DATE)) <= 2024-09-30)
 select * from t7 where d >= '2024-03-01' and d <= '2024-09-30' order by id;
 ➤ id[4,32,0]  ¦  d[91,64,0]  𝄀
 2  ¦  2024-03-15  𝄀
@@ -780,7 +780,7 @@ create table t9 (
 id varchar(64) not null,
 user_id varchar(64) not null,
 session_id varchar(64) not null,
-status varchar(32) not null,
+status varchar(32) null,
 due datetime(6) null,
 attempts int not null,
 primary key (user_id, session_id, id),
@@ -790,7 +790,8 @@ insert into t9 values
 ('a1', 'u1', 's1', 'active', '2026-07-02 00:00:00.000001', 10),
 ('a2', 'u1', 's2', 'expired', '2026-07-03 00:00:00.000002', 20),
 ('a3', 'u2', 's1', 'expiring', '2026-07-04 00:00:00.000003', 30),
-('a4', 'u2', 's2', 'active', NULL, 40);
+('a4', 'u2', 's2', 'active', NULL, 40),
+('a5', 'u3', 's1', NULL, '2026-07-05 00:00:00.000004', 50);
 select mo_ctl('dn', 'flush', 'd1.t9');
 ➤ mo_ctl(dn, flush, d1.t9)[12,-1,0]  𝄀
 {
@@ -812,7 +813,7 @@ Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
         ->  Index Table Scan on t9.idx_ret  𝄀
-              Filter Cond: prefix_eq(__mo_index_idx_col)
+              Filter Cond: prefix_eq(__mo_index_idx_col), (serial_extract(__mo_index_idx_col, 0, VARCHAR)) = 'active')
 explain select count(*) from t9 where status in ('active', 'expiring');
 -- @regex("prefix_in", true)
 ➤ TP QUERY PLAN[12,0,0]  𝄀
@@ -820,7 +821,7 @@ Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
         ->  Index Table Scan on t9.idx_ret  𝄀
-              Filter Cond: prefix_in(__mo_index_idx_col)
+              Filter Cond: prefix_in(__mo_index_idx_col), serial_extract(__mo_index_idx_col, 0, VARCHAR)) in ([active expiring])
 select count(*) as count_eq from t9 where status = 'active';
 ➤ count_eq[-5,64,0]  𝄀
 2
@@ -834,20 +835,37 @@ select count(*) as count_nullsafe from t9 where status <=> 'active';
 ➤ count_nullsafe[-5,64,0]  𝄀
 2
 select id, status, status = 'active' as row_eq, status <=> 'active' as row_nullsafe from t9 order by id;
-➤ id[12,-1,0]  ¦  status[12,-1,0]  ¦  row_eq[1,0,0]  ¦  row_nullsafe[1,0,0]  𝄀
+➤ id[12,-1,0]  ¦  status[12,-1,0]  ¦  row_eq[-7,1,0]  ¦  row_nullsafe[-7,1,0]  𝄀
 a1  ¦  active  ¦  1  ¦  1  𝄀
 a2  ¦  expired  ¦  0  ¦  0  𝄀
 a3  ¦  expiring  ¦  0  ¦  0  𝄀
-a4  ¦  active  ¦  1  ¦  1
+a4  ¦  active  ¦  1  ¦  1  𝄀
+a5  ¦  null  ¦  null  ¦  0
 prepare stmt_t9_status_in from 'select count(*) as count_prepare_in from t9 where status in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
 set @t9_active = 'active';
 set @t9_expired = 'expired';
 set @t9_expiring = 'expiring';
 set @t9_missing = 'missing';
+set @t9_null = NULL;
 execute stmt_t9_status_in using @t9_active,@t9_expired,@t9_expiring,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing;
 ➤ count_prepare_in[-5,64,0]  𝄀
 4
 deallocate prepare stmt_t9_status_in;
+prepare stmt_t9_status_eq_null from 'select count(*) as count_prepare_eq_null from t9 where status = ?';
+execute stmt_t9_status_eq_null using @t9_null;
+➤ count_prepare_eq_null[-5,64,0]  𝄀
+0
+deallocate prepare stmt_t9_status_eq_null;
+prepare stmt_t9_status_in_null from 'select count(*) as count_prepare_in_null from t9 where status in (?, ?)';
+execute stmt_t9_status_in_null using @t9_null,@t9_missing;
+➤ count_prepare_in_null[-5,64,0]  𝄀
+0
+deallocate prepare stmt_t9_status_in_null;
+prepare stmt_t9_status_between_null from 'select count(*) as count_prepare_between_null from t9 where status between ? and ?';
+execute stmt_t9_status_between_null using @t9_null,@t9_active;
+➤ count_prepare_between_null[-5,64,0]  𝄀
+0
+deallocate prepare stmt_t9_status_between_null;
 update t9 set status = 'active', due = '2026-07-05 00:00:00.000004' where id = 'a2';
 select count(*) as count_after_update_into_active from t9 where status = 'active';
 ➤ count_after_update_into_active[-5,64,0]  𝄀
@@ -885,5 +903,6 @@ select id, status, attempts from t9 order by id;
 ➤ id[12,-1,0]  ¦  status[12,-1,0]  ¦  attempts[4,32,0]  𝄀
 a1  ¦  done  ¦  10  𝄀
 a2  ¦  active  ¦  20  𝄀
-a3  ¦  closed  ¦  55
+a3  ¦  closed  ¦  55  𝄀
+a5  ¦  null  ¦  50
 drop database d1;

--- a/test/distributed/cases/optimizer/secondary_index_range.result
+++ b/test/distributed/cases/optimizer/secondary_index_range.result
@@ -839,6 +839,15 @@ a1  ¦  active  ¦  1  ¦  1  𝄀
 a2  ¦  expired  ¦  0  ¦  0  𝄀
 a3  ¦  expiring  ¦  0  ¦  0  𝄀
 a4  ¦  active  ¦  1  ¦  1
+prepare stmt_t9_status_in from 'select count(*) as count_prepare_in from t9 where status in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+set @t9_active = 'active';
+set @t9_expired = 'expired';
+set @t9_expiring = 'expiring';
+set @t9_missing = 'missing';
+execute stmt_t9_status_in using @t9_active,@t9_expired,@t9_expiring,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing;
+➤ count_prepare_in[-5,64,0]  𝄀
+4
+deallocate prepare stmt_t9_status_in;
 update t9 set status = 'active', due = '2026-07-05 00:00:00.000004' where id = 'a2';
 select count(*) as count_after_update_into_active from t9 where status = 'active';
 ➤ count_after_update_into_active[-5,64,0]  𝄀

--- a/test/distributed/cases/optimizer/secondary_index_range.result
+++ b/test/distributed/cases/optimizer/secondary_index_range.result
@@ -777,20 +777,20 @@ select * from t8 where price > 9.99 and price < 99.99 order by id;
 4  ¦  49.99
 drop table if exists t9;
 create table t9 (
-    id varchar(64) not null,
-    user_id varchar(64) not null,
-    session_id varchar(64) not null,
-    status varchar(32) not null,
-    due datetime(6) null,
-    attempts int not null,
-    primary key (user_id, session_id, id),
-    index idx_ret(status, due, user_id, session_id, id)
+id varchar(64) not null,
+user_id varchar(64) not null,
+session_id varchar(64) not null,
+status varchar(32) not null,
+due datetime(6) null,
+attempts int not null,
+primary key (user_id, session_id, id),
+index idx_ret(status, due, user_id, session_id, id)
 );
 insert into t9 values
-    ('a1', 'u1', 's1', 'active', '2026-07-02 00:00:00.000001', 10),
-    ('a2', 'u1', 's2', 'expired', '2026-07-03 00:00:00.000002', 20),
-    ('a3', 'u2', 's1', 'expiring', '2026-07-04 00:00:00.000003', 30),
-    ('a4', 'u2', 's2', 'active', NULL, 40);
+('a1', 'u1', 's1', 'active', '2026-07-02 00:00:00.000001', 10),
+('a2', 'u1', 's2', 'expired', '2026-07-03 00:00:00.000002', 20),
+('a3', 'u2', 's1', 'expiring', '2026-07-04 00:00:00.000003', 30),
+('a4', 'u2', 's2', 'active', NULL, 40);
 select mo_ctl('dn', 'flush', 'd1.t9');
 ➤ mo_ctl(dn, flush, d1.t9)[12,-1,0]  𝄀
 {
@@ -865,7 +865,7 @@ select count(*) as count_after_replace_expiring from t9 where status = 'expiring
 ➤ count_after_replace_expiring[-5,64,0]  𝄀
 0
 insert into t9 values ('a3', 'u2', 's1', 'closed', '2026-07-07 00:00:00.000006', 55)
-    on duplicate key update status = values(status), due = values(due), attempts = values(attempts);
+on duplicate key update status = values(status), due = values(due), attempts = values(attempts);
 select count(*) as count_after_odku_active from t9 where status = 'active';
 ➤ count_after_odku_active[-5,64,0]  𝄀
 1

--- a/test/distributed/cases/optimizer/secondary_index_range.result
+++ b/test/distributed/cases/optimizer/secondary_index_range.result
@@ -589,7 +589,7 @@ explain select * from t5 where val >= 100 and val <= 50;
 ➤ TP QUERY PLAN[12,0,0]  𝄀
 Project  𝄀
   ->  Index Table Scan on t5.idx_val  𝄀
-        Filter Cond: (__mo_index_idx_col >= ':d'), (serial_extract(__mo_index_idx_col, 0, INT)) >= 100), (serial_extract(__mo_index_idx_col, 0, INT)) <= 50)
+        Filter Cond: (__mo_index_idx_col >= ':d'), (serial_extract(__mo_index_idx_col, 0, INT)) <= 50)
 select * from t5 where val >= 100 and val <= 50;
 ➤ id[4,32,0]  ¦  val[4,32,0]
 select * from t5 where val > 30 and val < 10;
@@ -694,7 +694,7 @@ explain select * from t7 where d >= '2024-03-01' and d <= '2024-09-30';
 ➤ TP QUERY PLAN[12,0,0]  𝄀
 Project  𝄀
   ->  Index Table Scan on t7.idx_d  𝄀
-        Filter Cond: (__mo_index_idx_col >= 'AF�'), (serial_extract(__mo_index_idx_col, 0, DATE)) >= 2024-03-01), (serial_extract(__mo_index_idx_col, 0, DATE)) <= 2024-09-30)
+        Filter Cond: (__mo_index_idx_col >= 'AF�'), (serial_extract(__mo_index_idx_col, 0, DATE)) <= 2024-09-30)
 select * from t7 where d >= '2024-03-01' and d <= '2024-09-30' order by id;
 ➤ id[4,32,0]  ¦  d[91,64,0]  𝄀
 2  ¦  2024-03-15  𝄀
@@ -813,7 +813,7 @@ Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
         ->  Index Table Scan on t9.idx_ret  𝄀
-              Filter Cond: prefix_eq(__mo_index_idx_col), (serial_extract(__mo_index_idx_col, 0, VARCHAR)) = 'active')
+              Filter Cond: prefix_eq(__mo_index_idx_col)
 explain select count(*) from t9 where status in ('active', 'expiring');
 -- @regex("prefix_in", true)
 ➤ TP QUERY PLAN[12,0,0]  𝄀
@@ -821,7 +821,7 @@ Project  𝄀
   ->  Aggregate  𝄀
         Aggregate Functions: starcount(1)  𝄀
         ->  Index Table Scan on t9.idx_ret  𝄀
-              Filter Cond: prefix_in(__mo_index_idx_col), serial_extract(__mo_index_idx_col, 0, VARCHAR)) in ([active expiring])
+              Filter Cond: prefix_in(__mo_index_idx_col)
 select count(*) as count_eq from t9 where status = 'active';
 ➤ count_eq[-5,64,0]  𝄀
 2

--- a/test/distributed/cases/optimizer/secondary_index_range.sql
+++ b/test/distributed/cases/optimizer/secondary_index_range.sql
@@ -248,5 +248,61 @@ explain select * from t8 where price > 9.99 and price < 99.99;
 -- @sortkey:0
 select * from t8 where price > 9.99 and price < 99.99 order by id;
 
+-- 28. Regression #25341: predicates on a covering non-unique composite
+-- secondary index with an owner-bound composite PK. The DML lifecycle checks
+-- that the hidden index table is maintained after insert, update, delete,
+-- replace, and ON DUPLICATE KEY UPDATE.
+drop table if exists t9;
+create table t9 (
+    id varchar(64) not null,
+    user_id varchar(64) not null,
+    session_id varchar(64) not null,
+    status varchar(32) not null,
+    due datetime(6) null,
+    attempts int not null,
+    primary key (user_id, session_id, id),
+    index idx_ret(status, due, user_id, session_id, id)
+);
+insert into t9 values
+    ('a1', 'u1', 's1', 'active', '2026-07-02 00:00:00.000001', 10),
+    ('a2', 'u1', 's2', 'expired', '2026-07-03 00:00:00.000002', 20),
+    ('a3', 'u2', 's1', 'expiring', '2026-07-04 00:00:00.000003', 30),
+    ('a4', 'u2', 's2', 'active', NULL, 40);
+select mo_ctl('dn', 'flush', 'd1.t9');
+select Sleep(1);
+
+-- @regex("Index Table Scan",true)
+explain select count(*) from t9 where status = 'active';
+-- @regex("prefix_in",true)
+explain select count(*) from t9 where status in ('active', 'expiring');
+select count(*) as count_eq from t9 where status = 'active';
+select count(*) as count_in from t9 where status in ('active', 'expiring');
+select count(*) as count_range from t9 where status >= 'active' and status <= 'expired';
+select count(*) as count_nullsafe from t9 where status <=> 'active';
+-- @sortkey:0
+select id, status, status = 'active' as row_eq, status <=> 'active' as row_nullsafe from t9 order by id;
+
+update t9 set status = 'active', due = '2026-07-05 00:00:00.000004' where id = 'a2';
+select count(*) as count_after_update_into_active from t9 where status = 'active';
+select count(*) as count_after_update_out_of_expired from t9 where status = 'expired';
+
+update t9 set status = 'done' where id = 'a1';
+select count(*) as count_after_update_out_of_active from t9 where status = 'active';
+select count(*) as count_after_update_into_done from t9 where status = 'done';
+
+delete from t9 where id = 'a4';
+select count(*) as count_after_delete_active from t9 where status = 'active';
+
+replace into t9 values ('a3', 'u2', 's1', 'active', '2026-07-06 00:00:00.000005', 44);
+select count(*) as count_after_replace_active from t9 where status = 'active';
+select count(*) as count_after_replace_expiring from t9 where status = 'expiring';
+
+insert into t9 values ('a3', 'u2', 's1', 'closed', '2026-07-07 00:00:00.000006', 55)
+    on duplicate key update status = values(status), due = values(due), attempts = values(attempts);
+select count(*) as count_after_odku_active from t9 where status = 'active';
+select count(*) as count_after_odku_closed from t9 where status = 'closed';
+-- @sortkey:0
+select id, status, attempts from t9 order by id;
+
 -- Cleanup
 drop database d1;

--- a/test/distributed/cases/optimizer/secondary_index_range.sql
+++ b/test/distributed/cases/optimizer/secondary_index_range.sql
@@ -257,7 +257,7 @@ create table t9 (
     id varchar(64) not null,
     user_id varchar(64) not null,
     session_id varchar(64) not null,
-    status varchar(32) not null,
+    status varchar(32) null,
     due datetime(6) null,
     attempts int not null,
     primary key (user_id, session_id, id),
@@ -267,7 +267,8 @@ insert into t9 values
     ('a1', 'u1', 's1', 'active', '2026-07-02 00:00:00.000001', 10),
     ('a2', 'u1', 's2', 'expired', '2026-07-03 00:00:00.000002', 20),
     ('a3', 'u2', 's1', 'expiring', '2026-07-04 00:00:00.000003', 30),
-    ('a4', 'u2', 's2', 'active', NULL, 40);
+    ('a4', 'u2', 's2', 'active', NULL, 40),
+    ('a5', 'u3', 's1', NULL, '2026-07-05 00:00:00.000004', 50);
 select mo_ctl('dn', 'flush', 'd1.t9');
 select Sleep(1);
 
@@ -286,8 +287,18 @@ set @t9_active = 'active';
 set @t9_expired = 'expired';
 set @t9_expiring = 'expiring';
 set @t9_missing = 'missing';
+set @t9_null = NULL;
 execute stmt_t9_status_in using @t9_active,@t9_expired,@t9_expiring,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing;
 deallocate prepare stmt_t9_status_in;
+prepare stmt_t9_status_eq_null from 'select count(*) as count_prepare_eq_null from t9 where status = ?';
+execute stmt_t9_status_eq_null using @t9_null;
+deallocate prepare stmt_t9_status_eq_null;
+prepare stmt_t9_status_in_null from 'select count(*) as count_prepare_in_null from t9 where status in (?, ?)';
+execute stmt_t9_status_in_null using @t9_null,@t9_missing;
+deallocate prepare stmt_t9_status_in_null;
+prepare stmt_t9_status_between_null from 'select count(*) as count_prepare_between_null from t9 where status between ? and ?';
+execute stmt_t9_status_between_null using @t9_null,@t9_active;
+deallocate prepare stmt_t9_status_between_null;
 
 update t9 set status = 'active', due = '2026-07-05 00:00:00.000004' where id = 'a2';
 select count(*) as count_after_update_into_active from t9 where status = 'active';

--- a/test/distributed/cases/optimizer/secondary_index_range.sql
+++ b/test/distributed/cases/optimizer/secondary_index_range.sql
@@ -281,6 +281,13 @@ select count(*) as count_range from t9 where status >= 'active' and status <= 'e
 select count(*) as count_nullsafe from t9 where status <=> 'active';
 -- @sortkey:0
 select id, status, status = 'active' as row_eq, status <=> 'active' as row_nullsafe from t9 order by id;
+prepare stmt_t9_status_in from 'select count(*) as count_prepare_in from t9 where status in (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+set @t9_active = 'active';
+set @t9_expired = 'expired';
+set @t9_expiring = 'expiring';
+set @t9_missing = 'missing';
+execute stmt_t9_status_in using @t9_active,@t9_expired,@t9_expiring,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing,@t9_missing;
+deallocate prepare stmt_t9_status_in;
 
 update t9 set status = 'active', due = '2026-07-05 00:00:00.000004' where id = 'a2';
 select count(*) as count_after_update_into_active from t9 where status = 'active';


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [x] Code Refactoring

## Which issue(s) this PR fixes:

issue #25341

Backport of #25342 to 4.1-dev.

## What this PR does / why we need it:

Cherry-picks the same seven non-merge commits from #25342 onto 4.1-dev to keep covering secondary index behavior consistent with main.

Local verification:
- Confirmed 4.1-dev did not already contain the PR merge commit or the seven business commits.
- Cherry-pick completed without conflicts.
- Verified the cumulative backport diff matches #25342 merge diff by file list, diff stat, and stable patch-id (`ef42719220f8784404f6b4b72e329d6293303764`).
- Attempted `go test ./pkg/sql/plan` and targeted plan tests locally, but both were blocked by automatic download of `go1.26.4` on this machine. Local installed Go is `go1.25.4`; CI should run with the 4.1-dev toolchain.
