### PR TITLE
fix: address frontend vet failures

### DIFF
--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -3718,7 +3718,7 @@ func TestTransformIntoHours(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			if got := transformIntoHours(tt.input); got != tt.want {
-				t.Errorf("transformIntoHours(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("transformIntoHours(%q) = %d, want %d", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/pkg/frontend/mysql_cmd_executor.go
+++ b/pkg/frontend/mysql_cmd_executor.go
@@ -2687,11 +2687,7 @@ func readThenWrite(ses FeSession, execCtx *ExecCtx, param *tree.ExternParam, wri
 	if !skipWrite {
 		_, err = writer.Write(payload)
 		if err != nil {
-			ses.Errorf(execCtx.reqCtx,
-				"Failed to load local file",
-				zap.String("path", param.Filepath),
-				zap.Uint64("epoch", epoch),
-				zap.Error(err))
+			ses.Errorf(execCtx.reqCtx, "Failed to load local file: epoch=%d, error=%v", epoch, err)
 			skipWrite = true
 		}
 		writeTime = time.Since(start)


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

https://github.com/matrixorigin/matrixone/issues/25402

## What this PR does / why we need it:

This fixes two Go vet failures in `pkg/frontend` that block the coverage UT job on `4.1-dev`:

- use structured `SessionLogger.Error` instead of passing zap fields to the printf-style `Errorf`
- use `%d` for `int64` values in `TestTransformIntoHours`

Validation:

- macOS: `go test -run 'TestTransformIntoHours|TestIsValidFrequency' -count=1 -vet=all ./pkg/frontend`
- Linux Docker (`matrixorigin/golang:1.26.4-ubuntu22.04`): `go test -json -short -v -tags matrixone_test -p 6 -covermode=set -coverprofile=frontend_coverage.raw -coverpkg="<CI full package scope>" ./pkg/frontend`
