### PR TITLE
Fix zonemap pruning for nullable IN lists

### DIFF
--- a/pkg/sql/colexec/evalExpression.go
+++ b/pkg/sql/colexec/evalExpression.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/pb/plan"
 	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
 	"github.com/matrixorigin/matrixone/pkg/sql/util"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/compute"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
 	"github.com/matrixorigin/matrixone/pkg/vm/process"
 )
@@ -1130,7 +1131,8 @@ func EvaluateFilterByZoneMap(
 
 	zm := GetExprZoneMap(ctx, proc, expr, meta, columnMap, zms, vecs)
 	if !zm.IsInited() || zm.GetType() != types.T_bool {
-		selected = false
+		// Unknown zonemap results are not proof that the block cannot match.
+		selected = true
 	} else {
 		selected = types.DecodeBool(zm.GetMaxBuf())
 	}
@@ -1197,6 +1199,9 @@ func GetExprZoneMap(
 					return zms[expr.AuxId]
 				}
 			case "in":
+				if list := args[1].GetList(); list != nil {
+					return foldNativeInListZoneMap(ctx, proc, meta, columnMap, zms, vecs, args, expr.AuxId, false)
+				}
 				rid := args[1].AuxId
 				if vecs[rid] == nil {
 					if data, ok := args[1].Expr.(*plan.Expr_Vec); ok {
@@ -1222,6 +1227,13 @@ func GetExprZoneMap(
 				}
 
 				zms[expr.AuxId] = index.SetBool(zms[expr.AuxId], lhs.AnyIn(vecs[rid]))
+				return zms[expr.AuxId]
+
+			case "not_in":
+				if list := args[1].GetList(); list != nil {
+					return foldNativeInListZoneMap(ctx, proc, meta, columnMap, zms, vecs, args, expr.AuxId, true)
+				}
+				zms[expr.AuxId].Reset()
 				return zms[expr.AuxId]
 
 			case "prefix_eq":
@@ -1305,6 +1317,10 @@ func GetExprZoneMap(
 			var res, ok bool
 			switch t.F.Func.ObjName {
 			case ">":
+				if hasConstNullArg(args) {
+					zms[expr.AuxId] = index.SetBool(zms[expr.AuxId], false)
+					return zms[expr.AuxId]
+				}
 				if f() {
 					return zms[expr.AuxId]
 				}
@@ -1315,6 +1331,10 @@ func GetExprZoneMap(
 				}
 
 			case "<":
+				if hasConstNullArg(args) {
+					zms[expr.AuxId] = index.SetBool(zms[expr.AuxId], false)
+					return zms[expr.AuxId]
+				}
 				if f() {
 					return zms[expr.AuxId]
 				}
@@ -1325,6 +1345,10 @@ func GetExprZoneMap(
 				}
 
 			case ">=":
+				if hasConstNullArg(args) {
+					zms[expr.AuxId] = index.SetBool(zms[expr.AuxId], false)
+					return zms[expr.AuxId]
+				}
 				if f() {
 					return zms[expr.AuxId]
 				}
@@ -1335,6 +1359,10 @@ func GetExprZoneMap(
 				}
 
 			case "<=":
+				if hasConstNullArg(args) {
+					zms[expr.AuxId] = index.SetBool(zms[expr.AuxId], false)
+					return zms[expr.AuxId]
+				}
 				if f() {
 					return zms[expr.AuxId]
 				}
@@ -1345,6 +1373,10 @@ func GetExprZoneMap(
 				}
 
 			case "=":
+				if hasConstNullArg(args) {
+					zms[expr.AuxId] = index.SetBool(zms[expr.AuxId], false)
+					return zms[expr.AuxId]
+				}
 				if f() {
 					return zms[expr.AuxId]
 				}
@@ -1354,7 +1386,25 @@ func GetExprZoneMap(
 					zms[expr.AuxId] = index.SetBool(zms[expr.AuxId], res)
 				}
 
+			case "!=", "<>":
+				if hasConstNullArg(args) {
+					zms[expr.AuxId] = index.SetBool(zms[expr.AuxId], false)
+					return zms[expr.AuxId]
+				}
+				if f() {
+					return zms[expr.AuxId]
+				}
+				if res, ok = anyNotEqualZoneMap(zms[args[0].AuxId], zms[args[1].AuxId]); !ok {
+					zms[expr.AuxId].Reset()
+				} else {
+					zms[expr.AuxId] = index.SetBool(zms[expr.AuxId], res)
+				}
+
 			case "between":
+				if hasConstNullArg(args) {
+					zms[expr.AuxId] = index.SetBool(zms[expr.AuxId], false)
+					return zms[expr.AuxId]
+				}
 				if f() {
 					return zms[expr.AuxId]
 				}
@@ -1365,34 +1415,14 @@ func GetExprZoneMap(
 				}
 
 			case "and":
-				if f() {
+				if hasResult := foldAndZoneMap(ctx, proc, meta, columnMap, zms, vecs, args, expr.AuxId); hasResult {
 					return zms[expr.AuxId]
 				}
-				zmRes := zms[args[0].AuxId]
-				for i := 1; i < len(args); i++ {
-					if res, ok = zmRes.And(zms[args[i].AuxId]); !ok {
-						zmRes.Reset()
-						break
-					} else {
-						zmRes = index.SetBool(zmRes, res)
-					}
-				}
-				zms[expr.AuxId] = zmRes
 
 			case "or":
-				if f() {
+				if hasResult := foldOrZoneMap(ctx, proc, meta, columnMap, zms, vecs, args, expr.AuxId); hasResult {
 					return zms[expr.AuxId]
 				}
-				zmRes := zms[args[0].AuxId]
-				for i := 1; i < len(args); i++ {
-					if res, ok = zmRes.Or(zms[args[i].AuxId]); !ok {
-						zmRes.Reset()
-						break
-					} else {
-						zmRes = index.SetBool(zmRes, res)
-					}
-				}
-				zms[expr.AuxId] = zmRes
 
 			case "+":
 				if f() {
@@ -1489,6 +1519,195 @@ func GetExprZoneMap(
 	}
 
 	return zms[expr.AuxId]
+}
+
+func hasConstNullArg(args []*plan.Expr) bool {
+	for _, arg := range args {
+		if isConstNullExpr(arg) {
+			return true
+		}
+	}
+	return false
+}
+
+func isConstNullExpr(expr *plan.Expr) bool {
+	if lit := expr.GetLit(); lit != nil {
+		return lit.GetIsnull()
+	}
+	if f := expr.GetF(); f != nil && f.Func.GetObjName() == "cast" && len(f.Args) >= 1 {
+		return isConstNullExpr(f.Args[0])
+	}
+	return false
+}
+
+func foldNativeInListZoneMap(
+	ctx context.Context,
+	proc *process.Process,
+	meta objectio.ColumnMetaFetcher,
+	columnMap map[int]int,
+	zms []objectio.ZoneMap,
+	vecs []*vector.Vector,
+	args []*plan.Expr,
+	auxID int32,
+	notIn bool,
+) objectio.ZoneMap {
+	list := args[1].GetList()
+	if list == nil {
+		zms[auxID].Reset()
+		return zms[auxID]
+	}
+
+	for _, item := range list.List {
+		if isConstNullExpr(item) {
+			if notIn {
+				zms[auxID] = index.SetBool(zms[auxID], false)
+				return zms[auxID]
+			}
+			continue
+		}
+	}
+	if notIn {
+		zms[auxID].Reset()
+		return zms[auxID]
+	}
+
+	lhs := GetExprZoneMap(ctx, proc, args[0], meta, columnMap, zms, vecs)
+	if !lhs.IsInited() {
+		zms[auxID].Reset()
+		return zms[auxID]
+	}
+
+	hasUnknown := false
+	for _, item := range list.List {
+		rhs, isNull, ok := getConstExprZoneMap(proc, item)
+		if isNull {
+			continue
+		}
+		if !ok {
+			hasUnknown = true
+			continue
+		}
+		if res, ok := lhs.Intersect(rhs); !ok {
+			hasUnknown = true
+		} else if res {
+			zms[auxID] = index.SetBool(zms[auxID], true)
+			return zms[auxID]
+		}
+	}
+
+	if hasUnknown {
+		zms[auxID].Reset()
+		return zms[auxID]
+	}
+	zms[auxID] = index.SetBool(zms[auxID], false)
+	return zms[auxID]
+}
+
+func getConstExprZoneMap(proc *process.Process, expr *plan.Expr) (zm objectio.ZoneMap, isNull bool, ok bool) {
+	vec, free, err := GetReadonlyResultFromNoColumnExpression(proc, expr)
+	if err != nil {
+		return nil, false, false
+	}
+	defer free()
+
+	if vec.IsConstNull() || vec.GetNulls().Contains(0) {
+		return objectio.NewZM(vec.GetType().Oid, vec.GetType().Scale), true, true
+	}
+
+	zm = objectio.NewZM(vec.GetType().Oid, vec.GetType().Scale)
+	if err := index.BatchUpdateZM(zm, vec); err != nil || !zm.IsInited() {
+		return nil, false, false
+	}
+	return zm, false, true
+}
+
+func anyNotEqualZoneMap(lhs, rhs objectio.ZoneMap) (bool, bool) {
+	intersects, ok := lhs.Intersect(rhs)
+	if !ok {
+		return false, false
+	}
+	if !intersects {
+		return true, true
+	}
+	if isSingleValueZoneMap(lhs) && isSingleValueZoneMap(rhs) && lhs.CompareMin(rhs) == 0 {
+		return false, true
+	}
+	return true, true
+}
+
+func isSingleValueZoneMap(zm objectio.ZoneMap) bool {
+	if !zm.IsInited() {
+		return false
+	}
+	return compute.Compare(zm.GetMinBuf(), zm.GetMaxBuf(), zm.GetType(), zm.GetScale(), zm.GetScale()) == 0
+}
+
+func foldAndZoneMap(
+	ctx context.Context,
+	proc *process.Process,
+	meta objectio.ColumnMetaFetcher,
+	columnMap map[int]int,
+	zms []objectio.ZoneMap,
+	vecs []*vector.Vector,
+	args []*plan.Expr,
+	auxID int32,
+) bool {
+	hasKnown := false
+	hasUnknown := false
+
+	for _, arg := range args {
+		zms[arg.AuxId] = GetExprZoneMap(ctx, proc, arg, meta, columnMap, zms, vecs)
+		if !zms[arg.AuxId].IsInited() || zms[arg.AuxId].GetType() != types.T_bool {
+			hasUnknown = true
+			continue
+		}
+		hasKnown = true
+		if !types.DecodeBool(zms[arg.AuxId].GetMaxBuf()) {
+			zms[auxID] = index.SetBool(zms[auxID], false)
+			return true
+		}
+	}
+
+	if hasUnknown || !hasKnown {
+		zms[auxID].Reset()
+		return false
+	}
+	zms[auxID] = index.SetBool(zms[auxID], true)
+	return true
+}
+
+func foldOrZoneMap(
+	ctx context.Context,
+	proc *process.Process,
+	meta objectio.ColumnMetaFetcher,
+	columnMap map[int]int,
+	zms []objectio.ZoneMap,
+	vecs []*vector.Vector,
+	args []*plan.Expr,
+	auxID int32,
+) bool {
+	hasKnown := false
+	hasUnknown := false
+
+	for _, arg := range args {
+		zms[arg.AuxId] = GetExprZoneMap(ctx, proc, arg, meta, columnMap, zms, vecs)
+		if !zms[arg.AuxId].IsInited() || zms[arg.AuxId].GetType() != types.T_bool {
+			hasUnknown = true
+			continue
+		}
+		hasKnown = true
+		if types.DecodeBool(zms[arg.AuxId].GetMaxBuf()) {
+			zms[auxID] = index.SetBool(zms[auxID], true)
+			return true
+		}
+	}
+
+	if hasUnknown || !hasKnown {
+		zms[auxID].Reset()
+		return false
+	}
+	zms[auxID] = index.SetBool(zms[auxID], false)
+	return true
 }
 
 // RewriteFilterExprList will convert an expression list to be an AndExpr

--- a/pkg/sql/colexec/evalExpression_zonemap_internal_test.go
+++ b/pkg/sql/colexec/evalExpression_zonemap_internal_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package colexec
+
+import (
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnyNotEqualZoneMap(t *testing.T) {
+	key := makeInternalVarcharZoneMap("key")
+	keep := makeInternalVarcharZoneMap("keep")
+
+	res, ok := anyNotEqualZoneMap(key, keep)
+	require.True(t, ok)
+	require.True(t, res)
+
+	res, ok = anyNotEqualZoneMap(key, key)
+	require.True(t, ok)
+	require.False(t, res)
+
+	res, ok = anyNotEqualZoneMap(makeInternalVarcharZoneMap("key", "keep"), key)
+	require.True(t, ok)
+	require.True(t, res)
+
+	_, ok = anyNotEqualZoneMap(key, objectio.NewZM(types.T_varchar, 0))
+	require.False(t, ok)
+}
+
+func TestFoldBooleanZoneMapUnknownPaths(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	trueExpr := makeInternalBoolLitExpr(true, 0)
+	falseExpr := makeInternalBoolLitExpr(false, 1)
+	unknownExpr := &plan.Expr{
+		Typ:   plan.Type{Id: int32(types.T_bool)},
+		AuxId: 2,
+	}
+
+	zms := make([]objectio.ZoneMap, 4)
+	vecs := make([]*vector.Vector, 4)
+	require.False(t, foldAndZoneMap(ctx, proc, nil, nil, zms, vecs, []*plan.Expr{trueExpr, unknownExpr}, 3))
+	require.False(t, zms[3].IsInited())
+
+	zms = make([]objectio.ZoneMap, 4)
+	vecs = make([]*vector.Vector, 4)
+	require.False(t, foldOrZoneMap(ctx, proc, nil, nil, zms, vecs, []*plan.Expr{falseExpr, unknownExpr}, 3))
+	require.False(t, zms[3].IsInited())
+
+	zms = make([]objectio.ZoneMap, 4)
+	vecs = make([]*vector.Vector, 4)
+	require.True(t, foldOrZoneMap(ctx, proc, nil, nil, zms, vecs, []*plan.Expr{falseExpr}, 3))
+	require.True(t, zms[3].IsInited())
+	require.False(t, types.DecodeBool(zms[3].GetMaxBuf()))
+}
+
+func makeInternalBoolLitExpr(value bool, auxID int32) *plan.Expr {
+	return &plan.Expr{
+		Typ:   plan.Type{Id: int32(types.T_bool)},
+		AuxId: auxID,
+		Expr: &plan.Expr_Lit{
+			Lit: &plan.Literal{
+				Value: &plan.Literal_Bval{Bval: value},
+			},
+		},
+	}
+}
+
+func makeInternalVarcharZoneMap(values ...string) objectio.ZoneMap {
+	zm := index.NewZM(types.T_varchar, 0)
+	for _, value := range values {
+		index.UpdateZM(zm, []byte(value))
+	}
+	return zm
+}

--- a/pkg/sql/colexec/evalExpression_zonemap_test.go
+++ b/pkg/sql/colexec/evalExpression_zonemap_test.go
@@ -1,0 +1,401 @@
+// Copyright 2026 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package colexec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrixorigin/matrixone/pkg/container/types"
+	"github.com/matrixorigin/matrixone/pkg/container/vector"
+	"github.com/matrixorigin/matrixone/pkg/objectio"
+	"github.com/matrixorigin/matrixone/pkg/pb/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/colexec"
+	plan2 "github.com/matrixorigin/matrixone/pkg/sql/plan"
+	"github.com/matrixorigin/matrixone/pkg/sql/plan/function"
+	"github.com/matrixorigin/matrixone/pkg/testutil"
+	"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/index"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvaluateFilterByZoneMapNullableInListIsConservative(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	expr := makeVarcharInExpr(t, ctx, "keep", true)
+	meta := makeVarcharBlockMeta("key", "keep")
+	zms, vecs := makeZoneMapEvalScratch(expr)
+
+	selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+	require.True(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+}
+
+func TestEvaluateFilterByZoneMapStillPrunesFalseEquality(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	expr, err := plan2.BindFuncExprImplByPlanExpr(ctx, "=", []*plan.Expr{
+		makeVarcharColExpr(),
+		plan2.MakePlan2StringConstExprWithType("zzz"),
+	})
+	require.NoError(t, err)
+
+	meta := makeVarcharBlockMeta("key", "keep")
+	zms, vecs := makeZoneMapEvalScratch(expr)
+
+	selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+	require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+}
+
+func TestEvaluateFilterByZoneMapAndKeepsKnownFalsePruning(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	falseEq, err := plan2.BindFuncExprImplByPlanExpr(ctx, "=", []*plan.Expr{
+		makeVarcharColExpr(),
+		plan2.MakePlan2StringConstExprWithType("zzz"),
+	})
+	require.NoError(t, err)
+
+	nullExpr := plan2.MakePlan2StringConstExprWithType("")
+	nullExpr.Expr.(*plan.Expr_Lit).Lit.Isnull = true
+	nullEq, err := plan2.BindFuncExprImplByPlanExpr(ctx, "=", []*plan.Expr{
+		makeVarcharColExpr(),
+		nullExpr,
+	})
+	require.NoError(t, err)
+
+	expr, err := plan2.BindFuncExprImplByPlanExpr(ctx, "and", []*plan.Expr{falseEq, nullEq})
+	require.NoError(t, err)
+
+	meta := makeVarcharBlockMeta("key", "keep")
+	zms, vecs := makeZoneMapEvalScratch(expr)
+
+	selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+	require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+}
+
+func TestEvaluateFilterByZoneMapAndKeepsPossibleTrueBoolRange(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	eq, err := plan2.BindFuncExprImplByPlanExpr(ctx, "=", []*plan.Expr{
+		makeVarcharColExprAt(1),
+		plan2.MakePlan2StringConstExprWithType("keep"),
+	})
+	require.NoError(t, err)
+	expr, err := plan2.BindFuncExprImplByPlanExpr(ctx, "and", []*plan.Expr{makeBoolColExpr(), eq})
+	require.NoError(t, err)
+
+	meta := makeBoolAndVarcharBlockMeta(false, true, "key", "keep")
+	zms, vecs := makeZoneMapEvalScratch(expr)
+
+	selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0, 1: 1}, zms, vecs)
+	require.True(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+}
+
+func TestEvaluateFilterByZoneMapNullableInListWithoutMatchPrunes(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	expr := makeVarcharInExpr(t, ctx, "zzz", true)
+	meta := makeVarcharBlockMeta("key", "keep")
+	zms, vecs := makeZoneMapEvalScratch(expr)
+
+	selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+	require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+}
+
+func TestEvaluateFilterByZoneMapNullableNotInListPrunes(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	expr := makeVarcharNotInExpr(t, ctx, "zzz", true)
+	meta := makeVarcharBlockMeta("key", "keep")
+	zms, vecs := makeZoneMapEvalScratch(expr)
+
+	selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+	require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+}
+
+func TestEvaluateFilterByZoneMapNotInExpandedWithBareNullPrunes(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	neqValue, err := plan2.BindFuncExprImplByPlanExpr(ctx, "!=", []*plan.Expr{
+		makeVarcharColExpr(),
+		plan2.MakePlan2StringConstExprWithType("zzz"),
+	})
+	require.NoError(t, err)
+	neqNull, err := plan2.BindFuncExprImplByPlanExpr(ctx, "!=", []*plan.Expr{
+		makeVarcharColExpr(),
+		makeBareNullExpr(),
+	})
+	require.NoError(t, err)
+	expr, err := plan2.BindFuncExprImplByPlanExpr(ctx, "and", []*plan.Expr{neqValue, neqNull})
+	require.NoError(t, err)
+
+	meta := makeVarcharBlockMeta("key", "keep")
+	zms, vecs := makeZoneMapEvalScratch(expr)
+
+	selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+	require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+}
+
+func TestEvaluateFilterByZoneMapNotEqualBareNullPrunes(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	for _, op := range []string{"!=", "<>"} {
+		t.Run(op, func(t *testing.T) {
+			expr, err := plan2.BindFuncExprImplByPlanExpr(ctx, op, []*plan.Expr{
+				makeVarcharColExpr(),
+				makeBareNullExpr(),
+			})
+			require.NoError(t, err)
+
+			meta := makeVarcharBlockMeta("key", "keep")
+			zms, vecs := makeZoneMapEvalScratch(expr)
+
+			selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+			require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+		})
+	}
+}
+
+func TestEvaluateFilterByZoneMapUnknownResultIsConservative(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	expr := makeVarcharColExpr()
+	meta := makeVarcharBlockMeta("key", "keep")
+	zms, vecs := makeZoneMapEvalScratch(expr)
+
+	selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+	require.True(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+}
+
+func TestEvaluateFilterByZoneMapNullComparisonsPrune(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	for _, op := range []string{">", "<", ">=", "<=", "=", "!=", "<>"} {
+		t.Run(op, func(t *testing.T) {
+			expr, err := plan2.BindFuncExprImplByPlanExpr(ctx, op, []*plan.Expr{
+				makeVarcharColExpr(),
+				makeBareNullExpr(),
+			})
+			require.NoError(t, err)
+
+			meta := makeVarcharBlockMeta("key", "keep")
+			zms, vecs := makeZoneMapEvalScratch(expr)
+
+			selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+			require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+		})
+	}
+
+	t.Run("between", func(t *testing.T) {
+		expr, err := plan2.BindFuncExprImplByPlanExpr(ctx, "between", []*plan.Expr{
+			makeVarcharColExpr(),
+			makeBareNullExpr(),
+			plan2.MakePlan2StringConstExprWithType("zzz"),
+		})
+		require.NoError(t, err)
+
+		meta := makeVarcharBlockMeta("key", "keep")
+		zms, vecs := makeZoneMapEvalScratch(expr)
+
+		selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+		require.False(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+	})
+}
+
+func TestEvaluateFilterByZoneMapInListWithUnknownMemberIsConservative(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	listExpr := &plan.Expr{
+		Typ: makeVarcharColExpr().Typ,
+		Expr: &plan.Expr_List{
+			List: &plan.ExprList{List: []*plan.Expr{
+				// Unknown no-column item covers the conservative native IN fallback.
+				{Typ: makeVarcharColExpr().Typ},
+				makeBareNullExpr(),
+			}},
+		},
+	}
+	expr := makeNativeVarcharInExpr(t, ctx, []*plan.Expr{
+		makeVarcharColExprAt(0),
+		listExpr,
+	})
+
+	meta := makeVarcharBlockMeta("key", "keep")
+	zms, vecs := makeZoneMapEvalScratch(expr)
+
+	selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+	require.True(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+}
+
+func TestEvaluateFilterByZoneMapInListWithUninitializedLHSIsConservative(t *testing.T) {
+	proc := testutil.NewProcess(t)
+	ctx := proc.Ctx
+
+	expr := makeVarcharInExpr(t, ctx, "zzz", true)
+	dataMeta := objectio.BuildMetaData(1, 1)
+	meta := dataMeta.GetBlockMeta(0)
+	zms, vecs := makeZoneMapEvalScratch(expr)
+
+	selected := colexec.EvaluateFilterByZoneMap(ctx, proc, expr, meta, map[int]int{0: 0}, zms, vecs)
+	require.True(t, selected, plan2.FormatExpr(expr, plan2.FormatOption{}))
+}
+
+func makeVarcharInExpr(t *testing.T, ctx context.Context, value string, withNull bool) *plan.Expr {
+	t.Helper()
+
+	listValues := []*plan.Expr{plan2.MakePlan2StringConstExprWithType(value)}
+	if withNull {
+		nullExpr := plan2.MakePlan2StringConstExprWithType("")
+		nullExpr.Expr.(*plan.Expr_Lit).Lit.Isnull = true
+		listValues = append(listValues, nullExpr)
+	}
+
+	listExpr := &plan.Expr{
+		Typ: makeVarcharColExpr().Typ,
+		Expr: &plan.Expr_List{
+			List: &plan.ExprList{List: listValues},
+		},
+	}
+	expr, err := plan2.BindFuncExprImplByPlanExpr(ctx, "in", []*plan.Expr{
+		makeVarcharColExpr(),
+		listExpr,
+	})
+	require.NoError(t, err)
+	return expr
+}
+
+func makeNativeVarcharInExpr(t *testing.T, ctx context.Context, args []*plan.Expr) *plan.Expr {
+	t.Helper()
+
+	varcharType := types.T_varchar.ToType()
+	fGet, err := function.GetFunctionByName(ctx, "in", []types.Type{varcharType, varcharType})
+	require.NoError(t, err)
+	returnType := fGet.GetReturnType()
+	return &plan.Expr{
+		Typ: plan.Type{
+			Id:    int32(returnType.Oid),
+			Width: returnType.Width,
+			Scale: returnType.Scale,
+		},
+		Expr: &plan.Expr_F{
+			F: &plan.Function{
+				Func: &plan.ObjectRef{
+					Obj:     fGet.GetEncodedOverloadID(),
+					ObjName: "in",
+				},
+				Args: args,
+			},
+		},
+	}
+}
+
+func makeVarcharNotInExpr(t *testing.T, ctx context.Context, value string, withNull bool) *plan.Expr {
+	t.Helper()
+
+	listValues := []*plan.Expr{plan2.MakePlan2StringConstExprWithType(value)}
+	if withNull {
+		nullExpr := plan2.MakePlan2StringConstExprWithType("")
+		nullExpr.Expr.(*plan.Expr_Lit).Lit.Isnull = true
+		listValues = append(listValues, nullExpr)
+	}
+
+	listExpr := &plan.Expr{
+		Typ: makeVarcharColExpr().Typ,
+		Expr: &plan.Expr_List{
+			List: &plan.ExprList{List: listValues},
+		},
+	}
+	expr, err := plan2.BindFuncExprImplByPlanExpr(ctx, "not_in", []*plan.Expr{
+		makeVarcharColExpr(),
+		listExpr,
+	})
+	require.NoError(t, err)
+	return expr
+}
+
+func makeVarcharColExpr() *plan.Expr {
+	return makeVarcharColExprAt(0)
+}
+
+func makeVarcharColExprAt(pos int32) *plan.Expr {
+	return &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_varchar), Width: 16},
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{RelPos: 0, ColPos: pos, Name: "k"},
+		},
+	}
+}
+
+func makeBoolColExpr() *plan.Expr {
+	return &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_bool)},
+		Expr: &plan.Expr_Col{
+			Col: &plan.ColRef{RelPos: 0, ColPos: 0, Name: "flag"},
+		},
+	}
+}
+
+func makeBareNullExpr() *plan.Expr {
+	return &plan.Expr{
+		Typ: plan.Type{Id: int32(types.T_any)},
+		Expr: &plan.Expr_Lit{
+			Lit: &plan.Literal{Isnull: true},
+		},
+	}
+}
+
+func makeVarcharBlockMeta(values ...string) objectio.BlockObject {
+	dataMeta := objectio.BuildMetaData(1, 1)
+	meta := dataMeta.GetBlockMeta(0)
+
+	zm := index.NewZM(types.T_varchar, 0)
+	for _, value := range values {
+		index.UpdateZM(zm, []byte(value))
+	}
+	meta.MustGetColumn(0).SetZoneMap(zm)
+	return meta
+}
+
+func makeBoolAndVarcharBlockMeta(minBool, maxBool bool, values ...string) objectio.BlockObject {
+	dataMeta := objectio.BuildMetaData(1, 2)
+	meta := dataMeta.GetBlockMeta(0)
+
+	boolZM := index.NewZM(types.T_bool, 0)
+	index.UpdateZM(boolZM, types.EncodeBool(&minBool))
+	index.UpdateZM(boolZM, types.EncodeBool(&maxBool))
+	meta.MustGetColumn(0).SetZoneMap(boolZM)
+
+	varcharZM := index.NewZM(types.T_varchar, 0)
+	for _, value := range values {
+		index.UpdateZM(varcharZM, []byte(value))
+	}
+	meta.MustGetColumn(1).SetZoneMap(varcharZM)
+	return meta
+}
+
+func makeZoneMapEvalScratch(expr *plan.Expr) ([]objectio.ZoneMap, []*vector.Vector) {
+	need := plan2.AssignAuxIdForExpr(expr, 0)
+	return make([]objectio.ZoneMap, need), make([]*vector.Vector, need)
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [x] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

Refs #25346

## What this PR does / why we need it:

This PR backports the zonemap pruning fix for nullable `IN` lists to `4.1-dev`.

For `k IN ('keep', NULL)`, the binder expands the predicate into an OR over equality checks. The `k = NULL` branch produces an unknown/uninitialized zonemap, which previously caused the whole OR result to be treated as not selected by `EvaluateFilterByZoneMap`. That pruned the block before the normal row-level filter could return the matching `k = 'keep'` rows.

With this change, unknown zonemap results keep the block instead of pruning it. Row-level expression evaluation still applies the original predicate, so correctness is restored without changing SQL scalar semantics.

To limit pruning-rate regressions, boolean zonemap folding now uses pruning-specific may-true semantics: `AND` only prunes when a known branch cannot be true, and `OR` keeps the block when any known branch may be true. Only predicates that cannot be proven either way are treated as unknown and scanned.

Native nullable `IN` / `NOT IN` lists are also handled directly: `IN` ignores NULL list members for zonemap intersection, and `NOT IN` with any NULL list member is treated as impossible to be TRUE under a WHERE predicate.

The real SQL-shaped bare NULL expansion for nullable `NOT IN` is covered too: `!= NULL` and `<> NULL` are treated as impossible to be TRUE for zonemap pruning, and non-NULL `!=` keeps may-true semantics unless both sides are provably the same single value.

The regression test covers the nullable IN-list case from the issue, verifies that a normal false equality predicate still prunes by zonemap, verifies that `AND` keeps known-false pruning even when another branch is unknown, verifies that `AND` does not prune a `[false,true]` boolean zonemap that may still be true, covers nullable `IN` without a matching non-NULL member plus nullable `NOT IN`, and covers `NOT IN` after binder-style expansion to `!= ... AND != NULL`.

## Test result

- `go test ./pkg/sql/colexec -run 'TestEvaluateFilterByZoneMap(NullableInListIsConservative|StillPrunesFalseEquality|AndKeepsKnownFalsePruning|AndKeepsPossibleTrueBoolRange|NullableInListWithoutMatchPrunes|NullableNotInListPrunes|NotInExpandedWithBareNullPrunes|NotEqualBareNullPrunes)' -count=1 -v`
- `go test ./pkg/sql/colexec -count=1`
- `go vet ./pkg/sql/colexec`
