### PR TITLE
Fix CDC task state for permanent table errors

### DIFF
--- a/pkg/cdc/error_handler.go
+++ b/pkg/cdc/error_handler.go
@@ -174,7 +174,7 @@ func BuildErrorMetadata(old *ErrorMetadata, record *ErrorRecord) *ErrorMetadata 
 
 // IsErrorExpired checks if a non-retryable error has expired
 // Deprecated: Error expiration mechanism removed. Non-retryable errors now permanently block
-// until manually cleared via Resume.
+// until manually cleared via Restart/Resume.
 func IsErrorExpired(meta *ErrorMetadata) bool {
 	if meta == nil || meta.IsRetryable {
 		return false
@@ -186,7 +186,7 @@ func IsErrorExpired(meta *ErrorMetadata) bool {
 // Design:
 //   - nil metadata: allow retry (no error)
 //   - Retryable error: allow retry if count <= MaxRetryCount
-//   - Non-retryable error: permanently block (user must manually clear via Resume)
+//   - Non-retryable error: permanently block (user must manually clear via Restart/Resume)
 func ShouldRetry(meta *ErrorMetadata) bool {
 	if meta == nil {
 		return true // No error, allow
@@ -198,6 +198,6 @@ func ShouldRetry(meta *ErrorMetadata) bool {
 	}
 
 	// Non-retryable error: permanently block
-	// User must manually clear error via Pause → Resume or directly update mo_cdc_watermark
+	// User must manually clear error via Restart/Resume or directly update mo_cdc_watermark
 	return false
 }

--- a/pkg/cdc/sql_builder.go
+++ b/pkg/cdc/sql_builder.go
@@ -523,10 +523,10 @@ func (b cdcSQLBuilder) UpdateTaskStateAndErrMsgSQL(
 ) string {
 	return fmt.Sprintf(
 		CDCSQLTemplates[CDCUpdateTaskStateAndErrMsgSQL_Idx].SQL,
-		state,
-		errMsg,
+		escapeSQLString(state),
+		escapeSQLString(errMsg),
 		accountId,
-		taskId,
+		escapeSQLString(taskId),
 	)
 }
 

--- a/pkg/cdc/sql_builder_clear_errors_test.go
+++ b/pkg/cdc/sql_builder_clear_errors_test.go
@@ -75,3 +75,15 @@ func TestClearTaskTableErrorsSQL_TaskIsolation(t *testing.T) {
 	assert.Contains(t, sql1, "account_id = 1")
 	assert.Contains(t, sql3, "account_id = 2")
 }
+
+func TestUpdateTaskStateAndErrMsgSQL_SQLInjectionProtection(t *testing.T) {
+	sql := CDCSQLBuilder.UpdateTaskStateAndErrMsgSQL(
+		3,
+		"task'; DROP TABLE task; --",
+		"failed",
+		"CDC table db'.tbl has permanent error: read tcp \\n",
+	)
+
+	expected := "UPDATE `mo_catalog`.`mo_cdc_task` SET state = 'failed', err_msg = 'CDC table db''.tbl has permanent error: read tcp \\\\n' WHERE 1=1 AND account_id = 3 AND task_id = 'task''; DROP TABLE task; --'"
+	assert.Equal(t, expected, sql)
+}

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -904,6 +904,10 @@ func updateCDCTaskState(
 // This is called during Resume/Restart to allow retrying tables that had non-retryable errors
 // after user has fixed the underlying issues
 func (exec *CDCTaskExecutor) clearAllTableErrors(ctx context.Context) error {
+	if exec.ie == nil {
+		return moerr.NewInternalErrorNoCtx("cannot clear CDC table errors: internal executor is not initialized")
+	}
+
 	accountId := uint64(exec.spec.Accounts[0].GetId())
 	taskId := exec.spec.TaskId
 

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -409,9 +409,9 @@ func (exec *CDCTaskExecutor) Resume() error {
 
 // Restart cdc task from init watermark
 func (exec *CDCTaskExecutor) Restart() error {
-	state := exec.stateMachine.State()
-	wasRunning := state == StateRunning || state == StateStarting
-	wasFailed := state == StateFailed
+	stateBeforeRestart := exec.stateMachine.State()
+	shouldStopOldExecution := stateBeforeRestart == StateRunning || stateBeforeRestart == StateStarting
+	shouldClearTableErrors := stateBeforeRestart == StateFailed
 
 	// Transition to Restarting state
 	if err := exec.stateMachine.Transition(TransitionRestart); err != nil {
@@ -425,7 +425,7 @@ func (exec *CDCTaskExecutor) Restart() error {
 		exec.watermarkUpdater.UnmarkTaskPaused(exec.spec.TaskId)
 	}
 
-	if wasFailed {
+	if shouldClearTableErrors {
 		ctx := defines.AttachAccountId(context.Background(), uint32(exec.spec.Accounts[0].GetId()))
 		if err := exec.clearAllTableErrors(ctx); err != nil {
 			logutil.Warn(
@@ -452,7 +452,7 @@ func (exec *CDCTaskExecutor) Restart() error {
 		)
 	}()
 
-	if wasRunning {
+	if shouldStopOldExecution {
 		cdc.GetTableDetector(exec.cnUUID).UnRegister(exec.spec.TaskId)
 		exec.activeRoutine.CloseCancel()
 		// let Start() go
@@ -1097,9 +1097,9 @@ func (exec *CDCTaskExecutor) failTaskForPermanentTableError(ctx context.Context,
 		tbl.SourceTblName,
 	)
 
-	wasRunning := false
+	stateBeforeFail := StateIdle
 	if exec.stateMachine != nil {
-		wasRunning = exec.stateMachine.IsRunning()
+		stateBeforeFail = exec.stateMachine.State()
 		if err := exec.stateMachine.SetFailed(taskErr.Error()); err != nil {
 			logutil.Warn(
 				"cdc.frontend.task.set_state_failed",
@@ -1112,6 +1112,8 @@ func (exec *CDCTaskExecutor) failTaskForPermanentTableError(ctx context.Context,
 			return err
 		}
 	}
+
+	wasRunning := stateBeforeFail == StateRunning || stateBeforeFail == StateStarting
 
 	if err := exec.updateErrMsg(ctx, taskErr.Error()); err != nil {
 		logutil.Warn(

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -409,6 +409,8 @@ func (exec *CDCTaskExecutor) Resume() error {
 
 // Restart cdc task from init watermark
 func (exec *CDCTaskExecutor) Restart() error {
+	wasFailed := exec.stateMachine.State() == StateFailed
+
 	// Transition to Restarting state
 	if err := exec.stateMachine.Transition(TransitionRestart); err != nil {
 		return moerr.NewInternalErrorf(context.Background(), "cannot restart: %v", err)
@@ -419,6 +421,18 @@ func (exec *CDCTaskExecutor) Restart() error {
 	// and all watermark updates would be blocked, causing CDC to stop working
 	if exec.watermarkUpdater != nil {
 		exec.watermarkUpdater.UnmarkTaskPaused(exec.spec.TaskId)
+	}
+
+	if wasFailed {
+		ctx := defines.AttachAccountId(context.Background(), uint32(exec.spec.Accounts[0].GetId()))
+		if err := exec.clearAllTableErrors(ctx); err != nil {
+			logutil.Warn(
+				"cdc.frontend.task.restart_clear_errors_failed",
+				zap.String("task-id", exec.spec.TaskId),
+				zap.Error(err),
+			)
+			// Don't fail Restart if clearing errors fails - continue anyway
+		}
 	}
 
 	logutil.Info(
@@ -885,7 +899,7 @@ func updateCDCTaskState(
 }
 
 // clearAllTableErrors clears error messages for all tables in this task
-// This is called during Resume to allow retrying tables that had non-retryable errors
+// This is called during Resume/Restart to allow retrying tables that had non-retryable errors
 // after user has fixed the underlying issues
 func (exec *CDCTaskExecutor) clearAllTableErrors(ctx context.Context) error {
 	accountId := uint64(exec.spec.Accounts[0].GetId())

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/matrixorigin/matrixone/pkg/objectio"
@@ -133,6 +134,9 @@ type CDCTaskExecutor struct {
 	// stateMachine manages executor state transitions
 	stateMachine *ExecutorStateMachine
 	holdCh       chan int
+
+	callbackMu         sync.RWMutex
+	callbackGeneration atomic.Uint64
 
 	// start wrapper, for ut
 	startFunc func(ctx context.Context) error
@@ -280,7 +284,10 @@ func (exec *CDCTaskExecutor) Start(rootCtx context.Context) (err error) {
 	exec.watermarkUpdater = cdc.GetCDCWatermarkUpdater(exec.cnUUID, exec.ie)
 
 	// register to table scanner
-	if !detector.RegisterIfAbsent(taskId, accountId, dbs, tables, exec.handleNewTables) {
+	callbackGeneration := exec.callbackGeneration.Load()
+	if !detector.RegisterIfAbsent(taskId, accountId, dbs, tables, func(tbls map[uint32]cdc.TblMap) error {
+		return exec.handleNewTablesForGeneration(callbackGeneration, tbls)
+	}) {
 		logutil.Warn(
 			"cdc.frontend.task.duplicate_registration_detected",
 			zap.String("task-id", taskId),
@@ -344,10 +351,14 @@ func (exec *CDCTaskExecutor) Start(rootCtx context.Context) (err error) {
 
 // Resume cdc task from last recorded watermark
 func (exec *CDCTaskExecutor) Resume() error {
+	exec.callbackMu.Lock()
+	defer exec.callbackMu.Unlock()
+
 	// Transition to Starting state (via Resume transition)
 	if err := exec.stateMachine.Transition(TransitionResume); err != nil {
 		return moerr.NewInternalErrorf(context.Background(), "cannot resume: %v", err)
 	}
+	exec.callbackGeneration.Add(1)
 
 	// Log watermark states before resume
 	exec.logCurrentWatermarks("before_resume")
@@ -409,6 +420,9 @@ func (exec *CDCTaskExecutor) Resume() error {
 
 // Restart cdc task from init watermark
 func (exec *CDCTaskExecutor) Restart() error {
+	exec.callbackMu.Lock()
+	defer exec.callbackMu.Unlock()
+
 	stateBeforeRestart := exec.stateMachine.State()
 	shouldStopOldExecution := stateBeforeRestart == StateRunning || stateBeforeRestart == StateStarting
 	shouldClearTableErrors := stateBeforeRestart == StateFailed || stateBeforeRestart == StatePaused
@@ -418,6 +432,7 @@ func (exec *CDCTaskExecutor) Restart() error {
 		return moerr.NewInternalErrorf(context.Background(), "cannot restart: %v", err)
 	}
 	exec.recordLeavingFailedMetrics(stateBeforeRestart, StateRestarting)
+	exec.callbackGeneration.Add(1)
 
 	// FIX: Unmark task as paused to allow watermark updates after restart
 	// Without this, if task was paused before restart, it would remain in pausedTasks
@@ -962,10 +977,28 @@ func (exec *CDCTaskExecutor) clearAllTableErrors(ctx context.Context) error {
 }
 
 func (exec *CDCTaskExecutor) handleNewTables(allAccountTbls map[uint32]cdc.TblMap) error {
+	return exec.handleNewTablesForGeneration(exec.callbackGeneration.Load(), allAccountTbls)
+}
+
+func (exec *CDCTaskExecutor) handleNewTablesForGeneration(
+	callbackGeneration uint64,
+	allAccountTbls map[uint32]cdc.TblMap,
+) error {
+	exec.callbackMu.RLock()
+	defer exec.callbackMu.RUnlock()
+
+	if !exec.isCurrentCallbackGeneration(callbackGeneration) {
+		return nil
+	}
+
 	// lock to avoid create pipelines for the same table
 	// 2025.7, this lock might be needless now
 	exec.Lock()
 	defer exec.Unlock()
+
+	if !exec.isCurrentCallbackGeneration(callbackGeneration) {
+		return nil
+	}
 
 	// if injected, we expect nothing
 	if sleepSeconds, injected := objectio.CDCHandleSlowInjected(); injected {
@@ -1055,6 +1088,9 @@ func (exec *CDCTaskExecutor) handleNewTables(allAccountTbls map[uint32]cdc.TblMa
 			continue
 		}
 		if hasError {
+			if !exec.isCurrentCallbackGeneration(callbackGeneration) {
+				return nil
+			}
 			err = exec.failTaskForPermanentTableError(ctx, newTableInfo)
 			return err
 		}
@@ -1124,6 +1160,10 @@ func (exec *CDCTaskExecutor) handleNewTables(allAccountTbls map[uint32]cdc.TblMa
 	}
 
 	return nil
+}
+
+func (exec *CDCTaskExecutor) isCurrentCallbackGeneration(callbackGeneration uint64) bool {
+	return exec.callbackGeneration.Load() == callbackGeneration
 }
 
 func (exec *CDCTaskExecutor) failTaskForPermanentTableError(ctx context.Context, tbl *cdc.DbTableInfo) error {

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -1001,7 +1001,8 @@ func (exec *CDCTaskExecutor) handleNewTables(allAccountTbls map[uint32]cdc.TblMa
 			continue
 		}
 		if hasError {
-			continue
+			err = exec.failTaskForPermanentTableError(ctx, newTableInfo)
+			return err
 		}
 
 		logutil.Info(
@@ -1069,6 +1070,72 @@ func (exec *CDCTaskExecutor) handleNewTables(allAccountTbls map[uint32]cdc.TblMa
 	}
 
 	return nil
+}
+
+func (exec *CDCTaskExecutor) failTaskForPermanentTableError(ctx context.Context, tbl *cdc.DbTableInfo) error {
+	taskErr := moerr.NewInternalErrorf(
+		ctx,
+		"CDC task %s has permanent table error on %s.%s; check mo_catalog.mo_cdc_watermark.err_msg for details",
+		exec.spec.TaskName,
+		tbl.SourceDbName,
+		tbl.SourceTblName,
+	)
+
+	if err := exec.updateErrMsg(ctx, taskErr.Error()); err != nil {
+		logutil.Warn(
+			"cdc.frontend.task.update_task_error_failed",
+			zap.String("task-id", exec.spec.TaskId),
+			zap.String("task-name", exec.spec.TaskName),
+			zap.String("db", tbl.SourceDbName),
+			zap.String("table", tbl.SourceTblName),
+			zap.Error(err),
+		)
+	}
+
+	wasRunning := false
+	if exec.stateMachine != nil {
+		wasRunning = exec.stateMachine.IsRunning()
+		if err := exec.stateMachine.SetFailed(taskErr.Error()); err != nil {
+			logutil.Warn(
+				"cdc.frontend.task.set_state_failed",
+				zap.String("task-id", exec.spec.TaskId),
+				zap.String("task-name", exec.spec.TaskName),
+				zap.String("db", tbl.SourceDbName),
+				zap.String("table", tbl.SourceTblName),
+				zap.Error(err),
+			)
+		}
+	}
+
+	cdc.GetTableDetector(exec.cnUUID).UnRegister(exec.spec.TaskId)
+	if exec.activeRoutine != nil {
+		exec.activeRoutine.CloseCancel()
+	}
+	exec.stopAllReaders()
+	if exec.holdCh != nil {
+		select {
+		case exec.holdCh <- 1:
+		default:
+		}
+	}
+
+	if wasRunning {
+		v2.CdcTaskTotalGauge.WithLabelValues("running").Dec()
+		v2.CdcTaskStateChangeCounter.WithLabelValues("running", "failed").Inc()
+	}
+	v2.CdcTaskTotalGauge.WithLabelValues("failed").Inc()
+	v2.CdcTaskErrorCounter.WithLabelValues("permanent_table_error", "false").Inc()
+
+	logutil.Error(
+		"cdc.frontend.task.failed_by_permanent_table_error",
+		zap.String("task-id", exec.spec.TaskId),
+		zap.String("task-name", exec.spec.TaskName),
+		zap.String("db", tbl.SourceDbName),
+		zap.String("table", tbl.SourceTblName),
+		zap.Error(taskErr),
+	)
+
+	return taskErr
 }
 
 var GetTableErrMsg = func(

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -409,7 +409,9 @@ func (exec *CDCTaskExecutor) Resume() error {
 
 // Restart cdc task from init watermark
 func (exec *CDCTaskExecutor) Restart() error {
-	wasFailed := exec.stateMachine.State() == StateFailed
+	state := exec.stateMachine.State()
+	wasRunning := state == StateRunning || state == StateStarting
+	wasFailed := state == StateFailed
 
 	// Transition to Restarting state
 	if err := exec.stateMachine.Transition(TransitionRestart); err != nil {
@@ -450,7 +452,7 @@ func (exec *CDCTaskExecutor) Restart() error {
 		)
 	}()
 
-	if exec.stateMachine.IsRunning() {
+	if wasRunning {
 		cdc.GetTableDetector(exec.cnUUID).UnRegister(exec.spec.TaskId)
 		exec.activeRoutine.CloseCancel()
 		// let Start() go
@@ -1095,17 +1097,6 @@ func (exec *CDCTaskExecutor) failTaskForPermanentTableError(ctx context.Context,
 		tbl.SourceTblName,
 	)
 
-	if err := exec.updateErrMsg(ctx, taskErr.Error()); err != nil {
-		logutil.Warn(
-			"cdc.frontend.task.update_task_error_failed",
-			zap.String("task-id", exec.spec.TaskId),
-			zap.String("task-name", exec.spec.TaskName),
-			zap.String("db", tbl.SourceDbName),
-			zap.String("table", tbl.SourceTblName),
-			zap.Error(err),
-		)
-	}
-
 	wasRunning := false
 	if exec.stateMachine != nil {
 		wasRunning = exec.stateMachine.IsRunning()
@@ -1118,7 +1109,19 @@ func (exec *CDCTaskExecutor) failTaskForPermanentTableError(ctx context.Context,
 				zap.String("table", tbl.SourceTblName),
 				zap.Error(err),
 			)
+			return err
 		}
+	}
+
+	if err := exec.updateErrMsg(ctx, taskErr.Error()); err != nil {
+		logutil.Warn(
+			"cdc.frontend.task.update_task_error_failed",
+			zap.String("task-id", exec.spec.TaskId),
+			zap.String("task-name", exec.spec.TaskName),
+			zap.String("db", tbl.SourceDbName),
+			zap.String("table", tbl.SourceTblName),
+			zap.Error(err),
+		)
 	}
 
 	cdc.GetTableDetector(exec.cnUUID).UnRegister(exec.spec.TaskId)

--- a/pkg/frontend/cdc_exector.go
+++ b/pkg/frontend/cdc_exector.go
@@ -411,12 +411,13 @@ func (exec *CDCTaskExecutor) Resume() error {
 func (exec *CDCTaskExecutor) Restart() error {
 	stateBeforeRestart := exec.stateMachine.State()
 	shouldStopOldExecution := stateBeforeRestart == StateRunning || stateBeforeRestart == StateStarting
-	shouldClearTableErrors := stateBeforeRestart == StateFailed
+	shouldClearTableErrors := stateBeforeRestart == StateFailed || stateBeforeRestart == StatePaused
 
 	// Transition to Restarting state
 	if err := exec.stateMachine.Transition(TransitionRestart); err != nil {
 		return moerr.NewInternalErrorf(context.Background(), "cannot restart: %v", err)
 	}
+	exec.recordLeavingFailedMetrics(stateBeforeRestart, StateRestarting)
 
 	// FIX: Unmark task as paused to allow watermark updates after restart
 	// Without this, if task was paused before restart, it would remain in pausedTasks
@@ -603,12 +604,14 @@ func (exec *CDCTaskExecutor) Pause() error {
 // Cancel cdc task
 func (exec *CDCTaskExecutor) Cancel() error {
 	// Check if running before state transition
-	wasRunning := exec.stateMachine.IsRunning()
+	stateBeforeCancel := exec.stateMachine.State()
+	wasRunning := stateBeforeCancel == StateRunning || stateBeforeCancel == StateStarting
 
 	// Transition to Cancelling state
 	if err := exec.stateMachine.Transition(TransitionCancel); err != nil {
 		return moerr.NewInternalErrorf(context.Background(), "cannot cancel: %v", err)
 	}
+	exec.recordLeavingFailedMetrics(stateBeforeCancel, StateCancelling)
 
 	// FIX: Unmark task as paused to prevent pausedTasks leakage
 	// If task was paused before cancel, we need to clean up the pause mark
@@ -663,6 +666,37 @@ func (exec *CDCTaskExecutor) Cancel() error {
 		}
 	}
 	return nil
+}
+
+func (exec *CDCTaskExecutor) recordLeavingFailedMetrics(fromState ExecutorState, toState ExecutorState) {
+	if fromState != StateFailed {
+		return
+	}
+	v2.CdcTaskTotalGauge.WithLabelValues("failed").Dec()
+	v2.CdcTaskStateChangeCounter.WithLabelValues("failed", cdcTaskMetricStateLabel(toState)).Inc()
+}
+
+func cdcTaskMetricStateLabel(state ExecutorState) string {
+	switch state {
+	case StateStarting:
+		return "starting"
+	case StateRunning:
+		return "running"
+	case StatePausing:
+		return "pausing"
+	case StatePaused:
+		return "paused"
+	case StateRestarting:
+		return "restarting"
+	case StateCancelling:
+		return "cancelling"
+	case StateCancelled:
+		return "cancelled"
+	case StateFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
 }
 
 // logCurrentWatermarks logs current watermarks for all tables in this task

--- a/pkg/frontend/cdc_state_machine.go
+++ b/pkg/frontend/cdc_state_machine.go
@@ -247,7 +247,7 @@ func (sm *ExecutorStateMachine) SetFailed(errMsg string) error {
 	defer sm.mu.Unlock()
 
 	switch sm.currentState {
-	case StateStarting, StateRunning, StateRestarting:
+	case StateStarting, StateRunning:
 		sm.currentState = StateFailed
 		sm.errorMessage = errMsg
 		return nil

--- a/pkg/frontend/cdc_state_machine.go
+++ b/pkg/frontend/cdc_state_machine.go
@@ -246,8 +246,8 @@ func (sm *ExecutorStateMachine) SetFailed(errMsg string) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	// Can transition to Failed from Starting
-	if sm.currentState == StateStarting {
+	switch sm.currentState {
+	case StateStarting, StateRunning, StateRestarting:
 		sm.currentState = StateFailed
 		sm.errorMessage = errMsg
 		return nil

--- a/pkg/frontend/cdc_state_machine_test.go
+++ b/pkg/frontend/cdc_state_machine_test.go
@@ -224,6 +224,12 @@ func TestExecutorStateMachine_SetFailed(t *testing.T) {
 	require.NoError(t, sm.Transition(TransitionRestartBegin))
 	assert.Equal(t, StateStarting, sm.State())
 	assert.Equal(t, "", sm.GetErrorMessage())
+
+	require.NoError(t, sm.Transition(TransitionStartSuccess))
+	err = sm.SetFailed("runtime failed")
+	assert.NoError(t, err)
+	assert.Equal(t, StateFailed, sm.State())
+	assert.Equal(t, "runtime failed", sm.GetErrorMessage())
 }
 
 func TestExecutorStateMachine_Concurrency(t *testing.T) {

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -3246,6 +3246,156 @@ func TestCdcTask_PermanentTableErrorDoesNotFailWhilePausing(t *testing.T) {
 	}
 }
 
+func TestCdcTask_StaleCallbackDoesNotFailRestartGeneration(t *testing.T) {
+	stubGetTxnOp := gostub.Stub(&cdc.GetTxnOp, func(context.Context, engine.Engine, client.TxnClient, string) (client.TxnOperator, error) {
+		return nil, nil
+	})
+	defer stubGetTxnOp.Reset()
+
+	stubFinishTxnOp := gostub.Stub(&cdc.FinishTxnOp, func(context.Context, error, client.TxnOperator, engine.Engine) {})
+	defer stubFinishTxnOp.Reset()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	executor := &captureCDCExecutor{}
+	cdcTask := &CDCTaskExecutor{
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task-1",
+			TaskName: "task-name",
+			Accounts: []*task.Account{
+				{Id: 0},
+			},
+		},
+		tables: cdc.PatternTuples{
+			Pts: []*cdc.PatternTuple{
+				{
+					Source: cdc.PatternTable{
+						Database: "db1",
+						Table:    cdc.CDCPitrGranularity_All,
+					},
+				},
+			},
+		},
+		ie:             executor,
+		cnEngine:       eng,
+		runningReaders: &sync.Map{},
+		stateMachine:   NewExecutorStateMachine(),
+		activeRoutine:  cdc.NewCdcActiveRoutine(),
+		holdCh:         make(chan int, 1),
+	}
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStart))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStartSuccess))
+
+	staleGeneration := cdcTask.callbackGeneration.Load()
+	stubGetTableErrMsg := gostub.Stub(&GetTableErrMsg, func(context.Context, uint32, ie.InternalExecutor, string, *cdc.DbTableInfo) (bool, error) {
+		cdcTask.callbackGeneration.Add(1)
+		return true, nil
+	})
+	defer stubGetTableErrMsg.Reset()
+
+	err := cdcTask.handleNewTablesForGeneration(staleGeneration, map[uint32]cdc.TblMap{
+		0: {
+			"db1.tb1": &cdc.DbTableInfo{
+				SourceDbName:  "db1",
+				SourceTblName: "tb1",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, StateRunning, cdcTask.stateMachine.State())
+	require.Empty(t, executor.capturedExecSQLs())
+}
+
+func TestCdcTask_RestartDrainsInflightHandleNewTablesCallback(t *testing.T) {
+	stubGetTxnOp := gostub.Stub(&cdc.GetTxnOp, func(context.Context, engine.Engine, client.TxnClient, string) (client.TxnOperator, error) {
+		return nil, nil
+	})
+	defer stubGetTxnOp.Reset()
+
+	stubFinishTxnOp := gostub.Stub(&cdc.FinishTxnOp, func(context.Context, error, client.TxnOperator, engine.Engine) {})
+	defer stubFinishTxnOp.Reset()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	callbackEntered := make(chan struct{}, 1)
+	releaseCallback := make(chan struct{})
+	stubGetTableErrMsg := gostub.Stub(&GetTableErrMsg, func(context.Context, uint32, ie.InternalExecutor, string, *cdc.DbTableInfo) (bool, error) {
+		callbackEntered <- struct{}{}
+		<-releaseCallback
+		return false, moerr.NewInternalErrorNoCtx("stale callback stopped")
+	})
+	defer stubGetTableErrMsg.Reset()
+
+	started := make(chan struct{}, 1)
+	cdcTask := &CDCTaskExecutor{
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task-1",
+			TaskName: "task-name",
+			Accounts: []*task.Account{
+				{Id: 0},
+			},
+		},
+		tables: cdc.PatternTuples{
+			Pts: []*cdc.PatternTuple{
+				{
+					Source: cdc.PatternTable{
+						Database: "db1",
+						Table:    cdc.CDCPitrGranularity_All,
+					},
+				},
+			},
+		},
+		cnEngine:       eng,
+		runningReaders: &sync.Map{},
+		stateMachine:   NewExecutorStateMachine(),
+		activeRoutine:  cdc.NewCdcActiveRoutine(),
+		holdCh:         make(chan int, 1),
+		startFunc: func(context.Context) error {
+			started <- struct{}{}
+			return nil
+		},
+	}
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStart))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStartSuccess))
+
+	callbackDone := make(chan error, 1)
+	go func() {
+		callbackDone <- cdcTask.handleNewTablesForGeneration(cdcTask.callbackGeneration.Load(), map[uint32]cdc.TblMap{
+			0: {
+				"db1.tb1": &cdc.DbTableInfo{
+					SourceDbName:  "db1",
+					SourceTblName: "tb1",
+				},
+			},
+		})
+	}()
+	<-callbackEntered
+
+	restartDone := make(chan error, 1)
+	go func() {
+		restartDone <- cdcTask.Restart()
+	}()
+
+	select {
+	case <-started:
+		t.Fatal("restart should wait for in-flight handleNewTables callback before starting a new generation")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseCallback)
+	require.Error(t, <-callbackDone)
+	require.NoError(t, <-restartDone)
+	<-started
+}
+
 func TestCdcTask_RestartFromPausedClearsPermanentTableErrors(t *testing.T) {
 	executor := &captureCDCExecutor{}
 	started := make(chan struct{}, 1)

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/prashantv/gostub"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
@@ -51,6 +53,7 @@ import (
 	"github.com/matrixorigin/matrixone/pkg/taskservice"
 	"github.com/matrixorigin/matrixone/pkg/txn/client"
 	ie "github.com/matrixorigin/matrixone/pkg/util/internalExecutor"
+	v2 "github.com/matrixorigin/matrixone/pkg/util/metric/v2"
 	"github.com/matrixorigin/matrixone/pkg/vm/engine"
 )
 
@@ -2857,6 +2860,13 @@ func (e *captureCDCExecutor) capturedExecSQLs() []string {
 	return sqls
 }
 
+func readFrontendGaugeValue(t *testing.T, gauge prometheus.Gauge) float64 {
+	t.Helper()
+	var metric dto.Metric
+	require.NoError(t, gauge.Write(&metric))
+	return metric.GetGauge().GetValue()
+}
+
 type mockIe struct {
 	cnt int
 }
@@ -3234,6 +3244,81 @@ func TestCdcTask_PermanentTableErrorDoesNotFailWhilePausing(t *testing.T) {
 		t.Fatal("permanent error should not release Start while pause owns the state transition")
 	default:
 	}
+}
+
+func TestCdcTask_RestartFromPausedClearsPermanentTableErrors(t *testing.T) {
+	executor := &captureCDCExecutor{}
+	started := make(chan struct{}, 1)
+	cdcTask := &CDCTaskExecutor{
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task-1",
+			TaskName: "task-name",
+			Accounts: []*task.Account{
+				{Id: 0},
+			},
+		},
+		ie:             executor,
+		stateMachine:   NewExecutorStateMachine(),
+		activeRoutine:  cdc.NewCdcActiveRoutine(),
+		holdCh:         make(chan int, 1),
+		runningReaders: &sync.Map{},
+		startFunc: func(context.Context) error {
+			started <- struct{}{}
+			return nil
+		},
+	}
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStart))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStartSuccess))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionPause))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionPauseComplete))
+
+	require.NoError(t, cdcTask.Restart())
+	<-started
+
+	require.True(t, executor.tableErrorsAreCleared())
+	sqls := executor.capturedExecSQLs()
+	require.Len(t, sqls, 1)
+	require.Contains(t, sqls[0], "UPDATE `mo_catalog`.`mo_cdc_watermark` SET err_msg = ''")
+	require.Contains(t, sqls[0], "task-1")
+}
+
+func TestCdcTask_RestartFromFailedUpdatesFailedMetrics(t *testing.T) {
+	failedGauge := v2.CdcTaskTotalGauge.WithLabelValues("failed")
+	failedBefore := readFrontendGaugeValue(t, failedGauge)
+
+	executor := &captureCDCExecutor{}
+	started := make(chan struct{}, 1)
+	cdcTask := &CDCTaskExecutor{
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task-1",
+			TaskName: "task-name",
+			Accounts: []*task.Account{
+				{Id: 0},
+			},
+		},
+		ie:             executor,
+		stateMachine:   NewExecutorStateMachine(),
+		activeRoutine:  cdc.NewCdcActiveRoutine(),
+		holdCh:         make(chan int, 1),
+		runningReaders: &sync.Map{},
+		startFunc: func(context.Context) error {
+			started <- struct{}{}
+			return nil
+		},
+	}
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStart))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStartSuccess))
+
+	err := cdcTask.failTaskForPermanentTableError(context.Background(), &cdc.DbTableInfo{
+		SourceDbName:  "db1",
+		SourceTblName: "tb1",
+	})
+	require.Error(t, err)
+	require.Equal(t, failedBefore+1, readFrontendGaugeValue(t, failedGauge))
+
+	require.NoError(t, cdcTask.Restart())
+	<-started
+	require.Equal(t, failedBefore, readFrontendGaugeValue(t, failedGauge))
 }
 
 func TestCdcTask_RestartClearsPermanentTableErrorAndRecovers(t *testing.T) {

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -2822,11 +2822,18 @@ func Test_initAesKey(t *testing.T) {
 var _ ie.InternalExecutor = &mockIe{}
 
 type captureCDCExecutor struct {
-	execSQLs []string
+	mu                 sync.Mutex
+	execSQLs           []string
+	tableErrorsCleared bool
 }
 
 func (e *captureCDCExecutor) Exec(ctx context.Context, s string, options ie.SessionOverrideOptions) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.execSQLs = append(e.execSQLs, s)
+	if regexp.MustCompile("UPDATE `mo_catalog`.`mo_cdc_watermark` SET err_msg = ''").MatchString(s) {
+		e.tableErrorsCleared = true
+	}
 	return nil
 }
 
@@ -2835,6 +2842,20 @@ func (*captureCDCExecutor) Query(ctx context.Context, s string, options ie.Sessi
 }
 
 func (*captureCDCExecutor) ApplySessionOverride(options ie.SessionOverrideOptions) {}
+
+func (e *captureCDCExecutor) tableErrorsAreCleared() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.tableErrorsCleared
+}
+
+func (e *captureCDCExecutor) capturedExecSQLs() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	sqls := make([]string, len(e.execSQLs))
+	copy(sqls, e.execSQLs)
+	return sqls
+}
 
 type mockIe struct {
 	cnt int
@@ -3144,6 +3165,136 @@ func TestCdcTask_handleNewTables_PermanentTableErrorFailsTask(t *testing.T) {
 	require.Len(t, executor.execSQLs, 1)
 	require.Contains(t, executor.execSQLs[0], "SET state = 'failed'")
 	require.Contains(t, executor.execSQLs[0], "task-1")
+}
+
+func TestCdcTask_RestartClearsPermanentTableErrorAndRecovers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	txnOperator := mock_frontend.NewMockTxnOperator(ctrl)
+	txnOperator.EXPECT().SnapshotTS().Return(timestamp.Timestamp{}).AnyTimes()
+
+	stubGetTxnOp := gostub.Stub(&cdc.GetTxnOp, func(context.Context, engine.Engine, client.TxnClient, string) (client.TxnOperator, error) {
+		return txnOperator, nil
+	})
+	defer stubGetTxnOp.Reset()
+
+	stubFinishTxnOp := gostub.Stub(&cdc.FinishTxnOp, func(context.Context, error, client.TxnOperator, engine.Engine) {})
+	defer stubFinishTxnOp.Reset()
+
+	executor := &captureCDCExecutor{}
+	stubGetTableErrMsg := gostub.Stub(&GetTableErrMsg, func(context.Context, uint32, ie.InternalExecutor, string, *cdc.DbTableInfo) (bool, error) {
+		return !executor.tableErrorsAreCleared(), nil
+	})
+	defer stubGetTableErrMsg.Reset()
+
+	cdcStubs := setupCDCTestStubs(t)
+	defer func() {
+		for _, s := range cdcStubs {
+			s.Reset()
+		}
+	}()
+
+	stubSinker := gostub.Stub(
+		&cdc.NewSinker,
+		func(
+			cdc.UriInfo,
+			uint64,
+			string,
+			*cdc.DbTableInfo,
+			*cdc.CDCWatermarkUpdater,
+			*plan.TableDef,
+			int,
+			time.Duration,
+			*cdc.ActiveRoutine,
+			uint64,
+			string,
+		) (cdc.Sinker, error) {
+			return &mockSinker{}, nil
+		})
+	defer stubSinker.Reset()
+
+	u, _ := cdc.InitCDCWatermarkUpdaterForTest(t)
+	u.Start()
+	defer u.Stop()
+
+	tableMap := map[uint32]cdc.TblMap{
+		0: {
+			"db1.tb1": &cdc.DbTableInfo{
+				SourceDbName:  "db1",
+				SourceTblName: "tb1",
+				SourceTblId:   1,
+			},
+		},
+	}
+
+	cdcTask := &CDCTaskExecutor{
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task-1",
+			TaskName: "task-name",
+			Accounts: []*task.Account{
+				{Id: 0},
+			},
+		},
+		tables: cdc.PatternTuples{
+			Pts: []*cdc.PatternTuple{
+				{
+					Source: cdc.PatternTable{
+						Database: "db1",
+						Table:    cdc.CDCPitrGranularity_All,
+					},
+				},
+			},
+		},
+		ie:               executor,
+		cnEngine:         eng,
+		runningReaders:   &sync.Map{},
+		stateMachine:     NewExecutorStateMachine(),
+		activeRoutine:    cdc.NewCdcActiveRoutine(),
+		holdCh:           make(chan int, 1),
+		watermarkUpdater: u,
+		noFull:           true,
+		additionalConfig: map[string]interface{}{
+			cdc.CDCTaskExtraOptions_MaxSqlLength:         float64(cdc.CDCDefaultTaskExtra_MaxSQLLen),
+			cdc.CDCTaskExtraOptions_SendSqlTimeout:       cdc.CDCDefaultSendSqlTimeout,
+			cdc.CDCTaskExtraOptions_InitSnapshotSplitTxn: cdc.CDCDefaultTaskExtra_InitSnapshotSplitTxn,
+			cdc.CDCTaskExtraOptions_Frequency:            "",
+		},
+	}
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStart))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStartSuccess))
+
+	err := cdcTask.handleNewTables(tableMap)
+	require.Error(t, err)
+	require.Equal(t, StateFailed, cdcTask.stateMachine.State())
+	require.False(t, executor.tableErrorsAreCleared())
+
+	restartDone := make(chan error, 1)
+	cdcTask.startFunc = func(context.Context) error {
+		err := cdcTask.handleNewTables(tableMap)
+		restartDone <- err
+		return err
+	}
+
+	require.NoError(t, cdcTask.Restart())
+	require.NoError(t, <-restartDone)
+	require.True(t, executor.tableErrorsAreCleared())
+
+	sqls := executor.capturedExecSQLs()
+	require.Len(t, sqls, 2)
+	require.Contains(t, sqls[0], "SET state = 'failed'")
+	require.Contains(t, sqls[1], "UPDATE `mo_catalog`.`mo_cdc_watermark` SET err_msg = ''")
+	require.Contains(t, sqls[1], "task-1")
+
+	cdcTask.activeRoutine.CloseCancel()
+	if val, ok := cdcTask.runningReaders.Load("db1.tb1"); ok {
+		if reader, ok := val.(cdc.ChangeReader); ok {
+			reader.Wait()
+		}
+	}
 }
 
 func TestCdcTask_handleNewTables_GetTxnOpErr(t *testing.T) {

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -3167,6 +3167,75 @@ func TestCdcTask_handleNewTables_PermanentTableErrorFailsTask(t *testing.T) {
 	require.Contains(t, executor.execSQLs[0], "task-1")
 }
 
+func TestCdcTask_RestartRunningTaskUnregistersOldDetector(t *testing.T) {
+	detector := createMockTableDetectorForTest()("test-cn")
+	require.True(t, detector.RegisterIfAbsent("task-1", 0, []string{"db1"}, []string{"tb1"}, func(map[uint32]cdc.TblMap) error {
+		return nil
+	}))
+	require.True(t, detector.IsTaskRegistered("task-1"))
+
+	stubDetector := gostub.Stub(&cdc.GetTableDetector, func(string) *cdc.TableDetector {
+		return detector
+	})
+	defer stubDetector.Reset()
+
+	started := make(chan struct{}, 1)
+	cdcTask := &CDCTaskExecutor{
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task-1",
+			TaskName: "task-name",
+		},
+		stateMachine:  NewExecutorStateMachine(),
+		activeRoutine: cdc.NewCdcActiveRoutine(),
+		holdCh:        make(chan int, 1),
+		startFunc: func(context.Context) error {
+			started <- struct{}{}
+			return nil
+		},
+	}
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStart))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStartSuccess))
+
+	require.NoError(t, cdcTask.Restart())
+	<-started
+
+	require.False(t, detector.IsTaskRegistered("task-1"))
+}
+
+func TestCdcTask_PermanentTableErrorDoesNotFailWhilePausing(t *testing.T) {
+	executor := &captureCDCExecutor{}
+	cdcTask := &CDCTaskExecutor{
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task-1",
+			TaskName: "task-name",
+			Accounts: []*task.Account{
+				{Id: 0},
+			},
+		},
+		ie:             executor,
+		stateMachine:   NewExecutorStateMachine(),
+		activeRoutine:  cdc.NewCdcActiveRoutine(),
+		holdCh:         make(chan int, 1),
+		runningReaders: &sync.Map{},
+	}
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStart))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStartSuccess))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionPause))
+
+	err := cdcTask.failTaskForPermanentTableError(context.Background(), &cdc.DbTableInfo{
+		SourceDbName:  "db1",
+		SourceTblName: "tb1",
+	})
+	require.Error(t, err)
+	require.Equal(t, StatePausing, cdcTask.stateMachine.State())
+	require.Empty(t, executor.capturedExecSQLs())
+	select {
+	case <-cdcTask.holdCh:
+		t.Fatal("permanent error should not release Start while pause owns the state transition")
+	default:
+	}
+}
+
 func TestCdcTask_RestartClearsPermanentTableErrorAndRecovers(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/frontend/cdc_test.go
+++ b/pkg/frontend/cdc_test.go
@@ -2821,6 +2821,21 @@ func Test_initAesKey(t *testing.T) {
 
 var _ ie.InternalExecutor = &mockIe{}
 
+type captureCDCExecutor struct {
+	execSQLs []string
+}
+
+func (e *captureCDCExecutor) Exec(ctx context.Context, s string, options ie.SessionOverrideOptions) error {
+	e.execSQLs = append(e.execSQLs, s)
+	return nil
+}
+
+func (*captureCDCExecutor) Query(ctx context.Context, s string, options ie.SessionOverrideOptions) ie.InternalExecResult {
+	return &mockIeResult{}
+}
+
+func (*captureCDCExecutor) ApplySessionOverride(options ie.SessionOverrideOptions) {}
+
 type mockIe struct {
 	cnt int
 }
@@ -3064,6 +3079,71 @@ func TestCdcTask_handleNewTables_addpipeline(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, false, mp[0]["db1.tb2"].IdChanged)
 	fault.Disable()
+}
+
+func TestCdcTask_handleNewTables_PermanentTableErrorFailsTask(t *testing.T) {
+	stub1 := gostub.Stub(&cdc.GetTxnOp, func(context.Context, engine.Engine, client.TxnClient, string) (client.TxnOperator, error) {
+		return nil, nil
+	})
+	defer stub1.Reset()
+
+	stub2 := gostub.Stub(&cdc.FinishTxnOp, func(context.Context, error, client.TxnOperator, engine.Engine) {})
+	defer stub2.Reset()
+
+	stub3 := gostub.Stub(&GetTableErrMsg, func(context.Context, uint32, ie.InternalExecutor, string, *cdc.DbTableInfo) (bool, error) {
+		return true, nil
+	})
+	defer stub3.Reset()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eng := mock_frontend.NewMockEngine(ctrl)
+	eng.EXPECT().New(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	executor := &captureCDCExecutor{}
+	cdcTask := &CDCTaskExecutor{
+		spec: &task.CreateCdcDetails{
+			TaskId:   "task-1",
+			TaskName: "task-name",
+			Accounts: []*task.Account{
+				{Id: 0},
+			},
+		},
+		tables: cdc.PatternTuples{
+			Pts: []*cdc.PatternTuple{
+				{
+					Source: cdc.PatternTable{
+						Database: "db1",
+						Table:    cdc.CDCPitrGranularity_All,
+					},
+				},
+			},
+		},
+		ie:             executor,
+		cnEngine:       eng,
+		runningReaders: &sync.Map{},
+		stateMachine:   NewExecutorStateMachine(),
+		activeRoutine:  cdc.NewCdcActiveRoutine(),
+		holdCh:         make(chan int, 1),
+	}
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStart))
+	require.NoError(t, cdcTask.stateMachine.Transition(TransitionStartSuccess))
+
+	mp := map[uint32]cdc.TblMap{
+		0: {
+			"db1.tb1": &cdc.DbTableInfo{
+				SourceDbName:  "db1",
+				SourceTblName: "tb1",
+			},
+		},
+	}
+	err := cdcTask.handleNewTables(mp)
+	require.Error(t, err)
+	require.Equal(t, StateFailed, cdcTask.stateMachine.State())
+	require.Len(t, executor.execSQLs, 1)
+	require.Contains(t, executor.execSQLs[0], "SET state = 'failed'")
+	require.Contains(t, executor.execSQLs[0], "task-1")
 }
 
 func TestCdcTask_handleNewTables_GetTxnOpErr(t *testing.T) {


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [x] BUG
- [ ] Improvement
- [ ] Documentation
- [ ] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #25177

## What this PR does / why we need it:

This PR updates CDC task handling so table-level permanent errors no longer leave the task appearing healthy/running while checkpoints stop advancing.

  Changes:

  - Mark the CDC task as failed when a permanent table error is detected.
  - Stop active CDC readers and unregister the task from the table detector on permanent table failure.
  - Allow the CDC executor state machine to transition from running/restarting to failed.
  - Escape task state/error SQL fields when updating mo_cdc_task.err_msg.
  - Add regression tests for task failure behavior, runtime failure state transitions, and SQL escaping.